### PR TITLE
MIPS: Fix unsigned compare with zero in MipsSEInstrInfo::copyPhysReg

### DIFF
--- a/llvm/lib/Target/Mips/MipsSEInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsSEInstrInfo.cpp
@@ -242,7 +242,7 @@ void MipsSEInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
       Opc = Mips::FMOV_D64;
       unsigned DestRegOff = DestReg.id() - Mips::D0_64;
       unsigned SrcRegOff = SrcReg.id() - Mips::F0;
-      if (SrcRegOff == DestRegOff && SrcRegOff >= 0 && SrcRegOff <= 31)
+      if (SrcRegOff == DestRegOff && SrcRegOff <= 31)
         return;
     }
   } else if (Opc == 0 && Mips::FGR32RegClass.contains(DestReg) &&
@@ -253,7 +253,7 @@ void MipsSEInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
       Opc = Mips::FMOV_D32;
       unsigned DestRegOff = DestReg.id() - Mips::F0;
       unsigned SrcRegOff = SrcReg.id() - Mips::D0_64;
-      if (SrcRegOff == DestRegOff && SrcRegOff >= 0 && SrcRegOff <= 31)
+      if (SrcRegOff == DestRegOff && SrcRegOff <= 31)
         return;
     }
   }


### PR DESCRIPTION
SrcRegOff >= 0 is not needed at all for unsigned.

This fixes the warning:
```
llvm/lib/Target/Mips/MipsSEInstrInfo.cpp: In member function ‘virtual void llvm::MipsSEInstrInfo::copyPhysReg(llvm::MachineBasicBlock&, llvm::MachineBasicBlock::iterator, const llvm::DebugLoc&, llvm::Register, llvm::Register, bool, bool, bool) const’:
llvm/lib/Target/Mips/MipsSEInstrInfo.cpp:245:48: warning: comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
  245 |       if (SrcRegOff == DestRegOff && SrcRegOff >= 0 && SrcRegOff <= 31)
      |                                      ~~~~~~~~~~^~~~
llvm/lib/Target/Mips/MipsSEInstrInfo.cpp:256:48: warning: comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
  256 |       if (SrcRegOff == DestRegOff && SrcRegOff >= 0 && SrcRegOff <= 31)
```
