### PR TITLE
[InstCombine] Fold min/max(fpext x, C) to fpext(min/max(x, fptrunc C))

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -4748,6 +4748,17 @@ Constant *llvm::getLosslessInvCast(Constant *C, Type *InvCastTo,
     }
     return InvC;
   }
+  case Instruction::FPExt: {
+    Constant *InvC =
+        ConstantFoldCastOperand(Instruction::FPTrunc, C, InvCastTo, DL);
+    if (InvC) {
+      Constant *CastInvC =
+          ConstantFoldCastOperand(CastOp, InvC, C->getType(), DL);
+      if (CastInvC == C)
+        return InvC;
+    }
+    return nullptr;
+  }
   default:
     return nullptr;
   }

--- a/llvm/test/Transforms/InstCombine/minnum.ll
+++ b/llvm/test/Transforms/InstCombine/minnum.ll
@@ -488,9 +488,7 @@ define float @reduce_precision_multi_use_2(float %x, float %y, ptr %p, ptr %p2) 
 
 define float @reduce_precision_const(float %x) {
 ; CHECK-LABEL: @reduce_precision_const(
-; CHECK-NEXT:    [[X_EXT:%.*]] = fpext float [[X:%.*]] to double
-; CHECK-NEXT:    [[MINNUM:%.*]] = call double @llvm.minnum.f64(double [[X_EXT]], double 1.000000e+00)
-; CHECK-NEXT:    [[TRUNC:%.*]] = fptrunc double [[MINNUM]] to float
+; CHECK-NEXT:    [[TRUNC:%.*]] = call float @llvm.minnum.f32(float [[X:%.*]], float 1.000000e+00)
 ; CHECK-NEXT:    ret float [[TRUNC]]
 ;
   %x.ext = fpext float %x to double

--- a/llvm/test/Transforms/InstCombine/minnum.ll
+++ b/llvm/test/Transforms/InstCombine/minnum.ll
@@ -486,6 +486,47 @@ define float @reduce_precision_multi_use_2(float %x, float %y, ptr %p, ptr %p2) 
   ret float %trunc
 }
 
+define float @reduce_precision_const(float %x) {
+; CHECK-LABEL: @reduce_precision_const(
+; CHECK-NEXT:    [[X_EXT:%.*]] = fpext float [[X:%.*]] to double
+; CHECK-NEXT:    [[MINNUM:%.*]] = call double @llvm.minnum.f64(double [[X_EXT]], double 1.000000e+00)
+; CHECK-NEXT:    [[TRUNC:%.*]] = fptrunc double [[MINNUM]] to float
+; CHECK-NEXT:    ret float [[TRUNC]]
+;
+  %x.ext = fpext float %x to double
+  %minnum = call double @llvm.minnum.f64(double %x.ext, double 1.0)
+  %trunc = fptrunc double %minnum to float
+  ret float %trunc
+}
+
+define float @reduce_precision_const_not_lossless(float %x) {
+; CHECK-LABEL: @reduce_precision_const_not_lossless(
+; CHECK-NEXT:    [[X_EXT:%.*]] = fpext float [[X:%.*]] to double
+; CHECK-NEXT:    [[MINNUM:%.*]] = call double @llvm.minnum.f64(double [[X_EXT]], double 1.000000e-01)
+; CHECK-NEXT:    [[TRUNC:%.*]] = fptrunc double [[MINNUM]] to float
+; CHECK-NEXT:    ret float [[TRUNC]]
+;
+  %x.ext = fpext float %x to double
+  %minnum = call double @llvm.minnum.f64(double %x.ext, double 0.1)
+  %trunc = fptrunc double %minnum to float
+  ret float %trunc
+}
+
+define float @reduce_precision_const_multi_use(float %x) {
+; CHECK-LABEL: @reduce_precision_const_multi_use(
+; CHECK-NEXT:    [[X_EXT:%.*]] = fpext float [[X:%.*]] to double
+; CHECK-NEXT:    call void @use(double [[X_EXT]])
+; CHECK-NEXT:    [[MINNUM:%.*]] = call double @llvm.minnum.f64(double [[X_EXT]], double 1.000000e+00)
+; CHECK-NEXT:    [[TRUNC:%.*]] = fptrunc double [[MINNUM]] to float
+; CHECK-NEXT:    ret float [[TRUNC]]
+;
+  %x.ext = fpext float %x to double
+  call void @use(double %x.ext)
+  %minnum = call double @llvm.minnum.f64(double %x.ext, double 1.0)
+  %trunc = fptrunc double %minnum to float
+  ret float %trunc
+}
+
 define float @negated_op(float %x) {
 ; CHECK-LABEL: @negated_op(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call float @llvm.fabs.f32(float [[X:%.*]])


### PR DESCRIPTION
Fold `min/max(fpext x, C)` to `fpext(min/max(x, fptrunc C))` in cases where the truncation of the constant is lossless.

This helps eliminate fpext/fptrunc pairs around min/max and addresses the regression from https://github.com/llvm/llvm-project/pull/177988.

Proof: https://alive2.llvm.org/ce/z/y_Bcdd