### PR TITLE
[clang-tidy][mlir] Add check for passing value type by reference.

### DIFF
--- a/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.cpp
@@ -18,14 +18,8 @@ namespace clang::tidy::llvm_check {
 AvoidPassingAsRefCheck::AvoidPassingAsRefCheck(StringRef Name,
                                                ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      ClassNames(Options.get("ClassNames", "::mlir::Op")) {
-  if (!utils::options::parseStringList(ClassNames, ClassNameList) &&
-      !ClassNames.empty()) {
-    Context->getDiagnosticsEngine().Report(
-        Context->getDiagID(diag::err_invalid_option_value), SourceLocation{})
-        << "invalid value for 'ClassNames'" << ClassNames;
-  }
-}
+      ClassNameList(utils::options::parseStringList(
+          Options.get("ClassNames", "::mlir::Op"))) {}
 
 void AvoidPassingAsRefCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "ClassNames", ClassNames);
@@ -35,9 +29,10 @@ void AvoidPassingAsRefCheck::registerMatchers(MatchFinder *Finder) {
   if (ClassNameList.empty())
     return;
 
-  std::vector<ast_matchers::DeclarationMatcher> Matchers;
-  for (const auto &Name : ClassNameList)
-    Matchers.push_back(isSameOrDerivedFrom(Name));
+  std::vector<ast_matchers::internal::Matcher<CXXRecordDecl>> Matchers;
+  for (const auto &Name : ClassNameList) {
+    Matchers.push_back(isSameOrDerivedFrom(std::string(Name)));
+  }
 
   // Match parameters that are references to classes derived from any class in
   // ClassNameList.

--- a/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.cpp
@@ -1,0 +1,77 @@
+//===--- AvoidPassingAsRefCheck.cpp - clang-tidy --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "AvoidPassingAsRefCheck.h"
+#include "../utils/OptionsUtils.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::llvm_check {
+
+AvoidPassingAsRefCheck::AvoidPassingAsRefCheck(StringRef Name,
+                                               ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+      ClassNames(Options.get("ClassNames", "::mlir::Op")) {
+  if (!utils::options::parseStringList(ClassNames, ClassNameList) &&
+      !ClassNames.empty()) {
+    Context->getDiagnosticsEngine().Report(
+        Context->getDiagID(diag::err_invalid_option_value), SourceLocation{})
+        << "invalid value for 'ClassNames'" << ClassNames;
+  }
+}
+
+void AvoidPassingAsRefCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "ClassNames", ClassNames);
+}
+
+void AvoidPassingAsRefCheck::registerMatchers(MatchFinder *Finder) {
+  if (ClassNameList.empty())
+    return;
+
+  std::vector<ast_matchers::DeclarationMatcher> Matchers;
+  for (const auto &Name : ClassNameList)
+    Matchers.push_back(isSameOrDerivedFrom(Name));
+
+  // Match parameters that are references to classes derived from any class in
+  // ClassNameList.
+  Finder->addMatcher(
+      parmVarDecl(
+          hasType(qualType(
+              references(qualType(hasDeclaration(
+                  cxxRecordDecl(anyOfArrayRef(Matchers)).bind("op_type")))),
+              // We want to avoid matching `Op *&` (reference to pointer to Op)
+              // which is not common for Op but possible.
+              unless(references(pointerType())))),
+          unless(isImplicit()),
+          unless(hasAncestor(cxxConstructorDecl(
+              anyOf(isCopyConstructor(), isMoveConstructor())))),
+          unless(hasAncestor(cxxMethodDecl(isCopyAssignmentOperator()))),
+          unless(hasAncestor(cxxMethodDecl(isMoveAssignmentOperator()))),
+          decl().bind("param")),
+      this);
+}
+
+void AvoidPassingAsRefCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *Param = Result.Nodes.getNodeAs<ParmVarDecl>("param");
+  const auto *OpType = Result.Nodes.getNodeAs<CXXRecordDecl>("op_type");
+
+  // Exclude if we can't find definitions.
+  if (!Param || !OpType)
+    return;
+
+  // We should verify if the type is exactly what we expect.
+  // The matcher `isSameOrDerivedFrom` handles inheritance.
+
+  diag(Param->getLocation(),
+       "class '%0' should be passed by value, not by reference")
+      << OpType->getName();
+}
+
+} // namespace clang::tidy::llvm_check

--- a/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.cpp
@@ -66,9 +66,8 @@ void AvoidPassingAsRefCheck::check(const MatchFinder::MatchResult &Result) {
   if (!Param || !OpType)
     return;
 
-  // We should verify if the type is exactly what we expect.
-  // The matcher `isSameOrDerivedFrom` handles inheritance.
-
+  // We should verify if the type is exactly what we expect. The matcher
+  // `isSameOrDerivedFrom` handles inheritance.
   diag(Param->getLocation(),
        "class '%0' should be passed by value, not by reference")
       << OpType->getName();

--- a/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.cpp
@@ -1,4 +1,4 @@
-//===--- AvoidPassingAsRefCheck.cpp - clang-tidy --------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.h
@@ -1,4 +1,4 @@
-//===--- AvoidPassingAsRefCheck.h - clang-tidy ------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.h
@@ -29,7 +29,7 @@ public:
 
 private:
   const std::string ClassNames;
-  std::vector<std::string> ClassNameList;
+  const std::vector<StringRef> ClassNameList;
 };
 
 } // namespace clang::tidy::llvm_check

