### PR TITLE
[AMDGPU] Fix issue in fold_pow with F16 constant vector base.

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pown.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pown.ll
@@ -1155,5 +1155,17 @@ entry:
   ret float %call
 }
 
+; Test for constant half vector base with variable exponent (regression test for F16 constant folding).
+; This triggered an assertion without proper F16 handling for constant vectors.
+define <2 x half> @test_pown_afn_nnan_ninf_v2f16_constant_base_variable_exp(<2 x i32> %y) {
+; CHECK-LABEL: define <2 x half> @test_pown_afn_nnan_ninf_v2f16_constant_base_variable_exp
+; CHECK-SAME: (<2 x i32> [[Y:%.*]]) {
+; CHECK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn <2 x half> @llvm.ldexp.v2f16.v2i32(<2 x half> splat (half 0xH3C00), <2 x i32> [[Y]])
+; CHECK-NEXT:    ret <2 x half> [[__EXP2]]
+;
+  %call = call nnan ninf afn <2 x half> @_Z4pownDv2_DhDv2_i(<2 x half> <half 0xH4000, half 0xH4000>, <2 x i32> %y)
+  ret <2 x half> %call
+}
+
 attributes #0 = { nobuiltin }
 attributes #1 = { strictfp }


### PR DESCRIPTION
This patch fixes an assertion failure in `AMDGPULibCalls::fold_pow` when optimizing `pown` calls with a constant half vector base. The code handled fp32 and f[64 vector types but was missing fp16(half) support. For fp16 vectors, the code fell through to the fp64 path, creating a double vector constant instead of a half vector constant. This type mismatch caused the assertion when creating the exp2 call.