### PR TITLE
[AArch64][GlobalISel] Exclude arm64 from failing tests

### DIFF
--- a/llvm/test/DebugInfo/Generic/debug-label-mi.ll
+++ b/llvm/test/DebugInfo/Generic/debug-label-mi.ll
@@ -2,7 +2,7 @@
 ; REQUIRES: asserts
 
 ; AArch64 uses GlobalISel for optnone functions meaning the output from 'isel' will be empty as it will not be run.
-; UNSUPPORTED: target=aarch64{{.*}}
+; UNSUPPORTED: target=aarch64{{.*}}, target=arm64{{.*}}
 
 ; RUN: llc -debug-only=isel %s -o /dev/null 2> %t.debug
 ; RUN: cat %t.debug | FileCheck %s --check-prefix=CHECKMI

--- a/llvm/test/Feature/optnone-llc.ll
+++ b/llvm/test/Feature/optnone-llc.ll
@@ -7,7 +7,7 @@
 
 ; REQUIRES: asserts, default_triple
 ; AArch64 uses GlobalISel for optnone functions meaning the output from 'isel' will be empty as it will not be run.
-; UNSUPPORTED: target=nvptx{{.*}}, target=aarch64{{.*}}
+; UNSUPPORTED: target=nvptx{{.*}}, target=aarch64{{.*}}, target=arm64{{.*}}
 
 ; This test verifies that we don't run Machine Function optimizations
 ; on optnone functions, and that we can turn off FastISel.


### PR DESCRIPTION
As pointed out by the buildbots & https://github.com/llvm/llvm-project/pull/174746#issuecomment-3821237987, some of the tests modified by https://github.com/llvm/llvm-project/pull/174746 are missing exclusions for arm64 target triples causing the builds to fail.

I have added these exclusions here.