### PR TITLE
[lld][Hexagon] Fix R_HEX_TPREL_11_X relocation on duplex instructions

### DIFF
--- a/lld/ELF/Arch/Hexagon.cpp
+++ b/lld/ELF/Arch/Hexagon.cpp
@@ -225,6 +225,8 @@ static uint32_t findMaskR8(uint32_t insn) {
 }
 
 static uint32_t findMaskR11(uint32_t insn) {
+  if (isDuplex(insn))
+    return 0x03f00000;
   if ((0xff000000 & insn) == 0xa1000000)
     return 0x060020ff;
   return 0x06003fe0;


### PR DESCRIPTION
findMaskR11() was missing handling for duplex instructions.  This caused incorrect encoding when R_HEX_TPREL_11_X relocations were applied to duplex instructions with large TLS offsets.

For duplex instructions, the immediate bits are located at positions 20-25 (mask 0x03f00000), not in the standard positions used for non-duplex instructions.

This fix adds the isDuplex() check to findMaskR11() to return the correct mask for duplex instruction encodings.