### PR TITLE
[clangd] Add background index path mapping

### DIFF
--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -259,6 +259,7 @@ ClangdServer::ClangdServer(const GlobalCompilationDatabase &CDB,
     };
     BGOpts.ContextProvider = Opts.ContextProvider;
     BGOpts.SupportContainedRefs = Opts.EnableOutgoingCalls;
+    BGOpts.HasPathMappings = !Opts.BackgroundIndexPathMappings.empty();
     BackgroundIdx = std::make_unique<BackgroundIndex>(
         TFS, CDB,
         BackgroundIndexStorage::createDiskBackedStorageFactory(

--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -262,7 +262,8 @@ ClangdServer::ClangdServer(const GlobalCompilationDatabase &CDB,
     BackgroundIdx = std::make_unique<BackgroundIndex>(
         TFS, CDB,
         BackgroundIndexStorage::createDiskBackedStorageFactory(
-            [&CDB](llvm::StringRef File) { return CDB.getProjectInfo(File); }),
+            [&CDB](llvm::StringRef File) { return CDB.getProjectInfo(File); },
+            Opts.BackgroundIndexPathMappings),
         std::move(BGOpts));
     AddIndex(BackgroundIdx.get());
   }

--- a/clang-tools-extra/clangd/ClangdServer.h
+++ b/clang-tools-extra/clangd/ClangdServer.h
@@ -17,6 +17,7 @@
 #include "GlobalCompilationDatabase.h"
 #include "Hover.h"
 #include "ModulesBuilder.h"
+#include "PathMapping.h"
 #include "Protocol.h"
 #include "SemanticHighlighting.h"
 #include "TUScheduler.h"
@@ -198,6 +199,11 @@ public:
     /// Whether to collect and publish information about inactive preprocessor
     /// regions in the document.
     bool PublishInactiveRegions = false;
+
+    /// Path mappings applied to background index files on disk. Used to enable
+    /// sharing of indexes when the client path differs from the path of index
+    /// generation.
+    PathMappings BackgroundIndexPathMappings;
 
     explicit operator TUScheduler::Options() const;
   };

--- a/clang-tools-extra/clangd/PathMapping.cpp
+++ b/clang-tools-extra/clangd/PathMapping.cpp
@@ -45,6 +45,23 @@ std::optional<std::string> doPathMapping(llvm::StringRef S,
   return std::nullopt;
 }
 
+std::optional<std::string> doFilePathMapping(llvm::StringRef FilePath,
+                                             PathMapping::Direction Dir,
+                                             const PathMappings &Mappings) {
+  for (const auto &Mapping : Mappings) {
+    const std::string &From = Dir == PathMapping::Direction::ClientToServer
+                                  ? Mapping.ClientPath
+                                  : Mapping.ServerPath;
+    const std::string &To = Dir == PathMapping::Direction::ClientToServer
+                                ? Mapping.ServerPath
+                                : Mapping.ClientPath;
+    if (FilePath.consume_front(From) &&
+        (FilePath.empty() || FilePath.front() == '/'))
+      return (To + FilePath).str();
+  }
+  return std::nullopt;
+}
+
 void applyPathMappings(llvm::json::Value &V, PathMapping::Direction Dir,
                        const PathMappings &Mappings) {
   using Kind = llvm::json::Value::Kind;

--- a/clang-tools-extra/clangd/PathMapping.h
+++ b/clang-tools-extra/clangd/PathMapping.h
@@ -54,6 +54,12 @@ std::optional<std::string> doPathMapping(llvm::StringRef S,
                                          PathMapping::Direction Dir,
                                          const PathMappings &Mappings);
 
+/// Like doPathMapping, but operates directly on a file path rather than a
+/// file:// URI. Returns std::nullopt if no mapping matches.
+std::optional<std::string> doFilePathMapping(llvm::StringRef FilePath,
+                                             PathMapping::Direction Dir,
+                                             const PathMappings &Mappings);
+
 /// Applies the \p Mappings to all the file:// URIs in \p Params.
 /// NOTE: The first matching mapping will be applied, otherwise \p Params will
 /// be untouched.

--- a/clang-tools-extra/clangd/index/Background.cpp
+++ b/clang-tools-extra/clangd/index/Background.cpp
@@ -97,6 +97,7 @@ BackgroundIndex::BackgroundIndex(
     : SwapIndex(std::make_unique<MemIndex>()), TFS(TFS), CDB(CDB),
       IndexingPriority(Opts.IndexingPriority),
       ContextProvider(std::move(Opts.ContextProvider)),
+      HasPathMappings(Opts.HasPathMappings),
       IndexedSymbols(IndexContents::All, Opts.SupportContainedRefs),
       Rebuilder(this, &IndexedSymbols, Opts.ThreadPoolSize),
       IndexStorageFactory(std::move(IndexStorageFactory)),
@@ -396,6 +397,11 @@ BackgroundIndex::loadProject(std::vector<std::string> MainFiles) {
   }
   Rebuilder.loadedShard(LoadedShards);
   Rebuilder.doneLoading();
+
+  if (HasPathMappings && LoadedShards == 0 && !MainFiles.empty())
+    log("BackgroundIndex: path mappings are configured but no cached shards "
+        "were loaded. Verify mapping direction (local=canonical) and that "
+        "shards exist on disk.");
 
   auto FS = TFS.view(/*CWD=*/std::nullopt);
   llvm::DenseSet<PathRef> TUsToIndex;

--- a/clang-tools-extra/clangd/index/Background.cpp
+++ b/clang-tools-extra/clangd/index/Background.cpp
@@ -74,6 +74,7 @@ llvm::SmallString<128> getAbsolutePath(const tooling::CompileCommand &Cmd) {
     llvm::sys::path::append(AbsolutePath, Cmd.Filename);
     llvm::sys::path::remove_dots(AbsolutePath, true);
   }
+  llvm::sys::path::native(AbsolutePath);
   return AbsolutePath;
 }
 

--- a/clang-tools-extra/clangd/index/Background.h
+++ b/clang-tools-extra/clangd/index/Background.h
@@ -151,6 +151,9 @@ public:
     // Whether the index needs to support the containedRefs() operation.
     // May use extra memory.
     bool SupportContainedRefs = true;
+    // Whether background index path mappings are active. Used to surface
+    // a diagnostic when no cached shards are found.
+    bool HasPathMappings = false;
   };
 
   /// Creates a new background index and starts its threads.
@@ -205,6 +208,7 @@ private:
   const GlobalCompilationDatabase &CDB;
   llvm::ThreadPriority IndexingPriority;
   std::function<Context(PathRef)> ContextProvider;
+  bool HasPathMappings;
 
   llvm::Error index(tooling::CompileCommand);
 

--- a/clang-tools-extra/clangd/index/Background.h
+++ b/clang-tools-extra/clangd/index/Background.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANGD_INDEX_BACKGROUND_H
 
 #include "GlobalCompilationDatabase.h"
