### PR TITLE
[SLP] Avoid adding duplicate VFs into vectorizeStores()::CandidateVFs

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -24561,11 +24561,6 @@ bool SLPVectorizerPass::vectorizeStores(
                               find_if(RangeSizes, IsNotVectorized)) +
                 1));
         unsigned VF = bit_ceil(CandidateVFs.front()) * 2;
-        unsigned Limit =
-            getFloorFullVectorNumberOfElements(*TTI, StoreTy, MaxTotalNum);
-        CandidateVFs.clear();
-        if (bit_floor(Limit) == VF)
-          CandidateVFs.push_back(Limit);
         if (VF > MaxTotalNum || VF >= StoresLimit)
           break;
         for (std::pair<unsigned, unsigned> &P : RangeSizes) {
@@ -24574,6 +24569,11 @@ bool SLPVectorizerPass::vectorizeStores(
         }
         // Attempt again to vectorize even larger chains if all previous
         // attempts were unsuccessful because of the cost issues.
+        CandidateVFs.clear();
+        unsigned Limit =
+            getFloorFullVectorNumberOfElements(*TTI, StoreTy, MaxTotalNum);
+        if (bit_floor(Limit) == VF)
+          CandidateVFs.push_back(Limit);
         CandidateVFs.push_back(VF);
       }
     }

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -24572,7 +24572,7 @@ bool SLPVectorizerPass::vectorizeStores(
           if (P.first != 0)
             P.first = std::max(P.second, P.first);
         }
-        // Last attempt to vectorize max number of elements, if all previous
+        // Attempt again to vectorize even larger chains if all previous
         // attempts were unsuccessful because of the cost issues.
         CandidateVFs.push_back(VF);
       }

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -24572,7 +24572,7 @@ bool SLPVectorizerPass::vectorizeStores(
         CandidateVFs.clear();
         unsigned Limit =
             getFloorFullVectorNumberOfElements(*TTI, StoreTy, MaxTotalNum);
-        if (bit_floor(Limit) == VF)
+        if (bit_floor(Limit) == VF && Limit != VF)
           CandidateVFs.push_back(Limit);
         CandidateVFs.push_back(VF);
       }

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -24480,8 +24480,6 @@ bool SLPVectorizerPass::vectorizeStores(
                 // Mark the vectorized stores so that we don't vectorize them
                 // again.
                 VectorizedStores.insert_range(Slice);
-                // Mark the vectorized stores so that we don't vectorize them
-                // again.
                 AnyProfitableGraph = RepeatChanged = Changed = true;
                 // If we vectorized initial block, no need to try to vectorize
                 // it again.


### PR DESCRIPTION
Small compile time improvement:
```
stage1-O3: (-0.01%)
stage1-ReleaseThinLTO (-0.00%)
stage1-ReleaseLTO-g (-0.01%)
stage1-O0-g (-0.00%)
stage1-aarch64-O3 (+0.01%)
stage1-aarch64-O0-g (-0.02%)
stage2-O3 (-0.00%)
stage2-O0-g (-0.03%)
stage2-clang (+0.00%)
```

Also changes/removes a few comments for clarity.