### PR TITLE
[clang-tidy][NFC] Update broken HICPP documentation links

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-goto.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-goto.rst
@@ -9,7 +9,7 @@ with looping constructs. Only forward jumps in nested loops are accepted.
 This check implements `ES.76
 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es76-avoid-goto>`_
 from the C++ Core Guidelines and
-`6.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements>`_
+`6.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
 from High Integrity C++ Coding Standard.
 
 For more information on why to avoid programming

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-c-arrays.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-c-arrays.rst
@@ -8,4 +8,4 @@ hicpp-avoid-c-arrays
 The hicpp-avoid-c-arrays check is an alias, please see
 :doc:`modernize-avoid-c-arrays <../modernize/avoid-c-arrays>`
 for more information.
-It partly enforces the `rule 4.1.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-conversions>`_.
+It partly enforces the `rule 4.1.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-goto.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/avoid-goto.rst
@@ -8,4 +8,4 @@ hicpp-avoid-goto
 The `hicpp-avoid-goto` check is an alias, please see
 :doc:`cppcoreguidelines-avoid-goto <../cppcoreguidelines/avoid-goto>`
 for more information.
-It enforces the `rule 6.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements>`_.
+It enforces the `rule 6.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/braces-around-statements.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/braces-around-statements.rst
@@ -10,4 +10,4 @@ The `hicpp-braces-around-statements` check is an alias, please see
 <../readability/braces-around-statements>`
 for more information.
 It enforces the `rule 6.1.1
-<https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements>`_.
+<https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/deprecated-headers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/deprecated-headers.rst
@@ -8,4 +8,4 @@ hicpp-deprecated-headers
 The `hicpp-deprecated-headers` check is an alias, please see
 :doc:`modernize-deprecated-headers <../modernize/deprecated-headers>`
 for more information.
-It enforces the `rule 1.3.3 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/general>`_.
+It enforces the `rule 1.3.3 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/exception-baseclass.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/exception-baseclass.rst
@@ -6,7 +6,7 @@ hicpp-exception-baseclass
 Ensure that every value that in a ``throw`` expression is an instance of
 ``std::exception``.
 
-This enforces `rule 15.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard-exception-handling>`_
+This enforces `rule 15.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
 of the High Integrity C++ Coding Standard.
 
 .. code-block:: c++

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/explicit-conversions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/explicit-conversions.rst
@@ -9,7 +9,7 @@ This check is an alias for
 :doc:`google-explicit-constructor <../google/explicit-constructor>`.
 
 Used to enforce parts of `rule 5.4.1
-<https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard-expressions>`_.
+<https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.
 This check will enforce that constructors and conversion operators are
 marked ``explicit``. Other forms of casting checks are implemented in
 other places. The following checks can be used to check for more forms

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/function-size.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/function-size.rst
@@ -9,6 +9,6 @@ This check is an alias for
 :doc:`readability-function-size <../readability/function-size>`.
 Useful to enforce multiple sections on function complexity.
 
-- `rule 8.2.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/definitions>`_
-- `rule 8.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/definitions>`_
-- `rule 8.3.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/definitions>`_
+- `rule 8.2.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
+- `rule 8.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
+- `rule 8.3.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/ignored-remove-result.rst
@@ -5,7 +5,7 @@ hicpp-ignored-remove-result
 
 Ensure that the result of ``std::remove``, ``std::remove_if`` and ``std::unique``
 are not ignored according to
-`rule 17.5.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-library>`_.
+`rule 17.5.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.
 
 The mutating algorithms ``std::remove``, ``std::remove_if`` and both overloads
 of ``std::unique`` operate by swapping or moving elements of the range they are

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/invalid-access-moved.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/invalid-access-moved.rst
@@ -8,4 +8,4 @@ hicpp-invalid-access-moved
 This check is an alias for
 :doc:`bugprone-use-after-move <../bugprone/use-after-move>`.
 
-Implements parts of the `rule 8.4.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/definitions>`_ to check if moved-from objects are accessed.
+Implements parts of the `rule 8.4.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_ to check if moved-from objects are accessed.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/member-init.rst
@@ -7,5 +7,5 @@ hicpp-member-init
 
 This check is an alias for :doc:`cppcoreguidelines-pro-type-member-init <../cppcoreguidelines/pro-type-member-init>`.
 Implements the check for
-`rule 12.4.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions>`_
+`rule 12.4.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
 to initialize class members in the right order.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/move-const-arg.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/move-const-arg.rst
@@ -8,4 +8,4 @@ hicpp-move-const-arg
 The `hicpp-move-const-arg` check is an alias, please see
 :doc:`performance-move-const-arg <../performance/move-const-arg>`
 for more information.
