### PR TITLE
[NFC][analyzer] Get rid of imaginary friends (of classes)

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -48,8 +48,6 @@ class ExprEngine;
 /// CoreEngine - Implements the core logic of the graph-reachability analysis.
 /// It traverses the CFG and generates the ExplodedGraph.
 class CoreEngine {
-  friend class CommonNodeBuilder;
-  friend class EndOfFunctionNodeBuilder;
   friend class ExprEngine;
   friend class IndirectGotoNodeBuilder;
   friend class NodeBuilder;

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
@@ -66,7 +66,6 @@ class ExplodedGraph;
 class ExplodedNode : public llvm::FoldingSetNode {
   friend class BranchNodeBuilder;
   friend class CoreEngine;
-  friend class EndOfFunctionNodeBuilder;
   friend class ExplodedGraph;
   friend class IndirectGotoNodeBuilder;
   friend class NodeBuilder;


### PR DESCRIPTION
These NodeBuilder classes were deleted from the codebase in 2011 (fifteen years ago!) by 3eae33412d18c4a4a4a8592898b3e65ad5946a89 so don't declare them as friends.