### PR TITLE
[SafeStack] Fix crashing with scalable TypeSizes

### DIFF
--- a/llvm/lib/CodeGen/SafeStack.cpp
+++ b/llvm/lib/CodeGen/SafeStack.cpp
@@ -177,6 +177,8 @@ class SafeStack {
 
   bool IsMemIntrinsicSafe(const MemIntrinsic *MI, const Use &U,
                           const Value *AllocaPtr, uint64_t AllocaSize);
+  bool IsAccessSafe(Value *Addr, TypeSize Size, const Value *AllocaPtr,
+                    uint64_t AllocaSize);
   bool IsAccessSafe(Value *Addr, uint64_t Size, const Value *AllocaPtr,
                     uint64_t AllocaSize);
 
@@ -202,6 +204,16 @@ uint64_t SafeStack::getStaticAllocaAllocationSize(const AllocaInst* AI) {
     if (Size->isFixed())
       return Size->getFixedValue();
   return 0;
+}
+
+bool SafeStack::IsAccessSafe(Value *Addr, TypeSize AccessSize,
+                             const Value *AllocaPtr, uint64_t AllocaSize) {
+  if (AccessSize.isScalable()) {
+    // In case we don't know the size at compile time we cannot verify if the
+    // access is safe.
+    return false;
+  }
+  return IsAccessSafe(Addr, AccessSize.getFixedValue(), AllocaPtr, AllocaSize);
 }
 
 bool SafeStack::IsAccessSafe(Value *Addr, uint64_t AccessSize,

--- a/llvm/test/CodeGen/AArch64/safestack_scalar.ll
+++ b/llvm/test/CodeGen/AArch64/safestack_scalar.ll
@@ -1,0 +1,17 @@
+; RUN: llc -mtriple=aarch64-linux-gnu -stop-after=safe-stack < %s | FileCheck %s
+
+define void @test_sve() safestack {
+entry:
+  %v = alloca <vscale x 16 x i8>, align 16
+  %val = load <vscale x 16 x i8>, ptr %v
+  ret void
+}
+
+; CHECK-LABEL: define void @test_sve(
+; CHECK: [[USP:%.*]] = load ptr, ptr @__safestack_unsafe_stack_ptr
+; CHECK: [[USST:%.*]] = getelementptr i8, ptr [[USP]], i32 -16
+; CHECK: store ptr [[USST]], ptr @__safestack_unsafe_stack_ptr
+; CHECK: [[PTR:%.*]] = getelementptr i8, ptr [[USP]], i32 -16
+; CHECK: load <vscale x 16 x i8>, ptr [[PTR]]
+; CHECK: store ptr [[USP]], ptr @__safestack_unsafe_stack_ptr
+; CHECK: ret void


### PR DESCRIPTION
On e.g. aarch64 the TypeSize of scalar types can have a size that is not known at compile time.
Currently when safestack occurs those it simply crashes as described in https://github.com/llvm/llvm-project/issues/175868.

Since we cannot verify the size at compile time we simply consider the access to be unsafe (in regards to safestack).

Reproducer:
```
#include <arm_sve.h>

int main() {
    svint32_t vec = svindex_s32(0, 1);
    svint32_t res = svadd_s32_z(svptrue_b32(), vec, vec);
    int32_t buffer[1024];
    svst1_s32(svptrue_b32(), buffer, res);
    return 0;
}
```