### PR TITLE
[AMDGPU] Fix V_INDIRECT_REG_READ_GPR_IDX expansion with immediate index

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -2410,11 +2410,10 @@ bool SIInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
     Register Dst = MI.getOperand(0).getReg();
     Register VecReg = MI.getOperand(1).getReg();
     bool IsUndef = MI.getOperand(1).isUndef();
-    Register Idx = MI.getOperand(2).getReg();
     Register SubReg = MI.getOperand(3).getImm();
 
     MachineInstr *SetOn = BuildMI(MBB, MI, DL, get(AMDGPU::S_SET_GPR_IDX_ON))
-                              .addReg(Idx)
+                              .add(MI.getOperand(2))
                               .addImm(AMDGPU::VGPRIndexMode::SRC0_ENABLE);
     SetOn->getOperand(3).setIsUndef();
 

--- a/llvm/test/CodeGen/AMDGPU/indirect-reg-read-imm-idx.ll
+++ b/llvm/test/CodeGen/AMDGPU/indirect-reg-read-imm-idx.ll
@@ -1,0 +1,21 @@
+; RUN: llc -mtriple=amdgcn -mcpu=gfx90a -O1 -global-isel=true < %s | FileCheck %s
+
+; Test that V_INDIRECT_REG_READ_GPR_IDX expansion handles immediate index operands.
+; The wave.reduce.umin with constant arguments folds to 0, which becomes an
+; immediate index for the insertelement, triggering V_INDIRECT_REG_READ_GPR_IDX
+; with an immediate operand.
+
+; CHECK-LABEL: indirect_reg_read_imm_idx:
+; CHECK: s_set_gpr_idx_on 0, gpr_idx(SRC0)
+; CHECK-NEXT: v_mov_b32_e32
+; CHECK-NEXT: s_set_gpr_idx_off
+define amdgpu_kernel void @indirect_reg_read_imm_idx() {
+entry:
+  %vec = load <32 x i16>, ptr null, align 64
+  %idx = call i32 @llvm.amdgcn.wave.reduce.umin.i32(i32 0, i32 0)
+  %ins = insertelement <32 x i16> %vec, i16 0, i32 %idx
+  store <32 x i16> %ins, ptr null, align 64
+  ret void
+}
+
+declare i32 @llvm.amdgcn.wave.reduce.umin.i32(i32, i32 immarg)

--- a/llvm/test/CodeGen/AMDGPU/indirect-reg-read-imm-idx.ll
+++ b/llvm/test/CodeGen/AMDGPU/indirect-reg-read-imm-idx.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn -mcpu=gfx90a -O1 -global-isel=true < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx90a -O1 -global-isel < %s | FileCheck %s
 
 ; Test that V_INDIRECT_REG_READ_GPR_IDX expansion handles immediate index operands.
 ; The wave.reduce.umin with constant arguments folds to 0, which becomes an

--- a/llvm/test/CodeGen/AMDGPU/indirect-reg-read-imm-idx.mir
+++ b/llvm/test/CodeGen/AMDGPU/indirect-reg-read-imm-idx.mir
@@ -1,0 +1,18 @@
+# RUN: llc -mtriple=amdgcn -mcpu=gfx90a -start-before=twoaddressinstruction %s -o - | FileCheck %s
+
+# Test that V_INDIRECT_REG_READ_GPR_IDX expansion handles immediate index operands.
+
+
+# CHECK-LABEL: indirect_reg_read_imm_idx:
+# CHECK: s_set_gpr_idx_on 0, gpr_idx(SRC0)
+# CHECK-NEXT: v_mov_b32_e32
+# CHECK-NEXT: s_set_gpr_idx_off
+
+name: indirect_reg_read_imm_idx
+tracksRegLiveness: true
+body: |
+  bb.0.entry:
+    %0:vreg_512_align2 = IMPLICIT_DEF
+    %1:vgpr_32 = V_INDIRECT_REG_READ_GPR_IDX_B32_V16 %0, 0, 3, implicit-def $m0, implicit $m0, implicit $exec
+    S_ENDPGM 0
+...


### PR DESCRIPTION
The definition for V_INDIRECT_REG_READ_GPR_IDX_B32_V*'s SSrc_b32 operand allows immediates, but the expansion logic handles only register cases now. This can result in expansion failures when e.g. llvm.amdgcn.wave.reduce.umin.i32 is folded into a constant and then used as an insertelement idx.