### PR TITLE
[flang] Refactor "unused"/"used without definition" warnings

### DIFF
--- a/flang/include/flang/Evaluate/check-expression.h
+++ b/flang/include/flang/Evaluate/check-expression.h
@@ -180,5 +180,14 @@ std::optional<parser::Message> CheckStatementFunction(
 std::optional<bool> ActualArgNeedsCopy(const ActualArgument *,
     const characteristics::DummyArgument *, FoldingContext &, bool forCopyOut);
 
+// Scan expressions and note uses of values of symbols.
+semantics::UnorderedSymbolSet CollectUsedSymbolValues(
+    semantics::SemanticsContext &, const Expr<SomeType> &,
+    bool isDefinition = false);
+semantics::UnorderedSymbolSet CollectUsedSymbolValues(
+    semantics::SemanticsContext &, const ProcedureRef &);
+semantics::UnorderedSymbolSet CollectUsedSymbolValues(
+    semantics::SemanticsContext &, const Assignment &);
+
 } // namespace Fortran::evaluate
 #endif

--- a/flang/include/flang/Evaluate/tools.h
+++ b/flang/include/flang/Evaluate/tools.h
@@ -1638,6 +1638,9 @@ std::optional<int> GetDummyArgumentNumber(const Symbol *);
 
 const Symbol *FindAncestorModuleProcedure(const Symbol *symInSubmodule);
 
+// Given a Cray pointee symbol, returns the related Cray pointer symbol.
+const Symbol &GetCrayPointer(const Symbol &crayPointee);
+
 } // namespace Fortran::semantics
 
 #endif // FORTRAN_EVALUATE_TOOLS_H_

--- a/flang/include/flang/Semantics/semantics.h
+++ b/flang/include/flang/Semantics/semantics.h
@@ -332,6 +332,7 @@ public:
   void NoteDefinedSymbol(const Symbol &);
   bool IsSymbolDefined(const Symbol &) const;
   void NoteUsedSymbol(const Symbol &);
+  void NoteUsedSymbols(const UnorderedSymbolSet &);
   bool IsSymbolUsed(const Symbol &) const;
 
   void DumpSymbols(llvm::raw_ostream &);

