### PR TITLE
[ProfCheck] Add utility to get a MDNode for unknown branch weights

### DIFF
--- a/llvm/include/llvm/IR/ProfDataUtils.h
+++ b/llvm/include/llvm/IR/ProfDataUtils.h
@@ -206,6 +206,11 @@ LLVM_ABI void
 setExplicitlyUnknownBranchWeightsIfProfiled(Instruction &I, StringRef PassName,
                                             const Function *F = nullptr);
 
+/// Returns a metadata node containing unknown branch weights if the function
+/// has an entry count, otherwise returns nullptr.
+LLVM_ABI MDNode *
+getExplicitlyUnknownBranchWeightsIfProfiled(Function &F, StringRef PassName);
+
 /// Analogous to setExplicitlyUnknownBranchWeights, but for functions and their
 /// entry counts.
 LLVM_ABI void setExplicitlyUnknownFunctionEntryCount(Function &F,

--- a/llvm/lib/IR/ProfDataUtils.cpp
+++ b/llvm/lib/IR/ProfDataUtils.cpp
@@ -289,6 +289,18 @@ void llvm::setExplicitlyUnknownBranchWeightsIfProfiled(Instruction &I,
     setExplicitlyUnknownBranchWeights(I, PassName);
 }
 
+MDNode *llvm::getExplicitlyUnknownBranchWeightsIfProfiled(Function &F,
+                                                          StringRef PassName) {
+  if (std::optional<Function::ProfileCount> EC = F.getEntryCount();
+      !EC || EC->getCount() == 0)
+    return nullptr;
+  MDBuilder MDB(F.getContext());
+  return MDNode::get(
+      F.getContext(),
+      {MDB.createString(MDProfLabels::UnknownBranchWeightsMarker),
+       MDB.createString(PassName)});
+}
+
 void llvm::setExplicitlyUnknownFunctionEntryCount(Function &F,
                                                   StringRef PassName) {
   MDBuilder MDB(F.getContext());


### PR DESCRIPTION
There are some cases where it is non-trivial to get access to a
branch/select instruction and the helper function that creates the
branch/select of interest takes in a MDNode for branch weights. Add a
helper to create a MDNode for unknown branch weights if the function is
profiled to handle this case.
