### PR TITLE
[lldb-dap] Fix DAP_launch_io.py Test

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -477,6 +477,9 @@ class DAPTestCaseBase(TestBase):
 
     def continue_to_exit(self, exitCode=0):
         self.do_continue()
+        self.verify_process_exited(exitCode)
+
+    def verify_process_exited(self, exitCode: int = 0):
         stopped_events = self.dap_server.wait_for_stopped()
         self.assertEqual(
             len(stopped_events), 1, "stopped_events = {}".format(stopped_events)

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection.py
@@ -16,8 +16,8 @@ class TestDAP_launch_stdio_redirection(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
 
         with tempfile.NamedTemporaryFile("rt") as f:
-            self.launch(program, stdio=[None, f.name])
-            self.continue_to_exit()
+            self.launch_and_configurationDone(program, stdio=[None, f.name])
+            self.verify_process_exited()
             lines = f.readlines()
             self.assertIn(
                 program, lines[0], "make sure program path is in first argument"

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection_and_console.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection_and_console.py
@@ -29,10 +29,10 @@ class TestDAP_launch_stdio_redirection_and_console(lldbdap_testcase.DAPTestCaseB
         program = self.getBuildArtifact("a.out")
 
         with tempfile.NamedTemporaryFile("rt") as f:
-            self.launch(
+            self.launch_and_configurationDone(
                 program, console="integratedTerminal", stdio=[None, f.name, None]
             )
-            self.continue_to_exit()
+            self.verify_process_exited()
             lines = f.readlines()
             self.assertIn(
                 program, lines[0], "make sure program path is in first argument"

--- a/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io.py
+++ b/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io.py
@@ -46,13 +46,13 @@ class DAP_launchIO(lldbdap_testcase.DAPTestCaseBase):
         ) as stdout, NamedTemporaryFile("rt") as stderr:
             stdin.write(input_text)
             stdin.flush()
-            self.launch(
+            self.launch_and_configurationDone(
                 program,
                 stdio=[stdin.name, stdout.name, stderr.name],
                 console=console,
                 args=program_args,
             )
-            self.continue_to_exit()
+            self.verify_process_exited()
 
             all_stdout = stdout.read()
             all_stderr = stderr.read()
@@ -82,8 +82,10 @@ class DAP_launchIO(lldbdap_testcase.DAPTestCaseBase):
         with NamedTemporaryFile("w+t") as stdin:
             stdin.write(input_text)
             stdin.flush()
-            self.launch(program, stdio=[stdin.name], console=console, args=program_args)
-            self.continue_to_exit()
+            self.launch_and_configurationDone(
+                program, stdio=[stdin.name], console=console, args=program_args
+            )
+            self.verify_process_exited()
 
             stdout_text = self._get_debuggee_stdout()
             stderr_text = self._get_debuggee_stderr()
@@ -111,14 +113,14 @@ class DAP_launchIO(lldbdap_testcase.DAPTestCaseBase):
         env = {"FROM_ENV": env_text} if with_env else {}
 
         with NamedTemporaryFile("rt") as stdout:
-            self.launch(
+            self.launch_and_configurationDone(
                 program,
                 stdio=[None, stdout.name],
                 console=console,
                 args=program_args,
                 env=env,
             )
-            self.continue_to_exit()
+            self.verify_process_exited()
 
             # check stdout
             stdout_text = stdout.read()
@@ -172,14 +174,14 @@ class DAP_launchIO(lldbdap_testcase.DAPTestCaseBase):
         env = {"FROM_ENV": env_text} if with_env else {}
 
         with NamedTemporaryFile("rt") as stderr:
-            self.launch(
+            self.launch_and_configurationDone(
                 program,
                 stdio=[None, None, stderr.name],
                 console=console,
                 args=program_args,
                 env=env,
             )
-            self.continue_to_exit()
+            self.verify_process_exited()
             stdout_text = self._get_debuggee_stdout()
             stderr_text = stderr.read()
             if with_env:


### PR DESCRIPTION
DAP_launch_io sends a continue request for a nonstopped process. Use verify_process_exited instead.