### PR TITLE
[RISCV] Deprecate RISCVSubtarget::hasStdExtCOrZcd() and hasStdExtCOrZcfOrZce().

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -390,7 +390,7 @@ def FeatureStdExtZca
 // Note: Zca conditionally implies C (see RISCVISAInfo::updateImplication).
 def HasStdExtZca
     : Predicate<"Subtarget->hasStdExtZca()">,
-      AssemblerPredicate<(any_of FeatureStdExtZca),
+      AssemblerPredicate<(all_of FeatureStdExtZca),
                          "'C' (Compressed Instructions) or "
                          "'Zca' (part of the C extension, excluding "
                          "compressed floating point loads/stores)">;
@@ -407,23 +407,29 @@ def HasStdExtZcb : Predicate<"Subtarget->hasStdExtZcb()">,
                    AssemblerPredicate<(all_of FeatureStdExtZcb),
                        "'Zcb' (Compressed basic bit manipulation instructions)">;
 
+def FeatureStdExtZcf
+    : RISCVExtension<1, 0,
+                     "Compressed Single-Precision Floating-Point Instructions",
+                     [FeatureStdExtF, FeatureStdExtZca]>,
+      RISCVExtensionBitmask<1, 5>;
+
+def HasStdExtZcf
+    : Predicate<"Subtarget->hasStdExtZcf()">,
+      AssemblerPredicate<(all_of FeatureStdExtZcf),
+                         "'C' (Compressed Instructions) and 'F' (Single-Precision Floating-Point) or "
+                         "'Zcf' (Compressed Single-Precision Floating-Point Instructions)">;
+
 def FeatureStdExtZcd
     : RISCVExtension<1, 0,
                      "Compressed Double-Precision Floating-Point Instructions",
                      [FeatureStdExtD, FeatureStdExtZca]>,
       RISCVExtensionBitmask<1, 4>;
 
-def HasStdExtCOrZcd
-    : Predicate<"Subtarget->hasStdExtCOrZcd()">,
-      AssemblerPredicate<(any_of FeatureStdExtC, FeatureStdExtZcd),
-                         "'C' (Compressed Instructions) or "
+def HasStdExtZcd
+    : Predicate<"Subtarget->hasStdExtZcd()">,
+      AssemblerPredicate<(all_of FeatureStdExtZcd),
+                         "'C' (Compressed Instructions) and 'D' (Double-Precision Floating-Point) or "
                          "'Zcd' (Compressed Double-Precision Floating-Point Instructions)">;
-
-def FeatureStdExtZcf
-    : RISCVExtension<1, 0,
-                     "Compressed Single-Precision Floating-Point Instructions",
-                     [FeatureStdExtF, FeatureStdExtZca]>,
-      RISCVExtensionBitmask<1, 5>;
 
 def FeatureStdExtZclsd
     : RISCVExtension<1, 0,
@@ -456,13 +462,6 @@ def FeatureStdExtZce
                      "Compressed extensions for microcontrollers",
                      [FeatureStdExtZca, FeatureStdExtZcb, FeatureStdExtZcmp,
                       FeatureStdExtZcmt]>;
-
-def HasStdExtCOrZcfOrZce
-    : Predicate<"Subtarget->hasStdExtCOrZcfOrZce()">,
-      AssemblerPredicate<(any_of FeatureStdExtC, FeatureStdExtZcf,
-                                 FeatureStdExtZce),
-                         "'C' (Compressed Instructions) or "
-                         "'Zcf' (Compressed Single-Precision Floating-Point Instructions)">;
 
 def FeatureStdExtZcmop
     : RISCVExtension<1, 0, "Compressed May-Be-Operations",

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -516,7 +516,7 @@ def C_UNIMP : RVInst16<(outs), (ins), "c.unimp", "", [], InstFormatOther>,
 } // Predicates = [HasStdExtZca]
 
 let DecoderNamespace = "RV32Only",
