### PR TITLE
[Clang] Add [[readnone, readonly, writeonly]] parameter attributes

### DIFF
--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -4490,10 +4490,15 @@ public:
   /// not produce the latter.
   class ExtParameterInfo {
     enum {
-      ABIMask = 0x0F,
-      IsConsumed = 0x10,
-      HasPassObjSize = 0x20,
-      IsNoEscape = 0x40,
+      ABIMask = 0x07,
+      IsConsumed = 0x08,
+      HasPassObjSize = 0x10,
+      IsNoEscape = 0x20,
+      PtrAccessMask = 0xC0,
+
+      IsReadNone = 0x40,
+      IsReadOnly = 0x80,
+      IsWriteOnly = 0xC0,
     };
     unsigned char Data = 0;
 
@@ -4534,6 +4539,33 @@ public:
         Copy.Data |= IsNoEscape;
       else
         Copy.Data &= ~IsNoEscape;
+      return Copy;
+    }
+
+    bool isReadNone() const { return (Data & PtrAccessMask) == IsReadNone; }
+    ExtParameterInfo withIsReadNone() const {
+      assert((Data & PtrAccessMask) == 0 &&
+             "Trying to change ptr access that has already been set");
+      ExtParameterInfo Copy = *this;
+      Copy.Data |= IsReadNone;
+      return Copy;
+    }
+
+    bool isReadOnly() const { return (Data & PtrAccessMask) == IsReadOnly; }
+    ExtParameterInfo withIsReadOnly() const {
+      assert((Data & PtrAccessMask) == 0 &&
+             "Trying to change ptr access that has already been set");
+      ExtParameterInfo Copy = *this;
+      Copy.Data |= IsReadOnly;
+      return Copy;
+    }
+
+    bool isWriteOnly() const { return (Data & PtrAccessMask) == IsWriteOnly; }
+    ExtParameterInfo withIsWriteOnly() const {
+      assert((Data & PtrAccessMask) == 0 &&
+             "Trying to change ptr access that has already been set");
+      ExtParameterInfo Copy = *this;
+      Copy.Data |= IsWriteOnly;
       return Copy;
     }
 

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3085,6 +3085,25 @@ def ArmLocallyStreaming : InheritableAttr, TargetSpecificAttr<TargetAArch64> {
   let Documentation = [ArmSmeLocallyStreamingDocs];
 }
 
