### PR TITLE
[libc++] Remove `__wrap_iter::base()`

### DIFF
--- a/libcxx/docs/ReleaseNotes/22.rst
+++ b/libcxx/docs/ReleaseNotes/22.rst
@@ -121,6 +121,9 @@ Potentially breaking changes
   ``_LIBCPP_ABI_NO_ITERATOR_BASES``. If you are using this flag and care about ABI stability, you should set
   ``_LIBCPP_ABI_NO_REVERSE_ITERATOR_SECOND_MEMBER`` as well.
 
+- The `base()` function exposed by the contiguous iterator type `wrap_iter` has been removed. Code should no longer
+  rely on this function.
+
 Announcements About Future Releases
 -----------------------------------
 

--- a/libcxx/docs/ReleaseNotes/22.rst
+++ b/libcxx/docs/ReleaseNotes/22.rst
@@ -121,9 +121,6 @@ Potentially breaking changes
   ``_LIBCPP_ABI_NO_ITERATOR_BASES``. If you are using this flag and care about ABI stability, you should set
   ``_LIBCPP_ABI_NO_REVERSE_ITERATOR_SECOND_MEMBER`` as well.
 
-- The `base()` function exposed by the contiguous iterator type `wrap_iter` has been removed. Code should no longer
-  rely on this function.
-
 Announcements About Future Releases
 -----------------------------------
 

--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -53,7 +53,7 @@ Deprecations and Removals
 - The ``std::launch::any`` enumerator that was accidentally provided as an extension is now deprecated.
   It will be removed in LLVM 25.
 
-- ``wrap_iter``'s (iterator type for ``array``, ``span``, ``string``, ``string_view`` and ``vector``) ``base()``
+- ``__wrap_iter``'s (iterator type for ``array``, ``span``, ``string``, ``string_view`` and ``vector``) ``base()``
   method has been removed as it was non-standard.
 
 Potentially breaking changes

--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -52,8 +52,10 @@ Deprecations and Removals
 
 - The ``std::launch::any`` enumerator that was accidentally provided as an extension is now deprecated.
   It will be removed in LLVM 25.
+
 - ``wrap_iter``'s (iterator type for ``array``, ``span``, ``string``, ``string_view`` and ``vector``) ``base()``
   method has been removed as it was non-standard.
+
 Potentially breaking changes
 ----------------------------
 

--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -52,7 +52,8 @@ Deprecations and Removals
 
 - The ``std::launch::any`` enumerator that was accidentally provided as an extension is now deprecated.
   It will be removed in LLVM 25.
-
+- ``wrap_iter``'s (iterator type for ``array``, ``span``, ``string``, ``string_view`` and ``vector``) ``base()``
+  method has been removed as it was non-standard.
 Potentially breaking changes
 ----------------------------
 

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -131,8 +131,8 @@ private:
   auto
   operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT->decltype(__x.__i_ - __y.__i_);
 #else
-  typename __wrap_iter<_Iter>::difference_type
-  operator-(const __wrap_iter<_Iter>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT;
+  typename __wrap_iter<_Iter1>::difference_type
+  operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT;
 #endif // C++03
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __wrap_iter(iterator_type __x) _NOEXCEPT : __i_(__x) {}

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -103,38 +103,6 @@ public:
   }
 
 private:
