### PR TITLE
[BOLT][NFC] Stop populating unnecessary samples into MemSamples

### DIFF
--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -1729,10 +1729,10 @@ std::error_code DataAggregator::parseMemEvents() {
     if (std::error_code EC = Sample.getError())
       return EC;
 
-    if (BinaryFunction *BF = getBinaryFunctionContainingAddress(Sample->PC))
+    if (BinaryFunction *BF = getBinaryFunctionContainingAddress(Sample->PC)) {
       BF->setHasProfileAvailable();
-
-    MemSamples.emplace_back(std::move(Sample.get()));
+      MemSamples.emplace_back(std::move(Sample.get()));
+    }
   }
 
   return std::error_code();


### PR DESCRIPTION
Currently, many unnecessary samples are populated into MemSamples, including zero-initialized samples and samples in which the PC address is not contained in any BinaryFunction. But these samples are totally skipped during processing and the whole MemSamples vector is cleared immediately after processing. So, we could just stop populating these samples into MemSamples, which would reduce maximum resident set size when processing a large perf.data.