### PR TITLE
[SPIRV] Fix constant materialization for width > 64bit

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -378,9 +378,8 @@ Register SPIRVGlobalRegistry::getOrCreateConstInt(uint64_t Val, MachineInstr &I,
                                                   SPIRVType *SpvType,
                                                   const SPIRVInstrInfo &TII,
                                                   bool ZeroAsNull) {
-  return getOrCreateConstInt(
-      APInt(getScalarOrVectorBitWidth(SpvType), Val), I, SpvType, TII,
-      ZeroAsNull);
+  return getOrCreateConstInt(APInt(getScalarOrVectorBitWidth(SpvType), Val), I,
+                             SpvType, TII, ZeroAsNull);
 }
 
 Register SPIRVGlobalRegistry::getOrCreateConstInt(const APInt &Val,
@@ -588,9 +587,8 @@ Register SPIRVGlobalRegistry::getOrCreateConstVector(uint64_t Val,
                                                      SPIRVType *SpvType,
                                                      const SPIRVInstrInfo &TII,
                                                      bool ZeroAsNull) {
-  return getOrCreateConstVector(
-      APInt(getScalarOrVectorBitWidth(SpvType), Val), I, SpvType, TII,
-      ZeroAsNull);
+  return getOrCreateConstVector(APInt(getScalarOrVectorBitWidth(SpvType), Val),
+                                I, SpvType, TII, ZeroAsNull);
 }
 
 Register SPIRVGlobalRegistry::getOrCreateConstVector(const APInt &Val,

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -389,7 +389,7 @@ Register SPIRVGlobalRegistry::getOrCreateConstInt(uint64_t Val, MachineInstr &I,
 
 Register SPIRVGlobalRegistry::getOrCreateConstInt(const APInt &Val,
                                                   MachineInstr &I,
-                                                  SPIRVType *SpvType,
+                                                  const SPIRVType *SpvType,
                                                   const SPIRVInstrInfo &TII,
                                                   bool ZeroAsNull) {
   auto *const CI = ConstantInt::get(
@@ -608,7 +608,7 @@ Register SPIRVGlobalRegistry::getOrCreateConstVector(uint64_t Val,
 
 Register SPIRVGlobalRegistry::getOrCreateConstVector(const APInt &Val,
                                                      MachineInstr &I,
-                                                     SPIRVType *SpvType,
+                                                     const SPIRVType *SpvType,
                                                      const SPIRVInstrInfo &TII,
                                                      bool ZeroAsNull) {
   const Type *LLVMTy = getTypeForSPIRVType(SpvType);

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -521,7 +521,8 @@ public:
                                SPIRVType *SpvType, const SPIRVInstrInfo &TII,
                                bool ZeroAsNull = true);
   Register getOrCreateConstInt(const APInt &Val, MachineInstr &I,
-                               SPIRVType *SpvType, const SPIRVInstrInfo &TII,
+                               const SPIRVType *SpvType,
+                               const SPIRVInstrInfo &TII,
                                bool ZeroAsNull = true);
   Register createConstInt(const ConstantInt *CI, MachineInstr &I,
                           SPIRVType *SpvType, const SPIRVInstrInfo &TII,
@@ -539,7 +540,8 @@ public:
                                   SPIRVType *SpvType, const SPIRVInstrInfo &TII,
                                   bool ZeroAsNull = true);
   Register getOrCreateConstVector(const APInt &Val, MachineInstr &I,
-                                  SPIRVType *SpvType, const SPIRVInstrInfo &TII,
+                                  const SPIRVType *SpvType,
+                                  const SPIRVInstrInfo &TII,
                                   bool ZeroAsNull = true);
   Register getOrCreateConstVector(APFloat Val, MachineInstr &I,
                                   SPIRVType *SpvType, const SPIRVInstrInfo &TII,

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -520,6 +520,9 @@ public:
   Register getOrCreateConstInt(uint64_t Val, MachineInstr &I,
                                SPIRVType *SpvType, const SPIRVInstrInfo &TII,
                                bool ZeroAsNull = true);
+  Register getOrCreateConstInt(const APInt &Val, MachineInstr &I,
+                               SPIRVType *SpvType, const SPIRVInstrInfo &TII,
+                               bool ZeroAsNull = true);
   Register createConstInt(const ConstantInt *CI, MachineInstr &I,
                           SPIRVType *SpvType, const SPIRVInstrInfo &TII,
                           bool ZeroAsNull);
@@ -533,6 +536,9 @@ public:
                            SPIRVType *SpvType = nullptr);
 
   Register getOrCreateConstVector(uint64_t Val, MachineInstr &I,
+                                  SPIRVType *SpvType, const SPIRVInstrInfo &TII,
+                                  bool ZeroAsNull = true);
+  Register getOrCreateConstVector(const APInt &Val, MachineInstr &I,
                                   SPIRVType *SpvType, const SPIRVInstrInfo &TII,
                                   bool ZeroAsNull = true);
   Register getOrCreateConstVector(APFloat Val, MachineInstr &I,

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -3261,8 +3261,8 @@ Register SPIRVInstructionSelector::buildOnesVal(bool AllOnes,
   APInt One =
       AllOnes ? APInt::getAllOnes(BitWidth) : APInt::getOneBitSet(BitWidth, 0);
   if (ResType->getOpcode() == SPIRV::OpTypeVector)
-    return GR.getOrCreateConstVector(One.getZExtValue(), I, ResType, TII);
-  return GR.getOrCreateConstInt(One.getZExtValue(), I, ResType, TII);
+    return GR.getOrCreateConstVector(One, I, ResType, TII);
+  return GR.getOrCreateConstInt(One, I, ResType, TII);
 }
 
 bool SPIRVInstructionSelector::selectSelect(Register ResVReg,
@@ -3484,7 +3484,7 @@ bool SPIRVInstructionSelector::selectConst(Register ResVReg,
     Reg = GR.getOrCreateConstFP(I.getOperand(1).getFPImm()->getValue(), I,
                                 ResType, TII, !STI.isShader());
   } else {
-    Reg = GR.getOrCreateConstInt(I.getOperand(1).getCImm()->getZExtValue(), I,
+    Reg = GR.getOrCreateConstInt(I.getOperand(1).getCImm()->getValue(), I,
                                  ResType, TII, !STI.isShader());
   }
   return Reg == ResVReg ? true : BuildCOPY(ResVReg, Reg, I);

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/apint-constant.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/apint-constant.ll
@@ -1,0 +1,37 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_ALTERA_arbitrary_precision_integers %s -o - | FileCheck %s
+
+; Verify that wide integer constants (>64 bits) are correctly encoded as
+; OpConstant with multi-word literals.
+
+; CHECK-DAG: %[[#INT128:]] = OpTypeInt 128 0
+; CHECK-DAG: %[[#INT96:]] = OpTypeInt 96 0
+; CHECK-DAG: %[[#NEG128:]] = OpConstant %[[#INT128]] 4294965247 4294967295 4294967295 4294967295
+; CHECK-DAG: %[[#ONE128:]] = OpConstant %[[#INT128]] 1 0 0 0
+; CHECK-DAG: %[[#BOUNDARY:]] = OpConstant %[[#INT128]] 4294967295 4294967295 0 0
+; CHECK-DAG: %[[#ZERO128:]] = OpConstantNull %[[#INT128]]
+; CHECK-DAG: %[[#NEG96:]] = OpConstant %[[#INT96]] 4294967295 4294967295 4294967295 0
+; CHECK-DAG: %[[#OVER64:]] = OpConstant %[[#INT96]] 1 0 1 0
+
+; CHECK: OpStore %[[#]] %[[#NEG128]] Aligned 16
+; CHECK: OpStore %[[#]] %[[#ONE128]] Aligned 16
+; CHECK: OpStore %[[#]] %[[#BOUNDARY]] Aligned 16
+; CHECK: OpStore %[[#]] %[[#ZERO128]] Aligned 16
+
+; CHECK: OpStore %[[#]] %[[#NEG96]] Aligned 16
+; CHECK: OpStore %[[#]] %[[#OVER64]] Aligned 16
+
+define spir_func void @test_i128_const(ptr addrspace(4) %p) addrspace(4) {
+entry:
+  store i128 -2049, ptr addrspace(4) %p, align 16
+  store i128 1, ptr addrspace(4) %p, align 16
+  store i128 18446744073709551615, ptr addrspace(4) %p, align 16
+  store i128 0, ptr addrspace(4) %p, align 16
+  ret void
+}
+
+define spir_func void @test_i96_const(ptr addrspace(4) %p) addrspace(4) {
+entry:
+  store i96 -1, ptr addrspace(4) %p, align 16
+  store i96 18446744073709551617, ptr addrspace(4) %p, align 16
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/apint-constant.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/apint-constant.ll
@@ -4,21 +4,14 @@
 ; OpConstant with multi-word literals.
 
 ; CHECK-DAG: %[[#INT128:]] = OpTypeInt 128 0
-; CHECK-DAG: %[[#INT96:]] = OpTypeInt 96 0
 ; CHECK-DAG: %[[#NEG128:]] = OpConstant %[[#INT128]] 4294965247 4294967295 4294967295 4294967295
 ; CHECK-DAG: %[[#ONE128:]] = OpConstant %[[#INT128]] 1 0 0 0
 ; CHECK-DAG: %[[#BOUNDARY:]] = OpConstant %[[#INT128]] 4294967295 4294967295 0 0
 ; CHECK-DAG: %[[#ZERO128:]] = OpConstantNull %[[#INT128]]
-; CHECK-DAG: %[[#NEG96:]] = OpConstant %[[#INT96]] 4294967295 4294967295 4294967295 0
-; CHECK-DAG: %[[#OVER64:]] = OpConstant %[[#INT96]] 1 0 1 0
-
 ; CHECK: OpStore %[[#]] %[[#NEG128]] Aligned 16
 ; CHECK: OpStore %[[#]] %[[#ONE128]] Aligned 16
 ; CHECK: OpStore %[[#]] %[[#BOUNDARY]] Aligned 16
 ; CHECK: OpStore %[[#]] %[[#ZERO128]] Aligned 16
-
-; CHECK: OpStore %[[#]] %[[#NEG96]] Aligned 16
-; CHECK: OpStore %[[#]] %[[#OVER64]] Aligned 16
 
 define spir_func void @test_i128_const(ptr addrspace(4) %p) addrspace(4) {
 entry:
@@ -26,12 +19,5 @@ entry:
   store i128 1, ptr addrspace(4) %p, align 16
   store i128 18446744073709551615, ptr addrspace(4) %p, align 16
   store i128 0, ptr addrspace(4) %p, align 16
-  ret void
-}
-
-define spir_func void @test_i96_const(ptr addrspace(4) %p) addrspace(4) {
-entry:
-  store i96 -1, ptr addrspace(4) %p, align 16
-  store i96 18446744073709551617, ptr addrspace(4) %p, align 16
   ret void
 }


### PR DESCRIPTION
selectConst() was asserting for constants wider than 64 bits. Add APInt overloads of getOrCreateConstInt and getOrCreateConstVector that avoid the uint64_t truncation.