### PR TITLE
[mlir][dataflow] Overload visitNonControlFlowArguments

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
@@ -63,13 +63,19 @@ public:
 
   /// Visit block arguments or operation results of an operation with region
   /// control-flow for which values are not defined by region control-flow. This
-  /// function calls `InferIntRangeInterface` to provide values for block
-  /// arguments or tries to reduce the range on loop induction variables with
+  /// function tries to reduce the range on loop induction variables with
   /// known bounds.
   void visitNonControlFlowArguments(
       Operation *op, const RegionSuccessor &successor,
       ValueRange nonSuccessorInputs,
       ArrayRef<IntegerValueRangeLattice *> nonSuccessorInputLattices) override;
+
+  /// This function calls `InferIntRangeInterface` to provide values for entry
+  /// block arguments where the parentOp does not implement
+  /// `RegionBranchOpInterface` (e.g., gpu.launch).
+  void visitNonControlFlowArguments(
+      Operation *op, Region *const region, ValueRange arguments,
+      ArrayRef<IntegerValueRangeLattice *> argLattices) override;
 };
 
 /// Succeeds if an op can be converted to its unsigned equivalent without

--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -187,7 +187,7 @@ void AbstractSparseForwardDataFlowAnalysis::visitBlock(Block *block) {
 
     // All block arguments are non-successor-inputs.
     return visitNonControlFlowArgumentsImpl(block->getParentOp(),
-                                            RegionSuccessor(block->getParent()),
+                                            block->getParent(),
                                             block->getArguments(), argLattices);
   }
 


### PR DESCRIPTION
This PR distinguishes between the two scenarios in visitNonControlFlowArguments:
* The original visitNonControlFlowArguments included `RegionSuccessor` in its parameters, which was used to handle RegionBranchOpInterface.
* The new visitNonControlFlowArguments removes `RegionSuccessor` and replaces it with `Region*`. We use it to infer lattices for entry block arguments of Region Ops that do not implement `RegionBranchOpInterface`(We cannot construct a RegionSuccessor for ops that do not implement RegionBranchOpInterface).

RFC:  https://discourse.llvm.org/t/rfc-drop-the-firstindex-argument-of-visitnoncontrolflowarguments-of-sparseforwarddataflowanalysis/89419/5
