### PR TITLE
[scudo] Add resident pages info to getStats

### DIFF
--- a/compiler-rt/lib/scudo/standalone/primary64.h
+++ b/compiler-rt/lib/scudo/standalone/primary64.h
@@ -1167,9 +1167,14 @@ void SizeClassAllocator64<Config>::getStats(ScopedString *Str, uptr ClassId,
     const u64 LastReleaseSecAgo = DiffSinceLastReleaseNs / 1000000000;
     const u64 LastReleaseMsAgo =
         (DiffSinceLastReleaseNs % 1000000000) / 1000000;
-    Str->append(" Latest release: %" PRIu64 ":%" PRIu64 " seconds ago",
+    Str->append(" Latest release: %6" PRIu64 ":%" PRIu64 " seconds ago",
                 LastReleaseSecAgo, LastReleaseMsAgo);
   }
+#if SCUDO_LINUX
+  const uptr MapBase = Region->MemMapInfo.MemMap.getBase();
+  Str->append(" Resident Pages: %6" PRIu64,
+              getResidentPages(MapBase, RegionSize));
+#endif
   Str->append("\n");
 }
 


### PR DESCRIPTION
Adding resident pages field to the primary allocator's getStats function makes it consistent with the secondary allocator's getStats function.