### PR TITLE
[BPF] i128 direct return support

### DIFF
--- a/llvm/lib/Target/BPF/BPFCallingConv.td
+++ b/llvm/lib/Target/BPF/BPFCallingConv.td
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 // BPF 64-bit C return-value convention.
-def RetCC_BPF64 : CallingConv<[CCIfType<[i64], CCAssignToReg<[R0]>>]>;
+def RetCC_BPF64 : CallingConv<[CCIfType<[i64], CCAssignToReg<[R0, R1]>>]>;
 
 // BPF 64-bit C Calling convention.
 def CC_BPF64 : CallingConv<[
@@ -28,7 +28,9 @@ def CC_BPF64 : CallingConv<[
 // Return-value convention when -mattr=+alu32 enabled
 def RetCC_BPF32 : CallingConv<[
   CCIfType<[i32], CCAssignToRegWithShadow<[W0], [R0]>>,
-  CCIfType<[i64], CCAssignToRegWithShadow<[R0], [W0]>>
+  CCIfType<[i32], CCAssignToRegWithShadow<[W1], [R1]>>,
+  CCIfType<[i64], CCAssignToRegWithShadow<[R0], [W0]>>,
+  CCIfType<[i64], CCAssignToRegWithShadow<[R1], [W1]>>,
 ]>;
 
 // Calling convention when -mattr=+alu32 enabled

--- a/llvm/test/CodeGen/BPF/arr_ret1.ll
+++ b/llvm/test/CodeGen/BPF/arr_ret1.ll
@@ -1,0 +1,13 @@
+; RUN: llc -mtriple=bpf < %s | FileCheck %s
+
+; Function Attrs: nounwind uwtable
+define [2 x i64] @foo(i32 %a, i32 %b, i32 %c) #0 {
+; CHECK-LABEL: foo:
+; CHECK: w4 = 1
+; CHECK-NEXT: w5 = 2
+entry:
+  %call = tail call [2 x i64]  @bar(i32 %a, i32 %b, i32 %c, i32 1, i32 2) #3
+  ret [2 x i64] %call
+}
+
+declare [2 x i64] @bar(i32, i32, i32, i32, i32) #1

--- a/llvm/test/CodeGen/BPF/arr_ret2.ll
+++ b/llvm/test/CodeGen/BPF/arr_ret2.ll
@@ -1,0 +1,12 @@
+; RUN: not llc -mtriple=bpf < %s 2> %t1
+; RUN: FileCheck %s < %t1
+; CHECK: only small returns
+
+; Function Attrs: nounwind uwtable
+define [3 x i32] @foo(i32 %a, i32 %b, i32 %c) #0 {
+entry:
+  %call = tail call [3 x i32] @bar(i32 %a, i32 %b, i32 %c, i32 1, i32 2) #3
+  ret [3 x i32] %call
+}
+
+declare [3 x i32] @bar(i32, i32, i32, i32, i32) #1

