### PR TITLE
[clang-tidy] treat fragment includes as main-file parts

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.cpp
@@ -32,10 +32,12 @@
 #include "clang/Tooling/Inclusions/StandardLibrary.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FileSystem/UniqueID.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Regex.h"
 #include <optional>
@@ -53,6 +55,23 @@ struct MissingIncludeInfo {
 };
 } // namespace
 
+static llvm::SmallString<128> normalizePath(llvm::StringRef Path) {
+  namespace path = llvm::sys::path;
+
+  llvm::SmallString<128> P = Path;
+  path::remove_dots(P, /*remove_dot_dot=*/true);
+  path::native(P, path::Style::posix);
+  while (!P.empty() && P.back() == '/')
+    P.pop_back();
+  return P;
+}
+
+static bool matchesAnyRegex(llvm::ArrayRef<llvm::Regex> Regexes,
+                            llvm::StringRef Path) {
+  return llvm::any_of(Regexes,
+                      [&](const llvm::Regex &R) { return R.match(Path); });
+}
+
 IncludeCleanerCheck::IncludeCleanerCheck(StringRef Name,
                                          ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
@@ -61,6 +80,9 @@ IncludeCleanerCheck::IncludeCleanerCheck(StringRef Name,
       DeduplicateFindings(Options.get("DeduplicateFindings", true)),
       UnusedIncludes(Options.get("UnusedIncludes", true)),
       MissingIncludes(Options.get("MissingIncludes", true)) {
+  for (const StringRef Pattern :
+       utils::options::parseStringList(Options.get("FragmentHeaders", "")))
+    FragmentHeaderPatterns.push_back(Pattern.str());
   for (const auto &Header : IgnoreHeaders) {
     if (!llvm::Regex{Header}.isValid())
       configurationDiag("Invalid ignore headers regex '%0'") << Header;
@@ -68,6 +90,12 @@ IncludeCleanerCheck::IncludeCleanerCheck(StringRef Name,
     if (!Header.ends_with("$"))
       HeaderSuffix += "$";
     IgnoreHeadersRegex.emplace_back(HeaderSuffix);
+  }
+  for (const auto &Pattern : FragmentHeaderPatterns) {
+    llvm::Regex CompiledRegex(Pattern);
+    if (!CompiledRegex.isValid())
+      configurationDiag("Invalid fragment headers regex '%0'") << Pattern;
+    FragmentHeaderRegexes.push_back(std::move(CompiledRegex));
   }
 
   if (UnusedIncludes == false && MissingIncludes == false)
@@ -79,6 +107,12 @@ IncludeCleanerCheck::IncludeCleanerCheck(StringRef Name,
 void IncludeCleanerCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IgnoreHeaders",
                 utils::options::serializeStringList(IgnoreHeaders));
+  llvm::SmallVector<StringRef> FragmentHeaderRefs;
+  FragmentHeaderRefs.reserve(FragmentHeaderPatterns.size());
+  for (const auto &Pattern : FragmentHeaderPatterns)
+    FragmentHeaderRefs.push_back(Pattern);
+  Options.store(Opts, "FragmentHeaders",
+                utils::options::serializeStringList(FragmentHeaderRefs));
   Options.store(Opts, "DeduplicateFindings", DeduplicateFindings);
   Options.store(Opts, "UnusedIncludes", UnusedIncludes);
   Options.store(Opts, "MissingIncludes", MissingIncludes);
@@ -123,55 +157,106 @@ void IncludeCleanerCheck::check(const MatchFinder::MatchResult &Result) {
   const FileEntry *MainFile = SM->getFileEntryForID(SM->getMainFileID());
   llvm::DenseSet<const include_cleaner::Include *> Used;
   std::vector<MissingIncludeInfo> Missing;
-  llvm::SmallVector<Decl *> MainFileDecls;
+  // Include-cleaner normally limits analysis to main-file roots (see
+  // https://clangd.llvm.org/design/include-cleaner). Some generated headers
+  // (e.g. TableGen .inc/.def) are fragments of the main file. When configured,
+  // treat direct includes of such headers as part of the main file for usage
+  // scanning, while keeping diagnostics anchored to the main file.
+  // Use UniqueID for stable membership across FileEntry instances.
+  llvm::DenseSet<llvm::sys::fs::UniqueID> FragmentFiles;
+  if (!FragmentHeaderRegexes.empty()) {
+    for (const auto &Inc : RecordedPreprocessor.Includes.all()) {
+      if (!SM->isWrittenInMainFile(SM->getExpansionLoc(Inc.HashLocation)))
+        continue;
+      if (!Inc.Resolved)
+        continue;
+      const llvm::SmallString<128> ResolvedPath =
+          normalizePath(Inc.Resolved->getName());
+      bool IsFragment = matchesAnyRegex(FragmentHeaderRegexes, ResolvedPath);
+      if (!IsFragment) {
+        // Fall back to matching the spelled include for virtual paths.
+        const llvm::SmallString<128> SpelledPath = normalizePath(Inc.Spelled);
+        if (!SpelledPath.empty())
+          IsFragment = matchesAnyRegex(FragmentHeaderRegexes, SpelledPath);
+      }
+      if (IsFragment)
+        FragmentFiles.insert(Inc.Resolved->getUniqueID());
+    }
+  }
+  auto IsAnalyzedDecl = [&](Decl *D) {
+    const SourceLocation Loc = D->getLocation();
+    if (Loc.isInvalid())
+      return false;
+    const SourceLocation ExpandedLoc = SM->getExpansionLoc(Loc);
+    const FileID FID = SM->getFileID(ExpandedLoc);
+    if (FID == SM->getMainFileID())
+      return true;
+    if (FragmentFiles.empty())
+      return false;
+    if (auto FE = SM->getFileEntryRefForID(FID))
+      return FragmentFiles.contains(FE->getUniqueID());
+    return false;
+  };
+  llvm::SmallVector<Decl *> RootDecls;
   for (Decl *D : Result.Nodes.getNodeAs<TranslationUnitDecl>("top")->decls()) {
-    if (!SM->isWrittenInMainFile(SM->getExpansionLoc(D->getLocation())))
+    if (!IsAnalyzedDecl(D))
       continue;
     // FIXME: Filter out implicit template specializations.
-    MainFileDecls.push_back(D);
+    RootDecls.push_back(D);
   }
   llvm::DenseSet<include_cleaner::Symbol> SeenSymbols;
   OptionalDirectoryEntryRef ResourceDir =
       PP->getHeaderSearchInfo().getModuleMap().getBuiltinDir();
+  // include-cleaner filters uses to main/preamble; extend it to fragments.
+  auto IsUsageLocation = [&](FileID FID) {
+    if (FID == SM->getMainFileID() || FID == SM->getPreambleFileID())
+      return true;
+    if (FragmentFiles.empty())
+      return false;
+    if (auto FE = SM->getFileEntryRefForID(FID))
+      return FragmentFiles.contains(FE->getUniqueID());
+    return false;
+  };
   // FIXME: Find a way to have less code duplication between include-cleaner
   // analysis implementation and the below code.
-  walkUsed(MainFileDecls, RecordedPreprocessor.MacroReferences, &RecordedPI,
-           *PP,
-           [&](const include_cleaner::SymbolReference &Ref,
-               llvm::ArrayRef<include_cleaner::Header> Providers) {
-             // Process each symbol once to reduce noise in the findings.
-             // Tidy checks are used in two different workflows:
-             // - Ones that show all the findings for a given file. For such
-             // workflows there is not much point in showing all the occurences,
-             // as one is enough to indicate the issue.
-             // - Ones that show only the findings on changed pieces. For such
-             // workflows it's useful to show findings on every reference of a
-             // symbol as otherwise tools might give incosistent results
-             // depending on the parts of the file being edited. But it should
-             // still help surface findings for "new violations" (i.e.
-             // dependency did not exist in the code at all before).
-             if (DeduplicateFindings && !SeenSymbols.insert(Ref.Target).second)
-               return;
-             bool Satisfied = false;
-             for (const include_cleaner::Header &H : Providers) {
-               if (H.kind() == include_cleaner::Header::Physical &&
-                   (H.physical() == MainFile ||
-                    H.physical().getDir() == ResourceDir)) {
-                 Satisfied = true;
-                 continue;
-               }
+  walkUsed(
+      RootDecls, RecordedPreprocessor.MacroReferences, &RecordedPI, *PP,
+      [&](const include_cleaner::SymbolReference &Ref,
+          llvm::ArrayRef<include_cleaner::Header> Providers) {
+        // Process each symbol once to reduce noise in the findings.
+        // Tidy checks are used in two different workflows:
+        // - Ones that show all the findings for a given file. For such
+        // workflows there is not much point in showing all the occurences,
+        // as one is enough to indicate the issue.
+        // - Ones that show only the findings on changed pieces. For such
+        // workflows it's useful to show findings on every reference of a
+        // symbol as otherwise tools might give incosistent results
+        // depending on the parts of the file being edited. But it should
+        // still help surface findings for "new violations" (i.e.
+        // dependency did not exist in the code at all before).
+        if (DeduplicateFindings && !SeenSymbols.insert(Ref.Target).second)
+          return;
+        bool Satisfied = false;
+        for (const include_cleaner::Header &H : Providers) {
+          if (H.kind() == include_cleaner::Header::Physical &&
+              (H.physical() == MainFile ||
+               H.physical().getDir() == ResourceDir)) {
+            Satisfied = true;
+            continue;
+          }
 
-               for (const include_cleaner::Include *I :
-                    RecordedPreprocessor.Includes.match(H)) {
-                 Used.insert(I);
-                 Satisfied = true;
-               }
-             }
-             if (!Satisfied && !Providers.empty() &&
-                 Ref.RT == include_cleaner::RefType::Explicit &&
-                 !shouldIgnore(Providers.front()))
-               Missing.push_back({Ref, Providers.front()});
-           });
+          for (const include_cleaner::Include *I :
+               RecordedPreprocessor.Includes.match(H)) {
+            Used.insert(I);
+            Satisfied = true;
+          }
+        }
+        if (!Satisfied && !Providers.empty() &&
+            Ref.RT == include_cleaner::RefType::Explicit &&
+            !shouldIgnore(Providers.front()))
+          Missing.push_back({Ref, Providers.front()});
+      },
+      IsUsageLocation);
 
   std::vector<const include_cleaner::Include *> Unused;
   for (const include_cleaner::Include &I :
@@ -224,6 +309,21 @@ void IncludeCleanerCheck::check(const MatchFinder::MatchResult &Result) {
                                                  FileStyle->IncludeStyle);
     // Deduplicate insertions when running in bulk fix mode.
     llvm::StringSet<> InsertedHeaders{};
+    auto DiagLocation = [&](SourceLocation Loc) {
+      SourceLocation SpellingLoc = SM->getSpellingLoc(Loc);
+      if (SM->isWrittenInMainFile(SpellingLoc) || FragmentFiles.empty())
+        return SpellingLoc;
+      const SourceLocation ExpandedLoc = SM->getExpansionLoc(Loc);
+      const FileID FID = SM->getFileID(ExpandedLoc);
+      if (auto FE = SM->getFileEntryRefForID(FID);
+          FE && FragmentFiles.contains(FE->getUniqueID())) {
+        // Map fragment diagnostics to the include site in the main file.
+        SourceLocation IncludeLoc = SM->getIncludeLoc(FID);
+        if (IncludeLoc.isValid())
+          return IncludeLoc;
+      }
+      return SM->getLocForStartOfFile(SM->getMainFileID());
+    };
     for (const auto &Inc : Missing) {
       const std::string Spelling = include_cleaner::spellHeader(
           {Inc.Missing, PP->getHeaderSearchInfo(), MainFile});
@@ -236,7 +336,7 @@ void IncludeCleanerCheck::check(const MatchFinder::MatchResult &Result) {
               llvm::StringRef{Spelling}.trim("\"<>"), Angled,
               tooling::IncludeDirective::Include)) {
         const DiagnosticBuilder DB =
-            diag(SM->getSpellingLoc(Inc.SymRef.RefLocation),
+            diag(DiagLocation(Inc.SymRef.RefLocation),
                  "no header providing \"%0\" is directly included")
             << Inc.SymRef.Target.name();
         if (areDiagsSelfContained() ||

--- a/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.h
@@ -25,7 +25,8 @@
 namespace clang::tidy::misc {
 
 /// Checks for unused and missing includes. Generates findings only for
-/// the main file of a translation unit.
+/// the main file of a translation unit, optionally treating some direct
+/// includes as fragments of the main file for usage scanning.
 /// Findings correspond to https://clangd.llvm.org/design/include-cleaner.
 ///
 /// For the user-facing documentation see:
@@ -45,6 +46,7 @@ private:
   include_cleaner::PragmaIncludes RecordedPI;
   const Preprocessor *PP = nullptr;
   std::vector<StringRef> IgnoreHeaders;
+  llvm::SmallVector<std::string> FragmentHeaderPatterns;
   // Whether emit only one finding per usage of a symbol.
   const bool DeduplicateFindings;
   // Whether to report unused includes.
@@ -52,6 +54,7 @@ private:
   // Whether to report missing includes.
   const bool MissingIncludes;
   llvm::SmallVector<llvm::Regex> IgnoreHeadersRegex;
+  llvm::SmallVector<llvm::Regex> FragmentHeaderRegexes;
   bool shouldIgnore(const include_cleaner::Header &H);
 };
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -199,6 +199,12 @@ Changes in existing checks
   - Added support for analyzing function parameters with the `AnalyzeParameters`
     option.
 
+- Improved :doc:`misc-include-cleaner
+  <clang-tidy/checks/misc/include-cleaner>` check by adding the
+  `FragmentHeaders` option to treat direct includes matching regular
+  expressions as fragments of the main file for usage scanning, preserving
+  main-file includes required only by those fragments.
+
 - Improved :doc:`modernize-use-std-format
   <clang-tidy/checks/modernize/use-std-format>` check by fixing a crash
   when an argument is part of a macro expansion.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
@@ -4,7 +4,8 @@ misc-include-cleaner
 ====================
 
 Checks for unused and missing includes. Generates findings only for
-the main file of a translation unit.
+the main file of a translation unit. Optionally, direct includes can be
+treated as fragments of the main file for usage scanning.
 Findings correspond to https://clangd.llvm.org/design/include-cleaner.
 
 Example:
@@ -33,6 +34,29 @@ Options
    files that match this regex as a suffix.  E.g., `foo/.*` disables
    insertion/removal for all headers under the directory `foo`. Default is an
    empty string, no headers will be ignored.
+
+.. option:: FragmentHeaders
+
+   A semicolon-separated list of regular expressions that match against
+   normalized resolved include paths (POSIX-style separators). Direct includes
+   of the main file that match are treated as fragments of the main file for
+   usage scanning. This is intended for non-self-contained include fragments
+   such as TableGen ``.inc``/``.def`` files or generated headers. Only direct
+   includes are considered; includes inside fragments are not treated as
+   fragments.
+
+   Diagnostics remain anchored to the main file, but symbol uses inside
+   fragments can keep prerequisite includes in the main file from being
+   removed or marked missing. Note that include-cleaner does not support
+   ``// IWYU pragma: associated``.
+
+   Example configuration:
+
+   .. code-block:: yaml
+
+      CheckOptions:
+        - key: misc-include-cleaner.FragmentHeaders
+          value: 'gen-out/;generated/;\\.(inc|def)$'
 
 .. option:: DeduplicateFindings
 

--- a/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Analysis.h
+++ b/clang-tools-extra/include-cleaner/include/clang-include-cleaner/Analysis.h
@@ -25,6 +25,7 @@
 
 namespace clang {
 class SourceLocation;
+class FileID;
 class SourceManager;
 class Decl;
 class FileEntry;
@@ -60,6 +61,12 @@ void walkUsed(llvm::ArrayRef<Decl *> ASTRoots,
               llvm::ArrayRef<SymbolReference> MacroRefs,
               const PragmaIncludes *PI, const Preprocessor &PP,
               UsedSymbolCB CB);
+/// Overload that allows customizing which FileIDs are treated as "main file".
+/// The predicate is evaluated on the spelling file of a reference.
+void walkUsed(llvm::ArrayRef<Decl *> ASTRoots,
+              llvm::ArrayRef<SymbolReference> MacroRefs,
+              const PragmaIncludes *PI, const Preprocessor &PP, UsedSymbolCB CB,
+              llvm::function_ref<bool(FileID)> IsMainFile);
 
 struct AnalysisResults {
   std::vector<const Include *> Unused;


### PR DESCRIPTION
Add a `FragmentHeaders` option to `misc-include-cleaner`. Direct includes of matching headers are treated as fragments of the main file for usage scanning, while diagnostics remain anchored to the main file.

Extend `include-cleaner::walkUsed` with a `FileID` predicate so callers can define main-file semantics (used by clang-tidy to include fragment files). Macro references remain main-file-only.

Add tests for fragment behavior, generated-path matching, non-recursive includes, diagnostic anchoring, and macro uses. Update docs accordingly.