### PR TITLE
fix: add encoding for Python 3.14 compatibility in lit test file

### DIFF
--- a/llvm/utils/lit/tests/shtest-encoding.py
+++ b/llvm/utils/lit/tests/shtest-encoding.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # RUN: true
 
 # Here is a string that cannot be decoded in line mode: Â.


### PR DESCRIPTION
Fix: https://github.com/llvm/llvm-project/issues/178262