### PR TITLE
[ThinLTO] Stop attempting variable import once we see a non-variable

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -435,14 +435,24 @@ class GlobalsImporter final {
 
       for (const auto &RefSummary : VI.getSummaryList()) {
         const auto *GVS = dyn_cast<GlobalVarSummary>(RefSummary.get());
+        // Stop looking if this is not a global variable, e.g. a function.
         // Functions could be referenced by global vars - e.g. a vtable; but we
         // don't currently imagine a reason those would be imported here, rather
         // than as part of the logic deciding which functions to import (i.e.
         // based on profile information). Should we decide to handle them here,
         // we can refactor accordingly at that time.
+        // Note that it is safe to stop looking because the one case where we
+        // might have to import (a read/write-only global variable) cannot occur
+        // if this GUID has a non-variable summary. The only case where we even
+        // might find another summary in the list that is a variable is in the
+        // case of same-named locals in different modules not compiled with
+        // enough path, and during attribute propagation we will mark all
+        // summaries for a GUID (ValueInfo) as non read/write-only if any is not
+        // a global variable.
+        if (!GVS)
+          break;
         bool CanImportDecl = false;
-        if (!GVS ||
-            shouldSkipLocalInAnotherModule(GVS, VI.getSummaryList().size(),
+        if (shouldSkipLocalInAnotherModule(GVS, VI.getSummaryList().size(),
                                            Summary.modulePath()) ||
             !Index.canImportGlobalVar(GVS, /* AnalyzeRefs */ true,
                                       CanImportDecl)) {


### PR DESCRIPTION
This is a compile time improvement. Instead of looking through every
single copy of a value (of which there can be many for large targets
with linkonce_odr copies of the same values) for an importable variable,
stop immediately after we see a non-variable summary.

In most cases this is NFC because we expect all copies of a value to be
of the same type (e.g. all variables, or all functions). This only makes
a noticeable, slightly conservative, change in the case of same-named
local values in different modules compiled without distinguishing path.
The new test shows the effect of this (and is safe due to PR178761).

This makes a large reduction in thin link time for large targets that
have many copies of linkonce_odr vtables, all referencing functions.
