### PR TITLE
[Flang][OpenMP] Do not flag OmpPreDetermined for module variables

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2099,8 +2099,13 @@ void OmpAttributeVisitor::ResolveSeqLoopIndexInParallelOrTaskConstruct(
   // parallel or task
   if (auto *symbol{ResolveOmp(iv, Symbol::Flag::OmpPrivate, targetIt->scope)}) {
     targetIt++;
-    SetSymbolDSA(
-        *symbol, {Symbol::Flag::OmpPreDetermined, Symbol::Flag::OmpPrivate});
+    bool moduleSymbol{symbol->owner().IsModule() ||
+        symbol->GetUltimate().owner().IsModule() ||
+        symbol->detailsIf<semantics::UseDetails>()};
+    if (!moduleSymbol) {
+      SetSymbolDSA(
+          *symbol, {Symbol::Flag::OmpPreDetermined, Symbol::Flag::OmpPrivate});
+    }
     iv.symbol = symbol; // adjust the symbol within region
     for (auto it{dirContext_.rbegin()}; it != targetIt; ++it) {
       AddToContextObjectWithDSA(*symbol, Symbol::Flag::OmpPrivate, *it);

--- a/flang/test/Semantics/OpenMP/symbol10.f90
+++ b/flang/test/Semantics/OpenMP/symbol10.f90
@@ -1,0 +1,73 @@
+! RUN: %python %S/../test_symbols.py %s %flang_fc1 -fopenmp
+
+! Test that when using a variable from a module within an OpenMP Construct, such as taskloop or parallel do,
+! they are not marked as OmpPreDetermined. This ensures that it is correctly identified as a module variable,
+! rather than having Host Association details.
+
+!DEF: /test_module Module
+module test_module
+ !DEF: /test_module/n PUBLIC ObjectEntity INTEGER(4)
+ integer n
+end module
+!DEF: /test_parallel_do (Subroutine) Subprogram
+subroutine test_parallel_do
+ !DEF: /test_parallel_do/i ObjectEntity INTEGER(4)
+ integer i
+!$omp parallel do
+ !DEF: /test_parallel_do/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+ do i=1,5
+  block
+   !REF: /test_module
+   use :: test_module
+   !DEF: /test_parallel_do/OtherConstruct1/n (OmpPrivate) HostAssoc INTEGER(4)
+   do n=1,3
+    !REF: /test_parallel_do/OtherConstruct1/i
+    !REF: /test_parallel_do/OtherConstruct1/n
+    print *, i, n
+   end do
+  end block
+ end do
+!$omp end parallel do
+end subroutine
+
+!DEF: /test_task (Subroutine) Subprogram
+subroutine test_task
+ !DEF: /test_task/i ObjectEntity INTEGER(4)
+ integer i
+!$omp task
+ !DEF: /test_task/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+ do i=1,5
+  block
+   !REF: /test_module
+   use :: test_module
+   !DEF: /test_task/OtherConstruct1/n (OmpPrivate) HostAssoc INTEGER(4)
+   do n=1,3
+    !REF: /test_task/OtherConstruct1/i
+    !REF: /test_task/OtherConstruct1/n
+    print *, i, n
+   end do
+  end block
+ end do
+!$omp end task
+end subroutine
+
+!DEF: /test_taskloop (Subroutine) Subprogram
+subroutine test_taskloop
+ !DEF: /test_taskloop/i ObjectEntity INTEGER(4)
+ integer i
+!$omp taskloop
+ !DEF: /test_taskloop/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
+ do i=1,5
+  block
+   !REF: /test_module
+   use :: test_module
+   !DEF: /test_taskloop/OtherConstruct1/n (OmpPrivate) HostAssoc INTEGER(4)
+   do n=1,3
+    !REF: /test_taskloop/OtherConstruct1/i
+    !REF: /test_taskloop/OtherConstruct1/n
+    print *, i, n
+   end do
+  end block
+ end do
+!$omp end taskloop
+end subroutine


### PR DESCRIPTION
When a variable, used inside of a block, is accessed via a use association, Flang marked this as OmpPreDetermined, which meant later down the line it would look for a host association box, which won't exist.

In situations where module variables are used within blocks, nested within OpenMP Constructs, we should not be marking these as OmpPreDetermined.