### PR TITLE
[clang-tidy] Speed up `llvm-prefer-isa-or-dyn-cast-in-conditionals`

### DIFF
--- a/clang-tools-extra/clang-tidy/llvm/PreferIsaOrDynCastInConditionalsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/PreferIsaOrDynCastInConditionalsCheck.cpp
@@ -46,16 +46,17 @@ void PreferIsaOrDynCastInConditionalsCheck::registerMatchers(
           hasArgument(0, mapAnyOf(declRefExpr, cxxMemberCallExpr).bind("arg")))
           .bind("rhs");
 
-  Finder->addMatcher(
-      stmt(anyOf(ifStmt(CondExprOrCondVar), forStmt(CondExprOrCondVar),
-                 whileStmt(CondExprOrCondVar), doStmt(CondExpr),
-                 binaryOperator(unless(isExpansionInFileMatching(
-                                    "llvm/include/llvm/Support/Casting.h")),
-                                hasOperatorName("&&"),
-                                hasLHS(implicitCastExpr().bind("lhs")),
-                                hasRHS(ignoringImpCasts(CallWithBindedArg)))
-                     .bind("and"))),
-      this);
+  Finder->addMatcher(ifStmt(CondExprOrCondVar), this);
+  Finder->addMatcher(forStmt(CondExprOrCondVar), this);
+  Finder->addMatcher(whileStmt(CondExprOrCondVar), this);
+  Finder->addMatcher(doStmt(CondExpr), this);
+  Finder->addMatcher(binaryOperator(hasRHS(ignoringImpCasts(CallWithBindedArg)),
+                                    hasLHS(implicitCastExpr().bind("lhs")),
+                                    hasOperatorName("&&"),
+                                    unless(isExpansionInFileMatching(
+                                        "llvm/include/llvm/Support/Casting.h")))
+                         .bind("and"),
+                     this);
 }
 
 void PreferIsaOrDynCastInConditionalsCheck::check(


### PR DESCRIPTION
Same approach as described in #178829.
```txt
                    ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
Status quo:         0.2031 (100.0%)   0.0469 (100.0%)   0.2500 (100.0%)   0.2635 (100.0%)  llvm-prefer-isa-or-dyn-cast-in-conditionals
With this change:   0.0312 (100.0%)                     0.0312 (100.0%)   0.0190 (100.0%)  llvm-prefer-isa-or-dyn-cast-in-conditionals
```
(I think `--enable-check-profile` doesn't report any system time after this change because it's too small).