### PR TITLE
[libc++][NFC] Avoid checking that string::iterator is a contiguous iterator

### DIFF
--- a/libcxx/include/__format/unicode.h
+++ b/libcxx/include/__format/unicode.h
@@ -101,7 +101,7 @@ inline constexpr __consume_result __consume_result_error{__replacement_character
   return __unicode::__is_code_point(__value) && !__unicode::__is_surrogate(__value);
 }
 
-template <contiguous_iterator _Iterator>
+template <class _Iterator>
   requires same_as<iter_value_t<_Iterator>, char>
 _LIBCPP_HIDE_FROM_ABI constexpr bool __is_continuation(_Iterator __char, int __count) {
   do {


### PR DESCRIPTION
`__is_continuation` is only used in contexts where we already know that the argument is a contiguous iterator. However, due to the context in which it is used, we check it as soon as the header is included. The `contiguous_iterator` check is quite expensive (~12ms on my system), so avoiding it reduces compile times for quite a few headers, including `<vector>`.
