### PR TITLE
[test] Add bit < 8 testcase for x86 __builtin_bswapg

### DIFF
--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -881,6 +881,9 @@ namespace bswap {
   int h15 = __builtin_bswapg((_BitInt(24))0x1234) == (_BitInt(24))0x3412 ? 1 : f();
   // expected-error@-1 {{_BitInt type '_BitInt(24)' (24 bits) must be a multiple of 16 bits for byte swapping}}
   // ref-error@-2 {{_BitInt type '_BitInt(24)' (24 bits) must be a multiple of 16 bits for byte swapping}}
+  int h16 = __builtin_bswapg((_BitInt(5))0x1) == (_BitInt(5))0x1 ? 1 : f();
+  // expected-error@-1 {{_BitInt type '_BitInt(5)' (5 bits) must be a multiple of 16 bits for byte swapping}}
+  // ref-error@-2 {{_BitInt type '_BitInt(5)' (5 bits) must be a multiple of 16 bits for byte swapping}}
 #endif
 
   constexpr const int const_expr = 0x1234;

--- a/clang/test/Sema/constant-builtins-2.c
+++ b/clang/test/Sema/constant-builtins-2.c
@@ -502,6 +502,8 @@ int h21 = __builtin_bswapg((_BitInt(64))0x0000000000001234) == (_BitInt(64))0x34
 int h22 = __builtin_bswapg(~(_BitInt(128))0) == (~(_BitInt(128))0) ? 1 : f();
 int h23 = __builtin_bswapg((_BitInt(24))0x1234) == (_BitInt(24))0x3412 ? 1 : f();
 // expected-error@-1 {{_BitInt type '_BitInt(24)' (24 bits) must be a multiple of 16 bits for byte swapping}}
+int h23a = __builtin_bswapg((_BitInt(3))0x3) == (_BitInt(3))0x3 ? 1 : f();
+// expected-error@-1 {{_BitInt type '_BitInt(3)' (3 bits) must be a multiple of 16 bits for byte swapping}}
 
 char h24[__builtin_bitreverseg((char)0x01) == (char)0x80 ? 1 : -1];
 char h25[__builtin_bitreverseg((short)0x3C48) == (short)0x123C ? 1 : -1];

--- a/clang/test/SemaCXX/builtin-bswapg.cpp
+++ b/clang/test/SemaCXX/builtin-bswapg.cpp
@@ -228,4 +228,6 @@ void test_bitint() {
   static_assert(__builtin_bswapg(~(_BitInt(128))0) == (~(_BitInt(128))0), "");
   static_assert(__builtin_bswapg((_BitInt(24))0x1234) == (_BitInt(24))0x3412, "");
   // expected-error@-1 {{_BitInt type '_BitInt(24)' (24 bits) must be a multiple of 16 bits for byte swapping}}
+  static_assert(__builtin_bswapg((_BitInt(4))0x7) == (_BitInt(4))0x7, "");
+  // expected-error@-1 {{_BitInt type '_BitInt(4)' (4 bits) must be a multiple of 16 bits for byte swapping}}
 }


### PR DESCRIPTION
### Summary
the related PR: https://github.com/llvm/llvm-project/pull/179177, add bits < 8 testcase for __builtin_bswapg