### PR TITLE
[SPIRV] Do not emit @llvm.used

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2123,7 +2123,7 @@ void SPIRVEmitIntrinsics::processGlobalValue(GlobalVariable &GV,
                                              IRBuilder<> &B) {
   // Skip special artificial variables.
   static const StringSet<> ArtificialGlobals{"llvm.global.annotations",
-                                             "llvm.compiler.used"};
+                                             "llvm.compiler.used", "llvm.used"};
 
   if (ArtificialGlobals.contains(GV.getName()))
     return;

--- a/llvm/test/CodeGen/SPIRV/llvm-used.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-used.ll
@@ -1,0 +1,19 @@
+; RUN: llc -verify-machineinstrs -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
+
+; Verify that llvm.used is not lowered.
+; CHECK: OpName %{{[0-9]+}} "unused"
+; CHECK-NOT: OpName %{{[0-9]+}} "llvm.used"
+
+; Check that the type of llvm.used is not emitted too.
+; CHECK-NOT: OpTypeArray
+
+@unused = private addrspace(3) global i32 0
+@llvm.used = appending addrspace(2) global [1 x ptr addrspace (4)] [ptr addrspace(4) addrspacecast (ptr addrspace(3) @unused to ptr addrspace(4))]
+
+define spir_func void @foo() {
+entry:
+  ret void
+}


### PR DESCRIPTION
Extending the work from https://github.com/llvm/llvm-project/pull/162678 which skips `llvm.compiler.used`, we also need to skip processing of `llvm.used`.

The OpenMP frontend puts an `addrspace(2)` variable in `llvm_used`, but the `llvm.used` array type uses the generic AS `addrspace(4)` so there's a `addrspacecast` from `2` to `4` inside the initalizer for `llvm.used` which is illegal and errors in the backend.

There is [discussion](https://github.com/llvm/llvm-project/pull/162678#issuecomment-3396735124) in the above linked PR that the handing should be the same for `llvm.used` and `llvm.compiler.used`, but `llvm.used` was not added to minimize the scope of the PR.

This is required to use the OpenMP Device RTL with SPIR-V.