### PR TITLE
[AArch64][GlobalISel] Remove a couple of SUBREG_TO_REG from instruction selection.

### DIFF
--- a/llvm/test/CodeGen/AArch64/GlobalISel/fp16-copy-gpr.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/fp16-copy-gpr.mir
@@ -49,11 +49,13 @@ body:             |
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr16 = COPY $h0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:fpr16 = COPY $h1
     ; CHECK-NEXT: [[DEF:%[0-9]+]]:gpr32 = IMPLICIT_DEF
-    ; CHECK-NEXT: [[SUBREG_TO_REG:%[0-9]+]]:fpr32 = SUBREG_TO_REG [[COPY]], %subreg.hsub
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:gpr32 = COPY [[SUBREG_TO_REG]]
+    ; CHECK-NEXT: [[DEF1:%[0-9]+]]:fpr32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INSERT_SUBREG:%[0-9]+]]:fpr32 = INSERT_SUBREG [[DEF1]], [[COPY]], %subreg.hsub
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:gpr32 = COPY [[INSERT_SUBREG]]
     ; CHECK-NEXT: [[BFMWri:%[0-9]+]]:gpr32 = BFMWri [[DEF]], [[COPY2]], 0, 15
-    ; CHECK-NEXT: [[SUBREG_TO_REG1:%[0-9]+]]:fpr32 = SUBREG_TO_REG [[COPY1]], %subreg.hsub
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:gpr32 = COPY [[SUBREG_TO_REG1]]
+    ; CHECK-NEXT: [[DEF2:%[0-9]+]]:fpr32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INSERT_SUBREG1:%[0-9]+]]:fpr32 = INSERT_SUBREG [[DEF2]], [[COPY1]], %subreg.hsub
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:gpr32 = COPY [[INSERT_SUBREG1]]
     ; CHECK-NEXT: [[BFMWri1:%[0-9]+]]:gpr32 = BFMWri [[BFMWri]], [[COPY3]], 16, 15
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:gpr64sp = COPY $x0
     ; CHECK-NEXT: STRWui [[BFMWri1]], [[COPY4]], 0 :: (store (s32) into %ir.addr, align 2)

--- a/llvm/test/CodeGen/AArch64/GlobalISel/inline-asm.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/inline-asm.ll
@@ -32,7 +32,9 @@ define i16 @test_16bit_reg(i16 %x) {
 ; O0-NEXT:    //APP
 ; O0-NEXT:    nop
 ; O0-NEXT:    //NO_APP
-; O0-NEXT:    // kill: def $s0 killed $h0
+; O0-NEXT:    fmov s1, s0
+; O0-NEXT:    // implicit-def: $s0
+; O0-NEXT:    fmov s0, s1
 ; O0-NEXT:    fmov w0, s0
 ; O0-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/AArch64/GlobalISel/opt-fold-ext-tbz-tbnz.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/opt-fold-ext-tbz-tbnz.mir
@@ -80,8 +80,9 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.0(0x40000000), %bb.1(0x40000000)
   ; CHECK-NEXT:   liveins: $h0
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[SUBREG_TO_REG:%[0-9]+]]:fpr32 = SUBREG_TO_REG $h0, %subreg.hsub
-  ; CHECK-NEXT:   %copy:gpr32all = COPY [[SUBREG_TO_REG]]
+  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:fpr32 = IMPLICIT_DEF
+  ; CHECK-NEXT:   [[INSERT_SUBREG:%[0-9]+]]:fpr32 = INSERT_SUBREG [[DEF]], $h0, %subreg.hsub
+  ; CHECK-NEXT:   %copy:gpr32all = COPY [[INSERT_SUBREG]]
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr32 = COPY %copy
   ; CHECK-NEXT:   TBNZW [[COPY]], 3, %bb.1
   ; CHECK-NEXT:   B %bb.0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/preselect-process-phis.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/preselect-process-phis.mir
