### PR TITLE
[clang][bytecode] Handle missing target label in break statement

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -6036,7 +6036,9 @@ bool Compiler<Emitter>::visitBreakStmt(const BreakStmt *S) {
     }
   }
 
-  assert(TargetLabel);
+  // Faulty break statement (e.g. label redefined or named loops disabled).
+  if (!TargetLabel)
+    return false;
 
   for (VariableScope<Emitter> *C = this->VarScope; C != BreakScope;
        C = C->getParent()) {

--- a/clang/test/AST/ByteCode/invalid.cpp
+++ b/clang/test/AST/ByteCode/invalid.cpp
@@ -151,3 +151,16 @@ namespace NullRecord {
   };
   S2 s = S2();
 }
+
+namespace NamedLoops {
+  constexpr int foo() {
+  bar: // both-note {{previous definition is here}} \
+       // both-warning {{use of this statement in a constexpr function is a C++23 extension}}
+    return 0;
+
+  bar: // both-error {{redefinition of label 'bar'}}
+    do {
+      break bar; // both-error {{named 'break' is only supported in C2y}}
+    } while (0);
+  }
+}


### PR DESCRIPTION
Happens in error cases.