### PR TITLE
[offload][flang-rt] Fix NVPTX runtime build

### DIFF
--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -228,30 +228,16 @@ endif()
 
 include(CheckCXXSymbolExists)
 include(CheckCXXSourceCompiles)
-if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn|^nvptx")
-  # The GPU cross-build uses CMAKE_REQUIRED_FLAGS with -c (compile-only) for
-  # NVPTX because its output cannot be linked conventionally. This causes
-  # check_cxx_symbol_exists to only verify the symbol is declared in headers,
-  # not that it can be linked. Combined with the absence of -nostdlibinc in
-  # CMAKE_REQUIRED_FLAGS, the checks pick up host system headers and
-  # incorrectly detect functions that the GPU libc does not yet provide.
-  # Until the GPU libc headers are on the include path during CMake checks,
-  # disable the detection and rely on the RT_DEVICE_COMPILATION guards in the
-  # runtime source instead.
-  set(HAVE_STRERROR_R 0)
-  set(HAVE_DECL_STRERROR_S 0)
-else ()
-  check_cxx_symbol_exists(strerror_r string.h HAVE_STRERROR_R)
-  # Can't use symbol exists here as the function is overloaded in C++
-  check_cxx_source_compiles(
-    "#include <string.h>
-     int main() {
-       char buf[4096];
-       return strerror_s(buf, 4096, 0);
-     }
-    "
-    HAVE_DECL_STRERROR_S)
-endif ()
+check_cxx_symbol_exists(strerror_r string.h HAVE_STRERROR_R)
+# Can't use symbol exists here as the function is overloaded in C++
+check_cxx_source_compiles(
+  "#include <string.h>
+   int main() {
+     char buf[4096];
+     return strerror_s(buf, 4096, 0);
+   }
+  "
+  HAVE_DECL_STRERROR_S)
 
 # Search for clang_rt.builtins library. Need in addition to msvcrt.
 if (WIN32)
@@ -295,15 +281,9 @@ endif()
 find_package(Threads)
 
 # function checks
-if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn|^nvptx")
-  # Same issue as above: find_package(Backtrace) detects the host backtrace
-  # support, not the GPU target's.
-  set(HAVE_BACKTRACE FALSE)
-else ()
-  find_package(Backtrace)
-  set(HAVE_BACKTRACE ${Backtrace_FOUND})
-  set(BACKTRACE_HEADER ${Backtrace_HEADER})
-endif ()
+find_package(Backtrace)
+set(HAVE_BACKTRACE ${Backtrace_FOUND})
+set(BACKTRACE_HEADER ${Backtrace_HEADER})
 
 
 #####################

--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -228,16 +228,30 @@ endif()
 
 include(CheckCXXSymbolExists)
 include(CheckCXXSourceCompiles)
-check_cxx_symbol_exists(strerror_r string.h HAVE_STRERROR_R)
-# Can't use symbol exists here as the function is overloaded in C++
-check_cxx_source_compiles(
-  "#include <string.h>
-   int main() {
-     char buf[4096];
-     return strerror_s(buf, 4096, 0);
-   }
-  "
-  HAVE_DECL_STRERROR_S)
+if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn|^nvptx")
+  # The GPU cross-build uses CMAKE_REQUIRED_FLAGS with -c (compile-only) for
+  # NVPTX because its output cannot be linked conventionally. This causes
+  # check_cxx_symbol_exists to only verify the symbol is declared in headers,
+  # not that it can be linked. Combined with the absence of -nostdlibinc in
+  # CMAKE_REQUIRED_FLAGS, the checks pick up host system headers and
+  # incorrectly detect functions that the GPU libc does not yet provide.
+  # Until the GPU libc headers are on the include path during CMake checks,
+  # disable the detection and rely on the RT_DEVICE_COMPILATION guards in the
+  # runtime source instead.
+  set(HAVE_STRERROR_R 0)
+  set(HAVE_DECL_STRERROR_S 0)
+else ()
+  check_cxx_symbol_exists(strerror_r string.h HAVE_STRERROR_R)
+  # Can't use symbol exists here as the function is overloaded in C++
+  check_cxx_source_compiles(
+    "#include <string.h>
+     int main() {
+       char buf[4096];
+       return strerror_s(buf, 4096, 0);
+     }
+    "
+    HAVE_DECL_STRERROR_S)
+endif ()
 
 # Search for clang_rt.builtins library. Need in addition to msvcrt.
 if (WIN32)
@@ -281,9 +295,15 @@ endif()
 find_package(Threads)
 
 # function checks
-find_package(Backtrace)
-set(HAVE_BACKTRACE ${Backtrace_FOUND})
-set(BACKTRACE_HEADER ${Backtrace_HEADER})
+if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn|^nvptx")
+  # Same issue as above: find_package(Backtrace) detects the host backtrace
+  # support, not the GPU target's.
+  set(HAVE_BACKTRACE FALSE)
+else ()
+  find_package(Backtrace)
+  set(HAVE_BACKTRACE ${Backtrace_FOUND})
+  set(BACKTRACE_HEADER ${Backtrace_HEADER})
+endif ()
 
 
 #####################

