### PR TITLE
[mlir][tensor] Guard FromElementsOp fold

### DIFF
--- a/mlir/test/Dialect/Tensor/fold-from-elements.mlir
+++ b/mlir/test/Dialect/Tensor/fold-from-elements.mlir
@@ -27,3 +27,37 @@ module {
 // CHECK-LABEL: func.func @fold_from_elements_index
 // CHECK: arith.constant dense<[0, 1]> : tensor<2xindex>
 
+// -----
+
+// RUN: mlir-opt %s -canonicalize -split-input-file | FileCheck %s
+
+module {
+  func.func @fold_from_elements_i32() -> tensor<2xi32> {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %t = tensor.from_elements %c0, %c1 : tensor<2xi32>
+    return %t : tensor<2xi32>
+  }
+}
+
+// CHECK-LABEL: func.func @fold_from_elements_i32
+// CHECK: %[[CST:.*]] = arith.constant dense<[0, 1]> : tensor<2xi32>
+// CHECK: return %[[CST]] : tensor<2xi32>
+
+// -----
+
+module {
+  func.func @from_elements_no_fold_with_poison() -> tensor<2xi32> {
+    %p = ub.poison : i32
+    %c0 = arith.constant 0 : i32
+    %t = tensor.from_elements %p, %c0 : tensor<2xi32>
+    return %t : tensor<2xi32>
+  }
+}
+
+// CHECK-LABEL: func.func @from_elements_no_fold_with_poison
+// CHECK: %[[P:.*]] = ub.poison : i32
+// CHECK: %[[C0:.*]] = arith.constant 0 : i32
+// CHECK: %[[T:.*]] = tensor.from_elements %[[P]], %[[C0]] : tensor<2xi32>
+// CHECK: return %[[T]] : tensor<2xi32>
+// CHECK-NOT: arith.constant dense<

--- a/mlir/test/Dialect/Tensor/fold-from-elements.mlir
+++ b/mlir/test/Dialect/Tensor/fold-from-elements.mlir
@@ -1,0 +1,29 @@
+// RUN: mlir-opt %s -canonicalize -split-input-file | FileCheck %s
+
+module {
+  func.func @fold_from_elements_i32() -> tensor<2xi32> {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %t = tensor.from_elements %c0, %c1 : tensor<2xi32>
+    return %t : tensor<2xi32>
+  }
+}
+
+// CHECK-LABEL: func.func @fold_from_elements_i32
+// CHECK: %[[CST:.*]] = arith.constant dense<[0, 1]> : tensor<2xi32>
+// CHECK: return %[[CST]] : tensor<2xi32>
+
+// -----
+
+module {
+  func.func @fold_from_elements_index() -> tensor<2xindex> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %t = tensor.from_elements %c0, %c1 : tensor<2xindex>
+    return %t : tensor<2xindex>
+  }
+}
+
+// CHECK-LABEL: func.func @fold_from_elements_index
+// CHECK: arith.constant dense<[0, 1]> : tensor<2xindex>
+


### PR DESCRIPTION
FromElementsOp::fold currently attempts to build
a DenseElementsAttr whenever all elem fold results are non-null. This can include ub.poison ops,
which triggers an assertion failure when trying to cast elements to a DenseElementsAttr.
This commit adds a guard to prevent attempting
to fold FromElementsOps that contain ub.poison
elements.

Fixes https://github.com/llvm/llvm-project/issues/178818
Fixes https://github.com/llvm/llvm-project/issues/178217