### PR TITLE
[ItaniumDemangle][NFC] Rename argument to not conflict with SS from ptrace_abi.h

### DIFF
--- a/libcxxabi/src/demangle/ItaniumDemangle.h
+++ b/libcxxabi/src/demangle/ItaniumDemangle.h
@@ -1751,8 +1751,8 @@ public:
 };
 
 inline ExpandedSpecialSubstitution::ExpandedSpecialSubstitution(
-    SpecialSubstitution const *SS)
-    : ExpandedSpecialSubstitution(SS->SSK) {}
+    SpecialSubstitution const *SSub)
+    : ExpandedSpecialSubstitution(SSub->SSK) {}
 
 class CtorDtorName final : public Node {
   const Node *Basename;

--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -1751,8 +1751,8 @@ public:
 };
 
 inline ExpandedSpecialSubstitution::ExpandedSpecialSubstitution(
-    SpecialSubstitution const *SS)
-    : ExpandedSpecialSubstitution(SS->SSK) {}
+    SpecialSubstitution const *SSub)
+    : ExpandedSpecialSubstitution(SSub->SSK) {}
 
 class CtorDtorName final : public Node {
   const Node *Basename;


### PR DESCRIPTION
SS in x86 architecture typically represents the Stack Segment register so SS is typically defined in ptrace_abi.h. As a result, in our i686 Android build, the argument SS is getting confused with the define in ptrace_abi.h. I am just renaming the argument to fix the issue and the change does not cause any functional change.

Error:
```
/tmpfs/src/git/test/llvm-project/llvm/include/llvm/Demangle/ItaniumDemangle.h:1754:32: error: expected ')'
 1754 |     SpecialSubstitution const *SS)
      |                                ^
/tmpfs/src/git/test/sysroots/ndk/x86/usr/include/i686-linux-android/asm/ptrace-abi.h:26:12:
note: expanded from macro 'SS'
   26 | #define SS 16
      |            ^
```