### PR TITLE
[libc] provide str to float build configs

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -77,10 +77,6 @@ endfunction(_get_compile_options_from_flags)
 function(_get_compile_options_from_config output_var)
   set(config_options "")
 
-  if(LIBC_CONF_PRINTF_FLOAT_TO_STR_USE_FLOAT320)
-    list(APPEND config_options "-DLIBC_COPT_PRINTF_FLOAT_TO_STR_USE_FLOAT320")
-  endif()
-
   if(LIBC_CONF_STRTOFLOAT_DISABLE_EISEL_LEMIRE)
     list(APPEND config_options "-DLIBC_COPT_STRTOFLOAT_DISABLE_EISEL_LEMIRE")
   endif()

--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -77,6 +77,22 @@ endfunction(_get_compile_options_from_flags)
 function(_get_compile_options_from_config output_var)
   set(config_options "")
 
+  if(LIBC_CONF_PRINTF_FLOAT_TO_STR_USE_FLOAT320)
+    list(APPEND config_options "-DLIBC_COPT_PRINTF_FLOAT_TO_STR_USE_FLOAT320")
+  endif()
+
+  if(LIBC_CONF_STRTOFLOAT_DISABLE_EISEL_LEMIRE)
+    list(APPEND config_options "-DLIBC_COPT_STRTOFLOAT_DISABLE_EISEL_LEMIRE")
+  endif()
+
+  if(LIBC_CONF_STRTOFLOAT_DISABLE_SIMPLE_DECIMAL_CONVERSION)
+    list(APPEND config_options "-DLIBC_COPT_STRTOFLOAT_DISABLE_SIMPLE_DECIMAL_CONVERSION")
+  endif()
+
+  if(LIBC_CONF_STRTOFLOAT_DISABLE_CLINGER_FAST_PATH)
+    list(APPEND config_options "-DLIBC_COPT_STRTOFLOAT_DISABLE_CLINGER_FAST_PATH")
+  endif()
+
   if(LIBC_CONF_QSORT_IMPL)
     list(APPEND config_options "-DLIBC_QSORT_IMPL=${LIBC_CONF_QSORT_IMPL}")
   endif()

--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -34,6 +34,11 @@
       "value": "LIBC_QSORT_HEAP_SORT"
     }
   },
+  "str_to_float": {
+    "LIBC_CONF_STRTOFLOAT_DISABLE_EISEL_LEMIRE": {
+      "value": true
+    }
+  },
   "math": {
     "LIBC_CONF_MATH_OPTIMIZATIONS": {
       "value": "(LIBC_MATH_SKIP_ACCURATE_PASS | LIBC_MATH_SMALL_TABLES | LIBC_MATH_NO_ERRNO | LIBC_MATH_INTERMEDIATE_COMP_IN_FLOAT)"

--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -64,6 +64,20 @@
       "doc": "Disable index mode in the scanf format string."
     }
   },
+  "str_to_float": {
+    "LIBC_CONF_STRTOFLOAT_DISABLE_EISEL_LEMIRE": {
+      "value": false,
+      "doc": "Disable Eisel-Lemire algorithm for string to float conversion."
+    },
+    "LIBC_CONF_STRTOFLOAT_DISABLE_SIMPLE_DECIMAL_CONVERSION": {
+      "value": false,
+      "doc": "Disable simple decimal conversion for string to float conversion."
+    },
+    "LIBC_CONF_STRTOFLOAT_DISABLE_CLINGER_FAST_PATH": {
+      "value": false,
+      "doc": "Disable Clinger's fast path for string to float conversion."
+    }
+  },
   "string": {
     "LIBC_CONF_STRING_LENGTH_IMPL": {
       "value": "element",

--- a/libc/docs/configure.rst
+++ b/libc/docs/configure.rst
@@ -60,6 +60,10 @@ to learn about the defaults for your platform and target.
     - ``LIBC_CONF_SCANF_DISABLE_INDEX_MODE``: Disable index mode in the scanf format string.
 * **"setjmp" options**
     - ``LIBC_CONF_SETJMP_AARCH64_RESTORE_PLATFORM_REGISTER``: Make setjmp save the value of x18, and longjmp restore it. The AArch64 ABI delegates this register to platform ABIs, which can choose whether to make it caller-saved.
+* **"str_to_float" options**
+    - ``LIBC_CONF_STRTOFLOAT_DISABLE_CLINGER_FAST_PATH``: Disable Clinger's fast path for string to float conversion.
+    - ``LIBC_CONF_STRTOFLOAT_DISABLE_EISEL_LEMIRE``: Disable Eisel-Lemire algorithm for string to float conversion.
+    - ``LIBC_CONF_STRTOFLOAT_DISABLE_SIMPLE_DECIMAL_CONVERSION``: Disable simple decimal conversion for string to float conversion.
 * **"string" options**
     - ``LIBC_CONF_FIND_FIRST_CHARACTER_IMPL``: Selects the implementation for find-first-character-related functions: 'element', 'word', 'clang_vector', or 'arch_vector'.
     - ``LIBC_CONF_MEMSET_X86_USE_SOFTWARE_PREFETCHING``: Inserts prefetch for write instructions (PREFETCHW) for memset on x86 to recover performance when hardware prefetcher is disabled.

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -684,9 +684,7 @@ LIBC_INLINE FloatConvertReturn<T> decimal_exp_to_float(
     const CharType *__restrict numStart,
     const size_t num_len = cpp::numeric_limits<size_t>::max()) {
   using FPBits = typename fputil::FPBits<T>;
-  using StorageType = typename FPBits::StorageType;
 
-  StorageType mantissa = init_num.mantissa;
   int32_t exp10 = init_num.exponent;
 
   FloatConvertReturn<T> output;
@@ -725,6 +723,8 @@ LIBC_INLINE FloatConvertReturn<T> decimal_exp_to_float(
 
 #ifndef LIBC_COPT_STRTOFLOAT_DISABLE_EISEL_LEMIRE
   // Try Eisel-Lemire
+  using StorageType = typename FPBits::StorageType;
+  StorageType mantissa = init_num.mantissa;
   opt_output = eisel_lemire<T>(init_num, round);
   if (opt_output.has_value()) {
     if (!truncated) {


### PR DESCRIPTION
The str to float code path offers options which can reduce code bloat.
Expose them as build config options. Disable Eisel Lemire for avoiding
code bloat caused by DETAILED_POWERS_OF_TEN look up table.
