### PR TITLE
[flang][runtime] OPEN(STATUS='NEW') should fail on extant file

### DIFF
--- a/flang-rt/lib/runtime/iostat.cpp
+++ b/flang-rt/lib/runtime/iostat.cpp
@@ -119,6 +119,8 @@ const char *IostatErrorString(int iostat) {
     return "List-directed input value has trailing unused characters";
   case IostatNonExternalDefinedUnformattedIo:
     return "Defined unformatted I/O without an external unit";
+  case IostatOpenNewExtant:
+    return "OPEN(STATUS='NEW') on existing file";
   default:
     return nullptr;
   }

--- a/flang-rt/unittests/Runtime/ExternalIOTest.cpp
+++ b/flang-rt/unittests/Runtime/ExternalIOTest.cpp
@@ -951,3 +951,37 @@ TEST(ExternalIOTests, BigUnitNumbers) {
     EXPECT_EQ(std::strncmp(msg, expectedMsg, n), 0);
   }
 }
+
+TEST(ExternalIOTests, OpenNewExtant) {
+  // OPEN(10,STATUS='REPLACE')
+  Cookie io{IONAME(BeginOpenUnit)(10, __FILE__, __LINE__)};
+  ASSERT_TRUE(IONAME(SetFile)(io, "opennewextant", 13))
+      << "SetFile(opennewextant)";
+  ASSERT_TRUE(IONAME(SetStatus)(io, "REPLACE", 7)) << "SetStatus(REPLACE)";
+  ASSERT_EQ(IONAME(EndIoStatement)(io), IostatOk)
+      << "EndIoStatement() for OpenUnit(REPLACE)";
+  // CLOSE(10)
+  io = IONAME(BeginClose)(10, __FILE__, __LINE__);
+  ASSERT_EQ(IONAME(EndIoStatement)(io), IostatOk)
+      << "EndIoStatement() for Close";
+  // OPEN(10,STATUS='NEW') - should fail
+  io = IONAME(BeginOpenUnit)(10, __FILE__, __LINE__);
+  ASSERT_TRUE(IONAME(SetFile)(io, "opennewextant", 13))
+      << "SetFile(opennewextant)";
+  ASSERT_TRUE(IONAME(SetStatus)(io, "NEW", 3)) << "SetStatus(NEW)";
+  IONAME(EnableHandlers)(io, /*hasIoStat=*/true);
+  ASSERT_EQ(IONAME(EndIoStatement)(io), IostatOpenNewExtant)
+      << "EndIoStatement() for OpenUnit(NEW)";
+  // OPEN(10,STATUS='OLD')
+  io = IONAME(BeginOpenUnit)(10, __FILE__, __LINE__);
+  ASSERT_TRUE(IONAME(SetFile)(io, "opennewextant", 15))
+      << "SetFile(opennewextant)";
+  ASSERT_TRUE(IONAME(SetStatus)(io, "OLD", 3)) << "SetStatus(OLD)";
+  ASSERT_EQ(IONAME(EndIoStatement)(io), IostatOk)
+      << "EndIoStatement() for OpenUnit(OLD)";
+  // CLOSE(UNIT=10,STATUS='DELETE')
+  io = IONAME(BeginClose)(10, __FILE__, __LINE__);
+  ASSERT_TRUE(IONAME(SetStatus)(io, "DELETE", 6)) << "SetStatus(DELETE)";
+  ASSERT_EQ(IONAME(EndIoStatement)(io), IostatOk)
+      << "EndIoStatement() for CLOSE(DELETE)";
+}

--- a/flang/include/flang/Runtime/iostat-consts.h
+++ b/flang/include/flang/Runtime/iostat-consts.h
@@ -85,6 +85,7 @@ enum Iostat {
   IostatBadNewUnit,
   IostatBadListDirectedInputSeparator,
   IostatNonExternalDefinedUnformattedIo,
+  IostatOpenNewExtant,
 };
 
 } // namespace Fortran::runtime::io


### PR DESCRIPTION
An OPEN(..., STATUS='NEW') statement should fail when the named file exists, and also should not delete it when the failure is a recoverable error.