### PR TITLE
[flang] remove AbstractConverter.h include from IntrinsicCall.h

### DIFF
--- a/flang/include/flang/Optimizer/Builder/IntrinsicCall.h
+++ b/flang/include/flang/Optimizer/Builder/IntrinsicCall.h
@@ -9,7 +9,6 @@
 #ifndef FORTRAN_LOWER_INTRINSICCALL_H
 #define FORTRAN_LOWER_INTRINSICCALL_H
 
-#include "flang/Lower/AbstractConverter.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/Runtime/Character.h"
@@ -21,6 +20,15 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include <optional>
+
+namespace Fortran {
+namespace lower {
+// TODO: remove the usage of AbstractConverter to avoid making IntrinsicCall.cpp
+// depend upon Lower/Evaluate and use a data structure to pass options to
+// IntrinsicLibrary.
+class AbstractConverter;
+} // namespace lower
+} // namespace Fortran
 
 namespace fir {
 

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -15,6 +15,7 @@
 
 #include "flang/Optimizer/Builder/IntrinsicCall.h"
 #include "flang/Common/static-multimap-view.h"
+#include "flang/Lower/AbstractConverter.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/CUDAIntrinsicCall.h"
 #include "flang/Optimizer/Builder/CUFCommon.h"

--- a/flang/lib/Optimizer/Builder/PPCIntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/PPCIntrinsicCall.cpp
@@ -15,6 +15,7 @@
 
 #include "flang/Optimizer/Builder/PPCIntrinsicCall.h"
 #include "flang/Evaluate/common.h"
+#include "flang/Lower/AbstractConverter.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/MutableBox.h"
 #include "mlir/Dialect/Index/IR/IndexOps.h"


### PR DESCRIPTION
AbstractConverter.h is pulling a lot of headers, including some from Evaluate. This causes any library using IntrinsicCall.h to have to link against FortranEvaluate and FortranSupport while there is no actual need/usage of Evaluate data structures.

I opened https://github.com/llvm/llvm-project/issues/178142 to fully remove the AbstractConverter from IntrinsicCall.cpp, but for now this patch should at least prevent the consumers of IntrinsicCall.h to bring-in these extra libraries.

Should solve the DEBUG build problem from https://github.com/llvm/llvm-project/pull/178076.