### PR TITLE
[FileCheck] Allow -check-prefix to take multiple prefixes

### DIFF
--- a/llvm/docs/CommandGuide/FileCheck.rst
+++ b/llvm/docs/CommandGuide/FileCheck.rst
@@ -6,7 +6,7 @@ FileCheck - Flexible pattern matching file verifier
 SYNOPSIS
 --------
 
-:program:`FileCheck` *match-filename* [*--check-prefix=XXX*] [*--strict-whitespace*]
+:program:`FileCheck` *match-filename* [*--check-prefixes=XXX*] [*--strict-whitespace*]
 
 DESCRIPTION
 -----------
@@ -33,23 +33,22 @@ and from the command line.
 
  Print a summary of command line options.
 
-.. option:: --check-prefix prefix
+.. option:: --check-prefixes prefix1,prefix2,...
 
  FileCheck searches the contents of ``match-filename`` for patterns to
  match.  By default, these patterns are prefixed with "``CHECK:``".
  If you'd like to use a different prefix (e.g. because the same input
  file is checking multiple different tool or options), the
- :option:`--check-prefix` argument allows you to specify (without the trailing
+ :option:`--check-prefixes` argument allows you to specify (without the trailing
  "``:``") one or more prefixes to match. Multiple prefixes are useful for tests
  which might change for different run options, but most lines remain the same.
 
  FileCheck does not permit duplicate prefixes, even if one is a check prefix
  and one is a comment prefix (see :option:`--comment-prefixes` below).
 
-.. option:: --check-prefixes prefix1,prefix2,...
+.. option:: --check-prefix prefix1,prefix2,...
 
- An alias of :option:`--check-prefix` that allows multiple prefixes to be
- specified as a comma separated list.
+ An alias of :option:`--check-prefixes`.
 
 .. option:: --comment-prefixes prefix1,prefix2,...
 
@@ -67,7 +66,7 @@ and from the command line.
 .. option:: --allow-unused-prefixes
 
  This option controls the behavior when using more than one prefix as specified
- by :option:`--check-prefix` or :option:`--check-prefixes`, and some of these
+ by :option:`--check-prefixes`, and some of these
  prefixes are missing in the test file. If true, this is allowed, if false,
  FileCheck will report an error, listing the missing prefixes. The default value
  is false.
@@ -257,10 +256,10 @@ unless there is a "``subl``" in between those labels.  If it existed somewhere
 else in the file, that would not count: "``grep subl``" matches if "``subl``"
 exists anywhere in the file.
 
-The FileCheck -check-prefix option
+The FileCheck -check-prefixes option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The FileCheck `-check-prefix` option allows multiple test
+The FileCheck `-check-prefixes` option allows multiple test
 configurations to be driven from one `.ll` file.  This is useful in many
 circumstances, for example, testing different architectural variants with
 :program:`llc`.  Here's a simple example:
@@ -268,9 +267,9 @@ circumstances, for example, testing different architectural variants with
 .. code-block:: llvm
 
    ; RUN: llvm-as < %s | llc -mtriple=i686-apple-darwin9 -mattr=sse41 \
-   ; RUN:              | FileCheck %s -check-prefix=X32
+   ; RUN:              | FileCheck %s -check-prefixes=X32
    ; RUN: llvm-as < %s | llc -mtriple=x86_64-apple-darwin9 -mattr=sse41 \
-   ; RUN:              | FileCheck %s -check-prefix=X64
+   ; RUN:              | FileCheck %s -check-prefixes=X64
 
    define <4 x i32> @pinsrd_1(i32 %s, <4 x i32> %tmp) nounwind {
            %tmp1 = insertelement <4 x i32>; %tmp, i32 %s, i32 1

--- a/llvm/docs/CommandGuide/FileCheck.rst
+++ b/llvm/docs/CommandGuide/FileCheck.rst
@@ -257,7 +257,7 @@ else in the file, that would not count: "``grep subl``" matches if "``subl``"
 exists anywhere in the file.
 
 The FileCheck -check-prefixes option
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The FileCheck `-check-prefixes` option allows multiple test
 configurations to be driven from one `.ll` file.  This is useful in many

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -163,6 +163,8 @@ Changes to the LLVM tools
 -------------------------
 
 * `llvm-objcopy` no longer corrupts the symbol table when `--update-section` is called for ELF files.
+* `FileCheck` option `-check-prefix` now accepts a comma-separated list of
+  prefixes, making it an alias of the existing `-check-prefixes` option.
 
 Changes to LLDB
 ---------------

--- a/llvm/test/FileCheck/check-multiple-prefixes-mixed.txt
+++ b/llvm/test/FileCheck/check-multiple-prefixes-mixed.txt
@@ -2,10 +2,14 @@
 // RUN: FileCheck -check-prefix=A -check-prefix=BOTH -input-file %s %s
 // RUN: FileCheck -check-prefixes=B,BOTH -input-file %s %s
 // RUN: FileCheck -check-prefixes=A,BOTH -input-file %s %s
+// RUN: FileCheck -check-prefix=B,BOTH -input-file %s %s
+// RUN: FileCheck -check-prefix=A,BOTH -input-file %s %s
+// RUN: FileCheck -check-prefix=A,B -check-prefix=BOTH,C -input-file %s %s
 
 ; A: {{a}}aaaaa
 ; B: {{b}}bbbb
 ; BOTH: {{q}}qqqqq
+; C: {{c}}cccc
 aaaaaa
 bbbbb
 qqqqqq

--- a/llvm/utils/FileCheck/FileCheck.cpp
+++ b/llvm/utils/FileCheck/FileCheck.cpp
@@ -38,14 +38,13 @@ static cl::opt<std::string>
     InputFilename("input-file", cl::desc("File to check (defaults to stdin)"),
                   cl::init("-"), cl::value_desc("filename"));
 
-static cl::list<std::string> CheckPrefixes(
-    "check-prefix",
-    cl::desc("Prefix to use from check file (defaults to 'CHECK')"));
-static cl::alias CheckPrefixesAlias(
-    "check-prefixes", cl::aliasopt(CheckPrefixes), cl::CommaSeparated,
-    cl::NotHidden,
-    cl::desc(
-        "Alias for -check-prefix permitting multiple comma separated values"));
+static cl::list<std::string>
+    CheckPrefixes("check-prefixes", cl::CommaSeparated,
+                  cl::desc("Comma separated list of prefixes to use from check "
+                           "file\n(defaults to 'CHECK')"));
+static cl::alias CheckPrefixesAlias("check-prefix", cl::aliasopt(CheckPrefixes),
+                                    cl::CommaSeparated, cl::NotHidden,
+                                    cl::desc("Alias for -check-prefixes"));
 
 static cl::list<std::string> CommentPrefixes(
     "comment-prefixes", cl::CommaSeparated, cl::Hidden,


### PR DESCRIPTION
There was no real benefit to disallowing this, and it sometimes caused
unnecessary churn in the RUN lines of tests which were updated from
single-to-multiple or multiple-to-single prefixes.

This effectively makes -check-prefixes the primary option and
-check-prefix just an alias of it. The documentation is upated
accordingly.
