### PR TITLE
[MC][Wasm] Emit useful error message when encountering common symbols

### DIFF
--- a/llvm/lib/MC/MCWasmStreamer.cpp
+++ b/llvm/lib/MC/MCWasmStreamer.cpp
@@ -14,6 +14,7 @@
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCFixup.h"
 #include "llvm/MC/MCObjectStreamer.h"
@@ -129,7 +130,9 @@ bool MCWasmStreamer::emitSymbolAttribute(MCSymbol *S, MCSymbolAttr Attribute) {
 
 void MCWasmStreamer::emitCommonSymbol(MCSymbol *S, uint64_t Size,
                                       Align ByteAlignment) {
-  llvm_unreachable("Common symbols are not yet implemented for Wasm");
+  getContext().reportError(getStartTokLoc(),
+                           "common symbols are not yet implemented for Wasm: " +
+                               S->getName());
 }
 
 void MCWasmStreamer::emitELFSize(MCSymbol *Symbol, const MCExpr *Value) {
@@ -138,7 +141,10 @@ void MCWasmStreamer::emitELFSize(MCSymbol *Symbol, const MCExpr *Value) {
 
 void MCWasmStreamer::emitLocalCommonSymbol(MCSymbol *S, uint64_t Size,
                                            Align ByteAlignment) {
-  llvm_unreachable("Local common symbols are not yet implemented for Wasm");
+  getContext().reportError(getStartTokLoc(),
+                           "local common symbols are not yet implemented "
+                           "for Wasm: " +
+                               S->getName());
 }
 
 void MCWasmStreamer::emitIdent(StringRef IdentString) {

--- a/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
@@ -180,6 +180,11 @@ MCSymbolWasm *WebAssemblyAsmPrinter::getMCSymbolForFunction(
 }
 
 void WebAssemblyAsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
+  if (GV->hasCommonLinkage()) {
+    OutContext.reportError(SMLoc(), "common symbols are not yet implemented for Wasm: " + getSymbol(GV)->getName());
+    return;
+  }
+
   if (!WebAssembly::isWasmVarAddressSpace(GV->getAddressSpace())) {
     AsmPrinter::emitGlobalVariable(GV);
     return;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
@@ -181,7 +181,9 @@ MCSymbolWasm *WebAssemblyAsmPrinter::getMCSymbolForFunction(
 
 void WebAssemblyAsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
   if (GV->hasCommonLinkage()) {
-    OutContext.reportError(SMLoc(), "common symbols are not yet implemented for Wasm: " + getSymbol(GV)->getName());
+    OutContext.reportError(SMLoc(),
+                           "common symbols are not yet implemented for Wasm: " +
+                               getSymbol(GV)->getName());
     return;
   }
 

--- a/llvm/test/CodeGen/WebAssembly/common-error.ll
+++ b/llvm/test/CodeGen/WebAssembly/common-error.ll
@@ -1,4 +1,4 @@
-; RUN: not llc < %s -mtriple=wasm32-unknown-unknown -filetype=obj 2>&1 | FileCheck %s
+; RUN: not llc < %s -mtriple=wasm32-unknown-unknown -filetype=asm 2>&1 | FileCheck %s
 
 ; CHECK: error: common symbols are not yet implemented for Wasm: x
 ; CHECK: error: common symbols are not yet implemented for Wasm: y

--- a/llvm/test/CodeGen/WebAssembly/common-error.ll
+++ b/llvm/test/CodeGen/WebAssembly/common-error.ll
@@ -1,6 +1,6 @@
-; RUN: not llc < %s -mtriple=wasm32-unknown-unknown -filetype=asm 2>&1 | FileCheck %s
+; RUN: not llc -mtriple=wasm32-unknown-unknown -filetype=asm %s -o - 2>&1 | FileCheck %s
 
-; CHECK: error: common symbols are not yet implemented for Wasm: x
-; CHECK: error: common symbols are not yet implemented for Wasm: y
+; CHECK: common symbols are not yet implemented for Wasm: x
+; CHECK: common symbols are not yet implemented for Wasm: y
 @x = common global i32 0, align 4
 @y = common global i32 0, align 4

--- a/llvm/test/CodeGen/WebAssembly/common-error.ll
+++ b/llvm/test/CodeGen/WebAssembly/common-error.ll
@@ -1,0 +1,6 @@
+; RUN: not llc < %s -mtriple=wasm32-unknown-unknown -filetype=obj 2>&1 | FileCheck %s
+
+; CHECK: error: common symbols are not yet implemented for Wasm: x
+; CHECK: error: common symbols are not yet implemented for Wasm: y
+@x = common global i32 0, align 4
+@y = common global i32 0, align 4

--- a/llvm/test/MC/WebAssembly/common-error.s
+++ b/llvm/test/MC/WebAssembly/common-error.s
@@ -1,0 +1,6 @@
+# RUN: not llvm-mc -triple=wasm32-unknown-unknown -filetype=obj %s 2>&1 | FileCheck %s
+
+# CHECK: error: common symbols are not yet implemented for Wasm: x
+# CHECK: error: common symbols are not yet implemented for Wasm: y
+        .comm x,4,4
+        .comm y,4,4

--- a/llvm/test/MC/WebAssembly/common-error.s
+++ b/llvm/test/MC/WebAssembly/common-error.s
@@ -1,6 +1,6 @@
 # RUN: not llvm-mc -triple=wasm32-unknown-unknown -filetype=obj %s 2>&1 | FileCheck %s
 
-# CHECK: error: common symbols are not yet implemented for Wasm: x
-# CHECK: error: common symbols are not yet implemented for Wasm: y
+# CHECK:common-error.s:5:9: error: common symbols are not yet implemented for Wasm: x
+# CHECK:common-error.s:6:9: error: common symbols are not yet implemented for Wasm: y
         .comm x,4,4
         .comm y,4,4


### PR DESCRIPTION
We don't currently support common symbols for Wasm, and we currently
emit a generic error with a backtrace. Instead, don't crash, and report
the names of the offending symbols.
