### PR TITLE
[GISel][X86] Port CSE analysis to NPM

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
@@ -21,6 +21,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Target/TargetMachine.h"
 
 namespace llvm {
 class MachineBasicBlock;
@@ -225,13 +226,14 @@ public:
   void releaseMemory() { Info.releaseMemory(); }
 };
 
-class GISelCSEAnalysisWrapperAnalysis
-    : public AnalysisInfoMixin<GISelCSEAnalysisWrapperAnalysis> {
-  friend AnalysisInfoMixin<GISelCSEAnalysisWrapperAnalysis>;
+class GISelCSEAnalysis : public AnalysisInfoMixin<GISelCSEAnalysis> {
+  friend AnalysisInfoMixin<GISelCSEAnalysis>;
   LLVM_ABI static AnalysisKey Key;
+  TargetMachine *TM;
 
 public:
-  using Result = std::unique_ptr<GISelCSEAnalysisWrapper>;
+  using Result = std::unique_ptr<GISelCSEInfo>;
+  LLVM_ABI GISelCSEAnalysis(TargetMachine *TM) : TM(TM) {};
 
   LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &);
 };

--- a/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
@@ -18,6 +18,7 @@
 #include "llvm/CodeGen/GlobalISel/GISelWorkList.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Compiler.h"
@@ -223,6 +224,16 @@ public:
   void setMF(MachineFunction &MFunc) { MF = &MFunc; }
   void setComputed(bool Computed) { AlreadyComputed = Computed; }
   void releaseMemory() { Info.releaseMemory(); }
+};
+
+class GISelCSEAnalysisWrapperAnalysis : public AnalysisInfoMixin<GISelCSEAnalysisWrapperAnalysis> {
+  friend AnalysisInfoMixin<GISelCSEAnalysisWrapperAnalysis>;
+  LLVM_ABI static AnalysisKey Key;
+
+public:
+  using Result = std::unique_ptr<GISelCSEAnalysisWrapper>;
+
+  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &);
 };
 
 /// The actual analysis pass wrapper.

--- a/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
@@ -18,7 +18,6 @@
 #include "llvm/CodeGen/GlobalISel/GISelWorkList.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
-#include "llvm/IR/PassManager.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Compiler.h"
@@ -226,7 +225,8 @@ public:
   void releaseMemory() { Info.releaseMemory(); }
 };
 
-class GISelCSEAnalysisWrapperAnalysis : public AnalysisInfoMixin<GISelCSEAnalysisWrapperAnalysis> {
+class GISelCSEAnalysisWrapperAnalysis
+    : public AnalysisInfoMixin<GISelCSEAnalysisWrapperAnalysis> {
   friend AnalysisInfoMixin<GISelCSEAnalysisWrapperAnalysis>;
   LLVM_ABI static AnalysisKey Key;
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
@@ -235,7 +235,8 @@ public:
   using Result = std::unique_ptr<GISelCSEInfo>;
   LLVM_ABI GISelCSEAnalysis(TargetMachine *TM) : TM(TM) {};
 
-  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+  LLVM_ABI Result run(MachineFunction &MF,
+                      MachineFunctionAnalysisManager &MFAM);
 };
 
 /// The actual analysis pass wrapper.

--- a/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CSEInfo.h
@@ -235,7 +235,7 @@ public:
   using Result = std::unique_ptr<GISelCSEInfo>;
   LLVM_ABI GISelCSEAnalysis(TargetMachine *TM) : TM(TM) {};
 
-  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &);
+  LLVM_ABI Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
 };
 
 /// The actual analysis pass wrapper.

--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -63,7 +63,7 @@ LOOP_PASS("loop-term-fold", LoopTermFoldPass())
 // computed. (We still either need to regenerate kill flags after regalloc, or
 // preferably fix the scavenger to not depend on them).
 MACHINE_FUNCTION_ANALYSIS("edge-bundles", EdgeBundlesAnalysis())
-MACHINE_FUNCTION_ANALYSIS("gisel-cse-analysis", GISelCSEAnalysisWrapperAnalysis())
+MACHINE_FUNCTION_ANALYSIS("gisel-cse-analysis", GISelCSEAnalysis(TM))
 MACHINE_FUNCTION_ANALYSIS("gisel-value-tracking", GISelValueTrackingAnalysis())
 MACHINE_FUNCTION_ANALYSIS("livedebugvars", LiveDebugVariablesAnalysis())
 MACHINE_FUNCTION_ANALYSIS("live-intervals", LiveIntervalsAnalysis())

--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -63,6 +63,7 @@ LOOP_PASS("loop-term-fold", LoopTermFoldPass())
 // computed. (We still either need to regenerate kill flags after regalloc, or
 // preferably fix the scavenger to not depend on them).
 MACHINE_FUNCTION_ANALYSIS("edge-bundles", EdgeBundlesAnalysis())
