### PR TITLE
[flang][CUDA] Better analysis of actual argument CUDA data attrs

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1058,9 +1058,9 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
 
   // Warn about dubious actual argument association with a TARGET dummy
   // argument
+  bool actualIsVariable{evaluate::IsVariable(actual)};
   if (dummy.attrs.test(characteristics::DummyDataObject::Attr::Target) &&
       context.ShouldWarn(common::UsageWarning::NonTargetPassedToTarget)) {
-    bool actualIsVariable{evaluate::IsVariable(actual)};
     bool actualIsTemp{
         !actualIsVariable || HasVectorSubscript(actual) || actualCoarrayRef};
     if (actualIsTemp) {
@@ -1084,10 +1084,15 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
       !dummy.attrs.test(characteristics::DummyDataObject::Attr::Value) &&
       !FindOpenACCConstructContaining(scope)) {
     std::optional<common::CUDADataAttr> actualDataAttr, dummyDataAttr;
-    if (const auto *actualObject{actualLastSymbol
-                ? actualLastSymbol->detailsIf<ObjectEntityDetails>()
-                : nullptr}) {
-      actualDataAttr = actualObject->cudaDataAttr();
+    // For a%b%c, the last symbol with a CUDA data attribute wins
+    if (actualIsVariable) {
+      for (const Symbol &s : evaluate::GetSymbolVector(actual)) {
+        if (const auto *object{s.detailsIf<ObjectEntityDetails>()}) {
+          if (auto cudaAttr{object->cudaDataAttr()}) {
+            actualDataAttr = *cudaAttr;
+          }
+        }
+      }
     }
     dummyDataAttr = dummy.cudaDataAttr;
     // Treat MANAGED like DEVICE for nonallocatable nonpointer arguments to
@@ -1107,9 +1112,10 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
         actualDataAttr = common::CUDADataAttr::Device;
       }
       // For device procedures, treat actual arguments with VALUE attribute as
-      // device data; also constant actual arguments.
+      // device data; also constant actual arguments and the function result.
       if (!actualDataAttr &&
-          (!actualLastSymbol || IsValue(*actualLastSymbol)) &&
+          (!actualFirstSymbol || IsValue(*actualFirstSymbol) ||
+              IsFunctionResult(*actualFirstSymbol)) &&
           (*procedure.cudaSubprogramAttrs ==
               common::CUDASubprogramAttrs::Device)) {
         actualDataAttr = common::CUDADataAttr::Device;

--- a/flang/test/Semantics/bug1214.cuf
+++ b/flang/test/Semantics/bug1214.cuf
@@ -14,13 +14,13 @@ module overrides
     real, intent(in) :: x
     real, intent(in), device :: y
     type(realResult) result
-    result%a = x * y
+    result%a = x * (y)
   end
   elemental function multDeviceHost(x, y) result(result)
     real, intent(in), device :: x
     real, intent(in) :: y
     type(realResult) result
-    result%a = x * y
+    result%a = (x) * y
   end
   elemental subroutine assignHostResult(lhs, rhs)
     real, intent(out) :: lhs

--- a/flang/test/Semantics/bug2131b.cuf
+++ b/flang/test/Semantics/bug2131b.cuf
@@ -1,0 +1,33 @@
+!RUN: %flang_fc1 -fdebug-unparse %s | FileCheck %s
+module rgbCUDA
+  type rgb
+    real v(3)
+  end type
+  interface assignment (=)
+     module procedure rgbEqR3
+  end interface
+  interface operator(*)
+     module procedure rgbTimesR
+  end interface
+contains
+  attributes(device) subroutine rgbEqR3(rgbout, rin)
+    type(rgb), intent(out) :: rgbout
+    real(4), intent(in) :: rin(3)
+    rgbout%v = rin
+  end
+  attributes(device) function rgbTimesR(rgbin, rin) result(res)
+    type(rgb), intent(in) :: rgbin
+    real(4), intent(in) :: rin
+    real(4) :: res(3)
+    res = rgbin%v * rin
+  end
+  attributes(device) function color() result(res)
+    type(rgb) :: res
+    real :: attenuation
+!CHECK: CALL rgbeqr3(res,[REAL(4)::0._4,0._4,0._4])
+    res = [0.0, 0.0, 0.0]
+    attenuation = 0.5
+!CHECK: CALL rgbeqr3(res,rgbtimesr(res,attenuation))
+    res = res * attenuation
+  end
+end


### PR DESCRIPTION
When checking an actual argument for any CUDA data attributes, be sure to check the symbols in a designator like a%b%c in order, taking the last symbol that has a CUDA attribute.  And be sure to interpret a function result symbol of a device function as a device object, at least for generic interface resolution for defined assignments and operators.

This patch exposed errors in flang/test/Semantics/bug1214.cuf, which have been fixed.