### PR TITLE
[libc++] Fix FreeBSD atomic timed wait system call

### DIFF
--- a/libcxx/src/atomic.cpp
+++ b/libcxx/src/atomic.cpp
@@ -159,7 +159,7 @@ static void __platform_wait_on_address(void const* __ptr, void const* __val, May
     _umtx_op(const_cast<void*>(__ptr),
              UMTX_OP_WAIT,
              value,
-             static_cast<void*>(static_cast<uintptr_t>(sizeof(timeout))),
+             reinterpret_cast<void*>(static_cast<uintptr_t>(sizeof(timeout))),
              &timeout);
   }
 }

--- a/libcxx/src/atomic.cpp
+++ b/libcxx/src/atomic.cpp
@@ -153,8 +153,8 @@ static void __platform_wait_on_address(void const* __ptr, void const* __val, May
     _umtx_op(const_cast<void*>(__ptr), UMTX_OP_WAIT, value, nullptr, nullptr);
   } else {
     timespec timeout{};
-    timeout.tv_sec  = __timeout_ns / 1'000'000'000;
-    timeout.tv_nsec = __timeout_ns % 1'000'000'000;
+    timeout.tv_sec  = maybe_timeout_ns / 1'000'000'000;
+    timeout.tv_nsec = maybe_timeout_ns % 1'000'000'000;
 
     _umtx_op(const_cast<void*>(__ptr),
              UMTX_OP_WAIT,


### PR DESCRIPTION
This PR fixes atomic timed wait on FreeBSD platforms.

When we added timed wait support, on FreeBSD platform, we were looking only the `UMTX_OP_WAIT` section of the FreeBSD doc https://man.freebsd.org/cgi/man.cgi?query=_umtx_op&apropos=0&sektion=2&manpath=FreeBSD+16.0-CURRENT&format=html . Somehow we missed the generic section that describes the timeout parameter that applies to all operations. As a consequence, we missed the part that the FreeBSD is expecting the `size` to be casted to `uintptr_t`, then passed in to the `void*` parameter.

This PR fixes the issue by casting the type to what the system requires.

As drive by, this PR also
- uses simple `timespec` instead of the extended one
  - as documentation suggests, "Interval counting is  always  performed by the monotonic wall clock", and "If the flag is absent, the timeout value is relative", which means that using the simple version is enough and using the extended version is unnecessarily complex and might be confusing to the people who aren't familiar with the API. And using `timespec` is also consistent with the code in Linux case.
- directly reintepret_cast the comparison value to __cxx_contention_t
  - As FreeBSD only supports the old ABI at the moment, the input is ever going to be the exact type `__cxx_contention_t`. Copying to local buffer is unnecessary and confusing. 