### PR TITLE
[DTLTO][Windows] Expand short 8.3 form paths in ThinLTO module IDs

### DIFF
--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -2,6 +2,8 @@
 
 # Check that any short 8.3 form paths (containing '~' characters) in ThinLTO
 # Module IDs are expanded prior to being passed to the distributor.
+#
+# This test is Windows-specific, as enforced by `tempshortpaths`.
 
 RUN: rm -rf %t && split-file %s %t && cd %t
 

--- a/cross-project-tests/dtlto/path.test
+++ b/cross-project-tests/dtlto/path.test
@@ -1,0 +1,90 @@
+# REQUIRES: ld.lld,llvm-ar,tempshortpaths
+
+# Check that any short 8.3 form paths (containing '~' characters) in ThinLTO
+# Module IDs are expanded prior to being passed to the distributor.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+# Create an archive and a thin archive to confirm member paths are expanded.
+RUN: %clang --target=x86_64-linux-gnu -c foo.c moo.c start.c -flto=thin -O2
+RUN: prospero-llvm-ar rcs foo.a foo.o
+RUN: prospero-llvm-ar --thin rcs moo.a moo.o
+
+# Build with DTLTO.
+RUN: %python in-83-dir.py \
+RUN:   %clang --target=x86_64-linux-gnu -flto=thin -fuse-ld=lld -nostdlib \
+RUN:     foo.a moo.a start.o -Wl,--save-temps \
+RUN:     -fthinlto-distributor=%python \
+RUN:     -Xthinlto-distributor=%llvm_src_root/utils/dtlto/local.py
+
+# Check that all short 8.3 form paths have been expanded.
+RUN: FileCheck --input-file a.*.dist-file.json %s --check-prefix=TILDE
+TILDE-NOT: ~
+
+# It is important that cross-module inlining occurs for this test to show that
+# Clang can successfully load the bitcode file dependencies recorded in the
+# summary indices. Explicitly check that the expected importing has occurred.
+RUN: llvm-dis *.1.*.thinlto.bc -o - | \
+RUN:   FileCheck %s --check-prefixes=FOO,MOO,START
+RUN: llvm-dis *.2.*.thinlto.bc -o - | \
+RUN:   FileCheck %s --check-prefixes=FOO,MOO,START
+RUN: llvm-dis *.3.*.thinlto.bc -o - | \
+RUN:   FileCheck %s --check-prefixes=FOO,MOO,START
+FOO-DAG:   foo.o
+MOO-DAG:   moo.o
+START-DAG: start.o
+
+#--- foo.c
+extern int moo(int), _start(int);
+__attribute__((retain)) int foo(int x) { return x + moo(x) + _start(x); }
+
+#--- moo.c
+extern int foo(int), _start(int);
+__attribute__((retain)) int moo(int x) { return x + foo(x) + _start(x); }
+
+#--- start.c
+extern int foo(int), moo(int);
+__attribute__((retain)) int _start(int x) { return x + foo(x) + moo(x); }
+
+#--- in-83-dir.py
+import os, shutil, sys, uuid, subprocess
+from pathlib import Path
+import ctypes
+from ctypes import wintypes
+
+
+def get_short_path(p):
+    g = ctypes.windll.kernel32.GetShortPathNameW
+    g.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+    g.restype = wintypes.DWORD
+    n = g(os.path.abspath(p), None, 0)  # First call gets required buffer size.
+    b = ctypes.create_unicode_buffer(n)
+    if g(os.path.abspath(p), b, n):  # Second call fills buffer.
+        return b.value
+    raise ctypes.WinError()
+
+
+temp = Path(os.environ["TEMP"])
+assert temp.is_dir()
+
+# Copy the CWD to a unique directory inside TEMP and ensure that one of the path
+# components is long enough to have a distinct short 8.3 form.
+# TEMP is likely to be on a drive that supports short 8.3 form paths.
+d = (temp / str(uuid.uuid4()) / "veryverylong").resolve()
+d.parent.mkdir(parents=True)
+try:
+    shutil.copytree(Path.cwd(), d)
+
+    # Replace the arguments of the command that name files with equivalents in
+    # our temp directory, prefixed with the short 8.3 form.
+    cmd = [
+        a if Path(a).is_absolute() or not (d / a).is_file() else get_short_path(d / a)
+        for a in sys.argv[1:]
+    ]
+
+    print(cmd)
+
+    sys.exit(subprocess.run(cmd).returncode)
+
+finally:
+    shutil.rmtree(d.parent)

