### PR TITLE
[libc++][pstl] Generic implementation of parallel std::is_sorted_until

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -669,6 +669,7 @@ set(files
   __pstl/cpu_algos/transform_reduce.h
   __pstl/dispatch.h
   __pstl/handle_exception.h
+  __pstl/index_iterator.h
   __random/bernoulli_distribution.h
   __random/binomial_distribution.h
   __random/cauchy_distribution.h

--- a/libcxx/include/__algorithm/pstl.h
+++ b/libcxx/include/__algorithm/pstl.h
@@ -657,6 +657,31 @@ _LIBCPP_HIDE_FROM_ABI _ForwardOutIterator transform(
 template <class _ExecutionPolicy,
           class _ForwardIterator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
+          enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0 >
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI _ForwardIterator
+is_sorted_until(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last) {
+  _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "is_sorted_until requires ForwardIterators");
+  using _Implementation = __pstl::__dispatch<__pstl::__is_sorted_until, __pstl::__current_configuration, _RawPolicy>;
+  return __pstl::__handle_exception<_Implementation>(
+      std::forward<_ExecutionPolicy>(__policy), std::move(__first), std::move(__last), less{});
+}
+
+template <class _ExecutionPolicy,
+          class _ForwardIterator,
+          class _Comp,
+          class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
+          enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI _ForwardIterator
+is_sorted_until(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Comp __comp) {
+  _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "is_sorted_until requires ForwardIterators");
+  using _Implementation = __pstl::__dispatch<__pstl::__is_sorted_until, __pstl::__current_configuration, _RawPolicy>;
+  return __pstl::__handle_exception<_Implementation>(
+      std::forward<_ExecutionPolicy>(__policy), std::move(__first), std::move(__last), std::move(__comp));
+}
+
+template <class _ExecutionPolicy,
+          class _ForwardIterator,
+          class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
 [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
 is_sorted(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last) {

--- a/libcxx/include/__pstl/backend_fwd.h
+++ b/libcxx/include/__pstl/backend_fwd.h
@@ -297,6 +297,11 @@ struct __reduce;
 // operator()(_Policy&&, _ForwardIterator __first, _ForwardIterator __last,
 //                       _Tp __init, _BinaryOperation __op) const noexcept;
 
+struct __is_sorted_until;
+// template <class _Policy, class _ForwardIterator, class _Comp>
+// optional<_ForwardIterator>
+// operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Comp&& __comp) const noexcept;
+
 template <class _Backend, class _ExecutionPolicy>
 struct __is_sorted;
 // template <class _Policy, class _ForwardIterator, class _Comp>

--- a/libcxx/include/__pstl/backend_fwd.h
+++ b/libcxx/include/__pstl/backend_fwd.h
@@ -297,15 +297,16 @@ struct __reduce;
 // operator()(_Policy&&, _ForwardIterator __first, _ForwardIterator __last,
 //                       _Tp __init, _BinaryOperation __op) const noexcept;
 
-struct __is_sorted_until;
-// template <class _Policy, class _ForwardIterator, class _Comp>
-// optional<_ForwardIterator>
-// operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Comp&& __comp) const noexcept;
-
 template <class _Backend, class _ExecutionPolicy>
 struct __is_sorted;
 // template <class _Policy, class _ForwardIterator, class _Comp>
 // optional<bool>
+// operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Comp&& __comp) const noexcept;
+
+template <class _Backend, class _ExecutionPolicy>
+struct __is_sorted_until;
+// template <class _Policy, class _ForwardIterator, class _Comp>
+// optional<_ForwardIterator>
 // operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Comp&& __comp) const noexcept;
 
 } // namespace __pstl

--- a/libcxx/include/__pstl/index_iterator.h
+++ b/libcxx/include/__pstl/index_iterator.h
@@ -1,0 +1,135 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___PSTL_INDEX_ITERATOR_H
+#define _LIBCPP___PSTL_INDEX_ITERATOR_H
+
+#include <__config>
+#include <__iterator/iterator_traits.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+_LIBCPP_PUSH_MACROS
+#include <__undef_macros>
+
+#if _LIBCPP_STD_VER >= 17
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+namespace __pstl {
+
+// This iterator type is a stopgap solution to use the existing backend algorithms in PSTL and be able to implement
+// position-sensitive algorithms on top. While providing an iterator interface, this type is essentially a wrapper over
+// an index type.
+// Once the backends start providing a less restrictive interface, e.g. working with chunks of iterator
+// ranges, and supporting forward iterators, any algorithms that were implemented using this index wrapper should be
+// reimplemented using iterators as-is.
+
+template <typename _Index>
+class __index_iterator {
+public:
+  using value_type        = _Index;
+  using difference_type   = _Index;
+  using iterator_category = std::random_access_iterator_tag;
+  using reference         = _Index;
+  using pointer           = void;
+
+  _LIBCPP_HIDE_FROM_ABI constexpr __index_iterator() noexcept = default;
+
+  _LIBCPP_HIDE_FROM_ABI constexpr explicit __index_iterator(_Index __index) noexcept : __index_(__index) {}
+
+  _LIBCPP_HIDE_FROM_ABI constexpr _Index operator*() const noexcept { return __index_; }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr __index_iterator& operator++() noexcept {
+    ++__index_;
+    return *this;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr __index_iterator operator++(int) noexcept {
+    auto __tmp = *this;
+    ++__index_;
+    return __tmp;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr __index_iterator& operator--() noexcept {
+    --__index_;
+    return *this;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr __index_iterator operator--(int) noexcept {
+    auto __tmp = *this;
+    --__index_;
+    return __tmp;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr __index_iterator operator+(_Index __n) const noexcept {
+    return __index_iterator{__index_ + __n};
+  }
+
+  _LIBCPP_HIDE_FROM_ABI friend constexpr __index_iterator operator+(_Index __n, const __index_iterator& __x) noexcept {
+    return __x + __n;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr __index_iterator& operator+=(_Index __n) noexcept {
+    __index_ += __n;
+    return *this;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr __index_iterator operator-(_Index __n) const noexcept {
+    return __index_iterator{__index_ - __n};
+  }
+
+  _LIBCPP_HIDE_FROM_ABI friend constexpr _Index
+  operator-(const __index_iterator& __lhs, const __index_iterator& __rhs) noexcept {
+    return __lhs.__index_ - __rhs.__index_;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr __index_iterator& operator-=(_Index __n) noexcept {
+    __index_ -= __n;
+    return *this;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr _Index operator[](_Index __n) const noexcept { return __index_ + __n; }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr bool operator==(const __index_iterator& __other) const noexcept {
+    return __index_ == __other.__index_;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr bool operator!=(const __index_iterator& __other) const noexcept {
+    return !(*this == __other);
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr bool operator<(const __index_iterator& __other) const noexcept {
+    return __index_ < __other.__index_;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr bool operator<=(const __index_iterator& __other) const noexcept {
+    return __index_ <= __other.__index_;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr bool operator>(const __index_iterator& __other) const noexcept {
+    return __index_ > __other.__index_;
+  }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr bool operator>=(const __index_iterator& __other) const noexcept {
+    return __index_ >= __other.__index_;
+  }
+
+private:
+  _Index __index_ = {};
+};
+
+} // namespace __pstl
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP_STD_VER >= 17
+
+_LIBCPP_POP_MACROS
+
+#endif // _LIBCPP___PSTL_INDEX_ITERATOR_H

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -2356,6 +2356,7 @@ module std [system] {
     }
     module dispatch           { header "__pstl/dispatch.h" }
     module handle_exception   { header "__pstl/handle_exception.h" }
+    module index_iterator     { header "__pstl/index_iterator.h" }
   }
 
   // Miscellaneous modules for top-level headers

--- a/libcxx/test/libcxx/algorithms/pstl.index_iterator.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/pstl.index_iterator.pass.cpp
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++17
+
+// UNSUPPORTED: libcpp-has-no-incomplete-pstl
+
+// Checks the logic of the index wrapper iterator.
+
+#include <algorithm>
+#include <execution>
+#include <iterator>
+#include <type_traits>
+#include <cassert>
+#include <cstddef>
+
+int main(int, char**) {
+  using Index = std::ptrdiff_t;
+  using Iter  = std::__pstl::__index_iterator<Index>;
+  static_assert(std::is_nothrow_default_constructible_v<Iter>);
+  static_assert(std::is_nothrow_constructible_v<Iter, Index>);
+  static_assert(std::is_trivially_copy_constructible_v<Iter>);
+  static_assert(std::is_trivially_move_constructible_v<Iter>);
+  static_assert(std::is_trivially_assignable_v<Iter, Iter>);
+  static_assert(std::is_trivially_copy_assignable_v<Iter>);
+  static_assert(std::is_trivially_move_assignable_v<Iter>);
+  static_assert(std::is_trivially_destructible_v<Iter>);
+
+  {
+    assert((*Iter{}) == Index{});
+  }
+  {
+    assert((*Iter{7}) == 7);
+  }
+  {
+    Iter it{5};
+    assert(&(++it) == &it);
+    assert((*it) == 6);
+  }
+  {
+    Iter it{5};
+    assert(*(it++) == 5);
+    assert((*it) == 6);
+  }
+  {
+    Iter it{5};
+    assert(&(--it) == &it);
+    assert((*it) == 4);
+  }
+  {
+    Iter it{5};
+    assert(*(it--) == 5);
+    assert((*it) == 4);
+  }
+  {
+    assert(*(Iter{4} + 3) == 7);
+  }
+  {
+    assert(*(4 + Iter{3}) == 7);
+  }
+  {
+    Iter it{5};
+    assert(&(it += 3) == &it);
+    assert((*it) == 8);
+  }
+  {
+    assert((Iter{4} - 3) == Iter{1});
+  }
+  {
+    assert((Iter{4} - Iter{3}) == 1);
+  }
+  {
+    Iter it{5};
+    assert(&(it -= 3) == &it);
+    assert((*it) == 2);
+  }
+  {
+    assert(Iter{5}[3] == 8);
+  }
+  {
+    assert(Iter{5} == Iter{5});
+    assert(!(Iter{5} == Iter{6}));
+  }
+  {
+    assert(Iter{5} != Iter{6});
+    assert(!(Iter{5} != Iter{5}));
+  }
+
+  return 0;
+}

--- a/libcxx/test/libcxx/algorithms/pstl.index_iterator.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/pstl.index_iterator.pass.cpp
@@ -12,8 +12,7 @@
 
 // Checks the logic of the index wrapper iterator.
 
-#include <algorithm>
-#include <execution>
+#include <__pstl/index_iterator.h>
 #include <iterator>
 #include <type_traits>
 #include <cassert>

--- a/libcxx/test/libcxx/algorithms/pstl.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/algorithms/pstl.nodiscard.verify.cpp
@@ -52,4 +52,8 @@ void test() {
   std::is_sorted(std::execution::par, std::begin(a), std::end(a));
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::is_sorted(std::execution::par, std::begin(a), std::end(a), pred2);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::is_sorted_until(std::execution::par, std::begin(a), std::end(a));
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::is_sorted_until(std::execution::par, std::begin(a), std::end(a), pred2);
 }

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// REQUIRES: std-at-least-c++17
 
 // UNSUPPORTED: libcpp-has-no-incomplete-pstl
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until.pass.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cassert>
 #include <functional>
+#include <limits>
 #include <numeric>
 
 #include "test_execution_policies.h"
@@ -174,6 +175,46 @@ struct Test {
       int a[]     = {1, 1, 1, 1};
       unsigned sa = sizeof(a) / sizeof(a[0]);
       assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::max(),
+                     std::numeric_limits<int>::max()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::max(),
+                     std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::max()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 2));
+    }
+    {
+      int a[] = {
+          std::numeric_limits<int>::min(),
+          std::numeric_limits<int>::min() / 2,
+          -1,
+          0,
+          1,
+          std::numeric_limits<int>::max() / 2,
+          std::numeric_limits<int>::max()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[] = {
+          std::numeric_limits<int>::min(),
+          std::numeric_limits<int>::min() / 2,
+          1,
+          0,
+          -1,
+          std::numeric_limits<int>::max() / 2,
+          std::numeric_limits<int>::max()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 3));
     }
   }
 };

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until.pass.cpp
@@ -1,0 +1,188 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// UNSUPPORTED: libcpp-has-no-incomplete-pstl
+
+// template<class ExecutionPolicy, class ForwardIterator>
+// ForwardIterator is_sorted_until(ExecutionPolicy&& exec,
+//                                 ForwardIterator first, ForwardIterator last);
+
+#include <algorithm>
+#include <cassert>
+#include <functional>
+#include <numeric>
+
+#include "test_execution_policies.h"
+#include "test_iterators.h"
+#include "test_macros.h"
+
+template <class Iter>
+struct Test {
+  template <class ExecutionPolicy>
+  void operator()(ExecutionPolicy&& policy) {
+    {
+      int a[]     = {0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a)) == Iter(a));
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 1));
+    }
+    {
+      int a[]     = {1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+
+    {
+      int a[]     = {0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 2));
+    }
+    {
+      int a[]     = {0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 1));
+    }
+    {
+      int a[]     = {1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 1));
+    }
+    {
+      int a[]     = {1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 2));
+    }
+    {
+      int a[]     = {1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+
+    {
+      int a[]     = {0, 0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {0, 0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {0, 0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 3));
+    }
+    {
+      int a[]     = {0, 0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {0, 1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 2));
+    }
+    {
+      int a[]     = {0, 1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 2));
+    }
+    {
+      int a[]     = {0, 1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 3));
+    }
+    {
+      int a[]     = {0, 1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+    {
+      int a[]     = {1, 0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 1));
+    }
+    {
+      int a[]     = {1, 0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 1));
+    }
+    {
+      int a[]     = {1, 0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 1));
+    }
+    {
+      int a[]     = {1, 0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 1));
+    }
+    {
+      int a[]     = {1, 1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 2));
+    }
+    {
+      int a[]     = {1, 1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 2));
+    }
+    {
+      int a[]     = {1, 1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + 3));
+    }
+    {
+      int a[]     = {1, 1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa)) == Iter(a + sa));
+    }
+  }
+};
+
+int main(int, char**) {
+  types::for_each(types::concatenate_t<types::forward_iterator_list<int*>,
+                                       types::bidirectional_iterator_list<int*>,
+                                       types::random_access_iterator_list<int*>>{},
+                  TestIteratorWithPolicies<Test>{});
+
+  return 0;
+}

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until_comp.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until_comp.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// REQUIRES: std-at-least-c++17
 
 // UNSUPPORTED: libcpp-has-no-incomplete-pstl
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until_comp.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until_comp.pass.cpp
@@ -1,0 +1,187 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// UNSUPPORTED: libcpp-has-no-incomplete-pstl
+
+// template<class ExecutionPolicy, class ForwardIterator, class Comp>
+// ForwardIterator is_sorted_until(ExecutionPolicy&& exec,
+//                                 ForwardIterator first, ForwardIterator last,
+//                                 Comp comp);
+
+#include <algorithm>
+#include <functional>
+#include <cassert>
+
+#include "test_execution_policies.h"
+#include "test_iterators.h"
+#include "test_macros.h"
+
+template <class Iter>
+struct Test {
+  template <class ExecutionPolicy>
+  void operator()(ExecutionPolicy&& policy) {
+    {
+      int a[]     = {0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a), std::greater<int>()) == Iter(a));
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 1));
+    }
+    {
+      int a[]     = {1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+
+    {
+      int a[]     = {0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 2));
+    }
+    {
+      int a[]     = {0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 1));
+    }
+    {
+      int a[]     = {0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 1));
+    }
+    {
+      int a[]     = {1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 2));
+    }
+    {
+      int a[]     = {1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+
+    {
+      int a[]     = {0, 0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {0, 0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 3));
+    }
+    {
+      int a[]     = {0, 0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 2));
+    }
+    {
+      int a[]     = {0, 0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 2));
+    }
+    {
+      int a[]     = {0, 1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 1));
+    }
+    {
+      int a[]     = {0, 1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 1));
+    }
+    {
+      int a[]     = {0, 1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 1));
+    }
+    {
+      int a[]     = {0, 1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 1));
+    }
+    {
+      int a[]     = {1, 0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {1, 0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 3));
+    }
+    {
+      int a[]     = {1, 0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 2));
+    }
+    {
+      int a[]     = {1, 0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 2));
+    }
+    {
+      int a[]     = {1, 1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {1, 1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 3));
+    }
+    {
+      int a[]     = {1, 1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {1, 1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+  }
+};
+
+int main(int, char**) {
+  types::for_each(types::concatenate_t<types::forward_iterator_list<int*>,
+                                       types::bidirectional_iterator_list<int*>,
+                                       types::random_access_iterator_list<int*>>{},
+                  TestIteratorWithPolicies<Test>{});
+  return 0;
+}

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until_comp.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_until_comp.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <cassert>
 
 #include "test_execution_policies.h"
@@ -174,6 +175,46 @@ struct Test {
       int a[]     = {1, 1, 1, 1};
       unsigned sa = sizeof(a) / sizeof(a[0]);
       assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {std::numeric_limits<int>::max(),
+                     std::numeric_limits<int>::max(),
+                     std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::min()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[]     = {std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::max(),
+                     std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::max()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 1));
+    }
+    {
+      int a[] = {
+          std::numeric_limits<int>::max(),
+          std::numeric_limits<int>::max() / 2,
+          1,
+          0,
+          -1,
+          std::numeric_limits<int>::min() / 2,
+          std::numeric_limits<int>::min()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + sa));
+    }
+    {
+      int a[] = {
+          std::numeric_limits<int>::max(),
+          std::numeric_limits<int>::max() / 2,
+          -1,
+          0,
+          1,
+          std::numeric_limits<int>::min() / 2,
+          std::numeric_limits<int>::min()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted_until(policy, Iter(a), Iter(a + sa), std::greater<int>()) == Iter(a + 3));
     }
   }
 };

