### PR TITLE
[TableGen] Remove warning IntrinsicsToAttributesMap needs > 16 bits

### DIFF
--- a/llvm/utils/TableGen/Basic/IntrinsicEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/IntrinsicEmitter.cpp
@@ -654,10 +654,6 @@ static AttributeSet getIntrinsicFnAttributeSet(LLVMContext &C, unsigned ID) {
     AttributesMapDataBitSize = 8;
   else if (AttributesMapDataBitSize > 64)
     PrintFatalError("Packed ID of IntrinsicsToAttributesMap exceeds 64b!");
-  else if (AttributesMapDataBitSize > 16)
-    PrintWarning("Packed ID of IntrinsicsToAttributesMap exceeds 16b, "
-                 "this may cause performance drop (pr106809), "
-                 "please consider redesigning intrinsic sets!");
 
   // Assign a packed ID for each intrinsic. The lower bits will be its
   // "argument attribute ID" (index in UniqAttributes) and upper bits will be


### PR DESCRIPTION
Remove the warning issued by intrinsic emitter when an entry in the `IntrinsicsToAttributesMap` is > 16 bits. The exact conditions under which this happen is tightly coupled with how the intrinsic emitter represents intrinsic attributes and generally this warning may not be actionable in any way without changing the semantics of the intrinsics being compiled (i.e., changing their attributes to have less number of unique attributes).