### PR TITLE
[lldb-dap] fix substitution in lldb-dap shell test

### DIFF
--- a/lldb/test/Shell/DAP/TestHelp.test
+++ b/lldb/test/Shell/DAP/TestHelp.test
@@ -1,4 +1,4 @@
-# RUN: lldb-dap --help | FileCheck %s
+# RUN: %lldb-dap --help | FileCheck %s
 # CHECK: --connection
 # CHECK: -g
 # CHECK: --help

--- a/lldb/test/Shell/DAP/TestVersion.test
+++ b/lldb/test/Shell/DAP/TestVersion.test
@@ -1,3 +1,3 @@
-# RUN: lldb-dap --version | FileCheck %s
+# RUN: %lldb-dap --version | FileCheck %s
 # CHECK: lldb-dap:
 # CHECK: liblldb:


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/179685 fixed the `lldb-dap` substitution in shell tests.

This replaces the `lldb-dap` invocations with `%lldb-dap` to use the substitution.