### PR TITLE
Add DropArrayBounds option to drop array bounds assumes

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -8518,6 +8518,31 @@ without pointing to it directly (which is not possible in global
 metadata). Currently, the only metadata making use of it is
 ``llvm.loop.parallel_accesses``.
 
+'``llvm.array.bounds``' Metadata
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``llvm.array.bounds`` metadata can be attached to ``llvm.assume``
+intrinsic calls to indicate that the assumption originates from array
+bounds information provided by the frontend. This metadata is used by
+the optimizer to identify and remove these assumptions at appropriate
+points in the optimization pipeline.
+
+Frontends like Flang and Clang may generate ``llvm.assume`` calls based
+on array bounds information to help data dependence analysis and other
+optimizations. However, these assumes can cause IR bloat after
+vectorization and may negatively impact cost models in later passes
+like Loop Strength Reduction (LSR). The ``llvm.array.bounds`` metadata
+allows passes to selectively drop these assumptions after their primary
+purpose (aiding loop optimizations) has been fulfilled.
+
+The metadata node can be empty:
+
+.. code-block:: llvm
+
+   call void @llvm.assume(i1 %cmp), !llvm.array.bounds !0
+   ...
+   !0 = !{}
+
 '``llvm.loop.parallel_accesses``' Metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/llvm/include/llvm/Transforms/Scalar/DropUnnecessaryAssumes.h
