### PR TITLE
Revert "[NFC][LiveStacks] Use vectors instead of map and unordred_map"

### DIFF
--- a/llvm/include/llvm/CodeGen/LiveStacks.h
+++ b/llvm/include/llvm/CodeGen/LiveStacks.h
@@ -40,43 +40,49 @@ class LiveStacks {
   ///
   VNInfo::Allocator VNInfoAllocator;
 
-  int StartIdx = -1;
-  SmallVector<LiveInterval *> S2LI;
-  SmallVector<const TargetRegisterClass *> S2RC;
+  /// S2IMap - Stack slot indices to live interval mapping.
+  using SS2IntervalMap = std::unordered_map<int, LiveInterval>;
+  SS2IntervalMap S2IMap;
+
+  /// S2RCMap - Stack slot indices to register class mapping.
+  std::map<int, const TargetRegisterClass *> S2RCMap;
 
 public:
-  using iterator = SmallVector<LiveInterval *>::iterator;
-  using const_iterator = SmallVector<LiveInterval *>::const_iterator;
+  using iterator = SS2IntervalMap::iterator;
+  using const_iterator = SS2IntervalMap::const_iterator;
 
-  const_iterator begin() const { return S2LI.begin(); }
-  const_iterator end() const { return S2LI.end(); }
-  iterator begin() { return S2LI.begin(); }
-  iterator end() { return S2LI.end(); }
+  const_iterator begin() const { return S2IMap.begin(); }
+  const_iterator end() const { return S2IMap.end(); }
+  iterator begin() { return S2IMap.begin(); }
+  iterator end() { return S2IMap.end(); }
 
-  unsigned getStartIdx() const { return StartIdx; }
-  unsigned getNumIntervals() const { return (unsigned)S2LI.size(); }
+  unsigned getNumIntervals() const { return (unsigned)S2IMap.size(); }
 
   LiveInterval &getOrCreateInterval(int Slot, const TargetRegisterClass *RC);
 
   LiveInterval &getInterval(int Slot) {
     assert(Slot >= 0 && "Spill slot indice must be >= 0");
-    return *S2LI[Slot - StartIdx];
+    SS2IntervalMap::iterator I = S2IMap.find(Slot);
+    assert(I != S2IMap.end() && "Interval does not exist for stack slot");
+    return I->second;
   }
 
   const LiveInterval &getInterval(int Slot) const {
     assert(Slot >= 0 && "Spill slot indice must be >= 0");
-    return *S2LI[Slot - StartIdx];
+    SS2IntervalMap::const_iterator I = S2IMap.find(Slot);
+    assert(I != S2IMap.end() && "Interval does not exist for stack slot");
+    return I->second;
   }
 
-  bool hasInterval(int Slot) const {
-    if (Slot < StartIdx || StartIdx == -1)
-      return false;
-    return !getInterval(Slot).empty();
-  }
+  bool hasInterval(int Slot) const { return S2IMap.count(Slot); }
 
   const TargetRegisterClass *getIntervalRegClass(int Slot) const {
     assert(Slot >= 0 && "Spill slot indice must be >= 0");
-    return S2RC[Slot - StartIdx];
+    std::map<int, const TargetRegisterClass *>::const_iterator I =
+        S2RCMap.find(Slot);
+    assert(I != S2RCMap.end() &&
+           "Register class info does not exist for stack slot");
+    return I->second;
   }
 
   VNInfo::Allocator &getVNInfoAllocator() { return VNInfoAllocator; }

--- a/llvm/lib/CodeGen/StackSlotColoring.cpp
+++ b/llvm/lib/CodeGen/StackSlotColoring.cpp
@@ -260,14 +260,24 @@ void StackSlotColoring::InitializeSlots() {
   UsedColors[0].resize(LastFI);
   Assignments.resize(LastFI);
 
+  using Pair = std::iterator_traits<LiveStacks::iterator>::value_type;
+
+  SmallVector<Pair *, 16> Intervals;
+
+  Intervals.reserve(LS->getNumIntervals());
+  for (auto &I : *LS)
+    Intervals.push_back(&I);
+  llvm::sort(Intervals,
+             [](Pair *LHS, Pair *RHS) { return LHS->first < RHS->first; });
+
   // Gather all spill slots into a list.
   LLVM_DEBUG(dbgs() << "Spill slot intervals:\n");
-  for (auto [Idx, I] : llvm::enumerate(*LS)) {
-    int FI = Idx + LS->getStartIdx();
-    if (!I || MFI->isDeadObjectIndex(FI))
-      continue;
-    LiveInterval &li = *I;
+  for (auto *I : Intervals) {
+    LiveInterval &li = I->second;
     LLVM_DEBUG(li.dump());
+    int FI = li.reg().stackSlotIndex();
+    if (MFI->isDeadObjectIndex(FI))
+      continue;
 
     SSIntervals.push_back(&li);
     OrigAlignments[FI] = MFI->getObjectAlign(FI);

--- a/llvm/lib/Target/AMDGPU/AMDGPUMarkLastScratchLoad.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMarkLastScratchLoad.cpp
@@ -102,15 +102,15 @@ bool AMDGPUMarkLastScratchLoad::run(MachineFunction &MF) {
 
   bool Changed = false;
 
-  for (auto *LI : *LS) {
-    for (const LiveRange::Segment &Segment : LI->segments) {
+  for (auto &[SS, LI] : *LS) {
+    for (const LiveRange::Segment &Segment : LI.segments) {
 
       // Ignore segments that run to the end of basic block because in this case
       // slot is still live at the end of it.
       if (Segment.end.isBlock())
         continue;
 
-      const int FrameIndex = LI->reg().stackSlotIndex();
+      const int FrameIndex = LI.reg().stackSlotIndex();
       MachineInstr *LastLoad = nullptr;
 
       MachineInstr *MISegmentEnd = SI->getInstructionFromIndex(Segment.end);

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -480,14 +480,13 @@ void AMDGPURewriteAGPRCopyMFMAImpl::eliminateSpillsOfReassignedVGPRs() const {
   SmallVector<LiveInterval *, 32> StackIntervals;
   StackIntervals.reserve(NumSlots);
 
-  for (auto [Idx, LI] : llvm::enumerate(LSS)) {
-    int Slot = Idx + LSS.getStartIdx();
+  for (auto &[Slot, LI] : LSS) {
     if (!MFI.isSpillSlotObjectIndex(Slot) || MFI.isDeadObjectIndex(Slot))
       continue;
 
     const TargetRegisterClass *RC = LSS.getIntervalRegClass(Slot);
     if (TRI.hasVGPRs(RC))
-      StackIntervals.push_back(LI);
+      StackIntervals.push_back(&LI);
   }
 
   sort(StackIntervals, [](const LiveInterval *A, const LiveInterval *B) {


### PR DESCRIPTION
Reverts llvm/llvm-project#165477

Break https://lab.llvm.org/buildbot/#/builders/52/builds/14874