### PR TITLE
[ELF] Fix non-preemptible IFUNC IRELATIVE addends

### DIFF
--- a/lld/test/ELF/riscv-ifunc-nonpreemptible-relax.s
+++ b/lld/test/ELF/riscv-ifunc-nonpreemptible-relax.s
@@ -1,0 +1,27 @@
+# REQUIRES: riscv
+# RUN: llvm-mc -filetype=obj -triple=riscv64 %s -o %t.o
+# RUN: ld.lld -pie --relax %t.o -o %t
+# RUN: llvm-readelf -s -r %t | FileCheck %s
+# CHECK: Relocation section '.rela.dyn'
+# CHECK: R_RISCV_IRELATIVE {{ *}}[[IFUNC:[0-9A-Fa-f]+]]
+# CHECK: Symbol table '.symtab'
+# CHECK: {{0*}}[[IFUNC]] {{.*}} IFUNC {{.*}} ifunc
+
+.text
+.option relax
+.globl _start
+
+_start:
+  call target
+  # GOT-only reference to IFUNC (no direct relocations)
+.Lgot:
+  auipc t0, %got_pcrel_hi(ifunc)
+  ld t1, %pcrel_lo(.Lgot)(t0)
+  ret
+.globl target
+target:
+  ret
+.globl ifunc
+.type ifunc, @gnu_indirect_function
+ifunc:
+  ret


### PR DESCRIPTION
## Summary
- Fix non-preemptible IFUNC IRELATIVE addends to use resolver symbol unless direct relocations require canonicalization
- Prevent ld.so crashes in glibc on RISC-V

## Evidence

### Before the fix

```
readelf -rW ~/build/glibc-main/libc.so.6 | rg R_RISCV_IRELATIVE
000000000013d960  000000000000003a R_RISCV_IRELATIVE                         c62ac
000000000013d968  000000000000003a R_RISCV_IRELATIVE                         c591a

readelf -sW ~/build/glibc-main/libc.so.6 | rg "__libc_memcpy_ifunc|__libc_memset_ifunc"
 11660: 00000000000c0c00     4 FUNC    LOCAL  DEFAULT   47 __libc_memcpy_ifunc
 11746: 00000000000c1558     4 FUNC    LOCAL  DEFAULT   47 __libc_memset_ifunc
```

These addends don't match the resolver symbols, leading to a crash in glibc ld.so when resolving symbols.

### After the fix

```
readelf -rW ~/build/glibc-after/libc.so.6 | rg R_RISCV_IRELATIVE
000000000013d960  000000000000003a R_RISCV_IRELATIVE                         c1558
000000000013d968  000000000000003a R_RISCV_IRELATIVE                         c0c00

readelf -sW ~/build/glibc-after/libc.so.6 | rg "__libc_memcpy_ifunc|__libc_memset_ifunc"
 11660: 00000000000c0c00     4 FUNC    LOCAL  DEFAULT   47 __libc_memcpy_ifunc
 11746: 00000000000c1558     4 FUNC    LOCAL  DEFAULT   47 __libc_memset_ifunc
```

These addends match the resolver symbols:
- `__libc_memset_ifunc` at `0xc1558`
- `__libc_memcpy_ifunc` at `0xc0c00`

## Testing

### glibc relink + readelf verification
As shown above.

### `ninja check-lld` 
```
Total Discovered Tests: 3177
  Unsupported      :   20 (0.63%)
  Passed           : 3156 (99.34%)
  Expectedly Failed:    1 (0.03%)
```