### PR TITLE
[MC] Return const FeatureBitset& from MCSubtargetInfo::ToggleFeature/SetFeatureBitsTransitively/ClearFeatureBitsTransitively

### DIFF
--- a/llvm/include/llvm/MC/MCSubtargetInfo.h
+++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
@@ -137,23 +137,23 @@ public:
 
   /// Toggle a feature and return the re-computed feature bits.
   /// This version does not change the implied bits.
-  FeatureBitset ToggleFeature(uint64_t FB);
+  const FeatureBitset &ToggleFeature(uint64_t FB);
 
   /// Toggle a feature and return the re-computed feature bits.
   /// This version does not change the implied bits.
-  FeatureBitset ToggleFeature(const FeatureBitset& FB);
+  const FeatureBitset &ToggleFeature(const FeatureBitset& FB);
 
   /// Toggle a set of features and return the re-computed feature bits.
   /// This version will also change all implied bits.
-  FeatureBitset ToggleFeature(StringRef FS);
+  const FeatureBitset &ToggleFeature(StringRef FS);
 
   /// Apply a feature flag and return the re-computed feature bits, including
   /// all feature bits implied by the flag.
-  FeatureBitset ApplyFeatureFlag(StringRef FS);
+  const FeatureBitset &ApplyFeatureFlag(StringRef FS);
 
   /// Set/clear additional feature bits, including all other bits they imply.
-  FeatureBitset SetFeatureBitsTransitively(const FeatureBitset& FB);
-  FeatureBitset ClearFeatureBitsTransitively(const FeatureBitset &FB);
+  const FeatureBitset &SetFeatureBitsTransitively(const FeatureBitset& FB);
+  const FeatureBitset &ClearFeatureBitsTransitively(const FeatureBitset &FB);
 
   /// Check whether the subtarget features are enabled/disabled as per
   /// the provided string, ignoring all other features.

--- a/llvm/include/llvm/MC/MCSubtargetInfo.h
+++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
@@ -141,7 +141,7 @@ public:
 
   /// Toggle a feature and return the re-computed feature bits.
   /// This version does not change the implied bits.
-  const FeatureBitset &ToggleFeature(const FeatureBitset& FB);
+  const FeatureBitset &ToggleFeature(const FeatureBitset &FB);
 
   /// Toggle a set of features and return the re-computed feature bits.
   /// This version will also change all implied bits.
@@ -152,7 +152,7 @@ public:
   const FeatureBitset &ApplyFeatureFlag(StringRef FS);
 
   /// Set/clear additional feature bits, including all other bits they imply.
-  const FeatureBitset &SetFeatureBitsTransitively(const FeatureBitset& FB);
+  const FeatureBitset &SetFeatureBitsTransitively(const FeatureBitset &FB);
   const FeatureBitset &ClearFeatureBitsTransitively(const FeatureBitset &FB);
 
   /// Check whether the subtarget features are enabled/disabled as per

--- a/llvm/lib/MC/MCSubtargetInfo.cpp
+++ b/llvm/lib/MC/MCSubtargetInfo.cpp
@@ -269,14 +269,14 @@ const FeatureBitset &MCSubtargetInfo::ToggleFeature(const FeatureBitset &FB) {
   return FeatureBits;
 }
 
-const FeatureBitset &MCSubtargetInfo::SetFeatureBitsTransitively(
-  const FeatureBitset &FB) {
+const FeatureBitset &
+MCSubtargetInfo::SetFeatureBitsTransitively(const FeatureBitset &FB) {
   SetImpliedBits(FeatureBits, FB, ProcFeatures);
   return FeatureBits;
 }
 
-const FeatureBitset &MCSubtargetInfo::ClearFeatureBitsTransitively(
-  const FeatureBitset &FB) {
+const FeatureBitset &
+MCSubtargetInfo::ClearFeatureBitsTransitively(const FeatureBitset &FB) {
   for (unsigned I = 0, E = FB.size(); I < E; I++) {
     if (FB[I]) {
       FeatureBits.reset(I);

--- a/llvm/lib/MC/MCSubtargetInfo.cpp
+++ b/llvm/lib/MC/MCSubtargetInfo.cpp
@@ -259,23 +259,23 @@ MCSubtargetInfo::MCSubtargetInfo(
   InitMCProcessorInfo(CPU, TuneCPU, FS);
 }
 
-FeatureBitset MCSubtargetInfo::ToggleFeature(uint64_t FB) {
+const FeatureBitset &MCSubtargetInfo::ToggleFeature(uint64_t FB) {
   FeatureBits.flip(FB);
   return FeatureBits;
 }
 
-FeatureBitset MCSubtargetInfo::ToggleFeature(const FeatureBitset &FB) {
+const FeatureBitset &MCSubtargetInfo::ToggleFeature(const FeatureBitset &FB) {
   FeatureBits ^= FB;
   return FeatureBits;
 }
 
-FeatureBitset MCSubtargetInfo::SetFeatureBitsTransitively(
+const FeatureBitset &MCSubtargetInfo::SetFeatureBitsTransitively(
   const FeatureBitset &FB) {
   SetImpliedBits(FeatureBits, FB, ProcFeatures);
   return FeatureBits;
 }
 
-FeatureBitset MCSubtargetInfo::ClearFeatureBitsTransitively(
+const FeatureBitset &MCSubtargetInfo::ClearFeatureBitsTransitively(
   const FeatureBitset &FB) {
   for (unsigned I = 0, E = FB.size(); I < E; I++) {
     if (FB[I]) {
@@ -286,7 +286,7 @@ FeatureBitset MCSubtargetInfo::ClearFeatureBitsTransitively(
   return FeatureBits;
 }
 
-FeatureBitset MCSubtargetInfo::ToggleFeature(StringRef Feature) {
+const FeatureBitset &MCSubtargetInfo::ToggleFeature(StringRef Feature) {
   // Find feature in table.
   const SubtargetFeatureKV *FeatureEntry =
       Find(SubtargetFeatures::StripFlag(Feature), ProcFeatures);
@@ -311,7 +311,7 @@ FeatureBitset MCSubtargetInfo::ToggleFeature(StringRef Feature) {
   return FeatureBits;
 }
 
-FeatureBitset MCSubtargetInfo::ApplyFeatureFlag(StringRef FS) {
+const FeatureBitset &MCSubtargetInfo::ApplyFeatureFlag(StringRef FS) {
   ::ApplyFeatureFlag(FeatureBits, FS, ProcFeatures);
   return FeatureBits;
 }


### PR DESCRIPTION
These functions were returning a copy of an MCSubtargetInfo member after updating. This a convenience for some callers to avoid needing to call getFeatureBits(). Not all callers use the returned value and some just pass it on to a function that wants a reference.

FeatureBitset is currently 48 bytes. Return a reference so we don't speculatively copy it. Callers can make a copy if necessary.