### PR TITLE
[libc] Disable strong stack protector for baremetal

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -48,5 +48,10 @@
     "LIBC_ADD_NULL_CHECKS": {
       "value": false
     }
+  },
+  "codegen": {
+    "LIBC_CONF_ENABLE_STRONG_STACK_PROTECTOR": {
+      "value": false
+    }
   }
 }


### PR DESCRIPTION
Strong stack protector introduces references to __stack_chk_guard
symbols with GOT relocation in ARM 32 bit targets which is not supported
in typical baremetal environments. Turning this off for baremetal.
