### PR TITLE
[lldb-dap] fix executable substitution in tests

### DIFF
--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -167,7 +167,9 @@ def use_lldb_substitutions(config):
             unresolved="ignore",
         ),
         "lldb-test",
-        "lldb-dap",
+        ToolSubst(
+            "%lldb-dap", command=FindTool("lldb-dap"), extra_args=[], unresolved="fatal"
+        ),
         ToolSubst(
             "%build", command="'" + sys.executable + "'", extra_args=build_script_args
         ),


### PR DESCRIPTION
This patch fixes the `lldb-dap` executable substitution in tests. This was not done before.