### PR TITLE
[orc-rt] Add unit test for "re-throwing" errors in handleErrors.

### DIFF
--- a/orc-rt/unittests/ErrorTest.cpp
+++ b/orc-rt/unittests/ErrorTest.cpp
@@ -284,6 +284,21 @@ TEST(ErrorTest, IsAHandling) {
   consumeError(std::move(G));
 }
 
+TEST(Error, ReReturnErrorFromHandler) {
+  int ErrorInfo = 0;
+
+  Error E = handleErrors(make_error<CustomError>(7),
+                         [&](std::unique_ptr<CustomError> CE) {
+                           return make_error(std::move(CE));
+                         });
+
+  handleAllErrors(std::move(E),
+                  [&](const CustomError &CE) { ErrorInfo = CE.getInfo(); });
+
+  EXPECT_EQ(ErrorInfo, 7)
+      << "Failed to handle Error returned from handleErrors.";
+}
+
 TEST(ErrorTest, StringError) {
   auto E = make_error<StringError>("foo");
   if (E.isA<StringError>())


### PR DESCRIPTION
handleErrors supports several different handler signatures, including handlers that take a unique_ptr<T> (where T is a descendant of ErrorInfoBase) and return an Error: (std::unique_ptr<T>) -> Error. In this case the handler should be able to create an Error value to wrap the original ErrorInfoBase object without.

This functionality was not previously tested, and will be used in upcoming commits. This commit adds the missing test coverage.