### PR TITLE
[clang] [NFC] Improve move-assign and move-constructor for NestedNameSpecifierLocBuilder

### DIFF
--- a/clang/include/clang/AST/NestedNameSpecifierBase.h
+++ b/clang/include/clang/AST/NestedNameSpecifierBase.h
@@ -450,9 +450,13 @@ class NestedNameSpecifierLocBuilder {
 public:
   NestedNameSpecifierLocBuilder() = default;
   NestedNameSpecifierLocBuilder(const NestedNameSpecifierLocBuilder &Other);
+  NestedNameSpecifierLocBuilder(NestedNameSpecifierLocBuilder &&Other);
 
   NestedNameSpecifierLocBuilder &
   operator=(const NestedNameSpecifierLocBuilder &Other);
+
+  NestedNameSpecifierLocBuilder &
+  operator=(NestedNameSpecifierLocBuilder &&Other);
 
   ~NestedNameSpecifierLocBuilder() {
     if (BufferCapacity)

--- a/clang/lib/AST/NestedNameSpecifier.cpp
+++ b/clang/lib/AST/NestedNameSpecifier.cpp
@@ -212,8 +212,8 @@ NestedNameSpecifierLocBuilder::NestedNameSpecifierLocBuilder(
     NestedNameSpecifierLocBuilder &&Other)
     : Representation(std::move(Other.Representation)), Buffer(Other.Buffer),
       BufferSize(Other.BufferSize), BufferCapacity(Other.BufferCapacity) {
-  Other.buffer = nullptr;
-  Other.BufferCapacity = Other.size = 0;
+  Other.Buffer = nullptr;
+  Other.BufferCapacity = Other.BufferSize = 0;
 }
 
 NestedNameSpecifierLocBuilder &

--- a/clang/lib/AST/NestedNameSpecifier.cpp
+++ b/clang/lib/AST/NestedNameSpecifier.cpp
@@ -208,6 +208,14 @@ NestedNameSpecifierLocBuilder(const NestedNameSpecifierLocBuilder &Other)
          BufferCapacity);
 }
 
+NestedNameSpecifierLocBuilder::NestedNameSpecifierLocBuilder(
+    NestedNameSpecifierLocBuilder &&Other)
+    : Representation(std::move(Other.Representation)), Buffer(Other.Buffer),
+      BufferSize(Other.BufferSize), BufferCapacity(Other.BufferCapacity) {
+  Other.buffer = nullptr;
+  Other.BufferCapacity = Other.size = 0;
+}
+
 NestedNameSpecifierLocBuilder &
 NestedNameSpecifierLocBuilder::
 operator=(const NestedNameSpecifierLocBuilder &Other) {
@@ -244,6 +252,24 @@ operator=(const NestedNameSpecifierLocBuilder &Other) {
   BufferSize = 0;
   Append(Other.Buffer, Other.Buffer + Other.BufferSize, Buffer, BufferSize,
          BufferCapacity);
+  return *this;
+}
+
+NestedNameSpecifierLocBuilder &NestedNameSpecifierLocBuilder::operator=(
+    NestedNameSpecifierLocBuilder &&Other) {
+  Representation = std::move(Other.Representation);
+
+  // Free our storage, if we have any.
+  if (BufferCapacity) {
+    free(Buffer);
+  }
+  Buffer = Other.Buffer;
+  BufferSize = Other.BufferSize;
+  BufferCapacity = Other.BufferCapacity;
+
+  Other.Buffer = nullptr;
+  Other.BufferSize = Other.BufferCapacity = 0;
+
   return *this;
 }
 

--- a/clang/lib/AST/NestedNameSpecifier.cpp
+++ b/clang/lib/AST/NestedNameSpecifier.cpp
@@ -210,11 +210,10 @@ NestedNameSpecifierLocBuilder(const NestedNameSpecifierLocBuilder &Other)
 
 NestedNameSpecifierLocBuilder::NestedNameSpecifierLocBuilder(
     NestedNameSpecifierLocBuilder &&Other)
-    : Representation(std::move(Other.Representation)), Buffer(Other.Buffer),
-      BufferSize(Other.BufferSize), BufferCapacity(Other.BufferCapacity) {
-  Other.Buffer = nullptr;
-  Other.BufferCapacity = Other.BufferSize = 0;
-}
+    : Representation(std::move(Other.Representation)),
+      Buffer(std::exchange(Other.Buffer, nullptr)),
+      BufferSize(std::exchange(Other.BufferSize, 0)),
+      BufferCapacity(std::exchange(Other.BufferCapacity, 0)) {}
 
 NestedNameSpecifierLocBuilder &
 NestedNameSpecifierLocBuilder::
@@ -263,12 +262,9 @@ NestedNameSpecifierLocBuilder &NestedNameSpecifierLocBuilder::operator=(
   if (BufferCapacity) {
     free(Buffer);
   }
-  Buffer = Other.Buffer;
-  BufferSize = Other.BufferSize;
-  BufferCapacity = Other.BufferCapacity;
-
-  Other.Buffer = nullptr;
-  Other.BufferSize = Other.BufferCapacity = 0;
+  Buffer = std::exchange(Other.Buffer, nullptr);
+  BufferSize = std::exchange(Other.BufferSize, 0);
+  BufferCapacity = std::exchange(Other.BufferCapacity, 0);
 
   return *this;
 }


### PR DESCRIPTION
This avoids a deep copy of the manually managed underlying Buffer.

This is a follow-up to #180482.