### PR TITLE
[CIR] Implement initial flattening of cleanup scope ops

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -805,6 +805,12 @@ public:
               return mlir::success();
             })
             .Case<cir::GotoOp>([&](auto &gotoOp) {
+              // Correct goto handling requires determining whether the goto
+              // branches out of the cleanup scope or stays within it.
+              // Although the goto necessarily exits the cleanup scope in the
+              // case where it is the only exit from the scope, it is left
+              // as unimplemented for now so that it can be generalized when
+              // multi-exit flattening is implemented.
               cir::UnreachableOp::create(rewriter, loc);
               return gotoOp.emitError(
                   "goto in cleanup scope is not yet implemented");

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -22,6 +22,7 @@
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
 #include "clang/CIR/MissingFeatures.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
 using namespace cir;
@@ -176,6 +177,146 @@ public:
   }
 };
 
+// TODO(cir): Move CleanupExit and collectExits into
+//    CIRCleanupScopeOpFlattening after multi-exit handling is implemented.
+//    They're here for now so that we can use them to emit errors for the
+//    not-yet-implemented multi-exit case.
+
+struct CleanupExit {
+  // An operation that exits the cleanup scope (yield, break, continue,
+  // return, etc.)
+  mlir::Operation *exitOp;
+
+  // A unique identifier for this exit's destination (used for switch dispatch
+  // when there are multiple exits).
+  int destinationId;
+
+  CleanupExit(mlir::Operation *op, int id) : exitOp(op), destinationId(id) {}
+};
+
+// Collect all operations that exit a cleanup scope body. Return, goto, break,
+// and continue can all require branches through the cleanup region. When a loop
+// is encountered, only return and goto are collected because break and continue
+// are handled by the loop and stay within the cleanup scope. When a switch is
+// encountered, return, goto and continue are collected because they may all
+// branch through the cleanup, but break is local to the switch. When a nested
+// cleanup scope is encountered, we recursively collect exits since any return,
+// goto, break, or continue from the nested cleanup will also branch through the
+// outer cleanup.
+//
+// Note that goto statements may not necessarily exit the cleanup scope, but
+// for now we conservatively assume that they do. We'll need more nuanced
+// handling of that when multi-exit flattening is implemented.
+//
+// This function assigns unique destination IDs to each exit, which will be used
+// when multi-exit flattening is implemented.
+static void collectExits(mlir::Region &cleanupBodyRegion,
+                         llvm::SmallVectorImpl<CleanupExit> &exits,
+                         int &nextId) {
+  // Collect yield terminators from the body region. We do this separately
+  // because yields in nested operations, including those in nested cleanup
+  // scopes, won't branch through the outer cleanup region.
+  for (mlir::Block &block : cleanupBodyRegion) {
+    auto *terminator = block.getTerminator();
+    if (isa<cir::YieldOp>(terminator))
+      exits.emplace_back(terminator, nextId++);
+  }
+
+  // Lambda to walk a loop and collect only returns and gotos.
+  // Break and continue inside loops are handled by the loop itself.
+  // Loops don't require special handling for nested switch or cleanup scopes
+  // because break and continue never branch out of the loop.
+  auto collectExitsInLoop = [&](mlir::Operation *loopOp) {
+    loopOp->walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *nestedOp) {
+      if (isa<cir::ReturnOp, cir::GotoOp>(nestedOp))
+        exits.emplace_back(nestedOp, nextId++);
+      return mlir::WalkResult::advance();
+    });
+  };
+
+  // Forward declaration for mutual recursion.
+  std::function<void(mlir::Region &, bool)> collectExitsInCleanup;
+  std::function<void(mlir::Operation *)> collectExitsInSwitch;
+
+  // Lambda to collect exits from a switch. Collects return/goto/continue but
+  // not break (handled by switch). For nested loops/cleanups, recurses.
+  collectExitsInSwitch = [&](mlir::Operation *switchOp) {
+    switchOp->walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *nestedOp) {
+      if (isa<cir::CleanupScopeOp>(nestedOp)) {
+        // Walk the nested cleanup, but ignore break statements because they
+        // will be handled by the switch we are currently walking.
+        collectExitsInCleanup(
+            cast<cir::CleanupScopeOp>(nestedOp).getBodyRegion(),
+            /*ignoreBreak=*/true);
+        return mlir::WalkResult::skip();
+      } else if (isa<cir::LoopOpInterface>(nestedOp)) {
+        collectExitsInLoop(nestedOp);
+        return mlir::WalkResult::skip();
+      } else if (isa<cir::ReturnOp, cir::GotoOp, cir::ContinueOp>(nestedOp)) {
+        exits.emplace_back(nestedOp, nextId++);
+      }
+      return mlir::WalkResult::advance();
+    });
+  };
+
+  // Lambda to collect exits from a cleanup scope body region. This collects
+  // break (optionally), continue, return, and goto, handling nested loops,
+  // switches, and cleanups appropriately.
+  collectExitsInCleanup = [&](mlir::Region &region, bool ignoreBreak) {
+    region.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+      // We need special handling for break statements because if this cleanup
+      // scope was nested within a switch op, break will be handled by the
+      // switch operation and therefore won't exit the cleanup scope enclosing
+      // the switch. We're only collecting exits from the cleanup that started
+      // this walk. Exits from nested cleanups will be handled when we flatten
+      // the nested cleanup.
+      if (!ignoreBreak && isa<cir::BreakOp>(op)) {
+        exits.emplace_back(op, nextId++);
+      } else if (isa<cir::ContinueOp, cir::ReturnOp, cir::GotoOp>(op)) {
+        exits.emplace_back(op, nextId++);
+      } else if (isa<cir::CleanupScopeOp>(op)) {
+        // Recurse into nested cleanup's body region.
+        collectExitsInCleanup(cast<cir::CleanupScopeOp>(op).getBodyRegion(),
+                              /*ignoreBreak=*/ignoreBreak);
+        return mlir::WalkResult::skip();
+      } else if (isa<cir::LoopOpInterface>(op)) {
+        // This kicks off a separate walk rather than continuing to dig deeper
+        // in the current walk because we need to handle break and continue
+        // differently inside loops.
+        collectExitsInLoop(op);
+        return mlir::WalkResult::skip();
+      } else if (isa<cir::SwitchOp>(op)) {
+        // This kicks off a separate walk rather than continuing to dig deeper
+        // in the current walk because we need to handle break differently
+        // inside switches.
+        collectExitsInSwitch(op);
+        return mlir::WalkResult::skip();
+      }
+      return mlir::WalkResult::advance();
+    });
+  };
+
+  // Collect exits from the body region.
+  collectExitsInCleanup(cleanupBodyRegion, /*ignoreBreak=*/false);
+}
+
+// Check if this operation is within a cleanup scope or contains a cleanup
+// scope with multiple exits. Either of these are unimplemented conditions and
+// should trigger an error for now. This is a temporary check that is only
+// needed until multi-exit cleanup flattening is implemented.
+static bool enclosedByCleanupScopeWithMultipleExits(mlir::Operation *op) {
+  int nextId = 0;
+  cir::CleanupScopeOp cleanupParent =
+      op->getParentOfType<cir::CleanupScopeOp>();
+  if (!cleanupParent)
+    return false;
+  llvm::SmallVector<CleanupExit> exits;
+  collectExits(cleanupParent.getBodyRegion(), exits, nextId);
+  if (exits.size() > 1)
+    return true;
+  return false;
+}
+
 class CIRSwitchOpFlattening : public mlir::OpRewritePattern<cir::SwitchOp> {
 public:
   using OpRewritePattern<cir::SwitchOp>::OpRewritePattern;
@@ -226,6 +367,21 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::SwitchOp op,
                   mlir::PatternRewriter &rewriter) const override {
+    // Cleanup scopes must be lowered before the enclosing switch so that
+    // break inside them is properly routed through cleanup.
+    // Fail the match so the pattern rewriter will process cleanup scopes first.
+    bool hasNestedCleanup = false;
+    op->walk([&](cir::CleanupScopeOp) { hasNestedCleanup = true; });
+    if (hasNestedCleanup)
+      return mlir::failure();
+
+    // Don't flatten switches that contain cleanup scopes with multiple exits
+    // (break/continue/return/goto). Those cleanup scopes need multi-exit
+    // handling (destination slot + switch dispatch) which is not yet
+    // implemented.
+    if (enclosedByCleanupScopeWithMultipleExits(op))
+      return op->emitError("Cannot lower switch: cleanup with multiple exits");
+
     llvm::SmallVector<CaseOp> cases;
     op.collectCases(cases);
 
@@ -421,6 +577,21 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::LoopOpInterface op,
                   mlir::PatternRewriter &rewriter) const final {
+    // Cleanup scopes must be lowered before the enclosing loop so that
+    // break/continue inside them are properly routed through cleanup.
+    // Fail the match so the pattern rewriter will process cleanup scopes first.
+    bool hasNestedCleanup = false;
+    op->walk([&](cir::CleanupScopeOp) { hasNestedCleanup = true; });
+    if (hasNestedCleanup)
+      return mlir::failure();
+
+    // Don't flatten loops that contain cleanup scopes with multiple exits
+    // (break/continue/return/goto). Those cleanup scopes need multi-exit
+    // handling (destination slot + switch dispatch) which is not yet
+    // implemented.
+    if (enclosedByCleanupScopeWithMultipleExits(op))
+      return op->emitError("Cannot lower loop: cleanup with multiple exits");
+
     // Setup CFG blocks.
     mlir::Block *entry = rewriter.getInsertionBlock();
     mlir::Block *exit =
@@ -453,8 +624,7 @@ public:
     });
 
     // Lower break statements.
