### PR TITLE
[flang][OpenMP] Remove unused internal functions.

### DIFF
--- a/flang/test/Transforms/OpenMP/function-filtering-uncalled.mlir
+++ b/flang/test/Transforms/OpenMP/function-filtering-uncalled.mlir
@@ -1,0 +1,23 @@
+
+// RUN: fir-opt --omp-function-filtering %s | FileCheck %s
+
+// Test that uncalled internal procedures containing target regions are removed
+// on device side
+
+// CHECK-NOT: func.func @uncalled_internal_proc
+
+
+module attributes {omp.is_target_device = true} {
+  func.func @uncalled_internal_proc() -> ()
+      attributes {
+        fir.host_symbol = @main_program,
+        llvm.linkage = #llvm.linkage<internal>,
+        omp.declare_target =
+          #omp.declaretarget<device_type = (host), capture_clause = (to)>
+      } {
+    omp.target {
+      omp.terminator
+    }
+    func.return
+  }
+}


### PR DESCRIPTION
If an internal function is unused and contains target region, it creates a mismatch between host and device side resulting in an assertion failure in `OpenMPOpt`. This PR removes such functions from the device.

This is similar to https://github.com/llvm/llvm-project/pull/178937 but on function level.

Fixes #179930.