### PR TITLE
[clang][bytecode] Handle a null record better

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4501,6 +4501,8 @@ bool Compiler<Emitter>::visitZeroArrayInitializer(QualType T, const Expr *E) {
   }
   if (ElemType->isRecordType()) {
     const Record *R = getRecord(ElemType);
+    if (!R)
+      return false;
 
     for (size_t I = 0; I != NumElems; ++I) {
       if (!this->emitConstUint32(I, E))

--- a/clang/test/AST/ByteCode/invalid.cpp
+++ b/clang/test/AST/ByteCode/invalid.cpp
@@ -143,3 +143,11 @@ namespace BitCastWithErrors {
   template<class T> int f(); // both-note {{candidate template ignored}}
   static union { char *x = f(); }; // both-error {{no matching function for call to 'f'}}
 }
+
+namespace NullRecord {
+  struct S1; // both-note {{forward declaration}}
+  struct S2 {
+    S1 s[2]; // both-error {{field has incomplete type 'S1'}}
+  };
+  S2 s = S2();
+}


### PR DESCRIPTION
This would otherwise later assert in vsitZeroRecordInitializer().