### PR TITLE
Reapply [Offload][lit] Link against SPIR-V DeviceRTL if present

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -166,7 +166,8 @@ elif config.operating_system == 'Darwin':
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
 else: # Unices
-    if config.libomptarget_current_target != "nvptx64-nvidia-cuda":
+    if config.libomptarget_current_target != "nvptx64-nvidia-cuda" and \
+       not config.libomptarget_current_target.startswith('spirv'):
         config.test_flags += " -nogpulib"
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
@@ -214,7 +215,7 @@ def add_libraries(source):
     if "gpu" not in config.available_features:
         return source
     if "intelgpu" in config.available_features:
-        # There is no DeviceRTL for Intel yet and libc doesn't work.
+        # SPIR-V uses an out-of-tree linker and libc doesn't work.
         return source
     if config.libomptarget_has_libc:
         return source + " -Xoffload-linker -lc " + \

--- a/offload/test/mapping/firstprivate_aligned.cpp
+++ b/offload/test/mapping/firstprivate_aligned.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compilexx-generic -O3 && %libomptarget-run-generic
-// XFAIL: intelgpu
 
 #include <stdio.h>
 


### PR DESCRIPTION
I'll merge this at the same time as some llvm-zorg changes that start building the DeviceRTL.

We only see one new test passing because everything still fails because of the issue described in https://github.com/llvm/llvm-project/pull/178980

Once a fix for that issue is merged we will see many new passes.