### PR TITLE
[lldb-dap] Improving stability of TestDAP_launch_commands.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_commands.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_commands.py
@@ -71,14 +71,14 @@ class TestDAP_launch_commands(lldbdap_testcase.DAPTestCaseBase):
         # Get output from the console. This should contain both the
         # "stopCommands" that were run after the first breakpoint was hit
         self.continue_to_breakpoints(breakpoint_ids)
-        output = self.get_console()
+        output = self.collect_console(pattern=stopCommands[-1])
         self.verify_commands("stopCommands", output, stopCommands)
 
         # Continue again and hit the second breakpoint.
         # Get output from the console. This should contain both the
         # "stopCommands" that were run after the second breakpoint was hit
         self.continue_to_breakpoints(breakpoint_ids)
-        output = self.get_console()
+        output = self.collect_console(pattern=stopCommands[-1])
         self.verify_commands("stopCommands", output, stopCommands)
 
         # Continue until the program exits

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_commands.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_commands.py
@@ -47,7 +47,7 @@ class TestDAP_launch_commands(lldbdap_testcase.DAPTestCaseBase):
 
         # Get output from the console. This should contain both the
         # "initCommands" and the "preRunCommands".
-        output = self.get_console()
+        output = self.collect_console(pattern=postRunCommands[-1])
         # Verify all "initCommands" were found in console output
         self.verify_commands("initCommands", output, initCommands)
         # Verify all "preRunCommands" were found in console output


### PR DESCRIPTION
Improving stability of the TestDAP_launch_commands test.

When collecting output for verifying 'stopCommands' we were not waiting for the output to finish, which could cause issues if the test is running very fast.