### PR TITLE
[RISCV] Fold vmerge into op with undef passthru by using vmerge's vl

### DIFF
--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-peephole-vmerge-vops.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-peephole-vmerge-vops.ll
@@ -303,10 +303,8 @@ define <8 x i32> @vpselect_vpload2(<8 x i32> %passthru, ptr %p, <8 x i32> %x, <8
 define <8 x i32> @vpmerge_add(<8 x i32> %passthru, <8 x i32> %x, <8 x i32> %y, <8 x i1> %m, i32 zeroext %vl) {
 ; CHECK-LABEL: vpmerge_add:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e32, m1, ta, ma
-; CHECK-NEXT:    vadd.vv v9, v9, v10
-; CHECK-NEXT:    vsetvli zero, a0, e32, m1, tu, ma
-; CHECK-NEXT:    vmerge.vvm v8, v8, v9, v0
+; CHECK-NEXT:    vsetvli zero, a0, e32, m1, tu, mu
+; CHECK-NEXT:    vadd.vv v8, v9, v10, v0.t
 ; CHECK-NEXT:    ret
   %a = add <8 x i32> %x, %y
   %b = call <8 x i32> @llvm.vp.merge.v8i32(<8 x i1> %m, <8 x i32> %a, <8 x i32> %passthru, i32 %vl)

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-peephole-vmerge-vops.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-peephole-vmerge-vops.ll
@@ -299,3 +299,30 @@ define <8 x i32> @vpselect_vpload2(<8 x i32> %passthru, ptr %p, <8 x i32> %x, <8
   %b = call <8 x i32> @llvm.vp.select.v8i32(<8 x i1> %m, <8 x i32> %a, <8 x i32> %passthru, i32 %vl)
   ret <8 x i32> %b
 }
+
+define <8 x i32> @vpmerge_add(<8 x i32> %passthru, <8 x i32> %x, <8 x i32> %y, <8 x i1> %m, i32 zeroext %vl) {
+; CHECK-LABEL: vpmerge_add:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetivli zero, 8, e32, m1, ta, ma
+; CHECK-NEXT:    vadd.vv v9, v9, v10
+; CHECK-NEXT:    vsetvli zero, a0, e32, m1, tu, ma
+; CHECK-NEXT:    vmerge.vvm v8, v8, v9, v0
+; CHECK-NEXT:    ret
+  %a = add <8 x i32> %x, %y
+  %b = call <8 x i32> @llvm.vp.merge.v8i32(<8 x i1> %m, <8 x i32> %a, <8 x i32> %passthru, i32 %vl)
+  ret <8 x i32> %b
+}
+
+; Negative test: Shouldn't fold vmerge into the load because we may increase vl.
+define <8 x i32> @vpmerge_load(<8 x i32> %passthru, ptr %p, <8 x i1> %m, i32 zeroext %vl) {
+; CHECK-LABEL: vpmerge_load:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetivli zero, 8, e32, m1, ta, ma
+; CHECK-NEXT:    vle32.v v9, (a0)
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, tu, ma
+; CHECK-NEXT:    vmerge.vvm v8, v8, v9, v0
+; CHECK-NEXT:    ret
+  %a = load <8 x i32>, ptr %p
+  %b = call <8 x i32> @llvm.vp.merge.v8i32(<8 x i1> %m, <8 x i32> %a, <8 x i32> %passthru, i32 %vl)
+  ret <8 x i32> %b
+}

--- a/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
@@ -219,8 +219,7 @@ body: |
     ; CHECK: %passthru:vrnov0 = COPY $v8
     ; CHECK-NEXT: %avl:gprnox0 = COPY $x8
     ; CHECK-NEXT: %mask:vmv0 = COPY $v0
-    ; CHECK-NEXT: %add:vrnov0 = PseudoVADD_VV_M1 $noreg, %x:vr, %y:vr, 1 /* vl */, 5 /* e32 */, 0 /* tu, mu */
-    ; CHECK-NEXT: %merge:vrnov0 = PseudoVMERGE_VVM_M1 %passthru, %passthru, %add, %mask, %avl /* vl */, 5 /* e32 */
+    ; CHECK-NEXT: %merge:vrnov0 = PseudoVADD_VV_M1_MASK %passthru, %x:vr, %y:vr, %mask, %avl /* vl */, 5 /* e32 */, 0 /* tu, mu */
     %passthru:vrnov0 = COPY $v8
     %avl:gprnox0 = COPY $x8
     %mask:vmv0 = COPY $v0

--- a/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
@@ -211,3 +211,36 @@ body:             |
     %125:vrm8 = COPY %121
     PseudoRET
 ...
+---
+name: increase_vl
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: increase_vl
+    ; CHECK: %passthru:vrnov0 = COPY $v8
+    ; CHECK-NEXT: %avl:gprnox0 = COPY $x8
+    ; CHECK-NEXT: %mask:vmv0 = COPY $v0
+    ; CHECK-NEXT: %add:vrnov0 = PseudoVADD_VV_M1 $noreg, %x:vr, %y:vr, 1 /* vl */, 5 /* e32 */, 0 /* tu, mu */
+    ; CHECK-NEXT: %merge:vrnov0 = PseudoVMERGE_VVM_M1 %passthru, %passthru, %add, %mask, %avl /* vl */, 5 /* e32 */
+    %passthru:vrnov0 = COPY $v8
+    %avl:gprnox0 = COPY $x8
+    %mask:vmv0 = COPY $v0
+    %add:vrnov0 = PseudoVADD_VV_M1 $noreg, %x:vr, %y:vr, 1, 5 /* e32 */, 0 /* tu, mu */
+    %merge:vrnov0 = PseudoVMERGE_VVM_M1 %passthru, %passthru, %add, %mask, %avl, 5 /* e32 */
+...
+---
+# Negative test: Shouldn't fold vmerge into the load because we may increase vl.
+name: increase_vl_load
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: increase_vl_load
+    ; CHECK: %passthru:vrnov0 = COPY $v8
+    ; CHECK-NEXT: %avl:gprnox0 = COPY $x8
+    ; CHECK-NEXT: %mask:vmv0 = COPY $v0
+    ; CHECK-NEXT: %load:vrnov0 = PseudoVLE32_V_M1 $noreg, $noreg, 1 /* vl */, 5 /* e32 */, 0 /* tu, mu */ :: (load unknown-size, align 1)
+    ; CHECK-NEXT: %merge:vrnov0 = PseudoVMERGE_VVM_M1 %passthru, %passthru, %load, %mask, %avl /* vl */, 5 /* e32 */
+    %passthru:vrnov0 = COPY $v8
+    %avl:gprnox0 = COPY $x8
+    %mask:vmv0 = COPY $v0
+    %load:vrnov0 = PseudoVLE32_V_M1 $noreg, $noreg, 1, 5 /* e32 */, 0 /* tu, mu */ :: (load unknown-size)
+    %merge:vrnov0 = PseudoVMERGE_VVM_M1 %passthru, %passthru, %load, %mask, %avl, 5 /* e32 */
+...


### PR DESCRIPTION
Currently we only fold an op into vmerge if we know the smaller of the two vls, because we can't increase the vl.

However if the op's passthru is undef, then we can just use vmerge's vl because the lanes past op's vl were undef anyway. We need to make sure that the op doesn't access memory though. Other instructions where the result depends on the VL should already be handled by the RISCVII::elementsDependOnVL check below.

This is probably always profitable because even though we increase vl, we remove a vmerge which needs to process vl elements anyway.

This removes some regressions in #179622.