### PR TITLE
[clang] Check upperbound for attribute param index

### DIFF
--- a/clang/include/clang/AST/Attr.h
+++ b/clang/include/clang/AST/Attr.h
@@ -275,8 +275,11 @@ public:
 /// A single parameter index whose accessors require each use to make explicit
 /// the parameter index encoding needed.
 class ParamIdx {
+public:
+  constexpr static unsigned IdxBitWidth = 30;
+private:
   // Idx is exposed only via accessors that specify specific encodings.
-  unsigned Idx : 30;
+  unsigned Idx : IdxBitWidth;
   LLVM_PREFERRED_TYPE(bool)
   unsigned HasThis : 1;
   LLVM_PREFERRED_TYPE(bool)

--- a/clang/include/clang/AST/Attr.h
+++ b/clang/include/clang/AST/Attr.h
@@ -277,6 +277,7 @@ public:
 class ParamIdx {
 public:
   constexpr static unsigned IdxBitWidth = 30;
+
 private:
   // Idx is exposed only via accessors that specify specific encodings.
   unsigned Idx : IdxBitWidth;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5186,8 +5186,9 @@ public:
       return false;
     }
 
-    unsigned IdxSource = IdxInt->getLimitedValue(UINT_MAX);
-    if (IdxSource < 1 ||
+    constexpr unsigned Limit = 1 << ParamIdx::IdxBitWidth;
+    unsigned IdxSource = IdxInt->getLimitedValue(Limit);
+    if (IdxSource < 1 || IdxSource == Limit ||
         ((!IV || !CanIndexVariadicArguments) && IdxSource > NumParams)) {
       Diag(getAttrLoc(AI), diag::err_attribute_argument_out_of_bounds)
           << &AI << AttrArgNum << IdxExpr->getSourceRange();

--- a/clang/test/Sema/nonnull.c
+++ b/clang/test/Sema/nonnull.c
@@ -176,3 +176,8 @@ void pr30828(char *p) {}
 void call_pr30828(void) {
   pr30828(0); // expected-warning {{null passed to a callee that requires a non-null argument}}
 }
+
+void gh176638_1(int (*g)(const char *h, ...) __attribute__((nonnull(2147483648))) __attribute__((nonnull))) {} // expected-error {{attribute parameter 1 is out of bounds}}
+void gh176638_2(int (*g)(const char *h, ...) __attribute__((nonnull(1073741825))) __attribute__((nonnull))) {} // expected-error {{attribute parameter 1 is out of bounds}}
+void gh176638_3(int (*g)(const char *h, ...) __attribute__((nonnull(1073741824))) __attribute__((nonnull))) {} // expected-error {{attribute parameter 1 is out of bounds}} 
+void gh176638_4(int (*g)(const char *h, ...) __attribute__((nonnull(1073741823))) __attribute__((nonnull))) {} // no-warning


### PR DESCRIPTION
Fixes #176638

The `ParamIdx` class encodes attribute's parameter indexes in 30 bits, check if assignments overflow and issue an "attribute parameter out of bounds" error in that case.