### PR TITLE
[clang][Lexer] Save and restore MIOpt in `peekNextPPToken()`

### DIFF
--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -3233,6 +3233,7 @@ std::optional<Token> Lexer::peekNextPPToken() {
   bool atStartOfLine = IsAtStartOfLine;
   bool atPhysicalStartOfLine = IsAtPhysicalStartOfLine;
   bool leadingSpace = HasLeadingSpace;
+  MultipleIncludeOpt SavedMIOpt = MIOpt;
 
   Token Tok;
   Lex(Tok);
@@ -3243,6 +3244,7 @@ std::optional<Token> Lexer::peekNextPPToken() {
   HasLeadingSpace = leadingSpace;
   IsAtStartOfLine = atStartOfLine;
   IsAtPhysicalStartOfLine = atPhysicalStartOfLine;
+  MIOpt = SavedMIOpt;
   // Restore the lexer back to non-skipping mode.
   LexingRawMode = false;
 


### PR DESCRIPTION
Fixes #180155. 

As statet [here](https://github.com/llvm/llvm-project/blob/main/clang/include/clang/Lex/Lexer.h#L126):
`Any state that mutates...must have save/restore code in Lexer::peekNextPPToken.`

Note: This bug was detected while working on #177315 and is verified in this PR (by using `clang-tidy`).
Unfortunately I am not able to create a test for this under `clang/test/` that fails without the fix.
Do you maybe have some idea how?