### PR TITLE
[lldb] Implement bytecode based SyntheticChildren

### DIFF
--- a/lldb/docs/resources/formatterbytecode.rst
+++ b/lldb/docs/resources/formatterbytecode.rst
@@ -221,6 +221,7 @@ Signature    Mnemonic                Stack Effect
   0x03      ``@get_child_index``      ``(Object+ String -> UInt)``
   0x04      ``@get_child_at_index``   ``(Object+ UInt -> Object)``
   0x05      ``@get_value``            ``(Object+ -> String)``
+  0x06      ``@update``               ``(Object+ -> String)``
 =========  ========================= ==============================
 
 If not specified, the init function defaults to an empty function that just passes the Object along. Its results may be cached and allow common prep work to be done for an Object that can be reused by subsequent calls to the other methods. This way subsequent calls to ``@get_child_at_index`` can avoid recomputing shared information, for example.

--- a/lldb/docs/resources/formatterbytecode.rst
+++ b/lldb/docs/resources/formatterbytecode.rst
@@ -221,7 +221,7 @@ Signature    Mnemonic                Stack Effect
   0x03      ``@get_child_index``      ``(Object+ String -> UInt)``
   0x04      ``@get_child_at_index``   ``(Object+ UInt -> Object)``
   0x05      ``@get_value``            ``(Object+ -> String)``
-  0x06      ``@update``               ``(Object+ -> String)``
+  0x06      ``@update``               ``(Object+ -> Object+)``
 =========  ========================= ==============================
 
 If not specified, the init function defaults to an empty function that just passes the Object along. Its results may be cached and allow common prep work to be done for an Object that can be reused by subsequent calls to the other methods. This way subsequent calls to ``@get_child_at_index`` can avoid recomputing shared information, for example.

--- a/lldb/include/lldb/DataFormatters/FormatterBytecode.def
+++ b/lldb/include/lldb/DataFormatters/FormatterBytecode.def
@@ -97,6 +97,9 @@ DEFINE_SIGNATURE(3, get_child_index)
 DEFINE_SIGNATURE(4, get_child_at_index)
 DEFINE_SIGNATURE(5, get_value)
 DEFINE_SIGNATURE(6, update)
+#ifndef kSignatureCount
+#define kSignatureCount 7
+#endif
 
 #undef DEFINE_OPCODE
 #undef DEFINE_SELECTOR

--- a/lldb/include/lldb/DataFormatters/FormatterBytecode.def
+++ b/lldb/include/lldb/DataFormatters/FormatterBytecode.def
@@ -96,6 +96,7 @@ DEFINE_SIGNATURE(2, get_num_children)
 DEFINE_SIGNATURE(3, get_child_index)
 DEFINE_SIGNATURE(4, get_child_at_index)
 DEFINE_SIGNATURE(5, get_value)
+DEFINE_SIGNATURE(6, update)
 
 #undef DEFINE_OPCODE
 #undef DEFINE_SELECTOR

--- a/lldb/include/lldb/DataFormatters/FormatterBytecode.h
+++ b/lldb/include/lldb/DataFormatters/FormatterBytecode.h
@@ -11,8 +11,6 @@
 
 #include "lldb/DataFormatters/TypeSummary.h"
 #include "lldb/Symbol/CompilerType.h"
-#include "llvm/Support/MemoryBuffer.h"
-#include <memory>
 
 namespace lldb_private {
 
@@ -57,39 +55,6 @@ struct DataStack : public std::vector<DataStackElement> {
     DataStackElement el = back();
     pop_back();
     return el;
-  }
-};
-
-using BytecodeBytes = std::unique_ptr<llvm::MemoryBuffer>;
-
-struct SyntheticProviderDefinition {
-  BytecodeBytes init;
-  BytecodeBytes update;
-  BytecodeBytes num_children;
-  BytecodeBytes get_child_at_index;
-  BytecodeBytes get_child_index;
-
-  bool SetBytecode(Signatures sig, BytecodeBytes bytecode) {
-    switch (sig) {
-    case Signatures::sig_init:
-      init = std::move(bytecode);
-      break;
-    case Signatures::sig_update:
-      update = std::move(bytecode);
-      break;
-    case Signatures::sig_get_num_children:
-      num_children = std::move(bytecode);
-      break;
-    case Signatures::sig_get_child_at_index:
-      get_child_at_index = std::move(bytecode);
-      break;
-    case Signatures::sig_get_child_index:
-      get_child_index = std::move(bytecode);
-      break;
-    default:
-      return false;
-    }
-    return true;
   }
 };
 

