### PR TITLE
[mlir][Linalg] Preserve discardable/user-defined attributes during generalization

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/Generalization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Generalization.cpp
@@ -65,7 +65,11 @@ FailureOr<GenericOp> mlir::linalg::generalizeNamedOp(RewriterBase &rewriter,
   rewriter.inlineRegionBefore(linalgOp->getRegion(0), genericOp.getRegion(),
                               genericOp.getRegion().begin());
 
-  // Preserve discardable (user-defined) attributes from the original op.
+  // Discardable attributes carry user-defined metadata (e.g., annotations for
+  // downstream passes). Generalization is a semantics-preserving
+  // transformation, so dropping this metadata would be unexpected. This is safe
+  // because discardable attributes are by definition independent of op
+  // semantics.
   genericOp->setDiscardableAttrs(linalgOp->getDiscardableAttrDictionary());
 
   rewriter.replaceOp(linalgOp, genericOp->getResults());

--- a/mlir/lib/Dialect/Linalg/Transforms/Generalization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Generalization.cpp
@@ -64,6 +64,10 @@ FailureOr<GenericOp> mlir::linalg::generalizeNamedOp(RewriterBase &rewriter,
                         outputs, indexingMaps, iterators);
   rewriter.inlineRegionBefore(linalgOp->getRegion(0), genericOp.getRegion(),
                               genericOp.getRegion().begin());
+
+  // Preserve discardable (user-defined) attributes from the original op.
+  genericOp->setDiscardableAttrs(linalgOp->getDiscardableAttrDictionary());
+
   rewriter.replaceOp(linalgOp, genericOp->getResults());
   return genericOp;
 }

--- a/mlir/test/Dialect/Linalg/generalize-named-ops.mlir
+++ b/mlir/test/Dialect/Linalg/generalize-named-ops.mlir
@@ -1261,3 +1261,21 @@ func.func @contract_matmul_bcast_a_b(
       outs(%C: memref<3x7xf32>)
   return
 }
+
+// -----
+
+// Test that discardable (user-defined) attributes are preserved during
+// generalization.
+
+func.func @preserve_discardable_attrs(%A : tensor<16x8xf32>,
+                                            %B : tensor<8x32xf32>,
+                                            %C : tensor<16x32xf32>) -> tensor<16x32xf32> {
+  %0 = linalg.matmul {my_custom_attr = "preserved", another_attr = 42 : i64}
+                     ins(%A, %B: tensor<16x8xf32>, tensor<8x32xf32>)
+                     outs(%C: tensor<16x32xf32>) -> tensor<16x32xf32>
+  return %0: tensor<16x32xf32>
+}
+
+// CHECK-LABEL: func @preserve_discardable_attrs
+// CHECK:         linalg.generic
+// CHECK-SAME:        attrs = {another_attr = 42 : i64, my_custom_attr = "preserved"}


### PR DESCRIPTION
-- As observed in a [downstream project](https://github.com/iree-org/iree/pull/23294#discussion_r2734982998) : the named to generize linalg op conversion wasn't preserving discardable attributes.
-- This commit aims to fix the same.
-- Only a single test case is added as the change applies to any named linalg op's generalization.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>