### PR TITLE
[clang][dataflow] Fix a new crash on assigning values of unmodeled types.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -169,8 +169,16 @@ public:
         break;
 
       auto *RHSVal = Env.getValue(*RHS);
-      if (RHSVal == nullptr)
+      if (RHSVal == nullptr) {
         RHSVal = Env.createValue(LHS->getType());
+        if (RHSVal == nullptr) {
+          // At least make sure the old value is gone. It's unlikely to be there
+          // in the first place given that we don't even know how to create
+          // a basic unknown value of that type.
+          Env.clearValue(*LHSLoc);
+          break;
+        }
+      }
 
       // Assign a value to the storage location of the left-hand side.
       Env.setValue(*LHSLoc, *RHSVal);

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -1011,6 +1011,54 @@ TEST(TransferTest, BinaryOperatorAssignUnknown) {
       });
 }
 
+TEST(TransferTest, BinaryOperatorAssignFloat) {
+  using ast_matchers::binaryOperator;
+  using ast_matchers::match;
+  using ast_matchers::selectFirst;
+  using ast_matchers::hasOperatorName;
+
+  // This was crashing.
+  std::string Code = R"(
+    void target() {
+      double Foo = 0.0f;
+      double FooAtA = Foo;
+      Foo = 1.0f;
+      double FooAtB = Foo;
+      bool check = (FooAtA == FooAtB);
+      // [[p]]
+    }
+  )";
+  runDataflow(
+      Code,
+      [](const llvm::StringMap<DataflowAnalysisState<NoopLattice>> &Results,
+         ASTContext &ASTCtx) {
+        ASSERT_THAT(Results.keys(), UnorderedElementsAre("p"));
+
+        const Environment &EnvP = getEnvironmentAtAnnotation(Results, "p");
+
+        const ValueDecl *FooAtADecl = findValueDecl(ASTCtx, "FooAtA");
+        ASSERT_THAT(FooAtADecl, NotNull());
+        const Value *FooAtAVal = EnvP.getValue(*FooAtADecl);
+        // FIXME: Should be non-null. Floats aren't modeled at all.
+        EXPECT_THAT(FooAtAVal, IsNull());
+
+        const ValueDecl *FooAtBDecl = findValueDecl(ASTCtx, "FooAtB");
+        ASSERT_THAT(FooAtBDecl, NotNull());
+        const Value *FooAtBVal = EnvP.getValue(*FooAtBDecl);
+        // FIXME: Should be non-null. Floats aren't modeled at all.
+        EXPECT_THAT(FooAtBVal, IsNull());
+
+        // See if the storage location is correctly propagated.
+        auto MatchResult =
+            match(binaryOperator(hasOperatorName("=")).bind("bo"), ASTCtx);
+        const auto *BO = selectFirst<BinaryOperator>("bo", MatchResult);
+        ASSERT_THAT(BO, NotNull());
+        const StorageLocation *BOLoc = EnvP.getStorageLocation(*BO);
+        // FIXME: Should be non-null.
+        EXPECT_THAT(BOLoc, IsNull());
+      });
+}
+
 TEST(TransferTest, VarDeclInitAssign) {
   std::string Code = R"(
     void target() {

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -1013,9 +1013,9 @@ TEST(TransferTest, BinaryOperatorAssignUnknown) {
 
 TEST(TransferTest, BinaryOperatorAssignFloat) {
   using ast_matchers::binaryOperator;
+  using ast_matchers::hasOperatorName;
   using ast_matchers::match;
   using ast_matchers::selectFirst;
-  using ast_matchers::hasOperatorName;
 
   // This was crashing.
   std::string Code = R"(


### PR DESCRIPTION
Regressed by me in #178943. Caught by @jvoung.