### PR TITLE
[libc] Add pthread_getattr_np declaration

### DIFF
--- a/libc/include/pthread.yaml
+++ b/libc/include/pthread.yaml
@@ -176,6 +176,12 @@ functions:
     return_type: _Noreturn void
     arguments:
       - type: void *
+  - name: pthread_getattr_np
+    standards: gnu
+    return_type: int
+    arguments:
+      - type: pthread_t
+      - type: pthread_attr_t *
   - name: pthread_getname_np
     standards:
       - gnu

--- a/libc/src/pthread/pthread_getattr_np.h
+++ b/libc/src/pthread/pthread_getattr_np.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for pthread_getattr_np function -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_PTHREAD_PTHREAD_GETATTR_NP_H
+#define LLVM_LIBC_SRC_PTHREAD_PTHREAD_GETATTR_NP_H
+
+#include "src/__support/macros/config.h"
+#include <pthread.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+int pthread_getattr_np(pthread_t, pthread_attr_t *);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_PTHREAD_PTHREAD_GETATTR_NP_H


### PR DESCRIPTION
Add header declaration and implementation header for the GNU
extension function pthread_getattr_np.  An actual implementation
can come later.
