### PR TITLE
[CI] Add compiler-rt to LLDB runtime dependencies

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -71,7 +71,9 @@ DEPENDENTS_TO_TEST = {
 # This mapping describes runtimes that should be enabled for a specific project,
 # but not necessarily run for testing. The only case of this currently is lldb
 # which needs some runtimes enabled for tests.
-DEPENDENT_RUNTIMES_TO_BUILD = {"lldb": {"libcxx", "libcxxabi", "libunwind"}}
+DEPENDENT_RUNTIMES_TO_BUILD = {
+    "lldb": {"libcxx", "libcxxabi", "libunwind", "compiler-rt"}
+}
 
 # This mapping describes runtimes that should be tested when the key project is
 # touched.

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -333,10 +333,10 @@ class TestComputeProjects(unittest.TestCase):
         env_variables = compute_projects.get_env_variables(
             ["lldb/CMakeLists.txt"], "Linux"
         )
-        self.assertEqual(env_variables["projects_to_build"], "clang;lldb;llvm")
+        self.assertEqual(env_variables["projects_to_build"], "clang;lld;lldb;llvm")
         self.assertEqual(env_variables["project_check_targets"], "check-lldb")
         self.assertEqual(
-            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind"
+            env_variables["runtimes_to_build"], "compiler-rt;libcxx;libcxxabi;libunwind"
         )
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")


### PR DESCRIPTION
Some LLDB tests will only run if compiler-rt is built. This includes at least two tsan tests that passed in a PR (#179115) but then failed on other PRs that included compiler-rt in the build.