### PR TITLE
[SystemZ][GOFF] Implement emitGlobalAlias for GOFF/HLASM

### DIFF
--- a/llvm/lib/Support/StringMap.cpp
+++ b/llvm/lib/Support/StringMap.cpp
@@ -14,15 +14,8 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/ReverseIteration.h"
 #include "llvm/Support/xxhash.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
-
-cl::opt<bool> tonytest(
-    "tonytest", cl::init(false), cl::Hidden,
-    cl::desc("The maximum nesting depth allowed for assembly macros."));
 
 /// Returns the number of buckets to allocate to ensure that the DenseMap can
 /// accommodate \p NumEntries without need to grow().
@@ -41,8 +34,6 @@ static inline StringMapEntryBase **createTable(unsigned NewNumBuckets) {
 
   // Allocate one extra bucket, set it to look filled so the iterators stop at
   // end.
-  if (tonytest)
-  llvm::dbgs() << "TONY table" << Table << "\n";
   Table[NewNumBuckets] = (StringMapEntryBase *)2;
   return Table;
 }
@@ -73,11 +64,7 @@ void StringMapImpl::init(unsigned InitSize) {
   NumItems = 0;
   NumTombstones = 0;
 
-  if (tonytest)
-  llvm::dbgs() << "TONY a\n";
   TheTable = createTable(NewNumBuckets);
-  if (tonytest)
-  llvm::dbgs() << "TONY b\n";
 
   // Set the member only if TheTable was successfully allocated
   NumBuckets = NewNumBuckets;
@@ -90,20 +77,12 @@ void StringMapImpl::init(unsigned InitSize) {
 /// of the string.
 unsigned StringMapImpl::LookupBucketFor(StringRef Name,
                                         uint32_t FullHashValue) {
-                                        if (tonytest)
-  llvm::dbgs() << "TONY lookup bucket " << Name << " " << FullHashValue << "\n";
 #ifdef EXPENSIVE_CHECKS
   assert(FullHashValue == hash(Name));
 #endif
   // Hash table unallocated so far?
-  if (NumBuckets == 0) {
-  if (tonytest)
-  llvm::dbgs() << "TONY 1\n";
+  if (NumBuckets == 0)
     init(16);
-  if (tonytest)
-  llvm::dbgs() << "TONY 2\n";
-  }
-
   if constexpr (shouldReverseIterate())
     FullHashValue = ~FullHashValue;
   unsigned BucketNo = FullHashValue & (NumBuckets - 1);

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -159,6 +159,38 @@ static MCInst lowerVecEltInsertion(const MachineInstr *MI, unsigned Opcode) {
       .addImm(0);
 }
 
+bool SystemZAsmPrinter::doInitialization(Module &M) {
+  SM.reset();
+  bool RetVal = AsmPrinter::doInitialization(M);
+
+  // In HLASM, the only way to represent aliases is to use the 
+  // extra-label-at-definition strategy. This is similar to the AIX implementation
+  // with the additional caveat that all symbol attributes must be emitted before the label
+  // is emitted.
+  if (TM.getTargetTriple().isOSzOS()) {
+    // Construct an aliasing list for each GlobalObject.
+    for (const auto &Alias : M.aliases()) {
+      const GlobalObject *Aliasee = Alias.getAliaseeObject();
+      if (!Aliasee)
+      OutContext.reportError(
+          {}, "Alias without a base object is not yet supported on z/OS.");
+
+      bool IsFunc = isa<Function>(Aliasee->stripPointerCasts());
+      if (IsFunc) {
+        if (Alias.hasWeakLinkage() || Alias.hasLinkOnceLinkage())
+          OutContext.reportError(
+              {}, "Weak alias/reference not supported on z/OS");
+        
+        GOAliasMap[Aliasee].push_back(&Alias);
+      }
+      else
+        OutContext.reportError(
+            {}, "Only aliases to functions is supported in GOFF.");
+    }
+  }
+  return RetVal;
+}
+
 // The XPLINK ABI requires that a no-op encoding the call type is emitted after
 // each call to a subroutine. This information can be used by the called
 // function to determine its entry point, e.g. for generating a backtrace. The
@@ -1784,6 +1816,13 @@ void SystemZAsmPrinter::emitPPA2(Module &M) {
   OutStreamer->popSection();
 }
 
+void SystemZAsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
+  if (!TM.getTargetTriple().isOSzOS())
+    return AsmPrinter::emitGlobalAlias(M, GA);
+
+  // Aliased function labels have already been emitted for z/OS
+}
+
 const MCExpr *SystemZAsmPrinter::lowerConstant(const Constant *CV,
                                                const Constant *BaseCV,
                                                uint64_t Offset) {
@@ -1887,6 +1926,17 @@ void SystemZAsmPrinter::emitFunctionEntryLabel() {
   }
 
   AsmPrinter::emitFunctionEntryLabel();
+ 
+  if (Subtarget.getTargetTriple().isOSzOS()) {
+    const Function *F = &MF->getFunction();
+    // Emit aliasing label for function entry point label.
+    for (const GlobalAlias *Alias : GOAliasMap[F]) {
+      MCSymbol *Sym = getSymbol(Alias);
+      emitVisibility(Sym, Alias->getVisibility());
+      emitLinkage(Alias, Sym);
+      OutStreamer->emitLabel(Sym);
+    }
+  }
 }
 
 char SystemZAsmPrinter::ID = 0;

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -162,27 +162,26 @@ static MCInst lowerVecEltInsertion(const MachineInstr *MI, unsigned Opcode) {
 bool SystemZAsmPrinter::doInitialization(Module &M) {
   SM.reset();
 
-  // In HLASM, the only way to represent aliases is to use the 
-  // extra-label-at-definition strategy. This is similar to the AIX implementation
-  // with the additional caveat that all symbol attributes must be emitted before the label
-  // is emitted.
+  // In HLASM, the only way to represent aliases is to use the
+  // extra-label-at-definition strategy. This is similar to the AIX
+  // implementation with the additional caveat that all symbol attributes must
+  // be emitted before the label is emitted.
   if (TM.getTargetTriple().isOSzOS()) {
     // Construct an aliasing list for each GlobalObject.
     for (const auto &Alias : M.aliases()) {
       const GlobalObject *Aliasee = Alias.getAliaseeObject();
       if (!Aliasee)
-      OutContext.reportError(
-          {}, "Alias without a base object is not yet supported on z/OS.");
+        OutContext.reportError(
+            {}, "Alias without a base object is not yet supported on z/OS.");
 
       bool IsFunc = isa<Function>(Aliasee->stripPointerCasts());
       if (IsFunc) {
         if (Alias.hasWeakLinkage() || Alias.hasLinkOnceLinkage())
-          OutContext.reportError(
-              {}, "Weak alias/reference not supported on z/OS");
-        
+          OutContext.reportError({},
+                                 "Weak alias/reference not supported on z/OS");
+
         GOAliasMap[Aliasee].push_back(&Alias);
-      }
-      else
+      } else
         OutContext.reportError(
             {}, "Only aliases to functions is supported in GOFF.");
     }
@@ -1815,7 +1814,8 @@ void SystemZAsmPrinter::emitPPA2(Module &M) {
   OutStreamer->popSection();
 }
 
-void SystemZAsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
+void SystemZAsmPrinter::emitGlobalAlias(const Module &M,
+                                        const GlobalAlias &GA) {
   if (!TM.getTargetTriple().isOSzOS())
     return AsmPrinter::emitGlobalAlias(M, GA);
 
@@ -1925,7 +1925,7 @@ void SystemZAsmPrinter::emitFunctionEntryLabel() {
   }
 
   AsmPrinter::emitFunctionEntryLabel();
- 
+
   if (Subtarget.getTargetTriple().isOSzOS()) {
     const Function *F = &MF->getFunction();
     // Emit aliasing label for function entry point label.

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -161,7 +161,6 @@ static MCInst lowerVecEltInsertion(const MachineInstr *MI, unsigned Opcode) {
 
 bool SystemZAsmPrinter::doInitialization(Module &M) {
   SM.reset();
-  bool RetVal = AsmPrinter::doInitialization(M);
 
   // In HLASM, the only way to represent aliases is to use the 
   // extra-label-at-definition strategy. This is similar to the AIX implementation
@@ -188,7 +187,7 @@ bool SystemZAsmPrinter::doInitialization(Module &M) {
             {}, "Only aliases to functions is supported in GOFF.");
     }
   }
-  return RetVal;
+  return AsmPrinter::doInitialization(M);
 }
 
 // The XPLINK ABI requires that a no-op encoding the call type is emitted after
@@ -1932,6 +1931,7 @@ void SystemZAsmPrinter::emitFunctionEntryLabel() {
     // Emit aliasing label for function entry point label.
     for (const GlobalAlias *Alias : GOAliasMap[F]) {
       MCSymbol *Sym = getSymbol(Alias);
+      OutStreamer->emitSymbolAttribute(Sym, MCSA_ELF_TypeFunction);
       emitVisibility(Sym, Alias->getVisibility());
       emitLinkage(Alias, Sym);
       OutStreamer->emitLabel(Sym);

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
@@ -92,6 +92,12 @@ private:
   };
 
   AssociatedDataAreaTable ADATable;
+  
+  // Record a list of GlobalAlias associated with a GlobalObject.
+  // This is used for z/OS's extra-label-at-definition aliasing strategy.
+  // This is similar to what is done for AIX.
+  DenseMap<const GlobalObject *, SmallVector<const GlobalAlias *, 1>>
+      GOAliasMap;
 
   void emitPPA1(MCSymbol *FnEndSym);
   void emitPPA2(Module &M);
@@ -125,13 +131,11 @@ public:
     return false;
   }
 
-  bool doInitialization(Module &M) override {
-    SM.reset();
-    return AsmPrinter::doInitialization(M);
-  }
+  bool doInitialization(Module &M) override;
   void emitFunctionEntryLabel() override;
   void emitFunctionBodyEnd() override;
   void emitStartOfAsmFile(Module &M) override;
+  void emitGlobalAlias(const Module &M, const GlobalAlias &GA) override;
   const MCExpr *lowerConstant(const Constant *CV,
                               const Constant *BaseCV = nullptr,
                               uint64_t Offset = 0) override;

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
@@ -92,7 +92,7 @@ private:
   };
 
   AssociatedDataAreaTable ADATable;
-  
+
   // Record a list of GlobalAlias associated with a GlobalObject.
   // This is used for z/OS's extra-label-at-definition aliasing strategy.
   // This is similar to what is done for AIX.

--- a/llvm/test/CodeGen/SystemZ/zos-func-alias.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-func-alias.ll
@@ -1,0 +1,17 @@
+; Test function aliasing on z/OS
+;
+; RUN: llc < %s -mtriple=s390x-ibm-zos -emit-gnuas-syntax-on-zos=0 | FileCheck %s
+
+; CHECK:      ENTRY foo
+; CHECK-NEXT: foo XATTR LINKAGE(XPLINK),REFERENCE(CODE),SCOPE(LIBRARY)
+; CHECK-NEXT: foo DS 0H
+; CHECK-NEXT: ENTRY foo
+; CHECK-NEXT: foo1 XATTR LINKAGE(XPLINK),REFERENCE(CODE),SCOPE(LIBRARY)
+; CHECK-NEXT: foo1 DS 0H
+
+@foo1 = hidden alias i32 (i32), ptr @foo
+
+define hidden void @foo() {
+entry:
+  ret void
+}


### PR DESCRIPTION
HLASM has a requirement where aliasing labels need to be emitted at the same time as the aliasee label, similar to AIX. I used their implementation for reference with some modifications as we can only alias functions and we must emit all symbol attributes before the label is emitted to ensure the XATTR instruction contains the correct attributes.