### PR TITLE
[libc++][test] Make `EvilContainer` a sequence container

### DIFF
--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/move_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/move_exceptions.pass.cpp
@@ -27,6 +27,8 @@
 static int countdown = 0;
 
 struct EvilContainer : std::vector<int> {
+  using std::vector<int>::vector;
+
   EvilContainer() = default;
   EvilContainer(EvilContainer&& rhs) {
     // Throw on move-construction.
@@ -35,6 +37,11 @@ struct EvilContainer : std::vector<int> {
       rhs.insert(rhs.end(), 0);
       throw 42;
     }
+  }
+
+  EvilContainer& operator=(std::initializer_list<int> il) {
+    std::vector<int>::operator=(il);
+    return *this;
   }
 };
 

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move_exceptions.pass.cpp
@@ -27,6 +27,8 @@
 static int countdown = 0;
 
 struct EvilContainer : std::vector<int> {
+  using std::vector<int>::vector;
+
   EvilContainer() = default;
   EvilContainer(EvilContainer&& rhs) {
     // Throw on move-construction.
@@ -35,6 +37,11 @@ struct EvilContainer : std::vector<int> {
       rhs.insert(rhs.end(), 0);
       throw 42;
     }
+  }
+
+  EvilContainer& operator=(std::initializer_list<int> il) {
+    std::vector<int>::operator=(il);
+    return *this;
   }
 };
 

--- a/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/move.pass.cpp
@@ -159,6 +159,8 @@ void test_move_noexcept() {
 static int countdown = 0;
 
 struct EvilContainer : std::vector<int> {
+  using std::vector<int>::vector;
+
   EvilContainer() = default;
   EvilContainer(EvilContainer&& rhs) {
     // Throw on move-construction.
@@ -167,6 +169,11 @@ struct EvilContainer : std::vector<int> {
       rhs.insert(rhs.end(), 0);
       throw 42;
     }
+  }
+
+  EvilContainer& operator=(std::initializer_list<int> il) {
+    std::vector<int>::operator=(il);
+    return *this;
   }
 };
 

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/move.pass.cpp
@@ -150,6 +150,8 @@ constexpr bool test() {
 static int countdown = 0;
 
 struct EvilContainer : std::vector<int> {
+  using std::vector<int>::vector;
+
   EvilContainer() = default;
   EvilContainer(EvilContainer&& rhs) {
     // Throw on move-construction.
@@ -158,6 +160,11 @@ struct EvilContainer : std::vector<int> {
       rhs.insert(rhs.end(), 0);
       throw 42;
     }
+  }
+
+  EvilContainer& operator=(std::initializer_list<int> il) {
+    std::vector<int>::operator=(il);
+    return *this;
   }
 };
 


### PR DESCRIPTION
In tests for flat container adaptors, the `EvilContainer` type doesn't have sufficient constructors to meet the requirements for sequence containers ([sequence.reqmts]). Also, assignment from an `initializer_list` doesn't have correct return type.

This patch makes `EvilContainer` inherit constructors from `vector<int>` and add a correct assignment operator from `initializer_list<int>`.

Fixes #178624.