### PR TITLE
[Evaluator] require invariant size to fully span the global

### DIFF
--- a/llvm/lib/Transforms/Utils/Evaluator.cpp
+++ b/llvm/lib/Transforms/Utils/Evaluator.cpp
@@ -431,10 +431,9 @@ bool Evaluator::EvaluateBlock(BasicBlock::iterator CurInst, BasicBlock *&NextBB,
           Value *PtrArg = getVal(II->getArgOperand(1));
           Value *Ptr = PtrArg->stripPointerCasts();
           if (GlobalVariable *GV = dyn_cast<GlobalVariable>(Ptr)) {
-            Type *ElemTy = GV->getValueType();
+            uint64_t MinGVSize = GV->getGlobalSize(DL);
             if (!Size->isMinusOne() &&
-                Size->getValue().getLimitedValue() >=
-                    DL.getTypeStoreSize(ElemTy)) {
+                Size->getValue().getLimitedValue() >= MinGVSize) {
               Invariants.insert(GV);
               LLVM_DEBUG(dbgs() << "Found a global var that is an invariant: "
                                 << *GV << "\n");


### PR DESCRIPTION
Relying on the semantics of the type here is a bit potentially awkward, since the full allocated space may be accessible to the user if desired, since that space is defined to be a part of the type's sizeof computation (e.g. for a `memcpy(gv, gv, sizeof(*gv))` or when making an array of them). It also gets in the way of removing getAllocatedType from AllocaInst entirely (they are converted to GlobalVariable sometimes). It was originally added in 519561f418c77dcf46fd6d96d25d884fa07fd7da, though "correct size" is a difficult thing to define.

The frontend (in clang) appears to always emit the full type size here, so there seems like this shouldn't be visible change to clang users.

This is still a bit awkward though, since a global is defined to be any size that is bigger than this unless it has a known initizalizer, rendering the test still incomplete here against the IR semantics.