### PR TITLE
[mlir][vector] Separate multi_reduce lowering into transformations, flattening, and unrolling.

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/TransformOps/VectorTransformOps.td
+++ b/mlir/include/mlir/Dialect/Vector/TransformOps/VectorTransformOps.td
@@ -243,6 +243,26 @@ def ApplyLowerMultiReductionPatternsOp : Op<Transform_Dialect,
   }];
 }
 
+def ApplyUnrollMultiReductionPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.vector.unroll_multi_reduction",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
+  let description = [{
+    Unrolls vector.multi_reduction operations by progressively reducing rank
+    along the outermost dimension.
+
+    This is an alternative to the flattening-based lowering that preserves
+    the n-D structure during progressive lowering.
+  }];
+
+  let arguments = (ins DefaultValuedAttr<VectorMultiReductionLoweringAttr,
+      "vector::VectorMultiReductionLowering::InnerParallel">:$lowering_strategy
+  );
+
+  let assemblyFormat = [{
+    (`lowering_strategy` `=` $lowering_strategy^)? attr-dict
+  }];
+}
+
 def ApplyLowerOuterProductPatternsOp : Op<Transform_Dialect,
     "apply_patterns.vector.lower_outerproduct",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {

--- a/mlir/include/mlir/Dialect/Vector/TransformOps/VectorTransformOps.td
+++ b/mlir/include/mlir/Dialect/Vector/TransformOps/VectorTransformOps.td
@@ -247,11 +247,10 @@ def ApplyUnrollMultiReductionPatternsOp : Op<Transform_Dialect,
     "apply_patterns.vector.unroll_multi_reduction",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
   let description = [{
-    Unrolls vector.multi_reduction operations by progressively reducing rank
-    along the outermost dimension.
-
-    This is an alternative to the flattening-based lowering that preserves
-    the n-D structure during progressive lowering.
+    Populates patterns that unroll vector.multi_reduction operations by
+    progressively reducing rank. Terminal cases lower to either:
+    - vector.reduction (for 1-D reductions), or
+    - elementwise arith ops (when outermost dim is the only reduction dim).
   }];
 
   let arguments = (ins DefaultValuedAttr<VectorMultiReductionLoweringAttr,

--- a/mlir/include/mlir/Dialect/Vector/Transforms/LoweringPatterns.h
+++ b/mlir/include/mlir/Dialect/Vector/Transforms/LoweringPatterns.h
@@ -92,23 +92,6 @@ void populateVectorMultiReductionFlatteningPatterns(
 /// Collect a set of patterns to convert vector.multi_reduction op into
 /// a sequence of vector.reduction ops. The patterns comprise:
 ///
-/// [TwoDimMultiReductionToElementWise]
-/// Once in 2-D vector.multi_reduction form, with an **outermost** reduction
-/// dimension, unroll the outer dimension to obtain a sequence of 1-D vector
-/// ops. This also has an opportunity for tree-reduction (in the future).
-///
-/// [TwoDimMultiReductionToReduction]
-/// Once in 2-D vector.multi_reduction form, with an **innermost** reduction
-/// dimension, unroll the outer dimension to obtain a sequence of extract +
-/// vector.reduction + insert. This can further lower to horizontal reduction
-/// ops.
-void populateVectorMultiReductionUnrollingPatterns(
-    RewritePatternSet &patterns, VectorMultiReductionLowering options,
-    PatternBenefit benefit = 1);
-
-/// Collect a set of patterns to convert vector.multi_reduction op into
-/// a sequence of vector.reduction ops. The patterns comprise:
-///
 /// [InnerOuterDimReductionConversion]
 /// Rewrites vector.multi_reduction such that all reduction dimensions are
 /// either innermost or outermost, by adding the proper vector.transpose

--- a/mlir/include/mlir/Dialect/Vector/Transforms/LoweringPatterns.h
+++ b/mlir/include/mlir/Dialect/Vector/Transforms/LoweringPatterns.h
@@ -60,6 +60,46 @@ void populateVectorContractLoweringPatterns(
 void populateVectorOuterProductLoweringPatterns(RewritePatternSet &patterns,
                                                 PatternBenefit benefit = 1);
 
+/// Collect a set of patterns to set invariants for vector.multi_reduction's
+/// conversion. The patterns comprise:
+///
+/// [InnerOuterDimReductionConversion]
+/// Rewrites vector.multi_reduction such that all reduction dimensions are
+/// either innermost or outermost, by adding the proper vector.transpose
+/// operations.
+///
+/// [OneDimMultiReductionToTwoDim]
+/// For cases that reduce to 1-D vector<k> reduction (and are thus missing
+/// either a parallel or a reduction), we lift them back up to 2-D with a simple
+/// vector.shape_cast to vector<1xk> so that the other patterns can kick in,
+/// thus fully exiting out of the vector.multi_reduction abstraction.
+void populateVectorMultiReductionInnerOuterDimPatterns(
+    RewritePatternSet &patterns, VectorMultiReductionLowering options,
+    PatternBenefit benefit = 1);
+
+/// Collect a set of patterns to convert vector.multi_reduction op into
+/// a sequence of vector.reduction ops. The patterns comprise:
+///
+/// [ReduceMultiDimReductionRank]
+/// Once in innermost or outermost reduction
+/// form, rewrites n-D vector.multi_reduction into 2-D vector.multi_reduction,
+/// by introducing vector.shape_cast ops to collapse + multi-reduce + expand
+/// back.
+///
+/// [TwoDimMultiReductionToElementWise]
+/// Once in 2-D vector.multi_reduction form, with an **outermost** reduction
+/// dimension, unroll the outer dimension to obtain a sequence of 1-D vector
+/// ops. This also has an opportunity for tree-reduction (in the future).
+///
+/// [TwoDimMultiReductionToReduction]
+/// Once in 2-D vector.multi_reduction form, with an **innermost** reduction
+/// dimension, unroll the outer dimension to obtain a sequence of extract +
+/// vector.reduction + insert. This can further lower to horizontal reduction
+/// ops.
+void populateVectorMultiReductionFlatteningPatterns(
+    RewritePatternSet &patterns, VectorMultiReductionLowering options,
+    PatternBenefit benefit = 1);
+
 /// Collect a set of patterns to convert vector.multi_reduction op into
 /// a sequence of vector.reduction ops. The patterns comprise:
 ///

--- a/mlir/include/mlir/Dialect/Vector/Transforms/LoweringPatterns.h
+++ b/mlir/include/mlir/Dialect/Vector/Transforms/LoweringPatterns.h
@@ -85,6 +85,12 @@ void populateVectorMultiReductionInnerOuterDimPatterns(
 /// form, rewrites n-D vector.multi_reduction into 2-D vector.multi_reduction,
 /// by introducing vector.shape_cast ops to collapse + multi-reduce + expand
 /// back.
+void populateVectorMultiReductionFlatteningPatterns(
+    RewritePatternSet &patterns, VectorMultiReductionLowering options,
+    PatternBenefit benefit = 1);
+
+/// Collect a set of patterns to convert vector.multi_reduction op into
+/// a sequence of vector.reduction ops. The patterns comprise:
 ///
 /// [TwoDimMultiReductionToElementWise]
 /// Once in 2-D vector.multi_reduction form, with an **outermost** reduction
@@ -96,7 +102,7 @@ void populateVectorMultiReductionInnerOuterDimPatterns(
 /// dimension, unroll the outer dimension to obtain a sequence of extract +
 /// vector.reduction + insert. This can further lower to horizontal reduction
 /// ops.
-void populateVectorMultiReductionFlatteningPatterns(
+void populateVectorMultiReductionUnrollingPatterns(
     RewritePatternSet &patterns, VectorMultiReductionLowering options,
     PatternBenefit benefit = 1);
 

--- a/mlir/include/mlir/Dialect/Vector/Transforms/LoweringPatterns.h
+++ b/mlir/include/mlir/Dialect/Vector/Transforms/LoweringPatterns.h
@@ -140,6 +140,30 @@ void populateVectorMultiReductionLoweringPatterns(
     RewritePatternSet &patterns, VectorMultiReductionLowering options,
     PatternBenefit benefit = 1);
 
+/// Collect a set of patterns to unroll vector.multi_reduction ops by
+/// progressively reducing rank along the outermost dimension.
+///
+/// For OuterReduction (outermost dim is reduction):
+/// [UnrollMultiReductionOuterBaseCase]
+/// When the outermost dimension is the only reduction dimension, unroll to
+/// produce elementwise arithmetic operations.
+///
+/// [UnrollMultiReductionOuterGeneralCase]
+/// When the outermost dimension is one of multiple reduction dimensions,
+/// unroll to produce smaller multi_reduction operations.
+///
+/// For InnerReduction (innermost dim is reduction):
+/// [UnrollMultiReductionInnerBaseCase]
+/// When the innermost dimension is the only reduction dimension, unroll along
+/// the outermost parallel dimension.
+///
+/// [UnrollMultiReductionInnerGeneralCase]
+/// When the innermost dimension is one of multiple reduction dimensions,
+/// unroll along the outermost parallel dimension.
+void populateVectorUnrollMultiReduction(RewritePatternSet &patterns,
+                                        VectorMultiReductionLowering options,
+                                        PatternBenefit benefit = 1);
+
 /// Populate the pattern set with the following patterns:
 ///
 /// [TransferReadToVectorLoadLowering]

--- a/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
+++ b/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
@@ -136,6 +136,14 @@ void transform::ApplyLowerMultiReductionPatternsOp::populatePatterns(
       patterns, vectorTransformOptions.vectorMultiReductionLowering);
 }
 
+void transform::ApplyUnrollMultiReductionPatternsOp::populatePatterns(
+    RewritePatternSet &patterns) {
+  vector::VectorTransformsOptions vectorTransformOptions;
+  vectorTransformOptions.setVectorMultiReductionLowering(getLoweringStrategy());
+  vector::populateVectorUnrollMultiReduction(
+      patterns, vectorTransformOptions.vectorMultiReductionLowering);
+}
+
 void transform::ApplyLowerOuterProductPatternsOp::populatePatterns(
     RewritePatternSet &patterns) {
   populateVectorOuterProductLoweringPatterns(patterns);

--- a/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
+++ b/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
@@ -130,6 +130,8 @@ void transform::ApplyLowerMultiReductionPatternsOp::populatePatterns(
     RewritePatternSet &patterns) {
   vector::VectorTransformsOptions vectorTransformOptions;
   vectorTransformOptions.setVectorMultiReductionLowering(getLoweringStrategy());
+  vector::populateVectorMultiReductionInnerOuterDimPatterns(
+      patterns, vectorTransformOptions.vectorMultiReductionLowering);
   vector::populateVectorMultiReductionLoweringPatterns(
       patterns, vectorTransformOptions.vectorMultiReductionLowering);
 }

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -664,6 +664,11 @@ struct UnrollMultiReductionOuterGeneralCase
 
   LogicalResult matchAndRewrite(vector::MultiDimReductionOp multiReductionOp,
                                 PatternRewriter &rewriter) const override {
+    auto srcRank = multiReductionOp.getSourceVectorType().getRank();
+    if (srcRank < 2)
+      return rewriter.notifyMatchFailure(multiReductionOp,
+                                         "expected source rank >= 2.");
+
     if (!multiReductionOp.isReducedDim(0))
       return rewriter.notifyMatchFailure(
           multiReductionOp,

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -920,15 +920,10 @@ void mlir::vector::populateVectorUnrollMultiReduction(
     RewritePatternSet &patterns, VectorMultiReductionLowering options,
     PatternBenefit benefit) {
   patterns.add<OneDimMultiReductionToReduction>(patterns.getContext(), benefit);
-
-  if (options == VectorMultiReductionLowering::InnerReduction) {
-    patterns.add<UnrollInnerReductionAlongOuterParallel>(patterns.getContext(),
-                                                         benefit);
-  } else {
-    patterns.add<UnrollMultiReductionOuterBaseCase,
-                 UnrollMultiReductionOuterGeneralCase>(patterns.getContext(),
+  patterns.add<UnrollMultiReductionOuterBaseCase,
+               UnrollMultiReductionOuterGeneralCase,
+               UnrollInnerReductionAlongOuterParallel>(patterns.getContext(),
                                                        benefit);
-  }
 }
 
 void mlir::vector::populateVectorMultiReductionLoweringPatterns(

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -541,6 +541,11 @@ struct UnrollMultiReductionOuterBaseCase
 
   LogicalResult matchAndRewrite(vector::MultiDimReductionOp multiReductionOp,
                                 PatternRewriter &rewriter) const override {
+    auto srcRank = multiReductionOp.getSourceVectorType().getRank();
+    if (srcRank < 2)
+      return rewriter.notifyMatchFailure(multiReductionOp,
+                                         "expected source rank >= 2.");
+
     if (!multiReductionOp.isReducedDim(0))
       return rewriter.notifyMatchFailure(
           multiReductionOp,

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -714,7 +714,8 @@ struct UnrollMultiReductionOuterGeneralCase
         masks.push_back(nullptr);
 
     SmallVector<bool> fullReductionMask = multiReductionOp.getReductionMask();
-    ArrayRef<bool> reductionMask = ArrayRef<bool>(fullReductionMask).drop_front();
+    ArrayRef<bool> reductionMask =
+        ArrayRef<bool>(fullReductionMask).drop_front();
     Value result = multiReductionOp.getAcc();
     for (auto [innerVector, innerMask] : llvm::zip(vectors, masks)) {
 

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -883,8 +883,8 @@ struct LowerVectorMultiReductionPass
       signalPassFailure();
 
     RewritePatternSet unrollingPatterns(context);
-    populateVectorMultiReductionUnrollingPatterns(unrollingPatterns,
-                                                  this->loweringStrategy);
+    populateVectorUnrollMultiReduction(unrollingPatterns,
+                                       this->loweringStrategy);
 
     if (failed(applyPatternsGreedily(op, std::move(unrollingPatterns))))
       signalPassFailure();
@@ -910,21 +910,6 @@ void mlir::vector::populateVectorMultiReductionFlatteningPatterns(
     PatternBenefit benefit) {
   patterns.add<ReduceMultiDimReductionRank>(patterns.getContext(), options,
                                             benefit);
-}
-
-void mlir::vector::populateVectorMultiReductionUnrollingPatterns(
-    RewritePatternSet &patterns, VectorMultiReductionLowering options,
-    PatternBenefit benefit) {
-  patterns.add<OneDimMultiReductionToReduction>(patterns.getContext(), benefit);
-
-  if (options == VectorMultiReductionLowering ::InnerReduction) {
-    patterns.add<TwoDimMultiReductionToReduction>(patterns.getContext(),
-                                                  benefit);
-  } else {
-    patterns.add<UnrollMultiReductionOuterBaseCase,
-                 UnrollMultiReductionOuterGeneralCase>(patterns.getContext(),
-                                                       benefit);
-  }
 }
 
 void mlir::vector::populateVectorUnrollMultiReduction(

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -713,8 +713,8 @@ struct UnrollMultiReductionOuterGeneralCase
       else
         masks.push_back(nullptr);
 
-    ArrayRef<bool> reductionMask =
-        ArrayRef<bool>(multiReductionOp.getReductionMask()).drop_front();
+    SmallVector<bool> fullReductionMask = multiReductionOp.getReductionMask();
+    ArrayRef<bool> reductionMask = ArrayRef<bool>(fullReductionMask).drop_front();
     Value result = multiReductionOp.getAcc();
     for (auto [innerVector, innerMask] : llvm::zip(vectors, masks)) {
 
@@ -829,8 +829,9 @@ struct UnrollInnerReductionAlongOuterParallel
     // Compute new reduction mask by dropping the first element (dimension 0).
     // Since dimension 0 is parallel (not reduced), all reduction indices shift
     // down by 1.
+    SmallVector<bool> fullReductionMask = multiReductionOp.getReductionMask();
     ArrayRef<bool> newReductionMask =
-        ArrayRef<bool>(multiReductionOp.getReductionMask()).drop_front();
+        ArrayRef<bool>(fullReductionMask).drop_front();
 
     SmallVector<Value> reductionResults;
     for (auto [srcSlice, accSlice, maskSlice] :

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -509,6 +509,13 @@ struct LowerVectorMultiReductionPass
 
     if (failed(applyPatternsGreedily(op, std::move(flatteningPatterns))))
       signalPassFailure();
+
+    RewritePatternSet unrollingPatterns(context);
+    populateVectorMultiReductionUnrollingPatterns(unrollingPatterns,
+                                                  this->loweringStrategy);
+
+    if (failed(applyPatternsGreedily(op, std::move(unrollingPatterns))))
+      signalPassFailure();
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -531,6 +538,11 @@ void mlir::vector::populateVectorMultiReductionFlatteningPatterns(
     PatternBenefit benefit) {
   patterns.add<ReduceMultiDimReductionRank>(patterns.getContext(), options,
                                             benefit);
+}
+
+void mlir::vector::populateVectorMultiReductionUnrollingPatterns(
+    RewritePatternSet &patterns, VectorMultiReductionLowering options,
+    PatternBenefit benefit) {
   if (options == VectorMultiReductionLowering ::InnerReduction)
     patterns.add<TwoDimMultiReductionToReduction>(patterns.getContext(),
                                                   benefit);

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -760,7 +760,7 @@ struct UnrollMultiReductionOuterGeneralCase
 ///     : vector<Cxf32> into vector<AxCxf32>
 /// // ... repeat for indices 1 to A-1
 /// ```
-struct UnrollMultiReductionInner
+struct UnrollInnerReductionAlongOuterParallel
     : public OpRewritePattern<vector::MultiDimReductionOp> {
   using Base::Base;
 
@@ -918,7 +918,8 @@ void mlir::vector::populateVectorUnrollMultiReduction(
   patterns.add<OneDimMultiReductionToReduction>(patterns.getContext(), benefit);
 
   if (options == VectorMultiReductionLowering::InnerReduction) {
-    patterns.add<UnrollMultiReductionInner>(patterns.getContext(), benefit);
+    patterns.add<UnrollInnerReductionAlongOuterParallel>(patterns.getContext(),
+                                                         benefit);
   } else {
     patterns.add<UnrollMultiReductionOuterBaseCase,
                  UnrollMultiReductionOuterGeneralCase>(patterns.getContext(),

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -485,6 +485,195 @@ struct OneDimMultiReductionToTwoDim
   }
 };
 
+/// Unrolls outermost dimension for vector.multi_reduction.
+/// This patterns matches operations which reduce the outermost dimension,
+/// it does not transform operations for which the outermost dimension is not
+/// a reduction dimension.
+///
+/// There are two cases to consider:
+/// 1. The base case is when the outermost dimension is the only reduction
+/// dimension.
+/// 2. The general case is when the outermost dimension is not the only
+/// reduction dimension.
+///
+/// The base case transformation:
+///
+/// ```mlir
+/// %res = vector.multi_reduction <add> %src, %acc [0] : vector<NxMx...xf32> to
+/// vector<Mx...xf32>
+/// ```
+///
+/// will extract N vectors from %src and then perform elementwise operations.
+///
+/// ```mlir
+/// %0 = vector.extract %src[0] : vector<Mx...xf32> from vector<NxMx...xf32>
+/// ...
+/// %Nminus1 = vector.extract %src[ [[N-1]] ] : vector<Mx...x.f32> from
+/// vector<NxMx...xf32>
+///
+/// %res0 = arith.addf %0, %acc : vector<Mx...xf32>
+/// ...
+/// %res = arith.addf %Nminus1, %resNminus2 : vector<Mx...xf32>
+/// ```
+///
+/// For the general case, we still extract N vectors, but produce N
+/// vector.multi_reduction instead of elementwise operations.
+///
+/// ```mlir
+/// %res = vector.multi_reduction <add> %src, %acc [0, [[REDUCTION_DIMS]] ] :
+/// vector<NxMx...xf32> to vector<Ix...xf32>
+///
+/// ```mlir
+/// %0 = vector.extract %src[0] : vector<Mx...xf32> from vector<NxMx...xf32>
+/// ...
+/// %Nminus1 = vector.extract %src[ [[N-1]] ] : vector<Mx...x.f32> from
+/// vector<NxMx...xf32>
+///
+/// %red0 = vector.multi_reduction %0, %acc [ [[REDUCTION_DIMS]] ] :
+/// vector<Mx...xf32> to vector<Ix...xf32>
+/// ...
+/// %res = vector.multi_reduction %Nminus1, %redNminus2 [ [[REDUCTION_DIMS]] ] :
+/// vector<Mx...xf32> to vector<Ix...xf32>
+/// ```
+struct UnrollMultiReductionOuterBaseCase
+    : public OpRewritePattern<vector::MultiDimReductionOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(vector::MultiDimReductionOp multiReductionOp,
+                                PatternRewriter &rewriter) const override {
+    if (!multiReductionOp.isReducedDim(0))
+      return rewriter.notifyMatchFailure(
+          multiReductionOp,
+          "expected outermost dimension to be reduced dimension.");
+
+    Type elementType = getElementTypeOrSelf(multiReductionOp.getDestType());
+    if (!elementType.isIntOrIndexOrFloat())
+      return rewriter.notifyMatchFailure(
+          multiReductionOp, "expected integer or float element type.");
+
+    ArrayRef<int64_t> reductionDims = multiReductionOp.getReductionDims();
+    if (reductionDims.size() > 1)
+      return rewriter.notifyMatchFailure(
+          multiReductionOp, "expected only one reduction dimension.");
+
+    Location loc = multiReductionOp.getLoc();
+    Value source = multiReductionOp.getSource();
+
+    ArrayRef<int64_t> srcShape =
+        multiReductionOp.getSourceVectorType().getShape();
+    int64_t numElementwiseOps = srcShape.front();
+
+    OpBuilder::InsertionGuard guard(rewriter);
+    auto maskableOp =
+        cast<vector::MaskableOpInterface>(multiReductionOp.getOperation());
+    bool isMasked = maskableOp.isMasked();
+    Operation *rootOp;
+    Value mask = nullptr;
+    if (isMasked) {
+      rewriter.setInsertionPoint(maskableOp.getMaskingOp());
+      rootOp = maskableOp.getMaskingOp();
+      mask = maskableOp.getMaskingOp().getMask();
+    } else {
+      rootOp = multiReductionOp;
+    }
+
+    SmallVector<Value> vectors;
+    for (int64_t i = 0; i < numElementwiseOps; ++i)
+      vectors.push_back(vector::ExtractOp::create(rewriter, loc, source, i));
+
+    SmallVector<Value> masks;
+    for (int64_t i = 0; i < numElementwiseOps; ++i)
+      if (isMasked)
+        masks.push_back(vector::ExtractOp::create(rewriter, loc, mask, i));
+      else
+        masks.push_back(nullptr);
+
+    Value result = multiReductionOp.getAcc();
+    for (auto [innerVector, innerMask] : llvm::zip(vectors, masks))
+      result = makeArithReduction(rewriter, loc, multiReductionOp.getKind(),
+                                  innerVector, result, /*fastmath=*/nullptr,
+                                  innerMask);
+
+    rewriter.replaceOp(rootOp, result);
+    return success();
+  }
+};
+
+struct UnrollMultiReductionOuterGeneralCase
+    : public OpRewritePattern<vector::MultiDimReductionOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(vector::MultiDimReductionOp multiReductionOp,
+                                PatternRewriter &rewriter) const override {
+    if (!multiReductionOp.isReducedDim(0))
+      return rewriter.notifyMatchFailure(
+          multiReductionOp,
+          "expected outermost dimension to be reduced dimension.");
+
+    Type elementType = getElementTypeOrSelf(multiReductionOp.getDestType());
+    if (!elementType.isIntOrIndexOrFloat())
+      return rewriter.notifyMatchFailure(
+          multiReductionOp, "expected integer or float element type.");
+
+    ArrayRef<int64_t> reductionDims = multiReductionOp.getReductionDims();
+    if (reductionDims.size() <= 1)
+      return rewriter.notifyMatchFailure(
+          multiReductionOp, "expected more than one reduction dimension.");
+
+    Location loc = multiReductionOp.getLoc();
+    Value source = multiReductionOp.getSource();
+
+    ArrayRef<int64_t> srcShape =
+        multiReductionOp.getSourceVectorType().getShape();
+    int64_t numElementwiseOps = srcShape.front();
+
+    OpBuilder::InsertionGuard guard(rewriter);
+    auto maskableOp =
+        cast<vector::MaskableOpInterface>(multiReductionOp.getOperation());
+    bool isMasked = maskableOp.isMasked();
+    Operation *rootOp;
+    Value mask = nullptr;
+    if (isMasked) {
+      rewriter.setInsertionPoint(maskableOp.getMaskingOp());
+      rootOp = maskableOp.getMaskingOp();
+      mask = maskableOp.getMaskingOp().getMask();
+    } else {
+      rootOp = multiReductionOp;
+    }
+
+    SmallVector<Value> vectors;
+    for (int64_t i = 0; i < numElementwiseOps; ++i)
+      vectors.push_back(vector::ExtractOp::create(rewriter, loc, source, i));
+
+    SmallVector<Value> masks;
+    for (int64_t i = 0; i < numElementwiseOps; ++i)
+      if (isMasked)
+        masks.push_back(vector::ExtractOp::create(rewriter, loc, mask, i));
+      else
+        masks.push_back(nullptr);
+
+    ArrayRef<bool> reductionMask =
+        ArrayRef<bool>(multiReductionOp.getReductionMask()).drop_front();
+    Value result = multiReductionOp.getAcc();
+    for (auto [innerVector, innerMask] : llvm::zip(vectors, masks)) {
+
+      auto reductionOp = vector::MultiDimReductionOp::create(
+          rewriter, loc, innerVector, result, reductionMask,
+          multiReductionOp.getKind());
+
+      if (isMasked) {
+        auto maskOp = vector::maskOperation(rewriter, reductionOp, innerMask);
+        result = maskOp->getResult(0);
+      } else {
+        result = reductionOp.getResult();
+      }
+    }
+
+    rewriter.replaceOp(rootOp, result);
+    return success();
+  }
+};
+
 struct LowerVectorMultiReductionPass
     : public vector::impl::LowerVectorMultiReductionBase<
           LowerVectorMultiReductionPass> {
@@ -543,12 +732,14 @@ void mlir::vector::populateVectorMultiReductionFlatteningPatterns(
 void mlir::vector::populateVectorMultiReductionUnrollingPatterns(
     RewritePatternSet &patterns, VectorMultiReductionLowering options,
     PatternBenefit benefit) {
-  if (options == VectorMultiReductionLowering ::InnerReduction)
+  if (options == VectorMultiReductionLowering ::InnerReduction) {
     patterns.add<TwoDimMultiReductionToReduction>(patterns.getContext(),
                                                   benefit);
-  else
-    patterns.add<TwoDimMultiReductionToElementWise>(patterns.getContext(),
-                                                    benefit);
+  } else {
+    patterns.add<UnrollMultiReductionOuterBaseCase,
+                 UnrollMultiReductionOuterGeneralCase>(patterns.getContext(),
+                                                       benefit);
+  }
 }
 
 void mlir::vector::populateVectorMultiReductionLoweringPatterns(

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -742,6 +742,22 @@ void mlir::vector::populateVectorMultiReductionUnrollingPatterns(
   }
 }
 
+void mlir::vector::populateVectorUnrollMultiReduction(
+    RewritePatternSet &patterns, VectorMultiReductionLowering options,
+    PatternBenefit benefit) {
+  if (options == VectorMultiReductionLowering::InnerReduction) {
+    // TODO: Add UnrollMultiReductionInnerBaseCase and
+    // UnrollMultiReductionInnerGeneralCase patterns here once implemented.
+    // For now, fall back to the existing 2-D based lowering.
+    patterns.add<TwoDimMultiReductionToReduction>(patterns.getContext(),
+                                                  benefit);
+  } else {
+    patterns.add<UnrollMultiReductionOuterBaseCase,
+                 UnrollMultiReductionOuterGeneralCase>(patterns.getContext(),
+                                                       benefit);
+  }
+}
+
 void mlir::vector::populateVectorMultiReductionLoweringPatterns(
     RewritePatternSet &patterns, VectorMultiReductionLowering options,
     PatternBenefit benefit) {

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -554,7 +554,8 @@ struct OneDimMultiReductionToTwoDim
 /// ```mlir
 /// %0 = vector.extract %src[0] : vector<Mx...xf32> from vector<NxMx...xf32>
 /// ...
-/// %Nminus1 = vector.extract %src[N-1] : vector<Mx...xf32> from vector<NxMx...xf32>
+/// %Nminus1 = vector.extract %src[N-1] : vector<Mx...xf32> from
+/// vector<NxMx...xf32>
 ///
 /// %res0 = arith.addf %0, %acc : vector<Mx...xf32>
 /// ...
@@ -645,7 +646,8 @@ struct UnrollMultiReductionOuterBaseCase
 /// ```mlir
 /// %0 = vector.extract %src[0] : vector<Mx...xf32> from vector<NxMx...xf32>
 /// ...
-/// %Nminus1 = vector.extract %src[N-1] : vector<Mx...xf32> from vector<NxMx...xf32>
+/// %Nminus1 = vector.extract %src[N-1] : vector<Mx...xf32> from
+/// vector<NxMx...xf32>
 ///
 /// %red0 = vector.multi_reduction <add>, %0, %acc [1]
 ///     : vector<Mx...xf32> to vector<Ix...xf32>

--- a/mlir/test/Dialect/Vector/td/unroll-multi-reduction.mlir
+++ b/mlir/test/Dialect/Vector/td/unroll-multi-reduction.mlir
@@ -1,0 +1,24 @@
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @unroll_multi_reduction(%module_op: !transform.any_op {transform.readonly}) {
+
+    %func_op = transform.structured.match ops{["func.func"]} in %module_op
+      : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func_op {
+      // Test patterns
+      transform.apply_patterns.vector.unroll_multi_reduction
+    } : !transform.any_op
+
+    transform.yield
+  }
+  transform.named_sequence @unroll_multi_reduction_inner(%module_op: !transform.any_op {transform.readonly}) {
+
+    %func_op = transform.structured.match ops{["func.func"]} in %module_op
+      : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func_op {
+      // Test patterns
+      transform.apply_patterns.vector.unroll_multi_reduction lowering_strategy = "innerreduction"
+    } : !transform.any_op
+
+    transform.yield
+  }
+}

--- a/mlir/test/Dialect/Vector/unroll-vector-multi-reduction-inner.mlir
+++ b/mlir/test/Dialect/Vector/unroll-vector-multi-reduction-inner.mlir
@@ -1,0 +1,106 @@
+// RUN: mlir-opt --split-input-file %s -transform-preload-library='transform-library-paths=%p/td/unroll-multi-reduction.mlir' \
+// RUN: -transform-interpreter=entry-point=unroll_multi_reduction_inner | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Test UnrollVectorMultiReduction for Inner Reduction (Base Case)
+//===----------------------------------------------------------------------===//
+
+// The pattern recursively reduces rank until we reach 1D multi_reductions.
+// For vector<2x3x5xf32> with reduction on dim 2:
+// - First pass: unrolls along dim 0 (size 2), creating vector<3x5xf32> multi_reductions
+// - Second pass: unrolls along dim 0 (size 3), creating vector<5xf32> multi_reductions
+//
+// The generated IR groups operations by phase:
+// extracts (source) → extracts (acc) → multi_reductions → inserts
+
+// CHECK-LABEL: func @unroll_vector_multi_reduction_inner(
+// CHECK-SAME: %[[SOURCE:.+]]: vector<2x3x5xf32>,
+// CHECK-SAME: %[[ACC:.+]]: vector<2x3xf32>
+func.func @unroll_vector_multi_reduction_inner(%source: vector<2x3x5xf32>, %acc: vector<2x3xf32>) -> (vector<2x3xf32>) {
+  // First slice [0, ...]: extracts → reductions → inserts
+  // CHECK: vector.extract %[[SOURCE]][0, 0]
+  // CHECK: vector.extract %[[SOURCE]][0, 1]
+  // CHECK: vector.extract %[[SOURCE]][0, 2]
+  // CHECK: vector.extract %[[ACC]][0, 0]
+  // CHECK: vector.extract %[[ACC]][0, 1]
+  // CHECK: vector.extract %[[ACC]][0, 2]
+  // CHECK: vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32
+  // CHECK: vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32
+  // CHECK: vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32
+  // CHECK: vector.insert {{.*}} [0] : f32 into vector<3xf32>
+  // CHECK: vector.insert {{.*}} [1] : f32 into vector<3xf32>
+  // CHECK: vector.insert {{.*}} [2] : f32 into vector<3xf32>
+  // Second slice [1, ...]: extracts → reductions → inserts
+  // CHECK: vector.extract %[[SOURCE]][1, 0]
+  // CHECK: vector.extract %[[SOURCE]][1, 1]
+  // CHECK: vector.extract %[[SOURCE]][1, 2]
+  // CHECK: vector.extract %[[ACC]][1, 0]
+  // CHECK: vector.extract %[[ACC]][1, 1]
+  // CHECK: vector.extract %[[ACC]][1, 2]
+  // CHECK: vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32
+  // CHECK: vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32
+  // CHECK: vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32
+  // CHECK: vector.insert {{.*}} [0] : f32 into vector<3xf32>
+  // CHECK: vector.insert {{.*}} [1] : f32 into vector<3xf32>
+  // CHECK: vector.insert {{.*}} [2] : f32 into vector<3xf32>
+  // Final inserts to assemble result
+  // CHECK: vector.insert {{.*}} [0] : vector<3xf32> into vector<2x3xf32>
+  // CHECK: vector.insert {{.*}} [1] : vector<3xf32> into vector<2x3xf32>
+  // No original multi_reduction with [2] remains
+  // CHECK-NOT: vector.multi_reduction <add>, {{.*}} [2]
+  %1 = vector.multi_reduction <add>, %source, %acc [2] : vector<2x3x5xf32> to vector<2x3xf32>
+
+  return %1 : vector<2x3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @unroll_vector_multi_reduction_inner_masked(
+// CHECK-SAME: %[[SOURCE:.+]]: vector<2x3x5xf32>,
+// CHECK-SAME: %[[MASK:.+]]: vector<2x3x5xi1>,
+// CHECK-SAME: %[[ACC:.+]]: vector<2x3xf32>
+func.func @unroll_vector_multi_reduction_inner_masked(%source: vector<2x3x5xf32>, %mask: vector<2x3x5xi1>, %acc: vector<2x3xf32>) -> (vector<2x3xf32>) {
+  // First slice [0, ...]: extracts (source, acc, mask) → masked reductions → inserts
+  // CHECK: vector.extract %[[SOURCE]][0, 0]
+  // CHECK: vector.extract %[[SOURCE]][0, 1]
+  // CHECK: vector.extract %[[SOURCE]][0, 2]
+  // CHECK: vector.extract %[[ACC]][0, 0]
+  // CHECK: vector.extract %[[ACC]][0, 1]
+  // CHECK: vector.extract %[[ACC]][0, 2]
+  // CHECK: vector.extract %[[MASK]][0, 0]
+  // CHECK: vector.extract %[[MASK]][0, 1]
+  // CHECK: vector.extract %[[MASK]][0, 2]
+  // CHECK: vector.mask {{.*}} { vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32 }
+  // CHECK: vector.mask {{.*}} { vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32 }
+  // CHECK: vector.mask {{.*}} { vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32 }
+  // CHECK: vector.insert {{.*}} [0] : f32 into vector<3xf32>
+  // CHECK: vector.insert {{.*}} [1] : f32 into vector<3xf32>
+  // CHECK: vector.insert {{.*}} [2] : f32 into vector<3xf32>
+  // Second slice [1, ...]: extracts → masked reductions → inserts
+  // CHECK: vector.extract %[[SOURCE]][1, 0]
+  // CHECK: vector.extract %[[SOURCE]][1, 1]
+  // CHECK: vector.extract %[[SOURCE]][1, 2]
+  // CHECK: vector.extract %[[ACC]][1, 0]
+  // CHECK: vector.extract %[[ACC]][1, 1]
+  // CHECK: vector.extract %[[ACC]][1, 2]
+  // CHECK: vector.extract %[[MASK]][1, 0]
+  // CHECK: vector.extract %[[MASK]][1, 1]
+  // CHECK: vector.extract %[[MASK]][1, 2]
+  // CHECK: vector.mask {{.*}} { vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32 }
+  // CHECK: vector.mask {{.*}} { vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32 }
+  // CHECK: vector.mask {{.*}} { vector.multi_reduction <add>, {{.*}} [0] : vector<5xf32> to f32 }
+  // CHECK: vector.insert {{.*}} [0] : f32 into vector<3xf32>
+  // CHECK: vector.insert {{.*}} [1] : f32 into vector<3xf32>
+  // CHECK: vector.insert {{.*}} [2] : f32 into vector<3xf32>
+  // Final inserts to assemble result
+  // CHECK: vector.insert {{.*}} [0] : vector<3xf32> into vector<2x3xf32>
+  // CHECK: vector.insert {{.*}} [1] : vector<3xf32> into vector<2x3xf32>
+  // No original multi_reduction with [2] remains
+  // CHECK-NOT: vector.multi_reduction <add>, {{.*}} [2]
+
+  %0 = vector.mask %mask {
+    %1 = vector.multi_reduction <add>, %source, %acc [2] : vector<2x3x5xf32> to vector<2x3xf32>
+  } : vector<2x3x5xi1> -> vector<2x3xf32>
+
+  return %0 : vector<2x3xf32>
+}

--- a/mlir/test/Dialect/Vector/unroll-vector-multi-reduction-inner.mlir
+++ b/mlir/test/Dialect/Vector/unroll-vector-multi-reduction-inner.mlir
@@ -19,7 +19,6 @@
 // CHECK-SAME: %[[SOURCE:.+]]: vector<2x3x5xf32>,
 // CHECK-SAME: %[[ACC:.+]]: vector<2x3xf32>
 func.func @unroll_vector_multi_reduction_inner(%source: vector<2x3x5xf32>, %acc: vector<2x3xf32>) -> (vector<2x3xf32>) {
-  // First slice [0, ...]: extracts → reductions → inserts
   // CHECK: vector.extract %[[SOURCE]][0, 0]
   // CHECK: vector.extract %[[SOURCE]][0, 1]
   // CHECK: vector.extract %[[SOURCE]][0, 2]
@@ -32,7 +31,6 @@ func.func @unroll_vector_multi_reduction_inner(%source: vector<2x3x5xf32>, %acc:
   // CHECK: vector.insert {{.*}} [0] : f32 into vector<3xf32>
   // CHECK: vector.insert {{.*}} [1] : f32 into vector<3xf32>
   // CHECK: vector.insert {{.*}} [2] : f32 into vector<3xf32>
-  // Second slice [1, ...]: extracts → reductions → inserts
   // CHECK: vector.extract %[[SOURCE]][1, 0]
   // CHECK: vector.extract %[[SOURCE]][1, 1]
   // CHECK: vector.extract %[[SOURCE]][1, 2]
@@ -45,10 +43,8 @@ func.func @unroll_vector_multi_reduction_inner(%source: vector<2x3x5xf32>, %acc:
   // CHECK: vector.insert {{.*}} [0] : f32 into vector<3xf32>
   // CHECK: vector.insert {{.*}} [1] : f32 into vector<3xf32>
   // CHECK: vector.insert {{.*}} [2] : f32 into vector<3xf32>
-  // Final inserts to assemble result
   // CHECK: vector.insert {{.*}} [0] : vector<3xf32> into vector<2x3xf32>
   // CHECK: vector.insert {{.*}} [1] : vector<3xf32> into vector<2x3xf32>
-  // No original multi_reduction remains
   // CHECK-NOT: vector.multi_reduction
   %1 = vector.multi_reduction <add>, %source, %acc [2] : vector<2x3x5xf32> to vector<2x3xf32>
 
@@ -62,7 +58,6 @@ func.func @unroll_vector_multi_reduction_inner(%source: vector<2x3x5xf32>, %acc:
 // CHECK-SAME: %[[MASK:.+]]: vector<2x3x5xi1>,
 // CHECK-SAME: %[[ACC:.+]]: vector<2x3xf32>
 func.func @unroll_vector_multi_reduction_inner_masked(%source: vector<2x3x5xf32>, %mask: vector<2x3x5xi1>, %acc: vector<2x3xf32>) -> (vector<2x3xf32>) {
-  // First slice [0, ...]: extracts (source, acc, mask) → masked reductions → inserts
   // CHECK: vector.extract %[[SOURCE]][0, 0]
   // CHECK: vector.extract %[[SOURCE]][0, 1]
   // CHECK: vector.extract %[[SOURCE]][0, 2]
@@ -78,7 +73,6 @@ func.func @unroll_vector_multi_reduction_inner_masked(%source: vector<2x3x5xf32>
   // CHECK: vector.insert {{.*}} [0] : f32 into vector<3xf32>
   // CHECK: vector.insert {{.*}} [1] : f32 into vector<3xf32>
   // CHECK: vector.insert {{.*}} [2] : f32 into vector<3xf32>
-  // Second slice [1, ...]: extracts → masked reductions → inserts
   // CHECK: vector.extract %[[SOURCE]][1, 0]
   // CHECK: vector.extract %[[SOURCE]][1, 1]
   // CHECK: vector.extract %[[SOURCE]][1, 2]
@@ -94,10 +88,8 @@ func.func @unroll_vector_multi_reduction_inner_masked(%source: vector<2x3x5xf32>
   // CHECK: vector.insert {{.*}} [0] : f32 into vector<3xf32>
   // CHECK: vector.insert {{.*}} [1] : f32 into vector<3xf32>
   // CHECK: vector.insert {{.*}} [2] : f32 into vector<3xf32>
-  // Final inserts to assemble result
   // CHECK: vector.insert {{.*}} [0] : vector<3xf32> into vector<2x3xf32>
   // CHECK: vector.insert {{.*}} [1] : vector<3xf32> into vector<2x3xf32>
-  // No original multi_reduction remains
   // CHECK-NOT: vector.multi_reduction
 
   %0 = vector.mask %mask {
@@ -127,28 +119,20 @@ func.func @unroll_vector_multi_reduction_inner_masked(%source: vector<2x3x5xf32>
 func.func @unroll_vector_multi_reduction_inner_general(%source: vector<2x3x5xf32>, %acc: vector<2xf32>) -> (vector<2xf32>) {
   // CHECK-DAG: %[[ACC_0:.+]] = vector.extract %[[ACC]][0] : f32 from vector<2xf32>
   // CHECK-DAG: %[[ACC_1:.+]] = vector.extract %[[ACC]][1] : f32 from vector<2xf32>
-
-  // First slice [0, ...]: extracts → chained reductions
   // CHECK: vector.extract %[[SOURCE]][0, 0] : vector<5xf32>
   // CHECK: vector.extract %[[SOURCE]][0, 1] : vector<5xf32>
   // CHECK: vector.extract %[[SOURCE]][0, 2] : vector<5xf32>
   // CHECK: %[[R0_0:.+]] = vector.reduction <add>, {{.*}}, %[[ACC_0]] : vector<5xf32> into f32
   // CHECK: %[[R0_1:.+]] = vector.reduction <add>, {{.*}}, %[[R0_0]] : vector<5xf32> into f32
   // CHECK: %[[R0_2:.+]] = vector.reduction <add>, {{.*}}, %[[R0_1]] : vector<5xf32> into f32
-
-  // Second slice [1, ...]: extracts → chained reductions
   // CHECK: vector.extract %[[SOURCE]][1, 0] : vector<5xf32>
   // CHECK: vector.extract %[[SOURCE]][1, 1] : vector<5xf32>
   // CHECK: vector.extract %[[SOURCE]][1, 2] : vector<5xf32>
   // CHECK: %[[R1_0:.+]] = vector.reduction <add>, {{.*}}, %[[ACC_1]] : vector<5xf32> into f32
   // CHECK: %[[R1_1:.+]] = vector.reduction <add>, {{.*}}, %[[R1_0]] : vector<5xf32> into f32
   // CHECK: %[[R1_2:.+]] = vector.reduction <add>, {{.*}}, %[[R1_1]] : vector<5xf32> into f32
-
-  // Final inserts
   // CHECK: %[[INSERT_0:.+]] = vector.insert %[[R0_2]], %{{.*}} [0] : f32 into vector<2xf32>
   // CHECK: %[[INSERT_1:.+]] = vector.insert %[[R1_2]], %[[INSERT_0]] [1] : f32 into vector<2xf32>
-
-  // No original multi_reduction remains
   // CHECK-NOT: vector.multi_reduction
   %1 = vector.multi_reduction <add>, %source, %acc [1, 2] : vector<2x3x5xf32> to vector<2xf32>
 
@@ -165,8 +149,6 @@ func.func @unroll_vector_multi_reduction_inner_general(%source: vector<2x3x5xf32
 func.func @unroll_vector_multi_reduction_inner_general_masked(%source: vector<2x3x5xf32>, %mask: vector<2x3x5xi1>, %acc: vector<2xf32>) -> (vector<2xf32>) {
   // CHECK-DAG: %[[ACC_0:.+]] = vector.extract %[[ACC]][0] : f32 from vector<2xf32>
   // CHECK-DAG: %[[ACC_1:.+]] = vector.extract %[[ACC]][1] : f32 from vector<2xf32>
-
-  // First slice [0, ...]: extracts (source, mask) → chained masked reductions
   // CHECK: vector.extract %[[SOURCE]][0, 0] : vector<5xf32>
   // CHECK: vector.extract %[[SOURCE]][0, 1] : vector<5xf32>
   // CHECK: vector.extract %[[SOURCE]][0, 2] : vector<5xf32>
@@ -176,8 +158,6 @@ func.func @unroll_vector_multi_reduction_inner_general_masked(%source: vector<2x
   // CHECK: %[[R0_0:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[ACC_0]] : vector<5xf32> into f32 }
   // CHECK: %[[R0_1:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[R0_0]] : vector<5xf32> into f32 }
   // CHECK: %[[R0_2:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[R0_1]] : vector<5xf32> into f32 }
-
-  // Second slice [1, ...]: extracts (source, mask) → chained masked reductions
   // CHECK: vector.extract %[[SOURCE]][1, 0] : vector<5xf32>
   // CHECK: vector.extract %[[SOURCE]][1, 1] : vector<5xf32>
   // CHECK: vector.extract %[[SOURCE]][1, 2] : vector<5xf32>
@@ -187,12 +167,8 @@ func.func @unroll_vector_multi_reduction_inner_general_masked(%source: vector<2x
   // CHECK: %[[R1_0:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[ACC_1]] : vector<5xf32> into f32 }
   // CHECK: %[[R1_1:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[R1_0]] : vector<5xf32> into f32 }
   // CHECK: %[[R1_2:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[R1_1]] : vector<5xf32> into f32 }
-
-  // Final inserts
   // CHECK: %[[INSERT_0:.+]] = vector.insert %[[R0_2]], %{{.*}} [0] : f32 into vector<2xf32>
   // CHECK: %[[INSERT_1:.+]] = vector.insert %[[R1_2]], %[[INSERT_0]] [1] : f32 into vector<2xf32>
-
-  // No original multi_reduction remains
   // CHECK-NOT: vector.multi_reduction
 
   %0 = vector.mask %mask {

--- a/mlir/test/Dialect/Vector/unroll-vector-multi-reduction-inner.mlir
+++ b/mlir/test/Dialect/Vector/unroll-vector-multi-reduction-inner.mlir
@@ -164,3 +164,22 @@ func.func @unroll_vector_multi_reduction_inner_general_masked(%source: vector<2x
   // CHECK: return %[[INSERT_1]]
   return %0 : vector<2xf32>
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative Test: Rank-1 multi_reduction should NOT be matched by UnrollMultiReductionInner
+//===----------------------------------------------------------------------===//
+
+// UnrollMultiReductionInner requires srcRank >= 2, so rank-1 should not match.
+// The op should remain unchanged.
+
+// CHECK-LABEL: func @unroll_vector_multi_reduction_inner_rank1_negative(
+// CHECK-SAME: %[[SOURCE:.+]]: vector<8xf32>,
+// CHECK-SAME: %[[ACC:.+]]: f32
+func.func @unroll_vector_multi_reduction_inner_rank1_negative(%source: vector<8xf32>, %acc: f32) -> f32 {
+  // CHECK: %[[RESULT:.+]] = vector.multi_reduction <add>, %[[SOURCE]], %[[ACC]] [0] : vector<8xf32> to f32
+  %0 = vector.multi_reduction <add>, %source, %acc [0] : vector<8xf32> to f32
+  // CHECK: return %[[RESULT]]
+  return %0 : f32
+}

--- a/mlir/test/Dialect/Vector/unroll-vector-multi-reduction.mlir
+++ b/mlir/test/Dialect/Vector/unroll-vector-multi-reduction.mlir
@@ -1,0 +1,92 @@
+// RUN: mlir-opt --split-input-file %s -transform-preload-library='transform-library-paths=%p/td/unroll-multi-reduction.mlir' \
+// RUN: -transform-interpreter=entry-point=unroll_multi_reduction | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Test UnrollVectorMultiReduction
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func @unroll_vector_multi_reduction(
+// CHECK-SAME: %[[SOURCE:.+]]: vector<2x3x5xf32>,
+// CHECK-SAME: %[[ACC:.+]]: vector<3x5xf32>
+func.func @unroll_vector_multi_reduction(%source: vector<2x3x5xf32>, %acc: vector<3x5xf32>) -> (vector<3x5xf32>) {
+  // CHECK-DAG: %[[VEC_0:.+]] = vector.extract %[[SOURCE]][0] : vector<3x5xf32> from vector<2x3x5xf32>
+  // CHECK-DAG: %[[VEC_1:.+]] = vector.extract %[[SOURCE]][1] : vector<3x5xf32> from vector<2x3x5xf32>
+
+  // CHECK: %[[RES_0:.+]] = arith.addf %[[VEC_0]], %[[ACC]] : vector<3x5xf32>
+  // CHECK: %[[RES_1:.+]] = arith.addf %[[VEC_1]], %[[RES_0]] : vector<3x5xf32>
+  %1 = vector.multi_reduction <add>, %source, %acc [0] : vector<2x3x5xf32> to vector<3x5xf32>
+
+  // CHECK: return %[[RES_1]]
+  return %1 : vector<3x5xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @unroll_vector_multi_reduction_masked(
+// CHECK-SAME: %[[SOURCE:.+]]: vector<2x3x5xf32>,
+// CHECK-SAME: %[[MASK:.+]]: vector<2x3x5xi1>,
+// CHECK-SAME: %[[ACC:.+]]: vector<3x5xf32>
+func.func @unroll_vector_multi_reduction_masked(%source: vector<2x3x5xf32>, %mask: vector<2x3x5xi1>, %acc: vector<3x5xf32>) -> (vector<3x5xf32>) {
+  // CHECK-DAG: %[[VEC_0:.+]] = vector.extract %[[SOURCE]][0] : vector<3x5xf32> from vector<2x3x5xf32>
+  // CHECK-DAG: %[[VEC_1:.+]] = vector.extract %[[SOURCE]][1] : vector<3x5xf32> from vector<2x3x5xf32>
+
+  // CHECK-DAG: %[[MASK_0:.+]] = vector.extract %[[MASK]][0] : vector<3x5xi1> from vector<2x3x5xi1>
+  // CHECK-DAG: %[[MASK_1:.+]] = vector.extract %[[MASK]][1] : vector<3x5xi1> from vector<2x3x5xi1>
+
+  // CHECK: %[[RES_0:.+]] = arith.addf %[[VEC_0]], %[[ACC]] : vector<3x5xf32>
+  // CHECK: %[[RES_MASKED_0:.+]] = arith.select %[[MASK_0]], %[[RES_0]], %[[ACC]] : vector<3x5xi1>, vector<3x5xf32>
+
+  // CHECK: %[[RES_1:.+]] = arith.addf %[[VEC_1]], %[[RES_MASKED_0]] : vector<3x5xf32>
+  // CHECK: %[[RES_MASKED_1:.+]] = arith.select %[[MASK_1]], %[[RES_1]], %[[RES_MASKED_0]] : vector<3x5xi1>, vector<3x5xf32>
+
+  %0 = vector.mask %mask {
+    %1 = vector.multi_reduction <add>, %source, %acc [0] : vector<2x3x5xf32> to vector<3x5xf32>
+  } : vector<2x3x5xi1> -> vector<3x5xf32>
+
+  // CHECK: return %[[RES_MASKED_1]]
+  return %0 : vector<3x5xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @unroll_vector_multi_reduction_general(
+// CHECK-SAME: %[[SOURCE:.+]]: vector<2x3x5xf32>,
+// CHECK-SAME: %[[ACC:.+]]: vector<3xf32>
+func.func @unroll_vector_multi_reduction_general(%source: vector<2x3x5xf32>, %acc: vector<3xf32>) -> (vector<3xf32>) {
+
+  // CHECK-DAG: %[[VEC_0:.+]] = vector.extract %[[SOURCE]][0] : vector<3x5xf32> from vector<2x3x5xf32>
+  // CHECK-DAG: %[[VEC_1:.+]] = vector.extract %[[SOURCE]][1] : vector<3x5xf32> from vector<2x3x5xf32>
+
+  // CHECK: %[[RES_0:.+]] = vector.multi_reduction <add>, %[[VEC_0]], %[[ACC]] [1] : vector<3x5xf32> to vector<3xf32>
+  // CHECK: %[[RES_1:.+]] = vector.multi_reduction <add>, %[[VEC_1]], %[[RES_0]] [1] : vector<3x5xf32> to vector<3xf32>
+
+  %1 = vector.multi_reduction <add>, %source, %acc [0, 2] : vector<2x3x5xf32> to vector<3xf32>
+
+  // CHECK: return %[[RES_1]]
+  return %1 : vector<3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @unroll_vector_multi_reduction_general_masked(
+// CHECK-SAME: %[[SOURCE:.+]]: vector<2x3x5xf32>,
+// CHECK-SAME: %[[MASK:.+]]: vector<2x3x5xi1>,
+// CHECK-SAME: %[[ACC:.+]]: vector<3xf32>
+func.func @unroll_vector_multi_reduction_general_masked(%source: vector<2x3x5xf32>, %mask: vector<2x3x5xi1>, %acc: vector<3xf32>) -> (vector<3xf32>) {
+
+  // CHECK-DAG: %[[VEC_0:.+]] = vector.extract %[[SOURCE]][0] : vector<3x5xf32> from vector<2x3x5xf32>
+  // CHECK-DAG: %[[VEC_1:.+]] = vector.extract %[[SOURCE]][1] : vector<3x5xf32> from vector<2x3x5xf32>
+
+  // CHECK-DAG: %[[MASK_0:.+]] = vector.extract %[[MASK]][0] : vector<3x5xi1> from vector<2x3x5xi1>
+  // CHECK-DAG: %[[MASK_1:.+]] = vector.extract %[[MASK]][1] : vector<3x5xi1> from vector<2x3x5xi1>
+
+  // CHECK: %[[RES_0:.+]] = vector.mask %[[MASK_0]] { vector.multi_reduction <add>, %[[VEC_0]], %[[ACC]] [1] : vector<3x5xf32> to vector<3xf32> } : vector<3x5xi1> -> vector<3xf32>
+  // CHECK: %[[RES_1:.+]] = vector.mask %[[MASK_1]] { vector.multi_reduction <add>, %[[VEC_1]], %[[RES_0]] [1] : vector<3x5xf32> to vector<3xf32> } : vector<3x5xi1> -> vector<3xf32>
+
+  %0 = vector.mask %mask {
+    %1 = vector.multi_reduction <add>, %source, %acc [0, 2] : vector<2x3x5xf32> to vector<3xf32>
+  } : vector<2x3x5xi1> -> vector<3xf32>
+
+  // CHECK: return %[[RES_1]]
+  return %0 : vector<3xf32>
+}

--- a/mlir/test/Dialect/Vector/unroll-vector-multi-reduction.mlir
+++ b/mlir/test/Dialect/Vector/unroll-vector-multi-reduction.mlir
@@ -49,20 +49,47 @@ func.func @unroll_vector_multi_reduction_masked(%source: vector<2x3x5xf32>, %mas
 
 // -----
 
+// The general case (multiple reduction dims where outermost is reduction) now
+// fully lowers through:
+// - UnrollMultiReductionOuterGeneralCase: extracts along outermost reduction,
+//   chains smaller multi_reductions with remaining reduction dims
+// - UnrollInnerReductionAlongOuterParallel: handles resulting operations where
+//   outermost becomes parallel
+// - OneDimMultiReductionToReduction: converts 1-D multi_reductions to vector.reduction
+
 // CHECK-LABEL: func @unroll_vector_multi_reduction_general(
 // CHECK-SAME: %[[SOURCE:.+]]: vector<2x3x5xf32>,
 // CHECK-SAME: %[[ACC:.+]]: vector<3xf32>
 func.func @unroll_vector_multi_reduction_general(%source: vector<2x3x5xf32>, %acc: vector<3xf32>) -> (vector<3xf32>) {
+  // First row of reductions (source[0, ...])
+  // CHECK: vector.extract %[[SOURCE]][0, 0] : vector<5xf32>
+  // CHECK: vector.extract %[[SOURCE]][0, 1] : vector<5xf32>
+  // CHECK: vector.extract %[[SOURCE]][0, 2] : vector<5xf32>
+  // CHECK-DAG: %[[ACC_0:.+]] = vector.extract %[[ACC]][0] : f32
+  // CHECK-DAG: %[[ACC_1:.+]] = vector.extract %[[ACC]][1] : f32
+  // CHECK-DAG: %[[ACC_2:.+]] = vector.extract %[[ACC]][2] : f32
+  // CHECK: %[[R0_0:.+]] = vector.reduction <add>, {{.*}}, %[[ACC_0]] : vector<5xf32> into f32
+  // CHECK: %[[R0_1:.+]] = vector.reduction <add>, {{.*}}, %[[ACC_1]] : vector<5xf32> into f32
+  // CHECK: %[[R0_2:.+]] = vector.reduction <add>, {{.*}}, %[[ACC_2]] : vector<5xf32> into f32
 
-  // CHECK-DAG: %[[VEC_0:.+]] = vector.extract %[[SOURCE]][0] : vector<3x5xf32> from vector<2x3x5xf32>
-  // CHECK-DAG: %[[VEC_1:.+]] = vector.extract %[[SOURCE]][1] : vector<3x5xf32> from vector<2x3x5xf32>
+  // Second row of reductions (source[1, ...]), chaining from first row results
+  // CHECK: vector.extract %[[SOURCE]][1, 0] : vector<5xf32>
+  // CHECK: vector.extract %[[SOURCE]][1, 1] : vector<5xf32>
+  // CHECK: vector.extract %[[SOURCE]][1, 2] : vector<5xf32>
+  // CHECK: %[[R1_0:.+]] = vector.reduction <add>, {{.*}}, %[[R0_0]] : vector<5xf32> into f32
+  // CHECK: %[[R1_1:.+]] = vector.reduction <add>, {{.*}}, %[[R0_1]] : vector<5xf32> into f32
+  // CHECK: %[[R1_2:.+]] = vector.reduction <add>, {{.*}}, %[[R0_2]] : vector<5xf32> into f32
 
-  // CHECK: %[[RES_0:.+]] = vector.multi_reduction <add>, %[[VEC_0]], %[[ACC]] [1] : vector<3x5xf32> to vector<3xf32>
-  // CHECK: %[[RES_1:.+]] = vector.multi_reduction <add>, %[[VEC_1]], %[[RES_0]] [1] : vector<3x5xf32> to vector<3xf32>
+  // Final inserts to assemble result
+  // CHECK: %[[INSERT_0:.+]] = vector.insert %[[R1_0]], %{{.*}} [0] : f32 into vector<3xf32>
+  // CHECK: %[[INSERT_1:.+]] = vector.insert %[[R1_1]], %[[INSERT_0]] [1] : f32 into vector<3xf32>
+  // CHECK: %[[INSERT_2:.+]] = vector.insert %[[R1_2]], %[[INSERT_1]] [2] : f32 into vector<3xf32>
 
+  // No original multi_reduction remains
+  // CHECK-NOT: vector.multi_reduction
   %1 = vector.multi_reduction <add>, %source, %acc [0, 2] : vector<2x3x5xf32> to vector<3xf32>
 
-  // CHECK: return %[[RES_1]]
+  // CHECK: return %[[INSERT_2]]
   return %1 : vector<3xf32>
 }
 
@@ -73,21 +100,44 @@ func.func @unroll_vector_multi_reduction_general(%source: vector<2x3x5xf32>, %ac
 // CHECK-SAME: %[[MASK:.+]]: vector<2x3x5xi1>,
 // CHECK-SAME: %[[ACC:.+]]: vector<3xf32>
 func.func @unroll_vector_multi_reduction_general_masked(%source: vector<2x3x5xf32>, %mask: vector<2x3x5xi1>, %acc: vector<3xf32>) -> (vector<3xf32>) {
+  // First row of reductions (source[0, ...])
+  // CHECK: vector.extract %[[SOURCE]][0, 0] : vector<5xf32>
+  // CHECK: vector.extract %[[SOURCE]][0, 1] : vector<5xf32>
+  // CHECK: vector.extract %[[SOURCE]][0, 2] : vector<5xf32>
+  // CHECK-DAG: %[[ACC_0:.+]] = vector.extract %[[ACC]][0] : f32
+  // CHECK-DAG: %[[ACC_1:.+]] = vector.extract %[[ACC]][1] : f32
+  // CHECK-DAG: %[[ACC_2:.+]] = vector.extract %[[ACC]][2] : f32
+  // CHECK: vector.extract %[[MASK]][0, 0] : vector<5xi1>
+  // CHECK: vector.extract %[[MASK]][0, 1] : vector<5xi1>
+  // CHECK: vector.extract %[[MASK]][0, 2] : vector<5xi1>
+  // CHECK: %[[R0_0:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[ACC_0]] : vector<5xf32> into f32 }
+  // CHECK: %[[R0_1:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[ACC_1]] : vector<5xf32> into f32 }
+  // CHECK: %[[R0_2:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[ACC_2]] : vector<5xf32> into f32 }
 
-  // CHECK-DAG: %[[VEC_0:.+]] = vector.extract %[[SOURCE]][0] : vector<3x5xf32> from vector<2x3x5xf32>
-  // CHECK-DAG: %[[VEC_1:.+]] = vector.extract %[[SOURCE]][1] : vector<3x5xf32> from vector<2x3x5xf32>
+  // Second row of reductions (source[1, ...]), chaining from first row results
+  // CHECK: vector.extract %[[SOURCE]][1, 0] : vector<5xf32>
+  // CHECK: vector.extract %[[SOURCE]][1, 1] : vector<5xf32>
+  // CHECK: vector.extract %[[SOURCE]][1, 2] : vector<5xf32>
+  // CHECK: vector.extract %[[MASK]][1, 0] : vector<5xi1>
+  // CHECK: vector.extract %[[MASK]][1, 1] : vector<5xi1>
+  // CHECK: vector.extract %[[MASK]][1, 2] : vector<5xi1>
+  // CHECK: %[[R1_0:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[R0_0]] : vector<5xf32> into f32 }
+  // CHECK: %[[R1_1:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[R0_1]] : vector<5xf32> into f32 }
+  // CHECK: %[[R1_2:.+]] = vector.mask {{.*}} { vector.reduction <add>, {{.*}}, %[[R0_2]] : vector<5xf32> into f32 }
 
-  // CHECK-DAG: %[[MASK_0:.+]] = vector.extract %[[MASK]][0] : vector<3x5xi1> from vector<2x3x5xi1>
-  // CHECK-DAG: %[[MASK_1:.+]] = vector.extract %[[MASK]][1] : vector<3x5xi1> from vector<2x3x5xi1>
+  // Final inserts to assemble result
+  // CHECK: %[[INSERT_0:.+]] = vector.insert %[[R1_0]], %{{.*}} [0] : f32 into vector<3xf32>
+  // CHECK: %[[INSERT_1:.+]] = vector.insert %[[R1_1]], %[[INSERT_0]] [1] : f32 into vector<3xf32>
+  // CHECK: %[[INSERT_2:.+]] = vector.insert %[[R1_2]], %[[INSERT_1]] [2] : f32 into vector<3xf32>
 
-  // CHECK: %[[RES_0:.+]] = vector.mask %[[MASK_0]] { vector.multi_reduction <add>, %[[VEC_0]], %[[ACC]] [1] : vector<3x5xf32> to vector<3xf32> } : vector<3x5xi1> -> vector<3xf32>
-  // CHECK: %[[RES_1:.+]] = vector.mask %[[MASK_1]] { vector.multi_reduction <add>, %[[VEC_1]], %[[RES_0]] [1] : vector<3x5xf32> to vector<3xf32> } : vector<3x5xi1> -> vector<3xf32>
+  // No original multi_reduction remains
+  // CHECK-NOT: vector.multi_reduction
 
   %0 = vector.mask %mask {
     %1 = vector.multi_reduction <add>, %source, %acc [0, 2] : vector<2x3x5xf32> to vector<3xf32>
   } : vector<2x3x5xi1> -> vector<3xf32>
 
-  // CHECK: return %[[RES_1]]
+  // CHECK: return %[[INSERT_2]]
   return %0 : vector<3xf32>
 }
 

--- a/mlir/test/Dialect/Vector/unroll-vector-multi-reduction.mlir
+++ b/mlir/test/Dialect/Vector/unroll-vector-multi-reduction.mlir
@@ -90,3 +90,22 @@ func.func @unroll_vector_multi_reduction_general_masked(%source: vector<2x3x5xf3
   // CHECK: return %[[RES_1]]
   return %0 : vector<3xf32>
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Negative Test: Rank-1 multi_reduction should NOT be matched by unroll patterns
+//===----------------------------------------------------------------------===//
+
+// UnrollMultiReductionOuterBaseCase and UnrollMultiReductionOuterGeneralCase
+// should not match rank-1 multi_reduction ops. The op should remain unchanged.
+
+// CHECK-LABEL: func @unroll_vector_multi_reduction_rank1_negative(
+// CHECK-SAME: %[[SOURCE:.+]]: vector<8xf32>,
+// CHECK-SAME: %[[ACC:.+]]: f32
+func.func @unroll_vector_multi_reduction_rank1_negative(%source: vector<8xf32>, %acc: f32) -> f32 {
+  // CHECK: %[[RESULT:.+]] = vector.multi_reduction <add>, %[[SOURCE]], %[[ACC]] [0] : vector<8xf32> to f32
+  %0 = vector.multi_reduction <add>, %source, %acc [0] : vector<8xf32> to f32
+  // CHECK: return %[[RESULT]]
+  return %0 : f32
+}

--- a/mlir/test/Dialect/Vector/vector-multi-reduction-pass-lowering.mlir
+++ b/mlir/test/Dialect/Vector/vector-multi-reduction-pass-lowering.mlir
@@ -21,12 +21,12 @@ func.func @vector_multi_reduction(%arg0: vector<2x4xf32>, %acc: vector<2xf32>) -
 
 //      INNER-PARALLEL: %[[TRANSPOSED:.+]] = vector.transpose %[[INPUT]], [1, 0] : vector<2x4xf32> to vector<4x2xf32>
 //      INNER-PARALLEL: %[[V0:.+]] = vector.extract %[[TRANSPOSED]][0] : vector<2xf32> from vector<4x2xf32>
-//      INNER-PARALLEL: %[[RV0:.+]] = arith.mulf %[[V0]], %[[ACC]] : vector<2xf32>
 //      INNER-PARALLEL: %[[V1:.+]] = vector.extract %[[TRANSPOSED]][1] : vector<2xf32> from vector<4x2xf32>
-//      INNER-PARALLEL: %[[RV01:.+]] = arith.mulf %[[V1]], %[[RV0]] : vector<2xf32>
 //      INNER-PARALLEL: %[[V2:.+]] = vector.extract %[[TRANSPOSED]][2] : vector<2xf32> from vector<4x2xf32>
-//      INNER-PARALLEL: %[[RV012:.+]] = arith.mulf %[[V2]], %[[RV01]] : vector<2xf32>
 //      INNER-PARALLEL: %[[V3:.+]] = vector.extract %[[TRANSPOSED]][3] : vector<2xf32> from vector<4x2xf32>
+//      INNER-PARALLEL: %[[RV0:.+]] = arith.mulf %[[V0]], %[[ACC]] : vector<2xf32>
+//      INNER-PARALLEL: %[[RV01:.+]] = arith.mulf %[[V1]], %[[RV0]] : vector<2xf32>
+//      INNER-PARALLEL: %[[RV012:.+]] = arith.mulf %[[V2]], %[[RV01]] : vector<2xf32>
 //      INNER-PARALLEL: %[[RESULT_VEC:.+]] = arith.mulf %[[V3]], %[[RV012]] : vector<2xf32>
 //      INNER-PARALLEL: return %[[RESULT_VEC]] : vector<2xf32>
 

--- a/mlir/test/Dialect/Vector/vector-multi-reduction-pass-lowering.mlir
+++ b/mlir/test/Dialect/Vector/vector-multi-reduction-pass-lowering.mlir
@@ -10,13 +10,13 @@ func.func @vector_multi_reduction(%arg0: vector<2x4xf32>, %acc: vector<2xf32>) -
 //            ALL-SAME: %[[INPUT:.+]]: vector<2x4xf32>, %[[ACC:.*]]: vector<2xf32>)
 // INNER-REDUCTION-DAG: %[[RESULT_VEC_0:.+]] = arith.constant dense<{{.*}}> : vector<2xf32>
 //     INNER-REDUCTION: %[[V0:.+]] = vector.extract %[[INPUT]][0]
-//     INNER-REDUCTION: %[[ACC0:.+]] = vector.extract %[[ACC]][0]
-//     INNER-REDUCTION: %[[RV0:.+]] = vector.reduction <mul>, %[[V0]], %[[ACC0]] : vector<4xf32> into f32
-//     INNER-REDUCTION: %[[RESULT_VEC_1:.+]] = vector.insert %[[RV0:.+]], %[[RESULT_VEC_0]] [0] : f32 into vector<2xf32>
 //     INNER-REDUCTION: %[[V1:.+]] = vector.extract %[[INPUT]][1]
+//     INNER-REDUCTION: %[[ACC0:.+]] = vector.extract %[[ACC]][0]
 //     INNER-REDUCTION: %[[ACC1:.+]] = vector.extract %[[ACC]][1]
+//     INNER-REDUCTION: %[[RV0:.+]] = vector.reduction <mul>, %[[V0]], %[[ACC0]] : vector<4xf32> into f32
 //     INNER-REDUCTION: %[[RV1:.+]] = vector.reduction <mul>, %[[V1]], %[[ACC1]] : vector<4xf32> into f32
-//     INNER-REDUCTION: %[[RESULT_VEC:.+]] = vector.insert %[[RV1:.+]], %[[RESULT_VEC_1]] [1] : f32 into vector<2xf32>
+//     INNER-REDUCTION: %[[RESULT_VEC_1:.+]] = vector.insert %[[RV0]], %[[RESULT_VEC_0]] [0] : f32 into vector<2xf32>
+//     INNER-REDUCTION: %[[RESULT_VEC:.+]] = vector.insert %[[RV1]], %[[RESULT_VEC_1]] [1] : f32 into vector<2xf32>
 //     INNER-REDUCTION: return %[[RESULT_VEC]]
 
 //      INNER-PARALLEL: %[[TRANSPOSED:.+]] = vector.transpose %[[INPUT]], [1, 0] : vector<2x4xf32> to vector<4x2xf32>
@@ -51,10 +51,14 @@ func.func @vector_multi_reduction_masked(%arg0: vector<2x4xf32>, %acc: vector<2x
 
 //       ALL-LABEL: func @vector_multi_reduction_masked
 //        ALL-SAME: %[[INPUT:.+]]: vector<2x4xf32>, %[[ACC:.+]]: vector<2xf32>, %[[MASK:.+]]: vector<2x4xi1>
-// INNER-REDUCTION: %[[INNERVEC:.+]] = vector.extract %[[INPUT]][0] : vector<4xf32> from vector<2x4xf32>
-// INNER-REDUCTION: %[[INNERACC:.+]] = vector.extract %[[ACC]][0] : f32 from vector<2xf32>
-// INNER-REDUCTION: %[[INNERMASK:.+]] = vector.extract %[[MASK]][0] : vector<4xi1> from vector<2x4xi1>
-// INNER-REDUCTION: vector.mask %[[INNERMASK]] { vector.reduction <mul>, %[[INNERVEC]], %[[INNERACC]] : vector<4xf32> into f32 } : vector<4xi1> -> f32
+// INNER-REDUCTION: %[[V0:.+]] = vector.extract %[[INPUT]][0] : vector<4xf32> from vector<2x4xf32>
+// INNER-REDUCTION: %[[V1:.+]] = vector.extract %[[INPUT]][1] : vector<4xf32> from vector<2x4xf32>
+// INNER-REDUCTION: %[[ACC0:.+]] = vector.extract %[[ACC]][0] : f32 from vector<2xf32>
+// INNER-REDUCTION: %[[ACC1:.+]] = vector.extract %[[ACC]][1] : f32 from vector<2xf32>
+// INNER-REDUCTION: %[[MASK0:.+]] = vector.extract %[[MASK]][0] : vector<4xi1> from vector<2x4xi1>
+// INNER-REDUCTION: %[[MASK1:.+]] = vector.extract %[[MASK]][1] : vector<4xi1> from vector<2x4xi1>
+// INNER-REDUCTION: vector.mask %[[MASK0]] { vector.reduction <mul>, %[[V0]], %[[ACC0]] : vector<4xf32> into f32 } : vector<4xi1> -> f32
+// INNER-REDUCTION: vector.mask %[[MASK1]] { vector.reduction <mul>, %[[V1]], %[[ACC1]] : vector<4xf32> into f32 } : vector<4xi1> -> f32
 //  INNER-PARALLEL: %[[TPMASK:.+]] = vector.transpose %[[MASK]], [1, 0] : vector<2x4xi1> to vector<4x2xi1>
 //  INNER-PARALLEL: %[[TPINPUT:.+]] = vector.transpose %[[INPUT]], [1, 0] : vector<2x4xf32> to vector<4x2xf32>
 //  INNER-PARALLEL: %[[INNERVEC:.+]] = vector.extract %[[TPINPUT]][0] : vector<2xf32> from vector<4x2xf32>


### PR DESCRIPTION
The pass `lower-vector-multi-reduction` used flattening and unrolling along with several other patterns to lower multi_reduce operations into simpler operations. This makes it unrolling difficult to control. Therefore, we split these pattern sets into three stages.

1. Transformations useful for `lower-vector-multi-reduction` in `populateVectorMultiReductionInnerOuterDimPatterns` which populates `InnerOuterDimReductionConversion` and `OneDimMultiReductionToTwoDim`.
2. Set the pattern `ReduceMultiDimReductionRank` in `populateVectorMultiReductionFlatteningPatterns`.
3. Add unrolling patterns in `populateVectorUnrollMultiReduction` which are rank reducing.

The original population of patterns `populateVectorMultiReductionLoweringPatterns` is preserved to allow external projects to migrate to these new pattern population functions at their own pace.

The vector unrolling has been generalized. Previously only vectors of rank two (which were expected due to `ReduceMultiDimReductionRank` being run earlier) were unrolled. With this new structure, the unrolling patterns have been generalized to allow unrolling of n-dimensional vectors either with the innermost or outermost dimensions are reduced.

The generalization works in the following pattern:

1. Rank-1 multi_reduction -> convert directly to vector.reduction
2. OuterReduction with single reduction dim -> unroll to elementwise ops (base case).
3. OuterReduction with multiple reduction dims -> extract along outermost (reduced) dim, chain multi_reductions sequentially.
4. InnerReduction -> extract along outermost (parallel) dim, create independent multi_reductions, reassemble results.

The `lower-vector-multi-reduction` pass is now split into three different stages. Generalizing the unrolling patterns forces us to establish an order in which patterns must be applied. Otherwise, different patterns may match the same operations introducing non-determinism.

The first couple of commits were handwritten. The next couple of commits were based on other handwritten commits and just copy pasted by claude. The rest were mostly generated by claude.

Assisted-by: claude