### PR TITLE
[lib++][test] Align `atomic_ref` underlying variable as required

### DIFF
--- a/libcxx/test/std/atomics/atomics.ref/address.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/address.pass.cpp
@@ -20,7 +20,7 @@
 template <typename T>
 struct TestAddress {
   void operator()() const {
-    T x(T(1));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
     const std::atomic_ref<T> a(x);
 
     std::same_as<T*> decltype(auto) p = a.address();

--- a/libcxx/test/std/atomics/atomics.ref/assign.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/assign.pass.cpp
@@ -24,7 +24,7 @@ template <typename T>
 struct TestAssign {
   void operator()() const {
     {
-      T x(T(1));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
       std::atomic_ref<T> const a(x);
 
       std::same_as<T> decltype(auto) y = (a = T(2));

--- a/libcxx/test/std/atomics/atomics.ref/bitwise_and_assign.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/bitwise_and_assign.pass.cpp
@@ -32,7 +32,7 @@ struct TestBitwiseAndAssign {
   void operator()() const {
     static_assert(std::is_integral_v<T>);
 
-    T x(T(1));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
     std::atomic_ref<T> const a(x);
 
     std::same_as<T> decltype(auto) y = (a &= T(1));

--- a/libcxx/test/std/atomics/atomics.ref/bitwise_or_assign.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/bitwise_or_assign.pass.cpp
@@ -32,7 +32,7 @@ struct TestBitwiseOrAssign {
   void operator()() const {
     static_assert(std::is_integral_v<T>);
 
-    T x(T(1));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
     std::atomic_ref<T> const a(x);
 
     std::same_as<T> decltype(auto) y = (a |= T(2));

--- a/libcxx/test/std/atomics/atomics.ref/bitwise_xor_assign.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/bitwise_xor_assign.pass.cpp
@@ -32,7 +32,7 @@ struct TestBitwiseXorAssign {
   void operator()() const {
     static_assert(std::is_integral_v<T>);
 
-    T x(T(1));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
     std::atomic_ref<T> const a(x);
 
     std::same_as<T> decltype(auto) y = (a ^= T(2));

--- a/libcxx/test/std/atomics/atomics.ref/compare_exchange_strong.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/compare_exchange_strong.pass.cpp
@@ -28,7 +28,7 @@ template <typename T>
 struct TestCompareExchangeStrong {
   void operator()() const {
     {
-      T x(T(1));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
@@ -44,7 +44,7 @@ struct TestCompareExchangeStrong {
       ASSERT_NOEXCEPT(a.compare_exchange_strong(t, T(2)));
     }
     {
-      T x(T(1));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
@@ -60,7 +60,7 @@ struct TestCompareExchangeStrong {
       ASSERT_NOEXCEPT(a.compare_exchange_strong(t, T(2), std::memory_order_seq_cst));
     }
     {
-      T x(T(1));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
       std::atomic_ref<T> const a(x);
 
       T t(T(1));

--- a/libcxx/test/std/atomics/atomics.ref/compare_exchange_weak.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/compare_exchange_weak.pass.cpp
@@ -28,7 +28,7 @@ template <typename T>
 struct TestCompareExchangeWeak {
   void operator()() const {
     {
-      T x(T(1));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
       std::atomic_ref<T> const a(x);
 
       T t(T(1));
@@ -44,7 +44,7 @@ struct TestCompareExchangeWeak {
       ASSERT_NOEXCEPT(a.compare_exchange_weak(t, T(2)));
     }
     {
-      T x(T(1));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
       std::atomic_ref<T> const a(x);
 
       T t(T(1));

--- a/libcxx/test/std/atomics/atomics.ref/convert.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/convert.pass.cpp
@@ -24,7 +24,7 @@ struct TestConvert {
   void operator()() const {
     T x(T(1));
 
-    T copy = x;
+    alignas(std::atomic_ref<T>::required_alignment) T copy = x;
     std::atomic_ref<T> const a(copy);
 
     T converted = a;

--- a/libcxx/test/std/atomics/atomics.ref/ctor.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/ctor.pass.cpp
@@ -25,7 +25,7 @@ struct TestCtor {
     static_assert(!std::is_convertible_v<T, std::atomic_ref<T>>);
     static_assert(std::is_constructible_v<std::atomic_ref<T>, T&>);
 
-    T x(T(0));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(0));
     std::atomic_ref<T> a(x);
     (void)a;
   }

--- a/libcxx/test/std/atomics/atomics.ref/deduction.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/deduction.pass.cpp
@@ -21,7 +21,7 @@
 template <typename T>
 struct TestDeduction {
   void operator()() const {
-    T x(T(0));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(0));
     std::atomic_ref a(x);
     ASSERT_SAME_TYPE(decltype(a), std::atomic_ref<T>);
   }

--- a/libcxx/test/std/atomics/atomics.ref/exchange.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/exchange.pass.cpp
@@ -24,7 +24,7 @@ template <typename T>
 struct TestExchange {
   void operator()() const {
     {
-      T x(T(1));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
       std::atomic_ref<T> const a(x);
 
       {

--- a/libcxx/test/std/atomics/atomics.ref/fetch_add.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_add.pass.cpp
@@ -38,7 +38,7 @@ template <typename T>
 struct TestFetchAdd {
   void operator()() const {
     if constexpr (std::is_arithmetic_v<T>) {
-      T x(T(1));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
       std::atomic_ref<T> const a(x);
 
       {
@@ -57,7 +57,7 @@ struct TestFetchAdd {
     } else if constexpr (std::is_pointer_v<T>) {
       using U = std::remove_pointer_t<T>;
       U t[9]  = {};
-      T p{&t[1]};
+      alignas(std::atomic_ref<T>::required_alignment) T p{&t[1]};
       std::atomic_ref<T> const a(p);
 
       {

--- a/libcxx/test/std/atomics/atomics.ref/fetch_and.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_and.pass.cpp
@@ -35,7 +35,7 @@ struct TestFetchAnd {
   void operator()() const {
     static_assert(std::is_integral_v<T>);
 
-    T x(T(1));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
     std::atomic_ref<T> const a(x);
 
     {

--- a/libcxx/test/std/atomics/atomics.ref/fetch_or.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_or.pass.cpp
@@ -35,7 +35,7 @@ struct TestFetchOr {
   void operator()() const {
     static_assert(std::is_integral_v<T>);
 
-    T x(T(1));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
     std::atomic_ref<T> const a(x);
 
     {

--- a/libcxx/test/std/atomics/atomics.ref/fetch_sub.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_sub.pass.cpp
@@ -38,7 +38,7 @@ template <typename T>
 struct TestFetchSub {
   void operator()() const {
     if constexpr (std::is_arithmetic_v<T>) {
-      T x(T(7));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(7));
       std::atomic_ref<T> const a(x);
 
       {

--- a/libcxx/test/std/atomics/atomics.ref/fetch_xor.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/fetch_xor.pass.cpp
@@ -35,7 +35,7 @@ struct TestFetchXor {
   void operator()() const {
     static_assert(std::is_integral_v<T>);
 
-    T x(T(1));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
     std::atomic_ref<T> const a(x);
 
     {

--- a/libcxx/test/std/atomics/atomics.ref/increment_decrement.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/increment_decrement.pass.cpp
@@ -49,7 +49,7 @@ template <typename T>
 struct TestIncrementDecrement {
   void operator()() const {
     if constexpr (std::is_integral_v<T>) {
-      T x(T(1));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
       std::atomic_ref<T> const a(x);
 
       {
@@ -82,7 +82,7 @@ struct TestIncrementDecrement {
     } else if constexpr (std::is_pointer_v<T>) {
       using U = std::remove_pointer_t<T>;
       U t[9]  = {};
-      T p{&t[1]};
+      alignas(std::atomic_ref<T>::required_alignment) T p{&t[1]};
       std::atomic_ref<T> const a(p);
 
       {

--- a/libcxx/test/std/atomics/atomics.ref/is_always_lock_free.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/is_always_lock_free.pass.cpp
@@ -60,16 +60,16 @@ void check_always_lock_free(std::atomic_ref<T> const& a) {
   } while (0)
 
 void test() {
-  char c = 'x';
+  alignas(std::atomic_ref<char>::required_alignment) char c = 'x';
   check_always_lock_free(std::atomic_ref<char>(c));
 
-  int i = 0;
+  alignas(std::atomic_ref<int>::required_alignment) int i = 0;
   check_always_lock_free(std::atomic_ref<int>(i));
 
-  float f = 0.f;
+  alignas(std::atomic_ref<float>::required_alignment) float f = 0.f;
   check_always_lock_free(std::atomic_ref<float>(f));
 
-  int* p = &i;
+  alignas(std::atomic_ref<int*>::required_alignment) int* p = &i;
   check_always_lock_free(std::atomic_ref<int*>(p));
 
   CHECK_ALWAYS_LOCK_FREE(struct Empty{});

--- a/libcxx/test/std/atomics/atomics.ref/load.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/load.pass.cpp
@@ -23,7 +23,7 @@
 template <typename T>
 struct TestLoad {
   void operator()() const {
-    T x(T(1));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
     std::atomic_ref<T> const a(x);
 
     {

--- a/libcxx/test/std/atomics/atomics.ref/notify_all.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/notify_all.pass.cpp
@@ -25,7 +25,7 @@
 template <typename T>
 struct TestNotifyAll {
   void operator()() const {
-    T x(T(1));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
     std::atomic_ref<T> const a(x);
 
     bool done                      = false;

--- a/libcxx/test/std/atomics/atomics.ref/notify_one.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/notify_one.pass.cpp
@@ -25,7 +25,7 @@
 template <typename T>
 struct TestNotifyOne {
   void operator()() const {
-    T x(T(1));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
     std::atomic_ref<T> const a(x);
 
     std::thread t = support::make_test_thread([&]() {

--- a/libcxx/test/std/atomics/atomics.ref/operator_minus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/operator_minus_equals.pass.cpp
@@ -34,7 +34,7 @@ template <typename T>
 struct TestOperatorMinusEquals {
   void operator()() const {
     if constexpr (std::is_arithmetic_v<T>) {
-      T x(T(3));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(3));
       std::atomic_ref<T> const a(x);
 
       std::same_as<T> decltype(auto) y = (a -= T(2));
@@ -44,7 +44,7 @@ struct TestOperatorMinusEquals {
     } else if constexpr (std::is_pointer_v<T>) {
       using U = std::remove_pointer_t<T>;
       U t[9]  = {};
-      T p{&t[3]};
+      alignas(std::atomic_ref<T>::required_alignment) T p{&t[3]};
       std::atomic_ref<T> const a(p);
 
       std::same_as<T> decltype(auto) y = (a -= 2);

--- a/libcxx/test/std/atomics/atomics.ref/operator_plus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/operator_plus_equals.pass.cpp
@@ -34,7 +34,7 @@ template <typename T>
 struct TestOperatorPlusEquals {
   void operator()() const {
     if constexpr (std::is_arithmetic_v<T>) {
-      T x(T(1));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
       std::atomic_ref<T> const a(x);
 
       std::same_as<T> decltype(auto) y = (a += T(2));
@@ -44,7 +44,7 @@ struct TestOperatorPlusEquals {
     } else if constexpr (std::is_pointer_v<T>) {
       using U = std::remove_pointer_t<T>;
       U t[9]  = {};
-      T p{&t[1]};
+      alignas(std::atomic_ref<T>::required_alignment) T p{&t[1]};
       std::atomic_ref<T> const a(p);
 
       std::same_as<T> decltype(auto) y = (a += 2);

--- a/libcxx/test/std/atomics/atomics.ref/requires-trivially-copyable.verify.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/requires-trivially-copyable.verify.cpp
@@ -20,7 +20,8 @@ void trivially_copyable() {
   struct X {
     X() = default;
     X(X const&) {} // -> not trivially copyable
-  } x;
+  };
+  alignas(std::atomic_ref<X>::required_alignment) X x;
   // expected-error-re@*:* {{static assertion failed {{.*}}atomic_ref<T> requires that 'T' be a trivially copyable type}}
   std::atomic_ref<X> r(x);
 }

--- a/libcxx/test/std/atomics/atomics.ref/store.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/store.pass.cpp
@@ -22,7 +22,7 @@
 template <typename T>
 struct TestStore {
   void operator()() const {
-    T x(T(1));
+    alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
     std::atomic_ref<T> const a(x);
 
     a.store(T(2));

--- a/libcxx/test/std/atomics/atomics.ref/test_helper.h
+++ b/libcxx/test/std/atomics/atomics.ref/test_helper.h
@@ -48,9 +48,9 @@ void test_seq_cst(StoreOp store_op, LoadOp load_op) {
     T old_value(make_value<T>(0));
     T new_value(make_value<T>(1));
 
-    T copy_x = old_value;
+    alignas(std::atomic_ref<T>::required_alignment) T copy_x = old_value;
     std::atomic_ref<T> const x(copy_x);
-    T copy_y = old_value;
+    alignas(std::atomic_ref<T>::required_alignment) T copy_y = old_value;
     std::atomic_ref<T> const y(copy_y);
 
     std::atomic_bool x_updated_first(false);
@@ -101,7 +101,7 @@ void test_acquire_release(StoreOp store_op, LoadOp load_op) {
     T old_value(make_value<T>(0));
     T new_value(make_value<T>(1));
 
-    T copy = old_value;
+    alignas(std::atomic_ref<T>::required_alignment) T copy = old_value;
     std::atomic_ref<T> const at(copy);
     int non_atomic = 5;
 

--- a/libcxx/test/std/atomics/atomics.ref/wait.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/wait.pass.cpp
@@ -28,7 +28,7 @@ template <typename T>
 struct TestWait {
   void operator()() const {
     {
-      T x(T(1));
+      alignas(std::atomic_ref<T>::required_alignment) T x(T(1));
       std::atomic_ref<T> const a(x);
 
       assert(a.load() == T(1));


### PR DESCRIPTION
There is one pre-existing `alignas(std::atomic_ref<T>::required_alignment)`:
https://github.com/llvm/llvm-project/blob/1f8a3f2fdbf51cbba4635ef05e8139039a105c2c/libcxx/test/std/atomics/atomics.ref/is_always_lock_free.pass.cpp#L54-L60
This PR adds more of them.

On 32-bit Windows ABI just creating a variable on stack is not enough, so 32-bit MSVC fails these tests before the fix.
