### PR TITLE
[AMDGPU][SIInsertWaitcnts][NFC] Replace Wait.combined() with simple assignment

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -2332,7 +2332,7 @@ bool SIInsertWaitcnts::generateWaitcntInstBefore(
     if (ST->hasExtendedWaitCounts() &&
         !ScoreBrackets.hasPendingEvent(VMEM_ACCESS))
       AllZeroWait.LoadCnt = ~0u;
-    Wait = Wait.combined(AllZeroWait);
+    Wait = AllZeroWait;
     break;
   }
   case AMDGPU::S_ENDPGM:


### PR DESCRIPTION
Wait is initialized with all ~0s and by the time it reaches the updated line it still holds the same value. So Wait.combined(AllZeroWait) is effectively combining all ~0s with AllZeroWait and given that combined() returns the min() of the two it should always return AllZeroWait.

So this patch replaces the assignment with `= AllZeroWait` to make it easier to read.