### PR TITLE
[compiler-rt][lit] Avoid page size check for bare-metal

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -1011,7 +1011,8 @@ except ImportError:
         return 4096
 
 
-config.available_features.add(f"page-size-{target_page_size()}")
+if config.target_os != "Generic":
+    config.available_features.add(f"page-size-{target_page_size()}")
 
 if config.expensive_checks:
     config.available_features.add("expensive_checks")


### PR DESCRIPTION
When compiler-rt is built and tested for bare-metal, there is no need to check page sizes.

This change avoids an unnecessary initial check and output when configured with `-DCMAKE_SYSTEM_NAME=Generic`:
```console
$ ninja check-compiler-rt
[0/1] Running compiler_rt regression tests
  <emulator>: Error: 'python3': No such file
 [...]
```