### PR TITLE
[PowerPC] Only set QualName symbol on first section switch

### DIFF
--- a/llvm/lib/MC/MCXCOFFStreamer.cpp
+++ b/llvm/lib/MC/MCXCOFFStreamer.cpp
@@ -45,8 +45,12 @@ void MCXCOFFStreamer::changeSection(MCSection *Section, uint32_t Subsection) {
   // sections because we don't have other cases that hit this problem yet.
   // if (IsDwarfSec || CsectProp->MappingClass == XCOFF::XMC_PR)
   //   QualName->setFragment(F);
-  if (Sec->isDwarfSect() || Sec->getMappingClass() == XCOFF::XMC_PR)
-    Sec->getQualNameSymbol()->setFragment(CurFrag);
+  if (Sec->isDwarfSect() || Sec->getMappingClass() == XCOFF::XMC_PR) {
+    MCSymbol *QualNameSymbol = Sec->getQualNameSymbol();
+    // Only set the fragment the first time we're switching to the section.
+    if (!QualNameSymbol->isInSection())
+      QualNameSymbol->setFragment(CurFrag);
+  }
 }
 
 bool MCXCOFFStreamer::emitSymbolAttribute(MCSymbol *Sym,

--- a/llvm/test/CodeGen/PowerPC/aix-debug-aranges.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-debug-aranges.ll
@@ -1,0 +1,28 @@
+; RUN: llc -filetype=obj -function-sections -generate-arange-section < %s | \
+; RUN: llvm-objdump -dr - | FileCheck %s
+
+; Make sure that enabling debug_arange does not corrupt branches.
+
+target triple = "powerpc64-ibm-aix"
+
+define i64 @fn1() {
+; CHECK-LABEL: <.fn1>:
+; CHECK: bl {{.*}} <.fn2>
+; CHECK-NEXT: R_RBR .fn2
+  %1 = call i64 @fn2()
+  ret i64 %1
+}
+
+define i64 @fn2() !dbg !4 {
+  ret i64 0
+}
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !2, producer: "clang LLVM (rustc version 1.95.0-dev)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3, globals: !3, splitDebugInlining: false, nameTableKind: None)
+!2 = !DIFile(filename: "foo", directory: "")
+!3 = !{}
+!4 = distinct !DISubprogram(name: "fn2", file: !2, line: 277, type: !5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !1, templateParams: !3, retainedNodes: !3)
+!5 = !DISubroutineType(types: !3)


### PR DESCRIPTION
We were setting it every time when switching to the section. This caused problems when the debug_aranges emission performed a switch at the end of the section, resulting in symbols incorrectly pointing to the end instead of the start of the function.