### PR TITLE
[libc++] Throw future_error in future.get()

### DIFF
--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -986,6 +986,8 @@ future<_Rp>::~future() {
 
 template <class _Rp>
 _Rp future<_Rp>::get() {
+  if (__state_ == nullptr)
+    std::__throw_future_error(future_errc::no_state);
   unique_ptr<__shared_count, __release_shared_count> __guard(__state_);
   __assoc_state<_Rp>* __s = __state_;
   __state_                = nullptr;
@@ -1053,6 +1055,8 @@ future<_Rp&>::~future() {
 
 template <class _Rp>
 _Rp& future<_Rp&>::get() {
+  if (__state_ == nullptr)
+    std::__throw_future_error(future_errc::no_state);
   unique_ptr<__shared_count, __release_shared_count> __guard(__state_);
   __assoc_state<_Rp&>* __s = __state_;
   __state_                 = nullptr;

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -985,6 +985,8 @@ future<_Rp>::~future() {
 
 template <class _Rp>
 _Rp future<_Rp>::get() {
+  if (__state_ == nullptr)
+    std::__throw_future_error(future_errc::no_state);
   unique_ptr<__shared_count, __release_shared_count> __guard(__state_);
   __assoc_state<_Rp>* __s = __state_;
   __state_                = nullptr;
@@ -1052,6 +1054,8 @@ future<_Rp&>::~future() {
 
 template <class _Rp>
 _Rp& future<_Rp&>::get() {
+  if (__state_ == nullptr)
+    std::__throw_future_error(future_errc::no_state);
   unique_ptr<__shared_count, __release_shared_count> __guard(__state_);
   __assoc_state<_Rp&>* __s = __state_;
   __state_                 = nullptr;

--- a/libcxx/src/future.cpp
+++ b/libcxx/src/future.cpp
@@ -133,6 +133,8 @@ future<void>::~future() {
 }
 
 void future<void>::get() {
+  if (__state_ == nullptr)
+    std::__throw_future_error(future_errc::no_state);
   unique_ptr<__shared_count, __release_shared_count> __(__state_);
   __assoc_sub_state* __s = __state_;
   __state_               = nullptr;

--- a/libcxx/src/future.cpp
+++ b/libcxx/src/future.cpp
@@ -132,6 +132,8 @@ future<void>::~future() {
 }
 
 void future<void>::get() {
+  if (__state_ == nullptr)
+    std::__throw_future_error(future_errc::no_state);
   unique_ptr<__shared_count, __release_shared_count> __(__state_);
   __assoc_sub_state* __s = __state_;
   __state_               = nullptr;

--- a/libcxx/test/extensions/all/thread/futures/futures.unique_future/get.pass.cpp
+++ b/libcxx/test/extensions/all/thread/futures/futures.unique_future/get.pass.cpp
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: no-threads
+// UNSUPPORTED: c++03
+// UNSUPPORTED: no-exceptions
+
+// <future>
+
+// class future<R>
+
+// R future::get();
+// R& future<R&>::get();
+// void future<void>::get();
+
+#include <future>
+#include <cassert>
+
+#include "test_macros.h"
+
+int main(int, char**)
+{
+#ifndef TEST_HAS_NO_EXCEPTIONS
+    {
+        std::future<int> f;
+        try {
+            (void)f.get();
+            assert(false);
+        } catch (const std::future_error& e) {
+            assert(e.code() == std::make_error_code(std::future_errc::no_state));
+        }
+    }
+    {
+        std::promise<int> p;
+        std::future<int> f = p.get_future();
+        p.set_value(3);
+        (void)f.get();
+        try {
+            (void)f.get();
+            assert(false);
+        } catch (const std::future_error& e) {
+            assert(e.code() == std::make_error_code(std::future_errc::no_state));
+        }
+    }
+    {
+        std::future<int&> f;
+        try {
+            (void)f.get();
+            assert(false);
+        } catch (const std::future_error& e) {
+            assert(e.code() == std::make_error_code(std::future_errc::no_state));
+        }
+    }
+    {
+        std::promise<int&> p;
+        std::future<int&> f = p.get_future();
+        int j_val = 5;
+        p.set_value(j_val);
+        (void)f.get();
+        try {
+            (void)f.get();
+            assert(false);
+        } catch (const std::future_error& e) {
+            assert(e.code() == std::make_error_code(std::future_errc::no_state));
+        }
+    }
+    {
+        std::future<void> f;
+        try {
+            (void)f.get();
+            assert(false);
+        } catch (const std::future_error& e) {
+            assert(e.code() == std::make_error_code(std::future_errc::no_state));
+        }
+    }
+    {
+        std::promise<void> p;
+        std::future<void> f = p.get_future();
+        p.set_value();
+        (void)f.get();
+        try {
+            (void)f.get();
+            assert(false);
+        } catch (const std::future_error& e) {
+            assert(e.code() == std::make_error_code(std::future_errc::no_state));
+        }
+    }
+#endif
+
+  return 0;
+}

--- a/libcxx/test/extensions/all/thread/futures/futures.unique_future/get.pass.cpp
+++ b/libcxx/test/extensions/all/thread/futures/futures.unique_future/get.pass.cpp
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// UNSUPPORTED: no-threads
+// UNSUPPORTED: c++03
+// UNSUPPORTED: no-exceptions
+
+// <future>
+
+// class future<R>
+
+// R future::get();
+// R& future<R&>::get();
+// void future<void>::get();
+
+#include <future>
+#include <cassert>
+
+int main(int, char**) {
+  {
+    std::future<int> f;
+    try {
+      (void)f.get();
+      assert(false);
+    } catch (const std::future_error& e) {
+      assert(e.code() == std::make_error_code(std::future_errc::no_state));
+    }
+  }
+  {
+    std::promise<int> p;
+    std::future<int> f = p.get_future();
+    p.set_value(3);
+    (void)f.get();
+    try {
+      (void)f.get();
+      assert(false);
+    } catch (const std::future_error& e) {
+      assert(e.code() == std::make_error_code(std::future_errc::no_state));
+    }
+  }
+  {
+    std::future<int&> f;
+    try {
+      (void)f.get();
+      assert(false);
+    } catch (const std::future_error& e) {
+      assert(e.code() == std::make_error_code(std::future_errc::no_state));
+    }
+  }
+  {
+    std::promise<int&> p;
+    std::future<int&> f = p.get_future();
+    int j_val           = 5;
+    p.set_value(j_val);
+    (void)f.get();
+    try {
+      (void)f.get();
+      assert(false);
+    } catch (const std::future_error& e) {
+      assert(e.code() == std::make_error_code(std::future_errc::no_state));
+    }
+  }
+  {
+    std::future<void> f;
+    try {
+      (void)f.get();
+      assert(false);
+    } catch (const std::future_error& e) {
+      assert(e.code() == std::make_error_code(std::future_errc::no_state));
+    }
+  }
+  {
+    std::promise<void> p;
+    std::future<void> f = p.get_future();
+    p.set_value();
+    (void)f.get();
+    try {
+      (void)f.get();
+      assert(false);
+    } catch (const std::future_error& e) {
+      assert(e.code() == std::make_error_code(std::future_errc::no_state));
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
fix segfault when we call future.get() twice, it's future_error in libstdc++ and recommended throw future_error in cppref

https://en.cppreference.com/w/cpp/thread/future/get.html

<img width="815" height="90" alt="image" src="https://github.com/user-attachments/assets/c201bb60-e3b4-4080-bba2-ffda8bab514d" />
