### PR TITLE
[clang][test][NFC] Fix dependency test failures

### DIFF
--- a/clang/test/ClangScanDeps/target-filename.cpp
+++ b/clang/test/ClangScanDeps/target-filename.cpp
@@ -5,18 +5,18 @@
 // RUN: mkdir %t.dir/Inputs
 // RUN: cp %S/Inputs/header.h %t.dir/Inputs/header.h
 // RUN: sed -e "s|DIR|%/t.dir|g" %S/Inputs/target-filename-cdb.json > %t.cdb
-// RUN: clang-scan-deps -compilation-database %t.cdb -j 1 | FileCheck %s %if system-darwin %{ --check-prefixes=CHECK,CHECK-DARWIN %}
+// RUN: clang-scan-deps -compilation-database %t.cdb -j 1 | FileCheck %s --check-prefixes=CHECK,%if system-darwin %{CHECK-DARWIN %} %else %{CHECK-NON-DARWIN %}
 
 // CHECK: target-filename_input.o:
 // CHECK-DARWIN-NEXT: SDKSettings.json
 // CHECK-NEXT: target-filename_input.cpp
 
-// CHECK-NEXT: a.o:
-// CHECK-DARWIN-NEXT: SDKSettings.json
+// CHECK-NON-DARWIN-NEXT: a.o:
+// CHECK-DARWIN-NEXT: a.o:{{.*[[:space:]].*}}SDKSettings.json
 // CHECK-NEXT: target-filename_input.cpp
 
-// CHECK-NEXT: b.o:
-// CHECK-DARWIN-NEXT: SDKSettings.json
+// CHECK-NON-DARWIN-NEXT: b.o:
+// CHECK-DARWIN-NEXT: b.o:{{.*[[:space:]].*}}SDKSettings.json
 // CHECK-NEXT: target-filename_input.cpp
 
 // CHECK-NEXT: last.o:

--- a/clang/test/Frontend/dependency-gen-phony.c
+++ b/clang/test/Frontend/dependency-gen-phony.c
@@ -25,8 +25,7 @@
 // STDIO-NEXT: {{.*}}empty.h:
 // STDIO-NOT:  {{.}}
 
-// STDIO-DARWIN:      -.o: \
-// STDIO-DARWIN-NEXT: SDKSettings.json \
+// STDIO-DARWIN:      -.o:{{.*[[:space:]].*}}SDKSettings.json
 // STDIO-DARWIN-NEXT: Inputs{{/|\\}}empty.h
 // STDIO-DARWIN-NEXT: {{.*}}SDKSettings.json:
 // STDIO-DARWIN-NEXT: {{.*}}empty.h:


### PR DESCRIPTION
If the path to SDKSettings.json is short enough, it will go on the same line as the file in the output.