### PR TITLE
[CSSPGO] Preserve pseudo-probe discriminators in cloneWithBaseDiscriminator

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -3010,6 +3010,12 @@ unsigned DILocation::getCopyIdentifier() const {
 
 std::optional<const DILocation *>
 DILocation::cloneWithBaseDiscriminator(unsigned D) const {
+  // Do not interfere with pseudo probes. Pseudo probe at a callsite uses
+  // the dwarf discriminator to store pseudo probe related information,
+  // such as the probe id.
+  if (isPseudoProbeDiscriminator(getDiscriminator()))
+    return this;
+
   unsigned BD, DF, CI;
 
   if (EnableFSDiscriminator) {

--- a/llvm/test/Transforms/AddDiscriminators/pseudo-probe-discriminator.ll
+++ b/llvm/test/Transforms/AddDiscriminators/pseudo-probe-discriminator.ll
@@ -1,0 +1,33 @@
+; RUN: opt < %s -passes=add-discriminators -S | FileCheck %s
+
+; Test that AddDiscriminators preserves pseudo-probe discriminators.
+; Pseudo-probe discriminators use bits [2:0] = 0x7 as a marker.
+
+define void @foo() !dbg !4 {
+entry:
+  call void @bar(), !dbg !10
+  call void @bar(), !dbg !11
+  ret void
+}
+
+declare void @bar()
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!7, !8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, isOptimized: false, runtimeVersion: 0, emissionKind: NoDebug)
+!1 = !DIFile(filename: "test.cpp", directory: "/tmp")
+!4 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !5, scopeLine: 1, unit: !0)
+!5 = !DISubroutineType(types: !6)
+!6 = !{null}
+!7 = !{i32 2, !"Dwarf Version", i32 4}
+!8 = !{i32 2, !"Debug Info Version", i32 3}
+
+; Two calls on the same line with pseudo-probe discriminators (bits [2:0] = 0x7)
+!9 = !DILexicalBlockFile(scope: !4, file: !1, discriminator: 455081999)
+!10 = !DILocation(line: 2, column: 3, scope: !9)
+!12 = !DILexicalBlockFile(scope: !4, file: !1, discriminator: 455082007)
+!11 = !DILocation(line: 2, column: 3, scope: !12)
+
+; CHECK-DAG: !DILexicalBlockFile({{.*}}discriminator: 455081999)
+; CHECK-DAG: !DILexicalBlockFile({{.*}}discriminator: 455082007)


### PR DESCRIPTION
In the O0 pipeline, `SampleProfileProbePass` runs before `AddDiscriminatorsPass`. The 
pseudo-probe pass stores probe IDs in the discriminator field using a special encoding 
(bits [2:0] = 0x7 as marker). When `AddDiscriminatorsPass` later processes instructions 
on the same source line, it calls `cloneWithBaseDiscriminator()` which overwrites these 
pseudo-probe discriminators with DWARF base discriminators, breaking sample profile 
matching.

This patch adds a check to `cloneWithBaseDiscriminator()` to detect and preserve 
pseudo-probe discriminators, similar to the existing check in 
`cloneByMultiplyingDuplicationFactor()`.

In optimized pipelines (O1+), AddDiscriminators runs before pseudo-probe instrumentation,
so this issue doesn't manifest. However, the fix makes the code robust regardless of 
pass ordering.
