### PR TITLE
[RISCV] Correct the Predicates for Zvqdotq patterns. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVVLPatterns.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVVLPatterns.td
@@ -912,9 +912,10 @@ class VPatBinaryVL_XI<SDPatternOperator vop,
 
 multiclass VPatBinaryVL_VV_VX<SDPatternOperator vop, string instruction_name,
                               list<VTypeInfo> vtilist = AllIntegerVectors,
-                              bit isSEWAware = 0> {
+                              bit isSEWAware = 0,
+                              list<Predicate> ExtraPreds = []> {
   foreach vti = vtilist in {
-    let Predicates = GetVTypePredicates<vti>.Predicates in {
+    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in {
       def : VPatBinaryVL_V<vop, instruction_name, "VV",
                            vti.Vector, vti.Vector, vti.Vector, vti.Mask,
                            vti.Log2SEW, vti.LMul, vti.RegClass, vti.RegClass,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvqdotq.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvqdotq.td
@@ -89,18 +89,19 @@ let Predicates = [HasStdExtZvqdotq], mayLoad = 0, mayStore = 0,
 //===----------------------------------------------------------------------===//
 
 defvar AllE32Vectors = [VI32MF2, VI32M1, VI32M2, VI32M4, VI32M8];
-defm : VPatBinaryVL_VV_VX<riscv_vqdot_vl, "PseudoVQDOT", AllE32Vectors>;
-defm : VPatBinaryVL_VV_VX<riscv_vqdotu_vl, "PseudoVQDOTU", AllE32Vectors>;
-defm : VPatBinaryVL_VV_VX<riscv_vqdotsu_vl, "PseudoVQDOTSU", AllE32Vectors>;
+defm : VPatBinaryVL_VV_VX<riscv_vqdot_vl, "PseudoVQDOT", AllE32Vectors, ExtraPreds=[HasStdExtZvqdotq]>;
+defm : VPatBinaryVL_VV_VX<riscv_vqdotu_vl, "PseudoVQDOTU", AllE32Vectors, ExtraPreds=[HasStdExtZvqdotq]>;
+defm : VPatBinaryVL_VV_VX<riscv_vqdotsu_vl, "PseudoVQDOTSU", AllE32Vectors, ExtraPreds=[HasStdExtZvqdotq]>;
 
 // These VPat definitions are for vqdot because they have a different operand
 // order with other ternary instructions (i.e. vop.vx vd, vs2, rs1)
 multiclass VPatTernaryV_VX_AABX<string intrinsic, string instruction,
-                                list<VTypeInfoToWide> info_pairs> {
+                                list<VTypeInfoToWide> info_pairs,
+                                list<Predicate> ExtraPreds> {
   foreach pair = info_pairs in {
     defvar VdInfo = pair.Wti;
     defvar Vs2Info = pair.Vti;
-    let Predicates = GetVTypePredicates<VdInfo>.Predicates in
+    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<VdInfo>.Predicates) in
     defm : VPatTernaryWithPolicy<intrinsic, instruction,
                                  "V"#VdInfo.ScalarSuffix,
                                  VdInfo.Vector, Vs2Info.Vector, Vs2Info.Scalar,
@@ -111,11 +112,12 @@ multiclass VPatTernaryV_VX_AABX<string intrinsic, string instruction,
 }
 
 multiclass VPatTernaryV_VV_AABX<string intrinsic, string instruction,
-                                list<VTypeInfoToWide> info_pairs> {
+                                list<VTypeInfoToWide> info_pairs,
+                                list<Predicate> ExtraPreds> {
   foreach pair = info_pairs in {
     defvar VdInfo = pair.Wti;
     defvar Vs2Info = pair.Vti;
-    let Predicates = GetVTypePredicates<VdInfo>.Predicates in
+    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<VdInfo>.Predicates) in
     defm : VPatTernaryWithPolicy<intrinsic, instruction,
                                  "VV",
                                  VdInfo.Vector, Vs2Info.Vector, Vs2Info.Vector,
@@ -126,9 +128,10 @@ multiclass VPatTernaryV_VV_AABX<string intrinsic, string instruction,
 }
 
 multiclass VPatTernaryV_VV_VX_AABX<string intrinsic, string instruction,
-                                   list<VTypeInfoToWide> info_pairs>
-    : VPatTernaryV_VV_AABX<intrinsic, instruction, info_pairs>,
-      VPatTernaryV_VX_AABX<intrinsic, instruction, info_pairs>;
+                                   list<VTypeInfoToWide> info_pairs,
+                                   list<Predicate> ExtraPreds>
+    : VPatTernaryV_VV_AABX<intrinsic, instruction, info_pairs, ExtraPreds>,
+      VPatTernaryV_VX_AABX<intrinsic, instruction, info_pairs, ExtraPreds>;
 
 defset list<VTypeInfoToWide> VQDOTInfoPairs = {
   def : VTypeInfoToWide<VI8MF2, VI32MF2>;
@@ -138,9 +141,7 @@ defset list<VTypeInfoToWide> VQDOTInfoPairs = {
   def : VTypeInfoToWide<VI8M8, VI32M8>;
 }
 
-let Predicates = [HasStdExtZvqdotq] in {
-  defm : VPatTernaryV_VV_VX_AABX<"int_riscv_vqdot", "PseudoVQDOT", VQDOTInfoPairs>;
-  defm : VPatTernaryV_VV_VX_AABX<"int_riscv_vqdotu", "PseudoVQDOTU", VQDOTInfoPairs>;
-  defm : VPatTernaryV_VV_VX_AABX<"int_riscv_vqdotsu", "PseudoVQDOTSU", VQDOTInfoPairs>;
-  defm : VPatTernaryV_VX_AABX<"int_riscv_vqdotus", "PseudoVQDOTUS", VQDOTInfoPairs>;
-}
+defm : VPatTernaryV_VV_VX_AABX<"int_riscv_vqdot", "PseudoVQDOT", VQDOTInfoPairs, [HasStdExtZvqdotq]>;
+defm : VPatTernaryV_VV_VX_AABX<"int_riscv_vqdotu", "PseudoVQDOTU", VQDOTInfoPairs, [HasStdExtZvqdotq]>;
+defm : VPatTernaryV_VV_VX_AABX<"int_riscv_vqdotsu", "PseudoVQDOTSU", VQDOTInfoPairs, [HasStdExtZvqdotq]>;
+defm : VPatTernaryV_VX_AABX<"int_riscv_vqdotus", "PseudoVQDOTUS", VQDOTInfoPairs, [HasStdExtZvqdotq]>;


### PR DESCRIPTION
The _VL patterns only had GetTypePredicate. The intrinsic predicates only had Zvqdot. This patch updates them both to use Zvqdot and GetTypePredicate.

NFC because illegal types and opcodes shouldn't reach isel.