### PR TITLE
[DirectX] remove getAllocatedType in DXILDataScalarization

### DIFF
--- a/llvm/lib/Target/DirectX/DXILDataScalarization.cpp
+++ b/llvm/lib/Target/DirectX/DXILDataScalarization.cpp
@@ -67,7 +67,8 @@ public:
   friend bool findAndReplaceVectors(llvm::Module &M);
 
 private:
-  typedef std::pair<AllocaInst *, SmallVector<Value *, 4>> AllocaAndGEPs;
+  typedef std::tuple<AllocaInst *, Type *, SmallVector<Value *, 4>>
+      AllocaAndGEPs;
   typedef SmallDenseMap<Value *, AllocaAndGEPs>
       VectorToArrayMap; // A map from a vector-typed Value to its corresponding
                         // AllocaInst and GEPs to each element of an array
@@ -211,17 +212,16 @@ DataScalarizerVisitor::createArrayFromVector(IRBuilder<> &Builder, Value *Vec,
     Builder.CreateStore(EE, GEPs[I]);
   }
 
-  VectorAllocaMap.insert({Vec, {ArrAlloca, GEPs}});
+  VectorAllocaMap.insert({Vec, {ArrAlloca, ArrTy, GEPs}});
   Builder.SetInsertPoint(InsertPoint);
-  return {ArrAlloca, GEPs};
+  return {ArrAlloca, ArrTy, GEPs};
 }
 
 /// Returns a pair of Value* with the first being a GEP into ArrAlloca using
 /// indices {0, Index}, and the second Value* being a Load of the GEP
 static std::pair<Value *, Value *>
-dynamicallyLoadArray(IRBuilder<> &Builder, AllocaInst *ArrAlloca, Value *Index,
-                     const Twine &Name = "") {
-  Type *ArrTy = ArrAlloca->getAllocatedType();
+dynamicallyLoadArray(IRBuilder<> &Builder, AllocaInst *ArrAlloca, Type *ArrTy,
+                     Value *Index, const Twine &Name = "") {
   Value *GEP = Builder.CreateInBoundsGEP(
       ArrTy, ArrAlloca, {Builder.getInt32(0), Index}, Name + ".index");
   Value *Load =
@@ -239,12 +239,12 @@ bool DataScalarizerVisitor::replaceDynamicInsertElementInst(
 
   AllocaAndGEPs ArrAllocaAndGEPs =
       createArrayFromVector(Builder, Vec, IEI.getName());
-  AllocaInst *ArrAlloca = ArrAllocaAndGEPs.first;
-  Type *ArrTy = ArrAlloca->getAllocatedType();
-  SmallVector<Value *, 4> &ArrGEPs = ArrAllocaAndGEPs.second;
+  AllocaInst *ArrAlloca = std::get<0>(ArrAllocaAndGEPs);
+  Type *ArrTy = std::get<1>(ArrAllocaAndGEPs);
+  SmallVector<Value *, 4> &ArrGEPs = std::get<2>(ArrAllocaAndGEPs);
 
   auto GEPAndLoad =
-      dynamicallyLoadArray(Builder, ArrAlloca, Index, IEI.getName());
+      dynamicallyLoadArray(Builder, ArrAlloca, ArrTy, Index, IEI.getName());
   Value *GEP = GEPAndLoad.first;
   Value *Load = GEPAndLoad.second;
 
@@ -280,9 +280,10 @@ bool DataScalarizerVisitor::replaceDynamicExtractElementInst(
 
   AllocaAndGEPs ArrAllocaAndGEPs =
       createArrayFromVector(Builder, EEI.getVectorOperand(), EEI.getName());
-  AllocaInst *ArrAlloca = ArrAllocaAndGEPs.first;
+  AllocaInst *ArrAlloca = std::get<0>(ArrAllocaAndGEPs);
+  Type *ArrTy = std::get<1>(ArrAllocaAndGEPs);
 
-  auto GEPAndLoad = dynamicallyLoadArray(Builder, ArrAlloca,
+  auto GEPAndLoad = dynamicallyLoadArray(Builder, ArrAlloca, ArrTy,
                                          EEI.getIndexOperand(), EEI.getName());
   Value *Load = GEPAndLoad.second;
 


### PR DESCRIPTION
Update dynamicallyLoadArray to take the allocated type as a parameter instead of querying getAllocatedType. This is to facilitate removing other incorrect uses of getAllocatedType, and eventually possibly even getAllocatedType itself.