### PR TITLE
[AArch64] Support SHUFFLE of ANY_EXTEND in performBuildShuffleExtendCombine

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -19936,7 +19936,8 @@ static SDValue performBuildShuffleExtendCombine(SDValue BV, SelectionDAG &DAG) {
   // Shuffle inputs are vector, limit to SIGN_EXTEND/ZERO_EXTEND/ANY_EXTEND to
   // ensure calculatePreExtendType will work without issue.
   if (BV.getOpcode() == ISD::VECTOR_SHUFFLE &&
-      ExtendOpcode != ISD::SIGN_EXTEND && ExtendOpcode != ISD::ZERO_EXTEND)
+      ExtendOpcode != ISD::SIGN_EXTEND && ExtendOpcode != ISD::ZERO_EXTEND &&
+      ExtendOpcode != ISD::ANY_EXTEND)
     return SDValue();
 
   // Restrict valid pre-extend data type
@@ -19955,8 +19956,8 @@ static SDValue performBuildShuffleExtendCombine(SDValue BV, SelectionDAG &DAG) {
       return SDValue();
 
     unsigned Opc = Op.getOpcode();
-    if (BV.getOpcode() == ISD::VECTOR_SHUFFLE &&
-        (Opc != ISD::SIGN_EXTEND && Opc != ISD::ZERO_EXTEND))
+    if (BV.getOpcode() == ISD::VECTOR_SHUFFLE && Opc != ISD::SIGN_EXTEND &&
+        Opc != ISD::ZERO_EXTEND && Opc != ISD::ANY_EXTEND)
       return SDValue();
 
     if (Opc == ISD::ANY_EXTEND)

--- a/llvm/test/CodeGen/AArch64/aarch64-dup-ext.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-dup-ext.ll
@@ -170,6 +170,147 @@ entry:
   ret <2 x i32> %out
 }
 
