### PR TITLE
[NFC][LLVM] Make `constrainSelectedInstRegOperands` return `void`

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/Utils.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/Utils.h
@@ -132,12 +132,10 @@ LLVM_ABI Register constrainOperandRegClass(
 /// generic) virtual register operands to the instruction's register class.
 /// This could involve inserting COPYs before (for uses) or after (for defs).
 /// This requires the number of operands to match the instruction description.
-/// \returns whether operand regclass constraining succeeded.
-///
 // FIXME: Not all instructions have the same number of operands. We should
 // probably expose a constrain helper per operand and let the target selector
 // constrain individual registers, like fast-isel.
-LLVM_ABI bool constrainSelectedInstRegOperands(MachineInstr &I,
+LLVM_ABI void constrainSelectedInstRegOperands(MachineInstr &I,
                                                const TargetInstrInfo &TII,
                                                const TargetRegisterInfo &TRI,
                                                const RegisterBankInfo &RBI);

--- a/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
@@ -441,7 +441,8 @@ public:
   bool constrainAllUses(const TargetInstrInfo &TII,
                         const TargetRegisterInfo &TRI,
                         const RegisterBankInfo &RBI) const {
-    return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+    return true;
   }
 };
 

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -152,7 +152,7 @@ Register llvm::constrainOperandRegClass(
                                   RegMO);
 }
 
