### PR TITLE
[HLSL][DXIL][SPIRV] WavePrefixProduct intrinsic support

### DIFF
--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -5210,6 +5210,12 @@ def HLSLWavePrefixSum : LangBuiltin<"HLSL_LANG"> {
   let Prototype = "void(...)";
 }
 
+def HLSLWavePrefixProduct : LangBuiltin<"HLSL_LANG"> {
+  let Spellings = ["__builtin_hlsl_wave_prefix_product"];
+  let Attributes = [NoThrow, Const];
+  let Prototype = "void(...)";
+}
+
 def HLSLClamp : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_elementwise_clamp"];
   let Attributes = [NoThrow, Const, CustomTypeChecking];

--- a/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_alias_intrinsics.h
@@ -3008,6 +3008,105 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_sum)
 __attribute__((convergent)) double4 WavePrefixSum(double4);
 
 //===----------------------------------------------------------------------===//
+// WavePrefixProduct builtins
+//===----------------------------------------------------------------------===//
+
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) half WavePrefixProduct(half);
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) half2 WavePrefixProduct(half2);
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) half3 WavePrefixProduct(half3);
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) half4 WavePrefixProduct(half4);
+
+#ifdef __HLSL_ENABLE_16_BIT
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int16_t WavePrefixProduct(int16_t);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int16_t2 WavePrefixProduct(int16_t2);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int16_t3 WavePrefixProduct(int16_t3);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int16_t4 WavePrefixProduct(int16_t4);
+
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint16_t WavePrefixProduct(uint16_t);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint16_t2 WavePrefixProduct(uint16_t2);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint16_t3 WavePrefixProduct(uint16_t3);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint16_t4 WavePrefixProduct(uint16_t4);
+#endif
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int WavePrefixProduct(int);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int2 WavePrefixProduct(int2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int3 WavePrefixProduct(int3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int4 WavePrefixProduct(int4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint WavePrefixProduct(uint);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint2 WavePrefixProduct(uint2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint3 WavePrefixProduct(uint3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint4 WavePrefixProduct(uint4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int64_t WavePrefixProduct(int64_t);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int64_t2 WavePrefixProduct(int64_t2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int64_t3 WavePrefixProduct(int64_t3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) int64_t4 WavePrefixProduct(int64_t4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint64_t WavePrefixProduct(uint64_t);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint64_t2 WavePrefixProduct(uint64_t2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint64_t3 WavePrefixProduct(uint64_t3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) uint64_t4 WavePrefixProduct(uint64_t4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) float WavePrefixProduct(float);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) float2 WavePrefixProduct(float2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) float3 WavePrefixProduct(float3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) float4 WavePrefixProduct(float4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) double WavePrefixProduct(double);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) double2 WavePrefixProduct(double2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) double3 WavePrefixProduct(double3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_prefix_product)
+__attribute__((convergent)) double4 WavePrefixProduct(double4);
+
+//===----------------------------------------------------------------------===//
 // sign builtins
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -3885,7 +3885,8 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
       return true;
     break;
   }
-  case Builtin::BI__builtin_hlsl_wave_prefix_sum: {
+  case Builtin::BI__builtin_hlsl_wave_prefix_sum:
+  case Builtin::BI__builtin_hlsl_wave_prefix_product: {
     if (SemaRef.checkArgCount(TheCall, 1))
       return true;
 

--- a/clang/test/CodeGenHLSL/builtins/WavePrefixProduct.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/WavePrefixProduct.hlsl
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -triple \
+// RUN:   dxil-pc-shadermodel6.3-compute %s -emit-llvm -disable-llvm-passes -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,CHECK-DXIL
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -triple \
+// RUN:   spirv-pc-vulkan-compute %s -emit-llvm -disable-llvm-passes -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,CHECK-SPIRV
+
+// Test basic lowering to runtime function call.
+
+// CHECK-LABEL: test_int
+int test_int(int expr) {
+  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.wave.prefix.product.i32([[TY]] %[[#]])
+  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.wave.prefix.product.i32([[TY]] %[[#]])
+  // CHECK:  ret [[TY]] %[[RET]]
+  return WavePrefixProduct(expr);
+}
+
+// CHECK-DXIL: declare [[TY]] @llvm.dx.wave.prefix.product.i32([[TY]]) #[[#attr:]]
+// CHECK-SPIRV: declare [[TY]] @llvm.spv.wave.prefix.product.i32([[TY]]) #[[#attr:]]
+
+// CHECK-LABEL: test_uint64_t
+uint64_t test_uint64_t(uint64_t expr) {
+  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.wave.prefix.product.i64([[TY]] %[[#]])
+  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.wave.prefix.uproduct.i64([[TY]] %[[#]])
+  // CHECK:  ret [[TY]] %[[RET]]
+  return WavePrefixProduct(expr);
+}
+
+// CHECK-DXIL: declare [[TY]] @llvm.dx.wave.prefix.uproduct.i64([[TY]]) #[[#attr:]]
+// CHECK-SPIRV: declare [[TY]] @llvm.spv.wave.prefix.product.i64([[TY]]) #[[#attr:]]
+
+// Test basic lowering to runtime function call with array and float value.
+
+// CHECK-LABEL: test_floatv4
+float4 test_floatv4(float4 expr) {
+  // CHECK-SPIRV:  %[[RET1:.*]] = call reassoc nnan ninf nsz arcp afn spir_func [[TY1:.*]] @llvm.spv.wave.prefix.product.v4f32([[TY1]] %[[#]]
+  // CHECK-DXIL:  %[[RET1:.*]] = call reassoc nnan ninf nsz arcp afn [[TY1:.*]] @llvm.dx.wave.prefix.product.v4f32([[TY1]] %[[#]])
+  // CHECK:  ret [[TY1]] %[[RET1]]
+  return WavePrefixProduct(expr);
+}
+
+// CHECK-DXIL: declare [[TY1]] @llvm.dx.wave.prefix.product.v4f32([[TY1]]) #[[#attr]]
+// CHECK-SPIRV: declare [[TY1]] @llvm.spv.wave.prefix.product.v4f32([[TY1]]) #[[#attr]]
+
+// CHECK: attributes #[[#attr]] = {{{.*}} convergent {{.*}}}
+

--- a/clang/test/SemaHLSL/BuiltIns/WavePrefixProduct-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/WavePrefixProduct-errors.hlsl
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -emit-llvm-only -disable-llvm-passes -verify
+
+int test_too_few_arg() {
+  return __builtin_hlsl_wave_prefix_product();
+  // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
+}
+
+float2 test_too_many_arg(float2 p0) {
+  return __builtin_hlsl_wave_prefix_product(p0, p0);
+  // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
+}
+
+bool test_expr_bool_type_check(bool p0) {
+  return __builtin_hlsl_wave_prefix_product(p0);
+  // expected-error@-1 {{invalid operand of type 'bool'}}
+}
+
+bool2 test_expr_bool_vec_type_check(bool2 p0) {
+  return __builtin_hlsl_wave_prefix_product(p0);
+  // expected-error@-1 {{invalid operand of type 'bool2' (aka 'vector<bool, 2>')}}
+}
+
+struct S { float f; };
+
+S test_expr_struct_type_check(S p0) {
+  return __builtin_hlsl_wave_prefix_product(p0);
+  // expected-error@-1 {{invalid operand of type 'S' where a scalar or vector is required}}
+}

--- a/llvm/include/llvm/IR/IntrinsicsDirectX.td
+++ b/llvm/include/llvm/IR/IntrinsicsDirectX.td
@@ -229,6 +229,8 @@ def int_dx_wave_get_lane_count
     : DefaultAttrsIntrinsic<[llvm_i32_ty], [], [IntrConvergent]>;
 def int_dx_wave_prefix_sum : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
 def int_dx_wave_prefix_usum : DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
+def int_dx_wave_prefix_product : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
+def int_dx_wave_prefix_uproduct : DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
 def int_dx_sign : DefaultAttrsIntrinsic<[LLVMScalarOrSameVectorWidth<0, llvm_i32_ty>], [llvm_any_ty], [IntrNoMem]>;
 def int_dx_step : DefaultAttrsIntrinsic<[LLVMMatchType<0>], [llvm_anyfloat_ty, LLVMMatchType<0>], [IntrNoMem]>;
 def int_dx_splitdouble : DefaultAttrsIntrinsic<[llvm_anyint_ty, LLVMMatchType<0>],

--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -134,6 +134,7 @@ def int_spv_rsqrt : DefaultAttrsIntrinsic<[LLVMMatchType<0>], [llvm_anyfloat_ty]
   def int_spv_wave_get_lane_count
       : DefaultAttrsIntrinsic<[llvm_i32_ty], [], [IntrConvergent]>;
   def int_spv_wave_prefix_sum : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
+  def int_spv_wave_prefix_product : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
   def int_spv_sign : DefaultAttrsIntrinsic<[LLVMScalarOrSameVectorWidth<0, llvm_i32_ty>], [llvm_any_ty], [IntrNoMem]>;
   def int_spv_radians : DefaultAttrsIntrinsic<[LLVMMatchType<0>], [llvm_anyfloat_ty], [IntrNoMem]>;
   def int_spv_group_memory_barrier_with_group_sync : ClangBuiltin<"__builtin_spirv_group_barrier">,

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -1137,6 +1137,16 @@ def WavePrefixOp : DXILOp<121, wavePrefixOp> {
                    IntrinArgIndex<0>, IntrinArgI8<WaveOpKind_Sum>,
                    IntrinArgI8<SignedOpKind_Unsigned>
                  ]>,
+    IntrinSelect<int_dx_wave_prefix_product,
+                 [
+                   IntrinArgIndex<0>, IntrinArgI8<WaveOpKind_Product>,
+                   IntrinArgI8<SignedOpKind_Signed>
+                 ]>,
+    IntrinSelect<int_dx_wave_prefix_uproduct,
+                 [
+                   IntrinArgIndex<0>, IntrinArgI8<WaveOpKind_Product>,
+                   IntrinArgI8<SignedOpKind_Unsigned>
+                 ]>,
   ];
 
   let arguments = [OverloadTy, Int8Ty, Int8Ty];

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -100,6 +100,8 @@ static bool checkWaveOps(Intrinsic::ID IID) {
     // Wave Prefix Op Variants
   case Intrinsic::dx_wave_prefix_sum:
   case Intrinsic::dx_wave_prefix_usum:
+  case Intrinsic::dx_wave_prefix_product:
+  case Intrinsic::dx_wave_prefix_uproduct:
     return true;
   }
 }

--- a/llvm/lib/Target/DirectX/DirectXTargetTransformInfo.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetTransformInfo.cpp
@@ -62,10 +62,12 @@ bool DirectXTTIImpl::isTargetIntrinsicTriviallyScalarizable(
   case Intrinsic::dx_wave_reduce_min:
   case Intrinsic::dx_wave_reduce_sum:
   case Intrinsic::dx_wave_prefix_sum:
+  case Intrinsic::dx_wave_prefix_product:
   case Intrinsic::dx_wave_reduce_umax:
   case Intrinsic::dx_wave_reduce_umin:
   case Intrinsic::dx_wave_reduce_usum:
   case Intrinsic::dx_wave_prefix_usum:
+  case Intrinsic::dx_wave_prefix_uproduct:
   case Intrinsic::dx_imad:
   case Intrinsic::dx_umad:
   case Intrinsic::dx_ddx_coarse:

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -258,6 +258,9 @@ private:
   bool selectWaveExclusiveScanSum(Register ResVReg, SPIRVTypeInst ResType,
                                   MachineInstr &I) const;
 
+  bool selectWaveExclusiveScanProduct(Register ResVReg, SPIRVTypeInst ResType,
+                                      MachineInstr &I) const;
+
   bool selectConst(Register ResVReg, SPIRVTypeInst ResType,
                    MachineInstr &I) const;
 
@@ -2956,6 +2959,18 @@ bool SPIRVInstructionSelector::selectWaveExclusiveScanSum(
                                  });
 }
 
+bool SPIRVInstructionSelector::selectWaveExclusiveScanProduct(
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
+  return selectWaveExclusiveScan(ResVReg, ResType, I, /*IsUnsigned*/ false,
+                                 [&](Register InputRegister, bool IsUnsigned) {
+                                   bool IsFloatTy = GR.isScalarOrVectorOfType(
+                                       InputRegister, SPIRV::OpTypeFloat);
+                                   return IsFloatTy
+                                              ? SPIRV::OpGroupNonUniformFMul
+                                              : SPIRV::OpGroupNonUniformIMul;
+                                 });
+}
+
 template <typename PickOpcodeFn>
 bool SPIRVInstructionSelector::selectWaveExclusiveScan(
     Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I, bool IsUnsigned,
@@ -4092,6 +4107,8 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
                             SPIRV::OpGroupNonUniformShuffle);
   case Intrinsic::spv_wave_prefix_sum:
     return selectWaveExclusiveScanSum(ResVReg, ResType, I);
+  case Intrinsic::spv_wave_prefix_product:
+    return selectWaveExclusiveScanProduct(ResVReg, ResType, I);
   case Intrinsic::spv_step:
     return selectExtInst(ResVReg, ResType, I, CL::step, GL::Step);
   case Intrinsic::spv_radians:

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/wave-ops.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/wave-ops.ll
@@ -125,3 +125,17 @@ entry:
   %ret = call i32 @llvm.dx.wave.prefix.usum.i32(i32 %x)
   ret i32 %ret
 }
+
+define noundef i32 @wave_prefix_product(i32 noundef %x) {
+entry:
+  ; CHECK: Function wave_prefix_product : [[WAVE_FLAG]]
+  %ret = call i32 @llvm.dx.wave.prefix.product.i32(i32 %x)
+  ret i32 %ret
+}
+
+define noundef i32 @wave_prefix_uproduct(i32 noundef %x) {
+entry:
+  ; CHECK: Function wave_prefix_uproduct : [[WAVE_FLAG]]
+  %ret = call i32 @llvm.dx.wave.prefix.uproduct.i32(i32 %x)
+  ret i32 %ret
+}

--- a/llvm/test/CodeGen/DirectX/WavePrefixProduct.ll
+++ b/llvm/test/CodeGen/DirectX/WavePrefixProduct.ll
@@ -1,0 +1,143 @@
+; RUN: opt -S -scalarizer -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-library < %s | FileCheck %s
+
+; Test that for scalar values, WavePrefixProduct maps down to the DirectX op
+
+define noundef half @wave_prefix_product_half(half noundef %expr) {
+entry:
+; CHECK: call half @dx.op.wavePrefixOp.f16(i32 121, half %expr, i8 1, i8 0)
+  %ret = call half @llvm.dx.wave.prefix.product.f16(half %expr)
+  ret half %ret
+}
+
+define noundef float @wave_prefix_product_float(float noundef %expr) {
+entry:
+; CHECK: call float @dx.op.wavePrefixOp.f32(i32 121, float %expr, i8 1, i8 0)
+  %ret = call float @llvm.dx.wave.prefix.product.f32(float %expr)
+  ret float %ret
+}
+
+define noundef double @wave_prefix_product_double(double noundef %expr) {
+entry:
+; CHECK: call double @dx.op.wavePrefixOp.f64(i32 121, double %expr, i8 1, i8 0)
+  %ret = call double @llvm.dx.wave.prefix.product.f64(double %expr)
+  ret double %ret
+}
+
+define noundef i16 @wave_prefix_product_i16(i16 noundef %expr) {
+entry:
+; CHECK: call i16 @dx.op.wavePrefixOp.i16(i32 121, i16 %expr, i8 1, i8 0)
+  %ret = call i16 @llvm.dx.wave.prefix.product.i16(i16 %expr)
+  ret i16 %ret
+}
+
+define noundef i32 @wave_prefix_product_i32(i32 noundef %expr) {
+entry:
+; CHECK: call i32 @dx.op.wavePrefixOp.i32(i32 121, i32 %expr, i8 1, i8 0)
+  %ret = call i32 @llvm.dx.wave.prefix.product.i32(i32 %expr)
+  ret i32 %ret
+}
+
+define noundef i64 @wave_prefix_product_i64(i64 noundef %expr) {
+entry:
+; CHECK: call i64 @dx.op.wavePrefixOp.i64(i32 121, i64 %expr, i8 1, i8 0)
+  %ret = call i64 @llvm.dx.wave.prefix.product.i64(i64 %expr)
+  ret i64 %ret
+}
+
+define noundef i16 @wave_prefix_uproduct_i16(i16 noundef %expr) {
+entry:
+; CHECK: call i16 @dx.op.wavePrefixOp.i16(i32 121, i16 %expr, i8 1, i8 1)
+  %ret = call i16 @llvm.dx.wave.prefix.uproduct.i16(i16 %expr)
+  ret i16 %ret
+}
+
+define noundef i32 @wave_prefix_uproduct_i32(i32 noundef %expr) {
+entry:
+; CHECK: call i32 @dx.op.wavePrefixOp.i32(i32 121, i32 %expr, i8 1, i8 1)
+  %ret = call i32 @llvm.dx.wave.prefix.uproduct.i32(i32 %expr)
+  ret i32 %ret
+}
+
+define noundef i64 @wave_prefix_uproduct_i64(i64 noundef %expr) {
+entry:
+; CHECK: call i64 @dx.op.wavePrefixOp.i64(i32 121, i64 %expr, i8 1, i8 1)
+  %ret = call i64 @llvm.dx.wave.prefix.uproduct.i64(i64 %expr)
+  ret i64 %ret
+}
+
+declare half @llvm.dx.wave.prefix.product.f16(half)
+declare float @llvm.dx.wave.prefix.product.f32(float)
+declare double @llvm.dx.wave.prefix.product.f64(double)
+
+declare i16 @llvm.dx.wave.prefix.product.i16(i16)
+declare i32 @llvm.dx.wave.prefix.product.i32(i32)
+declare i64 @llvm.dx.wave.prefix.product.i64(i64)
+
+declare i16 @llvm.dx.wave.prefix.uproduct.i16(i16)
+declare i32 @llvm.dx.wave.prefix.uproduct.i32(i32)
+declare i64 @llvm.dx.wave.prefix.uproduct.i64(i64)
+
+; Test that for vector values, WavePrefixProduct scalarizes and maps down to the
+; DirectX op
+
+define noundef <2 x half> @wave_prefix_product_v2half(<2 x half> noundef %expr) {
+entry:
+; CHECK: call half @dx.op.wavePrefixOp.f16(i32 121, half %expr.i0, i8 1, i8 0)
+; CHECK: call half @dx.op.wavePrefixOp.f16(i32 121, half %expr.i1, i8 1, i8 0)
+  %ret = call <2 x half> @llvm.dx.wave.prefix.product.v2f16(<2 x half> %expr)
+  ret <2 x half> %ret
+}
+
+define noundef <3 x i32> @wave_prefix_product_v3i32(<3 x i32> noundef %expr) {
+entry:
+; CHECK: call i32 @dx.op.wavePrefixOp.i32(i32 121, i32 %expr.i0, i8 1, i8 0)
+; CHECK: call i32 @dx.op.wavePrefixOp.i32(i32 121, i32 %expr.i1, i8 1, i8 0)
+; CHECK: call i32 @dx.op.wavePrefixOp.i32(i32 121, i32 %expr.i2, i8 1, i8 0)
+  %ret = call <3 x i32> @llvm.dx.wave.prefix.product.v3i32(<3 x i32> %expr)
+  ret <3 x i32> %ret
+}
+
+define noundef <4 x double> @wave_prefix_product_v4f64(<4 x double> noundef %expr) {
+entry:
+; CHECK: call double @dx.op.wavePrefixOp.f64(i32 121, double %expr.i0, i8 1, i8 0)
+; CHECK: call double @dx.op.wavePrefixOp.f64(i32 121, double %expr.i1, i8 1, i8 0)
+; CHECK: call double @dx.op.wavePrefixOp.f64(i32 121, double %expr.i2, i8 1, i8 0)
+; CHECK: call double @dx.op.wavePrefixOp.f64(i32 121, double %expr.i3, i8 1, i8 0)
+  %ret = call <4 x double> @llvm.dx.wave.prefix.product.v464(<4 x double> %expr)
+  ret <4 x double> %ret
+}
+
+declare <2 x half> @llvm.dx.wave.prefix.product.v2f16(<2 x half>)
+declare <3 x i32> @llvm.dx.wave.prefix.product.v3i32(<3 x i32>)
+declare <4 x double> @llvm.dx.wave.prefix.product.v4f64(<4 x double>)
+
+define noundef <2 x i16> @wave_prefix_uproduct_v2i16(<2 x i16> noundef %expr) {
+entry:
+; CHECK: call i16 @dx.op.wavePrefixOp.i16(i32 121, i16 %expr.i0, i8 1, i8 1)
+; CHECK: call i16 @dx.op.wavePrefixOp.i16(i32 121, i16 %expr.i1, i8 1, i8 1)
+  %ret = call <2 x i16> @llvm.dx.wave.prefix.uproduct.v2f16(<2 x i16> %expr)
+  ret <2 x i16> %ret
+}
+
+define noundef <3 x i32> @wave_prefix_uproduct_v3i32(<3 x i32> noundef %expr) {
+entry:
+; CHECK: call i32 @dx.op.wavePrefixOp.i32(i32 121, i32 %expr.i0, i8 1, i8 1)
+; CHECK: call i32 @dx.op.wavePrefixOp.i32(i32 121, i32 %expr.i1, i8 1, i8 1)
+; CHECK: call i32 @dx.op.wavePrefixOp.i32(i32 121, i32 %expr.i2, i8 1, i8 1)
+  %ret = call <3 x i32> @llvm.dx.wave.prefix.uproduct.v3i32(<3 x i32> %expr)
+  ret <3 x i32> %ret
+}
+
+define noundef <4 x i64> @wave_prefix_uproduct_v4f64(<4 x i64> noundef %expr) {
+entry:
+; CHECK: call i64 @dx.op.wavePrefixOp.i64(i32 121, i64 %expr.i0, i8 1, i8 1)
+; CHECK: call i64 @dx.op.wavePrefixOp.i64(i32 121, i64 %expr.i1, i8 1, i8 1)
+; CHECK: call i64 @dx.op.wavePrefixOp.i64(i32 121, i64 %expr.i2, i8 1, i8 1)
+; CHECK: call i64 @dx.op.wavePrefixOp.i64(i32 121, i64 %expr.i3, i8 1, i8 1)
+  %ret = call <4 x i64> @llvm.dx.wave.prefix.uproduct.v464(<4 x i64> %expr)
+  ret <4 x i64> %ret
+}
+
+declare <2 x i16> @llvm.dx.wave.prefix.uproduct.v2f16(<2 x i16>)
+declare <3 x i32> @llvm.dx.wave.prefix.uproduct.v3i32(<3 x i32>)
+declare <4 x i64> @llvm.dx.wave.prefix.uproduct.v4f64(<4 x i64>)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/WavePrefixProduct.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/WavePrefixProduct.ll
@@ -1,0 +1,41 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-vulkan-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Test lowering to spir-v backend for various types and scalar/vector
+
+; CHECK-DAG:   %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG:   %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG:   %[[#uint:]] = OpTypeInt 32 0
+; CHECK-DAG:   %[[#v4_half:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG:   %[[#scope:]] = OpConstant %[[#uint]] 3
+
+; CHECK-LABEL: Begin function test_float
+; CHECK:   %[[#fexpr:]] = OpFunctionParameter %[[#f32]]
+define float @test_float(float %fexpr) {
+entry:
+; CHECK:   %[[#fret:]] = OpGroupNonUniformFMul %[[#f32]] %[[#scope]] ExclusiveScan %[[#fexpr]]
+  %0 = call float @llvm.spv.wave.prefix.product.f32(float %fexpr)
+  ret float %0
+}
+
+; CHECK-LABEL: Begin function test_int
+; CHECK:   %[[#iexpr:]] = OpFunctionParameter %[[#uint]]
+define i32 @test_int(i32 %iexpr) {
+entry:
+; CHECK:   %[[#iret:]] = OpGroupNonUniformIMul %[[#uint]] %[[#scope]] ExclusiveScan %[[#iexpr]]
+  %0 = call i32 @llvm.spv.wave.prefix.product.i32(i32 %iexpr)
+  ret i32 %0
+}
+
+; CHECK-LABEL: Begin function test_vhalf
+; CHECK:   %[[#vbexpr:]] = OpFunctionParameter %[[#v4_half]]
+define <4 x half> @test_vhalf(<4 x half> %vbexpr) {
+entry:
+; CHECK:   %[[#vhalfret:]] = OpGroupNonUniformFMul %[[#v4_half]] %[[#scope]] ExclusiveScan %[[#vbexpr]]
+  %0 = call <4 x half> @llvm.spv.wave.prefix.product.v4half(<4 x half> %vbexpr)
+  ret <4 x half> %0
+}
+
+declare float @llvm.spv.wave.prefix.product.f32(float)
+declare i32 @llvm.spv.wave.prefix.product.i32(i32)
+declare <4 x half> @llvm.spv.wave.prefix.product.v4half(<4 x half>)


### PR DESCRIPTION
This PR adds WavePrefixProduct intrinsic support in HLSL with codegen for both DirectX and SPIRV backends. Resolves https://github.com/llvm/llvm-project/issues/99173.

- [x] Implement `WavePrefixProduct` clang builtin
- [x] Link `WavePrefixProduct` clang builtin with `hlsl_intrinsics.h`
- [x] Add sema checks for `WavePrefixProduct` to `CheckHLSLBuiltinFunctionCall` in `SemaChecking.cpp`
- [x] Add codegen for `WavePrefixProduct` to `EmitHLSLBuiltinExpr` in `CGBuiltin.cpp`
- [x] Add codegen tests to `clang/test/CodeGenHLSL/builtins/WavePrefixProduct.hlsl`
- [x] Add sema tests to `clang/test/SemaHLSL/BuiltIns/WavePrefixProduct-errors.hlsl`
- [x] Create the `int_dx_WavePrefixProduct` intrinsic in `IntrinsicsDirectX.td`
- [x] Create the `DXILOpMapping` of `int_dx_WavePrefixProduct` to `121` in `DXIL.td`
- [x] Create the `WavePrefixProduct.ll` and `WavePrefixProduct_errors.ll` tests in `llvm/test/CodeGen/DirectX/`
- [x] Create the `int_spv_WavePrefixProduct` intrinsic in `IntrinsicsSPIRV.td`
- [x] In `SPIRVInstructionSelector.cpp` create the `WavePrefixProduct` lowering and map it to `int_spv_WavePrefixProduct` in `SPIRVInstructionSelector::selectIntrinsic`.
- [x] Create SPIR-V backend test case in `llvm/test/CodeGen/SPIRV/hlsl-intrinsics/WavePrefixProduct.ll`