+def ReadNone : InheritableParamAttr {
+  let Spellings = [Clang<"readnone">];
+  let Subjects = SubjectList<[ParmVar, ImplicitObjectParameter], ErrorDiag>;
+  let Documentation = [Undocumented];
+}
+
+def ReadOnly : InheritableParamAttr {
+  let Spellings = [Clang<"readonly">];
+  let Subjects = SubjectList<[ParmVar, ImplicitObjectParameter], ErrorDiag>;
+  let Documentation = [Undocumented];
+}
+
+def WriteOnly : InheritableParamAttr {
+  let Spellings = [Clang<"writeonly">];
+  let Subjects = SubjectList<[ParmVar, ImplicitObjectParameter], ErrorDiag>;
+  let Documentation = [Undocumented];
+}
+
+def : MutualExclusions<[ReadNone, ReadOnly, WriteOnly]>;
 
 def Pure : InheritableAttr {
   let Spellings = [GCC<"pure">];

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3258,6 +3258,9 @@ def warn_function_attribute_ignored_in_stmt : Warning<
   "use '%0' on statements">,
   InGroup<IgnoredAttributes>;
 
+def err_pointer_reference_attribute : Error<
+  "%0 attribute can only be applied to pointers and references">;
+
 def err_musttail_needs_trivial_args : Error<
   "tail call requires that the return value, all parameters, and any "
   "temporaries created by the expression are trivially destructible">;

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -1917,6 +1917,19 @@ void TypePrinter::printAttributedAfter(const AttributedType *T,
     return;
   }
 
+  if (T->getAttrKind() == attr::ReadNone) {
+    OS <<" [[clang::readnone]]";
+    return;
+  }
+  if (T->getAttrKind() == attr::ReadOnly) {
+    OS <<" [[clang::readonly]]";
+    return;
+  }
+  if (T->getAttrKind() == attr::WriteOnly) {
+    OS <<" [[clang::writeonly]]";
+    return;
+  }
+
   // The printing of the address_space attribute is handled by the qualifier
   // since it is still stored in the qualifier. Return early to prevent printing
   // this twice.

--- a/clang/test/CodeGenCXX/attr-ptr-access.cpp
+++ b/clang/test/CodeGenCXX/attr-ptr-access.cpp
@@ -1,0 +1,38 @@
+// RUN: %clang_cc1 -std=c++23 -emit-llvm -triple x86_64 %s -o - | FileCheck %s
+
+void func1([[clang::readnone]] int*) {
+  // CHECK: @_Z5func1Pi(ptr noundef readnone %0)
+}
+void func2([[clang::readnone]] int&) {
+  // CHECK: @_Z5func2Ri(ptr noundef nonnull readnone align 4 dereferenceable(4) %0)
+}
+
+void func3([[clang::readonly]] int*) {
+  // CHECK: @_Z5func3Pi(ptr noundef readonly %0)
+}
+void func4([[clang::readonly]] int&) {
+  // CHECK: @_Z5func4Ri(ptr noundef nonnull readonly align 4 dereferenceable(4) %0)
+}
+
+void func5([[clang::writeonly]] int*) {
+  // CHECK: @_Z5func5Pi(ptr noundef writeonly %0)
+}
+void func6([[clang::writeonly]] int&) {
+  // CHECK: @_Z5func6Ri(ptr noundef nonnull writeonly align 4 dereferenceable(4) %0)
+}
+
+struct S {
+  void func1() [[clang::readnone]];
+  void func2() [[clang::readonly]];
+  void func3() [[clang::writeonly]];
+};
+
+void S::func1() [[clang::readnone]] {
+  // CHECK: @_ZN1S5func1Ev(ptr noundef nonnull readnone align 1 dereferenceable(1) %this)
+}
+void S::func2() [[clang::readonly]] {
+  // CHECK: @_ZN1S5func2Ev(ptr noundef nonnull readonly align 1 dereferenceable(1) %this)
+}
+void S::func3() [[clang::writeonly]] {
+  // CHECK: @_ZN1S5func3Ev(ptr noundef nonnull writeonly align 1 dereferenceable(1) %this)
+}

--- a/clang/test/CodeGenCXX/attr-ptr-access.ll
+++ b/clang/test/CodeGenCXX/attr-ptr-access.ll
@@ -1,0 +1,60 @@
+; ModuleID = '/home/nikolas/source/clang/clang/test/CodeGenCXX/attr-ptr-access.cpp'
+source_filename = "/home/nikolas/source/clang/clang/test/CodeGenCXX/attr-ptr-access.cpp"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress noinline nounwind optnone
+define dso_local void @_Z5func1Pi(ptr noundef readnone %0) #0 {
+entry:
+  %.addr = alloca ptr, align 8
+  store ptr %0, ptr %.addr, align 8
+  ret void
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone
+define dso_local void @_Z5func2Ri(ptr noundef nonnull readnone align 4 dereferenceable(4) %0) #0 {
+entry:
+  %.addr = alloca ptr, align 8
+  store ptr %0, ptr %.addr, align 8
+  ret void
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone
+define dso_local void @_Z5func3Pi(ptr noundef readonly %0) #0 {
+entry:
+  %.addr = alloca ptr, align 8
+  store ptr %0, ptr %.addr, align 8
+  ret void
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone
+define dso_local void @_Z5func4Ri(ptr noundef nonnull readonly align 4 dereferenceable(4) %0) #0 {
+entry:
+  %.addr = alloca ptr, align 8
+  store ptr %0, ptr %.addr, align 8
+  ret void
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone
+define dso_local void @_Z5func5Pi(ptr noundef writeonly %0) #0 {
+entry:
+  %.addr = alloca ptr, align 8
+  store ptr %0, ptr %.addr, align 8
+  ret void
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone
+define dso_local void @_Z5func6Ri(ptr noundef nonnull writeonly align 4 dereferenceable(4) %0) #0 {
+entry:
+  %.addr = alloca ptr, align 8
+  store ptr %0, ptr %.addr, align 8
+  ret void
+}
+
+attributes #0 = { mustprogress noinline nounwind optnone "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-features"="+cx8,+mmx,+sse,+sse2,+x87" }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 23.0.0git (git@github.com:philnik777/llvm-project.git 4d55fb46624afb17e8bb70b308cf0d0e8a48e6cd)"}

