### PR TITLE
[libc++] Add hardening assertion test for `vector<bool>::operator[]`

### DIFF
--- a/libcxx/test/std/containers/sequences/vector.bool/assertions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/assertions.pass.cpp
@@ -1,0 +1,27 @@
+#include <vector>
+
+#include "test_macros.h"
+#include "check_assertion.h"
+
+
+int main(int, char**) {
+#if defined(_LIBCPP_HARDENING_MODE) && _LIBCPP_HARDENING_MODE != 0
+    {
+        std::vector<bool> v(3);
+        TEST_LIBCPP_ASSERT_FAILURE(
+            (void)v[3],
+            "vector<bool>::operator[] index out of bounds"
+        );
+    }
+
+    {
+        const std::vector<bool> v(3);
+        TEST_LIBCPP_ASSERT_FAILURE(
+            (void)v[100],
+            "vector<bool>::operator[] index out of bounds"
+        );
+    }
+#endif
+
+    return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector.bool/assertions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/assertions.pass.cpp
@@ -1,12 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include <vector>
 
 #include "test_macros.h"
 #include "check_assertion.h"
 
+// This test verifies that std::vector<bool>::operator[] performs a bounds
+// check and triggers a hardening assertion when accessed out of bounds.
+//
+// The behavior is only required when libc++ hardening is enabled; in release
+// or non-hardened builds, operator[] is intentionally unchecked.
 
 int main(int, char**) {
 #if defined(_LIBCPP_HARDENING_MODE) && _LIBCPP_HARDENING_MODE != 0
     {
+        // Non-const out-of-bounds access must trigger a hardening assertion.
         std::vector<bool> v(3);
         TEST_LIBCPP_ASSERT_FAILURE(
             (void)v[3],
@@ -15,6 +29,7 @@ int main(int, char**) {
     }
 
     {
+        // Const out-of-bounds access must also trigger a hardening assertion.
         const std::vector<bool> v(3);
         TEST_LIBCPP_ASSERT_FAILURE(
             (void)v[100],


### PR DESCRIPTION
### Summary
Added a libc++ test that verifies `std::vector<bool>::operator[]` triggers
a hardening assertion on out-of-bounds access when hardening is enabled.

### Motivation
Out-of-bounds access on `vector<bool>` is undefined behavior. libc++ already
contains the necessary hardening checks, but this behavior was not covered by
a dedicated test. This change ensures the assertion remains enforced and
prevents regressions.

### Testing
- Ran the new test in isolation using `llvm-lit`
- Verified it passes under `_LIBCPP_HARDENING_MODE != 0`

### Notes
This is a test-only change; no library code is modified.
