### PR TITLE
[flang] Better "out of memory" error for failure to allocate a unit

### DIFF
--- a/flang-rt/lib/runtime/descriptor-io.cpp
+++ b/flang-rt/lib/runtime/descriptor-io.cpp
@@ -165,9 +165,9 @@ static RT_API_ATTRS common::optional<bool> DefinedFormattedIo(
     external->PopChildIo(child);
     if (!actualExternal) {
       // Close unit created for internal I/O above.
-      auto *closing{external->LookUpForClose(external->unitNumber())};
+      auto *closing{external->LookUpForClose(external->unitNumber(), handler)};
       RUNTIME_CHECK(handler, external == closing);
-      external->DestroyClosed();
+      external->DestroyClosed(handler);
     }
     if (startPos) {
       io.GotChar(io.InquirePos() - *startPos);

--- a/flang-rt/lib/runtime/extensions.cpp
+++ b/flang-rt/lib/runtime/extensions.cpp
@@ -478,8 +478,9 @@ void RTNAME(ShowDescriptor)(const Fortran::runtime::Descriptor *descr) {
 namespace io {
 std::int32_t RTNAME(Fseek)(int unitNumber, std::int64_t zeroBasedPos,
     int whence, const char *sourceFileName, int lineNumber) {
-  if (ExternalFileUnit * unit{ExternalFileUnit::LookUp(unitNumber)}) {
-    Terminator terminator{sourceFileName, lineNumber};
+  Terminator terminator{sourceFileName, lineNumber};
+  if (ExternalFileUnit *
+      unit{ExternalFileUnit::LookUp(unitNumber, terminator)}) {
     IoErrorHandler handler{terminator};
     if (unit->Fseek(
             zeroBasedPos, static_cast<enum FseekWhence>(whence), handler)) {
@@ -493,7 +494,9 @@ std::int32_t RTNAME(Fseek)(int unitNumber, std::int64_t zeroBasedPos,
 }
 
 std::int64_t RTNAME(Ftell)(int unitNumber) {
-  if (ExternalFileUnit * unit{ExternalFileUnit::LookUp(unitNumber)}) {
+  Terminator terminator{__FILE__, __LINE__};
+  if (ExternalFileUnit *
+      unit{ExternalFileUnit::LookUp(unitNumber, terminator)}) {
     return unit->InquirePos() - 1; // zero-based result
   } else {
     return -1;
@@ -501,7 +504,9 @@ std::int64_t RTNAME(Ftell)(int unitNumber) {
 }
 
 std::int32_t FORTRAN_PROCEDURE_NAME(fnum)(const int &unitNumber) {
-  if (ExternalFileUnit * unit{ExternalFileUnit::LookUp(unitNumber)}) {
+  Terminator terminator{__FILE__, __LINE__};
+  if (ExternalFileUnit *
+      unit{ExternalFileUnit::LookUp(unitNumber, terminator)}) {
     return unit->fd();
   } else {
     return -1;
@@ -509,7 +514,5 @@ std::int32_t FORTRAN_PROCEDURE_NAME(fnum)(const int &unitNumber) {
 }
 
 } // namespace io
-
 } // extern "C"
-
 } // namespace Fortran::runtime

--- a/flang-rt/lib/runtime/external-unit.cpp
+++ b/flang-rt/lib/runtime/external-unit.cpp
@@ -47,13 +47,13 @@ void FlushOutputOnCrash(const Terminator &terminator) {
   }
 }
 
-ExternalFileUnit *ExternalFileUnit::LookUp(int unit) {
-  return GetUnitMap().LookUp(unit);
+ExternalFileUnit *ExternalFileUnit::LookUp(int unit, Terminator &terminator) {
+  return GetUnitMap(terminator).LookUp(unit);
 }
 
 ExternalFileUnit *ExternalFileUnit::LookUpOrCreate(
     int unit, const Terminator &terminator, bool &wasExtant) {
-  return GetUnitMap().LookUpOrCreate(unit, terminator, wasExtant);
+  return GetUnitMap(terminator).LookUpOrCreate(unit, terminator, wasExtant);
 }
 
 ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
@@ -63,7 +63,8 @@ ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
   // not just created in the unitMap.
   CriticalSection critical{createOpenLock};
   bool exists{false};
-  ExternalFileUnit *result{GetUnitMap().LookUpOrCreate(unit, handler, exists)};
+  ExternalFileUnit *result{
+      GetUnitMap(handler).LookUpOrCreate(unit, handler, exists)};
   if (result && !exists) {
     common::optional<Action> action;
     if (dir == Direction::Output) {
@@ -73,8 +74,9 @@ ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
             dir == Direction::Input ? OpenStatus::Unknown : OpenStatus::Replace,
             action, Position::Rewind, Convert::Unknown, handler)) {
       // fort.N isn't a writable file
-      if (ExternalFileUnit * closed{LookUpForClose(result->unitNumber())}) {
-        closed->DestroyClosed();
+      if (ExternalFileUnit *
+          closed{LookUpForClose(result->unitNumber(), handler)}) {
+        closed->DestroyClosed(handler);
       }
       result = nullptr;
     } else {
@@ -85,26 +87,27 @@ ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
 }
 
 ExternalFileUnit *ExternalFileUnit::LookUp(
-    const char *path, std::size_t pathLen) {
-  return GetUnitMap().LookUp(path, pathLen);
+    const char *path, std::size_t pathLen, Terminator &terminator) {
+  return GetUnitMap(terminator).LookUp(path, pathLen);
 }
 
 ExternalFileUnit &ExternalFileUnit::CreateNew(
     int unit, const Terminator &terminator) {
   bool wasExtant{false};
   ExternalFileUnit *result{
-      GetUnitMap().LookUpOrCreate(unit, terminator, wasExtant)};
+      GetUnitMap(terminator).LookUpOrCreate(unit, terminator, wasExtant)};
   RUNTIME_CHECK(terminator, result && !wasExtant);
   return *result;
 }
 
-ExternalFileUnit *ExternalFileUnit::LookUpForClose(int unit) {
-  return GetUnitMap().LookUpForClose(unit);
+ExternalFileUnit *ExternalFileUnit::LookUpForClose(
+    int unit, Terminator &terminator) {
+  return GetUnitMap(terminator).LookUpForClose(unit);
 }
 
 ExternalFileUnit &ExternalFileUnit::NewUnit(
     const Terminator &terminator, bool forChildIo) {
-  ExternalFileUnit &unit{GetUnitMap().NewUnit(terminator)};
+  ExternalFileUnit &unit{GetUnitMap(terminator).NewUnit(terminator)};
   unit.createdForInternalChildIo_ = forChildIo;
   return unit;
 }
@@ -143,7 +146,7 @@ bool ExternalFileUnit::OpenUnit(common::optional<OpenStatus> status,
   }
   if (newPath.get() && newPathLength > 0) {
     if (const auto *already{
-            GetUnitMap().LookUp(newPath.get(), newPathLength)}) {
+            GetUnitMap(handler).LookUp(newPath.get(), newPathLength)}) {
       handler.SignalError(IostatOpenAlreadyConnected,
           "OPEN(UNIT=%d,FILE='%.*s'): file is already connected to unit %d",
           unitNumber_, static_cast<int>(newPathLength), newPath.get(),
@@ -213,8 +216,8 @@ void ExternalFileUnit::CloseUnit(CloseStatus status, IoErrorHandler &handler) {
   Close(status, handler);
 }
 
-void ExternalFileUnit::DestroyClosed() {
-  GetUnitMap().DestroyClosed(*this); // destroys *this
+void ExternalFileUnit::DestroyClosed(Terminator &terminator) {
+  GetUnitMap(terminator).DestroyClosed(*this); // destroys *this
 }
 
 Iostat ExternalFileUnit::SetDirection(Direction direction) {
@@ -242,8 +245,7 @@ Iostat ExternalFileUnit::SetDirection(Direction direction) {
   }
 }
 
-UnitMap &ExternalFileUnit::CreateUnitMap() {
-  Terminator terminator{__FILE__, __LINE__};
+UnitMap &ExternalFileUnit::CreateUnitMap(const Terminator &terminator) {
   IoErrorHandler handler{terminator};
   UnitMap &newUnitMap{*New<UnitMap>{terminator}().release()};
 
@@ -285,7 +287,7 @@ static void CloseAllExternalUnits() {
   ExternalFileUnit::CloseAll(handler);
 }
 
-UnitMap &ExternalFileUnit::GetUnitMap() {
+UnitMap &ExternalFileUnit::GetUnitMap(const Terminator &terminator) {
   if (unitMap) {
     return *unitMap;
   }
@@ -294,7 +296,7 @@ UnitMap &ExternalFileUnit::GetUnitMap() {
     if (unitMap) {
       return *unitMap;
     }
-    unitMap = &CreateUnitMap();
+    unitMap = &CreateUnitMap(terminator);
   }
   std::atexit(CloseAllExternalUnits);
   return *unitMap;

--- a/flang-rt/lib/runtime/io-api.cpp
+++ b/flang-rt/lib/runtime/io-api.cpp
@@ -308,7 +308,8 @@ Cookie IODEF(BeginOpenNewUnit)( // OPEN(NEWUNIT=j)
 Cookie IODEF(BeginWait)(ExternalUnit unitNumber, AsynchronousId id,
     const char *sourceFile, int sourceLine) {
   Terminator terminator{sourceFile, sourceLine};
-  if (ExternalFileUnit * unit{ExternalFileUnit::LookUp(unitNumber)}) {
+  if (ExternalFileUnit *
+      unit{ExternalFileUnit::LookUp(unitNumber, terminator)}) {
     if (unit->Wait(id)) {
       return &unit->BeginIoStatement<ExternalMiscIoStatementState>(terminator,
           *unit, ExternalMiscIoStatementState::Wait, sourceFile, sourceLine);
@@ -329,14 +330,16 @@ Cookie IODEF(BeginWaitAll)(
 Cookie IODEF(BeginClose)(
     ExternalUnit unitNumber, const char *sourceFile, int sourceLine) {
   Terminator terminator{sourceFile, sourceLine};
-  if (ExternalFileUnit * unit{ExternalFileUnit::LookUp(unitNumber)}) {
+  if (ExternalFileUnit *
+      unit{ExternalFileUnit::LookUp(unitNumber, terminator)}) {
     if (ChildIo * child{unit->GetChildIo()}) {
       return &child->BeginIoStatement<ErroneousIoStatementState>(
           IostatBadOpOnChildUnit, nullptr /* no unit */, sourceFile,
           sourceLine);
     }
   }
-  if (ExternalFileUnit * unit{ExternalFileUnit::LookUpForClose(unitNumber)}) {
+  if (ExternalFileUnit *
+      unit{ExternalFileUnit::LookUpForClose(unitNumber, terminator)}) {
     return &unit->BeginIoStatement<CloseStatementState>(
         terminator, *unit, sourceFile, sourceLine);
   } else {
@@ -348,7 +351,8 @@ Cookie IODEF(BeginClose)(
 Cookie IODEF(BeginFlush)(
     ExternalUnit unitNumber, const char *sourceFile, int sourceLine) {
   Terminator terminator{sourceFile, sourceLine};
-  if (ExternalFileUnit * unit{ExternalFileUnit::LookUp(unitNumber)}) {
+  if (ExternalFileUnit *
+      unit{ExternalFileUnit::LookUp(unitNumber, terminator)}) {
     if (ChildIo * child{unit->GetChildIo()}) {
       return &child->BeginIoStatement<ExternalMiscIoStatementState>(
           *unit, ExternalMiscIoStatementState::Flush, sourceFile, sourceLine);
@@ -366,7 +370,8 @@ Cookie IODEF(BeginFlush)(
 Cookie IODEF(BeginBackspace)(
     ExternalUnit unitNumber, const char *sourceFile, int sourceLine) {
   Terminator terminator{sourceFile, sourceLine};
-  if (ExternalFileUnit * unit{ExternalFileUnit::LookUp(unitNumber)}) {
+  if (ExternalFileUnit *
+      unit{ExternalFileUnit::LookUp(unitNumber, terminator)}) {
     if (ChildIo * child{unit->GetChildIo()}) {
       return &child->BeginIoStatement<ErroneousIoStatementState>(
           IostatBadOpOnChildUnit, nullptr /* no unit */, sourceFile,
@@ -424,7 +429,8 @@ Cookie IODEF(BeginRewind)(
 Cookie IODEF(BeginInquireUnit)(
     ExternalUnit unitNumber, const char *sourceFile, int sourceLine) {
   Terminator terminator{sourceFile, sourceLine};
-  if (ExternalFileUnit * unit{ExternalFileUnit::LookUp(unitNumber)}) {
+  if (ExternalFileUnit *
+      unit{ExternalFileUnit::LookUp(unitNumber, terminator)}) {
     if (ChildIo * child{unit->GetChildIo()}) {
       return &child->BeginIoStatement<InquireUnitState>(
           *unit, sourceFile, sourceLine);
@@ -447,8 +453,8 @@ Cookie IODEF(BeginInquireFile)(const char *path, std::size_t pathLength,
   auto trimmed{SaveDefaultCharacter(
       path, TrimTrailingSpaces(path, pathLength), terminator)};
   if (ExternalFileUnit *
-      unit{ExternalFileUnit::LookUp(
-          trimmed.get(), Fortran::runtime::strlen(trimmed.get()))}) {
+      unit{ExternalFileUnit::LookUp(trimmed.get(),
+          Fortran::runtime::strlen(trimmed.get()), terminator)}) {
     // INQUIRE(FILE=) to a connected unit
     if (ChildIo * child{unit->GetChildIo()}) {
       return &child->BeginIoStatement<InquireUnitState>(

--- a/flang-rt/lib/runtime/io-stmt.cpp
+++ b/flang-rt/lib/runtime/io-stmt.cpp
@@ -264,9 +264,9 @@ int ExternalIoStatementBase::EndIoStatement() {
   unit_.EndIoStatement(); // annihilates *this in unit_.u_
   if (destroy_) {
     if (ExternalFileUnit *
-        toClose{ExternalFileUnit::LookUpForClose(unitNumber)}) {
+        toClose{ExternalFileUnit::LookUpForClose(unitNumber, *this)}) {
       toClose->Close(CloseStatus::Delete, *this);
-      toClose->DestroyClosed();
+      toClose->DestroyClosed(*this);
     }
   }
 #else
@@ -377,7 +377,7 @@ int CloseStatementState::EndIoStatement() {
   CompleteOperation();
   int result{ExternalIoStatementBase::EndIoStatement()};
   unit().CloseUnit(status_, *this);
-  unit().DestroyClosed();
+  unit().DestroyClosed(*this);
   return result;
 }
 

--- a/flang-rt/lib/runtime/pseudo-unit.cpp
+++ b/flang-rt/lib/runtime/pseudo-unit.cpp
@@ -25,13 +25,13 @@ namespace Fortran::runtime::io {
 
 void FlushOutputOnCrash(const Terminator &) {}
 
-ExternalFileUnit *ExternalFileUnit::LookUp(int) {
-  Terminator{__FILE__, __LINE__}.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
+ExternalFileUnit *ExternalFileUnit::LookUp(int, Terminator &terminator) {
+  terminator.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 
 ExternalFileUnit *ExternalFileUnit::LookUpOrCreate(
-    int, const Terminator &, bool &) {
-  Terminator{__FILE__, __LINE__}.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
+    int, const Terminator &terminator, bool &) {
+  terminator.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 
 ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
@@ -44,20 +44,24 @@ ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
   return New<ExternalFileUnit>{handler}(unit).release();
 }
 
-ExternalFileUnit *ExternalFileUnit::LookUp(const char *, std::size_t) {
-  Terminator{__FILE__, __LINE__}.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
+ExternalFileUnit *ExternalFileUnit::LookUp(
+    const char *, std::size_t, Terminator &terminator) {
+  terminator.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 
-ExternalFileUnit &ExternalFileUnit::CreateNew(int, const Terminator &) {
-  Terminator{__FILE__, __LINE__}.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
+ExternalFileUnit &ExternalFileUnit::CreateNew(
+    int, const Terminator &terminator) {
+  terminator.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 
-ExternalFileUnit *ExternalFileUnit::LookUpForClose(int) {
-  Terminator{__FILE__, __LINE__}.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
+ExternalFileUnit *ExternalFileUnit::LookUpForClose(
+    int, Terminator &terminator) {
+  terminator.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 
-ExternalFileUnit &ExternalFileUnit::NewUnit(const Terminator &, bool) {
-  Terminator{__FILE__, __LINE__}.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
+ExternalFileUnit &ExternalFileUnit::NewUnit(
+    const Terminator &terminator, bool) {
+  terminator.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 
 bool ExternalFileUnit::OpenUnit(common::optional<OpenStatus> status,
@@ -76,8 +80,8 @@ void ExternalFileUnit::CloseUnit(CloseStatus, IoErrorHandler &handler) {
   handler.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 
-void ExternalFileUnit::DestroyClosed() {
-  Terminator{__FILE__, __LINE__}.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
+void ExternalFileUnit::DestroyClosed(Terminator &terminator) {
+  terminator.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 
 Iostat ExternalFileUnit::SetDirection(Direction direction) {

--- a/flang-rt/lib/runtime/unit.h
+++ b/flang-rt/lib/runtime/unit.h
@@ -128,15 +128,15 @@ public:
     return createdForInternalChildIo_;
   }
 
-  static RT_API_ATTRS ExternalFileUnit *LookUp(int unit);
+  static RT_API_ATTRS ExternalFileUnit *LookUp(int unit, Terminator &);
   static RT_API_ATTRS ExternalFileUnit *LookUpOrCreate(
       int unit, const Terminator &, bool &wasExtant);
   static RT_API_ATTRS ExternalFileUnit *LookUpOrCreateAnonymous(int unit,
       Direction, common::optional<bool> isUnformatted, IoErrorHandler &);
   static RT_API_ATTRS ExternalFileUnit *LookUp(
-      const char *path, std::size_t pathLen);
+      const char *path, std::size_t pathLen, Terminator &);
   static RT_API_ATTRS ExternalFileUnit &CreateNew(int unit, const Terminator &);
-  static RT_API_ATTRS ExternalFileUnit *LookUpForClose(int unit);
+  static RT_API_ATTRS ExternalFileUnit *LookUpForClose(int unit, Terminator &);
   static RT_API_ATTRS ExternalFileUnit &NewUnit(
       const Terminator &, bool forChildIo);
   static RT_API_ATTRS void CloseAll(IoErrorHandler &);
@@ -149,7 +149,7 @@ public:
   RT_API_ATTRS bool OpenAnonymousUnit(common::optional<OpenStatus>,
       common::optional<Action>, Position, Convert, IoErrorHandler &);
   RT_API_ATTRS void CloseUnit(CloseStatus, IoErrorHandler &);
-  RT_API_ATTRS void DestroyClosed();
+  RT_API_ATTRS void DestroyClosed(Terminator &);
 
   RT_API_ATTRS Iostat SetDirection(Direction);
 
@@ -207,8 +207,8 @@ public:
   }
 
 private:
-  static RT_API_ATTRS UnitMap &CreateUnitMap();
-  static RT_API_ATTRS UnitMap &GetUnitMap();
+  static RT_API_ATTRS UnitMap &CreateUnitMap(const Terminator &);
+  static RT_API_ATTRS UnitMap &GetUnitMap(const Terminator &);
   RT_API_ATTRS const char *FrameNextInput(IoErrorHandler &, std::size_t);
   RT_API_ATTRS void SetPosition(std::int64_t zeroBasedPos);
   RT_API_ATTRS void Sought(std::int64_t zeroBasedPos);


### PR DESCRIPTION
When the I/O runtime fails to allocate storage for an I/O unit, the error message cites a source location in the runtime library, not the user program.  Thread instances of Terminator through to the code that attempts the allocation so that the failure has a source position in the user's program.