### PR TITLE
[MLIR][Python] Remove partial LLVM APIs in python bindings

### DIFF
--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -30,7 +30,6 @@
 #include "mlir/Bindings/Python/Nanobind.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/ThreadPool.h"
 
@@ -256,7 +255,7 @@ private:
   // extension mechanism on the MlirContext for stashing user pointers.
   // Note that this holds a handle, which does not imply ownership.
   // Mappings will be removed when the context is destructed.
-  using LiveContextMap = llvm::DenseMap<void *, PyMlirContext *>;
+  using LiveContextMap = std::unordered_map<void *, PyMlirContext *>;
   static nanobind::ft_mutex live_contexts_mutex;
   static LiveContextMap &getLiveContexts();
 
@@ -265,7 +264,7 @@ private:
   // from this map, and while it still exists as an instance, any
   // attempt to access it will raise an error.
   using LiveModuleMap =
-      llvm::DenseMap<const void *, std::pair<nanobind::handle, PyModule *>>;
+      std::unordered_map<const void *, std::pair<nanobind::handle, PyModule *>>;
   LiveModuleMap liveModules;
 
   bool emitErrorDiagnostics = false;

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -30,7 +30,6 @@
 #include "mlir/Bindings/Python/Nanobind.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 
-#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/ThreadPool.h"
 
 namespace mlir {

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -947,10 +947,9 @@ public:
     if (!DerivedTy::isaFunction(orig)) {
       auto origRepr =
           nanobind::cast<std::string>(nanobind::repr(nanobind::cast(orig)));
-      throw nanobind::value_error((::llvm::Twine("Cannot cast type to ") +
+      throw nanobind::value_error((std::string("Cannot cast type to ") +
                                    DerivedTy::pyClassName + " (from " +
                                    origRepr + ")")
-                                      .str()
                                       .c_str());
     }
     return orig;
@@ -966,8 +965,7 @@ public:
           if (DerivedTy::getTypeIdFunction)
             return PyTypeID(DerivedTy::getTypeIdFunction());
           throw nanobind::attribute_error(
-              (DerivedTy::pyClassName + ::llvm::Twine(" has no typeid."))
-                  .str()
+              (DerivedTy::pyClassName + std::string(" has no typeid."))
                   .c_str());
         },
         nanobind::sig("def static_typeid(/) -> TypeID"));
@@ -1080,10 +1078,9 @@ public:
     if (!DerivedTy::isaFunction(orig)) {
       auto origRepr =
           nanobind::cast<std::string>(nanobind::repr(nanobind::cast(orig)));
-      throw nanobind::value_error((::llvm::Twine("Cannot cast attribute to ") +
+      throw nanobind::value_error((std::string("Cannot cast attribute to ") +
                                    DerivedTy::pyClassName + " (from " +
                                    origRepr + ")")
-                                      .str()
                                       .c_str());
     }
     return orig;
@@ -1111,8 +1108,7 @@ public:
           if (DerivedTy::getTypeIdFunction)
             return PyTypeID(DerivedTy::getTypeIdFunction());
           throw nanobind::attribute_error(
-              (DerivedTy::pyClassName + ::llvm::Twine(" has no typeid."))
-                  .str()
+              (DerivedTy::pyClassName + std::string(" has no typeid."))
                   .c_str());
         },
         nanobind::sig("def static_typeid(/) -> TypeID"));
@@ -1329,9 +1325,9 @@ private:
 /// Custom exception that allows access to error diagnostic information. This is
 /// converted to the `ir.MLIRError` python exception when thrown.
 struct MLIR_PYTHON_API_EXPORTED MLIRError {
-  MLIRError(::llvm::Twine message,
+  MLIRError(std::string message,
             std::vector<PyDiagnostic::DiagnosticInfo> &&errorDiagnostics = {})
-      : message(message.str()), errorDiagnostics(std::move(errorDiagnostics)) {}
+      : message(message), errorDiagnostics(std::move(errorDiagnostics)) {}
   std::string message;
   std::vector<PyDiagnostic::DiagnosticInfo> errorDiagnostics;
 };
@@ -1549,10 +1545,9 @@ public:
     if (!DerivedTy::isaFunction(orig.get())) {
       auto origRepr =
           nanobind::cast<std::string>(nanobind::repr(nanobind::cast(orig)));
-      throw nanobind::value_error((::llvm::Twine("Cannot cast value to ") +
+      throw nanobind::value_error((std::string("Cannot cast value to ") +
                                    DerivedTy::pyClassName + " (from " +
                                    origRepr + ")")
-                                      .str()
                                       .c_str());
     }
     return orig.get();
@@ -1561,9 +1556,8 @@ public:
   /// Binds the Python module objects to functions of this class.
   static void bind(nanobind::module_ &m) {
     auto cls = ClassTy(m, DerivedTy::pyClassName, nanobind::is_generic(),
-                       nanobind::sig((::llvm::Twine("class ") +
+                       nanobind::sig((std::string("class ") +
                                       DerivedTy::pyClassName + "(Value[_T])")
-                                         .str()
                                          .c_str()));
     cls.def(nanobind::init<PyValue &>(), nanobind::keep_alive<0, 1>(),
             nanobind::arg("value"));

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -1328,7 +1328,8 @@ private:
 struct MLIR_PYTHON_API_EXPORTED MLIRError {
   MLIRError(std::string message,
             std::vector<PyDiagnostic::DiagnosticInfo> &&errorDiagnostics = {})
-      : message(std::move(message)), errorDiagnostics(std::move(errorDiagnostics)) {}
+      : message(std::move(message)),
+        errorDiagnostics(std::move(errorDiagnostics)) {}
   std::string message;
   std::vector<PyDiagnostic::DiagnosticInfo> errorDiagnostics;
 };

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -1820,9 +1820,8 @@ public:
 
   bool dunderContains(const std::string &name);
 
-  static void
-  forEachAttr(MlirOperation op,
-              llvm::function_ref<void(MlirStringRef, MlirAttribute)> fn);
+  static void forEachAttr(MlirOperation op,
+                          std::function<void(MlirStringRef, MlirAttribute)> fn);
 
   static void bind(nanobind::module_ &m);
 

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -10,6 +10,7 @@
 #ifndef MLIR_BINDINGS_PYTHON_IRCORE_H
 #define MLIR_BINDINGS_PYTHON_IRCORE_H
 
+#include <cstddef>
 #include <optional>
 #include <sstream>
 #include <utility>
@@ -687,7 +688,8 @@ public:
   /// Creates an operation. See corresponding python docstring.
   static nanobind::object
   create(std::string_view name, std::optional<std::vector<PyType *>> results,
-         llvm::ArrayRef<MlirValue> operands,
+         const MlirValue *operands,
+         size_t numOperands,
          std::optional<nanobind::dict> attributes,
          std::optional<std::vector<PyBlock *>> successors, int regions,
          PyLocation &location, const nanobind::object &ip, bool inferType);

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -1328,7 +1328,7 @@ private:
 struct MLIR_PYTHON_API_EXPORTED MLIRError {
   MLIRError(std::string message,
             std::vector<PyDiagnostic::DiagnosticInfo> &&errorDiagnostics = {})
-      : message(message), errorDiagnostics(std::move(errorDiagnostics)) {}
+      : message(std::move(message)), errorDiagnostics(std::move(errorDiagnostics)) {}
   std::string message;
   std::vector<PyDiagnostic::DiagnosticInfo> errorDiagnostics;
 };

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -688,8 +688,7 @@ public:
   /// Creates an operation. See corresponding python docstring.
   static nanobind::object
   create(std::string_view name, std::optional<std::vector<PyType *>> results,
-         const MlirValue *operands,
-         size_t numOperands,
+         const MlirValue *operands, size_t numOperands,
          std::optional<nanobind::dict> attributes,
          std::optional<std::vector<PyBlock *>> successors, int regions,
          PyLocation &location, const nanobind::object &ip, bool inferType);

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -25,7 +25,6 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace mlir;
 
-
 static const char kModuleParseDocstring[] =
     R"(Parses a module's assembly format from a string.
 
@@ -1099,9 +1098,10 @@ void PyOperationBase::writeBytecode(const nb::object &fileOrStringObject,
       operation, config, accum.getCallback(), accum.getUserData());
   mlirBytecodeWriterConfigDestroy(config);
   if (mlirLogicalResultIsFailure(res))
-    throw nb::value_error((std::string("Unable to honor desired bytecode version ") +
-                           std::to_string(*bytecodeVersion))
-                              .c_str());
+    throw nb::value_error(
+        (std::string("Unable to honor desired bytecode version ") +
+         std::to_string(*bytecodeVersion))
+            .c_str());
 }
 
 void PyOperationBase::walk(std::function<PyWalkResult(MlirOperation)> callback,
@@ -1248,8 +1248,7 @@ static void maybeInsertOperation(PyOperationRef &op,
 
 nb::object PyOperation::create(std::string_view name,
                                std::optional<std::vector<PyType *>> results,
-                               const MlirValue *operands,
-                               size_t numOperands,
+                               const MlirValue *operands, size_t numOperands,
                                std::optional<nb::dict> attributes,
                                std::optional<std::vector<PyBlock *>> successors,
                                int regions, PyLocation &location,
@@ -1477,7 +1476,8 @@ static void populateResultTypes(StringRef name, nb::list resultTypeList,
       } catch (nb::cast_error &err) {
         throw nb::value_error((std::string("Result ") +
                                std::to_string(it.index()) + " of operation \"" +
-                               std::string(name) + "\" must be a Type (" + err.what() + ")")
+                               std::string(name) + "\" must be a Type (" +
+                               err.what() + ")")
                                   .c_str());
       }
     }
@@ -1515,9 +1515,9 @@ static void populateResultTypes(StringRef name, nb::list resultTypeList,
           }
         } catch (nb::cast_error &err) {
           throw nb::value_error((std::string("Result ") +
-                                 std::to_string(it.index()) + " of operation \"" +
-                                 std::string(name) + "\" must be a Type (" + err.what() +
-                                 ")")
+                                 std::to_string(it.index()) +
+                                 " of operation \"" + std::string(name) +
+                                 "\" must be a Type (" + err.what() + ")")
                                     .c_str());
         }
       } else if (segmentSpec == -1) {
@@ -1541,12 +1541,12 @@ static void populateResultTypes(StringRef name, nb::list resultTypeList,
           // NOTE: Sloppy to be using a catch-all here, but there are at least
           // three different unrelated exceptions that can be thrown in the
           // above "casts". Just keep the scope above small and catch them all.
-          throw nb::value_error((std::string("Result ") +
-                                 std::to_string(it.index()) + " of operation \"" +
-                                 name + "\" must be a Sequence of Types (" +
-                                 err.what() + ")")
-                                    .str()
-                                    .c_str());
+          throw nb::value_error(
+              (std::string("Result ") + std::to_string(it.index()) +
+               " of operation \"" + name + "\" must be a Sequence of Types (" +
+               err.what() + ")")
+                  .str()
+                  .c_str());
         }
       } else {
         throw nb::value_error("Unexpected segment spec");
@@ -1616,15 +1616,15 @@ nb::object PyOpView::buildGeneric(
   }
   if (*regions < opMinRegionCount) {
     throw nb::value_error(
-        (std::string("Operation \"") + std::string(name) + "\" requires a minimum of " +
-         std::to_string(opMinRegionCount) +
+        (std::string("Operation \"") + std::string(name) +
+         "\" requires a minimum of " + std::to_string(opMinRegionCount) +
          " regions but was built with regions=" + std::to_string(*regions))
             .c_str());
   }
   if (opHasNoVariadicRegions && *regions > opMinRegionCount) {
     throw nb::value_error(
-        (std::string("Operation \"") + std::string(name) + "\" requires a maximum of " +
-         std::to_string(opMinRegionCount) +
+        (std::string("Operation \"") + std::string(name) +
+         "\" requires a maximum of " + std::to_string(opMinRegionCount) +
          " regions but was built with regions=" + std::to_string(*regions))
             .c_str());
   }
@@ -1647,7 +1647,8 @@ nb::object PyOpView::buildGeneric(
       } catch (nb::builtin_exception &err) {
         throw nb::value_error((std::string("Operand ") +
                                std::to_string(it.index()) + " of operation \"" +
-                               std::string(name) + "\" must be a Value (" + err.what() + ")")
+                               std::string(name) + "\" must be a Value (" +
+                               err.what() + ")")
                                   .c_str());
       }
     }
@@ -1676,8 +1677,7 @@ nb::object PyOpView::buildGeneric(
           } catch (nb::builtin_exception &err) {
             throw nb::value_error((std::string("Operand ") +
                                    std::to_string(it.index()) +
-                                   " of operation \"" 
-                                   + std::string(name) +
+                                   " of operation \"" + std::string(name) +
                                    "\" must be a Value (" + err.what() + ")")
                                       .c_str());
           }
@@ -1711,11 +1711,11 @@ nb::object PyOpView::buildGeneric(
           // NOTE: Sloppy to be using a catch-all here, but there are at least
           // three different unrelated exceptions that can be thrown in the
           // above "casts". Just keep the scope above small and catch them all.
-          throw nb::value_error((std::string("Operand ") +
-                                 std::to_string(it.index()) + " of operation \"" +
-                                 std::string(name) + "\" must be a Sequence of Values (" +
-                                 err.what() + ")")
-                                    .c_str());
+          throw nb::value_error(
+              (std::string("Operand ") + std::to_string(it.index()) +
+               " of operation \"" + std::string(name) +
+               "\" must be a Sequence of Values (" + err.what() + ")")
+                  .c_str());
         }
       } else {
         throw nb::value_error("Unexpected segment spec");
@@ -3759,9 +3759,9 @@ void populateIRCore(nb::module_ &m) {
             }
 
             PyLocation pyLoc = maybeGetTracebackLocation(location);
-            return PyOperation::create(name, results, mlirOperands.data(), mlirOperands.size(), attributes,
-                                       successors, regions, pyLoc, maybeIp,
-                                       inferType);
+            return PyOperation::create(
+                name, results, mlirOperands.data(), mlirOperands.size(),
+                attributes, successors, regions, pyLoc, maybeIp, inferType);
           },
           "name"_a, "results"_a = nb::none(), "operands"_a = nb::none(),
           "attributes"_a = nb::none(), "successors"_a = nb::none(),
@@ -3929,8 +3929,8 @@ void populateIRCore(nb::module_ &m) {
             mlirIdentifierStr(mlirOperationGetName(*parsed.get()));
         std::string_view parsedOpName(identifier.data, identifier.length);
         if (clsOpName != parsedOpName)
-          throw MLIRError(std::string("Expected a '") + std::string(clsOpName) + "' op, got: '" +
-                          std::string(parsedOpName) + "'");
+          throw MLIRError(std::string("Expected a '") + std::string(clsOpName) +
+                          "' op, got: '" + std::string(parsedOpName) + "'");
         return PyOpView::constructDerived(cls, parsed.getObject());
       },
       "cls"_a, "source"_a, nb::kw_only(), "source_name"_a = "",

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -1289,9 +1289,8 @@ nb::object PyOperation::create(std::string_view name,
       try {
         key = nb::cast<std::string>(it.first);
       } catch (nb::cast_error &err) {
-        std::string msg = "Invalid attribute key (not a string) when "
-                          "attempting to create the operation \"" +
-                          std::string(name) + "\" (" + err.what() + ")";
+        std::string msg = join("Invalid attribute key (not a string) when "
+                          "attempting to create the operation \"", name, "\" (", err.what(), ")");
         throw nb::type_error(msg.c_str());
       }
       try {
@@ -1299,16 +1298,14 @@ nb::object PyOperation::create(std::string_view name,
         // TODO: Verify attribute originates from the same context.
         mlirAttributes.emplace_back(std::move(key), attribute);
       } catch (nb::cast_error &err) {
-        std::string msg = "Invalid attribute value for the key \"" + key +
-                          "\" when attempting to create the operation \"" +
-                          std::string(name) + "\" (" + err.what() + ")";
+        std::string msg = join("Invalid attribute value for the key \"", key, 
+                          "\" when attempting to create the operation \"", name, "\" (", err.what(), ")");
         throw nb::type_error(msg.c_str());
       } catch (std::runtime_error &) {
         // This exception seems thrown when the value is "None".
-        std::string msg =
-            "Found an invalid (`None`?) attribute value for the key \"" + key +
-            "\" when attempting to create the operation \"" +
-            std::string(name) + "\"";
+        std::string msg =join(
+            "Found an invalid (`None`?) attribute value for the key \"", key, 
+            "\" when attempting to create the operation \"",name, "\"");
         throw std::runtime_error(msg);
       }
     }
@@ -2057,8 +2054,8 @@ nb::object PySymbolTable::dunderGetItem(const std::string &name) {
   MlirOperation symbol = mlirSymbolTableLookup(
       symbolTable, mlirStringRefCreate(name.data(), name.length()));
   if (mlirOperationIsNull(symbol))
-    throw nb::key_error(
-        ("Symbol '" + name + "' not in the symbol table.").c_str());
+    throw nb::key_error(join
+        ("Symbol '", name, "' not in the symbol table.").c_str());
 
   return PyOperation::forOperation(operation->getContext(), symbol,
                                    operation.getObject())
@@ -2940,8 +2937,8 @@ void populateIRCore(nb::module_ &m) {
             MlirDialect dialect = mlirContextGetOrLoadDialect(
                 self.get(), {name.data(), name.size()});
             if (mlirDialectIsNull(dialect)) {
-              throw nb::value_error(
-                  (std::string("Dialect '") + name + "' not found").c_str());
+              throw nb::value_error(join
+                  ("Dialect '", name, "' not found").c_str());
             }
             return PyDialectDescriptor(self.getRef(), dialect);
           },
@@ -3931,8 +3928,8 @@ void populateIRCore(nb::module_ &m) {
             mlirIdentifierStr(mlirOperationGetName(*parsed.get()));
         std::string_view parsedOpName(identifier.data, identifier.length);
         if (clsOpName != parsedOpName)
-          throw MLIRError(std::string("Expected a '") + std::string(clsOpName) +
-                          "' op, got: '" + std::string(parsedOpName) + "'");
+          throw MLIRError(join("Expected a '", clsOpName, 
+                          "' op, got: '", parsedOpName, "'"));
         return PyOpView::constructDerived(cls, parsed.getObject());
       },
       "cls"_a, "source"_a, nb::kw_only(), "source_name"_a = "",

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -50,7 +50,7 @@ operations.
 
 /// Local helper to concatenate string and integer arguments into a std::string.
 template <typename... Ts>
-std::string join(const Ts&... args) {
+std::string join(const Ts &...args) {
   std::ostringstream oss;
   (oss << ... << args);
   return oss.str();
@@ -104,9 +104,9 @@ MlirBlock createBlock(const nb::sequence &pyArgTypes,
   }
 
   if (argTypes.size() != argLocs.size())
-    throw nb::value_error(join("Expected ", argTypes.size(), 
-                           " locations, got: ", argLocs.size())
-                              .c_str());
+    throw nb::value_error(
+        join("Expected ", argTypes.size(), " locations, got: ", argLocs.size())
+            .c_str());
   return mlirBlockCreate(argTypes.size(), argTypes.data(), argLocs.data());
 }
 
@@ -1108,9 +1108,8 @@ void PyOperationBase::writeBytecode(const nb::object &fileOrStringObject,
       operation, config, accum.getCallback(), accum.getUserData());
   mlirBytecodeWriterConfigDestroy(config);
   if (mlirLogicalResultIsFailure(res))
-    throw nb::value_error(join
-        ("Unable to honor desired bytecode version ", 
-         *bytecodeVersion)
+    throw nb::value_error(
+        join("Unable to honor desired bytecode version ", *bytecodeVersion)
             .c_str());
 }
 
@@ -1290,7 +1289,8 @@ nb::object PyOperation::create(std::string_view name,
         key = nb::cast<std::string>(it.first);
       } catch (nb::cast_error &err) {
         std::string msg = join("Invalid attribute key (not a string) when "
-                          "attempting to create the operation \"", name, "\" (", err.what(), ")");
+                               "attempting to create the operation \"",
+                               name, "\" (", err.what(), ")");
         throw nb::type_error(msg.c_str());
       }
       try {
@@ -1298,14 +1298,15 @@ nb::object PyOperation::create(std::string_view name,
         // TODO: Verify attribute originates from the same context.
         mlirAttributes.emplace_back(std::move(key), attribute);
       } catch (nb::cast_error &err) {
-        std::string msg = join("Invalid attribute value for the key \"", key, 
-                          "\" when attempting to create the operation \"", name, "\" (", err.what(), ")");
+        std::string msg = join("Invalid attribute value for the key \"", key,
+                               "\" when attempting to create the operation \"",
+                               name, "\" (", err.what(), ")");
         throw nb::type_error(msg.c_str());
       } catch (std::runtime_error &) {
         // This exception seems thrown when the value is "None".
-        std::string msg =join(
-            "Found an invalid (`None`?) attribute value for the key \"", key, 
-            "\" when attempting to create the operation \"",name, "\"");
+        std::string msg = join(
+            "Found an invalid (`None`?) attribute value for the key \"", key,
+            "\" when attempting to create the operation \"", name, "\"");
         throw std::runtime_error(msg);
       }
     }
@@ -1481,9 +1482,8 @@ static void populateResultTypes(std::string_view name, nb::list resultTypeList,
         if (!resultTypes.back())
           throw nb::cast_error();
       } catch (nb::cast_error &err) {
-        throw nb::value_error(join("Result ", it.index(), " of operation \"", 
-                               name, "\" must be a Type (", 
-                               err.what(), ")")
+        throw nb::value_error(join("Result ", it.index(), " of operation \"",
+                                   name, "\" must be a Type (", err.what(), ")")
                                   .c_str());
       }
     }
@@ -1491,11 +1491,10 @@ static void populateResultTypes(std::string_view name, nb::list resultTypeList,
     // Sized result unpacking.
     auto resultSegmentSpec = nb::cast<std::vector<int>>(resultSegmentSpecObj);
     if (resultSegmentSpec.size() != resultTypeList.size()) {
-      throw nb::value_error(join("Operation \"", name, 
-                             "\" requires ", resultSegmentSpec.size(), 
-                             " result segments but was provided ", 
-                             resultTypeList.size())
-                                .c_str());
+      throw nb::value_error(
+          join("Operation \"", name, "\" requires ", resultSegmentSpec.size(),
+               " result segments but was provided ", resultTypeList.size())
+              .c_str());
     }
     resultSegmentLengths.reserve(resultTypeList.size());
     for (const auto &it :
@@ -1512,16 +1511,15 @@ static void populateResultTypes(std::string_view name, nb::list resultTypeList,
             // Allowed to be optional.
             resultSegmentLengths.push_back(0);
           } else {
-            throw nb::value_error(join
-                ("Result ", it.index(), 
-                 " of operation \"", name, 
-                 "\" must be a Type (was None and result is not optional)")
+            throw nb::value_error(
+                join("Result ", it.index(), " of operation \"", name,
+                     "\" must be a Type (was None and result is not optional)")
                     .c_str());
           }
         } catch (nb::cast_error &err) {
-          throw nb::value_error(join("Result ", it.index(), 
-                                 " of operation \"" , name, 
-                                 "\" must be a Type (", err.what(), ")")
+          throw nb::value_error(join("Result ", it.index(), " of operation \"",
+                                     name, "\" must be a Type (", err.what(),
+                                     ")")
                                     .c_str());
         }
       } else if (segmentSpec == -1) {
@@ -1545,11 +1543,10 @@ static void populateResultTypes(std::string_view name, nb::list resultTypeList,
           // NOTE: Sloppy to be using a catch-all here, but there are at least
           // three different unrelated exceptions that can be thrown in the
           // above "casts". Just keep the scope above small and catch them all.
-          throw nb::value_error(join
-              ("Result ", it.index(), 
-               " of operation \"", name, "\" must be a Sequence of Types (", 
-               err.what(), ")")
-                  .c_str());
+          throw nb::value_error(join("Result ", it.index(), " of operation \"",
+                                     name, "\" must be a Sequence of Types (",
+                                     err.what(), ")")
+                                    .c_str());
         }
       } else {
         throw nb::value_error("Unexpected segment spec");
@@ -1562,11 +1559,13 @@ MlirValue getUniqueResult(MlirOperation operation) {
   auto numResults = mlirOperationGetNumResults(operation);
   if (numResults != 1) {
     auto name = mlirIdentifierStr(mlirOperationGetName(operation));
-    throw nb::value_error(join("Cannot call .result on operation ", 
-                           std::string_view(name.data, name.length), " which has ", numResults, 
-                           " results (it is only valid for operations with a "
-                           "single result)")
-                              .c_str());
+    throw nb::value_error(
+        join("Cannot call .result on operation ",
+             std::string_view(name.data, name.length), " which has ",
+             numResults,
+             " results (it is only valid for operations with a "
+             "single result)")
+            .c_str());
   }
   return mlirOperationGetResult(operation, 0);
 }
@@ -1616,18 +1615,16 @@ nb::object PyOpView::buildGeneric(
     regions = opMinRegionCount;
   }
   if (*regions < opMinRegionCount) {
-    throw nb::value_error(join
-        ("Operation \"", name, 
-         "\" requires a minimum of ", opMinRegionCount, 
-         " regions but was built with regions=", *regions)
-            .c_str());
+    throw nb::value_error(join("Operation \"", name,
+                               "\" requires a minimum of ", opMinRegionCount,
+                               " regions but was built with regions=", *regions)
+                              .c_str());
   }
   if (opHasNoVariadicRegions && *regions > opMinRegionCount) {
-    throw nb::value_error(join
-        ("Operation \"", name, 
-         "\" requires a maximum of ", opMinRegionCount, 
-         " regions but was built with regions=", *regions)
-            .c_str());
+    throw nb::value_error(join("Operation \"", name,
+                               "\" requires a maximum of ", opMinRegionCount,
+                               " regions but was built with regions=", *regions)
+                              .c_str());
   }
 
   // Unpack results.
@@ -1646,9 +1643,9 @@ nb::object PyOpView::buildGeneric(
       try {
         operands.push_back(getOpResultOrValue(it.value()));
       } catch (nb::builtin_exception &err) {
-        throw nb::value_error(join("Operand ", it.index(), " of operation \"", 
-                               name, "\" must be a Value (", 
-                               err.what(), ")")
+        throw nb::value_error(join("Operand ", it.index(), " of operation \"",
+                                   name, "\" must be a Value (", err.what(),
+                                   ")")
                                   .c_str());
       }
     }
@@ -1656,12 +1653,10 @@ nb::object PyOpView::buildGeneric(
     // Sized operand unpacking.
     auto operandSegmentSpec = nb::cast<std::vector<int>>(operandSegmentSpecObj);
     if (operandSegmentSpec.size() != operandList.size()) {
-      throw nb::value_error(join("Operation \"", name,
-                             "\" requires ", 
-                             operandSegmentSpec.size(), 
-                             "operand segments but was provided ", 
-                             operandList.size())
-                                .c_str());
+      throw nb::value_error(
+          join("Operation \"", name, "\" requires ", operandSegmentSpec.size(),
+               "operand segments but was provided ", operandList.size())
+              .c_str());
     }
     operandSegmentLengths.reserve(operandList.size());
     for (const auto &it :
@@ -1675,9 +1670,9 @@ nb::object PyOpView::buildGeneric(
 
             operands.push_back(getOpResultOrValue(operand));
           } catch (nb::builtin_exception &err) {
-            throw nb::value_error(join("Operand ", it.index(), 
-                                   " of operation \"", name, 
-                                   "\" must be a Value (",  err.what(), ")")
+            throw nb::value_error(join("Operand ", it.index(),
+                                       " of operation \"", name,
+                                       "\" must be a Value (", err.what(), ")")
                                       .c_str());
           }
 
@@ -1686,10 +1681,9 @@ nb::object PyOpView::buildGeneric(
           // Allowed to be optional.
           operandSegmentLengths.push_back(0);
         } else {
-          throw nb::value_error(join
-              ("Operand ", it.index(), 
-               " of operation \"", name, 
-               "\" must be a Value (was None and operand is not optional)")
+          throw nb::value_error(
+              join("Operand ", it.index(), " of operation \"", name,
+                   "\" must be a Value (was None and operand is not optional)")
                   .c_str());
         }
       } else if (segmentSpec == -1) {
@@ -1710,11 +1704,10 @@ nb::object PyOpView::buildGeneric(
           // NOTE: Sloppy to be using a catch-all here, but there are at least
           // three different unrelated exceptions that can be thrown in the
           // above "casts". Just keep the scope above small and catch them all.
-          throw nb::value_error(join
-              ("Operand ", it.index(), 
-               " of operation \"", name, 
-               "\" must be a Sequence of Values (", err.what(), ")")
-                  .c_str());
+          throw nb::value_error(join("Operand ", it.index(), " of operation \"",
+                                     name, "\" must be a Sequence of Values (",
+                                     err.what(), ")")
+                                    .c_str());
         }
       } else {
         throw nb::value_error("Unexpected segment spec");
@@ -2054,8 +2047,8 @@ nb::object PySymbolTable::dunderGetItem(const std::string &name) {
   MlirOperation symbol = mlirSymbolTableLookup(
       symbolTable, mlirStringRefCreate(name.data(), name.length()));
   if (mlirOperationIsNull(symbol))
-    throw nb::key_error(join
-        ("Symbol '", name, "' not in the symbol table.").c_str());
+    throw nb::key_error(
+        join("Symbol '", name, "' not in the symbol table.").c_str());
 
   return PyOperation::forOperation(operation->getContext(), symbol,
                                    operation.getObject())
@@ -2937,8 +2930,8 @@ void populateIRCore(nb::module_ &m) {
             MlirDialect dialect = mlirContextGetOrLoadDialect(
                 self.get(), {name.data(), name.size()});
             if (mlirDialectIsNull(dialect)) {
-              throw nb::value_error(join
-                  ("Dialect '", name, "' not found").c_str());
+              throw nb::value_error(
+                  join("Dialect '", name, "' not found").c_str());
             }
             return PyDialectDescriptor(self.getRef(), dialect);
           },
@@ -3928,8 +3921,8 @@ void populateIRCore(nb::module_ &m) {
             mlirIdentifierStr(mlirOperationGetName(*parsed.get()));
         std::string_view parsedOpName(identifier.data, identifier.length);
         if (clsOpName != parsedOpName)
-          throw MLIRError(join("Expected a '", clsOpName, 
-                          "' op, got: '", parsedOpName, "'"));
+          throw MLIRError(join("Expected a '", clsOpName, "' op, got: '",
+                               parsedOpName, "'"));
         return PyOpView::constructDerived(cls, parsed.getObject());
       },
       "cls"_a, "source"_a, nb::kw_only(), "source_name"_a = "",

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -50,7 +50,7 @@ operations.
 
 /// Local helper to concatenate string and integer arguments into a std::string.
 template <typename... Ts>
-std::string join(const Ts &...args) {
+static std::string join(const Ts &...args) {
   std::ostringstream oss;
   (oss << ... << args);
   return oss.str();
@@ -827,7 +827,7 @@ MlirDialect PyDialects::getDialectForKey(const std::string &key,
   MlirDialect dialect = mlirContextGetOrLoadDialect(getContext()->get(),
                                                     {key.data(), key.size()});
   if (mlirDialectIsNull(dialect)) {
-    std::string msg = (std::string("Dialect '") + key + "' not found");
+    std::string msg = join("Dialect '", key, "' not found");
     if (attrError)
       throw nb::attribute_error(msg.c_str());
     throw nb::index_error(msg.c_str());
@@ -1326,7 +1326,7 @@ nb::object PyOperation::create(std::string_view name,
   // point, exceptions cannot be thrown or else the state will leak.
   MlirOperationState state =
       mlirOperationStateGet(toMlirStringRef(name), location);
-  if (numOperands)
+  if (numOperands > 0)
     mlirOperationStateAddOperands(&state, numOperands, operands);
   state.enableResultTypeInference = inferType;
   if (!mlirResults.empty())

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -20,6 +20,8 @@
 #include "mlir-c/Support.h"
 
 #include <optional>
+#include <sstream>
+#include <string>
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -45,6 +47,14 @@ operations.
 //------------------------------------------------------------------------------
 // Utilities.
 //------------------------------------------------------------------------------
+
+/// Local helper to concatenate string and integer arguments into a std::string.
+template <typename... Ts>
+std::string join(const Ts&... args) {
+  std::ostringstream oss;
+  (oss << ... << args);
+  return oss.str();
+}
 
 /// Helper for creating an @classmethod.
 template <class Func, typename... Args>
@@ -94,8 +104,8 @@ MlirBlock createBlock(const nb::sequence &pyArgTypes,
   }
 
   if (argTypes.size() != argLocs.size())
-    throw nb::value_error(("Expected " + std::to_string(argTypes.size()) +
-                           " locations, got: " + std::to_string(argLocs.size()))
+    throw nb::value_error(join("Expected ", argTypes.size(), 
+                           " locations, got: ", argLocs.size())
                               .c_str());
   return mlirBlockCreate(argTypes.size(), argTypes.data(), argLocs.data());
 }
@@ -1098,9 +1108,9 @@ void PyOperationBase::writeBytecode(const nb::object &fileOrStringObject,
       operation, config, accum.getCallback(), accum.getUserData());
   mlirBytecodeWriterConfigDestroy(config);
   if (mlirLogicalResultIsFailure(res))
-    throw nb::value_error(
-        (std::string("Unable to honor desired bytecode version ") +
-         std::to_string(*bytecodeVersion))
+    throw nb::value_error(join
+        ("Unable to honor desired bytecode version ", 
+         *bytecodeVersion)
             .c_str());
 }
 

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -48,7 +48,7 @@ operations.
 // Utilities.
 //------------------------------------------------------------------------------
 
-/// Local helper to concatenate string and integer arguments into a std::string.
+/// Local helper to concatenate arguments into a `std::string`.
 template <typename... Ts>
 static std::string join(const Ts &...args) {
   std::ostringstream oss;

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2422,8 +2422,7 @@ bool PyOpAttributeMap::dunderContains(const std::string &name) {
 }
 
 void PyOpAttributeMap::forEachAttr(
-    MlirOperation op,
-    llvm::function_ref<void(MlirStringRef, MlirAttribute)> fn) {
+    MlirOperation op, std::function<void(MlirStringRef, MlirAttribute)> fn) {
   intptr_t n = mlirOperationGetNumAttributes(op);
   for (intptr_t i = 0; i < n; ++i) {
     MlirNamedAttribute na = mlirOperationGetAttribute(op, i);

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -1484,10 +1484,9 @@ static void populateResultTypes(std::string_view name, nb::list resultTypeList,
         if (!resultTypes.back())
           throw nb::cast_error();
       } catch (nb::cast_error &err) {
-        throw nb::value_error((std::string("Result ") +
-                               std::to_string(it.index()) + " of operation \"" +
-                               std::string(name) + "\" must be a Type (" +
-                               err.what() + ")")
+        throw nb::value_error(join("Result ", it.index(), " of operation \"", 
+                               name, "\" must be a Type (", 
+                               err.what(), ")")
                                   .c_str());
       }
     }
@@ -1495,11 +1494,10 @@ static void populateResultTypes(std::string_view name, nb::list resultTypeList,
     // Sized result unpacking.
     auto resultSegmentSpec = nb::cast<std::vector<int>>(resultSegmentSpecObj);
     if (resultSegmentSpec.size() != resultTypeList.size()) {
-      throw nb::value_error((std::string("Operation \"") + std::string(name) +
-                             "\" requires " +
-                             std::to_string(resultSegmentSpec.size()) +
-                             " result segments but was provided " +
-                             std::to_string(resultTypeList.size()))
+      throw nb::value_error(join("Operation \"", name, 
+                             "\" requires ", resultSegmentSpec.size(), 
+                             " result segments but was provided ", 
+                             resultTypeList.size())
                                 .c_str());
     }
     resultSegmentLengths.reserve(resultTypeList.size());
@@ -1517,17 +1515,16 @@ static void populateResultTypes(std::string_view name, nb::list resultTypeList,
             // Allowed to be optional.
             resultSegmentLengths.push_back(0);
           } else {
-            throw nb::value_error(
-                (std::string("Result ") + std::to_string(it.index()) +
-                 " of operation \"" + std::string(name) +
+            throw nb::value_error(join
+                ("Result ", it.index(), 
+                 " of operation \"", name, 
                  "\" must be a Type (was None and result is not optional)")
                     .c_str());
           }
         } catch (nb::cast_error &err) {
-          throw nb::value_error((std::string("Result ") +
-                                 std::to_string(it.index()) +
-                                 " of operation \"" + std::string(name) +
-                                 "\" must be a Type (" + err.what() + ")")
+          throw nb::value_error(join("Result ", it.index(), 
+                                 " of operation \"" , name, 
+                                 "\" must be a Type (", err.what(), ")")
                                     .c_str());
         }
       } else if (segmentSpec == -1) {
@@ -1551,10 +1548,10 @@ static void populateResultTypes(std::string_view name, nb::list resultTypeList,
           // NOTE: Sloppy to be using a catch-all here, but there are at least
           // three different unrelated exceptions that can be thrown in the
           // above "casts". Just keep the scope above small and catch them all.
-          throw nb::value_error(
-              (std::string("Result ") + std::to_string(it.index()) +
-               " of operation \"" + std::string(name) + "\" must be a Sequence of Types (" +
-               err.what() + ")")
+          throw nb::value_error(join
+              ("Result ", it.index(), 
+               " of operation \"", name, "\" must be a Sequence of Types (", 
+               err.what(), ")")
                   .c_str());
         }
       } else {
@@ -1568,9 +1565,8 @@ MlirValue getUniqueResult(MlirOperation operation) {
   auto numResults = mlirOperationGetNumResults(operation);
   if (numResults != 1) {
     auto name = mlirIdentifierStr(mlirOperationGetName(operation));
-    throw nb::value_error((std::string("Cannot call .result on operation ") +
-                           std::string(name.data, name.length) + " which has " +
-                           std::to_string(numResults) +
+    throw nb::value_error(join("Cannot call .result on operation ", 
+                           std::string_view(name.data, name.length), " which has ", numResults, 
                            " results (it is only valid for operations with a "
                            "single result)")
                               .c_str());
@@ -1623,17 +1619,17 @@ nb::object PyOpView::buildGeneric(
     regions = opMinRegionCount;
   }
   if (*regions < opMinRegionCount) {
-    throw nb::value_error(
-        (std::string("Operation \"") + std::string(name) +
-         "\" requires a minimum of " + std::to_string(opMinRegionCount) +
-         " regions but was built with regions=" + std::to_string(*regions))
+    throw nb::value_error(join
+        ("Operation \"", name, 
+         "\" requires a minimum of ", opMinRegionCount, 
+         " regions but was built with regions=", *regions)
             .c_str());
   }
   if (opHasNoVariadicRegions && *regions > opMinRegionCount) {
-    throw nb::value_error(
-        (std::string("Operation \"") + std::string(name) +
-         "\" requires a maximum of " + std::to_string(opMinRegionCount) +
-         " regions but was built with regions=" + std::to_string(*regions))
+    throw nb::value_error(join
+        ("Operation \"", name, 
+         "\" requires a maximum of ", opMinRegionCount, 
+         " regions but was built with regions=", *regions)
             .c_str());
   }
 
@@ -1653,10 +1649,9 @@ nb::object PyOpView::buildGeneric(
       try {
         operands.push_back(getOpResultOrValue(it.value()));
       } catch (nb::builtin_exception &err) {
-        throw nb::value_error((std::string("Operand ") +
-                               std::to_string(it.index()) + " of operation \"" +
-                               std::string(name) + "\" must be a Value (" +
-                               err.what() + ")")
+        throw nb::value_error(join("Operand ", it.index(), " of operation \"", 
+                               name, "\" must be a Value (", 
+                               err.what(), ")")
                                   .c_str());
       }
     }
@@ -1664,11 +1659,11 @@ nb::object PyOpView::buildGeneric(
     // Sized operand unpacking.
     auto operandSegmentSpec = nb::cast<std::vector<int>>(operandSegmentSpecObj);
     if (operandSegmentSpec.size() != operandList.size()) {
-      throw nb::value_error((std::string("Operation \"") + std::string(name) +
-                             "\" requires " +
-                             std::to_string(operandSegmentSpec.size()) +
-                             "operand segments but was provided " +
-                             std::to_string(operandList.size()))
+      throw nb::value_error(join("Operation \"", name,
+                             "\" requires ", 
+                             operandSegmentSpec.size(), 
+                             "operand segments but was provided ", 
+                             operandList.size())
                                 .c_str());
     }
     operandSegmentLengths.reserve(operandList.size());
@@ -1683,10 +1678,9 @@ nb::object PyOpView::buildGeneric(
 
             operands.push_back(getOpResultOrValue(operand));
           } catch (nb::builtin_exception &err) {
-            throw nb::value_error((std::string("Operand ") +
-                                   std::to_string(it.index()) +
-                                   " of operation \"" + std::string(name) +
-                                   "\" must be a Value (" + err.what() + ")")
+            throw nb::value_error(join("Operand ", it.index(), 
+                                   " of operation \"", name, 
+                                   "\" must be a Value (",  err.what(), ")")
                                       .c_str());
           }
 
@@ -1695,9 +1689,9 @@ nb::object PyOpView::buildGeneric(
           // Allowed to be optional.
           operandSegmentLengths.push_back(0);
         } else {
-          throw nb::value_error(
-              (std::string("Operand ") + std::to_string(it.index()) +
-               " of operation \"" + std::string(name) +
+          throw nb::value_error(join
+              ("Operand ", it.index(), 
+               " of operation \"", name, 
                "\" must be a Value (was None and operand is not optional)")
                   .c_str());
         }
@@ -1719,10 +1713,10 @@ nb::object PyOpView::buildGeneric(
           // NOTE: Sloppy to be using a catch-all here, but there are at least
           // three different unrelated exceptions that can be thrown in the
           // above "casts". Just keep the scope above small and catch them all.
-          throw nb::value_error(
-              (std::string("Operand ") + std::to_string(it.index()) +
-               " of operation \"" + std::string(name) +
-               "\" must be a Sequence of Values (" + err.what() + ")")
+          throw nb::value_error(join
+              ("Operand ", it.index(), 
+               " of operation \"", name, 
+               "\" must be a Sequence of Values (", err.what(), ")")
                   .c_str());
         }
       } else {

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -4453,8 +4453,7 @@ void populateIRCore(nb::module_ &m) {
             if (!mlirTypeIDIsNull(mlirTypeID))
               return PyTypeID(mlirTypeID);
             auto origRepr = nb::cast<std::string>(nb::repr(nb::cast(self)));
-            throw nb::value_error(
-                (origRepr + std::string(" has no typeid.")).c_str());
+            throw nb::value_error(join(origRepr, " has no typeid.").c_str());
           },
           "Returns the `TypeID` of the `Type`, or raises `ValueError` if "
           "`Type` has no "


### PR DESCRIPTION
mlir-py bindings should only reply on C mlir APIs.
This PR replaced partial LLVM utilities (`Twine`, `ArrayRef`, `SmallVector`, `StringRef`) with equivalent STL, and added a `join()` helper function in `IRCore.cpp` to concat strings.