### PR TITLE
[lldb] Fix library step-in when the binary is linked with MOLD

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -69,6 +69,9 @@ filecheck = None
 # Path to the nm tool.
 nm: Optional[str] = None
 
+# Path to the objcopy tool
+objcopy: Optional[str] = None
+
 # Path to the yaml2obj tool. Not optional.
 yaml2obj = None
 
@@ -203,6 +206,14 @@ def get_nm_path():
     """
     if nm and os.path.lexists(nm):
         return nm
+
+
+def get_objcopy_path():
+    """
+    Get the path to the objcopy tool.
+    """
+    if objcopy and os.path.lexists(objcopy):
+        return objcopy
 
 
 def get_yaml2obj_path():

--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -208,7 +208,7 @@ def get_nm_path():
         return nm
 
 
-def get_objcopy_path():
+def get_objcopy_path() -> Optional[str]:
     """
     Get the path to the objcopy tool.
     """

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -286,6 +286,7 @@ def parseOptionsAndInitTestdirs():
         configuration.nm = shutil.which(
             "llvm-nm", path=args.llvm_tools_dir
         ) or shutil.which("nm", path=args.llvm_tools_dir)
+        configuration.objcopy = shutil.which("llvm-objcopy", path=args.llvm_tools_dir)
 
     if not configuration.get_filecheck_path():
         logging.warning("No valid FileCheck executable; some tests may fail...")

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -2358,6 +2358,16 @@ ObjectFileELF::ParseSymbols(Symtab *symtab, user_id_t start_id,
     // linkage.
     if (llvm::StringRef(symbol_name).starts_with(".L"))
       continue;
+
+    // The mold linker emits an extra function symbol like "foo$plt" in
+    // .symtab/.dynsym that overlaps the PLT stub which ParsePLTRelocations
+    // will synthesize as an eSymbolTypeTrampoline named "foo". Drop the
+    // redundant sibling here so the finalized symbol table has a single
+    // clean entry per PLT function.
+    if (symbol.getType() == STT_FUNC &&
+        llvm::StringRef(symbol_name).ends_with("$plt"))
+      continue;
+
     // No need to add non-section symbols that have no names
     if (symbol.getType() != STT_SECTION &&
         (symbol_name == nullptr || symbol_name[0] == '\0'))

--- a/lldb/test/API/lang/c/step-through-trampoline-with-symbol/Makefile
+++ b/lldb/test/API/lang/c/step-through-trampoline-with-symbol/Makefile
@@ -1,0 +1,7 @@
+DYLIB_NAME := add
+DYLIB_C_SOURCES := add.c
+C_SOURCES := main.c
+LD_EXTRAS := -fcf-protection=none
+
+include Makefile.rules
+

--- a/lldb/test/API/lang/c/step-through-trampoline-with-symbol/TestStepThroughTrampolineWithSymbol.py
+++ b/lldb/test/API/lang/c/step-through-trampoline-with-symbol/TestStepThroughTrampolineWithSymbol.py
@@ -1,0 +1,110 @@
+"""
+Test case to verify stepping behavior into shared library functions.
+Specifically, this tests the scenario where the mold linker emits an
+extra function symbol (e.g. `lib_add$plt`) in .symtab that overlaps
+the PLT stub. ObjectFileELF must drop that redundant symbol so the
+finalized symbol table exposes only the synthesized PLT trampoline,
+and step-into still lands in the real function.
+"""
+
+import lldb
+from lldbsuite.test.decorators import skipUnlessPlatform
+from lldbsuite.test.lldbtest import TestBase, line_number, configuration
+import lldbsuite.test.lldbutil as lldbutil
+
+
+@skipUnlessPlatform(["linux"])
+class StepThroughTrampolineWithSymbol(TestBase):
+    SYMBOL_NAME = "lib_add"
+    MOLD_STYLE_SYMBOL_NAME = "lib_add$plt"
+
+    def test(self):
+        modified_exe = self.create_modified_exe()
+
+        # Verify ObjectFileELF dropped the mold-style `$plt` sibling symbol.
+        modified_modulespec = lldb.SBModuleSpec()
+        modified_modulespec.SetFileSpec(lldb.SBFileSpec(modified_exe))
+        modified_module = lldb.SBModule(modified_modulespec)
+        self.assertTrue(modified_module.IsValid())
+        self.assertFalse(
+            modified_module.FindSymbol(self.MOLD_STYLE_SYMBOL_NAME).IsValid(),
+            f"{self.MOLD_STYLE_SYMBOL_NAME} should have been stripped by ObjectFileELF",
+        )
+
+        (_target, _process, thread, _bkpt) = lldbutil.run_to_source_breakpoint(
+            self,
+            "// Set a breakpoint here",
+            lldb.SBFileSpec("main.c"),
+            exe_name=modified_exe,
+            extra_images=["add"],
+        )
+
+        error = lldb.SBError()
+        thread.StepInto(
+            None, lldb.LLDB_INVALID_LINE_NUMBER, error, lldb.eOnlyDuringStepping
+        )
+
+        self.assertTrue(error.Success(), f"step into failed: {error.GetCString()}")
+
+        # Check frame in cli.
+        add_stop_line = line_number("add.c", "// End up here")
+        self.expect(
+            "frame info", substrs=[self.SYMBOL_NAME, "add.c:{}:".format(add_stop_line)]
+        )
+
+        # Check frame in SBAPI.
+        current_frame = thread.selected_frame
+        self.assertTrue(current_frame.IsValid())
+        function_name = current_frame.function.name
+        self.assertEqual(function_name, self.SYMBOL_NAME)
+
+        frame_module = current_frame.module
+        self.assertTrue(frame_module.IsValid())
+        frame_module_name = frame_module.file.basename
+        self.assertEqual(frame_module_name, "libadd.so")
+
+    def create_modified_exe(self) -> str:
+        """
+        Build the executable, find the `lib_add` trampoline and add a
+        `lib_add$plt` symbol at the trampoline's file address to mimic
+        mold's symbol table layout.
+
+        Returns the modified executable.
+        """
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        modulespec = lldb.SBModuleSpec()
+        modulespec.SetFileSpec(lldb.SBFileSpec(exe))
+        module = lldb.SBModule(modulespec)
+        self.assertTrue(module.IsValid())
+
+        add_trampoline = lldb.SBSymbol()
+        for sym in module.symbols:
+            if sym.name == self.SYMBOL_NAME and sym.type == lldb.eSymbolTypeTrampoline:
+                add_trampoline = sym
+                break
+
+        self.assertTrue(add_trampoline.IsValid())
+
+        # Get the trampoline's section and offset.
+        add_address = add_trampoline.addr
+        self.assertTrue(add_address.IsValid())
+
+        add_section_name = add_address.section.name
+        self.assertIn(".plt", add_section_name)
+        add_section_offset = add_address.offset
+
+        # Inject a mold-style `lib_add$plt` symbol at the PLT stub address.
+        modified_exe = self.getBuildArtifact("mod_a.out")
+        objcopy_bin = configuration.get_objcopy_path()
+
+        build_command = [
+            objcopy_bin,
+            "--add-symbol",
+            f"{self.MOLD_STYLE_SYMBOL_NAME}={add_section_name}:{add_section_offset},function,local",
+            exe,
+            modified_exe,
+        ]
+        self.runBuildCommand(build_command)
+
+        return modified_exe

--- a/lldb/test/API/lang/c/step-through-trampoline-with-symbol/add.c
+++ b/lldb/test/API/lang/c/step-through-trampoline-with-symbol/add.c
@@ -1,0 +1,5 @@
+#include "add.h"
+
+int lib_add(int LHS, int RHS) {
+  return LHS + RHS; // End up here
+}

--- a/lldb/test/API/lang/c/step-through-trampoline-with-symbol/add.h
+++ b/lldb/test/API/lang/c/step-through-trampoline-with-symbol/add.h
@@ -1,0 +1,1 @@
+LLDB_TEST_API extern int lib_add(int LHS, int RHS);

--- a/lldb/test/API/lang/c/step-through-trampoline-with-symbol/main.c
+++ b/lldb/test/API/lang/c/step-through-trampoline-with-symbol/main.c
@@ -1,0 +1,6 @@
+#include "add.h"
+
+int main(void) {
+  int result = lib_add(10, 20); // Set a breakpoint here
+  return 0;
+}


### PR DESCRIPTION
The mold linker adds a function symbol to the symbol table (.symtab) for every shared library exported function.
So if we try to step into a library, lldb will fail because the symbol at the address is not a trampline function.

Example:
```cpp
// lib.c
int lib_add(int a, int b);
```
when we link the library to an executable, mold will create the normal trampoline functions in the .plt section but add an extra symbol in symbol table `lib_add$plt`.


I cannot think of a way to add another symbol in the trampoline's file address without linking with mold. 
Is there a way to write a test for this ? 