### PR TITLE
[Github] Prevent updates to python version in release binaries workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,12 @@
       "matchPackageNames": ["windows", "macos"],
       "matchManagers": ["github-actions"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["actions/python-versions"],
+      "matchManagers": ["github-actions"],
+      "matchFileNames": ["release-binaries.yml"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This workflow needs special care around python versions. We should by default disable automatic python updates to this workflow.