### PR TITLE
[lldb-dap] Fix the breakpoint events test.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/breakpoint-events/Makefile
+++ b/lldb/test/API/tools/lldb-dap/breakpoint-events/Makefile
@@ -2,7 +2,4 @@ DYLIB_NAME := unlikely_name
 DYLIB_CXX_SOURCES := foo.cpp
 CXX_SOURCES := main.cpp
 
-LD_EXTRAS := -Wl,-rpath "-Wl,$(shell pwd)"
-USE_LIBDL :=1
-
 include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/breakpoint-events/Makefile
+++ b/lldb/test/API/tools/lldb-dap/breakpoint-events/Makefile
@@ -1,4 +1,8 @@
 DYLIB_NAME := unlikely_name
 DYLIB_CXX_SOURCES := foo.cpp
 CXX_SOURCES := main.cpp
+
+LD_EXTRAS := -Wl,-rpath "-Wl,$(shell pwd)"
+USE_LIBDL :=1
+
 include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/breakpoint-events/TestDAP_breakpointEvents.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint-events/TestDAP_breakpointEvents.py
@@ -11,36 +11,28 @@ import os
 
 
 class TestDAP_breakpointEvents(lldbdap_testcase.DAPTestCaseBase):
-    @skipUnlessDarwin
+    @skipIfWindows
     def test_breakpoint_events(self):
         """
-        This test sets a breakpoint in a shared library and runs and stops
-        at the entry point of a program. When we stop at the entry point,
-        the shared library won't be loaded yet. At this point the
-        breakpoint should set itself, but not be verified because no
-        locations are resolved. We will then continue and expect to get a
-        breakpoint event that informs us that the breakpoint in the shared
-        library is "changed" and the correct line number should be
-        supplied. We also set a breakpoint using a LLDB command using the
-        "preRunCommands" when launching our program. Any breakpoints set via
-        the command interpreter should not be have breakpoint events sent
-        back to VS Code as the UI isn't able to add new breakpoints to
-        their UI. Code has been added that tags breakpoints set from VS Code
+        This test follows the following steps.
+        - Sets a breakpoint in a shared library from the preCommands.
+        - Runs and stops at the entry point of a program.
+        - Sets two new breakpoints, one in the main executable and one in the shared library
+        - Both breakpoint is set but only the the shared library breakpoint is not verified yet.
+        - We will then continue and expect to get a breakpoint event that
+            informs us the breakpoint in the shared library has "changed"
+            and the correct line number should be supplied.
+        - We also verify the breakpoint set via the command interpreter should not
+            be have breakpoint events sent back to VS Code as the UI isn't able to
+            add new breakpoints to their UI.
+
+        Code has been added that tags breakpoints set from VS Code
         DAP packets so we know the IDE knows about them. If VS Code is ever
         able to register breakpoints that aren't initially set in the GUI,
         then we will need to revise this.
         """
-        main_source_basename = "main.cpp"
-        main_source_path = os.path.join(os.getcwd(), main_source_basename)
-        foo_source_basename = "foo.cpp"
-        foo_source_path = os.path.join(os.getcwd(), foo_source_basename)
-        main_bp_line = line_number("main.cpp", "main breakpoint 1")
-        foo_bp1_line = line_number("foo.cpp", "foo breakpoint 1")
-        foo_bp2_line = line_number("foo.cpp", "foo breakpoint 2")
-
-        # Visual Studio Code Debug Adapters have no way to specify the file
-        # without launching or attaching to a process, so we must start a
-        # process in order to be able to set breakpoints.
+        main_source_path = self.getSourcePath("main.cpp")
+        main_bp_line = line_number(main_source_path, "main breakpoint 1")
         program = self.getBuildArtifact("a.out")
 
         # Set a breakpoint after creating the target by running a command line
@@ -51,54 +43,80 @@ class TestDAP_breakpointEvents(lldbdap_testcase.DAPTestCaseBase):
         # registered and marked with a special keyword to ensure we deliver
         # breakpoint events for these breakpoints but not for ones that are not
         # set via the command interpreter.
-        bp_command = "breakpoint set --file foo.cpp --line %u" % (foo_bp2_line)
-        self.build_and_launch(program, preRunCommands=[bp_command])
-        main_bp_id = 0
-        foo_bp_id = 0
-        # Set breakpoints and verify that they got set correctly
+
+        # Set preCommand breakpoint
+        func_unique_function_name = "unique_function_name"
+        bp_command = f"breakpoint set --name {func_unique_function_name}"
+        launch_seq = self.build_and_launch(program, preRunCommands=[bp_command])
+        self.dap_server.wait_for_event(["initialized"])
         dap_breakpoint_ids = []
+
+        # We set the breakpoints after initialized event.
+        # Set and verify new line breakpoint.
         response = self.dap_server.request_setBreakpoints(
             Source.build(path=main_source_path), [main_bp_line]
         )
         self.assertTrue(response["success"])
         breakpoints = response["body"]["breakpoints"]
