### PR TITLE
Update my email across the project

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -32,7 +32,7 @@
 Min Hsu <min.hsu@sifive.com> <min@myhsu.dev>
 Min Hsu <min.hsu@sifive.com> <minyihh@uci.edu>
 <qcf@ecnelises.com> <qiucofan@cn.ibm.com> <qiucf@cn.ibm.com>
-<rnk@google.com> <reid@kleckner.net>
+<rnk@llvm.org> <rnk@nvidia.com> <rnk@google.com> <reid@kleckner.net>
 <thakis@chromium.org> <nicolasweber@gmx.de>
 Jianjian GUAN <jacquesguan@me.com>
 Jianjian GUAN <jacquesguan@me.com> <Jianjian.Guan@streamcomputing.com>

--- a/clang/AreaTeamMembers.txt
+++ b/clang/AreaTeamMembers.txt
@@ -8,7 +8,7 @@ aaron@aaronballman.com (email), AaronBallman (Discourse), AaronBallman (GitHub),
 Secretary
 ---------
 Reid Kleckner
-rnk@google.com (email), rnk (Discourse), rnk (GitHub), rnk (Discord)
+rnk@llvm.org (email), rnk (Discourse), rnk (GitHub), rnk (Discord)
 
 Other Members
 -------------

--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -249,7 +249,7 @@ Itanium ABI
 Microsoft ABI
 ~~~~~~~~~~~~~
 | Reid Kleckner
-| rnk\@google.com (email), rnk (Phabricator), rnk (GitHub)
+| rnk\@llvm.org (email), rnk (GitHub), rnk (Discourse), rnk (Discord), rnk (Phabricator)
 
 
 ARM EABI
@@ -297,7 +297,7 @@ CMake integration
 General Windows support
 ~~~~~~~~~~~~~~~~~~~~~~~
 | Reid Kleckner
-| rnk\@google.com (email), rnk (Phabricator), rnk (GitHub)
+| rnk\@llvm.org (email), rnk (GitHub), rnk (Discourse), rnk (Discord), rnk (Phabricator)
 
 
 Incremental compilation, REPLs, clang-repl

--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -186,7 +186,7 @@ i@maskray.me (email), [MaskRay](https://github.com/MaskRay) (GitHub)
 #### Windows ABI and codegen
 
 Reid Kleckner \
-rnk@google.com (email), [rnk](https://github.com/rnk) (GitHub)
+rnk@llvm.org (email), [rnk](https://github.com/rnk) (GitHub)
 
 ### Backends / Targets
 
@@ -484,7 +484,7 @@ echristo@gmail.com (email), [echristo](https://github.com/echristo) (GitHub)
 #### Exception handling
 
 Reid Kleckner \
-rnk@google.com (email), [rnk](https://github.com/rnk) (GitHub)
+rnk@llvm.org (email), [rnk](https://github.com/rnk) (GitHub)
 
 #### LLVM Buildbot
 


### PR DESCRIPTION
At the moment, LLVM OSS stuff should go to rnk@llvm.org.