### PR TITLE
[Thread Analysis] Fix a bug in context update in alias-analysis

### DIFF
--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -2277,7 +2277,6 @@ void BuildLockset::VisitUnaryOperator(const UnaryOperator *UO) {
 void BuildLockset::VisitBinaryOperator(const BinaryOperator *BO) {
   if (!BO->isAssignmentOp())
     return;
-  
   checkAccess(BO->getLHS(), AK_Written);
   updateLocalVarMapCtx(BO);
 }

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -7503,6 +7503,18 @@ void testEscapeInvalidationHappensRightAfterTheCall(Foo* F) {
     unlockFooWithEscapablePointer(&L);
 }
 
+
+void testEscapeInvalidationHappensRightAfterTheCtorCall(Foo* F) {
+  Foo* L = F;
+  MutexLock ScopeLock(&L->mu);
+
+  struct {
+    int DataMember GUARDED_BY(F->mu);
+  } Data;
+
+  Data.DataMember = 0;
+}
+
 void testCleanUpFunctionWithLocalVarUpdated(Foo* F) {
   F->mu.Lock();
   Foo * __attribute__((unused, cleanup(unlockFooWithEscapablePointer))) L = F;

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -7499,10 +7499,9 @@ void testEscapeInvalidationHappensRightAfterTheCall(Foo* F) {
     Foo* L;
     L = F;
     L->mu.Lock();
-    // Release the lock hold by 'L' before clear its definition.
+    // Release the lock held by 'L' before clearing its definition.
     unlockFooWithEscapablePointer(&L);
 }
-
 
 void testEscapeInvalidationHappensRightAfterTheCtorCall(Foo* F) {
   Foo* L = F;


### PR DESCRIPTION
[Thread Analysis] Fix a bug in context update in alias-analysis
    
Previously, in 'updateLocalVarMapCtx', context was updated to the one
immediately after the provided statement 'S'.  It is incorrect,
because 'S' hasn't been processed at that point.  This issue could
result in false positives.  For example,
    
```
    void f(Lock_t* F)
    {
        Lock_t* L = F; // 'L' aliases with 'F'
        L->Lock();     // 'L' holds the lock
        // Before the fix, the analyzer saw the definition of 'L' being cleared before 'L' was unlocked.
        unlock(&L);    // unlock (*L)
    }
```
    
This commit fixes the issue.
In addition, this commit adds `updateLocalVarMapCtx` for cleanup
functions, which was missed before.
    
rdar://169236809