### PR TITLE
[Sema] Fix format-strings test on AIX

### DIFF
--- a/clang/test/Sema/format-strings.c
+++ b/clang/test/Sema/format-strings.c
@@ -3,12 +3,10 @@
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -triple=x86_64-unknown-fuchsia %s
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -triple=x86_64-linux-android %s
 
-#include <limits.h>
 #include <stdarg.h>
 #include <stddef.h>
 #define __need_wint_t
 #include <stddef.h> // For wint_t and wchar_t
-#include <stdint.h>
 
 typedef struct _FILE FILE;
 int fprintf(FILE *, const char *restrict, ...);
@@ -988,16 +986,11 @@ void test_promotion(void) {
 
 void test_bool(_Bool b, _Bool* bp)
 {
-  // Expect a warning if size_t/ptrdiff_t size is greater than a _Bool promoted
-  // to an int or if it might be a long int, with the same size of an int.
-#if SIZE_MAX > UINT_MAX || UINT_MAX == ULONG_MAX
+#ifndef __arm__
   printf("%zu", b); // expected-warning-re{{format specifies type 'size_t' (aka '{{.+}}') but the argument has type '_Bool'}}
-#else
-  printf("%zu", b); // no-warning
-#endif
-#if PTRDIFF_MAX > INT_MAX || INT_MAX == LONG_MAX
   printf("%td", b); // expected-warning-re{{format specifies type 'ptrdiff_t' (aka '{{.+}}') but the argument has type '_Bool'}}
 #else
+  printf("%zu", b); // no-warning
   printf("%td", b); // no-warning
 #endif
   printf("%jd", b); // expected-warning-re{{format specifies type 'intmax_t' (aka '{{.+}}') but the argument has type '_Bool'}}

--- a/clang/test/Sema/format-strings.c
+++ b/clang/test/Sema/format-strings.c
@@ -988,12 +988,14 @@ void test_promotion(void) {
 
 void test_bool(_Bool b, _Bool* bp)
 {
-#if SIZE_MAX != UINT_MAX
+  // Expect a warning if size_t/ptrdiff_t size is greater than a _Bool promoted
+  // to an int or if it might be a long int, with the same size of an int.
+#if SIZE_MAX > UINT_MAX || UINT_MAX == ULONG_MAX
   printf("%zu", b); // expected-warning-re{{format specifies type 'size_t' (aka '{{.+}}') but the argument has type '_Bool'}}
 #else
   printf("%zu", b); // no-warning
 #endif
-#if PTRDIFF_MAX != INT_MAX
+#if PTRDIFF_MAX > INT_MAX || INT_MAX == LONG_MAX
   printf("%td", b); // expected-warning-re{{format specifies type 'ptrdiff_t' (aka '{{.+}}') but the argument has type '_Bool'}}
 #else
   printf("%td", b); // no-warning


### PR DESCRIPTION
Simplify the conditional compilation and skip the problematic warnings only on 32-bit Arm.
