### PR TITLE
[llvm] Always define dump() methods

### DIFF
--- a/llvm/bindings/ocaml/llvm/llvm_ocaml.c
+++ b/llvm/bindings/ocaml/llvm/llvm_ocaml.c
@@ -427,12 +427,7 @@ value llvm_type_context(value Ty) {
 
 /* lltype -> unit */
 value llvm_dump_type(value Val) {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVMDumpType(Type_val(Val));
-#else
-  caml_raise_with_arg(*caml_named_value("Llvm.FeatureDisabled"),
-                      caml_copy_string("dump"));
-#endif
   return Val_unit;
 }
 

--- a/llvm/include/llvm/ADT/APFixedPoint.h
+++ b/llvm/include/llvm/ADT/APFixedPoint.h
@@ -255,9 +255,7 @@ public:
 
   LLVM_ABI void print(raw_ostream &) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
   // If LHS > RHS, return 1. If LHS == RHS, return 0. If LHS < RHS, return -1.
   LLVM_ABI int compare(const APFixedPoint &Other) const;

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1546,9 +1546,7 @@ public:
 
   LLVM_ABI void print(raw_ostream &) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
   /// If this value is normal and has an exact, normal, multiplicative inverse,
   /// store it in inv and return true.

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -1938,10 +1938,8 @@ public:
   ///  FoldingSets.
   LLVM_ABI void Profile(FoldingSetNodeID &id) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// debug method
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
   /// Returns whether this instance allocated memory.
   bool needsCleanup() const { return !isSingleWord(); }

--- a/llvm/include/llvm/ADT/CoalescingBitVector.h
+++ b/llvm/include/llvm/ADT/CoalescingBitVector.h
@@ -382,7 +382,6 @@ public:
     OS << "}";
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const {
     // LLDB swallows the first line of output after callling dump(). Add
     // newlines before/after the braces to work around this.
@@ -390,7 +389,6 @@ public:
     print(dbgs());
     dbgs() << "\n";
   }
-#endif
 
 private:
   void insert(IndexT Start, IndexT End) { Intervals.insert(Start, End, 0); }

--- a/llvm/include/llvm/ADT/DynamicAPInt.h
+++ b/llvm/include/llvm/ADT/DynamicAPInt.h
@@ -227,9 +227,7 @@ public:
 
   LLVM_ABI raw_ostream &print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const DynamicAPInt &X) {

--- a/llvm/include/llvm/ADT/SlowDynamicAPInt.h
+++ b/llvm/include/llvm/ADT/SlowDynamicAPInt.h
@@ -81,9 +81,7 @@ public:
 
   LLVM_ABI void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const SlowDynamicAPInt &X) {

--- a/llvm/include/llvm/ADT/TrieRawHashMap.h
+++ b/llvm/include/llvm/ADT/TrieRawHashMap.h
@@ -91,9 +91,7 @@ public:
   static void *operator new(size_t Size) { return ::operator new(Size); }
   void operator delete(void *Ptr) { ::operator delete(Ptr); }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
   LLVM_ABI void print(raw_ostream &OS) const;
 
@@ -218,9 +216,7 @@ public:
   using ThreadSafeTrieRawHashMapBase::operator delete;
   using HashType = HashT;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   using ThreadSafeTrieRawHashMapBase::dump;
-#endif
 
   using ThreadSafeTrieRawHashMapBase::print;
 

--- a/llvm/include/llvm/ADT/Twine.h
+++ b/llvm/include/llvm/ADT/Twine.h
@@ -480,13 +480,11 @@ public:
   /// Write the representation of this twine to the stream \p OS.
   LLVM_ABI void printRepr(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Dump the concatenated string represented by this twine to stderr.
   LLVM_DUMP_METHOD void dump() const;
 
   /// Dump the representation of this twine to stderr.
   LLVM_DUMP_METHOD void dumpRepr() const;
-#endif
 
   /// @}
 };

--- a/llvm/include/llvm/Analysis/DominanceFrontier.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontier.h
@@ -89,9 +89,7 @@ public:
   void print(raw_ostream &OS) const;
 
   /// dump - Dump the dominance frontier to dbgs().
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const;
-#endif
 };
 
 //===-------------------------------------

--- a/llvm/include/llvm/Analysis/DominanceFrontierImpl.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontierImpl.h
@@ -66,12 +66,10 @@ void DominanceFrontierBase<BlockT, IsPostDom>::print(raw_ostream &OS) const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 template <class BlockT, bool IsPostDom>
 void DominanceFrontierBase<BlockT, IsPostDom>::dump() const {
   print(dbgs());
 }
-#endif
 
 template <class BlockT>
 void ForwardDominanceFrontierBase<BlockT>::calculate(const DomTreeT &DT,

--- a/llvm/include/llvm/Analysis/GenericDomTreeUpdaterImpl.h
+++ b/llvm/include/llvm/Analysis/GenericDomTreeUpdaterImpl.h
@@ -169,7 +169,6 @@ GenericDomTreeUpdater<DerivedT, DomTreeT, PostDomTreeT>::getPostDomTree() {
 template <typename DerivedT, typename DomTreeT, typename PostDomTreeT>
 LLVM_DUMP_METHOD void
 GenericDomTreeUpdater<DerivedT, DomTreeT, PostDomTreeT>::dump() const {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   raw_ostream &OS = llvm::dbgs();
 
   OS << "Available Trees: ";
@@ -259,7 +258,6 @@ GenericDomTreeUpdater<DerivedT, DomTreeT, PostDomTreeT>::dump() const {
       OS << "(no name)(";
     OS << BB << ")\n";
   }
-#endif
 }
 
 template <typename DerivedT, typename DomTreeT, typename PostDomTreeT>

--- a/llvm/include/llvm/Analysis/HashRecognize.h
+++ b/llvm/include/llvm/Analysis/HashRecognize.h
@@ -30,9 +30,7 @@ class LPMUpdater;
 struct CRCTable : public std::array<APInt, 256> {
   void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 };
 
 /// The structure that is returned when a polynomial algorithm was recognized by
@@ -88,9 +86,7 @@ public:
 
   void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 };
 
 class HashRecognizePrinterPass

--- a/llvm/include/llvm/Analysis/RegionInfo.h
+++ b/llvm/include/llvm/Analysis/RegionInfo.h
@@ -434,10 +434,8 @@ public:
   void print(raw_ostream &OS, bool printTree = true, unsigned level = 0,
              PrintStyle Style = PrintNone) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the region to stderr.
   void dump() const;
-#endif
 
   /// Check if the region contains a BasicBlock.
   ///
@@ -801,9 +799,7 @@ public:
   static typename RegionT::PrintStyle printStyle;
 
   void print(raw_ostream &OS) const;
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const;
-#endif
 
   void releaseMemory();
 

--- a/llvm/include/llvm/Analysis/RegionInfoImpl.h
+++ b/llvm/include/llvm/Analysis/RegionInfoImpl.h
@@ -495,12 +495,10 @@ void RegionBase<Tr>::print(raw_ostream &OS, bool print_tree, unsigned level,
     OS.indent(level * 2) << "} \n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 template <class Tr>
 void RegionBase<Tr>::dump() const {
   print(dbgs(), true, getDepth(), RegionInfoBase<Tr>::printStyle);
 }
-#endif
 
 template <class Tr>
 void RegionBase<Tr>::clearNodeCache() {
@@ -754,10 +752,8 @@ void RegionInfoBase<Tr>::print(raw_ostream &OS) const {
   OS << "End region tree\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 template <class Tr>
 void RegionInfoBase<Tr>::dump() const { print(dbgs()); }
-#endif
 
 template <class Tr> void RegionInfoBase<Tr>::releaseMemory() {
   BBtoRegion.clear();

--- a/llvm/include/llvm/Analysis/RegionInfoImpl.h
+++ b/llvm/include/llvm/Analysis/RegionInfoImpl.h
@@ -752,8 +752,7 @@ void RegionInfoBase<Tr>::print(raw_ostream &OS) const {
   OS << "End region tree\n";
 }
 
-template <class Tr>
-void RegionInfoBase<Tr>::dump() const { print(dbgs()); }
+template <class Tr> void RegionInfoBase<Tr>::dump() const { print(dbgs()); }
 
 template <class Tr> void RegionInfoBase<Tr>::releaseMemory() {
   BBtoRegion.clear();

--- a/llvm/include/llvm/CodeGen/DbgEntityHistoryCalculator.h
+++ b/llvm/include/llvm/CodeGen/DbgEntityHistoryCalculator.h
@@ -121,9 +121,7 @@ public:
   EntriesMap::const_iterator begin() const { return VarEntries.begin(); }
   EntriesMap::const_iterator end() const { return VarEntries.end(); }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump(StringRef FuncName) const;
-#endif
 };
 
 /// For each inlined instance of a source-level label, keep the corresponding

--- a/llvm/include/llvm/CodeGen/LatencyPriorityQueue.h
+++ b/llvm/include/llvm/CodeGen/LatencyPriorityQueue.h
@@ -83,9 +83,7 @@ namespace llvm {
 
     void remove(SUnit *SU) override;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     LLVM_DUMP_METHOD void dump(ScheduleDAG *DAG) const override;
-#endif
 
     // scheduledNode - As nodes are scheduled, we look to see if there are any
     // successor nodes that have a single unscheduled predecessor.  If so, that

--- a/llvm/include/llvm/CodeGen/LiveDebugVariables.h
+++ b/llvm/include/llvm/CodeGen/LiveDebugVariables.h
@@ -52,10 +52,8 @@ public:
   /// @param VRM Rename virtual registers according to map.
   void emitDebugValues(VirtRegMap *VRM);
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// dump - Print data structures to dbgs().
   void dump() const;
-#endif
 
   void print(raw_ostream &OS) const;
 

--- a/llvm/include/llvm/CodeGen/MachinePipeliner.h
+++ b/llvm/include/llvm/CodeGen/MachinePipeliner.h
@@ -624,9 +624,7 @@ public:
   iterator end() { return Nodes.end(); }
   void print(raw_ostream &os) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 };
 
 // 16 was selected based on the number of ProcResource kinds for all
@@ -678,9 +676,7 @@ private:
     return R;
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dumpMRT() const;
-#endif
 
 public:
   ResourceManager(const TargetSubtargetInfo *ST, ScheduleDAGInstrs *DAG)

--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -545,9 +545,7 @@ public:
   /// without any path separators then the file
   /// will be created in the current directory.
   /// Error will be emitted if the path is insane.
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dumpDotGraph(const Twine &FileName, const Twine &Title);
-#endif
 
   /// Pop up a GraphViz/gv window with the DAG rendered using 'dot'.
   LLVM_ABI void viewGraph(const std::string &Title);

--- a/llvm/include/llvm/CodeGen/TargetSchedule.h
+++ b/llvm/include/llvm/CodeGen/TargetSchedule.h
@@ -131,13 +131,11 @@ public:
     return SchedModel.getProcResource(PIdx);
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   const char *getResourceName(unsigned PIdx) const {
     if (!PIdx)
       return "MOps";
     return SchedModel.getProcResource(PIdx)->Name;
   }
-#endif
 
   using ProcResIter = const MCWriteProcResEntry *;
 

--- a/llvm/include/llvm/CodeGenTypes/LowLevelType.h
+++ b/llvm/include/llvm/CodeGenTypes/LowLevelType.h
@@ -299,9 +299,7 @@ public:
 
   LLVM_ABI void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
   constexpr bool operator==(const LLT &RHS) const {
     return IsPointer == RHS.IsPointer && IsVector == RHS.IsVector &&

--- a/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerCompileUnit.h
+++ b/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerCompileUnit.h
@@ -102,9 +102,7 @@ public:
     /// Is this a variable with a location attribute referencing address?
     bool HasLocationExpressionAddr : 1;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     LLVM_DUMP_METHOD void dump();
-#endif // if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   };
 
   CompileUnit(DWARFUnit &OrigUnit, unsigned ID, bool CanUseODR,

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVCompare.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVCompare.h
@@ -77,9 +77,7 @@ public:
   LLVM_ABI void printItem(LVElement *Element, LVComparePass Pass);
   LLVM_ABI void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
-#endif
 };
 
 inline LVCompare &getComparator() { return LVCompare::getInstance(); }

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVLocation.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVLocation.h
@@ -50,9 +50,7 @@ public:
 
   LLVM_ABI void print(raw_ostream &OS, bool Full = true) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
-#endif
 };
 
 class LLVM_ABI LVLocation : public LVObject {

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVObject.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVObject.h
@@ -313,9 +313,7 @@ public:
   // (class attributes, debug ranges, files, directories, etc).
   virtual void printExtra(raw_ostream &OS, bool Full = true) const {}
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
-#endif
 
   uint32_t getID() const { return ID; }
 };

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVOptions.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVOptions.h
@@ -440,9 +440,7 @@ public:
 
   LLVM_ABI void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
-#endif
 };
 
 inline LVOptions &options() { return (*LVOptions::getOptions()); }
@@ -637,9 +635,7 @@ public:
 
   LLVM_ABI void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
-#endif
 };
 
 inline LVPatterns &patterns() { return *LVPatterns::getPatterns(); }

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVReader.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVReader.h
@@ -352,9 +352,7 @@ public:
   void print(raw_ostream &OS) const;
   virtual void printRecords(raw_ostream &OS) const {}
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
-#endif
 };
 
 inline LVReader &getReader() { return LVReader::getInstance(); }

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVStringPool.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVStringPool.h
@@ -80,9 +80,7 @@ public:
     }
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
-#endif
 };
 
 } // namespace logicalview

--- a/llvm/include/llvm/DebugInfo/LogicalView/LVReaderHandler.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/LVReaderHandler.h
@@ -89,9 +89,7 @@ public:
 
   LLVM_ABI void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
-#endif
 };
 
 } // end namespace logicalview

--- a/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVBinaryReader.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVBinaryReader.h
@@ -222,9 +222,7 @@ public:
 
   void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
-#endif
 };
 
 } // end namespace logicalview

--- a/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVCodeViewReader.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVCodeViewReader.h
@@ -225,9 +225,7 @@ public:
     LogicalVisitor.printRecords(OS);
   };
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
-#endif
 };
 
 } // end namespace logicalview

--- a/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVDWARFReader.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVDWARFReader.h
@@ -145,9 +145,7 @@ public:
 
   void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }
-#endif
 };
 
 } // end namespace logicalview

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -512,9 +512,7 @@ public:
 
   LLVM_ABI iterator begin() const;
   LLVM_ABI iterator end() const;
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const;
-#endif
 };
 
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/IR/ConstantRangeList.h
+++ b/llvm/include/llvm/IR/ConstantRangeList.h
@@ -95,9 +95,7 @@ public:
   /// Print out the ranges to a stream.
   LLVM_ABI void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const;
-#endif
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCAsmMacro.h
+++ b/llvm/include/llvm/MC/MCAsmMacro.h
@@ -125,10 +125,8 @@ struct MCAsmMacroParameter {
   bool Required = false;
   bool Vararg = false;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { dump(dbgs()); }
   LLVM_DUMP_METHOD void dump(raw_ostream &OS) const;
-#endif
 };
 
 typedef std::vector<MCAsmMacroParameter> MCAsmMacroParameters;
@@ -148,10 +146,8 @@ public:
       : Name(N), Body(B), Parameters(std::move(P)), Locals(std::move(L)),
         IsFunction(F) {}
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { dump(dbgs()); }
   LLVM_DUMP_METHOD void dump(raw_ostream &OS) const;
-#endif
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Object/Wasm.h
+++ b/llvm/include/llvm/Object/Wasm.h
@@ -101,9 +101,7 @@ public:
 
   LLVM_ABI void print(raw_ostream &Out) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 };
 
 struct WasmSection {

--- a/llvm/include/llvm/Support/BranchProbability.h
+++ b/llvm/include/llvm/Support/BranchProbability.h
@@ -80,9 +80,7 @@ public:
 
   LLVM_ABI raw_ostream &print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
   /// Scale a large integer.
   ///

--- a/llvm/include/llvm/Support/CFGDiff.h
+++ b/llvm/include/llvm/Support/CFGDiff.h
@@ -166,9 +166,7 @@ public:
     OS << "\n";
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const { print(dbgs()); }
-#endif
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Support/CFGUpdate.h
+++ b/llvm/include/llvm/Support/CFGUpdate.h
@@ -48,9 +48,7 @@ public:
     getTo()->printAsOperand(OS, false);
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const { print(dbgs()); }
-#endif
 };
 
 // LegalizeUpdates function simplifies updates assuming a graph structure.

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -653,9 +653,6 @@ void AnnotateIgnoreWritesEnd(const char *file, int line);
 
 /// Mark debug helper function definitions like dump() that should not be
 /// stripped from debug builds.
-/// Note that you should also surround dump() functions with
-/// `#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)` so they do always
-/// get stripped in release builds.
 // FIXME: Move this to a private config.h as it's not usable in public headers.
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 #define LLVM_DUMP_METHOD                                                       \

--- a/llvm/include/llvm/Support/DebugCounter.h
+++ b/llvm/include/llvm/Support/DebugCounter.h
@@ -131,10 +131,8 @@ public:
     Info.CurrChunkIdx = State.ChunkIdx;
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   // Dump or print the current counter set into llvm::dbgs().
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
   LLVM_ABI void print(raw_ostream &OS) const;
 

--- a/llvm/include/llvm/Support/GraphWriter.h
+++ b/llvm/include/llvm/Support/GraphWriter.h
@@ -426,7 +426,6 @@ std::string WriteGraph(const GraphType &G, const Twine &Name,
 }
 
 /// DumpDotGraph - Just dump a dot graph to the user-provided file name.
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 template <typename GraphType>
 LLVM_DUMP_METHOD void
 dumpDotGraphToFile(const GraphType &G, const Twine &FileName,
@@ -434,7 +433,6 @@ dumpDotGraphToFile(const GraphType &G, const Twine &FileName,
                    const Twine &Name = "") {
   llvm::WriteGraph(G, Name, ShortNames, Title, FileName.str());
 }
-#endif
 
 /// ViewGraph - Emit a dot graph, run 'dot', run gv on the postscript file,
 /// then cleanup.  For use from the debugger.

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -476,9 +476,7 @@ public:
   }
 
   LLVM_ABI void print(llvm::raw_ostream &OS) const;
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif // !NDEBUG || LLVM_ENABLE_DUMP
 
 private:
   LLVM_ABI void destroy();

--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -559,9 +559,7 @@ public:
 
   LLVM_ABI void print(raw_ostream &OS) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
 private:
   // Internal helper for getting the initial KnownBits for an `srem` or `urem`

--- a/llvm/include/llvm/Support/SMTAPI.h
+++ b/llvm/include/llvm/Support/SMTAPI.h
@@ -71,9 +71,7 @@ public:
 
   virtual void print(raw_ostream &OS) const = 0;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
 protected:
   /// Query the SMT solver and returns true if two sorts are equal (same kind
@@ -120,9 +118,7 @@ public:
 
   virtual void print(raw_ostream &OS) const = 0;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
 protected:
   /// Query the SMT solver and returns true if two sorts are equal (same kind
@@ -140,9 +136,7 @@ public:
 
   virtual void print(raw_ostream &OS) const = 0;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 };
 
 /// Shared pointer for SMTExprs, used by SMTSolver API.
