### PR TITLE
[clang] Add explicit std::move(...) to avoid a few copies

### DIFF
--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -1477,7 +1477,7 @@ ASTUnit::create(std::shared_ptr<CompilerInvocation> CI,
   IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
       createVFSFromCompilerInvocation(*CI, *Diags);
   AST->DiagOpts = std::move(DiagOpts);
-  AST->Diagnostics = Diags;
+  AST->Diagnostics = std::move(Diags);
   AST->FileSystemOpts = CI->getFileSystemOpts();
   AST->Invocation = std::move(CI);
   AST->FileMgr =

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -1476,7 +1476,7 @@ ASTUnit::create(std::shared_ptr<CompilerInvocation> CI,
   ConfigureDiags(Diags, *AST, CaptureDiagnostics);
   IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
       createVFSFromCompilerInvocation(*CI, *Diags);
-  AST->DiagOpts = DiagOpts;
+  AST->DiagOpts = std::move(DiagOpts);
   AST->Diagnostics = Diags;
   AST->FileSystemOpts = CI->getFileSystemOpts();
   AST->Invocation = std::move(CI);

--- a/clang/lib/Frontend/LayoutOverrideSource.cpp
+++ b/clang/lib/Frontend/LayoutOverrideSource.cpp
@@ -186,7 +186,7 @@ LayoutOverrideSource::LayoutOverrideSource(StringRef Filename) {
 
   // Flush the last type/layout, if there is one.
   if (!CurrentType.empty())
-    Layouts[CurrentType] = CurrentLayout;
+    Layouts[CurrentType] = std::move(CurrentLayout);
 }
 
 bool


### PR DESCRIPTION
Moving an std::shared_ptr is always profitable (marginally).

Moving a clang::LayoutOverrideSource::Layout may be profitable depending on the size of the underlying llvm::SmallVector.

Changes suggested by performance-use-std-move from #179467