### PR TITLE
 [llvm/CAS] Add file-based APIs to `OnDiskGraphDB`

### DIFF
--- a/llvm/include/llvm/CAS/BuiltinObjectHasher.h
+++ b/llvm/include/llvm/CAS/BuiltinObjectHasher.h
@@ -39,6 +39,8 @@ public:
     return H.finish();
   }
 
+  static Expected<HashT> hashFile(StringRef FilePath);
+
 private:
   HashT finish() { return Hasher.final(); }
 

--- a/llvm/lib/CAS/BuiltinObjectHasher.cpp
+++ b/llvm/lib/CAS/BuiltinObjectHasher.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/BuiltinObjectHasher.h"
+#include "llvm/Support/BLAKE3.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+template <class HasherT>
+Expected<typename BuiltinObjectHasher<HasherT>::HashT>
+BuiltinObjectHasher<HasherT>::hashFile(StringRef FilePath) {
+  BuiltinObjectHasher H;
+  H.updateSize(0); // 0 refs
+
+  sys::fs::file_t FD;
+  if (Error E = sys::fs::openNativeFileForRead(FilePath).moveInto(FD))
+    return E;
+
+  sys::fs::file_status Status;
+  std::error_code EC = sys::fs::status(FD, Status);
+  if (EC)
+    return createFileError(FilePath, EC);
+  // FIXME: Do we need to add a hash of the data size? If we remove that we can
+  // avoid needing to read the file size before reading the file contents.
+  H.updateSize(Status.getSize());
+
+  size_t ChunkSize = sys::fs::DefaultReadChunkSize;
+  SmallVector<char, 0> Buffer;
+  Buffer.resize_for_overwrite(ChunkSize);
+  for (;;) {
+    Expected<size_t> ReadBytes =
+        sys::fs::readNativeFile(FD, MutableArrayRef(Buffer.begin(), ChunkSize));
+    if (!ReadBytes)
+      return ReadBytes.takeError();
+    if (*ReadBytes == 0)
+      break;
+    H.Hasher.update(toStringRef(ArrayRef(Buffer).take_front(*ReadBytes)));
+  }
+
+  return H.finish();
+}
+
+// Provide the definition for when using the BLAKE3 hasher.
+template Expected<BuiltinObjectHasher<BLAKE3>::HashT>
+BuiltinObjectHasher<BLAKE3>::hashFile(StringRef FilePath);

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llvm_component_library(LLVMCAS
   ActionCache.cpp
   ActionCaches.cpp
   BuiltinCAS.cpp
+  BuiltinObjectHasher.cpp
   BuiltinUnifiedCASDatabases.cpp
   CASNodeSchema.cpp
   DatabaseFile.cpp

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -65,6 +65,7 @@
 #include <atomic>
 #include <mutex>
 #include <optional>
+#include <variant>
 
 #define DEBUG_TYPE "on-disk-cas"
 
@@ -353,6 +354,13 @@ private:
 struct OnDiskContent {
   std::optional<DataRecordHandle> Record;
   std::optional<ArrayRef<char>> Bytes;
+
+  ArrayRef<char> getData() const {
+    if (Bytes)
+      return *Bytes;
+    assert(Record && "Expected record or bytes");
+    return Record->getData();
+  }
 };
 
 /// Data loaded inside the memory from standalone file.
@@ -360,9 +368,12 @@ class StandaloneDataInMemory {
 public:
   OnDiskContent getContent() const;
 
+  OnDiskGraphDB::FileBackedData
+  getInternalFileBackedObjectData(StringRef RootPath) const;
+
   StandaloneDataInMemory(std::unique_ptr<sys::fs::mapped_file_region> Region,
-                         TrieRecord::StorageKind SK)
-      : Region(std::move(Region)), SK(SK) {
+                         TrieRecord::StorageKind SK, FileOffset IndexOffset)
+      : Region(std::move(Region)), SK(SK), IndexOffset(IndexOffset) {
 #ifndef NDEBUG
     bool IsStandalone = false;
     switch (SK) {
@@ -381,6 +392,7 @@ public:
 private:
   std::unique_ptr<sys::fs::mapped_file_region> Region;
   TrieRecord::StorageKind SK;
+  FileOffset IndexOffset;
 };
 
 /// Container to lookup loaded standalone objects.
@@ -389,7 +401,8 @@ template <size_t NumShards> class StandaloneDataMap {
 
 public:
   uintptr_t insert(ArrayRef<uint8_t> Hash, TrieRecord::StorageKind SK,
-                   std::unique_ptr<sys::fs::mapped_file_region> Region);
+                   std::unique_ptr<sys::fs::mapped_file_region> Region,
+                   FileOffset IndexOffset);
 
   const StandaloneDataInMemory *lookup(ArrayRef<uint8_t> Hash) const;
   bool count(ArrayRef<uint8_t> Hash) const { return bool(lookup(Hash)); }
@@ -476,12 +489,14 @@ struct OnDiskGraphDB::IndexProxy {
 template <size_t N>
 uintptr_t StandaloneDataMap<N>::insert(
     ArrayRef<uint8_t> Hash, TrieRecord::StorageKind SK,
-    std::unique_ptr<sys::fs::mapped_file_region> Region) {
+    std::unique_ptr<sys::fs::mapped_file_region> Region,
+    FileOffset IndexOffset) {
   auto &S = getShard(Hash);
   std::lock_guard<std::mutex> Lock(S.Mutex);
   auto &V = S.Map[Hash.data()];
   if (!V)
-    V = std::make_unique<StandaloneDataInMemory>(std::move(Region), SK);
+    V = std::make_unique<StandaloneDataInMemory>(std::move(Region), SK,
+                                                 IndexOffset);
   return reinterpret_cast<uintptr_t>(V.get());
 }
 
@@ -949,7 +964,8 @@ Error OnDiskGraphDB::validate(bool Deep, HashingFuncT Hasher) const {
     case TrieRecord::StorageKind::StandaloneLeaf:
     case TrieRecord::StorageKind::StandaloneLeaf0:
       SmallString<256> Path;
-      getStandalonePath(TrieRecord::getStandaloneFilePrefix(D.SK), *I, Path);
+      getStandalonePath(TrieRecord::getStandaloneFilePrefix(D.SK), I->Offset,
+                        Path);
       // If need to validate the content of the file later, just load the
       // buffer here. Otherwise, just check the existance of the file.
       if (Deep) {
@@ -1201,28 +1217,37 @@ ArrayRef<uint8_t> OnDiskGraphDB::getDigest(const IndexProxy &I) const {
   return I.Hash;
 }
 
-static OnDiskContent getContentFromHandle(const OnDiskDataAllocator &DataPool,
-                                          ObjectHandle OH) {
+static std::variant<const StandaloneDataInMemory *, DataRecordHandle>
+getStandaloneDataOrDataRecord(const OnDiskDataAllocator &DataPool,
+                              ObjectHandle OH) {
   // Decode ObjectHandle to locate the stored content.
   uint64_t Data = OH.getOpaqueData();
   if (Data & 1) {
     const auto *SDIM =
         reinterpret_cast<const StandaloneDataInMemory *>(Data & (-1ULL << 1));
-    return SDIM->getContent();
+    return SDIM;
   }
 
   auto DataHandle =
       cantFail(DataRecordHandle::getFromDataPool(DataPool, FileOffset(Data)));
   assert(DataHandle.getData().end()[0] == 0 && "Null termination");
-  return OnDiskContent{DataHandle, std::nullopt};
+  return DataHandle;
+}
+
+static OnDiskContent getContentFromHandle(const OnDiskDataAllocator &DataPool,
+                                          ObjectHandle OH) {
+  auto SDIMOrRecord = getStandaloneDataOrDataRecord(DataPool, OH);
+  if (std::holds_alternative<const StandaloneDataInMemory *>(SDIMOrRecord)) {
+    return std::get<const StandaloneDataInMemory *>(SDIMOrRecord)->getContent();
+  } else {
+    auto DataHandle = std::get<DataRecordHandle>(std::move(SDIMOrRecord));
+    return OnDiskContent{std::move(DataHandle), std::nullopt};
+  }
 }
 
 ArrayRef<char> OnDiskGraphDB::getObjectData(ObjectHandle Node) const {
   OnDiskContent Content = getContentFromHandle(DataPool, Node);
-  if (Content.Bytes)
-    return *Content.Bytes;
-  assert(Content.Record && "Expected record or bytes");
-  return Content.Record->getData();
+  return Content.getData();
 }
 
 InternalRefArrayRef OnDiskGraphDB::getInternalRefs(ObjectHandle Node) const {
@@ -1230,6 +1255,18 @@ InternalRefArrayRef OnDiskGraphDB::getInternalRefs(ObjectHandle Node) const {
           getContentFromHandle(DataPool, Node).Record)
     return Record->getRefs();
   return std::nullopt;
+}
+
+OnDiskGraphDB::FileBackedData
+OnDiskGraphDB::getInternalFileBackedObjectData(ObjectHandle Node) const {
+  auto SDIMOrRecord = getStandaloneDataOrDataRecord(DataPool, Node);
+  if (std::holds_alternative<const StandaloneDataInMemory *>(SDIMOrRecord)) {
+    auto *SDIM = std::get<const StandaloneDataInMemory *>(SDIMOrRecord);
+    return SDIM->getInternalFileBackedObjectData(RootPath);
+  } else {
+    auto DataHandle = std::get<DataRecordHandle>(std::move(SDIMOrRecord));
+    return FileBackedData{DataHandle.getData(), /*FileInfo=*/std::nullopt};
+  }
 }
 
 Expected<std::optional<ObjectHandle>>
@@ -1269,7 +1306,8 @@ OnDiskGraphDB::load(ObjectID ExternalRef) {
   // suitably 0-padded. Requiring null-termination here would be too expensive
   // for extremely large objects that happen to be page-aligned.
   SmallString<256> Path;
-  getStandalonePath(TrieRecord::getStandaloneFilePrefix(Object.SK), *I, Path);
+  getStandalonePath(TrieRecord::getStandaloneFilePrefix(Object.SK), I->Offset,
+                    Path);
 
   auto BypassSandbox = sys::sandbox::scopedDisable();
 
@@ -1291,7 +1329,7 @@ OnDiskGraphDB::load(ObjectID ExternalRef) {
 
   return ObjectHandle::fromMemory(
       static_cast<StandaloneDataMapTy *>(StandaloneData)
-          ->insert(I->Hash, Object.SK, std::move(Region)));
+          ->insert(I->Hash, Object.SK, std::move(Region), I->Offset));
 }
 
 Expected<bool> OnDiskGraphDB::isMaterialized(ObjectID Ref) {
@@ -1337,11 +1375,17 @@ InternalRef OnDiskGraphDB::makeInternalRef(FileOffset IndexOffset) {
   return InternalRef::getFromOffset(IndexOffset);
 }
 
-void OnDiskGraphDB::getStandalonePath(StringRef Prefix, const IndexProxy &I,
-                                      SmallVectorImpl<char> &Path) const {
+static void getStandalonePath(StringRef RootPath, StringRef Prefix,
+                              FileOffset IndexOffset,
+                              SmallVectorImpl<char> &Path) {
   Path.assign(RootPath.begin(), RootPath.end());
   sys::path::append(Path,
-                    Prefix + Twine(I.Offset.get()) + "." + CASFormatVersion);
+                    Prefix + Twine(IndexOffset.get()) + "." + CASFormatVersion);
+}
+
+void OnDiskGraphDB::getStandalonePath(StringRef Prefix, FileOffset IndexOffset,
+                                      SmallVectorImpl<char> &Path) const {
+  return ::getStandalonePath(RootPath, Prefix, IndexOffset, Path);
 }
 
 OnDiskContent StandaloneDataInMemory::getContent() const {
@@ -1372,6 +1416,28 @@ OnDiskContent StandaloneDataInMemory::getContent() const {
   assert(Record.getData().end()[0] == 0 &&
          "Standalone object record missing null termination for data");
   return OnDiskContent{Record, std::nullopt};
+}
+
+OnDiskGraphDB::FileBackedData
+StandaloneDataInMemory::getInternalFileBackedObjectData(
+    StringRef RootPath) const {
+  switch (SK) {
+  case TrieRecord::StorageKind::Unknown:
+  case TrieRecord::StorageKind::DataPool:
+    llvm_unreachable("unexpected storage kind");
+  case TrieRecord::StorageKind::Standalone:
+    return OnDiskGraphDB::FileBackedData{getContent().getData(),
+                                         /*FileInfo=*/std::nullopt};
+  case TrieRecord::StorageKind::StandaloneLeaf0:
+  case TrieRecord::StorageKind::StandaloneLeaf:
+    bool IsFileNulTerminated = SK == TrieRecord::StorageKind::StandaloneLeaf0;
+    SmallString<256> Path;
+    ::getStandalonePath(RootPath, TrieRecord::getStandaloneFilePrefix(SK),
+                        IndexOffset, Path);
+    return OnDiskGraphDB::FileBackedData{
+        getContent().getData(), OnDiskGraphDB::FileBackedData::FileInfoTy{
+                                    std::string(Path), IsFileNulTerminated}};
+  }
 }
 
 static Expected<MappedTempFile>
@@ -1413,7 +1479,7 @@ Error OnDiskGraphDB::createStandaloneLeaf(IndexProxy &I, ArrayRef<char> Data) {
 
   SmallString<256> Path;
   int64_t FileSize = Data.size() + Leaf0;
-  getStandalonePath(TrieRecord::getStandaloneFilePrefix(SK), I, Path);
+  getStandalonePath(TrieRecord::getStandaloneFilePrefix(SK), I.Offset, Path);
 
   auto BypassSandbox = sys::sandbox::scopedDisable();
 
@@ -1484,7 +1550,7 @@ Error OnDiskGraphDB::store(ObjectID ID, ArrayRef<ObjectID> Refs,
   auto AllocStandaloneFile = [&](size_t Size) -> Expected<char *> {
     getStandalonePath(TrieRecord::getStandaloneFilePrefix(
                           TrieRecord::StorageKind::Standalone),
-                      *I, Path);
+                      I->Offset, Path);
     if (Error E = createTempFile(Path, Size, Logger.get()).moveInto(File))
       return std::move(E);
     assert(File->size() == Size);
@@ -1564,6 +1630,117 @@ Error OnDiskGraphDB::store(ObjectID ID, ArrayRef<ObjectID> Refs,
     return createCorruptObjectError(getDigest(*I));
 
   // Load existing object.
+  return Error::success();
+}
+
+Error OnDiskGraphDB::storeFile(ObjectID ID, StringRef FilePath) {
+  return storeFile(ID, FilePath, /*ImportKind=*/std::nullopt);
+}
+
+Error OnDiskGraphDB::storeFile(
+    ObjectID ID, StringRef FilePath,
+    std::optional<InternalUpstreamImportKind> ImportKind) {
+  auto I = getIndexProxyFromRef(getInternalRef(ID));
+  if (LLVM_UNLIKELY(!I))
+    return I.takeError();
+
+  // Early return in case the node exists.
+  {
+    TrieRecord::Data Existing = I->Ref.load();
+    if (Existing.SK != TrieRecord::StorageKind::Unknown)
+      return Error::success();
+  }
+
+  auto BypassSandbox = sys::sandbox::scopedDisable();
+
+  uint64_t FileSize;
+  if (std::error_code EC = sys::fs::file_size(FilePath, FileSize))
+    return createFileError(FilePath, EC);
+
+  if (FileSize <= TrieRecord::MaxEmbeddedSize) {
+    auto Buf = MemoryBuffer::getFile(FilePath);
+    if (!Buf)
+      return createFileError(FilePath, Buf.getError());
+    return store(ID, {}, arrayRefFromStringRef<char>((*Buf)->getBuffer()));
+  }
+
+  StringRef FromPath;
+  SmallString<256> TmpPath;
+
+  auto RemoveTmpFile = scope_exit([&TmpPath] {
+    if (!TmpPath.empty())
+      sys::fs::remove(TmpPath);
+  });
+
+  // \c clonefile requires that the destination path doesn't exist. We create
+  // a "placeholder" temporary file, then modify its path a bit and use that
+  // for \c clonefile to write to.
+  // FIXME: Instead of creating a dummy file, add a new file system API for
+  // copying to a unique path that can loop while checking EEXIST.
+  SmallString<256> UniqueTmpPath;
+  if (std::error_code EC =
+          sys::fs::createUniqueFile(RootPath + "/tmp.%%%%%%%", UniqueTmpPath))
+    return createFileError(RootPath + "/tmp.%%%%%%%", EC);
+  auto RemoveUniqueFile =
+      scope_exit([&UniqueTmpPath] { sys::fs::remove(UniqueTmpPath); });
+  TmpPath = UniqueTmpPath;
+  TmpPath += 'c'; // modify so that there's no file at that path.
+  // \c copy_file will use \c clonefile when applicable.
+  if (std::error_code EC = sys::fs::copy_file(FilePath, TmpPath))
+    return createFileError(FilePath, EC);
+  FromPath = TmpPath;
+
+  TrieRecord::StorageKind SK;
+  if (ImportKind.has_value()) {
+    // Importing the file from upstream, the nul is already added if necessary.
+    switch (*ImportKind) {
+    case InternalUpstreamImportKind::Leaf:
+      SK = TrieRecord::StorageKind::StandaloneLeaf;
+      break;
+    case InternalUpstreamImportKind::Leaf0:
+      SK = TrieRecord::StorageKind::StandaloneLeaf0;
+      break;
+    }
+  } else {
+    bool Leaf0 = isAligned(Align(getPageSize()), FileSize);
+    SK = Leaf0 ? TrieRecord::StorageKind::StandaloneLeaf0
+               : TrieRecord::StorageKind::StandaloneLeaf;
+
+    if (Leaf0) {
+      // Add a nul byte at the end.
+      std::error_code EC;
+      raw_fd_ostream OS(FromPath, EC, sys::fs::CD_OpenExisting,
+                        sys::fs::FA_Write, sys::fs::OF_Append);
+      if (EC)
+        return createFileError(FromPath, EC);
+      OS.write(0);
+      OS.close();
+      if (OS.has_error())
+        return createFileError(FromPath, OS.error());
+    }
+  }
+
+  SmallString<256> StandalonePath;
+  getStandalonePath(TrieRecord::getStandaloneFilePrefix(SK), I->Offset,
+                    StandalonePath);
+  if (std::error_code EC = sys::fs::rename(FromPath, StandalonePath))
+    return createFileError(FromPath, EC);
+  TmpPath.clear();
+
+  // Store the object reference.
+  TrieRecord::Data Existing;
+  {
+    TrieRecord::Data Leaf{SK, FileOffset()};
+    if (I->Ref.compare_exchange_strong(Existing, Leaf)) {
+      recordStandaloneSizeIncrease(FileSize);
+      return Error::success();
+    }
+  }
+
+  // If there was a race, confirm that the new value has valid storage.
+  if (Existing.SK == TrieRecord::StorageKind::Unknown)
+    return createCorruptObjectError(getDigest(*I));
+
   return Error::success();
 }
 
@@ -1715,8 +1892,6 @@ Error OnDiskGraphDB::importFullTree(ObjectID PrimaryID,
     UpstreamCursor &Cur = CursorStack.back();
     if (Cur.RefI == Cur.RefE) {
       // Copy the node data into the primary store.
-      // FIXME: Use hard-link or cloning if the file-system supports it and data
-      // is stored into a separate file.
 
       // The bottom of \p PrimaryNodesStack contains the primary ID for the
       // current node plus the list of imported referenced IDs.
@@ -1724,8 +1899,7 @@ Error OnDiskGraphDB::importFullTree(ObjectID PrimaryID,
       ObjectID PrimaryID = *(PrimaryNodesStack.end() - Cur.RefsCount - 1);
       auto PrimaryRefs = ArrayRef(PrimaryNodesStack)
                              .slice(PrimaryNodesStack.size() - Cur.RefsCount);
-      auto Data = UpstreamDB->getObjectData(Cur.Node);
-      if (Error E = store(PrimaryID, PrimaryRefs, Data))
+      if (Error E = importUpstreamData(PrimaryID, PrimaryRefs, Cur.Node))
         return E;
       // Remove the current node and its IDs from the stack.
       PrimaryNodesStack.truncate(PrimaryNodesStack.size() - Cur.RefsCount);
@@ -1760,10 +1934,6 @@ Error OnDiskGraphDB::importSingleNode(ObjectID PrimaryID,
                                       ObjectHandle UpstreamNode) {
   // Copies only a single node, it doesn't copy the referenced nodes.
 
-  // Copy the node data into the primary store.
-  // FIXME: Use hard-link or cloning if the file-system supports it and data is
-  // stored into a separate file.
-  auto Data = UpstreamDB->getObjectData(UpstreamNode);
   auto UpstreamRefs = UpstreamDB->getObjectRefs(UpstreamNode);
   SmallVector<ObjectID, 64> Refs;
   Refs.reserve(llvm::size(UpstreamRefs));
@@ -1774,7 +1944,29 @@ Error OnDiskGraphDB::importSingleNode(ObjectID PrimaryID,
     Refs.push_back(*Ref);
   }
 
-  return store(PrimaryID, Refs, Data);
+  return importUpstreamData(PrimaryID, Refs, UpstreamNode);
+}
+
+Error OnDiskGraphDB::importUpstreamData(ObjectID PrimaryID,
+                                        ArrayRef<ObjectID> PrimaryRefs,
+                                        ObjectHandle UpstreamNode) {
+  // If there are references we can't copy an upstream's standalone file because
+  // we need to re-resolve the reference offsets it contains.
+  if (PrimaryRefs.empty()) {
+    auto FBData = UpstreamDB->getInternalFileBackedObjectData(UpstreamNode);
+    if (FBData.FileInfo.has_value()) {
+      // Disk-space optimization, import the file directly since it is a
+      // standalone leaf.
+      return storeFile(
+          PrimaryID, FBData.FileInfo->FilePath,
+          /*InternalUpstreamImport=*/FBData.FileInfo->IsFileNulTerminated
+              ? InternalUpstreamImportKind::Leaf0
+              : InternalUpstreamImportKind::Leaf);
+    }
+  }
+
+  auto Data = UpstreamDB->getObjectData(UpstreamNode);
+  return store(PrimaryID, PrimaryRefs, Data);
 }
 
 Expected<std::optional<ObjectHandle>>

--- a/llvm/unittests/CAS/BuiltinObjectHasherTest.cpp
+++ b/llvm/unittests/CAS/BuiltinObjectHasherTest.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/BuiltinObjectHasher.h"
+#include "llvm/Support/BLAKE3.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+using HasherT = BLAKE3;
+using HashType = BuiltinObjectHasher<HasherT>::HashT;
+
+TEST(BuiltinObjectHasherTest, Basic) {
+  unittest::TempFile TmpFile("somefile.o", /*Suffix=*/"", /*Contents=*/"",
+                             /*Unique=*/true);
+  {
+    std::error_code EC;
+    raw_fd_stream Out(TmpFile.path(), EC);
+    ASSERT_FALSE(EC);
+    SmallVector<char, 200> Data;
+    for (unsigned i = 1; i != 201; ++i) {
+      Data.push_back(i);
+    }
+    for (unsigned i = 0; i != 1000; ++i) {
+      Out.write(Data.data(), Data.size());
+    }
+  }
+
+  ErrorOr<std::unique_ptr<MemoryBuffer>> MB =
+      MemoryBuffer::getFile(TmpFile.path());
+  ASSERT_TRUE(!!MB);
+  ASSERT_NE(*MB, nullptr);
+
+  HashType Hash1 =
+      BuiltinObjectHasher<HasherT>::hashObject({}, (*MB)->getBuffer());
+  std::optional<HashType> Hash2;
+  ASSERT_THAT_ERROR(
+      BuiltinObjectHasher<HasherT>::hashFile(TmpFile.path()).moveInto(Hash2),
+      Succeeded());
+  EXPECT_EQ(Hash1, *Hash2);
+}

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(ONDISK_CAS_TEST_SOURCES
+  BuiltinObjectHasherTest.cpp
   BuiltinUnifiedCASDatabasesTest.cpp
   OnDiskCASLoggerTest.cpp
   OnDiskGraphDBTest.cpp

--- a/llvm/unittests/CAS/OnDiskCommonUtils.h
+++ b/llvm/unittests/CAS/OnDiskCommonUtils.h
@@ -46,6 +46,21 @@ inline HashType digest(StringRef Data) {
   return HasherT::hash(arrayRefFromStringRef(Data));
 }
 
+inline HashType digestFile(StringRef FilePath) {
+  std::optional<HashType> Digest;
+  EXPECT_THAT_ERROR(
+      BuiltinObjectHasher<HasherT>::hashFile(FilePath).moveInto(Digest),
+      Succeeded());
+  return *Digest;
+}
+
+inline ObjectID digestFile(OnDiskGraphDB &DB, StringRef FilePath) {
+  HashType Digest = digestFile(FilePath);
+  std::optional<ObjectID> ID;
+  EXPECT_THAT_ERROR(DB.getReference(Digest).moveInto(ID), Succeeded());
+  return *ID;
+}
+
 inline ValueType valueFromString(StringRef S) {
   ValueType Val = {};
   llvm::copy(S.substr(0, sizeof(Val)), Val.data());

--- a/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
+++ b/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
@@ -8,6 +8,9 @@
 
 #include "CASTestConfig.h"
 #include "OnDiskCommonUtils.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
@@ -291,6 +294,211 @@ TEST_F(OnDiskCASTest, OnDiskGraphDBFaultInPolicyConflict) {
   // Open as 'full', then as 'single'.
   tryFaultInPolicyConflict(OnDiskGraphDB::FaultInPolicy::FullTree,
                            OnDiskGraphDB::FaultInPolicy::SingleNode);
+}
+
+static std::unique_ptr<unittest::TempFile> createLargeFile(char initChar) {
+  auto TmpFile = std::make_unique<unittest::TempFile>(
+      "largefile.o", /*Suffix=*/"", /*Contents=*/"",
+      /*Unique=*/true);
+  StringRef Path = TmpFile->path();
+  std::error_code EC;
+  raw_fd_stream Out(Path, EC);
+  EXPECT_FALSE(EC);
+  SmallString<200> Data;
+  Data += initChar;
+  for (unsigned i = 1; i != 200; ++i) {
+    Data += i;
+  }
+  for (unsigned i = 0; i != 1000; ++i) {
+    Out.write(Data.data(), Data.size());
+  }
+  return TmpFile;
+}
+
+static std::unique_ptr<unittest::TempFile>
+createLargePageAlignedFile(char initChar) {
+  auto TmpFile = std::make_unique<unittest::TempFile>(
+      "largepagealignedfile.o", /*Suffix=*/"", /*Contents=*/"",
+      /*Unique=*/true);
+  StringRef Path = TmpFile->path();
+  std::error_code EC;
+  raw_fd_stream Out(Path, EC);
+  EXPECT_FALSE(EC);
+  SmallString<256> Data;
+  Data += initChar;
+  for (unsigned i = 1; i != sys::Process::getPageSizeEstimate(); ++i) {
+    Data += char(i);
+  }
+  for (unsigned i = 0; i != 64; ++i) {
+    Out.write(Data.data(), Data.size());
+  }
+  Out.close();
+  uint64_t FileSize;
+  EC = sys::fs::file_size(Path, FileSize);
+  EXPECT_FALSE(EC);
+  assert(isAligned(Align(sys::Process::getPageSizeEstimate()), FileSize));
+  return TmpFile;
+}
+
+TEST_F(OnDiskCASTest, OnDiskGraphDBFaultInLargeFile) {
+  auto runCommonTests =
+      [](function_ref<std::unique_ptr<unittest::TempFile>(char)> createFileFn) {
+        unittest::TempDir TempUpstream("ondiskcas-upstream", /*Unique=*/true);
+        std::unique_ptr<OnDiskGraphDB> UpstreamDB;
+        ASSERT_THAT_ERROR(
+            OnDiskGraphDB::open(TempUpstream.path(), "blake3", sizeof(HashType))
+                .moveInto(UpstreamDB),
+            Succeeded());
+
+        auto TmpFile = createFileFn('a');
+        auto Path = TmpFile->path();
+        HashType FileDigest = digestFile(Path);
+        std::optional<ObjectID> UpstrID;
+        ASSERT_THAT_ERROR(
+            UpstreamDB->getReference(FileDigest).moveInto(UpstrID),
+            Succeeded());
+        ASSERT_THAT_ERROR(UpstreamDB->storeFile(*UpstrID, Path), Succeeded());
+
+        unittest::TempDir Temp("ondiskcas", /*Unique=*/true);
+        std::unique_ptr<OnDiskGraphDB> DB;
+        ASSERT_THAT_ERROR(
+            OnDiskGraphDB::open(Temp.path(), "blake3", sizeof(HashType),
+                                UpstreamDB.get(), /*Logger=*/nullptr,
+                                OnDiskGraphDB::FaultInPolicy::SingleNode)
+                .moveInto(DB),
+            Succeeded());
+
+        std::optional<ObjectID> ID1;
+        ASSERT_THAT_ERROR(DB->getReference(FileDigest).moveInto(ID1),
+                          Succeeded());
+        std::optional<ondisk::ObjectHandle> Obj;
+        ASSERT_THAT_ERROR(DB->load(*ID1).moveInto(Obj), Succeeded());
+        ASSERT_TRUE(Obj.has_value());
+
+        std::optional<ObjectID> ID2;
+        ASSERT_THAT_ERROR(
+            store(*DB, toStringRef(DB->getObjectData(*Obj)), {}).moveInto(ID2),
+            Succeeded());
+        ASSERT_TRUE(ID2.has_value());
+        EXPECT_EQ(*ID1, *ID2);
+      };
+
+  runCommonTests(createLargeFile);
+  runCommonTests(createLargePageAlignedFile);
+}
+
+TEST_F(OnDiskCASTest, OnDiskGraphDBFileAPIs) {
+  unittest::TempDir Temp("ondiskcas", /*Unique=*/true);
+  std::unique_ptr<OnDiskGraphDB> DB;
+  ASSERT_THAT_ERROR(
+      OnDiskGraphDB::open(Temp.path(), "blake3", sizeof(HashType)).moveInto(DB),
+      Succeeded());
+
+  SmallVector<std::unique_ptr<unittest::TempFile>, 4> TempFiles;
+
+  // Create a file with small size and and controlling the initial byte so
+  // caller can create different contents.
+  auto createSmallFile = [&TempFiles](char initChar) -> StringRef {
+    TempFiles.push_back(std::make_unique<unittest::TempFile>(
+        "smallfile.o", /*Suffix=*/"", /*Contents=*/"",
+        /*Unique=*/true));
+    StringRef Path = TempFiles.back()->path();
+    std::error_code EC;
+    raw_fd_stream Out(Path, EC);
+    EXPECT_FALSE(EC);
+    SmallString<200> Data;
+    Data += initChar;
+    for (unsigned i = 1; i != 200; ++i) {
+      Data += i;
+    }
+    Out.write(Data.data(), Data.size());
+    return Path;
+  };
+
+  auto createLargeFile = [&TempFiles](char initChar) -> StringRef {
+    TempFiles.push_back(::createLargeFile(initChar));
+    return TempFiles.back()->path();
+  };
+
+  auto createLargePageAlignedFile = [&TempFiles](char initChar) -> StringRef {
+    TempFiles.push_back(::createLargePageAlignedFile(initChar));
+    return TempFiles.back()->path();
+  };
+
+  auto runCommonTests =
+      [&DB](function_ref<StringRef(char)> createFileFn,
+            function_ref<void(const OnDiskGraphDB::FileBackedData &FBD)>
+                additionalChecks) {
+        {
+          auto FilePath = createFileFn('a');
+          ObjectID ID1 = digestFile(*DB, FilePath);
+          ASSERT_THAT_ERROR(DB->storeFile(ID1, FilePath), Succeeded());
+          EXPECT_TRUE(sys::fs::exists(FilePath));
+
+          std::optional<ondisk::ObjectHandle> Obj;
+          ASSERT_THAT_ERROR(DB->load(ID1).moveInto(Obj), Succeeded());
+          EXPECT_TRUE(DB->getObjectRefs(*Obj).empty());
+          ArrayRef<char> Contents = DB->getObjectData(*Obj);
+          EXPECT_EQ(Contents.data()[Contents.size()], '\0');
+          ObjectID ID2 = digest(*DB, toStringRef(Contents), {});
+          EXPECT_EQ(ID1, ID2);
+
+          auto FBD = DB->getInternalFileBackedObjectData(*Obj);
+          EXPECT_EQ(FBD.Data, Contents);
+          additionalChecks(FBD);
+        }
+      };
+
+  auto checkSmallFile = [](const OnDiskGraphDB::FileBackedData &FBD) {
+    EXPECT_FALSE(FBD.FileInfo.has_value());
+  };
+
+  auto checkLargeFile = [](const OnDiskGraphDB::FileBackedData &FBD) {
+    ASSERT_TRUE(FBD.FileInfo.has_value());
+    EXPECT_FALSE(FBD.FileInfo->IsFileNulTerminated);
+    ErrorOr<std::unique_ptr<MemoryBuffer>> MB =
+        MemoryBuffer::getFile(FBD.FileInfo->FilePath);
+    ASSERT_TRUE(!!MB);
+    ASSERT_NE(*MB, nullptr);
+    EXPECT_EQ((*MB)->getBuffer(), toStringRef(FBD.Data));
+  };
+
+  auto checkLargePageAlignedFile =
+      [](const OnDiskGraphDB::FileBackedData &FBD) {
+        ASSERT_TRUE(FBD.FileInfo.has_value());
+        EXPECT_TRUE(FBD.FileInfo->IsFileNulTerminated);
+        ErrorOr<std::unique_ptr<MemoryBuffer>> MB =
+            MemoryBuffer::getFile(FBD.FileInfo->FilePath);
+        ASSERT_TRUE(!!MB);
+        ASSERT_NE(*MB, nullptr);
+        EXPECT_EQ((*MB)->getBuffer().back(), '\0');
+        EXPECT_EQ((*MB)->getBuffer().drop_back(1), toStringRef(FBD.Data));
+      };
+
+  runCommonTests(createSmallFile, checkSmallFile);
+  runCommonTests(createLargeFile, checkLargeFile);
+  runCommonTests(createLargePageAlignedFile, checkLargePageAlignedFile);
+
+  // Check non-leaf node.
+  {
+    std::optional<ObjectID> ID1;
+    ASSERT_THAT_ERROR(store(*DB, "hello", {}).moveInto(ID1), Succeeded());
+
+    auto Path = createLargeFile('r');
+    ErrorOr<std::unique_ptr<MemoryBuffer>> MB = MemoryBuffer::getFile(Path);
+    ASSERT_TRUE(!!MB);
+    ASSERT_NE(*MB, nullptr);
+    std::optional<ObjectID> ID2;
+    ASSERT_THAT_ERROR(store(*DB, (*MB)->getBuffer(), *ID1).moveInto(ID2),
+                      Succeeded());
+
+    std::optional<ondisk::ObjectHandle> Obj;
+    ASSERT_THAT_ERROR(DB->load(*ID2).moveInto(Obj), Succeeded());
+    ArrayRef<char> Contents = DB->getObjectData(*Obj);
+    auto FBD = DB->getInternalFileBackedObjectData(*Obj);
+    EXPECT_EQ(FBD.Data, Contents);
+    EXPECT_FALSE(FBD.FileInfo.has_value());
+  }
 }
 
 #if defined(EXPENSIVE_CHECKS) && !defined(_WIN32)


### PR DESCRIPTION
These allow performing optimizations that reduce I/O and disk space consumption. For example, when applicable, a file can be cloned directly into the database directory, instead of needing to load it in memory and then copy its contents into a new file.

These APIs are then used to optimize importing data from an upstream DB by using file cloning where applicable.