### PR TITLE
[DataLayout] Add a specifier for element-aligned vectors

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3384,6 +3384,9 @@ as follows:
 ``v<size>:<abi>[:<pref>]``
     This specifies the alignment for a vector type of a given bit
     ``<size>``. The value of ``<size>`` must be in the range [1,2^24).
+``ve``
+    Specifies that vectors are element-aligned by default, rather than having
+    natural alignment.
 ``f<size>:<abi>[:<pref>]``
     This specifies the alignment for a floating-point type of a given bit
     ``<size>``. Only values of ``<size>`` that are supported by the target

--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -108,6 +108,7 @@ public:
 
 private:
   bool BigEndian = false;
+  bool VectorsAreElementAligned = false;
 
   unsigned AllocaAddrSpace = 0;
   unsigned ProgramAddrSpace = 0;
@@ -213,6 +214,9 @@ public:
   /// Layout endianness...
   bool isLittleEndian() const { return !BigEndian; }
   bool isBigEndian() const { return BigEndian; }
+
+  /// Whether vectors are element aligned, rather than naturally aligned.
+  bool vectorsAreElementAligned() const { return VectorsAreElementAligned; }
 
   /// Returns the string representation of the DataLayout.
   ///


### PR DESCRIPTION
This adds the "ve" specifier to Data Layout, which says that vectors are element-aligned by default for a target.

Note that we also remove the default vector specs for 64 and 128 bit vectors - these match the natural alignment of those vectors, so they didn't actually have any functional effect.