### PR TITLE
release/22.x: [Clang] prevent assertion in __has_embed parameter recovery at end-of-directive

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -571,6 +571,7 @@ Bug Fixes in This Version
 - Fixed a crash when parsing malformed #pragma clang loop vectorize_width(4,8,16)
   by diagnosing invalid comma-separated argument lists. (#GH166325)
 - Clang now treats enumeration constants of fixed-underlying enums as the enumerated type. (#GH172118)
+- Fixed a failed assertion in the preprocessor when ``__has_embed`` parameters are missing parentheses. (#GH175088)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -3686,14 +3686,14 @@ Preprocessor::LexEmbedParameters(Token &CurTok, bool ForHasEmbed) {
           std::pair<tok::TokenKind, SourceLocation> Matches) {
         Diag(CurTok, diag::err_expected) << Expected;
         Diag(Matches.second, diag::note_matching) << Matches.first;
-        if (CurTok.isNot(EndTokenKind))
+        if (CurTok.isNot(tok::eod))
           DiscardUntilEndOfDirective(CurTok);
       };
 
   auto ExpectOrDiagAndSkipToEOD = [&](tok::TokenKind Kind) {
     if (CurTok.isNot(Kind)) {
       Diag(CurTok, diag::err_expected) << Kind;
-      if (CurTok.isNot(EndTokenKind))
+      if (CurTok.isNot(tok::eod))
         DiscardUntilEndOfDirective(CurTok);
       return false;
     }

--- a/clang/test/Preprocessor/embed___has_embed_parsing_errors.c
+++ b/clang/test/Preprocessor/embed___has_embed_parsing_errors.c
@@ -282,3 +282,13 @@
 #if __has_embed (__FILE__ limit(1) foo
 int a = __has_embed (__FILE__);
 #endif
+
+// expected-error@+2 {{expected '('}} \
+   expected-error@+2 {{expected value in expression}}
+#if __has_embed("" if_empty
+#endif
+
+// expected-error@+2 {{expected '('}} \
+   expected-error@+2 {{expected value in expression}}
+#if __has_embed("" limit
+#endif


### PR DESCRIPTION
Manual backport of 1d316ef4ba71d843f1e49f86e831dbf8c64ebd83