### PR TITLE
[CodeGen] Improve documentation for SUBREG_TO_REG

### DIFF
--- a/llvm/include/llvm/Support/TargetOpcodes.def
+++ b/llvm/include/llvm/Support/TargetOpcodes.def
@@ -61,14 +61,14 @@ HANDLE_TARGET_OPCODE(IMPLICIT_DEF)
 /// early-clobber result operand.
 HANDLE_TARGET_OPCODE(INIT_UNDEF)
 
-/// SUBREG_TO_REG - Assert the value of bits in a super register.
+/// SUBREG_TO_REG - Expose the value of bits in a super register.
+/// This is typically used after an instruction which writes its result to a
+/// subregister but also, as a side effect, writes some value (often zero) into
+/// a larger super register.
 /// The result of this instruction is the value of the first operand inserted
 /// into the subregister specified by the second operand. All other bits are
-/// assumed to be zero.
-/// This instruction just communicates information; No code
-/// should be generated.
-/// This is typically used after an instruction where the write to a subregister
-/// implicitly cleared the bits in the super registers.
+/// left undefined or however they were set by the preceding instruction.
+/// This instruction just communicates information; No code should be generated.
 HANDLE_TARGET_OPCODE(SUBREG_TO_REG)
 
 /// COPY_TO_REGCLASS - This instruction is a placeholder for a plain


### PR DESCRIPTION
The most important change is to remove the claim that the extra bits are
necessarily set to zero.
