### PR TITLE
[FLANG][MLIR][OpenMP] add MathToNVVM conversion pass to NVPTX MLIR

### DIFF
--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -8,6 +8,7 @@
 
 #include "Flang.h"
 #include "Arch/RISCV.h"
+#include "Cuda.h"
 
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/Driver/CommonArgs.h"
@@ -519,6 +520,42 @@ void Flang::AddAMDGPUTargetArgs(const ArgList &Args,
   TC.addClangTargetOptions(Args, CmdArgs, Action::OffloadKind::OFK_OpenMP);
 }
 
+void Flang::AddNVPTXTargetArgs(const ArgList &Args,
+                               ArgStringList &CmdArgs) const {
+  // we cannot use addClangTargetOptions, as it appends unsupported args for
+  // flang: -fcuda-is-device, -fno-threadsafe-statics,
+  // -fcuda-allow-variadic-functions and -target-sdk-version Instead we manually
+  // detect the CUDA installation and link libdevice
+  const ToolChain &TC = getToolChain();
+  const Driver &D = TC.getDriver();
+  const llvm::Triple &Triple = TC.getEffectiveTriple();
+
+  if (!Args.hasFlag(options::OPT_offloadlib, options::OPT_no_offloadlib, true))
+    return;
+
+  // Detect CUDA installation and link libdevice
+  CudaInstallationDetector CudaInstallation(D, Triple, Args);
+  if (!CudaInstallation.isValid()) {
+    D.Diag(diag::err_drv_no_cuda_installation);
+    return;
+  }
+
+  StringRef GpuArch = Args.getLastArgValue(options::OPT_march_EQ);
+  if (GpuArch.empty()) {
+    D.Diag(diag::err_drv_offload_missing_gpu_arch) << "NVPTX" << "flang";
+    return;
+  }
+
+  std::string LibDeviceFile = CudaInstallation.getLibDeviceFile(GpuArch);
+  if (LibDeviceFile.empty()) {
+    D.Diag(diag::err_drv_no_cuda_libdevice) << GpuArch;
+    return;
+  }
+
+  CmdArgs.push_back("-mlink-builtin-bitcode");
+  CmdArgs.push_back(Args.MakeArgString(LibDeviceFile));
+}
+
 void Flang::addTargetOptions(const ArgList &Args,
                              ArgStringList &CmdArgs) const {
   const ToolChain &TC = getToolChain();
@@ -547,6 +584,10 @@ void Flang::addTargetOptions(const ArgList &Args,
   case llvm::Triple::amdgcn:
     getTargetFeatures(D, Triple, Args, CmdArgs, /*ForAs*/ false);
     AddAMDGPUTargetArgs(Args, CmdArgs);
+    break;
+  case llvm::Triple::nvptx:
+  case llvm::Triple::nvptx64:
+    AddNVPTXTargetArgs(Args, CmdArgs);
     break;
   case llvm::Triple::riscv64:
     getTargetFeatures(D, Triple, Args, CmdArgs, /*ForAs*/ false);

--- a/clang/lib/Driver/ToolChains/Flang.h
+++ b/clang/lib/Driver/ToolChains/Flang.h
@@ -78,6 +78,9 @@ private:
   void AddAMDGPUTargetArgs(const llvm::opt::ArgList &Args,
                            llvm::opt::ArgStringList &CmdArgs) const;
 
+  void AddNVPTXTargetArgs(const llvm::opt::ArgList &Args,
+                          llvm::opt::ArgStringList &CmdArgs) const;
+
   /// Add specific options for LoongArch64 target.
   ///
   /// \param [in] Args The list of input driver arguments

--- a/flang/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/flang/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -41,6 +41,7 @@ add_flang_library(FIRCodeGen
   MLIRMathToFuncs
   MLIRMathToLLVM
   MLIRMathToLibm
+  MLIRMathToNVVM
   MLIRMathToROCDL
   MLIROpenMPToLLVM
   MLIROpenACCDialect

--- a/flang/test/Driver/omp-driver-offload.f90
+++ b/flang/test/Driver/omp-driver-offload.f90
@@ -75,7 +75,7 @@
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=sm_70 \
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
-! RUN: -fopenmp-assume-threads-oversubscription  \
+! RUN: -fopenmp-assume-threads-oversubscription -nogpulib \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREADS-OVS
 ! CHECK-THREADS-OVS: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-threads-oversubscription" {{.*}}.f90"
 
@@ -87,7 +87,7 @@
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=sm_70 \
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
-! RUN: -fopenmp-assume-teams-oversubscription  \
+! RUN: -fopenmp-assume-teams-oversubscription -nogpulib \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TEAMS-OVS
 ! CHECK-TEAMS-OVS: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-teams-oversubscription" {{.*}}.f90"
 
@@ -99,7 +99,7 @@
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=sm_70 \
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
-! RUN: -fopenmp-assume-no-nested-parallelism  \
+! RUN: -fopenmp-assume-no-nested-parallelism -nogpulib \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-NEST-PAR
 ! CHECK-NEST-PAR: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-nested-parallelism" {{.*}}.f90"
 
@@ -111,7 +111,7 @@
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=sm_70 \
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
-! RUN: -fopenmp-assume-no-thread-state \
+! RUN: -fopenmp-assume-no-thread-state -nogpulib \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-THREAD-STATE
 ! CHECK-THREAD-STATE: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-assume-no-thread-state" {{.*}}.f90"
 
@@ -123,7 +123,7 @@
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=sm_70 \
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
-! RUN: -fopenmp-target-debug \
+! RUN: -fopenmp-target-debug -nogpulib \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG
 ! CHECK-TARGET-DEBUG: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" {{.*}}.f90"
 
@@ -135,7 +135,7 @@
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=sm_70 \
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
-! RUN: -fopenmp-target-debug=111 \
+! RUN: -fopenmp-target-debug=111 -nogpulib \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-TARGET-DEBUG-EQ
 ! CHECK-TARGET-DEBUG-EQ: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug=111" {{.*}}.f90"
 
@@ -151,7 +151,7 @@
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
 ! RUN: -fopenmp-target-debug -fopenmp-assume-threads-oversubscription \
 ! RUN: -fopenmp-assume-teams-oversubscription -fopenmp-assume-no-nested-parallelism \
-! RUN: -fopenmp-assume-no-thread-state \
+! RUN: -fopenmp-assume-no-thread-state -nogpulib \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-RTL-ALL
 ! CHECK-RTL-ALL: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" {{.*}} "-fopenmp-is-target-device" "-fopenmp-target-debug" "-fopenmp-assume-teams-oversubscription"
 ! CHECK-RTL-ALL: "-fopenmp-assume-threads-oversubscription" "-fopenmp-assume-no-thread-state" "-fopenmp-assume-no-nested-parallelism"
@@ -165,7 +165,7 @@
 ! RUN: %flang -### %s -o %t 2>&1 \
 ! RUN: -fopenmp --offload-arch=sm_70 \
 ! RUN: -fopenmp-targets=nvptx64-nvidia-cuda \
-! RUN: -fopenmp-version=45 \
+! RUN: -fopenmp-version=45 -nogpulib \
 ! RUN: | FileCheck %s --check-prefixes=CHECK-OPENMP-VERSION
 ! CHECK-OPENMP-VERSION: "{{[^"]*}}flang" "-fc1" {{.*}} "-fopenmp" "-fopenmp-version=45" {{.*}}.f90"
 

