### PR TITLE
[OCaml] Remove global_context

### DIFF
--- a/llvm/bindings/ocaml/llvm/llvm.ml
+++ b/llvm/bindings/ocaml/llvm/llvm.ml
@@ -390,7 +390,6 @@ external set_diagnostic_handler
 (*===-- Contexts ----------------------------------------------------------===*)
 external create_context : unit -> llcontext = "llvm_create_context"
 external dispose_context : llcontext -> unit = "llvm_dispose_context"
-external global_context : unit -> llcontext = "llvm_global_context"
 external mdkind_id : llcontext -> string -> llmdkind = "llvm_mdkind_id"
 
 (*===-- Attributes --------------------------------------------------------===*)

--- a/llvm/bindings/ocaml/llvm/llvm.mli
+++ b/llvm/bindings/ocaml/llvm/llvm.mli
@@ -464,9 +464,6 @@ val create_context : unit -> llcontext
     [llvm::LLVMContext::~LLVMContext]. *)
 val dispose_context : llcontext -> unit
 
-(** See the function [LLVMGetGlobalContext]. *)
-val global_context : unit -> llcontext
-
 (** [mdkind_id context name] returns the MDKind ID that corresponds to the
     name [name] in the context [context].  See the function
     [llvm::LLVMContext::getMDKindID]. *)

--- a/llvm/bindings/ocaml/llvm/llvm_ocaml.c
+++ b/llvm/bindings/ocaml/llvm/llvm_ocaml.c
@@ -238,11 +238,6 @@ value llvm_dispose_context(value C) {
   return Val_unit;
 }
 
