### PR TITLE
[X86][utils] Support `-basic-block-sections` in `update_llc_test_checks`

### DIFF
--- a/llvm/utils/UpdateTestChecks/isel.py
+++ b/llvm/utils/UpdateTestChecks/isel.py
@@ -35,7 +35,7 @@ def scrub_isel_default(isel, args):
     return isel
 
 
-def get_run_handler(triple):
+def get_run_handler(triple, bb_sections=False):
     target_handlers = {}
     handler = None
     best_prefix = ""

--- a/llvm/utils/update_llc_test_checks.py
+++ b/llvm/utils/update_llc_test_checks.py
@@ -170,7 +170,13 @@ def update_test(ti: common.TestInfo):
             )
         else:
             # ASM output mode
-            scrubber, function_re = output_type.get_run_handler(triple)
+
+            bb_sections = "basic-block-sections" in llc_args and (
+                triple.startswith("x86")
+                or triple.startswith("i686")
+                or triple.startswith("i386")
+            )
+            scrubber, function_re = output_type.get_run_handler(triple, bb_sections)
             if 0 == builder.process_run_line(
                 function_re, scrubber, raw_tool_output, prefixes
             ):


### PR DESCRIPTION
If `-basic-block-sections` is present in the `RUN` line then choose a different regex to extract function body from generated assembly. This regex does not end function body at `.section` or `.cfi_endproc`.