### PR TITLE
[flang-rt] Use std::numeric_limits::infinity

### DIFF
--- a/flang-rt/unittests/Runtime/Reduction.cpp
+++ b/flang-rt/unittests/Runtime/Reduction.cpp
@@ -674,7 +674,7 @@ TEST(Reductions, ReduceInt4Dim) {
 }
 
 TEST(Reductions, InfSums) {
-  float inf{1.0f / 0.0f};
+  auto inf{std::numeric_limits<float>::infinity()};
   auto inf0{MakeArray<TypeCategory::Real, 4>(
       std::vector<int>{2, 3}, std::vector<float>{inf, 0.0f})};
   auto t1{RTNAME(SumReal4)(*inf0, __FILE__, __LINE__)};


### PR DESCRIPTION
#175373 introduces a divide-by-zero to create an infinity value, which is undefined behavior in C++ (C++20 [expr.mul] §4), even when done at compile-time. This causes flaky test fails with the flang-x86_64-windows buildbot. Visual Studio 2026 refuses to compile it with error C2124.

Use `std::numeric_limits<float>::infinity()` instead.