### PR TITLE
[Offload][SYCL] Refactoring: get rid of newline separators

### DIFF
--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -491,17 +491,19 @@ Error runSYCLLink(ArrayRef<std::string> Files, const ArgList &Args) {
   SplitModules.emplace_back(*LinkedFile);
 
   // Generate symbol table.
-  SmallVector<std::string> SymbolTable;
+  SmallVector<SmallString<0>> SymbolTable;
   for (size_t I = 0, E = SplitModules.size(); I != E; ++I) {
     Expected<std::unique_ptr<Module>> ModOrErr =
         getBitcodeModule(SplitModules[I], C);
     if (!ModOrErr)
       return ModOrErr.takeError();
 
-    std::string SymbolData;
+    SmallString<0> SymbolData;
     for (Function &F : **ModOrErr) {
-      if (isKernel(F))
-        SymbolData.append(F.getName().data(), F.getName().size() + 1);
+      if (isKernel(F)) {
+        SymbolData.append(F.getName());
+        SymbolData.push_back('\0');
+      }
     }
     SymbolTable.emplace_back(std::move(SymbolData));
   }

--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -498,12 +498,12 @@ Error runSYCLLink(ArrayRef<std::string> Files, const ArgList &Args) {
     if (!ModOrErr)
       return ModOrErr.takeError();
 
-    SmallVector<StringRef> Symbols;
+    std::string SymbolData;
     for (Function &F : **ModOrErr) {
       if (isKernel(F))
-        Symbols.push_back(F.getName());
+        SymbolData.append(F.getName().data(), F.getName().size() + 1);
     }
-    SymbolTable.emplace_back(llvm::join(Symbols.begin(), Symbols.end(), "\n"));
+    SymbolTable.emplace_back(std::move(SymbolData));
   }
 
   bool IsAOTCompileNeeded = IsIntelOffloadArch(

--- a/llvm/lib/Frontend/Offloading/OffloadWrapper.cpp
+++ b/llvm/lib/Frontend/Offloading/OffloadWrapper.cpp
@@ -916,14 +916,19 @@ private:
   std::pair<Constant *, Constant *>
   initOffloadEntriesPerImage(StringRef Entries, const Twine &OffloadKindTag) {
     SmallVector<Constant *> EntriesInits;
-    std::unique_ptr<MemoryBuffer> MB = MemoryBuffer::getMemBuffer(
-        Entries, /*BufferName*/ "", /*RequiresNullTerminator*/ false);
-    for (line_iterator LI(*MB); !LI.is_at_eof(); ++LI) {
-      GlobalVariable *GV =
-          emitOffloadingEntry(M, /*Kind*/ OffloadKind::OFK_SYCL,
-                              Constant::getNullValue(PointerType::getUnqual(C)),
-                              /*Name*/ *LI, /*Size*/ 0,
-                              /*Flags*/ 0, /*Data*/ 0);
+    const char *Current = Entries.data();
+    const char *End = Current + Entries.size();
+    while (Current < End) {
+      StringRef Name(Current);
+      Current += Name.size() + 1;
+
+      if (Name.empty())
+        continue;
+
+      GlobalVariable *GV = emitOffloadingEntry(
+          M, /*Kind*/ OffloadKind::OFK_SYCL,
+          Constant::getNullValue(PointerType::getUnqual(C)), Name, /*Size*/ 0,
+          /*Flags*/ 0, /*Data*/ 0);
       EntriesInits.push_back(GV->getInitializer());
     }
 


### PR DESCRIPTION
Previously, kernel symbols in offload binaries for SYCL had to be stored as newline-separated strings and we had to use llvm::join and line_iterator. It was needed because Offload Binary v1 format did not store string value sizes. It is not necessary with Offload Binary v2 format, which stores string value size and hence eliminates the need for newline separators.