### PR TITLE
[lldb-dap] Conditionally check UBSan stack trace on Darwin only

### DIFF
--- a/lldb/test/API/tools/lldb-dap/exception/runtime-instruments/TestDAP_runtime_instruments.py
+++ b/lldb/test/API/tools/lldb-dap/exception/runtime-instruments/TestDAP_runtime_instruments.py
@@ -22,4 +22,8 @@ class TestDAP_runtime_instruments(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(exceptionInfo["breakMode"], "always")
         self.assertRegex(exceptionInfo["description"], r"Out of bounds index")
         self.assertEqual(exceptionInfo["exceptionId"], "runtime-instrumentation")
-        self.assertIn("main.c", exceptionInfo["details"]["stackTrace"])
+
+        # FIXME: Check on non macOS platform the stop infomation location heuristic
+        # may be wrong. enable when we have updated Ubsan stopInfo heuristic.
+        if self.platformIsDarwin():
+            self.assertIn("main.c", exceptionInfo["details"]["stackTrace"])


### PR DESCRIPTION
non-darwin platforms may have incorrect stop information location heuristics. Enable assertion once UBSan stopInfo heuristic is updated.

I hit this locally, I don't see it hitting any CI bot but should, Mostly likely the CI linux bots may not have `compiler_rt` run time enabled. 
see https://github.com/llvm/llvm-project/pull/177964#discussion_r2732271531