### PR TITLE
[SelectionDAGISel] Avoid unnecessary MatchScope copy. NFC

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -3565,7 +3565,7 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
 
       // Push a MatchScope which indicates where to go if the first child fails
       // to match.
-      MatchScope NewEntry;
+      MatchScope &NewEntry = MatchScopes.emplace_back();
       NewEntry.FailIndex = FailIndex;
       NewEntry.NodeStack.append(NodeStack.begin(), NodeStack.end());
       NewEntry.NumRecordedNodes = RecordedNodes.size();
@@ -3573,7 +3573,6 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
       NewEntry.InputChain = InputChain;
       NewEntry.InputGlue = InputGlue;
       NewEntry.HasChainNodesMatched = !ChainNodesMatched.empty();
-      MatchScopes.push_back(NewEntry);
       continue;
     }
     case OPC_RecordNode: {


### PR DESCRIPTION
Add the MatchScope to the vector first, then write its fields.