### PR TITLE
[lldb][test] Rename/remove duplicate methods in API tests

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/ordering/TestDataFormatterStdOrdering.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/ordering/TestDataFormatterStdOrdering.py
@@ -47,7 +47,7 @@ class StdOrderingTestCase(TestBase):
         self.assertEqual(frame.FindVariable("so_greater").summary, "greater")
 
     @add_test_categories(["libc++"])
-    def test_libstdcxx(self):
+    def test_libcxx(self):
         self.build(dictionary={"USE_LIBCPP": 1})
         self.do_test()
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/TestDataFormatterStdVBool.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/TestDataFormatterStdVBool.py
@@ -106,7 +106,7 @@ class StdVBoolDataFormatterTestCase(TestBase):
         self.do_test()
 
     @add_test_categories(["msvcstl"])
-    def test_libstdcxx(self):
+    def test_msvcstl(self):
         # No flags, because the "msvcstl" category checks that the MSVC STL is used by default.
         self.build()
         self.do_test()

--- a/lldb/test/API/functionalities/gdb_remote_client/TestWasm.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestWasm.py
@@ -99,9 +99,6 @@ class MyResponder(MockGDBServerResponder):
     def QEnableErrorStrings(self):
         return ""
 
-    def qfThreadInfo(self):
-        return "m1,"
-
     def qRegisterInfo(self, index):
         if index == 0:
             return "name:pc;alt-name:pc;bitsize:64;offset:0;encoding:uint;format:hex;set:General Purpose Registers;gcc:16;dwarf:16;generic:pc;"


### PR DESCRIPTION
Ran my python script from https://github.com/llvm/llvm-project/pull/97043 over the repo again and there were 2 duplicate test-cases that have been introduced since I last did this.

Also one of the WASM classes had a duplicate method which I just removed.