### PR TITLE
[mlir][tensor] Guard constant reshape folding

### DIFF
--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -2041,6 +2041,16 @@ static LogicalResult verifyTensorReshapeOp(TensorReshapeOp op,
           verifyReshapeLikeTypes(op, expandedType, collapsedType, isExpansion)))
     return failure();
 
+  // Reshape must preserve the number of elements when statically known.
+  int64_t expandedNumElements = expandedType.getNumElements();
+  int64_t collapsedNumElements = collapsedType.getNumElements();
+  if (!ShapedType::isDynamic(expandedNumElements) &&
+      !ShapedType::isDynamic(collapsedNumElements) &&
+      expandedNumElements != collapsedNumElements) {
+    return op.emitOpError("number of elements must be preserved: ")
+           << expandedNumElements << " != " << collapsedNumElements;
+  }
+
   auto maps = op.getReassociationMaps();
   RankedTensorType expectedType =
       CollapseShapeOp::inferCollapsedType(expandedType, maps);

--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -2042,13 +2042,13 @@ static LogicalResult verifyTensorReshapeOp(TensorReshapeOp op,
     return failure();
 
   // Reshape must preserve the number of elements when statically known.
-  int64_t expandedNumElements = expandedType.getNumElements();
-  int64_t collapsedNumElements = collapsedType.getNumElements();
-  if (!ShapedType::isDynamic(expandedNumElements) &&
-      !ShapedType::isDynamic(collapsedNumElements) &&
-      expandedNumElements != collapsedNumElements) {
-    return op.emitOpError("number of elements must be preserved: ")
-           << expandedNumElements << " != " << collapsedNumElements;
+  if (expandedType.hasStaticShape() && collapsedType.hasStaticShape()) {
+    int64_t expandedNumElements = expandedType.getNumElements();
+    int64_t collapsedNumElements = collapsedType.getNumElements();
+    if (expandedNumElements != collapsedNumElements) {
+      return op.emitOpError("number of elements must be preserved: ")
+             << expandedNumElements << " != " << collapsedNumElements;
+    }
   }
 
   auto maps = op.getReassociationMaps();

--- a/mlir/test/Dialect/Tensor/invalid.mlir
+++ b/mlir/test/Dialect/Tensor/invalid.mlir
@@ -706,3 +706,13 @@ func.func @expand_shape_requires_ranked_tensor(%arg0: tensor<*xf32>) {
   return
 }
 
+// -----
+
+
+func.func @no_fold_invalid_collapse() -> tensor<i64> {
+    %c = arith.constant dense<[1, 2, 3]> : tensor<3xi64>
+    // expected-error@below {{'tensor.collapse_shape' op number of elements must be preserved: 3 != 1}}
+    %0 = tensor.collapse_shape %c [] : tensor<3xi64> into tensor<i64>
+    return %0 : tensor<i64>
+}
+


### PR DESCRIPTION
1. Tighten verification for tensor.collapse_shape / tensor.expand_shape so invalid reshapes are rejected during verification of the ops. This check is performed when the shapes are known statically. 
2.  Also adds a test for this behavior.

Fixes https://github.com/llvm/llvm-project/issues/178205
Fixes https://github.com/llvm/llvm-project/issues/179436