### PR TITLE
[VPlan] Split out EVL exit cond transform from canonicalizeEVLLoops. NFC

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -7424,14 +7424,14 @@ DenseMap<const SCEV *, Value *> LoopVectorizationPlanner::executePlan(
   VPlanTransforms::removeDeadRecipes(BestVPlan);
 
   VPlanTransforms::convertToConcreteRecipes(BestVPlan);
+  // Convert the exit condition to AVLNext == 0 for EVL tail folded loops.
+  VPlanTransforms::convertEVLExitCond(BestVPlan);
   // Regions are dissolved after optimizing for VF and UF, which completely
   // removes unneeded loop regions first.
   VPlanTransforms::dissolveLoopRegions(BestVPlan);
   // Expand BranchOnTwoConds after dissolution, when latch has direct access to
   // its successors.
   VPlanTransforms::expandBranchOnTwoConds(BestVPlan);
-  // Switch the exit condition to AVLNext == 0 for EVL tail folded loops.
-  VPlanTransforms::convertEVLExitCond(BestVPlan);
   // Canonicalize EVL loops after regions are dissolved.
   VPlanTransforms::canonicalizeEVLLoops(BestVPlan);
   VPlanTransforms::materializeBackedgeTakenCount(BestVPlan, VectorPH);

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -7430,6 +7430,8 @@ DenseMap<const SCEV *, Value *> LoopVectorizationPlanner::executePlan(
   // Expand BranchOnTwoConds after dissolution, when latch has direct access to
   // its successors.
   VPlanTransforms::expandBranchOnTwoConds(BestVPlan);
+  // Switch the exit condition to AVLNext == 0 for EVL tail folded loops.
+  VPlanTransforms::convertEVLExitCond(BestVPlan);
   // Canonicalize EVL loops after regions are dissolved.
   VPlanTransforms::canonicalizeEVLLoops(BestVPlan);
   VPlanTransforms::materializeBackedgeTakenCount(BestVPlan, VectorPH);

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -3295,7 +3295,7 @@ void VPlanTransforms::convertEVLExitCond(VPlan &Plan) {
       !isa<VPCanonicalIVPHIRecipe>(LoopRegion->getEntryBasicBlock()->front()))
     return;
   VPCanonicalIVPHIRecipe *CanIV = LoopRegion->getCanonicalIV();
-  if (!CanIV || std::next(CanIV->getIterator()) == CanIV->getParent()->end())
+  if (std::next(CanIV->getIterator()) == CanIV->getParent()->end())
     return;
   // The EVL IV is always immediately after the canonical IV.
   auto *EVLPhi =

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
@@ -302,7 +302,7 @@ struct VPlanTransforms {
                                          VPBasicBlock *LatchVPBB);
 
   /// Replaces the exit condition from
-  ///   (branch-on-count CanonicalIVInc, VectorTripCount)
+  ///   (branch-on-cond eq CanonicalIVInc, VectorTripCount)
   /// to
   ///   (branch-on-cond eq AVLNext, 0)
   static void convertEVLExitCond(VPlan &Plan);

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
@@ -301,6 +301,12 @@ struct VPlanTransforms {
                                          VPlan &Plan, VPBasicBlock *HeaderVPBB,
                                          VPBasicBlock *LatchVPBB);
 
+  /// Replaces the exit condition from
+  ///   (branch-on-count CanonicalIVInc, VectorTripCount)
+  /// to
+  ///   (branch-on-cond eq AVLNext, 0)
+  static void convertEVLExitCond(VPlan &Plan);
+
   /// Replace loop regions with explicit CFG.
   static void dissolveLoopRegions(VPlan &Plan);
 
@@ -316,12 +322,6 @@ struct VPlanTransforms {
   ///  * Makes EVL-Phi concrete.
   //   * Removes CanonicalIV and increment.
   static void canonicalizeEVLLoops(VPlan &Plan);
-
-  /// Replaces the exit condition from
-  ///   (branch-on-count CanonicalIVInc, VectorTripCount)
-  /// to
-  ///   (branch-on-cond eq AVLNext, 0)
-  static void convertEVLExitCond(VPlan &Plan);
 
   /// Lower abstract recipes to concrete ones, that can be codegen'd.
   static void convertToConcreteRecipes(VPlan &Plan);

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
@@ -315,11 +315,13 @@ struct VPlanTransforms {
   /// variable vector lengths instead of fixed lengths. This transformation:
   ///  * Makes EVL-Phi concrete.
   //   * Removes CanonicalIV and increment.
-  ///  * Replaces the exit condition from
-  ///      (branch-on-count CanonicalIVInc, VectorTripCount)
-  ///    to
-  ///      (branch-on-cond eq AVLNext, 0)
   static void canonicalizeEVLLoops(VPlan &Plan);
+
+  /// Replaces the exit condition from
+  ///   (branch-on-count CanonicalIVInc, VectorTripCount)
+  /// to
+  ///   (branch-on-cond eq AVLNext, 0)
+  static void convertEVLExitCond(VPlan &Plan);
 
   /// Lower abstract recipes to concrete ones, that can be codegen'd.
   static void convertToConcreteRecipes(VPlan &Plan);

--- a/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
@@ -339,6 +339,13 @@ bool VPlanVerifier::verifyVPBasicBlock(const VPBasicBlock *VPBB) {
         return false;
       }
     }
+    if (const auto *EVLIV = dyn_cast<VPEVLBasedIVPHIRecipe>(&R)) {
+      if (!isa_and_nonnull<VPCanonicalIVPHIRecipe>(
+              std::prev(EVLIV->getIterator()))) {
+        errs() << "EVL based IV is not immediately after canonical IV\n";
+        return false;
+      }
+    }
     if (const auto *VPI = dyn_cast<VPInstruction>(&R)) {
       switch (VPI->getOpcode()) {
       case VPInstruction::ExplicitVectorLength:

--- a/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
@@ -103,6 +103,12 @@ bool VPlanVerifier::verifyPhiRecipes(const VPBasicBlock *VPBB) {
       return false;
     }
 
+    if (isa<VPEVLBasedIVPHIRecipe>(RecipeI) &&
+        !isa_and_nonnull<VPCanonicalIVPHIRecipe>(std::prev(RecipeI))) {
+      errs() << "EVL based IV is not immediately after canonical IV\n";
+      return false;
+    }
+
     // Check if the recipe operands match the number of predecessors.
     // TODO Extend to other phi-like recipes.
     if (auto *PhiIRI = dyn_cast<VPIRPhi>(&*RecipeI)) {
@@ -336,13 +342,6 @@ bool VPlanVerifier::verifyVPBasicBlock(const VPBasicBlock *VPBB) {
         R.print(errs(), "  ", Tracker);
         errs() << "\n";
 #endif
-        return false;
-      }
-    }
-    if (const auto *EVLIV = dyn_cast<VPEVLBasedIVPHIRecipe>(&R)) {
-      if (!isa_and_nonnull<VPCanonicalIVPHIRecipe>(
-              std::prev(EVLIV->getIterator()))) {
-        errs() << "EVL based IV is not immediately after canonical IV\n";
         return false;
       }
     }


### PR DESCRIPTION
This is split out from #177114.

In order to make canonicalizeEVLLoops a generic "convert to variable stepping" transform, move the code that changes the exit condition to a separate transform since not all variable stepping loops will want to transform the exit condition. Run it before canonicalizeEVLLoops before VPEVLBasedIVPHIRecipe is expanded.

Also relax the assertion for VPInstruction::ExplicitVectorLength to just bail instead, since eventually VPEVLBasedIVPHIRecipe will be used by other loops that aren't EVL tail folded.
