### PR TITLE
[libc++][NFC] Disable std_format_spec benchmarks through lit instead of the preprocessor

### DIFF
--- a/libcxx/test/benchmarks/format/std_format_spec_string_unicode.bench.cpp
+++ b/libcxx/test/benchmarks/format/std_format_spec_string_unicode.bench.cpp
@@ -6,17 +6,17 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-#  include <concepts>
-#  include <format>
-#  include <string_view>
+// UNSUPPORTED: libcpp-has-no-unicode
 
-#  include "benchmark/benchmark.h"
-#  include "make_string.h"
-#  include "test_macros.h"
+#include <concepts>
+#include <format>
+#include <string_view>
 
-#  define SV(S) MAKE_STRING_VIEW(CharT, S)
+#include "benchmark/benchmark.h"
+#include "make_string.h"
+#include "test_macros.h"
 
-#if _LIBCPP_HAS_UNICODE
+#define SV(S) MAKE_STRING_VIEW(CharT, S)
 
 // generated with https://generator.lorem-ipsum.info/_latin
 
@@ -285,16 +285,12 @@ BENCHMARK(BM_cyrillic_text<char>);
 BENCHMARK(BM_japanese_text<char>);
 BENCHMARK(BM_emoji_text<char>);
 
-#  ifndef TEST_HAS_NO_WIDE_CHARACTERS
+#ifndef TEST_HAS_NO_WIDE_CHARACTERS
 BENCHMARK(BM_ascii_text<wchar_t>);
 BENCHMARK(BM_unicode_text<wchar_t>);
 BENCHMARK(BM_cyrillic_text<wchar_t>);
 BENCHMARK(BM_japanese_text<wchar_t>);
 BENCHMARK(BM_emoji_text<wchar_t>);
-#  endif
+#endif
 
 BENCHMARK_MAIN();
-
-#else
-int main(int, char**) { return 0; }
-#endif

--- a/libcxx/test/benchmarks/format/std_format_spec_string_unicode_escape.bench.cpp
+++ b/libcxx/test/benchmarks/format/std_format_spec_string_unicode_escape.bench.cpp
@@ -8,21 +8,20 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
+// UNSUPPORTED: libcpp-has-no-unicode
+
 // This test formats a larger piece of text in "escaped" mode. It uses several
 // datasets to give an impression how the amount of multibyte UTF-8 sequences
 // and larger grapheme clusters affect the performance.
 
-#  include <concepts>
-#  include <format>
-#  include <string_view>
+#include <concepts>
+#include <format>
+#include <string_view>
 
-#  include "benchmark/benchmark.h"
-#  include "make_string.h"
-#  include "test_macros.h"
+#include "benchmark/benchmark.h"
+#include "make_string.h"
 
-#if _LIBCPP_HAS_UNICODE
-
-#  define SV(S) MAKE_STRING_VIEW(CharT, S)
+#define SV(S) MAKE_STRING_VIEW(CharT, S)
 
 // generated with https://generator.lorem-ipsum.info/_latin
 
@@ -288,16 +287,12 @@ BENCHMARK(BM_cyrillic_escaped<char>);
 BENCHMARK(BM_japanese_escaped<char>);
 BENCHMARK(BM_emoji_escaped<char>);
 
-#  ifndef TEST_HAS_NO_WIDE_CHARACTERS
+#ifndef TEST_HAS_NO_WIDE_CHARACTERS
 BENCHMARK(BM_ascii_escaped<wchar_t>);
 BENCHMARK(BM_unicode_escaped<wchar_t>);
 BENCHMARK(BM_cyrillic_escaped<wchar_t>);
 BENCHMARK(BM_japanese_escaped<wchar_t>);
 BENCHMARK(BM_emoji_escaped<wchar_t>);
-#  endif
+#endif
 
 BENCHMARK_MAIN();
-
-#else
-int main(int, char**) { return 0; }
-#endif


### PR DESCRIPTION
This is probably a relic from when we didn't use lit to run benchmarks. Nowadays we should just use the lit features to disable benchmarks like we do in any other test instead of using the preprocessor.
