### PR TITLE
[Offload] Make the RPC callbacks private to each running server

### DIFF
--- a/offload/plugins-nextgen/common/include/RPC.h
+++ b/offload/plugins-nextgen/common/include/RPC.h
@@ -17,6 +17,7 @@
 #define OPENMP_LIBOMPTARGET_PLUGINS_NEXTGEN_COMMON_RPC_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Error.h"
 
 #include <atomic>
@@ -80,6 +81,9 @@ private:
   /// Mutex that guards accesses to the buffers and device array.
   std::mutex BufferMutex{};
 
+  /// A list of callbacks the server will attempt to handle.
+  llvm::SmallSetVector<RPCServerCallbackTy, 0> Callbacks;
+
   /// A helper class for running the user thread that handles the RPC interface.
   /// Because we only need to check the RPC server while any kernels are
   /// working, we track submission / completion events to allow the thread to
@@ -101,6 +105,9 @@ private:
     /// A reference to the main server's mutex.
     std::mutex &BufferMutex;
 
+    /// A reference to the main server's callbacks.
+    llvm::SmallSetVector<RPCServerCallbackTy, 0> &Callbacks;
+
     /// A reference to all the RPC interfaces that the server is handling.
     llvm::ArrayRef<void *> Buffers;
 
@@ -109,9 +116,11 @@ private:
 
     /// Initialize the worker thread to run in the background.
     ServerThread(void *Buffers[], plugin::GenericDeviceTy *Devices[],
-                 size_t Length, std::mutex &BufferMutex)
+                 size_t Length, std::mutex &BufferMutex,
+                 llvm::SmallSetVector<RPCServerCallbackTy, 0> &Callbacks)
         : Running(false), NumUsers(0), CV(), Mutex(), BufferMutex(BufferMutex),
-          Buffers(Buffers, Length), Devices(Devices, Length) {}
+          Callbacks(Callbacks), Buffers(Buffers, Length),
+          Devices(Devices, Length) {}
 
     ~ServerThread() { assert(!Running && "Thread not shut down explicitly\n"); }
 

--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -21,12 +21,6 @@ using namespace llvm;
 using namespace omp;
 using namespace target;
 
-// List of user generated callbacks for the RPC server.
-static llvm::SmallVector<RPCServerTy::RPCServerCallbackTy> &getRPCCallbacks() {
-  static llvm::SmallVector<RPCServerTy::RPCServerCallbackTy> Callbacks;
-  return Callbacks;
-}
-
 template <uint32_t NumLanes>
 rpc::Status handleOffloadOpcodes(plugin::GenericDeviceTy &Device,
                                  rpc::Server::Port &Port) {
@@ -89,8 +83,10 @@ static rpc::Status handleOffloadOpcodes(plugin::GenericDeviceTy &Device,
     return rpc::RPC_ERROR;
 }
 
-static rpc::Status runServer(plugin::GenericDeviceTy &Device, void *Buffer,
-                             bool &ClientInUse) {
+static rpc::Status
+runServer(plugin::GenericDeviceTy &Device, void *Buffer,
+          llvm::SmallSetVector<RPCServerTy::RPCServerCallbackTy, 0> &Callbacks,
+          bool &ClientInUse) {
   const uint64_t NumPorts =
       std::min(Device.requestedRPCPortCount(), rpc::MAX_PORT_COUNT);
   rpc::Server Server(NumPorts, Buffer);
@@ -103,7 +99,7 @@ static rpc::Status runServer(plugin::GenericDeviceTy &Device, void *Buffer,
   rpc::Status Status = rpc::RPC_UNHANDLED_OPCODE;
   const uint32_t NumLanes = Device.getWarpSize();
 
-  for (RPCServerTy::RPCServerCallbackTy Callback : getRPCCallbacks()) {
+  for (RPCServerTy::RPCServerCallbackTy Callback : Callbacks) {
     Status = static_cast<rpc::Status>(Callback(&*Port, NumLanes));
     if (Status != rpc::RPC_UNHANDLED_OPCODE)
       break;
@@ -169,7 +165,8 @@ void RPCServerTy::ServerThread::run() {
           continue;
 
         // If running the server failed, print a message but keep running.
-        if (runServer(*Device, Buffer, ClientInUse) != rpc::RPC_SUCCESS)
+        if (runServer(*Device, Buffer, Callbacks, ClientInUse) !=
+            rpc::RPC_SUCCESS)
           FAILURE_MESSAGE("Unhandled or invalid RPC opcode!");
       }
     }
@@ -182,7 +179,8 @@ RPCServerTy::RPCServerTy(plugin::GenericPluginTy &Plugin)
       Devices(std::make_unique<plugin::GenericDeviceTy *[]>(
           Plugin.getNumDevices())),
       Thread(new ServerThread(Buffers.get(), Devices.get(),
-                              Plugin.getNumDevices(), BufferMutex)) {}
+                              Plugin.getNumDevices(), BufferMutex, Callbacks)) {
+}
 
 llvm::Error RPCServerTy::startThread() {
   Thread->startThread();
@@ -246,5 +244,5 @@ Error RPCServerTy::deinitDevice(plugin::GenericDeviceTy &Device) {
 
 void RPCServerTy::registerCallback(RPCServerCallbackTy FnPtr) {
   std::lock_guard<decltype(BufferMutex)> Lock(BufferMutex);
-  getRPCCallbacks().push_back(FnPtr);
+  Callbacks.insert(FnPtr);
 }


### PR DESCRIPTION
Summary:
The static object mixes callbacks from different plugins because ever
since we moved to the object library target these are actually shared.
Just make it a member of the base class and make it a pointer set just
to do some basic deduplication.
