### PR TITLE
[llvm][clang][lld][COFF] Add support for case-insensitive path lookup

### DIFF
--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -404,9 +404,8 @@ IntrusiveRefCntPtr<llvm::vfs::FileSystem> createVFSFromCompilerInvocation(
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS);
 
 IntrusiveRefCntPtr<llvm::vfs::FileSystem>
-createVFSFromOverlayFiles(ArrayRef<std::string> VFSOverlayFiles,
-                          DiagnosticsEngine &Diags,
-                          IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS);
+createVFSFromHSOpts(const HeaderSearchOptions &HSOpts, DiagnosticsEngine &Diags,
+                    IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS);
 
 } // namespace clang
 

--- a/clang/include/clang/Lex/HeaderSearchOptions.h
+++ b/clang/include/clang/Lex/HeaderSearchOptions.h
@@ -207,6 +207,10 @@ public:
   LLVM_PREFERRED_TYPE(bool)
   unsigned Verbose : 1;
 
+  /// Whether header search should be case-insensitive.
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned CaseInsensitive : 1;
+
   /// If true, skip verifying input files used by modules if the
   /// module was already verified during this build session (see
   /// \c BuildSessionTimestamp).
@@ -289,7 +293,7 @@ public:
         ModuleFileHomeIsCwd(false), EnablePrebuiltImplicitModules(false),
         UseBuiltinIncludes(true), UseStandardSystemIncludes(true),
         UseStandardCXXIncludes(true), UseLibcxx(false), Verbose(false),
-        ModulesValidateOncePerBuildSession(false),
+        CaseInsensitive(false), ModulesValidateOncePerBuildSession(false),
         ModulesValidateSystemHeaders(false),
         ModulesForceValidateUserHeaders(true),
         ValidateASTInputFilesContent(false),

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -2034,6 +2034,11 @@ def fansi_escape_codes : Flag<["-"], "fansi-escape-codes">, Group<f_Group>,
   Visibility<[ClangOption, CLOption, DXCOption, CC1Option]>,
   HelpText<"Use ANSI escape codes for diagnostics">,
   MarshallingInfoFlag<DiagnosticOpts<"UseANSIEscapeCodes">>;
+def fcase_insensitive_paths
+    : Flag<["-"], "fcase-insensitive-paths">,
+      Group<f_Group>,
+      Visibility<[ClangOption, CLOption, DXCOption, CC1Option]>,
+      HelpText<"Treat file paths as case-insensitive">;
 def fcomment_block_commands : CommaJoined<["-"], "fcomment-block-commands=">, Group<f_clang_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Treat each comma separated argument in <arg> as a documentation comment block command">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1186,6 +1186,9 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
 
   Args.addOptInFlag(CmdArgs, options::OPT_fdefine_target_os_macros,
                     options::OPT_fno_define_target_os_macros);
+
+  if (Args.hasArg(options::OPT_fcase_insensitive_paths))
+    CmdArgs.push_back("-fcase-insensitive-paths");
 }
 
 // FIXME: Move to target hook.

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -749,8 +749,7 @@ std::unique_ptr<ASTUnit> ASTUnit::LoadFromASTFile(
     return nullptr;
   }
 
-  VFS = createVFSFromOverlayFiles(AST->HSOpts->VFSOverlayFiles,
-                                  *AST->Diagnostics, std::move(VFS));
+  VFS = createVFSFromHSOpts(*AST->HSOpts, *AST->Diagnostics, std::move(VFS));
 
   AST->FileMgr = llvm::makeIntrusiveRefCnt<FileManager>(FileSystemOpts, VFS);
 

