### PR TITLE
[llvm][Support] Add InMemoryOutputBackend

### DIFF
--- a/llvm/include/llvm/Support/VirtualOutputBackends.h
+++ b/llvm/include/llvm/Support/VirtualOutputBackends.h
@@ -125,6 +125,8 @@ public:
 
 /// And output backend that creates files in memory, backed by string buffers in
 /// a map. This is useful for unittesting.
+/// Cloning it will result in a copy of the current state.
+/// This clone operation is not thread-safe.
 class InMemoryOutputBackend : public OutputBackend {
 protected:
   Expected<std::unique_ptr<OutputFileImpl>>
@@ -136,8 +138,9 @@ protected:
         Path, std::make_error_code(std::errc::file_exists));
   }
 
+  // Not thread-safe.
   IntrusiveRefCntPtr<OutputBackend> cloneImpl() const override {
-    return const_cast<InMemoryOutputBackend *>(this);
+    return makeIntrusiveRefCnt<InMemoryOutputBackend>(*this); // Deep copy
   }
 
 public:

--- a/llvm/include/llvm/Support/VirtualOutputBackends.h
+++ b/llvm/include/llvm/Support/VirtualOutputBackends.h
@@ -127,8 +127,7 @@ public:
 class InMemoryOutputBackend : public OutputBackend {
 protected:
   Expected<std::unique_ptr<OutputFileImpl>>
-  createFileImpl(StringRef Path, std::optional<OutputConfig> Config) override {
-    (void)Config; // FIXME: Not implemented.
+  createFileImpl(StringRef Path, std::optional<OutputConfig>) override {
     return std::make_unique<StringBackedOutputFileImpl>(Buffers[Path.str()]);
   }
 

--- a/llvm/include/llvm/Support/VirtualOutputBackends.h
+++ b/llvm/include/llvm/Support/VirtualOutputBackends.h
@@ -41,10 +41,6 @@ LLVM_ABI IntrusiveRefCntPtr<OutputBackend> makeFilteringOutputBackend(
     IntrusiveRefCntPtr<OutputBackend> UnderlyingBackend,
     std::function<bool(StringRef, std::optional<OutputConfig>)> Filter);
 
-/// Make a backend where \a OutputBackend::createFile() creates a file in a map,
-/// backed by a string buffer.
-LLVM_ABI IntrusiveRefCntPtr<OutputBackend> makeInMemoryOutputBackend();
-
 /// Create a backend that forwards \a OutputBackend::createFile() to both \p
 /// Backend1 and \p Backend2. Writing to such backend will create identical
 /// outputs using two different backends.

--- a/llvm/include/llvm/Support/VirtualOutputFile.h
+++ b/llvm/include/llvm/Support/VirtualOutputFile.h
@@ -52,6 +52,24 @@ private:
   raw_null_ostream OS;
 };
 
+class StringBackedOutputFileImpl final
+    : public RTTIExtends<StringBackedOutputFileImpl, OutputFileImpl> {
+public:
+  LLVM_ABI static char ID;
+  explicit StringBackedOutputFileImpl(
+      llvm::SmallVectorImpl<char> &BackingBuffer)
+      : OS(BackingBuffer) {}
+
+  Error keep() final { return Error::success(); }
+  Error discard() final { return Error::success(); }
+  raw_pwrite_stream &getOS() final { return OS; }
+
+private:
+  LLVM_ABI void anchor() override;
+
+  llvm::raw_svector_ostream OS;
+};
+
 /// A virtualized output file that writes to a specific backend.
 ///
 /// One of \a keep(), \a discard(), or \a discardOnDestroy() must be called

--- a/llvm/lib/Support/VirtualOutputBackends.cpp
+++ b/llvm/lib/Support/VirtualOutputBackends.cpp
@@ -32,6 +32,7 @@ using namespace llvm::vfs;
 
 void ProxyOutputBackend::anchor() {}
 void OnDiskOutputBackend::anchor() {}
+void InMemoryOutputBackend::anchor() {}
 
 IntrusiveRefCntPtr<OutputBackend> vfs::makeNullOutputBackend() {
   struct NullOutputBackend : public OutputBackend {
@@ -76,6 +77,10 @@ IntrusiveRefCntPtr<OutputBackend> vfs::makeFilteringOutputBackend(
 
   return makeIntrusiveRefCnt<FilteringOutputBackend>(
       std::move(UnderlyingBackend), std::move(Filter));
+}
+
+IntrusiveRefCntPtr<OutputBackend> vfs::makeInMemoryOutputBackend() {
+  return makeIntrusiveRefCnt<InMemoryOutputBackend>();
 }
 
 IntrusiveRefCntPtr<OutputBackend>

--- a/llvm/lib/Support/VirtualOutputBackends.cpp
+++ b/llvm/lib/Support/VirtualOutputBackends.cpp
@@ -79,10 +79,6 @@ IntrusiveRefCntPtr<OutputBackend> vfs::makeFilteringOutputBackend(
       std::move(UnderlyingBackend), std::move(Filter));
 }
 
-IntrusiveRefCntPtr<OutputBackend> vfs::makeInMemoryOutputBackend() {
-  return makeIntrusiveRefCnt<InMemoryOutputBackend>();
-}
-
 IntrusiveRefCntPtr<OutputBackend>
 vfs::makeMirroringOutputBackend(IntrusiveRefCntPtr<OutputBackend> Backend1,
                                 IntrusiveRefCntPtr<OutputBackend> Backend2) {

--- a/llvm/lib/Support/VirtualOutputFile.cpp
+++ b/llvm/lib/Support/VirtualOutputFile.cpp
@@ -21,9 +21,11 @@ using namespace llvm::vfs;
 
 char OutputFileImpl::ID = 0;
 char NullOutputFileImpl::ID = 0;
+char StringBackedOutputFileImpl::ID = 0;
 
 void OutputFileImpl::anchor() {}
 void NullOutputFileImpl::anchor() {}
+void StringBackedOutputFileImpl::anchor() {}
 
 class OutputFile::TrackedProxy : public raw_pwrite_stream_proxy {
 public:

--- a/llvm/unittests/Support/VirtualOutputBackendsTest.cpp
+++ b/llvm/unittests/Support/VirtualOutputBackendsTest.cpp
@@ -278,7 +278,7 @@ public:
   bool rejectsMissingDirectories() override { return false; }
 
   IntrusiveRefCntPtr<OutputBackend> createBackend() override {
-    return makeInMemoryOutputBackend();
+    return makeIntrusiveRefCnt<InMemoryOutputBackend>();
   }
   std::string getFilePathToCreate() override { return "ignored.data"; }
   std::string getFilePathToCreateUnder(StringRef Parent1,


### PR DESCRIPTION
Add InMemoryOutputBackend, an output backend that creates files in memory backed by string buffers in a map.
This is useful for unittests, where we don't want to create files on the file system, but still want to check the content of the created files.

Assisted-by: claude