### PR TITLE
[mlir][SPIRV] Add sub-element-byte lowering support for atomic_rmw ori/andi ops

### DIFF
--- a/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
+++ b/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
@@ -512,6 +512,8 @@ AtomicRMWOpPattern::matchAndRewrite(memref::AtomicRMWOp atomicOp,
   if (!accessChainOp)
     return failure();
 
+  // Compute the bit offset within the storage element and adjust the pointer
+  // to address the containing storage element.
   assert(accessChainOp.getIndices().size() == 2);
   Value lastDim = accessChainOp->getOperand(accessChainOp.getNumOperands() - 1);
   Value offset = getOffsetForBitwidth(loc, lastDim, srcBits, dstBits, rewriter);

--- a/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
+++ b/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
@@ -518,23 +518,25 @@ AtomicRMWOpPattern::matchAndRewrite(memref::AtomicRMWOp atomicOp,
   Value adjustedPtr = adjustAccessChainForBitwidth(typeConverter, accessChainOp,
                                                    srcBits, dstBits, rewriter);
   Value result;
-  if (atomicOp.getKind() == arith::AtomicRMWKind::ori) {
+  switch (atomicOp.getKind()) {
+  case arith::AtomicRMWKind::ori: {
     // OR only sets bits, so shifting the value to the target position and
     // ORing with zeros in other positions preserves the unaffected bits.
     Value elemMask = rewriter.createOrFold<spirv::ConstantOp>(
-        loc, dstType, rewriter.getIntegerAttr(dstType, (1 << srcBits) - 1));
+        loc, dstType, rewriter.getIntegerAttr(dstType, (1uLL << srcBits) - 1));
     Value storeVal =
         shiftValue(loc, adaptor.getValue(), offset, elemMask, rewriter);
     result = spirv::AtomicOrOp::create(
         rewriter, loc, dstType, adjustedPtr, *scope,
         spirv::MemorySemantics::AcquireRelease, storeVal);
-  } else {
-    assert(atomicOp.getKind() == arith::AtomicRMWKind::andi);
-    // AND: build a mask that preserves all bits outside the target element
+    break;
+  }
+  case arith::AtomicRMWKind::andi: {
+    // Build a mask that preserves all bits outside the target element
     // and applies the operand mask to the target element.
     //   mask = (operand << offset) | ~(elemMask << offset)
     Value elemMask = rewriter.createOrFold<spirv::ConstantOp>(
-        loc, dstType, rewriter.getIntegerAttr(dstType, (1 << srcBits) - 1));
+        loc, dstType, rewriter.getIntegerAttr(dstType, (1uLL << srcBits) - 1));
     Value storeVal =
         shiftValue(loc, adaptor.getValue(), offset, elemMask, rewriter);
     Value shiftedElemMask = rewriter.createOrFold<spirv::ShiftLeftLogicalOp>(
@@ -546,6 +548,10 @@ AtomicRMWOpPattern::matchAndRewrite(memref::AtomicRMWOp atomicOp,
     result = spirv::AtomicAndOp::create(
         rewriter, loc, dstType, adjustedPtr, *scope,
         spirv::MemorySemantics::AcquireRelease, mask);
+    break;
+  }
+  default:
+    return rewriter.notifyMatchFailure(atomicOp, "unimplemented atomic kind");
   }
 
   // The atomic op returns the old value of the full storage element (e.g.,
@@ -553,7 +559,7 @@ AtomicRMWOpPattern::matchAndRewrite(memref::AtomicRMWOp atomicOp,
   result = rewriter.createOrFold<spirv::ShiftRightLogicalOp>(loc, dstType,
                                                              result, offset);
   Value mask = rewriter.createOrFold<spirv::ConstantOp>(
-      loc, dstType, rewriter.getIntegerAttr(dstType, (1 << srcBits) - 1));
+      loc, dstType, rewriter.getIntegerAttr(dstType, (1uLL << srcBits) - 1));
   result =
       rewriter.createOrFold<spirv::BitwiseAndOp>(loc, dstType, result, mask);
   rewriter.replaceOp(atomicOp, result);

--- a/mlir/test/Conversion/MemRefToSPIRV/atomic.mlir
+++ b/mlir/test/Conversion/MemRefToSPIRV/atomic.mlir
@@ -74,3 +74,75 @@ func.func @atomic_andi_storage_buffer(%value: i32, %memref: memref<2x3x4xi32, #s
 
 }
 
+// -----
+
+// Check sub-element-width atomic ori on i8 memref (stored as i32 in SPIR-V).
+// The byte index must be divided by 4 to get the i32 index, and the value
+// must be shifted to the correct byte position within the i32.
+
+module attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Shader], []>, #spirv.resource_limits<>>} {
+
+// CHECK-LABEL: func.func @atomic_ori_i8_storage_buffer
+func.func @atomic_ori_i8_storage_buffer(%value: i8, %memref: memref<16xi8, #spirv.storage_class<StorageBuffer>>, %i0: index) -> i8 {
+  //      CHECK:     %[[IDX:.+]] = builtin.unrealized_conversion_cast %{{.*}} : index to i32
+  //      CHECK:     %[[MEM:.+]] = builtin.unrealized_conversion_cast %{{.*}} : memref{{.*}} to !spirv.ptr
+  //      CHECK:     %[[VAL:.+]] = builtin.unrealized_conversion_cast %{{.*}} : i8 to i32
+  // Compute bit offset: (idx % 4) * 8
+  //  CHECK-DAG:     %[[C4:.+]] = spirv.Constant 4 : i32
+  //  CHECK-DAG:     %[[C8:.+]] = spirv.Constant 8 : i32
+  //      CHECK:     %[[MOD:.+]] = spirv.UMod %[[IDX]], %[[C4]]
+  //      CHECK:     %[[OFFSET:.+]] = spirv.IMul %[[MOD]], %[[C8]]
+  // Adjust the access chain index: idx / 4
+  //      CHECK:     %[[DIV:.+]] = spirv.SDiv %[[IDX]], %{{.*}}
+  //      CHECK:     %[[AC:.+]] = spirv.AccessChain %[[MEM]][%{{.*}}, %[[DIV]]]
+  // Mask and shift the value
+  //      CHECK:     %[[C255:.+]] = spirv.Constant 255 : i32
+  //      CHECK:     %[[MASKED:.+]] = spirv.BitwiseAnd %[[VAL]], %[[C255]]
+  //      CHECK:     %[[SHIFTED:.+]] = spirv.ShiftLeftLogical %[[MASKED]], %[[OFFSET]]
+  // Atomic OR
+  //      CHECK:     %[[ATOMIC:.+]] = spirv.AtomicOr <Device> <AcquireRelease> %[[AC]], %[[SHIFTED]]
+  // Extract old value from result
+  //      CHECK:     spirv.ShiftRightLogical %[[ATOMIC]], %[[OFFSET]]
+  //      CHECK:     spirv.BitwiseAnd
+  //      CHECK:     return
+  %0 = memref.atomic_rmw "ori" %value, %memref[%i0] : (i8, memref<16xi8, #spirv.storage_class<StorageBuffer>>) -> i8
+  return %0: i8
+}
+
+}
+
+// -----
+
+// Check sub-element-width atomic andi on i8 memref.
+
+module attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Shader], []>, #spirv.resource_limits<>>} {
+
+// CHECK-LABEL: func.func @atomic_andi_i8_storage_buffer
+func.func @atomic_andi_i8_storage_buffer(%value: i8, %memref: memref<16xi8, #spirv.storage_class<StorageBuffer>>, %i0: index) -> i8 {
+  //      CHECK:     %[[IDX:.+]] = builtin.unrealized_conversion_cast %{{.*}} : index to i32
+  //      CHECK:     %[[MEM:.+]] = builtin.unrealized_conversion_cast %{{.*}} : memref{{.*}} to !spirv.ptr
+  //      CHECK:     %[[VAL:.+]] = builtin.unrealized_conversion_cast %{{.*}} : i8 to i32
+  //  CHECK-DAG:     %[[C4:.+]] = spirv.Constant 4 : i32
+  //  CHECK-DAG:     %[[C8:.+]] = spirv.Constant 8 : i32
+  //      CHECK:     %[[MOD:.+]] = spirv.UMod %[[IDX]], %[[C4]]
+  //      CHECK:     %[[OFFSET:.+]] = spirv.IMul %[[MOD]], %[[C8]]
+  //      CHECK:     %[[DIV:.+]] = spirv.SDiv %[[IDX]], %{{.*}}
+  //      CHECK:     %[[AC:.+]] = spirv.AccessChain %[[MEM]][%{{.*}}, %[[DIV]]]
+  // Build the AND mask: (val << offset) | ~(0xFF << offset)
+  //      CHECK:     %[[C255:.+]] = spirv.Constant 255 : i32
+  //      CHECK:     %[[MASKED:.+]] = spirv.BitwiseAnd %[[VAL]], %[[C255]]
+  //      CHECK:     %[[SHIFTED:.+]] = spirv.ShiftLeftLogical %[[MASKED]], %[[OFFSET]]
+  //      CHECK:     %[[ELEM_SHIFTED:.+]] = spirv.ShiftLeftLogical %[[C255]], %[[OFFSET]]
+  //      CHECK:     %[[NOT_ELEM:.+]] = spirv.Not %[[ELEM_SHIFTED]]
+  //      CHECK:     %[[MASK:.+]] = spirv.BitwiseOr %[[SHIFTED]], %[[NOT_ELEM]]
+  // Atomic AND
+  //      CHECK:     %[[ATOMIC:.+]] = spirv.AtomicAnd <Device> <AcquireRelease> %[[AC]], %[[MASK]]
+  // Extract old value
+  //      CHECK:     spirv.ShiftRightLogical %[[ATOMIC]], %[[OFFSET]]
+  //      CHECK:     spirv.BitwiseAnd
+  //      CHECK:     return
+  %0 = memref.atomic_rmw "andi" %value, %memref[%i0] : (i8, memref<16xi8, #spirv.storage_class<StorageBuffer>>) -> i8
+  return %0: i8
+}
+
+}


### PR DESCRIPTION
When the memref element type (e.g., i8) is narrower than the SPIR-V storage type (e.g., i32 on Vulkan), ori and andi can be lowered with a single wide atomic instruction because OR-with-0 and AND-with-1 are identity operations.

The revision follows `IntStoreOpPattern` to compute offsets/sizes via `adjustAccessChainForBitwidth` method and `getOffsetForBitwidth` method. Additionally, it handles the returned value (which is the old value by definition), which is different from `IntStoreOpPattern`. E.g., the check of `spirv::Capability::Kernel` is the same.

https://github.com/llvm/llvm-project/blob/07ebb18e07fb9e009b1f738d6214a49c7bbe8fee/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp#L847-L867

There are refactoring opportunities and it is not performed within the revision because the current implementation is already complicated. The refactoring can be happenned in a follow-up with its own patch, so reviewing this revision is easier.

Signed-off-by: hanhanW <hanhan0912@gmail.com>