### PR TITLE
[RISCV] Correct lowering of ISD::SETGE/SETULE/SETLE/SETUGE in lowerVPSetCCMaskOp.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -13922,7 +13922,7 @@ SDValue RISCVTargetLowering::lowerVPSetCCMaskOp(SDValue Op,
   case ISD::SETULE: {
     SDValue Temp =
         DAG.getNode(RISCVISD::VMXOR_VL, DL, ContainerVT, Op1, AllOneMask, VL);
-    Result = DAG.getNode(RISCVISD::VMXOR_VL, DL, ContainerVT, Temp, Op2, VL);
+    Result = DAG.getNode(RISCVISD::VMOR_VL, DL, ContainerVT, Temp, Op2, VL);
     break;
   }
   // X <=s Y  --> X == 1 | Y == 0  -->  ~Y | X
@@ -13931,7 +13931,7 @@ SDValue RISCVTargetLowering::lowerVPSetCCMaskOp(SDValue Op,
   case ISD::SETUGE: {
     SDValue Temp =
         DAG.getNode(RISCVISD::VMXOR_VL, DL, ContainerVT, Op2, AllOneMask, VL);
-    Result = DAG.getNode(RISCVISD::VMXOR_VL, DL, ContainerVT, Temp, Op1, VL);
+    Result = DAG.getNode(RISCVISD::VMOR_VL, DL, ContainerVT, Temp, Op1, VL);
     break;
   }
   }

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-setcc-int-vp-mask.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-setcc-int-vp-mask.ll
@@ -248,7 +248,7 @@ define <2 x i1> @icmp_sle_vv_v2i1(<2 x i1> %va, <2 x i1> %vb, <2 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_sle_vv_v2i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <2 x i1> @llvm.vp.icmp.v2i1(<2 x i1> %va, <2 x i1> %vb, metadata !"sle", <2 x i1> %m, i32 %evl)
   ret <2 x i1> %v
@@ -258,7 +258,7 @@ define <4 x i1> @icmp_sle_vv_v4i1(<4 x i1> %va, <4 x i1> %vb, <4 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_sle_vv_v4i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <4 x i1> @llvm.vp.icmp.v4i1(<4 x i1> %va, <4 x i1> %vb, metadata !"sle", <4 x i1> %m, i32 %evl)
   ret <4 x i1> %v
@@ -268,7 +268,7 @@ define <8 x i1> @icmp_sle_vv_v8i1(<8 x i1> %va, <8 x i1> %vb, <8 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_sle_vv_v8i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <8 x i1> @llvm.vp.icmp.v8i1(<8 x i1> %va, <8 x i1> %vb, metadata !"sle", <8 x i1> %m, i32 %evl)
   ret <8 x i1> %v
@@ -278,7 +278,7 @@ define <16 x i1> @icmp_sle_vv_v16i1(<16 x i1> %va, <16 x i1> %vb, <16 x i1> %m, 
 ; CHECK-LABEL: icmp_sle_vv_v16i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <16 x i1> @llvm.vp.icmp.v16i1(<16 x i1> %va, <16 x i1> %vb, metadata !"sle", <16 x i1> %m, i32 %evl)
   ret <16 x i1> %v
@@ -288,7 +288,7 @@ define <2 x i1> @icmp_ule_vv_v2i1(<2 x i1> %va, <2 x i1> %vb, <2 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_ule_vv_v2i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <2 x i1> @llvm.vp.icmp.v2i1(<2 x i1> %va, <2 x i1> %vb, metadata !"ule", <2 x i1> %m, i32 %evl)
   ret <2 x i1> %v
@@ -298,7 +298,7 @@ define <4 x i1> @icmp_ule_vv_v4i1(<4 x i1> %va, <4 x i1> %vb, <4 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_ule_vv_v4i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <4 x i1> @llvm.vp.icmp.v4i1(<4 x i1> %va, <4 x i1> %vb, metadata !"ule", <4 x i1> %m, i32 %evl)
   ret <4 x i1> %v
@@ -308,7 +308,7 @@ define <8 x i1> @icmp_ule_vv_v8i1(<8 x i1> %va, <8 x i1> %vb, <8 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_ule_vv_v8i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <8 x i1> @llvm.vp.icmp.v8i1(<8 x i1> %va, <8 x i1> %vb, metadata !"ule", <8 x i1> %m, i32 %evl)
   ret <8 x i1> %v
@@ -318,7 +318,7 @@ define <16 x i1> @icmp_ule_vv_v16i1(<16 x i1> %va, <16 x i1> %vb, <16 x i1> %m, 
 ; CHECK-LABEL: icmp_ule_vv_v16i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <16 x i1> @llvm.vp.icmp.v16i1(<16 x i1> %va, <16 x i1> %vb, metadata !"ule", <16 x i1> %m, i32 %evl)
   ret <16 x i1> %v
@@ -328,7 +328,7 @@ define <2 x i1> @icmp_sge_vv_v2i1(<2 x i1> %va, <2 x i1> %vb, <2 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_sge_vv_v2i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <2 x i1> @llvm.vp.icmp.v2i1(<2 x i1> %va, <2 x i1> %vb, metadata !"sge", <2 x i1> %m, i32 %evl)
   ret <2 x i1> %v
@@ -338,7 +338,7 @@ define <4 x i1> @icmp_sge_vv_v4i1(<4 x i1> %va, <4 x i1> %vb, <4 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_sge_vv_v4i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <4 x i1> @llvm.vp.icmp.v4i1(<4 x i1> %va, <4 x i1> %vb, metadata !"sge", <4 x i1> %m, i32 %evl)
   ret <4 x i1> %v
@@ -348,7 +348,7 @@ define <8 x i1> @icmp_sge_vv_v8i1(<8 x i1> %va, <8 x i1> %vb, <8 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_sge_vv_v8i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <8 x i1> @llvm.vp.icmp.v8i1(<8 x i1> %va, <8 x i1> %vb, metadata !"sge", <8 x i1> %m, i32 %evl)
   ret <8 x i1> %v
@@ -358,7 +358,7 @@ define <16 x i1> @icmp_sge_vv_v16i1(<16 x i1> %va, <16 x i1> %vb, <16 x i1> %m, 
 ; CHECK-LABEL: icmp_sge_vv_v16i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <16 x i1> @llvm.vp.icmp.v16i1(<16 x i1> %va, <16 x i1> %vb, metadata !"sge", <16 x i1> %m, i32 %evl)
   ret <16 x i1> %v
@@ -368,7 +368,7 @@ define <2 x i1> @icmp_uge_vv_v2i1(<2 x i1> %va, <2 x i1> %vb, <2 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_uge_vv_v2i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <2 x i1> @llvm.vp.icmp.v2i1(<2 x i1> %va, <2 x i1> %vb, metadata !"uge", <2 x i1> %m, i32 %evl)
   ret <2 x i1> %v
@@ -378,7 +378,7 @@ define <4 x i1> @icmp_uge_vv_v4i1(<4 x i1> %va, <4 x i1> %vb, <4 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_uge_vv_v4i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <4 x i1> @llvm.vp.icmp.v4i1(<4 x i1> %va, <4 x i1> %vb, metadata !"uge", <4 x i1> %m, i32 %evl)
   ret <4 x i1> %v
@@ -388,7 +388,7 @@ define <8 x i1> @icmp_uge_vv_v8i1(<8 x i1> %va, <8 x i1> %vb, <8 x i1> %m, i32 z
 ; CHECK-LABEL: icmp_uge_vv_v8i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <8 x i1> @llvm.vp.icmp.v8i1(<8 x i1> %va, <8 x i1> %vb, metadata !"uge", <8 x i1> %m, i32 %evl)
   ret <8 x i1> %v
@@ -398,7 +398,7 @@ define <16 x i1> @icmp_uge_vv_v16i1(<16 x i1> %va, <16 x i1> %vb, <16 x i1> %m, 
 ; CHECK-LABEL: icmp_uge_vv_v16i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <16 x i1> @llvm.vp.icmp.v16i1(<16 x i1> %va, <16 x i1> %vb, metadata !"uge", <16 x i1> %m, i32 %evl)
   ret <16 x i1> %v

--- a/llvm/test/CodeGen/RISCV/rvv/setcc-int-vp-mask.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/setcc-int-vp-mask.ll
@@ -428,7 +428,7 @@ define <vscale x 1 x i1> @icmp_sle_vv_nxv1i1(<vscale x 1 x i1> %va, <vscale x 1 
 ; CHECK-LABEL: icmp_sle_vv_nxv1i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 1 x i1> @llvm.vp.icmp.nxv1i1(<vscale x 1 x i1> %va, <vscale x 1 x i1> %vb, metadata !"sle", <vscale x 1 x i1> %m, i32 %evl)
   ret <vscale x 1 x i1> %v
@@ -438,7 +438,7 @@ define <vscale x 2 x i1> @icmp_sle_vv_nxv2i1(<vscale x 2 x i1> %va, <vscale x 2 
 ; CHECK-LABEL: icmp_sle_vv_nxv2i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 2 x i1> @llvm.vp.icmp.nxv2i1(<vscale x 2 x i1> %va, <vscale x 2 x i1> %vb, metadata !"sle", <vscale x 2 x i1> %m, i32 %evl)
   ret <vscale x 2 x i1> %v
@@ -448,7 +448,7 @@ define <vscale x 4 x i1> @icmp_sle_vv_nxv4i1(<vscale x 4 x i1> %va, <vscale x 4 
 ; CHECK-LABEL: icmp_sle_vv_nxv4i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 4 x i1> @llvm.vp.icmp.nxv4i1(<vscale x 4 x i1> %va, <vscale x 4 x i1> %vb, metadata !"sle", <vscale x 4 x i1> %m, i32 %evl)
   ret <vscale x 4 x i1> %v
@@ -458,7 +458,7 @@ define <vscale x 8 x i1> @icmp_sle_vv_nxv8i1(<vscale x 8 x i1> %va, <vscale x 8 
 ; CHECK-LABEL: icmp_sle_vv_nxv8i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 8 x i1> @llvm.vp.icmp.nxv8i1(<vscale x 8 x i1> %va, <vscale x 8 x i1> %vb, metadata !"sle", <vscale x 8 x i1> %m, i32 %evl)
   ret <vscale x 8 x i1> %v
@@ -468,7 +468,7 @@ define <vscale x 16 x i1> @icmp_sle_vv_nxv16i1(<vscale x 16 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_sle_vv_nxv16i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 16 x i1> @llvm.vp.icmp.nxv16i1(<vscale x 16 x i1> %va, <vscale x 16 x i1> %vb, metadata !"sle", <vscale x 16 x i1> %m, i32 %evl)
   ret <vscale x 16 x i1> %v
@@ -478,7 +478,7 @@ define <vscale x 32 x i1> @icmp_sle_vv_nxv32i1(<vscale x 32 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_sle_vv_nxv32i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 32 x i1> @llvm.vp.icmp.nxv32i1(<vscale x 32 x i1> %va, <vscale x 32 x i1> %vb, metadata !"sle", <vscale x 32 x i1> %m, i32 %evl)
   ret <vscale x 32 x i1> %v
@@ -488,7 +488,7 @@ define <vscale x 64 x i1> @icmp_sle_vv_nxv64i1(<vscale x 64 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_sle_vv_nxv64i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 64 x i1> @llvm.vp.icmp.nxv64i1(<vscale x 64 x i1> %va, <vscale x 64 x i1> %vb, metadata !"sle", <vscale x 64 x i1> %m, i32 %evl)
   ret <vscale x 64 x i1> %v
@@ -498,7 +498,7 @@ define <vscale x 1 x i1> @icmp_ule_vv_nxv1i1(<vscale x 1 x i1> %va, <vscale x 1 
 ; CHECK-LABEL: icmp_ule_vv_nxv1i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 1 x i1> @llvm.vp.icmp.nxv1i1(<vscale x 1 x i1> %va, <vscale x 1 x i1> %vb, metadata !"ule", <vscale x 1 x i1> %m, i32 %evl)
   ret <vscale x 1 x i1> %v
@@ -508,7 +508,7 @@ define <vscale x 2 x i1> @icmp_ule_vv_nxv2i1(<vscale x 2 x i1> %va, <vscale x 2 
 ; CHECK-LABEL: icmp_ule_vv_nxv2i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 2 x i1> @llvm.vp.icmp.nxv2i1(<vscale x 2 x i1> %va, <vscale x 2 x i1> %vb, metadata !"ule", <vscale x 2 x i1> %m, i32 %evl)
   ret <vscale x 2 x i1> %v
@@ -518,7 +518,7 @@ define <vscale x 4 x i1> @icmp_ule_vv_nxv4i1(<vscale x 4 x i1> %va, <vscale x 4 
 ; CHECK-LABEL: icmp_ule_vv_nxv4i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 4 x i1> @llvm.vp.icmp.nxv4i1(<vscale x 4 x i1> %va, <vscale x 4 x i1> %vb, metadata !"ule", <vscale x 4 x i1> %m, i32 %evl)
   ret <vscale x 4 x i1> %v
@@ -528,7 +528,7 @@ define <vscale x 8 x i1> @icmp_ule_vv_nxv8i1(<vscale x 8 x i1> %va, <vscale x 8 
 ; CHECK-LABEL: icmp_ule_vv_nxv8i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 8 x i1> @llvm.vp.icmp.nxv8i1(<vscale x 8 x i1> %va, <vscale x 8 x i1> %vb, metadata !"ule", <vscale x 8 x i1> %m, i32 %evl)
   ret <vscale x 8 x i1> %v
@@ -538,7 +538,7 @@ define <vscale x 16 x i1> @icmp_ule_vv_nxv16i1(<vscale x 16 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_ule_vv_nxv16i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 16 x i1> @llvm.vp.icmp.nxv16i1(<vscale x 16 x i1> %va, <vscale x 16 x i1> %vb, metadata !"ule", <vscale x 16 x i1> %m, i32 %evl)
   ret <vscale x 16 x i1> %v
@@ -548,7 +548,7 @@ define <vscale x 32 x i1> @icmp_ule_vv_nxv32i1(<vscale x 32 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_ule_vv_nxv32i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 32 x i1> @llvm.vp.icmp.nxv32i1(<vscale x 32 x i1> %va, <vscale x 32 x i1> %vb, metadata !"ule", <vscale x 32 x i1> %m, i32 %evl)
   ret <vscale x 32 x i1> %v
@@ -558,7 +558,7 @@ define <vscale x 64 x i1> @icmp_ule_vv_nxv64i1(<vscale x 64 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_ule_vv_nxv64i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 64 x i1> @llvm.vp.icmp.nxv64i1(<vscale x 64 x i1> %va, <vscale x 64 x i1> %vb, metadata !"ule", <vscale x 64 x i1> %m, i32 %evl)
   ret <vscale x 64 x i1> %v
@@ -568,7 +568,7 @@ define <vscale x 1 x i1> @icmp_sge_vv_nxv1i1(<vscale x 1 x i1> %va, <vscale x 1 
 ; CHECK-LABEL: icmp_sge_vv_nxv1i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 1 x i1> @llvm.vp.icmp.nxv1i1(<vscale x 1 x i1> %va, <vscale x 1 x i1> %vb, metadata !"sge", <vscale x 1 x i1> %m, i32 %evl)
   ret <vscale x 1 x i1> %v
@@ -578,7 +578,7 @@ define <vscale x 2 x i1> @icmp_sge_vv_nxv2i1(<vscale x 2 x i1> %va, <vscale x 2 
 ; CHECK-LABEL: icmp_sge_vv_nxv2i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 2 x i1> @llvm.vp.icmp.nxv2i1(<vscale x 2 x i1> %va, <vscale x 2 x i1> %vb, metadata !"sge", <vscale x 2 x i1> %m, i32 %evl)
   ret <vscale x 2 x i1> %v
@@ -588,7 +588,7 @@ define <vscale x 4 x i1> @icmp_sge_vv_nxv4i1(<vscale x 4 x i1> %va, <vscale x 4 
 ; CHECK-LABEL: icmp_sge_vv_nxv4i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 4 x i1> @llvm.vp.icmp.nxv4i1(<vscale x 4 x i1> %va, <vscale x 4 x i1> %vb, metadata !"sge", <vscale x 4 x i1> %m, i32 %evl)
   ret <vscale x 4 x i1> %v
@@ -598,7 +598,7 @@ define <vscale x 8 x i1> @icmp_sge_vv_nxv8i1(<vscale x 8 x i1> %va, <vscale x 8 
 ; CHECK-LABEL: icmp_sge_vv_nxv8i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 8 x i1> @llvm.vp.icmp.nxv8i1(<vscale x 8 x i1> %va, <vscale x 8 x i1> %vb, metadata !"sge", <vscale x 8 x i1> %m, i32 %evl)
   ret <vscale x 8 x i1> %v
@@ -608,7 +608,7 @@ define <vscale x 16 x i1> @icmp_sge_vv_nxv16i1(<vscale x 16 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_sge_vv_nxv16i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 16 x i1> @llvm.vp.icmp.nxv16i1(<vscale x 16 x i1> %va, <vscale x 16 x i1> %vb, metadata !"sge", <vscale x 16 x i1> %m, i32 %evl)
   ret <vscale x 16 x i1> %v
@@ -618,7 +618,7 @@ define <vscale x 32 x i1> @icmp_sge_vv_nxv32i1(<vscale x 32 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_sge_vv_nxv32i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 32 x i1> @llvm.vp.icmp.nxv32i1(<vscale x 32 x i1> %va, <vscale x 32 x i1> %vb, metadata !"sge", <vscale x 32 x i1> %m, i32 %evl)
   ret <vscale x 32 x i1> %v
@@ -628,7 +628,7 @@ define <vscale x 64 x i1> @icmp_sge_vv_nxv64i1(<vscale x 64 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_sge_vv_nxv64i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v0, v8
+; CHECK-NEXT:    vmorn.mm v0, v8, v0
 ; CHECK-NEXT:    ret
   %v = call <vscale x 64 x i1> @llvm.vp.icmp.nxv64i1(<vscale x 64 x i1> %va, <vscale x 64 x i1> %vb, metadata !"sge", <vscale x 64 x i1> %m, i32 %evl)
   ret <vscale x 64 x i1> %v
@@ -638,7 +638,7 @@ define <vscale x 1 x i1> @icmp_uge_vv_nxv1i1(<vscale x 1 x i1> %va, <vscale x 1 
 ; CHECK-LABEL: icmp_uge_vv_nxv1i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 1 x i1> @llvm.vp.icmp.nxv1i1(<vscale x 1 x i1> %va, <vscale x 1 x i1> %vb, metadata !"uge", <vscale x 1 x i1> %m, i32 %evl)
   ret <vscale x 1 x i1> %v
@@ -648,7 +648,7 @@ define <vscale x 2 x i1> @icmp_uge_vv_nxv2i1(<vscale x 2 x i1> %va, <vscale x 2 
 ; CHECK-LABEL: icmp_uge_vv_nxv2i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 2 x i1> @llvm.vp.icmp.nxv2i1(<vscale x 2 x i1> %va, <vscale x 2 x i1> %vb, metadata !"uge", <vscale x 2 x i1> %m, i32 %evl)
   ret <vscale x 2 x i1> %v
@@ -658,7 +658,7 @@ define <vscale x 4 x i1> @icmp_uge_vv_nxv4i1(<vscale x 4 x i1> %va, <vscale x 4 
 ; CHECK-LABEL: icmp_uge_vv_nxv4i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, mf2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 4 x i1> @llvm.vp.icmp.nxv4i1(<vscale x 4 x i1> %va, <vscale x 4 x i1> %vb, metadata !"uge", <vscale x 4 x i1> %m, i32 %evl)
   ret <vscale x 4 x i1> %v
@@ -668,7 +668,7 @@ define <vscale x 8 x i1> @icmp_uge_vv_nxv8i1(<vscale x 8 x i1> %va, <vscale x 8 
 ; CHECK-LABEL: icmp_uge_vv_nxv8i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m1, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 8 x i1> @llvm.vp.icmp.nxv8i1(<vscale x 8 x i1> %va, <vscale x 8 x i1> %vb, metadata !"uge", <vscale x 8 x i1> %m, i32 %evl)
   ret <vscale x 8 x i1> %v
@@ -678,7 +678,7 @@ define <vscale x 16 x i1> @icmp_uge_vv_nxv16i1(<vscale x 16 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_uge_vv_nxv16i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m2, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 16 x i1> @llvm.vp.icmp.nxv16i1(<vscale x 16 x i1> %va, <vscale x 16 x i1> %vb, metadata !"uge", <vscale x 16 x i1> %m, i32 %evl)
   ret <vscale x 16 x i1> %v
@@ -688,7 +688,7 @@ define <vscale x 32 x i1> @icmp_uge_vv_nxv32i1(<vscale x 32 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_uge_vv_nxv32i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m4, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 32 x i1> @llvm.vp.icmp.nxv32i1(<vscale x 32 x i1> %va, <vscale x 32 x i1> %vb, metadata !"uge", <vscale x 32 x i1> %m, i32 %evl)
   ret <vscale x 32 x i1> %v
@@ -698,7 +698,7 @@ define <vscale x 64 x i1> @icmp_uge_vv_nxv64i1(<vscale x 64 x i1> %va, <vscale x
 ; CHECK-LABEL: icmp_uge_vv_nxv64i1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
-; CHECK-NEXT:    vmxnor.mm v0, v8, v0
+; CHECK-NEXT:    vmorn.mm v0, v0, v8
 ; CHECK-NEXT:    ret
   %v = call <vscale x 64 x i1> @llvm.vp.icmp.nxv64i1(<vscale x 64 x i1> %va, <vscale x 64 x i1> %vb, metadata !"uge", <vscale x 64 x i1> %m, i32 %evl)
   ret <vscale x 64 x i1> %v


### PR DESCRIPTION
XOR should be OR to match the comment.

Found while reviewing #179622 which deletes this function. I would like to commit this first so we have a correct baseline for reviewing that patch.