### PR TITLE
[RISCV] Add macro fusion support for spacemit-x100

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVMacroFusion.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusion.td
@@ -193,8 +193,7 @@ def TuneFusionMulAdd
            "Enable MUL+ADD macrofusion",
            CheckOpcode<[MUL, MULW]>,
            CheckOpcode<[ADD, ADDW]>,
-           [],
-           [
+           epilog = [
              // Check that both instructions have the same width
              FusionPredicateWithCode<[{
                if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) !=
@@ -240,8 +239,7 @@ def TuneFusionShiftBitExtract
            "Enable SLLI+SRLI/SRAI macrofusion",
            CheckOpcode<ShiftLeft>,
            CheckOpcode<ShiftRight>,
-           [],
-           [
+           epilog = [
              // Check that both instructions have the same width
              FusionPredicateWithCode<[{
                if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) !=

--- a/llvm/lib/Target/RISCV/RISCVMacroFusion.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusion.td
@@ -190,20 +190,20 @@ def TuneFusionLogicImmReg
 //   add(w) rd, rd, rs3
 def TuneFusionMulAdd
   : SimpleFusion<"fusion-mul-add", "HasFusionMulAdd",
-           "Enable MUL+ADD macrofusion",
-           CheckOpcode<[MUL, MULW]>,
-           CheckOpcode<[ADD, ADDW]>,
-           epilog = [
-             // Check that both instructions have the same width
-             FusionPredicateWithCode<[{
-               if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) !=
-                   (SecondMI.getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask))
-                 return false;
-             }]>,
-             SecondFusionPredicateWithMCInstPredicate<
-               CheckNot<CheckSameRegOperand<0, 2>>
-             >
-           ]>;
+                 "Enable MUL+ADD macrofusion",
+                 CheckOpcode<[MUL, MULW]>,
+                 CheckOpcode<[ADD, ADDW]>,
+                 epilog = [
+                   // Check that both instructions have the same width
+                   FusionPredicateWithCode<[{
+                     if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) !=
+                         (SecondMI.getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask))
+                       return false;
+                   }]>,
+                   SecondFusionPredicateWithMCInstPredicate<
+                     CheckNot<CheckSameRegOperand<0, 2>>
+                   >
+                 ]>;
 
 // Fuse add with load or store with zero offset:
 //   add rd, rs1, rs2
@@ -236,21 +236,22 @@ def TuneFusionAddMem
 //   where imm1 <= imm2
 def TuneFusionShiftBitExtract
   : SimpleFusion<"fusion-shift-bit-extract", "HasFusionShiftBitExtract",
-           "Enable SLLI+SRLI/SRAI macrofusion",
-           CheckOpcode<ShiftLeft>,
-           CheckOpcode<ShiftRight>,
-           epilog = [
-             // Check that both instructions have the same width
-             FusionPredicateWithCode<[{
-               if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) !=
-                   (SecondMI.getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask))
-                 return false;
-             }]>,
-             // Check that FirstMI's immediate <= SecondMI's immediate
-             FusionPredicateWithCode<[{
-               if (!(FirstMI->getOperand(2).isImm() &&
-                     SecondMI.getOperand(2).isImm() &&
-                     FirstMI->getOperand(2).getImm() <= SecondMI.getOperand(2).getImm()))
-                 return false;
-             }]>,
-           ]>;
+                 "Enable SLLI+SRLI/SRAI macrofusion",
+                 CheckOpcode<ShiftLeft>,
+                 CheckOpcode<ShiftRight>,
+                 epilog = [
+                   // Check that both instructions have the same width
+                   FusionPredicateWithCode<[{
+                     if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) !=
+                         (SecondMI.getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask))
+                       return false;
+                   }]>,
+                   // Check that FirstMI's immediate <= SecondMI's immediate
+                   FusionPredicateWithCode<[{
+                     if (!(FirstMI->getOperand(2).isImm() &&
+                           SecondMI.getOperand(2).isImm() &&
+                           FirstMI->getOperand(2).getImm() <=
+                           SecondMI.getOperand(2).getImm()))
+                       return false;
+                   }]>,
+                 ]>;

--- a/llvm/lib/Target/RISCV/RISCVMacroFusion.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusion.td
@@ -93,6 +93,14 @@ def TuneLDADDFusion
                  ]>>;
 
 defvar Load = [LB, LH, LW, LD, LBU, LHU, LWU];
+defvar LoadStore = [LB, LBU, LH, LHU, LW, LWU, LD,
+                    FLH, FLW, FLD,
+                    SB, SH, SW, SD,
+                    FSH, FSW, FSD];
+defvar LogicOp = [AND, OR, XOR];
+defvar LogicImmOp = [ANDI, ORI, XORI];
+defvar ShiftLeft = [SLLI, SLLIW];
+defvar ShiftRight = [SRLI, SRLIW, SRAI, SRAIW];
 
 // Fuse add(.uw) followed by a load (lb, lh, lw, ld, lbu, lhu, lwu):
 //   add(.uw) rd, rs1, rs2
@@ -147,3 +155,118 @@ def TuneSHXADDLoadFusion
                  "Enable SH(1|2|3)ADD(.UW) + load macrofusion",
                  CheckOpcode<[SH1ADD, SH2ADD, SH3ADD, SH1ADD_UW, SH2ADD_UW, SH3ADD_UW]>,
                  CheckOpcode<Load>>;