@@ -158,9 +152,7 @@ public:
   SMTSolver() = default;
   virtual ~SMTSolver() = default;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
   // Returns an appropriate floating-point sort for the given bitwidth.
   SMTSortRef getFloatSort(unsigned BitWidth) {

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -351,9 +351,7 @@ public:
     visitChildFileSystems(Callback);
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
 protected:
   virtual void printImpl(raw_ostream &OS, PrintType Type,

--- a/llvm/include/llvm/TextAPI/Symbol.h
+++ b/llvm/include/llvm/TextAPI/Symbol.h
@@ -156,10 +156,8 @@ public:
   LLVM_ABI const_filtered_target_range
   targets(ArchitectureSet architectures) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump(raw_ostream &OS) const;
   void dump() const { dump(llvm::errs()); }
-#endif
 
   LLVM_ABI bool operator==(const Symbol &O) const;
 

--- a/llvm/include/llvm/Transforms/Coroutines/SuspendCrossingInfo.h
+++ b/llvm/include/llvm/Transforms/Coroutines/SuspendCrossingInfo.h
@@ -95,13 +95,11 @@ class SuspendCrossingInfo {
   bool computeBlockData(const ReversePostOrderTraversal<Function *> &RPOT);
 
 public:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   // Print order is in RPO
   void dump() const;
   void dump(StringRef Label, BitVector const &BV,
             const ReversePostOrderTraversal<Function *> &RPOT,
             ModuleSlotTracker &MST) const;
-#endif
 
   LLVM_ABI
   SuspendCrossingInfo(Function &F,

--- a/llvm/lib/Analysis/AliasSetTracker.cpp
+++ b/llvm/lib/Analysis/AliasSetTracker.cpp
@@ -557,10 +557,8 @@ void AliasSetTracker::print(raw_ostream &OS) const {
   OS << "\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void AliasSet::dump() const { print(dbgs()); }
 LLVM_DUMP_METHOD void AliasSetTracker::dump() const { print(dbgs()); }
-#endif
 
 //===----------------------------------------------------------------------===//
 //                            AliasSetPrinter Pass

--- a/llvm/lib/Analysis/BlockFrequencyInfoImpl.cpp
+++ b/llvm/lib/Analysis/BlockFrequencyInfoImpl.cpp
@@ -68,9 +68,7 @@ ScaledNumber<uint64_t> BlockMass::toScaled() const {
   return ScaledNumber<uint64_t>(getMass() + 1, -64);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void BlockMass::dump() const { print(dbgs()); }
-#endif
 
 static char getHexDigit(int N) {
   assert(N < 16);

--- a/llvm/lib/Analysis/CallGraph.cpp
+++ b/llvm/lib/Analysis/CallGraph.cpp
@@ -133,9 +133,7 @@ void CallGraph::print(raw_ostream &OS) const {
     CN->print(OS);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void CallGraph::dump() const { print(dbgs()); }
-#endif
 
 // removeFunctionFromModule - Unlink the function from this module, returning
 // it.  Because this removes the function from the module, the call graph node
@@ -188,9 +186,7 @@ void CallGraphNode::print(raw_ostream &OS) const {
   OS << '\n';
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void CallGraphNode::dump() const { print(dbgs()); }
-#endif
 
 /// removeOneAbstractEdgeTo - Remove one edge associated with a null callsite
 /// from this node to the specified callee function.
@@ -325,7 +321,5 @@ void CallGraphWrapperPass::print(raw_ostream &OS, const Module *) const {
   G->print(OS);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD
 void CallGraphWrapperPass::dump() const { print(dbgs(), nullptr); }
-#endif

--- a/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
+++ b/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
@@ -150,10 +150,8 @@ void DXILMetadataAnalysisWrapperPass::print(raw_ostream &OS,
   MetadataInfo->print(dbgs());
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD
 void DXILMetadataAnalysisWrapperPass::dump() const { print(dbgs(), nullptr); }
-#endif
 
 INITIALIZE_PASS(DXILMetadataAnalysisWrapperPass, "dxil-metadata-analysis",
                 "DXIL Module Metadata analysis", false, true)

--- a/llvm/lib/Analysis/DXILResource.cpp
+++ b/llvm/lib/Analysis/DXILResource.cpp
@@ -1164,10 +1164,8 @@ void DXILResourceWrapperPass::print(raw_ostream &OS, const Module *M) const {
   Map->print(OS, *DRTM, M->getDataLayout());
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD
 void DXILResourceWrapperPass::dump() const { print(dbgs(), nullptr); }
-#endif
 
 INITIALIZE_PASS(DXILResourceWrapperPass, "dxil-resources",
                 "DXIL Resources Analysis", false, true)

--- a/llvm/lib/Analysis/DomTreeUpdater.cpp
+++ b/llvm/lib/Analysis/DomTreeUpdater.cpp
@@ -105,7 +105,6 @@ void DomTreeUpdater::validateDeleteBB(BasicBlock *DelBB) {
 LLVM_DUMP_METHOD
 void DomTreeUpdater::dump() const {
   Base::dump();
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   raw_ostream &OS = dbgs();
   OS << "Pending Callbacks:\n";
   int Index = 0;
@@ -118,7 +117,6 @@ void DomTreeUpdater::dump() const {
       OS << "(no_name)(";
     OS << BB << ")\n";
   }
-#endif
 }
 
 } // namespace llvm

--- a/llvm/lib/Analysis/DominanceFrontier.cpp
+++ b/llvm/lib/Analysis/DominanceFrontier.cpp
@@ -57,11 +57,9 @@ void DominanceFrontierWrapperPass::print(raw_ostream &OS, const Module *) const 
   DF.print(OS);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void DominanceFrontierWrapperPass::dump() const {
   print(dbgs());
 }
-#endif
 
 /// Handle invalidation explicitly.
 bool DominanceFrontier::invalidate(Function &F, const PreservedAnalyses &PA,

--- a/llvm/lib/Analysis/HashRecognize.cpp
+++ b/llvm/lib/Analysis/HashRecognize.cpp
@@ -134,9 +134,7 @@ struct RecurrenceInfo {
     }
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const { print(dbgs()); }
-#endif
 
   bool matchSimpleRecurrence(const PHINode *P);
   bool matchConditionalRecurrence(
@@ -528,9 +526,7 @@ void CRCTable::print(raw_ostream &OS) const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void CRCTable::dump() const { print(dbgs()); }
-#endif
 
 void HashRecognize::print(raw_ostream &OS) const {
   if (!L.isInnermost())
@@ -568,9 +564,7 @@ void HashRecognize::print(raw_ostream &OS) const {
   genSarwateTable(Info.RHS, Info.ByteOrderSwapped).print(OS);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void HashRecognize::dump() const { print(dbgs()); }
-#endif
 
 std::optional<PolynomialInfo> HashRecognize::getResult() const {
   auto Res = HashRecognize(L, SE).recognizeCRC();

--- a/llvm/lib/Analysis/IVUsers.cpp
+++ b/llvm/lib/Analysis/IVUsers.cpp
@@ -288,9 +288,7 @@ void IVUsers::print(raw_ostream &OS, const Module *M) const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void IVUsers::dump() const { print(dbgs()); }
-#endif
 
 void IVUsers::releaseMemory() {
   Processed.clear();

--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -3071,10 +3071,8 @@ void InlineCostCallAnalyzer::print(raw_ostream &OS) {
 #undef DEBUG_PRINT_STAT
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// Dump stats about this call's analysis.
 LLVM_DUMP_METHOD void InlineCostCallAnalyzer::dump() { print(dbgs()); }
-#endif
 
 /// Test that there are no attribute conflicts between Caller and Callee
 ///        that prevent inlining.

--- a/llvm/lib/Analysis/LazyCallGraph.cpp
+++ b/llvm/lib/Analysis/LazyCallGraph.cpp
@@ -137,11 +137,9 @@ void LazyCallGraph::Node::replaceFunction(Function &NewF) {
   F = &NewF;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LazyCallGraph::Node::dump() const {
   dbgs() << *this << '\n';
 }
-#endif
 
 static bool isKnownLibFunction(Function &F, TargetLibraryInfo &TLI) {
   LibFunc LF;
@@ -240,11 +238,9 @@ LazyCallGraph &LazyCallGraph::operator=(LazyCallGraph &&G) {
   return *this;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LazyCallGraph::SCC::dump() const {
   dbgs() << *this << '\n';
 }
-#endif
 
 #if !defined(NDEBUG) || defined(EXPENSIVE_CHECKS)
 void LazyCallGraph::SCC::verify() {
@@ -332,11 +328,9 @@ bool LazyCallGraph::SCC::isAncestorOf(const SCC &TargetC) const {
 
 LazyCallGraph::RefSCC::RefSCC(LazyCallGraph &G) : G(&G) {}
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LazyCallGraph::RefSCC::dump() const {
   dbgs() << *this << '\n';
 }
-#endif
 
 #if !defined(NDEBUG) || defined(EXPENSIVE_CHECKS)
 void LazyCallGraph::RefSCC::verify() {

--- a/llvm/lib/Analysis/LoopInfo.cpp
+++ b/llvm/lib/Analysis/LoopInfo.cpp
@@ -675,13 +675,11 @@ std::string Loop::getLocStr() const {
   return Result;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void Loop::dump() const { print(dbgs()); }
 
 LLVM_DUMP_METHOD void Loop::dumpVerbose() const {
   print(dbgs(), /*Verbose=*/true);
 }
-#endif
 
 //===----------------------------------------------------------------------===//
 // UnloopUpdater implementation

--- a/llvm/lib/Analysis/MemorySSA.cpp
+++ b/llvm/lib/Analysis/MemorySSA.cpp
@@ -1898,9 +1898,7 @@ void MemorySSA::print(raw_ostream &OS) const {
   F->print(OS, &Writer);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MemorySSA::dump() const { print(dbgs()); }
-#endif
 
 void MemorySSA::verifyMemorySSA(VerificationLevel VL) const {
 #if !defined(NDEBUG) && defined(EXPENSIVE_CHECKS)
@@ -2271,10 +2269,8 @@ void MemoryUse::print(raw_ostream &OS) const {
 
 void MemoryAccess::dump() const {
 // Cannot completely remove virtual function even in release mode.
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   print(dbgs());
   dbgs() << "\n";
-#endif
 }
 
 class DOTFuncMSSAInfo {

--- a/llvm/lib/Analysis/MemorySSA.cpp
+++ b/llvm/lib/Analysis/MemorySSA.cpp
@@ -2268,7 +2268,7 @@ void MemoryUse::print(raw_ostream &OS) const {
 }
 
 void MemoryAccess::dump() const {
-// Cannot completely remove virtual function even in release mode.
+  // Cannot completely remove virtual function even in release mode.
   print(dbgs());
   dbgs() << "\n";
 }

--- a/llvm/lib/Analysis/PHITransAddr.cpp
+++ b/llvm/lib/Analysis/PHITransAddr.cpp
@@ -37,7 +37,6 @@ static bool canPHITrans(Instruction *Inst) {
   return false;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void PHITransAddr::dump() const {
   if (!Addr) {
     dbgs() << "PHITransAddr: null\n";
@@ -47,7 +46,6 @@ LLVM_DUMP_METHOD void PHITransAddr::dump() const {
   for (unsigned i = 0, e = InstInputs.size(); i != e; ++i)
     dbgs() << "  Input #" << i << " is " << *InstInputs[i] << "\n";
 }
-#endif
 
 static bool verifySubExpr(Value *Expr,
                           SmallVectorImpl<Instruction *> &InstInputs) {

--- a/llvm/lib/Analysis/RegionInfo.cpp
+++ b/llvm/lib/Analysis/RegionInfo.cpp
@@ -150,11 +150,9 @@ void RegionInfoPass::print(raw_ostream &OS, const Module *) const {
   RI.print(OS);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RegionInfoPass::dump() const {
   RI.dump();
 }
-#endif
 
 char RegionInfoPass::ID = 0;
 

--- a/llvm/lib/Analysis/RegionInfo.cpp
+++ b/llvm/lib/Analysis/RegionInfo.cpp
@@ -150,9 +150,7 @@ void RegionInfoPass::print(raw_ostream &OS, const Module *) const {
   RI.print(OS);
 }
 
-LLVM_DUMP_METHOD void RegionInfoPass::dump() const {
-  RI.dump();
-}
+LLVM_DUMP_METHOD void RegionInfoPass::dump() const { RI.dump(); }
 
 char RegionInfoPass::ID = 0;
 

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -262,12 +262,10 @@ static cl::opt<bool> UseContextForNoWrapFlagInference(
 // Implementation of the SCEV class.
 //
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SCEV::dump() const {
   print(dbgs());
   dbgs() << '\n';
 }
-#endif
 
 void SCEV::print(raw_ostream &OS) const {
   switch (getSCEVType()) {

--- a/llvm/lib/Analysis/StackLifetime.cpp
+++ b/llvm/lib/Analysis/StackLifetime.cpp
@@ -261,7 +261,6 @@ void StackLifetime::calculateLiveIntervals() {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void StackLifetime::dumpAllocas() const {
   dbgs() << "Allocas:\n";
   for (unsigned AllocaNo = 0; AllocaNo < NumAllocas; ++AllocaNo)
@@ -286,7 +285,6 @@ LLVM_DUMP_METHOD void StackLifetime::dumpLiveRanges() const {
   for (unsigned AllocaNo = 0; AllocaNo < NumAllocas; ++AllocaNo)
     dbgs() << "  " << AllocaNo << ": " << LiveRanges[AllocaNo] << "\n";
 }
-#endif
 
 StackLifetime::StackLifetime(const Function &F,
                              ArrayRef<const AllocaInst *> Allocas,

--- a/llvm/lib/Analysis/Trace.cpp
+++ b/llvm/lib/Analysis/Trace.cpp
@@ -46,6 +46,4 @@ void Trace::print(raw_ostream &O) const {
 
 /// dump - Debugger convenience method; writes trace to standard error
 /// output stream.
-LLVM_DUMP_METHOD void Trace::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void Trace::dump() const { print(dbgs()); }

--- a/llvm/lib/Analysis/Trace.cpp
+++ b/llvm/lib/Analysis/Trace.cpp
@@ -44,10 +44,8 @@ void Trace::print(raw_ostream &O) const {
   O << "; Trace parent function: \n" << *F;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// dump - Debugger convenience method; writes trace to standard error
 /// output stream.
 LLVM_DUMP_METHOD void Trace::dump() const {
   print(dbgs());
 }
-#endif

--- a/llvm/lib/Bitcode/Writer/ValueEnumerator.cpp
+++ b/llvm/lib/Bitcode/Writer/ValueEnumerator.cpp
@@ -538,14 +538,12 @@ unsigned ValueEnumerator::getValueID(const Value *V) const {
   return I->second-1;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ValueEnumerator::dump() const {
   print(dbgs(), ValueMap, "Default");
   dbgs() << '\n';
   print(dbgs(), MetadataMap, "MetaData");
   dbgs() << '\n';
 }
-#endif
 
 void ValueEnumerator::print(raw_ostream &OS, const ValueMapType &Map,
                             const char *Name) const {

--- a/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
@@ -118,9 +118,7 @@ void DIEAbbrev::print(raw_ostream &O) const {
   }
 }
 
-LLVM_DUMP_METHOD void DIEAbbrev::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void DIEAbbrev::dump() const { print(dbgs()); }
 
 //===----------------------------------------------------------------------===//
 // DIEAbbrevSet Implementation
@@ -255,9 +253,7 @@ void DIE::print(raw_ostream &O, unsigned IndentCount) const {
   O << "\n";
 }
 
-LLVM_DUMP_METHOD void DIE::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void DIE::dump() const { print(dbgs()); }
 
 unsigned DIE::computeOffsetsAndAbbrevs(const dwarf::FormParams &FormParams,
                                        DIEAbbrevSet &AbbrevSet,
@@ -345,9 +341,7 @@ void DIEValue::print(raw_ostream &O) const {
   }
 }
 
-LLVM_DUMP_METHOD void DIEValue::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void DIEValue::dump() const { print(dbgs()); }
 
 //===----------------------------------------------------------------------===//
 // DIEInteger Implementation

--- a/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DIE.cpp
@@ -118,11 +118,9 @@ void DIEAbbrev::print(raw_ostream &O) const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void DIEAbbrev::dump() const {
   print(dbgs());
 }
-#endif
 
 //===----------------------------------------------------------------------===//
 // DIEAbbrevSet Implementation
@@ -257,11 +255,9 @@ void DIE::print(raw_ostream &O, unsigned IndentCount) const {
   O << "\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void DIE::dump() const {
   print(dbgs());
 }
-#endif
 
 unsigned DIE::computeOffsetsAndAbbrevs(const dwarf::FormParams &FormParams,
                                        DIEAbbrevSet &AbbrevSet,
@@ -349,11 +345,9 @@ void DIEValue::print(raw_ostream &O) const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void DIEValue::dump() const {
   print(dbgs());
 }
-#endif
 
 //===----------------------------------------------------------------------===//
 // DIEInteger Implementation

--- a/llvm/lib/CodeGen/AsmPrinter/DbgEntityHistoryCalculator.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DbgEntityHistoryCalculator.cpp
@@ -568,7 +568,6 @@ void llvm::calculateDbgEntityHistory(const MachineFunction *MF,
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void DbgValueHistoryMap::dump(StringRef FuncName) const {
   dbgs() << "DbgValueHistoryMap('" << FuncName << "'):\n";
   for (const auto &VarRangePair : *this) {
@@ -606,4 +605,3 @@ LLVM_DUMP_METHOD void DbgValueHistoryMap::dump(StringRef FuncName) const {
     }
   }
 }
-#endif

--- a/llvm/lib/CodeGen/AsmPrinter/DebugLocEntry.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DebugLocEntry.h
@@ -91,7 +91,6 @@ public:
   MachineLocation getLoc() const { return Loc; }
   TargetIndexLocation getTargetIndexLocation() const { return TIL; }
   friend bool operator==(const DbgValueLocEntry &, const DbgValueLocEntry &);
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const {
     if (isLocation()) {
       llvm::dbgs() << "Loc = { reg=" << Loc.getReg() << " ";
@@ -103,7 +102,6 @@ public:
     else if (isConstantFP())
       Constant.CFP->dump();
   }
-#endif
 };
 
 /// The location of a single variable, composed of an expression and 0 or more
@@ -168,14 +166,12 @@ public:
   ArrayRef<DbgValueLocEntry> getLocEntries() const { return ValueLocEntries; }
   friend bool operator==(const DbgValueLoc &, const DbgValueLoc &);
   friend bool operator<(const DbgValueLoc &, const DbgValueLoc &);
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const {
     for (const DbgValueLocEntry &DV : ValueLocEntries)
       DV.dump();
     if (Expression)
       Expression->dump();
   }
-#endif
 };
 
 /// This struct describes location entries emitted in the .debug_loc

--- a/llvm/lib/CodeGen/BranchRelaxation.cpp
+++ b/llvm/lib/CodeGen/BranchRelaxation.cpp
@@ -171,7 +171,6 @@ void BranchRelaxation::verify() {
 #endif
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// print block size and offset information - debugging
 LLVM_DUMP_METHOD void BranchRelaxation::dumpBBs() {
   for (auto &MBB : *MF) {
@@ -180,7 +179,6 @@ LLVM_DUMP_METHOD void BranchRelaxation::dumpBBs() {
            << format("size=%#x\n", BBI.Size);
   }
 }
-#endif
 
 /// scanFunction - Do the initial scan of the function, building up
 /// information about each block.

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -3263,7 +3263,6 @@ static inline raw_ostream &operator<<(raw_ostream &OS, const ExtAddrMode &AM) {
 }
 #endif
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void ExtAddrMode::print(raw_ostream &OS) const {
   bool NeedPlus = false;
   OS << "[";
@@ -3297,7 +3296,6 @@ LLVM_DUMP_METHOD void ExtAddrMode::dump() const {
   print(dbgs());
   dbgs() << '\n';
 }
-#endif
 
 } // end anonymous namespace
 

--- a/llvm/lib/CodeGen/GlobalISel/RegBankSelect.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/RegBankSelect.cpp
@@ -1095,12 +1095,10 @@ bool RegBankSelect::MappingCost::operator==(const MappingCost &Cost) const {
          LocalFreq == Cost.LocalFreq;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RegBankSelect::MappingCost::dump() const {
   print(dbgs());
   dbgs() << '\n';
 }
-#endif
 
 void RegBankSelect::MappingCost::print(raw_ostream &OS) const {
   if (*this == ImpossibleCost()) {

--- a/llvm/lib/CodeGen/InlineSpiller.cpp
+++ b/llvm/lib/CodeGen/InlineSpiller.cpp
@@ -886,7 +886,7 @@ bool InlineSpiller::coalesceStackAccess(MachineInstr *MI, Register Reg) {
   return true;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+#ifndef NDEBUG
 LLVM_DUMP_METHOD
 // Dump the range of instructions from B to E with their slot indexes.
 static void dumpMachineInstrRangeWithSlotIndex(MachineBasicBlock::iterator B,

--- a/llvm/lib/CodeGen/LatencyPriorityQueue.cpp
+++ b/llvm/lib/CodeGen/LatencyPriorityQueue.cpp
@@ -135,7 +135,6 @@ void LatencyPriorityQueue::remove(SUnit *SU) {
   Queue.pop_back();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LatencyPriorityQueue::dump(ScheduleDAG *DAG) const {
   dbgs() << "Latency Priority Queue\n";
   dbgs() << "  Number of Queue Entries: " << Queue.size() << "\n";
@@ -144,4 +143,3 @@ LLVM_DUMP_METHOD void LatencyPriorityQueue::dump(ScheduleDAG *DAG) const {
     DAG->dumpNode(*SU);
   }
 }
-#endif

--- a/llvm/lib/CodeGen/LexicalScopes.cpp
+++ b/llvm/lib/CodeGen/LexicalScopes.cpp
@@ -341,7 +341,6 @@ bool LexicalScopes::dominates(const DILocation *DL, MachineBasicBlock *MBB) {
   return Set->contains(MBB);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LexicalScope::dump(unsigned Indent) const {
   raw_ostream &err = dbgs();
   err.indent(Indent);
@@ -358,4 +357,3 @@ LLVM_DUMP_METHOD void LexicalScope::dump(unsigned Indent) const {
     if (Child != this)
       Child->dump(Indent + 2);
 }
-#endif

--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
@@ -3445,7 +3445,6 @@ void InstrRefBasedLDV::placePHIsForSingleVarDefinition(
   // value will be given to them.
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void InstrRefBasedLDV::dump_mloc_transfer(
     const MLocTransferMap &mloc_transfer) const {
   for (const auto &P : mloc_transfer) {
@@ -3454,7 +3453,6 @@ void InstrRefBasedLDV::dump_mloc_transfer(
     dbgs() << "Loc " << foo << " --> " << bar << "\n";
   }
 }
-#endif
 
 void InstrRefBasedLDV::initialSetup(MachineFunction &MF) {
   // Build some useful data structures.

--- a/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
@@ -711,7 +711,6 @@ private:
       return LS.dominates(MI.getDebugLoc().get(), &MBB);
     }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     // TRI and TII can be null.
     void dump(const TargetRegisterInfo *TRI, const TargetInstrInfo *TII,
               raw_ostream &Out = dbgs()) const {
@@ -765,7 +764,6 @@ private:
       else
         Out << "\n";
     }
-#endif
 
     bool operator==(const VarLoc &Other) const {
       return std::tie(EVKind, Var, Expr, Locs) ==

--- a/llvm/lib/CodeGen/LiveDebugVariables.cpp
+++ b/llvm/lib/CodeGen/LiveDebugVariables.cpp
@@ -2004,9 +2004,7 @@ void LiveDebugVariables::emitDebugValues(VirtRegMap *VRM) {
     PImpl->emitDebugValues(VRM);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LiveDebugVariables::dump() const { print(dbgs()); }
-#endif
 
 void LiveDebugVariables::print(raw_ostream &OS) const {
   if (PImpl)

--- a/llvm/lib/CodeGen/LiveInterval.cpp
+++ b/llvm/lib/CodeGen/LiveInterval.cpp
@@ -990,11 +990,9 @@ raw_ostream& llvm::operator<<(raw_ostream& OS, const LiveRange::Segment &S) {
   return OS << '[' << S.start << ',' << S.end << ':' << S.valno->id << ')';
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LiveRange::Segment::dump() const {
   dbgs() << *this << '\n';
 }
-#endif
 
 void VNInfo::print(raw_ostream &OS) const {
   OS << id << '@';
@@ -1046,7 +1044,6 @@ void LiveInterval::print(raw_ostream &OS) const {
   OS << "  weight:" << Weight;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void VNInfo::dump() const { dbgs() << *this << '\n'; }
 
 LLVM_DUMP_METHOD void LiveRange::dump() const { dbgs() << *this << '\n'; }
@@ -1058,7 +1055,6 @@ LLVM_DUMP_METHOD void LiveInterval::SubRange::dump() const {
 LLVM_DUMP_METHOD void LiveInterval::dump() const {
   dbgs() << *this << '\n';
 }
-#endif
 
 #ifndef NDEBUG
 bool LiveRange::verify() const {
@@ -1152,7 +1148,6 @@ bool LiveInterval::verify(const MachineRegisterInfo *MRI) const {
 // When they exist, Spills.back().start <= LastStart,
 //                 and WriteI[-1].start <= LastStart.
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void LiveRangeUpdater::print(raw_ostream &OS) const {
   if (!isDirty()) {
     if (LR)
@@ -1179,7 +1174,6 @@ void LiveRangeUpdater::print(raw_ostream &OS) const {
 LLVM_DUMP_METHOD void LiveRangeUpdater::dump() const {
   print(errs());
 }
-#endif
 
 // Determine if A and B should be coalesced.
 static inline bool coalescable(const LiveRange::Segment &A,

--- a/llvm/lib/CodeGen/LiveInterval.cpp
+++ b/llvm/lib/CodeGen/LiveInterval.cpp
@@ -1052,9 +1052,7 @@ LLVM_DUMP_METHOD void LiveInterval::SubRange::dump() const {
   dbgs() << *this << '\n';
 }
 
-LLVM_DUMP_METHOD void LiveInterval::dump() const {
-  dbgs() << *this << '\n';
-}
+LLVM_DUMP_METHOD void LiveInterval::dump() const { dbgs() << *this << '\n'; }
 
 #ifndef NDEBUG
 bool LiveRange::verify() const {
@@ -1171,9 +1169,7 @@ void LiveRangeUpdater::print(raw_ostream &OS) const {
   OS << '\n';
 }
 
-LLVM_DUMP_METHOD void LiveRangeUpdater::dump() const {
-  print(errs());
-}
+LLVM_DUMP_METHOD void LiveRangeUpdater::dump() const { print(errs()); }
 
 // Determine if A and B should be coalesced.
 static inline bool coalescable(const LiveRange::Segment &A,

--- a/llvm/lib/CodeGen/LiveIntervals.cpp
+++ b/llvm/lib/CodeGen/LiveIntervals.cpp
@@ -209,15 +209,11 @@ void LiveIntervals::printInstrs(raw_ostream &OS) const {
   MF->print(OS, Indexes);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LiveIntervals::dumpInstrs() const {
   printInstrs(dbgs());
 }
-#endif
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LiveIntervals::dump() const { print(dbgs()); }
-#endif
 
 LiveInterval *LiveIntervals::createInterval(Register reg) {
   float Weight = reg.isPhysical() ? huge_valf : 0.0F;

--- a/llvm/lib/CodeGen/LiveIntervals.cpp
+++ b/llvm/lib/CodeGen/LiveIntervals.cpp
@@ -209,9 +209,7 @@ void LiveIntervals::printInstrs(raw_ostream &OS) const {
   MF->print(OS, Indexes);
 }
 
-LLVM_DUMP_METHOD void LiveIntervals::dumpInstrs() const {
-  printInstrs(dbgs());
-}
+LLVM_DUMP_METHOD void LiveIntervals::dumpInstrs() const { printInstrs(dbgs()); }
 
 LLVM_DUMP_METHOD void LiveIntervals::dump() const { print(dbgs()); }
 

--- a/llvm/lib/CodeGen/LivePhysRegs.cpp
+++ b/llvm/lib/CodeGen/LivePhysRegs.cpp
@@ -132,11 +132,9 @@ void LivePhysRegs::print(raw_ostream &OS) const {
   OS << "\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LivePhysRegs::dump() const {
   dbgs() << "  " << *this;
 }
-#endif
 
 bool LivePhysRegs::available(const MachineRegisterInfo &MRI,
                              MCRegister Reg) const {

--- a/llvm/lib/CodeGen/LivePhysRegs.cpp
+++ b/llvm/lib/CodeGen/LivePhysRegs.cpp
@@ -132,9 +132,7 @@ void LivePhysRegs::print(raw_ostream &OS) const {
   OS << "\n";
 }
 
-LLVM_DUMP_METHOD void LivePhysRegs::dump() const {
-  dbgs() << "  " << *this;
-}
+LLVM_DUMP_METHOD void LivePhysRegs::dump() const { dbgs() << "  " << *this; }
 
 bool LivePhysRegs::available(const MachineRegisterInfo &MRI,
                              MCRegister Reg) const {

--- a/llvm/lib/CodeGen/LiveVariables.cpp
+++ b/llvm/lib/CodeGen/LiveVariables.cpp
@@ -106,9 +106,7 @@ void LiveVariables::VarInfo::print(raw_ostream &OS) const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LiveVariables::VarInfo::dump() const { print(dbgs()); }
-#endif
 
 /// getVarInfo - Get (possibly creating) a VarInfo object for the given vreg.
 LiveVariables::VarInfo &LiveVariables::getVarInfo(Register Reg) {

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -295,9 +295,7 @@ bool MachineBasicBlock::isEntryBlock() const {
   return getParent()->begin() == getIterator();
 }
 
-LLVM_DUMP_METHOD void MachineBasicBlock::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void MachineBasicBlock::dump() const { print(dbgs()); }
 
 bool MachineBasicBlock::mayHaveInlineAsmBr() const {
   for (const MachineBasicBlock *Succ : successors()) {

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -295,11 +295,9 @@ bool MachineBasicBlock::isEntryBlock() const {
   return getParent()->begin() == getIterator();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MachineBasicBlock::dump() const {
   print(dbgs());
 }
-#endif
 
 bool MachineBasicBlock::mayHaveInlineAsmBr() const {
   for (const MachineBasicBlock *Succ : successors()) {

--- a/llvm/lib/CodeGen/MachineFrameInfo.cpp
+++ b/llvm/lib/CodeGen/MachineFrameInfo.cpp
@@ -262,8 +262,6 @@ void MachineFrameInfo::print(const MachineFunction &MF, raw_ostream &OS) const{
     OS << "restore points are empty\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MachineFrameInfo::dump(const MachineFunction &MF) const {
   print(MF, dbgs());
 }
-#endif

--- a/llvm/lib/CodeGen/MachineFunction.cpp
+++ b/llvm/lib/CodeGen/MachineFunction.cpp
@@ -636,11 +636,9 @@ ArrayRef<int> MachineFunction::allocateShuffleMask(ArrayRef<int> Mask) {
   return {AllocMask, Mask.size()};
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MachineFunction::dump() const {
   print(dbgs());
 }
-#endif
 
 StringRef MachineFunction::getName() const {
   return getFunction().getName();
@@ -1445,9 +1443,7 @@ void MachineJumpTableInfo::print(raw_ostream &OS) const {
   OS << '\n';
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MachineJumpTableInfo::dump() const { print(dbgs()); }
-#endif
 
 Printable llvm::printJumpTableEntryReference(unsigned Idx) {
   return Printable([Idx](raw_ostream &OS) { OS << "%jump-table." << Idx; });
@@ -1624,6 +1620,4 @@ ProfileSummaryInfo::getEntryCount<llvm::MachineFunction>(
   return F->getFunction().getEntryCount();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MachineConstantPool::dump() const { print(dbgs()); }
-#endif

--- a/llvm/lib/CodeGen/MachineFunction.cpp
+++ b/llvm/lib/CodeGen/MachineFunction.cpp
@@ -636,9 +636,7 @@ ArrayRef<int> MachineFunction::allocateShuffleMask(ArrayRef<int> Mask) {
   return {AllocMask, Mask.size()};
 }
 
-LLVM_DUMP_METHOD void MachineFunction::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void MachineFunction::dump() const { print(dbgs()); }
 
 StringRef MachineFunction::getName() const {
   return getFunction().getName();

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -1763,7 +1763,6 @@ LLT MachineInstr::getTypeToPrint(unsigned OpIdx, SmallBitVector &PrintedTypes,
   return TypeToPrint;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MachineInstr::dump() const {
   dbgs() << "  ";
   print(dbgs());
@@ -1799,7 +1798,6 @@ LLVM_DUMP_METHOD void MachineInstr::dumpr(const MachineRegisterInfo &MRI,
   SmallPtrSet<const MachineInstr *, 16> AlreadySeenInstrs;
   dumprImpl(MRI, 0, MaxDepth, AlreadySeenInstrs);
 }
-#endif
 
 void MachineInstr::print(raw_ostream &OS, bool IsStandalone, bool SkipOpers,
                          bool SkipDebugLoc, bool AddNewLine,

--- a/llvm/lib/CodeGen/MachineLoopInfo.cpp
+++ b/llvm/lib/CodeGen/MachineLoopInfo.cpp
@@ -287,6 +287,4 @@ bool MachineLoop::isLoopInvariant(MachineInstr &I,
   return true;
 }
 
-LLVM_DUMP_METHOD void MachineLoop::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void MachineLoop::dump() const { print(dbgs()); }

--- a/llvm/lib/CodeGen/MachineLoopInfo.cpp
+++ b/llvm/lib/CodeGen/MachineLoopInfo.cpp
@@ -287,8 +287,6 @@ bool MachineLoop::isLoopInvariant(MachineInstr &I,
   return true;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MachineLoop::dump() const {
   print(dbgs());
 }
-#endif

--- a/llvm/lib/CodeGen/MachineOperand.cpp
+++ b/llvm/lib/CodeGen/MachineOperand.cpp
@@ -1053,9 +1053,7 @@ void MachineOperand::print(raw_ostream &OS, ModuleSlotTracker &MST,
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MachineOperand::dump() const { dbgs() << *this << '\n'; }
-#endif
 
 //===----------------------------------------------------------------------===//
 // MachineMemOperand Implementation

--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -3896,7 +3896,6 @@ void NodeSet::print(raw_ostream &os) const {
   os << "\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// Print the schedule information to the given output.
 void SMSchedule::print(raw_ostream &os) const {
   // Iterate over each cycle.
@@ -3936,7 +3935,6 @@ void ResourceManager::dumpMRT() const {
     dbgs() << SS.str();
   });
 }
-#endif
 
 void ResourceManager::initProcResourceVectors(
     const MCSchedModel &SM, SmallVectorImpl<uint64_t> &Masks) {

--- a/llvm/lib/CodeGen/MachineRegionInfo.cpp
+++ b/llvm/lib/CodeGen/MachineRegionInfo.cpp
@@ -119,9 +119,7 @@ void MachineRegionInfoPass::print(raw_ostream &OS, const Module *) const {
   RI.print(OS);
 }
 
-LLVM_DUMP_METHOD void MachineRegionInfoPass::dump() const {
-  RI.dump();
-}
+LLVM_DUMP_METHOD void MachineRegionInfoPass::dump() const { RI.dump(); }
 
 char MachineRegionInfoPass::ID = 0;
 char &llvm::MachineRegionInfoPassID = MachineRegionInfoPass::ID;

--- a/llvm/lib/CodeGen/MachineRegionInfo.cpp
+++ b/llvm/lib/CodeGen/MachineRegionInfo.cpp
@@ -119,11 +119,9 @@ void MachineRegionInfoPass::print(raw_ostream &OS, const Module *) const {
   RI.print(OS);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MachineRegionInfoPass::dump() const {
   RI.dump();
 }
-#endif
 
 char MachineRegionInfoPass::ID = 0;
 char &llvm::MachineRegionInfoPassID = MachineRegionInfoPass::ID;

--- a/llvm/lib/CodeGen/MachineRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/MachineRegisterInfo.cpp
@@ -519,12 +519,10 @@ LaneBitmask MachineRegisterInfo::getMaxLaneMaskForVReg(Register Reg) const {
   return TRC.getLaneMask();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MachineRegisterInfo::dumpUses(Register Reg) const {
   for (MachineInstr &I : use_instructions(Reg))
     I.dump();
 }
-#endif
 
 void MachineRegisterInfo::freezeReservedRegs() {
   ReservedRegs = getTargetRegisterInfo()->getReservedRegs(*MF);

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -3165,7 +3165,6 @@ SUnit *SchedBoundary::pickOnlyChoice() {
   return nullptr;
 }
 
-
 /// Dump the content of the \ref ReservedCycles vector for the
 /// resources that are used in the basic block.
 ///
@@ -3711,8 +3710,7 @@ void GenericScheduler::dumpPolicy() const {
   dbgs() << "GenericScheduler RegionPolicy: "
          << " ShouldTrackPressure=" << RegionPolicy.ShouldTrackPressure
          << " OnlyTopDown=" << RegionPolicy.OnlyTopDown
-         << " OnlyBottomUp=" << RegionPolicy.OnlyBottomUp
-         << "\n";
+         << " OnlyBottomUp=" << RegionPolicy.OnlyBottomUp << "\n";
 }
 
 /// Set IsAcyclicLatencyLimited if the acyclic path is longer than the cyclic

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -224,9 +224,7 @@ static cl::opt<bool> MischedDetailResourceBooking(
 const bool llvm::ViewMISchedDAGs = false;
 const bool llvm::PrintDAGs = false;
 static const bool MischedDetailResourceBooking = false;
-#ifdef LLVM_ENABLE_DUMP
 static const bool MISchedDumpReservedCycles = false;
-#endif // LLVM_ENABLE_DUMP
 #endif // NDEBUG
 
 #ifndef NDEBUG
@@ -268,7 +266,6 @@ static cl::opt<unsigned>
                          cl::desc("The threshold for fast cluster"),
                          cl::init(1000));
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 static cl::opt<bool> MISchedDumpScheduleTrace(
     "misched-dump-schedule-trace", cl::Hidden, cl::init(false),
     cl::desc("Dump resource usage at schedule boundary."));
@@ -284,7 +281,6 @@ static cl::opt<unsigned>
 static cl::opt<bool> MISchedSortResourcesInTrace(
     "misched-sort-resources-in-trace", cl::Hidden, cl::init(true),
     cl::desc("Sort the resources printed in the dump trace"));
-#endif
 
 static cl::opt<unsigned>
     MIResourceCutOff("misched-resource-cutoff", cl::Hidden,
@@ -898,14 +894,12 @@ void MachineSchedulerBase::scheduleRegions(ScheduleDAGInstrs &Scheduler,
   Scheduler.finalizeSchedule();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ReadyQueue::dump() const {
   dbgs() << "Queue " << Name << ": ";
   for (const SUnit *SU : Queue)
     dbgs() << SU->NodeNum << " ";
   dbgs() << "\n";
 }
-#endif
 
 //===----------------------------------------------------------------------===//
 // ScheduleDAGMI - Basic machine instruction scheduling. This is
@@ -1213,7 +1207,6 @@ void ScheduleDAGMI::placeDebugValues() {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 static const char *scheduleTableLegend = "  i: issue\n  x: resource booked";
 
 LLVM_DUMP_METHOD void ScheduleDAGMI::dumpScheduleTraceTopDown() const {
@@ -1377,9 +1370,7 @@ LLVM_DUMP_METHOD void ScheduleDAGMI::dumpScheduleTraceBottomUp() const {
     }
   }
 }
-#endif
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ScheduleDAGMI::dumpSchedule() const {
   if (MISchedDumpScheduleTrace) {
     if (DumpDir == DumpDirection::TopDown)
@@ -1400,7 +1391,6 @@ LLVM_DUMP_METHOD void ScheduleDAGMI::dumpSchedule() const {
       dbgs() << "Missing SUnit\n";
   }
 }
-#endif
 
 //===----------------------------------------------------------------------===//
 // ScheduleDAGMILive - Base class for MachineInstr scheduling with LiveIntervals
@@ -1657,7 +1647,6 @@ void ScheduleDAGMILive::updatePressureDiffs(ArrayRef<VRegMaskOrUnit> LiveUses) {
 }
 
 void ScheduleDAGMILive::dump() const {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   if (EntrySU.getInstr() != nullptr)
     dumpNodeAll(EntrySU);
   for (const SUnit &SU : SUnits) {
@@ -1676,7 +1665,6 @@ void ScheduleDAGMILive::dump() const {
   }
   if (ExitSU.getInstr() != nullptr)
     dumpNodeAll(ExitSU);
-#endif
 }
 
 /// schedule - Called back from MachineScheduler::runOnMachineFunction
@@ -3177,7 +3165,6 @@ SUnit *SchedBoundary::pickOnlyChoice() {
   return nullptr;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 
 /// Dump the content of the \ref ReservedCycles vector for the
 /// resources that are used in the basic block.
@@ -3231,7 +3218,6 @@ LLVM_DUMP_METHOD void SchedBoundary::dumpScheduledState() const {
   if (MISchedDumpReservedCycles)
     dumpReservedCycles();
 }
-#endif
 
 //===----------------------------------------------------------------------===//
 // GenericScheduler - Generic implementation of MachineSchedStrategy.
@@ -3722,13 +3708,11 @@ void GenericScheduler::initPolicy(MachineBasicBlock::iterator Begin,
 
 void GenericScheduler::dumpPolicy() const {
   // Cannot completely remove virtual function even in release mode.
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   dbgs() << "GenericScheduler RegionPolicy: "
          << " ShouldTrackPressure=" << RegionPolicy.ShouldTrackPressure
          << " OnlyTopDown=" << RegionPolicy.OnlyTopDown
          << " OnlyBottomUp=" << RegionPolicy.OnlyBottomUp
          << "\n";
-#endif
 }
 
 /// Set IsAcyclicLatencyLimited if the acyclic path is longer than the cyclic

--- a/llvm/lib/CodeGen/PostRASchedulerList.cpp
+++ b/llvm/lib/CodeGen/PostRASchedulerList.cpp
@@ -252,7 +252,6 @@ void SchedulePostRATDList::exitRegion() {
   ScheduleDAGInstrs::exitRegion();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// dumpSchedule - dump the scheduled Sequence.
 LLVM_DUMP_METHOD void SchedulePostRATDList::dumpSchedule() const {
   for (const SUnit *SU : Sequence) {
@@ -262,7 +261,6 @@ LLVM_DUMP_METHOD void SchedulePostRATDList::dumpSchedule() const {
       dbgs() << "**** NOOP ****\n";
   }
 }
-#endif
 
 static bool enablePostRAScheduler(const TargetSubtargetInfo &ST,
                                   CodeGenOptLevel OptLevel) {

--- a/llvm/lib/CodeGen/RegAllocPBQP.cpp
+++ b/llvm/lib/CodeGen/RegAllocPBQP.cpp
@@ -892,7 +892,6 @@ static Printable PrintNodeInfo(PBQP::RegAlloc::PBQPRAGraph::NodeId NId,
   });
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void PBQP::RegAlloc::PBQPRAGraph::dump(raw_ostream &OS) const {
   for (auto NId : nodeIds()) {
     const Vector &Costs = getNodeCosts(NId);
@@ -917,7 +916,6 @@ LLVM_DUMP_METHOD void PBQP::RegAlloc::PBQPRAGraph::dump(raw_ostream &OS) const {
 LLVM_DUMP_METHOD void PBQP::RegAlloc::PBQPRAGraph::dump() const {
   dump(dbgs());
 }
-#endif
 
 void PBQP::RegAlloc::PBQPRAGraph::printDot(raw_ostream &OS) const {
   OS << "graph {\n";

--- a/llvm/lib/CodeGen/RegisterBank.cpp
+++ b/llvm/lib/CodeGen/RegisterBank.cpp
@@ -62,11 +62,9 @@ bool RegisterBank::operator==(const RegisterBank &OtherRB) const {
   return &OtherRB == this;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RegisterBank::dump(const TargetRegisterInfo *TRI) const {
   print(dbgs(), /* IsForDebug */ true, TRI);
 }
-#endif
 
 void RegisterBank::print(raw_ostream &OS, bool IsForDebug,
                          const TargetRegisterInfo *TRI) const {

--- a/llvm/lib/CodeGen/RegisterBankInfo.cpp
+++ b/llvm/lib/CodeGen/RegisterBankInfo.cpp
@@ -512,12 +512,10 @@ TypeSize RegisterBankInfo::getSizeInBits(Register Reg,
 //------------------------------------------------------------------------------
 // Helper classes implementation.
 //------------------------------------------------------------------------------
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RegisterBankInfo::PartialMapping::dump() const {
   print(dbgs());
   dbgs() << '\n';
 }
-#endif
 
 bool RegisterBankInfo::PartialMapping::verify(
     const RegisterBankInfo &RBI) const {
@@ -582,12 +580,10 @@ bool RegisterBankInfo::ValueMapping::verify(const RegisterBankInfo &RBI,
   return true;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RegisterBankInfo::ValueMapping::dump() const {
   print(dbgs());
   dbgs() << '\n';
 }
-#endif
 
 void RegisterBankInfo::ValueMapping::print(raw_ostream &OS) const {
   OS << "#BreakDown: " << NumBreakDowns << " ";
@@ -641,12 +637,10 @@ bool RegisterBankInfo::InstructionMapping::verify(
   return true;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RegisterBankInfo::InstructionMapping::dump() const {
   print(dbgs());
   dbgs() << '\n';
 }
-#endif
 
 void RegisterBankInfo::InstructionMapping::print(raw_ostream &OS) const {
   OS << "ID: " << getID() << " Cost: " << getCost() << " Mapping: ";
@@ -764,12 +758,10 @@ RegisterBankInfo::OperandsMapper::getVRegs(unsigned OpIdx,
   return Res;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RegisterBankInfo::OperandsMapper::dump() const {
   print(dbgs(), true);
   dbgs() << '\n';
 }
-#endif
 
 void RegisterBankInfo::OperandsMapper::print(raw_ostream &OS,
                                              bool ForDebug) const {

--- a/llvm/lib/CodeGen/RegisterPressure.cpp
+++ b/llvm/lib/CodeGen/RegisterPressure.cpp
@@ -147,7 +147,6 @@ void RegPressureDelta::dump() const {
   dbgs() << "]\n";
 }
 
-
 void RegPressureTracker::increaseRegPressure(VirtRegOrUnit VRegOrUnit,
                                              LaneBitmask PreviousMask,
                                              LaneBitmask NewMask) {

--- a/llvm/lib/CodeGen/RegisterPressure.cpp
+++ b/llvm/lib/CodeGen/RegisterPressure.cpp
@@ -77,7 +77,6 @@ static void decreaseSetPressure(std::vector<unsigned> &CurrSetPressure,
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD
 void llvm::dumpRegSetPressure(ArrayRef<unsigned> SetPressure,
                               const TargetRegisterInfo *TRI) {
@@ -148,7 +147,6 @@ void RegPressureDelta::dump() const {
   dbgs() << "]\n";
 }
 
-#endif
 
 void RegPressureTracker::increaseRegPressure(VirtRegOrUnit VRegOrUnit,
                                              LaneBitmask PreviousMask,

--- a/llvm/lib/CodeGen/ScheduleDAG.cpp
+++ b/llvm/lib/CodeGen/ScheduleDAG.cpp
@@ -339,7 +339,6 @@ void SUnit::biasCriticalPath() {
     std::swap(*Preds.begin(), *BestI);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SUnit::dumpAttributes() const {
   dbgs() << "  # preds left       : " << NumPredsLeft << "\n";
   dbgs() << "  # succs left       : " << NumSuccsLeft << "\n";
@@ -389,7 +388,6 @@ LLVM_DUMP_METHOD void ScheduleDAG::dumpNodeAll(const SUnit &SU) const {
     }
   }
 }
-#endif
 
 #ifndef NDEBUG
 unsigned ScheduleDAG::VerifyScheduledDAG(bool isBottomUp) {

--- a/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
+++ b/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
@@ -93,11 +93,9 @@ static cl::opt<unsigned> ReductionSize(
     cl::desc("A huge scheduling region will have maps reduced by this many "
              "nodes at a time. Defaults to HugeRegion / 2."));
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 static cl::opt<bool> SchedPrintCycles(
     "sched-print-cycles", cl::Hidden, cl::init(false),
     cl::desc("Report top/bottom cycles when dumping SUnit instances"));
-#endif
 
 static unsigned getReductionSize() {
   // Always reduce a huge region with half of the elements, except
@@ -108,7 +106,6 @@ static unsigned getReductionSize() {
 }
 
 static void dumpSUList(const ScheduleDAGInstrs::SUList &L) {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   dbgs() << "{ ";
   for (const SUnit *SU : L) {
     dbgs() << "SU(" << SU->NodeNum << ")";
@@ -116,7 +113,6 @@ static void dumpSUList(const ScheduleDAGInstrs::SUList &L) {
       dbgs() << ", ";
   }
   dbgs() << "}\n";
-#endif
 }
 
 ScheduleDAGInstrs::ScheduleDAGInstrs(MachineFunction &mf,
@@ -1193,25 +1189,21 @@ void ScheduleDAGInstrs::fixupKills(MachineBasicBlock &MBB) {
 }
 
 void ScheduleDAGInstrs::dumpNode(const SUnit &SU) const {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   dumpNodeName(SU);
   if (SchedPrintCycles)
     dbgs() << " [TopReadyCycle = " << SU.TopReadyCycle
            << ", BottomReadyCycle = " << SU.BotReadyCycle << "]";
   dbgs() << ": ";
   SU.getInstr()->dump();
-#endif
 }
 
 void ScheduleDAGInstrs::dump() const {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   if (EntrySU.getInstr() != nullptr)
     dumpNodeAll(EntrySU);
   for (const SUnit &SU : SUnits)
     dumpNodeAll(SU);
   if (ExitSU.getInstr() != nullptr)
     dumpNodeAll(ExitSU);
-#endif
 }
 
 std::string ScheduleDAGInstrs::getGraphNodeLabel(const SUnit *SU) const {
@@ -1538,7 +1530,6 @@ void SchedDFSResult::scheduleTree(unsigned SubtreeID) {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ILPValue::print(raw_ostream &OS) const {
   OS << InstrCount << " / " << Length << " = ";
   if (!Length)
@@ -1557,4 +1548,3 @@ raw_ostream &llvm::operator<<(raw_ostream &OS, const ILPValue &Val) {
   return OS;
 }
 
-#endif

--- a/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
+++ b/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
@@ -1547,4 +1547,3 @@ raw_ostream &llvm::operator<<(raw_ostream &OS, const ILPValue &Val) {
   Val.print(OS);
   return OS;
 }
-

--- a/llvm/lib/CodeGen/ScoreboardHazardRecognizer.cpp
+++ b/llvm/lib/CodeGen/ScoreboardHazardRecognizer.cpp
@@ -82,7 +82,6 @@ void ScoreboardHazardRecognizer::Reset() {
   ReservedScoreboard.reset();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ScoreboardHazardRecognizer::Scoreboard::dump() const {
   dbgs() << "Scoreboard:\n";
 
@@ -99,7 +98,6 @@ LLVM_DUMP_METHOD void ScoreboardHazardRecognizer::Scoreboard::dump() const {
     dbgs() << '\n';
   }
 }
-#endif
 
 bool ScoreboardHazardRecognizer::atIssueLimit() const {
   if (IssueWidth == 0)

--- a/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGRRList.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGRRList.cpp
@@ -1907,7 +1907,6 @@ public:
     return V;
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump(ScheduleDAG *DAG) const override {
     // Emulate pop() without clobbering NodeQueueIds.
     std::vector<SUnit *> DumpQueue = Queue;
@@ -1918,7 +1917,6 @@ public:
       DAG->dumpNode(*SU);
     }
   }
-#endif
 };
 
 using BURegReductionPriorityQueue = RegReductionPriorityQueue<bu_ls_rr_sort>;
@@ -2078,7 +2076,6 @@ unsigned RegReductionPQBase::getNodePriority(const SUnit *SU) const {
 //                     Register Pressure Tracking
 //===----------------------------------------------------------------------===//
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RegReductionPQBase::dumpRegPressure() const {
   for (const TargetRegisterClass *RC : TRI->regclasses()) {
     unsigned Id = RC->getID();
@@ -2088,7 +2085,6 @@ LLVM_DUMP_METHOD void RegReductionPQBase::dumpRegPressure() const {
                       << RegLimit[Id] << '\n');
   }
 }
-#endif
 
 bool RegReductionPQBase::HighRegPressure(const SUnit *SU) const {
   if (!TLI)

--- a/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
@@ -670,7 +670,6 @@ void ScheduleDAGSDNodes::computeOperandLatency(SDNode *Def, SDNode *Use,
 }
 
 void ScheduleDAGSDNodes::dumpNode(const SUnit &SU) const {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   dumpNodeName(SU);
   dbgs() << ": ";
 
@@ -690,21 +689,17 @@ void ScheduleDAGSDNodes::dumpNode(const SUnit &SU) const {
     dbgs() << "\n";
     GluedNodes.pop_back();
   }
-#endif
 }
 
 void ScheduleDAGSDNodes::dump() const {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   if (EntrySU.getNode() != nullptr)
     dumpNodeAll(EntrySU);
   for (const SUnit &SU : SUnits)
     dumpNodeAll(SU);
   if (ExitSU.getNode() != nullptr)
     dumpNodeAll(ExitSU);
-#endif
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void ScheduleDAGSDNodes::dumpSchedule() const {
   for (const SUnit *SU : Sequence) {
     if (SU)
@@ -713,7 +708,6 @@ void ScheduleDAGSDNodes::dumpSchedule() const {
       dbgs() << "**** NOOP ****\n";
   }
 }
-#endif
 
 #ifndef NDEBUG
 /// VerifyScheduledSequence - Verify that all SUnits were scheduled and that

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGAddressAnalysis.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGAddressAnalysis.cpp
@@ -308,7 +308,6 @@ BaseIndexOffset BaseIndexOffset::match(const SDNode *N,
   return BaseIndexOffset();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 
 LLVM_DUMP_METHOD void BaseIndexOffset::dump() const {
   print(dbgs());
@@ -323,4 +322,3 @@ void BaseIndexOffset::print(raw_ostream& OS) const {
   OS << "] offset=" << Offset;
 }
 
-#endif

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGAddressAnalysis.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGAddressAnalysis.cpp
@@ -308,7 +308,6 @@ BaseIndexOffset BaseIndexOffset::match(const SDNode *N,
   return BaseIndexOffset();
 }
 
-
 LLVM_DUMP_METHOD void BaseIndexOffset::dump() const {
   print(dbgs());
 }
@@ -321,4 +320,3 @@ void BaseIndexOffset::print(raw_ostream& OS) const {
     Index->print(OS);
   OS << "] offset=" << Offset;
 }
-

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
@@ -668,14 +668,12 @@ static void printMemOperand(raw_ostream &OS, const MachineMemOperand &MMO,
                          /*MFI=*/nullptr, /*TII=*/nullptr, Ctx);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SDNode::dump() const { dump(nullptr); }
 
 LLVM_DUMP_METHOD void SDNode::dump(const SelectionDAG *G) const {
   print(dbgs(), G);
   dbgs() << '\n';
 }
-#endif
 
 void SDNode::print_types(raw_ostream &OS, const SelectionDAG *G) const {
   for (unsigned i = 0, e = getNumValues(); i != e; ++i) {
@@ -1047,14 +1045,12 @@ LLVM_DUMP_METHOD void SDDbgValue::print(raw_ostream &OS) const {
 #endif
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SDDbgValue::dump() const {
   if (isInvalidated())
     return;
   print(dbgs());
   dbgs() << "\n";
 }
-#endif
 
 /// Return true if this node is so simple that we should just print it inline
 /// if it appears as an operand.
@@ -1068,7 +1064,6 @@ static bool shouldPrintInline(const SDNode &Node, const SelectionDAG *G) {
   return Node.getNumOperands() == 0;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 static void DumpNodes(const SDNode *N, unsigned indent, const SelectionDAG *G) {
   for (const SDValue &Op : N->op_values()) {
     if (shouldPrintInline(*Op.getNode(), G))
@@ -1116,7 +1111,6 @@ LLVM_DUMP_METHOD void SelectionDAG::dump(bool Sorted) const {
   }
   dbgs() << "\n";
 }
-#endif
 
 void SDNode::printr(raw_ostream &OS, const SelectionDAG *G) const {
   OS << PrintNodeId(*this) << ": ";
@@ -1145,7 +1139,6 @@ static bool printOperand(raw_ostream &OS, const SelectionDAG *G,
   return false;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 using VisitedSDNodeSet = SmallPtrSet<const SDNode *, 32>;
 
 static void DumpNodesr(raw_ostream &OS, const SDNode *N, unsigned indent,
@@ -1184,7 +1177,6 @@ LLVM_DUMP_METHOD void SDNode::dumpr(const SelectionDAG *G) const {
   VisitedSDNodeSet once;
   DumpNodesr(dbgs(), this, 0, G, once);
 }
-#endif
 
 static void printrWithDepthHelper(raw_ostream &OS, const SDNode *N,
                                   const SelectionDAG *G, unsigned depth,
@@ -1218,7 +1210,6 @@ void SDNode::printrFull(raw_ostream &OS, const SelectionDAG *G) const {
   printrWithDepth(OS, G, 10);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD
 void SDNode::dumprWithDepth(const SelectionDAG *G, unsigned depth) const {
   printrWithDepth(dbgs(), G, depth);
@@ -1228,7 +1219,6 @@ LLVM_DUMP_METHOD void SDNode::dumprFull(const SelectionDAG *G) const {
   // Don't print impossibly deep things.
   dumprWithDepth(G, 10);
 }
-#endif
 
 void SDNode::print(raw_ostream &OS, const SelectionDAG *G) const {
   printr(OS, G);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGPrinter.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGPrinter.cpp
@@ -167,12 +167,10 @@ void SelectionDAG::viewGraph() {
 /// without any path separators then the file
 /// will be created in the current directory.
 /// Error will be emitted if the path is insane.
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SelectionDAG::dumpDotGraph(const Twine &FileName,
                                                  const Twine &Title) {
   dumpDotGraphToFile(this, FileName, Title);
 }
-#endif
 
 /// clearGraphAttrs - Clear all previously defined node graph attributes.
 /// Intended to be used from a debugging tool (eg. gdb).

--- a/llvm/lib/CodeGen/SlotIndexes.cpp
+++ b/llvm/lib/CodeGen/SlotIndexes.cpp
@@ -276,9 +276,7 @@ void SlotIndexes::print(raw_ostream &OS) const {
        << MBBRanges[i].second << ")\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SlotIndexes::dump() const { print(dbgs()); }
-#endif
 
 // Print a SlotIndex to a raw_ostream.
 void SlotIndex::print(raw_ostream &os) const {
@@ -288,10 +286,8 @@ void SlotIndex::print(raw_ostream &os) const {
     os << "invalid";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 // Dump a SlotIndex to stderr.
 LLVM_DUMP_METHOD void SlotIndex::dump() const {
   print(dbgs());
   dbgs() << "\n";
 }
-#endif

--- a/llvm/lib/CodeGen/SplitKit.cpp
+++ b/llvm/lib/CodeGen/SplitKit.cpp
@@ -378,7 +378,6 @@ void SplitEditor::reset(LiveRangeEdit &LRE, ComplementSpillMode SM) {
                     &LIS.getVNInfoAllocator());
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SplitEditor::dump() const {
   if (RegAssign.empty()) {
     dbgs() << " empty\n";
@@ -389,7 +388,6 @@ LLVM_DUMP_METHOD void SplitEditor::dump() const {
     dbgs() << " [" << I.start() << ';' << I.stop() << "):" << I.value();
   dbgs() << '\n';
 }
-#endif
 
 /// Find a subrange corresponding to the exact lane mask @p LM in the live
 /// interval @p LI. The interval @p LI is assumed to contain such a subrange.

--- a/llvm/lib/CodeGen/StackColoring.cpp
+++ b/llvm/lib/CodeGen/StackColoring.cpp
@@ -531,7 +531,6 @@ void StackColoringLegacy::getAnalysisUsage(AnalysisUsage &AU) const {
   MachineFunctionPass::getAnalysisUsage(AU);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void StackColoring::dumpBV(const char *tag,
                                             const BitVector &BV) const {
   dbgs() << tag << " : { ";
@@ -565,7 +564,6 @@ LLVM_DUMP_METHOD void StackColoring::dumpIntervals() const {
     Intervals[I]->dump();
   }
 }
-#endif
 
 static inline int getStartOrEndSlot(const MachineInstr &MI)
 {

--- a/llvm/lib/CodeGen/TargetRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/TargetRegisterInfo.cpp
@@ -706,10 +706,8 @@ TargetRegisterInfo::prependOffsetExpression(const DIExpression *Expr,
                                       PrependFlags & DIExpression::EntryValue);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD
 void TargetRegisterInfo::dumpReg(Register Reg, unsigned SubRegIndex,
                                  const TargetRegisterInfo *TRI) {
   dbgs() << printReg(Reg, TRI, SubRegIndex) << "\n";
 }
-#endif

--- a/llvm/lib/CodeGen/ValueTypes.cpp
+++ b/llvm/lib/CodeGen/ValueTypes.cpp
@@ -205,12 +205,10 @@ std::string EVT::getEVTString() const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void EVT::dump() const {
   print(dbgs());
   dbgs() << "\n";
 }
-#endif
 
 /// getTypeForEVT - This method returns an LLVM type corresponding to the
 /// specified EVT.  For integer types, this returns an unsigned type.  Note
@@ -333,12 +331,10 @@ const fltSemantics &EVT::getFltSemantics() const {
   return getScalarType().getSimpleVT().getFltSemantics();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void MVT::dump() const {
   print(dbgs());
   dbgs() << "\n";
 }
-#endif
 
 void MVT::print(raw_ostream &OS) const {
   if (SimpleTy == INVALID_SIMPLE_VALUE_TYPE)

--- a/llvm/lib/CodeGen/VirtRegMap.cpp
+++ b/llvm/lib/CodeGen/VirtRegMap.cpp
@@ -164,9 +164,7 @@ void VirtRegMap::print(raw_ostream &OS, const Module*) const {
   OS << '\n';
 }
 
-LLVM_DUMP_METHOD void VirtRegMap::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void VirtRegMap::dump() const { print(dbgs()); }
 
 AnalysisKey VirtRegMapAnalysis::Key;
 

--- a/llvm/lib/CodeGen/VirtRegMap.cpp
+++ b/llvm/lib/CodeGen/VirtRegMap.cpp
@@ -164,11 +164,9 @@ void VirtRegMap::print(raw_ostream &OS, const Module*) const {
   OS << '\n';
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void VirtRegMap::dump() const {
   print(dbgs());
 }
-#endif
 
 AnalysisKey VirtRegMapAnalysis::Key;
 

--- a/llvm/lib/CodeGenTypes/LowLevelType.cpp
+++ b/llvm/lib/CodeGenTypes/LowLevelType.cpp
@@ -48,9 +48,7 @@ void LLT::print(raw_ostream &OS) const {
     OS << "LLT_invalid";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LLT::dump() const {
   print(dbgs());
   dbgs() << '\n';
 }
-#endif

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinkerCompileUnit.cpp
@@ -18,7 +18,6 @@ namespace llvm {
 using namespace dwarf_linker;
 using namespace dwarf_linker::classic;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void CompileUnit::DIEInfo::dump() {
   llvm::errs() << "{\n";
   llvm::errs() << "  AddrAdjust: " << AddrAdjust << '\n';
@@ -34,7 +33,6 @@ LLVM_DUMP_METHOD void CompileUnit::DIEInfo::dump() {
   llvm::errs() << "  UnclonedReference: " << UnclonedReference << '\n';
   llvm::errs() << "}\n";
 }
-#endif // if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 
 /// Check if the DIE at \p Idx is in the scope of a function.
 static bool inFunctionScope(CompileUnit &U, unsigned Idx) {

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
@@ -1634,7 +1634,6 @@ void CompileUnit::insertLineSequence(std::vector<DWARFDebugLine::Row> &Seq,
   Seq.clear();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void CompileUnit::DIEInfo::dump() {
   llvm::errs() << "{";
   llvm::errs() << "  Placement: ";
@@ -1663,7 +1662,6 @@ LLVM_DUMP_METHOD void CompileUnit::DIEInfo::dump() {
   llvm::errs() << "  TrackLiveness: " << getTrackLiveness();
   llvm::errs() << "}\n";
 }
-#endif // if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 
 std::optional<std::pair<StringRef, StringRef>>
 CompileUnit::getDirAndFilenameFromLineTable(

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.h
@@ -257,9 +257,7 @@ public:
     /// Erase all flags.
     void eraseData() { Flags = 0; }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     LLVM_DUMP_METHOD void dump();
-#endif
 
     bool needToPlaceInTypeTable() const {
       return (getKeep() && (getPlacement() == CompileUnit::TypeTable ||

--- a/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DependencyTracker.cpp
@@ -26,7 +26,6 @@ struct BrokenLink {
 /// Verify the keep chain by looking for DIEs that are kept but who's parent
 /// isn't.
 void DependencyTracker::verifyKeepChain() {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   SmallVector<DWARFDie> Worklist;
   Worklist.push_back(CU.getOrigUnit().getUnitDIE());
 
@@ -102,7 +101,6 @@ void DependencyTracker::verifyKeepChain() {
     }
     report_fatal_error("invalid keep chain");
   }
-#endif
 }
 
 bool DependencyTracker::resolveDependenciesAndMarkLiveness(

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -5451,7 +5451,6 @@ void ModuleSlotTracker::collectMDNodes(MachineMDNodeListType &L, unsigned LB,
       L.push_back(std::make_pair(I.second, I.first));
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 // Value::dump - allow easy printing of Values from the debugger.
 LLVM_DUMP_METHOD
 void Value::dump() const { print(dbgs(), /*IsForDebug=*/true); dbgs() << '\n'; }
@@ -5507,4 +5506,3 @@ void MDNode::dumpTree(const Module *M) const {
 // Allow printing of ModuleSummaryIndex from the debugger.
 LLVM_DUMP_METHOD
 void ModuleSummaryIndex::dump() const { print(dbgs(), /*IsForDebug=*/true); }
-#endif

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -1262,13 +1262,11 @@ AttributeSet::iterator AttributeSet::end() const {
   return SetNode ? SetNode->end() : nullptr;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void AttributeSet::dump() const {
   dbgs() << "AS =\n";
     dbgs() << "  { ";
     dbgs() << getAsString(true) << " }\n";
 }
-#endif
 
 //===----------------------------------------------------------------------===//
 // AttributeSetNode Definition
@@ -1511,11 +1509,9 @@ bool AttributeListImpl::hasAttrSomewhere(Attribute::AttrKind Kind,
 }
 
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void AttributeListImpl::dump() const {
   AttributeList(const_cast<AttributeListImpl *>(this)).dump();
 }
-#endif
 
 //===----------------------------------------------------------------------===//
 // AttributeList Construction and Mutation Methods
@@ -2101,9 +2097,7 @@ void AttributeList::print(raw_ostream &O) const {
   O << "]\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void AttributeList::dump() const { print(dbgs()); }
-#endif
 
 //===----------------------------------------------------------------------===//
 // AttrBuilder Method Implementations

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -1508,7 +1508,6 @@ bool AttributeListImpl::hasAttrSomewhere(Attribute::AttrKind Kind,
   return true;
 }
 
-
 LLVM_DUMP_METHOD void AttributeListImpl::dump() const {
   AttributeList(const_cast<AttributeListImpl *>(this)).dump();
 }

--- a/llvm/lib/IR/ConstantFPRange.cpp
+++ b/llvm/lib/IR/ConstantFPRange.cpp
@@ -373,9 +373,7 @@ void ConstantFPRange::print(raw_ostream &OS) const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ConstantFPRange::dump() const { print(dbgs()); }
-#endif
 
 ConstantFPRange
 ConstantFPRange::intersectWith(const ConstantFPRange &CR) const {

--- a/llvm/lib/IR/ConstantRange.cpp
+++ b/llvm/lib/IR/ConstantRange.cpp
@@ -2285,9 +2285,7 @@ void ConstantRange::print(raw_ostream &OS) const {
     OS << "[" << Lower << "," << Upper << ")";
 }
 
-LLVM_DUMP_METHOD void ConstantRange::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void ConstantRange::dump() const { print(dbgs()); }
 
 ConstantRange llvm::getConstantRangeFromMetadata(const MDNode &Ranges) {
   const unsigned NumRanges = Ranges.getNumOperands() / 2;

--- a/llvm/lib/IR/ConstantRange.cpp
+++ b/llvm/lib/IR/ConstantRange.cpp
@@ -2285,11 +2285,9 @@ void ConstantRange::print(raw_ostream &OS) const {
     OS << "[" << Lower << "," << Upper << ")";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ConstantRange::dump() const {
   print(dbgs());
 }
-#endif
 
 ConstantRange llvm::getConstantRangeFromMetadata(const MDNode &Ranges) {
   const unsigned NumRanges = Ranges.getNumOperands() / 2;

--- a/llvm/lib/IR/ConstantRangeList.cpp
+++ b/llvm/lib/IR/ConstantRangeList.cpp
@@ -238,9 +238,7 @@ void ConstantRangeList::print(raw_ostream &OS) const {
   });
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ConstantRangeList::dump() const {
   print(dbgs());
   dbgs() << '\n';
 }
-#endif

--- a/llvm/lib/IR/DebugLoc.cpp
+++ b/llvm/lib/IR/DebugLoc.cpp
@@ -193,9 +193,7 @@ DebugLoc DebugLoc::getMergedLocation(DebugLoc LocA, DebugLoc LocB) {
   return DILocation::getMergedLocation(LocA, LocB);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void DebugLoc::dump() const { print(dbgs()); }
-#endif
 
 void DebugLoc::print(raw_ostream &OS) const {
   if (!Loc)

--- a/llvm/lib/IR/Pass.cpp
+++ b/llvm/lib/IR/Pass.cpp
@@ -141,12 +141,10 @@ void Pass::print(raw_ostream &OS, const Module *) const {
   OS << "Pass::print not implemented for pass: '" << getPassName() << "'!\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 // dump - call print(cerr);
 LLVM_DUMP_METHOD void Pass::dump() const {
   print(dbgs(), nullptr);
 }
-#endif
 
 #ifdef EXPENSIVE_CHECKS
 uint64_t Pass::structuralHash(Module &M) const {

--- a/llvm/lib/IR/Pass.cpp
+++ b/llvm/lib/IR/Pass.cpp
@@ -142,9 +142,7 @@ void Pass::print(raw_ostream &OS, const Module *) const {
 }
 
 // dump - call print(cerr);
-LLVM_DUMP_METHOD void Pass::dump() const {
-  print(dbgs(), nullptr);
-}
+LLVM_DUMP_METHOD void Pass::dump() const { print(dbgs(), nullptr); }
 
 #ifdef EXPENSIVE_CHECKS
 uint64_t Pass::structuralHash(Module &M) const {

--- a/llvm/lib/IR/ValueSymbolTable.cpp
+++ b/llvm/lib/IR/ValueSymbolTable.cpp
@@ -126,7 +126,6 @@ ValueName *ValueSymbolTable::createValueName(StringRef Name, Value *V) {
   return makeUniqueName(V, UniqueName);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 // dump - print out the symbol table
 //
 LLVM_DUMP_METHOD void ValueSymbolTable::dump() const {
@@ -137,4 +136,3 @@ LLVM_DUMP_METHOD void ValueSymbolTable::dump() const {
     // dbgs() << "\n";
   }
 }
-#endif

--- a/llvm/lib/MC/MCAsmMacro.cpp
+++ b/llvm/lib/MC/MCAsmMacro.cpp
@@ -11,7 +11,6 @@
 
 using namespace llvm;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void MCAsmMacroParameter::dump(raw_ostream &OS) const {
   OS << "\"" << Name << "\"";
   if (Required)
@@ -45,4 +44,3 @@ void MCAsmMacro::dump(raw_ostream &OS) const {
   }
   OS << "  (BEGIN BODY)" << Body << "(END BODY)\n";
 }
-#endif

--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -1056,7 +1056,6 @@ void MCAssembler::flushPendingErrors() const {
   PendingErrors.clear();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MCAssembler::dump() const{
   raw_ostream &OS = errs();
   DenseMap<const MCFragment *, SmallVector<const MCSymbol *, 0>> FragToSyms;
@@ -1075,7 +1074,6 @@ LLVM_DUMP_METHOD void MCAssembler::dump() const{
   }
   OS << "\n]\n";
 }
-#endif
 
 SMLoc MCFixup::getLoc() const {
   if (auto *E = getValue())

--- a/llvm/lib/MC/MCExpr.cpp
+++ b/llvm/lib/MC/MCExpr.cpp
@@ -189,12 +189,10 @@ void MCExpr::print(raw_ostream &OS, const MCAsmInfo *MAI,
   llvm_unreachable("Invalid expression kind!");
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MCExpr::dump() const {
   print(dbgs(), nullptr);
   dbgs() << '\n';
 }
-#endif
 
 /* *** */
 

--- a/llvm/lib/MC/MCFragment.cpp
+++ b/llvm/lib/MC/MCFragment.cpp
@@ -38,7 +38,6 @@ const MCSymbol *MCFragment::getAtom() const {
   return static_cast<const MCSectionMachO *>(Parent)->getAtom(LayoutOrder);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MCFragment::dump() const {
   raw_ostream &OS = errs();
 
@@ -192,4 +191,3 @@ LLVM_DUMP_METHOD void MCFragment::dump() const {
   }
   }
 }
-#endif

--- a/llvm/lib/MC/MCInst.cpp
+++ b/llvm/lib/MC/MCInst.cpp
@@ -71,12 +71,10 @@ bool MCOperand::isBareSymbolRef() const {
          cast<MCSymbolRefExpr>(Expr)->getSpecifier() == 0;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MCOperand::dump() const {
   print(dbgs());
   dbgs() << "\n";
 }
-#endif
 
 void MCInst::print(raw_ostream &OS, const MCContext *Ctx) const {
   OS << "<MCInst " << getOpcode();
@@ -108,9 +106,7 @@ void MCInst::dump_pretty(raw_ostream &OS, StringRef Name, StringRef Separator,
   OS << ">";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MCInst::dump() const {
   print(dbgs());
   dbgs() << "\n";
 }
-#endif

--- a/llvm/lib/MC/MCLabel.cpp
+++ b/llvm/lib/MC/MCLabel.cpp
@@ -18,6 +18,4 @@ void MCLabel::print(raw_ostream &OS) const {
   OS << '"' << getInstance() << '"';
 }
 
-LLVM_DUMP_METHOD void MCLabel::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void MCLabel::dump() const { print(dbgs()); }

--- a/llvm/lib/MC/MCLabel.cpp
+++ b/llvm/lib/MC/MCLabel.cpp
@@ -18,8 +18,6 @@ void MCLabel::print(raw_ostream &OS) const {
   OS << '"' << getInstance() << '"';
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MCLabel::dump() const {
   print(dbgs());
 }
-#endif

--- a/llvm/lib/MC/MCParser/MCAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/MCAsmParser.cpp
@@ -174,8 +174,6 @@ bool MCAsmParser::parseSymbol(MCSymbol *&Res) {
 
 void MCParsedAsmOperand::dump() const {
   // Cannot completely remove virtual function even in release mode.
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   dbgs() << "  ";
   print(dbgs(), MCAsmInfo());
-#endif
 }

--- a/llvm/lib/MC/MCSection.cpp
+++ b/llvm/lib/MC/MCSection.cpp
@@ -42,7 +42,6 @@ Align MCSection::getAlignmentForObjectFile(uint64_t Size) const {
 
 bool MCSection::hasEnded() const { return End && End->isInSection(); }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MCSection::dump(
     DenseMap<const MCFragment *, SmallVector<const MCSymbol *, 0>> *FragToSyms)
     const {
@@ -66,7 +65,6 @@ LLVM_DUMP_METHOD void MCSection::dump(
     }
   }
 }
-#endif
 
 void MCFragment::setVarContents(ArrayRef<char> Contents) {
   auto &S = getParent()->ContentStorage;

--- a/llvm/lib/MC/MCSymbol.cpp
+++ b/llvm/lib/MC/MCSymbol.cpp
@@ -83,9 +83,7 @@ void MCSymbol::print(raw_ostream &OS, const MCAsmInfo *MAI) const {
   OS << '"';
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MCSymbol::dump() const { dbgs() << *this; }
-#endif
 
 // Determine whether the offset between two labels can change at link time.
 // Currently, this function is used only in DWARF info emission logic, where it

--- a/llvm/lib/MC/MCValue.cpp
+++ b/llvm/lib/MC/MCValue.cpp
@@ -37,6 +37,4 @@ void MCValue::print(raw_ostream &OS) const {
     OS << " + " << getConstant();
 }
 
-LLVM_DUMP_METHOD void MCValue::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void MCValue::dump() const { print(dbgs()); }

--- a/llvm/lib/MC/MCValue.cpp
+++ b/llvm/lib/MC/MCValue.cpp
@@ -37,8 +37,6 @@ void MCValue::print(raw_ostream &OS) const {
     OS << " + " << getConstant();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MCValue::dump() const {
   print(dbgs());
 }
-#endif

--- a/llvm/lib/MC/WasmObjectWriter.cpp
+++ b/llvm/lib/MC/WasmObjectWriter.cpp
@@ -109,9 +109,7 @@ struct WasmRelocationEntry {
         << ", FixupSection=" << FixupSection->getName();
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const { print(dbgs()); }
-#endif
 };
 
 static const uint32_t InvalidIndex = -1;

--- a/llvm/lib/Object/WasmObjectFile.cpp
+++ b/llvm/lib/Object/WasmObjectFile.cpp
@@ -67,9 +67,7 @@ void WasmSymbol::print(raw_ostream &Out) const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void WasmSymbol::dump() const { print(dbgs()); }
-#endif
 
 Expected<std::unique_ptr<WasmObjectFile>>
 ObjectFile::createWasmObjectFile(MemoryBufferRef Buffer) {

--- a/llvm/lib/Option/Arg.cpp
+++ b/llvm/lib/Option/Arg.cpp
@@ -60,9 +60,7 @@ void Arg::print(raw_ostream& O) const {
   O << "]>\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void Arg::dump() const { print(dbgs()); }
-#endif
 
 std::string Arg::getAsString(const ArgList &Args) const {
   if (Alias)

--- a/llvm/lib/Option/ArgList.cpp
+++ b/llvm/lib/Option/ArgList.cpp
@@ -199,9 +199,7 @@ void ArgList::print(raw_ostream &O) const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ArgList::dump() const { print(dbgs()); }
-#endif
 
 StringRef ArgList::getSubCommand(
     ArrayRef<OptTable::SubCommand> AllSubCommands,

--- a/llvm/lib/Option/Option.cpp
+++ b/llvm/lib/Option/Option.cpp
@@ -89,9 +89,7 @@ void Option::print(raw_ostream &O, bool AddNewLine) const {
     O << "\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void Option::dump() const { print(dbgs()); }
-#endif
 
 bool Option::matches(OptSpecifier Opt) const {
   // Aliases are never considered in matching, look through them.

--- a/llvm/lib/ProfileData/GCOV.cpp
+++ b/llvm/lib/ProfileData/GCOV.cpp
@@ -309,10 +309,8 @@ void GCOVFile::print(raw_ostream &OS) const {
     f.print(OS);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// dump - Dump GCOVFile content to dbgs() for debugging purposes.
 LLVM_DUMP_METHOD void GCOVFile::dump() const { print(dbgs()); }
-#endif
 
 unsigned GCOVFile::addNormalizedPathToMap(StringRef filename) {
   // unify filename, as the same path can have different form
@@ -428,10 +426,8 @@ void GCOVFunction::print(raw_ostream &OS) const {
     Block->print(OS);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// dump - Dump GCOVFunction content to dbgs() for debugging purposes.
 LLVM_DUMP_METHOD void GCOVFunction::dump() const { print(dbgs()); }
-#endif
 
 /// collectLineCounts - Collect line counts. This must be used after
 /// reading .gcno and .gcda files.
@@ -466,10 +462,8 @@ void GCOVBlock::print(raw_ostream &OS) const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// dump - Dump GCOVBlock content to dbgs() for debugging purposes.
 LLVM_DUMP_METHOD void GCOVBlock::dump() const { print(dbgs()); }
-#endif
 
 uint64_t
 GCOVBlock::augmentOneCycle(GCOVBlock *src,

--- a/llvm/lib/ProfileData/SampleProf.cpp
+++ b/llvm/lib/ProfileData/SampleProf.cpp
@@ -168,9 +168,7 @@ std::error_code SampleRecord::serialize(
   return sampleprof_error::success;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void LineLocation::dump() const { print(dbgs()); }
-#endif
 
 void LineLocation::serialize(raw_ostream &OS) const {
   encodeULEB128(LineOffset, OS);
@@ -188,9 +186,7 @@ void SampleRecord::print(raw_ostream &OS, unsigned Indent) const {
   OS << "\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SampleRecord::dump() const { print(dbgs(), 0); }
-#endif
 
 raw_ostream &llvm::sampleprof::operator<<(raw_ostream &OS,
                                           const SampleRecord &Sample) {
@@ -394,9 +390,7 @@ const FunctionSamples *FunctionSamples::findFunctionSamplesAt(
   return R;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void FunctionSamples::dump() const { print(dbgs(), 0); }
-#endif
 
 std::error_code ProfileSymbolList::read(const uint8_t *Data,
                                         uint64_t ListSize) {

--- a/llvm/lib/Support/APFixedPoint.cpp
+++ b/llvm/lib/Support/APFixedPoint.cpp
@@ -444,9 +444,7 @@ void APFixedPoint::print(raw_ostream &OS) const {
   OS << "})";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void APFixedPoint::dump() const { print(llvm::errs()); }
-#endif
 
 APFixedPoint APFixedPoint::negate(bool *Overflow) const {
   if (!isSaturated()) {

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -6008,12 +6008,10 @@ void APFloat::print(raw_ostream &OS) const {
   OS << Buffer;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void APFloat::dump() const {
   print(dbgs());
   dbgs() << '\n';
 }
-#endif
 
 void APFloat::Profile(FoldingSetNodeID &NID) const {
   NID.Add(bitcastToAPInt());

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -2305,7 +2305,6 @@ void APInt::toString(SmallVectorImpl<char> &Str, unsigned Radix, bool Signed,
   std::reverse(Str.begin()+StartDig, Str.end());
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void APInt::dump() const {
   SmallString<40> S, U;
   this->toStringUnsigned(U);
@@ -2313,7 +2312,6 @@ LLVM_DUMP_METHOD void APInt::dump() const {
   dbgs() << "APInt(" << BitWidth << "b, "
          << U << "u " << S << "s)\n";
 }
-#endif
 
 void APInt::print(raw_ostream &OS, bool isSigned) const {
   SmallString<40> S;

--- a/llvm/lib/Support/BranchProbability.cpp
+++ b/llvm/lib/Support/BranchProbability.cpp
@@ -31,9 +31,7 @@ raw_ostream &BranchProbability::print(raw_ostream &OS) const {
                       Percent);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void BranchProbability::dump() const { print(dbgs()) << '\n'; }
-#endif
 
 BranchProbability::BranchProbability(uint32_t Numerator, uint32_t Denominator) {
   assert(Denominator > 0 && "Denominator cannot be 0!");

--- a/llvm/lib/Support/DebugCounter.cpp
+++ b/llvm/lib/Support/DebugCounter.cpp
@@ -193,6 +193,4 @@ bool DebugCounter::shouldExecuteImpl(CounterInfo &Counter) {
   return Res;
 }
 
-LLVM_DUMP_METHOD void DebugCounter::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void DebugCounter::dump() const { print(dbgs()); }

--- a/llvm/lib/Support/DebugCounter.cpp
+++ b/llvm/lib/Support/DebugCounter.cpp
@@ -193,8 +193,6 @@ bool DebugCounter::shouldExecuteImpl(CounterInfo &Counter) {
   return Res;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void DebugCounter::dump() const {
   print(dbgs());
 }
-#endif

--- a/llvm/lib/Support/DynamicAPInt.cpp
+++ b/llvm/lib/Support/DynamicAPInt.cpp
@@ -32,6 +32,4 @@ raw_ostream &DynamicAPInt::print(raw_ostream &OS) const {
   return OS << ValLarge;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void DynamicAPInt::dump() const { print(dbgs()); }
-#endif

--- a/llvm/lib/Support/JSON.cpp
+++ b/llvm/lib/Support/JSON.cpp
@@ -175,12 +175,10 @@ void Value::destroy() {
 
 void Value::print(llvm::raw_ostream &OS) const { OS << *this; }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void Value::dump() const {
   print(llvm::dbgs());
   llvm::dbgs() << '\n';
 }
-#endif
 
 bool operator==(const Value &L, const Value &R) {
   if (L.kind() != R.kind())

--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -1344,9 +1344,7 @@ void KnownBits::print(raw_ostream &OS) const {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void KnownBits::dump() const {
   print(dbgs());
   dbgs() << "\n";
 }
-#endif

--- a/llvm/lib/Support/SlowDynamicAPInt.cpp
+++ b/llvm/lib/Support/SlowDynamicAPInt.cpp
@@ -283,6 +283,4 @@ SlowDynamicAPInt &SlowDynamicAPInt::operator--() {
 /// ---------------------------------------------------------------------------
 void SlowDynamicAPInt::print(raw_ostream &OS) const { OS << Val; }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SlowDynamicAPInt::dump() const { print(dbgs()); }
-#endif

--- a/llvm/lib/Support/Twine.cpp
+++ b/llvm/lib/Support/Twine.cpp
@@ -174,8 +174,6 @@ void Twine::printRepr(raw_ostream &OS) const {
   OS << ")";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void Twine::dump() const { print(dbgs()); }
 
 LLVM_DUMP_METHOD void Twine::dumpRepr() const { printRepr(dbgs()); }
-#endif

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -162,9 +162,7 @@ llvm::ErrorOr<bool> FileSystem::equivalent(const Twine &A, const Twine &B) {
   return StatusA->equivalent(*StatusB);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void FileSystem::dump() const { print(dbgs(), PrintType::RecursiveContents); }
-#endif
 
 #ifndef NDEBUG
 static bool isTraversalComponent(StringRef Component) {

--- a/llvm/lib/Support/Z3Solver.cpp
+++ b/llvm/lib/Support/Z3Solver.cpp
@@ -990,9 +990,7 @@ llvm::SMTSolverRef llvm::CreateZ3Solver() {
 #endif
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SMTSort::dump() const { print(llvm::errs()); }
 LLVM_DUMP_METHOD void SMTExpr::dump() const { print(llvm::errs()); }
 LLVM_DUMP_METHOD void SMTSolver::dump() const { print(llvm::errs()); }
 LLVM_DUMP_METHOD void SMTSolverStatistics::dump() const { print(llvm::errs()); }
-#endif

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -131,9 +131,7 @@ void detail::RecordKeeperImpl::dumpAllocationStats(raw_ostream &OS) const {
 //    Type implementations
 //===----------------------------------------------------------------------===//
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RecTy::dump() const { print(errs()); }
-#endif
 
 const ListRecTy *RecTy::getListTy() const {
   if (!ListTy)
@@ -374,9 +372,7 @@ const RecTy *llvm::resolveTypes(const RecTy *T1, const RecTy *T2) {
 
 void Init::anchor() {}
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void Init::dump() const { return print(errs()); }
-#endif
 
 RecordKeeper &Init::getRecordKeeper() const {
   if (auto *TyInit = dyn_cast<TypedInit>(this))
@@ -2915,9 +2911,7 @@ bool RecordVal::setValue(const Init *V, SMLoc NewLoc) {
   return setValue(V);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RecordVal::dump() const { errs() << *this; }
-#endif
 
 void RecordVal::print(raw_ostream &OS, bool PrintSem) const {
   if (isNonconcreteOK()) OS << "field ";
@@ -3030,9 +3024,7 @@ void Record::resolveReferences(const Init *NewName) {
   resolveReferences(R);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void Record::dump() const { errs() << *this; }
-#endif
 
 raw_ostream &llvm::operator<<(raw_ostream &OS, const Record &R) {
   OS << R.getNameInitAsString();
@@ -3278,9 +3270,7 @@ RecordKeeper::RecordKeeper()
 
 RecordKeeper::~RecordKeeper() = default;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RecordKeeper::dump() const { errs() << *this; }
-#endif
 
 raw_ostream &llvm::operator<<(raw_ostream &OS, const RecordKeeper &RK) {
   OS << "------------- Classes -----------------\n";

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -62,7 +62,6 @@ struct SubMultiClassReference {
 };
 } // end namespace llvm
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SubMultiClassReference::dump() const {
   errs() << "Multiclass:\n";
 
@@ -72,7 +71,6 @@ LLVM_DUMP_METHOD void SubMultiClassReference::dump() const {
   for (const Init *TA : TemplateArgs)
     TA->dump();
 }
-#endif
 
 static bool checkBitsConcrete(Record &R, const RecordVal &RV) {
   const auto *BV = cast<BitsInit>(RV.getValue());
@@ -4612,7 +4610,6 @@ bool TGParser::CheckTemplateArgValues(
   return HasError;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void RecordsEntry::dump() const {
   if (Loop)
     Loop->dump();
@@ -4638,7 +4635,6 @@ LLVM_DUMP_METHOD void MultiClass::dump() const {
   for (const auto &E : Entries)
     E.dump();
 }
-#endif
 
 bool TGParser::ParseDump(MultiClass *CurMultiClass, Record *CurRec) {
   // Location of the `dump` statement.

--- a/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
@@ -202,7 +202,6 @@ public:
       return Erase;
     }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     void dump() const {
       if (VALUCycles)
         dbgs() << " VALUCycles=" << (int)VALUCycles;
@@ -217,7 +216,6 @@ public:
       if (SALUCycles)
         dbgs() << " SALUCycles=" << (int)SALUCycles;
     }
-#endif
   };
 
   // A map from regunits to the delay info for that regunit.
@@ -255,7 +253,6 @@ public:
       }
     }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     void dump(const TargetRegisterInfo *TRI) const {
       if (empty()) {
         dbgs() << "    empty\n";
@@ -276,7 +273,6 @@ public:
         dbgs() << "\n";
       }
     }
-#endif
   };
 
   // The saved delay state at the end of each basic block.

--- a/llvm/lib/Target/AMDGPU/AMDGPUPerfHintAnalysis.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPerfHintAnalysis.cpp
@@ -75,14 +75,12 @@ private:
     int64_t Offset = 0;
     MemAccessInfo() = default;
     bool isLargeStride(MemAccessInfo &Reference) const;
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     Printable print() const {
       return Printable([this](raw_ostream &OS) {
         OS << "Value: " << *V << '\n'
            << "Base: " << *Base << " Offset: " << Offset << '\n';
       });
     }
-#endif
   };
 
   MemAccessInfo makeMemAccessInfo(Instruction *) const;

--- a/llvm/lib/Target/AMDGPU/GCNIterativeScheduler.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNIterativeScheduler.cpp
@@ -40,7 +40,6 @@ static inline MachineInstr *getMachineInstr(const SUnit &SU) {
   return SU.getInstr();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD
 static void printRegion(raw_ostream &OS,
                         MachineBasicBlock::iterator Begin,
@@ -117,7 +116,6 @@ void GCNIterativeScheduler::printSchedRP(raw_ostream &OS,
   OS << "RP before: " << print(Before, &ST)
      << "RP after:  " << print(After, &ST);
 }
-#endif
 
 void GCNIterativeScheduler::swapIGLPMutations(const Region &R, bool IsReentry) {
   bool HasIGLPInstrs = false;

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -996,7 +996,6 @@ bool GCNRegPressurePrinter::runOnMachineFunction(MachineFunction &MF) {
 #undef PFX
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void llvm::dumpMaxRegPressure(MachineFunction &MF,
                                                GCNRegPressure::RegKind Kind,
                                                LiveIntervals &LIS,
@@ -1119,4 +1118,3 @@ LLVM_DUMP_METHOD void llvm::dumpMaxRegPressure(MachineFunction &MF,
     PrintRegInfo(Reg, LiveSet->lookup(Reg));
   }
 }
-#endif

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -264,7 +264,6 @@ public:
     return UnifiedRF ? MaxUnifiedVGPRs : MaxVGPRs;
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   friend raw_ostream &operator<<(raw_ostream &OS, const GCNRPTarget &Target) {
     OS << "Actual/Target: " << Target.RP.getSGPRNum() << '/' << Target.MaxSGPRs
        << " SGPRs, " << Target.RP.getArchVGPRNum() << '/' << Target.MaxVGPRs
@@ -277,7 +276,6 @@ public:
     }
     return OS;
   }
-#endif
 
 private:
   const MachineFunction &MF;

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -84,7 +84,6 @@ static cl::opt<unsigned> PendingQueueLimit(
         "Max (Available+Pending) size to inspect pending queue (0 disables)"),
     cl::init(256));
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 #define DUMP_MAX_REG_PRESSURE
 static cl::opt<bool> PrintMaxRPRegUsageBeforeScheduler(
     "amdgpu-print-max-reg-pressure-regusage-before-scheduler", cl::Hidden,
@@ -97,7 +96,6 @@ static cl::opt<bool> PrintMaxRPRegUsageAfterScheduler(
     cl::desc("Print a list of live registers along with their def/uses at the "
              "point of maximum register pressure after scheduling."),
     cl::init(false));
-#endif
 
 static cl::opt<bool> DisableRewriteMFMAFormSchedStage(
     "amdgpu-disable-rewrite-mfma-form-sched-stage", cl::Hidden,
@@ -1396,13 +1394,11 @@ bool ClusteredLowOccStage::initGCNSchedStage() {
 #define REMAT_PREFIX "[PreRARemat] "
 #define REMAT_DEBUG(X) LLVM_DEBUG(dbgs() << REMAT_PREFIX; X;)
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 Printable PreRARematStage::ScoredRemat::print() const {
   return Printable([&](raw_ostream &OS) {
     OS << '(' << MaxFreq << ", " << FreqDiff << ", " << RegionImpact << ')';
   });
 }
-#endif
 
 bool PreRARematStage::initGCNSchedStage() {
   // FIXME: This pass will invalidate cached BBLiveInMap and MBBLiveIns for

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -626,9 +626,7 @@ private:
       return Remat > O.Remat;
     }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     Printable print() const;
-#endif
 
   private:
     /// Number of 32-bit registers this rematerialization covers.

--- a/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
@@ -109,7 +109,7 @@ public:
   SetVector<unsigned> Siblings;
   V2SCopyInfo() : Copy(nullptr), ID(0){};
   V2SCopyInfo(unsigned Id, MachineInstr *C, unsigned Width)
-      : Copy(C), NumReadfirstlanes(Width / 32), ID(Id){};
+      : Copy(C), NumReadfirstlanes(Width / 32), ID(Id) {};
   void dump() const {
     dbgs() << ID << " : " << *Copy << "\n\tS:" << SChain.size()
            << "\n\tSV:" << NumSVCopies << "\n\tSP: " << SiblingPenalty

--- a/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.cpp
@@ -110,13 +110,11 @@ public:
   V2SCopyInfo() : Copy(nullptr), ID(0){};
   V2SCopyInfo(unsigned Id, MachineInstr *C, unsigned Width)
       : Copy(C), NumReadfirstlanes(Width / 32), ID(Id){};
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const {
     dbgs() << ID << " : " << *Copy << "\n\tS:" << SChain.size()
            << "\n\tSV:" << NumSVCopies << "\n\tSP: " << SiblingPenalty
            << "\nScore: " << Score << "\n";
   }
-#endif
 };
 
 class SIFixSGPRCopies {

--- a/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
@@ -154,7 +154,7 @@ public:
   uint64_t getSrcMods(const SIInstrInfo *TII,
                       const MachineOperand *SrcOp) const;
 
-  void print(raw_ostream& OS) const override;
+  void print(raw_ostream &OS) const override;
 };
 
 class SDWADstOperand : public SDWAOperand {
@@ -177,7 +177,7 @@ public:
   SdwaSel getDstSel() const { return DstSel; }
   DstUnused getDstUnused() const { return DstUn; }
 
-  void print(raw_ostream& OS) const override;
+  void print(raw_ostream &OS) const override;
 };
 
 class SDWADstPreserveOperand : public SDWADstOperand {
@@ -196,7 +196,7 @@ public:
 
   MachineOperand *getPreservedOperand() const { return Preserve; }
 
-  void print(raw_ostream& OS) const override;
+  void print(raw_ostream &OS) const override;
 };
 
 } // end anonymous namespace
@@ -255,7 +255,6 @@ void SDWADstPreserveOperand::print(raw_ostream& OS) const {
     << " dst_sel:" << getDstSel()
     << " preserve:" << *getPreservedOperand() << '\n';
 }
-
 
 static void copyRegOperand(MachineOperand &To, const MachineOperand &From) {
   assert(To.isReg() && From.isReg());

--- a/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
@@ -121,10 +121,8 @@ public:
     return &getParentInst()->getMF()->getRegInfo();
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   virtual void print(raw_ostream& OS) const = 0;
   void dump() const { print(dbgs()); }
-#endif
 };
 
 class SDWASrcOperand : public SDWAOperand {
@@ -156,9 +154,7 @@ public:
   uint64_t getSrcMods(const SIInstrInfo *TII,
                       const MachineOperand *SrcOp) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void print(raw_ostream& OS) const override;
-#endif
 };
 
 class SDWADstOperand : public SDWAOperand {
@@ -181,9 +177,7 @@ public:
   SdwaSel getDstSel() const { return DstSel; }
   DstUnused getDstUnused() const { return DstUn; }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void print(raw_ostream& OS) const override;
-#endif
 };
 
 class SDWADstPreserveOperand : public SDWADstOperand {
@@ -202,9 +196,7 @@ public:
 
   MachineOperand *getPreservedOperand() const { return Preserve; }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void print(raw_ostream& OS) const override;
-#endif
 };
 
 } // end anonymous namespace
@@ -220,7 +212,6 @@ FunctionPass *llvm::createSIPeepholeSDWALegacyPass() {
   return new SIPeepholeSDWALegacy();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 static raw_ostream& operator<<(raw_ostream &OS, SdwaSel Sel) {
   switch(Sel) {
   case BYTE_0: OS << "BYTE_0"; break;
@@ -265,7 +256,6 @@ void SDWADstPreserveOperand::print(raw_ostream& OS) const {
     << " preserve:" << *getPreservedOperand() << '\n';
 }
 
-#endif
 
 static void copyRegOperand(MachineOperand &To, const MachineOperand &From) {
   assert(To.isReg() && From.isReg());

--- a/llvm/lib/Target/ARC/ARCOptAddrMode.cpp
+++ b/llvm/lib/Target/ARC/ARCOptAddrMode.cpp
@@ -498,10 +498,8 @@ bool ARCOptAddrMode::runOnMachineFunction(MachineFunction &MF) {
   if (skipFunction(MF.getFunction()) || KILL_PASS())
     return false;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   if (DUMP_BEFORE())
     MF.dump();
-#endif
   if (VIEW_BEFORE())
     MF.viewCFG();
 
@@ -514,10 +512,8 @@ bool ARCOptAddrMode::runOnMachineFunction(MachineFunction &MF) {
   for (auto &MBB : MF)
     Changed |= processBasicBlock(MBB);
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   if (DUMP_AFTER())
     MF.dump();
-#endif
   if (VIEW_AFTER())
     MF.viewCFG();
   return Changed;

--- a/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
+++ b/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
@@ -319,7 +319,6 @@ void ARMConstantIslands::verify() {
 #endif
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// print block size and offset information - debugging
 LLVM_DUMP_METHOD void ARMConstantIslands::dumpBBs() {
   LLVM_DEBUG({
@@ -333,7 +332,6 @@ LLVM_DUMP_METHOD void ARMConstantIslands::dumpBBs() {
     }
   });
 }
-#endif
 
 // Align blocks where the previous block does not fall through. This may add
 // extra NOP's but they will not be executed. It uses the PrefLoopAlignment as a

--- a/llvm/lib/Target/ARM/ARMConstantPoolValue.cpp
+++ b/llvm/lib/Target/ARM/ARMConstantPoolValue.cpp
@@ -98,11 +98,9 @@ ARMConstantPoolValue::hasSameValue(ARMConstantPoolValue *ACPV) {
   return false;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ARMConstantPoolValue::dump() const {
   errs() << "  " << *this;
 }
-#endif
 
 void ARMConstantPoolValue::print(raw_ostream &O) const {
   if (Modifier) O << "(" << getModifierText() << ")";

--- a/llvm/lib/Target/ARM/ARMFrameLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMFrameLowering.cpp
@@ -738,13 +738,11 @@ struct StackAdjustingInsts {
     unsigned SPAdjust;
     bool BeforeFPSet;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     void dump() {
       dbgs() << "  " << (BeforeFPSet ? "before-fp " : "          ")
              << "sp-adjust=" << SPAdjust;
       I->dump();
     }
-#endif
   };
 
   SmallVector<InstInfo, 4> Insts;
@@ -775,13 +773,11 @@ struct StackAdjustingInsts {
     }
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() {
     dbgs() << "StackAdjustingInsts:\n";
     for (auto &Info : Insts)
       Info.dump();
   }
-#endif
 };
 
 } // end anonymous namespace

--- a/llvm/lib/Target/CSKY/CSKYConstantIslandPass.cpp
+++ b/llvm/lib/Target/CSKY/CSKYConstantIslandPass.cpp
@@ -266,7 +266,6 @@ bool CSKYConstantIslands::isOffsetInRange(unsigned UserOffset,
   return isOffsetInRange(UserOffset, TrialOffset, U.getMaxDisp(), U.NegOk);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// print block size and offset information - debugging
 LLVM_DUMP_METHOD void CSKYConstantIslands::dumpBBs() {
   for (unsigned J = 0, E = BBInfo.size(); J != E; ++J) {
@@ -275,7 +274,6 @@ LLVM_DUMP_METHOD void CSKYConstantIslands::dumpBBs() {
            << format(" size=%#x\n", BBInfo[J].Size);
   }
 }
-#endif
 
 bool CSKYConstantIslands::runOnMachineFunction(MachineFunction &Mf) {
   MF = &Mf;

--- a/llvm/lib/Target/DirectX/DXILWriter/DXILValueEnumerator.cpp
+++ b/llvm/lib/Target/DirectX/DXILWriter/DXILValueEnumerator.cpp
@@ -527,14 +527,12 @@ unsigned ValueEnumerator::getValueID(const Value *V) const {
   return I->second - 1;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ValueEnumerator::dump() const {
   print(dbgs(), ValueMap, "Default");
   dbgs() << '\n';
   print(dbgs(), MetadataMap, "MetaData");
   dbgs() << '\n';
 }
-#endif
 
 void ValueEnumerator::print(raw_ostream &OS, const ValueMapType &Map,
                             const char *Name) const {

--- a/llvm/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp
@@ -267,7 +267,6 @@ bool Coloring::color() {
   return true;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void Coloring::dump() const {
   dbgs() << "{ Order:   {";
   for (Node P : Order) {
@@ -308,7 +307,6 @@ void Coloring::dump() const {
     dbgs() << "    " << C.first << " -> " << ColorKindToName(C.second) << "\n";
   dbgs() << "  }\n}\n";
 }
-#endif
 
 namespace {
 // Base class of for reordering networks. They don't strictly need to be
@@ -706,7 +704,6 @@ struct ResultStack {
 };
 } // namespace
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void OpRef::print(raw_ostream &OS, const SelectionDAG &G) const {
   if (isValue()) {
     OpV.getNode()->print(OS, &G);
@@ -756,7 +753,6 @@ void ResultStack::print(raw_ostream &OS, const SelectionDAG &G) const {
     OS << '\n';
   }
 }
-#endif
 
 namespace {
 struct ShuffleMask {

--- a/llvm/lib/Target/Hexagon/HexagonSplitDouble.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonSplitDouble.cpp
@@ -126,7 +126,6 @@ const TargetRegisterClass *const HexagonSplitDoubleRegs::DoubleRC =
 INITIALIZE_PASS(HexagonSplitDoubleRegs, "hexagon-split-double",
   "Hexagon Split Double Registers", false, false)
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void HexagonSplitDoubleRegs::dump_partition(raw_ostream &os,
       const USet &Part, const TargetRegisterInfo &TRI) {
   dbgs() << '{';
@@ -134,7 +133,6 @@ LLVM_DUMP_METHOD void HexagonSplitDoubleRegs::dump_partition(raw_ostream &os,
     dbgs() << ' ' << printReg(I, &TRI);
   dbgs() << " }";
 }
-#endif
 
 bool HexagonSplitDoubleRegs::isInduction(unsigned Reg, LoopRegMap &IRM) const {
   for (auto I : IRM) {

--- a/llvm/lib/Target/M68k/M68kISelDAGToDAG.cpp
+++ b/llvm/lib/Target/M68k/M68kISelDAGToDAG.cpp
@@ -147,7 +147,6 @@ struct M68kISelAddressMode {
 
   void setIndexReg(SDValue Reg) { IndexReg = Reg; }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() {
     dbgs() << "M68kISelAddressMode " << this;
     dbgs() << "\nDisp: " << Disp;
@@ -166,7 +165,6 @@ struct M68kISelAddressMode {
     }
     dbgs() << '\n';
   }
-#endif
 };
 } // end anonymous namespace
 

--- a/llvm/lib/Target/MSP430/MSP430ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/MSP430/MSP430ISelDAGToDAG.cpp
@@ -54,7 +54,6 @@ namespace {
       return GV != nullptr || CP != nullptr || ES != nullptr || JT != -1;
     }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     LLVM_DUMP_METHOD void dump() {
       errs() << "MSP430ISelAddressMode " << this << '\n';
       if (BaseType == RegBase && Base.Reg.getNode() != nullptr) {
@@ -77,7 +76,6 @@ namespace {
       } else if (JT != -1)
         errs() << " JT" << JT << " Align" << Alignment.value() << '\n';
     }
-#endif
   };
 }
 

--- a/llvm/lib/Target/Mips/MipsConstantIslandPass.cpp
+++ b/llvm/lib/Target/Mips/MipsConstantIslandPass.cpp
@@ -417,7 +417,6 @@ bool MipsConstantIslands::isOffsetInRange
                          U.getMaxDisp(), U.NegOk);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// print block size and offset information - debugging
 LLVM_DUMP_METHOD void MipsConstantIslands::dumpBBs() {
   for (unsigned J = 0, E = BBInfo.size(); J !=E; ++J) {
@@ -426,7 +425,6 @@ LLVM_DUMP_METHOD void MipsConstantIslands::dumpBBs() {
            << format(" size=%#x\n", BBInfo[J].Size);
   }
 }
-#endif
 
 bool MipsConstantIslands::runOnMachineFunction(MachineFunction &mf) {
   // The intention is for this to be a mips16 only pass for now

--- a/llvm/lib/Target/PowerPC/PPCReduceCRLogicals.cpp
+++ b/llvm/lib/Target/PowerPC/PPCReduceCRLogicals.cpp
@@ -439,7 +439,6 @@ public:
 };
 } // end anonymous namespace
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void PPCReduceCRLogicals::CRLogicalOpInfo::dump() {
   dbgs() << "CRLogicalOpMI: ";
   MI->dump();
@@ -465,7 +464,6 @@ LLVM_DUMP_METHOD void PPCReduceCRLogicals::CRLogicalOpInfo::dump() {
     CopyDefs.second->dump();
   }
 }
-#endif
 
 PPCReduceCRLogicals::CRLogicalOpInfo
 PPCReduceCRLogicals::createCRLogicalOpInfo(MachineInstr &MIParam) {

--- a/llvm/lib/Target/PowerPC/PPCVSXSwapRemoval.cpp
+++ b/llvm/lib/Target/PowerPC/PPCVSXSwapRemoval.cpp
@@ -987,7 +987,6 @@ bool PPCVSXSwapRemoval::removeSwaps() {
   return Changed;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 // For debug purposes, dump the contents of the swap vector.
 LLVM_DUMP_METHOD void PPCVSXSwapRemoval::dumpSwapVector() {
 
@@ -1058,7 +1057,6 @@ LLVM_DUMP_METHOD void PPCVSXSwapRemoval::dumpSwapVector() {
 
   dbgs() << "\n";
 }
-#endif
 
 INITIALIZE_PASS_BEGIN(PPCVSXSwapRemoval, DEBUG_TYPE,
                       "PowerPC VSX Swap Removal", false, false)

--- a/llvm/lib/Target/RISCV/RISCVInsertWriteVXRM.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertWriteVXRM.cpp
@@ -138,7 +138,6 @@ public:
     return VXRMInfo::getUnknown();
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Support for debugging, callable in GDB: V->dump()
   LLVM_DUMP_METHOD void dump() const {
     print(dbgs());
@@ -155,16 +154,13 @@ public:
       OS << getVXRMImm();
     OS << '}';
   }
-#endif
 };
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_ATTRIBUTE_USED
 inline raw_ostream &operator<<(raw_ostream &OS, const VXRMInfo &V) {
   V.print(OS);
   return OS;
 }
-#endif
 
 struct BlockData {
   // Indicates if the block uses VXRM. Uninitialized means no use.

--- a/llvm/lib/Target/RISCV/RISCVVSETVLIInfoAnalysis.h
+++ b/llvm/lib/Target/RISCV/RISCVVSETVLIInfoAnalysis.h
@@ -100,7 +100,6 @@ struct DemandedFields {
     TWiden |= B.TWiden;
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Support for debugging, callable in GDB: V->dump()
   LLVM_DUMP_METHOD void dump() const {
     print(dbgs());
@@ -149,16 +148,13 @@ struct DemandedFields {
     OS << "TWiden=" << TWiden;
     OS << "}";
   }
-#endif
 };
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_ATTRIBUTE_USED
 inline raw_ostream &operator<<(raw_ostream &OS, const DemandedFields &DF) {
   DF.print(OS);
   return OS;
 }
-#endif
 
 bool areCompatibleVTYPEs(uint64_t CurVType, uint64_t NewVType,
                          const DemandedFields &Used);
@@ -508,7 +504,6 @@ public:
     return VSETVLIInfo::getUnknown();
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Support for debugging, callable in GDB: V->dump()
   LLVM_DUMP_METHOD void dump() const {
     print(dbgs());
@@ -557,16 +552,13 @@ public:
 
     OS << '}';
   }
-#endif
 };
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_ATTRIBUTE_USED
 inline raw_ostream &operator<<(raw_ostream &OS, const VSETVLIInfo &V) {
   V.print(OS);
   return OS;
 }
-#endif
 
 class RISCVVSETVLIInfoAnalysis {
   const RISCVSubtarget *ST;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyExceptionInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyExceptionInfo.cpp
@@ -357,9 +357,7 @@ void WebAssemblyException::print(raw_ostream &OS, unsigned Depth) const {
     SubE->print(OS, Depth + 2);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void WebAssemblyException::dump() const { print(dbgs()); }
-#endif
 
 raw_ostream &operator<<(raw_ostream &OS, const WebAssemblyException &WE) {
   WE.print(OS);

--- a/llvm/lib/Target/X86/X86FloatingPoint.cpp
+++ b/llvm/lib/Target/X86/X86FloatingPoint.cpp
@@ -150,7 +150,6 @@ private:
   // Shuffle live registers to match the expectations of successor blocks.
   void finishBlockStack();
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dumpStack() const {
     dbgs() << "Stack contents:";
     for (unsigned i = 0; i != StackTop; ++i) {
@@ -158,7 +157,6 @@ private:
       assert(RegMap[Stack[i]] == i && "Stack[] doesn't match RegMap[]!");
     }
   }
-#endif
 
   /// getSlot - Return the stack slot number a particular register number is
   /// in.

--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -107,7 +107,6 @@ namespace {
       Base_Reg = Reg;
     }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     void dump(SelectionDAG *DAG = nullptr) {
       dbgs() << "X86ISelAddressMode " << this << '\n';
       dbgs() << "Base_Reg ";
@@ -149,7 +148,6 @@ namespace {
         dbgs() << "nul";
       dbgs() << " JT" << JT << " Align" << Alignment.value() << '\n';
     }
-#endif
   };
 }
 

--- a/llvm/lib/Target/Xtensa/XtensaConstantPoolValue.cpp
+++ b/llvm/lib/Target/Xtensa/XtensaConstantPoolValue.cpp
@@ -62,9 +62,7 @@ bool XtensaConstantPoolValue::hasSameValue(XtensaConstantPoolValue *ACPV) {
   return false;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void XtensaConstantPoolValue::dump() const { errs() << "  " << *this; }
-#endif
 
 void XtensaConstantPoolValue::print(raw_ostream &O) const {}
 

--- a/llvm/lib/Target/Xtensa/XtensaConstantPoolValue.h
+++ b/llvm/lib/Target/Xtensa/XtensaConstantPoolValue.h
@@ -109,9 +109,7 @@ public:
 
   void print(raw_ostream &O) const override;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const;
-#endif
 };
 
 inline raw_ostream &operator<<(raw_ostream &O,

--- a/llvm/lib/TargetParser/SubtargetFeature.cpp
+++ b/llvm/lib/TargetParser/SubtargetFeature.cpp
@@ -61,11 +61,9 @@ void SubtargetFeatures::print(raw_ostream &OS) const {
   OS << "\n";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SubtargetFeatures::dump() const {
   print(dbgs());
 }
-#endif
 
 void SubtargetFeatures::getDefaultSubtargetFeatures(const Triple& Triple) {
   // FIXME: This is an inelegant way of specifying the features of a

--- a/llvm/lib/TargetParser/SubtargetFeature.cpp
+++ b/llvm/lib/TargetParser/SubtargetFeature.cpp
@@ -61,9 +61,7 @@ void SubtargetFeatures::print(raw_ostream &OS) const {
   OS << "\n";
 }
 
-LLVM_DUMP_METHOD void SubtargetFeatures::dump() const {
-  print(dbgs());
-}
+LLVM_DUMP_METHOD void SubtargetFeatures::dump() const { print(dbgs()); }
 
 void SubtargetFeatures::getDefaultSubtargetFeatures(const Triple& Triple) {
   // FIXME: This is an inelegant way of specifying the features of a

--- a/llvm/lib/TextAPI/Symbol.cpp
+++ b/llvm/lib/TextAPI/Symbol.cpp
@@ -16,7 +16,6 @@
 namespace llvm {
 namespace MachO {
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void Symbol::dump(raw_ostream &OS) const {
   std::string Result;
   if (isUndefined())
@@ -43,7 +42,6 @@ LLVM_DUMP_METHOD void Symbol::dump(raw_ostream &OS) const {
   }
   OS << Result;
 }
-#endif
 
 Symbol::const_filtered_target_range
 Symbol::targets(ArchitectureSet Architectures) const {

--- a/llvm/lib/Transforms/Coroutines/MaterializationUtils.cpp
+++ b/llvm/lib/Transforms/Coroutines/MaterializationUtils.cpp
@@ -105,7 +105,6 @@ struct RematGraph {
     }
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   static void dumpBasicBlockLabel(const BasicBlock *BB,
                                   ModuleSlotTracker &MST) {
     if (BB->hasName()) {
@@ -132,7 +131,6 @@ struct RematGraph {
         dbgs() << "  " << *U->Node << "\n";
     }
   }
-#endif
 };
 
 } // namespace

--- a/llvm/lib/Transforms/Coroutines/SuspendCrossingInfo.cpp
+++ b/llvm/lib/Transforms/Coroutines/SuspendCrossingInfo.cpp
@@ -20,7 +20,6 @@
 #define DEBUG_TYPE "coro-suspend-crossing"
 
 namespace llvm {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 static void dumpBasicBlockLabel(const BasicBlock *BB, ModuleSlotTracker &MST) {
   if (BB->hasName()) {
     dbgs() << BB->getName();
@@ -65,7 +64,6 @@ LLVM_DUMP_METHOD void SuspendCrossingInfo::dump() const {
   }
   dbgs() << "\n";
 }
-#endif
 
 bool SuspendCrossingInfo::hasPathCrossingSuspendPoint(BasicBlock *From,
                                                       BasicBlock *To) const {

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -933,7 +933,6 @@ void GVNPass::salvageAndRemoveInstruction(Instruction *I) {
   removeInstruction(I);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void GVNPass::dump(DenseMap<uint32_t, Value *> &Map) const {
   errs() << "{\n";
   for (const auto &[Num, Exp] : Map) {
@@ -942,7 +941,6 @@ LLVM_DUMP_METHOD void GVNPass::dump(DenseMap<uint32_t, Value *> &Map) const {
   }
   errs() << "}\n";
 }
-#endif
 
 enum class AvailabilityState : char {
   /// We know the block *is not* fully available. This is a fixpoint.

--- a/llvm/lib/Transforms/Scalar/LoopFuse.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFuse.cpp
@@ -285,7 +285,6 @@ struct FusionCandidate {
                : GuardBranch->getSuccessor(0);
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const {
     dbgs() << "\tGuardBranch: ";
     if (GuardBranch)
@@ -306,7 +305,6 @@ struct FusionCandidate {
            << (getEntryBlock() ? getEntryBlock()->getName() : "nullptr")
            << "\n";
   }
-#endif
 
   /// Determine if a fusion candidate (representing a loop) is eligible for
   /// fusion. Note that this only checks whether a single loop can be fused - it

--- a/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -370,7 +370,6 @@ struct KeyOrderSizeTAndImmediate {
 };
 } // end anonymous namespace
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void RegSortData::print(raw_ostream &OS) const {
   OS << "[NumUses=" << UsedByIndices.count() << ']';
 }
@@ -378,7 +377,6 @@ void RegSortData::print(raw_ostream &OS) const {
 LLVM_DUMP_METHOD void RegSortData::dump() const {
   print(errs()); errs() << '\n';
 }
-#endif
 
 namespace {
 
@@ -758,7 +756,6 @@ bool Formula::hasRegsUsedByUsesOtherThan(size_t LUIdx,
   return false;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void Formula::print(raw_ostream &OS) const {
   ListSeparator Plus(" + ");
   if (BaseGV) {
@@ -791,7 +788,6 @@ void Formula::print(raw_ostream &OS) const {
 LLVM_DUMP_METHOD void Formula::dump() const {
   print(errs()); errs() << '\n';
 }
-#endif
 
 /// Return true if the given addrec can be sign-extended without changing its
 /// value.
@@ -1614,7 +1610,6 @@ bool Cost::isLess(const Cost &Other) const {
   return TTI->isLSRCostLess(C, Other.C);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void Cost::print(raw_ostream &OS) const {
   if (InsnsCost)
     OS << C.Insns << " instruction" << (C.Insns == 1 ? " " : "s ");
@@ -1638,7 +1633,6 @@ void Cost::print(raw_ostream &OS) const {
 LLVM_DUMP_METHOD void Cost::dump() const {
   print(errs()); errs() << '\n';
 }
-#endif
 
 /// Test whether this fixup always uses its value outside of the given loop.
 bool LSRFixup::isUseFullyOutsideLoop(const Loop *L) const {
@@ -1654,7 +1648,6 @@ bool LSRFixup::isUseFullyOutsideLoop(const Loop *L) const {
   return !L->contains(UserInst);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void LSRFixup::print(raw_ostream &OS) const {
   OS << "UserInst=";
   // Store is common and interesting enough to be worth special-casing.
@@ -1681,7 +1674,6 @@ void LSRFixup::print(raw_ostream &OS) const {
 LLVM_DUMP_METHOD void LSRFixup::dump() const {
   print(errs()); errs() << '\n';
 }
-#endif
 
 /// Test whether this use as a formula which has the same registers as the given
 /// formula.
@@ -1760,7 +1752,6 @@ void LSRUse::RecomputeRegs(size_t LUIdx, RegUseTracker &RegUses) {
       RegUses.dropRegister(S, LUIdx);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void LSRUse::print(raw_ostream &OS) const {
   OS << "LSR Use: Kind=";
   switch (Kind) {
@@ -1800,7 +1791,6 @@ void LSRUse::print(raw_ostream &OS) const {
 LLVM_DUMP_METHOD void LSRUse::dump() const {
   print(errs()); errs() << '\n';
 }
-#endif
 
 static bool isAMCompletelyFolded(const TargetTransformInfo &TTI,
                                  LSRUse::KindType Kind, MemAccessTy AccessTy,
@@ -4501,7 +4491,6 @@ struct WorkItem {
 
 } // end anonymous namespace
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void WorkItem::print(raw_ostream &OS) const {
   OS << "in formulae referencing " << *OrigReg << " in use " << LUIdx
      << " , add offset " << Imm;
@@ -4510,7 +4499,6 @@ void WorkItem::print(raw_ostream &OS) const {
 LLVM_DUMP_METHOD void WorkItem::dump() const {
   print(errs()); errs() << '\n';
 }
-#endif
 
 /// Look for registers which are a constant distance apart and try to form reuse
 /// opportunities between them.
@@ -6274,7 +6262,6 @@ LSRInstance::LSRInstance(Loop *L, IVUsers &IU, ScalarEvolution &SE,
   ImplementSolution(Solution);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void LSRInstance::print_factors_and_types(raw_ostream &OS) const {
   if (Factors.empty() && Types.empty()) return;
 
@@ -6322,7 +6309,6 @@ void LSRInstance::print(raw_ostream &OS) const {
 LLVM_DUMP_METHOD void LSRInstance::dump() const {
   print(errs()); errs() << '\n';
 }
-#endif
 
 namespace {
 

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -666,7 +666,6 @@ public:
   /// need to replace with undef.
   ArrayRef<Use *> getDeadOperands() const { return DeadOperands; }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void print(raw_ostream &OS, const_iterator I, StringRef Indent = "  ") const;
   void printSlice(raw_ostream &OS, const_iterator I,
                   StringRef Indent = "  ") const;
@@ -675,7 +674,6 @@ public:
   void print(raw_ostream &OS) const;
   void dump(const_iterator I) const;
   void dump() const;
-#endif
 
 private:
   template <typename DerivedT, typename RetT = void> class BuilderBase;
@@ -683,10 +681,8 @@ private:
 
   friend class AllocaSlices::SliceBuilder;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Handle to alloca instruction to simplify method interfaces.
   AllocaInst &AI;
-#endif
 
   /// The instruction responsible for this alloca not having a known set
   /// of slices.
@@ -1453,9 +1449,7 @@ private:
 
 AllocaSlices::AllocaSlices(const DataLayout &DL, AllocaInst &AI)
     :
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
       AI(AI),
-#endif
       PointerEscapingInstr(nullptr), PointerEscapingInstrReadOnly(nullptr) {
   SliceBuilder PB(DL, AI, *this);
   SliceBuilder::PtrInfo PtrI = PB.visitPtr(AI);
@@ -1476,7 +1470,6 @@ AllocaSlices::AllocaSlices(const DataLayout &DL, AllocaInst &AI)
   llvm::stable_sort(Slices);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 
 void AllocaSlices::print(raw_ostream &OS, const_iterator I,
                          StringRef Indent) const {
@@ -1518,7 +1511,6 @@ LLVM_DUMP_METHOD void AllocaSlices::dump(const_iterator I) const {
 }
 LLVM_DUMP_METHOD void AllocaSlices::dump() const { print(dbgs()); }
 
-#endif // !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 
 /// Walk the range of a partitioning looking for a common type to cover this
 /// sequence of slices.

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -1448,9 +1448,8 @@ private:
 };
 
 AllocaSlices::AllocaSlices(const DataLayout &DL, AllocaInst &AI)
-    :
-      AI(AI),
-      PointerEscapingInstr(nullptr), PointerEscapingInstrReadOnly(nullptr) {
+    : AI(AI), PointerEscapingInstr(nullptr),
+      PointerEscapingInstrReadOnly(nullptr) {
   SliceBuilder PB(DL, AI, *this);
   SliceBuilder::PtrInfo PtrI = PB.visitPtr(AI);
   if (PtrI.isEscaped() || PtrI.isAborted()) {
@@ -1469,7 +1468,6 @@ AllocaSlices::AllocaSlices(const DataLayout &DL, AllocaInst &AI)
   // and the sizes to be in descending order.
   llvm::stable_sort(Slices);
 }
-
 
 void AllocaSlices::print(raw_ostream &OS, const_iterator I,
                          StringRef Indent) const {
@@ -1510,7 +1508,6 @@ LLVM_DUMP_METHOD void AllocaSlices::dump(const_iterator I) const {
   print(dbgs(), I);
 }
 LLVM_DUMP_METHOD void AllocaSlices::dump() const { print(dbgs()); }
-
 
 /// Walk the range of a partitioning looking for a common type to cover this
 /// sequence of slices.

--- a/llvm/lib/Transforms/Utils/SplitModuleByCategory.cpp
+++ b/llvm/lib/Transforms/Utils/SplitModuleByCategory.cpp
@@ -43,7 +43,6 @@ struct EntryPointGroup {
 
   void clear() { Functions.clear(); }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const {
     constexpr size_t INDENT = 4;
     dbgs().indent(INDENT) << "ENTRY POINTS"
@@ -53,7 +52,6 @@ struct EntryPointGroup {
 
     dbgs().indent(INDENT) << "}\n";
   }
-#endif
 };
 
 /// Annotates an llvm::Module with information necessary to perform and track
@@ -78,13 +76,11 @@ public:
     return std::move(M);
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const {
     dbgs() << "ModuleDesc[" << M->getName() << "] {\n";
     EntryPoints.dump();
     dbgs() << "}\n";
   }
-#endif
 };
 
 bool isKernel(const Function &F) {

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -555,9 +555,7 @@ public:
                                               DominatorTree *DT,
                                               bool VectorizingEpilogue);
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void printPlans(raw_ostream &O);
-#endif
 
   /// Look through the existing plans and return true if we have one with
   /// vectorization factor \p VF.

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -366,11 +366,9 @@ cl::opt<bool>
                           cl::Hidden,
                           cl::desc("Verfiy VPlans after VPlan transforms."));
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 cl::opt<bool> llvm::PrintAfterEachVPlanPass(
     "vplan-print-after-all", cl::init(false), cl::Hidden,
     cl::desc("Print after each VPlanTransforms::runPass."));
-#endif
 
 // This flag enables the stress testing of the VPlan H-CFG construction in the
 // VPlan-native vectorization path. It must be used in conjuction with

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -3489,7 +3489,6 @@ public:
       }
     }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     LLVM_DUMP_METHOD static StringRef getModeStr(ReorderingMode RMode) {
       switch (RMode) {
       case ReorderingMode::Load:
@@ -3540,7 +3539,6 @@ public:
 
     /// Debug print.
     LLVM_DUMP_METHOD void dump() const { print(dbgs()); }
-#endif
   };
 
   /// Evaluate each pair in \p Candidates and return index into \p Candidates
@@ -4862,7 +4860,6 @@ private:
 
     static bool classof(const ScheduleEntity *) { return true; }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     void dump(raw_ostream &OS) const {
       if (const auto *SD = dyn_cast<ScheduleData>(this))
         return SD->dump(OS);
@@ -4875,16 +4872,13 @@ private:
       dump(dbgs());
       dbgs() << '\n';
     }
-#endif // if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   };
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   friend inline raw_ostream &operator<<(raw_ostream &OS,
                                         const BoUpSLP::ScheduleEntity &SE) {
     SE.dump(OS);
     return OS;
   }
-#endif
 
   /// Contains all scheduling relevant data for an instruction.
   /// A ScheduleData either represents a single instruction or a member of an
@@ -5250,14 +5244,12 @@ private:
     ScheduleBundle &getBundle() { return Bundle; }
     const ScheduleBundle &getBundle() const { return Bundle; }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     void dump(raw_ostream &OS) const { OS << "[Copyable]" << *getInst(); }
 
     LLVM_DUMP_METHOD void dump() const {
       dump(dbgs());
       dbgs() << '\n';
     }
-#endif // !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 
   private:
     /// true, if it has valid dependency information. These nodes always have

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -73,14 +73,12 @@ static cl::opt<bool> PrintVPlansInDotFormat(
 
 #define DEBUG_TYPE "loop-vectorize"
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 raw_ostream &llvm::operator<<(raw_ostream &OS, const VPRecipeBase &R) {
   const VPBasicBlock *Parent = R.getParent();
   VPSlotTracker SlotTracker(Parent ? Parent->getPlan() : nullptr);
   R.print(OS, "", SlotTracker);
   return OS;
 }
-#endif
 
 Value *VPLane::getAsRuntimeExpr(IRBuilderBase &Builder,
                                 const ElementCount &VF) const {
@@ -95,7 +93,6 @@ Value *VPLane::getAsRuntimeExpr(IRBuilderBase &Builder,
   llvm_unreachable("Unknown lane kind");
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPValue::print(raw_ostream &OS, VPSlotTracker &SlotTracker) const {
   if (const VPRecipeBase *R = getDefiningRecipe())
     R->print(OS, "", SlotTracker);
@@ -116,7 +113,6 @@ void VPRecipeBase::dump() const {
   print(dbgs(), "", SlotTracker);
   dbgs() << "\n";
 }
-#endif
 
 #if !defined(NDEBUG)
 bool VPRecipeValue::isDefinedBy(const VPDef *D) const { return Def == D; }
@@ -650,7 +646,6 @@ bool VPBasicBlock::isExiting() const {
   return getParent() && getParent()->getExitingBasicBlock() == this;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPBlockBase::print(raw_ostream &O) const {
   VPSlotTracker SlotTracker(getPlan());
   print(O, "", SlotTracker);
@@ -680,7 +675,6 @@ void VPBasicBlock::print(raw_ostream &O, const Twine &Indent,
 
   printSuccessors(O, Indent);
 }
-#endif
 
 static std::pair<VPBlockBase *, VPBlockBase *> cloneFrom(VPBlockBase *Entry);
 
@@ -828,7 +822,6 @@ InstructionCost VPRegionBlock::cost(ElementCount VF, VPCostContext &Ctx) {
   return Then->cost(VF, Ctx);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPRegionBlock::print(raw_ostream &O, const Twine &Indent,
                           VPSlotTracker &SlotTracker) const {
   O << Indent << (isReplicator() ? "<xVFxUF> " : "<x1> ") << getName() << ": {";
@@ -841,7 +834,6 @@ void VPRegionBlock::print(raw_ostream &O, const Twine &Indent,
 
   printSuccessors(O, Indent);
 }
-#endif
 
 void VPRegionBlock::dissolveToCFGLoop() {
   auto *Header = cast<VPBasicBlock>(getEntry());
@@ -1043,7 +1035,6 @@ const VPRegionBlock *VPlan::getVectorLoopRegion() const {
   return nullptr;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPlan::printLiveIns(raw_ostream &O) const {
   VPSlotTracker SlotTracker(this);
 
@@ -1130,7 +1121,6 @@ void VPlan::printDOT(raw_ostream &O) const {
 
 LLVM_DUMP_METHOD
 void VPlan::dump() const { print(dbgs()); }
-#endif
 
 static void remapOperands(VPBlockBase *Entry, VPBlockBase *NewEntry,
                           DenseMap<VPValue *, VPValue *> &Old2NewVPValues) {
@@ -1248,7 +1238,6 @@ VPIRBasicBlock *VPlan::createVPIRBasicBlock(BasicBlock *IRBB) {
   return VPIRBB;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 
 Twine VPlanPrinter::getUID(const VPBlockBase *Block) {
   return (isa<VPRegionBlock>(Block) ? "cluster_N" : "N") +
@@ -1378,7 +1367,6 @@ void VPlanPrinter::dumpRegion(const VPRegionBlock *Region) {
   dumpEdges(Region);
 }
 
-#endif
 
 /// Returns true if there is a vector loop region and \p VPV is defined in a
 /// loop region.
@@ -1429,7 +1417,6 @@ void VPUser::replaceUsesOfWith(VPValue *From, VPValue *To) {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPValue::printAsOperand(raw_ostream &OS, VPSlotTracker &Tracker) const {
   OS << Tracker.getOrCreateName(this);
 }
@@ -1439,7 +1426,6 @@ void VPUser::printOperands(raw_ostream &O, VPSlotTracker &SlotTracker) const {
     Op->printAsOperand(O, SlotTracker);
   });
 }
-#endif
 
 void VPSlotTracker::assignName(const VPValue *V) {
   assert(!VPValue2Name.contains(V) && "VPValue already has a name!");
@@ -1734,7 +1720,6 @@ void LoopVectorizationPlanner::updateLoopMetadataAndProfileInfo(
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void LoopVectorizationPlanner::printPlans(raw_ostream &O) {
   if (VPlans.empty()) {
     O << "LV: No VPlans built.\n";
@@ -1746,7 +1731,6 @@ void LoopVectorizationPlanner::printPlans(raw_ostream &O) {
     else
       Plan->print(O);
 }
-#endif
 
 bool llvm::canConstantBeExtended(const APInt *C, Type *NarrowType,
                                  TTI::PartialReductionExtendKind ExtKind) {

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1238,7 +1238,6 @@ VPIRBasicBlock *VPlan::createVPIRBasicBlock(BasicBlock *IRBB) {
   return VPIRBB;
 }
 
-
 Twine VPlanPrinter::getUID(const VPBlockBase *Block) {
   return (isa<VPRegionBlock>(Block) ? "cluster_N" : "N") +
          Twine(getOrCreateBID(Block));
@@ -1366,7 +1365,6 @@ void VPlanPrinter::dumpRegion(const VPRegionBlock *Region) {
   OS << Indent << "}\n";
   dumpEdges(Region);
 }
-
 
 /// Returns true if there is a vector loop region and \p VPV is defined in a
 /// loop region.

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -345,7 +345,6 @@ public:
   /// Return the cost of the block.
   virtual InstructionCost cost(ElementCount VF, VPCostContext &Ctx) = 0;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void printAsOperand(raw_ostream &OS, bool PrintType = false) const {
     OS << getName();
   }
@@ -368,7 +367,6 @@ public:
 
   /// Dump this VPBlockBase to dbgs().
   LLVM_DUMP_METHOD void dump() const { print(dbgs()); }
-#endif
 
   /// Clone the current block and it's recipes without updating the operands of
   /// the cloned recipes, including all blocks in the single-entry single-exit
@@ -541,14 +539,12 @@ public:
   /// Set the recipe's debug location to \p NewDL.
   void setDebugLoc(DebugLoc NewDL) { DL = NewDL; }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Dump the recipe to stderr (for debugging).
   LLVM_ABI_FOR_TEST void dump() const;
 
   /// Print the recipe, delegating to printRecipe().
   void print(raw_ostream &O, const Twine &Indent,
              VPSlotTracker &SlotTracker) const;
-#endif
 
 protected:
   /// Compute the cost of this recipe either using a recipe's specialized
@@ -557,12 +553,10 @@ protected:
   virtual InstructionCost computeCost(ElementCount VF,
                                       VPCostContext &Ctx) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Each concrete VPRecipe prints itself, without printing common information,
   /// like debug info or metadata.
   virtual void printRecipe(raw_ostream &O, const Twine &Indent,
                            VPSlotTracker &SlotTracker) const = 0;
-#endif
 };
 
 // Helper macro to define common classof implementations for recipes.
@@ -655,10 +649,8 @@ public:
     return cast<Instruction>(getUnderlyingValue());
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print this VPSingleDefRecipe to dbgs() (for debugging).
   LLVM_ABI_FOR_TEST LLVM_DUMP_METHOD void dump() const;
-#endif
 };
 
 /// Class to record and manage LLVM IR flags.
@@ -1020,9 +1012,7 @@ public:
   LLVM_ABI_FOR_TEST bool flagsValidForOpcode(unsigned Opcode) const;
 #endif
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void printFlags(raw_ostream &O) const;
-#endif
 };
 
 /// A pure-virtual common base class for recipes defining a single VPValue and
@@ -1126,10 +1116,8 @@ public:
     return It != Metadata.end() ? It->second : nullptr;
   }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print metadata with node IDs.
   void print(raw_ostream &O, VPSlotTracker &SlotTracker) const;
-#endif
 };
 
 /// This is a concrete Recipe that models a single VPlan-level instruction.
@@ -1308,10 +1296,8 @@ public:
   InstructionCost computeCost(ElementCount VF,
                               VPCostContext &Ctx) const override;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the VPInstruction to dbgs() (for debugging).
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
   bool hasResult() const {
     // CallInst may or may not have a result, depending on the called function.
@@ -1360,11 +1346,9 @@ public:
   void setName(StringRef NewName) { Name = NewName.str(); }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the VPInstruction to \p O.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A specialization of VPInstruction augmenting it with a dedicated result
@@ -1427,11 +1411,9 @@ public:
   Type *getResultType() const { return ResultTy; }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// Helper type to provide functions to access incoming values and blocks for
@@ -1486,10 +1468,8 @@ public:
   /// predecessor.
   void removeIncomingValueFor(VPBlockBase *IncomingBlock) const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printPhiOperands(raw_ostream &O, VPSlotTracker &SlotTracker) const;
-#endif
 };
 
 struct LLVM_ABI_FOR_TEST VPPhi : public VPInstruction, public VPPhiAccessors {
@@ -1520,11 +1500,9 @@ struct LLVM_ABI_FOR_TEST VPPhi : public VPInstruction, public VPPhiAccessors {
   void execute(VPTransformState &State) override;
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 
   const VPRecipeBase *getAsRecipe() const override { return this; }
 };
@@ -1589,11 +1567,9 @@ public:
   void extractLastLaneOfLastPartOfFirstOperand(VPBuilder &Builder);
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// An overlay for VPIRInstructions wrapping PHI nodes enabling convenient use
@@ -1614,11 +1590,9 @@ struct LLVM_ABI_FOR_TEST VPIRPhi : public VPIRInstruction,
   void execute(VPTransformState &State) override;
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 
   const VPRecipeBase *getAsRecipe() const override { return this; }
 };
@@ -1668,11 +1642,9 @@ public:
   unsigned getOpcode() const { return Opcode; }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 
   /// Returns true if the recipe only uses the first lane of operand \p Op.
   bool usesFirstLaneOnly(const VPValue *Op) const override {
@@ -1726,11 +1698,9 @@ public:
   Type *getResultType() const { return ResultTy; }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   LLVM_ABI_FOR_TEST void printRecipe(raw_ostream &O, const Twine &Indent,
                                      VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for widening vector intrinsics.
@@ -1825,11 +1795,9 @@ public:
   LLVM_ABI_FOR_TEST bool usesFirstLaneOnly(const VPValue *Op) const override;
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   LLVM_ABI_FOR_TEST void printRecipe(raw_ostream &O, const Twine &Indent,
                                      VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for widening Call instructions using library calls.
@@ -1878,11 +1846,9 @@ public:
   const_operand_range args() const { return drop_end(operands()); }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe representing a sequence of load -> update -> store as part of
@@ -1924,11 +1890,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for handling GEP instructions.
@@ -1984,11 +1948,9 @@ public:
   bool usesFirstLaneOnly(const VPValue *Op) const override;
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe to compute a pointer to the last element of each part of a widened
@@ -2047,11 +2009,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe to compute the pointers for widened memory accesses of \p
@@ -2106,11 +2066,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A pure virtual base class for all recipes modeling header phis, including
@@ -2193,11 +2151,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override = 0;
-#endif
 };
 
 /// Base class for widened induction (VPWidenIntOrFpInductionRecipe and
@@ -2365,11 +2321,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 class VPWidenPointerInductionRecipe : public VPWidenInductionRecipe {
@@ -2405,11 +2359,9 @@ public:
   bool onlyScalarsGenerated(bool IsScalable);
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for widened phis. Incoming values are operands of the recipe and
@@ -2453,11 +2405,9 @@ public:
                               VPCostContext &Ctx) const override;
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 
   const VPRecipeBase *getAsRecipe() const override { return this; }
 };
@@ -2494,11 +2444,9 @@ struct VPFirstOrderRecurrencePHIRecipe : public VPHeaderPHIRecipe {
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// Possible variants of a reduction.
@@ -2612,11 +2560,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for vectorizing a phi-node as a sequence of mask-based select
@@ -2685,11 +2631,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A common base class for interleaved memory operations.
@@ -2827,11 +2771,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for interleaved memory operations with vector-predication
@@ -2877,11 +2819,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe to represent inloop, ordered or partial reduction operations. It
@@ -2986,11 +2926,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe to represent inloop reduction operations with vector-predication
@@ -3030,11 +2968,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// VPReplicateRecipe replicates a given instruction producing multiple scalar
@@ -3115,11 +3051,9 @@ public:
   unsigned getOpcode() const { return getUnderlyingInstr()->getOpcode(); }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for generating conditional branches on the bits of a mask.
@@ -3142,14 +3076,12 @@ public:
   InstructionCost computeCost(ElementCount VF,
                               VPCostContext &Ctx) const override;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override {
     O << Indent << "BRANCH-ON-MASK ";
     printOperands(O, SlotTracker);
   }
-#endif
 
   /// Returns true if the recipe uses scalars of operand \p Op.
   bool usesScalars(const VPValue *Op) const override {
@@ -3298,11 +3230,9 @@ public:
   bool isSingleScalar() const;
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// VPPredInstPHIRecipe is a recipe for generating the phi nodes needed when
@@ -3343,11 +3273,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A common base class for widening memory operations. An optional mask can be
@@ -3475,11 +3403,9 @@ struct LLVM_ABI_FOR_TEST VPWidenLoadRecipe final : public VPWidenMemoryRecipe,
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for widening load operations with vector-predication intrinsics,
@@ -3518,11 +3444,9 @@ struct VPWidenLoadEVLRecipe final : public VPWidenMemoryRecipe,
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   LLVM_ABI_FOR_TEST void printRecipe(raw_ostream &O, const Twine &Indent,
                                      VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for widening store operations, using the stored value, the address
@@ -3561,11 +3485,9 @@ struct LLVM_ABI_FOR_TEST VPWidenStoreRecipe final : public VPWidenMemoryRecipe {
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for widening store operations with vector-predication intrinsics,
@@ -3610,11 +3532,9 @@ struct VPWidenStoreEVLRecipe final : public VPWidenMemoryRecipe {
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   LLVM_ABI_FOR_TEST void printRecipe(raw_ostream &O, const Twine &Indent,
                                      VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// Recipe to expand a SCEV expression.
@@ -3645,11 +3565,9 @@ public:
   const SCEV *getSCEV() const { return Expr; }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// Canonical scalar induction phi of the vector loop. Starting at the specified
@@ -3705,11 +3623,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   LLVM_ABI_FOR_TEST void printRecipe(raw_ostream &O, const Twine &Indent,
                                      VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for generating the active lane mask for the vector loop that is
@@ -3735,11 +3651,9 @@ public:
   void execute(VPTransformState &State) override;
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for generating the phi node for the current index of elements,
@@ -3780,11 +3694,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   LLVM_ABI_FOR_TEST void printRecipe(raw_ostream &O, const Twine &Indent,
                                      VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A Recipe for widening the canonical induction variable of the vector loop.
@@ -3816,11 +3728,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for converting the input value \p IV value to the corresponding
@@ -3884,11 +3794,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// A recipe for handling phi nodes of integer and floating-point inductions,
@@ -3960,11 +3868,9 @@ public:
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override;
-#endif
 };
 
 /// Casting from VPRecipeBase -> VPPhiAccessors is supported for all recipe
@@ -4182,7 +4088,6 @@ public:
   VPRegionBlock *getEnclosingLoopRegion();
   const VPRegionBlock *getEnclosingLoopRegion() const;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print this VPBsicBlock to \p O, prefixing all lines with \p Indent. \p
   /// SlotTracker is used to print unnamed VPValue's using consequtive numbers.
   ///
@@ -4191,7 +4096,6 @@ public:
   void print(raw_ostream &O, const Twine &Indent,
              VPSlotTracker &SlotTracker) const override;
   using VPBlockBase::print; // Get the print(raw_stream &O) version.
-#endif
 
   /// If the block has multiple successors, return the branch recipe terminating
   /// the block. If there are no or only a single successor, return nullptr;
@@ -4347,7 +4251,6 @@ public:
   // Return the cost of this region.
   InstructionCost cost(ElementCount VF, VPCostContext &Ctx) override;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print this VPRegionBlock to \p O (recursively), prefixing all lines with
   /// \p Indent. \p SlotTracker is used to print unnamed VPValue's using
   /// consequtive numbers.
@@ -4357,7 +4260,6 @@ public:
   void print(raw_ostream &O, const Twine &Indent,
              VPSlotTracker &SlotTracker) const override;
   using VPBlockBase::print; // Get the print(raw_stream &O) version.
-#endif
 
   /// Clone all blocks in the single-entry single-exit region of the block and
   /// their recipes without updating the operands of the cloned recipes.
@@ -4688,7 +4590,6 @@ public:
   /// Return the list of live-in VPValues available in the VPlan.
   auto getLiveIns() const { return LiveIns.values(); }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the live-ins of this VPlan to \p O.
   void printLiveIns(raw_ostream &O) const;
 
@@ -4700,7 +4601,6 @@ public:
 
   /// Dump the plan to stderr (for debugging).
   LLVM_DUMP_METHOD void dump() const;
-#endif
 
   /// Clone the current VPlan, update all VPValues of the new VPlan and cloned
   /// recipes to refer to the clones, and return it.
@@ -4769,12 +4669,10 @@ public:
   }
 };
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 inline raw_ostream &operator<<(raw_ostream &OS, const VPlan &Plan) {
   Plan.print(OS);
   return OS;
 }
-#endif
 
 } // end namespace llvm
 

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -441,7 +441,6 @@ public:
   const Module *getModule() const { return M; }
 };
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 /// VPlanPrinter prints a given VPlan to a given output stream. The printing is
 /// indented and follows the dot format.
 class VPlanPrinter {
@@ -490,7 +489,6 @@ public:
 
   LLVM_DUMP_METHOD void dump();
 };
-#endif
 
 /// Check if a constant \p CI can be safely treated as having been extended
 /// from a narrower type with the given extension kind.

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -381,7 +381,6 @@ FastMathFlags VPIRFlags::getFastMathFlags() const {
   return Res;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPSingleDefRecipe::dump() const { VPRecipeBase::dump(); }
 
 void VPRecipeBase::print(raw_ostream &O, const Twine &Indent,
@@ -395,7 +394,6 @@ void VPRecipeBase::print(raw_ostream &O, const Twine &Indent,
   if (auto *Metadata = dyn_cast<VPIRMetadata>(this))
     Metadata->print(O, SlotTracker);
 }
-#endif
 
 template <unsigned PartOpIdx>
 VPValue *
@@ -1408,7 +1406,6 @@ bool VPInstruction::usesFirstPartOnly(const VPValue *Op) const {
   llvm_unreachable("switch should return");
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPInstruction::dump() const {
   VPSlotTracker SlotTracker(getParent()->getPlan());
   printRecipe(dbgs(), "", SlotTracker);
@@ -1524,7 +1521,6 @@ void VPInstruction::printRecipe(raw_ostream &O, const Twine &Indent,
   printFlags(O);
   printOperands(O, SlotTracker);
 }
-#endif
 
 void VPInstructionWithType::execute(VPTransformState &State) {
   State.setDebugLocFrom(getDebugLoc());
@@ -1553,7 +1549,6 @@ void VPInstructionWithType::execute(VPTransformState &State) {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPInstructionWithType::printRecipe(raw_ostream &O, const Twine &Indent,
                                         VPSlotTracker &SlotTracker) const {
   O << Indent << "EMIT" << (isSingleScalar() ? "-SCALAR" : "") << " ";
@@ -1578,7 +1573,6 @@ void VPInstructionWithType::printRecipe(raw_ostream &O, const Twine &Indent,
     O << " to " << *ResultTy;
   }
 }
-#endif
 
 void VPPhi::execute(VPTransformState &State) {
   State.setDebugLocFrom(getDebugLoc());
@@ -1598,7 +1592,6 @@ void VPPhi::execute(VPTransformState &State) {
   State.set(this, NewPhi, VPLane(0));
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPPhi::printRecipe(raw_ostream &O, const Twine &Indent,
                         VPSlotTracker &SlotTracker) const {
   O << Indent << "EMIT" << (isSingleScalar() ? "-SCALAR" : "") << " ";
@@ -1606,7 +1599,6 @@ void VPPhi::printRecipe(raw_ostream &O, const Twine &Indent,
   O << " = phi ";
   printPhiOperands(O, SlotTracker);
 }
-#endif
 
 VPIRInstruction *VPIRInstruction ::create(Instruction &I) {
   if (auto *Phi = dyn_cast<PHINode>(&I))
@@ -1643,12 +1635,10 @@ void VPIRInstruction::extractLastLaneOfLastPartOfFirstOperand(
   setOperand(0, Exiting);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPIRInstruction::printRecipe(raw_ostream &O, const Twine &Indent,
                                   VPSlotTracker &SlotTracker) const {
   O << Indent << "IR " << I;
 }
-#endif
 
 void VPIRPhi::execute(VPTransformState &State) {
   PHINode *Phi = &getIRPhi();
@@ -1685,7 +1675,6 @@ void VPPhiAccessors::removeIncomingValueFor(VPBlockBase *IncomingBlock) const {
   R->removeOperand(Position);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPPhiAccessors::printPhiOperands(raw_ostream &O,
                                       VPSlotTracker &SlotTracker) const {
   interleaveComma(enumerate(getAsRecipe()->operands()), O,
@@ -1697,9 +1686,7 @@ void VPPhiAccessors::printPhiOperands(raw_ostream &O,
                     O << " ]";
                   });
 }
-#endif
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPIRPhi::printRecipe(raw_ostream &O, const Twine &Indent,
                           VPSlotTracker &SlotTracker) const {
   VPIRInstruction::printRecipe(O, Indent, SlotTracker);
@@ -1715,7 +1702,6 @@ void VPIRPhi::printRecipe(raw_ostream &O, const Twine &Indent,
     O << ")";
   }
 }
-#endif
 
 void VPIRMetadata::applyMetadata(Instruction &I) const {
   for (const auto &[Kind, Node] : Metadata)
@@ -1735,7 +1721,6 @@ void VPIRMetadata::intersect(const VPIRMetadata &Other) {
   Metadata = std::move(MetadataIntersection);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPIRMetadata::print(raw_ostream &O, VPSlotTracker &SlotTracker) const {
   const Module *M = SlotTracker.getModule();
   if (Metadata.empty() || !M)
@@ -1752,7 +1737,6 @@ void VPIRMetadata::print(raw_ostream &O, VPSlotTracker &SlotTracker) const {
   });
   O << ")";
 }
-#endif
 
 void VPWidenCallRecipe::execute(VPTransformState &State) {
   assert(State.VF.isVector() && "not widening");
@@ -1794,7 +1778,6 @@ InstructionCost VPWidenCallRecipe::computeCost(ElementCount VF,
                                   Ctx.CostKind);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenCallRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                     VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN-CALL ";
@@ -1820,7 +1803,6 @@ void VPWidenCallRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
     O << ": " << Variant->getName();
   O << ")";
 }
-#endif
 
 void VPWidenIntrinsicRecipe::execute(VPTransformState &State) {
   assert(State.VF.isVector() && "not widening");
@@ -1937,7 +1919,6 @@ bool VPWidenIntrinsicRecipe::usesFirstLaneOnly(const VPValue *Op) const {
   });
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenIntrinsicRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                          VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN-INTRINSIC ";
@@ -1957,7 +1938,6 @@ void VPWidenIntrinsicRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   });
   O << ")";
 }
-#endif
 
 void VPHistogramRecipe::execute(VPTransformState &State) {
   IRBuilderBase &Builder = State.Builder;
@@ -2021,7 +2001,6 @@ InstructionCost VPHistogramRecipe::computeCost(ElementCount VF,
          Ctx.TTI.getArithmeticInstrCost(Opcode, VTy, Ctx.CostKind);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPHistogramRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                     VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN-HISTOGRAM buckets: ";
@@ -2040,7 +2019,6 @@ void VPHistogramRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
     Mask->printAsOperand(O, SlotTracker);
   }
 }
-#endif
 
 VPIRFlags::FastMathFlagsTy::FastMathFlagsTy(const FastMathFlags &FMF) {
   AllowReassoc = FMF.allowReassoc();
@@ -2093,7 +2071,6 @@ bool VPIRFlags::flagsValidForOpcode(unsigned Opcode) const {
 }
 #endif
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPIRFlags::printFlags(raw_ostream &O) const {
   switch (OpType) {
   case OperationType::Cmp:
@@ -2192,7 +2169,6 @@ void VPIRFlags::printFlags(raw_ostream &O) const {
   }
   O << " ";
 }
-#endif
 
 void VPWidenRecipe::execute(VPTransformState &State) {
   auto &Builder = State.Builder;
@@ -2337,7 +2313,6 @@ InstructionCost VPWidenRecipe::computeCost(ElementCount VF,
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                 VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN ";
@@ -2346,7 +2321,6 @@ void VPWidenRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   printFlags(O);
   printOperands(O, SlotTracker);
 }
-#endif
 
 void VPWidenCastRecipe::execute(VPTransformState &State) {
   auto &Builder = State.Builder;
@@ -2373,7 +2347,6 @@ InstructionCost VPWidenCastRecipe::computeCost(ElementCount VF,
   return getCostForRecipeWithOpcode(getOpcode(), VF, Ctx);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenCastRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                     VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN-CAST ";
@@ -2383,14 +2356,12 @@ void VPWidenCastRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   printOperands(O, SlotTracker);
   O << " to " << *getResultType();
 }
-#endif
 
 InstructionCost VPHeaderPHIRecipe::computeCost(ElementCount VF,
                                                VPCostContext &Ctx) const {
   return Ctx.TTI.getCFInstrCost(Instruction::PHI, Ctx.CostKind);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenIntOrFpInductionRecipe::printRecipe(
     raw_ostream &O, const Twine &Indent, VPSlotTracker &SlotTracker) const {
   O << Indent;
@@ -2402,7 +2373,6 @@ void VPWidenIntOrFpInductionRecipe::printRecipe(
   if (auto *TI = getTruncInst())
     O << " (truncated to " << *TI->getType() << ")";
 }
-#endif
 
 bool VPWidenIntOrFpInductionRecipe::isCanonical() const {
   // The step may be defined by a recipe in the preheader (e.g. if it requires
@@ -2431,7 +2401,6 @@ void VPDerivedIVRecipe::execute(VPTransformState &State) {
   State.set(this, DerivedIV, VPLane(0));
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPDerivedIVRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                     VPSlotTracker &SlotTracker) const {
   O << Indent;
@@ -2443,7 +2412,6 @@ void VPDerivedIVRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   O << " * ";
   getStepValue()->printAsOperand(O, SlotTracker);
 }
-#endif
 
 void VPScalarIVStepsRecipe::execute(VPTransformState &State) {
   // Fast-math-flags propagate from the original induction instruction.
@@ -2507,7 +2475,6 @@ void VPScalarIVStepsRecipe::execute(VPTransformState &State) {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPScalarIVStepsRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                         VPSlotTracker &SlotTracker) const {
   O << Indent;
@@ -2515,7 +2482,6 @@ void VPScalarIVStepsRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   O << " = SCALAR-STEPS ";
   printOperands(O, SlotTracker);
 }
-#endif
 
 bool VPWidenGEPRecipe::usesFirstLaneOnly(const VPValue *Op) const {
   assert(is_contained(operands(), Op) && "Op must be an operand of the recipe");
@@ -2576,7 +2542,6 @@ void VPWidenGEPRecipe::execute(VPTransformState &State) {
   State.set(this, NewGEP);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenGEPRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                    VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN-GEP ";
@@ -2590,7 +2555,6 @@ void VPWidenGEPRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   printFlags(O);
   printOperands(O, SlotTracker);
 }
-#endif
 
 void VPVectorEndPointerRecipe::execute(VPTransformState &State) {
   auto &Builder = State.Builder;
@@ -2620,7 +2584,6 @@ void VPVectorEndPointerRecipe::execute(VPTransformState &State) {
   State.set(this, ResultPtr, /*IsScalar*/ true);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPVectorEndPointerRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                            VPSlotTracker &SlotTracker) const {
   O << Indent;
@@ -2629,7 +2592,6 @@ void VPVectorEndPointerRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   printFlags(O);
   printOperands(O, SlotTracker);
 }
-#endif
 
 void VPVectorPointerRecipe::execute(VPTransformState &State) {
   auto &Builder = State.Builder;
@@ -2642,7 +2604,6 @@ void VPVectorPointerRecipe::execute(VPTransformState &State) {
   State.set(this, ResultPtr, /*IsScalar*/ true);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPVectorPointerRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                         VPSlotTracker &SlotTracker) const {
   O << Indent;
@@ -2651,7 +2612,6 @@ void VPVectorPointerRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   printFlags(O);
   printOperands(O, SlotTracker);
 }
-#endif
 
 InstructionCost VPBlendRecipe::computeCost(ElementCount VF,
                                            VPCostContext &Ctx) const {
@@ -2667,7 +2627,6 @@ InstructionCost VPBlendRecipe::computeCost(ElementCount VF,
                                     CmpInst::BAD_ICMP_PREDICATE, Ctx.CostKind);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPBlendRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                 VPSlotTracker &SlotTracker) const {
   O << Indent << "BLEND ";
@@ -2689,7 +2648,6 @@ void VPBlendRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
     }
   }
 }
-#endif
 
 void VPReductionRecipe::execute(VPTransformState &State) {
   assert(!State.Lane && "Reduction being replicated.");
@@ -2986,7 +2944,6 @@ bool VPExpressionRecipe::isSingleScalar() const {
   return RR && !RR->isPartialReduction();
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 
 void VPExpressionRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                      VPSlotTracker &SlotTracker) const {
@@ -3121,7 +3078,6 @@ void VPReductionEVLRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   O << ")";
 }
 
-#endif
 
 /// A helper function to scalarize a single Instruction in the innermost loop.
 /// Generates a sequence of scalar instances for lane \p Lane. Uses the VPValue
@@ -3490,7 +3446,6 @@ InstructionCost VPReplicateRecipe::computeCost(ElementCount VF,
   return Ctx.getLegacyCost(UI, VF);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPReplicateRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                     VPSlotTracker &SlotTracker) const {
   O << Indent << (IsSingleScalar ? "CLONE " : "REPLICATE ");
@@ -3517,7 +3472,6 @@ void VPReplicateRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   if (shouldPack())
     O << " (S->V)";
 }
-#endif
 
 void VPBranchOnMaskRecipe::execute(VPTransformState &State) {
   assert(State.Lane && "Branch on Mask works only on single instance.");
@@ -3603,7 +3557,6 @@ void VPPredInstPHIRecipe::execute(VPTransformState &State) {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPPredInstPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                       VPSlotTracker &SlotTracker) const {
   O << Indent << "PHI-PREDICATED-INSTRUCTION ";
@@ -3611,7 +3564,6 @@ void VPPredInstPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   O << " = ";
   printOperands(O, SlotTracker);
 }
-#endif
 
 InstructionCost VPWidenMemoryRecipe::computeCost(ElementCount VF,
                                                  VPCostContext &Ctx) const {
@@ -3696,7 +3648,6 @@ void VPWidenLoadRecipe::execute(VPTransformState &State) {
   State.set(this, NewLI);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenLoadRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                     VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN ";
@@ -3704,7 +3655,6 @@ void VPWidenLoadRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   O << " = load ";
   printOperands(O, SlotTracker);
 }
-#endif
 
 /// Use all-true mask for reverse rather than actual mask, as it avoids a
 /// dependence w/o affecting the result.
@@ -3768,7 +3718,6 @@ InstructionCost VPWidenLoadEVLRecipe::computeCost(ElementCount VF,
       Ctx.CostKind);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenLoadEVLRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                        VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN ";
@@ -3776,7 +3725,6 @@ void VPWidenLoadEVLRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   O << " = vp.load ";
   printOperands(O, SlotTracker);
 }
-#endif
 
 void VPWidenStoreRecipe::execute(VPTransformState &State) {
   VPValue *StoredVPValue = getStoredValue();
@@ -3805,13 +3753,11 @@ void VPWidenStoreRecipe::execute(VPTransformState &State) {
   applyMetadata(*NewSI);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenStoreRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                      VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN store ";
   printOperands(O, SlotTracker);
 }
-#endif
 
 void VPWidenStoreEVLRecipe::execute(VPTransformState &State) {
   VPValue *StoredValue = getStoredValue();
@@ -3863,13 +3809,11 @@ InstructionCost VPWidenStoreEVLRecipe::computeCost(ElementCount VF,
       Ctx.CostKind);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenStoreEVLRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                         VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN vp.store ";
   printOperands(O, SlotTracker);
 }
-#endif
 
 static Value *createBitOrPointerCast(IRBuilderBase &Builder, Value *V,
                                      VectorType *DstVTy, const DataLayout &DL) {
@@ -4127,7 +4071,6 @@ void VPInterleaveRecipe::execute(VPTransformState &State) {
   Group->addMetadata(NewStoreInstr);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPInterleaveRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                      VPSlotTracker &SlotTracker) const {
   const InterleaveGroup<Instruction> *IG = getInterleaveGroup();
@@ -4157,7 +4100,6 @@ void VPInterleaveRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
     ++OpIdx;
   }
 }
-#endif
 
 void VPInterleaveEVLRecipe::execute(VPTransformState &State) {
   assert(!State.Lane && "Interleave group being replicated.");
@@ -4270,7 +4212,6 @@ void VPInterleaveEVLRecipe::execute(VPTransformState &State) {
   Group->addMetadata(NewStore);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPInterleaveEVLRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                         VPSlotTracker &SlotTracker) const {
   const InterleaveGroup<Instruction> *IG = getInterleaveGroup();
@@ -4301,7 +4242,6 @@ void VPInterleaveEVLRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
     ++OpIdx;
   }
 }
-#endif
 
 InstructionCost VPInterleaveBase::computeCost(ElementCount VF,
                                               VPCostContext &Ctx) const {
@@ -4344,7 +4284,6 @@ InstructionCost VPInterleaveBase::computeCost(ElementCount VF,
                                            0);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPCanonicalIVPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                          VPSlotTracker &SlotTracker) const {
   O << Indent << "EMIT ";
@@ -4352,14 +4291,12 @@ void VPCanonicalIVPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   O << " = CANONICAL-INDUCTION ";
   printOperands(O, SlotTracker);
 }
-#endif
 
 bool VPWidenPointerInductionRecipe::onlyScalarsGenerated(bool IsScalable) {
   return vputils::onlyScalarValuesUsed(this) &&
          (!IsScalable || vputils::onlyFirstLaneUsed(this));
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenPointerInductionRecipe::printRecipe(
     raw_ostream &O, const Twine &Indent, VPSlotTracker &SlotTracker) const {
   assert((getNumOperands() == 3 || getNumOperands() == 5) &&
@@ -4386,7 +4323,6 @@ void VPExpandSCEVRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   printAsOperand(O, SlotTracker);
   O << " = EXPAND SCEV " << *Expr;
 }
-#endif
 
 void VPWidenCanonicalIVRecipe::execute(VPTransformState &State) {
   Value *CanonicalIV = State.get(getOperand(0), /*IsScalar*/ true);
@@ -4406,7 +4342,6 @@ void VPWidenCanonicalIVRecipe::execute(VPTransformState &State) {
   State.set(this, CanonicalVectorIV);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenCanonicalIVRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                            VPSlotTracker &SlotTracker) const {
   O << Indent << "EMIT ";
@@ -4414,7 +4349,6 @@ void VPWidenCanonicalIVRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   O << " = WIDEN-CANONICAL-INDUCTION ";
   printOperands(O, SlotTracker);
 }
-#endif
 
 void VPFirstOrderRecurrencePHIRecipe::execute(VPTransformState &State) {
   auto &Builder = State.Builder;
@@ -4454,7 +4388,6 @@ VPFirstOrderRecurrencePHIRecipe::computeCost(ElementCount VF,
   return 0;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPFirstOrderRecurrencePHIRecipe::printRecipe(
     raw_ostream &O, const Twine &Indent, VPSlotTracker &SlotTracker) const {
   O << Indent << "FIRST-ORDER-RECURRENCE-PHI ";
@@ -4462,7 +4395,6 @@ void VPFirstOrderRecurrencePHIRecipe::printRecipe(
   O << " = phi ";
   printOperands(O, SlotTracker);
 }
-#endif
 
 void VPReductionPHIRecipe::execute(VPTransformState &State) {
   // Reductions do not have to start at zero. They can start with
@@ -4489,7 +4421,6 @@ void VPReductionPHIRecipe::execute(VPTransformState &State) {
   Phi->addIncoming(StartV, VectorPH);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPReductionPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                        VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN-REDUCTION-PHI ";
@@ -4500,7 +4431,6 @@ void VPReductionPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   if (getVFScaleFactor() > 1)
     O << " (VF scaled by 1/" << getVFScaleFactor() << ")";
 }
-#endif
 
 void VPWidenPHIRecipe::execute(VPTransformState &State) {
   Value *Op0 = State.get(getOperand(0));
@@ -4514,7 +4444,6 @@ InstructionCost VPWidenPHIRecipe::computeCost(ElementCount VF,
   return Ctx.TTI.getCFInstrCost(Instruction::PHI, Ctx.CostKind);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPWidenPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                    VPSlotTracker &SlotTracker) const {
   O << Indent << "WIDEN-PHI ";
@@ -4523,7 +4452,6 @@ void VPWidenPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   O << " = phi ";
   printPhiOperands(O, SlotTracker);
 }
-#endif
 
 void VPActiveLaneMaskPHIRecipe::execute(VPTransformState &State) {
   BasicBlock *VectorPH =
@@ -4535,7 +4463,6 @@ void VPActiveLaneMaskPHIRecipe::execute(VPTransformState &State) {
   State.set(this, Phi);
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPActiveLaneMaskPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                             VPSlotTracker &SlotTracker) const {
   O << Indent << "ACTIVE-LANE-MASK-PHI ";
@@ -4544,9 +4471,7 @@ void VPActiveLaneMaskPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   O << " = phi ";
   printOperands(O, SlotTracker);
 }
-#endif
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPEVLBasedIVPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                         VPSlotTracker &SlotTracker) const {
   O << Indent << "EXPLICIT-VECTOR-LENGTH-BASED-IV-PHI ";
@@ -4555,4 +4480,3 @@ void VPEVLBasedIVPHIRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   O << " = phi ";
   printOperands(O, SlotTracker);
 }
-#endif

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2944,7 +2944,6 @@ bool VPExpressionRecipe::isSingleScalar() const {
   return RR && !RR->isPartialReduction();
 }
 
-
 void VPExpressionRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
                                      VPSlotTracker &SlotTracker) const {
   O << Indent << "EXPRESSION ";
@@ -3077,7 +3076,6 @@ void VPReductionEVLRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
   }
   O << ")";
 }
-
 
 /// A helper function to scalarize a single Instruction in the innermost loop.
 /// Generates a sequence of scalar instances for lane \p Lane. Uses the VPValue

--- a/llvm/lib/Transforms/Vectorize/VPlanSLP.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanSLP.cpp
@@ -397,7 +397,6 @@ SmallVector<VPlanSlp::MultiNodeOpTy, 4> VPlanSlp::reorderMultiNodeOps() {
   return FinalOrder;
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void VPlanSlp::dumpBundle(ArrayRef<VPValue *> Values) {
   dbgs() << " Ops: ";
   for (auto *Op : Values) {
@@ -410,7 +409,6 @@ void VPlanSlp::dumpBundle(ArrayRef<VPValue *> Values) {
   }
   dbgs() << "\n";
 }
-#endif
 
 VPInstruction *VPlanSlp::buildGraph(ArrayRef<VPValue *> Values) {
   assert(!Values.empty() && "Need some operands!");

--- a/llvm/lib/Transforms/Vectorize/VPlanSLP.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanSLP.h
@@ -120,10 +120,8 @@ class VPlanSlp {
                                        SmallPtrSetImpl<VPValue *> &Candidates,
                                        VPInterleavedAccessInfo &IAI);
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print bundle \p Values to dbgs().
   void dumpBundle(ArrayRef<VPValue *> Values);
-#endif
 
 public:
   VPlanSlp(VPInterleavedAccessInfo &IAI, VPBasicBlock &BB) : IAI(IAI), BB(BB) {}

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
@@ -37,9 +37,7 @@ struct VFRange;
 LLVM_ABI_FOR_TEST extern cl::opt<bool> VerifyEachVPlan;
 LLVM_ABI_FOR_TEST extern cl::opt<bool> EnableWideActiveLaneMask;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_ABI_FOR_TEST extern cl::opt<bool> PrintAfterEachVPlanPass;
-#endif
 
 struct VPlanTransforms {
   /// Helper to run a VPlan pass \p Pass on \p VPlan, forwarding extra arguments
@@ -49,14 +47,12 @@ struct VPlanTransforms {
   static decltype(auto) runPass(StringRef PassName, PassTy &&Pass, VPlan &Plan,
                                 ArgsTy &&...Args) {
     scope_exit PostTransformActions{[&]() {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
       // Make sure to print before verification, so that output is more useful
       // in case of failures:
       if (PrintAfterEachVPlanPass) {
         dbgs() << "VPlan after " << PassName << '\n';
         dbgs() << Plan << '\n';
       }
-#endif
       if (VerifyEachVPlan && EnableVerify)
         verifyVPlanIsValid(Plan);
     }};

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -93,13 +93,11 @@ public:
   /// for any other purpose, as the values may change as LLVM evolves.
   unsigned getVPValueID() const { return SubclassID; }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void printAsOperand(raw_ostream &OS, VPSlotTracker &Tracker) const;
   void print(raw_ostream &OS, VPSlotTracker &Tracker) const;
 
   /// Dump the value to stderr (for debugging).
   void dump() const;
-#endif
 
   unsigned getNumUsers() const { return Users.size(); }
   void addUser(VPUser &User) { Users.push_back(&User); }
@@ -269,10 +267,8 @@ class VPUser {
   }
 
 protected:
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the operands to \p O.
   void printOperands(raw_ostream &O, VPSlotTracker &SlotTracker) const;
-#endif
 
   VPUser(ArrayRef<VPValue *> Operands) {
     for (VPValue *Operand : Operands)

--- a/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
@@ -87,19 +87,15 @@ bool VPlanVerifier::verifyPhiRecipes(const VPBasicBlock *VPBB) {
     if (IsHeaderVPBB &&
         !isa<VPHeaderPHIRecipe, VPWidenPHIRecipe, VPPhi>(*RecipeI)) {
       errs() << "Found non-header PHI recipe in header VPBB";
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
       errs() << ": ";
       RecipeI->dump();
-#endif
       return false;
     }
 
     if (!IsHeaderVPBB && isa<VPHeaderPHIRecipe>(*RecipeI)) {
       errs() << "Found header PHI recipe in non-header VPBB";
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
       errs() << ": ";
       RecipeI->dump();
-#endif
       return false;
     }
 
@@ -133,12 +129,10 @@ bool VPlanVerifier::verifyPhiRecipes(const VPBasicBlock *VPBB) {
     if (RecipeI->isPhi() && !isa<VPBlendRecipe>(&*RecipeI)) {
       errs() << "Found phi-like recipe after non-phi recipe";
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
       errs() << ": ";
       RecipeI->dump();
       errs() << "after\n";
       std::prev(RecipeI)->dump();
-#endif
       return false;
     }
     RecipeI++;
@@ -249,10 +243,8 @@ bool VPlanVerifier::verifyLastActiveLaneRecipe(
       continue;
 
     errs() << "LastActiveLane operand ";
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     VPSlotTracker Tracker(&Plan);
     Op->printAsOperand(errs(), Tracker);
-#endif
     errs() << " must be prefix mask (a header mask or an "
               "EVL-derived mask currently)\n";
     return false;
@@ -274,10 +266,8 @@ bool VPlanVerifier::verifyVPBasicBlock(const VPBasicBlock *VPBB) {
   for (const VPRecipeBase &R : *VPBB) {
     if (isa<VPIRInstruction>(&R) && !isa<VPIRBasicBlock>(VPBB)) {
       errs() << "VPIRInstructions ";
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
       R.dump();
       errs() << " ";
-#endif
       errs() << "not in a VPIRBasicBlock!\n";
       return false;
     }
@@ -309,13 +299,11 @@ bool VPlanVerifier::verifyVPBasicBlock(const VPBasicBlock *VPBB) {
               continue;
 
             errs() << "Incoming def does not dominate incoming block!\n";
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
             VPSlotTracker Tracker(VPBB->getPlan());
             IncomingVPV->getDefiningRecipe()->print(errs(), "  ", Tracker);
             errs() << "\n  does not dominate " << IncomingVPBB->getName()
                    << " for\n";
             UI->print(errs(), "  ", Tracker);
-#endif
             return false;
           }
           continue;
@@ -335,13 +323,11 @@ bool VPlanVerifier::verifyVPBasicBlock(const VPBasicBlock *VPBB) {
         }
 
         errs() << "Use before def!\n";
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
         VPSlotTracker Tracker(VPBB->getPlan());
         UI->print(errs(), "  ", Tracker);
         errs() << "\n  before\n";
         R.print(errs(), "  ", Tracker);
         errs() << "\n";
-#endif
         return false;
       }
     }

--- a/llvm/unittests/Transforms/Vectorize/VPlanHCFGTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanHCFGTest.cpp
@@ -93,7 +93,6 @@ TEST_F(VPlanHCFGTest, testBuildHCFGInnerLoop) {
   EXPECT_EQ(2u, ICmp->getNumOperands());
   EXPECT_EQ(IndvarAdd, ICmp->getOperand(0));
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   // Add an external value to check we do not print the list of external values,
   // as this is not required with the new printing.
   Plan->getOrAddLiveIn(&*F->arg_begin());
@@ -168,7 +167,6 @@ compound=true
 }
 )";
   EXPECT_EQ(ExpectedStr, FullDump);
-#endif
 }
 
 TEST_F(VPlanHCFGTest, testVPInstructionToVPRecipesInner) {
@@ -262,7 +260,6 @@ TEST_F(VPlanHCFGTest, testBuildHCFGInnerLoopMultiExit) {
   BasicBlock *LoopHeader = F->getEntryBlock().getSingleSuccessor();
   auto Plan = buildVPlan(LoopHeader);
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   // Add an external value to check we do not print the list of external values,
   // as this is not required with the new printing.
   Plan->getOrAddLiveIn(&*F->arg_begin());
@@ -340,7 +337,6 @@ compound=true
 }
 )";
   EXPECT_EQ(ExpectedStr, FullDump);
-#endif
 }
 
 } // namespace

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -718,7 +718,6 @@ TEST_F(VPBasicBlockTest, splitAtEnd) {
   EXPECT_EQ(Split->getSingleSuccessor(), Plan.getScalarHeader());
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 TEST_F(VPBasicBlockTest, print) {
   VPlan &Plan = getPlan();
   IntegerType *Int32 = IntegerType::get(C, 32);
@@ -960,7 +959,6 @@ compound=true
   EXPECT_EQ(ExpectedStr, FullDump);
   delete Clone;
 }
-#endif
 
 using VPRecipeTest = VPlanTestBase;
 
@@ -1398,7 +1396,6 @@ TEST_F(VPRecipeTest, MayHaveSideEffectsAndMayReadWriteMemory) {
   }
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 TEST_F(VPRecipeTest, dumpRecipeInPlan) {
   VPlan &Plan = getPlan();
   VPBasicBlock *VPBB0 = Plan.getEntry();
@@ -1587,7 +1584,6 @@ TEST_F(VPRecipeTest, dumpRecipeUnnamedVPValuesNotInPlanOrBlock) {
   delete AI;
 }
 
-#endif
 
 TEST_F(VPRecipeTest, CastVPReductionRecipeToVPUser) {
   IntegerType *Int32 = IntegerType::get(C, 32);
@@ -1624,10 +1620,8 @@ struct VPDoubleValueDef : public VPRecipeBase {
   VPRecipeBase *clone() override { return nullptr; }
 
   void execute(struct VPTransformState &State) override {}
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void printRecipe(raw_ostream &O, const Twine &Indent,
                    VPSlotTracker &SlotTracker) const override {}
-#endif
 };
 
 namespace {

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1584,7 +1584,6 @@ TEST_F(VPRecipeTest, dumpRecipeUnnamedVPValuesNotInPlanOrBlock) {
   delete AI;
 }
 
-
 TEST_F(VPRecipeTest, CastVPReductionRecipeToVPUser) {
   IntegerType *Int32 = IntegerType::get(C, 32);
   VPValue *ChainOp = getPlan().getOrAddLiveIn(ConstantInt::get(Int32, 1));

--- a/llvm/unittests/Transforms/Vectorize/VPlanVerifierTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanVerifierTest.cpp
@@ -41,7 +41,6 @@ TEST_F(VPVerifierTest, VPInstructionUseBeforeDefSameBB) {
 #endif
   EXPECT_FALSE(verifyVPlanIsValid(Plan));
 #if GTEST_HAS_STREAM_REDIRECTION
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   EXPECT_STREQ("Use before def!\n"
                "  EMIT vp<%1> = sub vp<%2>, ir<0>\n"
                "  before\n"
@@ -50,7 +49,6 @@ TEST_F(VPVerifierTest, VPInstructionUseBeforeDefSameBB) {
 #else
   EXPECT_STREQ("Use before def!\n",
                ::testing::internal::GetCapturedStderr().c_str());
-#endif
 #endif
 }
 
@@ -80,7 +78,6 @@ TEST_F(VPVerifierTest, VPInstructionUseBeforeDefDifferentBB) {
 #endif
   EXPECT_FALSE(verifyVPlanIsValid(Plan));
 #if GTEST_HAS_STREAM_REDIRECTION
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   EXPECT_STREQ("Use before def!\n"
                "  EMIT vp<%1> = sub vp<%3>, ir<0>\n"
                "  before\n"
@@ -89,7 +86,6 @@ TEST_F(VPVerifierTest, VPInstructionUseBeforeDefDifferentBB) {
 #else
   EXPECT_STREQ("Use before def!\n",
                ::testing::internal::GetCapturedStderr().c_str());
-#endif
 #endif
 }
 
@@ -128,7 +124,6 @@ TEST_F(VPVerifierTest, VPBlendUseBeforeDefDifferentBB) {
 #endif
   EXPECT_FALSE(verifyVPlanIsValid(Plan));
 #if GTEST_HAS_STREAM_REDIRECTION
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   EXPECT_STREQ("Use before def!\n"
                "  BLEND ir<<badref>> = vp<%2>\n"
                "  before\n"
@@ -137,7 +132,6 @@ TEST_F(VPVerifierTest, VPBlendUseBeforeDefDifferentBB) {
 #else
   EXPECT_STREQ("Use before def!\n",
                ::testing::internal::GetCapturedStderr().c_str());
-#endif
 #endif
 
   delete Phi;
@@ -169,7 +163,6 @@ TEST_F(VPVerifierTest, VPPhiIncomingValueDoesntDominateIncomingBlock) {
 #endif
   EXPECT_FALSE(verifyVPlanIsValid(Plan));
 #if GTEST_HAS_STREAM_REDIRECTION
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   EXPECT_STREQ("Incoming def does not dominate incoming block!\n"
                "  EMIT vp<%2> = add ir<0>, ir<0>\n"
                "  does not dominate preheader for\n"
@@ -178,7 +171,6 @@ TEST_F(VPVerifierTest, VPPhiIncomingValueDoesntDominateIncomingBlock) {
 #else
   EXPECT_STREQ("Incoming def does not dominate incoming block!\n",
                ::testing::internal::GetCapturedStderr().c_str());
-#endif
 #endif
 }
 
@@ -311,14 +303,12 @@ TEST_F(VPVerifierTest, NonHeaderPHIInHeader) {
 #endif
   EXPECT_FALSE(verifyVPlanIsValid(Plan));
 #if GTEST_HAS_STREAM_REDIRECTION
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   EXPECT_STREQ(
       "Found non-header PHI recipe in header VPBB: IR   <badref> = phi i32 \n",
       ::testing::internal::GetCapturedStderr().c_str());
 #else
   EXPECT_STREQ("Found non-header PHI recipe in header VPBB",
                ::testing::internal::GetCapturedStderr().c_str());
-#endif
 #endif
 
   delete PHINode;

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -848,7 +848,6 @@ public:
 
 } // end anonymous namespace
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MatchableInfo::dump() const {
   errs() << TheDef->getName() << " -- "
          << "flattened:\"" << AsmString << "\"\n";
@@ -860,7 +859,6 @@ LLVM_DUMP_METHOD void MatchableInfo::dump() const {
     errs() << '\"' << Op.Token << "\"\n";
   }
 }
-#endif
 
 static std::pair<StringRef, StringRef>
 parseTwoOperandConstraint(StringRef S, ArrayRef<SMLoc> Loc) {

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -872,7 +872,6 @@ const TypeSetByHwMode &TypeInfer::getLegalTypes() const {
 
 TypeInfer::ValidateOnExit::~ValidateOnExit() {
   if (Infer.Validate && !VTS.validate()) {
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     errs() << "Type set is empty for each HW mode:\n"
               "possible type contradiction in the pattern below "
               "(use -print-records with llvm-tblgen to see all "
@@ -880,7 +879,6 @@ TypeInfer::ValidateOnExit::~ValidateOnExit() {
     Infer.TP.dump();
     errs() << "Generated from record:\n";
     Infer.TP.getRecord()->dump();
-#endif
     PrintFatalError(Infer.TP.getRecord()->getLoc(),
                     "Type set is empty for each HW mode in '" +
                         Infer.TP.getRecord()->getName() + "'");

--- a/llvm/utils/TableGen/Common/SubtargetFeatureInfo.cpp
+++ b/llvm/utils/TableGen/Common/SubtargetFeatureInfo.cpp
@@ -14,11 +14,9 @@
 
 using namespace llvm;
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SubtargetFeatureInfo::dump() const {
   errs() << getEnumName() << " " << Index << "\n" << *TheDef;
 }
-#endif
 
 SubtargetFeaturesInfoVec
 SubtargetFeatureInfo::getAll(const RecordKeeper &Records) {


### PR DESCRIPTION
Currently, the standard pattern for `dump()` functions looks something like this:

    void print(raw_ostream &) const;

    #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
    LLVM_DUMP_METHOD void dump() const {
      print(dbgs());
    }
    #endif

My understanding is that dump() functions are conditionally declared so that they are omitted in release builds, reducing code size. However, most of the core dump functions are implemented in terms of a print() function which is always defined. As the actual implementation is in there, the value of conditionally defining dump() is very dubious.

Having these conditional definitions makes it easy to write code that fails in release builds, adds ABI hazards and makes the implementation more noisy.

I don't think that this pattern really makes sense anymore. We should just always define dump() methods. Note that what `LLVM_DUMP_METHOD` does still depends on whether we use an assertion-enabled build (or `LLVM_ENABLE_DUMP` is defined):

 * If assertions/enable_dump are disabled, the method is not marked used/retain and can be optimized away (by LTO or gc-sections) if unused.
 * If assertions/enable_dump are enabled, the method is marked used/retain and will be kept (for use in interactive debuggers) even if unused.

I think that this behavior of the `LLVM_DUMP_METHOD` attribute is all we actually need.