### PR TITLE
[lldb][TypeSystemClang] Remove mostly unused is_complex output parameter to IsFloatingPointType

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -144,8 +144,10 @@ public:
 
   bool IsDefined() const;
 
+  bool IsComplexType() const;
+
   /// Returns \c true for floating point types (including complex floats).
-  bool IsFloatingPointType(bool &is_complex) const;
+  bool IsFloatingPointType() const;
 
   /// Returns \c true for non-complex float types.
   bool IsRealFloatingPointType() const;

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -162,8 +162,7 @@ public:
 
   virtual bool IsDefined(lldb::opaque_compiler_type_t type) = 0;
 
-  virtual bool IsFloatingPointType(lldb::opaque_compiler_type_t type,
-                                   bool &is_complex) = 0;
+  virtual bool IsFloatingPointType(lldb::opaque_compiler_type_t type) = 0;
 
   virtual bool IsFunctionType(lldb::opaque_compiler_type_t type) = 0;
 

--- a/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
+++ b/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
@@ -1549,7 +1549,6 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
     return return_valobj_sp;
 
   bool is_signed;
-  bool is_complex;
   bool is_vfp_candidate = false;
   uint8_t vfp_count = 0;
   uint8_t vfp_byte_size = 0;
@@ -1633,9 +1632,9 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
       if (!GetReturnValuePassedInMemory(thread, reg_ctx, *byte_size, value))
         return return_valobj_sp;
     }
