### PR TITLE
[NFC][analyzer] Remove IndirectGotoNodeBuilder::iterator

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -402,48 +402,25 @@ public:
 };
 
 class IndirectGotoNodeBuilder {
-  CoreEngine& Eng;
+  const CoreEngine &Eng;
   const CFGBlock *Src;
   const CFGBlock &DispatchBlock;
   const Expr *E;
   ExplodedNode *Pred;
 
 public:
-  IndirectGotoNodeBuilder(ExplodedNode *pred, const CFGBlock *src,
-                    const Expr *e, const CFGBlock *dispatch, CoreEngine* eng)
-      : Eng(*eng), Src(src), DispatchBlock(*dispatch), E(e), Pred(pred) {}
+  IndirectGotoNodeBuilder(ExplodedNode *Pred, const CFGBlock *Src,
+                          const Expr *E, const CFGBlock *Dispatch,
+                          const CoreEngine *Eng)
+      : Eng(*Eng), Src(Src), DispatchBlock(*Dispatch), E(E), Pred(Pred) {}
 
-  class iterator {
-    friend class IndirectGotoNodeBuilder;
+  using iterator = CFGBlock::const_succ_iterator;
 
-    CFGBlock::const_succ_iterator I;
+  iterator begin() { return DispatchBlock.succ_begin(); }
+  iterator end() { return DispatchBlock.succ_end(); }
 
-    iterator(CFGBlock::const_succ_iterator i) : I(i) {}
-
-  public:
-    // This isn't really a conventional iterator.
-    // We just implement the deref as a no-op for now to make range-based for
-    // loops work.
-    const iterator &operator*() const { return *this; }
-
-    iterator &operator++() { ++I; return *this; }
-    bool operator!=(const iterator &X) const { return I != X.I; }
-
-    const LabelDecl *getLabel() const {
-      return cast<LabelStmt>((*I)->getLabel())->getDecl();
-    }
-
-    const CFGBlock *getBlock() const {
-      return *I;
-    }
-  };
-
-  iterator begin() { return iterator(DispatchBlock.succ_begin()); }
-  iterator end() { return iterator(DispatchBlock.succ_end()); }
-
-  ExplodedNode *generateNode(const iterator &I,
-                             ProgramStateRef State,
-                             bool isSink = false);
+  ExplodedNode *generateNode(const CFGBlock *Block, ProgramStateRef State,
+                             bool IsSink = false);
 
   const Expr *getTarget() const { return E; }
 

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -724,14 +724,12 @@ ExplodedNode *BranchNodeBuilder::generateNode(ProgramStateRef State,
   return Succ;
 }
 
-ExplodedNode*
-IndirectGotoNodeBuilder::generateNode(const iterator &I,
-                                      ProgramStateRef St,
-                                      bool IsSink) {
+ExplodedNode *IndirectGotoNodeBuilder::generateNode(const CFGBlock *Block,
+                                                    ProgramStateRef St,
+                                                    bool IsSink) {
   bool IsNew;
-  ExplodedNode *Succ =
-      Eng.G.getNode(BlockEdge(Src, I.getBlock(), Pred->getLocationContext()),
-                    St, IsSink, &IsNew);
+  ExplodedNode *Succ = Eng.G.getNode(
+      BlockEdge(Src, Block, Pred->getLocationContext()), St, IsSink, &IsNew);
   Succ->addPredecessor(Pred, Eng.G);
 
   if (!IsNew)

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3001,13 +3001,11 @@ void ExprEngine::processIndirectGoto(IndirectGotoNodeBuilder &builder) {
   //   (3) We have no clue about the label.  Dispatch to all targets.
   //
 
-  using iterator = IndirectGotoNodeBuilder::iterator;
-
   if (std::optional<loc::GotoLabel> LV = V.getAs<loc::GotoLabel>()) {
     const LabelDecl *L = LV->getLabel();
 
-    for (iterator Succ : builder) {
-      if (Succ.getLabel() == L) {
+    for (const CFGBlock *Succ : builder) {
+      if (cast<LabelStmt>(Succ->getLabel())->getDecl() == L) {
         builder.generateNode(Succ, state);
         return;
       }
@@ -3027,7 +3025,7 @@ void ExprEngine::processIndirectGoto(IndirectGotoNodeBuilder &builder) {
   // This is really a catch-all.  We don't support symbolics yet.
   // FIXME: Implement dispatch for symbolic pointers.
 
-  for (iterator Succ : builder)
+  for (const CFGBlock *Succ : builder)
     builder.generateNode(Succ, state);
 }
 


### PR DESCRIPTION
My recent commit b96ef9c97bee44017bd832efab899ba1ed1f9b8f removed a needlessly overcomplicated iterator class from SwitchNodeBuilder; this commit repeats the same cleanup for IndirectGotoNodeBuilder.

(This is just for the sake of consistency -- I don't have plans to work on indirect goto handling.)