### PR TITLE
[bolt][x86] Fixed process indirect branch instruction

### DIFF
--- a/bolt/test/X86/Inputs/jump-table-fixed-ref-pic.s
+++ b/bolt/test/X86/Inputs/jump-table-fixed-ref-pic.s
@@ -6,7 +6,7 @@ main:
   jae .L4
   cmpq $0x1, %rdi
   jne .L4
-  movslq .Ljt_pic+8(%rip), %rax
+  movslq .Ljt_pic+JT_ENTRY_OFFSET(%rip), %rax
   lea .Ljt_pic(%rip), %rdx
   add %rdx, %rax
   jmpq *%rax

--- a/bolt/test/X86/jump-table-fixed-ref-pic.test
+++ b/bolt/test/X86/jump-table-fixed-ref-pic.test
@@ -1,13 +1,26 @@
 ## Verify that BOLT detects fixed destination of indirect jump for PIC
 ## case.
 
-RUN: %clang %cflags -no-pie %S/Inputs/jump-table-fixed-ref-pic.s -Wl,-q -o %t
+RUN: %clang %cflags -no-pie %S/Inputs/jump-table-fixed-ref-pic.s -Wl,-q -o %t \
+RUN:    -Wa,--defsym,JT_ENTRY_OFFSET=8
 RUN: llvm-bolt %t --relocs -o %t.null -print-cfg 2>&1 | FileCheck %s
 
 CHECK: BOLT-INFO: fixed PIC indirect branch detected in main {{.*}} the destination value is 0x[[#TGT:]]
 CHECK: Binary Function "main" after building cfg
 
-CHECK:      movslq ".rodata/1"+8(%rip), %rax
+CHECK:      movslq ".rodata/1"+[[#OFFSET:8]](%rip), %rax
 CHECK-NEXT: leaq ".rodata/1"(%rip), %rdx
 CHECK-NEXT: addq %rdx, %rax
-CHECK-NEXT: jmpq *%rax # UNKNOWN CONTROL FLOW
+CHECK-NEXT: jmpq *%rax # JUMPTABLE
+
+RUN: %clang %cflags -no-pie %S/Inputs/jump-table-fixed-ref-pic.s -Wl,-q -o %t.exe \
+RUN:    -Wa,--defsym,JT_ENTRY_OFFSET=0
+RUN: llvm-bolt %t.exe --relocs -o %t.bolt -print-cfg 2>&1 | FileCheck %s --check-prefix=CHECK-ENTRY
+
+CHECK-ENTRY: BOLT-INFO: fixed PIC indirect branch detected in main {{.*}} the destination value is 0x[[#TGT:]]
+CHECK-ENTRY: Binary Function "main" after building cfg
+
+CHECK-ENTRY:      movslq ".rodata/1"(%rip), %rax
+CHECK-ENTRY-NEXT: leaq ".rodata/1"(%rip), %rdx
+CHECK-ENTRY-NEXT: addq %rdx, %rax
+CHECK-ENTRY-NEXT: jmpq *%rax # JUMPTABLE


### PR DESCRIPTION
Hi folks, during libc processing there is the crash when analyzing indirect branch instruction which is part of JT with fixed entry load instruction. 

JT pattern as:
    movslq En(%rip), {%r2|%r1}              <- FixedEntryLoadInstr   
    lea PIC_JUMP_TABLE(%rip), {%r1|%r2}     
    add %r2, %r1   
    jmp *%r1  

I extend the existing unit test to reproduce the error and found that we leave processing little bit early,
Print CFG function with the this JT pattern shows that indirect branch instruction has "UNKNOWN CONTROL FLOW" annotation.

libc.so binary can be found in the issue [link](https://github.com/llvm/llvm-project/pull/178578)
thanks to @Jianghibo for PR where he suggest the solution but  from my point of view it's better to re-create JT if the one is already exist and add the instruction offset to JTs call sites list.

https://github.com/llvm/llvm-project/issues/122828

__GI___res_context_query function contains 3 jump tables, before this patch bolt recognized only 2 JT.

