### PR TITLE
[clang][driver][darwin] Switch back to using CanonicalName to identify the SDK instead of SupportedTargets

### DIFF
--- a/clang/include/clang/Basic/DarwinSDKInfo.h
+++ b/clang/include/clang/Basic/DarwinSDKInfo.h
@@ -181,7 +181,8 @@ public:
   using PlatformInfoStorageType = SmallVector<SDKPlatformInfo, 2>;
 
   DarwinSDKInfo(
-      std::string FilePath, VersionTuple Version,
+      std::string FilePath, llvm::Triple::OSType OS,
+      llvm::Triple::EnvironmentType Environment, VersionTuple Version,
       VersionTuple MaximumDeploymentTarget,
       PlatformInfoStorageType PlatformInfos,
       llvm::DenseMap<OSEnvPair::StorageType,
@@ -189,12 +190,16 @@ public:
           VersionMappings =
               llvm::DenseMap<OSEnvPair::StorageType,
                              std::optional<RelatedTargetVersionMapping>>())
-      : FilePath(FilePath), Version(Version),
+      : FilePath(FilePath), OS(OS), Environment(Environment), Version(Version),
         MaximumDeploymentTarget(MaximumDeploymentTarget),
         PlatformInfos(std::move(PlatformInfos)),
         VersionMappings(std::move(VersionMappings)) {}
 
   StringRef getFilePath() const { return FilePath; }
+
+  llvm::Triple::OSType getOS() const { return OS; }
+
+  llvm::Triple::EnvironmentType getEnvironment() const { return Environment; }
 
   const llvm::VersionTuple &getVersion() const { return Version; }
 
@@ -233,6 +238,8 @@ public:
 
 private:
   std::string FilePath;
+  llvm::Triple::OSType OS;
+  llvm::Triple::EnvironmentType Environment;
   VersionTuple Version;
   VersionTuple MaximumDeploymentTarget;
   PlatformInfoStorageType PlatformInfos;

--- a/clang/lib/Basic/DarwinSDKInfo.cpp
+++ b/clang/lib/Basic/DarwinSDKInfo.cpp
@@ -63,59 +63,57 @@ DarwinSDKInfo::RelatedTargetVersionMapping::parseJSON(
       Min, Max, MinValue, MaximumDeploymentTarget, std::move(Mapping));
 }
 
