### PR TITLE
Revert "[clang][bytecode] Use in `Expr::tryEvaluateObjectSize` (#1790…

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -327,35 +327,6 @@ bool Context::evaluateStrlen(State &Parent, const Expr *E, uint64_t &Result) {
   return true;
 }
 
-bool Context::tryEvaluateObjectSize(State &Parent, const Expr *E, unsigned Kind,
-                                    uint64_t &Result) {
-  assert(Stk.empty());
-  Compiler<EvalEmitter> C(*this, *P, Parent, Stk);
-
-  auto PtrRes = C.interpretAsPointer(E, [&](const Pointer &Ptr) {
-    const Descriptor *DeclDesc = Ptr.getDeclDesc();
-    assert(DeclDesc);
-    QualType T = DeclDesc->getType().getNonReferenceType();
-    if (T->isIncompleteType() || T->isFunctionType() ||
-        !T->isConstantSizeType())
-      return false;
-
-    Pointer P = Ptr;
-    if (auto ObjectSize = evaluateBuiltinObjectSize(getASTContext(), Kind, P)) {
-      Result = *ObjectSize;
-      return true;
-    }
-    return false;
-  });
-
-  if (PtrRes.isInvalid()) {
-    C.cleanup();
-    Stk.clear();
-    return false;
-  }
-  return true;
-}
-
 const LangOptions &Context::getLangOpts() const { return Ctx.getLangOpts(); }
 
 static PrimType integralTypeToPrimTypeS(unsigned BitWidth) {

--- a/clang/lib/AST/ByteCode/Context.h
+++ b/clang/lib/AST/ByteCode/Context.h
@@ -75,19 +75,6 @@ public:
   /// run strlen() on it.
   bool evaluateStrlen(State &Parent, const Expr *E, uint64_t &Result);
 
-  /// If \param E evaluates to a pointer the number of accessible bytes
-  /// past the pointer is estimated in \param Result as if evaluated by
-  /// the builtin function __builtin_object_size. This is a best effort
-  /// approximation, when Kind & 2 == 0 the object size is less
-  /// than or equal to the estimated size, when Kind & 2 == 1 the
-  /// true value is greater than or equal to the estimated size.
-  /// When Kind & 1 == 1 only bytes belonging to the same subobject
-  /// as the one referred to by E are considered, when Kind & 1 == 0
-  /// bytes belonging to the same storage (stack, heap allocation,
-  /// global variable) are considered.
-  bool tryEvaluateObjectSize(State &Parent, const Expr *E, unsigned Kind,
-                             uint64_t &Result);
-
   /// Returns the AST context.
   ASTContext &getASTContext() const { return Ctx; }
   /// Returns the language options.

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -2304,36 +2304,54 @@ static bool isUserWritingOffTheEnd(const ASTContext &Ctx, const Pointer &Ptr) {
          isFlexibleArrayMember(FieldDesc);
 }
 
-UnsignedOrNone evaluateBuiltinObjectSize(const ASTContext &ASTCtx,
-                                         unsigned Kind, Pointer &Ptr) {
+static bool interp__builtin_object_size(InterpState &S, CodePtr OpPC,
+                                        const InterpFrame *Frame,
+                                        const CallExpr *Call) {
+  const ASTContext &ASTCtx = S.getASTContext();
+  // From the GCC docs:
+  // Kind is an integer constant from 0 to 3. If the least significant bit is
+  // clear, objects are whole variables. If it is set, a closest surrounding
+  // subobject is considered the object a pointer points to. The second bit
+  // determines if maximum or minimum of remaining bytes is computed.
+  unsigned Kind = popToUInt64(S, Call->getArg(1));
+  assert(Kind <= 3 && "unexpected kind");
+  bool UseFieldDesc = (Kind & 1u);
+  bool ReportMinimum = (Kind & 2u);
+  Pointer Ptr = S.Stk.pop<Pointer>();
+
+  if (Call->getArg(0)->HasSideEffects(ASTCtx)) {
+    // "If there are any side effects in them, it returns (size_t) -1
+    // for type 0 or 1 and (size_t) 0 for type 2 or 3."
+    pushInteger(S, Kind <= 1 ? -1 : 0, Call->getType());
+    return true;
+  }
+
   if (Ptr.isZero() || !Ptr.isBlockPointer())
-    return std::nullopt;
+    return false;
 
   // We can't load through pointers.
   if (Ptr.isDummy() && Ptr.getType()->isPointerType())
-    return std::nullopt;
+    return false;
 
   bool DetermineForCompleteObject = Ptr.getFieldDesc() == Ptr.getDeclDesc();
   const Descriptor *DeclDesc = Ptr.getDeclDesc();
   assert(DeclDesc);
 
-  bool UseFieldDesc = (Kind & 1u);
-  bool ReportMinimum = (Kind & 2u);
   if (!UseFieldDesc || DetermineForCompleteObject) {
     // Lower bound, so we can't fall back to this.
     if (ReportMinimum && !DetermineForCompleteObject)
-      return std::nullopt;
+      return false;
 
     // Can't read beyond the pointer decl desc.
     if (!UseFieldDesc && !ReportMinimum && DeclDesc->getType()->isPointerType())
-      return std::nullopt;
+      return false;
   } else {
     if (isUserWritingOffTheEnd(ASTCtx, Ptr.expand())) {
       // If we cannot determine the size of the initial allocation, then we
       // can't given an accurate upper-bound. However, we are still able to give
       // conservative lower-bounds for Type=3.
       if (Kind == 1)
-        return std::nullopt;
+        return false;
     }
   }
 
@@ -2347,7 +2365,7 @@ UnsignedOrNone evaluateBuiltinObjectSize(const ASTContext &ASTCtx,
 
   std::optional<unsigned> FullSize = computeFullDescSize(ASTCtx, Desc);
   if (!FullSize)
-    return std::nullopt;
+    return false;
 
   unsigned ByteOffset;
   if (UseFieldDesc) {
@@ -2368,34 +2386,10 @@ UnsignedOrNone evaluateBuiltinObjectSize(const ASTContext &ASTCtx,
     ByteOffset = computePointerOffset(ASTCtx, Ptr);
 
   assert(ByteOffset <= *FullSize);
-  return *FullSize - ByteOffset;
-}
+  unsigned Result = *FullSize - ByteOffset;
 
-static bool interp__builtin_object_size(InterpState &S, CodePtr OpPC,
-                                        const InterpFrame *Frame,
-                                        const CallExpr *Call) {
-  const ASTContext &ASTCtx = S.getASTContext();
-  // From the GCC docs:
-  // Kind is an integer constant from 0 to 3. If the least significant bit is
-  // clear, objects are whole variables. If it is set, a closest surrounding
-  // subobject is considered the object a pointer points to. The second bit
-  // determines if maximum or minimum of remaining bytes is computed.
-  unsigned Kind = popToUInt64(S, Call->getArg(1));
-  assert(Kind <= 3 && "unexpected kind");
-  Pointer Ptr = S.Stk.pop<Pointer>();
-
-  if (Call->getArg(0)->HasSideEffects(ASTCtx)) {
-    // "If there are any side effects in them, it returns (size_t) -1
-    // for type 0 or 1 and (size_t) 0 for type 2 or 3."
-    pushInteger(S, Kind <= 1 ? -1 : 0, Call->getType());
-    return true;
-  }
-
-  if (auto Result = evaluateBuiltinObjectSize(ASTCtx, Kind, Ptr)) {
-    pushInteger(S, *Result, Call->getType());
-    return true;
-  }
-  return false;
+  pushInteger(S, Result, Call->getType());
+  return true;
 }
 
 static bool interp__builtin_is_within_lifetime(InterpState &S, CodePtr OpPC,

--- a/clang/lib/AST/ByteCode/InterpHelpers.h
+++ b/clang/lib/AST/ByteCode/InterpHelpers.h
@@ -66,9 +66,6 @@ bool CheckNewDeleteForms(InterpState &S, CodePtr OpPC,
 /// Copy the contents of Src into Dest.
 bool DoMemcpy(InterpState &S, CodePtr OpPC, const Pointer &Src, Pointer &Dest);
 
-UnsignedOrNone evaluateBuiltinObjectSize(const ASTContext &ASTCtx,
-                                         unsigned Kind, Pointer &Ptr);
-
 template <typename T>
 static bool handleOverflow(InterpState &S, CodePtr OpPC, const T &SrcValue) {
   const Expr *E = S.Current->getExpr(OpPC);

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -21781,10 +21781,6 @@ bool Expr::tryEvaluateObjectSize(uint64_t &Result, ASTContext &Ctx,
 
   Expr::EvalStatus Status;
   EvalInfo Info(Ctx, Status, EvaluationMode::ConstantFold);
-  if (Info.EnableNewConstInterp) {
-    return Info.Ctx.getInterpContext().tryEvaluateObjectSize(Info, this, Type,
-                                                             Result);
-  }
   return tryEvaluateBuiltinObjectSize(this, Type, Info, Result);
 }
 

--- a/clang/test/Sema/address-packed-member-memops.c
+++ b/clang/test/Sema/address-packed-member-memops.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-new-constant-interpreter -verify %s
 // expected-no-diagnostics
 
 struct B {

--- a/clang/test/Sema/attr-diagnose-as-builtin.c
+++ b/clang/test/Sema/attr-diagnose-as-builtin.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -Wfortify-source -triple x86_64-apple-macosx10.14.0 %s -verify
-// RUN: %clang_cc1 -Wfortify-source -triple x86_64-apple-macosx10.14.0 %s -fexperimental-new-constant-interpreter -verify
 // RUN: %clang_cc1 -Wfortify-source -xc++ -triple x86_64-apple-macosx10.14.0 %s -verify
 
 typedef unsigned long size_t;

--- a/clang/test/Sema/builtin-memcpy.c
+++ b/clang/test/Sema/builtin-memcpy.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 %s -triple x86_64-unknown-linux -fsyntax-only -verify=c
-// RUN: %clang_cc1 %s -triple x86_64-unknown-linux -fsyntax-only -fexperimental-new-constant-interpreter -verify=c
 // RUN: %clang_cc1 -x c++ %s -triple x86_64-unknown-linux -fsyntax-only -verify=cxx
 
 // cxx-no-diagnostics

--- a/clang/test/Sema/format-strings-nonnull.c
+++ b/clang/test/Sema/format-strings-nonnull.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -fsyntax-only --std=c23 -verify -Wnonnull -Wno-format-security %s
-// RUN: %clang_cc1 -fsyntax-only --std=c23 -verify -Wnonnull -Wno-format-security -fexperimental-new-constant-interpreter %s
 
 #define NULL  (void*)0
 

--- a/clang/test/Sema/format-strings.c
+++ b/clang/test/Sema/format-strings.c
@@ -2,7 +2,6 @@
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -fno-signed-char %s
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -triple=x86_64-unknown-fuchsia %s
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -triple=x86_64-linux-android %s
-// RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -fexperimental-new-constant-interpreter -isystem %S/Inputs %s
 
 #include <limits.h>
 #include <stdarg.h>

--- a/clang/test/Sema/memset-invalid-1.c
+++ b/clang/test/Sema/memset-invalid-1.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -fsyntax-only %s -verify
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-new-constant-interpreter %s -verify
 
 typedef __SIZE_TYPE__ size_t;
 void *memset(void*, int, size_t);

--- a/clang/test/Sema/transpose-memset.c
+++ b/clang/test/Sema/transpose-memset.c
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1       -Wmemset-transposed-args -verify %s
 // RUN: %clang_cc1 -xc++ -Wmemset-transposed-args -verify %s
-// RUN: %clang_cc1       -Wmemset-transposed-args -fexperimental-new-constant-interpreter -verify %s
 
 #define memset(...) __builtin_memset(__VA_ARGS__)
 #define bzero(x,y) __builtin_memset(x, 0, y)

--- a/clang/test/Sema/warn-format-overflow-truncation.c
+++ b/clang/test/Sema/warn-format-overflow-truncation.c
@@ -6,7 +6,6 @@
 // RUN: %clang_cc1 -xc++ -triple x86_64-apple-macosx10.14.0 -Wno-format-truncation-non-kprintf -Wno-format-overflow-non-kprintf %s -verify=kprintf,expected
 // RUN: %clang_cc1 -triple x86_64-apple-macosx10.14.0 -Wno-format-overflow -Wno-format-truncation -Wformat-truncation-non-kprintf -Wformat-overflow-non-kprintf %s -verify=nonkprintf,expected
 // RUN: %clang_cc1 -xc++ -triple x86_64-apple-macosx10.14.0 -Wno-format-overflow -Wno-format-truncation -Wformat-truncation-non-kprintf -Wformat-overflow-non-kprintf %s -verify=nonkprintf,expected
-// RUN: %clang_cc1 -triple x86_64-apple-macosx10.14.0 -fexperimental-new-constant-interpreter %s -verify=kprintf,nonkprintf,expected
 
 typedef unsigned long size_t;
 

--- a/clang/test/Sema/warn-fortify-scanf.c
+++ b/clang/test/Sema/warn-fortify-scanf.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macosx10.14.0 %s -verify
-// RUN: %clang_cc1 -triple x86_64-apple-macosx10.14.0 -fexperimental-new-constant-interpreter %s -verify
 
 typedef struct _FILE FILE;
 extern int scanf(const char *format, ...);

--- a/clang/test/Sema/warn-fortify-source.c
+++ b/clang/test/Sema/warn-fortify-source.c
@@ -2,7 +2,11 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macosx10.14.0 %s -verify -DUSE_BUILTINS
 // RUN: %clang_cc1 -xc++ -triple x86_64-apple-macosx10.14.0 %s -verify
 // RUN: %clang_cc1 -xc++ -triple x86_64-apple-macosx10.14.0 %s -verify -DUSE_BUILTINS
+
+// RUN: %clang_cc1 -triple x86_64-apple-macosx10.14.0 %s -verify -fexperimental-new-constant-interpreter
 // RUN: %clang_cc1 -triple x86_64-apple-macosx10.14.0 %s -verify -DUSE_BUILTINS -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -xc++ -triple x86_64-apple-macosx10.14.0 %s -verify -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -xc++ -triple x86_64-apple-macosx10.14.0 %s -verify -DUSE_BUILTINS -fexperimental-new-constant-interpreter
 
 typedef unsigned long size_t;
 

--- a/clang/test/Sema/warn-memset-bad-sizeof.c
+++ b/clang/test/Sema/warn-memset-bad-sizeof.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-new-constant-interpreter -verify %s
 
 // expected-no-diagnostics
 

--- a/clang/test/Sema/warn-nontrivial-struct-memaccess-ptrauth.c
+++ b/clang/test/Sema/warn-nontrivial-struct-memaccess-ptrauth.c
@@ -2,7 +2,6 @@
 // RUN: %clang_cc1 -triple aarch64-linux-gnu -fptrauth-calls -fptrauth-intrinsics -fsyntax-only -verify=c,expected %s
 // RUN: %clang_cc1 -triple arm64-apple-ios -fptrauth-calls -fptrauth-intrinsics -fsyntax-only -x c++ -verify=cxx,expected %s
 // RUN: %clang_cc1 -triple aarch64-linux-gnu -fptrauth-calls -fptrauth-intrinsics -fsyntax-only -x c++ -verify=cxx,expected %s
-// RUN: %clang_cc1 -triple aarch64-linux-gnu -fptrauth-calls -fptrauth-intrinsics -fsyntax-only -fexperimental-new-constant-interpreter -verify=c,expected %s
 
 #if defined __cplusplus
 extern "C" {

--- a/clang/test/Sema/warn-strncat-size.c
+++ b/clang/test/Sema/warn-strncat-size.c
@@ -2,7 +2,6 @@
 // RUN: %clang_cc1 -DUSE_BUILTINS -Wstrncat-size -verify -fsyntax-only %s
 // RUN: %clang_cc1 -Wstrncat-size -fixit -x c %s
 // RUN: %clang_cc1 -DUSE_BUILTINS -Wstrncat-size -fixit -x c %s
-// RUN: %clang_cc1 -DUSE_BUILTINS -Wstrncat-size -fixit -x c -fexperimental-new-constant-interpreter %s
 
 typedef __SIZE_TYPE__ size_t;
 size_t strlen (const char *s);


### PR DESCRIPTION
…33)"

This reverts commit 756c321c33af2be0bd40707948aae3c06163a0a6.

Test failure in clang/test/AST/ByteCode/builtins.c in CI build

CC @tbaederr 