### PR TITLE
[AArch64][GlobalISel] Add GISel handling for FCVT fixed.

### DIFF
--- a/llvm/include/llvm/Target/GlobalISel/Target.td
+++ b/llvm/include/llvm/Target/GlobalISel/Target.td
@@ -22,8 +22,11 @@ class LLT;
 
 def s32 : LLT;
 def s64 : LLT;
+def v2s64 : LLT;
 def v2s32 : LLT;
+def v4s32 : LLT;
 def v4s16 : LLT;
+def v8s16 : LLT;
 def v8s8 : LLT;
 
 // Defines a matcher for complex operands. This is analogous to ComplexPattern

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -9116,12 +9116,25 @@ def fixedpoint_vec_xform : SDNodeXForm<timm, [{
   (void)N;
   return V;
 }]>;
+def gi_fixedpoint_vec_xform : GICustomOperandRenderer<"renderFixedPointXForm">,
+  GISDNodeXFormEquiv<fixedpoint_vec_xform>;
 
 def fixedpoint_v2f64 : fixedpoint_vec_f64<v2f64>;
 def fixedpoint_v2f32 : fixedpoint_vec_f32<v2f32>;
 def fixedpoint_v4f32 : fixedpoint_vec_f32<v4f32>;
 def fixedpoint_v4f16 : fixedpoint_vec_f16<v4f16>;
 def fixedpoint_v8f16 : fixedpoint_vec_f16<v8f16>;
