### PR TITLE
[libclc] Make output filename configurable; rename top-level targets

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -466,6 +466,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
       OPT_FLAGS ${opt_flags}
       LIB_FILES ${opencl_lib_files}
       ALIASES ${${d}_aliases}
+      OUTPUT_FILENAME libclc
       PARENT_TARGET libclc-opencl-builtins
       # Link in the CLC builtins and internalize their symbols
       INTERNAL_LINK_DEPENDENCIES builtins.link.clc-${arch_suffix}

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -241,6 +241,8 @@ endfunction()
 #      libclc architecture/triple suffix
 #  * TRIPLE <string>
 #      Triple used to compile
+#  * OUTPUT_FILENAME <string>
+#      libclc output library name
 #  * PARENT_TARGET <string>
 #      Target into which to group the target builtins
 #
@@ -263,7 +265,7 @@ endfunction()
 function(add_libclc_builtin_set)
   cmake_parse_arguments(ARG
     "CLC_INTERNAL"
-    "ARCH;DEVICE;TRIPLE;ARCH_SUFFIX;PARENT_TARGET"
+    "ARCH;DEVICE;TRIPLE;ARCH_SUFFIX;OUTPUT_FILENAME;PARENT_TARGET"
     "LIB_FILES;COMPILE_FLAGS;OPT_FLAGS;ALIASES;INTERNAL_LINK_DEPENDENCIES"
     ${ARGN}
   )
@@ -374,7 +376,7 @@ function(add_libclc_builtin_set)
     return()
   endif()
 
-  set( LIBCLC_OUTPUT_FILENAME libclc )
+  set( LIBCLC_OUTPUT_FILENAME ${ARG_OUTPUT_FILENAME} )
   set( builtins_link_lib $<TARGET_PROPERTY:${builtins_link_lib_tgt},TARGET_FILE> )
 
   # We store the library according to its triple and cpu if present.
@@ -418,16 +420,16 @@ function(add_libclc_builtin_set)
     FOLDER "libclc/Device IR/Library"
   )
 
-  # Also add a 'library' target for the triple. Since a triple may have
+  # Also add a 'libclc' target for the triple. Since a triple may have
   # multiple devices, ensure we only try to create the triple target once. The
   # triple's target will build all of the bytecode for its constituent devices.
-  if( NOT TARGET library-${ARG_TRIPLE} )
-    add_custom_target( library-${ARG_TRIPLE} ALL )
+  if( NOT TARGET libclc-${ARG_TRIPLE} )
+    add_custom_target( libclc-${ARG_TRIPLE} ALL )
   endif()
-  add_dependencies( library-${ARG_TRIPLE} library-${ARG_ARCH_SUFFIX} )
+  add_dependencies( libclc-${ARG_TRIPLE} library-${ARG_ARCH_SUFFIX} )
   # Add dependency to top-level pseudo target to ease making other
   # targets dependent on libclc.
-  add_dependencies( ${ARG_PARENT_TARGET} library-${ARG_TRIPLE} )
+  add_dependencies( ${ARG_PARENT_TARGET} libclc-${ARG_TRIPLE} )
 
   # Install the created library.
   install(

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -376,6 +376,9 @@ function(add_libclc_builtin_set)
     return()
   endif()
 
+  if (NOT DEFINED ARG_OUTPUT_FILENAME OR ARG_OUTPUT_FILENAME STREQUAL "")
+    message(FATAL_ERROR "OUTPUT_FILENAME parameter is required and must be non-empty.")
+  endif()
   set( LIBCLC_OUTPUT_FILENAME ${ARG_OUTPUT_FILENAME} )
   set( builtins_link_lib $<TARGET_PROPERTY:${builtins_link_lib_tgt},TARGET_FILE> )
 


### PR DESCRIPTION
This PR relates to c5cb48c39701.

Pass `OUTPUT_FILENAME` to `add_libclc_builtin_set` to allow downstream output naming (e.g. libspirv in https://github.com/intel/llvm/tree/sycl/libclc).

Rename top-level target to `libclc-${ARG_TRIPLE}` to avoid collision with `library-${ARG_ARCH_SUFFIX}` in our downstream when libclc TRIPLE matches libspirv ARCH_SUFFIX.