### PR TITLE
[libclc] remquo: avoid canonicalize for float

### DIFF
--- a/libclc/clc/lib/generic/math/clc_remquo.inc
+++ b/libclc/clc/lib/generic/math/clc_remquo.inc
@@ -70,7 +70,7 @@ _CLC_DEF _CLC_OVERLOAD float __clc_remquo(float x, float y,
 
     int qsgn = 1 + (((__clc_as_int(x) ^ __clc_as_int(y)) >> 31) << 1);
     float t = __clc_fma(y, -(float)qsgn, x);
-    ret = c ? t : __builtin_elementwise_canonicalize(x);
+    ret = c ? t : x;
     q7 = c ? qsgn : q7;
     ret = ax == ay ? __clc_copysign(0.0f, x) : ret;
     q7 = ax == ay ? qsgn : q7;


### PR DESCRIPTION
Fix SPIR-V target builds broken since 20c15c7afe97 due to llvm.canonicalize.f32 not supported in SPIR-V.

Keep `x` unchanged in the non-quotient path. OpenCL CTS remquo still passes on intel gpu.