-/* unit -> llcontext */
-value llvm_global_context(value Unit) {
-  return to_val(LLVMGetGlobalContext());
-}
-
 /* llcontext -> string -> int */
 value llvm_mdkind_id(value C, value Name) {
   unsigned MDKindID = LLVMGetMDKindIDInContext(Context_val(C), String_val(Name),

--- a/llvm/test/Bindings/OCaml/analysis.ml
+++ b/llvm/test/Bindings/OCaml/analysis.ml
@@ -12,7 +12,7 @@ open Llvm_analysis
 (* Note that this takes a moment to link, so it's best to keep the number of
    individual tests low. *)
 
-let context = global_context ()
+let context = create_context ()
 
 let test x = if not x then exit 1 else ()
 
@@ -49,6 +49,7 @@ let _ =
   if verify_function fn then bomb "invalid function passed verification!";
 
 
-  dispose_module m
+  dispose_module m;
+  dispose_context context
 
   (* Don't bother to test assert_valid_{module,function}. *)

--- a/llvm/test/Bindings/OCaml/bitreader.ml
+++ b/llvm/test/Bindings/OCaml/bitreader.ml
@@ -10,7 +10,7 @@
 (* Note that this takes a moment to link, so it's best to keep the number of
    individual tests low. *)
 
-let context = Llvm.global_context ()
+let context = Llvm.create_context ()
 
 let diagnostic_handler _ = ()
 
@@ -86,4 +86,6 @@ let _ =
       false
     with Llvm_bitreader.Error _ ->
       true
-  end
+  end;
+
+  Llvm.dispose_context context

--- a/llvm/test/Bindings/OCaml/bitwriter.ml
+++ b/llvm/test/Bindings/OCaml/bitwriter.ml
@@ -10,7 +10,7 @@
 (* Note that this takes a moment to link, so it's best to keep the number of
    individual tests low. *)
 
-let context = Llvm.global_context ()
+let context = Llvm.create_context ()
 
 let test x = if not x then exit 1 else ()
 
@@ -46,4 +46,5 @@ let _ =
   test (file_buf = temp_bitcode m);
   test (file_buf = temp_bitcode ~unbuffered:false m);
   test (file_buf = temp_bitcode ~unbuffered:true m);
-  test (file_buf = Bytes.of_string (Llvm.MemoryBuffer.as_string (Llvm_bitwriter.write_bitcode_to_memory_buffer m)))
+  test (file_buf = Bytes.of_string (Llvm.MemoryBuffer.as_string (Llvm_bitwriter.write_bitcode_to_memory_buffer m)));
+  Llvm.dispose_context context

--- a/llvm/test/Bindings/OCaml/core.ml
+++ b/llvm/test/Bindings/OCaml/core.ml
@@ -18,7 +18,7 @@ open Llvm
 open Llvm_bitwriter
 
 open Testsuite
-let context = global_context ()
+let context = create_context ()
 let i1_type = Llvm.i1_type context
 let i8_type = Llvm.i8_type context
 let i16_type = Llvm.i16_type context
@@ -1507,4 +1507,5 @@ let _ =
   suite "builder"          test_builder;
   suite "memory buffer"    test_memory_buffer;
   suite "writer"           test_writer; (* Keep this last; it disposes m. *)
+  dispose_context context;
   exit !exit_status

--- a/llvm/test/Bindings/OCaml/debuginfo.ml
+++ b/llvm/test/Bindings/OCaml/debuginfo.ml
@@ -8,7 +8,7 @@
 
 open Testsuite
 
-let context = Llvm.global_context ()
+let context = Llvm.create_context ()
 
 let filename = "di_test_file"
 
@@ -468,4 +468,5 @@ let () =
       prerr_endline ("Verification of module failed: " ^ err);
       exit_status := 1
   | None -> () );
+  Llvm.dispose_context context;
   exit !exit_status

--- a/llvm/test/Bindings/OCaml/diagnostic_handler.ml
+++ b/llvm/test/Bindings/OCaml/diagnostic_handler.ml
@@ -6,7 +6,7 @@
  * XFAIL: vg_leak
  *)
 
-let context = Llvm.global_context ()
+let context = Llvm.create_context ()
 
 let diagnostic_handler d =
   Printf.printf
@@ -45,4 +45,6 @@ let _ =
       false
     with Llvm_bitreader.Error _ ->
       true
-  end
+  end;
+
+  Llvm.dispose_context context

--- a/llvm/test/Bindings/OCaml/executionengine.ml
+++ b/llvm/test/Bindings/OCaml/executionengine.ml
@@ -14,7 +14,7 @@ open Llvm_target
 (* Note that this takes a moment to link, so it's best to keep the number of
    individual tests low. *)
 
-let context = global_context ()
+let context = create_context ()
 let i8_type = Llvm.i8_type context
 let i32_type = Llvm.i32_type context
 let i64_type = Llvm.i64_type context
@@ -30,7 +30,7 @@ let bomb msg =
 let define_getglobal m pg =
   let fty = function_type i32_type [||] in
   let fn = define_function "getglobal" fty m in
-  let b = builder_at_end (global_context ()) (entry_block fn) in
+  let b = builder_at_end context (entry_block fn) in
   let g = build_call fty pg [||] "" b in
   ignore (build_ret g b);
   fn
@@ -38,7 +38,7 @@ let define_getglobal m pg =
 let define_plus m =
   let fn = define_function "plus" (function_type i32_type [| i32_type;
                                                              i32_type |]) m in
-  let b = builder_at_end (global_context ()) (entry_block fn) in
+  let b = builder_at_end context (entry_block fn) in
   let add = build_add (param fn 0) (param fn 1) "sum" b in
   ignore (build_ret add b);
   fn
@@ -47,7 +47,7 @@ let test_executionengine () =
   let open Ctypes in
 
   (* create *)
-  let m = create_module (global_context ()) "test_module" in
+  let m = create_module context "test_module" in
   let ee = create m in
 
   (* add plus *)
@@ -57,7 +57,7 @@ let test_executionengine () =
   ignore (define_global "globvar" (const_int i32_type 23) m);
 
   (* add module *)
-  let m2 = create_module (global_context ()) "test_module2" in
+  let m2 = create_module context "test_module2" in
   add_module m2 ee;
 
   (* add global mapping *)
@@ -110,4 +110,5 @@ let test_executionengine () =
 
 let () =
   test_executionengine ();
-  Gc.compact ()
+  Gc.compact ();
+  dispose_context context

--- a/llvm/test/Bindings/OCaml/ext_exc.ml
+++ b/llvm/test/Bindings/OCaml/ext_exc.ml
@@ -6,7 +6,7 @@
  * XFAIL: vg_leak
  *)
 
