### PR TITLE
[lldb][CompilerType] Add CompilerType::IsRealFloatingPointType

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -144,7 +144,11 @@ public:
 
   bool IsDefined() const;
 
+  /// Returns \c true for floating point types (including complex floats).
   bool IsFloatingPointType(bool &is_complex) const;
+
+  /// Returns \c true for non-complex float types.
+  bool IsRealFloatingPointType() const;
 
   bool IsFunctionType() const;
 

--- a/lldb/source/Plugins/ABI/ARC/ABISysV_arc.cpp
+++ b/lldb/source/Plugins/ABI/ARC/ABISysV_arc.cpp
@@ -479,19 +479,14 @@ ABISysV_arc::GetReturnValueObjectSimple(Thread &thread,
     value.SetValueType(Value::ValueType::Scalar);
   }
   // Floating point return type.
-  else if (type_flags & eTypeIsFloat) {
-    bool is_complex = false;
+  else if (compiler_type.IsRealFloatingPointType()) {
+    const size_t byte_size =
+        llvm::expectedToOptional(compiler_type.GetByteSize(&thread))
+            .value_or(0);
+    auto raw_value = ReadRawValue(reg_ctx, byte_size);
 
-    if (compiler_type.IsFloatingPointType(is_complex) &&
-        !compiler_type.IsVectorType() && !is_complex) {
-      const size_t byte_size =
-          llvm::expectedToOptional(compiler_type.GetByteSize(&thread))
-              .value_or(0);
-      auto raw_value = ReadRawValue(reg_ctx, byte_size);
-
-      if (!SetSizedFloat(value.GetScalar(), raw_value, byte_size))
-        return ValueObjectSP();
-    }
+    if (!SetSizedFloat(value.GetScalar(), raw_value, byte_size))
+      return ValueObjectSP();
   }
   // Unsupported return type.
   else

--- a/lldb/source/Plugins/ABI/ARM/ABIMacOSX_arm.cpp
+++ b/lldb/source/Plugins/ABI/ARM/ABIMacOSX_arm.cpp
@@ -1695,7 +1695,6 @@ Status ABIMacOSX_arm::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   Thread *thread = frame_sp->GetThread().get();
 
   bool is_signed;
-  bool is_complex;
 
   RegisterContext *reg_ctx = thread->GetRegisterContext().get();
 
@@ -1766,13 +1765,6 @@ Status ABIMacOSX_arm::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
           "We don't support returning longer than 64 bit "
           "integer values at present.");
     }
-  } else if (compiler_type.IsFloatingPointType(is_complex)) {
-    if (is_complex)
-      error = Status::FromErrorString(
-          "We don't support returning complex values at present");
-    else
-      error = Status::FromErrorString(
-          "We don't support returning float values at present");
   }
 
   if (!set_it_simple)

--- a/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
+++ b/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
@@ -1842,7 +1842,6 @@ Status ABISysV_arm::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   Thread *thread = frame_sp->GetThread().get();
 
   bool is_signed;
-  bool is_complex;
 
   RegisterContext *reg_ctx = thread->GetRegisterContext().get();
 
@@ -1884,13 +1883,6 @@ Status ABISysV_arm::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
           "We don't support returning longer than 64 bit "
           "integer values at present.");
     }
-  } else if (compiler_type.IsFloatingPointType(is_complex)) {
-    if (is_complex)
-      error = Status::FromErrorString(
-          "We don't support returning complex values at present");
-    else
-      error = Status::FromErrorString(
-          "We don't support returning float values at present");
   }
 
   if (!set_it_simple)

--- a/lldb/source/Plugins/ABI/LoongArch/ABISysV_loongarch.cpp
+++ b/lldb/source/Plugins/ABI/LoongArch/ABISysV_loongarch.cpp
@@ -509,16 +509,12 @@ ValueObjectSP ABISysV_loongarch::GetReturnValueObjectSimple(
     return ValueObjectConstResult::Create(thread.GetStackFrameAtIndex(0).get(),
                                           value, ConstString(""));
   }
-  if (type_flags & eTypeIsFloat) {
-    bool is_complex = false;
-
-    if (compiler_type.IsFloatingPointType(is_complex) &&
-        !(type_flags & eTypeIsVector) && !is_complex) {
-      return_valobj_sp =
-          GetValObjFromFPRegs(thread, reg_ctx, machine, type_flags, byte_size);
-      return return_valobj_sp;
-    }
+  if (compiler_type.IsRealFloatingPointType()) {
+    return_valobj_sp =
+        GetValObjFromFPRegs(thread, reg_ctx, machine, type_flags, byte_size);
+    return return_valobj_sp;
   }
+
   return return_valobj_sp;
 }
 

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
@@ -426,7 +426,6 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   Thread *thread = frame_sp->GetThread().get();
 
   bool is_signed;
