### PR TITLE
[Flang] Fix type error when calling EXIT intrinsic

### DIFF
--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -1604,7 +1604,7 @@ static const IntrinsicInterface intrinsicSubroutine[]{
             {"cmdmsg", DefaultChar, Rank::scalar, Optionality::optional,
                 common::Intent::InOut}},
         {}, Rank::elemental, IntrinsicClass::impureSubroutine},
-    {"exit", {{"status", DefaultInt, Rank::scalar, Optionality::optional}}, {},
+    {"exit", {{"status", AnyInt, Rank::scalar, Optionality::optional}}, {},
         Rank::elemental, IntrinsicClass::impureSubroutine},
     {"free", {{"ptr", Addressable}}, {}},
     {"flush",

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -3852,9 +3852,6 @@ void IntrinsicLibrary::genExit(llvm::ArrayRef<fir::ExtendedValue> args) {
                                           EXIT_SUCCESS)
           : fir::getBase(args[0]);
 
-  assert(status.getType() == builder.getDefaultIntegerType() &&
-         "STATUS parameter must be an INTEGER of default kind");
-
   fir::runtime::genExit(builder, loc, status);
 }
 

--- a/flang/test/Lower/Intrinsics/exit.f90
+++ b/flang/test/Lower/Intrinsics/exit.f90
@@ -21,3 +21,11 @@ subroutine exit_test1
   ! CHECK-32: fir.call @_FortranAExit(%[[status]]) {{.*}}: (i32) -> ()
   ! CHECK-64: fir.call @_FortranAExit(%[[statusConv]]) {{.*}}: (i32) -> ()
   end subroutine exit_test2
+
+subroutine exit_test3(status)
+    integer(kind=4) :: status
+  ! CHECK: %[[status:.*]] = fir.load %[[statusArg]] : !fir.ref<i32>
+  ! CHECK-32: fir.call @_FortranAExit(%[[status]]) {{.*}}: (i32) -> ()
+  ! CHECK-64: fir.call @_FortranAExit(%[[status]]) {{.*}}: (i32) -> ()
+    call exit(status)
+end subroutine exit_test3


### PR DESCRIPTION
`EXIT` expects a `KIND=8` integer.  If such an integer was passed when `-fdefault-integer-8` was present, the `assert` removed in this PR would trigger.  Since Flang was already silently downcasting `KIND=8` to `KIND=4`, this PR removes the `assert` and adds a new test to validate the correct behavior when large integers are the default