### PR TITLE
[WebAssembly] Combine shuffle and signed extend to extend_high

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -2289,10 +2289,7 @@ WebAssemblyTargetLowering::LowerSIGN_EXTEND_INREG(SDValue Op,
 
 static SDValue GetExtendHigh(SDValue Op, unsigned UserOpc, EVT VT,
                              SelectionDAG &DAG) {
-  SDValue Source = Op;
-  if (Source.getOpcode() == ISD::BITCAST)
-    Source = Source.getOperand(0);
-
+  SDValue Source = peekThroughBitcasts(Op);
   if (Source.getOpcode() != ISD::VECTOR_SHUFFLE)
     return SDValue();
 

--- a/llvm/test/CodeGen/WebAssembly/simd-dot-reductions.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-dot-reductions.ll
@@ -104,3 +104,55 @@ define <4 x i32> @dot_wrong_shuffle(<8 x i16> %a, <8 x i16> %b) {
   %res = add <4 x i32> %shuffle1, %shuffle2
   ret <4 x i32> %res
 }
+
+define dso_local <4 x i32> @dot_with_bitcast_both(<4 x i32> %a, <4 x i32> %b) unnamed_addr {
+; CHECK-LABEL: dot_with_bitcast_both:
+; CHECK:         .functype dot_with_bitcast_both (v128, v128) -> (v128)
+; CHECK-NEXT:    .local v128
+; CHECK-NEXT:  # %bb.0: # %start
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i32x4.extmul_low_i16x8_s
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i8x16.shuffle 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i8x16.shuffle 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 0, 1, 2, 3
+; CHECK-NEXT:    i32x4.extmul_low_i16x8_s
+; CHECK-NEXT:    local.tee 0
+; CHECK-NEXT:    i8x16.shuffle 0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i8x16.shuffle 4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31
+; CHECK-NEXT:    i32x4.add
+; CHECK-NEXT:    # fallthrough-return
+start:
+  %_4 = bitcast <4 x i32> %a to <8 x i16>
+  %_5 = bitcast <4 x i32> %b to <8 x i16>
+  %0 = sext <8 x i16> %_4 to <8 x i32>
+  %1 = sext <8 x i16> %_5 to <8 x i32>
+  %2 = mul nsw <8 x i32> %1, %0
+  %3 = shufflevector <8 x i32> %2, <8 x i32> poison, <4 x i32> <i32 0, i32 2, i32 4, i32 6>
+  %4 = shufflevector <8 x i32> %2, <8 x i32> poison, <4 x i32> <i32 1, i32 3, i32 5, i32 7>
+  %5 = add <4 x i32> %3, %4
+  ret <4 x i32> %5
+}
+
+define <4 x i32> @dot_with_bitcast_one(<4 x i32> %a) {
+; CHECK-LABEL: dot_with_bitcast_one:
+; CHECK:         .functype dot_with_bitcast_one (v128) -> (v128)
+; CHECK-NEXT:  # %bb.0: # %start
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i32x4.extadd_pairwise_i16x8_s
+; CHECK-NEXT:    # fallthrough-return
+start:
+  %a1 = bitcast <4 x i32> %a to <8 x i16>
+  %0 = shufflevector <8 x i16> %a1, <8 x i16> %a1, <4 x i32> <i32 0, i32 2, i32 4, i32 6>
+  %1 = shufflevector <8 x i16> %a1, <8 x i16> %a1, <4 x i32> <i32 1, i32 3, i32 5, i32 7>
+  %2 = sext <4 x i16> %0 to <4 x i32>
+  %3 = sext <4 x i16> %1 to <4 x i32>
+  %4 = add nsw <4 x i32> %2, %3
+  ret <4 x i32> %4
+}

--- a/llvm/test/CodeGen/WebAssembly/simd-dot-reductions.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-dot-reductions.ll
@@ -108,25 +108,10 @@ define <4 x i32> @dot_wrong_shuffle(<8 x i16> %a, <8 x i16> %b) {
 define dso_local <4 x i32> @dot_with_bitcast_both(<4 x i32> %a, <4 x i32> %b) unnamed_addr {
 ; CHECK-LABEL: dot_with_bitcast_both:
 ; CHECK:         .functype dot_with_bitcast_both (v128, v128) -> (v128)
-; CHECK-NEXT:    .local v128
 ; CHECK-NEXT:  # %bb.0: # %start
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i32x4.extmul_low_i16x8_s
-; CHECK-NEXT:    local.tee 2
-; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i8x16.shuffle 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 0, 1, 2, 3
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i8x16.shuffle 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 0, 1, 2, 3
-; CHECK-NEXT:    i32x4.extmul_low_i16x8_s
-; CHECK-NEXT:    local.tee 0
-; CHECK-NEXT:    i8x16.shuffle 0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27
-; CHECK-NEXT:    local.get 2
-; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    i8x16.shuffle 4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31
-; CHECK-NEXT:    i32x4.add
+; CHECK-NEXT:    i32x4.dot_i16x8_s
 ; CHECK-NEXT:    # fallthrough-return
 start:
   %_4 = bitcast <4 x i32> %a to <8 x i16>


### PR DESCRIPTION

Fold shuffles and bitcasts feeding extend_low_s into extend_high_s.
This enables i32x4.dot_i16x8_s selection and removes redundant shuffles.

Fixed: https://github.com/llvm/llvm-project/issues/179145