### PR TITLE
[ExpandIRInsts] Support saturating fptoi

### DIFF
--- a/llvm/lib/CodeGen/ExpandIRInsts.cpp
+++ b/llvm/lib/CodeGen/ExpandIRInsts.cpp
@@ -40,6 +40,7 @@
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/InitializePasses.h"
@@ -495,7 +496,7 @@ static bool expandFRem(BinaryOperator &I, std::optional<SimplifyQuery> &SQ) {
 /// }
 ///
 /// Replace fp to integer with generated code.
-static void expandFPToI(Instruction *FPToI) {
+static void expandFPToI(Instruction *FPToI, bool IsSaturating, bool IsSigned) {
   // clang-format on
   IRBuilder<> Builder(FPToI);
   auto *FloatVal = FPToI->getOperand(0);
@@ -537,12 +538,15 @@ static void expandFPToI(Instruction *FPToI) {
   BasicBlock *Entry = Builder.GetInsertBlock();
   Function *F = Entry->getParent();
   Entry->setName(Twine(Entry->getName(), "fp-to-i-entry"));
+  BasicBlock *CheckSaturateBB, *SaturateBB;
   BasicBlock *End =
       Entry->splitBasicBlock(Builder.GetInsertPoint(), "fp-to-i-cleanup");
-  BasicBlock *CheckSaturateBB = BasicBlock::Create(
-      Builder.getContext(), "fp-to-i-if-check.saturate", F, End);
-  BasicBlock *SaturateBB =
-      BasicBlock::Create(Builder.getContext(), "fp-to-i-if-saturate", F, End);
+  if (IsSaturating) {
+    CheckSaturateBB = BasicBlock::Create(Builder.getContext(),
+                                         "fp-to-i-if-check.saturate", F, End);
+    SaturateBB =
+        BasicBlock::Create(Builder.getContext(), "fp-to-i-if-saturate", F, End);
+  }
   BasicBlock *CheckExpSizeBB = BasicBlock::Create(
       Builder.getContext(), "fp-to-i-if-check.exp.size", F, End);
   BasicBlock *ExpSmallBB =
@@ -563,40 +567,56 @@ static void expandFPToI(Instruction *FPToI) {
     FloatVal =
         Builder.CreateFPExt(FloatVal, Type::getFP128Ty(Builder.getContext()));
   Value *ARep = Builder.CreateBitCast(FloatVal, FloatIntTy);
-  Value *PosOrNeg =
-      Builder.CreateICmpSGT(ARep, ConstantInt::getSigned(FloatIntTy, -1));
-  Value *Sign = Builder.CreateSelect(PosOrNeg, ConstantInt::getSigned(IntTy, 1),
-                                     ConstantInt::getSigned(IntTy, -1), "sign");
+  Value *PosOrNeg, *Sign;
+  if (IsSigned) {
+    PosOrNeg =
+        Builder.CreateICmpSGT(ARep, ConstantInt::getSigned(FloatIntTy, -1));
+    Sign = Builder.CreateSelect(PosOrNeg, ConstantInt::getSigned(IntTy, 1),
+                                ConstantInt::getSigned(IntTy, -1), "sign");
+  }
   Value *And =
       Builder.CreateLShr(ARep, Builder.getIntN(FloatWidth, FPMantissaWidth));
   Value *BiasedExp = Builder.CreateAnd(
       And, Builder.getIntN(FloatWidth, (1 << ExponentWidth) - 1), "biased.exp");
   Value *Abs = Builder.CreateAnd(ARep, SignificandMask);
   Value *Significand = Builder.CreateOr(Abs, ImplicitBit, "significand");
-  Value *ExpIsNegative = Builder.CreateICmpULT(
+  Value *ZeroResultCond = Builder.CreateICmpULT(
       BiasedExp, Builder.getIntN(FloatWidth, ExponentBias), "exp.is.negative");
-  Builder.CreateCondBr(ExpIsNegative, End, CheckSaturateBB);
+  if (IsSaturating) {
+    Value *IsNaN = Builder.CreateFCmpUNO(FloatVal, FloatVal, "is.nan");
+    ZeroResultCond = Builder.CreateOr(ZeroResultCond, IsNaN);
+    if (!IsSigned) {
+      Value *IsNeg = Builder.CreateIsNeg(ARep);
+      ZeroResultCond = Builder.CreateOr(ZeroResultCond, IsNeg);
+    }
+  }
+  Builder.CreateCondBr(ZeroResultCond, End,
+                       IsSaturating ? CheckSaturateBB : CheckExpSizeBB);
 
-  // check.saturate:
-  Builder.SetInsertPoint(CheckSaturateBB);
-  Value *Add1 = Builder.CreateAdd(
-      BiasedExp,
-      ConstantInt::getSigned(FloatIntTy,
-                             -static_cast<int64_t>(ExponentBias + BitWidth)));
-  Value *Cmp3 = Builder.CreateICmpULT(
-      Add1,
-      ConstantInt::getSigned(FloatIntTy, -static_cast<int64_t>(BitWidth)));
-  Builder.CreateCondBr(Cmp3, SaturateBB, CheckExpSizeBB);
+  Value *Saturated;
+  if (IsSaturating) {
+    // check.saturate:
+    Builder.SetInsertPoint(CheckSaturateBB);
+    Value *Cmp3 = Builder.CreateICmpUGE(
+        BiasedExp, ConstantInt::getSigned(
+                       FloatIntTy, static_cast<int64_t>(ExponentBias +
+                                                        BitWidth - IsSigned)));
+    Builder.CreateCondBr(Cmp3, SaturateBB, CheckExpSizeBB);
 
-  // saturate:
-  Builder.SetInsertPoint(SaturateBB);
-  Value *SignedMax =
-      ConstantInt::get(IntTy, APInt::getSignedMaxValue(BitWidth));
-  Value *SignedMin =
-      ConstantInt::get(IntTy, APInt::getSignedMinValue(BitWidth));
-  Value *Saturated =
-      Builder.CreateSelect(PosOrNeg, SignedMax, SignedMin, "saturated");
-  Builder.CreateBr(End);
+    // saturate:
+    Builder.SetInsertPoint(SaturateBB);
+    if (IsSigned) {
+      Value *SignedMax =
+          ConstantInt::get(IntTy, APInt::getSignedMaxValue(BitWidth));
+      Value *SignedMin =
+          ConstantInt::get(IntTy, APInt::getSignedMinValue(BitWidth));
+      Saturated =
+          Builder.CreateSelect(PosOrNeg, SignedMax, SignedMin, "saturated");
+    } else {
+      Saturated = ConstantInt::getAllOnesValue(IntTy);
+    }
+    Builder.CreateBr(End);
+  }
 
   // if.end9:
   Builder.SetInsertPoint(CheckExpSizeBB);
@@ -609,9 +629,10 @@ static void expandFPToI(Instruction *FPToI) {
   Builder.SetInsertPoint(ExpSmallBB);
   Value *Sub13 = Builder.CreateSub(
       Builder.getIntN(FloatWidth, ExponentBias + FPMantissaWidth), BiasedExp);
-  Value *Shr14 =
+  Value *ExpSmallRes =
       Builder.CreateZExtOrTrunc(Builder.CreateLShr(Significand, Sub13), IntTy);
-  Value *Mul = Builder.CreateMul(Shr14, Sign);
+  if (IsSigned)
+    ExpSmallRes = Builder.CreateMul(ExpSmallRes, Sign);
   Builder.CreateBr(End);
 
   // exp.large:
@@ -621,18 +642,20 @@ static void expandFPToI(Instruction *FPToI) {
       ConstantInt::getSigned(
           FloatIntTy, -static_cast<int64_t>(ExponentBias + FPMantissaWidth)));
   Value *SignificandCast = Builder.CreateZExtOrTrunc(Significand, IntTy);
-  Value *Shl = Builder.CreateShl(SignificandCast,
-                                 Builder.CreateZExtOrTrunc(Sub15, IntTy));
-  Value *Mul16 = Builder.CreateMul(Shl, Sign);
+  Value *ExpLargeRes = Builder.CreateShl(
+      SignificandCast, Builder.CreateZExtOrTrunc(Sub15, IntTy));
+  if (IsSigned)
+    ExpLargeRes = Builder.CreateMul(ExpLargeRes, Sign);
   Builder.CreateBr(End);
 
   // cleanup:
   Builder.SetInsertPoint(End, End->begin());
-  PHINode *Retval0 = Builder.CreatePHI(FPToI->getType(), 4);
+  PHINode *Retval0 = Builder.CreatePHI(FPToI->getType(), 3 + IsSaturating);
 
-  Retval0->addIncoming(Saturated, SaturateBB);
-  Retval0->addIncoming(Mul, ExpSmallBB);
-  Retval0->addIncoming(Mul16, ExpLargeBB);
+  if (IsSaturating)
+    Retval0->addIncoming(Saturated, SaturateBB);
+  Retval0->addIncoming(ExpSmallRes, ExpSmallBB);
+  Retval0->addIncoming(ExpLargeRes, ExpLargeBB);
   Retval0->addIncoming(Builder.getIntN(BitWidth, 0), Entry);
 
   FPToI->replaceAllUsesWith(Retval0);
@@ -1080,6 +1103,16 @@ static bool runImpl(Function &F, const TargetLowering &TLI,
              // The backend has peephole optimizations for powers of two.
              // TODO: We don't consider vectors here.
              && !isConstantPowerOfTwo(I.getOperand(1), isSigned(I.getOpcode()));
+    case Instruction::Call: {
+      auto *II = dyn_cast<IntrinsicInst>(&I);
+      if (II && (II->getIntrinsicID() == Intrinsic::fptoui_sat ||
+                 II->getIntrinsicID() == Intrinsic::fptosi_sat)) {
+        return !DisableExpandLargeFp &&
+               cast<IntegerType>(Ty->getScalarType())->getIntegerBitWidth() >
+                   MaxLegalFpConvertBitWidth;
+      }
+      return false;
+    }
     }
 
     return false;
@@ -1115,8 +1148,10 @@ static bool runImpl(Function &F, const TargetLowering &TLI,
     }
 
     case Instruction::FPToUI:
+      expandFPToI(I, /*IsSaturating=*/false, /*IsSigned=*/false);
+      break;
     case Instruction::FPToSI:
-      expandFPToI(I);
+      expandFPToI(I, /*IsSaturating=*/false, /*IsSigned=*/true);
       break;
 
     case Instruction::UIToFP:
@@ -1132,6 +1167,15 @@ static bool runImpl(Function &F, const TargetLowering &TLI,
     case Instruction::SRem:
       expandRemainder(cast<BinaryOperator>(I));
       break;
+
+    case Instruction::Call: {
+      auto *II = cast<IntrinsicInst>(I);
+      assert(II->getIntrinsicID() == Intrinsic::fptoui_sat ||
+             II->getIntrinsicID() == Intrinsic::fptosi_sat);
+      expandFPToI(I, /*IsSaturating=*/true,
+                  /*IsSigned=*/II->getIntrinsicID() == Intrinsic::fptosi_sat);
+      break;
+    }
     }
   }
 

--- a/llvm/test/CodeGen/AMDGPU/fptoi.i128.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoi.i128.ll
@@ -16,105 +16,79 @@ define i128 @fptosi_f64_to_i128(double %x) {
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v1, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v3, 0
-; SDAG-NEXT:    s_and_saveexec_b64 s[8:9], vcc
-; SDAG-NEXT:    s_cbranch_execz .LBB0_10
-; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; SDAG-NEXT:    v_add_co_u32_e32 v0, vcc, 0xfffffb81, v6
-; SDAG-NEXT:    v_addc_co_u32_e64 v1, s[6:7], 0, -1, vcc
-; SDAG-NEXT:    s_movk_i32 s6, 0xff7f
-; SDAG-NEXT:    s_mov_b32 s7, -1
-; SDAG-NEXT:    v_cmp_lt_i64_e64 s[4:5], -1, v[4:5]
-; SDAG-NEXT:    v_cmp_lt_u64_e32 vcc, s[6:7], v[0:1]
-; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
-; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
 ; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], vcc
-; SDAG-NEXT:    s_xor_b64 s[10:11], exec, s[6:7]
-; SDAG-NEXT:    s_cbranch_execz .LBB0_7
-; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
-; SDAG-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
-; SDAG-NEXT:    v_add_co_u32_e32 v9, vcc, -1, v0
-; SDAG-NEXT:    s_mov_b64 s[6:7], 0x432
+; SDAG-NEXT:    s_cbranch_execz .LBB0_6
+; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
+; SDAG-NEXT:    s_mov_b64 s[4:5], 0x432
+; SDAG-NEXT:    v_ashrrev_i32_e32 v8, 31, v5
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0xfffff, v5
-; SDAG-NEXT:    v_cmp_lt_u64_e32 vcc, s[6:7], v[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v8, -1, 0, s[4:5]
-; SDAG-NEXT:    v_cndmask_b32_e64 v10, -1, 1, s[4:5]
+; SDAG-NEXT:    v_cmp_lt_u64_e32 vcc, s[4:5], v[6:7]
+; SDAG-NEXT:    v_or_b32_e32 v9, 1, v8
 ; SDAG-NEXT:    v_or_b32_e32 v5, 0x100000, v0
 ; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
 ; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
-; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], vcc
-; SDAG-NEXT:    s_xor_b64 s[12:13], exec, s[6:7]
-; SDAG-NEXT:    s_cbranch_execz .LBB0_4
-; SDAG-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
+; SDAG-NEXT:    s_and_saveexec_b64 s[4:5], vcc
+; SDAG-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
+; SDAG-NEXT:    s_cbranch_execz .LBB0_3
+; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
 ; SDAG-NEXT:    v_sub_u32_e32 v0, 0x473, v6
 ; SDAG-NEXT:    v_add_u32_e32 v2, 0xfffffb8d, v6
 ; SDAG-NEXT:    v_add_u32_e32 v3, 0xfffffbcd, v6
 ; SDAG-NEXT:    v_lshrrev_b64 v[0:1], v0, v[4:5]
 ; SDAG-NEXT:    v_lshlrev_b64 v[6:7], v2, v[4:5]
 ; SDAG-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v3
-; SDAG-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v3
+; SDAG-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v3
 ; SDAG-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
 ; SDAG-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s[6:7]
+; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s[4:5]
 ; SDAG-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
 ; SDAG-NEXT:    v_cndmask_b32_e32 v7, 0, v3, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v5, 0, v0, s[6:7]
-; SDAG-NEXT:    v_mul_lo_u32 v12, v10, v1
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v7, v10, 0
+; SDAG-NEXT:    v_cndmask_b32_e64 v5, 0, v0, s[4:5]
+; SDAG-NEXT:    v_mul_lo_u32 v11, v9, v1
+; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v7, v9, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_cndmask_b32_e32 v13, 0, v4, vcc
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[6:7], v13, v10, v[1:2]
-; SDAG-NEXT:    v_mul_lo_u32 v11, v8, v5
-; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v10, v5, 0
+; SDAG-NEXT:    v_cndmask_b32_e32 v12, 0, v4, vcc
+; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v12, v9, v[1:2]
+; SDAG-NEXT:    v_mul_lo_u32 v10, v8, v5
+; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v9, v5, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v1, v3
-; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[6:7], v7, v8, v[1:2]
-; SDAG-NEXT:    v_add3_u32 v6, v6, v12, v11
-; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v9, v7, v[5:6]
+; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v7, v8, v[1:2]
+; SDAG-NEXT:    v_add3_u32 v6, v6, v11, v10
+; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v8, v7, v[5:6]
 ; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v4, v2
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[6:7], 0, 0, vcc
-; SDAG-NEXT:    v_mul_lo_u32 v10, v9, v13
-; SDAG-NEXT:    v_mul_lo_u32 v7, v9, v7
-; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v13, v8, v[2:3]
+; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, vcc
+; SDAG-NEXT:    v_mul_lo_u32 v9, v8, v12
+; SDAG-NEXT:    v_mul_lo_u32 v7, v8, v7
+; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v12, v8, v[2:3]
 ; SDAG-NEXT:    ; implicit-def: $vgpr8
-; SDAG-NEXT:    ; implicit-def: $vgpr9
-; SDAG-NEXT:    v_add3_u32 v4, v7, v6, v10
+; SDAG-NEXT:    v_add3_u32 v4, v7, v6, v9
 ; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v5
 ; SDAG-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v4, vcc
 ; SDAG-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; SDAG-NEXT:    ; implicit-def: $vgpr4_vgpr5
-; SDAG-NEXT:    ; implicit-def: $vgpr10
-; SDAG-NEXT:  .LBB0_4: ; %Flow
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[6:7], s[12:13]
-; SDAG-NEXT:    s_cbranch_execz .LBB0_6
-; SDAG-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
+; SDAG-NEXT:    ; implicit-def: $vgpr9
+; SDAG-NEXT:  .LBB0_3: ; %Flow
+; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[8:9]
+; SDAG-NEXT:    s_cbranch_execz .LBB0_5
+; SDAG-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
 ; SDAG-NEXT:    v_sub_u32_e32 v0, 0x433, v6
 ; SDAG-NEXT:    v_lshrrev_b64 v[4:5], v0, v[4:5]
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[12:13], v4, v10, 0
-; SDAG-NEXT:    v_mad_u64_u32 v[6:7], s[12:13], v5, v10, v[1:2]
+; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v4, v9, 0
+; SDAG-NEXT:    v_mad_u64_u32 v[6:7], s[8:9], v5, v9, v[1:2]
 ; SDAG-NEXT:    v_mov_b32_e32 v1, v6
-; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[12:13], v4, v8, v[1:2]
+; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v4, v8, v[1:2]
 ; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v7, v2
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[12:13], 0, 0, vcc
-; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[12:13], v5, v8, v[2:3]
-; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[12:13], v9, v4, v[2:3]
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[12:13], v9, v4, v[3:4]
-; SDAG-NEXT:    v_mad_i32_i24 v3, v9, v5, v3
-; SDAG-NEXT:  .LBB0_6: ; %Flow1
+; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[8:9], 0, 0, vcc
+; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v5, v8, v[2:3]
+; SDAG-NEXT:    v_mul_lo_u32 v5, v8, v5
+; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v8, v4, v[2:3]
+; SDAG-NEXT:    v_mul_lo_u32 v4, v8, v4
+; SDAG-NEXT:    v_add3_u32 v3, v4, v3, v5
+; SDAG-NEXT:  .LBB0_5: ; %Flow1
+; SDAG-NEXT:    s_or_b64 exec, exec, s[4:5]
+; SDAG-NEXT:  .LBB0_6: ; %fp-to-i-cleanup
 ; SDAG-NEXT:    s_or_b64 exec, exec, s[6:7]
-; SDAG-NEXT:  .LBB0_7: ; %Flow2
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[6:7], s[10:11]
-; SDAG-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; SDAG-NEXT:    v_bfrev_b32_e32 v0, 1
-; SDAG-NEXT:    v_bfrev_b32_e32 v1, -2
-; SDAG-NEXT:    v_cndmask_b32_e64 v2, v0, v1, s[4:5]
-; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
-; SDAG-NEXT:    v_mov_b32_e32 v3, v2
-; SDAG-NEXT:    v_mov_b32_e32 v0, v1
-; SDAG-NEXT:    v_mov_b32_e32 v2, v1
-; SDAG-NEXT:  ; %bb.9: ; %Flow3
-; SDAG-NEXT:    s_or_b64 exec, exec, s[6:7]
-; SDAG-NEXT:  .LBB0_10: ; %fp-to-i-cleanup
-; SDAG-NEXT:    s_or_b64 exec, exec, s[8:9]
 ; SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-LABEL: fptosi_f64_to_i128:
@@ -134,24 +108,14 @@ define i128 @fptosi_f64_to_i128(double %x) {
 ; GISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GISEL-NEXT:    v_mov_b32_e32 v3, s7
-; GISEL-NEXT:    s_and_saveexec_b64 s[12:13], vcc
-; GISEL-NEXT:    s_cbranch_execz .LBB0_10
-; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; GISEL-NEXT:    v_add_co_u32_e32 v0, vcc, 0xfffffb81, v6
-; GISEL-NEXT:    v_mov_b32_e32 v2, 0xffffff80
-; GISEL-NEXT:    v_mov_b32_e32 v3, -1
-; GISEL-NEXT:    v_addc_co_u32_e64 v1, s[6:7], 0, -1, vcc
-; GISEL-NEXT:    v_cmp_lt_i64_e64 s[4:5], -1, v[4:5]
-; GISEL-NEXT:    v_cmp_ge_u64_e32 vcc, v[0:1], v[2:3]
-; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
-; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
-; GISEL-NEXT:    s_xor_b64 s[14:15], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB0_7
-; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
-; GISEL-NEXT:    s_xor_b64 s[6:7], s[4:5], -1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[6:7]
+; GISEL-NEXT:    s_and_saveexec_b64 s[10:11], vcc
+; GISEL-NEXT:    s_cbranch_execz .LBB0_6
+; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
+; GISEL-NEXT:    v_cmp_ge_i64_e32 vcc, -1, v[4:5]
+; GISEL-NEXT:    s_mov_b32 s4, 0x100000
+; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
 ; GISEL-NEXT:    v_and_b32_e32 v0, 1, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[6:7]
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GISEL-NEXT:    v_lshlrev_b16_e32 v2, 1, v0
 ; GISEL-NEXT:    v_or_b32_e32 v1, v1, v2
 ; GISEL-NEXT:    v_lshlrev_b16_e32 v3, 2, v0
@@ -205,137 +169,62 @@ define i128 @fptosi_f64_to_i128(double %x) {
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0x433
 ; GISEL-NEXT:    v_mov_b32_e32 v1, 0
 ; GISEL-NEXT:    v_mov_b32_e32 v2, 0xfffff
-; GISEL-NEXT:    s_mov_b32 s6, 0x100000
 ; GISEL-NEXT:    v_cmp_ge_u64_e32 vcc, v[6:7], v[0:1]
-; GISEL-NEXT:    v_and_or_b32 v5, v5, v2, s6
+; GISEL-NEXT:    v_and_or_b32 v5, v5, v2, s4
 ; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
-; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
-; GISEL-NEXT:    s_xor_b64 s[16:17], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB0_4
-; GISEL-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
+; GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
+; GISEL-NEXT:    s_xor_b64 s[12:13], exec, s[4:5]
+; GISEL-NEXT:    s_cbranch_execz .LBB0_3
+; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
 ; GISEL-NEXT:    v_add_u32_e32 v2, 0xfffffbcd, v6
 ; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v2, v[4:5]
 ; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v2
 ; GISEL-NEXT:    v_cndmask_b32_e32 v10, 0, v0, vcc
 ; GISEL-NEXT:    v_cndmask_b32_e32 v11, 0, v1, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v10, v9, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v10, v9, 0
 ; GISEL-NEXT:    v_add_u32_e32 v3, 0xfffffb8d, v6
 ; GISEL-NEXT:    v_sub_u32_e32 v6, 64, v2
 ; GISEL-NEXT:    v_lshrrev_b64 v[6:7], v6, v[4:5]
 ; GISEL-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], 0, v2
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v2
 ; GISEL-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v11, v9, v[0:1]
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, v3, 0, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v10, v8, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v12, v8, v[5:6]
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v11, v9, v[0:1]
+; GISEL-NEXT:    v_cndmask_b32_e64 v12, v3, 0, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v10, v8, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v12, v8, v[5:6]
 ; GISEL-NEXT:    v_mul_lo_u32 v13, v11, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v10, v9, v[1:2]
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v10, v9, v[1:2]
 ; GISEL-NEXT:    v_mul_lo_u32 v10, v10, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[10:11], v11, v8, v[5:6]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[10:11], v3, v10, s[10:11]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v13, s[8:9]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v12, v9, v[3:4]
+; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v11, v8, v[5:6]
+; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v10, s[8:9]
+; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[6:7], v3, v13, s[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v12, v9, v[3:4]
 ; GISEL-NEXT:    v_cndmask_b32_e32 v3, v4, v7, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, v3, 0, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[6:7], v7, v8, v[5:6]
+; GISEL-NEXT:    v_cndmask_b32_e64 v7, v3, 0, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v7, v8, v[5:6]
 ; GISEL-NEXT:    ; implicit-def: $vgpr6
 ; GISEL-NEXT:    ; implicit-def: $vgpr4_vgpr5
 ; GISEL-NEXT:    ; implicit-def: $vgpr8
 ; GISEL-NEXT:    ; implicit-def: $vgpr9
-; GISEL-NEXT:  .LBB0_4: ; %Flow
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[8:9], s[16:17]
-; GISEL-NEXT:    s_cbranch_execz .LBB0_6
-; GISEL-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
+; GISEL-NEXT:  .LBB0_3: ; %Flow
+; GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[12:13]
+; GISEL-NEXT:    s_cbranch_execz .LBB0_5
+; GISEL-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
 ; GISEL-NEXT:    v_sub_co_u32_e32 v0, vcc, 0x433, v6
 ; GISEL-NEXT:    v_lshrrev_b64 v[4:5], v0, v[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[6:7], v4, v9, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v4, v8, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v5, v9, v[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[4:5], v4, v9, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v4, v8, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v5, v9, v[6:7]
 ; GISEL-NEXT:    v_mul_lo_u32 v10, v5, v9
 ; GISEL-NEXT:    v_mad_u64_u32 v[6:7], vcc, v4, v9, v[1:2]
 ; GISEL-NEXT:    v_mul_lo_u32 v4, v4, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[6:7], v5, v8, v[6:7]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[6:7], v3, v4, s[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v5, v8, v[6:7]
+; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v3, v4, s[4:5]
 ; GISEL-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v10, vcc
-; GISEL-NEXT:  .LBB0_6: ; %Flow1
-; GISEL-NEXT:    s_or_b64 exec, exec, s[8:9]
-; GISEL-NEXT:  .LBB0_7: ; %Flow2
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[14:15]
-; GISEL-NEXT:    s_cbranch_execz .LBB0_9
-; GISEL-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
-; GISEL-NEXT:    v_and_b32_e32 v1, 1, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
-; GISEL-NEXT:    v_lshlrev_b32_e32 v2, 1, v1
-; GISEL-NEXT:    v_or_b32_e32 v0, v0, v2
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 2, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 3, v1
-; GISEL-NEXT:    v_or_b32_e32 v2, v1, v2
-; GISEL-NEXT:    v_or3_b32 v0, v0, v3, v4
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 4, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 5, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v3, v4
-; GISEL-NEXT:    v_or3_b32 v0, v0, v5, v6
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 6, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 7, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v5, v6
-; GISEL-NEXT:    v_or3_b32 v0, v0, v7, v8
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 8, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 9, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v7, v8
-; GISEL-NEXT:    v_or3_b32 v0, v0, v9, v10
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 10, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 11, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v9, v10
-; GISEL-NEXT:    v_or3_b32 v0, v0, v11, v12
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 12, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 13, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v11, v12
-; GISEL-NEXT:    v_or3_b32 v0, v0, v13, v14
-; GISEL-NEXT:    v_lshlrev_b32_e32 v15, 14, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v16, 15, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v13, v14
-; GISEL-NEXT:    v_or3_b32 v0, v0, v15, v16
-; GISEL-NEXT:    v_lshlrev_b32_e32 v17, 16, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v18, 17, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v15, v16
-; GISEL-NEXT:    v_or3_b32 v0, v0, v17, v18
-; GISEL-NEXT:    v_lshlrev_b32_e32 v19, 18, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 19, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v17, v18
-; GISEL-NEXT:    v_or3_b32 v0, v0, v19, v3
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 20, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 21, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v19, v3
-; GISEL-NEXT:    v_or3_b32 v0, v0, v4, v5
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 22, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 23, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v4, v5
-; GISEL-NEXT:    v_or3_b32 v0, v0, v6, v7
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 24, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 25, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v6, v7
-; GISEL-NEXT:    v_or3_b32 v0, v0, v8, v9
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 26, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 27, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v8, v9
-; GISEL-NEXT:    v_or3_b32 v0, v0, v10, v11
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 28, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 29, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v10, v11
-; GISEL-NEXT:    v_or3_b32 v0, v0, v12, v13
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 30, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v1, 31, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v12, v13
-; GISEL-NEXT:    v_or3_b32 v0, v0, v14, v1
-; GISEL-NEXT:    v_or3_b32 v1, v2, v14, v1
-; GISEL-NEXT:    v_add_u32_e32 v3, 0x80000000, v1
-; GISEL-NEXT:    v_mov_b32_e32 v2, v1
-; GISEL-NEXT:  .LBB0_9: ; %Flow3
+; GISEL-NEXT:  .LBB0_5: ; %Flow1
 ; GISEL-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GISEL-NEXT:  .LBB0_10: ; %fp-to-i-cleanup
-; GISEL-NEXT:    s_or_b64 exec, exec, s[12:13]
+; GISEL-NEXT:  .LBB0_6: ; %fp-to-i-cleanup
+; GISEL-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
   %cvt = fptosi double %x to i128
   ret i128 %cvt
@@ -345,115 +234,56 @@ define i128 @fptoui_f64_to_i128(double %x) {
 ; SDAG-LABEL: fptoui_f64_to_i128:
 ; SDAG:       ; %bb.0: ; %fp-to-i-entry
 ; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    v_mov_b32_e32 v5, v1
-; SDAG-NEXT:    v_bfe_u32 v6, v5, 20, 11
+; SDAG-NEXT:    v_bfe_u32 v6, v1, 20, 11
 ; SDAG-NEXT:    v_mov_b32_e32 v7, 0
 ; SDAG-NEXT:    s_mov_b64 s[4:5], 0x3fe
-; SDAG-NEXT:    v_mov_b32_e32 v4, v0
 ; SDAG-NEXT:    v_cmp_lt_u64_e32 vcc, s[4:5], v[6:7]
-; SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; SDAG-NEXT:    v_mov_b32_e32 v4, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_mov_b32_e32 v1, 0
+; SDAG-NEXT:    v_mov_b32_e32 v5, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v3, 0
-; SDAG-NEXT:    s_and_saveexec_b64 s[8:9], vcc
-; SDAG-NEXT:    s_cbranch_execz .LBB1_10
-; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; SDAG-NEXT:    v_add_co_u32_e32 v0, vcc, 0xfffffb81, v6
-; SDAG-NEXT:    v_addc_co_u32_e64 v1, s[6:7], 0, -1, vcc
-; SDAG-NEXT:    s_movk_i32 s6, 0xff7f
-; SDAG-NEXT:    s_mov_b32 s7, -1
-; SDAG-NEXT:    v_cmp_lt_i64_e64 s[4:5], -1, v[4:5]
-; SDAG-NEXT:    v_cmp_lt_u64_e32 vcc, s[6:7], v[0:1]
-; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
-; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
 ; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], vcc
-; SDAG-NEXT:    s_xor_b64 s[10:11], exec, s[6:7]
-; SDAG-NEXT:    s_cbranch_execz .LBB1_7
-; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
-; SDAG-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
-; SDAG-NEXT:    v_add_co_u32_e32 v9, vcc, -1, v0
-; SDAG-NEXT:    s_mov_b64 s[6:7], 0x432
-; SDAG-NEXT:    v_and_b32_e32 v0, 0xfffff, v5
-; SDAG-NEXT:    v_cmp_lt_u64_e32 vcc, s[6:7], v[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v8, -1, 0, s[4:5]
-; SDAG-NEXT:    v_cndmask_b32_e64 v10, -1, 1, s[4:5]
-; SDAG-NEXT:    v_or_b32_e32 v5, 0x100000, v0
-; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
-; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
-; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], vcc
-; SDAG-NEXT:    s_xor_b64 s[12:13], exec, s[6:7]
-; SDAG-NEXT:    s_cbranch_execz .LBB1_4
-; SDAG-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
-; SDAG-NEXT:    v_sub_u32_e32 v0, 0x473, v6
-; SDAG-NEXT:    v_add_u32_e32 v2, 0xfffffb8d, v6
-; SDAG-NEXT:    v_add_u32_e32 v3, 0xfffffbcd, v6
-; SDAG-NEXT:    v_lshrrev_b64 v[0:1], v0, v[4:5]
-; SDAG-NEXT:    v_lshlrev_b64 v[6:7], v2, v[4:5]
-; SDAG-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v3
-; SDAG-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v3
-; SDAG-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
-; SDAG-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
-; SDAG-NEXT:    v_cndmask_b32_e32 v7, 0, v3, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v5, 0, v0, s[6:7]
-; SDAG-NEXT:    v_mul_lo_u32 v12, v10, v1
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v7, v10, 0
-; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_cndmask_b32_e32 v13, 0, v4, vcc
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[6:7], v13, v10, v[1:2]
-; SDAG-NEXT:    v_mul_lo_u32 v11, v8, v5
-; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v10, v5, 0
-; SDAG-NEXT:    v_mov_b32_e32 v1, v3
-; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[6:7], v7, v8, v[1:2]
-; SDAG-NEXT:    v_add3_u32 v6, v6, v12, v11
-; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v9, v7, v[5:6]
-; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v4, v2
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[6:7], 0, 0, vcc
-; SDAG-NEXT:    v_mul_lo_u32 v10, v9, v13
-; SDAG-NEXT:    v_mul_lo_u32 v7, v9, v7
-; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v13, v8, v[2:3]
-; SDAG-NEXT:    ; implicit-def: $vgpr8
-; SDAG-NEXT:    ; implicit-def: $vgpr9
-; SDAG-NEXT:    v_add3_u32 v4, v7, v6, v10
-; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v5
-; SDAG-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v4, vcc
-; SDAG-NEXT:    ; implicit-def: $vgpr6_vgpr7
-; SDAG-NEXT:    ; implicit-def: $vgpr4_vgpr5
-; SDAG-NEXT:    ; implicit-def: $vgpr10
-; SDAG-NEXT:  .LBB1_4: ; %Flow
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[6:7], s[12:13]
 ; SDAG-NEXT:    s_cbranch_execz .LBB1_6
-; SDAG-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
-; SDAG-NEXT:    v_sub_u32_e32 v0, 0x433, v6
-; SDAG-NEXT:    v_lshrrev_b64 v[4:5], v0, v[4:5]
+; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
+; SDAG-NEXT:    s_mov_b64 s[4:5], 0x432
+; SDAG-NEXT:    v_and_b32_e32 v1, 0xfffff, v1
+; SDAG-NEXT:    v_cmp_lt_u64_e32 vcc, s[4:5], v[6:7]
+; SDAG-NEXT:    v_or_b32_e32 v1, 0x100000, v1
+; SDAG-NEXT:    ; implicit-def: $vgpr4_vgpr5
+; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
+; SDAG-NEXT:    s_and_saveexec_b64 s[4:5], vcc
+; SDAG-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
+; SDAG-NEXT:    s_cbranch_execz .LBB1_3
+; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
+; SDAG-NEXT:    v_sub_u32_e32 v2, 0x473, v6
+; SDAG-NEXT:    v_add_u32_e32 v4, 0xfffffb8d, v6
+; SDAG-NEXT:    v_add_u32_e32 v7, 0xfffffbcd, v6
+; SDAG-NEXT:    v_lshrrev_b64 v[2:3], v2, v[0:1]
+; SDAG-NEXT:    v_lshlrev_b64 v[4:5], v4, v[0:1]
+; SDAG-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v7
+; SDAG-NEXT:    v_lshlrev_b64 v[0:1], v7, v[0:1]
+; SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
+; SDAG-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v7
+; SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; SDAG-NEXT:    v_cndmask_b32_e64 v3, 0, v3, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e32 v5, 0, v1, vcc
+; SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v0, vcc
+; SDAG-NEXT:    ; implicit-def: $vgpr6_vgpr7
+; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
+; SDAG-NEXT:  .LBB1_3: ; %Flow
+; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[8:9]
+; SDAG-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
+; SDAG-NEXT:    v_sub_u32_e32 v2, 0x433, v6
+; SDAG-NEXT:    v_lshrrev_b64 v[4:5], v2, v[0:1]
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[12:13], v4, v10, 0
-; SDAG-NEXT:    v_mad_u64_u32 v[6:7], s[12:13], v5, v10, v[1:2]
-; SDAG-NEXT:    v_mov_b32_e32 v1, v6
-; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[12:13], v4, v8, v[1:2]
-; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v7, v2
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[12:13], 0, 0, vcc
-; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[12:13], v5, v8, v[2:3]
-; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[12:13], v9, v4, v[2:3]
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[12:13], v9, v4, v[3:4]
-; SDAG-NEXT:    v_mad_i32_i24 v3, v9, v5, v3
-; SDAG-NEXT:  .LBB1_6: ; %Flow1
+; SDAG-NEXT:    v_mov_b32_e32 v3, 0
+; SDAG-NEXT:  ; %bb.5: ; %Flow1
+; SDAG-NEXT:    s_or_b64 exec, exec, s[4:5]
+; SDAG-NEXT:  .LBB1_6: ; %fp-to-i-cleanup
 ; SDAG-NEXT:    s_or_b64 exec, exec, s[6:7]
-; SDAG-NEXT:  .LBB1_7: ; %Flow2
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[6:7], s[10:11]
-; SDAG-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; SDAG-NEXT:    v_bfrev_b32_e32 v0, 1
-; SDAG-NEXT:    v_bfrev_b32_e32 v1, -2
-; SDAG-NEXT:    v_cndmask_b32_e64 v2, v0, v1, s[4:5]
-; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
-; SDAG-NEXT:    v_mov_b32_e32 v3, v2
-; SDAG-NEXT:    v_mov_b32_e32 v0, v1
-; SDAG-NEXT:    v_mov_b32_e32 v2, v1
-; SDAG-NEXT:  ; %bb.9: ; %Flow3
-; SDAG-NEXT:    s_or_b64 exec, exec, s[6:7]
-; SDAG-NEXT:  .LBB1_10: ; %fp-to-i-cleanup
-; SDAG-NEXT:    s_or_b64 exec, exec, s[8:9]
+; SDAG-NEXT:    v_mov_b32_e32 v0, v4
+; SDAG-NEXT:    v_mov_b32_e32 v1, v5
 ; SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-LABEL: fptoui_f64_to_i128:
@@ -473,74 +303,9 @@ define i128 @fptoui_f64_to_i128(double %x) {
 ; GISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GISEL-NEXT:    v_mov_b32_e32 v3, s7
-; GISEL-NEXT:    s_and_saveexec_b64 s[12:13], vcc
-; GISEL-NEXT:    s_cbranch_execz .LBB1_10
-; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; GISEL-NEXT:    v_add_co_u32_e32 v0, vcc, 0xfffffb81, v6
-; GISEL-NEXT:    v_mov_b32_e32 v2, 0xffffff80
-; GISEL-NEXT:    v_mov_b32_e32 v3, -1
-; GISEL-NEXT:    v_addc_co_u32_e64 v1, s[6:7], 0, -1, vcc
-; GISEL-NEXT:    v_cmp_lt_i64_e64 s[4:5], -1, v[4:5]
-; GISEL-NEXT:    v_cmp_ge_u64_e32 vcc, v[0:1], v[2:3]
-; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
-; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
-; GISEL-NEXT:    s_xor_b64 s[14:15], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB1_7
-; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
-; GISEL-NEXT:    s_xor_b64 s[6:7], s[4:5], -1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[6:7]
-; GISEL-NEXT:    v_and_b32_e32 v0, 1, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[6:7]
-; GISEL-NEXT:    v_lshlrev_b16_e32 v2, 1, v0
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v2
-; GISEL-NEXT:    v_lshlrev_b16_e32 v3, 2, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v0, v2
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v3
-; GISEL-NEXT:    v_lshlrev_b16_e32 v8, 3, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v3
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v8
-; GISEL-NEXT:    v_lshlrev_b16_e32 v9, 4, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v8
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v9
-; GISEL-NEXT:    v_lshlrev_b16_e32 v10, 5, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v9
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v10
-; GISEL-NEXT:    v_lshlrev_b16_e32 v11, 6, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v10
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v11
-; GISEL-NEXT:    v_lshlrev_b16_e32 v12, 7, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v11
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v12
-; GISEL-NEXT:    v_lshlrev_b16_e32 v13, 8, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v12
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v13
-; GISEL-NEXT:    v_lshlrev_b16_e32 v14, 9, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v13
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v14
-; GISEL-NEXT:    v_lshlrev_b16_e32 v15, 10, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v14
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v15
-; GISEL-NEXT:    v_lshlrev_b16_e32 v16, 11, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v15
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v16
-; GISEL-NEXT:    v_lshlrev_b16_e32 v17, 12, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v16
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v17
-; GISEL-NEXT:    v_lshlrev_b16_e32 v18, 13, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v17
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v18
-; GISEL-NEXT:    v_lshlrev_b16_e32 v19, 14, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v18
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v19
-; GISEL-NEXT:    v_lshlrev_b16_e32 v0, 15, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v19
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v0
-; GISEL-NEXT:    v_or_b32_e32 v0, v2, v0
-; GISEL-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GISEL-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v2, 16, v0
-; GISEL-NEXT:    v_lshl_or_b32 v9, v0, 16, v0
-; GISEL-NEXT:    v_or3_b32 v8, v1, v2, 1
+; GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
+; GISEL-NEXT:    s_cbranch_execz .LBB1_6
+; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0x433
 ; GISEL-NEXT:    v_mov_b32_e32 v1, 0
 ; GISEL-NEXT:    v_mov_b32_e32 v2, 0xfffff
@@ -549,132 +314,36 @@ define i128 @fptoui_f64_to_i128(double %x) {
 ; GISEL-NEXT:    v_and_or_b32 v5, v5, v2, s6
 ; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
 ; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
-; GISEL-NEXT:    s_xor_b64 s[16:17], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB1_4
-; GISEL-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
-; GISEL-NEXT:    v_add_u32_e32 v2, 0xfffffbcd, v6
-; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v2, v[4:5]
-; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v2
-; GISEL-NEXT:    v_cndmask_b32_e32 v10, 0, v0, vcc
-; GISEL-NEXT:    v_cndmask_b32_e32 v11, 0, v1, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v10, v9, 0
-; GISEL-NEXT:    v_add_u32_e32 v3, 0xfffffb8d, v6
-; GISEL-NEXT:    v_sub_u32_e32 v6, 64, v2
-; GISEL-NEXT:    v_lshrrev_b64 v[6:7], v6, v[4:5]
-; GISEL-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], 0, v2
-; GISEL-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v11, v9, v[0:1]
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, v3, 0, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v10, v8, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v12, v8, v[5:6]
-; GISEL-NEXT:    v_mul_lo_u32 v13, v11, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v10, v9, v[1:2]
-; GISEL-NEXT:    v_mul_lo_u32 v10, v10, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[10:11], v11, v8, v[5:6]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[10:11], v3, v10, s[10:11]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v13, s[8:9]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v12, v9, v[3:4]
-; GISEL-NEXT:    v_cndmask_b32_e32 v3, v4, v7, vcc
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, v3, 0, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[6:7], v7, v8, v[5:6]
+; GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
+; GISEL-NEXT:    s_cbranch_execz .LBB1_3
+; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
+; GISEL-NEXT:    v_add_u32_e32 v7, 0xfffffbcd, v6
+; GISEL-NEXT:    v_add_u32_e32 v6, 0xfffffb8d, v6
+; GISEL-NEXT:    v_sub_u32_e32 v2, 64, v7
+; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v7, v[4:5]
+; GISEL-NEXT:    v_lshrrev_b64 v[2:3], v2, v[4:5]
+; GISEL-NEXT:    v_lshlrev_b64 v[4:5], v6, v[4:5]
+; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v7
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
 ; GISEL-NEXT:    ; implicit-def: $vgpr6
 ; GISEL-NEXT:    ; implicit-def: $vgpr4_vgpr5
-; GISEL-NEXT:    ; implicit-def: $vgpr8
-; GISEL-NEXT:    ; implicit-def: $vgpr9
-; GISEL-NEXT:  .LBB1_4: ; %Flow
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[8:9], s[16:17]
-; GISEL-NEXT:    s_cbranch_execz .LBB1_6
-; GISEL-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
+; GISEL-NEXT:  .LBB1_3: ; %Flow
+; GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
+; GISEL-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
 ; GISEL-NEXT:    v_sub_co_u32_e32 v0, vcc, 0x433, v6
-; GISEL-NEXT:    v_lshrrev_b64 v[4:5], v0, v[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[6:7], s[6:7], v4, v9, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v4, v8, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v5, v9, v[6:7]
-; GISEL-NEXT:    v_mul_lo_u32 v10, v5, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[6:7], vcc, v4, v9, v[1:2]
-; GISEL-NEXT:    v_mul_lo_u32 v4, v4, v9
-; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[6:7], v5, v8, v[6:7]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[6:7], v3, v4, s[6:7]
-; GISEL-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v10, vcc
-; GISEL-NEXT:  .LBB1_6: ; %Flow1
-; GISEL-NEXT:    s_or_b64 exec, exec, s[8:9]
-; GISEL-NEXT:  .LBB1_7: ; %Flow2
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[14:15]
-; GISEL-NEXT:    s_cbranch_execz .LBB1_9
-; GISEL-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
-; GISEL-NEXT:    v_and_b32_e32 v1, 1, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[4:5]
-; GISEL-NEXT:    v_lshlrev_b32_e32 v2, 1, v1
-; GISEL-NEXT:    v_or_b32_e32 v0, v0, v2
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 2, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 3, v1
-; GISEL-NEXT:    v_or_b32_e32 v2, v1, v2
-; GISEL-NEXT:    v_or3_b32 v0, v0, v3, v4
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 4, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 5, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v3, v4
-; GISEL-NEXT:    v_or3_b32 v0, v0, v5, v6
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 6, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 7, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v5, v6
-; GISEL-NEXT:    v_or3_b32 v0, v0, v7, v8
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 8, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 9, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v7, v8
-; GISEL-NEXT:    v_or3_b32 v0, v0, v9, v10
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 10, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 11, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v9, v10
-; GISEL-NEXT:    v_or3_b32 v0, v0, v11, v12
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 12, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 13, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v11, v12
-; GISEL-NEXT:    v_or3_b32 v0, v0, v13, v14
-; GISEL-NEXT:    v_lshlrev_b32_e32 v15, 14, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v16, 15, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v13, v14
-; GISEL-NEXT:    v_or3_b32 v0, v0, v15, v16
-; GISEL-NEXT:    v_lshlrev_b32_e32 v17, 16, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v18, 17, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v15, v16
-; GISEL-NEXT:    v_or3_b32 v0, v0, v17, v18
-; GISEL-NEXT:    v_lshlrev_b32_e32 v19, 18, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 19, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v17, v18
-; GISEL-NEXT:    v_or3_b32 v0, v0, v19, v3
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 20, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 21, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v19, v3
-; GISEL-NEXT:    v_or3_b32 v0, v0, v4, v5
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 22, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 23, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v4, v5
-; GISEL-NEXT:    v_or3_b32 v0, v0, v6, v7
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 24, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 25, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v6, v7
-; GISEL-NEXT:    v_or3_b32 v0, v0, v8, v9
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 26, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 27, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v8, v9
-; GISEL-NEXT:    v_or3_b32 v0, v0, v10, v11
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 28, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 29, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v10, v11
-; GISEL-NEXT:    v_or3_b32 v0, v0, v12, v13
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 30, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v1, 31, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v12, v13
-; GISEL-NEXT:    v_or3_b32 v0, v0, v14, v1
-; GISEL-NEXT:    v_or3_b32 v1, v2, v14, v1
-; GISEL-NEXT:    v_add_u32_e32 v3, 0x80000000, v1
-; GISEL-NEXT:    v_mov_b32_e32 v2, v1
-; GISEL-NEXT:  .LBB1_9: ; %Flow3
+; GISEL-NEXT:    v_lshrrev_b64 v[0:1], v0, v[4:5]
+; GISEL-NEXT:    v_mov_b32_e32 v2, 0
+; GISEL-NEXT:    v_mov_b32_e32 v3, 0
+; GISEL-NEXT:  ; %bb.5: ; %Flow1
 ; GISEL-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GISEL-NEXT:  .LBB1_10: ; %fp-to-i-cleanup
-; GISEL-NEXT:    s_or_b64 exec, exec, s[12:13]
+; GISEL-NEXT:  .LBB1_6: ; %fp-to-i-cleanup
+; GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
   %cvt = fptoui double %x to i128
   ret i128 %cvt
@@ -685,103 +354,80 @@ define i128 @fptosi_f32_to_i128(float %x) {
 ; SDAG:       ; %bb.0: ; %fp-to-i-entry
 ; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SDAG-NEXT:    v_mov_b32_e32 v4, v0
-; SDAG-NEXT:    v_bfe_u32 v7, v4, 23, 8
+; SDAG-NEXT:    v_bfe_u32 v9, v4, 23, 8
 ; SDAG-NEXT:    s_movk_i32 s4, 0x7e
 ; SDAG-NEXT:    v_mov_b32_e32 v0, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v1, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v3, 0
-; SDAG-NEXT:    v_cmp_lt_u32_e32 vcc, s4, v7
-; SDAG-NEXT:    s_and_saveexec_b64 s[8:9], vcc
-; SDAG-NEXT:    s_cbranch_execz .LBB2_10
-; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; SDAG-NEXT:    v_add_u32_e32 v0, 0xffffff01, v7
-; SDAG-NEXT:    s_movk_i32 s4, 0xff7f
-; SDAG-NEXT:    v_cmp_lt_i32_e32 vcc, -1, v4
-; SDAG-NEXT:    v_cmp_lt_u32_e64 s[4:5], s4, v0
-; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
-; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
-; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; SDAG-NEXT:    s_xor_b64 s[10:11], exec, s[6:7]
-; SDAG-NEXT:    s_cbranch_execz .LBB2_7
-; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
-; SDAG-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; SDAG-NEXT:    v_add_co_u32_e64 v6, s[4:5], -1, v0
+; SDAG-NEXT:    v_cmp_lt_u32_e32 vcc, s4, v9
+; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], vcc
+; SDAG-NEXT:    s_cbranch_execz .LBB2_6
+; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
+; SDAG-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x7fffff, v4
 ; SDAG-NEXT:    s_movk_i32 s4, 0x95
-; SDAG-NEXT:    v_cndmask_b32_e64 v5, -1, 0, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v8, -1, 1, vcc
+; SDAG-NEXT:    v_ashrrev_i32_e32 v7, 31, v5
+; SDAG-NEXT:    v_or_b32_e32 v8, 1, v5
 ; SDAG-NEXT:    v_or_b32_e32 v1, 0x800000, v0
-; SDAG-NEXT:    v_cmp_lt_u32_e64 s[4:5], s4, v7
+; SDAG-NEXT:    v_cmp_lt_u32_e32 vcc, s4, v9
 ; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
-; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; SDAG-NEXT:    s_xor_b64 s[12:13], exec, s[6:7]
-; SDAG-NEXT:    s_cbranch_execz .LBB2_4
-; SDAG-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
-; SDAG-NEXT:    v_add_u32_e32 v0, 0xffffff6a, v7
+; SDAG-NEXT:    s_and_saveexec_b64 s[4:5], vcc
+; SDAG-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
+; SDAG-NEXT:    s_cbranch_execz .LBB2_3
+; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_sub_u32_e32 v3, 0xd6, v7
-; SDAG-NEXT:    v_add_u32_e32 v7, 0xffffff2a, v7
+; SDAG-NEXT:    v_sub_u32_e32 v3, 0xd6, v9
+; SDAG-NEXT:    v_add_u32_e32 v6, 0xffffff2a, v9
+; SDAG-NEXT:    v_add_u32_e32 v0, 0xffffff6a, v9
 ; SDAG-NEXT:    v_lshrrev_b64 v[3:4], v3, v[1:2]
-; SDAG-NEXT:    v_lshlrev_b64 v[9:10], v7, v[1:2]
-; SDAG-NEXT:    v_cmp_gt_u32_e64 s[4:5], 64, v0
-; SDAG-NEXT:    v_cndmask_b32_e64 v4, v10, v4, s[4:5]
-; SDAG-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v0
-; SDAG-NEXT:    v_cndmask_b32_e64 v7, 0, v4, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v9, v9, v3, s[4:5]
+; SDAG-NEXT:    v_lshlrev_b64 v[9:10], v6, v[1:2]
+; SDAG-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v0
+; SDAG-NEXT:    v_cndmask_b32_e32 v4, v10, v4, vcc
+; SDAG-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v0
+; SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, v4, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e32 v9, v9, v3, vcc
 ; SDAG-NEXT:    v_lshlrev_b64 v[3:4], v0, v[1:2]
-; SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, v9, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v11, 0, v3, s[4:5]
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v11, v8, 0
-; SDAG-NEXT:    v_cndmask_b32_e64 v13, 0, v4, s[4:5]
-; SDAG-NEXT:    v_mul_lo_u32 v12, v5, v9
+; SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, v9, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e32 v11, 0, v3, vcc
+; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v11, v8, 0
+; SDAG-NEXT:    v_cndmask_b32_e32 v13, 0, v4, vcc
+; SDAG-NEXT:    v_mul_lo_u32 v12, v7, v9
 ; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v13, v8, v[1:2]
-; SDAG-NEXT:    v_mul_lo_u32 v7, v8, v7
-; SDAG-NEXT:    v_mad_u64_u32 v[9:10], s[6:7], v8, v9, 0
+; SDAG-NEXT:    v_mul_lo_u32 v6, v8, v6
+; SDAG-NEXT:    v_mad_u64_u32 v[9:10], s[4:5], v8, v9, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v1, v3
-; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v11, v5, v[1:2]
-; SDAG-NEXT:    v_add3_u32 v10, v10, v7, v12
-; SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v11, v[9:10]
-; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v4, v2
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, s[4:5]
-; SDAG-NEXT:    v_mul_lo_u32 v9, v6, v13
-; SDAG-NEXT:    v_mul_lo_u32 v6, v6, v11
-; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v13, v5, v[2:3]
-; SDAG-NEXT:    ; implicit-def: $vgpr5
-; SDAG-NEXT:    v_add3_u32 v4, v6, v8, v9
-; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v2, v7
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v3, v4, s[4:5]
+; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v11, v7, v[1:2]
+; SDAG-NEXT:    v_add3_u32 v10, v10, v6, v12
+; SDAG-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v11, v[9:10]
+; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v4, v2
+; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, vcc
+; SDAG-NEXT:    v_mul_lo_u32 v6, v5, v13
+; SDAG-NEXT:    v_mul_lo_u32 v5, v5, v11
+; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v13, v7, v[2:3]
 ; SDAG-NEXT:    ; implicit-def: $vgpr7
+; SDAG-NEXT:    v_add3_u32 v4, v5, v9, v6
+; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v8
+; SDAG-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v4, vcc
+; SDAG-NEXT:    ; implicit-def: $vgpr9
 ; SDAG-NEXT:    ; implicit-def: $vgpr8
-; SDAG-NEXT:    ; implicit-def: $vgpr6
-; SDAG-NEXT:  .LBB2_4: ; %Flow
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[12:13]
-; SDAG-NEXT:    s_cbranch_execz .LBB2_6
-; SDAG-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
-; SDAG-NEXT:    v_sub_u32_e32 v0, 0x96, v7
+; SDAG-NEXT:    ; implicit-def: $vgpr5_vgpr6
+; SDAG-NEXT:  .LBB2_3: ; %Flow
+; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[8:9]
+; SDAG-NEXT:    s_cbranch_execz .LBB2_5
+; SDAG-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
+; SDAG-NEXT:    v_sub_u32_e32 v0, 0x96, v9
 ; SDAG-NEXT:    v_lshrrev_b32_e32 v3, v0, v1
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v3, v8, 0
+; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v3, v8, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_mov_b32_e32 v9, v2
-; SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[6:7], v3, v5, v[1:2]
-; SDAG-NEXT:    v_mad_i64_i32 v[2:3], s[6:7], v6, v3, v[8:9]
-; SDAG-NEXT:    v_mov_b32_e32 v1, v7
-; SDAG-NEXT:  .LBB2_6: ; %Flow1
+; SDAG-NEXT:    v_mov_b32_e32 v8, v2
+; SDAG-NEXT:    v_mad_u64_u32 v[6:7], s[8:9], v3, v7, v[1:2]
+; SDAG-NEXT:    v_mad_i64_i32 v[2:3], s[8:9], v5, v3, v[7:8]
+; SDAG-NEXT:    v_mov_b32_e32 v1, v6
+; SDAG-NEXT:  .LBB2_5: ; %Flow1
 ; SDAG-NEXT:    s_or_b64 exec, exec, s[4:5]
-; SDAG-NEXT:  .LBB2_7: ; %Flow2
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[10:11]
-; SDAG-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; SDAG-NEXT:    v_bfrev_b32_e32 v0, 1
-; SDAG-NEXT:    v_bfrev_b32_e32 v1, -2
-; SDAG-NEXT:    v_cndmask_b32_e32 v2, v0, v1, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; SDAG-NEXT:    v_mov_b32_e32 v3, v2
-; SDAG-NEXT:    v_mov_b32_e32 v0, v1
-; SDAG-NEXT:    v_mov_b32_e32 v2, v1
-; SDAG-NEXT:  ; %bb.9: ; %Flow3
-; SDAG-NEXT:    s_or_b64 exec, exec, s[4:5]
-; SDAG-NEXT:  .LBB2_10: ; %fp-to-i-cleanup
-; SDAG-NEXT:    s_or_b64 exec, exec, s[8:9]
+; SDAG-NEXT:  .LBB2_6: ; %fp-to-i-cleanup
+; SDAG-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-LABEL: fptosi_f32_to_i128:
@@ -797,22 +443,13 @@ define i128 @fptosi_f32_to_i128(float %x) {
 ; GISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GISEL-NEXT:    v_mov_b32_e32 v3, s7
-; GISEL-NEXT:    s_and_saveexec_b64 s[12:13], vcc
-; GISEL-NEXT:    s_cbranch_execz .LBB2_10
-; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; GISEL-NEXT:    v_add_u32_e32 v0, 0xffffff01, v6
-; GISEL-NEXT:    v_mov_b32_e32 v1, 0xffffff80
-; GISEL-NEXT:    v_cmp_lt_i32_e32 vcc, -1, v4
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v1
-; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
-; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; GISEL-NEXT:    s_xor_b64 s[14:15], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB2_7
-; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
-; GISEL-NEXT:    s_xor_b64 s[4:5], vcc, -1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[4:5]
+; GISEL-NEXT:    s_and_saveexec_b64 s[10:11], vcc
+; GISEL-NEXT:    s_cbranch_execz .LBB2_6
+; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
+; GISEL-NEXT:    v_cmp_ge_i32_e32 vcc, -1, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
 ; GISEL-NEXT:    v_and_b32_e32 v0, 1, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GISEL-NEXT:    v_lshlrev_b16_e32 v2, 1, v0
 ; GISEL-NEXT:    v_or_b32_e32 v1, v1, v2
 ; GISEL-NEXT:    v_lshlrev_b16_e32 v3, 2, v0
@@ -868,133 +505,59 @@ define i128 @fptosi_f32_to_i128(float %x) {
 ; GISEL-NEXT:    v_and_or_b32 v4, v4, v0, v1
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0x96
 ; GISEL-NEXT:    v_mov_b32_e32 v5, 0
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v6, v0
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v6, v0
 ; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
-; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; GISEL-NEXT:    s_xor_b64 s[16:17], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB2_4
-; GISEL-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
+; GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
+; GISEL-NEXT:    s_xor_b64 s[12:13], exec, s[4:5]
+; GISEL-NEXT:    s_cbranch_execz .LBB2_3
+; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
 ; GISEL-NEXT:    v_add_u32_e32 v2, 0xffffff6a, v6
 ; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v2, v[4:5]
-; GISEL-NEXT:    v_cmp_gt_u32_e64 s[4:5], 64, v2
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, v0, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, v1, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v11, v7, 0
+; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v2
+; GISEL-NEXT:    v_cndmask_b32_e32 v11, 0, v0, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v12, 0, v1, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v11, v7, 0
 ; GISEL-NEXT:    v_add_u32_e32 v3, 0xffffff2a, v6
 ; GISEL-NEXT:    v_sub_u32_e32 v6, 64, v2
 ; GISEL-NEXT:    v_lshrrev_b64 v[9:10], v6, v[4:5]
 ; GISEL-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v12, v7, v[0:1]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v9, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], 0, v2
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, v3, 0, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v11, v8, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v9, v8, v[5:6]
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v12, v7, v[0:1]
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v3, v9, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v2
+; GISEL-NEXT:    v_cndmask_b32_e64 v9, v3, 0, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v11, v8, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v9, v8, v[5:6]
 ; GISEL-NEXT:    v_mul_lo_u32 v13, v12, v7
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v11, v7, v[1:2]
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v11, v7, v[1:2]
 ; GISEL-NEXT:    v_mul_lo_u32 v11, v11, v7
-; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[10:11], v12, v8, v[5:6]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[10:11], v3, v11, s[10:11]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v13, s[8:9]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v9, v7, v[3:4]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v4, v10, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, v3, 0, s[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v12, v8, v[5:6]
+; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v11, s[8:9]
+; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[6:7], v3, v13, s[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v9, v7, v[3:4]
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v4, v10, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v7, v3, 0, s[4:5]
 ; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v7, v8, v[5:6]
 ; GISEL-NEXT:    ; implicit-def: $vgpr6
 ; GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GISEL-NEXT:    ; implicit-def: $vgpr8
 ; GISEL-NEXT:    ; implicit-def: $vgpr7
-; GISEL-NEXT:  .LBB2_4: ; %Flow
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[16:17]
-; GISEL-NEXT:    s_cbranch_execz .LBB2_6
-; GISEL-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
+; GISEL-NEXT:  .LBB2_3: ; %Flow
+; GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[12:13]
+; GISEL-NEXT:    s_cbranch_execz .LBB2_5
+; GISEL-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
 ; GISEL-NEXT:    v_sub_u32_e32 v0, 0x96, v6
 ; GISEL-NEXT:    v_lshrrev_b32_e32 v6, v0, v4
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v8, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v7, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v6, v8, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v6, v7, 0
 ; GISEL-NEXT:    v_mul_lo_u32 v8, v6, v7
-; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v6, v7, v[1:2]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v3, v8, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[4:5], vcc, v6, v7, v[1:2]
+; GISEL-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v8, vcc
 ; GISEL-NEXT:    v_mov_b32_e32 v1, v4
 ; GISEL-NEXT:    v_mov_b32_e32 v2, v5
-; GISEL-NEXT:  .LBB2_6: ; %Flow1
-; GISEL-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GISEL-NEXT:  .LBB2_7: ; %Flow2
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[14:15]
-; GISEL-NEXT:    s_cbranch_execz .LBB2_9
-; GISEL-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; GISEL-NEXT:    v_and_b32_e32 v1, 1, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_lshlrev_b32_e32 v2, 1, v1
-; GISEL-NEXT:    v_or_b32_e32 v0, v0, v2
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 2, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 3, v1
-; GISEL-NEXT:    v_or_b32_e32 v2, v1, v2
-; GISEL-NEXT:    v_or3_b32 v0, v0, v3, v4
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 4, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 5, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v3, v4
-; GISEL-NEXT:    v_or3_b32 v0, v0, v5, v6
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 6, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 7, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v5, v6
-; GISEL-NEXT:    v_or3_b32 v0, v0, v7, v8
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 8, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 9, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v7, v8
-; GISEL-NEXT:    v_or3_b32 v0, v0, v9, v10
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 10, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 11, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v9, v10
-; GISEL-NEXT:    v_or3_b32 v0, v0, v11, v12
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 12, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 13, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v11, v12
-; GISEL-NEXT:    v_or3_b32 v0, v0, v13, v14
-; GISEL-NEXT:    v_lshlrev_b32_e32 v15, 14, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v16, 15, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v13, v14
-; GISEL-NEXT:    v_or3_b32 v0, v0, v15, v16
-; GISEL-NEXT:    v_lshlrev_b32_e32 v17, 16, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v18, 17, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v15, v16
-; GISEL-NEXT:    v_or3_b32 v0, v0, v17, v18
-; GISEL-NEXT:    v_lshlrev_b32_e32 v19, 18, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 19, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v17, v18
-; GISEL-NEXT:    v_or3_b32 v0, v0, v19, v3
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 20, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 21, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v19, v3
-; GISEL-NEXT:    v_or3_b32 v0, v0, v4, v5
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 22, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 23, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v4, v5
-; GISEL-NEXT:    v_or3_b32 v0, v0, v6, v7
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 24, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 25, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v6, v7
-; GISEL-NEXT:    v_or3_b32 v0, v0, v8, v9
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 26, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 27, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v8, v9
-; GISEL-NEXT:    v_or3_b32 v0, v0, v10, v11
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 28, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 29, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v10, v11
-; GISEL-NEXT:    v_or3_b32 v0, v0, v12, v13
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 30, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v1, 31, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v12, v13
-; GISEL-NEXT:    v_or3_b32 v0, v0, v14, v1
-; GISEL-NEXT:    v_or3_b32 v1, v2, v14, v1
-; GISEL-NEXT:    v_add_u32_e32 v3, 0x80000000, v1
-; GISEL-NEXT:    v_mov_b32_e32 v2, v1
-; GISEL-NEXT:  .LBB2_9: ; %Flow3
+; GISEL-NEXT:  .LBB2_5: ; %Flow1
 ; GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GISEL-NEXT:  .LBB2_10: ; %fp-to-i-cleanup
-; GISEL-NEXT:    s_or_b64 exec, exec, s[12:13]
+; GISEL-NEXT:  .LBB2_6: ; %fp-to-i-cleanup
+; GISEL-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
   %cvt = fptosi float %x to i128
   ret i128 %cvt
@@ -1005,103 +568,55 @@ define i128 @fptoui_f32_to_i128(float %x) {
 ; SDAG:       ; %bb.0: ; %fp-to-i-entry
 ; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SDAG-NEXT:    v_mov_b32_e32 v4, v0
-; SDAG-NEXT:    v_bfe_u32 v7, v4, 23, 8
+; SDAG-NEXT:    v_bfe_u32 v6, v4, 23, 8
 ; SDAG-NEXT:    s_movk_i32 s4, 0x7e
 ; SDAG-NEXT:    v_mov_b32_e32 v0, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v1, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v3, 0
-; SDAG-NEXT:    v_cmp_lt_u32_e32 vcc, s4, v7
-; SDAG-NEXT:    s_and_saveexec_b64 s[8:9], vcc
-; SDAG-NEXT:    s_cbranch_execz .LBB3_10
-; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; SDAG-NEXT:    v_add_u32_e32 v0, 0xffffff01, v7
-; SDAG-NEXT:    s_movk_i32 s4, 0xff7f
-; SDAG-NEXT:    v_cmp_lt_i32_e32 vcc, -1, v4
-; SDAG-NEXT:    v_cmp_lt_u32_e64 s[4:5], s4, v0
-; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
-; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
-; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; SDAG-NEXT:    s_xor_b64 s[10:11], exec, s[6:7]
-; SDAG-NEXT:    s_cbranch_execz .LBB3_7
-; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
-; SDAG-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; SDAG-NEXT:    v_add_co_u32_e64 v6, s[4:5], -1, v0
+; SDAG-NEXT:    v_cmp_lt_u32_e32 vcc, s4, v6
+; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], vcc
+; SDAG-NEXT:    s_cbranch_execz .LBB3_6
+; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x7fffff, v4
 ; SDAG-NEXT:    s_movk_i32 s4, 0x95
-; SDAG-NEXT:    v_cndmask_b32_e64 v5, -1, 0, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v8, -1, 1, vcc
-; SDAG-NEXT:    v_or_b32_e32 v1, 0x800000, v0
-; SDAG-NEXT:    v_cmp_lt_u32_e64 s[4:5], s4, v7
+; SDAG-NEXT:    v_or_b32_e32 v4, 0x800000, v0
+; SDAG-NEXT:    v_cmp_lt_u32_e32 vcc, s4, v6
+; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
 ; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
-; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; SDAG-NEXT:    s_xor_b64 s[12:13], exec, s[6:7]
-; SDAG-NEXT:    s_cbranch_execz .LBB3_4
-; SDAG-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
-; SDAG-NEXT:    v_add_u32_e32 v0, 0xffffff6a, v7
-; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_sub_u32_e32 v3, 0xd6, v7
-; SDAG-NEXT:    v_add_u32_e32 v7, 0xffffff2a, v7
-; SDAG-NEXT:    v_lshrrev_b64 v[3:4], v3, v[1:2]
-; SDAG-NEXT:    v_lshlrev_b64 v[9:10], v7, v[1:2]
-; SDAG-NEXT:    v_cmp_gt_u32_e64 s[4:5], 64, v0
-; SDAG-NEXT:    v_cndmask_b32_e64 v4, v10, v4, s[4:5]
-; SDAG-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v0
-; SDAG-NEXT:    v_cndmask_b32_e64 v7, 0, v4, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v9, v9, v3, s[4:5]
-; SDAG-NEXT:    v_lshlrev_b64 v[3:4], v0, v[1:2]
-; SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, v9, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v11, 0, v3, s[4:5]
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v11, v8, 0
-; SDAG-NEXT:    v_cndmask_b32_e64 v13, 0, v4, s[4:5]
-; SDAG-NEXT:    v_mul_lo_u32 v12, v5, v9
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v13, v8, v[1:2]
-; SDAG-NEXT:    v_mul_lo_u32 v7, v8, v7
-; SDAG-NEXT:    v_mad_u64_u32 v[9:10], s[6:7], v8, v9, 0
-; SDAG-NEXT:    v_mov_b32_e32 v1, v3
-; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v11, v5, v[1:2]
-; SDAG-NEXT:    v_add3_u32 v10, v10, v7, v12
-; SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v6, v11, v[9:10]
-; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v4, v2
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, s[4:5]
-; SDAG-NEXT:    v_mul_lo_u32 v9, v6, v13
-; SDAG-NEXT:    v_mul_lo_u32 v6, v6, v11
-; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v13, v5, v[2:3]
-; SDAG-NEXT:    ; implicit-def: $vgpr5
-; SDAG-NEXT:    v_add3_u32 v4, v6, v8, v9
-; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v2, v7
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v3, v4, s[4:5]
-; SDAG-NEXT:    ; implicit-def: $vgpr7
-; SDAG-NEXT:    ; implicit-def: $vgpr8
+; SDAG-NEXT:    s_and_saveexec_b64 s[4:5], vcc
+; SDAG-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
+; SDAG-NEXT:    s_cbranch_execz .LBB3_3
+; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
+; SDAG-NEXT:    v_mov_b32_e32 v5, 0
+; SDAG-NEXT:    v_sub_u32_e32 v0, 0xd6, v6
+; SDAG-NEXT:    v_add_u32_e32 v2, 0xffffff2a, v6
+; SDAG-NEXT:    v_add_u32_e32 v7, 0xffffff6a, v6
+; SDAG-NEXT:    v_lshrrev_b64 v[0:1], v0, v[4:5]
+; SDAG-NEXT:    v_lshlrev_b64 v[2:3], v2, v[4:5]
+; SDAG-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v7
+; SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; SDAG-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v7
+; SDAG-NEXT:    v_cndmask_b32_e64 v3, 0, v1, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e32 v2, v2, v0, vcc
+; SDAG-NEXT:    v_lshlrev_b64 v[0:1], v7, v[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
+; SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; SDAG-NEXT:    ; implicit-def: $vgpr6
-; SDAG-NEXT:  .LBB3_4: ; %Flow
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[12:13]
-; SDAG-NEXT:    s_cbranch_execz .LBB3_6
-; SDAG-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
-; SDAG-NEXT:    v_sub_u32_e32 v0, 0x96, v7
-; SDAG-NEXT:    v_lshrrev_b32_e32 v3, v0, v1
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v3, v8, 0
+; SDAG-NEXT:    ; implicit-def: $vgpr4
+; SDAG-NEXT:  .LBB3_3: ; %Flow
+; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[8:9]
+; SDAG-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
+; SDAG-NEXT:    v_sub_u32_e32 v0, 0x96, v6
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_mov_b32_e32 v9, v2
-; SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[6:7], v3, v5, v[1:2]
-; SDAG-NEXT:    v_mad_i64_i32 v[2:3], s[6:7], v6, v3, v[8:9]
-; SDAG-NEXT:    v_mov_b32_e32 v1, v7
-; SDAG-NEXT:  .LBB3_6: ; %Flow1
+; SDAG-NEXT:    v_lshrrev_b32_e32 v0, v0, v4
+; SDAG-NEXT:    v_mov_b32_e32 v3, 0
+; SDAG-NEXT:    v_mov_b32_e32 v1, 0
+; SDAG-NEXT:  ; %bb.5: ; %Flow1
 ; SDAG-NEXT:    s_or_b64 exec, exec, s[4:5]
-; SDAG-NEXT:  .LBB3_7: ; %Flow2
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[10:11]
-; SDAG-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; SDAG-NEXT:    v_bfrev_b32_e32 v0, 1
-; SDAG-NEXT:    v_bfrev_b32_e32 v1, -2
-; SDAG-NEXT:    v_cndmask_b32_e32 v2, v0, v1, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; SDAG-NEXT:    v_mov_b32_e32 v3, v2
-; SDAG-NEXT:    v_mov_b32_e32 v0, v1
-; SDAG-NEXT:    v_mov_b32_e32 v2, v1
-; SDAG-NEXT:  ; %bb.9: ; %Flow3
-; SDAG-NEXT:    s_or_b64 exec, exec, s[4:5]
-; SDAG-NEXT:  .LBB3_10: ; %fp-to-i-cleanup
-; SDAG-NEXT:    s_or_b64 exec, exec, s[8:9]
+; SDAG-NEXT:  .LBB3_6: ; %fp-to-i-cleanup
+; SDAG-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-LABEL: fptoui_f32_to_i128:
@@ -1117,204 +632,48 @@ define i128 @fptoui_f32_to_i128(float %x) {
 ; GISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GISEL-NEXT:    v_mov_b32_e32 v3, s7
-; GISEL-NEXT:    s_and_saveexec_b64 s[12:13], vcc
-; GISEL-NEXT:    s_cbranch_execz .LBB3_10
-; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; GISEL-NEXT:    v_add_u32_e32 v0, 0xffffff01, v6
-; GISEL-NEXT:    v_mov_b32_e32 v1, 0xffffff80
-; GISEL-NEXT:    v_cmp_lt_i32_e32 vcc, -1, v4
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v1
-; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
-; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; GISEL-NEXT:    s_xor_b64 s[14:15], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB3_7
-; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
-; GISEL-NEXT:    s_xor_b64 s[4:5], vcc, -1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[4:5]
-; GISEL-NEXT:    v_and_b32_e32 v0, 1, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
-; GISEL-NEXT:    v_lshlrev_b16_e32 v2, 1, v0
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v2
-; GISEL-NEXT:    v_lshlrev_b16_e32 v3, 2, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v0, v2
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v3
-; GISEL-NEXT:    v_lshlrev_b16_e32 v7, 3, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v3
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v7
-; GISEL-NEXT:    v_lshlrev_b16_e32 v8, 4, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v7
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v8
-; GISEL-NEXT:    v_lshlrev_b16_e32 v9, 5, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v8
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v9
-; GISEL-NEXT:    v_lshlrev_b16_e32 v10, 6, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v9
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v10
-; GISEL-NEXT:    v_lshlrev_b16_e32 v11, 7, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v10
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v11
-; GISEL-NEXT:    v_lshlrev_b16_e32 v12, 8, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v11
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v12
-; GISEL-NEXT:    v_lshlrev_b16_e32 v13, 9, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v12
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v13
-; GISEL-NEXT:    v_lshlrev_b16_e32 v14, 10, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v13
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v14
-; GISEL-NEXT:    v_lshlrev_b16_e32 v15, 11, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v14
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v15
-; GISEL-NEXT:    v_lshlrev_b16_e32 v16, 12, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v15
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v16
-; GISEL-NEXT:    v_lshlrev_b16_e32 v17, 13, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v16
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v17
-; GISEL-NEXT:    v_lshlrev_b16_e32 v18, 14, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v17
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v18
-; GISEL-NEXT:    v_lshlrev_b16_e32 v0, 15, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v18
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v0
-; GISEL-NEXT:    v_or_b32_e32 v0, v2, v0
-; GISEL-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GISEL-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v2, 16, v0
-; GISEL-NEXT:    v_lshl_or_b32 v7, v0, 16, v0
-; GISEL-NEXT:    v_or3_b32 v8, v1, v2, 1
+; GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
+; GISEL-NEXT:    s_cbranch_execz .LBB3_6
+; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0x7fffff
 ; GISEL-NEXT:    v_mov_b32_e32 v1, 0x800000
 ; GISEL-NEXT:    v_and_or_b32 v4, v4, v0, v1
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0x96
-; GISEL-NEXT:    v_mov_b32_e32 v5, 0
-; GISEL-NEXT:    v_cmp_ge_u32_e64 s[4:5], v6, v0
+; GISEL-NEXT:    v_cmp_ge_u32_e32 vcc, v6, v0
 ; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
-; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; GISEL-NEXT:    s_xor_b64 s[16:17], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB3_4
-; GISEL-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
-; GISEL-NEXT:    v_add_u32_e32 v2, 0xffffff6a, v6
-; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v2, v[4:5]
-; GISEL-NEXT:    v_cmp_gt_u32_e64 s[4:5], 64, v2
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, v0, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, v1, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v11, v7, 0
-; GISEL-NEXT:    v_add_u32_e32 v3, 0xffffff2a, v6
-; GISEL-NEXT:    v_sub_u32_e32 v6, 64, v2
-; GISEL-NEXT:    v_lshrrev_b64 v[9:10], v6, v[4:5]
-; GISEL-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v12, v7, v[0:1]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v9, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], 0, v2
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, v3, 0, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v11, v8, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v9, v8, v[5:6]
-; GISEL-NEXT:    v_mul_lo_u32 v13, v12, v7
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v11, v7, v[1:2]
-; GISEL-NEXT:    v_mul_lo_u32 v11, v11, v7
-; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[10:11], v12, v8, v[5:6]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[10:11], v3, v11, s[10:11]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v13, s[8:9]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v9, v7, v[3:4]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v4, v10, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v7, v3, 0, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v7, v8, v[5:6]
+; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
+; GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
+; GISEL-NEXT:    s_cbranch_execz .LBB3_3
+; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
+; GISEL-NEXT:    v_add_u32_e32 v7, 0xffffff6a, v6
+; GISEL-NEXT:    v_mov_b32_e32 v5, 0
+; GISEL-NEXT:    v_add_u32_e32 v6, 0xffffff2a, v6
+; GISEL-NEXT:    v_sub_u32_e32 v2, 64, v7
+; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v7, v[4:5]
+; GISEL-NEXT:    v_lshrrev_b64 v[2:3], v2, v[4:5]
+; GISEL-NEXT:    v_lshlrev_b64 v[4:5], v6, v[4:5]
+; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v7
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v7
+; GISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
 ; GISEL-NEXT:    ; implicit-def: $vgpr6
 ; GISEL-NEXT:    ; implicit-def: $vgpr4
-; GISEL-NEXT:    ; implicit-def: $vgpr8
-; GISEL-NEXT:    ; implicit-def: $vgpr7
-; GISEL-NEXT:  .LBB3_4: ; %Flow
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[16:17]
-; GISEL-NEXT:    s_cbranch_execz .LBB3_6
-; GISEL-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
+; GISEL-NEXT:  .LBB3_3: ; %Flow
+; GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
+; GISEL-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
 ; GISEL-NEXT:    v_sub_u32_e32 v0, 0x96, v6
-; GISEL-NEXT:    v_lshrrev_b32_e32 v6, v0, v4
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v6, v8, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v6, v7, 0
-; GISEL-NEXT:    v_mul_lo_u32 v8, v6, v7
-; GISEL-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], v6, v7, v[1:2]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v3, v8, s[4:5]
-; GISEL-NEXT:    v_mov_b32_e32 v1, v4
-; GISEL-NEXT:    v_mov_b32_e32 v2, v5
-; GISEL-NEXT:  .LBB3_6: ; %Flow1
+; GISEL-NEXT:    v_mov_b32_e32 v2, 0
+; GISEL-NEXT:    v_lshrrev_b32_e32 v0, v0, v4
+; GISEL-NEXT:    v_mov_b32_e32 v3, 0
+; GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GISEL-NEXT:  ; %bb.5: ; %Flow1
 ; GISEL-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GISEL-NEXT:  .LBB3_7: ; %Flow2
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[14:15]
-; GISEL-NEXT:    s_cbranch_execz .LBB3_9
-; GISEL-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; GISEL-NEXT:    v_and_b32_e32 v1, 1, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_lshlrev_b32_e32 v2, 1, v1
-; GISEL-NEXT:    v_or_b32_e32 v0, v0, v2
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 2, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 3, v1
-; GISEL-NEXT:    v_or_b32_e32 v2, v1, v2
-; GISEL-NEXT:    v_or3_b32 v0, v0, v3, v4
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 4, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 5, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v3, v4
-; GISEL-NEXT:    v_or3_b32 v0, v0, v5, v6
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 6, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 7, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v5, v6
-; GISEL-NEXT:    v_or3_b32 v0, v0, v7, v8
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 8, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 9, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v7, v8
-; GISEL-NEXT:    v_or3_b32 v0, v0, v9, v10
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 10, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 11, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v9, v10
-; GISEL-NEXT:    v_or3_b32 v0, v0, v11, v12
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 12, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 13, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v11, v12
-; GISEL-NEXT:    v_or3_b32 v0, v0, v13, v14
-; GISEL-NEXT:    v_lshlrev_b32_e32 v15, 14, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v16, 15, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v13, v14
-; GISEL-NEXT:    v_or3_b32 v0, v0, v15, v16
-; GISEL-NEXT:    v_lshlrev_b32_e32 v17, 16, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v18, 17, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v15, v16
-; GISEL-NEXT:    v_or3_b32 v0, v0, v17, v18
-; GISEL-NEXT:    v_lshlrev_b32_e32 v19, 18, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 19, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v17, v18
-; GISEL-NEXT:    v_or3_b32 v0, v0, v19, v3
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 20, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 21, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v19, v3
-; GISEL-NEXT:    v_or3_b32 v0, v0, v4, v5
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 22, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 23, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v4, v5
-; GISEL-NEXT:    v_or3_b32 v0, v0, v6, v7
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 24, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 25, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v6, v7
-; GISEL-NEXT:    v_or3_b32 v0, v0, v8, v9
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 26, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 27, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v8, v9
-; GISEL-NEXT:    v_or3_b32 v0, v0, v10, v11
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 28, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 29, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v10, v11
-; GISEL-NEXT:    v_or3_b32 v0, v0, v12, v13
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 30, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v1, 31, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v12, v13
-; GISEL-NEXT:    v_or3_b32 v0, v0, v14, v1
-; GISEL-NEXT:    v_or3_b32 v1, v2, v14, v1
-; GISEL-NEXT:    v_add_u32_e32 v3, 0x80000000, v1
-; GISEL-NEXT:    v_mov_b32_e32 v2, v1
-; GISEL-NEXT:  .LBB3_9: ; %Flow3
+; GISEL-NEXT:  .LBB3_6: ; %fp-to-i-cleanup
 ; GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GISEL-NEXT:  .LBB3_10: ; %fp-to-i-cleanup
-; GISEL-NEXT:    s_or_b64 exec, exec, s[12:13]
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
   %cvt = fptoui float %x to i128
   ret i128 %cvt
@@ -1363,106 +722,83 @@ define i128 @fptosi_bf16_to_i128(bfloat %x) {
 ; SDAG:       ; %bb.0: ; %fp-to-i-entry
 ; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SDAG-NEXT:    v_mov_b32_e32 v4, v0
-; SDAG-NEXT:    v_lshrrev_b16_e32 v7, 7, v4
+; SDAG-NEXT:    v_lshrrev_b16_e32 v8, 7, v4
 ; SDAG-NEXT:    s_movk_i32 s4, 0x7e
 ; SDAG-NEXT:    v_mov_b32_e32 v0, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v1, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v3, 0
-; SDAG-NEXT:    v_cmp_gt_u16_sdwa s[4:5], v7, s4 src0_sel:BYTE_0 src1_sel:DWORD
-; SDAG-NEXT:    s_and_saveexec_b64 s[8:9], s[4:5]
-; SDAG-NEXT:    s_cbranch_execz .LBB6_10
-; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; SDAG-NEXT:    s_movk_i32 s4, 0xff01
-; SDAG-NEXT:    v_add_u16_sdwa v0, v7, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; SDAG-NEXT:    s_movk_i32 s4, 0xff7f
-; SDAG-NEXT:    v_cmp_lt_i16_e32 vcc, -1, v4
-; SDAG-NEXT:    v_cmp_lt_u16_e64 s[4:5], s4, v0
-; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
-; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
+; SDAG-NEXT:    v_cmp_gt_u16_sdwa s[4:5], v8, s4 src0_sel:BYTE_0 src1_sel:DWORD
 ; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; SDAG-NEXT:    s_xor_b64 s[10:11], exec, s[6:7]
-; SDAG-NEXT:    s_cbranch_execz .LBB6_7
-; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
+; SDAG-NEXT:    s_cbranch_execz .LBB6_6
+; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
+; SDAG-NEXT:    v_ashrrev_i16_e32 v0, 15, v4
+; SDAG-NEXT:    v_bfe_i32 v7, v0, 0, 16
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x7f, v4
-; SDAG-NEXT:    s_movk_i32 s4, 0x85
-; SDAG-NEXT:    s_mov_b32 s6, 0
-; SDAG-NEXT:    v_cndmask_b32_e64 v6, -1, 0, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v5, -1, 1, vcc
+; SDAG-NEXT:    s_movk_i32 s5, 0x85
+; SDAG-NEXT:    s_mov_b32 s4, 0
+; SDAG-NEXT:    v_ashrrev_i32_e32 v6, 31, v7
+; SDAG-NEXT:    v_or_b32_e32 v5, 1, v7
 ; SDAG-NEXT:    v_or_b32_e32 v4, 0x80, v0
-; SDAG-NEXT:    v_cmp_gt_u16_sdwa s[4:5], v7, s4 src0_sel:BYTE_0 src1_sel:DWORD
+; SDAG-NEXT:    v_cmp_gt_u16_sdwa s[8:9], v8, s5 src0_sel:BYTE_0 src1_sel:DWORD
 ; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
 ; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
-; SDAG-NEXT:    s_and_saveexec_b64 s[12:13], s[4:5]
-; SDAG-NEXT:    s_xor_b64 s[12:13], exec, s[12:13]
-; SDAG-NEXT:    s_cbranch_execz .LBB6_4
-; SDAG-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
-; SDAG-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; SDAG-NEXT:    v_add_co_u32_e64 v9, s[4:5], -1, v0
-; SDAG-NEXT:    s_movk_i32 s4, 0xff7a
-; SDAG-NEXT:    v_add_u16_sdwa v10, v7, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; SDAG-NEXT:    s_and_saveexec_b64 s[10:11], s[8:9]
+; SDAG-NEXT:    s_xor_b64 s[8:9], exec, s[10:11]
+; SDAG-NEXT:    s_cbranch_execz .LBB6_3
+; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
+; SDAG-NEXT:    s_movk_i32 s5, 0xff7a
+; SDAG-NEXT:    v_add_u16_sdwa v10, v8, s5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0xffff, v4
-; SDAG-NEXT:    v_mov_b32_e32 v1, s6
+; SDAG-NEXT:    v_mov_b32_e32 v1, s4
 ; SDAG-NEXT:    v_sub_u32_e32 v2, 64, v10
 ; SDAG-NEXT:    v_lshrrev_b64 v[3:4], v2, v[0:1]
 ; SDAG-NEXT:    v_subrev_u32_e32 v2, 64, v10
-; SDAG-NEXT:    v_lshlrev_b64 v[7:8], v2, v[0:1]
-; SDAG-NEXT:    v_cmp_gt_u16_e64 s[4:5], 64, v10
-; SDAG-NEXT:    v_cndmask_b32_e64 v4, v8, v4, s[4:5]
-; SDAG-NEXT:    v_cmp_ne_u16_e64 s[6:7], 0, v10
-; SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, v4, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v7, v7, v3, s[4:5]
+; SDAG-NEXT:    v_lshlrev_b64 v[8:9], v2, v[0:1]
+; SDAG-NEXT:    v_cmp_gt_u16_e32 vcc, 64, v10
+; SDAG-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
+; SDAG-NEXT:    v_cmp_ne_u16_e64 s[4:5], 0, v10
+; SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, v4, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e32 v8, v8, v3, vcc
 ; SDAG-NEXT:    v_lshlrev_b64 v[3:4], v10, v[0:1]
-; SDAG-NEXT:    v_cndmask_b32_e64 v7, 0, v7, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v10, 0, v3, s[4:5]
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v10, v5, 0
+; SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e32 v10, 0, v3, vcc
+; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v10, v5, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_cndmask_b32_e64 v13, 0, v4, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e32 v13, 0, v4, vcc
 ; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v13, v5, v[1:2]
-; SDAG-NEXT:    v_mul_lo_u32 v11, v6, v7
-; SDAG-NEXT:    v_mul_lo_u32 v12, v5, v8
-; SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[6:7], v5, v7, 0
+; SDAG-NEXT:    v_mul_lo_u32 v11, v6, v8
+; SDAG-NEXT:    v_mul_lo_u32 v12, v5, v9
 ; SDAG-NEXT:    v_mov_b32_e32 v1, v3
 ; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v10, v6, v[1:2]
-; SDAG-NEXT:    v_add3_u32 v8, v8, v12, v11
-; SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v9, v10, v[7:8]
-; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v4, v2
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, s[4:5]
-; SDAG-NEXT:    v_mul_lo_u32 v5, v9, v13
-; SDAG-NEXT:    v_mul_lo_u32 v9, v9, v10
+; SDAG-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v5, v8, 0
+; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v4, v2
+; SDAG-NEXT:    v_add3_u32 v9, v9, v12, v11
+; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, vcc
+; SDAG-NEXT:    v_mad_u64_u32 v[8:9], s[4:5], v7, v10, v[8:9]
+; SDAG-NEXT:    v_mul_lo_u32 v5, v7, v13
+; SDAG-NEXT:    v_mul_lo_u32 v7, v7, v10
 ; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v13, v6, v[2:3]
-; SDAG-NEXT:    v_add3_u32 v4, v9, v8, v5
-; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v2, v7
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v3, v4, s[4:5]
-; SDAG-NEXT:    ; implicit-def: $vgpr7
+; SDAG-NEXT:    v_add3_u32 v4, v7, v9, v5
+; SDAG-NEXT:    v_add_co_u32_e32 v2, vcc, v2, v8
+; SDAG-NEXT:    v_addc_co_u32_e32 v3, vcc, v3, v4, vcc
+; SDAG-NEXT:    ; implicit-def: $vgpr8
 ; SDAG-NEXT:    ; implicit-def: $vgpr4
 ; SDAG-NEXT:    ; implicit-def: $vgpr5
-; SDAG-NEXT:  .LBB6_4: ; %Flow
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[12:13]
-; SDAG-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
-; SDAG-NEXT:    s_movk_i32 s6, 0x86
-; SDAG-NEXT:    v_sub_u16_sdwa v0, s6, v7 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
+; SDAG-NEXT:  .LBB6_3: ; %Flow
+; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[8:9]
+; SDAG-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
+; SDAG-NEXT:    s_movk_i32 s8, 0x86
+; SDAG-NEXT:    v_sub_u16_sdwa v0, s8, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
 ; SDAG-NEXT:    v_lshrrev_b16_e32 v0, v0, v4
 ; SDAG-NEXT:    v_mul_hi_i32_i24_e32 v1, v0, v5
 ; SDAG-NEXT:    v_ashrrev_i32_e32 v2, 31, v1
 ; SDAG-NEXT:    v_mul_i32_i24_e32 v0, v0, v5
 ; SDAG-NEXT:    v_mov_b32_e32 v3, v2
-; SDAG-NEXT:  ; %bb.6: ; %Flow1
+; SDAG-NEXT:  ; %bb.5: ; %Flow1
 ; SDAG-NEXT:    s_or_b64 exec, exec, s[4:5]
-; SDAG-NEXT:  .LBB6_7: ; %Flow2
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[10:11]
-; SDAG-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; SDAG-NEXT:    v_bfrev_b32_e32 v0, 1
-; SDAG-NEXT:    v_bfrev_b32_e32 v1, -2
-; SDAG-NEXT:    v_cndmask_b32_e32 v2, v0, v1, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; SDAG-NEXT:    v_mov_b32_e32 v3, v2
-; SDAG-NEXT:    v_mov_b32_e32 v0, v1
-; SDAG-NEXT:    v_mov_b32_e32 v2, v1
-; SDAG-NEXT:  ; %bb.9: ; %Flow3
-; SDAG-NEXT:    s_or_b64 exec, exec, s[4:5]
-; SDAG-NEXT:  .LBB6_10: ; %fp-to-i-cleanup
-; SDAG-NEXT:    s_or_b64 exec, exec, s[8:9]
+; SDAG-NEXT:  .LBB6_6: ; %fp-to-i-cleanup
+; SDAG-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-LABEL: fptosi_bf16_to_i128:
@@ -1478,23 +814,13 @@ define i128 @fptosi_bf16_to_i128(bfloat %x) {
 ; GISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GISEL-NEXT:    v_mov_b32_e32 v3, s7
-; GISEL-NEXT:    s_and_saveexec_b64 s[12:13], s[8:9]
-; GISEL-NEXT:    s_cbranch_execz .LBB6_10
-; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; GISEL-NEXT:    v_mov_b32_e32 v0, 0xffffff01
-; GISEL-NEXT:    v_add_u16_sdwa v0, v6, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GISEL-NEXT:    v_mov_b32_e32 v1, 0xffffff80
-; GISEL-NEXT:    v_cmp_lt_i16_e32 vcc, -1, v4
-; GISEL-NEXT:    v_cmp_ge_u16_e64 s[4:5], v0, v1
-; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
-; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; GISEL-NEXT:    s_xor_b64 s[14:15], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB6_7
-; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
-; GISEL-NEXT:    s_xor_b64 s[4:5], vcc, -1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[4:5]
+; GISEL-NEXT:    s_and_saveexec_b64 s[10:11], s[8:9]
+; GISEL-NEXT:    s_cbranch_execz .LBB6_6
+; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
+; GISEL-NEXT:    v_cmp_ge_i16_e32 vcc, -1, v4
+; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
 ; GISEL-NEXT:    v_and_b32_e32 v0, 1, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
+; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; GISEL-NEXT:    v_lshlrev_b16_e32 v2, 1, v0
 ; GISEL-NEXT:    v_or_b32_e32 v1, v1, v2
 ; GISEL-NEXT:    v_lshlrev_b16_e32 v3, 2, v0
@@ -1552,43 +878,43 @@ define i128 @fptosi_bf16_to_i128(bfloat %x) {
 ; GISEL-NEXT:    v_cmp_ge_u16_sdwa s[4:5], v6, v0 src0_sel:BYTE_0 src1_sel:DWORD
 ; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
 ; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; GISEL-NEXT:    s_xor_b64 s[16:17], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB6_4
-; GISEL-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
+; GISEL-NEXT:    s_xor_b64 s[12:13], exec, s[6:7]
+; GISEL-NEXT:    s_cbranch_execz .LBB6_3
+; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0xffffff7a
 ; GISEL-NEXT:    v_add_u16_sdwa v2, v6, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GISEL-NEXT:    v_and_b32_e32 v4, 0xffff, v4
 ; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v2, v[4:5]
-; GISEL-NEXT:    v_cmp_gt_u32_e64 s[4:5], 64, v2
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, v0, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, v1, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v11, v8, 0
+; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v2
+; GISEL-NEXT:    v_cndmask_b32_e32 v11, 0, v0, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v12, 0, v1, vcc
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v11, v8, 0
 ; GISEL-NEXT:    v_add_u32_e32 v3, 0xffffffc0, v2
 ; GISEL-NEXT:    v_sub_u32_e32 v6, 64, v2
 ; GISEL-NEXT:    v_lshrrev_b64 v[9:10], v6, v[4:5]
 ; GISEL-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v12, v8, v[0:1]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v9, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], 0, v2
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, v3, 0, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v11, v7, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v9, v7, v[5:6]
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v12, v8, v[0:1]
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v3, v9, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e64 s[4:5], 0, v2
+; GISEL-NEXT:    v_cndmask_b32_e64 v9, v3, 0, s[4:5]
+; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v11, v7, 0
+; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[6:7], v9, v7, v[5:6]
 ; GISEL-NEXT:    v_mul_lo_u32 v13, v12, v8
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v11, v8, v[1:2]
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v11, v8, v[1:2]
 ; GISEL-NEXT:    v_mul_lo_u32 v11, v11, v8
-; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[10:11], v12, v7, v[5:6]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[10:11], v3, v11, s[10:11]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v13, s[8:9]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v9, v8, v[3:4]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v4, v10, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, v3, 0, s[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[8:9], v12, v7, v[5:6]
+; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v11, s[8:9]
+; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[6:7], v3, v13, s[6:7]
+; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v9, v8, v[3:4]
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v4, v10, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v8, v3, 0, s[4:5]
 ; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v7, v[5:6]
 ; GISEL-NEXT:    ; implicit-def: $vgpr6
 ; GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GISEL-NEXT:    ; implicit-def: $vgpr7
-; GISEL-NEXT:  .LBB6_4: ; %Flow
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[16:17]
-; GISEL-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
+; GISEL-NEXT:  .LBB6_3: ; %Flow
+; GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[12:13]
+; GISEL-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0x86
 ; GISEL-NEXT:    v_sub_u16_sdwa v0, v0, v6 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
 ; GISEL-NEXT:    v_lshrrev_b16_e32 v0, v0, v4
@@ -1596,84 +922,10 @@ define i128 @fptosi_bf16_to_i128(bfloat %x) {
 ; GISEL-NEXT:    v_ashrrev_i32_e32 v2, 31, v1
 ; GISEL-NEXT:    v_mul_i32_i24_e32 v0, v0, v7
 ; GISEL-NEXT:    v_mov_b32_e32 v3, v2
-; GISEL-NEXT:  ; %bb.6: ; %Flow1
+; GISEL-NEXT:  ; %bb.5: ; %Flow1
 ; GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GISEL-NEXT:  .LBB6_7: ; %Flow2
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[14:15]
-; GISEL-NEXT:    s_cbranch_execz .LBB6_9
-; GISEL-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; GISEL-NEXT:    v_and_b32_e32 v1, 1, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_lshlrev_b32_e32 v2, 1, v1
-; GISEL-NEXT:    v_or_b32_e32 v0, v0, v2
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 2, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 3, v1
-; GISEL-NEXT:    v_or_b32_e32 v2, v1, v2
-; GISEL-NEXT:    v_or3_b32 v0, v0, v3, v4
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 4, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 5, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v3, v4
-; GISEL-NEXT:    v_or3_b32 v0, v0, v5, v6
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 6, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 7, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v5, v6
-; GISEL-NEXT:    v_or3_b32 v0, v0, v7, v8
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 8, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 9, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v7, v8
-; GISEL-NEXT:    v_or3_b32 v0, v0, v9, v10
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 10, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 11, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v9, v10
-; GISEL-NEXT:    v_or3_b32 v0, v0, v11, v12
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 12, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 13, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v11, v12
-; GISEL-NEXT:    v_or3_b32 v0, v0, v13, v14
-; GISEL-NEXT:    v_lshlrev_b32_e32 v15, 14, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v16, 15, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v13, v14
-; GISEL-NEXT:    v_or3_b32 v0, v0, v15, v16
-; GISEL-NEXT:    v_lshlrev_b32_e32 v17, 16, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v18, 17, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v15, v16
-; GISEL-NEXT:    v_or3_b32 v0, v0, v17, v18
-; GISEL-NEXT:    v_lshlrev_b32_e32 v19, 18, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 19, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v17, v18
-; GISEL-NEXT:    v_or3_b32 v0, v0, v19, v3
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 20, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 21, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v19, v3
-; GISEL-NEXT:    v_or3_b32 v0, v0, v4, v5
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 22, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 23, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v4, v5
-; GISEL-NEXT:    v_or3_b32 v0, v0, v6, v7
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 24, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 25, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v6, v7
-; GISEL-NEXT:    v_or3_b32 v0, v0, v8, v9
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 26, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 27, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v8, v9
-; GISEL-NEXT:    v_or3_b32 v0, v0, v10, v11
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 28, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 29, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v10, v11
-; GISEL-NEXT:    v_or3_b32 v0, v0, v12, v13
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 30, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v1, 31, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v12, v13
-; GISEL-NEXT:    v_or3_b32 v0, v0, v14, v1
-; GISEL-NEXT:    v_or3_b32 v1, v2, v14, v1
-; GISEL-NEXT:    v_add_u32_e32 v3, 0x80000000, v1
-; GISEL-NEXT:    v_mov_b32_e32 v2, v1
-; GISEL-NEXT:  .LBB6_9: ; %Flow3
-; GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GISEL-NEXT:  .LBB6_10: ; %fp-to-i-cleanup
-; GISEL-NEXT:    s_or_b64 exec, exec, s[12:13]
+; GISEL-NEXT:  .LBB6_6: ; %fp-to-i-cleanup
+; GISEL-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
   %cvt = fptosi bfloat %x to i128
   ret i128 %cvt
@@ -1684,317 +936,118 @@ define i128 @fptoui_bf16_to_i128(bfloat %x) {
 ; SDAG:       ; %bb.0: ; %fp-to-i-entry
 ; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SDAG-NEXT:    v_mov_b32_e32 v4, v0
-; SDAG-NEXT:    v_lshrrev_b16_e32 v7, 7, v4
+; SDAG-NEXT:    v_lshrrev_b16_e32 v5, 7, v4
 ; SDAG-NEXT:    s_movk_i32 s4, 0x7e
 ; SDAG-NEXT:    v_mov_b32_e32 v0, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v1, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v3, 0
-; SDAG-NEXT:    v_cmp_gt_u16_sdwa s[4:5], v7, s4 src0_sel:BYTE_0 src1_sel:DWORD
-; SDAG-NEXT:    s_and_saveexec_b64 s[8:9], s[4:5]
-; SDAG-NEXT:    s_cbranch_execz .LBB7_10
-; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; SDAG-NEXT:    s_movk_i32 s4, 0xff01
-; SDAG-NEXT:    v_add_u16_sdwa v0, v7, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; SDAG-NEXT:    s_movk_i32 s4, 0xff7f
-; SDAG-NEXT:    v_cmp_lt_i16_e32 vcc, -1, v4
-; SDAG-NEXT:    v_cmp_lt_u16_e64 s[4:5], s4, v0
-; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
-; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
+; SDAG-NEXT:    v_cmp_gt_u16_sdwa s[4:5], v5, s4 src0_sel:BYTE_0 src1_sel:DWORD
 ; SDAG-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; SDAG-NEXT:    s_xor_b64 s[10:11], exec, s[6:7]
-; SDAG-NEXT:    s_cbranch_execz .LBB7_7
-; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
+; SDAG-NEXT:    s_cbranch_execz .LBB7_6
+; SDAG-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x7f, v4
 ; SDAG-NEXT:    s_movk_i32 s4, 0x85
-; SDAG-NEXT:    s_mov_b32 s6, 0
-; SDAG-NEXT:    v_cndmask_b32_e64 v6, -1, 0, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v5, -1, 1, vcc
 ; SDAG-NEXT:    v_or_b32_e32 v4, 0x80, v0
-; SDAG-NEXT:    v_cmp_gt_u16_sdwa s[4:5], v7, s4 src0_sel:BYTE_0 src1_sel:DWORD
+; SDAG-NEXT:    v_cmp_gt_u16_sdwa s[4:5], v5, s4 src0_sel:BYTE_0 src1_sel:DWORD
 ; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1
 ; SDAG-NEXT:    ; implicit-def: $vgpr2_vgpr3
-; SDAG-NEXT:    s_and_saveexec_b64 s[12:13], s[4:5]
-; SDAG-NEXT:    s_xor_b64 s[12:13], exec, s[12:13]
-; SDAG-NEXT:    s_cbranch_execz .LBB7_4
-; SDAG-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
-; SDAG-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; SDAG-NEXT:    v_add_co_u32_e64 v9, s[4:5], -1, v0
+; SDAG-NEXT:    s_and_saveexec_b64 s[8:9], s[4:5]
+; SDAG-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
+; SDAG-NEXT:    s_cbranch_execz .LBB7_3
+; SDAG-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
 ; SDAG-NEXT:    s_movk_i32 s4, 0xff7a
-; SDAG-NEXT:    v_add_u16_sdwa v10, v7, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; SDAG-NEXT:    v_add_u16_sdwa v6, v5, s4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; SDAG-NEXT:    s_mov_b32 s4, 0
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0xffff, v4
-; SDAG-NEXT:    v_mov_b32_e32 v1, s6
-; SDAG-NEXT:    v_sub_u32_e32 v2, 64, v10
-; SDAG-NEXT:    v_lshrrev_b64 v[3:4], v2, v[0:1]
-; SDAG-NEXT:    v_subrev_u32_e32 v2, 64, v10
-; SDAG-NEXT:    v_lshlrev_b64 v[7:8], v2, v[0:1]
-; SDAG-NEXT:    v_cmp_gt_u16_e64 s[4:5], 64, v10
-; SDAG-NEXT:    v_cndmask_b32_e64 v4, v8, v4, s[4:5]
-; SDAG-NEXT:    v_cmp_ne_u16_e64 s[6:7], 0, v10
-; SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, v4, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v7, v7, v3, s[4:5]
-; SDAG-NEXT:    v_lshlrev_b64 v[3:4], v10, v[0:1]
-; SDAG-NEXT:    v_cndmask_b32_e64 v7, 0, v7, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v10, 0, v3, s[4:5]
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v10, v5, 0
-; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_cndmask_b32_e64 v13, 0, v4, s[4:5]
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v13, v5, v[1:2]
-; SDAG-NEXT:    v_mul_lo_u32 v11, v6, v7
-; SDAG-NEXT:    v_mul_lo_u32 v12, v5, v8
-; SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[6:7], v5, v7, 0
-; SDAG-NEXT:    v_mov_b32_e32 v1, v3
-; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v10, v6, v[1:2]
-; SDAG-NEXT:    v_add3_u32 v8, v8, v12, v11
-; SDAG-NEXT:    v_mad_u64_u32 v[7:8], s[4:5], v9, v10, v[7:8]
-; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v4, v2
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, s[4:5]
-; SDAG-NEXT:    v_mul_lo_u32 v5, v9, v13
-; SDAG-NEXT:    v_mul_lo_u32 v9, v9, v10
-; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v13, v6, v[2:3]
-; SDAG-NEXT:    v_add3_u32 v4, v9, v8, v5
-; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v2, v7
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v3, v4, s[4:5]
-; SDAG-NEXT:    ; implicit-def: $vgpr7
-; SDAG-NEXT:    ; implicit-def: $vgpr4
+; SDAG-NEXT:    v_mov_b32_e32 v1, s4
+; SDAG-NEXT:    v_sub_u32_e32 v2, 64, v6
+; SDAG-NEXT:    v_subrev_u32_e32 v4, 64, v6
+; SDAG-NEXT:    v_lshrrev_b64 v[2:3], v2, v[0:1]
+; SDAG-NEXT:    v_lshlrev_b64 v[4:5], v4, v[0:1]
+; SDAG-NEXT:    v_cmp_gt_u16_e32 vcc, 64, v6
+; SDAG-NEXT:    v_lshlrev_b64 v[0:1], v6, v[0:1]
+; SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
+; SDAG-NEXT:    v_cmp_ne_u16_e64 s[4:5], 0, v6
+; SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; SDAG-NEXT:    v_cndmask_b32_e64 v3, 0, v3, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
+; SDAG-NEXT:    v_cndmask_b32_e32 v0, 0, v0, vcc
 ; SDAG-NEXT:    ; implicit-def: $vgpr5
-; SDAG-NEXT:  .LBB7_4: ; %Flow
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[12:13]
-; SDAG-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
-; SDAG-NEXT:    s_movk_i32 s6, 0x86
-; SDAG-NEXT:    v_sub_u16_sdwa v0, s6, v7 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
+; SDAG-NEXT:    ; implicit-def: $vgpr4
+; SDAG-NEXT:  .LBB7_3: ; %Flow
+; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[8:9]
+; SDAG-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
+; SDAG-NEXT:    s_movk_i32 s8, 0x86
+; SDAG-NEXT:    v_sub_u16_sdwa v0, s8, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
+; SDAG-NEXT:    v_mov_b32_e32 v2, 0
 ; SDAG-NEXT:    v_lshrrev_b16_e32 v0, v0, v4
-; SDAG-NEXT:    v_mul_hi_i32_i24_e32 v1, v0, v5
-; SDAG-NEXT:    v_ashrrev_i32_e32 v2, 31, v1
-; SDAG-NEXT:    v_mul_i32_i24_e32 v0, v0, v5
-; SDAG-NEXT:    v_mov_b32_e32 v3, v2
-; SDAG-NEXT:  ; %bb.6: ; %Flow1
+; SDAG-NEXT:    v_mov_b32_e32 v3, 0
+; SDAG-NEXT:    v_mov_b32_e32 v1, 0
+; SDAG-NEXT:  ; %bb.5: ; %Flow1
 ; SDAG-NEXT:    s_or_b64 exec, exec, s[4:5]
-; SDAG-NEXT:  .LBB7_7: ; %Flow2
-; SDAG-NEXT:    s_andn2_saveexec_b64 s[4:5], s[10:11]
-; SDAG-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; SDAG-NEXT:    v_bfrev_b32_e32 v0, 1
-; SDAG-NEXT:    v_bfrev_b32_e32 v1, -2
-; SDAG-NEXT:    v_cndmask_b32_e32 v2, v0, v1, vcc
-; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; SDAG-NEXT:    v_mov_b32_e32 v3, v2
-; SDAG-NEXT:    v_mov_b32_e32 v0, v1
-; SDAG-NEXT:    v_mov_b32_e32 v2, v1
-; SDAG-NEXT:  ; %bb.9: ; %Flow3
-; SDAG-NEXT:    s_or_b64 exec, exec, s[4:5]
-; SDAG-NEXT:  .LBB7_10: ; %fp-to-i-cleanup
-; SDAG-NEXT:    s_or_b64 exec, exec, s[8:9]
+; SDAG-NEXT:  .LBB7_6: ; %fp-to-i-cleanup
+; SDAG-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-LABEL: fptoui_bf16_to_i128:
 ; GISEL:       ; %bb.0: ; %fp-to-i-entry
 ; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-NEXT:    v_mov_b32_e32 v4, v0
-; GISEL-NEXT:    v_lshrrev_b16_e32 v6, 7, v4
+; GISEL-NEXT:    v_lshrrev_b16_e32 v5, 7, v4
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0x7f
 ; GISEL-NEXT:    s_mov_b64 s[4:5], 0
-; GISEL-NEXT:    v_cmp_ge_u16_sdwa s[8:9], v6, v0 src0_sel:BYTE_0 src1_sel:DWORD
+; GISEL-NEXT:    v_cmp_ge_u16_sdwa s[8:9], v5, v0 src0_sel:BYTE_0 src1_sel:DWORD
 ; GISEL-NEXT:    s_mov_b64 s[6:7], s[4:5]
 ; GISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GISEL-NEXT:    v_mov_b32_e32 v3, s7
-; GISEL-NEXT:    s_and_saveexec_b64 s[12:13], s[8:9]
-; GISEL-NEXT:    s_cbranch_execz .LBB7_10
-; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.saturate
-; GISEL-NEXT:    v_mov_b32_e32 v0, 0xffffff01
-; GISEL-NEXT:    v_add_u16_sdwa v0, v6, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GISEL-NEXT:    v_mov_b32_e32 v1, 0xffffff80
-; GISEL-NEXT:    v_cmp_lt_i16_e32 vcc, -1, v4
-; GISEL-NEXT:    v_cmp_ge_u16_e64 s[4:5], v0, v1
-; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
-; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; GISEL-NEXT:    s_xor_b64 s[14:15], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB7_7
-; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-check.exp.size
-; GISEL-NEXT:    s_xor_b64 s[4:5], vcc, -1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[4:5]
-; GISEL-NEXT:    v_and_b32_e32 v0, 1, v0
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[4:5]
-; GISEL-NEXT:    v_lshlrev_b16_e32 v2, 1, v0
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v2
-; GISEL-NEXT:    v_lshlrev_b16_e32 v3, 2, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v0, v2
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v3
-; GISEL-NEXT:    v_lshlrev_b16_e32 v7, 3, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v3
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v7
-; GISEL-NEXT:    v_lshlrev_b16_e32 v8, 4, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v7
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v8
-; GISEL-NEXT:    v_lshlrev_b16_e32 v9, 5, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v8
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v9
-; GISEL-NEXT:    v_lshlrev_b16_e32 v10, 6, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v9
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v10
-; GISEL-NEXT:    v_lshlrev_b16_e32 v11, 7, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v10
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v11
-; GISEL-NEXT:    v_lshlrev_b16_e32 v12, 8, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v11
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v12
-; GISEL-NEXT:    v_lshlrev_b16_e32 v13, 9, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v12
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v13
-; GISEL-NEXT:    v_lshlrev_b16_e32 v14, 10, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v13
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v14
-; GISEL-NEXT:    v_lshlrev_b16_e32 v15, 11, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v14
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v15
-; GISEL-NEXT:    v_lshlrev_b16_e32 v16, 12, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v15
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v16
-; GISEL-NEXT:    v_lshlrev_b16_e32 v17, 13, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v16
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v17
-; GISEL-NEXT:    v_lshlrev_b16_e32 v18, 14, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v17
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v18
-; GISEL-NEXT:    v_lshlrev_b16_e32 v0, 15, v0
-; GISEL-NEXT:    v_or_b32_e32 v2, v2, v18
-; GISEL-NEXT:    v_or_b32_e32 v1, v1, v0
-; GISEL-NEXT:    v_or_b32_e32 v0, v2, v0
-; GISEL-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GISEL-NEXT:    v_lshlrev_b32_e32 v2, 16, v0
-; GISEL-NEXT:    v_lshl_or_b32 v8, v0, 16, v0
+; GISEL-NEXT:    s_and_saveexec_b64 s[4:5], s[8:9]
+; GISEL-NEXT:    s_cbranch_execz .LBB7_6
+; GISEL-NEXT:  ; %bb.1: ; %fp-to-i-if-check.exp.size
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0x7f, v4
-; GISEL-NEXT:    v_and_b32_e32 v1, 0xffff, v1
 ; GISEL-NEXT:    v_or_b32_e32 v4, 0x80, v0
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0x86
-; GISEL-NEXT:    v_mov_b32_e32 v5, 0
-; GISEL-NEXT:    v_or3_b32 v7, v1, v2, 1
-; GISEL-NEXT:    v_cmp_ge_u16_sdwa s[4:5], v6, v0 src0_sel:BYTE_0 src1_sel:DWORD
+; GISEL-NEXT:    v_cmp_ge_u16_sdwa s[6:7], v5, v0 src0_sel:BYTE_0 src1_sel:DWORD
 ; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
-; GISEL-NEXT:    s_and_saveexec_b64 s[6:7], s[4:5]
-; GISEL-NEXT:    s_xor_b64 s[16:17], exec, s[6:7]
-; GISEL-NEXT:    s_cbranch_execz .LBB7_4
-; GISEL-NEXT:  ; %bb.3: ; %fp-to-i-if-exp.large
+; GISEL-NEXT:    s_and_saveexec_b64 s[8:9], s[6:7]
+; GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[8:9]
+; GISEL-NEXT:    s_cbranch_execz .LBB7_3
+; GISEL-NEXT:  ; %bb.2: ; %fp-to-i-if-exp.large
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0xffffff7a
-; GISEL-NEXT:    v_add_u16_sdwa v2, v6, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
-; GISEL-NEXT:    v_and_b32_e32 v4, 0xffff, v4
-; GISEL-NEXT:    v_lshlrev_b64 v[0:1], v2, v[4:5]
-; GISEL-NEXT:    v_cmp_gt_u32_e64 s[4:5], 64, v2
-; GISEL-NEXT:    v_cndmask_b32_e64 v11, 0, v0, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v12, 0, v1, s[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v11, v8, 0
-; GISEL-NEXT:    v_add_u32_e32 v3, 0xffffffc0, v2
-; GISEL-NEXT:    v_sub_u32_e32 v6, 64, v2
-; GISEL-NEXT:    v_lshrrev_b64 v[9:10], v6, v[4:5]
-; GISEL-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v12, v8, v[0:1]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, v9, s[4:5]
-; GISEL-NEXT:    v_cmp_eq_u32_e64 s[6:7], 0, v2
-; GISEL-NEXT:    v_cndmask_b32_e64 v9, v3, 0, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[0:1], s[8:9], v11, v7, 0
-; GISEL-NEXT:    v_mad_u64_u32 v[2:3], s[8:9], v9, v7, v[5:6]
-; GISEL-NEXT:    v_mul_lo_u32 v13, v12, v8
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v11, v8, v[1:2]
-; GISEL-NEXT:    v_mul_lo_u32 v11, v11, v8
-; GISEL-NEXT:    v_mad_u64_u32 v[1:2], s[10:11], v12, v7, v[5:6]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[10:11], v3, v11, s[10:11]
-; GISEL-NEXT:    v_addc_co_u32_e64 v3, s[8:9], v3, v13, s[8:9]
-; GISEL-NEXT:    v_mad_u64_u32 v[5:6], s[8:9], v9, v8, v[3:4]
-; GISEL-NEXT:    v_cndmask_b32_e64 v3, v4, v10, s[4:5]
-; GISEL-NEXT:    v_cndmask_b32_e64 v8, v3, 0, s[6:7]
-; GISEL-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v8, v7, v[5:6]
-; GISEL-NEXT:    ; implicit-def: $vgpr6
+; GISEL-NEXT:    v_add_u16_sdwa v8, v5, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GISEL-NEXT:    v_and_b32_e32 v0, 0xffff, v4
+; GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GISEL-NEXT:    v_add_u32_e32 v6, 0xffffffc0, v8
+; GISEL-NEXT:    v_sub_u32_e32 v4, 64, v8
+; GISEL-NEXT:    v_lshlrev_b64 v[2:3], v8, v[0:1]
+; GISEL-NEXT:    v_lshrrev_b64 v[4:5], v4, v[0:1]
+; GISEL-NEXT:    v_lshlrev_b64 v[6:7], v6, v[0:1]
+; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v8
+; GISEL-NEXT:    v_cndmask_b32_e32 v0, 0, v2, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v1, 0, v3, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v2, v6, v4, vcc
+; GISEL-NEXT:    v_cndmask_b32_e32 v3, v7, v5, vcc
+; GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v8
+; GISEL-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GISEL-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
+; GISEL-NEXT:    ; implicit-def: $vgpr5
 ; GISEL-NEXT:    ; implicit-def: $vgpr4
-; GISEL-NEXT:    ; implicit-def: $vgpr7
-; GISEL-NEXT:  .LBB7_4: ; %Flow
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[16:17]
-; GISEL-NEXT:  ; %bb.5: ; %fp-to-i-if-exp.small
+; GISEL-NEXT:  .LBB7_3: ; %Flow
+; GISEL-NEXT:    s_andn2_saveexec_b64 s[6:7], s[6:7]
+; GISEL-NEXT:  ; %bb.4: ; %fp-to-i-if-exp.small
 ; GISEL-NEXT:    v_mov_b32_e32 v0, 0x86
-; GISEL-NEXT:    v_sub_u16_sdwa v0, v0, v6 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
+; GISEL-NEXT:    v_sub_u16_sdwa v0, v0, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
+; GISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GISEL-NEXT:    v_lshrrev_b16_e32 v0, v0, v4
-; GISEL-NEXT:    v_mul_hi_i32_i24_e32 v1, v0, v7
-; GISEL-NEXT:    v_ashrrev_i32_e32 v2, 31, v1
-; GISEL-NEXT:    v_mul_i32_i24_e32 v0, v0, v7
-; GISEL-NEXT:    v_mov_b32_e32 v3, v2
-; GISEL-NEXT:  ; %bb.6: ; %Flow1
+; GISEL-NEXT:    v_mov_b32_e32 v3, 0
+; GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GISEL-NEXT:  ; %bb.5: ; %Flow1
+; GISEL-NEXT:    s_or_b64 exec, exec, s[6:7]
+; GISEL-NEXT:  .LBB7_6: ; %fp-to-i-cleanup
 ; GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GISEL-NEXT:  .LBB7_7: ; %Flow2
-; GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[14:15]
-; GISEL-NEXT:    s_cbranch_execz .LBB7_9
-; GISEL-NEXT:  ; %bb.8: ; %fp-to-i-if-saturate
-; GISEL-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; GISEL-NEXT:    v_and_b32_e32 v1, 1, v1
-; GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; GISEL-NEXT:    v_lshlrev_b32_e32 v2, 1, v1
-; GISEL-NEXT:    v_or_b32_e32 v0, v0, v2
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 2, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 3, v1
-; GISEL-NEXT:    v_or_b32_e32 v2, v1, v2
-; GISEL-NEXT:    v_or3_b32 v0, v0, v3, v4
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 4, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 5, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v3, v4
-; GISEL-NEXT:    v_or3_b32 v0, v0, v5, v6
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 6, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 7, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v5, v6
-; GISEL-NEXT:    v_or3_b32 v0, v0, v7, v8
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 8, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 9, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v7, v8
-; GISEL-NEXT:    v_or3_b32 v0, v0, v9, v10
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 10, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 11, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v9, v10
-; GISEL-NEXT:    v_or3_b32 v0, v0, v11, v12
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 12, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 13, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v11, v12
-; GISEL-NEXT:    v_or3_b32 v0, v0, v13, v14
-; GISEL-NEXT:    v_lshlrev_b32_e32 v15, 14, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v16, 15, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v13, v14
-; GISEL-NEXT:    v_or3_b32 v0, v0, v15, v16
-; GISEL-NEXT:    v_lshlrev_b32_e32 v17, 16, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v18, 17, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v15, v16
-; GISEL-NEXT:    v_or3_b32 v0, v0, v17, v18
-; GISEL-NEXT:    v_lshlrev_b32_e32 v19, 18, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v3, 19, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v17, v18
-; GISEL-NEXT:    v_or3_b32 v0, v0, v19, v3
-; GISEL-NEXT:    v_lshlrev_b32_e32 v4, 20, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v5, 21, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v19, v3
-; GISEL-NEXT:    v_or3_b32 v0, v0, v4, v5
-; GISEL-NEXT:    v_lshlrev_b32_e32 v6, 22, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v7, 23, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v4, v5
-; GISEL-NEXT:    v_or3_b32 v0, v0, v6, v7
-; GISEL-NEXT:    v_lshlrev_b32_e32 v8, 24, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v9, 25, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v6, v7
-; GISEL-NEXT:    v_or3_b32 v0, v0, v8, v9
-; GISEL-NEXT:    v_lshlrev_b32_e32 v10, 26, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v11, 27, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v8, v9
-; GISEL-NEXT:    v_or3_b32 v0, v0, v10, v11
-; GISEL-NEXT:    v_lshlrev_b32_e32 v12, 28, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v13, 29, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v10, v11
-; GISEL-NEXT:    v_or3_b32 v0, v0, v12, v13
-; GISEL-NEXT:    v_lshlrev_b32_e32 v14, 30, v1
-; GISEL-NEXT:    v_lshlrev_b32_e32 v1, 31, v1
-; GISEL-NEXT:    v_or3_b32 v2, v2, v12, v13
-; GISEL-NEXT:    v_or3_b32 v0, v0, v14, v1
-; GISEL-NEXT:    v_or3_b32 v1, v2, v14, v1
-; GISEL-NEXT:    v_add_u32_e32 v3, 0x80000000, v1
-; GISEL-NEXT:    v_mov_b32_e32 v2, v1
-; GISEL-NEXT:  .LBB7_9: ; %Flow3
-; GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GISEL-NEXT:  .LBB7_10: ; %fp-to-i-cleanup
-; GISEL-NEXT:    s_or_b64 exec, exec, s[12:13]
 ; GISEL-NEXT:    s_setpc_b64 s[30:31]
   %cvt = fptoui bfloat %x to i128
   ret i128 %cvt

--- a/llvm/test/Transforms/ExpandIRInsts/X86/expand-fp-convert-small.ll
+++ b/llvm/test/Transforms/ExpandIRInsts/X86/expand-fp-convert-small.ll
@@ -16,14 +16,7 @@ define i16 @fptosi_f16_i16(half %x) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i16 [[TMP0]], 1023
 ; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = or i16 [[TMP3]], 1024
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i16 [[BIASED_EXP]], 15
-; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_SATURATE:.*]]
-; CHECK:       [[FP_TO_I_IF_CHECK_SATURATE]]:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i16 [[BIASED_EXP]], -31
-; CHECK-NEXT:    [[TMP5:%.*]] = icmp ult i16 [[TMP4]], -16
-; CHECK-NEXT:    br i1 [[TMP5]], label %[[FP_TO_I_IF_SATURATE:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
-; CHECK:       [[FP_TO_I_IF_SATURATE]]:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP1]], i16 32767, i16 -32768
-; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
 ; CHECK:       [[FP_TO_I_IF_CHECK_EXP_SIZE]]:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i16 [[BIASED_EXP]], 25
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label %[[FP_TO_I_IF_EXP_SMALL:.*]], label %[[FP_TO_I_IF_EXP_LARGE:.*]]
@@ -38,7 +31,7 @@ define i16 @fptosi_f16_i16(half %x) {
 ; CHECK-NEXT:    [[TMP11:%.*]] = mul i16 [[TMP10]], [[SIGN]]
 ; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
 ; CHECK:       [[FP_TO_I_CLEANUP]]:
-; CHECK-NEXT:    [[TMP12:%.*]] = phi i16 [ [[SATURATED]], %[[FP_TO_I_IF_SATURATE]] ], [ [[TMP8]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP11]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
+; CHECK-NEXT:    [[TMP12:%.*]] = phi i16 [ [[TMP8]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP11]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
 ; CHECK-NEXT:    ret i16 [[TMP12]]
 ;
   %res = fptosi half %x to i16
@@ -57,14 +50,7 @@ define i16 @fptosi_f16_i16_noundef(half noundef %x) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i16 [[TMP0]], 1023
 ; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = or i16 [[TMP3]], 1024
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i16 [[BIASED_EXP]], 15
-; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_SATURATE:.*]]
-; CHECK:       [[FP_TO_I_IF_CHECK_SATURATE]]:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i16 [[BIASED_EXP]], -31
-; CHECK-NEXT:    [[TMP5:%.*]] = icmp ult i16 [[TMP4]], -16
-; CHECK-NEXT:    br i1 [[TMP5]], label %[[FP_TO_I_IF_SATURATE:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
-; CHECK:       [[FP_TO_I_IF_SATURATE]]:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP1]], i16 32767, i16 -32768
-; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
 ; CHECK:       [[FP_TO_I_IF_CHECK_EXP_SIZE]]:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i16 [[BIASED_EXP]], 25
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label %[[FP_TO_I_IF_EXP_SMALL:.*]], label %[[FP_TO_I_IF_EXP_LARGE:.*]]
@@ -79,7 +65,7 @@ define i16 @fptosi_f16_i16_noundef(half noundef %x) {
 ; CHECK-NEXT:    [[TMP11:%.*]] = mul i16 [[TMP10]], [[SIGN]]
 ; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
 ; CHECK:       [[FP_TO_I_CLEANUP]]:
-; CHECK-NEXT:    [[TMP12:%.*]] = phi i16 [ [[SATURATED]], %[[FP_TO_I_IF_SATURATE]] ], [ [[TMP8]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP11]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
+; CHECK-NEXT:    [[TMP12:%.*]] = phi i16 [ [[TMP8]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP11]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
 ; CHECK-NEXT:    ret i16 [[TMP12]]
 ;
   %res = fptosi half %x to i16
@@ -99,14 +85,7 @@ define i24 @fptosi_f16_i24(half %x) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i16 [[TMP0]], 1023
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i16 [[TMP3]], 1024
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i16 [[BIASED_EXP]], 15
-; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_SATURATE:.*]]
-; CHECK:       [[FP_TO_I_IF_CHECK_SATURATE]]:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i16 [[BIASED_EXP]], -39
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i16 [[TMP4]], -24
-; CHECK-NEXT:    br i1 [[TMP6]], label %[[FP_TO_I_IF_SATURATE:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
-; CHECK:       [[FP_TO_I_IF_SATURATE]]:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP2]], i24 8388607, i24 -8388608
-; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
 ; CHECK:       [[FP_TO_I_IF_CHECK_EXP_SIZE]]:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i16 [[BIASED_EXP]], 25
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label %[[FP_TO_I_IF_EXP_SMALL:.*]], label %[[FP_TO_I_IF_EXP_LARGE:.*]]
@@ -124,7 +103,7 @@ define i24 @fptosi_f16_i24(half %x) {
 ; CHECK-NEXT:    [[TMP12:%.*]] = mul i24 [[TMP11]], [[SIGN]]
 ; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
 ; CHECK:       [[FP_TO_I_CLEANUP]]:
-; CHECK-NEXT:    [[TMP13:%.*]] = phi i24 [ [[SATURATED]], %[[FP_TO_I_IF_SATURATE]] ], [ [[TMP9]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi i24 [ [[TMP9]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
 ; CHECK-NEXT:    ret i24 [[TMP13]]
 ;
   %res = fptosi half %x to i24
@@ -144,14 +123,7 @@ define i8 @fptosi_f16_i8(half %x) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i16 [[TMP0]], 1023
 ; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = or i16 [[TMP3]], 1024
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i16 [[BIASED_EXP]], 15
-; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_SATURATE:.*]]
-; CHECK:       [[FP_TO_I_IF_CHECK_SATURATE]]:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i16 [[BIASED_EXP]], -23
-; CHECK-NEXT:    [[TMP5:%.*]] = icmp ult i16 [[TMP4]], -8
-; CHECK-NEXT:    br i1 [[TMP5]], label %[[FP_TO_I_IF_SATURATE:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
-; CHECK:       [[FP_TO_I_IF_SATURATE]]:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP1]], i8 127, i8 -128
-; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
 ; CHECK:       [[FP_TO_I_IF_CHECK_EXP_SIZE]]:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i16 [[BIASED_EXP]], 25
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label %[[FP_TO_I_IF_EXP_SMALL:.*]], label %[[FP_TO_I_IF_EXP_LARGE:.*]]
@@ -169,7 +141,7 @@ define i8 @fptosi_f16_i8(half %x) {
 ; CHECK-NEXT:    [[TMP14:%.*]] = mul i8 [[TMP13]], [[SIGN]]
 ; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
 ; CHECK:       [[FP_TO_I_CLEANUP]]:
-; CHECK-NEXT:    [[TMP15:%.*]] = phi i8 [ [[SATURATED]], %[[FP_TO_I_IF_SATURATE]] ], [ [[TMP9]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP14]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
+; CHECK-NEXT:    [[TMP15:%.*]] = phi i8 [ [[TMP9]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP14]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
 ; CHECK-NEXT:    ret i8 [[TMP15]]
 ;
   %res = fptosi half %x to i8
@@ -182,36 +154,25 @@ define i16 @fptoui_f16_i16(half %x) {
 ; CHECK-NEXT:  [[FP_TO_I_ENTRY:.*]]:
 ; CHECK-NEXT:    [[TMP13:%.*]] = freeze half [[X]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = bitcast half [[TMP13]] to i16
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp sgt i16 [[TMP0]], -1
-; CHECK-NEXT:    [[SIGN:%.*]] = select i1 [[TMP1]], i16 1, i16 -1
 ; CHECK-NEXT:    [[TMP2:%.*]] = lshr i16 [[TMP0]], 10
 ; CHECK-NEXT:    [[BIASED_EXP:%.*]] = and i16 [[TMP2]], 31
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i16 [[TMP0]], 1023
 ; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = or i16 [[TMP3]], 1024
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i16 [[BIASED_EXP]], 15
-; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_SATURATE:.*]]
-; CHECK:       [[FP_TO_I_IF_CHECK_SATURATE]]:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i16 [[BIASED_EXP]], -31
-; CHECK-NEXT:    [[TMP5:%.*]] = icmp ult i16 [[TMP4]], -16
-; CHECK-NEXT:    br i1 [[TMP5]], label %[[FP_TO_I_IF_SATURATE:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
-; CHECK:       [[FP_TO_I_IF_SATURATE]]:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP1]], i16 32767, i16 -32768
-; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
 ; CHECK:       [[FP_TO_I_IF_CHECK_EXP_SIZE]]:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i16 [[BIASED_EXP]], 25
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label %[[FP_TO_I_IF_EXP_SMALL:.*]], label %[[FP_TO_I_IF_EXP_LARGE:.*]]
 ; CHECK:       [[FP_TO_I_IF_EXP_SMALL]]:
 ; CHECK-NEXT:    [[TMP6:%.*]] = sub i16 25, [[BIASED_EXP]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = lshr i16 [[SIGNIFICAND]], [[TMP6]]
-; CHECK-NEXT:    [[TMP8:%.*]] = mul i16 [[TMP7]], [[SIGN]]
 ; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
 ; CHECK:       [[FP_TO_I_IF_EXP_LARGE]]:
 ; CHECK-NEXT:    [[TMP9:%.*]] = add i16 [[BIASED_EXP]], -25
 ; CHECK-NEXT:    [[TMP10:%.*]] = shl i16 [[SIGNIFICAND]], [[TMP9]]
-; CHECK-NEXT:    [[TMP11:%.*]] = mul i16 [[TMP10]], [[SIGN]]
 ; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
 ; CHECK:       [[FP_TO_I_CLEANUP]]:
-; CHECK-NEXT:    [[TMP12:%.*]] = phi i16 [ [[SATURATED]], %[[FP_TO_I_IF_SATURATE]] ], [ [[TMP8]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP11]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
+; CHECK-NEXT:    [[TMP12:%.*]] = phi i16 [ [[TMP7]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP10]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
 ; CHECK-NEXT:    ret i16 [[TMP12]]
 ;
   %res = fptoui half %x to i16
@@ -224,21 +185,12 @@ define i24 @fptoui_f16_i24(half %x) {
 ; CHECK-NEXT:  [[FP_TO_I_ENTRY:.*]]:
 ; CHECK-NEXT:    [[TMP1:%.*]] = freeze half [[X]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = bitcast half [[TMP1]] to i16
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp sgt i16 [[TMP0]], -1
-; CHECK-NEXT:    [[SIGN:%.*]] = select i1 [[TMP2]], i24 1, i24 -1
 ; CHECK-NEXT:    [[TMP5:%.*]] = lshr i16 [[TMP0]], 10
 ; CHECK-NEXT:    [[BIASED_EXP:%.*]] = and i16 [[TMP5]], 31
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i16 [[TMP0]], 1023
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i16 [[TMP3]], 1024
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i16 [[BIASED_EXP]], 15
-; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_SATURATE:.*]]
-; CHECK:       [[FP_TO_I_IF_CHECK_SATURATE]]:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i16 [[BIASED_EXP]], -39
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i16 [[TMP4]], -24
-; CHECK-NEXT:    br i1 [[TMP6]], label %[[FP_TO_I_IF_SATURATE:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
-; CHECK:       [[FP_TO_I_IF_SATURATE]]:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP2]], i24 8388607, i24 -8388608
-; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
 ; CHECK:       [[FP_TO_I_IF_CHECK_EXP_SIZE]]:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i16 [[BIASED_EXP]], 25
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label %[[FP_TO_I_IF_EXP_SMALL:.*]], label %[[FP_TO_I_IF_EXP_LARGE:.*]]
@@ -246,17 +198,15 @@ define i24 @fptoui_f16_i24(half %x) {
 ; CHECK-NEXT:    [[TMP14:%.*]] = sub i16 25, [[BIASED_EXP]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = lshr i16 [[SIGNIFICAND1]], [[TMP14]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = zext i16 [[TMP7]] to i24
-; CHECK-NEXT:    [[TMP9:%.*]] = mul i24 [[TMP8]], [[SIGN]]
 ; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
 ; CHECK:       [[FP_TO_I_IF_EXP_LARGE]]:
 ; CHECK-NEXT:    [[TMP15:%.*]] = add i16 [[BIASED_EXP]], -25
 ; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = zext i16 [[SIGNIFICAND1]] to i24
 ; CHECK-NEXT:    [[TMP10:%.*]] = zext i16 [[TMP15]] to i24
 ; CHECK-NEXT:    [[TMP11:%.*]] = shl i24 [[SIGNIFICAND]], [[TMP10]]
-; CHECK-NEXT:    [[TMP12:%.*]] = mul i24 [[TMP11]], [[SIGN]]
 ; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
 ; CHECK:       [[FP_TO_I_CLEANUP]]:
-; CHECK-NEXT:    [[TMP13:%.*]] = phi i24 [ [[SATURATED]], %[[FP_TO_I_IF_SATURATE]] ], [ [[TMP9]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi i24 [ [[TMP8]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP11]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
 ; CHECK-NEXT:    ret i24 [[TMP13]]
 ;
   %res = fptoui half %x to i24
@@ -269,21 +219,12 @@ define i8 @fptoui_f16_i8(half %x) {
 ; CHECK-NEXT:  [[FP_TO_I_ENTRY:.*]]:
 ; CHECK-NEXT:    [[TMP16:%.*]] = freeze half [[X]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = bitcast half [[TMP16]] to i16
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp sgt i16 [[TMP0]], -1
-; CHECK-NEXT:    [[SIGN:%.*]] = select i1 [[TMP1]], i8 1, i8 -1
 ; CHECK-NEXT:    [[TMP2:%.*]] = lshr i16 [[TMP0]], 10
 ; CHECK-NEXT:    [[BIASED_EXP:%.*]] = and i16 [[TMP2]], 31
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i16 [[TMP0]], 1023
 ; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = or i16 [[TMP3]], 1024
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i16 [[BIASED_EXP]], 15
-; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_SATURATE:.*]]
-; CHECK:       [[FP_TO_I_IF_CHECK_SATURATE]]:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i16 [[BIASED_EXP]], -23
-; CHECK-NEXT:    [[TMP5:%.*]] = icmp ult i16 [[TMP4]], -8
-; CHECK-NEXT:    br i1 [[TMP5]], label %[[FP_TO_I_IF_SATURATE:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
-; CHECK:       [[FP_TO_I_IF_SATURATE]]:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP1]], i8 127, i8 -128
-; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
 ; CHECK:       [[FP_TO_I_IF_CHECK_EXP_SIZE]]:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i16 [[BIASED_EXP]], 25
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label %[[FP_TO_I_IF_EXP_SMALL:.*]], label %[[FP_TO_I_IF_EXP_LARGE:.*]]
@@ -291,19 +232,106 @@ define i8 @fptoui_f16_i8(half %x) {
 ; CHECK-NEXT:    [[TMP6:%.*]] = sub i16 25, [[BIASED_EXP]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = lshr i16 [[SIGNIFICAND]], [[TMP6]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = trunc i16 [[TMP7]] to i8
-; CHECK-NEXT:    [[TMP9:%.*]] = mul i8 [[TMP8]], [[SIGN]]
 ; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
 ; CHECK:       [[FP_TO_I_IF_EXP_LARGE]]:
 ; CHECK-NEXT:    [[TMP10:%.*]] = add i16 [[BIASED_EXP]], -25
 ; CHECK-NEXT:    [[TMP11:%.*]] = trunc i16 [[SIGNIFICAND]] to i8
 ; CHECK-NEXT:    [[TMP12:%.*]] = trunc i16 [[TMP10]] to i8
 ; CHECK-NEXT:    [[TMP13:%.*]] = shl i8 [[TMP11]], [[TMP12]]
-; CHECK-NEXT:    [[TMP14:%.*]] = mul i8 [[TMP13]], [[SIGN]]
 ; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
 ; CHECK:       [[FP_TO_I_CLEANUP]]:
-; CHECK-NEXT:    [[TMP15:%.*]] = phi i8 [ [[SATURATED]], %[[FP_TO_I_IF_SATURATE]] ], [ [[TMP9]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP14]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
+; CHECK-NEXT:    [[TMP15:%.*]] = phi i8 [ [[TMP8]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP13]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
 ; CHECK-NEXT:    ret i8 [[TMP15]]
 ;
   %res = fptoui half %x to i8
+  ret i8 %res
+}
+
+define i8 @fptosi_sat_f16_i8(half %x) {
+; CHECK-LABEL: define i8 @fptosi_sat_f16_i8(
+; CHECK-SAME: half [[X:%.*]]) {
+; CHECK-NEXT:  [[FP_TO_I_ENTRY:.*]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = freeze half [[X]]
+; CHECK-NEXT:    [[TMP1:%.*]] = bitcast half [[TMP0]] to i16
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp sgt i16 [[TMP1]], -1
+; CHECK-NEXT:    [[SIGN:%.*]] = select i1 [[TMP2]], i8 1, i8 -1
+; CHECK-NEXT:    [[TMP3:%.*]] = lshr i16 [[TMP1]], 10
+; CHECK-NEXT:    [[BIASED_EXP:%.*]] = and i16 [[TMP3]], 31
+; CHECK-NEXT:    [[TMP4:%.*]] = and i16 [[TMP1]], 1023
+; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = or i16 [[TMP4]], 1024
+; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i16 [[BIASED_EXP]], 15
+; CHECK-NEXT:    [[IS_NAN:%.*]] = fcmp uno half [[TMP0]], [[TMP0]]
+; CHECK-NEXT:    [[TMP5:%.*]] = or i1 [[EXP_IS_NEGATIVE]], [[IS_NAN]]
+; CHECK-NEXT:    br i1 [[TMP5]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_SATURATE:.*]]
+; CHECK:       [[FP_TO_I_IF_CHECK_SATURATE]]:
+; CHECK-NEXT:    [[TMP7:%.*]] = icmp uge i16 [[BIASED_EXP]], 22
+; CHECK-NEXT:    br i1 [[TMP7]], label %[[FP_TO_I_IF_SATURATE:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
+; CHECK:       [[FP_TO_I_IF_SATURATE]]:
+; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP2]], i8 127, i8 -128
+; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK:       [[FP_TO_I_IF_CHECK_EXP_SIZE]]:
+; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i16 [[BIASED_EXP]], 25
+; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label %[[FP_TO_I_IF_EXP_SMALL:.*]], label %[[FP_TO_I_IF_EXP_LARGE:.*]]
+; CHECK:       [[FP_TO_I_IF_EXP_SMALL]]:
+; CHECK-NEXT:    [[TMP8:%.*]] = sub i16 25, [[BIASED_EXP]]
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i16 [[SIGNIFICAND]], [[TMP8]]
+; CHECK-NEXT:    [[TMP10:%.*]] = trunc i16 [[TMP9]] to i8
+; CHECK-NEXT:    [[TMP11:%.*]] = mul i8 [[TMP10]], [[SIGN]]
+; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK:       [[FP_TO_I_IF_EXP_LARGE]]:
+; CHECK-NEXT:    [[TMP12:%.*]] = add i16 [[BIASED_EXP]], -25
+; CHECK-NEXT:    [[TMP13:%.*]] = trunc i16 [[SIGNIFICAND]] to i8
+; CHECK-NEXT:    [[TMP14:%.*]] = trunc i16 [[TMP12]] to i8
+; CHECK-NEXT:    [[TMP15:%.*]] = shl i8 [[TMP13]], [[TMP14]]
+; CHECK-NEXT:    [[TMP16:%.*]] = mul i8 [[TMP15]], [[SIGN]]
+; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK:       [[FP_TO_I_CLEANUP]]:
+; CHECK-NEXT:    [[TMP17:%.*]] = phi i8 [ [[SATURATED]], %[[FP_TO_I_IF_SATURATE]] ], [ [[TMP11]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP16]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
+; CHECK-NEXT:    ret i8 [[TMP17]]
+;
+  %res = call i8 @llvm.fptosi.sat(half %x)
+  ret i8 %res
+}
+
+define i8 @fptoui_sat_f16_i8(half %x) {
+; CHECK-LABEL: define i8 @fptoui_sat_f16_i8(
+; CHECK-SAME: half [[X:%.*]]) {
+; CHECK-NEXT:  [[FP_TO_I_ENTRY:.*]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = freeze half [[X]]
+; CHECK-NEXT:    [[TMP1:%.*]] = bitcast half [[TMP0]] to i16
+; CHECK-NEXT:    [[TMP3:%.*]] = lshr i16 [[TMP1]], 10
+; CHECK-NEXT:    [[BIASED_EXP:%.*]] = and i16 [[TMP3]], 31
+; CHECK-NEXT:    [[TMP4:%.*]] = and i16 [[TMP1]], 1023
+; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = or i16 [[TMP4]], 1024
+; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i16 [[BIASED_EXP]], 15
+; CHECK-NEXT:    [[IS_NAN:%.*]] = fcmp uno half [[TMP0]], [[TMP0]]
+; CHECK-NEXT:    [[TMP5:%.*]] = or i1 [[EXP_IS_NEGATIVE]], [[IS_NAN]]
+; CHECK-NEXT:    [[TMP15:%.*]] = icmp slt i16 [[TMP1]], 0
+; CHECK-NEXT:    [[TMP16:%.*]] = or i1 [[TMP5]], [[TMP15]]
+; CHECK-NEXT:    br i1 [[TMP16]], label %[[FP_TO_I_CLEANUP:.*]], label %[[FP_TO_I_IF_CHECK_SATURATE:.*]]
+; CHECK:       [[FP_TO_I_IF_CHECK_SATURATE]]:
+; CHECK-NEXT:    [[TMP6:%.*]] = icmp uge i16 [[BIASED_EXP]], 23
+; CHECK-NEXT:    br i1 [[TMP6]], label %[[FP_TO_I_IF_SATURATE:.*]], label %[[FP_TO_I_IF_CHECK_EXP_SIZE:.*]]
+; CHECK:       [[FP_TO_I_IF_SATURATE]]:
+; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK:       [[FP_TO_I_IF_CHECK_EXP_SIZE]]:
+; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i16 [[BIASED_EXP]], 25
+; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label %[[FP_TO_I_IF_EXP_SMALL:.*]], label %[[FP_TO_I_IF_EXP_LARGE:.*]]
+; CHECK:       [[FP_TO_I_IF_EXP_SMALL]]:
+; CHECK-NEXT:    [[TMP7:%.*]] = sub i16 25, [[BIASED_EXP]]
+; CHECK-NEXT:    [[TMP8:%.*]] = lshr i16 [[SIGNIFICAND]], [[TMP7]]
+; CHECK-NEXT:    [[TMP9:%.*]] = trunc i16 [[TMP8]] to i8
+; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK:       [[FP_TO_I_IF_EXP_LARGE]]:
+; CHECK-NEXT:    [[TMP10:%.*]] = add i16 [[BIASED_EXP]], -25
+; CHECK-NEXT:    [[TMP11:%.*]] = trunc i16 [[SIGNIFICAND]] to i8
+; CHECK-NEXT:    [[TMP12:%.*]] = trunc i16 [[TMP10]] to i8
+; CHECK-NEXT:    [[TMP13:%.*]] = shl i8 [[TMP11]], [[TMP12]]
+; CHECK-NEXT:    br label %[[FP_TO_I_CLEANUP]]
+; CHECK:       [[FP_TO_I_CLEANUP]]:
+; CHECK-NEXT:    [[TMP14:%.*]] = phi i8 [ -1, %[[FP_TO_I_IF_SATURATE]] ], [ [[TMP9]], %[[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP13]], %[[FP_TO_I_IF_EXP_LARGE]] ], [ 0, %[[FP_TO_I_ENTRY]] ]
+; CHECK-NEXT:    ret i8 [[TMP14]]
+;
+  %res = call i8 @llvm.fptoui.sat(half %x)
   ret i8 %res
 }

--- a/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-convert-fptosi129.ll
+++ b/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-convert-fptosi129.ll
@@ -25,13 +25,6 @@ define i129 @floattosi129(float %a) {
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i32 [[TMP3]], 8388608
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i32 [[BIASED_EXP]], 127
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
-; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i32 [[BIASED_EXP]], -256
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 [[TMP4]], -129
-; CHECK-NEXT:    br i1 [[TMP6]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
-; CHECK:       fp-to-i-if-saturate:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP2]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-check.exp.size:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i32 [[BIASED_EXP]], 150
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label [[FP_TO_I_IF_EXP_SMALL:%.*]], label [[FP_TO_I_IF_EXP_LARGE:%.*]]
@@ -49,7 +42,7 @@ define i129 @floattosi129(float %a) {
 ; CHECK-NEXT:    [[TMP12:%.*]] = mul i129 [[TMP11]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-cleanup:
-; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[SATURATED]], [[FP_TO_I_IF_SATURATE]] ], [ [[TMP9]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[TMP9]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
 ; CHECK-NEXT:    ret i129 [[TMP13]]
 ;
   %conv = fptosi float %a to i129
@@ -69,13 +62,6 @@ define i129 @doubletosi129(double %a) {
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i64 [[TMP3]], 4503599627370496
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i64 [[BIASED_EXP]], 1023
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
-; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i64 [[BIASED_EXP]], -1152
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i64 [[TMP4]], -129
-; CHECK-NEXT:    br i1 [[TMP6]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
-; CHECK:       fp-to-i-if-saturate:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP2]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-check.exp.size:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i64 [[BIASED_EXP]], 1075
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label [[FP_TO_I_IF_EXP_SMALL:%.*]], label [[FP_TO_I_IF_EXP_LARGE:%.*]]
@@ -93,7 +79,7 @@ define i129 @doubletosi129(double %a) {
 ; CHECK-NEXT:    [[TMP12:%.*]] = mul i129 [[TMP11]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-cleanup:
-; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[SATURATED]], [[FP_TO_I_IF_SATURATE]] ], [ [[TMP9]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[TMP9]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
 ; CHECK-NEXT:    ret i129 [[TMP13]]
 ;
   %conv = fptosi double %a to i129
@@ -114,13 +100,6 @@ define i129 @x86_fp80tosi129(x86_fp80 %a) {
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i128 [[TMP4]], 5192296858534827628530496329220096
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i128 [[BIASED_EXP]], 16383
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
-; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP5:%.*]] = add i128 [[BIASED_EXP]], -16512
-; CHECK-NEXT:    [[TMP7:%.*]] = icmp ult i128 [[TMP5]], -129
-; CHECK-NEXT:    br i1 [[TMP7]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
-; CHECK:       fp-to-i-if-saturate:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP3]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-check.exp.size:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i128 [[BIASED_EXP]], 16495
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label [[FP_TO_I_IF_EXP_SMALL:%.*]], label [[FP_TO_I_IF_EXP_LARGE:%.*]]
@@ -138,7 +117,7 @@ define i129 @x86_fp80tosi129(x86_fp80 %a) {
 ; CHECK-NEXT:    [[TMP13:%.*]] = mul i129 [[TMP12]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-cleanup:
-; CHECK-NEXT:    [[TMP14:%.*]] = phi i129 [ [[SATURATED]], [[FP_TO_I_IF_SATURATE]] ], [ [[TMP10]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP13]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi i129 [ [[TMP10]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP13]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
 ; CHECK-NEXT:    ret i129 [[TMP14]]
 ;
   %conv = fptosi x86_fp80 %a to i129
@@ -158,13 +137,6 @@ define i129 @fp128tosi129(fp128 %a) {
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i128 [[TMP3]], 5192296858534827628530496329220096
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i128 [[BIASED_EXP]], 16383
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
-; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i128 [[BIASED_EXP]], -16512
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i128 [[TMP4]], -129
-; CHECK-NEXT:    br i1 [[TMP6]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
-; CHECK:       fp-to-i-if-saturate:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP2]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-check.exp.size:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i128 [[BIASED_EXP]], 16495
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label [[FP_TO_I_IF_EXP_SMALL:%.*]], label [[FP_TO_I_IF_EXP_LARGE:%.*]]
@@ -182,7 +154,7 @@ define i129 @fp128tosi129(fp128 %a) {
 ; CHECK-NEXT:    [[TMP12:%.*]] = mul i129 [[TMP11]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-cleanup:
-; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[SATURATED]], [[FP_TO_I_IF_SATURATE]] ], [ [[TMP9]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[TMP9]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
 ; CHECK-NEXT:    ret i129 [[TMP13]]
 ;
   %conv = fptosi fp128 %a to i129
@@ -203,23 +175,16 @@ define <2 x i129> @floattosi129v2(<2 x float> %a) {
 ; CHECK-NEXT:    [[SIGNIFICAND10:%.*]] = or i32 [[TMP4]], 8388608
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE10:%.*]] = icmp ult i32 [[BIASED_EXP8]], 127
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE10]], label [[FP_TO_I_CLEANUP1:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE2:%.*]]
-; CHECK:       fp-to-i-if-check.saturate2:
-; CHECK-NEXT:    [[TMP5:%.*]] = add i32 [[BIASED_EXP8]], -256
-; CHECK-NEXT:    [[TMP7:%.*]] = icmp ult i32 [[TMP5]], -129
-; CHECK-NEXT:    br i1 [[TMP7]], label [[FP_TO_I_IF_SATURATE3:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE4:%.*]]
-; CHECK:       fp-to-i-if-saturate3:
-; CHECK-NEXT:    [[SATURATED11:%.*]] = select i1 [[TMP3]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP1]]
-; CHECK:       fp-to-i-if-check.exp.size4:
+; CHECK:       fp-to-i-if-check.exp.size2:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH12:%.*]] = icmp ult i32 [[BIASED_EXP8]], 150
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH12]], label [[FP_TO_I_IF_EXP_SMALL5:%.*]], label [[FP_TO_I_IF_EXP_LARGE6:%.*]]
-; CHECK:       fp-to-i-if-exp.small5:
+; CHECK:       fp-to-i-if-exp.small3:
 ; CHECK-NEXT:    [[TMP18:%.*]] = sub i32 150, [[BIASED_EXP8]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = lshr i32 [[SIGNIFICAND10]], [[TMP18]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = zext i32 [[TMP8]] to i129
 ; CHECK-NEXT:    [[TMP10:%.*]] = mul i129 [[TMP9]], [[SIGN7]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP1]]
-; CHECK:       fp-to-i-if-exp.large6:
+; CHECK:       fp-to-i-if-exp.large4:
 ; CHECK-NEXT:    [[TMP20:%.*]] = add i32 [[BIASED_EXP8]], -150
 ; CHECK-NEXT:    [[SIGNIFICAND9:%.*]] = zext i32 [[SIGNIFICAND10]] to i129
 ; CHECK-NEXT:    [[TMP11:%.*]] = zext i32 [[TMP20]] to i129
@@ -227,7 +192,7 @@ define <2 x i129> @floattosi129v2(<2 x float> %a) {
 ; CHECK-NEXT:    [[TMP13:%.*]] = mul i129 [[TMP12]], [[SIGN7]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP1]]
 ; CHECK:       fp-to-i-cleanup1:
-; CHECK-NEXT:    [[TMP14:%.*]] = phi i129 [ [[SATURATED11]], [[FP_TO_I_IF_SATURATE3]] ], [ [[TMP10]], [[FP_TO_I_IF_EXP_SMALL5]] ], [ [[TMP13]], [[FP_TO_I_IF_EXP_LARGE6]] ], [ 0, [[FP_TO_I_ENTRYFP_TO_I_ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi i129 [ [[TMP10]], [[FP_TO_I_IF_EXP_SMALL5]] ], [ [[TMP13]], [[FP_TO_I_IF_EXP_LARGE6]] ], [ 0, [[FP_TO_I_ENTRYFP_TO_I_ENTRY:%.*]] ]
 ; CHECK-NEXT:    [[TMP15:%.*]] = insertelement <2 x i129> poison, i129 [[TMP14]], i64 0
 ; CHECK-NEXT:    [[TMP16:%.*]] = extractelement <2 x float> [[A]], i64 1
 ; CHECK-NEXT:    [[TMP35:%.*]] = freeze float [[TMP16]]
@@ -240,13 +205,6 @@ define <2 x i129> @floattosi129v2(<2 x float> %a) {
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i32 [[TMP22]], 8388608
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i32 [[BIASED_EXP]], 127
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
-; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP24:%.*]] = add i32 [[BIASED_EXP]], -256
-; CHECK-NEXT:    [[TMP23:%.*]] = icmp ult i32 [[TMP24]], -129
-; CHECK-NEXT:    br i1 [[TMP23]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
-; CHECK:       fp-to-i-if-saturate:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP19]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-check.exp.size:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i32 [[BIASED_EXP]], 150
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label [[FP_TO_I_IF_EXP_SMALL:%.*]], label [[FP_TO_I_IF_EXP_LARGE:%.*]]
@@ -264,7 +222,7 @@ define <2 x i129> @floattosi129v2(<2 x float> %a) {
 ; CHECK-NEXT:    [[TMP29:%.*]] = mul i129 [[TMP28]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-cleanup:
-; CHECK-NEXT:    [[TMP30:%.*]] = phi i129 [ [[SATURATED]], [[FP_TO_I_IF_SATURATE]] ], [ [[TMP26]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP29]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_CLEANUP1]] ]
+; CHECK-NEXT:    [[TMP30:%.*]] = phi i129 [ [[TMP26]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP29]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_CLEANUP1]] ]
 ; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <2 x i129> [[TMP15]], i129 [[TMP30]], i64 1
 ; CHECK-NEXT:    ret <2 x i129> [[TMP31]]
 ;

--- a/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-convert-fptoui129.ll
+++ b/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-convert-fptoui129.ll
@@ -17,21 +17,12 @@ define i129 @floattoui129(float %a) {
 ; CHECK-NEXT:  fp-to-i-entry:
 ; CHECK-NEXT:    [[A:%.*]] = freeze float [[A1:%.*]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = bitcast float [[A]] to i32
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp sgt i32 [[TMP0]], -1
-; CHECK-NEXT:    [[SIGN:%.*]] = select i1 [[TMP2]], i129 1, i129 -1
 ; CHECK-NEXT:    [[TMP5:%.*]] = lshr i32 [[TMP0]], 23
 ; CHECK-NEXT:    [[BIASED_EXP:%.*]] = and i32 [[TMP5]], 255
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i32 [[TMP0]], 8388607
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i32 [[TMP3]], 8388608
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i32 [[BIASED_EXP]], 127
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
-; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i32 [[BIASED_EXP]], -256
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 [[TMP4]], -129
-; CHECK-NEXT:    br i1 [[TMP6]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
-; CHECK:       fp-to-i-if-saturate:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP2]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-check.exp.size:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i32 [[BIASED_EXP]], 150
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label [[FP_TO_I_IF_EXP_SMALL:%.*]], label [[FP_TO_I_IF_EXP_LARGE:%.*]]
@@ -39,17 +30,15 @@ define i129 @floattoui129(float %a) {
 ; CHECK-NEXT:    [[TMP14:%.*]] = sub i32 150, [[BIASED_EXP]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = lshr i32 [[SIGNIFICAND1]], [[TMP14]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = zext i32 [[TMP7]] to i129
-; CHECK-NEXT:    [[TMP9:%.*]] = mul i129 [[TMP8]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-exp.large:
 ; CHECK-NEXT:    [[TMP15:%.*]] = add i32 [[BIASED_EXP]], -150
 ; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = zext i32 [[SIGNIFICAND1]] to i129
 ; CHECK-NEXT:    [[TMP10:%.*]] = zext i32 [[TMP15]] to i129
 ; CHECK-NEXT:    [[TMP11:%.*]] = shl i129 [[SIGNIFICAND]], [[TMP10]]
-; CHECK-NEXT:    [[TMP12:%.*]] = mul i129 [[TMP11]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-cleanup:
-; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[SATURATED]], [[FP_TO_I_IF_SATURATE]] ], [ [[TMP9]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[TMP8]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP11]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
 ; CHECK-NEXT:    ret i129 [[TMP13]]
 ;
   %conv = fptoui float %a to i129
@@ -61,21 +50,12 @@ define i129 @doubletoui129(double %a) {
 ; CHECK-NEXT:  fp-to-i-entry:
 ; CHECK-NEXT:    [[A:%.*]] = freeze double [[A1:%.*]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = bitcast double [[A]] to i64
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp sgt i64 [[TMP0]], -1
-; CHECK-NEXT:    [[SIGN:%.*]] = select i1 [[TMP2]], i129 1, i129 -1
 ; CHECK-NEXT:    [[TMP5:%.*]] = lshr i64 [[TMP0]], 52
 ; CHECK-NEXT:    [[BIASED_EXP:%.*]] = and i64 [[TMP5]], 2047
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i64 [[TMP0]], 4503599627370495
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i64 [[TMP3]], 4503599627370496
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i64 [[BIASED_EXP]], 1023
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
-; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i64 [[BIASED_EXP]], -1152
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i64 [[TMP4]], -129
-; CHECK-NEXT:    br i1 [[TMP6]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
-; CHECK:       fp-to-i-if-saturate:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP2]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-check.exp.size:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i64 [[BIASED_EXP]], 1075
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label [[FP_TO_I_IF_EXP_SMALL:%.*]], label [[FP_TO_I_IF_EXP_LARGE:%.*]]
@@ -83,17 +63,15 @@ define i129 @doubletoui129(double %a) {
 ; CHECK-NEXT:    [[TMP14:%.*]] = sub i64 1075, [[BIASED_EXP]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = lshr i64 [[SIGNIFICAND1]], [[TMP14]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = zext i64 [[TMP7]] to i129
-; CHECK-NEXT:    [[TMP9:%.*]] = mul i129 [[TMP8]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-exp.large:
 ; CHECK-NEXT:    [[TMP15:%.*]] = add i64 [[BIASED_EXP]], -1075
 ; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = zext i64 [[SIGNIFICAND1]] to i129
 ; CHECK-NEXT:    [[TMP10:%.*]] = zext i64 [[TMP15]] to i129
 ; CHECK-NEXT:    [[TMP11:%.*]] = shl i129 [[SIGNIFICAND]], [[TMP10]]
-; CHECK-NEXT:    [[TMP12:%.*]] = mul i129 [[TMP11]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-cleanup:
-; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[SATURATED]], [[FP_TO_I_IF_SATURATE]] ], [ [[TMP9]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[TMP8]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP11]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
 ; CHECK-NEXT:    ret i129 [[TMP13]]
 ;
   %conv = fptoui double %a to i129
@@ -106,21 +84,12 @@ define i129 @x86_fp80toui129(x86_fp80 %a) {
 ; CHECK-NEXT:    [[A:%.*]] = freeze x86_fp80 [[A1:%.*]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = fpext x86_fp80 [[A]] to fp128
 ; CHECK-NEXT:    [[TMP1:%.*]] = bitcast fp128 [[TMP0]] to i128
-; CHECK-NEXT:    [[TMP3:%.*]] = icmp sgt i128 [[TMP1]], -1
-; CHECK-NEXT:    [[SIGN:%.*]] = select i1 [[TMP3]], i129 1, i129 -1
 ; CHECK-NEXT:    [[TMP6:%.*]] = lshr i128 [[TMP1]], 112
 ; CHECK-NEXT:    [[BIASED_EXP:%.*]] = and i128 [[TMP6]], 32767
 ; CHECK-NEXT:    [[TMP4:%.*]] = and i128 [[TMP1]], 5192296858534827628530496329220095
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i128 [[TMP4]], 5192296858534827628530496329220096
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i128 [[BIASED_EXP]], 16383
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
-; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP5:%.*]] = add i128 [[BIASED_EXP]], -16512
-; CHECK-NEXT:    [[TMP7:%.*]] = icmp ult i128 [[TMP5]], -129
-; CHECK-NEXT:    br i1 [[TMP7]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
-; CHECK:       fp-to-i-if-saturate:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP3]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-check.exp.size:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i128 [[BIASED_EXP]], 16495
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label [[FP_TO_I_IF_EXP_SMALL:%.*]], label [[FP_TO_I_IF_EXP_LARGE:%.*]]
@@ -128,17 +97,15 @@ define i129 @x86_fp80toui129(x86_fp80 %a) {
 ; CHECK-NEXT:    [[TMP15:%.*]] = sub i128 16495, [[BIASED_EXP]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = lshr i128 [[SIGNIFICAND1]], [[TMP15]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = zext i128 [[TMP8]] to i129
-; CHECK-NEXT:    [[TMP10:%.*]] = mul i129 [[TMP9]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-exp.large:
 ; CHECK-NEXT:    [[TMP16:%.*]] = add i128 [[BIASED_EXP]], -16495
 ; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = zext i128 [[SIGNIFICAND1]] to i129
 ; CHECK-NEXT:    [[TMP11:%.*]] = zext i128 [[TMP16]] to i129
 ; CHECK-NEXT:    [[TMP12:%.*]] = shl i129 [[SIGNIFICAND]], [[TMP11]]
-; CHECK-NEXT:    [[TMP13:%.*]] = mul i129 [[TMP12]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-cleanup:
-; CHECK-NEXT:    [[TMP14:%.*]] = phi i129 [ [[SATURATED]], [[FP_TO_I_IF_SATURATE]] ], [ [[TMP10]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP13]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi i129 [ [[TMP9]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
 ; CHECK-NEXT:    ret i129 [[TMP14]]
 ;
   %conv = fptoui x86_fp80 %a to i129
@@ -150,21 +117,12 @@ define i129 @fp128toui129(fp128 %a) {
 ; CHECK-NEXT:  fp-to-i-entry:
 ; CHECK-NEXT:    [[A:%.*]] = freeze fp128 [[A1:%.*]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = bitcast fp128 [[A]] to i128
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp sgt i128 [[TMP0]], -1
-; CHECK-NEXT:    [[SIGN:%.*]] = select i1 [[TMP2]], i129 1, i129 -1
 ; CHECK-NEXT:    [[TMP5:%.*]] = lshr i128 [[TMP0]], 112
 ; CHECK-NEXT:    [[BIASED_EXP:%.*]] = and i128 [[TMP5]], 32767
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i128 [[TMP0]], 5192296858534827628530496329220095
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i128 [[TMP3]], 5192296858534827628530496329220096
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i128 [[BIASED_EXP]], 16383
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
-; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP4:%.*]] = add i128 [[BIASED_EXP]], -16512
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i128 [[TMP4]], -129
-; CHECK-NEXT:    br i1 [[TMP6]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
-; CHECK:       fp-to-i-if-saturate:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP2]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-check.exp.size:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i128 [[BIASED_EXP]], 16495
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label [[FP_TO_I_IF_EXP_SMALL:%.*]], label [[FP_TO_I_IF_EXP_LARGE:%.*]]
@@ -172,17 +130,15 @@ define i129 @fp128toui129(fp128 %a) {
 ; CHECK-NEXT:    [[TMP14:%.*]] = sub i128 16495, [[BIASED_EXP]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = lshr i128 [[SIGNIFICAND1]], [[TMP14]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = zext i128 [[TMP7]] to i129
-; CHECK-NEXT:    [[TMP9:%.*]] = mul i129 [[TMP8]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-exp.large:
 ; CHECK-NEXT:    [[TMP15:%.*]] = add i128 [[BIASED_EXP]], -16495
 ; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = zext i128 [[SIGNIFICAND1]] to i129
 ; CHECK-NEXT:    [[TMP10:%.*]] = zext i128 [[TMP15]] to i129
 ; CHECK-NEXT:    [[TMP11:%.*]] = shl i129 [[SIGNIFICAND]], [[TMP10]]
-; CHECK-NEXT:    [[TMP12:%.*]] = mul i129 [[TMP11]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-cleanup:
-; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[SATURATED]], [[FP_TO_I_IF_SATURATE]] ], [ [[TMP9]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP12]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP13:%.*]] = phi i129 [ [[TMP8]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP11]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_ENTRY:%.*]] ]
 ; CHECK-NEXT:    ret i129 [[TMP13]]
 ;
   %conv = fptoui fp128 %a to i129
@@ -195,58 +151,38 @@ define <2 x i129> @floattoui129v2(<2 x float> %a) {
 ; CHECK-NEXT:    [[TMP0:%.*]] = extractelement <2 x float> [[A:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = freeze float [[TMP0]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = bitcast float [[TMP2]] to i32
-; CHECK-NEXT:    [[TMP3:%.*]] = icmp sgt i32 [[TMP1]], -1
-; CHECK-NEXT:    [[SIGN7:%.*]] = select i1 [[TMP3]], i129 1, i129 -1
 ; CHECK-NEXT:    [[TMP6:%.*]] = lshr i32 [[TMP1]], 23
 ; CHECK-NEXT:    [[BIASED_EXP8:%.*]] = and i32 [[TMP6]], 255
 ; CHECK-NEXT:    [[TMP4:%.*]] = and i32 [[TMP1]], 8388607
 ; CHECK-NEXT:    [[SIGNIFICAND10:%.*]] = or i32 [[TMP4]], 8388608
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE10:%.*]] = icmp ult i32 [[BIASED_EXP8]], 127
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE10]], label [[FP_TO_I_CLEANUP1:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE2:%.*]]
-; CHECK:       fp-to-i-if-check.saturate2:
-; CHECK-NEXT:    [[TMP5:%.*]] = add i32 [[BIASED_EXP8]], -256
-; CHECK-NEXT:    [[TMP7:%.*]] = icmp ult i32 [[TMP5]], -129
-; CHECK-NEXT:    br i1 [[TMP7]], label [[FP_TO_I_IF_SATURATE3:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE4:%.*]]
-; CHECK:       fp-to-i-if-saturate3:
-; CHECK-NEXT:    [[SATURATED11:%.*]] = select i1 [[TMP3]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP1]]
-; CHECK:       fp-to-i-if-check.exp.size4:
+; CHECK:       fp-to-i-if-check.exp.size2:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH12:%.*]] = icmp ult i32 [[BIASED_EXP8]], 150
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH12]], label [[FP_TO_I_IF_EXP_SMALL5:%.*]], label [[FP_TO_I_IF_EXP_LARGE6:%.*]]
-; CHECK:       fp-to-i-if-exp.small5:
+; CHECK:       fp-to-i-if-exp.small3:
 ; CHECK-NEXT:    [[TMP18:%.*]] = sub i32 150, [[BIASED_EXP8]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = lshr i32 [[SIGNIFICAND10]], [[TMP18]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = zext i32 [[TMP8]] to i129
-; CHECK-NEXT:    [[TMP10:%.*]] = mul i129 [[TMP9]], [[SIGN7]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP1]]
-; CHECK:       fp-to-i-if-exp.large6:
+; CHECK:       fp-to-i-if-exp.large4:
 ; CHECK-NEXT:    [[TMP20:%.*]] = add i32 [[BIASED_EXP8]], -150
 ; CHECK-NEXT:    [[SIGNIFICAND9:%.*]] = zext i32 [[SIGNIFICAND10]] to i129
 ; CHECK-NEXT:    [[TMP11:%.*]] = zext i32 [[TMP20]] to i129
 ; CHECK-NEXT:    [[TMP12:%.*]] = shl i129 [[SIGNIFICAND9]], [[TMP11]]
-; CHECK-NEXT:    [[TMP13:%.*]] = mul i129 [[TMP12]], [[SIGN7]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP1]]
 ; CHECK:       fp-to-i-cleanup1:
-; CHECK-NEXT:    [[TMP14:%.*]] = phi i129 [ [[SATURATED11]], [[FP_TO_I_IF_SATURATE3]] ], [ [[TMP10]], [[FP_TO_I_IF_EXP_SMALL5]] ], [ [[TMP13]], [[FP_TO_I_IF_EXP_LARGE6]] ], [ 0, [[FP_TO_I_ENTRYFP_TO_I_ENTRY:%.*]] ]
+; CHECK-NEXT:    [[TMP14:%.*]] = phi i129 [ [[TMP9]], [[FP_TO_I_IF_EXP_SMALL5]] ], [ [[TMP12]], [[FP_TO_I_IF_EXP_LARGE6]] ], [ 0, [[FP_TO_I_ENTRYFP_TO_I_ENTRY:%.*]] ]
 ; CHECK-NEXT:    [[TMP15:%.*]] = insertelement <2 x i129> poison, i129 [[TMP14]], i64 0
 ; CHECK-NEXT:    [[TMP16:%.*]] = extractelement <2 x float> [[A]], i64 1
 ; CHECK-NEXT:    [[TMP35:%.*]] = freeze float [[TMP16]]
 ; CHECK-NEXT:    [[TMP17:%.*]] = bitcast float [[TMP35]] to i32
-; CHECK-NEXT:    [[TMP19:%.*]] = icmp sgt i32 [[TMP17]], -1
-; CHECK-NEXT:    [[SIGN:%.*]] = select i1 [[TMP19]], i129 1, i129 -1
 ; CHECK-NEXT:    [[TMP21:%.*]] = lshr i32 [[TMP17]], 23
 ; CHECK-NEXT:    [[BIASED_EXP:%.*]] = and i32 [[TMP21]], 255
 ; CHECK-NEXT:    [[TMP22:%.*]] = and i32 [[TMP17]], 8388607
 ; CHECK-NEXT:    [[SIGNIFICAND1:%.*]] = or i32 [[TMP22]], 8388608
 ; CHECK-NEXT:    [[EXP_IS_NEGATIVE:%.*]] = icmp ult i32 [[BIASED_EXP]], 127
 ; CHECK-NEXT:    br i1 [[EXP_IS_NEGATIVE]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
-; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP24:%.*]] = add i32 [[BIASED_EXP]], -256
-; CHECK-NEXT:    [[TMP23:%.*]] = icmp ult i32 [[TMP24]], -129
-; CHECK-NEXT:    br i1 [[TMP23]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
-; CHECK:       fp-to-i-if-saturate:
-; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP19]], i129 340282366920938463463374607431768211455, i129 -340282366920938463463374607431768211456
-; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-check.exp.size:
 ; CHECK-NEXT:    [[EXP_SMALLER_MANTISSA_WIDTH:%.*]] = icmp ult i32 [[BIASED_EXP]], 150
 ; CHECK-NEXT:    br i1 [[EXP_SMALLER_MANTISSA_WIDTH]], label [[FP_TO_I_IF_EXP_SMALL:%.*]], label [[FP_TO_I_IF_EXP_LARGE:%.*]]
@@ -254,17 +190,15 @@ define <2 x i129> @floattoui129v2(<2 x float> %a) {
 ; CHECK-NEXT:    [[TMP32:%.*]] = sub i32 150, [[BIASED_EXP]]
 ; CHECK-NEXT:    [[TMP33:%.*]] = lshr i32 [[SIGNIFICAND1]], [[TMP32]]
 ; CHECK-NEXT:    [[TMP25:%.*]] = zext i32 [[TMP33]] to i129
-; CHECK-NEXT:    [[TMP26:%.*]] = mul i129 [[TMP25]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-if-exp.large:
 ; CHECK-NEXT:    [[TMP34:%.*]] = add i32 [[BIASED_EXP]], -150
 ; CHECK-NEXT:    [[SIGNIFICAND:%.*]] = zext i32 [[SIGNIFICAND1]] to i129
 ; CHECK-NEXT:    [[TMP27:%.*]] = zext i32 [[TMP34]] to i129
 ; CHECK-NEXT:    [[TMP28:%.*]] = shl i129 [[SIGNIFICAND]], [[TMP27]]
-; CHECK-NEXT:    [[TMP29:%.*]] = mul i129 [[TMP28]], [[SIGN]]
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
 ; CHECK:       fp-to-i-cleanup:
-; CHECK-NEXT:    [[TMP30:%.*]] = phi i129 [ [[SATURATED]], [[FP_TO_I_IF_SATURATE]] ], [ [[TMP26]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP29]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_CLEANUP1]] ]
+; CHECK-NEXT:    [[TMP30:%.*]] = phi i129 [ [[TMP25]], [[FP_TO_I_IF_EXP_SMALL]] ], [ [[TMP28]], [[FP_TO_I_IF_EXP_LARGE]] ], [ 0, [[FP_TO_I_CLEANUP1]] ]
 ; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <2 x i129> [[TMP15]], i129 [[TMP30]], i64 1
 ; CHECK-NEXT:    ret <2 x i129> [[TMP31]]
 ;


### PR DESCRIPTION
Add support for expanding fptosi.sat and fptoui.sat via IR expansions. Similar to fptosi/fptoui we would get legalization errors otherwise.

The previous expansion for fptosi/fptoui was already saturating -- but those instructions do not actually require saturation, and the implementation of the saturation was incorrect in lots of ways. What this PR does is:

 * For fptosi, remove the unnecessary saturation handling.
 * For fptoui, remove the unnecessary saturation handling and sign multiplication.
 * For fptosi, use the previous saturation handling with fixes: We need to map NaNs to 0 and the saturation condition on the exponent was incorrect. (I'm performing the NaN check via fcmp -- there's no requirement to do everything bitwise here.)
 * For fptoui use a variation of the signed saturation handling: Negative values need to go to zero and we saturate to unsigned max.

Proofs: https://alive2.llvm.org/ce/z/Xv9FNd