### PR TITLE
[CIR][NFC] Cleanup some stale missing features markers

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -371,15 +371,9 @@ struct MissingFeatures {
   static bool stringTypeWithDifferentArraySize() { return false; }
 
   // Future CIR operations
-  static bool awaitOp() { return false; }
   static bool callOp() { return false; }
-  static bool ifOp() { return false; }
-  static bool labelOp() { return false; }
-  static bool ptrDiffOp() { return false; }
   static bool llvmLoweringPtrDiffConsidersPointee() { return false; }
-  static bool ptrStrideOp() { return false; }
   static bool switchOp() { return false; }
-  static bool throwOp() { return false; }
   static bool tryOp() { return false; }
   static bool vecTernaryOp() { return false; }
   static bool zextOp() { return false; }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -302,7 +302,6 @@ void cir::AllocaOp::build(mlir::OpBuilder &odsBuilder,
 //===----------------------------------------------------------------------===//
 
 LogicalResult cir::BreakOp::verify() {
-  assert(!cir::MissingFeatures::switchOp());
   if (!getOperation()->getParentOfType<LoopOpInterface>() &&
       !getOperation()->getParentOfType<SwitchOp>())
     return emitOpError("must be within a loop");

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -662,9 +662,6 @@ void CIRFlattenCFGPass::runOnOperation() {
   // Collect operations to apply patterns.
   llvm::SmallVector<Operation *, 16> ops;
   getOperation()->walk<mlir::WalkOrder::PostOrder>([&](Operation *op) {
-    assert(!cir::MissingFeatures::ifOp());
-    assert(!cir::MissingFeatures::switchOp());
-    assert(!cir::MissingFeatures::tryOp());
     if (isa<IfOp, ScopeOp, SwitchOp, LoopOpInterface, TernaryOp, TryOp>(op))
       ops.push_back(op);
   });


### PR DESCRIPTION
This deletes a few missing features markers where the missing code had actually been implemented and deletes a handful that were not being used anywhere.