### PR TITLE
[Offload][AMDGPU] Fix olQueryQueue uninitialized output parameter

### DIFF
--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1255,7 +1255,7 @@ Error olQueryQueue_impl(ol_queue_handle_t Queue, bool *IsQueueWorkCompleted) {
                                                      IsQueueWorkCompleted))
       return Err;
   } else if (IsQueueWorkCompleted) {
-    // No underlying queue means there's no work to complete
+    // No underlying queue means there's no work to complete.
     *IsQueueWorkCompleted = true;
   }
   return Error::success();

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1254,6 +1254,9 @@ Error olQueryQueue_impl(ol_queue_handle_t Queue, bool *IsQueueWorkCompleted) {
     if (auto Err = Queue->Device->Device->queryAsync(Queue->AsyncInfo, false,
                                                      IsQueueWorkCompleted))
       return Err;
+  } else if (IsQueueWorkCompleted) {
+    // No underlying queue means there's no work to complete
+    *IsQueueWorkCompleted = true;
   }
   return Error::success();
 }


### PR DESCRIPTION
## Summary
- Fix uninitialized output parameter in `olQueryQueue_impl` when `Queue->AsyncInfo->Queue` is null
- Set `IsQueueWorkCompleted` to `true` when no underlying queue exists (no pending work)
- Resolves test failure on AMDGPU for `olQueryQueueTest.SuccessEmptyAsyncQueueCheckResult`

Fixes #178462.

## Test plan
- [x] Fixed `OffloadAPI/queue.unittests/olQueryQueueTest/SuccessEmptyAsyncQueueCheckResult/AMDGPU_AMD_Radeon_RX_7700_XT_0` test
- [ ] CI tests pass