### PR TITLE
[clang][bytecode] Add a path to MemberPointers

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -269,34 +269,61 @@ bool Compiler<Emitter>::VisitCastExpr(const CastExpr *CE) {
   }
 
   case CK_DerivedToBaseMemberPointer: {
-    assert(classifyPrim(CE->getType()) == PT_MemberPtr);
-    assert(classifyPrim(SubExpr->getType()) == PT_MemberPtr);
-    const auto *FromMP = SubExpr->getType()->castAs<MemberPointerType>();
-    const auto *ToMP = CE->getType()->castAs<MemberPointerType>();
-
-    unsigned DerivedOffset =
-        Ctx.collectBaseOffset(ToMP->getMostRecentCXXRecordDecl(),
-                              FromMP->getMostRecentCXXRecordDecl());
+    assert(classifyPrim(CE) == PT_MemberPtr);
+    assert(classifyPrim(SubExpr) == PT_MemberPtr);
 
     if (!this->delegate(SubExpr))
       return false;
 
-    return this->emitGetMemberPtrBasePop(DerivedOffset, CE);
+    const CXXRecordDecl *CurDecl = SubExpr->getType()
+                                       ->castAs<MemberPointerType>()
+                                       ->getMostRecentCXXRecordDecl();
+    for (const CXXBaseSpecifier *B : CE->path()) {
+      const CXXRecordDecl *ToDecl = B->getType()->getAsCXXRecordDecl();
+      unsigned DerivedOffset = Ctx.collectBaseOffset(ToDecl, CurDecl);
+
+      if (!this->emitCastMemberPtrBasePop(DerivedOffset, ToDecl, CE))
+        return false;
+      CurDecl = ToDecl;
+    }
+
+    return true;
   }
 
   case CK_BaseToDerivedMemberPointer: {
     assert(classifyPrim(CE) == PT_MemberPtr);
     assert(classifyPrim(SubExpr) == PT_MemberPtr);
-    const auto *FromMP = SubExpr->getType()->castAs<MemberPointerType>();
-    const auto *ToMP = CE->getType()->castAs<MemberPointerType>();
-
-    unsigned DerivedOffset =
-        Ctx.collectBaseOffset(FromMP->getMostRecentCXXRecordDecl(),
-                              ToMP->getMostRecentCXXRecordDecl());
 
     if (!this->delegate(SubExpr))
       return false;
-    return this->emitGetMemberPtrBasePop(-DerivedOffset, CE);
+
+    const CXXRecordDecl *CurDecl = SubExpr->getType()
+                                       ->castAs<MemberPointerType>()
+                                       ->getMostRecentCXXRecordDecl();
+    // Base-to-derived member pointer casts store the path in derived-to-base
+    // order, so iterate backwards. The CXXBaseSpecifier also provides us with
+    // the wrong end of the derived->base arc, so stagger the path by one class.
+    typedef std::reverse_iterator<CastExpr::path_const_iterator> ReverseIter;
+    for (ReverseIter PathI(CE->path_end() - 1), PathE(CE->path_begin());
+         PathI != PathE; ++PathI) {
+      const CXXRecordDecl *ToDecl = (*PathI)->getType()->getAsCXXRecordDecl();
+      unsigned DerivedOffset = Ctx.collectBaseOffset(CurDecl, ToDecl);
+
+      if (!this->emitCastMemberPtrDerivedPop(-DerivedOffset, ToDecl, CE))
+        return false;
+      CurDecl = ToDecl;
+    }
+
+    const CXXRecordDecl *ToDecl = CE->getType()
+                                      ->castAs<MemberPointerType>()
+                                      ->getMostRecentCXXRecordDecl();
+    assert(ToDecl != CurDecl);
+    unsigned DerivedOffset = Ctx.collectBaseOffset(CurDecl, ToDecl);
+
+    if (!this->emitCastMemberPtrDerivedPop(-DerivedOffset, ToDecl, CE))
+      return false;
+
+    return true;
   }
 
   case CK_UncheckedDerivedToBase:
@@ -7624,7 +7651,6 @@ bool Compiler<Emitter>::emitDestructionPop(const Descriptor *Desc,
 template <class Emitter>
 bool Compiler<Emitter>::emitDummyPtr(const DeclTy &D, const Expr *E) {
   assert(!DiscardResult && "Should've been checked before");
-
   unsigned DummyID = P.getOrCreateDummy(D);
 
   if (!this->emitGetPtrGlobal(DummyID, E))

--- a/clang/lib/AST/ByteCode/InterpState.h
+++ b/clang/lib/AST/ByteCode/InterpState.h
@@ -118,6 +118,10 @@ public:
     // std::memset(Mem, 0, NumWords * sizeof(uint64_t)); // Debug
     return Floating(Mem, llvm::APFloatBase::SemanticsToEnum(Sem));
   }
+  const CXXRecordDecl **allocMemberPointerPath(unsigned Length) {
+    return reinterpret_cast<const CXXRecordDecl **>(
+        this->allocate(Length * sizeof(CXXRecordDecl *)));
+  }
 
   /// Note that a step has been executed. If there are no more steps remaining,
   /// diagnoses and returns \c false.

--- a/clang/lib/AST/ByteCode/MemberPointer.cpp
+++ b/clang/lib/AST/ByteCode/MemberPointer.cpp
@@ -16,9 +16,9 @@ namespace clang {
 namespace interp {
 
 std::optional<Pointer> MemberPointer::toPointer(const Context &Ctx) const {
-  if (!Dcl || isa<FunctionDecl>(Dcl))
+  if (!getDecl() || isa<FunctionDecl>(getDecl()))
     return Base;
-  assert((isa<FieldDecl, IndirectFieldDecl>(Dcl)));
+  assert((isa<FieldDecl, IndirectFieldDecl>(getDecl())));
 
   if (!Base.isBlockPointer())
     return std::nullopt;
@@ -42,7 +42,7 @@ std::optional<Pointer> MemberPointer::toPointer(const Context &Ctx) const {
   unsigned Offset = 0;
   Offset += BlockMDSize;
 
-  if (const auto *FD = dyn_cast<FieldDecl>(Dcl)) {
+  if (const auto *FD = dyn_cast<FieldDecl>(getDecl())) {
     if (FD->getParent() == BaseRecord->getDecl())
       return CastedBase.atField(BaseRecord->getField(FD)->Offset);
 
@@ -58,7 +58,7 @@ std::optional<Pointer> MemberPointer::toPointer(const Context &Ctx) const {
       Offset += Ctx.collectBaseOffset(FieldParent, BaseDecl);
 
   } else {
-    const auto *IFD = cast<IndirectFieldDecl>(Dcl);
+    const auto *IFD = cast<IndirectFieldDecl>(getDecl());
 
     for (const NamedDecl *ND : IFD->chain()) {
       const FieldDecl *F = cast<FieldDecl>(ND);
@@ -77,7 +77,8 @@ std::optional<Pointer> MemberPointer::toPointer(const Context &Ctx) const {
 }
 
 FunctionPointer MemberPointer::toFunctionPointer(const Context &Ctx) const {
-  return FunctionPointer(Ctx.getProgram().getFunction(cast<FunctionDecl>(Dcl)));
+  return FunctionPointer(
+      Ctx.getProgram().getFunction(cast<FunctionDecl>(getDecl())));
 }
 
 APValue MemberPointer::toAPValue(const ASTContext &ASTCtx) const {
@@ -88,8 +89,8 @@ APValue MemberPointer::toAPValue(const ASTContext &ASTCtx) const {
   if (hasBase())
     return Base.toAPValue(ASTCtx);
 
-  return APValue(getDecl(), /*IsDerivedMember=*/false,
-                 /*Path=*/{});
+  return APValue(getDecl(), /*IsDerivedMember=*/isDerivedMember(),
+                 /*Path=*/ArrayRef(Path, PathLength));
 }
 
 } // namespace interp

--- a/clang/lib/AST/ByteCode/MemberPointer.cpp
+++ b/clang/lib/AST/ByteCode/MemberPointer.cpp
@@ -93,5 +93,21 @@ APValue MemberPointer::toAPValue(const ASTContext &ASTCtx) const {
                  /*Path=*/ArrayRef(Path, PathLength));
 }
 
+ComparisonCategoryResult
+MemberPointer::compare(const MemberPointer &RHS) const {
+  if (this->getDecl() == RHS.getDecl()) {
+
+    if (this->PathLength != RHS.PathLength)
+      return ComparisonCategoryResult::Unordered;
+
+    if (PathLength != 0 &&
+        std::memcmp(Path, RHS.Path, PathLength * sizeof(CXXRecordDecl *)) != 0)
+      return ComparisonCategoryResult::Unordered;
+
+    return ComparisonCategoryResult::Equal;
+  }
+  return ComparisonCategoryResult::Unordered;
+}
+
 } // namespace interp
 } // namespace clang

--- a/clang/lib/AST/ByteCode/MemberPointer.h
+++ b/clang/lib/AST/ByteCode/MemberPointer.h
@@ -97,6 +97,7 @@ public:
 
   // Pretend we always have a path.
   bool singleWord() const { return false; }
+  ComparisonCategoryResult compare(const MemberPointer &RHS) const;
 
   std::optional<Pointer> toPointer(const Context &Ctx) const;
   FunctionPointer toFunctionPointer(const Context &Ctx) const;
@@ -161,22 +162,6 @@ public:
 
   std::string toDiagnosticString(const ASTContext &Ctx) const {
     return toAPValue(Ctx).getAsString(Ctx, getDecl()->getType());
-  }
-
-  ComparisonCategoryResult compare(const MemberPointer &RHS) const {
-    if (this->getDecl() == RHS.getDecl()) {
-
-      if (this->PathLength != RHS.PathLength)
-        return ComparisonCategoryResult::Unordered;
-
-      if (PathLength != 0 &&
-          std::memcmp(Path, RHS.Path, PathLength * sizeof(CXXRecordDecl *)) !=
-              0)
-        return ComparisonCategoryResult::Unordered;
-
-      return ComparisonCategoryResult::Equal;
-    }
-    return ComparisonCategoryResult::Unordered;
   }
 };
 

--- a/clang/lib/AST/ByteCode/Opcodes.td
+++ b/clang/lib/AST/ByteCode/Opcodes.td
@@ -332,9 +332,13 @@ def GetPtrThisField : OffsetOpcode;
 def GetPtrBase : OffsetOpcode;
 // [Pointer] -> [Pointer]
 def GetPtrBasePop : OffsetOpcode { let Args = [ArgUint32, ArgBool]; }
-def GetMemberPtrBasePop : Opcode {
+def CastMemberPtrBasePop : Opcode {
   // Offset of field, which is a base.
-  let Args = [ArgSint32];
+  let Args = [ArgSint32, ArgRecordDecl];
+}
+def CastMemberPtrDerivedPop : Opcode {
+  // Offset of field, which is a base.
+  let Args = [ArgSint32, ArgRecordDecl];
 }
 
 def FinishInitPop : Opcode;

--- a/clang/lib/AST/ByteCode/PrimType.h
+++ b/clang/lib/AST/ByteCode/PrimType.h
@@ -128,10 +128,11 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
 constexpr bool isIntegralType(PrimType T) { return T <= PT_FixedPoint; }
 template <typename T> constexpr bool needsAlloc() {
   return std::is_same_v<T, IntegralAP<false>> ||
-         std::is_same_v<T, IntegralAP<true>> || std::is_same_v<T, Floating>;
+         std::is_same_v<T, IntegralAP<true>> || std::is_same_v<T, Floating> ||
+         std::is_same_v<T, MemberPointer>;
 }
 constexpr bool needsAlloc(PrimType T) {
-  return T == PT_IntAP || T == PT_IntAPS || T == PT_Float;
+  return T == PT_IntAP || T == PT_IntAPS || T == PT_Float || T == PT_MemberPtr;
 }
 
 /// Mapping from primitive types to their representation.
@@ -272,6 +273,7 @@ static inline bool aligned(const void *P) {
       TYPE_SWITCH_CASE(PT_Float, B)                                            \
       TYPE_SWITCH_CASE(PT_IntAP, B)                                            \
       TYPE_SWITCH_CASE(PT_IntAPS, B)                                           \
+      TYPE_SWITCH_CASE(PT_MemberPtr, B)                                        \
     default:;                                                                  \
     }                                                                          \
   } while (0)

--- a/clang/test/AST/ByteCode/memberpointers.cpp
+++ b/clang/test/AST/ByteCode/memberpointers.cpp
@@ -276,3 +276,30 @@ namespace DiscardedAddrOfOperator {
 
   void baz() { &Foo::bar, Foo(); } // both-warning {{left operand of comma operator has no effect}}
 }
+
+namespace Equality {
+  struct B     { int x; };
+  struct C : B { int z; };
+  static_assert(&C::x == &B::x, "");
+  static_assert(&C::x == &C::x, "");
+
+  constexpr auto A = (int C::*)&B::x;
+  constexpr auto B = (int C::*)&B::x;
+  static_assert(A == B, "");
+
+  struct K {
+    int C::*const M = (int C::*)&B::x;
+  };
+  constexpr K k;
+  static_assert(A== k.M, "");
+
+  constexpr int C::*const MPA[] = {&B::x, &C::x};
+  static_assert(MPA[1] == A, "");
+
+  template<int n> struct T : T<n-1> { const int X = n;};
+  template<> struct T<0> { int n; char k;};
+  template<> struct T<30> : T<29> { int m; };
+
+  constexpr int (T<17>::*deepm) = (int(T<10>::*))&T<30>::m;
+  static_assert(deepm == &T<50>::m, "");
+}


### PR DESCRIPTION
Add a path and an `IsDerivedMember` member to our `MemberPointer` class. Fix base-to-derived/derived-to-base casts. Add tests and unit tests, since regular tests allow a lot and we want to check the path size exactly.