### PR TITLE
[LLVM][CodeGen]  Improve CTSELECT fallback lowering and target support modeling

### DIFF
--- a/llvm/include/llvm/CodeGen/ISDOpcodes.h
+++ b/llvm/include/llvm/CodeGen/ISDOpcodes.h
@@ -783,8 +783,8 @@ enum NodeType {
   /// i1 then the high bits must conform to getBooleanContents.
   SELECT,
 
-  /// Constant-time Select, implemented with CMOV instruction. This is used to
-  /// implement constant-time select.
+  /// CTSELECT(Cond, TrueVal, FalseVal). Cond is i1 and the value operands must
+  /// have the same type. Used to lower the constant-time select intrinsic.
   CTSELECT,
 
   /// Select with a vector condition (op #0) and two vector operands (ops #1

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -436,8 +436,6 @@ public:
     FastMathFlags = NoNaNs | NoInfs | NoSignedZeros | AllowReciprocal |
                     AllowContract | ApproximateFuncs | AllowReassociation,
 
-    // Flag for disabling optimization
-    NoMerge = 1 << 15,
   };
 
   /// Default constructor turns off all optimization flags.

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -247,10 +247,6 @@ public:
                          // and vector values (ex: cmov).
     VectorMaskSelect,    // The target supports vector selects with a vector
                          // mask (ex: x86 blends).
-    CtSelect,            // The target implements a custom constant-time select.
-    ScalarCondVectorValCtSelect, // The target supports selects with a scalar
-                                 // condition and vector values.
-    VectorMaskValCtSelect, // The target supports vector selects with a vector
   };
 
   /// Enum that specifies what an atomic load/AtomicRMWInst is expanded
@@ -481,9 +477,10 @@ public:
   MachineMemOperand::Flags
   getVPIntrinsicMemOperandFlags(const VPIntrinsic &VPIntrin) const;
 
-  virtual bool isSelectSupported(SelectSupportKind kind) const {
-    return kind != CtSelect;
-  }
+  virtual bool isSelectSupported(SelectSupportKind kind) const { return true; }
+
+  /// Return true if the target has custom lowering for constant-time select.
+  virtual bool isCtSelectSupported(EVT VT) const { return false; }
 
   /// Return true if the @llvm.get.active.lane.mask intrinsic should be expanded
   /// using generic code in SelectionDAGBuilder.

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1863,8 +1863,7 @@ def int_coro_subfn_addr : DefaultAttrsIntrinsic<
     [IntrReadMem, IntrArgMemOnly, ReadOnly<ArgIndex<0>>,
      NoCapture<ArgIndex<0>>]>;
 