-    assert(!cir::MissingFeatures::switchOp());
-    walkRegionSkipping<cir::LoopOpInterface>(
+    walkRegionSkipping<cir::LoopOpInterface, cir::SwitchOp>(
         op.getBody(), [&](mlir::Operation *op) {
           if (!isa<cir::BreakOp>(op))
             return mlir::WalkResult::advance();
@@ -556,6 +726,139 @@ public:
   }
 };
 
+class CIRCleanupScopeOpFlattening
+    : public mlir::OpRewritePattern<cir::CleanupScopeOp> {
+public:
+  using OpRewritePattern<cir::CleanupScopeOp>::OpRewritePattern;
+
+  // Flatten a cleanup scope with a single exit destination.
+  // The body region's exit branches to the cleanup block, the cleanup block
+  // branches to a cleanup exit block whose contents depend on the type of
+  // operation that exited the body region. Yield becomes a branch to the
+  // block after the cleanup scope, break and continue are preserved
+  // for later lowering by enclosing switch or loop. Return is preserved as is.
+  mlir::LogicalResult
+  flattenSimpleCleanup(cir::CleanupScopeOp cleanupOp, mlir::Operation *exitOp,
+                       mlir::PatternRewriter &rewriter) const {
+    mlir::Location loc = cleanupOp.getLoc();
+
+    // Get references to region blocks before inlining.
+    mlir::Block *bodyEntry = &cleanupOp.getBodyRegion().front();
+    mlir::Block *cleanupEntry = &cleanupOp.getCleanupRegion().front();
+    mlir::Block *cleanupExit = &cleanupOp.getCleanupRegion().back();
+
+    auto cleanupYield = dyn_cast<cir::YieldOp>(cleanupExit->getTerminator());
+    if (!cleanupYield) {
+      return rewriter.notifyMatchFailure(cleanupOp,
+                                         "Not yet implemented: cleanup region "
+                                         "terminated with non-yield operation");
+    }
+
+    // Split the current block to create the insertion point.
+    mlir::Block *currentBlock = rewriter.getInsertionBlock();
+    mlir::Block *continueBlock =
+        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+
+    // Inline the body region.
+    rewriter.inlineRegionBefore(cleanupOp.getBodyRegion(), continueBlock);
+
+    // Inline the cleanup region after the body.
+    rewriter.inlineRegionBefore(cleanupOp.getCleanupRegion(), continueBlock);
+
+    // Branch from current block to body entry.
+    rewriter.setInsertionPointToEnd(currentBlock);
+    cir::BrOp::create(rewriter, loc, bodyEntry);
+
+    // Create a block for the exit terminator (after cleanup, before continue).
+    mlir::Block *exitBlock = rewriter.createBlock(continueBlock);
+
+    // Rewrite the cleanup region's yield to branch to exit block.
+    rewriter.setInsertionPoint(cleanupYield);
+    rewriter.replaceOpWithNewOp<cir::BrOp>(cleanupYield, exitBlock);
+
+    // Put the appropriate terminator in the exit block.
+    rewriter.setInsertionPointToEnd(exitBlock);
+    llvm::TypeSwitch<mlir::Operation *, void>(exitOp)
+        .Case<cir::YieldOp>([&](auto) {
+          // Yield becomes a branch to continue block.
+          cir::BrOp::create(rewriter, loc, continueBlock);
+        })
+        .Case<cir::BreakOp>([&](auto) {
+          // Break is preserved for later lowering by enclosing switch/loop.
+          cir::BreakOp::create(rewriter, loc);
+        })
+        .Case<cir::ContinueOp>([&](auto) {
+          // Continue is preserved for later lowering by enclosing loop.
+          cir::ContinueOp::create(rewriter, loc);
+        })
+        .Case<cir::ReturnOp>([&](auto returnOp) {
+          // Return from the cleanup exit. Note, if this is a return inside a
+          // nested cleanup scope, the flattening of the outer scope will handle
+          // branching through the outer cleanup.
+          if (returnOp.hasOperand())
+            cir::ReturnOp::create(rewriter, loc, returnOp.getOperands());
+          else
+            cir::ReturnOp::create(rewriter, loc);
+        })
+        .Default([&](mlir::Operation *op) {
+          op->emitError("unexpected terminator in cleanup scope body");
+        });
+
+    // Replace body exit with branch to cleanup entry.
+    rewriter.setInsertionPoint(exitOp);
+    rewriter.replaceOpWithNewOp<cir::BrOp>(exitOp, cleanupEntry);
+
+    // Erase the original cleanup scope op.
+    rewriter.eraseOp(cleanupOp);
+
+    return mlir::success();
+  }
+
+  // Flatten a cleanup scope with multiple exit destinations.
+  // Uses a destination slot and switch dispatch after cleanup.
+  mlir::LogicalResult
+  flattenMultiExitCleanup(cir::CleanupScopeOp cleanupOp,
+                          llvm::SmallVectorImpl<CleanupExit> &exits,
+                          mlir::PatternRewriter &rewriter) const {
+    // This will implement the destination slot mechanism:
+    // 1. Allocate a destination slot at function entry
+    // 2. Each exit stores its destination ID to the slot
+    // 3. All exits branch to cleanup entry
+    // 4. Cleanup branches to a dispatch block
+    // 5. Dispatch block loads slot and switches to correct destination
+    //
+    // For now, we report this as a match failure and leave the cleanup scope
+    // unchanged. The cleanup scope must remain inside its enclosing loop so
+    // that break/continue ops remain valid.
+    return cleanupOp->emitError(
+        "cleanup scope with multiple exits is not yet implemented");
+  }
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::CleanupScopeOp cleanupOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    mlir::OpBuilder::InsertionGuard guard(rewriter);
+
+    // Only handle normal cleanups for now - EH and "all" cleanups are NYI.
+    cir::CleanupKind cleanupKind = cleanupOp.getCleanupKind();
+    if (cleanupKind != cir::CleanupKind::Normal)
+      return cleanupOp->emitError(
+          "EH cleanup flattening is not yet implemented");
+
+    // Collect all exits from the body region.
+    llvm::SmallVector<CleanupExit> exits;
+    int nextId = 0;
+    collectExits(cleanupOp.getBodyRegion(), exits, nextId);
+
+    if (exits.size() > 1)
+      return flattenMultiExitCleanup(cleanupOp, exits, rewriter);
+
+    assert(!exits.empty() && "cleanup scope body has no exit");
+
+    return flattenSimpleCleanup(cleanupOp, exits[0].exitOp, rewriter);
+  }
+};
+
 class CIRTryOpFlattening : public mlir::OpRewritePattern<cir::TryOp> {
 public:
   using OpRewritePattern<cir::TryOp>::OpRewritePattern;
@@ -651,7 +954,8 @@ public:
 void populateFlattenCFGPatterns(RewritePatternSet &patterns) {
   patterns
       .add<CIRIfFlattening, CIRLoopOpInterfaceFlattening, CIRScopeOpFlattening,
-           CIRSwitchOpFlattening, CIRTernaryOpFlattening, CIRTryOpFlattening>(
+           CIRSwitchOpFlattening, CIRTernaryOpFlattening,
+           CIRCleanupScopeOpFlattening, CIRTryOpFlattening>(
           patterns.getContext());
 }
 
@@ -662,7 +966,8 @@ void CIRFlattenCFGPass::runOnOperation() {
   // Collect operations to apply patterns.
   llvm::SmallVector<Operation *, 16> ops;
   getOperation()->walk<mlir::WalkOrder::PostOrder>([&](Operation *op) {
-    if (isa<IfOp, ScopeOp, SwitchOp, LoopOpInterface, TernaryOp, TryOp>(op))
+    if (isa<IfOp, ScopeOp, SwitchOp, LoopOpInterface, TernaryOp, CleanupScopeOp,
+            TryOp>(op))
       ops.push_back(op);
   });
 

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-eh-nyi.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-eh-nyi.cir
@@ -1,0 +1,38 @@
+// RUN: cir-opt %s -cir-flatten-cfg -verify-diagnostics -o -
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test that we issue a diagnostic for EH-only cleanup scopes.
+cir.func @test_eh_only_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  // expected-error @below {{EH cleanup flattening is not yet implemented}}
+  cir.cleanup.scope {
+    cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  } cleanup eh {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// Test that we issue a diagnostic for Normal+EH cleanup scopes.
+cir.func @test_all_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  // expected-error @below {{EH cleanup flattening is not yet implemented}}
+  cir.cleanup.scope {
+    cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  } cleanup all {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+cir.func private @doSomething(!cir.ptr<!rec_SomeClass>)

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-multi-exit.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-multi-exit.cir
@@ -1,0 +1,413 @@
+// RUN: cir-opt %s -cir-flatten-cfg -verify-diagnostics -split-input-file -o -
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test that we detect multiple exits in a loop with a break that branches
+// through a cleanup region.
+cir.func @test_multi_exit_with_break() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.while {
+    %true = cir.const #cir.bool<true> : !cir.bool
+    cir.condition(%true)
+  } do {
+    cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+    cir.cleanup.scope {
+      %cond = cir.call @shouldBreak() : () -> !cir.bool
+      cir.brcond %cond ^bb_break, ^bb_normal
+    ^bb_break:
+      cir.break  // Break through cleanup - exits loop
+    ^bb_normal:
+      cir.yield  // Normal exit through cleanup
+    } cleanup normal {
+      cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  }
+  cir.return
+}
+
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+cir.func private @shouldBreak() -> !cir.bool
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test that we detect multiple exits in a loop with a continue that branches
+// through a cleanup region.
+cir.func @test_multi_exit_with_continue() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.while {
+    %true = cir.const #cir.bool<true> : !cir.bool
+    cir.condition(%true)
+  } do {
+    cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+    cir.cleanup.scope {
+      %cond = cir.call @shouldContinue() : () -> !cir.bool
+      cir.brcond %cond ^bb_continue, ^bb_normal
+    ^bb_continue:
+      cir.continue  // Continue through cleanup - exits the region
+    ^bb_normal:
+      cir.yield  // Normal exit through cleanup
+    } cleanup normal {
+      cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  }
+  cir.return
+}
+
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+cir.func private @shouldContinue() -> !cir.bool
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test that we detect multiple exits in a switch statatement nested within a
+// loop with a continue statement inside the switch that branches through a
+// cleanup region.
+cir.func @test_continue_in_switch() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.while {
+    %true = cir.const #cir.bool<true> : !cir.bool
+    cir.condition(%true)
+  } do {
+    cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+    cir.cleanup.scope {
+      %x = cir.const #cir.int<1> : !s32i
+      // expected-error @below {{Cannot lower switch: cleanup with multiple exits}}
+      cir.switch (%x : !s32i) {
+        cir.case (equal, [#cir.int<1> : !s32i]) {
+          cir.break     // Break from switch -- no cleanup exit
+        }
+        cir.case (equal, [#cir.int<2> : !s32i]) {
+          cir.continue  // Continue to outer loop - exits through cleanup!
+        }
+        cir.yield
+      }
+      cir.yield  // Normal exit through cleanup
+    } cleanup normal {
+      cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  }
+  cir.return
+}
+
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test that we detect return inside a loop inside a switch inside a cleanup
+// scope. The return must be found even though it's nested inside the loop.
+cir.func @test_return_in_loop_in_switch() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.while {
+    %true = cir.const #cir.bool<true> : !cir.bool
+    cir.condition(%true)
+  } do {
+    cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+    cir.cleanup.scope {
+      %x = cir.const #cir.int<1> : !s32i
+      // expected-error @below {{Cannot lower switch: cleanup with multiple exits}}
+      cir.switch (%x : !s32i) {
+        cir.case (equal, [#cir.int<1> : !s32i]) {
+          // Nested loop inside switch
+          // expected-error @below {{Cannot lower loop: cleanup with multiple exits}}
+          cir.while {
+            %cond = cir.call @shouldContinue() : () -> !cir.bool
+            cir.condition(%cond)
+          } do {
+            %ret = cir.call @shouldReturn() : () -> !cir.bool
+            cir.brcond %ret ^bb_return, ^bb_continue
+          ^bb_return:
+            cir.return  // Return inside loop inside switch - exits through cleanup!
+          ^bb_continue:
+            cir.yield
+          }
+          cir.break  // Break from switch - handled by switch
+        }
+        cir.yield
+      }
+      cir.yield  // Normal exit through cleanup
+    } cleanup normal {
+      cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  }
+  cir.return
+}
+
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+cir.func private @shouldContinue() -> !cir.bool
+cir.func private @shouldReturn() -> !cir.bool
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test that a return inside nested cleanup scopes causes both to be detected
+// as having multiple exits. The return must go through both cleanup regions.
+cir.func @test_return_in_nested_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c1", init] {alignment = 4 : i64}
+  %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+  cir.cleanup.scope {
+    cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+    // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+    cir.cleanup.scope {
+      %cond = cir.call @shouldReturn() : () -> !cir.bool
+      cir.brcond %cond ^bb_return, ^bb_normal
+    ^bb_return:
+      cir.return  // Return exits through BOTH cleanup scopes
+    ^bb_normal:
+      cir.yield
+    } cleanup normal {
+      cir.call @dtor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+cir.func private @shouldReturn() -> !cir.bool
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test that a goto inside nested cleanup scopes causes both to be detected
+// as having multiple exits. The goto must go through both cleanup regions.
+cir.func @test_goto_in_nested_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c1", init] {alignment = 4 : i64}
+  %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+  cir.cleanup.scope {
+    cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+    // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+    cir.cleanup.scope {
+      %cond = cir.call @shouldGoto() : () -> !cir.bool
+      cir.brcond %cond ^bb_goto, ^bb_normal
+    ^bb_goto:
+      cir.goto "target"  // Goto exits through BOTH cleanup scopes
+    ^bb_normal:
+      cir.yield
+    } cleanup normal {
+      cir.call @dtor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.br ^bb_end
+^bb_goto_target:
+  cir.label "target"
+  cir.br ^bb_end
+^bb_end:
+  cir.return
+}
+
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+cir.func private @shouldGoto() -> !cir.bool
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test that a break inside nested cleanup scopes (within a loop) causes both
+// to be detected as having multiple exits. The break exits through both cleanups.
+cir.func @test_break_in_nested_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c1", init] {alignment = 4 : i64}
+  %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
+  cir.while {
+    %true = cir.const #cir.bool<true> : !cir.bool
+    cir.condition(%true)
+  } do {
+    cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+    cir.cleanup.scope {
+      cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+      // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+      cir.cleanup.scope {
+        %cond = cir.call @shouldBreak() : () -> !cir.bool
+        cir.brcond %cond ^bb_break, ^bb_normal
+      ^bb_break:
+        cir.break  // Break exits through BOTH cleanup scopes, then exits loop
+      ^bb_normal:
+        cir.yield
+      } cleanup normal {
+        cir.call @dtor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+        cir.yield
+      }
+      cir.yield
+    } cleanup normal {
+      cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  }
+  cir.return
+}
+
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+cir.func private @shouldBreak() -> !cir.bool
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test that a continue inside nested cleanup scopes (within a loop) causes both
+// to be detected as having multiple exits. The continue exits through both cleanups.
+cir.func @test_continue_in_nested_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c1", init] {alignment = 4 : i64}
+  %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
+  cir.while {
+    %true = cir.const #cir.bool<true> : !cir.bool
+    cir.condition(%true)
+  } do {
+    cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+    cir.cleanup.scope {
+      cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+      // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+      cir.cleanup.scope {
+        %cond = cir.call @shouldContinue() : () -> !cir.bool
+        cir.brcond %cond ^bb_continue, ^bb_normal
+      ^bb_continue:
+        cir.continue  // Continue exits through BOTH cleanup scopes, then continues loop
+      ^bb_normal:
+        cir.yield
+      } cleanup normal {
+        cir.call @dtor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+        cir.yield
+      }
+      cir.yield
+    } cleanup normal {
+      cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  }
+  cir.return
+}
+
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+cir.func private @shouldContinue() -> !cir.bool
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test a cleanup scope containing a switch which contains a nested cleanup
+// scope with a continue. The continue must branch through both cleanup scopes.
+cir.func @test_continue_in_nested_cleanup_in_switch() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c1", init] {alignment = 4 : i64}
+  %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
+  %2 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init] {alignment = 4 : i64}
+  cir.while {
+    %true = cir.const #cir.bool<true> : !cir.bool
+    cir.condition(%true)
+  } do {
+    cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+    cir.cleanup.scope {
+      %x = cir.load %2 : !cir.ptr<!s32i>, !s32i
+      // expected-error @below {{Cannot lower switch: cleanup with multiple exits}}
+      cir.switch (%x : !s32i) {
+        cir.case (equal, [#cir.int<1> : !s32i]) {
+          cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+          cir.cleanup.scope {
+            cir.continue  // Branches through both cleanups
+          } cleanup normal {
+            cir.call @dtor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+            cir.yield
+          }
+          cir.break
+        }
+        cir.yield
+      }
+      cir.yield
+    } cleanup normal {
+      cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  }
+  cir.return
+}
+
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+
+// -----
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test a cleanup scope containing a loop with a conditional return.
+// The return must branch through the cleanup scope.
+cir.func @test_return_in_loop_in_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
+  cir.cleanup.scope {
+    // expected-error @below {{Cannot lower loop: cleanup with multiple exits}}
+    cir.while {
+      %true = cir.const #cir.bool<true> : !cir.bool
+      cir.condition(%true)
+    } do {
+      %cond = cir.call @shouldReturn() : () -> !cir.bool
+      cir.brcond %cond ^bb_return, ^bb_continue
+    ^bb_return:
+      cir.return  // Return branches through cleanup
+    ^bb_continue:
+      cir.yield
+    }
+    cir.yield
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+cir.func private @shouldReturn() -> !cir.bool

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-multi-exit.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-multi-exit.cir
@@ -73,7 +73,7 @@ cir.func private @shouldContinue() -> !cir.bool
 !s32i = !cir.int<s, 32>
 !rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
 
-// Test that we detect multiple exits in a switch statatement nested within a
+// Test that we detect multiple exits in a switch statement nested within a
 // loop with a continue statement inside the switch that branches through a
 // cleanup region.
 cir.func @test_continue_in_switch() {
@@ -86,7 +86,7 @@ cir.func @test_continue_in_switch() {
     // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
     cir.cleanup.scope {
       %x = cir.const #cir.int<1> : !s32i
-      // expected-error @below {{Cannot lower switch: cleanup with multiple exits}}
+      // expected-error @below {{cannot lower switch: cleanup with multiple exits}}
       cir.switch (%x : !s32i) {
         cir.case (equal, [#cir.int<1> : !s32i]) {
           cir.break     // Break from switch -- no cleanup exit
@@ -126,11 +126,11 @@ cir.func @test_return_in_loop_in_switch() {
     // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
     cir.cleanup.scope {
       %x = cir.const #cir.int<1> : !s32i
-      // expected-error @below {{Cannot lower switch: cleanup with multiple exits}}
+      // expected-error @below {{cannot lower switch: cleanup with multiple exits}}
       cir.switch (%x : !s32i) {
         cir.case (equal, [#cir.int<1> : !s32i]) {
           // Nested loop inside switch
-          // expected-error @below {{Cannot lower loop: cleanup with multiple exits}}
+          // expected-error @below {{cannot lower loop: cleanup with multiple exits}}
           cir.while {
             %cond = cir.call @shouldContinue() : () -> !cir.bool
             cir.condition(%cond)
@@ -349,7 +349,7 @@ cir.func @test_continue_in_nested_cleanup_in_switch() {
     // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
     cir.cleanup.scope {
       %x = cir.load %2 : !cir.ptr<!s32i>, !s32i
-      // expected-error @below {{Cannot lower switch: cleanup with multiple exits}}
+      // expected-error @below {{cannot lower switch: cleanup with multiple exits}}
       cir.switch (%x : !s32i) {
         cir.case (equal, [#cir.int<1> : !s32i]) {
           cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
@@ -388,7 +388,7 @@ cir.func @test_return_in_loop_in_cleanup() {
   cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
   // expected-error @below {{cleanup scope with multiple exits is not yet implemented}}
   cir.cleanup.scope {
-    // expected-error @below {{Cannot lower loop: cleanup with multiple exits}}
+    // expected-error @below {{cannot lower loop: cleanup with multiple exits}}
     cir.while {
       %true = cir.const #cir.bool<true> : !cir.bool
       cir.condition(%true)

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
@@ -33,6 +33,27 @@ cir.func @test_all_cleanup() {
   cir.return
 }
 
+// Test that we issue a diagnostic for a single goto out of a cleanup scope.
+// Strictly speaking, we could handle this case, but it's left unimplemented
+// because when we handle multiple exits we'll need to do something to determine
+// whether gotos branch out of the cleanup scope or stay within it.
+cir.func @test_goto_out_of_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    // expected-error @below {{goto in cleanup scope is not yet implemented}}
+    cir.goto "exit"
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.br ^bb1
+^bb1:
+  cir.label "exit"
+  cir.return
+}
+
 cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
 cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
 cir.func private @doSomething(!cir.ptr<!rec_SomeClass>)

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-simple.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-simple.cir
@@ -1,0 +1,505 @@
+// RUN: cir-opt %s -cir-flatten-cfg -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+!s32i = !cir.int<s, 32>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+
+// Test basic cleanup scope flattening with normal cleanup.
+// The body yields to cleanup, cleanup yields to continue.
+cir.func @test_normal_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_normal_cleanup()
+// CHECK:         %[[ALLOCA:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.call @ctor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[BODY:bb[0-9]+]]
+// CHECK:       ^[[BODY]]:
+// CHECK:         cir.call @doSomething(%[[ALLOCA]])
+// CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.return
+
+// Test that a single return from the cleanup body branches through the cleanup.
+cir.func @test_return_from_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.return // Should branch through cleanup
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_return_from_cleanup()
+// CHECK:         %[[ALLOCA:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.call @ctor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[BODY:bb[0-9]+]]
+// CHECK:       ^[[BODY]]:
+// CHECK:         cir.call @doSomething(%[[ALLOCA]])
+// CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[CLEANUP_EXIT:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP_EXIT]]:
+// CHECK:         cir.return
+
+// Test that a continue statement in a cleanup scope branches through the
+// cleanup block before continuing the loop.
+cir.func @test_continue_in_cleanup_in_loop() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.while {
+    %cond = cir.call @shouldContinue() : () -> !cir.bool
+    cir.condition(%cond)
+  } do {
+    %cont = cir.call @shouldContinue() : () -> !cir.bool
+    cir.brcond %cont ^bb_continue, ^bb_normal
+  ^bb_continue:
+    cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.cleanup.scope {
+      cir.continue  // Branches through cleanup
+    } cleanup normal {
+      cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.br ^bb_normal
+  ^bb_normal:
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_continue_in_cleanup_in_loop()
+// CHECK:         %[[ALLOCA:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.br ^[[LOOP_COND:bb[0-9]+]]
+// CHECK:       ^[[LOOP_COND]]:
+// CHECK:         %[[COND1:.*]] = cir.call @shouldContinue() : () -> !cir.bool
+// CHECK:         cir.brcond %[[COND1]] ^[[LOOP_BODY:bb[0-9]+]], ^[[LOOP_EXIT:bb[0-9]+]]
+// CHECK:       ^[[LOOP_BODY]]:
+// CHECK:         %[[COND2:.*]] = cir.call @shouldContinue() : () -> !cir.bool
+// CHECK:         cir.brcond %[[COND2]] ^[[CONTINUE_PATH:bb[0-9]+]], ^[[NORMAL_PATH:bb[0-9]+]]
+// CHECK:       ^[[CONTINUE_PATH]]:
+// CHECK:         cir.call @ctor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[CLEANUP_BODY:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP_BODY]]:
+// CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[CLEANUP_EXIT:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP_EXIT]]:
+// CHECK:         cir.br ^[[LOOP_COND]]
+// CHECK:       ^[[NORMAL_PATH]]:
+// CHECK:         cir.br ^[[LOOP_COND]]
+// CHECK:       ^[[LOOP_EXIT]]:
+// CHECK:         cir.return
+
+// Test that a break statement in a cleanup scope branches through the
+// cleanup block before breaking out of the loop.
+cir.func @test_break_in_cleanup_in_loop() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.while {
+    %cond = cir.call @shouldContinue() : () -> !cir.bool
+    cir.condition(%cond)
+  } do {
+    %cont = cir.call @shouldContinue() : () -> !cir.bool
+    cir.brcond %cont ^bb_continue, ^bb_normal
+  ^bb_continue:
+    cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.cleanup.scope {
+      cir.break  // Branches through cleanup
+    } cleanup normal {
+      cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.br ^bb_normal
+  ^bb_normal:
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_break_in_cleanup_in_loop()
+// CHECK:         %[[ALLOCA:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.br ^[[LOOP_COND:bb[0-9]+]]
+// CHECK:       ^[[LOOP_COND]]:
+// CHECK:         %[[COND1:.*]] = cir.call @shouldContinue() : () -> !cir.bool
+// CHECK:         cir.brcond %[[COND1]] ^[[LOOP_BODY:bb[0-9]+]], ^[[LOOP_EXIT:bb[0-9]+]]
+// CHECK:       ^[[LOOP_BODY]]:
+// CHECK:         %[[COND2:.*]] = cir.call @shouldContinue() : () -> !cir.bool
+// CHECK:         cir.brcond %[[COND2]] ^[[CONTINUE_PATH:bb[0-9]+]], ^[[NORMAL_PATH:bb[0-9]+]]
+// CHECK:       ^[[CONTINUE_PATH]]:
+// CHECK:         cir.call @ctor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[CLEANUP_BODY:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP_BODY]]:
+// CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[CLEANUP_EXIT:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP_EXIT]]:
+// CHECK:         cir.br ^[[LOOP_EXIT]]
+// CHECK:       ^[[NORMAL_PATH]]:
+// CHECK:         cir.br ^[[LOOP_COND]]
+// CHECK:       ^[[LOOP_EXIT]]:
+// CHECK:         cir.return
+
+// Test nested cleanup scopes.
+cir.func @test_nested_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c1", init] {alignment = 4 : i64}
+  %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.cleanup.scope {
+      cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    } cleanup normal {
+      cir.call @dtor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_nested_cleanup()
+// CHECK:         %[[ALLOCA1:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         %[[ALLOCA2:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.call @ctor(%[[ALLOCA1]])
+// CHECK:         cir.br ^[[OUTER_BODY:bb[0-9]+]]
+// CHECK:       ^[[OUTER_BODY]]:
+// CHECK:         cir.call @ctor(%[[ALLOCA2]])
+// CHECK:         cir.br ^[[INNER_BODY:bb[0-9]+]]
+// CHECK:       ^[[INNER_BODY]]:
+// CHECK:         cir.call @doSomething(%[[ALLOCA1]])
+// CHECK:         cir.br ^[[INNER_CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[INNER_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA2]])
+// CHECK:         cir.br ^[[AFTER_INNER:bb[0-9]+]]
+// CHECK:       ^[[AFTER_INNER]]:
+// CHECK:         cir.br ^[[OUTER_CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[OUTER_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA1]])
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.return
+
+// Test a switch within a cleanup scope where the switch does not branch
+// through the cleanup.
+cir.func @test_normal_cleanup_with_switch() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    %1 = cir.call @get() : () -> !s32i
+    cir.switch (%1 : !s32i) {
+      cir.case (equal, [#cir.int<1> : !s32i]) {
+        cir.break  // Break from switch -- no cleanup exit
+      }
+      cir.case (equal, [#cir.int<2> : !s32i]) {
+        cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+        cir.break  // Break from switch -- no cleanup exit
+      }
+      cir.yield // Yield from switch -- no cleanup exit
+    }
+    cir.yield  // Normal exit through cleanup
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_normal_cleanup_with_switch()
+// CHECK:         %[[ALLOCA:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.call @ctor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[BODY:bb[0-9]+]]
+// CHECK:       ^[[BODY]]:
+// CHECK:         %[[X:.*]] = cir.call @get() : () -> !s32i
+// CHECK:         cir.br ^[[SWITCH:bb[0-9]+]]
+// CHECK:       ^[[SWITCH]]:
+// CHECK:         cir.switch.flat %[[X]] : !s32i, ^bb6 [
+// CHECK:           1: ^[[BREAK:bb[0-9]+]],
+// CHECK:           2: ^[[CALL:bb[0-9]+]]
+// CHECK:         ]
+// CHECK:       ^[[FALLTHROUGH:bb[0-9]+]]:
+// CHECK:         cir.br ^[[BREAK]]
+// CHECK:       ^[[BREAK]]:
+// CHECK:         cir.br ^[[SWITCH_END:bb[0-9]+]]
+// CHECK:       ^[[CALL]]:
+// CHECK:         cir.call @doSomething(%[[ALLOCA]])
+// CHECK:         cir.br ^[[SWITCH_END]]
+// CHECK:       ^[[SWITCH_END]]:
+// CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[DONE:bb[0-9]+]]
+// CHECK:       ^[[DONE]]:
+// CHECK:         cir.return
+
+// Test a loop within a cleanup scope where the loop's break and continue are
+// handled by the loop itself, so only the yield after the loop exits through
+// the cleanup.
+cir.func @test_loop_in_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.while {
+      %cond = cir.call @shouldContinue() : () -> !cir.bool
+      cir.condition(%cond)
+    } do {
+      %brk = cir.call @shouldBreak() : () -> !cir.bool
+      cir.brcond %brk ^bb_break, ^bb_continue
+    ^bb_break:
+      cir.break     // Break from loop - handled by loop, no cleanup exit
+    ^bb_continue:
+      cir.continue  // Continue loop - handled by loop, no cleanup exit
+    }
+    cir.yield  // Normal exit through cleanup
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_loop_in_cleanup()
+// CHECK:         %[[ALLOCA:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.call @ctor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[LOOP_BEGIN:bb[0-9]+]]
+// CHECK:       ^[[LOOP_BEGIN]]:
+// CHECK:         cir.br ^[[COND:bb[0-9]+]]
+// CHECK:       ^[[COND]]:
+// CHECK:         %[[SHOULDCONT:.*]] = cir.call @shouldContinue
+// CHECK:         cir.brcond %[[SHOULDCONT]] ^[[LOOP_BODY:bb[0-9]+]], ^[[LOOP_EXIT:bb[0-9]+]]
+// CHECK:       ^[[LOOP_BODY]]:
+// CHECK:         %[[SHOULDBRK:.*]] = cir.call @shouldBreak
+// CHECK:         cir.brcond %[[SHOULDBRK]] ^[[BREAK:bb[0-9]+]], ^[[CONT:bb[0-9]+]]
+// CHECK:       ^[[BREAK]]:
+// CHECK:         cir.br ^[[LOOP_EXIT]]
+// CHECK:       ^[[CONT]]:
+// CHECK:         cir.br ^[[COND]]
+// CHECK:       ^[[LOOP_EXIT]]:
+// CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[DONE:bb[0-9]+]]
+// CHECK:       ^[[DONE]]:
+// CHECK:         cir.return
+
+// Test a switch within a loop within a cleanup scope. The switch's break is
+// handled by the switch, the loop's break/continue are handled by the loop,
+// so only the yield exits through cleanup.
+cir.func @test_switch_in_loop_in_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.while {
+      %cond = cir.call @shouldContinue() : () -> !cir.bool
+      cir.condition(%cond)
+    } do {
+      %x = cir.call @get() : () -> !s32i
+      cir.switch (%x : !s32i) {
+        cir.case (equal, [#cir.int<1> : !s32i]) {
+          cir.break     // Break from switch - handled by switch
+        }
+        cir.case (equal, [#cir.int<2> : !s32i]) {
+          cir.continue  // Continue outer loop - handled by loop
+        }
+        cir.yield
+      }
+      cir.yield  // Yield from loop body
+    }
+    cir.yield  // Normal exit through cleanup
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_switch_in_loop_in_cleanup()
+// CHECK:         %[[ALLOCA:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.call @ctor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[LOOP_BEGIN:bb[0-9]+]]
+// CHECK:       ^[[LOOP_BEGIN]]:
+// CHECK:         cir.br ^[[COND:bb[0-9]+]]
+// CHECK:       ^[[COND]]:
+// CHECK:         %[[SHOULDCONT:.*]] = cir.call @shouldContinue
+// CHECK:         cir.brcond %[[SHOULDCONT]] ^[[LOOP_BODY:bb[0-9]+]], ^[[LOOP_EXIT:bb[0-9]+]]
+// CHECK:       ^[[LOOP_BODY]]:
+// CHECK:         %[[X:.*]] = cir.call @get() : () -> !s32i
+// CHECK:         cir.br ^[[SWITCH_BEGIN:bb[0-9]+]]
+// CHECK:       ^[[SWITCH_BEGIN]]:
+// CHECK:         cir.switch.flat %[[X]] : !s32i, ^[[FALLTHROUGH:bb[0-9]+]] [
+// CHECK:           1: ^[[SWITCH_BREAK:bb[0-9]+]],
+// CHECK:           2: ^[[SWITCH_CONTINUE:bb[0-9]+]]
+// CHECK:         ]
+// CHECK:       ^[[SWITCH_BREAK]]:
+// CHECK:         cir.br ^[[FALLTHROUGH]]
+// CHECK:       ^[[SWITCH_CONTINUE]]:
+// CHECK:         cir.br ^[[COND]]
+// CHECK:       ^[[FALLTHROUGH]]:
+// CHECK:         cir.br ^[[COND]]
+// CHECK:       ^[[LOOP_EXIT]]:
+// CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[DONE:bb[0-9]+]]
+// CHECK:       ^[[DONE]]:
+// CHECK:         cir.return
+
+// Test a loop within a switch within a cleanup scope. The loop's break/continue
+// are handled by the loop, the switch's break exits the switch, so only the
+// yield exits through cleanup.
+cir.func @test_loop_in_switch_in_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    %x = cir.call @get() : () -> !s32i
+    cir.switch (%x : !s32i) {
+      cir.case (equal, [#cir.int<1> : !s32i]) {
+        cir.while {
+          %cond = cir.call @shouldContinue() : () -> !cir.bool
+          cir.condition(%cond)
+        } do {
+          %brk = cir.call @shouldBreak() : () -> !cir.bool
+          cir.brcond %brk ^bb_break, ^bb_continue
+        ^bb_break:
+          cir.break     // Break from loop - handled by loop
+        ^bb_continue:
+          cir.continue  // Continue loop - handled by loop
+        }
+        cir.break  // Break from switch - handled by switch
+      }
+      cir.yield
+    }
+    cir.yield  // Normal exit through cleanup
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_loop_in_switch_in_cleanup()
+// CHECK:         %[[ALLOCA:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.call @ctor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[BODY:bb[0-9]+]]
+// CHECK:       ^[[BODY]]:
+// CHECK:         %[[X:.*]] = cir.call @get() : () -> !s32i
+// CHECK:         cir.br ^[[SWITCH_BEGIN:bb[0-9]+]]
+// CHECK:       ^[[SWITCH_BEGIN]]:
+// CHECK:         cir.switch.flat %[[X]] : !s32i, ^[[SWITCH_END:bb[0-9]+]] [
+// CHECK:           1: ^[[CASE1:bb[0-9]+]]
+// CHECK:         ]
+// CHECK:       ^[[FALLTHROUGH:bb[0-9]+]]:
+// CHECK:         cir.br ^[[CASE1]]
+// CHECK:       ^[[CASE1]]:
+// CHECK:         cir.br ^[[LOOP_COND:bb[0-9]+]]
+// CHECK:       ^[[LOOP_COND]]:
+// CHECK:         %[[SHOULDCONT:.*]] = cir.call @shouldContinue() : () -> !cir.bool
+// CHECK:         cir.brcond %[[SHOULDCONT]] ^[[LOOP_BODY:bb[0-9]+]], ^[[LOOP_EXIT:bb[0-9]+]]
+// CHECK:       ^[[LOOP_BODY]]:
+// CHECK:         %[[SHOULDBRK:.*]] = cir.call @shouldBreak() : () -> !cir.bool
+// CHECK:         cir.brcond %[[SHOULDBRK]] ^[[BREAK:bb[0-9]+]], ^[[CONT:bb[0-9]+]]
+// CHECK:       ^[[BREAK]]:
+// CHECK:         cir.br ^[[LOOP_EXIT]]
+// CHECK:       ^[[CONT]]:
+// CHECK:         cir.br ^[[LOOP_COND]]
+// CHECK:       ^[[LOOP_EXIT]]:
+// CHECK:         cir.br ^[[SWITCH_END]]
+// CHECK:       ^[[SWITCH_END]]:
+// CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[DONE:bb[0-9]+]]
+// CHECK:       ^[[DONE]]:
+// CHECK:         cir.return
+
+// Test a cleanup scope containing a switch which contains a nested cleanup
+// scope with a break. The break is handled by the switch, so the outer cleanup
+// has only one exit (yield) and should flatten successfully.
+cir.func @test_nested_cleanup_break_in_switch() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c1", init] {alignment = 4 : i64}
+  %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    %x = cir.call @get() : () -> !s32i
+    cir.switch (%x : !s32i) {
+      cir.case (equal, [#cir.int<1> : !s32i]) {
+        cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+        cir.cleanup.scope {
+          cir.call @doSomething(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+          cir.break  // Branch through inner cleanup, but not outer cleanup
+        } cleanup normal {
+          cir.call @dtor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+          cir.yield
+        }
+        cir.break
+      }
+      cir.yield
+    }
+    cir.yield  // Only exit from outer cleanup
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_nested_cleanup_break_in_switch()
+// CHECK:         %[[ALLOCA1:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         %[[ALLOCA2:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.call @ctor(%[[ALLOCA1]])
+// CHECK:         cir.br ^[[BODY:bb[0-9]+]]
+// CHECK:       ^[[BODY]]:
+// CHECK:         %[[X:.*]] = cir.call @get() : () -> !s32i
+// CHECK:         cir.br ^[[SWITCH_BEGIN:bb[0-9]+]]
+// CHECK:       ^[[SWITCH_BEGIN]]:
+// CHECK:         cir.switch.flat %[[X]] : !s32i, ^[[SWITCH_END:bb[0-9]+]] [
+// CHECK:           1: ^[[CASE1:bb[0-9]+]]
+// CHECK:         ]
+// CHECK:       ^[[CASE1]]:
+// CHECK:         cir.call @ctor(%[[ALLOCA2]])
+// CHECK:         cir.br ^[[INNER_BODY:bb[0-9]+]]
+// CHECK:       ^[[INNER_BODY]]:
+// CHECK:         cir.call @doSomething(%[[ALLOCA2]])
+// CHECK:         cir.br ^[[INNER_CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[INNER_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA2]])
+// CHECK:         cir.br ^[[EXIT_CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[EXIT_CLEANUP]]:
+// CHECK:         cir.br ^[[SWITCH_END]]
+// CHECK:       ^[[SWITCH_END]]:
+// CHECK:         cir.br ^[[OUTER_CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[OUTER_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA1]])
+// CHECK:         cir.br ^[[OUTER_CLEANUP_DONE:bb[0-9]+]]
+// CHECK:       ^[[OUTER_CLEANUP_DONE]]:
+// CHECK:         cir.br ^[[DONE:bb[0-9]+]]
+// CHECK:       ^[[DONE]]:
+// CHECK:         cir.return
+
+cir.func private @get() -> !s32i
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
+cir.func private @doSomething(!cir.ptr<!rec_SomeClass>)
+cir.func private @shouldBreak() -> !cir.bool
+cir.func private @shouldContinue() -> !cir.bool

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-simple.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-simple.cir
@@ -58,6 +58,41 @@ cir.func @test_return_from_cleanup() {
 // CHECK:         cir.br ^[[CLEANUP_EXIT:bb[0-9]+]]
 // CHECK:       ^[[CLEANUP_EXIT]]:
 // CHECK:         cir.return
+// CHECK:       ^[[UNREACHABLE_NORMAL_RETURN:bb[0-9]+]]
+// CHECK:         cir.return
+
+// Test that a single return from the cleanup body branches through the cleanup.
+cir.func @test_return_from_cleanup_with_operand() -> !s32i {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    %1 = cir.const #cir.int<-1> : !s32i
+    cir.return %1 : !s32i // Should branch through cleanup
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  %2 = cir.const #cir.int<0> : !s32i
+  cir.return %2 : !s32i
+}
+
+// CHECK-LABEL: cir.func @test_return_from_cleanup_with_operand()
+// CHECK:         %[[ALLOCA:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.call @ctor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[BODY:bb[0-9]+]]
+// CHECK:       ^[[BODY]]:
+// CHECK:         cir.call @doSomething(%[[ALLOCA]])
+// CHECK:         %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s32i
+// CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[CLEANUP_EXIT:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP_EXIT]]:
+// CHECK:         cir.return %[[MINUS_ONE]] : !s32i
+// CHECK:       ^[[UNREACHABLE_NORMAL_RETURN:bb[0-9]+]]
+// CHECK:         %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CHECK:         cir.return %[[ZERO]] : !s32i
 
 // Test that a continue statement in a cleanup scope branches through the
 // cleanup block before continuing the loop.


### PR DESCRIPTION
This implements flattening of `cir.cleanup.scope` operations that have a single exit, and introduces checks to detect multiple exit cases and report an error when they are encountered. At this point, only normal cleanups are flattened. EH cleanup handling will be added in a future change.

Substantial amounts of this PR were created using agentic AI tools, but I have carefully reviewed the code, comments, and tests and made changes as needed.