### PR TITLE
[mlir] Verify childen interface in transform named sequence

### DIFF
--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -2507,6 +2507,17 @@ verifyNamedSequenceOp(transform::NamedSequenceOp op, bool emitWarnings) {
   if (op.getBody().front().empty())
     return emitSilenceableFailure(op) << "expected a non-empty body block";
 
+  // Check that all operations in the body implement TransformOpInterface
+  for (Operation &child : op.getBody().front().without_terminator()) {
+    if (!isa<transform::TransformOpInterface>(child)) {
+      DiagnosedSilenceableFailure diag =
+          emitSilenceableFailure(&child)
+          << "expected children ops to implement TransformOpInterface";
+      diag.attachNote(child.getLoc()) << "op without interface";
+      return diag;
+    }
+  }
+
   Operation *terminator = &op.getBody().front().back();
   if (!isa<transform::YieldOp>(terminator)) {
     DiagnosedSilenceableFailure diag = emitSilenceableFailure(op)

--- a/mlir/test/Dialect/Transform/ops-invalid.mlir
+++ b/mlir/test/Dialect/Transform/ops-invalid.mlir
@@ -51,6 +51,17 @@ transform.sequence failures(propagate) {
 
 // -----
 
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) {
+    // expected-error @+2 {{expected children ops to implement TransformOpInterface}}
+    // expected-note @below {{op without interface}}
+    "test.unknown_op" () : () -> ()
+    transform.yield
+  }
+}
+
+// -----
+
 // expected-error @below {{expects the types of the terminator operands to match the types of the result}}
 %0 = transform.sequence -> !transform.any_op failures(propagate) {
 ^bb0(%arg0: !transform.any_op):
@@ -500,7 +511,7 @@ module attributes { transform.with_named_sequence} {
   // expected-error @below {{expected 'transform.yield' as terminator}}
   transform.named_sequence @nested() {
     // expected-note @below {{terminator}}
-    func.call @foo() : () -> ()
+    func.return 
   }
 }
 

--- a/mlir/test/Dialect/Transform/test-interpreter.mlir
+++ b/mlir/test/Dialect/Transform/test-interpreter.mlir
@@ -1947,7 +1947,7 @@ module attributes { transform.with_named_sequence } {
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) {
     // expected-error @below {{expected operations in the match part to implement MatchOpInterface}}
-    "test.unknown_op"() : () -> ()
+    transform.test_transform_op
     transform.yield
   }
   transform.named_sequence @action() {


### PR DESCRIPTION
Application of sequence blocks in the transform interpreter assumes that all operations (except for the terminator) in the sequence block have the `TransformOpInterface`. For `SequenceOp`, this was already verified, but not for `NamedSequenceOp`, causing assertion failures if the assumption doesn't hold.

This change adds verification that all operations in the block except for the terminator have the `TransformOpInterface`.