### PR TITLE
Fix the modal private state thread we use for running expressions on the private state thread

### DIFF
--- a/lldb/include/lldb/Host/HostThread.h
+++ b/lldb/include/lldb/Host/HostThread.h
@@ -42,6 +42,7 @@ public:
   lldb::thread_result_t GetResult() const;
 
   bool EqualsThread(lldb::thread_t thread) const;
+  bool EqualsThread(const HostThread &thread) const;
 
   bool HasThread() const;
 

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2999,8 +2999,6 @@ protected:
     return lldb::ThreadSP();
   }
 
-  lldb::StateType GetPrivateState();
-
   /// The "private" side of resuming a process.  This doesn't alter the state
   /// of m_run_lock, but just causes the process to resume.
   ///
@@ -3064,10 +3062,14 @@ protected:
     std::string m_exit_string;
   };
 
-  bool PrivateStateThreadIsValid() const {
-    lldb::StateType state = m_private_state.GetValue();
+  bool PrivateStateThreadIsRunning() const {
+    if (!m_current_private_state_thread 
+        || !m_current_private_state_thread->IsRunning())
+      return false;
+
+    lldb::StateType state = m_current_private_state_thread->GetPrivateState();
     return state != lldb::eStateInvalid && state != lldb::eStateDetached &&
-           state != lldb::eStateExited && m_private_state_thread.IsJoinable();
+           state != lldb::eStateExited;
   }
 
   void ForceNextEventDelivery() { m_force_next_event_delivery = true; }
@@ -3184,13 +3186,187 @@ protected:
       return callback == rhs.callback && baton == rhs.baton;
     }
   };
+  
+  /// The PrivateStateThread class gathers all the bits of state needed to
+  /// manage handling Process events, from receiving them on the Private State
+  /// to signaling when process events are broadcase publicly, to determining
+  /// when various actors can act on the process.  It also holds the current
+  /// private state thread.
+  /// These need to be swappable as a group to manage the temporary modal 
+  /// private state thread that we spin up when we need to run an expression on
+  /// the private state thread.   
+  struct PrivateStateThread {
+    PrivateStateThread(Process &process,
+                       lldb::StateType public_state, 
+                       lldb::StateType private_state,
+                       bool is_secondary_thread, // FIXME: Can I get rid of this?
+                       llvm::StringRef thread_name) : m_process(process),
+      m_public_state(public_state), m_private_state(private_state),
+      m_thread_name(thread_name) {}
+    // This returns false if we couldn't start up the thread.  If that happens,
+    // you won't be doing any debugging today.
+    bool StartupThread();
+    
+    bool IsOnThread(const HostThread &thread) const;
+
+    bool IsJoinable() {
+      return m_private_state_thread.IsJoinable();
+    }
+    
+    void JoinAndReset() {
+      lldb::thread_result_t result = {};
+      m_private_state_thread.Join(&result);
+      m_private_state_thread.Reset();
+      m_is_running = false;
+    }
+    
+    bool IsRunning() {
+      return m_is_running;
+    }
+    
+    void SetThreadName(llvm::StringRef new_name) {
+      m_thread_name = new_name;
+    }
+    
+    lldb::StateType GetPrivateState() const { 
+      return m_private_state.GetValue();
+    }
+    
+    lldb::StateType GetPublicState() const { 
+      return m_public_state.GetValue();
+    }
+    
+    void SetPublicState(lldb::StateType new_value) { 
+      m_public_state.SetValue(new_value);
+    }
+    
+    void SetPrivateState(lldb::StateType new_value) { 
+      m_private_state.SetValue(new_value);
+    }
+    
+    std::recursive_mutex &GetPrivateStateMutex() {
+      return m_private_state.GetMutex();
+    }
+
+    lldb::StateType GetPrivateStateNoLock() const {
+      return m_private_state.GetValueNoLock();
+    }
+    
+    void SetPrivateStateNoLock(lldb::StateType new_state) {
+      m_private_state.SetValueNoLock(new_state);
+    }
+    
+    void SetPublicStateNoLock(lldb::StateType new_state) {
+      m_public_state.SetValueNoLock(new_state);
+    }
+    
+    bool SetPublicRunLockToRunning() {
+      return m_public_run_lock.SetRunning();
+    }
+    
+    bool SetPrivateRunLockToRunning() {
+      return m_private_run_lock.SetRunning();
+    }
+    
+    bool SetPublicRunLockToStopped() {
+      return m_public_run_lock.SetStopped();
+    }
+
+    bool SetPrivateRunLockToStopped() {
+      return m_private_run_lock.SetStopped();
+    }
+    
+    ProcessRunLock &GetRunLock() {
+      if (IsOnThread(Host::GetCurrentThread()))
+        return m_private_run_lock;
+      else
+        return m_public_run_lock;
+    }
+    
+    Process &m_process;
+    ///< The process state that we show to client code.  This will often differ
+    ///< from the actual process state, for instance when we've stopped in the
+    ///< middle of a ThreadPlan's operations, before we've decided to stop or
+    ///< continue.
+    ThreadSafeValue<lldb::StateType> m_public_state;
+    ///< The actual state of our process
+    ThreadSafeValue<lldb::StateType>  m_private_state;
+    ///< HostThread for the thread that watches for internal state events                     
+    HostThread m_private_state_thread;
+    //< These are the locks that client code acquires both to wait on the 
+    //< process stopping, and then to ensure that it stays in the stopped state
+    //< while the client code is operating on it.  Again, we need a parallel set,
+    //< one for public client code and one for code working on behalf of the
+    //< private state management.
+    ProcessRunLock m_public_run_lock;
+    ProcessRunLock m_private_run_lock;
+    bool m_is_running = false;
+    /// If we need to run an expression modally in the private state thread, we
+    /// have to spin up a secondary private state thread to manage the events
+    /// that drive that interaction.  This will be true if this is a modal
+    /// private state thread. 
+    bool m_is_secondary_thread;
+    ///< This will be the thread name given to the Private State HostThread when
+    ///< it gets spun up.
+    std::string m_thread_name;
+  };
+
+  bool SetPrivateRunLockToStopped() {
+    assert(m_current_private_state_thread);
+    if (m_current_private_state_thread)
+      return m_current_private_state_thread->SetPrivateRunLockToStopped();
+    return false;
+  }
+  bool SetPrivateRunLockToRunning() {
+    assert(m_current_private_state_thread);
+    if (m_current_private_state_thread)
+      return m_current_private_state_thread->SetPrivateRunLockToStopped();
+    return false;
+  }
+  bool SetPublicRunLockToStopped() {
+    assert(m_current_private_state_thread);
+    if (m_current_private_state_thread)
+      return m_current_private_state_thread->SetPublicRunLockToStopped();
+    return false;
+  }
+  bool SetPublicRunLockToRunning() {
+    assert(m_current_private_state_thread);
+    if (m_current_private_state_thread)
+      return m_current_private_state_thread->SetPublicRunLockToRunning();
+    return false;
+  }
+  
+  std::recursive_mutex &GetPrivateStateMutex() {
+    assert(m_current_private_state_thread);
+    return m_current_private_state_thread->GetPrivateStateMutex();
+  }
+  
+  lldb::StateType GetPublicState() const {
+    if (!m_current_private_state_thread)
+      return lldb::eStateUnloaded;
+    return m_current_private_state_thread->GetPublicState();
+  }
+
+  lldb::StateType GetPrivateState() const {
+    if (!m_current_private_state_thread)
+      return lldb::eStateUnloaded;
+    return m_current_private_state_thread->GetPrivateState();
+  }
+  
+  lldb::StateType GetPrivateStateNoLock() const {
+    if (!m_current_private_state_thread)
+      return lldb::eStateUnloaded;
+    return m_current_private_state_thread->GetPrivateStateNoLock();
+  }
+  
+  void SetPrivateStateNoLock(lldb::StateType new_state) {
+    assert(m_current_private_state_thread);
+    m_current_private_state_thread->SetPrivateStateNoLock(new_state);
+  }
 
   // Member variables
   std::weak_ptr<Target> m_target_wp; ///< The target that owns this process.
   lldb::pid_t m_pid = LLDB_INVALID_PROCESS_ID;
