### PR TITLE
[MIPS][ISel] Write irrelevant test output to /dev/null

### DIFF
--- a/clang/test/CodeGen/Mips/musttail.c
+++ b/clang/test/CodeGen/Mips/musttail.c
@@ -1,7 +1,7 @@
-// RUN: not %clang_cc1 %s -triple mipsel-unknown-linux-gnu -emit-llvm 2>&1 \
+// RUN: not %clang_cc1 %s -triple mipsel-unknown-linux-gnu -emit-llvm -o /dev/null 2>&1 \
 // RUN:   | FileCheck %s
 // RUN: not %clang_cc1 %s -triple mipsel-unknown-linux-gnu -target-feature +mips16 \
-// RUN:   -emit-llvm 2>&1 | FileCheck %s --check-prefix=CHECK-MIPS16
+// RUN:   -emit-llvm -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-MIPS16
 
 // CHECK: error: 'musttail' attribute for this call is impossible because calls outside the current linkage unit cannot be tail called on MIPS
 // CHECK-MIPS16: error: 'musttail' attribute for this call is impossible because the MIPS16 ABI does not support tail calls


### PR DESCRIPTION
This allows the test to run on read-only file systems.  Fixes bdfe03bbceeb063b5ff9df9bcb31a3db870fcf62.