### PR TITLE
[lldb-dap][windows] allow STDIN to be a console

### DIFF
--- a/lldb/source/Host/windows/MainLoopWindows.cpp
+++ b/lldb/source/Host/windows/MainLoopWindows.cpp
@@ -247,7 +247,7 @@ MainLoopWindows::RegisterReadObject(const IOObjectSP &object_sp,
         callback};
   } else {
     DWORD file_type = GetFileType(waitable_handle);
-    if (file_type != FILE_TYPE_PIPE) {
+    if (file_type != FILE_TYPE_CHAR && file_type != FILE_TYPE_PIPE) {
       error = Status::FromErrorStringWithFormat("Unsupported file type %ld",
                                                 file_type);
       return nullptr;

--- a/lldb/test/Shell/DAP/TestSTDINConsole.test
+++ b/lldb/test/Shell/DAP/TestSTDINConsole.test
@@ -1,0 +1,62 @@
+# REQUIRES: python, system-windows
+# RUN: %python %s %lldb-dap > %t.out 2>&1
+# RUN: FileCheck %s --check-prefix=ERROR --allow-empty < %t.out
+
+# ERROR-NOT: DAP session error:
+
+# Test that we can successfully start the dap server from the console on Windows.
+
+import sys
+import subprocess
+import os
+
+lldb_dap_path = sys.argv[1]
+if lldb_dap_path.startswith('%'):
+    lldb_dap_path = lldb_dap_path[1:]
+lldb_dap_path = os.path.normpath(lldb_dap_path)
+
+import ctypes
+from ctypes import wintypes
+import msvcrt
+
+GENERIC_READ = 0x80000000
+GENERIC_WRITE = 0x40000000
+OPEN_EXISTING = 3
+FILE_SHARE_READ = 0x00000001
+FILE_SHARE_WRITE = 0x00000002
+
+kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+
+conin_handle = kernel32.CreateFileW(
+    "CONIN$",
+    GENERIC_READ | GENERIC_WRITE,
+    FILE_SHARE_READ | FILE_SHARE_WRITE,
+    None,
+    OPEN_EXISTING,
+    0,
+    None
+)
+
+if conin_handle == -1:
+    print("Failed to open CONIN$", file=sys.stderr)
+    sys.exit(1)
+
+conin_fd = msvcrt.open_osfhandle(conin_handle, os.O_RDONLY)
+
+proc = subprocess.Popen(
+    [lldb_dap_path],
+    stdin=conin_fd,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT
+)
+
+os.close(conin_fd)
+
+try:
+    output, _ = proc.communicate(timeout=2)
+except subprocess.TimeoutExpired:
+    proc.kill()
+    output, _ = proc.communicate()
+
+sys.stdout.buffer.write(output)
+sys.stdout.flush()


### PR DESCRIPTION
This patch allows starting `lldb-dap` from the console on Windows.

On Windows, the console is a device of type `FILE_TYPE_CHAR` and `lldb-dap` was only allowing devices of type `FILE_TYPE_PIPE`. This was causing a startup error when running `lldp-dap` from the console with no arguments.

Fixes #178194

This is a reland of https://github.com/llvm/llvm-project/pull/178409. Adding `--allow-empty` to the tests allows them to pass in CI. I was not hitting the CI error at desk because lldb-dap was printing warnings, which are not present in CI.