### PR TITLE
[OpenCL] Diagnose invalid conversion from pointer to vector

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -8112,6 +8112,12 @@ ExprResult Sema::BuildVectorLiteral(SourceLocation LParenLoc,
     // it will be replicated to all components of the vector.
     if (getLangOpts().OpenCL && VTy->getVectorKind() == VectorKind::Generic &&
         numExprs == 1) {
+      if (!exprs[0]->getType()->isArithmeticType()) {
+        Diag(exprs[0]->getBeginLoc(), diag::err_typecheck_convert_incompatible)
+            << Ty << exprs[0]->getType() << 4 << 0 << 0 << ""
+            << exprs[0]->getSourceRange();
+        return ExprError();
+      }
       QualType ElemTy = VTy->getElementType();
       ExprResult Literal = DefaultLvalueConversion(exprs[0]);
       if (Literal.isInvalid())

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -8112,10 +8112,11 @@ ExprResult Sema::BuildVectorLiteral(SourceLocation LParenLoc,
     // it will be replicated to all components of the vector.
     if (getLangOpts().OpenCL && VTy->getVectorKind() == VectorKind::Generic &&
         numExprs == 1) {
-      if (!exprs[0]->getType()->isArithmeticType()) {
+      QualType SrcTy = exprs[0]->getType();
+      if (!SrcTy->isArithmeticType()) {
         Diag(exprs[0]->getBeginLoc(), diag::err_typecheck_convert_incompatible)
-            << Ty << exprs[0]->getType() << AssignmentAction::Initializing << 0
-            << 0 << "" << exprs[0]->getSourceRange();
+            << Ty << SrcTy << AssignmentAction::Initializing << /*elidable=*/0
+            << /*c_style=*/0 << /*cast_kind=*/"" << exprs[0]->getSourceRange();
         return ExprError();
       }
       QualType ElemTy = VTy->getElementType();

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -8114,8 +8114,8 @@ ExprResult Sema::BuildVectorLiteral(SourceLocation LParenLoc,
         numExprs == 1) {
       if (!exprs[0]->getType()->isArithmeticType()) {
         Diag(exprs[0]->getBeginLoc(), diag::err_typecheck_convert_incompatible)
-            << Ty << exprs[0]->getType() << 4 << 0 << 0 << ""
-            << exprs[0]->getSourceRange();
+            << Ty << exprs[0]->getType() << AssignmentAction::Initializing << 0
+            << 0 << "" << exprs[0]->getSourceRange();
         return ExprError();
       }
       QualType ElemTy = VTy->getElementType();

--- a/clang/test/SemaOpenCL/invalid-vector-literals.cl
+++ b/clang/test/SemaOpenCL/invalid-vector-literals.cl
@@ -12,4 +12,6 @@ void vector_literals_invalid()
   ((int4)(0)).x = 8; // expected-error{{expression is not assignable}}
   int arr[4];
   int4 e = (int4)(arr); // expected-error{{initializing 'int4' (vector of 4 'int' values) with an expression of incompatible type '__private int[4]'}}
+  int *p = arr;
+  int4 f = (int4)(p); // expected-error{{initializing 'int4' (vector of 4 'int' values) with an expression of incompatible type '__private int *__private'}}
 }

--- a/clang/test/SemaOpenCL/invalid-vector-literals.cl
+++ b/clang/test/SemaOpenCL/invalid-vector-literals.cl
@@ -10,4 +10,6 @@ void vector_literals_invalid()
   int4 b = (int4)(1,2,3,4,5); // expected-error{{excess elements in vector}}
   int8 d = (int8)(a,(float4)(1)); // expected-error{{initializing 'int' with an expression of incompatible type 'float4'}}
   ((int4)(0)).x = 8; // expected-error{{expression is not assignable}}
+  int arr[4];
+  int4 e = (int4)(arr); // expected-error{{initializing 'int4' (vector of 4 'int' values) with an expression of incompatible type '__private int[4]'}}
 }


### PR DESCRIPTION
Fix crash in clang PrepareScalarCast when compiling OpenCL source: void foo() {
  int a[3] = {1, 2, 3};
  int3 b = (int3)(a);
}

PrepareScalarCast requires scalar src, but the provided src is a pointer.

Resolves https://github.com/intel/compute-runtime/issues/888