### PR TITLE
Remove dependency on FIRBuilder from FIRAnalysis.

### DIFF
--- a/flang/lib/Optimizer/Analysis/CMakeLists.txt
+++ b/flang/lib/Optimizer/Analysis/CMakeLists.txt
@@ -10,7 +10,6 @@ add_flang_library(FIRAnalysis
 
   LINK_LIBS
   CUFDialect
-  FIRBuilder
   FIRDialect
   FIRSupport
   HLFIRDialect


### PR DESCRIPTION
The dependency actually appears to be unused.