### PR TITLE
[libc][math] Refactor sqrtf to header-only 

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -99,6 +99,7 @@
 #include "math/sinhf16.h"
 #include "math/sinpif.h"
 #include "math/sqrt.h"
+#include "math/sqrtf.h"
 #include "math/sqrtf16.h"
 #include "math/tan.h"
 #include "math/tanf.h"

--- a/libc/shared/math/sqrtf.h
+++ b/libc/shared/math/sqrtf.h
@@ -1,4 +1,4 @@
-//===-- Shared header for sqrtf ----------------------------------*- C++ -*-===//
+//===-- Shared header for sqrtf ---------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/shared/math/sqrtf.h
+++ b/libc/shared/math/sqrtf.h
@@ -1,5 +1,4 @@
-//===-- Shared header for sqrtf ----------------------------------*- C++
-//-*-===//
+//===-- Shared header for sqrtf ----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/shared/math/sqrtf.h
+++ b/libc/shared/math/sqrtf.h
@@ -1,4 +1,5 @@
-//===-- Implementation of sqrtf function ----------------------------------===//
+//===-- Shared header for sqrtf ----------------------------------*- C++
+//-*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +7,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/sqrtf.h"
+#ifndef LLVM_LIBC_SHARED_MATH_SQRTF_H
+#define LLVM_LIBC_SHARED_MATH_SQRTF_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/sqrtf.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(float, sqrtf, (float x)) { return math::sqrtf(x); }
+using math::sqrtf;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_SQRTF_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1436,6 +1436,14 @@ add_header_library(
 )
 
 add_header_library(
+  sqrtf
+  HDRS
+    sqrtf.h
+  DEPENDS
+    libc.src.__support.FPUtil.sqrt
+)
+
+add_header_library(
   dfmal
   HDRS
     dfmal.h

--- a/libc/src/__support/math/sqrtf.h
+++ b/libc/src/__support/math/sqrtf.h
@@ -1,4 +1,4 @@
-//===-- Implementation header for sqrtf --------------------------*- C++ -*-===//
+//===-- Implementation header for sqrtf -------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/src/__support/math/sqrtf.h
+++ b/libc/src/__support/math/sqrtf.h
@@ -1,5 +1,4 @@
-//===-- Implementation header for sqrtf --------------------------*- C++
-//-*-===//
+//===-- Implementation header for sqrtf --------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/src/__support/math/sqrtf.h
+++ b/libc/src/__support/math/sqrtf.h
@@ -1,0 +1,25 @@
+//===-- Implementation header for sqrtf --------------------------*- C++
+//-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_SQRTF_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_SQRTF_H
+
+#include "src/__support/FPUtil/sqrt.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE static float sqrtf(float x) { return fputil::sqrt<float>(x); }
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_SQRTF_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -2985,7 +2985,6 @@ add_entrypoint_object(
     libc.src.__support.math.sqrt
 )
 
-
 add_entrypoint_object(
   sqrtf
   SRCS
@@ -2993,7 +2992,7 @@ add_entrypoint_object(
   HDRS
     ../sqrtf.h
   DEPENDS
-    libc.src.__support.FPUtil.sqrt
+    libc.src.__support.math.sqrtf
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -97,6 +97,7 @@ add_fp_unittest(
     libc.src.__support.math.sinhf16
     libc.src.__support.math.sinpif
     libc.src.__support.math.sqrt
+    libc.src.__support.math.sqrtf
     libc.src.__support.math.tan
     libc.src.__support.math.tanf
 )

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -99,6 +99,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat) {
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::rsqrtf(1.0f));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::sinpif(0.0f));
   EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::sinf(0.0f));
+  EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::sqrtf(0.0f));
   EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::shared::tanf(0.0f));
 }
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3640,6 +3640,14 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_sqrtf",
+    hdrs = ["src/__support/math/sqrtf.h"],
+    deps = [
+        ":__support_fputil_sqrt",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_hypotf",
     hdrs = ["src/__support/math/hypotf.h"],
     deps = [
@@ -5354,7 +5362,7 @@ libc_math_function(
 libc_math_function(
     name = "sqrtf",
     additional_deps = [
-        ":__support_fputil_sqrt",
+        ":__support_math_sqrtf",
     ],
 )
 


### PR DESCRIPTION
Refactors sqrtf to be header-only.

Closes #177649.
