### PR TITLE
[BOLT][perf2bolt] Support multiple perf data inputs

### DIFF
--- a/bolt/include/bolt/Profile/DataAggregator.h
+++ b/bolt/include/bolt/Profile/DataAggregator.h
@@ -51,7 +51,11 @@ class BoltAddressTranslation;
 class DataAggregator : public DataReader {
 public:
   explicit DataAggregator(StringRef Filename) : DataReader(Filename) {
-    start();
+    PerfDataFiles.push_back(std::string(Filename));
+  }
+
+  void addInputFile(StringRef Filename) {
+    PerfDataFiles.push_back(std::string(Filename));
   }
 
   ~DataAggregator();
@@ -76,6 +80,11 @@ public:
 
   /// Check whether \p FileName is a perf.data file
   static bool checkPerfDataMagic(StringRef FileName);
+
+  /// Start an aggregation job asynchronously.
+  void start();
+
+  bool isDataAggregator() const override { return true; }
 
 private:
   struct LBREntry {
@@ -202,6 +211,9 @@ private:
   BinaryContext *BC{nullptr};
 
   BoltAddressTranslation *BAT{nullptr};
+
+  /// Used to support multiple perf.data inputs
+  std::vector<std::string> PerfDataFiles;
 
   /// Update function execution profile with a recorded trace.
   /// A trace is region of code executed between two LBR entries supplied in
@@ -469,9 +481,6 @@ private:
 
   /// Populate functions in \p BC with profile.
   void processProfile(BinaryContext &BC);
-
-  /// Start an aggregation job asynchronously.
-  void start();
 
   /// Returns true if this aggregation job is using a translation table to
   /// remap samples collected on binaries already processed by BOLT.

--- a/bolt/include/bolt/Profile/ProfileReaderBase.h
+++ b/bolt/include/bolt/Profile/ProfileReaderBase.h
@@ -78,6 +78,9 @@ public:
   /// good source of profile data may contain discrepancies. Nevertheless, the
   /// rest of the profile is correct.
   virtual bool isTrustedSource() const = 0;
+
+  ///  Return true if this is an instance of DataAggregator.
+  virtual bool isDataAggregator() const { return false; }
 };
 
 } // namespace bolt

--- a/bolt/include/bolt/Utils/CommandLineOpts.h
+++ b/bolt/include/bolt/Utils/CommandLineOpts.h
@@ -94,7 +94,7 @@ extern llvm::cl::opt<bool> HotText;
 extern llvm::cl::opt<bool> Hugify;
 extern llvm::cl::opt<bool> Instrument;
 extern llvm::cl::opt<std::string> OutputFilename;