+define <2 x i32> @dupzext_vector_v2i32_v2i64_trunc(<2 x i32> %a, ptr %p) {
+; CHECK-SD-LABEL: dupzext_vector_v2i32_v2i64_trunc:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    ldr d1, [x0]
+; CHECK-SD-NEXT:    ushll v0.2d, v0.2s, #0
+; CHECK-SD-NEXT:    ushll v1.2d, v1.2s, #0
+; CHECK-SD-NEXT:    dup v2.2d, v0.d[0]
+; CHECK-SD-NEXT:    fmov w10, s0
+; CHECK-SD-NEXT:    fmov w11, s1
+; CHECK-SD-NEXT:    mov w8, v1.s[2]
+; CHECK-SD-NEXT:    mov w9, v2.s[2]
+; CHECK-SD-NEXT:    mul w10, w10, w11
+; CHECK-SD-NEXT:    mul w8, w9, w8
+; CHECK-SD-NEXT:    fmov d0, x10
+; CHECK-SD-NEXT:    mov v0.d[1], x8
+; CHECK-SD-NEXT:    xtn v0.2s, v0.2d
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: dupzext_vector_v2i32_v2i64_trunc:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    ushll v0.2d, v0.2s, #0
+; CHECK-GI-NEXT:    ldr d1, [x0]
+; CHECK-GI-NEXT:    dup v0.2d, v0.d[0]
+; CHECK-GI-NEXT:    xtn v0.2s, v0.2d
+; CHECK-GI-NEXT:    umull v0.2d, v0.2s, v1.2s
+; CHECK-GI-NEXT:    xtn v0.2s, v0.2d
+; CHECK-GI-NEXT:    ret
+entry:
+  %ext.a = zext <2 x i32> %a to <2 x i64>
+  %broadcast.splat = shufflevector <2 x i64> %ext.a, <2 x i64> poison, <2 x i32> zeroinitializer
+  %l = load <2 x i32>, ptr %p, align 4
+  %ext.l = zext <2 x i32> %l to <2 x i64>
+  %prod = mul nuw <2 x i64> %broadcast.splat, %ext.l
+  %out = trunc <2 x i64> %prod to <2 x i32>
+  ret <2 x i32> %out
+}
+
+define <2 x i32> @shufflezext_vector_v2i32_v2i64_trunc(<2 x i32> %a, <2 x i32> %b, ptr %p) {
+; CHECK-SD-LABEL: shufflezext_vector_v2i32_v2i64_trunc:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    ushll v0.2d, v0.2s, #0
+; CHECK-SD-NEXT:    ushll v1.2d, v1.2s, #0
+; CHECK-SD-NEXT:    ldr d2, [x0]
+; CHECK-SD-NEXT:    ushll v2.2d, v2.2s, #0
+; CHECK-SD-NEXT:    zip1 v1.2d, v0.2d, v1.2d
+; CHECK-SD-NEXT:    fmov w10, s0
+; CHECK-SD-NEXT:    fmov w11, s2
+; CHECK-SD-NEXT:    mov w9, v2.s[2]
+; CHECK-SD-NEXT:    mov w8, v1.s[2]
+; CHECK-SD-NEXT:    mul w10, w10, w11
+; CHECK-SD-NEXT:    mul w8, w8, w9
+; CHECK-SD-NEXT:    fmov d0, x10
+; CHECK-SD-NEXT:    mov v0.d[1], x8
+; CHECK-SD-NEXT:    xtn v0.2s, v0.2d
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: shufflezext_vector_v2i32_v2i64_trunc:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    ushll v0.2d, v0.2s, #0
+; CHECK-GI-NEXT:    ushll v1.2d, v1.2s, #0
+; CHECK-GI-NEXT:    zip1 v0.2d, v0.2d, v1.2d
+; CHECK-GI-NEXT:    ldr d1, [x0]
+; CHECK-GI-NEXT:    xtn v0.2s, v0.2d
+; CHECK-GI-NEXT:    umull v0.2d, v0.2s, v1.2s
+; CHECK-GI-NEXT:    xtn v0.2s, v0.2d
+; CHECK-GI-NEXT:    ret
+entry:
+  %ext.a = zext <2 x i32> %a to <2 x i64>
+  %ext.b = zext <2 x i32> %b to <2 x i64>
+  %broadcast.splat = shufflevector <2 x i64> %ext.a, <2 x i64> %ext.b, <2 x i32> <i32 0, i32 2>
+  %l = load <2 x i32>, ptr %p, align 4
+  %ext.l = zext <2 x i32> %l to <2 x i64>
+  %prod = mul nuw <2 x i64> %broadcast.splat, %ext.l
+  %out = trunc <2 x i64> %prod to <2 x i32>
+  ret <2 x i32> %out
+}
+
+define <8 x i8> @dupzext_vector_v8i8_v8i16_trunc(<8 x i8> %a, ptr %p) {
+; CHECK-SD-LABEL: dupzext_vector_v8i8_v8i16_trunc:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    ldr d1, [x0]
+; CHECK-SD-NEXT:    ushll v0.8h, v0.8b, #0
+; CHECK-SD-NEXT:    ushll v1.8h, v1.8b, #0
+; CHECK-SD-NEXT:    mul v0.8h, v1.8h, v0.h[0]
+; CHECK-SD-NEXT:    xtn v0.8b, v0.8h
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: dupzext_vector_v8i8_v8i16_trunc:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    ushll v0.8h, v0.8b, #0
+; CHECK-GI-NEXT:    ldr d1, [x0]
+; CHECK-GI-NEXT:    dup v0.8h, v0.h[0]
+; CHECK-GI-NEXT:    xtn v0.8b, v0.8h
+; CHECK-GI-NEXT:    umull v0.8h, v1.8b, v0.8b
+; CHECK-GI-NEXT:    xtn v0.8b, v0.8h
+; CHECK-GI-NEXT:    ret
+entry:
+  %ext.a = zext <8 x i8> %a to <8 x i16>
+  %broadcast.splat = shufflevector <8 x i16> %ext.a, <8 x i16> poison, <8 x i32> zeroinitializer
+  %l = load <8 x i8>, ptr %p, align 4
+  %ext.l = zext <8 x i8> %l to <8 x i16>
+  %prod = mul <8 x i16> %ext.l, %broadcast.splat
+  %out = trunc <8 x i16> %prod to <8 x i8>
+  ret <8 x i8> %out
+}
+
+define <8 x i8> @shufflezext_v8i8_v8i16_trunc(<8 x i8> %a, <8 x i8> %b, ptr %p) {
+; CHECK-SD-LABEL: shufflezext_v8i8_v8i16_trunc:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    zip1 v1.8b, v1.8b, v1.8b
+; CHECK-SD-NEXT:    zip1 v0.8b, v0.8b, v0.8b
+; CHECK-SD-NEXT:    ldr d2, [x0]
+; CHECK-SD-NEXT:    mov v0.d[1], v1.d[0]
+; CHECK-SD-NEXT:    ushll v1.8h, v2.8b, #0
+; CHECK-SD-NEXT:    mul v0.8h, v1.8h, v0.8h
+; CHECK-SD-NEXT:    xtn v0.8b, v0.8h
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: shufflezext_v8i8_v8i16_trunc:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    ushll v2.8h, v0.8b, #0
+; CHECK-GI-NEXT:    adrp x8, .LCPI10_0
+; CHECK-GI-NEXT:    ushll v3.8h, v1.8b, #0
+; CHECK-GI-NEXT:    ldr q0, [x8, :lo12:.LCPI10_0]
+; CHECK-GI-NEXT:    ldr d1, [x0]
+; CHECK-GI-NEXT:    tbl v0.16b, { v2.16b, v3.16b }, v0.16b
+; CHECK-GI-NEXT:    xtn v0.8b, v0.8h
+; CHECK-GI-NEXT:    umull v0.8h, v1.8b, v0.8b
+; CHECK-GI-NEXT:    xtn v0.8b, v0.8h
+; CHECK-GI-NEXT:    ret
+entry:
+  %ext.a = zext <8 x i8> %a to <8 x i16>
+  %ext.b = zext <8 x i8> %b to <8 x i16>
+  %broadcast.splat = shufflevector <8 x i16> %ext.a, <8 x i16> %ext.b, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 8, i32 9, i32 10, i32 11>
+  %l = load <8 x i8>, ptr %p, align 4
+  %ext.l = zext <8 x i8> %l to <8 x i16>
+  %prod = mul nuw <8 x i16> %ext.l, %broadcast.splat
+  %out = trunc <8 x i16> %prod to <8 x i8>
+  ret <8 x i8> %out
+}
+
 ; Unsupported combines
 
 define <2 x i16> @dupsext_v2i8_v2i16(i8 %src, <2 x i8> %b) {

--- a/llvm/test/CodeGen/AArch64/aarch64-dup-ext.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-dup-ext.ll
@@ -174,17 +174,8 @@ define <2 x i32> @dupzext_vector_v2i32_v2i64_trunc(<2 x i32> %a, ptr %p) {
 ; CHECK-SD-LABEL: dupzext_vector_v2i32_v2i64_trunc:
 ; CHECK-SD:       // %bb.0: // %entry
 ; CHECK-SD-NEXT:    ldr d1, [x0]
-; CHECK-SD-NEXT:    ushll v0.2d, v0.2s, #0
-; CHECK-SD-NEXT:    ushll v1.2d, v1.2s, #0
-; CHECK-SD-NEXT:    dup v2.2d, v0.d[0]
-; CHECK-SD-NEXT:    fmov w10, s0
-; CHECK-SD-NEXT:    fmov w11, s1
-; CHECK-SD-NEXT:    mov w8, v1.s[2]
-; CHECK-SD-NEXT:    mov w9, v2.s[2]
-; CHECK-SD-NEXT:    mul w10, w10, w11
-; CHECK-SD-NEXT:    mul w8, w9, w8
-; CHECK-SD-NEXT:    fmov d0, x10
-; CHECK-SD-NEXT:    mov v0.d[1], x8
+; CHECK-SD-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-SD-NEXT:    smull v0.2d, v1.2s, v0.s[0]
 ; CHECK-SD-NEXT:    xtn v0.2s, v0.2d
 ; CHECK-SD-NEXT:    ret
 ;
@@ -210,19 +201,9 @@ entry:
 define <2 x i32> @shufflezext_vector_v2i32_v2i64_trunc(<2 x i32> %a, <2 x i32> %b, ptr %p) {
 ; CHECK-SD-LABEL: shufflezext_vector_v2i32_v2i64_trunc:
 ; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ushll v0.2d, v0.2s, #0
-; CHECK-SD-NEXT:    ushll v1.2d, v1.2s, #0
-; CHECK-SD-NEXT:    ldr d2, [x0]
-; CHECK-SD-NEXT:    ushll v2.2d, v2.2s, #0
-; CHECK-SD-NEXT:    zip1 v1.2d, v0.2d, v1.2d
-; CHECK-SD-NEXT:    fmov w10, s0
-; CHECK-SD-NEXT:    fmov w11, s2
-; CHECK-SD-NEXT:    mov w9, v2.s[2]
-; CHECK-SD-NEXT:    mov w8, v1.s[2]
-; CHECK-SD-NEXT:    mul w10, w10, w11
-; CHECK-SD-NEXT:    mul w8, w8, w9
-; CHECK-SD-NEXT:    fmov d0, x10
-; CHECK-SD-NEXT:    mov v0.d[1], x8
+; CHECK-SD-NEXT:    zip1 v0.2s, v0.2s, v1.2s
+; CHECK-SD-NEXT:    ldr d1, [x0]
+; CHECK-SD-NEXT:    smull v0.2d, v0.2s, v1.2s
 ; CHECK-SD-NEXT:    xtn v0.2s, v0.2d
 ; CHECK-SD-NEXT:    ret
 ;
@@ -250,10 +231,10 @@ entry:
 define <8 x i8> @dupzext_vector_v8i8_v8i16_trunc(<8 x i8> %a, ptr %p) {
 ; CHECK-SD-LABEL: dupzext_vector_v8i8_v8i16_trunc:
 ; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    // kill: def $d0 killed $d0 def $q0
 ; CHECK-SD-NEXT:    ldr d1, [x0]
-; CHECK-SD-NEXT:    ushll v0.8h, v0.8b, #0
-; CHECK-SD-NEXT:    ushll v1.8h, v1.8b, #0
-; CHECK-SD-NEXT:    mul v0.8h, v1.8h, v0.h[0]
+; CHECK-SD-NEXT:    dup v0.8b, v0.b[0]
+; CHECK-SD-NEXT:    smull v0.8h, v1.8b, v0.8b
 ; CHECK-SD-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-SD-NEXT:    ret
 ;
@@ -279,12 +260,9 @@ entry:
 define <8 x i8> @shufflezext_v8i8_v8i16_trunc(<8 x i8> %a, <8 x i8> %b, ptr %p) {
 ; CHECK-SD-LABEL: shufflezext_v8i8_v8i16_trunc:
 ; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    zip1 v1.8b, v1.8b, v1.8b
-; CHECK-SD-NEXT:    zip1 v0.8b, v0.8b, v0.8b
-; CHECK-SD-NEXT:    ldr d2, [x0]
-; CHECK-SD-NEXT:    mov v0.d[1], v1.d[0]
-; CHECK-SD-NEXT:    ushll v1.8h, v2.8b, #0
-; CHECK-SD-NEXT:    mul v0.8h, v1.8h, v0.8h
+; CHECK-SD-NEXT:    zip1 v0.2s, v0.2s, v1.2s
+; CHECK-SD-NEXT:    ldr d1, [x0]
+; CHECK-SD-NEXT:    smull v0.8h, v1.8b, v0.8b
 ; CHECK-SD-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-SD-NEXT:    ret
 ;


### PR DESCRIPTION
    Currently performBuildShuffleExtendCombine only supports ANY_EXTEND
    operands for BUILD_VECTOR inputs, and will bail if it encounters a
    VECTOR_SHUFFLE with ANY_EXTEND operands. Update the logic so that we
    support shuffles with ANY_EXTEND operands, which brings the code in line
    with the comment.
