### PR TITLE
[libclc] Introduce __clc_recip function to enable 'arcp' flag for math reciprocal operations

### DIFF
--- a/libclc/clc/include/clc/math/math.h
+++ b/libclc/clc/include/clc/math/math.h
@@ -37,7 +37,6 @@ bool __attribute__((noinline)) __clc_runtime_has_hw_fma32(void);
 #define HAVE_FAST_FMA32() (0)
 
 #define MATH_DIVIDE(X, Y) ((X) / (Y))
-#define MATH_RECIP(X) (1.0f / (X))
 #define MATH_SQRT(X) sqrt(X)
 
 #define SIGNBIT_SP32 0x80000000

--- a/libclc/clc/lib/generic/SOURCES
+++ b/libclc/clc/lib/generic/SOURCES
@@ -131,6 +131,7 @@ math/clc_nextafter.cl
 math/clc_pow.cl
 math/clc_pown.cl
 math/clc_powr.cl
+math/clc_recip.cl
 math/clc_remainder.cl
 math/clc_remquo.cl
 math/clc_rint.cl

--- a/libclc/clc/lib/generic/math/clc_atan.cl
+++ b/libclc/clc/lib/generic/math/clc_atan.cl
@@ -14,6 +14,7 @@
 #include <clc/math/clc_mad.h>
 #include <clc/math/math.h>
 #include <clc/relational/clc_isnan.h>
+#include <clc_recip.h>
 
 #define __CLC_BODY <clc_atan.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_atan.inc
