### PR TITLE
[lldb] Batch breakpoint step-over for threads stopped at the same site

### DIFF
--- a/lldb/include/lldb/Target/ThreadList.h
+++ b/lldb/include/lldb/Target/ThreadList.h
@@ -9,9 +9,7 @@
 #ifndef LLDB_TARGET_THREADLIST_H
 #define LLDB_TARGET_THREADLIST_H
 
-#include <map>
 #include <mutex>
-#include <set>
 #include <vector>
 
 #include "lldb/Target/Thread.h"
@@ -19,6 +17,9 @@
 #include "lldb/Utility/Iterable.h"
 #include "lldb/Utility/UserID.h"
 #include "lldb/lldb-private.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 
 namespace lldb_private {
 
@@ -173,7 +174,8 @@ protected:
   /// Key: breakpoint address, Value: set of thread IDs stepping over it.
   /// When a thread finishes stepping, it's removed from the set. When the set
   /// becomes empty, the breakpoint is re-enabled.
-  std::map<lldb::addr_t, std::set<lldb::tid_t>> m_threads_stepping_over_bp;
+  llvm::DenseMap<lldb::addr_t, llvm::DenseSet<lldb::tid_t>>
+      m_threads_stepping_over_bp;
 
 private:
   ThreadList() = delete;

--- a/lldb/include/lldb/Target/ThreadPlanStepOverBreakpoint.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepOverBreakpoint.h
@@ -49,6 +49,11 @@ public:
     return m_defer_reenable_breakpoint_site;
   }
 
+  /// Mark the breakpoint site as already re-enabled, suppressing any
+  /// re-enable in DidPop()/ThreadDestroyed(). Used when discarding plans
+  /// during WillResume cleanup to avoid spurious breakpoint toggles.
+  void SetReenabledBreakpointSite() { m_reenabled_breakpoint_site = true; }
+
 protected:
   bool DoPlanExplainsStop(Event *event_ptr) override;
   bool DoWillResume(lldb::StateType resume_state, bool current_plan) override;

--- a/lldb/include/lldb/Target/ThreadPlanStepOverBreakpoint.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepOverBreakpoint.h
@@ -36,6 +36,19 @@ public:
 
   lldb::addr_t GetBreakpointLoadAddress() const { return m_breakpoint_addr; }
 
+  /// When set to true, the breakpoint site will NOT be re-enabled directly
+  /// by this plan. Instead, the plan will call
+  /// ThreadList::ThreadFinishedSteppingOverBreakpoint() when it completes,
+  /// allowing ThreadList to track all threads stepping over the same
+  /// breakpoint and only re-enable it when ALL threads have finished.
+  void SetDeferReenableBreakpointSite(bool defer) {
+    m_defer_reenable_breakpoint_site = defer;
+  }
+
+  bool GetDeferReenableBreakpointSite() const {
+    return m_defer_reenable_breakpoint_site;
+  }
+
 protected:
   bool DoPlanExplainsStop(Event *event_ptr) override;
   bool DoWillResume(lldb::StateType resume_state, bool current_plan) override;
@@ -47,6 +60,7 @@ private:
   lldb::user_id_t m_breakpoint_site_id;
   bool m_auto_continue;
   bool m_reenabled_breakpoint_site;
+  bool m_defer_reenable_breakpoint_site = false;
 
   ThreadPlanStepOverBreakpoint(const ThreadPlanStepOverBreakpoint &) = delete;
   const ThreadPlanStepOverBreakpoint &

--- a/lldb/include/lldb/Target/ThreadPlanStepOverBreakpoint.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepOverBreakpoint.h
@@ -65,7 +65,7 @@ private:
   lldb::user_id_t m_breakpoint_site_id;
   bool m_auto_continue;
   bool m_reenabled_breakpoint_site;
-  bool m_defer_reenable_breakpoint_site = false;
+  bool m_defer_reenable_breakpoint_site;
 
   ThreadPlanStepOverBreakpoint(const ThreadPlanStepOverBreakpoint &) = delete;
   const ThreadPlanStepOverBreakpoint &

