### PR TITLE
[C++20][Modules] Fix relocatable PCH feature.

### DIFF
--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -1526,10 +1526,10 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, StringRef isysroot) {
 
       // Write out all other paths relative to the base directory if possible.
       BaseDirectory.assign(BaseDir->begin(), BaseDir->end());
-    } else if (!isysroot.empty()) {
-      // Write out paths relative to the sysroot if possible.
-      BaseDirectory = std::string(isysroot);
     }
+  } else if (!isysroot.empty()) {
+    // Write out paths relative to the sysroot if possible.
+    BaseDirectory = std::string(isysroot);
   }
 
   // Module map file

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -1529,7 +1529,9 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, StringRef isysroot) {
     }
   } else if (!isysroot.empty()) {
     // Write out paths relative to the sysroot if possible.
-    BaseDirectory = std::string(isysroot);
+    SmallString<128> CleanedSysroot(isysroot);
+    cleanPathForOutput(PP.getFileManager(), CleanedSysroot);
+    BaseDirectory.assign(CleanedSysroot.begin(), CleanedSysroot.end());
   }
 
   // Module map file

--- a/clang/test/PCH/reloc.c
+++ b/clang/test/PCH/reloc.c
@@ -3,6 +3,11 @@
 // RUN: %clang -target x86_64-apple-darwin11 -fsyntax-only \
 // RUN:   -include-pch %t -isysroot %S/Inputs/libroot %s -Xclang -verify
 // RUN: not %clang -target x86_64-apple-darwin11 -include-pch %t %s
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t \
+// RUN:   | FileCheck %s
+// CHECK: <ORIGINAL_FILE {{.*}}/> blob data = 'usr{{[/\\]}}include{{[/\\]}}reloc.h'
+// CHECK: <INPUT_FILE {{.*}}/> blob data = 'usr{{[/\\]}}include{{[/\\]}}reloc.h'
+// CHECK: <INPUT_FILE {{.*}}/> blob data = 'usr{{[/\\]}}include{{[/\\]}}reloc2.h'
 // REQUIRES: x86-registered-target
 
 #include <reloc.h>


### PR DESCRIPTION
This PR fixes the relocatable PCH feature reported in https://github.com/llvm/llvm-project/issues/179482, and adds a new test to prevent regressions.

This is indeed a bug introduced in https://github.com/llvm/llvm-project/pull/135147.

Given the assertion [here](https://github.com/mpark/llvm-project/blob/e28affb1db46e5e3da14be07d88b05bb327bfeab/clang/lib/Serialization/ASTWriter.cpp#L1470-L1471):
```
  assert((!WritingModule || isysroot.empty()) &&
         "writing module as a relocatable PCH?");
```
They cannot both be set. Either one, or neither can be set.

So the `!isysroot.empty()` condition is currently dead, and it should be a `else if` condition for the `!WritingModule` case.