### PR TITLE
[libc][test] Fix TmMatcher and correct tm_yday/tm_wday test values

### DIFF
--- a/libc/test/src/time/TmMatcher.h
+++ b/libc/test/src/time/TmMatcher.h
@@ -25,14 +25,14 @@ public:
 
   bool match(::tm actualValue) {
     actual = actualValue;
-    return (actual.tm_sec == expected.tm_sec ||
-            actual.tm_min == expected.tm_min ||
-            actual.tm_hour == expected.tm_hour ||
-            actual.tm_mday == expected.tm_mday ||
-            actual.tm_mon == expected.tm_mon ||
-            actual.tm_year == expected.tm_year ||
-            actual.tm_wday == expected.tm_wday ||
-            actual.tm_yday == expected.tm_yday ||
+    return (actual.tm_sec == expected.tm_sec &&
+            actual.tm_min == expected.tm_min &&
+            actual.tm_hour == expected.tm_hour &&
+            actual.tm_mday == expected.tm_mday &&
+            actual.tm_mon == expected.tm_mon &&
+            actual.tm_year == expected.tm_year &&
+            actual.tm_wday == expected.tm_wday &&
+            actual.tm_yday == expected.tm_yday &&
             actual.tm_isdst == expected.tm_isdst);
   }
 

--- a/libc/test/src/time/gmtime_r_test.cpp
+++ b/libc/test/src/time/gmtime_r_test.cpp
@@ -31,7 +31,7 @@ TEST_F(LlvmLibcGmTimeR, EndOf32BitEpochYear) {
           0,  // tm_mon starts with 0 for Jan
           2038 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           2,                                                     // wday
-          7,                                                     // yday
+          18,                                                    // yday
           0}),
       *tm_data_ptr);
   EXPECT_TM_EQ(*tm_data_ptr, tm_data);
@@ -53,7 +53,7 @@ TEST_F(LlvmLibcGmTimeR, Max64BitYear) {
           0,  // tm_mon starts with 0 for Jan
           2147483647 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           2,                                                           // wday
-          50,                                                          // yday
+          0,                                                           // yday
           0}),
       *tm_data_ptr);
   EXPECT_TM_EQ(*tm_data_ptr, tm_data);

--- a/libc/test/src/time/gmtime_test.cpp
+++ b/libc/test/src/time/gmtime_test.cpp
@@ -86,7 +86,7 @@ TEST_F(LlvmLibcGmTime, InvalidMinutes) {
           11, // tm_mon starts with 0 for Jan
           1969 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           3,                                                     // wday
-          0,                                                     // yday
+          364,                                                   // yday
           0}),
       *tm_data);
   // 60 minutes from 1970-01-01 00:00:00 returns 1970-01-01 01:00:00.
@@ -119,7 +119,7 @@ TEST_F(LlvmLibcGmTime, InvalidHours) {
           11, // tm_mon starts with 0 for Jan
           1969 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           3,                                                     // wday
-          0,                                                     // yday
+          364,                                                   // yday
           0}),
       *tm_data);
   // 24 hours from 1970-01-01 00:00:00 returns 1970-01-02 00:00:00.
@@ -133,7 +133,7 @@ TEST_F(LlvmLibcGmTime, InvalidHours) {
           0, // tm_mon starts with 0 for Jan
           1970 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           5,                                                     // wday
-          0,                                                     // yday
+          1,                                                     // yday
           0}),
       *tm_data);
 }
@@ -170,7 +170,7 @@ TEST_F(LlvmLibcGmTime, InvalidMonths) {
           12 - 1, // tm_mon starts with 0 for Jan
           1969 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           1,                                                     // wday
-          0,                                                     // yday
+          334,                                                   // yday
           0}),
       *tm_data);
   // 1970-13-01 00:00:00 returns 1971-01-01 00:00:00.
@@ -204,7 +204,7 @@ TEST_F(LlvmLibcGmTime, InvalidDays) {
           11, // tm_mon starts with 0 for Jan
           1969 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           3,                                                     // wday
-          0,                                                     // yday
+          364,                                                   // yday
           0}),
       *tm_data);
 
@@ -216,10 +216,10 @@ TEST_F(LlvmLibcGmTime, InvalidDays) {
           0, // min
           0, // hr
           1, // day
-          0, // tm_mon starts with 0 for Jan
+          1, // tm_mon starts with 0 for Jan
           1970 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           0,                                                     // wday
-          0,                                                     // yday
+          31,                                                    // yday
           0}),
       *tm_data);
 
@@ -234,7 +234,7 @@ TEST_F(LlvmLibcGmTime, InvalidDays) {
           2, // tm_mon starts with 0 for Jan
           1970 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           0,                                                     // wday
-          0,                                                     // yday
+          59,                                                    // yday
           0}),
       *tm_data);
 
@@ -251,7 +251,7 @@ TEST_F(LlvmLibcGmTime, InvalidDays) {
           2, // tm_mon starts with 0 for Jan
           1972 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           3,                                                     // wday
-          0,                                                     // yday
+          60,                                                    // yday
           0}),
       *tm_data);
 }
@@ -269,7 +269,7 @@ TEST_F(LlvmLibcGmTime, EndOf32BitEpochYear) {
           0,  // tm_mon starts with 0 for Jan
           2038 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           2,                                                     // wday
-          7,                                                     // yday
+          18,                                                    // yday
           0}),
       *tm_data);
 }
