### PR TITLE
[OFFLOAD] Fix TARGET_NAME in plugins common code

### DIFF
--- a/offload/plugins-nextgen/common/CMakeLists.txt
+++ b/offload/plugins-nextgen/common/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(PluginCommon PRIVATE llvm-libc-common-utilities)
 
 # Define the TARGET_NAME and DEBUG_PREFIX.
 target_compile_definitions(PluginCommon PRIVATE
-  TARGET_NAME="PluginInterface"
+  TARGET_NAME=PluginInterface
   DEBUG_PREFIX="PluginInterface"
 )
 


### PR DESCRIPTION
Unlike other names is set between quotes which prevents our debug macros to properly match it.