### PR TITLE
[clang][Driver] Fix use after scope in darwin driver

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2076,7 +2076,8 @@ private:
                                   std::to_string(TargetEnvironment) +
                                   "' is unsupported when inferring SDK Info.");
     }
-    Components.push_back(Version.getAsString());
+    std::string VersionString = Version.getAsString();
+    Components.push_back(VersionString);
     return join(Components, " ");
   }
 


### PR DESCRIPTION
`Version.getAsString()` returns an `std::string`, and thus the
`StringRef` points to an invalid location when pushed into the
Components vector. This just keeps the temporary alive for the
new string to be generated, to fix the ASAN failure after #176541