### PR TITLE
[RISCV][llvm] Support INSERT_VECTOR_ELT codegen for P extension

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -570,7 +570,8 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
     setOperationAction(ISD::SCALAR_TO_VECTOR, VTs, Legal);
     setOperationAction({ISD::SHL, ISD::SRL, ISD::SRA}, VTs, Custom);
     setOperationAction(ISD::BITCAST, VTs, Custom);
-    setOperationAction(ISD::EXTRACT_VECTOR_ELT, VTs, Custom);
+    setOperationAction({ISD::EXTRACT_VECTOR_ELT, ISD::INSERT_VECTOR_ELT}, VTs,
+                       Custom);
     setOperationAction({ISD::SMIN, ISD::UMIN, ISD::SMAX, ISD::UMAX}, VTs,
                        Legal);
     setOperationAction(ISD::SELECT, VTs, Custom);
@@ -10686,6 +10687,52 @@ SDValue RISCVTargetLowering::lowerINSERT_VECTOR_ELT(SDValue Op,
         ISD::INSERT_VECTOR_ELT, DL, IntVT, DAG.getBitcast(IntVT, Vec),
         DAG.getNode(RISCVISD::FMV_X_ANYEXTH, DL, XLenVT, Val), Idx);
     return DAG.getBitcast(VecVT, IntInsert);
+  }
+
+  if (Subtarget.enablePExtSIMDCodeGen() && VecVT.isFixedLengthVector()) {
+    auto *IdxC = dyn_cast<ConstantSDNode>(Idx);
+    if (!IdxC)
+      return SDValue();
+
+    unsigned IdxVal = IdxC->getZExtValue();
+    unsigned NumElts = VecVT.getVectorNumElements();
+    MVT EltVT = VecVT.getVectorElementType();
+    Vec = DAG.getBitcast(XLenVT, Vec);
+    SDValue ExtVal = DAG.getNode(ISD::ANY_EXTEND, DL, XLenVT, Val);
+
+    // For 2-element vectors, BUILD_VECTOR is more efficient since it only needs
+    // at most 2 instructions.
+    if (NumElts == 2) {
+      unsigned EltBits = EltVT.getSizeInBits();
+      SDValue Elt0, Elt1;
+      if (IdxVal == 0) {
+        Elt0 = ExtVal;
+        Elt1 = DAG.getNode(ISD::SRL, DL, XLenVT, Vec,
+                           DAG.getConstant(EltBits, DL, XLenVT));
+      } else {
+        Elt0 = Vec;
+        Elt1 = ExtVal;
+      }
+      return DAG.getNode(ISD::BUILD_VECTOR, DL, VecVT, Elt0, Elt1);
+    }
+
+    // For 4/8-element vectors, use MVM(or MERGE) instruction which does bitwise
+    // select: rd = (~mask & rd) | (mask & rs1).
+    // This generates: slli + lui/li + mvm
+    if (NumElts == 4 || NumElts == 8) {
+      unsigned EltBits = EltVT.getSizeInBits();
+      unsigned ShiftAmt = IdxVal * EltBits;
+      uint64_t PosMask = ((1ULL << EltBits) - 1) << ShiftAmt;
+
+      SDValue ShiftedVal = DAG.getNode(ISD::SHL, DL, XLenVT, ExtVal,
+                                       DAG.getConstant(ShiftAmt, DL, XLenVT));
+      SDValue Mask = DAG.getConstant(PosMask, DL, XLenVT);
+      SDValue Result =
+          DAG.getNode(RISCVISD::MVM, DL, XLenVT, Vec, ShiftedVal, Mask);
+      return DAG.getBitcast(VecVT, Result);
+    }
+
+    return SDValue();
   }
 
   MVT ContainerVT = VecVT;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1486,6 +1486,12 @@ def riscv_pmulhr : RVSDNode<"PMULHR", SDT_RISCVPBinOp>;
 def riscv_pmulhru : RVSDNode<"PMULHRU", SDT_RISCVPBinOp>;
 def riscv_pmulhrsu : RVSDNode<"PMULHRSU", SDT_RISCVPBinOp>;
 