-let context = Llvm.global_context ()
+let context = Llvm.create_context ()
 
 let diagnostic_handler _ = ()
 
@@ -23,3 +23,4 @@ let _ =
         ignore (Llvm.MemoryBuffer.of_file "/path/to/nonexistent/file")
     with
     Llvm.IoError _ -> ();;
+    Llvm.dispose_context context

--- a/llvm/test/Bindings/OCaml/irreader.ml
+++ b/llvm/test/Bindings/OCaml/irreader.ml
@@ -13,7 +13,7 @@
 open Llvm
 open Llvm_irreader
 
-let context = global_context ()
+let context = create_context ()
 
 (* Tiny unit test framework - really just to help find which line is busted *)
 let print_checkpoints = false
@@ -75,4 +75,5 @@ let test_irreader () =
 (*===-- Driver ------------------------------------------------------------===*)
 
 let _ =
-  suite "irreader" test_irreader
+  suite "irreader" test_irreader;
+  dispose_context context

--- a/llvm/test/Bindings/OCaml/linker.ml
+++ b/llvm/test/Bindings/OCaml/linker.ml
@@ -13,7 +13,7 @@
 open Llvm
 open Llvm_linker
 
-let context = global_context ()
+let context = create_context ()
 let void_type = Llvm.void_type context
 
 let diagnostic_handler _ = ()
@@ -62,4 +62,5 @@ let test_linker () =
 (*===-- Driver ------------------------------------------------------------===*)
 
 let _ =
-  suite "linker" test_linker
+  suite "linker" test_linker;
+  dispose_context context

--- a/llvm/test/Bindings/OCaml/passbuilder.ml
+++ b/llvm/test/Bindings/OCaml/passbuilder.ml
@@ -10,7 +10,7 @@ let () = Llvm_all_backends.initialize ()
 
 (*===-- Fixture -----------------------------------------------------------===*)
 
-let context = Llvm.global_context ()
+let context = Llvm.create_context ()
 
 let m = Llvm.create_module context "mymodule"
 
@@ -71,4 +71,5 @@ let () =
 
 let () =
   Llvm_passbuilder.dispose_passbuilder_options options;
-  Llvm.dispose_module m
+  Llvm.dispose_module m;
+  Llvm.dispose_context context

--- a/llvm/test/Bindings/OCaml/target.ml
+++ b/llvm/test/Bindings/OCaml/target.ml
@@ -14,7 +14,7 @@ open Llvm_target
 
 let () = Llvm_all_backends.initialize ()
 
-let context = global_context ()
+let context = create_context ()
 let i32_type = Llvm.i32_type context
 let i64_type = Llvm.i64_type context
 
@@ -108,4 +108,5 @@ let _ =
   test_target ();
   test_target_machine ();
   test_code_emission ();
-  dispose_module m
+  dispose_module m;
+  dispose_context context

--- a/llvm/test/Bindings/OCaml/transform_utils.ml
+++ b/llvm/test/Bindings/OCaml/transform_utils.ml
@@ -9,7 +9,7 @@
 open Llvm
 open Llvm_transform_utils
 
-let context = global_context ()
+let context = create_context ()
 
 let test_clone_module () =
   let m  = create_module context "mod" in
@@ -18,4 +18,5 @@ let test_clone_module () =
   if string_of_llmodule m <> string_of_llmodule m' then failwith "string_of m <> m'"
 
 let () =
-  test_clone_module ()
+  test_clone_module ();
+  dispose_context context


### PR DESCRIPTION
This has been deprecated in the C API, so remove it from the OCaml bindings. create_context and dispose_context should be used instead.