### PR TITLE
[clang-apply-replacements] Change cleanup to only happen with --format

### DIFF
--- a/clang-tools-extra/clang-apply-replacements/tool/ClangApplyReplacementsMain.cpp
+++ b/clang-tools-extra/clang-apply-replacements/tool/ClangApplyReplacementsMain.cpp
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
     return 1;
 
   tooling::ApplyChangesSpec Spec;
-  Spec.Cleanup = true;
+  Spec.Cleanup = DoFormat;
   Spec.Format = DoFormat ? tooling::ApplyChangesSpec::kAll
                          : tooling::ApplyChangesSpec::kNone;
   Spec.Style = DoFormat ? FormatStyle : format::getNoStyle();


### PR DESCRIPTION
Cleanup can result in many unrelated changes to the given replacements.
This change makes that only apply if the user actually wants
clang-apply-replacements to format their code outside of the
replacements.
