### PR TITLE
[clang][CodeGen] Fix _BitInt return value miscompile

### DIFF
--- a/clang/test/CodeGen/ext-int.c
+++ b/clang/test/CodeGen/ext-int.c
@@ -252,4 +252,13 @@ void bitField() {
   // LIN64: store i64 %bf.set4, ptr %s1, align 8
 }
 
+// GH#179448: Ensure the return value alloca uses the memory type (i128)
+// instead of the IR type (i121) to avoid miscompilation when coercing
+// the return value to {i64, i64}.
+// LIN64: define {{.*}}{ i64, i64 } @returnBitInt121(i64 {{.*}}, i64 {{.*}})
+// LIN64: %retval = alloca i128, align 8
+_BitInt(121) returnBitInt121(_BitInt(121) a) {
+  return a;
+}
+
 #endif


### PR DESCRIPTION
## Summary
- Use `CreateMemTemp` instead of `CreateIRTemp` for return value allocas
- Ensures proper memory type for _BitInt types that have different IR and memory representations
- For _BitInt(121), the IR type is i121 but memory type is i128, fixing the coercion to {i64, i64}

Fixes #179448

## Test plan
- Added test case for _BitInt(121) return value in ext-int.c