### PR TITLE
[AMDGPU] Fix buggy insertion of DEALLOC_VGPRS message

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/release-vgprs.mir
+++ b/llvm/test/CodeGen/AMDGPU/release-vgprs.mir
@@ -364,54 +364,32 @@ body:             |
     S_ENDPGM 0, implicit $vgpr97
 ...
 
-# FIXME: The scratch store in the loop may still be pending at S_ENDPGM so we
-# should not insert S_SENDMSG.
+# The scratch store in the loop may still be pending at S_ENDPGM so we should
+# not insert S_SENDMSG.
 ---
 name: multiple_basic_blocks4
 machineFunctionInfo:
   isEntryFunction: true
 body: |
-  ; OPT-LABEL: name: multiple_basic_blocks4
-  ; OPT: bb.0:
-  ; OPT-NEXT:   successors: %bb.1(0x80000000)
-  ; OPT-NEXT: {{  $}}
-  ; OPT-NEXT:   GLOBAL_STORE_DWORD_SADDR killed renamable $vgpr2, killed renamable $vgpr0, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec
-  ; OPT-NEXT: {{  $}}
-  ; OPT-NEXT: bb.1:
-  ; OPT-NEXT:   successors: %bb.3(0x40000000), %bb.2(0x40000000)
-  ; OPT-NEXT: {{  $}}
-  ; OPT-NEXT:   S_CBRANCH_SCC1 %bb.3, implicit $scc
-  ; OPT-NEXT: {{  $}}
-  ; OPT-NEXT: bb.2:
-  ; OPT-NEXT:   successors: %bb.1(0x80000000)
-  ; OPT-NEXT: {{  $}}
-  ; OPT-NEXT:   SCRATCH_STORE_DWORD_SADDR killed renamable $vgpr0, killed renamable $sgpr0, 0, 0, implicit $exec, implicit $flat_scr
-  ; OPT-NEXT:   S_BRANCH %bb.1
-  ; OPT-NEXT: {{  $}}
-  ; OPT-NEXT: bb.3:
-  ; OPT-NEXT:   S_NOP 0
-  ; OPT-NEXT:   S_SENDMSG 3, implicit $exec, implicit $m0
-  ; OPT-NEXT:   S_ENDPGM 0, implicit $vgpr97
-  ;
-  ; NOOPT-LABEL: name: multiple_basic_blocks4
-  ; NOOPT: bb.0:
-  ; NOOPT-NEXT:   successors: %bb.1(0x80000000)
-  ; NOOPT-NEXT: {{  $}}
-  ; NOOPT-NEXT:   GLOBAL_STORE_DWORD_SADDR killed renamable $vgpr2, killed renamable $vgpr0, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec
-  ; NOOPT-NEXT: {{  $}}
-  ; NOOPT-NEXT: bb.1:
-  ; NOOPT-NEXT:   successors: %bb.3(0x40000000), %bb.2(0x40000000)
-  ; NOOPT-NEXT: {{  $}}
-  ; NOOPT-NEXT:   S_CBRANCH_SCC1 %bb.3, implicit $scc
-  ; NOOPT-NEXT: {{  $}}
-  ; NOOPT-NEXT: bb.2:
-  ; NOOPT-NEXT:   successors: %bb.1(0x80000000)
-  ; NOOPT-NEXT: {{  $}}
-  ; NOOPT-NEXT:   SCRATCH_STORE_DWORD_SADDR killed renamable $vgpr0, killed renamable $sgpr0, 0, 0, implicit $exec, implicit $flat_scr
-  ; NOOPT-NEXT:   S_BRANCH %bb.1
-  ; NOOPT-NEXT: {{  $}}
-  ; NOOPT-NEXT: bb.3:
-  ; NOOPT-NEXT:   S_ENDPGM 0, implicit $vgpr97
+  ; CHECK-LABEL: name: multiple_basic_blocks4
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   GLOBAL_STORE_DWORD_SADDR killed renamable $vgpr2, killed renamable $vgpr0, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   successors: %bb.3(0x40000000), %bb.2(0x40000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   S_CBRANCH_SCC1 %bb.3, implicit $scc
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   SCRATCH_STORE_DWORD_SADDR killed renamable $vgpr0, killed renamable $sgpr0, 0, 0, implicit $exec, implicit $flat_scr
+  ; CHECK-NEXT:   S_BRANCH %bb.1
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.3:
+  ; CHECK-NEXT:   S_ENDPGM 0, implicit $vgpr97
   bb.0:
     GLOBAL_STORE_DWORD_SADDR killed renamable $vgpr2, killed renamable $vgpr0, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec
 


### PR DESCRIPTION
We inserted the DEALLOC_VGPRS message if there were no pending scratch
stores the first time an S_ENDPGM instruction was visited. But because
this pass uses a worklist to revisit blocks until it reaches a fixed
point, it is possible that pending scratch stores are only discovered on
the second or later visit to a block. Fix this by storing a flag for
each S_ENDPGM instruction which can be updated by later visits.
