### PR TITLE
[ClangScanDeps][test] Avoid writing to readonly dirs

### DIFF
--- a/clang/test/ClangScanDeps/prune-scanning-modules.m
+++ b/clang/test/ClangScanDeps/prune-scanning-modules.m
@@ -8,14 +8,14 @@
 
 // Check no pruning happens because pcms are new enough.
 // RUN: touch -m -a -t 201101010000 %t/modules.timestamp 
-// RUN: clang-scan-deps -j 1 -format experimental-full -o info.json -- %clang -fmodules -F %t/Frameworks \
+// RUN: clang-scan-deps -j 1 -format experimental-full -o /dev/null -- %clang -fmodules -F %t/Frameworks \
 // RUN:   -fmodules-cache-path=%t/cache %t/prune.m -fmodules -fmodules-prune-interval=172800 -fmodules-prune-after=345600
 // RUN: ls -R %t | grep ^Module.*pcm
 // RUN: ls -R %t | grep DependsOnModule.*pcm
 
 // Check no pruning happens because modules.timestamp is new enough.
 // RUN: find %t/cache -name DependsOnModule*.pcm | sed -e 's/\\/\//g' | xargs touch -a -t 201101010000
-// RUN: clang-scan-deps -j 1 -format experimental-full -o info.json -- %clang -fmodules -F %t/Frameworks \
+// RUN: clang-scan-deps -j 1 -format experimental-full -o /dev/null -- %clang -fmodules -F %t/Frameworks \
 // RUN:   -fmodules-cache-path=%t/cache %t/prune.m -fmodules -fmodules-prune-interval=172800 -fmodules-prune-after=345600
 // RUN: ls -R %t/cache | grep ^Module.*pcm
 // RUN: ls -R %t/cache | grep DependsOnModule.*pcm
@@ -24,7 +24,7 @@
 // RUN: touch -m -a -t 201101010000 %t/cache/modules.timestamp 
 // RUN: find %t/cache -name DependsOnModule*.pcm | sed -e 's/\\/\//g' | xargs touch -a -t 201101010000
 // RUN: find %t/cache -name Module*.pcm | sed -e 's/\\/\//g' | xargs touch -a -t 201101010000
-// RUN: clang-scan-deps -j 1 -format experimental-full -o info.json -- %clang -fmodules -F %t/Frameworks -DSKIP_MODULE \
+// RUN: clang-scan-deps -j 1 -format experimental-full -o /dev/null -- %clang -fmodules -F %t/Frameworks -DSKIP_MODULE \
 // RUN:   -fmodules-cache-path=%t/cache %t/prune.m -fmodules -fmodules-prune-interval=172800 -fmodules-prune-after=345600
 // RUN: ls -R %t/cache | not grep ^Module.*pcm
 // RUN: ls -R %t/cache | not grep DependsOnModule.*pcm


### PR DESCRIPTION
Writing files to the current dir fails when tests are run in an environment w/ a readonly build tree. The normal fix is to write to an explicitly writeable dir (i.e. `-o %t/info.json`), but since we don't actually do anything w/ info.json, just write to `/dev/null` instead.