@@ -32,8 +32,9 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[PHI:%[0-9]+]]:gpr32 = PHI [[CSELWr]], %bb.1, %8, %bb.2
   ; CHECK-NEXT:   [[FCVTHSr:%[0-9]+]]:fpr16 = nofpexcept FCVTHSr [[COPY]], implicit $fpcr
-  ; CHECK-NEXT:   [[SUBREG_TO_REG:%[0-9]+]]:fpr32 = SUBREG_TO_REG [[FCVTHSr]], %subreg.hsub
-  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32all = COPY [[SUBREG_TO_REG]]
+  ; CHECK-NEXT:   [[DEF3:%[0-9]+]]:fpr32 = IMPLICIT_DEF
+  ; CHECK-NEXT:   [[INSERT_SUBREG:%[0-9]+]]:fpr32 = INSERT_SUBREG [[DEF3]], [[FCVTHSr]], %subreg.hsub
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr32all = COPY [[INSERT_SUBREG]]
   ; CHECK-NEXT:   STRHHui [[PHI]], [[DEF1]], 0 :: (store (s16) into `ptr undef`)
   ; CHECK-NEXT:   B %bb.2
   bb.0:
@@ -163,8 +164,9 @@ body:             |
   ; CHECK-NEXT:   %gp_phi1:gpr32 = PHI %gpr_1, %bb.3, %gpr_2, %bb.2
   ; CHECK-NEXT:   %gp_phi2:gpr32 = PHI %gpr_1, %bb.3, %gpr_2, %bb.2
   ; CHECK-NEXT:   %gp_phi3:gpr32 = PHI %gpr_1, %bb.3, %gpr_2, %bb.2
-  ; CHECK-NEXT:   [[SUBREG_TO_REG:%[0-9]+]]:fpr32 = SUBREG_TO_REG %fp_phi, %subreg.hsub
-  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gpr32all = COPY [[SUBREG_TO_REG]]
+  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:fpr32 = IMPLICIT_DEF
+  ; CHECK-NEXT:   [[INSERT_SUBREG:%[0-9]+]]:fpr32 = INSERT_SUBREG [[DEF]], %fp_phi, %subreg.hsub
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gpr32all = COPY [[INSERT_SUBREG]]
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.5:
   ; CHECK-NEXT:   %use_fp_phi:gpr32 = PHI %gpr_1, %bb.0, [[COPY2]], %bb.4

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-build-vector.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-build-vector.mir
@@ -249,9 +249,10 @@ body:             |
     ; CHECK-LABEL: name: undef_elts_to_subreg_to_reg
     ; CHECK: liveins: $s0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %val:fpr32 = COPY $s0
-    ; CHECK-NEXT: %bv:fpr128 = SUBREG_TO_REG %val, %subreg.ssub
-    ; CHECK-NEXT: $q0 = COPY %bv
+    ; CHECK-NEXT: %val:fpr32(s32) = COPY $s0
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(<4 x s32>) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: %bv:fpr128(<4 x s32>) = INSERT_SUBREG [[DEF]](<4 x s32>), %val(s32), %subreg.ssub
+    ; CHECK-NEXT: $q0 = COPY %bv(<4 x s32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
     %val:fpr(s32) = COPY $s0
     %undef:fpr(s32) = G_IMPLICIT_DEF

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-cmp.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-cmp.mir
@@ -231,8 +231,9 @@ body:             |
     ; CHECK-LABEL: name: cmp_arith_extended_s32
     ; CHECK: liveins: $w0, $w1, $h0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[SUBREG_TO_REG:%[0-9]+]]:fpr32 = SUBREG_TO_REG $h0, %subreg.hsub
