### PR TITLE
Add -emit-llvm to RUN line for test added in #173311.

### DIFF
--- a/clang/test/CodeGen/stack-protector-vars.cpp
+++ b/clang/test/CodeGen/stack-protector-vars.cpp
@@ -1,9 +1,7 @@
 // RUN: %clang -target x86_64-apple-darwin -emit-llvm -S -o - %s | FileCheck %s
 // RUN: %clang -target x86_64-apple-darwin -emit-llvm -S -o - %s -fstack-protector | FileCheck %s
 // RUN: %clang -target x86_64-apple-darwin -emit-llvm -S -o - %s -fstack-protector-all | FileCheck %s
-// RUN: %clang -target x86_64-apple-darwin -Xclang -verify -fstack-protector-all %s -o %t -c
-
-// REQUIRES: x86-reigstered-target
+// RUN: %clang -target x86_64-apple-darwin -emit-llvm -Xclang -verify -fstack-protector-all %s -o %t -c
 
 typedef __SIZE_TYPE__ size_t;
 

--- a/clang/test/CodeGen/stack-protector-vars.cpp
+++ b/clang/test/CodeGen/stack-protector-vars.cpp
@@ -3,6 +3,8 @@
 // RUN: %clang -target x86_64-apple-darwin -emit-llvm -S -o - %s -fstack-protector-all | FileCheck %s
 // RUN: %clang -target x86_64-apple-darwin -Xclang -verify -fstack-protector-all %s -o %t -c
 
+// REQUIRES: x86-reigstered-target
+
 typedef __SIZE_TYPE__ size_t;
 
 int printf(const char * _Format, ...);


### PR DESCRIPTION
PR #173311 added a test `clang/test/CodeGen/stack-protector-vars.cpp` that fails if the x86 backend is not built. This adds the proper `REQUIRES` line to fix that.

Should fix the test failure on buildbots that do not build the x86 backend such as https://lab.llvm.org/buildbot/#/builders/190/builds/35171 and https://lab.llvm.org/buildbot/#/builders/154/builds/26976.