### PR TITLE
[MLIR][Arith] Fix crash in `arith.select` verification with mixed types

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
@@ -1742,7 +1742,9 @@ class BooleanConditionOrMatchingShape<string condition, string result> :
     PredOpTrait<
       condition # " is signless i1 or has matching shape",
       Or<[TypeIsPred<condition, I1>,
-          AllShapesMatch<[condition, result]>.predicate]>>;
+          And<[SubstLeaves<"$_self", "$" # condition # ".getType()", IsShapedTypePred>,
+               SubstLeaves<"$_self", "$" # result # ".getType()", IsShapedTypePred>,
+               AllShapesMatch<[condition, result]>.predicate]>]>>;
 
 def SelectOp : Arith_Op<"select", [Pure,
     AllTypesMatch<["true_value", "false_value", "result"]>,

--- a/mlir/test/Dialect/Arith/invalid.mlir
+++ b/mlir/test/Dialect/Arith/invalid.mlir
@@ -872,11 +872,8 @@ func.func @bitcast_index_1(%arg0 : index) -> i64 {
 
 // -----
 
-func.func @select_vector_condition_scalar_operands() {
-  %0 = vector.vscale
-  %1 = vector.constant_mask [1] : vector<1xi1>
-  %3 = arith.index_castui %0 : index to i32
+func.func @select_vector_condition_scalar_operands(%arg0: vector<1xi1>, %arg1: i32) {
   // expected-error @+1 {{'arith.select' op failed to verify that condition is signless i1 or has matching shape}}
-  %4 = arith.select %1, %3, %3 : vector<1xi1>, i32
+  %0 = arith.select %arg0, %arg1, %arg1 : vector<1xi1>, i32
   return
 }

--- a/mlir/test/Dialect/Arith/invalid.mlir
+++ b/mlir/test/Dialect/Arith/invalid.mlir
@@ -869,3 +869,14 @@ func.func @bitcast_index_1(%arg0 : index) -> i64 {
   %0 = arith.bitcast %arg0 : index to i64
   return %0 : i64
 }
+
+// -----
+
+func.func @select_vector_condition_scalar_operands() {
+  %0 = vector.vscale
+  %1 = vector.constant_mask [1] : vector<1xi1>
+  %3 = arith.index_castui %0 : index to i32
+  // expected-error @+1 {{'arith.select' op failed to verify that condition is signless i1 or has matching shape}}
+  %4 = arith.select %1, %3, %3 : vector<1xi1>, i32
+  return
+}


### PR DESCRIPTION
The `BooleanConditionOrMatchingShape` trait was assuming that if the condition was not i1, both condition and result must be `ShapedTypes`. It would then call `AllShapesMatch` which performs a blind cast to `ShapedType`, causing a crash when one of the operands was a scalar. This PATCH fixes the problem.

Closes [#178230](https://github.com/llvm/llvm-project/issues/178230)