### PR TITLE
[lldb] [Process/FreeBSD] Assume minimum is FreeBSD 14

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_arm64.h
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_arm64.h
@@ -23,10 +23,6 @@
 
 #include <array>
 
-#if __FreeBSD_version >= 1300139
-#define LLDB_HAS_FREEBSD_WATCHPOINT 1
-#endif
-
 namespace lldb_private {
 namespace process_freebsd {
 
@@ -64,10 +60,8 @@ private:
   // and sizes, so we do not have to worry about these (and we have
   // a unittest to assert that).
   std::array<uint8_t, sizeof(reg) + sizeof(fpreg)> m_reg_data;
-#ifdef LLDB_HAS_FREEBSD_WATCHPOINT
   dbreg m_dbreg;
   bool m_read_dbreg;
-#endif
 
   Status ReadRegisterSet(uint32_t set);
   Status WriteRegisterSet(uint32_t set);

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -178,6 +178,8 @@ Changes to LLDB
 ---------------
 
 * Support for FreeBSD on MIPS64 has been removed.
+* The minimum assumed version of FreeBSD is now 14. The effect of which is that watchpoints are
+  assumed to be supported.
 
 Changes to BOLT
 ---------------


### PR DESCRIPTION
Currently versions under 13 are EOLed (see [FreeBSD Release Information](https://www.freebsd.org/releases/)).

FreeBSD 13 will be EOLed by April 30th (see [Supported FreeBSD releases](https://www.freebsd.org/security/#sup)) while LLVM 23 is expected to be released in August 25th according to the LLVM calendar.

Thus assumed that minimum supported FreeBSD version is 14.