### PR TITLE
Cleanup the use of m_is_secondary_thread from PR #179799.

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3213,9 +3213,9 @@ protected:
         bool is_secondary_thread, // FIXME: Can I get rid of this?
         llvm::StringRef thread_name)
         : m_process(process), m_public_state(public_state),
-          m_private_state(private_state), 
-          m_is_secondary_thread(is_secondary_thread), m_thread_name(thread_name)
-    {}
+          m_private_state(private_state),
+          m_is_secondary_thread(is_secondary_thread),
+          m_thread_name(thread_name) {}
     // This returns false if we couldn't start up the thread.  If that happens,
     // you won't be doing any debugging today.
     bool StartupThread();

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3213,7 +3213,9 @@ protected:
         bool is_secondary_thread, // FIXME: Can I get rid of this?
         llvm::StringRef thread_name)
         : m_process(process), m_public_state(public_state),
-          m_private_state(private_state), m_thread_name(thread_name) {}
+          m_private_state(private_state), 
+          m_is_secondary_thread(is_secondary_thread), m_thread_name(thread_name)
+    {}
     // This returns false if we couldn't start up the thread.  If that happens,
     // you won't be doing any debugging today.
     bool StartupThread();
@@ -3544,7 +3546,7 @@ private:
   // temporarily spin up a secondary state thread to handle events from a hand-
   // called function on the primary private state thread.
 
-  lldb::thread_result_t RunPrivateStateThread(bool is_secondary_thread);
+  lldb::thread_result_t RunPrivateStateThread();
 
 protected:
   void HandlePrivateEvent(lldb::EventSP &event_sp);

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -3916,7 +3916,7 @@ bool Process::PrivateStateThread::StartupThread() {
       ThreadLauncher::LaunchThread(
           m_thread_name,
           [this] {
-            return m_process.RunPrivateStateThread(m_is_secondary_thread);
+            return m_process.RunPrivateStateThread();
           },
           8 * 1024 * 1024);
   if (!private_state_thread) {
@@ -4196,7 +4196,7 @@ Status Process::HaltPrivate() {
   return error;
 }
 
-thread_result_t Process::RunPrivateStateThread(bool is_secondary_thread) {
+thread_result_t Process::RunPrivateStateThread() {
   bool control_only = true;
 
   Log *log = GetLog(LLDBLog::Process);

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -3914,10 +3914,7 @@ bool Process::ShouldBroadcastEvent(Event *event_ptr) {
 bool Process::PrivateStateThread::StartupThread() {
   llvm::Expected<HostThread> private_state_thread =
       ThreadLauncher::LaunchThread(
-          m_thread_name,
-          [this] {
-            return m_process.RunPrivateStateThread();
-          },
+          m_thread_name, [this] { return m_process.RunPrivateStateThread(); },
           8 * 1024 * 1024);
   if (!private_state_thread) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Host), private_state_thread.takeError(),


### PR DESCRIPTION
This ivar was passed to the thread function for the private state thread - mostly because the equivalent variable was passed in in the original version of the code. But it was never used, so I didn't notice that the ivar equivalent wasn't being initialized.  I'm going to keep the ivar because it will be useful when debugging to easily see whether you are on the main or secondary private state thread.

So in this change, I set m_is_secondary_thread properly in the constructor, but remove passing it to the thread function since it wasn't needed there.