### PR TITLE
[lldb] Increment max-children-depth to 5

### DIFF
--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -99,7 +99,7 @@ let Definition = "target" in {
     DefaultUnsignedValue<24>,
     Desc<"Maximum number of children to expand in any level of depth.">;
   def MaxChildrenDepth: Property<"max-children-depth", "UInt64">,
-    DefaultUnsignedValue<4>,
+    DefaultUnsignedValue<5>,
     Desc<"Maximum depth to expand children.">;
   def MaxSummaryLength: Property<"max-string-summary-length", "UInt64">,
     DefaultUnsignedValue<1024>,

--- a/lldb/test/Shell/Settings/TestChildDepthTruncation.test
+++ b/lldb/test/Shell/Settings/TestChildDepthTruncation.test
@@ -18,15 +18,18 @@
 #--- main.cpp
 
 struct L1 {
-    int w;
+    int a;
     struct L2 {
-        int x;
+        int b;
         struct L3 {
-            int y;
+            int c;
             struct L4 {
-              int z;
+                int d;
                 struct L5 {
-                  int a;
+                    int e;
+                    struct L6 {
+                      int f;
+                    } l6;
                 } l5;
             } l4;
         } l3;


### PR DESCRIPTION
`max-children-depth` was [originally 6][1], which produced too large of output. It was then [reduced to 4][2], which for some people is too low. This change is to try 5 as the default.

Originally upstreamed in https://github.com/llvm/llvm-project/pull/149282

[1]: https://github.com/swiftlang/llvm-project/pull/4280/changes/ee0782bf6b2e9705e261c5a82147ce0e45a8d753
[2]: https://github.com/swiftlang/llvm-project/pull/10683