--- a/cross-project-tests/lit.site.cfg.py.in
+++ b/cross-project-tests/lit.site.cfg.py.in
@@ -1,7 +1,8 @@
 @LIT_SITE_CFG_IN_HEADER@
 
-import sys
+import shutil, sys, os, uuid
 import lit.util
+from pathlib import Path
 
 config.targets_to_build = "@TARGETS_TO_BUILD@".split()
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
@@ -22,7 +23,19 @@ config.mlir_src_root = "@MLIR_SOURCE_DIR@"
 config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
 
 import lit.llvm
+
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@CROSS_PROJECT_TESTS_SOURCE_DIR@/lit.cfg.py")
+
+def are_short_names_enabled(path):
+    d = Path(path) / str(uuid.uuid4()) / "verylongdir"
+    d.mkdir(parents=True)
+    try:
+        return (d.parent / "verylo~1").exists()
+    finally:
+        shutil.rmtree(d.parent)
+
+if os.name == "nt" and are_short_names_enabled(config.environment.get("TEMP")):
+    config.available_features.add("tempshortpaths")

--- a/llvm/include/llvm/DTLTO/DTLTO.h
+++ b/llvm/include/llvm/DTLTO/DTLTO.h
@@ -24,7 +24,9 @@ namespace lto {
 // standalone file. Similarly, for FatLTO objects, the bitcode is stored in a
 // section of the containing ELF object file. To address this, the class ensures
 // that an individual bitcode file exists for each input (by writing it out if
-// necessary) and that the ModuleID is updated to point to it.
+// necessary) and that the ModuleID is updated to point to it. Module IDs are
+// also normalized on Windows to remove short 8.3 form paths that cannot be
+// loaded on remote machines.
 //
 // The class ensures that lto::InputFile objects are preserved until enough of
 // the LTO pipeline has executed to determine the required per-module
@@ -61,6 +63,9 @@ private:
 
   /// The output file to which this LTO invocation will contribute.
   StringRef LinkerOutputFile;
+
+  /// The normalized output directory, derived from LinkerOutputFile.
+  StringRef LinkerOutputDir;
 
   /// Controls preservation of any created temporary files.
   bool SaveTemps;


### PR DESCRIPTION
Windows supports short 8.3 form filenames (e.g. `compile_commands.json` -> `COMPIL~1.JSO`) for legacy reasons. See:
https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#short-vs-long-names.

Short 8.3 form paths are undesirable in distributed compilation scenarios because they are local mappings tied to a specific directory layout on a specific machine. As a result, they can break or defeat sandboxing and path-based isolation mechanisms used by distributed build systems.

We have observed such failures with DTLTO even in simple scenarios. For example, on Windows, running:

```
clang.exe hello.c -flto=thin -fuse-ld=lld -fthinlto-distributor=fastbuild.exe -###
```

on my development machine reveals a short 8.3 form path being passed to LLD (output paraphrased):

```
ld.lld -o a.out -plugin-opt=thinlto --thinlto-distributor=fastbuild.exe \
    --thinlto-remote-compiler=clang.exe C:\Users\DUNBOB~1\AppData\Local\Temp\hello-380d65.o
```

This behavior occurs because, on Windows, the system temporary directory is commonly derived from the `TMP`/`TEMP` environment variables. For historical compatibility reasons, these variables are often set to short 8.3 form paths, particularly on systems where user names exceed eight characters.

Whilst it's possible for users to work around these issues, in practice, especially in automated and CI environments, users often have limited control over their environment.

DTLTO generally tries to avoid embedding distribution-specific logic in the LLVM source tree, and this principle also applies to path normalization. However, on Windows, such short 8.3 form paths are undesirable for any distribution system. This normalization also cannot be delegated to distributors, as the ThinLTO module ID must be finalized early during LTO and cannot be modified later.

Given this, normalizing away short 8.3 paths on Windows is a pragmatic, targeted improvement, even though path normalization is not something a toolchain would typically perform in the general case.

SIE internal tracker: TOOLCHAIN-19185