### PR TITLE
[clang][Modules] Fixing Incorrect Diagnostics Issued during By-name Dependency Scanning

### DIFF
--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -686,6 +686,11 @@ bool CompilerInstanceWithContext::computeDependencies(
   assert(CIPtr && "CIPtr must be initialized before calling this method");
   auto &CI = *CIPtr;
 
+  // We need to reset the diagnostics, so that the diagnostics issued
+  // during a previous computeDependencies call do not affect the current call.
+  // If we do not reset, we may inherit fatal errors from a previous call.
+  CI.getDiagnostics().Reset();
+
   // We create this cleanup object because computeDependencies may exit
   // early with errors.
   llvm::scope_exit CleanUp([&]() {

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -370,6 +370,9 @@ DependencyScanningTool::computeDependenciesByNameWithContextOrError(
     LookupModuleOutputCallback LookupModuleOutput) {
   FullDependencyConsumer Consumer(AlreadySeen);
   CallbackActionController Controller(LookupModuleOutput);
+  // We need to clear the DiagnosticOutput so that each by-name lookup
+  // has a clean diagnostics buffer.
+  DiagPrinterWithOS->DiagnosticOutput.clear();
   if (Worker.computeDependenciesByNameWithContext(ModuleName, Consumer,
                                                   Controller))
     return Consumer.takeTranslationUnitDeps();

--- a/clang/test/ClangScanDeps/modules-full-by-mult-mod-names-diagnostics.c
+++ b/clang/test/ClangScanDeps/modules-full-by-mult-mod-names-diagnostics.c
@@ -21,16 +21,18 @@ module root2 { header "root2.h" }
 
 // RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
 // RUN: not clang-scan-deps -compilation-database %t/cdb.json -format \
-// RUN:   experimental-full -module-names=modA,root,modB,modC,root2 2>&1 | \
-// RUN:   FileCheck %s -DPREFIX=%/t
+// RUN:   experimental-full -module-names=modA,root,modB,modC,root2 2> \
+// RUN:   %t/error.txt > %t/result.json
+// RUN: cat %t/error.txt | FileCheck %s --check-prefixes=ERROR
+// RUN: cat %t/result.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
-// CHECK: Error while scanning dependencies for modA:
-// CHECK-NEXT: {{.*}}: fatal error: module 'modA' not found
-// CHECK-NEXT: Error while scanning dependencies for modB:
-// CHECK-NEXT: {{.*}}: fatal error: module 'modB' not found
-// CHECK-NEXT: Error while scanning dependencies for modC:
-// CHECK-NEXT: {{.*}}: fatal error: module 'modC' not found
-// CHECK-NEXT: {
+// ERROR: Error while scanning dependencies for modA:
+// ERROR-NEXT: {{.*}}: fatal error: module 'modA' not found
+// ERROR-NEXT: Error while scanning dependencies for modB:
+// ERROR-NEXT: {{.*}}: fatal error: module 'modB' not found
+// ERROR-NEXT: Error while scanning dependencies for modC:
+// ERROR-NEXT: {{.*}}: fatal error: module 'modC' not found
+// CHECK:      {
 // CHECK-NEXT:   "modules": [
 // CHECK-NEXT:     {
 // CHECK:            "file-deps": [

--- a/clang/test/ClangScanDeps/modules-full-by-mult-mod-names-diagnostics.c
+++ b/clang/test/ClangScanDeps/modules-full-by-mult-mod-names-diagnostics.c
@@ -1,0 +1,50 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// This test interleaves valid by-name lookups with invalid by-name lookups
+// to check that the valid lookups return correct results, and the invalid
+// ones generate correct diagnostics.
+
+//--- module.modulemap
+module root { header "root.h" }
+module root2 { header "root2.h" }
+//--- root.h
+
+//--- root2.h
+
+//--- cdb.json.template
+[{
+  "file": "",
+  "directory": "DIR",
+  "command": "clang -fmodules -fmodules-cache-path=DIR/cache -I DIR -x c"
+}]
+
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: not clang-scan-deps -compilation-database %t/cdb.json -format \
+// RUN:   experimental-full -module-names=modA,root,modB,modC,root2 2>&1 | \
+// RUN:   FileCheck %s -DPREFIX=%/t
+
+// CHECK: Error while scanning dependencies for modA:
+// CHECK-NEXT: {{.*}}: fatal error: module 'modA' not found
+// CHECK-NEXT: Error while scanning dependencies for modB:
+// CHECK-NEXT: {{.*}}: fatal error: module 'modB' not found
+// CHECK-NEXT: Error while scanning dependencies for modC:
+// CHECK-NEXT: {{.*}}: fatal error: module 'modC' not found
+// CHECK-NEXT: {
+// CHECK-NEXT:   "modules": [
+// CHECK-NEXT:     {
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/module.modulemap",
+// CHECK-NEXT:         "[[PREFIX]]/root.h"
+// CHECK-NEXT:       ],
+// CHECK-NEXT:       "link-libraries": [],
+// CHECK-NEXT:       "name": "root"
+// CHECK-NEXT:     },
+// CHECK-NEXT:    {
+// CHECK:            "file-deps": [
+// CHECK-NEXT:         "[[PREFIX]]/module.modulemap",
+// CHECK-NEXT:         "[[PREFIX]]/root2.h"
+// CHECK-NEXT:       ],
+// CHECK-NEXT:       "link-libraries": [],
+// CHECK-NEXT:       "name": "root2"
+// CHECK-NEXT:     }

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1085,7 +1085,6 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
             if (handleModuleResult(N, MaybeModuleDepsGraph, *FD, LocalIndex,
                                    DependencyOS, Errs)) {
               HadErrors = true;
-              break;
             }
           }
 


### PR DESCRIPTION
The by-name lookup API uses the same diagnostics engine and consumer for multiple lookups. When multiple lookups fail, the diagnostics could be incorrect for all but the first failing lookup. All the subsequent failing lookups inherit the diagnostics from the first failing lookup. 

This PR resets the diagnostics consumer's buffer and the CompilerInstance's diagnostics engine for each by-name lookup, so each lookup can produce the correct diagnostics. 

Part of work for rdar://136303612. 