### PR TITLE
Revert "[AutoUpgrade] Prevent deletion of call if uses still exist (#177606)"

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -63,14 +63,6 @@ static cl::opt<bool>
 
 static void rename(GlobalValue *GV) { GV->setName(GV->getName() + ".old"); }
 
-// Report a fatal error along with the
-// Call Instruction which caused the error
-[[noreturn]] static void reportFatalUsageErrorWithCI(StringRef reason,
-                                                     CallBase *CI) {
-  CI->dump();
-  reportFatalUsageError(reason);
-}
-
 // Upgrade the declarations of the SSE4.1 ptest intrinsics whose arguments have
 // changed their type from v4f32 to v2i64.
 static bool upgradePTESTIntrinsic(Function *F, Intrinsic::ID IID,
@@ -3038,8 +3030,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     Intrinsic::ID IID;
     switch (VecWidth) {
     default:
-      reportFatalUsageErrorWithCI("Unexpected intrinsic", CI);
-      break;
+      llvm_unreachable("Unexpected intrinsic");
     case 128:
       IID = Intrinsic::x86_avx512_vpshufbitqmb_128;
       break;
@@ -3072,7 +3063,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     else if (VecWidth == 512 && EltWidth == 64)
       IID = Intrinsic::x86_avx512_fpclass_pd_512;
     else
-      reportFatalUsageErrorWithCI("Unexpected intrinsic", CI);
+      llvm_unreachable("Unexpected intrinsic");
 
     Rep =
         Builder.CreateIntrinsic(IID, {CI->getOperand(0), CI->getArgOperand(1)});
@@ -3096,7 +3087,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     else if (VecWidth == 512 && EltWidth == 64)
       IID = Intrinsic::x86_avx512_mask_cmp_pd_512;
     else
-      reportFatalUsageErrorWithCI("Unexpected intrinsic", CI);
+      llvm_unreachable("Unexpected intrinsic");
 
     Value *Mask = Constant::getAllOnesValue(CI->getType());
     if (VecWidth == 512)
@@ -3266,7 +3257,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
              Name.ends_with("d") || Name.ends_with("q"))
       IsSigned = true;
     else
-      reportFatalUsageErrorWithCI("Intrinsic has unknown suffix", CI);
+      llvm_unreachable("Unknown suffix");
 
     unsigned Imm;
     if (CI->arg_size() == 3) {
@@ -3640,9 +3631,6 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     unsigned Imm = cast<ConstantInt>(CI->getArgOperand(1))->getZExtValue();
     unsigned NumElts = cast<FixedVectorType>(CI->getType())->getNumElements();
 
-    if (Name == "sse2.pshufl.w" && NumElts % 8 != 0)
-      reportFatalUsageErrorWithCI("Intrinsic has invalid signature", CI);
-
     SmallVector<int, 16> Idxs(NumElts);
     for (unsigned l = 0; l != NumElts; l += 8) {
       for (unsigned i = 0; i != 4; ++i)
@@ -3913,7 +3901,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
       else if (Name[17] == '3' && Name[18] == '2') // avx512.mask.psllv32hi
         IID = Intrinsic::x86_avx512_psllv_w_512;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     } else if (Name.ends_with(".128")) {
       if (Size == 'd') // avx512.mask.psll.d.128, avx512.mask.psll.di.128
         IID = IsImmediate ? Intrinsic::x86_sse2_pslli_d
@@ -3925,7 +3913,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
         IID = IsImmediate ? Intrinsic::x86_sse2_pslli_w
                           : Intrinsic::x86_sse2_psll_w;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     } else if (Name.ends_with(".256")) {
       if (Size == 'd') // avx512.mask.psll.d.256, avx512.mask.psll.di.256
         IID = IsImmediate ? Intrinsic::x86_avx2_pslli_d
@@ -3937,7 +3925,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
         IID = IsImmediate ? Intrinsic::x86_avx2_pslli_w
                           : Intrinsic::x86_avx2_psll_w;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     } else {
       if (Size == 'd') // psll.di.512, pslli.d, psll.d, psllv.d.512
         IID = IsImmediate  ? Intrinsic::x86_avx512_pslli_d_512
@@ -3951,7 +3939,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
         IID = IsImmediate ? Intrinsic::x86_avx512_pslli_w_512
                           : Intrinsic::x86_avx512_psll_w_512;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     }
 
     Rep = upgradeX86MaskedShift(Builder, *CI, IID);
@@ -3980,7 +3968,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
       else if (Name[17] == '3' && Name[18] == '2') // avx512.mask.psrlv32hi
         IID = Intrinsic::x86_avx512_psrlv_w_512;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     } else if (Name.ends_with(".128")) {
       if (Size == 'd') // avx512.mask.psrl.d.128, avx512.mask.psrl.di.128
         IID = IsImmediate ? Intrinsic::x86_sse2_psrli_d
@@ -3992,7 +3980,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
         IID = IsImmediate ? Intrinsic::x86_sse2_psrli_w
                           : Intrinsic::x86_sse2_psrl_w;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     } else if (Name.ends_with(".256")) {
       if (Size == 'd') // avx512.mask.psrl.d.256, avx512.mask.psrl.di.256
         IID = IsImmediate ? Intrinsic::x86_avx2_psrli_d
@@ -4004,7 +3992,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
         IID = IsImmediate ? Intrinsic::x86_avx2_psrli_w
                           : Intrinsic::x86_avx2_psrl_w;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     } else {
       if (Size == 'd') // psrl.di.512, psrli.d, psrl.d, psrl.d.512
         IID = IsImmediate  ? Intrinsic::x86_avx512_psrli_d_512
@@ -4018,7 +4006,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
         IID = IsImmediate ? Intrinsic::x86_avx512_psrli_w_512
                           : Intrinsic::x86_avx512_psrl_w_512;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     }
 
     Rep = upgradeX86MaskedShift(Builder, *CI, IID);
@@ -4043,7 +4031,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
       else if (Name[17] == '3' && Name[18] == '2') // avx512.mask.psrav32hi
         IID = Intrinsic::x86_avx512_psrav_w_512;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     } else if (Name.ends_with(".128")) {
       if (Size == 'd') // avx512.mask.psra.d.128, avx512.mask.psra.di.128
         IID = IsImmediate ? Intrinsic::x86_sse2_psrai_d
@@ -4056,7 +4044,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
         IID = IsImmediate ? Intrinsic::x86_sse2_psrai_w
                           : Intrinsic::x86_sse2_psra_w;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     } else if (Name.ends_with(".256")) {
       if (Size == 'd') // avx512.mask.psra.d.256, avx512.mask.psra.di.256
         IID = IsImmediate ? Intrinsic::x86_avx2_psrai_d
@@ -4069,7 +4057,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
         IID = IsImmediate ? Intrinsic::x86_avx2_psrai_w
                           : Intrinsic::x86_avx2_psra_w;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     } else {
       if (Size == 'd') // psra.di.512, psrai.d, psra.d, psrav.d.512
         IID = IsImmediate  ? Intrinsic::x86_avx512_psrai_d_512
@@ -4083,7 +4071,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
         IID = IsImmediate ? Intrinsic::x86_avx512_psrai_w_512
                           : Intrinsic::x86_avx512_psra_w_512;
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected size", CI);
+        llvm_unreachable("Unexpected size");
     }
 
     Rep = upgradeX86MaskedShift(Builder, *CI, IID);
