### PR TITLE
[Polly] Honor 'scops' phase being disabled

### DIFF
--- a/polly/lib/Pass/PhaseManager.cpp
+++ b/polly/lib/Pass/PhaseManager.cpp
@@ -128,6 +128,10 @@ public:
     if (Opts.isPhaseEnabled(PassPhase::ViewScopsOnly))
       ViewScops("scopsonly", true);
 
+    // Can't do anything after this without ScopInfo.
+    if (!Opts.isPhaseEnabled(PassPhase::ScopInfo))
+      return false;
+
     // Phase: scops
     AssumptionCache &AC = FAM.getResult<AssumptionAnalysis>(F);
     const DataLayout &DL = F.getParent()->getDataLayout();


### PR DESCRIPTION
`opt -passes=polly-custom<detect>`, or `stopafter=detect` would still run the ScopInfo analysis even though it should run when explicitly enabled or required by another phase.