### PR TITLE
[Hexagon] Fix use-after-poison in balanceSubTree

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
@@ -1785,7 +1785,8 @@ static bool isOpcodeHandled(const SDNode *N) {
     case ISD::SHL:
       // We only handle constant shifts because these can be easily flattened
       // into multiplications by 2^Op1.
-      return isa<ConstantSDNode>(N->getOperand(1).getNode());
+      return N->getNumOperands() >= 2 &&
+             isa<ConstantSDNode>(N->getOperand(1).getNode());
     default:
       return false;
   }
@@ -1909,7 +1910,7 @@ WeightedLeaf LeafPrioQueue::findSHL(uint64_t MaxAmount) {
   for (int Pos = 0, End = Q.size(); Pos != End; ++Pos) {
     const WeightedLeaf &L = Q[Pos];
     const SDValue &Val = L.Value;
-    if (Val.getOpcode() != ISD::SHL ||
+    if (Val.getOpcode() != ISD::SHL || Val.getNumOperands() < 2 ||
         !isa<ConstantSDNode>(Val.getOperand(1)) ||
         Val.getConstantOperandVal(1) > MaxAmount)
       continue;
@@ -1936,7 +1937,7 @@ WeightedLeaf LeafPrioQueue::findMULbyConst() {
   for (int Pos = 0, End = Q.size(); Pos != End; ++Pos) {
     const WeightedLeaf &L = Q[Pos];
     const SDValue &Val = L.Value;
-    if (Val.getOpcode() != ISD::MUL ||
+    if (Val.getOpcode() != ISD::MUL || Val.getNumOperands() < 2 ||
         !isa<ConstantSDNode>(Val.getOperand(1)) ||
         Val.getConstantOperandVal(1) > 127)
       continue;
@@ -1957,6 +1958,8 @@ WeightedLeaf LeafPrioQueue::findMULbyConst() {
 }
 
 SDValue HexagonDAGToDAGISel::getMultiplierForSHL(SDNode *N) {
+  if (N->getNumOperands() < 2)
+    return SDValue();
   uint64_t MulFactor = 1ull << N->getConstantOperandVal(1);
   return CurDAG->getConstant(MulFactor, SDLoc(N),
                              N->getOperand(1).getValueType());
@@ -1965,6 +1968,8 @@ SDValue HexagonDAGToDAGISel::getMultiplierForSHL(SDNode *N) {
 /// @returns the value x for which 2^x is a factor of Val
 static unsigned getPowerOf2Factor(SDValue Val) {
   if (Val.getOpcode() == ISD::MUL) {
+    if (Val.getNumOperands() < 2)
+      return 0;
     unsigned MaxFactor = 0;
     for (int i = 0; i < 2; ++i) {
       ConstantSDNode *C = dyn_cast<ConstantSDNode>(Val.getOperand(i));
@@ -1977,7 +1982,8 @@ static unsigned getPowerOf2Factor(SDValue Val) {
     return MaxFactor;
   }
   if (Val.getOpcode() == ISD::SHL) {
-    if (!isa<ConstantSDNode>(Val.getOperand(1).getNode()))
+    if (Val.getNumOperands() < 2 ||
+        !isa<ConstantSDNode>(Val.getOperand(1).getNode()))
       return 0;
     return (unsigned) Val.getConstantOperandVal(1);
   }
@@ -1988,6 +1994,8 @@ static unsigned getPowerOf2Factor(SDValue Val) {
 /// @returns true if V>>Amount will eliminate V's operation on its child
 static bool willShiftRightEliminate(SDValue V, unsigned Amount) {
   if (V.getOpcode() == ISD::MUL) {
+    if (V.getNumOperands() < 2)
+      return false;
     SDValue Ops[] = { V.getOperand(0), V.getOperand(1) };
     for (int i = 0; i < 2; ++i)
       if (isa<ConstantSDNode>(Ops[i].getNode()) &&
@@ -1996,6 +2004,9 @@ static bool willShiftRightEliminate(SDValue V, unsigned Amount) {
         return (NewConst == 1);
       }
   } else if (V.getOpcode() == ISD::SHL) {
+    if (V.getNumOperands() < 2 ||
+        !isa<ConstantSDNode>(V.getOperand(1).getNode()))
+      return false;
     return (Amount == V.getConstantOperandVal(1));
   }
 
@@ -2003,6 +2014,10 @@ static bool willShiftRightEliminate(SDValue V, unsigned Amount) {
 }
 
 SDValue HexagonDAGToDAGISel::factorOutPowerOf2(SDValue V, unsigned Power) {
+  // Ensure the node has at least 2 operands before accessing them.
+  if (V.getNumOperands() < 2)
+    return V;
+
   SDValue Ops[] = { V.getOperand(0), V.getOperand(1) };
   if (V.getOpcode() == ISD::MUL) {
     for (int i=0; i < 2; ++i) {
@@ -2017,6 +2032,8 @@ SDValue HexagonDAGToDAGISel::factorOutPowerOf2(SDValue V, unsigned Power) {
       }
     }
   } else if (V.getOpcode() == ISD::SHL) {
+    if (!isa<ConstantSDNode>(V.getOperand(1).getNode()))
+      return V;
     uint64_t ShiftAmount = V.getConstantOperandVal(1);
     if (ShiftAmount == Power)
       return Ops[0];
@@ -2066,6 +2083,9 @@ SDValue HexagonDAGToDAGISel::balanceSubTree(SDNode *N, bool TopLevel) {
 
   assert(isOpcodeHandled(N));
 
+  if (N->getNumOperands() < 2)
+    return SDValue(N, 0);
+
   SDValue Op0 = N->getOperand(0);
   SDValue Op1 = N->getOperand(1);
 
@@ -2080,7 +2100,7 @@ SDValue HexagonDAGToDAGISel::balanceSubTree(SDNode *N, bool TopLevel) {
     } else
       Weight = getWeight(Op0N);
 
-    SDNode *Op1N = N->getOperand(1).getNode(); // Op1 may have been RAUWd
+    SDNode *Op1N = Op1.getNode();
     if (isOpcodeHandled(Op1N) && RootWeights[Op1N] == -1) {
       Weight += getWeight(balanceSubTree(Op1N).getNode());
       // Weight += calculateWeight(Op1N);
@@ -2088,8 +2108,18 @@ SDValue HexagonDAGToDAGISel::balanceSubTree(SDNode *N, bool TopLevel) {
       Weight += getWeight(Op1N);
 
     RootWeights[N] = Weight;
-    RootHeights[N] = std::max(getHeight(N->getOperand(0).getNode()),
-                              getHeight(N->getOperand(1).getNode())) + 1;
+
+    // After recursive calls, check if Op0/Op1 are still valid before getting
+    // height
+    int Height0 = 0, Height1 = 0;
+    if (isOpcodeHandled(Op0N) && RootWeights.count(Op0N) &&
+        RootWeights[Op0N] >= 0)
+      Height0 = getHeight(Op0N);
+    if (isOpcodeHandled(Op1N) && RootWeights.count(Op1N) &&
+        RootWeights[Op1N] >= 0)
+      Height1 = getHeight(Op1N);
+
+    RootHeights[N] = std::max(Height0, Height1) + 1;
 
     LLVM_DEBUG(dbgs() << "--> No need to balance root (Weight=" << Weight
                       << " Height=" << RootHeights[N] << "): ");
@@ -2121,9 +2151,9 @@ SDValue HexagonDAGToDAGISel::balanceSubTree(SDNode *N, bool TopLevel) {
   bool HaveTopLevelShift = false;
   if (TopLevel &&
       ((isOpcodeHandled(Op0.getNode()) && Op0.getOpcode() == ISD::SHL &&
-                        Op0.getConstantOperandVal(1) < 4) ||
+        Op0.getNumOperands() >= 2 && Op0.getConstantOperandVal(1) < 4) ||
        (isOpcodeHandled(Op1.getNode()) && Op1.getOpcode() == ISD::SHL &&
-                        Op1.getConstantOperandVal(1) < 4)))
+        Op1.getNumOperands() >= 2 && Op1.getConstantOperandVal(1) < 4)))
     HaveTopLevelShift = true;
 
   // Flatten the subtree into an ordered list of leaves; at the same time
@@ -2194,11 +2224,21 @@ SDValue HexagonDAGToDAGISel::balanceSubTree(SDNode *N, bool TopLevel) {
       assert(ChildOpcode == NOpcode ||
              (NOpcode == ISD::MUL && ChildOpcode == ISD::SHL));
 
+      if (Child->getNumOperands() < 2) {
+        // Treat as a leaf if not enough operands
+        int Weight = getWeight(Child.getNode());
+        NodeHeights[Child] = getHeight(Child.getNode());
+        CurrentWeight += Weight;
+        Leaves.push(WeightedLeaf(Child, Weight, InsertionOrder++));
+        continue;
+      }
+
       // Convert SHL to MUL
       SDValue Op1;
-      if (ChildOpcode == ISD::SHL)
+      if (ChildOpcode == ISD::SHL) {
         Op1 = getMultiplierForSHL(Child.getNode());
-      else
+        assert(Op1.getNode() && "getMultiplierForSHL returned null");
+      } else
         Op1 = Child->getOperand(1);
 
       if (!NodeHeights.count(Op1) || !NodeHeights.count(Child->getOperand(0))) {
@@ -2253,7 +2293,8 @@ SDValue HexagonDAGToDAGISel::balanceSubTree(SDNode *N, bool TopLevel) {
   // amount of additional constant extenders introduced by this optimization.
   bool CombinedGA = false;
   if (NOpcode == ISD::ADD && GA.Value.getNode() && Leaves.hasConst() &&
-      GA.Value.hasOneUse() && N->use_size() < 3) {
+      GA.Value.hasOneUse() && N->use_size() < 3 &&
+      GA.Value.getNumOperands() >= 1) {
     GlobalAddressSDNode *GANode =
       cast<GlobalAddressSDNode>(GA.Value.getOperand(0));
     ConstantSDNode *Offset = cast<ConstantSDNode>(Leaves.top().Value);
@@ -2379,7 +2420,7 @@ SDValue HexagonDAGToDAGISel::balanceSubTree(SDNode *N, bool TopLevel) {
   int Height = NodeHeights[NewRoot];
 
   // Restore SHL if we earlier converted it to a MUL
-  if (NewRoot.getOpcode() == ISD::MUL) {
+  if (NewRoot.getOpcode() == ISD::MUL && NewRoot->getNumOperands() >= 2) {
     ConstantSDNode *V1C = dyn_cast<ConstantSDNode>(NewRoot.getOperand(1));
     if (V1C && V1C->getAPIntValue().isPowerOf2()) {
       EVT VT = NewRoot.getValueType();
@@ -2430,6 +2471,9 @@ void HexagonDAGToDAGISel::rebalanceAddressTrees() {
     // FindRoots
     SmallVector<SDNode *, 4> Worklist;
 
+    if (BasePtr->getNumOperands() < 2)
+      continue;
+
     Worklist.push_back(BasePtr.getOperand(0).getNode());
     Worklist.push_back(BasePtr.getOperand(1).getNode());
 
@@ -2438,6 +2482,9 @@ void HexagonDAGToDAGISel::rebalanceAddressTrees() {
       unsigned Opcode = N->getOpcode();
 
       if (!isOpcodeHandled(N))
+        continue;
+
+      if (N->getNumOperands() < 2)
         continue;
 
       Worklist.push_back(N->getOperand(0).getNode());
@@ -2455,12 +2502,15 @@ void HexagonDAGToDAGISel::rebalanceAddressTrees() {
     RootWeights[BasePtr.getNode()] = -1;
     SDValue NewBasePtr = balanceSubTree(BasePtr.getNode(), /*TopLevel=*/ true);
 
-    if (N->getOpcode() == ISD::LOAD)
-      N = CurDAG->UpdateNodeOperands(N, N->getOperand(0),
-            NewBasePtr, N->getOperand(2));
-    else
-      N = CurDAG->UpdateNodeOperands(N, N->getOperand(0), N->getOperand(1),
-            NewBasePtr, N->getOperand(3));
+    if (N->getOpcode() == ISD::LOAD) {
+      if (N->getNumOperands() >= 3)
+        N = CurDAG->UpdateNodeOperands(N, N->getOperand(0), NewBasePtr,
+                                       N->getOperand(2));
+    } else {
+      if (N->getNumOperands() >= 4)
+        N = CurDAG->UpdateNodeOperands(N, N->getOperand(0), N->getOperand(1),
+                                       NewBasePtr, N->getOperand(3));
+    }
 
     LLVM_DEBUG(dbgs() << "--> Final node: ");
     LLVM_DEBUG(N->dump(CurDAG));

--- a/llvm/test/CodeGen/Hexagon/dag-isel-balancetree-rauw.ll
+++ b/llvm/test/CodeGen/Hexagon/dag-isel-balancetree-rauw.ll
@@ -1,0 +1,22 @@
+; RUN: llc -march=hexagon < %s | FileCheck %s
+;
+; Test that the DAG ISel address tree balancing does not crash when nodes
+; are replaced (RAUW'd) during balancing. This is a regression test for
+; GitHub issue #64371 where use-after-poison occurred in balanceSubTree().
+;
+; The specific pattern that triggers the issue involves nested adds used
+; in address calculations with null pointers, causing nodes to be replaced
+; during the balancing process.
+
+; CHECK-LABEL: f:
+; CHECK: memb
+; CHECK: memb
+define void @f(i32 %LGV1, ptr %RP) {
+  %G6 = getelementptr i32, ptr null, i32 %LGV1
+  %B1 = add i32 %LGV1, %LGV1
+  store i1 false, ptr %G6, align 1
+  %B2 = add i32 %LGV1, %B1
+  %G1 = getelementptr float, ptr %RP, i32 %B2
+  store i1 false, ptr %G1, align 1
+  ret void
+}


### PR DESCRIPTION
The balanceSubTree() function in HexagonISelDAGToDAG was accessing node operands after recursive calls that could invalidate those nodes through RAUW.

Use pre-captured Op0/Op1 values instead of re-accessing N's operands after BST calls, add bounds checking before accessing node operands in several places, check if nodes were RAUW'd before calling getHeight() on them.