+++ b/llvm/include/llvm/Transforms/Scalar/DropUnnecessaryAssumes.h
@@ -19,13 +19,20 @@ namespace llvm {
 
 struct DropUnnecessaryAssumesPass
     : public OptionalPassInfoMixin<DropUnnecessaryAssumesPass> {
-  DropUnnecessaryAssumesPass(bool DropDereferenceable = false)
-      : DropDereferenceable(DropDereferenceable) {}
+  DropUnnecessaryAssumesPass(bool DropDereferenceable = false,
+                             bool DropArrayBounds = false)
+      : DropDereferenceable(DropDereferenceable),
+        DropArrayBounds(DropArrayBounds) {}
 
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
 private:
   bool DropDereferenceable;
+  // When true, drop assumes with "llvm.array.bounds" metadata. These are
+  // array bounds assumes from Fortran/C/C++ that should be dropped before
+  // vectorization to prevent IR bloat and avoid negatively impacting cost
+  // models in later passes like LSR.
+  bool DropArrayBounds;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -955,9 +955,24 @@ Expected<bool> parseEntryExitInstrumenterPassOptions(StringRef Params) {
                                             "EntryExitInstrumenter");
 }
 
-Expected<bool> parseDropUnnecessaryAssumesPassOptions(StringRef Params) {
-  return PassBuilder::parseSinglePassOption(Params, "drop-deref",
-                                            "DropUnnecessaryAssumes");
+Expected<std::pair<bool, bool>>
+parseDropUnnecessaryAssumesPassOptions(StringRef Params) {
+  // {DropDereferenceable, DropArrayBounds}
+  std::pair<bool, bool> Result = {false, false};
+  while (!Params.empty()) {
+    StringRef ParamName;
+    std::tie(ParamName, Params) = Params.split(';');
+    if (ParamName == "drop-deref")
+      Result.first = true;
+    else if (ParamName == "drop-array-bounds")
+      Result.second = true;
+    else
+      return make_error<StringError>(
+          formatv("invalid DropUnnecessaryAssumes option '{0}'", ParamName)
+              .str(),
+          inconvertibleErrorCode());
+  }
+  return Result;
 }
 
 Expected<bool> parseLoopExtractorPassOptions(StringRef Params) {

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -1345,6 +1345,13 @@ PassBuilder::buildModuleSimplificationPipeline(OptimizationLevel Level,
 void PassBuilder::addVectorPasses(OptimizationLevel Level,
                                   FunctionPassManager &FPM,
                                   ThinOrFullLTOPhase LTOPhase) {
+  // Drop array bounds assumes before vectorization to prevent IR bloat from
+  // vectorized assumes and avoid negatively impacting cost models in later
+  // passes like LSR. These assumes are marked with "llvm.array.bounds" metadata
+  // by frontends like Flang and Clang.
+  FPM.addPass(DropUnnecessaryAssumesPass(/*DropDereferenceable=*/false,
+                                         /*DropArrayBounds=*/true));
+
   FPM.addPass(LoopVectorizePass(
       LoopVectorizeOptions(!PTO.LoopInterleaving, !PTO.LoopVectorization)));
 

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -589,8 +589,10 @@ FUNCTION_PASS_WITH_PARAMS(
     parseEarlyCSEPassOptions, "memssa")
 FUNCTION_PASS_WITH_PARAMS(
     "drop-unnecessary-assumes", "DropUnnecessaryAssumesPass",
-    [](bool DropDereferenceable) { return DropUnnecessaryAssumesPass(DropDereferenceable); },
-    parseDropUnnecessaryAssumesPassOptions, "drop-deref")
+    [](std::pair<bool, bool> Options) {
+      return DropUnnecessaryAssumesPass(Options.first, Options.second);
+    },
+    parseDropUnnecessaryAssumesPassOptions, "drop-deref;drop-array-bounds")
 FUNCTION_PASS_WITH_PARAMS(
     "ee-instrument", "EntryExitInstrumenterPass",
     [](bool PostInlining) { return EntryExitInstrumenterPass(PostInlining); },

--- a/llvm/test/Other/new-pm-defaults.ll
+++ b/llvm/test/Other/new-pm-defaults.ll
@@ -247,6 +247,7 @@
 ; CHECK-O-NEXT: Running pass: LoopDistributePass
 ; CHECK-O-NEXT: Running analysis: LoopAccessAnalysis on foo
 ; CHECK-O-NEXT: Running pass: InjectTLIMappings
+; CHECK-O-NEXT: Running pass: DropUnnecessaryAssumesPass
 ; CHECK-O-NEXT: Running pass: LoopVectorizePass
 ; CHECK-DEFAULT-NEXT: Running pass: DropUnnecessaryAssumesPass
 ; CHECK-O-NEXT: Running pass: InferAlignmentPass

--- a/llvm/test/Other/new-pm-lto-defaults.ll
+++ b/llvm/test/Other/new-pm-lto-defaults.ll
@@ -126,6 +126,7 @@
 ; CHECK-O23-NEXT: Running pass: LoopFullUnrollPass on loop
 ; CHECK-O23-NEXT: Running pass: LoopDistributePass on foo
 ; CHECK-O23-NEXT: Running analysis: LoopAccessAnalysis on foo
+; CHECK-O23-NEXT: Running pass: DropUnnecessaryAssumesPass on foo
 ; CHECK-O23-NEXT: Running pass: LoopVectorizePass on foo
 ; CHECK-O23-NEXT: Running analysis: DemandedBitsAnalysis on foo
 ; CHECK-O23-NEXT: Running pass: DropUnnecessaryAssumesPass on foo

--- a/llvm/test/Other/new-pm-thinlto-postlink-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-defaults.ll
@@ -174,6 +174,7 @@
 ; CHECK-POSTLINK-O-NEXT: Running pass: LoopDistributePass
 ; CHECK-POSTLINK-O-NEXT: Running analysis: LoopAccessAnalysis on foo
 ; CHECK-POSTLINK-O-NEXT: Running pass: InjectTLIMappings
+; CHECK-POSTLINK-O-NEXT: Running pass: DropUnnecessaryAssumesPass
 ; CHECK-POSTLINK-O-NEXT: Running pass: LoopVectorizePass
 ; CHECK-POSTLINK-O-NEXT: Running pass: DropUnnecessaryAssumesPass
 ; CHECK-POSTLINK-O-NEXT: Running pass: InferAlignmentPass

--- a/llvm/test/Other/new-pm-thinlto-postlink-pgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-pgo-defaults.ll
@@ -159,6 +159,7 @@
 ; CHECK-O-NEXT: Running pass: LoopDistributePass
 ; CHECK-O-NEXT: Running analysis: LoopAccessAnalysis on foo
 ; CHECK-O-NEXT: Running pass: InjectTLIMappings
+; CHECK-O-NEXT: Running pass: DropUnnecessaryAssumesPass
 ; CHECK-O-NEXT: Running pass: LoopVectorizePass
 ; CHECK-O-NEXT: Running pass: DropUnnecessaryAssumesPass
 ; CHECK-O-NEXT: Running pass: InferAlignmentPass

--- a/llvm/test/Other/new-pm-thinlto-postlink-samplepgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-samplepgo-defaults.ll
@@ -166,6 +166,7 @@
 ; CHECK-O-NEXT: Running pass: LoopDistributePass
 ; CHECK-O-NEXT: Running analysis: LoopAccessAnalysis
 ; CHECK-O-NEXT: Running pass: InjectTLIMappings
+; CHECK-O-NEXT: Running pass: DropUnnecessaryAssumesPass
 ; CHECK-O-NEXT: Running pass: LoopVectorizePass
 ; CHECK-O-NEXT: Running pass: DropUnnecessaryAssumesPass
 ; CHECK-O-NEXT: Running pass: InferAlignmentPass

--- a/llvm/test/Transforms/LoopInterchange/position-in-pipeline.ll
+++ b/llvm/test/Transforms/LoopInterchange/position-in-pipeline.ll
@@ -15,6 +15,7 @@
 ; CHECK-NEXT: Running pass: LoopInterchangePass
 ; CHECK-NEXT: Running pass: LoopDistributePass
 ; CHECK-NEXT: Running pass: InjectTLIMappings
+; CHECK-NEXT: Running pass: DropUnnecessaryAssumesPass
 ; CHECK-NEXT: Running pass: LoopVectorizePass
 
 


### PR DESCRIPTION
Add a new DropArrayBounds option to DropUnnecessaryAssumesPass that drops assumes marked with "llvm.array.bounds" metadata. These are array bounds assumes from frontends like Flang and Clang that should be dropped before vectorization to prevent IR bloat and avoid negatively impacting cost models in later passes like LSR.