### PR TITLE
[RISCV] Add sp register as implicit/implicit-def register to save/restore call

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -2151,7 +2151,9 @@ bool RISCVFrameLowering::spillCalleeSavedRegisters(
     MachineInstrBuilder NewMI =
         BuildMI(MBB, MI, DL, TII.get(RISCV::PseudoCALLReg), RISCV::X5)
             .addExternalSymbol(SpillLibCall, RISCVII::MO_CALL)
-            .setMIFlag(MachineInstr::FrameSetup);
+            .setMIFlag(MachineInstr::FrameSetup)
+            .addUse(RISCV::X2, RegState::Implicit)
+            .addDef(RISCV::X2, RegState::ImplicitDefine);
 
     for (auto &CS : CSI) {
       // Add registers spilled as implicit used.
@@ -2300,7 +2302,8 @@ bool RISCVFrameLowering::restoreCalleeSavedRegisters(
     MachineInstrBuilder NewMI =
         BuildMI(MBB, MI, DL, TII.get(RISCV::PseudoTAIL))
             .addExternalSymbol(RestoreLibCall, RISCVII::MO_CALL)
-            .setMIFlag(MachineInstr::FrameDestroy);
+            .setMIFlag(MachineInstr::FrameDestroy)
+            .addDef(RISCV::X2, RegState::ImplicitDefine);
 
     // Add registers restored as implicit defined.
     for (auto &CS : CSI)

--- a/llvm/test/CodeGen/RISCV/zcmp-cm-popretz.mir
+++ b/llvm/test/CodeGen/RISCV/zcmp-cm-popretz.mir
@@ -30,13 +30,13 @@ body:                   |
     ; CHECK-LIBCALL32-LABEL: name: popret_rvlist5
     ; CHECK-LIBCALL32: liveins: $x1, $x8
     ; CHECK-LIBCALL32-NEXT: {{  $}}
-    ; CHECK-LIBCALL32-NEXT: $x5 = frame-setup PseudoCALLReg target-flags(riscv-call) &__riscv_save_1, implicit $x1, implicit $x8
+    ; CHECK-LIBCALL32-NEXT: $x5 = frame-setup PseudoCALLReg target-flags(riscv-call) &__riscv_save_1, implicit $x2, implicit-def $x2, implicit $x1, implicit $x8
     ; CHECK-LIBCALL32-NEXT: frame-setup CFI_INSTRUCTION def_cfa_offset 16
     ; CHECK-LIBCALL32-NEXT: frame-setup CFI_INSTRUCTION offset $x1, -4
     ; CHECK-LIBCALL32-NEXT: frame-setup CFI_INSTRUCTION offset $x8, -8
     ; CHECK-LIBCALL32-NEXT: $x1 = IMPLICIT_DEF
     ; CHECK-LIBCALL32-NEXT: $x8 = IMPLICIT_DEF
-    ; CHECK-LIBCALL32-NEXT: frame-destroy PseudoTAIL target-flags(riscv-call) &__riscv_restore_1, implicit $x2, implicit-def $x1, implicit-def $x8
+    ; CHECK-LIBCALL32-NEXT: frame-destroy PseudoTAIL target-flags(riscv-call) &__riscv_restore_1, implicit $x2, implicit-def $x2, implicit-def $x1, implicit-def $x8
     ;
     ; CHECK-ZCMP64-LABEL: name: popret_rvlist5
     ; CHECK-ZCMP64: liveins: $x1, $x8
@@ -52,13 +52,13 @@ body:                   |
     ; CHECK-LIBCALL64-LABEL: name: popret_rvlist5
     ; CHECK-LIBCALL64: liveins: $x1, $x8
     ; CHECK-LIBCALL64-NEXT: {{  $}}
-    ; CHECK-LIBCALL64-NEXT: $x5 = frame-setup PseudoCALLReg target-flags(riscv-call) &__riscv_save_1, implicit $x1, implicit $x8
+    ; CHECK-LIBCALL64-NEXT: $x5 = frame-setup PseudoCALLReg target-flags(riscv-call) &__riscv_save_1, implicit $x2, implicit-def $x2, implicit $x1, implicit $x8
     ; CHECK-LIBCALL64-NEXT: frame-setup CFI_INSTRUCTION def_cfa_offset 16
     ; CHECK-LIBCALL64-NEXT: frame-setup CFI_INSTRUCTION offset $x1, -8
     ; CHECK-LIBCALL64-NEXT: frame-setup CFI_INSTRUCTION offset $x8, -16
     ; CHECK-LIBCALL64-NEXT: $x1 = IMPLICIT_DEF
     ; CHECK-LIBCALL64-NEXT: $x8 = IMPLICIT_DEF
-    ; CHECK-LIBCALL64-NEXT: frame-destroy PseudoTAIL target-flags(riscv-call) &__riscv_restore_1, implicit $x2, implicit-def $x1, implicit-def $x8
+    ; CHECK-LIBCALL64-NEXT: frame-destroy PseudoTAIL target-flags(riscv-call) &__riscv_restore_1, implicit $x2, implicit-def $x2, implicit-def $x1, implicit-def $x8
     ;
     ; CHECK-NO-ZCMP32-LABEL: name: popret_rvlist5
     ; CHECK-NO-ZCMP32: liveins: $x1, $x8
@@ -120,14 +120,14 @@ body:                   |
     ; CHECK-LIBCALL32-LABEL: name: popretz_rvlist5
     ; CHECK-LIBCALL32: liveins: $x1, $x8
     ; CHECK-LIBCALL32-NEXT: {{  $}}
-    ; CHECK-LIBCALL32-NEXT: $x5 = frame-setup PseudoCALLReg target-flags(riscv-call) &__riscv_save_1, implicit $x1, implicit $x8
+    ; CHECK-LIBCALL32-NEXT: $x5 = frame-setup PseudoCALLReg target-flags(riscv-call) &__riscv_save_1, implicit $x2, implicit-def $x2, implicit $x1, implicit $x8
     ; CHECK-LIBCALL32-NEXT: frame-setup CFI_INSTRUCTION def_cfa_offset 16
     ; CHECK-LIBCALL32-NEXT: frame-setup CFI_INSTRUCTION offset $x1, -4
     ; CHECK-LIBCALL32-NEXT: frame-setup CFI_INSTRUCTION offset $x8, -8
     ; CHECK-LIBCALL32-NEXT: $x1 = IMPLICIT_DEF
     ; CHECK-LIBCALL32-NEXT: $x8 = IMPLICIT_DEF
     ; CHECK-LIBCALL32-NEXT: $x10 = ADDI $x0, 0
-    ; CHECK-LIBCALL32-NEXT: frame-destroy PseudoTAIL target-flags(riscv-call) &__riscv_restore_1, implicit $x2, implicit-def $x1, implicit-def $x8, implicit $x10
+    ; CHECK-LIBCALL32-NEXT: frame-destroy PseudoTAIL target-flags(riscv-call) &__riscv_restore_1, implicit $x2, implicit-def $x2, implicit-def $x1, implicit-def $x8, implicit $x10
     ;
     ; CHECK-ZCMP64-LABEL: name: popretz_rvlist5
     ; CHECK-ZCMP64: liveins: $x1, $x8
@@ -143,14 +143,14 @@ body:                   |
     ; CHECK-LIBCALL64-LABEL: name: popretz_rvlist5
     ; CHECK-LIBCALL64: liveins: $x1, $x8
     ; CHECK-LIBCALL64-NEXT: {{  $}}
-    ; CHECK-LIBCALL64-NEXT: $x5 = frame-setup PseudoCALLReg target-flags(riscv-call) &__riscv_save_1, implicit $x1, implicit $x8
+    ; CHECK-LIBCALL64-NEXT: $x5 = frame-setup PseudoCALLReg target-flags(riscv-call) &__riscv_save_1, implicit $x2, implicit-def $x2, implicit $x1, implicit $x8
     ; CHECK-LIBCALL64-NEXT: frame-setup CFI_INSTRUCTION def_cfa_offset 16
     ; CHECK-LIBCALL64-NEXT: frame-setup CFI_INSTRUCTION offset $x1, -8
     ; CHECK-LIBCALL64-NEXT: frame-setup CFI_INSTRUCTION offset $x8, -16
     ; CHECK-LIBCALL64-NEXT: $x1 = IMPLICIT_DEF
     ; CHECK-LIBCALL64-NEXT: $x8 = IMPLICIT_DEF
     ; CHECK-LIBCALL64-NEXT: $x10 = ADDI $x0, 0
-    ; CHECK-LIBCALL64-NEXT: frame-destroy PseudoTAIL target-flags(riscv-call) &__riscv_restore_1, implicit $x2, implicit-def $x1, implicit-def $x8, implicit $x10
+    ; CHECK-LIBCALL64-NEXT: frame-destroy PseudoTAIL target-flags(riscv-call) &__riscv_restore_1, implicit $x2, implicit-def $x2, implicit-def $x1, implicit-def $x8, implicit $x10
     ;
     ; CHECK-NO-ZCMP32-LABEL: name: popretz_rvlist5
     ; CHECK-NO-ZCMP32: liveins: $x1, $x8


### PR DESCRIPTION
This is a follow-up PR for https://github.com/llvm/llvm-project/pull/180133.