### PR TITLE
[AArch64] Move the existing fcvt fixed point selection to tblgen.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
@@ -479,8 +479,13 @@ private:
   bool SelectCVTFixedPosOperand(SDValue N, SDValue &FixedPos) {
     return SelectCVTFixedPosOperand(N, FixedPos, RegWidth);
   }
-
   bool SelectCVTFixedPosOperand(SDValue N, SDValue &FixedPos, unsigned Width);
+
+  template <unsigned RegWidth>
+  bool SelectCVTFixedPointVec(SDValue N, SDValue &FixedPos) {
+    return SelectCVTFixedPointVec(N, FixedPos, RegWidth);
+  }
+  bool SelectCVTFixedPointVec(SDValue N, SDValue &FixedPos, unsigned Width);
 
   template<unsigned RegWidth>
   bool SelectCVTFixedPosRecipOperand(SDValue N, SDValue &FixedPos) {
@@ -3980,6 +3985,38 @@ bool AArch64DAGToDAGISel::tryShiftAmountMod(SDNode *N) {
   return true;
 }
 
+static unsigned CheckFixedPointOperandConstant(APFloat &FVal, unsigned RegWidth,
+                                               bool isReciprocal) {
+  // An FCVT[SU] instruction performs: convertToInt(Val * 2^fbits) where fbits
+  // is between 1 and 32 for a destination w-register, or 1 and 64 for an
+  // x-register.
+  //
+  // By this stage, we've detected (fp_to_[su]int (fmul Val, THIS_NODE)) so we
+  // want THIS_NODE to be 2^fbits. This is much easier to deal with using
+  // integers.
+  bool IsExact;
+
+  if (isReciprocal)
+    if (!FVal.getExactInverse(&FVal))
+      return 0;
+
+  // fbits is between 1 and 64 in the worst-case, which means the fmul
+  // could have 2^64 as an actual operand. Need 65 bits of precision.
+  APSInt IntVal(65, true);
+  FVal.convertToInteger(IntVal, APFloat::rmTowardZero, &IsExact);
+
+  // N.b. isPowerOf2 also checks for > 0.
+  if (!IsExact || !IntVal.isPowerOf2())
+    return 0;
+  unsigned FBits = IntVal.logBase2();
+
+  // Checks above should have guaranteed that we haven't lost information in
+  // finding FBits, but it must still be in range.
+  if (FBits == 0 || FBits > RegWidth)
+    return 0;
+  return FBits;
+}
+
 static bool checkCVTFixedPointOperandWithFBits(SelectionDAG *CurDAG, SDValue N,
                                                SDValue &FixedPos,
                                                unsigned RegWidth,
@@ -3999,48 +4036,81 @@ static bool checkCVTFixedPointOperandWithFBits(SelectionDAG *CurDAG, SDValue N,
   } else
     return false;
 
-  // An FCVT[SU] instruction performs: convertToInt(Val * 2^fbits) where fbits
-  // is between 1 and 32 for a destination w-register, or 1 and 64 for an
-  // x-register.
-  //
-  // By this stage, we've detected (fp_to_[su]int (fmul Val, THIS_NODE)) so we
-  // want THIS_NODE to be 2^fbits. This is much easier to deal with using
-  // integers.
-  bool IsExact;
+  if (unsigned FBits =
+          CheckFixedPointOperandConstant(FVal, RegWidth, isReciprocal)) {
+    FixedPos = CurDAG->getTargetConstant(FBits, SDLoc(N), MVT::i32);
+    return true;
+  }
 
-  if (isReciprocal)
-    if (!FVal.getExactInverse(&FVal))
-      return false;
-
-  // fbits is between 1 and 64 in the worst-case, which means the fmul
-  // could have 2^64 as an actual operand. Need 65 bits of precision.
-  APSInt IntVal(65, true);
-  FVal.convertToInteger(IntVal, APFloat::rmTowardZero, &IsExact);
-
-  // N.b. isPowerOf2 also checks for > 0.
-  if (!IsExact || !IntVal.isPowerOf2())
-    return false;
-  unsigned FBits = IntVal.logBase2();
-
-  // Checks above should have guaranteed that we haven't lost information in
-  // finding FBits, but it must still be in range.
-  if (FBits == 0 || FBits > RegWidth) return false;
-
-  FixedPos = CurDAG->getTargetConstant(FBits, SDLoc(N), MVT::i32);
-  return true;
+  return false;
 }
 
 bool AArch64DAGToDAGISel::SelectCVTFixedPosOperand(SDValue N, SDValue &FixedPos,
                                                    unsigned RegWidth) {
   return checkCVTFixedPointOperandWithFBits(CurDAG, N, FixedPos, RegWidth,
-                                            false);
+                                            /*isReciprocal*/ false);
+}
+
+bool AArch64DAGToDAGISel::SelectCVTFixedPointVec(SDValue N, SDValue &FixedPos,
+                                                 unsigned RegWidth) {
+  if ((N.getOpcode() == AArch64ISD::NVCAST || N.getOpcode() == ISD::BITCAST) &&
+      N.getValueType().getScalarSizeInBits() ==
+          N.getOperand(0).getValueType().getScalarSizeInBits())
+    N = N.getOperand(0);
+
+  auto ImmToFloat = [RegWidth](APInt Imm) {
+    switch (RegWidth) {
+    case 16:
+      return APFloat(APFloat::IEEEhalf(), Imm);
+    case 32:
+      return APFloat(APFloat::IEEEsingle(), Imm);
+    case 64:
+      return APFloat(APFloat::IEEEdouble(), Imm);
+    default:
+      llvm_unreachable("Unexpected RegWidth!");
+    };
+  };
+
+  APFloat FVal(0.0);
+  switch (N->getOpcode()) {
+  case AArch64ISD::MOVIshift:
+    FVal = ImmToFloat(APInt(RegWidth, N.getConstantOperandVal(0)
+                                          << N.getConstantOperandVal(1)));
+    break;
+  case AArch64ISD::FMOV:
+    assert(RegWidth == 32 || RegWidth == 64);
+    if (RegWidth == 32)
+      FVal = ImmToFloat(
+          APInt(RegWidth, (uint32_t)AArch64_AM::decodeAdvSIMDModImmType11(
+                              N.getConstantOperandVal(0))));
+    else
+      FVal = ImmToFloat(APInt(RegWidth, AArch64_AM::decodeAdvSIMDModImmType12(
+                                            N.getConstantOperandVal(0))));
+    break;
+  case AArch64ISD::DUP:
+    if (isa<ConstantSDNode>(N.getOperand(0)))
+      FVal = ImmToFloat(N.getConstantOperandAPInt(0).trunc(RegWidth));
+    else
+      return false;
+    break;
+  default:
+    return false;
+  }
+
+  if (unsigned FBits = CheckFixedPointOperandConstant(FVal, RegWidth,
+                                                      /*isReciprocal*/ false)) {
+    FixedPos = CurDAG->getTargetConstant(FBits, SDLoc(N), MVT::i32);
+    return true;
+  }
+
+  return false;
 }
 
 bool AArch64DAGToDAGISel::SelectCVTFixedPosRecipOperand(SDValue N,
                                                         SDValue &FixedPos,
                                                         unsigned RegWidth) {
   return checkCVTFixedPointOperandWithFBits(CurDAG, N, FixedPos, RegWidth,
-                                            true);
+                                            /*isReciprocal*/ true);
 }
 
 // Inspects a register string of the form o0:op1:CRn:CRm:op2 gets the fields

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -20631,70 +20631,7 @@ static SDValue performFpToIntCombine(SDNode *N, SelectionDAG &DAG,
           tryToReplaceScalarFPConversionWithSVE(N, DAG, DCI, Subtarget))
     return Res;
 
