### PR TITLE
[flang][cuda] Update visibility of declaration copied to in gpu.module

### DIFF
--- a/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceFuncTransform.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceFuncTransform.cpp
@@ -223,6 +223,8 @@ class CUFDeviceFuncTransform
           clonedFuncOp->setAttr(gpu::GPUDialect::getKernelFuncAttrName(),
                                 builder.getUnitAttr());
           clonedFuncOp->removeAttr(cuf::getProcAttrName());
+          if (auto funcOp = mlir::dyn_cast<func::FuncOp>(clonedFuncOp))
+            funcOp.setNested();
         }
         gpuModSymTab.insert(clonedFuncOp);
       } else {

--- a/flang/test/Fir/CUDA/cuda-device-func-transform.mlir
+++ b/flang/test/Fir/CUDA/cuda-device-func-transform.mlir
@@ -45,7 +45,7 @@ func.func private @_QMmod1Psub1(!fir.ref<!fir.array<10xi32>> {cuf.data_attr = #c
 
 // CHECK: gpu.func @_QPsub_host_device1()
 
-// CHECK: func.func private @_QMmod1Psub1(!fir.ref<!fir.array<10xi32>> {cuf.data_attr = #cuf.cuda<device>}) attributes {gpu.kernel}
+// CHECK: func.func nested @_QMmod1Psub1(!fir.ref<!fir.array<10xi32>> {cuf.data_attr = #cuf.cuda<device>}) attributes {gpu.kernel}
 
 // CHECK: func.func @_QPsub_global1() attributes {cuf.proc_attr = #cuf.cuda_proc<global>}
 // CHECK-NEXT: return


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/179362 changes which op is checked for visibility during nested symbol resolution. This cause issues in the CUDA Fortran pipeline and make some lookup fails. Update the visibility of declaration copied to the gpu.module to nested. 