### PR TITLE
[Support] Improve jobserver concurrency handling

### DIFF
--- a/llvm/include/llvm/Support/Jobserver.h
+++ b/llvm/include/llvm/Support/Jobserver.h
@@ -142,8 +142,8 @@ public:
   /// Releases a job slot back to the pool.
   virtual void release(JobSlot Slot) = 0;
 
-  /// Returns the number of job slots available, as determined on first use.
-  /// This value is cached. Returns 0 if no jobserver is active.
+  /// Returns the number of job slots if known (e.g. from -jN in MAKEFLAGS).
+  /// This value is cached. Returns 0 if unknown or no jobserver is active.
   virtual unsigned getNumJobs() const = 0;
 
   /// Returns the singleton instance of the JobserverClient.

--- a/llvm/include/llvm/Support/Parallel.h
+++ b/llvm/include/llvm/Support/Parallel.h
@@ -50,6 +50,10 @@ LLVM_ABI extern thread_local unsigned threadIndex;
 inline unsigned getThreadIndex() { GET_THREAD_INDEX_IMPL; }
 #endif
 
+// getThreadIndex() is assigned by ThreadPoolExecutor and must be in the range
+// [0, getThreadCount()). Some users (e.g. PerThreadBumpPtrAllocator) rely on
+// this bound to size per-thread storage, so getThreadCount() represents the
+// maximum possible worker threads, not the current active count.
 LLVM_ABI size_t getThreadCount();
 #else
 inline unsigned getThreadIndex() { return 0; }

--- a/llvm/lib/Support/Jobserver.cpp
+++ b/llvm/lib/Support/Jobserver.cpp
@@ -36,6 +36,8 @@ struct JobserverConfig {
   Mode TheMode = None;
   std::string Path;
   FdPair PipeFDs;
+  /// The number of jobs specified by -jN in MAKEFLAGS. 0 if not specified.
+  unsigned ParsedNumJobs = 0;
 };
 
 /// A helper function that checks if `Input` starts with `Prefix`.
@@ -114,6 +116,10 @@ Expected<JobserverConfig> parseNativeMakeFlags(StringRef MakeFlags) {
         return createStringError(inconvertibleErrorCode(),
                                  "Invalid file descriptor pair in MAKEFLAGS");
       }
+    } else if (getPrefixedValue(Arg, "-j", Value) ||
+               getPrefixedValue(Arg, "--jobs=", Value)) {
+      // Parse the job count from -jN or --jobs=N (GNU Make 4.4+).
+      Value.getAsInteger(10, Config.ParsedNumJobs);
     }
   }
 

--- a/llvm/lib/Support/Parallel.cpp
+++ b/llvm/lib/Support/Parallel.cpp
@@ -18,6 +18,7 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -44,19 +45,17 @@ class Executor {
 public:
   virtual ~Executor() = default;
   virtual void add(std::function<void()> func) = 0;
+  virtual void stop() = 0;
   virtual size_t getThreadCount() const = 0;
 
   static Executor *getDefaultExecutor();
 };
 
 /// An implementation of an Executor that runs closures on a thread pool
