### PR TITLE
[RISCV] Enable SelectCompressOpt with HasStdExtZca.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -398,9 +398,6 @@ def HasStdExtZca
 def FeatureStdExtC
     : RISCVExtension<2, 0, "Compressed Instructions", [FeatureStdExtZca]>,
       RISCVExtensionBitmask<0, 2>;
-def HasStdExtC : Predicate<"Subtarget->hasStdExtC()">,
-                 AssemblerPredicate<(all_of FeatureStdExtC),
-                                    "'C' (Compressed Instructions)">;
 
 def FeatureStdExtZcb
     : RISCVExtension<1, 0, "Compressed basic bit manipulation instructions",

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1687,7 +1687,7 @@ class SelectCompressOpt<CondCode Cond>
 
 def OptForMinSize : Predicate<"MF ? MF->getFunction().hasMinSize() : false">;
 
-let Predicates = [HasStdExtC, OptForMinSize] in {
+let Predicates = [HasStdExtZca, OptForMinSize] in {
   def : SelectCompressOpt<SETEQ>;
   def : SelectCompressOpt<SETNE>;
 }

--- a/llvm/test/CodeGen/RISCV/compress-opt-select.ll
+++ b/llvm/test/CodeGen/RISCV/compress-opt-select.ll
@@ -2,6 +2,9 @@
 ; RUN: llc -mtriple=riscv32 -target-abi ilp32d -mattr=+c,+f,+d \
 ; RUN:     -M no-aliases < %s \
 ; RUN:   | FileCheck -check-prefix=RV32IFDC %s
+; RUN: llc -mtriple=riscv32 -target-abi ilp32d -mattr=+zca,+f,+d \
+; RUN:     -M no-aliases < %s \
+; RUN:   | FileCheck -check-prefix=RV32IFDC %s
 ; RUN: llc -mtriple=riscv32 -target-abi ilp32d -mattr=-c,+f,+d \
 ; RUN:     -M no-aliases < %s \
 ; RUN:   | FileCheck -check-prefix=RV32IFD %s


### PR DESCRIPTION
This removes the last use of HasStdExtC in tablegen so I've remove it as well.