### PR TITLE
[MLIR][Python] Remove partial LLVM APIs in python bindings (2/n)

### DIFF
--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -57,6 +57,12 @@ static std::string join(const Ts &...args) {
   return oss.str();
 }
 
+/// Local helper to compute std::hash for a value.
+template <typename T>
+static size_t hash(const T &value) {
+  return std::hash<T>{}(value);
+}
+
 /// Helper for creating an @classmethod.
 template <class Func, typename... Args>
 static nb::object classmethod(Func f, Args... args) {
@@ -4095,11 +4101,7 @@ void populateIRCore(nb::module_ &m) {
           "__eq__", [](PyBlock &self, nb::object &other) { return false; },
           "Compares block with non-block object (always returns False).")
       .def(
-          "__hash__",
-          [](PyBlock &self) {
-            return static_cast<size_t>(
-                std::hash<decltype(self.get().ptr)>{}(self.get().ptr));
-          },
+          "__hash__", [](PyBlock &self) { return hash(self.get().ptr); },
           "Returns the hash value of the block.")
       .def(
           "__str__",
@@ -4284,11 +4286,7 @@ void populateIRCore(nb::module_ &m) {
           "Compares attribute with non-attribute object (always returns "
           "False).")
       .def(
-          "__hash__",
-          [](PyAttribute &self) {
-            return static_cast<size_t>(
-                std::hash<decltype(self.get().ptr)>{}(self.get().ptr));
-          },
+          "__hash__", [](PyAttribute &self) { return hash(self.get().ptr); },
           "Returns the hash value of the attribute.")
       .def(
           "dump", [](PyAttribute &self) { mlirAttributeDump(self); },
@@ -4410,11 +4408,7 @@ void populateIRCore(nb::module_ &m) {
           "other"_a.none(),
           "Compares type with non-type object (always returns False).")
       .def(
-          "__hash__",
-          [](PyType &self) {
-            return static_cast<size_t>(
-                std::hash<decltype(self.get().ptr)>{}(self.get().ptr));
-          },
+          "__hash__", [](PyType &self) { return hash(self.get().ptr); },
           "Returns the hash value of the `Type`.")
       .def(
           "dump", [](PyType &self) { mlirTypeDump(self); }, kDumpDocstring)
@@ -4553,11 +4547,7 @@ void populateIRCore(nb::module_ &m) {
           "__eq__", [](PyValue &self, nb::object other) { return false; },
           "Compares value with non-value object (always returns False).")
       .def(
-          "__hash__",
-          [](PyValue &self) {
-            return static_cast<size_t>(
-                std::hash<decltype(self.get().ptr)>{}(self.get().ptr));
-          },
+          "__hash__", [](PyValue &self) { return hash(self.get().ptr); },
           "Returns the hash value of the value.")
       .def(
           "__str__",

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -3167,9 +3167,9 @@ void populateIRCore(nb::module_ &m) {
             if (frames.empty())
               throw nb::value_error("No caller frames provided.");
             MlirLocation caller = frames.back().get();
-            for (const PyLocation &frame :
-                 llvm::reverse(llvm::ArrayRef(frames).drop_back()))
-              caller = mlirLocationCallSiteGet(frame.get(), caller);
+            for (size_t index = frames.size() - 1; index-- > 0;) {
+              caller = mlirLocationCallSiteGet(frames[index].get(), caller);
+            }
             return PyLocation(context->getRef(),
                               mlirLocationCallSiteGet(callee.get(), caller));
           },

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -1500,13 +1500,12 @@ static void populateResultTypes(std::string_view name, nb::list resultTypeList,
               .c_str());
     }
     resultSegmentLengths.reserve(resultTypeList.size());
-    size_t size = resultSegmentSpec.size();
-    for (size_t index = 0; index < size; ++index) {
-      int segmentSpec = resultSegmentSpec[index];
+    for (size_t i = 0, e = resultSegmentSpec.size(); i < e; ++i) {
+      int segmentSpec = resultSegmentSpec[i];
       if (segmentSpec == 1 || segmentSpec == 0) {
         // Unpack unary element.
         try {
-          auto *resultType = nb::cast<PyType *>(resultTypeList[index]);
+          auto *resultType = nb::cast<PyType *>(resultTypeList[i]);
           if (resultType) {
             resultTypes.push_back(resultType);
             resultSegmentLengths.push_back(1);
@@ -1515,24 +1514,24 @@ static void populateResultTypes(std::string_view name, nb::list resultTypeList,
             resultSegmentLengths.push_back(0);
           } else {
             throw nb::value_error(
-                join("Result ", index, " of operation \"", name,
+                join("Result ", i, " of operation \"", name,
                      "\" must be a Type (was None and result is not optional)")
                     .c_str());
           }
         } catch (nb::cast_error &err) {
-          throw nb::value_error(join("Result ", index, " of operation \"", name,
+          throw nb::value_error(join("Result ", i, " of operation \"", name,
                                      "\" must be a Type (", err.what(), ")")
                                     .c_str());
         }
       } else if (segmentSpec == -1) {
         // Unpack sequence by appending.
         try {
-          if (resultTypeList[index].is_none()) {
+          if (resultTypeList[i].is_none()) {
             // Treat it as an empty list.
             resultSegmentLengths.push_back(0);
           } else {
             // Unpack the list.
-            auto segment = nb::cast<nb::sequence>(resultTypeList[index]);
+            auto segment = nb::cast<nb::sequence>(resultTypeList[i]);
             for (nb::handle segmentItem : segment) {
               resultTypes.push_back(nb::cast<PyType *>(segmentItem));
               if (!resultTypes.back()) {
@@ -1545,7 +1544,7 @@ static void populateResultTypes(std::string_view name, nb::list resultTypeList,
           // NOTE: Sloppy to be using a catch-all here, but there are at least
           // three different unrelated exceptions that can be thrown in the
           // above "casts". Just keep the scope above small and catch them all.
-          throw nb::value_error(join("Result ", index, " of operation \"", name,
+          throw nb::value_error(join("Result ", i, " of operation \"", name,
                                      "\" must be a Sequence of Types (",
                                      err.what(), ")")
                                     .c_str());
@@ -1662,19 +1661,17 @@ nb::object PyOpView::buildGeneric(
               .c_str());
     }
     operandSegmentLengths.reserve(operandList.size());
-    size_t size = operandSegmentSpec.size();
-    for (size_t index = 0; index < size; ++index) {
-      int segmentSpec = operandSegmentSpec[index];
+    for (size_t i = 0, e = operandSegmentSpec.size(); i < e; ++i) {
+      int segmentSpec = operandSegmentSpec[i];
       if (segmentSpec == 1 || segmentSpec == 0) {
         // Unpack unary element.
-        const auto operand = operandList[index];
+        const auto operand = operandList[i];
         if (!operand.is_none()) {
           try {
             operands.push_back(getOpResultOrValue(operand));
           } catch (nb::builtin_exception &err) {
-            throw nb::value_error(join("Operand ", index, " of operation \"",
-                                       name, "\" must be a Value (", err.what(),
-                                       ")")
+            throw nb::value_error(join("Operand ", i, " of operation \"", name,
+                                       "\" must be a Value (", err.what(), ")")
                                       .c_str());
           }
 
@@ -1684,19 +1681,19 @@ nb::object PyOpView::buildGeneric(
           operandSegmentLengths.push_back(0);
         } else {
           throw nb::value_error(
-              join("Operand ", index, " of operation \"", name,
+              join("Operand ", i, " of operation \"", name,
                    "\" must be a Value (was None and operand is not optional)")
                   .c_str());
         }
       } else if (segmentSpec == -1) {
         // Unpack sequence by appending.
         try {
-          if (operandList[index].is_none()) {
+          if (operandList[i].is_none()) {
             // Treat it as an empty list.
             operandSegmentLengths.push_back(0);
           } else {
             // Unpack the list.
-            auto segment = nb::cast<nb::sequence>(operandList[index]);
+            auto segment = nb::cast<nb::sequence>(operandList[i]);
             for (nb::handle segmentItem : segment) {
               operands.push_back(getOpResultOrValue(segmentItem));
             }
@@ -1706,8 +1703,8 @@ nb::object PyOpView::buildGeneric(
           // NOTE: Sloppy to be using a catch-all here, but there are at least
           // three different unrelated exceptions that can be thrown in the
           // above "casts". Just keep the scope above small and catch them all.
-          throw nb::value_error(join("Operand ", index, " of operation \"",
-                                     name, "\" must be a Sequence of Values (",
+          throw nb::value_error(join("Operand ", i, " of operation \"", name,
+                                     "\" must be a Sequence of Values (",
                                      err.what(), ")")
                                     .c_str());
         }

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -19,6 +19,7 @@
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
 
+#include <functional>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -4099,7 +4100,8 @@ void populateIRCore(nb::module_ &m) {
       .def(
           "__hash__",
           [](PyBlock &self) {
-            return static_cast<size_t>(llvm::hash_value(self.get().ptr));
+            return static_cast<size_t>(
+                std::hash<decltype(self.get().ptr)>{}(self.get().ptr));
           },
           "Returns the hash value of the block.")
       .def(
@@ -4287,7 +4289,8 @@ void populateIRCore(nb::module_ &m) {
       .def(
           "__hash__",
           [](PyAttribute &self) {
-            return static_cast<size_t>(llvm::hash_value(self.get().ptr));
+            return static_cast<size_t>(
+                std::hash<decltype(self.get().ptr)>{}(self.get().ptr));
           },
           "Returns the hash value of the attribute.")
       .def(
@@ -4412,7 +4415,8 @@ void populateIRCore(nb::module_ &m) {
       .def(
           "__hash__",
           [](PyType &self) {
-            return static_cast<size_t>(llvm::hash_value(self.get().ptr));
+            return static_cast<size_t>(
+                std::hash<decltype(self.get().ptr)>{}(self.get().ptr));
           },
           "Returns the hash value of the `Type`.")
       .def(
@@ -4554,7 +4558,8 @@ void populateIRCore(nb::module_ &m) {
       .def(
           "__hash__",
           [](PyValue &self) {
-            return static_cast<size_t>(llvm::hash_value(self.get().ptr));
+            return static_cast<size_t>(
+                std::hash<decltype(self.get().ptr)>{}(self.get().ptr));
           },
           "Returns the hash value of the value.")
       .def(


### PR DESCRIPTION
This PR continues work from #178290.
Cleaned up LLVM utilities in IRCore.cpp: `enumerate`, `zip`, `ArrayRef`, `hash_value`.