### PR TITLE
[NFC] Ensure MCTargetOptions outlives MCAsmInfo at createMCAsmInfo call sites

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -39,6 +39,7 @@
 #include "llvm/MC/MCSectionMachO.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSymbol.h"
+#include "llvm/MC/MCTargetOptions.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/RWMutex.h"
@@ -680,6 +681,8 @@ public:
   std::unique_ptr<MCCodeEmitter> MCE;
 
   std::unique_ptr<MCObjectFileInfo> MOFI;
+
+  MCTargetOptions MCOptions;
 
   std::unique_ptr<const MCAsmInfo> AsmInfo;
 

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -225,8 +225,9 @@ Expected<std::unique_ptr<BinaryContext>> BinaryContext::createBinaryContext(
         Twine("BOLT-ERROR: no register info for target ", TripleName));
 
   // Set up disassembler.
+  MCTargetOptions MCOptions;
   std::unique_ptr<MCAsmInfo> AsmInfo(
-      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCTargetOptions()));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!AsmInfo)
     return createStringError(
         make_error_code(std::errc::not_supported),

--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -77,6 +77,7 @@ private:
   MCDisasmInstance(std::unique_ptr<llvm::MCInstrInfo> &&instr_info_up,
                    std::unique_ptr<llvm::MCRegisterInfo> &&reg_info_up,
                    std::unique_ptr<llvm::MCSubtargetInfo> &&subtarget_info_up,
+                   llvm::MCTargetOptions mc_options,
                    std::unique_ptr<llvm::MCAsmInfo> &&asm_info_up,
                    std::unique_ptr<llvm::MCContext> &&context_up,
                    std::unique_ptr<llvm::MCDisassembler> &&disasm_up,
@@ -86,6 +87,7 @@ private:
   std::unique_ptr<llvm::MCInstrInfo> m_instr_info_up;
   std::unique_ptr<llvm::MCRegisterInfo> m_reg_info_up;
   std::unique_ptr<llvm::MCSubtargetInfo> m_subtarget_info_up;
+  llvm::MCTargetOptions m_mc_options;
   std::unique_ptr<llvm::MCAsmInfo> m_asm_info_up;
   std::unique_ptr<llvm::MCContext> m_context_up;
   std::unique_ptr<llvm::MCDisassembler> m_disasm_up;
@@ -1333,7 +1335,7 @@ DisassemblerLLVMC::MCDisasmInstance::Create(const char *triple_name,
 
   return Instance(new MCDisasmInstance(
       std::move(instr_info_up), std::move(reg_info_up),
-      std::move(subtarget_info_up), std::move(asm_info_up),
+      std::move(subtarget_info_up), MCOptions, std::move(asm_info_up),
       std::move(context_up), std::move(disasm_up), std::move(instr_printer_up),
       std::move(instr_analysis_up)));
 }
@@ -1342,6 +1344,7 @@ DisassemblerLLVMC::MCDisasmInstance::MCDisasmInstance(
     std::unique_ptr<llvm::MCInstrInfo> &&instr_info_up,
     std::unique_ptr<llvm::MCRegisterInfo> &&reg_info_up,
     std::unique_ptr<llvm::MCSubtargetInfo> &&subtarget_info_up,
+    llvm::MCTargetOptions mc_options,
     std::unique_ptr<llvm::MCAsmInfo> &&asm_info_up,
     std::unique_ptr<llvm::MCContext> &&context_up,
     std::unique_ptr<llvm::MCDisassembler> &&disasm_up,
@@ -1350,7 +1353,7 @@ DisassemblerLLVMC::MCDisasmInstance::MCDisasmInstance(
     : m_instr_info_up(std::move(instr_info_up)),
       m_reg_info_up(std::move(reg_info_up)),
       m_subtarget_info_up(std::move(subtarget_info_up)),
-      m_asm_info_up(std::move(asm_info_up)),
+      m_mc_options(mc_options), m_asm_info_up(std::move(asm_info_up)),
       m_context_up(std::move(context_up)), m_disasm_up(std::move(disasm_up)),
       m_instr_printer_up(std::move(instr_printer_up)),
       m_instr_analysis_up(std::move(instr_analysis_up)) {

--- a/lldb/source/Plugins/Instruction/MIPS/EmulateInstructionMIPS.cpp
+++ b/lldb/source/Plugins/Instruction/MIPS/EmulateInstructionMIPS.cpp
@@ -153,8 +153,7 @@ EmulateInstructionMIPS::EmulateInstructionMIPS(
   m_insn_info.reset(target->createMCInstrInfo());
   assert(m_insn_info.get());
 
-  llvm::MCTargetOptions MCOptions;
-  m_asm_info.reset(target->createMCAsmInfo(*m_reg_info, triple, MCOptions));
+  m_asm_info.reset(target->createMCAsmInfo(*m_reg_info, triple, m_mc_options));
   m_subtype_info.reset(target->createMCSubtargetInfo(triple, cpu, features));
   assert(m_asm_info.get() && m_subtype_info.get());
 

--- a/lldb/source/Plugins/Instruction/MIPS/EmulateInstructionMIPS.h
+++ b/lldb/source/Plugins/Instruction/MIPS/EmulateInstructionMIPS.h
@@ -10,6 +10,8 @@
 #ifndef LLDB_SOURCE_PLUGINS_INSTRUCTION_MIPS_EMULATEINSTRUCTIONMIPS_H
 #define LLDB_SOURCE_PLUGINS_INSTRUCTION_MIPS_EMULATEINSTRUCTIONMIPS_H
 
+#include "llvm/MC/MCTargetOptions.h"
+
 namespace llvm {
 class MCDisassembler;
 class MCSubtargetInfo;
@@ -210,6 +212,7 @@ private:
   std::unique_ptr<llvm::MCSubtargetInfo> m_subtype_info;
   std::unique_ptr<llvm::MCSubtargetInfo> m_alt_subtype_info;
   std::unique_ptr<llvm::MCRegisterInfo> m_reg_info;
+  llvm::MCTargetOptions m_mc_options;
   std::unique_ptr<llvm::MCAsmInfo> m_asm_info;
   std::unique_ptr<llvm::MCContext> m_context;
   std::unique_ptr<llvm::MCInstrInfo> m_insn_info;

--- a/lldb/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.cpp
+++ b/lldb/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.cpp
@@ -157,8 +157,7 @@ EmulateInstructionMIPS64::EmulateInstructionMIPS64(
   m_insn_info.reset(target->createMCInstrInfo());
   assert(m_insn_info.get());
 
-  llvm::MCTargetOptions MCOptions;
-  m_asm_info.reset(target->createMCAsmInfo(*m_reg_info, triple, MCOptions));
+  m_asm_info.reset(target->createMCAsmInfo(*m_reg_info, triple, m_mc_options));
   m_subtype_info.reset(target->createMCSubtargetInfo(triple, cpu, features));
   assert(m_asm_info.get() && m_subtype_info.get());
 

--- a/lldb/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.h
+++ b/lldb/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.h
@@ -12,6 +12,7 @@
 #include "lldb/Core/EmulateInstruction.h"
 #include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Status.h"
+#include "llvm/MC/MCTargetOptions.h"
 #include <optional>
 
 namespace llvm {
@@ -173,6 +174,7 @@ private:
   std::unique_ptr<llvm::MCDisassembler> m_disasm;
   std::unique_ptr<llvm::MCSubtargetInfo> m_subtype_info;
   std::unique_ptr<llvm::MCRegisterInfo> m_reg_info;
+  llvm::MCTargetOptions m_mc_options;
   std::unique_ptr<llvm::MCAsmInfo> m_asm_info;
   std::unique_ptr<llvm::MCContext> m_context;
   std::unique_ptr<llvm::MCInstrInfo> m_insn_info;

--- a/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVBinaryReader.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVBinaryReader.h
@@ -23,6 +23,7 @@
 #include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/MCTargetOptions.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/COFF.h"
 #include "llvm/Object/ObjectFile.h"
@@ -109,6 +110,7 @@ protected:
   LVLines CULines;
 
   std::unique_ptr<const MCRegisterInfo> MRI;
+  MCTargetOptions MCOptions;
   std::unique_ptr<const MCAsmInfo> MAI;
   std::unique_ptr<const MCSubtargetInfo> STI;
   std::unique_ptr<const MCInstrInfo> MII;

--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVBinaryReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVBinaryReader.cpp
@@ -292,7 +292,6 @@ Error LVBinaryReader::loadGenericTargetInfo(StringRef TripleName,
   MRI.reset(RegisterInfo);
 
   // Assembler properties and features.
-  MCTargetOptions MCOptions;
   MCAsmInfo *AsmInfo(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!AsmInfo)
     return createStringError(errc::invalid_argument,

--- a/llvm/tools/llvm-exegesis/lib/DisassemblerHelper.cpp
+++ b/llvm/tools/llvm-exegesis/lib/DisassemblerHelper.cpp
@@ -14,11 +14,10 @@ namespace llvm {
 namespace exegesis {
 
 DisassemblerHelper::DisassemblerHelper(const LLVMState &State) : State_(State) {
-  MCTargetOptions MCOptions;
   const auto &TM = State.getTargetMachine();
   const auto &Triple = TM.getTargetTriple();
   AsmInfo_.reset(
-      TM.getTarget().createMCAsmInfo(State_.getRegInfo(), Triple, MCOptions));
+      TM.getTarget().createMCAsmInfo(State_.getRegInfo(), Triple, MCOptions_));
   InstPrinter_.reset(TM.getTarget().createMCInstPrinter(
       Triple, 0 /*default variant*/, *AsmInfo_, State_.getInstrInfo(),
       State_.getRegInfo()));

--- a/llvm/tools/llvm-exegesis/lib/DisassemblerHelper.h
+++ b/llvm/tools/llvm-exegesis/lib/DisassemblerHelper.h
@@ -20,6 +20,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDisassembler/MCDisassembler.h"
 #include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCTargetOptions.h"
 
 #include <memory>
 
@@ -42,6 +43,7 @@ public:
 
 private:
   const LLVMState &State_;
+  MCTargetOptions MCOptions_;
   std::unique_ptr<MCContext> Context_;
   std::unique_ptr<MCAsmInfo> AsmInfo_;
   std::unique_ptr<MCInstPrinter> InstPrinter_;

--- a/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCopyBytesTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCopyBytesTest.cpp
@@ -49,6 +49,7 @@ public:
   Triple TheTriple;
 
   std::unique_ptr<MCRegisterInfo> MRI;
+  MCTargetOptions MCOptions;
   std::unique_ptr<MCAsmInfo> MAI;
   std::unique_ptr<const MCSubtargetInfo> STI;
   const Target *TheTarget;
@@ -64,7 +65,7 @@ public:
       return;
 
     MRI.reset(TheTarget->createMCRegInfo(TheTriple));
-    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCTargetOptions()));
+    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
     STI.reset(TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
   }
 

--- a/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.cpp
@@ -460,7 +460,7 @@ llvm::Error dwarfgen::Generator::init(Triple TheTriple, uint16_t V) {
                                        TripleName,
                                    inconvertibleErrorCode());
 
-  MCTargetOptions MCOptions = mc::InitMCTargetOptionsFromFlags();
+  MCOptions = mc::InitMCTargetOptionsFromFlags();
   MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!MAI)
     return make_error<StringError>("no asm info for target " + TripleName,

--- a/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.h
+++ b/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.h
@@ -17,6 +17,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/DIE.h"
 #include "llvm/DebugInfo/DWARF/DWARFDebugLine.h"
+#include "llvm/MC/MCTargetOptions.h"
 #include "llvm/Support/Error.h"
 
 #include <memory>
@@ -245,6 +246,7 @@ private:
 /// the returned compile unit and adding attributes and children to each DIE.
 class Generator {
   std::unique_ptr<MCRegisterInfo> MRI;
+  MCTargetOptions MCOptions;
   std::unique_ptr<MCAsmInfo> MAI;
   std::unique_ptr<MCContext> MC;
   MCAsmBackend *MAB; // Owned by MCStreamer

--- a/llvm/unittests/MC/AMDGPU/Disassembler.cpp
+++ b/llvm/unittests/MC/AMDGPU/Disassembler.cpp
@@ -79,8 +79,9 @@ TEST(AMDGPUDisassembler, MultiDisassembler) {
     GTEST_SKIP();
 
   std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TT));
+  MCTargetOptions MCOptions;
   std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TT, MCTargetOptions()));
+      TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
   std::unique_ptr<const MCInstrInfo> MII(TheTarget->createMCInstrInfo());
   std::unique_ptr<MCSubtargetInfo> STI(
       TheTarget->createMCSubtargetInfo(TT, CPUName, ""));
@@ -150,8 +151,9 @@ TEST(AMDGPUDisassembler, UCVersionOverride) {
     GTEST_SKIP();
 
   std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TT));
+  MCTargetOptions MCOptions;
   std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TT, MCTargetOptions()));
+      TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
   std::unique_ptr<const MCInstrInfo> MII(TheTarget->createMCInstrInfo());
   std::unique_ptr<MCSubtargetInfo> STI(
       TheTarget->createMCSubtargetInfo(TT, CPUName, ""));

--- a/llvm/unittests/MC/SystemZ/SystemZMCDisassemblerTest.cpp
+++ b/llvm/unittests/MC/SystemZ/SystemZMCDisassemblerTest.cpp
@@ -26,6 +26,7 @@ struct Context {
   static constexpr char TripleName[] = "systemz-unknown";
   Triple TT;
   std::unique_ptr<MCRegisterInfo> MRI;
+  MCTargetOptions MCOptions;
   std::unique_ptr<MCAsmInfo> MAI;
   std::unique_ptr<MCContext> Ctx;
   std::unique_ptr<MCSubtargetInfo> STI;
@@ -43,7 +44,7 @@ struct Context {
       return;
 
     MRI.reset(TheTarget->createMCRegInfo(TT));
-    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TT, MCTargetOptions()));
+    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
     STI.reset(TheTarget->createMCSubtargetInfo(TT, "", ""));
     Ctx = std::make_unique<MCContext>(TT, MAI.get(), MRI.get(), STI.get());
 

--- a/llvm/unittests/MC/X86/X86MCDisassemblerTest.cpp
+++ b/llvm/unittests/MC/X86/X86MCDisassemblerTest.cpp
@@ -26,6 +26,7 @@ struct Context {
   static constexpr char TripleName[] = "x86_64-unknown-elf";
   const Triple TheTriple;
   std::unique_ptr<MCRegisterInfo> MRI;
+  MCTargetOptions MCOptions;
   std::unique_ptr<MCAsmInfo> MAI;
   std::unique_ptr<MCContext> Ctx;
   std::unique_ptr<MCSubtargetInfo> STI;
@@ -43,7 +44,7 @@ struct Context {
       return;
 
     MRI.reset(TheTarget->createMCRegInfo(TheTriple));
-    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCTargetOptions()));
+    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
     STI.reset(TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
     Ctx =
         std::make_unique<MCContext>(TheTriple, MAI.get(), MRI.get(), STI.get());


### PR DESCRIPTION
Preparatory change for storing the MCTargetOptions pointer in MCAsmInfo
(#180464)
