### PR TITLE
[PowerPC] Align bcdsetsign Sema validation with other BCD builtins

### DIFF
--- a/clang/lib/Sema/SemaPPC.cpp
+++ b/clang/lib/Sema/SemaPPC.cpp
@@ -147,7 +147,14 @@ bool SemaPPC::CheckPPCBuiltinFunctionCall(const TargetInfo &TI,
   switch (BuiltinID) {
   default:
     return false;
-  case PPC::BI__builtin_ppc_bcdsetsign:
+  case PPC::BI__builtin_ppc_bcdsetsign: {
+    // Arg0 must be vector unsigned char
+    if (!IsTypeVecUChar(TheCall->getArg(0)->getType(), 0))
+      return false;
+
+    // Restrict Arg1 constant range (0–1)
+    return SemaRef.BuiltinConstantArgRange(TheCall, 1, 0, 1);
+  }
   case PPC::BI__builtin_ppc_national2packed:
   case PPC::BI__builtin_ppc_packed2zoned:
   case PPC::BI__builtin_ppc_zoned2packed:

--- a/clang/test/Sema/builtins-bcd-format-conversion.c
+++ b/clang/test/Sema/builtins-bcd-format-conversion.c
@@ -15,6 +15,7 @@
 vector unsigned char test_bcdsetsign(void) {
   DECL_COMMON_VARS
   vector unsigned char res_a = __builtin_ppc_bcdsetsign(scalar, '\1'); // expected-error {{argument 0 must be of type '__vector unsigned char' (vector of 16 'unsigned char' values}}
+  vector unsigned char res_d = __builtin_ppc_bcdsetsign(vec, f); // expected-error-re {{argument to {{.*}} must be a constant integer}}
   vector unsigned char res_b = __builtin_ppc_bcdsetsign(vec, 2); // expected-error-re {{argument value {{.*}} is outside the valid range}}
   vector unsigned char res_c = __builtin_ppc_bcdsetsign(vec, -1); // expected-error-re {{argument value {{.*}} is outside the valid range}}
   return __builtin_ppc_bcdsetsign(vec, '\1');

--- a/clang/test/Sema/builtins-bcd-format-conversion.c
+++ b/clang/test/Sema/builtins-bcd-format-conversion.c
@@ -12,6 +12,14 @@
   int i = 1;                        \
   float f = 1.0f;
 
+vector unsigned char test_bcdsetsign(void) {
+  DECL_COMMON_VARS
+  vector unsigned char res_a = __builtin_ppc_bcdsetsign(scalar, '\1'); // expected-error {{argument 0 must be of type '__vector unsigned char' (vector of 16 'unsigned char' values}}
+  vector unsigned char res_b = __builtin_ppc_bcdsetsign(vec, 2); // expected-error-re {{argument value {{.*}} is outside the valid range}}
+  vector unsigned char res_c = __builtin_ppc_bcdsetsign(vec, -1); // expected-error-re {{argument value {{.*}} is outside the valid range}}
+  return __builtin_ppc_bcdsetsign(vec, '\1');
+}
+
 vector unsigned char test_bcdshift(void) {
   DECL_COMMON_VARS
   vector unsigned char res_a = __builtin_ppc_bcdshift(scalar, i, i); // expected-error {{argument 0 must be of type '__vector unsigned char' (vector of 16 'unsigned char' values)}}


### PR DESCRIPTION
`__builtin_ppc_bcdsetsign` currently uses standalone argument checks due to the `"t"` option. This change brings it in line with the helper-based validation used by other BCD builtins and adds Sema coverage.