### PR TITLE
Disable TestCancelAttach.py for linux -> linux remote

### DIFF
--- a/lldb/test/API/python_api/process/cancel_attach/TestCancelAttach.py
+++ b/lldb/test/API/python_api/process/cancel_attach/TestCancelAttach.py
@@ -16,7 +16,7 @@ class AttachCancelTestCase(TestBase):
 
     @skipIf(
         remote=True,
-        hostoslist=["windows"],
+        hostoslist=["windows", "linux"],
         bugnumber="https://github.com/llvm/llvm-project/issues/115618",
     )
     def test_scripted_implementation(self):


### PR DESCRIPTION
This test was already disabled going from windows -> linux because it was timing out there.

The PR: https://github.com/llvm/llvm-project/pull/179799 seems to have exacerbated whatever this stall was, and now we're seeing it when debugging from a linux host to a remote linux as well. 

The native local host tests works correctly on all the bots that we have, however.  So I'm disabling the remote test till we can figure out why this is problematic.