### PR TITLE
SimplifyCFG: fold trivial non-empty blocks with safe instructions

### DIFF
--- a/llvm/test/Transforms/SimplifyCFG/trivial-nonempty-fold-final.ll
+++ b/llvm/test/Transforms/SimplifyCFG/trivial-nonempty-fold-final.ll
@@ -1,0 +1,74 @@
+; RUN: opt -S -passes=simplifycfg < %s | FileCheck %s
+; RUN: opt -S -passes='simplifycfg' < %s | FileCheck %s
+
+; CHECK-LABEL: @fold_load
+; CHECK-NOT: bb1
+; CHECK: load i32
+define i32 @fold_load(i1 %cond, ptr %p) {
+entry:
+  br i1 %cond, label %pred, label %other
+
+pred:
+  %d = add i32 1, 1
+  br label %bb1
+
+other:
+  %d2 = add i32 2, 2
+  br label %exit
+
+bb1:
+  %x = load i32, ptr %p
+  br label %exit
+
+exit:
+  %phi = phi i32 [ %x, %bb1 ], [ 42, %other ]
+  ret i32 %phi
+}
+
+; CHECK-LABEL: @fold_arith
+; CHECK-NOT: bb1
+; CHECK: add i32 %a, 1
+define i32 @fold_arith(i32 %a, i1 %cond) {
+entry:
+  br i1 %cond, label %pred, label %other
+
+pred:
+  %d = add i32 3, 3
+  br label %bb1
+
+other:
+  %d2 = add i32 4, 4
+  br label %exit
+
+bb1:
+  %x = add i32 %a, 1
+  br label %exit
+
+exit:
+  %phi = phi i32 [ %x, %bb1 ], [ %a, %other ]
+  ret i32 %phi
+}
+
+; CHECK-LABEL: @no_fold_multi_store
+; CHECK: bb1:
+; CHECK: store i32
+; CHECK: ret void
+define void @no_fold_multi_store(ptr %p, i1 %cond) {
+entry:
+  br i1 %cond, label %A, label %B
+
+A:
+  %dA = add i32 10, 1
+  br label %bb1
+
+B:
+  %dB = add i32 20, 1
+  br label %bb1
+
+bb1:
+  store i32 10, ptr %p
+  br label %exit
+
+exit:
+  ret void
+}

--- a/llvm/test/Transforms/SimplifyCFG/trivial-nonempty-fold-final.ll
+++ b/llvm/test/Transforms/SimplifyCFG/trivial-nonempty-fold-final.ll
@@ -72,3 +72,16 @@ bb1:
 exit:
   ret void
 }
+
+; CHECK-LABEL: @fold_store
+; CHECK: store i32
+; CHECK: ret void
+define void @fold_store(ptr %p) {
+entry:
+  br label %mid
+mid:
+  store i32 5, ptr %p
+  br label %exit
+exit:
+  ret void
+}


### PR DESCRIPTION
This patch extends SimplifyCFG to fold a small class of non-empty blocks that contain only side-effect-free instructions. Today the folder only handles fully empty blocks (PHIs/debug + terminator). Several simple patterns (e.g., a block with a single `load` or `add`) can also be safely removed without changing semantics.

The patch adds three helpers:

* `isSafeInstructionForTrivialMerge()`
  Conservative whitelist of instructions that are safe to move during a trivial fold (simple loads/stores, arithmetic ops, casts, GEPs, pure calls, etc.).

* `isTrivialNonEmptyBlockSafeToFold()`
  Checks whether a block ends in an unconditional branch and only contains instructions accepted by the helper above.

* `TryToSimplifyUncondBranchFromNonEmptyBlock()`
  Single-predecessor version of trivial block folding. It splices the safe instructions into the predecessor and updates successor PHIs. No cloning or speculation is performed.

The folding is hooked into `simplifyUncondBranch()` immediately after the existing empty-block fold.

The behavior is intentionally conservative:
– only single-pred blocks
– no PHIs inside the block
– no multi-pred duplication
– no speculation
– only explicitly whitelisted instructions

A focused regression test (`trivial-nonempty-fold-final.ll`) is included, covering:

1. folding a block with a simple load
2. folding a block with an arithmetic op
3. a multi-pred + store case that must not fold

`check-llvm` passes with this patch.

This is a small improvement but it eliminates some unnecessary trivial blocks before later passes run and keeps the IR cleaner.
