### PR TITLE
[lldb] Fix TSan report on Linux

### DIFF
--- a/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
@@ -88,8 +88,18 @@ extern "C"
     // TODO: dlsym won't work on Windows.
     void *dlsym(void* handle, const char* symbol);
     int (*ptr__tsan_get_report_loc_object_type)(void *report, unsigned long idx, const char **object_type);
-}
+)"
+#if defined(__linux__)
+R"(
+    void *const RTLD_DEFAULT = (void *)0;
+  }
 )";
+#else
+R"(
+    void *const RTLD_DEFAULT = (void *)-2;
+  }
+)";
+#endif
 
 const char *thread_sanitizer_retrieve_report_data_command = R"(
 
@@ -161,7 +171,7 @@ struct {
     } unique_tids[REPORT_ARRAY_SIZE];
 } t = {0};
 
-ptr__tsan_get_report_loc_object_type = (typeof(ptr__tsan_get_report_loc_object_type))(void *)dlsym((void*)-2 /*RTLD_DEFAULT*/, "__tsan_get_report_loc_object_type");
+ptr__tsan_get_report_loc_object_type = (typeof(ptr__tsan_get_report_loc_object_type))(void *)dlsym(RTLD_DEFAULT, "__tsan_get_report_loc_object_type");
 
 t.report = __tsan_get_current_report();
 __tsan_get_report_data(t.report, &t.description, &t.report_count, &t.stack_count, &t.mop_count, &t.loc_count, &t.mutex_count, &t.thread_count, &t.unique_tid_count, t.sleep_trace, REPORT_TRACE_SIZE);

--- a/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
@@ -89,6 +89,7 @@ extern "C"
     void *dlsym(void* handle, const char* symbol);
     int (*ptr__tsan_get_report_loc_object_type)(void *report, unsigned long idx, const char **object_type);
 )"
+// clang-format off
 #if defined(__linux__)
 R"(
     void *const RTLD_DEFAULT = (void *)0;
@@ -100,6 +101,7 @@ R"(
   }
 )";
 #endif
+// clang-format on
 
 const char *thread_sanitizer_retrieve_report_data_command = R"(
 

--- a/lldb/test/API/functionalities/tsan/thread_leak/TestTsanThreadLeak.py
+++ b/lldb/test/API/functionalities/tsan/thread_leak/TestTsanThreadLeak.py
@@ -9,10 +9,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TsanThreadLeakTestCase(TestBase):
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="non-core functionality, need to reenable and fix later (DES 2014.11.07)",
-    )
     @expectedFailureNetBSD
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @skipIfRemote

--- a/lldb/test/API/functionalities/tsan/thread_numbers/TestTsanThreadNumbers.py
+++ b/lldb/test/API/functionalities/tsan/thread_numbers/TestTsanThreadNumbers.py
@@ -10,10 +10,6 @@ import json
 
 
 class TsanThreadNumbersTestCase(TestBase):
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="non-core functionality, need to reenable and fix later (DES 2014.11.07)",
-    )
     @expectedFailureNetBSD
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @skipIfRemote


### PR DESCRIPTION
Linux uses 0 for `RTLD_DEFAULT` opposite to macOS and BSD systems (they use -2).

Before:
<img width="1271" height="742" alt="before" src="https://github.com/user-attachments/assets/870cc524-c39c-4717-9a65-d7b66ded3280" />

After:
<img width="1271" height="740" alt="after" src="https://github.com/user-attachments/assets/088ea43c-2cfd-4135-8af9-54edd4ae32ff" />
