### PR TITLE
[llvm/CAS] Insert llvm_unreachable to resolve missing return warning

### DIFF
--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -1422,11 +1422,14 @@ OnDiskGraphDB::FileBackedData
 StandaloneDataInMemory::getInternalFileBackedObjectData(
     StringRef RootPath) const {
   switch (SK) {
+  case TrieRecord::StorageKind::Unknown:
+  case TrieRecord::StorageKind::DataPool:
+    llvm_unreachable("unexpected storage kind");
   case TrieRecord::StorageKind::Standalone:
     return OnDiskGraphDB::FileBackedData{getContent().getData(),
                                          /*FileInfo=*/std::nullopt};
   case TrieRecord::StorageKind::StandaloneLeaf0:
-  case TrieRecord::StorageKind::StandaloneLeaf: {
+  case TrieRecord::StorageKind::StandaloneLeaf:
     bool IsFileNulTerminated = SK == TrieRecord::StorageKind::StandaloneLeaf0;
     SmallString<256> Path;
     ::getStandalonePath(RootPath, TrieRecord::getStandaloneFilePrefix(SK),
@@ -1435,11 +1438,7 @@ StandaloneDataInMemory::getInternalFileBackedObjectData(
         getContent().getData(), OnDiskGraphDB::FileBackedData::FileInfoTy{
                                     std::string(Path), IsFileNulTerminated}};
   }
-  case TrieRecord::StorageKind::Unknown:
-  case TrieRecord::StorageKind::DataPool:
-  default:
-    llvm_unreachable("unexpected storage kind");
-  }
+  llvm_unreachable("unexpected storage kind");
 }
 
 static Expected<MappedTempFile>

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -1422,14 +1422,11 @@ OnDiskGraphDB::FileBackedData
 StandaloneDataInMemory::getInternalFileBackedObjectData(
     StringRef RootPath) const {
   switch (SK) {
-  case TrieRecord::StorageKind::Unknown:
-  case TrieRecord::StorageKind::DataPool:
-    llvm_unreachable("unexpected storage kind");
   case TrieRecord::StorageKind::Standalone:
     return OnDiskGraphDB::FileBackedData{getContent().getData(),
                                          /*FileInfo=*/std::nullopt};
   case TrieRecord::StorageKind::StandaloneLeaf0:
-  case TrieRecord::StorageKind::StandaloneLeaf:
+  case TrieRecord::StorageKind::StandaloneLeaf: {
     bool IsFileNulTerminated = SK == TrieRecord::StorageKind::StandaloneLeaf0;
     SmallString<256> Path;
     ::getStandalonePath(RootPath, TrieRecord::getStandaloneFilePrefix(SK),
@@ -1437,6 +1434,11 @@ StandaloneDataInMemory::getInternalFileBackedObjectData(
     return OnDiskGraphDB::FileBackedData{
         getContent().getData(), OnDiskGraphDB::FileBackedData::FileInfoTy{
                                     std::string(Path), IsFileNulTerminated}};
+  }
+  case TrieRecord::StorageKind::Unknown:
+  case TrieRecord::StorageKind::DataPool:
+  default:
+    llvm_unreachable("unexpected storage kind");
   }
 }
 


### PR DESCRIPTION
 When I built code, it showed the warning below. I insert a llvm_unreachable in the end of function to fix "control reaches end of non-void function" warning.

```
$ ninja
/home/zjackhua/open-source/llvm-project/llvm/lib/CAS/OnDiskGraphDB.cpp: In member function ‘llvm::cas::ondisk::OnDiskGraphDB::FileBackedData {anonymous}::StandaloneDataInMemory::getInternalFileBackedObjectData(llvm::StringRef) const’:
/home/zjackhua/open-source/llvm-project/llvm/lib/CAS/OnDiskGraphDB.cpp:1441:1: warning: control reaches end of non-void function [-Wreturn-type]
1441 | }
     | ^
```

- System: `5.15.153.1-microsoft-standard-WSL2`
- Compiler: `g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0`
