### PR TITLE
[clang-tidy] Fix bugprone-bad-signal-to-kill-thread not working in clangd

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/BadSignalToKillThreadCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/BadSignalToKillThreadCheck.cpp
@@ -42,12 +42,11 @@ void BadSignalToKillThreadCheck::check(const MatchFinder::MatchResult &Result) {
     if (!T.isLiteral())
       return std::nullopt;
 
-    const char *Buffer = nullptr;
+    SmallVector<char> Buffer;
     bool Invalid = false;
-    const unsigned Length = PP->getSpelling(T, Buffer, &Invalid);
+    StringRef ValueStr = PP->getSpelling(T, Buffer, &Invalid);
     if (Invalid)
       return std::nullopt;
-    StringRef ValueStr(Buffer, Length);
 
     llvm::APInt IntValue;
     constexpr unsigned AutoSenseRadix = 0;

--- a/clang-tools-extra/clang-tidy/bugprone/BadSignalToKillThreadCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/BadSignalToKillThreadCheck.cpp
@@ -44,7 +44,7 @@ void BadSignalToKillThreadCheck::check(const MatchFinder::MatchResult &Result) {
 
     SmallVector<char> Buffer;
     bool Invalid = false;
-    StringRef ValueStr = PP->getSpelling(T, Buffer, &Invalid);
+    const StringRef ValueStr = PP->getSpelling(T, Buffer, &Invalid);
     if (Invalid)
       return std::nullopt;
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -144,6 +144,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/argument-comment>` to also check for C++11
   inherited constructors.
 
+- Improved :doc:`bugprone-bad-signal-to-kill-thread
+  <clang-tidy/checks/bugprone/bad-signal-to-kill-thread>` check by fixing false
+  negatives when the ``SIGTERM`` macro is obtained from a precompiled header.
+
 - Improved :doc:`bugprone-exception-escape
   <clang-tidy/checks/bugprone/exception-escape>` check by adding
   `TreatFunctionsWithoutSpecificationAsThrowing` option to support reporting


### PR DESCRIPTION
After preamble deserialization, `Token::getLiteralData()` returns `nullptr` for macro tokens defined in headers. Fall back to `SourceManager` to retrieve the token text from the source buffer.

Fixes https://github.com/clangd/clangd/issues/2473