--- a/clang/lib/Lex/HeaderSearch.cpp
+++ b/clang/lib/Lex/HeaderSearch.cpp
@@ -148,12 +148,12 @@ std::vector<bool> HeaderSearch::collectVFSUsageAndClear() const {
 
   llvm::vfs::FileSystem &RootFS = FileMgr.getVirtualFileSystem();
   // TODO: This only works if the `RedirectingFileSystem`s were all created by
-  //       `createVFSFromOverlayFiles`. But at least exclude the ones with null
+  //       `createVFSFromHSOpts`. But at least exclude the ones with null
   //       OverlayFileDir.
   RootFS.visit([&](llvm::vfs::FileSystem &FS) {
     if (auto *RFS = dyn_cast<llvm::vfs::RedirectingFileSystem>(&FS)) {
       // Skip a `RedirectingFileSystem` with null OverlayFileDir which indicates
-      // that they aren't created by createVFSFromOverlayFiles from the overlays
+      // that they aren't created by createVFSFromHSOpts from the overlays
       // in HeaderSearchOption::VFSOverlayFiles.
       if (!RFS->getOverlayFileDir().empty()) {
         VFSUsage.push_back(RFS->hasBeenUsed());

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -762,6 +762,7 @@
 // RUN:     -fno-wrapv \
 // RUN:     -fwrapv-pointer \
 // RUN:     -fno-wrapv-pointer \
+// RUN:     -fcase-insensitive-paths \
 // RUN:     --version \
 // RUN:     --warning-suppression-mappings=foo \
 // RUN:     -Werror /Zs -- %s 2>&1

--- a/clang/test/Frontend/case-insensitive-paths.c
+++ b/clang/test/Frontend/case-insensitive-paths.c
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -E -P -verify --show-includes -Wno-nonportable-include-path \
+// RUN:     -fcase-insensitive-paths %s 2>&1 | FileCheck %s
+
+#include "inPuts/eMptY.H" // expected-no-diagnostics
+
+// Make sure the exact spelling used in the #include directive is preserved
+// when printing header dependencies (consistent with MSVC /showIncludes).
+// CHECK: Note: including file: {{.*}}inPuts/eMptY.H

--- a/clang/test/Frontend/case-insensitive-paths.c
+++ b/clang/test/Frontend/case-insensitive-paths.c
@@ -1,8 +1,10 @@
-// RUN: %clang_cc1 -E -P -verify --show-includes -Wno-nonportable-include-path \
-// RUN:     -fcase-insensitive-paths %s 2>&1 | FileCheck %s
-
-#include "inPuts/eMptY.H" // expected-no-diagnostics
-
+// RUN: %clang_cc1 -E -P --show-includes -verify=suppressed \
+// RUN:   -fcase-insensitive-paths -Wno-nonportable-include-path %s 2>&1 \
+// RUN:   | FileCheck %s
 // Make sure the exact spelling used in the #include directive is preserved
 // when printing header dependencies (consistent with MSVC /showIncludes).
 // CHECK: Note: including file: {{.*}}inPuts/eMptY.H
+// suppressed-no-diagnostics@+1
+#include "inPuts/eMptY.H"
+// expected-warning@-1 {{non-portable path to file '"Inputs/empty.h"'; specified path differs in case from file name on disk}}
+// RUN: %clang_cc1 -E -P -verify -fcase-insensitive-paths %s

--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -35,6 +35,8 @@ def arm64xsameaddress
     : P<"arm64xsameaddress", "Generate a thunk for the symbol with the same "
                              "address in both native and EC views on ARM64X.">;
 def base    : P<"base", "Base address of the program">;
+def case_insensitive_paths : Flag<["--"], "case-insensitive-paths">,
+                             HelpText<"Treat file paths as case-insensitive">;
 def color_diagnostics: Flag<["--"], "color-diagnostics">,
     HelpText<"Alias for --color-diagnostics=always">;
 def no_color_diagnostics: Flag<["--"], "no-color-diagnostics">,

--- a/lld/test/COFF/case-insensitive-paths.test
+++ b/lld/test/COFF/case-insensitive-paths.test
@@ -1,0 +1,2 @@
+# RUN: lld-link %S/Inputs/hello64.obj /out:%t.exe /entry:main \
+# RUN:   /libpath:%p/inPutS /defaultlib:StD64 --case-insensitive-paths


### PR DESCRIPTION
This is a port of <https://reviews.llvm.org/D21113>.
Related: #161400
A new VFS, `llvm::vfs::CaseInsensitiveFileSystem` is added.
Adds clang/cc1 option `-fcase-insensitive-paths`. (`wiNdoWS.H` -> `Windows.h`)
This commit also adds a COFF lld-link flag `--case-insensitive-paths` for case-insensitive library lookup (`uuid.lib` -> `Uuid.lib`).
`--case-insensitive-paths` is NOT automatically passed to the linker even if `-fcase-insensitive-paths` is passed, users can use `-fuse-ld=lld-link -Wl,--case-insensitive-paths` if they want clang to pass the option to the linker.
If there is a case mismatch in the header path, [`-Wnonportable-include-path`](<https://clang.llvm.org/docs/DiagnosticsReference.html#wnonportable-include-path>) is issued.
When `--show-includes`(clang) or `/showIncludes`(clang-cl) is passed, the exact spelling used in the `#include` directive is preserved, matching MSVC behaviour.
With this, I was able to cross-compile a simple windows app with the Windows SDK extracted onto a case-sensitive file system(ext4)
CC: @zmodem