-        for breakpoint in breakpoints:
-            main_bp_id = breakpoint["id"]
-            dap_breakpoint_ids.append(main_bp_id)
-            self.assertTrue(
-                breakpoint["verified"], "expect main breakpoint to be verified"
-            )
-
-        response = self.dap_server.request_setBreakpoints(
-            Source.build(path=foo_source_path), [foo_bp1_line]
+        self.assertEqual(len(breakpoints), 1, "Expects only one line breakpoint")
+        main_breakpoint = breakpoints[0]
+        main_bp_id = main_breakpoint["id"]
+        dap_breakpoint_ids.append(main_bp_id)
+        self.assertTrue(
+            main_breakpoint["verified"], "Expects main breakpoint to be verified"
         )
+
+        # Set and verify new function breakpoint.
+        func_foo = "foo"
+        response = self.dap_server.request_setFunctionBreakpoints([func_foo])
         self.assertTrue(response["success"])
         breakpoints = response["body"]["breakpoints"]
-        for breakpoint in breakpoints:
-            foo_bp_id = breakpoint["id"]
-            dap_breakpoint_ids.append(foo_bp_id)
-            self.assertFalse(
-                breakpoint["verified"], "expect foo breakpoint to not be verified"
-            )
+        self.assertEqual(len(breakpoints), 1, "Expects only one function breakpoint")
+        func_foo_breakpoint = breakpoints[0]
+        foo_bp_id = func_foo_breakpoint["id"]
+        dap_breakpoint_ids.append(foo_bp_id)
+        self.assertFalse(
+            func_foo_breakpoint["verified"],
+            "Expects unique function breakpoint to not be verified",
+        )
 
-        # Flush the breakpoint events.
-        self.dap_server.wait_for_breakpoint_events()
+        self.dap_server.request_configurationDone()
+        launch_response = self.dap_server.receive_response(launch_seq)
+        self.assertIsNotNone(launch_response)
+        self.assertTrue(launch_response["success"])
 
-        # Continue to the breakpoint
-        self.continue_to_breakpoints(dap_breakpoint_ids)
+        # wait for the next stop (breakpoint foo).
+        self.verify_breakpoint_hit([foo_bp_id])
+        unique_bp_id = 1
 
+        # Check the breakpoints set in dap is verified
         verified_breakpoint_ids = []
-        unverified_breakpoint_ids = []
-        for breakpoint_event in self.dap_server.wait_for_breakpoint_events():
-            breakpoint = breakpoint_event["body"]["breakpoint"]
-            id = breakpoint["id"]
-            if breakpoint["verified"]:
-                verified_breakpoint_ids.append(id)
-            else:
-                unverified_breakpoint_ids.append(id)
+        events = self.dap_server.wait_for_breakpoint_events()
+        for breakpoint_event in events:
+            breakpoint_event_body = breakpoint_event["body"]
+            if breakpoint_event_body["reason"] != "changed":
+                continue
+            breakpoint = breakpoint_event_body["breakpoint"]
 
-        self.assertIn(main_bp_id, unverified_breakpoint_ids)
-        self.assertIn(foo_bp_id, unverified_breakpoint_ids)
+            if "verified" in breakpoint_event_body:
+                self.assertFalse(
+                    breakpoint_event_body["verified"],
+                    f"Expected changed breakpoint to be verified. event: {breakpoint_event}",
+                )
+            id = breakpoint["id"]
+            verified_breakpoint_ids.append(id)
 
         self.assertIn(main_bp_id, verified_breakpoint_ids)
         self.assertIn(foo_bp_id, verified_breakpoint_ids)
+        self.assertNotIn(unique_bp_id, verified_breakpoint_ids)
+
+        # Continue to the unique function breakpoint set from preRunCommands.
+        unique_function_stop_event = self.continue_to_next_stop()[0]
+        unique_body = unique_function_stop_event["body"]
+        self.assertEqual(unique_body["reason"], "breakpoint")
+        self.assertIn(unique_bp_id, unique_body["hitBreakpointIds"])
+
+        # Clear line and function breakpoints and exit.
+        self.dap_server.request_setFunctionBreakpoints([])
+        self.dap_server.request_setBreakpoints(Source.build(path=main_source_path), [])
+        self.continue_to_exit()

--- a/lldb/test/API/tools/lldb-dap/breakpoint-events/foo.cpp
+++ b/lldb/test/API/tools/lldb-dap/breakpoint-events/foo.cpp
@@ -1,11 +1,11 @@
 #include <stdio.h>
 
 static void unique_function_name() {
-  puts(__PRETTY_FUNCTION__); // foo breakpoint 2
+  puts(__PRETTY_FUNCTION__); // call puts
 }
 
 int foo(int x) {
-  // foo breakpoint 1
+  int value = 100;
   unique_function_name();
   return x + 42;
 }


### PR DESCRIPTION
Previously the test was written in a way that may be flaky, fixed with the following changes.
 - The breakpoint are placed on functions and set during the configuration stage of the protocol.
 - Add the rpath to the test binary.
 - Check we also hit the breakpoint we set directly using lldb.