### PR TITLE
[clang] avoid reentering header-name lexing on nested macro expansion

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -221,6 +221,7 @@ Bug Fixes in This Version
 - Fix lifetime extension of temporaries in for-range-initializers in templates. (#GH165182)
 - Fixed a preprocessor crash in ``__has_cpp_attribute`` on incomplete scoped attributes. (#GH178098)
 - Fixes an assertion failure when evaluating ``__underlying_type`` on enum redeclarations. (#GH177943)
+- Fixed an assertion failure caused by nested macro expansion during header-name lexing (``__has_embed(__has_include)``). (#GH178635)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/Preprocessor/embed___has_embed_parsing_errors.c
+++ b/clang/test/Preprocessor/embed___has_embed_parsing_errors.c
@@ -292,3 +292,14 @@ int a = __has_embed (__FILE__);
    expected-error@+2 {{expected value in expression}}
 #if __has_embed("" limit
 #endif
+
+// expected-error@+2 {{missing '(' after '__has_include'}}
+// expected-error@+1 {{expected "FILENAME" or <FILENAME>}}
+#if __has_embed(__has_include)
+#endif
+
+// expected-error@+3 {{missing '(' after '__has_embed'}}
+// expected-error@+2 {{expected value in expression}}
+// expected-error@+1 {{expected "FILENAME" or <FILENAME>}}
+#if __has_embed(__has_embed)
+#endif

--- a/clang/test/Preprocessor/has_include.c
+++ b/clang/test/Preprocessor/has_include.c
@@ -148,6 +148,16 @@ MACRO1  // This should be fine because it is never actually reached
 #if __has_include(stdint.h>)
 #endif
 
+// expected-error@+2 {{missing '(' after '__has_include'}}
+// expected-error@+1 {{expected "FILENAME" or <FILENAME>}}
+#if __has_include(__has_include)
+#endif
+
+// expected-error@+2 {{missing '(' after '__has_embed'}}
+// expected-error@+1 {{expected "FILENAME" or <FILENAME>}}
+#if __has_include(__has_embed)
+#endif
+
 // expected-error@+1 {{'__has_include' must be used within a preprocessing directive}}
 __has_include
 


### PR DESCRIPTION
Fixes #178635

---

This PR addressed the issue when header-name _lexing_ reentered on nested macro expansion.

`__has_include`/`__has_embed` lex a header name by calling `LexHeaderName`, and neither expects nested expansion in that context.

If `__has_include` appears inside the header name expression (e.g., `__has_include(__has_include)`, or `__has_embed(__has_include)`)

https://github.com/llvm/llvm-project/blob/6a18039298174562a38f28ca06d12dcbf7f14f06/clang/lib/Lex/PPMacroExpansion.cpp#L1252

macro expansion reenters `LexHeaderName` and hits the assertion

https://github.com/llvm/llvm-project/blob/6a18039298174562a38f28ca06d12dcbf7f14f06/clang/lib/Lex/PPMacroExpansion.cpp#L1898

https://github.com/llvm/llvm-project/blob/6a18039298174562a38f28ca06d12dcbf7f14f06/clang/lib/Lex/PPMacroExpansion.cpp#L1156

