### PR TITLE
[MC] Move MCTargetOptions ownership from MCContext to MCAsmInfo

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -434,6 +434,8 @@ protected:
   llvm::StringMap<uint32_t> NameToAtSpecifier;
   void initializeAtSpecifiers(ArrayRef<AtSpecifier>);
 
+  const MCTargetOptions *TargetOptions = nullptr;
+
 public:
   explicit MCAsmInfo();
   virtual ~MCAsmInfo();
@@ -441,6 +443,9 @@ public:
   // Explicitly non-copyable.
   MCAsmInfo(MCAsmInfo const &) = delete;
   MCAsmInfo &operator=(MCAsmInfo const &) = delete;
+
+  const MCTargetOptions *getTargetOptions() const { return TargetOptions; }
+  void setTargetOptions(const MCTargetOptions &TO) { TargetOptions = &TO; }
 
   /// Get the code pointer size in bytes.
   unsigned getCodePointerSize() const { return CodePointerSize; }

--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -326,8 +326,6 @@ private:
   /// Do automatic reset in destructor
   bool AutoReset;
 
-  MCTargetOptions const *TargetOptions;
-
   bool HadError = false;
 
   void reportCommon(SMLoc Loc,
@@ -417,7 +415,7 @@ public:
 
   const MCSubtargetInfo *getSubtargetInfo() const { return MSTI; }
 
-  const MCTargetOptions *getTargetOptions() const { return TargetOptions; }
+  LLVM_ABI const MCTargetOptions *getTargetOptions() const;
 
   LLVM_ABI CodeViewContext &getCVContext();
 

--- a/llvm/include/llvm/MC/TargetRegistry.h
+++ b/llvm/include/llvm/MC/TargetRegistry.h
@@ -21,6 +21,7 @@
 #include "llvm-c/DisassemblerTypes.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Compiler.h"
@@ -409,7 +410,10 @@ public:
                              const MCTargetOptions &Options) const {
     if (!MCAsmInfoCtorFn)
       return nullptr;
-    return MCAsmInfoCtorFn(MRI, TheTriple, Options);
+    auto *MAI = MCAsmInfoCtorFn(MRI, TheTriple, Options);
+    if (MAI)
+      MAI->setTargetOptions(Options);
+    return MAI;
   }
 
   /// Create a MCObjectFileInfo implementation for the specified target

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -673,7 +673,7 @@ MCSectionELF *ELFWriter::createRelocationSection(MCContext &Ctx,
 
   const StringRef SectionName = Sec.getName();
   const MCTargetOptions *TO = Ctx.getTargetOptions();
-  if (TO && TO->Crel) {
+  if (TO->Crel) {
     MCSectionELF *RelaSection =
         Ctx.createELFRelSection(".crel" + SectionName, ELF::SHT_CREL, Flags,
                                 /*EntrySize=*/1, Sec.getGroup(), &Sec);
@@ -724,8 +724,7 @@ void ELFWriter::writeSectionData(MCSection &Sec) {
   StringRef SectionName = Section.getName();
   auto &Ctx = Asm.getContext();
   const DebugCompressionType CompressionType =
-      Ctx.getTargetOptions() ? Ctx.getTargetOptions()->CompressDebugSections
-                             : DebugCompressionType::None;
+      Ctx.getTargetOptions()->CompressDebugSections;
   if (CompressionType == DebugCompressionType::None ||
       !SectionName.starts_with(".debug_")) {
     Asm.writeSectionData(W.OS, &Section);
@@ -1378,7 +1377,7 @@ bool ELFObjectWriter::usesRela(const MCTargetOptions *TO,
                                const MCSectionELF &Sec) const {
   return (hasRelocationAddend() &&
           Sec.getType() != ELF::SHT_LLVM_CALL_GRAPH_PROFILE) ||
-         (TO && TO->Crel);
+         TO->Crel;
 }
 
 bool ELFObjectWriter::isSymbolRefDifferenceFullyResolvedImpl(

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -100,8 +100,6 @@ public:
     Context.setUseNamesOnTempLabels(true);
 
     auto *TO = Context.getTargetOptions();
-    if (!TO)
-      return;
     IsVerboseAsm = TO->AsmVerbose;
     if (IsVerboseAsm)
       InstPrinter->setCommentStream(CommentStream);

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -76,10 +76,10 @@ MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo *mai,
          "MCAsmInfo and MCTargetOptions must be available");
   assert((!TargetOpts || TargetOpts == MAI->getTargetOptions()) &&
          "MCTargetOptions, if specified, must match MCAsmInfo");
-  SaveTempLabels = getTargetOptions() && getTargetOptions()->MCSaveTempLabels;
+  SaveTempLabels = getTargetOptions()->MCSaveTempLabels;
   if (SaveTempLabels)
     setUseNamesOnTempLabels(true);
-  SecureLogFile = getTargetOptions() ? getTargetOptions()->AsSecureLogFile : "";
+  SecureLogFile = getTargetOptions()->AsSecureLogFile;
 
   if (SrcMgr && SrcMgr->getNumBuffers())
     MainFileName = std::string(SrcMgr->getMemoryBuffer(SrcMgr->getMainFileID())
@@ -992,15 +992,11 @@ void MCContext::RemapDebugPaths() {
 //===----------------------------------------------------------------------===//
 
 EmitDwarfUnwindType MCContext::emitDwarfUnwindInfo() const {
-  if (!getTargetOptions())
-    return EmitDwarfUnwindType::Default;
   return getTargetOptions()->EmitDwarfUnwind;
 }
 
 bool MCContext::emitCompactUnwindNonCanonical() const {
-  if (getTargetOptions())
-    return getTargetOptions()->EmitCompactUnwindNonCanonical;
-  return false;
+  return getTargetOptions()->EmitCompactUnwindNonCanonical;
 }
 
 void MCContext::setGenDwarfRootFile(StringRef InputFileName, StringRef Buffer) {
@@ -1135,9 +1131,9 @@ void MCContext::reportError(SMLoc Loc, const Twine &Msg) {
 }
 
 void MCContext::reportWarning(SMLoc Loc, const Twine &Msg) {
-  if (getTargetOptions() && getTargetOptions()->MCNoWarn)
+  if (getTargetOptions()->MCNoWarn)
     return;
-  if (getTargetOptions() && getTargetOptions()->MCFatalWarnings) {
+  if (getTargetOptions()->MCFatalWarnings) {
     reportError(Loc, Msg);
   } else {
     reportCommon(Loc, [&](SMDiagnostic &D, const SourceMgr *SMP) {

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -71,11 +71,15 @@ MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo *mai,
       MAI(mai), MRI(mri), MSTI(msti), Symbols(Allocator),
       InlineAsmUsedLabelNames(Allocator),
       CurrentDwarfLoc(0, 0, 0, DWARF2_FLAG_IS_STMT, 0, 0),
-      AutoReset(DoAutoReset), TargetOptions(TargetOpts) {
-  SaveTempLabels = TargetOptions && TargetOptions->MCSaveTempLabels;
+      AutoReset(DoAutoReset) {
+  assert(MAI && MAI->getTargetOptions() &&
+         "MCAsmInfo and MCTargetOptions must be available");
+  assert((!TargetOpts || TargetOpts == MAI->getTargetOptions()) &&
+         "MCTargetOptions, if specified, must match MCAsmInfo");
+  SaveTempLabels = getTargetOptions() && getTargetOptions()->MCSaveTempLabels;
   if (SaveTempLabels)
     setUseNamesOnTempLabels(true);
-  SecureLogFile = TargetOptions ? TargetOptions->AsSecureLogFile : "";
+  SecureLogFile = getTargetOptions() ? getTargetOptions()->AsSecureLogFile : "";
 
   if (SrcMgr && SrcMgr->getNumBuffers())
     MainFileName = std::string(SrcMgr->getMemoryBuffer(SrcMgr->getMainFileID())
@@ -115,6 +119,10 @@ MCContext::MCContext(const Triple &TheTriple, const MCAsmInfo *mai,
     report_fatal_error("Cannot initialize MC for unknown object file format.");
     break;
   }
+}
+
+const MCTargetOptions *MCContext::getTargetOptions() const {
+  return MAI->getTargetOptions();
 }
 
 MCContext::~MCContext() {
@@ -984,14 +992,14 @@ void MCContext::RemapDebugPaths() {
 //===----------------------------------------------------------------------===//
 
 EmitDwarfUnwindType MCContext::emitDwarfUnwindInfo() const {
-  if (!TargetOptions)
+  if (!getTargetOptions())
     return EmitDwarfUnwindType::Default;
-  return TargetOptions->EmitDwarfUnwind;
+  return getTargetOptions()->EmitDwarfUnwind;
 }
 
 bool MCContext::emitCompactUnwindNonCanonical() const {
-  if (TargetOptions)
-    return TargetOptions->EmitCompactUnwindNonCanonical;
+  if (getTargetOptions())
+    return getTargetOptions()->EmitCompactUnwindNonCanonical;
   return false;
 }
 
@@ -1127,9 +1135,9 @@ void MCContext::reportError(SMLoc Loc, const Twine &Msg) {
 }
 
 void MCContext::reportWarning(SMLoc Loc, const Twine &Msg) {
-  if (TargetOptions && TargetOptions->MCNoWarn)
+  if (getTargetOptions() && getTargetOptions()->MCNoWarn)
     return;
-  if (TargetOptions && TargetOptions->MCFatalWarnings) {
+  if (getTargetOptions() && getTargetOptions()->MCFatalWarnings) {
     reportError(Loc, Msg);
   } else {
     reportCommon(Loc, [&](SMDiagnostic &D, const SourceMgr *SMP) {

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -35,7 +35,7 @@ MCObjectStreamer::MCObjectStreamer(MCContext &Context,
   assert(Assembler->getBackendPtr() && Assembler->getEmitterPtr());
   IsObj = true;
   setAllowAutoPadding(Assembler->getBackend().allowAutoPadding());
-  if (Context.getTargetOptions() && Context.getTargetOptions()->MCRelaxAll)
+  if (Context.getTargetOptions()->MCRelaxAll)
     Assembler->setRelaxAll(true);
 }
 
@@ -170,8 +170,7 @@ void MCObjectStreamer::emitAbsoluteSymbolDiffAsULEB128(const MCSymbol *Hi,
 void MCObjectStreamer::reset() {
   if (Assembler) {
     Assembler->reset();
-    if (getContext().getTargetOptions())
-      Assembler->setRelaxAll(getContext().getTargetOptions()->MCRelaxAll);
+    Assembler->setRelaxAll(getContext().getTargetOptions()->MCRelaxAll);
   }
   EmitEHFrame = true;
   EmitDebugFrame = false;
@@ -197,8 +196,7 @@ void MCObjectStreamer::emitFrames() {
   if (EmitDebugFrame)
     MCDwarfFrameEmitter::emit(*this, false);
 
-  if (EmitSFrame || (getContext().getTargetOptions() &&
-                     getContext().getTargetOptions()->EmitSFrameUnwind))
+  if (EmitSFrame || getContext().getTargetOptions()->EmitSFrameUnwind)
     MCSFrameEmitter::emit(*this);
 }
 


### PR DESCRIPTION
Except MC-internal `MCAsmInfo()` uses, MCAsmInfo is always constructed
with `const MCTargetOptions &` via `TargetRegistry::createMCAsmInfo`
(https://reviews.llvm.org/D41349). Store the pointer in MCAsmInfo and
change `MCContext::getTargetOptions()` to retrieve it from there,
removing the `MCTargetOptions const *TargetOptions` member from
MCContext.

MCContext's constructor still accepts an MCTargetOptions parameter
for now. An assert verifies it matches MCAsmInfo's copy when provided.
A subsequent change will remove this parameter and update all callers.

In addition, assert that MCTargetOptions is non-null in the MCAssembler
constructor and remove the now-unnecessary null checks in
ELFObjectWriter.
