### PR TITLE
[WinEH] Check object unwinding in seh block only when -eha is used

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -2228,8 +2228,8 @@ void CodeGenFunction::EmitAutoVarCleanups(const AutoVarEmission &emission) {
 
   // Check the type for a cleanup.
   if (QualType::DestructionKind dtorKind = D.needsDestruction(getContext())) {
-    // Check if we're in a SEH block, prevent it
-    if (currentFunctionUsesSEHTry())
+    // Check if we're in a SEH block with EHa, prevent it
+    if (getLangOpts().EHAsynch && currentFunctionUsesSEHTry())
       getContext().getDiagnostics().Report(D.getLocation(),
                                            diag::err_seh_object_unwinding);
     emitAutoVarTypeCleanup(emission, dtorKind);

--- a/clang/test/CodeGenCXX/exceptions-seh.cpp
+++ b/clang/test/CodeGenCXX/exceptions-seh.cpp
@@ -208,7 +208,7 @@ void seh_unwinding() {
 #elif defined(ERR4)
 void seh_unwinding() {
   __try {
-  HasCleanup x; // expected-no-diagnostics
+    HasCleanup x; // expected-no-diagnostics
   } __except (1) {
   }
 }

--- a/clang/test/CodeGenCXX/exceptions-seh.cpp
+++ b/clang/test/CodeGenCXX/exceptions-seh.cpp
@@ -10,6 +10,8 @@
 // RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR2
 // RUN: %clang_cc1 -triple x86_64-windows -fasync-exceptions -fcxx-exceptions -fexceptions \
 // RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR3
+// RUN: %clang_cc1 -triple x86_64-windows -fcxx-exceptions -fexceptions \
+// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR4
 
 extern "C" unsigned long _exception_code();
 extern "C" void might_throw();
@@ -200,6 +202,13 @@ void seh_unwinding() {
 void seh_unwinding() {
   HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
   __try {
+  } __except (1) {
+  }
+}
+#elif defined(ERR4)
+void seh_unwinding() {
+  __try {
+  HasCleanup x; // expected-no-diagnostics
   } __except (1) {
   }
 }


### PR DESCRIPTION
After this [PR](https://github.com/llvm/llvm-project/pull/172287), build errors may occur even when `/EHa` is not enabled(like use `/EHsc`).

While MSVC performs similar checks whenever exceptions are enabled, LLVM is more prone to generating invalid code where SEH fails to function correctly when asyn exceptions(`/EHa`) are not used. Valid SEH code generation is typically only ensured when `/EHa` are enabled. Therefore, this patch is designed to perform the check only when `/EHa` is used.

Of course, on Windows, if LLVM doesn't use `/EHa` but uses `/EHsc` or `/EHs` instead the code within the `__except` block may behave unexpectedly, it unlike msvc. This is consistent with previous LLVM versions.