### PR TITLE
[NFC][AMDGPU] Add missing `lit.local.cfg` to `PreISelIntrinsicLowering` tests

### DIFF
--- a/llvm/test/Transforms/PreISelIntrinsicLowering/AMDGPU/lit.local.cfg
+++ b/llvm/test/Transforms/PreISelIntrinsicLowering/AMDGPU/lit.local.cfg
@@ -1,0 +1,2 @@
+if not "AMDGPU" in config.root.targets:
+    config.unsupported = True


### PR DESCRIPTION
Add `lit.local.cfg` to restrict the `PreISelIntrinsicLowering/AMDGPU` tests to AMDGPU only.

These tests were previously being run for all targets.