### PR TITLE
[ThinLTO] Clear read/write only flags when referencing function summary

### DIFF
--- a/llvm/lib/IR/ModuleSummaryIndex.cpp
+++ b/llvm/lib/IR/ModuleSummaryIndex.cpp
@@ -274,7 +274,9 @@ propagateAttributesToRefs(GlobalValueSummary *S,
 //      reference is not readonly
 //   d. clear WO attribute from variable referenced by a function when
 //      reference is not writeonly
-//   e. clear IsDSOLocal flag in every summary if any of them is false.
+//   e. clear RO and WO attributes from variables with the same GUID as
+//      a non-variable.
+//   f. clear IsDSOLocal flag in every summary if any of them is false.
 //
 //   Because of (c, d) we don't internalize variables read by function A
 //   and modified by function B.

--- a/llvm/lib/IR/ModuleSummaryIndex.cpp
+++ b/llvm/lib/IR/ModuleSummaryIndex.cpp
@@ -219,7 +219,8 @@ propagateAttributesToRefs(GlobalValueSummary *S,
         continue;
     } else if (MarkedNonReadWriteOnly.contains(VI))
       continue;
-    for (auto &Ref : VI.getSummaryList())
+    bool HasNonGVar = false;
+    for (auto &Ref : VI.getSummaryList()) {
       // If references to alias is not read/writeonly then aliasee
       // is not read/writeonly
       if (auto *GVS = dyn_cast<GlobalVarSummary>(Ref->getBaseObject())) {
@@ -227,7 +228,29 @@ propagateAttributesToRefs(GlobalValueSummary *S,
           GVS->setReadOnly(false);
         if (!VI.isWriteOnly())
           GVS->setWriteOnly(false);
+      } else {
+        // Note that this needs special processing.
+        HasNonGVar = true;
+        break;
       }
+    }
+    // In the case where we have a reference to a VI that is a function not a
+    // variable, conservatively mark all summaries as non-read or write only.
+    // In most cases that would have happened in the above loop. However,
+    // this will make a difference in a few rare cases where there are same
+    // named locals in modules without enough distinguishing path, which end up
+    // with the same GUID. If these are a mix of variables and functions we want
+    // to handle the variables conservatively.
+    if (HasNonGVar) {
+      for (auto &Ref : VI.getSummaryList()) {
+        auto *GVS = dyn_cast<GlobalVarSummary>(Ref->getBaseObject());
+        if (!GVS)
+          continue;
+        GVS->setReadOnly(false);
+        GVS->setWriteOnly(false);
+      }
+      MarkedNonReadWriteOnly.insert(VI);
+    }
   }
 }
 

--- a/llvm/test/ThinLTO/X86/Inputs/local_name_conflict_var3.ll
+++ b/llvm/test/ThinLTO/X86/Inputs/local_name_conflict_var3.ll
@@ -7,7 +7,7 @@ define internal i32 @baz() {
   ret i32 0
 }
 
-define i32 @b() {
+define i32 @c() {
 entry:
   %is_null = icmp eq i32 ()* @baz, null
   ret i32 0

--- a/llvm/test/ThinLTO/X86/Inputs/local_name_conflict_var3.ll
+++ b/llvm/test/ThinLTO/X86/Inputs/local_name_conflict_var3.ll
@@ -1,0 +1,14 @@
+; ModuleID = 'local_name_conflict_var.o'
+source_filename = "local_name_conflict_var.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define internal i32 @baz() {
+  ret i32 0
+}
+
+define i32 @b() {
+entry:
+  %is_null = icmp eq i32 ()* @baz, null
+  ret i32 0
+}

--- a/llvm/test/ThinLTO/X86/Inputs/local_name_conflict_var3b.ll
+++ b/llvm/test/ThinLTO/X86/Inputs/local_name_conflict_var3b.ll
@@ -1,0 +1,14 @@
+; ModuleID = 'local_name_conflict_var.o'
+source_filename = "local_name_conflict_var.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define internal i32 @baz() {
+  ret i32 0
+}
+
+define i32 @b() {
+entry:
+  %call1 = call i32 (...) @baz()
+  ret i32 0
+}

