### PR TITLE
[LibC][RPC] Define LIBC_COPT_PRINTF_DISABLE_WIDE on Windows

### DIFF
--- a/libc/src/__support/RPC/rpc_server.h
+++ b/libc/src/__support/RPC/rpc_server.h
@@ -37,6 +37,10 @@
 #define LIBC_COPT_PRINTF_DISABLE_INDEX_MODE
 #define LIBC_COPT_PRINTF_DISABLE_STRERROR
 
+#if defined(_WIN32)
+#define LIBC_COPT_PRINTF_DISABLE_WIDE
+#endif
+
 // The 'long double' type is 8 bytes.
 #define LIBC_TYPES_LONG_DOUBLE_IS_FLOAT64
 

--- a/libc/src/__support/RPC/rpc_server.h
+++ b/libc/src/__support/RPC/rpc_server.h
@@ -37,6 +37,8 @@
 #define LIBC_COPT_PRINTF_DISABLE_INDEX_MODE
 #define LIBC_COPT_PRINTF_DISABLE_STRERROR
 
+// TODO: Clean up this.
+// We plan to support UTF-16 eventually and also windows is not the only UTF-16 platform.
 #if defined(_WIN32)
 #define LIBC_COPT_PRINTF_DISABLE_WIDE
 #endif

--- a/libc/src/__support/RPC/rpc_server.h
+++ b/libc/src/__support/RPC/rpc_server.h
@@ -38,7 +38,8 @@
 #define LIBC_COPT_PRINTF_DISABLE_STRERROR
 
 // TODO: Clean up this.
-// We plan to support UTF-16 eventually and also windows is not the only UTF-16 platform.
+// We plan to support UTF-16 eventually and also windows is not the only UTF-16
+// platform.
 #if defined(_WIN32)
 #define LIBC_COPT_PRINTF_DISABLE_WIDE
 #endif

--- a/libc/src/__support/RPC/rpc_server.h
+++ b/libc/src/__support/RPC/rpc_server.h
@@ -37,9 +37,8 @@
 #define LIBC_COPT_PRINTF_DISABLE_INDEX_MODE
 #define LIBC_COPT_PRINTF_DISABLE_STRERROR
 
-// TODO: Clean up this.
-// We plan to support UTF-16 eventually and also windows is not the only UTF-16
-// platform.
+// TODO: Remove this check once UTF-16 is supported. It may be necessary to add
+// additional targets for other systems that use UTF-16.
 #if defined(_WIN32)
 #define LIBC_COPT_PRINTF_DISABLE_WIDE
 #endif


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/176110

RPC headers are being used directly from offload.
The default setting in config.json won't take effect.
Set it in the rpc_server.h
