### PR TITLE
[lldb-dap] NFC Renaming files for consistency.

### DIFF
--- a/lldb/tools/lldb-dap/CMakeLists.txt
+++ b/lldb/tools/lldb-dap/CMakeLists.txt
@@ -29,10 +29,10 @@ add_lldb_library(lldbDAP
 
   Handler/ResponseHandler.cpp
   Handler/AttachRequestHandler.cpp
-  Handler/BreakpointLocationsHandler.cpp
+  Handler/BreakpointLocationsRequestHandler.cpp
   Handler/CancelRequestHandler.cpp
   Handler/CompileUnitsRequestHandler.cpp
-  Handler/CompletionsHandler.cpp
+  Handler/CompletionsRequestHandler.cpp
   Handler/ConfigurationDoneRequestHandler.cpp
   Handler/ContinueRequestHandler.cpp
   Handler/DataBreakpointInfoRequestHandler.cpp

--- a/lldb/tools/lldb-dap/Handler/BreakpointLocationsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/BreakpointLocationsRequestHandler.cpp
@@ -1,4 +1,4 @@
-//===-- BreakpointLocationsHandler..cpp -----------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/tools/lldb-dap/Handler/CompletionsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/CompletionsRequestHandler.cpp
@@ -1,4 +1,4 @@
-//===-- CompletionsHandler.cpp --------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
I noticed recently that CompletionsHandler.cpp and BreakpointLocationsHandler.cpp do not follow the same naming pattern as the rest of the request handlers.

Renaming to include `Request` for consistency.