### PR TITLE
AMDGPU: Add syntax for s_wait_event values

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.cpp
@@ -1661,6 +1661,19 @@ void AMDGPUInstPrinter::printSendMsg(const MCInst *MI, unsigned OpNo,
   }
 }
 
+void AMDGPUInstPrinter::printWaitEvent(const MCInst *MI, unsigned OpNo,
+                                       const MCSubtargetInfo &STI,
+                                       raw_ostream &O) {
+  using namespace llvm::AMDGPU::WaitEvent;
+  const uint16_t Imm16 = static_cast<uint16_t>(MI->getOperand(OpNo).getImm());
+
+  StringRef EventName = getWaitEventMaskName(Imm16, STI);
+  if (EventName.empty())
+    O << formatHex(static_cast<uint64_t>(Imm16));
+  else
+    O << EventName;
+}
+
 static void printSwizzleBitmask(const uint16_t AndMask,
                                 const uint16_t OrMask,
                                 const uint16_t XorMask,

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.h
@@ -235,6 +235,8 @@ protected:
                    raw_ostream &O);
   void printSendMsg(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
                     raw_ostream &O);
+  void printWaitEvent(const MCInst *MI, unsigned OpNo,
+                      const MCSubtargetInfo &STI, raw_ostream &O);
   void printSwizzle(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
                     raw_ostream &O);
   void printSWaitCnt(const MCInst *MI, unsigned OpNo,

--- a/llvm/lib/Target/AMDGPU/SIDefines.h
+++ b/llvm/lib/Target/AMDGPU/SIDefines.h
@@ -501,6 +501,14 @@ enum StreamId : unsigned { // Stream ID, (2) [9:8].
 
 } // namespace SendMsg
 
+namespace WaitEvent { // Encoding of SIMM16 used in s_wait_event
+enum Id {
+  DONT_WAIT_EXPORT_READY = 1 << 0, // Only used in gfx11
+  EXPORT_READY = 1 << 1,           // gfx12+
+};
+
+} // namespace WaitEvent
+
 namespace Hwreg { // Encoding of SIMM16 used in s_setreg/getreg* insns.
 
 enum Id { // HwRegCode, (6) [5:0]

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -1089,6 +1089,8 @@ def VReg32OrOffClass : AsmOperandClass {
 
 def SendMsg : CustomOperand<i32>;
 
+def WaitEvent : CustomOperand<i16>;
+
 def Swizzle : CustomOperand<i16, 1>;
 
 def Endpgm : CustomOperand<i16, 1>;

--- a/llvm/lib/Target/AMDGPU/SOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SOPInstructions.td
@@ -1834,7 +1834,7 @@ let SubtargetPredicate = isGFX10Plus in {
 
 let SubtargetPredicate = isGFX11Plus in {
 let OtherPredicates = [HasExportInsts] in
-  def S_WAIT_EVENT : SOPP_Pseudo<"s_wait_event", (ins s16imm:$simm16),
+  def S_WAIT_EVENT : SOPP_Pseudo<"s_wait_event", (ins WaitEvent:$simm16),
                                  "$simm16", [(int_amdgcn_s_wait_event timm:$simm16)]> {
                                    let hasSideEffects = 1;
                                  }

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUAsmUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUAsmUtils.cpp
@@ -156,6 +156,26 @@ StringRef getMsgOpName(int64_t MsgId, uint64_t Encoding,
 
 } // namespace SendMsg
 
+namespace WaitEvent {
+
+// clang-format off
+static constexpr CustomOperand WaitEventOperands[] = {
+  {{"{ export_ready: 0 }"},           0,                      isGFX12Plus},
+  {{"{ dont_wait_export_ready: 0 }"}, 0,                      isGFX11},
+  {{"{ dont_wait_export_ready: 1 }"}, DONT_WAIT_EXPORT_READY, isGFX11},
+  {{"{ export_ready: 1 }"},           EXPORT_READY,           isGFX12Plus}
+};
+// clang-format on
+
+int64_t getWaitEventMask(StringRef Name, const MCSubtargetInfo &STI) {
+  return getEncodingFromOperandTable(WaitEventOperands, Name, STI);
+}
+
+StringRef getWaitEventMaskName(uint64_t Encoding, const MCSubtargetInfo &STI) {
+  return getNameFromOperandTable(WaitEventOperands, Encoding, STI);
+}
+} // namespace WaitEvent
+
 namespace Hwreg {
 
 // Disable lint checking for this block since it makes the table unreadable.

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUAsmUtils.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUAsmUtils.h
@@ -84,6 +84,11 @@ StringRef getMsgOpName(int64_t MsgId, uint64_t Encoding,
 
 } // namespace SendMsg
 
+namespace WaitEvent {
+int64_t getWaitEventMask(StringRef Name, const MCSubtargetInfo &STI);
+StringRef getWaitEventMaskName(uint64_t Encoding, const MCSubtargetInfo &STI);
+} // namespace WaitEvent
+
 namespace Hwreg { // Symbolic names for the hwreg(...) syntax.
 
 int64_t getHwregId(StringRef Name, const MCSubtargetInfo &STI);

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.wait.event.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.wait.event.ll
@@ -1,10 +1,11 @@
-; RUN: llc -global-isel=0 -mtriple=amdgcn -mcpu=gfx1100 < %s | FileCheck -check-prefix=GCN %s
-; RUN: llc -global-isel=1 -mtriple=amdgcn -mcpu=gfx1100 < %s | FileCheck -check-prefix=GCN %s
-; RUN: llc -global-isel=0 -mtriple=amdgcn -mcpu=gfx1200 < %s | FileCheck -check-prefix=GCN %s
-; RUN: llc -global-isel=1 -mtriple=amdgcn -mcpu=gfx1200 < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -global-isel=0 -mtriple=amdgcn -mcpu=gfx1100 < %s | FileCheck -check-prefixes=GCN,GFX11 %s
+; RUN: llc -global-isel=1 -mtriple=amdgcn -mcpu=gfx1100 < %s | FileCheck -check-prefixes=GCN,GFX11 %s
+; RUN: llc -global-isel=0 -mtriple=amdgcn -mcpu=gfx1200 < %s | FileCheck -check-prefixes=GCN,GFX12 %s
+; RUN: llc -global-isel=1 -mtriple=amdgcn -mcpu=gfx1200 < %s | FileCheck -check-prefixes=GCN,GFX12 %s
 
 ; GCN-LABEL: {{^}}test_wait_event_export_ready:
-; GCN: s_wait_event 0x2
+; GFX11: s_wait_event 0x2
+; GFX12: s_wait_event { export_ready: 1 }
 define amdgpu_ps void @test_wait_event_export_ready() {
 entry:
   call void @llvm.amdgcn.s.wait.event.export.ready()
@@ -12,35 +13,40 @@ entry:
 }
 
 ; GCN-LABEL: {{^}}test_wait_event_0:
-; GCN: s_wait_event 0x0
+; GFX11: s_wait_event { dont_wait_export_ready: 0 }
+; GFX12: s_wait_event { export_ready: 0 }
 define amdgpu_ps void @test_wait_event_0() {
   call void @llvm.amdgcn.s.wait.event(i16 0)
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_wait_event_1:
-; GCN: s_wait_event 0x1
+; GFX11: s_wait_event { dont_wait_export_ready: 1 }
+; GFX12: s_wait_event 0x1
 define amdgpu_ps void @test_wait_event_1() {
   call void @llvm.amdgcn.s.wait.event(i16 1)
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_wait_event_2:
-; GCN: s_wait_event 0x2
+; GFX11: s_wait_event 0x2
+; GFX12: s_wait_event { export_ready: 1 }
 define amdgpu_ps void @test_wait_event_2() {
   call void @llvm.amdgcn.s.wait.event(i16 2)
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_wait_event_3:
-; GCN: s_wait_event 0x3
+; GFX11: s_wait_event 0x3
+; GFX12: s_wait_event 0x3
 define amdgpu_ps void @test_wait_event_3() {
   call void @llvm.amdgcn.s.wait.event(i16 3)
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_wait_event_max:
-; GCN: s_wait_event 0xffff
+; GFX11: s_wait_event 0xffff
+; GFX12: s_wait_event 0xffff
 define amdgpu_ps void @test_wait_event_max() {
   call void @llvm.amdgcn.s.wait.event(i16 -1)
   ret void

--- a/llvm/test/MC/AMDGPU/gfx11_asm_err.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_err.s
@@ -155,3 +155,21 @@ s_load_b96 s[20:22], s[2:3], s0
 
 s_buffer_load_b96 s[20:22], s[4:7], s0
 // GFX11: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU
+
+s_wait_event -1
+// GFX11: :[[@LINE-1]]:{{[0-9]+}}: error: invalid immediate: only 16-bit values are legal
+
+s_wait_event 65537
+// GFX11: :[[@LINE-1]]:{{[0-9]+}}: error: invalid immediate: only 16-bit values are legal
+
+s_wait_event NOT_EVENT
+// GFX11: :[[@LINE-1]]:{{[0-9]+}}: error: expected structured immediate or an absolute expression
+
+s_wait_event { export_ready: 0 }
+// GFX11: :[[@LINE-1]]:16: error: unknown field
+
+s_wait_event { export_ready: 1 }
+// GFX11: :[[@LINE-1]]:16: error: unknown field
+
+s_wait_event { dont_wait_export_ready: 2 }
+// GFX11: :[[@LINE-1]]:40: error: invalid bit value: only 1-bit values are legal

--- a/llvm/test/MC/AMDGPU/gfx11_asm_sopp.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_sopp.s
@@ -425,11 +425,29 @@ s_ttracedata_imm 0xc1d1
 s_set_inst_prefetch_distance 0xc1d1
 // GFX11: s_set_inst_prefetch_distance 0xc1d1 ; encoding: [0xd1,0xc1,0x84,0xbf]
 
+s_wait_event 0
+// GFX11:  s_wait_event { dont_wait_export_ready: 0 } ; encoding: [0x00,0x00,0x8b,0xbf]
+
+s_wait_event { dont_wait_export_ready: 0 } ; encoding: [0x00,0x00,0x8b,0xbf]a
+// GFX11:  s_wait_event { dont_wait_export_ready: 0 } ; encoding: [0x00,0x00,0x8b,0xbf]
+
+s_wait_event 1
+// GFX11:  s_wait_event { dont_wait_export_ready: 1 } ; encoding: [0x01,0x00,0x8b,0xbf]
+
+s_wait_event { dont_wait_export_ready: 1 }
+// GFX11:  s_wait_event { dont_wait_export_ready: 1 } ; encoding: [0x01,0x00,0x8b,0xbf]
+
+s_wait_event 2
+// GFX11: s_wait_event 0x2                        ; encoding: [0x02,0x00,0x8b,0xbf]
+
 s_wait_event 0x3141
 // GFX11: s_wait_event 0x3141 ; encoding: [0x41,0x31,0x8b,0xbf]
 
 s_wait_event 0xc1d1
 // GFX11: s_wait_event 0xc1d1 ; encoding: [0xd1,0xc1,0x8b,0xbf]
+
+s_wait_event 0xffff
+// GFX11: s_wait_event 0xffff                      ; encoding: [0xff,0xff,0x8b,0xbf]
 
 s_endpgm_ordered_ps_done
 // GFX11: s_endpgm_ordered_ps_done ; encoding: [0x00,0x00,0xb2,0xbf]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_sopp.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_sopp.s
@@ -388,3 +388,30 @@ s_waitcnt vmcnt(9)
 
 s_wakeup
 // GFX12: s_wakeup                                ; encoding: [0x00,0x00,0xb4,0xbf]
+
+s_wait_event 0
+// GFX1200: s_wait_event { export_ready: 0 }        ; encoding: [0x00,0x00,0x8b,0xbf]
+
+s_wait_event 1
+// GFX1200: s_wait_event 0x1                        ; encoding: [0x01,0x00,0x8b,0xbf]
+
+s_wait_event 2
+// GFX1200: s_wait_event { export_ready: 1 }        ; encoding: [0x02,0x00,0x8b,0xbf]
+
+s_wait_event 0x3141
+// GFX1200: s_wait_event 0x3141 ; encoding: [0x41,0x31,0x8b,0xbf]
+
+s_wait_event 0xc1d1
+// GFX1200: s_wait_event 0xc1d1 ; encoding: [0xd1,0xc1,0x8b,0xbf]
+
+s_wait_event 0xffff
+// GFX1200: s_wait_event 0xffff                      ; encoding: [0xff,0xff,0x8b,0xbf]
+
+s_wait_event { export_ready: 0 }
+// GFX1200: s_wait_event { export_ready: 0 }        ; encoding: [0x00,0x00,0x8b,0xbf]
+
+s_wait_event { export_ready: 1 }
+// GFX1200: s_wait_event 0x1                        ; encoding: [0x01,0x00,0x8b,0xbf]
+
+s_wait_event { }
+// GFX1200: s_wait_event { export_ready: 0 }        ; encoding: [0x00,0x00,0x8b,0xbf]

--- a/llvm/test/MC/AMDGPU/gfx12_err.s
+++ b/llvm/test/MC/AMDGPU/gfx12_err.s
@@ -642,3 +642,33 @@ s_buffer_load_u16 s5, s[4:7], s0 offset:-1
 
 s_buffer_prefetch_data s[20:23], -1, s10, 7
 // GFX12-ERR: [[@LINE-1]]:{{[0-9]+}}: error: expected a 23-bit unsigned offset for buffer ops
+
+s_wait_event NOT_EVENT
+// GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: expected structured immediate or an absolute expression
+
+s_wait_event DONT_WAIT_EXPORT_READY
+// GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: expected structured immediate or an absolute expression
+
+s_wait_event { export_ready: 2 }
+// GFX12-ERR: :[[@LINE-1]]:30: error: invalid bit value: only 1-bit values are legal
+
+s_wait_event { export_ready: -1 }
+// GFX12-ERR: :[[@LINE-1]]:30: error: invalid bit value: only 1-bit values are legal
+
+s_wait_event { export_ready 1 }
+// GFX12-ERR: :[[@LINE-1]]:29: error: colon expected
+
+s_wait_event { export_ready=1 }
+// GFX12-ERR: :[[@LINE-1]]:28: error: colon expected
+
+s_wait_event {0}
+// GFX12-ERR: :[[@LINE-1]]:15: error: field name expected
+
+s_wait_event {1}
+// GFX12-ERR: :[[@LINE-1]]:15: error: field name expected
+
+s_wait_event { dont_wait_export_ready: 1 }
+// GFX12-ERR: :[[@LINE-1]]:16: error: unknown field
+
+s_wait_event { dont_wait_export_ready: 0 }
+// GFX12-ERR: :[[@LINE-1]]:16: error: unknown field

--- a/llvm/test/MC/AMDGPU/gfx13_asm_sopp.s
+++ b/llvm/test/MC/AMDGPU/gfx13_asm_sopp.s
@@ -201,7 +201,13 @@ s_delay_alu instid1(SALU_CYCLE_3)
 // GFX13: s_delay_alu instid1(SALU_CYCLE_3)       ; encoding: [0x80,0x05,0xae,0xbf]
 
 s_wait_event 0
-// GFX13: s_wait_event 0x0                        ; encoding: [0x00,0x00,0xaf,0xbf]
+// GFX13: s_wait_event { export_ready: 0 }        ; encoding: [0x00,0x00,0xaf,0xbf]
+
+s_wait_event 1
+// GFX13: s_wait_event 0x1                        ; encoding: [0x01,0x00,0xaf,0xbf]
+
+s_wait_event 2
+// GFX13: s_wait_event { export_ready: 1 }        ; encoding: [0x02,0x00,0xaf,0xbf]
 
 s_wait_event 0x1234
 // GFX13: s_wait_event 0x1234                     ; encoding: [0x34,0x12,0xaf,0xbf]


### PR DESCRIPTION
Previously this would just print hex values. Print names for the
recognized values, matching the sp3 syntax.