### PR TITLE
[InstCombine][profcheck] Fix profile metadata propagation for umax in InstCombine

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -51,6 +51,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/PatternMatch.h"
+#include "llvm/IR/ProfDataUtils.h"
 #include "llvm/IR/Statepoint.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/User.h"
@@ -2117,8 +2118,9 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         return nullptr;
 
       Value *Cmp = Builder.CreateICmpEQ(X, ConstantInt::get(X->getType(), 0));
-      Value *NewSelect =
-          Builder.CreateSelect(Cmp, ConstantInt::get(X->getType(), 1), A);
+      Value *NewSelect = nullptr;
+      NewSelect = Builder.CreateSelectWithUnknownProfile(
+          Cmp, ConstantInt::get(X->getType(), 1), A, DEBUG_TYPE);
       return replaceInstUsesWith(*II, NewSelect);
     };
 

--- a/llvm/test/Transforms/InstCombine/add-shl-mul-umax.ll
+++ b/llvm/test/Transforms/InstCombine/add-shl-mul-umax.ll
@@ -11,12 +11,12 @@
 
 ; Positive Test Cases for `shl`
 
-define i64 @test_shl_by_2(i64 %x) {
+define i64 @test_shl_by_2(i64 %x) !prof !0 {
 ; CHECK-LABEL: define i64 @test_shl_by_2(
-; CHECK-SAME: i64 [[X:%.*]]) {
+; CHECK-SAME: i64 [[X:%.*]]) !prof [[PROF0:![0-9]+]] {
 ; CHECK-NEXT:    [[TMP2:%.*]] = shl nuw i64 [[X]], 2
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i64 [[X]], 0
-; CHECK-NEXT:    [[MAX:%.*]] = select i1 [[TMP1]], i64 1, i64 [[TMP2]]
+; CHECK-NEXT:    [[MAX:%.*]] = select i1 [[TMP1]], i64 1, i64 [[TMP2]], !prof [[PROF1:![0-9]+]]
 ; CHECK-NEXT:    ret i64 [[MAX]]
 ;
   %x1 = add i64 %x, 1
@@ -351,3 +351,9 @@ define i64 @test_mul_multi_use_mul(i64 %x) {
   %max = call i64 @llvm.umax.i64(i64 %mul, i64 %x1)
   ret i64 %max
 }
+
+!0 = !{!"function_entry_count", i64 1}
+;.
+; CHECK: [[PROF0]] = !{!"function_entry_count", i64 1}
+; CHECK: [[PROF1]] = !{!"unknown", !"instcombine"}
+;.

--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -208,7 +208,6 @@ Transforms/IndVarSimplify/invalidate-modified-lcssa-phi.ll
 Transforms/IndVarSimplify/pr45835.ll
 Transforms/IndVarSimplify/preserving-debugloc-rem-div.ll
 Transforms/InstCombine/2004-09-20-BadLoadCombine.ll
-Transforms/InstCombine/add-shl-mul-umax.ll
 Transforms/InstCombine/and2.ll
 Transforms/InstCombine/and-fcmp.ll
 Transforms/InstCombine/and-or-icmps.ll


### PR DESCRIPTION
Select instructions created from the expansion of an umax intrinsic do not have profile data even though the function may have profile data. This is because PGO instrumentation does not support intrinsics.