### PR TITLE
[DirectX] Making sure SROA is run when targeting DirectX

### DIFF
--- a/clang/test/CodeGenHLSL/intermediate-stores-removed-when-O0.hlsl
+++ b/clang/test/CodeGenHLSL/intermediate-stores-removed-when-O0.hlsl
@@ -1,0 +1,16 @@
+// RUN: not %clang_cc1 -triple dxilv1.7-unknown-shadermodel6.7-compute -O0 -S -hlsl-entry main -finclude-default-header -o - -x hlsl %s 2>&1
+
+
+// Issue caused by issue https://github.com/llvm/llvm-project/issues/168604
+// CHECK: error: Unsupported intrinsic llvm.experimental.noalias.scope.decl for DXIL lowering
+
+// CHECK-NOT: Load of {{.*}} is not a global resource handle
+
+RWBuffer<int> In : register(u0);
+RWBuffer<int> Out : register(u1);
+
+[numthreads(1,1,1)]
+void main(uint GI : SV_GroupIndex) {
+    Out[GI] = In[GI];
+}
+

--- a/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
@@ -70,6 +70,7 @@ LLVMInitializeDirectXTarget() {
   initializeDXContainerGlobalsPass(*PR);
   initializeGlobalDCELegacyPassPass(*PR);
   initializeDXILOpLoweringLegacyPass(*PR);
+  initializeSROALegacyPassPass(*PR);
   initializeDXILResourceAccessLegacyPass(*PR);
   initializeDXILResourceImplicitBindingLegacyPass(*PR);
   initializeDXILTranslateMetadataLegacyPass(*PR);
@@ -121,6 +122,7 @@ public:
     DxilScalarOptions.ScalarizeLoadStore = true;
     addPass(createScalarizerPass(DxilScalarOptions));
     addPass(createDXILFlattenArraysLegacyPass());
+    addPass(createSROAPass());
     addPass(createDXILForwardHandleAccessesLegacyPass());
     addPass(createDeadStoreEliminationPass());
     addPass(createDXILLegalizeLegacyPass());
@@ -147,7 +149,7 @@ DirectXTargetMachine::DirectXTargetMachine(const Target &T, const Triple &TT,
 
 DirectXTargetMachine::~DirectXTargetMachine() {}
 
-void DirectXTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
+void DirectXTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB){
 #define GET_PASS_REGISTRY "DirectXPassRegistry.def"
 #include "llvm/Passes/TargetPassRegistry.inc"
 }

--- a/llvm/test/CodeGen/DirectX/llc-pipeline.ll
+++ b/llvm/test/CodeGen/DirectX/llc-pipeline.ll
@@ -28,6 +28,7 @@
 ; CHECK-NEXT:   DXIL Array Flattener
 ; CHECK-NEXT:   FunctionPass Manager
 ; CHECK-NEXT:     Dominator Tree Construction
+; CHECK-NEXT:     SROA
 ; CHECK-NEXT:     DXIL Forward Handle Accesses
 ; CHECK-NEXT:     Dominator Tree Construction
 ; CHECK-NEXT:     Basic Alias Analysis (stateless AA impl)


### PR DESCRIPTION
SROA is required to execute when targeting directx, this pass is used to remove intermediate stores of the resource pointer. This patch makes sure SROA is run when we use `-O0`. Such has side effects, such as removing optnone from HLSL entry functions.


fix: https://github.com/llvm/llvm-project/issues/167936