-  if (!Subtarget->isNeonAvailable())
-    return SDValue();
-
-  if (!N->getValueType(0).isSimple())
-    return SDValue();
-
-  SDValue Op = N->getOperand(0);
-  if (!Op.getValueType().isSimple() || Op.getOpcode() != ISD::FMUL)
-    return SDValue();
-
-  if (!Op.getValueType().is64BitVector() && !Op.getValueType().is128BitVector())
-    return SDValue();
-
-  SDValue ConstVec = Op->getOperand(1);
-  if (!isa<BuildVectorSDNode>(ConstVec))
-    return SDValue();
-
-  MVT FloatTy = Op.getSimpleValueType().getVectorElementType();
-  uint32_t FloatBits = FloatTy.getSizeInBits();
-  if (FloatBits != 32 && FloatBits != 64 &&
-      (FloatBits != 16 || !Subtarget->hasFullFP16()))
-    return SDValue();
-
-  MVT IntTy = N->getSimpleValueType(0).getVectorElementType();
-  uint32_t IntBits = IntTy.getSizeInBits();
-  if (IntBits != 16 && IntBits != 32 && IntBits != 64)
-    return SDValue();
-
-  // Avoid conversions where iN is larger than the float (e.g., float -> i64).
-  if (IntBits > FloatBits)
-    return SDValue();
-
-  BitVector UndefElements;
-  BuildVectorSDNode *BV = cast<BuildVectorSDNode>(ConstVec);
-  int32_t Bits = IntBits == 64 ? 64 : 32;
-  int32_t C = BV->getConstantFPSplatPow2ToLog2Int(&UndefElements, Bits + 1);
-  if (C == -1 || C == 0 || C > Bits)
-    return SDValue();
-
-  EVT ResTy = Op.getValueType().changeVectorElementTypeToInteger();
-  if (!DAG.getTargetLoweringInfo().isTypeLegal(ResTy))
-    return SDValue();
-
-  if (N->getOpcode() == ISD::FP_TO_SINT_SAT ||
-      N->getOpcode() == ISD::FP_TO_UINT_SAT) {
-    EVT SatVT = cast<VTSDNode>(N->getOperand(1))->getVT();
-    if (SatVT.getScalarSizeInBits() != IntBits || IntBits != FloatBits)
-      return SDValue();
-  }
-
-  SDLoc DL(N);
-  bool IsSigned = (N->getOpcode() == ISD::FP_TO_SINT ||
-                   N->getOpcode() == ISD::FP_TO_SINT_SAT);
-  unsigned IntrinsicOpcode = IsSigned ? Intrinsic::aarch64_neon_vcvtfp2fxs
-                                      : Intrinsic::aarch64_neon_vcvtfp2fxu;
-  SDValue FixConv =
-      DAG.getNode(ISD::INTRINSIC_WO_CHAIN, DL, ResTy,
-                  DAG.getTargetConstant(IntrinsicOpcode, DL, MVT::i32),
-                  Op->getOperand(0), DAG.getTargetConstant(C, DL, MVT::i32));
-  // We can handle smaller integers by generating an extra trunc.
-  if (IntBits < FloatBits)
-    FixConv = DAG.getNode(ISD::TRUNCATE, DL, N->getValueType(0), FixConv);
-
-  return FixConv;
+  return SDValue();
 }
 
 // Given a tree of and/or(csel(0, 1, cc0), csel(0, 1, cc1)), we may be able to

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -9081,6 +9081,25 @@ defm SCVTF: SIMDVectorRShiftToFP<0, 0b11100, "scvtf",
 defm RSHRN   : SIMDVectorRShiftNarrowBHS<0, 0b10001, "rshrn", AArch64rshrn>;
 defm SHL     : SIMDVectorLShiftBHSD<0, 0b01010, "shl", AArch64vshl>;
 
