### PR TITLE
workflows/release-binaries: Fix typo

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -62,7 +62,7 @@ jobs:
       release-binary-filename: ${{ steps.vars.outputs.release-binary-filename }}
       build-runs-on: ${{ steps.vars.outputs.build-runs-on }}
       test-runs-on: ${{ steps.vars.outputs.build-runs-on }}
-      attestation-name: ${{ steps.vars.outptus.attestation-name }}
+      attestation-name: ${{ steps.vars.outputs.attestation-name }}
 
     steps:
     # It's good practice to use setup-python, but this is also required on macos-14


### PR DESCRIPTION
This was causing the attestation-name to be null which caused the attestation upoload to fail.