### PR TITLE
[MLIR][OpenMP] Fix mapper being attached to partial maps.

### DIFF
--- a/mlir/test/Target/LLVMIR/omptarget-mapper-combined-entry.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-mapper-combined-entry.mlir
@@ -1,0 +1,42 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+// Ensure that user-defined mappers are only attached to the base entry of a
+// combined parent mapping. Attaching the mapper to segment entries can invoke
+// the mapper with a partial size, which is undefined behaviour.
+
+module attributes {omp.target_triples = ["amdgcn-amd-amdhsa"]} {
+  omp.declare_mapper @mapper : !llvm.struct<"S", (i32, i32)> {
+  ^bb0(%arg0: !llvm.ptr):
+    %field0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"S", (i32, i32)>
+    %map_field0 = omp.map.info var_ptr(%field0 : !llvm.ptr, i32)
+        map_clauses(tofrom) capture(ByRef) -> !llvm.ptr {name = ""}
+    %map_parent = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<"S", (i32, i32)>)
+        map_clauses(tofrom) capture(ByRef) members(%map_field0 : [0] : !llvm.ptr) -> !llvm.ptr
+        {name = "", partial_map = true}
+    omp.declare_mapper.info map_entries(%map_parent, %map_field0 : !llvm.ptr, !llvm.ptr)
+  }
+
+  llvm.func @test_mapper_combined_entries() {
+    %one = llvm.mlir.constant(1 : i64) : i64
+    %s = llvm.alloca %one x !llvm.struct<"S", (i32, i32)> : (i64) -> !llvm.ptr
+    %field0 = llvm.getelementptr %s[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"S", (i32, i32)>
+    %map_field0 = omp.map.info var_ptr(%field0 : !llvm.ptr, i32)
+        map_clauses(tofrom) capture(ByRef) -> !llvm.ptr {name = "s.f0"}
+    %map_parent = omp.map.info var_ptr(%s : !llvm.ptr, !llvm.struct<"S", (i32, i32)>)
+        map_clauses(tofrom) capture(ByRef) mapper(@mapper) members(%map_field0 : [0] : !llvm.ptr) -> !llvm.ptr
+        {name = "s"}
+    omp.target map_entries(%map_parent -> %arg0, %map_field0 -> %arg1 : !llvm.ptr, !llvm.ptr) {
+      omp.terminator
+    }
+    llvm.return
+  }
+}
+
+// CHECK-LABEL: define void @test_mapper_combined_entries
+// CHECK: %[[MAPPERS:.*offload_mappers.*]] = alloca [4 x ptr]
+// CHECK: %[[MAPPER0:.*]] = getelementptr inbounds [4 x ptr], ptr %[[MAPPERS]], i64 0, i64 0
+// CHECK: store ptr @.omp_mapper.mapper, ptr %[[MAPPER0]]
+// CHECK: %[[MAPPER1:.*]] = getelementptr inbounds [4 x ptr], ptr %[[MAPPERS]], i64 0, i64 1
+// CHECK: store ptr null, ptr %[[MAPPER1]]
+// CHECK: %[[MAPPER2:.*]] = getelementptr inbounds [4 x ptr], ptr %[[MAPPERS]], i64 0, i64 2
+// CHECK: store ptr null, ptr %[[MAPPER2]]

--- a/offload/test/offloading/fortran/default-mapper-derived-enter-data-teams-collapse.f90
+++ b/offload/test/offloading/fortran/default-mapper-derived-enter-data-teams-collapse.f90
@@ -1,0 +1,53 @@
+! Regression test for default mappers on nested derived types with allocatable
+! members when mapping a parent object and running an optimized target region.
+
+! REQUIRES: flang, amdgpu
+
+! RUN: %libomptarget-compile-fortran-generic -O3
+! RUN: %libomptarget-run-generic | %fcheck-generic
+
+program test_default_mapper_enter_data_teams_collapse
+  implicit none
+
+  type inner_type
+    real, allocatable :: data(:)
+  end type inner_type
+
+  type outer_type
+    type(inner_type) :: inner
+    character(len=19) :: desc = ' '
+  end type outer_type
+
+  type(outer_type) :: obj
+  integer, parameter :: n = 10
+  integer :: i, j
+  real :: expected, actual
+
+  allocate(obj%inner%data(n))
+  obj%inner%data = 0.0
+
+  !$omp target enter data map(to: obj)
+
+  !$omp target teams distribute parallel do collapse(2)
+  do i = 1, n
+    do j = 1, n
+      obj%inner%data(i) = real(i)
+    end do
+  end do
+  !$omp end target teams distribute parallel do
+
+  !$omp target exit data map(from: obj)
+
+  expected = real(n * (n + 1)) / 2.0
+  actual = sum(obj%inner%data)
+
+  if (abs(actual - expected) < 1.0e-6) then
+    print *, "PASS"
+  else
+    print *, "FAIL", actual, expected
+  end if
+
+  deallocate(obj%inner%data)
+end program test_default_mapper_enter_data_teams_collapse
+
+! CHECK: PASS


### PR DESCRIPTION
Fix OpenMP mapper lowering by attaching user-defined/default mappers only to the base parent entry, not combined/segment entries. This prevents mapper calls with partial sizes. Added relevant tests.