### PR TITLE
[SystemZ][z/OS] Use the text section for jump tables

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
+++ b/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
@@ -325,6 +325,8 @@ public:
 
   void getModuleMetadata(Module &M) override;
 
+  bool shouldPutJumpTableInFunctionSection(bool UsesLabelDifference,
+                                           const Function &F) const override;
   MCSection *SelectSectionForGlobal(const GlobalObject *GO, SectionKind Kind,
                                     const TargetMachine &TM) const override;
   MCSection *getExplicitSectionGlobal(const GlobalObject *GO, SectionKind Kind,

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2810,6 +2810,11 @@ void TargetLoweringObjectFileGOFF::getModuleMetadata(Module &M) {
   ADAPR->setBeginSymbol(ADASym);
 }
 
+bool TargetLoweringObjectFileGOFF::shouldPutJumpTableInFunctionSection(
+    bool UsesLabelDifference, const Function &F) const {
+  return true;
+}
+
 MCSection *TargetLoweringObjectFileGOFF::getExplicitSectionGlobal(
     const GlobalObject *GO, SectionKind Kind, const TargetMachine &TM) const {
   return SelectSectionForGlobal(GO, Kind, TM);

--- a/llvm/test/CodeGen/SystemZ/zos-jumptable.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-jumptable.ll
@@ -1,0 +1,34 @@
+; RUN: llc -mtriple s390x-zos -emit-gnuas-syntax-on-zos=0 < %s | FileCheck %s
+
+define void @jumptable(i32 signext %in, ptr %out) {
+; CHECK-LABEL: jumptable DS 0H
+; CHECK:   larl 3,L#JTI0_0
+; CHECK: L#func_end1 DS 0H
+; CHECK: L#JTI0_0 DS 0H
+; CHECK:   DC AD(L#BB0_2)
+; CHECK:   DC AD(L#BB0_5)
+; CHECK:   DC AD(L#BB0_3)
+; CHECK:   DC AD(L#BB0_4)
+
+entry:
+  switch i32 %in, label %exit [
+    i32 1, label %bb1
+    i32 2, label %bb2
+    i32 3, label %bb3
+    i32 4, label %bb4
+  ]
+bb1:
+  store i32 4, ptr %out
+  br label %exit
+bb2:
+  store i32 3, ptr %out
+  br label %exit
+bb3:
+  store i32 2, ptr %out
+  br label %exit
+bb4:
+  store i32 1, ptr %out
+  br label %exit
+exit:
+  ret void
+}


### PR DESCRIPTION
Jump tables are read only data, and the text section is the best choice for them.