### PR TITLE
[DA] Remove "minor algebra" in the RDIV test

### DIFF
--- a/llvm/test/Analysis/DependenceAnalysis/ExactRDIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/ExactRDIV.ll
@@ -556,7 +556,7 @@ define void @rdiv10(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - flow [=> *|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx4, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4
@@ -666,7 +666,7 @@ define void @rdiv12(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4
-; CHECK-NEXT:    da analyze - flow [* *|<]!
+; CHECK-NEXT:    da analyze - flow [=> *|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx4, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/rdiv-minor-algebra.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/rdiv-minor-algebra.ll
@@ -12,16 +12,15 @@
 ;   }
 ; }
 ;
-; FIXME: DependenceAnalysis currently detects no dependency between the two
-; stores, but it does exist.
+; There is a dependency between the two stores.
 ;
 ;  memory access                | (i, j) == (1, 1)
 ; ------------------------------|------------------
 ;  A[-2]                        | A[-2]
 ;  A[INT64_MAX*i + INT64_MAX*j] | A[-2]
 ;
-; The root cause is that RDIV performs "minor algebra" and transforms the
-; subscripts as follows:
+; Previously, this dependency was missed because RDIV performs "minor algebra"
+; and transforms the subscripts as follows:
 ;
 ;   A[-2] and A[INT64_MAX*i + INT64_MAX*j]
 ;
@@ -45,7 +44,7 @@ define void @f(ptr %A) {
 ; CHECK-SYMBOLIC-RDIV-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 0, ptr %gep.0, align 1
 ; CHECK-SYMBOLIC-RDIV-NEXT:    da analyze - consistent output [S]!
 ; CHECK-SYMBOLIC-RDIV-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 1, ptr %gep.1, align 1
-; CHECK-SYMBOLIC-RDIV-NEXT:    da analyze - none!
+; CHECK-SYMBOLIC-RDIV-NEXT:    da analyze - output [*|<]!
 ; CHECK-SYMBOLIC-RDIV-NEXT:  Src: store i8 1, ptr %gep.1, align 1 --> Dst: store i8 1, ptr %gep.1, align 1
 ; CHECK-SYMBOLIC-RDIV-NEXT:    da analyze - output [* *]!
 ;


### PR DESCRIPTION
As mentioned in #179653, the "minor algebra" in `testRDIV` is incorrect. This patch deletes that part completely.

Fixes the test case added in #179653.