### PR TITLE
[HLSL] Amend f32tof16() and f16tof32() tests

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/f16tof32-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/f16tof32-builtin.hlsl
@@ -1,30 +1,51 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl \
+// RUN:   -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -O0 -o - | \
+// RUN:   FileCheck %s
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl \
+// RUN:   -triple spirv-unknown-vulkan-compute %s -emit-llvm -O0 -o - | \
+// RUN:   FileCheck %s --check-prefix=SPIRV
 
 // CHECK: define hidden noundef nofpclass(nan inf) float
 // CHECK: %hlsl.f16tof32 = call reassoc nnan ninf nsz arcp afn float @llvm.dx.legacyf16tof32.i32(i32 %0)
 // CHECK: ret float %hlsl.f16tof32
 // CHECK: declare float @llvm.dx.legacyf16tof32.i32(i32)
+//
+// SPIRV: define hidden spir_func noundef nofpclass(nan inf) float @_Z11test_scalarj(i32 noundef %p0) #0 {
+// SPIRV: %[[U1:[0-9]+]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]])
+// SPIRV: %[[R1:[0-9]+]] = extractelement <2 x float> %[[U1]], i64 0
+// SPIRV: ret float %[[R1]]
+// SPIRV: declare <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32) #2
 float test_scalar(uint p0) { return __builtin_hlsl_elementwise_f16tof32(p0); }
 
 // CHECK: define hidden noundef nofpclass(nan inf) <2 x float>
 // CHECK: %hlsl.f16tof32 = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.dx.legacyf16tof32.v2i32(<2 x i32> %0)
 // CHECK: ret <2 x float> %hlsl.f16tof32
 // CHECK: declare <2 x float> @llvm.dx.legacyf16tof32.v2i32(<2 x i32>)
+//
+// SPIRV: define hidden spir_func noundef nofpclass(nan inf) <2 x float> @_Z10test_uint2Dv2_j(<2 x i32> noundef %p0) #0 {
+// SPRIV-COUNT-2: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]]
+// SPRIV-NOT: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]])
+// SPIRV: ret <2 x float> %9
 float2 test_uint2(uint2 p0) { return __builtin_hlsl_elementwise_f16tof32(p0); }
 
 // CHECK: define hidden noundef nofpclass(nan inf) <3 x float> @_Z10test_uint3Dv3_j(<3 x i32> noundef %p0) #0 {
 // CHECK: %hlsl.f16tof32 = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.dx.legacyf16tof32.v3i32(<3 x i32> %0)
 // CHECK: ret <3 x float> %hlsl.f16tof32
 // CHECK: declare <3 x float> @llvm.dx.legacyf16tof32.v3i32(<3 x i32>)
+//
+// SPIRV: define hidden spir_func noundef nofpclass(nan inf) <3 x float> @_Z10test_uint3Dv3_j(<3 x i32> noundef %p0) #0 {
+// SPRIV-COUNT-3: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]]
+// SPRIV-NOT: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]])
+// SPIRV: ret <3 x float> %13
 float3 test_uint3(uint3 p0) { return __builtin_hlsl_elementwise_f16tof32(p0); }
 
 // CHECK: define hidden noundef nofpclass(nan inf) <4 x float> @_Z10test_uint4Dv4_j(<4 x i32> noundef %p0) #0 {
 // CHECK: %hlsl.f16tof32 = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.legacyf16tof32.v4i32(<4 x i32> %0)
 // CHECK: ret <4 x float> %hlsl.f16tof32
 // CHECK: declare <4 x float> @llvm.dx.legacyf16tof32.v4i32(<4 x i32>)
+//
+// SPRIV: define hidden spir_func noundef nofpclass(nan inf) <4 x float> @_Z10test_uint4Dv4_j(<4 x i32> noundef %p0) #0 {
+// SPRIV-COUNT-4: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]]
+// SPRIV-NOT: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]])
+// SPRIV: ret <4 x float> %[[#]]
 float4 test_uint4(uint4 p0) { return __builtin_hlsl_elementwise_f16tof32(p0); }
