### PR TITLE
[WebAssembly] Fix crash when storing externref to globals

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.td
@@ -458,6 +458,11 @@ def : Pat<(i32 (WebAssemblyWrapperREL texternalsym:$addr)),
 def : Pat<(i64 (WebAssemblyWrapperREL texternalsym:$addr)),
           (CONST_I64 texternalsym:$addr)>, Requires<[IsPIC, HasAddr64]>;
 
+// Manually define the pattern because 'externref' is not included in the
+// standard RegTypes iteration of the generic loop above.
+def : Pat<(WebAssemblyglobal_set externref:$src, (WebAssemblyWrapper tglobaladdr:$addr)),
+          (GLOBAL_SET_EXTERNREF tglobaladdr:$addr, externref:$src)>,
+          Requires<[HasReferenceTypes]>;
 //===----------------------------------------------------------------------===//
 // Additional sets of instructions.
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/WebAssembly/global-set.ll
+++ b/llvm/test/CodeGen/WebAssembly/global-set.ll
@@ -4,6 +4,19 @@
 @i64_global = local_unnamed_addr addrspace(1) global i64 undef
 @f32_global = local_unnamed_addr addrspace(1) global float undef
 @f64_global = local_unnamed_addr addrspace(1) global double undef
+@a = global ptr addrspace(10) null
+
+declare ptr addrspace(10) @function_that_gives_me_a_js_object()
+define void @object_store_to_global_ptr() {
+; CHECK-LABEL: object_store_to_global_ptr:
+; CHECK:         .functype object_store_to_global_ptr () -> ()
+; CHECK-NEXT:    call function_that_gives_me_a_js_object
+; CHECK-NEXT:    global.set a
+; CHECK-NEXT:    end_function
+  %object = call ptr addrspace(10) @function_that_gives_me_a_js_object()
+  store ptr addrspace(10) %object, ptr @a
+  ret void
+}
 
 define void @set_i32_global(i32 %v) {
 ; CHECK-LABEL: set_i32_global:


### PR DESCRIPTION
Storing `externref` values to global variables previously caused a selection error because the backend attempted a linear memory store.

This patch implements custom lowering for `ISD::STORE` to convert stores of `externref` values into `WebAssemblyISD::GLOBAL_SET`, ensuring they are correctly updated in the Wasm global space.

Fixes: #141011