--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -113,7 +113,6 @@ set(gpu_sources
   format.cpp
   inquiry.cpp
   internal-unit.cpp
-  io-error.cpp
   iostat.cpp
   matmul-transpose.cpp
   matmul.cpp


### PR DESCRIPTION
I noticed the compile error you see below (using configuration as in https://github.com/llvm/llvm-project/blob/main/offload/cmake/caches/FlangOffload.cmake). It seems that during the check for availability of `strerror_r`, the host include file is used. This doesn't matter for AMDGPU since it actually performs the link step during `check_cxx_symbol_exists`. But for NVPTX, due to `-c`, it doesn't link and then incorrectly assumes that the symbol exists.

```
-- Build files have been written to: .../build/llvm-project/main/runtimes/runtimes-amdgcn-amd-amdhsa-bins
[714/729] Performing build step for 'runtimes-nvptx64-nvidia-cuda'
[5/6] Building CXX object flang-rt/lib/runtime/CMakeFiles/flang_rt.runtime.static.dir/io-error.cpp.o
FAILED: flang-rt/lib/runtime/CMakeFiles/flang_rt.runtime.static.dir/io-error.cpp.o
.../build/llvm-project/main/./bin/clang++ --target=nvptx64-nvidia-cuda -DLIBCXX_BUILDING_LIBCXXABI -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GLIBCXX_NO_ASSERTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I.../llvm-project/flang-rt/include -I.../llvm-project/flang-rt/../flang/include -I.../build/llvm-project/main/runtimes/runtimes-nvptx64-nvidia-cuda-bins/flang-rt -I.../build/llvm-project/main/include/nvptx64-nvidia-cuda/c++/v1 -I.../build/llvm-project/main/include/c++/v1 -I.../llvm-project/libcxxabi/include -isystem .../build/llvm-project/main/include/nvptx64-nvidia-cuda -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wstring-conversion -Wno-pass-failed -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -UNDEBUG -fno-exceptions -fno-rtti -funwind-tables -fno-asynchronous-unwind-tables "-D_GLIBCXX_THROW_OR_ABORT(_EXC)=(__builtin_abort())" -nogpulib -flto -fvisibility=hidden -Wno-unknown-cuda-version --cuda-feature=+ptx63 -Wp,-U_GLIBCXX_ASSERTIONS -Wp,-U_LIBCPP_ENABLE_ASSERTIONS -fdebug-prefix-map=.../build/llvm-project/main/include/c++/v1=.../llvm-project/libcxx/include -nostdlibinc -nostdlib -nostdinc++ -std=gnu++17 -MD -MT flang-rt/lib/runtime/CMakeFiles/flang_rt.runtime.static.dir/io-error.cpp.o -MF flang-rt/lib/runtime/CMakeFiles/flang_rt.runtime.static.dir/io-error.cpp.o.d -o flang-rt/lib/runtime/CMakeFiles/flang_rt.runtime.static.dir/io-error.cpp.o -c .../llvm-project/flang-rt/lib/runtime/io-error.cpp
.../llvm-project/flang-rt/lib/runtime/io-error.cpp:140:10: error: no member named 'strerror_r' in the global namespace; did you mean 'strerror'?
  140 |   ok = ::strerror_r(ioStat_, buffer, bufferLength) == 0;
      |          ^~~~~~~~~~
      |          strerror
.../build/llvm-project/main/include/nvptx64-nvidia-cuda/string.h:61:7: note: 'strerror' declared here
   61 | char *strerror(int) __NOEXCEPT;
      |       ^
.../llvm-project/flang-rt/lib/runtime/io-error.cpp:140:30: error: too many arguments to function call, expected 1, have 3
  140 |   ok = ::strerror_r(ioStat_, buffer, bufferLength) == 0;
      |        ~~~~~~~~~~~~          ^~~~~~~~~~~~~~~~~~~~
2 errors generated.
ninja: build stopped: subcommand failed.
[717/729] No patch step for 'runtimes'
FAILED: runtimes/runtimes-nvptx64-nvidia-cuda-stamps/runtimes-nvptx64-nvidia-cuda-build .../build/llvm-project/main/runtimes/runtimes-nvptx64-nvidia-cuda-stamps/runtimes-nvptx64-nvidia-cuda-build
cd .../build/llvm-project/main/runtimes/runtimes-nvptx64-nvidia-cuda-bins && .../local/install/cmake-3.25.2/bin/cmake --build .
[719/729] Building CXX object tools/flang/tools/bbc/CMakeFiles/bbc.dir/bbc.cpp.o
ninja: build stopped: subcommand failed.
```