-  template <class _Iter1>
-  _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR bool
-  operator==(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEXCEPT;
-
-  template <class _Iter1, class _Iter2>
-  _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR bool
-  operator==(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT;
-
-  template <class _Iter1>
-  _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
-  operator<(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEXCEPT;
-
-  template <class _Iter1, class _Iter2>
-  _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
-  operator<(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT;
-
-#if _LIBCPP_STD_VER >= 20
-  template <class _Iter1, class _Iter2>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr strong_ordering
-  operator<=>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept;
-#endif
-
-  template <class _Iter1, class _Iter2>
-  _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14
-#ifndef _LIBCPP_CXX03_LANG
-  auto
-  operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT->decltype(__x.__i_ - __y.__i_);
-#else
-  typename __wrap_iter<_Iter1>::difference_type
-  operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT;
-#endif // C++03
-
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __wrap_iter(iterator_type __x) _NOEXCEPT : __i_(__x) {}
 
   template <class _Up>
@@ -220,10 +188,10 @@ private:
   }
 
 #else
-  template <class _Iter1, class _Iter2>
+  template <class _Iter2>
   _LIBCPP_HIDE_FROM_ABI friend constexpr strong_ordering
-  operator<=>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept {
-    if constexpr (three_way_comparable_with<_Iter1, _Iter2, strong_ordering>) {
+  operator<=>(const __wrap_iter& __x, const __wrap_iter<_Iter2>& __y) noexcept {
+    if constexpr (three_way_comparable_with<_Iter, _Iter2, strong_ordering>) {
       return __x.__i_ <=> __y.__i_;
     } else {
       if (__x.__i_ < __y.__i_)
@@ -238,9 +206,9 @@ private:
 #endif // _LIBCPP_STD_VER >= 20
 
 #ifndef _LIBCPP_CXX03_LANG
-  template <class _Iter1, class _Iter2>
+  template <class _Iter2>
   _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14 auto
-  operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT->decltype(__x.__i_ - __y.__i_)
+  operator-(const __wrap_iter& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT->decltype(__x.__i_ - __y.__i_)
 #else
   template <class _Iter2>
   _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -47,7 +47,7 @@ public:
 private:
   iterator_type __i_;
 
-  friend struct pointer_traits<__wrap_iter<_Iter>>;
+  friend struct pointer_traits<__wrap_iter<_Iter> >;
 
 public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __wrap_iter() _NOEXCEPT : __i_() {}

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -47,6 +47,8 @@ public:
 private:
   iterator_type __i_;
 
+  friend struct pointer_traits<__wrap_iter<_Iter>>;
+
 public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __wrap_iter() _NOEXCEPT : __i_() {}
   template <class _OtherIter,
@@ -100,9 +102,39 @@ public:
     return __i_[__n];
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 iterator_type base() const _NOEXCEPT { return __i_; }
-
 private:
+  template <class _Iter1>
+  _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR bool
+  operator==(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEXCEPT;
+
+  template <class _Iter1, class _Iter2>
+  _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR bool
+  operator==(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT;
+
+  template <class _Iter1>
+  _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+  operator<(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter1>& __y) _NOEXCEPT;
+
+  template <class _Iter1, class _Iter2>
+  _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+  operator<(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT;
+
+#if _LIBCPP_STD_VER >= 20
+  template <class _Iter1, class _Iter2>
+  _LIBCPP_HIDE_FROM_ABI friend constexpr strong_ordering
+  operator<=>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept;
+#endif
+
+  template <class _Iter1, class _Iter2>
+  _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14
+#ifndef _LIBCPP_CXX03_LANG
+  auto
+  operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT->decltype(__x.__i_ - __y.__i_);
+#else
+  typename __wrap_iter<_Iter>::difference_type
+  operator-(const __wrap_iter<_Iter>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT;
+#endif // C++03
+
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __wrap_iter(iterator_type __x) _NOEXCEPT : __i_(__x) {}
 
   template <class _Up>
@@ -122,24 +154,24 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR bool
   operator==(const __wrap_iter& __x, const __wrap_iter& __y) _NOEXCEPT {
-    return __x.base() == __y.base();
+    return __x.__i_ == __y.__i_;
   }
 
   template <class _Iter2>
   _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR bool
   operator==(const __wrap_iter& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT {
-    return __x.base() == __y.base();
+    return __x.__i_ == __y.__i_;
   }
 
   _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
   operator<(const __wrap_iter& __x, const __wrap_iter& __y) _NOEXCEPT {
-    return __x.base() < __y.base();
+    return __x.__i_ < __y.__i_;
   }
 
   template <class _Iter2>
   _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
   operator<(const __wrap_iter& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT {
-    return __x.base() < __y.base();
+    return __x.__i_ < __y.__i_;
   }
 
 #if _LIBCPP_STD_VER <= 17
@@ -188,35 +220,35 @@ private:
   }
 
 #else
-  template <class _Iter2>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr strong_ordering
-  operator<=>(const __wrap_iter& __x, const __wrap_iter<_Iter2>& __y) noexcept {
-    if constexpr (three_way_comparable_with<_Iter, _Iter2, strong_ordering>) {
-      return __x.base() <=> __y.base();
-    } else {
-      if (__x.base() < __y.base())
-        return strong_ordering::less;
+template <class _Iter1, class _Iter2>
+_LIBCPP_HIDE_FROM_ABI friend constexpr strong_ordering
+operator<=>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept {
+  if constexpr (three_way_comparable_with<_Iter1, _Iter2, strong_ordering>) {
+    return __x.__i_ <=> __y.__i_;
+  } else {
+    if (__x.__i_ < __y.__i_)
+      return strong_ordering::less;
 
-      if (__x.base() == __y.base())
-        return strong_ordering::equal;
+    if (__x.__i_ == __y.__i_)
+      return strong_ordering::equal;
 
-      return strong_ordering::greater;
+    return strong_ordering::greater;
     }
   }
 #endif // _LIBCPP_STD_VER >= 20
 
 #ifndef _LIBCPP_CXX03_LANG
-  template <class _Iter2>
+  template <class _Iter1, class _Iter2>
   _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14 auto
-  operator-(const __wrap_iter& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT->decltype(__x.base() - __y.base())
+  operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT->decltype(__x.__i_ - __y.__i_)
 #else
   template <class _Iter2>
   _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14
   typename __wrap_iter::difference_type operator-(const __wrap_iter& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
 #endif // C++03
-  {
-    return __x.base() - __y.base();
-  }
+{
+  return __x.__i_ - __y.__i_;
+}
 
   _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14 __wrap_iter
   operator+(typename __wrap_iter::difference_type __n, __wrap_iter __x) _NOEXCEPT {
@@ -237,7 +269,7 @@ struct pointer_traits<__wrap_iter<_It> > {
   typedef typename pointer_traits<_It>::difference_type difference_type;
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR static element_type* to_address(pointer __w) _NOEXCEPT {
-    return std::__to_address(__w.base());
+    return std::__to_address(__w.__i_);
   }
 };
 

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -220,19 +220,19 @@ private:
   }
 
 #else
-template <class _Iter1, class _Iter2>
-_LIBCPP_HIDE_FROM_ABI friend constexpr strong_ordering
-operator<=>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept {
-  if constexpr (three_way_comparable_with<_Iter1, _Iter2, strong_ordering>) {
-    return __x.__i_ <=> __y.__i_;
-  } else {
-    if (__x.__i_ < __y.__i_)
-      return strong_ordering::less;
+  template <class _Iter1, class _Iter2>
+  _LIBCPP_HIDE_FROM_ABI friend constexpr strong_ordering
+  operator<=>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noexcept {
+    if constexpr (three_way_comparable_with<_Iter1, _Iter2, strong_ordering>) {
+      return __x.__i_ <=> __y.__i_;
+    } else {
+      if (__x.__i_ < __y.__i_)
+        return strong_ordering::less;
 
-    if (__x.__i_ == __y.__i_)
-      return strong_ordering::equal;
+      if (__x.__i_ == __y.__i_)
+        return strong_ordering::equal;
 
-    return strong_ordering::greater;
+      return strong_ordering::greater;
     }
   }
 #endif // _LIBCPP_STD_VER >= 20
@@ -246,9 +246,9 @@ operator<=>(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) noex
   _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14
   typename __wrap_iter::difference_type operator-(const __wrap_iter& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
 #endif // C++03
-{
-  return __x.__i_ - __y.__i_;
-}
+  {
+    return __x.__i_ - __y.__i_;
+  }
 
   _LIBCPP_HIDE_FROM_ABI friend _LIBCPP_CONSTEXPR_SINCE_CXX14 __wrap_iter
   operator+(typename __wrap_iter::difference_type __n, __wrap_iter __x) _NOEXCEPT {

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -5167,7 +5167,7 @@ regex_search(__wrap_iter<_Iter> __first,
              const basic_regex<_CharT, _Traits>& __e,
              regex_constants::match_flag_type __flags = regex_constants::match_default) {
   match_results<const _CharT*> __mc;
-  bool __r = __e.__search(__first.base(), __last.base(), __mc, __flags);
+  bool __r = __e.__search(__first.operator->(), __last.operator->(), __mc, __flags);
   __m.__assign(__first, __last, __mc, __flags & regex_constants::__no_update_pos);
   return __r;
 }

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -817,6 +817,7 @@ typedef regex_token_iterator<wstring::const_iterator> wsregex_token_iterator;
 #    include <__iterator/wrap_iter.h>
 #    include <__locale>
 #    include <__memory/addressof.h>
+#    include <__memory/pointer_traits.h>
 #    include <__memory/shared_ptr.h>
 #    include <__memory_resource/polymorphic_allocator.h>
 #    include <__type_traits/is_swappable.h>
@@ -5167,7 +5168,7 @@ regex_search(__wrap_iter<_Iter> __first,
              const basic_regex<_CharT, _Traits>& __e,
              regex_constants::match_flag_type __flags = regex_constants::match_default) {
   match_results<const _CharT*> __mc;
-  bool __r = __e.__search(__first.operator->(), __last.operator->(), __mc, __flags);
+  bool __r = __e.__search(std::__to_address(__first), std::__to_address(__last), __mc, __flags);
   __m.__assign(__first, __last, __mc, __flags & regex_constants::__no_update_pos);
   return __r;
 }


### PR DESCRIPTION
Resolves #126442

- Converts all the relevant functions that used `.base()` into friends
- Fixed usage in `<regex>`