### PR TITLE
[DSE] Handle variable offsets with sized dead_on_return

### DIFF
--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -1227,7 +1227,11 @@ struct DSEState {
       int64_t ValueOffset;
       [[maybe_unused]] const Value *BaseValue =
           GetPointerBaseWithConstantOffset(Ptr, ValueOffset, DL);
-      assert(BaseValue == V);
+      // If we are not able to find a constant offset from the UO, we have to
+      // pessimistically assume that the store writes to memory out of the
+      // dead_on_return bounds.
+      if (BaseValue != V)
+        return false;
       // This store is only invisible after return if we are in bounds of the
       // range marked dead.
       if (StoreSize.hasValue() &&

--- a/llvm/test/Transforms/DeadStoreElimination/simple.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/simple.ll
@@ -955,5 +955,16 @@ define void @test_dead_on_return_variable_memset(ptr dead_on_return(8) %p, i64 %
   ret void
 }
 
+define void @test_dead_on_return_variable_offset(ptr dead_on_return(4) %p, i64 %offset) {
+; CHECK-LABEL: @test_dead_on_return_variable_offset(
+; CHECK-NEXT:    [[P1:%.*]] = getelementptr i8, ptr [[P:%.*]], i64 [[OFFSET:%.*]]
+; CHECK-NEXT:    store i32 0, ptr [[P1]], align 4
+; CHECK-NEXT:    ret void
+;
+  %p1 = getelementptr i8, ptr %p, i64 %offset
+  store i32 0, ptr %p1
+  ret void
+}
+
 declare void @opaque(ptr)
 declare void @maythrow() memory(none)


### PR DESCRIPTION
With a sized dead_on_return, we need to not eliminate stores if there are to a pointer with a variable offset from the underlying object marked dead_on_return. This manifested as an assertion failure as BaseValue/V ended up not being equal. It's possible we could do a range analysis to try and prove the variable offset stays within bounds, but this case seems to come up relatively rarely (only reproducible with a UBSan build of LLVM) and is probably not worth the compile time.

Fixes #180361.