### PR TITLE
[libclang/python] Ignore our own DeprecationWarnings in tests

### DIFF
--- a/clang/bindings/python/tests/CMakeLists.txt
+++ b/clang/bindings/python/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ add_custom_target(check-clang-python
     COMMAND ${CMAKE_COMMAND} -E env
             CLANG_NO_DEFAULT_CONFIG=1
             LIBCLANG_LIBRARY_PATH=$<TARGET_FILE_DIR:libclang>
-            "${Python3_EXECUTABLE}" -W ignore:DeprecationWarning::clang -m unittest discover
+            "${Python3_EXECUTABLE}" -m unittest discover
     DEPENDS libclang
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 

--- a/clang/bindings/python/tests/CMakeLists.txt
+++ b/clang/bindings/python/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ add_custom_target(check-clang-python
     COMMAND ${CMAKE_COMMAND} -E env
             CLANG_NO_DEFAULT_CONFIG=1
             LIBCLANG_LIBRARY_PATH=$<TARGET_FILE_DIR:libclang>
-            "${Python3_EXECUTABLE}" -m unittest discover
+            "${Python3_EXECUTABLE}" -W ignore:DeprecationWarning::clang -m unittest discover
     DEPENDS libclang
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -235,7 +235,7 @@ void f(P x, Q y) {
             with warnings.catch_warnings(record=True):
                 self.assertEqual(
                     SPELLING_CACHE[kind_key.value],
-                    CompletionChunk.SPELLING_CACHE[kind_key]
+                    CompletionChunk.SPELLING_CACHE[kind_key],
                 )
 
     def test_spelling_cache_missing_attribute(self):

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -234,7 +234,8 @@ void f(P x, Q y) {
         for kind_key in kind_keys:
             with warnings.catch_warnings(record=True):
                 self.assertEqual(
-                    SPELLING_CACHE[kind_key.value], CompletionChunk.SPELLING_CACHE[kind_key]
+                    SPELLING_CACHE[kind_key.value],
+                    CompletionChunk.SPELLING_CACHE[kind_key]
                 )
 
     def test_spelling_cache_missing_attribute(self):

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -9,6 +9,7 @@ from clang.cindex import (
 
 import unittest
 from pathlib import Path
+import warnings
 
 
 class TestCodeCompletion(unittest.TestCase):
@@ -16,7 +17,8 @@ class TestCodeCompletion(unittest.TestCase):
         self.assertIsNotNone(cr)
         self.assertEqual(len(cr.diagnostics), 0)
 
-        completions = [str(c) for c in cr.results]
+        with warnings.catch_warnings(record=True):
+            completions = [str(c) for c in cr.results]
 
         for c in expected:
             self.assertIn(c, completions)
@@ -180,7 +182,8 @@ void f(P x, Q y) {
         }
         for id, string in kindStringMap.items():
             kind = CompletionString.AvailabilityKindCompat.from_id(id)
-            self.assertEqual(str(kind), string)
+            with warnings.catch_warnings(record=True):
+                self.assertEqual(str(kind), string)
 
     def test_completion_chunk_kind_compatibility(self):
         value_to_old_str = {
@@ -210,12 +213,14 @@ void f(P x, Q y) {
         # Check that all new kinds correspond to an old kind
         for new_kind in CompletionChunkKind:
             old_str = value_to_old_str[new_kind.value]
-            self.assertEqual(old_str, str(new_kind))
+            with warnings.catch_warnings(record=True):
+                self.assertEqual(old_str, str(new_kind))
 
         # Check that all old kinds correspond to a new kind
         for value, old_str in value_to_old_str.items():
             new_kind = CompletionChunkKind.from_id(value)
-            self.assertEqual(old_str, str(new_kind))
+            with warnings.catch_warnings(record=True):
+                self.assertEqual(old_str, str(new_kind))
 
     def test_spelling_cache_missing_attribute(self):
         # Test that accessing missing attributes on SpellingCacheAlias raises
@@ -227,9 +232,10 @@ void f(P x, Q y) {
         kind_keys = list(CompletionChunk.SPELLING_CACHE)
         self.assertEqual(len(kind_keys), 13)
         for kind_key in kind_keys:
-            self.assertEqual(
-                SPELLING_CACHE[kind_key.value], CompletionChunk.SPELLING_CACHE[kind_key]
-            )
+            with warnings.catch_warnings(record=True):
+                self.assertEqual(
+                    SPELLING_CACHE[kind_key.value], CompletionChunk.SPELLING_CACHE[kind_key]
+                )
 
     def test_spelling_cache_missing_attribute(self):
         # Test that accessing missing attributes on SpellingCacheAlias raises

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -17,8 +17,11 @@ class TestCodeCompletion(unittest.TestCase):
         self.assertIsNotNone(cr)
         self.assertEqual(len(cr.diagnostics), 0)
 
-        with warnings.catch_warnings(record=True):
+        with warnings.catch_warnings(record=True) as log:
             completions = [str(c) for c in cr.results]
+            self.assertEqual(len(log), 2)
+            for warning in log:
+                self.assertIsInstance(warning.message, DeprecationWarning)
 
         for c in expected:
             self.assertIn(c, completions)
@@ -182,8 +185,10 @@ void f(P x, Q y) {
         }
         for id, string in kindStringMap.items():
             kind = CompletionString.AvailabilityKindCompat.from_id(id)
-            with warnings.catch_warnings(record=True):
+            with warnings.catch_warnings(record=True) as log:
                 self.assertEqual(str(kind), string)
+                self.assertEqual(len(log), 1)
+                self.assertIsInstance(log[0].message, DeprecationWarning)
 
     def test_completion_chunk_kind_compatibility(self):
         value_to_old_str = {
@@ -213,14 +218,18 @@ void f(P x, Q y) {
         # Check that all new kinds correspond to an old kind
         for new_kind in CompletionChunkKind:
             old_str = value_to_old_str[new_kind.value]
-            with warnings.catch_warnings(record=True):
+            with warnings.catch_warnings(record=True) as log:
                 self.assertEqual(old_str, str(new_kind))
+                self.assertEqual(len(log), 1)
+                self.assertIsInstance(log[0].message, DeprecationWarning)
 
         # Check that all old kinds correspond to a new kind
         for value, old_str in value_to_old_str.items():
             new_kind = CompletionChunkKind.from_id(value)
-            with warnings.catch_warnings(record=True):
+            with warnings.catch_warnings(record=True) as log:
                 self.assertEqual(old_str, str(new_kind))
+                self.assertEqual(len(log), 1)
+                self.assertIsInstance(log[0].message, DeprecationWarning)
 
     def test_spelling_cache_missing_attribute(self):
         # Test that accessing missing attributes on SpellingCacheAlias raises
@@ -232,11 +241,13 @@ void f(P x, Q y) {
         kind_keys = list(CompletionChunk.SPELLING_CACHE)
         self.assertEqual(len(kind_keys), 13)
         for kind_key in kind_keys:
-            with warnings.catch_warnings(record=True):
+            with warnings.catch_warnings(record=True) as log:
                 self.assertEqual(
                     SPELLING_CACHE[kind_key.value],
                     CompletionChunk.SPELLING_CACHE[kind_key],
                 )
+                self.assertEqual(len(log), 1)
+                self.assertIsInstance(log[0].message, DeprecationWarning)
 
     def test_spelling_cache_missing_attribute(self):
         # Test that accessing missing attributes on SpellingCacheAlias raises


### PR DESCRIPTION
Suppress `DeprecationWarnings` raised in the libclang python tests. Also ensure that they are returned where expected.
Resolves #178203