### PR TITLE
[SystemZ][asan] Handle error of pragma in struct so memory clean up happens

### DIFF
--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4534,6 +4534,10 @@ void Parser::ParseDeclarationSpecifiers(
       HandlePragmaMSPointersToMembers();
       continue;
 
+    case tok::annot_pragma_export:
+      HandlePragmaExport();
+      continue;
+
 #define TRANSFORM_TYPE_TRAIT_DEF(_, Trait) case tok::kw___##Trait:
 #include "clang/Basic/TransformTypeTraits.def"
       // HACK: libstdc++ already uses '__remove_cv' as an alias template so we

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1471,6 +1471,8 @@ bool Parser::isValidAfterTypeSpecifier(bool CouldBeBitfield) {
   case tok::annot_pragma_ms_vtordisp:
   // struct foo {...} _Pragma(pointers_to_members(...));
   case tok::annot_pragma_ms_pointers_to_members:
+  // struct foo {...} _Pragma(export(...));
+  case tok::annot_pragma_export:
     return true;
   case tok::colon:
     return CouldBeBitfield || // enum E { ... }   :         2;
@@ -3396,6 +3398,9 @@ Parser::DeclGroupPtrTy Parser::ParseCXXClassMemberDeclarationWithPragmas(
     return nullptr;
   case tok::annot_pragma_ms_vtordisp:
     HandlePragmaMSVtorDisp();
+    return nullptr;
+  case tok::annot_pragma_export:
+    HandlePragmaExport();
     return nullptr;
   case tok::annot_pragma_dump:
     HandlePragmaDump();

--- a/clang/test/Sema/pragma-export-failing.cpp
+++ b/clang/test/Sema/pragma-export-failing.cpp
@@ -26,7 +26,7 @@ void f11(int);
 template<auto func>
 struct S {
 
-#pragma export(func) // expected-error{{this pragma cannot appear in struct declaration}}
+#pragma export(func) // expected-error{{'#pragma export' can only appear at file scope}}
 };
 
 extern "C" void funcToExport();


### PR DESCRIPTION

I missed the other failing case for pragmas in declarations with the fix in #177979. Anytime the pragma is tokenized, the parser needs to call HandlePragmaExport() so the allocated token is consumed completely by EnterTokenStream().