### PR TITLE
[lldb-dap][windows] fix invalid path substitution for lldb-dap

### DIFF
--- a/lldb/test/Shell/DAP/TestSTDINConsole.test
+++ b/lldb/test/Shell/DAP/TestSTDINConsole.test
@@ -1,5 +1,5 @@
 # REQUIRES: python, system-windows
-# RUN: %python %s %lldb-dap > %t.out 2>&1
+# RUN: %python %s lldb-dap > %t.out 2>&1
 # RUN: FileCheck %s --check-prefix=ERROR --allow-empty < %t.out
 
 # ERROR-NOT: DAP session error:


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/178642 added `lldb/test/Shell/DAP/TestSTDINConsole.test` with an incorrect `%lldb-dap` expansion. This patch fixes it.