### PR TITLE
[NFCI][ELF][Mips] Refactor MipsGotSection to avoid explicit writes

### DIFF
--- a/lld/ELF/Arch/Mips.cpp
+++ b/lld/ELF/Arch/Mips.cpp
@@ -714,6 +714,7 @@ void MIPS<ELFT>::relocate(uint8_t *loc, const Relocation &rel,
 
   switch (type) {
   case R_MIPS_32:
+  case R_MIPS_REL32:
   case R_MIPS_GPREL32:
   case R_MIPS_TLS_DTPREL32:
   case R_MIPS_TLS_TPREL32:
@@ -722,6 +723,7 @@ void MIPS<ELFT>::relocate(uint8_t *loc, const Relocation &rel,
   case R_MIPS_64:
   case R_MIPS_TLS_DTPREL64:
   case R_MIPS_TLS_TPREL64:
+  case (R_MIPS_64 << 8) | R_MIPS_REL32:
     write64(ctx, loc, val);
     break;
   case R_MIPS_26:

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -204,6 +204,7 @@ public:
   // primary and optional multiple secondary GOTs.
   void build();
 
+  void addConstant(const Relocation &r);
   void addEntry(InputFile &file, Symbol &sym, int64_t addend, RelExpr expr);
   void addDynTlsEntry(InputFile &file, Symbol &sym);
   void addTlsIndex(InputFile &file);


### PR DESCRIPTION
Splitting the VA / addend calculations between build and writeTo means having to keep them in sync and duplicating some of the logic. Move all such calculations into build, mirroring how the normal non-MIPS code in Relocations.cpp ensures the addend and initial memory contents are set.