### PR TITLE
[clangd] Add explicit std::move(...) to avoid a few copies

### DIFF
--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -1833,7 +1833,7 @@ void ClangdLSPServer::onDiagnosticsReady(PathRef File, llvm::StringRef Version,
   // Cache DiagRefMap
   {
     std::lock_guard<std::mutex> Lock(DiagRefMutex);
-    DiagRefMap[File] = LocalDiagMap;
+    DiagRefMap[File] = std::move(LocalDiagMap);
   }
 
   // Send a notification to the LSP client.


### PR DESCRIPTION
Moving an std::map is almost always profitable (DiagnosticToDiagRefMap).

Changes suggested by performance-use-std-move from #179467