+def SDT_RISCVMVM : SDTypeProfile<1, 3, [SDTCisInt<0>,
+                                        SDTCisSameAs<0, 1>,
+                                        SDTCisSameAs<0, 2>,
+                                        SDTCisSameAs<0, 3>]>;
+def riscv_mvm : RVSDNode<"MVM", SDT_RISCVMVM>;
+
 let Predicates = [HasStdExtP] in {
   def : PatGpr<abs, ABS>;
   def : PatGpr<ctls, CLS>;
@@ -1494,6 +1500,10 @@ let Predicates = [HasStdExtP] in {
             (SLX GPR:$rd, GPR:$rs1, shiftMaskXLen:$rs2)>;
   def : Pat<(XLenVT (fshr GPR:$rs1, GPR:$rd, shiftMaskXLen:$rs2)),
             (SRX GPR:$rd, GPR:$rs1, shiftMaskXLen:$rs2)>;
+
+  // Pattern for insert_vector_elt
+  def : Pat<(XLenVT (riscv_mvm GPR:$rd, GPR:$rs1, GPR:$rs2)),
+            (MVM GPR:$rd, GPR:$rs1, GPR:$rs2)>;
 
   // Basic 8-bit arithmetic patterns
   def: Pat<(XLenVecI8VT (add GPR:$rs1, GPR:$rs2)), (PADD_B GPR:$rs1, GPR:$rs2)>;

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv32.ll
@@ -488,6 +488,76 @@ define i8 @test_extract_vector_8_elem1(<4 x i8> %a) {
   ret i8 %extracted
 }
 
+define <2 x i16> @test_insert_vector_16(<2 x i16> %a, i16 %val) {
+; CHECK-RV32-LABEL: test_insert_vector_16:
+; CHECK-RV32:       # %bb.0:
+; CHECK-RV32-NEXT:    srli a0, a0, 16
+; CHECK-RV32-NEXT:    pack a0, a1, a0
+; CHECK-RV32-NEXT:    ret
+;
+; CHECK-RV64-LABEL: test_insert_vector_16:
+; CHECK-RV64:       # %bb.0:
+; CHECK-RV64-NEXT:    srli a0, a0, 16
+; CHECK-RV64-NEXT:    ppaire.h a0, a1, a0
+; CHECK-RV64-NEXT:    ret
+  %res = insertelement <2 x i16> %a, i16 %val, i32 0
+  ret <2 x i16> %res
+}
+
+define <2 x i16> @test_insert_vector_16_elem1(<2 x i16> %a, i16 %val) {
+; CHECK-RV32-LABEL: test_insert_vector_16_elem1:
+; CHECK-RV32:       # %bb.0:
+; CHECK-RV32-NEXT:    pack a0, a0, a1
+; CHECK-RV32-NEXT:    ret
+;
+; CHECK-RV64-LABEL: test_insert_vector_16_elem1:
+; CHECK-RV64:       # %bb.0:
+; CHECK-RV64-NEXT:    ppaire.h a0, a0, a1
+; CHECK-RV64-NEXT:    ret
+  %res = insertelement <2 x i16> %a, i16 %val, i32 1
+  ret <2 x i16> %res
+}
+
+define <4 x i8> @test_insert_vector_8(<4 x i8> %a, i8 %val) {
+; CHECK-RV32-LABEL: test_insert_vector_8:
+; CHECK-RV32:       # %bb.0:
+; CHECK-RV32-NEXT:    li a2, 255
+; CHECK-RV32-NEXT:    mvm a0, a1, a2
+; CHECK-RV32-NEXT:    ret
+;
+; CHECK-RV64-LABEL: test_insert_vector_8:
+; CHECK-RV64:       # %bb.0:
+; CHECK-RV64-NEXT:    srli a2, a0, 8
+; CHECK-RV64-NEXT:    srli a3, a0, 24
+; CHECK-RV64-NEXT:    srli a0, a0, 16
+; CHECK-RV64-NEXT:    ppaire.b a0, a0, a3
+; CHECK-RV64-NEXT:    ppaire.b a1, a1, a2
+; CHECK-RV64-NEXT:    ppaire.h a0, a1, a0
+; CHECK-RV64-NEXT:    ret
+  %res = insertelement <4 x i8> %a, i8 %val, i32 0
+  ret <4 x i8> %res
+}
+
+define <4 x i8> @test_insert_vector_8_elem2(<4 x i8> %a, i8 %val) {
+; CHECK-RV32-LABEL: test_insert_vector_8_elem2:
+; CHECK-RV32:       # %bb.0:
+; CHECK-RV32-NEXT:    slli a1, a1, 16
+; CHECK-RV32-NEXT:    lui a2, 4080
+; CHECK-RV32-NEXT:    mvm a0, a1, a2
+; CHECK-RV32-NEXT:    ret
+;
+; CHECK-RV64-LABEL: test_insert_vector_8_elem2:
+; CHECK-RV64:       # %bb.0:
+; CHECK-RV64-NEXT:    srli a2, a0, 8
+; CHECK-RV64-NEXT:    srli a3, a0, 24
+; CHECK-RV64-NEXT:    ppaire.b a1, a1, a3
+; CHECK-RV64-NEXT:    ppaire.b a0, a0, a2
+; CHECK-RV64-NEXT:    ppaire.h a0, a0, a1
+; CHECK-RV64-NEXT:    ret
+  %res = insertelement <4 x i8> %a, i8 %val, i32 2
+  ret <4 x i8> %res
+}
+
 ; Test for splat
 define <4 x i8> @test_non_const_splat_i8(i8 %elt) {
 ; CHECK-LABEL: test_non_const_splat_i8:
@@ -1629,10 +1699,10 @@ define <2 x i16> @test_select_v2i16(i1 %cond, <2 x i16> %a, <2 x i16> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB115_2
+; CHECK-NEXT:    bnez a3, .LBB119_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB115_2:
+; CHECK-NEXT:  .LBB119_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <2 x i16> %a, <2 x i16> %b
   ret <2 x i16> %res
@@ -1643,10 +1713,10 @@ define <4 x i8> @test_select_v4i8(i1 %cond, <4 x i8> %a, <4 x i8> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB116_2
+; CHECK-NEXT:    bnez a3, .LBB120_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB116_2:
+; CHECK-NEXT:  .LBB120_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <4 x i8> %a, <4 x i8> %b
   ret <4 x i8> %res

--- a/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-ext-rv64.ll
@@ -545,6 +545,70 @@ define i32 @test_extract_vector_32_elem1(<2 x i32> %a) {
   ret i32 %extracted
 }
 
+define <4 x i16> @test_insert_vector_16(<4 x i16> %a, i16 %val) {
+; CHECK-LABEL: test_insert_vector_16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a2, 16
+; CHECK-NEXT:    addi a2, a2, -1
+; CHECK-NEXT:    mvm a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = insertelement <4 x i16> %a, i16 %val, i32 0
+  ret <4 x i16> %res
+}
+
+define <4 x i16> @test_insert_vector_16_elem2(<4 x i16> %a, i16 %val) {
+; CHECK-LABEL: test_insert_vector_16_elem2:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a1, a1, 32
+; CHECK-NEXT:    lui a2, 65535
+; CHECK-NEXT:    slli a2, a2, 20
+; CHECK-NEXT:    mvm a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = insertelement <4 x i16> %a, i16 %val, i32 2
+  ret <4 x i16> %res
+}
+
+define <8 x i8> @test_insert_vector_8(<8 x i8> %a, i8 %val) {
+; CHECK-LABEL: test_insert_vector_8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    li a2, 255
+; CHECK-NEXT:    mvm a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = insertelement <8 x i8> %a, i8 %val, i32 0
+  ret <8 x i8> %res
+}
+
+define <8 x i8> @test_insert_vector_8_elem3(<8 x i8> %a, i8 %val) {
+; CHECK-LABEL: test_insert_vector_8_elem3:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a1, a1, 24
+; CHECK-NEXT:    li a2, 255
+; CHECK-NEXT:    slli a2, a2, 24
+; CHECK-NEXT:    mvm a0, a1, a2
+; CHECK-NEXT:    ret
+  %res = insertelement <8 x i8> %a, i8 %val, i32 3
+  ret <8 x i8> %res
+}
+
+define <2 x i32> @test_insert_vector_32(<2 x i32> %a, i32 %val) {
+; CHECK-LABEL: test_insert_vector_32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    srli a0, a0, 32
+; CHECK-NEXT:    pack a0, a1, a0
+; CHECK-NEXT:    ret
+  %res = insertelement <2 x i32> %a, i32 %val, i32 0
+  ret <2 x i32> %res
+}
+
+define <2 x i32> @test_insert_vector_32_elem1(<2 x i32> %a, i32 %val) {
+; CHECK-LABEL: test_insert_vector_32_elem1:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pack a0, a0, a1
+; CHECK-NEXT:    ret
+  %res = insertelement <2 x i32> %a, i32 %val, i32 1
+  ret <2 x i32> %res
+}
+
 ; Test basic add/sub operations for v2i32 (RV64 only)
 define <2 x i32> @test_padd_w(<2 x i32> %a, <2 x i32> %b) {
 ; CHECK-LABEL: test_padd_w:
@@ -1941,10 +2005,10 @@ define <4 x i16> @test_select_v4i16(i1 %cond, <4 x i16> %a, <4 x i16> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB155_2
+; CHECK-NEXT:    bnez a3, .LBB161_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB155_2:
+; CHECK-NEXT:  .LBB161_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <4 x i16> %a, <4 x i16> %b
   ret <4 x i16> %res
@@ -1955,10 +2019,10 @@ define <8 x i8> @test_select_v8i8(i1 %cond, <8 x i8> %a, <8 x i8> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB156_2
+; CHECK-NEXT:    bnez a3, .LBB162_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB156_2:
+; CHECK-NEXT:  .LBB162_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <8 x i8> %a, <8 x i8> %b
   ret <8 x i8> %res
@@ -1969,10 +2033,10 @@ define <2 x i32> @test_select_v2i32(i1 %cond, <2 x i32> %a, <2 x i32> %b) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    andi a3, a0, 1
 ; CHECK-NEXT:    mv a0, a1
-; CHECK-NEXT:    bnez a3, .LBB157_2
+; CHECK-NEXT:    bnez a3, .LBB163_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    mv a0, a2
-; CHECK-NEXT:  .LBB157_2:
+; CHECK-NEXT:  .LBB163_2:
 ; CHECK-NEXT:    ret
   %res = select i1 %cond, <2 x i32> %a, <2 x i32> %b
   ret <2 x i32> %res


### PR DESCRIPTION
Add custom lowering for INSERT_VECTOR_ELT on P extension vector types
using the MVM instruction.

TODO: Handle <4 x i8> on RV64 which is constructed to extract_vector_elt
+ build_vector instead of insert_vector_elt.
