### PR TITLE
[clang][bytecode] Return Invalid() from atomic_is_lock_free calls

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -1125,7 +1125,7 @@ static bool interp__builtin_atomic_lock_free(InterpState &S, CodePtr OpPC,
   if (BuiltinOp == Builtin::BI__atomic_always_lock_free)
     return returnBool(false);
 
-  return false;
+  return Invalid(S, OpPC);
 }
 
 /// bool __c11_atomic_is_lock_free(size_t)

--- a/clang/test/AST/ByteCode/builtins.c
+++ b/clang/test/AST/ByteCode/builtins.c
@@ -1,8 +1,5 @@
-// RUN: %clang_cc1 -fexperimental-new-constant-interpreter %s -verify
-// RUN: %clang_cc1                                         %s -verify=ref
-
-// expected-no-diagnostics
-// ref-no-diagnostics
+// RUN: %clang_cc1 -fexperimental-new-constant-interpreter %s -verify=expected,both
+// RUN: %clang_cc1                                         %s -verify=ref,both
 
 extern __SIZE_TYPE__ strlen(const char *);
 
@@ -19,3 +16,6 @@ int structStrlen(void) {
 
 void f() { __builtin_memcpy(f, f, 1); }
 void f2()  { __builtin_memchr(f2, 0, 1); }
+
+
+_Static_assert(__atomic_is_lock_free(4, (void*)2), ""); // both-error {{not an integral constant expression}}


### PR DESCRIPTION
If they are invalid. This is what the current interpreter does.