### PR TITLE
[BOLT] Fix scavenge register after program point

### DIFF
--- a/bolt/include/bolt/Passes/LivenessAnalysis.h
+++ b/bolt/include/bolt/Passes/LivenessAnalysis.h
@@ -47,7 +47,7 @@ public:
   // Return a usable general-purpose reg after point P. Return 0 if no reg is
   // available.
   MCPhysReg scavengeRegAfter(ProgramPoint P) {
-    BitVector BV = *this->getStateAt(P);
+    BitVector BV = *this->getStateBefore(P);
     BV.flip();
     BitVector GPRegs(NumRegs, false);
     this->BC.MIB->getGPRegs(GPRegs, /*IncludeAlias=*/false);


### PR DESCRIPTION
The dataflow direction of liveness analysis is backward, so the register state after ProgramPoint in the original instruction sequence must be obtained by calling getStateBefore() instead of getStateAt();