### PR TITLE
[GitHub] Include memory tagging sources in sanitizer

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -184,6 +184,8 @@ compiler-rt:msan:
 compiler-rt:sanitizer:
   - changed-files:
     - any-glob-to-any-file:
+      - llvm/include/llvm/Transforms/Utils/MemoryTaggingSupport.*
+      - llvm/lib/Target/AArch64/AArch64StackTagging.cpp
       - llvm/lib/Transforms/Instrumentation/*Sanitizer*
       - compiler-rt/lib/interception/**
       - compiler-rt/lib/*san*/**


### PR DESCRIPTION
These are part of sanitizer implementation.