### PR TITLE
[CIR][NFC] Remove LowerModule from LowerToLLVM

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -268,10 +268,8 @@ class CIRAttrToValue {
 public:
   CIRAttrToValue(mlir::Operation *parentOp,
                  mlir::ConversionPatternRewriter &rewriter,
-                 const mlir::TypeConverter *converter,
-                 cir::LowerModule *lowerMod)
-      : parentOp(parentOp), rewriter(rewriter), converter(converter),
-        lowerMod(lowerMod) {}
+                 const mlir::TypeConverter *converter)
+      : parentOp(parentOp), rewriter(rewriter), converter(converter) {}
 
   mlir::Value visit(mlir::Attribute attr) {
     return llvm::TypeSwitch<mlir::Attribute, mlir::Value>(attr)
@@ -300,16 +298,14 @@ private:
   mlir::Operation *parentOp;
   mlir::ConversionPatternRewriter &rewriter;
   const mlir::TypeConverter *converter;
-  [[maybe_unused]] cir::LowerModule *lowerMod;
 };
 
 /// Switches on the type of attribute and calls the appropriate conversion.
 mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp,
                                 const mlir::Attribute attr,
                                 mlir::ConversionPatternRewriter &rewriter,
-                                const mlir::TypeConverter *converter,
-                                cir::LowerModule *lowerMod) {
-  CIRAttrToValue valueConverter(parentOp, rewriter, converter, lowerMod);
+                                const mlir::TypeConverter *converter) {
+  CIRAttrToValue valueConverter(parentOp, rewriter, converter);
   mlir::Value value = valueConverter.visit(attr);
   if (!value)
     llvm_unreachable("unhandled attribute type");
@@ -1895,8 +1891,7 @@ mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
     }
     // Lower GlobalViewAttr to llvm.mlir.addressof
     if (auto gv = mlir::dyn_cast<cir::GlobalViewAttr>(op.getValue())) {
-      auto newOp =
-          lowerCirAttrAsValue(op, gv, rewriter, getTypeConverter(), lowerMod);
+      auto newOp = lowerCirAttrAsValue(op, gv, rewriter, getTypeConverter());
       rewriter.replaceOp(op, newOp);
       return mlir::success();
     }
