### PR TITLE
[VPlan] Create edge mask for single-destination switch

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanPredicator.cpp
@@ -225,6 +225,10 @@ void VPPredicator::createSwitchEdgeMasks(VPInstruction *SI) {
     DefaultMask = Builder.createNot(DefaultMask);
     if (SrcMask)
       DefaultMask = Builder.createLogicalAnd(SrcMask, DefaultMask);
+  } else {
+    // There are no destinations other than the default destination, so this is
+    // an unconditional branch.
+    DefaultMask = SrcMask;
   }
   setEdgeMask(Src, DefaultDst, DefaultMask);
 }


### PR DESCRIPTION
When converting phis to blends, the `VPPredicator` expects to have edge masks to the phi node if the phi node has different incoming blocks. This was not the case if the predecessor of the phi was a switch where a conditional destination was the same as the default destination.

This was because when creating edge masks in `createSwitchEdgeMasks`, edge masks are set in a loop through the *non-default* destinations. But when there are no non-default destinations (but at least one condition, otherwise an earlier condition would trigger and just forward the source mask), this loop is never executed, so the masks are never set.

To resolve this, we explicitly forward the source mask for these cases as well, which is correct because it is an unconditional branch, just a very convoluted one.

fixes #179074