### PR TITLE
[SafeStack] remove unused variable

### DIFF
--- a/llvm/lib/CodeGen/SafeStack.cpp
+++ b/llvm/lib/CodeGen/SafeStack.cpp
@@ -663,9 +663,7 @@ void SafeStack::moveDynamicAllocasToUnsafeStack(
     IRBuilder<> IRB(AI);
 
     // Compute the new SP value (after AI).
-    Type *Ty = AI->getAllocatedType();
     Value *Size = IRB.CreateAllocationSize(IntPtrTy, AI);
-
     Value *SP = IRB.CreatePtrToInt(IRB.CreateLoad(StackPtrTy, UnsafeStackPtr),
                                    IntPtrTy);
     SP = IRB.CreateSub(SP, Size);


### PR DESCRIPTION
An accidental conflict between two of my PRs that each removed one of the two uses of this variable.