--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -334,9 +334,6 @@ const Symbol *FindExternallyVisibleObject(
 // specific procedure of the same name, return it instead.
 const Symbol &BypassGeneric(const Symbol &);
 
-// Given a cray pointee symbol, returns the related cray pointer symbol.
-const Symbol &GetCrayPointer(const Symbol &crayPointee);
-
 using SomeExpr = evaluate::Expr<evaluate::SomeType>;
 
 bool ExprHasTypeCategory(

--- a/flang/lib/Evaluate/tools.cpp
+++ b/flang/lib/Evaluate/tools.cpp
@@ -2645,4 +2645,16 @@ const Symbol *FindAncestorModuleProcedure(const Symbol *symInSubmodule) {
   return nullptr;
 }
 
+const Symbol &GetCrayPointer(const Symbol &crayPointee) {
+  const Symbol *found{nullptr};
+  const Symbol &ultimate{crayPointee.GetUltimate()};
+  for (const auto &[pointee, pointer] : ultimate.owner().crayPointers()) {
+    if (pointee == ultimate.name()) {
+      found = &pointer.get();
+      break;
+    }
+  }
+  return DEREF(found);
+}
+
 } // namespace Fortran::semantics

--- a/flang/lib/Semantics/check-coarray.cpp
+++ b/flang/lib/Semantics/check-coarray.cpp
@@ -9,6 +9,7 @@
 #include "check-coarray.h"
 #include "definable.h"
 #include "flang/Common/indirection.h"
+#include "flang/Evaluate/check-expression.h"
 #include "flang/Evaluate/expression.h"
 #include "flang/Parser/message.h"
 #include "flang/Parser/parse-tree.h"

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -5321,94 +5321,10 @@ evaluate::Expr<evaluate::SubscriptInteger> AnalyzeKindSelector(
   return analyzer.AnalyzeKindSelector(category, selector);
 }
 
-// NoteUsedSymbols()
-
-static void NoteUsedSymbol(SemanticsContext &context, const Symbol &symbol) {
-  const Symbol &root{GetAssociationRoot(symbol)};
-  switch (root.owner().kind()) {
-  case semantics::Scope::Kind::Subprogram:
-  case semantics::Scope::Kind::MainProgram:
-  case semantics::Scope::Kind::BlockConstruct:
-    if ((root.has<semantics::ObjectEntityDetails>() ||
-            IsProcedurePointer(root))) {
-      context.NoteUsedSymbol(root);
-      if (root.test(Symbol::Flag::CrayPointee)) {
-        context.NoteUsedSymbol(GetCrayPointer(root));
-      }
-    }
-    break;
-  default:
-    break;
-  }
-}
-
-template <typename A>
-void NoteUsedSymbolsHelper(SemanticsContext &context, const A &x) {
-  if (context.ShouldWarn(common::UsageWarning::UnusedVariable)) {
-    for (const Symbol &symbol : CollectSymbols(x)) {
-      NoteUsedSymbol(context, symbol);
-    }
-  }
-}
-
-void NoteUsedSymbols(SemanticsContext &context, const SomeExpr &expr) {
-  NoteUsedSymbolsHelper(context, expr);
-}
-
-static bool IsBindingUsedAsProcedure(const SomeExpr &expr) {
-  if (const auto *pd{std::get_if<evaluate::ProcedureDesignator>(&expr.u)}) {
-    if (const Symbol *symbol{pd->GetSymbol()}) {
-      return symbol->has<ProcBindingDetails>();
-    }
-  }
-  return false;
-}
-
 void NoteUsedSymbols(
-    SemanticsContext &context, const evaluate::ProcedureRef &call) {
-  NoteUsedSymbolsHelper(context, call.proc());
-  for (const auto &maybeArg : call.arguments()) {
-    if (maybeArg) {
-      if (const auto *expr{maybeArg->UnwrapExpr()}) {
-        if (!IsBindingUsedAsProcedure(*expr)) {
-          // Ignore procedure bindings being used as actual procedures
-          // (a local extension).
-          NoteUsedSymbolsHelper(context, *expr);
-        }
-      }
-    }
-  }
-}
-
-void NoteUsedSymbols(
-    SemanticsContext &context, const evaluate::Assignment &assignment) {
-  if (IsBindingUsedAsProcedure(assignment.rhs)) {
-    // Don't look at the RHS, we're just using its binding (extension).
-    NoteUsedSymbolsHelper(context, assignment.lhs);
-  } else {
-    NoteUsedSymbolsHelper(context, assignment);
-  }
-}
-
-void NoteUsedSymbols(
-    SemanticsContext &context, const parser::TypedExpr &typedExpr) {
-  if (typedExpr && typedExpr->v) {
-    NoteUsedSymbols(context, *typedExpr->v);
-  }
-}
-
-void NoteUsedSymbols(
-    SemanticsContext &context, const parser::TypedCall &typedCall) {
-  if (typedCall) {
-    NoteUsedSymbols(context, *typedCall);
-  }
-}
-
-void NoteUsedSymbols(
-    SemanticsContext &context, const parser::TypedAssignment &typedAssignment) {
-  if (typedAssignment && typedAssignment->v) {
-    NoteUsedSymbols(context, *typedAssignment->v);
-  }
+    SemanticsContext &context, const SomeExpr &expr, bool isDefinition) {
+  context.NoteUsedSymbols(
+      evaluate::CollectUsedSymbolValues(context, expr, isDefinition));
 }
 
 ExprChecker::ExprChecker(SemanticsContext &context) : context_{context} {}

--- a/flang/lib/Semantics/semantics.cpp
+++ b/flang/lib/Semantics/semantics.cpp
@@ -819,6 +819,11 @@ bool SemanticsContext::IsSymbolDefined(const Symbol &symbol) const {
 void SemanticsContext::NoteUsedSymbol(const Symbol &symbol) {
   isUsed_.insert(symbol);
 }
+void SemanticsContext::NoteUsedSymbols(const UnorderedSymbolSet &set) {
+  for (const Symbol &symbol : set) {
+    NoteUsedSymbol(symbol);
+  }
+}
 
 bool SemanticsContext::IsSymbolUsed(const Symbol &symbol) const {
   return isUsed_.find(symbol) != isUsed_.end();

--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -346,18 +346,6 @@ const Symbol &BypassGeneric(const Symbol &symbol) {
   return symbol;
 }
 
-const Symbol &GetCrayPointer(const Symbol &crayPointee) {
-  const Symbol *found{nullptr};
-  const Symbol &ultimate{crayPointee.GetUltimate()};
-  for (const auto &[pointee, pointer] : ultimate.owner().crayPointers()) {
-    if (pointee == ultimate.name()) {
-      found = &pointer.get();
-      break;
-    }
-  }
-  return DEREF(found);
-}
-
 bool ExprHasTypeCategory(
     const SomeExpr &expr, const common::TypeCategory &type) {
   auto dynamicType{expr.GetType()};

--- a/flang/test/Semantics/bug2174.f90
+++ b/flang/test/Semantics/bug2174.f90
@@ -1,0 +1,6 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+!WARNING: Value of local variable 'x' is never used [-Wunused-variable]
+real, allocatable:: x(:)
+allocate(x(1))
+print *, lbound(x)
+end


### PR DESCRIPTION
I'm emitting a false warning "used without definition" warning for variable cited in an inquiry intrinsic (e.g. LBOUND), and failing to emit an "unused local" warning for allocatables that only appear in ALLOCATE statements.

This patch makes the analysis more context-aware by rewriting it in terms of typed expression traversal, and moves the analysis part into Evaluate/check-expression.cpp from Semantics/expression.cpp.