### PR TITLE
[flang] Recognize compiler directives after expansion in comment

### DIFF
--- a/flang/include/flang/Parser/preprocessor.h
+++ b/flang/include/flang/Parser/preprocessor.h
@@ -49,8 +49,8 @@ public:
 
   bool set_isDisabled(bool disable);
 
-  TokenSequence Apply(const std::vector<TokenSequence> &args, Prescanner &,
-      bool inIfExpression = false);
+  TokenSequence Apply(const std::vector<TokenSequence> &args,
+      const Prescanner &, bool inIfExpression = false) const;
 
   void Print(llvm::raw_ostream &out, const char *macroName = "") const;
 
@@ -95,7 +95,7 @@ public:
   // that result and try again.  All other Fortran preprocessors share this
   // behavior.
   std::optional<TokenSequence> MacroReplacement(const TokenSequence &,
-      Prescanner &,
+      const Prescanner &,
       std::optional<std::size_t> *partialFunctionLikeMacro = nullptr,
       bool inIfExpression = false);
 
@@ -109,7 +109,7 @@ private:
   enum class CanDeadElseAppear { No, Yes };
 
   CharBlock SaveTokenAsName(const CharBlock &);
-  TokenSequence ReplaceMacros(const TokenSequence &, Prescanner &,
+  TokenSequence ReplaceMacros(const TokenSequence &, const Prescanner &,
       std::optional<std::size_t> *partialFunctionLikeMacro = nullptr,
       bool inIfExpression = false);
   void SkipDisabledConditionalCode(

--- a/flang/lib/Parser/preprocessor.cpp
+++ b/flang/lib/Parser/preprocessor.cpp
@@ -214,7 +214,7 @@ constexpr bool IsDefinedKeyword(CharBlock token) {
 }
 
 TokenSequence Definition::Apply(const std::vector<TokenSequence> &args,
-    Prescanner &prescanner, bool inIfExpression) {
+    const Prescanner &prescanner, bool inIfExpression) const {
   TokenSequence result;
   bool skipping{false};
   int parenthesesNesting{0};
@@ -254,7 +254,9 @@ TokenSequence Definition::Apply(const std::vector<TokenSequence> &args,
         CHECK(resultSize > 0 &&
             result.TokenAt(resultSize - 1) == replacement_.TokenAt(prev - 1));
         result.pop_back();
-        result.CopyAll(Stringify(args[index], prescanner.allSources()));
+        AllSources &allSources{
+            *const_cast<AllSources *>(&prescanner.allSources())};
+        result.CopyAll(Stringify(args[index], allSources));
       } else {
         const TokenSequence *arg{&args[index]};
         std::optional<TokenSequence> replaced;
@@ -267,7 +269,9 @@ TokenSequence Definition::Apply(const std::vector<TokenSequence> &args,
           auto next{replacement_.SkipBlanks(j + 1)};
           if (next >= tokens || !IsTokenPasting(replacement_.TokenAt(next))) {
             // Apply macro replacement to the actual argument
-            replaced = prescanner.preprocessor().MacroReplacement(
+            Preprocessor &preprocessor{
+                *const_cast<Preprocessor *>(&prescanner.preprocessor())};
+            replaced = preprocessor.MacroReplacement(
                 *arg, prescanner, nullptr, inIfExpression);
             if (replaced) {
               arg = &*replaced;
@@ -278,9 +282,9 @@ TokenSequence Definition::Apply(const std::vector<TokenSequence> &args,
       }
     } else if (bytes == 11 && isVariadic_ &&
         token.ToString() == "__VA_ARGS__") {
-      Provenance commaProvenance{
-          prescanner.preprocessor().allSources().CompilerInsertionProvenance(
-              ',')};
+      AllSources &allSources{
+          *const_cast<AllSources *>(&prescanner.allSources())};
+      Provenance commaProvenance{allSources.CompilerInsertionProvenance(',')};
       for (std::size_t k{argumentCount()}; k < args.size(); ++k) {
         if (k > argumentCount()) {
           result.Put(","s, commaProvenance);
@@ -440,7 +444,7 @@ void Preprocessor::Define(const std::string &macro, const std::string &value) {
 void Preprocessor::Undefine(std::string macro) { definitions_.erase(macro); }
 
 std::optional<TokenSequence> Preprocessor::MacroReplacement(
-    const TokenSequence &input, Prescanner &prescanner,
+    const TokenSequence &input, const Prescanner &prescanner,
     std::optional<std::size_t> *partialFunctionLikeMacro, bool inIfExpression) {
   // Do quick scan for any use of a defined name.
   if (!inIfExpression && definitions_.empty()) {
@@ -663,7 +667,7 @@ std::optional<TokenSequence> Preprocessor::MacroReplacement(
 }
 
 TokenSequence Preprocessor::ReplaceMacros(const TokenSequence &tokens,
-    Prescanner &prescanner,
+    const Prescanner &prescanner,
     std::optional<std::size_t> *partialFunctionLikeMacro, bool inIfExpression) {
   if (std::optional<TokenSequence> repl{MacroReplacement(
           tokens, prescanner, partialFunctionLikeMacro, inIfExpression)}) {

--- a/flang/lib/Parser/prescan.h
+++ b/flang/lib/Parser/prescan.h
@@ -81,6 +81,9 @@ public:
   TokenSequence TokenizePreprocessorDirective();
   Provenance GetCurrentProvenance() const { return GetProvenance(at_); }
 
+  std::optional<CharBlock> GetKeywordMacroName(const char *) const;
+  TokenSequence ExpandKeywordMacro(CharBlock, Provenance) const;
+
   const char *IsCompilerDirectiveSentinel(const char *, std::size_t) const;
   const char *IsCompilerDirectiveSentinel(CharBlock) const;
   // 'first' is the sentinel, 'second' is beginning of payload
@@ -109,6 +112,7 @@ private:
       PreprocessorDirective,
       IncludeLine, // Fortran INCLUDE
       CompilerDirective,
+      CompilerDirectiveAfterMacroExpansion, // !MACRO -> !$OMP ...
       Source
     };
     LineClassification(Kind k, std::size_t po = 0, const char *s = nullptr)
@@ -156,7 +160,7 @@ private:
   }
 
   void EmitInsertedChar(TokenSequence &tokens, char ch) {
-    Provenance provenance{allSources_.CompilerInsertionProvenance(ch)};
+    Provenance provenance{allSources().CompilerInsertionProvenance(ch)};
     tokens.PutNextTokenChar(ch, provenance);
   }
 
@@ -240,6 +244,8 @@ private:
   bool SourceFormChange(std::string &&);
   bool CompilerDirectiveContinuation(TokenSequence &, const char *sentinel);
   bool SourceLineContinuation(TokenSequence &);
+  std::optional<LineClassification>
+  IsCompilerDirectiveSentinelAfterKeywordMacro(const char *p) const;
 
   Messages &messages_;
   CookedSource &cooked_;
@@ -298,9 +304,9 @@ private:
   const std::size_t firstCookedCharacterOffset_{cooked_.BufferedBytes()};
 
   const Provenance spaceProvenance_{
-      allSources_.CompilerInsertionProvenance(' ')};
+      allSources().CompilerInsertionProvenance(' ')};
   const Provenance backslashProvenance_{
-      allSources_.CompilerInsertionProvenance('\\')};
+      allSources().CompilerInsertionProvenance('\\')};
 
   // To avoid probing the set of active compiler directive sentinel strings
   // on every comment line, they're checked first with a cheap Bloom filter.

--- a/flang/test/Preprocessing/bug178481.F90
+++ b/flang/test/Preprocessing/bug178481.F90
@@ -1,0 +1,7 @@
+!RUN: %flang_fc1 -fdebug-unparse -fopenmp %s 2>&1 | FileCheck %s
+!CHECK: !$OMP DECLARE TARGET
+#define OMP_DECLARE_TARGET $OMP declare target
+subroutine s
+  !OMP_DECLARE_TARGET
+end
+


### PR DESCRIPTION
The compiler can recognize a compiler directive when one results from a macro expansion at the beginning of a non-comment source line, as in "#define FOO !$OMP".  But it can't recognize a compiler directive that initially appears as a comment line, as in "!BAR" after "#define BAR $OMP".  Extend the prescanner to recognize such cases in free form source.  (Fixed form is a much more complicated case for this recognition and will be addressed later if needed.)

Fixes https://github.com/llvm/llvm-project/issues/178481.