### PR TITLE
[flang][OpenMP] Add source range to construct scopes

### DIFF
--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
@@ -479,8 +479,7 @@ void DataSharingProcessor::collectSymbols(
         for (const semantics::Scope &child : scope->children())
           collectScopes(&child);
       };
-  parser::CharBlock source =
-      clauses.empty() ? getSource(semaCtx, eval) : clauses.front().source;
+  parser::CharBlock source = getSource(semaCtx, eval);
   const semantics::Scope *curScope = nullptr;
   if (!source.empty()) {
     curScope = &semaCtx.FindScope(source);

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1575,6 +1575,10 @@ public:
   static bool NeedsScope(const parser::OmpBlockConstruct &);
   static bool NeedsScope(const parser::OmpClause &);
 
+  bool Pre(const parser::OpenMPRequiresConstruct &x) {
+    AddOmpSourceRange(x.source);
+    return true;
+  }
   bool Pre(const parser::OmpBlockConstruct &);
   void Post(const parser::OmpBlockConstruct &);
   bool Pre(const parser::OmpBeginDirective &x) {

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -1812,7 +1812,7 @@ void OmpVisitor::AddOmpSourceRange(const parser::CharBlock &source) {
 }
 
 void OmpVisitor::PushScopeWithSource(
-      Scope::Kind kind, parser::CharBlock source, Symbol *symbol) {
+    Scope::Kind kind, parser::CharBlock source, Symbol *symbol) {
   PushScope(kind, symbol);
   currScope().AddSourceRange(source);
 }


### PR DESCRIPTION
Make sure to add the source range whenever we create a scope for an OpenMP construct or a clause. This allows that scope to be located via context.FindScope(source).