### PR TITLE
[CIR] Allow return from cleanup scope op

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -722,7 +722,7 @@ def CIR_StoreOp : CIR_Op<"store", [
 //===----------------------------------------------------------------------===//
 
 defvar CIR_ReturnableScopes = [
-  "FuncOp", "ScopeOp", "IfOp", "SwitchOp", "CaseOp",
+  "FuncOp", "ScopeOp", "IfOp", "SwitchOp", "CaseOp", "CleanupScopeOp",
   "DoWhileOp", "WhileOp", "ForOp", "TryOp"
 ];
 

--- a/clang/test/CIR/IR/cleanup-scope.cir
+++ b/clang/test/CIR/IR/cleanup-scope.cir
@@ -113,4 +113,24 @@ cir.func @cleanup_in_scope() {
 // CHECK:   cir.return
 // CHECK: }
 
+
+// Test basic cleanup.scope with all cleanup kind (normal + eh)
+cir.func @return_within_cleanup() {
+  cir.cleanup.scope {
+    cir.return
+  } cleanup all {
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK: cir.func @return_within_cleanup() {
+// CHECK:   cir.cleanup.scope {
+// CHECK:     cir.return
+// CHECK:   } cleanup all {
+// CHECK:     cir.yield
+// CHECK:   }
+// CHECK:   cir.return
+// CHECK: }
+
 }


### PR DESCRIPTION
When the cir.cleanup.scope operation was added, it was not added to the list of "returnable" operations. This fixes that oversight.