### PR TITLE
[lldb][CompilerType] Remove CompilerType::IsFloat

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -205,8 +205,6 @@ public:
   /// This is used when you don't care about the signedness of the integer.
   bool IsInteger() const;
 
-  bool IsFloat() const;
-
   /// This is used when you don't care about the signedness of the enum.
   bool IsEnumerationType() const;
 

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -337,8 +337,6 @@ bool CompilerType::IsInteger() const {
   return IsIntegerType(is_signed);
 }
 
-bool CompilerType::IsFloat() const { return IsFloatingPointType(); }
-
 bool CompilerType::IsEnumerationType() const {
   bool is_signed = false; // May be reset by the call below.
   return IsEnumerationType(is_signed);

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -814,7 +814,7 @@ Interpreter::VerifyArithmeticCast(CompilerType source_type,
                                   CompilerType target_type, int location) {
   if (source_type.IsPointerType() || source_type.IsNullPtrType()) {
     // Cast from pointer to float/double is not allowed.
-    if (target_type.IsFloat()) {
+    if (target_type.IsFloatingPointType()) {
       std::string errMsg = llvm::formatv("Cast from {0} to {1} is not allowed",
                                          source_type.TypeDescription(),
                                          target_type.TypeDescription());
@@ -951,7 +951,8 @@ llvm::Expected<lldb::ValueObjectSP> Interpreter::Visit(const CastNode &node) {
 
   switch (cast_kind) {
   case CastKind::eEnumeration: {
-    if (op_type.IsFloat() || op_type.IsInteger() || op_type.IsEnumerationType())
+    if (op_type.IsFloatingPointType() || op_type.IsInteger() ||
+        op_type.IsEnumerationType())
       return operand->CastToEnumType(target_type);
     break;
   }

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1165,7 +1165,7 @@ llvm::Expected<llvm::APSInt> ValueObject::GetValueAsAPSInt() {
 }
 
 llvm::Expected<llvm::APFloat> ValueObject::GetValueAsAPFloat() {
-  if (!GetCompilerType().IsFloat())
+  if (!GetCompilerType().IsFloatingPointType())
     return llvm::make_error<llvm::StringError>(
         "type cannot be converted to APFloat", llvm::inconvertibleErrorCode());
 
@@ -1188,7 +1188,7 @@ llvm::Expected<bool> ValueObject::GetValueAsBool() {
     if (value_or_err)
       return value_or_err->getBoolValue();
   }
-  if (val_type.IsFloat()) {
+  if (val_type.IsFloatingPointType()) {
     auto value_or_err = GetValueAsAPFloat();
     if (value_or_err)
       return value_or_err->isNonZero();
@@ -1204,7 +1204,7 @@ void ValueObject::SetValueFromInteger(const llvm::APInt &value, Status &error) {
   // Verify the current object is an integer object
   CompilerType val_type = GetCompilerType();
   if (!val_type.IsInteger() && !val_type.IsUnscopedEnumerationType() &&
-      !val_type.IsFloat() && !val_type.IsPointerType() &&
+      !val_type.IsFloatingPointType() && !val_type.IsPointerType() &&
       !val_type.IsScalarType()) {
     error =
         Status::FromErrorString("current value object is not an integer objet");
@@ -1244,7 +1244,7 @@ void ValueObject::SetValueFromInteger(lldb::ValueObjectSP new_val_sp,
   // Verify the current object is an integer object
   CompilerType val_type = GetCompilerType();
   if (!val_type.IsInteger() && !val_type.IsUnscopedEnumerationType() &&
-      !val_type.IsFloat() && !val_type.IsPointerType() &&
+      !val_type.IsFloatingPointType() && !val_type.IsPointerType() &&
       !val_type.IsScalarType()) {
     error =
         Status::FromErrorString("current value object is not an integer objet");
@@ -1261,7 +1261,7 @@ void ValueObject::SetValueFromInteger(lldb::ValueObjectSP new_val_sp,
 
   // Verify the proposed new value is the right type.
   CompilerType new_val_type = new_val_sp->GetCompilerType();
-  if (!new_val_type.IsInteger() && !new_val_type.IsFloat() &&
+  if (!new_val_type.IsInteger() && !new_val_type.IsFloatingPointType() &&
       !new_val_type.IsPointerType()) {
     error = Status::FromErrorString(
         "illegal argument: new value should be of the same size");
@@ -1274,7 +1274,7 @@ void ValueObject::SetValueFromInteger(lldb::ValueObjectSP new_val_sp,
       SetValueFromInteger(*value_or_err, error);
     else
       error = Status::FromErrorString("error getting APSInt from new_val_sp");
-  } else if (new_val_type.IsFloat()) {
+  } else if (new_val_type.IsFloatingPointType()) {
     auto value_or_err = new_val_sp->GetValueAsAPFloat();
     if (value_or_err)
       SetValueFromInteger(value_or_err->bitcastToAPInt(), error);
@@ -3142,7 +3142,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
   bool is_enum = GetCompilerType().IsEnumerationType();
   bool is_pointer =
       GetCompilerType().IsPointerType() || GetCompilerType().IsNullPtrType();
-  bool is_float = GetCompilerType().IsFloat();
+  bool is_float = GetCompilerType().IsFloatingPointType();
   bool is_integer = GetCompilerType().IsInteger();
   ExecutionContext exe_ctx(GetExecutionContextRef());
 
@@ -3234,7 +3234,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
     }
   }
 
-  if (type.IsFloat()) {
+  if (type.IsFloatingPointType()) {
     if (!is_scalar) {
       auto int_value_or_err = GetValueAsAPSInt();
       if (int_value_or_err) {
@@ -3296,7 +3296,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
 lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
   bool is_enum = GetCompilerType().IsEnumerationType();
   bool is_integer = GetCompilerType().IsInteger();
-  bool is_float = GetCompilerType().IsFloat();
+  bool is_float = GetCompilerType().IsFloatingPointType();
   ExecutionContext exe_ctx(GetExecutionContextRef());
 
   if (!is_enum && !is_integer && !is_float)


### PR DESCRIPTION
Depends on:
* https://github.com/llvm/llvm-project/pull/178906

Ever since https://github.com/llvm/llvm-project/pull/178906 this API is the same as `IsFloatingPointType`. There's no compelling reason for this to exist.