### PR TITLE
[clang][modules] Support every import syntax in single-module-parse-mode

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1990,11 +1990,12 @@ CompilerInstance::loadModule(SourceLocation ImportLoc,
 
     MM.cacheModuleLoad(*Path[0].getIdentifierInfo(), Module);
   } else if (getPreprocessorOpts().SingleModuleParseMode) {
-    // This mimics how findOrCompileModuleAndReadAST() find the module.
+    // This mimics how findOrCompileModuleAndReadAST() finds the module.
     Module = getPreprocessor().getHeaderSearchInfo().lookupModule(
         ModuleName, ImportLoc, true, !IsInclusionDirective);
     if (Module) {
       // Mark the module and its submodules as if they were loaded from a PCM.
+      // This prevents emission of the "missing submodule" diagnostic below.
       std::vector Worklist{Module};
       while (!Worklist.empty()) {
         auto *M = Worklist.back();

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2534,7 +2534,7 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
            "the imported module is different than the suggested one");
 
     if (Imported) {
-      Action = PPOpts.SingleModuleParseMode ? Skip : Import;
+      Action = Import;
     } else if (Imported.isMissingExpected()) {
       markClangModuleAsAffecting(
           static_cast<Module *>(Imported)->getTopLevelModule());

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2494,15 +2494,10 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
       (getLangOpts().CPlusPlusModules || getLangOpts().Modules) &&
       ModuleToImport && !ModuleToImport->isHeaderUnit();
 
-  if (MaybeTranslateInclude && (UsableHeaderUnit || UsableClangHeaderModule) &&
-      PPOpts.SingleModuleParseMode) {
-    Action = IncludeLimitReached;
-  }
   // Determine whether we should try to import the module for this #include, if
   // there is one. Don't do so if precompiled module support is disabled or we
   // are processing this module textually (because we're building the module).
-  else if (MaybeTranslateInclude &&
-           (UsableHeaderUnit || UsableClangHeaderModule)) {
+  if (MaybeTranslateInclude && (UsableHeaderUnit || UsableClangHeaderModule)) {
     // If this include corresponds to a module but that module is
     // unavailable, diagnose the situation and bail out.
     // FIXME: Remove this; loadModule does the same check (but produces
@@ -2539,7 +2534,7 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
            "the imported module is different than the suggested one");
 
     if (Imported) {
-      Action = Import;
+      Action = PPOpts.SingleModuleParseMode ? Skip : Import;
     } else if (Imported.isMissingExpected()) {
       markClangModuleAsAffecting(
           static_cast<Module *>(Imported)->getTopLevelModule());

--- a/clang/test/Modules/single-module-parse-mode-compiles.m
+++ b/clang/test/Modules/single-module-parse-mode-compiles.m
@@ -1,0 +1,36 @@
+// This test checks that with -fmodules-single-module-parse-mode, no modules get
+// compiled into PCM files from any of the import syntax Clang supports.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: mkdir %t/cache
+
+// With -fmodules-single-module-parse-mode, no modules get compiled.
+// RUN: %clang_cc1 -x objective-c -fmodules -fmodules-cache-path=%t/cache \
+// RUN:   -emit-module %t/module.modulemap -fmodule-name=Mod -o %t/Mod.pcm \
+// RUN:   -fmodules-single-module-parse-mode
+// RUN: find %t/cache -name "*.pcm" | count 0
+
+// Without -fmodules-single-module-parse-mode, loaded modules get compiled.
+// RUN: %clang_cc1 -x objective-c -fmodules -fmodules-cache-path=%t/cache \
+// RUN:   -emit-module %t/module.modulemap -fmodule-name=Mod -o %t/Mod.pcm
+// RUN: find %t/cache -name "*.pcm" | count 5
+
+//--- module.modulemap
+module Mod { header "Mod.h" }
+module Load1 { header "Load1.h" }
+module Load2 { header "Load2.h" }
+module Load3 { header "Load3.h" }
+module Load4 { header "Load4.h" }
+module Load5 { header "Load5.h" }
+//--- Mod.h
+#include "Load1.h"
+#import "Load2.h"
+@import Load3;
+#pragma clang module import Load4
+#pragma clang module load Load5
+//--- Load1.h
+//--- Load2.h
+//--- Load3.h
+//--- Load4.h
+//--- Load5.h


### PR DESCRIPTION
Previously, `-fmodules-single-module-parse-mode` only prevented module compilation/loading when initiated from an `#include` or `#import` directive. This PR does the same for `@import`, `#pragma clang module import` and `#pragma clang module load`. This is done by sinking the logic down into `CompilerInstance::loadModule()`.