### PR TITLE
[RISCV] Rename RISCVISD::PPACK_DH->PPAIRE_DB. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -1876,7 +1876,7 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
     CurDAG->RemoveDeadNode(Node);
     return;
   }
-  case RISCVISD::PPACK_DH: {
+  case RISCVISD::PPAIRE_DB: {
     assert(Subtarget->enablePExtSIMDCodeGen() && Subtarget->isRV32());
 
     SDValue Val0 = Node->getOperand(0);
@@ -1901,13 +1901,13 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
                                        MVT::Untyped, Ops1),
                 0);
 
-    MachineSDNode *PackDH = CurDAG->getMachineNode(
+    MachineSDNode *PPAIRE_DB = CurDAG->getMachineNode(
         RISCV::PPAIRE_DB, DL, MVT::Untyped, {RegPair0, RegPair1});
 
     SDValue Lo = CurDAG->getTargetExtractSubreg(RISCV::sub_gpr_even, DL,
-                                                MVT::i32, SDValue(PackDH, 0));
+                                                MVT::i32, SDValue(PPAIRE_DB, 0));
     SDValue Hi = CurDAG->getTargetExtractSubreg(RISCV::sub_gpr_odd, DL,
-                                                MVT::i32, SDValue(PackDH, 0));
+                                                MVT::i32, SDValue(PPAIRE_DB, 0));
     ReplaceUses(SDValue(Node, 0), Lo);
     ReplaceUses(SDValue(Node, 1), Hi);
     CurDAG->RemoveDeadNode(Node);

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -1904,10 +1904,10 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
     MachineSDNode *PPAIRE_DB = CurDAG->getMachineNode(
         RISCV::PPAIRE_DB, DL, MVT::Untyped, {RegPair0, RegPair1});
 
-    SDValue Lo = CurDAG->getTargetExtractSubreg(RISCV::sub_gpr_even, DL,
-                                                MVT::i32, SDValue(PPAIRE_DB, 0));
-    SDValue Hi = CurDAG->getTargetExtractSubreg(RISCV::sub_gpr_odd, DL,
-                                                MVT::i32, SDValue(PPAIRE_DB, 0));
+    SDValue Lo = CurDAG->getTargetExtractSubreg(
+        RISCV::sub_gpr_even, DL, MVT::i32, SDValue(PPAIRE_DB, 0));
+    SDValue Hi = CurDAG->getTargetExtractSubreg(
+        RISCV::sub_gpr_odd, DL, MVT::i32, SDValue(PPAIRE_DB, 0));
     ReplaceUses(SDValue(Node, 0), Lo);
     ReplaceUses(SDValue(Node, 1), Hi);
     CurDAG->RemoveDeadNode(Node);

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -4608,7 +4608,7 @@ static SDValue lowerBUILD_VECTOR(SDValue Op, SelectionDAG &DAG,
     SDValue Val3 =
         DAG.getNode(ISD::SCALAR_TO_VECTOR, DL, MVT::v4i8, Op->getOperand(3));
     SDValue PackDH =
-        DAG.getNode(RISCVISD::PPACK_DH, DL, {MVT::v2i16, MVT::v2i16},
+        DAG.getNode(RISCVISD::PPAIRE_DB, DL, {MVT::v2i16, MVT::v2i16},
                     {Val0, Val1, Val2, Val3});
 
     return DAG.getNode(

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -24,12 +24,12 @@ def SImm8UnsignedAsmOperand : SImmAsmOperand<8, "Unsigned"> {
   let RenderMethod = "addSImm8UnsignedOperands";
 }
 
-// (<2 x i16>, <2 x i16>) PPACK_DH (<4 x i8>, <4 x i8>, <4 x i8>, <4 x i8>)
-def SDT_RISCVPPackDH
+// (<2 x i16>, <2 x i16>) PPAIRE_DB (<4 x i8>, <4 x i8>, <4 x i8>, <4 x i8>)
+def SDT_RISCVPPairE_DB
     : SDTypeProfile<2, 4, [SDTCisVT<0, v2i16>, SDTCisSameAs<0, 1>,
                            SDTCisVT<2, v4i8>, SDTCisSameAs<0, 3>,
                            SDTCisSameAs<0, 4>, SDTCisSameAs<0, 5>]>;
-def riscv_ppack_dh : RVSDNode<"PPACK_DH", SDT_RISCVPPackDH>;
+def riscv_ppaire_db : RVSDNode<"PPAIRE_DB", SDT_RISCVPPairE_DB>;
 
 // A 8-bit signed immediate allowing range [-128, 255]
 // but represented as [-128, 127].


### PR DESCRIPTION
The instruction was renamed, but we hadn't renamed the ISD opcode.