### PR TITLE
[llvm-ir2vec] Adding FuncEmb API to ir2vec python bindings

### DIFF
--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
@@ -22,6 +22,15 @@ if tool is not None:
         print(f"Function: {func_name}")
         print(f"  Embedding: {emb.tolist()}")
 
+    # Test getFuncEmb for individual functions
+    print("\n=== Single Function Embeddings ===")
+
+    # Test valid function names
+    for func_name in ["add", "multiply", "conditional"]:
+        func_emb = tool.getFuncEmb(func_name)
+        print(f"Function: {func_name}")
+        print(f"  Embedding: {func_emb.tolist()}")
+
 # CHECK: SUCCESS: Tool initialized
 # CHECK: Tool type: IR2VecTool
 # CHECK: === Function Embeddings ===
@@ -31,3 +40,10 @@ if tool is not None:
 # CHECK-NEXT:   Embedding: [413.20000000298023, 421.20000000298023, 429.20000000298023]
 # CHECK: Function: multiply
 # CHECK-NEXT:   Embedding: [50.0, 52.0, 54.0]
+# CHECK: === Single Function Embeddings ===
+# CHECK: Function: add
+# CHECK-NEXT:   Embedding: [38.0, 40.0, 42.0]
+# CHECK: Function: multiply
+# CHECK-NEXT:   Embedding: [50.0, 52.0, 54.0]
+# CHECK: Function: conditional
+# CHECK-NEXT:   Embedding: [413.20000000298023, 421.20000000298023, 429.20000000298023]

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -94,6 +94,30 @@ public:
 
     return NBFuncEmbMap;
   }
+
+  nb::ndarray<nb::numpy, double> getFuncEmb(const std::string &FuncName) {
+    const Function *FuncPtr = M->getFunction(FuncName);
+
+    if (!FuncPtr)
+      throw nb::value_error(("Function '" + FuncName + "' not found in module").c_str());
+
+    auto ToolFuncEmb = Tool->getFunctionEmbedding(*FuncPtr, OutputEmbeddingMode);
+
+    if (!ToolFuncEmb)
+      throw nb::value_error(toString(ToolFuncEmb.takeError()).c_str());
+
+    auto FuncEmbVec = ToolFuncEmb->getData();
+    double *NBFuncEmbVec = new double[FuncEmbVec.size()];
+    std::copy(FuncEmbVec.begin(), FuncEmbVec.end(), NBFuncEmbVec);
+
+    auto NbArray = nb::ndarray<nb::numpy, double>(
+        NBFuncEmbVec, {FuncEmbVec.size()},
+        nb::capsule(NBFuncEmbVec, [](void *P) noexcept {
+          delete[] static_cast<double *>(P);
+        }));
+
+    return NbArray;
+  }
 };
 
 } // namespace