--- a/llvm/test/ThinLTO/X86/Inputs/local_name_conflict_var3b.ll
+++ b/llvm/test/ThinLTO/X86/Inputs/local_name_conflict_var3b.ll
@@ -7,7 +7,7 @@ define internal i32 @baz() {
   ret i32 0
 }
 
-define i32 @b() {
+define i32 @c() {
 entry:
   %call1 = call i32 (...) @baz()
   ret i32 0

--- a/llvm/test/ThinLTO/X86/local_name_conflict_var.ll
+++ b/llvm/test/ThinLTO/X86/local_name_conflict_var.ll
@@ -20,15 +20,15 @@
 ;; summaries for baz as non-read only, which should cause the linkage type of
 ;; the imported copies of baz variables to be available_externally instead of
 ;; internal.
-; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var3b.ll -o %t3b.bc
-; RUN: llvm-lto -thinlto-action=thinlink -o %t5.bc %t.bc %t1.bc %t2.bc %t3b.bc
+; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var3b.ll -o %t3.bc
+; RUN: llvm-lto -thinlto-action=thinlink -o %t5.bc %t.bc %t1.bc %t2.bc %t3.bc
 ; RUN: llvm-lto -thinlto-action=import -exported-symbol=main %t.bc -thinlto-index=%t5.bc -o - | llvm-dis -o - | FileCheck %s --check-prefix=IMPORTNOREADONLY
 ; IMPORTNOREADONLY: @baz.llvm.{{.*}} = available_externally hidden global i32 10
 ; IMPORTNOREADONLY: @baz.llvm.{{.*}} = available_externally hidden global i32 10
 
 ;; Do this again but where the 3rd module calls local function baz.
-; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var3.ll -o %t3.bc
-; RUN: llvm-lto -thinlto-action=thinlink -o %t5.bc %t.bc %t1.bc %t2.bc %t3.bc
+; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var3.ll -o %t3b.bc
+; RUN: llvm-lto -thinlto-action=thinlink -o %t5.bc %t.bc %t1.bc %t2.bc %t3b.bc
 ; RUN: llvm-lto -thinlto-action=import -exported-symbol=main %t.bc -thinlto-index=%t5.bc -o - | llvm-dis -o - | FileCheck %s --check-prefix=IMPORTNOREADONLY
 
 ; ModuleID = 'local_name_conflict_var_main.o'

--- a/llvm/test/ThinLTO/X86/local_name_conflict_var.ll
+++ b/llvm/test/ThinLTO/X86/local_name_conflict_var.ll
@@ -1,4 +1,4 @@
-; Test handling when two files with the same source file name contain
+; Test handling when multiple files with the same source file name contain
 ; static read only variables with the same name (which will have the same GUID
 ; in the combined index).
 
@@ -16,7 +16,7 @@
 ; IMPORT: @baz.llvm.{{.*}} = internal global i32 10
 
 ;; Now do the same but linking in a 3rd module, in which baz is a local function,
-;; which has a non-call reference to it in b(). We should correctly mark all
+;; which has a non-call reference to it in c(). We should correctly mark all
 ;; summaries for baz as non-read only, which should cause the linkage type of
 ;; the imported copies of baz variables to be available_externally instead of
 ;; internal.
@@ -41,8 +41,10 @@ define i32 @main() {
 entry:
   %call1 = call i32 (...) @a()
   %call2 = call i32 (...) @b()
+  %call3 = call i32 (...) @c()
   ret i32 0
 }
 
 declare i32 @a(...)
 declare i32 @b(...)
+declare i32 @c(...)

--- a/llvm/test/ThinLTO/X86/local_name_conflict_var.ll
+++ b/llvm/test/ThinLTO/X86/local_name_conflict_var.ll
@@ -20,14 +20,14 @@
 ;; summaries for baz as non-read only, which should cause the linkage type of
 ;; the imported copies of baz variables to be available_externally instead of
 ;; internal.
-; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var3b.ll -o %t3.bc
+; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var3.ll -o %t3.bc
 ; RUN: llvm-lto -thinlto-action=thinlink -o %t5.bc %t.bc %t1.bc %t2.bc %t3.bc
 ; RUN: llvm-lto -thinlto-action=import -exported-symbol=main %t.bc -thinlto-index=%t5.bc -o - | llvm-dis -o - | FileCheck %s --check-prefix=IMPORTNOREADONLY
 ; IMPORTNOREADONLY: @baz.llvm.{{.*}} = available_externally hidden global i32 10
 ; IMPORTNOREADONLY: @baz.llvm.{{.*}} = available_externally hidden global i32 10
 
 ;; Do this again but where the 3rd module calls local function baz.
-; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var3.ll -o %t3b.bc
+; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var3b.ll -o %t3b.bc
 ; RUN: llvm-lto -thinlto-action=thinlink -o %t5.bc %t.bc %t1.bc %t2.bc %t3b.bc
 ; RUN: llvm-lto -thinlto-action=import -exported-symbol=main %t.bc -thinlto-index=%t5.bc -o - | llvm-dis -o - | FileCheck %s --check-prefix=IMPORTNOREADONLY
 

--- a/llvm/test/ThinLTO/X86/local_name_conflict_var.ll
+++ b/llvm/test/ThinLTO/X86/local_name_conflict_var.ll
@@ -4,9 +4,9 @@
 
 ; Do setup work for all below tests: generate bitcode and combined index
 ; RUN: opt -module-summary -module-hash %s -o %t.bc
-; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var1.ll -o %t2.bc
-; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var2.ll -o %t3.bc
-; RUN: llvm-lto -thinlto-action=thinlink -o %t4.bc %t.bc %t2.bc %t3.bc
+; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var1.ll -o %t1.bc
+; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var2.ll -o %t2.bc
+; RUN: llvm-lto -thinlto-action=thinlink -o %t4.bc %t.bc %t1.bc %t2.bc
 
 ; This module will import a() and b() which should cause the read only copy
 ; of baz from each of those modules to be imported. Check that the both are
@@ -14,6 +14,17 @@
 ; RUN: llvm-lto -thinlto-action=import -exported-symbol=main %t.bc -thinlto-index=%t4.bc -o - | llvm-dis -o - | FileCheck %s --check-prefix=IMPORT
 ; IMPORT: @baz.llvm.{{.*}} = internal global i32 10
 ; IMPORT: @baz.llvm.{{.*}} = internal global i32 10
+
+;; Now do the same but linking in a 3rd module, in which baz is a local function.
+;; We should correctly mark all summaries for baz as non-read only (which doesn't
+;; make sense for a function, as you can't load from it). This should cause the
+;; linkage type of the imported copies of baz variables to be available_externally
+;; instead of internal.
+; RUN: opt -module-summary -module-hash %p/Inputs/local_name_conflict_var3.ll -o %t3.bc
+; RUN: llvm-lto -thinlto-action=thinlink -o %t5.bc %t.bc %t1.bc %t2.bc %t3.bc
+; RUN: llvm-lto -thinlto-action=import -exported-symbol=main %t.bc -thinlto-index=%t5.bc -o - | llvm-dis -o - | FileCheck %s --check-prefix=IMPORTNOREADONLY
+; IMPORTNOREADONLY: @baz.llvm.{{.*}} = available_externally hidden global i32 10
+; IMPORTNOREADONLY: @baz.llvm.{{.*}} = available_externally hidden global i32 10
 
 ; ModuleID = 'local_name_conflict_var_main.o'
 source_filename = "local_name_conflict_var_main.c"


### PR DESCRIPTION
Conservatively clear read/write only flags during attribute propagation
across all of a ValueInfo's summaries when one is a function summary.
While function summaries will not be read/write-only, we need to ensure that
any global variable summary with the same GUID/ValueInfo is also not marked
read or write only. This case can occur with same named locals in different
modules compiled without enough path.

Enhance the current test to confirm this works correctly for a couple cases.

This change enables a follow on simplification and compile time improvement
during importing of global variables.
