### PR TITLE
[clang] Check that first modular_format argument is an identifier

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7035,6 +7035,11 @@ ModularFormatAttr *Sema::mergeModularFormatAttr(
 
 static void handleModularFormat(Sema &S, Decl *D, const ParsedAttr &AL) {
   bool Valid = true;
+  if (!AL.isArgIdent(0)) {
+    S.Diag(AL.getLoc(), diag::err_attribute_argument_n_type)
+        << AL << 1 << AANT_ArgumentIdentifier;
+    Valid = false;
+  }
   StringRef ImplName;
   if (!S.checkStringLiteralArgumentAttr(AL, 1, ImplName))
     Valid = false;

--- a/clang/test/Sema/attr-modular-format.c
+++ b/clang/test/Sema/attr-modular-format.c
@@ -3,6 +3,8 @@
 int printf(const char *fmt, ...)  __attribute__((modular_format(__modular_printf, "__printf", "float")));  // no-error
 int myprintf(const char *fmt, ...)  __attribute__((modular_format(__modular_printf, "__printf", "float")));  // expected-error {{'modular_format' attribute requires 'format' attribute}}
 
+int string_impl_fn(const char *fmt, ...)  __attribute__((modular_format("__modular_printf", "__printf", "float"), format(printf, 1, 2)));  // expected-error {{'modular_format' attribute requires parameter 1 to be an identifier}}
+
 int lprintf(const char *fmt, ...) __attribute__((modular_format(__modular_printf, L"__printf", L"float"), format(printf, 1, 2)));
 // expected-warning@-1 2{{encoding prefix 'L' on an unevaluated string literal has no effect}}
 


### PR DESCRIPTION
This fixes an oversight discovered in #147431.