### PR TITLE
[clang][Sema] Fix initialization of GRO when GRO-return type mismatches (CWG2563)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -237,6 +237,8 @@ Bug Fixes to C++ Support
 - Fixed a crash when a default argument is passed to an explicit object parameter. (#GH176639)
 - Fixed a crash when diagnosing an invalid static member function with an explicit object parameter (#GH177741)
 
+- Fix initialization of GRO when GRO-return type mismatches, as part of CWG2563. (#GH98744)
+
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -1870,7 +1870,8 @@ bool CoroutineStmtBuilder::makeGroDeclAndReturnStmt() {
   } else {
     GroDecl = VarDecl::Create(
         S.Context, &FD, FD.getLocation(), FD.getLocation(),
-        &S.PP.getIdentifierTable().get("__coro_gro"), GroType,
+        &S.PP.getIdentifierTable().get("__coro_gro"),
+        S.BuildDecltypeType(ReturnValue).getCanonicalType(),
         S.Context.getTrivialTypeSourceInfo(GroType, Loc), SC_None);
     GroDecl->setImplicit();
 

--- a/clang/test/CodeGenCoroutines/coro-gro3.cpp
+++ b/clang/test/CodeGenCoroutines/coro-gro3.cpp
@@ -1,0 +1,53 @@
+// Tests defination of get-return-object-invocation [dcl.fct.def.coroutine] (and CWG2563)
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -emit-llvm %s -o - -disable-llvm-passes | FileCheck %s
+
+#include "Inputs/coroutine.h"
+
+using namespace std;
+
+extern "C" {
+void wrong();
+}
+
+template<bool LValue>
+struct Promise {
+    Promise() = default;
+    Promise(const Promise&) { wrong(); }
+    Promise(Promise&&) { wrong(); }
+
+    // Tests: decltype(auto) gro = promise.get_return_object();
+    auto&& get_return_object() {
+      if constexpr (LValue)
+        return *this;
+      else
+        return static_cast<Promise&&>(*this);
+    }
+    std::suspend_never initial_suspend() const { return {}; }
+    std::suspend_never final_suspend() const noexcept { return {}; }
+    void return_void() const {}
+    void unhandled_exception() const noexcept {}
+};
+
+template<bool LValue>
+struct Handle {
+    using promise_type = Promise<LValue>;
+
+    Handle(promise_type& p) {
+      if constexpr (!LValue)
+        wrong();
+    }
+    Handle(promise_type&& p) {
+      if constexpr (LValue)
+        wrong();
+    }
+};
+
+Handle<true> lvalue() {
+  co_return;
+}
+
+Handle<false> rvalue() {
+  co_return;
+}
+
+// CHECK-NOT: call void @wrong


### PR DESCRIPTION
This patch implements one piece of proposed solution to [CWG2563](https://cplusplus.github.io/CWG/issues/2563.html):

> get-return-object-invocation is as follows:
> ...
> otherwise, get-return-object-invocation initializes a variable with the exposition-only name gro as if by
> decltype(auto) gro = promise.get_return_object();

Close #98744