### PR TITLE
[SelectionDAG][NFC] Rename isConstantSequence to isArithmeticSequence

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -2333,7 +2333,7 @@ public:
   /// integer, the value "<a, n>" is returned. Arithmetic is performed modulo
   /// 2^BitWidth, so this also matches sequences that wrap around. Poison
   /// elements are ignored and can take any value.
-  LLVM_ABI std::optional<std::pair<APInt, APInt>> isConstantSequence() const;
+  LLVM_ABI std::optional<std::pair<APInt, APInt>> isArithmeticSequence() const;
 
   /// Recast bit data \p SrcBitElements to \p DstEltSizeInBits wide elements.
   /// Undef elements are treated as zero, and entirely undefined elements are

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -14188,7 +14188,7 @@ bool BuildVectorSDNode::isConstant() const {
 }
 
 std::optional<std::pair<APInt, APInt>>
-BuildVectorSDNode::isConstantSequence() const {
+BuildVectorSDNode::isArithmeticSequence() const {
   unsigned NumOps = getNumOperands();
   if (NumOps < 2)
     return std::nullopt;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -15904,7 +15904,7 @@ SDValue AArch64TargetLowering::LowerFixedLengthBuildVectorToSVE(
   EVT ContainerVT = getContainerForFixedLengthVector(DAG, VT);
   auto *BVN = cast<BuildVectorSDNode>(Op);
 
-  if (auto SeqInfo = BVN->isConstantSequence()) {
+  if (auto SeqInfo = BVN->isArithmeticSequence()) {
     SDValue Start = DAG.getConstant(SeqInfo->first, DL, ContainerVT);
     SDValue Steps = DAG.getStepVector(DL, ContainerVT, SeqInfo->second);
     SDValue Seq = DAG.getNode(ISD::ADD, DL, ContainerVT, Start, Steps);
@@ -15961,7 +15961,7 @@ SDValue AArch64TargetLowering::LowerBUILD_VECTOR(SDValue Op,
   EVT VT = Op.getValueType();
 
   bool OverrideNEON = !Subtarget->isNeonAvailable() ||
-                      cast<BuildVectorSDNode>(Op)->isConstantSequence();
+                      cast<BuildVectorSDNode>(Op)->isArithmeticSequence();
   if (useSVEForFixedLengthVectorVT(VT, OverrideNEON))
     return LowerFixedLengthBuildVectorToSVE(Op, DAG);
 

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-build-vector.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-build-vector.ll
@@ -164,7 +164,7 @@ define void @build_vector_fractional_stride_v8i32(ptr %a) #0 {
 }
 
 ; zip1 pattern: constant <0, 1, 2, 3> is expanded to <0, 1, 2, 3, poison, poison, poison, poison>
-; to match the shuffle result width. isConstantSequence recognizes this as a sequence.
+; to match the shuffle result width. isArithmeticSequence recognizes this as a sequence.
 define <8 x i8> @zip_const_seq_with_variable(i8 %x) #0 {
 ; VBITS_GE_256-LABEL: zip_const_seq_with_variable:
 ; VBITS_GE_256:       // %bb.0:


### PR DESCRIPTION
The previous name was misleading: the method checks for an arithmetic
progression `(start, start+stride, start+2*stride, ...)`, not just any
constant sequence. The new name uses precise mathematical terminology.

https://github.com/llvm/llvm-project/pull/176671#discussion_r2735571479