### PR TITLE
[NFC][UTC] Avoid copy-paste in `update_analyze_test_checks.py`

### DIFF
--- a/llvm/utils/update_analyze_test_checks.py
+++ b/llvm/utils/update_analyze_test_checks.py
@@ -101,7 +101,7 @@ def update_test(opt_basename: str, ti: common.TestInfo):
 
         regex_map = {
             r"Printing analysis ": common.ANALYZE_FUNCTION_RE,
-            r"(LV|LDist|HashRecognize): Checking a loop in " : common.LOOP_PASS_DEBUG_RE,
+            r"(LV|LDist|HashRecognize): Checking a loop in ": common.LOOP_PASS_DEBUG_RE,
         }
 
         for split_by, regex in regex_map.items():

--- a/llvm/utils/update_analyze_test_checks.py
+++ b/llvm/utils/update_analyze_test_checks.py
@@ -99,30 +99,22 @@ def update_test(opt_basename: str, ti: common.TestInfo):
 
         raw_tool_outputs = common.invoke_tool(ti.args.opt_binary, opt_args, ti.path)
 
-        if re.search(r"Printing analysis ", raw_tool_outputs) is not None:
-            # Split analysis outputs by "Printing analysis " declarations.
-            for raw_tool_output in re.split(r"Printing analysis ", raw_tool_outputs):
+        regex_map = {
+            r"Printing analysis ": common.ANALYZE_FUNCTION_RE,
+            r"(LV|LDist|HashRecognize): Checking a loop in " : common.LOOP_PASS_DEBUG_RE,
+        }
+
+        for split_by, regex in regex_map.items():
+            if re.search(split_by, raw_tool_outputs) is None:
+                continue
+            for raw_tool_output in re.split(split_by, raw_tool_outputs):
                 builder.process_run_line(
-                    common.ANALYZE_FUNCTION_RE,
+                    regex,
                     common.scrub_body,
                     raw_tool_output,
                     prefixes,
                 )
-        elif (
-            re.search(
-                r"(LV|LDist|HashRecognize): Checking a loop in ", raw_tool_outputs
-            )
-            is not None
-        ):
-            for raw_tool_output in re.split(
-                r"(LV|LDist|HashRecognize): Checking a loop in ", raw_tool_outputs
-            ):
-                builder.process_run_line(
-                    common.LOOP_PASS_DEBUG_RE,
-                    common.scrub_body,
-                    raw_tool_output,
-                    prefixes,
-                )
+            break
         else:
             common.warn("Don't know how to deal with this output")
             continue


### PR DESCRIPTION
I'm going to extend it to support VPlan dump tests soon and this cleanup avoids future growth of the `if/elif/elif` chain.