### PR TITLE
[CodeGen] Add OffloadBlockUniformityAnalysis for offload PGO

### DIFF
--- a/llvm/include/llvm/CodeGen/BlockUniformityProfile.h
+++ b/llvm/include/llvm/CodeGen/BlockUniformityProfile.h
@@ -1,0 +1,79 @@
+//===- BlockUniformityProfile.h - Block uniformity from PGO -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Provide per-(Machine)basic-block uniformity information from PGO profiles.
+//
+// The source of truth is IR metadata attached during PGO use:
+//   - Metadata name: "block.uniformity.profile"
+//   - Payload: i1 (true = uniform, false = divergent)
+//
+// This is intentionally target-agnostic: any backend that produces
+// uniformity bits in the profile can attach the same metadata and reuse this
+// proxy in codegen.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CODEGEN_BLOCKUNIFORMITYPROFILE_H
+#define LLVM_CODEGEN_BLOCKUNIFORMITYPROFILE_H
+
+#include "llvm/ADT/BitVector.h"
+#include "llvm/CodeGen/MachineFunctionAnalysis.h"
+#include "llvm/CodeGen/MachineFunctionAnalysisManager.h"
+#include "llvm/CodeGen/MachinePassManager.h"
+#include "llvm/Support/Compiler.h"
+
+namespace llvm {
+
+class MachineBasicBlock;
+class MachineFunction;
+class raw_ostream;
+
+class BlockUniformityProfile {
+public:
+  LLVM_ABI void compute(const MachineFunction &MF);
+
+  bool hasProfile() const { return HasProfile; }
+
+  // Returns true if the block is considered divergent. If profile exists for
+  // the function but a block has no explicit annotation, it is treated as
+  // divergent (conservative).
+  LLVM_ABI bool isDivergent(const MachineBasicBlock &MBB) const;
+
+  LLVM_ABI void print(raw_ostream &OS, const MachineFunction &MF) const;
+
+private:
+  bool HasProfile = false;
+  unsigned NumBlockIDs = 0;
+  BitVector DivergentBlocks;
+};
+
+class BlockUniformityProfileProxy
+    : public AnalysisInfoMixin<BlockUniformityProfileProxy> {
+  friend AnalysisInfoMixin<BlockUniformityProfileProxy>;
+  static AnalysisKey Key;
+
+public:
+  using Result = BlockUniformityProfile;
+  LLVM_ABI Result run(MachineFunction &MF,
+                      MachineFunctionAnalysisManager &MFAM);
+};
+
+class BlockUniformityProfilePrinterPass
+    : public PassInfoMixin<BlockUniformityProfilePrinterPass> {
+  raw_ostream &OS;
+
+public:
+  explicit BlockUniformityProfilePrinterPass(raw_ostream &OS) : OS(OS) {}
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
+                                 MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
+};
+
+} // end namespace llvm
+
+#endif // LLVM_CODEGEN_BLOCKUNIFORMITYPROFILE_H

--- a/llvm/include/llvm/CodeGen/BlockUniformityProfile.h
+++ b/llvm/include/llvm/CodeGen/BlockUniformityProfile.h
@@ -10,7 +10,7 @@
 //
 // The source of truth is IR metadata attached during PGO use:
 //   - Metadata name: "block.uniformity.profile"
-//   - Payload: i1 (true = uniform, false = divergent)
+//   - Presence means the block is uniform.
 //
 // This is intentionally target-agnostic: any backend that produces
 // uniformity bits in the profile can attach the same metadata and reuse this
@@ -25,6 +25,7 @@
 #include "llvm/CodeGen/MachineFunctionAnalysis.h"
 #include "llvm/CodeGen/MachineFunctionAnalysisManager.h"
 #include "llvm/CodeGen/MachinePassManager.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Support/Compiler.h"
 
 namespace llvm {
@@ -64,14 +65,13 @@ public:
 };
 
 class BlockUniformityProfilePrinterPass
