### PR TITLE
[RISCV] Rename VUnitStrideLoadMask->VUnitStrideMaskLoad. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
@@ -358,7 +358,7 @@ class VWholeLoad<bits<3> nf, RISCVWidth width, string opcodestr, RegisterClass V
 }
 
 // unit-stride mask load vd, (rs1)
-class VUnitStrideLoadMask<string opcodestr>
+class VUnitStrideMaskLoad<string opcodestr>
     : RVInstVLU<0b000, LSWidth8.Value{3}, LUMOPUnitStrideMask, LSWidth8.Value{2-0},
                 (outs VR:$vd),
                 (ins GPRMemZeroOffset:$rs1), opcodestr, "$vd, $rs1">;
@@ -429,7 +429,7 @@ class VWholeStore<bits<3> nf, string opcodestr, RegisterClass VRC>
 }
 
 // unit-stride mask store vd, vs3, (rs1)
-class VUnitStrideStoreMask<string opcodestr>
+class VUnitStrideMaskStore<string opcodestr>
     : RVInstVSU<0b000, LSWidth8.Value{3}, SUMOPUnitStrideMask, LSWidth8.Value{2-0},
                 (outs), (ins VR:$vs3, GPRMemZeroOffset:$rs1), opcodestr,
                 "$vs3, $rs1">;
@@ -1120,9 +1120,9 @@ foreach eew = [8, 16, 32, 64] in {
 }
 
 let Predicates = [HasVInstructions] in {
-def VLM_V : VUnitStrideLoadMask<"vlm.v">,
+def VLM_V : VUnitStrideMaskLoad<"vlm.v">,
              Sched<[WriteVLDM_WorstCase, ReadVLDX]>;
-def VSM_V : VUnitStrideStoreMask<"vsm.v">,
+def VSM_V : VUnitStrideMaskStore<"vsm.v">,
              Sched<[WriteVSTM_WorstCase, ReadVSTM_WorstCase, ReadVSTX]>;
 def : MnemonicAlias<"vle1.v", "vlm.v">;
 def : MnemonicAlias<"vse1.v", "vsm.v">;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
@@ -1838,7 +1838,7 @@ multiclass VPseudoFFLoad {
   }
 }
 
-multiclass VPseudoLoadMask {
+multiclass VPseudoMaskLoad {
   foreach mti = AllMasks in {
     defvar mx = mti.LMul.MX;
     defvar WriteVLDM_MX = !cast<SchedWrite>("WriteVLDM_" # mx);
@@ -1914,7 +1914,7 @@ multiclass VPseudoUSStore {
   }
 }
 
-multiclass VPseudoStoreMask {
+multiclass VPseudoMaskStore {
   foreach mti = AllMasks in {
     defvar mx = mti.LMul.MX;
     defvar WriteVSTM_MX = !cast<SchedWrite>("WriteVSTM_" # mx);
@@ -6074,8 +6074,8 @@ def PseudoVSETIVLI : Pseudo<(outs GPR:$rd), (ins uimm5:$rs1, VTypeIOp10:$vtypei)
 defm PseudoVL : VPseudoUSLoad;
 defm PseudoVS : VPseudoUSStore;
 
-defm PseudoVLM : VPseudoLoadMask;
-defm PseudoVSM : VPseudoStoreMask;
+defm PseudoVLM : VPseudoMaskLoad;
+defm PseudoVSM : VPseudoMaskStore;
 
 //===----------------------------------------------------------------------===//
 // 7.5 Vector Strided Instructions

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVSDPatterns.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVSDPatterns.td
@@ -42,7 +42,7 @@ multiclass VPatUSLoadStoreSDNode<ValueType type,
             (store_instr reg_class:$rs2, GPR:$rs1, avl, log2sew)>;
 }
 
-multiclass VPatUSLoadStoreMaskSDNode<MTypeInfo m> {
+multiclass VPatUSMaskLoadStoreSDNode<MTypeInfo m> {
   defvar load_instr = !cast<Instruction>("PseudoVLM_V_"#m.BX);
   defvar store_instr = !cast<Instruction>("PseudoVSM_V_"#m.BX);
   // Load
@@ -879,7 +879,7 @@ foreach vti = AllVectors in
                                vti.AVL, vti.RegClass>;
 foreach mti = AllMasks in
   let Predicates = [HasVInstructions] in
-  defm : VPatUSLoadStoreMaskSDNode<mti>;
+  defm : VPatUSMaskLoadStoreSDNode<mti>;
 
 // 11. Vector Integer Arithmetic Instructions
 


### PR DESCRIPTION
Similar for store.

Having "Mask" at the end makes it look too much like the pseudo instruction classes that end in Mask or NoMask to indicate the presence of the "vm" operand.

This also matches the spec where they are referred to as "unit-stride mask load and store instructions"