-  ThreadSafeValue<lldb::StateType> m_public_state;
-  ThreadSafeValue<lldb::StateType>
-      m_private_state;                     // The actual state of our process
   Broadcaster m_private_state_broadcaster; // This broadcaster feeds state
                                            // changed events into the private
                                            // state thread's listener.
@@ -3200,8 +3376,13 @@ protected:
                                                    // private state thread.
   lldb::ListenerSP m_private_state_listener_sp; // This is the listener for the
                                                 // private state thread.
-  HostThread m_private_state_thread; ///< Thread ID for the thread that watches
-                                     ///internal state events
+  ///< This is filled on construction with the "main" private state which will
+  ///< be exposed to clients of this process.  It won't have a running private
+  ///< state thread until you call StartupThread.  This needs to be a pointer
+  ///< so I can transparently swap it out for the modal one, but there will
+  ///< always be a private state thread in this slot. 
+  PrivateStateThread *m_current_private_state_thread;
+
   ProcessModID m_mod_id; ///< Tracks the state of the process over stops and
                          ///other alterations.
   uint32_t m_process_unique_id; ///< Each lldb_private::Process class that is
@@ -3276,8 +3457,6 @@ protected:
   InstrumentationRuntimeCollection m_instrumentation_runtimes;
   std::unique_ptr<NextEventAction> m_next_event_action_up;
   std::vector<PreResumeCallbackAndBaton> m_pre_resume_actions;
-  ProcessRunLock m_public_run_lock;
-  ProcessRunLock m_private_run_lock;
   bool m_currently_handling_do_on_removals;
   bool m_resume_requested; // If m_currently_handling_event or
                            // m_currently_handling_do_on_removals are true,
@@ -3348,7 +3527,11 @@ protected:
 
   void SetPrivateState(lldb::StateType state);
 
-  bool StartPrivateStateThread(bool is_secondary_thread = false);
+  // Starts the private state thread and assigns it to 
+  // m_current_private_state_thread.  Clients who are making a secondary thread
+  // for now have to manage backing that up by hand.
+  bool StartPrivateStateThread(lldb::StateType state, bool run_lock_is_running, 
+                               bool is_secondary_thread = false);
 
   void StopPrivateStateThread();
 

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3187,7 +3187,7 @@ protected:
     }
   };
 
-  /// The PrivateStateThread class gathers all the bits of state needed to
+  /// The PrivateStateThread struct gathers all the bits of state needed to
   /// manage handling Process events, from receiving them on the Private State
   /// to signaling when process events are broadcase publicly, to determining
   /// when various actors can act on the process.  It also holds the current

