### PR TITLE
[EarlyIfConversion] Fix lambda capture in `callInRange`

### DIFF
--- a/llvm/lib/CodeGen/EarlyIfConversion.cpp
+++ b/llvm/lib/CodeGen/EarlyIfConversion.cpp
@@ -929,7 +929,7 @@ static bool callInRange(const MachineInstr *From, const MachineInstr *To) {
   int Count = 0;
   auto InstrRange =
       make_range(std::next(From->getIterator()), To->getIterator());
-  return any_of(InstrRange, [&Count](const MachineInstr &MI) {
+  return any_of(InstrRange, [&](const MachineInstr &MI) {
     return ++Count > MaxInstructionsToCheck || MI.isCall();
   });
 }


### PR DESCRIPTION
Post merge failure in windows buildbot: https://lab.llvm.org/buildbot/#/builders/46/builds/29831