### PR TITLE
[Object][Offload] Fix OffloadBinary::create to explicitly move return value

### DIFF
--- a/llvm/lib/Object/OffloadBinary.cpp
+++ b/llvm/lib/Object/OffloadBinary.cpp
@@ -259,7 +259,8 @@ OffloadBinary::create(MemoryBufferRef Buf, std::optional<uint64_t> Index) {
       return std::move(Err);
 
     Binaries.emplace_back(new OffloadBinary(Buf, TheHeader, TheEntry, *Index));
-    return Binaries;
+    // Explicit move for compatibility with GCC7.
+    return std::move(Binaries);
   }
 
   uint64_t EntriesCount = TheHeader->Version == 1 ? 1 : TheHeader->EntriesCount;
@@ -271,7 +272,8 @@ OffloadBinary::create(MemoryBufferRef Buf, std::optional<uint64_t> Index) {
     Binaries.emplace_back(new OffloadBinary(Buf, TheHeader, TheEntry, I));
   }
 
-  return Binaries;
+  // Explicit move for compatibility with GCC7.
+  return std::move(Binaries);
 }
 
 SmallString<0> OffloadBinary::write(ArrayRef<OffloadingImage> OffloadingData) {

--- a/llvm/lib/Object/OffloadBinary.cpp
+++ b/llvm/lib/Object/OffloadBinary.cpp
@@ -259,7 +259,6 @@ OffloadBinary::create(MemoryBufferRef Buf, std::optional<uint64_t> Index) {
       return std::move(Err);
 
     Binaries.emplace_back(new OffloadBinary(Buf, TheHeader, TheEntry, *Index));
-    // Explicit move for compatibility with GCC7.
     return std::move(Binaries);
   }
 
@@ -272,7 +271,6 @@ OffloadBinary::create(MemoryBufferRef Buf, std::optional<uint64_t> Index) {
     Binaries.emplace_back(new OffloadBinary(Buf, TheHeader, TheEntry, I));
   }
 
-  // Explicit move for compatibility with GCC7.
   return std::move(Binaries);
 }
 


### PR DESCRIPTION
On older compilers (GCC 7), implicit move on return is not guaranteed, causing the compiler to attempt copying the SmallVector of unique_ptr's, which fails because unique_ptr has a deleted copy constructor.
Added explicit std::move() on both return paths to ensure move semantics are used instead of copy, fixing compilation by GCC 7.