### PR TITLE
[clang]: immediate address of build issue

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4954,6 +4954,7 @@ recurse:
   case Expr::CXXReflectExprClass: {
     // TODO(Reflection): implement this after introducing std::meta::info
     assert(false && "unimplemented");
+    LLVM_FALLTHROUGH;
   }
 
   // FIXME: invent manglings for all these.

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4954,7 +4954,7 @@ recurse:
   case Expr::CXXReflectExprClass: {
     // TODO(Reflection): implement this after introducing std::meta::info
     assert(false && "unimplemented");
-    LLVM_FALLTHROUGH;
+    break;
   }
 
   // FIXME: invent manglings for all these.

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -13058,6 +13058,7 @@ template <typename Derived>
 ExprResult TreeTransform<Derived>::TransformCXXReflectExpr(CXXReflectExpr *E) {
   // TODO(reflection): Implement its transform
   assert(false && "not implemented yet");
+  return ExprError();
 }
 
 template<typename Derived>

--- a/clang/test/CodeGenCXX/reflection-mangle-itanium.cpp
+++ b/clang/test/CodeGenCXX/reflection-mangle-itanium.cpp
@@ -3,4 +3,5 @@
 
 int main() {
   (void)(^^int); // expected-error {{cannot compile this scalar expression yet}}
+  return 0;
 }

--- a/clang/test/CodeGenCXX/reflection-mangle-ms.cpp
+++ b/clang/test/CodeGenCXX/reflection-mangle-ms.cpp
@@ -3,4 +3,5 @@
 
 int main() {
   (void)(^^int); // expected-error {{cannot compile this scalar expression yet}}
+  return 0;
 }


### PR DESCRIPTION
Fixed the build issue happen [here](https://github.com/llvm/llvm-project/pull/164692)

Issue here is this [function ](https://github.com/llvm/llvm-project/blob/main/clang/lib/Sema/TreeTransform.h#L13057-L13061) doesn't return a type 