### PR TITLE
[Clang] Fix coroutine promise with inherited allocation functions

### DIFF
--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -1103,7 +1103,9 @@ static bool DiagnoseTypeAwareAllocators(Sema &S, SourceLocation Loc,
   S.LookupQualifiedName(R, PromiseType->getAsCXXRecordDecl());
   bool HaveIssuedWarning = false;
   for (auto Decl : R) {
-    if (!Decl->getAsFunction()->isTypeAwareOperatorNewOrDelete())
+    if (!Decl->getUnderlyingDecl()
+             ->getAsFunction()
+             ->isTypeAwareOperatorNewOrDelete())
       continue;
     if (!HaveIssuedWarning) {
       S.Diag(Loc, DiagnosticID) << Name;

--- a/clang/test/SemaCXX/coroutine-inherited-allocator.cpp
+++ b/clang/test/SemaCXX/coroutine-inherited-allocator.cpp
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -triple x86_64-linux-gnu %s -std=c++20 -fsyntax-only -verify
+
+// Verify that coroutines with promise types that inherit operator new/delete from a base class via
+// using declarations don't crash during compilation.
+// This is a regression test for a bug where DiagnoseTypeAwareAllocators didn't handle
+// UsingShadowDecl properly.
+
+// expected-no-diagnostics
+
+#include "Inputs/std-coroutine.h"
+
+namespace std {
+  typedef __SIZE_TYPE__ size_t;
+}
+
+struct PromiseBase {
+  static void *operator new(std::size_t size);
+  static void operator delete(void *ptr, std::size_t size);
+};
+
+struct Task {
+  struct promise_type : PromiseBase {
+    using PromiseBase::operator new;
+    using PromiseBase::operator delete;
+
+    Task get_return_object() {
+      return Task{std::coroutine_handle<promise_type>::from_promise(*this)};
+    }
+
+    std::suspend_never initial_suspend() noexcept { return {}; }
+    std::suspend_always final_suspend() noexcept { return {}; }
+    void return_void() {}
+    void unhandled_exception() {}
+  };
+
+  std::coroutine_handle<promise_type> handle;
+};
+
+Task example_coroutine() {
+  co_return;
+}


### PR DESCRIPTION
The compiler frontend crashed when the promise class overloads operator new/delete without a regular function declaration. This happens when the promise class derives from a base class and takes the allocation functions from the base class with:
    using Base::operator new;
    using Base::operator delete;

This was initially introduced by 1cd59264aa2fb4b0ba70ff03c1298b1b5c21271e.

This should also fix #164088 