### PR TITLE
[clang][ObjC][CodeComplete] Fix crash on C-Style cast with parenthesized operand in ObjC++

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -352,6 +352,9 @@ libclang
 Code Completion
 ---------------
 
+- Fixed a crash in code completion when using a C-Style cast with a parenthesized
+  operand in Objective-C++ mode. (#GH180125)
+
 Static Analyzer
 ---------------
 

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -5152,7 +5152,7 @@ void SemaCodeCompletion::CodeCompletePostfixExpression(Scope *S, ExprResult E,
                                                        QualType PreferredType) {
   if (E.isInvalid())
     CodeCompleteExpression(S, PreferredType);
-  else if (getLangOpts().ObjC)
+  else if (getLangOpts().ObjC && !E.get()->getType().isNull())
     CodeCompleteObjCInstanceMessage(S, E.get(), {}, false);
 }
 

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -5152,7 +5152,7 @@ void SemaCodeCompletion::CodeCompletePostfixExpression(Scope *S, ExprResult E,
                                                        QualType PreferredType) {
   if (E.isInvalid())
     CodeCompleteExpression(S, PreferredType);
-  else if (getLangOpts().ObjC && !E.get()->getType().isNull())
+  else if (getLangOpts().ObjC)
     CodeCompleteObjCInstanceMessage(S, E.get(), {}, false);
 }
 
@@ -8438,6 +8438,11 @@ void SemaCodeCompletion::CodeCompleteObjCInstanceMessage(
     bool AtArgumentExpression, ObjCInterfaceDecl *Super) {
   typedef CodeCompletionResult Result;
   ASTContext &Context = getASTContext();
+
+  // If the receiver expression has no type (e.g., a parenthesized C-style cast
+  // that hasn't been resolved), bail out to avoid dereferencing a null type.
+  if (RecExpr && RecExpr->getType().isNull())
+    return;
 
   // If necessary, apply function/array conversion to the receiver.
   // C99 6.7.5.3p[7,8].

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -8439,14 +8439,14 @@ void SemaCodeCompletion::CodeCompleteObjCInstanceMessage(
   typedef CodeCompletionResult Result;
   ASTContext &Context = getASTContext();
 
-  // If the receiver expression has no type (e.g., a parenthesized C-style cast
-  // that hasn't been resolved), bail out to avoid dereferencing a null type.
-  if (RecExpr && RecExpr->getType().isNull())
-    return;
-
   // If necessary, apply function/array conversion to the receiver.
   // C99 6.7.5.3p[7,8].
   if (RecExpr) {
+    // If the receiver expression has no type (e.g., a parenthesized C-style
+    // cast that hasn't been resolved), bail out to avoid dereferencing a null
+    // type.
+    if (RecExpr->getType().isNull())
+      return;
     ExprResult Conv = SemaRef.DefaultFunctionArrayLvalueConversion(RecExpr);
     if (Conv.isInvalid()) // conversion failed. bail.
       return;

--- a/clang/test/CodeCompletion/objc-cast-parenthesized-expr.m
+++ b/clang/test/CodeCompletion/objc-cast-parenthesized-expr.m
@@ -1,0 +1,12 @@
+// Note: the run lines follow their respective tests, since line/column
+// matter in this test.
+
+void func() {
+  int *foo = (int *)(0x200);
+  int *bar = (int *)((0x200));
+}
+
+// Make sure this doesn't crash
+// RUN: %clang_cc1 -fsyntax-only -xobjective-c++-header -code-completion-at=%s:%(line-5):28 %s
+// RUN: %clang_cc1 -fsyntax-only -xobjective-c++-header -code-completion-at=%s:%(line-5):30 %s
+


### PR DESCRIPTION
In ObjC++ mode, code-completion after a C-style cast like `(int*)(0x200)` crashed because the inner parenthesized expression was parsed as a `ParenListExpr` (null type) due to `AllowTypes` propagation.

Fixes https://github.com/llvm/llvm-project/issues/180125