### PR TITLE
[openmp] Build doxygen in bootstrapping builds

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -258,6 +258,11 @@ function(runtime_default_target)
     # The target libomp-mod is a dependee of check-flang needed to run its
     # OpenMP tests
     list(APPEND extra_targets "libomp-mod")
+
+    # When building `ninja doxygen`, also build openmp's doxygen, just like
+    # `ninja check` runs the runtimes' checks.
+    # TODO: Generalize for all runtimes, but currently openmp is the only
+    #       runtime that has a doxygen target.
     if (LLVM_ENABLE_DOXYGEN)
       list(APPEND extra_targets "doxygen-openmp")
       if (TARGET doxygen)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -258,6 +258,12 @@ function(runtime_default_target)
     # The target libomp-mod is a dependee of check-flang needed to run its
     # OpenMP tests
     list(APPEND extra_targets "libomp-mod")
+    if (LLVM_ENABLE_DOXYGEN)
+      list(APPEND extra_targets "doxygen-openmp")
+      if (TARGET doxygen)
+        add_dependencies(doxygen doxygen-openmp)
+      endif ()
+    endif ()
   endif ()
 
   if(LLVM_INCLUDE_TESTS)
@@ -278,6 +284,7 @@ function(runtime_default_target)
                                       -DLLVM_ENABLE_PROJECTS_USED=${LLVM_ENABLE_PROJECTS_USED}
                                       -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=${LLVM_ENABLE_PER_TARGET_RUNTIME_DIR}
                                       -DLLVM_BUILD_TOOLS=${LLVM_BUILD_TOOLS}
+                                      -DLLVM_ENABLE_DOXYGEN=${LLVM_ENABLE_DOXYGEN}
                                       -DCMAKE_C_COMPILER_WORKS=ON
                                       -DCMAKE_CXX_COMPILER_WORKS=ON
                                       -DCMAKE_Fortran_COMPILER_WORKS=ON

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -259,8 +259,8 @@ function(runtime_default_target)
     # OpenMP tests
     list(APPEND extra_targets "libomp-mod")
 
-    # When building `ninja doxygen`, also build openmp's doxygen, just like
-    # `ninja check` runs the runtimes' checks.
+    # Let the "doxygen" build target also build openmp's doxygen, just like
+    # "check" and "install" also apply to the runtimes builds.
     # TODO: Generalize for all runtimes, but currently openmp is the only
     #       runtime that has a doxygen target.
     if (LLVM_ENABLE_DOXYGEN)


### PR DESCRIPTION
When `LLVM_ENABLE_DOXYGEN=ON`, forward the `doxygen-openmp` build target from the nested (default target) runtimes build. When `LLVM_BUILD_DOCS=ON`, also trigger `doxygen-build` with `ninja doxygen`. `LLVM_INCLUDE_DOCS=ON` is required in the runtimes build, which is the [default](https://github.com/llvm/llvm-project/blob/e2427281c61f2cb60d09e717c56c0db7cdf4b423/runtimes/CMakeLists.txt#L240).

This is required to update the OpenMP doxygen documentation at https://openmp.llvm.org/doxygen by the publish-doxygen-docs buidbot, discussed here: https://github.com/llvm/llvm-zorg/pull/716#pullrequestreview-3713032311