### PR TITLE
[lit] Fix not builtin to treat signal deaths as crashes

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1071,6 +1071,10 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
         # Detect Ctrl-C in subprocess.
         if res == -signal.SIGINT:
             raise KeyboardInterrupt
+        # Treat crashes as failures
+        if res < 0 and proc_not_counts[i] > 0:
+            res = 1
+            proc_not_counts[i] -= 1
         if proc_not_counts[i] % 2:
             if proc_not_fail_if_crash[i]:
                 res = int(res <= 0)

--- a/llvm/utils/lit/tests/Inputs/shtest-not/crash.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-not/crash.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+import os, signal
+os.kill(os.getpid(), signal.SIGABRT)

--- a/llvm/utils/lit/tests/Inputs/shtest-not/not-calls-crash.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-not/not-calls-crash.txt
@@ -1,0 +1,4 @@
+# Verify that 'not' treats signal deaths as failures.
+
+# RUN: not not %{python} crash.py
+# RUN: not --crash %{python} crash.py

--- a/llvm/utils/lit/tests/shtest-not.py
+++ b/llvm/utils/lit/tests/shtest-not.py
@@ -7,7 +7,7 @@
 
 # Make sure not and env commands are included in printed commands.
 
-# CHECK: -- Testing: 17 tests{{.*}}
+# CHECK: -- Testing: 18 tests{{.*}}
 
 # CHECK: FAIL: shtest-not :: exclamation-args-nested-none.txt {{.*}}
 # CHECK: ! ! !
@@ -69,6 +69,12 @@
 # CHECK: # executed command: not --crash :
 # CHECK: # | Error: 'not --crash' cannot call ':'
 # CHECK: # error: command failed with exit status: {{.*}}
+
+# CHECK: PASS: shtest-not :: not-calls-crash.txt {{.*}}
+# CHECK: not not [[PYTHON]] crash.py
+# CHECK: # executed command: not not [[PYTHON_BARE]] crash.py
+# CHECK: not --crash [[PYTHON]] crash.py
+# CHECK: # executed command: not --crash [[PYTHON_BARE]] crash.py
 
 # CHECK: FAIL: shtest-not :: not-calls-diff-with-crash.txt {{.*}}
 # CHECK: not --crash diff -u {{.*}}
@@ -184,7 +190,7 @@
 # CHECK: # | Error: 'not --crash' cannot call 'rm'
 # CHECK: # error: command failed with exit status: {{.*}}
 
-# CHECK: Total Discovered Tests: 17
-# CHECK: Passed:  1 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK: Total Discovered Tests: 18
+# CHECK: Passed:  2 {{\([0-9]*\.[0-9]*%\)}}
 # CHECK: Failed: 16 {{\([0-9]*\.[0-9]*%\)}}
 # CHECK-NOT: {{.}}


### PR DESCRIPTION
Internal shell is treating all non zero exit codes the same. This is causing `not` to incorrectly invert a crash to success.

This is an attempt to try to get the same output between lit not and the external not tool (not.cpp). I originally tested this by writing this small test file:

```
// Reference: https://helloacm.com/how-to-kill-a-process-or-capture-signals-sigterm-sigkill-in-python/
// RUN: not false
// RUN: not true
// RUN: not python3 -c "import os, signal; os.kill(os.getpid(), signal.SIGABRT)"
// RUN: not --crash python3 -c "import os, signal; os.kill(os.getpid(), signal.SIGABRT)"
```

On the internal shell, `// RUN: not python3 -c "import os, signal; os.kill(os.getpid(), signal.SIGABRT)"` passes even though it is expected to fail:

| Command               | Internal | External |
| --------------------- | -------- | -------- |
| `not false`           | pass     | pass     |
| **`not <crash>`**     | **pass** | **fail** |
| `not true`            | fail     | fail     |
| **`not not <crash>`** | **fail** | **pass** |
| `not not false`       | fail     | fail     |
| `not not true`        | pass     | pass     |
| `not --crash <crash>` | pass     | pass     |
| `not --crash true`    | fail     | fail     |

Also, reading the python docs I think it's fair to say `res < 0` for signal deaths:

> A negative value -N indicates that the child was terminated by signal N (POSIX only).

Reference: https://docs.python.org/3/library/subprocess.html