### PR TITLE
[libc++] Default BUILDKITE_PULL_REQUEST_BASE_BRANCH to main when unset

### DIFF
--- a/libcxx/utils/ci/buildkite-pipeline-trigger.sh
+++ b/libcxx/utils/ci/buildkite-pipeline-trigger.sh
@@ -12,8 +12,8 @@
 # LLVM monorepo, and we make it a no-op unless the libc++ pipeline needs to be triggered.
 #
 
-# Set by buildkite
-: ${BUILDKITE_PULL_REQUEST_BASE_BRANCH:=}
+# Set by buildkite (may be unset for cross-fork PRs)
+: ${BUILDKITE_PULL_REQUEST_BASE_BRANCH:=main}
 
 # Fetch origin to have an up to date merge base for the diff.
 git fetch origin


### PR DESCRIPTION
The libcxx Buildkite trigger step fails when `BUILDKITE_PULL_REQUEST_BASE_BRANCH` is unset (e.g. for cross-fork PRs), because `git diff origin/...HEAD` is an invalid revision.

Default to `main` when the variable is unset so the script can determine modified files and exit cleanly with "No Buildkite jobs to trigger" when only non-libcxx paths are changed.

This fixes Buildkite CI failures for PRs from forks where the base branch env is not set.