### PR TITLE
AMDGPU/GlobalISel: Regbanklegalize rules for G_FREEZE

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalize.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalize.cpp
@@ -474,13 +474,6 @@ bool AMDGPURegBankLegalize::runOnMachineFunction(MachineFunction &MF) {
       continue;
     }
 
-    // Opcodes that also support S1.
-    if (Opc == G_FREEZE &&
-        MRI.getType(MI->getOperand(0).getReg()) != LLT::scalar(1)) {
-      RBLHelper.applyMappingTrivial(*MI);
-      continue;
-    }
-
     if ((Opc == AMDGPU::G_CONSTANT || Opc == AMDGPU::G_FCONSTANT ||
          Opc == AMDGPU::G_IMPLICIT_DEF)) {
       Register Dst = MI->getOperand(0).getReg();

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
@@ -1192,6 +1192,21 @@ LLT RegBankLegalizeHelper::getBTyFromID(RegBankLLTMappingApplyID ID, LLT Ty) {
         Ty == LLT::fixed_vector(8, 64))
       return Ty;
     return LLT();
+  case SgprBRC: {
+    const SIRegisterInfo *TRI =
+        static_cast<const SIRegisterInfo *>(MRI.getTargetRegisterInfo());
+    unsigned LLTSize = Ty.getSizeInBits();
+    if (LLTSize >= 32 && TRI->getSGPRClassForBitWidth(LLTSize))
+      return Ty;
+    return LLT();
+  }
+  case VgprBRC: {
+    const SIRegisterInfo *TRI =
+        static_cast<const SIRegisterInfo *>(MRI.getTargetRegisterInfo());
+    if (TRI->getSGPRClassForBitWidth(Ty.getSizeInBits()))
+      return Ty;
+    return LLT();
+  }
   default:
     return LLT();
   }
