### PR TITLE
[lldb-dap] Remove end line and column from disassemble response

### DIFF
--- a/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
@@ -156,22 +156,6 @@ static DisassembledInstruction ConvertSBInstructionToDisassembledInstruction(
     const auto column = line_entry.GetColumn();
     if (column != 0 && column != LLDB_INVALID_COLUMN_NUMBER)
       disassembled_inst.column = column;
-
-    lldb::SBAddress end_addr = line_entry.GetEndAddress();
-    auto end_line_entry = GetLineEntryForAddress(target, end_addr);
-    if (end_line_entry.IsValid() &&
-        end_line_entry.GetFileSpec() == line_entry.GetFileSpec()) {
-      const auto end_line = end_line_entry.GetLine();
-      if (end_line != 0 && end_line != LLDB_INVALID_LINE_NUMBER &&
-          end_line != line) {
-        disassembled_inst.endLine = end_line;
-
-        const auto end_column = end_line_entry.GetColumn();
-        if (end_column != 0 && end_column != LLDB_INVALID_COLUMN_NUMBER &&
-            end_column != column)
-          disassembled_inst.endColumn = end_column - 1;
-      }
-    }
   }
 
   return disassembled_inst;


### PR DESCRIPTION
The end line entry calculated from the instruction's end address is unreliable and could produce incorrect source ranges. especially if the instruction spans multiple lines.

We can end in situations where the current end line is the next start line and the source line is show to the client twice. confusing users what maps to what. 

| With EndLine | 
| :------------: |
| <img width="892" height="486" alt="Screenshot 2026-02-05 at 21 37 08" src="https://github.com/user-attachments/assets/f2fef592-5754-4168-bf93-2baba4742c5d" /> |

| Without Endline |
| :---------------: |
| <img width="892" height="486" alt="Screenshot 2026-02-05 at 21 59 29" src="https://github.com/user-attachments/assets/538dd462-9c7f-4483-804c-65fd83b5f2f2" />|

 Or the endline is smaller than the startline.
 ```json
 {
  "address": "0x5555555557B4",
  "column": 3,
  "endLine": 2,
  "instruction": "add     rsp, 0x20                ",
  "instructionBytes": "48 83 c4 20",
  "line": 17,
  "location": {
    "name": "test.cpp",
    "path": "/buildbot/test_process/test.cpp"
  }
},
```