### PR TITLE
[llvm/CAS] Add file-based APIs to `ObjectStore`

### DIFF
--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -106,6 +106,27 @@ public:
   /// Get an ID for \p Ref.
   virtual CASID getID(ObjectRef Ref) const = 0;
 
+  /// Stores the data of a file into ObjectStore.
+  ///
+  /// An underlying implementation could perform optimizations that reduce I/O
+  /// and disk space consumption.
+  ///
+  /// If there are any concurrent modifications to the file, the contents in the
+  /// CAS may be corrupt.
+  ///
+  /// \param FilePath the path of the file data.
+  virtual Expected<ObjectRef> storeFromFile(StringRef Path);
+
+  /// Exports the data of an object to a file path. It does not include any
+  /// references of the object.
+  ///
+  /// An underlying implementation could perform optimizations that reduce I/O
+  /// and disk space consumption.
+  ///
+  /// \param Node the object to read data from.
+  /// \param FilePath the path of the file data.
+  virtual Error exportDataToFile(ObjectHandle Node, StringRef Path) const;
+
   /// Get an existing reference to the object called \p ID.
   ///
   /// Returns \c None if the object is not stored in this CAS.
@@ -300,6 +321,11 @@ public:
 
   /// Get the content of the node. Valid as long as the CAS is valid.
   StringRef getData() const { return CAS->getDataString(H); }
