### PR TITLE
[lldb] [Process/Utility] Update code url for FreeBSD in comments

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_i386.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_i386.cpp
@@ -12,7 +12,7 @@
 using namespace lldb_private;
 using namespace lldb;
 
-// https://github.com/freebsd/freebsd-src/blob/main/sys/x86/include/reg.h
+// https://cgit.freebsd.org/src/tree/sys/x86/include/reg.h?h=stable/14
 struct GPR {
   uint32_t fs;
   uint32_t es;

--- a/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_i386.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_i386.cpp
@@ -12,7 +12,7 @@
 using namespace lldb_private;
 using namespace lldb;
 
-// http://svnweb.freebsd.org/base/head/sys/x86/include/reg.h
+// https://github.com/freebsd/freebsd-src/blob/main/sys/x86/include/reg.h
 struct GPR {
   uint32_t fs;
   uint32_t es;

--- a/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_mips64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_mips64.cpp
@@ -61,7 +61,7 @@ static const RegisterSet g_reg_sets_mips64[k_num_register_sets] = {
      g_fp_regnums_mips64},
 };
 
-// https://github.com/freebsd/freebsd-src/blob/stable/13/sys/mips/include/regnum.h
+// https://cgit.freebsd.org/src/tree/sys/mips/include/regnum.h?h=stable/13
 typedef struct _GPR {
   uint64_t zero;
   uint64_t r1;

--- a/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_mips64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_mips64.cpp
@@ -61,7 +61,7 @@ static const RegisterSet g_reg_sets_mips64[k_num_register_sets] = {
      g_fp_regnums_mips64},
 };
 
-// http://svnweb.freebsd.org/base/head/sys/mips/include/regnum.h
+// https://github.com/freebsd/freebsd-src/blob/stable/13/sys/mips/include/regnum.h
 typedef struct _GPR {
   uint64_t zero;
   uint64_t r1;

--- a/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_powerpc.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_powerpc.cpp
@@ -13,7 +13,7 @@
 using namespace lldb_private;
 using namespace lldb;
 
-// https://github.com/freebsd/freebsd-src/blob/main/sys/powerpc/include/reg.h
+// https://cgit.freebsd.org/src/tree/sys/powerpc/include/reg.h
 typedef struct _GPR64 {
   uint64_t r0;
   uint64_t r1;

--- a/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_powerpc.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_powerpc.cpp
@@ -13,7 +13,7 @@
 using namespace lldb_private;
 using namespace lldb;
 
-// http://svnweb.freebsd.org/base/head/sys/powerpc/include/reg.h
+// https://github.com/freebsd/freebsd-src/blob/main/sys/powerpc/include/reg.h
 typedef struct _GPR64 {
   uint64_t r0;
   uint64_t r1;

--- a/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_x86_64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_x86_64.cpp
@@ -15,7 +15,7 @@
 using namespace lldb_private;
 using namespace lldb;
 
-// https://github.com/freebsd/freebsd-src/blob/main/sys/x86/include/reg.h
+// https://cgit.freebsd.org/src/tree/sys/x86/include/reg.h
 typedef struct _GPR {
   uint64_t r15;
   uint64_t r14;

--- a/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_x86_64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextFreeBSD_x86_64.cpp
@@ -15,7 +15,7 @@
 using namespace lldb_private;
 using namespace lldb;
 
-// http://svnweb.freebsd.org/base/head/sys/x86/include/reg.h
+// https://github.com/freebsd/freebsd-src/blob/main/sys/x86/include/reg.h
 typedef struct _GPR {
   uint64_t r15;
   uint64_t r14;


### PR DESCRIPTION
FreeBSD has moved from svn to git. Use https://cgit.freebsd.org/src instead as it is the source of truth. i386 and mip64 were no longer supported as of FreeBSD 15 and 14, respectively, so link stable branch instead of main branch. See [FreeBSD platforms page](https://www.freebsd.org/platforms/).