### PR TITLE
[libc]  Size optimized defaults for baremetal

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -27,6 +27,17 @@
     },
     "LIBC_CONF_PRINTF_DISABLE_STRERROR": {
       "value": true
+    },
+    "LIBC_CONF_PRINTF_DISABLE_WIDE" : {
+      "value": true
+    }
+  },
+  "scanf": {
+    "LIBC_CONF_SCANF_DISABLE_INDEX_MODE": {
+      "value": true
+    },
+    "LIBC_CONF_SCANF_DISABLE_FLOAT": {
+      "value": true
     }
   },
   "qsort": {


### PR DESCRIPTION
Disabling options that bloat typical size constrained baremetal targets
and in general not common in these targets. These configuration changes
reduce binary size significantly in our 32 bit ARM target experiments.
