### PR TITLE
[Intrinsics] Check that element count is a valid multiple before calling VectorType::getOneNthElementsVectorType.

### DIFF
--- a/llvm/test/Assembler/invalid-interleave.ll
+++ b/llvm/test/Assembler/invalid-interleave.ll
@@ -1,0 +1,9 @@
+; RUN: not llvm-as < %s 2>&1 | FileCheck %s
+
+; Input element count without vscale is not a multiple of 3.
+
+; CHECK: error: invalid intrinsic signature
+define { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @test(<vscale x 8 x i8> %ptr) {
+  %v = tail call { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } @llvm.vector.deinterleave3.nxv6i32(<vscale x 8 x i8> %ptr)
+  ret { <vscale x 2 x i32>, <vscale x 2 x i32>, <vscale x 2 x i32> } %v
+}


### PR DESCRIPTION
Fixes #178275