### PR TITLE
[lldb] Nominate myself for FreeBSD maintainer

### DIFF
--- a/lldb/Maintainers.md
+++ b/lldb/Maintainers.md
@@ -195,6 +195,9 @@ jonas@devlieghere.com (email), [jdevlieghere](https://github.com/jdevlieghere) (
 Ed Maste
 emaste@freebsd.org (email), [emaste](https://github.com/emaste) (GitHub), [emaste](https://discourse.llvm.org/u/emaste) (Discourse), emaste (Discord)
 
+Minsoo Choo
+minsoochoo0122@proton.me (email), mchoo7 (GitHub), mchoo (Discourse), minsoochoo (Discord)
+
 #### Linux
 
 Pavel Labath


### PR DESCRIPTION
I've been FreeBSD src contributor since 2022 and started working for the FreeBSD Foundation starting from January. I created and have been actively working on #180061 to achieve [LLDB improvement on FreeBSD](https://wiki.freebsd.org/SummerOfCodeIdeas#Improve_LLDB_on_FreeBSD) which was originally Google Summer of Code idea.

The initial LLDB support for userspace and kernel debugging on FreeBSD was initiated by Moritz system back in 2020, but there are some missing bits like architecture support due to lack of time. Due to this, FreeBSD developers still depend on GDB-derived kernel debugger and it still remains de-facto tier 1 debugger (e.g. no scripts in source tree for lldb).

To track what/how I'm working on this task, please take a look at my foundation [status report on LLDB improvement](https://github.com/FreeBSDFoundation/status-updates/blob/main/Minsoo_Choo/kdb.md). As you see, I will also improve Lua scripting on LLDB as Lua remains most FreeBSD developer's choice for scripting language over Python.

Until school starts again in May, I will work full time in the foundation which means I can actively create new features, fix bugs, and review other's code changes. I will have less time to dedicate myself to contribute to open source projects after May, but I will still commit myself to code reviews and bug fixes that do not take too much time.

My FreeBSD contributions: https://cgit.freebsd.org/src/log/?qt=author&q=Minsoo+Choo
My FreeBSD Phabricator profile: https://reviews.freebsd.org/p/minsoochoo0122_proton.me/
