### PR TITLE
[llvm][DebugInfo] Avoid attaching retained nodes to unrelated subprograms in DIBuilder

### DIFF
--- a/clang/test/DebugInfo/CXX/ctor-homing-local-type.cpp
+++ b/clang/test/DebugInfo/CXX/ctor-homing-local-type.cpp
@@ -1,0 +1,40 @@
+// RUN: %clang_cc1 -triple %itanium_abi_triple -emit-llvm -debug-info-kind=limited -dwarf-version=5 -O0 -disable-llvm-passes %s -o - \
+// RUN:        | FileCheck %s
+
+// When compiling this with limited debug info, a replaceable forward declaration DICompositeType
+// for "n" is created in the scope of base object constructor (C2) of class l, and it's not immediately
+// replaced with a distinct node (the type is not "completed").
+// Later, it gets replaced with distinct definition DICompositeType, which is created in the scope of
+// complete object constructor (C1).
+//
+// In contrast to that, in standalone debug info mode, the complete definition DICompositeType
+// for "n" is created sooner, right in the context of C2.
+//
+// Check that DIBuilder processes the limited debug info case correctly, and doesn't add the same
+// local type to retainedNodes fields of both DISubprograms (C1 and C2).
+
+// FIXME: Should we ensure that DICompositeType is emitted in the same scope in both limited and
+// standalone modes?
+
+// CHECK: ![[C2:[0-9]+]] = distinct !DISubprogram(name: "l", linkageName: "_ZN1lC2Ev", {{.*}}, retainedNodes: ![[EMPTY:[0-9]+]])
+// CHECK: ![[EMPTY]] = !{}
+// CHECK: ![[N:[0-9]+]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "n",
+// CHECK: ![[C1:[0-9]+]] = distinct !DISubprogram(name: "l", linkageName: "_ZN1lC1Ev", {{.*}}, retainedNodes: ![[RN:[0-9]+]])
+// CHECK: ![[RN]] = !{![[N]]}
+
+template <class d>
+struct k {
+  void i() {
+    new d;
+  }
+};
+
+struct l {
+  l();
+};
+
+l::l() {
+  struct n {};
+  k<n> m;
+  m.i();
+}

--- a/clang/test/DebugInfo/CXX/ctor-homing-local-type.cpp
+++ b/clang/test/DebugInfo/CXX/ctor-homing-local-type.cpp
@@ -13,9 +13,6 @@
 // Check that DIBuilder processes the limited debug info case correctly, and doesn't add the same
 // local type to retainedNodes fields of both DISubprograms (C1 and C2).
 
-// FIXME: Should we ensure that DICompositeType is emitted in the same scope in both limited and
-// standalone modes?
-
 // CHECK: ![[C2:[0-9]+]] = distinct !DISubprogram(name: "l", linkageName: "_ZN1lC2Ev", {{.*}}, retainedNodes: ![[EMPTY:[0-9]+]])
 // CHECK: ![[EMPTY]] = !{}
 // CHECK: ![[N:[0-9]+]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "n",

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -53,10 +53,27 @@ void DIBuilder::trackIfUnresolved(MDNode *N) {
 
 void DIBuilder::finalizeSubprogram(DISubprogram *SP) {
   auto PN = SubprogramTrackedNodes.find(SP);
-  if (PN != SubprogramTrackedNodes.end())
-    SP->replaceRetainedNodes(
-        MDTuple::get(VMContext, SmallVector<Metadata *, 16>(PN->second.begin(),
-                                                            PN->second.end())));
+  if (PN != SubprogramTrackedNodes.end()) {
+    SmallVector<Metadata *, 16> RetainedNodes(PN->second.begin(),
+                                              PN->second.end());
+
+    // If the tracked node PN was temporary, and the DIBuilder user replaced it
+    // with a node that does not belong to SP or is non-local, do not add PN to
+    // SP's retainedNodes list.
+    auto IsNodeAlien = [SP](Metadata *M) {
+      MDNode *N = cast<MDNode>(M);
+      DILocalScope *Scope = dyn_cast_or_null<DILocalScope>(
+          DISubprogram::getRawRetainedNodeScope(N));
+      if (!Scope)
+        return true;
+      return Scope->getSubprogram() != SP;
+    };
+    RetainedNodes.erase(
+        std::remove_if(RetainedNodes.begin(), RetainedNodes.end(), IsNodeAlien),
+        RetainedNodes.end());
+
+    SP->replaceRetainedNodes(MDTuple::get(VMContext, RetainedNodes));
+  }
 }
 
 void DIBuilder::finalize() {


### PR DESCRIPTION
Fix a regression introduced by https://github.com/llvm/llvm-project/pull/165032, where DIBuilder could attach local metadata nodes to the wrong subprogram during finalization.

DIBuilder records freshly created local variables, labels, and types in `DIBuilder::SubprogramTrackedNodes`, and later attaches them to their parent subprogram's retainedNodes in `finalizeSubprogram()`.

However, a temporary local type created via `createReplaceableCompositeType()` may later be replaced by a type with a different scope.
DIBuilder does not currently verify that the scopes of the original and replacement types match.

As a result, local types can be incorrectly attached to the retainedNodes of an unrelated subprogram. This issue is observable in clang with limited debug info mode (see `clang/test/DebugInfo/CXX/ctor-homing-local-type.cpp`).

This patch updates `DIBuilder::finalizeSubprogram()` to verify that tracked metadata nodes still belong to the subprogram being finalized, and avoids adding nodes whose scopes no longer match to retainedNodes field of an unrelated subprogram.