### PR TITLE
[LLVM] Remove pass initialization from pass constructor

### DIFF
--- a/llvm/lib/CodeGen/CodeGen.cpp
+++ b/llvm/lib/CodeGen/CodeGen.cpp
@@ -52,6 +52,7 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializeFinalizeISelPass(Registry);
   initializeFixupStatepointCallerSavedLegacyPass(Registry);
   initializeFuncletLayoutPass(Registry);
+  initializeGCEmptyBasicBlocksLegacyPass(Registry);
   initializeGCMachineCodeAnalysisPass(Registry);
   initializeGCModuleInfoPass(Registry);
   initializeGlobalMergePass(Registry);

--- a/llvm/lib/CodeGen/GCEmptyBasicBlocks.cpp
+++ b/llvm/lib/CodeGen/GCEmptyBasicBlocks.cpp
@@ -42,12 +42,7 @@ class GCEmptyBasicBlocksLegacy : public MachineFunctionPass {
 public:
   static char ID;
 
-  GCEmptyBasicBlocksLegacy() : MachineFunctionPass(ID) {
-    // TODO: Move this call to llvm::initializeCodeGen() once
-    // `gc-empty-basic-blocks` command line alias in TargetPassConfig.cpp has
-    // been removed.
-    initializeGCEmptyBasicBlocksLegacyPass(*PassRegistry::getPassRegistry());
-  }
+  GCEmptyBasicBlocksLegacy() : MachineFunctionPass(ID) {}
 
   StringRef getPassName() const override {
     return "Remove Empty Basic Blocks.";


### PR DESCRIPTION
Remove pass initialization from pass constructor for GCEmptyBasicBlocksLegacy pass.