-///   in filo order.
+/// in filo order. This is the standard executor for non-jobserver mode.
 class ThreadPoolExecutor : public Executor {
 public:
   explicit ThreadPoolExecutor(ThreadPoolStrategy S) {
-    if (S.UseJobserver)
-      TheJobserver = JobserverClient::getInstance();
-
     ThreadCount = S.compute_thread_count();
     // Spawn all but one of the threads in another thread as spawning threads
     // can take a while.
@@ -81,7 +80,7 @@ public:
   // strategy.
   ThreadPoolExecutor() = delete;
 
-  void stop() {
+  void stop() override {
     {
       std::lock_guard<std::mutex> Lock(Mutex);
       if (Stop)
@@ -102,10 +101,10 @@ public:
   ~ThreadPoolExecutor() override { stop(); }
 
   struct Creator {
-    static void *call() { return new ThreadPoolExecutor(strategy); }
+    static void *call();
   };
   struct Deleter {
-    static void call(void *Ptr) { ((ThreadPoolExecutor *)Ptr)->stop(); }
+    static void call(void *Ptr) { ((Executor *)Ptr)->stop(); }
   };
 
   void add(std::function<void()> F) override {
@@ -122,60 +121,16 @@ private:
   void work(ThreadPoolStrategy S, unsigned ThreadID) {
     threadIndex = ThreadID;
     S.apply_thread_strategy(ThreadID);
-    // Note on jobserver deadlock avoidance:
-    // GNU Make grants each invoked process one implicit job slot. Our
-    // JobserverClient models this by returning an implicit JobSlot on the
-    // first successful tryAcquire() in a process. This guarantees forward
-    // progress without requiring a dedicated "always-on" thread here.
 
     while (true) {
-      if (TheJobserver) {
-        // Jobserver-mode scheduling:
-        // - Acquire one job slot (with exponential backoff to avoid busy-wait).
-        // - While holding the slot, drain and run tasks from the local queue.
-        // - Release the slot when the queue is empty or when shutting down.
-        // Rationale: Holding a slot amortizes acquire/release overhead over
-        // multiple tasks and avoids requeue/yield churn, while still enforcing
-        // the jobserver’s global concurrency limit. With K available slots,
-        // up to K workers run tasks in parallel; within each worker tasks run
-        // sequentially until the local queue is empty.
-        ExponentialBackoff Backoff(std::chrono::hours(24));
-        JobSlot Slot;
-        do {
-          if (Stop)
-            return;
-          Slot = TheJobserver->tryAcquire();
-          if (Slot.isValid())
-            break;
-        } while (Backoff.waitForNextAttempt());
-
-        llvm::scope_exit SlotReleaser(
-            [&] { TheJobserver->release(std::move(Slot)); });
-
-        while (true) {
-          std::function<void()> Task;
-          {
-            std::unique_lock<std::mutex> Lock(Mutex);
-            Cond.wait(Lock, [&] { return Stop || !WorkStack.empty(); });
-            if (Stop && WorkStack.empty())
-              return;
-            if (WorkStack.empty())
-              break;
-            Task = std::move(WorkStack.back());
-            WorkStack.pop_back();
-          }
-          Task();
-        }
-      } else {
-        std::unique_lock<std::mutex> Lock(Mutex);
-        Cond.wait(Lock, [&] { return Stop || !WorkStack.empty(); });
-        if (Stop)
-          break;
-        auto Task = std::move(WorkStack.back());
-        WorkStack.pop_back();
-        Lock.unlock();
-        Task();
-      }
+      std::unique_lock<std::mutex> Lock(Mutex);
+      Cond.wait(Lock, [&] { return Stop || !WorkStack.empty(); });
+      if (Stop)
+        break;
+      auto Task = std::move(WorkStack.back());
+      WorkStack.pop_back();
+      Lock.unlock();
+      Task();
     }
   }
 
@@ -186,28 +141,293 @@ private:
   std::promise<void> ThreadsCreated;
   std::vector<std::thread> Threads;
   unsigned ThreadCount;
+};
+
+/// Jobserver-aware executor that uses spawn-per-token thread management.
+///
+/// Problem (GitHub Issue #170184):
+/// The original JobserverClient::getNumJobs() tried to determine the total
+/// job count by draining all available tokens at startup. This is unreliable
+/// because sibling processes may already hold tokens, causing getNumJobs() to
+/// return a value lower than the actual -jN limit. If we then spawn that many
+/// threads (like the standard ThreadPoolExecutor does), we underutilize the
+/// available parallelism.
+///
+/// A naive fix (parsing -jN from MAKEFLAGS) causes a different problem: if
+/// make -j16 spawns 16 LLVM processes, and each creates 16 threads, we get
+/// 256 threads competing for 16 tokens - massive oversubscription.
+///
+/// Solution (spawn-per-token):
+/// Instead of pre-spawning threads based on an unreliable job count, we:
+/// 1. Start a single coordinator thread that waits for work
+/// 2. When work arrives, the coordinator acquires a jobserver token
+/// 3. Only after acquiring a token do we spawn an ephemeral worker thread
+/// 4. The worker executes one task, then releases the token and exits
+///
+/// Benefits:
+/// - Thread count automatically matches tokens actually held (not -jN guess)
+/// - No idle threads blocking on token acquisition
+/// - Multiple LLVM processes naturally share tokens without oversubscription
+/// - Memory overhead (VmSize) scales with actual parallelism, not -jN
+///
+/// The thread index pool ensures getThreadIndex() returns values in
+/// [0, getThreadCount()) for compatibility with PerThreadBumpPtrAllocator.
+class JobserverThreadPoolExecutor : public Executor {
+public:
+  explicit JobserverThreadPoolExecutor(ThreadPoolStrategy S) : Strategy(S) {
+    TheJobserver = JobserverClient::getInstance();
+    assert(TheJobserver && "JobserverThreadPoolExecutor requires jobserver");
+
+    // Size the thread-index pool independently of jobserver token count.
+    ThreadPoolStrategy NonJobserver = Strategy;
+    NonJobserver.UseJobserver = false;
+    ThreadCount = NonJobserver.compute_thread_count();
+    initThreadIndexPool();
+
+    // Start a single coordinator thread that manages token-based spawning.
+    Threads.reserve(1);
+    Threads.resize(1);
+    std::lock_guard<std::mutex> Lock(Mutex);
+    auto &Thread0 = Threads[0];
+    Thread0 = std::thread([this] { jobserverCoordinator(); });
+    ThreadsCreated.set_value();
+  }
+
+  JobserverThreadPoolExecutor() = delete;
+
+  void stop() override {
+    {
+      std::lock_guard<std::mutex> Lock(Mutex);
+      if (Stop)
+        return;
+      Stop = true;
+    }
+    Cond.notify_all();
+    IndexCond.notify_all();
+    ThreadsCreated.get_future().wait();
+
+    std::thread::id CurrentThreadId = std::this_thread::get_id();
+    for (std::thread &T : Threads)
+      if (T.get_id() == CurrentThreadId)
+        T.detach();
+      else
+        T.join();
+
+    // Join any remaining ephemeral workers.
+    joinFinishedWorkers(/*JoinAll=*/true);
+  }
+
+  ~JobserverThreadPoolExecutor() override { stop(); }
+
+  void add(std::function<void()> F) override {
+    {
+      std::lock_guard<std::mutex> Lock(Mutex);
+      WorkStack.push_back(std::move(F));
+    }
+    Cond.notify_one();
+  }
+
+  size_t getThreadCount() const override { return ThreadCount; }
+
+private:
+  struct EphemeralWorkerRecord {
+    std::thread Thread;
+    std::shared_ptr<std::atomic<bool>> Done;
+  };
+
+  /// Coordinator thread: waits for work, acquires tokens, spawns workers.
+  void jobserverCoordinator() {
+    threadIndex = 0;
+    Strategy.apply_thread_strategy(0);
+
+    while (true) {
+      // Wait until there's work or we're stopping.
+      {
+        std::unique_lock<std::mutex> Lock(Mutex);
+        Cond.wait(Lock, [&] { return Stop || !WorkStack.empty(); });
+        if (Stop)
+          break;
+      }
+
+      // Periodically join finished workers to avoid unbounded growth.
+      joinFinishedWorkers(/*JoinAll=*/false);
+
+      // Acquire a thread index before attempting to acquire a token.
+      std::optional<unsigned> ThreadIndex = acquireThreadIndex();
+      if (!ThreadIndex)
+        return;
+      unsigned Index = *ThreadIndex;
+      auto ReleaseIndex = llvm::scope_exit([&] { releaseThreadIndex(Index); });
+
+      // Try to acquire a token. If successful, spawn an ephemeral worker.
+      JobSlot Slot = TheJobserver->tryAcquire();
+      if (!Slot.isValid()) {
+        // No token available right now. Use backoff and retry.
+        ExponentialBackoff Backoff(std::chrono::seconds(1));
+        do {
+          if (Stop)
+            return;
+          Slot = TheJobserver->tryAcquire();
+          if (Slot.isValid())
+            break;
+        } while (Backoff.waitForNextAttempt());
+      }
+
+      if (!Slot.isValid())
+        continue; // ReleaseIndex will run, loop back and check Stop/WorkStack.
+
+      ReleaseIndex.release();
+
+      // Spawn an ephemeral worker that owns this token.
+      auto Done = std::make_shared<std::atomic<bool>>(false);
+      std::thread Worker([this, Slot = std::move(Slot), Index, Done]() mutable {
+        ephemeralWorker(std::move(Slot), Index, Done);
+      });
+
+      {
+        std::lock_guard<std::mutex> Lock(EphemeralMutex);
+        EphemeralWorkers.push_back({std::move(Worker), Done});
+      }
+    }
+  }
+
+  /// Ephemeral worker: executes one task while holding a token, then exits.
+  /// This ensures tokens are released promptly for load balancing across
+  /// processes. The coordinator will spawn another worker if more work exists.
+  void ephemeralWorker(JobSlot Slot, unsigned ThreadIdx,
+                       std::shared_ptr<std::atomic<bool>> Done) {
+    threadIndex = ThreadIdx;
+    Strategy.apply_thread_strategy(ThreadIdx);
+
+    auto ReleaseIndex = llvm::scope_exit([&] {
+      releaseThreadIndex(ThreadIdx);
+      Done->store(true, std::memory_order_release);
+    });
+
+    llvm::scope_exit SlotReleaser(
+        [&] { TheJobserver->release(std::move(Slot)); });
+
+    // Execute exactly one task, then release the token.
+    // This follows jobserver semantics: acquire token -> do one unit of work
+    // -> release token. Holding tokens longer would prevent other processes
+    // from obtaining them and break load balancing.
+    std::function<void()> Task;
+    {
+      std::unique_lock<std::mutex> Lock(Mutex);
+      if (WorkStack.empty() || Stop)
+        return;
+      Task = std::move(WorkStack.back());
+      WorkStack.pop_back();
+    }
+    Task();
+  }
+
+  /// Join finished ephemeral workers to reclaim resources.
+  void joinFinishedWorkers(bool JoinAll) {
+    std::vector<std::thread> ToJoin;
+    std::thread::id Current = std::this_thread::get_id();
+
+    {
+      std::lock_guard<std::mutex> Lock(EphemeralMutex);
+      for (auto It = EphemeralWorkers.begin(); It != EphemeralWorkers.end();) {
+        bool Finished = JoinAll || It->Done->load(std::memory_order_acquire);
+        if (!Finished) {
+          ++It;
+          continue;
+        }
+
+        if (It->Thread.get_id() == Current) {
+          // Avoid self-join in shutdown paths.
+          It->Thread.detach();
+          It = EphemeralWorkers.erase(It);
+          continue;
+        }
+
+        ToJoin.push_back(std::move(It->Thread));
+        It = EphemeralWorkers.erase(It);
+      }
+    }
+
+    for (auto &T : ToJoin)
+      if (T.joinable())
+        T.join();
+  }
+
+  void initThreadIndexPool() {
+    if (ThreadCount == 0)
+      ThreadCount = 1;
+    std::lock_guard<std::mutex> Lock(IndexMutex);
+    FreeThreadIndices.clear();
+    FreeThreadIndices.reserve(ThreadCount);
+    for (unsigned I = 0; I < ThreadCount; ++I)
+      FreeThreadIndices.push_back(I);
+  }
+
+  std::optional<unsigned> acquireThreadIndex() {
+    std::unique_lock<std::mutex> Lock(IndexMutex);
+    IndexCond.wait(Lock,
+                   [&] { return Stop.load() || !FreeThreadIndices.empty(); });
+    if (Stop)
+      return std::nullopt;
+    unsigned Index = FreeThreadIndices.back();
+    FreeThreadIndices.pop_back();
+    return Index;
+  }
+
+  void releaseThreadIndex(unsigned Index) {
+    {
+      std::lock_guard<std::mutex> Lock(IndexMutex);
+      FreeThreadIndices.push_back(Index);
+    }
+    IndexCond.notify_one();
+  }
+
+  ThreadPoolStrategy Strategy;
+  std::atomic<bool> Stop{false};
+  std::vector<std::function<void()>> WorkStack;
+  std::mutex Mutex;
+  std::condition_variable Cond;
+  std::promise<void> ThreadsCreated;
+  std::vector<std::thread> Threads;
+  unsigned ThreadCount;
 
   JobserverClient *TheJobserver = nullptr;
+
+  // Ephemeral workers and their mutex.
+  std::mutex EphemeralMutex;
+  std::vector<EphemeralWorkerRecord> EphemeralWorkers;
+
+  // Thread index pool for getThreadIndex() semantics.
+  std::mutex IndexMutex;
+  std::condition_variable IndexCond;
+  std::vector<unsigned> FreeThreadIndices;
 };
+
+// Factory function to create the appropriate executor.
+void *ThreadPoolExecutor::Creator::call() {
+  if (strategy.UseJobserver && JobserverClient::getInstance())
+    return new JobserverThreadPoolExecutor(strategy);
+  return new ThreadPoolExecutor(strategy);
+}
 
 Executor *Executor::getDefaultExecutor() {
 #ifdef _WIN32
-  // The ManagedStatic enables the ThreadPoolExecutor to be stopped via
-  // llvm_shutdown() on Windows. This is important to avoid various race
-  // conditions at process exit that can cause crashes or deadlocks.
-
-  static ManagedStatic<ThreadPoolExecutor, ThreadPoolExecutor::Creator,
+  // The ManagedStatic enables the executor to be stopped via llvm_shutdown()
+  // on Windows. This is important to avoid various race conditions at process
+  // exit that can cause crashes or deadlocks.
+  static ManagedStatic<Executor, ThreadPoolExecutor::Creator,
                        ThreadPoolExecutor::Deleter>
       ManagedExec;
-  static std::unique_ptr<ThreadPoolExecutor> Exec(&(*ManagedExec));
+  static std::unique_ptr<Executor> Exec(&(*ManagedExec));
   return Exec.get();
 #else
-  // ManagedStatic is not desired on other platforms. When `Exec` is destroyed
-  // by llvm_shutdown(), worker threads will clean up and invoke TLS
+  // ManagedStatic is not desired on other platforms. When the executor is
+  // destroyed by llvm_shutdown(), worker threads will clean up and invoke TLS
   // destructors. This can lead to race conditions if other threads attempt to
   // access TLS objects that have already been destroyed.
-  static ThreadPoolExecutor Exec(strategy);
-  return &Exec;
+  static std::unique_ptr<Executor> Exec(
+      static_cast<Executor *>(ThreadPoolExecutor::Creator::call()));
+  return Exec.get();
 #endif
 }
 } // namespace

--- a/llvm/lib/Support/Threading.cpp
+++ b/llvm/lib/Support/Threading.cpp
@@ -63,9 +63,13 @@ static int computeHostNumHardwareThreads();
 using namespace llvm;
 
 unsigned llvm::ThreadPoolStrategy::compute_thread_count() const {
-  if (UseJobserver)
-    if (auto JS = JobserverClient::getInstance())
-      return JS->getNumJobs();
+  if (UseJobserver) {
+    if (auto JS = JobserverClient::getInstance()) {
+      unsigned NumJobs = JS->getNumJobs();
+      if (NumJobs > 0)
+        return NumJobs;
+    }
+  }
 
   int MaxThreadCount =
       UseHyperThreads ? computeHostNumHardwareThreads() : get_physical_cores();

--- a/llvm/lib/Support/Unix/Jobserver.inc
+++ b/llvm/lib/Support/Unix/Jobserver.inc
@@ -31,9 +31,9 @@ bool areFdsValid(int ReadFD, int WriteFD) {
 /// The constructor sets up the client based on the provided configuration.
 /// For pipe-based jobservers, it duplicates the inherited file descriptors,
 /// sets them to close-on-exec, and makes the read descriptor non-blocking.
-/// For FIFO-based jobservers, it opens the named pipe. After setup, it drains
-/// all available tokens from the jobserver to determine the total number of
-/// available jobs (`NumJobs`), then immediately releases them back.
+/// For FIFO-based jobservers, it opens the named pipe. After setup, it records
+/// the `-jN` value from MAKEFLAGS when available; otherwise `NumJobs` remains
+/// unknown (0).
 JobserverClientImpl::JobserverClientImpl(const JobserverConfig &Config) {
   switch (Config.TheMode) {
   case JobserverConfig::PosixPipe: {
@@ -82,19 +82,9 @@ JobserverClientImpl::JobserverClientImpl(const JobserverConfig &Config) {
   }
 
   IsInitialized = true;
-  // Determine the total number of jobs by acquiring all available slots and
-  // then immediately releasing them.
-  SmallVector<JobSlot, 8> Slots;
-  while (true) {
-    auto S = tryAcquire();
-    if (!S.isValid())
-      break;
-    Slots.push_back(std::move(S));
-  }
-  NumJobs = Slots.size();
-  assert(NumJobs >= 1 && "Invalid number of jobs");
-  for (auto &S : Slots)
-    release(std::move(S));
+
+  // Record -jN if present; otherwise leave NumJobs unknown (0).
+  NumJobs = Config.ParsedNumJobs;
 }
 
 /// The destructor closes any open file descriptors.

--- a/llvm/lib/Support/Windows/Jobserver.inc
+++ b/llvm/lib/Support/Windows/Jobserver.inc
@@ -23,8 +23,12 @@ namespace llvm {
 JobserverClientImpl::JobserverClientImpl(const JobserverConfig &Config) {
   Semaphore = (void *)::OpenSemaphoreA(SEMAPHORE_MODIFY_STATE | SYNCHRONIZE,
                                        FALSE, Config.Path.c_str());
-  if (Semaphore != nullptr)
+  if (Semaphore != nullptr) {
     IsInitialized = true;
+
+    // Record -jN if present; otherwise leave NumJobs unknown (0).
+    NumJobs = Config.ParsedNumJobs;
+  }
 }
 
 /// The destructor closes the handle to the semaphore, releasing the resource.


### PR DESCRIPTION
Problem:
The original JobserverClient::getNumJobs() tried to determine the total
job count by draining all available tokens at startup. This is unreliable
because sibling processes may already hold tokens, causing getNumJobs() to
return a value lower than the actual -jN limit. If we then spawn that many
threads, we underutilize the available parallelism.

A naive fix (parsing -jN from MAKEFLAGS) causes a different problem: if
make -j16 spawns 16 LLVM processes, and each creates 16 threads, we get
256 threads competing for 16 tokens - massive oversubscription with
significant memory overhead from idle threads.

Solution:
Instead of pre-spawning threads based on an unreliable job count, we use
a spawn-per-token approach in jobserver mode:
1. Start a single coordinator thread that waits for work
2. When work arrives, the coordinator acquires a jobserver token
3. Only after acquiring a token do we spawn an ephemeral worker thread
4. The worker drains available tasks, then releases the token and exits

This is implemented as a separate JobserverThreadPoolExecutor class,
keeping the standard ThreadPoolExecutor unchanged for non-jobserver mode.

Benefits:
- Thread count automatically matches tokens actually held (not -jN guess)
- No idle threads blocking on token acquisition
- Multiple LLVM processes naturally share tokens without oversubscription
- Memory overhead (VmSize) scales with actual parallelism, not -jN

A thread index pool ensures getThreadIndex() returns values in
[0, getThreadCount()) for compatibility with PerThreadBumpPtrAllocator.

Fixes https://github.com/llvm/llvm-project/issues/170184