### PR TITLE
[CIR] Add TargetLowering pass

### DIFF
--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -18,12 +18,14 @@
 namespace clang {
 class ASTContext;
 }
+
 namespace mlir {
 
 std::unique_ptr<Pass> createCIRCanonicalizePass();
 std::unique_ptr<Pass> createCIRFlattenCFGPass();
 std::unique_ptr<Pass> createCIRSimplifyPass();
 std::unique_ptr<Pass> createCXXABILoweringPass();
+std::unique_ptr<Pass> createTargetLoweringPass();
 std::unique_ptr<Pass> createHoistAllocasPass();
 std::unique_ptr<Pass> createLoweringPreparePass();
 std::unique_ptr<Pass> createLoweringPreparePass(clang::ASTContext *astCtx);

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -83,15 +83,72 @@ def GotoSolver : Pass<"cir-goto-solver"> {
 }
 
 def CXXABILowering : Pass<"cir-cxxabi-lowering", "mlir::ModuleOp"> {
-  let summary = "Lower abstract C++ operations to target-specific ABI form";
+  let summary = "Lower CIR according to C++ ABI requirements";
   let description = [{
-    This pass lowers high-level operations that represent C++ constructs in a
-    target-independent way to concrete, target specific operations.
+    This pass lowers CIR operations and types that represent high-level C/C++
+    constructs to a more fundamental form according to the target ABI
+    requirements.
+
+    See the description of the `TargetLowering` pass for the difference between
+    this pass and the `TargetLowering` pass.
   }];
   let constructor = "mlir::createCXXABILoweringPass()";
   let dependentDialects = ["cir::CIRDialect"];
 }
 
+def TargetLowering : Pass<"cir-target-lowering", "mlir::ModuleOp"> {
+  let summary = "Lower CIR to a target-specific form";
+  let description = [{
+    This pass lowers CIR operations from a target-agnostic form to a
+    target-specific form without considering ABI requirements.
+
+    CIR has three passes in its lowering pipeline that transform input CIR
+    according to target-specific requirements, scheduled in the pipeline by the
+    following order:
+
+      1. The `TargetLowering` pass.
+      2. The `CXXABILowering` pass.
+      3. The `CallConvLowering` pass (not implemented yet).
+
+    The `TargetLowering` pass acts more like a legalization pass. It ensures
+    every operation in CIR conforms to the target's constraints. An example
+    would be the handling of synchronization scopes of atomic operations. The
+    x86 family of targets only support a system-wide synchronization scope, thus
+    any atomic operations with a different synchronization scope would be
+    transformed to use the system-wide scope in this pass.
+
+    The `CXXABILowering` pass and the (not yet implemented) `CallConvLowering`
+    pass transform the CIR according to the target's ABI requirements. The
+    former handles all ABI-related lowering except for calling convention
+    handling, which is handled specifically in the latter. Example
+    transformations that the `CXXABILowering` pass could make include:
+
+      - Replace C/C++ types that have an ABI-defined layout with more
+        fundamental types corresponding to the ABI requirements. For example,
+        the layout of the pointer-to-data-member type in C++ is ABI-defined,
+        thus the `CXXABILowering` pass would replace all occurrences of this
+        type according to the ABI requirements. With a typical target ABI, it
+        will be replaced by the `ptrdiff_t` type since this is the type most
+        ABIs use for the layout of the pointer-to-data-member type.
+      - Replace CIR operations that have ABI-dependent implementations with more
+        fundamental operations. For example, the `dynamic_cast` operator in C++
+        is implemented in an ABI-dependent way, typically by calling into a
+        library function provided by the implementation. The `CXXABILowering`
+        pass would thus replace all `cir.dyn_cast` operations with corresponding
+        library function calls.
+
+    The `CallConvLowering` pass is dedicated to handle calling conventions. It
+    rewrites function signatures according to calling convention requirements,
+    and updates function body and call sites accordingly. For example, when
+    passing a large struct by value in C/C++, most ABIs require passing a
+    pointer to a copy of the struct instead. Thus, the `CallConvLowering` pass
+    would rewrite function signatures that take a value of a large struct type
+    to take a pointer to the struct type instead, and update the function body
+    and the call sites accordingly.
+  }];
+  let constructor = "mlir::createTargetLoweringPass()";
+  let dependentDialects = ["cir::CIRDialect"];
+}
 
 def LoweringPrepare : Pass<"cir-lowering-prepare"> {
   let summary = "Lower to more fine-grained CIR operations before lowering to "

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_clang_library(MLIRCIRTransforms
   CIRCanonicalize.cpp
   CIRSimplify.cpp
   CXXABILowering.cpp
+  TargetLowering.cpp
   FlattenCFG.cpp
   HoistAllocas.cpp
   LoweringPrepare.cpp

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering.cpp
@@ -1,0 +1,68 @@
+//===- TargetLowering.cpp -------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the cir-target-lowering pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TargetLowering/LowerModule.h"
+
+#include "mlir/Support/LLVM.h"
+#include "clang/CIR/Dialect/Passes.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace cir;
+
+namespace mlir {
+#define GEN_PASS_DEF_TARGETLOWERING
+#include "clang/CIR/Dialect/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+
+struct TargetLoweringPass
+    : public impl::TargetLoweringBase<TargetLoweringPass> {
+  TargetLoweringPass() = default;
+  void runOnOperation() override;
+};
+
+} // namespace
+
+static void convertSyncScopeIfPresent(mlir::Operation *op,
+                                      cir::LowerModule &lowerModule) {
+  auto syncScopeAttr =
+      mlir::cast_if_present<cir::SyncScopeKindAttr>(op->getAttr("sync_scope"));
+  if (syncScopeAttr) {
+    cir::SyncScopeKind convertedSyncScope =
+        lowerModule.getTargetLoweringInfo().convertSyncScope(
+            syncScopeAttr.getValue());
+    op->setAttr("sync_scope", cir::SyncScopeKindAttr::get(op->getContext(),
+                                                          convertedSyncScope));
+  }
+}
+
+void TargetLoweringPass::runOnOperation() {
+  auto mod = mlir::cast<mlir::ModuleOp>(getOperation());
+  std::unique_ptr<cir::LowerModule> lowerModule = cir::createLowerModule(mod);
+  // If lower module is not available, skip the target lowering pass.
+  if (!lowerModule) {
+    mod.emitWarning("Cannot create a CIR lower module, skipping the ")
+        << getName() << " pass";
+    return;
+  }
+
+  mod->walk([&](mlir::Operation *op) {
+    if (mlir::isa<cir::LoadOp, cir::StoreOp>(op))
+      convertSyncScopeIfPresent(op, *lowerModule);
+  });
+}
+
+std::unique_ptr<Pass> mlir::createTargetLoweringPass() {
+  return std::make_unique<TargetLoweringPass>();
+}

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
@@ -31,12 +31,11 @@ class LowerModule {
   const std::unique_ptr<clang::TargetInfo> target;
   std::unique_ptr<TargetLoweringInfo> targetLoweringInfo;
   std::unique_ptr<CIRCXXABI> abi;
-  [[maybe_unused]] mlir::PatternRewriter &rewriter;
 
 public:
   LowerModule(clang::LangOptions langOpts, clang::CodeGenOptions codeGenOpts,
-              mlir::ModuleOp &module, std::unique_ptr<clang::TargetInfo> target,
-              mlir::PatternRewriter &rewriter);
+              mlir::ModuleOp &module,
+              std::unique_ptr<clang::TargetInfo> target);
   ~LowerModule() = default;
 
   clang::TargetCXXABI::Kind getCXXABIKind() const {
@@ -51,8 +50,7 @@ public:
   const TargetLoweringInfo &getTargetLoweringInfo();
 };
 
-std::unique_ptr<LowerModule> createLowerModule(mlir::ModuleOp module,
-                                               mlir::PatternRewriter &rewriter);
+std::unique_ptr<LowerModule> createLowerModule(mlir::ModuleOp module);
 
 } // namespace cir
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetLoweringInfo.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetLoweringInfo.cpp
@@ -17,9 +17,10 @@ namespace cir {
 
 TargetLoweringInfo::~TargetLoweringInfo() = default;
 
-std::string
-TargetLoweringInfo::getLLVMSyncScope(cir::SyncScopeKind syncScope) const {
-  return ""; // default sync scope
+cir::SyncScopeKind
+TargetLoweringInfo::convertSyncScope(cir::SyncScopeKind syncScope) const {
+  // By default, targets don't deal with sync scopes other than system scope.
+  return cir::SyncScopeKind::System;
 }
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetLoweringInfo.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/TargetLoweringInfo.h
@@ -15,7 +15,6 @@
 #define LLVM_CLANG_LIB_CIR_DIALECT_TRANSFORMS_TARGETLOWERING_TARGETLOWERINGINFO_H
 
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
-#include <string>
 
 namespace cir {
 
@@ -23,7 +22,8 @@ class TargetLoweringInfo {
 public:
   virtual ~TargetLoweringInfo();
 
-  virtual std::string getLLVMSyncScope(cir::SyncScopeKind syncScope) const;
+  virtual cir::SyncScopeKind
+  convertSyncScope(cir::SyncScopeKind syncScope) const;
 };
 
 } // namespace cir

--- a/clang/lib/CIR/Lowering/CIRPasses.cpp
+++ b/clang/lib/CIR/Lowering/CIRPasses.cpp
@@ -31,6 +31,7 @@ mlir::LogicalResult runCIRToCIRPasses(mlir::ModuleOp theModule,
   if (enableCIRSimplify)
     pm.addPass(mlir::createCIRSimplifyPass());
 
+  pm.addPass(mlir::createTargetLoweringPass());
   pm.addPass(mlir::createCXXABILoweringPass());
   pm.addPass(mlir::createLoweringPreparePass(&astContext));
 

--- a/clang/test/CIR/CodeGen/atomic-scoped.c
+++ b/clang/test/CIR/CodeGen/atomic-scoped.c
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-target-lowering %s -o %t.cir 2>%t-before-target-lowering.cir
+// RUN: FileCheck --input-file=%t-before-target-lowering.cir %s --check-prefixes=CIR-BEFORE-TL
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
@@ -6,17 +7,20 @@
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
 
 void scoped_atomic_load(int *ptr) {
+  // CIR-BEFORE-TL-LABEL: @scoped_atomic_load
   // CIR-LABEL: @scoped_atomic_load
   // LLVM-LABEL: @scoped_atomic_load
   // OGCG-LABEL: @scoped_atomic_load
 
   int x;
   __scoped_atomic_load(ptr, &x, __ATOMIC_RELAXED, __MEMORY_SCOPE_SINGLE);
-  // CIR: %{{.+}} = cir.load align(4) syncscope(single_thread) atomic(relaxed) %{{.+}} : !cir.ptr<!s32i>, !s32i
+  // CIR-BEFORE-TL: %{{.+}} = cir.load align(4) syncscope(single_thread) atomic(relaxed) %{{.+}} : !cir.ptr<!s32i>, !s32i
+  // CIR: %{{.+}} = cir.load align(4) syncscope(system) atomic(relaxed) %{{.+}} : !cir.ptr<!s32i>, !s32i
   // LLVM: %{{.+}} = load atomic i32, ptr %{{.+}} monotonic, align 4
   // OGCG: %{{.+}} = load atomic i32, ptr %{{.+}} monotonic, align 4
 
   __scoped_atomic_load(ptr, &x, __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
+  // CIR-BEFORE-TL: %{{.+}} = cir.load align(4) syncscope(system) atomic(relaxed) %{{.+}} : !cir.ptr<!s32i>, !s32i
   // CIR: %{{.+}} = cir.load align(4) syncscope(system) atomic(relaxed) %{{.+}} : !cir.ptr<!s32i>, !s32i
   // LLVM: %{{.+}} = load atomic i32, ptr %{{.+}} monotonic, align 4
   // OGCG: %{{.+}} = load atomic i32, ptr %{{.+}} monotonic, align 4
@@ -29,11 +33,13 @@ void scoped_atomic_load_n(int *ptr) {
 
   int x;
   x = __scoped_atomic_load_n(ptr, __ATOMIC_RELAXED, __MEMORY_SCOPE_SINGLE);
-  // CIR: %{{.+}} = cir.load align(4) syncscope(single_thread) atomic(relaxed) %{{.+}} : !cir.ptr<!s32i>, !s32i
+  // CIR-BEFORE-TL: %{{.+}} = cir.load align(4) syncscope(single_thread) atomic(relaxed) %{{.+}} : !cir.ptr<!s32i>, !s32i
+  // CIR: %{{.+}} = cir.load align(4) syncscope(system) atomic(relaxed) %{{.+}} : !cir.ptr<!s32i>, !s32i
   // LLVM: %{{.+}} = load atomic i32, ptr %{{.+}} monotonic, align 4
   // OGCG: %{{.+}} = load atomic i32, ptr %{{.+}} monotonic, align 4
 
   x = __scoped_atomic_load_n(ptr, __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
+  // CIR-BEFORE-TL: %{{.+}} = cir.load align(4) syncscope(system) atomic(relaxed) %{{.+}} : !cir.ptr<!s32i>, !s32i
   // CIR: %{{.+}} = cir.load align(4) syncscope(system) atomic(relaxed) %{{.+}} : !cir.ptr<!s32i>, !s32i
   // LLVM: %{{.+}} = load atomic i32, ptr %{{.+}} monotonic, align 4
   // OGCG: %{{.+}} = load atomic i32, ptr %{{.+}} monotonic, align 4
@@ -45,11 +51,13 @@ void scoped_atomic_store(int *ptr, int value) {
   // OGCG-LABEL: @scoped_atomic_store
 
   __scoped_atomic_store(ptr, &value, __ATOMIC_RELAXED, __MEMORY_SCOPE_SINGLE);
-  // CIR: cir.store align(4) syncscope(single_thread) atomic(relaxed) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
+  // CIR-BEFORE-TL: cir.store align(4) syncscope(single_thread) atomic(relaxed) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
+  // CIR: cir.store align(4) syncscope(system) atomic(relaxed) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
   // LLVM: store atomic i32 %{{.+}}, ptr %{{.+}} monotonic, align 4
   // OGCG: store atomic i32 %{{.+}}, ptr %{{.+}} monotonic, align 4
 
   __scoped_atomic_store(ptr, &value, __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
+  // CIR-BEFORE-TL: cir.store align(4) syncscope(system) atomic(relaxed) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
   // CIR: cir.store align(4) syncscope(system) atomic(relaxed) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
   // LLVM: store atomic i32 %{{.+}}, ptr %{{.+}} monotonic, align 4
   // OGCG: store atomic i32 %{{.+}}, ptr %{{.+}} monotonic, align 4
@@ -61,11 +69,13 @@ void scoped_atomic_store_n(int *ptr, int value) {
   // OGCG-LABEL: @scoped_atomic_store_n
 
   __scoped_atomic_store_n(ptr, value, __ATOMIC_RELAXED, __MEMORY_SCOPE_SINGLE);
-  // CIR: cir.store align(4) syncscope(single_thread) atomic(relaxed) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
+  // CIR-BEFORE-TL: cir.store align(4) syncscope(single_thread) atomic(relaxed) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
+  // CIR: cir.store align(4) syncscope(system) atomic(relaxed) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
   // LLVM: store atomic i32 %{{.+}}, ptr %{{.+}} monotonic, align 4
   // OGCG: store atomic i32 %{{.+}}, ptr %{{.+}} monotonic, align 4
 
   __scoped_atomic_store_n(ptr, value, __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
+  // CIR-BEFORE-TL: cir.store align(4) syncscope(system) atomic(relaxed) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
   // CIR: cir.store align(4) syncscope(system) atomic(relaxed) %{{.+}}, %{{.+}} : !s32i, !cir.ptr<!s32i>
   // LLVM: store atomic i32 %{{.+}}, ptr %{{.+}} monotonic, align 4
   // OGCG: store atomic i32 %{{.+}}, ptr %{{.+}} monotonic, align 4


### PR DESCRIPTION
This patch adds a new TargetLowering pass to the CIR pipeline. The new pass is run immediately before CXXABILowering. This new pass does not perform any heavy transformations yet -- for now it only converts sync scopes attached to load and store operations according to the target info, which was done in the LLVM lowering pass.

Related to #175968 .