### PR TITLE
llvm-cov: Fix a grammar error

### DIFF
--- a/llvm/tools/llvm-cov/CodeCoverage.cpp
+++ b/llvm/tools/llvm-cov/CodeCoverage.cpp
@@ -472,7 +472,9 @@ std::unique_ptr<CoverageMapping> CodeCoverageTool::load() {
   auto Coverage = std::move(CoverageOrErr.get());
   unsigned Mismatched = Coverage->getMismatchedCount();
   if (Mismatched) {
-    warning(Twine(Mismatched) + " functions have mismatched data");
+    Mismatched == 1
+        ? warning(Twine(Mismatched) + " function has mismatched data")
+        : warning(Twine(Mismatched) + " functions have mismatched data");
 
     if (ViewOpts.Debug) {
       for (const auto &HashMismatch : Coverage->getHashMismatches())


### PR DESCRIPTION
Fix the grammar of a print using plural for a singular case.