### PR TITLE
Revert "[NFC][LLVM][IPO] Remove pass initialization from pass constructors"

### DIFF
--- a/llvm/lib/Transforms/IPO/AlwaysInliner.cpp
+++ b/llvm/lib/Transforms/IPO/AlwaysInliner.cpp
@@ -122,7 +122,9 @@ struct AlwaysInlinerLegacyPass : public ModulePass {
       : AlwaysInlinerLegacyPass(/*InsertLifetime*/ true) {}
 
   AlwaysInlinerLegacyPass(bool InsertLifetime)
-      : ModulePass(ID), InsertLifetime(InsertLifetime) {}
+      : ModulePass(ID), InsertLifetime(InsertLifetime) {
+    initializeAlwaysInlinerLegacyPassPass(*PassRegistry::getPassRegistry());
+  }
 
   /// Main run interface method.
   bool runOnModule(Module &M) override {

--- a/llvm/lib/Transforms/IPO/BarrierNoopPass.cpp
+++ b/llvm/lib/Transforms/IPO/BarrierNoopPass.cpp
@@ -32,7 +32,9 @@ class BarrierNoop : public ModulePass {
 public:
   static char ID; // Pass identification.
 
-  BarrierNoop() : ModulePass(ID) {}
+  BarrierNoop() : ModulePass(ID) {
+    initializeBarrierNoopPass(*PassRegistry::getPassRegistry());
+  }
 
   bool runOnModule(Module &M) override { return false; }
 };

--- a/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
+++ b/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
@@ -71,7 +71,9 @@ protected:
 public:
   static char ID; // Pass identification, replacement for typeid
 
-  DAE() : ModulePass(ID) {}
+  DAE() : ModulePass(ID) {
+    initializeDAEPass(*PassRegistry::getPassRegistry());
+  }
 
   bool runOnModule(Module &M) override {
     if (skipModule(M))

--- a/llvm/lib/Transforms/IPO/GlobalDCE.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalDCE.cpp
@@ -36,7 +36,9 @@ namespace {
 class GlobalDCELegacyPass : public ModulePass {
 public:
   static char ID; // Pass identification, replacement for typeid
-  GlobalDCELegacyPass() : ModulePass(ID) {}
+  GlobalDCELegacyPass() : ModulePass(ID) {
+    initializeGlobalDCELegacyPassPass(*PassRegistry::getPassRegistry());
+  }
   bool runOnModule(Module &M) override {
     if (skipModule(M))
       return false;

--- a/llvm/lib/Transforms/IPO/IPO.cpp
+++ b/llvm/lib/Transforms/IPO/IPO.cpp
@@ -17,11 +17,10 @@
 using namespace llvm;
 
 void llvm::initializeIPO(PassRegistry &Registry) {
-  initializeAlwaysInlinerLegacyPassPass(Registry);
-  initializeBarrierNoopPass(Registry);
   initializeDAEPass(Registry);
   initializeDAHPass(Registry);
-  initializeGlobalDCELegacyPassPass(Registry);
+  initializeAlwaysInlinerLegacyPassPass(Registry);
   initializeLoopExtractorLegacyPassPass(Registry);
   initializeSingleLoopExtractorPass(Registry);
+  initializeBarrierNoopPass(Registry);
 }

--- a/llvm/lib/Transforms/IPO/LoopExtractor.cpp
+++ b/llvm/lib/Transforms/IPO/LoopExtractor.cpp
@@ -39,7 +39,9 @@ struct LoopExtractorLegacyPass : public ModulePass {
   unsigned NumLoops;
 
   explicit LoopExtractorLegacyPass(unsigned NumLoops = ~0)
-      : ModulePass(ID), NumLoops(NumLoops) {}
+      : ModulePass(ID), NumLoops(NumLoops) {
+    initializeLoopExtractorLegacyPassPass(*PassRegistry::getPassRegistry());
+  }
 
   bool runOnModule(Module &M) override;
 

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -389,7 +389,6 @@ int main(int argc, char **argv) {
   initializeUnreachableBlockElimLegacyPassPass(*Registry);
   initializeConstantHoistingLegacyPassPass(*Registry);
   initializeScalarOpts(*Registry);
-  initializeIPO(*Registry);
   initializeVectorization(*Registry);
   initializeScalarizeMaskedMemIntrinLegacyPassPass(*Registry);
   initializeTransformUtils(*Registry);


### PR DESCRIPTION
Reverts llvm/llvm-project#180154

It seems to cause llc build failures, likely due to missing `ipo` dependency.