### PR TITLE
[lldb] Refactor JSONTransport own MainLoop read handle.

### DIFF
--- a/lldb/include/lldb/Protocol/MCP/Server.h
+++ b/lldb/include/lldb/Protocol/MCP/Server.h
@@ -70,7 +70,6 @@ private:
 
   LogCallback m_log_callback;
   struct Client {
-    ReadHandleUP handle;
     MCPTransportUP transport;
     MCPBinderUP binder;
   };

--- a/lldb/include/lldb/Protocol/MCP/Server.h
+++ b/lldb/include/lldb/Protocol/MCP/Server.h
@@ -21,6 +21,7 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/Signals.h"
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -40,7 +41,7 @@ public:
   void AddTool(std::unique_ptr<Tool> tool);
   void AddResourceProvider(std::unique_ptr<ResourceProvider> resource_provider);
 
-  llvm::Error Accept(lldb_private::MainLoop &, MCPTransportUP);
+  llvm::Error Accept(MCPTransportUP);
 
 protected:
   MCPBinderUP Bind(MCPTransport &);

--- a/lldb/include/lldb/Protocol/MCP/Transport.h
+++ b/lldb/include/lldb/Protocol/MCP/Transport.h
@@ -83,8 +83,8 @@ using LogCallback = llvm::unique_function<void(llvm::StringRef message)>;
 class Transport final
     : public lldb_private::transport::JSONRPCTransport<ProtocolDescriptor> {
 public:
-  Transport(lldb::IOObjectSP in, lldb::IOObjectSP out,
-            LogCallback log_callback = {});
+  Transport(lldb_private::MainLoop &loop, lldb::IOObjectSP in,
+            lldb::IOObjectSP out, LogCallback log_callback = {});
   virtual ~Transport() = default;
 
   /// Transport is not copyable.

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
@@ -66,7 +66,7 @@ void ProtocolServerMCP::AcceptCallback(std::unique_ptr<Socket> socket) {
 
   lldb::IOObjectSP io_sp = std::move(socket);
   auto transport_up = std::make_unique<lldb_protocol::mcp::Transport>(
-      io_sp, io_sp, [client_name](llvm::StringRef message) {
+      m_loop, io_sp, io_sp, [client_name](llvm::StringRef message) {
         LLDB_LOG(GetLog(LLDBLog::Host), "{0}: {1}", client_name, message);
       });
 

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
@@ -70,7 +70,7 @@ void ProtocolServerMCP::AcceptCallback(std::unique_ptr<Socket> socket) {
         LLDB_LOG(GetLog(LLDBLog::Host), "{0}: {1}", client_name, message);
       });
 
-  if (auto error = m_server->Accept(m_loop, std::move(transport_up)))
+  if (auto error = m_server->Accept(std::move(transport_up)))
     LLDB_LOG_ERROR(log, std::move(error), "{0}:");
 }
 

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
@@ -13,11 +13,12 @@
 #include "lldb/Host/MainLoop.h"
 #include "lldb/Host/Socket.h"
 #include "lldb/Protocol/MCP/Server.h"
-#include "lldb/Protocol/MCP/Transport.h"
-#include <map>
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include <cstddef>
 #include <memory>
+#include <mutex>
 #include <thread>
-#include <tuple>
 #include <vector>
 
 namespace lldb_private::mcp {

--- a/lldb/source/Protocol/MCP/Server.cpp
+++ b/lldb/source/Protocol/MCP/Server.cpp
@@ -144,7 +144,7 @@ MCPBinderUP Server::Bind(MCPTransport &transport) {
   return binder_up;
 }
 
-llvm::Error Server::Accept(MainLoop &loop, MCPTransportUP transport) {
+llvm::Error Server::Accept(MCPTransportUP transport) {
   MCPBinderUP binder = Bind(*transport);
   MCPTransport *transport_ptr = transport.get();
   binder->OnDisconnect([this, transport_ptr]() {

--- a/lldb/source/Protocol/MCP/Server.cpp
+++ b/lldb/source/Protocol/MCP/Server.cpp
@@ -156,12 +156,10 @@ llvm::Error Server::Accept(MainLoop &loop, MCPTransportUP transport) {
     Logv("Transport error: {0}", llvm::toString(std::move(err)));
   });
 
-  auto handle = transport->RegisterMessageHandler(loop, *binder);
-  if (!handle)
-    return handle.takeError();
+  if (llvm::Error err = transport->RegisterMessageHandler(*binder))
+    return err;
 
-  m_instances[transport_ptr] =
-      Client{std::move(*handle), std::move(transport), std::move(binder)};
+  m_instances[transport_ptr] = Client{std::move(transport), std::move(binder)};
   return llvm::Error::success();
 }
 

--- a/lldb/source/Protocol/MCP/Transport.cpp
+++ b/lldb/source/Protocol/MCP/Transport.cpp
@@ -13,9 +13,10 @@
 using namespace lldb_protocol::mcp;
 using namespace llvm;
 
-Transport::Transport(lldb::IOObjectSP in, lldb::IOObjectSP out,
-                     LogCallback log_callback)
-    : JSONRPCTransport(in, out), m_log_callback(std::move(log_callback)) {}
+Transport::Transport(lldb_private::MainLoop &loop, lldb::IOObjectSP in,
+                     lldb::IOObjectSP out, LogCallback log_callback)
+    : JSONRPCTransport(loop, in, out), m_log_callback(std::move(log_callback)) {
+}
 
 void Transport::Log(StringRef message) {
   if (m_log_callback)

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1046,9 +1046,8 @@ void DAP::TransportHandler() {
     m_queue_cv.notify_all();
   });
 
-  auto handle = transport.RegisterMessageHandler(m_loop, *this);
-  if (!handle) {
-    DAP_LOG_ERROR(log, handle.takeError(),
+  if (llvm::Error err = transport.RegisterMessageHandler(*this)) {
+    DAP_LOG_ERROR(log, std::move(err),
                   "registering message handler failed: {0}");
     std::lock_guard<std::mutex> guard(m_queue_mutex);
     m_error_occurred = true;

--- a/lldb/tools/lldb-dap/Transport.cpp
+++ b/lldb/tools/lldb-dap/Transport.cpp
@@ -17,9 +17,9 @@ using namespace lldb_private;
 
 namespace lldb_dap {
 
-Transport::Transport(lldb_dap::Log &log, lldb::IOObjectSP input,
-                     lldb::IOObjectSP output)
-    : HTTPDelimitedJSONTransport(input, output), m_log(log) {}
+Transport::Transport(lldb_dap::Log &log, lldb_private::MainLoop &loop,
+                     lldb::IOObjectSP input, lldb::IOObjectSP output)
+    : HTTPDelimitedJSONTransport(loop, input, output), m_log(log) {}
 
 void Transport::Log(llvm::StringRef message) {
   // Emit the message directly, since this log was forwarded.

--- a/lldb/tools/lldb-dap/Transport.h
+++ b/lldb/tools/lldb-dap/Transport.h
@@ -35,8 +35,8 @@ class Transport final
     : public lldb_private::transport::HTTPDelimitedJSONTransport<
           ProtocolDescriptor> {
 public:
-  Transport(lldb_dap::Log &log, lldb::IOObjectSP input,
-            lldb::IOObjectSP output);
+  Transport(lldb_dap::Log &log, lldb_private::MainLoop &loop,
+            lldb::IOObjectSP input, lldb::IOObjectSP output);
   virtual ~Transport() = default;
 
   void Log(llvm::StringRef message) override;

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -47,7 +47,6 @@
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
-#include <condition_variable>
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
@@ -463,7 +462,7 @@ static llvm::Error serveConnection(
       DAP_LOG(client_log, "client connected");
 
       MainLoop loop;
-      Transport transport(client_log, io, io);
+      Transport transport(client_log, loop, io, io);
       DAP dap(client_log, default_repl_mode, pre_init_commands, no_lldbinit,
               client_name, transport, loop);
 
@@ -738,7 +737,7 @@ int main(int argc, char *argv[]) {
   constexpr llvm::StringLiteral client_name = "stdio";
   MainLoop loop;
   Log client_log = log.WithPrefix("(stdio)");
-  Transport transport(client_log, input, output);
+  Transport transport(client_log, loop, input, output);
   DAP dap(client_log, default_repl_mode, pre_init_commands, no_lldbinit,
           client_name, transport, loop);
 

--- a/lldb/unittests/DAP/TestBase.cpp
+++ b/lldb/unittests/DAP/TestBase.cpp
@@ -35,7 +35,7 @@ using lldb_private::MainLoop;
 using lldb_private::Pipe;
 
 void TransportBase::SetUp() {
-  std::tie(to_client, to_server) = TestDAPTransport::createPair();
+  std::tie(to_client, to_server) = TestDAPTransport::createPair(loop);
 
   log = std::make_unique<Log>(llvm::outs(), log_mutex);
   dap = std::make_unique<DAP>(
@@ -46,13 +46,8 @@ void TransportBase::SetUp() {
       /*client_name=*/"test_client",
       /*transport=*/*to_client, /*loop=*/loop);
 
-  auto server_handle = to_server->RegisterMessageHandler(loop, *dap);
-  EXPECT_THAT_EXPECTED(server_handle, Succeeded());
-  handles[0] = std::move(*server_handle);
-
-  auto client_handle = to_client->RegisterMessageHandler(loop, client);
-  EXPECT_THAT_EXPECTED(client_handle, Succeeded());
-  handles[1] = std::move(*client_handle);
+  EXPECT_THAT_ERROR(to_server->RegisterMessageHandler(*dap), Succeeded());
+  EXPECT_THAT_ERROR(to_client->RegisterMessageHandler(client), Succeeded());
 }
 
 void TransportBase::Run() {

--- a/lldb/unittests/DAP/TestBase.h
+++ b/lldb/unittests/DAP/TestBase.h
@@ -59,7 +59,6 @@ protected:
   lldb_private::SubsystemRAII<lldb_private::FileSystem, lldb_private::HostInfo>
       subsystems;
   lldb_private::MainLoop loop;
-  lldb_private::MainLoop::ReadHandleUP handles[2];
 
   std::unique_ptr<lldb_dap::Log> log;
   lldb_dap::Log::Mutex log_mutex;


### PR DESCRIPTION
When working with a MainLoop, if the file reaches the EOF it will immediately fire the read handle callback. We cannot readily determine if the file is at EOF or if the file is pointing to a socket/pipe that has consumed all the current data in the buffer but the remote end has not yet hung up. This is causing JSONTransport to continuously fire the OnRead callback trigging repeated calls to the `MessageHandler::OnClose`.

Since MainLoop does not perform the actual read, we need to adjust the behavior of JSONTransport to fully own the read handle.

This change moves the ownership of the `MainLoop::ReadHandleUP` and additionally own a reference to the `MainLoop` itself to ensure the loop outlives the JSONTransport object.

This allows us to remove the handle immediately when we detect an EOF / hang up has occurred.