### PR TITLE
[AArch64][llvm] Remove `+xs` gating for `tlbip *nxs` instructions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -909,7 +909,7 @@ multiclass TLBI<string name, bit hasTLBIP, bits<3> op1, bits<4> crn, bits<4> crm
     }
     def : TLBIPEntry<!strconcat(name, "nXS"), op1, crn, crm, op2, needsreg, optionalreg> {
       let Encoding{7} = 1;
-      let ExtraRequires = ["AArch64::FeatureD128", "AArch64::FeatureXS"];
+      let ExtraRequires = ["AArch64::FeatureD128"];
     }
   }
 }

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64InstPrinter.cpp
@@ -1163,12 +1163,6 @@ bool AArch64InstPrinter::printSyspAlias(const MCInst *MI,
   if (CnVal == 8 || CnVal == 9) {
     // TLBIP aliases
 
-    if (CnVal == 9) {
-      if (!STI.hasFeature(AArch64::FeatureXS))
-        return false;
-      Encoding &= ~(1 << 7);
-    }
-
     const AArch64TLBIP::TLBIP *TLBIP =
         AArch64TLBIP::lookupTLBIPByEncoding(Encoding);
     if (!TLBIP || !TLBIP->haveFeatures(STI.getFeatureBits()))
@@ -1176,8 +1170,6 @@ bool AArch64InstPrinter::printSyspAlias(const MCInst *MI,
 
     Ins = "tlbip\t";
     Name = std::string(TLBIP->Name);
-    if (CnVal == 9)
-      Name += "nXS";
   } else
     return false;
 

--- a/llvm/test/MC/AArch64/armv9a-tlbip.s
+++ b/llvm/test/MC/AArch64/armv9a-tlbip.s
@@ -1,20 +1,19 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+d128,+tlb-rmi,+xs < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+d128,+tlb-rmi < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+tlb-rmi,+xs < %s 2>&1 \
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+tlb-rmi < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+d128,+tlb-rmi,+xs < %s \
-// RUN:        | llvm-objdump -d --mattr=+d128,+tlb-rmi,+xs --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+d128,+tlb-rmi,+xs < %s \
-// RUN:   | llvm-objdump -d --mattr=-d128,+tlb-rmi,+xs --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+d128,+tlb-rmi < %s \
+// RUN:        | llvm-objdump -d --mattr=+d128,+tlb-rmi --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+d128,+tlb-rmi < %s \
+// RUN:        | llvm-objdump -d --mattr=-d128,-tlb-rmi --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+d128,+tlb-rmi,+xs < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+d128,+tlb-rmi < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+d128,+tlb-rmi,+xs -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+d128,+tlb-rmi -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 // +d128 required for tlbip
 // +tbl-rmi required for RIPA*/RVA*
-// +xs required for *NXS
 
 tlbip IPAS2E1, x4, x5
 // CHECK-INST: tlbip ipas2e1, x4, x5


### PR DESCRIPTION
A recent specification update has removed `FEAT_XS` gating for `tlbip *nxs`
instructions. It remains gated on `FEAT_XS` for `tlbi *nxs` instructions.