### PR TITLE
[Clang][Sema] Fix crash with asm goto and OpenMP pragma

### DIFF
--- a/clang/lib/Sema/JumpDiagnostics.cpp
+++ b/clang/lib/Sema/JumpDiagnostics.cpp
@@ -916,7 +916,8 @@ static void DiagnoseIndirectOrAsmJumpStmt(Sema &S, Stmt *Jump,
   bool IsAsmGoto = isa<GCCAsmStmt>(Jump);
   S.Diag(Jump->getBeginLoc(), diag::err_indirect_goto_in_protected_scope)
       << IsAsmGoto;
-  S.Diag(Target->getStmt()->getIdentLoc(), diag::note_indirect_goto_target)
+  if (Target && Target->getStmt())
+    S.Diag(Target->getStmt()->getIdentLoc(), diag::note_indirect_goto_target)
       << IsAsmGoto;
   Diagnosed = true;
 }

--- a/clang/test/Sema/openmp-asm-goto-crash.c
+++ b/clang/test/Sema/openmp-asm-goto-crash.c
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fopenmp -fsyntax-only -verify -triple x86_64-unknown-linux-gnu %s
+
+int test_asm_goto_undeclared_label() {
+#pragma omp assume
+  __asm__ goto("" : : : : undefined_label); // expected-error {{use of undeclared label 'undefined_label'}} \
+                                             // expected-error {{cannot jump from this asm goto statement to one of its possible targets}} \
+                                             // expected-note {{jump exits scope of OpenMP structured block}}
+  int x = 1;
+undefined_label:
+  return x;
+}


### PR DESCRIPTION
We were getting a segfault when using asm goto with an undeclared label inside an OpenMP pragma (see issue #179238). The issue was that when you have an undeclared label in an OpenMP scope, Target (which is a LabelDecl*) can be null. The code was just assuming it was always valid and dereferencing it without checking. Just adding a null check before using Target fixes it. Still reports the errors (undeclared label, invalid jump, etc.) but doesn't segfault.