### PR TITLE
Move target specific constant folding from ConstantFolding.cpp file

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -718,7 +718,8 @@ class Intrinsic<list<LLVMType> ret_types,
                 list<IntrinsicProperty> intr_properties = [],
                 string name = "",
                 list<SDNodeProperty> sd_properties = [],
-                bit disable_default_attributes = true> : SDPatternOperator {
+                bit disable_default_attributes = true,
+                string const_folder = ""> : SDPatternOperator {
   string LLVMName = name;
   string TargetPrefix = "";   // Set to a prefix for target-specific intrinsics.
   list<LLVMType> RetTypes = ret_types;
@@ -729,6 +730,7 @@ class Intrinsic<list<LLVMType> ret_types,
   // Disable applying IntrinsicProperties that are marked default with
   // IntrinsicProperty<1>
   bit DisableDefaultAttributes = disable_default_attributes;
+  string ConstFolder = const_folder;
 
   TypeInfoGen TypeInfo = TypeInfoGen<RetTypes, ParamTypes>;
 }

--- a/llvm/lib/Analysis/CMakeLists.txt
+++ b/llvm/lib/Analysis/CMakeLists.txt
@@ -34,6 +34,12 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   set_source_files_properties(ConstantFolding.cpp PROPERTIES COMPILE_OPTIONS "-ftrapping-math")
 endif()
 
+
+set(LLVM_TARGET_DEFINITIONS ${LLVM_MAIN_INCLUDE_DIR}/llvm/IR/Intrinsics.td)
+tablegen(LLVM IntrinsicConstantFolding.inc
+         -gen-constant-folding)
+add_public_tablegen_target(ConstFoldingGen)
+
 add_llvm_component_library(LLVMAnalysis
   AliasAnalysis.cpp
   AliasAnalysisEvaluator.cpp
@@ -168,6 +174,7 @@ add_llvm_component_library(LLVMAnalysis
   DEPENDS
   analysis_gen
   intrinsics_gen
+  ConstFoldingGen
   ${MLDeps}
 
   LINK_LIBS

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -71,6 +71,8 @@ static cl::opt<bool> DisableFPCallFolding(
 
 namespace {
 
+#include "IntrinsicConstantFolding.inc"
+
 //===----------------------------------------------------------------------===//
 // Constant Folding internal helper functions
 //===----------------------------------------------------------------------===//
@@ -4536,6 +4538,10 @@ Constant *llvm::ConstantFoldCall(const CallBase *Call, Function *F,
     return nullptr;
 
   StringRef Name = F->getName();
+  // Try to fold intrinsic with funtions from a ConstFolder intrinsic's field
+  if (auto *FoldedIntr = foldIntrinsic(Name, IID, Ty, Operands, F->getDataLayout(), TLI, Call))
+    return FoldedIntr;
+
   if (auto *FVTy = dyn_cast<FixedVectorType>(Ty))
     return ConstantFoldFixedVectorCall(
         Name, IID, FVTy, Operands, F->getDataLayout(), TLI, Call);

--- a/llvm/utils/TableGen/CMakeLists.txt
+++ b/llvm/utils/TableGen/CMakeLists.txt
@@ -56,6 +56,7 @@ add_tablegen(llvm-tblgen LLVM
   GlobalISelEmitter.cpp
   InstrDocsEmitter.cpp
   InstrInfoEmitter.cpp
+  IntrinsicFolderEmitter.cpp
   llvm-tblgen.cpp
   MacroFusionPredicatorEmitter.cpp
   OptionParserEmitter.cpp

--- a/llvm/utils/TableGen/IntrinsicFolderEmitter.cpp
+++ b/llvm/utils/TableGen/IntrinsicFolderEmitter.cpp
@@ -1,0 +1,58 @@
+#include "llvm/TableGen/Record.h"
+#include "llvm/TableGen/TableGenBackend.h"
+
+// utils/TableGen/IntrinsicFolderEmitter.cpp
+#include "llvm/TableGen/Record.h"
+#include "llvm/TableGen/TableGenBackend.h"
+#include <vector>
+
+using namespace llvm;
+
+namespace {
+class IntrinsicFolderEmitter {
+  const RecordKeeper &Records;
+
+public:
+  IntrinsicFolderEmitter(const RecordKeeper &R) : Records(R) {}
+
+  void run(raw_ostream &OS) {
+    emitSwitchFunction(OS);
+  }
+
+private:
+  void emitSwitchFunction(raw_ostream &OS) {
+    // Get all intrinsic definitions
+    ArrayRef<const Record*> Intrinsics =
+        Records.getAllDerivedDefinitions("Intrinsic");
+
+    OS << "// Automatically generated file. Do not edit!\n";
+    OS << "// Intrinsic constant folding switch function\n\n";
+
+    OS << "static Constant *foldIntrinsic(Intrinsic::ID IntrinsicID, Type *Ty,\n";
+    OS << "                               ArrayRef<Constant *> Operands,\n";
+    OS << "                               const CallBase *Call) {\n";
+    OS << "  switch (IntrinsicID) {\n";
+    OS << "    default: return nullptr;\n";
+
+    for (const Record *R : Intrinsics) {
+      if (R->isValueUnset("Folder"))
+        continue;
+
+      StringRef FolderName = R->getValueAsString("Folder");
+      if (FolderName.empty())
+        continue;
+
+      StringRef EnumName = R->getName();
+      // TODO: make a proper interface
+      OS << "    case Intrinsic::" << EnumName << ":\n";
+      OS << "      return " << FolderName << "(...);\n";
+    }
+
+    OS << "  }\n";
+    OS << "}\n";
+  }
+};
+} // namespace
+
+static TableGen::Emitter::OptClass<IntrinsicFolderEmitter>
+    X("gen-constant-folding-functions", "Generate functions for constants folding for intrinsics");

--- a/llvm/utils/gn/secondary/llvm/utils/TableGen/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/utils/TableGen/BUILD.gn
@@ -42,6 +42,7 @@ executable("llvm-tblgen") {
     "GlobalISelEmitter.cpp",
     "InstrDocsEmitter.cpp",
     "InstrInfoEmitter.cpp",
+    "IntrinsicFolderEmitter.cpp",
     "MacroFusionPredicatorEmitter.cpp",
     "OptionParserEmitter.cpp",
     "OptionRSTEmitter.cpp",


### PR DESCRIPTION
There was a [discussion](https://discourse.llvm.org/t/constant-propagation-for-target-specific-intrinsics) about moving target dependent intrinsics to a separate interface. This is an attempt to make an interface that allows developers to add folding code without changing ConstantFolding.cpp

## Idea
Intrinsics are generated in the general part of the LLVM, so target specific handling might be implemented in two ways: target hook and generated functions. The first one doesn't guarantee the same functionality as now, because folding functions are called from contexts where target information (like TTI) could not be accessed. An additional interface that was discussed [here](https://discourse.llvm.org/t/constant-propagation-for-target-specific-intrinsics) also doesn't fit because it would require to change all users of ConstantFolding API in order to support it.
 
The second way doesn't proved full separation of target dependent and target independent code, but makes it easier to add new implementation of folding.

## Implementation
The **IntrinsicFolderEmittaer.inc** file contains functions with a switch case:
```
switch (IntrID) {
case ID:
  return foldIntrinsc();
```
An **Intrinsic** class from Intrinsics.td file now has a new field ConstFolder which is a name of a function to which  IntrinsicFolderEmittaer generate call in the switch case.
Implementations of the functions should be in a file that should be in a lib/Analysis folder.
