### PR TITLE
[AMDGPU] Fix instruction size for 64-bit literal constant operands

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -9790,7 +9790,14 @@ unsigned SIInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
               LiteralSize = 8;
             break;
           case AMDGPU::OPERAND_REG_IMM_INT64:
-            if (!Op.isImm() || !AMDGPU::isValid32BitLiteral(Op.getImm(), false))
+            // A 32-bit literal is only valid when the value fits in BOTH signed
+            // and unsigned 32-bit ranges [0, 2^31-1], matching the MC code
+            // emitter's getLit64Encoding logic. This is because of the lack of
+            // abilility to tell signedness of the literal, therefore we need to
+            // be conservative and assume values outside this range require a
+            // 64-bit literal encoding (8 bytes).
+            if (!Op.isImm() || !isInt<32>(Op.getImm()) ||
+                !isUInt<32>(Op.getImm()))
               LiteralSize = 8;
             break;
           }

--- a/llvm/test/CodeGen/AMDGPU/branch-relaxation-inst-size-gfx1250.mir
+++ b/llvm/test/CodeGen/AMDGPU/branch-relaxation-inst-size-gfx1250.mir
@@ -30,11 +30,19 @@ machineFunctionInfo:
 body: |
   ; CHECK-LABEL: name: s_mov_b64_64bit_literal_size
   ; CHECK: bb.0:
-  ; CHECK-NEXT:   successors: %bb.2(0x40000000), %bb.1(0x40000000)
+  ; CHECK-NEXT:   successors: %bb.3(0x40000000), %bb.1(0x40000000)
   ; CHECK-NEXT:   liveins: $sgpr8
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   S_CMP_EQ_U32 $sgpr8, 0, implicit-def $scc
-  ; CHECK-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
+  ; CHECK-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit $scc
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.3:
+  ; CHECK-NEXT:   successors: %bb.2(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   $sgpr4_sgpr5 = S_GETPC_B64 post-instr-symbol <mcsymbol >
+  ; CHECK-NEXT:   $sgpr4 = S_ADD_U32 $sgpr4, target-flags(<unknown target flag>) <mcsymbol >, implicit-def $scc
+  ; CHECK-NEXT:   $sgpr5 = S_ADDC_U32 $sgpr5, target-flags(<unknown target flag>) <mcsymbol >, implicit-def $scc, implicit $scc
+  ; CHECK-NEXT:   S_SETPC_B64 $sgpr4_sgpr5
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)


### PR DESCRIPTION
`getLit64Encoding` uses a different approach to determine whether 64-bit literal encoding is used, which caused a size mismatch between the `MachineInstr` and the `MCInst`.

For `!isValid32BitLiteral`, it is effectively `!(isInt<32>(Val) || isUInt<32>(Val))`, which is `!isInt<32>(Val) && !isUInt<32>(Val)`, but in `getLit64Encoding`, it is `!isInt<32>(Val) || !isUInt<32>(Val)`.