### PR TITLE
[OpenACC] Added support for bounds generation for boxes and OPTIONAL.

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.h
@@ -152,6 +152,11 @@ struct LocalitySpecifierOperands {
   llvm::SmallVector<::mlir::Value> privateVars;
   llvm::SmallVector<::mlir::Attribute> privateSyms;
 };
+
+/// Returns true if the given box value may be absent.
+/// The given value must have BaseBoxType.
+bool mayBeAbsentBox(mlir::Value val);
+
 } // namespace fir
 
 #endif // FORTRAN_OPTIMIZER_DIALECT_FIROPS_H

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -174,9 +174,7 @@ static void printAllocatableOp(mlir::OpAsmPrinter &p, OP &op) {
   p.printOptionalAttrDict(op->getAttrs(), {"in_type", "operandSegmentSizes"});
 }
 
-/// Returns true if the given box value may be absent.
-/// The given value must have BaseBoxType.
-static bool mayBeAbsentBox(mlir::Value val) {
+bool fir::mayBeAbsentBox(mlir::Value val) {
   assert(mlir::isa<fir::BaseBoxType>(val.getType()) && "expected box argument");
   while (val) {
     mlir::Operation *defOp = val.getDefiningOp();

--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
@@ -226,48 +226,53 @@ generateSeqTyAccBounds(fir::SequenceType seqType, mlir::Value var,
   fir::FirOpBuilder firBuilder(builder, var.getDefiningOp());
   mlir::Location loc = var.getLoc();
 
-  if (seqType.hasDynamicExtents() || seqType.hasUnknownShape()) {
-    if (auto boxAddr =
-            mlir::dyn_cast_if_present<fir::BoxAddrOp>(var.getDefiningOp())) {
-      mlir::Value box = boxAddr.getVal();
-      auto res =
-          hlfir::translateToExtendedValue(loc, firBuilder, hlfir::Entity(box));
-      fir::ExtendedValue exv = res.first;
-      mlir::Value boxRef = box;
-      if (auto boxPtr = mlir::cast<mlir::acc::MappableType>(box.getType())
-                            .getVarPtr(box)) {
-        boxRef = boxPtr;
+  // If [hl]fir.declare is visible, extract the bounds from the declaration's
+  // shape (if it is provided).
+  if (mlir::isa<hlfir::DeclareOp, fir::DeclareOp>(var.getDefiningOp())) {
+    mlir::Value zero =
+        firBuilder.createIntegerConstant(loc, builder.getIndexType(), 0);
+    mlir::Value one =
+        firBuilder.createIntegerConstant(loc, builder.getIndexType(), 1);
+
+    mlir::Value shape;
+    if (auto declareOp =
+            mlir::dyn_cast_if_present<fir::DeclareOp>(var.getDefiningOp()))
+      shape = declareOp.getShape();
+    else if (auto declareOp = mlir::dyn_cast_if_present<hlfir::DeclareOp>(
+                 var.getDefiningOp()))
+      shape = declareOp.getShape();
+
+    const bool strideIncludeLowerExtent = true;
+
+    llvm::SmallVector<mlir::Value> accBounds;
+    if (auto shapeOp =
+            mlir::dyn_cast_if_present<fir::ShapeOp>(shape.getDefiningOp())) {
+      mlir::Value cummulativeExtent = one;
+      for (auto extent : shapeOp.getExtents()) {
+        mlir::Value upperbound =
+            mlir::arith::SubIOp::create(builder, loc, extent, one);
+        mlir::Value stride = one;
+        if (strideIncludeLowerExtent) {
+          stride = cummulativeExtent;
+          cummulativeExtent = mlir::arith::MulIOp::create(
+              builder, loc, cummulativeExtent, extent);
+        }
+        auto accBound = mlir::acc::DataBoundsOp::create(
+            builder, loc, mlir::acc::DataBoundsType::get(builder.getContext()),
+            /*lowerbound=*/zero, /*upperbound=*/upperbound,
+            /*extent=*/extent, /*stride=*/stride, /*strideInBytes=*/false,
+            /*startIdx=*/one);
+        accBounds.push_back(accBound);
       }
-      // TODO: Handle Fortran optional.
-      const mlir::Value isPresent;
-      fir::factory::AddrAndBoundsInfo info(box, boxRef, isPresent,
-                                           box.getType());
-      return fir::factory::genBoundsOpsFromBox<mlir::acc::DataBoundsOp,
-                                               mlir::acc::DataBoundsType>(
-          firBuilder, loc, exv, info);
-    }
-
-    if (mlir::isa<hlfir::DeclareOp, fir::DeclareOp>(var.getDefiningOp())) {
-      mlir::Value zero =
-          firBuilder.createIntegerConstant(loc, builder.getIndexType(), 0);
-      mlir::Value one =
-          firBuilder.createIntegerConstant(loc, builder.getIndexType(), 1);
-
-      mlir::Value shape;
-      if (auto declareOp =
-              mlir::dyn_cast_if_present<fir::DeclareOp>(var.getDefiningOp()))
-        shape = declareOp.getShape();
-      else if (auto declareOp = mlir::dyn_cast_if_present<hlfir::DeclareOp>(
-                   var.getDefiningOp()))
-        shape = declareOp.getShape();
-
-      const bool strideIncludeLowerExtent = true;
-
-      llvm::SmallVector<mlir::Value> accBounds;
-      if (auto shapeOp =
-              mlir::dyn_cast_if_present<fir::ShapeOp>(shape.getDefiningOp())) {
-        mlir::Value cummulativeExtent = one;
-        for (auto extent : shapeOp.getExtents()) {
+    } else if (auto shapeShiftOp = mlir::dyn_cast_if_present<fir::ShapeShiftOp>(
+                   shape.getDefiningOp())) {
+      mlir::Value lowerbound;
+      mlir::Value cummulativeExtent = one;
+      for (auto [idx, val] : llvm::enumerate(shapeShiftOp.getPairs())) {
+        if (idx % 2 == 0) {
+          lowerbound = val;
+        } else {
+          mlir::Value extent = val;
           mlir::Value upperbound =
               mlir::arith::SubIOp::create(builder, loc, extent, one);
           mlir::Value stride = one;
@@ -281,40 +286,51 @@ generateSeqTyAccBounds(fir::SequenceType seqType, mlir::Value var,
               mlir::acc::DataBoundsType::get(builder.getContext()),
               /*lowerbound=*/zero, /*upperbound=*/upperbound,
               /*extent=*/extent, /*stride=*/stride, /*strideInBytes=*/false,
-              /*startIdx=*/one);
+              /*startIdx=*/lowerbound);
           accBounds.push_back(accBound);
         }
-      } else if (auto shapeShiftOp =
-                     mlir::dyn_cast_if_present<fir::ShapeShiftOp>(
-                         shape.getDefiningOp())) {
-        mlir::Value lowerbound;
-        mlir::Value cummulativeExtent = one;
-        for (auto [idx, val] : llvm::enumerate(shapeShiftOp.getPairs())) {
-          if (idx % 2 == 0) {
-            lowerbound = val;
-          } else {
-            mlir::Value extent = val;
-            mlir::Value upperbound =
-                mlir::arith::SubIOp::create(builder, loc, extent, one);
-            mlir::Value stride = one;
-            if (strideIncludeLowerExtent) {
-              stride = cummulativeExtent;
-              cummulativeExtent = mlir::arith::MulIOp::create(
-                  builder, loc, cummulativeExtent, extent);
-            }
-            auto accBound = mlir::acc::DataBoundsOp::create(
-                builder, loc,
-                mlir::acc::DataBoundsType::get(builder.getContext()),
-                /*lowerbound=*/zero, /*upperbound=*/upperbound,
-                /*extent=*/extent, /*stride=*/stride, /*strideInBytes=*/false,
-                /*startIdx=*/lowerbound);
-            accBounds.push_back(accBound);
-          }
-        }
       }
+    }
 
-      if (!accBounds.empty())
-        return accBounds;
+    if (!accBounds.empty())
+      return accBounds;
+  }
+
+  if (seqType.hasDynamicExtents() || seqType.hasUnknownShape()) {
+    mlir::Value box;
+    bool mayBeOptional = false;
+    if (auto boxAddr =
+            mlir::dyn_cast_if_present<fir::BoxAddrOp>(var.getDefiningOp())) {
+      box = boxAddr.getVal();
+      // Since fir.box_addr already accesses the box, we do not care
+      // checking if it is optional.
+    } else if (mlir::isa<fir::BaseBoxType>(var.getType())) {
+      box = var;
+      mayBeOptional = fir::mayBeAbsentBox(box);
+    }
+
+    if (box) {
+      auto res =
+          hlfir::translateToExtendedValue(loc, firBuilder, hlfir::Entity(box));
+      fir::ExtendedValue exv = res.first;
+      mlir::Value boxRef = box;
+      if (auto boxPtr = mlir::cast<mlir::acc::MappableType>(box.getType())
+                            .getVarPtr(box)) {
+        boxRef = boxPtr;
+      }
+      // TODO: Handle Fortran optional, e.g. reuse mayBeAbsentBox()
+      // from FIROps.cpp.
+      const mlir::Value isPresent;
+      if (mayBeOptional) {
+        // TODO: generate the dynamic check for OPTIONAL.
+        // For now, return no bounds.
+        return {};
+      }
+      fir::factory::AddrAndBoundsInfo info(box, boxRef, isPresent,
+                                           box.getType());
+      return fir::factory::genBoundsOpsFromBox<mlir::acc::DataBoundsOp,
+                                               mlir::acc::DataBoundsType>(
+          firBuilder, loc, exv, info);
     }
 
     assert(false && "array with unknown dimension expected to have descriptor");

--- a/flang/test/Fir/OpenACC/openacc-mappable.fir
+++ b/flang/test/Fir/OpenACC/openacc-mappable.fir
@@ -89,4 +89,56 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<f16 = dense<16> : vector<2xi64>,
   // CHECK: Bound[0]: %{{.*}} = acc.bounds lowerbound(%[[LB3:.*]] : index) upperbound(%[[UB3:.*]] : index) extent(%c10{{.*}} : index) stride(%c1{{.*}} : index) startIdx(%c1{{.*}} : index)
   // CHECK: Lower bound: %[[LB3]] = arith.constant 0 : index
   // CHECK: Upper bound: %[[UB3]] = arith.subi %[[EXTENT3]], %c1{{.*}} : index
+
+  // Test the bounds generation for an opaque box.
+  func.func @_QPtest_opaque_box_hlfir(%arg0: !fir.box<!fir.array<?x?xf32>> {fir.bindc_name = "x"}) {
+    %0 = fir.dummy_scope : !fir.dscope
+    %1:2 = hlfir.declare %arg0 dummy_scope %0 arg 1 {uniq_name = "_QFtest_opaque_boxEx"} : (!fir.box<!fir.array<?x?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?x?xf32>>, !fir.box<!fir.array<?x?xf32>>)
+    %2 = acc.copyin var(%1#0 : !fir.box<!fir.array<?x?xf32>>) -> !fir.box<!fir.array<?x?xf32>> {name = "x", structured = false}
+    acc.enter_data dataOperands(%2 : !fir.box<!fir.array<?x?xf32>>)
+    return
+  }
+  // CHECK: Visiting: %{{.*}} = acc.copyin var(%[[VAR:.*]]#0 : !fir.box<!fir.array<?x?xf32>>) -> !fir.box<!fir.array<?x?xf32>> {name = "x", structured = false}
+  // CHECK: Var: %[[VAR]]:2 = hlfir.declare %{{.*}} dummy_scope %{{.*}} arg 1 {uniq_name = "_QFtest_opaque_boxEx"} : (!fir.box<!fir.array<?x?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?x?xf32>>, !fir.box<!fir.array<?x?xf32>>)
+  // CHECK: Mappable: !fir.box<!fir.array<?x?xf32>>
+  // CHECK: Type category: array
+  // CHECK: Has unknown dimensions: false
+  // CHECK: Shape: <<NULL VALUE>>
+  // CHECK: Bound[0]: %{{.*}} = acc.bounds lowerbound(%[[LB0:.*]] : index) upperbound(%[[UB0:.*]] : index) extent(%[[DIM0:.*]]#1 : index)
+  // CHECK-SAME: stride(%[[DIM0]]#2 : index) startIdx(%c1{{.*}} : index) {strideInBytes = true}
+  // CHECK: Lower bound: %[[LB0]] = arith.constant 0 : index
+  // CHECK: Upper bound: %[[UB0]] = arith.subi %[[DIM0]]#1, %c1{{.*}} : index
+  // CHECK: Bound[1]: %{{.*}} = acc.bounds lowerbound(%[[LB1:.*]] : index) upperbound(%[[UB1:.*]] : index) extent(%[[DIM1:.*]]#1 : index)
+  // CHECK-SAME: stride(%{{.*}} : index) startIdx(%c1{{.*}} : index) {strideInBytes = true}
+  // CHECK: Lower bound: %[[LB1]] = arith.constant 0 : index
+  // CHECK: Upper bound: %[[UB1]] = arith.subi %[[DIM1]]#1, %c1{{.*}} : index
+
+  func.func @_QPtest_optional(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x", fir.optional}) {
+    %0 = fir.dummy_scope : !fir.dscope
+    %1:2 = hlfir.declare %arg0 dummy_scope %0 arg 1 {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QFtest_optionalEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
+    %2 = acc.copyin var(%1#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {name = "x", structured = false}
+    acc.enter_data dataOperands(%2 : !fir.box<!fir.array<?xf32>>)
+    return
+  }
+  // CHECK: Visiting: %{{.*}} = acc.copyin var(%[[VAR:.*]]#0 : !fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>> {name = "x", structured = false}
+  // CHECK: Var: %[[VAR]]:2 = hlfir.declare %{{.*}} dummy_scope %{{.*}} arg 1 {fortran_attrs = #fir.var_attrs<optional>, uniq_name = "_QFtest_optionalEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
+  // CHECK: Mappable: !fir.box<!fir.array<?xf32>>
+  // CHECK: Type category: array
+  // CHECK: Has unknown dimensions: false
+  // CHECK: Shape: <<NULL VALUE>>
+  // CHECK: Bound[0]: %{{.*}} = acc.bounds lowerbound(%[[IF:.*]]#0 : index) upperbound(%[[IF]]#1 : index) extent(%[[IF]]#2 : index) stride(%[[IF]]#3 : index) startIdx(%[[IF]]#4 : index) {strideInBytes = true}
+  // CHECK: Lower bound: %[[IF]]:5 = fir.if %[[PRESENT:.*]] -> (index, index, index, index, index) {
+  // CHECK: %[[ONE:.*]] = arith.constant 1 : index
+  // CHECK: %[[ZERO1:.*]] = arith.constant 0 : index
+  // CHECK: %[[DIM0:.*]]:3 = fir.box_dims %[[VAR]]#0, %[[ZERO1]] : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
+  // CHECK: %[[ZERO2:.*]] = arith.constant 0 : index
+  // CHECK: %[[UB:.*]] = arith.subi %[[DIM0]]#1, %[[ONE]] : index
+  // CHECK: %[[NEXTSTRIDE:.*]] = arith.muli %[[DIM0]]#2, %[[DIM0]]#1 : index
+  // CHECK: fir.result %[[ZERO2]], %[[UB]], %[[DIM0]]#1, %[[DIM0]]#2, %[[ONE]] : index, index, index, index, index
+  // CHECK: } else {
+  // CHECK: %[[ZERO:.*]] = arith.constant 0 : index
+  // CHECK: %[[MINUSONE:.*]] = arith.constant -1 : index
+  // CHECK: fir.result %[[ZERO]], %[[MINUSONE]], %[[ZERO]], %[[ZERO]], %[[ZERO]] : index, index, index, index, index
+  // CHECK: }
+  // CHECK: Upper bound: %[[IF]]:5 = fir.if %[[PRESENT]] -> (index, index, index, index, index) {
 }

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
@@ -318,31 +318,27 @@ Operation *ACCImplicitData::getOriginalDataClauseOpForAlias(
   return nullptr;
 }
 
-// Generates bounds for variables that have unknown dimensions
-static void fillInBoundsForUnknownDimensions(Operation *dataClauseOp,
-                                             OpBuilder &builder) {
+// Generates bounds for variables.
+static void fillInBounds(Operation *dataClauseOp, OpBuilder &builder) {
 
   if (!acc::getBounds(dataClauseOp).empty())
     // If bounds are already present, do not overwrite them.
     return;
 
-  // For types that have unknown dimensions, attempt to generate bounds by
-  // relying on MappableType being able to extract it from the IR.
+  // Rely on MappableType to extract the bounds from the IR.
   auto var = acc::getVar(dataClauseOp);
   auto type = var.getType();
   if (auto mappableTy = dyn_cast<acc::MappableType>(type)) {
-    if (mappableTy.hasUnknownDimensions()) {
-      TypeSwitch<Operation *>(dataClauseOp)
-          .Case<ACC_DATA_ENTRY_OPS, ACC_DATA_EXIT_OPS>([&](auto dataClauseOp) {
-            if (std::is_same_v<decltype(dataClauseOp), acc::DevicePtrOp>)
-              return;
-            OpBuilder::InsertionGuard guard(builder);
-            builder.setInsertionPoint(dataClauseOp);
-            auto bounds = mappableTy.generateAccBounds(var, builder);
-            if (!bounds.empty())
-              dataClauseOp.getBoundsMutable().assign(bounds);
-          });
-    }
+    TypeSwitch<Operation *>(dataClauseOp)
+        .Case<ACC_DATA_ENTRY_OPS, ACC_DATA_EXIT_OPS>([&](auto dataClauseOp) {
+          if (std::is_same_v<decltype(dataClauseOp), acc::DevicePtrOp>)
+            return;
+          OpBuilder::InsertionGuard guard(builder);
+          builder.setInsertionPoint(dataClauseOp);
+          auto bounds = mappableTy.generateAccBounds(var, builder);
+          if (!bounds.empty())
+            dataClauseOp.getBoundsMutable().assign(bounds);
+        });
   }
 }
 
@@ -737,7 +733,7 @@ void ACCImplicitData::generateImplicitDataOps(
     auto newDataClauseOp = generateDataClauseOpForCandidate(
         var, module, builder, computeConstructOp, dominatingDataClauses,
         defaultClause);
-    fillInBoundsForUnknownDimensions(newDataClauseOp, builder);
+    fillInBounds(newDataClauseOp, builder);
     LLVM_DEBUG(llvm::dbgs() << "Generated data clause for " << var << ":\n"
                             << "\t" << *newDataClauseOp << "\n");
     if (isa_and_nonnull<acc::PrivateOp, acc::FirstprivateOp, acc::ReductionOp>(


### PR DESCRIPTION
This change allows `OpenACCMappableModel<Ty>::generateAccBounds()`
to generate the bounds operations for FIR boxes (including OPTIONAL).