-  bool is_complex;
 
   RegisterContext *reg_ctx = thread->GetRegisterContext().get();
 
@@ -453,38 +452,33 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
           "We don't support returning longer than 64 bit "
           "integer values at present.");
     }
-  } else if (compiler_type.IsFloatingPointType(is_complex)) {
-    if (is_complex)
-      error = Status::FromErrorString(
-          "We don't support returning complex values at present");
-    else {
-      std::optional<uint64_t> bit_width =
-          llvm::expectedToOptional(compiler_type.GetBitSize(frame_sp.get()));
-      if (!bit_width) {
-        error = Status::FromErrorString("can't get type size");
+  } else if (compiler_type.IsRealFloatingPointType()) {
+    std::optional<uint64_t> bit_width =
+        llvm::expectedToOptional(compiler_type.GetBitSize(frame_sp.get()));
+    if (!bit_width) {
+      error = Status::FromErrorString("can't get type size");
+      return error;
+    }
+    if (*bit_width <= 64) {
+      DataExtractor data;
+      Status data_error;
+      size_t num_bytes = new_value_sp->GetData(data, data_error);
+      if (data_error.Fail()) {
+        error = Status::FromErrorStringWithFormat(
+            "Couldn't convert return value to raw data: %s",
+            data_error.AsCString());
         return error;
       }
-      if (*bit_width <= 64) {
-        DataExtractor data;
-        Status data_error;
-        size_t num_bytes = new_value_sp->GetData(data, data_error);
-        if (data_error.Fail()) {
-          error = Status::FromErrorStringWithFormat(
-              "Couldn't convert return value to raw data: %s",
-              data_error.AsCString());
-          return error;
-        }
 
-        unsigned char buffer[16];
-        ByteOrder byte_order = data.GetByteOrder();
+      unsigned char buffer[16];
+      ByteOrder byte_order = data.GetByteOrder();
 
-        data.CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
-        set_it_simple = true;
-      } else {
-        // FIXME - don't know how to do 80 bit long doubles yet.
-        error = Status::FromErrorString(
-            "We don't support returning float values > 64 bits at present");
-      }
+      data.CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
+      set_it_simple = true;
+    } else {
+      // FIXME - don't know how to do 80 bit long doubles yet.
+      error = Status::FromErrorString(
+          "We don't support returning float values > 64 bits at present");
     }
   }
 

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc64.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc64.cpp
@@ -309,7 +309,6 @@ Status ABISysV_ppc64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   Thread *thread = frame_sp->GetThread().get();
 
   bool is_signed;
-  bool is_complex;
 
   RegisterContext *reg_ctx = thread->GetRegisterContext().get();
 
@@ -338,38 +337,33 @@ Status ABISysV_ppc64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
           "We don't support returning longer than 64 bit "
           "integer values at present.");
     }
