### PR TITLE
[clang] Add explicit std::move(...) to avoid a few copies

### DIFF
--- a/clang/lib/Analysis/CloneDetection.cpp
+++ b/clang/lib/Analysis/CloneDetection.cpp
@@ -403,7 +403,7 @@ void RecursiveCloneTypeIIHashConstraint::constrain(
       Result.push_back(NewGroup);
     }
   }
-  // Sequences is the output parameter, so we copy our result into it.
+  // Sequences is the output parameter, so we move our result into it.
   Sequences = std::move(Result);
 }
 

--- a/clang/lib/Analysis/CloneDetection.cpp
+++ b/clang/lib/Analysis/CloneDetection.cpp
@@ -404,7 +404,7 @@ void RecursiveCloneTypeIIHashConstraint::constrain(
     }
   }
   // Sequences is the output parameter, so we copy our result into it.
-  Sequences = Result;
+  Sequences = std::move(Result);
 }
 
 void RecursiveCloneTypeIIVerifyConstraint::constrain(
@@ -519,7 +519,7 @@ void CloneConstraint::splitCloneGroups(
 
     assert(llvm::all_of(Indexes, [](char c) { return c == 1; }));
   }
-  CloneGroups = Result;
+  CloneGroups = std::move(Result);
 }
 
 void VariablePattern::addVariableOccurence(const VarDecl *VarDecl,

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1405,7 +1405,7 @@ TypeResult Parser::ParseBaseTypeSpecifier(SourceLocation &BaseLoc,
   DeclSpec DS(AttrFactory);
   DS.SetRangeStart(IdLoc);
   DS.SetRangeEnd(EndLocation);
-  DS.getTypeSpecScope() = SS;
+  DS.getTypeSpecScope() = std::move(SS);
 
   const char *PrevSpec = nullptr;
   unsigned DiagID;

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1413,7 +1413,8 @@ namespace {
     }
 
     void RememberSubstitution(MultiLevelTemplateArgumentList Old) {
-      const_cast<MultiLevelTemplateArgumentList &>(this->TemplateArgs) = Old;
+      const_cast<MultiLevelTemplateArgumentList &>(this->TemplateArgs) =
+          std::move(Old);
     }
 
     TemplateArgument

--- a/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
@@ -308,7 +308,7 @@ ProgramStateRef ProgramState::BindExpr(const Stmt *S,
     return this;
 
   ProgramState NewSt = *this;
-  NewSt.Env = NewEnv;
+  NewSt.Env = std::move(NewEnv);
   return getStateManager().getPersistentState(NewSt);
 }
 

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -220,7 +220,7 @@ std::optional<P1689Rule> DependencyScanningTool::getP1689ModuleDependencyFile(
       Rule.Provides = Provided;
       if (Rule.Provides)
         Rule.Provides->SourcePath = Filename.str();
-      Rule.Requires = Requires;
+      Rule.Requires = std::move(Requires);
     }
 
     StringRef getMakeFormatDependencyOutputPath() {


### PR DESCRIPTION
Moving an std::vector is almost always profitable.

A clang::CXXScopeSpec contains an owned
clang::NestedNameSpecifierLocBuilder which currently does not benefit from being moved, but may structurally in the future.

A clang::MultiLevelTemplateArgumentList contains an llvm::SmalVector which may benefit from being moved dependiong on its size.

A clang::Environment contains an llvm::ImmutableMap which itself contains an llvm::IntrusiveRefCntPtr that benefits from being moved.

Changes suggested by performance-use-std-move from #179467