### PR TITLE
[SPIRV] Properly discover LLVM tools that live next to the compiler

### DIFF
--- a/clang/lib/Driver/ToolChains/SPIRV.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRV.cpp
@@ -172,6 +172,9 @@ SPIRVToolChain::SPIRVToolChain(const Driver &D, const llvm::Triple &Triple,
   // TODO: Revisit need/use of --sycl-link option once SYCL toolchain is
   // available and SYCL linking support is moved there.
   NativeLLVMSupport = Args.hasArg(options::OPT_sycl_link);
+
+  // Lookup binaries into the driver directory.
+  getProgramPaths().push_back(getDriver().Dir);
 }
 
 bool SPIRVToolChain::HasNativeLLVMSupport() const { return NativeLLVMSupport; }


### PR DESCRIPTION
Summary:
When we compile with `-emit-llvm` it will try to use `llvm-link`. The
toolchain does not properly add the driver directory as a valid path so
this will default to the user's search path. This, like other tools,
should prioritize the binaries living next to the compiler.

Side note, why is this not default behavior?
