### PR TITLE
release/22.x: [Sema] Fix ICE due to incorrect _Bool handling in format string checking

### DIFF
--- a/clang/lib/AST/FormatString.cpp
+++ b/clang/lib/AST/FormatString.cpp
@@ -371,7 +371,7 @@ static clang::analyze_format_string::ArgType::MatchKind
 matchesSizeTPtrdiffT(ASTContext &C, QualType T, QualType E) {
   using MatchKind = clang::analyze_format_string::ArgType::MatchKind;
 
-  if (!T->isIntegerType())
+  if (!T->isIntegerType() || T->isBooleanType())
     return MatchKind::NoMatch;
 
   if (C.hasSameType(T, E))

--- a/clang/test/Sema/format-strings.c
+++ b/clang/test/Sema/format-strings.c
@@ -3,10 +3,12 @@
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -triple=x86_64-unknown-fuchsia %s
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -triple=x86_64-linux-android %s
 
+#include <limits.h>
 #include <stdarg.h>
 #include <stddef.h>
 #define __need_wint_t
 #include <stddef.h> // For wint_t and wchar_t
+#include <stdint.h>
 
 typedef struct _FILE FILE;
 int fprintf(FILE *, const char *restrict, ...);
@@ -982,4 +984,44 @@ void test_promotion(void) {
   
   // pointers
   printf("%s", i); // expected-warning{{format specifies type 'char *' but the argument has type 'int'}}
+}
+
+void test_bool(_Bool b, _Bool* bp)
+{
+#if SIZE_MAX != UINT_MAX
+  printf("%zu", b); // expected-warning-re{{format specifies type 'size_t' (aka '{{.+}}') but the argument has type '_Bool'}}
+#else
+  printf("%zu", b); // no-warning
+#endif
+#if PTRDIFF_MAX != INT_MAX
+  printf("%td", b); // expected-warning-re{{format specifies type 'ptrdiff_t' (aka '{{.+}}') but the argument has type '_Bool'}}
+#else
+  printf("%td", b); // no-warning
+#endif
+  printf("%jd", b); // expected-warning-re{{format specifies type 'intmax_t' (aka '{{.+}}') but the argument has type '_Bool'}}
+  printf("%lld", b); // expected-warning{{format specifies type 'long long' but the argument has type '_Bool'}}
+  printf("%ld", b); // expected-warning{{format specifies type 'long' but the argument has type '_Bool'}}
+  printf("%d", b); // promoted from _Bool to int
+  printf("%hhd", b); // promoted from _Bool to int
+  printf("%hd", b); // promoted from _Bool to int
+#if !defined(__Fuchsia__) && !defined(__ANDROID__) //'%n' specifier not supported on this platform
+  // The n conversion specifier only supports signed types
+  printf("%zn", bp); // expected-warning-re{{format specifies type 'signed size_t *' (aka '{{.+}}') but the argument has type '_Bool *'}}
+  printf("%jn", bp); // expected-warning-re{{format specifies type 'intmax_t *' (aka '{{.+}}') but the argument has type '_Bool *'}}
+  printf("%lln", bp); // expected-warning{{format specifies type 'long long *' but the argument has type '_Bool *'}}
+  printf("%ln", bp); // expected-warning{{format specifies type 'long *' but the argument has type '_Bool *'}}
+  printf("%n", bp); // expected-warning{{format specifies type 'int *' but the argument has type '_Bool *'}}
+  printf("%hhn", bp); // expected-warning{{format specifies type 'signed char *' but the argument has type '_Bool *'}}
+  printf("%hn", bp); // belong to -Wformat-type-confusion
+#endif
+  printf("%c", b); // expected-warning{{using '%c' format specifier, but argument has boolean value}}
+  printf("%s", b); // expected-warning{{format specifies type 'char *' but the argument has type '_Bool'}}
+  printf("%d", b); // promoted from _Bool to int
+  printf("%o", b); // promoted from _Bool to int
+  printf("%x", b); // promoted from _Bool to int
+  printf("%u", b); // promoted from _Bool to int
+  printf("%f", b); // expected-warning{{format specifies type 'double' but the argument has type '_Bool'}}
+  printf("%e", b); // expected-warning{{format specifies type 'double' but the argument has type '_Bool'}}
+  printf("%a", b); // expected-warning{{format specifies type 'double' but the argument has type '_Bool'}}
+  printf("%g", b); // expected-warning{{format specifies type 'double' but the argument has type '_Bool'}}
 }


### PR DESCRIPTION
This cherry-picks 15365d31e6b to 22.x release branch, together with its follow-up 312078b117 which fixes the test on ARM32 targets.
