### PR TITLE
[Hexagon] Track type locally in HexagonVectorCombine

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
@@ -2239,13 +2239,13 @@ Value *HvxIdioms::processVScatter(Instruction &In) const {
   Value *CastIndex = nullptr;
   if (cstDataVector) {
     // Our indexes are represented as a constant. We need it in a reg.
-    AllocaInst *IndexesAlloca =
-        Builder.CreateAlloca(HVC.getHvxTy(HVC.getIntTy(32), false));
+    Type *IndexVectorType = HVC.getHvxTy(HVC.getIntTy(32), false);
+    AllocaInst *IndexesAlloca = Builder.CreateAlloca(IndexVectorType);
     [[maybe_unused]] auto *StoreIndexes =
         Builder.CreateStore(cstDataVector, IndexesAlloca);
     LLVM_DEBUG(dbgs() << "  StoreIndexes     : " << *StoreIndexes << "\n");
-    CastIndex = Builder.CreateLoad(IndexesAlloca->getAllocatedType(),
-                                   IndexesAlloca, "reload_index");
+    CastIndex =
+        Builder.CreateLoad(IndexVectorType, IndexesAlloca, "reload_index");
   } else {
     if (ElemWidth == 2)
       CastIndex = getReinterpretiveCast_i16_to_i32(HVC, Builder, Ctx, Indexes);
@@ -2622,8 +2622,8 @@ Value *HvxIdioms::processVGather(Instruction &In) const {
         [[maybe_unused]] auto *StoreIndexes =
             Builder.CreateStore(cstDataVector, IndexesAlloca);
         LLVM_DEBUG(dbgs() << "  StoreIndexes   : " << *StoreIndexes << "\n");
-        Value *LoadedIndex = Builder.CreateLoad(
-            IndexesAlloca->getAllocatedType(), IndexesAlloca, "reload_index");
+        Value *LoadedIndex =
+            Builder.CreateLoad(NT, IndexesAlloca, "reload_index");
         AllocaInst *ResultAlloca = Builder.CreateAlloca(NT);
         LLVM_DEBUG(dbgs() << "  ResultAlloca   : " << *ResultAlloca << "\n");
 
@@ -2703,8 +2703,8 @@ Value *HvxIdioms::processVGather(Instruction &In) const {
         [[maybe_unused]] auto *StoreIndexes =
             Builder.CreateStore(cstDataVector, IndexesAlloca);
         LLVM_DEBUG(dbgs() << "  StoreIndexes   : " << *StoreIndexes << "\n");
-        Value *LoadedIndex = Builder.CreateLoad(
-            IndexesAlloca->getAllocatedType(), IndexesAlloca, "reload_index");
+        Value *LoadedIndex =
+            Builder.CreateLoad(NT, IndexesAlloca, "reload_index");
         AllocaInst *ResultAlloca = Builder.CreateAlloca(NT);
         LLVM_DEBUG(dbgs() << "  ResultAlloca   : " << *ResultAlloca
                           << "\n  AddressSpace: "


### PR DESCRIPTION
Replace getAllocatedType calls with tracked types from alloca creation. The types are known at the CreateAlloca call sites, so we track them locally instead of re-querying through getAllocatedType, to facilitate someday possibly removing getAllocatedType from the API of AllocaInst.