### PR TITLE
[clang][ssaf] Add FormatInfo sub-registry and tests [2/2]

### DIFF
--- a/clang/include/clang/Analysis/Scalable/Serialization/SerializationFormat.h
+++ b/clang/include/clang/Analysis/Scalable/Serialization/SerializationFormat.h
@@ -15,6 +15,7 @@
 #define CLANG_ANALYSIS_SCALABLE_SERIALIZATION_SERIALIZATION_FORMAT_H
 
 #include "clang/Analysis/Scalable/Model/BuildNamespace.h"
+#include "clang/Analysis/Scalable/Model/SummaryName.h"
 #include "clang/Analysis/Scalable/TUSummary/TUSummary.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
@@ -26,8 +27,7 @@ namespace clang::ssaf {
 class EntityId;
 class EntityIdTable;
 class EntityName;
-class TUSummary;
-class TUSummaryData;
+class EntitySummary;
 
 /// Abstract base class for serialization formats.
 class SerializationFormat {
@@ -48,6 +48,8 @@ protected:
   static const llvm::SmallString<16> &getEntityNameSuffix(const EntityName &EN);
   static const NestedBuildNamespace &
   getEntityNameNamespace(const EntityName &EN);
+  static decltype(TUSummary::Data) &getData(TUSummary &S);
+  static const decltype(TUSummary::Data) &getData(const TUSummary &S);
 
 public:
   explicit SerializationFormat(
@@ -61,6 +63,17 @@ public:
 
 protected:
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS;
+};
+
+template <class SerializerFn, class DeserializerFn> struct FormatInfoEntry {
+  FormatInfoEntry(SummaryName ForSummary, SerializerFn Serialize,
+                  DeserializerFn Deserialize)
+      : ForSummary(ForSummary), Serialize(Serialize), Deserialize(Deserialize) {
+  }
+
+  SummaryName ForSummary;
+  SerializerFn Serialize;
+  DeserializerFn Deserialize;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/Analysis/Scalable/Serialization/SerializationFormatRegistry.h
+++ b/clang/include/clang/Analysis/Scalable/Serialization/SerializationFormatRegistry.h
@@ -16,6 +16,7 @@
 // format info for it:
 //
 //   namespace {
+//   using FormatInfo = MyFormat::FormatInfo;
 //   struct MyAnalysisFormatInfo : FormatInfo {
 //     MyAnalysisFormatInfo() : FormatInfo{
 //               SummaryName("MyAnalysis"),

--- a/clang/lib/Analysis/Scalable/Serialization/SerializationFormat.cpp
+++ b/clang/lib/Analysis/Scalable/Serialization/SerializationFormat.cpp
@@ -63,3 +63,12 @@ const NestedBuildNamespace &
 SerializationFormat::getEntityNameNamespace(const EntityName &EN) {
   return EN.Namespace;
 }
+
+const decltype(TUSummary::Data) &
+SerializationFormat::getData(const TUSummary &S) {
+  return S.Data;
+}
+
+decltype(TUSummary::Data) &SerializationFormat::getData(TUSummary &S) {
+  return S.Data;
+}

--- a/clang/unittests/Analysis/Scalable/CMakeLists.txt
+++ b/clang/unittests/Analysis/Scalable/CMakeLists.txt
@@ -4,6 +4,7 @@ add_distinct_clang_unittest(ClangScalableAnalysisTests
   EntityIdTest.cpp
   EntityIdTableTest.cpp
   EntityNameTest.cpp
+  Registries/FancyAnalysisData.cpp
   Registries/MockSerializationFormat.cpp
   Registries/MockSummaryExtractor1.cpp
   Registries/MockSummaryExtractor2.cpp

--- a/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
+++ b/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
@@ -15,7 +15,6 @@ using namespace ssaf;
 
 using SpecialFileRepresentation =
     MockSerializationFormat::SpecialFileRepresentation;
-using FormatInfo = MockSerializationFormat::FormatInfo;
 
 namespace {
 struct FancyAnalysisData : EntitySummary {
@@ -41,6 +40,7 @@ deserializeFancyAnalysis(const SpecialFileRepresentation &File,
 }
 
 namespace {
+using FormatInfo = MockSerializationFormat::FormatInfo;
 struct FancyAnalysisFormatInfo : FormatInfo {
   FancyAnalysisFormatInfo()
       : FormatInfo{

--- a/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
+++ b/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
@@ -9,7 +9,6 @@
 #include "Registries/MockSerializationFormat.h"
 #include "clang/Analysis/Scalable/TUSummary/EntitySummary.h"
 #include "llvm/Support/Registry.h"
-#include <vector>
 
 using namespace clang;
 using namespace ssaf;

--- a/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
+++ b/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
@@ -1,0 +1,87 @@
+//===- FancyAnalysisData.cpp ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Registries/MockSerializationFormat.h"
+#include "clang/Analysis/Scalable/TUSummary/EntitySummary.h"
+#include "llvm/Support/Registry.h"
+#include <vector>
+
+using namespace clang;
+using namespace ssaf;
+
+using SpecialFileRepresentation =
+    MockSerializationFormat::SpecialFileRepresentation;
+using FormatInfo = MockSerializationFormat::FormatInfo;
+
+namespace {
+struct FancyAnalysisData : EntitySummary {
+  FancyAnalysisData() : EntitySummary(SummaryName("FancyAnalysis")) {}
+
+  std::vector<std::string> SomeInternalList;
+};
+} // namespace
+
+static SpecialFileRepresentation
+serializeFancyAnalysis(const EntitySummary &Data,
+                       MockSerializationFormat &Format) {
+  const auto &FancyAnalysis = static_cast<const FancyAnalysisData &>(Data);
+
+  std::string Buffer;
+  llvm::raw_string_ostream OS(Buffer);
+  OS << "FancyAnalysisData{\n";
+  OS << "  SomeInternalList: ";
+  llvm::interleaveComma(FancyAnalysis.SomeInternalList, OS);
+  OS << "\n";
+  OS << "}\n";
+
+  return SpecialFileRepresentation{/*MockRepresentation=*/std::move(Buffer)};
+}
+
+static std::unique_ptr<EntitySummary>
+deserializeFancyAnalysis(const SpecialFileRepresentation &Obj,
+                         EntityIdTable &Table) {
+  auto Result = std::make_unique<FancyAnalysisData>();
+
+  llvm::StringRef Cursor = Obj.MockRepresentation;
+  if (!Cursor.consume_front("FancyAnalysisData{\n  SomeInternalList: "))
+    return nullptr;
+
+  auto IsNewLine = [](char C) { return C == '\n'; };
+  llvm::StringRef SomeInternalListStr = Cursor.take_until(IsNewLine);
+  llvm::SmallVector<llvm::StringRef> Parts;
+  SomeInternalListStr.split(Parts, ", ");
+  for (llvm::StringRef Part : Parts) {
+    Result->SomeInternalList.push_back(Part.str());
+  }
+
+  Cursor = Cursor.drop_front(SomeInternalListStr.size());
+
+  if (!Cursor.consume_front("\n}\n"))
+    return nullptr;
+
+  if (!Cursor.empty())
+    return nullptr;
+
+  return std::move(Result);
+}
+
+namespace {
+struct FancyAnalysisFormatInfo : FormatInfo {
+  FancyAnalysisFormatInfo()
+      : FormatInfo{
+            SummaryName("FancyAnalysis"),
+            serializeFancyAnalysis,
+            deserializeFancyAnalysis,
+        } {}
+};
+} // namespace
+
+static llvm::Registry<FormatInfo>::Add<FancyAnalysisFormatInfo>
+    RegisterFormatInfo("FancyAnalysisData",
+                       "Format info for FancyAnalysisData for the "
+                       "MockSerializationFormat1 format");

--- a/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
+++ b/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
@@ -54,4 +54,4 @@ struct FancyAnalysisFormatInfo : FormatInfo {
 static llvm::Registry<FormatInfo>::Add<FancyAnalysisFormatInfo>
     RegisterFormatInfo("FancyAnalysisData",
                        "Format info for FancyAnalysisData for the "
-                       "MockSerializationFormat1 format");
+                       "MockSerializationFormat format");

--- a/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
+++ b/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
@@ -22,7 +22,7 @@ namespace {
 struct FancyAnalysisData : EntitySummary {
   FancyAnalysisData() : EntitySummary(SummaryName("FancyAnalysis")) {}
 
-  std::vector<std::string> SomeInternalList;
+  std::string Text;
 };
 } // namespace
 
@@ -30,43 +30,14 @@ static SpecialFileRepresentation
 serializeFancyAnalysis(const EntitySummary &Data,
                        MockSerializationFormat &Format) {
   const auto &FancyAnalysis = static_cast<const FancyAnalysisData &>(Data);
-
-  std::string Buffer;
-  llvm::raw_string_ostream OS(Buffer);
-  OS << "FancyAnalysisData{\n";
-  OS << "  SomeInternalList: ";
-  llvm::interleaveComma(FancyAnalysis.SomeInternalList, OS);
-  OS << "\n";
-  OS << "}\n";
-
-  return SpecialFileRepresentation{/*MockRepresentation=*/std::move(Buffer)};
+  return SpecialFileRepresentation{/*MockRepresentation=*/FancyAnalysis.Text};
 }
 
 static std::unique_ptr<EntitySummary>
-deserializeFancyAnalysis(const SpecialFileRepresentation &Obj,
-                         EntityIdTable &Table) {
+deserializeFancyAnalysis(const SpecialFileRepresentation &File,
+                         EntityIdTable &) {
   auto Result = std::make_unique<FancyAnalysisData>();
-
-  llvm::StringRef Cursor = Obj.MockRepresentation;
-  if (!Cursor.consume_front("FancyAnalysisData{\n  SomeInternalList: "))
-    return nullptr;
-
-  auto IsNewLine = [](char C) { return C == '\n'; };
-  llvm::StringRef SomeInternalListStr = Cursor.take_until(IsNewLine);
-  llvm::SmallVector<llvm::StringRef> Parts;
-  SomeInternalListStr.split(Parts, ", ");
-  for (llvm::StringRef Part : Parts) {
-    Result->SomeInternalList.push_back(Part.str());
-  }
-
-  Cursor = Cursor.drop_front(SomeInternalListStr.size());
-
-  if (!Cursor.consume_front("\n}\n"))
-    return nullptr;
-
-  if (!Cursor.empty())
-    return nullptr;
-
+  Result->Text = File.MockRepresentation;
   return std::move(Result);
 }
 

--- a/clang/unittests/Analysis/Scalable/Registries/MockSerializationFormat.cpp
+++ b/clang/unittests/Analysis/Scalable/Registries/MockSerializationFormat.cpp
@@ -8,29 +8,130 @@
 
 #include "Registries/MockSerializationFormat.h"
 #include "clang/Analysis/Scalable/Model/BuildNamespace.h"
+#include "clang/Analysis/Scalable/Model/EntityName.h"
+#include "clang/Analysis/Scalable/Model/SummaryName.h"
 #include "clang/Analysis/Scalable/Serialization/SerializationFormat.h"
 #include "clang/Analysis/Scalable/Serialization/SerializationFormatRegistry.h"
 #include "clang/Analysis/Scalable/TUSummary/TUSummary.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cassert>
+#include <functional>
+#include <memory>
+#include <set>
 
 using namespace clang;
 using namespace ssaf;
 
 MockSerializationFormat::MockSerializationFormat(
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS)
-    : SerializationFormat(FS) {}
+    : SerializationFormat(FS) {
+  for (const auto &FormatInfoEntry : llvm::Registry<FormatInfo>::entries()) {
+    std::unique_ptr<FormatInfo> Info = FormatInfoEntry.instantiate();
+    bool Inserted = FormatInfos.try_emplace(Info->ForSummary, *Info).second;
+    if (!Inserted) {
+      llvm::report_fatal_error(
+          "Format info was already registered for summary name: " +
+          Info->ForSummary.str());
+    }
+  }
+}
 
 TUSummary MockSerializationFormat::readTUSummary(llvm::StringRef Path) {
-  // TODO: Implement this.
   BuildNamespace NS(BuildNamespaceKind::CompilationUnit, "Mock.cpp");
   TUSummary Summary(NS);
+
+  auto ManifestFile = FS->getBufferForFile(Path + "/analyses.txt");
+  assert(ManifestFile); // TODO Handle error.
+  llvm::StringRef ManifestFileContent = (*ManifestFile)->getBuffer();
+
+  llvm::SmallVector<llvm::StringRef, 5> Analyses;
+  ManifestFileContent.split(Analyses, /*Separator=*/"\n", /*MaxSplit=*/-1,
+                            /*KeepEmpty=*/false);
+
+  for (llvm::StringRef Analysis : Analyses) {
+    SummaryName Name(Analysis.str());
+    auto InputFile = FS->getBufferForFile(Path + "/" + Name.str() + ".special");
+    assert(InputFile);
+    auto InfoIt = FormatInfos.find(Name);
+    if (InfoIt == FormatInfos.end()) {
+      llvm::report_fatal_error(
+          "No FormatInfo was registered for summary name: " + Name.str());
+    }
+    const auto &InfoEntry = InfoIt->second;
+    assert(InfoEntry.ForSummary == Name);
+
+    SpecialFileRepresentation Repr{(*InputFile)->getBuffer().str()};
+    auto &Table = getIdTableForDeserialization(Summary);
+
+    std::unique_ptr<EntitySummary> Result = InfoEntry.Deserialize(Repr, Table);
+    if (!Result) // TODO: Handle error.
+      continue;
+
+    EntityId FooId = Table.getId(EntityName{"c:@F@foo", "", /*Namespace=*/{}});
+    auto &IdMappings = getData(Summary).try_emplace(Name).first->second;
+    [[maybe_unused]] bool Inserted =
+        IdMappings.try_emplace(FooId, std::move(Result)).second;
+    assert(Inserted);
+  }
+
   return Summary;
 }
 
 void MockSerializationFormat::writeTUSummary(const TUSummary &Summary,
                                              llvm::StringRef OutputDir) {
-  // TODO: Implement this.
+  std::error_code EC;
+
+  // Check if output directory exists, create if needed
+  if (!llvm::sys::fs::exists(OutputDir)) {
+    EC = llvm::sys::fs::create_directories(OutputDir);
+    if (EC) {
+      llvm::report_fatal_error("Failed to create output directory '" +
+                               OutputDir + "': " + EC.message());
+    }
+  }
+
+  std::set<SummaryName> Analyses;
+  for (const auto &[SummaryName, EntityMappings] : getData(Summary)) {
+    [[maybe_unused]] bool Inserted = Analyses.insert(SummaryName).second;
+    assert(Inserted);
+    for (const auto &Data : llvm::make_second_range(EntityMappings)) {
+      auto InfoIt = FormatInfos.find(SummaryName);
+      if (InfoIt == FormatInfos.end()) {
+        llvm::report_fatal_error(
+            "There was no FormatInfo registered for summary name '" +
+            SummaryName.str() + "'");
+      }
+      const auto &InfoEntry = InfoIt->second;
+      assert(InfoEntry.ForSummary == SummaryName);
+
+      auto Output = InfoEntry.Serialize(*Data, *this);
+
+      std::string AnalysisFilePath =
+          (OutputDir + "/" + SummaryName.str() + ".special").str();
+      llvm::raw_fd_ostream AnalysisOutputFile(AnalysisFilePath, EC);
+      if (EC) {
+        llvm::report_fatal_error("Failed to create file '" + AnalysisFilePath +
+                                 "': " + llvm::StringRef(EC.message()));
+      }
+      AnalysisOutputFile << Output.MockRepresentation;
+    }
+  }
+
+  std::string ManifestFilePath = (OutputDir + "/analyses.txt").str();
+  llvm::raw_fd_ostream ManifestFile(ManifestFilePath, EC);
+  if (EC) {
+    llvm::report_fatal_error("Failed to create manifest file '" +
+                             ManifestFilePath +
+                             "': " + llvm::StringRef(EC.message()));
+  }
+
+  interleave(map_range(Analyses, std::mem_fn(&SummaryName::str)), ManifestFile,
+             "\n");
+  ManifestFile << "\n";
 }
 
 static SerializationFormatRegistry::Add<MockSerializationFormat>

--- a/clang/unittests/Analysis/Scalable/Registries/MockSerializationFormat.h
+++ b/clang/unittests/Analysis/Scalable/Registries/MockSerializationFormat.h
@@ -9,7 +9,10 @@
 #ifndef LLVM_CLANG_UNITTESTS_ANALYSIS_SCALABLE_REGISTRIES_MOCKSERIALIZATIONFORMAT_H
 #define LLVM_CLANG_UNITTESTS_ANALYSIS_SCALABLE_REGISTRIES_MOCKSERIALIZATIONFORMAT_H
 
+#include "clang/Analysis/Scalable/Model/SummaryName.h"
 #include "clang/Analysis/Scalable/Serialization/SerializationFormat.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include <string>
 
 namespace clang::ssaf {
 
@@ -22,6 +25,18 @@ public:
 
   void writeTUSummary(const TUSummary &Summary,
                       llvm::StringRef OutputDir) override;
+
+  struct SpecialFileRepresentation {
+    std::string MockRepresentation;
+  };
+
+  using SerializerFn = llvm::function_ref<SpecialFileRepresentation(
+      const EntitySummary &, MockSerializationFormat &)>;
+  using DeserializerFn = llvm::function_ref<std::unique_ptr<EntitySummary>(
+      const SpecialFileRepresentation &, EntityIdTable &)>;
+
+  using FormatInfo = FormatInfoEntry<SerializerFn, DeserializerFn>;
+  std::map<SummaryName, FormatInfo> FormatInfos;
 };
 
 } // namespace clang::ssaf

--- a/clang/unittests/Analysis/Scalable/Registries/SerializationFormatRegistryTest.cpp
+++ b/clang/unittests/Analysis/Scalable/Registries/SerializationFormatRegistryTest.cpp
@@ -58,15 +58,11 @@ TEST(SerializationFormatRegistryTest, EnumeratingRegistryEntries) {
 }
 
 TEST(SerializationFormatRegistryTest, Roundtrip) {
-  StringLiteral FancyAnalysisFileData = "FancyAnalysisData{\n"
-                                        "  SomeInternalList: zed, vayne, lux\n"
-                                        "}\n";
-
   auto Inputs = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
   Inputs->addFile("input/analyses.txt", /*ModificationTime=*/{},
                   MemoryBuffer::getMemBufferCopy("FancyAnalysis\n"));
   Inputs->addFile("input/FancyAnalysis.special", /*ModificationTime=*/{},
-                  MemoryBuffer::getMemBufferCopy(FancyAnalysisFileData));
+                  MemoryBuffer::getMemBufferCopy("Some FancyAnalysisData..."));
 
   std::unique_ptr<SerializationFormat> Format =
       makeFormat(Inputs, "MockSerializationFormat");
@@ -86,7 +82,7 @@ TEST(SerializationFormatRegistryTest, Roundtrip) {
   EXPECT_EQ(readFilesFromDir(OutputDir),
             (std::map<std::string, std::string>{
                 {"analyses.txt", "FancyAnalysis\n"},
-                {"FancyAnalysis.special", FancyAnalysisFileData.str()},
+                {"FancyAnalysis.special", "Some FancyAnalysisData..."},
             }));
 }
 

--- a/clang/unittests/Analysis/Scalable/Registries/SerializationFormatRegistryTest.cpp
+++ b/clang/unittests/Analysis/Scalable/Registries/SerializationFormatRegistryTest.cpp
@@ -7,12 +7,43 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Analysis/Scalable/Serialization/SerializationFormatRegistry.h"
+#include "clang/Analysis/Scalable/TUSummary/TUSummary.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "gtest/gtest.h"
+#include <memory>
 
+using namespace llvm;
 using namespace clang;
 using namespace ssaf;
 
+// Returns the file name and content in a map.
+static std::map<std::string, std::string> readFilesFromDir(StringRef DirPath) {
+  std::map<std::string, std::string> Result;
+  std::error_code EC;
+
+  for (sys::fs::directory_iterator It(DirPath, EC), End; It != End && !EC;
+       It.increment(EC)) {
+    StringRef FilePath = It->path();
+
+    if (sys::fs::is_directory(FilePath))
+      continue;
+
+    auto BufferOrErr = MemoryBuffer::getFile(FilePath);
+    if (!BufferOrErr)
+      continue;
+
+    // Store only the filename (relative to DirPath).
+    StringRef FileName = sys::path::filename(FilePath);
+    Result[FileName.str()] = BufferOrErr.get()->getBuffer().str();
+  }
+
+  return Result;
+}
 namespace {
 
 TEST(SerializationFormatRegistryTest, isFormatRegistered) {
@@ -24,6 +55,39 @@ TEST(SerializationFormatRegistryTest, EnumeratingRegistryEntries) {
   auto Formats = SerializationFormatRegistry::entries();
   ASSERT_EQ(std::distance(Formats.begin(), Formats.end()), 1U);
   EXPECT_EQ(Formats.begin()->getName(), "MockSerializationFormat");
+}
+
+TEST(SerializationFormatRegistryTest, Roundtrip) {
+  StringLiteral FancyAnalysisFileData = "FancyAnalysisData{\n"
+                                        "  SomeInternalList: zed, vayne, lux\n"
+                                        "}\n";
+
+  auto Inputs = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
+  Inputs->addFile("input/analyses.txt", /*ModificationTime=*/{},
+                  MemoryBuffer::getMemBufferCopy("FancyAnalysis\n"));
+  Inputs->addFile("input/FancyAnalysis.special", /*ModificationTime=*/{},
+                  MemoryBuffer::getMemBufferCopy(FancyAnalysisFileData));
+
+  std::unique_ptr<SerializationFormat> Format =
+      makeFormat(Inputs, "MockSerializationFormat");
+  ASSERT_TRUE(Format);
+
+  TUSummary LoadedSummary = Format->readTUSummary("input");
+
+  // Create a temporary output directory
+  SmallString<128> OutputDir;
+  std::error_code EC = sys::fs::createUniqueDirectory("ssaf-test", OutputDir);
+  ASSERT_FALSE(EC) << "Failed to create temporary directory: " << EC.message();
+  llvm::scope_exit CleanupOnExit(
+      [&] { sys::fs::remove_directories(OutputDir); });
+
+  Format->writeTUSummary(LoadedSummary, OutputDir);
+
+  EXPECT_EQ(readFilesFromDir(OutputDir),
+            (std::map<std::string, std::string>{
+                {"analyses.txt", "FancyAnalysis\n"},
+                {"FancyAnalysis.special", FancyAnalysisFileData.str()},
+            }));
 }
 
 } // namespace


### PR DESCRIPTION
Add `FormatInfoEntry` template to support per-analysis-type serialization within a `SerializationFormat`.
This allows to implement different formats for the different analyses in a decoupled way.

For testing, this patch also implements the MockSerializationFormat demonstrating the FormatInfo sub-registry pattern.

Assisted-by: claude

Depends on #179516

rdar://169192127