### PR TITLE
[clang][dataflow] Fix assignment of unknown values.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -170,7 +170,7 @@ public:
 
       auto *RHSVal = Env.getValue(*RHS);
       if (RHSVal == nullptr)
-        break;
+        RHSVal = Env.createValue(LHS->getType());
 
       // Assign a value to the storage location of the left-hand side.
       Env.setValue(*LHSLoc, *RHSVal);

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -971,7 +971,7 @@ TEST(TransferTest, BinaryOperatorAssignUnknown) {
          ASTContext &ASTCtx) {
         ASSERT_THAT(Results.keys(), UnorderedElementsAre("p", "q", "r"));
 
-        // Check that the second unknown value is different.
+        // Check that the second/third unknown value is different.
         const Environment &EnvP = getEnvironmentAtAnnotation(Results, "p");
 
         const ValueDecl *FooAtADecl = findValueDecl(ASTCtx, "FooAtA");

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -1000,8 +1000,8 @@ TEST(TransferTest, BinaryOperatorAssignUnknown) {
         const StorageLocation *BOLoc = EnvP.getStorageLocation(*BO);
         EXPECT_NE(BOLoc, nullptr);
 
-        // Check that the branches are reachable
-        // with a non-false flow condition.
+        // Check that the branches are reachable with a non-false
+        // flow condition.
         const Environment &EnvQ = getEnvironmentAtAnnotation(Results, "q");
         const Environment &EnvR = getEnvironmentAtAnnotation(Results, "r");
 


### PR DESCRIPTION
Just because the right-hand side of the assignment doesn't have a known value, doesn't mean the left-hand side gets to keep its old value.