### PR TITLE
[lldb][FreeBSD] Remove MIPS64 unit tests

### DIFF
--- a/lldb/unittests/Process/Utility/RegisterContextFreeBSDTest.cpp
+++ b/lldb/unittests/Process/Utility/RegisterContextFreeBSDTest.cpp
@@ -18,7 +18,6 @@
 #include "gtest/gtest.h"
 
 #include "Plugins/Process/Utility/RegisterContextFreeBSD_i386.h"
-#include "Plugins/Process/Utility/RegisterContextFreeBSD_mips64.h"
 #include "Plugins/Process/Utility/RegisterContextFreeBSD_powerpc.h"
 #include "Plugins/Process/Utility/RegisterContextFreeBSD_x86_64.h"
 #include "Plugins/Process/Utility/RegisterContextPOSIX_powerpc.h"
@@ -26,7 +25,6 @@
 #include "Plugins/Process/Utility/RegisterInfoPOSIX_arm64.h"
 #include "Plugins/Process/Utility/lldb-arm-register-enums.h"
 #include "Plugins/Process/Utility/lldb-arm64-register-enums.h"
-#include "Plugins/Process/Utility/lldb-mips-freebsd-register-enums.h"
 #include "Plugins/Process/Utility/lldb-x86-register-enums.h"
 
 using namespace lldb;
@@ -403,73 +401,6 @@ TEST(RegisterContextFreeBSDTest, arm64) {
 }
 
 #endif // defined(__aarch64__)
-
-#if defined(__mips64__)
-
-#define EXPECT_GPR_MIPS64(lldb_reg, fbsd_regno)                                \
-  EXPECT_THAT(GetRegParams(reg_ctx, gpr_##lldb_reg##_mips64),                  \
-              ::testing::Pair(offsetof(reg, r_regs[fbsd_regno]),               \
-                              sizeof(reg::r_regs[fbsd_regno])))
-#define EXPECT_FPU_MIPS64(lldb_reg, fbsd_regno)                                \
-  EXPECT_THAT(                                                                 \
-      GetRegParams(reg_ctx, fpr_##lldb_reg##_mips64),                          \
-      ::testing::Pair(offsetof(fpreg, r_regs[fbsd_regno]) + base_offset,       \
-                      sizeof(fpreg::r_regs[fbsd_regno])))
-
-TEST(RegisterContextFreeBSDTest, mips64) {
-  ArchSpec arch{"mips64-unknown-freebsd"};
-  RegisterContextFreeBSD_mips64 reg_ctx{arch};
-
-  // we can not use aliases from <machine/regnum.h> because macros defined
-  // there are not namespaced and collide a lot, e.g. 'A1'
-
-  EXPECT_GPR_MIPS64(zero, 0);
-  EXPECT_GPR_MIPS64(r1, 1);
-  EXPECT_GPR_MIPS64(r2, 2);
-  EXPECT_GPR_MIPS64(r3, 3);
-  EXPECT_GPR_MIPS64(r4, 4);
-  EXPECT_GPR_MIPS64(r5, 5);
-  EXPECT_GPR_MIPS64(r6, 6);
-  EXPECT_GPR_MIPS64(r7, 7);
-  EXPECT_GPR_MIPS64(r8, 8);
-  EXPECT_GPR_MIPS64(r9, 9);
-  EXPECT_GPR_MIPS64(r10, 10);
-  EXPECT_GPR_MIPS64(r11, 11);
-  EXPECT_GPR_MIPS64(r12, 12);
-  EXPECT_GPR_MIPS64(r13, 13);
-  EXPECT_GPR_MIPS64(r14, 14);
-  EXPECT_GPR_MIPS64(r15, 15);
-  EXPECT_GPR_MIPS64(r16, 16);
-  EXPECT_GPR_MIPS64(r17, 17);
-  EXPECT_GPR_MIPS64(r18, 18);
-  EXPECT_GPR_MIPS64(r19, 19);
-  EXPECT_GPR_MIPS64(r20, 20);
-  EXPECT_GPR_MIPS64(r21, 21);
-  EXPECT_GPR_MIPS64(r22, 22);
-  EXPECT_GPR_MIPS64(r23, 23);
-  EXPECT_GPR_MIPS64(r24, 24);
-  EXPECT_GPR_MIPS64(r25, 25);
-  EXPECT_GPR_MIPS64(r26, 26);
-  EXPECT_GPR_MIPS64(r27, 27);
-  EXPECT_GPR_MIPS64(gp, 28);
-  EXPECT_GPR_MIPS64(sp, 29);
-  EXPECT_GPR_MIPS64(r30, 30);
-  EXPECT_GPR_MIPS64(ra, 31);
-  EXPECT_GPR_MIPS64(sr, 32);
-  EXPECT_GPR_MIPS64(mullo, 33);
-  EXPECT_GPR_MIPS64(mulhi, 34);
-  EXPECT_GPR_MIPS64(badvaddr, 35);
-  EXPECT_GPR_MIPS64(cause, 36);
-  EXPECT_GPR_MIPS64(pc, 37);
-  EXPECT_GPR_MIPS64(ic, 38);
-  EXPECT_GPR_MIPS64(dummy, 39);
-
-  size_t base_offset = reg_ctx.GetRegisterInfo()[fpr_f0_mips64].byte_offset;
-
-  EXPECT_FPU_MIPS64(f0, 0);
-}
-
-#endif // defined(__mips64__)
 
 #if defined(__powerpc__)
 


### PR DESCRIPTION
427bb1cc1b09ea68b8a13a667810681ba4074f6b removed FreeBSD on MIPS64 support. This test was missed because it only compiles on FreeBSD on MIPS64.