+#include "PathMapping.h"
 #include "SourceCode.h"
 #include "index/BackgroundRebuild.h"
 #include "index/FileIndex.h"
@@ -61,8 +62,10 @@ public:
   // CDBDirectory + ".cache/clangd/index/" as the folder to save shards.
   // CDBDirectory is the first directory containing a CDB in parent directories
   // of a file, or user cache directory if none was found, e.g. stdlib headers.
+  // If Mappings are given, paths are remapped before shards are saved to disk.
   static Factory createDiskBackedStorageFactory(
-      std::function<std::optional<ProjectInfo>(PathRef)> GetProjectInfo);
+      std::function<std::optional<ProjectInfo>(PathRef)> GetProjectInfo,
+      PathMappings Mappings);
 };
 
 // A priority queue of tasks which can be run on (external) worker threads.

--- a/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
+++ b/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
@@ -115,6 +115,8 @@ public:
                          IndexFileOut Shard) const override {
     auto ShardPath =
         getShardPathFromFilePath(DiskShardRoot, ShardIdentifier, Mappings);
+    if (!Mappings.empty())
+      Shard.Transform = &StoreTransform;
     return llvm::writeToOutput(ShardPath, [&Shard](llvm::raw_ostream &OS) {
       OS << Shard;
       return llvm::Error::success();

--- a/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
+++ b/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "GlobalCompilationDatabase.h"
+#include "PathMapping.h"
 #include "index/Background.h"
 #include "support/Logger.h"
 #include "support/Path.h"
@@ -150,7 +151,8 @@ private:
 
 BackgroundIndexStorage::Factory
 BackgroundIndexStorage::createDiskBackedStorageFactory(
-    std::function<std::optional<ProjectInfo>(PathRef)> GetProjectInfo) {
+    std::function<std::optional<ProjectInfo>(PathRef)> GetProjectInfo,
+    PathMappings Mappings) {
   return DiskBackedIndexStorageManager(std::move(GetProjectInfo));
 }
 

--- a/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
+++ b/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
@@ -101,8 +101,9 @@ public:
     auto Buffer = llvm::MemoryBuffer::getFile(ShardPath);
     if (!Buffer)
       return nullptr;
-    if (auto I =
-            readIndexFile(Buffer->get()->getBuffer(), SymbolOrigin::Background))
+    const URITransform *Transform = Mappings.empty() ? nullptr : &LoadTransform;
+    if (auto I = readIndexFile(Buffer->get()->getBuffer(),
+                               SymbolOrigin::Background, Transform))
       return std::make_unique<IndexFileIn>(std::move(*I));
     else
       elog("Error while reading shard {0}: {1}", ShardIdentifier,

--- a/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
+++ b/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
@@ -8,7 +8,6 @@
 
 #include "GlobalCompilationDatabase.h"
 #include "PathMapping.h"
-#include "URI.h"
 #include "index/Background.h"
 #include "support/Logger.h"
 #include "support/Path.h"
@@ -74,8 +73,8 @@ std::string getShardPathFromFilePath(llvm::StringRef ShardRoot,
 class DiskBackedIndexStorage : public BackgroundIndexStorage {
   std::string DiskShardRoot;
   PathMappings Mappings;
-  URITransform LoadTransform;
-  URITransform StoreTransform;
+  PathTransform LoadTransform;
+  PathTransform StoreTransform;
 
 public:
   // Creates `DiskShardRoot` and any parents during construction.
@@ -116,7 +115,8 @@ public:
     auto Buffer = llvm::MemoryBuffer::getFile(ShardPath);
     if (!Buffer)
       return nullptr;
-    const URITransform *Transform = Mappings.empty() ? nullptr : &LoadTransform;
+    const PathTransform *Transform =
+        Mappings.empty() ? nullptr : &LoadTransform;
     if (auto I = readIndexFile(Buffer->get()->getBuffer(),
                                SymbolOrigin::Background, Transform))
       return std::make_unique<IndexFileIn>(std::move(*I));

--- a/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
+++ b/clang-tools-extra/clangd/index/BackgroundIndexStorage.cpp
@@ -39,15 +39,11 @@ std::string getShardPathFromFilePath(llvm::StringRef ShardRoot,
                                      llvm::StringRef FilePath,
                                      const PathMappings &Mappings) {
   std::string HashInput;
-  if (Mappings.empty()) {
+  if (auto Remapped = doFilePathMapping(
+          FilePath, PathMapping::Direction::ClientToServer, Mappings))
+    HashInput = std::move(*Remapped);
+  else
     HashInput = FilePath.str();
-  } else {
-    // Hash the mapped URI so that shards are consistently named regardless of
-    // the path of the generating client
-    std::string FileURI = URI::createFile(FilePath).toString();
-    HashInput = applyPathMappingToURI(
-        FileURI, PathMapping::Direction::ClientToServer, Mappings);
-  }
   llvm::SmallString<128> ShardRootSS(ShardRoot);
   llvm::sys::path::append(ShardRootSS,
                           llvm::sys::path::filename(FilePath) + "." +

--- a/clang-tools-extra/clangd/index/Serialization.cpp
+++ b/clang-tools-extra/clangd/index/Serialization.cpp
@@ -172,7 +172,7 @@ class StringTableOut {
   llvm::DenseMap<std::pair<const char *, size_t>, unsigned> Index;
   llvm::BumpPtrAllocator Arena;
   llvm::StringSaver TransformSaver{Arena};
-  const URITransform *Transform = nullptr;
+  const PathTransform *Transform = nullptr;
 
 public:
   StringTableOut() {
@@ -180,7 +180,7 @@ public:
     // Table size zero is reserved to indicate no compression.
     Unique.insert("");
   }
-  void setTransform(const URITransform *T) { Transform = T; }
+  void setTransform(const PathTransform *T) { Transform = T; }
   // Add a string to the table. Overwrites S if an identical string exists.
   // If path remapping is enabled, transform and store the new value.
   void intern(llvm::StringRef &S) {
@@ -228,7 +228,8 @@ struct StringTableIn {
 };
 
 llvm::Expected<StringTableIn>
-readStringTable(llvm::StringRef Data, const URITransform *Transform = nullptr) {
+readStringTable(llvm::StringRef Data,
+                const PathTransform *Transform = nullptr) {
   Reader R(Data);
   size_t UncompressedSize = R.consume32();
   if (R.err())
@@ -478,7 +479,7 @@ readCompileCommand(Reader CmdReader, llvm::ArrayRef<llvm::StringRef> Strings) {
 constexpr static uint32_t Version = 20;
 
 llvm::Expected<IndexFileIn> readRIFF(llvm::StringRef Data, SymbolOrigin Origin,
-                                     const URITransform *Transform) {
+                                     const PathTransform *Transform) {
   auto RIFF = riff::readFile(Data);
   if (!RIFF)
     return RIFF.takeError();
@@ -712,7 +713,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const IndexFileOut &O) {
 
 llvm::Expected<IndexFileIn> readIndexFile(llvm::StringRef Data,
                                           SymbolOrigin Origin,
-                                          const URITransform *Transform) {
+                                          const PathTransform *Transform) {
   if (Data.starts_with("RIFF")) {
     return readRIFF(Data, Origin, Transform);
   }

--- a/clang-tools-extra/clangd/index/Serialization.h
+++ b/clang-tools-extra/clangd/index/Serialization.h
@@ -36,7 +36,9 @@ namespace clang {
 namespace clangd {
 
 // Used to remap URIs and paths during serialization/deserialization.
-using PathTransform = llvm::unique_function<std::string(llvm::StringRef) const>;
+// Return std::nullopt if the path was not transformed.
+using PathTransform =
+    llvm::unique_function<std::optional<std::string>(llvm::StringRef) const>;
 
 enum class IndexFileFormat {
   RIFF, // Versioned binary format, suitable for production use.

--- a/clang-tools-extra/clangd/index/Serialization.h
+++ b/clang-tools-extra/clangd/index/Serialization.h
@@ -69,6 +69,7 @@ struct IndexFileOut {
   // TODO: Support serializing Dex posting lists.
   IndexFileFormat Format = IndexFileFormat::RIFF;
   const tooling::CompileCommand *Cmd = nullptr;
+  const URITransform *Transform = nullptr;
 
   IndexFileOut() = default;
   IndexFileOut(const IndexFileIn &I)

--- a/clang-tools-extra/clangd/index/Serialization.h
+++ b/clang-tools-extra/clangd/index/Serialization.h
@@ -54,7 +54,10 @@ struct IndexFileIn {
   std::optional<tooling::CompileCommand> Cmd;
 };
 // Parse an index file. The input must be a RIFF or YAML file.
-llvm::Expected<IndexFileIn> readIndexFile(llvm::StringRef, SymbolOrigin);
+// If Transform is provided, use it to remap all URIs.
+llvm::Expected<IndexFileIn>
+readIndexFile(llvm::StringRef, SymbolOrigin,
+              const URITransform *Transform = nullptr);
 
 // Specifies the contents of an index file to be written.
 struct IndexFileOut {

--- a/clang-tools-extra/clangd/index/Serialization.h
+++ b/clang-tools-extra/clangd/index/Serialization.h
@@ -28,11 +28,15 @@
 #include "index/Index.h"
 #include "index/Symbol.h"
 #include "clang/Tooling/CompilationDatabase.h"
+#include "llvm/ADT/FunctionExtras.h"
 #include "llvm/Support/Error.h"
 #include <optional>
 
 namespace clang {
 namespace clangd {
+
+// Used to remap URIs during serialization/deserialization
+using URITransform = llvm::unique_function<std::string(llvm::StringRef) const>;
 
 enum class IndexFileFormat {
   RIFF, // Versioned binary format, suitable for production use.

--- a/clang-tools-extra/clangd/index/Serialization.h
+++ b/clang-tools-extra/clangd/index/Serialization.h
@@ -35,8 +35,8 @@
 namespace clang {
 namespace clangd {
 
-// Used to remap URIs during serialization/deserialization
-using URITransform = llvm::unique_function<std::string(llvm::StringRef) const>;
+// Used to remap URIs and paths during serialization/deserialization.
+using PathTransform = llvm::unique_function<std::string(llvm::StringRef) const>;
 
 enum class IndexFileFormat {
   RIFF, // Versioned binary format, suitable for production use.
@@ -57,7 +57,7 @@ struct IndexFileIn {
 // If Transform is provided, use it to remap all URIs.
 llvm::Expected<IndexFileIn>
 readIndexFile(llvm::StringRef, SymbolOrigin,
-              const URITransform *Transform = nullptr);
+              const PathTransform *Transform = nullptr);
 
 // Specifies the contents of an index file to be written.
 struct IndexFileOut {
@@ -69,7 +69,7 @@ struct IndexFileOut {
   // TODO: Support serializing Dex posting lists.
   IndexFileFormat Format = IndexFileFormat::RIFF;
   const tooling::CompileCommand *Cmd = nullptr;
-  const URITransform *Transform = nullptr;
+  const PathTransform *Transform = nullptr;
 
   IndexFileOut() = default;
   IndexFileOut(const IndexFileIn &I)

--- a/clang-tools-extra/clangd/test/background-index-path-mappings.test
+++ b/clang-tools-extra/clangd/test/background-index-path-mappings.test
@@ -1,102 +1,39 @@
-# Generate a canonical index at %/t. A second client at %/t2 loads the shards,
-# mapping its local paths to the canonical paths. The on-disk shards always
-# contain canonical paths.
+# Generate a canonical index at %/t, then copy the shards to a second workspace
+# at %/t2. Using --background-index-path-mappings, the second client should
+# reuse the transferred shards without reindexing and go-to-definition should
+# return local paths.
 
+# Build the canonical index at %/t
 # RUN: rm -rf %/t
 # RUN: cp -r %/S/Inputs/background-index %/t
 # RUN: sed -e "s|DIRECTORY|%/t|" %/t/definition.jsonrpc.tmpl > %/t/definition.jsonrpc.1
 # RUN: sed -e "s|DIRECTORY|%/t|" %/t/compile_commands.json.tmpl > %/t/compile_commands.json
 # On Windows, we need the URI in didOpen to look like "uri":"file:///C:/..."
 # RUN: sed -E -e 's|"file://([A-Z]):/|"file:///\1:/|g' %/t/definition.jsonrpc.1 > %/t/definition.jsonrpc
-
-# Generate the canonical background index with no path mapping
 # RUN: clangd -background-index -lit-test < %/t/definition.jsonrpc | FileCheck %/t/definition.jsonrpc
 
-###############################################################################
-# 1. Validate shard contents contain canonical paths
-###############################################################################
-
-# RUN: cp %/t/.cache/clangd/index/foo.cpp.*.idx %/t/foo.cpp.idx
-# RUN: dexp %/t/foo.cpp.idx -c "export %/t/foo.yaml -format=yaml"
-# RUN: FileCheck --check-prefix=SHARD-CONTENT %s -DDIR=%/t < %/t/foo.yaml
-
-# SHARD-CONTENT: --- !Symbol
-# SHARD-CONTENT: Name:{{.*}}foo
-# SHARD-CONTENT: CanonicalDeclaration:
-# SHARD-CONTENT:   FileURI:{{.*}}[[DIR]]/sub_dir/foo.h
-# SHARD-CONTENT: Definition:
-# SHARD-CONTENT:   FileURI:{{.*}}[[DIR]]/foo.cpp
-
-# SHARD-CONTENT: IncludeHeaders:
-# SHARD-CONTENT:   - Header:{{.*}}[[DIR]]/sub_dir/foo.h
-
-# SHARD-CONTENT: --- !Refs
-# SHARD-CONTENT: References:
-# SHARD-CONTENT:   FileURI:{{.*}}[[DIR]]/foo.cpp
-
-# SHARD-CONTENT: --- !Source
-# SHARD-CONTENT: URI:{{.*}}[[DIR]]/
-
-###############################################################################
-# 2. Validate the second client loads and remaps the shards
-###############################################################################
-
-# Set up the second client's workspace with the same source content.
+# Set up a second workspace at %/t2 with the same source and copied shards
 # RUN: rm -rf %/t2
 # RUN: mkdir -p %/t2
 # RUN: cp -r %/S/Inputs/background-index/* %/t2/
-
-# Copy the canonical index data to the second client's cache directory.
 # RUN: mkdir -p %/t2/.cache/clangd/index
 # RUN: cp %/t/.cache/clangd/index/*.idx %/t2/.cache/clangd/index/
 # RUN: mkdir -p %/t2/sub_dir/.cache/clangd/index
 # RUN: cp %/t/sub_dir/.cache/clangd/index/*.idx %/t2/sub_dir/.cache/clangd/index/
-
-# Set up the second client's compile_commands.json and request file.
 # RUN: sed -e "s|DIRECTORY|%/t2|" %/S/Inputs/background-index/compile_commands.json.tmpl > %/t2/compile_commands.json
 # RUN: sed -e "s|DIRECTORY|%/t2|" %/S/Inputs/background-index/definition.jsonrpc.tmpl > %/t2/definition.jsonrpc.1
 # RUN: sed -E -e 's|"file://([A-Z]):/|"file:///\1:/|g' %/t2/definition.jsonrpc.1 > %/t2/definition.jsonrpc
 
-# The mapping %/t2=%/t tells clangd that the local path %/t2 corresponds to
-# the canonical path %/t stored in the shards. clangd should load the shards
-# and translate canonical paths to local paths in memory. Go-to-definition
-# should work and return the local path.
+# Run clangd in the second workspace with a path mapping from local to canonical
 # RUN: clangd -background-index --background-index-path-mappings=%/t2=%/t -lit-test < %/t2/definition.jsonrpc > %/t2/clangd-output.json
-# RUN: FileCheck %/t2/definition.jsonrpc < %/t2/clangd-output.json
-# RUN: FileCheck --check-prefix=LOCAL-RESULT %s -DDIR=%/t2 < %/t2/clangd-output.json
-# Handle the extra slash needed on Windows
-# LOCAL-RESULT: "uri": "file://{{/?}}[[DIR]]/foo.cpp"
 
-# Verify the shard filenames are unchanged, proving that the canonical path
-# mapping was used for hashing rather than re-indexing with local paths.
+# Go-to-definition should work and return a local (%/t2) path
+# RUN: FileCheck %/t2/definition.jsonrpc < %/t2/clangd-output.json
+# On Windows, strip the extra / from file:///C:/ URIs to normalize for FileCheck.
+# RUN: sed -E -e 's|"file:///([A-Z]):/|"file://\1:/|g' %/t2/clangd-output.json | FileCheck --check-prefix=LOCAL-RESULT %s -DDIR=%/t2
+# LOCAL-RESULT: "uri": "file://[[DIR]]/foo.cpp"
+
+# The shard filenames must be unchanged, proving that no reindexing occurred
 # RUN: ls %/t/.cache/clangd/index/ | sort > %/t/shards-canonical.txt
 # RUN: ls %/t2/.cache/clangd/index/ | sort > %/t2/shards-local.txt
 # RUN: diff %/t/shards-canonical.txt %/t2/shards-local.txt
-
-###############################################################################
-# 3. Validate multiple comma-separated path mappings
-###############################################################################
-
-# Set up a third client at %/t3 with the same sources and copied shards.
-# RUN: rm -rf %/t3
-# RUN: mkdir -p %/t3
-# RUN: cp -r %/S/Inputs/background-index/* %/t3/
-# RUN: mkdir -p %/t3/.cache/clangd/index
-# RUN: cp %/t/.cache/clangd/index/*.idx %/t3/.cache/clangd/index/
-# RUN: mkdir -p %/t3/sub_dir/.cache/clangd/index
-# RUN: cp %/t/sub_dir/.cache/clangd/index/*.idx %/t3/sub_dir/.cache/clangd/index/
-# RUN: sed -e "s|DIRECTORY|%/t3|" %/S/Inputs/background-index/compile_commands.json.tmpl > %/t3/compile_commands.json
-# RUN: sed -e "s|DIRECTORY|%/t3|" %/S/Inputs/background-index/definition.jsonrpc.tmpl > %/t3/definition.jsonrpc.1
-# RUN: sed -E -e 's|"file://([A-Z]):/|"file:///\1:/|g' %/t3/definition.jsonrpc.1 > %/t3/definition.jsonrpc
-
-# The first specified mapping is intentionally non-matching; the second is the
-# real mapping. This validates that multiple mappings can be specified and the
-# correct one is applied.
-# RUN: clangd -background-index --background-index-path-mappings=/no/match=/also/no/match,%/t3=%/t -lit-test < %/t3/definition.jsonrpc > %/t3/clangd-output.json
-# RUN: FileCheck %/t3/definition.jsonrpc < %/t3/clangd-output.json
-# RUN: FileCheck --check-prefix=MULTI-LOCAL %s -DDIR=%/t3 < %/t3/clangd-output.json
-# MULTI-LOCAL: "uri": "file://{{/?}}[[DIR]]/foo.cpp"
-
-# Verify shard filenames are unchanged with multiple mappings
-# RUN: ls %/t3/.cache/clangd/index/ | sort > %/t3/shards-multi.txt
-# RUN: diff %/t/shards-canonical.txt %/t3/shards-multi.txt

--- a/clang-tools-extra/clangd/test/background-index-path-mappings.test
+++ b/clang-tools-extra/clangd/test/background-index-path-mappings.test
@@ -1,0 +1,87 @@
+# Use a copy of inputs, as we'll mutate it (as will the background index).
+# RUN: rm -rf %/t
+# RUN: cp -r %/S/Inputs/background-index %/t
+# Need to embed the correct temp path in the actual JSON-RPC requests.
+# RUN: sed -e "s|DIRECTORY|%/t|" %/t/definition.jsonrpc.tmpl > %/t/definition.jsonrpc.1
+# RUN: sed -e "s|DIRECTORY|%/t|" %/t/compile_commands.json.tmpl > %/t/compile_commands.json
+# On Windows, we need the URI in didOpen to look like "uri":"file:///C:/..."
+# (with the extra slash in the front), so we add it here
+# RUN: sed -E -e 's|"file://([A-Z]):/|"file:///\1:/|g' %/t/definition.jsonrpc.1 > %/t/definition.jsonrpc
+
+# Create the background index files with path mappings
+# RUN: clangd -background-index --background-index-path-mappings=%/t=/MAPPED_ROOT -lit-test < %/t/definition.jsonrpc | FileCheck %/t/definition.jsonrpc
+
+###############################################################################
+# 1. Validate shard filenames use the mapped path (not actual path) for hashing
+###############################################################################
+
+# The hash of "file:///MAPPED_ROOT/foo.cpp" is deterministic
+# RUN: ls %/t/.cache/clangd/index/foo.cpp.*.idx | FileCheck --check-prefix=MAPPED-HASH %s
+# MAPPED-HASH: foo.cpp.BE43CE222BC6EF16.idx
+
+###############################################################################
+# 2. Validate shard on-disk contents contain mapped paths, not actual paths
+###############################################################################
+
+# Copy the index file to a known location so we can pass it to dexp
+# RUN: cp %/t/.cache/clangd/index/foo.cpp.*.idx %/t/foo.cpp.idx
+
+# Export the shard to YAML format to validate its contents
+# RUN: dexp %/t/foo.cpp.idx -c "export %/t/foo.yaml -format=yaml"
+
+# RUN: FileCheck --check-prefix=SHARD-CONTENT %s < %/t/foo.yaml
+
+# Verify that the symbol 'foo' has URIs with /MAPPED_ROOT prefix
+# SHARD-CONTENT: --- !Symbol
+# SHARD-CONTENT: Name:{{.*}}foo
+# SHARD-CONTENT: CanonicalDeclaration:
+# SHARD-CONTENT:   FileURI:{{.*}}/MAPPED_ROOT/sub_dir/foo.h
+# SHARD-CONTENT: Definition:
+# SHARD-CONTENT:   FileURI:{{.*}}/MAPPED_ROOT/foo.cpp
+
+# Verify that IncludeHeaders also uses the mapped path
+# SHARD-CONTENT: IncludeHeaders:
+# SHARD-CONTENT:   - Header:{{.*}}/MAPPED_ROOT/sub_dir/foo.h
+
+# Verify that Refs use the mapped path
+# SHARD-CONTENT: --- !Refs
+# SHARD-CONTENT: References:
+# SHARD-CONTENT:   FileURI:{{.*}}/MAPPED_ROOT/foo.cpp
+
+# Verify that Sources use the mapped path
+# SHARD-CONTENT: --- !Source
+# SHARD-CONTENT: URI:{{.*}}/MAPPED_ROOT/
+
+# Verify that the Cmd section keeps original paths (not mapped), since compile
+# commands are machine-specific
+# SHARD-CONTENT: --- !Cmd
+# SHARD-CONTENT: Directory:
+# SHARD-CONTENT-NOT: MAPPED_ROOT
+
+###############################################################################
+# 3. Validate loading shards reverses the path mapping to the local path
+###############################################################################
+
+# Create "Client B" directory with a different path but same source content
+# RUN: rm -rf %/t2
+# RUN: mkdir -p %/t2
+# RUN: cp -r %/S/Inputs/background-index/* %/t2/
+
+# Copy "Client A" index data to "Client B" cache directory
+# RUN: mkdir -p %/t2/.cache/clangd/index
+# RUN: cp %/t/.cache/clangd/index/*.idx %/t2/.cache/clangd/index/
+# RUN: mkdir -p %/t2/sub_dir/.cache/clangd/index
+# RUN: cp %/t/sub_dir/.cache/clangd/index/*.idx %/t2/sub_dir/.cache/clangd/index/
+
+# Set up "Client B" compile_commands.json and request file
+# RUN: sed -e "s|DIRECTORY|%/t2|" %/S/Inputs/background-index/compile_commands.json.tmpl > %/t2/compile_commands.json
+# RUN: sed -e "s|DIRECTORY|%/t2|" %/S/Inputs/background-index/definition.jsonrpc.tmpl > %/t2/definition.jsonrpc.1
+# RUN: sed -E -e 's|"file://([A-Z]):/|"file:///\1:/|g' %/t2/definition.jsonrpc.1 > %/t2/definition.jsonrpc
+
+# clangd should load "Client A" shards, mapping data to "Client B" local paths.
+# Verify both that go-to-definition works (in definition.jsonrpc) and that the
+# returned URI points to a "Client B" path.
+# RUN: clangd -background-index --background-index-path-mappings=%/t2=/MAPPED_ROOT -lit-test < %/t2/definition.jsonrpc > %/t2/clangd-output.json
+# RUN: FileCheck %/t2/definition.jsonrpc < %/t2/clangd-output.json
+# RUN: FileCheck --check-prefix=ROUNDTRIP %s -DDIR=%/t2 < %/t2/clangd-output.json
+# ROUNDTRIP: "uri": "file://[[DIR]]/foo.cpp"

--- a/clang-tools-extra/clangd/test/background-index-path-mappings.test
+++ b/clang-tools-extra/clangd/test/background-index-path-mappings.test
@@ -84,4 +84,5 @@
 # RUN: clangd -background-index --background-index-path-mappings=%/t2=/MAPPED_ROOT -lit-test < %/t2/definition.jsonrpc > %/t2/clangd-output.json
 # RUN: FileCheck %/t2/definition.jsonrpc < %/t2/clangd-output.json
 # RUN: FileCheck --check-prefix=ROUNDTRIP %s -DDIR=%/t2 < %/t2/clangd-output.json
-# ROUNDTRIP: "uri": "file://[[DIR]]/foo.cpp"
+# Handle the extra slash needed on Windows
+# ROUNDTRIP: "uri": "file://{{/?}}[[DIR]]/foo.cpp"

--- a/clang-tools-extra/clangd/test/background-index-path-mappings.test
+++ b/clang-tools-extra/clangd/test/background-index-path-mappings.test
@@ -1,88 +1,74 @@
-# Use a copy of inputs, as we'll mutate it (as will the background index).
+# Generate a canonical index at %/t. A second client at %/t2 loads the shards,
+# mapping its local paths to the canonical paths. The on-disk shards always
+# contain canonical paths.
+
 # RUN: rm -rf %/t
 # RUN: cp -r %/S/Inputs/background-index %/t
-# Need to embed the correct temp path in the actual JSON-RPC requests.
 # RUN: sed -e "s|DIRECTORY|%/t|" %/t/definition.jsonrpc.tmpl > %/t/definition.jsonrpc.1
 # RUN: sed -e "s|DIRECTORY|%/t|" %/t/compile_commands.json.tmpl > %/t/compile_commands.json
 # On Windows, we need the URI in didOpen to look like "uri":"file:///C:/..."
-# (with the extra slash in the front), so we add it here
 # RUN: sed -E -e 's|"file://([A-Z]):/|"file:///\1:/|g' %/t/definition.jsonrpc.1 > %/t/definition.jsonrpc
 
-# Create the background index files with path mappings
-# RUN: clangd -background-index --background-index-path-mappings=%/t=/MAPPED_ROOT -lit-test < %/t/definition.jsonrpc | FileCheck %/t/definition.jsonrpc
+# Generate the canonical background index with no path mapping
+# RUN: clangd -background-index -lit-test < %/t/definition.jsonrpc | FileCheck %/t/definition.jsonrpc
 
 ###############################################################################
-# 1. Validate shard filenames use the mapped path (not actual path) for hashing
+# 1. Validate shard contents contain canonical paths
 ###############################################################################
 
-# The hash of "file:///MAPPED_ROOT/foo.cpp" is deterministic
-# RUN: ls %/t/.cache/clangd/index/foo.cpp.*.idx | FileCheck --check-prefix=MAPPED-HASH %s
-# MAPPED-HASH: foo.cpp.BE43CE222BC6EF16.idx
-
-###############################################################################
-# 2. Validate shard on-disk contents contain mapped paths, not actual paths
-###############################################################################
-
-# Copy the index file to a known location so we can pass it to dexp
 # RUN: cp %/t/.cache/clangd/index/foo.cpp.*.idx %/t/foo.cpp.idx
-
-# Export the shard to YAML format to validate its contents
 # RUN: dexp %/t/foo.cpp.idx -c "export %/t/foo.yaml -format=yaml"
+# RUN: FileCheck --check-prefix=SHARD-CONTENT %s -DDIR=%/t < %/t/foo.yaml
 
-# RUN: FileCheck --check-prefix=SHARD-CONTENT %s < %/t/foo.yaml
-
-# Verify that the symbol 'foo' has URIs with /MAPPED_ROOT prefix
 # SHARD-CONTENT: --- !Symbol
 # SHARD-CONTENT: Name:{{.*}}foo
 # SHARD-CONTENT: CanonicalDeclaration:
-# SHARD-CONTENT:   FileURI:{{.*}}/MAPPED_ROOT/sub_dir/foo.h
+# SHARD-CONTENT:   FileURI:{{.*}}[[DIR]]/sub_dir/foo.h
 # SHARD-CONTENT: Definition:
-# SHARD-CONTENT:   FileURI:{{.*}}/MAPPED_ROOT/foo.cpp
+# SHARD-CONTENT:   FileURI:{{.*}}[[DIR]]/foo.cpp
 
-# Verify that IncludeHeaders also uses the mapped path
 # SHARD-CONTENT: IncludeHeaders:
-# SHARD-CONTENT:   - Header:{{.*}}/MAPPED_ROOT/sub_dir/foo.h
+# SHARD-CONTENT:   - Header:{{.*}}[[DIR]]/sub_dir/foo.h
 
-# Verify that Refs use the mapped path
 # SHARD-CONTENT: --- !Refs
 # SHARD-CONTENT: References:
-# SHARD-CONTENT:   FileURI:{{.*}}/MAPPED_ROOT/foo.cpp
+# SHARD-CONTENT:   FileURI:{{.*}}[[DIR]]/foo.cpp
 
-# Verify that Sources use the mapped path
 # SHARD-CONTENT: --- !Source
-# SHARD-CONTENT: URI:{{.*}}/MAPPED_ROOT/
-
-# Verify that the Cmd section keeps original paths (not mapped), since compile
-# commands are machine-specific
-# SHARD-CONTENT: --- !Cmd
-# SHARD-CONTENT: Directory:
-# SHARD-CONTENT-NOT: MAPPED_ROOT
+# SHARD-CONTENT: URI:{{.*}}[[DIR]]/
 
 ###############################################################################
-# 3. Validate loading shards reverses the path mapping to the local path
+# 2. Validate the second client loads and remaps the shards
 ###############################################################################
 
-# Create "Client B" directory with a different path but same source content
+# Set up the second client's workspace with the same source content.
 # RUN: rm -rf %/t2
 # RUN: mkdir -p %/t2
 # RUN: cp -r %/S/Inputs/background-index/* %/t2/
 
-# Copy "Client A" index data to "Client B" cache directory
+# Copy the canonical index data to the second client's cache directory.
 # RUN: mkdir -p %/t2/.cache/clangd/index
 # RUN: cp %/t/.cache/clangd/index/*.idx %/t2/.cache/clangd/index/
 # RUN: mkdir -p %/t2/sub_dir/.cache/clangd/index
 # RUN: cp %/t/sub_dir/.cache/clangd/index/*.idx %/t2/sub_dir/.cache/clangd/index/
 
-# Set up "Client B" compile_commands.json and request file
+# Set up the second client's compile_commands.json and request file.
 # RUN: sed -e "s|DIRECTORY|%/t2|" %/S/Inputs/background-index/compile_commands.json.tmpl > %/t2/compile_commands.json
 # RUN: sed -e "s|DIRECTORY|%/t2|" %/S/Inputs/background-index/definition.jsonrpc.tmpl > %/t2/definition.jsonrpc.1
 # RUN: sed -E -e 's|"file://([A-Z]):/|"file:///\1:/|g' %/t2/definition.jsonrpc.1 > %/t2/definition.jsonrpc
 
-# clangd should load "Client A" shards, mapping data to "Client B" local paths.
-# Verify both that go-to-definition works (in definition.jsonrpc) and that the
-# returned URI points to a "Client B" path.
-# RUN: clangd -background-index --background-index-path-mappings=%/t2=/MAPPED_ROOT -lit-test < %/t2/definition.jsonrpc > %/t2/clangd-output.json
+# The mapping %/t2=%/t tells clangd that the local path %/t2 corresponds to
+# the canonical path %/t stored in the shards. clangd should load the shards
+# and translate canonical paths to local paths in memory. Go-to-definition
+# should work and return the local path.
+# RUN: clangd -background-index --background-index-path-mappings=%/t2=%/t -lit-test < %/t2/definition.jsonrpc > %/t2/clangd-output.json
 # RUN: FileCheck %/t2/definition.jsonrpc < %/t2/clangd-output.json
-# RUN: FileCheck --check-prefix=ROUNDTRIP %s -DDIR=%/t2 < %/t2/clangd-output.json
+# RUN: FileCheck --check-prefix=LOCAL-RESULT %s -DDIR=%/t2 < %/t2/clangd-output.json
 # Handle the extra slash needed on Windows
-# ROUNDTRIP: "uri": "file://{{/?}}[[DIR]]/foo.cpp"
+# LOCAL-RESULT: "uri": "file://{{/?}}[[DIR]]/foo.cpp"
+
+# Verify the shard filenames are unchanged, proving that the canonical path
+# mapping was used for hashing rather than re-indexing with local paths.
+# RUN: ls %/t/.cache/clangd/index/ | sort > %/t/shards-canonical.txt
+# RUN: ls %/t2/.cache/clangd/index/ | sort > %/t2/shards-local.txt
+# RUN: diff %/t/shards-canonical.txt %/t2/shards-local.txt

--- a/clang-tools-extra/clangd/test/background-index-path-mappings.test
+++ b/clang-tools-extra/clangd/test/background-index-path-mappings.test
@@ -72,3 +72,31 @@
 # RUN: ls %/t/.cache/clangd/index/ | sort > %/t/shards-canonical.txt
 # RUN: ls %/t2/.cache/clangd/index/ | sort > %/t2/shards-local.txt
 # RUN: diff %/t/shards-canonical.txt %/t2/shards-local.txt
+
+###############################################################################
+# 3. Validate multiple comma-separated path mappings
+###############################################################################
+
+# Set up a third client at %/t3 with the same sources and copied shards.
+# RUN: rm -rf %/t3
+# RUN: mkdir -p %/t3
+# RUN: cp -r %/S/Inputs/background-index/* %/t3/
+# RUN: mkdir -p %/t3/.cache/clangd/index
+# RUN: cp %/t/.cache/clangd/index/*.idx %/t3/.cache/clangd/index/
+# RUN: mkdir -p %/t3/sub_dir/.cache/clangd/index
+# RUN: cp %/t/sub_dir/.cache/clangd/index/*.idx %/t3/sub_dir/.cache/clangd/index/
+# RUN: sed -e "s|DIRECTORY|%/t3|" %/S/Inputs/background-index/compile_commands.json.tmpl > %/t3/compile_commands.json
+# RUN: sed -e "s|DIRECTORY|%/t3|" %/S/Inputs/background-index/definition.jsonrpc.tmpl > %/t3/definition.jsonrpc.1
+# RUN: sed -E -e 's|"file://([A-Z]):/|"file:///\1:/|g' %/t3/definition.jsonrpc.1 > %/t3/definition.jsonrpc
+
+# The first specified mapping is intentionally non-matching; the second is the
+# real mapping. This validates that multiple mappings can be specified and the
+# correct one is applied.
+# RUN: clangd -background-index --background-index-path-mappings=/no/match=/also/no/match,%/t3=%/t -lit-test < %/t3/definition.jsonrpc > %/t3/clangd-output.json
+# RUN: FileCheck %/t3/definition.jsonrpc < %/t3/clangd-output.json
+# RUN: FileCheck --check-prefix=MULTI-LOCAL %s -DDIR=%/t3 < %/t3/clangd-output.json
+# MULTI-LOCAL: "uri": "file://{{/?}}[[DIR]]/foo.cpp"
+
+# Verify shard filenames are unchanged with multiple mappings
+# RUN: ls %/t3/.cache/clangd/index/ | sort > %/t3/shards-multi.txt
+# RUN: diff %/t/shards-canonical.txt %/t3/shards-multi.txt

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -955,8 +955,11 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
       return 1;
     }
     Opts.BackgroundIndexPathMappings = std::move(*Mappings);
-    for (const auto &M : Opts.BackgroundIndexPathMappings)
-      log("Background index path mapping: {0}", M);
+    for (const auto &M : Opts.BackgroundIndexPathMappings) {
+      if (!llvm::sys::fs::exists(M.ClientPath))
+        log("BackgroundIndex: local mapping path does not exist: {0}",
+            M.ClientPath);
+    }
   }
   Opts.ReferencesLimit = ReferencesLimit;
   Opts.Rename.LimitFiles = RenameFileLimit;

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -435,6 +435,16 @@ opt<bool> EnableTestScheme{
     Hidden,
 };
 
+opt<std::string> BackgroundIndexPathMappings{
+    "background-index-path-mappings",
+    cat(Protocol),
+    desc("Translate clients paths prior to writing background index files to "
+         "disk. Enables sharing of background index files between clients. "
+         "Format is identical to --path-mappings. "
+         "e.g. /local/workspace=/TOKEN/workspace"),
+    init(""),
+};
+
 opt<std::string> PathMappingsArg{
     "path-mappings",
     cat(Protocol),
@@ -937,6 +947,15 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
 #endif
   Opts.BackgroundIndex = EnableBackgroundIndex;
   Opts.BackgroundIndexPriority = BackgroundIndexPriority;
+  if (!BackgroundIndexPathMappings.empty()) {
+    auto Mappings = parsePathMappings(BackgroundIndexPathMappings);
+    if (!Mappings) {
+      elog("Invalid --background-index-path-mappings: {0}",
+           Mappings.takeError());
+      return 1;
+    }
+    Opts.BackgroundIndexPathMappings = std::move(*Mappings);
+  }
   Opts.ReferencesLimit = ReferencesLimit;
   Opts.Rename.LimitFiles = RenameFileLimit;
   auto PAI = createProjectAwareIndex(

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -438,10 +438,10 @@ opt<bool> EnableTestScheme{
 opt<std::string> BackgroundIndexPathMappings{
     "background-index-path-mappings",
     cat(Protocol),
-    desc("Translate clients paths prior to writing background index files to "
-         "disk. Enables sharing of background index files between clients. "
+    desc("Translate client paths when reading and writing background index "
+         "files. Enables sharing of background index files between clients. "
          "Format is identical to --path-mappings. "
-         "e.g. /local/workspace=/TOKEN/workspace"),
+         "e.g. /home/project=/workarea/project"),
     init(""),
 };
 

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -955,6 +955,8 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
       return 1;
     }
     Opts.BackgroundIndexPathMappings = std::move(*Mappings);
+    for (const auto &M : Opts.BackgroundIndexPathMappings)
+      log("Background index path mapping: {0}", M);
   }
   Opts.ReferencesLimit = ReferencesLimit;
   Opts.Rename.LimitFiles = RenameFileLimit;

--- a/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
+++ b/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
@@ -2,6 +2,8 @@
 #include "CompileCommands.h"
 #include "Config.h"
 #include "Headers.h"
+#include "PathMapping.h"
+#include "SourceCode.h"
 #include "SyncAPI.h"
 #include "TestFS.h"
 #include "TestTU.h"
@@ -11,6 +13,8 @@
 #include "clang/Tooling/ArgumentsAdjusters.h"
 #include "clang/Tooling/CompilationDatabase.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/ScopedPrinter.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -1029,6 +1033,38 @@ TEST(BackgroundIndex, Profile) {
   Idx.profile(MT);
   ASSERT_THAT(MT.children(),
               UnorderedElementsAre(Pair("slabs", _), Pair("index", _)));
+}
+
+// Verify shard filenames are unchanged when no path mappings are used
+TEST(BackgroundIndexStorage, ShardFilenameUnchangedWithoutPathMappings) {
+  llvm::SmallString<256> TempDir;
+  ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory("clangd-test", TempDir));
+  llvm::scope_exit Cleanup([&] { llvm::sys::fs::remove_directories(TempDir); });
+
+  auto Factory = BackgroundIndexStorage::createDiskBackedStorageFactory(
+      [&](PathRef) -> std::optional<ProjectInfo> {
+        return ProjectInfo{TempDir.str().str()};
+      },
+      /*Mappings=*/{});
+
+  std::string TestFilePath = (TempDir + "/foo.cpp").str();
+  BackgroundIndexStorage *Storage = Factory(TestFilePath);
+  ASSERT_NE(Storage, nullptr);
+
+  // Store a minimal shard to create the file
+  SymbolSlab::Builder SB;
+  SymbolSlab Symbols = std::move(SB).build();
+  IndexFileOut Shard;
+  Shard.Symbols = &Symbols;
+  ASSERT_FALSE(Storage->storeShard(TestFilePath, std::move(Shard)));
+
+  // Shard filename hash must be based on TestFilePath, not a file:// URI
+  llvm::SmallString<256> ExpectedPath(TempDir);
+  llvm::sys::path::append(ExpectedPath, ".cache", "clangd", "index",
+                          "foo.cpp." + llvm::toHex(digest(TestFilePath)) +
+                              ".idx");
+  EXPECT_TRUE(llvm::sys::fs::exists(ExpectedPath))
+      << "Expected shard file not found: " << ExpectedPath;
 }
 
 } // namespace clangd

--- a/clang-tools-extra/clangd/unittests/SerializationTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SerializationTests.cpp
@@ -451,21 +451,27 @@ TEST(SerializationTest, NoCrashOnBadStringTableSize) {
 TEST(SerializationTest, PathTransformRoundTrip) {
   // Store transform: map /workarea/project -> /home/project so that
   // on-disk content stays in the canonical /home/project paths.
-  PathTransform StoreTransform = [](llvm::StringRef URI) -> std::string {
+  PathTransform StoreTransform =
+      [](llvm::StringRef URI) -> std::optional<std::string> {
     std::string S = URI.str();
     size_t Pos = S.find("/workarea/project/");
-    if (Pos != std::string::npos)
+    if (Pos != std::string::npos) {
       S.replace(Pos, strlen("/workarea/project/"), "/home/project/");
-    return S;
+      return S;
+    }
+    return std::nullopt;
   };
   // Load transform: map /home/project -> /workarea/project so that
   // in-memory paths match the local filesystem.
-  PathTransform LoadTransform = [](llvm::StringRef URI) -> std::string {
+  PathTransform LoadTransform =
+      [](llvm::StringRef URI) -> std::optional<std::string> {
     std::string S = URI.str();
     size_t Pos = S.find("/home/project/");
-    if (Pos != std::string::npos)
+    if (Pos != std::string::npos) {
       S.replace(Pos, strlen("/home/project/"), "/workarea/project/");
-    return S;
+      return S;
+    }
+    return std::nullopt;
   };
 
   // The index is generated with /home/project paths.

--- a/clang-tools-extra/clangd/unittests/SerializationTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SerializationTests.cpp
@@ -478,8 +478,8 @@ TEST(SerializationTest, PathTransformRoundTrip) {
   ASSERT_TRUE(bool(Loaded)) << Loaded.takeError();
 
   ASSERT_TRUE(Loaded->Symbols);
-  auto &Sym = *Loaded->Symbols->find(
-      cantFail(SymbolID::fromStr("057557CEBF6E6B2D")));
+  auto &Sym =
+      *Loaded->Symbols->find(cantFail(SymbolID::fromStr("057557CEBF6E6B2D")));
   EXPECT_EQ(llvm::StringRef(Sym.CanonicalDeclaration.FileURI),
             "file:///workarea/foo.h");
   EXPECT_EQ(Sym.Name, "Foo1");
@@ -494,9 +494,10 @@ TEST(SerializationTest, PathTransformRoundTrip) {
   auto Restored = readIndexFile(Reserialized, SymbolOrigin::Background);
   ASSERT_TRUE(bool(Restored)) << Restored.takeError();
   ASSERT_TRUE(Restored->Symbols);
-  EXPECT_EQ(llvm::StringRef(Restored->Symbols->find(cantFail(SymbolID::fromStr(
-                                 "057557CEBF6E6B2D")))
-                                 ->CanonicalDeclaration.FileURI),
+  EXPECT_EQ(llvm::StringRef(
+                Restored->Symbols
+                    ->find(cantFail(SymbolID::fromStr("057557CEBF6E6B2D")))
+                    ->CanonicalDeclaration.FileURI),
             "file:///path/foo.h");
 }
 

--- a/clang-tools-extra/clangd/unittests/SerializationTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SerializationTests.cpp
@@ -448,10 +448,10 @@ TEST(SerializationTest, NoCrashOnBadStringTableSize) {
 // An index is generated at /home/project. A second client at /workarea/project
 // loads and re-stores the shards. On-disk content always contains the
 // /home/project paths so the index remains portable.
-TEST(SerializationTest, URITransformRoundTrip) {
+TEST(SerializationTest, PathTransformRoundTrip) {
   // Store transform: map /workarea/project -> /home/project so that
   // on-disk content stays in the canonical /home/project paths.
-  URITransform StoreTransform = [](llvm::StringRef URI) -> std::string {
+  PathTransform StoreTransform = [](llvm::StringRef URI) -> std::string {
     std::string S = URI.str();
     size_t Pos = S.find("/workarea/project/");
     if (Pos != std::string::npos)
@@ -460,7 +460,7 @@ TEST(SerializationTest, URITransformRoundTrip) {
   };
   // Load transform: map /home/project -> /workarea/project so that
   // in-memory paths match the local filesystem.
-  URITransform LoadTransform = [](llvm::StringRef URI) -> std::string {
+  PathTransform LoadTransform = [](llvm::StringRef URI) -> std::string {
     std::string S = URI.str();
     size_t Pos = S.find("/home/project/");
     if (Pos != std::string::npos)


### PR DESCRIPTION
Add the ability to make a background index reusable using path mappings.
A similar concept is used for remote indexing (and more generally with
clang's `-ffile-prefix-map`).

Users supply a new flag to enable this behavior. For example:

```
--background-index-path-mappings=/my/local/path=/TOKEN
```

More concretely, one might specify this when using VSCode:

```
--background-index-path-mappings=${workspaceFolder}=/TOKEN
```

The flag is applied the same way during index generation and for a
client loading the pre-generated background index.

With this feature background index files can be generated from a
centralized location and shared with users whose clients all have
unique paths.

A few other notes:

- In addition to the tests added with this change, VSCode was used to
  manually validate generation and reuse of background index files.
- The change was reorganized into specific commits to aid code review.
- This work is based on concepts developed in an earlier prototype by my
  colleague, @mpriya501. Thanks!

Fixes clangd/clangd#847

Assisted-by: claude
