### PR TITLE
workflows/release-task: Use less privileged token for uploading release notes (#180299)

### DIFF
--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -26,6 +26,9 @@ on:
         required: false
         type: boolean
     secrets:
+      LLVMBOT_WWW_RELEASES_PUSH:
+        description: "Secret used to push changes to llvmbot www-releases fork."
+        required: false
       WWW_RELEASES_TOKEN:
         description: "Secret used to create a PR with the documentation changes."
         required: false
@@ -81,6 +84,7 @@ jobs:
       - name: Upload Release Notes
         if: env.upload
         env:
+          PUSH_TOKEN: ${{ secrets.LLVMBOT_WWW_RELEASES_PUSH }}
           GH_TOKEN: ${{ secrets.WWW_RELEASES_TOKEN }}
         run: |
           mkdir -p www-releases/${{ inputs.release-version }}
@@ -91,5 +95,5 @@ jobs:
           git config user.email "llvmbot@llvm.org"
           git config user.name "llvmbot"
           git commit -a -m "Add ${{ inputs.release-version }} documentation"
-          git push --force  "https://$GH_TOKEN@github.com/llvmbot/www-releases.git" HEAD:refs/heads/${{ inputs.release-version }}
+          git push --force  "https://$PUSH_TOKEN@github.com/llvmbot/www-releases.git" HEAD:refs/heads/${{ inputs.release-version }}
           gh pr create -f -B main -H llvmbot:${{ inputs.release-version }}

--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -56,6 +56,7 @@ jobs:
       upload: true
     # Called workflows don't have access to secrets by default, so we need to explicitly pass secrets that we use.
     secrets:
+      LLVMBOT_WWW_RELEASES_PUSH: ${{ secrets.LLVMBOT_WWW_RELEASES_PUSH }}
       WWW_RELEASES_TOKEN: ${{ secrets.WWW_RELEASES_TOKEN }}
 
   release-doxygen:


### PR DESCRIPTION


We were using one token for both pushing to the llvmbot fork and for creating a pull request against the www-releases repository, since the fork and the repository have different owners, we were using a classic access token which has very coarse-grained permissions. By using two separate tokens, we limit the permissions to just what we need to do the task.

This is a re-commit of b6ee085068972a41f3b2735a9f7e3ca48eab0f00 minus the environment changes which were causing the workflow to fail.