### PR TITLE
[Offload] Add a function to register an RPC Server callback

### DIFF
--- a/offload/include/omptarget.h
+++ b/offload/include/omptarget.h
@@ -429,7 +429,11 @@ int __tgt_activate_record_replay(int64_t DeviceId, uint64_t MemorySize,
                                  void *VAddr, bool IsRecord, bool SaveOutput,
                                  uint64_t &ReqPtrArgOffset);
 
+// Registers a callback for the RPC server. Expects this function type.
+// unsigned callback(rpc::Server::Port *Port, unsigned NumLanes). See the RPC
+// code for details.
 void __tgt_register_rpc_callback(unsigned (*Callback)(void *, unsigned));
+
 #ifdef __cplusplus
 }
 #endif

--- a/offload/include/omptarget.h
+++ b/offload/include/omptarget.h
@@ -429,6 +429,7 @@ int __tgt_activate_record_replay(int64_t DeviceId, uint64_t MemorySize,
                                  void *VAddr, bool IsRecord, bool SaveOutput,
                                  uint64_t &ReqPtrArgOffset);
 
+void __tgt_register_rpc_callback(unsigned (*Callback)(void *, unsigned));
 #ifdef __cplusplus
 }
 #endif

--- a/offload/liboffload/API/Platform.td
+++ b/offload/liboffload/API/Platform.td
@@ -80,7 +80,7 @@ def ol_platform_rpc_cb_t : FptrTypedef {
   let params = [Param<"void*", "Port", "opaque pointer to the RPC server port",
                       PARAM_IN>,
                 Param<"unsigned", "NumLanes",
-                      "number of active lanes in the warp", PARAM_IN>];
+                      "number of lanes handled in a single call", PARAM_IN>];
   let return = "unsigned";
 }
 

--- a/offload/liboffload/API/Platform.td
+++ b/offload/liboffload/API/Platform.td
@@ -74,3 +74,26 @@ def olGetPlatformInfoSize : Function {
     Return<"OL_ERRC_INVALID_PLATFORM">
   ];
 }
+
+def ol_platform_rpc_cb_t : FptrTypedef {
+  let desc = "User-provided RPC server callback for a platform.";
+  let params = [Param<"void*", "Port", "opaque pointer to the RPC server port",
+                      PARAM_IN>,
+                Param<"unsigned", "NumLanes",
+                      "number of active lanes in the warp", PARAM_IN>];
+  let return = "unsigned";
+}
+
+def olPlatformRegisterRPCCallback : Function {
+  let desc = "Registers a platform-wide RPC server callback.";
+  let details =
+      ["The registered callback is invoked before the default RPC opcode "
+       "handling.",
+       "If the callback returns a value other than RPC_UNHANDLED_OPCODE,",
+       "the default handling is skipped."];
+  let params = [Param<"ol_platform_handle_t", "Platform",
+                      "handle of the platform", PARAM_IN>,
+                Param<"ol_platform_rpc_cb_t", "Callback",
+                      "RPC callback function pointer", PARAM_IN>];
+  let returns = [Return<"OL_ERRC_INVALID_PLATFORM">, Return<"OL_ERRC_SUCCESS">];
+}

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -391,6 +391,12 @@ Error olGetPlatformInfoSize_impl(ol_platform_handle_t Platform,
                                      PropSizeRet);
 }
 
