### PR TITLE
[libc][math] Refactor tanhf implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -105,5 +105,6 @@
 #include "math/sqrtf16.h"
 #include "math/tan.h"
 #include "math/tanf.h"
+#include "math/tanhf.h"
 
 #endif // LLVM_LIBC_SHARED_MATH_H

--- a/libc/shared/math/tanhf.h
+++ b/libc/shared/math/tanhf.h
@@ -1,4 +1,4 @@
-//===-- Single-precision tanh function ------------------------------------===//
+//===-- Shared tanfh function ------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,12 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/tanhf.h"
+#ifndef LLVM_LIBC_SHARED_MATH_TANHF_H
+#define LLVM_LIBC_SHARED_MATH_TANHF_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/tanhf.h"
 
 namespace LIBC_NAMESPACE_DECL {
-  LLVM_LIBC_FUNCTION(float, tanhf, (float x)) {
-    return math::tanhf(x);
-  }
+namespace shared {
 
+using math::tanhf;
+
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_TANHF_H

--- a/libc/shared/math/tanhf.h
+++ b/libc/shared/math/tanhf.h
@@ -1,4 +1,4 @@
-//===-- Shared tanfh function ------------------------------------*- C++ -*-===//
+//===-- Shared tanhf function -----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1521,3 +1521,18 @@ add_header_library(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
 )
+
+add_header_library(
+  tanhf
+  HDRS
+    tanhf.h
+  DEPENDS
+    .exp10f_utils
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.polyeval
+    libc.src.__support.FPUtil.multiply_add
+    libc.src.__support.FPUtil.nearest_integer
+    libc.src.__support.macros.config
+    libc.src.__support.macros.optimization
+    libc.src.__support.macros.properties.cpu_features
+)

--- a/libc/src/__support/math/tanhf.h
+++ b/libc/src/__support/math/tanhf.h
@@ -1,0 +1,129 @@
+//===-- Single-precision tanh function -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_TANHF_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_TANHF_H
+
+#include "exp10f_utils.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/PolyEval.h"
+#include "src/__support/FPUtil/multiply_add.h"
+#include "src/__support/FPUtil/nearest_integer.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+#include "src/__support/macros/properties/cpu_features.h"
+
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE float tanhf(float x) {
+  // 2^6 * log2(e)
+  constexpr double LOG2_E_EXP2_6 = ExpBase::LOG2_B * 2.0;
+
+  using FPBits = typename fputil::FPBits<float>;
+  FPBits xbits(x);
+  uint32_t x_abs = xbits.abs().uintval();
+
+  const int sign_index = xbits.is_neg() ? 1 : 0;
+
+  // When |x| >= 15, or x is inf or nan, or |x| <= 0.078125
+  if (LIBC_UNLIKELY((x_abs >= 0x4170'0000U) || (x_abs <= 0x3da0'0000U))) {
+    if (x_abs <= 0x3da0'0000U) {
+      // |x| <= 0.078125
+      if (LIBC_UNLIKELY(x_abs <= 0x3280'0000U)) {
+        // |x| <= 2^-26
+        return (x_abs != 0)
+                    ? static_cast<float>(x - 0x1.5555555555555p-2 * x * x * x)
+                    : x;
+      }
+
+      const double TAYLOR[] = {-0x1.5555555555555p-2, 0x1.1111111111111p-3,
+                                -0x1.ba1ba1ba1ba1cp-5, 0x1.664f4882c10fap-6,
+                                -0x1.226e355e6c23dp-7};
+      double xdbl = x;
+      double x2 = xdbl * xdbl;
+      // Taylor polynomial.
+      double x4 = x2 * x2;
+      double c0 = x2 * TAYLOR[0];
+      double c1 = fputil::multiply_add(x2, TAYLOR[2], TAYLOR[1]);
+      double c2 = fputil::multiply_add(x2, TAYLOR[4], TAYLOR[3]);
+      double pe = fputil::polyeval(x4, c0, c1, c2);
+
+      return static_cast<float>(fputil::multiply_add(xdbl, pe, xdbl));
+    }
+
+    // |x| >= 15
+    if (LIBC_UNLIKELY(xbits.is_nan()))
+      return x + 1.0f; // sNaN to qNaN + signal
+
+    constexpr float SIGNS[2][2] = {{1.0f, -0x1.0p-25f}, {-1.0f, 0x1.0p-25f}};
+
+    if (LIBC_UNLIKELY(xbits.is_inf()))
+      return SIGNS[sign_index][0];
+
+    return SIGNS[sign_index][0] + SIGNS[sign_index][1];
+  }
+
+  // Range reduction: e^(2x) = 2^(hi + mid) * e^lo
+  // Let  k = round( x * 2^6 * log2(e)),
+  // So   k  = (hi + mid) * 2^5
+  // Then lo = 2x - (hi + mid) * log(2) = 2x - k * 2^-5 * log(2).
+
+  double xd = static_cast<double>(x);
+  // k = round( x* 2^6 * log2(e) )
+  double k = 0;
+  // mk = -k
+  int mk = 0;
+#ifdef LIBC_TARGET_CPU_HAS_NEAREST_INT
+  k = fputil::nearest_integer(xd * LOG2_E_EXP2_6);
+  mk = -static_cast<int>(k);
+#else
+  constexpr double HALF_WAY[2] = {-0.5, 0.5};
+
+  mk = static_cast<int>(
+      fputil::multiply_add(xd, -LOG2_E_EXP2_6, HALF_WAY[sign_index]));
+  k = static_cast<double>(-mk);
+#endif // LIBC_TARGET_CPU_HAS_NEAREST_INT
+  // -hi = floor(-k * 2^(-MID_BITS))
+  // exp_mhi = shift -hi to the exponent field of double precision.
+  int64_t exp_mhi = static_cast<int64_t>(mk >> ExpBase::MID_BITS)
+                    << fputil::FPBits<double>::FRACTION_LEN;
+  // mh = 2^(-hi - mid)
+  int64_t mh_bits = ExpBase::EXP_2_MID[mk & ExpBase::MID_MASK] + exp_mhi;
+  double mh = fputil::FPBits<double>(uint64_t(mh_bits)).get_val();
+  // dx = lo/2 = x - (hi + mid) * log(2)/2 = x - k * 2^-6 * log(2)
+  double dx = fputil::multiply_add(
+      k, ExpBase::M_LOGB_2_LO * 0.5,
+      fputil::multiply_add(k, ExpBase::M_LOGB_2_HI * 0.5, xd));
+
+  // > P = fpminimax(expm1(2*x)/x, 4, [|D...|], [-log(2)/128, log(2)/128]);
+  constexpr double COEFFS[] = {0x1.ffffffffe5bc8p0, 0x1.555555555cd67p0,
+                                0x1.5555c2a9b48b4p-1, 0x1.11112a0e34bdbp-2};
+
+  double dx2 = dx * dx;
+  double c0 = fputil::multiply_add(dx, 2.0, 1.0);
+  double c1 = fputil::multiply_add(dx, COEFFS[1], COEFFS[0]);
+  double c2 = fputil::multiply_add(dx, COEFFS[3], COEFFS[2]);
+  double r = fputil::polyeval(dx2, c0, c1, c2);
+
+  // tanh(x) = sinh(x) / cosh(x)
+  //         = (e^x - e^(-x)) / (e^x + e^(-x))
+  //         = (e^(2x) - 1) / (e^(2x) + 1)
+  //         = (2^(hi + mid) * e^lo - 1) / (2^(hi + mid) * e^lo + 1)
+  //         = (e^lo - 2^(-hi - mid)) / (e^lo + 2^(-hi - mid))
+  //         = (r - mh) / (r + mh)
+  return static_cast<float>((r - mh) / (r + mh));
+}
+
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_TANHF_H
+

--- a/libc/src/__support/math/tanhf.h
+++ b/libc/src/__support/math/tanhf.h
@@ -1,4 +1,4 @@
-//===-- Single-precision tanh function -------------------------------------===//
+//===-- Single-precision tanhf function -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -17,7 +17,6 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
 #include "src/__support/macros/properties/cpu_features.h"
-
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -40,13 +39,13 @@ LIBC_INLINE float tanhf(float x) {
       if (LIBC_UNLIKELY(x_abs <= 0x3280'0000U)) {
         // |x| <= 2^-26
         return (x_abs != 0)
-                    ? static_cast<float>(x - 0x1.5555555555555p-2 * x * x * x)
-                    : x;
+                   ? static_cast<float>(x - 0x1.5555555555555p-2 * x * x * x)
+                   : x;
       }
 
       const double TAYLOR[] = {-0x1.5555555555555p-2, 0x1.1111111111111p-3,
-                                -0x1.ba1ba1ba1ba1cp-5, 0x1.664f4882c10fap-6,
-                                -0x1.226e355e6c23dp-7};
+                               -0x1.ba1ba1ba1ba1cp-5, 0x1.664f4882c10fap-6,
+                               -0x1.226e355e6c23dp-7};
       double xdbl = x;
       double x2 = xdbl * xdbl;
       // Taylor polynomial.
@@ -105,7 +104,7 @@ LIBC_INLINE float tanhf(float x) {
 
   // > P = fpminimax(expm1(2*x)/x, 4, [|D...|], [-log(2)/128, log(2)/128]);
   constexpr double COEFFS[] = {0x1.ffffffffe5bc8p0, 0x1.555555555cd67p0,
-                                0x1.5555c2a9b48b4p-1, 0x1.11112a0e34bdbp-2};
+                               0x1.5555c2a9b48b4p-1, 0x1.11112a0e34bdbp-2};
 
   double dx2 = dx * dx;
   double c0 = fputil::multiply_add(dx, 2.0, 1.0);
@@ -126,4 +125,3 @@ LIBC_INLINE float tanhf(float x) {
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_TANHF_H
-

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -4116,12 +4116,7 @@ add_entrypoint_object(
   HDRS
     ../tanhf.h
   DEPENDS
-    libc.src.__support.FPUtil.fp_bits
-    libc.src.__support.FPUtil.rounding_mode
-    libc.src.__support.FPUtil.multiply_add
-    libc.src.__support.FPUtil.polyeval
-    libc.src.__support.macros.optimization
-    libc.src.__support.math.exp10f_utils
+    libc.src.__support.math.tanhf
 )
 
 add_entrypoint_object(

--- a/libc/src/math/generic/tanhf.cpp
+++ b/libc/src/math/generic/tanhf.cpp
@@ -10,8 +10,6 @@
 #include "src/__support/math/tanhf.h"
 
 namespace LIBC_NAMESPACE_DECL {
-  LLVM_LIBC_FUNCTION(float, tanhf, (float x)) {
-    return math::tanhf(x);
-  }
+LLVM_LIBC_FUNCTION(float, tanhf, (float x)) { return math::tanhf(x); }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -102,4 +102,5 @@ add_fp_unittest(
     libc.src.__support.math.sqrtf
     libc.src.__support.math.tan
     libc.src.__support.math.tanf
+    libc.src.__support.math.tanhf
 )

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -108,6 +108,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat) {
   EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::sinf(0.0f));
   EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::sqrtf(0.0f));
   EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::tanf(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::tanhf(0.0f));
 }
 
 TEST(LlvmLibcSharedMathTest, AllDouble) {

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3748,6 +3748,21 @@ libc_support_library(
     ],
 )
 
+libc_support_library(
+    name = "__support_math_tanhf",
+    hdrs = ["src/__support/math/tanhf.h"],
+    deps = [
+        ":__support_math_exp10f_utils",
+        ":__support_fputil_fp_bits",
+        ":__support_fputil_polyeval",
+        ":__support_fputil_multiply_add",
+        ":__support_fputil_nearest_integer",
+        ":__support_macros_config",
+        ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
+    ],
+)
+
 ############################### complex targets ################################
 
 libc_function(
@@ -5438,15 +5453,7 @@ libc_math_function(
 libc_math_function(
     name = "tanhf",
     additional_deps = [
-        ":__support_fputil_fma",
-        ":__support_fputil_multiply_add",
-        ":__support_fputil_nearest_integer",
-        ":__support_fputil_polyeval",
-        ":__support_fputil_rounding_mode",
-        ":__support_macros_optimization",
-        ":__support_macros_properties_cpu_features",
-        ":__support_math_exp10f_utils",
-        ":__support_math_common_constants",
+        ":__support_math_tanhf",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3752,14 +3752,14 @@ libc_support_library(
     name = "__support_math_tanhf",
     hdrs = ["src/__support/math/tanhf.h"],
     deps = [
-        ":__support_math_exp10f_utils",
         ":__support_fputil_fp_bits",
-        ":__support_fputil_polyeval",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
+        ":__support_fputil_polyeval",
         ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
+        ":__support_math_exp10f_utils",
     ],
 )
 


### PR DESCRIPTION
[libc][math] Refactor tanhf implementation to header-only in src/__support/math folder.

Part of https://github.com/llvm/llvm-project/issues/147386

closed https://github.com/llvm/llvm-project/issues/178493

 I have checked `libc-math-unittests` and `libc-math-smoke-tests`~