-static DarwinSDKInfo::PlatformInfoStorageType
-parsePlatformInfos(const llvm::json::Object &Obj, VersionTuple Version) {
+static std::optional<StringRef>
+parseXcodePlatform(const llvm::json::Object &Obj) {
   // The CanonicalName is the Xcode platform followed by a version, e.g.
-  // macosx15.0. The associated SDKPlatformInfo must be the first entry  in the
-  // returned PlatformInfoStorageType.
-  StringRef XcodePlatform;
-  if (auto CanonicalName = Obj.getString("CanonicalName")) {
-    size_t VersionStart = CanonicalName->find_first_of("0123456789");
-    XcodePlatform = CanonicalName->slice(0, VersionStart);
-  }
+  // macosx15.0.
+  auto CanonicalName = Obj.getString("CanonicalName");
+  if (!CanonicalName)
+    return std::nullopt;
+  size_t VersionStart = CanonicalName->find_first_of("0123456789");
+  return CanonicalName->slice(0, VersionStart);
+}
 
+static std::pair<llvm::Triple::OSType, llvm::Triple::EnvironmentType>
+parseOSAndEnvironment(std::optional<StringRef> XcodePlatform) {
+  if (!XcodePlatform)
+    return {llvm::Triple::UnknownOS, llvm::Triple::UnknownEnvironment};
+
+  llvm::Triple::OSType OS =
+      llvm::StringSwitch<llvm::Triple::OSType>(*XcodePlatform)
+          .Case("macosx", llvm::Triple::MacOSX)
+          .Cases({"iphoneos", "iphonesimulator"}, llvm::Triple::IOS)
+          .Cases({"appletvos", "appletvsimulator"}, llvm::Triple::TvOS)
+          .Cases({"watchos", "watchsimulator"}, llvm::Triple::WatchOS)
+          .Case("bridgeos", llvm::Triple::BridgeOS)
+          .Cases({"xros", "xrsimulator"}, llvm::Triple::XROS)
+          .Case("driverkit", llvm::Triple::DriverKit)
+          .Default(llvm::Triple::UnknownOS);
+
+  llvm::Triple::EnvironmentType Environment =
+      llvm::StringSwitch<llvm::Triple::EnvironmentType>(*XcodePlatform)
+          .Cases({"iphonesimulator", "appletvsimulator", "watchsimulator",
+                  "xrsimulator"},
+                 llvm::Triple::Simulator)
+          .Default(llvm::Triple::UnknownEnvironment);
+
+  return {OS, Environment};
+}
+
+static DarwinSDKInfo::PlatformInfoStorageType parsePlatformInfos(
+    const llvm::json::Object &Obj, std::optional<StringRef> XcodePlatform,
+    llvm::Triple::OSType SDKOS, llvm::Triple::EnvironmentType SDKEnvironment,
+    VersionTuple Version) {
   DarwinSDKInfo::PlatformInfoStorageType PlatformInfos;
   auto SupportedTargets = Obj.getObject("SupportedTargets");
   if (!SupportedTargets) {
-    // For older SDKs that don't have SupportedTargets, infer one from the Xcode
-    // platform.
-    if (XcodePlatform == "macosx") {
-      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::MacOSX,
-                               llvm::Triple::UnknownEnvironment,
-                               llvm::Triple::MachO, ""});
-    } else if (XcodePlatform == "iphoneos") {
-      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::IOS,
-                               llvm::Triple::UnknownEnvironment,
-                               llvm::Triple::MachO, ""});
-    } else if (XcodePlatform == "iphonesimulator") {
-      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::IOS,
-                               llvm::Triple::Simulator, llvm::Triple::MachO,
-                               ""});
-    } else if (XcodePlatform == "appletvos") {
-      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::TvOS,
-                               llvm::Triple::UnknownEnvironment,
-                               llvm::Triple::MachO, ""});
-    } else if (XcodePlatform == "appletvsimulator") {
-      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::TvOS,
-                               llvm::Triple::Simulator, llvm::Triple::MachO,
-                               ""});
-    } else if (XcodePlatform == "watchos") {
-      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::WatchOS,
-                               llvm::Triple::UnknownEnvironment,
-                               llvm::Triple::MachO, ""});
-    } else if (XcodePlatform == "watchsimulator") {
-      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::WatchOS,
-                               llvm::Triple::Simulator, llvm::Triple::MachO,
-                               ""});
-    } else if (XcodePlatform == "driverkit") {
-      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::DriverKit,
-                               llvm::Triple::UnknownEnvironment,
-                               llvm::Triple::MachO, "/System/DriverKit"});
-    } else {
-      llvm::reportFatalUsageError(
-          "Unrecognized CanonicalName in SDKSettings.json. SupportedTargets is "
-          "expected, or a recognized CanonicalName.");
-    }
+    // For older SDKs that don't have SupportedTargets, infer one from the SDK's
+    // OS/Environment.
+    StringRef PlatformPrefix;
+    if (SDKOS == llvm::Triple::DriverKit)
+      PlatformPrefix = "/System/DriverKit";
+    PlatformInfos.push_back({llvm::Triple::Apple, SDKOS, SDKEnvironment,
+                             llvm::Triple::MachO, PlatformPrefix});
     return PlatformInfos;
   }
 