-    : public PassInfoMixin<BlockUniformityProfilePrinterPass> {
+    : public RequiredPassInfoMixin<BlockUniformityProfilePrinterPass> {
   raw_ostream &OS;
 
 public:
   explicit BlockUniformityProfilePrinterPass(raw_ostream &OS) : OS(OS) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                                  MachineFunctionAnalysisManager &MFAM);
-  static bool isRequired() { return true; }
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/SpillPlacement.h
+++ b/llvm/include/llvm/CodeGen/SpillPlacement.h
@@ -36,6 +36,7 @@
 namespace llvm {
 
 class BitVector;
+class BlockUniformityProfile;
 class EdgeBundles;
 class MachineBlockFrequencyInfo;
 class MachineFunction;
@@ -169,7 +170,8 @@ private:
   LLVM_ABI void releaseMemory();
 
   void run(MachineFunction &MF, EdgeBundles *Bundles,
-           MachineBlockFrequencyInfo *MBFI);
+           MachineBlockFrequencyInfo *MBFI,
+           const BlockUniformityProfile *Profile);
   void activate(unsigned n);
   void setThreshold(BlockFrequency Entry);
 

--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -26,6 +26,8 @@
 // LiveVariables can be removed completely, and LiveIntervals can be directly
 // computed. (We still either need to regenerate kill flags after regalloc, or
 // preferably fix the scavenger to not depend on them).
+MACHINE_FUNCTION_ANALYSIS("block-uniformity-profile",
+                          BlockUniformityProfileProxy())
 MACHINE_FUNCTION_ANALYSIS("edge-bundles", EdgeBundlesAnalysis())
 MACHINE_FUNCTION_ANALYSIS("gisel-cse-analysis", GISelCSEAnalysis(TM))
 MACHINE_FUNCTION_ANALYSIS("gisel-value-tracking", GISelValueTrackingAnalysis())
@@ -110,6 +112,8 @@ MACHINE_FUNCTION_PASS("postra-machine-sink", PostRAMachineSinkingPass())
 MACHINE_FUNCTION_PASS("postmisched", PostMachineSchedulerPass(TM))
 MACHINE_FUNCTION_PASS("post-ra-pseudos", ExpandPostRAPseudosPass())
 MACHINE_FUNCTION_PASS("print", PrintMIRPass())
+MACHINE_FUNCTION_PASS("print<block-uniformity-profile>",
+                      BlockUniformityProfilePrinterPass(errs()))
 MACHINE_FUNCTION_PASS("print<gisel-value-tracking>", GISelValueTrackingPrinterPass(errs()))
 MACHINE_FUNCTION_PASS("print<livedebugvars>", LiveDebugVariablesPrinterPass(errs()))
 MACHINE_FUNCTION_PASS("print<live-intervals>", LiveIntervalsPrinterPass(errs()))

--- a/llvm/lib/CodeGen/BlockUniformityProfile.cpp
+++ b/llvm/lib/CodeGen/BlockUniformityProfile.cpp
@@ -1,0 +1,121 @@
+//===- BlockUniformityProfile.cpp - Block uniformity from PGO -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CodeGen/BlockUniformityProfile.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/Support/raw_ostream.h"
+#include <optional>
+
+using namespace llvm;
+
+static std::optional<bool> getIRBlockUniformity(const BasicBlock &BB) {
+  const Instruction *TI = BB.getTerminator();
+  if (!TI)
+    return std::nullopt;
+
+  MDNode *MD = TI->getMetadata(LLVMContext::MD_block_uniformity_profile);
+  if (!MD)
+    return std::nullopt;
+
+  // Metadata format: !{i1 IsUniform} - structural validity assumed (verifier).
+  // Returns true if uniform (not divergent).
+  return mdconst::extract<ConstantInt>(MD->getOperand(0))->isOne();
+}
+
+void BlockUniformityProfile::compute(const MachineFunction &MF) {
+  HasProfile = false;
+  NumBlockIDs = MF.getNumBlockIDs();
+  DivergentBlocks.clear();
+  DivergentBlocks.resize(NumBlockIDs);
+
+  // First determine whether any uniformity profile exists for this function.
+  for (const MachineBasicBlock &MBB : MF) {
+    const BasicBlock *BB = MBB.getBasicBlock();
+    if (!BB)
+      continue;
+    if (getIRBlockUniformity(*BB).has_value()) {
+      HasProfile = true;
+      break;
+    }
+  }
+
+  if (!HasProfile)
+    return;
+
+  // Conservative behavior: if profile exists for the function but we
+  // cannot classify a particular (Machine)basic block, treat it as divergent.
+  for (const MachineBasicBlock &MBB : MF) {
+    const unsigned Num = MBB.getNumber();
+    bool IsDivergent = true;
+    if (const BasicBlock *BB = MBB.getBasicBlock()) {
+      if (auto U = getIRBlockUniformity(*BB))
+        IsDivergent = !*U; // Metadata stores IsUniform, we want IsDivergent
+    }
+    if (Num < DivergentBlocks.size() && IsDivergent)
+      DivergentBlocks.set(Num);
+  }
+}
+
+void BlockUniformityProfile::print(raw_ostream &OS,
+                                   const MachineFunction &MF) const {
+  OS << "BlockUniformityProfile for function: ";
+  MF.getFunction().printAsOperand(OS, /*PrintType=*/false);
+  OS << '\n';
+  OS << "HasProfile: " << (HasProfile ? "true" : "false") << '\n';
+  if (!HasProfile)
+    return;
+
+  for (const MachineBasicBlock &MBB : MF) {
+    const BasicBlock *BB = MBB.getBasicBlock();
+    if (!BB)
+      continue;
+    OS << "  " << printMBBReference(MBB);
+    if (BB->hasName())
+      OS << " (%" << BB->getName() << ")";
+    if (auto U = getIRBlockUniformity(*BB)) {
+      OS << ": " << (*U ? "uniform" : "divergent") << '\n';
+      continue;
+    }
+    OS << ": no PGO annotation (treated divergent for spill placement)\n";
+  }
+}
+
+bool BlockUniformityProfile::isDivergent(const MachineBasicBlock &MBB) const {
+  if (!HasProfile)
+    return false;
+  assert(MBB.getParent()->getNumBlockIDs() == NumBlockIDs &&
+         "MachineFunction was modified without invalidating "
+         "BlockUniformityProfile");
+  const unsigned Num = MBB.getNumber();
+  assert(Num < DivergentBlocks.size() && "Block number out of range");
+  return DivergentBlocks.test(Num);
+}
+
+AnalysisKey BlockUniformityProfileProxy::Key;
+
+BlockUniformityProfileProxy::Result
+BlockUniformityProfileProxy::run(MachineFunction &MF,
+                                 MachineFunctionAnalysisManager &) {
+  BlockUniformityProfile Profile;
+  Profile.compute(MF);
+  return Profile;
+}
+
+PreservedAnalyses
+BlockUniformityProfilePrinterPass::run(MachineFunction &MF,
+                                       MachineFunctionAnalysisManager &MFAM) {
+  auto &Profile = MFAM.getResult<BlockUniformityProfileProxy>(MF);
+  Profile.print(OS, MF);
+  return PreservedAnalyses::all();
+}

--- a/llvm/lib/CodeGen/BlockUniformityProfile.cpp
+++ b/llvm/lib/CodeGen/BlockUniformityProfile.cpp
@@ -10,27 +10,16 @@
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/IR/BasicBlock.h"
-#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/Metadata.h"
 #include "llvm/Support/raw_ostream.h"
-#include <optional>
 
 using namespace llvm;
 
-static std::optional<bool> getIRBlockUniformity(const BasicBlock &BB) {
-  const Instruction *TI = BB.getTerminator();
-  if (!TI)
-    return std::nullopt;
-
-  MDNode *MD = TI->getMetadata(LLVMContext::MD_block_uniformity_profile);
-  if (!MD)
-    return std::nullopt;
-
-  // Metadata format: !{i1 IsUniform} - structural validity assumed (verifier).
-  // Returns true if uniform (not divergent).
-  return mdconst::extract<ConstantInt>(MD->getOperand(0))->isOne();
+static bool hasIRBlockUniformityProfile(const BasicBlock &BB) {
+  return BB.getTerminator()->getMetadata(
+      LLVMContext::MD_block_uniformity_profile);
 }
 
 void BlockUniformityProfile::compute(const MachineFunction &MF) {
@@ -39,30 +28,18 @@ void BlockUniformityProfile::compute(const MachineFunction &MF) {
   DivergentBlocks.clear();
   DivergentBlocks.resize(NumBlockIDs);
 
-  // First determine whether any uniformity profile exists for this function.
-  for (const MachineBasicBlock &MBB : MF) {
-    const BasicBlock *BB = MBB.getBasicBlock();
-    if (!BB)
-      continue;
-    if (getIRBlockUniformity(*BB).has_value()) {
-      HasProfile = true;
-      break;
-    }
-  }
-
-  if (!HasProfile)
-    return;
-
   // Conservative behavior: if profile exists for the function but we
   // cannot classify a particular (Machine)basic block, treat it as divergent.
   for (const MachineBasicBlock &MBB : MF) {
     const unsigned Num = MBB.getNumber();
-    bool IsDivergent = true;
+    bool IsUniform = false;
     if (const BasicBlock *BB = MBB.getBasicBlock()) {
-      if (auto U = getIRBlockUniformity(*BB))
-        IsDivergent = !*U; // Metadata stores IsUniform, we want IsDivergent
+      IsUniform = hasIRBlockUniformityProfile(*BB);
     }
-    if (Num < DivergentBlocks.size() && IsDivergent)
+    if (IsUniform)
+      HasProfile = true;
+
+    if (Num < DivergentBlocks.size() && !IsUniform)
       DivergentBlocks.set(Num);
   }
 }
@@ -83,8 +60,8 @@ void BlockUniformityProfile::print(raw_ostream &OS,
     OS << "  " << printMBBReference(MBB);
     if (BB->hasName())
       OS << " (%" << BB->getName() << ")";
-    if (auto U = getIRBlockUniformity(*BB)) {
-      OS << ": " << (*U ? "uniform" : "divergent") << '\n';
+    if (hasIRBlockUniformityProfile(*BB)) {
+      OS << ": uniform\n";
       continue;
     }
     OS << ": no PGO annotation (treated divergent for spill placement)\n";

--- a/llvm/lib/CodeGen/CMakeLists.txt
+++ b/llvm/lib/CodeGen/CMakeLists.txt
@@ -47,6 +47,7 @@ add_llvm_component_library(LLVMCodeGen
   BasicBlockPathCloning.cpp
   BasicBlockSectionsProfileReader.cpp
   BasicBlockMatchingAndInference.cpp
+  BlockUniformityProfile.cpp
   CalcSpillWeights.cpp
   CallingConvLower.cpp
   CFGuardLongjmp.cpp

--- a/llvm/lib/Passes/CodeGenPassBuilder.cpp
+++ b/llvm/lib/Passes/CodeGenPassBuilder.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Analysis/TypeBasedAliasAnalysis.h"
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "llvm/CodeGen/AsmPrinterAnalysis.h"
+#include "llvm/CodeGen/BlockUniformityProfile.h"
 #include "llvm/CodeGen/BranchFoldingPass.h"
 #include "llvm/CodeGen/CodeGenPrepare.h"
 #include "llvm/CodeGen/DeadMachineInstructionElim.h"

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -84,6 +84,7 @@
 #include "llvm/CodeGen/AssignmentTrackingAnalysis.h"
 #include "llvm/CodeGen/AtomicExpand.h"
 #include "llvm/CodeGen/BasicBlockSectionsProfileReader.h"
+#include "llvm/CodeGen/BlockUniformityProfile.h"
 #include "llvm/CodeGen/BranchFoldingPass.h"
 #include "llvm/CodeGen/BranchRelaxation.h"
 #include "llvm/CodeGen/BreakFalseDeps.h"

--- a/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp
@@ -1791,25 +1791,20 @@ void PGOUseFunc::setBlockUniformityAttribute() {
   // Annotate uniformity on each instrumented IR basic block so later codegen
   // passes (MachineFunction) can consume it without relying on fragile block
   // numbering heuristics.
-  //
-  // Metadata kind: LLVMContext::MD_block_uniformity_profile
-  // Payload: i1 (true = uniform, false = divergent)
+  // Metadata presence means uniform; divergent blocks have no metadata.
 
   std::vector<BasicBlock *> InstrumentBBs;
   FuncInfo.getInstrumentBBs(InstrumentBBs);
 
   LLVMContext &Ctx = F.getContext();
-  Type *Int1Ty = Type::getInt1Ty(Ctx);
-
   for (size_t I = 0, E = InstrumentBBs.size(); I < E; ++I) {
     BasicBlock *BB = InstrumentBBs[I];
     if (!BB || !BB->getTerminator())
       continue;
-    bool IsUniform = ProfileRecord.isBlockUniform(I);
-    auto *MD = MDNode::get(
-        Ctx, ConstantAsMetadata::get(ConstantInt::get(Int1Ty, IsUniform)));
+    if (!ProfileRecord.isBlockUniform(I))
+      continue;
     BB->getTerminator()->setMetadata(LLVMContext::MD_block_uniformity_profile,
-                                     MD);
+                                     MDNode::get(Ctx, {}));
   }
 
   LLVM_DEBUG({

--- a/llvm/test/Bitcode/block-uniformity-profile-metadata.ll
+++ b/llvm/test/Bitcode/block-uniformity-profile-metadata.ll
@@ -11,11 +11,9 @@ uniform:
   ret void
 
 divergent:
-  br label %uniform, !block.uniformity.profile !1
-; CHECK: br label %uniform, !block.uniformity.profile !1
+  br label %uniform, !block.uniformity.profile !0
+; CHECK: br label %uniform, !block.uniformity.profile !0
 }
 
-; CHECK: !0 = !{i1 true}
-; CHECK: !1 = !{i1 false}
-!0 = !{i1 true}
-!1 = !{i1 false}
+; CHECK: !0 = !{}
+!0 = !{}

--- a/llvm/test/CodeGen/AMDGPU/block-uniformity-profile.ll
+++ b/llvm/test/CodeGen/AMDGPU/block-uniformity-profile.ll
@@ -1,0 +1,79 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -O0 -stop-after=finalize-isel -o - %s | \
+; RUN:   llc -mtriple=amdgcn-amd-amdhsa -passes='print<block-uniformity-profile>' -x mir -filetype=null 2>&1 | FileCheck %s
+
+; Test that BlockUniformityProfileProxy correctly reads block.uniformity.profile
+; metadata from IR basic blocks and classifies machine blocks.
+;
+; This metadata is attached during PGO-use phase to indicate whether a basic block
+; was executed uniformly (all lanes together) or divergently (partial wave).
+;
+; The analysis is consumed by SpillPlacement to flatten block frequencies for
+; divergent blocks, preventing PGO from causing regressions on divergent code paths.
+
+; CHECK-LABEL: BlockUniformityProfile for function: @uniform_blocks
+; CHECK-NEXT: HasProfile: true
+; CHECK: %bb.{{[0-9]+}} (%entry): uniform
+define amdgpu_kernel void @uniform_blocks(ptr addrspace(1) %out) #0 {
+entry:
+  store i32 1, ptr addrspace(1) %out, align 4
+  ret void, !block.uniformity.profile !0
+}
+
+; CHECK-LABEL: BlockUniformityProfile for function: @divergent_blocks
+; CHECK-NEXT: HasProfile: true
+; CHECK-DAG: %bb.{{[0-9]+}} (%if.then): divergent
+; CHECK-DAG: %bb.{{[0-9]+}} (%if.else): uniform
+define amdgpu_kernel void @divergent_blocks(ptr addrspace(1) %out, i32 %tid) #0 {
+entry:
+  %cmp = icmp eq i32 %tid, 0
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:
+  store i32 1, ptr addrspace(1) %out, align 4
+  ret void, !block.uniformity.profile !1
+
+if.else:
+  store i32 2, ptr addrspace(1) %out, align 4
+  ret void, !block.uniformity.profile !0
+}
+
+; CHECK-LABEL: BlockUniformityProfile for function: @missing_metadata
+; CHECK-NEXT: HasProfile: true
+; CHECK-DAG: %bb.{{[0-9]+}} (%if.then): no PGO annotation (treated divergent for spill placement)
+; CHECK-DAG: %bb.{{[0-9]+}} (%if.else): uniform
+define amdgpu_kernel void @missing_metadata(ptr addrspace(1) %out, i32 %cond) #0 {
+entry:
+  %cmp = icmp sgt i32 %cond, 0
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:
+  store i32 1, ptr addrspace(1) %out, align 4
+  ret void
+
+if.else:
+  store i32 2, ptr addrspace(1) %out, align 4
+  ret void, !block.uniformity.profile !0
+}
+
+; CHECK-LABEL: BlockUniformityProfile for function: @no_divergence_metadata
+; CHECK-NEXT: HasProfile: false
+define amdgpu_kernel void @no_divergence_metadata(ptr addrspace(1) %out, i32 %cond) #0 {
+entry:
+  ; No uniformity metadata - analysis should report hasProfile() = false
+  %cmp = icmp sgt i32 %cond, 0
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:
+  store i32 1, ptr addrspace(1) %out, align 4
+  ret void
+
+if.else:
+  store i32 2, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+attributes #0 = { "amdgpu-flat-work-group-size"="1,256" }
+
+; Metadata: i1 true = uniform, i1 false = divergent
+!0 = !{i1 true}   ; uniform
+!1 = !{i1 false}  ; divergent

--- a/llvm/test/CodeGen/AMDGPU/block-uniformity-profile.ll
+++ b/llvm/test/CodeGen/AMDGPU/block-uniformity-profile.ll
@@ -5,7 +5,8 @@
 ; metadata from IR basic blocks and classifies machine blocks.
 ;
 ; This metadata is attached during PGO-use phase to indicate whether a basic block
-; was executed uniformly (all lanes together) or divergently (partial wave).
+; was executed uniformly (all lanes together). Missing metadata in a profiled
+; function is conservatively treated as divergent.
 ;
 ; The analysis is consumed by SpillPlacement to flatten block frequencies for
 ; divergent blocks, preventing PGO from causing regressions on divergent code paths.
@@ -21,7 +22,7 @@ entry:
 
 ; CHECK-LABEL: BlockUniformityProfile for function: @divergent_blocks
 ; CHECK-NEXT: HasProfile: true
-; CHECK-DAG: %bb.{{[0-9]+}} (%if.then): divergent
+; CHECK-DAG: %bb.{{[0-9]+}} (%if.then): no PGO annotation (treated divergent for spill placement)
 ; CHECK-DAG: %bb.{{[0-9]+}} (%if.else): uniform
 define amdgpu_kernel void @divergent_blocks(ptr addrspace(1) %out, i32 %tid) #0 {
 entry:
@@ -30,7 +31,7 @@ entry:
 
 if.then:
   store i32 1, ptr addrspace(1) %out, align 4
-  ret void, !block.uniformity.profile !1
+  ret void
 
 if.else:
   store i32 2, ptr addrspace(1) %out, align 4
@@ -55,6 +56,29 @@ if.else:
   ret void, !block.uniformity.profile !0
 }
 
+; CHECK-LABEL: BlockUniformityProfile for function: @loop_blocks
+; CHECK-NEXT: HasProfile: true
+; CHECK-DAG: %bb.{{[0-9]+}} (%loop.header): no PGO annotation (treated divergent for spill placement)
+; CHECK-DAG: %bb.{{[0-9]+}} (%loop.body): no PGO annotation (treated divergent for spill placement)
+; CHECK-DAG: %bb.{{[0-9]+}} (%exit): uniform
+define amdgpu_kernel void @loop_blocks(ptr addrspace(1) %out, i32 %n) #0 {
+entry:
+  br label %loop.header
+
+loop.header:
+  %i = phi i32 [ 0, %entry ], [ %inc, %loop.body ]
+  %cmp = icmp slt i32 %i, %n
+  br i1 %cmp, label %loop.body, label %exit
+
+loop.body:
+  store i32 %i, ptr addrspace(1) %out, align 4
+  %inc = add nuw nsw i32 %i, 1
+  br label %loop.header
+
+exit:
+  ret void, !block.uniformity.profile !0
+}
+
 ; CHECK-LABEL: BlockUniformityProfile for function: @no_divergence_metadata
 ; CHECK-NEXT: HasProfile: false
 define amdgpu_kernel void @no_divergence_metadata(ptr addrspace(1) %out, i32 %cond) #0 {
@@ -74,6 +98,5 @@ if.else:
 
 attributes #0 = { "amdgpu-flat-work-group-size"="1,256" }
 
-; Metadata: i1 true = uniform, i1 false = divergent
-!0 = !{i1 true}   ; uniform
-!1 = !{i1 false}  ; divergent
+; Metadata presence means uniform.
+!0 = !{}

--- a/llvm/unittests/Transforms/Instrumentation/PGOInstrumentationTest.cpp
+++ b/llvm/unittests/Transforms/Instrumentation/PGOInstrumentationTest.cpp
@@ -8,9 +8,13 @@
 
 #include "llvm/Transforms/Instrumentation/PGOInstrumentation.h"
 #include "llvm/AsmParser/Parser.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/ProfileData/InstrProf.h"
+#include "llvm/ProfileData/InstrProfWriter.h"
+#include "llvm/Testing/Support/Error.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -185,6 +189,107 @@ TEST_P(PGOInstrumentationGenTest, Instrumented) {
       M->getNamedGlobal(INSTR_PROF_QUOTE(INSTR_PROF_RAW_VERSION_VAR));
   EXPECT_THAT(IRInstrVar, NotNull());
   EXPECT_FALSE(IRInstrVar->isDeclaration());
+}
+
+TEST(PGOInstrumentationUseTest, BlockUniformityMetadataUsesPresence) {
+  static constexpr StringRef Code = R"(
+    define i32 @f(i1 %cond) {
+    entry:
+      br i1 %cond, label %then, label %else
+    then:
+      ret i32 1
+    else:
+      ret i32 0
+    })";
+
+  LLVMContext Context;
+  SMDiagnostic ParseError;
+  auto GenModule = parseAssemblyString(Code, ParseError, Context);
+  ASSERT_THAT(GenModule, NotNull());
+
+  PassBuilder PB;
+  LoopAnalysisManager LAM;
+  FunctionAnalysisManager FAM;
+  CGSCCAnalysisManager CGAM;
+  ModuleAnalysisManager MAM;
+  PB.registerModuleAnalyses(MAM);
+  PB.registerCGSCCAnalyses(CGAM);
+  PB.registerFunctionAnalyses(FAM);
+  PB.registerLoopAnalyses(LAM);
+  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+  ModulePassManager GenMPM;
+  GenMPM.addPass(PGOInstrumentationGen());
+  GenMPM.run(*GenModule, MAM);
+
+  Function *GenFunction = GenModule->getFunction("f");
+  ASSERT_THAT(GenFunction, NotNull());
+
+  uint64_t FunctionHash = 0;
+  unsigned NumCounters = 0;
+  std::vector<std::string> BlockNames;
+  for (Instruction &I : instructions(*GenFunction)) {
+    auto *Counter = dyn_cast<InstrProfCntrInstBase>(&I);
+    if (!Counter)
+      continue;
+
+    if (BlockNames.empty()) {
+      FunctionHash = Counter->getHash()->getZExtValue();
+      NumCounters = Counter->getNumCounters()->getZExtValue();
+      BlockNames.resize(NumCounters);
+    }
+
+    unsigned Index = Counter->getIndex()->getZExtValue();
+    ASSERT_LT(Index, NumCounters);
+    BlockNames[Index] = I.getParent()->getName().str();
+  }
+
+  ASSERT_GE(NumCounters, 2u);
+  for (const std::string &BlockName : BlockNames)
+    ASSERT_FALSE(BlockName.empty());
+
+  std::vector<uint8_t> UniformityBits((NumCounters + 7) / 8, 0);
+  UniformityBits[0] = 1;
+  std::string ProfileName = getIRPGOFuncName(*GenFunction);
+  NamedInstrProfRecord Record(ProfileName, FunctionHash,
+                              std::vector<uint64_t>(NumCounters, 10));
+  Record.UniformityBits = std::move(UniformityBits);
+
+  InstrProfWriter Writer;
+  ASSERT_THAT_ERROR(Writer.mergeProfileKind(InstrProfKind::IRInstrumentation),
+                    Succeeded());
+  Writer.addRecord(std::move(Record),
+                   [](Error E) { ADD_FAILURE() << toString(std::move(E)); });
+  auto Profile = Writer.writeBuffer();
+  ASSERT_THAT(Profile, NotNull());
+
+  auto FS = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
+  ASSERT_TRUE(FS->addFile("/profile.profdata", 0, std::move(Profile)));
+
+  auto UseModule = parseAssemblyString(Code, ParseError, Context);
+  ASSERT_THAT(UseModule, NotNull());
+  ModulePassManager UseMPM;
+  UseMPM.addPass(PGOInstrumentationUse("/profile.profdata", "", false, FS));
+  UseMPM.run(*UseModule, MAM);
+
+  Function *UseFunction = UseModule->getFunction("f");
+  ASSERT_THAT(UseFunction, NotNull());
+  for (unsigned I = 0; I < NumCounters; ++I) {
+    BasicBlock *BB = nullptr;
+    for (BasicBlock &Candidate : *UseFunction)
+      if (Candidate.getName() == BlockNames[I])
+        BB = &Candidate;
+    ASSERT_THAT(BB, NotNull());
+
+    MDNode *MD = BB->getTerminator()->getMetadata(
+        LLVMContext::MD_block_uniformity_profile);
+    if (I == 0) {
+      ASSERT_THAT(MD, NotNull());
+      EXPECT_EQ(MD->getNumOperands(), 0u);
+    } else {
+      EXPECT_EQ(MD, nullptr);
+    }
+  }
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
Add a target-agnostic MachineFunction analysis that propagates per-block
uniformity information from IR metadata to codegen passes.

The analysis reads "offload-block-uniformity" metadata attached to IR
BasicBlock terminators during PGO-use. This metadata is produced by the
offload PGO infrastructure when profile data includes uniformity bits.

SpillPlacement consumes this analysis to flatten block frequencies for
divergent blocks, preventing PGO-guided spill placement from causing
performance regressions on SIMT architectures where "cold" divergent
paths still execute with partial wave occupancy.

Key components:
- OffloadBlockUniformityInfo: Stores per-MBB divergence classification
- OffloadBlockUniformityAnalysis: MachineFunctionAnalysis wrapper
- SpillPlacement integration: Queries analysis for divergent blocks

This is independent of the core offload PGO infrastructure - if no
metadata exists, the analysis reports hasUniformity()=false and
SpillPlacement behaves normally.

Related PR: #177665 (offload PGO infrastructure)