### PR TITLE
[lldb] Handle STT_TLS symbol type in ELF parser

### DIFF
--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -2241,6 +2241,12 @@ ObjectFileELF::ParseSymbols(Symtab *symtab, user_id_t start_id,
         // function will be resolved if it is referenced.
         symbol_type = eSymbolTypeResolver;
         break;
+
+      case STT_TLS:
+        // The symbol is associated with a thread-local data object, such as
+        // a thread-local variable.
+        symbol_type = eSymbolTypeData;
+        break;
       }
     }
 

--- a/lldb/test/Shell/ObjectFile/ELF/stt-tls-symbol.yaml
+++ b/lldb/test/Shell/ObjectFile/ELF/stt-tls-symbol.yaml
@@ -1,0 +1,28 @@
+# Test that STT_TLS symbols are recognized and treated as data symbols.
+#
+# RUN: yaml2obj %s -o %t
+# RUN: %lldb %t -o "image dump symtab" -b | FileCheck %s
+
+# CHECK: Index   UserID DSX Type            File Address/Value Load Address       Size               Flags      Name
+# CHECK: [    0]      1     Data            0x0000000000001000                    0x0000000000000004 {{0x[0-9a-f]+}} tls_var
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .tdata
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_WRITE, SHF_TLS ]
+    Address:         0x1000
+    AddressAlign:    0x4
+    Size:            0x4
+Symbols:
+  - Name:            tls_var
+    Type:            STT_TLS
+    Section:         .tdata
+    Value:           0x1000
+    Size:            0x4
+...


### PR DESCRIPTION
Add handling for `STT_TLS` (thread-local storage) symbols in the ELF symbol parsing code. Previously, TLS symbols like `errno` from glibc were not recognized because `STT_TLS` was not handled in the symbol type switch statement.

This treats TLS symbols as data symbols (`eSymbolTypeData`), similar to `STT_OBJECT`. The actual TLS address resolution is already implemented in `DynamicLoaderPOSIXDYLD::GetThreadLocalData()` which uses the DWARF `DW_OP_form_tls_address` opcode to calculate thread-local addresses.