### PR TITLE
[clang][bytecode] Improve rejecting UnaryExprOrTypeTraitExprs

### DIFF
--- a/clang/test/AST/ByteCode/invalid.cpp
+++ b/clang/test/AST/ByteCode/invalid.cpp
@@ -171,5 +171,11 @@ constexpr int invalidUnaryOrTypeTrait() {
 
 static_assert(invalidUnaryOrTypeTrait() == 11, ""); // both-error {{not an integral constant expression}}
 
+constexpr int invalidUnaryOrTypeTrait2() {
+  return alignof * 10; // both-error {{indirection requires pointer operand}} \
+                       // both-warning {{'alignof' applied to an expression is a GNU extension}}
+}
+
 /// Pointer::toRValue() of a function type.
 void foo() { *(void (*)()) ""; } // both-warning {{expression result unused}}
+

--- a/clang/test/SemaCXX/alignof-sizeof-reference.cpp
+++ b/clang/test/SemaCXX/alignof-sizeof-reference.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify %s -fexperimental-new-constant-interpreter
 
 struct s0; // expected-note {{forward declaration}}
 char ar[sizeof(s0&)]; // expected-error {{invalid application of 'sizeof' to an incomplete type}}


### PR DESCRIPTION
Some of them work just fine, even if the expression contains errors.