### PR TITLE
[Hexagon] Fix signed constant creation in EmitVAArgFromMemory

### DIFF
--- a/clang/lib/CodeGen/Targets/Hexagon.cpp
+++ b/clang/lib/CodeGen/Targets/Hexagon.cpp
@@ -210,7 +210,7 @@ Address HexagonABIInfo::EmitVAArgFromMemory(CodeGenFunction &CGF,
 
     // Create a mask which should be "AND"ed
     // with (overflow_arg_area + align - 1)
-    llvm::Value *Mask = llvm::ConstantInt::get(CGF.Int32Ty, -(int)Align);
+    llvm::Value *Mask = llvm::ConstantInt::getSigned(CGF.Int32Ty, -(int)Align);
     __overflow_area_pointer = CGF.Builder.CreateIntToPtr(
         CGF.Builder.CreateAnd(AsInt, Mask), __overflow_area_pointer->getType(),
         "__overflow_area_pointer.align");


### PR DESCRIPTION
Use ConstantInt::getSigned instead of ConstantInt::get when creating a negative alignment mask in EmitVAArgFromMemory. This is the same fix as commit 8546294db95d (PR #176115) which addressed the issue in EmitVAArgForHexagonLinux.

Added a test case that exercises the EmitVAArgFromMemory alignment path using a struct that is both >8 bytes (to trigger EmitVAArgFromMemory) and has 8-byte alignment (to trigger the alignment masking code).