### PR TITLE
[MemorySSA] Relax clobbering checks for calls to consider writes only

### DIFF
--- a/llvm/lib/Analysis/MemorySSA.cpp
+++ b/llvm/lib/Analysis/MemorySSA.cpp
@@ -312,7 +312,7 @@ instructionClobbersQuery(const MemoryDef *MD, const MemoryLocation &UseLoc,
 
   if (auto *CB = dyn_cast_or_null<CallBase>(UseInst)) {
     ModRefInfo I = AA.getModRefInfo(DefInst, CB);
-    return isModOrRefSet(I);
+    return isModSet(I);
   }
 
   if (auto *DefLoad = dyn_cast<LoadInst>(DefInst))

--- a/llvm/test/Analysis/MemorySSA/function-clobber.ll
+++ b/llvm/test/Analysis/MemorySSA/function-clobber.ll
@@ -51,3 +51,16 @@ if.end:
   call void @readEverything()
   ret void
 }
+
+declare void @fn(ptr %p)
+
+define void @baz(ptr %p) {
+; CHECK:      1 = MemoryDef(liveOnEntry)
+; CHECK-NEXT: call void @fn(ptr %p)
+  call void @fn(ptr %p) memory(argmem: read, inaccessiblemem: readwrite)
+
+; CHECK:      MemoryUse(liveOnEntry)
+; CHECK-NEXT: call void @fn(ptr %p)
+  call void @fn(ptr %p) memory(argmem: read)
+  ret void
+}


### PR DESCRIPTION
Now that getModRefInfo for calls handles read and write effects by examining both calls, the clobbering query no longer needs to treat reads as clobbers. Update the check to consider writes only, aligning call handling with other instructions
