### PR TITLE
[MLIR][TOSA] Guard scatter lowering against unranked operand

### DIFF
--- a/mlir/lib/Conversion/TosaToSCF/TosaToSCF.cpp
+++ b/mlir/lib/Conversion/TosaToSCF/TosaToSCF.cpp
@@ -102,10 +102,10 @@ public:
     auto loc = scatter.getLoc();
 
     if (!isa<RankedTensorType>(valuesIn.getType()) ||
-    !isa<RankedTensorType>(indices.getType()) ||
-    !isa<RankedTensorType>(input.getType())) {
-      return rewriter.notifyMatchFailure(scatter,
-          "expected ranked tensor operands for scatter lowering");
+        !isa<RankedTensorType>(indices.getType()) ||
+        !isa<RankedTensorType>(input.getType())) {
+      return rewriter.notifyMatchFailure(
+          scatter, "expected ranked tensor operands for scatter lowering");
     }
 
     // N, W, C are chosen to match the TOSA spec

--- a/mlir/lib/Conversion/TosaToSCF/TosaToSCF.cpp
+++ b/mlir/lib/Conversion/TosaToSCF/TosaToSCF.cpp
@@ -101,13 +101,12 @@ public:
     auto input = scatter.getInput();
     auto loc = scatter.getLoc();
 
-    auto valuesType = dyn_cast<RankedTensorType>(valuesIn.getType());
-    auto indicesType = dyn_cast<RankedTensorType>(indices.getType());
-    auto inputType = dyn_cast<RankedTensorType>(input.getType());
-    if (!valuesType || !indicesType || !inputType ||
-        valuesType.getRank() != 3 || inputType.getRank() != 3 ||
-        indicesType.getRank() != 2)
-      return failure();
+    if (!isa<RankedTensorType>(valuesIn.getType()) ||
+    !isa<RankedTensorType>(indices.getType()) ||
+    !isa<RankedTensorType>(input.getType())) {
+      return rewriter.notifyMatchFailure(scatter,
+          "expected ranked tensor operands for scatter lowering");
+    }
 
     // N, W, C are chosen to match the TOSA spec
     auto dimN = createTensorDim(rewriter, loc, input, 0);

--- a/mlir/lib/Conversion/TosaToSCF/TosaToSCF.cpp
+++ b/mlir/lib/Conversion/TosaToSCF/TosaToSCF.cpp
@@ -101,6 +101,14 @@ public:
     auto input = scatter.getInput();
     auto loc = scatter.getLoc();
 
+    auto valuesType  = dyn_cast<RankedTensorType>(valuesIn.getType());
+    auto indicesType = dyn_cast<RankedTensorType>(indices.getType());
+    auto inputType   = dyn_cast<RankedTensorType>(input.getType());
+    if (!valuesType || !indicesType || !inputType ||
+        valuesType.getRank() != 3 || inputType.getRank() != 3 ||
+        indicesType.getRank() != 2)
+      return failure();
+
     // N, W, C are chosen to match the TOSA spec
     auto dimN = createTensorDim(rewriter, loc, input, 0);
     auto dimW = createTensorDim(rewriter, loc, input, 1);

--- a/mlir/lib/Conversion/TosaToSCF/TosaToSCF.cpp
+++ b/mlir/lib/Conversion/TosaToSCF/TosaToSCF.cpp
@@ -101,9 +101,9 @@ public:
     auto input = scatter.getInput();
     auto loc = scatter.getLoc();
 
-    auto valuesType  = dyn_cast<RankedTensorType>(valuesIn.getType());
+    auto valuesType = dyn_cast<RankedTensorType>(valuesIn.getType());
     auto indicesType = dyn_cast<RankedTensorType>(indices.getType());
-    auto inputType   = dyn_cast<RankedTensorType>(input.getType());
+    auto inputType = dyn_cast<RankedTensorType>(input.getType());
     if (!valuesType || !indicesType || !inputType ||
         valuesType.getRank() != 3 || inputType.getRank() != 3 ||
         indicesType.getRank() != 2)

--- a/mlir/test/Conversion/TosaToSCF/tosa-to-scf-invalid.mlir
+++ b/mlir/test/Conversion/TosaToSCF/tosa-to-scf-invalid.mlir
@@ -1,0 +1,9 @@
+// RUN: mlir-opt --split-input-file --tosa-to-scf %s -verify-diagnostics -o -
+
+// CHECK-LABEL: @scatter_unranked
+func.func @scatter_unranked(%v: tensor<*xi32>, %idx: tensor<*xi32>, %inp: tensor<*xi32>) -> tensor<*xi32> {
+  // expected-error @+1 {{failed to legalize operation 'tosa.scatter' that was explicitly marked illegal}}
+  %0 = tosa.scatter %v, %idx, %inp
+      : (tensor<*xi32>, tensor<*xi32>, tensor<*xi32>) -> tensor<*xi32>
+  return %0 : tensor<*xi32>
+}


### PR DESCRIPTION
### What the problem 

--tosa-to-scf crashes when lowering tosa.scatter if operands are unranked, because the lowering assumes RankedTensorType and later builds tensor.extract_slice, which asserts on unranked tensors.

### Why it Happened

The current pattern does not check operand ranks before lowering, even though the implementation hardcodes 3D (N,W,C) semantics and cannot handle unranked or differently-ranked tensors.

### Whats The Fix

Add rank/type guards in ScatterOpConverter and fail the rewrite unless operands are ranked with expected ranks (values/input: rank-3, indices: rank-2), allowing legalization to fail gracefully instead of crashing.

Fixes #177966