### PR TITLE
[alpha.webkit.RetainPtrCtorAdoptChecker] Don't treat calling (void)copy:(id) as a leak

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -337,8 +337,15 @@ bool isAllocInit(const Expr *E, const Expr **InnerExpr) {
   auto NameForFirstSlot = Selector.getNameForSlot(0);
   if (NameForFirstSlot.starts_with("alloc") ||
       NameForFirstSlot.starts_with("copy") ||
-      NameForFirstSlot.starts_with("mutableCopy"))
+      NameForFirstSlot.starts_with("mutableCopy")) {
+    if (auto *MD = ObjCMsgExpr->getMethodDecl()) {
+      if (auto *T = MD->getReturnType().getTypePtrOrNull()) {
+        if (T->isVoidType())
+          return false;
+      }
+    }
     return true;
+  }
   if (!NameForFirstSlot.starts_with("init") &&
       !NameForFirstSlot.starts_with("_init"))
     return false;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -339,8 +339,8 @@ bool isAllocInit(const Expr *E, const Expr **InnerExpr) {
       NameForFirstSlot.starts_with("copy") ||
       NameForFirstSlot.starts_with("mutableCopy")) {
     if (auto *MD = ObjCMsgExpr->getMethodDecl()) {
-      if (MD->getReturnType()->isVoidType()) {
-          return false;
+      if (MD->getReturnType()->isVoidType())
+        return false;
     }
     return true;
   }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -339,10 +339,8 @@ bool isAllocInit(const Expr *E, const Expr **InnerExpr) {
       NameForFirstSlot.starts_with("copy") ||
       NameForFirstSlot.starts_with("mutableCopy")) {
     if (auto *MD = ObjCMsgExpr->getMethodDecl()) {
-      if (auto *T = MD->getReturnType().getTypePtrOrNull()) {
-        if (T->isVoidType())
+      if (MD->getReturnType()->isVoidType()) {
           return false;
-      }
     }
     return true;
   }

--- a/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use-arc.mm
@@ -108,7 +108,7 @@ void basic_correct_arc() {
 @implementation SubObj
 
 - (void)copy:(id)sender {
-  [super copy:sender];
+  [super copy:sender]; // no-warning: a void copy does not actually copy anything
 }
 
 @end

--- a/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use-arc.mm
@@ -69,6 +69,9 @@ void basic_correct_arc() {
   return copy;
 }
 
+- (void)copy:(id)sender {
+}
+
 - (void)doWork {
   _number = [[NSNumber alloc] initWithInt:5];
 }
@@ -98,6 +101,17 @@ void basic_correct_arc() {
 }
 
 @end;
+
+@interface SubObj : SomeObj
+@end
+
+@implementation SubObj
+
+- (void)copy:(id)sender {
+  [super copy:sender];
+}
+
+@end
 
 RetainPtr<CVPixelBufferRef> cf_out_argument() {
   auto surface = adoptCF(IOSurfaceCreate(nullptr));

--- a/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use.mm
+++ b/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use.mm
@@ -76,6 +76,9 @@ void basic_correct_arc() {
   return copy;
 }
 
+- (void)copy:(id)sender {
+}
+
 - (void)doWork {
   _number = [[NSNumber alloc] initWithInt:5];
 }
@@ -113,6 +116,17 @@ void basic_correct_arc() {
 }
 
 @end;
+
+@interface SubObj : SomeObj
+@end
+
+@implementation SubObj
+
+- (void)copy:(id)sender {
+  [super copy:sender];
+}
+
+@end
 
 RetainPtr<CVPixelBufferRef> cf_out_argument() {
   auto surface = adoptCF(IOSurfaceCreate(nullptr));


### PR DESCRIPTION
UIResponderStandardEditActions defines (void)copy:(id)sender but this selector should not be treated as a copy operation since it's a "copy" in the sense of application triggering copy & paste for the system pasteboard.