--- a/libcxx/test/std/algorithms/pstl.exception_handling.pass.cpp
+++ b/libcxx/test/std/algorithms/pstl.exception_handling.pass.cpp
@@ -290,6 +290,14 @@ int main(int, char**) {
         assert_non_throwing([=, &policy] {
           (void)std::is_sorted(policy, std::move(first1), std::move(last1), compare);
         });
+
+        // is_sorted_until(first, last)
+        assert_non_throwing([=, &policy] { (void)std::is_sorted_until(policy, std::move(first1), std::move(last1)); });
+
+        // is_sorted_until(first, last, comp)
+        assert_non_throwing([=, &policy] {
+          (void)std::is_sorted_until(policy, std::move(first1), std::move(last1), compare);
+        });
       }
 
       {


### PR DESCRIPTION
This PR implements a generic backend-agnostic parallel `std::is_sorted_until` based on `std::find_if`.
To do that, it introduces `__pstl::__index_iterator` to use the existing backend interfaces but still be able to access prev/next elements.
Since this algorithm is based on `std::find_if`, it scales well and supports early termination.
As a byproduct, this PR also rebases `std::is_sorted` on `std::is_sorted_until` to have the same benefits.

Given the comparator predicate is not absolutely trivial, the parallel version can show speedup already at 1K elements.
For instance, these numbers were gathered on Apple M1 with the `libdispatch` backend:
```
| -----------------------------------------------------------------------------------------------
| Benchmark                                                     Time             CPU   Iterations
| -----------------------------------------------------------------------------------------------
| std::is_sorted_until_pred(vector<int>)/8                   29.4 ns         19.1 ns     36544937
| std::is_sorted_until_pred(vector<int>)/1024                4456 ns         2234 ns       307499
| std::is_sorted_until_pred(vector<int>)/8192               36031 ns        20007 ns        34369
| std::is_sorted_until_pred(vector<int>)/65536              84100 ns        84031 ns         7080
| std::is_sorted_until_pred(vector<int>)/1048576          1349890 ns      1347902 ns          521
| std::is_sorted_until_pred(vector<int>)/16777216        21729788 ns     21690613 ns           31
| std::is_sorted_until_pred(vector<int>)/134217728      180479903 ns    177226667 ns            3
| std::is_sorted_until_pred_par(vector<int>)/8               29.9 ns         29.8 ns     22861174
| std::is_sorted_until_pred_par(vector<int>)/1024            1833 ns         1709 ns       415805
| std::is_sorted_until_pred_par(vector<int>)/8192           10858 ns        10121 ns        68210
| std::is_sorted_until_pred_par(vector<int>)/65536          51746 ns        50379 ns        10000
| std::is_sorted_until_pred_par(vector<int>)/1048576       387577 ns       372001 ns         1883
| std::is_sorted_until_pred_par(vector<int>)/16777216     7154746 ns      5715174 ns          115
| std::is_sorted_until_pred_par(vector<int>)/134217728   52608917 ns     47539364 ns           11
```
```c++
auto std_is_sorted_until_pred = [](auto first, auto last) {
  return std::is_sorted_until(first, last, [](auto x, auto y) {
    benchmark::DoNotOptimize(x);
    benchmark::DoNotOptimize(y);
    return sqrt(x) < sqrt(y);
  });
};

auto std_is_sorted_until_pred_par = [](auto first, auto last) {
  return std::is_sorted_until(std::execution::par, first, last, [](auto x, auto y) {
    benchmark::DoNotOptimize(x);
    benchmark::DoNotOptimize(y);
    return sqrt(x) < sqrt(y);
  });
};
```

Parent issue: https://github.com/llvm/llvm-project/issues/99938