+
+  /// Exports the data of an object to a file path.
+  Error exportDataToFile(StringRef Path) const {
+    return CAS->exportDataToFile(H, Path);
+  }
 
   friend bool operator==(const ObjectProxy &Proxy, ObjectRef Ref) {
     return Proxy.getRef() == Ref;

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -7,12 +7,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "BuiltinCAS.h"
+#include "OnDiskCommon.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/CAS/BuiltinCASContext.h"
+#include "llvm/CAS/BuiltinObjectHasher.h"
 #include "llvm/CAS/OnDiskCASLogger.h"
 #include "llvm/CAS/OnDiskGraphDB.h"
 #include "llvm/CAS/UnifiedOnDiskCache.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/IOSandbox.h"
+#include "llvm/Support/Path.h"
 
 using namespace llvm;
 using namespace llvm::cas;
@@ -35,6 +40,10 @@ public:
   Expected<bool> isMaterialized(ObjectRef Ref) const final;
 
   ArrayRef<char> getDataConst(ObjectHandle Node) const final;
+
+  Expected<ObjectRef> storeFromFile(StringRef Path) final;
+
+  Error exportDataToFile(ObjectHandle Node, StringRef Path) const final;
 
   void print(raw_ostream &OS) const final;
   Error validate(bool CheckHash) const final;
@@ -143,6 +152,55 @@ Expected<ObjectRef> OnDiskCAS::storeImpl(ArrayRef<uint8_t> ComputedHash,
   if (Error E = DB->store(*StoredID, IDs, Data))
     return std::move(E);
   return convertRef(*StoredID);
+}
+
+Expected<ObjectRef> OnDiskCAS::storeFromFile(StringRef Path) {
+  auto Hash = BuiltinObjectHasher<HasherT>::hashFile(Path);
+  if (LLVM_UNLIKELY(!Hash))
+    return Hash.takeError();
+  auto StoredID = DB->getReference(*Hash);
+  if (LLVM_UNLIKELY(!StoredID))
+    return StoredID.takeError();
+  if (Error E = DB->storeFile(*StoredID, Path))
+    return E;
+  return convertRef(*StoredID);
+}
+
+Error OnDiskCAS::exportDataToFile(ObjectHandle Node, StringRef Path) const {
+  auto FBData = DB->getInternalFileBackedObjectData(convertHandle(Node));
+  if (!FBData.FileInfo.has_value())
+    return BuiltinCAS::exportDataToFile(Node, Path);
+
+  // Optimized version using the underlying database file.
+  assert(FBData.FileInfo.has_value());
+
+  auto BypassSandbox = sys::sandbox::scopedDisable();
+
+  ondisk::UniqueTempFile UniqueTmp;
+  auto ExpectedPath = UniqueTmp.createAndCopyFrom(sys::path::parent_path(Path),
+                                                  FBData.FileInfo->FilePath);
+  if (!ExpectedPath)
+    return ExpectedPath.takeError();
+  StringRef TmpPath = *ExpectedPath;
+
+  if (FBData.FileInfo->IsFileNulTerminated) {
+    // Remove the nul terminator.
+    int FD;
+    if (std::error_code EC =
+            sys::fs::openFileForWrite(TmpPath, FD, sys::fs::CD_OpenExisting))
+      return createFileError(TmpPath, EC);
+    auto CloseFile = scope_exit([&FD] {
+      sys::fs::file_t File = sys::fs::convertFDToNativeFile(FD);
+      sys::fs::closeFile(File);
+    });
+    if (std::error_code EC = sys::fs::resize_file(FD, FBData.Data.size()))
+      return createFileError(TmpPath, EC);
+  }
+
+  if (Error E = UniqueTmp.renameTo(Path))
+    return E;
+
+  return Error::success();
 }
 
 Error OnDiskCAS::forEachRef(ObjectHandle Node,

--- a/llvm/lib/CAS/OnDiskCommon.cpp
+++ b/llvm/lib/CAS/OnDiskCommon.cpp
@@ -9,6 +9,7 @@
 #include "OnDiskCommon.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include <mutex>
 #include <thread>
@@ -213,4 +214,41 @@ Expected<uint64_t> cas::ondisk::getBootTime() {
 #else
   return 0;
 #endif
+}
+
+Expected<StringRef>
+cas::ondisk::UniqueTempFile::createAndCopyFrom(StringRef ParentPath,
+                                               StringRef CopyFromPath) {
+  // \c clonefile requires that the destination path doesn't exist. We create
+  // a "placeholder" temporary file, then modify its path a bit and use that
+  // for \c clonefile to write to.
+  // FIXME: Instead of creating a dummy file, add a new file system API for
+  // copying to a unique path that can loop while checking EEXIST.
+  SmallString<256> UniqueTmpPath;
+  SmallString<256> Model;
+  Model += ParentPath;
+  sys::path::append(Model, "%%%%%%%.tmp");
+  if (std::error_code EC = sys::fs::createUniqueFile(Model, UniqueTmpPath))
+    return createFileError(Model, EC);
+  TmpPath = UniqueTmpPath;
+  TmpPath += ".tmp"; // modify so that there's no file at that path.
+  // \c copy_file will use \c clonefile when applicable.
+  if (std::error_code EC = sys::fs::copy_file(CopyFromPath, TmpPath))
+    return createFileError(TmpPath, EC);
+
+  return TmpPath;
+}
+
+Error cas::ondisk::UniqueTempFile::renameTo(StringRef RenameToPath) {
+  if (std::error_code EC = sys::fs::rename(TmpPath, RenameToPath))
+    return createFileError(RenameToPath, EC);
+  TmpPath.clear();
+  return Error::success();
+}
+
+cas::ondisk::UniqueTempFile::~UniqueTempFile() {
+  if (!TmpPath.empty())
+    sys::fs::remove(TmpPath);
+  if (!UniqueTmpPath.empty())
+    sys::fs::remove(UniqueTmpPath);
 }

--- a/llvm/lib/CAS/OnDiskCommon.h
+++ b/llvm/lib/CAS/OnDiskCommon.h
@@ -70,6 +70,29 @@ Expected<size_t> preallocateFileTail(int FD, size_t CurrentSize,
 /// Error.
 Expected<uint64_t> getBootTime();
 
+/// Helper RAII class for copying a file to a unique file path. At destruction
+/// time it will delete any new temporary files created.
+class UniqueTempFile {
+public:
+  UniqueTempFile() = default;
+  ~UniqueTempFile();
+
+  /// Create a new unique file path under \p ParentPath and copy the contents
+  /// of \p CopyFromPath into it. It will use file cloning when applicable.
+  ///
+  /// \returns the new unique file path.
+  Expected<StringRef> createAndCopyFrom(StringRef ParentPath,
+                                        StringRef CopyFromPath);
+
+  /// Rename the new unique file to \p RenameToPath. This is useful to indicate
+  /// that the unique file doesn't need to be cleared at destruction time.
+  Error renameTo(StringRef RenameToPath);
+
+private:
+  SmallString<256> TmpPath;
+  SmallString<256> UniqueTmpPath;
+};
+
 } // namespace llvm::cas::ondisk
 
 #endif // LLVM_LIB_CAS_ONDISKCOMMON_H

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -2,6 +2,7 @@ set(ONDISK_CAS_TEST_SOURCES
   BuiltinObjectHasherTest.cpp
   BuiltinUnifiedCASDatabasesTest.cpp
   OnDiskCASLoggerTest.cpp
+  OnDiskCommonUtils.cpp
   OnDiskGraphDBTest.cpp
   OnDiskDataAllocatorTest.cpp
   OnDiskKeyValueDBTest.cpp

--- a/llvm/unittests/CAS/OnDiskCommonUtils.cpp
+++ b/llvm/unittests/CAS/OnDiskCommonUtils.cpp
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnDiskCommonUtils.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/Process.h"
+
+using namespace llvm;
+
+// Create a file with small size and and controlling the initial byte so
+// caller can create different contents.
+std::unique_ptr<unittest::TempFile>
+unittest::cas::createSmallFile(char initChar) {
+  auto TmpFile = std::make_unique<unittest::TempFile>(
+      "smallfile.o", /*Suffix=*/"", /*Contents=*/"", /*Unique=*/true);
+  StringRef Path = TmpFile->path();
+  std::error_code EC;
+  raw_fd_stream Out(Path, EC);
+  EXPECT_FALSE(EC);
+  SmallString<200> Data;
+  Data += initChar;
+  for (unsigned i = 1; i != 200; ++i) {
+    Data += i;
+  }
+  Out.write(Data.data(), Data.size());
+  return TmpFile;
+}
+
+std::unique_ptr<unittest::TempFile>
+unittest::cas::createLargeFile(char initChar) {
+  auto TmpFile = std::make_unique<unittest::TempFile>(
+      "largefile.o", /*Suffix=*/"", /*Contents=*/"",
+      /*Unique=*/true);
+  StringRef Path = TmpFile->path();
+  std::error_code EC;
+  raw_fd_stream Out(Path, EC);
+  EXPECT_FALSE(EC);
+  SmallString<200> Data;
+  Data += initChar;
+  for (unsigned i = 1; i != 200; ++i) {
+    Data += i;
+  }
+  for (unsigned i = 0; i != 1000; ++i) {
+    Out.write(Data.data(), Data.size());
+  }
+  return TmpFile;
+}
+
+std::unique_ptr<unittest::TempFile>
+unittest::cas::createLargePageAlignedFile(char initChar) {
+  auto TmpFile = std::make_unique<unittest::TempFile>(
+      "largepagealignedfile.o", /*Suffix=*/"", /*Contents=*/"",
+      /*Unique=*/true);
+  StringRef Path = TmpFile->path();
+  std::error_code EC;
+  raw_fd_stream Out(Path, EC);
+  EXPECT_FALSE(EC);
+  SmallString<256> Data;
+  Data += initChar;
+  for (unsigned i = 1; i != sys::Process::getPageSizeEstimate(); ++i) {
+    Data += char(i);
+  }
+  for (unsigned i = 0; i != 64; ++i) {
+    Out.write(Data.data(), Data.size());
+  }
+  Out.close();
+  uint64_t FileSize;
+  EC = sys::fs::file_size(Path, FileSize);
+  EXPECT_FALSE(EC);
+  assert(isAligned(Align(sys::Process::getPageSizeEstimate()), FileSize));
+  return TmpFile;
+}

--- a/llvm/unittests/CAS/OnDiskCommonUtils.h
+++ b/llvm/unittests/CAS/OnDiskCommonUtils.h
@@ -109,4 +109,8 @@ inline Error printTree(OnDiskGraphDB &DB, ObjectID ID, raw_ostream &OS,
   return Error::success();
 }
 
+std::unique_ptr<unittest::TempFile> createSmallFile(char initChar);
+std::unique_ptr<unittest::TempFile> createLargeFile(char initChar);
+std::unique_ptr<unittest::TempFile> createLargePageAlignedFile(char initChar);
+
 } // namespace llvm::unittest::cas


### PR DESCRIPTION
Also add optimized implementations for `OnDiskCAS` that can take advantage of file cloning.