### PR TITLE
[RISCV] Add isel pattern (setlt (shl X, 32), 0) -> srliw.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1704,6 +1704,7 @@ def : Pat<(i32 (setlt (i32 GPR:$rs1), 0)), (SRLI GPR:$rs1, 31)>; // compressible
 let Predicates = [IsRV64] in {
 def : Pat<(i64 (setlt (i64 GPR:$rs1), 0)), (SRLI GPR:$rs1, 63)>; // compressible
 def : Pat<(i64 (setlt (sext_inreg GPR:$rs1, i32), 0)), (SRLIW GPR:$rs1, 31)>;
+def : Pat<(i64 (setlt (shl GPR:$rs1, (i64 32)), 0)), (SRLIW GPR:$rs1, 31)>;
 }
 
 /// Branches and jumps

--- a/llvm/test/CodeGen/RISCV/bittest.ll
+++ b/llvm/test/CodeGen/RISCV/bittest.ll
@@ -3553,8 +3553,7 @@ define i32 @bittest_31_slt0_i32(i32 %x, i1 %y) {
 ;
 ; RV64-LABEL: bittest_31_slt0_i32:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    slli a0, a0, 32
-; RV64-NEXT:    srli a0, a0, 63
+; RV64-NEXT:    srliw a0, a0, 31
 ; RV64-NEXT:    and a0, a0, a1
 ; RV64-NEXT:    ret
   %cmp = icmp slt i32 %x, 0
@@ -3572,8 +3571,7 @@ define i32 @bittest_63_slt0_i64(i32 %x, i1 %y) {
 ;
 ; RV64-LABEL: bittest_63_slt0_i64:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    slli a0, a0, 32
-; RV64-NEXT:    srli a0, a0, 63
+; RV64-NEXT:    srliw a0, a0, 31
 ; RV64-NEXT:    and a0, a0, a1
 ; RV64-NEXT:    ret
   %ext = sext i32 %x to i64

--- a/llvm/test/CodeGen/RISCV/float-intrinsics.ll
+++ b/llvm/test/CodeGen/RISCV/float-intrinsics.ll
@@ -1841,8 +1841,7 @@ define i1 @fpclass(float %x) {
 ; RV64I-NEXT:    add a4, a5, a4
 ; RV64I-NEXT:    addi a5, a5, -1
 ; RV64I-NEXT:    sltu a2, a5, a2
-; RV64I-NEXT:    slli a0, a0, 32
-; RV64I-NEXT:    srli a0, a0, 63
+; RV64I-NEXT:    srliw a0, a0, 31
 ; RV64I-NEXT:    seqz a1, a1
 ; RV64I-NEXT:    seqz a5, a6
 ; RV64I-NEXT:    srliw a4, a4, 24
@@ -2340,13 +2339,12 @@ define i1 @isnegfinite_fpclass(float %x) {
 ;
 ; RV64I-LABEL: isnegfinite_fpclass:
 ; RV64I:       # %bb.0:
-; RV64I-NEXT:    slli a1, a0, 32
-; RV64I-NEXT:    slli a0, a0, 33
+; RV64I-NEXT:    slli a1, a0, 33
 ; RV64I-NEXT:    lui a2, 522240
-; RV64I-NEXT:    srli a0, a0, 33
-; RV64I-NEXT:    slt a0, a0, a2
-; RV64I-NEXT:    srli a1, a1, 63
-; RV64I-NEXT:    and a0, a0, a1
+; RV64I-NEXT:    srli a1, a1, 33
+; RV64I-NEXT:    slt a1, a1, a2
+; RV64I-NEXT:    srliw a0, a0, 31
+; RV64I-NEXT:    and a0, a1, a0
 ; RV64I-NEXT:    ret
   %1 = call i1 @llvm.is.fpclass.f32(float %x, i32 56)  ; 0x38 = "-finite"
   ret i1 %1


### PR DESCRIPTION
DAGCombiner sometimes turns (setlt (sext_inreg, X, i32), 0) into this now so we need another pattern.

I tried to remove the sext_inreg pattern but it seems DAGCombiner doesn't always do this transform. I suspect it depends on if SimplifyDemandedBits visits the setcc. We should probably make (setlt Y, 0) call SimplifyDemandedBits on itself.

Fixes #178600.