### PR TITLE
[clang][bytecode] Check evaluate{String,Strlen} for pointer type

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -245,6 +245,9 @@ bool Context::evaluateString(State &Parent, const Expr *E,
   Compiler<EvalEmitter> C(*this, *P, Parent, Stk);
 
   auto PtrRes = C.interpretAsPointer(E, [&](const Pointer &Ptr) {
+    if (!Ptr.isBlockPointer())
+      return false;
+
     const Descriptor *FieldDesc = Ptr.getFieldDesc();
     if (!FieldDesc->isPrimitiveArray())
       return false;
@@ -291,6 +294,9 @@ std::optional<uint64_t> Context::evaluateStrlen(State &Parent, const Expr *E) {
 
   std::optional<uint64_t> Result;
   auto PtrRes = C.interpretAsPointer(E, [&](const Pointer &Ptr) {
+    if (!Ptr.isBlockPointer())
+      return false;
+
     const Descriptor *FieldDesc = Ptr.getFieldDesc();
     if (!FieldDesc->isPrimitiveArray())
       return false;

--- a/clang/test/AST/ByteCode/c.c
+++ b/clang/test/AST/ByteCode/c.c
@@ -433,3 +433,9 @@ void intPtrCmp1(void) { &i + 1 == 2; } // all-warning {{comparison between point
                                        // all-warning {{equality comparison result unused}}
 void intPtrCmp2(void) { 2 == &i + 1; } // all-warning {{comparison between pointer and integer}} \
                                        // all-warning {{equality comparison result unused}}
+
+/// evaluateStrlen on a non-block pointer.
+char *strcpy(char *restrict s1, const char *restrict s2);
+void strcpy_fn(char *x) {
+  strcpy(x, (char*)&strcpy_fn);
+}


### PR DESCRIPTION
We can only use block pointers here.