### PR TITLE
[CodeGen][NFC] Update a comment.

### DIFF
--- a/llvm/include/llvm/CodeGen/Register.h
+++ b/llvm/include/llvm/CodeGen/Register.h
@@ -47,7 +47,7 @@ public:
     return Register::StackSlotZero <= Reg && Reg < Register::VirtualRegFlag;
   }
 
-  /// Convert a non-negative frame index to a stack slot register value.
+  /// Convert a frame index to a stack slot register value.
   static Register index2StackSlot(int FI) {
     assert(isInt<MaxFrameIndexBitwidth>(FI) &&
            "Frame index must be at most 30 bits.");


### PR DESCRIPTION
Since a register can represent a negative frame index, remove "non-negative" from the comment.