### PR TITLE
[AArch64][PAC] Emit `!dbg` locations in `*_vfpthunk_` functions

### DIFF
--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -3480,6 +3480,10 @@ ItaniumCXXABI::getOrCreateVirtualFunctionPointerThunk(const CXXMethodDecl *MD) {
 
   CGF.StartFunction(GlobalDecl(), FnInfo.getReturnType(), ThunkFn, FnInfo,
                     FunctionArgs, MD->getLocation(), SourceLocation());
+
+  // Emit an artificial location for this function.
+  auto AL = ApplyDebugLocation::CreateArtificial(CGF);
+
   llvm::Value *ThisVal = loadIncomingCXXThis(CGF);
   setCXXABIThisValue(CGF, ThisVal);
 

--- a/clang/test/DebugInfo/CXX/ptrauth-member-function-pointer-debuglocs.cpp
+++ b/clang/test/DebugInfo/CXX/ptrauth-member-function-pointer-debuglocs.cpp
@@ -8,11 +8,19 @@
 // Check that compiler-generated *_vfpthunk_ function has a !dbg location
 // attached to the call instruction.
 
-// CHECK:      define {{.*}}@_ZN1A2f0Ev_vfpthunk_{{.*}} !dbg
+// CHECK:      define {{.*}}@_ZN1A2f0Ev_vfpthunk_({{.*}})
+// CHECK-SAME:     !dbg ![[SCOPE_INDEX:[0-9]+]]
+// CHECK-NOT:  define
+// CHECK:        %[[DISCR:[0-9]+]] = call i64 @llvm.ptrauth.blend(i64 %{{[0-9]+}}, i64 9385)
 // CHECK-NOT:  define
 // CHECK:        musttail call void %{{[0-9]+}}(ptr
-// CHECK-SAME:     [ "ptrauth"(i32 0, i64 %{{[0-9]+}}) ]
-// CHECK-SAME:     !dbg
+// CHECK-SAME:     [ "ptrauth"(i32 0, i64 %[[DISCR]]) ]
+// CHECK-SAME:     !dbg ![[LOCATION_INDEX:[0-9]+]]
+
+// CHECK:      ![[SCOPE_INDEX]] = distinct !DISubprogram(
+// CHECK-SAME:                        linkageName: "_ZN1A2f0Ev_vfpthunk_"
+// CHECK-SAME:                        flags: DIFlagArtificial | DIFlagThunk
+// CHECK:      ![[LOCATION_INDEX]] = !DILocation(line: 0, scope: ![[SCOPE_INDEX]])
 
 volatile long T;
 

--- a/clang/test/DebugInfo/CXX/ptrauth-member-function-pointer-debuglocs.cpp
+++ b/clang/test/DebugInfo/CXX/ptrauth-member-function-pointer-debuglocs.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -triple arm64-apple-ios   -fptrauth-calls -fptrauth-intrinsics \
+// RUN:     -emit-llvm -std=c++11 -O1 -disable-llvm-passes \
+// RUN:     -debug-info-kind=limited %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple aarch64-linux-gnu -fptrauth-calls -fptrauth-intrinsics \
+// RUN:     -emit-llvm -std=c++11 -O1 -disable-llvm-passes \
+// RUN:     -debug-info-kind=limited %s -o - | FileCheck %s
+
+// Check that compiler-generated *_vfpthunk_ function has a !dbg location
+// attached to the call instruction.
+
+// CHECK:      define {{.*}}@_ZN1A2f0Ev_vfpthunk_{{.*}} !dbg
+// CHECK-NOT:  define
+// CHECK:        musttail call void %{{[0-9]+}}(ptr
+// CHECK-SAME:     [ "ptrauth"(i32 0, i64 %{{[0-9]+}}) ]
+// CHECK-SAME:     !dbg
+
+volatile long T;
+
+struct A {
+  virtual void f0() {
+    T = 0;
+  }
+};
+typedef void (A::*MFP)();
+
+void caller() {
+  A a;
+
+  MFP x = &A::f0;
+  (a.*x)();
+}


### PR DESCRIPTION
The usage of pointers to member functions with Pointer Authentication requires generation of `*_vfpthunk_` functions. These thunk functions can be later inlined and optimized by replacing the indirect call instruction with a direct one and then inlining that function call.

In absence of `!dbg` metadata attached to the original call instruction, such inlining ultimately results in an assertion "!dbg attachment points at wrong subprogram for function" in the assertions-enabled builds. By manually executing `opt` with `-verify-each` option on the LLVM IR produced by the frontend, an actual issue can be observed: "inlinable function call in a function with debug info must have a !dbg location" after the replacement of indirect call instruction with the direct one takes place.

This commit fixes the issue by attaching artificial `!dbg` locations to the original call instruction (as well as most other instructions in `*_vfpthunk_` function) the same way it is done for other compiler-generated helper functions.