### PR TITLE
workflows/release-tasks: Add missing needs tag to release-lit job

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -80,6 +80,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write # Requred for pypi publishing
+    needs:
+      - validate-tag
     environment: pypi
     steps:
       - name: Checkout LLVM


### PR DESCRIPTION
The job references variables from the validate-tag job, so it needs to have it listed in the 'needs' tag.  This is why this job failed for the 22.1.0-rc2 release.