### PR TITLE
[ASan] Fix UnpoisonDefaultStack stack bottom estimation

### DIFF
--- a/compiler-rt/lib/asan/asan_rtl.cpp
+++ b/compiler-rt/lib/asan/asan_rtl.cpp
@@ -618,7 +618,9 @@ static void UnpoisonDefaultStack() {
     int local_stack;
     const uptr page_size = GetPageSizeCached();
     top = curr_thread->stack_top();
-    bottom = ((uptr)&local_stack - page_size) & ~(page_size - 1);
+    bottom = (uptr)&local_stack & ~(page_size - 1);
+    if (AddrIsInMem(bottom - page_size))
+      bottom -= page_size;
   } else {
     CHECK(!SANITIZER_FUCHSIA);
     // If we haven't seen this thread, try asking the OS for stack bounds.


### PR DESCRIPTION
UnpoisonDefaultStack estimates the stack bottom as:

```
    bottom = ((uptr)&local_stack - page_size) & ~(page_size - 1);
```

However, this can try to poision memory that doesn't have a shadow (i.e. AddrIsInMem(x) is false) if the local_stack variable is within two pages of the actual bottom of the space available for stack. This causes the unpoison-alternate-stack.cpp test (which allocates a very small stack) to fail.

This PR changes this computation to check AddrIsInMem before subtracting the additional page.

rdar://82645815