### PR TITLE
[clang][bytecode] Check pointer lifetime in CheckDestructor

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1549,6 +1549,8 @@ bool CheckDestructor(InterpState &S, CodePtr OpPC, const Pointer &Ptr) {
     return false;
   if (!CheckRange(S, OpPC, Ptr, AK_Destroy))
     return false;
+  if (!CheckLifetime(S, OpPC, Ptr.getLifetime(), AK_Destroy))
+    return false;
 
   // Can't call a dtor on a global variable.
   if (Ptr.block()->isStatic()) {

--- a/clang/test/AST/ByteCode/records.cpp
+++ b/clang/test/AST/ByteCode/records.cpp
@@ -602,6 +602,15 @@ namespace Destructors {
   }
   static_assert(testS() == 1); // both-error {{not an integral constant expression}} \
                                // both-note {{in call to 'testS()'}}
+
+  struct A { int n; };
+  constexpr void double_destroy() {
+    A a;
+    a.~A();
+    a.~A(); // both-note {{destruction of object outside its lifetime}}
+  }
+  static_assert((double_destroy(), true)); // both-error {{not an integral constant expression}} \
+                                           // both-note {{in call to}}
 }
 
 namespace BaseToDerived {


### PR DESCRIPTION
So we diagnose double-destroy scenarios.