### PR TITLE
[mlir][spirv] Fix crash in ArithToSPIRV trunc-i lowering on tensor types

### DIFF
--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -126,11 +126,9 @@ static bool isBoolScalarOrVector(Type type) {
 /// If `excludeBool` is true, i1/bool types are excluded.
 static bool isScalarOrVectorOfScalar(Type type, bool excludeBool = false) {
   auto isScalarOk = [&](Type t) {
-    if (!isa<spirv::ScalarType>(t))
-      return false;
     if (excludeBool && t.isInteger(1))
       return false;
-    return true;
+    return isa<mlir::spirv::ScalarType>(t);
   };
 
   if (isScalarOk(type))

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-unsupported.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-unsupported.mlir
@@ -199,3 +199,19 @@ func.func @type_conversion_failure(%arg0: i32) {
 }
 
 } // end module
+
+// -----
+
+module attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.0, [], []>, #spirv.resource_limits<>>
+} {
+
+// Tensor truncation is not supported; ensure conversion fails gracefully (no crash).
+func.func @unsupported_tensor_trunci(%arg0: tensor<1xi32>) -> tensor<1xi16> {
+// expected-error@+1 {{failed to legalize operation 'arith.trunci'}}
+%t = arith.trunci %arg0 : tensor<1xi32> to tensor<1xi16>
+return %t : tensor<1xi16>
+}
+
+} // end module

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-unsupported.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-unsupported.mlir
@@ -215,3 +215,33 @@ func.func @unsupported_tensor_trunci(%arg0: tensor<1xi32>) -> tensor<1xi16> {
 }
 
 } // end module
+
+// -----
+
+module attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.0, [], []>, #spirv.resource_limits<>>
+} {
+
+  // Tensor extui is not supported; ensure conversion fails (and does not crash).
+  func.func @unsupported_tensor_extui(%arg0: tensor<1xi8>) -> tensor<1xi32> {
+    // expected-error @+1 {{failed to legalize operation 'arith.extui'}}
+    %t = arith.extui %arg0 : tensor<1xi8> to tensor<1xi32>
+    return %t : tensor<1xi32>
+  }
+} // end module
+
+// -----
+
+module attributes {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.0, [], []>, #spirv.resource_limits<>>
+} {
+
+  // Tensor extsi is not supported; ensure conversion fails (and does not crash).
+  func.func @unsupported_tensor_extsi(%arg0: tensor<1xi8>) -> tensor<1xi32> {
+    // expected-error @+1 {{failed to legalize operation 'arith.extsi'}}
+    %t = arith.extsi %arg0 : tensor<1xi8> to tensor<1xi32>
+    return %t : tensor<1xi32>
+  }
+} // end module

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-unsupported.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv-unsupported.mlir
@@ -209,9 +209,9 @@ module attributes {
 
 // Tensor truncation is not supported; ensure conversion fails gracefully (no crash).
 func.func @unsupported_tensor_trunci(%arg0: tensor<1xi32>) -> tensor<1xi16> {
-// expected-error@+1 {{failed to legalize operation 'arith.trunci'}}
-%t = arith.trunci %arg0 : tensor<1xi32> to tensor<1xi16>
-return %t : tensor<1xi16>
+  // expected-error@+1 {{failed to legalize operation 'arith.trunci'}}
+  %t = arith.trunci %arg0 : tensor<1xi32> to tensor<1xi16>
+  return %t : tensor<1xi16>
 }
 
 } // end module


### PR DESCRIPTION
This PR fixes a crash in --convert-arith-to-spirv when lowering arith.trunci with tensor operand/result types (e.g., tensor<1xi32> -> tensor<1xi16>). The conversion patterns for arith.trunci could proceed even when the operand types were not legal SPIR-V value types and attempt to create SPIR-V ops (e.g., spirv.BitwiseAndOp) with unconverted tensor operands, leading to a hard abort during op construction.

The fix adds explicit legality checks in the arith.trunci lowering patterns to ensure only supported scalar/vector integer types are lowered. Unsupported tensor cases now fail legalization cleanly (with an error diagnostic) instead of crashing.

Fixes https://github.com/llvm/llvm-project/issues/178214