### PR TITLE
[clang][modules] Add single-module-parse-mode callback

### DIFF
--- a/clang/include/clang/Lex/PPCallbacks.h
+++ b/clang/include/clang/Lex/PPCallbacks.h
@@ -212,6 +212,13 @@ public:
                             const Module *Imported) {
   }
 
+  /// Callback invoked whenever a module load was skipped due to enabled
+  /// single-module-parse-mode.
+  ///
+  /// \param Skipped The module that was not loaded.
+  ///
+  virtual void moduleLoadSkipped(Module *Skipped) {}
+
   /// Callback invoked when the end of the main file is reached.
   ///
   /// No subsequent callbacks will be made.
@@ -552,6 +559,11 @@ public:
                     const Module *Imported) override {
     First->moduleImport(ImportLoc, Path, Imported);
     Second->moduleImport(ImportLoc, Path, Imported);
+  }
+
+  void moduleLoadSkipped(Module *Skipped) override {
+    First->moduleLoadSkipped(Skipped);
+    Second->moduleLoadSkipped(Skipped);
   }
 
   void EndOfMainFile() override {

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1994,6 +1994,8 @@ CompilerInstance::loadModule(SourceLocation ImportLoc,
     Module = getPreprocessor().getHeaderSearchInfo().lookupModule(
         ModuleName, ImportLoc, true, !IsInclusionDirective);
     if (Module) {
+      if (PPCallbacks *PPCb = getPreprocessor().getPPCallbacks())
+        PPCb->moduleLoadSkipped(Module);
       // Mark the module and its submodules as if they were loaded from a PCM.
       // This prevents emission of the "missing submodule" diagnostic below.
       std::vector Worklist{Module};

--- a/clang/unittests/Frontend/CompilerInstanceTest.cpp
+++ b/clang/unittests/Frontend/CompilerInstanceTest.cpp
@@ -12,6 +12,7 @@
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
+#include "clang/Lex/PreprocessorOptions.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Format.h"
@@ -150,5 +151,50 @@ TEST(CompilerInstance, MultipleInputsCleansFileIDs) {
   EXPECT_TRUE(Instance.ExecuteAction(Act)) << "Failed to execute action";
   EXPECT_FALSE(Diags->hasErrorOccurred());
   EXPECT_EQ(Diags->getNumWarnings(), 0u);
+}
+
+TEST(CompilerInstance, SingleModuleParseModeCallback) {
+  auto VFS = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
+  VFS->addFile("module.modulemap", 0,
+               MemoryBuffer::getMemBuffer(R"(module m { header "m.h" })"));
+  VFS->addFile("m.h", 0, MemoryBuffer::getMemBuffer(""));
+  VFS->addFile("tu.c", 0, MemoryBuffer::getMemBuffer(R"(#include "m.h")"));
+
+  auto Invocation = createInvocation(
+      {"clang", "tu.c", "-fmodules", "-fmodules-cache-path=/"});
+  Invocation->getPreprocessorOpts().SingleModuleParseMode = true;
+
+  CompilerInstance Instance(std::move(Invocation));
+  Instance.createVirtualFileSystem(VFS);
+  Instance.createFileManager();
+  Instance.createDiagnostics();
+
+  struct ModuleLoadSkippedCallback : PPCallbacks {
+    std::vector<std::string> &SkippedModules;
+    ModuleLoadSkippedCallback(std::vector<std::string> &SkippedModules)
+        : SkippedModules(SkippedModules) {}
+    void moduleLoadSkipped(Module *Skipped) override {
+      SkippedModules.emplace_back(Skipped->getFullModuleName());
+    }
+  };
+
+  struct MyAction : SyntaxOnlyAction {
+    std::vector<std::string> &SkippedModules;
+    MyAction(std::vector<std::string> &SkippedModules)
+        : SkippedModules(SkippedModules) {}
+    bool BeginSourceFileAction(CompilerInstance &CI) override {
+      auto Cb = std::make_unique<ModuleLoadSkippedCallback>(SkippedModules);
+      CI.getPreprocessor().addPPCallbacks(std::move(Cb));
+      return SyntaxOnlyAction::BeginInvocation(CI);
+    }
+  };
+
+  std::vector<std::string> SkippedModules;
+  MyAction Action(SkippedModules);
+  bool Success = Instance.ExecuteAction(Action);
+
+  ASSERT_TRUE(Success);
+  ASSERT_EQ(SkippedModules.size(), 1u);
+  EXPECT_EQ(SkippedModules[0], "m");
 }
 } // anonymous namespace


### PR DESCRIPTION
This PR adds new preprocessor callback that's invoked whenever the single-module-parse-mode skips over a module import. This will be used later on from the dependency scanner.