### PR TITLE
[libc] Remove "stdio.h" include from fx_bits.h

### DIFF
--- a/libc/src/__support/fixed_point/fx_bits.h
+++ b/libc/src/__support/fixed_point/fx_bits.h
@@ -23,8 +23,6 @@
 
 #include "fx_rep.h"
 
-#include <stdio.h>
-
 #ifdef LIBC_COMPILER_HAS_FIXED_POINT
 
 namespace LIBC_NAMESPACE_DECL {


### PR DESCRIPTION
The "stdio.h" is not used, so remove it from the file. This is causing a build failure as "stdio.h" is not specified in the build files.