### PR TITLE
[Hexagon] Disable new value jumps when packetizer is disabled

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonNewValueJump.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonNewValueJump.cpp
@@ -63,6 +63,8 @@ static cl::opt<int> DbgNVJCount("nvj-count", cl::init(-1), cl::Hidden,
 static cl::opt<bool> DisableNewValueJumps("disable-nvjump", cl::Hidden,
                                           cl::desc("Disable New Value Jumps"));
 
+extern cl::opt<bool> DisablePacketizer;
+
 namespace {
 
   struct HexagonNewValueJump : public MachineFunctionPass {
@@ -453,7 +455,9 @@ bool HexagonNewValueJump::runOnMachineFunction(MachineFunction &MF) {
       MF.getSubtarget().getRegisterInfo());
   MBPI = &getAnalysis<MachineBranchProbabilityInfoWrapperPass>().getMBPI();
 
-  if (DisableNewValueJumps ||
+  // New value jumps require the feeder instruction to be in the same packet.
+  // If packetization is disabled, we cannot generate new value jumps.
+  if (DisableNewValueJumps || DisablePacketizer ||
       !MF.getSubtarget<HexagonSubtarget>().useNewValueJumps())
     return false;
 

--- a/llvm/lib/Target/Hexagon/HexagonVLIWPacketizer.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVLIWPacketizer.cpp
@@ -55,9 +55,8 @@ using namespace llvm;
 
 #define DEBUG_TYPE "packets"
 
-static cl::opt<bool>
-    DisablePacketizer("disable-packetizer", cl::Hidden,
-                      cl::desc("Disable Hexagon packetizer pass"));
+cl::opt<bool> DisablePacketizer("disable-packetizer", cl::Hidden,
+                                cl::desc("Disable Hexagon packetizer pass"));
 
 static cl::opt<bool> Slot1Store("slot1-store-slot0-load", cl::Hidden,
                                 cl::init(true),

--- a/llvm/test/CodeGen/Hexagon/disable-packetizer-nvj.ll
+++ b/llvm/test/CodeGen/Hexagon/disable-packetizer-nvj.ll
@@ -1,0 +1,32 @@
+; RUN: llc -mtriple=hexagon -mcpu=hexagonv68 -O1 --disable-packetizer -filetype=obj -o /dev/null %s
+; REQUIRES: asserts
+
+; Check that compiling with --disable-packetizer does not crash.
+; When packetization is disabled, new value jumps should not be generated
+; because the producer instruction cannot be in the same packet as the
+; consumer (.new) instruction.
+
+target datalayout = "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048"
+target triple = "hexagon-unknown-linux-musl"
+
+; This pattern triggers new value jump generation:
+define i32 @test_nvj_disable_packetizer() {
+entry:
+  %ptr = load ptr, ptr null, align 4
+  %cmp = icmp eq ptr %ptr, null
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:
+  call void @llvm.memset.p0.i64(ptr null, i8 0, i64 19, i1 false)
+  br label %exit
+
+if.else:
+  %val = atomicrmw sub ptr null, i32 0 monotonic, align 4
+  br label %exit
+
+exit:
+  %result = phi i32 [ 0, %if.then ], [ 1, %if.else ]
+  ret i32 %result
+}
+
+declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg)

--- a/llvm/test/CodeGen/Hexagon/disable-packetizer-nvj.ll
+++ b/llvm/test/CodeGen/Hexagon/disable-packetizer-nvj.ll
@@ -1,32 +1,34 @@
-; RUN: llc -mtriple=hexagon -mcpu=hexagonv68 -O1 --disable-packetizer -filetype=obj -o /dev/null %s
+; RUN: llc -mtriple=hexagon -mcpu=hexagonv68 -O2 --disable-packetizer -filetype=obj -o /dev/null %s
+; RUN: llc -mtriple=hexagon -mcpu=hexagonv68 -O2 -mattr=-nvj -filetype=obj -o /dev/null %s
 ; REQUIRES: asserts
 
 ; Check that compiling with --disable-packetizer does not crash.
-; When packetization is disabled, new value jumps should not be generated
-; because the producer instruction cannot be in the same packet as the
-; consumer (.new) instruction.
+; New value jumps require the feeder instruction to be in the same packet
+; as the consumer (.new) instruction. When packetization is disabled, the
+; NVJ pass must be skipped to avoid an assertion in the MCCodeEmitter
+; ("Couldn't find producer").
+;
+; The branches here are non-if-convertible (due to calls), ensuring the
+; compare+branch pattern survives to the NVJ pass regardless of the
+; optimization pipeline used.
 
-target datalayout = "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048"
-target triple = "hexagon-unknown-linux-musl"
+declare void @do_work(i32)
+declare void @do_other(i32)
 
-; This pattern triggers new value jump generation:
-define i32 @test_nvj_disable_packetizer() {
+define void @test_nvj(ptr %p, i32 %threshold) {
 entry:
-  %ptr = load ptr, ptr null, align 4
-  %cmp = icmp eq ptr %ptr, null
+  %val = load i32, ptr %p, align 4
+  %cmp = icmp eq i32 %val, %threshold
   br i1 %cmp, label %if.then, label %if.else
 
 if.then:
-  call void @llvm.memset.p0.i64(ptr null, i8 0, i64 19, i1 false)
+  call void @do_work(i32 %val)
   br label %exit
 
 if.else:
-  %val = atomicrmw sub ptr null, i32 0 monotonic, align 4
+  call void @do_other(i32 %val)
   br label %exit
 
 exit:
-  %result = phi i32 [ 0, %if.then ], [ 1, %if.else ]
-  ret i32 %result
+  ret void
 }
-
-declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg)


### PR DESCRIPTION
New value jumps require the feeder instruction to be in the same packet as the consumer (.new) instruction. When --disable-packetizer is used, each instruction is placed in its own packet, making it impossible to satisfy this requirement.

Previously, using --disable-packetizer would cause an assertion failure in the MCCodeEmitter: "Couldn't find producer". This change fixes the crash by checking the DisablePacketizer flag in the NewValueJump pass and skipping NVJ generation when packetization is disabled.