### PR TITLE
[flang] Reject PARAMETER constants in NAMELIST groups

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -484,6 +484,18 @@ end
 * A pointer component that has no default initialization or explicit value
   in a structure constructor is defaulted to `NULL()`.
 * An assumed-rank entity is an acceptable `NAMELIST` group item.
+* A named constant (`PARAMETER`) may appear as a `namelist-group-object` in a
+  `NAMELIST` statement.  The Fortran standard requires namelist group objects
+  to be variables, but this usage is accepted by Flang as an extension.
+  When `-pedantic` is enabled, Flang emits a warning for this case.
+  For example:
+```
+program p
+  implicit none
+  integer, parameter :: k = 3
+  namelist /g/ k
+end program
+```
 
 ### Extensions supported when enabled by options
 

--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -82,7 +82,7 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
     HostAssociatedIntentOutInSpecExpr, NonVolatilePointerToVolatile,
     RealConstantWidening, VolatileOrAsynchronousTemporary, UnusedVariable,
     UsedUndefinedVariable, BadValueInDeadCode, AssumedTypeSizeDummy,
-    MisplacedIgnoreTKR)
+    MisplacedIgnoreTKR, NamelistParameter)
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;

--- a/flang/lib/Semantics/check-namelist.cpp
+++ b/flang/lib/Semantics/check-namelist.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "check-namelist.h"
+#include "flang/Semantics/tools.h"
 
 namespace Fortran::semantics {
 
@@ -26,6 +27,13 @@ void NamelistChecker::Leave(const parser::NamelistStmt &nmlStmt) {
             context_.Say(nmlObjName.source,
                 "A PRIVATE namelist group object '%s' must not be in a "
                 "PUBLIC namelist"_err_en_US,
+                nmlObjSymbol->name());
+          }
+          // `namelist-group-object` may only contain variables.
+          if (IsNamedConstant(*nmlObjSymbol)) {
+            context_.Warn(common::UsageWarning::NamelistParameter,
+                nmlObjName.source,
+                "A namelist group object '%s' should not be a PARAMETER"_port_en_US,
                 nmlObjSymbol->name());
           }
         }

--- a/flang/test/Semantics/namelist02.f90
+++ b/flang/test/Semantics/namelist02.f90
@@ -1,0 +1,29 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+
+module m
+  implicit none
+  integer, parameter :: mc = 42
+end module
+
+! Local named constant
+program p
+  use m
+  implicit none
+  integer, parameter :: k = 3
+  !PORTABILITY: A namelist group object 'k' should not be a PARAMETER [-Wnamelist-parameter]
+  namelist /g/ k
+  ! USE-associated named constant
+  !PORTABILITY: A namelist group object 'mc' should not be a PARAMETER [-Wnamelist-parameter]
+  namelist /g2/ mc
+end program
+
+! Host-associated named constant
+subroutine host
+  implicit none
+  integer, parameter :: hc = 10
+  contains
+    subroutine inner
+      !PORTABILITY: A namelist group object 'hc' should not be a PARAMETER [-Wnamelist-parameter]
+      namelist /g3/ hc
+    end subroutine
+end subroutine


### PR DESCRIPTION
The Fortran standard does not allow `PARAMETERS` within a `namelist-group-object`, it should only allow variables. An error should be emitted when a `PARAMETER` is found within a `namelist-group-object`.

Fixes: #178955 