### PR TITLE
[clang][lit] Disable spirv-tools-err.c on Windows

### DIFF
--- a/clang/test/Driver/spirv-tools-err.c
+++ b/clang/test/Driver/spirv-tools-err.c
@@ -1,4 +1,8 @@
 // UNSUPPORTED: spirv-tools
+
+// The RUN command doesn't work on some Windows shells.
+// UNSUPPORTED: system-windows
+
 // REQUIRES: spirv-registered-target
 
 // RUN: env PATH='' not %clang -o /dev/null --target=spirv64 --save-temps -v %s 2>&1 | FileCheck %s


### PR DESCRIPTION
Seems to fail when run from PowerShell, and we [shouldn't](https://github.com/llvm/llvm-project/pull/173313) use `REQUIRES: shell` anymore.