### PR TITLE
[lldb-dap] Improve DetectReplMode

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -605,6 +605,11 @@ ReplMode DAP::DetectReplMode(lldb::SBFrame &frame, std::string &expression,
 
   if (repl_mode != ReplMode::Auto)
     return repl_mode;
+
+  // We cannot check if expression is a variable without a frame.
+  if (!frame)
+    return ReplMode::Command;
+
   // To determine if the expression is a command or not, check if the first
   // term is a variable or command. If it's a variable in scope we will prefer
   // that behavior and give a warning to the user if they meant to invoke the


### PR DESCRIPTION
When DetectReplMode is called without a valid frame, we cannot check if an expression refers to a variable in scope.
This avoids unnecessary checks when completing expressions.