### PR TITLE
[OpenMP] Enable XFAIL OpenMP tests that pass now

### DIFF
--- a/offload/test/mapping/map_both_pointer_pointee.c
+++ b/offload/test/mapping/map_both_pointer_pointee.c
@@ -3,8 +3,6 @@
 // REQUIRES: unified_shared_memory
 // UNSUPPORTED: amdgcn-amd-amdhsa
 //
-// FIXME: https://github.com/llvm/llvm-project/issues/161265
-// XFAIL: nvidiagpu
 // XFAIL: intelgpu
 
 #pragma omp declare target

--- a/offload/test/mapping/map_ptr_and_star_local.c
+++ b/offload/test/mapping/map_ptr_and_star_local.c
@@ -2,8 +2,7 @@
 
 // REQUIRES: libc
 //
-// FIXME: https://github.com/llvm/llvm-project/issues/161265
-// XFAIL: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_structptr_and_member_global.c
+++ b/offload/test/mapping/map_structptr_and_member_global.c
@@ -2,8 +2,7 @@
 
 // REQUIRES: libc
 //
-// FIXME: https://github.com/llvm/llvm-project/issues/161265
-// XFAIL: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_structptr_and_member_local.c
+++ b/offload/test/mapping/map_structptr_and_member_local.c
@@ -2,8 +2,7 @@
 
 // REQUIRES: libc
 //
-// FIXME: https://github.com/llvm/llvm-project/issues/161265
-// XFAIL: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/unified_shared_memory/api.c
+++ b/offload/test/unified_shared_memory/api.c
@@ -1,8 +1,6 @@
 // RUN: %libomptarget-compile-generic
 // RUN: env HSA_XNACK=1 \
 // RUN: %libomptarget-run-generic | %fcheck-generic
-// XFAIL: nvptx64-nvidia-cuda
-// XFAIL: nvptx64-nvidia-cuda-LTO
 
 // REQUIRES: unified_shared_memory
 // XFAIL: intelgpu

--- a/offload/test/unified_shared_memory/close_enter_exit.c
+++ b/offload/test/unified_shared_memory/close_enter_exit.c
@@ -5,9 +5,6 @@
 // REQUIRES: unified_shared_memory
 // UNSUPPORTED: clang-6, clang-7, clang-8, clang-9
 
-// Fails on nvptx with error: an illegal memory access was encountered
-// XFAIL: nvptx64-nvidia-cuda
-// XFAIL: nvptx64-nvidia-cuda-LTO
 // XFAIL: intelgpu
 
 #include <omp.h>


### PR DESCRIPTION
Summary:
These have been fixed, should be updated
