### PR TITLE
[lldb-dap] Fix flaky TestDAP_stopped_events.py

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -44,7 +44,7 @@ DEFAULT_TIMEOUT: Final[float] = 50.0 * (10.0 if ("ASAN_OPTIONS" in os.environ) e
 # A quiet period between events, used to determine if we're done receiving
 # events in a given window, otherwise 'wait_for_stopped' would need to wait
 # until the DEFAULT_TIMEOUT occurs, slows down tests significantly.
-EVENT_QUIET_PERIOD = 0.25
+EVENT_QUIET_PERIOD = 0.25 * (20.0 if ("ASAN_OPTIONS" in os.environ) else 1.0)
 
 
 # See lldbtest.Base.spawnSubprocess, which should help ensure any processes

--- a/lldb/test/API/tools/lldb-dap/stopped-events/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/stopped-events/main.cpp
@@ -7,7 +7,7 @@ static int my_add(int a, int b) { // breakpoint
   return a + b;
 }
 
-int main(int argc, char const *argv[]) {
+static void do_test() {
   // Don't let either thread do anything until they're both ready.
   pseudo_barrier_init(g_barrier, 2);
 
@@ -24,6 +24,9 @@ int main(int argc, char const *argv[]) {
 
   t1.join();
   t2.join();
+}
 
+int main(int argc, char const *argv[]) {
+  do_test();
   return 0;
 }


### PR DESCRIPTION
We are waiting for both stopped event at once.
We may not get both events within the (0.25 seconds) time interval to fetch more events. Retry with the `DEFAULT TIMEOUT` if we got one of the event.

Increase the `EVENT_QUIET_PERIOD`'s value for ASAN mode

Fixes #179648