### PR TITLE
[OFFLOAD] Implement excluding filters for debugging

### DIFF
--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -317,7 +317,7 @@ struct DebugSettings {
     // Messages with Type/Components added to the exclude list are not
     // not printed when debug is enabled unless they are explicitly
     // requested by the user.
-    // Eventuall this should be configured from the upper layers but
+    // Eventually, this should be configured from the upper layers but
     // for now we can hardcode some excluded types here like:
     // Settings.ExcludeFilters.push_back(Type);
 

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -271,7 +271,11 @@ struct DebugFilter {
 struct DebugSettings {
   bool Enabled = false;
   uint32_t DefaultLevel = 1;
+  // Types/Components in this list are not printed when debug is enabled 
+  // unless they are explicitly requested by the user in IncludeFilters.
   llvm::SmallVector<StringRef> ExcludeFilters;
+  // Types/Components in this list are printed when debug is enabled if 
+  // the debug level is equal or higher than the specified level.
   llvm::SmallVector<DebugFilter> IncludeFilters;
 };
 
@@ -310,10 +314,10 @@ struct DebugSettings {
 
     Settings.Enabled = true;
 
-    // Messages with Type/Components added to the exclude list are not 
+    // Messages with Type/Components added to the exclude list are not
     // not printed when debug is enabled unless they are explicitly 
     // requested by the user.
-    // Eventuall this should be configured from the upper layers but 
+    // Eventuall this should be configured from the upper layers but
     // for now we can hardcode some excluded types here like:
     // Settings.ExcludeFilters.push_back(Type); 
 

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -271,10 +271,10 @@ struct DebugFilter {
 struct DebugSettings {
   bool Enabled = false;
   uint32_t DefaultLevel = 1;
-  // Types/Components in this list are not printed when debug is enabled 
+  // Types/Components in this list are not printed when debug is enabled
   // unless they are explicitly requested by the user in IncludeFilters.
   llvm::SmallVector<StringRef> ExcludeFilters;
-  // Types/Components in this list are printed when debug is enabled if 
+  // Types/Components in this list are printed when debug is enabled if
   // the debug level is equal or higher than the specified level.
   llvm::SmallVector<DebugFilter> IncludeFilters;
 };
@@ -315,11 +315,11 @@ struct DebugSettings {
     Settings.Enabled = true;
 
     // Messages with Type/Components added to the exclude list are not
-    // not printed when debug is enabled unless they are explicitly 
+    // not printed when debug is enabled unless they are explicitly
     // requested by the user.
     // Eventuall this should be configured from the upper layers but
     // for now we can hardcode some excluded types here like:
-    // Settings.ExcludeFilters.push_back(Type); 
+    // Settings.ExcludeFilters.push_back(Type);
 
     if (!EnvRef.getAsInteger(10, Settings.DefaultLevel))
       return;
@@ -333,12 +333,12 @@ struct DebugSettings {
 
       // Remove from ExcludeFilters if present
       Settings.ExcludeFilters.erase(
-            std::remove_if(Settings.ExcludeFilters.begin(),
-                           Settings.ExcludeFilters.end(),
-                           [&](StringRef OutType) {
-                             return OutType.equals_insensitive(Filter.Type);
-                           }),
-            Settings.ExcludeFilters.end());
+          std::remove_if(Settings.ExcludeFilters.begin(),
+                         Settings.ExcludeFilters.end(),
+                         [&](StringRef OutType) {
+                           return OutType.equals_insensitive(Filter.Type);
+                         }),
+          Settings.ExcludeFilters.end());
 
       Settings.IncludeFilters.push_back(Filter);
     }
@@ -356,8 +356,7 @@ shouldPrintDebug(const char *Component, const char *Type, uint32_t &Level) {
     return false;
 
   for (const auto &Filter : Settings.ExcludeFilters) {
-    if (Filter.equals_insensitive(Type) ||
-        Filter.equals_insensitive(Component))
+    if (Filter.equals_insensitive(Type) || Filter.equals_insensitive(Component))
       return false;
   }
 
@@ -372,8 +371,7 @@ shouldPrintDebug(const char *Component, const char *Type, uint32_t &Level) {
   for (const auto &DT : Settings.IncludeFilters) {
     if (DT.Level < Level)
       continue;
-    if (DT.Type.equals_insensitive("all") ||
-        DT.Type.equals_insensitive(Type) ||
+    if (DT.Type.equals_insensitive("all") || DT.Type.equals_insensitive(Type) ||
         DT.Type.equals_insensitive(Component)) {
       Level = DT.Level;
       return true;

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -272,7 +272,7 @@ struct DebugSettings {
   bool Enabled = false;
   uint32_t DefaultLevel = 1;
   llvm::SmallVector<StringRef> ExcludeFilters;
-  llvm::SmallVector<DebugFilter> Filters;
+  llvm::SmallVector<DebugFilter> IncludeFilters;
 };
 
 [[maybe_unused]] static DebugFilter parseDebugFilter(StringRef Filter) {
@@ -336,7 +336,7 @@ struct DebugSettings {
                            }),
             Settings.ExcludeFilters.end());
 
-      Settings.Filters.push_back(Filter);
+      Settings.IncludeFilters.push_back(Filter);
     }
   });
 
@@ -357,7 +357,7 @@ shouldPrintDebug(const char *Component, const char *Type, uint32_t &Level) {
       return false;
   }
 
-  if (Settings.Filters.empty()) {
+  if (Settings.IncludeFilters.empty()) {
     if (Level <= Settings.DefaultLevel) {
       Level = Settings.DefaultLevel;
       return true;
@@ -365,7 +365,7 @@ shouldPrintDebug(const char *Component, const char *Type, uint32_t &Level) {
     return false;
   }
 
-  for (const auto &DT : Settings.Filters) {
+  for (const auto &DT : Settings.IncludeFilters) {
     if (DT.Level < Level)
       continue;
     if (DT.Type.equals_insensitive("all") ||


### PR DESCRIPTION
Allow a to define a set of Types that are not shown by default when doing default debug loggin (e.g., LIBOMPTARGET_DEBUG=All). 

Users can enable output of those types of messages by explicitly adding them to LIBOMPTARGET_DEBUG.

Used to implement: #180545