### PR TITLE
[flang] Add warning and documentation for extension

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -481,6 +481,8 @@ end
 * A data object can be initialized multiple times by `DATA` statements
   and default component initialization, but only when all initializations
   are to the same value.  Distinct initializations remain errors.
+* A pointer component that has no default initialization or explicit value
+  in a structure constructor is defaulted to `NULL()`.
 
 ### Extensions supported when enabled by options
 

--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -56,7 +56,8 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     IgnoreIrrelevantAttributes, Unsigned, ContiguousOkForSeqAssociation,
     ForwardRefExplicitTypeDummy, InaccessibleDeferredOverride,
     CudaWarpMatchFunction, DoConcurrentOffload, TransferBOZ, Coarray,
-    PointerPassObject, MultipleIdenticalDATA)
+    PointerPassObject, MultipleIdenticalDATA,
+    DefaultStructConstructorNullPointer)
 
 // Portability and suspicious usage warnings
 ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2431,6 +2431,14 @@ MaybeExpr ExpressionAnalyzer::CheckStructureConstructor(
         result.Add(symbol, Expr<SomeType>{ProcedureDesignator{**proc->init()}});
       } else if (IsAllocatableOrPointer(symbol)) {
         result.Add(symbol, Expr<SomeType>{NullPointer{}});
+        if (IsPointer(symbol)) {
+          AttachDeclaration(
+              Warn(common::LanguageFeature::DefaultStructConstructorNullPointer,
+                  typeName,
+                  "Structure constructor lacks a value for pointer component '%s', NULL() assumed"_warn_en_US,
+                  symbol.name()),
+              symbol);
+        }
       } else {
         AttachDeclaration(
             Say(typeName,

--- a/flang/test/Semantics/bug179580.f90
+++ b/flang/test/Semantics/bug179580.f90
@@ -1,0 +1,9 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic -Werror
+type t
+  real v
+  integer, pointer :: p
+end type
+type(t), allocatable :: a
+!WARNING: Structure constructor lacks a value for pointer component 'p', NULL() assumed [-Wdefault-struct-constructor-null-pointer]
+allocate(a, source=t(v=3.3))
+end


### PR DESCRIPTION
When a pointer component has no default initialization in the derived type definition and does not appear explicitly as a component in a structure constructor, we assume that it is meant to be NULL() as an extension.  But there's no warning or documentation for this extension; add them.

Fixes https://github.com/llvm/llvm-project/issues/179580.