### PR TITLE
[RISCV] Replace riscv.clmul intrinsic with llvm.clmul

### DIFF
--- a/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
@@ -1155,7 +1155,7 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
     // Zbc
     case RISCV::BI__builtin_riscv_clmul_32:
     case RISCV::BI__builtin_riscv_clmul_64:
-      ID = Intrinsic::riscv_clmul;
+      ID = Intrinsic::clmul;
       break;
     case RISCV::BI__builtin_riscv_clmulh_32:
     case RISCV::BI__builtin_riscv_clmulh_64:

--- a/clang/test/CodeGen/RISCV/rvb-intrinsics/zbc.c
+++ b/clang/test/CodeGen/RISCV/rvb-intrinsics/zbc.c
@@ -11,7 +11,7 @@
 #if __riscv_xlen == 64
 // RV64ZBC-LABEL: @clmul_64(
 // RV64ZBC-NEXT:  entry:
-// RV64ZBC-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.clmul.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// RV64ZBC-NEXT:    [[TMP0:%.*]] = call i64 @llvm.clmul.i64(i64 [[A:%.*]], i64 [[B:%.*]])
 // RV64ZBC-NEXT:    ret i64 [[TMP0]]
 //
 uint64_t clmul_64(uint64_t a, uint64_t b) {
@@ -39,12 +39,12 @@ uint64_t clmulr_64(uint64_t a, uint64_t b) {
 
 // RV32ZBC-LABEL: @clmul_32(
 // RV32ZBC-NEXT:  entry:
-// RV32ZBC-NEXT:    [[TMP0:%.*]] = call i32 @llvm.riscv.clmul.i32(i32 [[A:%.*]], i32 [[B:%.*]])
+// RV32ZBC-NEXT:    [[TMP0:%.*]] = call i32 @llvm.clmul.i32(i32 [[A:%.*]], i32 [[B:%.*]])
 // RV32ZBC-NEXT:    ret i32 [[TMP0]]
 //
 // RV64ZBC-LABEL: @clmul_32(
 // RV64ZBC-NEXT:  entry:
-// RV64ZBC-NEXT:    [[TMP0:%.*]] = call i32 @llvm.riscv.clmul.i32(i32 [[A:%.*]], i32 [[B:%.*]])
+// RV64ZBC-NEXT:    [[TMP0:%.*]] = call i32 @llvm.clmul.i32(i32 [[A:%.*]], i32 [[B:%.*]])
 // RV64ZBC-NEXT:    ret i32 [[TMP0]]
 //
 uint32_t clmul_32(uint32_t a, uint32_t b) {

--- a/clang/test/CodeGen/RISCV/rvb-intrinsics/zbkc.c
+++ b/clang/test/CodeGen/RISCV/rvb-intrinsics/zbkc.c
@@ -11,7 +11,7 @@
 #if __riscv_xlen == 64
 // RV64ZBKC-LABEL: @clmul_64(
 // RV64ZBKC-NEXT:  entry:
-// RV64ZBKC-NEXT:    [[TMP0:%.*]] = call i64 @llvm.riscv.clmul.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// RV64ZBKC-NEXT:    [[TMP0:%.*]] = call i64 @llvm.clmul.i64(i64 [[A:%.*]], i64 [[B:%.*]])
 // RV64ZBKC-NEXT:    ret i64 [[TMP0]]
 //
 uint64_t clmul_64(uint64_t a, uint64_t b) {
@@ -30,12 +30,12 @@ uint64_t clmulh_64(uint64_t a, uint64_t b) {
 
 // RV32ZBKC-LABEL: @clmul_32(
 // RV32ZBKC-NEXT:  entry:
-// RV32ZBKC-NEXT:    [[TMP0:%.*]] = call i32 @llvm.riscv.clmul.i32(i32 [[A:%.*]], i32 [[B:%.*]])
+// RV32ZBKC-NEXT:    [[TMP0:%.*]] = call i32 @llvm.clmul.i32(i32 [[A:%.*]], i32 [[B:%.*]])
 // RV32ZBKC-NEXT:    ret i32 [[TMP0]]
 //
 // RV64ZBKC-LABEL: @clmul_32(
 // RV64ZBKC-NEXT:  entry:
-// RV64ZBKC-NEXT:    [[TMP0:%.*]] = call i32 @llvm.riscv.clmul.i32(i32 [[A:%.*]], i32 [[B:%.*]])
+// RV64ZBKC-NEXT:    [[TMP0:%.*]] = call i32 @llvm.clmul.i32(i32 [[A:%.*]], i32 [[B:%.*]])
 // RV64ZBKC-NEXT:    ret i32 [[TMP0]]
 //
 uint32_t clmul_32(uint32_t a, uint32_t b) {

--- a/llvm/include/llvm/IR/IntrinsicsRISCV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCV.td
@@ -78,7 +78,6 @@ let TargetPrefix = "riscv" in {
   def int_riscv_orc_b : RISCVBitManipGPRIntrinsics;
 
   // Zbc or Zbkc
-  def int_riscv_clmul  : RISCVBitManipGPRGPRIntrinsics;
   def int_riscv_clmulh : RISCVBitManipGPRGPRIntrinsics;
 
   // Zbc

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1750,6 +1750,14 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
         }
         break; // No other applicable upgrades.
       }
+
+      // Replace llvm.riscv.clmul with llvm.clmul.
+      if (Name == "clmul.i32" || Name == "clmul.i64") {
+        NewFn = Intrinsic::getOrInsertDeclaration(F->getParent(), Intrinsic::clmul,
+                                                  {F->getReturnType()});
+        return true;
+      }
+
       break; // No other 'riscv.*' intrinsics
     }
   } break;

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1753,8 +1753,8 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
 
       // Replace llvm.riscv.clmul with llvm.clmul.
       if (Name == "clmul.i32" || Name == "clmul.i64") {
-        NewFn = Intrinsic::getOrInsertDeclaration(F->getParent(), Intrinsic::clmul,
-                                                  {F->getReturnType()});
+        NewFn = Intrinsic::getOrInsertDeclaration(
+            F->getParent(), Intrinsic::clmul, {F->getReturnType()});
         return true;
       }
 

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -11370,9 +11370,6 @@ SDValue RISCVTargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
     return DAG.getNode(RISCVISD::MOP_RR, DL, XLenVT, Op.getOperand(1),
                        Op.getOperand(2), Op.getOperand(3));
   }
-  case Intrinsic::riscv_clmul:
-    return DAG.getNode(ISD::CLMUL, DL, XLenVT, Op.getOperand(1),
-                       Op.getOperand(2));
   case Intrinsic::riscv_clmulh:
   case Intrinsic::riscv_clmulr: {
     unsigned Opc = IntNo == Intrinsic::riscv_clmulh ? ISD::CLMULH : ISD::CLMULR;
@@ -15546,18 +15543,6 @@ void RISCVTargetLowering::ReplaceNodeResults(SDNode *N,
       SDValue Res = DAG.getNode(
           RISCVISD::MOP_RR, DL, MVT::i64, NewOp0, NewOp1,
           DAG.getTargetConstant(N->getConstantOperandVal(3), DL, MVT::i64));
-      Results.push_back(DAG.getNode(ISD::TRUNCATE, DL, MVT::i32, Res));
-      return;
-    }
-    case Intrinsic::riscv_clmul: {
-      if (!Subtarget.is64Bit() || N->getValueType(0) != MVT::i32)
-        return;
-
-      SDValue NewOp0 =
-          DAG.getNode(ISD::ANY_EXTEND, DL, MVT::i64, N->getOperand(1));
-      SDValue NewOp1 =
-          DAG.getNode(ISD::ANY_EXTEND, DL, MVT::i64, N->getOperand(2));
-      SDValue Res = DAG.getNode(ISD::CLMUL, DL, MVT::i64, NewOp0, NewOp1);
       Results.push_back(DAG.getNode(ISD::TRUNCATE, DL, MVT::i32, Res));
       return;
     }

--- a/llvm/test/CodeGen/RISCV/rv32zbc-zbkc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbc-zbkc-intrinsic.ll
@@ -4,6 +4,7 @@
 ; RUN: llc -mtriple=riscv32 -mattr=+zbkc -verify-machineinstrs < %s \
 ; RUN:   | FileCheck %s -check-prefix=RV32ZBC-ZBKC
 
+; NOTE: This intrinsic has been removed so this tests autoupgrade to llvm.clmul.
 define i32 @clmul32(i32 %a, i32 %b) nounwind {
 ; RV32ZBC-ZBKC-LABEL: clmul32:
 ; RV32ZBC-ZBKC:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/rv64zbc-zbkc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbc-zbkc-intrinsic.ll
@@ -4,6 +4,7 @@
 ; RUN: llc -mtriple=riscv64 -mattr=+zbkc -verify-machineinstrs < %s \
 ; RUN:   | FileCheck %s -check-prefix=RV64ZBC-ZBKC
 
+; NOTE: This intrinsic has been removed so this tests autoupgrade to llvm.clmul.
 define i64 @clmul64(i64 %a, i64 %b) nounwind {
 ; RV64ZBC-ZBKC-LABEL: clmul64:
 ; RV64ZBC-ZBKC:       # %bb.0:
@@ -22,6 +23,7 @@ define i64 @clmul64h(i64 %a, i64 %b) nounwind {
   ret i64 %tmp
 }
 
+; NOTE: This intrinsic has been removed so this tests autoupgrade to llvm.clmul.
 define signext i32 @clmul32(i32 signext %a, i32 signext %b) nounwind {
 ; RV64ZBC-ZBKC-LABEL: clmul32:
 ; RV64ZBC-ZBKC:       # %bb.0:


### PR DESCRIPTION
I did not replace riscv.clmulh/clmulr since those require a multiple instruction pattern match. I wanted to ensure that -O0 will select the correct instructions without relying on combines.