### PR TITLE
[milr][memref]: Add control options to FoldMemrefAliasOps

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/MemRef/Transforms/Passes.h
@@ -14,6 +14,9 @@
 #define MLIR_DIALECT_MEMREF_TRANSFORMS_PASSES_H
 
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace mlir {
 
@@ -44,6 +47,14 @@ namespace memref {
 
 #define GEN_PASS_DECL
 #include "mlir/Dialect/MemRef/Transforms/Passes.h.inc"
+
+/// Additional construction for FoldMemrefAliasOps to allow disabling
+/// patterns by name, and controlling folding via a callback function.
+/// `controlFn(Operation* userOp)` will be passed the user operation of the
+/// aliasing op (e.g., a load/store that uses the result of a memref.subview).
+std::unique_ptr<Pass> createFoldMemRefAliasOpsPass(
+    ArrayRef<StringRef> excludedPatterns,
+    function_ref<bool(Operation *)> controlFn = nullptr);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/mlir/include/mlir/Dialect/MemRef/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/MemRef/Transforms/Transforms.h
@@ -21,6 +21,7 @@ namespace mlir {
 class OpBuilder;
 class RewritePatternSet;
 class RewriterBase;
+class Operation;
 class Value;
 class ValueRange;
 class ReifyRankedShapedTypeOpInterface;
@@ -43,8 +44,13 @@ class DeallocOp;
 void populateExpandOpsPatterns(RewritePatternSet &patterns);
 
 /// Appends patterns for folding memref aliasing ops into consumer load/store
-/// ops into `patterns`.
-void populateFoldMemRefAliasOpPatterns(RewritePatternSet &patterns);
+/// ops into `patterns`. If `controlFn` is provided, each pattern invokes it and
+/// bails out when it returns false.
+/// `controlFn(Operation* userOp)` will be passed the user operation of the
+/// aliasing op (e.g., a load/store that uses the result of a memref.subview).
+void populateFoldMemRefAliasOpPatterns(
+    RewritePatternSet &patterns,
+    function_ref<bool(Operation *)> controlFn = nullptr);
 
 /// Appends patterns that resolve `memref.dim` operations with values that are
 /// defined by operations that implement the

--- a/mlir/test/Dialect/MemRef/fold-memref-alias-ops-options.mlir
+++ b/mlir/test/Dialect/MemRef/fold-memref-alias-ops-options.mlir
@@ -1,0 +1,34 @@
+// RUN: mlir-opt --test-fold-memref-alias-options="exclude-pattern=load-subview" -split-input-file %s | FileCheck %s --check-prefix=EXCLUDE
+// RUN: mlir-opt --test-fold-memref-alias-options="control-attr=no_fold" -split-input-file %s | FileCheck %s --check-prefix=CONTROL
+
+// -----
+
+// Excluding the load-subview pattern keeps the subview + load untouched.
+func.func @exclude_load_subview(%arg0: memref<4xf32>) -> f32 {
+  %c0 = arith.constant 0 : index
+  %sv = memref.subview %arg0[0] [4] [1] : memref<4xf32> to memref<4xf32, strided<[1], offset: 0>>
+  %v = memref.load %sv[%c0] : memref<4xf32, strided<[1], offset: 0>>
+  return %v : f32
+}
+
+// EXCLUDE-LABEL: func.func @exclude_load_subview
+// EXCLUDE: %[[SV:.*]] = memref.subview
+// EXCLUDE: memref.load %[[SV]]
+// EXCLUDE-NOT: memref.load %arg0
+
+// -----
+
+// Control callback rejects ops carrying the attribute; the plain load is still
+// folded through the subview.
+func.func @control_attr(%arg0: memref<4xf32>) -> (f32, f32) {
+  %c0 = arith.constant 0 : index
+  %sv = memref.subview %arg0[0] [4] [1] : memref<4xf32> to memref<4xf32, strided<[1], offset: 0>>
+  %blocked = memref.load %sv[%c0] {no_fold} : memref<4xf32, strided<[1], offset: 0>>
+  %folded = memref.load %sv[%c0] : memref<4xf32, strided<[1], offset: 0>>
+  return %blocked, %folded : f32, f32
+}
+
+// CONTROL-LABEL: func.func @control_attr
+// CONTROL: %[[SV:.*]] = memref.subview
+// CONTROL: %[[A:.*]] = memref.load %[[SV]][%c0] {no_fold}
+// CONTROL: %[[B:.*]] = memref.load %arg0[%c0]

--- a/mlir/test/lib/Dialect/MemRef/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/MemRef/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_mlir_library(MLIRMemRefTestPasses
   TestComposeSubView.cpp
   TestEmulateNarrowType.cpp
+  TestFoldMemRefAliasOptions.cpp
   TestMultiBuffer.cpp
 
   EXCLUDE_FROM_LIBMLIR

--- a/mlir/test/lib/Dialect/MemRef/TestFoldMemRefAliasOptions.cpp
+++ b/mlir/test/lib/Dialect/MemRef/TestFoldMemRefAliasOptions.cpp
@@ -1,0 +1,101 @@
+//===- TestFoldMemRefAliasOptions.cpp - Test FoldMemRefAlias options ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a test pass to exercise the optional arguments of
+// FoldMemRefAliasOps (excluded patterns and control callback).
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/TypeName.h"
+
+using namespace mlir;
+
+namespace {
+struct TestFoldMemRefAliasOptionsPass
+    : public PassWrapper<TestFoldMemRefAliasOptionsPass, OperationPass<>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestFoldMemRefAliasOptionsPass)
+
+  TestFoldMemRefAliasOptionsPass() = default;
+  TestFoldMemRefAliasOptionsPass(const TestFoldMemRefAliasOptionsPass &pass)
+      : PassWrapper(pass) {}
+
+  StringRef getArgument() const final {
+    return "test-fold-memref-alias-options";
+  }
+  StringRef getDescription() const final {
+    return "Test FoldMemRefAliasOps optional arguments";
+  }
+
+  ListOption<std::string> excludedPatternTokens{
+      *this, "exclude-pattern",
+      llvm::cl::desc("Comma-separated tokens to exclude certain patterns "
+                     "(e.g., load-subview)")};
+  Option<std::string> controlAttr{
+      *this, "control-attr",
+      llvm::cl::desc(
+          "Attribute name that disables rewrites when present on the "
+          "matched operation"),
+      llvm::cl::init("")};
+
+  void runOnOperation() override;
+};
+
+void TestFoldMemRefAliasOptionsPass::runOnOperation() {
+  // Custom version of "FoldMemRefAliasOps" to test its options, by:
+  // 1) Excluding patterns that fold memref.subview into load ops
+  // 2) Ignoring user ops that have a specific attribute.
+
+  // Map friendly tokens to concrete pattern names expected by the exclusion
+  // mechanism.
+  SmallVector<std::string> disabledPatternNames;
+  if (llvm::is_contained(excludedPatternTokens, "load-subview")) {
+    // Resolve pattern debug names from a populated set.
+    RewritePatternSet patternsSet(&getContext());
+    memref::populateFoldMemRefAliasOpPatterns(patternsSet);
+    for (auto &pattern : patternsSet.getNativePatterns()) {
+      std::optional<OperationName> rootKind = pattern->getRootKind();
+      if (rootKind &&
+          rootKind->getStringRef() == memref::LoadOp::getOperationName()) {
+        disabledPatternNames.push_back(pattern->getDebugName().str());
+        break;
+      }
+    }
+  }
+
+  std::function<bool(Operation *)> controlFnStorage;
+  function_ref<bool(Operation *)> controlFnRef;
+  if (!controlAttr.empty()) {
+    StringAttr attrName = StringAttr::get(&getContext(), controlAttr);
+    controlFnStorage = [attrName](Operation *op) {
+      return !op->hasAttr(attrName);
+    };
+    controlFnRef = controlFnStorage;
+  }
+
+  RewritePatternSet owningPatterns(&getContext());
+  memref::populateFoldMemRefAliasOpPatterns(owningPatterns, controlFnRef);
+  FrozenRewritePatternSet patterns(std::move(owningPatterns),
+                                   disabledPatternNames);
+  (void)applyPatternsGreedily(getOperation(), patterns);
+}
+} // namespace
+
+namespace mlir {
+namespace test {
+void registerTestFoldMemRefAliasOptionsPass() {
+  PassRegistration<TestFoldMemRefAliasOptionsPass>();
+}
+} // namespace test
+} // namespace mlir

--- a/mlir/tools/mlir-opt/mlir-opt.cpp
+++ b/mlir/tools/mlir-opt/mlir-opt.cpp
@@ -133,6 +133,7 @@ void registerTestMemRefToLLVMWithTransforms();
 void registerTestReshardingPartitionPass();
 void registerTestShardSimplificationsPass();
 void registerTestMultiBuffering();
+void registerTestFoldMemRefAliasOptionsPass();
 void registerTestNextAccessPass();
 void registerTestNVGPULowerings();
 void registerTestOpenACC();
@@ -248,6 +249,7 @@ static void registerTestPasses() {
   mlir::test::registerTestDominancePass();
   mlir::test::registerTestDynamicPipelinePass();
   mlir::test::registerTestRemarkPass();
+  mlir::test::registerTestFoldMemRefAliasOptionsPass();
   mlir::test::registerTestEmulateNarrowTypePass();
   mlir::test::registerTestFooAnalysisPass();
   mlir::test::registerTestComposeSubView();


### PR DESCRIPTION
Add two optional arguments "excludedPatterns" & "controlFn" to the constructor of the `FoldMemRefAliasOps` pass and to `memref::populateFoldMemRefAliasOpPatterns()`, to allow:
- disabling specific patterns by name,
- passing a control function to decide if pattern should ignore the current operation