### PR TITLE
[lld] Add explicit std::move(...) to avoid a few vector copies

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -1339,7 +1339,7 @@ void LinkerDriver::parsePDBAltPath() {
     cursor = secondMark + 1;
   }
 
-  ctx.config.pdbAltPath = buf;
+  ctx.config.pdbAltPath = std::move(buf);
 }
 
 /// Convert resource files and potentially merge input resource object

--- a/lld/wasm/OutputSections.cpp
+++ b/lld/wasm/OutputSections.cpp
@@ -232,7 +232,7 @@ void CustomSection::finalizeInputSections() {
     return;
 
   mergedSection->finalizeContents();
-  inputSections = newSections;
+  inputSections = std::move(newSections);
 }
 
 void CustomSection::finalizeContents() {

--- a/lld/wasm/Writer.cpp
+++ b/lld/wasm/Writer.cpp
@@ -1109,7 +1109,7 @@ void Writer::combineOutputSegments() {
     }
   }
 
-  segments = newSegments;
+  segments = std::move(newSegments);
 }
 
 static void createFunction(DefinedFunction *func, StringRef bodyContent) {


### PR DESCRIPTION
In corner cases, it is profitable to move an llvm::SmallString instead of copying it.

It is almost always profitable to move an std::vector

Changes suggested by performance-use-std-move from https://github.com/llvm/llvm-project/pull/179467