@@ -1908,33 +1903,32 @@ mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
 
     std::optional<mlir::Attribute> denseAttr;
     if (constArr && hasTrailingZeros(constArr)) {
-      const mlir::Value newOp = lowerCirAttrAsValue(
-          op, constArr, rewriter, getTypeConverter(), lowerMod);
+      const mlir::Value newOp =
+          lowerCirAttrAsValue(op, constArr, rewriter, getTypeConverter());
       rewriter.replaceOp(op, newOp);
       return mlir::success();
     } else if (constArr &&
                (denseAttr = lowerConstArrayAttr(constArr, typeConverter))) {
       attr = denseAttr.value();
     } else {
-      const mlir::Value initVal = lowerCirAttrAsValue(
-          op, op.getValue(), rewriter, typeConverter, lowerMod);
+      const mlir::Value initVal =
+          lowerCirAttrAsValue(op, op.getValue(), rewriter, typeConverter);
       rewriter.replaceOp(op, initVal);
       return mlir::success();
     }
   } else if (const auto recordAttr =
                  mlir::dyn_cast<cir::ConstRecordAttr>(op.getValue())) {
-    auto initVal =
-        lowerCirAttrAsValue(op, recordAttr, rewriter, typeConverter, lowerMod);
+    auto initVal = lowerCirAttrAsValue(op, recordAttr, rewriter, typeConverter);
     rewriter.replaceOp(op, initVal);
     return mlir::success();
   } else if (const auto vecTy = mlir::dyn_cast<cir::VectorType>(op.getType())) {
     rewriter.replaceOp(op, lowerCirAttrAsValue(op, op.getValue(), rewriter,
-                                               getTypeConverter(), lowerMod));
+                                               getTypeConverter()));
     return mlir::success();
   } else if (auto recTy = mlir::dyn_cast<cir::RecordType>(op.getType())) {
     if (mlir::isa<cir::ZeroAttr, cir::UndefAttr>(attr)) {
       mlir::Value initVal =
-          lowerCirAttrAsValue(op, attr, rewriter, typeConverter, lowerMod);
+          lowerCirAttrAsValue(op, attr, rewriter, typeConverter);
       rewriter.replaceOp(op, initVal);
       return mlir::success();
     }
@@ -2292,7 +2286,7 @@ CIRToLLVMGlobalOpLowering::matchAndRewriteRegionInitializedGlobal(
   // to the appropriate value.
   const mlir::Location loc = op.getLoc();
   setupRegionInitializedLLVMGlobalOp(op, rewriter);
-  CIRAttrToValue valueConverter(op, rewriter, typeConverter, lowerMod);
+  CIRAttrToValue valueConverter(op, rewriter, typeConverter);
   mlir::Value value = valueConverter.visit(init);
   mlir::LLVM::ReturnOp::create(rewriter, loc, value);
   return mlir::success();
@@ -3025,8 +3019,7 @@ mlir::LogicalResult CIRToLLVMSelectOpLowering::matchAndRewrite(
 }
 
 static void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
-                                 mlir::DataLayout &dataLayout,
-                                 cir::LowerModule *lowerModule) {
+                                 mlir::DataLayout &dataLayout) {
   converter.addConversion([&](cir::PointerType type) -> mlir::Type {
     unsigned addrSpace =
         type.getAddrSpace() ? type.getAddrSpace().getValue().getUInt() : 0;
@@ -3324,9 +3317,7 @@ void ConvertCIRToLLVMPass::runOnOperation() {
   mlir::ModuleOp module = getOperation();
   mlir::DataLayout dl(module);
   mlir::LLVMTypeConverter converter(&getContext());
-  std::unique_ptr<cir::LowerModule> lowerModule =
-      cir::createLowerModule(module);
-  prepareTypeConverter(converter, dl, lowerModule.get());
+  prepareTypeConverter(converter, dl);
 
   /// Tracks the state required to lower CIR `LabelOp` and `BlockAddressOp`.
   /// Maps labels to their corresponding `BlockTagOp` and keeps bookkeeping
@@ -3335,13 +3326,13 @@ void ConvertCIRToLLVMPass::runOnOperation() {
   LLVMBlockAddressInfo blockInfoAddr;
   mlir::RewritePatternSet patterns(&getContext());
   patterns.add<CIRToLLVMBlockAddressOpLowering, CIRToLLVMLabelOpLowering>(
-      converter, patterns.getContext(), lowerModule.get(), dl, blockInfoAddr);
+      converter, patterns.getContext(), dl, blockInfoAddr);
 
   patterns.add<
 #define GET_LLVM_LOWERING_PATTERNS_LIST
 #include "clang/CIR/Dialect/IR/CIRLowering.inc"
 #undef GET_LLVM_LOWERING_PATTERNS_LIST
-      >(converter, patterns.getContext(), lowerModule.get(), dl);
+      >(converter, patterns.getContext(), dl);
 
   processCIRAttrs(module);
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -12,8 +12,6 @@
 #ifndef CLANG_CIR_LOWERTOLLVM_H
 #define CLANG_CIR_LOWERTOLLVM_H
 
-#include "LowerModule.h"
-
 #include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Transforms/DialectConversion.h"

--- a/clang/utils/TableGen/CIRLoweringEmitter.cpp
+++ b/clang/utils/TableGen/CIRLoweringEmitter.cpp
@@ -140,7 +140,6 @@ void GenerateLLVMLoweringPattern(llvm::StringRef OpName,
 
   Code << "class " << PatternName
        << " : public mlir::OpConversionPattern<cir::" << OpName << "> {\n";
-  Code << "  [[maybe_unused]] cir::LowerModule *lowerMod;\n";
   Code << "  [[maybe_unused]] mlir::DataLayout const &dataLayout;\n";
 
   if (CustomCtor) {
@@ -156,10 +155,8 @@ void GenerateLLVMLoweringPattern(llvm::StringRef OpName,
 
   // Constructor
   Code << "  " << PatternName
-       << "(mlir::TypeConverter const "
-          "&typeConverter, mlir::MLIRContext *context, "
-          "cir::LowerModule *lowerMod, mlir::DataLayout const "
-          "&dataLayout";
+       << "(const mlir::TypeConverter &typeConverter, "
+          "mlir::MLIRContext *context, const mlir::DataLayout &dataLayout";
 
   if (CustomCtor)
     emitCustomParamList(Code, CustomCtor->Params);
@@ -167,8 +164,7 @@ void GenerateLLVMLoweringPattern(llvm::StringRef OpName,
   Code << ")\n";
 
   Code << "    : OpConversionPattern<cir::" << OpName
-       << ">(typeConverter, context), lowerMod(lowerMod), "
-          "dataLayout(dataLayout)";
+       << ">(typeConverter, context), dataLayout(dataLayout)";
 
   if (CustomCtor)
     emitCustomInitList(Code, CustomCtor->Params);


### PR DESCRIPTION
This patch removes `cir::LowerModule` from the `LowerToLLVM` pass.