### PR TITLE
[DebugInfo] Convert format() to formatv() in DWARFVerifier

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -712,11 +712,12 @@ unsigned DWARFVerifier::verifyDebugInfoAttribute(const DWARFDie &Die,
       if (U->isDWOUnit() && RangeSection.Data.empty())
         break;
       if (*SectionOffset >= RangeSection.Data.size())
-        ReportError("DW_AT_ranges offset out of bounds",
-                    "DW_AT_ranges offset is beyond " +
-                        StringRef(DwarfVersion < 5 ? ".debug_ranges"
-                                                   : ".debug_rnglists") +
-                        " bounds: " + llvm::formatv("{0:x8}", *SectionOffset));
+        ReportError(
+            "DW_AT_ranges offset out of bounds",
+            llvm::formatv("DW_AT_ranges offset is beyond {0} bounds: {1:x8}",
+                          StringRef(DwarfVersion < 5 ? ".debug_ranges"
+                                                     : ".debug_rnglists"),
+                          *SectionOffset));
       break;
     }
     ReportError("Invalid DW_AT_ranges encoding",
@@ -726,9 +727,11 @@ unsigned DWARFVerifier::verifyDebugInfoAttribute(const DWARFDie &Die,
     // Make sure the offset in the DW_AT_stmt_list attribute is valid.
     if (auto SectionOffset = AttrValue.Value.getAsSectionOffset()) {
       if (*SectionOffset >= U->getLineSection().Data.size())
-        ReportError("DW_AT_stmt_list offset out of bounds",
-                    "DW_AT_stmt_list offset is beyond .debug_line bounds: " +
-                        llvm::formatv("{0:x8}", *SectionOffset));
+        ReportError(
+            "DW_AT_stmt_list offset out of bounds",
+            llvm::formatv(
+                "DW_AT_stmt_list offset is beyond .debug_line bounds: {0:x8}",
+                *SectionOffset));
       break;
     }
     ReportError("Invalid DW_AT_stmt_list encoding",
@@ -811,12 +814,11 @@ unsigned DWARFVerifier::verifyDebugInfoAttribute(const DWARFDie &Die,
           if (std::optional<uint64_t> LastFileIdx =
                   LT->getLastValidFileIndex()) {
             ReportError("Invalid file index in DW_AT_decl_file",
-                        "DIE has " + AttributeString(Attr) +
-                            " with an invalid file index " +
-                            llvm::formatv("{0}", *FileIdx) +
-                            " (valid values are [" +
-                            (IsZeroIndexed ? "0-" : "1-") +
-                            llvm::formatv("{0}", *LastFileIdx) + "])");
+                        llvm::formatv("DIE has {0} with an invalid file index "
+                                      "{1} (valid values are [{2}-{3}])",
+                                      AttributeString(Attr), *FileIdx,
+                                      (IsZeroIndexed ? "0" : "1"),
+                                      *LastFileIdx));
           } else {
             ReportError("Invalid file index in DW_AT_decl_file",
                         "DIE has " + AttributeString(Attr) +

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -1110,11 +1110,10 @@ void DWARFVerifier::verifyDebugLineRows() {
         ErrorCategory.Report(
             "Invalid index in .debug_line->prologue.file_names->dir_idx",
             [&]() {
-              error() << formatv(".debug_line[{0:x+8}].prologue.file_names[{1}",
+              error() << formatv(".debug_line[{0:x+8}].prologue.file_names[{1}]"
+                                 ".dir_idx contains an invalid index: {2}\n",
                                  *toSectionOffset(Die.find(DW_AT_stmt_list)),
-                                 FileIndex)
-                      << "].dir_idx contains an invalid index: "
-                      << FileName.DirIdx << "\n";
+                                 FileIndex, FileName.DirIdx);
             });
       }
 
@@ -1127,10 +1126,10 @@ void DWARFVerifier::verifyDebugLineRows() {
       (void)HasFullPath;
       auto [It, Inserted] = FullPathMap.try_emplace(FullPath, FileIndex);
       if (!Inserted && It->second != FileIndex && DumpOpts.Verbose) {
-        warn() << formatv(".debug_line[{0:x+8}].prologue.file_names[{1}",
+        warn() << formatv(".debug_line[{0:x+8}].prologue.file_names[{1}] is a "
+                          "duplicate of file_names[{2}]\n",
                           *toSectionOffset(Die.find(DW_AT_stmt_list)),
-                          FileIndex)
-               << "] is a duplicate of file_names[" << It->second << "]\n";
+                          FileIndex, It->second);
       }
 
       FileIndex++;
@@ -1150,10 +1149,10 @@ void DWARFVerifier::verifyDebugLineRows() {
         ++NumDebugLineErrors;
         ErrorCategory.Report(
             "decreasing address between debug_line rows", [&]() {
-              error() << formatv(".debug_line[{0:x+8}] row[{1}",
+              error() << formatv(".debug_line[{0:x+8}] row[{1}] decreases in "
+                                 "address from previous row:\n",
                                  *toSectionOffset(Die.find(DW_AT_stmt_list)),
-                                 RowIndex)
-                      << "] decreases in address from previous row:\n";
+                                 RowIndex);
 
               DWARFDebugLine::Row::dumpTableHeader(OS, 0);
               if (RowIndex > 0)

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -421,7 +421,7 @@ unsigned DWARFVerifier::verifyUnits(const DWARFUnitVector &Units) {
   unsigned Index = 1;
 
   for (const auto &Unit : Units) {
-    OS << formatv("Verifying unit: {0} / {1}\n", Index, Units.getNumUnits());
+    OS << formatv("Verifying unit: {0} / {1}", Index, Units.getNumUnits());
     if (const char* Name = Unit->getUnitDIE(true).getShortName())
       OS << formatv(", \"{0}\"", Name);
     OS << '\n';
@@ -1167,7 +1167,7 @@ void DWARFVerifier::verifyDebugLineRows() {
         ++NumDebugLineErrors;
         ErrorCategory.Report("Invalid file index in debug_line", [&]() {
           error() << formatv(".debug_line[{0:x+8}][{1}] has invalid file index "
-                             "{2}  (valid values are [{3},{4}:\n",
+                             "{2}  (valid values are [{3},{4}{5}):\n",
                              *toSectionOffset(Die.find(DW_AT_stmt_list)),
                              RowIndex, Row.File, MinFileIndex,
                              LineTable->Prologue.FileNames.size(),


### PR DESCRIPTION
Replace all of calls of `format()` with `formatv()` in `DWARFVerifier.cpp`. Also use `formatv()` when strings were concatenated with `+` or streamed with `<<`.

See [llvm/include/llvm/Support/FormatProviders.h](https://github.com/llvm/llvm-project/blob/2f3935bcee6eaf7df8c85a21b7c0fbef967316b5/llvm/include/llvm/Support/FormatProviders.h#L96-L117) for the hexadecimal grammar. e.g. `x+` to print the `0x` prefix or `x-` to not print it.

My motivation is to:

1. make it easier to read the format strings and
2. have less `formatv()` calls when it was used on arguments to the format string before.

Concerns:
* I've searched the git history for replacements of `format()` where `PRIx64` was used (e.g. `format("0x%08" PRIx64, Pair.first)`) with `formatv()` (e.g. `formatv("{{0:x+8}", Pair.first)`) where no `PRIx64` was used. I couldn't find one. `PRIx64` expands to `llx` or `lx` depending on the wordsize. The existing code that uses `formatv()` to print hexadecimal numbers seems to be agnostic to the wordsize so I went with that approach as well.

Relates to #35980
