### PR TITLE
[LoopUnroll] Fix unused variable warning

### DIFF
--- a/llvm/lib/Transforms/Utils/LoopUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUtils.cpp
@@ -1027,14 +1027,14 @@ BranchProbability llvm::getBranchProbability(BasicBlock *Src, BasicBlock *Dst) {
   if (!TI || TI->getNumSuccessors() == 0)
     return BranchProbability::getZero();
 
-  auto NumSucc = TI->getNumSuccessors();
   SmallVector<uint32_t, 4> Weights;
 
   if (!extractBranchWeights(*TI, Weights)) {
     // No metadata
     return BranchProbability::getUnknown();
   }
-  assert(NumSucc == Weights.size() && "Missing weights in branch_weights");
+  assert(TI->getNumSuccessors() == Weights.size() &&
+         "Missing weights in branch_weights");
 
   uint64_t Total = 0;
   uint32_t Numerator = 0;


### PR DESCRIPTION
Fixes 362c39d36dd87c5659b0caa3115dfa67f592cdf6.