### PR TITLE
[lld][BP] Fix nondeterministic function order by using MapVector

### DIFF
--- a/lld/include/lld/Common/BPSectionOrdererBase.inc
+++ b/lld/include/lld/Common/BPSectionOrdererBase.inc
@@ -224,7 +224,7 @@ auto BPOrderer<D>::computeOrder(
   SmallVector<unsigned> sectionIdxsForFunctionCompression,
       sectionIdxsForDataCompression;
   for (unsigned sectionIdx = 0; sectionIdx < sections.size(); sectionIdx++) {
-    if (startupSectionIdxUNs.count(sectionIdx))
+    if (startupSectionIdxUNs.contains(sectionIdx))
       continue;
     const auto *isec = sections[sectionIdx];
     if (D::isCodeSection(*isec)) {

--- a/lld/include/lld/Common/BPSectionOrdererBase.inc
+++ b/lld/include/lld/Common/BPSectionOrdererBase.inc
@@ -161,7 +161,7 @@ auto BPOrderer<D>::computeOrder(
     sectionToIdx.try_emplace(isec, i);
 
   BPFunctionNode::UtilityNodeT maxUN = 0;
-  std::map<unsigned, UtilityNodes> startupSectionIdxUNs;
+  MapVector<unsigned, UtilityNodes> startupSectionIdxUNs;
   // Used to define the initial order for startup functions.
   DenseMap<unsigned, size_t> sectionIdxToTimestamp;
   std::unique_ptr<InstrProfReader> reader;
@@ -177,7 +177,7 @@ auto BPOrderer<D>::computeOrder(
     }
     auto &traces = reader->getTemporalProfTraces();
 
-    std::map<unsigned, BPFunctionNode::UtilityNodeT> sectionIdxToFirstUN;
+    MapVector<unsigned, BPFunctionNode::UtilityNodeT> sectionIdxToFirstUN;
     for (size_t traceIdx = 0; traceIdx < traces.size(); traceIdx++) {
       uint64_t currentSize = 0, cutoffSize = 1;
       size_t cutoffTimestamp = 1;

--- a/lld/include/lld/Common/BPSectionOrdererBase.inc
+++ b/lld/include/lld/Common/BPSectionOrdererBase.inc
@@ -161,7 +161,7 @@ auto BPOrderer<D>::computeOrder(
     sectionToIdx.try_emplace(isec, i);
 
   BPFunctionNode::UtilityNodeT maxUN = 0;
-  DenseMap<unsigned, UtilityNodes> startupSectionIdxUNs;
+  std::map<unsigned, UtilityNodes> startupSectionIdxUNs;
   // Used to define the initial order for startup functions.
   DenseMap<unsigned, size_t> sectionIdxToTimestamp;
   std::unique_ptr<InstrProfReader> reader;
@@ -177,7 +177,7 @@ auto BPOrderer<D>::computeOrder(
     }
     auto &traces = reader->getTemporalProfTraces();
 
-    DenseMap<unsigned, BPFunctionNode::UtilityNodeT> sectionIdxToFirstUN;
+    std::map<unsigned, BPFunctionNode::UtilityNodeT> sectionIdxToFirstUN;
     for (size_t traceIdx = 0; traceIdx < traces.size(); traceIdx++) {
       uint64_t currentSize = 0, cutoffSize = 1;
       size_t cutoffTimestamp = 1;
@@ -224,7 +224,7 @@ auto BPOrderer<D>::computeOrder(
   SmallVector<unsigned> sectionIdxsForFunctionCompression,
       sectionIdxsForDataCompression;
   for (unsigned sectionIdx = 0; sectionIdx < sections.size(); sectionIdx++) {
-    if (startupSectionIdxUNs.contains(sectionIdx))
+    if (startupSectionIdxUNs.count(sectionIdx))
       continue;
     const auto *isec = sections[sectionIdx];
     if (D::isCodeSection(*isec)) {


### PR DESCRIPTION
There are two places where the nondeterministic iteration order of `DenseMap` (the original type of `startupSectionIdxUNs`) causes the output function order to be nondeterministic.

https://github.com/llvm/llvm-project/blob/16e2e7f59134e63810228c9a0dc990bfd96f9a1f/lld/include/lld/Common/BPSectionOrdererBase.inc#L240-L245

https://github.com/llvm/llvm-project/blob/16e2e7f59134e63810228c9a0dc990bfd96f9a1f/lld/include/lld/Common/BPSectionOrdererBase.inc#L267-L268

The fix is to use `MapVector` whose iteration order is guaranteed to be deterministic.

To test, I built a large binary several times and observed this value no longer changes.
https://github.com/llvm/llvm-project/blob/16e2e7f59134e63810228c9a0dc990bfd96f9a1f/lld/include/lld/Common/BPSectionOrdererBase.inc#L410-L411

It seems that this regresses linktime by a few seconds, but I believe the tradeoff is worthwhile.