### PR TITLE
[AMDGPU] Add machineFunctionInfo to recent MIR tests

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/gfx11-sgpr-hazard-latency.mir
+++ b/llvm/test/CodeGen/AMDGPU/gfx11-sgpr-hazard-latency.mir
@@ -5,6 +5,8 @@
 ---
 name:            gemm_loop1
 tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
 body:             |
   ; GFX11-LABEL: name: gemm_loop1
   ; GFX11: bb.0:

--- a/llvm/test/CodeGen/AMDGPU/gfx11-sgpr-hazard-latency.mir
+++ b/llvm/test/CodeGen/AMDGPU/gfx11-sgpr-hazard-latency.mir
@@ -12,7 +12,6 @@ body:             |
   ; GFX11: bb.0:
   ; GFX11-NEXT:   successors: %bb.1(0x80000000)
   ; GFX11-NEXT: {{  $}}
-  ; GFX11-NEXT:   S_WAITCNT 0
   ; GFX11-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX11-NEXT:   renamable $vgpr1 = V_MOV_B32_e32 0, implicit $exec
   ; GFX11-NEXT:   renamable $vgpr2 = V_MOV_B32_e32 0, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/schedule-barrier-latency-gfx9.mir
+++ b/llvm/test/CodeGen/AMDGPU/schedule-barrier-latency-gfx9.mir
@@ -16,7 +16,6 @@
   ; GFX9:       ; %bb.0:
   ; GFX9-NEXT:    ; implicit-def: $vgpr0_vgpr1
   ; GFX9-NEXT:    ; implicit-def: $vgpr2_vgpr3
-  ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
   ; GFX9-NEXT:    global_load_ushort v14, v[0:1], off
   ; GFX9-NEXT:    ; implicit-def: $vgpr4_vgpr5
   ; GFX9-NEXT:    global_load_ushort v15, v[4:5], off
@@ -74,7 +73,6 @@
   ; GFX9-TGS:       ; %bb.0:
   ; GFX9-TGS-NEXT:    ; implicit-def: $vgpr0_vgpr1
   ; GFX9-TGS-NEXT:    ; implicit-def: $vgpr2_vgpr3
-  ; GFX9-TGS-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
   ; GFX9-TGS-NEXT:    global_load_ushort v14, v[0:1], off
   ; GFX9-TGS-NEXT:    ; implicit-def: $vgpr4_vgpr5
   ; GFX9-TGS-NEXT:    global_load_ushort v15, v[4:5], off

--- a/llvm/test/CodeGen/AMDGPU/schedule-barrier-latency-gfx9.mir
+++ b/llvm/test/CodeGen/AMDGPU/schedule-barrier-latency-gfx9.mir
@@ -136,6 +136,8 @@
 ---
 name: test_workgroup
 tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
 body: |
   bb.0:
     %0:sgpr_256 = IMPLICIT_DEF


### PR DESCRIPTION
Initialize machineFunctionInfo in recently added MIR tests to assist in downstream testing.