### PR TITLE
[mlir][shard,mpi][NFC] Add missing header

### DIFF
--- a/mlir/include/mlir/Dialect/MPI/IR/Utils.h
+++ b/mlir/include/mlir/Dialect/MPI/IR/Utils.h
@@ -10,6 +10,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/DLTI/DLTI.h"
+#include "mlir/Dialect/MPI/IR/MPI.h"
 #include "mlir/IR/PatternMatch.h"
 
 namespace mlir {


### PR DESCRIPTION
Utils.h uses `mlir::mpi::CommWorldOp` w/o including the necessary header (https://llvm.org/docs/CodingStandards.html#self-contained-headers), making this not self contained. It only works because all the .cpp files that use it have the necessary include.