### PR TITLE
[llvm] Update policy for Doxygen comments in the Coding Standards

### DIFF
--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -293,7 +293,8 @@ A minimal documentation comment:
 
 Only include code examples, function parameters and return values when it
 provides additional information, such as intent, usage, or behavior that’s
-non-obvious.
+non-obvious.  Use descriptive function and argument names to
+eliminate the need for documentation comments when possible.
 
 To refer to parameter names inside a paragraph, use the ``\p name`` command.
 Don't use the ``\arg name`` command since it starts a new paragraph that

--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -278,11 +278,23 @@ Use the ``\file`` command to turn the standard file header into a file-level
 comment.
 
 Include descriptive paragraphs for all public interfaces (public classes,
-member and non-member functions).  Avoid restating the information that can
-be inferred from the API name.  The first sentence (or a paragraph beginning
-with ``\brief``) is used as an abstract. Try to use a single sentence as the
-``\brief`` adds visual clutter.  Put detailed discussion into separate
-paragraphs.
+member and non-member functions).  Avoid restating the information that can be
+inferred from the API name or signature.  The first sentence (or a paragraph
+beginning with ``\brief``) is used as an abstract.  Try to use a single
+sentence as the ``\brief`` adds visual clutter.  Put detailed discussion into
+separate paragraphs.
+
+A minimal documentation comment:
+
+.. code-block:: c++
+
+  /// Sets the xyzzy property to \p Baz.
+  void setXyzzy(bool Baz);
+
+Only include code examples, function parameters and return values when it
+provides addtional information, such as intent, usage, or behavior that’s
+non-obvious.  Avoid restating information that can easily be inferred from the
+function signature.
 
 To refer to parameter names inside a paragraph, use the ``\p name`` command.
 Don't use the ``\arg name`` command since it starts a new paragraph that
@@ -297,13 +309,6 @@ respectively.
 
 To describe function return value, start a new paragraph with the ``\returns``
 command.
-
-A minimal documentation comment:
-
-.. code-block:: c++
-
-  /// Sets the xyzzy property to \p Baz.
-  void setXyzzy(bool Baz);
 
 A documentation comment that uses all Doxygen features in a preferred way:
 

--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -292,9 +292,8 @@ A minimal documentation comment:
   void setXyzzy(bool Baz);
 
 Only include code examples, function parameters and return values when it
-provides addtional information, such as intent, usage, or behavior that’s
-non-obvious.  Avoid restating information that can easily be inferred from the
-function signature.
+provides additional information, such as intent, usage, or behavior that’s
+non-obvious.
 
 To refer to parameter names inside a paragraph, use the ``\p name`` command.
 Don't use the ``\arg name`` command since it starts a new paragraph that


### PR DESCRIPTION
This PR updates the policy regarding Doxygen comments in the Coding Standards based on an RFC discussion on Discourse:

https://discourse.llvm.org/t/rfc-policy-for-doxygen-comments-in-lldb/89675/