-
-
-

--- a/clang/test/CodeGenHLSL/builtins/f16tof32.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/f16tof32.hlsl
@@ -1,30 +1,51 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl \
+// RUN:   -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -O0 -o - | \
+// RUN:   FileCheck %s
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl \
+// RUN:   -triple spirv-unknown-vulkan-compute %s -emit-llvm -O0 -o - | \
+// RUN:   FileCheck %s --check-prefix=SPIRV
 
 // CHECK: define hidden noundef nofpclass(nan inf) float
 // CHECK: %hlsl.f16tof32 = call reassoc nnan ninf nsz arcp afn float @llvm.dx.legacyf16tof32.i32(i32 %0)
 // CHECK: ret float %hlsl.f16tof32
 // CHECK: declare float @llvm.dx.legacyf16tof32.i32(i32)
+//
+// SPIRV: define hidden spir_func noundef nofpclass(nan inf) float @_Z11test_scalarj(i32 noundef %p0) #0 {
+// SPIRV: %[[U1:[0-9]+]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]])
+// SPIRV: %[[R1:[0-9]+]] = extractelement <2 x float> %[[U1]], i64 0
+// SPIRV: ret float %[[R1]]
+// SPIRV: declare <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32) #2
 float test_scalar(uint p0) { return f16tof32(p0); }
 
 // CHECK: define hidden noundef nofpclass(nan inf) <2 x float>
 // CHECK: %hlsl.f16tof32 = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.dx.legacyf16tof32.v2i32(<2 x i32> %0)
 // CHECK: ret <2 x float> %hlsl.f16tof32
 // CHECK: declare <2 x float> @llvm.dx.legacyf16tof32.v2i32(<2 x i32>)
+//
+// SPIRV: define hidden spir_func noundef nofpclass(nan inf) <2 x float> @_Z10test_uint2Dv2_j(<2 x i32> noundef %p0) #0 {
+// SPRIV-COUNT-2: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]]
+// SPRIV-NOT: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]])
+// SPIRV: ret <2 x float> %9
 float2 test_uint2(uint2 p0) { return f16tof32(p0); }
 
 // CHECK: define hidden noundef nofpclass(nan inf) <3 x float> @_Z10test_uint3Dv3_j(<3 x i32> noundef %p0) #0 {
 // CHECK: %hlsl.f16tof32 = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.dx.legacyf16tof32.v3i32(<3 x i32> %0)
 // CHECK: ret <3 x float> %hlsl.f16tof32
 // CHECK: declare <3 x float> @llvm.dx.legacyf16tof32.v3i32(<3 x i32>)
+//
+// SPIRV: define hidden spir_func noundef nofpclass(nan inf) <3 x float> @_Z10test_uint3Dv3_j(<3 x i32> noundef %p0) #0 {
+// SPRIV-COUNT-3: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]]
+// SPRIV-NOT: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]])
+// SPIRV: ret <3 x float> %13
 float3 test_uint3(uint3 p0) { return f16tof32(p0); }
 
 // CHECK: define hidden noundef nofpclass(nan inf) <4 x float> @_Z10test_uint4Dv4_j(<4 x i32> noundef %p0) #0 {
 // CHECK: %hlsl.f16tof32 = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.dx.legacyf16tof32.v4i32(<4 x i32> %0)
 // CHECK: ret <4 x float> %hlsl.f16tof32
 // CHECK: declare <4 x float> @llvm.dx.legacyf16tof32.v4i32(<4 x i32>)
+//
+// SPRIV: define hidden spir_func noundef nofpclass(nan inf) <4 x float> @_Z10test_uint4Dv4_j(<4 x i32> noundef %p0) #0 {
+// SPRIV-COUNT-4: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]]
+// SPRIV-NOT: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.spv.unpackhalf2x16.v2f32(i32 %[[#]])
+// SPRIV: ret <4 x float> %[[#]]
 float4 test_uint4(uint4 p0) { return f16tof32(p0); }
-
-
-