+
+// Fuse logic operation followed by another logic operation:
+//   and/or/xor rd, rs1, rs2
+//   and/or/xor rd, rd, rs3
+let IsCommutable = 1 in
+def TuneLogicRegRegFusion
+  : SimpleFusion<"logic-reg-reg-fusion", "HasLogicRegRegFusion",
+                 "Enable AND/OR/XOR+AND/OR/XOR macrofusion",
+                 CheckOpcode<LogicOp>,
+                 CheckOpcode<LogicOp>>;
+
+// Fuse logic operation followed by logic immediate operation:
+//   and/or/xor rd, rs1, rs2
+//   andi/ori/xori rd, rd, imm
+def TuneLogicRegImmFusion
+  : SimpleFusion<"logic-reg-imm-fusion", "HasLogicRegImmFusion",
+                 "Enable AND/OR/XOR+ANDI/ORI/XORI macrofusion",
+                 CheckOpcode<LogicOp>,
+                 CheckOpcode<LogicImmOp>>;
+
+// Fuse logic immediate operation followed by logic operation:
+//   andi/ori/xori rd, rs1, imm
+//   and/or/xor rd, rd, rs2
+let IsCommutable = 1 in
+def TuneLogicImmRegFusion
+  : SimpleFusion<"logic-imm-reg-fusion", "HasLogicImmRegFusion",
+                 "Enable ANDI/ORI/XORI+AND/OR/XOR macrofusion",
+                 CheckOpcode<LogicImmOp>,
+                 CheckOpcode<LogicOp>>;
+
+// Fuse multiply followed by add:
+//   mul(w) rd, rs1, rs2
+//   add(w) rd, rd, rs3
+def TuneMulAddFusion
+  : Fusion<"mul-add-fusion", "HasMulAddFusion",
+           "Enable MUL+ADD macrofusion",
+           [
+             SecondFusionPredicateWithMCInstPredicate<
+               CheckOpcode<[ADD, ADDW]>
+             >,
+             WildcardTrue,
+             FirstFusionPredicateWithMCInstPredicate<
+               CheckOpcode<[MUL, MULW]>
+             >,
+             // Check that both instructions have the same width
+             FusionPredicateWithCode<[{
+               if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) ^
+                   (SecondMI.getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask))
+                 return false;
+             }]>,
+             SecondFusionPredicateWithMCInstPredicate<
+               CheckNot<CheckSameRegOperand<0, 2>>
+             >,
+             SecondInstHasSameReg<0, 1>,
+             OneUse,
+             TieReg<0, 1>
+           ]>;
+
+// Fuse add with load or store with zero offset:
+//   add rd, rs1, rs2
+//   load/store rt, 0(rd)
+def TuneAddMemFusion
+  : Fusion<"add-mem-fusion", "HasAddMemFusion",
+           "Enable ADD+LOAD/STORE macrofusion",
+           [
+             SecondFusionPredicateWithMCInstPredicate<
+               CheckAll<[
+                 CheckOpcode<LoadStore>,
+                 CheckIsImmOperand<2>,
+                 CheckImmOperand<2, 0>
+               ]>
+             >,
+             WildcardTrue,
+             FirstFusionPredicateWithMCInstPredicate<
+               CheckAll<[
+                 CheckOpcode<[ADD]>,
+                 CheckNot<CheckSameRegOperand<0, 1>>,
+                 CheckNot<CheckSameRegOperand<0, 2>>
+               ]>
+             >,
+             TieReg<0, 1>
+           ]>;
+
+// Fuse shift left followed by shift right for bit extraction:
+//   slli(w) rd, rs1, imm1
+//   srli(w)/srai(w) rd, rd, imm2
+//   where imm1 <= imm2
+def TuneShiftBitextraFusion
+  : Fusion<"shift-bitextra-fusion", "HasShiftBitextraFusion",
+           "Enable SLLI+SRLI/SRAI macrofusion",
+           [
+             SecondFusionPredicateWithMCInstPredicate<
+               CheckOpcode<ShiftRight>
+             >,
+             WildcardTrue,
+             FirstFusionPredicateWithMCInstPredicate<
+               CheckOpcode<ShiftLeft>
+             >,
+             // Check that both instructions have the same width
+             FusionPredicateWithCode<[{
+               if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) ^
+                   (SecondMI.getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask))
+                 return false;
+             }]>,
+             // Check that FirstMI's immediate <= SecondMI's immediate
+             FusionPredicateWithCode<[{
+               if (!(FirstMI->getOperand(2).isImm() &&
+                     SecondMI.getOperand(2).isImm() &&
+                     FirstMI->getOperand(2).getImm() <= SecondMI.getOperand(2).getImm()))
+                 return false;
+             }]>,
+             SecondInstHasSameReg<0, 1>,
+             OneUse,
+             TieReg<0, 1>
+           ]>;

--- a/llvm/lib/Target/RISCV/RISCVMacroFusion.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusion.td
@@ -160,8 +160,8 @@ def TuneSHXADDLoadFusion
 //   and/or/xor rd, rs1, rs2
 //   and/or/xor rd, rd, rs3
 let IsCommutable = 1 in