@@ -108,7 +132,12 @@ NB_MODULE(ir2vec, m) {
       .def("getFuncEmbMap", &PyIR2VecTool::getFuncEmbMap,
            "Generate function-level embeddings for all functions\n"
            "Returns: dict[str, ndarray[float64]] - "
-           "{function_name: embedding}");
+           "{function_name: embedding}")
+      .def("getFuncEmb", &PyIR2VecTool::getFuncEmb,
+           nb::arg("funcName"),
+           "Generate embedding for a single function by name\n"
+           "Args: funcName (str) - IR-Name of the function\n"
+           "Returns: ndarray[float64] - Function embedding vector");
 
   m.def(
       "initEmbedding",

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -99,9 +99,11 @@ public:
     const Function *FuncPtr = M->getFunction(FuncName);
 
     if (!FuncPtr)
-      throw nb::value_error(("Function '" + FuncName + "' not found in module").c_str());
+      throw nb::value_error(
+          ("Function '" + FuncName + "' not found in module").c_str());
 
-    auto ToolFuncEmb = Tool->getFunctionEmbedding(*FuncPtr, OutputEmbeddingMode);
+    auto ToolFuncEmb =
+        Tool->getFunctionEmbedding(*FuncPtr, OutputEmbeddingMode);
 
     if (!ToolFuncEmb)
       throw nb::value_error(toString(ToolFuncEmb.takeError()).c_str());
@@ -133,8 +135,7 @@ NB_MODULE(ir2vec, m) {
            "Generate function-level embeddings for all functions\n"
            "Returns: dict[str, ndarray[float64]] - "
            "{function_name: embedding}")
-      .def("getFuncEmb", &PyIR2VecTool::getFuncEmb,
-           nb::arg("funcName"),
+      .def("getFuncEmb", &PyIR2VecTool::getFuncEmb, nb::arg("funcName"),
            "Generate embedding for a single function by name\n"
            "Args: funcName (str) - IR-Name of the function\n"
            "Returns: ndarray[float64] - Function embedding vector");

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -76,23 +76,23 @@ public:
     if (!ToolFuncEmbMap)
       throw nb::value_error(toString(ToolFuncEmbMap.takeError()).c_str());
 
-    nb::dict NBFuncEmbMap;
+    nb::dict NbFuncEmbMap;
 
     for (const auto &[FuncPtr, FuncEmb] : *ToolFuncEmbMap) {
       auto FuncEmbVec = FuncEmb.getData();
-      double *NBFuncEmbVec = new double[FuncEmbVec.size()];
-      std::copy(FuncEmbVec.begin(), FuncEmbVec.end(), NBFuncEmbVec);
+      double *NbFuncEmbVec = new double[FuncEmbVec.size()];
+      std::copy(FuncEmbVec.begin(), FuncEmbVec.end(), NbFuncEmbVec);
 
       auto NbArray = nb::ndarray<nb::numpy, double>(
-          NBFuncEmbVec, {FuncEmbVec.size()},
-          nb::capsule(NBFuncEmbVec, [](void *P) noexcept {
+          NbFuncEmbVec, {FuncEmbVec.size()},
+          nb::capsule(NbFuncEmbVec, [](void *P) noexcept {
             delete[] static_cast<double *>(P);
           }));
 
-      NBFuncEmbMap[nb::str(FuncPtr->getName().str().c_str())] = NbArray;
+      NbFuncEmbMap[nb::str(FuncPtr->getName().str().c_str())] = NbArray;
     }
 
-    return NBFuncEmbMap;
+    return NbFuncEmbMap;
   }
 
   nb::ndarray<nb::numpy, double> getFuncEmb(const std::string &FuncName) {
@@ -109,12 +109,12 @@ public:
       throw nb::value_error(toString(ToolFuncEmb.takeError()).c_str());
 
     auto FuncEmbVec = ToolFuncEmb->getData();
-    double *NBFuncEmbVec = new double[FuncEmbVec.size()];
-    std::copy(FuncEmbVec.begin(), FuncEmbVec.end(), NBFuncEmbVec);
+    double *NbFuncEmbVec = new double[FuncEmbVec.size()];
+    std::copy(FuncEmbVec.begin(), FuncEmbVec.end(), NbFuncEmbVec);
 
     auto NbArray = nb::ndarray<nb::numpy, double>(
-        NBFuncEmbVec, {FuncEmbVec.size()},
-        nb::capsule(NBFuncEmbVec, [](void *P) noexcept {
+        NbFuncEmbVec, {FuncEmbVec.size()},
+        nb::capsule(NbFuncEmbVec, [](void *P) noexcept {
           delete[] static_cast<double *>(P);
         }));
 

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -102,8 +102,7 @@ public:
       throw nb::value_error(
           ("Function '" + FuncName + "' not found in module").c_str());
 
-    auto ToolFuncEmb =
-        Tool->getFunctionEmbedding(*F, OutputEmbeddingMode);
+    auto ToolFuncEmb = Tool->getFunctionEmbedding(*F, OutputEmbeddingMode);
 
     if (!ToolFuncEmb)
       throw nb::value_error(toString(ToolFuncEmb.takeError()).c_str());

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -96,14 +96,14 @@ public:
   }
 
   nb::ndarray<nb::numpy, double> getFuncEmb(const std::string &FuncName) {
-    const Function *FuncPtr = M->getFunction(FuncName);
+    const Function *F = M->getFunction(FuncName);
 
-    if (!FuncPtr)
+    if (!F)
       throw nb::value_error(
           ("Function '" + FuncName + "' not found in module").c_str());
 
     auto ToolFuncEmb =
-        Tool->getFunctionEmbedding(*FuncPtr, OutputEmbeddingMode);
+        Tool->getFunctionEmbedding(*F, OutputEmbeddingMode);
 
     if (!ToolFuncEmb)
       throw nb::value_error(toString(ToolFuncEmb.takeError()).c_str());


### PR DESCRIPTION
Adding FuncEmb API to ir2vec python bindings. Provide the IR name of a function, and the API returns the func Embedding for it.


CC - @svkeerthy , @mtrofin, @boomanaiden154 , @nikic 