### PR TITLE
clang: add test for C2y n3605

### DIFF
--- a/clang/test/C/C2y/n3605.c
+++ b/clang/test/C/C2y/n3605.c
@@ -1,19 +1,18 @@
 // RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic %s
 // RUN: %clang_cc1 -verify -std=c23 -Wall -pedantic %s
+// RUN: %clang_cc1 -verify -std=c17 -Wall -pedantic %s
+// RUN: %clang_cc1 -verify -std=c11 -Wall -pedantic %s
 // expected-no-diagnostics
 // RUN: %clang_cc1 -std=c2y %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
 // RUN: %clang_cc1 -std=c23 %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -std=c17 %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -std=c11 %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
 
 enum A{ a=(int)(_Generic(0, int: (2.5))) };
 enum B{ b=(int)(_Generic(0, int: (2 + 1))) };
 
-#if (__STDC_VERSION__ >= 202311L)
-constexpr int c = _Generic((float*)0, default: 0);
-constexpr int d = _Generic((float*)0, default: (sizeof(c)));
-#else
 int c = _Generic((float*)0, default: 0);
 int d = _Generic((float*)0, default: (sizeof(c)));
-#endif
 
 char s[] = _Generic(0, default: ("word"));
 
@@ -28,12 +27,14 @@ int value_of_b(void) {
 }
 
 int value_of_c(void) {
-	// CHECK: ret i32 0
+	// CHECK: %0 = load i32, ptr @c, align 4
+	// CHECK: ret i32 %0
 	return c;
 }
 
 int value_of_d(void) {
-	// CHECK: ret i32 4
+	// CHECK: %0 = load i32, ptr @d, align 4
+	// CHECK: ret i32 %0
 	return d;
 }
 
@@ -52,3 +53,5 @@ float value_of_float(void) {
 	float (*f)(void)  = _Generic(1, default: (void*)0);
 	return f();
 }
+
+

--- a/clang/test/C/C2y/n3605.c
+++ b/clang/test/C/C2y/n3605.c
@@ -1,44 +1,48 @@
 // RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic %s
+// RUN: %clang_cc1 -verify -std=c23 -Wall -pedantic %s
 // expected-no-diagnostics
 // RUN: %clang_cc1 -std=c2y %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -std=c23 %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
 
 enum A{ a=(int)(_Generic(0, int: (2.5))) };
 enum B{ b=(int)(_Generic(0, int: (2 + 1))) };
 
-constexpr int c  = _Generic((float*)0, default: 0);
-
+#if (__STDC_VERSION__ >= 202311L)
+constexpr int c = _Generic((float*)0, default: 0);
 constexpr int d = _Generic((float*)0, default: (sizeof(c)));
+#else
+int c = _Generic((float*)0, default: 0);
+int d = _Generic((float*)0, default: (sizeof(c)));
+#endif
 
 char s[] = _Generic(0, default: ("word"));
 
