### PR TITLE
[mlir][Rewrite] Add match failure/success diagnostics to `PatternApplicator`

### DIFF
--- a/mlir/include/mlir/Rewrite/PatternApplicator.h
+++ b/mlir/include/mlir/Rewrite/PatternApplicator.h
@@ -96,6 +96,9 @@ private:
   std::unique_ptr<detail::PDLByteCodeMutableState> mutableByteCodeState;
 };
 
+/// Register command-line options for the pattern applicator.
+void registerPatternApplicatorCLOptions();
+
 } // namespace mlir
 
 #endif // MLIR_REWRITE_PATTERNAPPLICATOR_H

--- a/mlir/lib/Tools/mlir-opt/CMakeLists.txt
+++ b/mlir/lib/Tools/mlir-opt/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_library(MLIROptLib
   MLIRPass
   MLIRParser
   MLIRPluginsLib
+  MLIRRewrite
   MLIRSupport
   MLIRIRDL
   MLIRRemarkStreamer

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -28,6 +28,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Remark/RemarkStreamer.h"
+#include "mlir/Rewrite/PatternApplicator.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/Timing.h"
 #include "mlir/Support/ToolUtilities.h"
@@ -688,6 +689,7 @@ std::string mlir::registerCLIOptions(llvm::StringRef toolName,
   registerMLIRContextCLOptions();
   registerPassManagerCLOptions();
   registerDefaultTimingManagerCLOptions();
+  registerPatternApplicatorCLOptions();
   tracing::DebugCounter::registerCLOptions();
 
   // Build the list of dialects as a header for the --help message.

--- a/mlir/test/Rewrite/test-pattern-applicator-diagnostics.mlir
+++ b/mlir/test/Rewrite/test-pattern-applicator-diagnostics.mlir
@@ -1,0 +1,10 @@
+// RUN: mlir-opt %s -canonicalize -mlir-emit-pattern-match-diagnostics="match-success" -verify-diagnostics
+
+func.func @tensor_empty_canonicalization() -> tensor<?xf32> {
+  %c4 = arith.constant 4 : index
+  // Do not match "(anonymous namespace)::", as it may render differently
+  // depending on the C++ compiler.
+  // expected-remark-re @+1 {{pattern match success: {{.*}}ReplaceEmptyTensorStaticShapeDims}}
+  %r = tensor.empty(%c4) : tensor<?xf32>
+  return %r : tensor<?xf32>
+}


### PR DESCRIPTION
It is a best practice to write "negative" test cases to check that a (canonicalization) does not accidentally apply to IR where it should not match. To that end, users have to FileCheck for the original IR to make sure that no pattern was applied.

This commit adds a new testing flag to `mlir-opt`: `-mlir-emit-pattern-match-diagnostics="match-success"` emits a diagnostic remark for every successful pattern application. Together with `-verify-diagnostics`, this flag can be used to ensure that no pattern was applied to a certain piece of IR.

Note: This flag was motivated by a test case pattern that I found in a downstream project:
```
// RUN: mlir-opt -split-input-file %s -canonicalize -debug 2>&1 | FileCheck %s
// CHECK: Trying to match "(pattern name)"
// CHECK-NEXT: matchAndRewrite failed
```
