### PR TITLE
workflows/issue-release-workflow: Add an environment in order to limit secret access

### DIFF
--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -33,6 +33,7 @@ jobs:
   backport-commits:
     name: Backport Commits
     runs-on: ubuntu-24.04
+    environment: main-branch-only
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
I've created a new environment called `main-branch-only` which is meant to be used for running the GitHub Actions based automations for the project.  By using an environment, we can move some of the secrets we use from the repository configuration and into the environment configuration, which means they will only be accessible for jobs that run on the branch we specify, which in this case is the main branch.

This will prevent people from using user branches as a way to gain access to secret values (which they can do now very easily by creating a workflow that dumps the secrets).  Even though someone could still do this by pushing to main, user branches are hard to monitor and they can be easily deleted after dumping the secrets leaving no trace.

If someone where to do this on the main branch it would be much more visible and impossible to cover up.

I would like to apply this to more workflows, but I'm starting here so I can test it and make sure it works the way I expect.