### PR TITLE
[clang] Store the Input PCH Path Using Absolute Paths in a PCH

### DIFF
--- a/clang/test/PCH/pch-input-path-independent.c
+++ b/clang/test/PCH/pch-input-path-independent.c
@@ -1,0 +1,19 @@
+// Tests that when PCHs are chained, the dependent PCHs produced are identical
+// whether the input PCH is specified through a relative path or an absolute path.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: cd %t
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -emit-pch h1.h -o %t/h1.h.pch
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -emit-pch bridging.h \
+// RUN:  -o %t/bridging1.h.pch -include-pch %t/h1.h.pch
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -emit-pch bridging.h \
+// RUN:  -o %t/bridging2.h.pch -include-pch ./h1.h.pch
+
+// RUN: diff %t/bridging1.h.pch %t/bridging2.h.pch
+
+//--- h1.h
+int bar1() { return 42; }
+
+//--- bridging.h
+int bar() { return bar1(); }


### PR DESCRIPTION
When a PCH file includes another PCH file, the ASTWriter does not normalize the input PCH's path. This leads to a situation where the final PCH can be different depending on whether the input PCH is passed using a relative path or an absolute path. 

This PR corrects the ASTWriter, so it always normalizes the input PCH's path when necessary, regardless of how the input pch file is specified on the command line.

rdar://168596546