### PR TITLE
[mlir][vector] Fix fold result for empty vector.mask with no results

### DIFF
--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -7614,7 +7614,7 @@ static LogicalResult foldEmptyMaskOp(MaskOp maskOp, MaskOp::FoldAdaptor adaptor,
   auto terminator = cast<vector::YieldOp>(block->front());
   if (terminator.getNumOperands() == 0) {
     // `vector.mask` has no results, just remove the `vector.mask`.
-    return success();
+    return failure();
   }
 
   // `vector.mask` has results, propagate the results.

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -7612,10 +7612,8 @@ static LogicalResult foldEmptyMaskOp(MaskOp maskOp, MaskOp::FoldAdaptor adaptor,
 
   Block *block = maskOp.getMaskBlock();
   auto terminator = cast<vector::YieldOp>(block->front());
-  if (terminator.getNumOperands() == 0) {
-    // `vector.mask` has no results, just remove the `vector.mask`.
+  if (terminator.getNumOperands() == 0)
     return failure();
-  }
 
   // `vector.mask` has results, propagate the results.
   llvm::append_range(results, terminator.getOperands());

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -772,3 +772,14 @@ func.func @arith_truncf(%arg0: f64) -> f16 {
 
   return %truncd1 : f16
 }
+
+// -----
+
+// Ensure that vector.mask with an empty mask does not cause issues.
+
+// CHECK-LABEL: empty_vector_mask
+func.func @empty_vector_mask(%mask : vector<8xi1>) {
+  // CHECK: vector.mask
+  vector.mask %mask { vector.yield } : vector<8xi1>
+  return
+}

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -772,14 +772,3 @@ func.func @arith_truncf(%arg0: f64) -> f16 {
 
   return %truncd1 : f16
 }
-
-// -----
-
-// Ensure that vector.mask with an empty mask does not cause issues.
-
-// CHECK-LABEL: empty_vector_mask
-func.func @empty_vector_mask(%mask : vector<8xi1>) {
-  // CHECK: vector.mask
-  vector.mask %mask { vector.yield } : vector<8xi1>
-  return
-}


### PR DESCRIPTION
This PR fixes `foldEmptyMaskOp` to return `failure` when folding an empty vector.mask whose terminatorhas no operands. Previously this case returned success without producing any folded results, which violates the folding contract. Fixes #177825.