### PR TITLE
[docs] Fix a small error in the Programmer's Manual

### DIFF
--- a/llvm/docs/ProgrammersManual.rst
+++ b/llvm/docs/ProgrammersManual.rst
@@ -391,7 +391,7 @@ doxygen documentation or by looking at the unit test suite.
   S = formatv("{0,+7}", 'a');  // S == "      a";
 
   // Custom styles
-  S = formatv("{0:N} - {0:x} - {1:E}", 12345, 123908342); // S == "12,345 - 0x3039 - 1.24E8"
+  S = formatv("{0:N} - {0:x}", 12345); // S == "12,345 - 0x3039"
 
   // Adapters
   S = formatv("{0}", fmt_align(42, AlignStyle::Center, 7));  // S == "  42   "


### PR DESCRIPTION
We remove from the Programmer's Manual reference to the "E" formatting style for the "int" values because this style is not defined by the corresponding [formatter class](https://github.com/llvm/llvm-project/blob/70914cc246b3842ef4f46b50c03a9b1df648a5b5/llvm/include/llvm/Support/FormatProviders.h#L96-L143).