### PR TITLE
[lldb] [test/FreeBSDKernel] Disable testing

### DIFF
--- a/lldb/test/API/functionalities/postmortem/FreeBSDKernel/README.rst
+++ b/lldb/test/API/functionalities/postmortem/FreeBSDKernel/README.rst
@@ -1,0 +1,5 @@
+FreeBSD Kernel Test Suite
+===============================
+
+This test suite is disabled due to low maintenance and influx of new features.
+A complete test suite will be added once new changes are merged.


### PR DESCRIPTION
The old test suite depends on patches but considering additional features coming in the next few weeks it's inefficient to update them for every PR. Not only that, many parts of the test suite needs to be replaced (e.g. core dump) thus it is reasonable to temporarilyarily disable testing and reenable it once the new features are merged.