### PR TITLE
[clang-tidy] Fix crash in readability-suspicious-call-argument on invalid option

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
@@ -528,7 +528,11 @@ SuspiciousCallArgumentCheck::SuspiciousCallArgumentCheck(
   for (const StringRef Abbreviation : optutils::parseStringList(
            Options.get("Abbreviations", DefaultAbbreviations))) {
     const auto [Key, Value] = Abbreviation.split("=");
-    assert(!Key.empty() && !Value.empty());
+    if (Key.empty() || Value.empty()) {
+      configurationDiag("Invalid abbreviation configuration '%0', ignoring.")
+          << Abbreviation;
+      continue;
+    }
     AbbreviationDictionary.try_emplace(Key, Value.str());
   }
 }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -115,7 +115,7 @@ New checks
 
   Looks for functions returning ``std::[w|u8|u16|u32]string`` and suggests to
   change it to ``std::[...]string_view`` for performance reasons if possible.
-  
+
 - New :doc:`modernize-use-structured-binding
   <clang-tidy/checks/modernize/use-structured-binding>` check.
 
@@ -202,6 +202,10 @@ Changes in existing checks
 - Improved :doc:`readability-non-const-parameter
   <clang-tidy/checks/readability/non-const-parameter>` check by avoiding false
   positives on parameters used in dependent expressions.
+
+- Improved :doc:`readability-suspicious-call-argument
+  <clang-tidy/checks/readability/suspicious-call-argument>` check by avoiding a
+  crash from malformed `Abbreviations` configuration.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -205,7 +205,7 @@ Changes in existing checks
 
 - Improved :doc:`readability-suspicious-call-argument
   <clang-tidy/checks/readability/suspicious-call-argument>` check by avoiding a
-  crash from malformed `Abbreviations` configuration.
+  crash from invalid ``Abbreviations`` option.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/suspicious-call-argument-option.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/suspicious-call-argument-option.cpp
@@ -1,0 +1,7 @@
+// RUN: %check_clang_tidy %s readability-suspicious-call-argument %t \
+// RUN: -config="{CheckOptions: {readability-suspicious-call-argument.Abbreviations: 'crash='}}" -- -std=c++11-or-later
+
+void f() {}
+// CHECK-MESSAGES: warning: Invalid abbreviation configuration 'crash=', ignoring.
+
+// TODO: Add testcases for other options

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/suspicious-call-argument.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/suspicious-call-argument.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s readability-suspicious-call-argument %t -- -- -std=c++11
+// RUN: %check_clang_tidy %s readability-suspicious-call-argument %t -- -- -std=c++11-or-later
 
 void foo_1(int aaaaaa, int bbbbbb) {}
 


### PR DESCRIPTION
Closes #180346