### PR TITLE
[BOLT] Get symbol for const island referenced across func by relocation

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -3136,10 +3136,11 @@ void RewriteInstance::handleRelocation(const SectionRef &RelocatedSection,
         ReferencedSymbol = nullptr;
         ExtractedValue = Address;
       } else if (RefFunctionOffset) {
-        if (ContainingBF && ContainingBF != ReferencedBF &&
-            !ReferencedBF->isInConstantIsland(Address)) {
+        if (ContainingBF && ContainingBF != ReferencedBF) {
           ReferencedSymbol =
-              ReferencedBF->addEntryPointAtOffset(RefFunctionOffset);
+              ReferencedBF->isInConstantIsland(Address)
+                  ? ReferencedBF->getOrCreateIslandAccess(Address)
+                  : ReferencedBF->addEntryPointAtOffset(RefFunctionOffset);
         } else {
           ReferencedSymbol = ReferencedBF->getOrCreateLocalLabel(Address);
 

--- a/bolt/test/AArch64/constant-island-reference.s
+++ b/bolt/test/AArch64/constant-island-reference.s
@@ -1,0 +1,20 @@
+// Test BOLT won't ignore function having reference to constant island
+// that is defined in another function.
+
+// RUN: %clang %cxxflags -fuse-ld=lld %s -o %t.so -Wl,-q -no-pie
+// RUN: llvm-bolt %t.so -o %t.bolt.so --strict
+
+  .text
+  .type foo,@function
+foo:
+  adrp x9, :got:_global_func_ptr
+  ldr x9, [x9, #:got_lo12:_global_func_ptr]
+  blr x9
+  .size foo, .-foo
+
+  .type bar,@function
+bar:
+  nop
+_global_func_ptr:
+  .quad 0
+  .size bar, .-bar


### PR DESCRIPTION
When handling relocation in one function referencing code or data defined
in another function, we should check if relocation target is constant island
and get the referenced symbol accordingly for both cases.