### PR TITLE
[X86] canonicalizeLaneShuffleWithRepeatedOps - avoid folding vperm2x128(vpshufd(load()),undef) -> vpshufd(vperm2x128(load(),undef))

### DIFF
--- a/llvm/test/CodeGen/X86/merge-consecutive-loads-256.ll
+++ b/llvm/test/CodeGen/X86/merge-consecutive-loads-256.ll
@@ -129,8 +129,8 @@ define <4 x double> @merge_4f64_f64_45zz(ptr %ptr) nounwind uwtable noinline ssp
 define <4 x double> @merge_v4f64_f64_3210(ptr %ptr) nounwind uwtable noinline ssp {
 ; AVX1-LABEL: merge_v4f64_f64_3210:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vperm2f128 {{.*#+}} ymm0 = mem[2,3,0,1]
-; AVX1-NEXT:    vshufpd {{.*#+}} ymm0 = ymm0[1,0,3,2]
+; AVX1-NEXT:    vpermilpd {{.*#+}} ymm0 = mem[1,0,3,2]
+; AVX1-NEXT:    vperm2f128 {{.*#+}} ymm0 = ymm0[2,3,0,1]
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: merge_v4f64_f64_3210:
@@ -146,8 +146,8 @@ define <4 x double> @merge_v4f64_f64_3210(ptr %ptr) nounwind uwtable noinline ss
 ; X86-AVX-LABEL: merge_v4f64_f64_3210:
 ; X86-AVX:       # %bb.0:
 ; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
-; X86-AVX-NEXT:    vperm2f128 {{.*#+}} ymm0 = mem[2,3,0,1]
-; X86-AVX-NEXT:    vshufpd {{.*#+}} ymm0 = ymm0[1,0,3,2]
+; X86-AVX-NEXT:    vpermilpd {{.*#+}} ymm0 = mem[1,0,3,2]
+; X86-AVX-NEXT:    vperm2f128 {{.*#+}} ymm0 = ymm0[2,3,0,1]
 ; X86-AVX-NEXT:    retl
   %ptr0 = getelementptr inbounds double, ptr %ptr, i64 3
   %ptr1 = getelementptr inbounds double, ptr %ptr, i64 2
@@ -421,8 +421,8 @@ define <8 x float> @merge_8f32_f32_1u3u5zu8(ptr %ptr) nounwind uwtable noinline 
 define <8 x float> @merge_8f32_f32_76543210(ptr %ptr) nounwind uwtable noinline ssp {
 ; AVX1-LABEL: merge_8f32_f32_76543210:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vperm2f128 {{.*#+}} ymm0 = mem[2,3,0,1]
-; AVX1-NEXT:    vshufps {{.*#+}} ymm0 = ymm0[3,2,1,0,7,6,5,4]
+; AVX1-NEXT:    vpermilps {{.*#+}} ymm0 = mem[3,2,1,0,7,6,5,4]
+; AVX1-NEXT:    vperm2f128 {{.*#+}} ymm0 = ymm0[2,3,0,1]
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: merge_8f32_f32_76543210:
@@ -440,8 +440,8 @@ define <8 x float> @merge_8f32_f32_76543210(ptr %ptr) nounwind uwtable noinline 
 ; X86-AVX-LABEL: merge_8f32_f32_76543210:
 ; X86-AVX:       # %bb.0:
 ; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
-; X86-AVX-NEXT:    vperm2f128 {{.*#+}} ymm0 = mem[2,3,0,1]
-; X86-AVX-NEXT:    vshufps {{.*#+}} ymm0 = ymm0[3,2,1,0,7,6,5,4]
+; X86-AVX-NEXT:    vpermilps {{.*#+}} ymm0 = mem[3,2,1,0,7,6,5,4]
+; X86-AVX-NEXT:    vperm2f128 {{.*#+}} ymm0 = ymm0[2,3,0,1]
 ; X86-AVX-NEXT:    retl
   %ptr0 = getelementptr inbounds float, ptr %ptr, i64 7
   %ptr1 = getelementptr inbounds float, ptr %ptr, i64 6


### PR DESCRIPTION
There's no benefit to letting vperm2x128 handle the fold in an unary shuffle and llvm-mca assumes there's an extra register dependency, which confuses analysis.

Fixes #178632