-    ; CHECK-NEXT: %reg0:gpr32all = COPY [[SUBREG_TO_REG]]
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:fpr32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INSERT_SUBREG:%[0-9]+]]:fpr32 = INSERT_SUBREG [[DEF]], $h0, %subreg.hsub
+    ; CHECK-NEXT: %reg0:gpr32all = COPY [[INSERT_SUBREG]]
     ; CHECK-NEXT: %reg1:gpr32sp = COPY $w1
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr32 = COPY %reg0
     ; CHECK-NEXT: [[SUBSWrx:%[0-9]+]]:gpr32 = SUBSWrx %reg1, [[COPY]], 10, implicit-def $nzcv

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-extract-vector-elt-with-extend.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-extract-vector-elt-with-extend.mir
@@ -323,8 +323,9 @@ body:             |
     ; CHECK-LABEL: name: skip_anyext_to_16
     ; CHECK: [[DEF:%[0-9]+]]:fpr128 = IMPLICIT_DEF
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr8 = COPY [[DEF]].bsub
-    ; CHECK-NEXT: [[SUBREG_TO_REG:%[0-9]+]]:fpr32 = SUBREG_TO_REG [[COPY]], %subreg.bsub
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr32all = COPY [[SUBREG_TO_REG]]
+    ; CHECK-NEXT: [[DEF1:%[0-9]+]]:fpr32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INSERT_SUBREG:%[0-9]+]]:fpr32 = INSERT_SUBREG [[DEF1]], [[COPY]], %subreg.bsub
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr32all = COPY [[INSERT_SUBREG]]
     ; CHECK-NEXT: $w0 = COPY [[COPY1]]
     %5:fpr(<16 x s8>) = G_IMPLICIT_DEF
     %12:gpr(s64) = G_CONSTANT i64 0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-insert-extract.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-insert-extract.mir
@@ -13,14 +13,16 @@ body:             |
     ; CHECK-LABEL: name: insert_gprx
     ; CHECK: liveins: $x0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr32 = COPY $w0
-    ; CHECK-NEXT: [[DEF:%[0-9]+]]:gpr64 = IMPLICIT_DEF
-    ; CHECK-NEXT: [[SUBREG_TO_REG:%[0-9]+]]:gpr64 = SUBREG_TO_REG [[COPY]], %subreg.sub_32
-    ; CHECK-NEXT: [[BFMXri:%[0-9]+]]:gpr64 = BFMXri [[DEF]], [[SUBREG_TO_REG]], 0, 31
-    ; CHECK-NEXT: [[SUBREG_TO_REG1:%[0-9]+]]:gpr64 = SUBREG_TO_REG [[COPY]], %subreg.sub_32
-    ; CHECK-NEXT: [[BFMXri1:%[0-9]+]]:gpr64 = BFMXri [[DEF]], [[SUBREG_TO_REG1]], 51, 31
-    ; CHECK-NEXT: $x0 = COPY [[BFMXri]]
-    ; CHECK-NEXT: $x1 = COPY [[BFMXri1]]
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr32(s32) = COPY $w0
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:gpr64(s64) = IMPLICIT_DEF
+    ; CHECK-NEXT: [[DEF1:%[0-9]+]]:_(s64) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[INSERT_SUBREG:%[0-9]+]]:gpr64(s64) = INSERT_SUBREG [[DEF1]](s64), [[COPY]](s32), %subreg.sub_32
+    ; CHECK-NEXT: [[BFMXri:%[0-9]+]]:gpr64(s64) = BFMXri [[DEF]](s64), [[INSERT_SUBREG]](s64), 0, 31
+    ; CHECK-NEXT: [[DEF2:%[0-9]+]]:_(s64) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[INSERT_SUBREG1:%[0-9]+]]:gpr64(s64) = INSERT_SUBREG [[DEF2]](s64), [[COPY]](s32), %subreg.sub_32
+    ; CHECK-NEXT: [[BFMXri1:%[0-9]+]]:gpr64(s64) = BFMXri [[DEF]](s64), [[INSERT_SUBREG1]](s64), 51, 31
+    ; CHECK-NEXT: $x0 = COPY [[BFMXri]](s64)
+    ; CHECK-NEXT: $x1 = COPY [[BFMXri1]](s64)
     %0:gpr(s32) = COPY $w0
 
     %1:gpr(s64) = G_IMPLICIT_DEF

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-reduce-add.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-reduce-add.mir
@@ -18,8 +18,9 @@ body:             |
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64sp = COPY $x0
     ; CHECK-NEXT: [[LDRQui:%[0-9]+]]:fpr128 = LDRQui [[COPY]], 0 :: (load (<16 x s8>))
     ; CHECK-NEXT: [[ADDVv16i8v:%[0-9]+]]:fpr8 = ADDVv16i8v [[LDRQui]]
