### PR TITLE
[Flang][OpenMP] Enabling support for Allocate clause in DO construct

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -1887,14 +1887,13 @@ static void genWsloopClauses(
     mlir::Location loc, mlir::omp::WsloopOperands &clauseOps,
     llvm::SmallVectorImpl<const semantics::Symbol *> &reductionSyms) {
   ClauseProcessor cp(converter, semaCtx, clauses);
+  cp.processAllocate(clauseOps);
   cp.processNowait(clauseOps);
   cp.processOrder(clauseOps);
   cp.processOrdered(clauseOps);
   cp.processReduction(loc, clauseOps, reductionSyms);
   cp.processSchedule(stmtCtx, clauseOps);
   cp.processLinear(clauseOps);
-
-  cp.processTODO<clause::Allocate>(loc, llvm::omp::Directive::OMPD_do);
 }
 
 //===----------------------------------------------------------------------===//

--- a/flang/test/Semantics/OpenMP/allocate_do.f90
+++ b/flang/test/Semantics/OpenMP/allocate_do.f90
@@ -1,0 +1,46 @@
+! REQUIRES: openmp_runtime
+! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags -fopenmp-version=52
+module all_mod
+    integer, parameter :: N = 100
+    integer(kind=4), dimension(N) :: AAA
+    integer(kind=4), dimension(N) :: BBB
+    integer(kind=4), dimension(N) :: CCC
+    integer(kind=4), dimension(N) :: DDD
+    integer val, error_count
+    contains
+    subroutine initialize()
+        do i=1,N
+            AAA(i) = i
+            BBB(i) = 2*i
+            CCC(i) = 0
+            DDD(i) = 0
+        end do
+        val = 0
+    end subroutine
+end module
+
+subroutine test_omp_do()
+    use all_mod
+    !$omp parallel shared(AAA,BBB,CCC,DDD,val)
+    !$omp do private(CCC, val) allocate(0:CCC, val)
+    do i=1,N
+        CCC(i) = AAA(i) + BBB(i)
+        val    = AAA(i) + BBB(i)
+        DDD(i) = CCC(i) + val
+    end do
+    !$omp end do
+    !$omp end parallel
+end subroutine test_omp_do
+
+subroutine test_omp_parallel_do()
+    use all_mod
+    !$omp parallel do private(CCC, val) allocate(0:CCC, val) shared(AAA,BBB,DDD)
+    do i=1,N
+        CCC(i) = AAA(i) + BBB(i)
+        val    = AAA(i) + BBB(i)
+        DDD(i) = CCC(i) + val
+    end do
+    !$omp end parallel do
+end subroutine test_omp_parallel_do
+program test_omp_do
+end program

--- a/flang/test/Semantics/OpenMP/allocate_do1.f90
+++ b/flang/test/Semantics/OpenMP/allocate_do1.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/../test_errors.py %s %flang -fopenmp -fopenmp-version=50
+!RUN: %python %S/../test_errors.py %s %flang -fopenmp -fopenmp-version=45
 module all_mod
     integer, parameter :: N = 100
     integer(kind=4), dimension(N) :: AAA
@@ -21,6 +21,8 @@ end module
 subroutine test_omp_do()
     use all_mod
     !$omp parallel shared(AAA,BBB,CCC,DDD,val)
+    !ERROR: ALLOCATE clause is not allowed on directive DO in OpenMP v4.5, try -fopenmp-version=50
+    !ERROR: 'allocator-simple-modifier' modifier is not supported in OpenMP v4.5, try -fopenmp-version=50
     !$omp do private(CCC, val) allocate(0:CCC, val)
     do i=1,N
         CCC(i) = AAA(i) + BBB(i)
@@ -33,6 +35,8 @@ end subroutine test_omp_do
 
 subroutine test_omp_parallel_do()
     use all_mod
+    !ERROR: ALLOCATE clause is not allowed on directive PARALLEL DO in OpenMP v4.5, try -fopenmp-version=50
+    !ERROR: 'allocator-simple-modifier' modifier is not supported in OpenMP v4.5, try -fopenmp-version=50
     !$omp parallel do private(CCC, val) allocate(0:CCC, val) shared(AAA,BBB,DDD)
     do i=1,N
         CCC(i) = AAA(i) + BBB(i)

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -890,7 +890,7 @@ def OMP_Distribute : Directive<[Spelling<"distribute">]> {
 }
 def OMP_Do : Directive<[Spelling<"do">]> {
   let allowedClauses = [
-    VersionedClause<OMPC_Allocate>,
+    VersionedClause<OMPC_Allocate, 50>,
     VersionedClause<OMPC_FirstPrivate>,
     VersionedClause<OMPC_LastPrivate>,
     VersionedClause<OMPC_Linear>,
@@ -1792,7 +1792,7 @@ def OMP_MasterTaskloopSimd : Directive<[Spelling<"master taskloop simd">]> {
 }
 def OMP_ParallelDo : Directive<[Spelling<"parallel do">]> {
   let allowedClauses = [
-    VersionedClause<OMPC_Allocate>,
+    VersionedClause<OMPC_Allocate, 50>,
     VersionedClause<OMPC_Copyin>,
     VersionedClause<OMPC_Default>,
     VersionedClause<OMPC_FirstPrivate>,

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -890,6 +890,7 @@ def OMP_Distribute : Directive<[Spelling<"distribute">]> {
 }
 def OMP_Do : Directive<[Spelling<"do">]> {
   let allowedClauses = [
+    VersionedClause<OMPC_Allocate>,
     VersionedClause<OMPC_FirstPrivate>,
     VersionedClause<OMPC_LastPrivate>,
     VersionedClause<OMPC_Linear>,
@@ -1791,6 +1792,7 @@ def OMP_MasterTaskloopSimd : Directive<[Spelling<"master taskloop simd">]> {
 }
 def OMP_ParallelDo : Directive<[Spelling<"parallel do">]> {
   let allowedClauses = [
+    VersionedClause<OMPC_Allocate>,
     VersionedClause<OMPC_Copyin>,
     VersionedClause<OMPC_Default>,
     VersionedClause<OMPC_FirstPrivate>,


### PR DESCRIPTION
Fixes [#179425](https://github.com/llvm/llvm-project/issues/179425).

Allocate clause is allowed inside DO and parallel DO constructs as per [13.6.2](https://www.openmp.org/wp-content/uploads/OpenMP-API-Specification-6-0.pdf) but flang seemed to throw diagnostic against the same. This patch enables initial support for allocate clause in DO construct.