### PR TITLE
[RISCV] Add C/Zcf/Zcd/Zce implication rules to subtarget construction.

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h
@@ -39,6 +39,11 @@ std::unique_ptr<MCObjectTargetWriter> createRISCVELFObjectWriter(uint8_t OSABI,
                                                                  bool Is64Bit);
 std::unique_ptr<MCObjectTargetWriter>
 createRISCVMachObjectWriter(uint32_t CPUType, uint32_t CPUSubtype);
+
+namespace RISCV {
+void updateCZceFeatureImplications(MCSubtargetInfo &STI);
+}
+
 } // namespace llvm
 
 // Defines symbolic names for RISC-V registers.

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -458,8 +458,7 @@ def FeatureStdExtZce
                       FeatureStdExtZcmt]>;
 
 def HasStdExtCOrZcfOrZce
-    : Predicate<"Subtarget->hasStdExtC() || Subtarget->hasStdExtZcf() ||"
-                "Subtarget->hasStdExtZce()">,
+    : Predicate<"Subtarget->hasStdExtCOrZcfOrZce()">,
       AssemblerPredicate<(any_of FeatureStdExtC, FeatureStdExtZcf,
                                  FeatureStdExtZce),
                          "'C' (Compressed Instructions) or "

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -98,6 +98,56 @@ RISCVSubtarget::initializeSubtargetDependencies(const Triple &TT, StringRef CPU,
   assert(TuneInfo && "TuneInfo shouldn't be nullptr!");
 
   ParseSubtargetFeatures(CPU, TuneCPU, FS);
+
+  // Add Zcd if C and D are enabled.
+  if (!HasStdExtZcd && HasStdExtC && HasStdExtD) {
+    ToggleFeature(RISCV::FeatureStdExtZcd);
+    HasStdExtZcd = true;
+  }
+
+  // Add Zcf if F and C or Zce are enabled on RV32.
+  if (!HasStdExtZcf && !Is64Bit && HasStdExtF && (HasStdExtC || HasStdExtZce)) {
+    ToggleFeature(RISCV::FeatureStdExtZcf);
+    HasStdExtZcf = true;
+  }
+
+  // Add C if Zca is enabled and the conditions are met.
+  // This follows the RISC-V spec rules for MISA.C and matches GCC behavior
+  // (PR119122). The rule is:
+  // For RV32:
+  //   - No F and no D: Zca alone implies C
+  //   - F but no D: Zca + Zcf implies C
+  //   - F and D: Zca + Zcf + Zcd implies C
+  // For RV64:
+  //   - No D: Zca alone implies C
+  //   - D: Zca + Zcd implies C
+  if (!HasStdExtC && HasStdExtZca) {
+    bool ShouldAddC = false;
+    if (!Is64Bit)
+      ShouldAddC =
+          (!HasStdExtD || HasStdExtZcd) && (!HasStdExtF || HasStdExtZcf);
+    else
+      ShouldAddC = !HasStdExtD || HasStdExtZcd;
+    if (ShouldAddC) {
+      ToggleFeature(RISCV::FeatureStdExtC);
+      HasStdExtC = true;
+    }
+  }
+
+  // Add Zce if Zca+Zcb+Zcmp+Zcmt are enabled and the conditions are met.
+  // For RV32:
+  //   - No F and no D: Zca+Zcb+Zcmp+Zcmt alone implies Zce
+  //   - F: Zca+Zcb+Zcmp+Zcmt + Zcf implies Zce
+  // For RV64:
+  //   - Zca+Zcb+Zcmp+Zcmt alone implies Zce
+  if (!HasStdExtZce && HasStdExtZca && HasStdExtZcb && HasStdExtZcmp &&
+      HasStdExtZcmt) {
+    if (Is64Bit || !HasStdExtF || HasStdExtZcf) {
+      ToggleFeature(RISCV::FeatureStdExtZce);
+      HasStdExtZce = true;
+    }
+  }
+
   TargetABI = RISCVABI::computeTargetABI(TT, getFeatureBits(), ABIName);
   RISCVFeatures::validate(TT, getFeatureBits());
   return *this;

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -172,9 +172,10 @@ public:
 
   LLVM_DEPRECATED("Now Equivalent to hasStdExtZca", "hasStdExtZca")
   bool hasStdExtCOrZca() const { return HasStdExtZca; }
-  bool hasStdExtCOrZcd() const { return HasStdExtC || HasStdExtZcd; }
+  // FIXME: Remove these and use hasStdExtZcd/hasStdExtZcf() instead.
+  bool hasStdExtCOrZcd() const { return HasStdExtZcd; }
   bool hasStdExtCOrZcfOrZce() const {
-    return HasStdExtC || HasStdExtZcf || HasStdExtZce;
+    return HasStdExtZcf;
   }
   bool hasStdExtZvl() const { return ZvlLen != 0; }
   bool hasStdExtFOrZfinx() const { return HasStdExtF || HasStdExtZfinx; }

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -174,9 +174,7 @@ public:
   bool hasStdExtCOrZca() const { return HasStdExtZca; }
   // FIXME: Remove these and use hasStdExtZcd/hasStdExtZcf() instead.
   bool hasStdExtCOrZcd() const { return HasStdExtZcd; }
-  bool hasStdExtCOrZcfOrZce() const {
-    return HasStdExtZcf;
-  }
+  bool hasStdExtCOrZcfOrZce() const { return HasStdExtZcf; }
   bool hasStdExtZvl() const { return ZvlLen != 0; }
   bool hasStdExtFOrZfinx() const { return HasStdExtF || HasStdExtZfinx; }
   bool hasStdExtDOrZdinx() const { return HasStdExtD || HasStdExtZdinx; }


### PR DESCRIPTION
This ensures the feature bits and RISCVSubtarget flags match what RISCVISAInfo would do.

I'm not excited about the code duplication, but I need to set the RISCVSubtarget flags along with calling ToggleFeature. I'll think about how to improve this.