### PR TITLE
[mlir][DeadCodeAnalysis] Fix predecessors when running DeadCodeAnalysis on callable

### DIFF
--- a/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
@@ -149,6 +149,14 @@ LogicalResult DeadCodeAnalysis::initialize(Operation *top) {
            << OpWithFlags(top, OpPrintingFlags().skipRegions());
   }
 
+  // If the top level op is a callable, we cannot identify all of its callers.
+  if (isa<CallableOpInterface>(top)) {
+    auto *state = getOrCreate<PredecessorState>(getProgramPointAfter(top));
+    propagateIfChanged(state, state->setHasUnknownPredecessors());
+    LDBG() << "[init] Marked callable root as having unknown predecessors: "
+           << OpWithFlags(top, OpPrintingFlags().skipRegions());
+  }
+
   // Mark as overdefined the predecessors of symbol callables with potentially
   // unknown predecessors.
   initializeSymbolCallables(top);

--- a/mlir/test/Analysis/DataFlow/test-dead-code-analysis-func.mlir
+++ b/mlir/test/Analysis/DataFlow/test-dead-code-analysis-func.mlir
@@ -1,0 +1,12 @@
+// RUN: mlir-opt --pass-pipeline="builtin.module(func.func(test-dead-code-analysis))" 2>&1 %s | FileCheck %s
+
+// Test that when dead code analysis is run on a single function, we correctly
+// identify that we do not know all of the predecessors.
+// CHECK:      foo:
+// CHECK-NEXT:   region #0
+// CHECK-NEXT:     ^bb0 = live
+// CHECK-NEXT: op_preds: predecessors: (none)
+func.func @foo(%arg0: i32) -> i32
+    attributes {tag = "foo"} {
+  return {a} %arg0 : i32
+}


### PR DESCRIPTION
`initializeSymbolCallables` only identifies potentially escaping functions inside a `SymbolTable` operation. If the top level operation is itself a callable, we should always treat it as escaping because we are not analysing its potential users.