### PR TITLE
[NFC][LoopUnroll] Add `-unroll-runtime-other-exit-predictable=false` to `unroll-multi-exit-loop-heuristics.ll`

### DIFF
--- a/llvm/test/Transforms/LoopUnroll/unroll-multi-exit-loop-heuristics.ll
+++ b/llvm/test/Transforms/LoopUnroll/unroll-multi-exit-loop-heuristics.ll
@@ -1,5 +1,5 @@
-; RUN: opt < %s -passes=loop-unroll -unroll-runtime=true -verify-dom-info -verify-loop-info -S | FileCheck %s
-; RUN: opt < %s -passes=loop-unroll -unroll-runtime=true -verify-dom-info -verify-loop-info -unroll-runtime-multi-exit=false -S | FileCheck %s -check-prefix=NOUNROLL
+; RUN: opt < %s -passes=loop-unroll -unroll-runtime=true -verify-dom-info -verify-loop-info -unroll-runtime-other-exit-predictable=false -S | FileCheck %s
+; RUN: opt < %s -passes=loop-unroll -unroll-runtime=true -verify-dom-info -verify-loop-info -unroll-runtime-multi-exit=false -unroll-runtime-other-exit-predictable=false -S | FileCheck %s -check-prefix=NOUNROLL
 
 ; Multi exit loop with predictable exit -- unroll
 ; Exit before loop body.


### PR DESCRIPTION
Adds `-unroll-runtime-other-exit-predictable=false` option to `unroll-multi-exit-loop-heuristics.ll` test for stability reasons.

This is a followup to a discussion in !164799 and a similar patch https://reviews.llvm.org/D98098. Since this option is false by default, this is an NFC.