### PR TITLE
[libc++] Add link to the running job from the benchmarking bot

### DIFF
--- a/.github/workflows/libcxx-run-benchmarks.yml
+++ b/.github/workflows/libcxx-run-benchmarks.yml
@@ -37,15 +37,18 @@ jobs:
         with:
           python-version: '3.14'
 
-      - name: Extract information from the PR
-        id: vars
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
+      - name: Setup virtual environment
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
           python -m pip install pygithub
 
+      - name: Extract information from the PR
+        id: vars
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          source .venv/bin/activate
           cat <<EOF | python >> ${GITHUB_OUTPUT}
           import github
           repo = github.Github(auth=github.Auth.Token("${{ github.token }}")).get_repo("${{ github.repository }}")
@@ -58,7 +61,7 @@ jobs:
 
       - name: Update comment with link to the job
         run: |
-          source .venv/bin/activate && cd repo
+          source .venv/bin/activate
           cat <<EOF | python
           import github
           repo = github.Github(auth=github.Auth.Token("${{ github.token }}")).get_repo("${{ github.repository }}")

--- a/.github/workflows/libcxx-run-benchmarks.yml
+++ b/.github/workflows/libcxx-run-benchmarks.yml
@@ -56,6 +56,18 @@ jobs:
           BENCHMARKS=$(echo "$COMMENT_BODY" | sed -nE 's/\/libcxx-bot benchmark (.+)/\1/p')
           echo "benchmarks=${BENCHMARKS}" >> ${GITHUB_OUTPUT}
 
+      - name: Update comment with link to the job
+        run: |
+          source .venv/bin/activate && cd repo
+          cat <<EOF | python
+          import github
+          repo = github.Github(auth=github.Auth.Token("${{ github.token }}")).get_repo("${{ github.repository }}")
+          pr = repo.get_pull(${{ github.event.issue.number }})
+          comment = pr.get_issue_comment(${{ github.event.comment.id }})
+          add_text = "> _Running benchmarks in ${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}/job/${{ env.GITHUB_JOB }}_"
+          comment.edit('\n\n'.join([comment.body, add_text]))
+          EOF
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ steps.vars.outputs.pr_head }}

--- a/.github/workflows/libcxx-run-benchmarks.yml
+++ b/.github/workflows/libcxx-run-benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          python -m pip install pygithub
+          python -m pip install pygithub==2.8.1
 
       - name: Extract information from the PR
         id: vars


### PR DESCRIPTION
This allows following the progress of the benchmarking job and also spotting when it fails.

Fixes #158296