### PR TITLE
[RISCV] Fix P-extension instruction names per spec 0.19

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1269,9 +1269,9 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PNSRAI_H     : RVPNarrowingShiftH_ri<0b100, "pnsrai.h">;
   def NSRAI        : RVPNarrowingShiftW_ri<0b100, "nsrai">;
 
-  def PNSARI_B     : RVPNarrowingShiftB_ri<0b101, "pnsari.b">;
-  def PNSARI_H     : RVPNarrowingShiftH_ri<0b101, "pnsari.h">;
-  def NSARI        : RVPNarrowingShiftW_ri<0b101, "nsari">;
+  def PNSRARI_B    : RVPNarrowingShiftB_ri<0b101, "pnsrari.b">;
+  def PNSRARI_H    : RVPNarrowingShiftH_ri<0b101, "pnsrari.h">;
+  def NSRARI       : RVPNarrowingShiftW_ri<0b101, "nsrari">;
 
   def PNCLIPI_B    : RVPNarrowingShiftB_ri<0b110, "pnclipi.b">;
   def PNCLIPI_H    : RVPNarrowingShiftH_ri<0b110, "pnclipi.h">;
@@ -1435,7 +1435,7 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PSAS_DHX     : RVPPairBinaryExchanged_rr<0b0010, 0b00, "psas.dhx">;
   def PSSA_DHX     : RVPPairBinaryExchanged_rr<0b0010, 0b10, "pssa.dhx">;
 
-  def PAAX_DHX     : RVPPairBinaryExchanged_rr<0b0011, 0b00, "paax.dhx">;
+  def PAAS_DHX     : RVPPairBinaryExchanged_rr<0b0011, 0b00, "paas.dhx">;
   def PASA_DHX     : RVPPairBinaryExchanged_rr<0b0011, 0b10, "pasa.dhx">;
 
   def PMSEQ_DH     : RVPPairBinaryExchanged_rr<0b1000, 0b00, "pmseq.dh", Commutable=1>;

--- a/llvm/test/MC/RISCV/rv32p-valid.s
+++ b/llvm/test/MC/RISCV/rv32p-valid.s
@@ -906,15 +906,15 @@ pnsrai.h s0, a0, 2
 # CHECK-ASM-AND-OBJ: nsrai a4, t3
 # CHECK-ASM: encoding: [0x1b,0xc7,0x4e,0x44]
 nsrai a4, t3, 4
-# CHECK-ASM-AND-OBJ: pnsari.b t5, t5
+# CHECK-ASM-AND-OBJ: pnsrari.b t5, t5
 # CHECK-ASM: encoding: [0x1b,0xcf,0x0f,0x51]
-pnsari.b t5, t5, 0
-# CHECK-ASM-AND-OBJ: pnsari.h t1, a4
+pnsrari.b t5, t5, 0
+# CHECK-ASM-AND-OBJ: pnsrari.h t1, a4
 # CHECK-ASM: encoding: [0x1b,0xc3,0x37,0x52]
-pnsari.h t1, a4, 3
-# CHECK-ASM-AND-OBJ: nsari s0, t1
+pnsrari.h t1, a4, 3
+# CHECK-ASM-AND-OBJ: nsrari s0, t1
 # CHECK-ASM: encoding: [0x1b,0xc4,0x53,0x54]
-nsari s0, t1, 5
+nsrari s0, t1, 5
 # CHECK-ASM-AND-OBJ: pnclipi.b t1, a4
 # CHECK-ASM: encoding: [0x1b,0xc3,0x77,0x61]
 pnclipi.b t1, a4, 7
@@ -1266,9 +1266,9 @@ psas.dhx a2, a2, s0
 # CHECK-ASM-AND-OBJ: pssa.dhx t3, t3, t3
 # CHECK-ASM: encoding: [0x1b,0xee,0xde,0x95]
 pssa.dhx t3, t3, t3
-# CHECK-ASM-AND-OBJ: paax.dhx t3, t3, a4
+# CHECK-ASM-AND-OBJ: paas.dhx t3, t3, a4
 # CHECK-ASM: encoding: [0x1b,0xee,0xfe,0x98]
-paax.dhx t3, t3, a4
+paas.dhx t3, t3, a4
 # CHECK-ASM-AND-OBJ: pasa.dhx a0, t1, t1
 # CHECK-ASM: encoding: [0x1b,0xe5,0x73,0x9c]
 pasa.dhx a0, t1, t1


### PR DESCRIPTION
Fix instruction naming to match P-extension specification 0.19:
- pnsari.b -> pnsrari.b (Packed Narrowing Shift Right Arithmetic Rounding)
- pnsari.h -> pnsrari.h
- nsari -> nsrari
- paax.dhx -> paas.dhx (Packed Average Add/Sub, not Add/Add-Cross)

The instruction encodings remain unchanged as they were already correct.

Ref: https://www.jhauser.us/RISCV/ext-P/RVP-baseInstrs-Sail-019.txt