@@ -1227,6 +1242,7 @@ RegBankLegalizeHelper::getRegBankFromID(RegBankLLTMappingApplyID ID) {
   case SgprB128:
   case SgprB256:
   case SgprB512:
+  case SgprBRC:
   case UniInVcc:
   case UniInVgprS16:
   case UniInVgprS32:
@@ -1271,6 +1287,7 @@ RegBankLegalizeHelper::getRegBankFromID(RegBankLLTMappingApplyID ID) {
   case VgprB128:
   case VgprB256:
   case VgprB512:
+  case VgprBRC:
   case Vgpr32AExt:
   case Vgpr32SExt:
   case Vgpr32ZExt:
@@ -1334,6 +1351,7 @@ bool RegBankLegalizeHelper::applyMappingDst(
     case SgprB128:
     case SgprB256:
     case SgprB512:
+    case SgprBRC:
     case SgprPtr32:
     case SgprPtr64:
     case SgprPtr128:
@@ -1343,6 +1361,7 @@ bool RegBankLegalizeHelper::applyMappingDst(
     case VgprB128:
     case VgprB256:
     case VgprB512:
+    case VgprBRC:
     case VgprPtr32:
     case VgprPtr64:
     case VgprPtr128: {
@@ -1478,6 +1497,7 @@ bool RegBankLegalizeHelper::applyMappingSrc(
     case SgprB128:
     case SgprB256:
     case SgprB512:
+    case SgprBRC:
     case SgprPtr32:
     case SgprPtr64:
     case SgprPtr128: {
@@ -1515,6 +1535,7 @@ bool RegBankLegalizeHelper::applyMappingSrc(
     case VgprB128:
     case VgprB256:
     case VgprB512:
+    case VgprBRC:
     case VgprPtr32:
     case VgprPtr64:
     case VgprPtr128: {

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -617,12 +617,18 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
       .Uni(V2S16, {{SgprV2S16}, {SgprV2S16, SgprV2S16}, UnpackMinMax})
       .Div(V2S16, {{VgprV2S16}, {VgprV2S16, VgprV2S16}});
 
-  // Note: we only write S1 rules for G_IMPLICIT_DEF, G_CONSTANT, G_FCONSTANT
-  // and G_FREEZE here, rest is trivially regbankselected earlier
+  // Note: we only write S1 rules for G_IMPLICIT_DEF, G_CONSTANT and G_FCONSTANT
+  // here, rest is trivially regbankselected earlier
   addRulesForGOpcs({G_IMPLICIT_DEF}).Any({{UniS1}, {{Sgpr32Trunc}, {}}});
   addRulesForGOpcs({G_CONSTANT})
       .Any({{UniS1, _}, {{Sgpr32Trunc}, {None}, UniCstExt}});
-  addRulesForGOpcs({G_FREEZE}).Any({{DivS1}, {{Vcc}, {Vcc}}});
+
+  addRulesForGOpcs({G_FREEZE})
+      .Any({{UniS1}, {{Sgpr32Trunc}, {Sgpr32AExt}}})
+      .Any({{DivS1}, {{Vcc}, {Vcc}}})
+      .Any({{UniS16}, {{Sgpr16}, {Sgpr16}}})
+      .Any({{UniBRC}, {{SgprBRC}, {SgprBRC}}})
+      .Any({{DivBRC}, {{VgprBRC}, {VgprBRC}}});
 
   addRulesForGOpcs({G_UNMERGE_VALUES})
       .Any({{UniS16}, {{}, {}, UnmergeToShiftTrunc}})

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.h
@@ -165,6 +165,7 @@ enum RegBankLLTMappingApplyID {
   SgprB128,
   SgprB256,
   SgprB512,
+  SgprBRC,
 
   // vgpr scalars, pointers, vectors and B-types
   Vgpr16,
@@ -189,6 +190,7 @@ enum RegBankLLTMappingApplyID {
   VgprB128,
   VgprB256,
   VgprB512,
+  VgprBRC,
   VgprV4S32,
   VgprV2S64,
 

--- a/llvm/test/CodeGen/AMDGPU/freeze.ll
+++ b/llvm/test/CodeGen/AMDGPU/freeze.ll
@@ -13697,6 +13697,140 @@ define void @freeze_v3i1(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
   ret void
 }
 
+define void @freeze_i1_scc(i32 inreg %a, i32 inreg %b, ptr addrspace(1) %ptrb) {
+; GFX6-SDAG-LABEL: freeze_i1_scc:
+; GFX6-SDAG:       ; %bb.0:
+; GFX6-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-SDAG-NEXT:    s_cmp_eq_u32 s16, s17
+; GFX6-SDAG-NEXT:    s_mov_b32 s6, 0
+; GFX6-SDAG-NEXT:    s_cselect_b64 s[8:9], -1, 0
+; GFX6-SDAG-NEXT:    s_mov_b32 s7, 0xf000
+; GFX6-SDAG-NEXT:    s_mov_b32 s4, s6
+; GFX6-SDAG-NEXT:    s_mov_b32 s5, s6
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[8:9]
+; GFX6-SDAG-NEXT:    buffer_store_byte v2, v[0:1], s[4:7], 0 addr64
+; GFX6-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
+; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX6-GISEL-LABEL: freeze_i1_scc:
+; GFX6-GISEL:       ; %bb.0:
+; GFX6-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX6-GISEL-NEXT:    s_cmp_eq_u32 s16, s17
+; GFX6-GISEL-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX6-GISEL-NEXT:    s_and_b32 s4, s4, 1
+; GFX6-GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX6-GISEL-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX6-GISEL-NEXT:    s_mov_b32 s6, 0
+; GFX6-GISEL-NEXT:    v_mov_b32_e32 v2, s4
+; GFX6-GISEL-NEXT:    s_mov_b32 s7, 0xf000
+; GFX6-GISEL-NEXT:    s_mov_b64 s[4:5], 0
+; GFX6-GISEL-NEXT:    buffer_store_byte v2, v[0:1], s[4:7], 0 addr64
+; GFX6-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
+; GFX6-GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-SDAG-LABEL: freeze_i1_scc:
+; GFX7-SDAG:       ; %bb.0:
+; GFX7-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-SDAG-NEXT:    s_cmp_eq_u32 s16, s17
+; GFX7-SDAG-NEXT:    s_mov_b32 s6, 0
+; GFX7-SDAG-NEXT:    s_cselect_b64 s[8:9], -1, 0
+; GFX7-SDAG-NEXT:    s_mov_b32 s7, 0xf000
+; GFX7-SDAG-NEXT:    s_mov_b32 s4, s6
+; GFX7-SDAG-NEXT:    s_mov_b32 s5, s6
+; GFX7-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s[8:9]
+; GFX7-SDAG-NEXT:    buffer_store_byte v2, v[0:1], s[4:7], 0 addr64
+; GFX7-SDAG-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-SDAG-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX7-GISEL-LABEL: freeze_i1_scc:
+; GFX7-GISEL:       ; %bb.0:
+; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-GISEL-NEXT:    s_cmp_eq_u32 s16, s17
+; GFX7-GISEL-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX7-GISEL-NEXT:    s_and_b32 s4, s4, 1
+; GFX7-GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX7-GISEL-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX7-GISEL-NEXT:    s_mov_b32 s6, 0
+; GFX7-GISEL-NEXT:    v_mov_b32_e32 v2, s4
+; GFX7-GISEL-NEXT:    s_mov_b32 s7, 0xf000
+; GFX7-GISEL-NEXT:    s_mov_b64 s[4:5], 0
+; GFX7-GISEL-NEXT:    buffer_store_byte v2, v[0:1], s[4:7], 0 addr64
+; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8-GISEL-LABEL: freeze_i1_scc:
+; GFX8-GISEL:       ; %bb.0:
+; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8-GISEL-NEXT:    s_cmp_eq_u32 s16, s17
+; GFX8-GISEL-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX8-GISEL-NEXT:    s_and_b32 s4, s4, 1
+; GFX8-GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX8-GISEL-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX8-GISEL-NEXT:    v_mov_b32_e32 v2, s4
+; GFX8-GISEL-NEXT:    flat_store_byte v[0:1], v2
+; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9-GISEL-LABEL: freeze_i1_scc:
+; GFX9-GISEL:       ; %bb.0:
+; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-GISEL-NEXT:    s_cmp_eq_u32 s16, s17
+; GFX9-GISEL-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX9-GISEL-NEXT:    s_and_b32 s4, s4, 1
+; GFX9-GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX9-GISEL-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX9-GISEL-NEXT:    v_mov_b32_e32 v2, s4
+; GFX9-GISEL-NEXT:    global_store_byte v[0:1], v2, off
+; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX10-SDAG-LABEL: freeze_i1_scc:
+; GFX10-SDAG:       ; %bb.0:
+; GFX10-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-SDAG-NEXT:    s_cmp_eq_u32 s16, s17
+; GFX10-SDAG-NEXT:    s_cselect_b32 s4, -1, 0
+; GFX10-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s4
+; GFX10-SDAG-NEXT:    global_store_byte v[0:1], v2, off
+; GFX10-SDAG-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX10-GISEL-LABEL: freeze_i1_scc:
+; GFX10-GISEL:       ; %bb.0:
+; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX10-GISEL-NEXT:    s_cmp_eq_u32 s16, s17
+; GFX10-GISEL-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX10-GISEL-NEXT:    s_and_b32 s4, s4, 1
+; GFX10-GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX10-GISEL-NEXT:    s_cselect_b32 s4, 1, 0
+; GFX10-GISEL-NEXT:    v_mov_b32_e32 v2, s4
+; GFX10-GISEL-NEXT:    global_store_byte v[0:1], v2, off
+; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-SDAG-LABEL: freeze_i1_scc:
+; GFX11-SDAG:       ; %bb.0:
+; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-SDAG-NEXT:    s_cmp_eq_u32 s0, s1
+; GFX11-SDAG-NEXT:    s_cselect_b32 s0, -1, 0
+; GFX11-SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s0
+; GFX11-SDAG-NEXT:    global_store_b8 v[0:1], v2, off
+; GFX11-SDAG-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-GISEL-LABEL: freeze_i1_scc:
+; GFX11-GISEL:       ; %bb.0:
+; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-GISEL-NEXT:    s_cmp_eq_u32 s0, s1
+; GFX11-GISEL-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-GISEL-NEXT:    s_and_b32 s0, s0, 1
+; GFX11-GISEL-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX11-GISEL-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX11-GISEL-NEXT:    v_mov_b32_e32 v2, s0
+; GFX11-GISEL-NEXT:    global_store_b8 v[0:1], v2, off
+; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
+  %cmp = icmp eq i32 %a, %b
+  %freeze = freeze i1 %cmp
+  store i1 %freeze, ptr addrspace(1) %ptrb
+  ret void
+}
+
 define void @freeze_i1_vcc(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX6-SDAG-LABEL: freeze_i1_vcc:
 ; GFX6-SDAG:       ; %bb.0:


### PR DESCRIPTION
Move G_FREEZE handling to AMDGPURegBankLegalizeRules.cpp.
Added support for uniform S1.