### PR TITLE
[clang-tidy] Fix readability-use-anyofallof false positive for shared_ptr

### DIFF
--- a/clang/lib/Analysis/ExprMutationAnalyzer.cpp
+++ b/clang/lib/Analysis/ExprMutationAnalyzer.cpp
@@ -449,7 +449,13 @@ ExprMutationAnalyzer::Analyzer::findDirectMutation(const Expr *Exp) {
   const auto AsOperatorArrowThis = cxxOperatorCallExpr(
       hasOverloadedOperatorName("->"),
       callee(
-          cxxMethodDecl(ofClass(isMoveOnly()), returns(nonConstPointerType()))),
+          cxxMethodDecl(
+             anyOf(
+              ofClass(isMoveOnly()),
+              ofClass(hasAnyName("std::shared_ptr", "std::weak_ptr"))
+            ),
+            returns(nonConstPointerType())
+          )),
       argumentCountIs(1), hasArgument(0, canResolveToExpr(Exp)));
 
   // Used as non-const-ref argument when calling a function.


### PR DESCRIPTION
Fixes issue #179941 where `readability-use-anyofallof` was incorrectly suggesting `std::any_of` for loops that mutate data through `std::shared_ptr`. The checker detected mutations through `unique_ptr` but not `shared_ptr`, even though both use `operator->` the same way. Extended the mutation detection in `ExprMutationAnalyzer` to also match `std::shared_ptr` and `std::weak_ptr`.