### PR TITLE
[MIPS] Fix argument size in Fast ISel

### DIFF
--- a/llvm/lib/Target/Mips/MipsFastISel.cpp
+++ b/llvm/lib/Target/Mips/MipsFastISel.cpp
@@ -1493,7 +1493,7 @@ bool MipsFastISel::fastLowerArguments() {
   // Account for the reserved argument area on ABI's that have one (O32).
   // It seems strange to do this on the caller side but it's necessary in
   // SelectionDAG's implementation.
-  IncomingArgSizeInBytes = std::min(getABI().GetCalleeAllocdArgSizeInBytes(CC),
+  IncomingArgSizeInBytes = std::max(getABI().GetCalleeAllocdArgSizeInBytes(CC),
                                     IncomingArgSizeInBytes);
 
   MF->getInfo<MipsFunctionInfo>()->setFormalArgInfo(IncomingArgSizeInBytes,

--- a/llvm/test/CodeGen/Mips/musttail-fastisel.ll
+++ b/llvm/test/CodeGen/Mips/musttail-fastisel.ll
@@ -1,0 +1,28 @@
+; RUN: llc -mtriple=mips-unknown-linux-gnu -mips-tail-calls=1 -O0 < %s | FileCheck %s
+; RUN: llc -mtriple=mips64-unknown-linux-gnu -mips-tail-calls=1 -O0 < %s | FileCheck %s
+
+; Test that musttail works correctly at -O0 when Fast ISel is used.
+; This is a regression test for a bug where Fast ISel incorrectly set
+; IncomingArgSize to 0 for functions with no arguments, causing the
+; tail call eligibility check to fail.
+
+@ptr = dso_local global ptr null, align 4
+
+define dso_local void @callee() {
+entry:
+  %local = alloca i32, align 4
+  store volatile i32 2, ptr %local, align 4
+  ret void
+}
+
+; CHECK-LABEL: caller:
+; CHECK: j callee
+; CHECK-NOT: jal callee
+define dso_local void @caller() {
+entry:
+  %local = alloca i32, align 4
+  store i32 1, ptr %local, align 4
+  store ptr %local, ptr @ptr, align 4
+  musttail call void @callee()
+  ret void
+}


### PR DESCRIPTION
Fix bug where Fast ISel incorrectly set `IncomingArgSize` to `0` for functions with no arguments, since `MIPS O32` uses _the reserved argument area_ of 16 bytes even for the functions with no args at all.