### PR TITLE
[SPIRV] Fix APInt overflow in memset constant array creation

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -629,9 +629,10 @@ Register SPIRVGlobalRegistry::getOrCreateConstIntArray(
   // that would be a truly unique but dangerous key, because it could lead to
   // the creation of constants of arbitrary length (that is, the parameter of
   // memset) which were missing in the original module.
+  Type *I64Ty = Type::getInt64Ty(LLVMBaseTy->getContext());
   Constant *UniqueKey = ConstantStruct::getAnon(
       {PoisonValue::get(const_cast<ArrayType *>(LLVMArrTy)),
-       ConstantInt::get(LLVMBaseTy, Val), ConstantInt::get(LLVMBaseTy, Num)});
+       ConstantInt::get(LLVMBaseTy, Val), ConstantInt::get(I64Ty, Num)});
   return getOrCreateCompositeOrNull(CI, I, SpvType, TII, UniqueKey, BW,
                                     LLVMArrTy->getNumElements());
 }

--- a/llvm/test/CodeGen/SPIRV/memset-large-size.ll
+++ b/llvm/test/CodeGen/SPIRV/memset-large-size.ll
@@ -1,0 +1,22 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; A regression test that checks if memset with a size larger exceeding i8 range
+; does not crash the backend.
+
+; CHECK-DAG: %[[#INT8:]] = OpTypeInt 8 0
+; CHECK-DAG: %[[#INT32:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#INT64:]] = OpTypeInt 64 0
+; CHECK-DAG: %[[#SIZE:]] = OpConstant %[[#INT32]] 444
+; CHECK-DAG: %[[#ARRTY:]] = OpTypeArray %[[#INT8]] %[[#SIZE]]
+; CHECK-DAG: %[[#ZERO:]] = OpConstantNull %[[#ARRTY]]
+; CHECK-DAG: %[[#LEN:]] = OpConstant %[[#INT64]] 444
+; CHECK: OpCopyMemorySized %[[#]] %[[#]] %[[#LEN]] Aligned 1
+
+define spir_func void @test_memset_large(ptr addrspace(4) %p) addrspace(4) {
+entry:
+  call addrspace(4) void @llvm.memset.p4.i64(ptr addrspace(4) %p, i8 0, i64 444, i1 false)
+  ret void
+}
+
+declare void @llvm.memset.p4.i64(ptr addrspace(4) writeonly captures(none), i8, i64, i1 immarg) addrspace(4)


### PR DESCRIPTION
In getOrCreateConstIntArray(), the cache UniqueKey encoded the array size (Num) using the array element type (e.g. i8 for memset). Since Num is a size_t that can exceed 255, this caused an APInt overflow when Num > 255. Use i64 for Num in the UniqueKey.