### PR TITLE
[libc++] Reduce the number of runs on the format_to{,n} and formatted_size benchmarks

### DIFF
--- a/libcxx/test/benchmarks/format/format_to.bench.cpp
+++ b/libcxx/test/benchmarks/format/format_to.bench.cpp
@@ -84,24 +84,24 @@ static void BM_format_to_string_pointer(benchmark::State& state) {
 
 /*** Main ***/
 
-BENCHMARK(BM_format_to_string_back_inserter<std::string>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_back_inserter<std::vector<char>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_back_inserter<std::list<char>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_begin<std::string>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_begin<std::vector<char>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_begin<std::list<char>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_span<char>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_pointer<char>)->RangeMultiplier(2)->Range(1, 1 << 20);
+BENCHMARK(BM_format_to_string_back_inserter<std::string>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_back_inserter<std::vector<char>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_back_inserter<std::list<char>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_begin<std::string>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_begin<std::vector<char>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_begin<std::list<char>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_span<char>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_pointer<char>)->Arg(1)->Arg(16384)->Arg(1048576);
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-BENCHMARK(BM_format_to_string_back_inserter<std::wstring>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_back_inserter<std::vector<wchar_t>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_back_inserter<std::list<wchar_t>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_begin<std::wstring>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_begin<std::vector<wchar_t>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_begin<std::list<wchar_t>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_span<wchar_t>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_string_pointer<wchar_t>)->RangeMultiplier(2)->Range(1, 1 << 20);
+BENCHMARK(BM_format_to_string_back_inserter<std::wstring>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_back_inserter<std::vector<wchar_t>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_back_inserter<std::list<wchar_t>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_begin<std::wstring>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_begin<std::vector<wchar_t>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_begin<std::list<wchar_t>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_span<wchar_t>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_string_pointer<wchar_t>)->Arg(1)->Arg(16384)->Arg(1048576);
 #endif
 
 BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/format/format_to_n.bench.cpp
+++ b/libcxx/test/benchmarks/format/format_to_n.bench.cpp
@@ -84,24 +84,24 @@ static void BM_format_to_n_string_pointer(benchmark::State& state) {
 
 /*** Main ***/
 
-BENCHMARK(BM_format_to_n_string_back_inserter<std::string>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_back_inserter<std::vector<char>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_back_inserter<std::list<char>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_begin<std::string>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_begin<std::vector<char>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_begin<std::list<char>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_span<char>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_pointer<char>)->RangeMultiplier(2)->Range(1, 1 << 20);
+BENCHMARK(BM_format_to_n_string_back_inserter<std::string>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_back_inserter<std::vector<char>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_back_inserter<std::list<char>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_begin<std::string>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_begin<std::vector<char>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_begin<std::list<char>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_span<char>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_pointer<char>)->Arg(1)->Arg(16384)->Arg(1048576);
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-BENCHMARK(BM_format_to_n_string_back_inserter<std::wstring>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_back_inserter<std::vector<wchar_t>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_back_inserter<std::list<wchar_t>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_begin<std::wstring>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_begin<std::vector<wchar_t>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_begin<std::list<wchar_t>>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_span<wchar_t>)->RangeMultiplier(2)->Range(1, 1 << 20);
-BENCHMARK(BM_format_to_n_string_pointer<wchar_t>)->RangeMultiplier(2)->Range(1, 1 << 20);
+BENCHMARK(BM_format_to_n_string_back_inserter<std::wstring>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_back_inserter<std::vector<wchar_t>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_back_inserter<std::list<wchar_t>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_begin<std::wstring>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_begin<std::vector<wchar_t>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_begin<std::list<wchar_t>>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_span<wchar_t>)->Arg(1)->Arg(16384)->Arg(1048576);
+BENCHMARK(BM_format_to_n_string_pointer<wchar_t>)->Arg(1)->Arg(16384)->Arg(1048576);
 #endif
 
 BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/format/formatted_size.bench.cpp
+++ b/libcxx/test/benchmarks/format/formatted_size.bench.cpp
@@ -28,9 +28,9 @@ static void BM_formatted_size_string(benchmark::State& state) {
 
   state.SetBytesProcessed(state.iterations() * size * sizeof(CharT));
 }
-BENCHMARK(BM_formatted_size_string<char>)->RangeMultiplier(2)->Range(1, 1 << 20);
+BENCHMARK(BM_formatted_size_string<char>)->Arg(1)->Arg(16384)->Arg(1048576);
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-BENCHMARK(BM_formatted_size_string<wchar_t>)->RangeMultiplier(2)->Range(1, 1 << 20);
+BENCHMARK(BM_formatted_size_string<wchar_t>)->Arg(1)->Arg(16384)->Arg(1048576);
 #endif
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
Testing a bunch of sizes has relatively little value. This reduces the number of benchmarks so we can run them on a regular basis. This saves ~8 minutes when running the benchmarks.
