### PR TITLE
[clang] __builtin_os_log_format has incorrect PrintfFormat Attribute argument

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -210,6 +210,7 @@ Bug Fixes to AST Handling
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^
+- Fixed the arguments of the format attribute on ``__builtin_os_log_format``.  Previously, they were off by 1.
 
 Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -4970,8 +4970,7 @@ def OSLogFormatBufferSize : Builtin {
 
 def OSLogFormat : Builtin {
   let Spellings = ["__builtin_os_log_format"];
-  // FIXME: The printf attribute looks suspiciously like it should be argument #1.
-  let Attributes = [PrintfFormat<0>, NoThrow, CustomTypeChecking];
+  let Attributes = [PrintfFormat<1>, NoThrow, CustomTypeChecking];
   let Prototype = "void*(void*, char const*, ...)";
 }
 

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-format-attr-builtins.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-format-attr-builtins.cpp
@@ -1,7 +1,5 @@
-// RUN: %clang_cc1 -std=c++20 -Wno-all -Wformat \
-// RUN:            -verify=expected-format %s
-// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage -Wunsafe-buffer-usage-in-format-attr-call \
-// RUN:            -verify %s
+// RUN: %clang_cc1 -Wformat -verify=expected-format %s
+// RUN: %clang_cc1 -Wunsafe-buffer-usage -Wunsafe-buffer-usage-in-format-attr-call -verify=expected,expected-format %s
 
 namespace std {
   template<typename T>

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-format-attr-builtins.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-format-attr-builtins.cpp
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wformat \
+// RUN:            -verify=expected-format %s
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage -Wunsafe-buffer-usage-in-format-attr-call \
+// RUN:            -verify %s
+
+namespace std {
+  template<typename T>
+  struct basic_string {
+    T* p;
+    T *c_str();
+    T *data();
+    unsigned size_bytes();
+    unsigned size();
+  };
+
+  typedef basic_string<char> string;
+} // namespace std
+
+// PR#178320 corrects the format attribute arguments for
+// '__builtin_os_log_format' so that
+// '-Wunsafe-buffer-usage-in-format-attr-call' behaves correctly on
+// them.  For '-Wformat', the check for '__builtin_os_log_format' is
+// hand-craft without using the attribute. So they are still fine.
+
+void test_format_attr(char * Str, std::string StdStr) {
+  __builtin_os_log_format(nullptr, "hello", Str); // expected-format-warning{{data argument not used by format string}}
+  __builtin_os_log_format(nullptr, "hello %s", StdStr.c_str());
+  __builtin_os_log_format(nullptr, "hello %s", Str);  // expected-warning{{formatting function '__builtin_os_log_format' is unsafe}} \
+			         expected-note{{string argument is not guaranteed to be null-terminated}} 
+
+  __builtin_os_log_format(nullptr, "hello %"); // expected-format-warning{{incomplete format specifier}}
+  __builtin_os_log_format(nullptr, "hello %d", .42); // expected-format-warning{{format specifies type 'int' but the argument has type 'double'}} 
+}


### PR DESCRIPTION
The format string is the 2nd argument of __builtin_os_log_format, thus has index 1 instead of 0 in 0-based indexing.
The incorrect format attribute argument causes false positive -Wunsafe-buffer-usage-in-format-attr-call warnings.

rdar://169043228