### PR TITLE
[LifetimeSafety] Treat std::unique_ptr::release() as a move operation

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -66,6 +66,11 @@ bool isGslPointerType(QualType QT);
 // Tells whether the type is annotated with [[gsl::Owner]].
 bool isGslOwnerType(QualType QT);
 
+// Returns true if the given method is std::unique_ptr::release().
+// This is treated as a move in lifetime analysis to avoid false-positives
+// when ownership is manually transferred.
+bool isUniquePtrRelease(const CXXMethodDecl &MD);
+
 // Returns true if the given method invalidates iterators or references to
 // container elements (e.g. vector::push_back).
 bool isContainerInvalidationMethod(const CXXMethodDecl &MD);

--- a/clang/test/Sema/Inputs/lifetime-analysis.h
+++ b/clang/test/Sema/Inputs/lifetime-analysis.h
@@ -129,6 +129,7 @@ struct unique_ptr {
   unique_ptr();
   unique_ptr(unique_ptr<T>&&);
   ~unique_ptr();
+  T* release();
   T &operator*();
   T *get() const;
 };

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -1456,6 +1456,18 @@ void wrong_use_of_move_is_permissive() {
   }         // expected-note {{destroyed here}}
   (void)p;  // expected-note {{later used here}}
 }
+
+void take(int*);
+void test_release_no_uaf() {
+  int* r;
+  // Calling release() marks p as moved from, so its destruction doesn't invalidate r.
+  {
+    std::unique_ptr<int> p;
+    r = p.get();        // expected-warning-re {{object whose reference {{.*}} may have been moved}}
+    take(p.release());  // expected-note {{potentially moved here}}
+  }                     // expected-note {{destroyed here}}
+  (void)*r;             // expected-note {{later used here}}
+}
 } // namespace strict_warn_on_move
 
 // Implicit this annotations with redecls.


### PR DESCRIPTION
Add support for `std::unique_ptr::release()` in lifetime analysis to avoid false positives when ownership is manually transferred via `release()`.

- Added a new function `isUniquePtrRelease()` to detect when `std::unique_ptr::release()` is called
- Modified `handleInvalidatingCall()` to mark the unique_ptr as moved when release() is called

When manually transferring ownership using `std::unique_ptr::release()`, the lifetime analysis would previously generate false positive use-after-free warnings. This change treats `release()` as a move operation, correctly modeling the ownership transfer semantics and reducing false positives in code that manually manages ownership.