-extern llvm::cl::opt<std::string> PerfData;
+extern llvm::cl::list<std::string> PerfData;
 extern llvm::cl::opt<bool> PrintCacheMetrics;
 extern llvm::cl::opt<bool> PrintSections;
 extern llvm::cl::opt<bool> UpdateBranchProtection;

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -464,6 +464,12 @@ Error RewriteInstance::setProfile(StringRef Filename) {
     return errorCodeToError(make_error_code(errc::no_such_file_or_directory));
 
   if (ProfileReader) {
+    if (ProfileReader->isDataAggregator() &&
+        DataAggregator::checkPerfDataMagic(Filename)) {
+      auto *DA = static_cast<DataAggregator *>(ProfileReader.get());
+      DA->addInputFile(Filename);
+      return Error::success();
+    }
     // Already exists
     return make_error<StringError>(Twine("multiple profiles specified: ") +
                                        ProfileReader->getFilename() + " and " +

--- a/bolt/lib/Utils/CommandLineOpts.cpp
+++ b/bolt/lib/Utils/CommandLineOpts.cpp
@@ -230,9 +230,11 @@ OutputFilename("o",
   cl::Optional,
   cl::cat(BoltOutputCategory));
 
-cl::opt<std::string> PerfData("perfdata", cl::desc("<data file>"), cl::Optional,
-                              cl::cat(AggregatorCategory),
-                              cl::sub(cl::SubCommand::getAll()));
+cl::list<std::string>
+    PerfData("perfdata",
+             cl::desc("<data file> (can be specified multiple times)"),
+             cl::Optional, cl::cat(AggregatorCategory),
+             cl::sub(cl::SubCommand::getAll()));
 
 static cl::alias
 PerfDataA("p",

--- a/bolt/test/perf2bolt/perf_test.test
+++ b/bolt/test/perf2bolt/perf_test.test
@@ -2,7 +2,7 @@
 
 REQUIRES: system-linux, perf
 
-RUN: %clang %S/Inputs/perf_test.c -fuse-ld=lld -pie -Wl,--script=%S/Inputs/perf_test.lds -o %t
+RUN: %clang %S/Inputs/perf_test.c -fuse-ld=lld -pie -Wl,--script=%S/Inputs/perf_test.lds,--build-id -o %t
 RUN: perf record -Fmax -e cycles:u -o %t2 -- %t
 RUN: perf2bolt %t -p=%t2 -o %t3 -ba -ignore-build-id --show-density \
 RUN:   --heatmap %t.hm 2>&1 | FileCheck %s
@@ -20,3 +20,14 @@ RUN:   --heatmap %t.hm2 2>&1 | FileCheck %s
 RUN: FileCheck %s --input-file %t.hm2-section-hotness.csv --check-prefix=CHECK-HM
 
 CHECK-HM: .text
+
+# Check perf2bolt can correctly process multiple perf.data inputs
+RUN: perf record -Fmax -e cycles:u -o %t.perf.data1 -- %t
+RUN: perf record -Fmax -e cycles:u -o %t.perf.data2 -- %t
+RUN: perf record -Fmax -e cycles:u -o %t.perf.data3 -- %t
+RUN: perf2bolt %t -p=%t.perf.data1 -p=%t.perf.data2 -p=%t.perf.data3 -o %t7 -ba | FileCheck %s --check-prefix=CHECK-MUTI-PERF
+
+CHECK-MUTI-PERF: Starting data aggregation job for 3 perf data files
+CHECK-MUTI-PERF: matched build-id and file name
+CHECK-MUTI-PERF-NOT: PERF2BOLT-ERROR
+CHECK-MUTI-PERF-NOT: !! WARNING !! This high mismatch ratio indicates the input binary is probably not the same binary used during profiling collection.

--- a/bolt/tools/heatmap/heatmap.cpp
+++ b/bolt/tools/heatmap/heatmap.cpp
@@ -121,8 +121,10 @@ int main(int argc, char **argv) {
       report_error("RewriteInstance", std::move(E));
 
     RewriteInstance &RI = *RIOrErr.get();
-    if (Error E = RI.setProfile(opts::PerfData))
-      report_error(opts::PerfData, std::move(E));
+    for (const auto &PerfFile : opts::PerfData) {
+      if (Error E = RI.setProfile(PerfFile))
+        report_error(PerfFile, std::move(E));
+    }
 
     if (Error E = RI.run())
       report_error(opts::InputFilename, std::move(E));


### PR DESCRIPTION
Currently, aggregating data from multiple perf runs typically requires generating individual .fdata files and then merging them using the merge-fdata tool. However, generating these intermediate files requires invoking perf2bolt multiple times. This is inefficient as it involves repeatedly parsing and disassembling the same binary for each input file.

So this patch tries to enable perf2bolt to process multiple perf data files in a single invocation. Users can specify multiple inputs via repeated flags, e.g., perf2bolt -p=perf.data1 -p=perf.data2 ....

Implementation-wise, `parsePerfData` is already capable of handling events from multiple processes associated with the same binary in the perf script output. This change may leverage that capability to provide a more convenient and efficient workflow for aggregating profiles.