### PR TITLE
[ADT] Add LLVM_UNLIKELY hint to SmallVector::reserve()

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -664,7 +664,7 @@ public:
   }
 
   void reserve(size_type N) {
-    if (this->capacity() < N)
+    if (LLVM_UNLIKELY(this->capacity() < N))
       this->grow(N);
   }
 


### PR DESCRIPTION
## Summary
Add `LLVM_UNLIKELY` branch prediction hint to `SmallVector::reserve()` for the case where reallocation is needed.

## Rationale
- The common case for `reserve()` is that capacity is already sufficient (defensive calls, repeated reserves)
- This matches the existing pattern in `reserveForParamAndGetAddressImpl()` at line 238 which uses `LLVM_LIKELY` for the same capacity check
- Helps branch predictor optimize for the fast path

## Test plan
- [ ] Existing SmallVector unit tests pass
- [ ] LLVM builds successfully