--- a/lldb/source/Host/common/HostThread.cpp
+++ b/lldb/source/Host/common/HostThread.cpp
@@ -46,7 +46,8 @@ bool HostThread::EqualsThread(lldb::thread_t thread) const {
 }
 
 bool HostThread::EqualsThread(const HostThread &thread) const {
-  return m_native_thread->EqualsThread(thread.GetNativeThread().GetSystemHandle());
+  return m_native_thread->EqualsThread(
+      thread.GetNativeThread().GetSystemHandle());
 }
 
 bool HostThread::HasThread() const {

--- a/lldb/source/Host/common/HostThread.cpp
+++ b/lldb/source/Host/common/HostThread.cpp
@@ -45,6 +45,10 @@ bool HostThread::EqualsThread(lldb::thread_t thread) const {
   return m_native_thread->EqualsThread(thread);
 }
 
+bool HostThread::EqualsThread(const HostThread &thread) const {
+  return m_native_thread->EqualsThread(thread.GetNativeThread().GetSystemHandle());
+}
+
 bool HostThread::HasThread() const {
   if (!m_native_thread)
     return false;

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -2546,7 +2546,7 @@ void ProcessGDBRemote::RefreshStateAfterStop() {
 Status ProcessGDBRemote::DoHalt(bool &caused_stop) {
   Status error;
 
-  if (m_public_state.GetValue() == eStateAttaching) {
+  if (GetPublicState() == eStateAttaching) {
     // We are being asked to halt during an attach. We used to just close our
     // file handle and debugserver will go away, but with remote proxies, it
     // is better to send a positive signal, so let's send the interrupt first...
@@ -2595,7 +2595,7 @@ Status ProcessGDBRemote::DoDestroy() {
   std::string exit_string;
 
   if (m_gdb_comm.IsConnected()) {
-    if (m_public_state.GetValue() != eStateAttaching) {
+    if (GetPublicState() != eStateAttaching) {
       llvm::Expected<int> kill_res = m_gdb_comm.KillProcess(GetID());
 
       if (kill_res) {

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2737,7 +2737,7 @@ Status Process::Launch(ProcessLaunchInfo &launch_info) {
   } else {
     StartPrivateStateThread(state_after_launch, false);
     if (!m_current_private_state_thread) {
-      // We are not going to get any further here The only way this could fail
+      // We are not going to get any further here. The only way this could fail
       // is if we can't start a host thread, so we're pretty much toast at that
       // point.
       return Status::FromErrorString("could not start private state thread.");
@@ -2898,7 +2898,7 @@ Status Process::LoadCore() {
       StartPrivateStateThread(lldb::eStateStopped,
                               /*RunLock Is stopped*/ false);
       if (!m_current_private_state_thread) {
-        // FIXME: We are not going to get any further here. The only way this
+        // We are not going to get any further here. The only way this
         // could fail is if we can't start a host thread, so we're pretty much
         //  toast at that point.
         return Status::FromErrorString("could not start private state thread.");
@@ -3110,7 +3110,7 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
                 this, attach_info.GetResumeCount()));
             StartPrivateStateThread(lldb::eStateAttaching, true);
             if (!m_current_private_state_thread) {
-              // FIXME: We are not going to get any further here.  The only way
+              // We are not going to get any further here.  The only way
               // this could fail is if we can't start a host thread, and we're
               // pretty much toast at that point.
               return Status::FromErrorString(
@@ -3173,7 +3173,7 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
 
         StartPrivateStateThread(lldb::eStateAttaching, true);
         if (!m_current_private_state_thread) {
-          // FIXME: We are not going to get any further here.  The only way this
+          // We are not going to get any further here.  The only way this
           // could fail is if we can't start a host thread, so we're pretty much
           // toast at thatpoint.
           return Status::FromErrorString(
@@ -3360,7 +3360,7 @@ Status Process::ConnectRemote(llvm::StringRef remote_url) {
       StartPrivateStateThread(lldb::eStateStopped,
                               /*RunLock is stopped */ false);
       if (!m_current_private_state_thread) {
-        // FIXME: We are not going to get any further here.  The only way this
+        // We are not going to get any further here.  The only way this
         // could fail is if we can't start a host thread, so we're pretty much
         // toast at that point.
         return Status::FromErrorString("could not start private state thread.");
@@ -6046,8 +6046,7 @@ void Process::ClearPreResumeAction(PreResumeActionCallback callback, void *baton
 ProcessRunLock &Process::GetRunLock() {
   if (Process::CurrentThreadPosesAsPrivateStateThread())
     return m_current_private_state_thread->GetRunLock();
-  else
-    return m_current_private_state_thread->GetRunLock();
+  return m_current_private_state_thread->GetRunLock();
 }
 
 bool Process::CurrentThreadIsPrivateStateThread()

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2896,7 +2896,7 @@ Status Process::LoadCore() {
       ResumePrivateStateThread();
     else {
       StartPrivateStateThread(lldb::eStateStopped,
-                              /*RunLock Is stopped*/ false);
+                              /*RunLock is stopped*/ false);
       if (!m_current_private_state_thread) {
         // We are not going to get any further here. The only way this
         // could fail is if we can't start a host thread, so we're pretty much
@@ -6044,8 +6044,6 @@ void Process::ClearPreResumeAction(PreResumeActionCallback callback, void *baton
 }
 
 ProcessRunLock &Process::GetRunLock() {
-  if (Process::CurrentThreadPosesAsPrivateStateThread())
-    return m_current_private_state_thread->GetRunLock();
   return m_current_private_state_thread->GetRunLock();
 }
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -5249,7 +5249,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     selected_tid = LLDB_INVALID_THREAD_ID;
   }
 
-  PrivateStateThread *backup_private_state_thread;
+  PrivateStateThread *backup_private_state_thread = nullptr;
   lldb::StateType old_state = eStateInvalid;
   lldb::ThreadPlanSP stopper_base_plan_sp;
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -436,15 +436,15 @@ Process::Process(lldb::TargetSP target_sp, ListenerSP listener_sp,
     : ProcessProperties(this),
       Broadcaster((target_sp->GetDebugger().GetBroadcasterManager()),
                   Process::GetStaticBroadcasterClass().str()),
-      m_target_wp(target_sp), 
+      m_target_wp(target_sp),
       m_private_state_broadcaster(nullptr,
-          "lldb.process.internal_state_broadcaster"),
-      m_private_state_control_broadcaster(nullptr, 
-          "lldb.process.internal_state_control_broadcaster"),
+                                  "lldb.process.internal_state_broadcaster"),
+      m_private_state_control_broadcaster(
+          nullptr, "lldb.process.internal_state_control_broadcaster"),
       m_private_state_listener_sp(
           Listener::MakeListener("lldb.process.internal_state_listener")),
-      m_current_private_state_thread(new PrivateStateThread(*this, 
-          eStateUnloaded, eStateUnloaded, false, "rename-this-thread")),
+      m_current_private_state_thread(new PrivateStateThread(
+          *this, eStateUnloaded, eStateUnloaded, false, "rename-this-thread")),
       m_mod_id(), m_process_unique_id(0), m_thread_index_id(0),
       m_thread_id_to_index_id_map(), m_exit_status(-1),
       m_thread_list_real(*this), m_thread_list(*this), m_thread_plans(*this),
@@ -456,14 +456,13 @@ Process::Process(lldb::TargetSP target_sp, ListenerSP listener_sp,
       m_stdin_forward(false), m_stdout_data(), m_stderr_data(),
       m_profile_data_comm_mutex(), m_profile_data(), m_iohandler_sync(0),
       m_memory_cache(*this), m_allocated_memory_cache(*this),
-      m_should_detach(false), m_next_event_action_up(), 
-      m_currently_handling_do_on_removals(false),
-      m_resume_requested(false), m_interrupt_tid(LLDB_INVALID_THREAD_ID),
-      m_finalizing(false), m_destructing(false),
-      m_clear_thread_plans_on_stop(false), m_force_next_event_delivery(false),
-      m_last_broadcast_state(eStateInvalid), m_destroy_in_process(false),
-      m_can_interpret_function_calls(false), m_run_thread_plan_lock(),
-      m_can_jit(eCanJITDontKnow),
+      m_should_detach(false), m_next_event_action_up(),
+      m_currently_handling_do_on_removals(false), m_resume_requested(false),
+      m_interrupt_tid(LLDB_INVALID_THREAD_ID), m_finalizing(false),
+      m_destructing(false), m_clear_thread_plans_on_stop(false),
+      m_force_next_event_delivery(false), m_last_broadcast_state(eStateInvalid),
+      m_destroy_in_process(false), m_can_interpret_function_calls(false),
+      m_run_thread_plan_lock(), m_can_jit(eCanJITDontKnow),
       m_crash_info_dict_sp(new StructuredData::Dictionary()) {
   CheckInWithManager();
 
@@ -1329,7 +1328,7 @@ void Process::SetPublicState(StateType new_state, bool restarted) {
         if (new_state_is_stopped && !restarted) {
           LLDB_LOGF(log, "(plugin = %s, state = %s) -- unlocking run lock",
                    GetPluginName().data(), StateAsCString(new_state));
-        SetPublicRunLockToStopped();
+          SetPublicRunLockToStopped();
         }
       }
     }
@@ -1415,7 +1414,7 @@ void Process::SetPrivateState(StateType new_state) {
   // been destroyed.
   if (m_destructing)
     return;
-  
+
   if (!m_current_private_state_thread)
     return;
 
@@ -2744,7 +2743,7 @@ Status Process::Launch(ProcessLaunchInfo &launch_info) {
       return Status::FromErrorString("could not start private state thread.");
     }
   }
-  
+
   // Target was stopped at entry as was intended. Need to notify the
   // listeners about it.
   if (launch_info.GetFlags().Test(eLaunchFlagStopAtEntry))
@@ -2896,7 +2895,8 @@ Status Process::LoadCore() {
     if (PrivateStateThreadIsRunning())
       ResumePrivateStateThread();
     else {
-      StartPrivateStateThread(lldb::eStateStopped, /*RunLock Is stopped*/ false);
+      StartPrivateStateThread(lldb::eStateStopped,
+                              /*RunLock Is stopped*/ false);
       if (!m_current_private_state_thread) {
         // FIXME: We are not going to get any further here. The only way this
         // could fail is if we can't start a host thread, so we're pretty much
@@ -3110,8 +3110,8 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
                 this, attach_info.GetResumeCount()));
             StartPrivateStateThread(lldb::eStateAttaching, true);
             if (!m_current_private_state_thread) {
-              // FIXME: We are not going to get any further here.  The only way 
-              // this could fail is if we can't start a host thread, and we're 
+              // FIXME: We are not going to get any further here.  The only way
+              // this could fail is if we can't start a host thread, and we're
               // pretty much toast at that point.
               return Status::FromErrorString(
                   "could not start private state thread.");
@@ -3176,7 +3176,8 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
           // FIXME: We are not going to get any further here.  The only way this
           // could fail is if we can't start a host thread, so we're pretty much
           // toast at thatpoint.
-          return Status::FromErrorString("could not start private state thread.");
+          return Status::FromErrorString(
+              "could not start private state thread.");
         }
       } else {
         if (GetID() != LLDB_INVALID_PROCESS_ID)
@@ -3356,7 +3357,8 @@ Status Process::ConnectRemote(llvm::StringRef remote_url) {
     if (PrivateStateThreadIsRunning())
       ResumePrivateStateThread();
     else {
-      StartPrivateStateThread(lldb::eStateStopped, /*RunLock is stopped */false);
+      StartPrivateStateThread(lldb::eStateStopped,
+                              /*RunLock is stopped */ false);
       if (!m_current_private_state_thread) {
         // FIXME: We are not going to get any further here.  The only way this
         // could fail is if we can't start a host thread, so we're pretty much
@@ -3911,8 +3913,7 @@ bool Process::ShouldBroadcastEvent(Event *event_ptr) {
   return return_value;
 }
 
-bool Process::PrivateStateThread::StartupThread()
-{
+bool Process::PrivateStateThread::StartupThread() {
   llvm::Expected<HostThread> private_state_thread =
       ThreadLauncher::LaunchThread(
           m_thread_name,
@@ -3937,9 +3938,10 @@ bool Process::PrivateStateThread::IsOnThread(const HostThread &thread) const {
   return m_private_state_thread.EqualsThread(thread);
 }
 
-bool Process::StartPrivateStateThread(lldb::StateType state, 
-    bool run_lock_is_running, bool is_secondary_thread) {
-  Log *log = GetLog(LLDBLog::Events); 
+bool Process::StartPrivateStateThread(lldb::StateType state,
+                                      bool run_lock_is_running,
+                                      bool is_secondary_thread) {
+  Log *log = GetLog(LLDBLog::Events);
 
   bool already_running = PrivateStateThreadIsRunning();
   LLDB_LOGF(log, "Process::%s()%s ", __FUNCTION__,
@@ -3969,18 +3971,18 @@ bool Process::StartPrivateStateThread(lldb::StateType state,
       snprintf(thread_name, sizeof(thread_name),
                "<lldb.process.internal-state(pid=%" PRIu64 ")>", GetID());
   }
-  
+
   if (is_secondary_thread) {
-    PrivateStateThread *new_private_state_thread = 
-        new PrivateStateThread(*this, GetPublicState(), GetPrivateState(), 
-            is_secondary_thread, thread_name);
+    PrivateStateThread *new_private_state_thread =
+        new PrivateStateThread(*this, GetPublicState(), GetPrivateState(),
+                               is_secondary_thread, thread_name);
     // StartupThread expects the m_current_private_state_thread to be in place
     // already, so do that first:
     m_current_private_state_thread = new_private_state_thread;
   } else
     m_current_private_state_thread->SetThreadName(thread_name);
 
-  SetPublicState(state, /*restarted=*/ false);
+  SetPublicState(state, /*restarted=*/false);
   if (run_lock_is_running)
     SetPublicRunLockToRunning();
   else
@@ -5278,8 +5280,8 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     m_current_private_state_thread->SetPublicStateNoLock(eStateStopped);
 
     // Now spin up the private state thread:
-    StartPrivateStateThread(lldb::eStateStopped, /* RunLock is stopped*/false, 
-        /*secondary_thread=*/true);
+    StartPrivateStateThread(lldb::eStateStopped, /* RunLock is stopped*/ false,
+                            /*secondary_thread=*/true);
     if (!m_current_private_state_thread) {
       // If we can't spin up a thread here we can't run this expression.  But
       // presumably the old private state thread is still good, so just put it
@@ -5730,7 +5732,8 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
 
     // If we had to start up a temporary private state thread to run this
     // thread plan, shut it down now.
-    if (backup_private_state_thread && backup_private_state_thread->IsJoinable()) {
+    if (backup_private_state_thread &&
+        backup_private_state_thread->IsJoinable()) {
       StopPrivateStateThread();
       Status error;
       m_current_private_state_thread = backup_private_state_thread;
@@ -6057,8 +6060,8 @@ bool Process::CurrentThreadIsPrivateStateThread()
 bool Process::CurrentThreadPosesAsPrivateStateThread() {
   // If we haven't started up the private state thread yet, then whatever thread
   // is fetching this event should be temporarily the private state thread.
-  if (!m_current_private_state_thread 
-      || !m_current_private_state_thread->IsRunning())
+  if (!m_current_private_state_thread ||
+      !m_current_private_state_thread->IsRunning())
     return true;
   return m_current_private_state_thread->IsOnThread(Host::GetCurrentThread());
 }

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -436,14 +436,15 @@ Process::Process(lldb::TargetSP target_sp, ListenerSP listener_sp,
     : ProcessProperties(this),
       Broadcaster((target_sp->GetDebugger().GetBroadcasterManager()),
                   Process::GetStaticBroadcasterClass().str()),
-      m_target_wp(target_sp), m_public_state(eStateUnloaded),
-      m_private_state(eStateUnloaded),
+      m_target_wp(target_sp), 
       m_private_state_broadcaster(nullptr,
-                                  "lldb.process.internal_state_broadcaster"),
-      m_private_state_control_broadcaster(
-          nullptr, "lldb.process.internal_state_control_broadcaster"),
+          "lldb.process.internal_state_broadcaster"),
+      m_private_state_control_broadcaster(nullptr, 
+          "lldb.process.internal_state_control_broadcaster"),
       m_private_state_listener_sp(
           Listener::MakeListener("lldb.process.internal_state_listener")),
+      m_current_private_state_thread(new PrivateStateThread(*this, 
+          eStateUnloaded, eStateUnloaded, false, "rename-this-thread")),
       m_mod_id(), m_process_unique_id(0), m_thread_index_id(0),
       m_thread_id_to_index_id_map(), m_exit_status(-1),
       m_thread_list_real(*this), m_thread_list(*this), m_thread_plans(*this),
@@ -455,8 +456,8 @@ Process::Process(lldb::TargetSP target_sp, ListenerSP listener_sp,
       m_stdin_forward(false), m_stdout_data(), m_stderr_data(),
       m_profile_data_comm_mutex(), m_profile_data(), m_iohandler_sync(0),
       m_memory_cache(*this), m_allocated_memory_cache(*this),
-      m_should_detach(false), m_next_event_action_up(), m_public_run_lock(),
-      m_private_run_lock(), m_currently_handling_do_on_removals(false),
+      m_should_detach(false), m_next_event_action_up(), 
+      m_currently_handling_do_on_removals(false),
       m_resume_requested(false), m_interrupt_tid(LLDB_INVALID_THREAD_ID),
       m_finalizing(false), m_destructing(false),
       m_clear_thread_plans_on_stop(false), m_force_next_event_delivery(false),
@@ -585,8 +586,8 @@ void Process::Finalize(bool destructing) {
   // contain events that have ProcessSP values in them which can keep this
   // process around forever. These events need to be cleared out.
   m_private_state_listener_sp->Clear();
-  m_public_run_lock.SetStopped();
-  m_private_run_lock.SetStopped();
+  SetPublicRunLockToStopped();
+  SetPrivateRunLockToStopped();
   m_structured_data_plugin_map.clear();
 }
 
@@ -689,7 +690,7 @@ StateType Process::WaitForProcessToStop(
     // We need to toggle the run lock as this won't get done in
     // SetPublicState() if the process is hijacked.
     if (hijack_listener_sp && use_run_lock)
-      m_public_run_lock.SetStopped();
+      SetPublicRunLockToStopped();
     return state;
   }
 
@@ -711,7 +712,7 @@ StateType Process::WaitForProcessToStop(
       // We need to toggle the run lock as this won't get done in
       // SetPublicState() if the process is hijacked.
       if (hijack_listener_sp && use_run_lock)
-        m_public_run_lock.SetStopped();
+        SetPublicRunLockToStopped();
       return state;
     case eStateStopped:
       if (Process::ProcessEventData::GetRestartedFromEvent(event_sp.get()))
@@ -720,7 +721,7 @@ StateType Process::WaitForProcessToStop(
         // We need to toggle the run lock as this won't get done in
         // SetPublicState() if the process is hijacked.
         if (hijack_listener_sp && use_run_lock)
-          m_public_run_lock.SetStopped();
+          SetPublicRunLockToStopped();
         return state;
       }
     default:
@@ -1002,13 +1003,13 @@ bool Process::GetEventsPrivate(EventSP &event_sp,
 }
 
 bool Process::IsRunning() const {
-  return StateIsRunningState(m_public_state.GetValue());
+  return StateIsRunningState(GetPublicState());
 }
 
 int Process::GetExitStatus() {
   std::lock_guard<std::mutex> guard(m_exit_status_mutex);
 
-  if (m_public_state.GetValue() == eStateExited)
+  if (GetPublicState() == eStateExited)
     return m_exit_status;
   return -1;
 }
@@ -1016,7 +1017,7 @@ int Process::GetExitStatus() {
 const char *Process::GetExitDescription() {
   std::lock_guard<std::mutex> guard(m_exit_status_mutex);
 
-  if (m_public_state.GetValue() == eStateExited && !m_exit_string.empty())
+  if (GetPublicState() == eStateExited && !m_exit_string.empty())
     return m_exit_string.c_str();
   return nullptr;
 }
@@ -1029,7 +1030,7 @@ bool Process::SetExitStatus(int status, llvm::StringRef exit_string) {
            GetPluginName(), status, exit_string);
 
   // We were already in the exited state
-  if (m_private_state.GetValue() == eStateExited) {
+  if (GetPrivateState() == eStateExited) {
     LLDB_LOG(
         log,
         "(plugin = {0}) ignoring exit status because state was already set "
@@ -1080,7 +1081,10 @@ bool Process::SetExitStatus(int status, llvm::StringRef exit_string) {
 }
 
 bool Process::IsAlive() {
-  switch (m_private_state.GetValue()) {
+  if (!m_current_private_state_thread)
+    return false;
+
+  switch (GetPrivateState()) {
   case eStateConnected:
   case eStateAttaching:
   case eStateLaunching:
@@ -1283,10 +1287,13 @@ uint32_t Process::AssignIndexIDToThread(uint64_t thread_id) {
 }
 
 StateType Process::GetState() {
+  if (!m_current_private_state_thread)
+    return eStateUnloaded;
+
   if (CurrentThreadPosesAsPrivateStateThread())
-    return m_private_state.GetValue();
+    return GetPrivateState();
   else
-    return m_public_state.GetValue();
+    return GetPublicState();
 }
 
 void Process::SetPublicState(StateType new_state, bool restarted) {
@@ -1304,8 +1311,8 @@ void Process::SetPublicState(StateType new_state, bool restarted) {
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process));
   LLDB_LOGF(log, "(plugin = %s, state = %s, restarted = %i)",
            GetPluginName().data(), StateAsCString(new_state), restarted);
-  const StateType old_state = m_public_state.GetValue();
-  m_public_state.SetValue(new_state);
+  const StateType old_state = GetPublicState();
+  m_current_private_state_thread->SetPublicState(new_state);
 
   // On the transition from Run to Stopped, we unlock the writer end of the run
   // lock.  The lock gets locked in Resume, which is the public API to tell the
@@ -1315,14 +1322,14 @@ void Process::SetPublicState(StateType new_state, bool restarted) {
       LLDB_LOGF(log,
                "(plugin = %s, state = %s) -- unlocking run lock for detach",
                GetPluginName().data(), StateAsCString(new_state));
-      m_public_run_lock.SetStopped();
+      SetPublicRunLockToStopped();
     } else {
       const bool old_state_is_stopped = StateIsStoppedState(old_state, false);
       if ((old_state_is_stopped != new_state_is_stopped)) {
         if (new_state_is_stopped && !restarted) {
           LLDB_LOGF(log, "(plugin = %s, state = %s) -- unlocking run lock",
                    GetPluginName().data(), StateAsCString(new_state));
-          m_public_run_lock.SetStopped();
+        SetPublicRunLockToStopped();
         }
       }
     }
@@ -1332,7 +1339,7 @@ void Process::SetPublicState(StateType new_state, bool restarted) {
 Status Process::Resume() {
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process));
   LLDB_LOGF(log, "(plugin = %s) -- locking run lock", GetPluginName().data());
-  if (!m_public_run_lock.SetRunning()) {
+  if (!SetPublicRunLockToRunning()) {
     LLDB_LOGF(log, "(plugin = %s) -- SetRunning failed, not resuming.",
               GetPluginName().data());
     return Status::FromErrorString(
@@ -1341,7 +1348,7 @@ Status Process::Resume() {
   Status error = PrivateResume();
   if (!error.Success()) {
     // Undo running state change
-    m_public_run_lock.SetStopped();
+    SetPublicRunLockToStopped();
   }
   return error;
 }
@@ -1349,7 +1356,7 @@ Status Process::Resume() {
 Status Process::ResumeSynchronous(Stream *stream) {
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process));
   LLDB_LOGF(log, "Process::ResumeSynchronous -- locking run lock");
-  if (!m_public_run_lock.SetRunning()) {
+  if (!SetPublicRunLockToRunning()) {
     LLDB_LOGF(log, "Process::Resume: -- SetRunning failed, not resuming.");
     return Status::FromErrorString(
         "resume request failed: process already running");
@@ -1372,7 +1379,7 @@ Status Process::ResumeSynchronous(Stream *stream) {
           StateAsCString(state));
   } else {
     // Undo running state change
-    m_public_run_lock.SetStopped();
+    SetPublicRunLockToStopped();
   }
 
   // Undo the hijacking of process events...
@@ -1399,8 +1406,6 @@ bool Process::StateChangedIsHijackedForSynchronousResume() {
   return false;
 }
 
-StateType Process::GetPrivateState() { return m_private_state.GetValue(); }
-
 void Process::SetPrivateState(StateType new_state) {
   // Use m_destructing not m_finalizing here.  If we are finalizing a process
   // that we haven't started tearing down, we'd like to be able to nicely
@@ -1410,6 +1415,9 @@ void Process::SetPrivateState(StateType new_state) {
   // been destroyed.
   if (m_destructing)
     return;
+  
+  if (!m_current_private_state_thread)
+    return;
 
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process | LLDBLog::Unwind));
   bool state_changed = false;
@@ -1418,22 +1426,22 @@ void Process::SetPrivateState(StateType new_state) {
            StateAsCString(new_state));
 
   std::lock_guard<std::recursive_mutex> thread_guard(m_thread_list.GetMutex());
-  std::lock_guard<std::recursive_mutex> guard(m_private_state.GetMutex());
+  std::lock_guard<std::recursive_mutex> guard(GetPrivateStateMutex());
 
-  const StateType old_state = m_private_state.GetValueNoLock();
+  const StateType old_state = GetPrivateStateNoLock();
   state_changed = old_state != new_state;
 
   const bool old_state_is_stopped = StateIsStoppedState(old_state, false);
   const bool new_state_is_stopped = StateIsStoppedState(new_state, false);
   if (old_state_is_stopped != new_state_is_stopped) {
     if (new_state_is_stopped)
-      m_private_run_lock.SetStopped();
+      SetPrivateRunLockToStopped();
     else
-      m_private_run_lock.SetRunning();
+      SetPrivateRunLockToRunning();
   }
 
   if (state_changed) {
-    m_private_state.SetValueNoLock(new_state);
+    SetPrivateStateNoLock(new_state);
     EventSP event_sp(
         new Event(eBroadcastBitStateChanged,
                   new ProcessEventData(shared_from_this(), new_state)));
@@ -2723,13 +2731,20 @@ Status Process::Launch(ProcessLaunchInfo &launch_info) {
   // stopped or crashed. Directly set the state.  This is done to
   // prevent a stop message with a bunch of spurious output on thread
   // status, as well as not pop a ProcessIOHandler.
-  SetPublicState(state_after_launch, false);
 
-  if (PrivateStateThreadIsValid())
+  if (PrivateStateThreadIsRunning()) {
+    SetPublicState(state_after_launch, false);
     ResumePrivateStateThread();
-  else
-    StartPrivateStateThread();
-
+  } else {
+    StartPrivateStateThread(state_after_launch, false);
+    if (!m_current_private_state_thread) {
+      // We are not going to get any further here The only way this could fail
+      // is if we can't start a host thread, so we're pretty much toast at that
+      // point.
+      return Status::FromErrorString("could not start private state thread.");
+    }
+  }
+  
   // Target was stopped at entry as was intended. Need to notify the
   // listeners about it.
   if (launch_info.GetFlags().Test(eLaunchFlagStopAtEntry))
@@ -2786,7 +2801,7 @@ Status Process::LaunchPrivate(ProcessLaunchInfo &launch_info, StateType &state,
   HijackProcessEvents(listener_sp);
   llvm::scope_exit on_exit([this]() { RestoreProcessEvents(); });
 
-  if (PrivateStateThreadIsValid())
+  if (PrivateStateThreadIsRunning())
     PausePrivateStateThread();
 
   error = WillLaunch(exe_module);
@@ -2800,7 +2815,7 @@ Status Process::LaunchPrivate(ProcessLaunchInfo &launch_info, StateType &state,
   SetPublicState(eStateLaunching, restarted);
   m_should_detach = false;
 
-  m_public_run_lock.SetRunning();
+  SetPublicRunLockToRunning();
   error = DoLaunch(exe_module, launch_info);
 
   if (error.Fail()) {
@@ -2878,10 +2893,17 @@ Status Process::LoadCore() {
         Listener::MakeListener("lldb.process.load_core_listener"));
     HijackProcessEvents(listener_sp);
 
-    if (PrivateStateThreadIsValid())
+    if (PrivateStateThreadIsRunning())
       ResumePrivateStateThread();
-    else
-      StartPrivateStateThread();
+    else {
+      StartPrivateStateThread(lldb::eStateStopped, /*RunLock Is stopped*/ false);
+      if (!m_current_private_state_thread) {
+        // FIXME: We are not going to get any further here. The only way this
+        // could fail is if we can't start a host thread, so we're pretty much
+        //  toast at that point.
+        return Status::FromErrorString("could not start private state thread.");
+      }
+    }
 
     DynamicLoader *dyld = GetDynamicLoader();
     if (dyld)
@@ -3071,10 +3093,7 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
       if (wait_for_launch) {
         error = WillAttachToProcessWithName(process_name, wait_for_launch);
         if (error.Success()) {
-          m_public_run_lock.SetRunning();
           m_should_detach = true;
-          const bool restarted = false;
-          SetPublicState(eStateAttaching, restarted);
           // Now attach using these arguments.
           error = DoAttachToProcessWithName(process_name, attach_info);
 
@@ -3089,7 +3108,14 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
           } else {
             SetNextEventAction(new Process::AttachCompletionHandler(
                 this, attach_info.GetResumeCount()));
-            StartPrivateStateThread();
+            StartPrivateStateThread(lldb::eStateAttaching, true);
+            if (!m_current_private_state_thread) {
+              // FIXME: We are not going to get any further here.  The only way 
+              // this could fail is if we can't start a host thread, and we're 
+              // pretty much toast at that point.
+              return Status::FromErrorString(
+                  "could not start private state thread.");
+            }
           }
           return error;
         }
@@ -3137,18 +3163,21 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
   if (attach_pid != LLDB_INVALID_PROCESS_ID) {
     error = WillAttachToProcessWithID(attach_pid);
     if (error.Success()) {
-      m_public_run_lock.SetRunning();
-
       // Now attach using these arguments.
       m_should_detach = true;
-      const bool restarted = false;
-      SetPublicState(eStateAttaching, restarted);
       error = DoAttachToProcessWithID(attach_pid, attach_info);
 
       if (error.Success()) {
         SetNextEventAction(new Process::AttachCompletionHandler(
             this, attach_info.GetResumeCount()));
-        StartPrivateStateThread();
+
+        StartPrivateStateThread(lldb::eStateAttaching, true);
+        if (!m_current_private_state_thread) {
+          // FIXME: We are not going to get any further here.  The only way this
+          // could fail is if we can't start a host thread, so we're pretty much
+          // toast at thatpoint.
+          return Status::FromErrorString("could not start private state thread.");
+        }
       } else {
         if (GetID() != LLDB_INVALID_PROCESS_ID)
           SetID(LLDB_INVALID_PROCESS_ID);
@@ -3324,10 +3353,17 @@ Status Process::ConnectRemote(llvm::StringRef remote_url) {
       }
     }
 
-    if (PrivateStateThreadIsValid())
+    if (PrivateStateThreadIsRunning())
       ResumePrivateStateThread();
-    else
-      StartPrivateStateThread();
+    else {
+      StartPrivateStateThread(lldb::eStateStopped, /*RunLock is stopped */false);
+      if (!m_current_private_state_thread) {
+        // FIXME: We are not going to get any further here.  The only way this
+        // could fail is if we can't start a host thread, so we're pretty much
+        // toast at that point.
+        return Status::FromErrorString("could not start private state thread.");
+      }
+    }
   }
   return error;
 }
@@ -3344,8 +3380,8 @@ Status Process::PrivateResume() {
   LLDB_LOGF(log,
             "Process::PrivateResume() m_stop_id = %u, public state: %s "
             "private state: %s",
-            m_mod_id.GetStopID(), StateAsCString(m_public_state.GetValue()),
-            StateAsCString(m_private_state.GetValue()));
+            m_mod_id.GetStopID(), StateAsCString(GetPublicState()),
+            StateAsCString(GetPrivateState()));
 
   // If signals handing status changed we might want to update our signal
   // filters before resuming.
@@ -3407,7 +3443,7 @@ Status Process::PrivateResume() {
 }
 
 Status Process::Halt(bool clear_thread_plans, bool use_run_lock) {
-  if (!StateIsRunningState(m_public_state.GetValue()))
+  if (!StateIsRunningState(GetPublicState()))
     return Status::FromErrorString("Process is not running.");
 
   // Don't clear the m_clear_thread_plans_on_stop, only set it to true if in
@@ -3422,7 +3458,7 @@ Status Process::Halt(bool clear_thread_plans, bool use_run_lock) {
 
   SendAsyncInterrupt();
 
-  if (m_public_state.GetValue() == eStateAttaching) {
+  if (GetPublicState() == eStateAttaching) {
     // Don't hijack and eat the eStateExited as the code that was doing the
     // attach will be waiting for this event...
     RestoreProcessEvents();
@@ -3514,8 +3550,7 @@ Status Process::StopForDestroyOrDetach(lldb::EventSP &exit_event_sp) {
   // Check both the public & private states here.  If we're hung evaluating an
   // expression, for instance, then the public state will be stopped, but we
   // still need to interrupt.
-  if (m_public_state.GetValue() == eStateRunning ||
-      m_private_state.GetValue() == eStateRunning) {
+  if (GetPublicState() == eStateRunning || GetPrivateState() == eStateRunning) {
     Log *log = GetLog(LLDBLog::Process);
     LLDB_LOGF(log, "Process::%s() About to stop.", __FUNCTION__);
 
@@ -3536,7 +3571,7 @@ Status Process::StopForDestroyOrDetach(lldb::EventSP &exit_event_sp) {
     // doesn't need to do anything else, since they don't have a process
     // anymore...
 
-    if (state == eStateExited || m_private_state.GetValue() == eStateExited) {
+    if (state == eStateExited || GetPrivateState() == eStateExited) {
       LLDB_LOGF(log, "Process::%s() Process exited while waiting to stop.",
                 __FUNCTION__);
       return error;
@@ -3549,7 +3584,7 @@ Status Process::StopForDestroyOrDetach(lldb::EventSP &exit_event_sp) {
       // If we really couldn't stop the process then we should just error out
       // here, but if the lower levels just bobbled sending the event and we
       // really are stopped, then continue on.
-      StateType private_state = m_private_state.GetValue();
+      StateType private_state = GetPrivateState();
       if (private_state != eStateStopped) {
         return Status::FromErrorStringWithFormat(
             "Attempt to stop the target in order to detach timed out. "
@@ -3609,7 +3644,7 @@ Status Process::Detach(bool keep_stopped) {
   // case we might strand the write lock.  Unlock it here so when we do to tear
   // down the process we don't get an error destroying the lock.
 
-  m_public_run_lock.SetStopped();
+  SetPublicRunLockToStopped();
   return error;
 }
 
@@ -3646,7 +3681,7 @@ Status Process::DestroyImpl(bool force_kill) {
       error = StopForDestroyOrDetach(exit_event_sp);
     }
 
-    if (m_public_state.GetValue() == eStateStopped) {
+    if (GetPublicState() == eStateStopped) {
       // Ditch all thread plans, and remove all our breakpoints: in case we
       // have to restart the target to kill it, we don't want it hitting a
       // breakpoint... Only do this if we've stopped, however, since if we
@@ -3686,7 +3721,7 @@ Status Process::DestroyImpl(bool force_kill) {
     // may not end up propagating the last events through the event system, in
     // which case we might strand the write lock.  Unlock it here so when we do
     // to tear down the process we don't get an error destroying the lock.
-    m_public_run_lock.SetStopped();
+    SetPublicRunLockToStopped();
   }
 
   m_destroy_in_process = false;
@@ -3876,10 +3911,37 @@ bool Process::ShouldBroadcastEvent(Event *event_ptr) {
   return return_value;
 }
 
-bool Process::StartPrivateStateThread(bool is_secondary_thread) {
-  Log *log = GetLog(LLDBLog::Events);
+bool Process::PrivateStateThread::StartupThread()
+{
+  llvm::Expected<HostThread> private_state_thread =
+      ThreadLauncher::LaunchThread(
+          m_thread_name,
+          [this] {
+            return m_process.RunPrivateStateThread(m_is_secondary_thread);
+          },
+          8 * 1024 * 1024);
+  if (!private_state_thread) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Host), private_state_thread.takeError(),
+                   "failed to launch host thread: {0}");
+    return false;
+  }
 
-  bool already_running = PrivateStateThreadIsValid();
+  assert(private_state_thread->IsJoinable());
+  m_private_state_thread = *private_state_thread;
+  m_is_running = true;
+  m_process.ResumePrivateStateThread();
+  return true;
+}
+
+bool Process::PrivateStateThread::IsOnThread(const HostThread &thread) const {
+  return m_private_state_thread.EqualsThread(thread);
+}
+
+bool Process::StartPrivateStateThread(lldb::StateType state, 
+    bool run_lock_is_running, bool is_secondary_thread) {
+  Log *log = GetLog(LLDBLog::Events); 
+
+  bool already_running = PrivateStateThreadIsRunning();
   LLDB_LOGF(log, "Process::%s()%s ", __FUNCTION__,
             already_running ? " already running"
                             : " starting private state thread");
@@ -3907,24 +3969,24 @@ bool Process::StartPrivateStateThread(bool is_secondary_thread) {
       snprintf(thread_name, sizeof(thread_name),
                "<lldb.process.internal-state(pid=%" PRIu64 ")>", GetID());
   }
+  
+  if (is_secondary_thread) {
+    PrivateStateThread *new_private_state_thread = 
+        new PrivateStateThread(*this, GetPublicState(), GetPrivateState(), 
+            is_secondary_thread, thread_name);
+    // StartupThread expects the m_current_private_state_thread to be in place
+    // already, so do that first:
+    m_current_private_state_thread = new_private_state_thread;
+  } else
+    m_current_private_state_thread->SetThreadName(thread_name);
 
-  llvm::Expected<HostThread> private_state_thread =
-      ThreadLauncher::LaunchThread(
-          thread_name,
-          [this, is_secondary_thread] {
-            return RunPrivateStateThread(is_secondary_thread);
-          },
-          8 * 1024 * 1024);
-  if (!private_state_thread) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::Host), private_state_thread.takeError(),
-                   "failed to launch host thread: {0}");
-    return false;
-  }
+  SetPublicState(state, /*restarted=*/ false);
+  if (run_lock_is_running)
+    SetPublicRunLockToRunning();
+  else
+    SetPublicRunLockToStopped();
 
-  assert(private_state_thread->IsJoinable());
-  m_private_state_thread = *private_state_thread;
-  ResumePrivateStateThread();
-  return true;
+  return m_current_private_state_thread->StartupThread();
 }
 
 void Process::PausePrivateStateThread() {
@@ -3936,7 +3998,10 @@ void Process::ResumePrivateStateThread() {
 }
 
 void Process::StopPrivateStateThread() {
-  if (m_private_state_thread.IsJoinable())
+  if (!m_current_private_state_thread)
+    return;
+
+  if (m_current_private_state_thread->IsJoinable())
     ControlPrivateStateThread(eBroadcastInternalStateControlStop);
   else {
     Log *log = GetLog(LLDBLog::Process);
@@ -3956,7 +4021,7 @@ void Process::ControlPrivateStateThread(uint32_t signal) {
   LLDB_LOGF(log, "Process::%s (signal = %d)", __FUNCTION__, signal);
 
   // Signal the private state thread
-  if (m_private_state_thread.IsJoinable()) {
+  if (m_current_private_state_thread->IsJoinable()) {
     // Broadcast the event.
     // It is important to do this outside of the if below, because it's
     // possible that the thread state is invalid but that the thread is waiting
@@ -3969,7 +4034,7 @@ void Process::ControlPrivateStateThread(uint32_t signal) {
 
     // Wait for the event receipt or for the private state thread to exit
     bool receipt_received = false;
-    if (PrivateStateThreadIsValid()) {
+    if (PrivateStateThreadIsRunning()) {
       while (!receipt_received) {
         // Check for a receipt for n seconds and then check if the private
         // state thread is still around.
@@ -3978,17 +4043,15 @@ void Process::ControlPrivateStateThread(uint32_t signal) {
         if (!receipt_received) {
           // Check if the private state thread is still around. If it isn't
           // then we are done waiting
-          if (!PrivateStateThreadIsValid())
+          if (!PrivateStateThreadIsRunning())
             break; // Private state thread exited or is exiting, we are done
         }
       }
     }
 
-    if (signal == eBroadcastInternalStateControlStop) {
-      thread_result_t result = {};
-      m_private_state_thread.Join(&result);
-      m_private_state_thread.Reset();
-    }
+    if (signal == eBroadcastInternalStateControlStop)
+      m_current_private_state_thread->JoinAndReset();
+
   } else {
     LLDB_LOGF(
         log,
@@ -4001,7 +4064,7 @@ void Process::SendAsyncInterrupt(Thread *thread) {
     m_interrupt_tid = thread->GetProtocolID();
   else
     m_interrupt_tid = LLDB_INVALID_THREAD_ID;
-  if (PrivateStateThreadIsValid())
+  if (PrivateStateThreadIsRunning())
     m_private_state_broadcaster.BroadcastEvent(Process::eBroadcastBitInterrupt,
                                                nullptr);
   else
@@ -4168,7 +4231,7 @@ thread_result_t Process::RunPrivateStateThread(bool is_secondary_thread) {
 
       continue;
     } else if (event_sp->GetType() == eBroadcastBitInterrupt) {
-      if (m_public_state.GetValue() == eStateAttaching) {
+      if (GetPublicState() == eStateAttaching) {
         LLDB_LOGF(log,
                   "Process::%s (arg = %p, pid = %" PRIu64
                   ") woke up with an interrupt while attaching - "
@@ -4262,11 +4325,7 @@ thread_result_t Process::RunPrivateStateThread(bool is_secondary_thread) {
   LLDB_LOGF(log, "Process::%s (arg = %p, pid = %" PRIu64 ") thread exiting...",
             __FUNCTION__, static_cast<void *>(this), GetID());
 
-  // If we are a secondary thread, then the primary thread we are working for
-  // will have already acquired the public_run_lock, and isn't done with what
-  // it was doing yet, so don't try to change it on the way out.
-  if (!is_secondary_thread)
-    m_public_run_lock.SetStopped();
+  SetPublicRunLockToStopped();
   return {};
 }
 
@@ -5130,7 +5189,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
   // and reverting the mark it once we are done running the expression.
   UtilityFunctionScope util_scope(options.IsForUtilityExpr() ? this : nullptr);
 
-  if (m_private_state.GetValue() != eStateStopped) {
+  if (GetPrivateState() != eStateStopped) {
     diagnostic_manager.PutString(
         lldb::eSeverityError,
         "RunThreadPlan called while the private state was not stopped.");
@@ -5188,12 +5247,12 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     selected_tid = LLDB_INVALID_THREAD_ID;
   }
 
-  HostThread backup_private_state_thread;
+  PrivateStateThread *backup_private_state_thread;
   lldb::StateType old_state = eStateInvalid;
   lldb::ThreadPlanSP stopper_base_plan_sp;
 
   Log *log(GetLog(LLDBLog::Step | LLDBLog::Process));
-  if (m_private_state_thread.EqualsThread(Host::GetCurrentThread())) {
+  if (m_current_private_state_thread->IsOnThread(Host::GetCurrentThread())) {
     // Yikes, we are running on the private state thread!  So we can't wait for
     // public events on this thread, since we are the thread that is generating
     // public events. The simplest thing to do is to spin up a temporary thread
@@ -5202,7 +5261,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     LLDB_LOGF(log, "Running thread plan on private state thread, spinning up "
                    "another state thread to handle the events.");
 
-    backup_private_state_thread = m_private_state_thread;
+    backup_private_state_thread = m_current_private_state_thread;
 
     // One other bit of business: we want to run just this thread plan and
     // anything it pushes, and then stop, returning control here. But in the
@@ -5215,11 +5274,23 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     thread->QueueThreadPlan(stopper_base_plan_sp, false);
     // Have to make sure our public state is stopped, since otherwise the
     // reporting logic below doesn't work correctly.
-    old_state = m_public_state.GetValue();
-    m_public_state.SetValueNoLock(eStateStopped);
+    old_state = GetPublicState();
+    m_current_private_state_thread->SetPublicStateNoLock(eStateStopped);
 
     // Now spin up the private state thread:
-    StartPrivateStateThread(true);
+    StartPrivateStateThread(lldb::eStateStopped, /* RunLock is stopped*/false, 
+        /*secondary_thread=*/true);
+    if (!m_current_private_state_thread) {
+      // If we can't spin up a thread here we can't run this expression.  But
+      // presumably the old private state thread is still good, so just put it
+      // back and return an error.
+      diagnostic_manager.Printf(
+          lldb::eSeverityError,
+          "could not spin up a thread to handle events for an expression"
+          " run on the private state thread.");
+      m_current_private_state_thread = backup_private_state_thread;
+      return eExpressionSetupError;
+    }
   }
 
   thread->QueueThreadPlan(
@@ -5659,15 +5730,15 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
 
     // If we had to start up a temporary private state thread to run this
     // thread plan, shut it down now.
-    if (backup_private_state_thread.IsJoinable()) {
+    if (backup_private_state_thread && backup_private_state_thread->IsJoinable()) {
       StopPrivateStateThread();
       Status error;
-      m_private_state_thread = backup_private_state_thread;
+      m_current_private_state_thread = backup_private_state_thread;
       if (stopper_base_plan_sp) {
         thread->DiscardThreadPlansUpToPlan(stopper_base_plan_sp);
       }
       if (old_state != eStateInvalid)
-        m_public_state.SetValueNoLock(old_state);
+        m_current_private_state_thread->SetPublicStateNoLock(old_state);
     }
 
     // If our thread went away on us, we need to get out of here without
@@ -5970,22 +6041,26 @@ void Process::ClearPreResumeAction(PreResumeActionCallback callback, void *baton
 }
 
 ProcessRunLock &Process::GetRunLock() {
-  if (Process::CurrentThreadIsPrivateStateThread())
-    return m_private_run_lock;
-  return m_public_run_lock;
+  if (Process::CurrentThreadPosesAsPrivateStateThread())
+    return m_current_private_state_thread->GetRunLock();
+  else
+    return m_current_private_state_thread->GetRunLock();
 }
 
 bool Process::CurrentThreadIsPrivateStateThread()
 {
-  return m_private_state_thread.EqualsThread(Host::GetCurrentThread());
+  if (!m_current_private_state_thread)
+    return true;
+  return m_current_private_state_thread->IsOnThread(Host::GetCurrentThread());
 }
 
 bool Process::CurrentThreadPosesAsPrivateStateThread() {
   // If we haven't started up the private state thread yet, then whatever thread
   // is fetching this event should be temporarily the private state thread.
-  if (!m_private_state_thread.HasThread())
+  if (!m_current_private_state_thread 
+      || !m_current_private_state_thread->IsRunning())
     return true;
-  return m_private_state_thread.EqualsThread(Host::GetCurrentThread());
+  return m_current_private_state_thread->IsOnThread(Host::GetCurrentThread());
 }
 
 void Process::Flush() {

--- a/lldb/source/Target/ProcessTrace.cpp
+++ b/lldb/source/Target/ProcessTrace.cpp
@@ -68,7 +68,7 @@ void ProcessTrace::DidAttach(ArchSpec &process_arch) {
   StartPrivateStateThread(lldb::eStateStopped, false);
   if (!m_current_private_state_thread) {
     LLDB_LOG(GetLog(LLDBLog::Process), "ProcessTrace: failed to start private "
-        "state thread.");
+                                       "state thread.");
     return;
   }
 

--- a/lldb/source/Target/ProcessTrace.cpp
+++ b/lldb/source/Target/ProcessTrace.cpp
@@ -16,6 +16,8 @@
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/SectionLoadList.h"
 #include "lldb/Target/Target.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -63,8 +65,12 @@ void ProcessTrace::DidAttach(ArchSpec &process_arch) {
   HijackProcessEvents(listener_sp);
 
   SetCanJIT(false);
-  StartPrivateStateThread();
-  SetPrivateState(eStateStopped);
+  StartPrivateStateThread(lldb::eStateStopped, false);
+  if (!m_current_private_state_thread) {
+    LLDB_LOG(GetLog(LLDBLog::Process), "ProcessTrace: failed to start private "
+        "state thread.");
+    return;
+  }
 
   EventSP event_sp;
   WaitForProcessToStop(std::nullopt, &event_sp, true, listener_sp);

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/TestWasHit.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/TestWasHit.py
@@ -65,6 +65,13 @@ class TestWasHit(TestBase):
         )
         self.assertEqual(thread.stop_reason_data[1], 1, "First location hit is 1")
 
+        # Check that we did increment our global:
+        values = target.FindGlobalVariables("g_change_me", 2, lldb.eSymbolTypeCode)
+        self.assertEqual(values.GetSize(), 1, "Got the change me global")
+        change_me = values.GetValueAtIndex(0)
+        change_me_value = 1
+        self.assertEqual(change_me.signed, change_me_value, "g_change_me had the right value")
+        
         for loc in [3, 4]:
             process.Continue()
             self.assertEqual(
@@ -76,6 +83,8 @@ class TestWasHit(TestBase):
             self.assertEqual(
                 thread.stop_reason_data[1], loc, f"Hit the right location: {loc}"
             )
+            change_me_value += 1
+            self.assertEqual(change_me.signed, change_me_value, "g_change_me was updated correctly")
 
         # At this point we should have hit three of the four locations, and not location 1.2.
         # Check that that is true, and that the descriptions for the location are the ones

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/TestWasHit.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/TestWasHit.py
@@ -70,8 +70,10 @@ class TestWasHit(TestBase):
         self.assertEqual(values.GetSize(), 1, "Got the change me global")
         change_me = values.GetValueAtIndex(0)
         change_me_value = 1
-        self.assertEqual(change_me.signed, change_me_value, "g_change_me had the right value")
-        
+        self.assertEqual(
+            change_me.signed, change_me_value, "g_change_me had the right value"
+        )
+
         for loc in [3, 4]:
             process.Continue()
             self.assertEqual(
@@ -84,7 +86,9 @@ class TestWasHit(TestBase):
                 thread.stop_reason_data[1], loc, f"Hit the right location: {loc}"
             )
             change_me_value += 1
-            self.assertEqual(change_me.signed, change_me_value, "g_change_me was updated correctly")
+            self.assertEqual(
+                change_me.signed, change_me_value, "g_change_me was updated correctly"
+            )
 
         # At this point we should have hit three of the four locations, and not location 1.2.
         # Check that that is true, and that the descriptions for the location are the ones

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/bkpt_resolver.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/bkpt_resolver.py
@@ -43,6 +43,18 @@ class FacadeExample:
         if tmp_loc == self.loc_to_miss:
             return None
 
+        # Make sure we can call a function here as well:
+        options = lldb.SBExpressionOptions()
+        options.SetStopOthers(True)
+        options.SetTryAllThreads(False)
+        
+        result = frame.EvaluateExpression("change_him()", options)
+        if not result.error.success:
+            print("****** I got an error running the expression")
+            return lldb.LLDB_INVALID_BREAK_ID
+
+        print(f"Expression Evaluation returned: {result.signed}")
+
         return self.facade_locs[tmp_loc]
 
     def get_location_description(self, bp_loc, desc_level):

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/bkpt_resolver.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/bkpt_resolver.py
@@ -47,7 +47,7 @@ class FacadeExample:
         options = lldb.SBExpressionOptions()
         options.SetStopOthers(True)
         options.SetTryAllThreads(False)
-        
+
         result = frame.EvaluateExpression("change_him()", options)
         if not result.error.success:
             print("****** I got an error running the expression")

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/bkpt_resolver.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/bkpt_resolver.py
@@ -50,10 +50,7 @@ class FacadeExample:
 
         result = frame.EvaluateExpression("change_him()", options)
         if not result.error.success:
-            print("****** I got an error running the expression")
             return lldb.LLDB_INVALID_BREAK_ID
-
-        print(f"Expression Evaluation returned: {result.signed}")
 
         return self.facade_locs[tmp_loc]
 

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/main.c
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/main.c
@@ -2,9 +2,7 @@
 
 int g_change_me = 0;
 
-int change_him() {
-  return ++g_change_me;
-}
+int change_him() { return ++g_change_me; }
 
 int stop_symbol() {
   static int s_cnt = 0;

--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/main.c
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/was_hit/main.c
@@ -1,5 +1,11 @@
 #include <stdio.h>
 
+int g_change_me = 0;
+
+int change_him() {
+  return ++g_change_me;
+}
+
 int stop_symbol() {
   static int s_cnt = 0;
   printf("I am in the stop symbol: %d\n", s_cnt++);
@@ -10,5 +16,6 @@ int main() {
   for (int i = 0; i < 100; i++) {
     stop_symbol();
   }
+  change_him();
   return 0;
 }


### PR DESCRIPTION
We have a problem when some code on the private state thread needs to run an expression.  The private state thread is the one that fetches "raw" events from the Process Plugin and decides how to handle them.  But if the private state thread needs to fetch the processed events to drive running an expression, it can't also be the thread processing the raw events.

We solve this by swapping in a modal private state thread just to handle the events from the expression evaluation.  That worked until you could cause the expression evaluation to happen from Python, because then it wasn't just the fetching of events that matter, but also the state of the process and the state of the runlocks.  The modal private state thread is really a modal version of the thread and its associated state.

This patch gathers all the relevant control parameters into a structure which we can swap in and out when needed.

It also adds a test using the new "was_hit" breakpoint resolver affordance, which, since it acts as an asynchronous breakpoint callback, gets run on the private state thread, showing that with the change we can call expressions in the `was_hit` callback without problems.