### PR TITLE
[NFC][analyzer] Cleanup dead code around NodeBuilder

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -401,8 +401,7 @@ public:
                   NodeBuilder *Enclosing = nullptr)
       : NodeBuilder(SrcSet, DstSet, Ctx), EnclosingBldr(Enclosing) {
     if (EnclosingBldr)
-      for (const auto I : SrcSet)
-        EnclosingBldr->takeNodes(I);
+      EnclosingBldr->takeNodes(SrcSet);
   }
 
   ~StmtNodeBuilder() override;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -319,41 +319,6 @@ public:
   void addNodes(ExplodedNode *N) { Frontier.Add(N); }
 };
 
-/// \class NodeBuilderWithSinks
-/// This node builder keeps track of the generated sink nodes.
-class NodeBuilderWithSinks: public NodeBuilder {
-  void anchor() override;
-
-protected:
-  SmallVector<ExplodedNode*, 2> sinksGenerated;
-  ProgramPoint &Location;
-
-public:
-  NodeBuilderWithSinks(ExplodedNode *Pred, ExplodedNodeSet &DstSet,
-                       const NodeBuilderContext &Ctx, ProgramPoint &L)
-      : NodeBuilder(Pred, DstSet, Ctx), Location(L) {}
-
-  ExplodedNode *generateNode(ProgramStateRef State,
-                             ExplodedNode *Pred,
-                             const ProgramPointTag *Tag = nullptr) {
-    const ProgramPoint &LocalLoc = (Tag ? Location.withTag(Tag) : Location);
-    return NodeBuilder::generateNode(LocalLoc, State, Pred);
-  }
-
-  ExplodedNode *generateSink(ProgramStateRef State, ExplodedNode *Pred,
-                             const ProgramPointTag *Tag = nullptr) {
-    const ProgramPoint &LocalLoc = (Tag ? Location.withTag(Tag) : Location);
-    ExplodedNode *N = NodeBuilder::generateSink(LocalLoc, State, Pred);
-    if (N && N->isSink())
-      sinksGenerated.push_back(N);
-    return N;
-  }
-
-  const SmallVectorImpl<ExplodedNode*> &getSinks() const {
-    return sinksGenerated;
-  }
-};
-
 /// \class StmtNodeBuilder
 /// This builder class is useful for generating nodes that resulted from
 /// visiting a statement. The main difference from its parent NodeBuilder is

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -86,7 +86,6 @@ class ExplodedNode;
 class IndirectGotoNodeBuilder;
 class MemRegion;
 class NodeBuilderContext;
-class NodeBuilderWithSinks;
 class ProgramState;
 class ProgramStateManager;
 class RegionAndSymbolInvalidationTraits;
@@ -320,9 +319,8 @@ public:
                             ExplodedNode *Pred, ExplodedNodeSet &Dst);
 
   /// Called by CoreEngine when processing the entrance of a CFGBlock.
-  void processCFGBlockEntrance(const BlockEdge &L,
-                               NodeBuilderWithSinks &nodeBuilder,
-                               ExplodedNode *Pred);
+  void processCFGBlockEntrance(const BlockEdge &L, const BlockEntrance &BE,
+                               NodeBuilder &Builder, ExplodedNode *Pred);
 
   void runCheckersForBlockEntrance(const NodeBuilderContext &BldCtx,
                                    const BlockEntrance &Entrance,

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -320,12 +320,12 @@ void CoreEngine::HandleBlockEdge(const BlockEdge &L, ExplodedNode *Pred) {
   // Call into the ExprEngine to process entering the CFGBlock.
   BlockEntrance BE(L.getSrc(), L.getDst(), Pred->getLocationContext());
   ExplodedNodeSet DstNodes;
-  NodeBuilderWithSinks NodeBuilder(Pred, DstNodes, BuilderCtx, BE);
-  ExprEng.processCFGBlockEntrance(L, NodeBuilder, Pred);
+  NodeBuilder Builder(Pred, DstNodes, BuilderCtx);
+  ExprEng.processCFGBlockEntrance(L, BE, Builder, Pred);
 
   // Auto-generate a node.
-  if (!NodeBuilder.hasGeneratedNodes()) {
-    NodeBuilder.generateNode(Pred->State, Pred);
+  if (!Builder.hasGeneratedNodes()) {
+    Builder.generateNode(BE, Pred->State, Pred);
   }
 
   ExplodedNodeSet CheckerNodes;
@@ -701,8 +701,6 @@ ExplodedNode* NodeBuilder::generateNodeImpl(const ProgramPoint &Loc,
 
   return N;
 }
-
-void NodeBuilderWithSinks::anchor() {}
 
 StmtNodeBuilder::~StmtNodeBuilder() {
   if (EnclosingBldr)


### PR DESCRIPTION
As I was trying to understand the class `NodeBuilder` and its subclasses, I wasted a few hours on studying dead or needlessly complicated code. I'm creating this patch to ensure that others in the future won't need to bother with this cruft.

This commit eliminates three deficiencies:
- (Small change:) In a constructor of `StmtNodeBuilder` I switched to using the `takeNodes()` overload which accepts an `ExplodedNodeSet` (instead of manually iterating).
- The `Finalized` attribute of NodeBuilder was completely irrelevant (it was always initialized to `true`).
- The "main" feature of `NodeBuilderWithSinks` was that it gathered the generated sink nodes into a set, but this was never actually used. As the only other feature (storing a `ProgramPoint` in a data member) was very trivial, I replaced this class with a plain `NodeBuilder` in the only location that used it.