### PR TITLE
workflows/release-asset-audit: Split workflow into two jobs

### DIFF
--- a/.github/workflows/release-asset-audit.yml
+++ b/.github/workflows/release-asset-audit.yml
@@ -34,10 +34,30 @@ jobs:
         run: |
           pip install --require-hashes -r ./llvm/utils/git/requirements.txt
           python3 ./.github/workflows/release-asset-audit.py $GITHUB_TOKEN
+
+      - name: Upload comment file
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: comment
+          path: |
+            comment
+
+  notify-audit-failed:
+    name: "Notify Audit Failed"
+    runs-on: ubuntu-24.04
+    if: >-
+      github.repository == 'llvm/llvm-project' &&
+      github.event_name != 'pull_request' &&
+      failure()
+    needs:
+      - audit
+    steps:
+      - name: Download Comment
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: comment
       - name: "File Issue"
-        if: >-
-          github.event_name != 'pull_request' &&
-          failure()
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.ISSUE_SUBSCRIBER_TOKEN }}


### PR DESCRIPTION
This way we can assign an environment to the job that uses the ISSUE_SUBSCRIBER_TOKEN secret.