--- a/clang/test/CodeGenHLSL/builtins/f32tof16-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/f32tof16-builtin.hlsl
@@ -1,27 +1,51 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl \
+// RUN:   -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -O0 -o - | \
+// RUN:   FileCheck %s
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl \
+// RUN:   -triple spirv-unknown-vulkan-compute %s -emit-llvm -O0 -o - | \
+// RUN:   FileCheck %s --check-prefix=SPIRV
 
 // CHECK: define hidden noundef i32 @_Z11test_scalarf(float noundef nofpclass(nan inf) %p0) #0 {
 // CHECK: %hlsl.f32tof16 = call i32 @llvm.dx.legacyf32tof16.f32(float %0)
 // CHECK: ret i32 %hlsl.f32tof16
 // CHECK: declare i32 @llvm.dx.legacyf32tof16.f32(float) #1
+//
+// SPIRV: define hidden spir_func noundef i32 @_Z11test_scalarf(float noundef nofpclass(nan inf) %p0) #0 {
+// SPIRV: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV-NOT: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV: ret i32 %[[#]]
+// SPIRV: declare i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float>)
 uint test_scalar(float p0) { return __builtin_hlsl_elementwise_f32tof16(p0); }
 
 // CHECK: define hidden noundef <2 x i32> @_Z10test_uint2Dv2_f(<2 x float> noundef nofpclass(nan inf) %p0) #0 {
 // CHECK: %hlsl.f32tof16 = call <2 x i32> @llvm.dx.legacyf32tof16.v2f32(<2 x float> %0)
 // CHECK: ret <2 x i32> %hlsl.f32tof16
 // CHECK: declare <2 x i32> @llvm.dx.legacyf32tof16.v2f32(<2 x float>) #1
+//
+// SPIRV: define hidden spir_func noundef <2 x i32> @_Z10test_uint2Dv2_f(<2 x float> noundef nofpclass(nan inf) %p0) #0 {
+// SPIRV-COUNT-2: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV-NOT: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV: ret <2 x i32> %[[#]]
 uint2 test_uint2(float2 p0) { return __builtin_hlsl_elementwise_f32tof16(p0); }
 
 // CHECK: define hidden noundef <3 x i32> @_Z10test_uint3Dv3_f(<3 x float> noundef nofpclass(nan inf) %p0) #0 {
 // CHECK: %hlsl.f32tof16 = call <3 x i32> @llvm.dx.legacyf32tof16.v3f32(<3 x float> %0)
 // CHECK: ret <3 x i32> %hlsl.f32tof16
 // CHECK: declare <3 x i32> @llvm.dx.legacyf32tof16.v3f32(<3 x float>) #1
+//
+// SPIRV: define hidden spir_func noundef <3 x i32> @_Z10test_uint3Dv3_f(<3 x float> noundef nofpclass(nan inf) %p0) #0 {
+// SPIRV-COUNT-3: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV-NOT: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV: ret <3 x i32> %[[#]]
 uint3 test_uint3(float3 p0) { return __builtin_hlsl_elementwise_f32tof16(p0); }
 
 // CHECK: define hidden noundef <4 x i32> @_Z10test_uint4Dv4_f(<4 x float> noundef nofpclass(nan inf) %p0) #0 {
 // CHECK: %hlsl.f32tof16 = call <4 x i32> @llvm.dx.legacyf32tof16.v4f32(<4 x float> %0)
 // CHECK: ret <4 x i32> %hlsl.f32tof16
 // CHECK: declare <4 x i32> @llvm.dx.legacyf32tof16.v4f32(<4 x float>) #1
+//
+// SPIRV: define hidden spir_func noundef <4 x i32> @_Z10test_uint4Dv4_f(<4 x float> noundef nofpclass(nan inf) %p0) #0 {
+// SPIRV-COUNT-4: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV-NOT: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV: ret <4 x i32> %[[#]]
 uint4 test_uint4(float4 p0) { return __builtin_hlsl_elementwise_f32tof16(p0); }

