### PR TITLE
[lldb] Unify thread detaching by making HostThreadPosix override Reset()

### DIFF
--- a/lldb/include/lldb/Host/posix/HostThreadPosix.h
+++ b/lldb/include/lldb/Host/posix/HostThreadPosix.h
@@ -25,7 +25,7 @@ public:
   Status Join(lldb::thread_result_t *result) override;
   Status Cancel() override;
 
-  Status Detach();
+  void Reset() override;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Host/posix/HostThreadPosix.cpp
+++ b/lldb/source/Host/posix/HostThreadPosix.cpp
@@ -50,12 +50,8 @@ Status HostThreadPosix::Cancel() {
   return error;
 }
 
-Status HostThreadPosix::Detach() {
-  Status error;
-  if (IsJoinable()) {
-    int err = ::pthread_detach(m_thread);
-    error = Status(err, eErrorTypePOSIX);
-  }
-  Reset();
-  return error;
+void HostThreadPosix::Reset() {
+  if (IsJoinable())
+    ::pthread_detach(m_thread);
+  HostNativeThreadBase::Reset();
 }


### PR DESCRIPTION
Remove the Detach() method from HostThreadPosix and instead override the virtual Reset() function from HostNativeThreadBase, following the pattern already used by HostThreadWindows. This provides a consistent interface for platform-specific thread cleanup on all platforms.

The HostThreadPosix::Reset() implementation first calls pthread_detach() before delegating to the base implementation HostNativeThreadBase::Reset(), similar to how HostThreadWindows calls CloseHandle() in its Reset() override.

This is a preparatory refactoring for https://github.com/llvm/llvm-project/pull/177572, which addresses memory leakage in lldb-server. By unifying the logic of detaching, it would be possible to introduce the behavioral change in a more straightforward manner.