### PR TITLE
[MLIR][Python] Ignore the returned status of `loadDialectModule` in lookup functions

### DIFF
--- a/mlir/lib/Bindings/Python/Globals.cpp
+++ b/mlir/lib/Bindings/Python/Globals.cpp
@@ -189,8 +189,8 @@ std::optional<nb::callable> PyGlobals::lookupValueCaster(MlirTypeID mlirTypeID,
 std::optional<nb::object>
 PyGlobals::lookupDialectClass(const std::string &dialectNamespace) {
   // Make sure dialect module is loaded.
-  if (!loadDialectModule(dialectNamespace))
-    return std::nullopt;
+  (void)loadDialectModule(dialectNamespace);
+
   nb::ft_lock_guard lock(mutex);
   const auto foundIt = dialectClassMap.find(dialectNamespace);
   if (foundIt != dialectClassMap.end()) {
@@ -206,8 +206,7 @@ PyGlobals::lookupOperationClass(llvm::StringRef operationName) {
   // Make sure dialect module is loaded.
   auto split = operationName.split('.');
   llvm::StringRef dialectNamespace = split.first;
-  if (!loadDialectModule(dialectNamespace))
-    return std::nullopt;
+  (void)loadDialectModule(dialectNamespace);
 
   nb::ft_lock_guard lock(mutex);
   auto foundIt = operationClassMap.find(operationName);
@@ -224,8 +223,7 @@ PyGlobals::lookupOpAdaptorClass(llvm::StringRef operationName) {
   // Make sure dialect module is loaded.
   auto split = operationName.split('.');
   llvm::StringRef dialectNamespace = split.first;
-  if (!loadDialectModule(dialectNamespace))
-    return std::nullopt;
+  (void)loadDialectModule(dialectNamespace);
 
   nb::ft_lock_guard lock(mutex);
   auto foundIt = opAdaptorClassMap.find(operationName);


### PR DESCRIPTION
Since `loadDialectModule` doesn't work for Python-defined dialects (`mlir.dialects.ext`), currently we should lookup for dialect/operation/opadaptor class even if the `loadDialectModule` function fails. It's also because users can import some modules manually, and we do already ignore it in some cases:
https://github.com/llvm/llvm-project/blob/e2061328a8ae51cdf80e211ad27dd13d7bba766d/mlir/lib/Bindings/Python/Globals.cpp#L163-L166


Related to https://github.com/llvm/llvm-project/pull/176920#discussion_r2762029022.