### PR TITLE
[flang] Fix proc ptr default initializers in structure constructors

### DIFF
--- a/flang/test/Semantics/bug178813.f90
+++ b/flang/test/Semantics/bug178813.f90
@@ -1,0 +1,8 @@
+!RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
+external s
+type t
+  procedure(), nopass, pointer :: p => s
+end type
+!CHECK: TYPE(t) :: x = t(p=s)
+type(t) :: x = t()
+end


### PR DESCRIPTION
The default initializers for procedure pointer components are not being used for unspecified components in structure constructors.

Fixes https://github.com/llvm/llvm-project/issues/178813.