### PR TITLE
[clang][bytecode] Fix crash on __builtin_infer_alloc_token with struct argument

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -1399,7 +1399,7 @@ static bool interp__builtin_infer_alloc_token(InterpState &S, CodePtr OpPC,
 
   // We do not read any of the arguments; discard them.
   for (int I = Call->getNumArgs() - 1; I >= 0; --I)
-    discard(S.Stk, *S.getContext().classify(Call->getArg(I)));
+    discard(S.Stk, S.getContext().classify(Call->getArg(I)).value_or(PT_Ptr));
 
   // Note: Type inference from a surrounding cast is not supported in
   // constexpr evaluation.

--- a/clang/test/SemaCXX/alloc-token.cpp
+++ b/clang/test/SemaCXX/alloc-token.cpp
@@ -79,4 +79,9 @@ void negative_tests() {
   negative_template_test<void>(); // expected-note {{in instantiation of function template specialization 'negative_template_test<void>' requested here}}
   constexpr auto inference_fail = __builtin_infer_alloc_token(123); // expected-error {{must be initialized by a constant expression}} \
                                                                     // expected-note {{could not infer allocation type for __builtin_infer_alloc_token}}
+
+  // PR178892: Ensure struct arguments don't crash the bytecode interpreter.
+  struct S {};
+  constexpr auto struct_arg = __builtin_infer_alloc_token(S()); // expected-error {{must be initialized by a constant expression}} \
+                                                                // expected-note {{could not infer allocation type for __builtin_infer_alloc_token}}
 }


### PR DESCRIPTION
## Summary
- Fix crash when passing non primitive types (structs) to `__builtin_infer_alloc_token`
- The bytecode interpreter's discard loop dereferenced an empty `OptPrimType` for non primitive arguments

## Test plan
- Added regression test in `clang/test/SemaCXX/alloc-token.cpp`
- Existing tests continue to pass

Fixes #178892