### PR TITLE
[clang-tidy] performance-enum-size should ignore enums within extern "C"

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/EnumSizeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/EnumSizeCheck.cpp
@@ -25,6 +25,17 @@ namespace {
 
 AST_MATCHER(EnumDecl, hasEnumerators) { return !Node.enumerators().empty(); }
 
+AST_MATCHER(EnumDecl, isExternC) {
+  return Node.getLexicalDeclContext()->isExternCContext();
+}
+
+AST_MATCHER_P(EnumDecl, hasTypedefNameForAnonDecl,
+              ast_matchers::internal::Matcher<NamedDecl>, InnerMatcher) {
+  if (const TypedefNameDecl *TD = Node.getTypedefNameForAnonDecl())
+    return InnerMatcher.matches(*TD, Finder, Builder);
+  return false;
+}
+
 const std::uint64_t Min8 =
     std::imaxabs(std::numeric_limits<std::int8_t>::min());
 const std::uint64_t Max8 = std::numeric_limits<std::int8_t>::max();
@@ -90,8 +101,11 @@ bool EnumSizeCheck::isLanguageVersionSupported(
 void EnumSizeCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       enumDecl(unless(isExpansionInSystemHeader()), isDefinition(),
-               hasEnumerators(),
-               unless(matchers::matchesAnyListedRegexName(EnumIgnoreList)))
+               hasEnumerators(), unless(isExternC()),
+               unless(anyOf(
+                   matchers::matchesAnyListedRegexName(EnumIgnoreList),
+                   hasTypedefNameForAnonDecl(
+                       matchers::matchesAnyListedRegexName(EnumIgnoreList)))))
           .bind("e"),
       this);
 }

--- a/clang-tools-extra/clang-tidy/performance/EnumSizeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/EnumSizeCheck.cpp
@@ -26,7 +26,7 @@ namespace {
 AST_MATCHER(EnumDecl, hasEnumerators) { return !Node.enumerators().empty(); }
 
 AST_MATCHER(EnumDecl, isExternC) {
-  return Node.getLexicalDeclContext()->isExternCContext();
+  return Node.getDeclContext()->isExternCContext();
 }
 
 AST_MATCHER_P(EnumDecl, hasTypedefNameForAnonDecl,

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -150,6 +150,13 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-using>` check by avoiding the generation
   of invalid code for function types with redundant parentheses.
 
+- Improved :doc:`performance-enum-size
+  <clang-tidy/checks/performance/enum-size>` check:
+
+  - Exclude ``enum`` in ``extern "C"`` blocks.
+
+  - Improved the ignore list to correctly handle ``typedef`` and  ``enum``.
+
 - Improved :doc:`performance-move-const-arg
   <clang-tidy/checks/performance/move-const-arg>` check by avoiding false
   positives on trivially copyable types with a non-public copy constructor.

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/enum-size.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/enum-size.cpp
@@ -1,5 +1,5 @@
 // RUN: %check_clang_tidy -std=c++17-or-later %s performance-enum-size %t -- \
-// RUN:   -config="{CheckOptions: {performance-enum-size.EnumIgnoreList: '::IgnoredEnum;IgnoredSecondEnum'}}"
+// RUN:   -config="{CheckOptions: {performance-enum-size.EnumIgnoreList: '::IgnoredEnum;IgnoredSecondEnum;IgnoredTypedefEnum'}}"
 
 namespace std
 {
@@ -105,4 +105,16 @@ enum class IgnoredSecondEnum
 enum class EnumClassWithoutValues : int {};
 enum EnumWithoutValues {};
 
+}
+
+extern "C" {
+enum ExternCEnum {
+    ec1,
+    ec2
+};
+
+typedef enum {
+    tec1,
+    tec2
+} IgnoredTypedefEnum;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/enum-size.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/enum-size.cpp
@@ -117,4 +117,4 @@ typedef enum {
     tec1,
     tec2
 } IgnoredTypedefEnum;
-}
+} // extern "C"


### PR DESCRIPTION
Closes [#178114](https://github.com/llvm/llvm-project/issues/178114)