### PR TITLE
[flang] Add support for additional compiler directive sentinel

### DIFF
--- a/flang/include/flang/Parser/options.h
+++ b/flang/include/flang/Parser/options.h
@@ -36,7 +36,7 @@ struct Options {
   bool prescanAndReformat{false}; // -E
   bool expandIncludeLinesInPreprocessedOutput{true};
   bool showColors{false};
-  std::vector<std::string> compilerDirectivesSentinels;
+  std::vector<std::string> compilerDirectiveSentinels;
 };
 
 } // namespace Fortran::parser

--- a/flang/include/flang/Parser/options.h
+++ b/flang/include/flang/Parser/options.h
@@ -36,6 +36,7 @@ struct Options {
   bool prescanAndReformat{false}; // -E
   bool expandIncludeLinesInPreprocessedOutput{true};
   bool showColors{false};
+  std::vector<std::string> compilerDirectivesSentinels;
 };
 
 } // namespace Fortran::parser

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -1340,7 +1340,7 @@ constexpr auto noinlineDir{
     "NOINLINE" >> construct<CompilerDirective::NoInline>()};
 constexpr auto inlineDir{"INLINE" >> construct<CompilerDirective::Inline>()};
 constexpr auto ivdep{"IVDEP" >> construct<CompilerDirective::IVDep>()};
-TYPE_PARSER(beginDirective >> "DIR$ "_tok >>
+TYPE_PARSER(beginDirective >> some(letter) >> "$ "_tok >>
     sourced((construct<CompilerDirective>(ignore_tkr) ||
                 construct<CompilerDirective>(loopCount) ||
                 construct<CompilerDirective>(assumeAligned) ||

--- a/flang/lib/Parser/parsing.cpp
+++ b/flang/lib/Parser/parsing.cpp
@@ -97,6 +97,9 @@ const SourceFile *Parsing::Prescan(const std::string &path, Options options) {
     prescanner.AddCompilerDirectiveSentinel("$cuf");
     prescanner.AddCompilerDirectiveSentinel("@cuf");
   }
+  for (const auto &sentinel : options.compilerDirectivesSentinels) {
+    prescanner.AddCompilerDirectiveSentinel(sentinel);
+  }
   ProvenanceRange range{allSources.AddIncludedFile(
       *sourceFile, ProvenanceRange{}, options.isModuleFile)};
   prescanner.Prescan(range);

--- a/flang/lib/Parser/parsing.cpp
+++ b/flang/lib/Parser/parsing.cpp
@@ -97,7 +97,7 @@ const SourceFile *Parsing::Prescan(const std::string &path, Options options) {
     prescanner.AddCompilerDirectiveSentinel("$cuf");
     prescanner.AddCompilerDirectiveSentinel("@cuf");
   }
-  for (const auto &sentinel : options.compilerDirectivesSentinels) {
+  for (const auto &sentinel : options.compilerDirectiveSentinels) {
     prescanner.AddCompilerDirectiveSentinel(sentinel);
   }
   ProvenanceRange range{allSources.AddIncludedFile(

--- a/flang/test/Parser/compiler-directive-sentinel.f90
+++ b/flang/test/Parser/compiler-directive-sentinel.f90
@@ -1,0 +1,14 @@
+! RUN: bbc -sentinel-test=sen$ --pft-test %s -o - 2>&1 | FileCheck %s
+
+! Test support additional compiler directive sentinels.
+
+module test_sentinel
+  interface
+  subroutine alternative_sentinel(a)
+    integer(4) :: a
+    !sen$ ignore_tkr a
+    !CHECK: CompilerDirective: !ignore_tkr a
+  end subroutine
+end interface
+
+end module test_sentinel

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -375,7 +375,7 @@ static llvm::LogicalResult convertFortranSourceToMLIR(
   // prep for prescan and parse
   Fortran::parser::Parsing parsing{semanticsContext.allCookedSources()};
   if (!compilerDirectiveSentinel.empty()) {
-    options.compilerDirectivesSentinels.push_back(compilerDirectiveSentinel);
+    options.compilerDirectiveSentinels.push_back(compilerDirectiveSentinel);
   }
   parsing.Prescan(path, options);
   if (!parsing.messages().empty() && (parsing.messages().AnyFatalError())) {

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -237,6 +237,11 @@ static llvm::cl::opt<std::string>
     enableGPUMode("gpu", llvm::cl::desc("Enable GPU Mode managed|unified"),
                   llvm::cl::init(""));
 
+static llvm::cl::opt<std::string>
+    compilerDirectiveSentinel("sentinel-test",
+                              llvm::cl::desc("Test additional sentinel"),
+                              llvm::cl::init("dir$"));
+
 static llvm::cl::opt<bool> fixedForm("ffixed-form",
                                      llvm::cl::desc("enable fixed form"),
                                      llvm::cl::init(false));
@@ -369,6 +374,9 @@ static llvm::LogicalResult convertFortranSourceToMLIR(
 
   // prep for prescan and parse
   Fortran::parser::Parsing parsing{semanticsContext.allCookedSources()};
+  if (!compilerDirectiveSentinel.empty()) {
+    options.compilerDirectivesSentinels.push_back(compilerDirectiveSentinel);
+  }
   parsing.Prescan(path, options);
   if (!parsing.messages().empty() && (parsing.messages().AnyFatalError())) {
     llvm::errs() << programPrefix << "could not scan " << path << '\n';


### PR DESCRIPTION
This patch allows to set up additional compiler directive sentinel in addition to the default `!dir$`. Some user code could use other vendor specific compiler directive sentinel and this solution allows to add them to the parser options. 