### PR TITLE
[Clang] Fix inverted diagnostic location for duplicate default labels

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11015,8 +11015,8 @@ public:
   void ActOnCaseStmtBody(Stmt *CaseStmt, Stmt *SubStmt);
 
   StmtResult ActOnDefaultStmt(SourceLocation DefaultLoc,
-                              SourceLocation ColonLoc, Stmt *SubStmt,
-                              Scope *CurScope);
+                              SourceLocation ColonLoc, Scope *CurScope);
+  void ActOnDefaultStmtBody(Stmt *S, Stmt *SubStmt);
   StmtResult ActOnLabelStmt(SourceLocation IdentLoc, LabelDecl *TheDecl,
                             SourceLocation ColonLoc, Stmt *SubStmt);
 

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -937,6 +937,12 @@ StmtResult Parser::ParseDefaultStatement(ParsedStmtContext StmtCtx) {
     ColonLoc = ExpectedLoc;
   }
 
+  StmtResult Default =
+      Actions.ActOnDefaultStmt(DefaultLoc, ColonLoc, getCurScope());
+
+  if (Default.isInvalid())
+    return ParseStatement(/*TrailingElseLoc=*/nullptr, StmtCtx);
+
   StmtResult SubStmt;
 
   if (Tok.is(tok::r_brace)) {
@@ -953,8 +959,8 @@ StmtResult Parser::ParseDefaultStatement(ParsedStmtContext StmtCtx) {
     SubStmt = Actions.ActOnNullStmt(ColonLoc);
 
   DiagnoseLabelFollowedByDecl(*this, SubStmt.get());
-  return Actions.ActOnDefaultStmt(DefaultLoc, ColonLoc,
-                                  SubStmt.get(), getCurScope());
+  Actions.ActOnDefaultStmtBody(Default.get(), SubStmt.get());
+  return Default;
 }
 
 StmtResult Parser::ParseCompoundStatement(bool isStmtExpr) {

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -1395,8 +1395,12 @@ public:
   StmtResult RebuildDefaultStmt(SourceLocation DefaultLoc,
                                       SourceLocation ColonLoc,
                                       Stmt *SubStmt) {
-    return getSema().ActOnDefaultStmt(DefaultLoc, ColonLoc, SubStmt,
-                                      /*CurScope=*/nullptr);
+    StmtResult Default = getSema().ActOnDefaultStmt(DefaultLoc, ColonLoc,
+                                                    /*CurScope=*/nullptr);
+    if (Default.isInvalid())
+      return StmtError();
+    getSema().ActOnDefaultStmtBody(Default.get(), SubStmt);
+    return Default;
   }
 
   /// Build a new label statement.

--- a/clang/test/Sema/switch-default.cpp
+++ b/clang/test/Sema/switch-default.cpp
@@ -16,6 +16,15 @@ int f2(int a) {
   return a;
 }
 
+void f3(int z) {
+    switch(z) {
+      default: // expected-note {{previous case defined here}}
+      case 1:
+      default:  // expected-error {{multiple default labels in one switch}}
+        break;
+    }
+}
+
 // Warn even completely covered Enum cases(GCC compatibility).
 enum E { A, B };
 enum E check_enum(enum E e) {

--- a/clang/test/SemaCXX/switch.cpp
+++ b/clang/test/SemaCXX/switch.cpp
@@ -14,6 +14,15 @@ void test() {
   }
 }
 
+void test2(int z) {
+  switch(z) {
+    default:   // expected-note {{previous case defined here}}
+    case 1:
+    case 2:
+    default: break; // expected-error {{multiple default labels in one switch}}
+  }
+}
+
 // PR5518
 struct A { 
   operator int(); // expected-note{{conversion to integral type}}


### PR DESCRIPTION
Fixes #180429.

Currently, Clang reports the error for a duplicate `default` label on the *first* occurrence instead of the second one. This happens because the switch case list is often built in reverse order during parsing, so the loop encounters the "second" default first.

This patch attempts to fix the diagnostic by identifying which label is physically later in the source.

(Note: Based on @erichkeane's feedback, I am investigating fixing the AST ordering instead of using SourceLocation).