-It enforces the `rule 17.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-library>`_.
+It enforces the `rule 17.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/multiway-paths-covered.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/multiway-paths-covered.rst
@@ -6,8 +6,8 @@ hicpp-multiway-paths-covered
 This check discovers situations where code paths are not fully-covered.
 It furthermore suggests using ``if`` instead of ``switch`` if the code
 will be more clear.
-The `rule 6.1.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements>`_
-and `rule 6.1.4 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements>`_
+The `rule 6.1.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
+and `rule 6.1.4 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
 of the High Integrity C++ Coding Standard are enforced.
 
 ``if-else if`` chains that miss a final ``else`` branch might lead to
@@ -59,7 +59,7 @@ possible code paths.
   }
 
 
-The `rule 6.1.4 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/statements>`_
+The `rule 6.1.4 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
 requires every ``switch`` statement to have at least two ``case`` labels other than a `default` label.
 Otherwise, the ``switch`` could be better expressed with an ``if`` statement.
 Degenerated ``switch`` statements without any labels are caught as well.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/named-parameter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/named-parameter.rst
@@ -8,4 +8,4 @@ hicpp-named-parameter
 This check is an alias for :doc:`readability-named-parameter
 <../readability/named-parameter>`.
 
-Implements `rule 8.2.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/definitions>`_.
+Implements `rule 8.2.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/new-delete-operators.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/new-delete-operators.rst
@@ -6,5 +6,5 @@ hicpp-new-delete-operators
 ==========================
 
 This check is an alias for :doc:`misc-new-delete-overloads <../misc/new-delete-overloads>`.
-Implements `rule 12.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions>`_ to ensure
+Implements `rule 12.3.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_ to ensure
 the `new` and `delete` operators have the correct signature.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-array-decay.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-array-decay.rst
@@ -9,4 +9,4 @@ The `hicpp-no-array-decay` check is an alias, please see
 :doc:`cppcoreguidelines-pro-bounds-array-to-pointer-decay
 <../cppcoreguidelines/pro-bounds-array-to-pointer-decay>`
 for more information.
-It enforces the `rule 4.1.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-conversions>`_.
+It enforces the `rule 4.1.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-assembler.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-assembler.rst
@@ -6,5 +6,5 @@ hicpp-no-assembler
 Checks for assembler statements. Use of inline assembly should be avoided since
 it restricts the portability of the code.
 
-This enforces `rule 7.5.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/declarations>`_
+This enforces `rule 7.5.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
 of the High Integrity C++ Coding Standard.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-malloc.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/no-malloc.rst
@@ -8,4 +8,4 @@ hicpp-no-malloc
 The `hicpp-no-malloc` check is an alias, please see
 :doc:`cppcoreguidelines-no-malloc <../cppcoreguidelines/no-malloc>`
 for more information.
-It enforces the `rule 5.3.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard-expressions>`_.
+It enforces the `rule 5.3.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/noexcept-move.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/noexcept-move.rst
@@ -7,4 +7,4 @@ hicpp-noexcept-move
 
 This check is an alias for :doc:`performance-noexcept-move-constructor
 <../performance/noexcept-move-constructor>`.
-Checks `rule 12.5.4 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions>`_ to mark move assignment and move construction `noexcept`.
+Checks `rule 12.5.4 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_ to mark move assignment and move construction `noexcept`.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/signed-bitwise.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/signed-bitwise.rst
@@ -6,7 +6,7 @@ hicpp-signed-bitwise
 Finds uses of bitwise operations on signed integer types, which may lead to
 undefined or implementation defined behavior.
 
-The according rule is defined in the `High Integrity C++ Standard, Section 5.6.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard-expressions>`_.
+The according rule is defined in the `High Integrity C++ Standard, Section 5.6.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.
 
 Options
 -------

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/special-member-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/special-member-functions.rst
@@ -6,4 +6,4 @@ hicpp-special-member-functions
 ==============================
 
 This check is an alias for :doc:`cppcoreguidelines-special-member-functions <../cppcoreguidelines/special-member-functions>`.
-Checks that special member functions have the correct signature, according to `rule 12.5.7 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions>`_.
+Checks that special member functions have the correct signature, according to `rule 12.5.7 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/static-assert.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/static-assert.rst
@@ -7,4 +7,4 @@ hicpp-static-assert
 
 The `hicpp-static-assert` check is an alias, please see
 :doc:`misc-static-assert <../misc/static-assert>` for more information.
