### PR TITLE
[MachineScheduler] Add an option to split regions into chunks of a given maximum size

### DIFF
--- a/llvm/test/CodeGen/AArch64/misched-max-region-instrs.mir
+++ b/llvm/test/CodeGen/AArch64/misched-max-region-instrs.mir
@@ -1,0 +1,50 @@
+# RUN: llc -mtriple=arm64-apple-ios -run-pass=machine-scheduler -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=CHECK-DEFAULT
+# RUN: llc -mtriple=arm64-apple-ios -run-pass=machine-scheduler -misched-max-region-instrs=3 -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=CHECK-SPLIT
+
+# REQUIRES: asserts
+
+# Test that -misched-max-region-size splits large scheduling regions.
+
+# test_region_split_uneven
+# CHECK-DEFAULT: RegionInstrs: 6
+# CHECK-SPLIT: RegionInstrs: 3
+# CHECK-SPLIT: RegionInstrs: 2
+
+# test_region_split_even
+# CHECK-DEFAULT: RegionInstrs: 8
+# CHECK-SPLIT: RegionInstrs: 3
+# CHECK-SPLIT: RegionInstrs: 3
+
+# CHECK-DEFAULT-NOT: RegionInstrs:
+# CHECK-SPLIT-NOT: RegionInstrs:
+
+---
+name: test_region_split_uneven
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $x0, $x1, $x2, $x3, $x4, $x5
+    $x10 = ADDXrr $x0, $x1 ; 1
+    $x11 = ADDXrr $x2, $x3 ; 2
+    $x12 = ADDXrr $x4, $x5 ; 3
+    $x13 = SUBXrr $x0, $x1 ; Boundary
+    $x14 = SUBXrr $x2, $x3 ; 1
+    $x15 = SUBXrr $x4, $x5 ; 2
+    RET_ReallyLR
+...
+---
+name: test_region_split_even
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $x0, $x1, $x2, $x3, $x4, $x5, $x6, $x7
+    $x10 = ADDXrr $x0, $x1 ; 1
+    $x11 = ADDXrr $x2, $x3 ; 2
+    $x12 = ADDXrr $x4, $x5 ; 3
+    $x13 = SUBXrr $x0, $x1 ; Boundary
+    $x14 = SUBXrr $x2, $x3 ; 1
+    $x15 = SUBXrr $x4, $x5 ; 2
+    $x16 = ANDXrr $x0, $x6 ; 3
+    $x17 = ORRXrr $x0, $x7 ; Boundary
+    RET_ReallyLR
+...


### PR DESCRIPTION
Adds an option to the machine scheduler (`-misched-max-region-instrs=N`) setting the maximum number of instructions in a scheduling region. In case `N == 0`, the option is ignored. If the number of instructions in a region would otherwise exceed `N`, the region is split into chunks of at most `N` instructions. As implemented, if the number of instructions is `K`, the first `K / N` chunks contain `N` instructions and the final chunk (if applicable) contains the remaining `K % N` instructions.