### PR TITLE
[mlir][MemRef] Fix crash in GenericAtomicRMWOp parser on non-memref type

### DIFF
--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -1543,11 +1543,16 @@ ParseResult GenericAtomicRMWOp::parse(OpAsmParser &parser,
       parser.resolveOperands(ivs, indexType, result.operands))
     return failure();
 
+  auto memref_type = llvm::dyn_cast<MemRefType>(memrefType);
+  if (!memref_type)
+    return parser.emitError(parser.getNameLoc())
+           << "expected memref type, but got " << memrefType;
+
   Region *body = result.addRegion();
   if (parser.parseRegion(*body, {}) ||
       parser.parseOptionalAttrDict(result.attributes))
     return failure();
-  result.types.push_back(llvm::cast<MemRefType>(memrefType).getElementType());
+  result.types.push_back(memref_type.getElementType());
   return success();
 }
 

--- a/mlir/test/Dialect/MemRef/invalid.mlir
+++ b/mlir/test/Dialect/MemRef/invalid.mlir
@@ -1117,6 +1117,18 @@ func.func @atomic_yield_type_mismatch(%I: memref<10xf32>, %i : index) {
 
 // -----
 
+func.func @generic_atomic_rmw_tensor_type(%T: tensor<10xf32>, %i : index) {
+  // expected-error@+1 {{expected memref type, but got 'tensor<10xf32>'}}
+  %x = memref.generic_atomic_rmw %T[%i] : tensor<10xf32> {
+    ^bb0(%old_value : f32):
+      %c1 = arith.constant 1.0 : f32
+      memref.atomic_yield %c1 : f32
+  }
+  return
+}
+
+// -----
+
 #map0 = affine_map<(d0) -> (d0 floordiv 8, d0 mod 8)>
 func.func @memref_realloc_layout(%src : memref<256xf32, #map0>) -> memref<?xf32>{
   // expected-error@+1 {{unsupported layout}}


### PR DESCRIPTION
Resolve #179047 
Previously `generic_atomic_rmw` caused an assertion failure when the operand was a tensor type instead of
a memref type. Now replaces the unchecked cast with dyn_cast and emits a proper
diagnostic error message when the type is not a memref.