@@ -4252,7 +4240,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     else if (VecWidth == 256 && EltWidth == 64)
       IID = Intrinsic::x86_fma_vfmaddsub_pd_256;
     else
-      reportFatalUsageErrorWithCI("Unexpected intrinsic", CI);
+      llvm_unreachable("Unexpected intrinsic");
 
     Value *Ops[] = {CI->getArgOperand(0), CI->getArgOperand(1),
                     CI->getArgOperand(2)};
@@ -4327,7 +4315,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     else if (VecWidth == 512 && EltWidth == 64)
       IID = Intrinsic::x86_avx512_pternlog_q_512;
     else
-      reportFatalUsageErrorWithCI("Unexpected intrinsic", CI);
+      llvm_unreachable("Unexpected intrinsic");
 
     Value *Args[] = {CI->getArgOperand(0), CI->getArgOperand(1),
                      CI->getArgOperand(2), CI->getArgOperand(3)};
@@ -4354,7 +4342,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     else if (VecWidth == 512 && High)
       IID = Intrinsic::x86_avx512_vpmadd52h_uq_512;
     else
-      reportFatalUsageErrorWithCI("Unexpected intrinsic", CI);
+      llvm_unreachable("Unexpected intrinsic");
 
     Value *Args[] = {CI->getArgOperand(0), CI->getArgOperand(1),
                      CI->getArgOperand(2)};
