### PR TITLE
[clang] Add explicit std::move(...) to avoid a few copies

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1875,7 +1875,7 @@ struct DarwinPlatform {
         auto TargetVariantVersion = TargetVariantTriple->getOSVersion();
         if (TargetVariantVersion.getMajor()) {
           if (TargetVariantVersion < ZipperedOSVersion)
-            ZipperedOSVersion = TargetVariantVersion;
+            ZipperedOSVersion = std::move(TargetVariantVersion);
         }
       }
       break;

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -1090,7 +1090,7 @@ static bool findMipsMuslMultilibs(const Driver &D,
     });
   }
   if (MuslMipsMultilibs.select(D, Flags, Result.SelectedMultilibs)) {
-    Result.Multilibs = MuslMipsMultilibs;
+    Result.Multilibs = std::move(MuslMipsMultilibs);
     return true;
   }
   return false;
@@ -1501,7 +1501,7 @@ static void findAndroidArmMultilibs(const Driver &D,
   addMultilibFlag(IsThumbMode, "-mthumb", Flags);
 
   if (AndroidArmMultilibs.select(D, Flags, Result.SelectedMultilibs))
-    Result.Multilibs = AndroidArmMultilibs;
+    Result.Multilibs = std::move(AndroidArmMultilibs);
 }
 
 static bool findMSP430Multilibs(const Driver &D,
@@ -1594,7 +1594,7 @@ static void findCSKYMultilibs(const Driver &D, const llvm::Triple &TargetTriple,
           .FilterOut(NonExistent);
 
   if (CSKYMultilibs.select(D, Flags, Result.SelectedMultilibs))
-    Result.Multilibs = CSKYMultilibs;
+    Result.Multilibs = std::move(CSKYMultilibs);
 }
 
 /// Extend the multi-lib re-use selection mechanism for RISC-V.
@@ -1771,7 +1771,7 @@ static void findRISCVBareMetalMultilibs(const Driver &D,
 
   if (selectRISCVMultilib(D, RISCVMultilibs, MArch, Flags,
                           Result.SelectedMultilibs))
-    Result.Multilibs = RISCVMultilibs;
+    Result.Multilibs = std::move(RISCVMultilibs);
 }
 
 static void findRISCVMultilibs(const Driver &D,
@@ -1813,7 +1813,7 @@ static void findRISCVMultilibs(const Driver &D,
   addMultilibFlag(ABIName == "lp64d", "-mabi=lp64d", Flags);
 
   if (RISCVMultilibs.select(D, Flags, Result.SelectedMultilibs))
-    Result.Multilibs = RISCVMultilibs;
+    Result.Multilibs = std::move(RISCVMultilibs);
 }
 
 static bool findBiarchMultilibs(const Driver &D,

--- a/clang/lib/Driver/ToolChains/OHOS.cpp
+++ b/clang/lib/Driver/ToolChains/OHOS.cpp
@@ -50,7 +50,7 @@ static bool findOHOSMuslMultilibs(const Driver &D,
                {"-mcpu=cortex-a7", "-mfloat-abi=hard", "-mfpu=neon-vfpv4"}));
 
   if (Multilibs.select(D, Flags, Result.SelectedMultilibs)) {
-    Result.Multilibs = Multilibs;
+    Result.Multilibs = std::move(Multilibs);
     return true;
   }
   return false;


### PR DESCRIPTION
Moving a clang::MultilibSet is almost always profitable.

Changes suggested by performance-use-std-move from #179467