### PR TITLE
[libunwind] Fix building with EXCEPTION_DISPOSITION as enum

### DIFF
--- a/libunwind/src/Unwind-seh.cpp
+++ b/libunwind/src/Unwind-seh.cpp
@@ -163,7 +163,7 @@ _GCC_specific_handler(PEXCEPTION_RECORD ms_exc, PVOID frame, PCONTEXT ms_ctx,
     // If we were called by __libunwind_seh_personality(), indicate that
     // a handler was found; otherwise, initiate phase 2 by unwinding.
     if (ours && ms_exc->NumberParameters > 1)
-      return 4 /* ExceptionExecuteHandler in mingw */;
+      return static_cast<EXCEPTION_DISPOSITION>(4);
     // This should never happen in phase 2.
     if (IS_UNWINDING(ms_exc->ExceptionFlags))
       _LIBUNWIND_ABORT("Personality indicated exception handler in phase 2!");
@@ -182,7 +182,7 @@ _GCC_specific_handler(PEXCEPTION_RECORD ms_exc, PVOID frame, PCONTEXT ms_ctx,
     // a handler was found; otherwise, it's time to initiate a collided
     // unwind to the target.
     if (ours && !IS_UNWINDING(ms_exc->ExceptionFlags) && ms_exc->NumberParameters > 1)
-      return 4 /* ExceptionExecuteHandler in mingw */;
+      return static_cast<EXCEPTION_DISPOSITION>(4);
     // This should never happen in phase 1.
     if (!IS_UNWINDING(ms_exc->ExceptionFlags))
       _LIBUNWIND_ABORT("Personality installed context during phase 1!");
@@ -259,13 +259,12 @@ __libunwind_seh_personality(int version, _Unwind_Action state,
                              (void *)disp_ctx->LanguageHandler, (void *)&ms_exc,
                              (void *)disp_ctx->EstablisherFrame,
                              (void *)disp_ctx->ContextRecord, (void *)disp_ctx);
-  EXCEPTION_DISPOSITION ms_act = disp_ctx->LanguageHandler(&ms_exc,
-                                                           (PVOID)disp_ctx->EstablisherFrame,
-                                                           disp_ctx->ContextRecord,
-                                                           disp_ctx);
+  int ms_act = static_cast<int>(
+      disp_ctx->LanguageHandler(&ms_exc, (PVOID)disp_ctx->EstablisherFrame,
+                                disp_ctx->ContextRecord, disp_ctx));
   _LIBUNWIND_TRACE_UNWINDING("__libunwind_seh_personality() LanguageHandler "
                              "returned %d",
-                             (int)ms_act);
+                             ms_act);
   switch (ms_act) {
   case ExceptionContinueExecution: return _URC_END_OF_STACK;
   case ExceptionContinueSearch: return _URC_CONTINUE_UNWIND;


### PR DESCRIPTION
On Windows, libunwind is normally only built in mingw mode; it's not relevant for MSVC targets. (Attempting to build it is entirely blocked in CMake, see [1]).

In mingw headers, the type EXCEPTION_DISPOSITION is defined as an int while it is an enum in the MSVC vcruntime headers.

However, in addition to the canonical enum members, we also use a value which has no assigned enum member. In older mingw-w64 headers, there was a define for this value, 4, with the name ExceptionExecuteHandler, but that was removed in [2]. The libunwind code reference this value just by the literal value 4, with a comment referencing it as ExceptionExecuteHandler.

This extra enum value isn't passed to the outside Microsoft runtime, but is only used to pass values from one part of libunwind to another; this handling is necessary for the forced_unwind{1-3}.pass.cpp tests to succeed.

If the mingw-w64 headers would define EXCEPTION_DISPOSITION as an enum, just like the MSVC vcruntime headers, then we'd run into build errors and warnings like this:

    llvm-project/libunwind/src/Unwind-seh.cpp:166:14: error: cannot initialize return object of type 'EXCEPTION_DISPOSITION' (aka 'enum _EXCEPTION_DISPOSITION') with an rvalue of type 'int'
      166 |       return 4 /* ExceptionExecuteHandler in mingw */;
          |              ^
    llvm-project/libunwind/src/Unwind-seh.cpp:185:14: error: cannot initialize return object of type 'EXCEPTION_DISPOSITION' (aka 'enum _EXCEPTION_DISPOSITION') with an rvalue of type 'int'
      185 |       return 4 /* ExceptionExecuteHandler in mingw */;
          |              ^
    llvm-project/libunwind/src/Unwind-seh.cpp:272:8: warning: case value not in enumerated type 'EXCEPTION_DISPOSITION' (aka 'enum _EXCEPTION_DISPOSITION') [-Wswitch]
      272 |   case 4 /*ExceptionExecuteHandler*/:
          |        ^

Fix these cases by adding explicit casts between EXCEPTION_DISPOSITION and int.

A (partial) similar change was proposed in [3], but the author never followed up on the discussion, and the PR was later closed.

[1] b0b546d44777eb1fa25995384876bd14a006a929
[2] https://github.com/mingw-w64/mingw-w64/commit/2de6703961c0d519046b841f7b392a040e1e5b55
[3] https://github.com/llvm/llvm-project/pull/159293