### PR TITLE
[Docs][Intrisics] Fix the name of llvm.memset.inline in the documentation

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16385,10 +16385,10 @@ support all bit widths however.
 
 ::
 
-      declare void @llvm.memset.inline.p0.p0i8.i32(ptr <dest>, i8 <val>,
-                                                   i32 <len>, i1 <isvolatile>)
-      declare void @llvm.memset.inline.p0.p0.i64(ptr <dest>, i8 <val>,
-                                                 i64 <len>, i1 <isvolatile>)
+      declare void @llvm.memset.inline.p0.i32(ptr <dest>, i8 <val>,
+                                              i32 <len>, i1 <isvolatile>)
+      declare void @llvm.memset.inline.p0.i64(ptr <dest>, i8 <val>,
+                                              i64 <len>, i1 <isvolatile>)
 
 Overview:
 """""""""


### PR DESCRIPTION
LLVM intrinsic `llvm.memset.inline` indicates in its name the types of the destination pointer and the size. There is no second pointer.

Moreover, the tests are already verifying that generated code uses `@llvm.memset.inline.p0.i32` and `@llvm.memset.inline.p0.i64`. So make the documentation reference these names as well.

Fixes: https://github.com/llvm/llvm-project/issues/163454