### PR TITLE
[msan] Add intermediate verbosity instruction dump

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -7447,15 +7447,15 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     // Instruction prototype (including return type and parameter types)
     // For intrinsics, we use the base/non-overloaded name
     //
-    // e.g., "call <16 x i8> llvm.aarch64.neon.uqsub(<16 x i8>, <16 x i8>)"
+    // e.g., "call <16 x i8> @llvm.aarch64.neon.uqsub(<16 x i8>, <16 x i8>)"
     unsigned NumOperands = I.getNumOperands();
     if (CallInst *CI = dyn_cast<CallInst>(&I)) {
-      errs() << "YYY call " << *I.getType() << " ";
+      errs() << "YYY call " << *I.getType() << " @";
 
       if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(CI))
         errs() << Intrinsic::getBaseName(II->getIntrinsicID());
       else
-        errs() << " " << CI->getCalledFunction()->getName();
+        errs() << CI->getCalledFunction()->getName();
 
       errs() << "(";
 

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -7434,11 +7434,51 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
   }
 
   void dumpInst(Instruction &I) {
+    // Instruction name only
+    // For intrinsics, the full/overloaded name is used
+    //
+    // e.g., "call llvm.aarch64.neon.uqsub.v16i8"
     if (CallInst *CI = dyn_cast<CallInst>(&I)) {
       errs() << "ZZZ call " << CI->getCalledFunction()->getName() << "\n";
     } else {
       errs() << "ZZZ " << I.getOpcodeName() << "\n";
     }
+
+    // Instruction prototype (including return type and parameter types)
+    // For intrinsics, we use the base/non-overloaded name
+    //
+    // e.g., "call <16 x i8> llvm.aarch64.neon.uqsub(<16 x i8>, <16 x i8>)"
+    unsigned NumOperands = I.getNumOperands();
+    if (CallInst *CI = dyn_cast<CallInst>(&I)) {
+      errs() << "YYY call " << *I.getType() << " ";
+
+      if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(CI))
+        errs() << Intrinsic::getBaseName(II->getIntrinsicID());
+      else
+        errs() << " " << CI->getCalledFunction()->getName();
+
+      errs() << "(";
+
+      // The last operand of a CallInst is the function itself.
+      NumOperands--;
+    } else
+      errs() << "YYY " << *I.getType() << " " << I.getOpcodeName() << "(";
+
+    for (size_t i = 0; i < NumOperands; i++) {
+      if (i > 0)
+        errs() << ", ";
+
+      errs() << *(I.getOperand(i)->getType());
+    }
+
+    errs() << ")\n";
+
+    // Full instruction, including types and operand values
+    // For intrinsics, the full/overloaded name is used
+    //
+    // e.g., "%vqsubq_v.i15 = call noundef <16 x i8>
+    //            @llvm.aarch64.neon.uqsub.v16i8(<16 x i8> %vext21.i,
+    //            <16 x i8> splat (i8 1)), !dbg !66"
     errs() << "QQQ " << I << "\n";
   }
 


### PR DESCRIPTION
This patch does not change MSan's instrumentation.

-msan-dump-{heuristic,strict}-instructions currently prints out two lines per instruction:
1) instruction name only e.g., `call llvm.aarch64.neon.uqsub.v16i8`
2) the full instruction, including actual variables e.g., `%vqsubq_v.i15 = call noundef <16 x i8> @llvm.aarch64.neon.uqsub.v16i8(<16 x i8> %vext21.i, <16 x i8> splat (i8 1)), !dbg !66`

Option 1) is too sparse for some uses, because it does not contain the return types or parameter types (although `.v16i8` is part of the function name in this example, in general, the function name does not describe the types completely; e.g., `<16 x float> llvm.x86.avx512.mask.scalef.ps.512(<16 x float>, <16 x float>, <16 x float>, i16, i32)`). OTOH option 2) can be too verbose because it contains the actual variables.

This patch adds a Goldilocks-verbosity line:
- instruction prototype (including return type and parameter types) e.g., `call <16 x i8> @llvm.aarch64.neon.uqsub(<16 x i8>, <16 x i8>)`. Note that this uses the base/non-overloaded function name, since the parameter types are already included in the output.