### PR TITLE
[libc][math] Refactor f16sqrtf128 to Header Only.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -62,6 +62,7 @@
 #include "math/f16fma.h"
 #include "math/f16fmal.h"
 #include "math/f16sqrtl.h"
+#include "math/f16sqrtf128.h"
 #include "math/frexpf.h"
 #include "math/frexpf128.h"
 #include "math/frexpf16.h"

--- a/libc/shared/math/f16sqrtf128.h
+++ b/libc/shared/math/f16sqrtf128.h
@@ -1,0 +1,35 @@
+//===-- Shared f16sqrtf128 function -----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_MATH_F16SQRTF128_H
+#define LLVM_LIBC_SHARED_MATH_F16SQRTF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "include/llvm-libc-macros/float16-macros.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
+#include "shared/libc_common.h"
+#include "src/__support/math/f16sqrtf128.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using math::f16sqrtf128;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SHARED_MATH_F16SQRTF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1090,6 +1090,12 @@ add_header_library(
     libc.src.__support.FPUtil.manipulation_functions
     libc.src.__support.common
     libc.src.__support.macros.config
+  f16sqrtf128
+  HDRS
+    f16sqrtf128.h
+  DEPENDS
+    libc.src.__support.macros.properties.types
+    libc.src.__support.FPUtil.sqrt
 )
 
 add_header_library(

--- a/libc/src/__support/math/f16sqrtf128.h
+++ b/libc/src/__support/math/f16sqrtf128.h
@@ -1,0 +1,39 @@
+//===-- Implementation header for f16sqrtf128 -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_F16SQRTF128_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_F16SQRTF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "include/llvm-libc-macros/float16-macros.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
+#include "src/__support/FPUtil/sqrt.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LLVM_LIBC_FUNCTION(float16, f16sqrtf128, (float128 x)) {
+  return fputil::sqrt<float16>(x);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_F16SQRTF128_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -5112,8 +5112,7 @@ add_entrypoint_object(
   HDRS
     ../f16sqrtf128.h
   DEPENDS
-    libc.src.__support.macros.properties.types
-    libc.src.__support.FPUtil.sqrt
+    libc.src.__support.math.f16sqrtf128
 )
 
 add_entrypoint_object(

--- a/libc/src/math/generic/f16sqrtf128.cpp
+++ b/libc/src/math/generic/f16sqrtf128.cpp
@@ -7,14 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/f16sqrtf128.h"
-#include "src/__support/FPUtil/sqrt.h"
-#include "src/__support/common.h"
-#include "src/__support/macros/config.h"
+#include "src/__support/math/f16sqrtf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(float16, f16sqrtf128, (float128 x)) {
-  return fputil::sqrt<float16>(x);
+  return math::f16sqrtf128(x);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -58,6 +58,7 @@ add_fp_unittest(
     libc.src.__support.math.f16fma
     libc.src.__support.math.f16fmal
     libc.src.__support.math.f16sqrtl
+    libc.src.__support.math.f16sqrtf128
     libc.src.__support.math.frexpf
     libc.src.__support.math.frexpf128
     libc.src.__support.math.frexpf16

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -155,6 +155,10 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                         float128(0.0), float128(0.0), float128(0.0)));
 
   EXPECT_EQ(0L, LIBC_NAMESPACE::shared::llogbf128(float128(1.0)));
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+  EXPECT_FP_EQ(2.0f16, LIBC_NAMESPACE::shared::f16sqrtf128(float128(4.0)));
+#endif // LIBC_TYPES_HAS_FLOAT16
 }
 
 #endif // LIBC_TYPES_HAS_FLOAT128

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2888,6 +2888,17 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_f16sqrtf128",
+    hdrs = ["src/__support/math/f16sqrtf128.h"],
+    deps = [
+        ":__support.macros.properties.types",
+        ":__support.FPUtil.sqrt",
+        ":llvm_libc_macros_float16_macros",
+        ":llvm_libc_types_float128",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_f16fma",
     hdrs = ["src/__support/math/f16fma.h"],
     deps = [
@@ -4443,7 +4454,7 @@ libc_math_function(
 libc_math_function(
     name = "f16sqrtf128",
     additional_deps = [
-        ":__support_fputil_sqrt",
+        ":__support_math_f16sqrtf128",
     ],
 )
 


### PR DESCRIPTION
Closes #175328 

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450