### PR TITLE
[RISCV] Remove non-alias tests from rv32zbb-aliases-valid.s and rv64zbb-aliases-valid.s. NFC

### DIFF
--- a/llvm/test/MC/RISCV/rv32zbb-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv32zbb-aliases-valid.s
@@ -15,14 +15,6 @@
 # CHECK-S-OBJ-NOALIAS    Match both the .s and objdumped object output with
 #                        aliases disabled
 
-# CHECK-S-OBJ-NOALIAS: zext.h t0, t1
-# CHECK-S-OBJ: zext.h t0, t1
-zext.h x5, x6
-
-# CHECK-S-OBJ-NOALIAS: rev8 t0, t1
-# CHECK-S-OBJ: rev8 t0, t1
-rev8 x5, x6
-
 # CHECK-S-OBJ-NOALIAS: orc.b t0, t1
 # CHECK-S-OBJ: orc.b t0, t1
 orc.b x5, x6

--- a/llvm/test/MC/RISCV/rv32zbb-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv32zbb-aliases-valid.s
@@ -15,10 +15,6 @@
 # CHECK-S-OBJ-NOALIAS    Match both the .s and objdumped object output with
 #                        aliases disabled
 
-# CHECK-S-OBJ-NOALIAS: orc.b t0, t1
-# CHECK-S-OBJ: orc.b t0, t1
-orc.b x5, x6
-
 # CHECK-S-OBJ-NOALIAS: rori t0, t1, 8
 # CHECK-S-OBJ: rori t0, t1, 8
 ror x5, x6, 8

--- a/llvm/test/MC/RISCV/rv64zbb-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv64zbb-aliases-valid.s
@@ -15,18 +15,6 @@
 # CHECK-S-OBJ-NOALIAS    Match both the .s and objdumped object output with
 #                        aliases disabled
 
-# CHECK-S-OBJ-NOALIAS: zext.h t0, t1
-# CHECK-S-OBJ: zext.h t0, t1
-zext.h x5, x6
-
-# CHECK-S-OBJ-NOALIAS: rev8 t0, t1
-# CHECK-S-OBJ: rev8 t0, t1
-rev8 x5, x6
-
-# CHECK-S-OBJ-NOALIAS: orc.b t0, t1
-# CHECK-S-OBJ: orc.b t0, t1
-orc.b x5, x6
-
 # CHECK-S-OBJ-NOALIAS: rori t0, t1, 8
 # CHECK-S-OBJ: rori t0, t1, 8
 ror x5, x6, 8


### PR DESCRIPTION
These are real instructions and are tested in rv32zbb-only-valid.s, rv64-zbb-valid.s, or rvzbb-valid.s

I think this is some artifact of the refactoring that happened when some of the Bitmanip extensions/instructions were removed years ago.