### PR TITLE
[MLGO] Ensure cmd_filter is marked Optional

### DIFF
--- a/llvm/utils/mlgo-utils/mlgo/corpus/extract_ir_lib.py
+++ b/llvm/utils/mlgo-utils/mlgo/corpus/extract_ir_lib.py
@@ -122,7 +122,7 @@ class TrainingIRExtractor:
     def _extract_clang_artifacts(
         self,
         llvm_objcopy_path: str,
-        cmd_filter: str,
+        cmd_filter: Optional[str],
         is_thinlto: bool,
         cmd_section_name: str,
         bitcode_section_name: str,
@@ -343,7 +343,7 @@ def run_extraction(
     objs: List[TrainingIRExtractor],
     num_workers: int,
     llvm_objcopy_path: str,
-    cmd_filter: str,
+    cmd_filter: Optional[str],
     thinlto_build: str,
     cmd_section_name: str,
     bitcode_section_name: str,


### PR DESCRIPTION
cmd_filter is supposed to be set to None if there is no filter according to the API documentation. This is not actually allowed currently though according to the type information. Update the type information to match what is intended.