-    ; CHECK-NEXT: [[SUBREG_TO_REG:%[0-9]+]]:fpr32 = SUBREG_TO_REG [[ADDVv16i8v]], %subreg.bsub
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr32all = COPY [[SUBREG_TO_REG]]
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:fpr32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INSERT_SUBREG:%[0-9]+]]:fpr32 = INSERT_SUBREG [[DEF]], [[ADDVv16i8v]], %subreg.bsub
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr32all = COPY [[INSERT_SUBREG]]
     ; CHECK-NEXT: $w0 = COPY [[COPY1]]
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %0:gpr(p0) = COPY $x0
@@ -49,8 +50,9 @@ body:             |
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64sp = COPY $x0
     ; CHECK-NEXT: [[LDRQui:%[0-9]+]]:fpr128 = LDRQui [[COPY]], 0 :: (load (<8 x s16>))
     ; CHECK-NEXT: [[ADDVv8i16v:%[0-9]+]]:fpr16 = ADDVv8i16v [[LDRQui]]
-    ; CHECK-NEXT: [[SUBREG_TO_REG:%[0-9]+]]:fpr32 = SUBREG_TO_REG [[ADDVv8i16v]], %subreg.hsub
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr32all = COPY [[SUBREG_TO_REG]]
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:fpr32 = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INSERT_SUBREG:%[0-9]+]]:fpr32 = INSERT_SUBREG [[DEF]], [[ADDVv8i16v]], %subreg.hsub
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr32all = COPY [[INSERT_SUBREG]]
     ; CHECK-NEXT: $w0 = COPY [[COPY1]]
     ; CHECK-NEXT: RET_ReallyLR implicit $w0
     %0:gpr(p0) = COPY $x0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-zext-as-copy.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-zext-as-copy.mir
@@ -24,8 +24,9 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[DEF:%[0-9]+]]:gpr64common = IMPLICIT_DEF
     ; CHECK-NEXT: [[LDRBBui:%[0-9]+]]:gpr32 = LDRBBui [[DEF]], 0 :: (load (s8))
-    ; CHECK-NEXT: [[SUBREG_TO_REG:%[0-9]+]]:gpr64all = SUBREG_TO_REG [[LDRBBui]], %subreg.sub_32
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64 = COPY [[SUBREG_TO_REG]]
+    ; CHECK-NEXT: [[DEF1:%[0-9]+]]:gpr64all = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INSERT_SUBREG:%[0-9]+]]:gpr64all = INSERT_SUBREG [[DEF1]], [[LDRBBui]], %subreg.sub_32
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64 = COPY [[INSERT_SUBREG]]
     ; CHECK-NEXT: [[ANDXri:%[0-9]+]]:gpr64sp = ANDXri [[COPY]], 4096
     ; CHECK-NEXT: $x0 = COPY [[ANDXri]]
     %3:gpr(p0) = G_IMPLICIT_DEF