-def TuneLogicRegRegFusion
-  : SimpleFusion<"logic-reg-reg-fusion", "HasLogicRegRegFusion",
+def TuneFusionLogicRegReg
+  : SimpleFusion<"fusion-logic-reg-reg", "HasFusionLogicRegReg",
                  "Enable AND/OR/XOR+AND/OR/XOR macrofusion",
                  CheckOpcode<LogicOp>,
                  CheckOpcode<LogicOp>>;
@@ -169,8 +169,8 @@ def TuneLogicRegRegFusion
 // Fuse logic operation followed by logic immediate operation:
 //   and/or/xor rd, rs1, rs2
 //   andi/ori/xori rd, rd, imm
-def TuneLogicRegImmFusion
-  : SimpleFusion<"logic-reg-imm-fusion", "HasLogicRegImmFusion",
+def TuneFusionLogicRegImm
+  : SimpleFusion<"fusion-logic-reg-imm", "HasFusionLogicRegImm",
                  "Enable AND/OR/XOR+ANDI/ORI/XORI macrofusion",
                  CheckOpcode<LogicOp>,
                  CheckOpcode<LogicImmOp>>;
@@ -179,8 +179,8 @@ def TuneLogicRegImmFusion
 //   andi/ori/xori rd, rs1, imm
 //   and/or/xor rd, rd, rs2
 let IsCommutable = 1 in
-def TuneLogicImmRegFusion
-  : SimpleFusion<"logic-imm-reg-fusion", "HasLogicImmRegFusion",
+def TuneFusionLogicImmReg
+  : SimpleFusion<"fusion-logic-imm-reg", "HasFusionLogicImmReg",
                  "Enable ANDI/ORI/XORI+AND/OR/XOR macrofusion",
                  CheckOpcode<LogicImmOp>,
                  CheckOpcode<LogicOp>>;
@@ -188,8 +188,8 @@ def TuneLogicImmRegFusion
 // Fuse multiply followed by add:
 //   mul(w) rd, rs1, rs2
 //   add(w) rd, rd, rs3
-def TuneMulAddFusion
-  : Fusion<"mul-add-fusion", "HasMulAddFusion",
+def TuneFusionMulAdd
+  : Fusion<"fusion-mul-add", "HasFusionMulAdd",
            "Enable MUL+ADD macrofusion",
            [
              SecondFusionPredicateWithMCInstPredicate<
@@ -216,8 +216,8 @@ def TuneMulAddFusion
 // Fuse add with load or store with zero offset:
 //   add rd, rs1, rs2
 //   load/store rt, 0(rd)
-def TuneAddMemFusion
-  : Fusion<"add-mem-fusion", "HasAddMemFusion",
+def TuneFusionAddMem
+  : Fusion<"fusion-add-mem", "HasFusionAddMem",
            "Enable ADD+LOAD/STORE macrofusion",
            [
              SecondFusionPredicateWithMCInstPredicate<
@@ -242,8 +242,8 @@ def TuneAddMemFusion
 //   slli(w) rd, rs1, imm1
 //   srli(w)/srai(w) rd, rd, imm2
 //   where imm1 <= imm2
-def TuneShiftBitextraFusion
-  : Fusion<"shift-bitextra-fusion", "HasShiftBitextraFusion",
+def TuneFusionShiftBitExtract
+  : Fusion<"fusion-shift-bit-extract", "HasFusionShiftBitExtract",
            "Enable SLLI+SRLI/SRAI macrofusion",
            [
              SecondFusionPredicateWithMCInstPredicate<

--- a/llvm/lib/Target/RISCV/RISCVMacroFusion.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusion.td
@@ -201,7 +201,7 @@ def TuneFusionMulAdd
              >,
              // Check that both instructions have the same width
              FusionPredicateWithCode<[{
-               if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) ^
+               if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) !=
                    (SecondMI.getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask))
                  return false;
              }]>,
@@ -255,7 +255,7 @@ def TuneFusionShiftBitExtract
              >,
              // Check that both instructions have the same width
              FusionPredicateWithCode<[{
-               if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) ^
+               if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) !=
                    (SecondMI.getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask))
                  return false;
              }]>,

--- a/llvm/lib/Target/RISCV/RISCVMacroFusion.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusion.td
@@ -189,17 +189,12 @@ def TuneFusionLogicImmReg
 //   mul(w) rd, rs1, rs2
 //   add(w) rd, rd, rs3
 def TuneFusionMulAdd
-  : Fusion<"fusion-mul-add", "HasFusionMulAdd",
+  : SimpleFusion<"fusion-mul-add", "HasFusionMulAdd",
            "Enable MUL+ADD macrofusion",
-           [
-             SecondFusionPredicateWithMCInstPredicate<
-               CheckOpcode<[ADD, ADDW]>
-             >,
-             WildcardTrue,
-             FirstFusionPredicateWithMCInstPredicate<
-               CheckOpcode<[MUL, MULW]>
-             >,
-             // Check that both instructions have the same width
+           CheckOpcode<[MUL, MULW]>,
+           CheckOpcode<[ADD, ADDW]>,
+           [],
+           [// Check that both instructions have the same width
              FusionPredicateWithCode<[{
                if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) !=
                    (SecondMI.getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask))
@@ -207,10 +202,7 @@ def TuneFusionMulAdd
              }]>,
              SecondFusionPredicateWithMCInstPredicate<
                CheckNot<CheckSameRegOperand<0, 2>>
