### PR TITLE
[mlir][linalg] Use inferConvolutionDims for generic convolution downscaling

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
@@ -288,9 +288,13 @@ def DecomposeOp : Op<Transform_Dialect, "structured.decompose",
      TransformEachOpTrait,
      ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
-    Decomposes named complex operations, such as higher-dimensional
-    (depthwise) convolutions, into combinations of lower-dimensional equivalents
-    when possible.
+    Decomposes higher-dimensional convolution ops into lower-dimensional
+    equivalents when possible. This operates on both named ops and equivalent
+    `linalg.generic` ops that have convolution-like structure (as determined
+    by `inferConvolutionDims`).
+
+    The transformation always attempts to specialize the result back to a named
+    op when possible.
 
     #### Return modes
 

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -1640,10 +1640,11 @@ FailureOr<linalg::GenericOp> deduplicateOperandsAndRemoveDeadResults(
 // functional-stye API call.
 //===----------------------------------------------------------------------===//
 
-/// Rewrite 2-D convolution/pooling/depthwise ops with size-1 window dimensions
+/// Rewrite convolution/pooling/depthwise ops with size-1 window dimensions
 /// into lower-dimensional ops. Uses `inferConvolutionDims` to work with any
 /// layout and handles both named ops and equivalent linalg.generic ops
 /// uniformly. The result is specialized back to a named op when possible.
+/// TODO: Support n-D to (n-1)-D downscaling.
 FailureOr<LinalgOp> downscaleSizeOneWindowedConvolution(RewriterBase &rewriter,
                                                         LinalgOp op);
 

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -1641,10 +1641,11 @@ FailureOr<linalg::GenericOp> deduplicateOperandsAndRemoveDeadResults(
 //===----------------------------------------------------------------------===//
 
 /// Rewrite 2-D convolution/pooling/depthwise ops with size-1 window dimensions
-/// into lower-dimensional linalg.generic ops.
-/// Handles both named ops and equivalent linalg.generic ops uniformly.
-FailureOr<linalg::GenericOp>
-downscaleSizeOneWindowedConvolution(RewriterBase &rewriter, LinalgOp op);
+/// into lower-dimensional ops. Uses `inferConvolutionDims` to work with any
+/// layout and handles both named ops and equivalent linalg.generic ops
+/// uniformly. The result is specialized back to a named op when possible.
+FailureOr<LinalgOp> downscaleSizeOneWindowedConvolution(RewriterBase &rewriter,
+                                                        LinalgOp op);
 
 /// Pattern wrapper around `downscaleSizeOneWindowedConvolution`.
 struct DownscaleSizeOneWindowedConvolution final

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -1640,54 +1640,22 @@ FailureOr<linalg::GenericOp> deduplicateOperandsAndRemoveDeadResults(
 // functional-stye API call.
 //===----------------------------------------------------------------------===//
 
-/// Rewrites 2-D convolution ops with size-1 window dimensions into 1-D
-/// convolution ops. Works with both named ops and equivalent generic ops.
-template <typename Conv2DOp, typename Conv1DOp>
-struct DownscaleSizeOneWindowed2DConvolution final
+/// Rewrite 2-D convolution/pooling/depthwise ops with size-1 window dimensions
+/// into lower-dimensional linalg.generic ops.
+/// Handles both named ops and equivalent linalg.generic ops uniformly.
+FailureOr<linalg::GenericOp>
+downscaleSizeOneWindowedConvolution(RewriterBase &rewriter, LinalgOp op);
+
+/// Pattern wrapper around `downscaleSizeOneWindowedConvolution`.
+struct DownscaleSizeOneWindowedConvolution final
     : public OpInterfaceRewritePattern<LinalgOp> {
-  using OpInterfaceRewritePattern<LinalgOp>::OpInterfaceRewritePattern;
-
-  FailureOr<Conv1DOp> returningMatchAndRewrite(LinalgOp convOp,
-                                               PatternRewriter &rewriter) const;
-
-  LogicalResult matchAndRewrite(LinalgOp convOp,
-                                PatternRewriter &rewriter) const override {
-    return returningMatchAndRewrite(convOp, rewriter);
-  }
-};
-
-extern template struct DownscaleSizeOneWindowed2DConvolution<Conv2DNhwcHwcfOp,
-                                                             Conv1DNwcWcfOp>;
-extern template struct DownscaleSizeOneWindowed2DConvolution<Conv2DNchwFchwOp,
-                                                             Conv1DNcwFcwOp>;
-
-/// Rewrites 2-D depthwise convolution ops with size-1 (w, kw) or (h, kh)
-/// dimensions into 1-D depthwise convolution ops.
-struct DownscaleDepthwiseConv2DNhwcHwcOp final
-    : public OpInterfaceRewritePattern<LinalgOp> {
-  DownscaleDepthwiseConv2DNhwcHwcOp(MLIRContext *context,
-                                    PatternBenefit benefit = 1)
+  DownscaleSizeOneWindowedConvolution(MLIRContext *context,
+                                      PatternBenefit benefit = 1)
       : OpInterfaceRewritePattern<LinalgOp>(context, benefit) {}
 
-  FailureOr<DepthwiseConv1DNwcWcOp>
-  returningMatchAndRewrite(LinalgOp convOp, PatternRewriter &rewriter) const;
-
-  LogicalResult matchAndRewrite(LinalgOp convOp,
+  LogicalResult matchAndRewrite(LinalgOp op,
                                 PatternRewriter &rewriter) const override {
-    return returningMatchAndRewrite(convOp, rewriter);
-  }
-};
-
-struct DownscaleConv2DOp final : public OpInterfaceRewritePattern<LinalgOp> {
-  DownscaleConv2DOp(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpInterfaceRewritePattern<LinalgOp>(context, benefit) {}
-
-  FailureOr<Conv1DOp> returningMatchAndRewrite(LinalgOp convOp,
-                                               PatternRewriter &rewriter) const;
-
-  LogicalResult matchAndRewrite(LinalgOp convOp,
-                                PatternRewriter &rewriter) const override {
-    return returningMatchAndRewrite(convOp, rewriter);
+    return downscaleSizeOneWindowedConvolution(rewriter, op);
   }
 };
 

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -1647,19 +1647,6 @@ FailureOr<linalg::GenericOp> deduplicateOperandsAndRemoveDeadResults(
 FailureOr<LinalgOp> downscaleSizeOneWindowedConvolution(RewriterBase &rewriter,
                                                         LinalgOp op);
 
-/// Pattern wrapper around `downscaleSizeOneWindowedConvolution`.
-struct DownscaleSizeOneWindowedConvolution final
-    : public OpInterfaceRewritePattern<LinalgOp> {
-  DownscaleSizeOneWindowedConvolution(MLIRContext *context,
-                                      PatternBenefit benefit = 1)
-      : OpInterfaceRewritePattern<LinalgOp>(context, benefit) {}
-
-  LogicalResult matchAndRewrite(LinalgOp op,
-                                PatternRewriter &rewriter) const override {
-    return downscaleSizeOneWindowedConvolution(rewriter, op);
-  }
-};
-
 ///
 /// Linalg generalization pattern.
 ///

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -1634,19 +1634,21 @@ decomposeWinogradOutputTransformOp(RewriterBase &rewriter,
 FailureOr<linalg::GenericOp> deduplicateOperandsAndRemoveDeadResults(
     RewriterBase &rewriter, linalg::GenericOp genericOp, bool removeOutputs);
 
+/// Rewrite convolution/pooling/depthwise ops with size-1 window dimensions
+/// into lower-dimensional ops. Uses `inferConvolutionDims` to work with any
+/// layout and handles both named ops and equivalent linalg.generic ops
+/// uniformly. The result is specialized back to a named op if the input was a
+/// named op.
+/// TODO: Support n-D to (n-1)-D downscaling. Currently it only support 2D->1D
+/// downscaling.
+FailureOr<LinalgOp> downscaleSizeOneWindowedConvolution(RewriterBase &rewriter,
+                                                        LinalgOp op);
+
 //===----------------------------------------------------------------------===//
 // Rewrite patterns wrapping transformations.
 // TODO: every single such pattern should be a close to noop wrapper around a
 // functional-stye API call.
 //===----------------------------------------------------------------------===//
-
-/// Rewrite convolution/pooling/depthwise ops with size-1 window dimensions
-/// into lower-dimensional ops. Uses `inferConvolutionDims` to work with any
-/// layout and handles both named ops and equivalent linalg.generic ops
-/// uniformly. The result is specialized back to a named op when possible.
-/// TODO: Support n-D to (n-1)-D downscaling.
-FailureOr<LinalgOp> downscaleSizeOneWindowedConvolution(RewriterBase &rewriter,
-                                                        LinalgOp op);
 
 ///
 /// Linalg generalization pattern.

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -484,7 +484,7 @@ transform::DecomposeOp::applyToOne(transform::TransformRewriter &rewriter,
                                    LinalgOp target,
                                    transform::ApplyToEachResultList &results,
                                    transform::TransformState &state) {
-  FailureOr<linalg::GenericOp> res =
+  FailureOr<linalg::LinalgOp> res =
       downscaleSizeOneWindowedConvolution(rewriter, target);
   if (succeeded(res)) {
     results.push_back(*res);

--- a/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp
@@ -1504,7 +1504,7 @@ linalg::downscaleSizeOneWindowedConvolution(RewriterBase &rewriter,
   if (failed(maybeDims))
     return failure();
 
-  // Requires exactly 2 spatial dimensions to downscale to 1D.
+  // Currently supports only 2D convolutions.
   if (maybeDims->outputImage.size() != 2 || maybeDims->filterLoop.size() != 2)
     return failure();
 

--- a/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp
@@ -1614,11 +1614,14 @@ linalg::downscaleSizeOneWindowedConvolution(RewriterBase &rewriter,
                                 mapping.lookup(yield.getOperand(0)));
       });
 
-  // Try to specialize the generic back to a named op if possible.
+  // Try to specialize the generic back to a named op only if the input was
+  // already a specialized (named) op.
   LinalgOp resultOp = newOp;
-  FailureOr<LinalgOp> specializedOp = specializeGenericOp(rewriter, newOp);
-  if (succeeded(specializedOp))
-    resultOp = *specializedOp;
+  if (!isa<GenericOp>(op)) {
+    FailureOr<LinalgOp> specializedOp = specializeGenericOp(rewriter, newOp);
+    if (succeeded(specializedOp))
+      resultOp = *specializedOp;
+  }
 
   // Insert result back into original shape.
   Value result = tensor::createCanonicalRankReducingInsertSliceOp(

--- a/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp
@@ -1530,20 +1530,17 @@ linalg::downscaleSizeOneWindowedConvolution(RewriterBase &rewriter,
   if (!canRemoveSpatial0 && !canRemoveSpatial1)
     return failure();
 
-  // Prioritize dropping the leading spatial dimension if both are removable.
-  bool removeSpatial0 = canRemoveSpatial0;
-
   // Determine which loop dims to remove (output spatial + corresponding filter)
+  // and sort for correct index compression when removing dimensions from affine
+  // maps.
   SmallVector<unsigned> loopDimsToRemove;
-  if (removeSpatial0) {
+  if (canRemoveSpatial0) {
     loopDimsToRemove.push_back(outSpatial0);
     loopDimsToRemove.push_back(filterSpatial0);
   } else {
     loopDimsToRemove.push_back(outSpatial1);
     loopDimsToRemove.push_back(filterSpatial1);
   }
-  // Sort for correct index compression when removing dimensions from affine
-  // maps.
   llvm::sort(loopDimsToRemove);
 
   // Create new indexing maps with dimensions removed.
@@ -1551,9 +1548,7 @@ linalg::downscaleSizeOneWindowedConvolution(RewriterBase &rewriter,
   MLIRContext *ctx = op.getContext();
   unsigned numDims = op.getNumLoops();
   unsigned newNumDims = numDims - loopDimsToRemove.size();
-
   for (AffineMap map : op.getIndexingMapsArray()) {
-    // Remove the loop dimensions from the map.
     SmallVector<AffineExpr> newResults;
     for (AffineExpr expr : map.getResults()) {
       auto newExpr =
@@ -1584,35 +1579,19 @@ linalg::downscaleSizeOneWindowedConvolution(RewriterBase &rewriter,
     newInputs.push_back(reduced);
   }
 
-  SmallVector<Value> newOutputs;
-  Value originalOutput;
-  SmallVector<OpOperand *> initOperands =
-      llvm::to_vector(llvm::make_pointer_range(op.getDpsInitsMutable()));
-  for (OpOperand *output : initOperands) {
-    originalOutput = output->get();
-    AffineMap map = op.getMatchingIndexingMap(output);
-    SmallVector<unsigned> tensorDimsToRemove =
-        getResultIndicesReferencingDims(map, loopDimsToRemove);
-    Value reduced = createRankReducingExtractSlice(rewriter, loc, output->get(),
-                                                   tensorDimsToRemove);
-    newOutputs.push_back(reduced);
-  }
+  OpOperand &output = *op.getDpsInitsMutable().begin();
+  AffineMap outputMap = op.getMatchingIndexingMap(&output);
+  SmallVector<unsigned> outputDimsToRemove =
+      getResultIndicesReferencingDims(outputMap, loopDimsToRemove);
+  Value newOutput = createRankReducingExtractSlice(rewriter, loc, output.get(),
+                                                   outputDimsToRemove);
 
   // Create new linalg.generic with reduced dimensions.
-  auto newOp = linalg::GenericOp::create(
-      rewriter, loc, TypeRange{newOutputs[0].getType()}, newInputs, newOutputs,
-      newMaps, newIterTypes,
-      [&](OpBuilder &b, Location nestedLoc, ValueRange args) {
-        IRMapping mapping;
-        for (auto [oldArg, newArg] :
-             llvm::zip(op.getBlock()->getArguments(), args))
-          mapping.map(oldArg, newArg);
-        for (Operation &bodyOp : op.getBlock()->without_terminator())
-          b.clone(bodyOp, mapping);
-        auto yield = cast<linalg::YieldOp>(op.getBlock()->getTerminator());
-        linalg::YieldOp::create(b, nestedLoc,
-                                mapping.lookup(yield.getOperand(0)));
-      });
+  auto newOp =
+      linalg::GenericOp::create(rewriter, loc, TypeRange{newOutput.getType()},
+                                newInputs, newOutput, newMaps, newIterTypes);
+  rewriter.inlineRegionBefore(op->getRegion(0), newOp.getRegion(),
+                              newOp.getRegion().begin());
 
   // Try to specialize the generic back to a named op only if the input was
   // already a specialized (named) op.
@@ -1625,7 +1604,7 @@ linalg::downscaleSizeOneWindowedConvolution(RewriterBase &rewriter,
 
   // Insert result back into original shape.
   Value result = tensor::createCanonicalRankReducingInsertSliceOp(
-      rewriter, loc, resultOp->getResult(0), originalOutput);
+      rewriter, loc, resultOp->getResult(0), output.get());
 
   rewriter.replaceOp(op, result);
   return resultOp;

--- a/mlir/test/Dialect/Linalg/transform-op-decompose.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-decompose.mlir
@@ -1,7 +1,20 @@
-// RUN: mlir-opt --transform-interpreter --linalg-specialize-generic-ops --split-input-file %s | FileCheck %s
+// RUN: mlir-opt --transform-interpreter --split-input-file %s | FileCheck %s
 // Test the same patterns on generic convolution ops by first generalizing the
 // named ops. This avoids duplicating lit tests for linalg.generic conv ops.
-// RUN: mlir-opt --linalg-generalize-named-ops --transform-interpreter --linalg-specialize-generic-ops --split-input-file %s | FileCheck %s
+// RUN: mlir-opt --linalg-generalize-named-ops --transform-interpreter --split-input-file %s | FileCheck %s
+
+// Expected indexing maps for batchless conv_1d_nwc_wcf.
+// CHECK-DAG:  #[[$CONV_I:.+]] = affine_map<(d0, d1, d2, d3) -> (d0 + d2, d3)>
+// CHECK-DAG:  #[[$CONV_F:.+]] = affine_map<(d0, d1, d2, d3) -> (d2, d3, d1)>
+// CHECK-DAG:  #[[$CONV_O:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+
+// Expected indexing maps for batchless depthwise_conv_1d_wc_wcf.
+// CHECK-DAG:  #[[$DW_I:.+]] = affine_map<(d0, d1, d2) -> (d0 + d2, d1)>
+// CHECK-DAG:  #[[$DW_F:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+
+// Expected indexing maps for batchless pooling_cw_min.
+// CHECK-DAG:  #[[$POOL_I:.+]] = affine_map<(d0, d1, d2) -> (d0, d1 + d2)>
+// CHECK-DAG:  #[[$POOL_F:.+]] = affine_map<(d0, d1, d2) -> (d2)>
 
 // CHECK-DAG:  #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 // CHECK-DAG:  #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -227,6 +240,95 @@ func.func @pooling_nchw_max(%input: tensor<?x?x1x?xf32>, %filter: tensor<1x?xf32
   return %0 : tensor<?x?x1x?xf32>
 }
 
+#map_conv_i = affine_map<(oh, ow, f, kh, kw, c) -> (oh + kh, ow + kw, c)>
+#map_conv_f = affine_map<(oh, ow, f, kh, kw, c) -> (kh, kw, c, f)>
+#map_conv_o = affine_map<(oh, ow, f, kh, kw, c) -> (oh, ow, f)>
+
+// CHECK-LABEL: @batchless_conv_2d_hwc_hwcf
+// CHECK-SAME:    %[[ARG0:.+]]: tensor<1x14x8xf32>
+// CHECK-SAME:    %[[ARG1:.+]]: tensor<1x3x8x16xf32>
+// CHECK-SAME:    %[[ARG2:.+]]: tensor<1x12x16xf32>
+func.func @batchless_conv_2d_hwc_hwcf(%input: tensor<1x14x8xf32>, %filter: tensor<1x3x8x16xf32>, %output: tensor<1x12x16xf32>) -> tensor<1x12x16xf32> {
+  // CHECK:       %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]]
+  // CHECK:       %[[SLICE1:.+]] = tensor.extract_slice %[[ARG1]]
+  // CHECK:       %[[SLICE2:.+]] = tensor.extract_slice %[[ARG2]]
+  // CHECK:       %[[SLICERES:.+]] = linalg.generic
+  // CHECK-SAME:    indexing_maps = [#[[$CONV_I]], #[[$CONV_F]], #[[$CONV_O]]]
+  // CHECK-SAME:    iterator_types = ["parallel", "parallel", "reduction", "reduction"]
+  // CHECK:       %[[RES:.+]] = tensor.insert_slice %[[SLICERES]] into %[[ARG2]]
+  %0 = linalg.generic {
+    indexing_maps = [#map_conv_i, #map_conv_f, #map_conv_o],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<1x14x8xf32>, tensor<1x3x8x16xf32>)
+    outs(%output : tensor<1x12x16xf32>) {
+  ^bb0(%in: f32, %fil: f32, %out: f32):
+    %mul = arith.mulf %in, %fil : f32
+    %add = arith.addf %out, %mul : f32
+    linalg.yield %add : f32
+  } -> tensor<1x12x16xf32>
+  // CHECK:       return %[[RES]]
+  return %0 : tensor<1x12x16xf32>
+}
+
+#map_dw_i = affine_map<(oh, ow, c, kh, kw) -> (oh + kh, ow + kw, c)>
+#map_dw_f = affine_map<(oh, ow, c, kh, kw) -> (kh, kw, c)>
+#map_dw_o = affine_map<(oh, ow, c, kh, kw) -> (oh, ow, c)>
+
+// CHECK-LABEL: @batchless_depthwise_conv_2d_hwc_hwc
+// CHECK-SAME:    %[[ARG0:.+]]: tensor<1x14x8xf32>
+// CHECK-SAME:    %[[ARG1:.+]]: tensor<1x3x8xf32>
+// CHECK-SAME:    %[[ARG2:.+]]: tensor<1x12x8xf32>
+func.func @batchless_depthwise_conv_2d_hwc_hwc(%input: tensor<1x14x8xf32>, %filter: tensor<1x3x8xf32>, %output: tensor<1x12x8xf32>) -> tensor<1x12x8xf32> {
+  // CHECK:       %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]]
+  // CHECK:       %[[SLICE1:.+]] = tensor.extract_slice %[[ARG1]]
+  // CHECK:       %[[SLICE2:.+]] = tensor.extract_slice %[[ARG2]]
+  // CHECK:       %[[SLICERES:.+]] = linalg.generic
+  // CHECK-SAME:    indexing_maps = [#[[$DW_I]], #[[$DW_F]], #[[$MAP1]]]
+  // CHECK-SAME:    iterator_types = ["parallel", "parallel", "reduction"]
+  // CHECK:       %[[RES:.+]] = tensor.insert_slice %[[SLICERES]] into %[[ARG2]]
+  %0 = linalg.generic {
+    indexing_maps = [#map_dw_i, #map_dw_f, #map_dw_o],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<1x14x8xf32>, tensor<1x3x8xf32>)
+    outs(%output : tensor<1x12x8xf32>) {
+  ^bb0(%in: f32, %fil: f32, %out: f32):
+    %mul = arith.mulf %in, %fil : f32
+    %add = arith.addf %out, %mul : f32
+    linalg.yield %add : f32
+  } -> tensor<1x12x8xf32>
+  // CHECK:       return %[[RES]]
+  return %0 : tensor<1x12x8xf32>
+}
+
+#map_pool_i = affine_map<(c, oh, ow, kh, kw) -> (c, oh + kh, ow + kw)>
+#map_pool_f = affine_map<(c, oh, ow, kh, kw) -> (kh, kw)>
+#map_pool_o = affine_map<(c, oh, ow, kh, kw) -> (c, oh, ow)>
+
+// CHECK-LABEL: @batchless_pooling_chw_min
+// CHECK-SAME:    %[[ARG0:.+]]: tensor<8x1x14xf32>
+// CHECK-SAME:    %[[ARG1:.+]]: tensor<1x3xf32>
+// CHECK-SAME:    %[[ARG2:.+]]: tensor<8x1x12xf32>
+func.func @batchless_pooling_chw_min(%input: tensor<8x1x14xf32>, %filter: tensor<1x3xf32>, %output: tensor<8x1x12xf32>) -> tensor<8x1x12xf32> {
+  // CHECK:       %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]]
+  // CHECK:       %[[SLICE1:.+]] = tensor.extract_slice %[[ARG1]]
+  // CHECK:       %[[SLICE2:.+]] = tensor.extract_slice %[[ARG2]]
+  // CHECK:       %[[SLICERES:.+]] = linalg.generic
+  // CHECK-SAME:    indexing_maps = [#[[$POOL_I]], #[[$POOL_F]], #[[$MAP1]]]
+  // CHECK-SAME:    iterator_types = ["parallel", "parallel", "reduction"]
+  // CHECK:       %[[RES:.+]] = tensor.insert_slice %[[SLICERES]] into %[[ARG2]]
+  %0 = linalg.generic {
+    indexing_maps = [#map_pool_i, #map_pool_f, #map_pool_o],
+    iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+  } ins(%input, %filter : tensor<8x1x14xf32>, tensor<1x3xf32>)
+    outs(%output : tensor<8x1x12xf32>) {
+  ^bb0(%in: f32, %fil: f32, %out: f32):
+    %min = arith.minimumf %out, %in : f32
+    linalg.yield %min : f32
+  } -> tensor<8x1x12xf32>
+  // CHECK:       return %[[RES]]
+  return %0 : tensor<8x1x12xf32>
+}
+
 func.func @softmax(%arg0: tensor<2x16x32xf32>, %dst: tensor<2x16x32xf32>) -> tensor<2x16x32xf32> {
   %1 = linalg.softmax dimension(2) ins(%arg0 : tensor<2x16x32xf32>) outs(%dst: tensor<2x16x32xf32>) -> tensor<2x16x32xf32>
   return %1 : tensor<2x16x32xf32>
@@ -234,19 +336,39 @@ func.func @softmax(%arg0: tensor<2x16x32xf32>, %dst: tensor<2x16x32xf32>) -> ten
 
 // CHECK-LABEL:      func.func @softmax(
 // CHECK-SAME:           %[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x16x32xf32>, %[[DST:[a-zA-Z0-9_]+]]: tensor<2x16x32xf32>) -> tensor<2x16x32xf32> {
-// CHECK:        linalg.fill
-// CHECK:        linalg.generic
-// CHECK:          arith.maxnumf
-// CHECK:        linalg.broadcast
-// CHECK:        linalg.generic
-// CHECK:          arith.subf
-// CHECK:          math.exp
-// CHECK:        linalg.fill
-// CHECK:        linalg.generic
-// CHECK:          arith.addf
-// CHECK:        linalg.broadcast
-// CHECK:        linalg.div
-// CHECK:        return
+// CHECK-DAG:        %[[D1:.+]] = tensor.empty() : tensor<2x16xf32>
+// CHECK-DAG:        %[[CST:.+]] = arith.constant 0xFFC00000 : f32
+// CHECK:        %[[D2:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D1]] : tensor<2x16xf32>) -> tensor<2x16xf32>
+// CHECK:        %[[D3:.+]] = linalg.generic {indexing_maps = [#[[$MAP]], #[[$MAP1]]], iterator_types = ["parallel",
+// CHECK-SAME:     "parallel", "reduction"]} ins(%[[ARG0]] : tensor<2x16x32xf32>) outs(%[[D2]] : tensor<2x16xf32>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:          %[[D8:.+]] = arith.maxnumf %[[IN]], %[[OUT]] : f32
+// CHECK:          linalg.yield %[[D8]] : f32
+// CHECK:        } -> tensor<2x16xf32>
+// CHECK:        %[[D4:.+]] = linalg.generic {indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP]]], iterator_types =
+// CHECK-SAME:     ["parallel", "parallel", "parallel"]} ins(%[[ARG0]], %[[D3]] : tensor<2x16x32xf32>, tensor<2x16xf32>)
+// CHECK-SAME:     outs(%[[DST]] : tensor<2x16x32xf32>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f32, %[[IN_1:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:          %[[D8]] = arith.subf %[[IN]], %[[IN_1]] : f32
+// CHECK:          %[[D9:.+]] = math.exp %[[D8]] : f32
+// CHECK:          linalg.yield %[[D9]] : f32
+// CHECK:        } -> tensor<2x16x32xf32>
+// CHECK:        %[[CST_0:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[D5:.+]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[D1]] : tensor<2x16xf32>) -> tensor<2x16xf32>
+// CHECK:        %[[D6:.+]] = linalg.generic {indexing_maps = [#[[$MAP]], #[[$MAP1]]], iterator_types = ["parallel",
+// CHECK-SAME:     "parallel", "reduction"]} ins(%[[D4]] : tensor<2x16x32xf32>) outs(%[[D5]] : tensor<2x16xf32>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:          %[[D8]] = arith.addf %[[IN]], %[[OUT]] : f32
+// CHECK:          linalg.yield %[[D8]] : f32
+// CHECK:        } -> tensor<2x16xf32>
+// CHECK:        %[[D7:.+]] = linalg.generic {indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP]]], iterator_types =
+// CHECK-SAME:     ["parallel", "parallel", "parallel"]} ins(%[[D4]], %[[D6]] : tensor<2x16x32xf32>, tensor<2x16xf32>)
+// CHECK-SAME:     outs(%[[DST]] : tensor<2x16x32xf32>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f32, %[[IN_1:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:          %[[D8]] = arith.divf %[[IN]], %[[IN_1]] : f32
+// CHECK:          linalg.yield %[[D8]] : f32
+// CHECK:        } -> tensor<2x16x32xf32>
+// CHECK:        return %[[D7]] : tensor<2x16x32xf32>
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {

--- a/mlir/test/Dialect/Linalg/transform-op-decompose.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-decompose.mlir
@@ -1,7 +1,4 @@
 // RUN: mlir-opt --transform-interpreter --split-input-file %s | FileCheck %s
-// Test the same patterns on generic convolution ops by first generalizing the
-// named ops. This avoids duplicating lit tests for linalg.generic conv ops.
-// RUN: mlir-opt --linalg-generalize-named-ops --transform-interpreter --split-input-file %s | FileCheck %s
 
 // Expected indexing maps for batchless conv_1d_nwc_wcf.
 // CHECK-DAG:  #[[$CONV_I:.+]] = affine_map<(d0, d1, d2, d3) -> (d0 + d2, d3)>
@@ -18,6 +15,11 @@
 
 // CHECK-DAG:  #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 // CHECK-DAG:  #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// Expected indexing maps for 1D conv (cross-conv after downscale from generic).
+// CHECK-DAG:  #[[$CROSS_1D_I:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
+// CHECK-DAG:  #[[$CROSS_1D_F:.+]] = affine_map<(d0, d1) -> (d1)>
+// CHECK-DAG:  #[[$CROSS_1D_O:.+]] = affine_map<(d0, d1) -> (d0)>
 
 // CHECK-LABEL: @conv_2d_nhwc_hwcf
 // CHECK-SAME: %[[ARG0:.+]]: tensor<?x1x?x?xf32>,
@@ -341,7 +343,9 @@ func.func @cross_conv_nonstandard_loop_order(%input: tensor<1x15xf32>, %filter: 
   // CHECK:       %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]]
   // CHECK:       %[[SLICE1:.+]] = tensor.extract_slice %[[ARG1]]
   // CHECK:       %[[SLICE2:.+]] = tensor.extract_slice %[[ARG2]]
-  // CHECK:       %[[SLICERES:.+]] = linalg.conv_1d
+  // CHECK:       %[[SLICERES:.+]] = linalg.generic
+  // CHECK-SAME:    indexing_maps = [#[[$CROSS_1D_I]], #[[$CROSS_1D_F]], #[[$CROSS_1D_O]]]
+  // CHECK-SAME:    iterator_types = ["parallel", "reduction"]
   // CHECK:       %[[RES:.+]] = tensor.insert_slice %[[SLICERES]] into %[[ARG2]]
   // CHECK:       return %[[RES]]
   %0 = linalg.generic {

--- a/mlir/test/Dialect/Linalg/transform-op-peel-and-vectorize-conv.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-peel-and-vectorize-conv.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --transform-interpreter --linalg-specialize-generic-ops --split-input-file -resolve-shaped-type-result-dims -canonicalize | FileCheck %s
+// RUN: mlir-opt %s --transform-interpreter --split-input-file -resolve-shaped-type-result-dims -canonicalize | FileCheck %s
 
 // Demonstrates what happens when peeling the 4th loop (that corresponds to the
 // "depth" dimension in depthwise convs) followed by vectorization in the
@@ -73,9 +73,7 @@ module attributes {transform.with_named_sequence} {
 
     // 4. Apply loop peeling - only the 4th loop
     %main_loop, %remainder_loop = transform.loop.peel %loops_1#3 : (!transform.op<"scf.for">) -> (!transform.op<"scf.for">, !transform.op<"scf.for">)
-    // Match linalg.generic since decompose produces generic ops, and
-    // --linalg-specialize-generic-ops runs after the transform interpreter.
-    %5 = transform.structured.match ops{["linalg.generic"]} in %main_loop : (!transform.op<"scf.for">) -> !transform.any_op
+    %5 = transform.structured.match ops{["linalg.depthwise_conv_1d_nwc_wc"]} in %main_loop : (!transform.op<"scf.for">) -> !transform.any_op
 
     // 5. Vectorize, but only the main loop
     transform.structured.vectorize %5 vector_sizes [2, 4, [4], 16] : !transform.any_op


### PR DESCRIPTION
The goal of this PR is to implement a generic, structure-aware convolution downscaling transformation that works for any convolution-like operation regardless of its specific layout or naming, rather than relying on pattern-matching against specific named operations.

Each pattern we currently have, have hardcoded dimension indices specific to its layout (e.g., NHWC vs NCHW).
This approach :-
1. Requires maintaining many similar patterns.
2. Is brittle when new layouts are introduced.
3. Cannot handle batchless versions of the conv variants.

This PR thus creates a single downscaleSizeOneWindowedConvolution function that uses `inferConvolutionDims` to semantically understand the convolution structure (batch dims, output image dims, filter loop dims, etc.) rather than hardcoding indices.
It works with any layout - NHWC, NCHW, or any other - because it reasons about the meaning of dimensions, not their positions.

If the input to the downscaling pattern is a named op -> the output will be a named op. Else it'd be a generic op input/output.
And for this reason we now remove the second RUN line as the infra tests both named as well as generic ops.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>