### PR TITLE
Revert "[lldb-dap] fix executable substitution in tests (#179685)"

### DIFF
--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -167,9 +167,7 @@ def use_lldb_substitutions(config):
             unresolved="ignore",
         ),
         "lldb-test",
-        ToolSubst(
-            "%lldb-dap", command=FindTool("lldb-dap"), extra_args=[], unresolved="fatal"
-        ),
+        "lldb-dap",
         ToolSubst(
             "%build", command="'" + sys.executable + "'", extra_args=build_script_args
         ),


### PR DESCRIPTION
This reverts commit 082a47d8944da242993bf28980b07f2c8c3df4a6.

`ToolSubst` should only be used explicitely for passing `extra_args`. 