### PR TITLE
[flang] Support alternative sentinel !pgi$ for compiler directive

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -481,6 +481,7 @@ end
 * A data object can be initialized multiple times by `DATA` statements
   and default component initialization, but only when all initializations
   are to the same value.  Distinct initializations remain errors.
+* `!pgi$` as an alias to `!dir$`.
 
 ### Extensions supported when enabled by options
 

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -1340,7 +1340,7 @@ constexpr auto noinlineDir{
     "NOINLINE" >> construct<CompilerDirective::NoInline>()};
 constexpr auto inlineDir{"INLINE" >> construct<CompilerDirective::Inline>()};
 constexpr auto ivdep{"IVDEP" >> construct<CompilerDirective::IVDep>()};
-TYPE_PARSER(beginDirective >> "DIR$ "_tok >>
+TYPE_PARSER(beginDirective >> ("DIR$ "_tok || "PGI$ "_tok) >>
     sourced((construct<CompilerDirective>(ignore_tkr) ||
                 construct<CompilerDirective>(loopCount) ||
                 construct<CompilerDirective>(assumeAligned) ||

--- a/flang/lib/Parser/parsing.cpp
+++ b/flang/lib/Parser/parsing.cpp
@@ -78,7 +78,8 @@ const SourceFile *Parsing::Prescan(const std::string &path, Options options) {
       .set_preprocessingOnly(options.prescanAndReformat)
       .set_expandIncludeLines(!options.prescanAndReformat ||
           options.expandIncludeLinesInPreprocessedOutput)
-      .AddCompilerDirectiveSentinel("dir$");
+      .AddCompilerDirectiveSentinel("dir$")
+      .AddCompilerDirectiveSentinel("pgi$");
   bool noneOfTheAbove{!options.features.IsEnabled(LanguageFeature::OpenACC) &&
       !options.features.IsEnabled(LanguageFeature::OpenMP) &&
       !options.features.IsEnabled(LanguageFeature::CUDA)};

--- a/flang/test/Parser/compiler-directives.f90
+++ b/flang/test/Parser/compiler-directives.f90
@@ -27,6 +27,14 @@ module m
      real(8), allocatable :: d(:)
      !dir$  align : 1024 :: d
   end type stuff
+
+  interface
+    subroutine alternative_sentinel(a)
+      integer(4) :: a
+      !pgi$ ignore_tkr a
+      !CHECK: !DIR$ IGNORE_TKR a
+    end subroutine
+  end interface
 end
 
 subroutine vector_always


### PR DESCRIPTION
Support `!pgi$` as an alias to `!dir$` instead of being silently ignored. 

As a general principle in flang, we would like people to be able to easily port their code. This sentinel is just ignored if not supported and lead to other semantics errors. 

```
As a general principle, this compiler will accept by default and without complaint many legacy features, extensions to the standard language, and features that have been deleted from the standard, so long as the recognition of those features would not cause a standard-conforming program to be rejected or misinterpreted.
```

An alternative would be to emit an error so the user know this is not supported. 