### PR TITLE
[NFC][CAS][Unittests] Pass env for MultiProcess tests

### DIFF
--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -23,7 +23,7 @@ using namespace llvm::cas;
 using namespace llvm::cas::ondisk;
 using namespace llvm::sys;
 
-class OnDiskCASLoggerTest: public testing::Test {
+class OnDiskCASLoggerTest : public testing::Test {
   std::vector<StringRef> EnvTable;
   std::vector<std::string> EnvStorage;
 
@@ -212,8 +212,8 @@ TEST_F(OnDiskCASLoggerTest, MultiProcess) {
   SmallVector<ProcessInfo> PIs;
   for (int I = 0; I < 5; ++I) {
     bool ExecutionFailed;
-    auto PI = ExecuteNoWait(Executable, Argv, getEnviron(), {}, 0,
-                            &Error, &ExecutionFailed);
+    auto PI = ExecuteNoWait(Executable, Argv, getEnviron(), {}, 0, &Error,
+                            &ExecutionFailed);
     ASSERT_FALSE(ExecutionFailed) << Error;
     PIs.push_back(std::move(PI));
   }

--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -23,6 +23,58 @@ using namespace llvm::cas;
 using namespace llvm::cas::ondisk;
 using namespace llvm::sys;
 
+class OnDiskCASLoggerTest: public testing::Test {
+  std::vector<StringRef> EnvTable;
+  std::vector<std::string> EnvStorage;
+
+protected:
+  void SetUp() override {
+    auto EnvP = [] {
+#if defined(_WIN32)
+      _wgetenv(L"TMP"); // Populate _wenviron, initially is null
+      return _wenviron;
+#elif defined(__APPLE__)
+      return *_NSGetEnviron();
+#else
+      return environ;
+#endif
+    }();
+    ASSERT_TRUE(EnvP);
+
+    auto prepareEnvVar = [this](decltype(*EnvP) Var) -> StringRef {
+#if defined(_WIN32)
+      // On Windows convert UTF16 encoded variable to UTF8
+      auto Len = wcslen(Var);
+      ArrayRef<char> Ref{reinterpret_cast<char const *>(Var),
+                         Len * sizeof(*Var)};
+      EnvStorage.emplace_back();
+      auto convStatus = llvm::convertUTF16ToUTF8String(Ref, EnvStorage.back());
+      EXPECT_TRUE(convStatus);
+      return EnvStorage.back();
+#else
+      (void)this;
+      return StringRef(Var);
+#endif
+    };
+
+    while (*EnvP != nullptr) {
+      auto S = prepareEnvVar(*EnvP);
+      if (!StringRef(S).starts_with("GTEST_"))
+        EnvTable.emplace_back(S);
+      ++EnvP;
+    }
+  }
+
+  void TearDown() override {
+    EnvTable.clear();
+    EnvStorage.clear();
+  }
+
+  void addEnvVar(StringRef Var) { EnvTable.emplace_back(Var); }
+
+  ArrayRef<StringRef> getEnviron() const { return EnvTable; }
+};
+
 #ifndef _WIN32 // windows doesn't support logging yet.
 
 static void writeToLog(OnDiskCASLogger *Logger, int NumOpens, int NumEntries) {
@@ -97,7 +149,7 @@ static Error checkLog(StringRef Dir) {
   return Error::success();
 }
 
-TEST(OnDiskCASLoggerTest, MultiThread) {
+TEST_F(OnDiskCASLoggerTest, MultiThread) {
   unittest::TempDir Dir("OnDiskCASLoggerTest_MultiThread", /*Unique=*/true);
   llvm::DefaultThreadPool Pool(llvm::hardware_concurrency());
 
@@ -133,7 +185,7 @@ static cl::opt<std::string> CASLogDir("cas-log-dir");
 // From TestMain.cpp.
 extern const char *TestMainArgv0;
 
-TEST(OnDiskCASLoggerTest, MultiProcess) {
+TEST_F(OnDiskCASLoggerTest, MultiProcess) {
   if (!CASLogDir.empty()) {
     // Child process.
     std::unique_ptr<OnDiskCASLogger> Logger;
@@ -160,7 +212,7 @@ TEST(OnDiskCASLoggerTest, MultiProcess) {
   SmallVector<ProcessInfo> PIs;
   for (int I = 0; I < 5; ++I) {
     bool ExecutionFailed;
-    auto PI = ExecuteNoWait(Executable, Argv, ArrayRef<StringRef>{}, {}, 0,
+    auto PI = ExecuteNoWait(Executable, Argv, getEnviron(), {}, 0,
                             &Error, &ExecutionFailed);
     ASSERT_FALSE(ExecutionFailed) << Error;
     PIs.push_back(std::move(PI));

--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/CAS/OnDiskCASLogger.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/LineIterator.h"
 #include "llvm/Support/MemoryBuffer.h"


### PR DESCRIPTION
Set up the test similar to ProgramTest to avoid missing necessary env.

eg: In our downstream build, the process would rely on a shared libs,
the test would fail to find the dependent lib if we don't pass the env
down to multiprocess test.
