### PR TITLE
[mlir][Python] fix liveContextMap under free-threading after #178529

### DIFF
--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -1671,7 +1671,7 @@ nb::object PyOpView::buildGeneric(
       int segmentSpec = operandSegmentSpec[i];
       if (segmentSpec == 1 || segmentSpec == 0) {
         // Unpack unary element.
-        const auto operand = operandList[i];
+        const nanobind::handle operand = operandList[i];
         if (!operand.is_none()) {
           try {
             operands.push_back(getOpResultOrValue(operand));


### PR DESCRIPTION
#178529 introduced a small bug under free-threading by bumping a reference count (or something like that) when accessing the operand list passed to `build_generic`. This PR fixes that.