-It enforces the `rule 7.1.10 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/declarations>`_.
+It enforces the `rule 7.1.10 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/undelegated-constructor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/undelegated-constructor.rst
@@ -6,7 +6,7 @@ hicpp-undelegated-constructor
 =============================
 
 This check is an alias for :doc:`bugprone-undelegated-constructor <../bugprone/undelegated-constructor>`.
-Partially implements `rule 12.4.5 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions>`_
+Partially implements `rule 12.4.5 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
 to find misplaced constructor calls inside a constructor.
 
 .. code-block:: c++

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/uppercase-literal-suffix.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/uppercase-literal-suffix.rst
@@ -9,5 +9,5 @@ The hicpp-uppercase-literal-suffix check is an alias, please see
 :doc:`readability-uppercase-literal-suffix
 <../readability/uppercase-literal-suffix>` for more information.
 
-Partially implements `rule 4.2.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-conversions>`_
+Partially implements `rule 4.2.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
 to ensure that the ``U`` suffix is writeln properly.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-auto.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-auto.rst
@@ -7,4 +7,4 @@ hicpp-use-auto
 
 The `hicpp-use-auto` check is an alias, please see
 :doc:`modernize-use-auto <../modernize/use-auto>` for more information.
-It enforces the `rule 7.1.8 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/declarations>`_.
+It enforces the `rule 7.1.8 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-emplace.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-emplace.rst
@@ -7,4 +7,4 @@ hicpp-use-emplace
 
 The `hicpp-use-emplace` check is an alias, please see
 :doc:`modernize-use-emplace <../modernize/use-emplace>` for more information.
-It enforces the `rule 17.4.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/standard-library>`_.
+It enforces the `rule 17.4.2 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-equals-default.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-equals-default.rst
@@ -6,4 +6,4 @@ hicpp-use-equals-default
 ========================
 
 This check is an alias for :doc:`modernize-use-equals-default <../modernize/use-equals-default>`.
-Implements `rule 12.5.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions>`_ to explicitly default special member functions.
+Implements `rule 12.5.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_ to explicitly default special member functions.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-equals-delete.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-equals-delete.rst
@@ -6,5 +6,5 @@ hicpp-use-equals-delete
 =======================
 
 This check is an alias for :doc:`modernize-use-equals-delete <../modernize/use-equals-delete>`.
-Implements `rule 12.5.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/special-member-functions>`_
+Implements `rule 12.5.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
 to explicitly default or delete special member functions.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-noexcept.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-noexcept.rst
@@ -7,4 +7,4 @@ hicpp-use-noexcept
 
 The `hicpp-use-noexcept` check is an alias, please see
 :doc:`modernize-use-noexcept <../modernize/use-noexcept>` for more information.
-It enforces the `rule 1.3.5 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/general>`_.
+It enforces the `rule 1.3.5 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-nullptr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-nullptr.rst
@@ -7,4 +7,4 @@ hicpp-use-nullptr
 
 The `hicpp-use-nullptr` check is an alias, please see
 :doc:`modernize-use-nullptr <../modernize/use-nullptr>` for more information.
-It enforces the `rule 2.5.3 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/lexical-conventions>`_.
+It enforces the `rule 2.5.3 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-override.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/use-override.rst
@@ -6,5 +6,5 @@ hicpp-use-override
 ==================
 
 This check is an alias for :doc:`modernize-use-override <../modernize/use-override>`.
-Implements `rule 10.2.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/derived-classes>`_ to
+Implements `rule 10.2.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_ to
 declare a virtual function `override` when overriding.

--- a/clang-tools-extra/docs/clang-tidy/checks/hicpp/vararg.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/hicpp/vararg.rst
@@ -8,4 +8,4 @@ hicpp-vararg
 The `hicpp-vararg` check is an alias, please see
 :doc:`cppcoreguidelines-pro-type-vararg <../cppcoreguidelines/pro-type-vararg>`
 for more information.
-It enforces the `rule 14.1.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard/templates>`_.
+It enforces the `rule 14.1.1 <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.rst
@@ -10,7 +10,7 @@ Many coding guidelines advise replacing the magic values with symbolic
 constants to improve readability. Here are a few references:
 
    * `Rule ES.45: Avoid "magic constants"; use symbolic constants in C++ Core Guidelines <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#res-magic>`_
-   * `Rule 5.1.1 Use symbolic names instead of literal values in code in High Integrity C++ <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard-expressions>`_
+   * `Rule 5.1.1 Use symbolic names instead of literal values in code in High Integrity C++ <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-rules>`_
    * Item 17 in "C++ Coding Standards: 101 Rules, Guidelines and Best
      Practices" by Herb Sutter and Andrei Alexandrescu
    * Chapter 17 in "Clean Code - A handbook of agile software craftsmanship."


### PR DESCRIPTION
The original links to the High Integrity C++ Coding Standard now redirects to an [irrelevant page](https://www.perforce.com/resources) because Perforce made the document private (it now requires email to apply).

This PR updates all HICPP-related documentation links to point to the application form, ensuring users can still find the official source for these rules.