+++ b/libclc/clc/lib/generic/math/clc_atan.inc
@@ -28,7 +28,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atan(__CLC_GENTYPE x) {
   // Reduce arguments 2^-19 <= |x| < 2^26
 
   // 39/16 <= x < 2^26
-  x = -MATH_RECIP(v);
+  x = -__clc_recip(v);
   __CLC_GENTYPE c = 1.57079632679489655800f; // atan(infinity)
 
   // 19/16 <= x < 39/16

--- a/libclc/clc/lib/generic/math/clc_atan2.cl
+++ b/libclc/clc/lib/generic/math/clc_atan2.cl
@@ -21,6 +21,7 @@
 #include <clc/relational/clc_select.h>
 #include <clc/shared/clc_max.h>
 #include <clc/shared/clc_min.h>
+#include <clc_recip.h>
 
 #define __CLC_BODY <clc_atan2.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_atan2.inc
+++ b/libclc/clc/lib/generic/math/clc_atan2.inc
@@ -47,7 +47,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atan2(__CLC_GENTYPE y,
 #endif
 
   // Octant 0 result
-  __CLC_GENTYPE a = __clc_mad(p, MATH_RECIP(q), vbyu);
+  __CLC_GENTYPE a = __clc_mad(p, __clc_recip(q), vbyu);
 
   // Fix up 3 other octants
   __CLC_GENTYPE at = piby2 - a;

--- a/libclc/clc/lib/generic/math/clc_atan2pi.cl
+++ b/libclc/clc/lib/generic/math/clc_atan2pi.cl
@@ -21,6 +21,7 @@
 #include <clc/relational/clc_select.h>
 #include <clc/shared/clc_max.h>
 #include <clc/shared/clc_min.h>
+#include <clc_recip.h>
 
 #define __CLC_BODY <clc_atan2pi.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_atan2pi.inc
+++ b/libclc/clc/lib/generic/math/clc_atan2pi.inc
@@ -31,7 +31,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atan2pi(__CLC_GENTYPE y,
       __clc_mad(vbyu2, __clc_mad(vbyu2, 0x1.1a714cp-2f, 0x1.287c56p+0f), 1.0f);
 
   // Octant 0 result
-  __CLC_GENTYPE a = MATH_DIVIDE(__clc_mad(p, MATH_RECIP(q), vbyu), pi);
+  __CLC_GENTYPE a = MATH_DIVIDE(__clc_mad(p, __clc_recip(q), vbyu), pi);
 
   // Fix up 3 other octants
   __CLC_GENTYPE at = 0.5f - a;

--- a/libclc/clc/lib/generic/math/clc_atanpi.inc
+++ b/libclc/clc/lib/generic/math/clc_atanpi.inc
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if __CLC_FPSIZE == 32
+#if __CLC_FPSIZE == 32 && __CLC_VECSIZE_OR_1 == 2
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
   const __CLC_GENTYPE pi = __CLC_FP_LIT(3.1415926535897932);
@@ -30,7 +30,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
   // Reduce arguments 2^-19 <= |x| < 2^26
 
   // 39/16 <= x < 2^26
-  x = -MATH_RECIP(v);
+  x = -__clc_recip(v);
   __CLC_GENTYPE c = 1.57079632679489655800f; // atan(infinity)
 
   // 19/16 <= x < 39/16

--- a/libclc/clc/lib/generic/math/clc_recip.cl
+++ b/libclc/clc/lib/generic/math/clc_recip.cl
@@ -6,16 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/clc_convert.h>
-#include <clc/float/definitions.h>
-#include <clc/internal/clc.h>
-#include <clc/math/clc_fabs.h>
-#include <clc/math/clc_fma.h>
-#include <clc/math/clc_mad.h>
-#include <clc/math/math.h>
-#include <clc/relational/clc_isnan.h>
 #include <clc_recip.h>
 
-#define __CLC_FLOAT_ONLY
-#define __CLC_BODY <clc_atanpi.inc>
+#define __CLC_BODY <clc_recip.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_recip.h
+++ b/libclc/clc/lib/generic/math/clc_recip.h
@@ -6,16 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/clc_convert.h>
-#include <clc/float/definitions.h>
-#include <clc/internal/clc.h>
-#include <clc/math/clc_fabs.h>
-#include <clc/math/clc_fma.h>
-#include <clc/math/clc_mad.h>
-#include <clc/math/math.h>
-#include <clc/relational/clc_isnan.h>
-#include <clc_recip.h>
+#ifndef __CLC_MATH_CLC_RECIP_H__
+#define __CLC_MATH_CLC_RECIP_H__
 
-#define __CLC_FLOAT_ONLY
-#define __CLC_BODY <clc_atanpi.inc>
+#define __CLC_FUNCTION __clc_recip
+
+#define __CLC_BODY <clc/math/unary_decl.inc>
 #include <clc/math/gentype.inc>
+
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_CLC_RECIP_H__

--- a/libclc/clc/lib/generic/math/clc_recip.inc
+++ b/libclc/clc/lib/generic/math/clc_recip.inc
@@ -7,6 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_recip(__CLC_GENTYPE x) {
-  _Pragma("clang fp reciprocal(on)");
+#pragma clang fp reciprocal(on)
   return __CLC_FP_LIT(1.0) / x;
 }

--- a/libclc/clc/lib/generic/math/clc_recip.inc
+++ b/libclc/clc/lib/generic/math/clc_recip.inc
@@ -6,16 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/clc_convert.h>
-#include <clc/float/definitions.h>
-#include <clc/internal/clc.h>
-#include <clc/math/clc_fabs.h>
-#include <clc/math/clc_fma.h>
-#include <clc/math/clc_mad.h>
-#include <clc/math/math.h>
-#include <clc/relational/clc_isnan.h>
-#include <clc_recip.h>
-
-#define __CLC_FLOAT_ONLY
-#define __CLC_BODY <clc_atanpi.inc>
-#include <clc/math/gentype.inc>
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_recip(__CLC_GENTYPE x) {
+  _Pragma("clang fp reciprocal(on)");
+  return __CLC_FP_LIT(1.0) / x;
+}

--- a/libclc/clc/lib/generic/math/clc_rootn.cl
+++ b/libclc/clc/lib/generic/math/clc_rootn.cl
@@ -16,6 +16,7 @@
 #include <clc/math/clc_subnormal_config.h>
 #include <clc/math/math.h>
 #include <clc/math/tables.h>
+#include <clc_recip.h>
 
 #define __CLC_BODY <clc_rootn.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_rootn.inc
+++ b/libclc/clc/lib/generic/math/clc_rootn.inc
@@ -54,7 +54,7 @@
 
 _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_rootn(__CLC_GENTYPE x,
                                                  __CLC_INTN ny) {
-  __CLC_GENTYPE y = MATH_RECIP(__CLC_CONVERT_GENTYPE(ny));
+  __CLC_GENTYPE y = __clc_recip(__CLC_CONVERT_GENTYPE(ny));
 
   __CLC_INTN ix = __CLC_AS_INTN(x);
   __CLC_INTN ax = ix & EXSIGNBIT_SP32;

--- a/libclc/clc/lib/generic/math/clc_sincos_helpers.cl
+++ b/libclc/clc/lib/generic/math/clc_sincos_helpers.cl
@@ -15,6 +15,7 @@
 #include <clc/math/clc_native_divide.h>
 #include <clc/math/clc_trunc.h>
 #include <clc/math/math.h>
+#include <clc_recip.h>
 
 #define bitalign(hi, lo, shift) ((hi) << (32 - (shift))) | ((lo) >> (shift));
 

--- a/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
+++ b/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
@@ -125,7 +125,7 @@ _CLC_DEF _CLC_OVERLOAD __CLC_FLOATN __clc_tanf_piby4(__CLC_FLOATN x,
       1.15588821434688393452299f);
 
   __CLC_FLOATN t = __clc_mad(x * r, __clc_native_divide(a, b), x);
-  __CLC_FLOATN tr = -MATH_RECIP(t);
+  __CLC_FLOATN tr = -__clc_recip(t);
 
   return (regn & 1) != 0 ? tr : t;
 }

--- a/libclc/clc/lib/generic/math/clc_sincos_helpers_fp64.inc
+++ b/libclc/clc/lib/generic/math/clc_sincos_helpers_fp64.inc
@@ -115,7 +115,7 @@ _CLC_DEF _CLC_OVERLOAD void __clc_tan_piby4(__CLC_DOUBLEN x, __CLC_DOUBLEN xx,
   __CLC_DOUBLEN z1 =
       __CLC_AS_GENTYPE(__CLC_AS_ULONGN(tp) & 0xffffffff00000000L);
   __CLC_DOUBLEN z2 = t2 - (z1 - t1);
-  __CLC_DOUBLEN trec = -MATH_RECIP(tp);
+  __CLC_DOUBLEN trec = -__clc_recip(tp);
   __CLC_DOUBLEN trec_top =
       __CLC_AS_GENTYPE(__CLC_AS_ULONGN(trec) & 0xffffffff00000000L);
 


### PR DESCRIPTION
MATH_RECIP name implies arcp flag can be added.

Replace the MATH_RECIP macro with a new __clc_recip function, which adds 'arcp' (approximate reciprocal) flag. The flag enables our downstream gpu target generating hardware reciprocal instructions.

Adding __clc_recip function avoids the limitations of using pragmas within macros, especially in subexpressions.

LLVM IR change to atan2/atan2pi/rootn:
  %19 = fdiv <2 x float> splat (float 1.000000e+00), %18, !fpmath !23
->
  %19 = fdiv arcp <2 x float> splat (float 1.000000e+00), %18, !fpmath !23