### PR TITLE
[lldb-dap] Add validation for RunInTerminal client capability

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1183,7 +1183,9 @@ class DebugCommunication(object):
         }
         return self._send_recv(command_dict)
 
-    def request_initialize(self, sourceInitFile=False):
+    def request_initialize(
+        self, client_features: Optional[dict[str, bool]] = None, sourceInitFile=False
+    ):
         command_dict = {
             "command": "initialize",
             "type": "request",
@@ -1204,6 +1206,13 @@ class DebugCommunication(object):
                 "$__lldb_sourceInitFile": sourceInitFile,
             },
         }
+
+        if client_features is not None:
+            arguments = command_dict["arguments"]
+            # replace the default client features.
+            for key, value in client_features.items():
+                arguments[key] = value
+
         response = self._send_recv(command_dict)
         if response:
             if "body" in response:
@@ -1866,7 +1875,7 @@ def attach_options_specified(opts):
 
 
 def run_adapter(dbg: DebugCommunication, opts: argparse.Namespace) -> None:
-    dbg.request_initialize(opts.source_init_file)
+    dbg.request_initialize(sourceInitFile=opts.source_init_file)
 
     source_to_lines: Dict[str, List[int]] = {}
     for sbp in cast(List[str], opts.source_bp):

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -535,6 +535,7 @@ class DAPTestCaseBase(TestBase):
     def attach(
         self,
         *,
+        client_features: Optional[dict[str, bool]] = None,
         disconnectAutomatically=True,
         sourceInitFile=False,
         **kwargs,
@@ -551,7 +552,9 @@ class DAPTestCaseBase(TestBase):
         # Execute the cleanup function during test case tear down.
         self.addTearDownHook(cleanup)
         # Initialize and launch the program
-        self.dap_server.request_initialize(sourceInitFile)
+        self.dap_server.request_initialize(
+            client_features=client_features, sourceInitFile=sourceInitFile
+        )
         return self.dap_server.request_attach(**kwargs)
 
     def attach_and_configurationDone(
@@ -568,6 +571,7 @@ class DAPTestCaseBase(TestBase):
         self,
         program: str,
         *,
+        client_features: Optional[dict[str, bool]] = None,
         sourceInitFile=False,
         disconnectAutomatically=True,
         **kwargs,
@@ -585,7 +589,9 @@ class DAPTestCaseBase(TestBase):
         self.addTearDownHook(cleanup)
 
         # Initialize and launch the program
-        self.dap_server.request_initialize(sourceInitFile)
+        self.dap_server.request_initialize(
+            client_features=client_features, sourceInitFile=sourceInitFile
+        )
         return self.dap_server.request_launch(program, **kwargs)
 
     def launch_and_configurationDone(

--- a/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
@@ -215,3 +215,15 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
 
         _, stderr = proc.communicate()
         self.assertIn("Timed out trying to get messages from the debug adapter", stderr)
+
+    def test_client_missing_runInTerminal_feature(self):
+        program = self.getBuildArtifact("a.out")
+        self.build_and_create_debug_adapter()
+        response = self.launch_and_configurationDone(
+            program,
+            console="integratedTerminal",
+            client_features={"supportsRunInTerminalRequest": False},
+        )
+        self.assertFalse(response["success"], f"Expected failure got {response!r}")
+        error_message = response["body"]["error"]["format"]
+        self.assertIn("Client does not support RunInTerminal.", error_message)

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -236,7 +236,7 @@ llvm::Error BaseRequestHandler::LaunchProcess(
     if (arguments.console != protocol::eConsoleInternal) {
       if (!dap.clientFeatures.contains(eClientFeatureRunInTerminalRequest))
         return llvm::make_error<DAPError>(
-            R"(Client does not support RunInTerminal. Please set "console": "integratedConsole" in your launch configuration)");
+            R"(Client does not support RunInTerminal. Please set '"console": "integratedConsole"' in your launch configuration)");
 
       if (llvm::Error err = RunInTerminal(dap, arguments))
         return err;

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -234,6 +234,10 @@ llvm::Error BaseRequestHandler::LaunchProcess(
     ScopeSyncMode scope_sync_mode(dap.debugger);
 
     if (arguments.console != protocol::eConsoleInternal) {
+      if (!dap.clientFeatures.contains(eClientFeatureRunInTerminalRequest))
+        return llvm::make_error<DAPError>(
+            R"(Client does not support RunInTerminal. Please set "console": "integratedConsole" in your launch configuration)");
+
       if (llvm::Error err = RunInTerminal(dap, arguments))
         return err;
     } else if (launchCommands.empty()) {


### PR DESCRIPTION
Check if the client supports RunInTerminal before attempting to run in the preferred terminal.
One less unknown reason for failed to launch