### PR TITLE
[RISCV] Add missing HasStdExtZvkb Predicate to some of the vector rotate patterns. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVSDPatterns.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVSDPatterns.td
@@ -125,9 +125,10 @@ class VPatBinarySDNode_XI<SDPatternOperator vop,
 
 multiclass VPatBinarySDNode_VV_VX<SDPatternOperator vop, string instruction_name,
                                   list<VTypeInfo> vtilist = AllIntegerVectors,
-                                  bit isSEWAware = 0> {
+                                  bit isSEWAware = 0,
+                                  list<Predicate> ExtraPreds = []> {
   foreach vti = vtilist in {
-    let Predicates = GetVTypePredicates<vti>.Predicates in {
+    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in {
       def : VPatBinarySDNode_VV<vop, instruction_name,
                                 vti.Vector, vti.Vector, vti.Log2SEW,
                                 vti.LMul, vti.AVL, vti.RegClass, isSEWAware>;
@@ -140,10 +141,11 @@ multiclass VPatBinarySDNode_VV_VX<SDPatternOperator vop, string instruction_name
 }
 
 multiclass VPatBinarySDNode_VV_VX_VI<SDPatternOperator vop, string instruction_name,
-                                     Operand ImmType = simm5>
-    : VPatBinarySDNode_VV_VX<vop, instruction_name> {
+                                     Operand ImmType = simm5,
+                                     list<Predicate> ExtraPreds = []>
+    : VPatBinarySDNode_VV_VX<vop, instruction_name, ExtraPreds=ExtraPreds> {
   foreach vti = AllIntegerVectors in {
-    let Predicates = GetVTypePredicates<vti>.Predicates in
+    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in
     def : VPatBinarySDNode_XI<vop, instruction_name, "VI",
                               vti.Vector, vti.Vector, vti.Log2SEW,
                               vti.LMul, vti.AVL, vti.RegClass,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVVLPatterns.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVVLPatterns.td
@@ -912,9 +912,10 @@ class VPatBinaryVL_XI<SDPatternOperator vop,
 
 multiclass VPatBinaryVL_VV_VX<SDPatternOperator vop, string instruction_name,
                               list<VTypeInfo> vtilist = AllIntegerVectors,
-                              bit isSEWAware = 0> {
+                              bit isSEWAware = 0,
+                              list<Predicate> ExtraPreds = []> {
   foreach vti = vtilist in {
-    let Predicates = GetVTypePredicates<vti>.Predicates in {
+    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in {
       def : VPatBinaryVL_V<vop, instruction_name, "VV",
                            vti.Vector, vti.Vector, vti.Vector, vti.Mask,
                            vti.Log2SEW, vti.LMul, vti.RegClass, vti.RegClass,
@@ -928,10 +929,11 @@ multiclass VPatBinaryVL_VV_VX<SDPatternOperator vop, string instruction_name,
 }
 
 multiclass VPatBinaryVL_VV_VX_VI<SDPatternOperator vop, string instruction_name,
-                                 Operand ImmType = simm5>
-    : VPatBinaryVL_VV_VX<vop, instruction_name> {
+                                 Operand ImmType = simm5,
+                                 list<Predicate> ExtraPreds = []>
+    : VPatBinaryVL_VV_VX<vop, instruction_name, ExtraPreds=ExtraPreds> {
   foreach vti = AllIntegerVectors in {
-    let Predicates = GetVTypePredicates<vti>.Predicates in
+    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in
     def : VPatBinaryVL_XI<vop, instruction_name, "VI",
                           vti.Vector, vti.Vector, vti.Vector, vti.Mask,
                           vti.Log2SEW, vti.LMul, vti.RegClass, vti.RegClass,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvk.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvk.td
@@ -639,7 +639,7 @@ defm : VPatUnarySDNode_V<ctlz, "PseudoVCLZ">;
 defm : VPatUnarySDNode_V<cttz, "PseudoVCTZ">;
 defm : VPatUnarySDNode_V<ctpop, "PseudoVCPOP">;
 
-defm : VPatBinarySDNode_VV_VX<rotl, "PseudoVROL">;
+defm : VPatBinarySDNode_VV_VX<rotl, "PseudoVROL", ExtraPreds=[HasStdExtZvkb]>;
 
 // Invert the immediate and mask it to SEW for readability.
 def InvRot8Imm : SDNodeXForm<imm, [{
@@ -673,7 +673,7 @@ foreach vti = AllIntegerVectors in {
                  vti.AVL, vti.Log2SEW, TA_MA)>;
   }
 }
-defm : VPatBinarySDNode_VV_VX_VI<rotr, "PseudoVROR", uimm6>;
+defm : VPatBinarySDNode_VV_VX_VI<rotr, "PseudoVROR", uimm6, ExtraPreds=[HasStdExtZvkb]>;
 
 foreach vtiToWti = AllWidenableIntVectors in {
   defvar vti = vtiToWti.Vti;
@@ -787,7 +787,7 @@ defm : VPatUnaryVL_V<riscv_ctlz_vl, "PseudoVCLZ">;
 defm : VPatUnaryVL_V<riscv_cttz_vl, "PseudoVCTZ">;
 defm : VPatUnaryVL_V<riscv_ctpop_vl, "PseudoVCPOP">;
 
-defm : VPatBinaryVL_VV_VX<riscv_rotl_vl, "PseudoVROL">;
+defm : VPatBinaryVL_VV_VX<riscv_rotl_vl, "PseudoVROL", ExtraPreds=[HasStdExtZvkb]>;
 // Although there is no vrol.vi, an immediate rotate left can be achieved by
 // negating the immediate in vror.vi
 foreach vti = AllIntegerVectors in {
@@ -804,7 +804,7 @@ foreach vti = AllIntegerVectors in {
                  (vti.Mask VMV0:$vm), GPR:$vl, vti.Log2SEW, TAIL_AGNOSTIC)>;
   }
 }
-defm : VPatBinaryVL_VV_VX_VI<riscv_rotr_vl, "PseudoVROR", uimm6>;
+defm : VPatBinaryVL_VV_VX_VI<riscv_rotr_vl, "PseudoVROR", uimm6, ExtraPreds=[HasStdExtZvkb]>;
 
 foreach vtiToWti = AllWidenableIntVectors in {
   defvar vti = vtiToWti.Vti;


### PR DESCRIPTION
We already had it on the rotl with immediate patterns, but not any of the others. This reduces the isel table size by a few hundred bytes by allowing additional factoring with the rotl with immediate patterns.

This is NFC because these patterns shouldn't make it to isel if the predicate wasn't already satisfied.