### PR TITLE
[RISCV] Add OPC_C0/C1/C2 named values to tablegen. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrFormatsC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormatsC.td
@@ -10,6 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+class RISCVCOpcode<string name, bits<2> val> {
+  string Name = name;
+  bits<2> Value = val;
+}
+
+def OPC_C0 : RISCVCOpcode<"C0", 0b00>;
+def OPC_C1 : RISCVCOpcode<"C1", 0b01>;
+def OPC_C2 : RISCVCOpcode<"C2", 0b10>;
+
 class RVInst16<dag outs, dag ins, string opcodestr, string argstr,
                list<dag> pattern, InstFormat format>
     : RVInstCommon<outs, ins, opcodestr, argstr, pattern, format> {
@@ -17,7 +26,7 @@ class RVInst16<dag outs, dag ins, string opcodestr, string argstr,
   let Size = 2;
 }
 
-class RVInst16CR<bits<4> funct4, bits<2> opcode, dag outs, dag ins,
+class RVInst16CR<bits<4> funct4, RISCVCOpcode opcode, dag outs, dag ins,
                  string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCR> {
   bits<5> rs1;
@@ -26,14 +35,14 @@ class RVInst16CR<bits<4> funct4, bits<2> opcode, dag outs, dag ins,
   let Inst{15-12} = funct4;
   let Inst{11-7} = rs1;
   let Inst{6-2} = rs2;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
 // The immediate value encoding differs for each instruction, so each subclass
 // is responsible for setting the appropriate bits in the Inst field.
 // The bits Inst{12} and Inst{6-2} may need to be set differently for some
 // instructions.
-class RVInst16CI<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+class RVInst16CI<bits<3> funct3, RISCVCOpcode opcode, dag outs, dag ins,
                  string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCI> {
   bits<10> imm;
@@ -43,13 +52,13 @@ class RVInst16CI<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
   let Inst{12} = imm{5};
   let Inst{11-7} = rd;
   let Inst{6-2} = imm{4-0};
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
 // The immediate value encoding differs for each instruction, so each subclass
 // is responsible for setting the appropriate bits in the Inst field.
 // The bits Inst{12-7} may need to be set differently for some instructions.
-class RVInst16CSS<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+class RVInst16CSS<bits<3> funct3, RISCVCOpcode opcode, dag outs, dag ins,
                   string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCSS> {
   bits<10> imm;
@@ -58,10 +67,10 @@ class RVInst16CSS<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
   let Inst{15-13} = funct3;
   let Inst{12-7} = imm{5-0};
   let Inst{6-2} = rs2;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
-class RVInst16CIW<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+class RVInst16CIW<bits<3> funct3, RISCVCOpcode opcode, dag outs, dag ins,
                   string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCIW> {
   bits<10> imm;
@@ -69,13 +78,13 @@ class RVInst16CIW<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
 
   let Inst{15-13} = funct3;
   let Inst{4-2} = rd;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
 // The immediate value encoding differs for each instruction, so each subclass
 // is responsible for setting the appropriate bits in the Inst field.
 // The bits Inst{12-10} and Inst{6-5} must be set for each instruction.
-class RVInst16CL<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+class RVInst16CL<bits<3> funct3, RISCVCOpcode opcode, dag outs, dag ins,
                  string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCL> {
   bits<3> rd;
@@ -84,13 +93,13 @@ class RVInst16CL<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
   let Inst{15-13} = funct3;
   let Inst{9-7} = rs1;
   let Inst{4-2} = rd;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
 // The immediate value encoding differs for each instruction, so each subclass
 // is responsible for setting the appropriate bits in the Inst field.
 // The bits Inst{12-10} and Inst{6-5} must be set for each instruction.
-class RVInst16CS<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+class RVInst16CS<bits<3> funct3, RISCVCOpcode opcode, dag outs, dag ins,
                  string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCS> {
   bits<3> rs2;
@@ -99,10 +108,10 @@ class RVInst16CS<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
   let Inst{15-13} = funct3;
   let Inst{9-7} = rs1;
   let Inst{4-2} = rs2;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
-class RVInst16CA<bits<6> funct6, bits<2> funct2, bits<2> opcode, dag outs,
+class RVInst16CA<bits<6> funct6, bits<2> funct2, RISCVCOpcode opcode, dag outs,
                  dag ins, string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCA> {
   bits<3> rs2;
@@ -112,10 +121,10 @@ class RVInst16CA<bits<6> funct6, bits<2> funct2, bits<2> opcode, dag outs,
   let Inst{9-7} = rs1;
   let Inst{6-5} = funct2;
   let Inst{4-2} = rs2;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
-class RVInst16CB<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+class RVInst16CB<bits<3> funct3, RISCVCOpcode opcode, dag outs, dag ins,
                  string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCB> {
   bits<9> imm;
@@ -123,10 +132,10 @@ class RVInst16CB<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
 
   let Inst{15-13} = funct3;
   let Inst{9-7} = rs1;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
-class RVInst16CJ<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+class RVInst16CJ<bits<3> funct3, RISCVCOpcode opcode, dag outs, dag ins,
                  string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCJ> {
   bits<11> offset;
@@ -140,10 +149,10 @@ class RVInst16CJ<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
   let Inst{6} = offset{6};
   let Inst{5-3} = offset{2-0};
   let Inst{2} = offset{4};
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
-class RVInst16CU<bits<6> funct6, bits<5> funct5, bits<2> opcode, dag outs,
+class RVInst16CU<bits<6> funct6, bits<5> funct5, RISCVCOpcode opcode, dag outs,
                  dag ins, string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCU>{
   bits<3> rd;
@@ -151,13 +160,13 @@ class RVInst16CU<bits<6> funct6, bits<5> funct5, bits<2> opcode, dag outs,
   let Inst{15-10} = funct6;
   let Inst{9-7} = rd;
   let Inst{6-2} = funct5;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
 // The immediate value encoding differs for each instruction, so each subclass
 // is responsible for setting the appropriate bits in the Inst field.
 // The bits Inst{6-5} must be set for each instruction.
-class RVInst16CLB<bits<6> funct6, bits<2> opcode, dag outs, dag ins,
+class RVInst16CLB<bits<6> funct6, RISCVCOpcode opcode, dag outs, dag ins,
                   string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCLB> {
   bits<3> rd;
@@ -166,13 +175,13 @@ class RVInst16CLB<bits<6> funct6, bits<2> opcode, dag outs, dag ins,
   let Inst{15-10} = funct6;
   let Inst{9-7} = rs1;
   let Inst{4-2} = rd;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
 // The immediate value encoding differs for each instruction, so each subclass
 // is responsible for setting the appropriate bits in the Inst field.
 // The bits Inst{5} must be set for each instruction.
-class RVInst16CLH<bits<6> funct6, bit funct1, bits<2> opcode, dag outs,
+class RVInst16CLH<bits<6> funct6, bit funct1, RISCVCOpcode opcode, dag outs,
                   dag ins, string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCLH> {
   bits<3> rd;
@@ -182,13 +191,13 @@ class RVInst16CLH<bits<6> funct6, bit funct1, bits<2> opcode, dag outs,
   let Inst{9-7} = rs1;
   let Inst{6} = funct1;
   let Inst{4-2} = rd;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
 // The immediate value encoding differs for each instruction, so each subclass
 // is responsible for setting the appropriate bits in the Inst field.
 // The bits Inst{6-5} must be set for each instruction.
-class RVInst16CSB<bits<6> funct6, bits<2> opcode, dag outs, dag ins,
+class RVInst16CSB<bits<6> funct6, RISCVCOpcode opcode, dag outs, dag ins,
                   string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCSB> {
   bits<3> rs2;
@@ -197,13 +206,13 @@ class RVInst16CSB<bits<6> funct6, bits<2> opcode, dag outs, dag ins,
   let Inst{15-10} = funct6;
   let Inst{9-7} = rs1;
   let Inst{4-2} = rs2;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
 // The immediate value encoding differs for each instruction, so each subclass
 // is responsible for setting the appropriate bits in the Inst field.
 // The bits Inst{5} must be set for each instruction.
-class RVInst16CSH<bits<6> funct6, bit funct1, bits<2> opcode, dag outs,
+class RVInst16CSH<bits<6> funct6, bit funct1, RISCVCOpcode opcode, dag outs,
                   dag ins, string opcodestr, string argstr>
     : RVInst16<outs, ins, opcodestr, argstr, [], InstFormatCSH> {
   bits<3> rs2;
@@ -213,7 +222,7 @@ class RVInst16CSH<bits<6> funct6, bit funct1, bits<2> opcode, dag outs,
   let Inst{9-7} = rs1;
   let Inst{6} = funct1;
   let Inst{4-2} = rs2;
-  let Inst{1-0} = opcode;
+  let Inst{1-0} = opcode.Value;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -202,7 +202,7 @@ def uimm2_opcode : RISCVUImmOp<2> {
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CStackLoad<bits<3> funct3, string OpcodeStr,
                  DAGOperand cls, DAGOperand opnd>
-    : RVInst16CI<funct3, 0b10, (outs cls:$rd), (ins SPMem:$rs1, opnd:$imm),
+    : RVInst16CI<funct3, OPC_C2, (outs cls:$rd), (ins SPMem:$rs1, opnd:$imm),
                  OpcodeStr, "$rd, ${imm}(${rs1})"> {
   bits<0> rs1;
 }
@@ -210,7 +210,7 @@ class CStackLoad<bits<3> funct3, string OpcodeStr,
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CStackStore<bits<3> funct3, string OpcodeStr,
                   DAGOperand cls, DAGOperand opnd>
-    : RVInst16CSS<funct3, 0b10, (outs), (ins cls:$rs2, SPMem:$rs1, opnd:$imm),
+    : RVInst16CSS<funct3, OPC_C2, (outs), (ins cls:$rs2, SPMem:$rs1, opnd:$imm),
                   OpcodeStr, "$rs2, ${imm}(${rs1})"> {
   bits<0> rs1;
 }
@@ -218,18 +218,18 @@ class CStackStore<bits<3> funct3, string OpcodeStr,
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CLoad_ri<bits<3> funct3, string OpcodeStr,
                DAGOperand cls, DAGOperand opnd>
-    : RVInst16CL<funct3, 0b00, (outs cls:$rd), (ins GPRCMem:$rs1, opnd:$imm),
+    : RVInst16CL<funct3, OPC_C0, (outs cls:$rd), (ins GPRCMem:$rs1, opnd:$imm),
                  OpcodeStr, "$rd, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CStore_rri<bits<3> funct3, string OpcodeStr,
                  DAGOperand cls, DAGOperand opnd>
-    : RVInst16CS<funct3, 0b00, (outs), (ins cls:$rs2,GPRCMem:$rs1, opnd:$imm),
+    : RVInst16CS<funct3, OPC_C0, (outs), (ins cls:$rs2,GPRCMem:$rs1, opnd:$imm),
                  OpcodeStr, "$rs2, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class Bcz<bits<3> funct3, string OpcodeStr>
-    : RVInst16CB<funct3, 0b01, (outs), (ins GPRC:$rs1, bare_simm9_lsb0:$imm),
+    : RVInst16CB<funct3, OPC_C1, (outs), (ins GPRC:$rs1, bare_simm9_lsb0:$imm),
                  OpcodeStr, "$rs1, $imm"> {
   let isBranch = 1;
   let isTerminator = 1;
@@ -242,7 +242,7 @@ class Bcz<bits<3> funct3, string OpcodeStr>
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class Shift_right<bits<2> funct2, string OpcodeStr>
-    : RVInst16CB<0b100, 0b01, (outs GPRC:$rd),
+    : RVInst16CB<0b100, OPC_C1, (outs GPRC:$rd),
                  (ins GPRC:$rs1, uimmlog2xlen:$imm),
                  OpcodeStr, "$rs1, $imm"> {
   let Constraints = "$rs1 = $rd";
@@ -253,7 +253,7 @@ class Shift_right<bits<2> funct2, string OpcodeStr>
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class CA_ALU<bits<6> funct6, bits<2> funct2, string OpcodeStr>
-    : RVInst16CA<funct6, funct2, 0b01, (outs GPRC:$rd_wb),
+    : RVInst16CA<funct6, funct2, OPC_C1, (outs GPRC:$rd_wb),
                  (ins GPRC:$rd, GPRC:$rs2), OpcodeStr, "$rd, $rs2"> {
   bits<3> rd;
   let Constraints = "$rd = $rd_wb";
@@ -267,7 +267,7 @@ class CA_ALU<bits<6> funct6, bits<2> funct2, string OpcodeStr>
 let Predicates = [HasStdExtZca] in {
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Uses = [X2] in
-def C_ADDI4SPN : RVInst16CIW<0b000, 0b00, (outs GPRC:$rd),
+def C_ADDI4SPN : RVInst16CIW<0b000, OPC_C0, (outs GPRC:$rd),
                              (ins SP:$rs1, uimm10_lsb00nonzero:$imm),
                              "c.addi4spn", "$rd, $rs1, $imm">,
                              Sched<[WriteIALU, ReadIALU]> {
@@ -329,14 +329,14 @@ def C_SD : CStore_rri<0b111, "c.sd", GPRC, uimm8_lsb000>,
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-def C_NOP : RVInst16CI<0b000, 0b01, (outs), (ins), "c.nop", "">,
+def C_NOP : RVInst16CI<0b000, OPC_C1, (outs), (ins), "c.nop", "">,
             Sched<[WriteNop]> {
   let rd = 0;
   let imm = 0;
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-def C_ADDI : RVInst16CI<0b000, 0b01, (outs GPRNoX0:$rd_wb),
+def C_ADDI : RVInst16CI<0b000, OPC_C1, (outs GPRNoX0:$rd_wb),
                         (ins GPRNoX0:$rd, simm6:$imm),
                         "c.addi", "$rd, $imm">,
              Sched<[WriteIALU, ReadIALU]> {
@@ -354,12 +354,12 @@ def PseudoC_ADDI_NOP : Pseudo<(outs GPRX0:$rd), (ins GPRX0:$rs1, simm6:$imm),
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCall = 1,
     DecoderNamespace = "RV32Only", Defs = [X1],
     Predicates = [HasStdExtZca, IsRV32]  in
-def C_JAL : RVInst16CJ<0b001, 0b01, (outs), (ins bare_simm12_lsb0:$offset),
+def C_JAL : RVInst16CJ<0b001, OPC_C1, (outs), (ins bare_simm12_lsb0:$offset),
                        "c.jal", "$offset">, Sched<[WriteJal]>;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0,
     Predicates = [HasStdExtZca, IsRV64] in
-def C_ADDIW : RVInst16CI<0b001, 0b01, (outs GPRNoX0:$rd_wb),
+def C_ADDIW : RVInst16CI<0b001, OPC_C1, (outs GPRNoX0:$rd_wb),
                          (ins GPRNoX0:$rd, simm6:$imm),
                          "c.addiw", "$rd, $imm">,
               Sched<[WriteIALU32, ReadIALU32]> {
@@ -367,12 +367,12 @@ def C_ADDIW : RVInst16CI<0b001, 0b01, (outs GPRNoX0:$rd_wb),
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-def C_LI : RVInst16CI<0b010, 0b01, (outs GPR:$rd), (ins simm6:$imm),
+def C_LI : RVInst16CI<0b010, OPC_C1, (outs GPR:$rd), (ins simm6:$imm),
                       "c.li", "$rd, $imm">,
            Sched<[WriteIALU]>;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-def C_ADDI16SP : RVInst16CI<0b011, 0b01, (outs SP:$rd_wb),
+def C_ADDI16SP : RVInst16CI<0b011, OPC_C1, (outs SP:$rd_wb),
                             (ins SP:$rd, simm10_lsb0000nonzero:$imm),
                             "c.addi16sp", "$rd, $imm">,
                  Sched<[WriteIALU, ReadIALU]> {
@@ -386,7 +386,7 @@ def C_ADDI16SP : RVInst16CI<0b011, 0b01, (outs SP:$rd_wb),
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-def C_LUI : RVInst16CI<0b011, 0b01, (outs GPRNoX2:$rd),
+def C_LUI : RVInst16CI<0b011, OPC_C1, (outs GPRNoX2:$rd),
                        (ins c_lui_imm:$imm),
                        "c.lui", "$rd, $imm">,
             Sched<[WriteIALU]>;
@@ -397,7 +397,7 @@ def C_SRAI : Shift_right<0b01, "c.srai">,
              Sched<[WriteShiftImm, ReadShiftImm]>;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-def C_ANDI : RVInst16CB<0b100, 0b01, (outs GPRC:$rd), (ins GPRC:$rs1, simm6:$imm),
+def C_ANDI : RVInst16CB<0b100, OPC_C1, (outs GPRC:$rd), (ins GPRC:$rs1, simm6:$imm),
                         "c.andi", "$rs1, $imm">,
              Sched<[WriteIALU, ReadIALU]> {
   let Constraints = "$rs1 = $rd";
@@ -423,7 +423,7 @@ def C_ADDW : CA_ALU<0b100111, 0b01, "c.addw">,
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-def C_J : RVInst16CJ<0b101, 0b01, (outs), (ins bare_simm12_lsb0:$offset),
+def C_J : RVInst16CJ<0b101, OPC_C1, (outs), (ins bare_simm12_lsb0:$offset),
                      "c.j", "$offset">, Sched<[WriteJmp]> {
   let isBranch = 1;
   let isTerminator=1;
@@ -434,7 +434,7 @@ def C_BEQZ : Bcz<0b110, "c.beqz">, Sched<[WriteJmp, ReadJmp]>;
 def C_BNEZ : Bcz<0b111, "c.bnez">, Sched<[WriteJmp, ReadJmp]>;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-def C_SLLI : RVInst16CI<0b000, 0b10, (outs GPR:$rd_wb),
+def C_SLLI : RVInst16CI<0b000, OPC_C2, (outs GPR:$rd_wb),
                         (ins GPR:$rd, uimmlog2xlen:$imm),
                         "c.slli", "$rd, $imm">,
              Sched<[WriteShiftImm, ReadShiftImm]> {
@@ -459,7 +459,7 @@ def C_LDSP : CStackLoad<0b011, "c.ldsp", GPRNoX0, uimm9_lsb000>,
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-def C_JR : RVInst16CR<0b1000, 0b10, (outs), (ins GPRNoX0:$rs1),
+def C_JR : RVInst16CR<0b1000, OPC_C2, (outs), (ins GPRNoX0:$rs1),
                       "c.jr", "$rs1">, Sched<[WriteJalr, ReadJalr]> {
   let isBarrier = 1;
   let isTerminator = 1;
@@ -468,20 +468,20 @@ def C_JR : RVInst16CR<0b1000, 0b10, (outs), (ins GPRNoX0:$rs1),
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isMoveReg = 1,
     isAsCheapAsAMove = 1 in
-def C_MV : RVInst16CR<0b1000, 0b10, (outs GPR:$rs1), (ins GPRNoX0:$rs2),
+def C_MV : RVInst16CR<0b1000, OPC_C2, (outs GPR:$rs1), (ins GPRNoX0:$rs2),
                       "c.mv", "$rs1, $rs2">,
            Sched<[WriteIALU, ReadIALU]>;
 
 let rs1 = 0, rs2 = 0, hasSideEffects = 1, mayLoad = 0, mayStore = 0 in
-def C_EBREAK : RVInst16CR<0b1001, 0b10, (outs), (ins), "c.ebreak", "">, Sched<[]>;
+def C_EBREAK : RVInst16CR<0b1001, OPC_C2, (outs), (ins), "c.ebreak", "">, Sched<[]>;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0,
     isCall=1, Defs=[X1], rs2 = 0 in
-def C_JALR : RVInst16CR<0b1001, 0b10, (outs), (ins GPRNoX0:$rs1),
+def C_JALR : RVInst16CR<0b1001, OPC_C2, (outs), (ins GPRNoX0:$rs1),
                         "c.jalr", "$rs1">, Sched<[WriteJalr, ReadJalr]>;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-def C_ADD : RVInst16CR<0b1001, 0b10, (outs GPR:$rd),
+def C_ADD : RVInst16CR<0b1001, OPC_C2, (outs GPR:$rd),
                        (ins GPR:$rs1, GPRNoX0:$rs2),
                        "c.add", "$rs1, $rs2">,
             Sched<[WriteIALU, ReadIALU, ReadIALU]> {
@@ -577,7 +577,7 @@ let Predicates = [HasStdExtCOrZcd, HasStdExtD] in {
 let Predicates = [HasStdExtZca], hasSideEffects = 0, mayLoad = 0,
     mayStore = 0 in {
 
-def C_NOP_HINT : RVInst16CI<0b000, 0b01, (outs), (ins simm6nonzero:$imm),
+def C_NOP_HINT : RVInst16CI<0b000, OPC_C1, (outs), (ins simm6nonzero:$imm),
                             "c.nop", "$imm">, Sched<[WriteNop]> {
   let rd = 0;
 }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqccmp.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqccmp.td
@@ -79,12 +79,12 @@ let DecoderNamespace = "Xqccmp", Predicates = [HasVendorXqccmp] in {
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
 let Defs = [X10, X11] in
-def QC_CM_MVA01S : RVInst16CA<0b101011, 0b11, 0b10, (outs),
+def QC_CM_MVA01S : RVInst16CA<0b101011, 0b11, OPC_C2, (outs),
                               (ins SR07:$rs1, SR07:$rs2), "qc.cm.mva01s", "$rs1, $rs2">,
                    Sched<[WriteIALU, WriteIALU, ReadIALU, ReadIALU]>;
 
 let Uses = [X10, X11] in
-def QC_CM_MVSA01 : RVInst16CA<0b101011, 0b01, 0b10, (outs SR07:$rs1, SR07:$rs2),
+def QC_CM_MVSA01 : RVInst16CA<0b101011, 0b01, OPC_C2, (outs SR07:$rs1, SR07:$rs2),
                               (ins), "qc.cm.mvsa01", "$rs1, $rs2">,
                    Sched<[WriteIALU, WriteIALU, ReadIALU, ReadIALU]>;
 } // hasSideEffects = 0, mayLoad = 0, mayStore = 0

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -643,7 +643,7 @@ class QCIMVCCI<bits<3> funct3, string opcodestr, DAGOperand immType>
 }
 
 class QCI_RVInst16CB_BM<bits<2> funct2, string opcodestr>
-    : RVInst16CB<0b100, 0b01, (outs GPRC:$rd),
+    : RVInst16CB<0b100, OPC_C1, (outs GPRC:$rd),
                  (ins GPRC:$rs1, uimmlog2xlennonzero:$shamt),
                  opcodestr, "$rs1, $shamt"> {
   bits<5> shamt;
@@ -655,7 +655,7 @@ class QCI_RVInst16CB_BM<bits<2> funct2, string opcodestr>
 
 let hasSideEffects = 1, mayLoad = 0, mayStore = 0 in
 class QCIRVInst16CI_RS1<bits<5> funct5, string OpcodeStr>
-    : RVInst16CI<0b000, 0b10, (outs), (ins GPRNoX0:$rs1), OpcodeStr, "$rs1"> {
+    : RVInst16CI<0b000, OPC_C2, (outs), (ins GPRNoX0:$rs1), OpcodeStr, "$rs1"> {
   bits<5> rs1;
 
   let Inst{12} = 0b1;
@@ -700,7 +700,7 @@ class QCIBranchInst48_rii<bits<5> funct5, DAGOperand InTyImm16, string opcodestr
 
 let hasSideEffects = 1 in
 class QCIRVInst16CI_NONE<bits<5> funct5, string OpcodeStr>
-    : RVInst16CI<0b000, 0b10, (outs), (ins), OpcodeStr, ""> {
+    : RVInst16CI<0b000, OPC_C2, (outs), (ins), OpcodeStr, ""> {
   let Inst{12} = 0b1;
   let Inst{11-7} = funct5;
   let Inst{6-2} = 0b00100;
@@ -744,7 +744,7 @@ class QCISync_UIMM5<bits<4> imm11_8, string opcodestr>
 
 let mayLoad = 0, mayStore = 0, hasSideEffects = 1 in
 class QCIRVInst16CBSYNC<bits<3> imm5_func2, string OpcodeStr>
-    : RVInst16CB<0b100, 0b01, (outs), (ins uimm5slist:$slist), OpcodeStr, "$slist"> {
+    : RVInst16CB<0b100, OPC_C1, (outs), (ins uimm5slist:$slist), OpcodeStr, "$slist"> {
     bits<3> slist;
 
     let Inst{6-2} = 0;
@@ -984,7 +984,7 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
                     Sched<[WriteIALU, ReadIALU]>;
   def QC_C_BSETI  : QCI_RVInst16CB_BM<0b01, "qc.c.bseti">,
                     Sched<[WriteIALU, ReadIALU]>;
-  def QC_C_EXTU : RVInst16CI<0b000, 0b10, (outs GPRNoX0:$rd_wb),
+  def QC_C_EXTU : RVInst16CI<0b000, OPC_C2, (outs GPRNoX0:$rd_wb),
                              (ins GPRNoX0:$rd, uimm5ge6_plus1:$width),
                              "qc.c.extu", "$rd, $width">,
                   Sched<[WriteIALU, ReadIALU]> {
@@ -1000,7 +1000,7 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
 
 let Predicates = [HasVendorXqciac, IsRV32] in {
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
-  def QC_C_MULIADD : RVInst16CL<0b001, 0b10, (outs GPRC:$rd_wb),
+  def QC_C_MULIADD : RVInst16CL<0b001, OPC_C2, (outs GPRC:$rd_wb),
                                (ins GPRC:$rd, GPRC:$rs1, uimm5:$uimm),
                                "qc.c.muliadd", "$rd, $rs1, $uimm">,
                      Sched<[WriteIALU, ReadIALU, ReadIALU]> {
@@ -1083,7 +1083,7 @@ let Predicates = [HasVendorXqcicli, IsRV32] in {
 
 let Predicates = [HasVendorXqcicm, IsRV32] in {
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-  def QC_C_MVEQZ   : RVInst16CL<0b101, 0b10, (outs GPRC:$rd_wb),
+  def QC_C_MVEQZ   : RVInst16CL<0b101, OPC_C2, (outs GPRC:$rd_wb),
                               (ins GPRC:$rd, GPRC:$rs1),
                               "qc.c.mveqz", "$rd, $rs1">,
                      Sched<[WriteIALU, ReadIALU, ReadIALU]> {
@@ -1111,7 +1111,7 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 let Predicates = [HasVendorXqciint, IsRV32], hasSideEffects = 1 in {
 
 let mayLoad = 0, mayStore = 0 in {
-def QC_C_DIR : RVInst16CI<0b000, 0b10, (outs GPRNoX0:$rd), (ins),
+def QC_C_DIR : RVInst16CI<0b000, OPC_C2, (outs GPRNoX0:$rd), (ins),
                           "qc.c.dir", "$rd"> {
   bits<5> rd;
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXwch.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXwch.td
@@ -37,7 +37,7 @@ def uimm6_lsb0 : RISCVUImmLsbZeroOp<6, 1>;
 let Predicates = [HasVendorXwchc], DecoderNamespace = "Xwchc" in {
 
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
-def QK_C_LBU : RVInst16CL<0b001, 0b00, (outs GPRC:$rd),
+def QK_C_LBU : RVInst16CL<0b001, OPC_C0, (outs GPRC:$rd),
                           (ins GPRCMem:$rs1, uimm5:$imm),
                           "qk.c.lbu", "$rd, ${imm}(${rs1})">,
                Sched<[WriteLDB, ReadMemBase]> {
@@ -47,7 +47,7 @@ def QK_C_LBU : RVInst16CL<0b001, 0b00, (outs GPRC:$rd),
   let Inst{6-5} = imm{2-1};
 }
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
-def QK_C_SB : RVInst16CS<0b101, 0b00, (outs),
+def QK_C_SB : RVInst16CS<0b101, OPC_C0, (outs),
                          (ins GPRC:$rs2, GPRCMem:$rs1,
                               uimm5:$imm),
                          "qk.c.sb", "$rs2, ${imm}(${rs1})">,
@@ -59,7 +59,7 @@ def QK_C_SB : RVInst16CS<0b101, 0b00, (outs),
 }
 
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
-def QK_C_LHU : RVInst16CL<0b001, 0b10, (outs GPRC:$rd),
+def QK_C_LHU : RVInst16CL<0b001, OPC_C2, (outs GPRC:$rd),
                           (ins GPRCMem:$rs1, uimm6_lsb0:$imm),
                           "qk.c.lhu", "$rd, ${imm}(${rs1})">,
                Sched<[WriteLDH, ReadMemBase]> {
@@ -68,7 +68,7 @@ def QK_C_LHU : RVInst16CL<0b001, 0b10, (outs GPRC:$rd),
   let Inst{6-5} = imm{2-1};
 }
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
-def QK_C_SH : RVInst16CS<0b101, 0b10, (outs),
+def QK_C_SH : RVInst16CS<0b101, OPC_C2, (outs),
                          (ins GPRC:$rs2, GPRCMem:$rs1, uimm6_lsb0:$imm),
                          "qk.c.sh", "$rs2, ${imm}(${rs1})">,
               Sched<[WriteSTH, ReadStoreData, ReadMemBase]> {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZc.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZc.td
@@ -92,7 +92,7 @@ def negstackadj : RISCVOp<OtherVT> {
 
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CLoadB_ri<bits<6> funct6, string OpcodeStr>
-    : RVInst16CLB<funct6, 0b00, (outs GPRC:$rd),
+    : RVInst16CLB<funct6, OPC_C0, (outs GPRC:$rd),
                   (ins GPRCMem:$rs1, uimm2:$imm),
                   OpcodeStr, "$rd, ${imm}(${rs1})"> {
   bits<2> imm;
@@ -103,7 +103,7 @@ class CLoadB_ri<bits<6> funct6, string OpcodeStr>
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CLoadH_ri<bits<6> funct6, bit funct1, string OpcodeStr,
                 DAGOperand rty = GPRC>
-    : RVInst16CLH<funct6, funct1, 0b00, (outs rty:$rd),
+    : RVInst16CLH<funct6, funct1, OPC_C0, (outs rty:$rd),
                   (ins GPRCMem:$rs1, uimm2_lsb0:$imm),
                   OpcodeStr, "$rd, ${imm}(${rs1})"> {
   bits<2> imm;
@@ -113,7 +113,7 @@ class CLoadH_ri<bits<6> funct6, bit funct1, string OpcodeStr,
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CStoreB_rri<bits<6> funct6, string OpcodeStr>
-    : RVInst16CSB<funct6, 0b00, (outs),
+    : RVInst16CSB<funct6, OPC_C0, (outs),
                   (ins GPRC:$rs2, GPRCMem:$rs1, uimm2:$imm),
                   OpcodeStr, "$rs2, ${imm}(${rs1})"> {
   bits<2> imm;
@@ -124,7 +124,7 @@ class CStoreB_rri<bits<6> funct6, string OpcodeStr>
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CStoreH_rri<bits<6> funct6, bit funct1, string OpcodeStr,
                   DAGOperand rty = GPRC>
-    : RVInst16CSH<funct6, funct1, 0b00, (outs),
+    : RVInst16CSH<funct6, funct1, OPC_C0, (outs),
                   (ins rty:$rs2, GPRCMem:$rs1, uimm2_lsb0:$imm),
                   OpcodeStr, "$rs2, ${imm}(${rs1})"> {
   bits<2> imm;
@@ -134,7 +134,7 @@ class CStoreH_rri<bits<6> funct6, bit funct1, string OpcodeStr,
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVZcArith_r<bits<5> funct5, string OpcodeStr> :
-  RVInst16CU<0b100111, funct5, 0b01, (outs GPRC:$rd_wb), (ins GPRC:$rd),
+  RVInst16CU<0b100111, funct5, OPC_C1, (outs GPRC:$rd_wb), (ins GPRC:$rd),
              OpcodeStr, "$rd"> {
   let Constraints = "$rd = $rd_wb";
 }
@@ -207,12 +207,12 @@ def C_SH_INX : CStoreH_rri<0b100011, 0b0, "c.sh", GPRF16C>,
 let DecoderNamespace = "ZcOverlap", Predicates = [HasStdExtZcmp],
     hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
 let Defs = [X10, X11] in
-def CM_MVA01S : RVInst16CA<0b101011, 0b11, 0b10, (outs),
+def CM_MVA01S : RVInst16CA<0b101011, 0b11, OPC_C2, (outs),
                             (ins SR07:$rs1, SR07:$rs2), "cm.mva01s", "$rs1, $rs2">,
                 Sched<[WriteIALU, WriteIALU, ReadIALU, ReadIALU]>;
 
 let Uses = [X10, X11] in
-def CM_MVSA01 : RVInst16CA<0b101011, 0b01, 0b10, (outs SR07:$rs1, SR07:$rs2),
+def CM_MVSA01 : RVInst16CA<0b101011, 0b01, OPC_C2, (outs SR07:$rs1, SR07:$rs2),
                             (ins), "cm.mvsa01", "$rs1, $rs2">,
                 Sched<[WriteIALU, WriteIALU, ReadIALU, ReadIALU]>;
 } // DecoderNamespace = "ZcOverlap", Predicates = [HasStdExtZcmp]...
@@ -250,7 +250,7 @@ def CM_POP : RVInstZcCPPP<0b11010, "cm.pop">,
 
 let DecoderNamespace = "ZcOverlap", Predicates = [HasStdExtZcmt],
     hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
-def CM_JT : RVInst16CJ<0b101, 0b10, (outs), (ins uimm5:$index),
+def CM_JT : RVInst16CJ<0b101, OPC_C2, (outs), (ins uimm5:$index),
                        "cm.jt", "$index">{
   bits<5> index;
 
@@ -259,7 +259,7 @@ def CM_JT : RVInst16CJ<0b101, 0b10, (outs), (ins uimm5:$index),
 }
 
 let Defs = [X1] in
-def CM_JALT : RVInst16CJ<0b101, 0b10, (outs), (ins uimm8ge32:$index),
+def CM_JALT : RVInst16CJ<0b101, OPC_C2, (outs), (ins uimm8ge32:$index),
                          "cm.jalt", "$index">{
   bits<8> index;
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZcmop.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZcmop.td
@@ -13,7 +13,7 @@
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class CMOPInst<bits<3> imm3, string opcodestr>
-    : RVInst16CI<0b011, 0b01, (outs), (ins), opcodestr, ""> {
+    : RVInst16CI<0b011, OPC_C1, (outs), (ins), opcodestr, ""> {
   let Inst{6-2} = 0;
   let Inst{7} = 1;
   let Inst{10-8} = imm3;


### PR DESCRIPTION
This adds named opcodes for the compressed instructions like we have for the 32-bit instructions.