@@ -136,6 +134,8 @@ parsePlatformInfos(const llvm::json::Object &Obj, VersionTuple Version) {
     else
       Triple = llvm::Triple(Arch, *Vendor, *OS);
 
+    // The key is either the Xcode platform, or a variant. The platform must be
+    // the first entry in the returned PlatformInfoStorageType.
     StringRef PlatformOrVariant = SupportedTargetPair.getFirst();
 
     StringRef EffectivePlatformPrefix;
@@ -185,7 +185,12 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(std::string FilePath,
       getVersionKey(*Obj, "MaximumDeploymentTarget");
   if (!MaximumDeploymentVersion)
     return std::nullopt;
-  PlatformInfoStorageType PlatformInfos = parsePlatformInfos(*Obj, *Version);
+  std::optional<StringRef> XcodePlatform = parseXcodePlatform(*Obj);
+  std::pair<llvm::Triple::OSType, llvm::Triple::EnvironmentType>
+      OSAndEnvironment = parseOSAndEnvironment(XcodePlatform);
+  PlatformInfoStorageType PlatformInfos =
+      parsePlatformInfos(*Obj, XcodePlatform, OSAndEnvironment.first,
+                         OSAndEnvironment.second, *Version);
   llvm::DenseMap<OSEnvPair::StorageType,
                  std::optional<RelatedTargetVersionMapping>>
       VersionMappings;
@@ -227,7 +232,8 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(std::string FilePath,
     }
   }
 
-  return DarwinSDKInfo(std::move(FilePath), std::move(*Version),
+  return DarwinSDKInfo(std::move(FilePath), OSAndEnvironment.first,
+                       OSAndEnvironment.second, std::move(*Version),
                        std::move(*MaximumDeploymentVersion),
                        std::move(PlatformInfos), std::move(VersionMappings));
 }

--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -355,6 +355,7 @@ public:
   // the argument translation business.
   mutable bool TargetInitialized;
 
+  // TODO: Are these useful? Can we use Triple::OSType/EnvironmentType instead?
   enum DarwinPlatformKind {
     MacOS,
     IPhoneOS,

--- a/clang/test/Driver/Inputs/FakeOS1.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/FakeOS1.0.sdk/SDKSettings.json
@@ -1,0 +1,27 @@
+{
+  "CanonicalName": "fakeos1.0",
+  "Version": "1.0",
+  "IsBaseSDK": "YES",
+  "DisplayName": "fakeOS 1.0",
+  "MinimalDisplayName": "1.0",
+  "SupportedTargets": {
+    "fakeos": {
+      "PlatformFamilyName": "fakeOS",
+      "PlatformFamilyDisplayName": "fakeOS",
+      "Archs": ["arm64e", "arm64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "",
+      "BuildVersionPlatformID": "11",
+      "ClangRuntimeLibraryPlatformName": "ios",
+      "SystemPrefix": "",
+      "DefaultDeploymentTarget": "1.0",
+      "RecommendedDeploymentTarget": "1.0",
+      "MinimumDeploymentTarget": "1.0", "MaximumDeploymentTarget": "1.0.99",
+      "ValidDeploymentTargets": ["1.0"]
+    }
+  },
+  "VersionMap": {
+    "fakeOS_iOS": {"1.0": "26.0"},
+    "iOS_fakeOS": {"26.0": "1.0"}
+  },
+  "DefaultDeploymentTarget": "1.0",
+  "MaximumDeploymentTarget": "1.0.99"
+}

--- a/clang/test/Driver/darwin-builtin-modules.c
+++ b/clang/test/Driver/darwin-builtin-modules.c
@@ -1,15 +1,16 @@
 // Check that darwin passes -fbuiltin-headers-in-system-modules
 // when expected.
 
-// RUN: %clang -target x86_64-apple-darwin22.4 -### %s 2>&1 | FileCheck %s
-// RUN: %clang -isysroot %S/Inputs/MacOSX10.15.sdk -target x86_64-apple-macos10.15 -### %s 2>&1 | FileCheck %s
-// RUN: %clang -isysroot %S/Inputs/iPhoneOS13.0.sdk -target arm64-apple-ios13.0 -### %s 2>&1 | FileCheck %s
-// CHECK: -fbuiltin-headers-in-system-modules
+// RUN: %clang -target x86_64-apple-darwin22.4 -### %s 2>&1 | FileCheck --check-prefix=CHECK_OLD %s
+// RUN: %clang -isysroot %S/Inputs/MacOSX10.15.sdk -target x86_64-apple-macos10.15 -### %s 2>&1 | FileCheck --check-prefix=CHECK_OLD %s
+// RUN: %clang -isysroot %S/Inputs/iPhoneOS13.0.sdk -target arm64-apple-ios13.0 -### %s 2>&1 | FileCheck --check-prefix=CHECK_OLD %s
+// CHECK_OLD: -fbuiltin-headers-in-system-modules
 
-// RUN: %clang -isysroot %S/Inputs/MacOSX15.0.sdk -target x86_64-apple-macos14.0 -### %s 2>&1 | FileCheck --check-prefix=CHECK_FUTURE %s
-// RUN: %clang -isysroot %S/Inputs/MacOSX15.0.sdk -target x86_64-apple-macos15.0 -### %s 2>&1 | FileCheck --check-prefix=CHECK_FUTURE %s
-// RUN: %clang -isysroot %S/Inputs/MacOSX15.0.sdk -target x86_64-apple-ios18.0-macabi -### %s 2>&1 | FileCheck --check-prefix=CHECK_FUTURE %s
-// RUN: %clang -isysroot %S/Inputs/MacOSX15.1.sdk -target x86_64-apple-macos15.1 -darwin-target-variant x86_64-apple-ios18.1-macabi -### %s 2>&1 | FileCheck --check-prefix=CHECK_FUTURE %s
-// RUN: %clang -isysroot %S/Inputs/MacOSX15.1.sdk -target x86_64-apple-ios18.1-macabi -darwin-target-variant x86_64-apple-macos15.1 -### %s 2>&1 | FileCheck --check-prefix=CHECK_FUTURE %s
-// RUN: %clang -isysroot %S/Inputs/DriverKit23.0.sdk -target arm64-apple-driverkit23.0 -### %s 2>&1 | FileCheck --check-prefix=CHECK_FUTURE %s
-// CHECK_FUTURE-NOT: -fbuiltin-headers-in-system-modules
+// RUN: %clang -isysroot %S/Inputs/MacOSX15.0.sdk -target x86_64-apple-macos14.0 -### %s 2>&1 | FileCheck --check-prefix=CHECK_NEW %s
+// RUN: %clang -isysroot %S/Inputs/MacOSX15.0.sdk -target x86_64-apple-macos15.0 -### %s 2>&1 | FileCheck --check-prefix=CHECK_NEW %s
+// RUN: %clang -isysroot %S/Inputs/MacOSX15.0.sdk -target x86_64-apple-ios18.0-macabi -### %s 2>&1 | FileCheck --check-prefix=CHECK_NEW %s
+// RUN: %clang -isysroot %S/Inputs/MacOSX15.1.sdk -target x86_64-apple-macos15.1 -darwin-target-variant x86_64-apple-ios18.1-macabi -### %s 2>&1 | FileCheck --check-prefix=CHECK_NEW %s
+// RUN: %clang -isysroot %S/Inputs/MacOSX15.1.sdk -target x86_64-apple-ios18.1-macabi -darwin-target-variant x86_64-apple-macos15.1 -### %s 2>&1 | FileCheck --check-prefix=CHECK_NEW %s
+// RUN: %clang -isysroot %S/Inputs/DriverKit23.0.sdk -target arm64-apple-driverkit23.0 -### %s 2>&1 | FileCheck --check-prefix=CHECK_NEW %s
+// RUN: %clang -isysroot %S/Inputs/FakeOS1.0.sdk -target arm64-apple-ios1.0 -### %s 2>&1 | FileCheck --check-prefix=CHECK_NEW %s
+// CHECK_NEW-NOT: -fbuiltin-headers-in-system-modules


### PR DESCRIPTION
The SDK's SupportedTarget for its CanonicalName doesn't necessarily have an LLVMTargetTripleSys/LLVMTargetTripleEnvironment that matches the CanonicalName. e.g. sometimes new SDKs use arm64-apple-ios1.0 during bringup, but their CanonicalName is set to the new platform. Go back to using CanonicalName to identify the SDK as a Triple::OSType, and expose the Triple::EnvironmentType used to build the SDKPlatformInfo when SupportedTargets isn't present.