### PR TITLE
[lldb] Return Expected<ModuleSP> from Process::ReadModuleFromMemory

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2016,9 +2016,20 @@ public:
   ///     the instruction has completed executing.
   bool GetWatchpointReportedAfter();
 
-  lldb::ModuleSP ReadModuleFromMemory(const FileSpec &file_spec,
-                                      lldb::addr_t header_addr,
-                                      size_t size_to_read = 512);
+  /// Creates and populates a module using an in-memory object file.
+  ///
+  /// \param[in] file_spec
+  ///   The name or path to the module file. May be empty.
+  ///
+  /// \param[in] header_addr
+  ///   The address pointing to the beginning of the object file's header.
+  ///
+  /// \param[in] size_to_read
+  ///   The number of bytes to read from memory. This should be large enough to
+  ///   identify the object file format. Defaults to 512.
+  llvm::Expected<lldb::ModuleSP>
+  ReadModuleFromMemory(const FileSpec &file_spec, lldb::addr_t header_addr,
+                       size_t size_to_read = 512);
 
   /// Attempt to get the attributes for a region of memory in the process.
   ///

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -180,8 +180,15 @@ ModuleSP DynamicLoader::LoadModuleAtAddress(const FileSpec &file,
   // We have a core file, try to load the image from memory if we didn't find
   // the module.
   if (!module_sp && !m_process->IsLiveDebugSession()) {
-    module_sp = m_process->ReadModuleFromMemory(file, base_addr);
-    m_process->GetTarget().GetImages().AppendIfNeeded(module_sp, false);
+    llvm::Expected<ModuleSP> memory_module_sp_or_err =
+        m_process->ReadModuleFromMemory(file, base_addr);
+    if (auto err = memory_module_sp_or_err.takeError())
+      LLDB_LOG_ERROR(GetLog(LLDBLog::DynamicLoader), std::move(err),
+                     "Failed to read module from memory: {0}");
+    else {
+      module_sp = *memory_module_sp_or_err;
+      m_process->GetTarget().GetImages().AppendIfNeeded(module_sp, false);
+    }
   }
   if (module_sp)
     UpdateLoadedSections(module_sp, link_map_addr, base_addr,
@@ -196,7 +203,14 @@ static ModuleSP ReadUnnamedMemoryModule(Process *process, addr_t addr,
     snprintf(namebuf, sizeof(namebuf), "memory-image-0x%" PRIx64, addr);
     name = namebuf;
   }
-  return process->ReadModuleFromMemory(FileSpec(name), addr);
+  llvm::Expected<ModuleSP> module_sp_or_err =
+      process->ReadModuleFromMemory(FileSpec(name), addr);
+  if (auto err = module_sp_or_err.takeError()) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::DynamicLoader), std::move(err),
+                   "Failed to read module from memory: {0}");
+    return {};
+  }
+  return *module_sp_or_err;
 }
 
 ModuleSP DynamicLoader::LoadBinaryWithUUIDAndAddress(

--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -465,8 +465,15 @@ DynamicLoaderDarwinKernel::CheckForKernelImageAtAddress(lldb::addr_t addr,
   if (header.filetype == llvm::MachO::MH_EXECUTE &&
       (header.flags & llvm::MachO::MH_DYLDLINK) == 0) {
     // Create a full module to get the UUID
-    ModuleSP memory_module_sp =
+    llvm::Expected<ModuleSP> memory_module_sp_or_err =
         process->ReadModuleFromMemory(FileSpec("temp_mach_kernel"), addr);
+    if (auto err = memory_module_sp_or_err.takeError()) {
+      LLDB_LOG_ERROR(log, std::move(err),
+                     "DynamicLoaderDarwinKernel::CheckForKernelImageAtAddress: "
+                     "Failed to read module in memory -- {0}");
+      return UUID();
+    }
+    ModuleSP memory_module_sp = *memory_module_sp_or_err;
     if (!memory_module_sp.get())
       return UUID();
 
@@ -663,9 +670,16 @@ bool DynamicLoaderDarwinKernel::KextImageInfo::ReadMemoryModule(
       size_to_read = sizeof(llvm::MachO::mach_header_64) + mh.sizeofcmds;
   }
 
-  ModuleSP memory_module_sp =
+  llvm::Expected<ModuleSP> memory_module_sp_or_err =
       process->ReadModuleFromMemory(file_spec, m_load_address, size_to_read);
+  if (auto err = memory_module_sp_or_err.takeError()) {
+    LLDB_LOG_ERROR(log, std::move(err),
+                   "KextImageInfo::ReadMemoryModule failed to read module from "
+                   "memory: {0}");
+    return false;
+  }
 
+  ModuleSP memory_module_sp = *memory_module_sp_or_err;
   if (memory_module_sp.get() == nullptr)
     return false;
 

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -738,8 +738,7 @@ bool DynamicLoaderDarwin::AddModulesUsingPreloadedModules(
                 } else {
                   // Always load a memory image right away in the target in case
                   // we end up trying to read the symbol table from memory...
-                  // The
-                  // __LINKEDIT will need to be mapped so we can figure out
+                  // The __LINKEDIT will need to be mapped so we can figure out
                   // where the symbol table bits are...
                   commpage_image_module_sp = *module_sp_or_err;
                   bool changed = false;

--- a/lldb/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
+++ b/lldb/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
@@ -323,8 +323,16 @@ bool JITLoaderGDB::ReadJITDescriptorImpl(bool all_entries) {
 
       char jit_name[64];
       snprintf(jit_name, 64, "JIT(0x%" PRIx64 ")", symbolfile_addr);
-      module_sp = m_process->ReadModuleFromMemory(
-          FileSpec(jit_name), symbolfile_addr, symbolfile_size);
+      llvm::Expected<ModuleSP> module_sp_or_err =
+          m_process->ReadModuleFromMemory(FileSpec(jit_name), symbolfile_addr,
+                                          symbolfile_size);
+      if (auto err = module_sp_or_err.takeError())
+        LLDB_LOG_ERROR(
+            log, std::move(err),
+            "JITLoaderGDB::{1} failed to read module from memory: {0}",
+            __FUNCTION__);
+      else
+        module_sp = *module_sp_or_err;
 
       if (module_sp && module_sp->GetObjectFile()) {
         // Object formats (like ELF) have no representation for a JIT type.

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -282,9 +282,14 @@ Status ProcessElfCore::DoLoadCore() {
               break;
             }
           }
-          if (exe_header_addr.has_value())
-            exe_module_sp = ReadModuleFromMemory(exe_module_spec.GetFileSpec(),
-                                                 *exe_header_addr);
+          if (exe_header_addr) {
+            if (llvm::Expected<lldb::ModuleSP> module_sp_or_err =
+                    ReadModuleFromMemory(exe_module_spec.GetFileSpec(),
+                                         *exe_header_addr))
+              exe_module_sp = *module_sp_or_err;
+            else
+              llvm::consumeError(module_sp_or_err.takeError());
+          }
         }
         if (exe_module_sp)
           GetTarget().SetExecutableModule(exe_module_sp, eLoadDependentsNo);

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2638,7 +2638,7 @@ Process::ReadModuleFromMemory(const FileSpec &file_spec,
     progress_up = std::make_unique<Progress>(
         "Reading binary from memory", file_spec.GetFilename().GetString());
 
-  if (ObjectFile *objfile = module_sp->GetMemoryObjectFile(
+  if (ObjectFile *_ = module_sp->GetMemoryObjectFile(
           shared_from_this(), header_addr, error, size_to_read))
     return module_sp;
 


### PR DESCRIPTION
I noticed that Module::GetMemoryObjectFile populates a Status object upon error but it's effectively dropped on the floor. Instead, the clients can report the error as desired.

At the moment, all clients are either (1) consuming the error because it's only trying to find a module, or (2) log the error and bail out early. I tried to preserve existing behavior as faithfully as possible.