### PR TITLE
[mlir][affine][spirv] Fix build issues found in 19.x

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h
+++ b/mlir/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h
@@ -9,6 +9,8 @@
 #ifndef MLIR_DIALECT_AFFINE_IR_VALUEBOUNDSOPINTERFACEIMPL_H
 #define MLIR_DIALECT_AFFINE_IR_VALUEBOUNDSOPINTERFACEIMPL_H
 
+#include <cstdint>
+
 #include "mlir/Support/LLVM.h"
 
 namespace mlir {

--- a/mlir/include/mlir/Target/SPIRV/Deserialization.h
+++ b/mlir/include/mlir/Target/SPIRV/Deserialization.h
@@ -13,6 +13,8 @@
 #ifndef MLIR_TARGET_SPIRV_DESERIALIZATION_H
 #define MLIR_TARGET_SPIRV_DESERIALIZATION_H
 
+#include <cstdint>
+
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/Support/LLVM.h"
 

--- a/mlir/include/mlir/Target/SPIRV/Serialization.h
+++ b/mlir/include/mlir/Target/SPIRV/Serialization.h
@@ -13,6 +13,8 @@
 #ifndef MLIR_TARGET_SPIRV_SERIALIZATION_H
 #define MLIR_TARGET_SPIRV_SERIALIZATION_H
 
+#include <cstdint>
+
 #include "mlir/Support/LLVM.h"
 
 namespace mlir {


### PR DESCRIPTION
Add missing includes `#include <cstdint>` to make the build pass.