### PR TITLE
[BPF] Replace copy-assign by move-assign in llvm/lib/Target/BPF/

### DIFF
--- a/llvm/lib/Target/BPF/BPFISelLowering.cpp
+++ b/llvm/lib/Target/BPF/BPFISelLowering.cpp
@@ -812,7 +812,7 @@ SDValue BPFTargetLowering::LowerTRAP(SDValue Op, SelectionDAG &DAG) const {
   CLI.IsTailCall = false;
   CLI.CallConv = CallingConv::C;
   CLI.IsVarArg = false;
-  CLI.DL = DL;
+  CLI.DL = std::move(DL);
   CLI.NoMerge = false;
   CLI.DoesNotReturn = true;
   return LowerCall(CLI, InVals);

--- a/llvm/lib/Target/BPF/BTFDebug.cpp
+++ b/llvm/lib/Target/BPF/BTFDebug.cpp
@@ -1125,7 +1125,7 @@ std::string BTFDebug::populateFileContent(const DIFile *File) {
     for (line_iterator I(*Buf, false), E; I != E; ++I)
       Content.push_back(std::string(*I));
 
-  FileContent[FileName] = Content;
+  FileContent[FileName] = std::move(Content);
   return FileName;
 }
 


### PR DESCRIPTION
An SDLoc transitively contains a TrackingMDRef which have a specialized
move constructor. It's more efficient to move element to it instead of
copying them.

FileContent contains std::vector<...> values. It's more efficient to
move then to copy the whole vector.