### PR TITLE
[lld][WebAssembly] Fix symbol type for __memory_base/__table_base.

### DIFF
--- a/lld/test/wasm/export-all.s
+++ b/lld/test/wasm/export-all.s
@@ -30,35 +30,35 @@ foo:
 # CHECK-NEXT:         Index:           1
 # CHECK-NEXT:       - Name:            __dso_handle
 # CHECK-NEXT:         Kind:            GLOBAL
-# CHECK-NEXT:         Index:           2
+# CHECK-NEXT:         Index:           4
 # CHECK-NEXT:       - Name:            __data_end
 # CHECK-NEXT:         Kind:            GLOBAL
-# CHECK-NEXT:         Index:           3
+# CHECK-NEXT:         Index:           5
 # CHECK-NEXT:       - Name:            __stack_low
 # CHECK-NEXT:         Kind:            GLOBAL
-# CHECK-NEXT:         Index:           4
+# CHECK-NEXT:         Index:           6
 # CHECK-NEXT:       - Name:            __stack_high
 # CHECK-NEXT:         Kind:            GLOBAL
-# CHECK-NEXT:         Index:           5
+# CHECK-NEXT:         Index:           7
 # CHECK-NEXT:       - Name:            __global_base
 # CHECK-NEXT:         Kind:            GLOBAL
-# CHECK-NEXT:         Index:           6
+# CHECK-NEXT:         Index:           8
 # CHECK-NEXT:       - Name:            __heap_base
 # CHECK-NEXT:         Kind:            GLOBAL
-# CHECK-NEXT:         Index:           7
+# CHECK-NEXT:         Index:           9
 # CHECK-NEXT:       - Name:            __heap_end
 # CHECK-NEXT:         Kind:            GLOBAL
-# CHECK-NEXT:         Index:           8
+# CHECK-NEXT:         Index:           10
 # CHECK-NEXT:       - Name:            __memory_base
 # CHECK-NEXT:         Kind:            GLOBAL
-# CHECK-NEXT:         Index:           9
+# CHECK-NEXT:         Index:           1
 # CHECK-NEXT:       - Name:            __table_base
 # CHECK-NEXT:         Kind:            GLOBAL
-# CHECK-NEXT:         Index:           10
+# CHECK-NEXT:         Index:           2
 # CHECK-NEXT:       - Name:            __wasm_first_page_end
 # CHECK-NEXT:         Kind:            GLOBAL
 # CHECK-NEXT:         Index:           11
 # CHECK-NEXT:       - Name:            __tls_base
 # CHECK-NEXT:         Kind:            GLOBAL
-# CHECK-NEXT:         Index:           1
+# CHECK-NEXT:         Index:           3
 # CHECK-NEXT:    - Type:            CODE

--- a/lld/test/wasm/mutable-global-exports.s
+++ b/lld/test/wasm/mutable-global-exports.s
@@ -81,43 +81,43 @@ _start:
 # CHECK-ALL-NEXT:        Index:           1
 # CHECK-ALL-NEXT:      - Name:            foo_global
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           2
+# CHECK-ALL-NEXT:        Index:           4
 # CHECK-ALL-NEXT:      - Name:            bar_global
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           3
+# CHECK-ALL-NEXT:        Index:           5
 # CHECK-ALL-NEXT:      - Name:            __dso_handle
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           4
+# CHECK-ALL-NEXT:        Index:           6
 # CHECK-ALL-NEXT:      - Name:            __data_end
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           5
+# CHECK-ALL-NEXT:        Index:           7
 # CHECK-ALL-NEXT:      - Name:            __stack_low
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           6
+# CHECK-ALL-NEXT:        Index:           8
 # CHECK-ALL-NEXT:      - Name:            __stack_high
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           7
+# CHECK-ALL-NEXT:        Index:           9
 # CHECK-ALL-NEXT:      - Name:            __global_base
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           8
+# CHECK-ALL-NEXT:        Index:           10
 # CHECK-ALL-NEXT:      - Name:            __heap_base
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           9
+# CHECK-ALL-NEXT:        Index:           11
 # CHECK-ALL-NEXT:      - Name:            __heap_end
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           10
+# CHECK-ALL-NEXT:        Index:           12
 # CHECK-ALL-NEXT:      - Name:            __memory_base
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           11
+# CHECK-ALL-NEXT:        Index:           1
 # CHECK-ALL-NEXT:      - Name:            __table_base
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           12
+# CHECK-ALL-NEXT:        Index:           2
 # CHECK-ALL-NEXT:      - Name:            __wasm_first_page_end
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
 # CHECK-ALL-NEXT:        Index:           13
 # CHECK-ALL-NEXT:      - Name:            __tls_base
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           1
+# CHECK-ALL-NEXT:        Index:           3
 # CHECK-ALL-NEXT:  - Type:            CODE
 
 # CHECK-ALL:         Name:            target_features

