### PR TITLE
[clang] Fix checkMathBuiltinElementType SignedIntOrFloatTy checks

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -2200,7 +2200,7 @@ checkMathBuiltinElementType(Sema &S, SourceLocation Loc, QualType ArgTy,
     }
     break;
   case Sema::EltwiseBuiltinArgTyRestriction::SignedIntOrFloatTy:
-    if (EltTy->isUnsignedIntegerType()) {
+    if (!EltTy->isSignedIntegerType() && !EltTy->isRealFloatingType()) {
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
              << 1 << /* scalar or vector */ 5 << /* signed int */ 2
              << /* or fp */ 1 << ArgTy;

--- a/clang/test/Sema/builtins-elementwise-math.c
+++ b/clang/test/Sema/builtins-elementwise-math.c
@@ -43,6 +43,9 @@ void test_builtin_elementwise_abs(int i, double d, float4 v, int3 iv, unsigned u
 
   uv = __builtin_elementwise_abs(uv);
   // expected-error@-1 {{1st argument must be a scalar or vector of signed integer or floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+
+  i = __builtin_elementwise_abs(&i);
+  // expected-error@-1 {{1st argument must be a scalar or vector of signed integer or floating-point types (was 'int *')}}
 }
 
 void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {


### PR DESCRIPTION
The previous check was way too loose and let everything except unsigned integer types through.
See e.g. https://godbolt.org/z/3qY8EbK56