### PR TITLE
[mlir][tensor] Fix return type for ExtractSlice canonicalizer

### DIFF
--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -2707,8 +2707,24 @@ struct SliceReturnTypeCanonicalizer {
                               ArrayRef<OpFoldResult> mixedOffsets,
                               ArrayRef<OpFoldResult> mixedSizes,
                               ArrayRef<OpFoldResult> mixedStrides) {
-    return ExtractSliceOp::inferCanonicalRankReducedResultType(
-        op.getType().getRank(), op.getSourceType(), mixedSizes);
+    // Infer a tensor type without taking into account any rank reductions.
+    RankedTensorType nonReducedType =
+        ExtractSliceOp::inferResultType(op.getSourceType(), mixedSizes);
+
+    // Directly return the non-rank reduced type if there are no dropped
+    // dims.
+    llvm::SmallBitVector droppedDims = op.getDroppedDims();
+    if (droppedDims.none())
+      return nonReducedType;
+
+    // Build the reduced shape, preserving the original rank reduction pattern.
+    SmallVector<int64_t> targetShape;
+    for (int64_t i = 0; i < static_cast<int64_t>(mixedSizes.size()); ++i)
+      if (!droppedDims.test(i))
+        targetShape.push_back(nonReducedType.getDimSize(i));
+
+    return RankedTensorType::get(targetShape, nonReducedType.getElementType(),
+                                 nonReducedType.getEncoding());
   }
 };
 

--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -2719,7 +2719,7 @@ struct SliceReturnTypeCanonicalizer {
 
     // Build the reduced shape, preserving the original rank reduction pattern.
     SmallVector<int64_t> targetShape;
-    for (int64_t i = 0; i < static_cast<int64_t>(mixedSizes.size()); ++i)
+    for (auto i : llvm::seq<int64_t>(mixedSizes.size()))
       if (!droppedDims.test(i))
         targetShape.push_back(nonReducedType.getDimSize(i));
 

--- a/mlir/test/Dialect/Tensor/canonicalize.mlir
+++ b/mlir/test/Dialect/Tensor/canonicalize.mlir
@@ -567,6 +567,23 @@ func.func @rank_reducing_slice_canonicalize(%arg0 : tensor<?x?x?xf32>, %arg1 : i
 
 // -----
 
+func.func @rank_reducing_slice_preserve_dropped_dims(
+    %arg0 : tensor<1x1x8x1xf16>, %arg1 : index) -> tensor<1x4xf16> {
+  %c0 = arith.constant 0 : index
+  %0 = tensor.extract_slice %arg0[%c0, 0, %arg1, 0] [1, 1, 4, 1] [1, 1, 1, 1]
+    : tensor<1x1x8x1xf16> to tensor<1x4xf16>
+  return %0 : tensor<1x4xf16>
+}
+// CHECK-LABEL: func @rank_reducing_slice_preserve_dropped_dims
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<1x1x8x1xf16>
+//  CHECK-SAME:   %[[ARG1:.+]]: index
+//       CHECK:   %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]]
+//  CHECK-SAME:      [0, 0, %[[ARG1]], 0] [1, 1, 4, 1] [1, 1, 1, 1]
+//  CHECK-SAME:      : tensor<1x1x8x1xf16> to tensor<1x4xf16>
+//       CHECK:   return %[[SLICE]]
+
+// -----
+
 // CHECK-LABEL: func @trivial_slice
 //  CHECK-SAME:   %[[ARG0:.[a-z0-9A-Z_]+]]: tensor<4x6x16x32xi8>
 //   CHECK-NOT:   tensor.extract_slice


### PR DESCRIPTION
The `OpWithOffsetSizesAndStridesConstantArgumentFolder` pattern for tensor.extract_slice was incorrectly using `inferCanonicalRankReducedResultType()` to compute the result type after folding constant offsets. This function infers a canonical rank reduction (dropping the first N unit dimensions), which breaks when the original operation used a non-canonical rank reduction. This change is similar to the existing correct behavior in `SubViewReturnTypeCanonicalizer` for `memref.subview`.

For example, extracting `tensor<1x4xf16>` from `tensor<1x1x8x1xf16>` by dropping dims 0 and 3 would incorrectly produce tensor<4x1xf16> (canonical: drop dims 0 and 1).