### PR TITLE
[SPIRV] Split async copy tests and fix invalid tests

### DIFF
--- a/llvm/test/CodeGen/SPIRV/event-zero-const-64.ll
+++ b/llvm/test/CodeGen/SPIRV/event-zero-const-64.ll
@@ -1,5 +1,5 @@
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-DAG: %[[#LongTy:]] = OpTypeInt 64 0
 ; CHECK-DAG: %[[#IntTy:]] = OpTypeInt 32 0
@@ -7,7 +7,7 @@
 ; CHECK-DAG: %[[#LongNull:]] = OpConstantNull %[[#LongTy]]
 ; CHECK-DAG: %[[#EventNull:]] = OpConstantNull %[[#EventTy]]
 ; CHECK-DAG: %[[#Scope:]] = OpConstant %[[#IntTy]] 2
-; CHECK-DAG: %[[#One:]] = OpConstant %[[#IntTy]] 1
+; CHECK-DAG: %[[#One:]] = OpConstant %[[#LongTy]] 1
 ; CHECK: OpFunction
 ; CHECK: OpINotEqual %[[#]] %[[#]] %[[#LongNull]]
 ; CHECK: OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#]] %[[#]] %[[#One]] %[[#One]] %[[#EventNull]]
@@ -19,9 +19,9 @@ define weak_odr dso_local spir_kernel void @foo(i64 %_arg_i, ptr addrspace(1) %_
 entry:
   %r1 = icmp ne i64 %_arg_i, 0
   store i1 %r1, ptr @G_r1
-  %e1 = tail call spir_func target("spirv.Event") @__spirv_GroupAsyncCopy(i32 2, ptr addrspace(3) %_arg_local, ptr addrspace(1) %_arg_ptr, i32 1, i32 1, target("spirv.Event") zeroinitializer)
+  %e1 = tail call spir_func target("spirv.Event") @__spirv_GroupAsyncCopy(i32 2, ptr addrspace(3) %_arg_local, ptr addrspace(1) %_arg_ptr, i64 1, i64 1, target("spirv.Event") zeroinitializer)
   store target("spirv.Event") %e1, ptr @G_e1
   ret void
 }
 
-declare dso_local spir_func target("spirv.Event") @__spirv_GroupAsyncCopy(i32, ptr addrspace(3), ptr addrspace(1), i32, i32, target("spirv.Event"))
+declare dso_local spir_func target("spirv.Event") @__spirv_GroupAsyncCopy(i32, ptr addrspace(3), ptr addrspace(1), i64, i64, target("spirv.Event"))

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy-strided-64.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy-strided-64.ll
@@ -1,14 +1,15 @@
-; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
+; CHECK-SPIRV-DAG: %[[#LongTy:]] = OpTypeInt 64 0
 ; CHECK-SPIRV-DAG: %[[#IntTy:]] = OpTypeInt 32 0
 ; CHECK-SPIRV-DAG: %[[#Int8Ty:]] = OpTypeInt 8 0
 ; CHECK-SPIRV-DAG: %[[#EventTy:]] = OpTypeEvent
 ; CHECK-SPIRV-DAG: %[[#WGPtrTy:]] = OpTypePointer Workgroup %[[#Int8Ty]]
 ; CHECK-SPIRV-DAG: %[[#CWGPtrTy:]] = OpTypePointer CrossWorkgroup %[[#Int8Ty]]
 ; CHECK-SPIRV-DAG: %[[#Scope:]] = OpConstant %[[#IntTy]] 2
-; CHECK-SPIRV-DAG: %[[#NumElem:]] = OpConstant %[[#IntTy]] 123
-; CHECK-SPIRV-DAG: %[[#Stride:]] = OpConstant %[[#IntTy]] 1
+; CHECK-SPIRV-DAG: %[[#NumElem:]] = OpConstant %[[#LongTy]] 123
+; CHECK-SPIRV-DAG: %[[#Stride:]] = OpConstant %[[#LongTy]] 1
 ; CHECK-SPIRV-DAG: %[[#DstNull:]] = OpConstantNull %[[#WGPtrTy]]
 ; CHECK-SPIRV-DAG: %[[#SrcNull:]] = OpConstantNull %[[#CWGPtrTy]]
 ; CHECK-SPIRV-DAG: %[[#EventNull:]] = OpConstantNull %[[#EventTy]]
@@ -19,17 +20,18 @@
 ; CHECK-SPIRV: %[[#ResEvent:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#DstNull]] %[[#SrcNull]] %[[#NumElem]] %[[#Stride]] %[[#EventNull]]
 ; CHECK-SPIRV: OpStore %[[#Var]] %[[#ResEvent]]
 ; CHECK-SPIRV: %[[#PtrEventGen:]] = OpPtrCastToGeneric %[[#GenPtrEventTy]] %[[#Var]]
-; CHECK-SPIRV: OpGroupWaitEvents %[[#Scope]] %[[#Stride]] %[[#PtrEventGen]]
+; CHECK-SPIRV: OpGroupWaitEvents %[[#Scope]] %[[#]] %[[#PtrEventGen]]
 ; CHECK-SPIRV: OpFunctionEnd
 
 define spir_kernel void @foo() {
   %event = alloca target("spirv.Event"), align 8
-  %call = call spir_func target("spirv.Event") @_Z29async_work_group_strided_copyPU3AS3hPU3AS1Khjj9ocl_event(ptr addrspace(3) null, ptr addrspace(1) null, i32 123, i32 1, target("spirv.Event") zeroinitializer)
+  %call = call spir_func target("spirv.Event") @_Z29async_work_group_strided_copyPU3AS3hPU3AS1Khmm9ocl_event(ptr addrspace(3) null, ptr addrspace(1) null, i64 123, i64 1, target("spirv.Event") zeroinitializer)
   store target("spirv.Event") %call, ptr %event, align 8
   %event.ascast = addrspacecast ptr %event to ptr addrspace(4)
   call spir_func void @_Z17wait_group_eventsiPU3AS49ocl_event(i32 1, ptr addrspace(4) %event.ascast)
   ret void
 }
 
-declare spir_func target("spirv.Event") @_Z29async_work_group_strided_copyPU3AS3hPU3AS1Khjj9ocl_event(ptr addrspace(3), ptr addrspace(1), i32, i32, target("spirv.Event"))
+declare spir_func target("spirv.Event") @_Z29async_work_group_strided_copyPU3AS3hPU3AS1Khmm9ocl_event(ptr addrspace(3), ptr addrspace(1), i64, i64, target("spirv.Event"))
 declare spir_func void @_Z17wait_group_eventsiPU3AS49ocl_event(i32, ptr addrspace(4))
+

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy-strided-64.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy-strided-64.ll
@@ -1,27 +1,27 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; CHECK-SPIRV-DAG: %[[#LongTy:]] = OpTypeInt 64 0
-; CHECK-SPIRV-DAG: %[[#IntTy:]] = OpTypeInt 32 0
-; CHECK-SPIRV-DAG: %[[#Int8Ty:]] = OpTypeInt 8 0
-; CHECK-SPIRV-DAG: %[[#EventTy:]] = OpTypeEvent
-; CHECK-SPIRV-DAG: %[[#WGPtrTy:]] = OpTypePointer Workgroup %[[#Int8Ty]]
-; CHECK-SPIRV-DAG: %[[#CWGPtrTy:]] = OpTypePointer CrossWorkgroup %[[#Int8Ty]]
-; CHECK-SPIRV-DAG: %[[#Scope:]] = OpConstant %[[#IntTy]] 2
-; CHECK-SPIRV-DAG: %[[#NumElem:]] = OpConstant %[[#LongTy]] 123
-; CHECK-SPIRV-DAG: %[[#Stride:]] = OpConstant %[[#LongTy]] 1
-; CHECK-SPIRV-DAG: %[[#DstNull:]] = OpConstantNull %[[#WGPtrTy]]
-; CHECK-SPIRV-DAG: %[[#SrcNull:]] = OpConstantNull %[[#CWGPtrTy]]
-; CHECK-SPIRV-DAG: %[[#EventNull:]] = OpConstantNull %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#GenPtrEventTy:]] = OpTypePointer Generic %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#FunPtrEventTy:]] = OpTypePointer Function %[[#EventTy]]
-; CHECK-SPIRV: OpFunction
-; CHECK-SPIRV: %[[#Var:]] = OpVariable %[[#FunPtrEventTy]] Function
-; CHECK-SPIRV: %[[#ResEvent:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#DstNull]] %[[#SrcNull]] %[[#NumElem]] %[[#Stride]] %[[#EventNull]]
-; CHECK-SPIRV: OpStore %[[#Var]] %[[#ResEvent]]
-; CHECK-SPIRV: %[[#PtrEventGen:]] = OpPtrCastToGeneric %[[#GenPtrEventTy]] %[[#Var]]
-; CHECK-SPIRV: OpGroupWaitEvents %[[#Scope]] %[[#]] %[[#PtrEventGen]]
-; CHECK-SPIRV: OpFunctionEnd
+; CHECK-DAG: %[[#LongTy:]] = OpTypeInt 64 0
+; CHECK-DAG: %[[#IntTy:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#Int8Ty:]] = OpTypeInt 8 0
+; CHECK-DAG: %[[#EventTy:]] = OpTypeEvent
+; CHECK-DAG: %[[#WGPtrTy:]] = OpTypePointer Workgroup %[[#Int8Ty]]
+; CHECK-DAG: %[[#CWGPtrTy:]] = OpTypePointer CrossWorkgroup %[[#Int8Ty]]
+; CHECK-DAG: %[[#Scope:]] = OpConstant %[[#IntTy]] 2
+; CHECK-DAG: %[[#NumElem:]] = OpConstant %[[#LongTy]] 123
+; CHECK-DAG: %[[#Stride:]] = OpConstant %[[#LongTy]] 1
+; CHECK-DAG: %[[#DstNull:]] = OpConstantNull %[[#WGPtrTy]]
+; CHECK-DAG: %[[#SrcNull:]] = OpConstantNull %[[#CWGPtrTy]]
+; CHECK-DAG: %[[#EventNull:]] = OpConstantNull %[[#EventTy]]
+; CHECK-DAG: %[[#GenPtrEventTy:]] = OpTypePointer Generic %[[#EventTy]]
+; CHECK-DAG: %[[#FunPtrEventTy:]] = OpTypePointer Function %[[#EventTy]]
+; CHECK: OpFunction
+; CHECK: %[[#Var:]] = OpVariable %[[#FunPtrEventTy]] Function
+; CHECK: %[[#ResEvent:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#DstNull]] %[[#SrcNull]] %[[#NumElem]] %[[#Stride]] %[[#EventNull]]
+; CHECK: OpStore %[[#Var]] %[[#ResEvent]]
+; CHECK: %[[#PtrEventGen:]] = OpPtrCastToGeneric %[[#GenPtrEventTy]] %[[#Var]]
+; CHECK: OpGroupWaitEvents %[[#Scope]] %[[#]] %[[#PtrEventGen]]
+; CHECK: OpFunctionEnd
 
 define spir_kernel void @foo() {
   %event = alloca target("spirv.Event"), align 8

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy-strided-64.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy-strided-64.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-SPIRV-DAG: %[[#LongTy:]] = OpTypeInt 64 0

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy-strided.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy-strided.ll
@@ -1,26 +1,26 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; CHECK-SPIRV-DAG: %[[#IntTy:]] = OpTypeInt 32 0
-; CHECK-SPIRV-DAG: %[[#Int8Ty:]] = OpTypeInt 8 0
-; CHECK-SPIRV-DAG: %[[#EventTy:]] = OpTypeEvent
-; CHECK-SPIRV-DAG: %[[#WGPtrTy:]] = OpTypePointer Workgroup %[[#Int8Ty]]
-; CHECK-SPIRV-DAG: %[[#CWGPtrTy:]] = OpTypePointer CrossWorkgroup %[[#Int8Ty]]
-; CHECK-SPIRV-DAG: %[[#Scope:]] = OpConstant %[[#IntTy]] 2
-; CHECK-SPIRV-DAG: %[[#NumElem:]] = OpConstant %[[#IntTy]] 123
-; CHECK-SPIRV-DAG: %[[#Stride:]] = OpConstant %[[#IntTy]] 1
-; CHECK-SPIRV-DAG: %[[#DstNull:]] = OpConstantNull %[[#WGPtrTy]]
-; CHECK-SPIRV-DAG: %[[#SrcNull:]] = OpConstantNull %[[#CWGPtrTy]]
-; CHECK-SPIRV-DAG: %[[#EventNull:]] = OpConstantNull %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#GenPtrEventTy:]] = OpTypePointer Generic %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#FunPtrEventTy:]] = OpTypePointer Function %[[#EventTy]]
-; CHECK-SPIRV: OpFunction
-; CHECK-SPIRV: %[[#Var:]] = OpVariable %[[#FunPtrEventTy]] Function
-; CHECK-SPIRV: %[[#ResEvent:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#DstNull]] %[[#SrcNull]] %[[#NumElem]] %[[#Stride]] %[[#EventNull]]
-; CHECK-SPIRV: OpStore %[[#Var]] %[[#ResEvent]]
-; CHECK-SPIRV: %[[#PtrEventGen:]] = OpPtrCastToGeneric %[[#GenPtrEventTy]] %[[#Var]]
-; CHECK-SPIRV: OpGroupWaitEvents %[[#Scope]] %[[#Stride]] %[[#PtrEventGen]]
-; CHECK-SPIRV: OpFunctionEnd
+; CHECK-DAG: %[[#IntTy:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#Int8Ty:]] = OpTypeInt 8 0
+; CHECK-DAG: %[[#EventTy:]] = OpTypeEvent
+; CHECK-DAG: %[[#WGPtrTy:]] = OpTypePointer Workgroup %[[#Int8Ty]]
+; CHECK-DAG: %[[#CWGPtrTy:]] = OpTypePointer CrossWorkgroup %[[#Int8Ty]]
+; CHECK-DAG: %[[#Scope:]] = OpConstant %[[#IntTy]] 2
+; CHECK-DAG: %[[#NumElem:]] = OpConstant %[[#IntTy]] 123
+; CHECK-DAG: %[[#Stride:]] = OpConstant %[[#IntTy]] 1
+; CHECK-DAG: %[[#DstNull:]] = OpConstantNull %[[#WGPtrTy]]
+; CHECK-DAG: %[[#SrcNull:]] = OpConstantNull %[[#CWGPtrTy]]
+; CHECK-DAG: %[[#EventNull:]] = OpConstantNull %[[#EventTy]]
+; CHECK-DAG: %[[#GenPtrEventTy:]] = OpTypePointer Generic %[[#EventTy]]
+; CHECK-DAG: %[[#FunPtrEventTy:]] = OpTypePointer Function %[[#EventTy]]
+; CHECK: OpFunction
+; CHECK: %[[#Var:]] = OpVariable %[[#FunPtrEventTy]] Function
+; CHECK: %[[#ResEvent:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#DstNull]] %[[#SrcNull]] %[[#NumElem]] %[[#Stride]] %[[#EventNull]]
+; CHECK: OpStore %[[#Var]] %[[#ResEvent]]
+; CHECK: %[[#PtrEventGen:]] = OpPtrCastToGeneric %[[#GenPtrEventTy]] %[[#Var]]
+; CHECK: OpGroupWaitEvents %[[#Scope]] %[[#Stride]] %[[#PtrEventGen]]
+; CHECK: OpFunctionEnd
 
 define spir_kernel void @foo() {
   %event = alloca target("spirv.Event"), align 8

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy-strided.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpGroupAsyncCopy-strided.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-SPIRV-DAG: %[[#IntTy:]] = OpTypeInt 32 0

--- a/llvm/test/CodeGen/SPIRV/transcoding/spirv-event-null-64.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/spirv-event-null-64.ll
@@ -1,28 +1,28 @@
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; CHECK-SPIRV-DAG: %[[#IntTy:]] = OpTypeInt 32 0
-; CHECK-SPIRV-DAG: %[[#LongTy:]] = OpTypeInt 64 0
-; CHECK-SPIRV-DAG: %[[#EventTy:]] = OpTypeEvent
-; CHECK-SPIRV-DAG: %[[#ConstEvent:]] = OpConstantNull %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#TyEventPtr:]] = OpTypePointer Function %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#TyEventPtrGen:]] = OpTypePointer Generic %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#TyStruct:]] = OpTypeStruct %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#TyStructPtr:]] = OpTypePointer Function %[[#TyStruct]]
-; CHECK-SPIRV-DAG: %[[#TyChar:]] = OpTypeInt 8 0
-; CHECK-SPIRV-DAG: %[[#TyV4:]] = OpTypeVector %[[#TyChar]] 4
-; CHECK-SPIRV-DAG: %[[#TyStructV4:]] = OpTypeStruct %[[#TyV4]]
-; CHECK-SPIRV-DAG: %[[#TyPtrSV4_CW:]] = OpTypePointer CrossWorkgroup %[[#TyStructV4]]
-; CHECK-SPIRV-DAG: %[[#TyPtrV4_W:]] = OpTypePointer Workgroup %[[#TyV4]]
-; CHECK-SPIRV-DAG: %[[#TyPtrV4_CW:]] = OpTypePointer CrossWorkgroup %[[#TyV4]]
-; CHECK-SPIRV-DAG: %[[#TyHalf:]] = OpTypeFloat 16
-; CHECK-SPIRV-DAG: %[[#TyHalfV2:]] = OpTypeVector %[[#TyHalf]] 2
-; CHECK-SPIRV-DAG: %[[#TyHalfV2_W:]] = OpTypePointer Workgroup %[[#TyHalfV2]]
-; CHECK-SPIRV-DAG: %[[#TyHalfV2_CW:]] = OpTypePointer CrossWorkgroup %[[#TyHalfV2]]
-; CHECK-SPIRV-DAG: %[[#Scope:]] = OpConstant %[[#IntTy]] 2
-; CHECK-SPIRV-DAG: %[[#NumElem:]] = OpConstant %[[#LongTy]] 16
-; CHECK-SPIRV-DAG: %[[#Stride:]] = OpConstant %[[#LongTy]] 10
-; CHECK-SPIRV-DAG: %[[#NumEvents:]] = OpConstant %[[#IntTy]] 1
+; CHECK-DAG: %[[#IntTy:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#LongTy:]] = OpTypeInt 64 0
+; CHECK-DAG: %[[#EventTy:]] = OpTypeEvent
+; CHECK-DAG: %[[#ConstEvent:]] = OpConstantNull %[[#EventTy]]
+; CHECK-DAG: %[[#TyEventPtr:]] = OpTypePointer Function %[[#EventTy]]
+; CHECK-DAG: %[[#TyEventPtrGen:]] = OpTypePointer Generic %[[#EventTy]]
+; CHECK-DAG: %[[#TyStruct:]] = OpTypeStruct %[[#EventTy]]
+; CHECK-DAG: %[[#TyStructPtr:]] = OpTypePointer Function %[[#TyStruct]]
+; CHECK-DAG: %[[#TyChar:]] = OpTypeInt 8 0
+; CHECK-DAG: %[[#TyV4:]] = OpTypeVector %[[#TyChar]] 4
+; CHECK-DAG: %[[#TyStructV4:]] = OpTypeStruct %[[#TyV4]]
+; CHECK-DAG: %[[#TyPtrSV4_CW:]] = OpTypePointer CrossWorkgroup %[[#TyStructV4]]
+; CHECK-DAG: %[[#TyPtrV4_W:]] = OpTypePointer Workgroup %[[#TyV4]]
+; CHECK-DAG: %[[#TyPtrV4_CW:]] = OpTypePointer CrossWorkgroup %[[#TyV4]]
+; CHECK-DAG: %[[#TyHalf:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#TyHalfV2:]] = OpTypeVector %[[#TyHalf]] 2
+; CHECK-DAG: %[[#TyHalfV2_W:]] = OpTypePointer Workgroup %[[#TyHalfV2]]
+; CHECK-DAG: %[[#TyHalfV2_CW:]] = OpTypePointer CrossWorkgroup %[[#TyHalfV2]]
+; CHECK-DAG: %[[#Scope:]] = OpConstant %[[#IntTy]] 2
+; CHECK-DAG: %[[#NumElem:]] = OpConstant %[[#LongTy]] 16
+; CHECK-DAG: %[[#Stride:]] = OpConstant %[[#LongTy]] 10
+; CHECK-DAG: %[[#NumEvents:]] = OpConstant %[[#IntTy]] 1
 
 ; Check correct translation of __spirv_GroupAsyncCopy and target("spirv.Event") zeroinitializer
 
@@ -30,11 +30,11 @@
 
 @G_r = global target("spirv.Event") poison
 
-; CHECK-SPIRV: OpFunction
-; CHECK-SPIRV: %[[#HalfA1:]] = OpFunctionParameter %[[#TyHalfV2_W]]
-; CHECK-SPIRV: %[[#HalfA2:]] = OpFunctionParameter %[[#TyHalfV2_CW]]
-; CHECK-SPIRV: OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#HalfA1]] %[[#HalfA2]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
-; CHECK-SPIRV: OpFunctionEnd
+; CHECK: OpFunction
+; CHECK: %[[#HalfA1:]] = OpFunctionParameter %[[#TyHalfV2_W]]
+; CHECK: %[[#HalfA2:]] = OpFunctionParameter %[[#TyHalfV2_CW]]
+; CHECK: OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#HalfA1]] %[[#HalfA2]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
+; CHECK: OpFunctionEnd
 
 define spir_kernel void @test_half(ptr addrspace(3) %_arg1, ptr addrspace(1) %_arg2) {
 entry:
@@ -45,14 +45,14 @@ entry:
 
 declare dso_local spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS3Dv2_DF16_PU3AS1KS_mm9ocl_event(i32 noundef, ptr addrspace(3) noundef, ptr addrspace(1) noundef, i64 noundef, i64 noundef, target("spirv.Event"))
 
-; CHECK-SPIRV: OpFunction
-; CHECK-SPIRV: OpFunctionParameter
-; CHECK-SPIRV: %[[#Src:]] = OpFunctionParameter
-; CHECK-SPIRV: %[[#EventVar:]] = OpVariable %[[#TyEventPtr]] Function
-; CHECK-SPIRV: %[[#Dest:]] = OpInBoundsPtrAccessChain
-; CHECK-SPIRV: %[[#CopyRes:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#Dest]] %[[#Src]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
-; CHECK-SPIRV: OpStore %[[#EventVar]] %[[#CopyRes]]
-; CHECK-SPIRV: OpFunctionEnd
+; CHECK: OpFunction
+; CHECK: OpFunctionParameter
+; CHECK: %[[#Src:]] = OpFunctionParameter
+; CHECK: %[[#EventVar:]] = OpVariable %[[#TyEventPtr]] Function
+; CHECK: %[[#Dest:]] = OpInBoundsPtrAccessChain
+; CHECK: %[[#CopyRes:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#Dest]] %[[#Src]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
+; CHECK: OpStore %[[#EventVar]] %[[#CopyRes]]
+; CHECK: OpFunctionEnd
 
 define spir_kernel void @foo(ptr addrspace(1) %_arg_out_ptr, ptr addrspace(3) %_arg_local_acc) {
 entry:
@@ -73,17 +73,17 @@ declare dso_local spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU
 
 %Vec4 = type { <4 x i8> }
 
-; CHECK-SPIRV: OpFunction
-; CHECK-SPIRV: %[[#BarArg1:]] = OpFunctionParameter %[[#TyPtrV4_W]]
-; CHECK-SPIRV: %[[#BarArg2:]] = OpFunctionParameter %[[#TyPtrSV4_CW]]
-; CHECK-SPIRV: %[[#EventVarBar:]] = OpVariable %[[#TyStructPtr]] Function
-; CHECK-SPIRV: %[[#EventVarBarCasted2:]] = OpBitcast %[[#TyEventPtr]] %[[#EventVarBar]]
-; CHECK-SPIRV: %[[#ResBar:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#BarArg1]] %[[#]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
-; CHECK-SPIRV: %[[#EventVarBarCasted:]] = OpBitcast %[[#TyEventPtr]] %[[#EventVarBar]]
-; CHECK-SPIRV: OpStore %[[#EventVarBarCasted]] %[[#ResBar]]
-; CHECK-SPIRV: %[[#EventVarBarGen:]] = OpPtrCastToGeneric %[[#TyEventPtrGen]] %[[#EventVarBarCasted2]]
-; CHECK-SPIRV: OpGroupWaitEvents %[[#Scope]] %[[#NumEvents]] %[[#EventVarBarGen]]
-; CHECK-SPIRV: OpFunctionEnd
+; CHECK: OpFunction
+; CHECK: %[[#BarArg1:]] = OpFunctionParameter %[[#TyPtrV4_W]]
+; CHECK: %[[#BarArg2:]] = OpFunctionParameter %[[#TyPtrSV4_CW]]
+; CHECK: %[[#EventVarBar:]] = OpVariable %[[#TyStructPtr]] Function
+; CHECK: %[[#EventVarBarCasted2:]] = OpBitcast %[[#TyEventPtr]] %[[#EventVarBar]]
+; CHECK: %[[#ResBar:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#BarArg1]] %[[#]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
+; CHECK: %[[#EventVarBarCasted:]] = OpBitcast %[[#TyEventPtr]] %[[#EventVarBar]]
+; CHECK: OpStore %[[#EventVarBarCasted]] %[[#ResBar]]
+; CHECK: %[[#EventVarBarGen:]] = OpPtrCastToGeneric %[[#TyEventPtrGen]] %[[#EventVarBarCasted2]]
+; CHECK: OpGroupWaitEvents %[[#Scope]] %[[#NumEvents]] %[[#EventVarBarGen]]
+; CHECK: OpFunctionEnd
 
 define spir_kernel void @bar(ptr addrspace(3) %_arg_Local, ptr addrspace(1) readonly %_arg) {
 entry:

--- a/llvm/test/CodeGen/SPIRV/transcoding/spirv-event-null-64.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/spirv-event-null-64.ll
@@ -1,7 +1,8 @@
-; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-SPIRV-DAG: %[[#IntTy:]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG: %[[#LongTy:]] = OpTypeInt 64 0
 ; CHECK-SPIRV-DAG: %[[#EventTy:]] = OpTypeEvent
 ; CHECK-SPIRV-DAG: %[[#ConstEvent:]] = OpConstantNull %[[#EventTy]]
 ; CHECK-SPIRV-DAG: %[[#TyEventPtr:]] = OpTypePointer Function %[[#EventTy]]
@@ -19,8 +20,8 @@
 ; CHECK-SPIRV-DAG: %[[#TyHalfV2_W:]] = OpTypePointer Workgroup %[[#TyHalfV2]]
 ; CHECK-SPIRV-DAG: %[[#TyHalfV2_CW:]] = OpTypePointer CrossWorkgroup %[[#TyHalfV2]]
 ; CHECK-SPIRV-DAG: %[[#Scope:]] = OpConstant %[[#IntTy]] 2
-; CHECK-SPIRV-DAG: %[[#NumElem:]] = OpConstant %[[#IntTy]] 16
-; CHECK-SPIRV-DAG: %[[#Stride:]] = OpConstant %[[#IntTy]] 10
+; CHECK-SPIRV-DAG: %[[#NumElem:]] = OpConstant %[[#LongTy]] 16
+; CHECK-SPIRV-DAG: %[[#Stride:]] = OpConstant %[[#LongTy]] 10
 ; CHECK-SPIRV-DAG: %[[#NumEvents:]] = OpConstant %[[#IntTy]] 1
 
 ; Check correct translation of __spirv_GroupAsyncCopy and target("spirv.Event") zeroinitializer
@@ -37,12 +38,12 @@
 
 define spir_kernel void @test_half(ptr addrspace(3) %_arg1, ptr addrspace(1) %_arg2) {
 entry:
-  %r = tail call spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS3Dv2_DF16_PU3AS1KS_jj9ocl_event(i32 2, ptr addrspace(3) %_arg1, ptr addrspace(1) %_arg2, i32 16, i32 10, target("spirv.Event") zeroinitializer)
+  %r = tail call spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS3Dv2_DF16_PU3AS1KS_mm9ocl_event(i32 2, ptr addrspace(3) %_arg1, ptr addrspace(1) %_arg2, i64 16, i64 10, target("spirv.Event") zeroinitializer)
   store target("spirv.Event") %r, ptr @G_r
   ret void
 }
 
-declare dso_local spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS3Dv2_DF16_PU3AS1KS_jj9ocl_event(i32 noundef, ptr addrspace(3) noundef, ptr addrspace(1) noundef, i32 noundef, i32 noundef, target("spirv.Event"))
+declare dso_local spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS3Dv2_DF16_PU3AS1KS_mm9ocl_event(i32 noundef, ptr addrspace(3) noundef, ptr addrspace(1) noundef, i64 noundef, i64 noundef, target("spirv.Event"))
 
 ; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: OpFunctionParameter
@@ -58,12 +59,12 @@ entry:
   %var = alloca %StructEvent
   %dev_event.i.sroa.0 = alloca target("spirv.Event")
   %add.ptr.i26 = getelementptr inbounds i32, ptr addrspace(1) %_arg_out_ptr, i64 0
-  %call3.i = tail call spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS1iPU3AS3Kijj9ocl_event(i32 2, ptr addrspace(1) %add.ptr.i26, ptr addrspace(3) %_arg_local_acc, i32 16, i32 10, target("spirv.Event") zeroinitializer)
+  %call3.i = tail call spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS1iPU3AS3Kimm9ocl_event(i32 2, ptr addrspace(1) %add.ptr.i26, ptr addrspace(3) %_arg_local_acc, i64 16, i64 10, target("spirv.Event") zeroinitializer)
   store target("spirv.Event") %call3.i, ptr %dev_event.i.sroa.0
   ret void
 }
 
-declare dso_local spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS1iPU3AS3Kijj9ocl_event(i32, ptr addrspace(1), ptr addrspace(3), i32, i32, target("spirv.Event"))
+declare dso_local spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS1iPU3AS3Kimm9ocl_event(i32, ptr addrspace(1), ptr addrspace(3), i64, i64, target("spirv.Event"))
 
 ; Check correct type inference when calling __spirv_GroupAsyncCopy:
 ; we expect that the Backend is able to deduce a type of the %_arg_Local
@@ -88,13 +89,13 @@ define spir_kernel void @bar(ptr addrspace(3) %_arg_Local, ptr addrspace(1) read
 entry:
   %E1 = alloca %StructEvent
   %srcptr = getelementptr inbounds %Vec4, ptr addrspace(1) %_arg, i64 0
-  %r1 = tail call spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS3Dv4_aPU3AS1KS_jj9ocl_event(i32 2, ptr addrspace(3) %_arg_Local, ptr addrspace(1) %srcptr, i32 16, i32 10, target("spirv.Event") zeroinitializer)
+  %r1 = tail call spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS3Dv4_aPU3AS1KS_mm9ocl_event(i32 2, ptr addrspace(3) %_arg_Local, ptr addrspace(1) %srcptr, i64 16, i64 10, target("spirv.Event") zeroinitializer)
   store target("spirv.Event") %r1, ptr %E1
   %E.ascast.i = addrspacecast ptr %E1 to ptr addrspace(4)
   call spir_func void @_Z23__spirv_GroupWaitEventsjiP9ocl_event(i32 2, i32 1, ptr addrspace(4) %E.ascast.i)
   ret void
 }
 
-declare dso_local spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS3Dv4_aPU3AS1KS_jj9ocl_event(i32, ptr addrspace(3), ptr addrspace(1), i32, i32, target("spirv.Event"))
+declare dso_local spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS3Dv4_aPU3AS1KS_mm9ocl_event(i32, ptr addrspace(3), ptr addrspace(1), i64, i64, target("spirv.Event"))
 declare dso_local spir_func void @_Z23__spirv_GroupWaitEventsjiP9ocl_event(i32, i32, ptr addrspace(4))
 

--- a/llvm/test/CodeGen/SPIRV/transcoding/spirv-event-null-64.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/spirv-event-null-64.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-SPIRV-DAG: %[[#IntTy:]] = OpTypeInt 32 0

--- a/llvm/test/CodeGen/SPIRV/transcoding/spirv-event-null.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/spirv-event-null.ll
@@ -1,27 +1,27 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; CHECK-SPIRV-DAG: %[[#IntTy:]] = OpTypeInt 32 0
-; CHECK-SPIRV-DAG: %[[#EventTy:]] = OpTypeEvent
-; CHECK-SPIRV-DAG: %[[#ConstEvent:]] = OpConstantNull %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#TyEventPtr:]] = OpTypePointer Function %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#TyEventPtrGen:]] = OpTypePointer Generic %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#TyStruct:]] = OpTypeStruct %[[#EventTy]]
-; CHECK-SPIRV-DAG: %[[#TyStructPtr:]] = OpTypePointer Function %[[#TyStruct]]
-; CHECK-SPIRV-DAG: %[[#TyChar:]] = OpTypeInt 8 0
-; CHECK-SPIRV-DAG: %[[#TyV4:]] = OpTypeVector %[[#TyChar]] 4
-; CHECK-SPIRV-DAG: %[[#TyStructV4:]] = OpTypeStruct %[[#TyV4]]
-; CHECK-SPIRV-DAG: %[[#TyPtrSV4_CW:]] = OpTypePointer CrossWorkgroup %[[#TyStructV4]]
-; CHECK-SPIRV-DAG: %[[#TyPtrV4_W:]] = OpTypePointer Workgroup %[[#TyV4]]
-; CHECK-SPIRV-DAG: %[[#TyPtrV4_CW:]] = OpTypePointer CrossWorkgroup %[[#TyV4]]
-; CHECK-SPIRV-DAG: %[[#TyHalf:]] = OpTypeFloat 16
-; CHECK-SPIRV-DAG: %[[#TyHalfV2:]] = OpTypeVector %[[#TyHalf]] 2
-; CHECK-SPIRV-DAG: %[[#TyHalfV2_W:]] = OpTypePointer Workgroup %[[#TyHalfV2]]
-; CHECK-SPIRV-DAG: %[[#TyHalfV2_CW:]] = OpTypePointer CrossWorkgroup %[[#TyHalfV2]]
-; CHECK-SPIRV-DAG: %[[#Scope:]] = OpConstant %[[#IntTy]] 2
-; CHECK-SPIRV-DAG: %[[#NumElem:]] = OpConstant %[[#IntTy]] 16
-; CHECK-SPIRV-DAG: %[[#Stride:]] = OpConstant %[[#IntTy]] 10
-; CHECK-SPIRV-DAG: %[[#NumEvents:]] = OpConstant %[[#IntTy]] 1
+; CHECK-DAG: %[[#IntTy:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#EventTy:]] = OpTypeEvent
+; CHECK-DAG: %[[#ConstEvent:]] = OpConstantNull %[[#EventTy]]
+; CHECK-DAG: %[[#TyEventPtr:]] = OpTypePointer Function %[[#EventTy]]
+; CHECK-DAG: %[[#TyEventPtrGen:]] = OpTypePointer Generic %[[#EventTy]]
+; CHECK-DAG: %[[#TyStruct:]] = OpTypeStruct %[[#EventTy]]
+; CHECK-DAG: %[[#TyStructPtr:]] = OpTypePointer Function %[[#TyStruct]]
+; CHECK-DAG: %[[#TyChar:]] = OpTypeInt 8 0
+; CHECK-DAG: %[[#TyV4:]] = OpTypeVector %[[#TyChar]] 4
+; CHECK-DAG: %[[#TyStructV4:]] = OpTypeStruct %[[#TyV4]]
+; CHECK-DAG: %[[#TyPtrSV4_CW:]] = OpTypePointer CrossWorkgroup %[[#TyStructV4]]
+; CHECK-DAG: %[[#TyPtrV4_W:]] = OpTypePointer Workgroup %[[#TyV4]]
+; CHECK-DAG: %[[#TyPtrV4_CW:]] = OpTypePointer CrossWorkgroup %[[#TyV4]]
+; CHECK-DAG: %[[#TyHalf:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#TyHalfV2:]] = OpTypeVector %[[#TyHalf]] 2
+; CHECK-DAG: %[[#TyHalfV2_W:]] = OpTypePointer Workgroup %[[#TyHalfV2]]
+; CHECK-DAG: %[[#TyHalfV2_CW:]] = OpTypePointer CrossWorkgroup %[[#TyHalfV2]]
+; CHECK-DAG: %[[#Scope:]] = OpConstant %[[#IntTy]] 2
+; CHECK-DAG: %[[#NumElem:]] = OpConstant %[[#IntTy]] 16
+; CHECK-DAG: %[[#Stride:]] = OpConstant %[[#IntTy]] 10
+; CHECK-DAG: %[[#NumEvents:]] = OpConstant %[[#IntTy]] 1
 
 ; Check correct translation of __spirv_GroupAsyncCopy and target("spirv.Event") zeroinitializer
 
@@ -29,11 +29,11 @@
 
 @G_r = global target("spirv.Event") poison
 
-; CHECK-SPIRV: OpFunction
-; CHECK-SPIRV: %[[#HalfA1:]] = OpFunctionParameter %[[#TyHalfV2_W]]
-; CHECK-SPIRV: %[[#HalfA2:]] = OpFunctionParameter %[[#TyHalfV2_CW]]
-; CHECK-SPIRV: OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#HalfA1]] %[[#HalfA2]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
-; CHECK-SPIRV: OpFunctionEnd
+; CHECK: OpFunction
+; CHECK: %[[#HalfA1:]] = OpFunctionParameter %[[#TyHalfV2_W]]
+; CHECK: %[[#HalfA2:]] = OpFunctionParameter %[[#TyHalfV2_CW]]
+; CHECK: OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#HalfA1]] %[[#HalfA2]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
+; CHECK: OpFunctionEnd
 
 define spir_kernel void @test_half(ptr addrspace(3) %_arg1, ptr addrspace(1) %_arg2) {
 entry:
@@ -44,14 +44,14 @@ entry:
 
 declare dso_local spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU3AS3Dv2_DF16_PU3AS1KS_jj9ocl_event(i32 noundef, ptr addrspace(3) noundef, ptr addrspace(1) noundef, i32 noundef, i32 noundef, target("spirv.Event"))
 
-; CHECK-SPIRV: OpFunction
-; CHECK-SPIRV: OpFunctionParameter
-; CHECK-SPIRV: %[[#Src:]] = OpFunctionParameter
-; CHECK-SPIRV: %[[#EventVar:]] = OpVariable %[[#TyEventPtr]] Function
-; CHECK-SPIRV: %[[#Dest:]] = OpInBoundsPtrAccessChain
-; CHECK-SPIRV: %[[#CopyRes:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#Dest]] %[[#Src]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
-; CHECK-SPIRV: OpStore %[[#EventVar]] %[[#CopyRes]]
-; CHECK-SPIRV: OpFunctionEnd
+; CHECK: OpFunction
+; CHECK: OpFunctionParameter
+; CHECK: %[[#Src:]] = OpFunctionParameter
+; CHECK: %[[#EventVar:]] = OpVariable %[[#TyEventPtr]] Function
+; CHECK: %[[#Dest:]] = OpInBoundsPtrAccessChain
+; CHECK: %[[#CopyRes:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#Dest]] %[[#Src]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
+; CHECK: OpStore %[[#EventVar]] %[[#CopyRes]]
+; CHECK: OpFunctionEnd
 
 define spir_kernel void @foo(ptr addrspace(1) %_arg_out_ptr, ptr addrspace(3) %_arg_local_acc) {
 entry:
@@ -72,17 +72,17 @@ declare dso_local spir_func target("spirv.Event") @_Z22__spirv_GroupAsyncCopyjPU
 
 %Vec4 = type { <4 x i8> }
 
-; CHECK-SPIRV: OpFunction
-; CHECK-SPIRV: %[[#BarArg1:]] = OpFunctionParameter %[[#TyPtrV4_W]]
-; CHECK-SPIRV: %[[#BarArg2:]] = OpFunctionParameter %[[#TyPtrSV4_CW]]
-; CHECK-SPIRV: %[[#EventVarBar:]] = OpVariable %[[#TyStructPtr]] Function
-; CHECK-SPIRV: %[[#EventVarBarCasted2:]] = OpBitcast %[[#TyEventPtr]] %[[#EventVarBar]]
-; CHECK-SPIRV: %[[#ResBar:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#BarArg1]] %[[#]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
-; CHECK-SPIRV: %[[#EventVarBarCasted:]] = OpBitcast %[[#TyEventPtr]] %[[#EventVarBar]]
-; CHECK-SPIRV: OpStore %[[#EventVarBarCasted]] %[[#ResBar]]
-; CHECK-SPIRV: %[[#EventVarBarGen:]] = OpPtrCastToGeneric %[[#TyEventPtrGen]] %[[#EventVarBarCasted2]]
-; CHECK-SPIRV: OpGroupWaitEvents %[[#Scope]] %[[#NumEvents]] %[[#EventVarBarGen]]
-; CHECK-SPIRV: OpFunctionEnd
+; CHECK: OpFunction
+; CHECK: %[[#BarArg1:]] = OpFunctionParameter %[[#TyPtrV4_W]]
+; CHECK: %[[#BarArg2:]] = OpFunctionParameter %[[#TyPtrSV4_CW]]
+; CHECK: %[[#EventVarBar:]] = OpVariable %[[#TyStructPtr]] Function
+; CHECK: %[[#EventVarBarCasted2:]] = OpBitcast %[[#TyEventPtr]] %[[#EventVarBar]]
+; CHECK: %[[#ResBar:]] = OpGroupAsyncCopy %[[#EventTy]] %[[#Scope]] %[[#BarArg1]] %[[#]] %[[#NumElem]] %[[#Stride]] %[[#ConstEvent]]
+; CHECK: %[[#EventVarBarCasted:]] = OpBitcast %[[#TyEventPtr]] %[[#EventVarBar]]
+; CHECK: OpStore %[[#EventVarBarCasted]] %[[#ResBar]]
+; CHECK: %[[#EventVarBarGen:]] = OpPtrCastToGeneric %[[#TyEventPtrGen]] %[[#EventVarBarCasted2]]
+; CHECK: OpGroupWaitEvents %[[#Scope]] %[[#NumEvents]] %[[#EventVarBarGen]]
+; CHECK: OpFunctionEnd
 
 define spir_kernel void @bar(ptr addrspace(3) %_arg_Local, ptr addrspace(1) readonly %_arg) {
 entry:

--- a/llvm/test/CodeGen/SPIRV/transcoding/spirv-event-null.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/spirv-event-null.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-SPIRV-DAG: %[[#IntTy:]] = OpTypeInt 32 0


### PR DESCRIPTION
Some tests started failing recently because `spirv-val` now considers their output invalid. This is likely due to an update in `spirv-val`. I'm not familiar with what the tests are doing but here is my attempt to fix them. At the LLVM-IR level, tests had for example incorrect `addresspace` for certain arguments. To fix them, I used as a reference some of the tests in the SPIRV-LLVM translator. The goal of the PR is just to fix the tests in case they had incorrect IR.