### PR TITLE
Backport "Fix crash when copying uninitialized data in function named "swap""

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -903,6 +903,8 @@ Crash and bug fixes
 - The ``core.builtin.BuiltinFunctions`` checker crashed when passing
   ``_BitInt(N)`` or ``__int128_t`` to ``__builtin_add_overflow`` or similar
   checked arithmetic builtin functions. (#GH173795)
+- Fixed a crash introduced in clang-20 when analyzing some "swap" functions.
+  (#GH178797)
 
 Improvements
 ^^^^^^^^^^^^

--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -2659,11 +2659,8 @@ RegionStoreManager::bindArray(LimitedRegionBindingsConstRef B,
     return bindAggregate(B, R, Init);
   }
 
-  if (isa<nonloc::SymbolVal>(Init))
+  if (isa<nonloc::SymbolVal, UnknownVal, UndefinedVal>(Init))
     return bindAggregate(B, R, Init);
-
-  if (Init.isUnknown())
-    return bindAggregate(B, R, UnknownVal());
 
   // Remaining case: explicit compound values.
   const nonloc::CompoundVal& CV = Init.castAs<nonloc::CompoundVal>();

--- a/clang/test/Analysis/uninit-vals.cpp
+++ b/clang/test/Analysis/uninit-vals.cpp
@@ -33,3 +33,21 @@ void foo() {
 }
 }
 
+namespace gh_178797 {
+struct SpecialBuffer {
+    SpecialBuffer() : src(defaultBuffer), dst(defaultBuffer) {}
+    int* src;
+    int* dst;
+    int defaultBuffer[2];
+};
+// Not really a swap, but we need an assignment assigning UndefinedVal
+// within a "swap" function to trigger this behavior.
+void swap(int& lhs, int& rhs) {
+    lhs = rhs; // no-crash
+    // Not reporting copying uninitialized data because that is explicitly suppressed in the checker.
+}
+void entry_point() {
+    SpecialBuffer special;
+    swap(*special.dst, *++special.src);
+}
+}  // namespace gh_178797


### PR DESCRIPTION
Requested the backport in https://github.com/llvm/llvm-project/pull/178923#issuecomment-3837025990