### PR TITLE
[RISCV] Combine ADDD+WMULSU to WMACCSU

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1510,6 +1510,7 @@ def riscv_wmacc  : RVSDNode<"WMACC", SDT_RISCVWideningMAccW,
                             [SDNPCommutative]>;
 def riscv_wmaccu : RVSDNode<"WMACCU", SDT_RISCVWideningMAccW,
                             [SDNPCommutative]>;
+def riscv_wmaccsu : RVSDNode<"WMACCSU", SDT_RISCVWideningMAccW>;
 
 // MULH/MULHU/MULHSU with rounding.
 def riscv_mulhr : RVSDNode<"MULHR", SDTIntBinOp>;

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -681,8 +681,9 @@ define i64 @wmacc_commute(i32 %a, i32 %b, i64 %c) nounwind {
 define i64 @wmaccsu(i32 %a, i32 %b, i64 %c) nounwind {
 ; CHECK-LABEL: wmaccsu:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    wmulsu a0, a0, a1
-; CHECK-NEXT:    addd a0, a2, a0
+; CHECK-NEXT:    wmaccsu a2, a0, a1
+; CHECK-NEXT:    mv a0, a2
+; CHECK-NEXT:    mv a1, a3
 ; CHECK-NEXT:    ret
   %aext = sext i32 %a to i64
   %bext = zext i32 %b to i64
@@ -694,8 +695,9 @@ define i64 @wmaccsu(i32 %a, i32 %b, i64 %c) nounwind {
 define i64 @wmaccsu_commute(i32 %a, i32 %b, i64 %c) nounwind {
 ; CHECK-LABEL: wmaccsu_commute:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    wmulsu a0, a0, a1
-; CHECK-NEXT:    addd a0, a0, a2
+; CHECK-NEXT:    wmaccsu a2, a0, a1
+; CHECK-NEXT:    mv a0, a2
+; CHECK-NEXT:    mv a1, a3
 ; CHECK-NEXT:    ret
   %aext = sext i32 %a to i64
   %bext = zext i32 %b to i64

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -678,6 +678,32 @@ define i64 @wmacc_commute(i32 %a, i32 %b, i64 %c) nounwind {
   ret i64 %result
 }
 
+define i64 @wmaccsu(i32 %a, i32 %b, i64 %c) nounwind {
+; CHECK-LABEL: wmaccsu:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    wmulsu a0, a0, a1
+; CHECK-NEXT:    addd a0, a2, a0
+; CHECK-NEXT:    ret
+  %aext = sext i32 %a to i64
+  %bext = zext i32 %b to i64
+  %mul = mul i64 %aext, %bext
+  %result = add i64 %c, %mul
+  ret i64 %result
+}
+
+define i64 @wmaccsu_commute(i32 %a, i32 %b, i64 %c) nounwind {
+; CHECK-LABEL: wmaccsu_commute:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    wmulsu a0, a0, a1
+; CHECK-NEXT:    addd a0, a0, a2
+; CHECK-NEXT:    ret
+  %aext = sext i32 %a to i64
+  %bext = zext i32 %b to i64
+  %mul = mul i64 %aext, %bext
+  %result = add i64 %mul, %c
+  ret i64 %result
+}
+
 ; Negative test: multiply result has multiple uses, should not combine
 define void @wmaccu_multiple_uses(i32 %a, i32 %b, i64 %c, ptr %out1, ptr %out2) nounwind {
 ; CHECK-LABEL: wmaccu_multiple_uses:


### PR DESCRIPTION
Extend the existing combineADDDToWMACC DAG combine to also match
RISCVISD::WMULSU and produce RISCVISD::WMACCSU. This is similar to
how ADDD+UMUL_LOHI is combined to WMACCU and ADDD+SMUL_LOHI is
combined to WMACC.

This reduces wmulsu+addd to a single wmaccsu instruction.

This patch was generated by AI, but I reviewed it.