+MACHINE_FUNCTION_ANALYSIS("gisel-cse-analysis", GISelCSEAnalysisWrapperAnalysis())
 MACHINE_FUNCTION_ANALYSIS("gisel-value-tracking", GISelValueTrackingAnalysis())
 MACHINE_FUNCTION_ANALYSIS("livedebugvars", LiveDebugVariablesAnalysis())
 MACHINE_FUNCTION_ANALYSIS("live-intervals", LiveIntervalsAnalysis())

--- a/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
@@ -445,6 +445,16 @@ GISelCSEAnalysisWrapper::get(std::unique_ptr<CSEConfigBase> CSEOpt,
   }
   return Info;
 }
+
+AnalysisKey GISelCSEAnalysisWrapperAnalysis::Key;
+
+GISelCSEAnalysisWrapperAnalysis::Result
+GISelCSEAnalysisWrapperAnalysis::run(MachineFunction &MF, MachineFunctionAnalysisManager &) {
+  auto Wrapper = std::make_unique<GISelCSEAnalysisWrapper>();
+  Wrapper->setMF(MF);
+  return Wrapper;
+}
+
 void GISelCSEAnalysisWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesAll();
   MachineFunctionPass::getAnalysisUsage(AU);

--- a/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
@@ -449,7 +449,8 @@ GISelCSEAnalysisWrapper::get(std::unique_ptr<CSEConfigBase> CSEOpt,
 AnalysisKey GISelCSEAnalysisWrapperAnalysis::Key;
 
 GISelCSEAnalysisWrapperAnalysis::Result
-GISelCSEAnalysisWrapperAnalysis::run(MachineFunction &MF, MachineFunctionAnalysisManager &) {
+GISelCSEAnalysisWrapperAnalysis::run(MachineFunction &MF,
+                                     MachineFunctionAnalysisManager &) {
   auto Wrapper = std::make_unique<GISelCSEAnalysisWrapper>();
   Wrapper->setMF(MF);
   return Wrapper;

--- a/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
@@ -446,14 +446,16 @@ GISelCSEAnalysisWrapper::get(std::unique_ptr<CSEConfigBase> CSEOpt,
   return Info;
 }
 
-AnalysisKey GISelCSEAnalysisWrapperAnalysis::Key;
+AnalysisKey GISelCSEAnalysis::Key;
 
-GISelCSEAnalysisWrapperAnalysis::Result
-GISelCSEAnalysisWrapperAnalysis::run(MachineFunction &MF,
-                                     MachineFunctionAnalysisManager &) {
-  auto Wrapper = std::make_unique<GISelCSEAnalysisWrapper>();
-  Wrapper->setMF(MF);
-  return Wrapper;
+GISelCSEAnalysis::Result
+GISelCSEAnalysis::run(MachineFunction &MF, MachineFunctionAnalysisManager &) {
+  auto Info = std::make_unique<GISelCSEInfo>();
+
+  Info->setCSEConfig(getStandardCSEConfigForOpt(TM->getOptLevel()));
+  Info->analyze(MF);
+
+  return Info;
 }
 
 void GISelCSEAnalysisWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {

--- a/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
@@ -12,6 +12,7 @@
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/Error.h"
+#include <memory>
 
 #define DEBUG_TYPE "cseinfo"
 
@@ -449,12 +450,11 @@ GISelCSEAnalysisWrapper::get(std::unique_ptr<CSEConfigBase> CSEOpt,
 AnalysisKey GISelCSEAnalysis::Key;
 
 GISelCSEAnalysis::Result
-GISelCSEAnalysis::run(MachineFunction &MF, MachineFunctionAnalysisManager &) {
-  auto Info = std::make_unique<GISelCSEInfo>();
-
+GISelCSEAnalysis::run(MachineFunction &MF,
+                      MachineFunctionAnalysisManager &MFAM) {
+  std::unique_ptr<GISelCSEInfo> Info = std::make_unique<GISelCSEInfo>();
   Info->setCSEConfig(getStandardCSEConfigForOpt(TM->getOptLevel()));
   Info->analyze(MF);
-
   return Info;
 }
 

--- a/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CSEInfo.cpp
@@ -12,7 +12,6 @@
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/Error.h"
-#include <memory>
 
 #define DEBUG_TYPE "cseinfo"
 

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -100,6 +100,7 @@
 #include "llvm/CodeGen/FixupStatepointCallerSaved.h"
 #include "llvm/CodeGen/GCEmptyBasicBlocks.h"
 #include "llvm/CodeGen/GCMetadata.h"
+#include "llvm/CodeGen/GlobalISel/CSEInfo.h"
 #include "llvm/CodeGen/GlobalISel/GISelValueTracking.h"
 #include "llvm/CodeGen/GlobalMerge.h"
 #include "llvm/CodeGen/GlobalMergeFunctions.h"


### PR DESCRIPTION
As part of #178192 it came up that the `GISelCSEAnalysisWrapperPass` doesn't seem to have a npm version. This patch adds an npm wrapper around `GISelCSEAnalysisWrapper`.