### PR TITLE
[llvm-ir2vec] Adding Inst Embeddings Map API to ir2vec python bindings

### DIFF
--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
@@ -54,7 +54,7 @@ if tool is not None:
         for inst_str in sorted(func_inst_map.keys()):
             emb = func_inst_map[inst_str]
             inst_sorted.append((inst_str, emb))
-    
+
     for inst_str, emb in inst_sorted:
         print(f"Inst: {inst_str}")
         print(f"  Embedding: {emb.tolist()}")

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
@@ -43,6 +43,22 @@ if tool is not None:
             print(f"  BB: {bb_name}")
             print(f"    Embedding: {emb.tolist()}")
 
+    # Test getInstEmbMap
+    print("\n=== Instruction Embeddings ===")
+    inst_emb_map = tool.getInstEmbMap()
+
+    # Sorting by function name, then instruction string for deterministic output
+    inst_sorted = []
+    for func_name in sorted(inst_emb_map.keys()):
+        func_inst_map = inst_emb_map[func_name]
+        for inst_str in sorted(func_inst_map.keys()):
+            emb = func_inst_map[inst_str]
+            inst_sorted.append((inst_str, emb))
+    
+    for inst_str, emb in inst_sorted:
+        print(f"Inst: {inst_str}")
+        print(f"  Embedding: {emb.tolist()}")
+
 # CHECK: SUCCESS: Tool initialized
 # CHECK: Tool type: IR2VecTool
 # CHECK: === Function Embeddings ===
@@ -75,3 +91,26 @@ if tool is not None:
 # CHECK: Function: multiply
 # CHECK:   BB: entry
 # CHECK-NEXT:     Embedding: [50.0, 52.0, 54.0]
+# CHECK: === Instruction Embeddings ===
+# CHECK: Inst: %sum = add i32 %a, %b
+# CHECK-NEXT:   Embedding: [37.0, 38.0, 39.0]
+# CHECK: Inst: ret i32 %sum
+# CHECK-NEXT:   Embedding: [1.0, 2.0, 3.0]
+# CHECK: Inst: %cmp = icmp sgt i32 %n, 0
+# CHECK-NEXT:   Embedding: [157.20000000298023, 158.20000000298023, 159.20000000298023]
+# CHECK: Inst: %neg_val = sub i32 %n, 10
+# CHECK-NEXT:   Embedding: [43.0, 44.0, 45.0]
+# CHECK: Inst: %pos_val = add i32 %n, 10
+# CHECK-NEXT:   Embedding: [37.0, 38.0, 39.0]
+# CHECK: Inst: %result = phi i32 [ %pos_val, %positive ], [ %neg_val, %negative ]
+# CHECK-NEXT:   Embedding: [163.0, 164.0, 165.0]
+# CHECK: Inst: br i1 %cmp, label %positive, label %negative
+# CHECK-NEXT:   Embedding: [4.0, 5.0, 6.0]
+# CHECK: Inst: br label %exit
+# CHECK-NEXT:   Embedding: [4.0, 5.0, 6.0]
+# CHECK: Inst: ret i32 %result
+# CHECK-NEXT:   Embedding: [1.0, 2.0, 3.0]
+# CHECK: Inst: %prod = mul i32 %x, %y
+# CHECK-NEXT:   Embedding: [49.0, 50.0, 51.0]
+# CHECK: Inst: ret i32 %prod
+# CHECK-NEXT:   Embedding: [1.0, 2.0, 3.0]

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
@@ -45,7 +45,7 @@ if tool is not None:
 
     # Test getInstEmbMap
     print("\n=== Instruction Embeddings ===")
-    
+
     # Test valid function names in sorted order
     for func_name in sorted(["add", "multiply", "conditional"]):
         inst_emb_map = tool.getInstEmbMap(func_name)

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
@@ -45,19 +45,15 @@ if tool is not None:
 
     # Test getInstEmbMap
     print("\n=== Instruction Embeddings ===")