-bool llvm::constrainSelectedInstRegOperands(MachineInstr &I,
+void llvm::constrainSelectedInstRegOperands(MachineInstr &I,
                                             const TargetInstrInfo &TII,
                                             const TargetRegisterInfo &TRI,
                                             const RegisterBankInfo &RBI) {
@@ -195,7 +195,6 @@ bool llvm::constrainSelectedInstRegOperands(MachineInstr &I,
         I.tieOperands(DefIdx, OpI);
     }
   }
-  return true;
 }
 
 bool llvm::canReplaceReg(Register DstReg, Register SrcReg,

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -242,8 +242,7 @@ bool AMDGPUInstructionSelector::selectCOPY_SCC_VCC(MachineInstr &I) const {
               .addReg(VCCReg);
   }
 
-  if (!constrainSelectedInstRegOperands(*Cmp, TII, TRI, RBI))
-    return false;
+  constrainSelectedInstRegOperands(*Cmp, TII, TRI, RBI);
 
   Register DstReg = I.getOperand(0).getReg();
   BuildMI(*BB, &I, DL, TII.get(AMDGPU::COPY), DstReg).addReg(AMDGPU::SCC);
@@ -284,7 +283,8 @@ bool AMDGPUInstructionSelector::selectCOPY_VCC_SCC(MachineInstr &I) const {
                              .addImm(0);
 
   I.eraseFromParent();
-  return constrainSelectedInstRegOperands(*Select, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*Select, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectReadAnyLane(MachineInstr &I) const {
@@ -298,7 +298,8 @@ bool AMDGPUInstructionSelector::selectReadAnyLane(MachineInstr &I) const {
                  .addReg(SrcReg);
 
   I.eraseFromParent();
-  return constrainSelectedInstRegOperands(*RFL, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*RFL, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectPHI(MachineInstr &I) const {
@@ -415,10 +416,11 @@ bool AMDGPUInstructionSelector::selectG_AND_OR_XOR(MachineInstr &I) const {
 
   // Dead implicit-def of scc
   I.addOperand(MachineOperand::CreateReg(AMDGPU::SCC, true, // isDef
-                                         true, // isImp
-                                         false, // isKill
-                                         true)); // isDead
-  return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+                                         true,              // isImp
+                                         false,             // isKill
+                                         true));            // isDead
+  constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectG_ADD_SUB(MachineInstr &I) const {
@@ -444,7 +446,8 @@ bool AMDGPUInstructionSelector::selectG_ADD_SUB(MachineInstr &I) const {
         .add(I.getOperand(2))
         .setOperandDead(3); // Dead scc
       I.eraseFromParent();
-      return constrainSelectedInstRegOperands(*Add, TII, TRI, RBI);
+      constrainSelectedInstRegOperands(*Add, TII, TRI, RBI);
+      return true;
     }
 
     if (STI.hasAddNoCarryInsts()) {
@@ -452,7 +455,8 @@ bool AMDGPUInstructionSelector::selectG_ADD_SUB(MachineInstr &I) const {
       I.setDesc(TII.get(Opc));
       I.addOperand(*MF, MachineOperand::CreateImm(0));
       I.addOperand(*MF, MachineOperand::CreateReg(AMDGPU::EXEC, false, true));
-      return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+      constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+      return true;
     }
 
     const unsigned Opc = Sub ? AMDGPU::V_SUB_CO_U32_e64 : AMDGPU::V_ADD_CO_U32_e64;
@@ -465,7 +469,8 @@ bool AMDGPUInstructionSelector::selectG_ADD_SUB(MachineInstr &I) const {
       .add(I.getOperand(2))
       .addImm(0);
     I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*Add, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*Add, TII, TRI, RBI);
+    return true;
   }
 
   assert(!Sub && "illegal sub should not reach here");
@@ -506,8 +511,7 @@ bool AMDGPUInstructionSelector::selectG_ADD_SUB(MachineInstr &I) const {
       .addReg(CarryReg, RegState::Kill)
       .addImm(0);
 
-    if (!constrainSelectedInstRegOperands(*Addc, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*Addc, TII, TRI, RBI);
   }
 
   BuildMI(*BB, &I, DL, TII.get(AMDGPU::REG_SEQUENCE), DstReg)
@@ -543,7 +547,8 @@ bool AMDGPUInstructionSelector::selectG_UADDO_USUBO_UADDE_USUBE(
     I.setDesc(TII.get(HasCarryIn ? CarryOpc : NoCarryOpc));
     I.addOperand(*MF, MachineOperand::CreateReg(AMDGPU::EXEC, false, true));
     I.addOperand(*MF, MachineOperand::CreateImm(0));
-    return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+    return true;
   }
 
   Register Src0Reg = I.getOperand(2).getReg();
@@ -609,7 +614,8 @@ bool AMDGPUInstructionSelector::selectG_AMDGPU_MAD_64_32(
   I.addOperand(*MF, MachineOperand::CreateImm(0));
   I.addImplicitDefUseOperands(*MF);
   I.getOperand(0).setIsEarlyClobber(true);
-  return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  return true;
 }
 
 // TODO: We should probably legalize these to only using 32-bit results.
@@ -825,15 +831,13 @@ bool AMDGPUInstructionSelector::selectG_BUILD_VECTOR(MachineInstr &MI) const {
     auto MIB = BuildMI(*BB, MI, DL, TII.get(AMDGPU::V_AND_B32_e32), TmpReg)
                    .addImm(0xFFFF)
                    .addReg(Src0);
-    if (!constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
 
     MIB = BuildMI(*BB, MI, DL, TII.get(AMDGPU::V_LSHL_OR_B32_e64), Dst)
               .addReg(Src1)
               .addImm(16)
               .addReg(TmpReg);
-    if (!constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
 
     MI.eraseFromParent();
     return true;
@@ -879,7 +883,8 @@ bool AMDGPUInstructionSelector::selectG_BUILD_VECTOR(MachineInstr &MI) const {
                      .setOperandDead(3); // Dead scc
 
       MI.eraseFromParent();
-      return constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+      constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+      return true;
     }
     if (STI.hasSPackHL()) {
       Opc = AMDGPU::S_PACK_HL_B32_B16;
@@ -888,7 +893,8 @@ bool AMDGPUInstructionSelector::selectG_BUILD_VECTOR(MachineInstr &MI) const {
   }
 
   MI.setDesc(TII.get(Opc));
-  return constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectG_IMPLICIT_DEF(MachineInstr &I) const {
@@ -986,7 +992,8 @@ bool AMDGPUInstructionSelector::selectG_SBFX_UBFX(MachineInstr &MI) const {
                  .addReg(OffsetReg)
                  .addReg(WidthReg);
   MI.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectInterpP1F16(MachineInstr &MI) const {
@@ -1088,7 +1095,8 @@ bool AMDGPUInstructionSelector::selectWritelane(MachineInstr &MI) const {
   MIB.addReg(VDstIn);
 
   MI.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  return true;
 }
 
 // We need to handle this here because tablegen doesn't support matching
@@ -1129,7 +1137,8 @@ bool AMDGPUInstructionSelector::selectDivScale(MachineInstr &MI) const {
     .addImm(0);    // $omod
 
   MI.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectG_INTRINSIC(MachineInstr &I) const {
@@ -1486,8 +1495,8 @@ bool AMDGPUInstructionSelector::selectG_ICMP_or_FCMP(MachineInstr &I) const {
             .add(I.getOperand(3));
     BuildMI(*BB, &I, DL, TII.get(AMDGPU::COPY), CCReg)
       .addReg(AMDGPU::SCC);
+    constrainSelectedInstRegOperands(*ICmp, TII, TRI, RBI);
     bool Ret =
-        constrainSelectedInstRegOperands(*ICmp, TII, TRI, RBI) &&
         RBI.constrainGenericRegister(CCReg, AMDGPU::SReg_32RegClass, *MRI);
     I.eraseFromParent();
     return Ret;
@@ -1517,9 +1526,9 @@ bool AMDGPUInstructionSelector::selectG_ICMP_or_FCMP(MachineInstr &I) const {
 
   RBI.constrainGenericRegister(ICmp->getOperand(0).getReg(),
                                *TRI.getBoolRC(), *MRI);
-  bool Ret = constrainSelectedInstRegOperands(*ICmp, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*ICmp, TII, TRI, RBI);
   I.eraseFromParent();
-  return Ret;
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectIntrinsicCmp(MachineInstr &I) const {
@@ -1573,8 +1582,7 @@ bool AMDGPUInstructionSelector::selectIntrinsicCmp(MachineInstr &I) const {
     SelectedMI.addImm(0); // op_sel
 
   RBI.constrainGenericRegister(Dst, *TRI.getBoolRC(), *MRI);
-  if (!constrainSelectedInstRegOperands(*SelectedMI, TII, TRI, RBI))
-    return false;
+  constrainSelectedInstRegOperands(*SelectedMI, TII, TRI, RBI);
 
   I.eraseFromParent();
   return true;
@@ -1660,8 +1668,7 @@ bool AMDGPUInstructionSelector::selectBallot(MachineInstr &I) const {
                      .addReg(SrcReg)
                      .addReg(TRI.getExec())
                      .setOperandDead(3); // Dead scc
-      if (!constrainSelectedInstRegOperands(*And, TII, TRI, RBI))
-        return false;
+      constrainSelectedInstRegOperands(*And, TII, TRI, RBI);
     }
   }
 
@@ -1728,7 +1735,8 @@ bool AMDGPUInstructionSelector::selectGroupStaticSize(MachineInstr &I) const {
   }
 
   I.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectReturnAddress(MachineInstr &I) const {
@@ -1852,9 +1860,9 @@ bool AMDGPUInstructionSelector::selectDSOrderedIntrinsic(
   if (!RBI.constrainGenericRegister(M0Val, AMDGPU::SReg_32RegClass, *MRI))
     return false;
 
-  bool Ret = constrainSelectedInstRegOperands(*DS, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*DS, TII, TRI, RBI);
   MI.eraseFromParent();
-  return Ret;
+  return true;
 }
 
 static unsigned gwsIntrinToOpcode(unsigned IntrID) {
@@ -2028,7 +2036,8 @@ bool AMDGPUInstructionSelector::selectDSAppendConsume(MachineInstr &MI,
     .addImm(IsGDS ? -1 : 0)
     .cloneMemRefs(MI);
   MI.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectInitWholeWave(MachineInstr &MI) const {
@@ -2340,7 +2349,8 @@ bool AMDGPUInstructionSelector::selectDSBvhStackIntrinsic(
                  .cloneMemRefs(MI);
 
   MI.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectG_INTRINSIC_W_SIDE_EFFECTS(
@@ -2442,11 +2452,10 @@ bool AMDGPUInstructionSelector::selectG_SELECT(MachineInstr &I) const {
             .add(I.getOperand(2))
             .add(I.getOperand(3));
 
-    bool Ret = false;
-    Ret |= constrainSelectedInstRegOperands(*Select, TII, TRI, RBI);
-    Ret |= constrainSelectedInstRegOperands(*CopySCC, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*Select, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*CopySCC, TII, TRI, RBI);
     I.eraseFromParent();
-    return Ret;
+    return true;
   }
 
   // Wide VGPR select should have been split in RegBankSelect.
@@ -2461,9 +2470,9 @@ bool AMDGPUInstructionSelector::selectG_SELECT(MachineInstr &I) const {
               .add(I.getOperand(2))
               .add(I.getOperand(1));
 
-  bool Ret = constrainSelectedInstRegOperands(*Select, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*Select, TII, TRI, RBI);
   I.eraseFromParent();
-  return Ret;
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectG_TRUNC(MachineInstr &I) const {
@@ -2679,7 +2688,8 @@ bool AMDGPUInstructionSelector::selectG_SZA_EXT(MachineInstr &I) const {
         .addImm(Mask)
         .addReg(SrcReg);
       I.eraseFromParent();
-      return constrainSelectedInstRegOperands(*ExtI, TII, TRI, RBI);
+      constrainSelectedInstRegOperands(*ExtI, TII, TRI, RBI);
+      return true;
     }
 
     const unsigned BFE = Signed ? AMDGPU::V_BFE_I32_e64 : AMDGPU::V_BFE_U32_e64;
@@ -2689,7 +2699,8 @@ bool AMDGPUInstructionSelector::selectG_SZA_EXT(MachineInstr &I) const {
       .addImm(0) // Offset
       .addImm(SrcSize); // Width
     I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*ExtI, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*ExtI, TII, TRI, RBI);
+    return true;
   }
 
   if (SrcBank->getID() == AMDGPU::SGPRRegBankID && DstSize <= 64) {
@@ -3163,7 +3174,8 @@ bool AMDGPUInstructionSelector::selectG_PTRMASK(MachineInstr &I) const {
       .addReg(MaskReg)
       .setOperandDead(3); // Dead scc
     I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+    return true;
   }
 
   unsigned NewOpc = IsVGPR ? AMDGPU::V_AND_B32_e64 : AMDGPU::S_AND_B32;
@@ -3538,7 +3550,8 @@ bool AMDGPUInstructionSelector::selectBufferLoadLds(MachineInstr &MI) const {
   MIB.setMemRefs({LoadMMO, StoreMMO});
 
   MI.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  return true;
 }
 
 /// Match a zero extend from a 32-bit value to 64-bits.
@@ -3725,7 +3738,8 @@ bool AMDGPUInstructionSelector::selectGlobalLoadLds(MachineInstr &MI) const{
   MIB.setMemRefs({LoadMMO, StoreMMO});
 
   MI.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectBVHIntersectRayIntrinsic(
@@ -3735,7 +3749,8 @@ bool AMDGPUInstructionSelector::selectBVHIntersectRayIntrinsic(
   MI.setDesc(TII.get(MI.getOperand(OpcodeOpIdx).getImm()));
   MI.removeOperand(OpcodeOpIdx);
   MI.addImplicitDefUseOperands(*MI.getMF());
-  return constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+  return true;
 }
 
 // FIXME: This should be removed and let the patterns select. We just need the
@@ -3865,7 +3880,8 @@ bool AMDGPUInstructionSelector::selectPermlaneSwapIntrin(
   MachineOperand &FI = MI.getOperand(4);
   FI.setImm(FI.getImm() ? AMDGPU::DPP::DPP_FI_1 : AMDGPU::DPP::DPP_FI_0);
 
-  return constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectWaveAddress(MachineInstr &MI) const {

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
@@ -650,13 +650,8 @@ bool RegBankLegalizeHelper::lowerS_BFE(MachineInstr &MI) {
   // copies from reg class to reg bank.
   auto S_BFE = B.buildInstr(Opc, {{SgprRB, Ty}},
                             {B.buildCopy(Ty, Src), B.buildCopy(S32, Src1)});
-  if (!constrainSelectedInstRegOperands(*S_BFE, *ST.getInstrInfo(),
-                                        *ST.getRegisterInfo(), RBI)) {
-    reportGISelFailure(
-        MF, MORE, "amdgpu-regbanklegalize",
-        "AMDGPU RegBankLegalize: lowerS_BFE, failed to constrain BFE", MI);
-    return false;
-  }
+  constrainSelectedInstRegOperands(*S_BFE, *ST.getInstrInfo(),
+                                   *ST.getRegisterInfo(), RBI);
 
   B.buildCopy(DstReg, S_BFE->getOperand(0).getReg());
   MI.eraseFromParent();

--- a/llvm/lib/Target/AMDGPU/AMDGPURegisterBankInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegisterBankInfo.cpp
@@ -1562,8 +1562,7 @@ bool AMDGPURegisterBankInfo::applyMappingBFE(MachineIRBuilder &B,
                              (Signed ? AMDGPU::S_BFE_I64 : AMDGPU::S_BFE_U64);
 
   auto MIB = B.buildInstr(Opc, {DstReg}, {SrcReg, MergedInputs});
-  if (!constrainSelectedInstRegOperands(*MIB, *TII, *TRI, *this))
-    llvm_unreachable("failed to constrain BFE");
+  constrainSelectedInstRegOperands(*MIB, *TII, *TRI, *this);
 
   MI.eraseFromParent();
   return true;

--- a/llvm/lib/Target/Mips/MipsInstructionSelector.cpp
+++ b/llvm/lib/Target/Mips/MipsInstructionSelector.cpp
@@ -153,20 +153,23 @@ bool MipsInstructionSelector::materialize32BitImm(Register DestReg, APInt Imm,
     MachineInstr *Inst =
         B.buildInstr(Mips::ORi, {DestReg}, {Register(Mips::ZERO)})
             .addImm(Imm.getLoBits(16).getLimitedValue());
-    return constrainSelectedInstRegOperands(*Inst, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*Inst, TII, TRI, RBI);
+    return true;
   }
   // Lui places immediate in high 16 bits and sets low 16 bits to zero.
   if (Imm.getLoBits(16).isZero()) {
     MachineInstr *Inst = B.buildInstr(Mips::LUi, {DestReg}, {})
                              .addImm(Imm.getHiBits(16).getLimitedValue());
-    return constrainSelectedInstRegOperands(*Inst, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*Inst, TII, TRI, RBI);
+    return true;
   }
   // ADDiu sign extends immediate. Used for values with 1s in high 17 bits.
   if (Imm.isSignedIntN(16)) {
     MachineInstr *Inst =
         B.buildInstr(Mips::ADDiu, {DestReg}, {Register(Mips::ZERO)})
             .addImm(Imm.getLoBits(16).getLimitedValue());
-    return constrainSelectedInstRegOperands(*Inst, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*Inst, TII, TRI, RBI);
+    return true;
   }
   // Values that cannot be materialized with single immediate instruction.
   Register LUiReg = B.getMRI()->createVirtualRegister(&Mips::GPR32RegClass);
@@ -174,10 +177,8 @@ bool MipsInstructionSelector::materialize32BitImm(Register DestReg, APInt Imm,
                           .addImm(Imm.getHiBits(16).getLimitedValue());
   MachineInstr *ORi = B.buildInstr(Mips::ORi, {DestReg}, {LUiReg})
                           .addImm(Imm.getLoBits(16).getLimitedValue());
-  if (!constrainSelectedInstRegOperands(*LUi, TII, TRI, RBI))
-    return false;
-  if (!constrainSelectedInstRegOperands(*ORi, TII, TRI, RBI))
-    return false;
+  constrainSelectedInstRegOperands(*LUi, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*ORi, TII, TRI, RBI);
   return true;
 }
 
@@ -268,8 +269,7 @@ bool MipsInstructionSelector::buildUnalignedStore(
           .add(BaseAddr)
           .addImm(Offset)
           .addMemOperand(MMO);
-  if (!constrainSelectedInstRegOperands(*NewInst, TII, TRI, RBI))
-    return false;
+  constrainSelectedInstRegOperands(*NewInst, TII, TRI, RBI);
   return true;
 }
 
@@ -283,8 +283,7 @@ bool MipsInstructionSelector::buildUnalignedLoad(
           .addImm(Offset)
           .addUse(TiedDest)
           .addMemOperand(*I.memoperands_begin());
-  if (!constrainSelectedInstRegOperands(*NewInst, TII, TRI, RBI))
-    return false;
+  constrainSelectedInstRegOperands(*NewInst, TII, TRI, RBI);
   return true;
 }
 
@@ -307,8 +306,7 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
                             .add(I.getOperand(0))
                             .add(I.getOperand(1))
                             .add(I.getOperand(2));
-    if (!constrainSelectedInstRegOperands(*Mul, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*Mul, TII, TRI, RBI);
     Mul->getOperand(3).setIsDead(true);
     Mul->getOperand(4).setIsDead(true);
 
@@ -331,14 +329,12 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
                       .addDef(PseudoMULTuReg)
                       .add(I.getOperand(1))
                       .add(I.getOperand(2));
-    if (!constrainSelectedInstRegOperands(*PseudoMULTu, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*PseudoMULTu, TII, TRI, RBI);
 
     PseudoMove = BuildMI(MBB, I, I.getDebugLoc(), TII.get(Mips::PseudoMFHI))
                      .addDef(I.getOperand(0).getReg())
                      .addUse(PseudoMULTuReg);
-    if (!constrainSelectedInstRegOperands(*PseudoMove, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*PseudoMove, TII, TRI, RBI);
 
     I.eraseFromParent();
     return true;
@@ -373,16 +369,14 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
                             .addDef(JTIndex)
                             .addUse(I.getOperand(2).getReg())
                             .addImm(Log2_32(EntrySize));
-    if (!constrainSelectedInstRegOperands(*SLL, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*SLL, TII, TRI, RBI);
 
     Register DestAddress = MRI.createVirtualRegister(&Mips::GPR32RegClass);
     MachineInstr *ADDu = BuildMI(MBB, I, I.getDebugLoc(), TII.get(Mips::ADDu))
                              .addDef(DestAddress)
                              .addUse(I.getOperand(0).getReg())
                              .addUse(JTIndex);
-    if (!constrainSelectedInstRegOperands(*ADDu, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*ADDu, TII, TRI, RBI);
 
     Register Dest = MRI.createVirtualRegister(&Mips::GPR32RegClass);
     MachineInstr *LW =
@@ -392,8 +386,7 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
             .addJumpTableIndex(I.getOperand(1).getIndex(), MipsII::MO_ABS_LO)
             .addMemOperand(MF.getMachineMemOperand(
                 MachinePointerInfo(), MachineMemOperand::MOLoad, 4, Align(4)));
-    if (!constrainSelectedInstRegOperands(*LW, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*LW, TII, TRI, RBI);
 
     if (MF.getTarget().isPositionIndependent()) {
       Register DestTmp = MRI.createVirtualRegister(&Mips::GPR32RegClass);
@@ -403,15 +396,13 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
                                .addUse(DestTmp)
                                .addUse(MF.getInfo<MipsFunctionInfo>()
                                            ->getGlobalBaseRegForGlobalISel(MF));
-      if (!constrainSelectedInstRegOperands(*ADDu, TII, TRI, RBI))
-        return false;
+      constrainSelectedInstRegOperands(*ADDu, TII, TRI, RBI);
     }
 
     MachineInstr *Branch =
         BuildMI(MBB, I, I.getDebugLoc(), TII.get(Mips::PseudoIndirectBranch))
             .addUse(Dest);
-    if (!constrainSelectedInstRegOperands(*Branch, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*Branch, TII, TRI, RBI);
 
     I.eraseFromParent();
     return true;
@@ -518,15 +509,13 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
                     .addDef(HILOReg)
                     .add(I.getOperand(1))
                     .add(I.getOperand(2));
-    if (!constrainSelectedInstRegOperands(*PseudoDIV, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*PseudoDIV, TII, TRI, RBI);
 
     PseudoMove = BuildMI(MBB, I, I.getDebugLoc(),
                          TII.get(IsDiv ? Mips::PseudoMFLO : Mips::PseudoMFHI))
                      .addDef(I.getOperand(0).getReg())
                      .addUse(HILOReg);
-    if (!constrainSelectedInstRegOperands(*PseudoMove, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*PseudoMove, TII, TRI, RBI);
 
     I.eraseFromParent();
     return true;
@@ -557,15 +546,13 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
                                   .addDef(Lo)
                                   .addUse(Src)
                                   .addImm(0);
-    if (!constrainSelectedInstRegOperands(*ExtractLo, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*ExtractLo, TII, TRI, RBI);
 
     MachineInstr *ExtractHi = BuildMI(MBB, I, I.getDebugLoc(), TII.get(Opcode))
                                   .addDef(Hi)
                                   .addUse(Src)
                                   .addImm(1);
-    if (!constrainSelectedInstRegOperands(*ExtractHi, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*ExtractHi, TII, TRI, RBI);
 
     I.eraseFromParent();
     return true;
@@ -650,14 +637,12 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
     MachineInstr *Trunc = BuildMI(MBB, I, I.getDebugLoc(), TII.get(Opcode))
                 .addDef(ResultInFPR)
                 .addUse(I.getOperand(1).getReg());
-    if (!constrainSelectedInstRegOperands(*Trunc, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*Trunc, TII, TRI, RBI);
 
     MachineInstr *Move = BuildMI(MBB, I, I.getDebugLoc(), TII.get(Mips::MFC1))
                              .addDef(I.getOperand(0).getReg())
                              .addUse(ResultInFPR);
-    if (!constrainSelectedInstRegOperands(*Move, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*Move, TII, TRI, RBI);
 
     I.eraseFromParent();
     return true;
@@ -681,8 +666,7 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
       LWGOT->addMemOperand(
           MF, MF.getMachineMemOperand(MachinePointerInfo::getGOT(MF),
                                       MachineMemOperand::MOLoad, 4, Align(4)));
-      if (!constrainSelectedInstRegOperands(*LWGOT, TII, TRI, RBI))
-        return false;
+      constrainSelectedInstRegOperands(*LWGOT, TII, TRI, RBI);
 
       if (GVal->hasLocalLinkage()) {
         Register LWGOTDef = MRI.createVirtualRegister(&Mips::GPR32RegClass);
@@ -694,8 +678,7 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
                 .addReg(LWGOTDef)
                 .addGlobalAddress(GVal);
         ADDiu->getOperand(2).setTargetFlags(MipsII::MO_ABS_LO);
-        if (!constrainSelectedInstRegOperands(*ADDiu, TII, TRI, RBI))
-          return false;
+        constrainSelectedInstRegOperands(*ADDiu, TII, TRI, RBI);
       }
     } else {
       Register LUiReg = MRI.createVirtualRegister(&Mips::GPR32RegClass);
@@ -704,8 +687,7 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
                               .addDef(LUiReg)
                               .addGlobalAddress(GVal);
       LUi->getOperand(1).setTargetFlags(MipsII::MO_ABS_HI);
-      if (!constrainSelectedInstRegOperands(*LUi, TII, TRI, RBI))
-        return false;
+      constrainSelectedInstRegOperands(*LUi, TII, TRI, RBI);
 
       MachineInstr *ADDiu =
           BuildMI(MBB, I, I.getDebugLoc(), TII.get(Mips::ADDiu))
@@ -713,8 +695,7 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
               .addUse(LUiReg)
               .addGlobalAddress(GVal);
       ADDiu->getOperand(2).setTargetFlags(MipsII::MO_ABS_LO);
-      if (!constrainSelectedInstRegOperands(*ADDiu, TII, TRI, RBI))
-        return false;
+      constrainSelectedInstRegOperands(*ADDiu, TII, TRI, RBI);
     }
     I.eraseFromParent();
     return true;
@@ -881,16 +862,14 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
                              .addUse(I.getOperand(2).getReg())
                              .addUse(I.getOperand(3).getReg())
                              .addImm(MipsFCMPCondCode);
-    if (!constrainSelectedInstRegOperands(*FCMP, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*FCMP, TII, TRI, RBI);
 
     MachineInstr *Move = BuildMI(MBB, I, I.getDebugLoc(), TII.get(MoveOpcode))
                              .addDef(I.getOperand(0).getReg())
                              .addUse(Mips::ZERO)
                              .addUse(Mips::FCC0)
                              .addUse(TrueInReg);
-    if (!constrainSelectedInstRegOperands(*Move, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*Move, TII, TRI, RBI);
 
     I.eraseFromParent();
     return true;
@@ -909,15 +888,13 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
             .addDef(LeaReg)
             .addFrameIndex(FI)
             .addImm(0);
-    if (!constrainSelectedInstRegOperands(*LEA_ADDiu, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*LEA_ADDiu, TII, TRI, RBI);
 
     MachineInstr *Store = BuildMI(MBB, I, I.getDebugLoc(), TII.get(Mips::SW))
                               .addUse(LeaReg)
                               .addUse(I.getOperand(0).getReg())
                               .addImm(0);
-    if (!constrainSelectedInstRegOperands(*Store, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*Store, TII, TRI, RBI);
 
     I.eraseFromParent();
     return true;
@@ -927,7 +904,8 @@ bool MipsInstructionSelector::select(MachineInstr &I) {
   }
 
   I.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  return true;
 }
 
 namespace llvm {

--- a/llvm/lib/Target/PowerPC/GISel/PPCInstructionSelector.cpp
+++ b/llvm/lib/Target/PowerPC/GISel/PPCInstructionSelector.cpp
@@ -205,7 +205,8 @@ bool PPCInstructionSelector::selectIntToFP(MachineInstr &I,
       BuildMI(MBB, I, DbgLoc, TII.get(ConvOp), DstReg).addReg(MoveReg);
 
   I.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  return true;
 }
 
 bool PPCInstructionSelector::selectFPToInt(MachineInstr &I,
@@ -235,7 +236,8 @@ bool PPCInstructionSelector::selectFPToInt(MachineInstr &I,
       BuildMI(MBB, I, DbgLoc, TII.get(PPC::MFVSRD), DstReg).addReg(ConvReg);
 
   I.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  return true;
 }
 
 bool PPCInstructionSelector::selectZExt(MachineInstr &I, MachineBasicBlock &MBB,
@@ -269,7 +271,8 @@ bool PPCInstructionSelector::selectZExt(MachineInstr &I, MachineBasicBlock &MBB,
           .addImm(32);
 
   I.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  return true;
 }
 
 // For any 32 < Num < 64, check if the Imm contains at least Num consecutive
@@ -702,7 +705,8 @@ bool PPCInstructionSelector::selectConstantPool(
   }
 
   I.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  return true;
 }
 
 bool PPCInstructionSelector::select(MachineInstr &I) {
@@ -760,7 +764,8 @@ bool PPCInstructionSelector::select(MachineInstr &I) {
     if (!LoadStore)
       return false;
 
-    return constrainSelectedInstRegOperands(*LoadStore, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*LoadStore, TII, TRI, RBI);
+    return true;
   }
   case TargetOpcode::G_SITOFP:
   case TargetOpcode::G_UITOFP:

--- a/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
@@ -808,7 +808,8 @@ bool RISCVInstructionSelector::selectIntrinsicWithSideEffects(
     PseudoMI.cloneMemRefs(I);
 
     I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+    return true;
   }
   case Intrinsic::riscv_vloxei:
   case Intrinsic::riscv_vloxei_mask:
@@ -872,7 +873,8 @@ bool RISCVInstructionSelector::selectIntrinsicWithSideEffects(
     PseudoMI.cloneMemRefs(I);
 
     I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+    return true;
   }
   case Intrinsic::riscv_vsm:
   case Intrinsic::riscv_vse:
@@ -914,7 +916,8 @@ bool RISCVInstructionSelector::selectIntrinsicWithSideEffects(
     PseudoMI.cloneMemRefs(I);
 
     I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+    return true;
   }
   case Intrinsic::riscv_vsoxei:
   case Intrinsic::riscv_vsoxei_mask:
@@ -964,7 +967,8 @@ bool RISCVInstructionSelector::selectIntrinsicWithSideEffects(
     PseudoMI.cloneMemRefs(I);
 
     I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+    return true;
   }
   }
 }
@@ -1029,7 +1033,8 @@ bool RISCVInstructionSelector::selectIntrinsic(MachineInstr &I,
                               .addImm(AVL)
                               .addImm(VTypeI);
           I.eraseFromParent();
-          return constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+          constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+          return true;
         }
       }
     }
@@ -1037,7 +1042,8 @@ bool RISCVInstructionSelector::selectIntrinsic(MachineInstr &I,
     auto PseudoMI =
         MIB.buildInstr(Opcode, {DstReg}, {VLOperand}).addImm(VTypeI);
     I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*PseudoMI, TII, TRI, RBI);
+    return true;
   }
   }
 }
@@ -1162,14 +1168,16 @@ bool RISCVInstructionSelector::select(MachineInstr &MI) {
     if (IsSigned && SrcSize == 32) {
       MI.setDesc(TII.get(RISCV::ADDIW));
       MI.addOperand(MachineOperand::CreateImm(0));
-      return constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      return true;
     }
 
     // Use add.uw SrcReg, X0 (zext.w) for i32 with Zba.
     if (!IsSigned && SrcSize == 32 && STI.hasStdExtZba()) {
       MI.setDesc(TII.get(RISCV::ADD_UW));
       MI.addOperand(MachineOperand::CreateReg(RISCV::X0, /*isDef=*/false));
-      return constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      return true;
     }
 
     // Use sext.h/zext.h for i16 with Zbb.
@@ -1177,14 +1185,16 @@ bool RISCVInstructionSelector::select(MachineInstr &MI) {
       MI.setDesc(TII.get(IsSigned       ? RISCV::SEXT_H
                          : STI.isRV64() ? RISCV::ZEXT_H_RV64
                                         : RISCV::ZEXT_H_RV32));
-      return constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      return true;
     }
 
     // Use pack(w) SrcReg, X0 for i16 zext with Zbkb.
     if (!IsSigned && SrcSize == 16 && STI.hasStdExtZbkb()) {
       MI.setDesc(TII.get(STI.is64Bit() ? RISCV::PACKW : RISCV::PACK));
       MI.addOperand(MachineOperand::CreateReg(RISCV::X0, /*isDef=*/false));
-      return constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      return true;
     }
 
     // Fall back to shift pair.
@@ -1276,12 +1286,14 @@ bool RISCVInstructionSelector::select(MachineInstr &MI) {
     auto Bcc = MIB.buildInstr(RISCVCC::getBrCond(CC), {}, {LHS, RHS})
                    .addMBB(MI.getOperand(1).getMBB());
     MI.eraseFromParent();
-    return constrainSelectedInstRegOperands(*Bcc, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*Bcc, TII, TRI, RBI);
+    return true;
   }
   case TargetOpcode::G_BRINDIRECT:
     MI.setDesc(TII.get(RISCV::PseudoBRIND));
     MI.addOperand(MachineOperand::CreateImm(0));
-    return constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+    return true;
   case TargetOpcode::G_SELECT:
     return selectSelect(MI, MIB);
   case TargetOpcode::G_FCMP:
@@ -1327,7 +1339,8 @@ bool RISCVInstructionSelector::select(MachineInstr &MI) {
 
     if (isStrongerThanMonotonic(Order)) {
       MI.setDesc(TII.get(selectZalasrLoadStoreOp(Opc, MemSize)));
-      return constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      return true;
     }
 
     const unsigned NewOpc = selectRegImmLoadStoreOp(MI.getOpcode(), MemSize);
@@ -1350,7 +1363,8 @@ bool RISCVInstructionSelector::select(MachineInstr &MI) {
       Fn(NewInst);
     MI.eraseFromParent();
 
-    return constrainSelectedInstRegOperands(*NewInst, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*NewInst, TII, TRI, RBI);
+    return true;
   }
   case TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS:
     return selectIntrinsicWithSideEffects(MI, MIB);
@@ -1380,12 +1394,10 @@ bool RISCVInstructionSelector::selectUnmergeValues(
     return false;
 
   MachineInstr *ExtractLo = MIB.buildInstr(RISCV::FMV_X_W_FPR64, {Lo}, {Src});
-  if (!constrainSelectedInstRegOperands(*ExtractLo, TII, TRI, RBI))
-    return false;
+  constrainSelectedInstRegOperands(*ExtractLo, TII, TRI, RBI);
 
   MachineInstr *ExtractHi = MIB.buildInstr(RISCV::FMVH_X_D, {Hi}, {Src});
-  if (!constrainSelectedInstRegOperands(*ExtractHi, TII, TRI, RBI))
-    return false;
+  constrainSelectedInstRegOperands(*ExtractHi, TII, TRI, RBI);
 
   MI.eraseFromParent();
   return true;
@@ -1629,8 +1641,7 @@ bool RISCVInstructionSelector::materializeImm(Register DstReg, int64_t Imm,
       break;
     }
 
-    if (!constrainSelectedInstRegOperands(*Result, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*Result, TII, TRI, RBI);
 
     SrcReg = TmpReg;
   }
@@ -1661,7 +1672,8 @@ bool RISCVInstructionSelector::selectAddr(MachineInstr &MI,
       // pattern (PseudoLLA sym), which expands to (addi (auipc %pcrel_hi(sym))
       // %pcrel_lo(auipc)).
       MI.setDesc(TII.get(RISCV::PseudoLLA));
-      return constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+      return true;
     }
 
     // Use PC-relative addressing to access the GOT for this symbol, then
@@ -1679,8 +1691,7 @@ bool RISCVInstructionSelector::selectAddr(MachineInstr &MI,
                       .addDisp(DispMO, 0)
                       .addMemOperand(MemOp);
 
-    if (!constrainSelectedInstRegOperands(*Result, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*Result, TII, TRI, RBI);
 
     MI.eraseFromParent();
     return true;
@@ -1700,14 +1711,12 @@ bool RISCVInstructionSelector::selectAddr(MachineInstr &MI,
     MachineInstr *AddrHi = MIB.buildInstr(RISCV::LUI, {AddrHiDest}, {})
                                .addDisp(DispMO, 0, RISCVII::MO_HI);
 
-    if (!constrainSelectedInstRegOperands(*AddrHi, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*AddrHi, TII, TRI, RBI);
 
     auto Result = MIB.buildInstr(RISCV::ADDI, {DefReg}, {AddrHiDest})
                       .addDisp(DispMO, 0, RISCVII::MO_LO);
 
-    if (!constrainSelectedInstRegOperands(*Result, TII, TRI, RBI))
-      return false;
+    constrainSelectedInstRegOperands(*Result, TII, TRI, RBI);
 
     MI.eraseFromParent();
     return true;
@@ -1733,8 +1742,7 @@ bool RISCVInstructionSelector::selectAddr(MachineInstr &MI,
                         .addDisp(DispMO, 0)
                         .addMemOperand(MemOp);
 
-      if (!constrainSelectedInstRegOperands(*Result, TII, TRI, RBI))
-        return false;
+      constrainSelectedInstRegOperands(*Result, TII, TRI, RBI);
 
       MI.eraseFromParent();
       return true;
@@ -1744,7 +1752,8 @@ bool RISCVInstructionSelector::selectAddr(MachineInstr &MI,
     // within the address space. This generates the pattern (PseudoLLA sym),
     // which expands to (addi (auipc %pcrel_hi(sym)) %pcrel_lo(auipc)).
     MI.setDesc(TII.get(RISCV::PseudoLLA));
-    return constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
+    return true;
   }
 
   return false;
@@ -1775,7 +1784,8 @@ bool RISCVInstructionSelector::selectSelect(MachineInstr &MI,
                              .addReg(SelectMI.getTrueReg())
                              .addReg(SelectMI.getFalseReg());
   MI.eraseFromParent();
-  return constrainSelectedInstRegOperands(*Result, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(*Result, TII, TRI, RBI);
+  return true;
 }
 
 // Convert an FCMP predicate to one of the supported F or D instructions.

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -792,7 +792,8 @@ bool SPIRVInstructionSelector::select(MachineInstr &I) {
       // Make all vregs 64 bits (for SPIR-V IDs).
       MRI->setType(I.getOperand(0).getReg(), LLT::scalar(64));
     }
-    return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+    return true;
   }
 
   if (DeadMIs.contains(&I)) {
@@ -3099,7 +3100,7 @@ SPIRVInstructionSelector::buildI32Constant(uint32_t Val, MachineInstr &I,
                   .addDef(NewReg)
                   .addUse(GR.getSPIRVTypeID(SpvI32Ty))
                   .addImm(APInt(32, Val).getZExtValue());
-    Result &= constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+    constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
     GR.add(ConstInt, MI);
   }
   return {NewReg, Result};
@@ -3698,8 +3699,7 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
           GR.getSPIRVTypeID(ResType));
       for (auto *Instr : Instructions) {
         Instr->setDebugLoc(I.getDebugLoc());
-        if (!constrainSelectedInstRegOperands(*Instr, TII, TRI, RBI))
-          return false;
+        constrainSelectedInstRegOperands(*Instr, TII, TRI, RBI);
       }
       return true;
     } else {

--- a/llvm/lib/Target/X86/GISel/X86InstructionSelector.cpp
+++ b/llvm/lib/Target/X86/GISel/X86InstructionSelector.cpp
@@ -725,9 +725,9 @@ bool X86InstructionSelector::selectLoadStoreOp(MachineInstr &I,
     I.removeOperand(0);
     addFullAddress(MIB, AM).addUse(DefReg);
   }
-  bool Constrained = constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(I, TII, TRI, RBI);
   I.addImplicitDefUseOperands(MF);
-  return Constrained;
+  return true;
 }
 
 static unsigned getLeaOP(LLT Ty, const X86Subtarget &STI) {
@@ -764,7 +764,8 @@ bool X86InstructionSelector::selectFrameIndexOrGep(MachineInstr &I,
     MIB.addImm(0).addReg(0);
   }
 
-  return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  return true;
 }
 
 bool X86InstructionSelector::selectGlobalValue(MachineInstr &I,
@@ -787,7 +788,8 @@ bool X86InstructionSelector::selectGlobalValue(MachineInstr &I,
   I.removeOperand(1);
   addFullAddress(MIB, AM);
 
-  return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  return true;
 }
 
 bool X86InstructionSelector::selectConstant(MachineInstr &I,
@@ -834,7 +836,8 @@ bool X86InstructionSelector::selectConstant(MachineInstr &I,
   }
 
   I.setDesc(TII.get(NewOpc));
-  return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  return true;
 }
 
 // Helper function for selectTruncOrPtrToInt and selectAnyext.
@@ -1301,8 +1304,8 @@ bool X86InstructionSelector::selectUAddSub(MachineInstr &I,
   BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(X86::SETCCr), CarryOutReg)
       .addImm(X86::COND_B);
 
-  if (!constrainSelectedInstRegOperands(Inst, TII, TRI, RBI) ||
-      !RBI.constrainGenericRegister(CarryOutReg, *CarryRC, MRI))
+  constrainSelectedInstRegOperands(Inst, TII, TRI, RBI);
+  if (!RBI.constrainGenericRegister(CarryOutReg, *CarryRC, MRI))
     return false;
 
   I.eraseFromParent();
@@ -1363,7 +1366,8 @@ bool X86InstructionSelector::selectExtract(MachineInstr &I,
   Index = Index / DstTy.getSizeInBits();
   I.getOperand(2).setImm(Index);
 
-  return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  return true;
 }
 
 bool X86InstructionSelector::emitExtractSubreg(Register DstReg, Register SrcReg,
@@ -1497,7 +1501,8 @@ bool X86InstructionSelector::selectInsert(MachineInstr &I,
 
   I.getOperand(3).setImm(Index);
 
-  return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  constrainSelectedInstRegOperands(I, TII, TRI, RBI);
+  return true;
 }
 
 bool X86InstructionSelector::selectUnmergeValues(


### PR DESCRIPTION
`constrainSelectedInstRegOperands` always returns `true`; so it can be safely transformed to return `void` instead.

A follow-up patch should update `MachineInstrBuilder::constrainAllUses`.