### PR TITLE
[flang] Fix -debug crash from VScaleAttrPass

### DIFF
--- a/flang/include/flang/Optimizer/Transforms/Passes.td
+++ b/flang/include/flang/Optimizer/Transforms/Passes.td
@@ -399,10 +399,10 @@ def VScaleAttr : Pass<"vscale-attr", "mlir::func::FuncOp"> {
      Set an attribute for the vscale range on functions, to allow scalable
      vector operations to be used on processors with variable vector length.
   }];
-  let options = [
-    Option<"vscaleRange", "vscale-range",
-           "std::pair<unsigned, unsigned>", /*default=*/"std::pair<unsigned, unsigned>{}",
-           "vector scale range">,
+  let options = [Option<"vscaleMin", "vscale-min", "unsigned", /*default=*/"1",
+                        "vector scale minimum value. Defaults to \"1\"">,
+                 Option<"vscaleMax", "vscale-max", "unsigned", /*default=*/"0",
+                        "vector scale maximum value. Defaults to \"0\"">,
   ];
 }
 

--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -383,7 +383,7 @@ void createDefaultFIRCodeGenPassPipeline(mlir::PassManager &pm,
   fir::addCompilerGeneratedNamesConversionPass(pm);
 
   if (config.VScaleMin != 0)
-    pm.addPass(fir::createVScaleAttr({{config.VScaleMin, config.VScaleMax}}));
+    pm.addPass(fir::createVScaleAttr({config.VScaleMin, config.VScaleMax}));
 
   // Add function attributes
   mlir::LLVM::framePointerKind::FramePointerKind framePointerKind;

--- a/flang/test/Transforms/vscale-attr.fir
+++ b/flang/test/Transforms/vscale-attr.fir
@@ -1,0 +1,24 @@
+// RUN: fir-opt --vscale-attr %s | FileCheck %s --check-prefix=CHECK-DEFAULT
+// RUN: fir-opt --vscale-attr="vscale-min=4" %s | FileCheck %s --check-prefix=CHECK-MIN
+// RUN: fir-opt --vscale-attr="vscale-max=16" %s | FileCheck %s --check-prefix=CHECK-MAX
+// RUN: fir-opt --vscale-attr="vscale-min=8 vscale-max=16" %s | FileCheck %s --check-prefix=CHECK-BOTH
+// RUN: fir-opt --vscale-attr="vscale-min=8 vscale-max=8" %s | FileCheck %s --check-prefix=CHECK-EQUAL
+// RUN: not fir-opt --vscale-attr="vscale-min=0 vscale-max=4" %s 2>&1 | FileCheck %s --check-prefix=VSCALE-MIN-0
+// RUN: not fir-opt --vscale-attr="vscale-min=3 vscale-max=4" %s 2>&1 | FileCheck %s --check-prefix=VSCALE-MIN-NO-PO2
+// RUN: not fir-opt --vscale-attr="vscale-max=6" %s 2>&1 | FileCheck %s --check-prefix=VSCALE-MAX-NO-PO2
+// RUN: not fir-opt --vscale-attr="vscale-min=16 vscale-max=8" %s 2>&1 | FileCheck %s --check-prefix=VSCALE-MIN-GREATER
+
+
+// CHECK-DEFAULT: attributes {vscale_range = #llvm.vscale_range<minRange = 1 : i32, maxRange = 0 : i32>}
+// CHECK-MIN: attributes {vscale_range = #llvm.vscale_range<minRange = 4 : i32, maxRange = 0 : i32>}
+// CHECK-MAX: attributes {vscale_range = #llvm.vscale_range<minRange = 1 : i32, maxRange = 16 : i32>}
+// CHECK-BOTH: attributes {vscale_range = #llvm.vscale_range<minRange = 8 : i32, maxRange = 16 : i32>}
+// CHECK-EQUAL: attributes {vscale_range = #llvm.vscale_range<minRange = 8 : i32, maxRange = 8 : i32>}
+
+// VSCALE-MIN-0:      VScaleAttr: vscaleMin has to be a power-of-two greater than 0
+// VSCALE-MIN-NO-PO2: VScaleAttr: vscaleMin has to be a power-of-two greater than 0
+// VSCALE-MAX-NO-PO2: VScaleAttr: vscaleMax has to be a power-of-two greater-than-or-equal to vscaleMin or 0 to signify an unbounded maximum
+// VSCALE-MIN-GREATER: VScaleAttr: vscaleMax has to be a power-of-two greater-than-or-equal to vscaleMin or 0 to signify an unbounded maximum
+func.func @_QPtest(%arg0: !fir.ref<i32> {fir.bindc_name = "x"}) {
+  return
+}


### PR DESCRIPTION
This pass splits up the `vscaleRange` pass-option from the `VScaleAttrPass` into `vscaleMin` and `vscaleMax` respectively, since a `std::pair<>` cannot be used as a cli-option and crashes when running `flang -march=rv64gcv -O3 file.f90 -mmlir -debug`.

Since the options can now be set individually I added some error checking following the semantics described in the langref https://llvm.org/docs/LangRef.html#function-attributes.

I also added tests since there were none for only this pass before.