### PR TITLE
[SPIRV] Prevent BB start emission for service functions

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -194,7 +194,7 @@ void SPIRVAsmPrinter::emitOpLabel(const MachineBasicBlock &MBB) {
 
 void SPIRVAsmPrinter::emitBasicBlockStart(const MachineBasicBlock &MBB) {
   // Do not emit anything if it's an internal service function.
-  if (MBB.empty())
+  if (MBB.empty() || isHidden())
     return;
 
   // If it's the first MBB in MF, it has OpFunction and OpFunctionParameter, so

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fun-ptr-service-func.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fun-ptr-service-func.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - -filetype=obj | spirv-val %}
 
 declare spir_func i32 @_Z12get_local_idj(i32)
 
@@ -13,14 +14,14 @@ declare spir_func i32 @_Z12get_local_idj(i32)
 ; CHECK: OpUConvert %[[I32]] %[[COMPOSITE_EXTRACT]] 
 
 define spir_func i32 @func_1() {
-  %2 = tail call spir_func i32 @_Z12get_local_idj(i32 0)
-  ret i32 %2
+  %id = tail call spir_func i32 @_Z12get_local_idj(i32 0)
+  ret i32 %id
 }
 
 ; CHECK: %[[F2]] = OpFunction %[[I64]] None
 ; CHECK: OpCompositeExtract %[[I64]] 
 
 define spir_func i64 @func_2() {
-  %2 = tail call spir_func i64 @_Z12get_local_idj(i32 0)
-  ret i64 %2
+  %id = tail call spir_func i64 @_Z12get_local_idj(i32 0)
+  ret i64 %id
 }

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fun-ptr-service-func.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fun-ptr-service-func.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - | FileCheck %s
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - -filetype=obj | spirv-val %}
+; TODO: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - -filetype=obj | spirv-val %}
 
 declare spir_func i32 @_Z12get_local_idj(i32)
 

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fun-ptr-service-func.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fun-ptr-service-func.ll
@@ -1,0 +1,26 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - | FileCheck %s
+
+declare spir_func i32 @_Z12get_local_idj(i32)
+
+; CHECK: OpName %[[F1:.*]] "func_1"
+; CHECK: OpName %[[F2:.*]] "func_2"
+
+; CHECK: %[[I32:.*]] = OpTypeInt 32 0
+; CHECK: %[[I64:.*]] = OpTypeInt 64 0
+
+; CHECK: %[[F1]] = OpFunction %[[I32]] None
+; CHECK: %[[COMPOSITE_EXTRACT:.*]] = OpCompositeExtract %[[I64]]
+; CHECK: OpUConvert %[[I32]] %[[COMPOSITE_EXTRACT]] 
+
+define spir_func i32 @func_1() {
+  %2 = tail call spir_func i32 @_Z12get_local_idj(i32 0)
+  ret i32 %2
+}
+
+; CHECK: %[[F2]] = OpFunction %[[I64]] None
+; CHECK: OpCompositeExtract %[[I64]] 
+
+define spir_func i64 @func_2() {
+  %2 = tail call spir_func i64 @_Z12get_local_idj(i32 0)
+  ret i64 %2
+}


### PR DESCRIPTION
When working with function pointers, the backend service functions might still retain call instructions to the original functions. This PR skips BB start emission for such cases. 