### PR TITLE
[mlir][tensor] Emit diagnostics for unranked tensor reshape ops instead of asserting

### DIFF
--- a/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
+++ b/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
@@ -1133,7 +1133,7 @@ def Tensor_ExpandShapeOp : Tensor_ReassociativeReshapeOp<"expand_shape"> {
     ```
   }];
 
-  let arguments = (ins AnyTensor:$src, IndexListArrayAttr:$reassociation,
+  let arguments = (ins AnyRankedTensor:$src, IndexListArrayAttr:$reassociation,
                        Variadic<Index>:$output_shape,
                        DenseI64ArrayAttr:$static_output_shape);
 

--- a/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
+++ b/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
@@ -1191,7 +1191,7 @@ def Tensor_ExpandShapeOp : Tensor_ReassociativeReshapeOp<"expand_shape"> {
 
 def Tensor_CollapseShapeOp : Tensor_ReassociativeReshapeOp<"collapse_shape"> {
   let summary = "operation to produce a tensor with a smaller rank";
-  let arguments = (ins AnyTensor:$src, IndexListArrayAttr:$reassociation);
+  let arguments = (ins AnyRankedTensor:$src, IndexListArrayAttr:$reassociation);
   let description = [{
     The `tensor.collapse_shape` op produces a new tensor of lower (or equal)
     rank whose dimension sizes are a reassociation of the original `src` dimensions.

--- a/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
+++ b/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
@@ -1077,7 +1077,7 @@ class Tensor_ReassociativeReshapeOp<string mnemonic, list<Trait> traits = []> :
     Tensor_Op<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
       Pure])>,
-    Results<(outs AnyTensor:$result)> {
+    Results<(outs AnyRankedTensor:$result)> {
 
   code commonExtraClassDeclaration = [{
     static StringRef getReassociationAttrStrName() { return "reassociation"; }

--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -2051,14 +2051,8 @@ static LogicalResult verifyTensorReshapeOp(TensorReshapeOp op,
 }
 
 LogicalResult ExpandShapeOp::verify() {
-  auto srcType = llvm::dyn_cast<RankedTensorType>(getSrc().getType());
-  if (!srcType)
-    return emitOpError("expects ranked tensor source type, but got ")
-           << getSrc().getType();
-  auto resultType = llvm::dyn_cast<RankedTensorType>(getResult().getType());
-  if (!resultType)
-    return emitOpError("expects ranked tensor result type, but got ")
-           << getResult().getType();
+  auto srcType = llvm::cast<RankedTensorType>(getSrc().getType());
+  auto resultType = llvm::cast<RankedTensorType>(getResult().getType());
 
   if ((int64_t)getStaticOutputShape().size() != resultType.getRank())
     return emitOpError("expected number of static shape dims to be equal to "

--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -2077,15 +2077,8 @@ LogicalResult CollapseShapeOp::verify() {
                    [](ReassociationIndices group) { return group.empty(); })) {
     return op.emitOpError("reassociation indices must not be empty");
   }
-  auto srcType = llvm::dyn_cast<RankedTensorType>(op.getSrc().getType());
-  if (!srcType)
-    return op.emitOpError("expects ranked tensor source type, but got ")
-           << op.getSrc().getType();
-
-  auto resultType = llvm::dyn_cast<RankedTensorType>(op.getResult().getType());
-  if (!resultType)
-    return op.emitOpError("expects ranked tensor result type, but got ")
-           << op.getResult().getType();
+  auto srcType = llvm::cast<RankedTensorType>(op.getSrc().getType());
+  auto resultType = llvm::cast<RankedTensorType>(op.getResult().getType());
 
   return verifyTensorReshapeOp(op, srcType, resultType);
 }

--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -2051,8 +2051,8 @@ static LogicalResult verifyTensorReshapeOp(TensorReshapeOp op,
 }
 
 LogicalResult ExpandShapeOp::verify() {
-  auto srcType = llvm::cast<RankedTensorType>(getSrc().getType());
-  auto resultType = llvm::cast<RankedTensorType>(getResult().getType());
+  RankedTensorType srcType = getSrc().getType();
+  RankedTensorType resultType = getResult().getType();
 
   if ((int64_t)getStaticOutputShape().size() != resultType.getRank())
     return emitOpError("expected number of static shape dims to be equal to "
@@ -2077,8 +2077,8 @@ LogicalResult CollapseShapeOp::verify() {
                    [](ReassociationIndices group) { return group.empty(); })) {
     return op.emitOpError("reassociation indices must not be empty");
   }
-  auto srcType = llvm::cast<RankedTensorType>(getSrc().getType());
-  auto resultType = llvm::cast<RankedTensorType>(op.getResult().getType());
+  RankedTensorType srcType = op.getSrc().getType();
+  RankedTensorType resultType = op.getResult().getType();
 
   return verifyTensorReshapeOp(op, srcType, resultType);
 }

--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -2077,7 +2077,7 @@ LogicalResult CollapseShapeOp::verify() {
                    [](ReassociationIndices group) { return group.empty(); })) {
     return op.emitOpError("reassociation indices must not be empty");
   }
-  auto srcType = llvm::cast<RankedTensorType>(op.getSrc().getType());
+  auto srcType = llvm::cast<RankedTensorType>(getSrc().getType());
   auto resultType = llvm::cast<RankedTensorType>(op.getResult().getType());
 
   return verifyTensorReshapeOp(op, srcType, resultType);

--- a/mlir/test/Dialect/Tensor/invalid.mlir
+++ b/mlir/test/Dialect/Tensor/invalid.mlir
@@ -690,3 +690,19 @@ func.func @test_empty_reassociation(%arg0: tensor<1x?xf32>) -> tensor<?x10xf32> 
   return %0 : tensor<?x10xf32>
 }
 
+// -----
+
+func.func @collapse_shape_requires_ranked_tensor(%arg0: tensor<*xf32>) {
+  // expected-error@+1 {{expects ranked tensor source type}}
+  %0 = tensor.collapse_shape %arg0 [[0]] : tensor<*xf32> into tensor<f32>
+  return
+}
+
+// -----
+
+func.func @expand_shape_requires_ranked_tensor(%arg0: tensor<*xf32>) {
+  // expected-error@+1 {{expects ranked tensor source type}}
+  %0 = tensor.expand_shape %arg0 [[0]] output_shape [1] : tensor<*xf32> into tensor<1xf32>
+  return
+}
+

--- a/mlir/test/Dialect/Tensor/invalid.mlir
+++ b/mlir/test/Dialect/Tensor/invalid.mlir
@@ -693,7 +693,7 @@ func.func @test_empty_reassociation(%arg0: tensor<1x?xf32>) -> tensor<?x10xf32> 
 // -----
 
 func.func @collapse_shape_requires_ranked_tensor(%arg0: tensor<*xf32>) {
-  // expected-error@+1 {{expects ranked tensor source type}}
+  // expected-error@+1 {{custom op 'tensor.collapse_shape' invalid kind of type specified: expected builtin.tensor, but found 'tensor<*xf32>'}}
   %0 = tensor.collapse_shape %arg0 [[0]] : tensor<*xf32> into tensor<f32>
   return
 }
@@ -701,7 +701,7 @@ func.func @collapse_shape_requires_ranked_tensor(%arg0: tensor<*xf32>) {
 // -----
 
 func.func @expand_shape_requires_ranked_tensor(%arg0: tensor<*xf32>) {
-  // expected-error@+1 {{expects ranked tensor source type}}
+  // expected-error@+1 {{custom op 'tensor.expand_shape' invalid kind of type specified: expected builtin.tensor, but found 'tensor<*xf32>'}}
   %0 = tensor.expand_shape %arg0 [[0]] output_shape [1] : tensor<*xf32> into tensor<1xf32>
   return
 }


### PR DESCRIPTION
This PR updates tensor.expand_shape and tensor.collapse_shape ODS definitions to require ranked tensor operands/results by switching from AnyTensor to AnyRankedTensor.

Fixes https://github.com/llvm/llvm-project/issues/178228

