### PR TITLE
[clang][bytecode] Don't call InterpFrame::getThis() on the bottom frame

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1260,7 +1260,8 @@ static bool runRecordDestructor(InterpState &S, CodePtr OpPC,
   const Record *R = Desc->ElemRecord;
   assert(R);
 
-  if (S.Current->hasThisPointer() && S.Current->getFunction()->isDestructor() &&
+  if (!S.Current->isBottomFrame() && S.Current->hasThisPointer() &&
+      S.Current->getFunction()->isDestructor() &&
       Pointer::pointToSameBlock(BasePtr, S.Current->getThis())) {
     const SourceInfo &Loc = S.Current->getSource(OpPC);
     S.FFDiag(Loc, diag::note_constexpr_double_destroy);

--- a/clang/test/AST/ByteCode/new-delete.cpp
+++ b/clang/test/AST/ByteCode/new-delete.cpp
@@ -117,6 +117,12 @@ constexpr int AutoArray() {
 
 static_assert(AutoArray() == 3);
 
+namespace ThisPtrInRunRecordDestructor {
+  struct S {
+    constexpr ~S() { delete new S; };
+  };
+}
+
 #if 0
 consteval int largeArray1(bool b) {
   if (b) {


### PR DESCRIPTION
This happens when we're in checkingPotentialConstantExpression() and we try to evaluate a delete expression.