### PR TITLE
[SimplifyLibCalls] Directly canonicalize fminimum_num to intrinsic

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/SimplifyLibCalls.h
+++ b/llvm/include/llvm/Transforms/Utils/SimplifyLibCalls.h
@@ -205,7 +205,6 @@ private:
   Value *replacePowWithSqrt(CallInst *Pow, IRBuilderBase &B);
   Value *optimizeExp2(CallInst *CI, IRBuilderBase &B);
   Value *optimizeFMinFMax(CallInst *CI, IRBuilderBase &B, Intrinsic::ID IID);
-  Value *optimizeFMinimumnumFMaximumnum(CallInst *CI, IRBuilderBase &B);
   Value *optimizeLog(CallInst *CI, IRBuilderBase &B);
   Value *optimizeSqrt(CallInst *CI, IRBuilderBase &B);
   Value *optimizeFMod(CallInst *CI, IRBuilderBase &B);

--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -1942,6 +1942,14 @@ static Value *replaceUnaryCall(CallInst *CI, IRBuilderBase &B,
   return copyFlags(*CI, NewCall);
 }
 
+static Value *replaceBinaryCall(CallInst *CI, IRBuilderBase &B,
+                                Intrinsic::ID IID) {
+  Value *NewCall = B.CreateBinaryIntrinsic(IID, CI->getArgOperand(0),
+                                           CI->getArgOperand(1), CI);
+  NewCall->takeName(CI);
+  return copyFlags(*CI, NewCall);
+}
+
 /// Return a variant of Val with float type.
 /// Currently this works in two cases: If Val is an FPExtension of a float
 /// value to something bigger, simply return the operand.
@@ -2534,30 +2542,6 @@ Value *LibCallSimplifier::optimizeFMinFMax(CallInst *CI, IRBuilderBase &B,
   FMF.setNoSignedZeros();
   return copyFlags(*CI, B.CreateBinaryIntrinsic(IID, CI->getArgOperand(0),
                                                 CI->getArgOperand(1), FMF));
-}
-
-Value *LibCallSimplifier::optimizeFMinimumnumFMaximumnum(CallInst *CI,
-                                                         IRBuilderBase &B) {
-  Module *M = CI->getModule();
-
-  // If we can shrink the call to a float function rather than a double
-  // function, do that first.
-  Function *Callee = CI->getCalledFunction();
-  StringRef Name = Callee->getName();
-  if ((Name == "fminimum_num" || Name == "fmaximum_num") &&
-      hasFloatVersion(M, Name))
-    if (Value *Ret = optimizeBinaryDoubleFP(CI, B, TLI))
-      return Ret;
-
-  // The new fminimum_num/fmaximum_num functions, unlike fmin/fmax, *are*
-  // sensitive to the sign of zero, so we don't change the fast-math flags like
-  // we did for those.
-
-  Intrinsic::ID IID = Callee->getName().starts_with("fminimum_num")
-                          ? Intrinsic::minimumnum
-                          : Intrinsic::maximumnum;
-  return copyFlags(*CI, B.CreateBinaryIntrinsic(IID, CI->getArgOperand(0),
-                                                CI->getArgOperand(1), CI));
 }
 
 Value *LibCallSimplifier::optimizeLog(CallInst *Log, IRBuilderBase &B) {
@@ -4144,10 +4128,11 @@ Value *LibCallSimplifier::optimizeFloatingPointLibCall(CallInst *CI,
   case LibFunc_fminimum_numf:
   case LibFunc_fminimum_num:
   case LibFunc_fminimum_numl:
+    return replaceBinaryCall(CI, Builder, Intrinsic::minimumnum);
   case LibFunc_fmaximum_numf:
   case LibFunc_fmaximum_num:
   case LibFunc_fmaximum_numl:
-    return optimizeFMinimumnumFMaximumnum(CI, Builder);
+    return replaceBinaryCall(CI, Builder, Intrinsic::maximumnum);
   case LibFunc_cabs:
   case LibFunc_cabsf:
   case LibFunc_cabsl:


### PR DESCRIPTION
Same as https://github.com/llvm/llvm-project/pull/177988, but for fminimum_num/fmaximum_num. Directly canonicalize these to the corresponding intrinsics, and let the shrinking happen directly on the intrinsics.