### PR TITLE
[clang-tidy] Speed up `cppcoreguidelines-pro-bounds-array-to-pointer-decay`

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsArrayToPointerDecayCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsArrayToPointerDecayCheck.cpp
@@ -57,6 +57,7 @@ void ProBoundsArrayToPointerDecayCheck::registerMatchers(MatchFinder *Finder) {
       traverse(
           TK_AsIs,
           implicitCastExpr(
+              hasCastKind(CK_ArrayToPointerDecay),
               unless(hasParent(arraySubscriptExpr())),
               unless(hasSourceExpression(predefinedExpr())),
               unless(hasParentIgnoringImpCasts(explicitCastExpr())),
@@ -72,9 +73,6 @@ void ProBoundsArrayToPointerDecayCheck::registerMatchers(MatchFinder *Finder) {
 void ProBoundsArrayToPointerDecayCheck::check(
     const MatchFinder::MatchResult &Result) {
   const auto *MatchedCast = Result.Nodes.getNodeAs<ImplicitCastExpr>("cast");
-  if (MatchedCast->getCastKind() != CK_ArrayToPointerDecay)
-    return;
-
   diag(MatchedCast->getExprLoc(), "do not implicitly decay an array into a "
                                   "pointer; consider using gsl::array_view or "
                                   "an explicit cast instead");


### PR DESCRIPTION
By just changing the order of some conditions, the check goes from fairly expensive to very cheap:

```txt
                    ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
Status quo:         0.7812 (  1.7%)   0.0469 (  0.7%)   0.8281 (  1.6%)   0.5585 (  1.1%)  cppcoreguidelines-pro-bounds-array-to-pointer-decay
With this change:   0.0312 (  0.1%)   0.0000 (  0.0%)   0.0312 (  0.1%)   0.0598 (  0.1%)  cppcoreguidelines-pro-bounds-array-to-pointer-decay
```
`hicpp-no-array-decay` is an alias of this check and so benefits too.