### PR TITLE
[SystemZ][GOFF] Implement emitGlobalAlias for GOFF/HLASM

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -159,6 +159,36 @@ static MCInst lowerVecEltInsertion(const MachineInstr *MI, unsigned Opcode) {
       .addImm(0);
 }
 
+bool SystemZAsmPrinter::doInitialization(Module &M) {
+  SM.reset();
+
+  // In HLASM, the only way to represent aliases is to use the
+  // extra-label-at-definition strategy. This is similar to the AIX
+  // implementation with the additional caveat that all symbol attributes must
+  // be emitted before the label is emitted.
+  if (TM.getTargetTriple().isOSzOS()) {
+    // Construct an aliasing list for each GlobalObject.
+    for (const auto &Alias : M.aliases()) {
+      const GlobalObject *Aliasee = Alias.getAliaseeObject();
+      if (!Aliasee)
+        OutContext.reportError(
+            {}, "Alias without a base object is not yet supported on z/OS.");
+
+      bool IsFunc = isa<Function>(Aliasee->stripPointerCasts());
+      if (IsFunc) {
+        if (Alias.hasWeakLinkage() || Alias.hasLinkOnceLinkage())
+          OutContext.reportError({},
+                                 "Weak alias/reference not supported on z/OS");
+
+        GOAliasMap[Aliasee].push_back(&Alias);
+      } else
+        OutContext.reportError(
+            {}, "Only aliases to functions is supported in GOFF.");
+    }
+  }
+  return AsmPrinter::doInitialization(M);
+}
+
 // The XPLINK ABI requires that a no-op encoding the call type is emitted after
 // each call to a subroutine. This information can be used by the called
 // function to determine its entry point, e.g. for generating a backtrace. The
@@ -1784,6 +1814,14 @@ void SystemZAsmPrinter::emitPPA2(Module &M) {
   OutStreamer->popSection();
 }
 
+void SystemZAsmPrinter::emitGlobalAlias(const Module &M,
+                                        const GlobalAlias &GA) {
+  if (!TM.getTargetTriple().isOSzOS())
+    return AsmPrinter::emitGlobalAlias(M, GA);
+
+  // Aliased function labels have already been emitted for z/OS
+}
+
 const MCExpr *SystemZAsmPrinter::lowerConstant(const Constant *CV,
                                                const Constant *BaseCV,
                                                uint64_t Offset) {
@@ -1887,6 +1925,18 @@ void SystemZAsmPrinter::emitFunctionEntryLabel() {
   }
 
   AsmPrinter::emitFunctionEntryLabel();
+
+  if (Subtarget.getTargetTriple().isOSzOS()) {
+    const Function *F = &MF->getFunction();
+    // Emit aliasing label for function entry point label.
+    for (const GlobalAlias *Alias : GOAliasMap[F]) {
+      MCSymbol *Sym = getSymbol(Alias);
+      OutStreamer->emitSymbolAttribute(Sym, MCSA_ELF_TypeFunction);
+      emitVisibility(Sym, Alias->getVisibility());
+      emitLinkage(Alias, Sym);
+      OutStreamer->emitLabel(Sym);
+    }
+  }
 }
 
 char SystemZAsmPrinter::ID = 0;

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
@@ -93,6 +93,12 @@ private:
 
   AssociatedDataAreaTable ADATable;
 
+  // Record a list of GlobalAlias associated with a GlobalObject.
+  // This is used for z/OS's extra-label-at-definition aliasing strategy.
+  // This is similar to what is done for AIX.
+  DenseMap<const GlobalObject *, SmallVector<const GlobalAlias *, 1>>
+      GOAliasMap;
+
   void emitPPA1(MCSymbol *FnEndSym);
   void emitPPA2(Module &M);
   void emitADASection();
@@ -125,13 +131,11 @@ public:
     return false;
   }
 
-  bool doInitialization(Module &M) override {
-    SM.reset();
-    return AsmPrinter::doInitialization(M);
-  }
+  bool doInitialization(Module &M) override;
   void emitFunctionEntryLabel() override;
   void emitFunctionBodyEnd() override;
   void emitStartOfAsmFile(Module &M) override;
+  void emitGlobalAlias(const Module &M, const GlobalAlias &GA) override;
   const MCExpr *lowerConstant(const Constant *CV,
                               const Constant *BaseCV = nullptr,
                               uint64_t Offset = 0) override;

--- a/llvm/test/CodeGen/SystemZ/zos-alias-unsupported.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-alias-unsupported.ll
@@ -1,0 +1,16 @@
+; Test aliasing errors on z/OS
+
+; RUN: not llc < %s -mtriple=s390x-ibm-zos -emit-gnuas-syntax-on-zos=0 2>&1 | FileCheck %s
+
+; CHECK: error: Only aliases to functions is supported in GOFF.
+; CHECK: error: Weak alias/reference not supported on z/OS
+
+@actual_variable = global i32 0
+@alias_variable = alias i32, ptr @actual_variable
+
+@foo1 = weak alias i32 (i32), ptr @foo
+define hidden void @foo() {
+entry:
+  ret void
+}
+

--- a/llvm/test/CodeGen/SystemZ/zos-func-alias.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-func-alias.ll
@@ -1,0 +1,17 @@
+; Test function aliasing on z/OS
+;
+; RUN: llc < %s -mtriple=s390x-ibm-zos -emit-gnuas-syntax-on-zos=0 | FileCheck %s
+
+; CHECK:      ENTRY foo
+; CHECK-NEXT: foo XATTR LINKAGE(XPLINK),REFERENCE(CODE),SCOPE(LIBRARY)
+; CHECK-NEXT: foo DS 0H
+; CHECK-NEXT: ENTRY foo
+; CHECK-NEXT: foo1 XATTR LINKAGE(XPLINK),REFERENCE(CODE),SCOPE(LIBRARY)
+; CHECK-NEXT: foo1 DS 0H
+
+@foo1 = hidden alias i32 (i32), ptr @foo
+
+define hidden void @foo() {
+entry:
+  ret void
+}


### PR DESCRIPTION
HLASM has a requirement where aliasing labels need to be emitted at the same time as the aliasee label, similar to AIX. I used their implementation for reference with some modifications as we can only alias functions and we must emit all symbol attributes before the label is emitted to ensure the XATTR instruction contains the correct attributes.