### PR TITLE
[Clang] Add -Wtrivial-auto-var-init warning for unreachable variables

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -187,6 +187,9 @@ Improvements to Clang's diagnostics
     int* p(int *in [[clang::noescape]]) { return in; }
                                                  ^~
 
+- Added ``-Wtrivial-auto-var-init`` to detect when ``-ftrivial-auto-var-init``
+  cannot initialize a variable because it is in unreachable code.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Analysis/Analyses/ReachableCode.h
+++ b/clang/include/clang/Analysis/Analyses/ReachableCode.h
@@ -51,6 +51,7 @@ public:
   virtual void HandleUnreachable(UnreachableKind UK, SourceLocation L,
                                  SourceRange ConditionVal, SourceRange R1,
                                  SourceRange R2, bool HasFallThroughAttr) = 0;
+  virtual void HandleUnreachableBlock(const CFGBlock *B) {}
 };
 
 /// ScanReachableFromBlock - Mark all blocks reachable from Start.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -814,10 +814,11 @@ def warn_unreachable_association : Warning<
   "due to lvalue conversion of the controlling expression, association of type "
   "%0 will never be selected because it is %select{of array type|qualified}1">,
   InGroup<UnreachableCodeGenericAssoc>;
-def warn_trivial_auto_var_init_unreachable : Warning<
-  "variable %0 is uninitialized and cannot be initialized with "
-  "'-ftrivial-auto-var-init' because it is unreachable">,
-  InGroup<TrivialAutoVarInit>, DefaultIgnore;
+def warn_trivial_auto_var_init_unreachable
+    : Warning<"variable %0 is uninitialized and cannot be initialized with "
+              "'-ftrivial-auto-var-init' because it is unreachable">,
+      InGroup<TrivialAutoVarInit>,
+      DefaultIgnore;
 
 /// Built-in functions.
 def ext_implicit_lib_function_decl : ExtWarn<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -814,6 +814,10 @@ def warn_unreachable_association : Warning<
   "due to lvalue conversion of the controlling expression, association of type "
   "%0 will never be selected because it is %select{of array type|qualified}1">,
   InGroup<UnreachableCodeGenericAssoc>;
+def warn_trivial_auto_var_init_unreachable : Warning<
+  "variable %0 is uninitialized and cannot be initialized with "
+  "'-ftrivial-auto-var-init' because it is unreachable">,
+  InGroup<TrivialAutoVarInit>, DefaultIgnore;
 
 /// Built-in functions.
 def ext_implicit_lib_function_decl : ExtWarn<

--- a/clang/lib/Analysis/ReachableCode.cpp
+++ b/clang/lib/Analysis/ReachableCode.cpp
@@ -761,6 +761,8 @@ void FindUnreachableCode(AnalysisDeclContext &AC, Preprocessor &PP,
     if (reachable[block->getBlockID()])
       continue;
 
+    CB.HandleUnreachableBlock(block);
+
     DeadCodeScan DS(reachable, PP, AC.getASTContext());
     numReachable += DS.scanBackwards(block, CB);
 

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -180,8 +180,16 @@ public:
 };
 } // anonymous namespace
 
+/// CheckUnreachable - Check for unreachable code.
 static void CheckUnreachable(Sema &S, AnalysisDeclContext &AC,
                              bool CheckTrivialAutoVarInit) {
+  // As a heuristic prune all diagnostics not in the main file.  Currently
+  // the majority of warnings in headers are false positives.  These
+  // are largely caused by configuration state, e.g. preprocessor
+  // defined code, etc.
+  //
+  // Note that this is also a performance optimization.  Analyzing
+  // headers many times can be expensive.
   if (!S.getSourceManager().isInMainFile(AC.getDecl()->getBeginLoc()))
     return;
 

--- a/clang/test/Sema/trivial-auto-var-init-warn.c
+++ b/clang/test/Sema/trivial-auto-var-init-warn.c
@@ -1,0 +1,35 @@
+// RUN: %clang_cc1 -ftrivial-auto-var-init=zero -Wtrivial-auto-var-init -fsyntax-only -verify=zero %s
+// RUN: %clang_cc1 -ftrivial-auto-var-init=pattern -Wtrivial-auto-var-init -fsyntax-only -verify=pattern %s
+// RUN: %clang_cc1 -fsyntax-only -verify=noflag %s
+// RUN: %clang_cc1 -ftrivial-auto-var-init=zero -Wno-trivial-auto-var-init -fsyntax-only -verify=suppressed %s
+// RUN: %clang_cc1 -ftrivial-auto-var-init=zero -fsyntax-only -verify=default %s
+
+// noflag-no-diagnostics
+// suppressed-no-diagnostics
+// default-no-diagnostics
+
+void use(int *);
+
+void switch_precase(int c) {
+  switch (c) {
+    int x; // zero-warning{{variable 'x' is uninitialized and cannot be initialized with '-ftrivial-auto-var-init' because it is unreachable}}
+           // pattern-warning@-1{{variable 'x' is uninitialized and cannot be initialized with '-ftrivial-auto-var-init' because it is unreachable}}
+  case 0:
+    x = 1;
+    use(&x);
+    break;
+  }
+}
+
+void goto_bypass(void) {
+  goto skip;
+  int y; // zero-warning{{variable 'y' is uninitialized and cannot be initialized with '-ftrivial-auto-var-init' because it is unreachable}}
+         // pattern-warning@-1{{variable 'y' is uninitialized and cannot be initialized with '-ftrivial-auto-var-init' because it is unreachable}}
+skip:
+  use(&y);
+}
+
+void normal_var(void) {
+  int x;
+  use(&x);
+}

--- a/clang/test/SemaCXX/trivial-auto-var-init-warn.cpp
+++ b/clang/test/SemaCXX/trivial-auto-var-init-warn.cpp
@@ -1,0 +1,38 @@
+// RUN: %clang_cc1 -std=c++17 -ftrivial-auto-var-init=zero -Wtrivial-auto-var-init -fsyntax-only -verify %s
+
+void use(int *);
+void use(void *);
+
+struct Trivial {
+  int a, b;
+};
+
+void uninitialized_attr(int c) {
+  switch (c) {
+    [[clang::uninitialized]] int x;
+  case 0:
+    x = 1;
+    use(&x);
+    break;
+  }
+}
+
+void struct_precase(int c) {
+  switch (c) {
+    Trivial t; // expected-warning{{variable 't' is uninitialized and cannot be initialized with '-ftrivial-auto-var-init' because it is unreachable}}
+  case 0:
+    t.a = 1;
+    use(&t);
+    break;
+  }
+}
+
+void int_precase(int c) {
+  switch (c) {
+    int x; // expected-warning{{variable 'x' is uninitialized and cannot be initialized with '-ftrivial-auto-var-init' because it is unreachable}}
+  case 0:
+    x = 1;
+    use(&x);
+    break;
+  }
+}


### PR DESCRIPTION
Add an off-by-default warning `-Wtrivial-auto-var-init` which warns when `-ftrivial-auto-var-init` cannot initialize a variable because it is in unreachable code. This usually happens due to pre-case switch declarations and goto-bypassed declarations.

The spelling and functionality of this warning matches [GCC 12+](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wtrivial-auto-var-init).

Fixes: https://github.com/KSPP/linux/issues/125

CC @kees 