--- a/flang/test/Lower/OpenMP/math-nvptx.f90
+++ b/flang/test/Lower/OpenMP/math-nvptx.f90
@@ -1,0 +1,338 @@
+!REQUIRES: nvptx-registered-target
+!RUN: %flang_fc1 -triple nvptx64-nvidia-cuda -emit-llvm -fopenmp -fopenmp-is-target-device %s -o - | FileCheck %s
+
+subroutine omp_pow_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_powf(float {{.*}}, float {{.*}})
+  y = x ** x
+end subroutine omp_pow_f32
+
+subroutine omp_pow_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_pow(double {{.*}}, double {{.*}})
+  y = x ** x
+end subroutine omp_pow_f64
+
+subroutine omp_sin_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_sinf(float {{.*}})
+  y = sin(x)
+end subroutine omp_sin_f32
+
+subroutine omp_sin_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_sin(double {{.*}})
+  y = sin(x)
+end subroutine omp_sin_f64
+
+subroutine omp_abs_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_fabsf(float {{.*}})
+  y = abs(x)
+end subroutine omp_abs_f32
+
+subroutine omp_abs_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_fabs(double {{.*}})
+  y = abs(x)
+end subroutine omp_abs_f64
+
+subroutine omp_atan_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_atanf(float {{.*}})
+  y = atan(x)
+end subroutine omp_atan_f32
+
+subroutine omp_atan_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_atan(double {{.*}})
+  y = atan(x)
+end subroutine omp_atan_f64
+
+subroutine omp_atanh_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_atanhf(float {{.*}})
+  y = atanh(x)
+end subroutine omp_atanh_f32
+
+subroutine omp_atanh_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_atanh(double {{.*}})
+  y = atanh(x)
+end subroutine omp_atanh_f64
+
+subroutine omp_atan2_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_atan2f(float {{.*}}, float {{.*}})
+  y = atan2(x, x)
+end subroutine omp_atan2_f32
+
+subroutine omp_atan2_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_atan2(double {{.*}}, double {{.*}})
+  y = atan2(x, x)
+end subroutine omp_atan2_f64
+
+subroutine omp_cos_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_cosf(float {{.*}})
+  y = cos(x)
+end subroutine omp_cos_f32
+
+subroutine omp_cos_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_cos(double {{.*}})
+  y = cos(x)
+end subroutine omp_cos_f64
+
+subroutine omp_erf_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_erff(float {{.*}})
+  y = erf(x)
+end subroutine omp_erf_f32
+
+subroutine omp_erf_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_erf(double {{.*}})
+  y = erf(x)
+end subroutine omp_erf_f64
+
+subroutine omp_erfc_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_erfcf(float {{.*}})
+  y = erfc(x)
+end subroutine omp_erfc_f32
+
+subroutine omp_erfc_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_erfc(double {{.*}})
+  y = erfc(x)
+end subroutine omp_erfc_f64
+
+subroutine omp_exp_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_expf(float {{.*}})
+  y = exp(x)
+end subroutine omp_exp_f32
+
+subroutine omp_exp_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_exp(double {{.*}})
+  y = exp(x)
+end subroutine omp_exp_f64
+
+subroutine omp_log_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_logf(float {{.*}})
+  y = log(x)
+end subroutine omp_log_f32
+
+subroutine omp_log_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_log(double {{.*}})
+  y = log(x)
+end subroutine omp_log_f64
+
+subroutine omp_log10_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_log10f(float {{.*}})
+  y = log10(x)
+end subroutine omp_log10_f32
+
+subroutine omp_log10_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_log10(double {{.*}})
+  y = log10(x)
+end subroutine omp_log10_f64
+
+subroutine omp_sqrt_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_sqrtf(float {{.*}})
+  y = sqrt(x)
+end subroutine omp_sqrt_f32
+
+subroutine omp_sqrt_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_sqrt(double {{.*}})
+  y = sqrt(x)
+end subroutine omp_sqrt_f64
+
+subroutine omp_tan_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_tanf(float {{.*}})
+  y = tan(x)
+end subroutine omp_tan_f32
+
+subroutine omp_tan_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_tan(double {{.*}})
+  y = tan(x)
+end subroutine omp_tan_f64
+
+subroutine omp_tanh_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_tanhf(float {{.*}})
+  y = tanh(x)
+end subroutine omp_tanh_f32
+
+subroutine omp_tanh_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_tanh(double {{.*}})
+  y = tanh(x)
+end subroutine omp_tanh_f64
+
+subroutine omp_acos_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_acosf(float {{.*}})
+  y = acos(x)
+end subroutine omp_acos_f32
+
+subroutine omp_acos_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_acos(double {{.*}})
+  y = acos(x)
+end subroutine omp_acos_f64
+
+subroutine omp_acosh_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_acoshf(float {{.*}})
+  y = acosh(x)
+end subroutine omp_acosh_f32
+
+subroutine omp_acosh_f64(x, y)
+!$omp declare target
+    real(8) :: x, y
+!CHECK: call double @__nv_acosh(double {{.*}})
+    y = acosh(x)
+end subroutine omp_acosh_f64
+
+subroutine omp_asin_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_asinf(float {{.*}})
+  y = asin(x)
+end subroutine omp_asin_f32
+
+subroutine omp_asin_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_asin(double {{.*}})
+  y = asin(x)
+end subroutine omp_asin_f64
+
+subroutine omp_asinh_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_asinhf(float {{.*}})
+  y = asinh(x)
+end subroutine omp_asinh_f32
+
+subroutine omp_asinh_f64(x, y)
+!$omp declare target
+    real(8) :: x, y
+!CHECK: call double @__nv_asinh(double {{.*}})
+    y = asinh(x)
+end subroutine omp_asinh_f64
+
+subroutine omp_cosh_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_coshf(float {{.*}})
+  y = cosh(x)
+end subroutine omp_cosh_f32
+
+subroutine omp_cosh_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_cosh(double {{.*}})
+  y = cosh(x)
+end subroutine omp_cosh_f64
+
+subroutine omp_sinh_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_sinhf(float {{.*}})
+  y = sinh(x)
+end subroutine omp_sinh_f32
+
+subroutine omp_sinh_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_sinh(double {{.*}})
+  y = sinh(x)
+end subroutine omp_sinh_f64
+
+subroutine omp_ceiling_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_ceilf(float {{.*}})
+  y = ceiling(x)
+end subroutine omp_ceiling_f32
+
+subroutine omp_ceiling_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_ceil(double {{.*}})
+  y = ceiling(x)
+end subroutine omp_ceiling_f64
+
+subroutine omp_floor_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__nv_floorf(float {{.*}})
+  y = floor(x)
+end subroutine omp_floor_f32    
+
+subroutine omp_floor_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__nv_floor(double {{.*}})
+  y = floor(x)
+end subroutine omp_floor_f64
+
+subroutine omp_sign_f32(x, y)
+!$omp declare target
+    real :: x, y, z
+!CHECK: call float @__nv_copysignf(float {{.*}}, float {{.*}})
+    y = sign(x, z)
+end subroutine omp_sign_f32
+
+subroutine omp_sign_f64(x, y)
+!$omp declare target
+    real(8) :: x, y, z
+!CHECK: call double @__nv_copysign(double {{.*}}, double {{.*.}})
+    y = sign(x, z)
+end subroutine omp_sign_f64


### PR DESCRIPTION
This Commit adds the MLIR MathToNVVM conversion pass to flang's
NVPTX codegen lowering Math and Arith operations to libdevice library calls.
This allows support for calls to Fortran math intrinsics for OpenMP offload
for NVIDIA Targets.

This is PR (2/2) to fix https://github.com/llvm/llvm-project/issues/147023 and https://github.com/llvm/llvm-project/issues/179347. Commit: 1f39bcf0643a73c840c39b7ee8136d21f4e5cd7e is not apart of this PR and is reviewed in: https://github.com/llvm/llvm-project/pull/180058

Fix #147023  
Fix #179347