-    inst_emb_map = tool.getInstEmbMap()
-
-    # Sorting by function name, then instruction string for deterministic output
-    inst_sorted = []
-    for func_name in sorted(inst_emb_map.keys()):
-        func_inst_map = inst_emb_map[func_name]
-        for inst_str in sorted(func_inst_map.keys()):
-            emb = func_inst_map[inst_str]
-            inst_sorted.append((inst_str, emb))
-
-    for inst_str, emb in inst_sorted:
-        print(f"Inst: {inst_str}")
-        print(f"  Embedding: {emb.tolist()}")
+    
+    # Test valid function names in sorted order
+    for func_name in sorted(["add", "multiply", "conditional"]):
+        inst_emb_map = tool.getInstEmbMap(func_name)
+        print(f"Function: {func_name}")
+        for inst_str in sorted(inst_emb_map.keys()):
+            emb = inst_emb_map[inst_str]
+            print(f"  Inst: {inst_str}")
+            print(f"    Embedding: {emb.tolist()}")
 
 # CHECK: SUCCESS: Tool initialized
 # CHECK: Tool type: IR2VecTool
@@ -92,25 +88,28 @@ if tool is not None:
 # CHECK:   BB: entry
 # CHECK-NEXT:     Embedding: [50.0, 52.0, 54.0]
 # CHECK: === Instruction Embeddings ===
-# CHECK: Inst: %sum = add i32 %a, %b
-# CHECK-NEXT:   Embedding: [37.0, 38.0, 39.0]
-# CHECK: Inst: ret i32 %sum
-# CHECK-NEXT:   Embedding: [1.0, 2.0, 3.0]
-# CHECK: Inst: %cmp = icmp sgt i32 %n, 0
-# CHECK-NEXT:   Embedding: [157.20000000298023, 158.20000000298023, 159.20000000298023]
-# CHECK: Inst: %neg_val = sub i32 %n, 10
-# CHECK-NEXT:   Embedding: [43.0, 44.0, 45.0]
-# CHECK: Inst: %pos_val = add i32 %n, 10
-# CHECK-NEXT:   Embedding: [37.0, 38.0, 39.0]
-# CHECK: Inst: %result = phi i32 [ %pos_val, %positive ], [ %neg_val, %negative ]
-# CHECK-NEXT:   Embedding: [163.0, 164.0, 165.0]
-# CHECK: Inst: br i1 %cmp, label %positive, label %negative
-# CHECK-NEXT:   Embedding: [4.0, 5.0, 6.0]
-# CHECK: Inst: br label %exit
-# CHECK-NEXT:   Embedding: [4.0, 5.0, 6.0]
-# CHECK: Inst: ret i32 %result
-# CHECK-NEXT:   Embedding: [1.0, 2.0, 3.0]
-# CHECK: Inst: %prod = mul i32 %x, %y
-# CHECK-NEXT:   Embedding: [49.0, 50.0, 51.0]
-# CHECK: Inst: ret i32 %prod
-# CHECK-NEXT:   Embedding: [1.0, 2.0, 3.0]
+# CHECK: Function: add
+# CHECK:   Inst: %sum = add i32 %a, %b
+# CHECK-NEXT:     Embedding: [37.0, 38.0, 39.0]
+# CHECK:   Inst: ret i32 %sum
+# CHECK-NEXT:     Embedding: [1.0, 2.0, 3.0]
+# CHECK: Function: conditional
+# CHECK:   Inst: %cmp = icmp sgt i32 %n, 0
+# CHECK-NEXT:     Embedding: [157.20000000298023, 158.20000000298023, 159.20000000298023]
+# CHECK:   Inst: %neg_val = sub i32 %n, 10
+# CHECK-NEXT:     Embedding: [43.0, 44.0, 45.0]
+# CHECK:   Inst: %pos_val = add i32 %n, 10
+# CHECK-NEXT:     Embedding: [37.0, 38.0, 39.0]
+# CHECK:   Inst: %result = phi i32 [ %pos_val, %positive ], [ %neg_val, %negative ]
+# CHECK-NEXT:     Embedding: [163.0, 164.0, 165.0]
+# CHECK:   Inst: br i1 %cmp, label %positive, label %negative
+# CHECK-NEXT:     Embedding: [4.0, 5.0, 6.0]
+# CHECK:   Inst: br label %exit
+# CHECK-NEXT:     Embedding: [4.0, 5.0, 6.0]
+# CHECK:   Inst: ret i32 %result
+# CHECK-NEXT:     Embedding: [1.0, 2.0, 3.0]
+# CHECK: Function: multiply
+# CHECK:   Inst: %prod = mul i32 %x, %y
+# CHECK-NEXT:     Embedding: [49.0, 50.0, 51.0]
+# CHECK:   Inst: ret i32 %prod
+# CHECK-NEXT:     Embedding: [1.0, 2.0, 3.0]

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -151,36 +151,36 @@ public:
     return NbBBEmbMap;
   }
 
