### PR TITLE
Reapply: [lit] Avoid multiprocessing for -j1 runs

### DIFF
--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -436,8 +436,11 @@ def killProcessAndChildren(pid):
             for child in children_iterator:
                 try:
                     child.kill()
-                except psutil.NoSuchProcess:
+                except psutil.Error:
+                    # Ignore errors killing children (NoSuchProcess, AccessDenied, etc.)
                     pass
             psutilProc.kill()
-        except psutil.NoSuchProcess:
+        except psutil.Error:
+            # Ignore errors killing process (NoSuchProcess, AccessDenied, etc.)
+            # The process may have already exited or we may not have permission.
             pass

--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -128,6 +128,26 @@ if not llvm_config:
     if platform.system() == "AIX":
         config.available_features.add("system-aix")
 
+# Check for strace availability (Linux only)
+# We need to actually try running strace, not just check if it exists,
+# because ptrace_scope and other security settings may prevent its use.
+if platform.system() == "Linux":
+    try:
+        result = subprocess.run(
+            ["strace", "-o", "/dev/null", "true"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode == 0:
+            config.available_features.add("strace")
+    except FileNotFoundError:
+        pass
+
+# Capture the system PATH _BEFORE_ we prepend fake-externals to PATH.
+# This allows tests that need external commands (e.g., strace) to bypass the
+# fake binaries by using: env PATH="%{system-path}" <command>
+config.substitutions.append(("%{system-path}", config.environment.get("PATH", "")))
+
 # For each of lit's internal shell commands ('env', 'cd', 'diff', etc.), put
 # a fake command that always fails at the start of PATH.  This helps us check
 # that we always use lit's internal version rather than some external version

--- a/llvm/utils/lit/tests/single-process.py
+++ b/llvm/utils/lit/tests/single-process.py
@@ -1,0 +1,35 @@
+# Test that -j1 runs in single-process mode (no multiprocessing).
+#
+# This ensures lit can run in sandboxed environments where multiprocessing
+# primitives (semaphores, process creation) are blocked.
+
+# REQUIRES: strace
+
+# Use strace to trace file operations. With -j1, lit should NOT create
+# POSIX semaphores in /dev/shm which are used by multiprocessing.Pool.
+#
+# Python's multiprocessing.BoundedSemaphore creates files like:
+#   openat(AT_FDCWD, "/dev/shm/sem.XXXXXX", O_RDWR|O_CREAT|O_EXCL|...)
+#
+# These are the semaphores that fail in sandboxed environments, so verifying
+# they don't appear with -j1 confirms the fix works.
+
+# RUN: export PATH="%{system-path}"
+#
+# RUN: strace -f -e trace=openat not %{lit} -j1 %{inputs}/shtest-format 2>&1 \
+# RUN:   | FileCheck --check-prefix=CHECK-J1 %s
+#
+# CHECK-J1: 1 workers
+# CHECK-J1-NOT: /dev/shm/sem
+# CHECK-J1: Total Discovered Tests:
+
+# With -j2 and multiple tests, lit MUST use multiprocessing.Pool which creates
+# POSIX semaphores. This validates that the CHECK-NOT pattern above is correct
+# and won't become stale if Python/glibc changes how semaphores are created.
+#
+# RUN: strace -f -e trace=openat not %{lit} -j2 %{inputs}/shtest-format 2>&1 \
+# RUN:   | FileCheck --check-prefix=CHECK-J2 %s
+#
+# CHECK-J2: /dev/shm/sem
+# CHECK-J2: 2 workers
+# CHECK-J2: Total Discovered Tests:


### PR DESCRIPTION
### Problem

When running `lit` with `-j1` in a sandboxed environment (e.g., [Cursor Sandbox Mode](https://cursor.com/blog/enterprise#sandbox-mode)), `lit` crashes with `PermissionError: [Errno 1] Operation not permitted` because it still attempts to create a `multiprocessing.Pool`, which requires POSIX semaphores (`/dev/shm/sem.*`) that are blocked by the sandbox.

**Reproducer:** Run any lit test suite with `-j1` in a [restricted sandbox](https://cursor.com/blog/enterprise#sandbox-mode):
`LIT_OPTS="-j1 -v" ninja check-lld`

**Error trace:** https://gist.github.com/alx32/0dc6abb45c40cf5753669e4c6cce929d

### Solution

When `workers == 1`, skip `multiprocessing.Pool` entirely and run tests sequentially in the main process. This avoids creating POSIX semaphores that fail in sandboxed environments.

To properly support `--max-time` in single-process mode (where we can't terminate workers mid-test), we temporarily set `maxIndividualTestTime` to the remaining time before the deadline. If a test times out due to hitting the deadline, it's marked as SKIPPED to match multiprocessing behavior.

### Testing

Added `single-process.py` test that uses strace to verify:
- With `-j1`: No `/dev/shm/sem.*` POSIX semaphores are created
- With `-j2`: Semaphores ARE created (validates the test won't XPASS)

### Historical Context

Lit previously had a "single process mode" that was:
- **Added** in Sept 2017 (42b6dcbcef4f) for debugging
- **Enhanced** in Feb 2019 (96adb78b120b) to auto-enable for `-j1`
- **Removed** in Oct 2019 (f3c329986cf4) as it "did not carry its weight"

The original motivation was performance/debugging. The new motivation is **compatibility with sandboxed execution environments** where multiprocessing primitives are unavailable.

[Assisted-by](https://t.ly/Dkjjk): Cursor IDE + claude-opus-4.5-high + gpt-5.2-xhigh

----------------------------------------
**NOTE**: This is a re-apply of https://github.com/llvm/llvm-project/pull/175587 after revert https://github.com/llvm/llvm-project/commit/3fcba45de123f2c3a09faf50b51f507437fe6b21 . 

The previous commit broke `max-time.py` on the `intel-sycl-gpu` (and other) buildbots. The issue was a race condition in the timeout handling code: when `--max-time` triggered, the timer thread called `_kill()` to terminate the running process, but psutil sometimes threw exceptions (e.g., `AccessDenied`, process already exited) that weren't being caught. This crashed the timer thread and dumped a traceback to stderr, which caused the FileCheck expecting "reached timeout, skipping remaining tests" to fail.

Fixed by:
1. Catching the broader `psutil.Error` base class in `killProcessAndChildren()` instead of just `NoSuchProcess`
2. Wrapping `_kill()` in `_handleTimeoutReached()` with a try/except so the timer thread doesn't crash—the timeout flag is already set, so the test still gets marked as timed out even if we couldn't kill the process