### PR TITLE
[alpha.webkit.NoDeleteChecker] Fix a nullptr deference crash during lookupInBases

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/NoDeleteChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/NoDeleteChecker.cpp
@@ -82,6 +82,9 @@ public:
                 return false;
 
               const CXXRecordDecl *R = T->getAsCXXRecordDecl();
+              if (!R)
+                return false;
+
               for (const CXXMethodDecl *BaseMD : R->methods()) {
                 if (BaseMD->getCorrespondingMethodInClass(Cls) == MD) {
                   if (isNoDeleteFunction(FD)) {

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -65,3 +65,15 @@ class DerivedClass : public IntermediateClass {
     someFunction();
   }
 };
+
+template <class Type>
+class Base {
+public:
+  virtual unsigned foo() const = 0;
+};
+
+template <class Type>
+class Derived : public Base<Type> {
+public:
+  virtual unsigned foo() const { return 0; }
+};


### PR DESCRIPTION
Added a null check in the lambda passed to lookupInBases.