--- a/llvm/test/CodeGen/AArch64/neon-dotreduce.ll
+++ b/llvm/test/CodeGen/AArch64/neon-dotreduce.ll
@@ -589,14 +589,14 @@ define i32 @test_sdot_v5i8_double(<5 x i8> %a, <5 x i8> %b, <5 x i8> %c, <5 x i8
 ; CHECK-GI-LABEL: test_sdot_v5i8_double:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-GI-NEXT:    mov b17, v0.b[1]
+; CHECK-GI-NEXT:    mov b16, v0.b[1]
 ; CHECK-GI-NEXT:    fmov w8, s0
 ; CHECK-GI-NEXT:    // kill: def $d1 killed $d1 def $q1
 ; CHECK-GI-NEXT:    // kill: def $d2 killed $d2 def $q2
 ; CHECK-GI-NEXT:    // kill: def $d3 killed $d3 def $q3
 ; CHECK-GI-NEXT:    fmov w11, s1
 ; CHECK-GI-NEXT:    mov b25, v1.b[1]
-; CHECK-GI-NEXT:    mov b16, v1.b[2]
+; CHECK-GI-NEXT:    mov b17, v1.b[2]
 ; CHECK-GI-NEXT:    mov b7, v1.b[3]
 ; CHECK-GI-NEXT:    mov b5, v1.b[4]
 ; CHECK-GI-NEXT:    mov b22, v2.b[1]
@@ -604,7 +604,7 @@ define i32 @test_sdot_v5i8_double(<5 x i8> %a, <5 x i8> %b, <5 x i8> %c, <5 x i8
 ; CHECK-GI-NEXT:    sxtb w9, w8
 ; CHECK-GI-NEXT:    sxtb w11, w11
 ; CHECK-GI-NEXT:    mov b24, v0.b[2]
-; CHECK-GI-NEXT:    fmov w8, s17
+; CHECK-GI-NEXT:    fmov w8, s16
 ; CHECK-GI-NEXT:    mov b6, v0.b[3]
 ; CHECK-GI-NEXT:    mov b4, v0.b[4]
 ; CHECK-GI-NEXT:    fmov s1, w9
@@ -617,7 +617,7 @@ define i32 @test_sdot_v5i8_double(<5 x i8> %a, <5 x i8> %b, <5 x i8> %c, <5 x i8
 ; CHECK-GI-NEXT:    mov b21, v3.b[2]
 ; CHECK-GI-NEXT:    fmov w13, s23
 ; CHECK-GI-NEXT:    mov b20, v3.b[3]
-; CHECK-GI-NEXT:    mov b17, v3.b[4]
+; CHECK-GI-NEXT:    mov b16, v3.b[4]
 ; CHECK-GI-NEXT:    fmov w8, s24
 ; CHECK-GI-NEXT:    sxtb w9, w9
 ; CHECK-GI-NEXT:    sxtb w12, w12
@@ -629,7 +629,7 @@ define i32 @test_sdot_v5i8_double(<5 x i8> %a, <5 x i8> %b, <5 x i8> %c, <5 x i8
 ; CHECK-GI-NEXT:    fmov w11, s3
 ; CHECK-GI-NEXT:    sxtb w10, w10
 ; CHECK-GI-NEXT:    mov v2.h[1], w9
-; CHECK-GI-NEXT:    fmov w9, s16
+; CHECK-GI-NEXT:    fmov w9, s17
 ; CHECK-GI-NEXT:    sxtb w11, w11
 ; CHECK-GI-NEXT:    mov v1.h[2], w8
 ; CHECK-GI-NEXT:    fmov w8, s7
@@ -660,7 +660,7 @@ define i32 @test_sdot_v5i8_double(<5 x i8> %a, <5 x i8> %b, <5 x i8> %c, <5 x i8
 ; CHECK-GI-NEXT:    fmov w9, s0
 ; CHECK-GI-NEXT:    sxtb w11, w11
 ; CHECK-GI-NEXT:    mov v22.h[3], w10
-; CHECK-GI-NEXT:    fmov w10, s17
+; CHECK-GI-NEXT:    fmov w10, s16
 ; CHECK-GI-NEXT:    sxtb w8, w8
 ; CHECK-GI-NEXT:    sxtb w9, w9
 ; CHECK-GI-NEXT:    mov v1.h[4], w11


### PR DESCRIPTION
These generations of SUBREG_TO_REG seem incorrect, implying that the top bits of the input are zero where they are not necessarily. Change them to INSERT_SUBREG.