### PR TITLE
[mlir][Utils] Add overflow<nsw> flags to dimension calculations in ReshapeOpsUtils

### DIFF
--- a/mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h
@@ -332,11 +332,13 @@ struct ComposeCollapseOfExpandOp : public OpRewritePattern<CollapseOpTy> {
         // the first dynamic size.
         Value result = dynamicSizes[0];
         for (Value v : llvm::drop_begin(dynamicSizes))
-          result = arith::MulIOp::create(rewriter, loc, result, v);
+          result = arith::MulIOp::create(rewriter, loc, result, v,
+                                         arith::IntegerOverflowFlags::nsw);
         if (numStaticElems != 1) {
           result = arith::MulIOp::create(
               rewriter, loc, result,
-              arith::ConstantIndexOp::create(rewriter, loc, numStaticElems));
+              arith::ConstantIndexOp::create(rewriter, loc, numStaticElems),
+              arith::IntegerOverflowFlags::nsw);
         }
         newOutputShape.push_back(result);
       }

--- a/mlir/test/Dialect/Tensor/canonicalize.mlir
+++ b/mlir/test/Dialect/Tensor/canonicalize.mlir
@@ -1264,7 +1264,7 @@ func.func @compose_collapse_of_expand_partially_dynamic(%arg0: tensor<?xf16>, %a
 //  CHECK-SAME:   %[[ORIG_D2:.[a-zA-Z0-9]+]]
 //  CHECK-SAME:   %[[ORIG_D3:.[a-zA-Z0-9]+]]
 //   CHECK-DAG:   %[[C32:.+]] = arith.constant 32
-//       CHECK:   %[[COLLAPSED_D2:.+]] = arith.muli %[[ORIG_D3]], %[[C32]]
+//       CHECK:   %[[COLLAPSED_D2:.+]] = arith.muli %[[ORIG_D3]], %[[C32]] overflow<nsw>
 //       CHECK:   %[[RESULT:.+]] = tensor.expand_shape %[[SRC]]
 //  CHECK-SAME:     [0, 1, 2]
 //  CHECK-SAME:     output_shape [8, %[[ORIG_D2]], %[[COLLAPSED_D2]]]


### PR DESCRIPTION
This follows the convention that `tensor/memref` indexing calculations generally should never signed overflow:

- [ArithIndexingBuilder](https://github.com/llvm/llvm-project/blob/1ae93c634a16adc0eff8d5693496425cc4725033/mlir/include/mlir/Dialect/Arith/Utils/Utils.h#L123-L125)
- [Affine lowering](https://github.com/llvm/llvm-project/blob/1ae93c634a16adc0eff8d5693496425cc4725033/mlir/lib/Dialect/Affine/Utils/Utils.cpp#L68-L70)
 
It also enables CSE to properly merge duplicate dimension computations.