### PR TITLE
[bolt] Use --reorder-functions option directly

### DIFF
--- a/bolt/include/bolt/Passes/ReorderFunctions.h
+++ b/bolt/include/bolt/Passes/ReorderFunctions.h
@@ -21,7 +21,7 @@ class ReorderFunctions : public BinaryFunctionPass {
   BinaryFunctionCallGraph Cg;
 
   void reorder(BinaryContext &BC, std::vector<Cluster> &&Clusters,
-               std::map<uint64_t, BinaryFunction> &BFs);
+               BinaryFunctionListType &BFs);
 
   void printStats(BinaryContext &BC, const std::vector<Cluster> &Clusters,
                   const std::vector<uint64_t> &FuncAddr);

--- a/bolt/lib/Passes/BinaryPasses.cpp
+++ b/bolt/lib/Passes/BinaryPasses.cpp
@@ -398,7 +398,8 @@ bool ReorderBasicBlocks::shouldPrint(const BinaryFunction &BF) const {
 
 bool ReorderBasicBlocks::shouldOptimize(const BinaryFunction &BF) const {
   // Apply execution count threshold
-  if (BF.getKnownExecutionCount() < opts::ExecutionCountThreshold)
+  if (BF.getKnownExecutionCount() < opts::ExecutionCountThreshold ||
+      BF.isPLTFunction())
     return false;
 
   return BinaryFunctionPass::shouldOptimize(BF);

--- a/bolt/lib/Passes/BinaryPasses.cpp
+++ b/bolt/lib/Passes/BinaryPasses.cpp
@@ -2072,7 +2072,7 @@ Error RemoveNops::runOnFunctions(BinaryContext &BC) {
   };
 
   ParallelUtilities::PredicateTy SkipFunc = [&](const BinaryFunction &BF) {
-    return BF.shouldPreserveNops();
+    return BF.shouldPreserveNops() || !BinaryFunctionPass::shouldOptimize(BF);
   };
 
   ParallelUtilities::runOnEachFunction(

--- a/bolt/lib/Passes/BinaryPasses.cpp
+++ b/bolt/lib/Passes/BinaryPasses.cpp
@@ -2072,7 +2072,7 @@ Error RemoveNops::runOnFunctions(BinaryContext &BC) {
   };
 
   ParallelUtilities::PredicateTy SkipFunc = [&](const BinaryFunction &BF) {
-    return BF.shouldPreserveNops() || !BinaryFunctionPass::shouldOptimize(BF);
+    return BF.shouldPreserveNops() || BF.isPLTFunction();
   };
 
   ParallelUtilities::runOnEachFunction(

--- a/bolt/lib/Passes/ReorderFunctions.cpp
+++ b/bolt/lib/Passes/ReorderFunctions.cpp
@@ -117,7 +117,7 @@ using Node = CallGraph::Node;
 
 void ReorderFunctions::reorder(BinaryContext &BC,
                                std::vector<Cluster> &&Clusters,
-                               std::map<uint64_t, BinaryFunction> &BFs) {
+                               BinaryFunctionListType &BFs) {
   std::vector<uint64_t> FuncAddr(Cg.numNodes()); // Just for computing stats
   uint64_t TotalSize = 0;
   uint32_t Index = 0;
@@ -132,10 +132,9 @@ void ReorderFunctions::reorder(BinaryContext &BC,
   }
 
   // Assign valid index for functions with valid profile.
-  for (auto &It : BFs) {
-    BinaryFunction &BF = It.second;
-    if (!BF.hasValidIndex() && BF.hasValidProfile())
-      BF.setIndex(Index++);
+  for (BinaryFunction *BF : BFs) {
+    if (!BF->hasValidIndex() && BF->hasValidProfile())
+      BF->setIndex(Index++);
   }
 
   if (opts::ReorderFunctions == RT_NONE)
@@ -273,7 +272,12 @@ Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
   if (opts::ReorderFunctions == RT_NONE)
     return Error::success();
 
-  auto &BFs = BC.getBinaryFunctions();
+  BinaryFunctionListType BFs;
+  BFs.reserve(BC.getBinaryFunctions().size());
+  llvm::transform(llvm::make_second_range(BC.getBinaryFunctions()),
+                  std::back_inserter(BFs),
+                  [](BinaryFunction &BF) { return &BF; });
+  llvm::erase_if(BFs, [](BinaryFunction *BF) { return BF->isPLTFunction(); });
   if (opts::ReorderFunctions != RT_NONE &&
       opts::ReorderFunctions != RT_EXEC_COUNT &&
       opts::ReorderFunctions != RT_USER) {
@@ -283,6 +287,8 @@ Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
           if (!BF.hasProfile())
             return true;
           if (BF.getState() != BinaryFunction::State::CFG)
+            return true;
+          if (BF.isPLTFunction())
             return true;
           return false;
         },
@@ -299,9 +305,7 @@ Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
   case RT_NONE:
     break;
   case RT_EXEC_COUNT: {
-    BinaryFunctionListType SortedFunctions(BFs.size());
-    llvm::transform(llvm::make_second_range(BFs), SortedFunctions.begin(),
-                    [](BinaryFunction &BF) { return &BF; });
+    BinaryFunctionListType SortedFunctions = BFs;
     llvm::stable_sort(SortedFunctions,
                       [&](const BinaryFunction *A, const BinaryFunction *B) {
                         if (A->isIgnored())
@@ -376,10 +380,10 @@ Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
   case RT_USER: {
     // Build LTOCommonNameMap
     StringMap<std::vector<uint64_t>> LTOCommonNameMap;
-    for (const BinaryFunction &BF : llvm::make_second_range(BFs))
-      for (StringRef Name : BF.getNames())
+    for (const BinaryFunction *BF : BFs)
+      for (StringRef Name : BF->getNames())
         if (std::optional<StringRef> LTOCommonName = getLTOCommonName(Name))
-          LTOCommonNameMap[*LTOCommonName].push_back(BF.getAddress());
+          LTOCommonNameMap[*LTOCommonName].push_back(BF->getAddress());
 
     uint32_t Index = 0;
     uint32_t InvalidEntries = 0;
@@ -474,9 +478,7 @@ Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
   }
 
   if (FuncsFile || LinkSectionsFile) {
-    BinaryFunctionListType SortedFunctions(BFs.size());
-    llvm::transform(llvm::make_second_range(BFs), SortedFunctions.begin(),
-                    [](BinaryFunction &BF) { return &BF; });
+    BinaryFunctionListType SortedFunctions = BFs;
 
     // Sort functions by index.
     llvm::stable_sort(SortedFunctions, compareBinaryFunctionByIndex);

--- a/bolt/lib/Passes/ReorderFunctions.cpp
+++ b/bolt/lib/Passes/ReorderFunctions.cpp
@@ -270,6 +270,9 @@ Error ReorderFunctions::readFunctionOrderFile(
 }
 
 Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
+  if (opts::ReorderFunctions == RT_NONE)
+    return Error::success();
+
   auto &BFs = BC.getBinaryFunctions();
   if (opts::ReorderFunctions != RT_NONE &&
       opts::ReorderFunctions != RT_EXEC_COUNT &&

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -3335,6 +3335,8 @@ void RewriteInstance::selectFunctionsToProcess() {
     std::vector<const BinaryFunction *> TopFunctions;
     for (auto &BFI : BC->getBinaryFunctions()) {
       const BinaryFunction &Function = BFI.second;
+      if (Function.isPLTFunction())
+        continue;
       if (ProfileReader->mayHaveProfileData(Function))
         TopFunctions.push_back(&Function);
     }
@@ -3465,7 +3467,7 @@ void RewriteInstance::selectFunctionsToProcess() {
   // - if the parent is processed, process the fragment(s) as well.
   for (auto &BFI : BC->getBinaryFunctions()) {
     BinaryFunction &Function = BFI.second;
-    if (!Function.isFragment())
+    if (!Function.isFragment() || Function.isPLTFunction())
       continue;
     if (mustSkip(Function)) {
       for (BinaryFunction *Parent : Function.ParentFragments) {

--- a/bolt/test/AArch64/compact-code-model.s
+++ b/bolt/test/AArch64/compact-code-model.s
@@ -8,7 +8,7 @@
 # RUN: llvm-strip --strip-unneeded %t.o
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -static
 # RUN: llvm-bolt %t.exe -o %t.bolt --data %t.fdata --split-functions \
-# RUN:   --keep-nops --compact-code-model
+# RUN:   --keep-nops --compact-code-model --reorder-functions=cdsort
 # RUN: llvm-objdump -d \
 # RUN:   --disassemble-symbols=_start,_start.cold.0,foo,foo.cold.0 %t.bolt \
 # RUN:   | FileCheck %s

--- a/bolt/test/AArch64/lite-mode.s
+++ b/bolt/test/AArch64/lite-mode.s
@@ -8,9 +8,10 @@
 # RUN: llvm-strip --strip-unneeded %t*.o
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -static
 # RUN: %clang %cflags %t.compact.o -o %t.compact.exe -Wl,-q -static
-# RUN: llvm-bolt %t.exe -o %t.bolt --data %t.fdata --lite
+# RUN: llvm-bolt %t.exe -o %t.bolt --data %t.fdata --lite \
+# RUN:   --reorder-functions=exec-count
 # RUN: llvm-bolt %t.compact.exe -o %t.compact.bolt --data %t.fdata --lite \
-# RUN:   --compact-code-model
+# RUN:   --compact-code-model --reorder-functions=exec-count
 # RUN: llvm-objdump -d --disassemble-symbols=cold_function %t.exe \
 # RUN:   | FileCheck %s --check-prefix=CHECK-INPUT
 # RUN: llvm-objdump -d --disassemble-symbols=cold_function %t.bolt \

--- a/bolt/test/X86/bb-with-two-tail-calls.s
+++ b/bolt/test/X86/bb-with-two-tail-calls.s
@@ -7,6 +7,7 @@
 # RUN: llvm-strip --strip-unneeded %t.o
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -nostdlib
 # RUN: llvm-bolt %t.exe -o %t.out --data %t.fdata --lite=0 --dyno-stats \
+# RUN:    --reorder-functions=cdsort \
 # RUN:    --print-sctc --print-only=_start -enable-bat 2>&1 | FileCheck %s
 # RUN: llvm-objdump --syms %t.out > %t.log
 # RUN: llvm-bat-dump %t.out --dump-all >> %t.log

--- a/bolt/test/X86/cdsplit-call-scale.s
+++ b/bolt/test/X86/cdsplit-call-scale.s
@@ -15,10 +15,12 @@
 # RUN:         --data=%t.fdata --reorder-blocks=ext-tsp \
 # RUN:     2>&1 | FileCheck --check-prefix=LOWINCENTIVE %s
 # RUN: llvm-bolt %t.exe -o %t.bolt --split-functions --split-strategy=cdsplit \
+# RUN:         --reorder-functions=exec-count \
 # RUN:         --call-scale=1.0 --print-split --print-only=chain \
 # RUN:         --data=%t.fdata --reorder-blocks=ext-tsp \
 # RUN:     2>&1 | FileCheck --check-prefix=MEDINCENTIVE %s
 # RUN: llvm-bolt %t.exe -o %t.bolt --split-functions --split-strategy=cdsplit \
+# RUN:         --reorder-functions=exec-count \
 # RUN:         --call-scale=1000.0 --print-split --print-only=chain \
 # RUN:         --data=%t.fdata --reorder-blocks=ext-tsp \
 # RUN:     2>&1 | FileCheck --check-prefix=HIGHINCENTIVE %s

--- a/bolt/test/X86/cdsplit-symbol-names.s
+++ b/bolt/test/X86/cdsplit-symbol-names.s
@@ -7,6 +7,7 @@
 # RUN: llvm-strip --strip-unneeded %t.o
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q
 # RUN: llvm-bolt %t.exe -o %t.bolt --split-functions --split-strategy=cdsplit \
+# RUN:         --reorder-functions=exec-count \
 # RUN:         --call-scale=2 --data=%t.fdata --reorder-blocks=ext-tsp
 # RUN: llvm-objdump --syms %t.bolt | FileCheck %s --check-prefix=CHECK-SYMS-WARM
 

--- a/bolt/test/X86/pie-eh-split-undo.s
+++ b/bolt/test/X86/pie-eh-split-undo.s
@@ -6,6 +6,7 @@
 # RUN: ld.lld --pie %t.o -o %t.exe -q
 # RUN: llvm-bolt %t.exe -o %t.out --data %t.fdata --split-functions --split-eh \
 # RUN:   --split-all-cold --print-after-lowering  --print-only=_start 2>&1 \
+# RUN:   --reorder-functions=exec-count \
 # RUN:   | FileCheck %s
 
 ## _start has two landing pads: one hot and one cold. Hence, BOLT will introduce

--- a/bolt/test/X86/register-fragments-bolt-symbols.s
+++ b/bolt/test/X86/register-fragments-bolt-symbols.s
@@ -8,6 +8,7 @@
 ## Check warm fragment name matching (produced by cdsplit)
 # RUN: %clang %cflags %t.main.o -o %t.warm.exe -Wl,-q
 # RUN: llvm-bolt %t.warm.exe -o %t.warm.bolt --split-functions --split-strategy=cdsplit \
+# RUN:   --reorder-functions=exec-count \
 # RUN:   --call-scale=2 --data=%t.fdata --reorder-blocks=ext-tsp --enable-bat
 # RUN: link_fdata %s %t.warm.bolt %t.preagg.warm PREAGGWARM
 # PREAGGWARM: B X:0 #chain.warm# 1 0
@@ -24,7 +25,8 @@
 # RUN: llvm-objcopy --localize-symbol=chain %t.main.o
 # RUN: %clang %cflags %t.chain.o %t.main.o -o %t.exe -Wl,-q
 # RUN: llvm-bolt %t.exe -o %t.bolt --split-functions --split-strategy=randomN \
-# RUN:   --reorder-blocks=ext-tsp --enable-bat --bolt-seed=7 --data=%t.fdata
+# RUN:   --reorder-blocks=ext-tsp --enable-bat --bolt-seed=7 --data=%t.fdata \
+# RUN:   --reorder-functions=exec-count
 # RUN: llvm-objdump --syms %t.bolt | FileCheck %s --check-prefix=CHECK-SYMS
 
 # RUN: link_fdata %s %t.bolt %t.preagg PREAGG

--- a/bolt/test/X86/yaml-secondary-entry-discriminator.s
+++ b/bolt/test/X86/yaml-secondary-entry-discriminator.s
@@ -36,7 +36,8 @@
 ## YAML BAT test of calling BAT secondary entry from non-BAT function
 ## Now force-split func and skip main (making it call secondary entries)
 # RUN: llvm-bolt %t.exe -o %t.bat --data %t.fdata --funcs=func \
-# RUN:   --split-functions --split-strategy=all --split-all-cold --enable-bat
+# RUN:   --split-functions --split-strategy=all --split-all-cold --enable-bat \
+# RUN:   --reorder-functions=exec-count
 
 ## Prepare pre-aggregated profile using %t.bat
 # RUN: link_fdata %s %t.bat %t.preagg PREAGG
@@ -57,7 +58,8 @@
 
 ## YAML BAT test of calling BAT secondary entry from BAT function
 # RUN: llvm-bolt %t.exe -o %t.bat2 --data %t.fdata --funcs=main,func \
-# RUN:   --split-functions --split-strategy=all --split-all-cold --enable-bat
+# RUN:   --split-functions --split-strategy=all --split-all-cold --enable-bat \
+# RUN:   --reorder-functions=exec-count
 
 ## Prepare pre-aggregated profile using %t.bat
 # RUN: link_fdata %s %t.bat2 %t.preagg2 PREAGG2

--- a/bolt/test/code-at-high-address.c
+++ b/bolt/test/code-at-high-address.c
@@ -8,6 +8,7 @@
 // RUN: link_fdata %s %t %t.fdata
 // RUN: llvm-bolt %t -o %t.bolt --data %t.fdata --use-old-text \
 // RUN:   --align-functions=1 --no-huge-pages --align-text=1 --use-gnu-stack \
+// RUN:   --reorder-functions=cdsort \
 // RUN:    --hot-functions-at-end | FileCheck %s --check-prefix=CHECK-BOLT
 // RUN: llvm-readelf --sections %t.bolt | FileCheck %s
 


### PR DESCRIPTION
I am going to add disassemble functionality for .plt section, but before that need to exclude the plt binary function from specific optimization like (reorder functions or split functions or reorder basic blocks). Disassembled functions from .plt section can be used for BTI patching, also further can be updated and emitted to new execution segment.