-///===-------------------------- Constant Time Intrinsics
-///--------------------------===//
+///===---------------------- Constant Time Intrinsics ----------------------===//
 //
 // Intrinsic to support constant time select
 def int_ct_select

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -484,7 +484,8 @@ namespace {
     SDValue visitCTTZ_ZERO_UNDEF(SDNode *N);
     SDValue visitCTPOP(SDNode *N);
     SDValue visitSELECT(SDNode *N);
-    SDValue visitCTSELECT(SDNode *N);
+    // visit CTSELECT Node
+    SDValue visitConstantTimeSelect(SDNode *N);
     SDValue visitVSELECT(SDNode *N);
     SDValue visitVP_SELECT(SDNode *N);
     SDValue visitSELECT_CC(SDNode *N);
@@ -1905,7 +1906,6 @@ void DAGCombiner::Run(CombineLevel AtLevel) {
 }
 
 SDValue DAGCombiner::visit(SDNode *N) {
-
   // clang-format off
   switch (N->getOpcode()) {
   default: break;
@@ -1976,7 +1976,7 @@ SDValue DAGCombiner::visit(SDNode *N) {
   case ISD::CTTZ_ZERO_UNDEF:    return visitCTTZ_ZERO_UNDEF(N);
   case ISD::CTPOP:              return visitCTPOP(N);
   case ISD::SELECT:             return visitSELECT(N);
-  case ISD::CTSELECT:           return visitCTSELECT(N);
+  case ISD::CTSELECT:           return visitConstantTimeSelect(N);
   case ISD::VSELECT:            return visitVSELECT(N);
   case ISD::SELECT_CC:          return visitSELECT_CC(N);
   case ISD::SETCC:              return visitSETCC(N);
@@ -12583,7 +12583,7 @@ SDValue DAGCombiner::visitSELECT(SDNode *N) {
   return SDValue();
 }
 
-SDValue DAGCombiner::visitCTSELECT(SDNode *N) {
+SDValue DAGCombiner::visitConstantTimeSelect(SDNode *N) {
   SDValue N0 = N->getOperand(0);
   SDValue N1 = N->getOperand(1);
   SDValue N2 = N->getOperand(2);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -6582,7 +6582,10 @@ void SelectionDAGBuilder::visitVectorExtractLastActive(const CallInst &I,
 
 /// Fallback implementation for constant-time select using DAG chaining.
 /// This implementation uses data dependencies through virtual registers to
-/// prevent optimizations from breaking the constant-time property.
+/// prevent optimizations from breaking the constant-time property. It is a
+/// best-effort safeguard; for stronger guarantees we prefer target-specific
+/// lowering pipelines that preserve the select pattern by construction.
+///
 /// It handles scalars, vectors (fixed and scalable), and floating-point types.
 SDValue SelectionDAGBuilder::createProtectedCtSelectFallback(
     SelectionDAG &DAG, const SDLoc &DL, SDValue Cond, SDValue T, SDValue F,
@@ -6599,28 +6602,12 @@ SDValue SelectionDAGBuilder::createProtectedCtSelectFallback(
   if (VT.isVector() && !Cond.getValueType().isVector()) {
     ElementCount NumElems = VT.getVectorElementCount();
     EVT CondVT = EVT::getVectorVT(*DAG.getContext(), MVT::i1, NumElems);
-
-    if (VT.isScalableVector()) {
-      Cond = DAG.getSplatVector(CondVT, DL, Cond);
-    } else {
-      Cond = DAG.getSplatBuildVector(CondVT, DL, Cond);
-    }
+    Cond = DAG.getSplat(CondVT, DL, Cond);
   }
 
   // Handle floating-point types: bitcast to integer for bitwise operations
   if (VT.isFloatingPoint()) {
-    if (VT.isVector()) {
-      // float vector -> int vector
-      EVT ElemVT = VT.getVectorElementType();
-      unsigned int ElemBitWidth = ElemVT.getScalarSizeInBits();
-      EVT IntElemVT = EVT::getIntegerVT(*DAG.getContext(), ElemBitWidth);
-
-      WorkingVT = EVT::getVectorVT(*DAG.getContext(), IntElemVT,
-                                   VT.getVectorElementCount());
-    } else {
-      WorkingVT = EVT::getIntegerVT(*DAG.getContext(), VT.getSizeInBits());
-    }
-
+    WorkingVT = VT.changeTypeToInteger();
     WorkingT = DAG.getBitcast(WorkingVT, T);
     WorkingF = DAG.getBitcast(WorkingVT, F);
   }
@@ -6628,24 +6615,10 @@ SDValue SelectionDAGBuilder::createProtectedCtSelectFallback(
   // Create mask: sign-extend condition to all bits
   SDValue Mask = DAG.getSExtOrTrunc(Cond, DL, WorkingVT);
 
-  // Create all-ones constant for inversion
-  SDValue AllOnes;
-  if (WorkingVT.isScalableVector()) {
-    unsigned BitWidth = WorkingVT.getScalarSizeInBits();
-    APInt AllOnesVal = APInt::getAllOnes(BitWidth);
-    SDValue ScalarAllOnes =
-        DAG.getConstant(AllOnesVal, DL, WorkingVT.getScalarType());
-    AllOnes = DAG.getSplatVector(WorkingVT, DL, ScalarAllOnes);
-  } else {
-    AllOnes = DAG.getAllOnesConstant(DL, WorkingVT);
-  }
-
-  // Invert mask for false value
-  SDValue Invert = DAG.getNode(ISD::XOR, DL, WorkingVT, Mask, AllOnes);
-
-  // Compute: (T & Mask) | (F & ~Mask)
+  // Compute: F ^ ((T ^ F) & Mask)
   // This is constant-time because both branches are always computed
-  SDValue TM = DAG.getNode(ISD::AND, DL, WorkingVT, Mask, WorkingT);
+  SDValue XorTF = DAG.getNode(ISD::XOR, DL, WorkingVT, WorkingT, WorkingF);
+  SDValue TM = DAG.getNode(ISD::AND, DL, WorkingVT, XorTF, Mask);
 
   // DAG chaining: create data dependency through virtual register
   // This prevents optimizations from reordering or eliminating operations
@@ -6653,10 +6626,15 @@ SDValue SelectionDAGBuilder::createProtectedCtSelectFallback(
   bool CanUseChaining = false;
 
   if (!WorkingVT.isScalableVector()) {
-    // For fixed-size vectors and scalars, check if type is legal
+    // For fixed-size vectors and scalars, chaining is a best-effort hardening
+    // step. The CT guarantee comes from the dataflow-only select
+    // pattern (both sides computed, no control-flow). Chaining only adds an
+    // extra dependency to discourage later combines.
     CanUseChaining = TLI.isTypeLegal(WorkingVT.getSimpleVT());
   } else {
-    // For scalable vectors, disable chaining (conservative approach)
+    // For scalable vectors, skip chaining because there is no stable register
+    // class to copy through. CT behavior still relies on the masking/select
+    // pattern above.
     CanUseChaining = false;
   }
 
@@ -6668,8 +6646,7 @@ SDValue SelectionDAGBuilder::createProtectedCtSelectFallback(
     TM = DAG.getCopyFromReg(Chain, DL, TMReg, WorkingVT);
   }
 
-  SDValue FM = DAG.getNode(ISD::AND, DL, WorkingVT, Invert, WorkingF);
-  SDValue Result = DAG.getNode(ISD::OR, DL, WorkingVT, TM, FM);
+  SDValue Result = DAG.getNode(ISD::XOR, DL, WorkingVT, WorkingF, TM);
 
   // Convert back to original type if needed
   if (WorkingVT != VT) {
@@ -6878,9 +6855,7 @@ void SelectionDAGBuilder::visitIntrinsicCall(const CallInst &I,
     assert(!CondVT.isVector() && "Vector type cond not supported yet");
 
     // Handle scalar types
-    if (TLI.isSelectSupported(
-            TargetLoweringBase::SelectSupportKind::CtSelect) &&
-        !CondVT.isVector()) {
+    if (TLI.isCtSelectSupported(VT) && !CondVT.isVector()) {
       SDValue Result = DAG.getNode(ISD::CTSELECT, DL, VT, Cond, A, B);
       setValue(&I, Result);
       return;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -157,6 +157,8 @@ public:
   EVT getSetCCResultType(const DataLayout &DL, LLVMContext &Context,
                          EVT VT) const override;
 
+  bool isCtSelectSupported(EVT VT) const override { return false; }
+
   SDValue ReconstructShuffle(SDValue Op, SelectionDAG &DAG) const;
 
   MachineBasicBlock *EmitF128CSEL(MachineInstr &MI,

--- a/llvm/lib/Target/ARM/ARMISelLowering.h
+++ b/llvm/lib/Target/ARM/ARMISelLowering.h
@@ -119,6 +119,8 @@ class VectorType;
       return (Kind != ScalarCondVectorVal);
     }
 
+    bool isCtSelectSupported(EVT VT) const override { return false; }
+
     bool isReadOnly(const GlobalValue *GV) const;
 
     /// getSetCCResultType - Return the value type to use for ISD::SETCC.

--- a/llvm/lib/Target/X86/X86ISelLowering.h
+++ b/llvm/lib/Target/X86/X86ISelLowering.h
@@ -1078,6 +1078,8 @@ namespace llvm {
     unsigned getJumpTableEncoding() const override;
     bool useSoftFloat() const override;
 
+    bool isCtSelectSupported(EVT VT) const override { return false; }
+
     void markLibCallAttributes(MachineFunction *MF, unsigned CC,
                                ArgListTy &Args) const override;
 


### PR DESCRIPTION
This pull request refactors and improves the **fallback handling** of constant-time select (CTSELECT) in LLVM’s code generation infrastructure. The changes clarify semantics, simplify target-capability checks, and improve the correctness and maintainability of fallback lowering, without changing the intended constant-time guarantees.

### Summary of Changes

- **CTSELECT semantics**
  - Clarified documentation for the `CTSELECT` node to explicitly describe its operands and its role as the lowering target for the constant-time select intrinsic.

- **TargetLowering cleanup**
  - Removed CTSELECT-specific entries from `SelectSupportKind`.
  - Introduced a dedicated `isCtSelectSupported(EVT)` hook to cleanly separate ISA select support from constant-time guarantees.
  - Updated intrinsic lowering to use this new capability check.

- **Fallback implementation improvements**
  - Updated the generic SelectionDAG fallback lowering to use the canonical bitwise formulation:
    ```
    F ^ ((T ^ F) & Mask)
    ```
  - Simplified handling of vector splats and bitcasting in the fallback path.

- **DAGCombiner refactor**
  - Renamed and clarified CTSELECT-related DAGCombiner code paths for improved readability.

- **Miscellaneous cleanups**
  - Improved documentation headers for constant-time intrinsics.
  - Removed unused flags and minor nits uncovered during review.

These changes primarily affect the **generic fallback path** used when targets do not provide specialized CTSELECT lowering. Target-specific implementations are handled in follow-up PRs