### PR TITLE
[mlir][ROCDL] do not hardcode partial lld path in utilities

### DIFF
--- a/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
@@ -49,7 +49,7 @@ assembleIsa(StringRef isa, StringRef targetTriple, StringRef chip,
             StringRef features, function_ref<InFlightDiagnostic()> emitError);
 
 FailureOr<SmallVector<char, 0>>
-linkObjectCode(ArrayRef<char> objectCode, StringRef toolkitPath,
+linkObjectCode(ArrayRef<char> objectCode, StringRef lldPath,
                function_ref<InFlightDiagnostic()> emitError);
 
 /// Base class for all ROCDL serializations from GPU modules into binary


### PR DESCRIPTION
`ROCDL::linkObjectCode` was unconditionally appending llvm/bin/ld.lld to the path it is been passed to to look for lld, which isn't desirable for a utility function and makes it unusable with, e.g., system lld or one from the LLVM's own build directory. Move this logic to the caller and let the utility take a full path.