-    Predicates = [HasStdExtCOrZcfOrZce, HasStdExtF, IsRV32] in {
+    Predicates = [HasStdExtZcf, IsRV32] in {
   def C_FLW  : CLoad_ri<0b011, "c.flw", FPR32C, uimm7_lsb00>,
                Sched<[WriteFLD32, ReadFMemBase]> {
     bits<7> imm;
@@ -542,9 +542,9 @@ let DecoderNamespace = "RV32Only",
                  Sched<[WriteFST32, ReadFStoreData, ReadFMemBase]> {
     let Inst{8-7}  = imm{7-6};
   }
-} // DecoderNamespace = "RV32Only", Predicates = [HasStdExtCOrZcfOrZce, HasStdExtF, IsRV32]
+} // DecoderNamespace = "RV32Only", Predicates = [HasStdExtZcf, IsRV32]
 
-let Predicates = [HasStdExtCOrZcd, HasStdExtD] in {
+let Predicates = [HasStdExtZcd] in {
   def C_FLD  : CLoad_ri<0b001, "c.fld", FPR64C, uimm8_lsb000>,
                Sched<[WriteFLD64, ReadFMemBase]> {
     bits<8> imm;
@@ -568,7 +568,7 @@ let Predicates = [HasStdExtCOrZcd, HasStdExtD] in {
                  Sched<[WriteFST64, ReadFStoreData, ReadFMemBase]> {
     let Inst{9-7}   = imm{8-6};
   }
-} // Predicates = [HasStdExtCOrZcd, HasStdExtD] in {
+} // Predicates = [HasStdExtZcd] in {
 
 //===----------------------------------------------------------------------===//
 // HINT Instructions
@@ -620,14 +620,14 @@ def : InstAlias<"c.ldsp $rd, (${rs1})", (C_LDSP GPRNoX0:$rd, SPMem:$rs1, 0)>;
 def : InstAlias<"c.sdsp $rs2, (${rs1})", (C_SDSP GPR:$rs2, SPMem:$rs1, 0)>;
 }
 
-let Predicates = [HasStdExtCOrZcfOrZce, HasStdExtF, IsRV32] in {
+let Predicates = [HasStdExtZcf, IsRV32] in {
 def : InstAlias<"c.flw $rd, (${rs1})", (C_FLW FPR32C:$rd, GPRCMem:$rs1, 0)>;
 def : InstAlias<"c.fsw $rs2, (${rs1})", (C_FSW FPR32C:$rs2, GPRCMem:$rs1, 0)>;
 def : InstAlias<"c.flwsp $rd, (${rs1})", (C_FLWSP FPR32:$rd, SPMem:$rs1, 0)>;
 def : InstAlias<"c.fswsp $rs2, (${rs1})", (C_FSWSP FPR32:$rs2, SPMem:$rs1, 0)>;
 }
 
-let Predicates = [HasStdExtCOrZcd, HasStdExtD] in {
+let Predicates = [HasStdExtZcd] in {
 def : InstAlias<"c.fld $rd, (${rs1})", (C_FLD FPR64C:$rd, GPRCMem:$rs1, 0)>;
 def : InstAlias<"c.fsd $rs2, (${rs1})", (C_FSD FPR64C:$rs2, GPRCMem:$rs1, 0)>;
 def : InstAlias<"c.fldsp $rd, (${rs1})", (C_FLDSP FPR64:$rd, SPMem:$rs1, 0)>;
@@ -912,7 +912,7 @@ def : CompressPat<(SD GPR:$rs2, SPMem:$rs1, uimm9_lsb000:$imm),
 } // Predicates = [HasStdExtZca, IsRV64]
 
 // Zcf Instructions
-let Predicates = [HasStdExtCOrZcfOrZce, HasStdExtF, IsRV32] in {
+let Predicates = [HasStdExtZcf, IsRV32] in {
   // Quadrant 0
   def : CompressPat<(FLW FPR32C:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm),
                     (C_FLW FPR32C:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
@@ -924,10 +924,10 @@ let Predicates = [HasStdExtCOrZcfOrZce, HasStdExtF, IsRV32] in {
                     (C_FLWSP FPR32:$rd, SPMem:$rs1, uimm8_lsb00:$imm)>;
   def : CompressPat<(FSW FPR32:$rs2, SPMem:$rs1, uimm8_lsb00:$imm),
                     (C_FSWSP FPR32:$rs2, SPMem:$rs1, uimm8_lsb00:$imm)>;
-} // Predicates = [HasStdExtCOrZcfOrZce, HasStdExtF, IsRV32]
+} // Predicates = [HasStdExtZcf, IsRV32]
 
 // Zcd Instructions
-let Predicates = [HasStdExtCOrZcd, HasStdExtD] in {
+let Predicates = [HasStdExtZcd] in {
   // Quadrant 0
   def : CompressPat<(FLD FPR64C:$rd, GPRCMem:$rs1, uimm8_lsb000:$imm),
                     (C_FLD FPR64C:$rd, GPRCMem:$rs1, uimm8_lsb000:$imm)>;
@@ -939,4 +939,4 @@ let Predicates = [HasStdExtCOrZcd, HasStdExtD] in {
                     (C_FLDSP FPR64:$rd, SPMem:$rs1, uimm9_lsb000:$imm)>;
   def : CompressPat<(FSD FPR64:$rs2, SPMem:$rs1, uimm9_lsb000:$imm),
                     (C_FSDSP FPR64:$rs2, SPMem:$rs1, uimm9_lsb000:$imm)>;
-} // Predicates = [HasStdExtCOrZcd, HasStdExtD]
+} // Predicates = [HasStdExtZcd]

--- a/llvm/lib/Target/RISCV/RISCVMakeCompressible.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMakeCompressible.cpp
@@ -225,9 +225,9 @@ static bool isCompressibleLoad(const MachineInstr &MI) {
   case RISCV::LD_RV32:
     return STI.hasStdExtZclsd();
   case RISCV::FLW:
-    return !STI.is64Bit() && STI.hasStdExtCOrZcfOrZce();
+    return !STI.is64Bit() && STI.hasStdExtZcf();
   case RISCV::FLD:
-    return STI.hasStdExtCOrZcd();
+    return STI.hasStdExtZcd();
   // For the Xqcilo loads we mark it as compressible only if Xqcilia is also
   // enabled so that QC_E_ADDI can be used to create the new base.
   case RISCV::QC_E_LBU:
@@ -258,9 +258,9 @@ static bool isCompressibleStore(const MachineInstr &MI) {
   case RISCV::SD_RV32:
     return STI.hasStdExtZclsd();
   case RISCV::FSW:
-    return !STI.is64Bit() && STI.hasStdExtCOrZcfOrZce();
+    return !STI.is64Bit() && STI.hasStdExtZcf();
   case RISCV::FSD:
-    return STI.hasStdExtCOrZcd();
+    return STI.hasStdExtZcd();
   // For the Xqcilo stores we mark it as compressible only if Xqcilia is also
   // enabled so that QC_E_ADDI can be used to create the new base.
   case RISCV::QC_E_SB:

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -170,8 +170,9 @@ public:
   bool GETTER() const { return ATTRIBUTE; }
 #include "RISCVGenSubtargetInfo.inc"
 
-  // FIXME: Remove these and use hasStdExtZcd/hasStdExtZcf() instead.
+  LLVM_DEPRECATED("Now Equivalent to hasStdExtZcd", "hasStdExtZcd")
   bool hasStdExtCOrZcd() const { return HasStdExtZcd; }
+  LLVM_DEPRECATED("Now Equivalent to hasStdExtZcf", "hasStdExtZcf")
   bool hasStdExtCOrZcfOrZce() const { return HasStdExtZcf; }
   bool hasStdExtZvl() const { return ZvlLen != 0; }
   bool hasStdExtFOrZfinx() const { return HasStdExtF || HasStdExtZfinx; }

--- a/llvm/test/MC/RISCV/option-arch.s
+++ b/llvm/test/MC/RISCV/option-arch.s
@@ -127,7 +127,8 @@ addi a0, a1, 0
 # CHECK: .option arch, +zve32x
 
 .option arch, rv32i
-.option arch, +zce, +f
+# FIXME: This shouldn't require +zcf.
+.option arch, +zce, +f, +zcf
 # CHECK-INST: flw fa0, 0x0(a0)
 # CHECK: # encoding: [0x08,0x61]
 c.flw fa0, 0(a0)

--- a/llvm/test/MC/RISCV/rv32dc-valid.s
+++ b/llvm/test/MC/RISCV/rv32dc-valid.s
@@ -11,28 +11,24 @@
 #
 # RUN: not llvm-mc -triple riscv32 -mattr=+c \
 # RUN:     -M no-aliases -show-encoding < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT-D %s
+# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT %s
 # RUN: not llvm-mc -triple riscv32 -M no-aliases -show-encoding < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT-DC %s
+# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT %s
 
 # CHECK-ASM-AND-OBJ: c.fldsp  fs0, 504(sp)
 # CHECK-ASM: encoding: [0x7e,0x34]
-# CHECK-NO-EXT-D:  error: instruction requires the following: 'D' (Double-Precision Floating-Point){{$}}
-# CHECK-NO-EXT-DC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions), 'D' (Double-Precision Floating-Point){{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'D' (Double-Precision Floating-Point) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions)
 c.fldsp  fs0, 504(sp)
 # CHECK-ASM-AND-OBJ: c.fsdsp  fa7, 504(sp)
 # CHECK-ASM: encoding: [0xc6,0xbf]
-# CHECK-NO-EXT-D:  error: instruction requires the following: 'D' (Double-Precision Floating-Point){{$}}
-# CHECK-NO-EXT-DC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions), 'D' (Double-Precision Floating-Point){{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'D' (Double-Precision Floating-Point) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions)
 c.fsdsp  fa7, 504(sp)
 
 # CHECK-ASM-AND-OBJ: c.fld  fa3, 248(a5)
 # CHECK-ASM: encoding: [0xf4,0x3f]
-# CHECK-NO-EXT-D:  error: instruction requires the following: 'D' (Double-Precision Floating-Point){{$}}
-# CHECK-NO-EXT-DC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions), 'D' (Double-Precision Floating-Point){{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'D' (Double-Precision Floating-Point) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions)
 c.fld  fa3, 248(a5)
 # CHECK-ASM-AND-OBJ: c.fsd  fa2, 248(a1)
 # CHECK-ASM: encoding: [0xf0,0xbd]
-# CHECK-NO-EXT-D:  error: instruction requires the following: 'D' (Double-Precision Floating-Point){{$}}
-# CHECK-NO-EXT-DC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions), 'D' (Double-Precision Floating-Point){{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'D' (Double-Precision Floating-Point) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions)
 c.fsd  fa2, 248(a1)

--- a/llvm/test/MC/RISCV/rv32fc-valid.s
+++ b/llvm/test/MC/RISCV/rv32fc-valid.s
@@ -11,10 +11,10 @@
 #
 # RUN: not llvm-mc -triple riscv32 -mattr=+c \
 # RUN:     -M no-aliases -show-encoding < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT-F %s
+# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT %s
 # RUN: not llvm-mc -triple riscv32 \
 # RUN:     -M no-aliases -show-encoding < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT-FC %s
+# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT %s
 # RUN: not llvm-mc -triple riscv64 -mattr=+c,+f \
 # RUN:     -M no-aliases -show-encoding < %s 2>&1 \
 # RUN:     | FileCheck -check-prefixes=CHECK-NO-RV32 %s
@@ -23,26 +23,22 @@
 
 # CHECK-ASM-AND-OBJ: c.flwsp  fs0, 252(sp)
 # CHECK-ASM: encoding: [0x7e,0x74]
-# CHECK-NO-EXT-F:  error: instruction requires the following: 'F' (Single-Precision Floating-Point){{$}}
-# CHECK-NO-EXT-FC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions), 'F' (Single-Precision Floating-Point){{$}}
-# CHECK-NO-RV32:  error: instruction requires the following: RV32I Base Instruction Set{{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'F' (Single-Precision Floating-Point) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions){{$}}
+# CHECK-NO-RV32:  error: instruction requires the following: 'C' (Compressed Instructions) and 'F' (Single-Precision Floating-Point) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions), RV32I Base Instruction Set{{$}}
 c.flwsp  fs0, 252(sp)
 # CHECK-ASM-AND-OBJ: c.fswsp  fa7, 252(sp)
 # CHECK-ASM: encoding: [0xc6,0xff]
-# CHECK-NO-EXT-F:  error: instruction requires the following: 'F' (Single-Precision Floating-Point){{$}}
-# CHECK-NO-EXT-FC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions), 'F' (Single-Precision Floating-Point){{$}}
-# CHECK-NO-RV32:  error: instruction requires the following: RV32I Base Instruction Set{{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'F' (Single-Precision Floating-Point) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions){{$}}
+# CHECK-NO-RV32:  error: instruction requires the following: 'C' (Compressed Instructions) and 'F' (Single-Precision Floating-Point) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions), RV32I Base Instruction Set{{$}}
 c.fswsp  fa7, 252(sp)
 
 # CHECK-ASM-AND-OBJ: c.flw  fa3, 124(a5)
 # CHECK-ASM: encoding: [0xf4,0x7f]
-# CHECK-NO-EXT-F:  error: instruction requires the following: 'F' (Single-Precision Floating-Point){{$}}
-# CHECK-NO-EXT-FC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions), 'F' (Single-Precision Floating-Point){{$}}
-# CHECK-NO-RV32:  error: instruction requires the following: RV32I Base Instruction Set{{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'F' (Single-Precision Floating-Point) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions){{$}}
+# CHECK-NO-RV32:  error: instruction requires the following: 'C' (Compressed Instructions) and 'F' (Single-Precision Floating-Point) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions), RV32I Base Instruction Set{{$}}
 c.flw  fa3, 124(a5)
 # CHECK-ASM-AND-OBJ: c.fsw  fa2, 124(a1)
 # CHECK-ASM: encoding: [0xf0,0xfd]
-# CHECK-NO-EXT-F:  error: instruction requires the following: 'F' (Single-Precision Floating-Point){{$}}
-# CHECK-NO-EXT-FC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions), 'F' (Single-Precision Floating-Point){{$}}
-# CHECK-NO-RV32:  error: instruction requires the following: RV32I Base Instruction Set{{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'F' (Single-Precision Floating-Point) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions){{$}}
+# CHECK-NO-RV32:  error: instruction requires the following: 'C' (Compressed Instructions) and 'F' (Single-Precision Floating-Point) or 'Zcf' (Compressed Single-Precision Floating-Point Instructions), RV32I Base Instruction Set{{$}}
 c.fsw  fa2, 124(a1)

--- a/llvm/test/MC/RISCV/rv64dc-valid.s
+++ b/llvm/test/MC/RISCV/rv64dc-valid.s
@@ -11,28 +11,28 @@
 #
 # RUN: not llvm-mc -triple riscv64 -mattr=+c \
 # RUN:     -M no-aliases -show-encoding < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT-D %s
+# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT %s
 # RUN: not llvm-mc -triple riscv64 -M no-aliases -show-encoding < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT-DC %s
+# RUN:     | FileCheck -check-prefixes=CHECK-NO-EXT %s
 
 # CHECK-ASM-AND-OBJ: c.fldsp  fs0, 504(sp)
 # CHECK-ASM: encoding: [0x7e,0x34]
-# CHECK-NO-EXT-D:  error: instruction requires the following: 'D' (Double-Precision Floating-Point){{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'D' (Double-Precision Floating-Point) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions){{$}}
 # CHECK-NO-EXT-DC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions), 'D' (Double-Precision Floating-Point){{$}}
 c.fldsp  fs0, 504(sp)
 # CHECK-ASM-AND-OBJ: c.fsdsp  fa7, 504(sp)
 # CHECK-ASM: encoding: [0xc6,0xbf]
-# CHECK-NO-EXT-D:  error: instruction requires the following: 'D' (Double-Precision Floating-Point){{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'D' (Double-Precision Floating-Point) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions){{$}}
 # CHECK-NO-EXT-DC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions), 'D' (Double-Precision Floating-Point){{$}}
 c.fsdsp  fa7, 504(sp)
 
 # CHECK-ASM-AND-OBJ: c.fld  fa3, 248(a5)
 # CHECK-ASM: encoding: [0xf4,0x3f]
-# CHECK-NO-EXT-D:  error: instruction requires the following: 'D' (Double-Precision Floating-Point){{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'D' (Double-Precision Floating-Point) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions){{$}}
 # CHECK-NO-EXT-DC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions), 'D' (Double-Precision Floating-Point){{$}}
 c.fld  fa3, 248(a5)
 # CHECK-ASM-AND-OBJ: c.fsd  fa2, 248(a1)
 # CHECK-ASM: encoding: [0xf0,0xbd]
-# CHECK-NO-EXT-D:  error: instruction requires the following: 'D' (Double-Precision Floating-Point){{$}}
+# CHECK-NO-EXT:  error: instruction requires the following: 'C' (Compressed Instructions) and 'D' (Double-Precision Floating-Point) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions){{$}}
 # CHECK-NO-EXT-DC:  error: instruction requires the following: 'C' (Compressed Instructions) or 'Zcd' (Compressed Double-Precision Floating-Point Instructions), 'D' (Double-Precision Floating-Point){{$}}
 c.fsd  fa2, 248(a1)


### PR DESCRIPTION
Replace with hasStdExtZcd() and hastStdExtZcf().

Creation of RISCVSubtarget/MCSubtargetInfo handles implication of Zcf and Zcd now. The exception is .option arch handling which will require +zcf and +zcd to be listed explicitly. I'll try to fix this in a follow up. #155035 had the same issue.

I've left the error messages mentioning both Zcf and C+F/D. We can consider changing that in a follow up.