### PR TITLE
[flang-rt] Fix defining `pid_t` on GPU builds

### DIFF
--- a/flang/include/flang/Runtime/extensions.h
+++ b/flang/include/flang/Runtime/extensions.h
@@ -18,8 +18,8 @@
 
 #define FORTRAN_PROCEDURE_NAME(name) name##_
 
-#ifdef _WIN32
-// UID and GID don't exist on Windows, these exist to avoid errors.
+#if defined(_WIN32) || !__has_include("sys/types.h")
+// UID and GID don't exist on all targets, these exist to avoid errors.
 typedef std::uint32_t uid_t;
 typedef std::uint32_t gid_t;
 #else


### PR DESCRIPTION
Summary:
We support building flang-rt on GPU targets. These do not have POSIX
types so we should not include this if it's not present.
