### PR TITLE
[clang][NFC] Use full diagnostic text in C++ DR tests

### DIFF
--- a/clang/test/CXX/drs/cwg0xx.cpp
+++ b/clang/test/CXX/drs/cwg0xx.cpp
@@ -335,14 +335,14 @@ namespace cwg25 { // cwg25: 4
   //   since-cxx17-note@-2 {{use 'noexcept(false)' instead}}
   void (A::*g)() throw () = f;
   // cxx98-14-error@-1 {{target exception specification is not superset of source}}
-  // since-cxx17-error@-2 {{different exception specifications}}
+  // since-cxx17-error@-2 {{cannot initialize a variable of type 'void (A::*)() throw()' with an lvalue of type 'void (A::*)() throw(int)': different exception specifications}}
   void (A::*g2)() throw () = 0;
   void (A::*h)() throw (int, char) = f;
   // since-cxx17-error@-1 {{ISO C++17 does not allow dynamic exception specifications}}
   //   since-cxx17-note@-2 {{use 'noexcept(false)' instead}}
   void (A::*i)() throw () = &A::f;
   // cxx98-14-error@-1 {{target exception specification is not superset of source}}
-  // since-cxx17-error@-2 {{different exception specifications}}
+  // since-cxx17-error@-2 {{cannot initialize a variable of type 'void (A::*)() throw()' with an rvalue of type 'void (A::*)() throw(int)': different exception specifications}}
   void (A::*i2)() throw () = 0;
   void (A::*j)() throw (int, char) = &A::f;
   // since-cxx17-error@-1 {{ISO C++17 does not allow dynamic exception specifications}}
@@ -350,11 +350,11 @@ namespace cwg25 { // cwg25: 4
   void x() {
     g2 = f;
     // cxx98-14-error@-1 {{target exception specification is not superset of source}}
-    // since-cxx17-error@-2 {{different exception specifications}}
+    // since-cxx17-error@-2 {{assigning to 'void (A::*)() throw()' from incompatible type 'void (A::*)() throw(int)': different exception specifications}}
     h = f;
     i2 = &A::f;
     // cxx98-14-error@-1 {{target exception specification is not superset of source}}
-    // since-cxx17-error@-2 {{different exception specifications}}
+    // since-cxx17-error@-2 {{assigning to 'void (A::*)() throw()' from incompatible type 'void (A::*)() throw(int)': different exception specifications}}
     j = &A::f;
   }
 } // namespace cwg25
@@ -708,7 +708,7 @@ namespace cwg39 { // cwg39: no
     struct cwg39::PR5916::D -> C -> A}} */
     //   expected-note@#cwg39-A-n {{member found by ambiguous name lookup}}
 
