### PR TITLE
[lldb] add cross platform test commands in Makefile.rules

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -37,6 +37,29 @@
 # Uncomment line below for debugging shell commands
 # SHELL = /bin/sh -x
 
+# Cross platform shell commands
+ifeq "$(OS)" "Windows_NT"
+	MKDIR_P = md $(subst /,\,$(1)) > nul 2>&1 || (exit 0)
+	CP = copy $(subst /,\,$(1)) $(subst /,\,$(2))
+	CP_R = xcopy $(subst /,\,$(1)) $(subst /,\,$(2)) /s /e /y
+	RM = del $(subst /,\,$(1)) > nul 2>&1 || (exit 0)
+	RM_F = del /f /q $(subst /,\,$(1))
+	RM_RF = rd /s /q $(subst /,\,$(1))
+	LN_SF = mklink /D "$(subst /,\,$(2))" "$(subst /,\,$(1))"
+	ECHO = echo $(1)
+	ECHO_TO_FILE = echo $(1) > $(subst /,\,$(2))
+else
+	MKDIR_P = mkdir -p $(1)
+	CP = cp $(1) $(2)
+	CP_R = cp -r $(1) $(2)
+	RM = rm $(1) > /dev/null 2>&1 || true
+	RM_F = rm -f $(1)
+	RM_RF = rm -rf $(1)
+	LN_SF = ln -sf $(1) $(2)
+	ECHO = echo "$(1)"
+	ECHO_TO_FILE = echo $(1) > $(2)
+endif
+
 # Suppress built-in suffix rules. We explicitly define rules for %.o.
 .SUFFIXES:
 


### PR DESCRIPTION
This patch adds cross platform (Darwin, Linux, Windows) commands in `Makefile.rules` which is used to build lldb test targets.

This maps POSIX commands like `mkdir -p` to their Windows equivalent, which allows to create cross platform `Makefile` for lldb's test targets. This is currently not needed by any test but might become useful later as we are working on enabling more lldb Windows tests.

This was originally done in the `swiftlang/llvm-project` fork (https://github.com/swiftlang/llvm-project/pull/12127)