### PR TITLE
[sanitizers] [Darwin] Fix erroneous warning when external_symbolizer_path=""

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
@@ -475,6 +475,13 @@ static SymbolizerTool *ChooseExternalSymbolizer(LowLevelAllocator *allocator) {
       return new (*allocator) Addr2LinePool(found_path, allocator);
     }
   }
+
+#    if SANITIZER_APPLE
+  Report(
+      "WARN: No external symbolizers found. Symbols may be missing or "
+      "unreliable.\n");
+  Report("HINT: Is PATH set? Does sandbox allow file-read of /usr/bin/atos?\n");
+#    endif
   return nullptr;
 #  endif    // SANITIZER_DISABLE_SYMBOLIZER_PATH_SEARCH
 }
@@ -509,13 +516,6 @@ static void ChooseSymbolizerTools(IntrusiveList<SymbolizerTool> *list,
   }
 
 #  if SANITIZER_APPLE
-  if (list->empty()) {
-    Report(
-        "WARN: No external symbolizers found. Symbols may be missing or "
-        "unreliable.\n");
-    Report(
-        "HINT: Is PATH set? Does sandbox allow file-read of /usr/bin/atos?\n");
-  }
   VReport(2, "Using dladdr symbolizer.\n");
   list->push_back(new (*allocator) DlAddrSymbolizer());
 #  endif  // SANITIZER_APPLE


### PR DESCRIPTION
Some tools pass external_symbolizer_path="", which means it is not expected to have any symbolizers in the list at the point we inserted a (Darwin-only) warning.

This moves the symbolizer warning into ChooseExternalSymbolizer, after the external_symbolizer_path="" case has been handled.

rdar://169137614