### PR TITLE
[Clang][CIR] Replace -1ULL with std::numeric_limits in Itanium CXXABI

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -26,6 +26,8 @@
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/Support/ErrorHandling.h"
 
+#include <limits>
+
 using namespace clang;
 using namespace clang::CIRGen;
 
@@ -1939,7 +1941,7 @@ static CharUnits computeOffsetHint(ASTContext &astContext,
       // If the path contains a virtual base class we can't give any hint.
       // -1: no hint.
       if (pathElement.Base->isVirtual())
-        return CharUnits::fromQuantity(-1ULL);
+        return CharUnits::fromQuantity( std::numeric_limits<uint64_t>::max());
 
       if (numPublicPaths > 1) // Won't use offsets, skip computation.
         continue;

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -26,6 +26,8 @@
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/Support/ErrorHandling.h"
 
+#include <limits>
+
 namespace cir {
 
 namespace {
@@ -170,7 +172,7 @@ mlir::TypedAttr LowerItaniumCXXABI::lowerDataMemberConstant(
   if (attr.isNullPtr()) {
     // Itanium C++ ABI 2.3:
     //   A NULL pointer is represented as -1.
-    memberOffset = -1ull;
+    memberOffset = std::numeric_limits<uint64_t>::max();
   } else {
     // Itanium C++ ABI 2.3:
     //   A pointer to data member is an offset from the base address of

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -172,7 +172,7 @@ mlir::TypedAttr LowerItaniumCXXABI::lowerDataMemberConstant(
   if (attr.isNullPtr()) {
     // Itanium C++ ABI 2.3:
     //   A NULL pointer is represented as -1.
-    memberOffset = std::numeric_limits<uint64_t>::max();
+    memberOffset = -1;
   } else {
     // Itanium C++ ABI 2.3:
     //   A pointer to data member is an offset from the base address of


### PR DESCRIPTION
Replace instances of -1ULL with std::numeric_limits<uint64_t>::max() in CIR Itanium C++ ABI implementations to address C4146 compiler warning.

This change improves code clarity and eliminates MSVC warning C4146 (unary minus operator applied to unsigned type) in the experimental Clang IR (CIR) implementations.

Files changed:
- clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
- clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp

Fixes part of #147439