### PR TITLE
[EntryExitInstrumenter] Mark CFG as preserved

### DIFF
--- a/llvm/lib/Transforms/Utils/EntryExitInstrumenter.cpp
+++ b/llvm/lib/Transforms/Utils/EntryExitInstrumenter.cpp
@@ -173,7 +173,7 @@ struct PostInlineEntryExitInstrumenter : public FunctionPass {
   }
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addPreserved<GlobalsAAWrapperPass>();
-    AU.addPreserved<DominatorTreeWrapperPass>();
+    AU.setPreservesCFG();
   }
   bool runOnFunction(Function &F) override { return ::runOnFunction(F, true); }
 };


### PR DESCRIPTION
This pass does not change the CFG, so mark all CFG analyses as preserved, instead of DT in particular. This matches what the NewPM implementation does.

(This currently has no direct benefit as nearby passes end up invalidating things anyway.)