### PR TITLE
[flang][OpenMP] Attach compiler-emitted mappers to arrays of records

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -2784,7 +2784,8 @@ genTargetOp(lower::AbstractConverter &converter, lower::SymMap &symTable,
 
           if (!mapperIdName.empty()) {
             bool allowImplicitMapper =
-                semantics::IsAllocatableOrObjectPointer(&sym);
+                semantics::IsAllocatableOrObjectPointer(&sym) ||
+                requiresImplicitDefaultDeclareMapper(*typeSpec);
             bool hasDefaultMapper =
                 converter.getModuleOp().lookupSymbol(mapperIdName);
             if (hasDefaultMapper || allowImplicitMapper) {


### PR DESCRIPTION
Extends support for compiler-defined declare mappers for records. This fixes a bug where arrays of records that have allocatable fields were mapped incorrectly.