-    // expected-error@#cwg39-sizeof {{unknown type name}}
+    // expected-error@#cwg39-sizeof {{unknown type name 'n'}}
 #if __cplusplus >= 201103L
     decltype(D::n) n;
     /* since-cxx11-error@-1
@@ -1058,19 +1058,19 @@ namespace cwg62 { // cwg62: 2.9
   void f() {
     struct NoLinkage {};
     X<NoLinkage> a;
-    // cxx98-error@-1 {{template argument uses local type }}
+    // cxx98-error@-1 {{template argument uses local type 'NoLinkage'}}
     X<const NoLinkage> b;
-    // cxx98-error@-1 {{template argument uses local type }}
+    // cxx98-error@-1 {{template argument uses local type 'NoLinkage'}}
     get<NoLinkage>();
-    // cxx98-error@-1 {{template argument uses local type }}
-    //   cxx98-note@-2 {{while substituting explicitly-specified template arguments}}
+    // cxx98-error@-1 {{template argument uses local type 'NoLinkage'}}
+    //   cxx98-note@-2 {{while substituting explicitly-specified template arguments into function template 'get'}}
     get<const NoLinkage>();
-    // cxx98-error@-1 {{template argument uses local type }}
-    //   cxx98-note@-2 {{while substituting explicitly-specified template arguments}}
+    // cxx98-error@-1 {{template argument uses local type 'NoLinkage'}}
+    //   cxx98-note@-2 {{while substituting explicitly-specified template arguments into function template 'get'}}
     X<void (*)(NoLinkage A::*)> c;
-    // cxx98-error@-1 {{template argument uses local type }}
+    // cxx98-error@-1 {{template argument uses local type 'NoLinkage'}}
     X<int NoLinkage::*> d;
-    // cxx98-error@-1 {{template argument uses local type }}
+    // cxx98-error@-1 {{template argument uses local type 'NoLinkage'}}
   }
 } // namespace cwg62
 

--- a/clang/test/CXX/drs/cwg11xx.cpp
+++ b/clang/test/CXX/drs/cwg11xx.cpp
@@ -81,7 +81,7 @@ struct B : A {
 } b;
 void foo() {
   b.A::operator T(); // FIXME: qualified lookup should find T in A.
-  // expected-error@-1 {{unknown type name 'T'}}
+  // expected-error@-1 {{unknown type name 'T'; did you mean 'A::T'?}}
   //   expected-note@#cwg1111-A-T {{'A::T' declared here}}
 }
 } // namespace example4
@@ -107,7 +107,7 @@ namespace cwg1113 { // cwg1113: partial
   namespace named {
     extern int a; // #cwg1113-a
     static int a;
-    // expected-error@-1 {{static declaration of 'a' follows non-static}}
+    // expected-error@-1 {{static declaration of 'a' follows non-static declaration}}
     //   expected-note@#cwg1113-a {{previous declaration is here}}
   }
   namespace {

--- a/clang/test/CXX/drs/cwg13xx.cpp
+++ b/clang/test/CXX/drs/cwg13xx.cpp
@@ -528,11 +528,11 @@ namespace cwg1359 { // cwg1359: 3.5
   union B { constexpr B() = default; int a; }; // #cwg1359-B
   // cxx11-17-error@-1 {{defaulted definition of default constructor cannot be marked constexpr before C++23}}
   union C { constexpr C() = default; int a, b; }; // #cwg1359-C
-  // cxx11-17-error@-1 {{defaulted definition of default constructor cannot be marked constexpr}}
+  // cxx11-17-error@-1 {{defaulted definition of default constructor cannot be marked constexpr before C++23}}
   struct X { constexpr X() = default; union {}; };
   // since-cxx11-error@-1 {{declaration does not declare anything}}
   struct Y { constexpr Y() = default; union { int a; }; }; // #cwg1359-Y
-  // cxx11-17-error@-1 {{defaulted definition of default constructor cannot be marked constexpr}}
+  // cxx11-17-error@-1 {{defaulted definition of default constructor cannot be marked constexpr before C++23}}
 
   constexpr A a = A();
   constexpr B b = B();

--- a/clang/test/CXX/drs/cwg14xx.cpp
+++ b/clang/test/CXX/drs/cwg14xx.cpp
@@ -31,20 +31,20 @@ namespace cwg1413 { // cwg1413: 12
       // ok, variable declaration
       Check<true ? 0 : a>::type *var2; // #cwg1413-var2
       Check<true ? 0 : b>::type *var3;
-      // expected-error@-1 {{use of undeclared identifier 'var3'}}
+      // expected-error@-1 {{use of undeclared identifier 'var3'; did you mean 'var2'?}}
       //   expected-note@#cwg1413-var2 {{'var2' declared here}}
       Check<true ? 0 : ((void)c, 0)>::type *var4;
-      // expected-error@-1 {{use of undeclared identifier 'var4'}}
+      // expected-error@-1 {{use of undeclared identifier 'var4'; did you mean 'var2'?}}
       //   expected-note@#cwg1413-var2 {{'var2' declared here}}
 
       // value-dependent because of the implied type-dependent 'this->', not because of 'd'
       Check<true ? 0 : (d(), 0)>::type *var5;
-      // expected-error@-1 {{use of undeclared identifier 'var5'}}
+      // expected-error@-1 {{use of undeclared identifier 'var5'; did you mean 'var2'?}}
       //   expected-note@#cwg1413-var2 {{'var2' declared here}}
 
       // value-dependent because of the value-dependent '&' operator, not because of 'A::d'
       Check<true ? 0 : (&A::d(), 0)>::type *var5;
-      // expected-error@-1 {{use of undeclared identifier 'var5'}}
+      // expected-error@-1 {{use of undeclared identifier 'var5'; did you mean 'var2'?}}
       //   expected-note@#cwg1413-var2 {{'var2' declared here}}
     }
   };
@@ -116,7 +116,7 @@ void f() {
   // since-cxx11-error@-1 {{cannot initialize a variable of type 'const int' with an rvalue of type 'A *'}}
   constexpr A *p2 = &*a;
   // since-cxx11-error@-1 {{constexpr variable 'p2' must be initialized by a constant expression}}
-  // since-cxx11-note@-2 {{dereferencing a null pointer}}
+  //   since-cxx11-note@-2 {{dereferencing a null pointer is not allowed in a constant expression}}
 }
 
 struct A {
@@ -192,16 +192,16 @@ namespace cwg1460 { // cwg1460: 3.5
   namespace Defaulted {
     union A { constexpr A() = default; };
     union B { int n; constexpr B() = default; };
-    // cxx11-17-error@-1 {{defaulted definition of default constructor cannot be marked constexpr}}
+    // cxx11-17-error@-1 {{defaulted definition of default constructor cannot be marked constexpr before C++23}}
     union C { int n = 0; constexpr C() = default; };
     struct D { union {}; constexpr D() = default; };
     // since-cxx11-error@-1 {{declaration does not declare anything}}
     struct E { union { int n; }; constexpr E() = default; };
-    // cxx11-17-error@-1 {{defaulted definition of default constructor cannot be marked constexpr}}
+    // cxx11-17-error@-1 {{defaulted definition of default constructor cannot be marked constexpr before C++23}}
     struct F { union { int n = 0; }; constexpr F() = default; };
 
     struct G { union { int n = 0; }; union { int m; }; constexpr G() = default; };
-    // cxx11-17-error@-1 {{defaulted definition of default constructor cannot be marked constexpr}}
+    // cxx11-17-error@-1 {{defaulted definition of default constructor cannot be marked constexpr before C++23}}
     struct H {
       union {
         int n = 0;

--- a/clang/test/CXX/drs/cwg16xx.cpp
+++ b/clang/test/CXX/drs/cwg16xx.cpp
@@ -162,10 +162,10 @@ namespace cwg1653 { // cwg1653: 4 c++17
   void f(bool b) {
     ++b;
     // cxx98-14-warning@-1 {{incrementing expression of type bool is deprecated and incompatible with C++17}}
-    // since-cxx17-error@-2 {{SO C++17 does not allow incrementing expression of type bool}}
+    // since-cxx17-error@-2 {{ISO C++17 does not allow incrementing expression of type bool}}
     b++;
     // cxx98-14-warning@-1 {{incrementing expression of type bool is deprecated and incompatible with C++17}}
-    // since-cxx17-error@-2 {{SO C++17 does not allow incrementing expression of type bool}}
+    // since-cxx17-error@-2 {{ISO C++17 does not allow incrementing expression of type bool}}
     --b;
     // expected-error@-1 {{cannot decrement expression of type bool}}
     b--;
@@ -453,7 +453,7 @@ namespace cwg1696 { // cwg1696: 7
     struct A1 {
       A1() : v(42) {}
       // since-cxx14-error@-1 {{reference member 'v' binds to a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
-      // since-cxx14-note@#cwg1696-A1 {{reference member declared here}}
+      //   since-cxx14-note@#cwg1696-A1 {{reference member declared here}}
       const int &v; // #cwg1696-A1
     };
 
@@ -551,7 +551,7 @@ namespace cwg1696 { // cwg1696: 7
     std::initializer_list<int> il = {1, 2, 3}; // #cwg1696-il-5
     haslist5() {}
     // since-cxx11-error@-1 {{backing array for 'std::initializer_list' member 'il' is a temporary object whose lifetime would be shorter than the lifetime of the constructed object}}
-    //   since-cxx11-note@#cwg1696-il-5 {{nitializing field 'il' with default member initializer}}
+    //   since-cxx11-note@#cwg1696-il-5 {{initializing field 'il' with default member initializer}}
   };
 #endif
 } // namespace cwg1696

--- a/clang/test/CXX/drs/cwg18xx.cpp
+++ b/clang/test/CXX/drs/cwg18xx.cpp
@@ -568,7 +568,7 @@ struct Bar {
     int a = 0;
   };
   static_assert(__is_constructible(Baz), "");
-  // since-cxx11-error@-1 {{static assertion failed due to requirement '__is_constructible(cwg1890::ex2::Bar::Baz)'}}
+  // since-cxx11-error@-1 {{static assertion failed due to requirement '__is_constructible(cwg1890::ex2::Bar::Baz)':}}
   // since-cxx11-note@#cwg1890-Baz {{'Baz' defined here}}
 };
 #endif

--- a/clang/test/CXX/drs/cwg19xx.cpp
+++ b/clang/test/CXX/drs/cwg19xx.cpp
@@ -123,7 +123,7 @@ namespace cwg1940 { // cwg1940: 3.5
 static union {
   static_assert(true, "");  // ok
   static_assert(false, "");
-  // since-cxx11-error@-1 {{static assertion failed}}
+  // since-cxx11-error@-1 {{static assertion failed:}}
   int not_empty;
 };
 #endif

--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -910,7 +910,7 @@ namespace cwg152 { // cwg152: 2.7
 
 namespace cwg154 { // cwg154: 2.7
   union { int a; };
-  // expected-error@-1 {{nonymous unions at namespace or global scope must be declared 'static'}}
+  // expected-error@-1 {{anonymous unions at namespace or global scope must be declared 'static'}}
   namespace {
     union { int b; };
   }
@@ -960,7 +960,7 @@ namespace cwg161 { // cwg161: 3.1
       f();
       sf();
       c.f();
-      // expected-error@-1 {{protected}}
+      // expected-error@-1 {{'f' is a protected member of 'cwg161::A'}}
       //   expected-note@#cwg161-f {{declared protected here}}
       c.sf();
       A::f();

--- a/clang/test/CXX/drs/cwg20xx.cpp
+++ b/clang/test/CXX/drs/cwg20xx.cpp
@@ -160,16 +160,16 @@ namespace cwg2076 { // cwg2076: 13
     foo({arg});
     foo({{arg}});
     foo({{{arg}}});
-    // since-cxx11-error@-1 {{no matching function}}
-    //   since-cxx11-note@#cwg2076-foo  {{cannot convert initializer list}}
+    // since-cxx11-error@-1 {{no matching function for call to 'foo'}}
+    //   since-cxx11-note@#cwg2076-foo {{candidate function not viable: cannot convert initializer list argument to 'const string'}}
     bar(arg);
     bar({arg});
     bar({{arg}});
-    // since-cxx11-error@-1 {{no matching function}}
-    //   since-cxx11-note@#cwg2076-bar {{cannot convert initializer list}}
+    // since-cxx11-error@-1 {{no matching function for call to 'bar'}}
+    //   since-cxx11-note@#cwg2076-bar {{candidate function not viable: cannot convert initializer list argument to 'string_view'}}
     bar({{{arg}}});
-    // since-cxx11-error@-1 {{no matching function}}
-    //   since-cxx11-note@#cwg2076-bar {{cannot convert initializer list}}
+    // since-cxx11-error@-1 {{no matching function for call to 'bar'}}
+    //   since-cxx11-note@#cwg2076-bar {{candidate function not viable: cannot convert initializer list argument to 'string_view'}}
   }
 #endif
 } // namespace cwg2076

--- a/clang/test/CXX/drs/cwg22xx.cpp
+++ b/clang/test/CXX/drs/cwg22xx.cpp
@@ -108,7 +108,7 @@ namespace MultilevelSpecialization {
   template<> template<int a, int b>
     void B<int, int>::f(int i, int (&arr1)[a], int (&arr2)[b]) {}
     // since-cxx11-error@-1 {{out-of-line definition of 'f' does not match any declaration in 'cwg2233::MultilevelSpecialization::B<int, int>'}}
-    //   since-cxx11-note@#cwg2233-B {{defined here}}
+    //   since-cxx11-note@#cwg2233-B {{B defined here}}
   template<> template<>
     void B<int, int>::f<1, 1>(int i, int (&arr1a)[1], int (&arr2a)[1]) {}
 }

--- a/clang/test/CXX/drs/cwg23xx.cpp
+++ b/clang/test/CXX/drs/cwg23xx.cpp
@@ -270,7 +270,7 @@ namespace cwg2352 { // cwg2352: 10
   // lvalue of type 'const int *const * const'?
   const int * const * r;
   void *y = &(true ? p : r);
-  // expected-error@-1 {{rvalue of type 'const int *const *'}}
+  // expected-error@-1 {{cannot take the address of an rvalue of type 'const int *const *'}}
 
   // FIXME: We order these as a speculative defect resolution.
   void f(const int * const * const &r);

--- a/clang/test/CXX/drs/cwg26xx.cpp
+++ b/clang/test/CXX/drs/cwg26xx.cpp
@@ -142,8 +142,8 @@ struct foo {
 
 void f() {
   foo fooable; // #cwg2628-fooable
-  // since-cxx20-error@#cwg2628-fooable {{call to deleted}}
-  //   since-cxx20-note@#cwg2628-ctor {{marked deleted here}}
+  // since-cxx20-error@#cwg2628-fooable {{call to deleted constructor of 'foo<>' (aka 'cwg2628::foo<>')}}
+  //   since-cxx20-note@#cwg2628-ctor {{'foo' has been explicitly marked deleted here}}
 }
 #endif
 } // namespace cwg2628
@@ -244,7 +244,7 @@ class X {
 };
 int i0 = f<X>(0);
 // since-cxx23-error@-1 {{no matching function for call to 'f'}}
-//   since-cxx23-note@#cwg2650-f {{type 'X' of non-type template parameter is not a structural type}}
+//   since-cxx23-note@#cwg2650-f {{candidate template ignored: substitution failure [with T = X]: type 'X' of non-type template parameter is not a structural type}}
 #endif
 } // namespace cwg2650
 
@@ -290,7 +290,7 @@ static_assert(__is_same(decltype(h), H<char, 4>));  // Not H<const char, 4>
 static_assert(__is_same(decltype(i), I<char, 4>));
 
 J j = { "ghi" };
-// since-cxx20-error@-1 {{no viable constructor or deduction guide}}
+// since-cxx20-error@-1 {{no viable constructor or deduction guide for deduction of template arguments of 'J'}}
 //   since-cxx20-note@#cwg2681-J {{candidate template ignored: could not match 'cwg2681::J<N>' against 'const char *'}}
 //   since-cxx20-note@#cwg2681-J {{implicit deduction guide declared as 'template <size_t N> J(cwg2681::J<N>) -> cwg2681::J<N>'}}
 //   since-cxx20-note@#cwg2681-J {{candidate template ignored: could not match 'const unsigned char' against 'const char'}}
@@ -370,8 +370,8 @@ void A::test() {
 
     (&A::g)(A());
     // since-cxx23-error@-1 {{call to 'g' is ambiguous}}
-    //   since-cxx23-note@#cwg2692-3 {{candidate function}}
-    //   since-cxx23-note@#cwg2692-4 {{candidate function}}
+    //   since-cxx23-note@#cwg2692-3 {{candidate function [with T = cwg2692::A]}}
+    //   since-cxx23-note@#cwg2692-4 {{candidate function [with T = cwg2692::A]}}
     (&A::g<A>)();
     // since-cxx23-error@-1 {{no matching function for call to 'g'}}
     //   since-cxx23-note@#cwg2692-3 {{candidate function template not viable: requires 1 argument, but 0 were provided}}

--- a/clang/test/CXX/drs/cwg27xx.cpp
+++ b/clang/test/CXX/drs/cwg27xx.cpp
@@ -46,13 +46,13 @@ A(T...) -> A<int, sizeof...(T)> requires (sizeof...(T) == 2); // #cwg2707-guide-
 A a = {1, 2};
 
 A b = {3, 4, 5};
-// since-cxx20-error@-1 {{no viable constructor or deduction guide}}
-//   since-cxx20-note@#cwg2707-A {{candidate function template not viable}}
-//   since-cxx20-note@#cwg2707-A {{implicit deduction guide}}
-//   since-cxx20-note@#cwg2707-guide-A {{constraints not satisfied}}
+// since-cxx20-error@-1 {{no viable constructor or deduction guide for deduction of template arguments of 'A'}}
+//   since-cxx20-note@#cwg2707-A {{candidate function template not viable: requires 1 argument, but 3 were provided}}
+//   since-cxx20-note@#cwg2707-A {{implicit deduction guide declared as 'template <class T, unsigned int N> A(cwg2707::A<T, N>) -> cwg2707::A<T, N>'}}
+//   since-cxx20-note@#cwg2707-guide-A {{candidate template ignored: constraints not satisfied [with T = <int, int, int>]}}
 //   since-cxx20-note@#cwg2707-guide-A {{because 'sizeof...(T) == 2' (3 == 2) evaluated to false}}
-//   since-cxx20-note@#cwg2707-A {{candidate function template not viable}}
-//   since-cxx20-note@#cwg2707-A {{implicit deduction guide}}
+//   since-cxx20-note@#cwg2707-A {{candidate function template not viable: requires 0 arguments, but 3 were provided}}
+//   since-cxx20-note@#cwg2707-A {{implicit deduction guide declared as 'template <class T, unsigned int N> A() -> cwg2707::A<T, N>'}}
 
 #endif
 

--- a/clang/test/CXX/drs/cwg29xx.cpp
+++ b/clang/test/CXX/drs/cwg29xx.cpp
@@ -74,8 +74,10 @@ template<bool B> struct X {
 };
 
 void test() {
-  &X<true>::f;      // since-cxx20-error {{reference to overloaded function could not be resolved}}
-  &X<true>::g<int>; // since-cxx20-error {{reference to overloaded function could not be resolved}}
+  &X<true>::f;
+  // since-cxx20-error@-1 {{reference to overloaded function could not be resolved; did you mean to call it?}}
+  &X<true>::g<int>;
+  // since-cxx20-error@-1 {{reference to overloaded function could not be resolved; did you mean to call it?}}
 }
 
 } // namespace Example1

--- a/clang/test/CXX/drs/cwg30xx.cpp
+++ b/clang/test/CXX/drs/cwg30xx.cpp
@@ -13,11 +13,11 @@ void f(
     int _, // #cwg3005-first-param
     int _)
     // expected-error@-1 {{redefinition of parameter '_'}}
-    //   expected-note@#cwg3005-first-param {{previous definition is here}}
+    //   expected-note@#cwg3005-first-param {{previous declaration is here}}
 {
     int _;
     // expected-error@-1 {{redefinition of '_'}}
-    // expected-note@#cwg3005-first-param {{previous declaration is here}}
+    // expected-note@#cwg3005-first-param {{previous definition is here}}
 }
 
 } // namespace cwg3005

--- a/clang/test/CXX/drs/cwg3xx.cpp
+++ b/clang/test/CXX/drs/cwg3xx.cpp
@@ -198,8 +198,8 @@ namespace cwg306 { // cwg306: dup 39
   Z<X>::X zx;
   Z<const X>::X zcx;
   // expected-error@-1 {{member 'X' found in multiple base classes of different types}}
-  //   expected-note@#cwg306-X {{member type 'cwg306::X' found}}
-  //   expected-note@#cwg306-typedef-X {{member type 'const cwg306::X' found}}
+  //   expected-note@#cwg306-X {{member type 'cwg306::X' found by ambiguous name lookup}}
+  //   expected-note@#cwg306-typedef-X {{member type 'const cwg306::X' found by ambiguous name lookup}}
 } // namespace cwg306
 
 // cwg307: na
@@ -601,7 +601,7 @@ namespace cwg336 { // cwg336: 2.7
     template<> template<class X> class A<int>::B {}; // #cwg336-B
     template<> template<> template<class T> void A<int>::B<double>::mf1(T t) {}
     // expected-error@-1 {{out-of-line definition of 'mf1' does not match any declaration in 'cwg336::Pre::A<int>::B<double>'}}
-    //   expected-note@#cwg336-B {{defined here}}
+    //   expected-note@#cwg336-B {{B defined here}}
     template<class Y> template<> void A<Y>::B<double>::mf2() {}
     // expected-error@-1 {{nested name specifier 'A<Y>::B<double>' for declaration does not refer into a class, class template or class template partial specialization}}
   }
@@ -652,8 +652,8 @@ namespace cwg339 { // cwg339: 2.8
     A<1> a = f(0);
     A<2> b = f(0.0f);
     A<3> c = f("foo");
-    // expected-error@-1 {{no matching function}}
-    //   expected-note@#cwg339-f {{candidate}}
+    // expected-error@-1 {{no matching function for call to 'f'}}
+    //   expected-note@#cwg339-f {{candidate template ignored: substitution failure [with T = const char *]: no matching function for call to 'xxx'}}
   }
 
 
@@ -770,10 +770,10 @@ namespace cwg347 { // cwg347: 2.7
   // expected-error@-1 {{no member named 'n' in 'cwg347::derived'}}
   void derived::f() {}
   // expected-error@-1 {{out-of-line definition of 'f' does not match any declaration in 'cwg347::derived'}}
-  //   expected-note@#cwg347-derived {{defined here}}
+  //   expected-note@#cwg347-derived {{derived defined here}}
   void derived::g() {}
   // expected-error@-1 {{out-of-line definition of 'g' does not match any declaration in 'cwg347::derived'}}
-  //   expected-note@#cwg347-derived {{defined here}}
+  //   expected-note@#cwg347-derived {{derived defined here}}
 } // namespace cwg347
 
 // cwg348: na
@@ -1028,7 +1028,7 @@ namespace cwg357 { // cwg357: 2.7
   };
   template<typename T> void A<T>::f() {}
   // expected-error@-1 {{out-of-line definition of 'f' does not match any declaration in 'cwg357::A<T>'}}
-  //   expected-note@#cwg357-A {{defined here}}
+  //   expected-note@#cwg357-A {{A defined here}}
   //   expected-note@#cwg357-f {{member declaration does not match because it is const qualified}}
 
   struct B { // #cwg357-B
@@ -1036,7 +1036,7 @@ namespace cwg357 { // cwg357: 2.7
   };
   template<typename T> void B::f() const {}
   // expected-error@-1 {{out-of-line definition of 'f' does not match any declaration in 'cwg357::B'}}
-  //   expected-note@#cwg357-B {{defined here}}
+  //   expected-note@#cwg357-B {{B defined here}}
 } // namespace cwg357
 
 namespace cwg358 { // cwg358: 2.7
@@ -1128,10 +1128,10 @@ namespace cwg366 { // cwg366: 2.7
 
 namespace cwg367 { // cwg367: 2.7
   static_assert(__enable_constant_folding(true ? throw 0 : 4), "");
-  // expected-error@-1 {{expression is not an integral constant expression}}
+  // expected-error@-1 {{static assertion expression is not an integral constant expression}}
   static_assert(__enable_constant_folding(true ? 4 : throw 0), "");
   static_assert(__enable_constant_folding(true ? *new int : 4), "");
-  // expected-error@-1 {{expression is not an integral constant expression}}
+  // expected-error@-1 {{static assertion expression is not an integral constant expression}}
   //   expected-note@-2 {{read of uninitialized object is not allowed in a constant expression}}
   static_assert(__enable_constant_folding(true ? 4 : *new int), "");
 } // namespace cwg367
@@ -1781,7 +1781,7 @@ namespace cwg398 { // cwg398: 2.7
       //   expected-note@#cwg398-f {{candidate template ignored: substitution failure [with T = B]: typename specifier refers to non-type member 'Y' in 'cwg398::example2::B'}}
       g<C>(0);
       // expected-error@-1 {{no matching function for call to 'g'}}
-      //   expected-note@#cwg398-g {{candidate template ignored: substitution failure [with T = C]: missing 'typename' prior to dependent type name 'C::N'}}
+      //   expected-note@#cwg398-g {{candidate template ignored: substitution failure [with T = C]: missing 'typename' prior to dependent type name 'C::N' (aka 'int')}}
       h<D>(0);
       // expected-error@-1 {{no matching function for call to 'h'}}
       //   expected-note@#cwg398-h {{candidate template ignored: substitution failure [with T = D]: 'TT' following the 'template' keyword does not refer to a template}}

--- a/clang/test/CXX/drs/cwg4xx.cpp
+++ b/clang/test/CXX/drs/cwg4xx.cpp
@@ -196,7 +196,7 @@ namespace cwg407 { // cwg407: 3.8
       using namespace A;
       using namespace B;
       struct S s;
-      // expected-error@-1 {{ambiguous}}
+      // expected-error@-1 {{reference to 'S' is ambiguous}}
       //   expected-note@#cwg407-A-S {{candidate found by name lookup is 'cwg407::UsingDir::A::S'}}
       //   expected-note@#cwg407-B-S {{candidate found by name lookup is 'cwg407::UsingDir::B::S'}}
     }
@@ -595,7 +595,7 @@ namespace cwg429 { // cwg429: 2.8 c++11
     static void operator delete(void*, size_t); // #cwg429-delete
   } *a = new (0) A;
   // since-cxx11-error@-1 {{'new' expression with placement arguments refers to non-placement 'operator delete'}}
-  //   since-cxx11-note@#cwg429-delete {{here}}
+  //   since-cxx11-note@#cwg429-delete {{'operator delete' declared here}}
   struct B {
     static void *operator new(size_t, size_t);
     static void operator delete(void*);
@@ -857,7 +857,7 @@ namespace cwg451 { // cwg451: 2.7
   const int b = 1 / 0; // #cwg451-b
   // expected-warning@-1 {{division by zero is undefined}}
   static_assert(b, "");
-  // expected-error@-1 {{expression is not an integral constant expression}}
+  // expected-error@-1 {{static assertion expression is not an integral constant expression}}
   //   expected-note@-2 {{initializer of 'b' is not a constant expression}}
   //   expected-note@#cwg451-b {{declared here}}
 } // namespace cwg451
@@ -882,7 +882,7 @@ namespace cwg456 { // cwg456: 3.4
 
   const bool f = false;
   void *q = f;
-  // cxx98-warning@-1 {{initialization of pointer of type 'void *' to null from a constant boolean}}
+  // cxx98-warning@-1 {{initialization of pointer of type 'void *' to null from a constant boolean expression}}
   // since-cxx11-error@-2 {{cannot initialize a variable of type 'void *' with an lvalue of type 'const bool'}}
 } // namespace cwg456
 
@@ -891,7 +891,7 @@ namespace cwg457 { // cwg457: 2.7
   const volatile int b = 1;
   static_assert(a, "");
   static_assert(b, "");
-  // expected-error@-1 {{expression is not an integral constant expression}}
+  // expected-error@-1 {{static assertion expression is not an integral constant expression}}
   //   expected-note@-2 {{read of volatile-qualified type 'const volatile int' is not allowed in a constant expression}}
 
   enum E {
@@ -1119,9 +1119,9 @@ namespace cwg477 { // cwg477: 3.5
     // expected-error@-1 {{'virtual' is invalid in friend declarations}}
   };
   explicit A::A() {}
-  // expected-error@-1 {{can only be specified inside the class definition}}
+  // expected-error@-1 {{'explicit' can only be specified inside the class definition}}
   virtual void A::f() {}
-  // expected-error@-1 {{can only be specified inside the class definition}}
+  // expected-error@-1 {{'virtual' can only be specified inside the class definition}}
 } // namespace cwg477
 
 namespace cwg478 { // cwg478: 2.7
@@ -1379,7 +1379,7 @@ namespace cwg487 { // cwg487: 2.7
   enum E { e };
   int operator+(int, E); // #cwg487-operator-plus
   static_assert(4 + e, "");
-  // expected-error@-1 {{expression is not an integral constant expression}}
+  // expected-error@-1 {{static assertion expression is not an integral constant expression}}
   //   since-cxx11-note@-2 {{non-constexpr function 'operator+' cannot be used in a constant expression}}
   //   since-cxx11-note@#cwg487-operator-plus {{declared here}}
 } // namespace cwg487
@@ -1395,7 +1395,7 @@ namespace cwg488 { // cwg488: 2.9 c++11
     enum E { e };
     f(e);
     // cxx98-error@-1 {{template argument uses local type 'E'}}
-    //   cxx98-note@-2 {{while substituting deduced template arguments}}
+    //   cxx98-note@-2 {{while substituting deduced template arguments into function template 'f' [with T = E]}}
   }
 } // namespace cwg488
 

--- a/clang/test/CXX/drs/cwg5xx.cpp
+++ b/clang/test/CXX/drs/cwg5xx.cpp
@@ -184,7 +184,7 @@ namespace cwg522 { // cwg522: 2.7
     b2(am);
     b2a(am);
     // expected-error@-1 {{no matching function for call to 'b2a'}}
-    //   expected-note@#cwg522-b2a {{candidate template ignored: deduced type 'volatile int *S::*const *' of 1st parameter does not match adjusted type 'int *S::**' of argument}}
+    //   expected-note@#cwg522-b2a {{candidate template ignored: deduced type 'volatile int *S::*const *' of 1st parameter does not match adjusted type 'int *S::**' of argument [with T = int]}}
     b3(d);
     b3(cd);
   }
@@ -348,11 +348,11 @@ namespace cwg531 { // cwg531: partial
     void A<int>::f(int) {}
     // expected-error@-1 {{template specialization requires 'template<>'}}
     template<typename U> void A<int>::g(int, U) {}
-    // expected-error@-1 {{template parameter list matching the non-templated nested type 'cwg531::bad::A<int>' should be empty}}
+    // expected-error@-1 {{template parameter list matching the non-templated nested type 'cwg531::bad::A<int>' should be empty ('template<>')}}
     struct A<int>::B {};
     // expected-error@-1 {{template specialization requires 'template<>'}}
     template<typename U> struct A<int>::C {};
-    // expected-error@-1 {{template parameter list matching the non-templated nested type 'cwg531::bad::A<int>' should be empty}}
+    // expected-error@-1 {{template parameter list matching the non-templated nested type 'cwg531::bad::A<int>' should be empty ('template<>')}}
     // expected-error@-2 {{redefinition of 'C' as different kind of symbol}}
     //   expected-note@#cwg531-C {{previous definition is here}}
     int A<int>::n = 0;
@@ -880,7 +880,7 @@ namespace cwg569 { // cwg569: 2.7 c++11
   // FIXME: This is a DR issue against C++98, so should probably apply there
   // too.
   ;;;;;
-  // cxx98-error@-1 {{C++11 extension}}
+  // cxx98-error@-1 {{extra ';' outside of a function is a C++11 extension}}
 } // namespace cwg569
 
 namespace cwg570 { // cwg570: dup 633
@@ -957,7 +957,7 @@ namespace cwg574 { // cwg574: 3.0
 #elif __cplusplus >= 201103L
     // FIXME: We shouldn't produce the 'cannot overload' diagnostics here.
     friend C &C::operator=(const C&); // #cwg574-test-C
-    // since-cxx11-error@#cwg574-test-C {{cannot overload}}
+    // since-cxx11-error@#cwg574-test-C {{cannot overload a member function without a ref-qualifier with a member function with ref-qualifier '&'}}
     //   since-cxx11-note@#cwg574-C-copy-assign {{previous declaration is here}}
     // since-cxx11-error@#cwg574-test-C {{friend declaration of 'operator=' does not match any declaration in 'cwg574::C'}}
     //   since-cxx11-note@#cwg574-C-copy-assign {{candidate function}}
@@ -1238,7 +1238,7 @@ namespace cwg591 { // cwg591: 20
 
   template<typename T> struct A<T>::B::D : A<T*> {
     M m;
-    // expected-error@-1 {{field has incomplete type 'M' (aka 'void'}}
+    // expected-error@-1 {{field has incomplete type 'M' (aka 'void')}}
   };
 
   template<typename T>
@@ -1246,7 +1246,7 @@ namespace cwg591 { // cwg591: 20
   template<typename F>
   struct H<T>::B<U>::C<F>::P : B<F> {
     M m;
-    // expected-error@-1 {{field has incomplete type 'M' (aka 'void'}}
+    // expected-error@-1 {{field has incomplete type 'M' (aka 'void')}}
   };
 } // namespace cwg591
 

--- a/clang/test/CXX/drs/cwg6xx.cpp
+++ b/clang/test/CXX/drs/cwg6xx.cpp
@@ -618,8 +618,8 @@ namespace cwg647 { // cwg647: 3.1
         : n(0),
           d(0.0f) {} // #cwg647-int-d
     constexpr E(float f)
-    // cxx11-20-error@-1 {{never produces a constant expression}}
-    //   cxx11-20-note@#cwg647-float-d {{non-constexpr constructor}}
+    // cxx11-20-error@-1 {{constexpr constructor never produces a constant expression}}
+    //   cxx11-20-note@#cwg647-float-d {{non-constexpr constructor 'D' cannot be used in a constant expression}}
     //   cxx11-20-note@#cwg647-D-float-ctor {{declared here}}
         : n(get()),
           d(D(0) + f) {} // #cwg647-float-d
@@ -895,12 +895,12 @@ namespace cwg666 { // cwg666: 2.8
   template<int> int f();
   template<typename T> int f() {
     T::type *p = 0;
-    // expected-error@-1 {{missing 'typename' prior to dependent type name 'cwg666::Y::type'}}
+    // expected-error@-1 {{missing 'typename' prior to dependent type name 'cwg666::Y::type' (aka 'int')}}
     //   expected-note@#cwg666-f-Y {{in instantiation of function template specialization 'cwg666::f<cwg666::Y>' requested here}}
     int a(T::type);
-    // expected-error@-1 {{missing 'typename' prior to dependent type name 'cwg666::Y::type'}}
+    // expected-error@-1 {{missing 'typename' prior to dependent type name 'cwg666::Y::type' (aka 'int')}}
     return f<T::type>();
-    // expected-error@-1 {{missing 'typename' prior to dependent type name 'cwg666::Y::type'}}
+    // expected-error@-1 {{missing 'typename' prior to dependent type name 'cwg666::Y::type' (aka 'int')}}
   }
   struct X { static const int type = 0; };
   struct Y { typedef int type; };
@@ -1159,7 +1159,7 @@ namespace cwg684 { // cwg684: sup 1454
     constexpr int *p = &a;
     // since-cxx11-error@-1 {{constexpr variable 'p' must be initialized by a constant expression}}
     //   since-cxx11-note@-2 {{pointer to 'a' is not a constant expression}}
-    //   since-cxx11-note@#cwg684-a {{here}}
+    //   since-cxx11-note@#cwg684-a {{declared here}}
   }
 #endif
 } // namespace cwg684
@@ -1308,7 +1308,7 @@ namespace cwg692 { // cwg692: 16
       //   expected-note@#cwg692-f-deleted {{candidate function [with T = int, U = int] has been explicitly deleted}}
       //   expected-note@#cwg692-f {{candidate function [with U = int]}}
       g(42);
-      // expected-error@-1 {{ambiguous}}
+      // expected-error@-1 {{call to 'g' is ambiguous}}
       //   expected-note@#cwg692-g {{candidate function [with T = int]}}
       //   expected-note@#cwg692-g-variadic {{candidate function [with T = int, U = <>]}}
     }

--- a/clang/test/CXX/drs/cwg7xx.cpp
+++ b/clang/test/CXX/drs/cwg7xx.cpp
@@ -21,7 +21,7 @@ namespace cwg705 { // cwg705: 2.7
     N::S s;
     f(s);      // ok
     (f)(s);
-    // expected-error@-1 {{use of undeclared identifier 'f'}}
+    // expected-error@-1 {{use of undeclared identifier 'f'; did you mean 'N::f'?}}
     //   expected-note@#cwg705-f {{'N::f' declared here}}
   }
 } // namespace cwg705
@@ -273,7 +273,7 @@ namespace cwg727 { // cwg727: partial
     static_assert(B<1>().v<0> == 2, "");
     static_assert(B<0>().v<1> == 3, "");
     static_assert(B<0>().v<0> == 4, "");
-    // cxx14-error@-1 {{static assertion failed due to requirement 'cwg727::mixed_inner_outer_specialization::B<0>().v<0> == 4'}}
+    // cxx14-error@-1 {{static assertion failed due to requirement 'cwg727::mixed_inner_outer_specialization::B<0>().v<0> == 4':}}
     //   cxx14-note@-2 {{expression evaluates to '2 == 4'}}
 
     static_assert(B<1>().w<1> == 1, "");


### PR DESCRIPTION
This is the first of two patches that apply various fixes to C++ DR tests based on new tooling I developed. This patch is almost entirely about incomplete diagnostic text in `expected` directives, which was intended to be complete, but I failed to notice that during reviews.

There is also a couple of fixes for `expected-note` directives that were not correctly indented relative to the error they attach to. Then there is couple of fixes when `expected` directives where not placed correctly (didn't use `@-1` way).