### PR TITLE
[lldb][NativeRegisterContext] Rename to x86 for shared files

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/FreeBSD/CMakeLists.txt
@@ -4,7 +4,7 @@ add_lldb_library(lldbPluginProcessFreeBSD
   NativeRegisterContextFreeBSD_arm.cpp
   NativeRegisterContextFreeBSD_arm64.cpp
   NativeRegisterContextFreeBSD_powerpc.cpp
-  NativeRegisterContextFreeBSD_x86_64.cpp
+  NativeRegisterContextFreeBSD_x86.cpp
   NativeThreadFreeBSD.cpp
 
   LINK_COMPONENTS

--- a/lldb/source/Plugins/Process/Linux/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/Linux/CMakeLists.txt
@@ -13,7 +13,7 @@ add_lldb_library(lldbPluginProcessLinux
   NativeRegisterContextLinux_ppc64le.cpp
   NativeRegisterContextLinux_riscv64.cpp
   NativeRegisterContextLinux_s390x.cpp
-  NativeRegisterContextLinux_x86_64.cpp
+  NativeRegisterContextLinux_x86.cpp
   NativeThreadLinux.cpp
   Perf.cpp
   Procfs.cpp

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_x86.h
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_x86.h
@@ -1,4 +1,4 @@
-//===-- NativeRegisterContextLinux_x86_64.h ---------------------*- C++ -*-===//
+//===-- NativeRegisterContextLinux_x86.h ------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,8 +8,8 @@
 
 #if defined(__i386__) || defined(__x86_64__)
 
-#ifndef lldb_NativeRegisterContextLinux_x86_64_h
-#define lldb_NativeRegisterContextLinux_x86_64_h
+#ifndef lldb_NativeRegisterContextLinux_x86_h
+#define lldb_NativeRegisterContextLinux_x86_h
 
 #include "Plugins/Process/Linux/NativeRegisterContextLinux.h"
 #include "Plugins/Process/Utility/NativeRegisterContextDBReg_x86.h"
@@ -24,11 +24,11 @@ namespace process_linux {
 
 class NativeProcessLinux;
 
-class NativeRegisterContextLinux_x86_64
+class NativeRegisterContextLinux_x86
     : public NativeRegisterContextLinux,
       public NativeRegisterContextDBReg_x86 {
 public:
-  NativeRegisterContextLinux_x86_64(const ArchSpec &target_arch,
+  NativeRegisterContextLinux_x86(const ArchSpec &target_arch,
                                     NativeThreadProtocol &native_thread);
 
   uint32_t GetRegisterSetCount() const override;
@@ -143,6 +143,6 @@ private:
 } // namespace process_linux
 } // namespace lldb_private
 
-#endif // #ifndef lldb_NativeRegisterContextLinux_x86_64_h
+#endif // #ifndef lldb_NativeRegisterContextLinux_x86_h
 
 #endif // defined(__i386__) || defined(__x86_64__)

--- a/lldb/source/Plugins/Process/NetBSD/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/NetBSD/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_lldb_library(lldbPluginProcessNetBSD
   NativeProcessNetBSD.cpp
   NativeRegisterContextNetBSD.cpp
-  NativeRegisterContextNetBSD_x86_64.cpp
+  NativeRegisterContextNetBSD_x86.cpp
   NativeThreadNetBSD.cpp
 
   LINK_COMPONENTS

--- a/lldb/source/Plugins/Process/NetBSD/NativeRegisterContextNetBSD_x86.cpp
+++ b/lldb/source/Plugins/Process/NetBSD/NativeRegisterContextNetBSD_x86.cpp
@@ -1,4 +1,4 @@
-//===-- NativeRegisterContextFreeBSD_x86_64.cpp ---------------------------===//
+//===-- NativeRegisterContextNetBSD_x86.cpp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,13 +8,7 @@
 
 #if defined(__i386__) || defined(__x86_64__)
 
-#include "NativeRegisterContextFreeBSD_x86_64.h"
-
-// clang-format off
-#include <x86/fpu.h>
-#include <x86/specialreg.h>
-#include <cpuid.h>
-// clang-format on
+#include "NativeRegisterContextNetBSD_x86.h"
 
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Utility/DataBufferHeap.h"
@@ -22,13 +16,26 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "lldb/Utility/Status.h"
 
-#include "NativeProcessFreeBSD.h"
-#include "Plugins/Process/Utility/RegisterContextFreeBSD_i386.h"
-#include "Plugins/Process/Utility/RegisterContextFreeBSD_x86_64.h"
+#include "Plugins/Process/Utility/RegisterContextNetBSD_i386.h"
+#include "Plugins/Process/Utility/RegisterContextNetBSD_x86_64.h"
+
+// clang-format off
+#include <sys/types.h>
+#include <sys/ptrace.h>
+#include <sys/sysctl.h>
+#include <sys/uio.h>
+#include <x86/cpu.h>
+#include <x86/cpu_extended_state.h>
+#include <x86/specialreg.h>
+#include <elf.h>
+#include <err.h>
+#include <cstdint>
+#include <cstdlib>
 #include <optional>
+// clang-format on
 
 using namespace lldb_private;
-using namespace lldb_private::process_freebsd;
+using namespace lldb_private::process_netbsd;
 
 // x86 64-bit general purpose registers.
 static const uint32_t g_gpr_regnums_x86_64[] = {
@@ -235,35 +242,35 @@ static const RegisterSet g_reg_sets_x86_64[k_num_register_sets] = {
 
 #define REG_CONTEXT_SIZE (GetRegisterInfoInterface().GetGPRSize())
 
-NativeRegisterContextFreeBSD *
-NativeRegisterContextFreeBSD::CreateHostNativeRegisterContextFreeBSD(
-    const ArchSpec &target_arch, NativeThreadFreeBSD &native_thread) {
-  return new NativeRegisterContextFreeBSD_x86_64(target_arch, native_thread);
+NativeRegisterContextNetBSD *
+NativeRegisterContextNetBSD::CreateHostNativeRegisterContextNetBSD(
+    const ArchSpec &target_arch, NativeThreadProtocol &native_thread) {
+  return new NativeRegisterContextNetBSD_x86(target_arch, native_thread);
 }
 
-// NativeRegisterContextFreeBSD_x86_64 members.
+// NativeRegisterContextNetBSD_x86 members.
 
 static RegisterInfoInterface *
 CreateRegisterInfoInterface(const ArchSpec &target_arch) {
   if (HostInfo::GetArchitecture().GetAddressByteSize() == 4) {
-    // 32-bit hosts run with a RegisterContextFreeBSD_i386 context.
-    return new RegisterContextFreeBSD_i386(target_arch);
+    // 32-bit hosts run with a RegisterContextNetBSD_i386 context.
+    return new RegisterContextNetBSD_i386(target_arch);
   } else {
     assert((HostInfo::GetArchitecture().GetAddressByteSize() == 8) &&
            "Register setting path assumes this is a 64-bit host");
     // X86_64 hosts know how to work with 64-bit and 32-bit EXEs using the
     // x86_64 register context.
-    return new RegisterContextFreeBSD_x86_64(target_arch);
+    return new RegisterContextNetBSD_x86_64(target_arch);
   }
 }
 
-NativeRegisterContextFreeBSD_x86_64::NativeRegisterContextFreeBSD_x86_64(
-    const ArchSpec &target_arch, NativeThreadFreeBSD &native_thread)
+NativeRegisterContextNetBSD_x86::NativeRegisterContextNetBSD_x86(
+    const ArchSpec &target_arch, NativeThreadProtocol &native_thread)
     : NativeRegisterContextRegisterInfo(
           native_thread, CreateRegisterInfoInterface(target_arch)),
       NativeRegisterContextDBReg_x86(native_thread), m_regset_offsets({0}) {
   assert(m_gpr.size() == GetRegisterInfoInterface().GetGPRSize());
-  std::array<uint32_t, MaxRegSet + 1> first_regnos;
+  std::array<uint32_t, MaxRegularRegSet + 1> first_regnos;
 
   switch (GetRegisterInfoInterface().GetTargetArchitecture().GetMachine()) {
   case llvm::Triple::x86:
@@ -284,12 +291,12 @@ NativeRegisterContextFreeBSD_x86_64::NativeRegisterContextFreeBSD_x86_64(
                               .byte_offset;
 }
 
-uint32_t NativeRegisterContextFreeBSD_x86_64::GetRegisterSetCount() const {
+uint32_t NativeRegisterContextNetBSD_x86::GetRegisterSetCount() const {
   return k_num_register_sets;
 }
 
 const RegisterSet *
-NativeRegisterContextFreeBSD_x86_64::GetRegisterSet(uint32_t set_index) const {
+NativeRegisterContextNetBSD_x86::GetRegisterSet(uint32_t set_index) const {
   switch (GetRegisterInfoInterface().GetTargetArchitecture().GetMachine()) {
   case llvm::Triple::x86:
     return &g_reg_sets_i386[set_index];
@@ -300,8 +307,8 @@ NativeRegisterContextFreeBSD_x86_64::GetRegisterSet(uint32_t set_index) const {
   }
 }
 
-std::optional<NativeRegisterContextFreeBSD_x86_64::RegSetKind>
-NativeRegisterContextFreeBSD_x86_64::GetSetForNativeRegNum(
+std::optional<NativeRegisterContextNetBSD_x86::RegSetKind>
+NativeRegisterContextNetBSD_x86::GetSetForNativeRegNum(
     uint32_t reg_num) const {
   switch (GetRegisterInfoInterface().GetTargetArchitecture().GetMachine()) {
   case llvm::Triple::x86:
@@ -339,76 +346,43 @@ NativeRegisterContextFreeBSD_x86_64::GetSetForNativeRegNum(
   llvm_unreachable("Register does not belong to any register set");
 }
 
-Status NativeRegisterContextFreeBSD_x86_64::ReadRegisterSet(RegSetKind set) {
+Status NativeRegisterContextNetBSD_x86::ReadRegisterSet(RegSetKind set) {
   switch (set) {
   case GPRegSet:
-    return NativeProcessFreeBSD::PtraceWrapper(PT_GETREGS, m_thread.GetID(),
-                                               m_gpr.data());
-  case FPRegSet:
-#if defined(__x86_64__)
-    return NativeProcessFreeBSD::PtraceWrapper(PT_GETFPREGS, m_thread.GetID(),
-                                               m_fpr.data());
-#else
-    return NativeProcessFreeBSD::PtraceWrapper(PT_GETXMMREGS, m_thread.GetID(),
-                                               m_fpr.data());
-#endif
+    return DoRegisterSet(PT_GETREGS, m_gpr.data());
   case DBRegSet:
-    return NativeProcessFreeBSD::PtraceWrapper(PT_GETDBREGS, m_thread.GetID(),
-                                               m_dbr.data());
+    return DoRegisterSet(PT_GETDBREGS, m_dbr.data());
+  case FPRegSet:
   case YMMRegSet:
   case MPXRegSet: {
-    struct ptrace_xstate_info info;
-    Status ret = NativeProcessFreeBSD::PtraceWrapper(
-        PT_GETXSTATE_INFO, GetProcessPid(), &info, sizeof(info));
-    if (!ret.Success())
-      return ret;
-
-    assert(info.xsave_mask & XFEATURE_ENABLED_X87);
-    assert(info.xsave_mask & XFEATURE_ENABLED_SSE);
-
-    m_xsave_offsets[YMMRegSet] = LLDB_INVALID_XSAVE_OFFSET;
-    if (info.xsave_mask & XFEATURE_ENABLED_YMM_HI128) {
-      uint32_t eax, ecx, edx;
-      __get_cpuid_count(0x0D, 2, &eax, &m_xsave_offsets[YMMRegSet], &ecx, &edx);
-    }
-
-    m_xsave.resize(info.xsave_len);
-    return NativeProcessFreeBSD::PtraceWrapper(PT_GETXSTATE, GetProcessPid(),
-                                               m_xsave.data(), m_xsave.size());
+    struct iovec iov = {m_xstate.data(), m_xstate.size()};
+    Status ret = DoRegisterSet(PT_GETXSTATE, &iov);
+    assert(reinterpret_cast<xstate *>(m_xstate.data())->xs_rfbm & XCR0_X87);
+    return ret;
   }
   }
-  llvm_unreachable("NativeRegisterContextFreeBSD_x86_64::ReadRegisterSet");
+  llvm_unreachable("NativeRegisterContextNetBSD_x86::ReadRegisterSet");
 }
 
-Status NativeRegisterContextFreeBSD_x86_64::WriteRegisterSet(RegSetKind set) {
+Status NativeRegisterContextNetBSD_x86::WriteRegisterSet(RegSetKind set) {
   switch (set) {
   case GPRegSet:
-    return NativeProcessFreeBSD::PtraceWrapper(PT_SETREGS, m_thread.GetID(),
-                                               m_gpr.data());
-  case FPRegSet:
-#if defined(__x86_64__)
-    return NativeProcessFreeBSD::PtraceWrapper(PT_SETFPREGS, m_thread.GetID(),
-                                               m_fpr.data());
-#else
-    return NativeProcessFreeBSD::PtraceWrapper(PT_SETXMMREGS, m_thread.GetID(),
-                                               m_fpr.data());
-#endif
+    return DoRegisterSet(PT_SETREGS, m_gpr.data());
   case DBRegSet:
-    return NativeProcessFreeBSD::PtraceWrapper(PT_SETDBREGS, m_thread.GetID(),
-                                               m_dbr.data());
+    return DoRegisterSet(PT_SETDBREGS, m_dbr.data());
+  case FPRegSet:
   case YMMRegSet:
-  case MPXRegSet:
-    // ReadRegisterSet() must always be called before WriteRegisterSet().
-    assert(m_xsave.size() > 0);
-    return NativeProcessFreeBSD::PtraceWrapper(PT_SETXSTATE, GetProcessPid(),
-                                               m_xsave.data(), m_xsave.size());
+  case MPXRegSet: {
+    struct iovec iov = {&m_xstate, sizeof(m_xstate)};
+    return DoRegisterSet(PT_SETXSTATE, &iov);
   }
-  llvm_unreachable("NativeRegisterContextFreeBSD_x86_64::WriteRegisterSet");
+  }
+  llvm_unreachable("NativeRegisterContextNetBSD_x86::WriteRegisterSet");
 }
 
 Status
-NativeRegisterContextFreeBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
-                                                  RegisterValue &reg_value) {
+NativeRegisterContextNetBSD_x86::ReadRegister(const RegisterInfo *reg_info,
+                                                 RegisterValue &reg_value) {
   Status error;
 
   if (!reg_info) {
@@ -436,7 +410,7 @@ NativeRegisterContextFreeBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
     return error;
   }
 
-  RegSetKind set = opt_set.value();
+  RegSetKind set = *opt_set;
   error = ReadRegisterSet(set);
   if (error.Fail())
     return error;
@@ -446,7 +420,8 @@ NativeRegisterContextFreeBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
   case FPRegSet:
   case DBRegSet: {
     void *data = GetOffsetRegSetData(set, reg_info->byte_offset);
-    FXSAVE *fpr = reinterpret_cast<FXSAVE *>(m_fpr.data());
+    FXSAVE *fpr = reinterpret_cast<FXSAVE *>(m_xstate.data() +
+                                             offsetof(xstate, xs_fxsave));
     if (data == &fpr->ftag) // ftag
       reg_value.SetUInt16(
           AbridgedToFullTagWord(fpr->ftag, fpr->fstat, fpr->stmm));
@@ -473,7 +448,7 @@ NativeRegisterContextFreeBSD_x86_64::ReadRegister(const RegisterInfo *reg_info,
   return error;
 }
 
-Status NativeRegisterContextFreeBSD_x86_64::WriteRegister(
+Status NativeRegisterContextNetBSD_x86::WriteRegister(
     const RegisterInfo *reg_info, const RegisterValue &reg_value) {
 
   Status error;
@@ -503,21 +478,33 @@ Status NativeRegisterContextFreeBSD_x86_64::WriteRegister(
     return error;
   }
 
-  RegSetKind set = opt_set.value();
+  RegSetKind set = *opt_set;
+  uint64_t new_xstate_bv = 0;
+
   error = ReadRegisterSet(set);
   if (error.Fail())
     return error;
 
   switch (set) {
   case GPRegSet:
-  case FPRegSet:
-  case DBRegSet: {
+  case DBRegSet:
+    ::memcpy(GetOffsetRegSetData(set, reg_info->byte_offset),
+             reg_value.GetBytes(), reg_value.GetByteSize());
+    break;
+  case FPRegSet: {
     void *data = GetOffsetRegSetData(set, reg_info->byte_offset);
-    FXSAVE *fpr = reinterpret_cast<FXSAVE *>(m_fpr.data());
+    FXSAVE *fpr = reinterpret_cast<FXSAVE *>(m_xstate.data() +
+                                             offsetof(xstate, xs_fxsave));
     if (data == &fpr->ftag) // ftag
       fpr->ftag = FullToAbridgedTagWord(reg_value.GetAsUInt16());
     else
       ::memcpy(data, reg_value.GetBytes(), reg_value.GetByteSize());
+    if (data >= &fpr->xmm)
+      new_xstate_bv |= XCR0_SSE;
+    else if (data >= &fpr->mxcsr && data < &fpr->stmm)
+      new_xstate_bv |= XCR0_SSE;
+    else
+      new_xstate_bv |= XCR0_X87;
     break;
   }
   case YMMRegSet: {
@@ -529,6 +516,7 @@ Status NativeRegisterContextFreeBSD_x86_64::WriteRegister(
       YMMReg ymm;
       ::memcpy(ymm.bytes, reg_value.GetBytes(), reg_value.GetByteSize());
       YMMToXState(ymm, ymm_reg->xmm, ymm_reg->ymm_hi);
+      new_xstate_bv |= XCR0_SSE | XCR0_YMM_Hi128;
     }
     break;
   }
@@ -536,10 +524,12 @@ Status NativeRegisterContextFreeBSD_x86_64::WriteRegister(
     llvm_unreachable("MPX regset should have returned error");
   }
 
+  if (new_xstate_bv != 0)
+    reinterpret_cast<xstate *>(m_xstate.data())->xs_xstate_bv |= new_xstate_bv;
   return WriteRegisterSet(set);
 }
 
-Status NativeRegisterContextFreeBSD_x86_64::ReadAllRegisterValues(
+Status NativeRegisterContextNetBSD_x86::ReadAllRegisterValues(
     lldb::WritableDataBufferSP &data_sp) {
   Status error;
 
@@ -555,20 +545,20 @@ Status NativeRegisterContextFreeBSD_x86_64::ReadAllRegisterValues(
   return error;
 }
 
-Status NativeRegisterContextFreeBSD_x86_64::WriteAllRegisterValues(
+Status NativeRegisterContextNetBSD_x86::WriteAllRegisterValues(
     const lldb::DataBufferSP &data_sp) {
   Status error;
 
   if (!data_sp) {
     error = Status::FromErrorStringWithFormat(
-        "NativeRegisterContextFreeBSD_x86_64::%s invalid data_sp provided",
+        "NativeRegisterContextNetBSD_x86::%s invalid data_sp provided",
         __FUNCTION__);
     return error;
   }
 
   if (data_sp->GetByteSize() != REG_CONTEXT_SIZE) {
     error = Status::FromErrorStringWithFormat(
-        "NativeRegisterContextFreeBSD_x86_64::%s data_sp contained mismatched "
+        "NativeRegisterContextNetBSD_x86::%s data_sp contained mismatched "
         "data size, expected %zu, actual %" PRIu64,
         __FUNCTION__, REG_CONTEXT_SIZE, data_sp->GetByteSize());
     return error;
@@ -577,7 +567,7 @@ Status NativeRegisterContextFreeBSD_x86_64::WriteAllRegisterValues(
   const uint8_t *src = data_sp->GetBytes();
   if (src == nullptr) {
     error = Status::FromErrorStringWithFormat(
-        "NativeRegisterContextFreeBSD_x86_64::%s "
+        "NativeRegisterContextNetBSD_x86::%s "
         "DataBuffer::GetBytes() returned a null "
         "pointer",
         __FUNCTION__);
@@ -593,9 +583,9 @@ Status NativeRegisterContextFreeBSD_x86_64::WriteAllRegisterValues(
   return error;
 }
 
-llvm::Error NativeRegisterContextFreeBSD_x86_64::CopyHardwareWatchpointsFrom(
-    NativeRegisterContextFreeBSD &source) {
-  auto &r_source = static_cast<NativeRegisterContextFreeBSD_x86_64 &>(source);
+llvm::Error NativeRegisterContextNetBSD_x86::CopyHardwareWatchpointsFrom(
+    NativeRegisterContextNetBSD &source) {
+  auto &r_source = static_cast<NativeRegisterContextNetBSD_x86 &>(source);
   // NB: This implicitly reads the whole dbreg set.
   RegisterValue dr7;
   Status res = r_source.ReadRegister(GetDR(7), dr7);
@@ -611,15 +601,15 @@ llvm::Error NativeRegisterContextFreeBSD_x86_64::CopyHardwareWatchpointsFrom(
 }
 
 uint8_t *
-NativeRegisterContextFreeBSD_x86_64::GetOffsetRegSetData(RegSetKind set,
-                                                         size_t reg_offset) {
+NativeRegisterContextNetBSD_x86::GetOffsetRegSetData(RegSetKind set,
+                                                        size_t reg_offset) {
   uint8_t *base;
   switch (set) {
   case GPRegSet:
     base = m_gpr.data();
     break;
   case FPRegSet:
-    base = m_fpr.data();
+    base = m_xstate.data() + offsetof(xstate, xs_fxsave);
     break;
   case DBRegSet:
     base = m_dbr.data();
@@ -633,10 +623,10 @@ NativeRegisterContextFreeBSD_x86_64::GetOffsetRegSetData(RegSetKind set,
   return base + (reg_offset - m_regset_offsets[set]);
 }
 
-std::optional<NativeRegisterContextFreeBSD_x86_64::YMMSplitPtr>
-NativeRegisterContextFreeBSD_x86_64::GetYMMSplitReg(uint32_t reg) {
-  uint32_t offset = m_xsave_offsets[YMMRegSet];
-  if (offset == LLDB_INVALID_XSAVE_OFFSET)
+std::optional<NativeRegisterContextNetBSD_x86::YMMSplitPtr>
+NativeRegisterContextNetBSD_x86::GetYMMSplitReg(uint32_t reg) {
+  auto xst = reinterpret_cast<xstate *>(m_xstate.data());
+  if (!(xst->xs_rfbm & XCR0_SSE) || !(xst->xs_rfbm & XCR0_YMM_Hi128))
     return std::nullopt;
 
   uint32_t reg_index;
@@ -651,10 +641,8 @@ NativeRegisterContextFreeBSD_x86_64::GetYMMSplitReg(uint32_t reg) {
     llvm_unreachable("Unhandled target architecture.");
   }
 
-  auto *fpreg = reinterpret_cast<struct savexmm_ymm *>(m_xsave.data());
-  auto *ymmreg = reinterpret_cast<struct ymmacc *>(m_xsave.data() + offset);
-
-  return YMMSplitPtr{&fpreg->sv_xmm[reg_index], &ymmreg[reg_index]};
+  return YMMSplitPtr{&xst->xs_fxsave.fx_xmm[reg_index],
+                     &xst->xs_ymm_hi128.xs_ymm[reg_index]};
 }
 
-#endif // defined(__x86_64__)
+#endif // defined(__i386__) || defined(__x86_64__)

--- a/lldb/source/Plugins/Process/NetBSD/NativeRegisterContextNetBSD_x86.h
+++ b/lldb/source/Plugins/Process/NetBSD/NativeRegisterContextNetBSD_x86.h
@@ -1,4 +1,4 @@
-//===-- NativeRegisterContextFreeBSD_x86_64.h -------------------*- C++ -*-===//
+//===-- NativeRegisterContextNetBSD_x86.h -----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,37 +8,35 @@
 
 #if defined(__i386__) || defined(__x86_64__)
 
-#ifndef lldb_NativeRegisterContextFreeBSD_x86_64_h
-#define lldb_NativeRegisterContextFreeBSD_x86_64_h
+#ifndef lldb_NativeRegisterContextNetBSD_x86_h
+#define lldb_NativeRegisterContextNetBSD_x86_h
 
 // clang-format off
 #include <sys/param.h>
-#include <sys/ptrace.h>
 #include <sys/types.h>
+#include <sys/ptrace.h>
 #include <machine/reg.h>
 // clang-format on
 
 #include <array>
 #include <optional>
 
-#include "Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD.h"
-#include "Plugins/Process/Utility/NativeRegisterContextDBReg_x86.h"
+#include "Plugins/Process/NetBSD/NativeRegisterContextNetBSD.h"
 #include "Plugins/Process/Utility/RegisterContext_x86.h"
+#include "Plugins/Process/Utility/NativeRegisterContextDBReg_x86.h"
 #include "Plugins/Process/Utility/lldb-x86-register-enums.h"
 
-#define LLDB_INVALID_XSAVE_OFFSET UINT32_MAX
-
 namespace lldb_private {
-namespace process_freebsd {
+namespace process_netbsd {
 
-class NativeProcessFreeBSD;
+class NativeProcessNetBSD;
 
-class NativeRegisterContextFreeBSD_x86_64
-    : public NativeRegisterContextFreeBSD,
+class NativeRegisterContextNetBSD_x86
+    : public NativeRegisterContextNetBSD,
       public NativeRegisterContextDBReg_x86 {
 public:
-  NativeRegisterContextFreeBSD_x86_64(const ArchSpec &target_arch,
-                                      NativeThreadFreeBSD &native_thread);
+  NativeRegisterContextNetBSD_x86(const ArchSpec &target_arch,
+                                     NativeThreadProtocol &native_thread);
   uint32_t GetRegisterSetCount() const override;
 
   const RegisterSet *GetRegisterSet(uint32_t set_index) const override;
@@ -54,7 +52,7 @@ public:
   Status WriteAllRegisterValues(const lldb::DataBufferSP &data_sp) override;
 
   llvm::Error
-  CopyHardwareWatchpointsFrom(NativeRegisterContextFreeBSD &source) override;
+  CopyHardwareWatchpointsFrom(NativeRegisterContextNetBSD &source) override;
 
 private:
   // Private member types.
@@ -62,6 +60,7 @@ private:
     GPRegSet,
     FPRegSet,
     DBRegSet,
+    MaxRegularRegSet = DBRegSet,
     YMMRegSet,
     MPXRegSet,
     MaxRegSet = MPXRegSet,
@@ -69,11 +68,9 @@ private:
 
   // Private member variables.
   std::array<uint8_t, sizeof(struct reg)> m_gpr;
-  std::array<uint8_t, 512> m_fpr; // FXSAVE
+  std::array<uint8_t, sizeof(struct xstate)> m_xstate;
   std::array<uint8_t, sizeof(struct dbreg)> m_dbr;
-  std::vector<uint8_t> m_xsave;
-  std::array<uint32_t, MaxRegSet + 1> m_xsave_offsets;
-  std::array<size_t, MaxRegSet + 1> m_regset_offsets;
+  std::array<size_t, MaxRegularRegSet + 1> m_regset_offsets;
 
   std::optional<RegSetKind> GetSetForNativeRegNum(uint32_t reg_num) const;
 
@@ -89,9 +86,9 @@ private:
   std::optional<YMMSplitPtr> GetYMMSplitReg(uint32_t reg);
 };
 
-} // namespace process_freebsd
+} // namespace process_netbsd
 } // namespace lldb_private
 
-#endif // #ifndef lldb_NativeRegisterContextFreeBSD_x86_64_h
+#endif // #ifndef lldb_NativeRegisterContextNetBSD_x86_h
 
-#endif // defined(__x86_64__)
+#endif // defined(__i386__) || defined(__x86_64__)

--- a/lldb/source/Plugins/Process/elf-core/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/elf-core/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_lldb_library(lldbPluginProcessElfCore PLUGIN
   ProcessElfCore.cpp
   ThreadElfCore.cpp
-  RegisterContextLinuxCore_x86_64.cpp
+  RegisterContextLinuxCore_x86.cpp
   RegisterContextPOSIXCore_arm.cpp
   RegisterContextPOSIXCore_arm64.cpp
   RegisterContextPOSIXCore_powerpc.cpp
   RegisterContextPOSIXCore_ppc64le.cpp
   RegisterContextPOSIXCore_s390x.cpp
-  RegisterContextPOSIXCore_x86_64.cpp
+  RegisterContextPOSIXCore_x86.cpp
   RegisterContextPOSIXCore_riscv32.cpp
   RegisterContextPOSIXCore_riscv64.cpp
   RegisterContextPOSIXCore_loongarch64.cpp

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextLinuxCore_x86.cpp
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextLinuxCore_x86.cpp
@@ -1,4 +1,4 @@
-//===-- RegisterContextLinuxCore_x86_64.cpp -------------------------------===//
+//===-- RegisterContextLinuxCore_x86.cpp ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "RegisterContextLinuxCore_x86_64.h"
+#include "RegisterContextLinuxCore_x86.h"
 #include "lldb/Target/Thread.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/RegisterValue.h"
@@ -210,12 +210,12 @@ static const RegisterSet g_reg_sets_x86_64[] = {
     {"Advanced Vector Extensions", "avx", x86_64_with_base::k_num_avx_registers,
      g_avx_regnums_x86_64}};
 
-RegisterContextLinuxCore_x86_64::RegisterContextLinuxCore_x86_64(
+RegisterContextLinuxCore_x86::RegisterContextLinuxCore_x86(
     Thread &thread, RegisterInfoInterface *register_info,
     const DataExtractor &gpregset, llvm::ArrayRef<CoreNote> notes)
-    : RegisterContextCorePOSIX_x86_64(thread, register_info, gpregset, notes) {}
+    : RegisterContextCorePOSIX_x86(thread, register_info, gpregset, notes) {}
 
-const RegisterSet *RegisterContextLinuxCore_x86_64::GetRegisterSet(size_t set) {
+const RegisterSet *RegisterContextLinuxCore_x86::GetRegisterSet(size_t set) {
   if (IsRegisterSetAvailable(set)) {
     switch (m_register_info_up->GetTargetArchitecture().GetMachine()) {
     case llvm::Triple::x86:
@@ -230,7 +230,7 @@ const RegisterSet *RegisterContextLinuxCore_x86_64::GetRegisterSet(size_t set) {
   return nullptr;
 }
 
-RegInfo &RegisterContextLinuxCore_x86_64::GetRegInfo() {
+RegInfo &RegisterContextLinuxCore_x86::GetRegInfo() {
   return GetRegInfoShared(
       m_register_info_up->GetTargetArchitecture().GetMachine(),
       /*with_base=*/true);

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextLinuxCore_x86.h
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextLinuxCore_x86.h
@@ -1,4 +1,4 @@
-//===-- RegisterContextLinuxCore_x86_64.h -----------------------*- C++ -*-===//
+//===-- RegisterContextLinuxCore_x86.h --------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,15 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTLINUXCORE_X86_64_H
-#define LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTLINUXCORE_X86_64_H
+#ifndef LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTLINUXCORE_X86_H
+#define LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTLINUXCORE_X86_H
 
 #include "Plugins/Process/elf-core/RegisterUtilities.h"
-#include "RegisterContextPOSIXCore_x86_64.h"
+#include "RegisterContextPOSIXCore_x86.h"
 
-class RegisterContextLinuxCore_x86_64 : public RegisterContextCorePOSIX_x86_64 {
+class RegisterContextLinuxCore_x86 : public RegisterContextCorePOSIX_x86 {
 public:
-  RegisterContextLinuxCore_x86_64(
+  RegisterContextLinuxCore_x86(
       lldb_private::Thread &thread,
       lldb_private::RegisterInfoInterface *register_info,
       const lldb_private::DataExtractor &gpregset,
@@ -25,4 +25,4 @@ public:
   lldb_private::RegInfo &GetRegInfo() override;
 };
 
-#endif // LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTLINUXCORE_X86_64_H
+#endif // LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTLINUXCORE_X86_H

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_x86.cpp
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_x86.cpp
@@ -1,4 +1,4 @@
-//===-- RegisterContextPOSIXCore_x86_64.cpp -------------------------------===//
+//===-- RegisterContextPOSIXCore_x86.cpp ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,14 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "RegisterContextPOSIXCore_x86_64.h"
+#include "RegisterContextPOSIXCore_x86.h"
 #include "lldb/Target/Thread.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/RegisterValue.h"
 
 using namespace lldb_private;
 
-RegisterContextCorePOSIX_x86_64::RegisterContextCorePOSIX_x86_64(
+RegisterContextCorePOSIX_x86::RegisterContextCorePOSIX_x86(
     Thread &thread, RegisterInfoInterface *register_info,
     const DataExtractor &gpregset, llvm::ArrayRef<CoreNote> notes)
     : RegisterContextPOSIX_x86(thread, 0, register_info) {
@@ -36,25 +36,25 @@ RegisterContextCorePOSIX_x86_64::RegisterContextCorePOSIX_x86_64(
     m_fpregset.reset();
 }
 
-bool RegisterContextCorePOSIX_x86_64::ReadGPR() {
+bool RegisterContextCorePOSIX_x86::ReadGPR() {
   return m_gpregset != nullptr;
 }
 
-bool RegisterContextCorePOSIX_x86_64::ReadFPR() {
+bool RegisterContextCorePOSIX_x86::ReadFPR() {
   return m_fpregset != nullptr;
 }
 
-bool RegisterContextCorePOSIX_x86_64::WriteGPR() {
+bool RegisterContextCorePOSIX_x86::WriteGPR() {
   assert(0);
   return false;
 }
 
-bool RegisterContextCorePOSIX_x86_64::WriteFPR() {
+bool RegisterContextCorePOSIX_x86::WriteFPR() {
   assert(0);
   return false;
 }
 
-bool RegisterContextCorePOSIX_x86_64::ReadRegister(const RegisterInfo *reg_info,
+bool RegisterContextCorePOSIX_x86::ReadRegister(const RegisterInfo *reg_info,
                                                    RegisterValue &value) {
   const uint8_t *src;
   size_t offset;
@@ -79,21 +79,21 @@ bool RegisterContextCorePOSIX_x86_64::ReadRegister(const RegisterInfo *reg_info,
   return error.Success();
 }
 
-bool RegisterContextCorePOSIX_x86_64::ReadAllRegisterValues(
+bool RegisterContextCorePOSIX_x86::ReadAllRegisterValues(
     lldb::WritableDataBufferSP &data_sp) {
   return false;
 }
 
-bool RegisterContextCorePOSIX_x86_64::WriteRegister(
+bool RegisterContextCorePOSIX_x86::WriteRegister(
     const RegisterInfo *reg_info, const RegisterValue &value) {
   return false;
 }
 
-bool RegisterContextCorePOSIX_x86_64::WriteAllRegisterValues(
+bool RegisterContextCorePOSIX_x86::WriteAllRegisterValues(
     const lldb::DataBufferSP &data_sp) {
   return false;
 }
 
-bool RegisterContextCorePOSIX_x86_64::HardwareSingleStep(bool enable) {
+bool RegisterContextCorePOSIX_x86::HardwareSingleStep(bool enable) {
   return false;
 }

--- a/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_x86.h
+++ b/lldb/source/Plugins/Process/elf-core/RegisterContextPOSIXCore_x86.h
@@ -1,4 +1,4 @@
-//===-- RegisterContextPOSIXCore_x86_64.h -----------------------*- C++ -*-===//
+//===-- RegisterContextPOSIXCore_x86.h --------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,15 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTPOSIXCORE_X86_64_H
-#define LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTPOSIXCORE_X86_64_H
+#ifndef LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTPOSIXCORE_X86_H
+#define LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTPOSIXCORE_X86_H
 
 #include "Plugins/Process/Utility/RegisterContextPOSIX_x86.h"
 #include "Plugins/Process/elf-core/RegisterUtilities.h"
 
-class RegisterContextCorePOSIX_x86_64 : public RegisterContextPOSIX_x86 {
+class RegisterContextCorePOSIX_x86 : public RegisterContextPOSIX_x86 {
 public:
-  RegisterContextCorePOSIX_x86_64(
+  RegisterContextCorePOSIX_x86(
       lldb_private::Thread &thread,
       lldb_private::RegisterInfoInterface *register_info,
       const lldb_private::DataExtractor &gpregset,
@@ -46,4 +46,4 @@ private:
   std::unique_ptr<uint8_t[]> m_fpregset;
 };
 
-#endif // LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTPOSIXCORE_X86_64_H
+#endif // LLDB_SOURCE_PLUGINS_PROCESS_ELF_CORE_REGISTERCONTEXTPOSIXCORE_X86_H

--- a/lldb/source/Plugins/Process/elf-core/ThreadElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ThreadElfCore.cpp
@@ -30,7 +30,7 @@
 #include "Plugins/Process/Utility/RegisterInfoPOSIX_arm64.h"
 #include "Plugins/Process/Utility/RegisterInfoPOSIX_ppc64le.h"
 #include "ProcessElfCore.h"
-#include "RegisterContextLinuxCore_x86_64.h"
+#include "RegisterContextLinuxCore_x86.h"
 #include "RegisterContextPOSIXCore_arm.h"
 #include "RegisterContextPOSIXCore_arm64.h"
 #include "RegisterContextPOSIXCore_loongarch64.h"
@@ -39,7 +39,7 @@
 #include "RegisterContextPOSIXCore_riscv32.h"
 #include "RegisterContextPOSIXCore_riscv64.h"
 #include "RegisterContextPOSIXCore_s390x.h"
-#include "RegisterContextPOSIXCore_x86_64.h"
+#include "RegisterContextPOSIXCore_x86.h"
 #include "ThreadElfCore.h"
 
 #include <memory>
@@ -216,10 +216,10 @@ ThreadElfCore::CreateRegisterContextForFrame(StackFrame *frame) {
     case llvm::Triple::x86:
     case llvm::Triple::x86_64:
       if (is_linux) {
-        m_thread_reg_ctx_sp = std::make_shared<RegisterContextLinuxCore_x86_64>(
+        m_thread_reg_ctx_sp = std::make_shared<RegisterContextLinuxCore_x86>(
               *this, reg_interface, m_gpregset_data, m_notes);
       } else {
-        m_thread_reg_ctx_sp = std::make_shared<RegisterContextCorePOSIX_x86_64>(
+        m_thread_reg_ctx_sp = std::make_shared<RegisterContextCorePOSIX_x86>(
               *this, reg_interface, m_gpregset_data, m_notes);
       }
       break;

--- a/lldb/source/Plugins/Process/minidump/ThreadMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ThreadMinidump.cpp
@@ -17,7 +17,7 @@
 
 #include "Plugins/Process/Utility/RegisterContextLinux_i386.h"
 #include "Plugins/Process/Utility/RegisterContextLinux_x86_64.h"
-#include "Plugins/Process/elf-core/RegisterContextPOSIXCore_x86_64.h"
+#include "Plugins/Process/elf-core/RegisterContextPOSIXCore_x86.h"
 #include "Plugins/Process/elf-core/RegisterUtilities.h"
 
 #include "lldb/Target/RegisterContext.h"
@@ -73,7 +73,7 @@ ThreadMinidump::CreateRegisterContextForFrame(StackFrame *frame) {
       lldb::DataBufferSP buf =
           ConvertMinidumpContext_x86_32(m_gpregset_data, reg_interface);
       DataExtractor gpregset(buf, lldb::eByteOrderLittle, 4);
-      m_thread_reg_ctx_sp = std::make_shared<RegisterContextCorePOSIX_x86_64>(
+      m_thread_reg_ctx_sp = std::make_shared<RegisterContextCorePOSIX_x86>(
           *this, reg_interface, gpregset,
           llvm::ArrayRef<lldb_private::CoreNote>());
       break;
@@ -83,7 +83,7 @@ ThreadMinidump::CreateRegisterContextForFrame(StackFrame *frame) {
       lldb::DataBufferSP buf =
           ConvertMinidumpContext_x86_64(m_gpregset_data, reg_interface);
       DataExtractor gpregset(buf, lldb::eByteOrderLittle, 8);
-      m_thread_reg_ctx_sp = std::make_shared<RegisterContextCorePOSIX_x86_64>(
+      m_thread_reg_ctx_sp = std::make_shared<RegisterContextCorePOSIX_x86>(
           *this, reg_interface, gpregset,
           llvm::ArrayRef<lldb_private::CoreNote>());
       break;


### PR DESCRIPTION
These files run both on 32/64bit host and target. In LLVM the name x86 is for 32bit systems, but operating systems like FreeBSD, Linux, and NetBSD use x86 for shared code between 32/64bit. Usually i386 describes 32bit and amd64/x86_64 describe 64bit, and LLDB already follows these conventions under `Process/Utility` but not for other directories. Some files under those directories are named *_x86_64 even though they are used for both architectures, confusing LLDB developers. Thus, rename these files to *_x86 to clarify that they are used for both architectures.