### PR TITLE
InstCombine: Fix SimplifyDemandedFPClass bug with known-snan sources

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2261,6 +2261,8 @@ simplifyDemandedUseFPClassFPTrunc(InstCombinerImpl &IC, Instruction &I,
                                   KnownFPClass &Known, unsigned Depth) {
 
   FPClassTest SrcDemandedMask = DemandedMask;
+  if (DemandedMask & fcNan)
+    SrcDemandedMask |= fcNan;
 
   // Zero results may have been rounded from subnormal or normal sources.
   if (DemandedMask & fcNegZero)
@@ -2366,6 +2368,8 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       DenormalMode Mode = F.getDenormalMode(EltTy->getFltSemantics());
 
       FPClassTest SrcDemandedMask = DemandedMask;
+      if (DemandedMask & fcNan)
+        SrcDemandedMask |= fcNan;
 
       // Doubling a subnormal could have resulted in a normal value.
       if (DemandedMask & fcPosNormal)
@@ -2465,7 +2469,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
 
     if (DemandedMask & fcNan) {
       // mul +/-inf, 0 => nan
-      SrcDemandedMask |= fcZero | fcInf;
+      SrcDemandedMask |= fcZero | fcInf | fcNan;
 
       // TODO: Mode check
       // mul +/-inf, sub => nan if daz
@@ -2645,7 +2649,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       // Subnormal is added in case of DAZ, but this isn't strictly
       // necessary. Every other input class implies a possible subnormal source,
       // so this only could matter in the degenerate case of only-nan results.
-      SrcDemandedMask |= fcZero | fcInf;
+      SrcDemandedMask |= fcZero | fcInf | fcNan;
     }
 
     // Zero outputs may be the result of underflow.
@@ -2731,6 +2735,8 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
                                              Known, Depth);
   case Instruction::FPExt: {
     FPClassTest SrcDemandedMask = DemandedMask;
+    if (DemandedMask & fcNan)
+      SrcDemandedMask |= fcNan;
 
     // No subnormal result does not imply not-subnormal in the source type.
     if ((DemandedMask & fcNegNormal) != fcNone)
@@ -2828,7 +2834,9 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
     case Intrinsic::fmuladd: {
       // We can't do any simplification on the source besides stripping out
       // unneeded nans.
-      FPClassTest SrcDemandedMask = (DemandedMask & fcNan) | ~fcNan;
+      FPClassTest SrcDemandedMask = DemandedMask | ~fcNan;
+      if (DemandedMask & fcNan)
+        SrcDemandedMask |= fcNan;
 
       KnownFPClass KnownSrc[3];
 
@@ -2870,7 +2878,9 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       // operands (e.g., a known-positive result could have been clamped), but
       // we can still prune known-nan inputs.
       FPClassTest SrcDemandedMask =
-          PropagateNaN ? DemandedMask | ~fcNan : fcAllFlags;
+          PropagateNaN && ((DemandedMask & fcNan) == fcNone)
+              ? DemandedMask | ~fcNan
+              : fcAllFlags;
 
       KnownFPClass KnownLHS, KnownRHS;
       if (SimplifyDemandedFPClass(CI, 1, SrcDemandedMask, KnownRHS,
@@ -2937,6 +2947,8 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       }
 
       FPClassTest SrcDemandedMask = DemandedMask & fcNan;
+      if (DemandedMask & fcNan)
+        SrcDemandedMask |= fcNan;
 
       if (DemandedMask & fcZero) {
         // exp(-infinity) = 0
@@ -3022,6 +3034,8 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
     case Intrinsic::log2:
     case Intrinsic::log10: {
       FPClassTest DemandedSrcMask = DemandedMask & (fcNan | fcPosInf);
+      if (DemandedMask & fcNan)
+        DemandedSrcMask |= fcNan;
 
       Type *EltTy = VTy->getScalarType();
       DenormalMode Mode = F.getDenormalMode(EltTy->getFltSemantics());
@@ -3061,7 +3075,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
           DemandedMask & (fcNegZero | fcPositive | fcNan);
 
       if (DemandedMask & fcNan)
-        DemandedSrcMask |= (fcNegative & ~fcNegZero);
+        DemandedSrcMask |= fcNan | (fcNegative & ~fcNegZero);
 
       // sqrt(max_subnormal) is a normal value
       if (DemandedMask & fcPosNormal)
@@ -3111,6 +3125,8 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
     case Intrinsic::round:
     case Intrinsic::roundeven: {
       FPClassTest DemandedSrcMask = DemandedMask;
+      if (DemandedMask & fcNan)
+        DemandedSrcMask |= fcNan;
 
       // Zero results imply valid subnormal sources.
       if (DemandedMask & fcNegZero)

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-exp.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-exp.ll
@@ -609,7 +609,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_src(i1 %cond, float %unkn
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_src(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.exp.f32(float [[UNKNOWN]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.exp.f32(float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
@@ -2049,7 +2049,7 @@ define nofpclass(snan) half @qnan_result_self_demands_snan(i1 noundef %cond, hal
 ; CHECK-SAME: i1 noundef [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call noundef half @returns_snan()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[SNAN]], half [[UNKNOWN]]
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[UNKNOWN]], [[SELECT]]
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[SELECT]], [[SELECT]]
 ; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %snan = call noundef half @returns_snan()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fdiv.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fdiv.ll
@@ -2300,7 +2300,8 @@ define nofpclass(snan) half @qnan_result_demands_snan_src_lhs(i1 %cond, half %un
 ; CHECK-LABEL: define nofpclass(snan) half @qnan_result_demands_snan_src_lhs(
 ; CHECK-SAME: i1 [[COND:%.*]], half [[UNKNOWN0:%.*]], half [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call half @returns_snan()
-; CHECK-NEXT:    [[MUL:%.*]] = fdiv half [[UNKNOWN0]], [[UNKNOWN1]]
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[SNAN]], half [[UNKNOWN0]]
+; CHECK-NEXT:    [[MUL:%.*]] = fdiv half [[SELECT]], [[UNKNOWN1]]
 ; CHECK-NEXT:    ret half [[MUL]]
 ;
   %snan = call half @returns_snan()
@@ -2313,7 +2314,8 @@ define nofpclass(snan) half @qnan_result_demands_snan_src_rhs(i1 %cond, half %un
 ; CHECK-LABEL: define nofpclass(snan) half @qnan_result_demands_snan_src_rhs(
 ; CHECK-SAME: i1 [[COND:%.*]], half [[UNKNOWN0:%.*]], half [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call half @returns_snan()
-; CHECK-NEXT:    [[MUL:%.*]] = fdiv half [[UNKNOWN1]], [[UNKNOWN0]]
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[SNAN]], half [[UNKNOWN0]]
+; CHECK-NEXT:    [[MUL:%.*]] = fdiv half [[UNKNOWN1]], [[SELECT]]
 ; CHECK-NEXT:    ret half [[MUL]]
 ;
   %snan = call half @returns_snan()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fma.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fma.ll
@@ -297,7 +297,8 @@ define nofpclass(snan) half @qnan_result_demands_snan_square_src0(i1 noundef %co
 ; CHECK-LABEL: define nofpclass(snan) half @qnan_result_demands_snan_square_src0(
 ; CHECK-SAME: i1 noundef [[COND:%.*]], half noundef [[UNKNOWN0:%.*]], half noundef [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call half @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fma.f16(half [[UNKNOWN0]], half [[UNKNOWN0]], half [[UNKNOWN1]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[SNAN]], half [[UNKNOWN0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fma.f16(half [[SELECT]], half [[SELECT]], half [[UNKNOWN1]])
 ; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %snan = call half @returns_snan()
@@ -310,7 +311,8 @@ define nofpclass(snan) half @qnan_result_demands_snan_square_src1(i1 noundef %co
 ; CHECK-LABEL: define nofpclass(snan) half @qnan_result_demands_snan_square_src1(
 ; CHECK-SAME: i1 noundef [[COND:%.*]], half noundef [[UNKNOWN0:%.*]], half noundef [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call half @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fma.f16(half [[UNKNOWN1]], half [[UNKNOWN1]], half [[UNKNOWN0]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[SNAN]], half [[UNKNOWN0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fma.f16(half [[UNKNOWN1]], half [[UNKNOWN1]], half [[SELECT]])
 ; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %snan = call half @returns_snan()
@@ -323,7 +325,8 @@ define nofpclass(snan) half @qnan_result_demands_snan_src0(i1 %cond, half %unkno
 ; CHECK-LABEL: define nofpclass(snan) half @qnan_result_demands_snan_src0(
 ; CHECK-SAME: i1 [[COND:%.*]], half [[UNKNOWN0:%.*]], half [[UNKNOWN1:%.*]], half [[UNKNOWN2:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call half @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fma.f16(half [[UNKNOWN0]], half [[UNKNOWN1]], half [[UNKNOWN2]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[SNAN]], half [[UNKNOWN0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fma.f16(half [[SELECT]], half [[UNKNOWN1]], half [[UNKNOWN2]])
 ; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %snan = call half @returns_snan()
@@ -336,7 +339,8 @@ define nofpclass(snan) half @qnan_result_demands_snan_src1(i1 %cond, half %unkno
 ; CHECK-LABEL: define nofpclass(snan) half @qnan_result_demands_snan_src1(
 ; CHECK-SAME: i1 [[COND:%.*]], half [[UNKNOWN0:%.*]], half [[UNKNOWN1:%.*]], half [[UNKNOWN2:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call half @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fma.f16(half [[UNKNOWN1]], half [[UNKNOWN0]], half [[UNKNOWN2]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[SNAN]], half [[UNKNOWN0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fma.f16(half [[UNKNOWN1]], half [[SELECT]], half [[UNKNOWN2]])
 ; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %snan = call half @returns_snan()
@@ -349,7 +353,8 @@ define nofpclass(snan) half @qnan_result_demands_snan_src2(i1 %cond, half %unkno
 ; CHECK-LABEL: define nofpclass(snan) half @qnan_result_demands_snan_src2(
 ; CHECK-SAME: i1 [[COND:%.*]], half [[UNKNOWN0:%.*]], half [[UNKNOWN1:%.*]], half [[UNKNOWN2:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call half @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fma.f16(half [[UNKNOWN1]], half [[UNKNOWN2]], half [[UNKNOWN0]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[SNAN]], half [[UNKNOWN0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fma.f16(half [[UNKNOWN1]], half [[UNKNOWN2]], half [[SELECT]])
 ; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %snan = call half @returns_snan()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fmul.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fmul.ll
@@ -1407,7 +1407,8 @@ define nofpclass(snan) float @qnan_result_square_demands_snan(i1 noundef %cond, 
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_square_demands_snan(
 ; CHECK-SAME: i1 noundef [[COND:%.*]], float noundef [[UNKNOWN0:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call noundef float @returns_snan()
-; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[UNKNOWN0]], [[UNKNOWN0]]
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN0]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[SELECT]], [[SELECT]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %snan = call noundef float @returns_snan()
@@ -1420,7 +1421,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_lhs(i1 %cond, float %unkn
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_lhs(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[UNKNOWN0]], [[UNKNOWN1]]
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN0]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[SELECT]], [[UNKNOWN1]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %snan = call float @returns_snan()
@@ -1433,7 +1435,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_rhs(i1 %cond, float %unkn
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_rhs(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[UNKNOWN1]], [[UNKNOWN0]]
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN0]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[UNKNOWN1]], [[SELECT]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %snan = call float @returns_snan()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fpext.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fpext.ll
@@ -476,7 +476,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_src(i1 %cond, half %unkno
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_src(
 ; CHECK-SAME: i1 [[COND:%.*]], half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call half @returns_snan_f16()
-; CHECK-NEXT:    [[RESULT:%.*]] = fpext half [[UNKNOWN]] to float
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[SNAN]], half [[UNKNOWN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = fpext half [[SELECT]] to float
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call half @returns_snan_f16()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fptrunc-round.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fptrunc-round.ll
@@ -623,7 +623,8 @@ define nofpclass(snan) half @qnan_result_demands_snan_src2(i1 %cond, float %unkn
 ; CHECK-LABEL: define nofpclass(snan) half @qnan_result_demands_snan_src2(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan_f32()
-; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fptrunc.round.f16.f32(float [[UNKNOWN0]], metadata !"round.downward")
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call half @llvm.fptrunc.round.f16.f32(float [[SELECT]], metadata !"round.downward")
 ; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %snan = call float @returns_snan_f32()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fptrunc.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fptrunc.ll
@@ -611,7 +611,8 @@ define nofpclass(snan) half @qnan_result_demands_snan_src2(i1 %cond, float %unkn
 ; CHECK-LABEL: define nofpclass(snan) half @qnan_result_demands_snan_src2(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan_f32()
-; CHECK-NEXT:    [[RESULT:%.*]] = fptrunc float [[UNKNOWN0]] to half
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = fptrunc float [[SELECT]] to half
 ; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %snan = call float @returns_snan_f32()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-log.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-log.ll
@@ -357,7 +357,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_src(i1 %cond, float %unkn
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_src(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.log.f32(float [[UNKNOWN]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.log.f32(float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximum.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximum.ll
@@ -2164,7 +2164,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_lhs(i1 %cond, float %unkn
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_lhs(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[SELECT]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()
@@ -2177,7 +2178,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_rhs(i1 %cond, float %unkn
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_rhs(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN1]], float [[UNKNOWN0]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN1]], float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-minimum.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-minimum.ll
@@ -2153,7 +2153,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_lhs(i1 %cond, float %unkn
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_lhs(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[SELECT]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()
@@ -2166,7 +2167,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_rhs(i1 %cond, float %unkn
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_rhs(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN1]], float [[UNKNOWN0]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN0]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN1]], float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-rounding-intrinsics.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-rounding-intrinsics.ll
@@ -1248,7 +1248,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_src__trunc(i1 %cond, floa
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_src__trunc(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.trunc.f32(float [[UNKNOWN]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.trunc.f32(float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()
@@ -1261,7 +1262,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_src__floor(i1 %cond, floa
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_src__floor(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.floor.f32(float [[UNKNOWN]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.floor.f32(float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()
@@ -1274,7 +1276,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_src__ceil(i1 %cond, float
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_src__ceil(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.ceil.f32(float [[UNKNOWN]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.ceil.f32(float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()
@@ -1287,7 +1290,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_src__rint(i1 %cond, float
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_src__rint(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.rint.f32(float [[UNKNOWN]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.rint.f32(float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()
@@ -1300,7 +1304,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_src__nearbyint(i1 %cond, 
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_src__nearbyint(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.nearbyint.f32(float [[UNKNOWN]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.nearbyint.f32(float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()
@@ -1313,7 +1318,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_src__round(i1 %cond, floa
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_src__round(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.round.f32(float [[UNKNOWN]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.round.f32(float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()
@@ -1326,7 +1332,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_src__roundeven(i1 %cond, 
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_src__roundeven(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.roundeven.f32(float [[UNKNOWN]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.roundeven.f32(float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-sqrt.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-sqrt.ll
@@ -349,7 +349,8 @@ define nofpclass(snan) float @qnan_result_demands_snan_src(i1 %cond, float %unkn
 ; CHECK-LABEL: define nofpclass(snan) float @qnan_result_demands_snan_src(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SNAN:%.*]] = call float @returns_snan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.sqrt.f32(float [[UNKNOWN]])
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SNAN]], float [[UNKNOWN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.sqrt.f32(float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %snan = call float @returns_snan()


### PR DESCRIPTION
If the result can be a qnan, the source can be a signaling nan.