### PR TITLE
[ASan] Don't mark alloca as safe if address escapes to callee

### DIFF
--- a/llvm/include/llvm/Analysis/StackSafetyAnalysis.h
+++ b/llvm/include/llvm/Analysis/StackSafetyAnalysis.h
@@ -79,6 +79,11 @@ public:
   // during its lifetime.
   bool isSafe(const AllocaInst &AI) const;
 
+  // Returns true if the alloca's address is passed to a function call.
+  // This is relevant for ASan which needs the caller to initialize shadow
+  // memory when addresses escape to callees.
+  bool addressEscapesToCall(const AllocaInst &AI) const;
+
   // Returns true if the instruction can be proven to do only two types of
   // memory accesses:
   //  (1) live stack locations in-bounds or

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1447,8 +1447,9 @@ bool AddressSanitizer::isInterestingAlloca(const AllocaInst &AI) {
        !AI.isUsedWithInAlloca() &&
        // swifterror allocas are register promoted by ISel
        !AI.isSwiftError() &&
-       // safe allocas are not interesting
-       !(SSGI && SSGI->isSafe(AI)));
+       // safe allocas are not interesting, but for ASan we also need to ensure
+       // the address doesn't escape to calls (callee may access shadow memory)
+       !(SSGI && SSGI->isSafe(AI) && !SSGI->addressEscapesToCall(AI)));
 
   It->second = IsInteresting;
   return IsInteresting;

--- a/llvm/test/Instrumentation/AddressSanitizer/asan-stack-safety-escape.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/asan-stack-safety-escape.ll
@@ -1,0 +1,43 @@
+; REQUIRES: x86-registered-target
+;
+; Test that allocas whose addresses escape to another function are still
+; instrumented by ASan, even if all accesses are in-bounds.
+;
+; This is a regression test for https://github.com/llvm/llvm-project/issues/178576
+; where passing an alloca's address to a function that performs a load on it
+; would cause a false positive. The callee's load would be instrumented by ASan,
+; but the caller's alloca would not be (because it was considered "safe"),
+; leaving the shadow memory uninitialized.
+
+; RUN: opt < %s -S -passes=asan -asan-use-stack-safety=1 -o - | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function that loads from a pointer parameter - ASan will instrument this load.
+; If the caller's alloca is not instrumented, the shadow memory will be uninitialized.
+declare void @func(ptr %ptr)
+
+; CHECK-LABEL: define void @caller
+define void @caller() sanitize_address {
+entry:
+  ; The alloca's address escapes via the call to @func.
+  ; Even though all direct accesses are in-bounds, we must instrument this
+  ; alloca so that shadow memory is properly initialized for the callee.
+  ; CHECK: call i64 @__asan_stack_malloc
+  %ptr = alloca ptr, align 8
+  store ptr null, ptr %ptr, align 8
+  call void @func(ptr %ptr)
+  ret void
+}
+
+; Test case where the alloca's address does NOT escape - should still be optimized.
+; CHECK-LABEL: define i32 @no_escape
+define i32 @no_escape() sanitize_address {
+entry:
+  ; No call passes the address, so this alloca can remain uninstrumented.
+  ; CHECK-NOT: call i64 @__asan_stack_malloc
+  %buf = alloca [10 x i8], align 1
+  %0 = load volatile i8, ptr %buf, align 1
+  ret i32 0
+}


### PR DESCRIPTION
## Summary
Stack safety analysis was marking allocas as "safe" when all accesses were in-bounds, even if the alloca's address was passed to another function. This caused ASan to skip instrumenting the alloca (no shadow memory initialization), but the callee's accesses would still be instrumented, leading to potential false positives from uninitialized shadow memory.

## Root Cause
In `StackSafetyGlobalInfo::getInfo()`, an alloca was marked as safe if `AIRange.contains(KV.second.Range)` - i.e., all accesses were within the alloca's bounds. However, this didn't account for the case where the alloca's address escapes to another function. When this happens:
1. The caller's alloca is marked "safe" → ASan skips instrumentation (no shadow init)
2. The callee's load is still instrumented (because `findAllocaForValue` returns nullptr for parameters)
3. The callee checks uninitialized shadow memory → potential false positive

## Fix
Add a check for `KV.second.Calls.empty()` to ensure the alloca's address doesn't escape before marking it as safe.

Fixes #178576

## Test plan
- Added regression test `llvm/test/Instrumentation/AddressSanitizer/asan-stack-safety-escape.ll`