--- a/clang/test/CodeGenHLSL/builtins/f32tof16.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/f32tof16.hlsl
@@ -1,27 +1,51 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl \
+// RUN:   -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -O0 -o - | \
+// RUN:   FileCheck %s
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl \
+// RUN:   -triple spirv-unknown-vulkan-compute %s -emit-llvm -O0 -o - | \
+// RUN:   FileCheck %s --check-prefix=SPIRV
 
 // CHECK: define hidden noundef i32 @_Z11test_scalarf(float noundef nofpclass(nan inf) %p0) #0 {
 // CHECK: %hlsl.f32tof16 = call i32 @llvm.dx.legacyf32tof16.f32(float %0)
 // CHECK: ret i32 %hlsl.f32tof16
 // CHECK: declare i32 @llvm.dx.legacyf32tof16.f32(float) #1
+//
+// SPIRV: define hidden spir_func noundef i32 @_Z11test_scalarf(float noundef nofpclass(nan inf) %p0) #0 {
+// SPIRV: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV-NOT: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV: ret i32 %[[#]]
+// SPIRV: declare i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float>)
 uint test_scalar(float p0) { return f32tof16(p0); }
 
 // CHECK: define hidden noundef <2 x i32> @_Z10test_uint2Dv2_f(<2 x float> noundef nofpclass(nan inf) %p0) #0 {
 // CHECK: %hlsl.f32tof16 = call <2 x i32> @llvm.dx.legacyf32tof16.v2f32(<2 x float> %0)
 // CHECK: ret <2 x i32> %hlsl.f32tof16
 // CHECK: declare <2 x i32> @llvm.dx.legacyf32tof16.v2f32(<2 x float>) #1
+//
+// SPIRV: define hidden spir_func noundef <2 x i32> @_Z10test_uint2Dv2_f(<2 x float> noundef nofpclass(nan inf) %p0) #0 {
+// SPIRV-COUNT-2: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV-NOT: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV: ret <2 x i32> %[[#]]
 uint2 test_uint2(float2 p0) { return f32tof16(p0); }
 
 // CHECK: define hidden noundef <3 x i32> @_Z10test_uint3Dv3_f(<3 x float> noundef nofpclass(nan inf) %p0) #0 {
 // CHECK: %hlsl.f32tof16 = call <3 x i32> @llvm.dx.legacyf32tof16.v3f32(<3 x float> %0)
 // CHECK: ret <3 x i32> %hlsl.f32tof16
 // CHECK: declare <3 x i32> @llvm.dx.legacyf32tof16.v3f32(<3 x float>) #1
+//
+// SPIRV: define hidden spir_func noundef <3 x i32> @_Z10test_uint3Dv3_f(<3 x float> noundef nofpclass(nan inf) %p0) #0 {
+// SPIRV-COUNT-3: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV-NOT: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV: ret <3 x i32> %[[#]]
 uint3 test_uint3(float3 p0) { return f32tof16(p0); }
 
 // CHECK: define hidden noundef <4 x i32> @_Z10test_uint4Dv4_f(<4 x float> noundef nofpclass(nan inf) %p0) #0 {
 // CHECK: %hlsl.f32tof16 = call <4 x i32> @llvm.dx.legacyf32tof16.v4f32(<4 x float> %0)
 // CHECK: ret <4 x i32> %hlsl.f32tof16
 // CHECK: declare <4 x i32> @llvm.dx.legacyf32tof16.v4f32(<4 x float>) #1
+//
+// SPIRV: define hidden spir_func noundef <4 x i32> @_Z10test_uint4Dv4_f(<4 x float> noundef nofpclass(nan inf) %p0) #0 {
+// SPIRV-COUNT-4: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV-NOT: call i32 @llvm.spv.packhalf2x16.i32.v2f32(<2 x float> %[[#]])
+// SPIRV: ret <4 x i32> %[[#]]
 uint4 test_uint4(float4 p0) { return f32tof16(p0); }


### PR DESCRIPTION
Amend the codegen tests for f32tof16() and f16tof32() to include SPIRV as a target in addition to DXIL.

Fixes #179257