### PR TITLE
[lldb] Make "help format" test more strict

### DIFF
--- a/lldb/test/API/commands/help/TestHelp.py
+++ b/lldb/test/API/commands/help/TestHelp.py
@@ -237,12 +237,38 @@ class HelpCommandTestCase(TestBase):
 
     @no_debug_info_test
     def test_help_format_output(self):
-        """Test that help output reaches TerminalWidth."""
+        """Test that help output reaches TerminalWidth and wraps to the next
+        line if needed."""
+        self.runCmd("settings set term-width 118")
+        self.expect(
+            "help format",
+            matching=True,
+            patterns=[
+                r"^<format> -- One of the format names \(or one-character names\) that can be used to show a variable's value:\n"
+                r"\s+\"default\"\n"
+            ],
+        )
+
+        # The length of the first line will not be exactly 108 because we split
+        # at the last whitespace point before the limit.
         self.runCmd("settings set term-width 108")
         self.expect(
             "help format",
             matching=True,
-            substrs=["<format> -- One of the format names"],
+            patterns=[
+                r"^<format> -- One of the format names \(or one-character names\) that can be used to show a variable's\n"
+                r"\s+value:\n"
+            ],
+        )
+
+        self.runCmd("settings set term-width 90")
+        self.expect(
+            "help format",
+            matching=True,
+            patterns=[
+                r"<format> -- One of the format names \(or one-character names\) that can be used to show a\n"
+                r"\s+variable's value:\n"
+            ],
         )
 
     @no_debug_info_test


### PR DESCRIPTION
Originally added in a81bd7f1014f316b42bf7274f76a340b833e663b / https://reviews.llvm.org/D35525, this test either was not strict enough, or lldb's behaviour has drifted since.

I think the intention was to check exactly when the output of "help format" would wrap. Which should happen when we have printed up to the terminal width, minus a few characters because we walk backwards to the closest whitespace point to break at (so we don't split a word).

I've updated the test to check the exact outputs and cover printing one line and two instances where we need to split different amounts onto a second line.