### PR TITLE
Rename the IR ops for `StackSaveOp` and `StackRestoreOp`

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3629,17 +3629,17 @@ def CIR_AddrOfReturnAddrOp : CIR_Op<"address_of_return_address"> {
 // StackSaveOp & StackRestoreOp
 //===----------------------------------------------------------------------===//
 
-def CIR_StackSaveOp : CIR_Op<"stacksave"> {
+def CIR_StackSaveOp : CIR_Op<"stack_save"> {
   let summary = "remembers the current state of the function stack";
   let description = [{
     Saves current state of the function stack. Returns a pointer to an opaque object
-    that later can be passed into cir.stackrestore.
+    that later can be passed into cir.stack_restore.
     This is used during the lowering of variable length array allocas.
 
     This operation corresponds to LLVM intrinsic `stacksave`.
 
     ```mlir
-    %0 = cir.stacksave : <!u8i>
+    %0 = cir.stack_save : <!u8i>
     ```
   }];
 
@@ -3647,21 +3647,21 @@ def CIR_StackSaveOp : CIR_Op<"stacksave"> {
   let assemblyFormat = "attr-dict `:` qualified(type($result))";
 }
 
-def CIR_StackRestoreOp : CIR_Op<"stackrestore"> {
+def CIR_StackRestoreOp : CIR_Op<"stack_restore"> {
   let summary = "restores the state of the function stack";
   let description = [{
     Restore the state of the function stack to the state it was
-    in when the corresponding cir.stacksave executed.
+    in when the corresponding cir.stack_save executed.
     This is used during the lowering of variable length array allocas.
 
-    This operation corresponds to LLVM intrinsic `stackrestore`.
+    This operation corresponds to LLVM intrinsic `stack_restore`.
 
     ```mlir
     %0 = cir.alloca !cir.ptr<!u8i>, !cir.ptr<!cir.ptr<!u8i>>, ["saved_stack"] {alignment = 8 : i64}
-    %1 = cir.stacksave : <!u8i>
+    %1 = cir.stack_save : <!u8i>
     cir.store %1, %0 : !cir.ptr<!u8i>, !cir.ptr<!cir.ptr<!u8i>>
     %2 = cir.load %0 : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
-    cir.stackrestore %2 : !cir.ptr<!u8i>
+    cir.stack_restore %2 : !cir.ptr<!u8i>
     ```
   }];
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -193,8 +193,8 @@ public:
   using SymTableTy = llvm::ScopedHashTable<const clang::Decl *, mlir::Value>;
   SymTableTy symbolTable;
 
-  /// Whether a cir.stacksave operation has been added. Used to avoid
-  /// inserting cir.stacksave for multiple VLAs in the same scope.
+  /// Whether a cir.stack_save operation has been added. Used to avoid
+  /// inserting cir.stack_save for multiple VLAs in the same scope.
   bool didCallStackSave = false;
 
   /// Whether or not a Microsoft-style asm block has been processed within

--- a/clang/test/CIR/CodeGen/size-of-vla.cpp
+++ b/clang/test/CIR/CodeGen/size-of-vla.cpp
@@ -68,13 +68,13 @@ void vla_expr_element_type_of_size_1() {
 // CIR: %[[CONST_10:.*]] = cir.const #cir.int<10> : !u64i
 // CIR: cir.store {{.*}} %[[CONST_10]], %[[N_ADDR]] : !u64i, !cir.ptr<!u64i>
 // CIR: %[[TMP_N:.*]] = cir.load {{.*}} %[[N_ADDR]] : !cir.ptr<!u64i>, !u64i
-// CIR: %[[STACK_SAVE:.*]] = cir.stacksave : !cir.ptr<!u8i>
+// CIR: %[[STACK_SAVE:.*]] = cir.stack_save : !cir.ptr<!u8i>
 // CIR: cir.store {{.*}} %[[STACK_SAVE]], %[[SAVED_STACK_ADDR]] : !cir.ptr<!u8i>, !cir.ptr<!cir.ptr<!u8i>>
 // CIR: %[[ARR_ADDR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, %[[TMP_N]] : !u64i, ["arr"]
 // CIR: %[[SIZE_ADDR:.*]] = cir.alloca !u64i, !cir.ptr<!u64i>, ["size", init]
 // CIR: cir.store {{.*}} %[[TMP_N]], %[[SIZE_ADDR]] : !u64i, !cir.ptr<!u64i>
 // CIR: %[[TMP_SAVED_STACK:.*]] = cir.load {{.*}} %[[SAVED_STACK_ADDR]] : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
-// CIR: cir.stackrestore %[[TMP_SAVED_STACK]] : !cir.ptr<!u8i>
+// CIR: cir.stack_restore %[[TMP_SAVED_STACK]] : !cir.ptr<!u8i>
 
 // LLVM: %[[N_ADDR:.*]] = alloca i64, i64 1, align 8
 // LLVM: %[[SAVED_STACK_ADDR:.*]] = alloca ptr, i64 1, align 8
@@ -115,7 +115,7 @@ void vla_expr_element_type_int() {
 // CIR: %[[CONST_10:.*]] = cir.const #cir.int<10> : !u64i
 // CIR: cir.store {{.*}} %[[CONST_10]], %[[N_ADDR]] : !u64i, !cir.ptr<!u64i>
 // CIR: %[[TMP_N:.*]] = cir.load {{.*}} %[[N_ADDR]] : !cir.ptr<!u64i>, !u64i
-// CIR: %[[STACK_SAVE:.*]] = cir.stacksave : !cir.ptr<!u8i>
+// CIR: %[[STACK_SAVE:.*]] = cir.stack_save : !cir.ptr<!u8i>
 // CIR: cir.store {{.*}} %[[STACK_SAVE]], %[[SAVED_STACK_ADDR]] : !cir.ptr<!u8i>, !cir.ptr<!cir.ptr<!u8i>>
 // CIR: %[[ARR_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, %[[TMP_N]] : !u64i, ["arr"]
 // CIR: %[[SIZE_ADDR:.*]] = cir.alloca !u64i, !cir.ptr<!u64i>, ["size", init]
@@ -123,7 +123,7 @@ void vla_expr_element_type_int() {
 // CIR: %[[SIZE:.*]] = cir.binop(mul, %[[CONST_4]], %[[TMP_N]]) nuw : !u64i
 // CIR: cir.store {{.*}} %[[SIZE]], %[[SIZE_ADDR]] : !u64i, !cir.ptr<!u64i>
 // CIR: %[[TMP_SAVED_STACK:.*]] = cir.load {{.*}} %[[SAVED_STACK_ADDR]] : !cir.ptr<!cir.ptr<!u8i>>, !cir.ptr<!u8i>
-// CIR: cir.stackrestore %[[TMP_SAVED_STACK]] : !cir.ptr<!u8i>
+// CIR: cir.stack_restore %[[TMP_SAVED_STACK]] : !cir.ptr<!u8i>
 
 // LLVM: %[[N_ADDR:.*]] = alloca i64, i64 1, align 8
 // LLVM: %[[SAVED_STACK_ADDR:.*]] = alloca ptr, i64 1, align 8

--- a/clang/test/CIR/CodeGen/vla.c
+++ b/clang/test/CIR/CodeGen/vla.c
@@ -15,11 +15,11 @@ void f0(int len) {
 // CIR:   cir.store{{.*}} %[[LEN_ARG]], %[[LEN_ADDR]]
 // CIR:   %[[LEN:.*]] = cir.load{{.*}} %[[LEN_ADDR]]
 // CIR:   %[[LEN_SIZE_T:.*]] = cir.cast integral %[[LEN]] : !s32i -> !u64i
-// CIR:   %[[STACK_PTR:.*]] = cir.stacksave
+// CIR:   %[[STACK_PTR:.*]] = cir.stack_save
 // CIR:   cir.store{{.*}} %[[STACK_PTR]], %[[SAVED_STACK]]
 // CIR:   %[[ARR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, %[[LEN_SIZE_T]] : !u64i, ["arr"]
 // CIR:   %[[STACK_RESTORE_PTR:.*]] = cir.load{{.*}} %[[SAVED_STACK]]
-// CIR:   cir.stackrestore %[[STACK_RESTORE_PTR]]
+// CIR:   cir.stack_restore %[[STACK_RESTORE_PTR]]
 
 // LLVM: define{{.*}} void @f0(i32 %[[LEN_ARG:.*]])
 // LLVM:   %[[LEN_ADDR:.*]] = alloca i32
@@ -60,12 +60,12 @@ void f1(int len) {
 // CIR:   %[[SIXTEEN:.*]] = cir.const #cir.int<16> : !u64i
 // CIR:   %[[LEN:.*]] = cir.load{{.*}} %[[LEN_ADDR]]
 // CIR:   %[[LEN_SIZE_T:.*]] = cir.cast integral %[[LEN]] : !s32i -> !u64i
-// CIR:   %[[STACK_PTR:.*]] = cir.stacksave
+// CIR:   %[[STACK_PTR:.*]] = cir.stack_save
 // CIR:   cir.store{{.*}} %[[STACK_PTR]], %[[SAVED_STACK]]
 // CIR:   %[[TOTAL_LEN:.*]] = cir.binop(mul, %[[SIXTEEN]], %[[LEN_SIZE_T]]) nuw
 // CIR:   %[[ARR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, %[[TOTAL_LEN]] : !u64i, ["arr"]
 // CIR:   %[[STACK_RESTORE_PTR:.*]] = cir.load{{.*}} %[[SAVED_STACK]]
-// CIR:   cir.stackrestore %[[STACK_RESTORE_PTR]]
+// CIR:   cir.stack_restore %[[STACK_RESTORE_PTR]]
 
 // LLVM: define{{.*}} void @f1(i32 %[[LEN_ARG:.*]])
 // LLVM:   %[[LEN_ADDR:.*]] = alloca i32
@@ -109,11 +109,11 @@ void f2(int len) {
 // CIR:   %[[FOUR:.*]] = cir.const #cir.int<4> : !s32i
 // CIR:   %[[TOTAL_LEN:.*]] = cir.binop(add, %[[LEN]], %[[FOUR]]) nsw : !s32i
 // CIR:   %[[TOTAL_LEN_SIZE_T:.*]] = cir.cast integral %[[TOTAL_LEN]] : !s32i -> !u64i
-// CIR:   %[[STACK_PTR:.*]] = cir.stacksave
+// CIR:   %[[STACK_PTR:.*]] = cir.stack_save
 // CIR:   cir.store{{.*}} %[[STACK_PTR]], %[[SAVED_STACK]]
 // CIR:   %[[ARR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, %[[TOTAL_LEN_SIZE_T]] : !u64i, ["arr"]
 // CIR:   %[[STACK_RESTORE_PTR:.*]] = cir.load{{.*}} %[[SAVED_STACK]]
-// CIR:   cir.stackrestore %[[STACK_RESTORE_PTR]]
+// CIR:   cir.stack_restore %[[STACK_RESTORE_PTR]]
   
 // LLVM: define{{.*}} void @f2(i32 %[[LEN_ARG:.*]])
 // LLVM:   %[[LEN_ADDR:.*]] = alloca i32
@@ -159,7 +159,7 @@ void f3(unsigned len) {
 // CIR:   cir.store{{.*}} %[[LEN_ARG]], %[[LEN_ADDR]]
 // CIR:   %[[LEN:.*]] = cir.load{{.*}} %[[LEN_ADDR]]
 // CIR:   %[[LEN_SIZE_T:.*]] = cir.cast integral %[[LEN]] : !u32i -> !u64i
-// CIR:   %[[STACK_PTR:.*]] = cir.stacksave
+// CIR:   %[[STACK_PTR:.*]] = cir.stack_save
 // CIR:   cir.store{{.*}} %[[STACK_PTR]], %[[SAVED_STACK]]
 // CIR:   %[[S1:.*]] = cir.alloca !s8i, !cir.ptr<!s8i>, %[[LEN_SIZE_T]] : !u64i, ["s1"]
 // CIR:   %[[I:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["i", init]
@@ -178,17 +178,17 @@ void f3(unsigned len) {
 // CIR:         %[[SAVED_STACK2:.*]] = cir.alloca !cir.ptr<!u8i>, !cir.ptr<!cir.ptr<!u8i>>, ["saved_stack"]
 // CIR:         %[[I_LEN:.*]] = cir.load{{.*}} %[[I]]
 // CIR:         %[[I_LEN_SIZE_T2:.*]] = cir.cast integral %[[I_LEN]] : !u32i -> !u64i
-// CIR:         %[[STACK_PTR2:.*]] = cir.stacksave
+// CIR:         %[[STACK_PTR2:.*]] = cir.stack_save
 // CIR:         cir.store{{.*}} %[[STACK_PTR2]], %[[SAVED_STACK2]]
 // CIR:         %[[S2:.*]] = cir.alloca !s8i, !cir.ptr<!s8i>, %[[I_LEN_SIZE_T2]] : !u64i, ["s2"]
 // CIR:         %[[SAVED_RESTORE_PTR2:.*]] = cir.load{{.*}} %[[SAVED_STACK2]]
-// CIR:         cir.stackrestore %[[SAVED_RESTORE_PTR2]]
+// CIR:         cir.stack_restore %[[SAVED_RESTORE_PTR2]]
 // CIR:       }
 // CIR:       cir.yield
 // CIR:     }
 // CIR:   }
 // CIR:   %[[STACK_RESTORE_PTR:.*]] = cir.load{{.*}} %[[SAVED_STACK]]
-// CIR:   cir.stackrestore %[[STACK_RESTORE_PTR]]
+// CIR:   cir.stack_restore %[[STACK_RESTORE_PTR]]
 
 // LLVM: define{{.*}} void @f3(i32 %[[LEN_ARG:.*]])
 // LLVM:   %[[SAVED_STACK2:.*]] = alloca ptr
@@ -293,7 +293,7 @@ int f5(unsigned long len) {
 // CIR:   %[[SAVED_STACK:.*]] = cir.alloca !cir.ptr<!u8i>, !cir.ptr<!cir.ptr<!u8i>>, ["saved_stack"]
 // CIR:   cir.store{{.*}} %[[LEN_ARG]], %[[LEN_ADDR]]
 // CIR:   %[[LEN:.*]] = cir.load{{.*}} %[[LEN_ADDR]]
-// CIR:   %[[STACK_PTR:.*]] = cir.stacksave
+// CIR:   %[[STACK_PTR:.*]] = cir.stack_save
 // CIR:   cir.store{{.*}} %[[STACK_PTR]], %[[SAVED_STACK]]
 // CIR:   %[[ARR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, %[[LEN]] : !u64i, ["arr"]
 // CIR:   %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
@@ -301,7 +301,7 @@ int f5(unsigned long len) {
 // CIR:   %[[ARR_VAL:.*]] = cir.load{{.*}} %[[ARR_2]] : !cir.ptr<!s32i>, !s32i
 // CIR:   cir.store{{.*}} %[[ARR_VAL]], %[[RET_ADDR]] : !s32i, !cir.ptr<!s32i>
 // CIR:   %[[STACK_RESTORE_PTR:.*]] = cir.load{{.*}} %[[SAVED_STACK]]
-// CIR:   cir.stackrestore %[[STACK_RESTORE_PTR]]
+// CIR:   cir.stack_restore %[[STACK_RESTORE_PTR]]
 // CIR:   %[[RET_VAL:.*]] = cir.load{{.*}} %[[RET_ADDR]]
 // CIR:   cir.return %[[RET_VAL]] : !s32i
 

--- a/clang/test/CIR/IR/stack-save-restore.cir
+++ b/clang/test/CIR/IR/stack-save-restore.cir
@@ -6,8 +6,8 @@
 
 module  {
   cir.func @stack_save_restore() {
-    %0 = cir.stacksave : !cir.ptr<!u8i>
-    cir.stackrestore %0 : !cir.ptr<!u8i>
+    %0 = cir.stack_save : !cir.ptr<!u8i>
+    cir.stack_restore %0 : !cir.ptr<!u8i>
     cir.return
   }
 }
@@ -15,8 +15,8 @@ module  {
 //CHECK: module  {
 
 //CHECK-NEXT: cir.func @stack_save_restore() {
-//CHECK-NEXT:   %0 = cir.stacksave : !cir.ptr<!u8i>
-//CHECK-NEXT:   cir.stackrestore %0 : !cir.ptr<!u8i>
+//CHECK-NEXT:   %0 = cir.stack_save : !cir.ptr<!u8i>
+//CHECK-NEXT:   cir.stack_restore %0 : !cir.ptr<!u8i>
 //CHECK-NEXT:   cir.return
 //CHECK-NEXT: }
 

--- a/clang/test/CIR/Lowering/stack-save-restore.cir
+++ b/clang/test/CIR/Lowering/stack-save-restore.cir
@@ -5,8 +5,8 @@
 
 module  {
   cir.func @stack_save() {
-    %0 = cir.stacksave : !cir.ptr<!u8i>
-    cir.stackrestore %0 : !cir.ptr<!u8i>
+    %0 = cir.stack_save : !cir.ptr<!u8i>
+    cir.stack_restore %0 : !cir.ptr<!u8i>
     cir.return
   }
 }


### PR DESCRIPTION
Renamed the IR ops for `StackSaveOp` and `StackRestoreOp` to match docs, i.e., from `cir.stacksave` to `cir.stack_save`.