### PR TITLE
[flang][docs] Update the `-Ofast` description in `FlangDriver.md`

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -849,7 +849,7 @@ def O_flag : Flag<["-"], "O">, Visibility<[ClangOption, CC1Option, FC1Option]>,
 def Ofast : Joined<["-"], "Ofast">, Group<O_Group>,
   Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
   HelpTextForVariants<[FlangOption, FC1Option],
-    "Deprecated; use '-O3 -ffast-math -fstack-arrays' for the same behavior,"
+    "Deprecated; use '-O3 -ffast-math -fstack-arrays -fno-protect-parens' for the same behavior,"
     " or '-O3 -fstack-arrays' to enable only conforming optimizations">,
   HelpText<"Deprecated; use '-O3 -ffast-math' for the same behavior,"
            " or '-O3' to enable only conforming optimizations">;

--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -559,7 +559,7 @@ See the
 documentation for more details.
 
 ## Ofast and Fast Math
-`-Ofast` in Flang means `-O3 -ffast-math -fstack-arrays`.
+`-Ofast` in Flang means `-O3 -ffast-math -fstack-arrays -fno-protect-parens`.
 
 `-ffast-math` means the following:
  - `-fno-honor-infinities`


### PR DESCRIPTION
After #170505, `-fno-protect-parens` is now required for flang to behave the same as `-Ofast`. This patch adds that information to the description of `-Ofast` in `FlangDriver.md`.