### PR TITLE
[MLIR][Python] Support region in python-defined dialects

### DIFF
--- a/mlir/python/mlir/dialects/ext.py
+++ b/mlir/python/mlir/dialects/ext.py
@@ -275,9 +275,7 @@ class Operation(ir.OpView):
         # results are placed at the beginning of the parameter list,
         # but operands and attributes can appear in any relative order.
         args = result_args + [
-            i
-            for i in fields
-            if not isinstance(i, ResultDef | RegionDef)
+            i for i in fields if not isinstance(i, ResultDef | RegionDef)
         ]
         positional_args = [
             i.name for i in args if i.variadicity != Variadicity.optional

--- a/mlir/python/mlir/dialects/ext.py
+++ b/mlir/python/mlir/dialects/ext.py
@@ -30,6 +30,7 @@ __all__ = [
     "Operand",
     "Result",
     "Region",
+    "Operation",
 ]
 
 Operand = ir.Value
@@ -228,6 +229,11 @@ class Operation(ir.OpView):
         # just treat them as normal classes
         if not name:
             return
+
+        if not hasattr(cls, "_dialect_name") or not hasattr(cls, "_dialect_obj"):
+            raise RuntimeError(
+                "Operation subclasses must inherit from a Dialect's Operation subclass"
+            )
 
         op_name = name
         cls._op_name = op_name

--- a/mlir/python/mlir/dialects/ext.py
+++ b/mlir/python/mlir/dialects/ext.py
@@ -277,7 +277,7 @@ class Operation(ir.OpView):
         args = result_args + [
             i
             for i in fields
-            if not isinstance(i, ResultDef) and not isinstance(i, RegionDef)
+            if not isinstance(i, ResultDef | RegionDef)
         ]
         positional_args = [
             i.name for i in args if i.variadicity != Variadicity.optional

--- a/mlir/test/python/dialects/ext.py
+++ b/mlir/test/python/dialects/ext.py
@@ -76,6 +76,8 @@ def testMyInt():
         print(add1._ODS_OPERAND_SEGMENTS)
         # CHECK: None
         print(add1._ODS_RESULT_SEGMENTS)
+        # CHECK: (0, True)
+        print(add1._ODS_REGIONS)
         # CHECK: %0 = "myint.constant"() {value = 2 : i32} : () -> i32
         print(add1.lhs.owner)
         # CHECK: %1 = "myint.constant"() {value = 3 : i32} : () -> i32
@@ -338,3 +340,68 @@ def testExtDialect():
             except TypeError as e:
                 # CHECK：too many positional arguments
                 print(e)
+
+
+# CHECK: TEST: testExtDialectWithRegion
+@run
+def testExtDialectWithRegion():
+    class TestRegion(Dialect, name="ext_region"):
+        pass
+
+    class IfOp(TestRegion.Operation, name="if"):
+        cond: Operand[IntegerType[1]]
+        then: Region
+        else_: Region
+
+    with Context(), Location.unknown():
+        TestRegion.load()
+        # CHECK: irdl.dialect @ext_region {
+        # CHECK:     irdl.operation @if {
+        # CHECK:     %0 = irdl.is i1
+        # CHECK:     irdl.operands(cond: %0)
+        # CHECK:     %1 = irdl.region
+        # CHECK:     %2 = irdl.region
+        # CHECK:     irdl.regions(then: %1, else_: %2)
+        # CHECK: }
+        print(TestRegion._mlir_module)
+
+        # CHECK: (self, /, cond, *, loc=None, ip=None)
+        print(IfOp.__init__.__signature__)
+
+        # CHECK: None None
+        print(IfOp._ODS_OPERAND_SEGMENTS, IfOp._ODS_RESULT_SEGMENTS)
+        # CHECK: (2, True)
+        print(IfOp._ODS_REGIONS)
+
+        from mlir.dialects import llvm
+
+        module = Module.create()
+        with InsertionPoint(module.body):
+            i1 = IntegerType.get_signless(1)
+            i32 = IntegerType.get_signless(32)
+            cond = arith.constant(i1, 1)
+
+            if_ = IfOp(cond)
+            if_.then.blocks.append()
+            if_.else_.blocks.append()
+
+            with InsertionPoint(if_.then.blocks[0]):
+                v = arith.constant(i32, 2)
+                llvm.unreachable()
+
+            with InsertionPoint(if_.else_.blocks[0]):
+                v = arith.constant(i32, 3)
+                llvm.unreachable()
+
+        assert module.operation.verify()
+        # CHECK: module {
+        # CHECK:     %true = arith.constant true
+        # CHECK:     "ext_region.if"(%true) ({
+        # CHECK:         %c2_i32 = arith.constant 2 : i32
+        # CHECK:         llvm.unreachable
+        # CHECK:     }, {
+        # CHECK:         %c3_i32 = arith.constant 3 : i32
+        # CHECK:         llvm.unreachable
+        # CHECK:     }) : (i1) -> ()
+        # CHECK: }
+        print(module)

--- a/mlir/test/python/dialects/ext.py
+++ b/mlir/test/python/dialects/ext.py
@@ -405,3 +405,8 @@ def testExtDialectWithRegion():
         # CHECK:     }) : (i1) -> ()
         # CHECK: }
         print(module)
+
+        # CHECK: %c2_i32 = arith.constant 2 : i32
+        print(if_.then.blocks[0])
+        # CHECK: %c3_i32 = arith.constant 3 : i32
+        print(if_.else_.blocks[0])


### PR DESCRIPTION
This PR adds basic support for defining regions in Python-defined dialects. Example usage:

```python
class TestRegion(Dialect, name="ext_region"):
    pass

class IfOp(TestRegion.Operation, name="if"):
    cond: Operand[IntegerType[1]]
    then: Region
    else_: Region
```

Current limitations:

* We can’t specify region constraints yet (e.g., number of blocks or block argument types). This will be addressed as a follow-up task.
* We can’t mark an op as a `Terminator` or `NoTerminator` yet. This depends on `DynamicOpTraits` (#177735) and Python-side trait API support, and will be implemented in a follow-up PR.

This is the first PR after splitting off #179032.

This is a follow-up PR of #169045.
