### PR TITLE
[AsmPrinter] Add a command-line option to emit stack usage files

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -192,6 +192,11 @@ static cl::opt<bool> PrintLatency(
     cl::desc("Print instruction latencies as verbose asm comments"), cl::Hidden,
     cl::init(false));
 
+static cl::opt<std::string>
+    StackUsageFile("stack-usage-file",
+                   cl::desc("Output filename for stack usage information"),
+                   cl::value_desc("filename"), cl::Hidden);
+
 extern cl::opt<bool> EmitBBHash;
 
 STATISTIC(EmittedInsts, "Number of machine instrs printed");
@@ -1672,7 +1677,9 @@ void AsmPrinter::emitStackSizeSection(const MachineFunction &MF) {
 }
 
 void AsmPrinter::emitStackUsage(const MachineFunction &MF) {
-  const std::string &OutputFilename = MF.getTarget().Options.StackUsageFile;
+  const std::string OutputFilename =
+      !StackUsageFile.empty() ? StackUsageFile
+                              : MF.getTarget().Options.StackUsageFile;
 
   // OutputFilename empty implies -fstack-usage is not passed.
   if (OutputFilename.empty())

--- a/llvm/test/CodeGen/X86/stack-usage-file.ll
+++ b/llvm/test/CodeGen/X86/stack-usage-file.ll
@@ -1,0 +1,13 @@
+; RUN: llc < %s -mtriple x86_64-unknown-linux-gnu -stack-usage-file=%t.su
+; RUN: FileCheck --input-file=%t.su %s
+
+declare void @g(ptr)
+
+define void @f() {
+  %a = alloca [64 x i8]
+  call void @g(ptr %a)
+  ret void
+}
+
+; CHECK: f {{[0-9]+}} static
+

--- a/llvm/test/CodeGen/X86/stack-usage-file.ll
+++ b/llvm/test/CodeGen/X86/stack-usage-file.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s -mtriple x86_64-unknown-linux-gnu -stack-usage-file=%t.su
+; RUN: llc < %s -mtriple=x86_64 -stack-usage-file=%t.su
 ; RUN: FileCheck --input-file=%t.su %s
 
 declare void @g(ptr)
@@ -9,5 +9,4 @@ define void @f() {
   ret void
 }
 
-; CHECK: f {{[0-9]+}} static
-
+; CHECK: f [[#]] static


### PR DESCRIPTION
Preparation for #178005.

This will allow stack usage files to be requested during the linking step in LTO builds, in a more straightforward way than via TargetOptions.