### PR TITLE
[Polly][DeLICM] Check for error state

### DIFF
--- a/polly/lib/Transform/ZoneAlgo.cpp
+++ b/polly/lib/Transform/ZoneAlgo.cpp
@@ -855,7 +855,10 @@ static isl::union_map normalizeValInst(isl::union_map Input,
 
     // Instructions within the SCoP are always wrapped. Non-wrapped tuples
     // are therefore invariant in the SCoP and don't need normalization.
-    if (!RangeSpace.is_wrapping()) {
+    auto IsWrapping = RangeSpace.is_wrapping();
+    if (IsWrapping.is_error())
+      return {};
+    if (!IsWrapping) {
       Result = Result.unite(Map);
       continue;
     }


### PR DESCRIPTION
When the ISL max-operations is exceeded, `is_wrapping` will return an error state. Propagate the error state to the caller.

Fixes #175953