-  } else if (compiler_type.IsFloatingPointType(is_complex)) {
-    if (is_complex)
-      error = Status::FromErrorString(
-          "We don't support returning complex values at present");
-    else {
-      std::optional<uint64_t> bit_width =
-          llvm::expectedToOptional(compiler_type.GetBitSize(frame_sp.get()));
-      if (!bit_width) {
-        error = Status::FromErrorString("can't get size of type");
+  } else if (compiler_type.IsRealFloatingPointType()) {
+    std::optional<uint64_t> bit_width =
+        llvm::expectedToOptional(compiler_type.GetBitSize(frame_sp.get()));
+    if (!bit_width) {
+      error = Status::FromErrorString("can't get size of type");
+      return error;
+    }
+    if (*bit_width <= 64) {
+      DataExtractor data;
+      Status data_error;
+      size_t num_bytes = new_value_sp->GetData(data, data_error);
+      if (data_error.Fail()) {
+        error = Status::FromErrorStringWithFormat(
+            "Couldn't convert return value to raw data: %s",
+            data_error.AsCString());
         return error;
       }
-      if (*bit_width <= 64) {
-        DataExtractor data;
-        Status data_error;
-        size_t num_bytes = new_value_sp->GetData(data, data_error);
-        if (data_error.Fail()) {
-          error = Status::FromErrorStringWithFormat(
-              "Couldn't convert return value to raw data: %s",
-              data_error.AsCString());
-          return error;
-        }
 
-        unsigned char buffer[16];
-        ByteOrder byte_order = data.GetByteOrder();
+      unsigned char buffer[16];
+      ByteOrder byte_order = data.GetByteOrder();
 
-        data.CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
-        set_it_simple = true;
-      } else {
-        // FIXME - don't know how to do 80 bit long doubles yet.
-        error = Status::FromErrorString(
-            "We don't support returning float values > 64 bits at present");
-      }
+      data.CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
+      set_it_simple = true;
+    } else {
+      // FIXME - don't know how to do 80 bit long doubles yet.
+      error = Status::FromErrorString(
+          "We don't support returning float values > 64 bits at present");
     }
   }
 

--- a/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
+++ b/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
@@ -642,18 +642,14 @@ ABISysV_riscv::GetReturnValueObjectSimple(Thread &thread,
                                           value, ConstString(""));
   }
   // Floating point return type.
-  else if (type_flags & eTypeIsFloat) {
-    bool is_complex = false;
-
-    if (compiler_type.IsFloatingPointType(is_complex) &&
-        !(type_flags & eTypeIsVector) && !is_complex) {
-      const uint32_t arch_fp_flags =
-          arch.GetFlags() & ArchSpec::eRISCV_float_abi_mask;
-      return_valobj_sp = GetValObjFromFPRegs(
-          thread, reg_ctx, machine, arch_fp_flags, type_flags, byte_size);
-      return return_valobj_sp;
-    }
+  else if (compiler_type.IsRealFloatingPointType()) {
+    const uint32_t arch_fp_flags =
+        arch.GetFlags() & ArchSpec::eRISCV_float_abi_mask;
+    return_valobj_sp = GetValObjFromFPRegs(
+        thread, reg_ctx, machine, arch_fp_flags, type_flags, byte_size);
+    return return_valobj_sp;
   }
+
   // Unsupported return type.
   return return_valobj_sp;
 }

--- a/lldb/source/Plugins/ABI/X86/ABIMacOSX_i386.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIMacOSX_i386.cpp
@@ -198,7 +198,6 @@ Status ABIMacOSX_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   Thread *thread = frame_sp->GetThread().get();
 
   bool is_signed;
-  bool is_complex;
 
   RegisterContext *reg_ctx = thread->GetRegisterContext().get();
 
@@ -239,13 +238,6 @@ Status ABIMacOSX_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
           "We don't support returning longer than 64 bit "
           "integer values at present.");
     }
-  } else if (compiler_type.IsFloatingPointType(is_complex)) {
-    if (is_complex)
-      error = Status::FromErrorString(
-          "We don't support returning complex values at present");
-    else
-      error = Status::FromErrorString(
-          "We don't support returning float values at present");
   }
 
   if (!set_it_simple)

--- a/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
@@ -312,7 +312,6 @@ Status ABIWindows_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   Thread *thread = frame_sp->GetThread().get();
 
   bool is_signed;
-  bool is_complex;
 
   RegisterContext *reg_ctx = thread->GetRegisterContext().get();
 
@@ -341,43 +340,37 @@ Status ABIWindows_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
           "We don't support returning longer than 64 bit "
           "integer values at present.");
     }
