### PR TITLE
[HLSL] Make round, trunc, floor overload tests stricter. NFC

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/floor-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/floor-overloads.hlsl
@@ -1,70 +1,118 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -disable-llvm-passes -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
+
 
 using hlsl::floor;
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_floor_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.floor.f32(
+// CHECK: define [[FNATTRS]] float @_Z17test_floor_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.floor.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x 64 bit API lowering for floor is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float test_floor_double(double p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_floor_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.floor.v2f32(
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_floor_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.floor.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x 64 bit API lowering for floor is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float2 test_floor_double2(double2 p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_floor_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.floor.v3f32(
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_floor_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.floor.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x 64 bit API lowering for floor is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float3 test_floor_double3(double3 p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_floor_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.floor.v4f32(
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_floor_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.floor.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x 64 bit API lowering for floor is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float4 test_floor_double4(double4 p0) { return floor(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_floor_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.floor.f32(
+// CHECK: define [[FNATTRS]] float @_Z14test_floor_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float test_floor_int(int p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_floor_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.floor.v2f32(
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_floor_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float2 test_floor_int2(int2 p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_floor_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.floor.v3f32(
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_floor_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float3 test_floor_int3(int3 p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_floor_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.floor.v4f32(
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_floor_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float4 test_floor_int4(int4 p0) { return floor(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_floor_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.floor.f32(
+// CHECK: define [[FNATTRS]] float @_Z15test_floor_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float test_floor_uint(uint p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_floor_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.floor.v2f32(
+// CHECK: define [[FNATTRS]] <2 x float> @_Z16test_floor_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float2 test_floor_uint2(uint2 p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_floor_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.floor.v3f32(
+// CHECK: define [[FNATTRS]] <3 x float> @_Z16test_floor_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float3 test_floor_uint3(uint3 p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_floor_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.floor.v4f32(
+// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_floor_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float4 test_floor_uint4(uint4 p0) { return floor(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_floor_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.floor.f32(
+// CHECK: define [[FNATTRS]] float @_Z18test_floor_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float test_floor_int64_t(int64_t p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_floor_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.floor.v2f32(
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_floor_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float2 test_floor_int64_t2(int64_t2 p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_floor_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.floor.v3f32(
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_floor_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float3 test_floor_int64_t3(int64_t3 p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_floor_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.floor.v4f32(
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_floor_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float4 test_floor_int64_t4(int64_t4 p0) { return floor(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_floor_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.floor.f32(
+// CHECK: define [[FNATTRS]] float @_Z19test_floor_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float test_floor_uint64_t(uint64_t p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_floor_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.floor.v2f32(
+// CHECK: define [[FNATTRS]] <2 x float> @_Z20test_floor_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float2 test_floor_uint64_t2(uint64_t2 p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_floor_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.floor.v3f32(
+// CHECK: define [[FNATTRS]] <3 x float> @_Z20test_floor_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float3 test_floor_uint64_t3(uint64_t3 p0) { return floor(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_floor_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.floor.v4f32(
+// CHECK: define [[FNATTRS]] <4 x float> @_Z20test_floor_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float4 test_floor_uint64_t4(uint64_t4 p0) { return floor(p0); }

--- a/clang/test/CodeGenHLSL/builtins/round-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/round-overloads.hlsl
@@ -1,88 +1,115 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -disable-llvm-passes -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_double
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
-// CHECK: ret float [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] float @_Z17test_round_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.roundeven.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'round' is deprecated: In 202x 64 bit API lowering for round is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float test_round_double(double p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_double2
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
-// CHECK: ret <2 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_round_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.roundeven.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'round' is deprecated: In 202x 64 bit API lowering for round is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float2 test_round_double2(double2 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_double3
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
-// CHECK: ret <3 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_round_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.roundeven.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'round' is deprecated: In 202x 64 bit API lowering for round is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float3 test_round_double3(double3 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_double4
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
-// CHECK: ret <4 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_round_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.roundeven.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'round' is deprecated: In 202x 64 bit API lowering for round is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float4 test_round_double4(double4 p0) { return round(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_int
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
-// CHECK: ret float [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] float @_Z14test_round_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float test_round_int(int p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_int2
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
-// CHECK: ret <2 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_round_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float2 test_round_int2(int2 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_int3
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
-// CHECK: ret <3 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_round_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float3 test_round_int3(int3 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_int4
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
-// CHECK: ret <4 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_round_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float4 test_round_int4(int4 p0) { return round(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_uint
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
-// CHECK: ret float [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] float @_Z15test_round_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float test_round_uint(uint p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_uint2
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
-// CHECK: ret <2 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z16test_round_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float2 test_round_uint2(uint2 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_uint3
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
-// CHECK: ret <3 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z16test_round_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float3 test_round_uint3(uint3 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_uint4
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
-// CHECK: ret <4 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_round_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float4 test_round_uint4(uint4 p0) { return round(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_int64_t
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
-// CHECK: ret float [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] float @_Z18test_round_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float test_round_int64_t(int64_t p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_int64_t2
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
-// CHECK: ret <2 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_round_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float2 test_round_int64_t2(int64_t2 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_int64_t3
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
-// CHECK: ret <3 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_round_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float3 test_round_int64_t3(int64_t3 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_int64_t4
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
-// CHECK: ret <4 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_round_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float4 test_round_int64_t4(int64_t4 p0) { return round(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_uint64_t
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
-// CHECK: ret float [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] float @_Z19test_round_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float test_round_uint64_t(uint64_t p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_uint64_t2
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
-// CHECK: ret <2 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z20test_round_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float2 test_round_uint64_t2(uint64_t2 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_uint64_t3
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
-// CHECK: ret <3 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z20test_round_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float3 test_round_uint64_t3(uint64_t3 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_uint64_t4
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
-// CHECK: ret <4 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z20test_round_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float4 test_round_uint64_t4(uint64_t4 p0) { return round(p0); }

--- a/clang/test/CodeGenHLSL/builtins/trunc-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/trunc-overloads.hlsl
@@ -1,83 +1,130 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -disable-llvm-passes -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_trunc_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.trunc.f32(
+// CHECK: define [[FNATTRS]] float @_Z17test_trunc_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.trunc.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x 64 bit API lowering for trunc is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float test_trunc_double(double p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_trunc_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.trunc.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_trunc_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.trunc.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x 64 bit API lowering for trunc is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float2 test_trunc_double2(double2 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_trunc_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.trunc.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_trunc_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.trunc.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x 64 bit API lowering for trunc is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float3 test_trunc_double3(double3 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_trunc_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_trunc_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.trunc.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x 64 bit API lowering for trunc is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float4 test_trunc_double4(double4 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_trunc_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.trunc.f32(
+// CHECK: define [[FNATTRS]] float @_Z14test_trunc_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float test_trunc_int(int p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_trunc_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.trunc.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_trunc_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float2 test_trunc_int2(int2 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_trunc_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.trunc.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_trunc_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float3 test_trunc_int3(int3 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_trunc_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_trunc_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float4 test_trunc_int4(int4 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_trunc_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.trunc.f32(
+// CHECK: define [[FNATTRS]] float @_Z15test_trunc_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float test_trunc_uint(uint p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_trunc_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.trunc.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z16test_trunc_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float2 test_trunc_uint2(uint2 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_trunc_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.trunc.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z16test_trunc_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float3 test_trunc_uint3(uint3 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_trunc_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_trunc_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float4 test_trunc_uint4(uint4 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_trunc_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.trunc.f32(
+// CHECK: define [[FNATTRS]] float @_Z18test_trunc_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float test_trunc_int64_t(int64_t p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_trunc_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.trunc.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_trunc_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float2 test_trunc_int64_t2(int64_t2 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_trunc_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.trunc.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_trunc_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float3 test_trunc_int64_t3(int64_t3 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_trunc_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_trunc_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float4 test_trunc_int64_t4(int64_t4 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_trunc_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.trunc.f32(
+// CHECK: define [[FNATTRS]] float @_Z19test_trunc_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float test_trunc_uint64_t(uint64_t p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_trunc_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.trunc.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z20test_trunc_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float2 test_trunc_uint64_t2(uint64_t2 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_trunc_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.trunc.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z20test_trunc_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float3 test_trunc_uint64_t3(uint64_t3 p0) { return trunc(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_trunc_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z20test_trunc_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
+// expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float4 test_trunc_uint64_t4(uint64_t4 p0) { return trunc(p0); }


### PR DESCRIPTION
This patch changes the run lines for round, trunc, floor overload test to use -O1 instead of -disable-llvm-passes and rewrite the tests to actually look at the whole function.

This work is part of https://github.com/llvm/llvm-project/issues/138016.