### PR TITLE
[MLIR] [Python] Added plumbing to run stubgen on the mlir._mlir package

### DIFF
--- a/utils/bazel/MODULE.bazel.lock
+++ b/utils/bazel/MODULE.bazel.lock
@@ -234,7 +234,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%llvm_repos_extension": {
       "general": {
-        "bzlTransitiveDigest": "9jGazpNxASw0pQCCKAMsxGYnVBJH8Mkddp3w7yRm6eU=",
+        "bzlTransitiveDigest": "DqyjXvFpPyfsmyt58EuR0v0Xy+nPN74iTGxjOW99OcQ=",
         "usagesDigest": "X0yUkkWyxQ2Y5oZVDkRSE/K4YkDWo1IjhHsL+1weKyU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -300,7 +300,8 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "urls": [
-                "https://versaweb.dl.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.13.0.tar.gz"
+                "https://versaweb.dl.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.13.0.tar.gz",
+                "https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.13.0.tar.gz"
               ],
               "sha256": "d18b97764c755528c1051d376e33545d0eb60c6ebf85680436813fa5b04cc3d1",
               "strip_prefix": "libpfm-4.13.0",

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -15,6 +15,7 @@ load(
     "cc_headers_only",
     "if_cuda_available",
     "mlir_c_api_cc_library",
+    "nanobind_pyi_genrule",
 )
 load(":linalggen.bzl", "genlinalg")
 load(":tblgen.bzl", "gentbl_cc_library", "td_library")
@@ -1417,6 +1418,30 @@ cc_binary(
         "@nanobind",
         "@rules_python//python/cc:current_py_cc_headers",
     ],
+)
+
+##---------------------------------------------------------------------------##
+# Python stub generation for native extensions.
+##---------------------------------------------------------------------------##
+
+py_binary(
+    name = "stubgen_runner",
+    srcs = ["stubgen_runner.py"],
+    data = ["@nanobind//:src/stubgen.py"],
+    visibility = ["//visibility:private"],
+    deps = ["@rules_python//python/runfiles"],
+)
+
+nanobind_pyi_genrule(
+    name = "_mlir_pyi",
+    outs = [
+        "_mlir/__init__.pyi",
+        "_mlir/ir.pyi",
+        "_mlir/passmanager.pyi",
+        "_mlir/rewrite.pyi",
+    ],
+    module_name = "_mlir",
+    deps = [":_mlir.so"],
 )
 
 ##---------------------------------------------------------------------------##

--- a/utils/bazel/llvm-project-overlay/mlir/build_defs.bzl
+++ b/utils/bazel/llvm-project-overlay/mlir/build_defs.bzl
@@ -72,3 +72,24 @@ def mlir_c_api_cc_library(
         alwayslink = True,
         **kwargs
     )
+
+def nanobind_pyi_genrule(name, module_name, outs, deps, visibility = None):
+    """Generates .pyi stub file(s) for a nanobind extension module.
+
+    Args:
+        name: Name of the generated target.
+        module_name: Name of the module to generate stubs for (e.g., "_mlir").
+        outs: List of expected output .pyi files.
+        deps: All .so modules to load (including the target module).
+        visibility: Visibility for the generated .pyi file(s).
+    """
+    deps_arg = ",".join(["$(location " + d + ")" for d in deps])
+
+    native.genrule(
+        name = name,
+        srcs = deps,
+        outs = outs,
+        cmd = "$(location :stubgen_runner) --module " + module_name + " --deps " + deps_arg + " -o $(RULEDIR)",
+        tools = [":stubgen_runner"],
+        visibility = visibility,
+    )

--- a/utils/bazel/llvm-project-overlay/mlir/stubgen_runner.py
+++ b/utils/bazel/llvm-project-overlay/mlir/stubgen_runner.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Generates .pyi stubs for nanobind extensions using nanobind's stubgen."""
+
+import argparse
+import ctypes
+import importlib.util
+import sys
+from pathlib import Path
+
+from python.runfiles import Runfiles
+
+
+def load_extension(path: Path):
+    """Load an extension module from a .so file with RTLD_GLOBAL."""
+    module_name = path.stem.removesuffix(".abi3")
+
+    # Load with RTLD_GLOBAL so symbols are available to dependent extensions.
+    ctypes.CDLL(str(path), mode=ctypes.RTLD_GLOBAL)
+
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        sys.exit(f"Failed to load extension from {path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module_name
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--module", required=True, help="Module name to generate stubs for"
+    )
+    parser.add_argument(
+        "--deps", required=True, help="Comma-separated .so files to load"
+    )
+    parser.add_argument("-o", "--output", required=True, help="Output directory")
+    args = parser.parse_args()
+
+    for dep_path in args.deps.split(","):
+        load_extension(Path(dep_path).resolve())
+
+    runfiles = Runfiles.Create()
+    stubgen_path = runfiles.Rlocation("+llvm_repos_extension+nanobind/src/stubgen.py")
+    spec = importlib.util.spec_from_file_location("stubgen", stubgen_path)
+    stubgen = importlib.util.module_from_spec(spec)
+    sys.modules["stubgen"] = stubgen
+    spec.loader.exec_module(stubgen)
+    stubgen.main(["-m", args.module, "-r", "-O", args.output])
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/bazel/third_party_build/nanobind.BUILD
+++ b/utils/bazel/third_party_build/nanobind.BUILD
@@ -1,5 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
+exports_files(["src/stubgen.py"])
+
 cc_library(
     name = "nanobind",
     srcs = glob(


### PR DESCRIPTION
This allows generating stubs during Bazel builds, which was previously only supported under CMake.

I decided not to use nanobind_stubgen from nanobind-bazel, because the py_binary it generates is not easily usable in a genrule.