### PR TITLE
[MLIR][Python] Support dynamic traits in python-defined dialects

### DIFF
--- a/mlir/.clang-tidy
+++ b/mlir/.clang-tidy
@@ -29,6 +29,7 @@ Checks: >
         modernize-use-emplace,
         modernize-use-nullptr,
         modernize-use-override,
+        modernize-use-using,
         performance-for-range-copy,
         performance-implicit-conversion-in-loop,
         performance-inefficient-algorithm,

--- a/mlir/.clang-tidy
+++ b/mlir/.clang-tidy
@@ -29,7 +29,6 @@ Checks: >
         modernize-use-emplace,
         modernize-use-nullptr,
         modernize-use-override,
-        modernize-use-using,
         performance-for-range-copy,
         performance-implicit-conversion-in-loop,
         performance-inefficient-algorithm,

--- a/mlir/include/mlir-c/ExtensibleDialect.h
+++ b/mlir/include/mlir-c/ExtensibleDialect.h
@@ -1,0 +1,55 @@
+//===-- mlir-c/ExtensibleDialect.h - Extensible dialect management ---*- C
+//-*-====//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header provides basic access to the MLIR JIT. This is minimalist and
+// experimental at the moment.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_C_EXTENSIBLEDIALECT_H
+#define MLIR_C_EXTENSIBLEDIALECT_H
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//===----------------------------------------------------------------------===//
+/// Opaque type declarations (see mlir-c/IR.h for more details).
+//===----------------------------------------------------------------------===//
+
+#define DEFINE_C_API_STRUCT(name, storage)                                     \
+  struct name {                                                                \
+    storage *ptr;                                                              \
+  };                                                                           \
+  typedef struct name name
+
+DEFINE_C_API_STRUCT(MlirDynamicOpTrait, void);
+
+/// Attach a dynamic op trait to the given operation name.
+/// Note that the operation name must be modeled by dynamic dialect and must be
+/// registered.
+MLIR_CAPI_EXPORTED bool
+mlirDynamicOpTraitAttach(MlirDynamicOpTrait dynamicOpTrait,
+                         MlirStringRef opName, MlirContext context);
+
+/// Get the dynamic op trait that indicates the operation is a terminator.
+MLIR_CAPI_EXPORTED MlirDynamicOpTrait mlirDynamicOpTraitGetIsTerminator(void);
+
+/// Get the dynamic op trait that indicates regions have no terminator.
+MLIR_CAPI_EXPORTED MlirDynamicOpTrait mlirDynamicOpTraitGetNoTerminator(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MLIR_C_EXTENSIBLEDIALECT_H

--- a/mlir/include/mlir-c/ExtensibleDialect.h
+++ b/mlir/include/mlir-c/ExtensibleDialect.h
@@ -52,6 +52,23 @@ MLIR_CAPI_EXPORTED MlirDynamicOpTrait mlirDynamicOpTraitGetNoTerminator(void);
 MLIR_CAPI_EXPORTED void
 mlirDynamicOpTraitDestroy(MlirDynamicOpTrait dynamicOpTrait);
 
+typedef struct {
+  /// Optional constructor for the user data.
+  /// Set to nullptr to disable it.
+  void (*construct)(void *userData);
+  /// Optional destructor for the user data.
+  /// Set to nullptr to disable it.
+  void (*destruct)(void *userData);
+  /// The callback function to verify the operation.
+  MlirLogicalResult (*verifyTrait)(MlirOperation op, void *userData);
+  /// The callback function to verify the operation with access to regions.
+  MlirLogicalResult (*verifyRegionTrait)(MlirOperation op, void *userData);
+} MlirDynamicOpTraitCallbacks;
+
+/// Create a custom dynamic op trait with the given type ID and callbacks.
+MLIR_CAPI_EXPORTED MlirDynamicOpTrait mlirDynamicOpTraitCreate(
+    MlirTypeID typeID, MlirDynamicOpTraitCallbacks callbacks, void *userData);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mlir/include/mlir-c/ExtensibleDialect.h
+++ b/mlir/include/mlir-c/ExtensibleDialect.h
@@ -1,5 +1,4 @@
-//===-- mlir-c/ExtensibleDialect.h - Extensible dialect management ---*- C
-//-*-====//
+//===-- mlir-c/ExtensibleDialect.h - Extensible dialect APIs -----*- C -*-====//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM
 // Exceptions.
@@ -8,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This header provides basic access to the MLIR JIT. This is minimalist and
-// experimental at the moment.
+// This header provides APIs for extensible dialects.
 //
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir-c/ExtensibleDialect.h
+++ b/mlir/include/mlir-c/ExtensibleDialect.h
@@ -38,6 +38,8 @@ DEFINE_C_API_STRUCT(MlirDynamicOpTrait, void);
 /// Attach a dynamic op trait to the given operation name.
 /// Note that the operation name must be modeled by dynamic dialect and must be
 /// registered.
+/// The ownership of the trait will be transferred to the operation name
+/// after this call.
 MLIR_CAPI_EXPORTED bool
 mlirDynamicOpTraitAttach(MlirDynamicOpTrait dynamicOpTrait,
                          MlirStringRef opName, MlirContext context);
@@ -47,6 +49,10 @@ MLIR_CAPI_EXPORTED MlirDynamicOpTrait mlirDynamicOpTraitGetIsTerminator(void);
 
 /// Get the dynamic op trait that indicates regions have no terminator.
 MLIR_CAPI_EXPORTED MlirDynamicOpTrait mlirDynamicOpTraitGetNoTerminator(void);
+
+/// Destroy the dynamic op trait.
+MLIR_CAPI_EXPORTED void
+mlirDynamicOpTraitDestroy(MlirDynamicOpTrait dynamicOpTrait);
 
 #ifdef __cplusplus
 }

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -1848,11 +1848,22 @@ private:
 class MLIR_PYTHON_API_EXPORTED PyDynamicOpTrait {
 public:
   PyDynamicOpTrait(MlirDynamicOpTrait trait) : trait(trait) {}
+  ~PyDynamicOpTrait() { mlirDynamicOpTraitDestroy(trait); }
 
   bool attach(std::string opName, DefaultingPyMlirContext context) {
+    assert(this->trait.ptr && "Trait has already been attached");
+
+    MlirDynamicOpTrait trait = this->trait;
+    this->trait = MlirDynamicOpTrait{nullptr};
     return mlirDynamicOpTraitAttach(trait,
                                     MlirStringRef{opName.data(), opName.size()},
                                     context.get()->get());
+  }
+
+  bool attachToOpView(const nanobind::type_object &opView,
+                      DefaultingPyMlirContext context) {
+    return attach(nanobind::cast<std::string>(opView.attr("OPERATION_NAME")),
+                  context);
   }
 
   static void bind(nanobind::module_ &m);

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -1874,7 +1874,7 @@ private:
 
 namespace PyDynamicOpTraits {
 
-class IsTerminator : public PyDynamicOpTrait {
+class MLIR_PYTHON_API_EXPORTED IsTerminator : public PyDynamicOpTrait {
 public:
   IsTerminator() : PyDynamicOpTrait(mlirDynamicOpTraitGetIsTerminator()) {}
   static void bind(nanobind::module_ &m) {
@@ -1883,7 +1883,7 @@ public:
   }
 };
 
-class NoTerminator : public PyDynamicOpTrait {
+class MLIR_PYTHON_API_EXPORTED NoTerminator : public PyDynamicOpTrait {
 public:
   NoTerminator() : PyDynamicOpTrait(mlirDynamicOpTraitGetNoTerminator()) {}
   static void bind(nanobind::module_ &m) {

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -23,6 +23,7 @@
 #include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/Debug.h"
 #include "mlir-c/Diagnostics.h"
+#include "mlir-c/ExtensibleDialect.h"
 #include "mlir-c/IR.h"
 #include "mlir-c/IntegerSet.h"
 #include "mlir-c/Support.h"
@@ -1843,6 +1844,44 @@ private:
   nanobind::list operands;
   PyOpAttributeMap attributes;
 };
+
+class MLIR_PYTHON_API_EXPORTED PyDynamicOpTrait {
+public:
+  PyDynamicOpTrait(MlirDynamicOpTrait trait) : trait(trait) {}
+
+  bool attach(std::string opName, DefaultingPyMlirContext context) {
+    return mlirDynamicOpTraitAttach(trait,
+                                    MlirStringRef{opName.data(), opName.size()},
+                                    context.get()->get());
+  }
+
+  static void bind(nanobind::module_ &m);
+
+private:
+  MlirDynamicOpTrait trait;
+};
+
+namespace PyDynamicOpTraits {
+
+class IsTerminator : public PyDynamicOpTrait {
+public:
+  IsTerminator() : PyDynamicOpTrait(mlirDynamicOpTraitGetIsTerminator()) {}
+  static void bind(nanobind::module_ &m) {
+    nanobind::class_<IsTerminator, PyDynamicOpTrait>(m, "IsTerminatorTrait")
+        .def(nanobind::init<>());
+  }
+};
+
+class NoTerminator : public PyDynamicOpTrait {
+public:
+  NoTerminator() : PyDynamicOpTrait(mlirDynamicOpTraitGetNoTerminator()) {}
+  static void bind(nanobind::module_ &m) {
+    nanobind::class_<NoTerminator, PyDynamicOpTrait>(m, "NoTerminatorTrait")
+        .def(nanobind::init<>());
+  }
+};
+
+} // namespace PyDynamicOpTraits
 
 MLIR_PYTHON_API_EXPORTED MlirValue getUniqueResult(MlirOperation operation);
 MLIR_PYTHON_API_EXPORTED void populateIRCore(nanobind::module_ &m);

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -1847,49 +1847,24 @@ private:
 
 class MLIR_PYTHON_API_EXPORTED PyDynamicOpTrait {
 public:
-  PyDynamicOpTrait(MlirDynamicOpTrait trait) : trait(trait) {}
-  ~PyDynamicOpTrait() { mlirDynamicOpTraitDestroy(trait); }
-
-  bool attach(std::string opName, DefaultingPyMlirContext context) {
-    assert(this->trait.ptr && "Trait has already been attached");
-
-    MlirDynamicOpTrait trait = this->trait;
-    this->trait = MlirDynamicOpTrait{nullptr};
-    return mlirDynamicOpTraitAttach(trait,
-                                    MlirStringRef{opName.data(), opName.size()},
-                                    context.get()->get());
-  }
-
-  bool attachToOpView(const nanobind::type_object &opView,
-                      DefaultingPyMlirContext context) {
-    return attach(nanobind::cast<std::string>(opView.attr("OPERATION_NAME")),
-                  context);
-  }
+  static bool attach(const nanobind::object &opName,
+                     const nanobind::object &target, PyMlirContext &context);
 
   static void bind(nanobind::module_ &m);
-
-private:
-  MlirDynamicOpTrait trait;
 };
 
 namespace PyDynamicOpTraits {
 
 class MLIR_PYTHON_API_EXPORTED IsTerminator : public PyDynamicOpTrait {
 public:
-  IsTerminator() : PyDynamicOpTrait(mlirDynamicOpTraitGetIsTerminator()) {}
-  static void bind(nanobind::module_ &m) {
-    nanobind::class_<IsTerminator, PyDynamicOpTrait>(m, "IsTerminatorTrait")
-        .def(nanobind::init<>());
-  }
+  static bool attach(const nanobind::object &opName, PyMlirContext &context);
+  static void bind(nanobind::module_ &m);
 };
 
 class MLIR_PYTHON_API_EXPORTED NoTerminator : public PyDynamicOpTrait {
 public:
-  NoTerminator() : PyDynamicOpTrait(mlirDynamicOpTraitGetNoTerminator()) {}
-  static void bind(nanobind::module_ &m) {
-    nanobind::class_<NoTerminator, PyDynamicOpTrait>(m, "NoTerminatorTrait")
-        .def(nanobind::init<>());
-  }
+  static bool attach(const nanobind::object &opName, PyMlirContext &context);
+  static void bind(nanobind::module_ &m);
 };
 
 } // namespace PyDynamicOpTraits

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2521,6 +2521,22 @@ void PyOpAdaptor::bind(nb::module_ &m) {
           "Returns the attributes of the adaptor.");
 }
 
+void PyDynamicOpTrait::bind(nb::module_ &m) {
+  nb::class_<PyDynamicOpTrait>(m, "DynamicOpTrait")
+      .def("attach", &PyDynamicOpTrait::attach,
+           "Attach the dynamic op trait to the given operation name.",
+           nb::arg("op_name"), nb::arg("context").none() = nb::none())
+      .def(
+          "attach",
+          [](PyDynamicOpTrait &self, const nb::type_object &opView,
+             DefaultingPyMlirContext context) {
+            return self.attach(
+                nb::cast<std::string>(opView.attr("OPERATION_NAME")), context);
+          },
+          "Attach the dynamic op trait to the given OpView class.",
+          nb::arg("op_view"), nb::arg("context").none() = nb::none());
+}
+
 } // namespace MLIR_BINDINGS_PYTHON_DOMAIN
 } // namespace python
 } // namespace mlir
@@ -4844,6 +4860,11 @@ void populateIRCore(nb::module_ &m) {
 
   // Attribute builder getter.
   PyAttrBuilderMap::bind(m);
+
+  // Extensible Dialect
+  PyDynamicOpTrait::bind(m);
+  PyDynamicOpTraits::IsTerminator::bind(m);
+  PyDynamicOpTraits::NoTerminator::bind(m);
 }
 } // namespace MLIR_BINDINGS_PYTHON_DOMAIN
 } // namespace python

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2526,15 +2526,9 @@ void PyDynamicOpTrait::bind(nb::module_ &m) {
       .def("attach", &PyDynamicOpTrait::attach,
            "Attach the dynamic op trait to the given operation name.",
            nb::arg("op_name"), nb::arg("context").none() = nb::none())
-      .def(
-          "attach",
-          [](PyDynamicOpTrait &self, const nb::type_object &opView,
-             DefaultingPyMlirContext context) {
-            return self.attach(
-                nb::cast<std::string>(opView.attr("OPERATION_NAME")), context);
-          },
-          "Attach the dynamic op trait to the given OpView class.",
-          nb::arg("op_view"), nb::arg("context").none() = nb::none());
+      .def("attach", &PyDynamicOpTrait::attachToOpView,
+           "Attach the dynamic op trait to the given OpView class.",
+           nb::arg("op_view"), nb::arg("context").none() = nb::none());
 }
 
 } // namespace MLIR_BINDINGS_PYTHON_DOMAIN

