### PR TITLE
[clang][bytecode] Fix assertion failure when returning function type

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -937,6 +937,11 @@ std::optional<APValue> Pointer::toRValue(const Context &Ctx,
     llvm_unreachable("invalid value to return");
   };
 
+  // Can't return functions as rvalues.
+  if (ResultType->isFunctionType() || ResultType->isFunctionPointerType() ||
+      ResultType->isFunctionReferenceType())
+    return std::nullopt;
+
   // Invalid to read from.
   if (isDummy() || !isLive() || isPastEnd())
     return std::nullopt;

--- a/clang/test/AST/ByteCode/invalid.cpp
+++ b/clang/test/AST/ByteCode/invalid.cpp
@@ -170,3 +170,6 @@ constexpr int invalidUnaryOrTypeTrait() {
 }
 
 static_assert(invalidUnaryOrTypeTrait() == 11, ""); // both-error {{not an integral constant expression}}
+
+/// Pointer::toRValue() of a function type.
+void foo() { *(void (*)()) ""; } // both-warning {{expression result unused}}


### PR DESCRIPTION
... as an rvalue. Which can't work, so reject.