### PR TITLE
[objcopy][Wasm] Make strip-all remove all non-engine-interpreted sections

### DIFF
--- a/llvm/docs/CommandGuide/llvm-objcopy.rst
+++ b/llvm/docs/CommandGuide/llvm-objcopy.rst
@@ -251,6 +251,9 @@ multiple file formats.
  For COFF and Mach-O objects, remove all symbols, debug sections, and
  relocations from the output.
 
+ For WebAssembly objects, remove all custom sections except for those named
+ metadata.code.*.
+
 .. option:: --strip-debug, -g
 
  Remove all debug sections from the output.

--- a/llvm/docs/CommandGuide/llvm-strip.rst
+++ b/llvm/docs/CommandGuide/llvm-strip.rst
@@ -90,8 +90,11 @@ multiple file formats.
  within segments, except for .gnu.warning, .ARM.attribute sections and the
  section name table.
 
- For COFF objects, remove all symbols, debug sections, and relocations from the
- output.
+ For COFF and Mach-O objects, remove all symbols, debug sections, and
+ relocations from the output.
+
+ For WebAssembly objects, remove all custom sections except for those named
+ metadata.code.*.
 
 .. option:: --strip-debug, -d, -g, -S
 

--- a/llvm/lib/ObjCopy/wasm/WasmObjcopy.cpp
+++ b/llvm/lib/ObjCopy/wasm/WasmObjcopy.cpp
@@ -25,16 +25,9 @@ static bool isDebugSection(const Section &Sec) {
   return Sec.Name.starts_with(".debug") || Sec.Name.starts_with("reloc..debug");
 }
 
-static bool isLinkerSection(const Section &Sec) {
-  return Sec.Name.starts_with("reloc.") || Sec.Name == "linking";
-}
-
-static bool isNameSection(const Section &Sec) { return Sec.Name == "name"; }
-
-// Sections which are known to be "comments" or informational and do not affect
-// program semantics.
-static bool isCommentSection(const Section &Sec) {
-  return Sec.Name == "producers";
+static bool isEngineInterpretedSection(const Section &Sec) {
+  return Sec.SectionType != llvm::wasm::WASM_SEC_CUSTOM ||
+         Sec.Name.starts_with("metadata.code.");
 }
 
 static Error dumpSectionToFile(StringRef SecName, StringRef Filename,
@@ -75,8 +68,7 @@ static void removeSections(const CommonConfig &Config, Object &Obj) {
 
   if (Config.StripAll) {
     RemovePred = [RemovePred](const Section &Sec) {
-      return RemovePred(Sec) || isDebugSection(Sec) || isLinkerSection(Sec) ||
-             isNameSection(Sec) || isCommentSection(Sec);
+      return RemovePred(Sec) || !isEngineInterpretedSection(Sec);
     };
   }
 

--- a/llvm/test/tools/llvm-objcopy/wasm/basic-strip.test
+++ b/llvm/test/tools/llvm-objcopy/wasm/basic-strip.test
@@ -1,16 +1,17 @@
 ## Test that debug, name, and producers sections are stripped with --strip-all.
-## Other sections (unknown to LLVM, such as foo) are not stripped by --strip-all.
+## Unknown custom sections (such as foo) are also stripped, but metadata.code.
+## sections are not.
 # RUN: yaml2obj %s -o %t
 # RUN: llvm-strip --strip-all %t
-# RUN: obj2yaml %t | FileCheck --implicit-check-not producers --implicit-check-not .debug --implicit-check-not name %s
+# RUN: obj2yaml %t | FileCheck --implicit-check-not producers --implicit-check-not .debug --implicit-check-not name --implicit-check-not foo %s
 
 ## The default no-arg behavior is the same as --strip-all.
 # RUN: llvm-strip %t
-# RUN: obj2yaml %t | FileCheck --implicit-check-not producers --implicit-check-not .debug --implicit-check-not name %s
+# RUN: obj2yaml %t | FileCheck --implicit-check-not producers --implicit-check-not .debug --implicit-check-not name --implicit-check-not foo %s
 
 # CHECK:      Sections:
 # CHECK-NEXT:   - Type: TYPE
-# CHECK:          Name: foo
+# CHECK:          Name: metadata.code.bar
 
 --- !WASM
 FileHeader:
@@ -44,3 +45,6 @@ Sections:
   - Type: CUSTOM
     Name: foo
     Payload: CAFE
+  - Type: CUSTOM
+    Name: metadata.code.bar
+    Payload: BACE

--- a/llvm/test/tools/llvm-objcopy/wasm/strip-all.test
+++ b/llvm/test/tools/llvm-objcopy/wasm/strip-all.test
@@ -1,5 +1,5 @@
-## Test that --strip-all removes debug, linking, and producers sections, but not
-## known or unknown-custom sections.
+## Test that --strip-all removes debug, linking, and producers sections, and
+## unknown-custom sections, but not known or metadata.code. custom sections.
 # RUN: yaml2obj %s -o %t
 # RUN: llvm-objcopy --strip-all %t %t2
 # RUN: obj2yaml %t2 | FileCheck --implicit-check-not=Type: %s
@@ -13,7 +13,9 @@
 # CHECK:        - Type: CUSTOM
 # CHECK-NEXT:        Name: .objcopy.removed
 # CHECK:        - Type: CUSTOM
-# CHECK-NEXT:        Name: foo
+# CHECK-NEXT:        Name: .objcopy.removed
+# CHECK:        - Type: CUSTOM
+# CHECK-NEXT:        Name: metadata.code.bar
 
 --- !WASM
 FileHeader:
@@ -38,3 +40,6 @@ Sections:
   - Type: CUSTOM
     Name: foo
     Payload: CAFE
+  - Type: CUSTOM
+    Name: metadata.code.bar
+    Payload: BACE

--- a/llvm/tools/llvm-objcopy/CommonOpts.td
+++ b/llvm/tools/llvm-objcopy/CommonOpts.td
@@ -50,7 +50,8 @@ def p : Flag<["-"], "p">,
 def strip_all : Flag<["--"], "strip-all">,
     HelpText<"For ELF, remove all symbols and non-alloc sections not within "
              "segments, except for .gnu.warning*, .ARM.attribute, and the section name table. "
-             "For COFF and Mach-O, remove all symbols, debug sections, and relocations">;
+             "For COFF and Mach-O, remove all symbols, debug sections, and relocations. "
+             "For WebAssembly, remove all custom sections except for metadata.code.*">;
 
 def strip_all_gnu
     : Flag<["--"], "strip-all-gnu">,


### PR DESCRIPTION
Currently the default strip-all behavior is to remove sections known
to LLVM but leave others. Now that the standard specifies the section name
"metadata.code.*" as used for compiler annotations interpreted by Wasm
engines, we can more confidently give strip its more conventional behavior
of removing everything that won't be used by the engine.
