### PR TITLE
[lldb] Correct handling of ANSI codes in command option help

### DIFF
--- a/lldb/test/API/commands/help/TestHelp.py
+++ b/lldb/test/API/commands/help/TestHelp.py
@@ -6,6 +6,7 @@ See also CommandInterpreter::OutputFormattedHelpText().
 
 
 import os
+import re
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -327,13 +328,10 @@ class HelpCommandTestCase(TestBase):
         ANSI codes acccording to the terminal width."""
         self.runCmd("settings set use-color on")
 
-        # FIXME: lldb crashes when the width is exactly 135 - https://github.com/llvm/llvm-project/issues/177570
-
         # Should fit on one line.
-        self.runCmd("settings set term-width 138")
+        self.runCmd("settings set term-width 140")
         self.expect(
             "help breakpoint set",
-            matching=True,
             patterns=[
                 # The "S" of "Set" is underlined.
                 r"\s+\x1b\[4mS\x1b\[0met the breakpoint only in this shared library.  Can repeat this option multiple times to specify multiple shared libraries.\n"
@@ -341,16 +339,27 @@ class HelpCommandTestCase(TestBase):
         )
 
         # Must be printed on two lines.
-        # FIXME: Second line is truncated - https://github.com/llvm/llvm-project/issues/177570
-        self.runCmd("settings set term-width 100")
+        self.runCmd("settings set term-width 90")
         self.expect(
             "help breakpoint set",
-            matching=True,
             patterns=[
                 r"\s+\x1b\[4mS\x1b\[0met the breakpoint only in this shared library.  Can repeat this option\n"
-                r"\s+multiple times to specify multiple shared li\n"
+                r"\s+multiple times to specify multiple shared libraries.\n"
             ],
         )
+
+        # If we do not account for the difference between the visible character's
+        # index and that character's real index into the string with the invisible
+        # ANSI codes, we will crash in various ways. Writing tests for each width
+        # would require duplicating the line splitting algorithm here. So instead,
+        # we will try to provoke crashes if any exist, checking that the start
+        # and end of the output is shown.
+
+        for width in range(70, 150):
+            self.runCmd(f"settings set term-width {width}")
+            self.expect(
+                "help breakpoint set", substrs=["\x1b[4mS\x1b[0met the", "libraries."]
+            )
 
     @no_debug_info_test
     def test_help_shows_optional_short_options(self):

--- a/lldb/unittests/Utility/AnsiTerminalTest.cpp
+++ b/lldb/unittests/Utility/AnsiTerminalTest.cpp
@@ -116,3 +116,62 @@ TEST(AnsiTerminal, TrimAndPad) {
   EXPECT_EQ("12❤️4❤️", ansi::TrimAndPad("12❤️4❤️", 5));
   EXPECT_EQ("12❤️45", ansi::TrimAndPad("12❤️45❤️", 5));
 }
+
+TEST(AnsiTerminal, VisibleIndexToActualIndex) {
+  using Hint = ansi::VisibleActualIdxPair;
+  EXPECT_EQ((Hint{0, 0}), ansi::VisibleIndexToActualIndex("", 0, std::nullopt));
+  EXPECT_EQ((Hint{0, 0}),
+            ansi::VisibleIndexToActualIndex("abc", 0, std::nullopt));
+  EXPECT_EQ((Hint{1, 1}),
+            ansi::VisibleIndexToActualIndex("abc", 1, std::nullopt));
+  EXPECT_EQ((Hint{2, 2}),
+            ansi::VisibleIndexToActualIndex("abc", 2, std::nullopt));
+  // We expect callers to limit the visible index to its valid range.
+
+  // When a visible character is preceeded by an ANSI code, we would need to
+  // print that code when printing the character. Therefore, the actual index
+  // points to the preceeding ANSI code, not the visible character itself.
+  EXPECT_EQ((Hint{0, 0}),
+            ansi::VisibleIndexToActualIndex("\x1B[4mabc", 0, std::nullopt));
+  EXPECT_EQ((Hint{1, 1}),
+            ansi::VisibleIndexToActualIndex("a\x1B[4mbc", 1, std::nullopt));
+  EXPECT_EQ((Hint{2, 2}),
+            ansi::VisibleIndexToActualIndex("ab\x1B[4mc", 2, std::nullopt));
+
+  // If the visible character is proceeded by an ANSI code, we don't need to
+  // adjust anything. The actual index is the index of the visible character
+  // itself.
+  EXPECT_EQ((Hint{0, 0}),
+            ansi::VisibleIndexToActualIndex("a\x1B[4mbc", 0, std::nullopt));
+  EXPECT_EQ((Hint{1, 1}),
+            ansi::VisibleIndexToActualIndex("ab\x1B[4mc", 1, std::nullopt));
+  EXPECT_EQ((Hint{2, 2}),
+            ansi::VisibleIndexToActualIndex("abc\x1B[4m", 2, std::nullopt));
+
+  // If we want a visible character that is after ANSI codes for other
+  // characters, the actual index must know to skip those previous codes.
+  EXPECT_EQ((Hint{1, 5}),
+            ansi::VisibleIndexToActualIndex("\x1B[4mabc", 1, std::nullopt));
+  EXPECT_EQ((Hint{2, 6}),
+            ansi::VisibleIndexToActualIndex("a\x1B[4mbc", 2, std::nullopt));
+
+  // We can give it a previous result to skip forward. To prove it does not look
+  // at the early parts of the string, give it hints that actually produce
+  // incorrect results.
+
+  const char *actual_text = "abcdefghijk";
+  // This does nothing because the hint is the answer.
+  EXPECT_EQ((Hint{1, 5}),
+            ansi::VisibleIndexToActualIndex(actual_text, 1, Hint{1, 5}));
+  // The hint can be completely bogus, but we trust it. So if it refers to the
+  // visible index being asked for, we just return the hint.
+  EXPECT_EQ((Hint{99, 127}),
+            ansi::VisibleIndexToActualIndex(actual_text, 99, Hint{99, 127}));
+  // This should return {2, 1}, but the actual is offset by 5 due to the hint.
+  EXPECT_EQ((Hint{2, 6}),
+            ansi::VisibleIndexToActualIndex(actual_text, 2, Hint{1, 5}));
+  // If the hint is for a visible index > the wanted visible index, we cannot do
+  // anything with it. The function can only look forward.
+  EXPECT_EQ((Hint{2, 2}),
+            ansi::VisibleIndexToActualIndex(actual_text, 2, Hint{3, 6}));
+}


### PR DESCRIPTION
Fixes #177570

In which I describe 2 problems:
1. When the terminal was a specific width, printing the help of certain commands would crash lldb.
2. When lldb did not crash, some descriptions had their last lines truncated.

The cause of both of these is a faulty assumption that the "visible" index of a character after rendering the ANSI codes will be the same as the actual index of the character in the data you print.

A simple example of why this is not the case:
   String data: "abcd"
Visible string: "abcd"

When there are no ANSI codes, the index of characters once rendered to the terminal, and in the original data, line up. "b" is index 1 in both cases.

   String data: "\x1b[4ma\x1b[0mbcd"
Visible string: "abcd"

When the data contains ANSI codes (here the "a" is underlined), the indexes do not match up. If we want to print "b", then we cannot start at index 1, because this points to the "[" of the first ANSI code.

The help line splitting function needs to be aware of this difference.

To achieve that, I've done 2 things:
* Re-written the first part of the line wrapping code to only use visible lengths and indexes. As this is what impacts the decision to wrap text or not.
* Added a new utility function VisibleIndexToActualIndex that converts the visible index into the actual index we must start printing from.
* Once we've decided what to print using visible indexes, convert them into actual indexes and print using those.

There are some limitations to VisibleIndexToActualIndex that I get away with because OutputFormattedUsageText is the only caller:
* OutputFormattedUsageText will never split a word over 2 lines, which means I do not have to go back more than one character to find a preceeding ANSI code.
* ANSI codes are currently only applied to single characters. Whole words would be fine as long as you don't split words. If you modify multiple words, the ANSI code will be split over two lines. In this case, the indentation would also be formatted by the code.
* OutputFormattedUsageText only ever searches forward, so I am able to pass previous results to VisibleIndexToActualIndex to save walking the string over and over.

Though VisibleIndexToActualIndex is kind of specialised to its caller, I have placed it in AnsiTerminal.h so I can easily unit test it.

I have also updated the API tests for the help output. If I wanted to test every width, I'd have to generate every expected output. This is possible but requires duplicating the splitting algorithm. I tried this and failed several times. I think even if I got it right, it would just be a time sink if we ever need to update it.

So instead, I have a few hard coded tests and then a loop that iterates a bunch of terminal widths and just checks that some parts of the normal output are present so we know that it's not been truncated and that we do not crash.