### PR TITLE
[OpenMP] Stub vprintf on non-NVPTX if no libc

### DIFF
--- a/openmp/device/src/LibC.cpp
+++ b/openmp/device/src/LibC.cpp
@@ -8,7 +8,7 @@
 
 #include "LibC.h"
 
-#if defined(__AMDGPU__) && !defined(OMPTARGET_HAS_LIBC)
+#if !defined(__NVPTX__) && !defined(OMPTARGET_HAS_LIBC)
 extern "C" int vprintf(const char *format, __builtin_va_list) { return -1; }
 #else
 extern "C" int vprintf(const char *format, __builtin_va_list);


### PR DESCRIPTION
The AMDGPU check was added in https://github.com/llvm/llvm-project/pull/123670 where the reasoning seems to be that the NVIDIA SDK will provide `vprintf` for the NVPTX case and AMDGPU was the only other supported target at the time.

SPIR-V also needs this stubbed out, so just check that it's not NVPTX.