### PR TITLE
[BOLT]Preserve dynamic relocation table provenance

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -1462,7 +1462,7 @@ public:
   /// Register dynamic relocation at \p Address.
   void addDynamicRelocation(uint64_t Address, MCSymbol *Symbol, uint32_t Type,
                             uint64_t Addend, uint64_t Value = 0,
-                            bool IsRELR = false);
+                            bool IsRELR = false, bool IsJmpRel = false);
 
   /// Return a dynamic relocation registered at a given \p Address, or nullptr
   /// if there is no dynamic relocation at such address.

--- a/bolt/include/bolt/Core/BinarySection.h
+++ b/bolt/include/bolt/Core/BinarySection.h
@@ -367,9 +367,9 @@ public:
   /// Add a dynamic relocation at the given /p Offset.
   void addDynamicRelocation(uint64_t Offset, MCSymbol *Symbol, uint32_t Type,
                             uint64_t Addend, uint64_t Value = 0,
-                            bool IsRELR = false) {
+                            bool IsRELR = false, bool IsJmpRel = false) {
     addDynamicRelocation(
-        Relocation{Offset, Symbol, Type, Addend, Value, IsRELR});
+        Relocation{Offset, Symbol, Type, Addend, Value, IsRELR, IsJmpRel});
   }
 
   void addDynamicRelocation(const Relocation &Reloc) {

--- a/bolt/include/bolt/Core/Relocation.h
+++ b/bolt/include/bolt/Core/Relocation.h
@@ -38,16 +38,18 @@ namespace bolt {
 class Relocation {
 public:
   Relocation(uint64_t Offset, MCSymbol *Symbol, uint32_t Type, uint64_t Addend,
-             uint64_t Value, bool IsRELR = false)
+             uint64_t Value, bool IsRELR = false, bool IsJmpRel = false)
       : Offset(Offset), Symbol(Symbol), Type(Type), Optional(false),
-        IsRELR(IsRELR), Addend(Addend), Value(Value) {
+        IsRELR(IsRELR), IsJmpRel(IsJmpRel), Addend(Addend), Value(Value) {
     assert((isRelative() || !isRELR()) &&
            "Only relative relocations can be relr.");
+    assert((!IsRELR || !IsJmpRel) &&
+           "RELR relocations cannot originate from DT_JMPREL");
   }
 
   Relocation()
-      : Offset(0), Symbol(0), Type(0), Optional(0), IsRELR(0), Addend(0),
-        Value(0) {}
+      : Offset(0), Symbol(0), Type(0), Optional(0), IsRELR(0), IsJmpRel(0),
+        Addend(0), Value(0) {}
 
   static Triple::ArchType Arch; /// set by BinaryContext ctor.
 
@@ -70,6 +72,9 @@ private:
   /// rela entries, because that would require growing the relr section.
   bool IsRELR = false;
 
+  /// Whether this dynamic relocation originated in the DT_JMPREL table.
+  bool IsJmpRel = false;
+
 public:
   /// The offset from the \p Symbol base used to compute the final
   /// value of this relocation.
@@ -87,6 +92,9 @@ public:
   bool isOptional() { return Optional; }
 
   bool isRELR() const { return IsRELR; }
+
+  /// Return whether this relocation originated in the DT_JMPREL table.
+  bool isJmpRel() const { return IsJmpRel; }
 
   /// Return size of this relocation.
   size_t getSize() const { return getSizeForType(Type); }

--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -502,8 +502,9 @@ private:
   std::optional<uint64_t> PLTRelocationsAddress;
   uint64_t PLTRelocationsSize{0};
 
-  /// True if relocation of specified type came from .rela.plt
-  DenseMap<uint64_t, bool> IsJmpRelocation;
+  /// Relocation types may exist in both section .rela.plt and .rela.dyn.
+  /// The relocation address in .rela.plt are recorded to distinguish them.
+  DenseSet<uint64_t> RelaPLTJmpRelocations;
 
   /// Index of specified symbol in the dynamic symbol table. NOTE Currently it
   /// is filled and used only with the relocations-related symbols.

--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -543,9 +543,6 @@ private:
   std::optional<uint64_t> PLTRelocationsAddress;
   uint64_t PLTRelocationsSize{0};
 
-  /// True if relocation of specified type came from .rela.plt
-  DenseMap<uint64_t, bool> IsJmpRelocation;
-
   /// Index of specified symbol in the dynamic symbol table. NOTE Currently it
   /// is filled and used only with the relocations-related symbols.
   std::unordered_map<const MCSymbol *, uint32_t> SymbolIndex;

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2683,11 +2683,12 @@ void BinaryContext::addRelocation(uint64_t Address, MCSymbol *Symbol,
 
 void BinaryContext::addDynamicRelocation(uint64_t Address, MCSymbol *Symbol,
                                          uint32_t Type, uint64_t Addend,
-                                         uint64_t Value, bool IsRELR) {
+                                         uint64_t Value, bool IsRELR,
+                                         bool IsJmpRel) {
   ErrorOr<BinarySection &> Section = getSectionForAddress(Address);
   assert(Section && "cannot find section for address");
   Section->addDynamicRelocation(Address - Section->getAddress(), Symbol, Type,
-                                Addend, Value, IsRELR);
+                                Addend, Value, IsRELR, IsJmpRel);
 }
 
 bool BinaryContext::removeRelocationAt(uint64_t Address) {

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2722,7 +2722,7 @@ void RewriteInstance::readDynamicRelocations(const SectionRef &Section,
     );
 
     if (IsJmpRel)
-      IsJmpRelocation[RType] = true;
+      RelaPLTJmpRelocations.insert(Rel.getOffset());
 
     if (Symbol)
       SymbolIndex[Symbol] = getRelocationSymbol(InputFile, Rel);
@@ -5784,10 +5784,10 @@ RewriteInstance::patchELFAllocatableRelaSections(ELFObjectFile<ELFT> *File) {
         NewRelA.r_offset = RelOffset;
         NewRelA.r_addend = Addend;
 
-        const bool IsJmpRel = IsJmpRelocation.contains(Rel.Type);
-        uint64_t &Offset = IsJmpRel ? RelPltOffset : RelDynOffset;
+        const bool IsPltJmpRel = RelaPLTJmpRelocations.contains(RelOffset);
+        uint64_t &Offset = IsPltJmpRel ? RelPltOffset : RelDynOffset;
         const uint64_t &EndOffset =
-            IsJmpRel ? RelPltEndOffset : RelDynEndOffset;
+            IsPltJmpRel ? RelPltEndOffset : RelDynEndOffset;
         if (!Offset || !EndOffset) {
           BC->errs() << "BOLT-ERROR: Invalid offsets for dynamic relocation\n";
           exit(1);

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -1668,9 +1668,12 @@ Error RewriteInstance::updateRtInitReloc() {
       if (BF->getAddress() + Reloc->Addend != BC->StartFunctionAddress)
         return createStringError(std::errc::not_supported,
                                  "inconsistent .init_array dynamic relocation");
+      // This .init_array relocation is expected to come from DT_RELA.
+      // Preserve its origin defensively when constructing the replacement.
       InitArraySection->addDynamicRelocation(Relocation{
           /*Offset*/ 0, /*Symbol*/ nullptr, /*Type*/ Relocation::getAbs64(),
-          /*Addend*/ RT->getRuntimeStartAddress(), /*Value*/ 0});
+          /*Addend*/ RT->getRuntimeStartAddress(), /*Value*/ 0,
+          /*IsRELR=*/false, /*IsJmpRel=*/Reloc->isJmpRel()});
     }
   }
   // Update the static relocation by adding a pending relocation which will get
@@ -3065,9 +3068,6 @@ void RewriteInstance::readDynamicRelocations(const SectionRef &Section,
              << " : + 0x" << Twine::utohexstr(Addend) << '\n'
     );
 
-    if (IsJmpRel)
-      IsJmpRelocation[RType] = true;
-
     if (Symbol)
       SymbolIndex[Symbol] = getRelocationSymbol(InputFile, Rel);
 
@@ -3083,7 +3083,8 @@ void RewriteInstance::readDynamicRelocations(const SectionRef &Section,
       handleRelativeDynamicRelocation(Rel.getOffset(), ReferencedAddress);
     }
 
-    BC->addDynamicRelocation(Rel.getOffset(), Symbol, RType, Addend);
+    BC->addDynamicRelocation(Rel.getOffset(), Symbol, RType, Addend,
+                             /*Value=*/0, /*IsRELR=*/false, IsJmpRel);
   }
 }
 
@@ -6339,10 +6340,10 @@ RewriteInstance::patchELFAllocatableRelaSections(ELFObjectFile<ELFT> *File) {
         NewRelA.r_offset = RelOffset;
         NewRelA.r_addend = Addend;
 
-        const bool IsJmpRel = IsJmpRelocation.contains(Rel.Type);
-        uint64_t &Offset = IsJmpRel ? RelPltOffset : RelDynOffset;
+        const bool IsPltJmpRel = Rel.isJmpRel();
+        uint64_t &Offset = IsPltJmpRel ? RelPltOffset : RelDynOffset;
         const uint64_t &EndOffset =
-            IsJmpRel ? RelPltEndOffset : RelDynEndOffset;
+            IsPltJmpRel ? RelPltEndOffset : RelDynEndOffset;
         if (!Offset || !EndOffset) {
           BC->errs() << "BOLT-ERROR: Invalid offsets for dynamic relocation\n";
           exit(1);

--- a/bolt/test/X86/dynamic-relocation-origin.test
+++ b/bolt/test/X86/dynamic-relocation-origin.test
@@ -1,0 +1,192 @@
+## IRELATIVE relocations can occur in both DT_RELA and DT_JMPREL.
+## Preserve their input table even when data reordering moves the relocation
+## site. Both entries deliberately use symbol index zero and the same resolver.
+##
+## RUN: split-file %s %t
+## RUN: yaml2obj %t/input.yaml -o %t/input.so
+## RUN: llvm-readelf -r %t/input.so | FileCheck %s --check-prefix=INPUT
+## RUN: llvm-bolt %t/input.so -o %t/output.so --lite=0
+## RUN: llvm-readelf -rs %t/output.so > %t/output.txt
+## RUN: FileCheck %s --input-file=%t/output.txt --check-prefixes=CHECK,FIXED
+## RUN: FileCheck %s --input-file=%t/output.txt --check-prefix=ADDR
+## RUN: llvm-bolt %t/input.so -o %t/moved.so --lite=0 \
+## RUN:   --reorder-data=.data --data=%t/profile.fdata
+## RUN: llvm-readelf -rs %t/moved.so > %t/moved.txt
+## RUN: FileCheck %s --input-file=%t/moved.txt --check-prefixes=CHECK,MOVED
+## RUN: FileCheck %s --input-file=%t/moved.txt --check-prefixes=ADDR,MOVED-ADDR
+
+# INPUT:      Relocation section '.rela.dyn' {{.*}} contains 1 entries:
+# INPUT-NEXT: {{.*}}Offset
+# INPUT-NEXT: {{^0*3000}} {{0*25}} R_X86_64_IRELATIVE 1008{{$}}
+# INPUT:      Relocation section '.rela.plt' {{.*}} contains 1 entries:
+# INPUT-NEXT: {{.*}}Offset
+# INPUT-NEXT: {{^0*3008}} {{0*25}} R_X86_64_IRELATIVE 1008{{$}}
+
+## Check table membership, the relocated data symbol, and the updated resolver.
+# CHECK:      Relocation section '.rela.dyn' {{.*}} contains 1 entries:
+# CHECK-NEXT: {{.*}}Offset
+# CHECK-NEXT: {{^0*3000}} {{0*25}} R_X86_64_IRELATIVE [[#%x,RES:]]{{$}}
+# CHECK:      Relocation section '.rela.plt' {{.*}} contains 1 entries:
+# CHECK-NEXT: {{.*}}Offset
+# FIXED-NEXT: {{^0*3008}} {{0*25}} R_X86_64_IRELATIVE [[#RES]]{{$}}
+# MOVED-NEXT: {{^}}[[#%x,SITE:]] {{0*25}} R_X86_64_IRELATIVE [[#RES]]{{$}}
+# CHECK:      Symbol table '.symtab'
+# CHECK: {{^ *[0-9]+: +0*}}[[#RES]] 8 FUNC {{.*}} resolver{{$}}
+# CHECK: {{^ *[0-9]+: +0*3000}} 8 OBJECT {{.*}} ptr_dyn{{$}}
+# FIXED: {{^ *[0-9]+: +0*3008}} 8 OBJECT {{.*}} ptr_plt{{$}}
+# MOVED: {{^ *[0-9]+: +0*}}[[#SITE]] 8 OBJECT {{.*}} ptr_plt{{$}}
+
+## Check movement separately: CHECK-NOT cannot reject text consumed by a
+## positive match. With no following positive checks, these NOT patterns cover
+## the entire symbol table and only reject the old addresses of these symbols.
+# ADDR:           Symbol table '.symtab'
+# ADDR-NOT:       {{^ *[0-9]+: +0*1008 +.* resolver$}}
+# MOVED-ADDR-NOT: {{^ *[0-9]+: +0*3008 +.* ptr_plt$}}
+
+#--- profile.fdata
+4 entry 0 4 ptr_plt 0 100
+#--- input.yaml
+## .text contains:
+## entry:          mov ptr_plt(%rip), %rax; ret
+## resolver:       lea implementation(%rip), %rax; ret
+## implementation: ret
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_DYN
+  Machine: EM_X86_64
+ProgramHeaders:
+  - Type:     PT_LOAD
+    Flags:    [ PF_R, PF_W, PF_X ]
+    FirstSec: .dynsym
+    LastSec:  .data
+    VAddr:    0
+    Offset:   0
+    Align:    0x1000
+  - Type:     PT_DYNAMIC
+    Flags:    [ PF_R, PF_W ]
+    FirstSec: .dynamic
+    LastSec:  .dynamic
+    VAddr:    0x2000
+    Align:    8
+Sections:
+  - Name:    .dynsym
+    Type:    SHT_DYNSYM
+    Flags:   [ SHF_ALLOC ]
+    Address: 0x200
+    Offset:  0x200
+    Link:    .dynstr
+  - Name:    .dynstr
+    Type:    SHT_STRTAB
+    Flags:   [ SHF_ALLOC ]
+    Address: 0x230
+    Offset:  0x230
+  - Name:    .rela.dyn
+    Type:    SHT_RELA
+    Flags:   [ SHF_ALLOC ]
+    Address: 0x240
+    Offset:  0x240
+    Link:    .dynsym
+    Relocations:
+      - Offset: 0x3000
+        Type:   R_X86_64_IRELATIVE
+        Addend: 0x1008
+  - Name:    .rela.plt
+    Type:    SHT_RELA
+    Flags:   [ SHF_ALLOC ]
+    Address: 0x258
+    Offset:  0x258
+    Link:    .dynsym
+    Relocations:
+      - Offset: 0x3008
+        Type:   R_X86_64_IRELATIVE
+        Addend: 0x1008
+  - Name:    .text
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address: 0x1000
+    Offset:  0x1000
+    Content: 488B0501200000C3488D0501000000C3C3
+  - Name:    .dynamic
+    Type:    SHT_DYNAMIC
+    Flags:   [ SHF_ALLOC, SHF_WRITE ]
+    Address: 0x2000
+    Offset:  0x2000
+    Link:    .dynstr
+    Entries:
+      - Tag: DT_RELA
+        Value: 0x240
+      - Tag: DT_RELASZ
+        Value: 24
+      - Tag: DT_RELAENT
+        Value: 24
+      - Tag: DT_JMPREL
+        Value: 0x258
+      - Tag: DT_PLTRELSZ
+        Value: 24
+      - Tag: DT_PLTREL
+        Value: 7
+      - Tag: DT_SYMTAB
+        Value: 0x200
+      - Tag: DT_SYMENT
+        Value: 24
+      - Tag: DT_STRTAB
+        Value: 0x230
+      - Tag: DT_STRSZ
+        Value: 7
+      - Tag: DT_NULL
+        Value: 0
+  - Name:    .data
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_WRITE ]
+    Address: 0x3000
+    Offset:  0x3000
+    Content: '00000000000000000000000000000000'
+  - Name: .rela.text
+    Type: SHT_RELA
+    Link: .symtab
+    Info: .text
+    Relocations:
+      - Offset: 0x1003
+        Symbol: ptr_plt
+        Type:   R_X86_64_PC32
+        Addend: -4
+Symbols:
+  - Name: entry
+    Type: STT_FUNC
+    Binding: STB_GLOBAL
+    Section: .text
+    Value: 0x1000
+    Size: 8
+  - Name: resolver
+    Type: STT_FUNC
+    Binding: STB_GLOBAL
+    Section: .text
+    Value: 0x1008
+    Size: 8
+  - Name: implementation
+    Type: STT_FUNC
+    Binding: STB_GLOBAL
+    Section: .text
+    Value: 0x1010
+    Size: 1
+  - Name: ptr_dyn
+    Type: STT_OBJECT
+    Binding: STB_GLOBAL
+    Section: .data
+    Value: 0x3000
+    Size: 8
+  - Name: ptr_plt
+    Type: STT_OBJECT
+    Binding: STB_GLOBAL
+    Section: .data
+    Value: 0x3008
+    Size: 8
+DynamicSymbols:
+  - Name: entry
+    Type: STT_FUNC
+    Binding: STB_GLOBAL
+    Section: .text
+    Value: 0x1000
+    Size: 8


### PR DESCRIPTION
For glibc, the relocation entries of R_X86_64_IRELATIVE exits in both .rela.dyn and .rela.plt.
Therefore, these relocation entries cannot be distinguished which section they belong to based only on the relocation type.

fixes: #63069  
fixes: #85567