### PR TITLE
[flang] propagate IVDEP in array expressions optimization

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2408,6 +2408,14 @@ private:
             // necessary to forward the AccessGroups attribute.
             assignOp.getOperation()->setAttr(fir::getAccessGroupsAttrName(),
                                              attrs);
+          } else if (hlfir::RegionAssignOp regionAssignOp =
+                         mlir::dyn_cast<hlfir::RegionAssignOp>(op)) {
+            // User defined assignment, WHERE and FORALL assignments are
+            // abstracted via hlfir.region_assign at that stage. Set the
+            // access group on it so that it can later be propagated to
+            // hlfir.assign/fir.store/fir.loads created to implement it.
+            regionAssignOp.getOperation()->setAttr(
+                fir::getAccessGroupsAttrName(), attrs);
           } else if (fir::CallOp callOp = mlir::dyn_cast<fir::CallOp>(op)) {
             callOp.setAccessGroupsAttr(attrs);
           }

--- a/flang/lib/Optimizer/HLFIR/Transforms/LowerHLFIROrderedAssignments.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/LowerHLFIROrderedAssignments.cpp
@@ -517,7 +517,10 @@ void OrderedAssignmentRewriter::pre(hlfir::RegionAssignOp regionAssignOp) {
   } else {
     // TODO: preserve allocatable assignment aspects for forall once
     // they are conveyed in hlfir.region_assign.
-    hlfir::AssignOp::create(builder, loc, rhsEntity, lhsEntity);
+    auto assignOp = hlfir::AssignOp::create(builder, loc, rhsEntity, lhsEntity);
+    if (auto accessGroups = regionAssignOp->getAttrOfType<mlir::ArrayAttr>(
+            fir::getAccessGroupsAttrName()))
+      assignOp->setAttr(fir::getAccessGroupsAttrName(), accessGroups);
   }
   generateCleanupIfAny(loweredLhs.elementalCleanup);
   if (loweredLhs.vectorSubscriptLoopNest)

--- a/flang/test/Lower/HLFIR/ivdep-elemental.f90
+++ b/flang/test/Lower/HLFIR/ivdep-elemental.f90
@@ -1,0 +1,20 @@
+! RUN: %flang_fc1 -emit-fir -O2 %s -o - | FileCheck %s
+
+! CHECK: #[[ANNOTATION:.*]] = #llvm.loop_annotation<vectorize = #{{.*}}, parallelAccesses = #[[GROUP:.*]]>
+subroutine elemental_assignment_in_loop(a, b)
+  real :: a(100,100), b(100,100)
+  !dir$ ivdep
+  ! CHECK: fir.do_loop
+  ! CHECK-SAME: loopAnnotation = #[[ANNOTATION]]
+  do i=1,100
+    ! CHECK: fir.do_loop
+      ! CHECK: fir.load
+      ! CHECK-SAME: accessGroups = [#[[GROUP]]]
+      ! CHECK: fir.store
+      ! CHECK-SAME: accessGroups = [#[[GROUP]]]
+    a(i, :) = b(i, :) * 3.0
+    ! CHECK: }
+  ! CHECK: }
+  ! CHECK: return
+  end do
+end subroutine

--- a/flang/test/Lower/HLFIR/ivdep-where.f90
+++ b/flang/test/Lower/HLFIR/ivdep-where.f90
@@ -1,0 +1,17 @@
+! RUN: %flang_fc1 -emit-fir -O2 %s -o - | FileCheck %s
+
+! CHECK: #[[ANNOTATION:.*]] = #llvm.loop_annotation<vectorize = #{{.*}}, parallelAccesses = #[[GROUP:.*]]>
+subroutine test_where(a, l)
+  real :: a(100,100)
+  logical :: l(100, 100)
+  !dir$ ivdep
+  ! CHECK: fir.do_loop
+  ! CHECK-SAME: loopAnnotation = #[[ANNOTATION]]
+  do i=1,100
+    ! CHECK: fir.do_loop
+    where (l(i, :)) a(i, :) = 3.0
+    ! CHECK: fir.store
+    ! CHECK-SAME: accessGroups = [#[[GROUP]]]
+    ! CHECK: }
+  end do
+end subroutine


### PR DESCRIPTION
Follow-up on https://github.com/llvm/llvm-project/pull/177940.
This propagates the access attribute in cases where hlfir.assign is being transformed in array expression optimizations.
It also adds handling for the cases where there are WHERE/FORALL or user defined assignments inside the loop and that an hlfir.region_assign is first being generated.