### PR TITLE
[clang][unittests] Fix linker error for DirectoryWatcherTest with CLANG_LINK_CLANG_DYLIB

### DIFF
--- a/clang/unittests/DirectoryWatcher/CMakeLists.txt
+++ b/clang/unittests/DirectoryWatcher/CMakeLists.txt
@@ -2,9 +2,10 @@ if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME STREQUAL Wind
 
   add_clang_unittest(DirectoryWatcherTests
     DirectoryWatcherTest.cpp
+    CLANG_LIBS
+    clangDirectoryWatcher
     LINK_LIBS
     LLVMTestingSupport
-    clangDirectoryWatcher
     LLVM_COMPONENTS
     Support
     )


### PR DESCRIPTION
Move clangDirectoryWatcher from LINK_LIBS to CLANG_LIBS so it gets replaced by clang-cpp when building with CLANG_LINK_CLANG_DYLIB=ON.

When using both CLANG_LINK_CLANG_DYLIB=ON and LLVM_ENABLE_LTO=Thin, the test would fail with:
ld.lld: error: undefined symbol: clang::DirectoryWatcher::create(llvm::StringRef, std::function<void (llvm::ArrayRef

This happens because clangDirectoryWatcher was being linked as a separate library alongside clang-cpp (which already contains clangDirectoryWatcher), causing duplicate symbol issues with LTO.

The fix correctly categorizes:
- clangDirectoryWatcher → CLANG_LIBS (Clang library, bundled in clang-cpp)
- LLVMTestingSupport → LINK_LIBS (LLVM library, always linked directly)

#178302