### PR TITLE
[NFC][TableGen] Adopt CodeGenHelpers in GobalISel emitters

### DIFF
--- a/llvm/include/llvm/TableGen/CodeGenHelpers.h
+++ b/llvm/include/llvm/TableGen/CodeGenHelpers.h
@@ -46,21 +46,46 @@ private:
   bool LateUndef;
 };
 
-// Simple RAII helper for emitting #if guard. It emits:
-// #if <Condition>
-// #endif // <Condition>
-class IfGuardEmitter {
-public:
-  IfGuardEmitter(raw_ostream &OS, StringRef Condition)
+// Base class for RAII helpers for emitting various if guards.
+class IfGuardEmitterBase {
+protected:
+  IfGuardEmitterBase(raw_ostream &OS, StringRef If, StringRef Condition)
       : Condition(Condition.str()), OS(OS) {
-    OS << "#if " << Condition << "\n\n";
+    OS << If << " " << Condition << "\n\n";
   }
 
-  ~IfGuardEmitter() { OS << "\n#endif // " << Condition << "\n\n"; }
+  ~IfGuardEmitterBase() { OS << "\n#endif // " << Condition << "\n\n"; }
 
 private:
   std::string Condition;
   raw_ostream &OS;
+};
+
+// RAII emitter for:
+// #if <Condition>
+// #endif // <Condition>
+class IfGuardEmitter : private IfGuardEmitterBase {
+public:
+  IfGuardEmitter(raw_ostream &OS, StringRef Condition)
+      : IfGuardEmitterBase(OS, "#if", Condition) {}
+};
+
+// RAII emitter for:
+// #ifdef <Condition>
+// #endif // <Condition>
+class IfDefGuardEmitter : private IfGuardEmitterBase {
+public:
+  IfDefGuardEmitter(raw_ostream &OS, StringRef Condition)
+      : IfGuardEmitterBase(OS, "#ifdef", Condition) {}
+};
+
+// RAII emitter for:
+// #ifndef <Condition>
+// #endif // <Condition>
+class IfNDefGuardEmitter : private IfGuardEmitterBase {
+public:
+  IfNDefGuardEmitter(raw_ostream &OS, StringRef Condition)
+      : IfGuardEmitterBase(OS, "#ifndef", Condition) {}
 };
 
 // Simple RAII helper for emitting header include guard (ifndef-define-endif).

--- a/llvm/test/TableGen/GlobalISelEmitter/GlobalISelEmitter.td
+++ b/llvm/test/TableGen/GlobalISelEmitter/GlobalISelEmitter.td
@@ -71,6 +71,7 @@ def HasC : Predicate<"Subtarget->hasC()"> { let RecomputePerFunction = 1; }
 // CHECK: using PredicateBitset = llvm::Bitset<MAX_SUBTARGET_PREDICATES>;
 
 // CHECK-LABEL: #ifdef GET_GLOBALISEL_TEMPORARIES_DECL
+// CHECK-EMPTY:
 // CHECK-NEXT:    mutable MatcherState State;
 // CHECK-NEXT:    typedef ComplexRendererFns(MyTargetInstructionSelector::*ComplexMatcherMemFn)(MachineOperand &) const;
 // CHECK-NEXT:    typedef void(MyTargetInstructionSelector::*CustomRendererFn)(MachineInstrBuilder &, const MachineInstr &, int) const;
@@ -85,12 +86,15 @@ def HasC : Predicate<"Subtarget->hasC()"> { let RecomputePerFunction = 1; }
 // CHECK-NEXT:    bool testMOPredicate_MO(unsigned PredicateID, const MachineOperand &MO, const MatcherState &State) const override;
 // CHECK-NEXT:    bool testSimplePredicate(unsigned PredicateID) const override;
 // CHECK-NEXT:    bool runCustomAction(unsigned FnID, const MatcherState &State, NewMIVector &OutMIs) const override;
-// CHECK-NEXT:  #endif // ifdef GET_GLOBALISEL_TEMPORARIES_DECL
+// CHECK-EMPTY:
+// CHECK-NEXT:  #endif // GET_GLOBALISEL_TEMPORARIES_DECL
 
 // CHECK-LABEL: #ifdef GET_GLOBALISEL_TEMPORARIES_INIT
+// CHECK-EMPTY:
 // CHECK-NEXT:    , State(3),
 // CHECK-NEXT:    ExecInfo(TypeObjects, NumTypeObjects, FeatureBitsets, ComplexPredicateFns, CustomRenderers)
-// CHECK-NEXT:  #endif // ifdef GET_GLOBALISEL_TEMPORARIES_INIT
+// CHECK-EMPTY:
+// CHECK-NEXT:  #endif // GET_GLOBALISEL_TEMPORARIES_INIT
 
 // CHECK-LABEL: // LLT Objects.
 // CHECK-NEXT:  enum {

--- a/llvm/test/TableGen/GlobalISelEmitter/HwModes.td
+++ b/llvm/test/TableGen/GlobalISelEmitter/HwModes.td
@@ -43,6 +43,7 @@ class I<dag OOps, dag IOps, list<dag> Pat>
 // CHECK: using PredicateBitset = llvm::Bitset<MAX_SUBTARGET_PREDICATES>;
 
 // CHECK-LABEL: #ifdef GET_GLOBALISEL_TEMPORARIES_DECL
+// CHECK-EMPTY:
 // CHECK-NEXT:    mutable MatcherState State;
 // CHECK-NEXT:    typedef ComplexRendererFns(MyTargetInstructionSelector::*ComplexMatcherMemFn)(MachineOperand &) const;
 // CHECK-NEXT:    typedef void(MyTargetInstructionSelector::*CustomRendererFn)(MachineInstrBuilder &, const MachineInstr &, int) const;
@@ -57,12 +58,15 @@ class I<dag OOps, dag IOps, list<dag> Pat>
 // CHECK-NEXT:    bool testMOPredicate_MO(unsigned PredicateID, const MachineOperand &MO, const MatcherState &State) const override;
 // CHECK-NEXT:    bool testSimplePredicate(unsigned PredicateID) const override;
 // CHECK-NEXT:    bool runCustomAction(unsigned FnID, const MatcherState &State, NewMIVector &OutMIs) const override;
-// CHECK-NEXT:  #endif // ifdef GET_GLOBALISEL_TEMPORARIES_DECL
+// CHECK-EMPTY:
+// CHECK-NEXT:  #endif // GET_GLOBALISEL_TEMPORARIES_DECL
 
 // CHECK-LABEL: #ifdef GET_GLOBALISEL_TEMPORARIES_INIT
+// CHECK-EMPTY:
 // CHECK-NEXT:    , State(0),
 // CHECK-NEXT:    ExecInfo(TypeObjects, NumTypeObjects, FeatureBitsets, ComplexPredicateFns, CustomRenderers)
-// CHECK-NEXT:  #endif // ifdef GET_GLOBALISEL_TEMPORARIES_INIT
+// CHECK-EMPTY:
+// CHECK-NEXT:  #endif // GET_GLOBALISEL_TEMPORARIES_INIT
 
 // CHECK-LABEL: // LLT Objects.
 // CHECK-NEXT:  enum {


### PR DESCRIPTION
Add specific emitters for `#ifdef` and `#ifndef` based guards and adopt them and other CodeGenHelpers in Global ISel emitters.