### PR TITLE
[IR] Change getParamIndexForOptionalMask to assume masked parameter is last

### DIFF
--- a/llvm/include/llvm/IR/VFABIDemangler.h
+++ b/llvm/include/llvm/IR/VFABIDemangler.h
@@ -132,11 +132,10 @@ struct VFInfo {
   /// if any exist.
   std::optional<unsigned> getParamIndexForOptionalMask() const {
     unsigned ParamCount = Shape.Parameters.size();
-    for (unsigned i = 0; i < ParamCount; ++i)
-      if (Shape.Parameters[i].ParamKind == VFParamKind::GlobalPredicate)
-        return i;
-
-    return std::nullopt;
+    if (!ParamCount || Shape.Parameters[ParamCount - 1].ParamKind !=
+                           VFParamKind::GlobalPredicate)
+      return std::nullopt;
+    return ParamCount - 1;
   }
 
   /// Returns true if at least one of the operands to the vectorized function

--- a/llvm/include/llvm/IR/VFABIDemangler.h
+++ b/llvm/include/llvm/IR/VFABIDemangler.h
@@ -134,15 +134,13 @@ struct VFInfo {
     unsigned ParamCount = Shape.Parameters.size();
 
 #ifndef NDEBUG
-    unsigned NumMaskParams = 0, MaskIdx = 0;
-    for (unsigned I = 0; I < ParamCount; I++) {
-      if (Shape.Parameters[I].ParamKind == VFParamKind::GlobalPredicate) {
-        NumMaskParams++;
-        MaskIdx = I;
-      }
-    }
+    unsigned NumMaskParams =
+        llvm::count_if(Shape.Parameters, [](const VFParameter &I) {
+          return I.ParamKind == VFParamKind::GlobalPredicate;
+        });
     assert(NumMaskParams <= 1 && "Unexpected number of mask parameters");
-    assert((!NumMaskParams || MaskIdx == (ParamCount - 1)) &&
+    assert((!NumMaskParams || Shape.Parameters[ParamCount - 1].ParamKind ==
+                                  VFParamKind::GlobalPredicate) &&
            "Mask parameter in unexpected position");
 #endif
 

--- a/llvm/include/llvm/IR/VFABIDemangler.h
+++ b/llvm/include/llvm/IR/VFABIDemangler.h
@@ -132,6 +132,20 @@ struct VFInfo {
   /// if any exist.
   std::optional<unsigned> getParamIndexForOptionalMask() const {
     unsigned ParamCount = Shape.Parameters.size();
+
+#ifndef NDEBUG
+    unsigned NumMaskParams = 0, MaskIdx = 0;
+    for (unsigned I = 0; I < ParamCount; I++) {
+      if (Shape.Parameters[I].ParamKind == VFParamKind::GlobalPredicate) {
+        NumMaskParams++;
+        MaskIdx = I;
+      }
+    }
+    assert(NumMaskParams <= 1 && "Unexpected number of mask parameters");
+    assert((!NumMaskParams || MaskIdx == (ParamCount - 1)) &&
+           "Mask parameter in unexpected position");
+#endif
+
     if (!ParamCount || Shape.Parameters[ParamCount - 1].ParamKind !=
                            VFParamKind::GlobalPredicate)
       return std::nullopt;


### PR DESCRIPTION
At the moment all code in LLVM seems to explicitly assume that the masked parameter passed to vector math functions always lives at the end of the parameter list. See VFShape::get as an example. It seems odd then for getParamIndexForOptionalMask to walk the parameter list looking for the mask. Indeed, the loop vectoriser would break if the mask was passed in any other argument position. For example, if the masked parameter position was 1 for a vector version of powf it would end up over-writing the exponent.