### PR TITLE
[flang][NFC] Separated test for --enable-constant-argument-globalisation

### DIFF
--- a/flang/test/Lower/const-arg-glob.f90
+++ b/flang/test/Lower/const-arg-glob.f90
@@ -1,0 +1,13 @@
+! RUN: %flang_fc1 -emit-llvm -O2 -mllvm --enable-constant-argument-globalisation %s -o - | FileCheck %s
+
+! CHECK: @_global_const_{{.*}} = internal constant i32 2
+! CHECK: call void @take_int_(ptr nonnull @_global_const_{{.*}})
+
+subroutine test()
+  interface
+  subroutine take_int(n)
+    integer :: n
+  end subroutine
+  end interface
+  call take_int(2)
+end


### PR DESCRIPTION
The test for --enable-constant-argument-globalisation was added to existing lowering test as part of https://github.com/llvm/llvm-project/commit/de528ffb17ebce96e0bc4dde1749146c41ca1d0d

Decouple this test from the other lowering tests to ease conversion to HLFIR lowering.

Co-authored-by: Jean Perier <jperier@nvidia.com>