### PR TITLE
[analyzer] Fix crash when copying uninitialized data in function named "swap"

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/UndefinedAssignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UndefinedAssignmentChecker.cpp
@@ -40,12 +40,9 @@ void UndefinedAssignmentChecker::checkBind(SVal location, SVal val,
   // Do not report assignments of uninitialized values inside swap functions.
   // This should allow to swap partially uninitialized structs
   if (const FunctionDecl *EnclosingFunctionDecl =
-          dyn_cast<FunctionDecl>(C.getStackFrame()->getDecl())) {
-    if (C.getCalleeName(EnclosingFunctionDecl) == "swap") {
-      C.generateSink(C.getState(), C.getPredecessor());
+      dyn_cast<FunctionDecl>(C.getStackFrame()->getDecl()))
+    if (C.getCalleeName(EnclosingFunctionDecl) == "swap")
       return;
-    }
-  }
 
   ExplodedNode *N = C.generateErrorNode();
 

--- a/clang/lib/StaticAnalyzer/Checkers/UndefinedAssignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UndefinedAssignmentChecker.cpp
@@ -40,9 +40,12 @@ void UndefinedAssignmentChecker::checkBind(SVal location, SVal val,
   // Do not report assignments of uninitialized values inside swap functions.
   // This should allow to swap partially uninitialized structs
   if (const FunctionDecl *EnclosingFunctionDecl =
-      dyn_cast<FunctionDecl>(C.getStackFrame()->getDecl()))
-    if (C.getCalleeName(EnclosingFunctionDecl) == "swap")
+          dyn_cast<FunctionDecl>(C.getStackFrame()->getDecl())) {
+    if (C.getCalleeName(EnclosingFunctionDecl) == "swap") {
+      C.generateSink(C.getState(), C.getPredecessor());
       return;
+    }
+  }
 
   ExplodedNode *N = C.generateErrorNode();
 

--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -2659,11 +2659,8 @@ RegionStoreManager::bindArray(LimitedRegionBindingsConstRef B,
     return bindAggregate(B, R, Init);
   }
 
-  if (isa<nonloc::SymbolVal>(Init))
+  if (isa<nonloc::SymbolVal, UnknownVal, UndefinedVal>(Init))
     return bindAggregate(B, R, Init);
-
-  if (Init.isUnknown())
-    return bindAggregate(B, R, UnknownVal());
 
   // Remaining case: explicit compound values.
   const nonloc::CompoundVal& CV = Init.castAs<nonloc::CompoundVal>();

--- a/clang/test/Analysis/uninit-vals.cpp
+++ b/clang/test/Analysis/uninit-vals.cpp
@@ -33,3 +33,21 @@ void foo() {
 }
 }
 
+namespace gh_178797 {
+struct SpecialBuffer {
+    SpecialBuffer() : src(defaultBuffer), dst(defaultBuffer) {}
+    int* src;
+    int* dst;
+    int defaultBuffer[2];
+};
+// Not really a swap, but we need an assignment assigning UndefinedVal
+// within a "swap" function to trigger this behavior.
+void swap(int& lhs, int& rhs) {
+    lhs = rhs; // no-crash
+    // Not reporting copying uninitialized data because that is explicitly suppressed in the checker.
+}
+void entry_point() {
+    SpecialBuffer special;
+    swap(*special.dst, *++special.src);
+}
+}  // namespace gh_178797


### PR DESCRIPTION
So the RegionStore has some assumptions, namely that the core.unitialized.Assign checker is enabled and detects copying Undefined (read of uninitialized data) before the Store is instructed to model this.

As it turns out, there is a little hack in the UndefinedAssignmentChecker:
```c++
void UndefinedAssignmentChecker::checkBind(SVal location, SVal val,
                                           const Stmt *StoreE, bool AtDeclInit,
                                           CheckerContext &C) const {
  if (!val.isUndef())
    return;

  // Do not report assignments of uninitialized values inside swap functions.
  // This should allow to swap partially uninitialized structs
  if (const FunctionDecl *EnclosingFunctionDecl =
      dyn_cast<FunctionDecl>(C.getStackFrame()->getDecl()))
    if (C.getCalleeName(EnclosingFunctionDecl) == "swap")
      return;
  // ...
```

This meant that no Sink node was inserted by the checker, thus the Store would just go and try to fulfill the bind operation.

However, the Store also assumed that it's not going to see Undefined vals, so that case wasn't handled, but simply cast the value to a nonloc::CompoundVal.

The checker should have created the Sink node regardless if it wants to emit a report or not.
In addition to this, I'm also hardedning the Store to also be able to handle UndefinedVals a bit better.

The crash bisects to #118096, but that's only surfaced this issue.

Fixes #178797