--- a/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.h
@@ -1,0 +1,37 @@
+//===--- AvoidPassingAsRefCheck.h - clang-tidy ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_AVOIDPASSINGASREFCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_AVOIDPASSINGASREFCHECK_H
+
+#include "../ClangTidyCheck.h"
+#include <string>
+#include <vector>
+
+namespace clang::tidy::llvm_check {
+
+/// Flags function parameters of types that should be passed by value but are
+/// passed by reference instead.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/llvm/avoid-passing-as-ref.html
+class AvoidPassingAsRefCheck : public ClangTidyCheck {
+public:
+  AvoidPassingAsRefCheck(StringRef Name, ClangTidyContext *Context);
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+
+private:
+  const std::string ClassNames;
+  std::vector<std::string> ClassNameList;
+};
+
+} // namespace clang::tidy::llvm_check
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_AVOIDPASSINGASREFCHECK_H

--- a/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/AvoidPassingAsRefCheck.h
@@ -19,7 +19,7 @@ namespace clang::tidy::llvm_check {
 /// passed by reference instead.
 ///
 /// For the user-facing documentation see:
-/// http://clang.llvm.org/extra/clang-tidy/checks/llvm/avoid-passing-as-ref.html
+/// https://clang.llvm.org/extra/clang-tidy/checks/llvm/avoid-passing-as-ref.html
 class AvoidPassingAsRefCheck : public ClangTidyCheck {
 public:
   AvoidPassingAsRefCheck(StringRef Name, ClangTidyContext *Context);

--- a/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_clang_library(clangTidyLLVMModule STATIC
+  AvoidPassingAsRefCheck.cpp
   HeaderGuardCheck.cpp
   IncludeOrderCheck.cpp
   LLVMTidyModule.cpp

--- a/clang-tools-extra/clang-tidy/llvm/LLVMTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/LLVMTidyModule.cpp
@@ -11,6 +11,7 @@
 #include "../readability/ElseAfterReturnCheck.h"
 #include "../readability/NamespaceCommentCheck.h"
 #include "../readability/QualifiedAutoCheck.h"
+#include "AvoidPassingAsRefCheck.h"
 #include "HeaderGuardCheck.h"
 #include "IncludeOrderCheck.h"
 #include "PreferIsaOrDynCastInConditionalsCheck.h"
@@ -29,6 +30,8 @@ namespace {
 class LLVMModule : public ClangTidyModule {
 public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+    CheckFactories.registerCheck<AvoidPassingAsRefCheck>(
+        "llvm-avoid-passing-as-ref");
     CheckFactories.registerCheck<readability::ElseAfterReturnCheck>(
         "llvm-else-after-return");
     CheckFactories.registerCheck<LLVMHeaderGuardCheck>("llvm-header-guard");

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -111,6 +111,12 @@ New checks
   Finds functions where throwing exceptions is unsafe but the function is still
   marked as potentially throwing.
 
+- New :doc:`llvm-avoid-passing-as-ref
+  <clang-tidy/checks/llvm/avoid-passing-as-ref>` check.
+
+  Flags function parameters of types that should be passed by value, but are
+  passed by reference.
+
 - New :doc:`llvm-type-switch-case-types
   <clang-tidy/checks/llvm/type-switch-case-types>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -245,6 +245,7 @@ Clang-Tidy Checks
    :doc:`hicpp-multiway-paths-covered <hicpp/multiway-paths-covered>`,
    :doc:`hicpp-signed-bitwise <hicpp/signed-bitwise>`,
    :doc:`linuxkernel-must-check-errs <linuxkernel/must-check-errs>`,
+   :doc:`llvm-avoid-passing-as-ref <llvm/avoid-passing-as-ref>`,
    :doc:`llvm-header-guard <llvm/header-guard>`,
    :doc:`llvm-include-order <llvm/include-order>`, "Yes"
    :doc:`llvm-namespace-comment <llvm/namespace-comment>`,

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/avoid-passing-as-ref.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/avoid-passing-as-ref.rst
@@ -1,0 +1,27 @@
+.. title:: llvm-avoid-passing-as-ref
+
+Flags function parameters of types that should be passed by value, but are passed
+by reference. By default, it flags types derived from ``mlir::Op`` as ``mlir::Op``
+derived classes are lightweight wrappers around a pointer and should be passed
+by value. This check can be customized to flag other types using the `ClassNames`
+option.
+
+Example:
+
+.. code-block:: c++
+
+  // Bad: passed by reference
+  void processOp(const MyOp &op);
+  void mutateOp(MyOp &op);
+
+  // Good: passed by value
+  void processOp(MyOp op);
+  void mutateOp(MyOp op);
+
+Options
+-------
+
+.. option:: ClassNames
+
+   A semicolon-separated list of fully qualified class names that should be
+   passed by value. Default is ``"::mlir::Op"``.

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/avoid-passing-as-ref.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/avoid-passing-as-ref.rst
@@ -24,4 +24,4 @@ Options
 .. option:: ClassNames
 
    A semicolon-separated list of fully qualified class names that should be
-   passed by value. Default is ``"::mlir::Op"``.
+   passed by value. Default is ``::mlir::Op``.

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/avoid-passing-as-ref.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/avoid-passing-as-ref.cpp
@@ -15,12 +15,12 @@ class OtherClass {};
 
 // Should trigger warning
 void badFunction(const MyOp &op) {
-  // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: MLIR Op class 'MyOp' should be passed by value, not by reference [llvm-avoid-passing-as-ref]
+  // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: class 'MyOp' should be passed by value, not by reference [llvm-avoid-passing-as-ref]
 }
 
 // Should trigger warning logic for non-const ref too
 void badFunctionMutable(MyOp &op) {
-  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: MLIR Op class 'MyOp' should be passed by value, not by reference [llvm-avoid-passing-as-ref]
+  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: class 'MyOp' should be passed by value, not by reference [llvm-avoid-passing-as-ref]
 }
 
 // Good: passed by value

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/avoid-passing-as-ref.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/avoid-passing-as-ref.cpp
@@ -1,0 +1,33 @@
+// RUN: %check_clang_tidy %s llvm-avoid-passing-as-ref %t
+
+namespace mlir {
+template <typename ConcreteType, template <typename T> class... Traits>
+class Op {
+public:
+  // Minimal definition to satisfy isSameOrDerivedFrom
+};
+} // namespace mlir
+
+class MyOp : public mlir::Op<MyOp> {
+  using Op::Op;
+};
+class OtherClass {};
+
+// Should trigger warning
+void badFunction(const MyOp &op) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: MLIR Op class 'MyOp' should be passed by value, not by reference [llvm-avoid-passing-as-ref]
+}
+
+// Should trigger warning logic for non-const ref too
+void badFunctionMutable(MyOp &op) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: MLIR Op class 'MyOp' should be passed by value, not by reference [llvm-avoid-passing-as-ref]
+}
+
+// Good: passed by value
+void goodFunction(MyOp op) {}
+
+// Good: not an Op
+void otherFunction(const OtherClass &c) {}
+
+// Good: pointer to Op (if ever used)
+void pointerFunction(MyOp *op) {}

--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -2939,6 +2939,43 @@ extern const internal::VariadicOperatorMatcherFunc<
     2, std::numeric_limits<unsigned>::max()>
     anyOf;
 
+/// Like \c anyOf, but accepts a runtime ArrayRef of matchers instead of
+/// compile-time variadic arguments.
+///
+/// This is useful when the set of matchers is built dynamically, e.g. from
+/// configuration options.
+///
+/// Example:
+/// \code
+///   std::vector<Matcher<Decl>> Matchers = {hasName("A"), hasName("B")};
+///   auto M = cxxRecordDecl(anyOfArrayRef(Matchers));
+/// \endcode
+/// is equivalent to:
+/// \code
+///   auto M = cxxRecordDecl(anyOf(hasName("A"), hasName("B")));
+/// \endcode
+///
+/// Usable as: Any Matcher
+template <typename T>
+internal::Matcher<T> anyOfArrayRef(ArrayRef<internal::Matcher<T>> Matchers) {
+  if (Matchers.size() == 1)
+    return Matchers[0];
+  std::vector<internal::DynTypedMatcher> DynMatchers(Matchers.begin(),
+                                                     Matchers.end());
+  return internal::DynTypedMatcher::constructVariadic(
+             internal::DynTypedMatcher::VO_AnyOf,
+             ASTNodeKind::getFromNodeKind<T>(), std::move(DynMatchers))
+      .template unconditionalConvertTo<T>();
+}
+
+/// Overload accepting a std::vector (avoids template argument deduction issues
+/// with implicit ArrayRef conversion).
+template <typename T>
+internal::Matcher<T>
+anyOfArrayRef(const std::vector<internal::Matcher<T>> &Matchers) {
+  return anyOfArrayRef(ArrayRef<internal::Matcher<T>>(Matchers));
+}
+
 /// Matches if all given matchers match.
 ///
 /// Usable as: Any Matcher


### PR DESCRIPTION
This instance is effectively a wrapper around a pointer and should be passed by value.

There are a few existing such cases in MLIR upstream. Didn't fix along with this to avoid mixing discussions.