### PR TITLE
[MLIR][Shape] Fix crash in ShapeOfOp canonicalization during inlining

### DIFF
--- a/mlir/test/Dialect/Shape/canonicalize.mlir
+++ b/mlir/test/Dialect/Shape/canonicalize.mlir
@@ -1616,19 +1616,16 @@ func.func @shape_of_0d(%arg0: tensor<f32>) -> tensor<?xindex> {
 }
 
 
-// --------------------------------------------
-// ---- shape.shape_of canonicalize regression ----
+// -----
 
-// RUN: mlir-opt %s -canonicalize | FileCheck %s
-
-module {
-  func.func @main(%arg0: tensor<2x3xi32>) -> !shape.shape {
-    %0 = shape.shape_of %arg0 : tensor<2x3xi32> -> !shape.shape
-    return %0 : !shape.shape
-  }
-}
-
-// CHECK-LABEL: func.func @main
+// CHECK-LABEL: func.func @shape_of_canonicalize_regression
 // CHECK:       shape.const_shape [2, 3] : !shape.shape
-// CHECK-NOT:   shape.shape_of
-
+// CHECK:       shape.const_shape [2, 3] : tensor<2xindex>
+// CHECK:       tensor.cast
+func.func @shape_of_canonicalize_regression(%arg0: tensor<2x3xi32>)
+    -> (!shape.shape, tensor<2xindex>, tensor<?xindex>) {
+  %0 = shape.shape_of %arg0 : tensor<2x3xi32> -> !shape.shape
+  %1 = shape.shape_of %arg0 : tensor<2x3xi32> -> tensor<2xindex>
+  %2 = shape.shape_of %arg0 : tensor<2x3xi32> -> tensor<?xindex>
+  return %0, %1, %2 : !shape.shape, tensor<2xindex>, tensor<?xindex>
+}

--- a/mlir/test/Dialect/Shape/canonicalize.mlir
+++ b/mlir/test/Dialect/Shape/canonicalize.mlir
@@ -1614,3 +1614,21 @@ func.func @shape_of_0d(%arg0: tensor<f32>) -> tensor<?xindex> {
   %0 = shape.shape_of %arg0 : tensor<f32> -> tensor<?xindex>
   return %0 : tensor<?xindex>
 }
+
+
+// --------------------------------------------
+// ---- shape.shape_of canonicalize regression ----
+
+// RUN: mlir-opt %s -canonicalize | FileCheck %s
+
+module {
+  func.func @main(%arg0: tensor<2x3xi32>) -> !shape.shape {
+    %0 = shape.shape_of %arg0 : tensor<2x3xi32> -> !shape.shape
+    return %0 : !shape.shape
+  }
+}
+
+// CHECK-LABEL: func.func @main
+// CHECK:       shape.const_shape [2, 3] : !shape.shape
+// CHECK-NOT:   shape.shape_of
+


### PR DESCRIPTION
This fixes a crash in the Shape dialect canonicalization triggered when
running mlir-opt with --inline.

ShapeOfOpToConstShapeOp previously constructed a shape.const_shape with
a tensor result and attempted to tensor.cast it to !shape.shape, which is
invalid and triggers an assertion during inlining + canonicalization.

This change constructs shape.const_shape directly with the result type of
shape.shape_of, avoiding illegal cross-dialect casts.

A regression test is added to ensure shape.shape_of does not crash when
running the inliner.

Fixes #177840