--- a/clang/test/SemaCXX/attr-ptr-access.cpp
+++ b/clang/test/SemaCXX/attr-ptr-access.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -std=c++23 -fsyntax-only -verify %s
+
+[[clang::readnone]] void func_readnone(); // expected-error {{'clang::readnone' attribute only applies to parameters and implicit object parameters}}
+void func_readnone(int [[clang::readnone]]); // expected-error {{'clang::readnone' attribute cannot be applied to types}}
+void func_readnone([[clang::readnone]] int); // expected-error {{'clang::readnone' attribute can only be applied to pointers and references}}
+void func_readnone([[clang::readnone]] int*);
+void func_readnone([[clang::readnone]] int&);
+
+[[clang::readonly]] void func_readonly(); // expected-error {{'clang::readonly' attribute only applies to parameters and implicit object parameters}}
+void func_readonly(int [[clang::readonly]]); // expected-error {{'clang::readonly' attribute cannot be applied to types}}
+void func_readonly([[clang::readonly]] int); // expected-error {{'clang::readonly' attribute can only be applied to pointers and references}}
+void func_readonly([[clang::readonly]] int*);
+void func_readonly([[clang::readonly]] int&);
+
+[[clang::writeonly]] void func_writeonly(); // expected-error {{'clang::writeonly' attribute only applies to parameters and implicit object parameters}}
+void func_writeonly(int [[clang::writeonly]]); // expected-error {{'clang::writeonly' attribute cannot be applied to types}}
+void func_writeonly([[clang::writeonly]] int); // expected-error {{'clang::writeonly' attribute can only be applied to pointers and references}}
+void func_writeonly([[clang::writeonly]] int*);
+void func_writeonly([[clang::writeonly]] int&);
+
+void func_mutex1([[clang::readnone, clang::readonly]] int*); // expected-error {{'clang::readonly' and 'clang::readnone' attributes are not compatible}} expected-note {{here}}
+void func_mutex2([[clang::readnone, clang::writeonly]] int*); // expected-error {{'clang::writeonly' and 'clang::readnone' attributes are not compatible}} expected-note {{here}}
+void func_mutex3([[clang::readonly, clang::writeonly]] int*); // expected-error {{'clang::writeonly' and 'clang::readonly' attributes are not compatible}} expected-note {{here}}
+
+void func_arg_mismatch([[clang::readnone]] int*);
+void func_arg_mismatch([[clang::readnone]] int*); // expected-note {{here}}
+void func_arg_mismatch([[clang::readonly]] int*); // expected-error {{conflicting types for 'func_arg_mismatch'}}
+
+struct S {
+  void func1() [[clang::readnone]];
+  void func2() [[clang::readonly]];
+  void func3() [[clang::writeonly]];
+  void func4() [[clang::readnone, clang::readonly]];
+  void func5() [[clang::readnone, clang::writeonly]];
+  void func6() [[clang::readonly, clang::writeonly]];
+};


### PR DESCRIPTION
These attributes allow annotating pointers and references with how they are accessed inside a function. This allows the compiler to track the value of the pointees better, improving CodeGen.
