### PR TITLE
[Clang][Sema] Diagnose multiversioning of out-of-class `virtual` func…

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -151,6 +151,7 @@ Miscellaneous Clang Crashes Fixed
 - Fixed a crash when attempting to jump over initialization of a variable with variably modified type. (#GH175540)
 - Fixed a crash when using loop hint with a value dependent argument inside a
   generic lambda. (#GH172289)
+- Fixed a crash when attempting to multiversion a ``virtual`` function in its out-of-class definition. (#GH115317)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -11492,6 +11492,11 @@ bool Sema::areMultiversionVariantFunctionsCompatible(
     return Diag(NoSupportDiagIDAt.first, NoSupportDiagIDAt.second)
            << FuncTemplates;
 
+  if (const auto *OldCXXFD = dyn_cast_or_null<CXXMethodDecl>(OldFD))
+    if (OldCXXFD->isVirtual())
+      return Diag(NoSupportDiagIDAt.first, NoSupportDiagIDAt.second)
+             << VirtFuncs;
+
   if (const auto *NewCXXFD = dyn_cast<CXXMethodDecl>(NewFD)) {
     if (NewCXXFD->isVirtual())
       return Diag(NoSupportDiagIDAt.first, NoSupportDiagIDAt.second)

--- a/clang/test/SemaCXX/attr-target-mv.cpp
+++ b/clang/test/SemaCXX/attr-target-mv.cpp
@@ -192,3 +192,33 @@ int __attribute__((target("default"))) BadOutOfLine::foo(int) { return 1; }
 // expected-note@-4 {{member declaration nearly matches}}
 // expected-note@-4 {{member declaration nearly matches}}
 int __attribute__((target("arch=atom"))) BadOutOfLine::foo(int) { return 1; }
+
+namespace gh115317 {
+  struct S1 {
+    virtual void mv();
+  };
+  // expected-error@+2 {{multiversioned functions do not yet support virtual functions}}
+  __attribute__((target_clones("arch=ivybridge", "default")))
+  void S1::mv() {}
+
+  struct S2 {
+    virtual void mv();
+  };
+  // expected-error@+2 {{multiversioned functions do not yet support virtual functions}}
+  __attribute__((cpu_dispatch(ivybridge, generic)))
+  void S2::mv() {}
+
+  struct S3 {
+    virtual void mv();
+  };
+  // expected-error@+2 {{multiversioned functions do not yet support virtual functions}}
+  __attribute__((target("default")))
+  void S3::mv() {}
+
+  struct S4 {
+    virtual void mv();
+  };
+  // expected-error@+2 {{multiversioned functions do not yet support virtual functions}}
+  __attribute__((cpu_specific(ivybridge)))
+  void S4::mv() {}
+}


### PR DESCRIPTION
…tion definitions

Virtual function multiversioning was never supported, but Sema did not diagnose this if the multiversioning attributes were only applied on the out-of-class definition of the virtual function.

As a result codegen failed with a crash/assertion.

This was caused by checking the `virtual` modifier only on the declaration of the out-of-class definition currently being analyzed, not also the previous declaration.

In the current state not all kinds of multiversioning attributes are handled. Specifically `target_clones` seems to skip the checking function.

Parially addresses #115317