### PR TITLE
[MLIR][Python] Add llvm raw fd ostream c api

### DIFF
--- a/mlir/include/mlir-c/Support.h
+++ b/mlir/include/mlir-c/Support.h
@@ -62,7 +62,7 @@ extern "C" {
 DEFINE_C_API_STRUCT(MlirLlvmThreadPool, void);
 /// Re-export llvm::raw_fd_ostream so as to avoid including the LLVM C API
 /// directly.
-DEFINE_C_API_STRUCT(MlirLlvmRawFdOstream, void);
+DEFINE_C_API_STRUCT(MlirLlvmRawFdOStream, void);
 DEFINE_C_API_STRUCT(MlirTypeID, const void);
 DEFINE_C_API_STRUCT(MlirTypeIDAllocator, void);
 
@@ -157,27 +157,27 @@ MLIR_CAPI_EXPORTED MlirLlvmThreadPool mlirLlvmThreadPoolCreate(void);
 MLIR_CAPI_EXPORTED void mlirLlvmThreadPoolDestroy(MlirLlvmThreadPool pool);
 
 //===----------------------------------------------------------------------===//
-// MlirLlvmRawFdOstream.
+// MlirLlvmRawFdOStream.
 //===----------------------------------------------------------------------===//
 
 /// Create a raw_fd_ostream for the given path. This wrapper is needed because
 /// std::ostream does not provide the file sharing semantics required on
 /// Windows. On failure, returns a null stream and invokes the optional error
 /// callback with the error message.
-MLIR_CAPI_EXPORTED MlirLlvmRawFdOstream
-mlirLlvmRawFdOstreamCreate(const char *path, bool binary,
+MLIR_CAPI_EXPORTED MlirLlvmRawFdOStream
+mlirLlvmRawFdOStreamCreate(const char *path, bool binary,
                            MlirStringCallback errorCallback, void *userData);
 
-/// Write a string to a raw_fd_ostream created with mlirLlvmRawFdOstreamCreate.
-MLIR_CAPI_EXPORTED void mlirLlvmRawFdOstreamWrite(MlirLlvmRawFdOstream stream,
+/// Write a string to a raw_fd_ostream created with mlirLlvmRawFdOStreamCreate.
+MLIR_CAPI_EXPORTED void mlirLlvmRawFdOStreamWrite(MlirLlvmRawFdOStream stream,
                                                   MlirStringRef string);
 
 /// Checks if a raw_fd_ostream is null.
-MLIR_CAPI_EXPORTED bool mlirLlvmRawFdOstreamIsNull(MlirLlvmRawFdOstream stream);
+MLIR_CAPI_EXPORTED bool mlirLlvmRawFdOStreamIsNull(MlirLlvmRawFdOStream stream);
 
-/// Destroy a raw_fd_ostream created with mlirLlvmRawFdOstreamCreate.
+/// Destroy a raw_fd_ostream created with mlirLlvmRawFdOStreamCreate.
 MLIR_CAPI_EXPORTED void
-mlirLlvmRawFdOstreamDestroy(MlirLlvmRawFdOstream stream);
+mlirLlvmRawFdOStreamDestroy(MlirLlvmRawFdOStream stream);
 
 //===----------------------------------------------------------------------===//
 // TypeID API.

--- a/mlir/include/mlir-c/Support.h
+++ b/mlir/include/mlir-c/Support.h
@@ -162,8 +162,14 @@ MLIR_CAPI_EXPORTED void mlirLlvmThreadPoolDestroy(MlirLlvmThreadPool pool);
 
 /// Create a raw_fd_ostream for the given path. This wrapper is needed because
 /// std::ostream does not provide the file sharing semantics required on
-/// Windows. On failure, returns a null stream and invokes the optional error
-/// callback with the error message.
+/// Windows.
+/// - `path`: output file path.
+/// - `binary`: controls text vs binary mode.
+/// - `errorCallback`: called with an error message on failure (optional).
+/// - `userData`: forwarded to `errorCallback` so it can copy the error message
+///   into caller-owned storage (e.g., a `std::string`).
+/// On failure, returns a null stream and invokes the optional error callback
+/// with the error message.
 MLIR_CAPI_EXPORTED MlirLlvmRawFdOStream
 mlirLlvmRawFdOStreamCreate(const char *path, bool binary,
                            MlirStringCallback errorCallback, void *userData);

--- a/mlir/include/mlir-c/Support.h
+++ b/mlir/include/mlir-c/Support.h
@@ -60,6 +60,9 @@ extern "C" {
 
 /// Re-export llvm::ThreadPool so as to avoid including the LLVM C API directly.
 DEFINE_C_API_STRUCT(MlirLlvmThreadPool, void);
+/// Re-export llvm::raw_fd_ostream so as to avoid including the LLVM C API
+/// directly.
+DEFINE_C_API_STRUCT(MlirLlvmRawFdOstream, void);
 DEFINE_C_API_STRUCT(MlirTypeID, const void);
 DEFINE_C_API_STRUCT(MlirTypeIDAllocator, void);
 
@@ -152,6 +155,29 @@ MLIR_CAPI_EXPORTED MlirLlvmThreadPool mlirLlvmThreadPoolCreate(void);
 
 /// Destroy an LLVM thread pool.
 MLIR_CAPI_EXPORTED void mlirLlvmThreadPoolDestroy(MlirLlvmThreadPool pool);
+
+//===----------------------------------------------------------------------===//
+// MlirLlvmRawFdOstream.
+//===----------------------------------------------------------------------===//
+
+/// Create a raw_fd_ostream for the given path. This wrapper is needed because
+/// std::ostream does not provide the file sharing semantics required on
+/// Windows. On failure, returns a null stream and invokes the optional error
+/// callback with the error message.
+MLIR_CAPI_EXPORTED MlirLlvmRawFdOstream mlirLlvmRawFdOstreamCreate(
+    const char *path, bool binary, MlirStringCallback errorCallback,
+    void *userData);
+
+/// Write a string to a raw_fd_ostream created with mlirLlvmRawFdOstreamCreate.
+MLIR_CAPI_EXPORTED void mlirLlvmRawFdOstreamWrite(
+    MlirLlvmRawFdOstream stream, MlirStringRef string);
+
+/// Checks if a raw_fd_ostream is null.
+MLIR_CAPI_EXPORTED bool mlirLlvmRawFdOstreamIsNull(MlirLlvmRawFdOstream stream);
+
+/// Destroy a raw_fd_ostream created with mlirLlvmRawFdOstreamCreate.
+MLIR_CAPI_EXPORTED void
+mlirLlvmRawFdOstreamDestroy(MlirLlvmRawFdOstream stream);
 
 //===----------------------------------------------------------------------===//
 // TypeID API.

--- a/mlir/include/mlir-c/Support.h
+++ b/mlir/include/mlir-c/Support.h
@@ -164,13 +164,13 @@ MLIR_CAPI_EXPORTED void mlirLlvmThreadPoolDestroy(MlirLlvmThreadPool pool);
 /// std::ostream does not provide the file sharing semantics required on
 /// Windows. On failure, returns a null stream and invokes the optional error
 /// callback with the error message.
-MLIR_CAPI_EXPORTED MlirLlvmRawFdOstream mlirLlvmRawFdOstreamCreate(
-    const char *path, bool binary, MlirStringCallback errorCallback,
-    void *userData);
+MLIR_CAPI_EXPORTED MlirLlvmRawFdOstream
+mlirLlvmRawFdOstreamCreate(const char *path, bool binary,
+                           MlirStringCallback errorCallback, void *userData);
 
 /// Write a string to a raw_fd_ostream created with mlirLlvmRawFdOstreamCreate.
-MLIR_CAPI_EXPORTED void mlirLlvmRawFdOstreamWrite(
-    MlirLlvmRawFdOstream stream, MlirStringRef string);
+MLIR_CAPI_EXPORTED void mlirLlvmRawFdOstreamWrite(MlirLlvmRawFdOstream stream,
+                                                  MlirStringRef string);
 
 /// Checks if a raw_fd_ostream is null.
 MLIR_CAPI_EXPORTED bool mlirLlvmRawFdOstreamIsNull(MlirLlvmRawFdOstream stream);

--- a/mlir/include/mlir/Bindings/Python/NanobindUtils.h
+++ b/mlir/include/mlir/Bindings/Python/NanobindUtils.h
@@ -165,7 +165,7 @@ public:
     std::string filePath;
     if (nanobind::try_cast<std::string>(fileOrStringObject, filePath)) {
       std::string errorMessage;
-      auto errorCallback = [](MlirStringRef message, void *userData) {
+      auto errorCallback = +[](MlirStringRef message, void *userData) {
         auto *storage = static_cast<std::string *>(userData);
         storage->assign(message.data, message.length);
       };

--- a/mlir/include/mlir/Bindings/Python/NanobindUtils.h
+++ b/mlir/include/mlir/Bindings/Python/NanobindUtils.h
@@ -169,14 +169,14 @@ public:
         auto *storage = static_cast<std::string *>(userData);
         storage->assign(message.data, message.length);
       };
-      MlirLlvmRawFdOstream stream = mlirLlvmRawFdOstreamCreate(
+      MlirLlvmRawFdOStream stream = mlirLlvmRawFdOStreamCreate(
           filePath.c_str(), binary, errorCallback, &errorMessage);
-      if (mlirLlvmRawFdOstreamIsNull(stream)) {
+      if (mlirLlvmRawFdOStreamIsNull(stream)) {
         throw nanobind::value_error(
             (std::string("Unable to open file for writing: ") + errorMessage)
                 .c_str());
       }
-      writeTarget.emplace<MlirLlvmRawFdOstream>(stream);
+      writeTarget.emplace<MlirLlvmRawFdOStream>(stream);
     } else {
       writeTarget.emplace<nanobind::object>(fileOrStringObject.attr("write"));
     }
@@ -184,12 +184,12 @@ public:
 
   ~PyFileAccumulator() {
     if (writeTarget.index() == 1)
-      mlirLlvmRawFdOstreamDestroy(std::get<MlirLlvmRawFdOstream>(writeTarget));
+      mlirLlvmRawFdOStreamDestroy(std::get<MlirLlvmRawFdOStream>(writeTarget));
   }
 
   MlirStringCallback getCallback() {
     return writeTarget.index() == 0 ? getPyWriteCallback()
-                                    : getOstreamCallback();
+                                    : getOStreamCallback();
   }
 
   void *getUserData() { return this; }
@@ -211,15 +211,15 @@ private:
     };
   }
 
-  MlirStringCallback getOstreamCallback() {
+  MlirStringCallback getOStreamCallback() {
     return [](MlirStringRef part, void *userData) {
       PyFileAccumulator *accum = static_cast<PyFileAccumulator *>(userData);
-      mlirLlvmRawFdOstreamWrite(
-          std::get<MlirLlvmRawFdOstream>(accum->writeTarget), part);
+      mlirLlvmRawFdOStreamWrite(
+          std::get<MlirLlvmRawFdOStream>(accum->writeTarget), part);
     };
   }
 
-  std::variant<nanobind::object, MlirLlvmRawFdOstream> writeTarget;
+  std::variant<nanobind::object, MlirLlvmRawFdOStream> writeTarget;
   bool binary;
 };
 

--- a/mlir/include/mlir/Bindings/Python/NanobindUtils.h
+++ b/mlir/include/mlir/Bindings/Python/NanobindUtils.h
@@ -156,21 +156,21 @@ struct PyPrintAccumulator {
   }
 };
 
+/// RAII wrapper for MlirLlvmRawFdOStream that ensures destruction on scope
+/// exit.
+struct RAIIMlirLlvmRawFdOStream : MlirLlvmRawFdOStream {
+  RAIIMlirLlvmRawFdOStream(MlirLlvmRawFdOStream stream)
+      : MlirLlvmRawFdOStream(stream) {}
+  RAIIMlirLlvmRawFdOStream(const RAIIMlirLlvmRawFdOStream &) = delete;
+  RAIIMlirLlvmRawFdOStream &
+  operator=(const RAIIMlirLlvmRawFdOStream &) = delete;
+  ~RAIIMlirLlvmRawFdOStream() { mlirLlvmRawFdOStreamDestroy(*this); }
+};
+
 /// Accumulates into a file, either writing text (default)
 /// or binary. The file may be a Python file-like object or a path to a file.
 class PyFileAccumulator {
 public:
-  /// RAII wrapper for MlirLlvmRawFdOStream that ensures destruction on scope
-  /// exit.
-  struct RAIIMlirLlvmRawFdOStream : MlirLlvmRawFdOStream {
-    RAIIMlirLlvmRawFdOStream(MlirLlvmRawFdOStream stream)
-        : MlirLlvmRawFdOStream(stream) {}
-    RAIIMlirLlvmRawFdOStream(const RAIIMlirLlvmRawFdOStream &) = delete;
-    RAIIMlirLlvmRawFdOStream &
-    operator=(const RAIIMlirLlvmRawFdOStream &) = delete;
-    ~RAIIMlirLlvmRawFdOStream() { mlirLlvmRawFdOStreamDestroy(*this); }
-  };
-
   PyFileAccumulator(const nanobind::object &fileOrStringObject, bool binary)
       : binary(binary) {
     std::string filePath;

--- a/mlir/include/mlir/CAPI/Support.h
+++ b/mlir/include/mlir/CAPI/Support.h
@@ -47,7 +47,7 @@ inline llvm::LogicalResult unwrap(MlirLogicalResult res) {
 }
 
 DEFINE_C_API_PTR_METHODS(MlirLlvmThreadPool, llvm::ThreadPoolInterface)
-DEFINE_C_API_PTR_METHODS(MlirLlvmRawFdOstream, llvm::raw_fd_ostream)
+DEFINE_C_API_PTR_METHODS(MlirLlvmRawFdOStream, llvm::raw_fd_ostream)
 DEFINE_C_API_METHODS(MlirTypeID, mlir::TypeID)
 DEFINE_C_API_PTR_METHODS(MlirTypeIDAllocator, mlir::TypeIDAllocator)
 

--- a/mlir/include/mlir/CAPI/Support.h
+++ b/mlir/include/mlir/CAPI/Support.h
@@ -23,6 +23,7 @@
 
 namespace llvm {
 class ThreadPoolInterface;
+class raw_fd_ostream;
 } // namespace llvm
 
 /// Converts a StringRef into its MLIR C API equivalent.
@@ -46,6 +47,7 @@ inline llvm::LogicalResult unwrap(MlirLogicalResult res) {
 }
 
 DEFINE_C_API_PTR_METHODS(MlirLlvmThreadPool, llvm::ThreadPoolInterface)
+DEFINE_C_API_PTR_METHODS(MlirLlvmRawFdOstream, llvm::raw_fd_ostream)
 DEFINE_C_API_METHODS(MlirTypeID, mlir::TypeID)
 DEFINE_C_API_PTR_METHODS(MlirTypeIDAllocator, mlir::TypeIDAllocator)
 

--- a/mlir/lib/CAPI/IR/Support.cpp
+++ b/mlir/lib/CAPI/IR/Support.cpp
@@ -39,8 +39,8 @@ void mlirLlvmThreadPoolDestroy(MlirLlvmThreadPool threadPool) {
 // LLVM raw_fd_ostream API.
 //===----------------------------------------------------------------------===//
 
-MlirLlvmRawFdOstream
-mlirLlvmRawFdOstreamCreate(const char *path, bool binary,
+MlirLlvmRawFdOStream
+mlirLlvmRawFdOStreamCreate(const char *path, bool binary,
                            MlirStringCallback errorCallback, void *userData) {
   std::error_code ec;
   auto flags = binary ? llvm::sys::fs::OF_None : llvm::sys::fs::OF_Text;
@@ -57,16 +57,16 @@ mlirLlvmRawFdOstreamCreate(const char *path, bool binary,
   return wrap(stream);
 }
 
-void mlirLlvmRawFdOstreamWrite(MlirLlvmRawFdOstream stream,
+void mlirLlvmRawFdOStreamWrite(MlirLlvmRawFdOStream stream,
                                MlirStringRef string) {
   unwrap(stream)->write(string.data, string.length);
 }
 
-bool mlirLlvmRawFdOstreamIsNull(MlirLlvmRawFdOstream stream) {
+bool mlirLlvmRawFdOStreamIsNull(MlirLlvmRawFdOStream stream) {
   return !stream.ptr;
 }
 
-void mlirLlvmRawFdOstreamDestroy(MlirLlvmRawFdOstream stream) {
+void mlirLlvmRawFdOStreamDestroy(MlirLlvmRawFdOStream stream) {
   delete unwrap(stream);
 }
 

--- a/mlir/lib/CAPI/IR/Support.cpp
+++ b/mlir/lib/CAPI/IR/Support.cpp
@@ -39,9 +39,9 @@ void mlirLlvmThreadPoolDestroy(MlirLlvmThreadPool threadPool) {
 // LLVM raw_fd_ostream API.
 //===----------------------------------------------------------------------===//
 
-MlirLlvmRawFdOstream mlirLlvmRawFdOstreamCreate(
-    const char *path, bool binary, MlirStringCallback errorCallback,
-    void *userData) {
+MlirLlvmRawFdOstream
+mlirLlvmRawFdOstreamCreate(const char *path, bool binary,
+                           MlirStringCallback errorCallback, void *userData) {
   std::error_code ec;
   auto flags = binary ? llvm::sys::fs::OF_None : llvm::sys::fs::OF_Text;
   auto *stream = new llvm::raw_fd_ostream(path, ec, flags);


### PR DESCRIPTION
This PR adds a C API `MlirLlvmRawFdOstream` for `llvm::raw_fd_ostream`, which cannot be safely replaced by `std::ofstream` on Windows.
`llvm::raw_fd_ostream` configures Win32 file sharing flags, allowing other handles (e.g. Python temp file handles) to coexist, see details [here](https://llvm.org/doxygen/Windows_2Path_8inc_source.html#l1281), while `std::ofstream` disables file sharing by default.