### PR TITLE
[Clang] Fix missing -Warray-bounds warning on member function calls.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -204,6 +204,10 @@ Improvements to Clang's diagnostics
 
 - Improved ``-Wassign-enum`` performance by caching enum enumerator values. (#GH176454)
 
+- Fixed a false negative in ``-Warray-bounds`` where the warning was suppressed
+  when accessing a member function on a past-the-end array element.
+  (#GH179128)
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -15449,6 +15449,10 @@ void Sema::CheckArrayAccess(const Expr *expr) {
         expr = cast<MemberExpr>(expr)->getBase();
         break;
       }
+      case Stmt::CXXMemberCallExprClass: {
+        expr = cast<CXXMemberCallExpr>(expr)->getImplicitObjectArgument();
+        break;
+      }
       case Stmt::ArraySectionExprClass: {
         const ArraySectionExpr *ASE = cast<ArraySectionExpr>(expr);
         // FIXME: We should probably be checking all of the elements to the

--- a/clang/test/SemaCXX/constant-expression-cxx2a.cpp
+++ b/clang/test/SemaCXX/constant-expression-cxx2a.cpp
@@ -1241,8 +1241,9 @@ namespace dtor_call {
   }
 
   constexpr void destroy_past_end_array() { // expected-error {{never produces a constant expression}}
-    A a[2];
-    a[2].~A(); // expected-note {{destruction of dereferenced one-past-the-end pointer}}
+    A a[2]; // expected-note {{array 'a' declared here}}
+    a[2].~A(); // expected-note {{destruction of dereferenced one-past-the-end pointer}} \
+             // expected-warning {{array index 2 is past the end of the array}}
   }
 
   union As {


### PR DESCRIPTION
Fixes #179128.
This patch fixes a false negative where Clang failed to detect out-of-bounds access when calling a member function on an invalid array index. It adds handling for CXXMemberCallExpr in CheckArrayAccess.