-// static_assert(1, _Generic(1, default: "Error Message"));
-
-int value_of_a() {
+int value_of_a(void) {
 	// CHECK: ret i32 2
 	return a;
 }
 
-int value_of_b() {
+int value_of_b(void) {
 	// CHECK: ret i32 3
 	return b;
 }
 
-int value_of_c() {
+int value_of_c(void) {
 	// CHECK: ret i32 0
 	return c;
 }
 
-int value_of_d() {
+int value_of_d(void) {
 	// CHECK: ret i32 4
 	return d;
 }
 
-char *value_of_s() {
+char *value_of_s(void) {
 	// CHECK: ret ptr @s
     return s;
 }
 
-float value_of_float() {
+float value_of_float(void) {
 	// CHECK: %f = alloca ptr, align 8
 	// CHECK: store ptr null, ptr %f, align 8
 	// CHECK: %0 = load ptr, ptr %f, align 8

--- a/clang/test/C/C2y/n3605.c
+++ b/clang/test/C/C2y/n3605.c
@@ -1,0 +1,50 @@
+// RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic %s
+// expected-no-diagnostics
+// RUN: %clang_cc1 -std=c2y %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
+
+enum A{ a=(int)(_Generic(0, int: (2.5))) };
+enum B{ b=(int)(_Generic(0, int: (2 + 1))) };
+
+constexpr int c  = _Generic((float*)0, default: 0);
+
+constexpr int d = _Generic((float*)0, default: (sizeof(c)));
+
+char s[] = _Generic(0, default: ("word"));
+
+// static_assert(1, _Generic(1, default: "Error Message"));
+
+int value_of_a() {
+	// CHECK: ret i32 2
+	return a;
+}
+
+int value_of_b() {
+	// CHECK: ret i32 3
+	return b;
+}
+
+int value_of_c() {
+	// CHECK: ret i32 0
+	return c;
+}
+
+int value_of_d() {
+	// CHECK: ret i32 4
+	return d;
+}
+
+char *value_of_s() {
+	// CHECK: ret ptr @s
+    return s;
+}
+
+float value_of_float() {
+	// CHECK: %f = alloca ptr, align 8
+	// CHECK: store ptr null, ptr %f, align 8
+	// CHECK: %0 = load ptr, ptr %f, align 8
+	// CHECK: %call = call float %0()
+	// CHECK: ret float %call
+
+	float (*f)(void)  = _Generic(1, default: (void*)0);
+	return f();
+}

--- a/clang/test/C/C2y/n3605_1.c
+++ b/clang/test/C/C2y/n3605_1.c
@@ -1,51 +1,19 @@
-// RUN: %clang_cc1 -verify -std=c17 -Wall -pedantic %s
-// RUN: %clang_cc1 -verify -std=c11 -Wall -pedantic %s
+// RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic %s
+// RUN: %clang_cc1 -verify -std=c23 -Wall -pedantic %s
 // expected-no-diagnostics
-// RUN: %clang_cc1 -std=c17 %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
-// RUN: %clang_cc1 -std=c11 %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -std=c2y %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -std=c23 %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
 
-enum A{ a=(int)(_Generic(0, int: (2.5))) };
-enum B{ b=(int)(_Generic(0, int: (2 + 1))) };
-
-int c = _Generic((float*)0, default: 0);
-int d = _Generic((float*)0, default: (sizeof(c)));
-
-char s[] = _Generic(0, default: ("word"));
+constexpr int a = _Generic((float*)0, default: 0);
+constexpr int b = _Generic((float*)0, default: (sizeof(a)));
 
 int value_of_a(void) {
-	// CHECK: ret i32 2
+	// CHECK: ret i32 0
 	return a;
 }
 
 int value_of_b(void) {
-	// CHECK: ret i32 3
+	// CHECK: ret i32 4
 	return b;
 }
 
-int value_of_c(void) {
-	// CHECK: %0 = load i32, ptr @c, align 4
-	// CHECK: ret i32 %0
-	return c;
-}
-
-int value_of_d(void) {
-	// CHECK: %0 = load i32, ptr @d, align 4
-	// CHECK: ret i32 %0
-	return d;
-}
-
-char *value_of_s(void) {
-	// CHECK: ret ptr @s
-    return s;
-}
-
-float value_of_float(void) {
-	// CHECK: %f = alloca ptr, align 8
-	// CHECK: store ptr null, ptr %f, align 8
-	// CHECK: %0 = load ptr, ptr %f, align 8
-	// CHECK: %call = call float %0()
-	// CHECK: ret float %call
-
-	float (*f)(void)  = _Generic(1, default: (void*)0);
-	return f();
-}

--- a/clang/test/C/C2y/n3605_1.c
+++ b/clang/test/C/C2y/n3605_1.c
@@ -1,0 +1,3 @@
+// RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic %s
+
+static_assert(1, _Generic(1, default: "Error Message"));  // expected-error{{expected string literal for diagnostic message in static_assert}}

--- a/clang/test/C/C2y/n3605_1.c
+++ b/clang/test/C/C2y/n3605_1.c
@@ -1,3 +1,51 @@
-// RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic %s
+// RUN: %clang_cc1 -verify -std=c17 -Wall -pedantic %s
+// RUN: %clang_cc1 -verify -std=c11 -Wall -pedantic %s
+// expected-no-diagnostics
+// RUN: %clang_cc1 -std=c17 %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -std=c11 %s -triple x86_64 --embed-dir=%S/Inputs -emit-llvm -o - | FileCheck %s
 
-static_assert(1, _Generic(1, default: "Error Message"));  // expected-error{{expected string literal for diagnostic message in static_assert}}
+enum A{ a=(int)(_Generic(0, int: (2.5))) };
+enum B{ b=(int)(_Generic(0, int: (2 + 1))) };
+
+int c = _Generic((float*)0, default: 0);
+int d = _Generic((float*)0, default: (sizeof(c)));
+
+char s[] = _Generic(0, default: ("word"));
+
+int value_of_a(void) {
+	// CHECK: ret i32 2
+	return a;
+}
+
+int value_of_b(void) {
+	// CHECK: ret i32 3
+	return b;
+}
+
+int value_of_c(void) {
+	// CHECK: %0 = load i32, ptr @c, align 4
+	// CHECK: ret i32 %0
+	return c;
+}
+
+int value_of_d(void) {
+	// CHECK: %0 = load i32, ptr @d, align 4
+	// CHECK: ret i32 %0
+	return d;
+}
+
+char *value_of_s(void) {
+	// CHECK: ret ptr @s
+    return s;
+}
+
+float value_of_float(void) {
+	// CHECK: %f = alloca ptr, align 8
+	// CHECK: store ptr null, ptr %f, align 8
+	// CHECK: %0 = load ptr, ptr %f, align 8
+	// CHECK: %call = call float %0()
+	// CHECK: ret float %call
+
+	float (*f)(void)  = _Generic(1, default: (void*)0);
+	return f();
+}

--- a/clang/test/C/C2y/n3605_2.c
+++ b/clang/test/C/C2y/n3605_2.c
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -verify -std=c2y -Wall -pedantic %s
+// RUN: %clang_cc1 -verify -std=c23 -Wall -pedantic %s
+
+static_assert(1, _Generic(1, default: "Error Message"));  // expected-error{{expected string literal for diagnostic message in static_assert}}

--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -354,7 +354,7 @@ conformance.</p>
     <tr>
       <td>Generic replacement (v. 2 of quasi-literals)</td>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3605.pdf">N3605</a></td>
-      <td class="unknown" align="center">Unknown</td>
+      <td class="full" align="center">Yes</td>
 	</tr>
     <tr>
       <td>Member access of an incomplete object</td>


### PR DESCRIPTION
Add a test for N3605: Generic replacement (v. 2 of quasi-literals)

The paper clarifies existing behavior of _Generic selection and parenthesis.  This PR adds tests along the same lines and mark the feature as supported.