### PR TITLE
[SPIRV] selectDot4AddPacked: add missing PackedVectorFormat4x8Bit optional operand

### DIFF
--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/dot4add_i8packed.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/dot4add_i8packed.ll
@@ -25,7 +25,7 @@ entry:
 
 ; Test that we use the dot product op when capabilities allow
 
-; CHECK-DOT: %[[#DOT:]] = OpSDot %[[#int_32]] %[[#X]] %[[#Y]]
+; CHECK-DOT: %[[#DOT:]] = OpSDot %[[#int_32]] %[[#X]] %[[#Y]] PackedVectorFormat4x8Bit
 ; CHECK-DOT: %[[#RES:]] = OpIAdd %[[#int_32]] %[[#DOT]] %[[#ACC]]
 
 ; Test expansion is used when spirv dot product capabilities aren't available:

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/dot4add_u8packed.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/dot4add_u8packed.ll
@@ -25,7 +25,7 @@ entry:
 
 ; Test that we use the dot product op when capabilities allow
 
-; CHECK-DOT: %[[#DOT:]] = OpUDot %[[#int_32]] %[[#X]] %[[#Y]]
+; CHECK-DOT: %[[#DOT:]] = OpUDot %[[#int_32]] %[[#X]] %[[#Y]] PackedVectorFormat4x8Bit
 ; CHECK-DOT: %[[#RES:]] = OpIAdd %[[#int_32]] %[[#DOT]] %[[#ACC]]
 
 ; Test expansion is used when spirv dot product capabilities aren't available:


### PR DESCRIPTION
According to SPIRV:

```
PackedVectorFormat4x8Bit (PackedVectorFormat4x8BitKHR)

Interpret 32-bit scalar integer operands as vectors of four 8-bit
components. Vector components follow byte significance order with the
lowest-numbered component stored in the least significant byte.
```

And in OpSDot / OpUDot:

```
When Vector 1 and Vector 2 are scalar integer types, Packed Vector
Format must be specified to select how the integers are to be
interpreted as vectors.
```