### PR TITLE
[mlir][sparse] Implement missing BufferizableOpInterface methods for NewOp

### DIFF
--- a/mlir/lib/Dialect/SparseTensor/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -112,6 +112,24 @@ struct LoadOpInterface
 struct NewOpInterface
     : public SparseBufferizableOpInterfaceExternalModel<NewOpInterface,
                                                         sparse_tensor::NewOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    // The source tensor is read to create the sparse tensor.
+    return true;
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    // NewOp does not write to the source.
+    return false;
+  }
+
+  AliasingValueList getAliasingValues(Operation *op, OpOperand &opOperand,
+                                      const AnalysisState &state) const {
+    // The result is a newly allocated sparse tensor, not an alias of the input.
+    return {};
+  }
+
   bool resultBufferizesToMemoryWrite(Operation *op, OpResult opResult,
                                      const AnalysisState &state) const {
     // NewOps allocate but do not write.

--- a/mlir/test/Dialect/SparseTensor/one_shot_bufferize_tensor_copy_insertion.mlir
+++ b/mlir/test/Dialect/SparseTensor/one_shot_bufferize_tensor_copy_insertion.mlir
@@ -25,6 +25,15 @@ func.func @sparse_tensor_new(%file: !Filename) -> tensor<20x40xf32, #DCSR> {
   return %0 : tensor<20x40xf32, #DCSR>
 }
 
+// CHECK-LABEL: func @sparse_tensor_new_from_tensor
+// CHECK-FUNC-LABEL: func @sparse_tensor_new_from_tensor
+func.func @sparse_tensor_new_from_tensor(%arg0: tensor<20x40xf32>) -> tensor<20x40xf32, #DCSR> {
+  // CHECK: sparse_tensor.new {{.*}}
+  // CHECK-FUNC: sparse_tensor.new {{.*}}
+  %0 = sparse_tensor.new %arg0 : tensor<20x40xf32> to tensor<20x40xf32, #DCSR>
+  return %0 : tensor<20x40xf32, #DCSR>
+}
+
 // CHECK-LABEL: func @sparse_tensor_convert
 // CHECK-FUNC-LABEL: func @sparse_tensor_convert
 func.func @sparse_tensor_convert() -> tensor<20x40xf32> {


### PR DESCRIPTION
## Summary
Fixes crash when running `--eliminate-empty-tensors` on MLIR modules containing `sparse_tensor.new` with a tensor input.

## Problem
The `sparse_tensor.new` operation was missing the `bufferizesToMemoryRead`, `bufferizesToMemoryWrite`, and `getAliasingValues` methods in its `BufferizableOpInterface` implementation. This caused an `UNREACHABLE` crash with message "bufferizesToMemoryRead not implemented".

## Solution
Implemented the missing methods in `NewOpInterface`:
- `bufferizesToMemoryRead`: returns `true` (reads from source tensor)
- `bufferizesToMemoryWrite`: returns `false` (doesn't write to source)  
- `getAliasingValues`: returns empty (result is new allocation, not an alias)

Also added a test case for `sparse_tensor.new` with tensor input.

Fixes #178419