### PR TITLE
[ExpandIRInsts] Freeze input in itofp expansion

### DIFF
--- a/llvm/lib/CodeGen/ExpandIRInsts.cpp
+++ b/llvm/lib/CodeGen/ExpandIRInsts.cpp
@@ -742,6 +742,10 @@ static void expandIToFP(Instruction *IToFP) {
   unsigned FloatWidth = PowerOf2Ceil(FPMantissaWidth);
   bool IsSigned = IToFP->getOpcode() == Instruction::SIToFP;
 
+  // We're going to introduce branches on the value, so freeze it.
+  if (!isGuaranteedNotToBeUndefOrPoison(IntVal))
+    IntVal = Builder.CreateFreeze(IntVal);
+
   // The expansion below assumes that int width >= float width. Zero or sign
   // extend the integer accordingly.
   if (BitWidth < FloatWidth) {

--- a/llvm/test/CodeGen/AMDGPU/itofp.i128.ll
+++ b/llvm/test/CodeGen/AMDGPU/itofp.i128.ll
@@ -417,8 +417,7 @@ define float @uitofp_i128_to_f32(i128 %x) {
 ; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v2
 ; GISEL-NEXT:    v_cndmask_b32_e32 v4, 0, v0, vcc
 ; GISEL-NEXT:    ; implicit-def: $vgpr6
-; GISEL-NEXT:    ; implicit-def: $vgpr0
-; GISEL-NEXT:    ; implicit-def: $vgpr2
+; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
 ; GISEL-NEXT:  ; %bb.3: ; %Flow3
 ; GISEL-NEXT:    s_or_saveexec_b64 s[8:9], s[4:5]
 ; GISEL-NEXT:    v_sub_u32_e32 v7, 0x7f, v5
@@ -978,7 +977,7 @@ define double @uitofp_i128_to_f64(i128 %x) {
 ; GISEL-NEXT:    v_cndmask_b32_e32 v4, 0, v0, vcc
 ; GISEL-NEXT:    v_cndmask_b32_e32 v9, 0, v1, vcc
 ; GISEL-NEXT:    ; implicit-def: $vgpr6
-; GISEL-NEXT:    ; implicit-def: $vgpr0
+; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
 ; GISEL-NEXT:  ; %bb.3: ; %Flow3
 ; GISEL-NEXT:    s_or_saveexec_b64 s[8:9], s[4:5]
 ; GISEL-NEXT:    v_sub_u32_e32 v7, 0x7f, v8
@@ -1509,8 +1508,7 @@ define half @uitofp_i128_to_f16(i128 %x) {
 ; GISEL-NEXT:    v_cmp_gt_u32_e32 vcc, 64, v2
 ; GISEL-NEXT:    v_cndmask_b32_e32 v4, 0, v0, vcc
 ; GISEL-NEXT:    ; implicit-def: $vgpr6
-; GISEL-NEXT:    ; implicit-def: $vgpr0
-; GISEL-NEXT:    ; implicit-def: $vgpr2
+; GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3
 ; GISEL-NEXT:  ; %bb.3: ; %Flow3
 ; GISEL-NEXT:    s_or_saveexec_b64 s[8:9], s[4:5]
 ; GISEL-NEXT:    v_sub_u32_e32 v7, 0x7f, v5

--- a/llvm/test/CodeGen/X86/expand-large-fp-optnone.ll
+++ b/llvm/test/CodeGen/X86/expand-large-fp-optnone.ll
@@ -27,13 +27,13 @@ define double @main(i224 %0) #0 {
 ; CHECK-NEXT:    .cfi_offset %r14, -32
 ; CHECK-NEXT:    .cfi_offset %r15, -24
 ; CHECK-NEXT:    .cfi_offset %rbp, -16
-; CHECK-NEXT:    movq %rdi, %rax
-; CHECK-NEXT:    orq %rdx, %rax
-; CHECK-NEXT:    movl %ecx, %r8d
+; CHECK-NEXT:    movl %ecx, %eax
+; CHECK-NEXT:    movq %rdi, %r8
+; CHECK-NEXT:    orq %rdx, %r8
 ; CHECK-NEXT:    movq %rsi, %r9
-; CHECK-NEXT:    orq %r8, %r9
+; CHECK-NEXT:    orq %rax, %r9
 ; CHECK-NEXT:    xorps %xmm0, %xmm0
-; CHECK-NEXT:    orq %r9, %rax
+; CHECK-NEXT:    orq %r9, %r8
 ; CHECK-NEXT:    je .LBB0_10
 ; CHECK-NEXT:    jmp .LBB0_1
 ; CHECK-NEXT:  .LBB0_1: # %itofp-if-end

--- a/llvm/test/Transforms/ExpandIRInsts/X86/expand-int-convert-small.ll
+++ b/llvm/test/Transforms/ExpandIRInsts/X86/expand-int-convert-small.ll
@@ -7,6 +7,80 @@ define half @uitofp_i32_f16(i32 %x) {
 ; CHECK-LABEL: define half @uitofp_i32_f16(
 ; CHECK-SAME: i32 [[X:%.*]]) {
 ; CHECK-NEXT:  [[ITOFP_ENTRY:.*]]:
+; CHECK-NEXT:    [[TMP8:%.*]] = freeze i32 [[X]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i32 [[TMP8]], 0
+; CHECK-NEXT:    br i1 [[TMP0]], label %[[ITOFP_RETURN:.*]], label %[[ITOFP_IF_END:.*]]
+; CHECK:       [[ITOFP_IF_END]]:
+; CHECK-NEXT:    [[TMP1:%.*]] = ashr i32 [[TMP8]], 31
+; CHECK-NEXT:    [[TMP2:%.*]] = xor i32 [[TMP1]], [[TMP8]]
+; CHECK-NEXT:    [[TMP3:%.*]] = sub i32 [[TMP2]], [[TMP1]]
+; CHECK-NEXT:    [[TMP4:%.*]] = call i32 @llvm.ctlz.i32(i32 [[TMP8]], i1 true)
+; CHECK-NEXT:    [[TMP5:%.*]] = sub i32 32, [[TMP4]]
+; CHECK-NEXT:    [[TMP6:%.*]] = sub i32 31, [[TMP4]]
+; CHECK-NEXT:    [[TMP7:%.*]] = icmp sgt i32 [[TMP5]], 24
+; CHECK-NEXT:    br i1 [[TMP7]], label %[[ITOFP_IF_THEN4:.*]], label %[[ITOFP_IF_ELSE:.*]]
+; CHECK:       [[ITOFP_IF_THEN4]]:
+; CHECK-NEXT:    switch i32 [[TMP5]], label %[[ITOFP_SW_DEFAULT:.*]] [
+; CHECK-NEXT:      i32 25, label %[[ITOFP_SW_BB:.*]]
+; CHECK-NEXT:      i32 26, label %[[ITOFP_SW_EPILOG:.*]]
+; CHECK-NEXT:    ]
+; CHECK:       [[ITOFP_SW_BB]]:
+; CHECK-NEXT:    [[TMP41:%.*]] = shl i32 [[TMP8]], 1
+; CHECK-NEXT:    br label %[[ITOFP_SW_EPILOG]]
+; CHECK:       [[ITOFP_SW_DEFAULT]]:
+; CHECK-NEXT:    [[TMP9:%.*]] = sub i32 6, [[TMP4]]
+; CHECK-NEXT:    [[TMP10:%.*]] = lshr i32 [[TMP8]], [[TMP9]]
+; CHECK-NEXT:    [[TMP11:%.*]] = add i32 [[TMP4]], 26
+; CHECK-NEXT:    [[TMP12:%.*]] = lshr i32 -1, [[TMP11]]
+; CHECK-NEXT:    [[TMP13:%.*]] = and i32 [[TMP12]], [[TMP8]]
+; CHECK-NEXT:    [[TMP14:%.*]] = icmp ne i32 [[TMP13]], 0
+; CHECK-NEXT:    [[TMP15:%.*]] = zext i1 [[TMP14]] to i32
+; CHECK-NEXT:    [[TMP16:%.*]] = or i32 [[TMP10]], [[TMP15]]
+; CHECK-NEXT:    br label %[[ITOFP_SW_EPILOG]]
+; CHECK:       [[ITOFP_SW_EPILOG]]:
+; CHECK-NEXT:    [[TMP17:%.*]] = phi i32 [ [[TMP16]], %[[ITOFP_SW_DEFAULT]] ], [ [[TMP8]], %[[ITOFP_IF_THEN4]] ], [ [[TMP41]], %[[ITOFP_SW_BB]] ]
+; CHECK-NEXT:    [[TMP18:%.*]] = lshr i32 [[TMP17]], 2
+; CHECK-NEXT:    [[TMP19:%.*]] = and i32 [[TMP18]], 1
+; CHECK-NEXT:    [[TMP20:%.*]] = or i32 [[TMP17]], [[TMP19]]
+; CHECK-NEXT:    [[TMP21:%.*]] = add i32 [[TMP20]], 1
+; CHECK-NEXT:    [[TMP22:%.*]] = lshr i32 [[TMP21]], 2
+; CHECK-NEXT:    [[A3:%.*]] = and i32 [[TMP21]], 67108864
+; CHECK-NEXT:    [[TMP23:%.*]] = icmp eq i32 [[A3]], 0
+; CHECK-NEXT:    [[TMP24:%.*]] = lshr i32 [[TMP22]], 32
+; CHECK-NEXT:    br i1 [[TMP23]], label %[[ITOFP_IF_END26:.*]], label %[[ITOFP_IF_THEN20:.*]]
+; CHECK:       [[ITOFP_IF_THEN20]]:
+; CHECK-NEXT:    [[TMP25:%.*]] = lshr i32 [[TMP21]], 3
+; CHECK-NEXT:    [[TMP26:%.*]] = lshr i32 [[TMP25]], 32
+; CHECK-NEXT:    br label %[[ITOFP_IF_END26]]
+; CHECK:       [[ITOFP_IF_ELSE]]:
+; CHECK-NEXT:    [[TMP27:%.*]] = add i32 [[TMP4]], -8
+; CHECK-NEXT:    [[TMP28:%.*]] = shl i32 [[TMP8]], [[TMP27]]
+; CHECK-NEXT:    [[TMP29:%.*]] = lshr i32 [[TMP28]], 32
+; CHECK-NEXT:    br label %[[ITOFP_IF_END26]]
+; CHECK:       [[ITOFP_IF_END26]]:
+; CHECK-NEXT:    [[TMP30:%.*]] = phi i32 [ [[TMP25]], %[[ITOFP_IF_THEN20]] ], [ [[TMP22]], %[[ITOFP_SW_EPILOG]] ], [ [[TMP28]], %[[ITOFP_IF_ELSE]] ]
+; CHECK-NEXT:    [[TMP31:%.*]] = phi i32 [ [[TMP5]], %[[ITOFP_IF_THEN20]] ], [ [[TMP6]], %[[ITOFP_SW_EPILOG]] ], [ [[TMP6]], %[[ITOFP_IF_ELSE]] ]
+; CHECK-NEXT:    [[TMP32:%.*]] = and i32 [[TMP1]], -2147483648
+; CHECK-NEXT:    [[TMP33:%.*]] = shl i32 [[TMP31]], 23
+; CHECK-NEXT:    [[TMP34:%.*]] = add i32 [[TMP33]], 1065353216
+; CHECK-NEXT:    [[TMP35:%.*]] = and i32 [[TMP30]], 8388607
+; CHECK-NEXT:    [[TMP36:%.*]] = or i32 [[TMP35]], [[TMP32]]
+; CHECK-NEXT:    [[TMP37:%.*]] = or i32 [[TMP35]], [[TMP34]]
+; CHECK-NEXT:    [[TMP38:%.*]] = bitcast i32 [[TMP37]] to float
+; CHECK-NEXT:    [[TMP39:%.*]] = fptrunc float [[TMP38]] to half
+; CHECK-NEXT:    br label %[[ITOFP_RETURN]]
+; CHECK:       [[ITOFP_RETURN]]:
+; CHECK-NEXT:    [[TMP40:%.*]] = phi half [ [[TMP39]], %[[ITOFP_IF_END26]] ], [ 0xH0000, %[[ITOFP_ENTRY]] ]
+; CHECK-NEXT:    ret half [[TMP40]]
+;
+  %res = uitofp i32 %x to half
+  ret half %res
+}
+
+define half @uitofp_i32_f16_noundef(i32 noundef %x) {
+; CHECK-LABEL: define half @uitofp_i32_f16_noundef(
+; CHECK-SAME: i32 noundef [[X:%.*]]) {
+; CHECK-NEXT:  [[ITOFP_ENTRY:.*]]:
 ; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i32 [[X]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label %[[ITOFP_RETURN:.*]], label %[[ITOFP_IF_END:.*]]
 ; CHECK:       [[ITOFP_IF_END]]:
@@ -80,7 +154,8 @@ define half @uitofp_i16_f16(i16 %x) {
 ; CHECK-LABEL: define half @uitofp_i16_f16(
 ; CHECK-SAME: i16 [[X:%.*]]) {
 ; CHECK-NEXT:  [[ITOFP_ENTRY:.*]]:
-; CHECK-NEXT:    [[TMP0:%.*]] = zext i16 [[X]] to i32
+; CHECK-NEXT:    [[TMP42:%.*]] = freeze i16 [[X]]
+; CHECK-NEXT:    [[TMP0:%.*]] = zext i16 [[TMP42]] to i32
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i32 [[TMP0]], 0
 ; CHECK-NEXT:    br i1 [[TMP1]], label %[[ITOFP_RETURN:.*]], label %[[ITOFP_IF_END:.*]]
 ; CHECK:       [[ITOFP_IF_END]]:
@@ -154,11 +229,12 @@ define half @sitofp_i32_f16(i32 %x) {
 ; CHECK-LABEL: define half @sitofp_i32_f16(
 ; CHECK-SAME: i32 [[X:%.*]]) {
 ; CHECK-NEXT:  [[ITOFP_ENTRY:.*]]:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i32 [[X]], 0
+; CHECK-NEXT:    [[TMP41:%.*]] = freeze i32 [[X]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i32 [[TMP41]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label %[[ITOFP_RETURN:.*]], label %[[ITOFP_IF_END:.*]]
 ; CHECK:       [[ITOFP_IF_END]]:
-; CHECK-NEXT:    [[TMP1:%.*]] = ashr i32 [[X]], 31
-; CHECK-NEXT:    [[TMP2:%.*]] = xor i32 [[TMP1]], [[X]]
+; CHECK-NEXT:    [[TMP1:%.*]] = ashr i32 [[TMP41]], 31
+; CHECK-NEXT:    [[TMP2:%.*]] = xor i32 [[TMP1]], [[TMP41]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = sub i32 [[TMP2]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = call i32 @llvm.ctlz.i32(i32 [[TMP3]], i1 true)
 ; CHECK-NEXT:    [[TMP5:%.*]] = sub i32 32, [[TMP4]]
@@ -227,7 +303,8 @@ define half @sitofp_i16_f16(i16 %x) {
 ; CHECK-LABEL: define half @sitofp_i16_f16(
 ; CHECK-SAME: i16 [[X:%.*]]) {
 ; CHECK-NEXT:  [[ITOFP_ENTRY:.*]]:
-; CHECK-NEXT:    [[TMP1:%.*]] = sext i16 [[X]] to i32
+; CHECK-NEXT:    [[TMP42:%.*]] = freeze i16 [[X]]
+; CHECK-NEXT:    [[TMP1:%.*]] = sext i16 [[TMP42]] to i32
 ; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i32 [[TMP1]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label %[[ITOFP_RETURN:.*]], label %[[ITOFP_IF_END:.*]]
 ; CHECK:       [[ITOFP_IF_END]]:

--- a/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-convert-si129tofp.ll
+++ b/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-convert-si129tofp.ll
@@ -5,7 +5,8 @@
 define half @si129tohalf(i129 %a) {
 ; CHECK-LABEL: @si129tohalf(
 ; CHECK-NEXT:  itofp-entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A:%.*]], 0
+; CHECK-NEXT:    [[A:%.*]] = freeze i129 [[A1:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
 ; CHECK-NEXT:    [[TMP1:%.*]] = ashr i129 [[A]], 128
@@ -90,7 +91,8 @@ define half @si129tohalf(i129 %a) {
 define float @si129tofloat(i129 %a) {
 ; CHECK-LABEL: @si129tofloat(
 ; CHECK-NEXT:  itofp-entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A:%.*]], 0
+; CHECK-NEXT:    [[A:%.*]] = freeze i129 [[A1:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
 ; CHECK-NEXT:    [[TMP1:%.*]] = ashr i129 [[A]], 128
@@ -174,7 +176,8 @@ define float @si129tofloat(i129 %a) {
 define double @si129todouble(i129 %a) {
 ; CHECK-LABEL: @si129todouble(
 ; CHECK-NEXT:  itofp-entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A:%.*]], 0
+; CHECK-NEXT:    [[A:%.*]] = freeze i129 [[A1:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
 ; CHECK-NEXT:    [[TMP1:%.*]] = ashr i129 [[A]], 128
@@ -263,7 +266,8 @@ define double @si129todouble(i129 %a) {
 define x86_fp80 @si129tox86_fp80(i129 %a) {
 ; CHECK-LABEL: @si129tox86_fp80(
 ; CHECK-NEXT:  itofp-entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A:%.*]], 0
+; CHECK-NEXT:    [[A:%.*]] = freeze i129 [[A1:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
 ; CHECK-NEXT:    [[TMP1:%.*]] = ashr i129 [[A]], 128
@@ -347,7 +351,8 @@ define x86_fp80 @si129tox86_fp80(i129 %a) {
 define fp128 @si129tofp128(i129 %a) {
 ; CHECK-LABEL: @si129tofp128(
 ; CHECK-NEXT:  itofp-entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A:%.*]], 0
+; CHECK-NEXT:    [[A:%.*]] = freeze i129 [[A1:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
 ; CHECK-NEXT:    [[TMP1:%.*]] = ashr i129 [[A]], 128
@@ -431,11 +436,12 @@ define <2 x float> @si129tofloatv2(<2 x i129> %a) {
 ; CHECK-LABEL: @si129tofloatv2(
 ; CHECK-NEXT:  itofp-entryitofp-entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = extractelement <2 x i129> [[A:%.*]], i64 0
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i129 [[TMP0]], 0
+; CHECK-NEXT:    [[TMP110:%.*]] = freeze i129 [[TMP0]]
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i129 [[TMP110]], 0
 ; CHECK-NEXT:    br i1 [[TMP1]], label [[ITOFP_RETURN1:%.*]], label [[ITOFP_IF_END2:%.*]]
 ; CHECK:       itofp-if-end2:
-; CHECK-NEXT:    [[TMP2:%.*]] = ashr i129 [[TMP0]], 128
-; CHECK-NEXT:    [[TMP3:%.*]] = xor i129 [[TMP2]], [[TMP0]]
+; CHECK-NEXT:    [[TMP2:%.*]] = ashr i129 [[TMP110]], 128
+; CHECK-NEXT:    [[TMP3:%.*]] = xor i129 [[TMP2]], [[TMP110]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = sub i129 [[TMP3]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP5:%.*]] = call i129 @llvm.ctlz.i129(i129 [[TMP4]], i1 true)
 ; CHECK-NEXT:    [[TMP6:%.*]] = trunc i129 [[TMP5]] to i32
@@ -508,11 +514,12 @@ define <2 x float> @si129tofloatv2(<2 x i129> %a) {
 ; CHECK-NEXT:    [[TMP53:%.*]] = phi float [ [[TMP52]], [[ITOFP_IF_END269]] ], [ 0.000000e+00, [[ITOFP_ENTRYITOFP_ENTRY:%.*]] ]
 ; CHECK-NEXT:    [[TMP54:%.*]] = insertelement <2 x float> poison, float [[TMP53]], i64 0
 ; CHECK-NEXT:    [[TMP55:%.*]] = extractelement <2 x i129> [[A]], i64 1
-; CHECK-NEXT:    [[TMP56:%.*]] = icmp eq i129 [[TMP55]], 0
+; CHECK-NEXT:    [[TMP111:%.*]] = freeze i129 [[TMP55]]
+; CHECK-NEXT:    [[TMP56:%.*]] = icmp eq i129 [[TMP111]], 0
 ; CHECK-NEXT:    br i1 [[TMP56]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
-; CHECK-NEXT:    [[TMP57:%.*]] = ashr i129 [[TMP55]], 128
-; CHECK-NEXT:    [[TMP58:%.*]] = xor i129 [[TMP57]], [[TMP55]]
+; CHECK-NEXT:    [[TMP57:%.*]] = ashr i129 [[TMP111]], 128
+; CHECK-NEXT:    [[TMP58:%.*]] = xor i129 [[TMP57]], [[TMP111]]
 ; CHECK-NEXT:    [[TMP59:%.*]] = sub i129 [[TMP58]], [[TMP57]]
 ; CHECK-NEXT:    [[TMP60:%.*]] = call i129 @llvm.ctlz.i129(i129 [[TMP59]], i1 true)
 ; CHECK-NEXT:    [[TMP61:%.*]] = trunc i129 [[TMP60]] to i32

--- a/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-convert-ui129tofp.ll
+++ b/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-convert-ui129tofp.ll
@@ -5,7 +5,8 @@
 define half @ui129tohalf(i129 %a) {
 ; CHECK-LABEL: @ui129tohalf(
 ; CHECK-NEXT:  itofp-entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A:%.*]], 0
+; CHECK-NEXT:    [[A:%.*]] = freeze i129 [[A1:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
 ; CHECK-NEXT:    [[TMP1:%.*]] = ashr i129 [[A]], 128
@@ -90,7 +91,8 @@ define half @ui129tohalf(i129 %a) {
 define float @ui129tofloat(i129 %a) {
 ; CHECK-LABEL: @ui129tofloat(
 ; CHECK-NEXT:  itofp-entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A:%.*]], 0
+; CHECK-NEXT:    [[A:%.*]] = freeze i129 [[A1:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
 ; CHECK-NEXT:    [[TMP1:%.*]] = ashr i129 [[A]], 128
@@ -174,7 +176,8 @@ define float @ui129tofloat(i129 %a) {
 define double @ui129todouble(i129 %a) {
 ; CHECK-LABEL: @ui129todouble(
 ; CHECK-NEXT:  itofp-entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A:%.*]], 0
+; CHECK-NEXT:    [[A:%.*]] = freeze i129 [[A1:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
 ; CHECK-NEXT:    [[TMP1:%.*]] = ashr i129 [[A]], 128
@@ -263,7 +266,8 @@ define double @ui129todouble(i129 %a) {
 define x86_fp80 @ui129tox86_fp80(i129 %a) {
 ; CHECK-LABEL: @ui129tox86_fp80(
 ; CHECK-NEXT:  itofp-entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A:%.*]], 0
+; CHECK-NEXT:    [[A:%.*]] = freeze i129 [[A1:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
 ; CHECK-NEXT:    [[TMP1:%.*]] = ashr i129 [[A]], 128
@@ -347,7 +351,8 @@ define x86_fp80 @ui129tox86_fp80(i129 %a) {
 define fp128 @ui129tofp128(i129 %a) {
 ; CHECK-LABEL: @ui129tofp128(
 ; CHECK-NEXT:  itofp-entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A:%.*]], 0
+; CHECK-NEXT:    [[A:%.*]] = freeze i129 [[A1:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp eq i129 [[A]], 0
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
 ; CHECK-NEXT:    [[TMP1:%.*]] = ashr i129 [[A]], 128
@@ -431,13 +436,14 @@ define <2 x float> @ui129tofloatv2(<2 x i129> %a) {
 ; CHECK-LABEL: @ui129tofloatv2(
 ; CHECK-NEXT:  itofp-entryitofp-entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = extractelement <2 x i129> [[A:%.*]], i64 0
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i129 [[TMP0]], 0
+; CHECK-NEXT:    [[TMP10:%.*]] = freeze i129 [[TMP0]]
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i129 [[TMP10]], 0
 ; CHECK-NEXT:    br i1 [[TMP1]], label [[ITOFP_RETURN1:%.*]], label [[ITOFP_IF_END2:%.*]]
 ; CHECK:       itofp-if-end2:
-; CHECK-NEXT:    [[TMP2:%.*]] = ashr i129 [[TMP0]], 128
-; CHECK-NEXT:    [[TMP3:%.*]] = xor i129 [[TMP2]], [[TMP0]]
+; CHECK-NEXT:    [[TMP2:%.*]] = ashr i129 [[TMP10]], 128
+; CHECK-NEXT:    [[TMP3:%.*]] = xor i129 [[TMP2]], [[TMP10]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = sub i129 [[TMP3]], [[TMP2]]
-; CHECK-NEXT:    [[TMP5:%.*]] = call i129 @llvm.ctlz.i129(i129 [[TMP0]], i1 true)
+; CHECK-NEXT:    [[TMP5:%.*]] = call i129 @llvm.ctlz.i129(i129 [[TMP10]], i1 true)
 ; CHECK-NEXT:    [[TMP6:%.*]] = trunc i129 [[TMP5]] to i32
 ; CHECK-NEXT:    [[TMP7:%.*]] = sub i32 129, [[TMP6]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = sub i32 128, [[TMP6]]
@@ -449,22 +455,22 @@ define <2 x float> @ui129tofloatv2(<2 x i129> %a) {
 ; CHECK-NEXT:      i32 26, label [[ITOFP_SW_EPILOG6:%.*]]
 ; CHECK-NEXT:    ]
 ; CHECK:       itofp-sw-bb4:
-; CHECK-NEXT:    [[TMP10:%.*]] = shl i129 [[TMP0]], 1
+; CHECK-NEXT:    [[TMP65:%.*]] = shl i129 [[TMP10]], 1
 ; CHECK-NEXT:    br label [[ITOFP_SW_EPILOG6]]
 ; CHECK:       itofp-sw-default5:
 ; CHECK-NEXT:    [[TMP11:%.*]] = sub i32 103, [[TMP6]]
 ; CHECK-NEXT:    [[TMP12:%.*]] = zext i32 [[TMP11]] to i129
-; CHECK-NEXT:    [[TMP13:%.*]] = lshr i129 [[TMP0]], [[TMP12]]
+; CHECK-NEXT:    [[TMP13:%.*]] = lshr i129 [[TMP10]], [[TMP12]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = add i32 [[TMP6]], 26
 ; CHECK-NEXT:    [[TMP15:%.*]] = zext i32 [[TMP14]] to i129
 ; CHECK-NEXT:    [[TMP16:%.*]] = lshr i129 -1, [[TMP15]]
-; CHECK-NEXT:    [[TMP17:%.*]] = and i129 [[TMP16]], [[TMP0]]
+; CHECK-NEXT:    [[TMP17:%.*]] = and i129 [[TMP16]], [[TMP10]]
 ; CHECK-NEXT:    [[TMP18:%.*]] = icmp ne i129 [[TMP17]], 0
 ; CHECK-NEXT:    [[TMP19:%.*]] = zext i1 [[TMP18]] to i129
 ; CHECK-NEXT:    [[TMP20:%.*]] = or i129 [[TMP13]], [[TMP19]]
 ; CHECK-NEXT:    br label [[ITOFP_SW_EPILOG6]]
 ; CHECK:       itofp-sw-epilog6:
-; CHECK-NEXT:    [[TMP21:%.*]] = phi i129 [ [[TMP20]], [[ITOFP_SW_DEFAULT5]] ], [ [[TMP0]], [[ITOFP_IF_THEN43]] ], [ [[TMP10]], [[ITOFP_SW_BB4]] ]
+; CHECK-NEXT:    [[TMP21:%.*]] = phi i129 [ [[TMP20]], [[ITOFP_SW_DEFAULT5]] ], [ [[TMP10]], [[ITOFP_IF_THEN43]] ], [ [[TMP65]], [[ITOFP_SW_BB4]] ]
 ; CHECK-NEXT:    [[TMP22:%.*]] = trunc i129 [[TMP21]] to i32
 ; CHECK-NEXT:    [[TMP23:%.*]] = lshr i32 [[TMP22]], 2
 ; CHECK-NEXT:    [[TMP24:%.*]] = and i32 [[TMP23]], 1
@@ -487,7 +493,7 @@ define <2 x float> @ui129tofloatv2(<2 x i129> %a) {
 ; CHECK:       itofp-if-else8:
 ; CHECK-NEXT:    [[TMP37:%.*]] = add i32 [[TMP6]], -105
 ; CHECK-NEXT:    [[TMP38:%.*]] = zext i32 [[TMP37]] to i129
-; CHECK-NEXT:    [[TMP39:%.*]] = shl i129 [[TMP0]], [[TMP38]]
+; CHECK-NEXT:    [[TMP39:%.*]] = shl i129 [[TMP10]], [[TMP38]]
 ; CHECK-NEXT:    [[TMP40:%.*]] = trunc i129 [[TMP39]] to i32
 ; CHECK-NEXT:    [[TMP41:%.*]] = lshr i129 [[TMP39]], 32
 ; CHECK-NEXT:    [[TMP42:%.*]] = trunc i129 [[TMP41]] to i32
@@ -508,13 +514,14 @@ define <2 x float> @ui129tofloatv2(<2 x i129> %a) {
 ; CHECK-NEXT:    [[TMP53:%.*]] = phi float [ [[TMP52]], [[ITOFP_IF_END269]] ], [ 0.000000e+00, [[ITOFP_ENTRYITOFP_ENTRY:%.*]] ]
 ; CHECK-NEXT:    [[TMP54:%.*]] = insertelement <2 x float> poison, float [[TMP53]], i64 0
 ; CHECK-NEXT:    [[TMP55:%.*]] = extractelement <2 x i129> [[A]], i64 1
-; CHECK-NEXT:    [[TMP56:%.*]] = icmp eq i129 [[TMP55]], 0
+; CHECK-NEXT:    [[TMP110:%.*]] = freeze i129 [[TMP55]]
+; CHECK-NEXT:    [[TMP56:%.*]] = icmp eq i129 [[TMP110]], 0
 ; CHECK-NEXT:    br i1 [[TMP56]], label [[ITOFP_RETURN:%.*]], label [[ITOFP_IF_END:%.*]]
 ; CHECK:       itofp-if-end:
-; CHECK-NEXT:    [[TMP57:%.*]] = ashr i129 [[TMP55]], 128
-; CHECK-NEXT:    [[TMP58:%.*]] = xor i129 [[TMP57]], [[TMP55]]
+; CHECK-NEXT:    [[TMP57:%.*]] = ashr i129 [[TMP110]], 128
+; CHECK-NEXT:    [[TMP58:%.*]] = xor i129 [[TMP57]], [[TMP110]]
 ; CHECK-NEXT:    [[TMP59:%.*]] = sub i129 [[TMP58]], [[TMP57]]
-; CHECK-NEXT:    [[TMP60:%.*]] = call i129 @llvm.ctlz.i129(i129 [[TMP55]], i1 true)
+; CHECK-NEXT:    [[TMP60:%.*]] = call i129 @llvm.ctlz.i129(i129 [[TMP110]], i1 true)
 ; CHECK-NEXT:    [[TMP61:%.*]] = trunc i129 [[TMP60]] to i32
 ; CHECK-NEXT:    [[TMP62:%.*]] = sub i32 129, [[TMP61]]
 ; CHECK-NEXT:    [[TMP63:%.*]] = sub i32 128, [[TMP61]]
@@ -526,22 +533,22 @@ define <2 x float> @ui129tofloatv2(<2 x i129> %a) {
 ; CHECK-NEXT:      i32 26, label [[ITOFP_SW_EPILOG:%.*]]
 ; CHECK-NEXT:    ]
 ; CHECK:       itofp-sw-bb:
-; CHECK-NEXT:    [[TMP65:%.*]] = shl i129 [[TMP55]], 1
+; CHECK-NEXT:    [[TMP111:%.*]] = shl i129 [[TMP110]], 1
 ; CHECK-NEXT:    br label [[ITOFP_SW_EPILOG]]
 ; CHECK:       itofp-sw-default:
 ; CHECK-NEXT:    [[TMP66:%.*]] = sub i32 103, [[TMP61]]
 ; CHECK-NEXT:    [[TMP67:%.*]] = zext i32 [[TMP66]] to i129
-; CHECK-NEXT:    [[TMP68:%.*]] = lshr i129 [[TMP55]], [[TMP67]]
+; CHECK-NEXT:    [[TMP68:%.*]] = lshr i129 [[TMP110]], [[TMP67]]
 ; CHECK-NEXT:    [[TMP69:%.*]] = add i32 [[TMP61]], 26
 ; CHECK-NEXT:    [[TMP70:%.*]] = zext i32 [[TMP69]] to i129
 ; CHECK-NEXT:    [[TMP71:%.*]] = lshr i129 -1, [[TMP70]]
-; CHECK-NEXT:    [[TMP72:%.*]] = and i129 [[TMP71]], [[TMP55]]
+; CHECK-NEXT:    [[TMP72:%.*]] = and i129 [[TMP71]], [[TMP110]]
 ; CHECK-NEXT:    [[TMP73:%.*]] = icmp ne i129 [[TMP72]], 0
 ; CHECK-NEXT:    [[TMP74:%.*]] = zext i1 [[TMP73]] to i129
 ; CHECK-NEXT:    [[TMP75:%.*]] = or i129 [[TMP68]], [[TMP74]]
 ; CHECK-NEXT:    br label [[ITOFP_SW_EPILOG]]
 ; CHECK:       itofp-sw-epilog:
-; CHECK-NEXT:    [[TMP76:%.*]] = phi i129 [ [[TMP75]], [[ITOFP_SW_DEFAULT]] ], [ [[TMP55]], [[ITOFP_IF_THEN4]] ], [ [[TMP65]], [[ITOFP_SW_BB]] ]
+; CHECK-NEXT:    [[TMP76:%.*]] = phi i129 [ [[TMP75]], [[ITOFP_SW_DEFAULT]] ], [ [[TMP110]], [[ITOFP_IF_THEN4]] ], [ [[TMP111]], [[ITOFP_SW_BB]] ]
 ; CHECK-NEXT:    [[TMP77:%.*]] = trunc i129 [[TMP76]] to i32
 ; CHECK-NEXT:    [[TMP78:%.*]] = lshr i32 [[TMP77]], 2
 ; CHECK-NEXT:    [[TMP79:%.*]] = and i32 [[TMP78]], 1
@@ -564,7 +571,7 @@ define <2 x float> @ui129tofloatv2(<2 x i129> %a) {
 ; CHECK:       itofp-if-else:
 ; CHECK-NEXT:    [[TMP92:%.*]] = add i32 [[TMP61]], -105
 ; CHECK-NEXT:    [[TMP93:%.*]] = zext i32 [[TMP92]] to i129
-; CHECK-NEXT:    [[TMP94:%.*]] = shl i129 [[TMP55]], [[TMP93]]
+; CHECK-NEXT:    [[TMP94:%.*]] = shl i129 [[TMP110]], [[TMP93]]
 ; CHECK-NEXT:    [[TMP95:%.*]] = trunc i129 [[TMP94]] to i32
 ; CHECK-NEXT:    [[TMP96:%.*]] = lshr i129 [[TMP94]], 32
 ; CHECK-NEXT:    [[TMP97:%.*]] = trunc i129 [[TMP96]] to i32

--- a/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-optnone.ll
+++ b/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-optnone.ll
@@ -9,11 +9,12 @@ define double @main(i224 %0) #0 {
 ; CHECK-LABEL: define double @main(
 ; CHECK-SAME: i224 [[TMP0:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  [[ENTRYITOFP_ENTRY:.*]]:
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i224 [[TMP0]], 0
+; CHECK-NEXT:    [[TMP59:%.*]] = freeze i224 [[TMP0]]
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i224 [[TMP59]], 0
 ; CHECK-NEXT:    br i1 [[TMP1]], label %[[ITOFP_RETURN:.*]], label %[[ITOFP_IF_END:.*]]
 ; CHECK:       [[ITOFP_IF_END]]:
-; CHECK-NEXT:    [[TMP2:%.*]] = ashr i224 [[TMP0]], 223
-; CHECK-NEXT:    [[TMP3:%.*]] = xor i224 [[TMP2]], [[TMP0]]
+; CHECK-NEXT:    [[TMP2:%.*]] = ashr i224 [[TMP59]], 223
+; CHECK-NEXT:    [[TMP3:%.*]] = xor i224 [[TMP2]], [[TMP59]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = sub i224 [[TMP3]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP5:%.*]] = call i224 @llvm.ctlz.i224(i224 [[TMP4]], i1 true)
 ; CHECK-NEXT:    [[TMP6:%.*]] = trunc i224 [[TMP5]] to i32


### PR DESCRIPTION
We are introducing branches on the value, and branch on undef/poison is UB, so the value needs to be frozen.