### PR TITLE
[clang] Add -Wused-but-marked-unused to -Wattributes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -161,6 +161,8 @@ Attribute Changes in Clang
   will still generate a stack protector if other local variables or command line flags
   require it.
 
+- Added ``-Wused-but-marked-unused`` to ``-Wattributes``.
+
 Improvements to Clang's diagnostics
 -----------------------------------
 - Added ``-Wlifetime-safety`` to enable lifetime safety analysis,

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1036,8 +1036,9 @@ def IndependentClassAttribute : DiagGroup<"IndependentClass-attribute">;
 def UnknownAttributes : DiagGroup<"unknown-attributes">;
 def IgnoredAttributes : DiagGroup<"ignored-attributes",
                                   [DllexportExplicitInstantiation]>;
-def Attributes : DiagGroup<"attributes", [UnknownAttributes,
-                                          IgnoredAttributes]>;
+def UsedButMarkedUnused : DiagGroup<"used-but-marked-unused">;
+def Attributes : DiagGroup<"attributes", [UnknownAttributes, IgnoredAttributes,
+                                          UsedButMarkedUnused]>;
 def UnknownSanitizers : DiagGroup<"unknown-sanitizers">;
 def UnnamedTypeTemplateArgs : DiagGroup<"unnamed-type-template-args",
                                         [CXX98CompatUnnamedTypeTemplateArgs]>;
@@ -1073,7 +1074,6 @@ def UnusedButSetVariable : DiagGroup<"unused-but-set-variable">;
 def UnusedLocalTypedef : DiagGroup<"unused-local-typedef">;
 def UnusedPropertyIvar :  DiagGroup<"unused-property-ivar">;
 def UnusedGetterReturnValue : DiagGroup<"unused-getter-return-value">;
-def UsedButMarkedUnused : DiagGroup<"used-but-marked-unused">;
 def UsedSearchPath : DiagGroup<"search-path-usage">;
 def UserDefinedLiterals : DiagGroup<"user-defined-literals">;
 def UserDefinedWarnings : DiagGroup<"user-defined-warnings">;

--- a/clang/test/Sema/attr-unused.c
+++ b/clang/test/Sema/attr-unused.c
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -verify -Wunused -Wused-but-marked-unused -Wunused-parameter -Wunused -Wno-strict-prototypes -fsyntax-only %s
+// RUN: %clang_cc1 -verify -Wunused -Wused-but-marked-unused -Wunused-parameter -Wno-strict-prototypes -fsyntax-only %s
+// RUN: %clang_cc1 -verify -Wunused -Wattributes -Wunused-parameter -Wno-strict-prototypes -fsyntax-only %s
 
 static void (*fp0)(void) __attribute__((unused));
 


### PR DESCRIPTION
Running the following code with `-Wattributes` triggers no warnings:
```cpp
int main(__attribute__((unused)) int argc, __attribute__((unused)) char **argv)
{
    return argc;
}
```
```
$ clang -Wall -Wattributes main.cpp
[no output]
```
https://godbolt.org/z/qd54raM8s

But `-Wused-but-marked-unused` does warn (currently disabled by default):
```
$ clang -Wall -Wused-but-marked-unused main.cpp
/tmp/main.c:4:10: warning: 'argc' was marked unused but was used [-Wused-but-marked-unused]
    4 |   return argc;
      |          ^
1 warning generated.
```
https://godbolt.org/z/hn5Me539r

This warning was disabled by default and removed from `-Wunused` in 2010 due to concerns about false-positives, as the `unused` attribute was traditionally interpreted as "it's okay if this isn't used" rather than "this must not be used" (paraphrased from https://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20101018/035732.html).

However, now that we have the `maybe_unused` attribute with explicit "may or may not be used" semantics, I would contend `unused` should have a stricter definition of "should not be used." Warning on variables marked `unused` that are actually used would improve code quality without the original false-positive concerns, since programmers should prefer `maybe_unused` in those cases.

Here I propose simply adding it to `-Wattributes`, which leaves it out of `-Wall`, but enables it alongside other attribute-related warnings. Thoughts?