### PR TITLE
[SPARC][IAS] Add lzd alias for lzcnt

### DIFF
--- a/llvm/lib/Target/Sparc/SparcInstrAliases.td
+++ b/llvm/lib/Target/Sparc/SparcInstrAliases.td
@@ -756,6 +756,8 @@ def : MnemonicAlias<"addccc", "addxcc">, Requires<[HasV9]>;
 def : MnemonicAlias<"subc", "subx">, Requires<[HasV9]>;
 def : MnemonicAlias<"subccc", "subxcc">, Requires<[HasV9]>;
 
+def : MnemonicAlias<"lzd", "lzcnt">;
+
 // Solaris Natural Instructions extension
 // We match GCC's coverage of the extension; everything except setn & setnhi.
 // See also: https://docs.oracle.com/cd/E53394_01/html/E54833/gmael.html

--- a/llvm/test/MC/Sparc/sparc-vis3.s
+++ b/llvm/test/MC/Sparc/sparc-vis3.s
@@ -101,6 +101,9 @@ fsra32 %f0, %f2, %f4
 ! NO-VIS3: error: instruction requires a CPU feature not currently enabled
 ! VIS3: lzcnt %o0, %o1                          ! encoding: [0x93,0xb0,0x02,0xe8]
 lzcnt %o0, %o1
+! NO-VIS3: error: instruction requires a CPU feature not currently enabled
+! VIS3: lzcnt %o0, %o1                          ! encoding: [0x93,0xb0,0x02,0xe8]
+lzd %o0, %o1
 
 ! NO-VIS3: error: instruction requires a CPU feature not currently enabled
 ! VIS3: movstosw %f0, %o0                       ! encoding: [0x91,0xb0,0x22,0x60]


### PR DESCRIPTION
This is used in e.g GMP assembly code.