### PR TITLE
MC: Move generateCompactUnwindEncodings to MCObjectStreamer. NFC

### DIFF
--- a/llvm/include/llvm/MC/MCDwarf.h
+++ b/llvm/include/llvm/MC/MCDwarf.h
@@ -778,13 +778,11 @@ struct MCDwarfFrameInfo {
   bool IsMTETaggedFrame = false;
 };
 
+// Emit DWARF call frame information and, when available, compact unwind
+// information.
 class MCDwarfFrameEmitter {
 public:
-  //
-  // This emits the frame info section.
-  //
-  LLVM_ABI static void Emit(MCObjectStreamer &streamer, MCAsmBackend *MAB,
-                            bool isEH);
+  LLVM_ABI static void emit(MCObjectStreamer &streamer, bool isEH);
   LLVM_ABI static void encodeAdvanceLoc(MCContext &Context, uint64_t AddrDelta,
                                         SmallVectorImpl<char> &OS);
 };

--- a/llvm/include/llvm/MC/MCObjectStreamer.h
+++ b/llvm/include/llvm/MC/MCObjectStreamer.h
@@ -79,6 +79,7 @@ public:
   bool isIntegratedAssemblerRequired() const override { return true; }
 
   void emitFrames();
+  void generateCompactUnwindEncodings();
   MCSymbol *emitCFILabel() override;
   void emitCFISections(bool EH, bool Debug, bool SFrame) override;
 

--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -221,7 +221,6 @@ class LLVM_ABI MCStreamer {
   MCContext &Context;
   std::unique_ptr<MCTargetStreamer> TargetStreamer;
 
-  std::vector<MCDwarfFrameInfo> DwarfFrameInfos;
   // This is a pair of index into DwarfFrameInfos and the MCSection associated
   // with the frame. Note, we use an index instead of an iterator because they
   // can be invalidated in std::vector.
@@ -265,6 +264,8 @@ protected:
   WinEH::FrameInfo::Epilog *CurrentWinEpilog = nullptr;
 
   MCFragment *CurFrag = nullptr;
+
+  SmallVector<MCDwarfFrameInfo, 0> DwarfFrameInfos;
 
   MCStreamer(MCContext &Ctx);
 
@@ -353,8 +354,6 @@ public:
   }
 
   bool isInEpilogCFI() const { return CurrentWinEpilog; }
-
-  void generateCompactUnwindEncodings(MCAsmBackend *MAB);
 
   /// \name Assembly File Formatting.
   /// @{

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -1902,8 +1902,7 @@ struct CIEKey {
 
 } // end anonymous namespace
 
-void MCDwarfFrameEmitter::Emit(MCObjectStreamer &Streamer, MCAsmBackend *MAB,
-                               bool IsEH) {
+void MCDwarfFrameEmitter::emit(MCObjectStreamer &Streamer, bool IsEH) {
   MCContext &Context = Streamer.getContext();
   const MCObjectFileInfo *MOFI = Context.getObjectFileInfo();
   const MCAsmInfo *AsmInfo = Context.getAsmInfo();
@@ -1913,7 +1912,7 @@ void MCDwarfFrameEmitter::Emit(MCObjectStreamer &Streamer, MCAsmBackend *MAB,
   // Emit the compact unwind info if available.
   bool NeedsEHFrameSection = !MOFI->getSupportsCompactUnwindWithoutEHFrame();
   if (IsEH && MOFI->getCompactUnwindSection()) {
-    Streamer.generateCompactUnwindEncodings(MAB);
+    Streamer.generateCompactUnwindEncodings();
     bool SectionEmitted = false;
     for (const MCDwarfFrameInfo &Frame : FrameArray) {
       if (Frame.CompactUnwindEncoding == 0) continue;

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -181,16 +181,21 @@ void MCObjectStreamer::reset() {
   MCStreamer::reset();
 }
 
+void MCObjectStreamer::generateCompactUnwindEncodings() {
+  auto &Backend = getAssembler().getBackend();
+  for (auto &FI : DwarfFrameInfos)
+    FI.CompactUnwindEncoding =
+        Backend.generateCompactUnwindEncoding(&FI, &getContext());
+}
+
 void MCObjectStreamer::emitFrames() {
   if (!getNumFrameInfos())
     return;
 
-  auto *MAB = &getAssembler().getBackend();
   if (EmitEHFrame)
-    MCDwarfFrameEmitter::Emit(*this, MAB, true);
-
+    MCDwarfFrameEmitter::emit(*this, true);
   if (EmitDebugFrame)
-    MCDwarfFrameEmitter::Emit(*this, MAB, false);
+    MCDwarfFrameEmitter::emit(*this, false);
 
   if (EmitSFrame || (getContext().getTargetOptions() &&
                      getContext().getTargetOptions()->EmitSFrameUnwind))

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -13,7 +13,6 @@
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/DebugInfo/CodeView/SymbolRecord.h"
-#include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCCodeView.h"
 #include "llvm/MC/MCContext.h"
@@ -120,12 +119,6 @@ void MCStreamer::emitRawComment(const Twine &T, bool TabPrefix) {}
 
 void MCStreamer::addExplicitComment(const Twine &T) {}
 void MCStreamer::emitExplicitComments() {}
-
-void MCStreamer::generateCompactUnwindEncodings(MCAsmBackend *MAB) {
-  for (auto &FI : DwarfFrameInfos)
-    FI.CompactUnwindEncoding =
-        (MAB ? MAB->generateCompactUnwindEncoding(&FI, &Context) : 0);
-}
 
 /// EmitIntValue - Special case of EmitValue that avoids the client having to
 /// pass in a MCExpr for constant integers.


### PR DESCRIPTION
... removing the need to pass MCAsmBackend as a parameter.

This allows MCStreamer.cpp to not include MCAsmBackend.h.