--- a/lld/test/wasm/pic-static-unused.s
+++ b/lld/test/wasm/pic-static-unused.s
@@ -1,0 +1,21 @@
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %s -o %t.o
+# RUN: wasm-ld -o %t.wasm %t.o
+# RUN: obj2yaml %t.wasm | FileCheck %s
+
+.globaltype __memory_base, i32, immutable
+.globaltype __table_base, i32, immutable
+
+.globl _start
+_start:
+  .functype _start () -> ()
+  end_function
+
+.section .debug_info,"",@
+  .int32 __memory_base
+  .int32 __table_base
+
+## Check that relocations against unused __memory_base and __table_base
+## work in non-pic mode.
+
+# CHECK:         Name:            .debug_info
+# CHECK-NEXT:    Payload:         FFFFFFFFFFFFFFFF

--- a/lld/test/wasm/pic-static.s
+++ b/lld/test/wasm/pic-static.s
@@ -102,7 +102,7 @@ ret32_ptr:
 # CHECK-NEXT:           Opcode:          I32_CONST
 # CHECK-NEXT:           Value:           65536
 
-# __tls_base
+# __memory_base
 # CHECK-NEXT:       - Index:           1
 # CHECK-NEXT:         Type:            I32
 # CHECK-NEXT:         Mutable:         false
@@ -110,8 +110,24 @@ ret32_ptr:
 # CHECK-NEXT:           Opcode:          I32_CONST
 # CHECK-NEXT:           Value:           0
 
-# GOT.func.internal.ret32
+# __table_base
 # CHECK-NEXT:       - Index:           2
+# CHECK-NEXT:         Type:            I32
+# CHECK-NEXT:         Mutable:         false
+# CHECK-NEXT:         InitExpr:
+# CHECK-NEXT:           Opcode:          I32_CONST
+# CHECK-NEXT:           Value:           1
+
+# __tls_base
+# CHECK-NEXT:       - Index:           3
+# CHECK-NEXT:         Type:            I32
+# CHECK-NEXT:         Mutable:         false
+# CHECK-NEXT:         InitExpr:
+# CHECK-NEXT:           Opcode:          I32_CONST
+# CHECK-NEXT:           Value:           0
+
+# GOT.func.internal.ret32
+# CHECK-NEXT:       - Index:           4
 # CHECK-NEXT:         Type:            I32
 # CHECK-NEXT:         Mutable:         false
 # CHECK-NEXT:         InitExpr:
@@ -119,23 +135,15 @@ ret32_ptr:
 # CHECK-NEXT:           Value: 1
 
 # GOT.func.missing_function
-# CHECK-NEXT:       - Index:           3
+# CHECK-NEXT:       - Index:           5
 # CHECK-NEXT:         Type:            I32
 # CHECK-NEXT:         Mutable:         false
 # CHECK-NEXT:         InitExpr:
 # CHECK-NEXT:           Opcode:          I32_CONST
 # CHECK-NEXT:           Value:           2
 
-# GOT.data.internal.__table_base
-# CHECK-NEXT:       - Index:           4
-# CHECK-NEXT:         Type:            I32
-# CHECK-NEXT:         Mutable:         false
-# CHECK-NEXT:         InitExpr:
-# CHECK-NEXT:           Opcode:          I32_CONST
-# CHECK-NEXT:           Value:           1
-
 # GOT.mem.missing_float
-# CHECK-NEXT:       - Index:           5
+# CHECK-NEXT:       - Index:           6
 # CHECK-NEXT:         Type:            I32
 # CHECK-NEXT:         Mutable:         false
 # CHECK-NEXT:         InitExpr:
@@ -143,7 +151,7 @@ ret32_ptr:
 # CHECK-NEXT:           Value:           0
 
 # GOT.mem.global_float
-# CHECK-NEXT:       - Index:           6
+# CHECK-NEXT:       - Index:           7
 # CHECK-NEXT:         Type:            I32
 # CHECK-NEXT:         Mutable:         false
 # CHECK-NEXT:         InitExpr:
@@ -151,7 +159,7 @@ ret32_ptr:
 # CHECK-NEXT:           Value:           65536
 
 # GOT.mem.ret32_ptr
-# CHECK-NEXT:       - Index:           7
+# CHECK-NEXT:       - Index:           8
 # CHECK-NEXT:         Type:            I32
 # CHECK-NEXT:         Mutable:         false
 # CHECK-NEXT:         InitExpr:
@@ -162,19 +170,19 @@ ret32_ptr:
 # CHECK-NEXT:       - Index:           0
 # CHECK-NEXT:         Name:            __stack_pointer
 # CHECK-NEXT:       - Index:           1
-# CHECK-NEXT:         Name:            __tls_base
+# CHECK-NEXT:         Name:            __memory_base
 # CHECK-NEXT:       - Index:           2
-# CHECK-NEXT:         Name:            GOT.func.internal.ret32
+# CHECK-NEXT:         Name:            __table_base
 # CHECK-NEXT:       - Index:           3
-# CHECK-NEXT:         Name:            GOT.func.internal.missing_function
+# CHECK-NEXT:         Name:            __tls_base
 # CHECK-NEXT:       - Index:           4