-  } else if (compiler_type.IsFloatingPointType(is_complex)) {
-    if (is_complex)
-      error = Status::FromErrorString(
-          "We don't support returning complex values at present");
-    else {
-      std::optional<uint64_t> bit_width =
-          llvm::expectedToOptional(compiler_type.GetBitSize(frame_sp.get()));
-      if (!bit_width) {
-        error = Status::FromErrorString("can't get type size");
+  } else if (compiler_type.IsRealFloatingPointType()) {
+    std::optional<uint64_t> bit_width =
+        llvm::expectedToOptional(compiler_type.GetBitSize(frame_sp.get()));
+    if (!bit_width) {
+      error = Status::FromErrorString("can't get type size");
+      return error;
+    }
+    if (*bit_width <= 64) {
+      const RegisterInfo *xmm0_info = reg_ctx->GetRegisterInfoByName("xmm0", 0);
+      RegisterValue xmm0_value;
+      DataExtractor data;
+      Status data_error;
+      size_t num_bytes = new_value_sp->GetData(data, data_error);
+      if (data_error.Fail()) {
+        error = Status::FromErrorStringWithFormat(
+            "Couldn't convert return value to raw data: %s",
+            data_error.AsCString());
         return error;
       }
-      if (*bit_width <= 64) {
-        const RegisterInfo *xmm0_info =
-            reg_ctx->GetRegisterInfoByName("xmm0", 0);
-        RegisterValue xmm0_value;
-        DataExtractor data;
-        Status data_error;
-        size_t num_bytes = new_value_sp->GetData(data, data_error);
-        if (data_error.Fail()) {
-          error = Status::FromErrorStringWithFormat(
-              "Couldn't convert return value to raw data: %s",
-              data_error.AsCString());
-          return error;
-        }
 
-        unsigned char buffer[16];
-        ByteOrder byte_order = data.GetByteOrder();
+      unsigned char buffer[16];
+      ByteOrder byte_order = data.GetByteOrder();
 
-        data.CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
-        xmm0_value.SetBytes(buffer, 16, byte_order);
-        reg_ctx->WriteRegister(xmm0_info, xmm0_value);
-        set_it_simple = true;
-      } else {
-        // Windows doesn't support 80 bit FP
-        error = Status::FromErrorString(
-            "Windows-x86_64 doesn't allow FP larger than 64 bits.");
-      }
+      data.CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
+      xmm0_value.SetBytes(buffer, 16, byte_order);
+      reg_ctx->WriteRegister(xmm0_info, xmm0_value);
+      set_it_simple = true;
+    } else {
+      // Windows doesn't support 80 bit FP
+      error = Status::FromErrorString(
+          "Windows-x86_64 doesn't allow FP larger than 64 bits.");
     }
   }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2041,10 +2041,9 @@ static std::optional<clang::APValue> MakeAPValue(const clang::ASTContext &ast,
   if (is_integral)
     return clang::APValue(apint);
 
-  bool is_complex;
   // FIXME: we currently support a limited set of floating point types.
   // E.g., 16-bit floats are not supported.
-  if (!clang_type.IsFloatingPointType(is_complex))
+  if (!clang_type.IsRealFloatingPointType())
     return std::nullopt;
 
   return clang::APValue(llvm::APFloat(

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -249,6 +249,11 @@ bool CompilerType::IsFloatingPointType(bool &is_complex) const {
   return false;
 }
 
+bool CompilerType::IsRealFloatingPointType() const {
+  bool is_complex = false;
+  return IsFloatingPointType(is_complex) && !is_complex && !IsVectorType();
+}
+
 bool CompilerType::IsDefined() const {
   if (IsValid())
     if (auto type_system_sp = GetTypeSystem())

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -1350,6 +1350,27 @@ TEST_F(TestTypeSystemClang, TestGetTypeInfo) {
             (eTypeIsFloat | eTypeIsVector | eTypeHasChildren));
 }
 
+TEST_F(TestTypeSystemClang, TestIsRealFloatingPointType) {
+  // Tests CompilerType::IsRealFloatingPointType
+
+  const ASTContext &ast = m_ast->getASTContext();
+
+  EXPECT_FALSE(m_ast->GetType(ast.getComplexType(ast.FloatTy))
+                   .IsRealFloatingPointType());
+  EXPECT_FALSE(
+      m_ast->GetType(ast.getVectorType(ast.FloatTy, 1, VectorKind::Generic))
+          .IsRealFloatingPointType());
+  EXPECT_TRUE(m_ast->GetType(ast.FloatTy).IsRealFloatingPointType());
+  EXPECT_TRUE(m_ast->GetType(ast.DoubleTy).IsRealFloatingPointType());
+  EXPECT_TRUE(m_ast->GetType(ast.LongDoubleTy).IsRealFloatingPointType());
+
+  // FIXME: these should be true
+  EXPECT_FALSE(m_ast->GetType(ast.HalfTy).IsRealFloatingPointType());
+  EXPECT_FALSE(m_ast->GetType(ast.Float128Ty).IsRealFloatingPointType());
+  EXPECT_FALSE(m_ast->GetType(ast.BFloat16Ty).IsRealFloatingPointType());
+  EXPECT_FALSE(m_ast->GetType(ast.Ibm128Ty).IsRealFloatingPointType());
+}
+
 TEST_F(TestTypeSystemClang, AsmLabel_CtorDtor) {
   // Tests TypeSystemClang::DeclGetMangledName for constructors/destructors
   // with and without AsmLabels.


### PR DESCRIPTION
This is part of a patch series to clean up the `TypeSystemClang::IsFloatingPointType` API. Currently the API is a bit of a foot-gun because it returns `true` for both Complex floats and vector types whose element types are floats, but most call-sites probably don't handle these correctly. The former aligns with the `clang::Type::isFloatingType` API, but the latter doesn't. This specific implementation choice will be addressed in a separate patch. This patch adds a new `CompilerType::IsRealFloatingPointType` API which clients can use to query about non-complex floats (named after the similarly named `clang::Type::isRealFloatingType`).

This allows us to clean up some of the callers which only wanted to handle non-complex floats. I cleaned those up as part of this patch. Wherever we checked for `is_float && !is_complex && !is_vector_type` i just replaced it with the new API.

On encountering complex/vector floats, some of the ABI plugins would set an error but then immediately overwrite the error to something else. I just removed those branches entirely, since it was essentially dead code.

Some of the diff is large because of un-indentation when we remove if-guards, so I would recommend turning off white-space diff when reviewing.