### PR TITLE
[clang-format] Update goto label indentation styles

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -4535,22 +4535,69 @@ the configuration (without a prefix: ``Auto``).
 
 .. _IndentGotoLabels:
 
-**IndentGotoLabels** (``Boolean``) :versionbadge:`clang-format 10` :ref:`¶ <IndentGotoLabels>`
-  Indent goto labels.
+**IndentGotoLabels** (``IndentGotoLabelStyle``) :versionbadge:`clang-format 23` :ref:`¶ <IndentGotoLabels>`
+  The goto label indenting style to use.
 
-  When ``false``, goto labels are flushed left.
+  Possible values:
 
-  .. code-block:: c++
+  * ``IGLS_LeftAlign`` (in configuration: ``LeftAlign``)
+    Left align goto labels.
 
-     true:                                  false:
-     int f() {                      vs.     int f() {
-       if (foo()) {                           if (foo()) {
-       label1:                              label1:
-         bar();                                 bar();
-       }                                      }
-     label2:                                label2:
-       return 1;                              return 1;
-     }                                      }
+    .. code-block:: c++
+
+       int f() {
+         if (foo()) {
+       label1:
+           bar();
+         }
+       label2:
+         return 1;
+       }
+
+  * ``IGLS_NoIndent`` (in configuration: ``NoIndent``)
+    Do not indent goto labels.
+
+    .. code-block:: c++
+
+       int f() {
+         if (foo()) {
+         label1:
+           bar();
+         }
+       label2:
+         return 1;
+       }
+
+  * ``IGLS_Indent`` (in configuration: ``Indent``)
+    Indent goto labels.
+
+    .. code-block:: c++
+
+       int f() {
+         if (foo()) {
+           label1:
+           bar();
+         }
+         label2:
+         return 1;
+       }
+
+  * ``IGLS_HalfIndent`` (in configuration: ``HalfIndent``)
+    Indent goto labels to half the indentation of the surrounding code.
+    If the indentation width is not an even number, it will round up.
+
+    .. code-block:: c++
+
+       int f() {
+         if (foo()) {
+          label1:
+           bar();
+         }
+        label2:
+         return 1;
+       }
+
+
 
 .. _IndentPPDirectives:
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -4535,13 +4535,13 @@ the configuration (without a prefix: ``Auto``).
 
 .. _IndentGotoLabels:
 
-**IndentGotoLabels** (``IndentGotoLabelStyle``) :versionbadge:`clang-format 23` :ref:`¶ <IndentGotoLabels>`
+**IndentGotoLabels** (``IndentGotoLabelStyle``) :versionbadge:`clang-format 10` :ref:`¶ <IndentGotoLabels>`
   The goto label indenting style to use.
 
   Possible values:
 
-  * ``IGLS_LeftAlign`` (in configuration: ``LeftAlign``)
-    Left align goto labels.
+  * ``IGLS_NoIndent`` (in configuration: ``NoIndent``)
+    Do not indent goto labels.
 
     .. code-block:: c++
 
@@ -4554,8 +4554,8 @@ the configuration (without a prefix: ``Auto``).
          return 1;
        }
 
-  * ``IGLS_NoIndent`` (in configuration: ``NoIndent``)
-    Do not indent goto labels.
+  * ``IGLS_OuterIndent`` (in configuration: ``OuterIndent``)
+    Indent goto labels to the enclosing block (previous indenting level).
 
     .. code-block:: c++
 
@@ -4568,8 +4568,9 @@ the configuration (without a prefix: ``Auto``).
          return 1;
        }
 
-  * ``IGLS_Indent`` (in configuration: ``Indent``)
-    Indent goto labels.
+  * ``IGLS_InnerIndent`` (in configuration: ``InnerIndent``)
+    Indent goto labels to the surrounding statements (current indenting
+    level).
 
     .. code-block:: c++
 
@@ -4584,7 +4585,7 @@ the configuration (without a prefix: ``Auto``).
 
   * ``IGLS_HalfIndent`` (in configuration: ``HalfIndent``)
     Indent goto labels to half the indentation of the surrounding code.
