### PR TITLE
[MLIR][Python] Remove partial LLVM APIs in python bindings (5/n)

### DIFF
--- a/mlir/include/mlir/Bindings/Python/NanobindUtils.h
+++ b/mlir/include/mlir/Bindings/Python/NanobindUtils.h
@@ -82,24 +82,6 @@ private:
 namespace nanobind {
 namespace detail {
 
-/// Local helper adapted from llvm::join for a range, adding Separator between
-/// elements.
-template <typename Range>
-inline std::string joinRange(Range &&R, std::string_view Separator) {
-  auto Begin = R.begin();
-  auto End = R.end();
-  std::string S;
-  if (Begin == End)
-    return S;
-
-  S += *Begin;
-  while (++Begin != End) {
-    S += Separator;
-    S += *Begin;
-  }
-  return S;
-}
-
 /// Helper function to concatenate arguments into a `std::string`.
 template <typename... Ts>
 inline std::string join(const Ts &...args) {

--- a/mlir/include/mlir/Bindings/Python/NanobindUtils.h
+++ b/mlir/include/mlir/Bindings/Python/NanobindUtils.h
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <typeinfo>
 #include <variant>
@@ -80,6 +81,24 @@ private:
 
 namespace nanobind {
 namespace detail {
+
+/// Local helper adapted from llvm::join for a range, adding Separator between
+/// elements.
+template <typename Range>
+inline std::string joinRange(Range &&R, std::string_view Separator) {
+  auto Begin = R.begin();
+  auto End = R.end();
+  std::string S;
+  if (Begin == End)
+    return S;
+
+  S += *Begin;
+  while (++Begin != End) {
+    S += Separator;
+    S += *Begin;
+  }
+  return S;
+}
 
 /// Helper function to concatenate arguments into a `std::string`.
 template <typename... Ts>

--- a/mlir/lib/Bindings/Python/Globals.cpp
+++ b/mlir/lib/Bindings/Python/Globals.cpp
@@ -25,10 +25,8 @@ namespace nb = nanobind;
 using namespace mlir;
 
 /// Local helper adapted from llvm::Regex::escape.
-namespace {
-static const char RegexMetachars[] = "()^$|*+?.[]\\{}";
-
 static std::string escapeRegex(std::string_view String) {
+  static constexpr char RegexMetachars[] = "()^$|*+?.[]\\{}";
   std::string RegexStr;
   for (char C : String) {
     if (std::strchr(RegexMetachars, C))
@@ -37,7 +35,6 @@ static std::string escapeRegex(std::string_view String) {
   }
   return RegexStr;
 }
-} // namespace
 
 // -----------------------------------------------------------------------------
 // PyGlobals

--- a/mlir/lib/Bindings/Python/Globals.cpp
+++ b/mlir/lib/Bindings/Python/Globals.cpp
@@ -301,13 +301,13 @@ bool PyGlobals::TracebackLoc::isUserTracebackFilename(
   nanobind::ft_lock_guard lock(mutex);
   if (rebuildUserTracebackIncludeRegex) {
     userTracebackIncludeRegex.assign(
-        llvm::join(userTracebackIncludeFiles, "|"));
+        nanobind::detail::joinRange(userTracebackIncludeFiles, "|"));
     rebuildUserTracebackIncludeRegex = false;
     isUserTracebackFilenameCache.clear();
   }
   if (rebuildUserTracebackExcludeRegex) {
     userTracebackExcludeRegex.assign(
-        llvm::join(userTracebackExcludeFiles, "|"));
+        nanobind::detail::joinRange(userTracebackExcludeFiles, "|"));
     rebuildUserTracebackExcludeRegex = false;
     isUserTracebackFilenameCache.clear();
   }

--- a/mlir/lib/Bindings/Python/Globals.cpp
+++ b/mlir/lib/Bindings/Python/Globals.cpp
@@ -307,14 +307,12 @@ bool PyGlobals::TracebackLoc::isUserTracebackFilename(
     return os.str();
   };
   if (rebuildUserTracebackIncludeRegex) {
-    userTracebackIncludeRegex.assign(
-        joinWithPipe(userTracebackIncludeFiles));
+    userTracebackIncludeRegex.assign(joinWithPipe(userTracebackIncludeFiles));
     rebuildUserTracebackIncludeRegex = false;
     isUserTracebackFilenameCache.clear();
   }
   if (rebuildUserTracebackExcludeRegex) {
-    userTracebackExcludeRegex.assign(
-        joinWithPipe(userTracebackExcludeFiles));
+    userTracebackExcludeRegex.assign(joinWithPipe(userTracebackExcludeFiles));
     rebuildUserTracebackExcludeRegex = false;
     isUserTracebackFilenameCache.clear();
   }

--- a/mlir/lib/Bindings/Python/Globals.cpp
+++ b/mlir/lib/Bindings/Python/Globals.cpp
@@ -10,6 +10,7 @@
 
 #include <cstring>
 #include <optional>
+#include <sstream>
 #include <string_view>
 #include <vector>
 
@@ -296,15 +297,24 @@ void PyGlobals::TracebackLoc::registerTracebackFileExclusion(
 bool PyGlobals::TracebackLoc::isUserTracebackFilename(
     const std::string_view file) {
   nanobind::ft_lock_guard lock(mutex);
+  auto joinWithPipe = [](const std::unordered_set<std::string> &set) {
+    std::ostringstream os;
+    for (auto it = set.begin(); it != set.end(); ++it) {
+      if (it != set.begin())
+        os << "|";
+      os << *it;
+    }
+    return os.str();
+  };
   if (rebuildUserTracebackIncludeRegex) {
     userTracebackIncludeRegex.assign(
-        nanobind::detail::joinRange(userTracebackIncludeFiles, "|"));
+        joinWithPipe(userTracebackIncludeFiles));
     rebuildUserTracebackIncludeRegex = false;
     isUserTracebackFilenameCache.clear();
   }
   if (rebuildUserTracebackExcludeRegex) {
     userTracebackExcludeRegex.assign(
-        nanobind::detail::joinRange(userTracebackExcludeFiles, "|"));
+        joinWithPipe(userTracebackExcludeFiles));
     rebuildUserTracebackExcludeRegex = false;
     isUserTracebackFilenameCache.clear();
   }

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -988,7 +988,7 @@ PyDenseElementsAttribute::getBooleanBufferFromBitpackedAttribute() const {
   }
 
   int64_t numBooleans = mlirElementsAttrGetNumElements(*this);
-  int64_t numBitpackedBytes = llvm::divideCeil(numBooleans, 8);
+  int64_t numBitpackedBytes = (numBooleans + 7) / 8;
   uint8_t *bitpackedData = static_cast<uint8_t *>(
       const_cast<void *>(mlirDenseElementsAttrGetRawData(*this)));
   nb::ndarray<uint8_t, nb::numpy, nb::ndim<1>, nb::c_contig> packedArray(

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include <algorithm>
-#include <bit>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -125,12 +125,10 @@ Raises:
 namespace {
 /// Local helper checking if the current machine is little endian.
 bool isLittleEndian() {
-#if defined(__cpp_lib_endian)
-  return std::endian::native == std::endian::little;
-#else
   const uint16_t value = 1;
-  return *reinterpret_cast<const uint8_t *>(&value) == 1;
-#endif
+  unsigned char first_byte = 0;
+  std::memcpy(&first_byte, &value, 1);
+  return first_byte == 1;
 }
 
 /// Local helper adapted from llvm::scope_exit.

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -122,15 +122,15 @@ Raises:
     type or if the buffer does not meet expectations.
 )";
 
-namespace {
 /// Local helper checking if the current machine is little endian.
-bool isLittleEndian() {
+static bool isLittleEndian() {
   const uint16_t value = 1;
   unsigned char first_byte = 0;
   std::memcpy(&first_byte, &value, 1);
   return first_byte == 1;
 }
 
+namespace {
 /// Local helper adapted from llvm::scope_exit.
 template <typename Callable>
 class [[nodiscard]] scope_exit {
@@ -159,7 +159,6 @@ public:
 
 template <typename Callable>
 scope_exit(Callable) -> scope_exit<Callable>;
-
 } // namespace
 
 namespace mlir {


### PR DESCRIPTION
This PR continues work from https://github.com/llvm/llvm-project/pull/178290
Added local helper functions to avoid dependency on LLVM APIs.