### PR TITLE
[mlir] Fix integer overflow in ShapedType::getNumElements and `makeCanonicalStridedLayoutExpr`

### DIFF
--- a/mlir/include/mlir/IR/BuiltinTypeInterfaces.td
+++ b/mlir/include/mlir/IR/BuiltinTypeInterfaces.td
@@ -237,6 +237,10 @@ def ShapedTypeInterface : TypeInterface<"ShapedType"> {
     /// Return the number of elements present in the given shape.
     static int64_t getNumElements(ArrayRef<int64_t> shape);
 
+    /// Return the number of elements present in the given shape, or
+    /// std::nullopt if the computation would overflow.
+    static std::optional<int64_t> tryGetNumElements(ArrayRef<int64_t> shape);
+
     /// Return a clone of this type with the given new shape and element type.
     /// The returned type is ranked, even if this type is unranked.
     auto clone(::llvm::ArrayRef<int64_t> shape, Type elementType) {
@@ -274,6 +278,13 @@ def ShapedTypeInterface : TypeInterface<"ShapedType"> {
     int64_t getNumElements() const {
       assert(hasStaticShape() && "cannot get element count of dynamic shaped type");
       return ::mlir::ShapedType::getNumElements($_type.getShape());
+    }
+
+    /// If it has static shape, return the number of elements, or std::nullopt
+    /// if the computation would overflow. Otherwise, abort.
+    std::optional<int64_t> tryGetNumElements() const {
+      assert(hasStaticShape() && "cannot get element count of dynamic shaped type");
+      return ::mlir::ShapedType::tryGetNumElements($_type.getShape());
     }
 
     /// Returns true if this dimension has a dynamic size (for ranked types);

--- a/mlir/include/mlir/IR/BuiltinTypeInterfaces.td
+++ b/mlir/include/mlir/IR/BuiltinTypeInterfaces.td
@@ -280,8 +280,8 @@ def ShapedTypeInterface : TypeInterface<"ShapedType"> {
       return ::mlir::ShapedType::getNumElements($_type.getShape());
     }
 
-    /// If it has static shape, return the number of elements, or std::nullopt
-    /// if the computation would overflow. Otherwise, abort.
+    /// Return the number of elements, or std::nullopt if the computation would overflow.
+    /// Precondition: `hasStaticShape()`, otherwise abort.
     std::optional<int64_t> tryGetNumElements() const {
       assert(hasStaticShape() && "cannot get element count of dynamic shaped type");
       return ::mlir::ShapedType::tryGetNumElements($_type.getShape());

--- a/mlir/lib/IR/BuiltinTypeInterfaces.cpp
+++ b/mlir/lib/IR/BuiltinTypeInterfaces.cpp
@@ -47,7 +47,14 @@ std::optional<int64_t> ShapedType::tryGetNumElements(ArrayRef<int64_t> shape) {
 }
 
 int64_t ShapedType::getNumElements(ArrayRef<int64_t> shape) {
+#ifndef NDEBUG
   std::optional<int64_t> num = tryGetNumElements(shape);
   assert(num.has_value() && "integer overflow in element count computation");
   return *num;
+#else
+  int64_t num = 1;
+  for (int64_t dim : shape)
+    num *= dim;
+  return num;
+#endif
 }

--- a/mlir/lib/IR/BuiltinTypeInterfaces.cpp
+++ b/mlir/lib/IR/BuiltinTypeInterfaces.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/APFloat.h"
+#include "llvm/Support/CheckedArithmetic.h"
 
 using namespace mlir;
 using namespace mlir::detail;
@@ -34,11 +35,19 @@ unsigned FloatType::getFPMantissaWidth() {
 // ShapedType
 //===----------------------------------------------------------------------===//
 
-int64_t ShapedType::getNumElements(ArrayRef<int64_t> shape) {
+std::optional<int64_t> ShapedType::tryGetNumElements(ArrayRef<int64_t> shape) {
   int64_t num = 1;
   for (int64_t dim : shape) {
-    num *= dim;
-    assert(num >= 0 && "integer overflow in element count computation");
+    auto result = llvm::checkedMul(num, dim);
+    if (!result)
+      return std::nullopt;
+    num = *result;
   }
   return num;
+}
+
+int64_t ShapedType::getNumElements(ArrayRef<int64_t> shape) {
+  std::optional<int64_t> num = tryGetNumElements(shape);
+  assert(num.has_value() && "integer overflow in element count computation");
+  return *num;
 }

--- a/mlir/test/Dialect/MemRef/high-rank-overflow.mlir
+++ b/mlir/test/Dialect/MemRef/high-rank-overflow.mlir
@@ -1,0 +1,21 @@
+// RUN: mlir-opt %s --convert-to-llvm --split-input-file --verify-diagnostics | FileCheck %s
+
+// Test that extremely high-rank memrefs with overflow in stride calculation
+// are handled gracefully instead of crashing (issue #177816).
+
+// CHECK-LABEL: func @high_rank_memref_overflow
+func.func @high_rank_memref_overflow() {
+  // This creates a memref with 64 dimensions of size 2, resulting in 2^64 elements
+  // which overflows int64_t. The stride calculation should handle this gracefully.
+  %0 = memref.alloc() : memref<2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2x2xi32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @high_rank_memref_max_dim
+func.func @high_rank_memref_max_dim() {
+  // Test with fewer dimensions but larger sizes that also cause overflow
+  %0 = memref.alloc() : memref<9223372036854775807x2xi32>
+  return
+}


### PR DESCRIPTION
Add to `ShapedTypeInterface` a new `tryGetNumElements()` API which returns `std::optional<int64_t>` - returns `std::nullopt` on overflow instead of UB, using `llvm::checkedMul` for proper overflow detection. 
`getNumElements()` now uses this new API to assert on overflow.

Also fix `AffineExpr` canonicalization to avoid crashing on overflow using `llvm::checkedMul`.

Fixes #178362
Fixes #177816