### PR TITLE
[MLIR][NFC] Ignore clang-tidy `modernize-use-using` check in C code

### DIFF
--- a/mlir/.clang-tidy
+++ b/mlir/.clang-tidy
@@ -58,3 +58,5 @@ CheckOptions:
     value:           camelBack
   - key:             readability-identifier-naming.VariableCase
     value:           camelBack
+  - key:             modernize-use-using.IgnoreExternC
+    value:           true


### PR DESCRIPTION
In the MLIR C API headers, clang-tidy’s `modernize-use-using` check reports a large number of type definitions that use `typedef`. In my IDE, this even causes the `typedef` code to be shown as struck through. However, in this case it is clearly not possible to replace them with `using`. This PR suppresses the `modernize-use-using` check for the code inside `extern "C"` blocks.
