### PR TITLE
[RISCV] Add missing instruction tests to rv64p-valid.s. NFC

### DIFF
--- a/llvm/test/MC/RISCV/rv64p-valid.s
+++ b/llvm/test/MC/RISCV/rv64p-valid.s
@@ -169,24 +169,36 @@ psrl.hs a6, a7, a1
 # CHECK-ASM-AND-OBJ: psrl.bs a1, a2, a3
 # CHECK-ASM: encoding: [0x9b,0x45,0xd6,0x8c]
 psrl.bs a1, a2, a3
+# CHECK-ASM-AND-OBJ: psrl.ws a4, a5, a6
+# CHECK-ASM: encoding: [0x1b,0xc7,0x07,0x8b]
+psrl.ws a4, a5, a6
 # CHECK-ASM-AND-OBJ: predsum.hs a4, a5, a6
 # CHECK-ASM: encoding: [0x1b,0xc7,0x07,0x99]
 predsum.hs a4, a5, a6
 # CHECK-ASM-AND-OBJ: predsum.bs a7, a1, a1
 # CHECK-ASM: encoding: [0x9b,0xc8,0xb5,0x9c]
 predsum.bs a7, a1, a1
+# CHECK-ASM-AND-OBJ: predsum.ws t0, t1, t2
+# CHECK-ASM: encoding: [0x9b,0x42,0x73,0x9a]
+predsum.ws t0, t1, t2
 # CHECK-ASM-AND-OBJ: predsumu.hs t0, t1, t2
 # CHECK-ASM: encoding: [0x9b,0x42,0x73,0xb8]
 predsumu.hs t0, t1, t2
 # CHECK-ASM-AND-OBJ: predsumu.bs t3, t4, t5
 # CHECK-ASM: encoding: [0x1b,0xce,0xee,0xbd]
 predsumu.bs t3, t4, t5
+# CHECK-ASM-AND-OBJ: predsumu.ws a0, a1, a2
+# CHECK-ASM: encoding: [0x1b,0xc5,0xc5,0xba]
+predsumu.ws a0, a1, a2
 # CHECK-ASM-AND-OBJ: psra.hs ra, a1, a2
 # CHECK-ASM: encoding: [0x9b,0xc0,0xc5,0xc8]
 psra.hs ra, a1, a2
 # CHECK-ASM-AND-OBJ: psra.bs sp, a2, a3
 # CHECK-ASM: encoding: [0x1b,0x41,0xd6,0xcc]
 psra.bs sp, a2, a3
+# CHECK-ASM-AND-OBJ: psra.ws a3, a4, a5
+# CHECK-ASM: encoding: [0x9b,0x46,0xf7,0xca]
+psra.ws a3, a4, a5
 # CHECK-ASM-AND-OBJ: padd.h t1, t5, s2
 # CHECK-ASM: encoding: [0x3b,0x03,0x2f,0x81]
 padd.h t1, t5, s2


### PR DESCRIPTION
An AI told me these were missing and helped me add them.