### PR TITLE
[llvm][ADT] Mark the whole scope_exit class [[nodiscard]] instead

### DIFF
--- a/llvm/include/llvm/ADT/ScopeExit.h
+++ b/llvm/include/llvm/ADT/ScopeExit.h
@@ -20,16 +20,15 @@
 
 namespace llvm {
 
-template <typename Callable> class scope_exit {
+template <typename Callable> class [[nodiscard]] scope_exit {
   Callable ExitFunction;
   bool Engaged = true; // False once moved-from or release()d.
 
 public:
   template <typename Fp>
-  [[nodiscard]] explicit scope_exit(Fp &&F)
-      : ExitFunction(std::forward<Fp>(F)) {}
+  explicit scope_exit(Fp &&F) : ExitFunction(std::forward<Fp>(F)) {}
 
-  [[nodiscard]] scope_exit(scope_exit &&Rhs)
+  scope_exit(scope_exit &&Rhs)
       : ExitFunction(std::move(Rhs.ExitFunction)), Engaged(Rhs.Engaged) {
     Rhs.release();
   }


### PR DESCRIPTION
This PR is to address:
https://github.com/llvm/llvm-project/pull/179720#issuecomment-3854792269
https://github.com/llvm/llvm-project/pull/179720#issuecomment-3855339636