### PR TITLE
[ARM] Remove duplicate statement in ARMLatencyMutations (NFC)

### DIFF
--- a/llvm/lib/Target/ARM/ARMLatencyMutations.cpp
+++ b/llvm/lib/Target/ARM/ARMLatencyMutations.cpp
@@ -109,8 +109,6 @@ InstructionInformation::InstructionInformation(const ARMBaseInstrInfo *TII) {
     Info[op].HasBRegAddrShift = true;
   }
 
-  Info[t2SDIV].IsDivide = Info[t2UDIV].IsDivide = true;
-
   std::initializer_list<unsigned> isInlineShiftALUList = {
       t2ADCrs,  t2ADDSrs, t2ADDrs,  t2BICrs, t2EORrs,
       t2ORNrs,  t2RSBSrs, t2RSBrs,  t2SBCrs, t2SUBrs,
@@ -119,6 +117,8 @@ InstructionInformation::InstructionInformation(const ARMBaseInstrInfo *TII) {
   for (auto op : isInlineShiftALUList) {
     Info[op].IsInlineShiftALU = true;
   }
+
+  Info[t2SDIV].IsDivide = Info[t2UDIV].IsDivide = true;
 
   std::initializer_list<unsigned> isMultiplyList = {
       t2MUL,    t2MLA,     t2MLS,     t2SMLABB, t2SMLABT,  t2SMLAD,   t2SMLADX,

--- a/llvm/lib/Target/ARM/ARMLatencyMutations.cpp
+++ b/llvm/lib/Target/ARM/ARMLatencyMutations.cpp
@@ -120,8 +120,6 @@ InstructionInformation::InstructionInformation(const ARMBaseInstrInfo *TII) {
     Info[op].IsInlineShiftALU = true;
   }
 
-  Info[t2SDIV].IsDivide = Info[t2UDIV].IsDivide = true;
-
   std::initializer_list<unsigned> isMultiplyList = {
       t2MUL,    t2MLA,     t2MLS,     t2SMLABB, t2SMLABT,  t2SMLAD,   t2SMLADX,
       t2SMLAL,  t2SMLALBB, t2SMLALBT, t2SMLALD, t2SMLALDX, t2SMLALTB, t2SMLALTT,


### PR DESCRIPTION
Looks like a copy-paste mistake as this statement is also below the table below it. Chose to remove the duplicate that is before the shifts, since the other one is closer to multiplication.

I do not have merge permissions.