### PR TITLE
[LoopUnrollPass] Only emit `shouldPartialUnroll()` missed optimization remark when the user requested full unrolling

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -1032,8 +1032,7 @@ bool llvm::computeUnrollCount(
   if (auto UnrollFactor = shouldPartialUnroll(LoopSize, TripCount, UCE, UP)) {
     UP.Count = *UnrollFactor;
 
-    if ((PragmaFullUnroll || PragmaEnableUnroll) && TripCount &&
-        UP.Count != TripCount)
+    if (PragmaFullUnroll && TripCount && UP.Count && TripCount != UP.Count)
       ORE->emit([&]() {
         return OptimizationRemarkMissed(DEBUG_TYPE,
                                         "FullUnrollAsDirectedTooLarge",


### PR DESCRIPTION
If the user has set `PragmaEnableUnroll` and we decide to partially unroll, we have still honored the user's request. We should not emit a missed optimization remark. 

Additionally, only emit the missed optimization remark if the 