### PR TITLE
[Flang][OpenMP] Reject INTENT(IN) pointers in LASTPRIVATE clause

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -4700,6 +4700,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Lastprivate &x) {
   SymbolSourceMap currSymbols;
   GetSymbolsInObjectList(objectList, currSymbols);
   CheckDefinableObjects(currSymbols, llvm::omp::Clause::OMPC_lastprivate);
+  CheckIntentInPointer(currSymbols, llvm::omp::Clause::OMPC_lastprivate);
   CheckCopyingPolymorphicAllocatable(
       currSymbols, llvm::omp::Clause::OMPC_lastprivate);
 

--- a/flang/test/Semantics/OpenMP/lastprivate-intent-in-pointer.f90
+++ b/flang/test/Semantics/OpenMP/lastprivate-intent-in-pointer.f90
@@ -1,0 +1,94 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp
+! OpenMP Version 4.5
+! 2.15.3.5 lastprivate Clause
+! Pointers with the INTENT(IN) attribute may not appear in a lastprivate clause.
+
+subroutine omp_lastprivate(p)
+  integer :: a(10), b(10), c(10)
+  integer, pointer, intent(in) :: p
+
+  a = 10
+  b = 20
+
+  !ERROR: Pointer 'p' with the INTENT(IN) attribute may not appear in a LASTPRIVATE clause
+  !$omp parallel do lastprivate(p)
+  do i = 1, 10
+    c(i) = a(i) + b(i) + p
+  end do
+  !$omp end parallel do
+
+  print *, c
+
+end subroutine omp_lastprivate
+
+subroutine omp_lastprivate_do(p)
+  integer :: a(10), b(10), c(10)
+  integer, pointer, intent(in) :: p
+
+  a = 10
+  b = 20
+
+  !$omp parallel
+  !ERROR: Pointer 'p' with the INTENT(IN) attribute may not appear in a LASTPRIVATE clause
+  !$omp do lastprivate(p)
+  do i = 1, 10
+    c(i) = a(i) + b(i) + p
+  end do
+  !$omp end do
+  !$omp end parallel
+
+  print *, c
+
+end subroutine omp_lastprivate_do
+
+subroutine omp_lastprivate_simd(p)
+  integer :: a(10), b(10), c(10)
+  integer, pointer, intent(in) :: p
+
+  a = 10
+  b = 20
+
+  !ERROR: Pointer 'p' with the INTENT(IN) attribute may not appear in a LASTPRIVATE clause
+  !$omp parallel do simd lastprivate(p)
+  do i = 1, 10
+    c(i) = a(i) + b(i) + p
+  end do
+  !$omp end parallel do simd
+
+  print *, c
+
+end subroutine omp_lastprivate_simd
+
+subroutine omp_lastprivate_sections(p)
+  integer :: a(10), b(10), c(10)
+  integer, pointer, intent(in) :: p
+
+  a = 10
+  b = 20
+
+  !ERROR: Pointer 'p' with the INTENT(IN) attribute may not appear in a LASTPRIVATE clause
+  !$omp sections lastprivate(p)
+  !$omp section
+    c = a + b + p
+  !$omp end sections
+
+  print *, c
+
+end subroutine omp_lastprivate_sections
+
+subroutine omp_lastprivate_parallel_sections(p)
+  integer :: a(10), b(10), c(10)
+  integer, pointer, intent(in) :: p
+
+  a = 10
+  b = 20
+
+  !ERROR: Pointer 'p' with the INTENT(IN) attribute may not appear in a LASTPRIVATE clause
+  !$omp parallel sections lastprivate(p)
+  !$omp section
+    c = a + b + p
+  !$omp end parallel sections
+
+  print *, c
+
+end subroutine omp_lastprivate_parallel_sections


### PR DESCRIPTION
`LASTPRIVATE` clause requires the list item to be definable since the value from the last iteration is assigned back to the original variable. For pointers, this assignment occurs "as if by pointer assignment" (OpenMP 5.2 Section 5.4.5).

An `INTENT(IN)` pointer dummy argument is not a valid target for pointer assignment, therefore it should not be permitted in a `LASTPRIVATE` clause.

This patch adds the `CheckIntentInPointer()` call to the `LASTPRIVATE` clause handler, consistent with other data-sharing clauses like `PRIVATE`, `COPYPRIVATE`, and `REDUCTION`.

Fixes [#178398](https://github.com/llvm/llvm-project/issues/178398)