### PR TITLE
[mlir] Fix a crash in ensure-debug-info-scope-on-llvm-func.

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/Transforms/DIScopeForLLVMFuncOp.cpp
+++ b/mlir/lib/Dialect/LLVMIR/Transforms/DIScopeForLLVMFuncOp.cpp
@@ -120,11 +120,13 @@ static void setLexicalBlockFileAttr(Operation *op) {
     LLVM::DIScopeAttr scopeAttr;
     // We assemble the full inline stack so the parent of this loc must be a
     // function
-    auto funcOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-    if (auto funcOpLoc = llvm::dyn_cast_if_present<FusedLoc>(funcOp.getLoc())) {
-      scopeAttr = cast<LLVM::DISubprogramAttr>(funcOpLoc.getMetadata());
-      op->setLoc(
-          CallSiteLoc::get(getNestedLoc(op, scopeAttr, calleeLoc), callerLoc));
+    if (auto funcOp = op->getParentOfType<LLVM::LLVMFuncOp>()) {
+      if (auto funcOpLoc =
+              llvm::dyn_cast_if_present<FusedLoc>(funcOp.getLoc())) {
+        scopeAttr = cast<LLVM::DISubprogramAttr>(funcOpLoc.getMetadata());
+        op->setLoc(CallSiteLoc::get(getNestedLoc(op, scopeAttr, calleeLoc),
+                                    callerLoc));
+      }
     }
 
     return;

--- a/mlir/test/Dialect/LLVMIR/add-debuginfo-func-scope.mlir
+++ b/mlir/test/Dialect/LLVMIR/add-debuginfo-func-scope.mlir
@@ -160,3 +160,15 @@ module {
   } loc(#loc)
 } loc(unknown)
 
+
+// -----
+
+// Test that operations with CallSiteLoc outside of an llvm.func do not crash.
+llvm.func @dummy()
+func.func @test_func() {
+  return
+} loc(#loc2)
+
+#loc = loc("a.py":1150:34)
+#loc1 = loc("b.py":321:17)
+#loc2 = loc(callsite(#loc at #loc1))


### PR DESCRIPTION
This pass was not defensive enough about the presence of non-llvm functions with call site locs.