### PR TITLE
[PTX][Debug] Make emitInlineAsm virtual

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -943,11 +943,12 @@ private:
   void emitFunctionPrefix(ArrayRef<const Constant *> Prefix);
 
   /// Emit a blob of inline asm to the output streamer.
-  void emitInlineAsm(StringRef Str, const MCSubtargetInfo &STI,
-                     const MCTargetOptions &MCOptions,
-                     const MDNode *LocMDNode = nullptr,
-                     InlineAsm::AsmDialect AsmDialect = InlineAsm::AD_ATT,
-                     const MachineInstr *MI = nullptr);
+  virtual void
+  emitInlineAsm(StringRef Str, const MCSubtargetInfo &STI,
+                const MCTargetOptions &MCOptions,
+                const MDNode *LocMDNode = nullptr,
+                InlineAsm::AsmDialect AsmDialect = InlineAsm::AD_ATT,
+                const MachineInstr *MI = nullptr);
 
   /// This method formats and emits the specified machine instruction that is an
   /// inline asm.


### PR DESCRIPTION
The emitInlineAsm function is now virtual, allowing it to be overridden in the NVPTX backend.