### PR TITLE
[clang-tidy] Add IgnoreAboveThreshold option to readability-function-cognitive-complexity

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/FunctionCognitiveComplexityCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/FunctionCognitiveComplexityCheck.h
@@ -19,6 +19,9 @@ namespace clang::tidy::readability {
 ///
 ///   * `Threshold` - flag functions with Cognitive Complexity exceeding
 ///     this number. The default is `25`.
+///   * `IgnoreAboveThreshold` - do not flag functions with Cognitive Complexity
+///     at or above this number. This can be used to skip "hopelessly" complex
+///     functions. The default is none (option disabled).
 ///   * `DescribeBasicIncrements`- if set to `true`, then for each function
 ///     exceeding the complexity threshold the check will issue additional
 ///     diagnostics on every piece of code (loop, `if` statement, etc.) which
@@ -42,6 +45,7 @@ public:
 
 private:
   const unsigned Threshold;
+  const std::optional<unsigned> IgnoreAboveThreshold;
   const bool DescribeBasicIncrements;
   const bool IgnoreMacros;
 };

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -193,6 +193,10 @@ Changes in existing checks
   now uses separate note diagnostics for each uninitialized enumerator, making
   it easier to see which specific enumerators need explicit initialization.
 
+- Improved :doc:`readability-function-cognitive-complexity
+  <clang-tidy/checks/readability/function-cognitive-complexity>` check by adding
+  an `IgnoreAboveThreshold` option to skip overly complex functions.
+
 - Improved :doc:`readability-non-const-parameter
   <clang-tidy/checks/readability/non-const-parameter>` check by avoiding false
   positives on parameters used in dependent expressions.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/function-cognitive-complexity.rst
@@ -17,6 +17,12 @@ Options
    Flag functions with Cognitive Complexity exceeding this number.
    The default is `25`.
 
+.. option:: IgnoreAboveThreshold
+
+   Do not flag functions with Cognitive Complexity at or above this number.
+   This can be used to skip "hopelessly" complex functions that would be too
+   costly to refactor. The default is none (option disabled).
+
 .. option:: DescribeBasicIncrements
 
    If set to `true`, then for each function exceeding the complexity threshold

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity-flags.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity-flags.cpp
@@ -11,10 +11,16 @@
 // RUN:             {readability-function-cognitive-complexity.Threshold: 0, \
 // RUN:              readability-function-cognitive-complexity.IgnoreMacros: "true", \
 // RUN:              readability-function-cognitive-complexity.DescribeBasicIncrements: "false"}}'
+// RUN: %check_clang_tidy -check-suffix=IGNORE-ABOVE %s readability-function-cognitive-complexity %t -- \
+// RUN:   -config='{CheckOptions: \
+// RUN:             {readability-function-cognitive-complexity.Threshold: 0, \
+// RUN:              readability-function-cognitive-complexity.IgnoreAboveThreshold: 10, \
+// RUN:              readability-function-cognitive-complexity.DescribeBasicIncrements: "false"}}'
 
 void func_of_complexity_4() {
   // CHECK-NOTES: :[[@LINE-1]]:6: warning: function 'func_of_complexity_4' has cognitive complexity of 4 (threshold 0) [readability-function-cognitive-complexity]
   // CHECK-NOTES-IGNORE-MACROS: :[[@LINE-2]]:6: warning: function 'func_of_complexity_4' has cognitive complexity of 4 (threshold 0) [readability-function-cognitive-complexity]
+  // CHECK-NOTES-IGNORE-ABOVE: :[[@LINE-3]]:6: warning: function 'func_of_complexity_4' has cognitive complexity of 4 (threshold 0) [readability-function-cognitive-complexity]
   if (1) {
     if (1) {
     }
@@ -55,6 +61,7 @@ void function_with_macro() {
 void func_macro_1() {
   // CHECK-NOTES: :[[@LINE-1]]:6: warning: function 'func_macro_1' has cognitive complexity of 2 (threshold 0) [readability-function-cognitive-complexity]
   // CHECK-NOTES-IGNORE-MACROS: :[[@LINE-2]]:6: warning: function 'func_macro_1' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
+  // CHECK-NOTES-IGNORE-ABOVE: :[[@LINE-3]]:6: warning: function 'func_macro_1' has cognitive complexity of 2 (threshold 0) [readability-function-cognitive-complexity]
 
   if (1) {
   }
@@ -64,6 +71,7 @@ void func_macro_1() {
 void func_macro_2() {
   // CHECK-NOTES: :[[@LINE-1]]:6: warning: function 'func_macro_2' has cognitive complexity of 4 (threshold 0) [readability-function-cognitive-complexity]
   // CHECK-NOTES-IGNORE-MACROS: :[[@LINE-2]]:6: warning: function 'func_macro_2' has cognitive complexity of 1 (threshold 0) [readability-function-cognitive-complexity]
+  // CHECK-NOTES-IGNORE-ABOVE: :[[@LINE-3]]:6: warning: function 'func_macro_2' has cognitive complexity of 4 (threshold 0) [readability-function-cognitive-complexity]
 
   if (1) {
   }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity-wrong-config.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-cognitive-complexity-wrong-config.cpp
@@ -1,0 +1,22 @@
+// RUN: %check_clang_tidy %s readability-function-cognitive-complexity %t -- \
+// RUN:   -config='{CheckOptions: { \
+// RUN:     readability-function-cognitive-complexity.Threshold: 10, \
+// RUN:     readability-function-cognitive-complexity.IgnoreAboveThreshold: 5, \
+// RUN:     readability-function-cognitive-complexity.DescribeBasicIncrements: false \
+// RUN:   }}'
+
+// CHECK-MESSAGES: warning: 'IgnoreAboveThreshold' option value '5' is less than 'Threshold' option value '10'; the option will be ignored [clang-tidy-config]
+
+// The IgnoreAboveThreshold option is ignored when it's less than Threshold,
+// so this function with complexity 11 should still be flagged.
+void func_of_complexity_11() {
+  // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'func_of_complexity_11' has cognitive complexity of 11 (threshold 10) [readability-function-cognitive-complexity]
+  if (1) {
+    if (1) {
+      if (1) {
+        if (1) {
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a new option `IgnoreAboveThreshold` that allows users to skip functions with cognitive complexity at or above a certain threshold. This is useful for ignoring "hopelessly" complex functions that would be too costly to refactor.

When set to `0` (the default), this option is disabled.

Example usage:
```yaml
CheckOptions:
  readability-function-cognitive-complexity.Threshold: 25
  readability-function-cognitive-complexity.IgnoreAboveThreshold: 100
This would flag functions with complexity between 26-99, but skip those with complexity >= 100.
```

Fixes #178959