### PR TITLE
[BOLT] Fix fixed pic handling in indirect jumps

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -917,7 +917,7 @@ BinaryFunction::processIndirectBranch(MCInst &Instruction, unsigned Size,
   if (BaseRegNum == BC.MRI->getProgramCounter())
     ArrayStart += getAddress() + Offset + Size;
 
-  if (FixedEntryLoadInstr) {
+  if (FixedEntryLoadInstr && BC.HasRelocations) {
     assert(BranchType == IndirectBranchType::POSSIBLE_PIC_FIXED_BRANCH &&
            "Invalid IndirectBranch type");
     MCInst::iterator FixedEntryDispOperand =
@@ -942,7 +942,8 @@ BinaryFunction::processIndirectBranch(MCInst &Instruction, unsigned Size,
 
     // Remove spurious JumpTable at EntryAddress caused by PIC reference from
     // the load instruction.
-    BC.deleteJumpTable(EntryAddress);
+    if (EntryAddress != ArrayStart)
+      BC.deleteJumpTable(EntryAddress);
 
     // Replace FixedEntryDispExpr used in target address calculation with outer
     // jump table reference.

--- a/bolt/test/X86/Inputs/jump-table-fixed-ref-pic.s
+++ b/bolt/test/X86/Inputs/jump-table-fixed-ref-pic.s
@@ -3,10 +3,15 @@
 main:
   .cfi_startproc
   cmpq $0x3, %rdi
-  jae .L4
+  jae .Ltmp
   cmpq $0x1, %rdi
   jne .L4
   movslq .Ljt_pic+8(%rip), %rax
+  lea .Ljt_pic(%rip), %rdx
+  add %rdx, %rax
+  jmpq *%rax
+.Ltmp:
+  movslq .Ljt_pic(%rip), %rax
   lea .Ljt_pic(%rip), %rdx
   add %rdx, %rax
   jmpq *%rax

--- a/bolt/test/X86/jump-table-fixed-ref-pic.test
+++ b/bolt/test/X86/jump-table-fixed-ref-pic.test
@@ -11,3 +11,8 @@ CHECK:      movslq ".rodata/1"+8(%rip), %rax
 CHECK-NEXT: leaq ".rodata/1"(%rip), %rdx
 CHECK-NEXT: addq %rdx, %rax
 CHECK-NEXT: jmpq *%rax # UNKNOWN CONTROL FLOW
+
+CHECK:      movslq ".rodata/1"(%rip), %rax
+CHECK-NEXT: leaq ".rodata/1"(%rip), %rdx
+CHECK-NEXT: addq %rdx, %rax
+CHECK-NEXT: jmpq *%rax # UNKNOWN CONTROL FLOW


### PR DESCRIPTION
Fixed the issue encountered when bolt is used to optimize glibc x86 in both relocation and non-relocation modes, which is the same as https://github.com/llvm/llvm-project/issues/122828.