### PR TITLE
[libc++] Use ValueError instead of non-existent ArgumentError

### DIFF
--- a/libcxx/test/libcxx-03/transitive_includes/to_csv.py
+++ b/libcxx/test/libcxx-03/transitive_includes/to_csv.py
@@ -28,7 +28,7 @@ def parse_line(line: str) -> Tuple[int, str]:
     """
     match = re.match(r"(\.+) (.+)", line)
     if not match:
-        raise ArgumentError(f"Line {line} contains invalid data.")
+        raise ValueError(f"Line {line} contains invalid data.")
 
     # The number of periods in front of the header name is the nesting level of
     # that header.

--- a/libcxx/test/libcxx/transitive_includes/to_csv.py
+++ b/libcxx/test/libcxx/transitive_includes/to_csv.py
@@ -28,7 +28,7 @@ def parse_line(line: str) -> Tuple[int, str]:
     """
     match = re.match(r"(\.+) (.+)", line)
     if not match:
-        raise ArgumentError(f"Line {line} contains invalid data.")
+        raise ValueError(f"Line {line} contains invalid data.")
 
     # The number of periods in front of the header name is the nesting level of
     # that header.


### PR DESCRIPTION
ArgumentError does not exist. argparse.ArgumentError does exist, but that is not what we want to use. I presume this was never caught because we never execute that line.