### PR TITLE
[Clang][CMake] Fix header target creation

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -516,8 +516,8 @@ foreach( f ${generated_files} )
   endif()
 endforeach( f )
 
-function(add_header_target target_name file_list)
-  add_library(${target_name} INTERFACE ${file_list})
+function(add_header_target target_name)
+  add_library(${target_name} INTERFACE ${ARGN})
   set_target_properties(${target_name} PROPERTIES
     FOLDER "Clang/Resources"
     RUNTIME_OUTPUT_DIRECTORY "${output_dir}")


### PR DESCRIPTION
The `add_header_target` function was using a `file_list` parameter that
was supposed to capture all the header files that should be added to the
interface library target. However, the parameter was only capturing the
first header file, and the rest of the header files were not being added
to the target properties. I.e. the `get_target_properties` command was
only returning the first header file instead of all the header files.

The commit removes the `file_list` parameter and replaces it with `ARGN`,
which captures all the header files passed to the function. This ensures
that all the header files are added to the interface library target and
can be accessed through the target properties.