### PR TITLE
[MLIR][XeGPU] Fixing PR179016 minor issues

### DIFF
--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
@@ -91,9 +91,9 @@ bool xegpu::recoverTemporaryLayouts(Operation *rootOp) {
         continue;
       auto layout = xegpu::getDistributeLayoutAttr(operand.get());
       if (!layout) {
-        op->emitError("Could not find layout attribute for operand ")
+        op->emitWarning("Could not find layout attribute for operand ")
             << operand.getOperandNumber() << " of operation " << op->getName();
-        return WalkResult::interrupt();
+        continue;
       }
       xegpu::setDistributeLayoutAttr(operand, layout);
     }
@@ -167,8 +167,8 @@ xegpu::inferMultiReductionSourceLayout(xegpu::DistributeLayoutAttr resLayout,
          "reduction result layout must be slice layout");
 
   xegpu::SliceAttr sliceLayout = dyn_cast<xegpu::SliceAttr>(resLayout);
-  auto sliceDims = sliceLayout.getDims().asArrayRef();
-  assert(reduceDims == sliceDims &&
+
+  assert((reduceDims == sliceLayout.getDims().asArrayRef()) &&
          "reduction dims must match with slice dims");
 
   return sliceLayout.getParent();


### PR DESCRIPTION
Fix two issues brough by PR179016: 
1. unused variable if build the option with "DLLVM_ENABLE_ASSERTIONS=OFF"
 2. Recover modification to recoverTemporaryLayouts() brought by PR176737. Unintentionally lost during the merging process. 