### PR TITLE
[DAGISel][NFC] Add XForm/Convert/CopyToReg Comments

### DIFF
--- a/llvm/utils/TableGen/DAGISelMatcher.h
+++ b/llvm/utils/TableGen/DAGISelMatcher.h
@@ -885,8 +885,10 @@ private:
 /// recorded node and converts it from being a ISD::Constant to
 /// ISD::TargetConstant, likewise for ConstantFP.
 class EmitConvertToTargetMatcher : public Matcher {
+  // Recorded Node
   unsigned Slot;
 
+  // Result
   unsigned ResultNo;
 
 public:
@@ -940,7 +942,9 @@ private:
 /// pushing the chain and glue results.
 ///
 class EmitCopyToRegMatcher : public Matcher {
-  unsigned SrcSlot; // Value to copy into the physreg.
+  // Value to copy into the physreg.
+  unsigned SrcSlot;
+  // Register Destination
   const CodeGenRegister *DestPhysReg;
 
 public:
@@ -965,9 +969,12 @@ private:
 /// EmitNodeXFormMatcher - Emit an operation that runs an SDNodeXForm on a
 /// recorded node and records the result.
 class EmitNodeXFormMatcher : public Matcher {
+  // Recorded Node
   unsigned Slot;
+  // Transform
   const Record *NodeXForm;
 
+  // Result
   unsigned ResultNo;
 
 public:

--- a/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
@@ -946,7 +946,7 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
       OS << ", ";
     OS << Slot << ',';
     if (!OmitComments)
-      OS << " // #" << CTTM->getResultNo();
+      OS << " // #" << CTTM->getResultNo() << " = ConvertToTarget #" << Slot;
     OS << '\n';
     return 1 + (Slot >= 8);
   }
@@ -975,19 +975,22 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
     if (Reg->EnumValue > 255) {
       assert(isUInt<16>(Reg->EnumValue) && "not handled");
       OS << "OPC_EmitCopyToRegTwoByte, " << Slot << ", "
-         << "TARGET_VAL(" << getQualifiedName(Reg->TheDef) << "),\n";
+         << "TARGET_VAL(" << getQualifiedName(Reg->TheDef) << "),";
       ++Bytes;
     } else {
       if (Slot < 8) {
         OS << "OPC_EmitCopyToReg" << Slot << ", "
-           << getQualifiedName(Reg->TheDef) << ",\n";
+           << getQualifiedName(Reg->TheDef) << ",";
         --Bytes;
       } else {
         OS << "OPC_EmitCopyToReg, " << Slot << ", "
-           << getQualifiedName(Reg->TheDef) << ",\n";
+           << getQualifiedName(Reg->TheDef) << ",";
       }
     }
+    if (!OmitComments)
+      OS << " // = #" << Slot;
 
+    OS << '\n';
     return Bytes;
   }
   case Matcher::EmitNodeXForm: {
@@ -995,8 +998,8 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
     OS << "OPC_EmitNodeXForm, " << getNodeXFormID(XF->getNodeXForm()) << ", "
        << XF->getSlot() << ',';
     if (!OmitComments)
-      OS << " // " << XF->getNodeXForm()->getName() << " #"
-         << XF->getResultNo();
+      OS << " // #" << XF->getResultNo() << " = "
+         << XF->getNodeXForm()->getName() << " #" << XF->getSlot();
     OS << '\n';
     return 3;
   }


### PR DESCRIPTION
Thus updates the TableGen comments (both in the TableGen source, and the code that TableGen produces) to make it clearer what is being represented by the ConvertToTarget emitter, the XForm emitter, and the CopyToReg emitter.