### PR TITLE
[mlir][linalg] Fix linalg.select crash with index type operands

### DIFF
--- a/mlir/test/Dialect/Linalg/named-ops.mlir
+++ b/mlir/test/Dialect/Linalg/named-ops.mlir
@@ -2718,6 +2718,19 @@ func.func @select_tensor(%arg0: tensor<4x8x16xi1>, %arg1: tensor<4x8x16xf32>, %a
   return %1 : tensor<4x8x16xf32>
 }
 
+// -----
+
+// GH#179046: Test linalg.select with index type values (condition must be i1).
+// CHECK-LABEL: func @select_index
+func.func @select_index(%arg0: tensor<4x8x16xi1>, %arg1: tensor<4x8x16xindex>, %arg2: tensor<4x8x16xindex>) -> tensor<4x8x16xindex> {
+  %0 = tensor.empty() : tensor<4x8x16xindex>
+  // CHECK: linalg.select
+  // CHECK-SAME: ins(%{{.+}}, %{{.+}}, %{{.+}} : tensor<4x8x16xi1>, tensor<4x8x16xindex>, tensor<4x8x16xindex>)
+  // CHECK-SAME: outs(%{{.+}} : tensor<4x8x16xindex>)
+  %1 = linalg.select ins(%arg0, %arg1, %arg2 : tensor<4x8x16xi1>, tensor<4x8x16xindex>, tensor<4x8x16xindex>) outs(%0: tensor<4x8x16xindex>) -> tensor<4x8x16xindex>
+  return %1 : tensor<4x8x16xindex>
+}
+
 //===----------------------------------------------------------------------===//
 // linalg.pack + linalg.unpack
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary
Fix UNREACHABLE crash in `linalg.select` when using index type operands.

The `buildTernaryFn` function in `RegionBuilderHelper` only validated integer and floating point types, causing an assertion failure when `linalg.select` was used with index type operands.

## Changes
- Add `isIndex()` helper function to check for `IndexType`
- Add `tailIndex` check in `buildTernaryFn` for index type operands
- Add regression test `@select_index` in `named-ops.mlir`

## Test plan
- Added `@select_index` test case that reproduces the crash
- Run: `ninja check-mlir-linalg`

Fixes #179046