### PR TITLE
[clang][driver][darwin] Tweak the use after scope fix in Darwin driver toolchain

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2043,7 +2043,7 @@ private:
   static std::string getDisplayName(DarwinPlatformKind TargetPlatform,
                                     DarwinEnvironmentKind TargetEnvironment,
                                     VersionTuple Version) {
-    SmallVector<StringRef, 3> Components;
+    SmallVector<std::string, 3> Components;
     switch (TargetPlatform) {
     case DarwinPlatformKind::MacOS:
       Components.push_back("macOS");
@@ -2076,8 +2076,7 @@ private:
                                   std::to_string(TargetEnvironment) +
                                   "' is unsupported when inferring SDK Info.");
     }
-    std::string VersionString = Version.getAsString();
-    Components.push_back(VersionString);
+    Components.push_back(Version.getAsString());
     return join(Components, " ");
   }
 


### PR DESCRIPTION
It's ever so slightly cleaner looking and less error prone to make the SmallVector hold std::string instead of making a local just for the version string.