### PR TITLE
[flang] Reject SIZE of TRANSFER with non-constant source in constant expressions

### DIFF
--- a/flang/lib/Evaluate/check-expression.cpp
+++ b/flang/lib/Evaluate/check-expression.cpp
@@ -133,12 +133,12 @@ bool IsConstantExprHelper<INVARIANT>::operator()(
       auto base{ExtractNamedEntity(call.arguments()[0]->UnwrapExpr())};
       if (base) {
         auto shape{GetShape(*base)};
-	return shape && IsConstantExprShape(*shape);
+        return shape && IsConstantExprShape(*shape);
       } else {
         // Argument is not a named entity (e.g., it's a function call);
-	// it must be a constant expression for SIZE/SHAPE to be constant.
-	const auto *argExpr{call.arguments()[0]->UnwrapExpr()};
-	return argExpr && (*this)(*argExpr);
+        // it must be a constant expression for SIZE/SHAPE to be constant.
+        const auto *argExpr{call.arguments()[0]->UnwrapExpr()};
+        return argExpr && (*this)(*argExpr);
       }
     } else if (proc.IsPure()) {
       std::size_t j{0};

--- a/flang/lib/Evaluate/fold-integer.cpp
+++ b/flang/lib/Evaluate/fold-integer.cpp
@@ -14,7 +14,7 @@
 namespace Fortran::evaluate {
 
 // Check if the argument is a TRANSFER intrinsic call with a non-constant
-// source. SIZE of such a call cannot be folded.
+// source.
 static bool IsNonConstantTransferArg(const ActualArgument &arg) {
   if (const auto *expr{arg.UnwrapExpr()}) {
     if (const auto *procRef{UnwrapProcedureRef(*expr)}) {
@@ -1408,9 +1408,10 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
           return result.value;
         }));
   } else if (name == "size") {
-    // Don't fold SIZE of TRANSFER with non-constant source.
+    // Warn about SIZE of TRANSFER with non-constant source.
     if (IsNonConstantTransferArg(args[0].value())) {
-      return Expr<T>{std::move(funcRef)};
+      context.Warn(common::UsageWarning::Portability,
+          "SIZE(TRANSFER(variable,..)) is not portable"_port_en_US);
     }
     if (auto shape{GetContextFreeShape(context, args[0])}) {
       if (args[1]) { // DIM= is present, get one extent

--- a/flang/test/Semantics/size-const.f90
+++ b/flang/test/Semantics/size-const.f90
@@ -1,6 +1,6 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror -Wno-unused-variable
 ! Test that SIZE of TRANSFER with non-constant SOURCE argument
-! is not accepted as a constant expression (per F2018 10.1.12)
+! emits a portability warning.
 
 program test
   implicit none
@@ -11,9 +11,10 @@ program test
   type(t) :: s
   type(t), parameter :: s_const = t(42)
 
-  !ERROR: Must be a constant value
+  ! These should warn: s is not a constant (portability issue)
+  !PORTABILITY: SIZE(TRANSFER(variable,..)) is not portable [-Wportability]
   integer :: k = size(transfer(s, [1]))
-  !ERROR: Must be a constant value
+  !PORTABILITY: SIZE(TRANSFER(variable,..)) is not portable [-Wportability]
   integer, parameter :: m = size(transfer(s, [1]))
 
   integer :: ok1 = size(transfer(s_const, [1]))

--- a/flang/test/Semantics/size-const.f90
+++ b/flang/test/Semantics/size-const.f90
@@ -1,0 +1,22 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! Test that SIZE of TRANSFER with non-constant SOURCE argument
+! is not accepted as a constant expression (per F2018 10.1.12)
+
+program test
+  implicit none
+  type t
+    integer :: n
+  end type t
+
+  type(t) :: s
+  type(t), parameter :: s_const = t(42)
+
+  !ERROR: Must be a constant value
+  integer :: k = size(transfer(s, [1]))
+  !ERROR: Must be a constant value
+  integer, parameter :: m = size(transfer(s, [1]))
+
+  integer :: ok1 = size(transfer(s_const, [1]))
+  integer, parameter :: ok2 = size(transfer(s_const, [1]))
+
+end program test


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/178426.
Flang incorrectly accepted `SIZE(TRANSFER(variable, [1]))` in constant expression contexts. Per F2018 10.1.12, inquiry function arguments must be constant expressions. This patch prevents folding SIZE when their argument is a TRANSFER call with non-constant source, allowing semantic analysis to diagnose the error. 