### PR TITLE
[libcxx] Add missing header to re/re.alg/re.alg.search/grep.pass.cpp

### DIFF
--- a/libcxx/test/std/re/re.alg/re.alg.search/grep.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/grep.pass.cpp
@@ -16,6 +16,7 @@
 //                  regex_constants::match_flag_type flags = regex_constants::match_default);
 
 #include <regex>
+#include <cstring>
 #include <cassert>
 
 #include "test_macros.h"
@@ -24,7 +25,7 @@
 extern "C" void LLVMFuzzerTestOneInput(const char *data)
 {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    std::size_t size = strlen(data);
+    std::size_t size = std::strlen(data);
     if (size > 0)
     {
         try


### PR DESCRIPTION
This test can't be compiled with GCC without this fix.