@@ -288,7 +288,7 @@ TEST_F(LlvmLibcGmTime, Max64BitYear) {
           0,  // tm_mon starts with 0 for Jan
           2170 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           1,                                                     // wday
-          50,                                                    // yday
+          0,                                                     // yday
           0}),
       *tm_data);
 
@@ -303,7 +303,7 @@ TEST_F(LlvmLibcGmTime, Max64BitYear) {
           0,  // tm_mon starts with 0 for Jan
           2147483647 - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE, // year
           2,                                                           // wday
-          50,                                                          // yday
+          0,                                                           // yday
           0}),
       *tm_data);
 }

--- a/libc/test/src/time/mktime_test.cpp
+++ b/libc/test/src/time/mktime_test.cpp
@@ -110,7 +110,7 @@ TEST(LlvmLibcMkTime, InvalidMinutes) {
                      .tm_mon = Month::DECEMBER,
                      .tm_year = tm_year(1969),
                      .tm_wday = 3,
-                     .tm_yday = 0,
+                     .tm_yday = 364,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -162,7 +162,7 @@ TEST(LlvmLibcMkTime, InvalidHours) {
                      .tm_mon = Month::DECEMBER,
                      .tm_year = tm_year(1969),
                      .tm_wday = 3,
-                     .tm_yday = 0,
+                     .tm_yday = 364,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -188,7 +188,7 @@ TEST(LlvmLibcMkTime, InvalidHours) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(1970),
                      .tm_wday = 5,
-                     .tm_yday = 0,
+                     .tm_yday = 1,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -326,11 +326,11 @@ TEST(LlvmLibcMkTime, InvalidMonths) {
     EXPECT_TM_EQ((tm{.tm_sec = 0,
                      .tm_min = 0,
                      .tm_hour = 0,
-                     .tm_mday = 1,
-                     .tm_mon = Month::DECEMBER,
+                     .tm_mday = 30,
+                     .tm_mon = Month::NOVEMBER,
                      .tm_year = tm_year(1969),
-                     .tm_wday = 1,
-                     .tm_yday = 0,
+                     .tm_wday = 0,
+                     .tm_yday = 333,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -384,7 +384,7 @@ TEST(LlvmLibcMkTime, InvalidDays) {
                      .tm_mon = Month::DECEMBER,
                      .tm_year = tm_year(1969),
                      .tm_wday = 3,
-                     .tm_yday = 0,
+                     .tm_yday = 364,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -409,7 +409,7 @@ TEST(LlvmLibcMkTime, InvalidDays) {
                      .tm_mon = Month::FEBRUARY,
                      .tm_year = tm_year(1970),
                      .tm_wday = 0,
-                     .tm_yday = 0,
+                     .tm_yday = 31,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -434,7 +434,7 @@ TEST(LlvmLibcMkTime, InvalidDays) {
                      .tm_mon = Month::MARCH,
                      .tm_year = tm_year(1970),
                      .tm_wday = 0,
-                     .tm_yday = 0,
+                     .tm_yday = 59,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -462,7 +462,7 @@ TEST(LlvmLibcMkTime, InvalidDays) {
                      .tm_mon = Month::MARCH,
                      .tm_year = tm_year(1972),
                      .tm_wday = 3,
-                     .tm_yday = 0,
+                     .tm_yday = 60,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -489,7 +489,7 @@ TEST(LlvmLibcMkTime, EndOf32BitEpochYear) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(2038),
                      .tm_wday = 2,
-                     .tm_yday = 7,
+                     .tm_yday = 18,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -515,7 +515,7 @@ TEST(LlvmLibcMkTime, EndOf32BitEpochYear) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(2038),
                      .tm_wday = 2,
-                     .tm_yday = 7,
+                     .tm_yday = 18,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -542,7 +542,7 @@ TEST(LlvmLibcMkTime, EndOf32BitEpochYear) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(2038),
                      .tm_wday = 2,
-                     .tm_yday = 7,
+                     .tm_yday = 18,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -569,8 +569,8 @@ TEST(LlvmLibcMkTime, EndOf32BitEpochYear) {
                      .tm_mday = 18,
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(2038),
-                     .tm_wday = 2,
-                     .tm_yday = 7,
+                     .tm_wday = 1,
+                     .tm_yday = 17,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -598,8 +598,8 @@ TEST(LlvmLibcMkTime, EndOf32BitEpochYear) {
                      .tm_mday = 31,
                      .tm_mon = Month::DECEMBER,
                      .tm_year = tm_year(2037),
-                     .tm_wday = 2,
-                     .tm_yday = 7,
+                     .tm_wday = 4,
+                     .tm_yday = 364,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -627,7 +627,7 @@ TEST(LlvmLibcMkTime, Max64BitYear) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(2170),
                      .tm_wday = 1,
-                     .tm_yday = 50,
+                     .tm_yday = 0,
                      .tm_isdst = 0}),
                  tm_data);
   }
@@ -651,7 +651,7 @@ TEST(LlvmLibcMkTime, Max64BitYear) {
                      .tm_mon = Month::JANUARY,
                      .tm_year = tm_year(2147483647),
                      .tm_wday = 2,
-                     .tm_yday = 50,
+                     .tm_yday = 0,
                      .tm_isdst = 0}),
                  tm_data);
   }


### PR DESCRIPTION
The TmMatcher was using || instead of && to compare tm struct fields, causing it to match if ANY field was equal rather than ALL fields. This masked incorrect expected values in the time tests.

Happily, only the tests needed fixing.  The code was correct.

Fixed the matcher and corrected all tm_yday and tm_wday values to match glibc's gmtime_r output.