### PR TITLE
[MLIR][Python] Remove partial LLVM APIs in python bindings (4/n) 

### DIFF
--- a/mlir/include/mlir/Bindings/Python/Globals.h
+++ b/mlir/include/mlir/Bindings/Python/Globals.h
@@ -23,7 +23,6 @@
 #include "mlir/CAPI/Support.h"
 
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Regex.h"
 
 namespace mlir {
@@ -127,7 +126,7 @@ public:
   /// name. Note that this may trigger a load of the dialect, which can
   /// arbitrarily re-enter.
   std::optional<nanobind::object>
-  lookupOpAdaptorClass(llvm::StringRef operationName);
+  lookupOpAdaptorClass(std::string_view operationName);
 
   class MLIR_PYTHON_API_EXPORTED TracebackLoc {
   public:

--- a/mlir/include/mlir/Bindings/Python/IRAttributes.h
+++ b/mlir/include/mlir/Bindings/Python/IRAttributes.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/BuiltinTypes.h"
@@ -31,13 +32,13 @@ struct nb_buffer_info {
   ssize_t size = 0;
   const char *format = nullptr;
   ssize_t ndim = 0;
-  SmallVector<ssize_t, 4> shape;
-  SmallVector<ssize_t, 4> strides;
+  std::vector<ssize_t> shape;
+  std::vector<ssize_t> strides;
   bool readonly = false;
 
   nb_buffer_info(
       void *ptr, ssize_t itemsize, const char *format, ssize_t ndim,
-      SmallVector<ssize_t, 4> shape_in, SmallVector<ssize_t, 4> strides_in,
+      std::vector<ssize_t> shape_in, std::vector<ssize_t> strides_in,
       bool readonly = false,
       std::unique_ptr<Py_buffer, void (*)(Py_buffer *)> owned_view_in =
           std::unique_ptr<Py_buffer, void (*)(Py_buffer *)>(nullptr, nullptr));
@@ -462,11 +463,11 @@ private:
     Type *data = static_cast<Type *>(
         const_cast<void *>(mlirDenseElementsAttrGetRawData(*this)));
     // Prepare the shape for the buffer_info.
-    SmallVector<intptr_t, 4> shape;
+    std::vector<ssize_t> shape;
     for (intptr_t i = 0; i < rank; ++i)
       shape.push_back(mlirShapedTypeGetDimSize(shapedType, i));
     // Prepare the strides for the buffer_info.
-    SmallVector<intptr_t, 4> strides;
+    std::vector<ssize_t> strides;
     if (mlirDenseElementsAttrIsSplat(*this)) {
       // Splats are special, only the single value is stored.
       strides.assign(rank, 0);

--- a/mlir/include/mlir/Bindings/Python/NanobindUtils.h
+++ b/mlir/include/mlir/Bindings/Python/NanobindUtils.h
@@ -336,7 +336,7 @@ protected:
   /// Returns a new instance of the pseudo-container restricted to the given
   /// slice. Returns a nullptr object on failure.
   nanobind::object getItemSlice(PyObject *slice) {
-    ssize_t start, stop, extraStep, sliceLength;
+    Py_ssize_t start, stop, extraStep, sliceLength;
     if (PySlice_GetIndicesEx(slice, length, &start, &stop, &extraStep,
                              &sliceLength) != 0) {
       PyErr_SetString(PyExc_IndexError, "index out of range");

--- a/mlir/include/mlir/Bindings/Python/NanobindUtils.h
+++ b/mlir/include/mlir/Bindings/Python/NanobindUtils.h
@@ -12,10 +12,6 @@
 
 #include "mlir-c/Support.h"
 #include "mlir/Bindings/Python/Nanobind.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/Twine.h"
-#include "llvm/Support/DataTypes.h"
 
 #include <fstream>
 #include <sstream>

--- a/mlir/lib/Bindings/Python/ExecutionEngineModule.cpp
+++ b/mlir/lib/Bindings/Python/ExecutionEngineModule.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <vector>
+
 #include "mlir-c/ExecutionEngine.h"
 #include "mlir/Bindings/Python/IRCore.h"
 #include "mlir/Bindings/Python/Nanobind.h"
@@ -83,7 +85,8 @@ NB_MODULE(_mlirExecutionEngine, m) {
           [](PyExecutionEngine &self, PyModule &module, int optLevel,
              const std::vector<std::string> &sharedLibPaths,
              bool enableObjectDump, bool enablePIC) {
-            llvm::SmallVector<MlirStringRef, 4> libPaths;
+            std::vector<MlirStringRef> libPaths;
+            libPaths.reserve(sharedLibPaths.size());
             for (const std::string &path : sharedLibPaths)
               libPaths.push_back({path.c_str(), path.length()});
             MlirExecutionEngine executionEngine = mlirExecutionEngineCreate(

--- a/mlir/lib/Bindings/Python/Globals.cpp
+++ b/mlir/lib/Bindings/Python/Globals.cpp
@@ -86,11 +86,11 @@ void PyGlobals::registerAttributeBuilder(const std::string &attributeKind,
   nb::ft_lock_guard lock(mutex);
   nb::object &found = attributeBuilderMap[attributeKind];
   if (found && !replace) {
-    throw std::runtime_error((llvm::Twine("Attribute builder for '") +
-                              attributeKind +
-                              "' is already registered with func: " +
-                              nb::cast<std::string>(nb::str(found)))
-                                 .str());
+    throw std::runtime_error(nanobind::detail::join(
+        "Attribute builder for '", attributeKind,
+        "' is already registered with func: ",
+        nb::cast<std::string>(nb::str(found)))
+                                 .c_str());
   }
   found = std::move(pyFunc);
 }
@@ -120,9 +120,9 @@ void PyGlobals::registerDialectImpl(const std::string &dialectNamespace,
   nb::ft_lock_guard lock(mutex);
   nb::object &found = dialectClassMap[dialectNamespace];
   if (found) {
-    throw std::runtime_error((llvm::Twine("Dialect namespace '") +
-                              dialectNamespace + "' is already registered.")
-                                 .str());
+    throw std::runtime_error(nanobind::detail::join(
+        "Dialect namespace '", dialectNamespace,
+        "' is already registered.").c_str());
   }
   found = std::move(pyClass);
 }
@@ -132,9 +132,8 @@ void PyGlobals::registerOperationImpl(const std::string &operationName,
   nb::ft_lock_guard lock(mutex);
   nb::object &found = operationClassMap[operationName];
   if (found && !replace) {
-    throw std::runtime_error((llvm::Twine("Operation '") + operationName +
-                              "' is already registered.")
-                                 .str());
+    throw std::runtime_error(nanobind::detail::join(
+        "Operation '", operationName, "' is already registered.").c_str());
   }
   found = std::move(pyClass);
 }
@@ -144,9 +143,9 @@ void PyGlobals::registerOpAdaptorImpl(const std::string &operationName,
   nb::ft_lock_guard lock(mutex);
   nb::object &found = opAdaptorClassMap[operationName];
   if (found && !replace) {
-    throw std::runtime_error((llvm::Twine("Operation adaptor of '") +
-                              operationName + "' is already registered.")
-                                 .str());
+    throw std::runtime_error(nanobind::detail::join(
+        "Operation adaptor of '", operationName,
+        "' is already registered.").c_str());
   }
   found = std::move(pyClass);
 }

--- a/mlir/lib/Bindings/Python/Globals.cpp
+++ b/mlir/lib/Bindings/Python/Globals.cpp
@@ -89,8 +89,7 @@ void PyGlobals::registerAttributeBuilder(const std::string &attributeKind,
     throw std::runtime_error(
         nanobind::detail::join("Attribute builder for '", attributeKind,
                                "' is already registered with func: ",
-                               nb::cast<std::string>(nb::str(found)))
-            .c_str());
+                               nb::cast<std::string>(nb::str(found))));
   }
   found = std::move(pyFunc);
 }
@@ -120,10 +119,8 @@ void PyGlobals::registerDialectImpl(const std::string &dialectNamespace,
   nb::ft_lock_guard lock(mutex);
   nb::object &found = dialectClassMap[dialectNamespace];
   if (found) {
-    throw std::runtime_error(nanobind::detail::join("Dialect namespace '",
-                                                    dialectNamespace,
-                                                    "' is already registered.")
-                                 .c_str());
+    throw std::runtime_error(nanobind::detail::join(
+        "Dialect namespace '", dialectNamespace, "' is already registered."));
   }
   found = std::move(pyClass);
 }
@@ -133,10 +130,8 @@ void PyGlobals::registerOperationImpl(const std::string &operationName,
   nb::ft_lock_guard lock(mutex);
   nb::object &found = operationClassMap[operationName];
   if (found && !replace) {
-    throw std::runtime_error(nanobind::detail::join("Operation '",
-                                                    operationName,
-                                                    "' is already registered.")
-                                 .c_str());
+    throw std::runtime_error(nanobind::detail::join(
+        "Operation '", operationName, "' is already registered."));
   }
   found = std::move(pyClass);
 }
@@ -146,10 +141,8 @@ void PyGlobals::registerOpAdaptorImpl(const std::string &operationName,
   nb::ft_lock_guard lock(mutex);
   nb::object &found = opAdaptorClassMap[operationName];
   if (found && !replace) {
-    throw std::runtime_error(nanobind::detail::join("Operation adaptor of '",
-                                                    operationName,
-                                                    "' is already registered.")
-                                 .c_str());
+    throw std::runtime_error(nanobind::detail::join(
+        "Operation adaptor of '", operationName, "' is already registered."));
   }
   found = std::move(pyClass);
 }

--- a/mlir/lib/Bindings/Python/Globals.cpp
+++ b/mlir/lib/Bindings/Python/Globals.cpp
@@ -86,11 +86,11 @@ void PyGlobals::registerAttributeBuilder(const std::string &attributeKind,
   nb::ft_lock_guard lock(mutex);
   nb::object &found = attributeBuilderMap[attributeKind];
   if (found && !replace) {
-    throw std::runtime_error(nanobind::detail::join(
-        "Attribute builder for '", attributeKind,
-        "' is already registered with func: ",
-        nb::cast<std::string>(nb::str(found)))
-                                 .c_str());
+    throw std::runtime_error(
+        nanobind::detail::join("Attribute builder for '", attributeKind,
+                               "' is already registered with func: ",
+                               nb::cast<std::string>(nb::str(found)))
+            .c_str());
   }
   found = std::move(pyFunc);
 }
@@ -120,9 +120,10 @@ void PyGlobals::registerDialectImpl(const std::string &dialectNamespace,
   nb::ft_lock_guard lock(mutex);
   nb::object &found = dialectClassMap[dialectNamespace];
   if (found) {
-    throw std::runtime_error(nanobind::detail::join(
-        "Dialect namespace '", dialectNamespace,
-        "' is already registered.").c_str());
+    throw std::runtime_error(nanobind::detail::join("Dialect namespace '",
+                                                    dialectNamespace,
+                                                    "' is already registered.")
+                                 .c_str());
   }
   found = std::move(pyClass);
 }
@@ -132,8 +133,10 @@ void PyGlobals::registerOperationImpl(const std::string &operationName,
   nb::ft_lock_guard lock(mutex);
   nb::object &found = operationClassMap[operationName];
   if (found && !replace) {
-    throw std::runtime_error(nanobind::detail::join(
-        "Operation '", operationName, "' is already registered.").c_str());
+    throw std::runtime_error(nanobind::detail::join("Operation '",
+                                                    operationName,
+                                                    "' is already registered.")
+                                 .c_str());
   }
   found = std::move(pyClass);
 }
@@ -143,9 +146,10 @@ void PyGlobals::registerOpAdaptorImpl(const std::string &operationName,
   nb::ft_lock_guard lock(mutex);
   nb::object &found = opAdaptorClassMap[operationName];
   if (found && !replace) {
-    throw std::runtime_error(nanobind::detail::join(
-        "Operation adaptor of '", operationName,
-        "' is already registered.").c_str());
+    throw std::runtime_error(nanobind::detail::join("Operation adaptor of '",
+                                                    operationName,
+                                                    "' is already registered.")
+                                 .c_str());
   }
   found = std::move(pyClass);
 }
@@ -221,10 +225,10 @@ PyGlobals::lookupOperationClass(std::string_view operationName) {
 }
 
 std::optional<nb::object>
-PyGlobals::lookupOpAdaptorClass(llvm::StringRef operationName) {
+PyGlobals::lookupOpAdaptorClass(std::string_view operationName) {
   // Make sure dialect module is loaded.
-  auto split = operationName.split('.');
-  llvm::StringRef dialectNamespace = split.first;
+  std::string_view dialectNamespace =
+      operationName.substr(0, operationName.find('.'));
   (void)loadDialectModule(dialectNamespace);
 
   nb::ft_lock_guard lock(mutex);

--- a/mlir/lib/Bindings/Python/IRAffine.cpp
+++ b/mlir/lib/Bindings/Python/IRAffine.cpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -25,14 +26,12 @@
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
 
 namespace nb = nanobind;
 using namespace mlir;
 using namespace mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN;
 
 using llvm::SmallVector;
-using llvm::StringRef;
 
 static const char kDumpDocstring[] =
     R"(Dumps a debug representation of the object to stderr.)";
@@ -44,21 +43,21 @@ static const char kDumpDocstring[] =
 template <typename PyType, typename CType>
 static void pyListToVector(const nb::list &list,
                            llvm::SmallVectorImpl<CType> &result,
-                           StringRef action) {
+                           std::string_view action) {
   result.reserve(nb::len(list));
   for (nb::handle item : list) {
     try {
       result.push_back(nb::cast<PyType>(item));
     } catch (nb::cast_error &err) {
       std::string msg = nanobind::detail::join(
-                             "Invalid expression when ", action.str(), " (",
+                             "Invalid expression when ", action, " (",
                              err.what(), ")")
                              .c_str();
       throw std::runtime_error(msg.c_str());
     } catch (std::runtime_error &err) {
       std::string msg = nanobind::detail::join(
-                             "Invalid expression (None?) when ", action.str(),
-                             " (", err.what(), ")")
+                             "Invalid expression (None?) when ", action, " (",
+                             err.what(), ")")
                              .c_str();
       throw std::runtime_error(msg.c_str());
     }

--- a/mlir/lib/Bindings/Python/IRAffine.cpp
+++ b/mlir/lib/Bindings/Python/IRAffine.cpp
@@ -25,7 +25,6 @@
 #include "mlir-c/IntegerSet.h"
 #include "mlir/Bindings/Python/Nanobind.h"
 #include "mlir/Support/LLVM.h"
-#include "llvm/ADT/Hashing.h"
 
 namespace nb = nanobind;
 using namespace mlir;
@@ -597,7 +596,7 @@ void populateIRAffine(nb::module_ &m) {
            })
       .def("__hash__",
            [](PyAffineExpr &self) {
-             return static_cast<size_t>(llvm::hash_value(self.get().ptr));
+             return std::hash<const void *>{}(self.get().ptr);
            })
       .def_prop_ro(
           "context",
@@ -734,7 +733,7 @@ void populateIRAffine(nb::module_ &m) {
            })
       .def("__hash__",
            [](PyAffineMap &self) {
-             return static_cast<size_t>(llvm::hash_value(self.get().ptr));
+             return std::hash<const void *>{}(self.get().ptr);
            })
       .def_static(
           "compress_unused_symbols",
@@ -920,7 +919,7 @@ void populateIRAffine(nb::module_ &m) {
            })
       .def("__hash__",
            [](PyIntegerSet &self) {
-             return static_cast<size_t>(llvm::hash_value(self.get().ptr));
+             return std::hash<const void *>{}(self.get().ptr);
            })
       .def_prop_ro(
           "context",

--- a/mlir/lib/Bindings/Python/IRAffine.cpp
+++ b/mlir/lib/Bindings/Python/IRAffine.cpp
@@ -941,17 +941,13 @@ void populateIRAffine(nb::module_ &m) {
               throw nb::value_error("Expected non-empty list of constraints");
 
             // std::vector<bool> does not expose a bool* data pointer.
-            std::unique_ptr<bool[]> flags =
-                std::make_unique<bool[]>(eqFlags.size());
-            for (size_t i = 0, e = eqFlags.size(); i < e; ++i)
-              flags[i] = eqFlags[i];
-
+            std::vector<char> flags(eqFlags.begin(), eqFlags.end());
             std::vector<MlirAffineExpr> affineExprs;
             pyListToVector<PyAffineExpr>(exprs, affineExprs,
                                          "attempting to create an IntegerSet");
             MlirIntegerSet set = mlirIntegerSetGet(
                 context->get(), numDims, numSymbols, exprs.size(),
-                affineExprs.data(), flags.get());
+                affineExprs.data(), reinterpret_cast<bool *>(flags.data()));
             return PyIntegerSet(context->getRef(), set);
           },
           nb::arg("num_dims"), nb::arg("num_symbols"), nb::arg("exprs"),

--- a/mlir/lib/Bindings/Python/IRAffine.cpp
+++ b/mlir/lib/Bindings/Python/IRAffine.cpp
@@ -46,14 +46,11 @@ static void pyListToVector(const nb::list &list, std::vector<CType> &result,
       result.push_back(nb::cast<PyType>(item));
     } catch (nb::cast_error &err) {
       std::string msg = nanobind::detail::join("Invalid expression when ",
-                                               action, " (", err.what(), ")")
-                            .c_str();
+                                               action, " (", err.what(), ")");
       throw std::runtime_error(msg.c_str());
     } catch (std::runtime_error &err) {
-      std::string msg =
-          nanobind::detail::join("Invalid expression (None?) when ", action,
-                                 " (", err.what(), ")")
-              .c_str();
+      std::string msg = nanobind::detail::join(
+          "Invalid expression (None?) when ", action, " (", err.what(), ")");
       throw std::runtime_error(msg.c_str());
     }
   }

--- a/mlir/lib/Bindings/Python/IRAffine.cpp
+++ b/mlir/lib/Bindings/Python/IRAffine.cpp
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -25,13 +26,10 @@
 #include "mlir/Bindings/Python/Nanobind.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/Hashing.h"
-#include "llvm/ADT/SmallVector.h"
 
 namespace nb = nanobind;
 using namespace mlir;
 using namespace mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN;
-
-using llvm::SmallVector;
 
 static const char kDumpDocstring[] =
     R"(Dumps a debug representation of the object to stderr.)";
@@ -41,24 +39,22 @@ static const char kDumpDocstring[] =
 /// Throws errors in case of failure, using "action" to describe what the caller
 /// was attempting to do.
 template <typename PyType, typename CType>
-static void pyListToVector(const nb::list &list,
-                           llvm::SmallVectorImpl<CType> &result,
+static void pyListToVector(const nb::list &list, std::vector<CType> &result,
                            std::string_view action) {
   result.reserve(nb::len(list));
   for (nb::handle item : list) {
     try {
       result.push_back(nb::cast<PyType>(item));
     } catch (nb::cast_error &err) {
-      std::string msg = nanobind::detail::join(
-                             "Invalid expression when ", action, " (",
-                             err.what(), ")")
-                             .c_str();
+      std::string msg = nanobind::detail::join("Invalid expression when ",
+                                               action, " (", err.what(), ")")
+                            .c_str();
       throw std::runtime_error(msg.c_str());
     } catch (std::runtime_error &err) {
-      std::string msg = nanobind::detail::join(
-                             "Invalid expression (None?) when ", action, " (",
-                             err.what(), ")")
-                             .c_str();
+      std::string msg =
+          nanobind::detail::join("Invalid expression (None?) when ", action,
+                                 " (", err.what(), ")")
+              .c_str();
       throw std::runtime_error(msg.c_str());
     }
   }
@@ -66,7 +62,7 @@ static void pyListToVector(const nb::list &list,
 
 template <typename PermutationTy>
 static bool isPermutation(const std::vector<PermutationTy> &permutation) {
-  llvm::SmallVector<bool, 8> seen(permutation.size(), false);
+  std::vector<bool> seen(permutation.size(), false);
   for (auto val : permutation) {
     if (val < permutation.size()) {
       if (seen[val])
@@ -105,9 +101,11 @@ public:
   static MlirAffineExpr castFrom(PyAffineExpr &orig) {
     if (!DerivedTy::isaFunction(orig)) {
       auto origRepr = nb::cast<std::string>(nb::repr(nb::cast(orig)));
-      throw nb::value_error(nanobind::detail::join(
-          "Cannot cast affine expression to ", DerivedTy::pyClassName,
-          " (from ", origRepr, ")").c_str());
+      throw nb::value_error(
+          nanobind::detail::join("Cannot cast affine expression to ",
+                                 DerivedTy::pyClassName, " (from ", origRepr,
+                                 ")")
+              .c_str());
     }
     return orig;
   }
@@ -741,7 +739,7 @@ void populateIRAffine(nb::module_ &m) {
       .def_static(
           "compress_unused_symbols",
           [](const nb::list &affineMaps, DefaultingPyMlirContext context) {
-            SmallVector<MlirAffineMap> maps;
+            std::vector<MlirAffineMap> maps;
             pyListToVector<PyAffineMap, MlirAffineMap>(
                 affineMaps, maps, "attempting to create an AffineMap");
             std::vector<MlirAffineMap> compressed(affineMaps.size());
@@ -769,7 +767,7 @@ void populateIRAffine(nb::module_ &m) {
           "get",
           [](intptr_t dimCount, intptr_t symbolCount, const nb::list &exprs,
              DefaultingPyMlirContext context) {
-            SmallVector<MlirAffineExpr> affineExprs;
+            std::vector<MlirAffineExpr> affineExprs;
             pyListToVector<PyAffineExpr, MlirAffineExpr>(
                 exprs, affineExprs, "attempting to create an AffineMap");
             MlirAffineMap map =
@@ -943,17 +941,18 @@ void populateIRAffine(nb::module_ &m) {
             if (exprs.size() == 0)
               throw nb::value_error("Expected non-empty list of constraints");
 
-            // Copy over to a SmallVector because std::vector has a
-            // specialization for booleans that packs data and does not
-            // expose a `bool *`.
-            SmallVector<bool, 8> flags(eqFlags.begin(), eqFlags.end());
+            // std::vector<bool> does not expose a bool* data pointer.
+            std::unique_ptr<bool[]> flags =
+                std::make_unique<bool[]>(eqFlags.size());
+            for (size_t i = 0, e = eqFlags.size(); i < e; ++i)
+              flags[i] = eqFlags[i];
 
-            SmallVector<MlirAffineExpr> affineExprs;
+            std::vector<MlirAffineExpr> affineExprs;
             pyListToVector<PyAffineExpr>(exprs, affineExprs,
                                          "attempting to create an IntegerSet");
             MlirIntegerSet set = mlirIntegerSetGet(
                 context->get(), numDims, numSymbols, exprs.size(),
-                affineExprs.data(), flags.data());
+                affineExprs.data(), flags.get());
             return PyIntegerSet(context->getRef(), set);
           },
           nb::arg("num_dims"), nb::arg("num_symbols"), nb::arg("exprs"),
@@ -984,7 +983,8 @@ void populateIRAffine(nb::module_ &m) {
                   "Expected the number of symbol replacement expressions "
                   "to match that of symbols");
 
-            SmallVector<MlirAffineExpr> dimAffineExprs, symbolAffineExprs;
+            std::vector<MlirAffineExpr> dimAffineExprs;
+            std::vector<MlirAffineExpr> symbolAffineExprs;
             pyListToVector<PyAffineExpr>(
                 dimExprs, dimAffineExprs,
                 "attempting to create an IntegerSet by replacing dimensions");

--- a/mlir/lib/Bindings/Python/IRAffine.cpp
+++ b/mlir/lib/Bindings/Python/IRAffine.cpp
@@ -26,7 +26,6 @@
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/Twine.h"
 
 namespace nb = nanobind;
 using namespace mlir;
@@ -34,7 +33,6 @@ using namespace mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN;
 
 using llvm::SmallVector;
 using llvm::StringRef;
-using llvm::Twine;
 
 static const char kDumpDocstring[] =
     R"(Dumps a debug representation of the object to stderr.)";
@@ -52,14 +50,16 @@ static void pyListToVector(const nb::list &list,
     try {
       result.push_back(nb::cast<PyType>(item));
     } catch (nb::cast_error &err) {
-      std::string msg = (llvm::Twine("Invalid expression when ") + action +
-                         " (" + err.what() + ")")
-                            .str();
+      std::string msg = nanobind::detail::join(
+                             "Invalid expression when ", action.str(), " (",
+                             err.what(), ")")
+                             .c_str();
       throw std::runtime_error(msg.c_str());
     } catch (std::runtime_error &err) {
-      std::string msg = (llvm::Twine("Invalid expression (None?) when ") +
-                         action + " (" + err.what() + ")")
-                            .str();
+      std::string msg = nanobind::detail::join(
+                             "Invalid expression (None?) when ", action.str(),
+                             " (", err.what(), ")")
+                             .c_str();
       throw std::runtime_error(msg.c_str());
     }
   }
@@ -106,11 +106,9 @@ public:
   static MlirAffineExpr castFrom(PyAffineExpr &orig) {
     if (!DerivedTy::isaFunction(orig)) {
       auto origRepr = nb::cast<std::string>(nb::repr(nb::cast(orig)));
-      throw nb::value_error((Twine("Cannot cast affine expression to ") +
-                             DerivedTy::pyClassName + " (from " + origRepr +
-                             ")")
-                                .str()
-                                .c_str());
+      throw nb::value_error(nanobind::detail::join(
+          "Cannot cast affine expression to ", DerivedTy::pyClassName,
+          " (from ", origRepr, ")").c_str());
     }
     return orig;
   }

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -22,7 +22,6 @@
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 #include "mlir/Bindings/Python/NanobindUtils.h"
 #include "llvm/ADT/ScopeExit.h"
-#include "llvm/Support/raw_ostream.h"
 
 namespace nb = nanobind;
 using namespace nanobind::literals;
@@ -565,10 +564,9 @@ PyDenseElementsAttribute::getFromList(const nb::list &attributes,
     if ((!mlirTypeIsAShaped(*explicitType) ||
          !mlirShapedTypeHasStaticShape(*explicitType))) {
 
-      std::string message;
-      llvm::raw_string_ostream os(message);
-      os << "Expected a static ShapedType for the shaped_type parameter: "
-         << nb::cast<std::string>(nb::repr(nb::cast(*explicitType)));
+      std::string message = nanobind::detail::join(
+          "Expected a static ShapedType for the shaped_type parameter: ",
+          nb::cast<std::string>(nb::repr(nb::cast(*explicitType))));
       throw nb::value_error(message.c_str());
     }
     shapedType = *explicitType;
@@ -588,12 +586,11 @@ PyDenseElementsAttribute::getFromList(const nb::list &attributes,
     mlirAttributes.push_back(mlirAttribute);
 
     if (!mlirTypeEqual(mlirShapedTypeGetElementType(shapedType), attrType)) {
-      std::string message;
-      llvm::raw_string_ostream os(message);
-      os << "All attributes must be of the same type and match "
-         << "the type parameter: expected="
-         << nb::cast<std::string>(nb::repr(nb::cast(shapedType)))
-         << ", but got=" << nb::cast<std::string>(nb::repr(nb::cast(attrType)));
+      std::string message = nanobind::detail::join(
+          "All attributes must be of the same type and match the type "
+          "parameter: expected=",
+          nb::cast<std::string>(nb::repr(nb::cast(shapedType))),
+          ", but got=", nb::cast<std::string>(nb::repr(nb::cast(attrType))));
       throw nb::value_error(message.c_str());
     }
   }

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <optional>
@@ -1299,7 +1300,7 @@ void PyStridedLayoutAttribute::bindDerived(ClassTy &c) {
       [](int64_t rank, DefaultingPyMlirContext ctx) {
         auto dynamic = mlirShapedTypeGetDynamicStrideOrOffset();
         std::vector<int64_t> strides(rank);
-        llvm::fill(strides, dynamic);
+        std::fill(strides.begin(), strides.end(), dynamic);
         MlirAttribute attr = mlirStridedLayoutAttrGet(
             ctx->get(), dynamic, strides.size(), strides.data());
         return PyStridedLayoutAttribute(ctx->getRef(), attr);

--- a/mlir/lib/Bindings/Python/IRInterfaces.cpp
+++ b/mlir/lib/Bindings/Python/IRInterfaces.cpp
@@ -19,7 +19,6 @@
 #include "mlir/Bindings/Python/IRCore.h"
 #include "mlir/Bindings/Python/Nanobind.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallVector.h"
 
 namespace nb = nanobind;
 
@@ -48,10 +47,10 @@ its return shaped type components. Raises ValueError on failure.)";
 
 namespace {
 
-/// Takes in an optional ist of operands and converts them into a SmallVector
-/// of MlirVlaues. Returns an empty SmallVector if the list is empty.
-llvm::SmallVector<MlirValue> wrapOperands(std::optional<nb::list> operandList) {
-  llvm::SmallVector<MlirValue> mlirOperands;
+/// Takes in an optional ist of operands and converts them into a std::vector
+/// of MlirVlaues. Returns an empty std::vector if the list is empty.
+std::vector<MlirValue> wrapOperands(std::optional<nb::list> operandList) {
+  std::vector<MlirValue> mlirOperands;
 
   if (!operandList || operandList->size() == 0) {
     return mlirOperands;
@@ -84,20 +83,17 @@ llvm::SmallVector<MlirValue> wrapOperands(std::optional<nb::list> operandList) {
             throw nb::cast_error();
           mlirOperands.push_back(val->get());
         } catch (nb::cast_error &err) {
-          throw nb::value_error(
-              (llvm::Twine("Operand ") + llvm::Twine(it.index()) +
-               " must be a Value or Sequence of Values (" + err.what() + ")")
-                  .str()
-                  .c_str());
+          throw nb::value_error(nanobind::detail::join(
+              "Operand ", it.index(),
+              " must be a Value or Sequence of Values (", err.what(), ")")
+                                    .c_str());
         }
       }
       continue;
     } catch (nb::cast_error &err) {
-      throw nb::value_error((llvm::Twine("Operand ") + llvm::Twine(it.index()) +
-                             " must be a Value or Sequence of Values (" +
-                             err.what() + ")")
-                                .str()
-                                .c_str());
+      throw nb::value_error(nanobind::detail::join(
+          "Operand ", it.index(), " must be a Value or Sequence of Values (",
+          err.what(), ")").c_str());
     }
 
     throw nb::cast_error();
@@ -106,11 +102,11 @@ llvm::SmallVector<MlirValue> wrapOperands(std::optional<nb::list> operandList) {
   return mlirOperands;
 }
 
-/// Takes in an optional vector of PyRegions and returns a SmallVector of
-/// MlirRegion. Returns an empty SmallVector if the list is empty.
-llvm::SmallVector<MlirRegion>
+/// Takes in an optional vector of PyRegions and returns a std::vector of
+/// MlirRegion. Returns an empty std::vector if the list is empty.
+std::vector<MlirRegion>
 wrapRegions(std::optional<std::vector<PyRegion>> regions) {
-  llvm::SmallVector<MlirRegion> mlirRegions;
+  std::vector<MlirRegion> mlirRegions;
 
   if (regions) {
     mlirRegions.reserve(regions->size());
@@ -273,9 +269,9 @@ public:
                    std::optional<std::vector<PyRegion>> regions,
                    DefaultingPyMlirContext context,
                    DefaultingPyLocation location) {
-    llvm::SmallVector<MlirValue> mlirOperands =
+    std::vector<MlirValue> mlirOperands =
         wrapOperands(std::move(operandList));
-    llvm::SmallVector<MlirRegion> mlirRegions = wrapRegions(std::move(regions));
+    std::vector<MlirRegion> mlirRegions = wrapRegions(std::move(regions));
 
     std::vector<PyType> inferredTypes;
     PyMlirContext &pyContext = context.resolve();
@@ -430,9 +426,9 @@ public:
       std::optional<PyAttribute> attributes, void *properties,
       std::optional<std::vector<PyRegion>> regions,
       DefaultingPyMlirContext context, DefaultingPyLocation location) {
-    llvm::SmallVector<MlirValue> mlirOperands =
+    std::vector<MlirValue> mlirOperands =
         wrapOperands(std::move(operandList));
-    llvm::SmallVector<MlirRegion> mlirRegions = wrapRegions(std::move(regions));
+    std::vector<MlirRegion> mlirRegions = wrapRegions(std::move(regions));
 
     std::vector<PyShapedTypeComponents> inferredShapedTypeComponents;
     PyMlirContext &pyContext = context.resolve();

--- a/mlir/lib/Bindings/Python/IRInterfaces.cpp
+++ b/mlir/lib/Bindings/Python/IRInterfaces.cpp
@@ -84,17 +84,20 @@ std::vector<MlirValue> wrapOperands(std::optional<nb::list> operandList) {
             throw nb::cast_error();
           mlirOperands.push_back(val->get());
         } catch (nb::cast_error &err) {
-          throw nb::value_error(nanobind::detail::join(
-              "Operand ", index,
-              " must be a Value or Sequence of Values (", err.what(), ")")
-                                    .c_str());
+          throw nb::value_error(
+              nanobind::detail::join("Operand ", index,
+                                     " must be a Value or Sequence of Values (",
+                                     err.what(), ")")
+                  .c_str());
         }
       }
       continue;
     } catch (nb::cast_error &err) {
-      throw nb::value_error(nanobind::detail::join(
-          "Operand ", index, " must be a Value or Sequence of Values (",
-          err.what(), ")").c_str());
+      throw nb::value_error(
+          nanobind::detail::join("Operand ", index,
+                                 " must be a Value or Sequence of Values (",
+                                 err.what(), ")")
+              .c_str());
     }
 
     throw nb::cast_error();
@@ -270,8 +273,7 @@ public:
                    std::optional<std::vector<PyRegion>> regions,
                    DefaultingPyMlirContext context,
                    DefaultingPyLocation location) {
-    std::vector<MlirValue> mlirOperands =
-        wrapOperands(std::move(operandList));
+    std::vector<MlirValue> mlirOperands = wrapOperands(std::move(operandList));
     std::vector<MlirRegion> mlirRegions = wrapRegions(std::move(regions));
 
     std::vector<PyType> inferredTypes;
@@ -427,8 +429,7 @@ public:
       std::optional<PyAttribute> attributes, void *properties,
       std::optional<std::vector<PyRegion>> regions,
       DefaultingPyMlirContext context, DefaultingPyLocation location) {
-    std::vector<MlirValue> mlirOperands =
-        wrapOperands(std::move(operandList));
+    std::vector<MlirValue> mlirOperands = wrapOperands(std::move(operandList));
     std::vector<MlirRegion> mlirRegions = wrapRegions(std::move(regions));
 
     std::vector<PyShapedTypeComponents> inferredShapedTypeComponents;

--- a/mlir/lib/Bindings/Python/IRTypes.cpp
+++ b/mlir/lib/Bindings/Python/IRTypes.cpp
@@ -309,9 +309,12 @@ void PyComplexType::bindDerived(ClassTy &c) {
           MlirType t = mlirComplexTypeGet(elementType);
           return PyComplexType(elementType.getContext(), t);
         }
-        throw nb::value_error(nanobind::detail::join(
-            "invalid '", nb::cast<std::string>(nb::repr(nb::cast(elementType))),
-            "' and expected floating point or integer type.").c_str());
+        throw nb::value_error(
+            nanobind::detail::join(
+                "invalid '",
+                nb::cast<std::string>(nb::repr(nb::cast(elementType))),
+                "' and expected floating point or integer type.")
+                .c_str());
       },
       "Create a complex type");
   c.def_prop_ro(

--- a/mlir/lib/Bindings/Python/IRTypes.cpp
+++ b/mlir/lib/Bindings/Python/IRTypes.cpp
@@ -24,7 +24,6 @@ using namespace mlir;
 using namespace mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN;
 
 using llvm::SmallVector;
-using llvm::Twine;
 
 namespace mlir {
 namespace python {
@@ -310,12 +309,9 @@ void PyComplexType::bindDerived(ClassTy &c) {
           MlirType t = mlirComplexTypeGet(elementType);
           return PyComplexType(elementType.getContext(), t);
         }
-        throw nb::value_error(
-            (Twine("invalid '") +
-             nb::cast<std::string>(nb::repr(nb::cast(elementType))) +
-             "' and expected floating point or integer type.")
-                .str()
-                .c_str());
+        throw nb::value_error(nanobind::detail::join(
+            "invalid '", nb::cast<std::string>(nb::repr(nb::cast(elementType))),
+            "' and expected floating point or integer type.").c_str());
       },
       "Create a complex type");
   c.def_prop_ro(


### PR DESCRIPTION
This PR continues work from #178290 
It replaces some LLVM utilities with straightforward `std::` equivalents.