### PR TITLE
[LoopInterchange] Initialize new_var to InitValue on first iteration

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -1911,7 +1911,6 @@ void LoopInterchangeTransform::reduction2Memory() {
                          InnerLoop->getLoopPreheader());
   FirstIter->addIncoming(ConstantInt::get(Type::getInt1Ty(Context), 0),
                          InnerLoop->getLoopLatch());
-  FirstIter->dropDbgRecords();
   assert(FirstIter->isComplete() && "The FirstIter PHI node is not complete.");
 
   // When the reduction is initialized from a constant value, we need to add

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -1911,6 +1911,7 @@ void LoopInterchangeTransform::reduction2Memory() {
                          InnerLoop->getLoopPreheader());
   FirstIter->addIncoming(ConstantInt::get(Type::getInt1Ty(Context), 0),
                          InnerLoop->getLoopLatch());
+  FirstIter->dropDbgRecords();
   assert(FirstIter->isComplete() && "The FirstIter PHI node is not complete.");
 
   // When the reduction is initialized from a constant value, we need to add
@@ -1919,7 +1920,7 @@ void LoopInterchangeTransform::reduction2Memory() {
   Instruction *LoadMem = Builder.CreateLoad(SR.ElemTy, SR.MemRef);
 
   // Init new_var to MEM_REF or CONST depending on if it is the first iteration.
-  Value *NewVar = Builder.CreateSelect(FirstIter, LoadMem, SR.Init, "new.var");
+  Value *NewVar = Builder.CreateSelect(FirstIter, SR.Init, LoadMem, "new.var");
 
   // Replace all uses of the reduction variable with a new variable.
   SR.Reduction->replaceAllUsesWith(NewVar);

--- a/llvm/test/Transforms/LoopInterchange/reduction2mem-limitation.ll
+++ b/llvm/test/Transforms/LoopInterchange/reduction2mem-limitation.ll
@@ -1,4 +1,4 @@
-; Several inner-loop reduction patterns not yet supported.
+; Several inner-loop reduction patterns are not yet supported.
 ; RUN: opt < %s -passes="loop-interchange"  -loop-interchange-reduction-to-mem -pass-remarks-missed='loop-interchange' \
 ; RUN:            -pass-remarks-output=%t -S | FileCheck -check-prefix=IR %s
 ; RUN: FileCheck --input-file=%t %s

--- a/llvm/test/Transforms/LoopInterchange/reduction2mem.ll
+++ b/llvm/test/Transforms/LoopInterchange/reduction2mem.ll
@@ -32,7 +32,7 @@ define void @func(ptr noalias readonly %a, ptr noalias readonly %b, ptr noalias 
 ; CHECK-NEXT:    br label %[[OUTERLOOPHEADER_PREHEADER]]
 ; CHECK:       [[INNERLOOP_SPLIT1]]:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load double, ptr [[ADDR_S]], align 8
-; CHECK-NEXT:    [[NEW_VAR:%.*]] = select i1 [[FIRSTITER]], double [[TMP0]], double 0.000000e+00
+; CHECK-NEXT:    [[NEW_VAR:%.*]] = select i1 [[FIRSTITER]], double 0.000000e+00, double [[TMP0]]
 ; CHECK-NEXT:    [[ADDR_A_J_I:%.*]] = getelementptr inbounds nuw double, ptr [[ADDR_A]], i64 [[INDEX_J]]
 ; CHECK-NEXT:    [[A_J_I:%.*]] = load double, ptr [[ADDR_A_J_I]], align 8
 ; CHECK-NEXT:    [[ADDR_B_J_I:%.*]] = getelementptr inbounds nuw double, ptr [[ADDR_B]], i64 [[INDEX_J]]


### PR DESCRIPTION
Fixed a bug found during testing:
- If it is the first iteration, `new_var` should be initialized to 'InitValue'.

