### PR TITLE
[LoopUnrollPass] Remove unhelpful comment in `shouldPragmaUnroll` (NFC)

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -831,7 +831,6 @@ shouldPragmaUnroll(Loop *L, const PragmaInfo &PInfo,
       MaxTripCount <= UP.MaxUpperBound)
     return MaxTripCount;
 
-  // if didn't return until here, should continue to other priorties
   return std::nullopt;
 }
 


### PR DESCRIPTION
The note the comment is making should be obvious based on the structure of the pass. Additionally, it is grammatically incorrect and has spelling errors. 