### PR TITLE
ScheduleDAG: Clear registers on DEBUG_VALUE_LIST correctly.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
@@ -1083,7 +1083,13 @@ EmitSchedule(MachineBasicBlock::iterator &InsertPos) {
 
       // The DBG_VALUE was referencing a value produced by a terminator. By
       // moving the DBG_VALUE, the referenced value also needs invalidating.
-      MI.getOperand(0).ChangeToRegister(0, false);
+      if (MI.isDebugValueList()) {
+        for (MachineOperand &Op : MI.operands())
+          if (Op.isReg())
+            Op.ChangeToRegister(Register(), false);
+      } else {
+        MI.getOperand(0).ChangeToRegister(Register(), false);
+      }
       MI.moveBefore(&*FirstTerm);
     }
   }


### PR DESCRIPTION
Previously we were unconditionally setting operand 0 to a register which
is the metadata operand with DEBUG_VALUE_LIST, which led to assertion
failures. DEBUG_VALUE_LIST register operands start with operand 2,
so enumerate them and clear any that are already registers.

Exposed by #172962. No test because I'm not sure how to test this on
its own.
