### PR TITLE
[SystemZ][z/OS] Reverse the order of instructions to save and restore CSRs

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZFrameLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZFrameLowering.cpp
@@ -1153,6 +1153,10 @@ bool SystemZXPLINKFrameLowering::spillCalleeSavedRegisters(
   }
 
   // Spill FPRs to the stack in the normal TargetInstrInfo way
+  // Registers in CSI are in inverted order so registers with large
+  // numbers will be assigned to high address.
+  // Reverse the order at spilling and restoring so instructions on
+  // registers with small numbers are emitted first.
   for (const CalleeSavedInfo &I : llvm::reverse(CSI)) {
     MCRegister Reg = I.getReg();
     if (SystemZ::FP64BitRegClass.contains(Reg)) {

--- a/llvm/lib/Target/SystemZ/SystemZFrameLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZFrameLowering.cpp
@@ -12,6 +12,7 @@
 #include "SystemZMachineFunctionInfo.h"
 #include "SystemZRegisterInfo.h"
 #include "SystemZSubtarget.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/CodeGen/LivePhysRegs.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
@@ -1152,7 +1153,7 @@ bool SystemZXPLINKFrameLowering::spillCalleeSavedRegisters(
   }
 
   // Spill FPRs to the stack in the normal TargetInstrInfo way
-  for (const CalleeSavedInfo &I : CSI) {
+  for (const CalleeSavedInfo &I : llvm::reverse(CSI)) {
     MCRegister Reg = I.getReg();
     if (SystemZ::FP64BitRegClass.contains(Reg)) {
       MBB.addLiveIn(Reg);
@@ -1185,7 +1186,7 @@ bool SystemZXPLINKFrameLowering::restoreCalleeSavedRegisters(
   DebugLoc DL = MBBI != MBB.end() ? MBBI->getDebugLoc() : DebugLoc();
 
   // Restore FPRs in the normal TargetInstrInfo way.
-  for (const CalleeSavedInfo &I : CSI) {
+  for (const CalleeSavedInfo &I : llvm::reverse(CSI)) {
     MCRegister Reg = I.getReg();
     if (SystemZ::FP64BitRegClass.contains(Reg))
       TII->loadRegFromStackSlot(MBB, MBBI, Reg, I.getFrameIdx(),

--- a/llvm/test/CodeGen/SystemZ/zos-prologue-epilog.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-prologue-epilog.ll
@@ -87,39 +87,39 @@ define void @func1(ptr %ptr) {
 ; CHECK-LABEL: func2
 ; CHECK64: stmg	6,7,1744(4)
 ; CHECK64: aghi  4,-320
-; CHECK64: std	15,{{[0-9]+}}(4)                      * 8-byte Spill
-; CHECK64: std	14,{{[0-9]+}}(4)                      * 8-byte Spill
-; CHECK64: std	13,{{[0-9]+}}(4)                      * 8-byte Spill
-; CHECK64: std	12,{{[0-9]+}}(4)                      * 8-byte Spill
-; CHECK64: std	11,{{[0-9]+}}(4)                      * 8-byte Spill
-; CHECK64: std	10,{{[0-9]+}}(4)                      * 8-byte Spill
-; CHECK64: std	9,{{[0-9]+}}(4)                       * 8-byte Spill
+; CHECK64: vst  16,{{[0-9]+}}(4),4                   * 16-byte Spill
+; CHECK64: vst  17,{{[0-9]+}}(4),4                   * 16-byte Spill
+; CHECK64: vst  18,{{[0-9]+}}(4),4                   * 16-byte Spill
+; CHECK64: vst  19,{{[0-9]+}}(4),4                   * 16-byte Spill
+; CHECK64: vst  20,{{[0-9]+}}(4),4                   * 16-byte Spill
+; CHECK64: vst  21,{{[0-9]+}}(4),4                   * 16-byte Spill
+; CHECK64: vst  22,{{[0-9]+}}(4),4                   * 16-byte Spill
+; CHECK64: vst  23,{{[0-9]+}}(4),4                   * 16-byte Spill
 ; CHECK64: std	8,{{[0-9]+}}(4)                       * 8-byte Spill
-; CHECK64: vst	23,{{[0-9]+}}(4),4                   * 16-byte Spill
-; CHECK64: vst	22,{{[0-9]+}}(4),4                   * 16-byte Spill
-; CHECK64: vst	21,{{[0-9]+}}(4),4                   * 16-byte Spill
-; CHECK64: vst	20,{{[0-9]+}}(4),4                   * 16-byte Spill
-; CHECK64: vst	19,{{[0-9]+}}(4),4                   * 16-byte Spill
-; CHECK64: vst	18,{{[0-9]+}}(4),4                   * 16-byte Spill
-; CHECK64: vst	17,{{[0-9]+}}(4),4                   * 16-byte Spill
-; CHECK64: vst	16,{{[0-9]+}}(4),4                   * 16-byte Spill
+; CHECK64: std	9,{{[0-9]+}}(4)                       * 8-byte Spill
+; CHECK64: std	10,{{[0-9]+}}(4)                      * 8-byte Spill
+; CHECK64: std	11,{{[0-9]+}}(4)                      * 8-byte Spill
+; CHECK64: std	12,{{[0-9]+}}(4)                      * 8-byte Spill
+; CHECK64: std	13,{{[0-9]+}}(4)                      * 8-byte Spill
+; CHECK64: std	14,{{[0-9]+}}(4)                      * 8-byte Spill
+; CHECK64: std	15,{{[0-9]+}}(4)                      * 8-byte Spill
 
-; CHECK64: ld	15,{{[0-9]+}}(4)                      * 8-byte Reload
-; CHECK64: ld	14,{{[0-9]+}}(4)                      * 8-byte Reload
-; CHECK64: ld	13,{{[0-9]+}}(4)                      * 8-byte Reload
-; CHECK64: ld	12,{{[0-9]+}}(4)                      * 8-byte Reload
-; CHECK64: ld	11,{{[0-9]+}}(4)                      * 8-byte Reload
-; CHECK64: ld	10,{{[0-9]+}}(4)                      * 8-byte Reload
-; CHECK64: ld	9,{{[0-9]+}}(4)                       * 8-byte Reload
+; CHECK64: vl   16,{{[0-9]+}}(4),4                   * 16-byte Reload
+; CHECK64: vl   17,{{[0-9]+}}(4),4                   * 16-byte Reload
+; CHECK64: vl   18,{{[0-9]+}}(4),4                   * 16-byte Reload
+; CHECK64: vl   19,{{[0-9]+}}(4),4                   * 16-byte Reload
+; CHECK64: vl   20,{{[0-9]+}}(4),4                   * 16-byte Reload
+; CHECK64: vl   21,{{[0-9]+}}(4),4                   * 16-byte Reload
+; CHECK64: vl   22,{{[0-9]+}}(4),4                   * 16-byte Reload
+; CHECK64: vl   23,{{[0-9]+}}(4),4                   * 16-byte Reload
 ; CHECK64: ld	8,{{[0-9]+}}(4)                       * 8-byte Reload
-; CHECK64: vl	23,{{[0-9]+}}(4),4                   * 16-byte Reload
-; CHECK64: vl	22,{{[0-9]+}}(4),4                   * 16-byte Reload
-; CHECK64: vl	21,{{[0-9]+}}(4),4                   * 16-byte Reload
-; CHECK64: vl	20,{{[0-9]+}}(4),4                   * 16-byte Reload
-; CHECK64: vl	19,{{[0-9]+}}(4),4                   * 16-byte Reload
-; CHECK64: vl	18,{{[0-9]+}}(4),4                   * 16-byte Reload
-; CHECK64: vl	17,{{[0-9]+}}(4),4                   * 16-byte Reload
-; CHECK64: vl	16,{{[0-9]+}}(4),4                   * 16-byte Reload
+; CHECK64: ld	9,{{[0-9]+}}(4)                       * 8-byte Reload
+; CHECK64: ld	10,{{[0-9]+}}(4)                      * 8-byte Reload
+; CHECK64: ld	11,{{[0-9]+}}(4)                      * 8-byte Reload
+; CHECK64: ld	12,{{[0-9]+}}(4)                      * 8-byte Reload
+; CHECK64: ld	13,{{[0-9]+}}(4)                      * 8-byte Reload
+; CHECK64: ld	14,{{[0-9]+}}(4)                      * 8-byte Reload
+; CHECK64: ld	15,{{[0-9]+}}(4)                      * 8-byte Reload
 ; CHECK64: lg  7,2072(4)
 ; CHECK64: aghi  4,320
 ; CHECK64: b 2(7)


### PR DESCRIPTION
Reverse the order of instructions to save and restore CSRs so instruction on small numbered reg goes first.