### PR TITLE
[cross-project-tests] Fix lldb version regex

### DIFF
--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -255,13 +255,13 @@ def get_gdb_version_string():
             subprocess.check_output(["gdb", "--version"]).decode().splitlines()
         )
     except:
-        return None  # We coudln't find gdb or something went wrong running it.
+        return None  # We couldn't find gdb or something went wrong running it.
     if len(gdb_vers_lines) < 1:
-        print("Unkown GDB version format (too few lines)", file=sys.stderr)
+        print("Unknown GDB version format (too few lines)", file=sys.stderr)
         return None
     match = re.search(r"GNU gdb \(.*?\) ((\d|\.)+)", gdb_vers_lines[0].strip())
     if match is None:
-        print(f"Unkown GDB version format: {gdb_vers_lines[0]}", file=sys.stderr)
+        print(f"Unknown GDB version format: {gdb_vers_lines[0]}", file=sys.stderr)
         return None
     return match.group(1)
 
@@ -293,11 +293,11 @@ def get_lldb_version_string():
     except:
         return None
     if len(lldb_vers_lines) < 1:
-        print("Unkown LLDB version format (too few lines)", file=sys.stderr)
+        print("Unknown LLDB version format (too few lines)", file=sys.stderr)
         return None
-    match = re.search(r"lldb.*[ -]((\d|\.)+)", lldb_vers_lines[0].strip())
+    match = re.search(r"lldb.*?[ -]((\d|\.)+)", lldb_vers_lines[0].strip())
     if match is None:
-        print(f"Unkown LLDB version format: {lldb_vers_lines[0]}", file=sys.stderr)
+        print(f"Unknown LLDB version format: {lldb_vers_lines[0]}", file=sys.stderr)
         return None
     return match.group(1)
 


### PR DESCRIPTION
The get_lldb_version_string function in the lit config used a greedy regex that could, if using a lldb binary built with git revision output, using a SHA that starts with a digit, result in the first digits of the SHA being interpreted as the lldb version.

For example, if lldb emits:

    $ lldb --version
    lldb version 23.0.0git \
    (https://github.com/dstenb/llvm-project.git revision \
    7e565729e33d19d468520e7bfbb8b23a918adc9c)

the version would be interpreted as 7 rather than 23.0.0:

    Marking some LLDB LLVM data-formatter tests as unsupported: using
    version 7 whereas a version >= 1900 is required

(That check should compare towards 19.0.0, but that issue is addressed
 in an other patch.)

Resolve this by using a non-greedy matcher.

Also, include a drive-by fix of some typos.