### PR TITLE
[clang][Sema] Guard polymorphic check in TransformCXXTypeidExpr for incomplete record types

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -313,6 +313,7 @@ Bug Fixes to C++ Support
 - Fixed a bug where captured variables in non-mutable lambdas were incorrectly treated as mutable 
   when used inside decltype in the return type. (#GH180460)
 - Fixed a crash when evaluating uninitialized GCC vector/ext_vector_type vectors in ``constexpr``. (#GH180044)
+- Fixed a crash on ``typeid`` of incomplete local types during template instantiation. (#GH63242), (#GH176397)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/SemaCXX/typeid-incomplete-local-crash.cpp
+++ b/clang/test/SemaCXX/typeid-incomplete-local-crash.cpp
@@ -1,0 +1,48 @@
+// RUN: %clang_cc1 -std=c++17 -fsyntax-only -verify %s
+
+namespace std {
+class type_info;
+}
+
+namespace gh176397 {
+auto recursiveLambda = [](auto, int) {
+  struct S; // #S-fwd
+  typeid(*static_cast<S *>(nullptr));
+  // expected-error@-1 {{'typeid' of incomplete type 'S'}}
+  // expected-note@#S-fwd {{forward declaration of 'S'}}
+  // expected-note@#call {{in instantiation of function template specialization}}
+};
+
+void test() {
+  recursiveLambda(recursiveLambda, 10); // #call
+}
+} // namespace gh176397
+
+namespace gh63242 {
+struct scoped {
+  enum class scoped2 {
+    RED,
+    YELLOW,
+    GREEN
+  };
+};
+
+template <auto N>
+struct scoped_struct {
+  void f() {
+    class scoped2 e = scoped::scoped2::RED; // #scoped2-fwd
+    // expected-error@-1 {{implicit instantiation of undefined member 'scoped2'}}
+    // expected-note@#scoped2-fwd {{member is declared here}}
+    // expected-note@#f-call {{in instantiation of member function 'gh63242::scoped_struct<gh63242::scoped::scoped2::RED>::f' requested here}}
+
+    (void)typeid(e);
+    // expected-error@-1 {{'typeid' of incomplete type 'class scoped2'}}
+    // expected-note@#scoped2-fwd {{forward declaration of 'scoped2'}}
+  }
+};
+
+void test() {
+  scoped_struct<scoped::scoped2::RED> s;
+  s.f(); // #f-call
+}
+} // namespace gh63242


### PR DESCRIPTION
## Summary
In template instantiation, dependent `typeid(expr)` is first formed without completeness checks in `BuildCXXTypeId`, then transformed in `TransformCXXTypeidExpr`.
On that path, `TransformCXXTypeidExpr` may call `RD->isPolymorphic()` to select the evaluation context before completeness is enforced.
If the operand class type is incomplete, this can trigger an assertion.

## Fix
Call and check `RequireCompleteType` before calling `RD->isPolymorphic()`.

**Note: Used Codex for analysis and wording assistance. No AI tools were used for code changes.**

Fixes #176397
Fixes #63242