--- a/llvm/test/CodeGen/BPF/i128-bpf64.ll
+++ b/llvm/test/CodeGen/BPF/i128-bpf64.ll
@@ -1,14 +1,14 @@
-; RUN: llc -mtriple=bpf < %s | FileCheck %s
+; RUN: llc -mtriple=bpf -mcpu=generic < %s | FileCheck %s
 
 define void @test(ptr %a) nounwind {
 ; CHECK-LABEL: test:
 ; CHECK: r6 = r1
-; CHECK-NEXT: w2 = 0
+; CHECK-NEXT: r2 = 0
 ; CHECK-NEXT: call __atomic_load_16
 ; CHECK-NEXT: r3 = r1
 ; CHECK-NEXT: r1 = r6
 ; CHECK-NEXT: r2 = r0
-; CHECK-NEXT: w4 = 0
+; CHECK-NEXT: r4 = 0
 ; CHECK-NEXT: call __atomic_store_16
   %1 = load atomic i128, ptr %a monotonic, align 16
   store atomic i128 %1, ptr %a monotonic, align 16

--- a/llvm/test/CodeGen/BPF/struct_ret1.ll
+++ b/llvm/test/CodeGen/BPF/struct_ret1.ll
@@ -1,6 +1,5 @@
 ; RUN: not llc -mtriple=bpf < %s 2> %t1
 ; RUN: FileCheck %s < %t1
-; CHECK: error: <unknown>:0:0: in function bar { i64, i32 } (i32, i32, i32, i32, i32): aggregate returns are not supported
 
 %struct.S = type { i32, i32, i32 }
 

--- a/llvm/test/CodeGen/BPF/struct_ret2.ll
+++ b/llvm/test/CodeGen/BPF/struct_ret2.ll
@@ -1,9 +1,10 @@
-; RUN: not llc -mtriple=bpf < %s 2> %t1
-; RUN: FileCheck %s < %t1
-; CHECK: only small returns
+; RUN: llc -mtriple=bpf < %s | FileCheck %s
 
 ; Function Attrs: nounwind uwtable
 define { i64, i32 } @foo(i32 %a, i32 %b, i32 %c) #0 {
+; CHECK-LABEL: foo:
+; CHECK: w4 = 1
+; CHECK-NEXT: w5 = 2
 entry:
   %call = tail call { i64, i32 } @bar(i32 %a, i32 %b, i32 %c, i32 1, i32 2) #3
   ret { i64, i32 } %call

--- a/llvm/test/CodeGen/BPF/struct_ret3.ll
+++ b/llvm/test/CodeGen/BPF/struct_ret3.ll
@@ -1,0 +1,12 @@
+; RUN: not llc -mtriple=bpf < %s 2> %t1
+; RUN: FileCheck %s < %t1
+; CHECK: only small returns
+
+; Function Attrs: nounwind uwtable
+define { i64, i32, i32 } @foo(i32 %a, i32 %b, i32 %c) #0 {
+entry:
+  %call = tail call { i64, i32, i32 } @bar(i32 %a, i32 %b, i32 %c, i32 1, i32 2) #3
+  ret { i64, i32, i32 } %call
+}
+
+declare { i64, i32, i32 } @bar(i32, i32, i32, i32, i32) #1

--- a/llvm/test/CodeGen/BPF/struct_ret4.ll
+++ b/llvm/test/CodeGen/BPF/struct_ret4.ll
@@ -1,0 +1,12 @@
+; RUN: not llc -mtriple=bpf < %s 2> %t1
+; RUN: FileCheck %s < %t1
+; CHECK: only small returns
+
+; Function Attrs: nounwind uwtable
+define { i32, i32, i32 } @foo(i32 %a, i32 %b, i32 %c) #0 {
+entry:
+  %call = tail call { i32, i32, i32 } @bar(i32 %a, i32 %b, i32 %c, i32 1, i32 2) #3
+  ret { i32, i32, i32 } %call
+}
+
+declare { i32, i32, i32 } @bar(i32, i32, i32, i32, i32) #1


### PR DESCRIPTION
This patch adds i128 return type support for BPF targets through direct return using registers R0/R1. It also extends support to small aggregate return types that can fit within two 64-bit registers, such as structs or arrays with a total size ≤ 128 bits and fewer than two elements

**Test Updates**

`atomic-oversize.ll`: i128 return type now supported
`struct_ret2.ll`: {i64, i32} return type now supported
`struct_ret1.ll`: bar function with {i64, i32} return type is now supported; large struct return remains unsupported and still correctly triggers the “aggregate return unsupported” error

**New Tests**

`i128-bpf64.ll`: Verifies i128 return under RetCC_BPF64
`struct_ret3.ll` / `struct_ret4.ll`: {i32, i32, i32} and {i64, i32, i32} (more than 3 elements) returns remain unsupported
`arr_ret1.ll` / `arr_ret2.ll`: Tests array-type returns