### PR TITLE
[ABITest] Use _Alignof instead of __alignof__ for ABI alignment

### DIFF
--- a/clang/utils/ABITest/ABITestGen.py
+++ b/clang/utils/ABITest/ABITestGen.py
@@ -306,7 +306,7 @@ class TypePrinter(object):
 
     def printAlignOfType(self, prefix, name, t, output=None, indent=2):
         print(
-            '%*sprintf("%s: __alignof__(%s) = %%ld\\n", (long)__alignof__(%s));'
+            '%*sprintf("%s: _Alignof(%s) = %%ld\\n", (long)_Alignof(%s));'
             % (indent, "", prefix, name, name),
             file=output,
         )


### PR DESCRIPTION
`__alignof__` returns the "preferred" alignment, which can differ from the actual ABI required alignment on some architectures. This can give misleading results in the generated layout tests when testing ABI compatibility.

Use `_Alignof` (C11 standard keyword) instead, which returns the actual ABI required alignment.

Fixes #179007.