### PR TITLE
[mlir][UB] Erase ops that precede `ub.unreachable`

### DIFF
--- a/mlir/include/mlir/Dialect/UB/IR/UBOps.td
+++ b/mlir/include/mlir/Dialect/UB/IR/UBOps.td
@@ -84,6 +84,7 @@ def UnreachableOp : UB_Op<"unreachable", [Terminator]> {
   }];
 
   let assemblyFormat = "attr-dict";
+  let hasCanonicalizeMethod = 1;
 }
 
 #endif // MLIR_DIALECT_UB_IR_UBOPS_TD

--- a/mlir/test/Dialect/UB/canonicalize.mlir
+++ b/mlir/test/Dialect/UB/canonicalize.mlir
@@ -9,3 +9,28 @@ func.func @merge_poison() -> (i32, i32) {
   %1 = ub.poison : i32
   return %0, %1 : i32, i32
 }
+
+// -----
+
+// CHECK-LABEL: func @drop_ops_before_unreachable( 
+//  CHECK-NEXT:   arith.constant
+//  CHECK-NEXT:   arith.constant
+//  CHECK-NEXT:   arith.constant
+//  CHECK-NEXT:   vector.print
+//  CHECK-NEXT:   scf.for {{.*}} {
+//  CHECK-NEXT:     vector.print
+//  CHECK-NEXT:   }
+//  CHECK-NEXT:   ub.unreachable
+func.func @drop_ops_before_unreachable(%arg0: i32) {
+  %lb = arith.constant 3 : index
+  %ub = arith.constant 4 : index
+  %step = arith.constant 0 : index
+  vector.print %arg0 : i32
+  // Infinite loop that may not progress. Such ops (and everything before)
+  // is not erased.
+  scf.for %iv = %lb to %ub step %step {
+    vector.print %arg0 : i32
+  } {mustProgress = false}
+  vector.print %arg0 : i32
+  ub.unreachable
+}


### PR DESCRIPTION
Erase ops that precede `ub.unreachable` if they must progress, i.e., it's guaranteed that their next operation is reached.

