### PR TITLE
Remove Kadir as clangd maintainer

### DIFF
--- a/clang-tools-extra/Maintainers.rst
+++ b/clang-tools-extra/Maintainers.rst
@@ -57,9 +57,6 @@ clangd
 | Chris Bieneman
 | chris.bieneman@gmail.com (email), llvm-beanz (GitHub), beanz (Discord), beanz (Discourse)
 
-| Kadir Çetinkaya
-| kadircet@google.com (email), kadircet (GitHub) kadircet (Discourse), kadircet (Discord)
-
 
 Inactive Maintainers
 ====================
@@ -79,3 +76,4 @@ Inactive component maintainers
 | Sam McCall (sammccall@google.com (email), sam-mccall (GitHub, Discourse, Discord)) -- clangd
 | Peter Chou (peterchou411@gmail.com (email), PeterChou1 (GitHub, Discourse), .peterchou (Discord)) -- clang-doc
 | Piotr Zegar (me@piotrzegar.pl (email), PiotrZSL (GitHub), PiotrZSL (Discourse), PiotrZSL (Discord)) -- clang-tidy
+| Kadir Çetinkaya (kadircet@google.com (email), kadircet (GitHub) kadircet (Discourse), kadircet (Discord)) -- clangd


### PR DESCRIPTION
When doing the maintainer list refresh, Kadir mentioned he'd like to become inactive due to other commitments. Thank you for all that you've done for clangd!