### PR TITLE
[RISCV] Add signext attribute to llvm.clmul test caes in rv64zbc(-zbkc)-intrinsic.ll. NFC

### DIFF
--- a/llvm/test/CodeGen/RISCV/rv64zbc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbc-intrinsic.ll
@@ -50,13 +50,14 @@ define i64 @llvm_clmulr_i64(i64 %a, i64 %b) nounwind {
   ret i64 %tmp5
 }
 
-define i32 @llvm_clmulr_i32(i32 %a, i32 %b) nounwind {
+define signext i32 @llvm_clmulr_i32(i32 signext %a, i32 signext %b) nounwind {
 ; RV64ZBC-LABEL: llvm_clmulr_i32:
 ; RV64ZBC:       # %bb.0:
 ; RV64ZBC-NEXT:    slli a1, a1, 32
 ; RV64ZBC-NEXT:    slli a0, a0, 32
 ; RV64ZBC-NEXT:    clmulh a0, a0, a1
 ; RV64ZBC-NEXT:    srli a0, a0, 31
+; RV64ZBC-NEXT:    sext.w a0, a0
 ; RV64ZBC-NEXT:    ret
   %tmp1 = zext i32 %a to i64
   %tmp2 = zext i32 %b to i64

--- a/llvm/test/CodeGen/RISCV/rv64zbc-zbkc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbc-zbkc-intrinsic.ll
@@ -82,16 +82,17 @@ define i64 @llvm_clmulh_i64(i64 %a, i64 %b) nounwind {
   ret i64 %tmp5
 }
 
-define i32 @llvm_clmul_i32(i32 %a, i32 %b) nounwind {
+define signext i32 @llvm_clmul_i32(i32 signext %a, i32 signext %b) nounwind {
 ; RV64ZBC-ZBKC-LABEL: llvm_clmul_i32:
 ; RV64ZBC-ZBKC:       # %bb.0:
 ; RV64ZBC-ZBKC-NEXT:    clmul a0, a0, a1
+; RV64ZBC-ZBKC-NEXT:    sext.w a0, a0
 ; RV64ZBC-ZBKC-NEXT:    ret
   %tmp = call i32 @llvm.clmul.i32(i32 %a, i32 %b)
   ret i32 %tmp
 }
 
-define i32 @llvm_clmulh_i32(i32 %a, i32 %b) nounwind {
+define signext i32 @llvm_clmulh_i32(i32 signext %a, i32 signext %b) nounwind {
 ; RV64ZBC-ZBKC-LABEL: llvm_clmulh_i32:
 ; RV64ZBC-ZBKC:       # %bb.0:
 ; RV64ZBC-ZBKC-NEXT:    slli a1, a1, 32


### PR DESCRIPTION
This shows an extra instruction in the clmulr case. We could replace clmulh+srli+sext.w with clmulr+srai.