### PR TITLE
[CodeGen] Simplify ExpandPostRA::LowerSubregToReg. NFC.

### DIFF
--- a/llvm/lib/CodeGen/ExpandPostRAPseudos.cpp
+++ b/llvm/lib/CodeGen/ExpandPostRAPseudos.cpp
@@ -95,15 +95,7 @@ bool ExpandPostRA::LowerSubregToReg(MachineInstr *MI) {
 
   LLVM_DEBUG(dbgs() << "subreg: CONVERTING: " << *MI);
 
-  if (MI->allDefsAreDead()) {
-    MI->setDesc(TII->get(TargetOpcode::KILL));
-    MI->removeOperand(3); // SubIdx
-    MI->removeOperand(1); // Imm
-    LLVM_DEBUG(dbgs() << "subreg: replaced by: " << *MI);
-    return true;
-  }
-
-  if (DstSubReg == InsReg) {
+  if (MI->allDefsAreDead() || DstSubReg == InsReg) {
     // No need to insert an identity copy instruction.
     // Watch out for case like this:
     // %rax = SUBREG_TO_REG 0, killed %eax, 3

--- a/llvm/lib/CodeGen/ExpandPostRAPseudos.cpp
+++ b/llvm/lib/CodeGen/ExpandPostRAPseudos.cpp
@@ -108,26 +108,22 @@ bool ExpandPostRA::LowerSubregToReg(MachineInstr *MI) {
     // Watch out for case like this:
     // %rax = SUBREG_TO_REG 0, killed %eax, 3
     // We must leave %rax live.
-    if (DstReg != InsReg) {
-      MI->setDesc(TII->get(TargetOpcode::KILL));
-      MI->removeOperand(3);     // SubIdx
-      MI->removeOperand(1);     // Imm
-      LLVM_DEBUG(dbgs() << "subreg: replace by: " << *MI);
-      return true;
-    }
-    LLVM_DEBUG(dbgs() << "subreg: eliminated!");
-  } else {
-    TII->copyPhysReg(*MBB, MI, MI->getDebugLoc(), DstSubReg, InsReg,
-                     MI->getOperand(2).isKill());
-
-    // Implicitly define DstReg for subsequent uses.
-    MachineBasicBlock::iterator CopyMI = MI;
-    --CopyMI;
-    CopyMI->addRegisterDefined(DstReg);
-    LLVM_DEBUG(dbgs() << "subreg: " << *CopyMI);
+    MI->setDesc(TII->get(TargetOpcode::KILL));
+    MI->removeOperand(3);     // SubIdx
+    MI->removeOperand(1);     // Imm
+    LLVM_DEBUG(dbgs() << "subreg: replaced by: " << *MI);
+    return true;
   }
 
-  LLVM_DEBUG(dbgs() << '\n');
+  TII->copyPhysReg(*MBB, MI, MI->getDebugLoc(), DstSubReg, InsReg,
+                   MI->getOperand(2).isKill());
+
+  // Implicitly define DstReg for subsequent uses.
+  MachineBasicBlock::iterator CopyMI = MI;
+  --CopyMI;
+  CopyMI->addRegisterDefined(DstReg);
+  LLVM_DEBUG(dbgs() << "subreg: " << *CopyMI);
+
   MBB->erase(MI);
   return true;
 }

--- a/llvm/lib/CodeGen/ExpandPostRAPseudos.cpp
+++ b/llvm/lib/CodeGen/ExpandPostRAPseudos.cpp
@@ -109,8 +109,8 @@ bool ExpandPostRA::LowerSubregToReg(MachineInstr *MI) {
     // %rax = SUBREG_TO_REG 0, killed %eax, 3
     // We must leave %rax live.
     MI->setDesc(TII->get(TargetOpcode::KILL));
-    MI->removeOperand(3);     // SubIdx
-    MI->removeOperand(1);     // Imm
+    MI->removeOperand(3); // SubIdx
+    MI->removeOperand(1); // Imm
     LLVM_DEBUG(dbgs() << "subreg: replaced by: " << *MI);
     return true;
   }


### PR DESCRIPTION
SUBREG_TO_REG always has a non-zero subreg index so DstSubReg can never
be the same as DstReg.
