### PR TITLE
[AMDGPU] Propagate debug info to constant materialization instr

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -1754,9 +1754,8 @@ class ConstantSDNode : public SDNode {
   const ConstantInt *Value;
 
   ConstantSDNode(bool isTarget, bool isOpaque, const ConstantInt *val,
-                 SDVTList VTs)
-      : SDNode(isTarget ? ISD::TargetConstant : ISD::Constant, 0, DebugLoc(),
-               VTs),
+                 SDVTList VTs, const DebugLoc &dl)
+      : SDNode(isTarget ? ISD::TargetConstant : ISD::Constant, 0, dl, VTs),
         Value(val) {
     assert(!isa<VectorType>(val->getType()) && "Unexpected vector type!");
     ConstantSDNodeBits.IsOpaque = isOpaque;

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -3542,6 +3542,10 @@ public:
   /// passed to the fp16 to fp conversion library function.
   virtual bool shouldKeepZExtForFP16Conv() const { return false; }
 
+  /// Targets that materialize constants to registers (e.g., AMDGPU) may benefit
+  /// from having debug locations on constant nodes for improved debug stepping.
+  virtual bool shouldPropagateConstantDebugLoc() const { return false; }
+
   /// Should we generate fp_to_si_sat and fp_to_ui_sat from type FPVT to type VT
   /// from min(max(fptoi)) saturation patterns.
   virtual bool shouldConvertFpToSat(unsigned Op, EVT FPVT, EVT VT) const {

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -1796,7 +1796,10 @@ SDValue SelectionDAG::getConstant(const ConstantInt &Val, const SDLoc &DL,
       return SDValue(N, 0);
 
   if (!N) {
-    N = newSDNode<ConstantSDNode>(isT, isO, Elt, VTs);
+    DebugLoc DbgLoc;
+    if (TLI->shouldPropagateConstantDebugLoc())
+      DbgLoc = DL.getDebugLoc();
+    N = newSDNode<ConstantSDNode>(isT, isO, Elt, VTs, DbgLoc);
     CSEMap.InsertNode(N, IP);
     InsertNode(N);
     NewSDValueDbgMsg(SDValue(N, 0), "Creating constant: ", this);

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.h
@@ -281,6 +281,8 @@ public:
 
   bool shouldPreservePtrArith(const Function &F, EVT PtrVT) const override;
 
+  bool shouldPropagateConstantDebugLoc() const override { return true; }
+
   bool canTransformPtrArithOutOfBounds(const Function &F,
                                        EVT PtrVT) const override;
 

--- a/llvm/test/CodeGen/AMDGPU/ptr-arg-dbg-value.ll
+++ b/llvm/test/CodeGen/AMDGPU/ptr-arg-dbg-value.ll
@@ -17,9 +17,9 @@ define hidden void @ptr_arg_split_subregs(ptr %arg1) #0 !dbg !9 {
 ; CHECK-NEXT:    ;DEBUG_VALUE: ptr_arg_split_subregs:a <- [DW_OP_LLVM_fragment 32 32] [$vgpr1+0]
 ; CHECK-NEXT:    ;DEBUG_VALUE: ptr_arg_split_subregs:a <- [DW_OP_LLVM_fragment 0 32] [$vgpr0+0]
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CHECK-NEXT:    v_mov_b32_e32 v2, 1
 ; CHECK-NEXT:  .Ltmp0:
 ; CHECK-NEXT:    .loc 1 7 13 prologue_end ; example.cpp:7:13
+; CHECK-NEXT:    v_mov_b32_e32 v2, 1
 ; CHECK-NEXT:    flat_store_dword v[0:1], v2 offset:396
 ; CHECK-NEXT:    .loc 1 8 5 ; example.cpp:8:5
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -46,9 +46,9 @@ define hidden void @ptr_arg_split_reg_mem(<30 x i32>, ptr %arg2) #0 !dbg !25 {
 ; CHECK-NEXT:    ;DEBUG_VALUE: ptr_arg_split_reg_mem:b <- [$vgpr30+0]
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    buffer_load_dword v31, off, s[0:3], s32
-; CHECK-NEXT:    v_mov_b32_e32 v0, 1
 ; CHECK-NEXT:  .Ltmp2:
 ; CHECK-NEXT:    .loc 1 12 13 prologue_end ; example.cpp:12:13
+; CHECK-NEXT:    v_mov_b32_e32 v0, 1
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
 ; CHECK-NEXT:    flat_store_dword v[30:31], v0 offset:396
 ; CHECK-NEXT:    .loc 1 13 5 ; example.cpp:13:5
@@ -72,9 +72,9 @@ define hidden void @ptr_arg_in_memory(<32 x i32>, ptr %arg3) #0 !dbg !31 {
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:8
 ; CHECK-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4
-; CHECK-NEXT:    v_mov_b32_e32 v2, 1
 ; CHECK-NEXT:  .Ltmp4:
 ; CHECK-NEXT:    .loc 1 17 13 prologue_end ; example.cpp:17:13
+; CHECK-NEXT:    v_mov_b32_e32 v2, 1
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
 ; CHECK-NEXT:    flat_store_dword v[0:1], v2 offset:396
 ; CHECK-NEXT:    .loc 1 18 5 ; example.cpp:18:5

--- a/llvm/test/DebugInfo/AMDGPU/constant-materialization-debug-loc.ll
+++ b/llvm/test/DebugInfo/AMDGPU/constant-materialization-debug-loc.ll
@@ -1,0 +1,35 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1200 -O0 < %s | FileCheck %s
+
+; Test that constant materialization instructions get debug locations.
+
+define amdgpu_kernel void @test_constant_debug_loc(ptr addrspace(1) %out, i32 %x) !dbg !7 {
+entry:
+  ; Compare against constant 15 - this will generate S_MOV_B32 to materialize the constant
+  %cmp = icmp ugt i32 %x, 15, !dbg !11
+  %sel = select i1 %cmp, i32 100, i32 200, !dbg !12
+  store i32 %sel, ptr addrspace(1) %out, align 4, !dbg !13
+  ret void, !dbg !14
+}
+
+; Verify constant 15 is materialized under the .loc scope from line 5
+; CHECK: .loc	1 5 14
+; CHECK: s_mov_b32 s{{[0-9]+}}, 15
+; CHECK: .loc	1 6 10
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!4, !5}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "test.cl", directory: "/tmp")
+!2 = !{}
+!4 = !{i32 2, !"Dwarf Version", i32 4}
+!5 = !{i32 2, !"Debug Info Version", i32 3}
+!7 = distinct !DISubprogram(name: "test_constant_debug_loc", scope: !1, file: !1, line: 1, type: !8, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !2)
+!8 = !DISubroutineType(types: !9)
+!9 = !{null, !10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !DILocation(line: 5, column: 14, scope: !7)
+!12 = !DILocation(line: 6, column: 10, scope: !7)
+!13 = !DILocation(line: 7, column: 3, scope: !7)
+!14 = !DILocation(line: 8, column: 1, scope: !7)
+


### PR DESCRIPTION
Constant materialization instruction (S_MOV_B32)
is assigned appropriate debug location.