### PR TITLE
[AMDGPU] Revert incorrect fsub fpext into mad-mix pattern

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -223,12 +223,6 @@ multiclass MadFmaMixFP32Pats<SDPatternOperator fma_like,
                (f32 (VOP3PMadMixModsNegPat f32:$src1, i32:$src1_mods)))),
     (mix_inst $src0_mods, $src0, (i32 8), (i32 OneImm), $src1_mods, $src1,
               DSTCLAMP.NONE)>;
-
-  def : GCNPat <
-    (f32 (fsub (f32 (VOP3PMadMixModsNegPat f32:$src0, i32:$src0_mods)),
-               (f32 (VOP3PMadMixModsExtPat VT:$src1, i32:$src1_mods)))),
-    (mix_inst $src0_mods, $src0, (i32 8), (i32 OneImm), $src1_mods, $src1,
-              DSTCLAMP.NONE)>;
 }
 
 multiclass MadFmaMixFP16Pats<SDPatternOperator fma_like,

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-mul.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-mul.ll
@@ -72,10 +72,14 @@ define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_ext_mul_rhs(<4 x float> %x
 ; GFX9-DENORM:       ; %bb.0: ; %.entry
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v4, v4, v6
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v5, v5, v7
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, -v0, 1.0, v4 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, -v1, 1.0, v4 op_sel:[0,0,1] op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, -v2, 1.0, v5 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, -v3, 1.0, v5 op_sel:[0,0,1] op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v6, v4
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v4, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v7, v5
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v5, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v0, v6
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v1, v4
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v2, v7
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v3, v5
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_mul_rhs:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-neg-mul.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-fma-sub-ext-neg-mul.ll
@@ -146,10 +146,14 @@ define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_ext_neg_mul2(<4 x float> %
 ; GFX9-DENORM:       ; %bb.0: ; %entry
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v4, v4, v6 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v5, v5, v7 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, -v0, 1.0, v4 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, -v1, 1.0, v4 op_sel:[0,0,1] op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, -v2, 1.0, v5 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, -v3, 1.0, v5 op_sel:[0,0,1] op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v6, v4
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v4, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v7, v5
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v5, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v0, v6
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v1, v4
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v2, v7
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v3, v5
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_ext_neg_mul2:
@@ -175,10 +179,14 @@ define amdgpu_vs <4 x float> @test_v4f16_to_v4f32_sub_neg_ext_mul2(<4 x float> %
 ; GFX9-DENORM:       ; %bb.0: ; %entry
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v4, v4, v6 neg_lo:[0,1] neg_hi:[0,1]
 ; GFX9-DENORM-NEXT:    v_pk_mul_f16 v5, v5, v7 neg_lo:[0,1] neg_hi:[0,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v0, -v0, 1.0, v4 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v1, -v1, 1.0, v4 op_sel:[0,0,1] op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v2, -v2, 1.0, v5 op_sel_hi:[0,1,1]
-; GFX9-DENORM-NEXT:    v_mad_mix_f32 v3, -v3, 1.0, v5 op_sel:[0,0,1] op_sel_hi:[0,1,1]
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v6, v4
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v4, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_e32 v7, v5
+; GFX9-DENORM-NEXT:    v_cvt_f32_f16_sdwa v5, v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_1
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v0, v0, v6
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v1, v1, v4
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v2, v2, v7
+; GFX9-DENORM-NEXT:    v_sub_f32_e32 v3, v3, v5
 ; GFX9-DENORM-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-DENORM-LABEL: test_v4f16_to_v4f32_sub_neg_ext_mul2:

--- a/llvm/test/CodeGen/AMDGPU/fpext-free.ll
+++ b/llvm/test/CodeGen/AMDGPU/fpext-free.ll
@@ -676,16 +676,18 @@ define float @fsub_fpext_fmul_f16_to_f32_commute(float %x, half %y, half %z) #0 
 ; GFX11-F32DENORM-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-F32DENORM-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-F32DENORM-TRUE16-NEXT:    v_mul_f16_e32 v1.l, v1.l, v2.l
-; GFX11-F32DENORM-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-F32DENORM-TRUE16-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[0,1,1]
+; GFX11-F32DENORM-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-F32DENORM-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; GFX11-F32DENORM-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX11-F32DENORM-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-F32DENORM-FAKE16-LABEL: fsub_fpext_fmul_f16_to_f32_commute:
 ; GFX11-F32DENORM-FAKE16:       ; %bb.0: ; %entry
 ; GFX11-F32DENORM-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-F32DENORM-FAKE16-NEXT:    v_mul_f16_e32 v1, v1, v2
-; GFX11-F32DENORM-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-F32DENORM-FAKE16-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[0,1,1]
+; GFX11-F32DENORM-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-F32DENORM-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX11-F32DENORM-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX11-F32DENORM-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-F32FLUSH-LABEL: fsub_fpext_fmul_f16_to_f32_commute:
@@ -1001,10 +1003,12 @@ define float @fsub_fpext_muladd_mul_f16_to_f32_commute(float %x, half %y, half %
 ; GFX11-TRUE16-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
 ; GFX11-TRUE16:       ; %bb.0: ; %entry
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v3.l, v3.l, v4.l
+; GFX11-TRUE16-NEXT:    v_mul_f16_e32 v1.h, v3.l, v4.l
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fmac_f16_e32 v3.l, v1.l, v2.l
-; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v3 op_sel_hi:[0,1,1]
+; GFX11-TRUE16-NEXT:    v_fmac_f16_e32 v1.h, v1.l, v2.l
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
@@ -1013,34 +1017,19 @@ define float @fsub_fpext_muladd_mul_f16_to_f32_commute(float %x, half %y, half %
 ; GFX11-FAKE16-NEXT:    v_mul_f16_e32 v3, v3, v4
 ; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-FAKE16-NEXT:    v_fmac_f16_e32 v3, v1, v2
-; GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v3 op_sel_hi:[0,1,1]
+; GFX11-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, v3
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-FAKE16-NEXT:    v_sub_f32_e32 v0, v0, v1
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX9-F32FLUSH-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
-; GFX9-F32FLUSH:       ; %bb.0: ; %entry
-; GFX9-F32FLUSH-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-F32FLUSH-NEXT:    v_mul_f16_e32 v3, v3, v4
-; GFX9-F32FLUSH-NEXT:    v_fma_f16 v1, v1, v2, v3
-; GFX9-F32FLUSH-NEXT:    v_mad_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[0,1,1]
-; GFX9-F32FLUSH-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX9-F32DENORM-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
-; GFX9-F32DENORM:       ; %bb.0: ; %entry
-; GFX9-F32DENORM-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-F32DENORM-NEXT:    v_mul_f16_e32 v3, v3, v4
-; GFX9-F32DENORM-NEXT:    v_fma_f16 v1, v1, v2, v3
-; GFX9-F32DENORM-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX9-F32DENORM-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GFX9-F32DENORM-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX8-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
-; GFX8:       ; %bb.0: ; %entry
-; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_mul_f16_e32 v3, v3, v4
-; GFX8-NEXT:    v_fma_f16 v1, v1, v2, v3
-; GFX8-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX8-NEXT:    v_sub_f32_e32 v0, v0, v1
-; GFX8-NEXT:    s_setpc_b64 s[30:31]
+; GFX89-LABEL: fsub_fpext_muladd_mul_f16_to_f32_commute:
+; GFX89:       ; %bb.0: ; %entry
+; GFX89-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX89-NEXT:    v_mul_f16_e32 v3, v3, v4
+; GFX89-NEXT:    v_fma_f16 v1, v1, v2, v3
+; GFX89-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX89-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX89-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %mul = fmul half %u, %v
   %fma = call half @llvm.fmuladd.f16(half %y, half %z, half %mul)


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/160151 added a invalid select of f_fma_mix for `A - ext(B)` where we generate `-A * 1.0 + B` => `B - A`

This PR reverts this pattern.

Reproducer `llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950`:
```mlir
define float @fsub_f32_fpext_f16(float %a, half %b) {
  %b.ext = fpext half %b to float
  %result = fsub float %a, %b.ext
  ret float %result
}
```
yields:
```asm
v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel_hi:[0,1,1]
```
but we expect:
```asm
v_fma_mix_f32 v0, v0, 1.0, -v1 op_sel_hi:[0,1,1]
```