### PR TITLE
[IR] Update docstring for stripAndAccumulateConstantOffset

### DIFF
--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -733,8 +733,8 @@ public:
   /// Note that this function will never return a nullptr. It will also never
   /// manipulate the \p Offset in a way that would not match the difference
   /// between the underlying value and the returned one. Thus, if no constant
-  /// offset was found, the returned value is the underlying one and \p Offset
-  /// is unchanged.
+  /// offset was found, \p Offset is unchanged and the returned value is the
+  /// first traversed value to introduce a non-constant offset.
   LLVM_ABI const Value *stripAndAccumulateConstantOffsets(
       const DataLayout &DL, APInt &Offset, bool AllowNonInbounds,
       bool AllowInvariantGroup = false,

--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -733,9 +733,9 @@ public:
   /// Note that this function will never return a nullptr. It will also never
   /// manipulate the \p Offset in a way that would not match the difference
   /// between the underlying value and the returned one. Thus, if a variable
-  /// offset was encountered, the returned value is the first traversed value
-  /// to introduce a non-constant offset and \p Offset is the accumulated
-  /// constant offset up to that point.
+  /// offset is encountered during traversal, the returned value is the first
+  /// traversed Value that introduces a non-constant offset and \p Offset is the
+  /// accumulated constant offset up to that point.
   LLVM_ABI const Value *stripAndAccumulateConstantOffsets(
       const DataLayout &DL, APInt &Offset, bool AllowNonInbounds,
       bool AllowInvariantGroup = false,

--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -732,9 +732,10 @@ public:
   ///
   /// Note that this function will never return a nullptr. It will also never
   /// manipulate the \p Offset in a way that would not match the difference
-  /// between the underlying value and the returned one. Thus, if no constant
-  /// offset was found, \p Offset is unchanged and the returned value is the
-  /// first traversed value to introduce a non-constant offset.
+  /// between the underlying value and the returned one. Thus, if a variable
+  /// offset was encountered, the returned value is the first traversed value
+  /// to introduce a non-constant offset and \p Offset is the accumulated
+  /// constant offset up to that point.
   LLVM_ABI const Value *stripAndAccumulateConstantOffsets(
       const DataLayout &DL, APInt &Offset, bool AllowNonInbounds,
       bool AllowInvariantGroup = false,


### PR DESCRIPTION
Make it clear that the returned object in the case where a variable offset is found is the first value to introduce a non-constant offset, not necessarily the actual underlying object.

Found while investigating #180361.