### PR TITLE
[Clang] Fix stack overflow with recursive lambdas in templates

### DIFF
--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -15963,8 +15963,16 @@ TreeTransform<Derived>::TransformLambdaExpr(LambdaExpr *E) {
     getSema().pushCodeSynthesisContext(C);
 
     // Instantiate the body of the lambda expression.
-    Body = Invalid ? StmtError()
-                   : getDerived().TransformLambdaBody(E, E->getBody());
+    // Use runWithSufficientStackSpace to handle deeply nested recursive
+    // lambdas that might exhaust the stack before hitting the template
+    // instantiation depth limit.
+    if (Invalid) {
+      Body = StmtError();
+    } else {
+      getSema().runWithSufficientStackSpace(E->getBody()->getBeginLoc(), [&] {
+        Body = getDerived().TransformLambdaBody(E, E->getBody());
+      });
+    }
 
     getSema().popCodeSynthesisContext();
   }


### PR DESCRIPTION
## Summary

Fixes #180319

Recursive lambdas in templates could cause Clang to crash with a stack overflow before hitting the template instantiation depth limit. This happened because `LambdaExpressionSubstitution` doesn't count toward the depth limit (by design for SFINAE per [temp.deduct]p9).

This PR wraps the `TransformLambdaBody` call in `runWithSufficientStackSpace` to handle deeply nested recursive lambdas gracefully:
- If threads are enabled, it runs on a new 8MB stack when stack is nearly exhausted
- If threads are disabled, it emits a warning and continues

## Test plan

- Added TEST=4 to `clang/test/SemaTemplate/stack-exhaustion.cpp` with the reproduction case from the issue
- The test uses `complexify<200>` which would previously crash but now handles gracefully