+
+def gi_fixedpoint_v2f64 : GIComplexOperandMatcher<v2s64, "selectCVTFixedPointVec">,
+                          GIComplexPatternEquiv<fixedpoint_v2f64>;
+def gi_fixedpoint_v2f32 : GIComplexOperandMatcher<v2s32, "selectCVTFixedPointVec">,
+                          GIComplexPatternEquiv<fixedpoint_v2f32>;
+def gi_fixedpoint_v4f32 : GIComplexOperandMatcher<v4s32, "selectCVTFixedPointVec">,
+                          GIComplexPatternEquiv<fixedpoint_v4f32>;
+def gi_fixedpoint_v4f16 : GIComplexOperandMatcher<v4s16, "selectCVTFixedPointVec">,
+                          GIComplexPatternEquiv<fixedpoint_v4f16>;
+def gi_fixedpoint_v8f16 : GIComplexOperandMatcher<v8s16, "selectCVTFixedPointVec">,
+                          GIComplexPatternEquiv<fixedpoint_v8f16>;
 
 let Predicates = [HasNEON] in {
 def : Pat<(v2f32 (sint_to_fp (v2i32 (AArch64vashr_exact v2i32:$Vn, i32:$shift)))),
@@ -9161,11 +9174,15 @@ multiclass FCVTPat<ValueType FVT, ValueType IVT, ValueType ScalarVT, RegisterOpe
             (!cast<Instruction>("FCVTZS"#IVT#"_shift") $Vn, (fixedpoint_vec_xform fixedpoint:$scale))>;
   def : Pat<(IVT (fp_to_sint_sat (FVT (fmul FVT:$Vn, fixedpoint:$scale)), ScalarVT)),
             (!cast<Instruction>("FCVTZS"#IVT#"_shift") $Vn, (fixedpoint_vec_xform fixedpoint:$scale))>;
+  def : Pat<(IVT (fp_to_sint_sat_gi (FVT (fmul FVT:$Vn, fixedpoint:$scale)))),
+            (!cast<Instruction>("FCVTZS"#IVT#"_shift") $Vn, (fixedpoint_vec_xform fixedpoint:$scale))>;
 
   // fptoui(fmul(x, power2)) -> FCVTZU_shift x, log2(power2)
   def : Pat<(IVT (fp_to_uint (FVT (fmul FVT:$Vn, fixedpoint:$scale)))),
             (!cast<Instruction>("FCVTZU"#IVT#"_shift") $Vn, (fixedpoint_vec_xform fixedpoint:$scale))>;
   def : Pat<(IVT (fp_to_uint_sat (FVT (fmul FVT:$Vn, fixedpoint:$scale)), ScalarVT)),
+            (!cast<Instruction>("FCVTZU"#IVT#"_shift") $Vn, (fixedpoint_vec_xform fixedpoint:$scale))>;
+  def : Pat<(IVT (fp_to_uint_sat_gi (FVT (fmul FVT:$Vn, fixedpoint:$scale)))),
             (!cast<Instruction>("FCVTZU"#IVT#"_shift") $Vn, (fixedpoint_vec_xform fixedpoint:$scale))>;
 }
 

--- a/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
+++ b/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
@@ -19,6 +19,8 @@
 // FIXME: Is it easiest to fix this layering violation by moving the .inc
 // #includes from AArch64MCTargetDesc.h to here?
 #include "MCTargetDesc/AArch64MCTargetDesc.h" // For AArch64::X0 and friends.
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -245,6 +247,38 @@ static inline bool atomicBarrierDroppedOnZero(unsigned Opcode) {
     return true;
   }
   return false;
+}
+
+inline unsigned CheckFixedPointOperandConstant(APFloat &FVal, unsigned RegWidth,
+                                               bool isReciprocal) {
+  // An FCVT[SU] instruction performs: convertToInt(Val * 2^fbits) where fbits
+  // is between 1 and 32 for a destination w-register, or 1 and 64 for an
+  // x-register.
+  //
+  // By this stage, we've detected (fp_to_[su]int (fmul Val, THIS_NODE)) so we
+  // want THIS_NODE to be 2^fbits. This is much easier to deal with using
+  // integers.
+  bool IsExact;
+
+  if (isReciprocal)
+    if (!FVal.getExactInverse(&FVal))
+      return 0;
+
+  // fbits is between 1 and 64 in the worst-case, which means the fmul
+  // could have 2^64 as an actual operand. Need 65 bits of precision.
+  APSInt IntVal(65, true);
+  FVal.convertToInteger(IntVal, APFloat::rmTowardZero, &IsExact);
+
+  // N.b. isPowerOf2 also checks for > 0.
+  if (!IsExact || !IntVal.isPowerOf2())
+    return 0;
+  unsigned FBits = IntVal.logBase2();
+
+  // Checks above should have guaranteed that we haven't lost information in
+  // finding FBits, but it must still be in range.
+  if (FBits == 0 || FBits > RegWidth)
+    return 0;
+  return FBits;
 }
 
 namespace AArch64CC {

--- a/llvm/test/CodeGen/AArch64/fcvt_combine.ll
+++ b/llvm/test/CodeGen/AArch64/fcvt_combine.ll
@@ -5,89 +5,30 @@
 ; RUN: llc -mtriple=aarch64-linux-gnu -mattr=+fullfp16 -verify-machineinstrs -global-isel -o - %s | FileCheck %s --check-prefixes=CHECK,CHECK-FP16,CHECK-FP16-GI
 
 define <2 x i32> @test1(<2 x float> %f) {
-; CHECK-NO16-SD-LABEL: test1:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.2s, v0.2s, #4
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test1:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.2s, v0.2s, #4
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test1:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-NO16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.2s, v0.2s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test1:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-FP16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.2s, v0.2s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test1:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.2s, v0.2s, #4
+; CHECK-NEXT:    ret
   %mul.i = fmul <2 x float> %f, <float 16.000000e+00, float 16.000000e+00>
   %vcvt.i = fptosi <2 x float> %mul.i to <2 x i32>
   ret <2 x i32> %vcvt.i
 }
 
 define <4 x i32> @test2(<4 x float> %f) {
-; CHECK-NO16-SD-LABEL: test2:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.4s, v0.4s, #3
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test2:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.4s, v0.4s, #3
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test2:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #8.00000000
-; CHECK-NO16-GI-NEXT:    fmul v0.4s, v0.4s, v1.s[0]
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test2:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #8.00000000
-; CHECK-FP16-GI-NEXT:    fmul v0.4s, v0.4s, v1.s[0]
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test2:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.4s, v0.4s, #3
+; CHECK-NEXT:    ret
   %mul.i = fmul <4 x float> %f, <float 8.000000e+00, float 8.000000e+00, float 8.000000e+00, float 8.000000e+00>
   %vcvt.i = fptosi <4 x float> %mul.i to <4 x i32>
   ret <4 x i32> %vcvt.i
 }
 
 define <2 x i64> @test3(<2 x double> %d) {
-; CHECK-NO16-SD-LABEL: test3:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.2d, v0.2d, #5
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test3:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.2d, v0.2d, #5
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test3:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    mov x8, #4629700416936869888 // =0x4040000000000000
-; CHECK-NO16-GI-NEXT:    fmov d1, x8
-; CHECK-NO16-GI-NEXT:    fmul v0.2d, v0.2d, v1.d[0]
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.2d, v0.2d
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test3:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    mov x8, #4629700416936869888 // =0x4040000000000000
-; CHECK-FP16-GI-NEXT:    fmov d1, x8
-; CHECK-FP16-GI-NEXT:    fmul v0.2d, v0.2d, v1.d[0]
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.2d, v0.2d
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test3:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.2d, v0.2d, #5
+; CHECK-NEXT:    ret
   %mul.i = fmul <2 x double> %d, <double 32.000000e+00, double 32.000000e+00>
   %vcvt.i = fptosi <2 x double> %mul.i to <2 x i64>
   ret <2 x i64> %vcvt.i
@@ -95,33 +36,11 @@ define <2 x i64> @test3(<2 x double> %d) {
 
 ; Truncate double to i32
 define <2 x i32> @test4(<2 x double> %d) {
-; CHECK-NO16-SD-LABEL: test4:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.2d, v0.2d, #4
-; CHECK-NO16-SD-NEXT:    xtn v0.2s, v0.2d
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test4:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.2d, v0.2d, #4
-; CHECK-FP16-SD-NEXT:    xtn v0.2s, v0.2d
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test4:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov d1, #16.00000000
-; CHECK-NO16-GI-NEXT:    fmul v0.2d, v0.2d, v1.d[0]
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.2d, v0.2d
-; CHECK-NO16-GI-NEXT:    xtn v0.2s, v0.2d
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test4:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov d1, #16.00000000
-; CHECK-FP16-GI-NEXT:    fmul v0.2d, v0.2d, v1.d[0]
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.2d, v0.2d
-; CHECK-FP16-GI-NEXT:    xtn v0.2s, v0.2d
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test4:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.2d, v0.2d, #4
+; CHECK-NEXT:    xtn v0.2s, v0.2d
+; CHECK-NEXT:    ret
   %mul.i = fmul <2 x double> %d, <double 16.000000e+00, double 16.000000e+00>
   %vcvt.i = fptosi <2 x double> %mul.i to <2 x i32>
   ret <2 x i32> %vcvt.i
@@ -129,29 +48,10 @@ define <2 x i32> @test4(<2 x double> %d) {
 
 ; Truncate float to i16
 define <2 x i16> @test5(<2 x float> %f) {
-; CHECK-NO16-SD-LABEL: test5:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.2s, v0.2s, #4
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test5:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.2s, v0.2s, #4
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test5:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-NO16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.2s, v0.2s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test5:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-FP16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.2s, v0.2s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test5:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.2s, v0.2s, #4
+; CHECK-NEXT:    ret
   %mul.i = fmul <2 x float> %f, <float 16.000000e+00, float 16.000000e+00>
   %vcvt.i = fptosi <2 x float> %mul.i to <2 x i16>
   ret <2 x i16> %vcvt.i
@@ -196,29 +96,10 @@ define <2 x i64> @test6(<2 x float> %f) {
 }
 
 define <2 x i32> @test7(<2 x float> %f) {
-; CHECK-NO16-SD-LABEL: test7:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzu v0.2s, v0.2s, #4
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test7:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzu v0.2s, v0.2s, #4
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test7:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-NO16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-NO16-GI-NEXT:    fcvtzu v0.2s, v0.2s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test7:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-FP16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-FP16-GI-NEXT:    fcvtzu v0.2s, v0.2s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test7:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzu v0.2s, v0.2s, #4
+; CHECK-NEXT:    ret
   %mul.i = fmul <2 x float> %f, <float 16.000000e+00, float 16.000000e+00>
   %vcvt.i = fptoui <2 x float> %mul.i to <2 x i32>
   ret <2 x i32> %vcvt.i
@@ -406,31 +287,10 @@ define <2 x i32> @test13(<2 x float> %f) {
 
 ; Test case where const is max power of 2 (i.e., 2^32).
 define <2 x i32> @test14(<2 x float> %f) {
-; CHECK-NO16-SD-LABEL: test14:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.2s, v0.2s, #32
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test14:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.2s, v0.2s, #32
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test14:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    mov w8, #1333788672 // =0x4f800000
-; CHECK-NO16-GI-NEXT:    fmov s1, w8
-; CHECK-NO16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.2s, v0.2s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test14:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    mov w8, #1333788672 // =0x4f800000
-; CHECK-FP16-GI-NEXT:    fmov s1, w8
-; CHECK-FP16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.2s, v0.2s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test14:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.2s, v0.2s, #32
+; CHECK-NEXT:    ret
   %mul.i = fmul <2 x float> %f, <float 0x41F0000000000000, float 0x41F0000000000000>
   %vcvt.i = fptosi <2 x float> %mul.i to <2 x i32>
   ret <2 x i32> %vcvt.i
@@ -490,10 +350,10 @@ define <8 x i16> @test_v8f16(<8 x half> %in) {
 ; CHECK-NO16-SD-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
 ; CHECK-NO16-SD-NEXT:    ret
 ;
-; CHECK-FP16-SD-LABEL: test_v8f16:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.8h, v0.8h, #2
-; CHECK-FP16-SD-NEXT:    ret
+; CHECK-FP16-LABEL: test_v8f16:
+; CHECK-FP16:       // %bb.0:
+; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h, #2
+; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-NO16-GI-LABEL: test_v8f16:
 ; CHECK-NO16-GI:       // %bb.0:
@@ -511,13 +371,6 @@ define <8 x i16> @test_v8f16(<8 x half> %in) {
 ; CHECK-NO16-GI-NEXT:    fcvtzs v0.4s, v0.4s
 ; CHECK-NO16-GI-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
 ; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test_v8f16:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    movi v1.8h, #68, lsl #8
-; CHECK-FP16-GI-NEXT:    fmul v0.8h, v0.8h, v1.8h
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.8h, v0.8h
-; CHECK-FP16-GI-NEXT:    ret
   %scale = fmul <8 x half> %in, <half 4.0, half 4.0, half 4.0, half 4.0, half 4.0, half 4.0, half 4.0, half 4.0>
   %val = fptosi <8 x half> %scale to <8 x i16>
   ret <8 x i16> %val
@@ -535,10 +388,10 @@ define <4 x i16> @test_v4f16(<4 x half> %in) {
 ; CHECK-NO16-SD-NEXT:    xtn v0.4h, v0.4s
 ; CHECK-NO16-SD-NEXT:    ret
 ;
-; CHECK-FP16-SD-LABEL: test_v4f16:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzu v0.4h, v0.4h, #2
-; CHECK-FP16-SD-NEXT:    ret
+; CHECK-FP16-LABEL: test_v4f16:
+; CHECK-FP16:       // %bb.0:
+; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h, #2
+; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-NO16-GI-LABEL: test_v4f16:
 ; CHECK-NO16-GI:       // %bb.0:
@@ -551,13 +404,6 @@ define <4 x i16> @test_v4f16(<4 x half> %in) {
 ; CHECK-NO16-GI-NEXT:    fcvtzu v0.4s, v0.4s
 ; CHECK-NO16-GI-NEXT:    xtn v0.4h, v0.4s
 ; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test_v4f16:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    movi v1.4h, #68, lsl #8
-; CHECK-FP16-GI-NEXT:    fmul v0.4h, v0.4h, v1.4h
-; CHECK-FP16-GI-NEXT:    fcvtzu v0.4h, v0.4h
-; CHECK-FP16-GI-NEXT:    ret
   %scale = fmul <4 x half> %in, <half 4.0, half 4.0, half 4.0, half 4.0>
   %val = fptoui <4 x half> %scale to <4 x i16>
   ret <4 x i16> %val
@@ -613,89 +459,30 @@ declare <4 x i32> @llvm.fptosi.sat.v4i32.v4f16(<4 x half>)
 declare <4 x i24> @llvm.fptoui.sat.v4i24.v4f32(<4 x float>)
 
 define <2 x i32> @test1_sat(<2 x float> %f) {
-; CHECK-NO16-SD-LABEL: test1_sat:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.2s, v0.2s, #4
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test1_sat:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.2s, v0.2s, #4
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test1_sat:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-NO16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.2s, v0.2s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test1_sat:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-FP16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.2s, v0.2s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test1_sat:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.2s, v0.2s, #4
+; CHECK-NEXT:    ret
   %mul.i = fmul <2 x float> %f, <float 16.000000e+00, float 16.000000e+00>
   %vcvt.i = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %mul.i)
   ret <2 x i32> %vcvt.i
 }
 
 define <4 x i32> @test2_sat(<4 x float> %f) {
-; CHECK-NO16-SD-LABEL: test2_sat:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.4s, v0.4s, #3
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test2_sat:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.4s, v0.4s, #3
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test2_sat:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #8.00000000
-; CHECK-NO16-GI-NEXT:    fmul v0.4s, v0.4s, v1.s[0]
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test2_sat:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #8.00000000
-; CHECK-FP16-GI-NEXT:    fmul v0.4s, v0.4s, v1.s[0]
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test2_sat:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.4s, v0.4s, #3
+; CHECK-NEXT:    ret
   %mul.i = fmul <4 x float> %f, <float 8.000000e+00, float 8.000000e+00, float 8.000000e+00, float 8.000000e+00>
   %vcvt.i = call <4 x i32> @llvm.fptosi.sat.v4i32.v4f32(<4 x float> %mul.i)
   ret <4 x i32> %vcvt.i
 }
 
 define <2 x i64> @test3_sat(<2 x double> %d) {
-; CHECK-NO16-SD-LABEL: test3_sat:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.2d, v0.2d, #5
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test3_sat:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.2d, v0.2d, #5
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test3_sat:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    mov x8, #4629700416936869888 // =0x4040000000000000
-; CHECK-NO16-GI-NEXT:    fmov d1, x8
-; CHECK-NO16-GI-NEXT:    fmul v0.2d, v0.2d, v1.d[0]
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.2d, v0.2d
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test3_sat:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    mov x8, #4629700416936869888 // =0x4040000000000000
-; CHECK-FP16-GI-NEXT:    fmov d1, x8
-; CHECK-FP16-GI-NEXT:    fmul v0.2d, v0.2d, v1.d[0]
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.2d, v0.2d
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test3_sat:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.2d, v0.2d, #5
+; CHECK-NEXT:    ret
   %mul.i = fmul <2 x double> %d, <double 32.000000e+00, double 32.000000e+00>
   %vcvt.i = call <2 x i64> @llvm.fptosi.sat.v2i64.v2f64(<2 x double> %mul.i)
   ret <2 x i64> %vcvt.i
@@ -729,12 +516,10 @@ define <2 x i32> @test4_sat(<2 x double> %d) {
 ;
 ; CHECK-NO16-GI-LABEL: test4_sat:
 ; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov d1, #16.00000000
+; CHECK-NO16-GI-NEXT:    fcvtzs v0.2d, v0.2d, #4
 ; CHECK-NO16-GI-NEXT:    adrp x8, .LCPI21_1
-; CHECK-NO16-GI-NEXT:    fmul v0.2d, v0.2d, v1.d[0]
 ; CHECK-NO16-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI21_1]
 ; CHECK-NO16-GI-NEXT:    adrp x8, .LCPI21_0
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.2d, v0.2d
 ; CHECK-NO16-GI-NEXT:    cmgt v2.2d, v1.2d, v0.2d
 ; CHECK-NO16-GI-NEXT:    bif v0.16b, v1.16b, v2.16b
 ; CHECK-NO16-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI21_0]
@@ -745,12 +530,10 @@ define <2 x i32> @test4_sat(<2 x double> %d) {
 ;
 ; CHECK-FP16-GI-LABEL: test4_sat:
 ; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov d1, #16.00000000
+; CHECK-FP16-GI-NEXT:    fcvtzs v0.2d, v0.2d, #4
 ; CHECK-FP16-GI-NEXT:    adrp x8, .LCPI21_1
-; CHECK-FP16-GI-NEXT:    fmul v0.2d, v0.2d, v1.d[0]
 ; CHECK-FP16-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI21_1]
 ; CHECK-FP16-GI-NEXT:    adrp x8, .LCPI21_0
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.2d, v0.2d
 ; CHECK-FP16-GI-NEXT:    cmgt v2.2d, v1.2d, v0.2d
 ; CHECK-FP16-GI-NEXT:    bif v0.16b, v1.16b, v2.16b
 ; CHECK-FP16-GI-NEXT:    ldr q1, [x8, :lo12:.LCPI21_0]
@@ -785,22 +568,18 @@ define <2 x i16> @test5_sat(<2 x float> %f) {
 ;
 ; CHECK-NO16-GI-LABEL: test5_sat:
 ; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-NO16-GI-NEXT:    mvni v2.2s, #127, msl #8
-; CHECK-NO16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
 ; CHECK-NO16-GI-NEXT:    movi v1.2s, #127, msl #8
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NO16-GI-NEXT:    fcvtzs v0.2s, v0.2s, #4
+; CHECK-NO16-GI-NEXT:    mvni v2.2s, #127, msl #8
 ; CHECK-NO16-GI-NEXT:    smin v0.2s, v0.2s, v1.2s
 ; CHECK-NO16-GI-NEXT:    smax v0.2s, v0.2s, v2.2s
 ; CHECK-NO16-GI-NEXT:    ret
 ;
 ; CHECK-FP16-GI-LABEL: test5_sat:
 ; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-FP16-GI-NEXT:    mvni v2.2s, #127, msl #8
-; CHECK-FP16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
 ; CHECK-FP16-GI-NEXT:    movi v1.2s, #127, msl #8
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-FP16-GI-NEXT:    fcvtzs v0.2s, v0.2s, #4
+; CHECK-FP16-GI-NEXT:    mvni v2.2s, #127, msl #8
 ; CHECK-FP16-GI-NEXT:    smin v0.2s, v0.2s, v1.2s
 ; CHECK-FP16-GI-NEXT:    smax v0.2s, v0.2s, v2.2s
 ; CHECK-FP16-GI-NEXT:    ret
@@ -811,33 +590,11 @@ define <2 x i16> @test5_sat(<2 x float> %f) {
 
 ; Truncate float to i16
 define <4 x i16> @test5l_sat(<4 x float> %f) {
-; CHECK-NO16-SD-LABEL: test5l_sat:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.4s, v0.4s, #4
-; CHECK-NO16-SD-NEXT:    sqxtn v0.4h, v0.4s
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test5l_sat:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.4s, v0.4s, #4
-; CHECK-FP16-SD-NEXT:    sqxtn v0.4h, v0.4s
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test5l_sat:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-NO16-GI-NEXT:    fmul v0.4s, v0.4s, v1.s[0]
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NO16-GI-NEXT:    sqxtn v0.4h, v0.4s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test5l_sat:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-FP16-GI-NEXT:    fmul v0.4s, v0.4s, v1.s[0]
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-FP16-GI-NEXT:    sqxtn v0.4h, v0.4s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test5l_sat:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.4s, v0.4s, #4
+; CHECK-NEXT:    sqxtn v0.4h, v0.4s
+; CHECK-NEXT:    ret
   %mul.i = fmul <4 x float> %f, <float 16.000000e+00, float 16.000000e+00, float 16.000000e+00, float 16.000000e+00>
   %vcvt.i = call <4 x i16> @llvm.fptosi.sat.v4i16.v4f32(<4 x float> %mul.i)
   ret <4 x i16> %vcvt.i
@@ -882,29 +639,10 @@ define <2 x i64> @test6_sat(<2 x float> %f) {
 }
 
 define <2 x i32> @test7_sat(<2 x float> %f) {
-; CHECK-NO16-SD-LABEL: test7_sat:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzu v0.2s, v0.2s, #4
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test7_sat:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzu v0.2s, v0.2s, #4
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test7_sat:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-NO16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-NO16-GI-NEXT:    fcvtzu v0.2s, v0.2s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test7_sat:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #16.00000000
-; CHECK-FP16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-FP16-GI-NEXT:    fcvtzu v0.2s, v0.2s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test7_sat:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzu v0.2s, v0.2s, #4
+; CHECK-NEXT:    ret
   %mul.i = fmul <2 x float> %f, <float 16.000000e+00, float 16.000000e+00>
   %vcvt.i = call <2 x i32> @llvm.fptoui.sat.v2i32.v2f32(<2 x float> %mul.i)
   ret <2 x i32> %vcvt.i
@@ -1092,31 +830,10 @@ define <2 x i32> @test13_sat(<2 x float> %f) {
 
 ; Test case where const is max power of 2 (i.e., 2^32).
 define <2 x i32> @test14_sat(<2 x float> %f) {
-; CHECK-NO16-SD-LABEL: test14_sat:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    fcvtzs v0.2s, v0.2s, #32
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test14_sat:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.2s, v0.2s, #32
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test14_sat:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    mov w8, #1333788672 // =0x4f800000
-; CHECK-NO16-GI-NEXT:    fmov s1, w8
-; CHECK-NO16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-NO16-GI-NEXT:    fcvtzs v0.2s, v0.2s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test14_sat:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    mov w8, #1333788672 // =0x4f800000
-; CHECK-FP16-GI-NEXT:    fmov s1, w8
-; CHECK-FP16-GI-NEXT:    fmul v0.2s, v0.2s, v1.s[0]
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.2s, v0.2s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test14_sat:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs v0.2s, v0.2s, #32
+; CHECK-NEXT:    ret
   %mul.i = fmul <2 x float> %f, <float 0x41F0000000000000, float 0x41F0000000000000>
   %vcvt.i = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %mul.i)
   ret <2 x i32> %vcvt.i
@@ -1177,10 +894,10 @@ define <8 x i16> @test_v8f16_sat(<8 x half> %in) {
 ; CHECK-NO16-SD-NEXT:    sqxtn2 v0.8h, v1.4s
 ; CHECK-NO16-SD-NEXT:    ret
 ;
-; CHECK-FP16-SD-LABEL: test_v8f16_sat:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzs v0.8h, v0.8h, #2
-; CHECK-FP16-SD-NEXT:    ret
+; CHECK-FP16-LABEL: test_v8f16_sat:
+; CHECK-FP16:       // %bb.0:
+; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h, #2
+; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-NO16-GI-LABEL: test_v8f16_sat:
 ; CHECK-NO16-GI:       // %bb.0:
@@ -1199,13 +916,6 @@ define <8 x i16> @test_v8f16_sat(<8 x half> %in) {
 ; CHECK-NO16-GI-NEXT:    sqxtn v0.4h, v1.4s
 ; CHECK-NO16-GI-NEXT:    sqxtn2 v0.8h, v2.4s
 ; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test_v8f16_sat:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    movi v1.8h, #68, lsl #8
-; CHECK-FP16-GI-NEXT:    fmul v0.8h, v0.8h, v1.8h
-; CHECK-FP16-GI-NEXT:    fcvtzs v0.8h, v0.8h
-; CHECK-FP16-GI-NEXT:    ret
   %mul.i = fmul <8 x half> %in, <half 4.0, half 4.0, half 4.0, half 4.0, half 4.0, half 4.0, half 4.0, half 4.0>
   %val = call <8 x i16> @llvm.fptosi.sat.v8i16.v8f16(<8 x half> %mul.i)
   ret <8 x i16> %val
@@ -1223,10 +933,10 @@ define <4 x i16> @test_v4f16_sat(<4 x half> %in) {
 ; CHECK-NO16-SD-NEXT:    uqxtn v0.4h, v0.4s
 ; CHECK-NO16-SD-NEXT:    ret
 ;
-; CHECK-FP16-SD-LABEL: test_v4f16_sat:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    fcvtzu v0.4h, v0.4h, #2
-; CHECK-FP16-SD-NEXT:    ret
+; CHECK-FP16-LABEL: test_v4f16_sat:
+; CHECK-FP16:       // %bb.0:
+; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h, #2
+; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-NO16-GI-LABEL: test_v4f16_sat:
 ; CHECK-NO16-GI:       // %bb.0:
@@ -1239,13 +949,6 @@ define <4 x i16> @test_v4f16_sat(<4 x half> %in) {
 ; CHECK-NO16-GI-NEXT:    fcvtzu v0.4s, v0.4s
 ; CHECK-NO16-GI-NEXT:    uqxtn v0.4h, v0.4s
 ; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test_v4f16_sat:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    movi v1.4h, #68, lsl #8
-; CHECK-FP16-GI-NEXT:    fmul v0.4h, v0.4h, v1.4h
-; CHECK-FP16-GI-NEXT:    fcvtzu v0.4h, v0.4h
-; CHECK-FP16-GI-NEXT:    ret
   %mul.i = fmul <4 x half> %in, <half 4.0, half 4.0, half 4.0, half 4.0>
   %val = call <4 x i16> @llvm.fptoui.sat.v4i16.v4f16(<4 x half> %mul.i)
   ret <4 x i16> %val
@@ -1286,37 +989,12 @@ define <4 x i32> @test_v4f16_i32_sat(<4 x half> %in) {
 }
 
 define <4 x i32> @test_extrasat(<4 x float> %f) {
-; CHECK-NO16-SD-LABEL: test_extrasat:
-; CHECK-NO16-SD:       // %bb.0:
-; CHECK-NO16-SD-NEXT:    movi v1.2d, #0xffffff00ffffff
-; CHECK-NO16-SD-NEXT:    fcvtzu v0.4s, v0.4s, #3
-; CHECK-NO16-SD-NEXT:    umin v0.4s, v0.4s, v1.4s
-; CHECK-NO16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: test_extrasat:
-; CHECK-FP16-SD:       // %bb.0:
-; CHECK-FP16-SD-NEXT:    movi v1.2d, #0xffffff00ffffff
-; CHECK-FP16-SD-NEXT:    fcvtzu v0.4s, v0.4s, #3
-; CHECK-FP16-SD-NEXT:    umin v0.4s, v0.4s, v1.4s
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NO16-GI-LABEL: test_extrasat:
-; CHECK-NO16-GI:       // %bb.0:
-; CHECK-NO16-GI-NEXT:    fmov s1, #8.00000000
-; CHECK-NO16-GI-NEXT:    fmul v0.4s, v0.4s, v1.s[0]
-; CHECK-NO16-GI-NEXT:    movi v1.2d, #0xffffff00ffffff
-; CHECK-NO16-GI-NEXT:    fcvtzu v0.4s, v0.4s
-; CHECK-NO16-GI-NEXT:    umin v0.4s, v0.4s, v1.4s
-; CHECK-NO16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: test_extrasat:
-; CHECK-FP16-GI:       // %bb.0:
-; CHECK-FP16-GI-NEXT:    fmov s1, #8.00000000
-; CHECK-FP16-GI-NEXT:    fmul v0.4s, v0.4s, v1.s[0]
-; CHECK-FP16-GI-NEXT:    movi v1.2d, #0xffffff00ffffff
-; CHECK-FP16-GI-NEXT:    fcvtzu v0.4s, v0.4s
-; CHECK-FP16-GI-NEXT:    umin v0.4s, v0.4s, v1.4s
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: test_extrasat:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v1.2d, #0xffffff00ffffff
+; CHECK-NEXT:    fcvtzu v0.4s, v0.4s, #3
+; CHECK-NEXT:    umin v0.4s, v0.4s, v1.4s
+; CHECK-NEXT:    ret
   %mul.i = fmul <4 x float> %f, <float 8.000000e+00, float 8.000000e+00, float 8.000000e+00, float 8.000000e+00>
   %vcvt.i = call <4 x i24> @llvm.fptoui.sat.v4i24.v4f32(<4 x float> %mul.i)
   %t = zext <4 x i24> %vcvt.i to <4 x i32>


### PR DESCRIPTION
This uses the generalized code from https://github.com/llvm/llvm-project/pull/178603 to allow GISel to select
fixed-point fcvt in the same way as SDAG.