-    If the indentation width is not an even number, it will round up.
+    If the indentation width is an odd number, it will round up.
 
     .. code-block:: c++
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3080,7 +3080,7 @@ struct FormatStyle {
 
   /// Options for indenting goto labels.
   enum IndentGotoLabelStyle : int8_t {
-    /// Left align goto labels.
+    /// Do not indent goto labels.
     /// \code
     ///    int f() {
     ///      if (foo()) {
@@ -3091,8 +3091,8 @@ struct FormatStyle {
     ///      return 1;
     ///    }
     /// \endcode
-    IGLS_LeftAlign,
-    /// Do not indent goto labels.
+    IGLS_NoIndent,
+    /// Indent goto labels to the enclosing block (previous indenting level).
     /// \code
     ///    int f() {
     ///      if (foo()) {
@@ -3103,8 +3103,9 @@ struct FormatStyle {
     ///      return 1;
     ///    }
     /// \endcode
-    IGLS_NoIndent,
-    /// Indent goto labels.
+    IGLS_OuterIndent,
+    /// Indent goto labels to the surrounding statements (current indenting
+    /// level).
     /// \code
     ///    int f() {
     ///      if (foo()) {
@@ -3115,9 +3116,9 @@ struct FormatStyle {
     ///      return 1;
     ///    }
     /// \endcode
-    IGLS_Indent,
+    IGLS_InnerIndent,
     /// Indent goto labels to half the indentation of the surrounding code.
-    /// If the indentation width is not an even number, it will round up.
+    /// If the indentation width is an odd number, it will round up.
     /// \code
     ///    int f() {
     ///      if (foo()) {
@@ -3132,7 +3133,7 @@ struct FormatStyle {
   };
 
   /// The goto label indenting style to use.
-  /// \version 23
+  /// \version 10
   IndentGotoLabelStyle IndentGotoLabels;
 
   /// Options for indenting preprocessor directives.

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3078,22 +3078,62 @@ struct FormatStyle {
   /// \version 11
   IndentExternBlockStyle IndentExternBlock;
 
-  /// Indent goto labels.
-  ///
-  /// When ``false``, goto labels are flushed left.
-  /// \code
-  ///    true:                                  false:
-  ///    int f() {                      vs.     int f() {
-  ///      if (foo()) {                           if (foo()) {
-  ///      label1:                              label1:
-  ///        bar();                                 bar();
-  ///      }                                      }
-  ///    label2:                                label2:
-  ///      return 1;                              return 1;
-  ///    }                                      }
-  /// \endcode
-  /// \version 10
-  bool IndentGotoLabels;
+  /// Options for indenting goto labels.
+  enum IndentGotoLabelStyle : int8_t {
+    /// Left align goto labels.
+    /// \code
+    ///    int f() {
+    ///      if (foo()) {
+    ///    label1:
+    ///        bar();
+    ///      }
+    ///    label2:
+    ///      return 1;
+    ///    }
+    /// \endcode
+    IGLS_LeftAlign,
+    /// Do not indent goto labels.
+    /// \code
+    ///    int f() {
+    ///      if (foo()) {
+    ///      label1:
+    ///        bar();
+    ///      }
+    ///    label2:
+    ///      return 1;
+    ///    }
+    /// \endcode
+    IGLS_NoIndent,
+    /// Indent goto labels.
+    /// \code
+    ///    int f() {
+    ///      if (foo()) {
+    ///        label1:
+    ///        bar();
+    ///      }
+    ///      label2:
+    ///      return 1;
+    ///    }
+    /// \endcode
+    IGLS_Indent,
+    /// Indent goto labels to half the indentation of the surrounding code.
+    /// If the indentation width is not an even number, it will round up.
+    /// \code
+    ///    int f() {
+    ///      if (foo()) {
+    ///       label1:
+    ///        bar();
+    ///      }
+    ///     label2:
+    ///      return 1;
+    ///    }
+    /// \endcode
+    IGLS_HalfIndent,
+  };
+
+  /// The goto label indenting style to use.
+  /// \version 23
+  IndentGotoLabelStyle IndentGotoLabels;
 
   /// Options for indenting preprocessor directives.
   enum PPDirectiveIndentStyle : int8_t {

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1465,6 +1465,18 @@ template <> struct DocumentListTraits<std::vector<FormatStyle>> {
     return Seq[Index];
   }
 };
+
+template <> struct ScalarEnumerationTraits<FormatStyle::IndentGotoLabelStyle> {
+  static void enumeration(IO &IO, FormatStyle::IndentGotoLabelStyle &Value) {
+    IO.enumCase(Value, "LeftAlign", FormatStyle::IGLS_LeftAlign);
+    IO.enumCase(Value, "NoIndent", FormatStyle::IGLS_NoIndent);
+    IO.enumCase(Value, "Indent", FormatStyle::IGLS_Indent);
+    IO.enumCase(Value, "HalfIndent", FormatStyle::IGLS_HalfIndent);
+    IO.enumCase(Value, "false", FormatStyle::IGLS_LeftAlign);
+    IO.enumCase(Value, "true", FormatStyle::IGLS_NoIndent);
+  }
+};
+
 } // namespace yaml
 } // namespace llvm
 
@@ -1759,7 +1771,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.IndentCaseLabels = false;
   LLVMStyle.IndentExportBlock = true;
   LLVMStyle.IndentExternBlock = FormatStyle::IEBS_AfterExternBlock;
-  LLVMStyle.IndentGotoLabels = true;
+  LLVMStyle.IndentGotoLabels = FormatStyle::IGLS_NoIndent;
   LLVMStyle.IndentPPDirectives = FormatStyle::PPDIS_None;
   LLVMStyle.IndentRequiresClause = true;
   LLVMStyle.IndentWidth = 2;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1468,12 +1468,14 @@ template <> struct DocumentListTraits<std::vector<FormatStyle>> {
 
 template <> struct ScalarEnumerationTraits<FormatStyle::IndentGotoLabelStyle> {
   static void enumeration(IO &IO, FormatStyle::IndentGotoLabelStyle &Value) {
-    IO.enumCase(Value, "LeftAlign", FormatStyle::IGLS_LeftAlign);
     IO.enumCase(Value, "NoIndent", FormatStyle::IGLS_NoIndent);
-    IO.enumCase(Value, "Indent", FormatStyle::IGLS_Indent);
+    IO.enumCase(Value, "OuterIndent", FormatStyle::IGLS_OuterIndent);
+    IO.enumCase(Value, "InnerIndent", FormatStyle::IGLS_InnerIndent);
     IO.enumCase(Value, "HalfIndent", FormatStyle::IGLS_HalfIndent);
-    IO.enumCase(Value, "false", FormatStyle::IGLS_LeftAlign);
-    IO.enumCase(Value, "true", FormatStyle::IGLS_NoIndent);
+
+    // For backward compatibility.
+    IO.enumCase(Value, "false", FormatStyle::IGLS_NoIndent);
+    IO.enumCase(Value, "true", FormatStyle::IGLS_OuterIndent);
   }
 };
 
@@ -1771,7 +1773,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.IndentCaseLabels = false;
   LLVMStyle.IndentExportBlock = true;
   LLVMStyle.IndentExternBlock = FormatStyle::IEBS_AfterExternBlock;
-  LLVMStyle.IndentGotoLabels = FormatStyle::IGLS_NoIndent;
+  LLVMStyle.IndentGotoLabels = FormatStyle::IGLS_OuterIndent;
   LLVMStyle.IndentPPDirectives = FormatStyle::PPDIS_None;
   LLVMStyle.IndentRequiresClause = true;
   LLVMStyle.IndentWidth = 2;

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -120,7 +120,14 @@ private:
   int getIndentOffset(const AnnotatedLine &Line) {
     if (Style.isJava() || Style.isJavaScript() || Style.isCSharp())
       return 0;
+
     const auto &RootToken = *Line.First;
+
+    if (Style.IndentGotoLabels == FormatStyle::IGLS_HalfIndent &&
+        RootToken.Next != NULL && RootToken.Next->is(TT_GotoLabelColon)) {
+      return -static_cast<int>(Style.IndentWidth / 2);
+    }
+
     if (Line.Type == LT_AccessModifier ||
         RootToken.isAccessSpecifier(/*ColonRequired=*/false) ||
         RootToken.isObjCAccessSpecifier() ||

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -124,7 +124,7 @@ private:
     const auto &RootToken = *Line.First;
 
     if (Style.IndentGotoLabels == FormatStyle::IGLS_HalfIndent &&
-        RootToken.Next != NULL && RootToken.Next->is(TT_GotoLabelColon)) {
+        RootToken.Next && RootToken.Next->is(TT_GotoLabelColon)) {
       return -static_cast<int>(Style.IndentWidth / 2);
     }
 

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1710,7 +1710,7 @@ void UnwrappedLineParser::parseStructuralElement(
       if (!Line->InMacroBody || CurrentLines->size() > 1)
         Line->Tokens.begin()->Tok->MustBreakBefore = true;
       FormatTok->setFinalizedType(TT_GotoLabelColon);
-      parseLabel(!Style.IndentGotoLabels);
+      parseLabel(Style.IndentGotoLabels);
       if (HasLabel)
         *HasLabel = true;
       return;
@@ -3354,14 +3354,24 @@ void UnwrappedLineParser::parseDoWhile() {
   parseStructuralElement();
 }
 
-void UnwrappedLineParser::parseLabel(bool LeftAlignLabel) {
+void UnwrappedLineParser::parseLabel(
+    FormatStyle::IndentGotoLabelStyle IndentGotoLabels) {
   nextToken();
   unsigned OldLineLevel = Line->Level;
 
-  if (LeftAlignLabel)
+  switch (IndentGotoLabels) {
+  case FormatStyle::IGLS_LeftAlign:
     Line->Level = 0;
-  else if (Line->Level > 1 || (!Line->InPPDirective && Line->Level > 0))
-    --Line->Level;
+    break;
+  case FormatStyle::IGLS_NoIndent:
+    if (Line->Level > 1 || (!Line->InPPDirective && Line->Level > 0))
+      --Line->Level;
+    break;
+  case FormatStyle::IGLS_HalfIndent:
+  case FormatStyle::IGLS_Indent:
+  default:
+    break;
+  }
 
   if (!Style.IndentCaseBlocks && CommentsBeforeNextToken.empty() &&
       FormatTok->is(tok::l_brace)) {

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -3360,16 +3360,15 @@ void UnwrappedLineParser::parseLabel(
   unsigned OldLineLevel = Line->Level;
 
   switch (IndentGotoLabels) {
-  case FormatStyle::IGLS_LeftAlign:
+  case FormatStyle::IGLS_NoIndent:
     Line->Level = 0;
     break;
-  case FormatStyle::IGLS_NoIndent:
+  case FormatStyle::IGLS_OuterIndent:
     if (Line->Level > 1 || (!Line->InPPDirective && Line->Level > 0))
       --Line->Level;
     break;
   case FormatStyle::IGLS_HalfIndent:
-  case FormatStyle::IGLS_Indent:
-  default:
+  case FormatStyle::IGLS_InnerIndent:
     break;
   }
 

--- a/clang/lib/Format/UnwrappedLineParser.h
+++ b/clang/lib/Format/UnwrappedLineParser.h
@@ -159,7 +159,8 @@ private:
   void parseLoopBody(bool KeepBraces, bool WrapRightBrace);
   void parseForOrWhileLoop(bool HasParens = true);
   void parseDoWhile();
-  void parseLabel(bool LeftAlignLabel = false);
+  void parseLabel(FormatStyle::IndentGotoLabelStyle IndentGotoLabels =
+                      FormatStyle::IGLS_NoIndent);
   void parseCaseLabel();
   void parseSwitch(bool IsExpr);
   void parseNamespace();

--- a/clang/lib/Format/UnwrappedLineParser.h
+++ b/clang/lib/Format/UnwrappedLineParser.h
@@ -160,7 +160,7 @@ private:
   void parseForOrWhileLoop(bool HasParens = true);
   void parseDoWhile();
   void parseLabel(FormatStyle::IndentGotoLabelStyle IndentGotoLabels =
-                      FormatStyle::IGLS_NoIndent);
+                      FormatStyle::IGLS_OuterIndent);
   void parseCaseLabel();
   void parseSwitch(bool IsExpr);
   void parseNamespace();

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -891,19 +891,19 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("IndentExternBlock: false", IndentExternBlock,
               FormatStyle::IEBS_NoIndent);
 
-  Style.IndentGotoLabels = FormatStyle::IGLS_NoIndent;
-  CHECK_PARSE("IndentGotoLabels: LeftAlign", IndentGotoLabels,
-              FormatStyle::IGLS_LeftAlign);
+  Style.IndentGotoLabels = FormatStyle::IGLS_OuterIndent;
   CHECK_PARSE("IndentGotoLabels: NoIndent", IndentGotoLabels,
               FormatStyle::IGLS_NoIndent);
-  CHECK_PARSE("IndentGotoLabels: Indent", IndentGotoLabels,
-              FormatStyle::IGLS_Indent);
+  CHECK_PARSE("IndentGotoLabels: OuterIndent", IndentGotoLabels,
+              FormatStyle::IGLS_OuterIndent);
+  CHECK_PARSE("IndentGotoLabels: InnerIndent", IndentGotoLabels,
+              FormatStyle::IGLS_InnerIndent);
   CHECK_PARSE("IndentGotoLabels: HalfIndent", IndentGotoLabels,
               FormatStyle::IGLS_HalfIndent);
   CHECK_PARSE("IndentGotoLabels: false", IndentGotoLabels,
-              FormatStyle::IGLS_LeftAlign);
-  CHECK_PARSE("IndentGotoLabels: true", IndentGotoLabels,
               FormatStyle::IGLS_NoIndent);
+  CHECK_PARSE("IndentGotoLabels: true", IndentGotoLabels,
+              FormatStyle::IGLS_OuterIndent);
 
   Style.BitFieldColonSpacing = FormatStyle::BFCS_None;
   CHECK_PARSE("BitFieldColonSpacing: Both", BitFieldColonSpacing,

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -193,7 +193,6 @@ TEST(ConfigParseTest, ParsesConfigurationBools) {
   CHECK_PARSE_BOOL(IndentCaseBlocks);
   CHECK_PARSE_BOOL(IndentCaseLabels);
   CHECK_PARSE_BOOL(IndentExportBlock);
-  CHECK_PARSE_BOOL(IndentGotoLabels);
   CHECK_PARSE_BOOL(IndentRequiresClause);
   CHECK_PARSE_BOOL_FIELD(IndentRequiresClause, "IndentRequires");
   CHECK_PARSE_BOOL(IndentWrappedFunctionNames);
@@ -891,6 +890,20 @@ TEST(ConfigParseTest, ParsesConfiguration) {
               FormatStyle::IEBS_Indent);
   CHECK_PARSE("IndentExternBlock: false", IndentExternBlock,
               FormatStyle::IEBS_NoIndent);
+
+  Style.IndentGotoLabels = FormatStyle::IGLS_NoIndent;
+  CHECK_PARSE("IndentGotoLabels: LeftAlign", IndentGotoLabels,
+              FormatStyle::IGLS_LeftAlign);
+  CHECK_PARSE("IndentGotoLabels: NoIndent", IndentGotoLabels,
+              FormatStyle::IGLS_NoIndent);
+  CHECK_PARSE("IndentGotoLabels: Indent", IndentGotoLabels,
+              FormatStyle::IGLS_Indent);
+  CHECK_PARSE("IndentGotoLabels: HalfIndent", IndentGotoLabels,
+              FormatStyle::IGLS_HalfIndent);
+  CHECK_PARSE("IndentGotoLabels: false", IndentGotoLabels,
+              FormatStyle::IGLS_LeftAlign);
+  CHECK_PARSE("IndentGotoLabels: true", IndentGotoLabels,
+              FormatStyle::IGLS_NoIndent);
 
   Style.BitFieldColonSpacing = FormatStyle::BFCS_None;
   CHECK_PARSE("BitFieldColonSpacing: Both", BitFieldColonSpacing,

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -3158,7 +3158,7 @@ TEST_F(FormatTest, FormatsLabels) {
                "}");
 
   FormatStyle Style = getLLVMStyle();
-  Style.IndentGotoLabels = FormatStyle::IGLS_LeftAlign;
+  Style.IndentGotoLabels = FormatStyle::IGLS_NoIndent;
   verifyFormat("void f() {\n"
                "  some_code();\n"
                "test_label:\n"
@@ -3196,7 +3196,23 @@ TEST_F(FormatTest, FormatsLabels) {
                "  }\n"
                "}",
                Style);
-  Style.IndentGotoLabels = FormatStyle::IGLS_NoIndent;
+  verifyFormat("void f() {\n"
+               "L1:\n"
+               "  a();\n"
+               "  {\n"
+               "L2:\n"
+               "    b();\n"
+               "    {\n"
+               "L3:\n"
+               "      c();\n"
+               "      {\n"
+               "L4:\n"
+               "      }\n"
+               "    }\n"
+               "  }\n"
+               "}",
+               Style);
+  Style.IndentGotoLabels = FormatStyle::IGLS_OuterIndent;
   verifyFormat("void f() {\n"
                "  some_code();\n"
                "test_label:\n"
@@ -3208,7 +3224,23 @@ TEST_F(FormatTest, FormatsLabels) {
                "  }\n"
                "}",
                Style);
-  Style.IndentGotoLabels = FormatStyle::IGLS_Indent;
+  verifyFormat("void f() {\n"
+               "L1:\n"
+               "  a();\n"
+               "  {\n"
+               "  L2:\n"
+               "    b();\n"
+               "    {\n"
+               "    L3:\n"
+               "      c();\n"
+               "      {\n"
+               "      L4:\n"
+               "      }\n"
+               "    }\n"
+               "  }\n"
+               "}",
+               Style);
+  Style.IndentGotoLabels = FormatStyle::IGLS_InnerIndent;
   verifyFormat("void f() {\n"
                "  some_code();\n"
                "  test_label:\n"
@@ -3217,6 +3249,22 @@ TEST_F(FormatTest, FormatsLabels) {
                "    some_more_code();\n"
                "    another_label:\n"
                "    some_more_code();\n"
+               "  }\n"
+               "}",
+               Style);
+  verifyFormat("void f() {\n"
+               "  L1:\n"
+               "  a();\n"
+               "  {\n"
+               "    L2:\n"
+               "    b();\n"
+               "    {\n"
+               "      L3:\n"
+               "      c();\n"
+               "      {\n"
+               "        L4:\n"
+               "      }\n"
+               "    }\n"
                "  }\n"
                "}",
                Style);
@@ -3232,6 +3280,22 @@ TEST_F(FormatTest, FormatsLabels) {
                "  }\n"
                "}",
                Style);
+  verifyFormat("void f() {\n"
+               " L1:\n"
+               "  a();\n"
+               "  {\n"
+               "   L2:\n"
+               "    b();\n"
+               "    {\n"
+               "     L3:\n"
+               "      c();\n"
+               "      {\n"
+               "       L4:\n"
+               "      }\n"
+               "    }\n"
+               "  }\n"
+               "}",
+               Style);
   Style.IndentWidth = 3;
   verifyFormat("void f() {\n"
                "   some_code();\n"
@@ -3240,7 +3304,7 @@ TEST_F(FormatTest, FormatsLabels) {
                "}",
                Style);
   Style.IndentWidth = 2;
-  Style.IndentGotoLabels = FormatStyle::IGLS_LeftAlign;
+  Style.IndentGotoLabels = FormatStyle::IGLS_NoIndent;
 
   Style.ColumnLimit = 15;
   verifyFormat("#define FOO   \\\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -3158,7 +3158,7 @@ TEST_F(FormatTest, FormatsLabels) {
                "}");
 
   FormatStyle Style = getLLVMStyle();
-  Style.IndentGotoLabels = false;
+  Style.IndentGotoLabels = FormatStyle::IGLS_LeftAlign;
   verifyFormat("void f() {\n"
                "  some_code();\n"
                "test_label:\n"
@@ -3196,6 +3196,51 @@ TEST_F(FormatTest, FormatsLabels) {
                "  }\n"
                "}",
                Style);
+  Style.IndentGotoLabels = FormatStyle::IGLS_NoIndent;
+  verifyFormat("void f() {\n"
+               "  some_code();\n"
+               "test_label:\n"
+               "  some_other_code();\n"
+               "  {\n"
+               "    some_more_code();\n"
+               "  another_label:\n"
+               "    some_more_code();\n"
+               "  }\n"
+               "}",
+               Style);
+  Style.IndentGotoLabels = FormatStyle::IGLS_Indent;
+  verifyFormat("void f() {\n"
+               "  some_code();\n"
+               "  test_label:\n"
+               "  some_other_code();\n"
+               "  {\n"
+               "    some_more_code();\n"
+               "    another_label:\n"
+               "    some_more_code();\n"
+               "  }\n"
+               "}",
+               Style);
+  Style.IndentGotoLabels = FormatStyle::IGLS_HalfIndent;
+  verifyFormat("void f() {\n"
+               "  some_code();\n"
+               " test_label:\n"
+               "  some_other_code();\n"
+               "  {\n"
+               "    some_more_code();\n"
+               "   another_label:\n"
+               "    some_more_code();\n"
+               "  }\n"
+               "}",
+               Style);
+  Style.IndentWidth = 3;
+  verifyFormat("void f() {\n"
+               "   some_code();\n"
+               "  test_label:\n"
+               "   some_other_code();\n"
+               "}",
+               Style);
+  Style.IndentWidth = 2;
+  Style.IndentGotoLabels = FormatStyle::IGLS_LeftAlign;
 
   Style.ColumnLimit = 15;
   verifyFormat("#define FOO   \\\n"


### PR DESCRIPTION
Updates the goto label indentation styles based on the feature request. 

Resolves #24492.
