### PR TITLE
[libc++] Avoid template instantiations in the duration aliases

### DIFF
--- a/libcxx/include/__chrono/duration.h
+++ b/libcxx/include/__chrono/duration.h
@@ -291,13 +291,13 @@ typedef duration<long long, nano> nanoseconds;
 typedef duration<long long, micro> microseconds;
 typedef duration<long long, milli> milliseconds;
 typedef duration<long long > seconds;
-typedef duration< long, ratio< 60> > minutes;
-typedef duration< long, ratio<3600> > hours;
+typedef duration<long, ratio<60> > minutes;
+typedef duration<long, ratio<60 * 60> > hours;
 #if _LIBCPP_STD_VER >= 20
-typedef duration< int, ratio_multiply<ratio<24>, hours::period>> days;
-typedef duration< int, ratio_multiply<ratio<7>, days::period>> weeks;
-typedef duration< int, ratio_multiply<ratio<146097, 400>, days::period>> years;
-typedef duration< int, ratio_divide<years::period, ratio<12>>> months;
+typedef duration<int, ratio<60 * 60 * 24>> days;
+typedef duration<int, ratio<60 * 60 * 24 * 7>> weeks;
+typedef duration<int, ratio<static_cast<int>(365.2425 * 60 * 60 * 24)>> years;
+typedef duration<int, ratio<static_cast<int>(365.2425 * 60 * 60 * 24) / 12>> months;
 #endif
 // Duration ==
 


### PR DESCRIPTION
These templates are instantiated whenever `<__chrono/duration.h>` is included, making these calculations quite costly. I also don't think that folding the calculations decreases readability here (IMO it's actually easier to read now), so I don't think there is a reason we shouldn't do this.

`<__chrono/duration.h>` is currently (transitively) included in at least (I stopped checking) `<algorithm>`, `<atomic>`, `<barrier>`, `<chrono>`, `<condition_variable>`, `<future>`, `<iomanip>`, `<ios>`, `<iostream>`, `<istream>`, `<latch>`, `<locale>`, `<mutex>`, `<ostream>`, `<semaphore>`, `<shared_mutex>`, `<syncstream>` and `<thread>`