-# CHECK-NEXT:         Name:            GOT.data.internal.__table_base
+# CHECK-NEXT:         Name:            GOT.func.internal.ret32
 # CHECK-NEXT:       - Index:           5
-# CHECK-NEXT:         Name:            GOT.data.internal.missing_float
+# CHECK-NEXT:         Name:            GOT.func.internal.missing_function
 # CHECK-NEXT:       - Index:           6
-# CHECK-NEXT:         Name:            GOT.data.internal.global_float
+# CHECK-NEXT:         Name:            GOT.data.internal.missing_float
 # CHECK-NEXT:       - Index:           7
-# CHECK-NEXT:         Name:            GOT.data.internal.ret32_ptr
+# CHECK-NEXT:         Name:            GOT.data.internal.global_float
 # CHECK-NEXT:       - Index:           8
-# CHECK-NEXT:         Name:            GOT.data.internal.__memory_base
+# CHECK-NEXT:         Name:            GOT.data.internal.ret32_ptr
 # CHECK-NEXT:     DataSegmentNames:

--- a/lld/wasm/Config.h
+++ b/lld/wasm/Config.h
@@ -35,6 +35,7 @@ class Symbol;
 class DefinedData;
 class GlobalSymbol;
 class DefinedFunction;
+class DefinedGlobal;
 class UndefinedGlobal;
 class TableSymbol;
 
@@ -236,13 +237,11 @@ struct Ctx {
 
     // __table_base
     // Used in PIC code for offset of indirect function table
-    UndefinedGlobal *tableBase;
-    DefinedData *definedTableBase;
+    GlobalSymbol *tableBase;
 
     // __memory_base
     // Used in PIC code for offset of global data
-    UndefinedGlobal *memoryBase;
-    DefinedData *definedMemoryBase;
+    GlobalSymbol *memoryBase;
 
     // __indirect_function_table
     // Used as an address space for function pointers, with each function that

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -915,13 +915,13 @@ static InputGlobal *createGlobal(StringRef name, bool isMutable) {
   return make<InputGlobal>(wasmGlobal, nullptr);
 }
 
-static GlobalSymbol *createGlobalVariable(StringRef name, bool isMutable,
-                                          uint32_t flags = 0) {
+static DefinedGlobal *createGlobalVariable(StringRef name, bool isMutable,
+                                           uint32_t flags = 0) {
   InputGlobal *g = createGlobal(name, isMutable);
   return symtab->addSyntheticGlobal(name, flags, g);
 }
 
-static GlobalSymbol *createOptionalGlobal(StringRef name, bool isMutable) {
+static DefinedGlobal *createOptionalGlobal(StringRef name, bool isMutable) {
   InputGlobal *g = createGlobal(name, isMutable);
   return symtab->addOptionalGlobalSymbol(name, g);
 }
@@ -997,8 +997,8 @@ static void createOptionalSymbols() {
     ctx.sym.globalBase = symtab->addOptionalDataSymbol("__global_base");
     ctx.sym.heapBase = symtab->addOptionalDataSymbol("__heap_base");
     ctx.sym.heapEnd = symtab->addOptionalDataSymbol("__heap_end");
-    ctx.sym.definedMemoryBase = symtab->addOptionalDataSymbol("__memory_base");
-    ctx.sym.definedTableBase = symtab->addOptionalDataSymbol("__table_base");
+    ctx.sym.memoryBase = createOptionalGlobal("__memory_base", false);
+    ctx.sym.tableBase = createOptionalGlobal("__table_base", false);
   }
 
   ctx.sym.firstPageEnd = symtab->addOptionalDataSymbol("__wasm_first_page_end");

--- a/lld/wasm/Writer.cpp
+++ b/lld/wasm/Writer.cpp
@@ -1713,8 +1713,8 @@ void Writer::createSyntheticSectionsPostLayout() {
 void Writer::run() {
   // For PIC code the table base is assigned dynamically by the loader.
   // For non-PIC, we start at 1 so that accessing table index 0 always traps.
-  if (!ctx.isPic && ctx.sym.definedTableBase)
-    ctx.sym.definedTableBase->setVA(ctx.arg.tableBase);
+  if (!ctx.isPic && ctx.sym.tableBase)
+    setGlobalPtr(cast<DefinedGlobal>(ctx.sym.tableBase), ctx.arg.tableBase);
 
   log("-- createOutputSegments");
   createOutputSegments();


### PR DESCRIPTION
When linking PIC code as non-PIC we internally define `__memory_base` and `__table_base`.  However we were defining these incorrectly as data symbols and not global symbols (as in Wasm globals).

This happened to work incidentally as long as there was a live reference to the symbol.  This is because the live reference would cause a GOT entry to be created for these symbol and then they could be referenced via via `R_WASM_GLOBAL_INDEX_LEB` or `R_WASM_GLOBAL_INDEX_I32`. However, when no live reference existed there could still be references from debug sections, and in that case the relocation code was crashing.

Fixes: #174676