### PR TITLE
InstCombine: Stop preserving undef in SimplifyDemandedFPClass

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -3389,7 +3389,7 @@ bool InstCombinerImpl::SimplifyDemandedFPClass(Instruction *I, unsigned OpNo,
   Type *VTy = V->getType();
 
   if (DemandedMask == fcNone) {
-    if (isa<UndefValue>(V))
+    if (isa<PoisonValue>(V))
       return false;
     replaceUse(U, PoisonValue::get(VTy));
     return true;
@@ -3403,7 +3403,7 @@ bool InstCombinerImpl::SimplifyDemandedFPClass(Instruction *I, unsigned OpNo,
     Known.knownNot(~DemandedMask);
 
     if (Known.KnownFPClasses == fcNone) {
-      if (isa<UndefValue>(V))
+      if (isa<PoisonValue>(V))
         return false;
       replaceUse(U, PoisonValue::get(VTy));
       return true;

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
@@ -40,6 +40,23 @@ define nofpclass(inf) float @ret_nofpclass_inf_undef() {
   ret float undef
 }
 
+define nofpclass(all) float @ret_nofpclass_all_undef() {
+; CHECK-LABEL: define nofpclass(all) float @ret_nofpclass_all_undef() {
+; CHECK-NEXT:    ret float poison
+;
+  ret float undef
+}
+
+; Use + callsite implies no values, should fold undef to poison.
+define nofpclass(nan) float @undef_folds_to_poison_arg() {
+; CHECK-LABEL: define nofpclass(nan) float @undef_folds_to_poison_arg() {
+; CHECK-NEXT:    [[FENCE:%.*]] = call float @llvm.arithmetic.fence.f32(float nofpclass(inf zero sub norm) poison)
+; CHECK-NEXT:    ret float [[FENCE]]
+;
+  %fence = call float @llvm.arithmetic.fence.f32(float nofpclass(inf sub norm zero) undef)
+  ret float %fence
+}
+
 ; Make sure there's no infinite loop
 define nofpclass(all) float @ret_nofpclass_all_var(float %arg) {
 ; CHECK-LABEL: define nofpclass(all) float @ret_nofpclass_all_var


### PR DESCRIPTION
If we know there are no valid values, fold to poison. Previously this
would leave values that started as undef alone.