### PR TITLE
[lldb] Remove --debug/-d option from lldb

### DIFF
--- a/lldb/tools/driver/Options.td
+++ b/lldb/tools/driver/Options.td
@@ -240,9 +240,4 @@ def arch : Separate<["--", "-"], "arch">,
                     "starting and running the program.">;
 def : Separate<["-"], "a">, Alias<arch>, HelpText<"Alias for --arch">;
 
-def debug : F<"debug">,
-            HelpText<"Tells the debugger to print out extra information for "
-                     "debugging itself.">;
-def : Flag<["-"], "d">, Alias<debug>, HelpText<"Alias for --debug">;
-
 def REM : R<["--"], "">;


### PR DESCRIPTION
The functionality was removed in d3173f4ab61c17337908eb7df3f1c515ddcd428c after being broken for a long time.

There's a small risk someone is still passing the option, but I think it's time to remove it and they can fix their scripts.