### PR TITLE
[lldb][windows] fix an invalid cast from a file descriptor to a HANDLE

### DIFF
--- a/lldb/include/lldb/Host/FileAction.h
+++ b/lldb/include/lldb/Host/FileAction.h
@@ -35,6 +35,8 @@ public:
 
   int GetFD() const { return m_fd; }
 
+  void *GetHandle() const;
+
   Action GetAction() const { return m_action; }
 
   int GetActionArgument() const { return m_arg; }

--- a/lldb/include/lldb/Host/FileAction.h
+++ b/lldb/include/lldb/Host/FileAction.h
@@ -35,7 +35,9 @@ public:
 
   int GetFD() const { return m_fd; }
 
+#ifdef _WIN32
   void *GetHandle() const;
+#endif
 
   Action GetAction() const { return m_action; }
 

--- a/lldb/source/Host/common/FileAction.cpp
+++ b/lldb/source/Host/common/FileAction.cpp
@@ -12,11 +12,23 @@
 #include "lldb/Host/PosixApi.h"
 #include "lldb/Utility/Stream.h"
 
+#ifdef _WIN32
+#include "lldb/Host/windows/windows.h"
+#endif
+
 using namespace lldb_private;
 
 // FileAction member functions
 
 FileAction::FileAction() : m_file_spec() {}
+
+#ifdef _WIN32
+HANDLE FileAction::GetHandle() const {
+  if (m_fd == -1)
+    return INVALID_HANDLE_VALUE;
+  return reinterpret_cast<HANDLE>(_get_osfhandle(m_fd));
+}
+#endif
 
 void FileAction::Clear() {
   m_action = eFileActionNone;

--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -242,8 +242,9 @@ llvm::ErrorOr<std::vector<HANDLE>> ProcessLauncherWindows::GetInheritedHandles(
   for (size_t i = 0; i < launch_info.GetNumFileActions(); ++i) {
     const FileAction *act = launch_info.GetFileActionAtIndex(i);
     if (act->GetAction() == FileAction::eFileActionDuplicate &&
-        act->GetFD() == act->GetActionArgument())
-      inherited_handles.push_back(reinterpret_cast<HANDLE>(act->GetFD()));
+        act->GetFD() == act->GetActionArgument()) {
+      inherited_handles.push_back(act->GetHandle());
+    }
   }
 
   if (inherited_handles.empty())


### PR DESCRIPTION
This patch fixes a cast from a file descriptor to a HANDLE which did not use `_get_osfhandle`.

Casting a file descriptor to a HANDLE directly is incorrect, the conversion needs to go through the CRT mapping.