### PR TITLE
[flang] Set common linkage to common block with zero initializer

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -3345,12 +3345,14 @@ struct GlobalOpConversion : public fir::FIROpConversion<fir::GlobalOp> {
           rewriter.setInsertionPointAfter(insertOp);
           rewriter.replaceOpWithNewOp<mlir::arith::ConstantOp>(
               insertOp, seqTyAttr, denseAttr);
-          if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(constant.getValue()))
+          if (auto intAttr =
+                  mlir::dyn_cast<mlir::IntegerAttr>(constant.getValue()))
             if (intAttr.getInt() == 0)
               ++nbZeroInitializers;
         }
       }
-      if (nbRanges > 0 && nbRanges == nbZeroInitializers && linkage == mlir::LLVM::Linkage::External)
+      if (nbRanges > 0 && nbRanges == nbZeroInitializers &&
+          linkage == mlir::LLVM::Linkage::External)
         g.setLinkage(mlir::LLVM::Linkage::Common);
     }
 

--- a/flang/test/Fir/common-block-zero-init.fir
+++ b/flang/test/Fir/common-block-zero-init.fir
@@ -1,0 +1,12 @@
+  // RUN: %flang_fc1 -emit-llvm %s -o - | FileCheck %s
+  
+  fir.global @cdb_com_ {acc.declare = #acc.declare<dataClause =  acc_create>, alignment = 4 : i64} : tuple<!fir.array<100xi32>> {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = fir.zero_bits tuple<!fir.array<100xi32>>
+    %1 = fir.undefined !fir.array<100xi32>
+    %2 = fir.insert_on_range %1, %c0_i32 from (0) to (99) : (!fir.array<100xi32>, i32) -> !fir.array<100xi32>
+    %3 = fir.insert_value %0, %2, [0 : index] : (tuple<!fir.array<100xi32>>, !fir.array<100xi32>) -> tuple<!fir.array<100xi32>>
+    fir.has_value %3 : tuple<!fir.array<100xi32>>
+  }
+
+// CHECK-LABEL: @cdb_com_ = common global { [100 x i32] } zeroinitializer


### PR DESCRIPTION
Currently, we do not set a linkage for common block with an init region. With some linker this is problematic because we can have multiple global for the common block with different linkage and the linker will complain about multiple definition. 

```
MODULE M
      INTEGER*4 CODE(100)
      COMMON/COM/CODE
      DATA CODE/100*0/
END MODULE
```

```
SUBROUTINE SUB1(CODE)
      IMPLICIT NONE
      INTEGER*4 CODE
      INTEGER*4 CODE(100)
      COMMON/COM/CODE
      END SUBROUTINE
```

This patch detect zero initializer region and set the linkage to common when it was not set. 