### PR TITLE
OCaml bindings: Remove `ctypes` dependency

### DIFF
--- a/llvm/bindings/ocaml/README.txt
+++ b/llvm/bindings/ocaml/README.txt
@@ -5,7 +5,6 @@ Prerequisites
 -------------
 
 * OCaml 4.00.0+.
-* ctypes 0.4+.
 * CMake (to build LLVM).
 
 Building the bindings

--- a/llvm/bindings/ocaml/executionengine/CMakeLists.txt
+++ b/llvm/bindings/ocaml/executionengine/CMakeLists.txt
@@ -3,5 +3,4 @@ add_ocaml_library(llvm_executionengine
   OCAMLDEP llvm llvm_target
   C        executionengine_ocaml
   CFLAGS   "-I${CMAKE_CURRENT_SOURCE_DIR}/../llvm"
-  LLVM     ExecutionEngine MCJIT native
-  PKG      ctypes)
+  LLVM     ExecutionEngine MCJIT native)

--- a/llvm/bindings/ocaml/executionengine/llvm_executionengine.ml
+++ b/llvm/bindings/ocaml/executionengine/llvm_executionengine.ml
@@ -42,29 +42,12 @@ external run_static_dtors : llexecutionengine -> unit
   = "llvm_ee_run_static_dtors"
 external data_layout : llexecutionengine -> Llvm_target.DataLayout.t
   = "llvm_ee_get_data_layout"
-external add_global_mapping_ : Llvm.llvalue -> nativeint -> llexecutionengine -> unit
+external add_global_mapping : Llvm.llvalue -> nativeint -> llexecutionengine -> unit
   = "llvm_ee_add_global_mapping"
-external get_global_value_address_ : string -> llexecutionengine -> nativeint
+external get_global_value_address : string -> llexecutionengine -> nativeint
   = "llvm_ee_get_global_value_address"
-external get_function_address_ : string -> llexecutionengine -> nativeint
+external get_function_address : string -> llexecutionengine -> nativeint
   = "llvm_ee_get_function_address"
-
-let add_global_mapping llval ptr ee =
-  add_global_mapping_ llval (Ctypes.raw_address_of_ptr (Ctypes.to_voidp ptr)) ee
-
-let get_global_value_address name typ ee =
-  let vptr = get_global_value_address_ name ee in
-  if Nativeint.to_int vptr <> 0 then
-    let open Ctypes in !@ (coerce (ptr void) (ptr typ) (ptr_of_raw_address vptr))
-  else
-    raise (Error ("Value " ^ name ^ " not found"))
-
-let get_function_address name typ ee =
-  let fptr = get_function_address_ name ee in
-  if Nativeint.to_int fptr <> 0 then
-    let open Ctypes in coerce (ptr void) typ (ptr_of_raw_address fptr)
-  else
-    raise (Error ("Function " ^ name ^ " not found"))
 
 (* The following are not bound. Patches are welcome.
 target_machine : llexecutionengine -> Llvm_target.TargetMachine.t

--- a/llvm/bindings/ocaml/executionengine/llvm_executionengine.mli
+++ b/llvm/bindings/ocaml/executionengine/llvm_executionengine.mli
@@ -73,20 +73,18 @@ val data_layout : llexecutionengine -> Llvm_target.DataLayout.t
     the global [gv] is at the specified location [ptr], which must outlive
     [gv] and [ee].
     All uses of [gv] in the compiled code will refer to [ptr]. *)
-val add_global_mapping : Llvm.llvalue -> 'a Ctypes.ptr -> llexecutionengine -> unit
+val add_global_mapping : Llvm.llvalue -> nativeint -> llexecutionengine -> unit
 
-(** [get_global_value_address id typ ee] returns a pointer to the
-    identifier [id] as type [typ], which will be a pointer type for a
-    value, and which will be live as long as [id] and [ee]
+(** [get_global_value_address id ee] returns a pointer to the
+    identifier [id], and which will be live as long as [id] and [ee]
     are. Caution: this function finalizes, i.e. forces code
     generation, all loaded modules.  Further modifications to the
     modules will not have any effect. *)
-val get_global_value_address : string -> 'a Ctypes.typ -> llexecutionengine -> 'a
+val get_global_value_address : string -> llexecutionengine -> nativeint
 
-(** [get_function_address fn typ ee] returns a pointer to the function
-    [fn] as type [typ], which will be a pointer type for a function
-    (e.g. [(int -> int) typ]), and which will be live as long as [fn]
-    and [ee] are. Caution: this function finalizes, i.e. forces code
+(** [get_function_address fn ee] returns a pointer to the function
+    [fn], and which will be live as long as [fn] and [ee] are.
+    Caution: this function finalizes, i.e. forces code
     generation, all loaded modules.  Further modifications to the
     modules will not have any effect. *)
-val get_function_address : string -> 'a Ctypes.typ -> llexecutionengine -> 'a
+val get_function_address : string -> llexecutionengine -> nativeint

--- a/llvm/bindings/ocaml/llvm/META.llvm.in
+++ b/llvm/bindings/ocaml/llvm/META.llvm.in
@@ -30,7 +30,7 @@ package "bitwriter" (
 )
 
 package "executionengine" (
-    requires = "llvm,llvm.target,ctypes"
+    requires = "llvm,llvm.target"
     version = "@PACKAGE_VERSION@"
     description = "JIT and Interpreter for LLVM"
     archive(byte) = "llvm_executionengine.cma"


### PR DESCRIPTION
This PR proposes to remove the `ctypes` dependency on the OCaml bindings. This dependency is used in a completely trivial manner by the bindings (essentially to implement an "identity" cast), and removing it makes the bindings easier to use in OPAM-less environments or environments where `ctypes` is harder to use (eg Windows).

cc @alan-j-hu