### PR TITLE
[SPIR-V] Emit ceil(Bitwidth / 32) words during OpConstant creation

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -171,15 +171,17 @@ void addNumImm(const APInt &Imm, MachineInstrBuilder &MIB) {
     // Asm Printer needs this info to print 64-bit operands correctly
     MIB.getInstr()->setAsmPrinterFlag(SPIRV::ASM_PRINTER_WIDTH64);
     return;
-  } else if (Bitwidth <= 128) {
-    uint32_t LowBits = Imm.getRawData()[0] & 0xffffffff;
-    uint32_t MidBits0 = (Imm.getRawData()[0] >> 32) & 0xffffffff;
-    uint32_t MidBits1 = Imm.getRawData()[1] & 0xffffffff;
-    uint32_t HighBits = (Imm.getRawData()[1] >> 32) & 0xffffffff;
-    MIB.addImm(LowBits).addImm(MidBits0).addImm(MidBits1).addImm(HighBits);
+  } else {
+    // Emit ceil(Bitwidth / 32) words to conform SPIR-V spec.
+    unsigned NumWords = (Bitwidth + 31) / 32;
+    for (unsigned I = 0; I < NumWords; ++I) {
+      unsigned LimbIdx = I / 2;
+      unsigned LimbShift = (I % 2) * 32;
+      uint32_t Word = (Imm.getRawData()[LimbIdx] >> LimbShift) & 0xffffffff;
+      MIB.addImm(Word);
+    }
     return;
   }
-  report_fatal_error("Unsupported constant bitwidth");
 }
 
 void buildOpName(Register Target, const StringRef &Name,

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/apint-constant.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/apint-constant.ll
@@ -4,14 +4,20 @@
 ; OpConstant with multi-word literals.
 
 ; CHECK-DAG: %[[#INT128:]] = OpTypeInt 128 0
+; CHECK-DAG: %[[#INT96:]] = OpTypeInt 96 0
 ; CHECK-DAG: %[[#NEG128:]] = OpConstant %[[#INT128]] 4294965247 4294967295 4294967295 4294967295
 ; CHECK-DAG: %[[#ONE128:]] = OpConstant %[[#INT128]] 1 0 0 0
 ; CHECK-DAG: %[[#BOUNDARY:]] = OpConstant %[[#INT128]] 4294967295 4294967295 0 0
 ; CHECK-DAG: %[[#ZERO128:]] = OpConstantNull %[[#INT128]]
+; CHECK-DAG: %[[#NEG96:]] = OpConstant %[[#INT96]] 4294967295 4294967295 4294967295
+; CHECK-DAG: %[[#OVER64:]] = OpConstant %[[#INT96]] 1 0 1
 ; CHECK: OpStore %[[#]] %[[#NEG128]] Aligned 16
 ; CHECK: OpStore %[[#]] %[[#ONE128]] Aligned 16
 ; CHECK: OpStore %[[#]] %[[#BOUNDARY]] Aligned 16
 ; CHECK: OpStore %[[#]] %[[#ZERO128]] Aligned 16
+
+; CHECK: OpStore %[[#]] %[[#NEG96]] Aligned 16
+; CHECK: OpStore %[[#]] %[[#OVER64]] Aligned 16
 
 define spir_func void @test_i128_const(ptr addrspace(4) %p) addrspace(4) {
 entry:
@@ -19,5 +25,12 @@ entry:
   store i128 1, ptr addrspace(4) %p, align 16
   store i128 18446744073709551615, ptr addrspace(4) %p, align 16
   store i128 0, ptr addrspace(4) %p, align 16
+  ret void
+}
+
+define spir_func void @test_i96_const(ptr addrspace(4) %p) addrspace(4) {
+entry:
+  store i96 -1, ptr addrspace(4) %p, align 16
+  store i96 18446744073709551617, ptr addrspace(4) %p, align 16
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/apint-constant.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/apint-constant.ll
@@ -5,12 +5,17 @@
 
 ; CHECK-DAG: %[[#INT128:]] = OpTypeInt 128 0
 ; CHECK-DAG: %[[#INT96:]] = OpTypeInt 96 0
+; CHECK-DAG: %[[#INT97:]] = OpTypeInt 97 0
 ; CHECK-DAG: %[[#NEG128:]] = OpConstant %[[#INT128]] 4294965247 4294967295 4294967295 4294967295
 ; CHECK-DAG: %[[#ONE128:]] = OpConstant %[[#INT128]] 1 0 0 0
 ; CHECK-DAG: %[[#BOUNDARY:]] = OpConstant %[[#INT128]] 4294967295 4294967295 0 0
 ; CHECK-DAG: %[[#ZERO128:]] = OpConstantNull %[[#INT128]]
 ; CHECK-DAG: %[[#NEG96:]] = OpConstant %[[#INT96]] 4294967295 4294967295 4294967295
 ; CHECK-DAG: %[[#OVER64:]] = OpConstant %[[#INT96]] 1 0 1
+; CHECK-DAG: %[[#NEG97:]] = OpConstant %[[#INT97]] 4294967295 4294967295 4294967295 1
+; CHECK-DAG: %[[#OVER64_I97:]] = OpConstant %[[#INT97]] 1 0 1 0
+; CHECK-DAG: %[[#I97_MAX:]] = OpConstant %[[#INT97]] 0 0 0 1
+
 ; CHECK: OpStore %[[#]] %[[#NEG128]] Aligned 16
 ; CHECK: OpStore %[[#]] %[[#ONE128]] Aligned 16
 ; CHECK: OpStore %[[#]] %[[#BOUNDARY]] Aligned 16
@@ -18,6 +23,10 @@
 
 ; CHECK: OpStore %[[#]] %[[#NEG96]] Aligned 16
 ; CHECK: OpStore %[[#]] %[[#OVER64]] Aligned 16
+
+; CHECK: OpStore %[[#]] %[[#NEG97]] Aligned 16
+; CHECK: OpStore %[[#]] %[[#OVER64_I97]] Aligned 16
+; CHECK: OpStore %[[#]] %[[#I97_MAX]] Aligned 16
 
 define spir_func void @test_i128_const(ptr addrspace(4) %p) addrspace(4) {
 entry:
@@ -32,5 +41,13 @@ define spir_func void @test_i96_const(ptr addrspace(4) %p) addrspace(4) {
 entry:
   store i96 -1, ptr addrspace(4) %p, align 16
   store i96 18446744073709551617, ptr addrspace(4) %p, align 16
+  ret void
+}
+
+define spir_func void @test_i97_const(ptr addrspace(4) %p) addrspace(4) {
+entry:
+  store i97 -1, ptr addrspace(4) %p, align 16
+  store i97 18446744073709551617, ptr addrspace(4) %p, align 16
+  store i97 79228162514264337593543950336, ptr addrspace(4) %p, align 16
   ret void
 }


### PR DESCRIPTION
Fixes error of handing constant integers with width in (64; 128) range.
Found during review of
https://github.com/llvm/llvm-project/pull/180182