### PR TITLE
[clang][dataflow] Fix crash on base-to-derived cast of unmodeled pointer value.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -329,8 +329,7 @@ public:
       if (S->getType()->isPointerType()) {
         auto *PV = Env.get<PointerValue>(*SubExpr);
         if (PV == nullptr)
-          PV = cast<PointerValue>(Env.createValue(S->getType()));
-
+          break;
         Loc = cast<RecordStorageLocation>(&PV->getPointeeLoc());
       } else {
         assert(S->getType()->isRecordType());

--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -328,9 +328,9 @@ public:
       RecordStorageLocation *Loc = nullptr;
       if (S->getType()->isPointerType()) {
         auto *PV = Env.get<PointerValue>(*SubExpr);
-        assert(PV != nullptr);
         if (PV == nullptr)
-          break;
+          PV = cast<PointerValue>(Env.createValue(S->getType()));
+
         Loc = cast<RecordStorageLocation>(&PV->getPointeeLoc());
       } else {
         assert(S->getType()->isRecordType());

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -3786,6 +3786,33 @@ TEST(TransferTest, StaticCastBaseToDerived) {
       });
 }
 
+TEST(TransferTest, StaticCastBaseToDerivedUnknown) {
+  std::string Code = R"(
+    struct Base {};
+    struct Derived: Base {};
+
+    Base *unknown();
+    void target() {
+      Derived *DPtr = static_cast<Derived *>(unknown());
+      // [[p]]
+    }
+  )";
+  runDataflow(
+      Code,
+      [](const llvm::StringMap<DataflowAnalysisState<NoopLattice>> &Results,
+         ASTContext &ASTCtx) {
+        ASSERT_THAT(Results.keys(), UnorderedElementsAre("p"));
+        const Environment &Env = getEnvironmentAtAnnotation(Results, "p");
+
+        const ValueDecl *DPtrDecl = findValueDecl(ASTCtx, "DPtr");
+        ASSERT_THAT(DPtrDecl, NotNull());
+
+        const auto *DPtrVal =
+            dyn_cast_or_null<PointerValue>(Env.getValue(*DPtrDecl));
+        EXPECT_THAT(DPtrVal, NotNull());
+      });
+}
+
 TEST(TransferTest, MultipleConstructionsFromStaticCastsBaseToDerived) {
   std::string Code = R"cc(
  struct Base {};

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -3787,6 +3787,7 @@ TEST(TransferTest, StaticCastBaseToDerived) {
 }
 
 TEST(TransferTest, StaticCastBaseToDerivedUnknown) {
+  // This code used to crash.
   std::string Code = R"(
     struct Base {};
     struct Derived: Base {};


### PR DESCRIPTION
Remove the assertion because null values occur naturally on a regular basis.

Un-crashes the newly added test.