### PR TITLE
[CodeGen] Remove -gc-empty-basic-blocks alias flag

### DIFF
--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -270,13 +270,6 @@ static cl::opt<bool> EnableGCEmptyBlocks(
     "enable-gc-empty-basic-blocks", cl::init(false), cl::Hidden,
     cl::desc("Enable garbage-collecting empty basic blocks"));
 
-// TODO: remove this once all downstream users have migrated to using
-// enable-gc-empty-basic-blocks.
-static cl::alias
-    EnableGCEmptyBlocksAlias("gc-empty-basic-blocks",
-                             cl::desc("Alias for enable-gc-empty-basic-blocks"),
-                             cl::aliasopt(EnableGCEmptyBlocks));
-
 static cl::opt<bool>
     SplitStaticData("split-static-data", cl::Hidden, cl::init(false),
                     cl::desc("Split static data sections into hot and cold "


### PR DESCRIPTION
This was deprecated earlier and switched to an alias so we would have some time to update things through our internal compiler release process. That has completed, so we can now remove the flag upstream.