### PR TITLE
Attributor: Add -light options to -attributor-enable flag

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -6625,7 +6625,11 @@ enum AttributorRunOption {
   NONE = 0,
   MODULE = 1 << 0,
   CGSCC = 1 << 1,
-  ALL = MODULE | CGSCC
+  MODULE_LIGHT = 1 << 2,
+  CGSCC_LIGHT = 1 << 3,
+
+  ALL = MODULE | CGSCC,
+  LIGHT = MODULE_LIGHT | CGSCC_LIGHT
 };
 
 namespace AA {

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -6628,7 +6628,7 @@ enum AttributorRunOption {
   MODULE_LIGHT = 1 << 2,
   CGSCC_LIGHT = 1 << 3,
 
-  ALL = MODULE | CGSCC,
+  FULL = MODULE | CGSCC,
   LIGHT = MODULE_LIGHT | CGSCC_LIGHT
 };
 

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -285,8 +285,8 @@ static cl::opt<bool> EnableConstraintElimination(
 static cl::opt<AttributorRunOption> AttributorRun(
     "attributor-enable", cl::Hidden, cl::init(AttributorRunOption::NONE),
     cl::desc("Enable the attributor inter-procedural deduction pass"),
-    cl::values(clEnumValN(AttributorRunOption::ALL, "all",
-                          "enable all attributor runs"),
+    cl::values(clEnumValN(AttributorRunOption::FULL, "full",
+                          "enable all full attributor runs"),
                clEnumValN(AttributorRunOption::LIGHT, "light",
                           "enable all attributor-light runs"),
                clEnumValN(AttributorRunOption::MODULE, "module",

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -287,10 +287,16 @@ static cl::opt<AttributorRunOption> AttributorRun(
     cl::desc("Enable the attributor inter-procedural deduction pass"),
     cl::values(clEnumValN(AttributorRunOption::ALL, "all",
                           "enable all attributor runs"),
+               clEnumValN(AttributorRunOption::LIGHT, "light",
+                          "enable all attributor-light runs"),
                clEnumValN(AttributorRunOption::MODULE, "module",
                           "enable module-wide attributor runs"),
+               clEnumValN(AttributorRunOption::MODULE_LIGHT, "module-light",
+                          "enable module-wide attributor-light runs"),
                clEnumValN(AttributorRunOption::CGSCC, "cgscc",
                           "enable call graph SCC attributor runs"),
+               clEnumValN(AttributorRunOption::CGSCC_LIGHT, "cgscc-light",
+                          "enable call graph SCC attributor-light runs"),
                clEnumValN(AttributorRunOption::NONE, "none",
                           "disable attributor runs")));
 
@@ -984,6 +990,8 @@ PassBuilder::buildInlinerPipeline(OptimizationLevel Level,
 
   if (AttributorRun & AttributorRunOption::CGSCC)
     MainCGPipeline.addPass(AttributorCGSCCPass());
+  else if (AttributorRun & AttributorRunOption::CGSCC_LIGHT)
+    MainCGPipeline.addPass(AttributorLightCGSCCPass());
 
   // Deduce function attributes. We do another run of this after the function
   // simplification pipeline, so this only needs to run when it could affect the
@@ -1171,6 +1179,8 @@ PassBuilder::buildModuleSimplificationPipeline(OptimizationLevel Level,
 
   if (AttributorRun & AttributorRunOption::MODULE)
     MPM.addPass(AttributorPass());
+  else if (AttributorRun & AttributorRunOption::MODULE_LIGHT)
+    MPM.addPass(AttributorLightPass());
 
   // Lower type metadata and the type.test intrinsic in the ThinLTO
   // post link pipeline after ICP. This is to enable usage of the type

--- a/llvm/test/Other/opt-pipeline-attributor-enable.ll
+++ b/llvm/test/Other/opt-pipeline-attributor-enable.ll
@@ -1,0 +1,24 @@
+; RUN: opt -S -passes='default<O1>' -attributor-enable=cgscc-light -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=CGSCCLIGHT %s
+; RUN: opt -S -passes='default<O1>' -attributor-enable=module-light -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=MODULELIGHT %s
+; RUN: opt -S -passes='default<O1>' -attributor-enable=light -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=LIGHT %s
+
+; RUN: opt -S -passes='default<O1>' -attributor-enable=cgscc -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=CGSCC %s
+; RUN: opt -S -passes='default<O1>' -attributor-enable=module -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=MODULE %s
+; RUN: opt -S -passes='default<O1>' -attributor-enable=all -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=ALL %s
+
+; CGSCCLIGHT: attributor-light-cgscc,function-attrs
+; MODULELIGHT: openmp-opt,attributor-light,ipsccp
+
+; LIGHT: openmp-opt,attributor-light,
+; LIGHT-SAME: attributor-light-cgscc,function-attrs
+
+
+; MODULE: ,openmp-opt,attributor,ipsccp
+
+; CGSCC: inline,attributor-cgscc,function-attrs
+
+; ALL: openmp-opt,attributor,
+; ALL-SAME: attributor-cgscc,function-attrs
+define ptr @return_arg(ptr %arg) {
+  ret ptr %arg
+}

--- a/llvm/test/Other/opt-pipeline-attributor-enable.ll
+++ b/llvm/test/Other/opt-pipeline-attributor-enable.ll
@@ -4,7 +4,7 @@
 
 ; RUN: opt -S -passes='default<O1>' -attributor-enable=cgscc -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=CGSCC %s
 ; RUN: opt -S -passes='default<O1>' -attributor-enable=module -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=MODULE %s
-; RUN: opt -S -passes='default<O1>' -attributor-enable=all -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=ALL %s
+; RUN: opt -S -passes='default<O1>' -attributor-enable=full -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=FULL %s
 
 ; CGSCCLIGHT: attributor-light-cgscc,function-attrs
 ; MODULELIGHT: openmp-opt,attributor-light,ipsccp
@@ -17,8 +17,8 @@
 
 ; CGSCC: inline,attributor-cgscc,function-attrs
 
-; ALL: openmp-opt,attributor,
-; ALL-SAME: attributor-cgscc,function-attrs
+; FULL: openmp-opt,attributor,
+; FULL-SAME: attributor-cgscc,function-attrs
 define ptr @return_arg(ptr %arg) {
   ret ptr %arg
 }


### PR DESCRIPTION
Add light, module-light, and cgscc-light options. This just
supplements the existing flag to use the light variants of the
pass in place of the full versions.

Way back when attributor-light was added in 400fde92963588ae2b,
there was no way to change the pass pipeline to use it. There
were some benchmarks posted, but I don't see precisely how it
was benchmarked in the pipeline.

I'm also surprised this option is only additive, and doesn't remove
FunctionAttrs. If this is to be the option to drive the enablement,
I would expect it to not run the old passes.