### PR TITLE
[mlir][IR] Diagnose index element type in DenseArrayAttr

### DIFF
--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -923,7 +923,7 @@ Attribute Parser::parseDenseArrayAttr(Type attrType) {
 
   // Only bool or integer and floating point elements divisible by bytes are
   // supported.
-  if (!eltType.isIntOrIndexOrFloat()) {
+  if (!eltType.isIntOrFloat()) {
     emitError(typeLoc, "expected integer or float type, got: ") << eltType;
     return {};
   }
@@ -940,7 +940,7 @@ Attribute Parser::parseDenseArrayAttr(Type attrType) {
     return {};
 
   DenseArrayElementParser eltParser(eltType);
-  if (eltType.isIntOrIndex()) {
+  if (isa<IntegerType>(eltType)) {
     if (parseCommaSeparatedList(
             [&] { return eltParser.parseIntegerElement(*this); }))
       return {};

--- a/mlir/test/IR/invalid-dense-array-attr.mlir
+++ b/mlir/test/IR/invalid-dense-array-attr.mlir
@@ -1,0 +1,22 @@
+// RUN: mlir-opt %s -split-input-file -verify-diagnostics
+
+// -----
+// Reject index element type in dense array attribute.
+// expected-error@+1 {{expected integer or float type, got: 'index'}}
+module attributes { a = array<index: 1, 2> } {}
+
+// -----
+// Reject tensor element type in dense array attribute.
+// expected-error@+1 {{expected integer or float type, got: 'tensor<2xi32>'}}
+module attributes { a = array<tensor<2xi32>: 1, 2> } {}
+
+// -----
+// Reject memref element type in dense array attribute.
+// expected-error@+1 {{expected integer or float type, got: 'memref<2xi32>'}}
+module attributes { a = array<memref<2xi32>: 1, 2> } {}
+
+// -----
+// Reject complex element type in dense array attribute.
+// expected-error@+1 {{expected integer or float type, got: 'complex<f32>'}}
+module attributes { a = array<complex<f32>: 1, 2> } {} 
+


### PR DESCRIPTION
The dense array attribute parser accepted `index` element types viaisIntOrIndexOrFloat(), but then queried the element bitwidth with getIntOrFloatBitWidth(), which asserts for `index` types.
Reject `index` as a dense array element type and emit a diagnostic instead. Also add corresponding tests. 

Fixes https://github.com/llvm/llvm-project/issues/179045