### PR TITLE
[clangd] Unify IndexAction callbacks into one

### DIFF
--- a/clang-tools-extra/clangd/index/Background.cpp
+++ b/clang-tools-extra/clangd/index/Background.cpp
@@ -309,10 +309,7 @@ llvm::Error BackgroundIndex::index(tooling::CompileCommand Cmd) {
 
   IndexFileIn Index;
   auto Action = createStaticIndexingAction(
-      IndexOpts, [&](SymbolSlab S) { Index.Symbols = std::move(S); },
-      [&](RefSlab R) { Index.Refs = std::move(R); },
-      [&](RelationSlab R) { Index.Relations = std::move(R); },
-      [&](IncludeGraph IG) { Index.Sources = std::move(IG); });
+      IndexOpts, [&](IndexFileIn Result) { Index = std::move(Result); });
 
   // We're going to run clang here, and it could potentially crash.
   // We could use CrashRecoveryContext to try to make indexing crashes nonfatal,

--- a/clang-tools-extra/clangd/index/IndexAction.h
+++ b/clang-tools-extra/clangd/index/IndexAction.h
@@ -8,15 +8,16 @@
 
 #ifndef LLVM_CLANG_TOOLS_EXTRA_CLANGD_INDEX_INDEXACTION_H
 #define LLVM_CLANG_TOOLS_EXTRA_CLANGD_INDEX_INDEXACTION_H
-#include "Headers.h"
 #include "index/SymbolCollector.h"
 #include "clang/Frontend/FrontendAction.h"
 
 namespace clang {
 namespace clangd {
 
+struct IndexFileIn;
+
 // Creates an action that indexes translation units and delivers the results
-// for SymbolsCallback (each slab corresponds to one TU).
+// for IndexContentsCallback (each call corresponds to one TU).
 //
 // Only a subset of SymbolCollector::Options are respected:
 //   - include paths are always collected, and canonicalized appropriately
@@ -25,10 +26,7 @@ namespace clangd {
 //   - the symbol origin is set to Static if not specified by caller
 std::unique_ptr<FrontendAction> createStaticIndexingAction(
     SymbolCollector::Options Opts,
-    std::function<void(SymbolSlab)> SymbolsCallback,
-    std::function<void(RefSlab)> RefsCallback,
-    std::function<void(RelationSlab)> RelationsCallback,
-    std::function<void(IncludeGraph)> IncludeGraphCallback);
+    std::function<void(IndexFileIn)> IndexContentsCallback);
 
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/unittests/IndexActionTests.cpp
+++ b/clang-tools-extra/clangd/unittests/IndexActionTests.cpp
@@ -86,10 +86,7 @@ public:
         new FileManager(FileSystemOptions(), InMemoryFileSystem));
 
     auto Action = createStaticIndexingAction(
-        Opts, [&](SymbolSlab S) { IndexFile.Symbols = std::move(S); },
-        [&](RefSlab R) { IndexFile.Refs = std::move(R); },
-        [&](RelationSlab R) { IndexFile.Relations = std::move(R); },
-        [&](IncludeGraph IG) { IndexFile.Sources = std::move(IG); });
+        Opts, [&](IndexFileIn Result) { IndexFile = std::move(Result); });
 
     std::vector<std::string> Args = {"index_action", "-fsyntax-only",
                                      "-xc++",        "-std=c++11",


### PR DESCRIPTION
This allows users of IndexAction who create the action but do not call it (e.g. the call will happen through ToolExecutor) to do some work when the action is complete, without assuming that a particular one of the individual callbacks (e.g. include graph) will be called last.