### PR TITLE
[CIR] Add ASTVarDeclInterface for AST attribute access

### DIFF
--- a/clang/include/clang/CIR/Interfaces/ASTAttrInterfaces.h
+++ b/clang/include/clang/CIR/Interfaces/ASTAttrInterfaces.h
@@ -1,0 +1,22 @@
+//===- ASTAttrInterfaces.h - CIR AST Interfaces -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_CIR_INTERFACES_ASTATTRINTERFACES_H
+#define CLANG_CIR_INTERFACES_ASTATTRINTERFACES_H
+
+#include "mlir/IR/Attributes.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "clang/AST/Attr.h"
+#include "clang/AST/DeclTemplate.h"
+#include "clang/AST/Mangle.h"
+
+/// Include the generated interface declarations.
+#include "clang/CIR/Interfaces/ASTAttrInterfaces.h.inc"
+
+#endif // CLANG_CIR_INTERFACES_ASTATTRINTERFACES_H

--- a/clang/include/clang/CIR/Interfaces/ASTAttrInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/ASTAttrInterfaces.td
@@ -1,0 +1,51 @@
+//===- ASTAttrInterfaces.td - CIR AST Interface Definitions -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_CIR_INTERFACES_ASTATTRINTERFACES_TD
+#define MLIR_CIR_INTERFACES_ASTATTRINTERFACES_TD
+
+include "mlir/IR/OpBase.td"
+
+let cppNamespace = "::cir" in {
+  def ASTVarDeclInterface : AttrInterface<"ASTVarDeclInterface"> {
+    let methods = [
+      InterfaceMethod<"", "void", "mangleStaticGuardVariable",
+                      (ins "llvm::raw_ostream&":$out), [{}],
+                      /*defaultImplementation=*/[{
+        std::unique_ptr<clang::MangleContext> mangleCtx(
+          $_attr.getAst()->getASTContext().createMangleContext());
+        mangleCtx->mangleStaticGuardVariable($_attr.getAst(), out);
+      }]>,
+      InterfaceMethod<"", "bool", "isLocalVarDecl", (ins), [{}],
+                      /*defaultImplementation=*/[{
+        return $_attr.getAst()->isLocalVarDecl();
+      }]>,
+      InterfaceMethod<"", "clang::VarDecl::TLSKind", "getTLSKind",
+                      (ins), [{}],
+                      /*defaultImplementation=*/[{
+        return $_attr.getAst()->getTLSKind();
+      }]>,
+      InterfaceMethod<"", "bool", "isInline", (ins), [{}],
+                      /*defaultImplementation=*/[{
+        return $_attr.getAst()->isInline();
+      }]>,
+      InterfaceMethod<"", "clang::TemplateSpecializationKind",
+                      "getTemplateSpecializationKind", (ins), [{}],
+                      /*defaultImplementation=*/[{
+        return $_attr.getAst()->getTemplateSpecializationKind();
+      }]>,
+      InterfaceMethod<"Get the underlying VarDecl pointer.",
+                      "const clang::VarDecl *", "getVarDecl", (ins), [{}],
+                      /*defaultImplementation=*/[{
+        return $_attr.getAst();
+      }]>
+    ];
+  }
+} // namespace cir
+
+#endif // MLIR_CIR_INTERFACES_ASTATTRINTERFACES_TD

--- a/clang/include/clang/CIR/Interfaces/CMakeLists.txt
+++ b/clang/include/clang/CIR/Interfaces/CMakeLists.txt
@@ -3,6 +3,14 @@
 # directory which is not the case for CIR (and also FIR, both have similar
 # workarounds).
 
+function(add_clang_mlir_attr_interface interface)
+  set(LLVM_TARGET_DEFINITIONS ${interface}.td)
+  mlir_tablegen(${interface}.h.inc -gen-attr-interface-decls)
+  mlir_tablegen(${interface}.cpp.inc -gen-attr-interface-defs)
+  add_public_tablegen_target(MLIRCIR${interface}IncGen)
+  add_dependencies(mlir-generic-headers MLIRCIR${interface}IncGen)
+endfunction()
+
 function(add_clang_mlir_op_interface interface)
   set(LLVM_TARGET_DEFINITIONS ${interface}.td)
   mlir_tablegen(${interface}.h.inc -gen-op-interface-decls)
@@ -19,6 +27,7 @@ function(add_clang_mlir_type_interface interface)
   add_dependencies(mlir-generic-headers MLIR${interface}IncGen)
 endfunction()
 
+add_clang_mlir_attr_interface(ASTAttrInterfaces)
 add_clang_mlir_op_interface(CIROpInterfaces)
 add_clang_mlir_op_interface(CIRLoopOpInterface)
 add_clang_mlir_type_interface(CIRTypeInterfaces)

--- a/clang/lib/CIR/Interfaces/ASTAttrInterfaces.cpp
+++ b/clang/lib/CIR/Interfaces/ASTAttrInterfaces.cpp
@@ -1,0 +1,21 @@
+//====- ASTAttrInterfaces.cpp - Interface to AST Attributes ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the interface to AST variable declaration attributes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/CIR/Interfaces/ASTAttrInterfaces.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/Mangle.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
+
+using namespace cir;
+
+/// Include the generated attribute interfaces.
+#include "clang/CIR/Interfaces/ASTAttrInterfaces.cpp.inc"

--- a/clang/lib/CIR/Interfaces/CMakeLists.txt
+++ b/clang/lib/CIR/Interfaces/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_clang_library(MLIRCIRInterfaces
+  ASTAttrInterfaces.cpp
   CIROpInterfaces.cpp
   CIRLoopOpInterface.cpp
   CIRTypeInterfaces.cpp
@@ -7,6 +8,7 @@ add_clang_library(MLIRCIRInterfaces
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Interfaces
 
   DEPENDS
+  MLIRCIRASTAttrInterfacesIncGen
   MLIRCIREnumsGen
   MLIRCIRTypeInterfacesIncGen
   MLIRCIRLoopOpInterfaceIncGen


### PR DESCRIPTION
Add the ASTVarDeclInterface which provides methods to access clang AST
VarDecl information from CIR attributes. This interface enables:
- mangleStaticGuardVariable: Mangle guard variable names using clang's
  MangleContext
- isLocalVarDecl: Check if a variable is function-local
- getTLSKind: Get thread-local storage kind
- isInline: Check if the variable is inline
- getTemplateSpecializationKind: Get template specialization info
- getVarDecl: Direct access to the underlying VarDecl pointer

This infrastructure is needed for proper handling of static local
variables with guard variables in LoweringPrepare.