### PR TITLE
[libc++] fixes `__split_buffer_size_layout` bugs

### DIFF
--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -575,7 +575,7 @@ public:
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void
   __swap_without_allocator(__split_buffer<value_type, allocator_type, _Layout>& __other) _NOEXCEPT {
-    __base_type::__swap_without_allocator(__other);
+    __base_type::__swap_without_allocator(static_cast<__base_type&>(__other));
   }
 
 private:

--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -156,10 +156,8 @@ public:
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI const_reference back() const _NOEXCEPT { return *(__end_ - 1); }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __swap_without_allocator(
-      __split_buffer_pointer_layout<__split_buffer<value_type, allocator_type, __split_buffer_pointer_layout>,
-                                    value_type,
-                                    allocator_type>& __other) _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void
+  __swap_without_allocator(__split_buffer_pointer_layout& __other) _NOEXCEPT {
     std::swap(__front_cap_, __other.__front_cap_);
     std::swap(__begin_, __other.__begin_);
     std::swap(__back_cap_, __other.__back_cap_);
@@ -263,25 +261,19 @@ public:
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void
   __set_valid_range(pointer __new_begin, pointer __new_end) _NOEXCEPT {
-    // Size-based __split_buffers track their size directly: we need to explicitly update the size
-    // when the front is adjusted.
-    __size_ -= __new_begin - __begin_;
     __begin_ = __new_begin;
     __set_sentinel(__new_end);
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void
   __set_valid_range(pointer __new_begin, size_type __new_size) _NOEXCEPT {
-    // Size-based __split_buffers track their size directly: we need to explicitly update the size
-    // when the front is adjusted.
-    __size_ -= __new_begin - __begin_;
     __begin_ = __new_begin;
     __set_sentinel(__new_size);
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __set_sentinel(pointer __new_end) _NOEXCEPT {
     _LIBCPP_ASSERT_INTERNAL(__front_cap_ <= __new_end, "__new_end cannot precede __front_cap_");
-    __size_ += __new_end - end();
+    __size_ = __new_end - __begin_;
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __set_sentinel(size_type __new_size) _NOEXCEPT {
@@ -312,10 +304,8 @@ public:
     return __begin_[__size_ - 1];
   }
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __swap_without_allocator(
-      __split_buffer_pointer_layout<__split_buffer<value_type, allocator_type, __split_buffer_pointer_layout>,
-                                    value_type,
-                                    allocator_type>& __other) _NOEXCEPT {
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void
+  __swap_without_allocator(__split_buffer_size_layout& __other) _NOEXCEPT {
     std::swap(__front_cap_, __other.__front_cap_);
     std::swap(__begin_, __other.__begin_);
     std::swap(__cap_, __other.__cap_);


### PR DESCRIPTION
**tl;dr**

As `__split_buffer` doesn't have any unit tests, and because #139632 disassociated adding `__split_buffer` support for both pointer-based and size-based layouts from its `vector` counterpart, libc++ had no way to expose `__split_buffer_size_layout` bugs until the size-based vector patch integrated #139632. This commit fixes the two problems that were identified while working on #155330.

**Context**

* `__split_buffer_size_layout` needs to update its size whenever `__begin_` is adjusted (relative to `__front_`).
* `__split_buffer`'s layout types originally updated `__begin_` independently of the sentinel type, via `__set_begin()` and `__set_sentinel()`, respectively.
* [Louis Dionne observed that `__set_begin()` was always coupled with `__set_sentinel()`][1], and suggested combining them into a single setter. This feedback was applied in ec20ccc.

**What went wrong (part 1)**

ec20ccc combined `__set_begin()` and `__set_sentinel()` into a single function, but didn't remove the overlapping behaviour for `__split_buffer_size_layout`. The code below shows how this caused a problem:

```
void __set_valid_range(pointer __new_begin, pointer __new_end)
{
  __size_ -= __new_begin - __begin_;
  __begin_ = __new_begin;
  __set_sentinel(__new_end);

  // Inlining call to `__set_sentinel(__new_end)`:
  // __size_ += __new_end - end();
  //
  // Inlining call to `end()`:
  // __size_ += __new_end - (__begin_ + __size_);
}
```

`__set_valid_range(pointer, pointer)` sets `__size_` on both sides of setting `__begin_`. While either is valid on its own, applying both is incorrect. `__set_valid_range(pointer, size_type)` has the same abstract logic, but only wastes compute cycles, rather than affecting correctness:

```
void __set_valid_range(pointer __new_begin, size_type __new_size)
{
  __size_ -= __new_begin_ - __begin_;
  __begin_ = __new_begin_;
  __set_sentinel(__new_size);

  // Inlining call to `__set_sentinel(__new_size)`:
  // __size = __new_size;
  //
  // First line is an efficiency bug, not a correctness bug.
}
```

This commit removes the first line both overloads. Additionally, this commit optimises `__set_sentinel(pointer)` computes, as described below:

```
__set_sentinel(__new_end)
  ≡ __size_ += __new_end - end()
  ≡ __size_ += __new_end - (__begin_ + __size_)
  ≡ __size_  = __size_ + __new_end - (__begin_ + __size_)
             = __size_ + __new_end - __begin_ - __size_
             = __new_end - __begin_
```

**What went wrong (part 2)**

The second bug was a type error in `__swap_without_allocator`. As most function signatures identical in both layout types, they were copied from `__split_buffer_pointer_layout` into `__split_buffer_size_layout` to ensure that they were correct. `__swap_without_allocator` is a member function that operates on the layout type directly, and so its signature needs to differ with each layout type. Although other member functions were adjusted (e.g. `swap`), `__swap_without_allocator` was not, leading to compile-time errors when working on size-based vector, since `__split_buffer_pointer_layout` is not used when `vector` is size-based.

**How this ended up in the main branch**

Since the size-based vector project applies very similar changes to `__split_buffer` and `std::vector`, it was split into two PRs, so that reviewers didn't need to provide duplicate feedback. The PRs were split on types: #139632 patches `__split_buffer` and #155330 patches `vector`. Since `vector` needs a layout-compatible `__split_buffer`, #139632 was merged before #155330, to keep the PR story as simple as possible.

`__split_buffer` is an implementation detail and does not have its own unit tests: correctness bugs are being surfaced by its drivers, namely `std::vector` and `std::deque`. As such, there isn't a way to identify that `__split_buffer_size_layout` was correct without paradoxically testing it alongside a size-based vector implementation.

**How this can be avoided in the future**

There are two primary ways to avoid this type of problem moving forward.

1. **Split work across logic instead of types.** #139632 could have introduced the pointer layouts for both `__split_buffer` and `vector`, which would have set the structure for both types, but not made any material changes to the implementation. This would have coupled dependencies instead of typenames, and possibly simplified the review process further, as no logic would have changed.

   The trade-off for this approach is that both layouts influenced the layout's API design, and might have initially favoured the pointer layout, leading to adjustments later on.
2. **Stack dependent PRs, and submit when all have been LGTM'd.** This approach would allow the PRs to be sent for review as they were, but ensures that logic that's coupled across commits is checked in together. Stacking the PRs would allow CI to pick up both PRs, which is critical for ensuring that the dependent PR is correct.

   This was considered for #155330, but the GitHub model for [stacking PRs][2] required some work to be done ahead of #139632's creation without the risk of confusing reviewers. Closing #139632 and opening a new PR in service wasn't ideal, as it would have separated the PR history from the PR that was ultimately merged.

**How this patch was tested**

Since this commit is a change to `__split_buffer_size_layout`, and needs to be merged with `main` before #155330, this commit was cherry-picked into #155330, and tested using the libc++ buildbot job for the unstable ABI.

[1]: https://github.com/llvm/llvm-project/pull/139632/#discussion_r2282535795
[2]: https://llvm.org/docs/GitHub.html#stacked-pull-requests