### PR TITLE
[clang-tidy] Allow type-generic builtins in pro-type-vararg check

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -136,6 +136,12 @@ Changes in existing checks
   the invalidating function in the warning message when a custom invalidation
   function is used (via the `InvalidationFunctions` option).
 
+- Improved :doc:`cppcoreguidelines-pro-type-vararg
+  <clang-tidy/checks/cppcoreguidelines/pro-type-vararg>` check by no longer
+  warning on builtins with custom type checking (e.g., type-generic builtins
+  like ``__builtin_clzg``) that use variadic declarations as an implementation
+  detail.
+
 - Improved :doc:`llvm-use-ranges
   <clang-tidy/checks/llvm/use-ranges>` check by adding support for the following
   algorithms: ``std::accumulate``, ``std::replace_copy``, and

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-vararg.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-vararg.cpp
@@ -57,6 +57,12 @@ void ignoredBuiltinsTest(void *ptr) {
   (void)__builtin_fpclassify(0, 0, 0, 0, 0, 0.f);
   (void)__builtin_isinf_sign(0.f);
   (void)__builtin_prefetch(nullptr);
+
+  // GH#178629: Type-generic builtins should not warn.
+  (void)__builtin_clzg(1u);
+  (void)__builtin_ctzg(1u);
+  (void)__builtin_popcountg(1u);
+  (void)__builtin_bswapg(1u);
 }
 
 // Some implementations of __builtin_va_list and __builtin_ms_va_list desugared


### PR DESCRIPTION
## Summary
Add type generic builtins to the allowed variadics list in the `cppcoreguidelines-pro-type-vararg` check (also used by `hicpp-vararg`):
- `__builtin_clzg`
- `__builtin_ctzg`
- `__builtin_popcountg`
- `__builtin_bswapg`

## Root Cause
These builtins are declared as variadic (`int(...)`) to accept any integer type via `CustomTypeChecking`. However, they are not C style vararg functions , they take exactly one argument of a generic integer type.

## Test
Added test cases in `pro-type-vararg.cpp` to verify no warning is emitted.

Fixes #178629 