### PR TITLE
[Clang][Lexer] Reland "Detect SSE4.2 availability at runtime in fastParseASCIIIdentifier"

### DIFF
--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -762,4 +762,35 @@ void AnnotateIgnoreWritesEnd(const char *file, int line);
 #endif
 // clang-format on
 
+/// \macro LLVM_IS_X86
+/// Whether the target architecture is x86 / x86-64.
+#if defined(__x86_64__) || defined(__i386__)
+#define LLVM_IS_X86 1
+#else
+#define LLVM_IS_X86 0
+#endif
+
+/// \macro LLVM_TARGET_SSE42
+/// Function attribute to compile a function with SSE4.2 enabled.
+#if defined(__has_attribute) && __has_attribute(target)
+#define LLVM_TARGET_SSE42 __attribute__((target("sse4.2")))
+#else
+#define LLVM_TARGET_SSE42
+#endif
+
+#if __has_builtin(__builtin_cpu_supports)
+#define LLVM_CPU_SUPPORTS(feature) __builtin_cpu_supports(feature)
+#else
+#define LLVM_CPU_SUPPORTS(feature) 0
+#endif
+
+/// \macro LLVM_CPU_SUPPORTS_SSE42
+/// Expands to true if the runtime cpu supports SSE4.2, or if compiled with
+/// SSE4.2 enabled.
+#if defined(__SSE4_2__)
+#define LLVM_CPU_SUPPORTS_SSE42 1
+#else
+#define LLVM_CPU_SUPPORTS_SSE42 LLVM_CPU_SUPPORTS("sse4.2")
+#endif
+
 #endif

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -778,7 +778,8 @@ void AnnotateIgnoreWritesEnd(const char *file, int line);
 #define LLVM_TARGET_SSE42
 #endif
 
-#if __has_builtin(__builtin_cpu_supports)
+#if __has_builtin(__builtin_cpu_supports) &&                                   \
+    (defined(__linux__) || defined(__APPLE__))
 #define LLVM_CPU_SUPPORTS(feature) __builtin_cpu_supports(feature)
 #else
 #define LLVM_CPU_SUPPORTS(feature) 0


### PR DESCRIPTION
This PR reopens #175452 after it was merged then reverted by #177322 because of compilation failures and compatibility issues.

This change attempts to maximize usage of the SSE fast path in `fastParseASCIIIdentifier`.

If the binary is compiled with SSE4.2 enabled, or if we are not compiling for x86, then the behavior is the exact same, ensuring we have no regressions.
Otherwise, we compile both the SSE fast path and the scalar loop. At runtime, we check if SSE4.2 is available and dispatch to the right function by using `__builtin_cpu_supports`. If it _is_ available, this allows a net performance improvement. Otherwise, there's a very slight but negligible regression... I believe that's perfectly reasonable for a non-SSE4.2-supporting processor.

The benchmark results are available here: https://llvm-compile-time-tracker.com/compare.php?from=3192fe2c7b08912cc72c86471a593165b615dc28&to=8960c57a2e5880616d2dd549f8422ca91c864e86&stat=instructions%3Au.