### PR TITLE
[orc-rt] Use future rather than condition_variable for shutdown wait.

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -23,7 +23,7 @@
 #include "orc-rt-c/WrapperFunction.h"
 
 #include <cassert>
-#include <condition_variable>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -163,7 +163,6 @@ public:
 private:
   struct ShutdownInfo {
     bool Complete = false;
-    std::condition_variable CompleteCV;
     std::vector<std::unique_ptr<ResourceManager>> ResourceMgrs;
     std::vector<OnShutdownCompleteFn> OnCompletes;
   };


### PR DESCRIPTION
Session::waitForShutdown is a convenience wrapper around the asynchronous Session::shutdown call. The previous Session::waitForShutdown call waited on a std::condition_variable to signal the end of shutdown, but it's easier to just embed a std::promise in a callback to the asynchronous shutdown method.