### PR TITLE
[clang-tidy][NFC] Fix incorrect `list.rst` modification by `add_new_check.py`

### DIFF
--- a/clang-tools-extra/clang-tidy/add_new_check.py
+++ b/clang-tools-extra/clang-tidy/add_new_check.py
@@ -452,6 +452,7 @@ def update_checks_list(clang_tidy_path: str) -> None:
             "FixItHint",
             "ReplacementText",
             "fixit",
+            "FixIt",
             "TransformerClangTidyCheck",
         ]:
             if needle in code:

--- a/clang-tools-extra/clang-tidy/android/ComparisonInTempFailureRetryCheck.cpp
+++ b/clang-tools-extra/clang-tidy/android/ComparisonInTempFailureRetryCheck.cpp
@@ -83,7 +83,7 @@ void ComparisonInTempFailureRetryCheck::check(
   const auto &Inner = *Result.Nodes.getNodeAs<BinaryOperator>("inner");
   diag(Inner.getOperatorLoc(), "top-level comparison in %0") << RetryMacroName;
 
-  // FIXME: FixIts would be nice, but potentially nontrivial when nested macros
+  // FIXME: Fix-its would be nice, but potentially nontrivial when nested macros
   // happen, e.g. `TEMP_FAILURE_RETRY(IS_ZERO(foo()))`
 }
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl58-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl58-cpp.rst
@@ -1,4 +1,6 @@
 .. title:: clang-tidy - cert-dcl58-cpp
+.. meta::
+   :http-equiv=refresh: 5;URL=../bugprone/std-namespace-modification.html
 
 cert-dcl58-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/env33-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/env33-c.rst
@@ -1,4 +1,6 @@
 .. title:: clang-tidy - cert-env33-c
+.. meta::
+   :http-equiv=refresh: 5;URL=../bugprone/command-processor.html
 
 cert-env33-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err52-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err52-cpp.rst
@@ -1,4 +1,6 @@
 .. title:: clang-tidy - cert-err52-cpp
+.. meta::
+   :http-equiv=refresh: 5;URL=../modernize/avoid-setjmp-longjmp.html
 
 cert-err52-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/flp30-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/flp30-c.rst
@@ -1,4 +1,6 @@
 .. title:: clang-tidy - cert-flp30-c
+.. meta::
+   :http-equiv=refresh: 5;URL=../bugprone/float-loop-counter.html
 
 cert-flp30-c
 ============

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/mem57-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/mem57-cpp.rst
@@ -1,4 +1,6 @@
 .. title:: clang-tidy - cert-mem57-cpp
+.. meta::
+   :http-equiv=refresh: 5;URL=../bugprone/default-operator-new-on-overaligned-type.html
 
 cert-mem57-cpp
 ==============

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/multiple-inheritance.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/multiple-inheritance.rst
@@ -1,4 +1,6 @@
 .. title:: clang-tidy - fuchsia-multiple-inheritance
+.. meta::
+   :http-equiv=refresh: 5;URL=../misc/multiple-inheritance.html
 
 fuchsia-multiple-inheritance
 ============================

--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-casting.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-casting.rst
@@ -1,4 +1,6 @@
 .. title:: clang-tidy - google-readability-casting
+.. meta::
+   :http-equiv=refresh: 5;URL=../modernize/avoid-c-style-cast.html
 
 google-readability-casting
 ==========================

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -182,10 +182,6 @@ Clang-Tidy Checks
    :doc:`bugprone-use-after-move <bugprone/use-after-move>`,
    :doc:`bugprone-virtual-near-miss <bugprone/virtual-near-miss>`, "Yes"
    :doc:`cert-err33-c <cert/err33-c>`,
-   :doc:`cert-err60-cpp <cert/err60-cpp>`,
-   :doc:`cert-flp30-c <cert/flp30-c>`,
-   :doc:`cert-msc50-cpp <cert/msc50-cpp>`,
-   :doc:`cert-oop58-cpp <cert/oop58-cpp>`,
    :doc:`concurrency-mt-unsafe <concurrency/mt-unsafe>`,
    :doc:`concurrency-thread-canceltype-asynchronous <concurrency/thread-canceltype-asynchronous>`,
    :doc:`cppcoreguidelines-avoid-capturing-lambda-coroutines <cppcoreguidelines/avoid-capturing-lambda-coroutines>`,
@@ -292,7 +288,7 @@ Clang-Tidy Checks
    :doc:`misc-use-internal-linkage <misc/use-internal-linkage>`, "Yes"
    :doc:`modernize-avoid-bind <modernize/avoid-bind>`, "Yes"
    :doc:`modernize-avoid-c-arrays <modernize/avoid-c-arrays>`,
-   :doc:`modernize-avoid-c-style-cast <modernize/avoid-c-style-cast>`,
+   :doc:`modernize-avoid-c-style-cast <modernize/avoid-c-style-cast>`, "Yes"
    :doc:`modernize-avoid-setjmp-longjmp <modernize/avoid-setjmp-longjmp>`,
    :doc:`modernize-avoid-variadic-functions <modernize/avoid-variadic-functions>`,
    :doc:`modernize-concat-nested-namespaces <modernize/concat-nested-namespaces>`, "Yes"
@@ -592,7 +588,7 @@ Check aliases
    :doc:`fuchsia-multiple-inheritance <fuchsia/multiple-inheritance>`, :doc:`misc-multiple-inheritance <misc/multiple-inheritance>`,
    :doc:`google-build-namespaces <google/build-namespaces>`, :doc:`misc-anonymous-namespace-in-header <misc/anonymous-namespace-in-header>`,
    :doc:`google-readability-braces-around-statements <google/readability-braces-around-statements>`, :doc:`readability-braces-around-statements <readability/braces-around-statements>`, "Yes"
-   :doc:`google-readability-casting <google/readability-casting>`, :doc:`modernize-avoid-c-style-cast <modernize/avoid-c-style-cast>`,
+   :doc:`google-readability-casting <google/readability-casting>`, :doc:`modernize-avoid-c-style-cast <modernize/avoid-c-style-cast>`, "Yes"
    :doc:`google-readability-function-size <google/readability-function-size>`, :doc:`readability-function-size <readability/function-size>`,
    :doc:`google-readability-namespace-comments <google/readability-namespace-comments>`, :doc:`llvm-namespace-comment <llvm/namespace-comment>`,
    :doc:`hicpp-avoid-c-arrays <hicpp/avoid-c-arrays>`, :doc:`modernize-avoid-c-arrays <modernize/avoid-c-arrays>`,


### PR DESCRIPTION
We have observed unexpected and extensive modifications to `list.rst` in a few Pull Requests. After some investigation I found that `add_new_check.py` was misclassifying existing checks, leading to instability in the generated documentation list.

More specifically:
- The script relies on `http-equiv=refresh` meta tags to identify alias checks, which is missing in several existing checks, causing them to be incorrectly listed as regular checks.
- The script fails to detect fix-its in checks that use CamelCase helper methods.

With this patch, running `add_new_check.py` now generates a stable and correct `list.rst` consistent with the actual codebase state.
