### PR TITLE
[MLIR] Fix allSymUsesVisible inside private symbol table

### DIFF
--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -357,14 +357,10 @@ void SymbolTable::walkSymbolTables(
     Operation *op, bool allSymUsesVisible,
     function_ref<void(Operation *, bool)> callback) {
   bool isSymbolTable = op->hasTrait<OpTrait::SymbolTable>();
-  if (isSymbolTable) {
-    SymbolOpInterface symbol = dyn_cast<SymbolOpInterface>(op);
-    allSymUsesVisible |= !symbol || symbol.isPrivate();
-  } else {
-    // Otherwise if 'op' is not a symbol table, any nested symbols are
-    // guaranteed to be hidden.
-    allSymUsesVisible = true;
-  }
+  // If the current op is not a symbol table, or if it is a symbol table but
+  // does not itself define a symbol, outside ops cannot reference symbols
+  // defined inside it, so all their uses are visible.
+  allSymUsesVisible |= !isSymbolTable || !isa<SymbolOpInterface>(op);
 
   for (Region &region : op->getRegions())
     for (Block &block : region)

--- a/mlir/test/Analysis/DataFlow/test-dead-code-analysis-nested-module.mlir
+++ b/mlir/test/Analysis/DataFlow/test-dead-code-analysis-nested-module.mlir
@@ -1,0 +1,16 @@
+// RUN: mlir-opt --pass-pipeline="builtin.module(builtin.module(test-dead-code-analysis))" %s 2>&1 | FileCheck %s
+
+// Test that when dead code analysis runs directly on a nested module with a
+// private symbol name, we account for the fact that functions within that
+// module may be invoked from outside the module.
+module {
+  module @inner_module attributes {sym_visibility = "private"} {
+    // CHECK:      nested:
+    // CHECK-NEXT:  region #0
+    // CHECK-NEXT:   ^bb0 = live
+    // CHECK-NEXT: op_preds: predecessors: (none)
+    func.func nested @nested_inner(%arg0: i32) -> i32 attributes {tag = "nested"} {
+      return %arg0 : i32
+    }
+  }
+}


### PR DESCRIPTION
We currently always set `allSymUsesVisible` to true if the current operation is a symbol table that defines a private symbol. However, this is incorrect since the symbols inside that symbol table can still be referenced by siblings of the symbol table.

For example, if we have a nested module defining a private symbol, the functions inside it may be referenced by functions in the outer module.

This can affect `DeadCodeAnalysis` for example, which computes whether a callable's uses are all known.