--- a/lldb/source/Target/ThreadList.cpp
+++ b/lldb/source/Target/ThreadList.cpp
@@ -913,11 +913,12 @@ void ThreadList::RegisterThreadSteppingOverBreakpoint(addr_t breakpoint_addr,
   m_threads_stepping_over_bp[breakpoint_addr].insert(tid);
 
   Log *log = GetLog(LLDBLog::Step);
-  LLDB_LOGF(log,
-            "ThreadList::%s: Registered thread 0x%" PRIx64
-            " stepping over breakpoint at 0x%" PRIx64 " (now %zu threads)",
-            __FUNCTION__, tid, breakpoint_addr,
-            m_threads_stepping_over_bp[breakpoint_addr].size());
+  LLDB_LOGF(
+      log,
+      "ThreadList::%s: Registered thread 0x%" PRIx64
+      " stepping over breakpoint at 0x%" PRIx64 " (now %zu threads)",
+      __FUNCTION__, tid, breakpoint_addr,
+      static_cast<size_t>(m_threads_stepping_over_bp[breakpoint_addr].size()));
 }
 
 void ThreadList::ThreadFinishedSteppingOverBreakpoint(addr_t breakpoint_addr,
@@ -948,7 +949,8 @@ void ThreadList::ThreadFinishedSteppingOverBreakpoint(addr_t breakpoint_addr,
             "ThreadList::%s: Thread 0x%" PRIx64
             " finished stepping over breakpoint at 0x%" PRIx64
             " (%zu threads remaining)",
-            __FUNCTION__, tid, breakpoint_addr, it->second.size());
+            __FUNCTION__, tid, breakpoint_addr,
+            static_cast<size_t>(it->second.size()));
 
   // If no more threads are stepping over this breakpoint, re-enable it.
   if (it->second.empty()) {

--- a/lldb/source/Target/ThreadList.cpp
+++ b/lldb/source/Target/ThreadList.cpp
@@ -512,8 +512,7 @@ bool ThreadList::WillResume(RunDirection &direction) {
   // recreated fresh by SetupToStepOverBreakpointIfNeeded below, and the
   // batching logic will recompute deferred state from scratch.
   m_threads_stepping_over_bp.clear();
-  for (pos = m_threads.begin(); pos != end; ++pos) {
-    ThreadSP thread_sp(*pos);
+  for (const auto &thread_sp : m_threads) {
     ThreadPlan *plan = thread_sp->GetCurrentPlan();
     if (plan && plan->GetKind() == ThreadPlan::eKindStepOverBreakpoint) {
       // Suppress the re-enable side effect in DidPop() — the breakpoint
@@ -709,8 +708,7 @@ bool ThreadList::WillResume(RunDirection &direction) {
     for (ThreadSP &thread_sp : batched_step_threads)
       batch_tids.insert(thread_sp->GetID());
 
-    for (pos = m_threads.begin(); pos != end; ++pos) {
-      ThreadSP thread_sp(*pos);
+    for (const auto &thread_sp : m_threads) {
       if (batch_tids.count(thread_sp->GetID()) > 0) {
         // This thread is in the batch, let it step.
         if (!thread_sp->ShouldResume(thread_sp->GetCurrentPlan()->RunState()))

--- a/lldb/source/Target/ThreadList.cpp
+++ b/lldb/source/Target/ThreadList.cpp
@@ -933,9 +933,8 @@ void ThreadList::ThreadFinishedSteppingOverBreakpoint(addr_t breakpoint_addr,
               " finished stepping over breakpoint at 0x%" PRIx64
               " but no threads were registered, re-enabling directly",
               __FUNCTION__, tid, breakpoint_addr);
-    BreakpointSiteSP bp_site_sp(
-        m_process.GetBreakpointSiteList().FindByAddress(breakpoint_addr));
-    if (bp_site_sp)
+    if (BreakpointSiteSP bp_site_sp =
+            m_process.GetBreakpointSiteList().FindByAddress(breakpoint_addr))
       m_process.EnableBreakpointSite(bp_site_sp.get());
     return;
   }
@@ -957,9 +956,8 @@ void ThreadList::ThreadFinishedSteppingOverBreakpoint(addr_t breakpoint_addr,
               "at 0x%" PRIx64 ", re-enabling breakpoint",
               __FUNCTION__, breakpoint_addr);
 
-    BreakpointSiteSP bp_site_sp(
-        m_process.GetBreakpointSiteList().FindByAddress(breakpoint_addr));
-    if (bp_site_sp)
+    if (BreakpointSiteSP bp_site_sp =
+            m_process.GetBreakpointSiteList().FindByAddress(breakpoint_addr))
       m_process.EnableBreakpointSite(bp_site_sp.get());
 
     // Clean up the entry.

--- a/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
@@ -163,12 +163,11 @@ void ThreadPlanStepOverBreakpoint::ReenableBreakpointSite() {
       m_process.GetThreadList().ThreadFinishedSteppingOverBreakpoint(
           m_breakpoint_addr, GetThread().GetID());
     } else {
-      // Default behavior: re-enable the breakpoint directly
+      // Default behavior: re-enable the breakpoint directly.
       BreakpointSiteSP bp_site_sp(
           m_process.GetBreakpointSiteList().FindByAddress(m_breakpoint_addr));
-      if (bp_site_sp) {
+      if (bp_site_sp)
         m_process.EnableBreakpointSite(bp_site_sp.get());
-      }
     }
   }
 }

--- a/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
@@ -164,9 +164,9 @@ void ThreadPlanStepOverBreakpoint::ReenableBreakpointSite() {
           m_breakpoint_addr, GetThread().GetID());
     } else {
       // Default behavior: re-enable the breakpoint directly.
-      BreakpointSiteSP bp_site_sp(
-          m_process.GetBreakpointSiteList().FindByAddress(m_breakpoint_addr));
-      if (bp_site_sp)
+      if (BreakpointSiteSP bp_site_sp =
+              m_process.GetBreakpointSiteList().FindByAddress(
+                  m_breakpoint_addr))
         m_process.EnableBreakpointSite(bp_site_sp.get());
     }
   }

--- a/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverBreakpoint.cpp
@@ -22,14 +22,14 @@ using namespace lldb_private;
 // the pc.
 
 ThreadPlanStepOverBreakpoint::ThreadPlanStepOverBreakpoint(Thread &thread)
-    : ThreadPlan(
-          ThreadPlan::eKindStepOverBreakpoint, "Step over breakpoint trap",
-          thread, eVoteNo,
-          eVoteNoOpinion), // We need to report the run since this happens
-                           // first in the thread plan stack when stepping over
-                           // a breakpoint
-      m_breakpoint_addr(LLDB_INVALID_ADDRESS),
-      m_auto_continue(false), m_reenabled_breakpoint_site(false)
+    : ThreadPlan(ThreadPlan::eKindStepOverBreakpoint,
+                 "Step over breakpoint trap", thread, eVoteNo,
+                 eVoteNoOpinion), // We need to report the run since this
+                                  // happens first in the thread plan stack when
+                                  // stepping over a breakpoint
+      m_breakpoint_addr(LLDB_INVALID_ADDRESS), m_auto_continue(false),
+      m_reenabled_breakpoint_site(false),
+      m_defer_reenable_breakpoint_site(false)
 
 {
   m_breakpoint_addr = thread.GetRegisterContext()->GetPC();

--- a/lldb/test/API/functionalities/gdb_remote_client/TestBatchedBreakpointStepOver.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestBatchedBreakpointStepOver.py
@@ -1,0 +1,222 @@
+"""
+Test that when multiple threads are stopped at the same breakpoint, LLDB sends
+a batched vCont with multiple step actions and only one breakpoint disable/
+re-enable pair, rather than stepping each thread individually with repeated
+breakpoint toggles.
+
+Uses a mock GDB server to directly verify the packets LLDB sends.
+"""
+
+import re
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test.gdbclientutils import *
+from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
+
+
+class TestBatchedBreakpointStepOver(GDBRemoteTestBase):
+    @skipIfXmlSupportMissing
+    def test(self):
+        BP_ADDR = 0x0000000000401020
+        # PC after stepping past the breakpoint instruction.
+        STEPPED_PC = BP_ADDR + 1
+        NUM_THREADS = 10
+        TIDS = [0x101 + i for i in range(NUM_THREADS)]
+
+        class MyResponder(MockGDBServerResponder):
+            def __init__(self):
+                MockGDBServerResponder.__init__(self)
+                self.resume_count = 0
+                # Track which threads have completed their step
+                self.stepped_threads = set()
+
+            def qSupported(self, client_supported):
+                return (
+                    "PacketSize=3fff;QStartNoAckMode+;"
+                    "qXfer:features:read+;swbreak+;hwbreak+"
+                )
+
+            def qfThreadInfo(self):
+                return "m" + ",".join("{:x}".format(t) for t in TIDS)
+
+            def qsThreadInfo(self):
+                return "l"
+
+            def haltReason(self):
+                # All threads stopped at the breakpoint address.
+                threads_str = ",".join("{:x}".format(t) for t in TIDS)
+                pcs_str = ",".join("{:x}".format(BP_ADDR) for _ in TIDS)
+                return (
+                    "T05thread:{:x};threads:{};thread-pcs:{};"
+                    "swbreak:;".format(TIDS[0], threads_str, pcs_str)
+                )
+
+            def threadStopInfo(self, threadnum):
+                threads_str = ",".join("{:x}".format(t) for t in TIDS)
+                pcs_str = ",".join("{:x}".format(BP_ADDR) for _ in TIDS)
+                return (
+                    "T05thread:{:x};threads:{};thread-pcs:{};"
+                    "swbreak:;".format(threadnum, threads_str, pcs_str)
+                )
+
+            def setBreakpoint(self, packet):
+                return "OK"
+
+            def readRegisters(self):
+                return "00" * 160
+
+            def readRegister(self, regno):
+                return "00" * 8
+
+            def qXferRead(self, obj, annex, offset, length):
+                if annex == "target.xml":
+                    return (
+                        """<?xml version="1.0"?>
+                        <target version="1.0">
+                          <architecture>i386:x86-64</architecture>
+                          <feature name="org.gnu.gdb.i386.core">
+                            <reg name="rax" bitsize="64" regnum="0" type="int" group="general"/>
+                            <reg name="rbx" bitsize="64" regnum="1" type="int" group="general"/>
+                            <reg name="rcx" bitsize="64" regnum="2" type="int" group="general"/>
+                            <reg name="rdx" bitsize="64" regnum="3" type="int" group="general"/>
+                            <reg name="rsi" bitsize="64" regnum="4" type="int" group="general"/>
+                            <reg name="rdi" bitsize="64" regnum="5" type="int" group="general"/>
+                            <reg name="rbp" bitsize="64" regnum="6" type="data_ptr" group="general"/>
+                            <reg name="rsp" bitsize="64" regnum="7" type="data_ptr" group="general"/>
+                            <reg name="r8" bitsize="64" regnum="8" type="int" group="general"/>
+                            <reg name="r9" bitsize="64" regnum="9" type="int" group="general"/>
+                            <reg name="r10" bitsize="64" regnum="10" type="int" group="general"/>
+                            <reg name="r11" bitsize="64" regnum="11" type="int" group="general"/>
+                            <reg name="r12" bitsize="64" regnum="12" type="int" group="general"/>
+                            <reg name="r13" bitsize="64" regnum="13" type="int" group="general"/>
+                            <reg name="r14" bitsize="64" regnum="14" type="int" group="general"/>
+                            <reg name="r15" bitsize="64" regnum="15" type="int" group="general"/>
+                            <reg name="rip" bitsize="64" regnum="16" type="code_ptr" group="general"/>
+                            <reg name="eflags" bitsize="32" regnum="17" type="int" group="general"/>
+                            <reg name="cs" bitsize="32" regnum="18" type="int" group="general"/>
+                            <reg name="ss" bitsize="32" regnum="19" type="int" group="general"/>
+                          </feature>
+                        </target>""",
+                        False,
+                    )
+                return None, False
+
+            def other(self, packet):
+                if packet == "vCont?":
+                    return "vCont;c;C;s;S"
+                if packet.startswith("vCont;"):
+                    return self._handle_vCont(packet)
+                if packet.startswith("z"):
+                    return "OK"
+                return ""
+
+            def _handle_vCont(self, packet):
+                self.resume_count += 1
+                # Parse step actions from vCont.
+                stepping_tids = []
+                for action in packet[6:].split(";"):
+                    if not action:
+                        continue
+                    if action.startswith("s:"):
+                        tid_str = action[2:]
+                        if "." in tid_str:
+                            tid_str = tid_str.split(".")[1]
+                        stepping_tids.append(int(tid_str, 16))
+
+                # All stepping threads complete their step.
+                for tid in stepping_tids:
+                    self.stepped_threads.add(tid)
+
+                all_done = self.stepped_threads >= set(TIDS)
+
+                # Report stop, use the first stepping thread as the reporter.
+                report_tid = stepping_tids[0] if stepping_tids else TIDS[0]
+                threads_str = ",".join("{:x}".format(t) for t in TIDS)
+                if all_done:
+                    # All threads moved past breakpoint
+                    pcs_str = ",".join(
+                        "{:x}".format(STEPPED_PC) for _ in TIDS
+                    )
+                else:
+                    # Stepped threads moved, others still at breakpoint.
+                    pcs_str = ",".join(
+                        "{:x}".format(
+                            STEPPED_PC if t in self.stepped_threads else BP_ADDR
+                        )
+                        for t in TIDS
+                    )
+                return "T05thread:{:x};threads:{};thread-pcs:{};".format(
+                    report_tid, threads_str, pcs_str
+                )
+
+        self.server.responder = MyResponder()
+        self.runCmd("platform select remote-linux")
+        target = self.createTarget("a.yaml")
+        process = self.connect(target)
+
+        self.assertEqual(process.GetNumThreads(), NUM_THREADS)
+
+        # Set a breakpoint at BP_ADDR, all threads are already stopped there.
+        bkpt = target.BreakpointCreateByAddress(BP_ADDR)
+        self.assertTrue(bkpt.IsValid())
+
+        # Continue, LLDB should step all threads over the breakpoint.
+        process.Continue()
+
+        # Collect packets from the log
+        received = self.server.responder.packetLog.get_received()
+
+        bp_addr_hex = "{:x}".format(BP_ADDR)
+
+        # Count z0 (disable) and Z0 (enable) packets for our breakpoint.
+        z0_packets = []
+        Z0_packets = []
+        vcont_step_packets = []
+
+        for pkt in received:
+            if pkt.startswith("z0,{},".format(bp_addr_hex)):
+                z0_packets.append(pkt)
+            elif pkt.startswith("Z0,{},".format(bp_addr_hex)):
+                Z0_packets.append(pkt)
+            elif pkt.startswith("vCont;"):
+                step_count = len(re.findall(r";s:", pkt))
+                if step_count > 0:
+                    vcont_step_packets.append((step_count, pkt))
+
+        # Verify: exactly 1 breakpoint disable (z0)
+        self.assertEqual(
+            len(z0_packets),
+            1,
+            "Expected 1 z0 (disable) packet, got {}: {}".format(
+                len(z0_packets), z0_packets
+            ),
+        )
+
+        # The initial Z0 is the breakpoint set. After stepping, there should
+        # be exactly 1 re-enable Z0 (total Z0 count = 2: set + re-enable).
+        # But we set the breakpoint via SB API, so count Z0 packets with
+        # our address, initial set + 1 re-enable = 2.
+        self.assertEqual(
+            len(Z0_packets),
+            2,
+            "Expected 2 Z0 packets (1 set + 1 re-enable), got {}: {}".format(
+                len(Z0_packets), Z0_packets
+            ),
+        )
+
+        # At least one batched vCont with multiple step actions.
+        max_batch = max(
+            (count for count, _ in vcont_step_packets), default=0
+        )
+        self.assertGreaterEqual(
+            max_batch,
+            NUM_THREADS,
+            "Expected a vCont with {} step actions (batched), "
+            "but max was {}. Packets: {}".format(
+                NUM_THREADS,
+                max_batch,
+                [(c, p) for c, p in vcont_step_packets],
+            ),
+        )

--- a/lldb/test/API/functionalities/gdb_remote_client/TestBatchedBreakpointStepOver.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestBatchedBreakpointStepOver.py
@@ -48,17 +48,15 @@ class TestBatchedBreakpointStepOver(GDBRemoteTestBase):
                 # All threads stopped at the breakpoint address.
                 threads_str = ",".join("{:x}".format(t) for t in TIDS)
                 pcs_str = ",".join("{:x}".format(BP_ADDR) for _ in TIDS)
-                return (
-                    "T05thread:{:x};threads:{};thread-pcs:{};"
-                    "swbreak:;".format(TIDS[0], threads_str, pcs_str)
+                return "T05thread:{:x};threads:{};thread-pcs:{};" "swbreak:;".format(
+                    TIDS[0], threads_str, pcs_str
                 )
 
             def threadStopInfo(self, threadnum):
                 threads_str = ",".join("{:x}".format(t) for t in TIDS)
                 pcs_str = ",".join("{:x}".format(BP_ADDR) for _ in TIDS)
-                return (
-                    "T05thread:{:x};threads:{};thread-pcs:{};"
-                    "swbreak:;".format(threadnum, threads_str, pcs_str)
+                return "T05thread:{:x};threads:{};thread-pcs:{};" "swbreak:;".format(
+                    threadnum, threads_str, pcs_str
                 )
 
             def setBreakpoint(self, packet):
@@ -136,9 +134,7 @@ class TestBatchedBreakpointStepOver(GDBRemoteTestBase):
                 threads_str = ",".join("{:x}".format(t) for t in TIDS)
                 if all_done:
                     # All threads moved past breakpoint
-                    pcs_str = ",".join(
-                        "{:x}".format(STEPPED_PC) for _ in TIDS
-                    )
+                    pcs_str = ",".join("{:x}".format(STEPPED_PC) for _ in TIDS)
                 else:
                     # Stepped threads moved, others still at breakpoint.
                     pcs_str = ",".join(
@@ -207,9 +203,7 @@ class TestBatchedBreakpointStepOver(GDBRemoteTestBase):
         )
 
         # At least one batched vCont with multiple step actions.
-        max_batch = max(
-            (count for count, _ in vcont_step_packets), default=0
-        )
+        max_batch = max((count for count, _ in vcont_step_packets), default=0)
         self.assertGreaterEqual(
             max_batch,
             NUM_THREADS,

--- a/lldb/test/API/functionalities/gdb_remote_client/TestBatchedBreakpointStepOver.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestBatchedBreakpointStepOver.py
@@ -29,7 +29,7 @@ class TestBatchedBreakpointStepOver(GDBRemoteTestBase):
             def __init__(self):
                 MockGDBServerResponder.__init__(self)
                 self.resume_count = 0
-                # Track which threads have completed their step
+                # Track which threads have completed their step.
                 self.stepped_threads = set()
 
             def qSupported(self, client_supported):
@@ -133,7 +133,7 @@ class TestBatchedBreakpointStepOver(GDBRemoteTestBase):
                 report_tid = stepping_tids[0] if stepping_tids else TIDS[0]
                 threads_str = ",".join("{:x}".format(t) for t in TIDS)
                 if all_done:
-                    # All threads moved past breakpoint
+                    # All threads moved past breakpoint.
                     pcs_str = ",".join("{:x}".format(STEPPED_PC) for _ in TIDS)
                 else:
                     # Stepped threads moved, others still at breakpoint.
@@ -161,7 +161,7 @@ class TestBatchedBreakpointStepOver(GDBRemoteTestBase):
         # Continue, LLDB should step all threads over the breakpoint.
         process.Continue()
 
-        # Collect packets from the log
+        # Collect packets from the log.
         received = self.server.responder.packetLog.get_received()
 
         bp_addr_hex = "{:x}".format(BP_ADDR)

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBatchedBreakpointStepOver.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBatchedBreakpointStepOver.py
@@ -15,7 +15,6 @@ from lldbsuite.test.lldbtest import TestBase
 
 @skipIfWindows
 class ConcurrentBatchedBreakpointStepOver(ConcurrentEventsBase):
-
     @skipIf(triple="^mips")
     @expectedFailureAll(
         archs=["aarch64"], oslist=["freebsd"], bugnumber="llvm.org/pr49433"

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBatchedBreakpointStepOver.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBatchedBreakpointStepOver.py
@@ -1,0 +1,179 @@
+"""
+Test that the batched breakpoint step-over optimization is used when multiple
+threads hit the same breakpoint simultaneously. Verifies that when N threads
+need to step over the same breakpoint, the breakpoint is only disabled once
+and re-enabled once, rather than N times.
+"""
+
+import os
+import re
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.concurrent_base import ConcurrentEventsBase
+from lldbsuite.test.lldbtest import TestBase
+
+
+@skipIfWindows
+class ConcurrentBatchedBreakpointStepOver(ConcurrentEventsBase):
+
+    @skipIf(triple="^mips")
+    @expectedFailureAll(
+        archs=["aarch64"], oslist=["freebsd"], bugnumber="llvm.org/pr49433"
+    )
+    def test(self):
+        """Test that batched breakpoint step-over reduces breakpoint
+        toggle operations when multiple threads hit the same breakpoint."""
+        self.build()
+
+        # Enable logging to capture optimization messages and GDB packets.
+        # Both categories must be in a single command because successive
+        # 'log enable lldb <cat> -f <file>' calls redirect the entire 'lldb'
+        # channel to the new file, leaving the old file empty.
+        lldb_logfile = self.getBuildArtifact("lldb-log.txt")
+        self.runCmd(
+            "log enable lldb step break -f {}".format(lldb_logfile)
+        )
+
+        gdb_logfile = self.getBuildArtifact("gdb-remote-log.txt")
+        self.runCmd("log enable gdb-remote packets -f {}".format(gdb_logfile))
+
+        # Run with 10 breakpoint threads - the pseudo_barrier in main.cpp
+        # ensures they all race to the breakpoint simultaneously, making it
+        # very likely multiple threads are at the same address when stopped.
+        self.do_thread_actions(num_breakpoint_threads=10)
+
+        # --- Analyze the lldb log ---
+        self.assertTrue(
+            os.path.isfile(lldb_logfile), "lldb log file not found"
+        )
+        with open(lldb_logfile, "r") as f:
+            lldb_log = f.read()
+
+        # 1) Find the thread breakpoint address from "Registered thread"
+        #    messages, which tell us the optimization was used.
+        registered_matches = re.findall(
+            r"Registered thread 0x[0-9a-fA-F]+ stepping over "
+            r"breakpoint at (0x[0-9a-fA-F]+)",
+            lldb_log,
+        )
+        self.assertGreater(
+            len(registered_matches),
+            0,
+            "Expected batched breakpoint step-over optimization to be "
+            "used (no 'Registered thread' messages found in log).",
+        )
+        thread_bp_addr = registered_matches[0]
+
+        # 2) Verify all threads completed their step-over.
+        completed_count = lldb_log.count(
+            "Completed step over breakpoint plan."
+        )
+        self.assertGreaterEqual(
+            completed_count,
+            10,
+            "Expected at least 10 'Completed step over breakpoint plan.' "
+            "messages (one per thread), but got {}.".format(completed_count),
+        )
+
+        # 3) Verify the deferred re-enable path was used: "finished stepping
+        #    over breakpoint" messages show threads completed via the tracking
+        #    mechanism. The last thread may use the direct path (when only 1
+        #    thread remains, deferred is not set), so we expect at least N-1.
+        finished_matches = re.findall(
+            r"Thread 0x[0-9a-fA-F]+ finished stepping over breakpoint at "
+            r"(0x[0-9a-fA-F]+)",
+            lldb_log,
+        )
+        self.assertGreaterEqual(
+            len(finished_matches),
+            9,
+            "Expected at least 9 'finished stepping over breakpoint' "
+            "messages (deferred path), but got {}.".format(
+                len(finished_matches)
+            ),
+        )
+
+        # --- Count z0/Z0 packets for the thread breakpoint address ---
+        # z0 = remove (disable) software breakpoint
+        # Z0 = set (enable) software breakpoint
+        # Strip the "0x" prefix and leading zeros to match the GDB packet
+        # format (which uses lowercase hex without "0x" prefix).
+        bp_addr_hex = thread_bp_addr[2:].lstrip("0") if thread_bp_addr else ""
+
+        z0_count = 0  # disable packets
+        Z0_count = 0  # enable packets (excluding the initial set)
+        initial_Z0_seen = False
+        max_vcont_step_threads = 0  # largest number of s: actions in one vCont
+
+        self.assertTrue(
+            os.path.isfile(gdb_logfile), "gdb-remote log file not found"
+        )
+        with open(gdb_logfile, "r") as f:
+            for line in f:
+                if "send packet: $" not in line:
+                    continue
+                # Match z0,<addr> (disable) or Z0,<addr> (enable)
+                m = re.search(
+                    r'send packet: \$([Zz])0,([0-9a-fA-F]+),', line
+                )
+                if m and m.group(2) == bp_addr_hex:
+                    if m.group(1) == "Z":
+                        if not initial_Z0_seen:
+                            # Skip the initial breakpoint set
+                            initial_Z0_seen = True
+                        else:
+                            Z0_count += 1
+                    else:
+                        z0_count += 1
+
+                # Count step actions in vCont packets to detect batching.
+                # A batched vCont looks like: vCont;s:tid1;s:tid2;...
+                vcont_m = re.search(
+                    r'send packet: \$vCont((?:;[^#]+)*)', line
+                )
+                if vcont_m:
+                    actions = vcont_m.group(1)
+                    step_count = len(re.findall(r';s:', actions))
+                    if step_count > max_vcont_step_threads:
+                        max_vcont_step_threads = step_count
+
+        print("\n--- Breakpoint packet summary for {} ---".format(
+            thread_bp_addr))
+        print("  z0 (disable) packets: {}".format(z0_count))
+        print("  Z0 (re-enable) packets: {}".format(Z0_count))
+        print("  Max threads in a single vCont step: {}".format(
+            max_vcont_step_threads))
+
+        # 4) With the optimization: 1 z0 (disable once) + 1 Z0 (re-enable once)
+        #    Without optimization: N z0 + N Z0 (one pair per thread)
+        self.assertEqual(
+            z0_count,
+            1,
+            "Expected exactly 1 breakpoint disable (z0) for the thread "
+            "breakpoint at {}, but got {}. The optimization should disable "
+            "the breakpoint only once for all {} threads.".format(
+                thread_bp_addr, z0_count, 10
+            ),
+        )
+        self.assertEqual(
+            Z0_count,
+            1,
+            "Expected exactly 1 breakpoint re-enable (Z0) for the thread "
+            "breakpoint at {}, but got {}. The optimization should re-enable "
+            "the breakpoint only once after all threads finish.".format(
+                thread_bp_addr, Z0_count
+            ),
+        )
+
+        # 5) Verify batched vCont: at least one vCont packet should contain
+        #    multiple s: (step) actions, proving threads were stepped together
+        #    in a single packet rather than one at a time.
+        self.assertGreater(
+            max_vcont_step_threads,
+            1,
+            "Expected at least one batched vCont packet with multiple "
+            "step actions (s:), but the maximum was {}. The optimization "
+            "should step multiple threads in a single vCont.".format(
+                max_vcont_step_threads
+            ),
+        )

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBatchedBreakpointStepOver.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentBatchedBreakpointStepOver.py
@@ -65,7 +65,7 @@ class ConcurrentBatchedBreakpointStepOver(ConcurrentEventsBase):
         # Verify the deferred re-enable path was used: "finished stepping
         # over breakpoint" messages show threads completed via the tracking
         # mechanism. The last thread may use the direct path (when only 1
-        # hread remains, deferred is not set), so we expect at least N-1.
+        # thread remains, deferred is not set), so we expect at least N-1.
         finished_matches = re.findall(
             r"Thread 0x[0-9a-fA-F]+ finished stepping over breakpoint at "
             r"(0x[0-9a-fA-F]+)",
@@ -78,9 +78,9 @@ class ConcurrentBatchedBreakpointStepOver(ConcurrentEventsBase):
             "messages (deferred path), but got {}.".format(len(finished_matches)),
         )
 
-        # Count z0/Z0 packets for the thread breakpoint address
-        # z0 = remove (disable) software breakpoint
-        # Z0 = set (enable) software breakpoint
+        # Count z0/Z0 packets for the thread breakpoint address.
+        # z0 = remove (disable) software breakpoint.
+        # Z0 = set (enable) software breakpoint.
         # Strip the "0x" prefix and leading zeros to match the GDB packet
         # format (which uses lowercase hex without "0x" prefix).
         bp_addr_hex = thread_bp_addr[2:].lstrip("0") if thread_bp_addr else ""


### PR DESCRIPTION
Following up from https://discourse.llvm.org/t/improving-performance-of-multiple-threads-stepping-over-the-same-breakpoint/89637 

When multiple threads are stopped at the same breakpoint, LLDB currently steps each thread over the breakpoint one at a time. Each step requires disabling the breakpoint, single-stepping one thread, and re-enabling it, resulting in N disable/enable cycles and N individual vCont packets for N threads. 

Now we batch the step-over so that all threads at the same breakpoint site are stepped together in a single vCont packet, with the breakpoint disabled once at the start and re-enabled once after the last thread finishes.

When we hit `WillResume` any leftover `StepOverBreakpoint` plans from a previous cycle are popped with their re-enable side effect suppressed via `SetReenabledBreakpointSite`, giving a clean slate. `SetupToStepOverBreakpointIfNeeded` then creates fresh plans for all threads that still need to step over a breakpoint, and these are grouped by breakpoint address.

For groups with multiple threads, each plan is set to defer its re-enable through `SetDeferReenableBreakpointSite`. Instead of re-enabling the breakpoint directly when a plan completes, it calls `ThreadFinishedSteppingOverBreakpoint`, which decrements a tracking count per address. The breakpoint is only re-enabled when the count reaches zero.

All threads in the largest group are resumed together in a single batched vCont packet. If some threads don't complete their step in one cycle, the pop-and-recreate logic naturally re-batches the remaining threads on the next WillResume call.



Claude AI assisted in syntex fixes and making the comments more understandable. 