### PR TITLE
[Github] Fully remove use of login_or_token

### DIFF
--- a/.ci/premerge_advisor_explain.py
+++ b/.ci/premerge_advisor_explain.py
@@ -33,7 +33,9 @@ def get_comment(
     pr_number: int,
     body: str,
 ) -> dict[str, str]:
-    repo = github.Github(github_token).get_repo("llvm/llvm-project")
+    repo = github.Github(auth=github.Auth.Token(github_token)).get_repo(
+        "llvm/llvm-project"
+    )
     pr = repo.get_issue(pr_number).as_pull_request()
     body = COMMENT_TAG.format(platform=platform.system()) + "\n" + body
     comment = {"body": body}

--- a/.github/workflows/commit-create-issue.py
+++ b/.github/workflows/commit-create-issue.py
@@ -2,7 +2,7 @@ import github
 import sys
 
 token = sys.argv[1]
-gh = github.Github(login_or_token=token)
+gh = github.Github(auth=github.Auth.Token(token))
 repo = gh.get_repo("llvm/llvm-project")
 
 length = "4 weeks"

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -124,7 +124,7 @@ View the diff from {self.name} here.
         import github
         from github import IssueComment, PullRequest
 
-        repo = github.Github(args.token).get_repo(args.repo)
+        repo = github.Github(auth=github.Auth.Token(args.token)).get_repo(args.repo)
         pr = repo.get_issue(args.issue_number).as_pull_request()
 
         comment_text = self.comment_tag + "\n\n" + comment_text

--- a/llvm/utils/git/code-lint-helper.py
+++ b/llvm/utils/git/code-lint-helper.py
@@ -111,7 +111,7 @@ View the output from {self.name} here.
 
     def update_pr(self, comment_text: str, args: LintArgs, create_new: bool) -> None:
         assert args.repo is not None
-        repo = github.Github(args.token).get_repo(args.repo)
+        repo = github.Github(auth=github.Auth.Token(args.token)).get_repo(args.repo)
         pr = repo.get_issue(args.issue_number).as_pull_request()
 
         comment_text = f"{self.comment_tag}\n\n{comment_text}"

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -66,8 +66,10 @@ class IssueSubscriber:
         return self._team_name
 
     def __init__(self, token: str, repo: str, issue_number: int, label_name: str):
-        self.repo = github.Github(token).get_repo(repo)
-        self.org = github.Github(token).get_organization(self.repo.organization.login)
+        self.repo = github.Github(auth=github.Auth.Token(token)).get_repo(repo)
+        self.org = github.Github(auth=github.Auth.Token(token)).get_organization(
+            self.repo.organization.login
+        )
         self.issue = self.repo.get_issue(issue_number)
         self._team_name = "issue-subscribers-{}".format(label_name).lower()
 
@@ -111,8 +113,10 @@ class PRSubscriber:
         return self._team_name
 
     def __init__(self, token: str, repo: str, pr_number: int, label_name: str):
-        self.repo = github.Github(token).get_repo(repo)
-        self.org = github.Github(token).get_organization(self.repo.organization.login)
+        self.repo = github.Github(auth=github.Auth.Token(token)).get_repo(repo)
+        self.org = github.Github(auth=github.Auth.Token(token)).get_organization(
+            self.repo.organization.login
+        )
         self.pr = self.repo.get_issue(pr_number).as_pull_request()
         self._team_name = "pr-subscribers-{}".format(
             label_name.replace("+", "x")
@@ -230,7 +234,7 @@ class PRGreeter:
     COMMENT_TAG = "<!--LLVM NEW CONTRIBUTOR COMMENT-->\n"
 
     def __init__(self, token: str, repo: str, pr_number: int):
-        repo = github.Github(token).get_repo(repo)
+        repo = github.Github(auth=github.Auth.Token(token)).get_repo(repo)
         self.pr = repo.get_issue(pr_number).as_pull_request()
 
     def run(self) -> bool:
@@ -260,7 +264,7 @@ You can also ask questions in a comment on this PR, on the [LLVM Discord](https:
 
 class CommitRequestGreeter:
     def __init__(self, token: str, repo: str, issue_number: int):
-        self.repo = github.Github(token).get_repo(repo)
+        self.repo = github.Github(auth=github.Auth.Token(token)).get_repo(repo)
         self.issue = self.repo.get_issue(issue_number)
 
     def run(self) -> bool:
@@ -323,7 +327,7 @@ class PRBuildbotInformation:
     COMMENT_TAG = "<!--LLVM BUILDBOT INFORMATION COMMENT-->\n"
 
     def __init__(self, token: str, repo: str, pr_number: int, author: str):
-        repo = github.Github(token).get_repo(repo)
+        repo = github.Github(auth=github.Auth.Token(token)).get_repo(repo)
         self.pr = repo.get_issue(pr_number).as_pull_request()
         self.author = author
 
@@ -460,7 +464,9 @@ class ReleaseWorkflow:
 
     @property
     def repo(self) -> github.Repository.Repository:
-        return github.Github(self.token).get_repo(self.repo_name)
+        return github.Github(auth=github.Auth.Token(self.token)).get_repo(
+            self.repo_name
+        )
 
     @property
     def issue(self) -> github.Issue.Issue:
@@ -725,7 +731,9 @@ class ReleaseWorkflow:
         https://docs.github.com/en/get-started/quickstart/github-glossary#base-branch
         https://docs.github.com/en/get-started/quickstart/github-glossary#compare-branch
         """
-        repo = github.Github(self.token).get_repo(self.repo_name)
+        repo = github.Github(auth=github.Auth.Token(self.token)).get_repo(
+            self.repo_name
+        )
         issue_ref = "{}#{}".format(self.repo_name, self.issue_number)
         pull = None
         release_branch_for_issue = self.release_branch_for_issue
@@ -800,7 +808,7 @@ class ReleaseWorkflow:
 
 
 def request_release_note(token: str, repo_name: str, pr_number: int):
-    repo = github.Github(token).get_repo(repo_name)
+    repo = github.Github(auth=github.Auth.Token(token)).get_repo(repo_name)
     pr = repo.get_issue(pr_number).as_pull_request()
     submitter = pr.user.login
     if submitter == "llvmbot":

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -280,7 +280,7 @@ parser.add_argument("--files", nargs="+", type=str)
 
 args = parser.parse_args()
 
-gh = github.Github(args.token)
+gh = github.Github(auth=github.Auth.Token(args.token))
 llvm_org = gh.get_organization("llvm")
 llvm_repo = llvm_org.get_repo("llvm-project")
 
@@ -291,7 +291,7 @@ if args.user:
     # Validate that this user is allowed to modify releases.
     user = gh.get_user(args.user)
     team = (
-        github.Github(args.user_token)
+        github.Github(auth=github.Auth.Token(args.user_token))
         .get_organization("llvm")
         .get_team_by_slug("llvm-release-managers")
     )


### PR DESCRIPTION
PyGithub deprecated this a while back. An earlier patch attempted to fix all the deprecations, but it looks like my grep expression missed a bunch of cases. This patch should catch the remaining ones (minus libc++ which have been split for review by libc++ maintainers).