### PR TITLE
[ExpandIRInsts] Support int bw < float bw in itofp expansion

### DIFF
--- a/llvm/lib/CodeGen/ExpandIRInsts.cpp
+++ b/llvm/lib/CodeGen/ExpandIRInsts.cpp
@@ -742,8 +742,13 @@ static void expandIToFP(Instruction *IToFP) {
   unsigned FloatWidth = PowerOf2Ceil(FPMantissaWidth);
   bool IsSigned = IToFP->getOpcode() == Instruction::SIToFP;
 
-  assert(BitWidth >= FloatWidth && "Unexpected conversion. expandIToFP() "
-                                   "assumes integer width >= fp width.");
+  // The expansion below assumes that int width >= float width. Zero or sign
+  // extend the integer accordingly.
+  if (BitWidth < FloatWidth) {
+    BitWidth = FloatWidth;
+    IntTy = Builder.getIntNTy(BitWidth);
+    IntVal = Builder.CreateIntCast(IntVal, IntTy, IsSigned);
+  }
 
   Value *Temp1 =
       Builder.CreateShl(Builder.getIntN(BitWidth, 1),

--- a/llvm/test/Transforms/ExpandIRInsts/X86/expand-int-convert-small.ll
+++ b/llvm/test/Transforms/ExpandIRInsts/X86/expand-int-convert-small.ll
@@ -76,6 +76,80 @@ define half @uitofp_i32_f16(i32 %x) {
   ret half %res
 }
 
+define half @uitofp_i16_f16(i16 %x) {
+; CHECK-LABEL: define half @uitofp_i16_f16(
+; CHECK-SAME: i16 [[X:%.*]]) {
+; CHECK-NEXT:  [[ITOFP_ENTRY:.*]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = zext i16 [[X]] to i32
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i32 [[TMP0]], 0
+; CHECK-NEXT:    br i1 [[TMP1]], label %[[ITOFP_RETURN:.*]], label %[[ITOFP_IF_END:.*]]
+; CHECK:       [[ITOFP_IF_END]]:
+; CHECK-NEXT:    [[TMP2:%.*]] = ashr i32 [[TMP0]], 31
+; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP2]], [[TMP0]]
+; CHECK-NEXT:    [[TMP4:%.*]] = sub i32 [[TMP3]], [[TMP2]]
+; CHECK-NEXT:    [[TMP5:%.*]] = call i32 @llvm.ctlz.i32(i32 [[TMP0]], i1 true)
+; CHECK-NEXT:    [[TMP6:%.*]] = sub i32 32, [[TMP5]]
+; CHECK-NEXT:    [[TMP7:%.*]] = sub i32 31, [[TMP5]]
+; CHECK-NEXT:    [[TMP8:%.*]] = icmp sgt i32 [[TMP6]], 24
+; CHECK-NEXT:    br i1 [[TMP8]], label %[[ITOFP_IF_THEN4:.*]], label %[[ITOFP_IF_ELSE:.*]]
+; CHECK:       [[ITOFP_IF_THEN4]]:
+; CHECK-NEXT:    switch i32 [[TMP6]], label %[[ITOFP_SW_DEFAULT:.*]] [
+; CHECK-NEXT:      i32 25, label %[[ITOFP_SW_BB:.*]]
+; CHECK-NEXT:      i32 26, label %[[ITOFP_SW_EPILOG:.*]]
+; CHECK-NEXT:    ]
+; CHECK:       [[ITOFP_SW_BB]]:
+; CHECK-NEXT:    [[TMP9:%.*]] = shl i32 [[TMP0]], 1
+; CHECK-NEXT:    br label %[[ITOFP_SW_EPILOG]]
+; CHECK:       [[ITOFP_SW_DEFAULT]]:
+; CHECK-NEXT:    [[TMP10:%.*]] = sub i32 6, [[TMP5]]
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP0]], [[TMP10]]
+; CHECK-NEXT:    [[TMP12:%.*]] = add i32 [[TMP5]], 26
+; CHECK-NEXT:    [[TMP13:%.*]] = lshr i32 -1, [[TMP12]]
+; CHECK-NEXT:    [[TMP14:%.*]] = and i32 [[TMP13]], [[TMP0]]
+; CHECK-NEXT:    [[TMP15:%.*]] = icmp ne i32 [[TMP14]], 0
+; CHECK-NEXT:    [[TMP16:%.*]] = zext i1 [[TMP15]] to i32
+; CHECK-NEXT:    [[TMP17:%.*]] = or i32 [[TMP11]], [[TMP16]]
+; CHECK-NEXT:    br label %[[ITOFP_SW_EPILOG]]
+; CHECK:       [[ITOFP_SW_EPILOG]]:
+; CHECK-NEXT:    [[TMP18:%.*]] = phi i32 [ [[TMP17]], %[[ITOFP_SW_DEFAULT]] ], [ [[TMP0]], %[[ITOFP_IF_THEN4]] ], [ [[TMP9]], %[[ITOFP_SW_BB]] ]
+; CHECK-NEXT:    [[TMP19:%.*]] = lshr i32 [[TMP18]], 2
+; CHECK-NEXT:    [[TMP20:%.*]] = and i32 [[TMP19]], 1
+; CHECK-NEXT:    [[TMP21:%.*]] = or i32 [[TMP18]], [[TMP20]]
+; CHECK-NEXT:    [[TMP22:%.*]] = add i32 [[TMP21]], 1
+; CHECK-NEXT:    [[TMP23:%.*]] = lshr i32 [[TMP22]], 2
+; CHECK-NEXT:    [[A3:%.*]] = and i32 [[TMP22]], 67108864
+; CHECK-NEXT:    [[TMP24:%.*]] = icmp eq i32 [[A3]], 0
+; CHECK-NEXT:    [[TMP25:%.*]] = lshr i32 [[TMP23]], 32
+; CHECK-NEXT:    br i1 [[TMP24]], label %[[ITOFP_IF_END26:.*]], label %[[ITOFP_IF_THEN20:.*]]
+; CHECK:       [[ITOFP_IF_THEN20]]:
+; CHECK-NEXT:    [[TMP26:%.*]] = lshr i32 [[TMP22]], 3
+; CHECK-NEXT:    [[TMP27:%.*]] = lshr i32 [[TMP26]], 32
+; CHECK-NEXT:    br label %[[ITOFP_IF_END26]]
+; CHECK:       [[ITOFP_IF_ELSE]]:
+; CHECK-NEXT:    [[TMP28:%.*]] = add i32 [[TMP5]], -8
+; CHECK-NEXT:    [[TMP29:%.*]] = shl i32 [[TMP0]], [[TMP28]]
+; CHECK-NEXT:    [[TMP30:%.*]] = lshr i32 [[TMP29]], 32
+; CHECK-NEXT:    br label %[[ITOFP_IF_END26]]
+; CHECK:       [[ITOFP_IF_END26]]:
+; CHECK-NEXT:    [[TMP31:%.*]] = phi i32 [ [[TMP26]], %[[ITOFP_IF_THEN20]] ], [ [[TMP23]], %[[ITOFP_SW_EPILOG]] ], [ [[TMP29]], %[[ITOFP_IF_ELSE]] ]
+; CHECK-NEXT:    [[TMP32:%.*]] = phi i32 [ [[TMP6]], %[[ITOFP_IF_THEN20]] ], [ [[TMP7]], %[[ITOFP_SW_EPILOG]] ], [ [[TMP7]], %[[ITOFP_IF_ELSE]] ]
+; CHECK-NEXT:    [[TMP33:%.*]] = and i32 [[TMP2]], -2147483648
+; CHECK-NEXT:    [[TMP34:%.*]] = shl i32 [[TMP32]], 23
+; CHECK-NEXT:    [[TMP35:%.*]] = add i32 [[TMP34]], 1065353216
+; CHECK-NEXT:    [[TMP36:%.*]] = and i32 [[TMP31]], 8388607
+; CHECK-NEXT:    [[TMP37:%.*]] = or i32 [[TMP36]], [[TMP33]]
+; CHECK-NEXT:    [[TMP38:%.*]] = or i32 [[TMP36]], [[TMP35]]
+; CHECK-NEXT:    [[TMP39:%.*]] = bitcast i32 [[TMP38]] to float
+; CHECK-NEXT:    [[TMP40:%.*]] = fptrunc float [[TMP39]] to half
+; CHECK-NEXT:    br label %[[ITOFP_RETURN]]
+; CHECK:       [[ITOFP_RETURN]]:
+; CHECK-NEXT:    [[TMP41:%.*]] = phi half [ [[TMP40]], %[[ITOFP_IF_END26]] ], [ 0xH0000, %[[ITOFP_ENTRY]] ]
+; CHECK-NEXT:    ret half [[TMP41]]
+;
+  %res = uitofp i16 %x to half
+  ret half %res
+}
+
 define half @sitofp_i32_f16(i32 %x) {
 ; CHECK-LABEL: define half @sitofp_i32_f16(
 ; CHECK-SAME: i32 [[X:%.*]]) {
@@ -146,5 +220,79 @@ define half @sitofp_i32_f16(i32 %x) {
 ; CHECK-NEXT:    ret half [[TMP40]]
 ;
   %res = sitofp i32 %x to half
+  ret half %res
+}
+
+define half @sitofp_i16_f16(i16 %x) {
+; CHECK-LABEL: define half @sitofp_i16_f16(
+; CHECK-SAME: i16 [[X:%.*]]) {
+; CHECK-NEXT:  [[ITOFP_ENTRY:.*]]:
+; CHECK-NEXT:    [[TMP1:%.*]] = sext i16 [[X]] to i32
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i32 [[TMP1]], 0
+; CHECK-NEXT:    br i1 [[TMP0]], label %[[ITOFP_RETURN:.*]], label %[[ITOFP_IF_END:.*]]
+; CHECK:       [[ITOFP_IF_END]]:
+; CHECK-NEXT:    [[TMP2:%.*]] = ashr i32 [[TMP1]], 31
+; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP2]], [[TMP1]]
+; CHECK-NEXT:    [[TMP4:%.*]] = sub i32 [[TMP3]], [[TMP2]]
+; CHECK-NEXT:    [[TMP5:%.*]] = call i32 @llvm.ctlz.i32(i32 [[TMP4]], i1 true)
+; CHECK-NEXT:    [[TMP6:%.*]] = sub i32 32, [[TMP5]]
+; CHECK-NEXT:    [[TMP8:%.*]] = sub i32 31, [[TMP5]]
+; CHECK-NEXT:    [[TMP7:%.*]] = icmp sgt i32 [[TMP6]], 24
+; CHECK-NEXT:    br i1 [[TMP7]], label %[[ITOFP_IF_THEN4:.*]], label %[[ITOFP_IF_ELSE:.*]]
+; CHECK:       [[ITOFP_IF_THEN4]]:
+; CHECK-NEXT:    switch i32 [[TMP6]], label %[[ITOFP_SW_DEFAULT:.*]] [
+; CHECK-NEXT:      i32 25, label %[[ITOFP_SW_BB:.*]]
+; CHECK-NEXT:      i32 26, label %[[ITOFP_SW_EPILOG:.*]]
+; CHECK-NEXT:    ]
+; CHECK:       [[ITOFP_SW_BB]]:
+; CHECK-NEXT:    [[TMP9:%.*]] = shl i32 [[TMP4]], 1
+; CHECK-NEXT:    br label %[[ITOFP_SW_EPILOG]]
+; CHECK:       [[ITOFP_SW_DEFAULT]]:
+; CHECK-NEXT:    [[TMP10:%.*]] = sub i32 6, [[TMP5]]
+; CHECK-NEXT:    [[TMP11:%.*]] = lshr i32 [[TMP4]], [[TMP10]]
+; CHECK-NEXT:    [[TMP12:%.*]] = add i32 [[TMP5]], 26
+; CHECK-NEXT:    [[TMP13:%.*]] = lshr i32 -1, [[TMP12]]
+; CHECK-NEXT:    [[TMP14:%.*]] = and i32 [[TMP13]], [[TMP4]]
+; CHECK-NEXT:    [[TMP15:%.*]] = icmp ne i32 [[TMP14]], 0
+; CHECK-NEXT:    [[TMP16:%.*]] = zext i1 [[TMP15]] to i32
+; CHECK-NEXT:    [[TMP17:%.*]] = or i32 [[TMP11]], [[TMP16]]
+; CHECK-NEXT:    br label %[[ITOFP_SW_EPILOG]]
+; CHECK:       [[ITOFP_SW_EPILOG]]:
+; CHECK-NEXT:    [[TMP18:%.*]] = phi i32 [ [[TMP17]], %[[ITOFP_SW_DEFAULT]] ], [ [[TMP4]], %[[ITOFP_IF_THEN4]] ], [ [[TMP9]], %[[ITOFP_SW_BB]] ]
+; CHECK-NEXT:    [[TMP19:%.*]] = lshr i32 [[TMP18]], 2
+; CHECK-NEXT:    [[TMP20:%.*]] = and i32 [[TMP19]], 1
+; CHECK-NEXT:    [[TMP21:%.*]] = or i32 [[TMP18]], [[TMP20]]
+; CHECK-NEXT:    [[TMP22:%.*]] = add i32 [[TMP21]], 1
+; CHECK-NEXT:    [[TMP24:%.*]] = ashr i32 [[TMP22]], 2
+; CHECK-NEXT:    [[A3:%.*]] = and i32 [[TMP22]], 67108864
+; CHECK-NEXT:    [[TMP23:%.*]] = icmp eq i32 [[A3]], 0
+; CHECK-NEXT:    [[TMP25:%.*]] = lshr i32 [[TMP24]], 32
+; CHECK-NEXT:    br i1 [[TMP23]], label %[[ITOFP_IF_END26:.*]], label %[[ITOFP_IF_THEN20:.*]]
+; CHECK:       [[ITOFP_IF_THEN20]]:
+; CHECK-NEXT:    [[TMP26:%.*]] = ashr i32 [[TMP22]], 3
+; CHECK-NEXT:    [[TMP27:%.*]] = lshr i32 [[TMP26]], 32
+; CHECK-NEXT:    br label %[[ITOFP_IF_END26]]
+; CHECK:       [[ITOFP_IF_ELSE]]:
+; CHECK-NEXT:    [[TMP28:%.*]] = add i32 [[TMP5]], -8
+; CHECK-NEXT:    [[TMP29:%.*]] = shl i32 [[TMP4]], [[TMP28]]
+; CHECK-NEXT:    [[TMP30:%.*]] = lshr i32 [[TMP29]], 32
+; CHECK-NEXT:    br label %[[ITOFP_IF_END26]]
+; CHECK:       [[ITOFP_IF_END26]]:
+; CHECK-NEXT:    [[TMP31:%.*]] = phi i32 [ [[TMP26]], %[[ITOFP_IF_THEN20]] ], [ [[TMP24]], %[[ITOFP_SW_EPILOG]] ], [ [[TMP29]], %[[ITOFP_IF_ELSE]] ]
+; CHECK-NEXT:    [[TMP32:%.*]] = phi i32 [ [[TMP6]], %[[ITOFP_IF_THEN20]] ], [ [[TMP8]], %[[ITOFP_SW_EPILOG]] ], [ [[TMP8]], %[[ITOFP_IF_ELSE]] ]
+; CHECK-NEXT:    [[TMP33:%.*]] = and i32 [[TMP2]], -2147483648
+; CHECK-NEXT:    [[TMP34:%.*]] = shl i32 [[TMP32]], 23
+; CHECK-NEXT:    [[TMP35:%.*]] = add i32 [[TMP34]], 1065353216
+; CHECK-NEXT:    [[TMP36:%.*]] = and i32 [[TMP31]], 8388607
+; CHECK-NEXT:    [[TMP37:%.*]] = or i32 [[TMP36]], [[TMP33]]
+; CHECK-NEXT:    [[TMP41:%.*]] = or i32 [[TMP37]], [[TMP35]]
+; CHECK-NEXT:    [[TMP38:%.*]] = bitcast i32 [[TMP41]] to float
+; CHECK-NEXT:    [[TMP39:%.*]] = fptrunc float [[TMP38]] to half
+; CHECK-NEXT:    br label %[[ITOFP_RETURN]]
+; CHECK:       [[ITOFP_RETURN]]:
+; CHECK-NEXT:    [[TMP40:%.*]] = phi half [ [[TMP39]], %[[ITOFP_IF_END26]] ], [ 0xH0000, %[[ITOFP_ENTRY]] ]
+; CHECK-NEXT:    ret half [[TMP40]]
+;
+  %res = sitofp i16 %x to half
   ret half %res
 }


### PR DESCRIPTION
Handle this case by extending the integer to a wider type. This can probably be handled more optimally, but this is conservatively correct.

Proof: https://alive2.llvm.org/ce/z/0RwDO1