--- a/lldb/include/lldb/DataFormatters/TypeSummary.h
+++ b/lldb/include/lldb/DataFormatters/TypeSummary.h
@@ -424,6 +424,11 @@ private:
 };
 
 /// A summary formatter that is defined in LLDB formmater bytecode.
+///
+/// See `BytecodeSyntheticChildren` for the corresponding synthetic formatter.
+///
+/// Formatter bytecode documentation can be found in
+/// lldb/docs/resources/formatterbytecode.rst
 class BytecodeSummaryFormat : public TypeSummaryImpl {
   std::unique_ptr<llvm::MemoryBuffer> m_bytecode;
 

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -476,6 +476,12 @@ private:
   operator=(const ScriptedSyntheticChildren &) = delete;
 };
 
+/// A synthetic formatter that is defined in LLDB formmater bytecode.
+///
+/// See `BytecodeSummaryFormat` for the corresponding summary formatter.
+///
+/// Formatter bytecode documentation can be found in
+/// lldb/docs/resources/formatterbytecode.rst
 class BytecodeSyntheticChildren : public SyntheticChildren {
   class FrontEnd : public SyntheticChildrenFrontEnd {
   public:

--- a/lldb/source/DataFormatters/FormatterBytecode.cpp
+++ b/lldb/source/DataFormatters/FormatterBytecode.cpp
@@ -12,6 +12,7 @@
 #include "lldb/ValueObject/ValueObjectConstResult.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/DataExtractor.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/FormatProviders.h"
 #include "llvm/Support/FormatVariadicDetails.h"
@@ -181,8 +182,7 @@ static llvm::Error TypeCheck(llvm::ArrayRef<DataStackElement> data,
   return TypeCheck(data.drop_back(1), type2, type1);
 }
 
-llvm::Error Interpret(std::vector<ControlStackElement> &control,
-                      DataStack &data, Selectors sel) {
+llvm::Error Interpret(ControlStack &control, DataStack &data, Signatures sig) {
   if (control.empty())
     return llvm::Error::success();
   // Since the only data types are single endian and ULEBs, the
@@ -223,7 +223,7 @@ llvm::Error Interpret(std::vector<ControlStackElement> &control,
       return pc.takeError();
 
     LLDB_LOGV(GetLog(LLDBLog::DataFormatters),
-              "[eval {0}] opcode={1}, control={2}, data={3}", toString(sel),
+              "[eval {0}] opcode={1}, control={2}, data={3}", toString(sig),
               toString(opcode), control.size(), toString(data));
 
     // Various shorthands to improve the readability of error handling.

--- a/lldb/source/DataFormatters/TypeSummary.cpp
+++ b/lldb/source/DataFormatters/TypeSummary.cpp
@@ -261,11 +261,10 @@ bool BytecodeSummaryFormat::FormatObject(ValueObject *valobj,
     return false;
   }
 
-  std::vector<FormatterBytecode::ControlStackElement> control(
-      {m_bytecode->getBuffer()});
+  FormatterBytecode::ControlStack control({m_bytecode->getBuffer()});
   FormatterBytecode::DataStack data({valobj->GetSP()});
   llvm::Error error = FormatterBytecode::Interpret(
-      control, data, FormatterBytecode::sel_summary);
+      control, data, FormatterBytecode::sig_summary);
   if (error) {
     retval = llvm::toString(std::move(error));
     return false;

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -317,7 +317,7 @@ BytecodeSyntheticChildren::FrontEnd::CalculateNumChildren() {
     return llvm::createStringError(message);
   }
 
-  const auto &top = data.back();
+  const FormatterBytecode::DataStackElement &top = data.back();
   if (auto *u = std::get_if<uint64_t>(&top))
     if (*u <= UINT32_MAX)
       return *u;
@@ -353,7 +353,7 @@ BytecodeSyntheticChildren::FrontEnd::GetChildAtIndex(uint32_t idx) {
     return {};
   }
 
-  const auto &top = data.back();
+  const FormatterBytecode::DataStackElement &top = data.back();
   if (auto *child = std::get_if<ValueObjectSP>(&top))
     return *child;
 
@@ -380,7 +380,7 @@ BytecodeSyntheticChildren::FrontEnd::GetIndexOfChildWithName(ConstString name) {
     return llvm::createStringError(message);
   }
 
-  const auto &top = data.back();
+  const FormatterBytecode::DataStackElement &top = data.back();
   if (auto *u = std::get_if<uint64_t>(&top))
     if (*u <= SIZE_MAX)
       return *u;

--- a/lldb/test/API/functionalities/data-formatter/bytecode-summary/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-summary/main.cpp
@@ -33,7 +33,7 @@ __attribute__((used, section("__DATA_CONST,__lldbformatters"))) unsigned char
         "^MyOptional<.+>$" // type name
         "\x00"             // flags
         "\x00"             // sig_summary
-        "\x8d"             // program size
+        "\x8e"             // program size
         "\x01"             // program size
         "\x1\x22\x7Storage#\x12\x60\x1,C\x10\x1\x5\x11\x2\x1\x22\x6hasVal#"
         "\x12\x60\x1,\x10\x1e\x2\x22\x1b<could not read MyOptional>\x10G#!\x60 "

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/Makefile
@@ -1,0 +1,2 @@
+C_SOURCES := main.c
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
@@ -17,7 +17,6 @@ class TestCase(TestBase):
 
         frame = thread.selected_frame
         account = frame.var("acc")
-        # breakpoint()
         self.assertEqual(account.num_children, 1)
         self.assertEqual(account.child[0].name, "username")
 

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
@@ -1,0 +1,24 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    @skipUnlessDarwin
+    def test(self):
+        self.build()
+        if self.TraceOn():
+            self.expect("log enable -v lldb formatters")
+
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        frame = thread.selected_frame
+        account = frame.var("acc")
+        # breakpoint()
+        self.assertEqual(account.num_children, 1)
+        self.assertEqual(account.child[0].name, "username")
+
+        self.expect("v acc", matching=False, substrs=["password"])

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/main.cpp
@@ -1,0 +1,28 @@
+struct Account {
+  char *username;
+  char *password;
+};
+
+void stop() {}
+
+int main(int argc, char **argv) {
+  struct Account acc;
+  acc.username = "jake";
+  acc.password = "popcorn";
+  stop(); // break here
+  return 0;
+}
+
+__attribute__((used, section("__DATA_CONST,__lldbformatters"))) unsigned char
+    _Account_synthetic[] =
+        "\x01"                      // version
+        "\x15"                      // remaining record size
+        "\x07"                      // type name size
+        "Account"                   // type name
+        "\x00"                      // flags
+        "\x02"                      // sig_get_num_children
+        "\x02"                      // program size
+        "\x20\x01"                  // `return 1`
+        "\x04"                      // sig_get_child_at_index
+        "\x06"                      // program size
+        "\x02\x20\x00\x23\x11\x60"; // `return self.valobj.GetChildAtIndex(0)`

--- a/lldb/unittests/DataFormatter/FormatterBytecodeTest.cpp
+++ b/lldb/unittests/DataFormatter/FormatterBytecodeTest.cpp
@@ -15,7 +15,7 @@ bool Interpret(std::vector<uint8_t> code, DataStack &data) {
   auto buf =
       StringRef(reinterpret_cast<const char *>(code.data()), code.size());
   ControlStack control({buf});
-  if (auto error = Interpret(control, data, sel_summary)) {
+  if (auto error = Interpret(control, data, sig_summary)) {
 #ifndef NDEBUG
     llvm::errs() << llvm::toString(std::move(error)) << '\n';
 #else

--- a/lldb/unittests/DataFormatter/FormatterBytecodeTest.cpp
+++ b/lldb/unittests/DataFormatter/FormatterBytecodeTest.cpp
@@ -14,7 +14,7 @@ class FormatterBytecodeTest : public ::testing::Test {};
 bool Interpret(std::vector<uint8_t> code, DataStack &data) {
   auto buf =
       StringRef(reinterpret_cast<const char *>(code.data()), code.size());
-  std::vector<ControlStackElement> control({buf});
+  ControlStack control({buf});
   if (auto error = Interpret(control, data, sel_summary)) {
 #ifndef NDEBUG
     llvm::errs() << llvm::toString(std::move(error)) << '\n';


### PR DESCRIPTION
Initial implementation of a [bytecode](https://lldb.llvm.org/resources/formatterbytecode.html) synthetic provider. This is a follow up to https://github.com/llvm/llvm-project/pull/114333 which implemented the bytecode interpreter, support for summary formatters, and more.

rdar://169727764