### PR TITLE
[libc++][test] Include `<ios>` and `<ctime>` in tests for `time` locale facets

### DIFF
--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_date.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_date.pass.cpp
@@ -24,6 +24,7 @@
 
 #include <cassert>
 #include <ctime>
+#include <ios>
 #include <locale>
 
 #include "test_macros.h"

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_date_wide.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_date_wide.pass.cpp
@@ -24,8 +24,11 @@
 // get_date(iter_type s, iter_type end, ios_base& str,
 //          ios_base::iostate& err, tm* t) const;
 
-#include <locale>
 #include <cassert>
+#include <ctime>
+#include <ios>
+#include <locale>
+
 #include "test_macros.h"
 #include "test_iterators.h"
 

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_monthname.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_monthname.pass.cpp
@@ -22,6 +22,7 @@
 
 #include <cassert>
 #include <ctime>
+#include <ios>
 #include <locale>
 
 #include "test_macros.h"

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_monthname_wide.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_monthname_wide.pass.cpp
@@ -21,8 +21,11 @@
 // get_monthname(iter_type s, iter_type end, ios_base& str,
 //               ios_base::iostate& err, tm* t) const;
 
-#include <locale>
 #include <cassert>
+#include <ctime>
+#include <ios>
+#include <locale>
+
 #include "test_macros.h"
 #include "test_iterators.h"
 

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_one.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_one.pass.cpp
@@ -25,6 +25,7 @@
 
 #include <cassert>
 #include <ctime>
+#include <ios>
 #include <locale>
 
 #include "test_macros.h"

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_one_wide.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_one_wide.pass.cpp
@@ -25,8 +25,11 @@
 // iter_type get(iter_type s, iter_type end, ios_base& f,
 //               ios_base::iostate& err, tm *t, char format, char modifier = 0) const;
 
-#include <locale>
 #include <cassert>
+#include <ctime>
+#include <ios>
+#include <locale>
+
 #include "test_macros.h"
 #include "test_iterators.h"
 

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_weekday.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_weekday.pass.cpp
@@ -21,6 +21,7 @@
 
 #include <cassert>
 #include <ctime>
+#include <ios>
 #include <locale>
 
 #include "test_macros.h"

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_weekday_wide.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get.byname/get_weekday_wide.pass.cpp
@@ -21,8 +21,11 @@
 // get_weekday(iter_type s, iter_type end, ios_base& str,
 //             ios_base::iostate& err, tm* t) const;
 
-#include <locale>
 #include <cassert>
+#include <ctime>
+#include <ios>
+#include <locale>
+
 #include "test_macros.h"
 #include "test_iterators.h"
 

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_monthname.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_monthname.pass.cpp
@@ -16,6 +16,7 @@
 
 #include <cassert>
 #include <ctime>
+#include <ios>
 #include <locale>
 
 #include "test_macros.h"

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_monthname_wide.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_monthname_wide.pass.cpp
@@ -16,8 +16,11 @@
 
 // XFAIL: no-wide-characters
 
-#include <locale>
 #include <cassert>
+#include <ctime>
+#include <ios>
+#include <locale>
+
 #include "test_macros.h"
 #include "test_iterators.h"
 

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_one.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_one.pass.cpp
@@ -15,6 +15,7 @@
 
 #include <cassert>
 #include <ctime>
+#include <ios>
 #include <locale>
 
 #include "test_macros.h"

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_time.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_time.pass.cpp
@@ -16,6 +16,7 @@
 
 #include <cassert>
 #include <ctime>
+#include <ios>
 #include <locale>
 
 #include "test_macros.h"

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_time_wide.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_time_wide.pass.cpp
@@ -16,8 +16,11 @@
 
 // XFAIL: no-wide-characters
 
-#include <locale>
 #include <cassert>
+#include <ctime>
+#include <ios>
+#include <locale>
+
 #include "test_macros.h"
 #include "test_iterators.h"
 

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_weekday.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_weekday.pass.cpp
@@ -16,6 +16,7 @@
 
 #include <cassert>
 #include <ctime>
+#include <ios>
 #include <locale>
 
 #include "test_macros.h"

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_weekday_wide.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_weekday_wide.pass.cpp
@@ -16,8 +16,11 @@
 
 // XFAIL: no-wide-characters
 
-#include <locale>
 #include <cassert>
+#include <ctime>
+#include <ios>
+#include <locale>
+
 #include "test_macros.h"
 #include "test_iterators.h"
 

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.put.byname/put1.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.put.byname/put1.pass.cpp
@@ -29,8 +29,11 @@
 //     ~time_put_byname();
 // };
 
-#include <locale>
 #include <cassert>
+#include <ctime>
+#include <ios>
+#include <locale>
+
 #include "test_macros.h"
 #include "test_iterators.h"
 

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.put.byname/put1.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.put.byname/put1.pass.cpp
@@ -52,7 +52,7 @@ public:
 int main(int, char**)
 {
     char str[200];
-    tm t;
+    std::tm t;
     t.tm_sec = 6;
     t.tm_min = 3;
     t.tm_hour = 13;

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put1.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put1.pass.cpp
@@ -35,7 +35,7 @@ int main(int, char**)
 {
     const my_facet f(1);
     char str[200];
-    tm t;
+    std::tm t;
     t.tm_sec = 6;
     t.tm_min = 3;
     t.tm_hour = 13;

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put1.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put1.pass.cpp
@@ -13,9 +13,11 @@
 // iter_type put(iter_type s, ios_base& str, char_type fill, const tm* t,
 //               const charT* pattern, const charT* pat_end) const;
 
-#include <locale>
 #include <cassert>
+#include <ctime>
 #include <ios>
+#include <locale>
+
 #include "test_macros.h"
 #include "test_iterators.h"
 

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put2.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put2.pass.cpp
@@ -13,8 +13,11 @@
 // iter_type put(iter_type s, ios_base& str, char_type fill, const tm* t,
 //               char format, char modifier = 0) const;
 
-#include <locale>
 #include <cassert>
+#include <ctime>
+#include <ios>
+#include <locale>
+
 #include "test_macros.h"
 #include "test_iterators.h"
 

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put2.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put2.pass.cpp
@@ -35,7 +35,7 @@ int main(int, char**)
 {
     const my_facet f(1);
     char str[200];
-    tm t = {};
+    std::tm t = {};
     t.tm_sec = 6;
     t.tm_min = 3;
     t.tm_hour = 13;


### PR DESCRIPTION
These tests define a variable of type `std::ios` (which is an alias of `std::basic_ios<char>`). The standard says `std::basic_ios` is defined in `<ios>`.

Some of these tests do not include `<ctime>`, but they use the type `std::tm`.

This PR adds inclusion of `<ios>` and `<ctime>` to ensure that the definitions of `std::basic_ios` and `std::tm` are available in these tests.

As a drive-by fix, this PR changes several uses of `tm` to `std::tm`. The latter is guaranteed to be available in `<ctime>`, but the former isn't.