### PR TITLE
Implement lazy fetching for "Globals" scope.

### DIFF
--- a/lldb/tools/lldb-dap/Handler/ScopesRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ScopesRequestHandler.cpp
@@ -79,16 +79,12 @@ ScopesRequestHandler::Run(const ScopesArguments &args) const {
                                             /*locals=*/true,
                                             /*statics=*/false,
                                             /*in_scope_only=*/true);
-  dap.variables.globals = frame.GetVariables(/*arguments=*/false,
-                                             /*locals=*/false,
-                                             /*statics=*/true,
-                                             /*in_scope_only=*/true);
+  dap.variables.SetFrameForLazyFetchingGlobals(frame);
   dap.variables.registers = frame.GetRegisters();
 
   std::vector scopes = {CreateScope("Locals", VARREF_LOCALS,
                                     dap.variables.locals.GetSize(), false),
-                        CreateScope("Globals", VARREF_GLOBALS,
-                                    dap.variables.globals.GetSize(), false),
+                        CreateScope("Globals", VARREF_GLOBALS, 0, false),
                         CreateScope("Registers", VARREF_REGS,
                                     dap.variables.registers.GetSize(), false)};
 

--- a/lldb/tools/lldb-dap/Variables.cpp
+++ b/lldb/tools/lldb-dap/Variables.cpp
@@ -19,9 +19,9 @@ lldb::SBValueList *Variables::GetTopLevelScope(int64_t variablesReference) {
     // Lazy fetch globals if needed.
     if (!globals.has_value())
       globals = frame.GetVariables(/*arguments=*/false,
-                                  /*locals=*/false,
-                                  /*statics=*/true,
-                                  /*in_scope_only=*/true);
+                                   /*locals=*/false,
+                                   /*statics=*/true,
+                                   /*in_scope_only=*/true);
     return &globals.value();
   case VARREF_REGS:
     return &registers;

--- a/lldb/tools/lldb-dap/Variables.cpp
+++ b/lldb/tools/lldb-dap/Variables.cpp
@@ -16,7 +16,13 @@ lldb::SBValueList *Variables::GetTopLevelScope(int64_t variablesReference) {
   case VARREF_LOCALS:
     return &locals;
   case VARREF_GLOBALS:
-    return &globals;
+    // Lazy fetch globals if needed.
+    if (!globals.has_value())
+      globals = frame.GetVariables(/*arguments=*/false,
+                                  /*locals=*/false,
+                                  /*statics=*/true,
+                                  /*in_scope_only=*/true);
+    return &globals.value();
   case VARREF_REGS:
     return &registers;
   default:
@@ -26,7 +32,7 @@ lldb::SBValueList *Variables::GetTopLevelScope(int64_t variablesReference) {
 
 void Variables::Clear() {
   locals.Clear();
-  globals.Clear();
+  globals = std::nullopt;
   registers.Clear();
   m_referencedvariables.clear();
 }

--- a/lldb/tools/lldb-dap/Variables.h
+++ b/lldb/tools/lldb-dap/Variables.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_VARIABLES_H
 #define LLDB_TOOLS_LLDB_DAP_VARIABLES_H
 
+#include "lldb/API/SBFrame.h"
 #include "lldb/API/SBValue.h"
 #include "lldb/API/SBValueList.h"
 #include "llvm/ADT/DenseMap.h"
@@ -21,10 +22,19 @@
 namespace lldb_dap {
 
 struct Variables {
+  lldb::SBFrame frame; ///< Used for lazy fetching of globals.
   lldb::SBValueList locals;
-  lldb::SBValueList globals;
+  std::optional<lldb::SBValueList> globals;
   lldb::SBValueList registers;
 
+  /// Set the frame to be used for lazy fetching of globals if needed. Lazy
+  /// getching globals can improve performance and avoid having LLDB fetching
+  /// all file globals even if the user never requests them by expanding the
+  /// "Globals" scope.
+  void SetFrameForLazyFetchingGlobals(lldb::SBFrame f) {
+    globals = std::nullopt;
+    frame = f;
+  }
   /// Check if \p var_ref points to a variable that should persist for the
   /// entire duration of the debug session, e.g. repl expandable variables
   static bool IsPermanentVariableReference(int64_t var_ref);

--- a/lldb/tools/lldb-dap/Variables.h
+++ b/lldb/tools/lldb-dap/Variables.h
@@ -27,10 +27,10 @@ struct Variables {
   std::optional<lldb::SBValueList> globals;
   lldb::SBValueList registers;
 
-  /// Set the frame to be used for lazy fetching of globals if needed. Lazy
-  /// getching globals can improve performance and avoid having LLDB fetching
-  /// all file globals even if the user never requests them by expanding the
-  /// "Globals" scope.
+  /// Set the frame to be used for lazy fetching of globals. Only fetching
+  /// globals on demand improves performance by avoiding materializing all file
+  /// globals even if the user never requests them by expanding the "Globals"
+  /// scope.
   void SetFrameForLazyFetchingGlobals(lldb::SBFrame f) {
     globals = std::nullopt;
     frame = f;

--- a/lldb/unittests/DAP/VariablesTest.cpp
+++ b/lldb/unittests/DAP/VariablesTest.cpp
@@ -67,11 +67,13 @@ TEST_F(VariablesTest, Clear_RemovesTemporaryKeepsPermanent) {
 
 TEST_F(VariablesTest, GetTopLevelScope_ReturnsCorrectScope) {
   vars.locals.Append(lldb::SBValue());
-  vars.globals.Append(lldb::SBValue());
+  // Globals are lazy initialized into a std::optional, so initialize it.
+  vars.globals = lldb::SBValueList();
+  vars.globals->Append(lldb::SBValue());
   vars.registers.Append(lldb::SBValue());
 
   EXPECT_EQ(vars.GetTopLevelScope(VARREF_LOCALS), &vars.locals);
-  EXPECT_EQ(vars.GetTopLevelScope(VARREF_GLOBALS), &vars.globals);
+  EXPECT_EQ(vars.GetTopLevelScope(VARREF_GLOBALS), &vars.globals.value());
   EXPECT_EQ(vars.GetTopLevelScope(VARREF_REGS), &vars.registers);
   EXPECT_EQ(vars.GetTopLevelScope(9999), nullptr);
 }


### PR DESCRIPTION
This patch doesn't fetch the "Globals" each time we stop unless the user expands the "Globals" scope in the debugger. Fetching globals can be expensive because we must search the debug information for all globals for a source file by searching the debug index. Now we only do the work when the user expands the "Globals" which should speed up debugging of large projects.