@@ -4389,7 +4377,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     else if (VecWidth == 512 && IsSaturating)
       IID = Intrinsic::x86_avx512_vpdpbusds_512;
     else
-      reportFatalUsageErrorWithCI("Unexpected intrinsic", CI);
+      llvm_unreachable("Unexpected intrinsic");
 
     Value *Args[] = {CI->getArgOperand(0), CI->getArgOperand(1),
                      CI->getArgOperand(2)};
@@ -4413,8 +4401,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
       else if (VecWidth == 512)
         NewArgType = VectorType::get(Builder.getInt8Ty(), 64, false);
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected vector bit width",
-                                    CI);
+        llvm_unreachable("Unexpected vector bit width");
 
       Args[1] = Builder.CreateBitCast(Args[1], NewArgType);
       Args[2] = Builder.CreateBitCast(Args[2], NewArgType);
@@ -4445,7 +4432,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     else if (VecWidth == 512 && IsSaturating)
       IID = Intrinsic::x86_avx512_vpdpwssds_512;
     else
-      reportFatalUsageErrorWithCI("Unexpected intrinsic", CI);
+      llvm_unreachable("Unexpected intrinsic");
 
     Value *Args[] = {CI->getArgOperand(0), CI->getArgOperand(1),
                      CI->getArgOperand(2)};
@@ -4469,8 +4456,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
       else if (VecWidth == 512)
         NewArgType = VectorType::get(Builder.getInt16Ty(), 32, false);
       else
-        reportFatalUsageErrorWithCI("Intrinsic has unexpected vector bit width",
-                                    CI);
+        llvm_unreachable("Unexpected vector bit width");
 
       Args[1] = Builder.CreateBitCast(Args[1], NewArgType);
       Args[2] = Builder.CreateBitCast(Args[2], NewArgType);
@@ -4493,7 +4479,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
     else if (Name[0] == 's' && Name.back() == '4')
       IID = Intrinsic::x86_subborrow_64;
     else
-      reportFatalUsageErrorWithCI("Unexpected intrinsic", CI);
+      llvm_unreachable("Unexpected intrinsic");
 
     // Make a call with 3 operands.
     Value *Args[] = {CI->getArgOperand(0), CI->getArgOperand(1),
@@ -4511,8 +4497,7 @@ static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
   } else if (Name.starts_with("avx512.mask.") &&
              upgradeAVX512MaskToSelect(Name, Builder, *CI, Rep)) {
     // Rep will be updated by the call in the condition.
-  } else
-    reportFatalUsageErrorWithCI("Unexpected intrinsic", CI);
+  }
 
   return Rep;
 }

--- a/llvm/test/Verifier/issue176674.ll
+++ b/llvm/test/Verifier/issue176674.ll
@@ -1,9 +1,0 @@
-; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
-; CHECK:   %v = call <4 x i32> @llvm.x86.sse2.pshuflw.128(<4 x i32> zeroinitializer, i8 0)
-; CHECK: LLVM ERROR: Unexpected intrinsic
-
-define void @test(ptr %a) {
-  %v = call <4 x i32> @llvm.x86.sse2.pshuflw.128(<4 x i32> zeroinitializer, i8 0)
-  store <4 x i32> %v, ptr %a
-  ret void
-}

