### PR TITLE
[SimplifyCFG] Increase iterative simplification convergence limit.

### DIFF
--- a/llvm/lib/Transforms/Scalar/SimplifyCFGPass.cpp
+++ b/llvm/lib/Transforms/Scalar/SimplifyCFGPass.cpp
@@ -244,7 +244,7 @@ static bool iterativelySimplifyCFG(Function &F, const TargetTransformInfo &TTI,
   unsigned IterCnt = 0;
   (void)IterCnt;
   while (LocalChange) {
-    assert(IterCnt++ < 1000 && "Iterative simplification didn't converge!");
+    assert(IterCnt++ < 2000 && "Iterative simplification didn't converge!");
     LocalChange = false;
 
     // Loop over all of the basic blocks and remove them if they are unneeded.


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/a9b0776a81e84d8042716863842fe1f8adf39cad added an assertion to avoid infinite loops. However, the limit seems arbitrary, there is no justification for it neither in the code nor in the commit message, so I think this can be increased.