### PR TITLE
[SelectionDAGISel] Use size_t for MatcherIndex. NFC

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -2729,7 +2729,7 @@ void SelectionDAGISel::Select_PATCHPOINT(SDNode *N) {
 
 /// GetVBR - decode a vbr encoding whose top bit is set.
 LLVM_ATTRIBUTE_ALWAYS_INLINE static uint64_t
-GetVBR(uint64_t Val, const uint8_t *MatcherTable, unsigned &Idx) {
+GetVBR(uint64_t Val, const uint8_t *MatcherTable, size_t &Idx) {
   assert(Val >= 128 && "Not a VBR");
   Val &= 127;  // Remove first vbr bit.
 
@@ -2745,7 +2745,7 @@ GetVBR(uint64_t Val, const uint8_t *MatcherTable, unsigned &Idx) {
 }
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE static int64_t
-GetSignedVBR(const unsigned char *MatcherTable, unsigned &Idx) {
+GetSignedVBR(const unsigned char *MatcherTable, size_t &Idx) {
   int64_t Val = 0;
   unsigned Shift = 0;
   uint64_t NextBits;
@@ -2764,7 +2764,7 @@ GetSignedVBR(const unsigned char *MatcherTable, unsigned &Idx) {
 /// getSimpleVT - Decode a value in MatcherTable, if it's a VBR encoded value,
 /// use GetVBR to decode it.
 LLVM_ATTRIBUTE_ALWAYS_INLINE static MVT::SimpleValueType
-getSimpleVT(const uint8_t *MatcherTable, unsigned &MatcherIndex) {
+getSimpleVT(const uint8_t *MatcherTable, size_t &MatcherIndex) {
   unsigned SimpleVT = MatcherTable[MatcherIndex++];
   if (SimpleVT & 128)
     SimpleVT = GetVBR(SimpleVT, MatcherTable, MatcherIndex);
@@ -2774,7 +2774,7 @@ getSimpleVT(const uint8_t *MatcherTable, unsigned &MatcherIndex) {
 
 /// Decode a HwMode VT in MatcherTable by calling getValueTypeForHwMode.
 LLVM_ATTRIBUTE_ALWAYS_INLINE static MVT
-getHwModeVT(const uint8_t *MatcherTable, unsigned &MatcherIndex,
+getHwModeVT(const uint8_t *MatcherTable, size_t &MatcherIndex,
             const SelectionDAGISel &SDISel) {
   unsigned Index = MatcherTable[MatcherIndex++];
   return SDISel.getValueTypeForHwMode(Index);
@@ -2976,7 +2976,7 @@ MorphNode(SDNode *Node, unsigned TargetOpc, SDVTList VTList,
 
 /// CheckSame - Implements OP_CheckSame.
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool
-CheckSame(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N,
+CheckSame(const uint8_t *MatcherTable, size_t &MatcherIndex, SDValue N,
           const SmallVectorImpl<std::pair<SDValue, SDNode *>> &RecordedNodes) {
   // Accept if it is exactly the same as a previously recorded node.
   unsigned RecNo = MatcherTable[MatcherIndex++];
@@ -2986,7 +2986,7 @@ CheckSame(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N,
 
 /// CheckChildSame - Implements OP_CheckChildXSame.
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool CheckChildSame(
-    const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N,
+    const uint8_t *MatcherTable, size_t &MatcherIndex, SDValue N,
     const SmallVectorImpl<std::pair<SDValue, SDNode *>> &RecordedNodes,
     unsigned ChildNo) {
   if (ChildNo >= N.getNumOperands())
@@ -2998,7 +2998,7 @@ LLVM_ATTRIBUTE_ALWAYS_INLINE static bool CheckChildSame(
 /// CheckPatternPredicate - Implements OP_CheckPatternPredicate.
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool
 CheckPatternPredicate(unsigned Opcode, const uint8_t *MatcherTable,
-                      unsigned &MatcherIndex, const SelectionDAGISel &SDISel) {
+                      size_t &MatcherIndex, const SelectionDAGISel &SDISel) {
   bool TwoBytePredNo =
       Opcode == SelectionDAGISel::OPC_CheckPatternPredicateTwoByte;
   unsigned PredNo =
@@ -3013,7 +3013,7 @@ CheckPatternPredicate(unsigned Opcode, const uint8_t *MatcherTable,
 /// CheckNodePredicate - Implements OP_CheckNodePredicate.
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool
 CheckNodePredicate(unsigned Opcode, const uint8_t *MatcherTable,
-                   unsigned &MatcherIndex, const SelectionDAGISel &SDISel,
+                   size_t &MatcherIndex, const SelectionDAGISel &SDISel,
                    SDValue Op) {
   unsigned PredNo = Opcode == SelectionDAGISel::OPC_CheckPredicate
                         ? MatcherTable[MatcherIndex++]
@@ -3022,7 +3022,7 @@ CheckNodePredicate(unsigned Opcode, const uint8_t *MatcherTable,
 }
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool
-CheckOpcode(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDNode *N) {
+CheckOpcode(const uint8_t *MatcherTable, size_t &MatcherIndex, SDNode *N) {
   uint16_t Opc = MatcherTable[MatcherIndex++];
   Opc |= static_cast<uint16_t>(MatcherTable[MatcherIndex++]) << 8;
   return N->getOpcode() == Opc;
@@ -3048,13 +3048,13 @@ CheckChildType(MVT::SimpleValueType VT, SDValue N, const TargetLowering *TLI,
 }
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool
-CheckCondCode(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N) {
+CheckCondCode(const uint8_t *MatcherTable, size_t &MatcherIndex, SDValue N) {
   return cast<CondCodeSDNode>(N)->get() ==
          static_cast<ISD::CondCode>(MatcherTable[MatcherIndex++]);
 }
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool
-CheckChild2CondCode(const uint8_t *MatcherTable, unsigned &MatcherIndex,
+CheckChild2CondCode(const uint8_t *MatcherTable, size_t &MatcherIndex,
                     SDValue N) {
   if (2 >= N.getNumOperands())
     return false;
@@ -3062,7 +3062,7 @@ CheckChild2CondCode(const uint8_t *MatcherTable, unsigned &MatcherIndex,
 }
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool
-CheckValueType(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N,
+CheckValueType(const uint8_t *MatcherTable, size_t &MatcherIndex, SDValue N,
                const TargetLowering *TLI, const DataLayout &DL) {
   MVT::SimpleValueType VT = getSimpleVT(MatcherTable, MatcherIndex);
   if (cast<VTSDNode>(N)->getVT() == VT)
@@ -3073,7 +3073,7 @@ CheckValueType(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N,
 }
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool
-CheckInteger(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N) {
+CheckInteger(const uint8_t *MatcherTable, size_t &MatcherIndex, SDValue N) {
   int64_t Val = GetSignedVBR(MatcherTable, MatcherIndex);
 
   ConstantSDNode *C = dyn_cast<ConstantSDNode>(N);
@@ -3081,15 +3081,15 @@ CheckInteger(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N) {
 }
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool
-CheckChildInteger(const uint8_t *MatcherTable, unsigned &MatcherIndex,
-                  SDValue N, unsigned ChildNo) {
+CheckChildInteger(const uint8_t *MatcherTable, size_t &MatcherIndex, SDValue N,
+                  unsigned ChildNo) {
   if (ChildNo >= N.getNumOperands())
     return false;  // Match fails if out of range child #.
   return ::CheckInteger(MatcherTable, MatcherIndex, N.getOperand(ChildNo));
 }
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool
-CheckAndImm(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N,
+CheckAndImm(const uint8_t *MatcherTable, size_t &MatcherIndex, SDValue N,
             const SelectionDAGISel &SDISel) {
   int64_t Val = MatcherTable[MatcherIndex++];
   if (Val & 128)
@@ -3102,7 +3102,7 @@ CheckAndImm(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N,
 }
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool
-CheckOrImm(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N,
+CheckOrImm(const uint8_t *MatcherTable, size_t &MatcherIndex, SDValue N,
            const SelectionDAGISel &SDISel) {
   int64_t Val = MatcherTable[MatcherIndex++];
   if (Val & 128)
@@ -3120,8 +3120,8 @@ CheckOrImm(const uint8_t *MatcherTable, unsigned &MatcherIndex, SDValue N,
 /// known to pass, set Result=false and return the MatcherIndex to continue
 /// with.  If the current predicate is unknown, set Result=false and return the
 /// MatcherIndex to continue with.
-static unsigned IsPredicateKnownToFail(
-    const uint8_t *Table, unsigned Index, SDValue N, bool &Result,
+static size_t IsPredicateKnownToFail(
+    const uint8_t *Table, size_t Index, SDValue N, bool &Result,
     const SelectionDAGISel &SDISel,
     SmallVectorImpl<std::pair<SDValue, SDNode *>> &RecordedNodes) {
   unsigned Opcode = Table[Index++];
@@ -3475,7 +3475,7 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
   // but if the state machine starts with an OPC_SwitchOpcode, then we
   // accelerate the first lookup (which is guaranteed to be hot) with the
   // OpcodeOffset table.
-  unsigned MatcherIndex = 0;
+  size_t MatcherIndex = 0;
 
   if (!OpcodeOffset.empty()) {
     // Already computed the OpcodeOffset table, just index into it.
@@ -3487,7 +3487,7 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
     // Otherwise, the table isn't computed, but the state machine does start
     // with an OPC_SwitchOpcode instruction.  Populate the table now, since this
     // is the first time we're selecting an instruction.
-    unsigned Idx = 1;
+    size_t Idx = 1;
     while (true) {
       // Get the size of this case.
       unsigned CaseSize = MatcherTable[Idx++];
@@ -3512,7 +3512,7 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
   while (true) {
     assert(MatcherIndex < TableSize && "Invalid index");
 #ifndef NDEBUG
-    unsigned CurrentOpcodeIndex = MatcherIndex;
+    size_t CurrentOpcodeIndex = MatcherIndex;
 #endif
     BuiltinOpcodes Opcode =
         static_cast<BuiltinOpcodes>(MatcherTable[MatcherIndex++]);
@@ -3523,7 +3523,7 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
       // the first check fail (which then pops it) is inefficient.  If we can
       // determine immediately that the first check (or first several) will
       // immediately fail, don't even bother pushing a scope for them.
-      unsigned FailIndex;
+      size_t FailIndex;
 
       while (true) {
         unsigned NumToSkip = MatcherTable[MatcherIndex++];
@@ -3537,7 +3537,7 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
 
         FailIndex = MatcherIndex+NumToSkip;
 
-        unsigned MatcherIndexOfPredicate = MatcherIndex;
+        size_t MatcherIndexOfPredicate = MatcherIndex;
         (void)MatcherIndexOfPredicate; // silence warning.
 
         // If we can't evaluate this predicate without pushing a scope (e.g. if


### PR DESCRIPTION
There's some evidence that this improves compile time on stage2-O3. https://llvm-compile-time-tracker.com/compare.php?from=75f03a62d1f9b0081fff57ceebb29a3ae1560a61&to=d9cdb41d51f7010ba710403e2d1e30c969e4f88b&stat=instructions:u