--- a/mlir/lib/CAPI/IR/CMakeLists.txt
+++ b/mlir/lib/CAPI/IR/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_upstream_c_api_library(MLIRCAPIIR
   BuiltinTypes.cpp
   Diagnostics.cpp
   DialectHandle.cpp
+  ExtensibleDialect.cpp
   IntegerSet.cpp
   IR.cpp
   Pass.cpp

--- a/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
+++ b/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
@@ -31,11 +31,10 @@ bool mlirDynamicOpTraitAttach(MlirDynamicOpTrait dynamicOpTrait,
   OperationName::Impl *impl =
       static_cast<RegisteredOperationNameWithImpl &>(*opNameFound).getImpl();
 
-  DynamicOpTrait *trait = unwrap(dynamicOpTrait);
+  std::unique_ptr<DynamicOpTrait> trait(unwrap(dynamicOpTrait));
   // TODO: we should check whether the `impl` is a DynamicOpDefinition here
   // via llvm-style RTTI.
-  return static_cast<DynamicOpDefinition *>(impl)->addTrait(
-      std::unique_ptr<DynamicOpTrait>(trait));
+  return static_cast<DynamicOpDefinition *>(impl)->addTrait(std::move(trait));
 }
 
 MlirDynamicOpTrait mlirDynamicOpTraitGetIsTerminator() {
@@ -44,4 +43,8 @@ MlirDynamicOpTrait mlirDynamicOpTraitGetIsTerminator() {
 
 MlirDynamicOpTrait mlirDynamicOpTraitGetNoTerminator() {
   return wrap(new DynamicOpTraits::NoTerminator());
+}
+
+void mlirDynamicOpTraitDestroy(MlirDynamicOpTrait dynamicOpTrait) {
+  delete unwrap(dynamicOpTrait);
 }

--- a/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
+++ b/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
@@ -1,5 +1,4 @@
-//===- ExtensibleDialect - C API for MLIR Extensible Dialect
-//-----------------===//
+//===- ExtensibleDialect - C API for MLIR Extensible Dialect --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/mlir/test/python/dialects/ext.py
+++ b/mlir/test/python/dialects/ext.py
@@ -390,9 +390,10 @@ def testExtDialectWithRegion():
             @staticmethod
             def verify(op) -> bool:
                 if not isinstance(op.parent.opview, IfOp):
-                    raise RuntimeError(
+                    op.location.emit_error(
                         f"{op.name} should be put inside {IfOp.OPERATION_NAME}"
                     )
+                    return False
                 return True
 
         ParentIsIfTrait.attach(YieldOp)
@@ -485,5 +486,6 @@ def testExtDialectWithRegion():
         try:
             module.operation.verify()
         except Exception as e:
+            # CHECK: Verification failed:
             # CHECK: ext_region.yield should be put inside ext_region.if
             print(e)

--- a/mlir/test/python/dialects/ext.py
+++ b/mlir/test/python/dialects/ext.py
@@ -353,7 +353,7 @@ def testExtDialectWithRegion():
         result: Result[Any]
         then: Region
         else_: Region
-    
+
     class YieldOp(TestRegion.Operation, name="yield"):
         value: Operand[Any]
 
@@ -411,7 +411,7 @@ def testExtDialectWithRegion():
             with InsertionPoint(if_.else_.blocks[0]):
                 v = arith.constant(i32, 3)
                 YieldOp(v)
-            
+
             nt = NoTermOp()
             nt.body.blocks.append()
 

--- a/mlir/test/python/dialects/ext.py
+++ b/mlir/test/python/dialects/ext.py
@@ -350,22 +350,43 @@ def testExtDialectWithRegion():
 
     class IfOp(TestRegion.Operation, name="if"):
         cond: Operand[IntegerType[1]]
+        result: Result[Any]
         then: Region
         else_: Region
+    
+    class YieldOp(TestRegion.Operation, name="yield"):
+        value: Operand[Any]
+
+    class NoTermOp(TestRegion.Operation, name="no_term"):
+        body: Region
 
     with Context(), Location.unknown():
         TestRegion.load()
         # CHECK: irdl.dialect @ext_region {
-        # CHECK:     irdl.operation @if {
+        # CHECK:   irdl.operation @if {
         # CHECK:     %0 = irdl.is i1
         # CHECK:     irdl.operands(cond: %0)
-        # CHECK:     %1 = irdl.region
+        # CHECK:     %1 = irdl.any
+        # CHECK:     irdl.results(result: %1)
         # CHECK:     %2 = irdl.region
-        # CHECK:     irdl.regions(then: %1, else_: %2)
+        # CHECK:     %3 = irdl.region
+        # CHECK:     irdl.regions(then: %2, else_: %3)
+        # CHECK:   }
+        # CHECK:   irdl.operation @yield {
+        # CHECK:     %0 = irdl.any
+        # CHECK:     irdl.operands(value: %0)
+        # CHECK:   }
+        # CHECK:   irdl.operation @no_term {
+        # CHECK:     %0 = irdl.region
+        # CHECK:     irdl.regions(body: %0)
+        # CHECK:   }
         # CHECK: }
         print(TestRegion._mlir_module)
 
-        # CHECK: (self, /, cond, *, loc=None, ip=None)
+        IsTerminatorTrait().attach(YieldOp)
+        NoTerminatorTrait().attach(NoTermOp)
+
+        # CHECK: (self, /, result, cond, *, loc=None, ip=None)
         print(IfOp.__init__.__signature__)
 
         # CHECK: None None
@@ -373,36 +394,44 @@ def testExtDialectWithRegion():
         # CHECK: (2, True)
         print(IfOp._ODS_REGIONS)
 
-        from mlir.dialects import llvm
-
         module = Module.create()
         with InsertionPoint(module.body):
             i1 = IntegerType.get_signless(1)
             i32 = IntegerType.get_signless(32)
             cond = arith.constant(i1, 1)
 
-            if_ = IfOp(cond)
+            if_ = IfOp(i32, cond)
             if_.then.blocks.append()
             if_.else_.blocks.append()
 
             with InsertionPoint(if_.then.blocks[0]):
                 v = arith.constant(i32, 2)
-                llvm.unreachable()
+                YieldOp(v)
 
             with InsertionPoint(if_.else_.blocks[0]):
                 v = arith.constant(i32, 3)
-                llvm.unreachable()
+                YieldOp(v)
+            
+            nt = NoTermOp()
+            nt.body.blocks.append()
+
+            with InsertionPoint(nt.body.blocks[0]):
+                arith.constant(i32, 4)
+                # No terminator here
 
         assert module.operation.verify()
         # CHECK: module {
         # CHECK:     %true = arith.constant true
-        # CHECK:     "ext_region.if"(%true) ({
+        # CHECK:     %0 = "ext_region.if"(%true) ({
         # CHECK:         %c2_i32 = arith.constant 2 : i32
-        # CHECK:         llvm.unreachable
+        # CHECK:         "ext_region.yield"(%c2_i32) : (i32) -> ()
         # CHECK:     }, {
         # CHECK:         %c3_i32 = arith.constant 3 : i32
-        # CHECK:         llvm.unreachable
-        # CHECK:     }) : (i1) -> ()
+        # CHECK:         "ext_region.yield"(%c3_i32) : (i32) -> ()
+        # CHECK:     }) : (i1) -> i32
+        # CHECK:     "ext_region.no_term"() ({
+        # CHECK:       %c4_i32 = arith.constant 4 : i32
+        # CHECK:     }) : () -> ()
         # CHECK: }
         print(module)
 

--- a/mlir/test/python/dialects/ext.py
+++ b/mlir/test/python/dialects/ext.py
@@ -439,3 +439,29 @@ def testExtDialectWithRegion():
         print(if_.then.blocks[0])
         # CHECK: %c3_i32 = arith.constant 3 : i32
         print(if_.else_.blocks[0])
+
+        # CHECK-LABEL: Testing violation cases
+        print("Testing violation cases:")
+
+        module = Module.create()
+        with InsertionPoint(module.body):
+            i1 = IntegerType.get_signless(1)
+            i32 = IntegerType.get_signless(32)
+            cond = arith.constant(i1, 1)
+
+            if_ = IfOp(i32, cond)
+            if_.then.blocks.append()
+            if_.else_.blocks.append()
+
+            with InsertionPoint(if_.then.blocks[0]):
+                v = arith.constant(i32, 2)
+
+            with InsertionPoint(if_.else_.blocks[0]):
+                v = arith.constant(i32, 3)
+
+        try:
+            module.operation.verify()
+        except Exception as e:
+            # CHECK: Verification failed:
+            # CHECK: block with no terminator
+            print(e)


### PR DESCRIPTION
This is a follow-up PR of #169045 and the second part of #179086.

In #179086, we added support for defining regions in Python-defined ops, but its usefulness was quite limited because we still couldn’t mark an op as a `Terminator` or `NoTerminator`. In this PR, we port the `DynamicOpTrait` (introduced on the C++ side for `DynamicDialect` in #177735) to Python, so we can dynamically attach traits to Python-defined ops.
