### PR TITLE
[mlir][acc] Support lazy remark message construction

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h
+++ b/mlir/include/mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h
@@ -249,9 +249,10 @@ public:
   remark::detail::InFlightRemark
   emitRemark(Operation *op, const Twine &message,
              llvm::StringRef category = "openacc") {
-    return emitRemark(
-        op, std::function<std::string()>([msg = message.str()]() { return msg; }),
-        category);
+    return emitRemark(op, std::function<std::string()>([msg = message.str()]() {
+                        return msg;
+                      }),
+                      category);
   }
 
   /// Check if a symbol use is valid for use in an OpenACC region.

--- a/mlir/include/mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h
+++ b/mlir/include/mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h
@@ -55,6 +55,7 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/AnalysisManager.h"
 #include "llvm/ADT/StringRef.h"
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -85,7 +86,7 @@ struct OpenACCSupportTraits {
     // emitted. When not provided, in the default implementation, the category
     // is "openacc".
     virtual remark::detail::InFlightRemark
-    emitRemark(Operation *op, const Twine &message,
+    emitRemark(Operation *op, std::function<std::string()> messageFn,
                llvm::StringRef category) = 0;
 
     /// Check if a symbol use is valid for use in an OpenACC region.
@@ -120,8 +121,9 @@ struct OpenACCSupportTraits {
       decltype(std::declval<ImplT>().emitRemark(std::declval<Args>()...));
 
   template <typename ImplT>
-  using has_emitRemark = llvm::is_detected<emitRemark_t, ImplT, Operation *,
-                                           const Twine &, llvm::StringRef>;
+  using has_emitRemark =
+      llvm::is_detected<emitRemark_t, ImplT, Operation *,
+                        std::function<std::string()>, llvm::StringRef>;
 
   /// This class wraps a concrete OpenACCSupport implementation and forwards
   /// interface calls to it. This provides type erasure, allowing different
@@ -146,13 +148,13 @@ struct OpenACCSupportTraits {
       return impl.emitNYI(loc, message);
     }
 
-    remark::detail::InFlightRemark emitRemark(Operation *op,
-                                              const Twine &message,
-                                              llvm::StringRef category) final {
+    remark::detail::InFlightRemark
+    emitRemark(Operation *op, std::function<std::string()> messageFn,
+               llvm::StringRef category) final {
       if constexpr (has_emitRemark<ImplT>::value)
-        return impl.emitRemark(op, message, category);
+        return impl.emitRemark(op, std::move(messageFn), category);
       else
-        return acc::emitRemark(op, message, category);
+        return acc::emitRemark(op, messageFn(), category);
     }
 
     bool isValidSymbolUse(Operation *user, SymbolRefAttr symbol,
@@ -222,6 +224,21 @@ public:
   ///         unsupported case.
   InFlightDiagnostic emitNYI(Location loc, const Twine &message);
 
+  /// Emit an OpenACC remark with lazy message generation.
+  ///
+  /// The messageFn is only invoked if remarks are enabled for the given
+  /// operation, allowing callers to avoid constructing expensive messages
+  /// when remarks are disabled.
+  ///
+  /// \param op The operation to emit the remark for.
+  /// \param messageFn A callable that returns the remark message.
+  /// \param category Optional category for the remark. Defaults to "openacc".
+  /// \return An in-flight remark object that can be used to append
+  ///         additional information to the remark.
+  remark::detail::InFlightRemark
+  emitRemark(Operation *op, std::function<std::string()> messageFn,
+             llvm::StringRef category = "openacc");
+
   /// Emit an OpenACC remark.
   ///
   /// \param op The operation to emit the remark for.
@@ -231,7 +248,11 @@ public:
   ///         additional information to the remark.
   remark::detail::InFlightRemark
   emitRemark(Operation *op, const Twine &message,
-             llvm::StringRef category = "openacc");
+             llvm::StringRef category = "openacc") {
+    return emitRemark(
+        op, std::function<std::string()>([msg = message.str()]() { return msg; }),
+        category);
+  }
 
   /// Check if a symbol use is valid for use in an OpenACC region.
   ///

--- a/mlir/lib/Dialect/OpenACC/Analysis/OpenACCSupport.cpp
+++ b/mlir/lib/Dialect/OpenACC/Analysis/OpenACCSupport.cpp
@@ -42,11 +42,12 @@ InFlightDiagnostic OpenACCSupport::emitNYI(Location loc, const Twine &message) {
 }
 
 remark::detail::InFlightRemark
-OpenACCSupport::emitRemark(Operation *op, const Twine &message,
+OpenACCSupport::emitRemark(Operation *op,
+                           std::function<std::string()> messageFn,
                            llvm::StringRef category) {
   if (impl)
-    return impl->emitRemark(op, message, category);
-  return acc::emitRemark(op, message, category);
+    return impl->emitRemark(op, std::move(messageFn), category);
+  return acc::emitRemark(op, messageFn(), category);
 }
 
 bool OpenACCSupport::isValidSymbolUse(Operation *user, SymbolRefAttr symbol,

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsTest.cpp
@@ -488,6 +488,30 @@ TEST_F(OpenACCUtilsTest, getVariableNameFromCopyin) {
   EXPECT_EQ(varName, name);
 }
 
+TEST_F(OpenACCUtilsTest, getVariableNameConstantInt) {
+  // Create a constant integer value
+  OwningOpRef<arith::ConstantOp> constOp =
+      arith::ConstantOp::create(b, loc, b.getI64IntegerAttr(42));
+
+  Value constVal = constOp->getResult();
+
+  // Test that getVariableName returns the constant value as a string
+  std::string varName = getVariableName(constVal);
+  EXPECT_EQ(varName, "42");
+}
+
+TEST_F(OpenACCUtilsTest, getVariableNameNegativeConstantInt) {
+  // Create a negative constant integer value
+  OwningOpRef<arith::ConstantOp> constOp =
+      arith::ConstantOp::create(b, loc, b.getI64IntegerAttr(-123));
+
+  Value constVal = constOp->getResult();
+
+  // Test that getVariableName returns the negative constant value as a string
+  std::string varName = getVariableName(constVal);
+  EXPECT_EQ(varName, "-123");
+}
+
 //===----------------------------------------------------------------------===//
 // getRecipeName Tests
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The OpenACC remark emission utilities previously only accepted Twine for message construction. However, complex remarks often require additional logic to build messages, such as resolving variable names. This results in unnecessary work when remarks are disabled.

Add an overload that accepts a lambda for message generation, which is only invoked when remark emission is enabled. Update ACCLoopTiling to use this lazy API for tile size reporting.

Additionally, getVariableName now returns numeric strings for constant integer values. This is also being used by ACCLoopTiling along with the lazy remark update.