### PR TITLE
[CIR] Allow multiple blocks in cir.await ready region

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3411,7 +3411,7 @@ def CIR_AwaitOp : CIR_Op<"await",[
   }];
 
   let arguments = (ins CIR_AwaitKind:$kind);
-  let regions = (region SizedRegion<1>:$ready,
+  let regions = (region MinSizedRegion<1>:$ready,
                         SizedRegion<1>:$suspend,
                         SizedRegion<1>:$resume);
   let assemblyFormat = [{

--- a/clang/test/CIR/IR/await.cir
+++ b/clang/test/CIR/IR/await.cir
@@ -1,4 +1,4 @@
-// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+// RUN: cir-opt %s --cir-flatten-cfg --verify-roundtrip | FileCheck %s
 
 cir.func coroutine @checkPrintParse(%arg0 : !cir.bool) {
   cir.await(user, ready : {
@@ -19,3 +19,29 @@ cir.func coroutine @checkPrintParse(%arg0 : !cir.bool) {
 // CHECK:  }, resume : {
 // CHECK:    cir.yield
 // CHECK:  },)
+
+#true = #cir.bool<true> : !cir.bool
+
+cir.func coroutine @checkReadyRegion() {
+  cir.await(init, ready : {
+    %1 = cir.scope {
+      %0 = cir.const #true
+      cir.yield %0 : !cir.bool
+    } : !cir.bool
+    cir.condition(%1)
+  }, suspend : {
+    cir.yield
+  }, resume : {
+    cir.yield
+  },)
+  cir.return
+}
+
+// CHECK:  cir.await(init, ready : {
+// CHECK:    cir.br ^bb1
+// CHECK:^bb1
+// CHECK:    %0 = cir.const #true
+// CHECK:    cir.br ^bb2(%0 : !cir.bool)
+// CHECK:^bb2(%1: !cir.bool)
+// CHECK:    cir.condition(%1)
+// CHECK:  },


### PR DESCRIPTION
After running the cir-flatten-cfg pass, the scope op inside the cir.await ready region can be expanded into multiple basic blocks. The ready region was previously assuming a single block, which caused verification/lowering failures.
```bash
error: 'cir.await' op region #0 ('ready') failed to verify constraint: region with 1 blocks
```
This change relaxes that restriction and allows the ready region to contain more than one block.