### PR TITLE
[NFC] To fix comment in the code as getIntN no longer does truncation.

### DIFF
--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -531,7 +531,7 @@ public:
   /// Get a constant N-bit value, zero extended or truncated from
   /// a 64-bit value.
   ConstantInt *getIntN(unsigned N, uint64_t C) {
-    return ConstantInt::get(getIntNTy(N), C);
+    return ConstantInt::get(getIntNTy(N), C, false, true);
   }
 
   /// Get a constant integer value.

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -528,7 +528,7 @@ public:
     return ConstantInt::get(getInt64Ty(), C);
   }
 
-  /// Get a constant N-bit value, zero extended a 64-bit value. 
+  /// Get a constant N-bit value, zero extended a 64-bit value.
   ConstantInt *getIntN(unsigned N, uint64_t C) {
     return ConstantInt::get(getIntNTy(N), C);
   }

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -528,7 +528,7 @@ public:
     return ConstantInt::get(getInt64Ty(), C);
   }
 
-  /// Get a constant N-bit value, zero extended a 64-bit value.
+  /// Get a constant N-bit value, zero extended from a 64-bit value.
   ConstantInt *getIntN(unsigned N, uint64_t C) {
     return ConstantInt::get(getIntNTy(N), C);
   }

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -528,10 +528,9 @@ public:
     return ConstantInt::get(getInt64Ty(), C);
   }
 
-  /// Get a constant N-bit value, zero extended or truncated from
-  /// a 64-bit value.
+  /// Get a constant N-bit value, zero extended a 64-bit value. 
   ConstantInt *getIntN(unsigned N, uint64_t C) {
-    return ConstantInt::get(getIntNTy(N), C, false, true);
+    return ConstantInt::get(getIntNTy(N), C);
   }
 
   /// Get a constant integer value.


### PR DESCRIPTION
The comment of `getIntN` says it may truncate the result. However, PR #171456 changed the default of truncation of `ConstantInt::get` to false, so it no longer truncates. Fix the comments to reflect the change.