--- a/llvm/test/Verifier/issue176674_1.ll
+++ b/llvm/test/Verifier/issue176674_1.ll
@@ -1,9 +1,0 @@
-; RUN: not llvm-as < %s -o /dev/null 2>&1 | FileCheck %s
-; CHECK:   %v = call <4 x i32> @llvm.x86.sse2.pshufl.w(<4 x i32> zeroinitializer, i8 0)
-; CHECK: LLVM ERROR: Intrinsic has invalid signature
-
-define void @test(ptr %a) {
-  %v = call <4 x i32> @llvm.x86.sse2.pshufl.w(<4 x i32> zeroinitializer, i8 0)
-  store <4 x i32> %v, ptr %a
-  ret void
-}


### PR DESCRIPTION
This reverts commit 3007e2f050bd36e5e8dab68a5c9abbfbf4561314 (#177606)

Buildbot:

```
Step 2 (annotate) failure: 'python ../sanitizer_buildbot/sanitizers/zorg/buildbot/builders/sanitizers/buildbot_selector.py' (failure)
...
[9/137] Linking CXX shared module unittests/Passes/Plugins/TestPlugin.so
[10/137] Linking CXX executable bin/llvm-config
[11/137] Building CXX object lib/IR/CMakeFiles/LLVMCore.dir/AutoUpgrade.cpp.o
[12/137] Linking CXX static library lib/libLLVMCore.a
[13/137] Generating VCSVersion.inc
[14/135] Linking CXX executable bin/apinotes-test
[15/135] Linking CXX executable bin/llvm-cxxmap
[16/135] Linking CXX executable bin/llvm-bcanalyzer
[17/135] Linking CXX executable bin/llvm-ctxprof-util
[18/135] Linking CXX executable bin/llvm-objcopy
FAILED: bin/llvm-objcopy 
: && /usr/bin/clang++ -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wno-pass-failed -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -fuse-ld=lld -Wl,--color-diagnostics    -Wl,--gc-sections  -Xlinker --dependency-file=tools/llvm-objcopy/CMakeFiles/llvm-objcopy.dir/link.d tools/llvm-objcopy/CMakeFiles/llvm-objcopy.dir/ObjcopyOptions.cpp.o tools/llvm-objcopy/CMakeFiles/llvm-objcopy.dir/llvm-objcopy.cpp.o tools/llvm-objcopy/CMakeFiles/llvm-objcopy.dir/llvm-objcopy-driver.cpp.o -o bin/llvm-objcopy  -Wl,-rpath,"\$ORIGIN/../lib:"  lib/libLLVMObject.a  lib/libLLVMObjCopy.a  lib/libLLVMOption.a  lib/libLLVMSupport.a  lib/libLLVMTargetParser.a  lib/libLLVMMC.a  lib/libLLVMBinaryFormat.a  lib/libLLVMIRReader.a  lib/libLLVMBitReader.a  lib/libLLVMAsmParser.a  lib/libLLVMCore.a  lib/libLLVMRemarks.a  lib/libLLVMBitstreamReader.a  lib/libLLVMMCParser.a  lib/libLLVMTextAPI.a  lib/libLLVMDebugInfoDWARFLowLevel.a  -lrt  -ldl  -lm  /usr/lib/aarch64-linux-gnu/libz.so  /usr/lib/aarch64-linux-gnu/libzstd.so  lib/libLLVMDemangle.a && :
ld.lld: error: undefined symbol: llvm::Value::dump() const
>>> referenced by AutoUpgrade.cpp
>>>               AutoUpgrade.cpp.o:(reportFatalUsageErrorWithCI(llvm::StringRef, llvm::CallBase*)) in archive lib/libLLVMCore.a
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```