+class fixedpoint_vec_f64<ValueType FloatVT>
+    : ComplexPattern<FloatVT, 1, "SelectCVTFixedPointVec<64>">;
+class fixedpoint_vec_f32<ValueType FloatVT>
+    : ComplexPattern<FloatVT, 1, "SelectCVTFixedPointVec<32>">;
+class fixedpoint_vec_f16<ValueType FloatVT>
+    : ComplexPattern<FloatVT, 1, "SelectCVTFixedPointVec<16>">;
+// This thing just allows us to change the type of the node produced. The imm
+// value we want is already in V from SelectCVTFixedPointVec.
+def fixedpoint_vec_xform : SDNodeXForm<timm, [{
+  (void)N;
+  return V;
+}]>;
+
+def fixedpoint_v2f64 : fixedpoint_vec_f64<v2f64>;
+def fixedpoint_v2f32 : fixedpoint_vec_f32<v2f32>;
+def fixedpoint_v4f32 : fixedpoint_vec_f32<v4f32>;
+def fixedpoint_v4f16 : fixedpoint_vec_f16<v4f16>;
+def fixedpoint_v8f16 : fixedpoint_vec_f16<v8f16>;
+
 let Predicates = [HasNEON] in {
 def : Pat<(v2f32 (sint_to_fp (v2i32 (AArch64vashr_exact v2i32:$Vn, i32:$shift)))),
           (SCVTFv2i32_shift $Vn, vecshiftR32:$shift)>;
@@ -9097,7 +9116,7 @@ def : Pat<(v8f16 (sint_to_fp (v8i16 (AArch64vashr_exact v8i16:$Vn, i32:$shift)))
           (SCVTFv8i16_shift $Vn, vecshiftR16:$shift)>;
 }
 
-multiclass FCVTPat<ValueType FVT, ValueType IVT, ValueType ScalarVT, RegisterOperand RC> {
+multiclass FCVTPat<ValueType FVT, ValueType IVT, ValueType ScalarVT, RegisterOperand RC, ComplexPattern fixedpoint> {
   // fptosi(fadd(x, x)) -> FCVTZS_shift x, 1
   def : Pat<(IVT (fp_to_sint (FVT (fadd RC:$Vn, RC:$Vn)))),
             (!cast<Instruction>("FCVTZS"#IVT#"_shift") (FVT RC:$Vn), (i32 1))>;
@@ -9113,16 +9132,28 @@ multiclass FCVTPat<ValueType FVT, ValueType IVT, ValueType ScalarVT, RegisterOpe
             (!cast<Instruction>("FCVTZU"#IVT#"_shift") (FVT RC:$Vn), (i32 1))>;
   def : Pat<(IVT (fp_to_uint_sat_gi (FVT (fadd RC:$Vn, RC:$Vn)))),
             (!cast<Instruction>("FCVTZU"#IVT#"_shift") (FVT RC:$Vn), (i32 1))>;
+
+  // fptosi(fmul(x, power2)) -> FCVTZS_shift x, log2(power2)
+  def : Pat<(IVT (fp_to_sint (FVT (fmul FVT:$Vn, fixedpoint:$scale)))),
+            (!cast<Instruction>("FCVTZS"#IVT#"_shift") $Vn, (fixedpoint_vec_xform fixedpoint:$scale))>;
+  def : Pat<(IVT (fp_to_sint_sat (FVT (fmul FVT:$Vn, fixedpoint:$scale)), ScalarVT)),
+            (!cast<Instruction>("FCVTZS"#IVT#"_shift") $Vn, (fixedpoint_vec_xform fixedpoint:$scale))>;
+
+  // fptoui(fmul(x, power2)) -> FCVTZU_shift x, log2(power2)
+  def : Pat<(IVT (fp_to_uint (FVT (fmul FVT:$Vn, fixedpoint:$scale)))),
+            (!cast<Instruction>("FCVTZU"#IVT#"_shift") $Vn, (fixedpoint_vec_xform fixedpoint:$scale))>;
+  def : Pat<(IVT (fp_to_uint_sat (FVT (fmul FVT:$Vn, fixedpoint:$scale)), ScalarVT)),
+            (!cast<Instruction>("FCVTZU"#IVT#"_shift") $Vn, (fixedpoint_vec_xform fixedpoint:$scale))>;
 }
 
 let Predicates = [HasNEON] in {
-defm : FCVTPat<v2f64, v2i64, i64, V128>;
-defm : FCVTPat<v2f32, v2i32, i32, V64>;
-defm : FCVTPat<v4f32, v4i32, i32, V128>;
+defm : FCVTPat<v2f64, v2i64, i64, V128, fixedpoint_v2f64>;
+defm : FCVTPat<v2f32, v2i32, i32, V64, fixedpoint_v2f32>;
+defm : FCVTPat<v4f32, v4i32, i32, V128, fixedpoint_v4f32>;
 }
 let Predicates = [HasNEON, HasFullFP16] in {
-defm : FCVTPat<v4f16, v4i16, i16, V64>;
-defm : FCVTPat<v8f16, v8i16, i16, V128>;
+defm : FCVTPat<v4f16, v4i16, i16, V64, fixedpoint_v4f16>;
+defm : FCVTPat<v8f16, v8i16, i16, V128, fixedpoint_v8f16>;
 }
 
 // X << 1 ==> X + X

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AddressingModes.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AddressingModes.h
@@ -769,7 +769,7 @@ static inline uint64_t decodeAdvSIMDModImmType12(uint8_t Imm) {
   if (Imm & 0x04) EncVal |= 0x0004000000000000ULL;
   if (Imm & 0x02) EncVal |= 0x0002000000000000ULL;
   if (Imm & 0x01) EncVal |= 0x0001000000000000ULL;
-  return (EncVal << 32) | EncVal;
+  return EncVal;
 }
 
 /// Returns true if Imm is the concatenation of a repeating pattern of type T.


### PR DESCRIPTION
This removes the existing fcvt(fmul) -> vcvtfp2fx intrinsics combine from selection dag, moving the code into a tablegen pattern like the other fixed-point converts are. This will allow gisel to share the same patterns (but this part is just SDAG).

The is expected to be roughly an NFC, the existing tests keep passing, but there might be some differences due to performing the optimization later.