### PR TITLE
[lldb] Fix SBBreakpointName::SetEnabled to propagate changes to breakpoints

### DIFF
--- a/lldb/source/API/SBBreakpointName.cpp
+++ b/lldb/source/API/SBBreakpointName.cpp
@@ -213,6 +213,7 @@ void SBBreakpointName::SetEnabled(bool enable) {
         m_impl_up->GetTarget()->GetAPIMutex());
 
   bp_name->GetOptions().SetEnabled(enable);
+  UpdateName(*bp_name);
 }
 
 void SBBreakpointName::UpdateName(BreakpointName &bp_name) {

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_names/TestBreakpointNames.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_names/TestBreakpointNames.py
@@ -2,11 +2,10 @@
 Test breakpoint names.
 """
 
-
 import os
 import lldb
 from lldbsuite.test.decorators import *
-from lldbsuite.test.lldbtest import *
+from lldbsuite.test.lldbtest import TestBase, VALID_BREAKPOINT, VALID_TARGET
 from lldbsuite.test import lldbutil
 
 
@@ -50,6 +49,14 @@ class BreakpointNames(TestBase):
         self.build()
         self.setup_target()
         self.do_check_configuring_permissions_cli()
+
+    def test_breakpointname_enabled(self):
+        """Use Commands and Python APIs to test that enabling and disabling a
+        breakpoint name is propagated to all breakpoints with that name.
+        """
+        self.build()
+        self.setup_target()
+        self.do_check_breakpointname_enabled()
 
     def setup_target(self):
         exe = self.getBuildArtifact("a.out")
@@ -474,3 +481,60 @@ class BreakpointNames(TestBase):
             bp_name.IsValid(), "Didn't make a breakpoint name we could find."
         )
         self.check_permission_results(bp_name)
+
+    def do_check_breakpointname_enabled(self):
+        target: lldb.SBTarget = self.target
+        self.assertTrue(target.IsValid(), "Target name must be valid.")
+        bp_name: lldb.SBBreakpointName = lldb.SBBreakpointName(
+            target, self.bp_name_string
+        )
+        self.assertTrue(bp_name.IsValid(), "Breakpoint name must be valid.")
+
+        # Create two function breakpoints a and b.
+        a_breakpoint: lldb.SBBreakpoint = target.BreakpointCreateByName("a")
+        self.assertTrue(a_breakpoint and a_breakpoint.IsValid(), VALID_BREAKPOINT)
+        self.assertEqual(a_breakpoint.GetNumLocations(), 1)
+        self.assertTrue(a_breakpoint.IsEnabled())
+        self.assertTrue(a_breakpoint.AddNameWithErrorHandling(self.bp_name_string))
+
+        b_breakpoint = target.BreakpointCreateByName("b")
+        self.assertTrue(b_breakpoint and b_breakpoint.IsValid(), VALID_BREAKPOINT)
+        self.assertEqual(b_breakpoint.GetNumLocations(), 1)
+        self.assertTrue(b_breakpoint.IsEnabled())
+        self.assertTrue(b_breakpoint.AddNameWithErrorHandling(self.bp_name_string))
+
+        # enabled and disable the function breakpoints with the breakpoint name.
+        # With API.
+        bp_name.SetEnabled(False)
+        self.assertFalse(bp_name.IsEnabled())
+        self.assertFalse(a_breakpoint.IsEnabled())
+        self.assertFalse(b_breakpoint.IsEnabled())
+        bp_name.SetEnabled(True)
+        self.assertTrue(a_breakpoint.IsEnabled())
+        self.assertTrue(b_breakpoint.IsEnabled())
+        self.assertTrue(bp_name.IsEnabled())
+
+        # With cli.
+        self.runCmd(f"breakpoint name configure {self.bp_name_string} --disable")
+        self.assertFalse(bp_name.IsEnabled())
+        self.assertFalse(a_breakpoint.IsEnabled())
+        self.assertFalse(b_breakpoint.IsEnabled())
+        self.runCmd(f"breakpoint name configure {self.bp_name_string} --enable")
+        self.assertTrue(a_breakpoint.IsEnabled())
+        self.assertTrue(b_breakpoint.IsEnabled())
+        self.assertTrue(bp_name.IsEnabled())
+
+        # Disabling all the Breakpoints in a BreakpointName
+        # does not disable the BreakpointName.
+        a_breakpoint.SetEnabled(False)
+        b_breakpoint.SetEnabled(False)
+        self.assertFalse(a_breakpoint.IsEnabled())
+        self.assertFalse(b_breakpoint.IsEnabled())
+        self.assertTrue(bp_name.IsEnabled())
+
+        # BreakpointName should enable all disabled breakpoints with the name.
+        b_breakpoint.SetEnabled(True)
+        bp_name.SetEnabled(True)
+        self.assertTrue(a_breakpoint.IsEnabled())
+        self.assertTrue(b_breakpoint.IsEnabled())
+        self.assertTrue(bp_name.IsEnabled())


### PR DESCRIPTION
When setting the enabled state of a breakpoint name via the API, the change was not being propagated to breakpoints using that name. 
This was inconsistent with the CLI behaviour where `breakpoint name configure --enable/--disable` correctly updates all associated breakpoints.

Reported from discord.