### PR TITLE
[BOLT] Drop -znow requirement for PLT optimization on x86-64

### DIFF
--- a/bolt/docs/CommandLineArgumentReference.md
+++ b/bolt/docs/CommandLineArgumentReference.md
@@ -724,7 +724,7 @@
 
 - `--plt=<value>`
 
-  Optimize PLT calls (requires linking with -znow)
+  Optimize PLT calls (requires linking with -znow on non-x86 architectures)
   - `none`: do not optimize PLT calls
   - `hot`: optimize executed (hot) PLT calls
   - `all`: optimize all PLT calls

--- a/bolt/test/runtime/X86/plt-call.c
+++ b/bolt/test/runtime/X86/plt-call.c
@@ -1,0 +1,14 @@
+// Check that PLT optimization works on X86-64 without -znow.
+
+// RUN: %clang %cflags %s -o %t.exe -Wl,-q
+// RUN: llvm-bolt %t.exe -o %t.bolt --plt=all
+// RUN: %t.bolt | FileCheck %s
+
+// CHECK: Success
+
+#include <stdio.h>
+
+int main() {
+  puts("Success");
+  return 0;
+}


### PR DESCRIPTION
On x86-64, PLT optimization does not require the binary to be linked with -znow because indirect calls through GOT work correctly with lazy binding. At runtime, the dynamic linker's resolver will populate the GOT entry on the first call, just like with a regular PLT call.

This change removes the -znow requirement specifically for x86-64 while keeping it for other architectures. I haven't checked RISV-V, but it's still necessary on AArch64.