### PR TITLE
[mlir][tensor]-Handle Dynamic Offset in BubbleUpSliceOpThroughCollapse

### DIFF
--- a/mlir/include/mlir/Dialect/Tensor/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Tensor/Transforms/Transforms.h
@@ -156,14 +156,14 @@ getCollapsedExtractSliceInfo(OpBuilder &b, tensor::ExtractSliceOp sliceOp,
 
 /// Computes the offsets, sizes, and strides needed to build an expanded
 /// `sliceOp`. The dimensions to expand are specified by `reassociation` and
-/// `expandedShape`.
+/// the shape of `expandedValue`.
 ///
 /// This fails when the specified expansion cannot be represented by a valid
 /// ExtractSliceOp.
 LogicalResult
 getExpandedExtractSliceInfo(OpBuilder &b, tensor::ExtractSliceOp sliceOp,
                             ArrayRef<ReassociationIndices> reassociation,
-                            ArrayRef<int64_t> expandedShape,
+                            Value expandedValue,
                             SmallVectorImpl<OpFoldResult> &expandedOffsets,
                             SmallVectorImpl<OpFoldResult> &expandedSizes,
                             SmallVectorImpl<OpFoldResult> &expandedStrides);

--- a/mlir/lib/Dialect/Tensor/Transforms/ReshapePatterns.cpp
+++ b/mlir/lib/Dialect/Tensor/Transforms/ReshapePatterns.cpp
@@ -722,8 +722,7 @@ static LogicalResult computeExpandedSliceInfoForReassocGroup(
       // to check the validity of the range.
       if ((expandedShapeSize % currentCollapsedsize) != 0)
         return failure();
-      if (!isMultipleOf(collapsedOffset,
-                        currentOffsetDivisor * currentCollapsedsize))
+      if (!isMultipleOf(collapsedOffset, staticSize.value()))
         return failure();
     }
     // Slicing dimension gets the remaining collapsed size.

--- a/mlir/test/Dialect/Tensor/bubble-up-extract-slice-op.mlir
+++ b/mlir/test/Dialect/Tensor/bubble-up-extract-slice-op.mlir
@@ -135,7 +135,8 @@ func.func @bubble_up_extract_slice_affine_apply_not_folded(%src: tensor<60xf32>,
 
 // CHECK-LABEL:   func.func @bubble_up_extract_slice_through_collapse_shape_single_reassoc_group(
 // CHECK-SAME:                   %[[SRC:.*]]: tensor<6x5x2xf32>) -> tensor<1xf32> {
-// CHECK:           %[[EXTRACT:.*]] = tensor.extract_slice %[[SRC]][0, 0, 0] [1, 1, 1] [1, 1, 1]
+// CHECK:           %[[C0:.*]] = arith.constant 0 : index
+// CHECK:           %[[EXTRACT:.*]] = tensor.extract_slice %[[SRC]][%[[C0]], %[[C0]], %[[C0]]] [1, 1, 1] [1, 1, 1]
 // CHECK:           %[[COLLAPSE:.*]] = tensor.collapse_shape %[[EXTRACT]] {{\[\[}}0, 1, 2]]
 // CHECK:           return %[[COLLAPSE]]
 func.func @bubble_up_extract_slice_through_collapse_shape_single_reassoc_group(%src: tensor<6x5x2xf32>) -> tensor<1xf32> {
@@ -146,7 +147,9 @@ func.func @bubble_up_extract_slice_through_collapse_shape_single_reassoc_group(%
 
 // CHECK-LABEL:   func.func @bubble_up_extract_slice_through_collapse_shape_multiple_reassoc_group(
 // CHECK-SAME:                      %[[SRC:.*]]: tensor<6x5x3x10xf32>) -> tensor<15x10xf32> {
-// CHECK:           %[[EXTRACT:.*]] = tensor.extract_slice %[[SRC]][1, 0, 1, 0] [3, 5, 1, 10] [1, 1, 1, 1]
+// CHECK-DAG:       %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : index
+// CHECK:           %[[EXTRACT:.*]] = tensor.extract_slice %[[SRC]][%[[C1]], %[[C0]], %[[C1]], %[[C0]]] [3, 5, 1, 10] [1, 1, 1, 1]
 // CHECK:           %[[COLLAPSE:.*]] = tensor.collapse_shape %[[EXTRACT]] {{\[\[}}0, 1], [2, 3]]
 // CHECK:           return %[[COLLAPSE]]
 func.func @bubble_up_extract_slice_through_collapse_shape_multiple_reassoc_group(%src: tensor<6x5x3x10xf32>) -> tensor<15x10xf32> {
@@ -157,7 +160,9 @@ func.func @bubble_up_extract_slice_through_collapse_shape_multiple_reassoc_group
 
 // CHECK-LABEL:   func.func @bubble_up_extract_slice_through_collapse_shape_offset_on_leading_dim(
 // CHECK-SAME:                         %[[SRC:.*]]: tensor<6x5x2xf32>) -> tensor<4xf32> {
-// CHECK:           %[[EXTRACT:.*]] = tensor.extract_slice %[[SRC]][2, 0, 0] [1, 2, 2] [1, 1, 1] 
+// CHECK-DAG:       %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : index
+// CHECK:           %[[EXTRACT:.*]] = tensor.extract_slice %[[SRC]][%[[C2]], %[[C0]], %[[C0]]] [1, 2, 2] [1, 1, 1]
 // CHECK:           %[[COLLAPSE:.*]] = tensor.collapse_shape %[[EXTRACT]] {{\[\[}}0, 1, 2]]
 // CHECK:           return %[[COLLAPSE]]
 func.func @bubble_up_extract_slice_through_collapse_shape_offset_on_leading_dim(%src: tensor<6x5x2xf32>) -> tensor<4xf32> {
@@ -219,7 +224,9 @@ func.func @bubble_up_extract_slice_through_collapse_shape_dynamic_offset_and_siz
 // CHECK-SAME:                      %[[SRC:.*]]: tensor<5x10x1x1x40xf32>,
 // CHECK-SAME:                      %[[OFFSET:.*]]: index,
 // CHECK-SAME:                      %[[SIZE:.*]]: index) -> tensor<20x?xf32> {
-// CHECK:           %[[EXTRACT:.*]] = tensor.extract_slice %[[SRC]][1, 0, 0, 0, %[[OFFSET]]] [2, 10, 1, 1, %[[SIZE]]] [1, 1, 1, 1, 1]
+// CHECK-DAG:       %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[C0:.*]] = arith.constant 0 : index
+// CHECK:           %[[EXTRACT:.*]] = tensor.extract_slice %[[SRC]][%[[C1]], %[[C0]], 0, 0, %[[OFFSET]]] [2, 10, 1, 1, %[[SIZE]]] [1, 1, 1, 1, 1]
 // CHECK:           %[[COLLAPSE:.*]] = tensor.collapse_shape %[[EXTRACT]] {{\[\[}}0, 1], [2, 3, 4]]
 // CHECK:           return %[[COLLAPSE]]
 func.func @bubble_up_extract_slice_through_collapse_shape_dynamic_and_static_groups(%src: tensor<5x10x1x1x40xf32>, %offset : index, %size : index) -> tensor<20x?xf32> {


### PR DESCRIPTION
This patch extends the `BubbleUpExtractSliceThroughCollapseShape` pattern to handle cases where `tensor.extract_slice` has a dynamic offset.

During tile and fuse transformations, it is common to encounter IR where `tensor.extract_slice` operations appear after `tensor.collapse_shape`. These patterns are used as cleanup transformations to canonicalize the IR by bubbling up the slice operation before the reshape. This enables further optimizations and simplifications downstream.

Previously, the pattern only handled:
  1. Static offsets and sizes.
  2. Dynamic sizes with a single non-unit expanded dimension.

This left a gap for additional common cases where we may have:
 - Dynamic offsets with size == 1 (single element extraction).
 - Size greater than 1 but the offset is computed dynamically.

Regarding the first case, It's always legal to perform such a transformation.

Regarding the second case (i.e. dynamic offset with static
 size > 1) we can guarantee contiguity by more restricted
conditions:

  1. The innermost expanded dimension is divisible by the slice size (ensures the slice fits within a single "row")
  2. The offset is probably a multiple of the slice size (ensures the slice starts at an aligned boundary)

For example, given:
  - collapse_shape: tensor<6x10xf32> -> tensor<60xf32>
  - extract_slice at offset with size

If 10 % size == 0 and offset % 5 == 0, the slice is guaranteed contiguous. The transformation delinearizes the offset to get [row, col] indices and extracts [1, size] from the expanded 6x10 shape.

The offset divisibility check uses affine analysis to statically verify that affine expressions (e.g., `idx * 5`) are multiples of the slice size.