### PR TITLE
[X86] Fix lower1BitShuffle blend-with-zero shuffles to AND mask

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -18364,8 +18364,8 @@ static SDValue lower1BitShuffle(const SDLoc &DL, ArrayRef<int> Mask,
     const unsigned Width = std::max<unsigned>(NumElts, 8u);
     MVT IntVT = MVT::getIntegerVT(Width);
 
-    APInt MaskVlaue = (~Zeroable).zextOrTrunc(Width);
-    SDValue MaskNode = DAG.getConstant(MaskVlaue, DL, IntVT);
+    APInt MaskValue = (~Zeroable).zextOrTrunc(Width);
+    SDValue MaskNode = DAG.getConstant(MaskValue, DL, IntVT);
 
     MVT MaskVecVT = MVT::getVectorVT(MVT::i1, Width);
     SDValue MaskVecNode = DAG.getBitcast(MaskVecVT, MaskNode);

--- a/llvm/test/CodeGen/X86/avx512bwvl-arith.ll
+++ b/llvm/test/CodeGen/X86/avx512bwvl-arith.ll
@@ -251,9 +251,9 @@ define i16 @PR90356(<16 x i1> %a) {
   ret i16 %2
 }
 
-define <4 x i1> @ISSUE180426(<4 x i1> %0) {
-; CHECK-LABEL: ISSUE180426:
-; CHECK:       # %bb.0: # %entry
+define <4 x i1> @PR180472(<4 x i1> %0) {
+; CHECK-LABEL: PR180472:
+; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vpslld $31, %xmm0, %xmm0
 ; CHECK-NEXT:    movb $5, %al
 ; CHECK-NEXT:    kmovd %eax, %k1
@@ -261,7 +261,6 @@ define <4 x i1> @ISSUE180426(<4 x i1> %0) {
 ; CHECK-NEXT:    vpcmpeqd %xmm0, %xmm0, %xmm0
 ; CHECK-NEXT:    vmovdqa32 %xmm0, %xmm0 {%k1} {z}
 ; CHECK-NEXT:    retq
-entry:
-  %1 = shufflevector <4 x i1> %0, <4 x i1> zeroinitializer, <4 x i32> <i32 0, i32 5, i32 2, i32 7>
-  ret <4 x i1> %1
+  %x = shufflevector <4 x i1> %0, <4 x i1> zeroinitializer, <4 x i32> <i32 0, i32 5, i32 2, i32 7>
+  ret <4 x i1> %x
 }

--- a/llvm/test/CodeGen/X86/avx512bwvl-arith.ll
+++ b/llvm/test/CodeGen/X86/avx512bwvl-arith.ll
@@ -250,3 +250,18 @@ define i16 @PR90356(<16 x i1> %a) {
   %2 = bitcast <16 x i1> %1 to i16
   ret i16 %2
 }
+
+define <4 x i1> @ISSUE180426(<4 x i1> %0) {
+; CHECK-LABEL: ISSUE180426:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    vpslld $31, %xmm0, %xmm0
+; CHECK-NEXT:    movb $5, %al
+; CHECK-NEXT:    kmovd %eax, %k1
+; CHECK-NEXT:    vptestmd %xmm0, %xmm0, %k1 {%k1}
+; CHECK-NEXT:    vpcmpeqd %xmm0, %xmm0, %xmm0
+; CHECK-NEXT:    vmovdqa32 %xmm0, %xmm0 {%k1} {z}
+; CHECK-NEXT:    retq
+entry:
+  %1 = shufflevector <4 x i1> %0, <4 x i1> zeroinitializer, <4 x i32> <i32 0, i32 5, i32 2, i32 7>
+  ret <4 x i1> %1
+}


### PR DESCRIPTION
### Summary
This PR resolves https://github.com/llvm/llvm-project/issues/180426.