### PR TITLE
[DAGCombiner] Fold trunc(build_vector(ext(x), ext(x)) -> build_vector(x,x)

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -16641,9 +16641,7 @@ SDValue DAGCombiner::visitTRUNCATE(SDNode *N) {
 
     // trunc(build_vector(ext(x), ext(x)) -> build_vector(x,x)
     if (SDValue SplatVal = DAG.getSplatValue(N0)) {
-      unsigned Opcode = SplatVal.getOpcode();
-      if ((Opcode == ISD::SIGN_EXTEND || Opcode == ISD::ZERO_EXTEND ||
-           Opcode == ISD::ANY_EXTEND) &&
+      if (ISD::isExtOpcode(SplatVal.getOpcode()) &&
           SrcVT.getScalarType() == SplatVal.getValueType())
         return DAG.UnrollVectorOp(N);
     }

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vaaddu.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vaaddu.ll
@@ -215,13 +215,10 @@ define <8 x i64> @vaaddu_vx_v8i64_floor(<8 x i64> %x, i64 %y) {
 define <8 x i8> @vaaddu_vx_floor_splat_scalar(<8 x i8> %a, i8 %sc) {
 ; CHECK-LABEL: vaaddu_vx_floor_splat_scalar:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    xori a0, a0, -126
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; CHECK-NEXT:    vmv.v.x v9, a0
-; CHECK-NEXT:    vsetvli zero, zero, e8, mf2, ta, ma
-; CHECK-NEXT:    vnsrl.wi v9, v9, 0
+; CHECK-NEXT:    xori a0, a0, 130
 ; CHECK-NEXT:    csrwi vxrm, 2
-; CHECK-NEXT:    vaaddu.vv v8, v9, v8
+; CHECK-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
+; CHECK-NEXT:    vaaddu.vx v8, v8, a0
 ; CHECK-NEXT:    ret
   %1 = xor i8 %sc, -126
   %c = zext i8 %1 to i16
@@ -237,13 +234,10 @@ define <8 x i8> @vaaddu_vx_floor_splat_scalar(<8 x i8> %a, i8 %sc) {
 define <8 x i8> @vaaddu_vx_ceil_splat_scalar(<8 x i8> %x, i8 %y) {
 ; CHECK-LABEL: vaaddu_vx_ceil_splat_scalar:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    xori a0, a0, -126
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; CHECK-NEXT:    vmv.v.x v9, a0
-; CHECK-NEXT:    vsetvli zero, zero, e8, mf2, ta, ma
-; CHECK-NEXT:    vnsrl.wi v9, v9, 0
+; CHECK-NEXT:    xori a0, a0, 130
 ; CHECK-NEXT:    csrwi vxrm, 0
-; CHECK-NEXT:    vaaddu.vv v8, v8, v9
+; CHECK-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
+; CHECK-NEXT:    vaaddu.vx v8, v8, a0
 ; CHECK-NEXT:    ret
   %1 = xor i8 %y, -126
   %c = zext i8 %1 to i16

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vaaddu.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vaaddu.ll
@@ -212,6 +212,51 @@ define <8 x i64> @vaaddu_vx_v8i64_floor(<8 x i64> %x, i64 %y) {
   ret <8 x i64> %ret
 }
 
+define <8 x i8> @vaaddu_vx_floor_splat_scalar(<8 x i8> %a, i8 %sc) {
+; CHECK-LABEL: vaaddu_vx_floor_splat_scalar:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    xori a0, a0, -126
+; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vmv.v.x v9, a0
+; CHECK-NEXT:    vsetvli zero, zero, e8, mf2, ta, ma
+; CHECK-NEXT:    vnsrl.wi v9, v9, 0
+; CHECK-NEXT:    csrwi vxrm, 2
+; CHECK-NEXT:    vaaddu.vv v8, v9, v8
+; CHECK-NEXT:    ret
+  %1 = xor i8 %sc, -126
+  %c = zext i8 %1 to i16
+  %za = zext <8 x i8> %a to <8 x i16>
+  %yhead = insertelement <8 x i16> poison, i16 %c, i64 0
+  %yzv = shufflevector <8 x i16> %yhead, <8 x i16> poison, <8 x i32> zeroinitializer
+  %add = add nuw nsw <8 x i16> %yzv, %za
+  %div = lshr <8 x i16> %add, splat (i16 1)
+  %ret = trunc nuw <8 x i16> %div to <8 x i8>
+  ret <8 x i8> %ret
+}
+
+define <8 x i8> @vaaddu_vx_ceil_splat_scalar(<8 x i8> %x, i8 %y) {
+; CHECK-LABEL: vaaddu_vx_ceil_splat_scalar:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    xori a0, a0, -126
+; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vmv.v.x v9, a0
+; CHECK-NEXT:    vsetvli zero, zero, e8, mf2, ta, ma
+; CHECK-NEXT:    vnsrl.wi v9, v9, 0
+; CHECK-NEXT:    csrwi vxrm, 0
+; CHECK-NEXT:    vaaddu.vv v8, v8, v9
+; CHECK-NEXT:    ret
+  %1 = xor i8 %y, -126
+  %c = zext i8 %1 to i16
+  %xzv = zext <8 x i8> %x to <8 x i16>
+  %yhead = insertelement <8 x i16> poison, i16 %c, i32 0
+  %yzv = shufflevector <8 x i16> %yhead, <8 x i16> poison, <8 x i32> zeroinitializer
+  %add = add nuw nsw <8 x i16> %xzv, %yzv
+  %add1 = add nuw nsw <8 x i16> %add, <i16 1, i16 1, i16 1, i16 1, i16 1, i16 1, i16 1, i16 1>
+  %div = lshr <8 x i16> %add1, splat (i16 1)
+  %ret = trunc <8 x i16> %div to <8 x i8>
+  ret <8 x i8> %ret
+}
+
 define <8 x i8> @vaaddu_vv_v8i8_ceil(<8 x i8> %x, <8 x i8> %y) {
 ; CHECK-LABEL: vaaddu_vv_v8i8_ceil:
 ; CHECK:       # %bb.0:


### PR DESCRIPTION
 The original implementation performed the transformation when isTruncateFree was true:
 truncate(build_vector(x, x)) -> build_vector(truncate(x), truncate(x)).
    
 In some cases, x comes from an ext, try to pre-truncate build_vectors source operands
 when the source operands of build_vectors comes from an ext.
    
 Testcase from: https://gcc.godbolt.org/z/bbxbYK7dh