### PR TITLE
llvm-tli-checker: Print custom name instead of standard name

### DIFF
--- a/llvm/tools/llvm-tli-checker/llvm-tli-checker.cpp
+++ b/llvm/tools/llvm-tli-checker/llvm-tli-checker.cpp
@@ -129,10 +129,19 @@ static void dumpTLIEntries(const TargetLibraryInfo &TLI) {
   for (unsigned FI = LibFunc::Begin_LibFunc; FI != LibFunc::End_LibFunc; ++FI) {
     LibFunc LF = static_cast<LibFunc>(FI);
     bool IsAvailable = TLI.has(LF);
-    StringRef FuncName = TargetLibraryInfo::getStandardName(LF);
 
     outs() << (IsAvailable ? "    " : "not ") << "available: ";
-    printPrintableName(outs(), FuncName) << '\n';
+
+    if (IsAvailable) {
+      // Print the (possibly custom) name.
+      // TODO: Should we include the standard name in the printed line?
+      printPrintableName(outs(), TLI.getName(LF));
+    } else {
+      // If it's not available, refer to it by the standard name.
+      printPrintableName(outs(), TargetLibraryInfo::getStandardName(LF));
+    }
+
+    outs() << '\n';
   }
 }
 


### PR DESCRIPTION
Previously this always printed the standard name if the function
was available, leaving any custom name override untested. Print the
target's name instead. The message should possibly include the standard
name for reference.

Closes #142537