### PR TITLE
[asan][AIX] Change #ifdef to #if for AIX guard

### DIFF
--- a/compiler-rt/lib/asan/asan_flags.cpp
+++ b/compiler-rt/lib/asan/asan_flags.cpp
@@ -160,7 +160,7 @@ static void ProcessFlags() {
   // Make "strict_init_order" imply "check_initialization_order".
   // TODO(samsonov): Use a single runtime flag for an init-order checker.
   if (f->strict_init_order) {
-#ifdef SANITIZER_AIX
+#if SANITIZER_AIX
     Report("WARNING: strict_init_order is not supported on AIX.\n");
     f->strict_init_order = false;
 #else


### PR DESCRIPTION
When `SANITIZER_AIX` is introduced in #131866, it will always be defined to either 0 or 1, so this guard should use `#if`.