-             >,
-             SecondInstHasSameReg<0, 1>,
-             OneUse,
-             TieReg<0, 1>
+             >
            ]>;
 
 // Fuse add with load or store with zero offset:

--- a/llvm/lib/Target/RISCV/RISCVMacroFusion.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusion.td
@@ -194,7 +194,8 @@ def TuneFusionMulAdd
            CheckOpcode<[MUL, MULW]>,
            CheckOpcode<[ADD, ADDW]>,
            [],
-           [// Check that both instructions have the same width
+           [
+             // Check that both instructions have the same width
              FusionPredicateWithCode<[{
                if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) !=
                    (SecondMI.getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask))
@@ -235,16 +236,12 @@ def TuneFusionAddMem
 //   srli(w)/srai(w) rd, rd, imm2
 //   where imm1 <= imm2
 def TuneFusionShiftBitExtract
-  : Fusion<"fusion-shift-bit-extract", "HasFusionShiftBitExtract",
+  : SimpleFusion<"fusion-shift-bit-extract", "HasFusionShiftBitExtract",
            "Enable SLLI+SRLI/SRAI macrofusion",
+           CheckOpcode<ShiftLeft>,
+           CheckOpcode<ShiftRight>,
+           [],
            [
-             SecondFusionPredicateWithMCInstPredicate<
-               CheckOpcode<ShiftRight>
-             >,
-             WildcardTrue,
-             FirstFusionPredicateWithMCInstPredicate<
-               CheckOpcode<ShiftLeft>
-             >,
              // Check that both instructions have the same width
              FusionPredicateWithCode<[{
                if ((FirstMI->getDesc().TSFlags & RISCVII::IsSignExtendingOpWMask) !=
@@ -258,7 +255,4 @@ def TuneFusionShiftBitExtract
                      FirstMI->getOperand(2).getImm() <= SecondMI.getOperand(2).getImm()))
                  return false;
              }]>,
-             SecondInstHasSameReg<0, 1>,
-             OneUse,
-             TieReg<0, 1>
            ]>;

--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -789,7 +789,13 @@ def SPACEMIT_X100 : RISCVProcessorModel<"spacemit-x100",
                                          TuneOptimizedNF2SegmentLoadStore,
                                          TuneOptimizedNF3SegmentLoadStore,
                                          TuneOptimizedNF4SegmentLoadStore,
-                                         TuneVXRMPipelineFlush]> {
+                                         TuneVXRMPipelineFlush,
+                                         TuneLogicRegRegFusion,
+                                         TuneLogicRegImmFusion,
+                                         TuneLogicImmRegFusion,
+                                         TuneMulAddFusion,
+                                         TuneAddMemFusion,
+                                         TuneShiftBitextraFusion]> {
   let MVendorID = 0x710;
   let MArchID = 0x8000000058000002;
   let MImpID = 0x33d8a600;

--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -790,12 +790,12 @@ def SPACEMIT_X100 : RISCVProcessorModel<"spacemit-x100",
                                          TuneOptimizedNF3SegmentLoadStore,
                                          TuneOptimizedNF4SegmentLoadStore,
                                          TuneVXRMPipelineFlush,
-                                         TuneLogicRegRegFusion,
-                                         TuneLogicRegImmFusion,
-                                         TuneLogicImmRegFusion,
-                                         TuneMulAddFusion,
-                                         TuneAddMemFusion,
-                                         TuneShiftBitextraFusion]> {
+                                         TuneFusionLogicRegReg,
+                                         TuneFusionLogicRegImm,
+                                         TuneFusionLogicImmReg,
+                                         TuneFusionMulAdd,
+                                         TuneFusionAddMem,
+                                         TuneFusionShiftBitExtract]> {
   let MVendorID = 0x710;
   let MArchID = 0x8000000058000002;
   let MImpID = 0x33d8a600;

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -7,6 +7,7 @@
 ; CHECK-NEXT:   64bit                            - Implements RV64.
 ; CHECK-NEXT:   a                                - 'A' (Atomic Instructions).
 ; CHECK-NEXT:   add-load-fusion                  - Enable ADD(.UW) + load macrofusion.
+; CHECK-NEXT:   add-mem-fusion                   - Enable ADD+LOAD/STORE macrofusion.
 ; CHECK-NEXT:   addi-load-fusion                 - Enable ADDI + load macrofusion.
 ; CHECK-NEXT:   andes45                          - Andes 45-Series processors.
 ; CHECK-NEXT:   auipc-addi-fusion                - Enable AUIPC+ADDI macrofusion.
@@ -50,10 +51,14 @@
 ; CHECK-NEXT:   i                                - 'I' (Base Integer Instruction Set).
 ; CHECK-NEXT:   ld-add-fusion                    - Enable LD+ADD macrofusion.
 ; CHECK-NEXT:   log-vrgather                     - Has vrgather.vv with LMUL*log2(LMUL) latency
+; CHECK-NEXT:   logic-imm-reg-fusion             - Enable ANDI/ORI/XORI+AND/OR/XOR macrofusion.
+; CHECK-NEXT:   logic-reg-imm-fusion             - Enable AND/OR/XOR+ANDI/ORI/XORI macrofusion.
+; CHECK-NEXT:   logic-reg-reg-fusion             - Enable AND/OR/XOR+AND/OR/XOR macrofusion.
 ; CHECK-NEXT:   lui-addi-fusion                  - Enable LUI+ADDI macro fusion.
 ; CHECK-NEXT:   lui-load-fusion                  - Enable LUI + load macrofusion.
 ; CHECK-NEXT:   m                                - 'M' (Integer Multiplication and Division).
 ; CHECK-NEXT:   mips-p8700                       - MIPS p8700 processor.
+; CHECK-NEXT:   mul-add-fusion                   - Enable MUL+ADD macrofusion.
 ; CHECK-NEXT:   no-default-unroll                - Disable default unroll preference..
 ; CHECK-NEXT:   no-sink-splat-operands           - Disable sink splat operands to enable .vx, .vf,.wx, and .wf instructions.
 ; CHECK-NEXT:   no-trailing-seq-cst-fence        - Disable trailing fence for seq-cst store..
@@ -118,6 +123,7 @@
 ; CHECK-NEXT:   sha                              - 'Sha' (Augmented Hypervisor).
 ; CHECK-NEXT:   shcounterenw                     - 'Shcounterenw' (Support writeable hcounteren enable bit for any hpmcounter that is not read-only zero).
 ; CHECK-NEXT:   shgatpa                          - 'Shgatpa' (SvNNx4 mode supported for all modes supported by satp, as well as Bare).
+; CHECK-NEXT:   shift-bitextra-fusion            - Enable SLLI+SRLI/SRAI macrofusion.
 ; CHECK-NEXT:   shifted-zextw-fusion             - Enable SLLI+SRLI to be fused when computing (shifted) word zero extension.
 ; CHECK-NEXT:   shlcofideleg                     - 'Shlcofideleg' (Delegating LCOFI Interrupts to VS-mode).
 ; CHECK-NEXT:   short-forward-branch-ialu        - Enable short forward branch optimization for RVI base instructions.

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -7,7 +7,6 @@
 ; CHECK-NEXT:   64bit                            - Implements RV64.
 ; CHECK-NEXT:   a                                - 'A' (Atomic Instructions).
 ; CHECK-NEXT:   add-load-fusion                  - Enable ADD(.UW) + load macrofusion.
-; CHECK-NEXT:   add-mem-fusion                   - Enable ADD+LOAD/STORE macrofusion.
 ; CHECK-NEXT:   addi-load-fusion                 - Enable ADDI + load macrofusion.
 ; CHECK-NEXT:   andes45                          - Andes 45-Series processors.
 ; CHECK-NEXT:   auipc-addi-fusion                - Enable AUIPC+ADDI macrofusion.
@@ -47,18 +46,20 @@
 ; CHECK-NEXT:   experimental-zvqdotq             - 'Zvqdotq' (Vector quad widening 4D Dot Product).
 ; CHECK-NEXT:   f                                - 'F' (Single-Precision Floating-Point).
 ; CHECK-NEXT:   forced-atomics                   - Assume that lock-free native-width atomics are available.
+; CHECK-NEXT:   fusion-add-mem                   - Enable ADD+LOAD/STORE macrofusion.
+; CHECK-NEXT:   fusion-logic-imm-reg             - Enable ANDI/ORI/XORI+AND/OR/XOR macrofusion.
+; CHECK-NEXT:   fusion-logic-reg-imm             - Enable AND/OR/XOR+ANDI/ORI/XORI macrofusion.
+; CHECK-NEXT:   fusion-logic-reg-reg             - Enable AND/OR/XOR+AND/OR/XOR macrofusion.
+; CHECK-NEXT:   fusion-mul-add                   - Enable MUL+ADD macrofusion.
+; CHECK-NEXT:   fusion-shift-bit-extract         - Enable SLLI+SRLI/SRAI macrofusion.
 ; CHECK-NEXT:   h                                - 'H' (Hypervisor).
 ; CHECK-NEXT:   i                                - 'I' (Base Integer Instruction Set).
 ; CHECK-NEXT:   ld-add-fusion                    - Enable LD+ADD macrofusion.
 ; CHECK-NEXT:   log-vrgather                     - Has vrgather.vv with LMUL*log2(LMUL) latency
-; CHECK-NEXT:   logic-imm-reg-fusion             - Enable ANDI/ORI/XORI+AND/OR/XOR macrofusion.
-; CHECK-NEXT:   logic-reg-imm-fusion             - Enable AND/OR/XOR+ANDI/ORI/XORI macrofusion.
-; CHECK-NEXT:   logic-reg-reg-fusion             - Enable AND/OR/XOR+AND/OR/XOR macrofusion.
 ; CHECK-NEXT:   lui-addi-fusion                  - Enable LUI+ADDI macro fusion.
 ; CHECK-NEXT:   lui-load-fusion                  - Enable LUI + load macrofusion.
 ; CHECK-NEXT:   m                                - 'M' (Integer Multiplication and Division).
 ; CHECK-NEXT:   mips-p8700                       - MIPS p8700 processor.
-; CHECK-NEXT:   mul-add-fusion                   - Enable MUL+ADD macrofusion.
 ; CHECK-NEXT:   no-default-unroll                - Disable default unroll preference..
 ; CHECK-NEXT:   no-sink-splat-operands           - Disable sink splat operands to enable .vx, .vf,.wx, and .wf instructions.
 ; CHECK-NEXT:   no-trailing-seq-cst-fence        - Disable trailing fence for seq-cst store..
@@ -123,7 +124,6 @@
 ; CHECK-NEXT:   sha                              - 'Sha' (Augmented Hypervisor).
 ; CHECK-NEXT:   shcounterenw                     - 'Shcounterenw' (Support writeable hcounteren enable bit for any hpmcounter that is not read-only zero).
 ; CHECK-NEXT:   shgatpa                          - 'Shgatpa' (SvNNx4 mode supported for all modes supported by satp, as well as Bare).
-; CHECK-NEXT:   shift-bitextra-fusion            - Enable SLLI+SRLI/SRAI macrofusion.
 ; CHECK-NEXT:   shifted-zextw-fusion             - Enable SLLI+SRLI to be fused when computing (shifted) word zero extension.
 ; CHECK-NEXT:   shlcofideleg                     - 'Shlcofideleg' (Delegating LCOFI Interrupts to VS-mode).
 ; CHECK-NEXT:   short-forward-branch-ialu        - Enable short forward branch optimization for RVI base instructions.

--- a/llvm/test/CodeGen/RISCV/macro-fusion-add-mem.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-add-mem.mir
@@ -1,7 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
 # RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
-# RUN:   -mattr=+add-mem-fusion | FileCheck %s
+# RUN:   -mattr=+fusion-add-mem | FileCheck %s
 
 # Test add-mem fusion: ADD + load/store with offset 0
 # This fusion combines an address calculation (ADD) with a memory operation

--- a/llvm/test/CodeGen/RISCV/macro-fusion-add-mem.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-add-mem.mir
@@ -1,0 +1,102 @@
+# REQUIRES: asserts
+# RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
+# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -mattr=+add-mem-fusion | FileCheck %s
+
+# Test add-mem fusion: ADD + load/store with offset 0
+# This fusion combines an address calculation (ADD) with a memory operation
+# that uses the calculated address with zero offset.
+
+# CHECK: add_lb
+# CHECK: Macro fuse: {{.*}}ADD - LB
+---
+name: add_lb
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = COPY $x12
+    %4:gpr = ADD %1, %2
+    %5:gpr = LB %4, 0
+    %6:gpr = XORI %3, 3
+    $x10 = COPY %6
+    $x11 = COPY %5
+    PseudoRET
+...
+
+# CHECK: add_lh
+# CHECK: Macro fuse: {{.*}}ADD - LH
+---
+name: add_lh
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = COPY $x12
+    %4:gpr = ADD %1, %2
+    %5:gpr = LH %4, 0
+    %6:gpr = XORI %3, 3
+    $x10 = COPY %6
+    $x11 = COPY %5
+    PseudoRET
+...
+
+# CHECK: add_sw
+# CHECK: Macro fuse: {{.*}}ADD - SW
+---
+name: add_sw
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = COPY $x12
+    %4:gpr = ADD %1, %2
+    SW %3, %4, 0
+    %5:gpr = XORI %3, 3
+    $x10 = COPY %5
+    PseudoRET
+...
+
+# CHECK: add_sd
+# CHECK: Macro fuse: {{.*}}ADD - SD
+---
+name: add_sd
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = COPY $x12
+    %4:gpr = ADD %1, %2
+    SD %3, %4, 0
+    %5:gpr = XORI %3, 3
+    $x10 = COPY %5
+    PseudoRET
+...
+
+# Test that add-mem fusion does not happen with non-zero offset
+# CHECK: add_lb_no_fusion
+# CHECK-NOT: Macro fuse: {{.*}}ADD - LB
+---
+name: add_lb_no_fusion
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = COPY $x12
+    %4:gpr = ADD %1, %2
+    %5:gpr = LB %4, 8
+    %6:gpr = XORI %3, 3
+    $x10 = COPY %6
+    $x11 = COPY %5
+    PseudoRET
+...

--- a/llvm/test/CodeGen/RISCV/macro-fusion-logic-imm-reg.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-logic-imm-reg.mir
@@ -1,7 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
 # RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
-# RUN:   -mattr=+logic-imm-reg-fusion | FileCheck %s
+# RUN:   -mattr=+fusion-logic-imm-reg | FileCheck %s
 
 # Test logic immediate-register fusion: ANDI/ORI/XORI + AND/OR/XOR
 # This fusion combines a logic operation with an immediate followed by

--- a/llvm/test/CodeGen/RISCV/macro-fusion-logic-imm-reg.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-logic-imm-reg.mir
@@ -1,0 +1,62 @@
+# REQUIRES: asserts
+# RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
+# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -mattr=+logic-imm-reg-fusion | FileCheck %s
+
+# Test logic immediate-register fusion: ANDI/ORI/XORI + AND/OR/XOR
+# This fusion combines a logic operation with an immediate followed by
+# a logic operation on registers.
+
+# CHECK: andi_and
+# CHECK: Macro fuse: {{.*}}ANDI - AND
+---
+name: andi_and
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = ANDI %1, 255
+    %4:gpr = XORI %2, 3
+    %5:gpr = AND %3, %2
+    $x10 = COPY %4
+    $x11 = COPY %5
+    PseudoRET
+...
+
+# CHECK: ori_or
+# CHECK: Macro fuse: {{.*}}ORI - OR
+---
+name: ori_or
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = ORI %1, 15
+    %4:gpr = XORI %2, 3
+    %5:gpr = OR %3, %2
+    $x10 = COPY %4
+    $x11 = COPY %5
+    PseudoRET
+...
+
+# CHECK: xori_xor
+# CHECK: Macro fuse: {{.*}}XORI - XOR
+---
+name: xori_xor
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = XORI %1, 15
+    %4:gpr = XORI %2, 3
+    %5:gpr = XOR %3, %2
+    $x10 = COPY %4
+    $x11 = COPY %5
+    PseudoRET
+...

--- a/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-imm.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-imm.mir
@@ -1,0 +1,62 @@
+# REQUIRES: asserts
+# RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
+# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -mattr=+logic-reg-imm-fusion | FileCheck %s
+
+# Test logic register-immediate fusion: AND/OR/XOR + ANDI/ORI/XORI
+# This fusion combines a logic operation on registers followed by
+# a logic operation with an immediate.
+
+# CHECK: and_andi
+# CHECK: Macro fuse: {{.*}}AND - ANDI
+---
+name: and_andi
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = AND %1, %2
+    %4:gpr = XORI %2, 3
+    %5:gpr = ANDI %3, 255
+    $x10 = COPY %4
+    $x11 = COPY %5
+    PseudoRET
+...
+
+# CHECK: or_ori
+# CHECK: Macro fuse: {{.*}}OR - ORI
+---
+name: or_ori
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = OR %1, %2
+    %4:gpr = XORI %2, 3
+    %5:gpr = ORI %3, 15
+    $x10 = COPY %4
+    $x11 = COPY %5
+    PseudoRET
+...
+
+# CHECK: xor_xori
+# CHECK: Macro fuse: {{.*}}XOR - XORI
+---
+name: xor_xori
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = XOR %1, %2
+    %4:gpr = XORI %2, 3
+    %5:gpr = XORI %3, 7
+    $x10 = COPY %4
+    $x11 = COPY %5
+    PseudoRET
+...

--- a/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-imm.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-imm.mir
@@ -1,7 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
 # RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
-# RUN:   -mattr=+logic-reg-imm-fusion | FileCheck %s
+# RUN:   -mattr=+fusion-logic-reg-imm | FileCheck %s
 
 # Test logic register-immediate fusion: AND/OR/XOR + ANDI/ORI/XORI
 # This fusion combines a logic operation on registers followed by

--- a/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-reg.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-reg.mir
@@ -1,7 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
 # RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
-# RUN:   -mattr=+logic-reg-reg-fusion | FileCheck %s
+# RUN:   -mattr=+fusion-logic-reg-reg | FileCheck %s
 
 # Test logic register-register fusion: AND/OR/XOR + AND/OR/XOR
 # This fusion combines two consecutive logic operations on registers.

--- a/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-reg.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-logic-reg-reg.mir
@@ -1,0 +1,64 @@
+# REQUIRES: asserts
+# RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
+# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -mattr=+logic-reg-reg-fusion | FileCheck %s
+
+# Test logic register-register fusion: AND/OR/XOR + AND/OR/XOR
+# This fusion combines two consecutive logic operations on registers.
+
+# CHECK: and_or
+# CHECK: Macro fuse: {{.*}}AND - OR
+---
+name: and_or
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = COPY $x12
+    %4:gpr = AND %1, %2
+    %5:gpr = XORI %3, 3
+    %6:gpr = OR %4, %3
+    $x10 = COPY %5
+    $x11 = COPY %6
+    PseudoRET
+...
+
+# CHECK: xor_and
+# CHECK: Macro fuse: {{.*}}XOR - AND
+---
+name: xor_and
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = COPY $x12
+    %4:gpr = XOR %1, %2
+    %5:gpr = XORI %3, 3
+    %6:gpr = AND %4, %3
+    $x10 = COPY %5
+    $x11 = COPY %6
+    PseudoRET
+...
+
+# CHECK: or_xor
+# CHECK: Macro fuse: {{.*}}OR - XOR
+---
+name: or_xor
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = COPY $x12
+    %4:gpr = OR %1, %2
+    %5:gpr = XORI %3, 3
+    %6:gpr = XOR %4, %3
+    $x10 = COPY %5
+    $x11 = COPY %6
+    PseudoRET
+...

--- a/llvm/test/CodeGen/RISCV/macro-fusion-mul-add.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-mul-add.mir
@@ -1,0 +1,67 @@
+# REQUIRES: asserts
+# RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
+# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -mattr=+m,+mul-add-fusion | FileCheck %s
+
+# Test mul-add fusion: MUL + ADD and MULW + ADDW
+# This fusion combines a multiplication followed by an addition.
+# Both instructions must have the same width (W suffix or not).
+
+# CHECK: mul_add
+# CHECK: Macro fuse: {{.*}}MUL - ADD
+---
+name: mul_add
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = COPY $x12
+    %4:gpr = MUL %1, %2
+    %5:gpr = XORI %3, 3
+    %6:gpr = ADD %4, %3
+    $x10 = COPY %5
+    $x11 = COPY %6
+    PseudoRET
+...
+
+# CHECK: mulw_addw
+# CHECK: Macro fuse: {{.*}}MULW - ADDW
+---
+name: mulw_addw
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = COPY $x12
+    %4:gpr = MULW %1, %2
+    %5:gpr = XORI %3, 3
+    %6:gpr = ADDW %4, %3
+    $x10 = COPY %5
+    $x11 = COPY %6
+    PseudoRET
+...
+
+# Test that fusion does not happen with different widths
+# CHECK: mul_addw_no_fusion
+# CHECK-NOT: Macro fuse: {{.*}}MUL - ADDW
+---
+name: mul_addw_no_fusion
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %1:gpr = COPY $x10
+    %2:gpr = COPY $x11
+    %3:gpr = COPY $x12
+    %4:gpr = MUL %1, %2
+    %5:gpr = XORI %3, 3
+    %6:gpr = ADDW %4, %3
+    $x10 = COPY %5
+    $x11 = COPY %6
+    PseudoRET
+...
+

--- a/llvm/test/CodeGen/RISCV/macro-fusion-mul-add.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-mul-add.mir
@@ -1,7 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
 # RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
-# RUN:   -mattr=+m,+mul-add-fusion | FileCheck %s
+# RUN:   -mattr=+m,+fusion-mul-add | FileCheck %s
 
 # Test mul-add fusion: MUL + ADD and MULW + ADDW
 # This fusion combines a multiplication followed by an addition.

--- a/llvm/test/CodeGen/RISCV/macro-fusion-shift-bit-extract.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-shift-bit-extract.mir
@@ -1,9 +1,9 @@
 # REQUIRES: asserts
 # RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
 # RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
-# RUN:   -mattr=+shift-bitextra-fusion | FileCheck %s
+# RUN:   -mattr=+fusion-shift-bit-extract | FileCheck %s
 
-# Test shift-bitextra fusion: SLLI + SRLI/SRAI
+# Test shift-bit-extract fusion: SLLI + SRLI/SRAI
 # This fusion combines left shift followed by right shift with the constraint
 # that the first immediate must be less than or equal to the second immediate.
 # It also checks that both instructions have the same width (W suffix or not).

--- a/llvm/test/CodeGen/RISCV/macro-fusion-shift-bitextra.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusion-shift-bitextra.mir
@@ -1,0 +1,132 @@
+# REQUIRES: asserts
+# RUN: llc -mtriple=riscv64-linux-gnu -x=mir < %s \
+# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -mattr=+shift-bitextra-fusion | FileCheck %s
+
+# Test shift-bitextra fusion: SLLI + SRLI/SRAI
+# This fusion combines left shift followed by right shift with the constraint
+# that the first immediate must be less than or equal to the second immediate.
+# It also checks that both instructions have the same width (W suffix or not).
+
+# CHECK: slli_srli
+# CHECK: Macro fuse: {{.*}}SLLI - SRLI
+---
+name: slli_srli
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLI %1, 8
+    %3:gpr = XORI %1, 3
+    %4:gpr = SRLI %2, 16
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: slli_srai
+# CHECK: Macro fuse: {{.*}}SLLI - SRAI
+---
+name: slli_srai
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLI %1, 4
+    %3:gpr = XORI %1, 3
+    %4:gpr = SRAI %2, 8
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# Test with equal immediates
+# CHECK: slli_srai_equal
+# CHECK: Macro fuse: {{.*}}SLLI - SRAI
+---
+name: slli_srai_equal
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLI %1, 12
+    %3:gpr = XORI %1, 3
+    %4:gpr = SRAI %2, 12
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# Test W-suffix variants (32-bit operations on RV64)
+# CHECK: slliw_srliw
+# CHECK: Macro fuse: {{.*}}SLLIW - SRLIW
+---
+name: slliw_srliw
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLIW %1, 8
+    %3:gpr = XORI %1, 3
+    %4:gpr = SRLIW %2, 16
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: slliw_sraiw
+# CHECK: Macro fuse: {{.*}}SLLIW - SRAIW
+---
+name: slliw_sraiw
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLIW %1, 4
+    %3:gpr = XORI %1, 3
+    %4:gpr = SRAIW %2, 8
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# Test that fusion does not happen with different widths
+# CHECK: slli_srliw_no_fusion
+# CHECK-NOT: Macro fuse: {{.*}}SLLI - SRLIW
+---
+name: slli_srliw_no_fusion
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLI %1, 8
+    %3:gpr = XORI %1, 3
+    %4:gpr = SRLIW %2, 16
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# Test that fusion does not happen when imm1 > imm2
+# CHECK: slli_srli_no_fusion
+# CHECK-NOT: Macro fuse: {{.*}}SLLI - SRLI
+---
+name: slli_srli_no_fusion
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = SLLI %1, 16
+    %3:gpr = XORI %1, 3
+    %4:gpr = SRLI %2, 8
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...


### PR DESCRIPTION
New fusion types:
- AND(I)/OR(I)/XOR(I) + AND(I)/OR(I)/XOR(I) (3 variants)
- MUL(W)+ADD(W)
- ADD + LOAD/STORE
- SLLI + SRLI/SRAI