+Error olPlatformRegisterRPCCallback_impl(ol_platform_handle_t Platform,
+                                         ol_platform_rpc_cb_t Callback) {
+  Platform->Plugin->getRPCServer().registerCallback(Callback);
+  return Error::success();
+}
+
 Error olGetDeviceInfoImplDetail(ol_device_handle_t Device,
                                 ol_device_info_t PropName, size_t PropSize,
                                 void *PropValue, size_t *PropSizeRet) {

--- a/offload/libomptarget/exports
+++ b/offload/libomptarget/exports
@@ -78,6 +78,7 @@ VERS1.0 {
     __tgt_interop_use60;
     __tgt_interop_release;
     __tgt_target_sync;
+    __tgt_register_rpc_callback;
     __llvmPushCallConfiguration;
     __llvmPopCallConfiguration;
     llvmLaunchKernel;

--- a/offload/libomptarget/interface.cpp
+++ b/offload/libomptarget/interface.cpp
@@ -573,3 +573,10 @@ EXTERN void __tgt_target_nowait_query(void **AsyncHandle) {
   delete AsyncInfo;
   *AsyncHandle = nullptr;
 }
+
+EXTERN void __tgt_register_rpc_callback(unsigned (*Callback)(void *,
+                                                             unsigned)) {
+  for (auto &Plugin : PM->plugins())
+    if (Plugin.is_initialized())
+      Plugin.getRPCServer().registerCallback(Callback);
+}

--- a/offload/plugins-nextgen/common/include/RPC.h
+++ b/offload/plugins-nextgen/common/include/RPC.h
@@ -38,6 +38,8 @@ class DeviceImageTy;
 /// these routines will perform no action.
 struct RPCServerTy {
 public:
+  using RPCServerCallbackTy = uint32_t (*)(void *, uint32_t);
+
   /// Initializes the handles to the number of devices we may need to service.
   RPCServerTy(plugin::GenericPluginTy &Plugin);
 
@@ -64,6 +66,9 @@ public:
   /// Deinitialize the RPC server for the given device. This will free the
   /// memory associated with the k
   llvm::Error deinitDevice(plugin::GenericDeviceTy &Device);
+
+  /// Register a custom callback for the RPC server to manage.
+  void registerCallback(RPCServerCallbackTy FnPtr);
 
 private:
   /// Array from this device's identifier to its attached devices.

--- a/offload/test/libc/rpc_callback.c
+++ b/offload/test/libc/rpc_callback.c
@@ -7,9 +7,13 @@
 #include <stdint.h>
 #include <stdio.h>
 
+// CHECK: PASS
+
 // This should be present in-tree relative to the test directory. If someone is
 // using a partial tree just pass the test.
-#if __has_include(<../../libc/shared/rpc.h>)
+#if !__has_include(<../../libc/shared/rpc.h>)
+int main() { printf("PASS\n"); }
+#else
 #include <../../libc/shared/rpc.h>
 
 extern "C" void __tgt_register_rpc_callback(unsigned (*Callback)(void *,
@@ -57,9 +61,6 @@ int main() {
     Port.recv([](rpc::Buffer *, uint32_t) {});
     Port.close();
   }
-  // CHECK: PASS
   printf("PASS\n");
 }
-#else
-int main() { printf("PASS\n"); }
 #endif

--- a/offload/test/libc/rpc_callback.c
+++ b/offload/test/libc/rpc_callback.c
@@ -1,0 +1,65 @@
+// RUN: %libomptarget-compilexx-run-and-check-generic
+
+// REQUIRES: libc
+// REQUIRES: gpu
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// This should be present in-tree relative to the test directory. If someone is
+// using a partial tree just pass the test.
+#if __has_include(<../../libc/shared/rpc.h>)
+#include <../../libc/shared/rpc.h>
+
+extern "C" void __tgt_register_rpc_callback(unsigned (*Callback)(void *,
+                                                                 unsigned));
+constexpr uint32_t RPC_TEST_OPCODE = 1;
+
+template<uint32_t NumLanes> rpc::Status handleOpcodes(rpc::Server::Port &Port) {
+  switch (Port.get_opcode()) {
+  case RPC_TEST_OPCODE: {
+    Port.recv(
+        [&](rpc::Buffer *Buffer, uint32_t) { assert(Buffer->data[0] == 42); });
+    Port.send([&](rpc::Buffer *, uint32_t) {});
+    break;
+  }
+  default:
+    return rpc::RPC_UNHANDLED_OPCODE;
+    break;
+  }
+  return rpc::RPC_SUCCESS;
+}
+
+static uint32_t handleOffloadOpcodes(void *Raw, uint32_t NumLanes) {
+  rpc::Server::Port &Port = *reinterpret_cast<rpc::Server::Port *>(Raw);
+  if (NumLanes == 1)
+    return handleOpcodes<1>(Port);
+  else if (NumLanes == 32)
+    return handleOpcodes<32>(Port);
+  else if (NumLanes == 64)
+    return handleOpcodes<64>(Port);
+  else
+    return rpc::RPC_ERROR;
+}
+
+[[gnu::weak]] rpc::Client client asm("__llvm_rpc_client");
+#pragma omp declare target to(client) device_type(nohost)
+
+void __tgt_register_rpc_callback(unsigned (*Callback)(void *, unsigned));
+
+int main() {
+  __tgt_register_rpc_callback(&handleOffloadOpcodes);
+#pragma omp target
+  {
+    rpc::Client::Port Port = client.open<RPC_TEST_OPCODE>();
+    Port.send([=](rpc::Buffer *buffer, uint32_t) { buffer->data[0] = 42; });
+    Port.recv([](rpc::Buffer *, uint32_t) {});
+    Port.close();
+  }
+  // CHECK: PASS
+  printf("PASS\n");
+}
+#else
+int main() { printf("PASS\n"); }
+#endif

--- a/offload/unittests/OffloadAPI/platform/olRegisterRPCCallback.cpp
+++ b/offload/unittests/OffloadAPI/platform/olRegisterRPCCallback.cpp
@@ -1,0 +1,30 @@
+//===------- Offload API tests - olRegisterRPCCallback --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <OffloadAPI.h>
+
+#include "../common/Fixtures.hpp"
+
+using olRegisterRPCCallbackTest = OffloadPlatformTest;
+OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olRegisterRPCCallbackTest);
+
+static unsigned callback(void *Raw, unsigned NumLanes) {}
+
+TEST_P(olRegisterRPCCallbackTest, SuccessBackend) {
+  ASSERT_SUCCESS(olPlatformRegisterRPCCallback(Platform, &callback));
+}
+
+TEST_P(olRegisterRPCCallbackTest, InvalidNullHandle) {
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+               olPlatformRegisterRPCCallback(nullptr, &callback));
+}
+
+TEST_P(olRegisterRPCCallbackTest, InvalidNullPointer) {
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+               olPlatformRegisterRPCCallback(Platform, nullptr));
+}


### PR DESCRIPTION
Summary:
We provide an RPC server to manage calls initiated by the device to run
on the host. This is very useful for the built-in handling we have,
however there are cases where we would want to extend this
functionality.

Cases like Fortran or MPI would be useful, but we cannot put references
to these in the core offloading runtime. This way, we can provide this
as a library interface that registers custom handlers for whatever code
people want.