-  } else if (compiler_type.IsFloatingPointType(is_complex)) {
+  } else if (compiler_type.IsFloatingPointType()) {
     // Vector types are handled above.
-    if (!is_complex) {
+    if (!compiler_type.IsCompleteType()) {
       switch (*bit_width) {
       default:
         return return_valobj_sp;
@@ -1681,7 +1680,7 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
         break;
       }
       }
-    } else if (is_complex) {
+    } else {
       if (IsArmHardFloat(thread)) {
         is_vfp_candidate = true;
         vfp_byte_size = *byte_size / 2;
@@ -1689,9 +1688,7 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
       } else if (!GetReturnValuePassedInMemory(thread, reg_ctx, *bit_width / 8,
                                                value))
         return return_valobj_sp;
-    } else
-      // not handled yet
-      return return_valobj_sp;
+    }
   } else if (compiler_type.IsAggregateType()) {
     if (IsArmHardFloat(thread)) {
       CompilerType base_type;
@@ -1709,9 +1706,10 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
             vfp_count = (*base_byte_size == 8 ? homogeneous_count
                                               : homogeneous_count * 2);
           }
-        } else if (base_type.IsFloatingPointType(is_complex)) {
-          // Vector types are handled above.
-          if (!is_complex) {
+        } else if (base_type.IsFloatingPointType()) {
+          assert(!base_type.IsVectorType() &&
+                 "Vector types should've been handled above.");
+          if (!base_type.IsComplexType()) {
             is_vfp_candidate = true;
             if (base_byte_size)
               vfp_byte_size = *base_byte_size;
@@ -1728,10 +1726,10 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
             base_type = compiler_type.GetFieldAtIndex(index, name, nullptr,
                                                       nullptr, nullptr);
 
-            if (base_type.IsFloatingPointType(is_complex)) {
+            if (base_type.IsFloatingPointType()) {
               std::optional<uint64_t> base_byte_size =
                   llvm::expectedToOptional(base_type.GetByteSize(&thread));
-              if (is_complex) {
+              if (base_type.IsComplexType()) {
                 if (index != 0 && base_byte_size &&
                     vfp_byte_size != *base_byte_size)
                   break;

--- a/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
+++ b/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
@@ -922,7 +922,6 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
       // True if the result is copied into our data buffer
       bool sucess = false;
       std::string name;
-      bool is_complex;
       const uint32_t num_children = return_compiler_type.GetNumFields();
 
       // A structure consisting of one or two FP values (and nothing else) will
@@ -936,7 +935,7 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
               return_compiler_type.GetFieldAtIndex(idx, name, &field_bit_offset,
                                                    nullptr, nullptr);
 
-          if (field_compiler_type.IsFloatingPointType(is_complex))
+          if (field_compiler_type.IsFloatingPointType())
             use_fp_regs = true;
           else
             found_non_fp_field = true;
@@ -1043,7 +1042,7 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
 
         if (field_compiler_type.IsIntegerOrEnumerationType(is_signed) ||
             field_compiler_type.IsPointerType() ||
-            field_compiler_type.IsFloatingPointType(is_complex)) {
+            field_compiler_type.IsFloatingPointType()) {
           padding = field_byte_offset - integer_bytes;
 
           if (integer_bytes < 8) {

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
@@ -687,7 +687,6 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectImpl(
         std::string name;
         uint64_t field_bit_offset = 0;
         bool is_signed;
-        bool is_complex;
 
         CompilerType field_compiler_type = return_compiler_type.GetFieldAtIndex(
             idx, name, &field_bit_offset, nullptr, nullptr);
@@ -733,7 +732,7 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectImpl(
             // return a nullptr return value object.
             return return_valobj_sp;
           }
-        } else if (field_compiler_type.IsFloatingPointType(is_complex)) {
+        } else if (field_compiler_type.IsFloatingPointType()) {
           // Structs with long doubles are always passed in memory.
           if (*field_bit_width == 128) {
             is_memory = true;

--- a/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
@@ -579,7 +579,6 @@ static bool FlattenAggregateType(
   for (uint32_t idx = 0; idx < num_children; ++idx) {
     std::string name;
     bool is_signed;
-    bool is_complex;
 
     uint64_t field_bit_offset = 0;
     CompilerType field_compiler_type = return_compiler_type.GetFieldAtIndex(
@@ -597,7 +596,7 @@ static bool FlattenAggregateType(
     const uint32_t field_type_flags = field_compiler_type.GetTypeInfo();
     if (field_compiler_type.IsIntegerOrEnumerationType(is_signed) ||
         field_compiler_type.IsPointerType() ||
-        field_compiler_type.IsFloatingPointType(is_complex)) {
+        field_compiler_type.IsFloatingPointType()) {
       aggregate_field_offsets.push_back(field_byte_offset);
       aggregate_compiler_types.push_back(field_compiler_type);
     } else if (field_type_flags & eTypeHasChildren) {
@@ -687,7 +686,6 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
       is_memory = false;
       for (uint32_t idx = 0; idx < num_children; idx++) {
         bool is_signed;
-        bool is_complex;
 
         CompilerType field_compiler_type = aggregate_compiler_types[idx];
         uint32_t field_byte_width =
@@ -726,7 +724,7 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
             // return a nullptr return value object.
             return return_valobj_sp;
           }
-        } else if (field_compiler_type.IsFloatingPointType(is_complex)) {
+        } else if (field_compiler_type.IsFloatingPointType()) {
           // Structs with long doubles are always passed in memory.
           if (field_bit_width == 128) {
             is_memory = true;

--- a/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
@@ -550,7 +550,6 @@ static bool FlattenAggregateType(
   for (uint32_t idx = 0; idx < num_children; ++idx) {
     std::string name;
     bool is_signed;
-    bool is_complex;
 
     uint64_t field_bit_offset = 0;
     CompilerType field_compiler_type = return_compiler_type.GetFieldAtIndex(
@@ -573,7 +572,7 @@ static bool FlattenAggregateType(
     const uint32_t field_type_flags = field_compiler_type.GetTypeInfo();
     if (field_compiler_type.IsIntegerOrEnumerationType(is_signed) ||
         field_compiler_type.IsPointerType() ||
-        field_compiler_type.IsFloatingPointType(is_complex)) {
+        field_compiler_type.IsFloatingPointType()) {
       aggregate_field_offsets.push_back(field_byte_offset);
       aggregate_compiler_types.push_back(field_compiler_type);
     } else if (field_type_flags & eTypeHasChildren) {
@@ -662,7 +661,6 @@ ValueObjectSP ABIWindows_x86_64::GetReturnValueObjectImpl(
     const uint32_t num_children = aggregate_compiler_types.size();
     for (uint32_t idx = 0; idx < num_children; idx++) {
       bool is_signed;
-      bool is_complex;
 
       CompilerType field_compiler_type = aggregate_compiler_types[idx];
       uint32_t field_byte_width =
@@ -681,7 +679,7 @@ ValueObjectSP ABIWindows_x86_64::GetReturnValueObjectImpl(
       uint32_t copy_from_offset = 0;
       if (field_compiler_type.IsIntegerOrEnumerationType(is_signed) ||
           field_compiler_type.IsPointerType() ||
-          field_compiler_type.IsFloatingPointType(is_complex)) {
+          field_compiler_type.IsFloatingPointType()) {
         copy_from_extractor = &rax_data;
         copy_from_offset = used_bytes;
         used_bytes += field_byte_width;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3473,8 +3473,7 @@ bool TypeSystemClang::IsReferenceType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
-bool TypeSystemClang::IsFloatingPointType(lldb::opaque_compiler_type_t type,
-                                          bool &is_complex) {
+bool TypeSystemClang::IsFloatingPointType(lldb::opaque_compiler_type_t type) {
   if (type) {
     clang::QualType qual_type(GetCanonicalQualType(type));
 
@@ -3482,28 +3481,20 @@ bool TypeSystemClang::IsFloatingPointType(lldb::opaque_compiler_type_t type,
             qual_type->getCanonicalTypeInternal())) {
       clang::BuiltinType::Kind kind = BT->getKind();
       if (kind >= clang::BuiltinType::Float &&
-          kind <= clang::BuiltinType::LongDouble) {
-        is_complex = false;
+          kind <= clang::BuiltinType::LongDouble)
         return true;
-      }
     } else if (const clang::ComplexType *CT =
                    llvm::dyn_cast<clang::ComplexType>(
                        qual_type->getCanonicalTypeInternal())) {
-      if (IsFloatingPointType(CT->getElementType().getAsOpaquePtr(),
-                              is_complex)) {
-        is_complex = true;
+      if (IsFloatingPointType(CT->getElementType().getAsOpaquePtr()))
         return true;
-      }
     } else if (const clang::VectorType *VT = llvm::dyn_cast<clang::VectorType>(
                    qual_type->getCanonicalTypeInternal())) {
-      if (IsFloatingPointType(VT->getElementType().getAsOpaquePtr(),
-                              is_complex)) {
-        is_complex = false;
+      if (IsFloatingPointType(VT->getElementType().getAsOpaquePtr()))
         return true;
-      }
     }
   }
-  is_complex = false;
+
   return false;
 }
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -657,8 +657,7 @@ public:
 
   bool IsDefined(lldb::opaque_compiler_type_t type) override;
 
-  bool IsFloatingPointType(lldb::opaque_compiler_type_t type,
-                           bool &is_complex) override;
+  bool IsFloatingPointType(lldb::opaque_compiler_type_t type) override;
 
   unsigned GetPtrAuthKey(lldb::opaque_compiler_type_t type) override;
   unsigned GetPtrAuthDiscriminator(lldb::opaque_compiler_type_t type) override;

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -20,6 +20,7 @@
 #include "lldb/Utility/Scalar.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/StreamString.h"
+#include "lldb/lldb-enumerations.h"
 
 #include <iterator>
 #include <mutex>
@@ -240,18 +241,21 @@ bool CompilerType::ShouldTreatScalarValueAsAddress() const {
   return false;
 }
 
-bool CompilerType::IsFloatingPointType(bool &is_complex) const {
-  if (IsValid()) {
+bool CompilerType::IsComplexType() const {
+  return GetTypeClass() & eTypeClassComplexFloat ||
+         GetTypeClass() & eTypeClassComplexInteger;
+}
+
+bool CompilerType::IsFloatingPointType() const {
+  if (IsValid())
     if (auto type_system_sp = GetTypeSystem())
-      return type_system_sp->IsFloatingPointType(m_type, is_complex);
-  }
-  is_complex = false;
+      return type_system_sp->IsFloatingPointType(m_type);
+
   return false;
 }
 
 bool CompilerType::IsRealFloatingPointType() const {
-  bool is_complex = false;
-  return IsFloatingPointType(is_complex) && !is_complex && !IsVectorType();
+  return IsFloatingPointType() && !IsComplexType() && !IsVectorType();
 }
 
 bool CompilerType::IsDefined() const {
@@ -333,10 +337,7 @@ bool CompilerType::IsInteger() const {
   return IsIntegerType(is_signed);
 }
 
-bool CompilerType::IsFloat() const {
-  bool is_complex = false;
-  return IsFloatingPointType(is_complex);
-}
+bool CompilerType::IsFloat() const { return IsFloatingPointType(); }
 
 bool CompilerType::IsEnumerationType() const {
   bool is_signed = false; // May be reset by the call below.

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -1371,6 +1371,21 @@ TEST_F(TestTypeSystemClang, TestIsRealFloatingPointType) {
   EXPECT_FALSE(m_ast->GetType(ast.Ibm128Ty).IsRealFloatingPointType());
 }
 
+TEST_F(TestTypeSystemClang, TestGetIsComplexType) {
+  // Tests CompilerType::IsComplexType
+
+  const ASTContext &ast = m_ast->getASTContext();
+
+  EXPECT_TRUE(m_ast->GetType(ast.getComplexType(ast.IntTy)).IsComplexType());
+  EXPECT_TRUE(m_ast->GetType(ast.getComplexType(ast.FloatTy)).IsComplexType());
+  EXPECT_TRUE(m_ast->GetType(ast.getComplexType(ast.VoidTy)).IsComplexType());
+  EXPECT_FALSE(m_ast
+                   ->GetType(ast.getIncompleteArrayType(
+                       ast.getComplexType(ast.FloatTy), /*ASM=*/{},
+                       /*IndexTypeQuals=*/{}))
+                   .IsComplexType());
+}
+
 TEST_F(TestTypeSystemClang, AsmLabel_CtorDtor) {
   // Tests TypeSystemClang::DeclGetMangledName for constructors/destructors
   // with and without AsmLabels.


### PR DESCRIPTION
Depends on:
* https://github.com/llvm/llvm-project/pull/178904

(only last commit is relevant for the review)

This is part of a patch series to clean up the TypeSystemClang::IsFloatingPointType API. The `is_complex` parameter is rarely checked. This patch introduces a `CompilerType::IsComplexType` API which callers that previously checked `is_complex` can use instead.

This will also allow us to remove `CompilerType::IsFloat`, which is just `IsFloatingPointType` that ignores the `is_complex` parameter.