### PR TITLE
IR: Add stub LLVMCreateDenormalFPEnvAttribute to C API

### DIFF
--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -732,6 +732,40 @@ LLVM_C_ABI LLVMAttributeRef LLVMCreateConstantRangeAttribute(
     const uint64_t LowerWords[], const uint64_t UpperWords[]);
 
 /**
+ * Represent different denormal handling kinds for use with
+ * LLVMCreateDenormalFPEnvAttribute.
+ */
+typedef enum {
+  LLVMDenormalModeKindIEEE = 0,
+  LLVMDenormalModeKindPreserveSign = 1,
+  LLVMDenormalModeKindPositiveZero = 2,
+  LLVMDenormalModeKindDynamic = 3
+} LLVMDenormalModeKind;
+
+/**
+ * Create a DenormalFPEnv attribute.
+ *
+ * \p DefaultModeOutput is the assumed denormal handling for the outputs of most
+ *    floating-point types.
+ *
+ * \p DefaultModeInput is the assumed denormal handling for the inputs of most
+ *    floating-point types.
+ *
+ * \p FloatModeOutput is the assumed denormal handling for the outputs of
+ *    float. This should always be the same as as DefaultModeOutput for most
+ *    targets.
+ *
+ * \p FloatModeInput is the assumed denormal handling for the inputs of
+ *    float. This should always be the same as as DefaultModeInput for most
+ *    targets.
+ *
+ */
+LLVM_C_ABI LLVMAttributeRef LLVMCreateDenormalFPEnvAttribute(
+    LLVMContextRef C, LLVMDenormalModeKind DefaultModeOutput,
+    LLVMDenormalModeKind DefaultModeInput, LLVMDenormalModeKind FloatModeOutput,
+    LLVMDenormalModeKind FloatModeInput);
+
+/**
  * Create a string attribute.
  */
 LLVM_C_ABI LLVMAttributeRef LLVMCreateStringAttribute(LLVMContextRef C,

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -209,6 +209,19 @@ LLVMAttributeRef LLVMCreateConstantRangeAttribute(LLVMContextRef C,
                     APInt(NumBits, ArrayRef(UpperWords, NumWords)))));
 }
 
+LLVMAttributeRef LLVMCreateDenormalFPEnvAttribute(
+    LLVMContextRef C, LLVMDenormalModeKind DefaultModeOutput,
+    LLVMDenormalModeKind DefaultModeInput, LLVMDenormalModeKind FloatModeOutput,
+    LLVMDenormalModeKind FloatModeInput) {
+  assert(DefaultModeOutput == LLVMDenormalModeKindIEEE &&
+         DefaultModeInput == LLVMDenormalModeKindIEEE &&
+         "staging API only supports setting float modes");
+
+  DenormalMode DM(static_cast<DenormalMode::DenormalModeKind>(FloatModeOutput),
+                  static_cast<DenormalMode::DenormalModeKind>(FloatModeInput));
+  return wrap(Attribute::get(*unwrap(C), "denormal-fp-math-f32", DM.str()));
+}
+
 LLVMAttributeRef LLVMCreateStringAttribute(LLVMContextRef C,
                                            const char *K, unsigned KLength,
                                            const char *V, unsigned VLength) {

--- a/llvm/unittests/IR/AttributesTest.cpp
+++ b/llvm/unittests/IR/AttributesTest.cpp
@@ -344,6 +344,24 @@ TEST(Attributes, ConstantRangeAttributeCAPI) {
   }
 }
 
+TEST(Attributes, DenormalFPEnvAttributeCAPI) {
+  LLVMContext C;
+  LLVMContextRef CtxC = wrap(&C);
+  {
+    LLVMAttributeRef CAttr = LLVMCreateDenormalFPEnvAttribute(
+        CtxC, LLVMDenormalModeKindIEEE, LLVMDenormalModeKindIEEE,
+        LLVMDenormalModeKindPreserveSign, LLVMDenormalModeKindPreserveSign);
+
+    Attribute OutAttr = unwrap(CAttr);
+
+    ASSERT_TRUE(OutAttr.isStringAttribute());
+    EXPECT_EQ(OutAttr.getKindAsString(), "denormal-fp-math-f32");
+
+    StringRef Val = OutAttr.getValueAsString();
+    EXPECT_EQ(parseDenormalFPAttribute(Val), DenormalMode::getPreserveSign());
+  }
+}
+
 TEST(Attributes, CalleeAttributes) {
   const char *IRString = R"IR(
     declare void @f1(i32 %i)


### PR DESCRIPTION
This is a staging commit for #174293 to avoid an intermediate
break of the mesa build when committed. Implement just enough
of the API in terms of the old attributes to avoid breaking
the mesa use. #174293 will then implement the full API in terms
of the new attribute.