### PR TITLE
[Clang] prevent preprocessor crash on incomplete scoped __has_cpp_attribute arguments

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -175,6 +175,7 @@ Bug Fixes in This Version
 - Fixed a failed assertion in the preprocessor when ``__has_embed`` parameters are missing parentheses. (#GH175088)
 
 - Fix lifetime extension of temporaries in for-range-initializers in templates. (#GH165182)
+- Fixed a preprocessor crash in ``__has_cpp_attribute`` on incomplete scoped attributes. (#GH178098)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/clang/lib/Lex/PPMacroExpansion.cpp
@@ -1443,7 +1443,7 @@ already_lexed:
       PP.Diag(LParenLoc, diag::note_matching) << tok::l_paren;
       SuppressDiagnostic = true;
     }
-  }
+}
 }
 
 /// Helper function to return the IdentifierInfo structure of a Token

--- a/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/clang/lib/Lex/PPMacroExpansion.cpp
@@ -1364,7 +1364,7 @@ static void EvaluateFeatureLikeBuiltinMacro(llvm::raw_svector_ostream& OS,
 
   Token ResultTok;
   bool SuppressDiagnostic = false;
-  while (true) {
+  while (Tok.isNoneOf(tok::eod, tok::eof)) {
     // Parse next token.
     if (ExpandArgs)
       PP.Lex(Tok);

--- a/clang/test/Preprocessor/has_attribute_errors.cpp
+++ b/clang/test/Preprocessor/has_attribute_errors.cpp
@@ -20,6 +20,13 @@ namespace GH178098 {
 #if __has_cpp_attribute(clang::
 #endif
 
+// expected-error@+4 {{unterminated function-like macro invocation}}
+// expected-error@+3 {{missing ')' after 'clang'}}
+// expected-error@+2 {{expected value in expression}}
+// expected-note@+1 {{to match this '('}}
+#if __has_attribute(clang::
+#endif
+
 // expected-error@+3 {{builtin feature check macro requires a parenthesized identifier}}
 // expected-error@+2 {{unterminated function-like macro invocation}}
 __has_cpp_attribute(clang::

--- a/clang/test/Preprocessor/has_attribute_errors.cpp
+++ b/clang/test/Preprocessor/has_attribute_errors.cpp
@@ -14,3 +14,13 @@ __has_cpp_attribute(__clang__::fallthrough) // expected-error {{missing ')' afte
                                             // expected-note {{to match this '('}} \
                                             // expected-error {{builtin feature check macro requires a parenthesized identifier}}
 
+namespace GH178098 {
+// expected-error@+2 {{builtin feature check macro requires a parenthesized identifier}}
+// expected-error@+1 {{expected value in expression}}
+#if __has_cpp_attribute(clang::
+#endif
+
+// expected-error@+3 {{builtin feature check macro requires a parenthesized identifier}}
+// expected-error@+2 {{unterminated function-like macro invocation}}
+__has_cpp_attribute(clang::
+}

--- a/clang/test/Preprocessor/has_c_attribute_errors.c
+++ b/clang/test/Preprocessor/has_c_attribute_errors.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -triple i386-unknown-unknown -Eonly -verify %s
+
+// expected-error@+2 {{builtin feature check macro requires a parenthesized identifier}}
+// expected-error@+1 {{expected value in expression}}
+#if __has_c_attribute(clang::
+#endif
+
+// expected-error@+1 {{builtin feature check macro requires a parenthesized identifier}}
+__has_c_attribute(clang::


### PR DESCRIPTION
Fixes #178098

---

This patch addressed the issue when `__has_cpp_attribute` is expanded with incomplete scoped attributes. The scoped name parsing can lex to `eof`/`eod` at

https://github.com/llvm/llvm-project/blob/3f5a5d45d18a514f086f3e07c9676ca5fb95bbe9/clang/lib/Lex/PPMacroExpansion.cpp#L1877-L1881

and then proceed with

https://github.com/llvm/llvm-project/blob/3f5a5d45d18a514f086f3e07c9676ca5fb95bbe9/clang/lib/Lex/PPMacroExpansion.cpp#L1425-L1430


since `eof`/`eod` is not guarded at

https://github.com/llvm/llvm-project/blob/3f5a5d45d18a514f086f3e07c9676ca5fb95bbe9/clang/lib/Lex/PPMacroExpansion.cpp#L1367-L1372

this could lead to a preprocessor crash

https://github.com/llvm/llvm-project/blob/3f5a5d45d18a514f086f3e07c9676ca5fb95bbe9/clang/lib/Lex/PPMacroExpansion.cpp#L1370
