### PR TITLE
[AMDGPU][SIInsertWaitcnt][NFC] Move eventCounter() function

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -478,7 +478,7 @@ public:
   // WaitEventType to corresponding counter values in InstCounterType.
   virtual const WaitEventSet *getWaitEventMask() const = 0;
 
-  /// \Returns the counter that corresponds to event \p E.
+  /// \returns the counter that corresponds to event \p E.
   InstCounterType getCounterFromEvent(WaitEventType E) const {
     const WaitEventSet *WaitEvents = getWaitEventMask();
     for (auto T : inst_counter_types()) {

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -3406,7 +3406,7 @@ bool SIInsertWaitcnts::run(MachineFunction &MF) {
   for (auto T : inst_counter_types())
     ForceEmitWaitcnt[T] = false;
 
-  SmemAccessCounter = WCG->getCounterFromEvent(SMEM_ACCESS);
+  SmemAccessCounter = getCounterFromEvent(SMEM_ACCESS);
 
   BlockInfos.clear();
   bool Modified = false;


### PR DESCRIPTION
The eventCounter() function searches through the array of events. This array is owned by the WaitcntGenerator class.

This patch moves the function into the WaitcntGenerator class which helps hide the event array from the user.
It also renames it to getCounterFromEvent().

This should be NFC.