### PR TITLE
[mlir][vector] Reuse vector TD op in vector.xfer flatten tests

### DIFF
--- a/mlir/test/Dialect/Vector/td/flatten.mlir
+++ b/mlir/test/Dialect/Vector/td/flatten.mlir
@@ -1,0 +1,9 @@
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @flatten(%arg1: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.vector.flatten_vector_transfer_ops
+    } : !transform.any_op
+    transform.yield
+  }
+}

--- a/mlir/test/Dialect/Vector/transform-vector.mlir
+++ b/mlir/test/Dialect/Vector/transform-vector.mlir
@@ -137,35 +137,3 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
-
-// -----
-
-func.func @flatten_transfer_ops(%arg0: memref<16x16xf32>, %arg1: vector<8xf32>) -> vector<8xf32> {
-  %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %b0 = ub.poison : f32
-  %0 = vector.transfer_read %arg0[%c0, %c0], %b0 {in_bounds = [true, true]} : memref<16x16xf32>, vector<1x8xf32>
-  %1 = vector.transfer_read %arg0[%c0, %c8], %b0 {in_bounds = [true, true]} : memref<16x16xf32>, vector<1x8xf32>
-  %2 = vector.shape_cast %0 : vector<1x8xf32> to vector<8xf32>
-  %3 = vector.shape_cast %1 : vector<1x8xf32> to vector<8xf32>
-  %4 = vector.fma %2, %3, %arg1 : vector<8xf32>
-  return %4 : vector<8xf32>
-}
-
-// CHECK-LABEL: @flatten_transfer_ops
-// CHECK-NOT: vector.transfer_read {{.*}},  vector<1x8xf32>
-// CHECK-NOT: vector.transfer_read {{.*}},  vector<1x8xf32>
-// CHECK: vector.transfer_read {{.*}},  vector<8xf32>
-// CHECK-NEXT: vector.transfer_read {{.*}},  vector<8xf32>
-// CHECK-NOT: vector.shape_cast
-// CHECK-NOT: vector.shape_cast
-
-module attributes {transform.with_named_sequence} {
-  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
-    %func = transform.structured.match ops{["func.func"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    transform.apply_patterns to %func {
-      transform.apply_patterns.vector.flatten_vector_transfer_ops
-    } : !transform.any_op
-    transform.yield
-  }
-}

--- a/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
@@ -1,5 +1,8 @@
 // RUN: mlir-opt %s -test-vector-transfer-flatten-patterns -split-input-file | FileCheck %s
 // RUN: mlir-opt %s -test-vector-transfer-flatten-patterns=target-vector-bitwidth=128 -split-input-file | FileCheck %s --check-prefix=CHECK-128B
+// RUN: mlir-opt -split-input-file \
+// RUN: -transform-preload-library='transform-library-paths=%p/td/flatten.mlir' \
+// RUN: -transform-interpreter=entry-point=flatten %s | FileCheck %s
 
 // TODO: Align naming and format with e.g. vector-transfer-permutation-lowering.mlir
 


### PR DESCRIPTION
This change adds a `RUN` line in vector-transfer-flatten.mlir that will
use `vector.flatten_vector_transfer_ops` that was introduced in #178134.
It also removes a test added in the original PR whose coverage is
already provided by pre-existing tests.
