### PR TITLE
[clang][bytecode] fix assertion failure on invalid init list (GH175432)

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -211,6 +211,9 @@ private:
 
 template <class Emitter>
 bool Compiler<Emitter>::VisitCastExpr(const CastExpr *CE) {
+  if (CE->containsErrors())
+    return this->emitError(CE);
+
   const Expr *SubExpr = CE->getSubExpr();
 
   if (DiscardResult)
@@ -2184,6 +2187,9 @@ bool Compiler<Emitter>::visitCallArgs(ArrayRef<const Expr *> Args,
 
 template <class Emitter>
 bool Compiler<Emitter>::VisitInitListExpr(const InitListExpr *E) {
+  if (E->containsErrors())
+    return this->emitError(E);
+
   return this->visitInitList(E->inits(), E->getArrayFiller(), E);
 }
 

--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -448,10 +448,10 @@ bool Pointer::isInitialized() const {
   if (!isBlockPointer())
     return true;
 
-  if (isRoot() && BS.Base == sizeof(GlobalInlineDescriptor) &&
-      Offset == BS.Base) {
+  if (isStatic() && BS.Base == sizeof(GlobalInlineDescriptor)) {
     const auto &GD = block()->getBlockDesc<GlobalInlineDescriptor>();
-    return GD.InitState == GlobalInitState::Initialized;
+    if (GD.InitState == GlobalInitState::Initialized)
+      return true;
   }
 
   assert(BS.Pointee && "Cannot check if null pointer was initialized");
@@ -462,6 +462,12 @@ bool Pointer::isInitialized() const {
 
   if (asBlockPointer().Base == 0)
     return true;
+
+  if (isRoot() && BS.Base == sizeof(GlobalInlineDescriptor)) {
+    const auto &GD = block()->getBlockDesc<GlobalInlineDescriptor>();
+    return GD.InitState == GlobalInitState::Initialized;
+  }
+
   // Field has its bit in an inline descriptor.
   return getInlineDesc()->IsInitialized;
 }
@@ -476,10 +482,10 @@ bool Pointer::isElementInitialized(unsigned Index) const {
   if (isStatic() && BS.Base == 0)
     return true;
 
-  if (isRoot() && BS.Base == sizeof(GlobalInlineDescriptor) &&
-      Offset == BS.Base) {
+  if (isStatic() && BS.Base == sizeof(GlobalInlineDescriptor)) {
     const auto &GD = block()->getBlockDesc<GlobalInlineDescriptor>();
-    return GD.InitState == GlobalInitState::Initialized;
+    if (GD.InitState == GlobalInitState::Initialized)
+      return true;
   }
 
   if (Desc->isPrimitiveArray()) {

--- a/clang/test/AST/ByteCode/gh175432.cpp
+++ b/clang/test/AST/ByteCode/gh175432.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -verify %s
+
+constexpr const int *foo[][2] = { {nullptr, int}, }; // expected-error {{expected '(' for function-style cast or type construction}} \
+                                                     // expected-note {{declared here}}
+static_assert(foo[0][0] == nullptr, ""); // expected-error {{constant expression}} \
+                                         // expected-note {{initializer of 'foo' is unknown}}


### PR DESCRIPTION
this fixes an assertion failure where the interpreter would crash on invalid initializer lists 
The problem was that we kept processing expressions even after they were flagged with errors. this led to bad state and the eventual crash so i  added checks for `containsErrors()` in compiler.cpp and other entry points so we bail out early instead of asserting.
fixes #175432