### PR TITLE
[clang][bytecode] Reject composite copies on primitive pointers

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -6110,6 +6110,11 @@ static bool copyComposite(InterpState &S, CodePtr OpPC, const Pointer &Src,
 }
 
 bool DoMemcpy(InterpState &S, CodePtr OpPC, const Pointer &Src, Pointer &Dest) {
+  if (!Src.isBlockPointer() || Src.getFieldDesc()->isPrimitive())
+    return false;
+  if (!Dest.isBlockPointer() || Dest.getFieldDesc()->isPrimitive())
+    return false;
+
   return copyComposite(S, OpPC, Src, Dest);
 }
 

--- a/clang/test/AST/ByteCode/complex.cpp
+++ b/clang/test/AST/ByteCode/complex.cpp
@@ -460,3 +460,12 @@ namespace Discard {
   }
   static_assert(test_side_effect() == 1);
 }
+
+namespace MemcpyOp {
+  const double x = 0.;
+
+  void foo() {
+    _Complex double z;
+    z = *(_Complex double *)&x;
+  };
+}


### PR DESCRIPTION
This should fail.