### PR TITLE
[GHA] Disable the ids-check workflow

### DIFF
--- a/.github/workflows/ids-check.yml
+++ b/.github/workflows/ids-check.yml
@@ -1,6 +1,10 @@
 name: "Check LLVM ABI annotations"
+
+# TODO(https://github.com/llvm/llvm-project/issues/109483): Re-enable on pull
+# requests once the workflow is less diruptive.
 on:
-  pull_request:
+  # pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
The workflow is too disruptive as it is because we are still missing too many `LLVM_ABI` annotations. Disable it for the time being.

See #109483 for details.