### PR TITLE
[clang-repl] Suppress [[nodiscard]] warnings for REPL printed express

### DIFF
--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -40,6 +40,7 @@
 #include "clang/Options/OptionUtils.h"
 #include "clang/Options/Options.h"
 #include "clang/Sema/Lookup.h"
+#include "clang/Sema/Sema.h"
 #include "clang/Serialization/ObjectFilePCHContainerReader.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h"
@@ -465,14 +466,34 @@ Interpreter::Parse(llvm::StringRef Code) {
       return std::move(Err);
   }
 
-  // Tell the interpreter sliently ignore unused expressions since value
-  // printing could cause it.
-  getCompilerInstance()->getDiagnostics().setSeverity(
-      clang::diag::warn_unused_expr, diag::Severity::Ignored, SourceLocation());
+  // Tell the interpreter to silently ignore unused expression and
+  // [[nodiscard]] warnings during parsing. At parse time, we don't yet know
+  // whether the user omitted the semicolon (value will be printed, i.e.
+  // "used") or included it (value truly discarded). We suppress both warnings
+  // here and retroactively diagnose only the truly-discarded cases below.
+  DiagnosticsEngine &Diags = getCompilerInstance()->getDiagnostics();
+  Diags.setSeverity(clang::diag::warn_unused_expr, diag::Severity::Ignored,
+                    SourceLocation());
+  Diags.setSeverity(clang::diag::warn_unused_result, diag::Severity::Ignored,
+                    SourceLocation());
 
   llvm::Expected<TranslationUnitDecl *> TuOrErr = IncrParser->Parse(Code);
   if (!TuOrErr)
     return TuOrErr.takeError();
+
+  // Re-enable [[nodiscard]] warnings and retroactively diagnose for
+  // top-level expressions where the semicolon IS present (value discarded).
+  // Expressions without semicolons will have their values printed by the
+  // REPL, so the result is genuinely "used" and should not warn.
+  Diags.setSeverity(clang::diag::warn_unused_result, diag::Severity::Warning,
+                    SourceLocation());
+  for (Decl *D : (*TuOrErr)->decls()) {
+    if (auto *TLSD = llvm::dyn_cast<TopLevelStmtDecl>(D))
+      if (!TLSD->isSemiMissing())
+        if (auto *E = llvm::dyn_cast_or_null<Expr>(TLSD->getStmt()))
+          getCompilerInstance()->getSema().DiagnoseUnusedExprResult(
+              E, diag::warn_unused_result);
+  }
 
   PartialTranslationUnit &LastPTU = IncrParser->RegisterPTU(*TuOrErr);
 

--- a/clang/test/Interpreter/nodiscard.cpp
+++ b/clang/test/Interpreter/nodiscard.cpp
@@ -1,0 +1,25 @@
+// REQUIRES: host-supports-jit
+// RUN: cat %s | clang-repl 2>&1 | FileCheck %s
+
+// Test that [[nodiscard]] warnings are suppressed for REPL top-level
+// expressions that will have their values printed (no semicolon),
+// but are still emitted when the value is actually discarded (with semicolon).
+
+extern "C" int printf(const char*,...);
+
+[[nodiscard]] int getValue() { return 42; }
+
+// Negative test: Warning when value is discarded (with semicolon)
+getValue();
+// CHECK: warning: ignoring return value of function declared with 'nodiscard' attribute
+
+// Positive test: No warning when expression value is printed (no semicolon)
+getValue()
+// CHECK: (int) 42
+
+// Verify assignment doesn't warn
+int x = getValue();
+printf("x = %d\n", x);
+// CHECK: x = 42
+
+%quit


### PR DESCRIPTION
In clang-repl, expressions typed without a semicolon have their values printed to the console. This means the return value is actually being used, not discarded.
However, the compiler was emitting `[[nodiscard]]` warnings because it didn't know the REPL would use the value for printing.
This fix detects when we're in REPL mode evaluating a top-level expression and skips the warning, since printing the result counts as "using" it.

Fixes #178595.