### PR TITLE
[ELFDebugObjectPlugin] Do not wait for std::future in post-fixup phase in the absent of debug info

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.cpp
@@ -349,7 +349,10 @@ void ELFDebugObjectPlugin::modifyPassConfig(MaterializationResponsibility &MR,
     // register the memory range with the GDB JIT Interface in an allocation
     // action of the LinkGraph's own allocation
     DebugObject *DebugObj = getPendingDebugObj(MR);
-    assert(DebugObj && "no debug object?");
+    assert(DebugObj && "Don't inject passes if we have no debug object");
+    // Post-allocation phases would bail out if there is no debug section,
+    // in which case we wouldn't collect target memory and therefore shouldn't
+    // wait for the transaction to finish.
     if (!DebugObj->hasPendingTargetMem())
       return Error::success();
     Expected<ExecutorAddrRange> R = DebugObj->awaitTargetMem();

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_no_debug_info.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_no_debug_info.s
@@ -2,11 +2,10 @@
 
 # RUN: rm -rf %t && mkdir %t
 # RUN: llvm-mc -triple=x86_64-unknown-linux \
-# RUN:     -filetype=obj -o %t/ELF_x86-64_simple.o %s
-# RUN: llvm-jitlink %t/ELF_x86-64_simple.o
+# RUN:     -filetype=obj -o %t/ELF_x86-64_no_debug_info.o %s
+# RUN: llvm-jitlink %t/ELF_x86-64_no_debug_info.o
 
-# Test with the most basic function. Also check if everything works
-# in the absent of any debug information.
+# Check if everything works in the absent of any debug information.
 
 	.text
 	.globl	main                            # -- Begin function main

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_simple.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_simple.s
@@ -1,0 +1,21 @@
+# REQUIRES: native && x86_64-linux
+
+# RUN: rm -rf %t && mkdir %t
+# RUN: llvm-mc -triple=x86_64-unknown-linux \
+# RUN:     -filetype=obj -o %t/ELF_x86-64_simple.o %s
+# RUN: llvm-jitlink %t/ELF_x86-64_simple.o
+
+# Test with the most basic function. Also check if everything works
+# in the absent of any debug information.
+
+	.text
+	.globl	main                            # -- Begin function main
+	.p2align	4
+	.type	main,@function
+main:                                   # @main
+	pushq	%rbp
+	movq	%rsp, %rbp
+	movl	$0, -4(%rbp)
+	movl	$0, %eax
+	popq	%rbp
+	retq


### PR DESCRIPTION
If there is no debug information, we wouldn't call `DebugObject::collectTargetAlloc` in the post-allocation phase. Therefore, when it's in the post-fixup phase, `DebugObject::awaitTargetMem` will fail with _"std::future_error: No associated state"_ because the std::future was not even populated.