### PR TITLE
[lldb] Quit automatically if --batch has no commands to run

### DIFF
--- a/lldb/test/API/driver/batch_mode/TestBatchMode.py
+++ b/lldb/test/API/driver/batch_mode/TestBatchMode.py
@@ -4,6 +4,7 @@ Test that the lldb driver's batch mode works correctly.
 
 
 import lldb
+import subprocess
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
@@ -12,6 +13,24 @@ from lldbsuite.test.lldbpexpect import PExpectTest
 
 class DriverBatchModeTest(PExpectTest):
     source = "main.c"
+
+    @skipIfRemote
+    def test_batch_mode_no_commands_quits(self):
+        """--batch should immediately quit if there are no commands given."""
+        try:
+            proc = subprocess.run(
+                [lldbtest_config.lldbExec, "--batch"],
+                timeout=60,
+                stdout=subprocess.PIPE,
+                text=True,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("lldb did not quit automatically.")
+
+        # Exit succesfully.
+        self.assertEqual(proc.returncode, 0)
+        # No prompt printed.
+        self.assertEqual(proc.stdout, "")
 
     @skipIf(macos_version=["<", "14.0"], asan=True)
     @skipIf(oslist=["linux"], archs=["arm$", "aarch64"])  # Randomly fails on buildbot

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -672,6 +672,7 @@ int Driver::MainLoop() {
     if (m_option_data.m_batch &&
         results.GetResult() == lldb::eCommandInterpreterResultInferiorCrash &&
         !m_option_data.m_after_crash_commands.empty()) {
+      go_interactive = true;
       SBStream crash_commands_stream;
       WriteCommandsForSourcing(eCommandPlacementAfterCrash,
                                crash_commands_stream);

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -634,7 +634,7 @@ int Driver::MainLoop() {
   // Check if we have any data in the commands stream, and if so, save it to a
   // temp file
   // so we can then run the command interpreter using the file contents.
-  bool go_interactive = true;
+  bool go_interactive = !m_option_data.m_batch;
   if ((commands_stream.GetData() != nullptr) &&
       (commands_stream.GetSize() != 0u)) {
     SBError error = m_debugger.SetInputString(commands_stream.GetData());


### PR DESCRIPTION
Fixes #179700

Simple fix, if we are in batch mode, don't go into an interactive session after checking if there are commands to run.

Testing it is more tricky. I tried a shell test as I thought it would be simplest. However to be able to FileCheck I had to pipe and the pipe turns off the prompt because it's non-interactive. The prompt is the thing that must not be printed.

So I've just spawned lldb as a subprocess. If it doesn't quit quickly then something is wrong. The timeout is high not because it should normally take that long, but because sometimes a process will get stalled for a while and I don't want this to be flaky.

(though in theory it can get stalled for much longer than a minute)

If it does time out, the process will be cleaned up automatically. See https://docs.python.org/3/library/subprocess.html#subprocess.run

> A timeout may be specified in seconds, it is internally
> passed on to Popen.communicate(). If the timeout expires,
> the child process will be killed and waited for.