### PR TITLE
[NFC] Fix darwin failures due to missing headers

### DIFF
--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -18,6 +18,12 @@
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
+#if defined(__APPLE__)
+#include <crt_externs.h>
+#elif !defined(_MSC_VER)
+// Forward declare environ in case it's not provided by stdlib.h.
+extern char **environ;
+#endif
 
 using namespace llvm;
 using namespace llvm::cas;


### PR DESCRIPTION
Handle the include similar to ProgramTest, to fix the build failures in darwin
```

/Users/buildbot/buildbot-root/aarch64-darwin/llvm-project/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp:38:15: error: use of undeclared identifier '_NSGetEnviron'
      return *_NSGetEnviron();
              ^
1 error generated.

```
