### PR TITLE
[NFC][lldb][windows] extract the UpdateProcThreadAttribute logic

### DIFF
--- a/lldb/include/lldb/Host/windows/ProcessLauncherWindows.h
+++ b/lldb/include/lldb/Host/windows/ProcessLauncherWindows.h
@@ -11,7 +11,7 @@
 
 #include "lldb/Host/ProcessLauncher.h"
 #include "lldb/Host/windows/windows.h"
-#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/Error.h"
 
 namespace lldb_private {
 
@@ -37,6 +37,13 @@ public:
   ///     failure.
   static llvm::ErrorOr<ProcThreadAttributeList>
   Create(STARTUPINFOEXW &startupinfoex);
+
+  /// Setup the PseudoConsole handle in the underlying
+  /// LPPROC_THREAD_ATTRIBUTE_LIST.
+  ///
+  /// \param hPC
+  ///     The handle to the PseudoConsole.
+  llvm::Error SetupPseudoConsole(HPCON hPC);
 
   ~ProcThreadAttributeList() {
     if (lpAttributeList) {

--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -106,6 +106,15 @@ ProcThreadAttributeList::Create(STARTUPINFOEXW &startupinfoex) {
   return ProcThreadAttributeList(startupinfoex.lpAttributeList);
 }
 
+llvm::Error ProcThreadAttributeList::SetupPseudoConsole(HPCON hPC) {
+  BOOL ok = UpdateProcThreadAttribute(lpAttributeList, 0,
+                                      PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, hPC,
+                                      sizeof(hPC), NULL, NULL);
+  if (!ok)
+    return llvm::errorCodeToError(llvm::mapWindowsError(GetLastError()));
+  return llvm::Error::success();
+}
+
 HostProcess
 ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
                                       Status &error) {
@@ -135,15 +144,15 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
     error = attributelist_or_err.getError();
     return HostProcess();
   }
+  ProcThreadAttributeList attributelist = std::move(*attributelist_or_err);
+
   llvm::scope_exit delete_attributelist(
       [&] { DeleteProcThreadAttributeList(startupinfoex.lpAttributeList); });
 
   std::vector<HANDLE> inherited_handles;
   if (use_pty) {
-    if (!UpdateProcThreadAttribute(startupinfoex.lpAttributeList, 0,
-                                   PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, hPC,
-                                   sizeof(hPC), NULL, NULL)) {
-      error = Status(::GetLastError(), eErrorTypeWin32);
+    if (auto err = attributelist.SetupPseudoConsole(hPC)) {
+      error = Status::FromError(std::move(err));
       return HostProcess();
     }
   } else {


### PR DESCRIPTION
This NFC patch extracts the `UpdateProcThreadAttribute` logic to a dedicated method be able to reuse it in https://github.com/llvm/llvm-project/pull/180561.