### PR TITLE
[PowerPC] Fix miscompilation when using 32-bit ucmp on 64-bit PowerPC

### DIFF
--- a/llvm/test/CodeGen/PowerPC/ucmp.ll
+++ b/llvm/test/CodeGen/PowerPC/ucmp.ll
@@ -4,8 +4,10 @@
 define i8 @ucmp_8_8(i8 zeroext %x, i8 zeroext %y) nounwind {
 ; CHECK-LABEL: ucmp_8_8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    subc 6, 4, 3
+; CHECK-NEXT:    clrldi 3, 3, 32
+; CHECK-NEXT:    clrldi 4, 4, 32
 ; CHECK-NEXT:    sub 5, 3, 4
+; CHECK-NEXT:    subc 6, 4, 3
 ; CHECK-NEXT:    subfe 3, 4, 3
 ; CHECK-NEXT:    subfe 3, 3, 5
 ; CHECK-NEXT:    blr
@@ -16,8 +18,10 @@ define i8 @ucmp_8_8(i8 zeroext %x, i8 zeroext %y) nounwind {
 define i8 @ucmp_8_16(i16 zeroext %x, i16 zeroext %y) nounwind {
 ; CHECK-LABEL: ucmp_8_16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    subc 6, 4, 3
+; CHECK-NEXT:    clrldi 3, 3, 32
+; CHECK-NEXT:    clrldi 4, 4, 32
 ; CHECK-NEXT:    sub 5, 3, 4
+; CHECK-NEXT:    subc 6, 4, 3
 ; CHECK-NEXT:    subfe 3, 4, 3
 ; CHECK-NEXT:    subfe 3, 3, 5
 ; CHECK-NEXT:    blr
@@ -28,8 +32,10 @@ define i8 @ucmp_8_16(i16 zeroext %x, i16 zeroext %y) nounwind {
 define i8 @ucmp_8_32(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: ucmp_8_32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    subc 6, 4, 3
+; CHECK-NEXT:    clrldi 3, 3, 32
+; CHECK-NEXT:    clrldi 4, 4, 32
 ; CHECK-NEXT:    sub 5, 3, 4
+; CHECK-NEXT:    subc 6, 4, 3
 ; CHECK-NEXT:    subfe 3, 4, 3
 ; CHECK-NEXT:    subfe 3, 3, 5
 ; CHECK-NEXT:    blr
@@ -72,8 +78,10 @@ define i8 @ucmp_8_128(i128 %x, i128 %y) nounwind {
 define i32 @ucmp_32_32(i32 %x, i32 %y) nounwind {
 ; CHECK-LABEL: ucmp_32_32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    subc 6, 4, 3
+; CHECK-NEXT:    clrldi 3, 3, 32
+; CHECK-NEXT:    clrldi 4, 4, 32
 ; CHECK-NEXT:    sub 5, 3, 4
+; CHECK-NEXT:    subc 6, 4, 3
 ; CHECK-NEXT:    subfe 3, 4, 3
 ; CHECK-NEXT:    subfe 3, 3, 5
 ; CHECK-NEXT:    blr


### PR DESCRIPTION
I forgot that you need to clear the upper 32 bits for the carry flag to work properly on ppc64 or else there will be garbage and possibly incorrect results.

Fixes: https://github.com/llvm/llvm-project/issues/179119

I do not have merge permissions.