### PR TITLE
[RISCV] Add ppair.e and ppaire.w as aliases for pack on RV32 and RV64 respectively

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -854,8 +854,14 @@ let Predicates = [HasStdExtP] in {
   def PPAIRO_B    : RVPBinary_rr<0b0110, 0b00, 0b100, "ppairo.b">;
   def PPAIRO_H    : RVPBinary_rr<0b0110, 0b01, 0b100, "ppairo.h">;
 } // Predicates = [HasStdExtP]
+let Predicates = [HasStdExtP, IsRV32] in {
+  // This should be a MnemonicAlias, but InstAlias produces better errors.
+  def : InstAlias<"ppaire.h $rd, $rs1, $rs2", (PACK GPR:$rd, GPR:$rs1, GPR:$rs2), 0>;
+}
 let Predicates = [HasStdExtP, IsRV64] in {
   def PPAIRE_H    : RVPBinary_rr<0b0000, 0b01, 0b100, "ppaire.h">;
+  // This should be a MnemonicAlias, but InstAlias produces better errors.
+  def : InstAlias<"ppaire.w $rd, $rs1, $rs2", (PACK GPR:$rd, GPR:$rs1, GPR:$rs2), 0>;
 
   def PPAIREO_W   : RVPBinary_rr<0b0010, 0b11, 0b100, "ppaireo.w">;
 

--- a/llvm/test/MC/RISCV/rv32p-invalid.s
+++ b/llvm/test/MC/RISCV/rv32p-invalid.s
@@ -102,8 +102,7 @@ maccsu.w00 a4, s2, s0 # CHECK: :[[@LINE]]:1: error: instruction requires the fol
 pmaccsu.w.h11 a0, a2, t3 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set
 maccsu.w11 t5, a4, s2 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set
 
-ppaire.h t5, a2, a4 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set
-
+ppaire.w t5, s0, t5 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set
 ppaireo.w t5, s0, t5 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set
 ppairoe.w t5, t1, t1 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set
 ppairo.w t3, a0, s2 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set

--- a/llvm/test/MC/RISCV/rv32p-valid.s
+++ b/llvm/test/MC/RISCV/rv32p-valid.s
@@ -337,6 +337,9 @@ maccsu.h11 s0, a2, s6
 # CHECK-ASM-AND-OBJ: ppaire.b t1, a2, t5
 # CHECK-ASM: encoding: [0x3b,0x43,0xe6,0x81]
 ppaire.b t1, a2, t5
+# CHECK-ASM-AND-OBJ: pack s0, s1, s2
+# CHECK-ASM: encoding: [0x33,0xc4,0x24,0x09]
+ppaire.h s0, s1, s2
 # CHECK-ASM-AND-OBJ: ppaireo.b t5, t3, s2
 # CHECK-ASM: encoding: [0x3b,0x4f,0x2e,0x91]
 ppaireo.b t5, t3, s2

--- a/llvm/test/MC/RISCV/rv64p-valid.s
+++ b/llvm/test/MC/RISCV/rv64p-valid.s
@@ -472,6 +472,9 @@ ppaire.b s0, s0, s2
 # CHECK-ASM-AND-OBJ: ppaire.h t5, a2, a4
 # CHECK-ASM: encoding: [0x3b,0x4f,0xe6,0x82]
 ppaire.h t5, a2, a4
+# CHECK-ASM-AND-OBJ: pack s0, s1, s2
+# CHECK-ASM: encoding: [0x33,0xc4,0x24,0x09]
+ppaire.w s0, s1, s2
 # CHECK-ASM-AND-OBJ: ppaireo.b a4, s2, t3
 # CHECK-ASM: encoding: [0x3b,0x47,0xc9,0x91]
 ppaireo.b a4, s2, t3


### PR DESCRIPTION
Based on this note from https://jhauser.us/RISCV/ext-P/RVP-baseInstrs-018.pdf

(*1) For RV32, PPAIRE.H is a pseudoinstruction for PACK.
(*2) For RV64, PPAIRE.W is a pseudoinstruction for PACK.