### PR TITLE
[NFC][llvm][docs] Fix alphabetical order of commands

### DIFF
--- a/llvm/docs/CommandGuide/llvm-readelf.rst
+++ b/llvm/docs/CommandGuide/llvm-readelf.rst
@@ -20,14 +20,14 @@ input. Otherwise, it will read from the specified ``filenames``.
 OPTIONS
 -------
 
-.. option:: --all, -a
-
- Equivalent to specifying all the main display options relevant to the file
- format.
-
 .. option:: --addrsig
 
  Display the address-significance table.
+
+ .. option:: --all, -a
+
+ Equivalent to specifying all the main display options relevant to the file
+ format.
 
 .. option:: --arch-specific, -A
 
@@ -55,6 +55,10 @@ OPTIONS
 
  Display the dependent libraries section.
 
+.. option:: --dynamic-table, --dynamic, -d
+
+ Display the dynamic table.
+
 .. option:: --dyn-relocations
 
  Display the dynamic relocation entries.
@@ -62,14 +66,6 @@ OPTIONS
 .. option:: --dyn-symbols, --dyn-syms
 
  Display the dynamic symbol table.
-
-.. option:: --dynamic-table, --dynamic, -d
-
- Display the dynamic table.
-
-.. option:: --histogram, -I
-
- Display a bucket list histogram for dynamic symbol hash tables.
 
 .. option:: --elf-linker-options
 
@@ -85,10 +81,6 @@ OPTIONS
 .. option:: --extra-sym-info
 
  Display extra information (section name) when showing symbols.
-
-.. option:: --section-groups, -g
-
- Display section groups.
 
 .. option:: --expand-relocs
 
@@ -125,6 +117,10 @@ OPTIONS
  Display the specified section(s) as hexadecimal bytes. ``section`` may be a
  section index or section name.
 
+.. option:: --histogram, -I
+
+ Display a bucket list histogram for dynamic symbol hash tables.
+
 .. option:: --memtag
 
  Display information about memory tagging present in the binary. This includes
@@ -160,10 +156,6 @@ OPTIONS
 
  Display the relocation entries in the file.
 
-.. option:: --sections, --section-headers, -S
-
- Display all sections.
-
 .. option:: --section-data
 
  When used with :option:`--sections`, display section data for each section
@@ -173,6 +165,10 @@ OPTIONS
 
  Display all section details. Used as an alternative to :option:`--sections`.
 
+.. option:: --section-groups, -g
+
+ Display section groups.
+
 .. option:: --section-mapping
 
  Display the section to segment mapping.
@@ -181,6 +177,10 @@ OPTIONS
 
  When used with :option:`--sections`, display relocations for each section
  shown. This option has no effect for GNU style output.
+
+.. option:: --sections, --section-headers, -S
+
+ Display all sections.
 
 .. option:: --section-symbols
 

--- a/llvm/docs/CommandGuide/llvm-readobj.rst
+++ b/llvm/docs/CommandGuide/llvm-readobj.rst
@@ -89,12 +89,6 @@ file formats.
  Display the specified section(s) as hexadecimal bytes. ``section`` may be a
  section index or section name.
 
- .. option:: --memtag
-
- Display information about memory tagging present in the binary. This includes
- various memtag-specific dynamic entries, decoded global descriptor sections,
- and decoded Android-specific ELF notes.
-
 .. option:: --needed-libs
 
  Display the needed libraries.

--- a/llvm/docs/CommandGuide/llvm-readobj.rst
+++ b/llvm/docs/CommandGuide/llvm-readobj.rst
@@ -47,14 +47,14 @@ GENERAL AND MULTI-FORMAT OPTIONS
 These options are applicable to more than one file format, or are unrelated to
 file formats.
 
+.. option:: --addrsig
+
+ Display the address-significance table.
+
 .. option:: --all
 
  Equivalent to specifying all the main display options relevant to the file
  format.
-
-.. option:: --addrsig
-
- Display the address-significance table.
 
 .. option:: --decompress, -z
 
@@ -112,10 +112,6 @@ file formats.
 
  Display the relocation entries in the file.
 
-.. option:: --sections, --section-headers, -S
-
- Display all sections.
-
 .. option:: --section-data, --sd
 
  When used with :option:`--sections`, display section data for each section
@@ -125,6 +121,10 @@ file formats.
 
  When used with :option:`--sections`, display relocations for each section
  shown. This option has no effect for GNU style output.
+
+.. option:: --sections, --section-headers, -S
+
+ Display all sections.
 
 .. option:: --section-symbols, --st
 
@@ -189,6 +189,10 @@ The following options are implemented only for the ELF file format.
 
  Display the dependent libraries section.
 
+.. option:: --dynamic-table, --dynamic, -d
+
+ Display the dynamic table.
+
 .. option:: --dyn-relocations
 
  Display the dynamic relocation entries.
@@ -196,10 +200,6 @@ The following options are implemented only for the ELF file format.
 .. option:: --dyn-symbols, --dyn-syms, --dt
 
  Display the dynamic symbol table.
-
-.. option:: --dynamic-table, --dynamic, -d
-
- Display the dynamic table.
 
 .. option:: --elf-linker-options
 
@@ -331,10 +331,6 @@ The following options are implemented only for the PE/COFF file format.
 
  Display the debug directory.
 
-.. option:: --coff-tls-directory
-
- Display the TLS directory.
-
 .. option:: --coff-directives
 
  Display the .drectve section.
@@ -355,6 +351,10 @@ The following options are implemented only for the PE/COFF file format.
 
  Display the .rsrc section.
 
+.. option:: --coff-tls-directory
+
+ Display the TLS directory.
+
 XCOFF SPECIFIC OPTIONS
 ----------------------
 
@@ -372,13 +372,13 @@ The following options are implemented only for the XCOFF file format.
 
   Display XCOFF loader section header.
 
-.. option:: --loader-section-symbols
-
-  Display symbol table of loader section.
-
 .. option:: --loader-section-relocations
 
   Display relocation entries of loader section.
+
+.. option:: --loader-section-symbols
+
+  Display symbol table of loader section.
 
 EXIT STATUS
 -----------


### PR DESCRIPTION
Fix the order of commands for llvm-readelf and llvm-readobj docs.