-  nb::dict getInstEmbMap() {
-    auto ToolInstEmbMap = Tool->getFuncInstEmbMap(OutputEmbeddingMode);
+  nb::dict getInstEmbMap(const std::string &FuncName) {
+    const Function *F = M->getFunction(FuncName);
+
+    if (!F)
+      throw nb::value_error(
+          ("Function '" + FuncName + "' not found in module").c_str());
+
+    auto ToolInstEmbMap = Tool->getInstEmbeddingsMap(*F, OutputEmbeddingMode);
 
     if (!ToolInstEmbMap)
       throw nb::value_error(toString(ToolInstEmbMap.takeError()).c_str());
 
     nb::dict NbInstEmbMap;
 
-    for (const auto &[FuncPtr, InstMap] : *ToolInstEmbMap) {
-      nb::dict NbFuncInstMap;
+    for (const auto &[InstPtr, InstEmb] : *ToolInstEmbMap) {
+      auto InstEmbVec = InstEmb.getData();
+      double *NbInstEmbVec = new double[InstEmbVec.size()];
+      std::copy(InstEmbVec.begin(), InstEmbVec.end(), NbInstEmbVec);
 
-      for (const auto &[InstPtr, InstEmb] : InstMap) {
-        auto InstEmbVec = InstEmb.getData();
-        double *NbInstEmbVec = new double[InstEmbVec.size()];
-        std::copy(InstEmbVec.begin(), InstEmbVec.end(), NbInstEmbVec);
+      auto NbArray = nb::ndarray<nb::numpy, double>(
+          NbInstEmbVec, {InstEmbVec.size()},
+          nb::capsule(NbInstEmbVec, [](void *P) noexcept {
+            delete[] static_cast<double *>(P);
+          }));
 
-        auto NbArray = nb::ndarray<nb::numpy, double>(
-            NbInstEmbVec, {InstEmbVec.size()},
-            nb::capsule(NbInstEmbVec, [](void *P) noexcept {
-              delete[] static_cast<double *>(P);
-            }));
+      std::string InstStr;
+      raw_string_ostream OS(InstStr);
+      InstPtr->print(OS);
 
-        std::string InstStr;
-        raw_string_ostream OS(InstStr);
-        InstPtr->print(OS);
-
-        NbFuncInstMap[nb::str(OS.str().c_str())] = NbArray;
-      }
-
-      NbInstEmbMap[nb::str(FuncPtr->getName().str().c_str())] = NbFuncInstMap;
+      NbInstEmbMap[nb::str(OS.str().c_str())] = NbArray;
     }
 
     return NbInstEmbMap;
@@ -204,27 +204,17 @@ NB_MODULE(ir2vec, m) {
            "Generate embedding for a single function by name\n"
            "Args: funcName (str) - IR-Name of the function\n"
            "Returns: ndarray[float64] - Function embedding vector")
-<<<<<<< HEAD
       .def("getBBEmbMap", &PyIR2VecTool::getBBEmbMap, nb::arg("funcName"),
            "Generate embeddings for all basic blocks in a function\n"
            "Args: funcName (str) - IR-Name of the function\n"
            "Returns: dict[str, ndarray[float64]] - "
-           "{basic_block_name: embedding vector}");
-=======
-      .def("getBBEmbMap", &PyIR2VecTool::getBBEmbMap,
-           "Generate embeddings for all basic blocks in the module\n"
-           "Returns: dict[str, dict[str, ndarray[float64]]] - Nested "
-           "dictionary mapping "
-           "function names to dictionaries of basic block names to embedding "
-           "vectors")
-      .def("getInstEmbMap", &PyIR2VecTool::getInstEmbMap,
-           "Generate embeddings for all instructions in the module\n"
-           "Returns: dict[str, dict[str, ndarray[float64]]] - Nested "
-           "dictionary mapping "
-           "function names to dictionaries of instruction strings to embedding "
-           "vectors");
+           "{basic_block_name: embedding vector}")
+      .def("getInstEmbMap", &PyIR2VecTool::getInstEmbMap, nb::arg("funcName"),
+           "Generate embeddings for all instructions in a function\n"
+           "Args: funcName (str) - IR-Name of the function\n"
+           "Returns: dict[str, ndarray[float64]] - "
+           "{instruction_string: embedding_vector}");
 
->>>>>>> b259e51c5fdd (Adding Inst Embeddings Map API to ir2vec python bindings - returns a nested map indexed by functions)
   m.def(
       "initEmbedding",
       [](const std::string &filename, const std::string &mode,

--- a/llvm/tools/llvm-ir2vec/lib/Utils.cpp
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.cpp
@@ -241,8 +241,7 @@ IR2VecTool::getInstEmbMap(const Function &F, IR2VecKind Kind) const {
   return Result;
 }
 
-Expected<FuncInstEmbMap>
-IR2VecTool::getFuncInstEmbMap(IR2VecKind Kind) const {
+Expected<FuncInstEmbMap> IR2VecTool::getFuncInstEmbMap(IR2VecKind Kind) const {
   if (!Vocab || !Vocab->isValid())
     return createStringError(
         errc::invalid_argument,

--- a/llvm/tools/llvm-ir2vec/lib/Utils.cpp
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.cpp
@@ -217,7 +217,7 @@ IR2VecTool::getBBEmbeddingsMap(const Function &F, IR2VecKind Kind) const {
 }
 
 Expected<InstEmbeddingsMap>
-IR2VecTool::getInstEmbMap(const Function &F, IR2VecKind Kind) const {
+IR2VecTool::getInstEmbeddingsMap(const Function &F, IR2VecKind Kind) const {
   if (!Vocab || !Vocab->isValid())
     return createStringError(
         errc::invalid_argument,
@@ -237,25 +237,6 @@ IR2VecTool::getInstEmbMap(const Function &F, IR2VecKind Kind) const {
 
   for (const Instruction &I : instructions(F))
     Result.try_emplace(&I, Emb->getInstVector(I));
-
-  return Result;
-}
-
-Expected<FuncInstEmbMap> IR2VecTool::getFuncInstEmbMap(IR2VecKind Kind) const {
-  if (!Vocab || !Vocab->isValid())
-    return createStringError(
-        errc::invalid_argument,
-        "Vocabulary is not valid. IR2VecTool not initialized.");
-
-  FuncInstEmbMap Result;
-
-  for (const Function &F : M.getFunctionDefs()) {
-    auto FuncInstVecs = getInstEmbMap(F, Kind);
-    if (!FuncInstVecs)
-      return FuncInstVecs.takeError();
-
-    Result.try_emplace(&F, std::move(*FuncInstVecs));
-  }
 
   return Result;
 }

--- a/llvm/tools/llvm-ir2vec/lib/Utils.cpp
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.cpp
@@ -152,8 +152,8 @@ void IR2VecTool::writeEntitiesToStream(raw_ostream &OS) {
     OS << Entities[EntityID] << '\t' << EntityID << '\n';
 }
 
-Expected<Embedding> IR2VecTool::getFunctionEmbedding(const Function &F,
-                                                     IR2VecKind Kind) const {
+Expected<std::unique_ptr<Embedder>>
+IR2VecTool::getIR2VecEmbedder(const Function &F, IR2VecKind Kind) const {
   if (!Vocab || !Vocab->isValid())
     return createStringError(
         errc::invalid_argument,
@@ -169,16 +169,20 @@ Expected<Embedding> IR2VecTool::getFunctionEmbedding(const Function &F,
                              "Failed to create embedder for function '%s'.",
                              F.getName().str().c_str());
 
-  return Emb->getFunctionVector();
+  return Emb;
+}
+
+Expected<Embedding> IR2VecTool::getFunctionEmbedding(const Function &F,
+                                                     IR2VecKind Kind) const {
+  auto Emb = getIR2VecEmbedder(F, Kind);
+  if (!Emb)
+    return Emb.takeError();
+
+  return (*Emb)->getFunctionVector();
 }
 
 Expected<FuncEmbMap>
 IR2VecTool::getFunctionEmbeddingsMap(IR2VecKind Kind) const {
-  if (!Vocab || !Vocab->isValid())
-    return createStringError(
-        errc::invalid_argument,
-        "Vocabulary is not valid. IR2VecTool not initialized.");
-
   FuncEmbMap Result;
 
   for (const Function &F : M.getFunctionDefs()) {
@@ -193,86 +197,47 @@ IR2VecTool::getFunctionEmbeddingsMap(IR2VecKind Kind) const {
 
 Expected<BBEmbeddingsMap>
 IR2VecTool::getBBEmbeddingsMap(const Function &F, IR2VecKind Kind) const {
-  if (!Vocab || !Vocab->isValid())
-    return createStringError(
-        errc::invalid_argument,
-        "Vocabulary is not valid. IR2VecTool not initialized.");
+  auto Emb = getIR2VecEmbedder(F, Kind);
+  if (!Emb)
+    return Emb.takeError();
 
   BBEmbeddingsMap Result;
 
-  if (F.isDeclaration())
-    return createStringError(errc::invalid_argument,
-                             "Function is a declaration.");
-
-  auto Emb = Embedder::create(Kind, F, *Vocab);
-  if (!Emb)
-    return createStringError(errc::invalid_argument,
-                             "Failed to create embedder for function '%s'.",
-                             F.getName().str().c_str());
-
   for (const BasicBlock &BB : F)
-    Result.try_emplace(&BB, Emb->getBBVector(BB));
+    Result.try_emplace(&BB, (*Emb)->getBBVector(BB));
 
   return Result;
 }
 
 Expected<InstEmbeddingsMap>
 IR2VecTool::getInstEmbeddingsMap(const Function &F, IR2VecKind Kind) const {
-  if (!Vocab || !Vocab->isValid())
-    return createStringError(
-        errc::invalid_argument,
-        "Vocabulary is not valid. IR2VecTool not initialized.");
+  auto Emb = getIR2VecEmbedder(F, Kind);
+  if (!Emb)
+    return Emb.takeError();
 
   InstEmbeddingsMap Result;
 
-  if (F.isDeclaration())
-    return createStringError(errc::invalid_argument,
-                             "Function is a declaration.");
-
-  auto Emb = Embedder::create(Kind, F, *Vocab);
-  if (!Emb)
-    return createStringError(errc::invalid_argument,
-                             "Failed to create embedder for function '%s'.",
-                             F.getName().str().c_str());
-
   for (const Instruction &I : instructions(F))
-    Result.try_emplace(&I, Emb->getInstVector(I));
+    Result.try_emplace(&I, (*Emb)->getInstVector(I));
 
   return Result;
 }
 
 void IR2VecTool::writeEmbeddingsToStream(raw_ostream &OS,
                                          EmbeddingLevel Level) const {
-  if (!Vocab || !Vocab->isValid()) {
-    WithColor::error(errs(), ToolName)
-        << "Vocabulary is not valid. IR2VecTool not initialized.\n";
-    return;
-  }
-
   for (const Function &F : M.getFunctionDefs())
     writeEmbeddingsToStream(F, OS, Level);
 }
 
 void IR2VecTool::writeEmbeddingsToStream(const Function &F, raw_ostream &OS,
                                          EmbeddingLevel Level) const {
-  if (!Vocab || !Vocab->isValid()) {
+  auto IR2VecEmbedderObj = getIR2VecEmbedder(F, IR2VecEmbeddingKind);
+  if (!IR2VecEmbedderObj) {
     WithColor::error(errs(), ToolName)
-        << "Vocabulary is not valid. IR2VecTool not initialized.\n";
+        << toString(IR2VecEmbedderObj.takeError()) << "\n";
     return;
   }
-
-  if (F.isDeclaration()) {
-    OS << "Function " << F.getName() << " is a declaration, skipping.\n";
-    return;
-  }
-
-  // Create embedder for this function
-  auto Emb = Embedder::create(IR2VecEmbeddingKind, F, *Vocab);
-  if (!Emb) {
-    WithColor::error(errs(), ToolName)
-        << "Failed to create embedder for function " << F.getName() << "\n";
-    return;
-  }
+  auto Emb = std::move(*IR2VecEmbedderObj);
 
   OS << "Function: " << F.getName() << "\n";
 

--- a/llvm/tools/llvm-ir2vec/lib/Utils.cpp
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.cpp
@@ -153,7 +153,7 @@ void IR2VecTool::writeEntitiesToStream(raw_ostream &OS) {
 }
 
 Expected<std::unique_ptr<Embedder>>
-IR2VecTool::getIR2VecEmbedder(const Function &F, IR2VecKind Kind) const {
+IR2VecTool::createIR2VecEmbedder(const Function &F, IR2VecKind Kind) const {
   if (!Vocab || !Vocab->isValid())
     return createStringError(
         errc::invalid_argument,
@@ -174,7 +174,7 @@ IR2VecTool::getIR2VecEmbedder(const Function &F, IR2VecKind Kind) const {
 
 Expected<Embedding> IR2VecTool::getFunctionEmbedding(const Function &F,
                                                      IR2VecKind Kind) const {
-  auto Emb = getIR2VecEmbedder(F, Kind);
+  auto Emb = createIR2VecEmbedder(F, Kind);
   if (!Emb)
     return Emb.takeError();
 
@@ -197,7 +197,7 @@ IR2VecTool::getFunctionEmbeddingsMap(IR2VecKind Kind) const {
 
 Expected<BBEmbeddingsMap>
 IR2VecTool::getBBEmbeddingsMap(const Function &F, IR2VecKind Kind) const {
-  auto Emb = getIR2VecEmbedder(F, Kind);
+  auto Emb = createIR2VecEmbedder(F, Kind);
   if (!Emb)
     return Emb.takeError();
 
@@ -211,7 +211,7 @@ IR2VecTool::getBBEmbeddingsMap(const Function &F, IR2VecKind Kind) const {
 
 Expected<InstEmbeddingsMap>
 IR2VecTool::getInstEmbeddingsMap(const Function &F, IR2VecKind Kind) const {
-  auto Emb = getIR2VecEmbedder(F, Kind);
+  auto Emb = createIR2VecEmbedder(F, Kind);
   if (!Emb)
     return Emb.takeError();
 
@@ -231,7 +231,7 @@ void IR2VecTool::writeEmbeddingsToStream(raw_ostream &OS,
 
 void IR2VecTool::writeEmbeddingsToStream(const Function &F, raw_ostream &OS,
                                          EmbeddingLevel Level) const {
-  auto IR2VecEmbedderObj = getIR2VecEmbedder(F, IR2VecEmbeddingKind);
+  auto IR2VecEmbedderObj = createIR2VecEmbedder(F, IR2VecEmbeddingKind);
   if (!IR2VecEmbedderObj) {
     WithColor::error(errs(), ToolName)
         << toString(IR2VecEmbedderObj.takeError()) << "\n";

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -74,7 +74,6 @@ struct TripletResult {
 /// Entity mappings: [entity_name]
 using EntityList = std::vector<std::string>;
 using FuncEmbMap = DenseMap<const Function *, ir2vec::Embedding>;
-using FuncInstEmbMap = DenseMap<const Function *, ir2vec::InstEmbeddingsMap>;
 
 namespace ir2vec {
 
@@ -129,14 +128,8 @@ public:
   Expected<BBEmbeddingsMap> getBBEmbeddingsMap(const Function &F,
                                                IR2VecKind Kind) const;
   /// Get embeddings for all instructions in a function
-  Expected<InstEmbeddingsMap> getInstEmbMap(const Function &F,
+  Expected<InstEmbeddingsMap> getInstEmbeddingsMap(const Function &F,
                                             IR2VecKind Kind) const;
-
-  /// Get embeddings for all instructions in the module, organized by function
-  Expected<FuncInstEmbMap> getFuncInstEmbMap(IR2VecKind Kind) const;
-
-  /// Dump entity ID to string mappings
-  static void writeEntitiesToStream(raw_ostream &OS);
 
   /// Generate embeddings for the entire module
   void writeEmbeddingsToStream(raw_ostream &OS, EmbeddingLevel Level) const;

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -129,7 +129,7 @@ public:
                                                IR2VecKind Kind) const;
   /// Get embeddings for all instructions in a function
   Expected<InstEmbeddingsMap> getInstEmbeddingsMap(const Function &F,
-                                            IR2VecKind Kind) const;
+                                                   IR2VecKind Kind) const;
 
   /// Generate embeddings for the entire module
   void writeEmbeddingsToStream(raw_ostream &OS, EmbeddingLevel Level) const;

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -129,7 +129,8 @@ public:
   Expected<BBEmbeddingsMap> getBBEmbeddingsMap(const Function &F,
                                                IR2VecKind Kind) const;
   /// Get embeddings for all instructions in a function
-  Expected<InstEmbeddingsMap> getInstEmbMap(const Function &F, IR2VecKind Kind) const;
+  Expected<InstEmbeddingsMap> getInstEmbMap(const Function &F,
+                                            IR2VecKind Kind) const;
 
   /// Get embeddings for all instructions in the module, organized by function
   Expected<FuncInstEmbMap> getFuncInstEmbMap(IR2VecKind Kind) const;

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -74,6 +74,7 @@ struct TripletResult {
 /// Entity mappings: [entity_name]
 using EntityList = std::vector<std::string>;
 using FuncEmbMap = DenseMap<const Function *, ir2vec::Embedding>;
+using FuncInstEmbMap = DenseMap<const Function *, ir2vec::InstEmbeddingsMap>;
 
 namespace ir2vec {
 
@@ -127,6 +128,14 @@ public:
   /// Get embeddings for all basic blocks in a function
   Expected<BBEmbeddingsMap> getBBEmbeddingsMap(const Function &F,
                                                IR2VecKind Kind) const;
+  /// Get embeddings for all instructions in a function
+  Expected<InstEmbeddingsMap> getInstEmbMap(const Function &F, IR2VecKind Kind) const;
+
+  /// Get embeddings for all instructions in the module, organized by function
+  Expected<FuncInstEmbMap> getFuncInstEmbMap(IR2VecKind Kind) const;
+
+  /// Dump entity ID to string mappings
+  static void writeEntitiesToStream(raw_ostream &OS);
 
   /// Generate embeddings for the entire module
   void writeEmbeddingsToStream(raw_ostream &OS, EmbeddingLevel Level) const;

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -94,6 +94,10 @@ private:
 public:
   explicit IR2VecTool(Module &M) : M(M) {}
 
+  /// Creates the embedding object for downstream embedding streaming
+  Expected<std::unique_ptr<Embedder>> getIR2VecEmbedder(const Function &F,
+                                                        IR2VecKind Kind) const;
+
   /// Initialize the IR2Vec vocabulary from the specified file path.
   Error initializeVocabulary(StringRef VocabPath);
 

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -95,8 +95,8 @@ public:
   explicit IR2VecTool(Module &M) : M(M) {}
 
   /// Creates the embedding object for downstream embedding streaming
-  Expected<std::unique_ptr<Embedder>> getIR2VecEmbedder(const Function &F,
-                                                        IR2VecKind Kind) const;
+  Expected<std::unique_ptr<Embedder>>
+  createIR2VecEmbedder(const Function &F, IR2VecKind Kind) const;
 
   /// Initialize the IR2Vec vocabulary from the specified file path.
   Error initializeVocabulary(StringRef VocabPath);


### PR DESCRIPTION
- Returns a Inst Embedding Map based on the input function name
 `getInstEmbMap(funcName) -> Map<Inst string, Embedding>`

- Refactors IR2VecTool methods to have a separate call to create the embedder object


CC - @svkeerthy , @mtrofin , @boomanaiden154 , @nikic