### PR TITLE
[CMake][TableGen] Fix Ninja depslog error with implicit outputs on Ninja <1.10

### DIFF
--- a/llvm/cmake/modules/TableGen.cmake
+++ b/llvm/cmake/modules/TableGen.cmake
@@ -24,6 +24,14 @@ function(tablegen project ofn)
   # Filter out any empty include items.
   list(REMOVE_ITEM tblgen_includes "")
 
+  # Check for multi-output tablegen invocations BEFORE deciding on depfile mode.
+  # Ninja's depslog cannot handle multiple outputs with depfile, so we must use
+  # fallback mode (globbing) for these cases.
+  set(has_extra_outputs FALSE)
+  if("-gen-register-info" IN_LIST ARGN)
+    set(has_extra_outputs TRUE)
+  endif()
+
   # Use depfile instead of globbing arbitrary *.td(s) for Ninja. We force
   # CMake versions older than v3.30 on Windows to use the fallback behavior
   # due to a depfile parsing bug on Windows paths in versions prior to 3.30.
@@ -32,10 +40,28 @@ function(tablegen project ofn)
   # behavior as v3.22 and earlier fail to parse some depfiles that get
   # generated, and this behavior was fixed in CMake commit
   # e04a352cca523eba2ac0d60063a3799f5bb1c69e.
+  # CRITICAL: Ninja <1.10 has a depslog limitation: it cannot handle depfile
+  # mode when CMake generates implicit outputs (absolute path aliases for IDE
+  # support). For multi-output rules OR when using Ninja <1.10, we MUST use
+  # fallback mode (glob .td files) to avoid "multiple outputs aren't supported
+  # by depslog" errors.
   cmake_policy(GET CMP0116 cmp0116_state)
+  
+  # Check Ninja version to avoid depslog errors with implicit outputs
+  set(ninja_version_supports_depfile TRUE)
+  if(CMAKE_GENERATOR MATCHES "Ninja")
+    execute_process(COMMAND ${CMAKE_MAKE_PROGRAM} --version
+                    OUTPUT_VARIABLE ninja_version
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(ninja_version VERSION_LESS "1.10")
+      set(ninja_version_supports_depfile FALSE)
+    endif()
+  endif()
   if(CMAKE_GENERATOR MATCHES "Ninja" AND cmp0116_state STREQUAL NEW
      AND NOT (CMAKE_HOST_WIN32 AND CMAKE_VERSION VERSION_LESS 3.30)
-     AND NOT (CMAKE_VERSION VERSION_LESS 3.23))
+     AND NOT (CMAKE_VERSION VERSION_LESS 3.23)
+     AND NOT has_extra_outputs
+     AND ninja_version_supports_depfile)
     # CMake emits build targets as relative paths but Ninja doesn't identify
     # absolute path (in *.d) as relative path (in build.ninja). Post CMP0116,
     # CMake handles this discrepancy for us, otherwise we use the fallback
@@ -128,13 +154,27 @@ function(tablegen project ofn)
   # ("${${project}_TABLEGEN_TARGET}" STREQUAL "${${project}_TABLEGEN_EXE}")
   # but lets us having smaller and cleaner code here.
   set(tablegen_exe ${${project}_TABLEGEN_EXE})
-  set(tablegen_depends ${${project}_TABLEGEN_TARGET} ${tablegen_exe})
+  set(tablegen_target ${${project}_TABLEGEN_TARGET})
 
   if(LLVM_PARALLEL_TABLEGEN_JOBS)
     set(LLVM_TABLEGEN_JOB_POOL JOB_POOL tablegen_job_pool)
   else()
     set(LLVM_TABLEGEN_JOB_POOL "")
   endif()
+
+  # For Ninja with multiple outputs, we cannot add the target to DEPENDS due to
+  # depslog limitations. Instead, rely on the implicit tool dependency from COMMAND
+  # and the globbed .td files for proper dependency tracking.
+  # For single outputs or non-Ninja generators, include the target in DEPENDS.
+  set(tablegen_target_dep)
+  if(NOT EXTRA_OUTPUTS)
+    # Single output: safe to add explicit target dependency
+    set(tablegen_target_dep ${tablegen_target})
+  elseif(NOT CMAKE_GENERATOR MATCHES "Ninja")
+    # Multiple outputs but not Ninja: Ninja's depslog is not a constraint
+    set(tablegen_target_dep ${tablegen_target})
+  endif()
+  # Multiple outputs + Ninja: Don't add target dependency; rely on COMMAND implicit tracking
 
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ofn} ${EXTRA_OUTPUTS}
     COMMAND ${tablegen_exe} ${ARG_UNPARSED_ARGUMENTS}
@@ -146,7 +186,7 @@ function(tablegen project ofn)
     # The file in LLVM_TARGET_DEFINITIONS may be not in the current
     # directory and local_tds may not contain it, so we must
     # explicitly list it here:
-    DEPENDS ${ARG_DEPENDS} ${tablegen_depends}
+    DEPENDS ${ARG_DEPENDS} ${tablegen_target_dep}
       ${global_tds}
     ${LLVM_TARGET_DEFINITIONS_ABSOLUTE}
     ${LLVM_TARGET_DEPENDS}


### PR DESCRIPTION
Ninja versions prior to 1.10 cannot handle depfile mode when CMake
generates build rules with implicit outputs (the `| ${cmake_ninja_workdir}`
syntax used for IDE support). Ninja's depslog interprets these as multiple
outputs and rejects them with the error:

  ninja: error: build.ninja:XXXX: multiple outputs aren't (yet?) supported
  by depslog; bring this up on the mailing list if it affects you

This primarily affected builds where CMake generates NATIVE subdirectory builds for host tools.

This patch modifies TableGen.cmake to:
1. Detect the Ninja version at configure time
2. Disable depfile mode (fall back to globbing .td files) when:
   - Ninja version is < 1.10, OR
   - The tablegen invocation produces multiple outputs (e.g. -gen-register-info)

The fallback mode maintains correct dependency tracking by explicitly
globbing all .td files in include directories, ensuring tablegen reruns
when dependencies change.

Tested with:
- Ninja 1.8.2 (now works - previously failed with depslog error)
- CMake 4.2.3
- build scenarios with NATIVE tool builds

This commit used a significant amount of tooling to construct.