### PR TITLE
[lldb][doc] Improve documentation for `ScriptedFrameProvider`

### DIFF
--- a/lldb/examples/python/templates/scripted_frame_provider.py
+++ b/lldb/examples/python/templates/scripted_frame_provider.py
@@ -34,20 +34,20 @@ class ScriptedFrameProvider(metaclass=ABCMeta):
         import lldb
         from lldb.plugins.scripted_frame_provider import ScriptedFrameProvider
 
-        class CoroFrameProvider(ScriptedFrameProvider):
+        class MyFrameProvider(ScriptedFrameProvider):
             def __init__(self, input_frames, args):
                 super().__init__(input_frames, args)
 
             @staticmethod
             def get_description():
-                return "C++ coroutine frame unwinding"
+                return "Show each frame twice"
 
             def get_frame_at_index(self, index):
                 # Duplicate every frame
                 return int(index / 2)
 
         def __lldb_init_module(debugger, internal_dict):
-            debugger.HandleCommand(f"target frame-provider register -C {__name__}.CoroFrameProvider")
+            debugger.HandleCommand(f"target frame-provider register -C {__name__}.MyFrameProvider")
 
         if __name__ == '__main__':
             print("This script should be loaded from LLDB using `command script import <filename>`")

--- a/lldb/examples/python/templates/scripted_frame_provider.py
+++ b/lldb/examples/python/templates/scripted_frame_provider.py
@@ -172,19 +172,20 @@ class ScriptedFrameProvider(metaclass=ABCMeta):
             index (int): The frame index to retrieve (0 for youngest/top frame).
 
         Returns:
-            Dict or None: A frame dictionary describing the stack frame, or None
-                if no frame exists at this index. The dictionary should contain:
+            ScriptedFrame, integer, Dict or None: An object describing the stack
+               stack frame, or None if no frame exists at this index.
 
-            Required fields:
+            An integer represents the corresponding input frame index to reuse,
+            in case you want to just forward an frame from the ``input_frames``.
+
+            Returning a ScriptedFrame object injects artificial frames giving
+            you full control over the frame behavior.
+
+            Returning a dictionary also injects an artificial frame, but with
+            less control over the frame behavior. The dictionary must contain:
 
             - idx (int): The synthetic frame index (0 for youngest/top frame)
             - pc (int): The program counter address for the synthetic frame
-
-            Alternatively, you can return:
-
-            - A ScriptedFrame object for full control over frame behavior
-            - An integer representing an input frame index to reuse
-            - None to indicate no more frames exist
 
         Example:
 

--- a/lldb/examples/python/templates/scripted_frame_provider.py
+++ b/lldb/examples/python/templates/scripted_frame_provider.py
@@ -23,8 +23,8 @@ class ScriptedFrameProvider(metaclass=ABCMeta):
 
     - ``input_frames`` (lldb.SBFrameList or None): The frame list to use as input
     - ``thread`` (lldb.SBThread or None): The thread this provider is attached to.
-    - ``target`` (lldb.SBTarget or None): The target from the thread's process.
     - ``process`` (lldb.SBProcess or None): The process that owns the thread.
+    - ``target`` (lldb.SBTarget or None): The target from the thread's process.
     - ``args`` (lldb.SBStructuredData or None): Dictionary-like structured data passed when the provider was registered.
 
     Example usage:

--- a/lldb/examples/python/templates/scripted_frame_provider.py
+++ b/lldb/examples/python/templates/scripted_frame_provider.py
@@ -31,7 +31,6 @@ class ScriptedFrameProvider(metaclass=ABCMeta):
 
     .. code-block:: python
 
-        import lldb
         from lldb.plugins.scripted_frame_provider import ScriptedFrameProvider
 
         class MyFrameProvider(ScriptedFrameProvider):


### PR DESCRIPTION
* Provide a minimal, working example
* Document the instance variables
* Remove mention of `thread.SetScriptedFrameProvider` (which doesn't exist)
* add missing `@staticmethod` annotation
* fix rendering of bullet-pointed lists