### PR TITLE
[SPIRV] Replace `SPIRVType` with `SPIRVTypeInst` as much as we can

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -45,11 +45,11 @@ struct IncomingCall {
   const DemangledBuiltin *Builtin;
 
   const Register ReturnRegister;
-  const SPIRVType *ReturnType;
+  const SPIRVTypeInst ReturnType;
   const SmallVectorImpl<Register> &Arguments;
 
   IncomingCall(const std::string BuiltinName, const DemangledBuiltin *Builtin,
-               const Register ReturnRegister, const SPIRVType *ReturnType,
+               const Register ReturnRegister, SPIRVTypeInst ReturnType,
                const SmallVectorImpl<Register> &Arguments)
       : BuiltinName(std::move(BuiltinName)), Builtin(Builtin),
         ReturnRegister(ReturnRegister), ReturnType(ReturnType),
@@ -273,7 +273,7 @@ std::string lookupBuiltinNameHelper(StringRef DemangledCall,
 static std::unique_ptr<const SPIRV::IncomingCall>
 lookupBuiltin(StringRef DemangledCall,
               SPIRV::InstructionSet::InstructionSet Set,
-              Register ReturnRegister, const SPIRVType *ReturnType,
+              Register ReturnRegister, SPIRVTypeInst ReturnType,
               const SmallVectorImpl<Register> &Arguments) {
   std::string BuiltinName = SPIRV::lookupBuiltinNameHelper(DemangledCall);
 
@@ -439,11 +439,11 @@ static const Type *getBlockStructType(Register ParamReg,
 /// depending on the expected \p ResultType.
 ///
 /// \returns Tuple of the resulting register and its type.
-static std::tuple<Register, SPIRVType *>
-buildBoolRegister(MachineIRBuilder &MIRBuilder, const SPIRVType *ResultType,
+static std::tuple<Register, SPIRVTypeInst>
+buildBoolRegister(MachineIRBuilder &MIRBuilder, SPIRVTypeInst ResultType,
                   SPIRVGlobalRegistry *GR) {
   LLT Type;
-  SPIRVType *BoolType = GR->getOrCreateSPIRVBoolType(MIRBuilder, true);
+  SPIRVTypeInst BoolType = GR->getOrCreateSPIRVBoolType(MIRBuilder, true);
 
   if (ResultType->getOpcode() == SPIRV::OpTypeVector) {
     unsigned VectorElements = ResultType->getOperand(2).getImm();
@@ -467,8 +467,7 @@ buildBoolRegister(MachineIRBuilder &MIRBuilder, const SPIRVType *ResultType,
 /// depending on the expected \p ResultType.
 static bool buildSelectInst(MachineIRBuilder &MIRBuilder,
                             Register ReturnRegister, Register SourceRegister,
-                            const SPIRVType *ReturnType,
-                            SPIRVGlobalRegistry *GR) {
+                            SPIRVTypeInst ReturnType, SPIRVGlobalRegistry *GR) {
   Register TrueConst, FalseConst;
 
   if (ReturnType->getOpcode() == SPIRV::OpTypeVector) {
@@ -488,7 +487,7 @@ static bool buildSelectInst(MachineIRBuilder &MIRBuilder,
 
 /// Helper function for building a load instruction loading into the
 /// \p DestinationReg.
-static Register buildLoadInst(SPIRVType *BaseType, Register PtrRegister,
+static Register buildLoadInst(SPIRVTypeInst BaseType, Register PtrRegister,
                               MachineIRBuilder &MIRBuilder,
                               SPIRVGlobalRegistry *GR, LLT LowLevelType,
                               Register DestinationReg = Register(0)) {
@@ -504,7 +503,7 @@ static Register buildLoadInst(SPIRVType *BaseType, Register PtrRegister,
 /// Helper function for building a load instruction for loading a builtin global
 /// variable of \p BuiltinValue value.
 static Register buildBuiltinVariableLoad(
-    MachineIRBuilder &MIRBuilder, SPIRVType *VariableType,
+    MachineIRBuilder &MIRBuilder, SPIRVTypeInst VariableType,
     SPIRVGlobalRegistry *GR, SPIRV::BuiltIn::BuiltIn BuiltinValue, LLT LLType,
     Register Reg = Register(0), bool isConst = true,
     const std::optional<SPIRV::LinkageType::LinkageType> &LinkageTy = {
@@ -515,7 +514,7 @@ static Register buildBuiltinVariableLoad(
       NewRegister,
       LLT::pointer(storageClassToAddressSpace(SPIRV::StorageClass::Function),
                    GR->getPointerSize()));
-  SPIRVType *PtrType = GR->getOrCreateSPIRVPointerType(
+  SPIRVTypeInst PtrType = GR->getOrCreateSPIRVPointerType(
       VariableType, MIRBuilder, SPIRV::StorageClass::Input);
   GR->assignSPIRVTypeToVReg(PtrType, NewRegister, MIRBuilder.getMF());
 
@@ -534,7 +533,7 @@ static Register buildBuiltinVariableLoad(
 
 /// Helper external function for assigning SPIRVType to a register, ensuring the
 /// register class and type are set in MRI. Defined in SPIRVPreLegalizer.cpp.
-extern void updateRegType(Register Reg, Type *Ty, SPIRVType *SpirvTy,
+extern void updateRegType(Register Reg, Type *Ty, SPIRVTypeInst SpirvTy,
                           SPIRVGlobalRegistry *GR, MachineIRBuilder &MIB,
                           MachineRegisterInfo &MRI);
 
@@ -602,7 +601,7 @@ static void setRegClassIfNull(Register Reg, MachineRegisterInfo *MRI,
                               SPIRVGlobalRegistry *GR) {
   if (MRI->getRegClassOrNull(Reg))
     return;
-  SPIRVType *SpvType = GR->getSPIRVTypeForVReg(Reg);
+  SPIRVTypeInst SpvType = GR->getSPIRVTypeForVReg(Reg);
   MRI->setRegClass(Reg,
                    SpvType ? GR->getRegClass(SpvType) : &SPIRV::iIDRegClass);
 }
@@ -728,7 +727,7 @@ static bool buildAtomicCompareExchangeInst(
   Register ObjectPtr = Call->Arguments[0];   // Pointer (volatile A *object.)
   Register ExpectedArg = Call->Arguments[1]; // Comparator (C* expected).
   Register Desired = Call->Arguments[2];     // Value (C Desired).
-  SPIRVType *SpvDesiredTy = GR->getSPIRVTypeForVReg(Desired);
+  SPIRVTypeInst SpvDesiredTy = GR->getSPIRVTypeForVReg(Desired);
   LLT DesiredLLT = MRI->getType(Desired);
 
   assert(GR->getSPIRVTypeForVReg(ObjectPtr)->getOpcode() ==
@@ -739,7 +738,7 @@ static bool buildAtomicCompareExchangeInst(
                    : ExpectedType == SPIRV::OpTypePointer);
   assert(GR->isScalarOfType(Desired, SPIRV::OpTypeInt));
 
-  SPIRVType *SpvObjectPtrTy = GR->getSPIRVTypeForVReg(ObjectPtr);
+  SPIRVTypeInst SpvObjectPtrTy = GR->getSPIRVTypeForVReg(ObjectPtr);
   assert(SpvObjectPtrTy->getOperand(2).isReg() && "SPIRV type is expected");
   auto StorageClass = static_cast<SPIRV::StorageClass::StorageClass>(
       SpvObjectPtrTy->getOperand(1).getImm());
@@ -1162,7 +1161,7 @@ static unsigned getNumComponentsForDim(SPIRV::Dim::Dim dim) {
 }
 
 /// Helper function for obtaining the number of size components.
-static unsigned getNumSizeComponents(SPIRVType *imgType) {
+static unsigned getNumSizeComponents(SPIRVTypeInst imgType) {
   assert(imgType->getOpcode() == SPIRV::OpTypeImage);
   auto dim = static_cast<SPIRV::Dim::Dim>(imgType->getOperand(2).getImm());
   unsigned numComps = getNumComponentsForDim(dim);
@@ -1213,7 +1212,7 @@ getBuiltinCallArguments(const SPIRV::IncomingCall *Call, uint32_t BuiltinNumber,
   SmallVector<Register> Arguments;
   for (Register Argument : Call->Arguments) {
     Register VecArg = Argument;
-    SPIRVType *ArgumentType = GR->getSPIRVTypeForVReg(Argument);
+    SPIRVTypeInst ArgumentType = GR->getSPIRVTypeForVReg(Argument);
     if (ArgumentType != Call->ReturnType) {
       VecArg = createVirtualRegister(Call->ReturnType, GR, MIRBuilder);
       auto VecSplat = MIRBuilder.buildInstr(SPIRV::OpCompositeConstruct)
@@ -1291,7 +1290,7 @@ static bool generateRelationalInst(const SPIRV::IncomingCall *Call,
       SPIRV::lookupNativeBuiltin(Builtin->Name, Builtin->Set)->Opcode;
 
   Register CompareRegister;
-  SPIRVType *RelationType;
+  SPIRVTypeInst RelationType = nullptr;
   std::tie(CompareRegister, RelationType) =
       buildBoolRegister(MIRBuilder, Call->ReturnType, GR);
 
@@ -1347,9 +1346,9 @@ static bool generateGroupInst(const SPIRV::IncomingCall *Call,
 
   Register Arg0;
   if (GroupBuiltin->HasBoolArg) {
-    SPIRVType *BoolType = GR->getOrCreateSPIRVBoolType(MIRBuilder, true);
+    SPIRVTypeInst BoolType = GR->getOrCreateSPIRVBoolType(MIRBuilder, true);
     Register BoolReg = Call->Arguments[0];
-    SPIRVType *BoolRegType = GR->getSPIRVTypeForVReg(BoolReg);
+    SPIRVTypeInst BoolRegType = GR->getSPIRVTypeForVReg(BoolReg);
     if (!BoolRegType)
       report_fatal_error("Can't find a register's type definition");
     MachineInstr *ArgInstruction = getDefInstrMaybeConstant(BoolReg, MRI);
@@ -1375,7 +1374,7 @@ static bool generateGroupInst(const SPIRV::IncomingCall *Call,
   }
 
   Register GroupResultRegister = Call->ReturnRegister;
-  SPIRVType *GroupResultType = Call->ReturnType;
+  SPIRVTypeInst GroupResultType = Call->ReturnType;
 
   // TODO: maybe we need to check whether the result type is already boolean
   // and in this case do not insert select instruction.
@@ -1401,14 +1400,14 @@ static bool generateGroupInst(const SPIRV::IncomingCall *Call,
     // it's a work_group_broadcast(val, local_id_x, local_id_y) or
     // work_group_broadcast(val, local_id_x, local_id_y, local_id_z) call.
     Register ElemReg = Call->Arguments[1];
-    SPIRVType *ElemType = GR->getSPIRVTypeForVReg(ElemReg);
+    SPIRVTypeInst ElemType = GR->getSPIRVTypeForVReg(ElemReg);
     if (!ElemType || ElemType->getOpcode() != SPIRV::OpTypeInt)
       report_fatal_error("Expect an integer <LocalId> argument");
     unsigned VecLen = Call->Arguments.size() - 1;
     VecReg = MRI->createGenericVirtualRegister(
         LLT::fixed_vector(VecLen, MRI->getType(ElemReg)));
     MRI->setRegClass(VecReg, &SPIRV::vIDRegClass);
-    SPIRVType *VecType =
+    SPIRVTypeInst VecType =
         GR->getOrCreateSPIRVVectorType(ElemType, VecLen, MIRBuilder, true);
     GR->assignSPIRVTypeToVReg(VecType, VecReg, MIRBuilder.getMF());
     auto MIB =
@@ -1481,7 +1480,7 @@ static bool generateIntelSubgroupsInst(const SPIRV::IncomingCall *Call,
 
   if (IntelSubgroups->IsBlock) {
     // Minimal number or arguments set in TableGen records is 1
-    if (SPIRVType *Arg0Type = GR->getSPIRVTypeForVReg(Call->Arguments[0])) {
+    if (SPIRVTypeInst Arg0Type = GR->getSPIRVTypeForVReg(Call->Arguments[0])) {
       if (Arg0Type->getOpcode() == SPIRV::OpTypeImage) {
         // TODO: add required validation from the specification:
         // "'Image' must be an object whose type is OpTypeImage with a 'Sampled'
@@ -1636,7 +1635,7 @@ static bool genWorkgroupQuery(const SPIRV::IncomingCall *Call,
   Register IndexRegister = Call->Arguments[0];
   const unsigned ResultWidth = Call->ReturnType->getOperand(1).getImm();
   const unsigned PointerSize = GR->getPointerSize();
-  const SPIRVType *PointerSizeType =
+  const SPIRVTypeInst PointerSizeType =
       GR->getOrCreateSPIRVIntegerType(PointerSize, MIRBuilder);
   MachineRegisterInfo *MRI = MIRBuilder.getMRI();
   auto IndexInstruction = getDefInstrMaybeConstant(IndexRegister, MRI);
@@ -1955,16 +1954,16 @@ static bool generateICarryBorrowInst(const SPIRV::IncomingCall *Call,
       SPIRV::lookupNativeBuiltin(Builtin->Name, Builtin->Set)->Opcode;
 
   Register SRetReg = Call->Arguments[0];
-  SPIRVType *PtrRetType = GR->getSPIRVTypeForVReg(SRetReg);
-  SPIRVType *RetType = GR->getPointeeType(PtrRetType);
+  SPIRVTypeInst PtrRetType = GR->getSPIRVTypeForVReg(SRetReg);
+  SPIRVTypeInst RetType = GR->getPointeeType(PtrRetType);
   if (!RetType)
     report_fatal_error("The first parameter must be a pointer");
   if (RetType->getOpcode() != SPIRV::OpTypeStruct)
     report_fatal_error("Expected struct type result for the arithmetic with "
                        "overflow builtins");
 
-  SPIRVType *OpType1 = GR->getSPIRVTypeForVReg(Call->Arguments[1]);
-  SPIRVType *OpType2 = GR->getSPIRVTypeForVReg(Call->Arguments[2]);
+  SPIRVTypeInst OpType1 = GR->getSPIRVTypeForVReg(Call->Arguments[1]);
+  SPIRVTypeInst OpType2 = GR->getSPIRVTypeForVReg(Call->Arguments[2]);
   if (!OpType1 || !OpType2 || OpType1 != OpType2)
     report_fatal_error("Operands must have the same type");
   if (OpType1->getOpcode() == SPIRV::OpTypeVector)
@@ -2024,10 +2023,10 @@ static bool generateImageSizeQueryInst(const SPIRV::IncomingCall *Call,
           ? Call->ReturnType->getOperand(2).getImm()
           : 1;
   // Get the actual number of query result/size components.
-  SPIRVType *ImgType = GR->getSPIRVTypeForVReg(Call->Arguments[0]);
+  SPIRVTypeInst ImgType = GR->getSPIRVTypeForVReg(Call->Arguments[0]);
   unsigned NumActualRetComponents = getNumSizeComponents(ImgType);
   Register QueryResult = Call->ReturnRegister;
-  SPIRVType *QueryResultType = Call->ReturnType;
+  SPIRVTypeInst QueryResultType = Call->ReturnType;
   if (NumExpectedRetComponents != NumActualRetComponents) {
     unsigned Bitwidth = Call->ReturnType->getOpcode() == SPIRV::OpTypeInt
                             ? Call->ReturnType->getOperand(1).getImm()
@@ -2035,7 +2034,7 @@ static bool generateImageSizeQueryInst(const SPIRV::IncomingCall *Call,
     QueryResult = MIRBuilder.getMRI()->createGenericVirtualRegister(
         LLT::fixed_vector(NumActualRetComponents, Bitwidth));
     MIRBuilder.getMRI()->setRegClass(QueryResult, &SPIRV::vIDRegClass);
-    SPIRVType *IntTy = GR->getOrCreateSPIRVIntegerType(Bitwidth, MIRBuilder);
+    SPIRVTypeInst IntTy = GR->getOrCreateSPIRVIntegerType(Bitwidth, MIRBuilder);
     QueryResultType = GR->getOrCreateSPIRVVectorType(
         IntTy, NumActualRetComponents, MIRBuilder, true);
     GR->assignSPIRVTypeToVReg(QueryResultType, QueryResult, MIRBuilder.getMF());
@@ -2058,11 +2057,11 @@ static bool generateImageSizeQueryInst(const SPIRV::IncomingCall *Call,
     assert(ExtractedComposite < NumActualRetComponents &&
            "Invalid composite index!");
     Register TypeReg = GR->getSPIRVTypeID(Call->ReturnType);
-    SPIRVType *NewType = nullptr;
+    SPIRVTypeInst NewType = nullptr;
     if (QueryResultType->getOpcode() == SPIRV::OpTypeVector) {
       Register NewTypeReg = QueryResultType->getOperand(1).getReg();
       if (TypeReg != NewTypeReg &&
-          (NewType = GR->getSPIRVTypeForVReg(NewTypeReg)) != nullptr)
+          (NewType = GR->getSPIRVTypeForVReg(NewTypeReg)))
         TypeReg = NewTypeReg;
     }
     MIRBuilder.buildInstr(SPIRV::OpCompositeExtract)
@@ -2070,7 +2069,7 @@ static bool generateImageSizeQueryInst(const SPIRV::IncomingCall *Call,
         .addUse(TypeReg)
         .addUse(QueryResult)
         .addImm(ExtractedComposite);
-    if (NewType != nullptr)
+    if (NewType)
       updateRegType(Call->ReturnRegister, nullptr, NewType, GR, MIRBuilder,
                     MIRBuilder.getMF().getRegInfo());
   } else {
@@ -2177,8 +2176,8 @@ static bool generateReadImageInst(const StringRef DemangledCall,
           getSamplerParamFromBitmask(SamplerMask),
           getSamplerFilterModeFromBitmask(SamplerMask), MIRBuilder);
     }
-    SPIRVType *ImageType = GR->getSPIRVTypeForVReg(Image);
-    SPIRVType *SampledImageType =
+    SPIRVTypeInst ImageType = GR->getSPIRVTypeForVReg(Image);
+    SPIRVTypeInst SampledImageType =
         GR->getOrCreateOpTypeSampledImage(ImageType, MIRBuilder);
     Register SampledImage = MRI->createVirtualRegister(&SPIRV::iIDRegClass);
 
@@ -2192,7 +2191,7 @@ static bool generateReadImageInst(const StringRef DemangledCall,
                                        MIRBuilder);
 
     if (Call->ReturnType->getOpcode() != SPIRV::OpTypeVector) {
-      SPIRVType *TempType =
+      SPIRVTypeInst TempType =
           GR->getOrCreateSPIRVVectorType(Call->ReturnType, 4, MIRBuilder, true);
       Register TempRegister =
           MRI->createGenericVirtualRegister(GR->getRegType(TempType));
@@ -2267,8 +2266,8 @@ static bool generateSampleImageInst(const StringRef DemangledCall,
   } else if (Call->Builtin->Name.contains_insensitive("__spirv_SampledImage")) {
     // Create OpSampledImage.
     Register Image = Call->Arguments[0];
-    SPIRVType *ImageType = GR->getSPIRVTypeForVReg(Image);
-    SPIRVType *SampledImageType =
+    SPIRVTypeInst ImageType = GR->getSPIRVTypeForVReg(Image);
+    SPIRVTypeInst SampledImageType =
         GR->getOrCreateOpTypeSampledImage(ImageType, MIRBuilder);
     Register SampledImage =
         Call->ReturnRegister.isValid()
@@ -2288,10 +2287,10 @@ static bool generateSampleImageInst(const StringRef DemangledCall,
       ReturnType = ReturnType.substr(ReturnType.find("_R") + 2);
       ReturnType = ReturnType.substr(0, ReturnType.find('('));
     }
-    SPIRVType *Type =
-        Call->ReturnType
-            ? Call->ReturnType
-            : GR->getOrCreateSPIRVTypeByName(ReturnType, MIRBuilder, true);
+    SPIRVTypeInst Type = Call->ReturnType
+                             ? Call->ReturnType
+                             : SPIRVTypeInst(GR->getOrCreateSPIRVTypeByName(
+                                   ReturnType, MIRBuilder, true));
     if (!Type) {
       std::string DiagMsg =
           "Unable to recognize SPIRV type name: " + ReturnType;
@@ -2379,7 +2378,7 @@ static bool generateCoopMatrInst(const SPIRV::IncomingCall *Call,
     ImmArgs.push_back(getConstFromIntrinsic(Call->Arguments[LiteralIdx], MRI));
   Register TypeReg = GR->getSPIRVTypeID(Call->ReturnType);
   if (Opcode == SPIRV::OpCooperativeMatrixLengthKHR) {
-    SPIRVType *CoopMatrType = GR->getSPIRVTypeForVReg(Call->Arguments[0]);
+    SPIRVTypeInst CoopMatrType = GR->getSPIRVTypeForVReg(Call->Arguments[0]);
     if (!CoopMatrType)
       report_fatal_error("Can't find a register's type definition");
     MIRBuilder.buildInstr(Opcode)
@@ -2490,7 +2489,7 @@ static bool buildAPFixedPointInst(const SPIRV::IncomingCall *Call,
   if (IsSRet) {
     const LLT ValTy = MRI->getType(InputReg);
     Register ActualRetValReg = MRI->createGenericVirtualRegister(ValTy);
-    SPIRVType *InstructionType =
+    SPIRVTypeInst InstructionType =
         GR->getPointeeType(GR->getSPIRVTypeForVReg(InputReg));
     InputReg = Call->Arguments[1];
     auto InputType = GR->getTypeForSPIRVType(GR->getSPIRVTypeForVReg(InputReg));
@@ -2498,7 +2497,7 @@ static bool buildAPFixedPointInst(const SPIRV::IncomingCall *Call,
     if (InputType->getTypeID() == llvm::Type::TypeID::TypedPointerTyID) {
       LLT InputLLT = MRI->getType(InputReg);
       PtrInputReg = MRI->createGenericVirtualRegister(InputLLT);
-      SPIRVType *PtrType =
+      SPIRVTypeInst PtrType =
           GR->getPointeeType(GR->getSPIRVTypeForVReg(InputReg));
       MachineMemOperand *MMO1 = MIRBuilder.getMF().getMachineMemOperand(
           MachinePointerInfo(), MachineMemOperand::MOLoad,
@@ -2621,11 +2620,11 @@ static bool buildNDRange(const SPIRV::IncomingCall *Call,
                          MachineIRBuilder &MIRBuilder,
                          SPIRVGlobalRegistry *GR) {
   MachineRegisterInfo *MRI = MIRBuilder.getMRI();
-  SPIRVType *PtrType = GR->getSPIRVTypeForVReg(Call->Arguments[0]);
+  SPIRVTypeInst PtrType = GR->getSPIRVTypeForVReg(Call->Arguments[0]);
   assert(PtrType->getOpcode() == SPIRV::OpTypePointer &&
          PtrType->getOperand(2).isReg());
   Register TypeReg = PtrType->getOperand(2).getReg();
-  SPIRVType *StructType = GR->getSPIRVTypeForVReg(TypeReg);
+  SPIRVTypeInst StructType = GR->getSPIRVTypeForVReg(TypeReg);
   MachineFunction &MF = MIRBuilder.getMF();
   Register TmpReg = MRI->createVirtualRegister(&SPIRV::iIDRegClass);
   GR->assignSPIRVTypeToVReg(StructType, TmpReg, MF);
@@ -2639,7 +2638,7 @@ static bool buildNDRange(const SPIRV::IncomingCall *Call,
   Register GlobalWorkOffset = NumArgs <= 3 ? Register(0) : Call->Arguments[1];
   if (NumArgs < 4) {
     Register Const;
-    SPIRVType *SpvTy = GR->getSPIRVTypeForVReg(GlobalWorkSize);
+    SPIRVTypeInst SpvTy = GR->getSPIRVTypeForVReg(GlobalWorkSize);
     if (SpvTy->getOpcode() == SPIRV::OpTypePointer) {
       MachineInstr *DefInstr = MRI->getUniqueVRegDef(GlobalWorkSize);
       assert(DefInstr && isSpvIntrinsic(*DefInstr, Intrinsic::spv_gep) &&
@@ -2650,7 +2649,7 @@ static bool buildNDRange(const SPIRV::IncomingCall *Call,
       unsigned BitWidth = GR->getPointerSize() == 64 ? 64 : 32;
       Type *BaseTy = IntegerType::get(MF.getFunction().getContext(), BitWidth);
       Type *FieldTy = ArrayType::get(BaseTy, Size);
-      SPIRVType *SpvFieldTy = GR->getOrCreateSPIRVType(
+      SPIRVTypeInst SpvFieldTy = GR->getOrCreateSPIRVType(
           FieldTy, MIRBuilder, SPIRV::AccessQualifier::ReadWrite, true);
       GlobalWorkSize = MRI->createVirtualRegister(&SPIRV::iIDRegClass);
       GR->assignSPIRVTypeToVReg(SpvFieldTy, GlobalWorkSize, MF);
@@ -2683,7 +2682,7 @@ static bool buildNDRange(const SPIRV::IncomingCall *Call,
 }
 
 // TODO: maybe move to the global register.
-static SPIRVType *
+static SPIRVTypeInst
 getOrCreateSPIRVDeviceEventPointer(MachineIRBuilder &MIRBuilder,
                                    SPIRVGlobalRegistry *GR) {
   LLVMContext &Context = MIRBuilder.getMF().getFunction().getContext();
@@ -2700,7 +2699,7 @@ static bool buildEnqueueKernel(const SPIRV::IncomingCall *Call,
   const DataLayout &DL = MIRBuilder.getDataLayout();
   bool IsSpirvOp = Call->isSpirvOp();
   bool HasEvents = Call->Builtin->Name.contains("events") || IsSpirvOp;
-  const SPIRVType *Int32Ty = GR->getOrCreateSPIRVIntegerType(32, MIRBuilder);
+  const SPIRVTypeInst Int32Ty = GR->getOrCreateSPIRVIntegerType(32, MIRBuilder);
 
   // Make vararg instructions before OpEnqueueKernel.
   // Local sizes arguments: Sizes of block invoke arguments. Clang generates
@@ -2720,7 +2719,7 @@ static bool buildEnqueueKernel(const SPIRV::IncomingCall *Call,
         cast<ArrayType>(LocalSizeTy)->getNumElements();
     unsigned SC = storageClassToAddressSpace(SPIRV::StorageClass::Generic);
     const LLT LLType = LLT::pointer(SC, GR->getPointerSize());
-    const SPIRVType *PointerSizeTy = GR->getOrCreateSPIRVPointerType(
+    const SPIRVTypeInst PointerSizeTy = GR->getOrCreateSPIRVPointerType(
         Int32Ty, MIRBuilder, SPIRV::StorageClass::Function);
     for (unsigned I = 0; I < LocalSizeNum; ++I) {
       Register Reg = MRI->createVirtualRegister(&SPIRV::pIDRegClass);
@@ -2836,7 +2835,7 @@ static bool generateAsyncCopy(const SPIRV::IncomingCall *Call,
 
   switch (Opcode) {
   case SPIRV::OpGroupAsyncCopy: {
-    SPIRVType *NewType =
+    SPIRVTypeInst NewType =
         Call->ReturnType->getOpcode() == SPIRV::OpTypeEvent
             ? nullptr
             : GR->getOrCreateSPIRVTypeByName("spirv.Event", MIRBuilder, true);
@@ -2854,7 +2853,7 @@ static bool generateAsyncCopy(const SPIRV::IncomingCall *Call,
                                ? Call->Arguments[3]
                                : buildConstantIntReg32(1, MIRBuilder, GR))
                    .addUse(EventReg);
-    if (NewType != nullptr)
+    if (NewType)
       updateRegType(Call->ReturnRegister, nullptr, NewType, GR, MIRBuilder,
                     MIRBuilder.getMF().getRegInfo());
     return Res;
@@ -3028,7 +3027,7 @@ static bool generateAFPInst(const SPIRV::IncomingCall *Call,
     LLT PtrTy = MRI->getType(Call->Arguments[0]);
     DestReg = MRI->createGenericVirtualRegister(PtrTy);
     MRI->setRegClass(DestReg, &SPIRV::pIDRegClass);
-    SPIRVType *PointeeTy =
+    SPIRVTypeInst PointeeTy =
         GR->getPointeeType(GR->getSPIRVTypeForVReg(Call->Arguments[0]));
     MIB.addDef(DestReg);
     MIB.addUse(GR->getSPIRVTypeID(PointeeTy));
@@ -3173,7 +3172,7 @@ std::optional<bool> lowerBuiltin(const StringRef DemangledCall,
   LLVM_DEBUG(dbgs() << "Lowering builtin call: " << DemangledCall << "\n");
 
   // Lookup the builtin in the TableGen records.
-  SPIRVType *SpvType = GR->getSPIRVTypeForVReg(OrigRet);
+  SPIRVTypeInst SpvType = GR->getSPIRVTypeForVReg(OrigRet);
   assert(SpvType && "Inconsistent return register: expected valid type info");
   std::unique_ptr<const IncomingCall> Call =
       lookupBuiltin(DemangledCall, Set, OrigRet, SpvType, Args);
@@ -3380,24 +3379,24 @@ static Type *parseTypeString(const StringRef Name, LLVMContext &Context) {
 // Implementation functions for builtin types.
 //===----------------------------------------------------------------------===//
 
-static SPIRVType *getNonParameterizedType(const TargetExtType *ExtensionType,
-                                          const SPIRV::BuiltinType *TypeRecord,
-                                          MachineIRBuilder &MIRBuilder,
-                                          SPIRVGlobalRegistry *GR) {
+static SPIRVTypeInst
+getNonParameterizedType(const TargetExtType *ExtensionType,
+                        const SPIRV::BuiltinType *TypeRecord,
+                        MachineIRBuilder &MIRBuilder, SPIRVGlobalRegistry *GR) {
   unsigned Opcode = TypeRecord->Opcode;
   // Create or get an existing type from GlobalRegistry.
   return GR->getOrCreateOpTypeByOpcode(ExtensionType, MIRBuilder, Opcode);
 }
 
-static SPIRVType *getSamplerType(MachineIRBuilder &MIRBuilder,
-                                 SPIRVGlobalRegistry *GR) {
+static SPIRVTypeInst getSamplerType(MachineIRBuilder &MIRBuilder,
+                                    SPIRVGlobalRegistry *GR) {
   // Create or get an existing type from GlobalRegistry.
   return GR->getOrCreateOpTypeSampler(MIRBuilder);
 }
 
-static SPIRVType *getPipeType(const TargetExtType *ExtensionType,
-                              MachineIRBuilder &MIRBuilder,
-                              SPIRVGlobalRegistry *GR) {
+static SPIRVTypeInst getPipeType(const TargetExtType *ExtensionType,
+                                 MachineIRBuilder &MIRBuilder,
+                                 SPIRVGlobalRegistry *GR) {
   assert(ExtensionType->getNumIntParameters() == 1 &&
          "Invalid number of parameters for SPIR-V pipe builtin!");
   // Create or get an existing type from GlobalRegistry.
@@ -3406,14 +3405,14 @@ static SPIRVType *getPipeType(const TargetExtType *ExtensionType,
                                        ExtensionType->getIntParameter(0)));
 }
 
-static SPIRVType *getCoopMatrType(const TargetExtType *ExtensionType,
-                                  MachineIRBuilder &MIRBuilder,
-                                  SPIRVGlobalRegistry *GR) {
+static SPIRVTypeInst getCoopMatrType(const TargetExtType *ExtensionType,
+                                     MachineIRBuilder &MIRBuilder,
+                                     SPIRVGlobalRegistry *GR) {
   assert(ExtensionType->getNumIntParameters() == 4 &&
          "Invalid number of parameters for SPIR-V coop matrices builtin!");
   assert(ExtensionType->getNumTypeParameters() == 1 &&
          "SPIR-V coop matrices builtin type must have a type parameter!");
-  const SPIRVType *ElemType =
+  SPIRVTypeInst ElemType =
       GR->getOrCreateSPIRVType(ExtensionType->getTypeParameter(0), MIRBuilder,
                                SPIRV::AccessQualifier::ReadWrite, true);
   // Create or get an existing type from GlobalRegistry.
@@ -3423,18 +3422,18 @@ static SPIRVType *getCoopMatrType(const TargetExtType *ExtensionType,
       ExtensionType->getIntParameter(3), true);
 }
 
-static SPIRVType *getSampledImageType(const TargetExtType *OpaqueType,
-                                      MachineIRBuilder &MIRBuilder,
-                                      SPIRVGlobalRegistry *GR) {
-  SPIRVType *OpaqueImageType = GR->getImageType(
+static SPIRVTypeInst getSampledImageType(const TargetExtType *OpaqueType,
+                                         MachineIRBuilder &MIRBuilder,
+                                         SPIRVGlobalRegistry *GR) {
+  SPIRVTypeInst OpaqueImageType = GR->getImageType(
       OpaqueType, SPIRV::AccessQualifier::ReadOnly, MIRBuilder);
   // Create or get an existing type from GlobalRegistry.
   return GR->getOrCreateOpTypeSampledImage(OpaqueImageType, MIRBuilder);
 }
 
-static SPIRVType *getInlineSpirvType(const TargetExtType *ExtensionType,
-                                     MachineIRBuilder &MIRBuilder,
-                                     SPIRVGlobalRegistry *GR) {
+static SPIRVTypeInst getInlineSpirvType(const TargetExtType *ExtensionType,
+                                        MachineIRBuilder &MIRBuilder,
+                                        SPIRVGlobalRegistry *GR) {
   assert(ExtensionType->getNumIntParameters() == 3 &&
          "Inline SPIR-V type builtin takes an opcode, size, and alignment "
          "parameter");
@@ -3454,7 +3453,7 @@ static SPIRVType *getInlineSpirvType(const TargetExtType *ExtensionType,
         auto OperandValue = ParamEType->getIntParameter(0);
         auto *OperandType = ParamEType->getTypeParameter(0);
 
-        const SPIRVType *OperandSPIRVType = GR->getOrCreateSPIRVType(
+        SPIRVTypeInst OperandSPIRVType = GR->getOrCreateSPIRVType(
             OperandType, MIRBuilder, SPIRV::AccessQualifier::ReadWrite, true);
 
         Operands.push_back(MCOperand::createReg(GR->buildConstantInt(
@@ -3474,7 +3473,7 @@ static SPIRVType *getInlineSpirvType(const TargetExtType *ExtensionType,
         continue;
       }
     }
-    const SPIRVType *TypeOperand = GR->getOrCreateSPIRVType(
+    SPIRVTypeInst TypeOperand = GR->getOrCreateSPIRVType(
         Param, MIRBuilder, SPIRV::AccessQualifier::ReadWrite, true);
     Operands.push_back(MCOperand::createReg(GR->getSPIRVTypeID(TypeOperand)));
   }
@@ -3483,9 +3482,9 @@ static SPIRVType *getInlineSpirvType(const TargetExtType *ExtensionType,
                                     Operands);
 }
 
-static SPIRVType *getVulkanBufferType(const TargetExtType *ExtensionType,
-                                      MachineIRBuilder &MIRBuilder,
-                                      SPIRVGlobalRegistry *GR) {
+static SPIRVTypeInst getVulkanBufferType(const TargetExtType *ExtensionType,
+                                         MachineIRBuilder &MIRBuilder,
+                                         SPIRVGlobalRegistry *GR) {
   assert(ExtensionType->getNumTypeParameters() == 1 &&
          "Vulkan buffers have exactly one type for the type of the buffer.");
   assert(ExtensionType->getNumIntParameters() == 2 &&
@@ -3499,18 +3498,19 @@ static SPIRVType *getVulkanBufferType(const TargetExtType *ExtensionType,
   return GR->getOrCreateVulkanBufferType(MIRBuilder, T, SC, IsWritable);
 }
 
-static SPIRVType *getVulkanPushConstantType(const TargetExtType *ExtensionType,
-                                            MachineIRBuilder &MIRBuilder,
-                                            SPIRVGlobalRegistry *GR) {
+static SPIRVTypeInst
+getVulkanPushConstantType(const TargetExtType *ExtensionType,
+                          MachineIRBuilder &MIRBuilder,
+                          SPIRVGlobalRegistry *GR) {
   assert(ExtensionType->getNumTypeParameters() == 1 &&
          "Vulkan push constants have exactly one type as argument.");
   auto *T = ExtensionType->getTypeParameter(0);
   return GR->getOrCreateVulkanPushConstantType(MIRBuilder, T);
 }
 
-static SPIRVType *getLayoutType(const TargetExtType *ExtensionType,
-                                MachineIRBuilder &MIRBuilder,
-                                SPIRVGlobalRegistry *GR) {
+static SPIRVTypeInst getLayoutType(const TargetExtType *ExtensionType,
+                                   MachineIRBuilder &MIRBuilder,
+                                   SPIRVGlobalRegistry *GR) {
   return GR->getOrCreateLayoutType(MIRBuilder, ExtensionType);
 }
 
@@ -3564,10 +3564,10 @@ TargetExtType *parseBuiltinTypeNameToTargetExtType(std::string TypeName,
                             TypeParameters, IntParameters);
 }
 
-SPIRVType *lowerBuiltinType(const Type *OpaqueType,
-                            SPIRV::AccessQualifier::AccessQualifier AccessQual,
-                            MachineIRBuilder &MIRBuilder,
-                            SPIRVGlobalRegistry *GR) {
+SPIRVTypeInst
+lowerBuiltinType(const Type *OpaqueType,
+                 SPIRV::AccessQualifier::AccessQualifier AccessQual,
+                 MachineIRBuilder &MIRBuilder, SPIRVGlobalRegistry *GR) {
   // In LLVM IR, SPIR-V and OpenCL builtin types are represented as either
   // target(...) target extension types or pointers-to-opaque-structs. The
   // approach relying on structs is deprecated and works only in the non-opaque
@@ -3586,7 +3586,7 @@ SPIRVType *lowerBuiltinType(const Type *OpaqueType,
   const StringRef Name = BuiltinType->getName();
   LLVM_DEBUG(dbgs() << "Lowering builtin type: " << Name << "\n");
 
-  SPIRVType *TargetType;
+  SPIRVTypeInst TargetType = nullptr;
   if (Name == "spirv.Type") {
     TargetType = getInlineSpirvType(BuiltinType, MIRBuilder, GR);
   } else if (Name == "spirv.VulkanBuffer") {

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.h
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.h
@@ -79,10 +79,10 @@ TargetExtType *parseBuiltinTypeNameToTargetExtType(std::string TypeName,
 /// \return A machine instruction representing the OpType<...> SPIR-V type.
 ///
 /// \p Type is the special opaque/builtin type to be lowered.
-SPIRVType *lowerBuiltinType(const Type *Type,
-                            AccessQualifier::AccessQualifier AccessQual,
-                            MachineIRBuilder &MIRBuilder,
-                            SPIRVGlobalRegistry *GR);
+SPIRVTypeInst lowerBuiltinType(const Type *Type,
+                               AccessQualifier::AccessQualifier AccessQual,
+                               MachineIRBuilder &MIRBuilder,
+                               SPIRVGlobalRegistry *GR);
 } // namespace SPIRV
 } // namespace llvm
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVBUILTINS_H

--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -101,8 +101,8 @@ static ConstantInt *getConstInt(MDNode *MD, unsigned NumOp) {
 // invalidating logic behind global registry and duplicates tracker.
 static FunctionType *
 fixFunctionTypeIfPtrArgs(SPIRVGlobalRegistry *GR, const Function &F,
-                         FunctionType *FTy, const SPIRVType *SRetTy,
-                         const SmallVector<SPIRVType *, 4> &SArgTys) {
+                         FunctionType *FTy, SPIRVTypeInst SRetTy,
+                         const SmallVector<SPIRVTypeInst, 4> &SArgTys) {
   bool hasArgPtrs = false;
   for (auto &Arg : F.args()) {
     // check if it's an instance of a non-typed PointerType
@@ -151,10 +151,10 @@ getKernelArgTypeQual(const Function &F, unsigned ArgIdx) {
   return {};
 }
 
-static SPIRVType *getArgSPIRVType(const Function &F, unsigned ArgIdx,
-                                  SPIRVGlobalRegistry *GR,
-                                  MachineIRBuilder &MIRBuilder,
-                                  const SPIRVSubtarget &ST) {
+static SPIRVTypeInst getArgSPIRVType(const Function &F, unsigned ArgIdx,
+                                     SPIRVGlobalRegistry *GR,
+                                     MachineIRBuilder &MIRBuilder,
+                                     const SPIRVSubtarget &ST) {
   // Read argument's access qualifier from metadata or default.
   SPIRV::AccessQualifier::AccessQualifier ArgAccessQual =
       getArgAccessQual(F, ArgIdx);
@@ -262,7 +262,7 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
       static_cast<const SPIRVSubtarget *>(&MIRBuilder.getMF().getSubtarget());
 
   // Assign types and names to all args, and store their types for later.
-  SmallVector<SPIRVType *, 4> ArgTypeVRegs;
+  SmallVector<SPIRVTypeInst, 4> ArgTypeVRegs;
   if (VRegs.size() > 0) {
     unsigned i = 0;
     for (const auto &Arg : F.args()) {
@@ -270,7 +270,7 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
       // TODO: handle the case of multiple registers.
       if (VRegs[i].size() > 1)
         return false;
-      auto *SpirvTy = getArgSPIRVType(F, i, GR, MIRBuilder, *ST);
+      SPIRVTypeInst SpirvTy = getArgSPIRVType(F, i, GR, MIRBuilder, *ST);
       GR->assignSPIRVTypeToVReg(SpirvTy, VRegs[i][0], MIRBuilder.getMF());
       ArgTypeVRegs.push_back(SpirvTy);
 
@@ -371,10 +371,10 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
       FRetTy = DerivedTy;
     }
   }
-  SPIRVType *RetTy = GR->getOrCreateSPIRVType(
+  SPIRVTypeInst RetTy = GR->getOrCreateSPIRVType(
       FRetTy, MIRBuilder, SPIRV::AccessQualifier::ReadWrite, true);
   FTy = fixFunctionTypeIfPtrArgs(GR, F, FTy, RetTy, ArgTypeVRegs);
-  SPIRVType *FuncTy = GR->getOrCreateOpTypeFunctionWithArgs(
+  SPIRVTypeInst FuncTy = GR->getOrCreateOpTypeFunctionWithArgs(
       FTy, RetTy, ArgTypeVRegs, MIRBuilder);
   uint32_t FuncControl = getFunctionControl(F, ST);
 
@@ -449,11 +449,11 @@ void SPIRVCallLowering::produceIndirectPtrType(
   // Create indirect call data type if any
   MachineFunction &MF = MIRBuilder.getMF();
   const SPIRVSubtarget &ST = MF.getSubtarget<SPIRVSubtarget>();
-  SPIRVType *SpirvRetTy = GR->getOrCreateSPIRVType(
+  SPIRVTypeInst SpirvRetTy = GR->getOrCreateSPIRVType(
       IC.RetTy, MIRBuilder, SPIRV::AccessQualifier::ReadWrite, true);
-  SmallVector<SPIRVType *, 4> SpirvArgTypes;
+  SmallVector<SPIRVTypeInst, 4> SpirvArgTypes;
   for (size_t i = 0; i < IC.ArgTys.size(); ++i) {
-    SPIRVType *SPIRVTy = GR->getOrCreateSPIRVType(
+    SPIRVTypeInst SPIRVTy = GR->getOrCreateSPIRVType(
         IC.ArgTys[i], MIRBuilder, SPIRV::AccessQualifier::ReadWrite, true);
     SpirvArgTypes.push_back(SPIRVTy);
     if (!GR->getSPIRVTypeForVReg(IC.ArgRegs[i]))
@@ -462,13 +462,13 @@ void SPIRVCallLowering::produceIndirectPtrType(
     // SPIR-V function type:
     FunctionType *FTy =
         FunctionType::get(const_cast<Type *>(IC.RetTy), IC.ArgTys, false);
-    SPIRVType *SpirvFuncTy = GR->getOrCreateOpTypeFunctionWithArgs(
+    SPIRVTypeInst SpirvFuncTy = GR->getOrCreateOpTypeFunctionWithArgs(
         FTy, SpirvRetTy, SpirvArgTypes, MIRBuilder);
     // SPIR-V pointer to function type:
     auto SC = ST.canUseExtension(SPIRV::Extension::SPV_INTEL_function_pointers)
                   ? SPIRV::StorageClass::CodeSectionINTEL
                   : SPIRV::StorageClass::Function;
-    SPIRVType *IndirectFuncPtrTy =
+    SPIRVTypeInst IndirectFuncPtrTy =
         GR->getOrCreateSPIRVPointerType(SpirvFuncTy, MIRBuilder, SC);
     // Correct the Callee type
     GR->assignSPIRVTypeToVReg(IndirectFuncPtrTy, IC.Callee, MF);
@@ -536,7 +536,7 @@ bool SPIRVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
       assert(Arg.Regs.size() == 1 && "Call arg has multiple VRegs");
       Register ArgReg = Arg.Regs[0];
       ArgVRegs.push_back(ArgReg);
-      SPIRVType *SpvType = GR->getSPIRVTypeForVReg(ArgReg);
+      SPIRVTypeInst SpvType = GR->getSPIRVTypeForVReg(ArgReg);
       if (!SpvType) {
         Type *ArgTy = nullptr;
         if (auto *PtrArgTy = dyn_cast<PointerType>(Arg.Ty)) {
@@ -642,7 +642,7 @@ bool SPIRVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
   // Make sure there's a valid return reg, even for functions returning void.
   if (!ResVReg.isValid())
     ResVReg = MIRBuilder.getMRI()->createVirtualRegister(&SPIRV::iIDRegClass);
-  SPIRVType *RetType = GR->assignTypeToVReg(
+  SPIRVTypeInst RetType = GR->assignTypeToVReg(
       OrigRetTy, ResVReg, MIRBuilder, SPIRV::AccessQualifier::ReadWrite, true);
 
   // Emit the call instruction and its args.

--- a/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
@@ -251,7 +251,7 @@ bool SPIRVCombinerHelper::matchMatrixMultiply(MachineInstr &MI) const {
 
 SmallVector<Register, 4>
 SPIRVCombinerHelper::extractColumns(Register MatrixReg, uint32_t NumberOfCols,
-                                    SPIRVType *SpvColType,
+                                    SPIRVTypeInst SpvColType,
                                     SPIRVGlobalRegistry *GR) const {
   // If the matrix is a single colunm, return that single column.
   if (NumberOfCols == 1)
@@ -270,7 +270,7 @@ SPIRVCombinerHelper::extractColumns(Register MatrixReg, uint32_t NumberOfCols,
 
 SmallVector<Register, 4>
 SPIRVCombinerHelper::extractRows(Register MatrixReg, uint32_t NumRows,
-                                 uint32_t NumCols, SPIRVType *SpvRowType,
+                                 uint32_t NumCols, SPIRVTypeInst SpvRowType,
                                  SPIRVGlobalRegistry *GR) const {
   SmallVector<Register, 4> Rows;
   LLT VecTy = GR->getRegType(SpvRowType);
@@ -307,10 +307,10 @@ SPIRVCombinerHelper::extractRows(Register MatrixReg, uint32_t NumRows,
 }
 
 Register SPIRVCombinerHelper::computeDotProduct(Register RowA, Register ColB,
-                                                SPIRVType *SpvVecType,
+                                                SPIRVTypeInst SpvVecType,
                                                 SPIRVGlobalRegistry *GR) const {
   bool IsVectorOp = SpvVecType->getOpcode() == SPIRV::OpTypeVector;
-  SPIRVType *SpvScalarType = GR->getScalarOrVectorComponentType(SpvVecType);
+  SPIRVTypeInst SpvScalarType = GR->getScalarOrVectorComponentType(SpvVecType);
   bool IsFloatOp = SpvScalarType->getOpcode() == SPIRV::OpTypeFloat;
   LLT VecTy = GR->getRegType(SpvVecType);
 
@@ -336,7 +336,7 @@ Register SPIRVCombinerHelper::computeDotProduct(Register RowA, Register ColB,
 SmallVector<Register, 16>
 SPIRVCombinerHelper::computeDotProducts(const SmallVector<Register, 4> &RowsA,
                                         const SmallVector<Register, 4> &ColsB,
-                                        SPIRVType *SpvVecType,
+                                        SPIRVTypeInst SpvVecType,
                                         SPIRVGlobalRegistry *GR) const {
   SmallVector<Register, 16> ResultScalars;
   for (uint32_t J = 0; J < ColsB.size(); ++J) {
@@ -348,7 +348,7 @@ SPIRVCombinerHelper::computeDotProducts(const SmallVector<Register, 4> &RowsA,
   return ResultScalars;
 }
 
-SPIRVType *
+SPIRVTypeInst
 SPIRVCombinerHelper::getDotProductVectorType(Register ResReg, uint32_t K,
                                              SPIRVGlobalRegistry *GR) const {
   // Loop over all non debug uses of ResReg
@@ -389,7 +389,7 @@ void SPIRVCombinerHelper::applyMatrixMultiply(MachineInstr &MI) const {
   SPIRVGlobalRegistry *GR =
       MI.getMF()->getSubtarget<SPIRVSubtarget>().getSPIRVGlobalRegistry();
 
-  SPIRVType *SpvVecType = getDotProductVectorType(ResReg, NumColsA, GR);
+  SPIRVTypeInst SpvVecType = getDotProductVectorType(ResReg, NumColsA, GR);
   SmallVector<Register, 4> ColsB =
       extractColumns(BReg, NumColsB, SpvVecType, GR);
   SmallVector<Register, 4> RowsA =

--- a/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.h
+++ b/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.h
@@ -39,20 +39,21 @@ public:
   void applyMatrixMultiply(MachineInstr &MI) const;
 
 private:
-  SPIRVType *getDotProductVectorType(Register ResReg, uint32_t K,
-                                     SPIRVGlobalRegistry *GR) const;
+  SPIRVTypeInst getDotProductVectorType(Register ResReg, uint32_t K,
+                                        SPIRVGlobalRegistry *GR) const;
   SmallVector<Register, 4> extractColumns(Register BReg, uint32_t N,
-                                          SPIRVType *SpvVecType,
+                                          SPIRVTypeInst SpvVecType,
                                           SPIRVGlobalRegistry *GR) const;
   SmallVector<Register, 4> extractRows(Register AReg, uint32_t NumRows,
-                                       uint32_t NumCols, SPIRVType *SpvRowType,
+                                       uint32_t NumCols,
+                                       SPIRVTypeInst SpvRowType,
                                        SPIRVGlobalRegistry *GR) const;
   SmallVector<Register, 16>
   computeDotProducts(const SmallVector<Register, 4> &RowsA,
                      const SmallVector<Register, 4> &ColsB,
-                     SPIRVType *SpvVecType, SPIRVGlobalRegistry *GR) const;
+                     SPIRVTypeInst SpvVecType, SPIRVGlobalRegistry *GR) const;
   Register computeDotProduct(Register RowA, Register ColB,
-                             SPIRVType *SpvVecType,
+                             SPIRVTypeInst SpvVecType,
                              SPIRVGlobalRegistry *GR) const;
 };
 

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -184,7 +184,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
       return StrReg;
     };
 
-    const SPIRVType *VoidTy =
+    const SPIRVTypeInst VoidTy =
         GR->getOrCreateSPIRVType(Type::getVoidTy(*Context), MIRBuilder,
                                  SPIRV::AccessQualifier::ReadWrite, false);
 
@@ -209,7 +209,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
           return InstReg;
         };
 
-    const SPIRVType *I32Ty =
+    const SPIRVTypeInst I32Ty =
         GR->getOrCreateSPIRVType(Type::getInt32Ty(*Context), MIRBuilder,
                                  SPIRV::AccessQualifier::ReadWrite, false);
 

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -91,43 +91,43 @@ storageClassRequiresExplictLayout(SPIRV::StorageClass::StorageClass SC) {
 SPIRVGlobalRegistry::SPIRVGlobalRegistry(unsigned PointerSize)
     : PointerSize(PointerSize), Bound(0), CurMF(nullptr) {}
 
-SPIRVType *SPIRVGlobalRegistry::assignIntTypeToVReg(unsigned BitWidth,
-                                                    Register VReg,
-                                                    MachineInstr &I,
-                                                    const SPIRVInstrInfo &TII) {
-  SPIRVType *SpirvType = getOrCreateSPIRVIntegerType(BitWidth, I, TII);
+SPIRVTypeInst
+SPIRVGlobalRegistry::assignIntTypeToVReg(unsigned BitWidth, Register VReg,
+                                         MachineInstr &I,
+                                         const SPIRVInstrInfo &TII) {
+  SPIRVTypeInst SpirvType = getOrCreateSPIRVIntegerType(BitWidth, I, TII);
   assignSPIRVTypeToVReg(SpirvType, VReg, *CurMF);
   return SpirvType;
 }
 
-SPIRVType *
+SPIRVTypeInst
 SPIRVGlobalRegistry::assignFloatTypeToVReg(unsigned BitWidth, Register VReg,
                                            MachineInstr &I,
                                            const SPIRVInstrInfo &TII) {
-  SPIRVType *SpirvType = getOrCreateSPIRVFloatType(BitWidth, I, TII);
+  SPIRVTypeInst SpirvType = getOrCreateSPIRVFloatType(BitWidth, I, TII);
   assignSPIRVTypeToVReg(SpirvType, VReg, *CurMF);
   return SpirvType;
 }
 
-SPIRVType *SPIRVGlobalRegistry::assignVectTypeToVReg(
-    SPIRVType *BaseType, unsigned NumElements, Register VReg, MachineInstr &I,
-    const SPIRVInstrInfo &TII) {
-  SPIRVType *SpirvType =
+SPIRVTypeInst SPIRVGlobalRegistry::assignVectTypeToVReg(
+    SPIRVTypeInst BaseType, unsigned NumElements, Register VReg,
+    MachineInstr &I, const SPIRVInstrInfo &TII) {
+  SPIRVTypeInst SpirvType =
       getOrCreateSPIRVVectorType(BaseType, NumElements, I, TII);
   assignSPIRVTypeToVReg(SpirvType, VReg, *CurMF);
   return SpirvType;
 }
 
-SPIRVType *SPIRVGlobalRegistry::assignTypeToVReg(
+SPIRVTypeInst SPIRVGlobalRegistry::assignTypeToVReg(
     const Type *Type, Register VReg, MachineIRBuilder &MIRBuilder,
     SPIRV::AccessQualifier::AccessQualifier AccessQual, bool EmitIR) {
-  SPIRVType *SpirvType =
+  SPIRVTypeInst SpirvType =
       getOrCreateSPIRVType(Type, MIRBuilder, AccessQual, EmitIR);
   assignSPIRVTypeToVReg(SpirvType, VReg, MIRBuilder.getMF());
   return SpirvType;
 }
 
-void SPIRVGlobalRegistry::assignSPIRVTypeToVReg(SPIRVType *SpirvType,
+void SPIRVGlobalRegistry::assignSPIRVTypeToVReg(SPIRVTypeInst SpirvType,
                                                 Register VReg,
                                                 const MachineFunction &MF) {
   VRegToTypeMap[&MF][VReg] = SpirvType;
@@ -143,7 +143,7 @@ inline Register createTypeVReg(MachineIRBuilder &MIRBuilder) {
   return createTypeVReg(MIRBuilder.getMF().getRegInfo());
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypeBool(MachineIRBuilder &MIRBuilder) {
+SPIRVTypeInst SPIRVGlobalRegistry::getOpTypeBool(MachineIRBuilder &MIRBuilder) {
   return createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
     return MIRBuilder.buildInstr(SPIRV::OpTypeBool)
         .addDef(createTypeVReg(MIRBuilder));
@@ -169,9 +169,9 @@ unsigned SPIRVGlobalRegistry::adjustOpTypeIntWidth(unsigned Width) const {
   reportFatalUsageError("Unsupported Integer width!");
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypeInt(unsigned Width,
-                                             MachineIRBuilder &MIRBuilder,
-                                             bool IsSigned) {
+SPIRVTypeInst SPIRVGlobalRegistry::getOpTypeInt(unsigned Width,
+                                                MachineIRBuilder &MIRBuilder,
+                                                bool IsSigned) {
   Width = adjustOpTypeIntWidth(Width);
   const SPIRVSubtarget &ST =
       cast<SPIRVSubtarget>(MIRBuilder.getMF().getSubtarget());
@@ -196,8 +196,9 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeInt(unsigned Width,
   });
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypeFloat(uint32_t Width,
-                                               MachineIRBuilder &MIRBuilder) {
+SPIRVTypeInst
+SPIRVGlobalRegistry::getOpTypeFloat(uint32_t Width,
+                                    MachineIRBuilder &MIRBuilder) {
   return createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
     return MIRBuilder.buildInstr(SPIRV::OpTypeFloat)
         .addDef(createTypeVReg(MIRBuilder))
@@ -205,7 +206,7 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeFloat(uint32_t Width,
   });
 }
 
-SPIRVType *
+SPIRVTypeInst
 SPIRVGlobalRegistry::getOpTypeFloat(uint32_t Width,
                                     MachineIRBuilder &MIRBuilder,
                                     SPIRV::FPEncoding::FPEncoding FPEncode) {
@@ -217,7 +218,7 @@ SPIRVGlobalRegistry::getOpTypeFloat(uint32_t Width,
   });
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypeVoid(MachineIRBuilder &MIRBuilder) {
+SPIRVTypeInst SPIRVGlobalRegistry::getOpTypeVoid(MachineIRBuilder &MIRBuilder) {
   return createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
     return MIRBuilder.buildInstr(SPIRV::OpTypeVoid)
         .addDef(createTypeVReg(MIRBuilder));
@@ -306,9 +307,9 @@ SPIRVType *SPIRVGlobalRegistry::createOpType(
   return Type;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypeVector(uint32_t NumElems,
-                                                SPIRVType *ElemType,
-                                                MachineIRBuilder &MIRBuilder) {
+SPIRVTypeInst
+SPIRVGlobalRegistry::getOpTypeVector(uint32_t NumElems, SPIRVTypeInst ElemType,
+                                     MachineIRBuilder &MIRBuilder) {
   auto EleOpc = ElemType->getOpcode();
   (void)EleOpc;
   assert((EleOpc == SPIRV::OpTypeInt || EleOpc == SPIRV::OpTypeFloat ||
@@ -324,7 +325,7 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeVector(uint32_t NumElems,
 }
 
 Register SPIRVGlobalRegistry::getOrCreateConstFP(APFloat Val, MachineInstr &I,
-                                                 SPIRVType *SpvType,
+                                                 SPIRVTypeInst SpvType,
                                                  const SPIRVInstrInfo &TII,
                                                  bool ZeroAsNull) {
   LLVMContext &Ctx = CurMF->getFunction().getContext();
@@ -337,7 +338,8 @@ Register SPIRVGlobalRegistry::getOrCreateConstFP(APFloat Val, MachineInstr &I,
 }
 
 Register SPIRVGlobalRegistry::createConstFP(const ConstantFP *CF,
-                                            MachineInstr &I, SPIRVType *SpvType,
+                                            MachineInstr &I,
+                                            SPIRVTypeInst SpvType,
                                             const SPIRVInstrInfo &TII,
                                             bool ZeroAsNull) {
   unsigned BitWidth = getScalarOrVectorBitWidth(SpvType);
@@ -346,7 +348,8 @@ Register SPIRVGlobalRegistry::createConstFP(const ConstantFP *CF,
   CurMF->getRegInfo().setRegClass(Res, &SPIRV::fIDRegClass);
   assignSPIRVTypeToVReg(SpvType, Res, *CurMF);
 
-  MachineInstr *DepMI = const_cast<MachineInstr *>(SpvType);
+  MachineInstr *DepMI =
+      const_cast<MachineInstr *>(static_cast<const MachineInstr *>(SpvType));
   MachineIRBuilder MIRBuilder(*DepMI->getParent(), DepMI->getIterator());
   SPIRVType *NewType =
       createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
@@ -375,7 +378,7 @@ Register SPIRVGlobalRegistry::createConstFP(const ConstantFP *CF,
 }
 
 Register SPIRVGlobalRegistry::getOrCreateConstInt(uint64_t Val, MachineInstr &I,
-                                                  SPIRVType *SpvType,
+                                                  SPIRVTypeInst SpvType,
                                                   const SPIRVInstrInfo &TII,
                                                   bool ZeroAsNull) {
   return getOrCreateConstInt(APInt(getScalarOrVectorBitWidth(SpvType), Val), I,
@@ -384,7 +387,7 @@ Register SPIRVGlobalRegistry::getOrCreateConstInt(uint64_t Val, MachineInstr &I,
 
 Register SPIRVGlobalRegistry::getOrCreateConstInt(const APInt &Val,
                                                   MachineInstr &I,
-                                                  const SPIRVType *SpvType,
+                                                  SPIRVTypeInst SpvType,
                                                   const SPIRVInstrInfo &TII,
                                                   bool ZeroAsNull) {
   auto *const CI = ConstantInt::get(
@@ -398,7 +401,7 @@ Register SPIRVGlobalRegistry::getOrCreateConstInt(const APInt &Val,
 
 Register SPIRVGlobalRegistry::createConstInt(const ConstantInt *CI,
                                              MachineInstr &I,
-                                             SPIRVType *SpvType,
+                                             SPIRVTypeInst SpvType,
                                              const SPIRVInstrInfo &TII,
                                              bool ZeroAsNull) {
   unsigned BitWidth = getScalarOrVectorBitWidth(SpvType);
@@ -407,7 +410,8 @@ Register SPIRVGlobalRegistry::createConstInt(const ConstantInt *CI,
   CurMF->getRegInfo().setRegClass(Res, &SPIRV::iIDRegClass);
   assignIntTypeToVReg(BitWidth, Res, I, TII);
 
-  MachineInstr *DepMI = const_cast<MachineInstr *>(SpvType);
+  MachineInstr *DepMI =
+      const_cast<MachineInstr *>(static_cast<const MachineInstr *>(SpvType));
   MachineIRBuilder MIRBuilder(*DepMI->getParent(), DepMI->getIterator());
   SPIRVType *NewType =
       createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
@@ -440,8 +444,8 @@ Register SPIRVGlobalRegistry::createConstInt(const ConstantInt *CI,
 
 Register SPIRVGlobalRegistry::buildConstantInt(uint64_t Val,
                                                MachineIRBuilder &MIRBuilder,
-                                               SPIRVType *SpvType, bool EmitIR,
-                                               bool ZeroAsNull) {
+                                               SPIRVTypeInst SpvType,
+                                               bool EmitIR, bool ZeroAsNull) {
   assert(SpvType);
   auto &MF = MIRBuilder.getMF();
   const IntegerType *Ty = cast<IntegerType>(getTypeForSPIRVType(SpvType));
@@ -489,7 +493,7 @@ Register SPIRVGlobalRegistry::buildConstantInt(uint64_t Val,
 
 Register SPIRVGlobalRegistry::buildConstantFP(APFloat Val,
                                               MachineIRBuilder &MIRBuilder,
-                                              SPIRVType *SpvType) {
+                                              SPIRVTypeInst SpvType) {
   auto &MF = MIRBuilder.getMF();
   LLVMContext &Ctx = MF.getFunction().getContext();
   if (!SpvType)
@@ -519,27 +523,27 @@ Register SPIRVGlobalRegistry::buildConstantFP(APFloat Val,
 }
 
 Register SPIRVGlobalRegistry::getOrCreateBaseRegister(
-    Constant *Val, MachineInstr &I, SPIRVType *SpvType,
+    Constant *Val, MachineInstr &I, SPIRVTypeInst SpvType,
     const SPIRVInstrInfo &TII, unsigned BitWidth, bool ZeroAsNull) {
-  SPIRVType *Type = SpvType;
+  SPIRVTypeInst Type = SpvType;
   if (SpvType->getOpcode() == SPIRV::OpTypeVector ||
       SpvType->getOpcode() == SPIRV::OpTypeArray) {
     auto EleTypeReg = SpvType->getOperand(1).getReg();
     Type = getSPIRVTypeForVReg(EleTypeReg);
   }
   if (Type->getOpcode() == SPIRV::OpTypeFloat) {
-    SPIRVType *SpvBaseType = getOrCreateSPIRVFloatType(BitWidth, I, TII);
+    SPIRVTypeInst SpvBaseType = getOrCreateSPIRVFloatType(BitWidth, I, TII);
     return getOrCreateConstFP(cast<ConstantFP>(Val)->getValue(), I, SpvBaseType,
                               TII, ZeroAsNull);
   }
   assert(Type->getOpcode() == SPIRV::OpTypeInt);
-  SPIRVType *SpvBaseType = getOrCreateSPIRVIntegerType(BitWidth, I, TII);
+  SPIRVTypeInst SpvBaseType = getOrCreateSPIRVIntegerType(BitWidth, I, TII);
   return getOrCreateConstInt(Val->getUniqueInteger(), I, SpvBaseType, TII,
                              ZeroAsNull);
 }
 
 Register SPIRVGlobalRegistry::getOrCreateCompositeOrNull(
-    Constant *Val, MachineInstr &I, SPIRVType *SpvType,
+    Constant *Val, MachineInstr &I, SPIRVTypeInst SpvType,
     const SPIRVInstrInfo &TII, Constant *CA, unsigned BitWidth,
     unsigned ElemCnt, bool ZeroAsNull) {
   if (Register R = find(CA, CurMF); R.isValid())
@@ -556,7 +560,8 @@ Register SPIRVGlobalRegistry::getOrCreateCompositeOrNull(
   CurMF->getRegInfo().setRegClass(Res, getRegClass(SpvType));
   assignSPIRVTypeToVReg(SpvType, Res, *CurMF);
 
-  MachineInstr *DepMI = const_cast<MachineInstr *>(SpvType);
+  MachineInstr *DepMI =
+      const_cast<MachineInstr *>(static_cast<const MachineInstr *>(SpvType));
   MachineIRBuilder MIRBuilder(*DepMI->getParent(), DepMI->getIterator());
   const MachineInstr *NewMI =
       createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
@@ -584,7 +589,7 @@ Register SPIRVGlobalRegistry::getOrCreateCompositeOrNull(
 
 Register SPIRVGlobalRegistry::getOrCreateConstVector(uint64_t Val,
                                                      MachineInstr &I,
-                                                     SPIRVType *SpvType,
+                                                     SPIRVTypeInst SpvType,
                                                      const SPIRVInstrInfo &TII,
                                                      bool ZeroAsNull) {
   return getOrCreateConstVector(APInt(getScalarOrVectorBitWidth(SpvType), Val),
@@ -593,7 +598,7 @@ Register SPIRVGlobalRegistry::getOrCreateConstVector(uint64_t Val,
 
 Register SPIRVGlobalRegistry::getOrCreateConstVector(const APInt &Val,
                                                      MachineInstr &I,
-                                                     const SPIRVType *SpvType,
+                                                     SPIRVTypeInst SpvType,
                                                      const SPIRVInstrInfo &TII,
                                                      bool ZeroAsNull) {
   const Type *LLVMTy = getTypeForSPIRVType(SpvType);
@@ -614,7 +619,7 @@ Register SPIRVGlobalRegistry::getOrCreateConstVector(const APInt &Val,
 
 Register SPIRVGlobalRegistry::getOrCreateConstVector(APFloat Val,
                                                      MachineInstr &I,
-                                                     SPIRVType *SpvType,
+                                                     SPIRVTypeInst SpvType,
                                                      const SPIRVInstrInfo &TII,
                                                      bool ZeroAsNull) {
   const Type *LLVMTy = getTypeForSPIRVType(SpvType);
@@ -632,14 +637,15 @@ Register SPIRVGlobalRegistry::getOrCreateConstVector(APFloat Val,
 }
 
 Register SPIRVGlobalRegistry::getOrCreateConstIntArray(
-    uint64_t Val, size_t Num, MachineInstr &I, SPIRVType *SpvType,
+    uint64_t Val, size_t Num, MachineInstr &I, SPIRVTypeInst SpvType,
     const SPIRVInstrInfo &TII) {
   const Type *LLVMTy = getTypeForSPIRVType(SpvType);
   assert(LLVMTy->isArrayTy());
   const ArrayType *LLVMArrTy = cast<ArrayType>(LLVMTy);
   Type *LLVMBaseTy = LLVMArrTy->getElementType();
   Constant *CI = ConstantInt::get(LLVMBaseTy, Val);
-  SPIRVType *SpvBaseTy = getSPIRVTypeForVReg(SpvType->getOperand(1).getReg());
+  SPIRVTypeInst SpvBaseTy =
+      getSPIRVTypeForVReg(SpvType->getOperand(1).getReg());
   unsigned BW = getScalarOrVectorBitWidth(SpvBaseTy);
   // The following is reasonably unique key that is better that [Val]. The naive
   // alternative would be something along the lines of:
@@ -658,14 +664,15 @@ Register SPIRVGlobalRegistry::getOrCreateConstIntArray(
 }
 
 Register SPIRVGlobalRegistry::getOrCreateIntCompositeOrNull(
-    uint64_t Val, MachineIRBuilder &MIRBuilder, SPIRVType *SpvType, bool EmitIR,
-    Constant *CA, unsigned BitWidth, unsigned ElemCnt) {
+    uint64_t Val, MachineIRBuilder &MIRBuilder, SPIRVTypeInst SpvType,
+    bool EmitIR, Constant *CA, unsigned BitWidth, unsigned ElemCnt) {
   if (Register R = find(CA, CurMF); R.isValid())
     return R;
 
   Register ElemReg;
   if (Val || EmitIR) {
-    SPIRVType *SpvBaseType = getOrCreateSPIRVIntegerType(BitWidth, MIRBuilder);
+    SPIRVTypeInst SpvBaseType =
+        getOrCreateSPIRVIntegerType(BitWidth, MIRBuilder);
     ElemReg = buildConstantInt(Val, MIRBuilder, SpvBaseType, EmitIR);
   }
   LLT LLTy = EmitIR ? LLT::fixed_vector(ElemCnt, BitWidth) : LLT::scalar(64);
@@ -695,10 +702,9 @@ Register SPIRVGlobalRegistry::getOrCreateIntCompositeOrNull(
   return Res;
 }
 
-Register
-SPIRVGlobalRegistry::getOrCreateConsIntVector(uint64_t Val,
-                                              MachineIRBuilder &MIRBuilder,
-                                              SPIRVType *SpvType, bool EmitIR) {
+Register SPIRVGlobalRegistry::getOrCreateConsIntVector(
+    uint64_t Val, MachineIRBuilder &MIRBuilder, SPIRVTypeInst SpvType,
+    bool EmitIR) {
   const Type *LLVMTy = getTypeForSPIRVType(SpvType);
   assert(LLVMTy->isVectorTy());
   const FixedVectorType *LLVMVecTy = cast<FixedVectorType>(LLVMTy);
@@ -714,7 +720,7 @@ SPIRVGlobalRegistry::getOrCreateConsIntVector(uint64_t Val,
 
 Register
 SPIRVGlobalRegistry::getOrCreateConstNullPtr(MachineIRBuilder &MIRBuilder,
-                                             SPIRVType *SpvType) {
+                                             SPIRVTypeInst SpvType) {
   const Type *Ty = getTypeForSPIRVType(SpvType);
   unsigned AddressSpace = typeToAddressSpace(Ty);
   Type *ElemTy = ::getPointeeType(Ty);
@@ -748,7 +754,7 @@ SPIRVGlobalRegistry::buildConstantSampler(Register ResReg, unsigned AddrMode,
       ResReg.isValid()
           ? ResReg
           : MIRBuilder.getMRI()->createVirtualRegister(&SPIRV::iIDRegClass);
-  SPIRVType *TypeSampler = getOrCreateOpTypeSampler(MIRBuilder);
+  SPIRVTypeInst TypeSampler = getOrCreateOpTypeSampler(MIRBuilder);
   Register TypeSamplerReg = getSPIRVTypeID(TypeSampler);
   // We cannot use createOpType() logic here, because of the
   // GlobalISel/IRTranslator.cpp check for a tail call that expects that
@@ -765,7 +771,7 @@ SPIRVGlobalRegistry::buildConstantSampler(Register ResReg, unsigned AddrMode,
 }
 
 Register SPIRVGlobalRegistry::buildGlobalVariable(
-    Register ResVReg, SPIRVType *BaseType, StringRef Name,
+    Register ResVReg, SPIRVTypeInst BaseType, StringRef Name,
     const GlobalValue *GV, SPIRV::StorageClass::StorageClass Storage,
     const MachineInstr *Init, bool IsConst,
     const std::optional<SPIRV::LinkageType::LinkageType> &LinkageType,
@@ -826,8 +832,8 @@ Register SPIRVGlobalRegistry::buildGlobalVariable(
     // Our knowledge about the type may be updated.
     // If that's the case, we need to update a type
     // associated with the register.
-    SPIRVType *DefType = getSPIRVTypeForVReg(ResVReg);
-    if (!DefType || DefType != BaseType)
+    SPIRVTypeInst DefType = getSPIRVTypeForVReg(ResVReg);
+    if (!DefType || DefType != SPIRVTypeInst(BaseType))
       assignSPIRVTypeToVReg(BaseType, Reg, MIRBuilder.getMF());
   }
 
@@ -870,7 +876,7 @@ Register SPIRVGlobalRegistry::buildGlobalVariable(
 // decorations, and will return the same string for two types that are the same
 // except for decorations.
 Register SPIRVGlobalRegistry::getOrCreateGlobalVariableWithBinding(
-    const SPIRVType *VarType, uint32_t Set, uint32_t Binding, StringRef Name,
+    SPIRVTypeInst VarType, uint32_t Set, uint32_t Binding, StringRef Name,
     MachineIRBuilder &MIRBuilder) {
   Register VarReg =
       MIRBuilder.getMRI()->createVirtualRegister(&SPIRV::iIDRegClass);
@@ -886,15 +892,15 @@ Register SPIRVGlobalRegistry::getOrCreateGlobalVariableWithBinding(
 
 // TODO: Double check the calls to getOpTypeArray to make sure that `ElemType`
 // is explicitly laid out when required.
-SPIRVType *SPIRVGlobalRegistry::getOpTypeArray(uint32_t NumElems,
-                                               SPIRVType *ElemType,
-                                               MachineIRBuilder &MIRBuilder,
-                                               bool ExplicitLayoutRequired,
-                                               bool EmitIR) {
+SPIRVTypeInst SPIRVGlobalRegistry::getOpTypeArray(uint32_t NumElems,
+                                                  SPIRVTypeInst ElemType,
+                                                  MachineIRBuilder &MIRBuilder,
+                                                  bool ExplicitLayoutRequired,
+                                                  bool EmitIR) {
   assert((ElemType->getOpcode() != SPIRV::OpTypeVoid) &&
          "Invalid array element type");
-  SPIRVType *SpvTypeInt32 = getOrCreateSPIRVIntegerType(32, MIRBuilder);
-  SPIRVType *ArrayType = nullptr;
+  SPIRVTypeInst SpvTypeInt32 = getOrCreateSPIRVIntegerType(32, MIRBuilder);
+  SPIRVTypeInst ArrayType = nullptr;
   const SPIRVSubtarget &ST =
       cast<SPIRVSubtarget>(MIRBuilder.getMF().getSubtarget());
   if (NumElems != 0) {
@@ -909,7 +915,7 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeArray(uint32_t NumElems,
   } else if (ST.getTargetTriple().getVendor() == Triple::VendorType::AMD) {
     // We set the array size to the token UINT64_MAX value, which is generally
     // illegal (the maximum legal size is 61-bits) for the foreseeable future.
-    SPIRVType *SpvTypeInt64 = getOrCreateSPIRVIntegerType(64, MIRBuilder);
+    SPIRVTypeInst SpvTypeInt64 = getOrCreateSPIRVIntegerType(64, MIRBuilder);
     Register NumElementsVReg =
         buildConstantInt(UINT64_MAX, MIRBuilder, SpvTypeInt64, EmitIR);
     ArrayType = createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
@@ -941,8 +947,9 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeArray(uint32_t NumElems,
   return ArrayType;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypeOpaque(const StructType *Ty,
-                                                MachineIRBuilder &MIRBuilder) {
+SPIRVTypeInst
+SPIRVGlobalRegistry::getOpTypeOpaque(const StructType *Ty,
+                                     MachineIRBuilder &MIRBuilder) {
   assert(Ty->hasName());
   const StringRef Name = Ty->hasName() ? Ty->getName() : "";
   Register ResVReg = createTypeVReg(MIRBuilder);
@@ -954,14 +961,14 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeOpaque(const StructType *Ty,
   });
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypeStruct(
+SPIRVTypeInst SPIRVGlobalRegistry::getOpTypeStruct(
     const StructType *Ty, MachineIRBuilder &MIRBuilder,
     SPIRV::AccessQualifier::AccessQualifier AccQual,
     StructOffsetDecorator Decorator, bool EmitIR) {
   Type *OriginalElementType = nullptr;
   uint64_t TotalSize = 0;
   if (matchPeeledArrayPattern(Ty, OriginalElementType, TotalSize)) {
-    SPIRVType *ElementSPIRVType = findSPIRVType(
+    SPIRVTypeInst ElementSPIRVType = findSPIRVType(
         OriginalElementType, MIRBuilder, AccQual,
         /* ExplicitLayoutRequired= */ Decorator != nullptr, EmitIR);
     return getOpTypeArray(TotalSize, ElementSPIRVType, MIRBuilder,
@@ -984,7 +991,7 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeStruct(
   }
 
   for (const auto &Elem : Ty->elements()) {
-    SPIRVType *ElemTy = findSPIRVType(
+    SPIRVTypeInst ElemTy = findSPIRVType(
         toTypedPointer(Elem), MIRBuilder, AccQual,
         /* ExplicitLayoutRequired= */ Decorator != nullptr, EmitIR);
     assert(ElemTy && ElemTy->getOpcode() != SPIRV::OpTypeVoid &&
@@ -997,7 +1004,7 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeStruct(
   if (Ty->isPacked() && !ST.isShader())
     buildOpDecorate(ResVReg, MIRBuilder, SPIRV::Decoration::CPacked, {});
 
-  SPIRVType *SPVType =
+  SPIRVTypeInst SPVType =
       createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
         auto MIBStruct =
             MIRBuilder.buildInstr(SPIRV::OpTypeStruct).addDef(ResVReg);
@@ -1019,15 +1026,15 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeStruct(
   return SPVType;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSpecialType(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateSpecialType(
     const Type *Ty, MachineIRBuilder &MIRBuilder,
     SPIRV::AccessQualifier::AccessQualifier AccQual) {
   assert(isSpecialOpaqueType(Ty) && "Not a special opaque builtin type");
   return SPIRV::lowerBuiltinType(Ty, AccQual, MIRBuilder, this);
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypePointer(
-    SPIRV::StorageClass::StorageClass SC, SPIRVType *ElemType,
+SPIRVTypeInst SPIRVGlobalRegistry::getOpTypePointer(
+    SPIRV::StorageClass::StorageClass SC, SPIRVTypeInst ElemType,
     MachineIRBuilder &MIRBuilder, Register Reg) {
   if (!Reg.isValid())
     Reg = createTypeVReg(MIRBuilder);
@@ -1040,7 +1047,7 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypePointer(
   });
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypeForwardPointer(
+SPIRVTypeInst SPIRVGlobalRegistry::getOpTypeForwardPointer(
     SPIRV::StorageClass::StorageClass SC, MachineIRBuilder &MIRBuilder) {
   return createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
     return MIRBuilder.buildInstr(SPIRV::OpTypeForwardPointer)
@@ -1049,9 +1056,9 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeForwardPointer(
   });
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypeFunction(
-    const FunctionType *Ty, SPIRVType *RetType,
-    const SmallVectorImpl<SPIRVType *> &ArgTypes,
+SPIRVTypeInst SPIRVGlobalRegistry::getOpTypeFunction(
+    const FunctionType *Ty, SPIRVTypeInst RetType,
+    const SmallVectorImpl<SPIRVTypeInst> &ArgTypes,
     MachineIRBuilder &MIRBuilder) {
   const SPIRVSubtarget *ST =
       static_cast<const SPIRVSubtarget *>(&MIRBuilder.getMF().getSubtarget());
@@ -1065,15 +1072,15 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeFunction(
     auto MIB = MIRBuilder.buildInstr(SPIRV::OpTypeFunction)
                    .addDef(createTypeVReg(MIRBuilder))
                    .addUse(getSPIRVTypeID(RetType));
-    for (const SPIRVType *ArgType : ArgTypes)
+    for (auto &ArgType : ArgTypes)
       MIB.addUse(getSPIRVTypeID(ArgType));
     return MIB;
   });
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeFunctionWithArgs(
-    const Type *Ty, SPIRVType *RetType,
-    const SmallVectorImpl<SPIRVType *> &ArgTypes,
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateOpTypeFunctionWithArgs(
+    const Type *Ty, SPIRVTypeInst RetType,
+    const SmallVectorImpl<SPIRVTypeInst> &ArgTypes,
     MachineIRBuilder &MIRBuilder) {
   if (const MachineInstr *MI = findMI(Ty, false, &MIRBuilder.getMF()))
     return MI;
@@ -1083,7 +1090,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeFunctionWithArgs(
   return finishCreatingSPIRVType(Ty, NewMI);
 }
 
-SPIRVType *SPIRVGlobalRegistry::findSPIRVType(
+SPIRVTypeInst SPIRVGlobalRegistry::findSPIRVType(
     const Type *Ty, MachineIRBuilder &MIRBuilder,
     SPIRV::AccessQualifier::AccessQualifier AccQual,
     bool ExplicitLayoutRequired, bool EmitIR) {
@@ -1098,7 +1105,7 @@ SPIRVType *SPIRVGlobalRegistry::findSPIRVType(
                                EmitIR);
 }
 
-Register SPIRVGlobalRegistry::getSPIRVTypeID(const SPIRVType *SpirvType) const {
+Register SPIRVGlobalRegistry::getSPIRVTypeID(SPIRVTypeInst SpirvType) const {
   assert(SpirvType && "Attempting to get type id for nullptr type.");
   if (SpirvType->getOpcode() == SPIRV::OpTypeForwardPointer ||
       SpirvType->getOpcode() == SPIRV::OpTypeStructContinuedINTEL)
@@ -1127,7 +1134,7 @@ const Type *SPIRVGlobalRegistry::adjustIntTypeByWidth(const Type *Ty) const {
   return Ty;
 }
 
-SPIRVType *SPIRVGlobalRegistry::createSPIRVType(
+SPIRVTypeInst SPIRVGlobalRegistry::createSPIRVType(
     const Type *Ty, MachineIRBuilder &MIRBuilder,
     SPIRV::AccessQualifier::AccessQualifier AccQual,
     bool ExplicitLayoutRequired, bool EmitIR) {
@@ -1154,15 +1161,15 @@ SPIRVType *SPIRVGlobalRegistry::createSPIRVType(
   if (Ty->isVoidTy())
     return getOpTypeVoid(MIRBuilder);
   if (Ty->isVectorTy()) {
-    SPIRVType *El =
+    SPIRVTypeInst El =
         findSPIRVType(cast<FixedVectorType>(Ty)->getElementType(), MIRBuilder,
                       AccQual, ExplicitLayoutRequired, EmitIR);
     return getOpTypeVector(cast<FixedVectorType>(Ty)->getNumElements(), El,
                            MIRBuilder);
   }
   if (Ty->isArrayTy()) {
-    SPIRVType *El = findSPIRVType(Ty->getArrayElementType(), MIRBuilder,
-                                  AccQual, ExplicitLayoutRequired, EmitIR);
+    SPIRVTypeInst El = findSPIRVType(Ty->getArrayElementType(), MIRBuilder,
+                                     AccQual, ExplicitLayoutRequired, EmitIR);
     return getOpTypeArray(Ty->getArrayNumElements(), El, MIRBuilder,
                           ExplicitLayoutRequired, EmitIR);
   }
@@ -1181,9 +1188,10 @@ SPIRVType *SPIRVGlobalRegistry::createSPIRVType(
                            EmitIR);
   }
   if (auto FType = dyn_cast<FunctionType>(Ty)) {
-    SPIRVType *RetTy = findSPIRVType(FType->getReturnType(), MIRBuilder,
-                                     AccQual, ExplicitLayoutRequired, EmitIR);
-    SmallVector<SPIRVType *, 4> ParamTypes;
+    SPIRVTypeInst RetTy =
+        findSPIRVType(FType->getReturnType(), MIRBuilder, AccQual,
+                      ExplicitLayoutRequired, EmitIR);
+    SmallVector<SPIRVTypeInst, 4> ParamTypes;
     for (const auto &ParamTy : FType->params())
       ParamTypes.push_back(findSPIRVType(ParamTy, MIRBuilder, AccQual,
                                          ExplicitLayoutRequired, EmitIR));
@@ -1191,7 +1199,7 @@ SPIRVType *SPIRVGlobalRegistry::createSPIRVType(
   }
 
   unsigned AddrSpace = typeToAddressSpace(Ty);
-  SPIRVType *SpvElementType = nullptr;
+  SPIRVTypeInst SpvElementType = nullptr;
   if (Type *ElemTy = ::getPointeeType(Ty))
     SpvElementType = getOrCreateSPIRVType(ElemTy, MIRBuilder, AccQual, EmitIR);
   else
@@ -1218,7 +1226,7 @@ SPIRVType *SPIRVGlobalRegistry::createSPIRVType(
   return getOrCreateSPIRVPointerType(ElemTy, MIRBuilder, SC);
 }
 
-SPIRVType *SPIRVGlobalRegistry::restOfCreateSPIRVType(
+SPIRVTypeInst SPIRVGlobalRegistry::restOfCreateSPIRVType(
     const Type *Ty, MachineIRBuilder &MIRBuilder,
     SPIRV::AccessQualifier::AccessQualifier AccessQual,
     bool ExplicitLayoutRequired, bool EmitIR) {
@@ -1227,8 +1235,8 @@ SPIRVType *SPIRVGlobalRegistry::restOfCreateSPIRVType(
   if (TypesInProcessing.count(Ty) && !isPointerTyOrWrapper(Ty))
     return nullptr;
   TypesInProcessing.insert(Ty);
-  SPIRVType *SpirvType = createSPIRVType(Ty, MIRBuilder, AccessQual,
-                                         ExplicitLayoutRequired, EmitIR);
+  SPIRVTypeInst SpirvType = createSPIRVType(Ty, MIRBuilder, AccessQual,
+                                            ExplicitLayoutRequired, EmitIR);
   TypesInProcessing.erase(Ty);
   VRegToTypeMap[&MIRBuilder.getMF()][getSPIRVTypeID(SpirvType)] = SpirvType;
 
@@ -1266,15 +1274,15 @@ SPIRVGlobalRegistry::getSPIRVTypeForVReg(Register VReg,
   return nullptr;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getResultType(Register VReg,
-                                              MachineFunction *MF) {
+SPIRVTypeInst SPIRVGlobalRegistry::getResultType(Register VReg,
+                                                 MachineFunction *MF) {
   if (!MF)
     MF = CurMF;
   MachineInstr *Instr = getVRegDef(MF->getRegInfo(), VReg);
   return getSPIRVTypeForVReg(Instr->getOperand(1).getReg(), MF);
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVType(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateSPIRVType(
     const Type *Ty, MachineIRBuilder &MIRBuilder,
     SPIRV::AccessQualifier::AccessQualifier AccessQual,
     bool ExplicitLayoutRequired, bool EmitIR) {
@@ -1295,15 +1303,15 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVType(
     return getSPIRVTypeForVReg(Reg);
 
   TypesInProcessing.clear();
-  SPIRVType *STy = restOfCreateSPIRVType(Ty, MIRBuilder, AccessQual,
-                                         ExplicitLayoutRequired, EmitIR);
+  SPIRVTypeInst STy = restOfCreateSPIRVType(Ty, MIRBuilder, AccessQual,
+                                            ExplicitLayoutRequired, EmitIR);
   // Create normal pointer types for the corresponding OpTypeForwardPointers.
   for (auto &CU : ForwardPointerTypes) {
     // Pointer type themselves do not require an explicit layout. The types
     // they pointer to might, but that is taken care of when creating the type.
     bool PtrNeedsLayout = false;
     const Type *Ty2 = CU.first;
-    SPIRVType *STy2 = CU.second;
+    SPIRVTypeInst STy2 = CU.second;
     if ((Reg = find(Ty2, PtrNeedsLayout, MF)).isValid())
       STy2 = getSPIRVTypeForVReg(Reg);
     else
@@ -1318,26 +1326,26 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVType(
 
 bool SPIRVGlobalRegistry::isScalarOfType(Register VReg,
                                          unsigned TypeOpcode) const {
-  SPIRVType *Type = getSPIRVTypeForVReg(VReg);
+  SPIRVTypeInst Type = getSPIRVTypeForVReg(VReg);
   assert(Type && "isScalarOfType VReg has no type assigned");
   return Type->getOpcode() == TypeOpcode;
 }
 
 bool SPIRVGlobalRegistry::isScalarOrVectorOfType(Register VReg,
                                                  unsigned TypeOpcode) const {
-  SPIRVType *Type = getSPIRVTypeForVReg(VReg);
+  SPIRVTypeInst Type = getSPIRVTypeForVReg(VReg);
   assert(Type && "isScalarOrVectorOfType VReg has no type assigned");
   if (Type->getOpcode() == TypeOpcode)
     return true;
   if (Type->getOpcode() == SPIRV::OpTypeVector) {
     Register ScalarTypeVReg = Type->getOperand(1).getReg();
-    SPIRVType *ScalarType = getSPIRVTypeForVReg(ScalarTypeVReg);
+    SPIRVTypeInst ScalarType = getSPIRVTypeForVReg(ScalarTypeVReg);
     return ScalarType->getOpcode() == TypeOpcode;
   }
   return false;
 }
 
-bool SPIRVGlobalRegistry::isResourceType(SPIRVType *Type) const {
+bool SPIRVGlobalRegistry::isResourceType(SPIRVTypeInst Type) const {
   switch (Type->getOpcode()) {
   case SPIRV::OpTypeImage:
   case SPIRV::OpTypeSampler:
@@ -1356,7 +1364,7 @@ SPIRVGlobalRegistry::getScalarOrVectorComponentCount(Register VReg) const {
 }
 
 unsigned
-SPIRVGlobalRegistry::getScalarOrVectorComponentCount(SPIRVType *Type) const {
+SPIRVGlobalRegistry::getScalarOrVectorComponentCount(SPIRVTypeInst Type) const {
   if (!Type)
     return 0;
   return Type->getOpcode() == SPIRV::OpTypeVector
@@ -1364,26 +1372,21 @@ SPIRVGlobalRegistry::getScalarOrVectorComponentCount(SPIRVType *Type) const {
              : 1;
 }
 
-SPIRVType *
-SPIRVGlobalRegistry::getScalarOrVectorComponentType(Register VReg) const {
-  return getScalarOrVectorComponentType(getSPIRVTypeForVReg(VReg));
-}
-
-SPIRVType *
-SPIRVGlobalRegistry::getScalarOrVectorComponentType(SPIRVType *Type) const {
+SPIRVTypeInst
+SPIRVGlobalRegistry::getScalarOrVectorComponentType(SPIRVTypeInst Type) const {
   if (!Type)
     return nullptr;
   Register ScalarReg = Type->getOpcode() == SPIRV::OpTypeVector
                            ? Type->getOperand(1).getReg()
                            : Type->getOperand(0).getReg();
-  SPIRVType *ScalarType = getSPIRVTypeForVReg(ScalarReg);
+  SPIRVTypeInst ScalarType = getSPIRVTypeForVReg(ScalarReg);
   assert(isScalarOrVectorOfType(Type->getOperand(0).getReg(),
                                 ScalarType->getOpcode()));
   return ScalarType;
 }
 
 unsigned
-SPIRVGlobalRegistry::getScalarOrVectorBitWidth(const SPIRVType *Type) const {
+SPIRVGlobalRegistry::getScalarOrVectorBitWidth(SPIRVTypeInst Type) const {
   assert(Type && "Invalid Type pointer");
   if (Type->getOpcode() == SPIRV::OpTypeVector) {
     auto EleTypeReg = Type->getOperand(1).getReg();
@@ -1398,7 +1401,7 @@ SPIRVGlobalRegistry::getScalarOrVectorBitWidth(const SPIRVType *Type) const {
 }
 
 unsigned SPIRVGlobalRegistry::getNumScalarOrVectorTotalBitWidth(
-    const SPIRVType *Type) const {
+    SPIRVTypeInst Type) const {
   assert(Type && "Invalid Type pointer");
   unsigned NumElements = 1;
   if (Type->getOpcode() == SPIRV::OpTypeVector) {
@@ -1411,31 +1414,31 @@ unsigned SPIRVGlobalRegistry::getNumScalarOrVectorTotalBitWidth(
              : 0;
 }
 
-const SPIRVType *SPIRVGlobalRegistry::retrieveScalarOrVectorIntType(
-    const SPIRVType *Type) const {
+SPIRVTypeInst
+SPIRVGlobalRegistry::retrieveScalarOrVectorIntType(SPIRVTypeInst Type) const {
   if (Type && Type->getOpcode() == SPIRV::OpTypeVector)
     Type = getSPIRVTypeForVReg(Type->getOperand(1).getReg());
   return Type && Type->getOpcode() == SPIRV::OpTypeInt ? Type : nullptr;
 }
 
-bool SPIRVGlobalRegistry::isScalarOrVectorSigned(const SPIRVType *Type) const {
-  const SPIRVType *IntType = retrieveScalarOrVectorIntType(Type);
+bool SPIRVGlobalRegistry::isScalarOrVectorSigned(SPIRVTypeInst Type) const {
+  SPIRVTypeInst IntType = retrieveScalarOrVectorIntType(Type);
   return IntType && IntType->getOperand(2).getImm() != 0;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getPointeeType(SPIRVType *PtrType) {
+SPIRVTypeInst SPIRVGlobalRegistry::getPointeeType(SPIRVTypeInst PtrType) {
   return PtrType && PtrType->getOpcode() == SPIRV::OpTypePointer
              ? getSPIRVTypeForVReg(PtrType->getOperand(2).getReg())
              : nullptr;
 }
 
 unsigned SPIRVGlobalRegistry::getPointeeTypeOp(Register PtrReg) {
-  SPIRVType *ElemType = getPointeeType(getSPIRVTypeForVReg(PtrReg));
+  SPIRVTypeInst ElemType = getPointeeType(getSPIRVTypeForVReg(PtrReg));
   return ElemType ? ElemType->getOpcode() : 0;
 }
 
-bool SPIRVGlobalRegistry::isBitcastCompatible(const SPIRVType *Type1,
-                                              const SPIRVType *Type2) const {
+bool SPIRVGlobalRegistry::isBitcastCompatible(SPIRVTypeInst Type1,
+                                              SPIRVTypeInst Type2) const {
   if (!Type1 || !Type2)
     return false;
   auto Op1 = Type1->getOpcode(), Op2 = Type2->getOpcode();
@@ -1455,19 +1458,19 @@ bool SPIRVGlobalRegistry::isBitcastCompatible(const SPIRVType *Type1,
 
 SPIRV::StorageClass::StorageClass
 SPIRVGlobalRegistry::getPointerStorageClass(Register VReg) const {
-  SPIRVType *Type = getSPIRVTypeForVReg(VReg);
+  SPIRVTypeInst Type = getSPIRVTypeForVReg(VReg);
   assert(Type && Type->getOpcode() == SPIRV::OpTypePointer &&
          Type->getOperand(1).isImm() && "Pointer type is expected");
   return getPointerStorageClass(Type);
 }
 
 SPIRV::StorageClass::StorageClass
-SPIRVGlobalRegistry::getPointerStorageClass(const SPIRVType *Type) const {
+SPIRVGlobalRegistry::getPointerStorageClass(SPIRVTypeInst Type) const {
   return static_cast<SPIRV::StorageClass::StorageClass>(
       Type->getOperand(1).getImm());
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateVulkanBufferType(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateVulkanBufferType(
     MachineIRBuilder &MIRBuilder, Type *ElemType,
     SPIRV::StorageClass::StorageClass SC, bool IsWritable, bool EmitIr) {
   auto Key = SPIRV::irhandle_vkbuffer(ElemType, SC, IsWritable);
@@ -1478,7 +1481,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateVulkanBufferType(
   // We need to get the SPIR-V type for the element here, so we can add the
   // decoration to it.
   auto *T = StructType::create(ElemType);
-  auto *BlockType =
+  SPIRVTypeInst BlockType =
       getOrCreateSPIRVType(T, MIRBuilder, SPIRV::AccessQualifier::None,
                            ExplicitLayoutRequired, EmitIr);
 
@@ -1490,24 +1493,25 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateVulkanBufferType(
                           SPIRV::Decoration::NonWritable, 0, {});
   }
 
-  SPIRVType *R = getOrCreateSPIRVPointerTypeInternal(BlockType, MIRBuilder, SC);
+  SPIRVTypeInst R =
+      getOrCreateSPIRVPointerTypeInternal(BlockType, MIRBuilder, SC);
   add(Key, R);
   return R;
 }
 
-SPIRVType *
+SPIRVTypeInst
 SPIRVGlobalRegistry::getOrCreatePaddingType(MachineIRBuilder &MIRBuilder) {
   auto Key = SPIRV::irhandle_padding();
   if (const MachineInstr *MI = findMI(Key, &MIRBuilder.getMF()))
     return MI;
   auto *T = Type::getInt8Ty(MIRBuilder.getContext());
-  SPIRVType *R = getOrCreateSPIRVIntegerType(8, MIRBuilder);
+  SPIRVTypeInst R = getOrCreateSPIRVIntegerType(8, MIRBuilder);
   finishCreatingSPIRVType(T, R);
   add(Key, R);
   return R;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateVulkanPushConstantType(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateVulkanPushConstantType(
     MachineIRBuilder &MIRBuilder, Type *T) {
   const auto SC = SPIRV::StorageClass::PushConstant;
 
@@ -1517,18 +1521,18 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateVulkanPushConstantType(
 
   // We need to get the SPIR-V type for the element here, so we can add the
   // decoration to it.
-  auto *BlockType = getOrCreateSPIRVType(
+  SPIRVTypeInst BlockType = getOrCreateSPIRVType(
       T, MIRBuilder, SPIRV::AccessQualifier::None,
       /* ExplicitLayoutRequired= */ true, /* EmitIr= */ false);
 
   buildOpDecorate(BlockType->defs().begin()->getReg(), MIRBuilder,
                   SPIRV::Decoration::Block, {});
-  SPIRVType *R = BlockType;
+  SPIRVTypeInst R = BlockType;
   add(Key, R);
   return R;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateLayoutType(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateLayoutType(
     MachineIRBuilder &MIRBuilder, const TargetExtType *T, bool EmitIr) {
   auto Key = SPIRV::handle(T);
   if (const MachineInstr *MI = findMI(Key, &MIRBuilder.getMF()))
@@ -1548,20 +1552,20 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateLayoutType(
   // We need a new OpTypeStruct instruction because decorations will be
   // different from a struct with an explicit layout created from a different
   // entry point.
-  SPIRVType *SPIRVStructType =
+  SPIRVTypeInst SPIRVStructType =
       getOpTypeStruct(ST, MIRBuilder, SPIRV::AccessQualifier::None,
                       std::move(Decorator), EmitIr);
   add(Key, SPIRVStructType);
   return SPIRVStructType;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getImageType(
+SPIRVTypeInst SPIRVGlobalRegistry::getImageType(
     const TargetExtType *ExtensionType,
     const SPIRV::AccessQualifier::AccessQualifier Qualifier,
     MachineIRBuilder &MIRBuilder) {
   assert(ExtensionType->getNumTypeParameters() == 1 &&
          "SPIR-V image builtin type must have sampled type parameter!");
-  const SPIRVType *SampledType =
+  const SPIRVTypeInst SampledType =
       getOrCreateSPIRVType(ExtensionType->getTypeParameter(0), MIRBuilder,
                            SPIRV::AccessQualifier::ReadWrite, true);
   assert((ExtensionType->getNumIntParameters() == 7 ||
@@ -1578,7 +1582,7 @@ SPIRVType *SPIRVGlobalRegistry::getImageType(
   }
 
   // Create or get an existing type from GlobalRegistry.
-  SPIRVType *R = getOrCreateOpTypeImage(
+  SPIRVTypeInst R = getOrCreateOpTypeImage(
       MIRBuilder, SampledType,
       SPIRV::Dim::Dim(ExtensionType->getIntParameter(0)),
       ExtensionType->getIntParameter(1), ExtensionType->getIntParameter(2),
@@ -1589,9 +1593,10 @@ SPIRVType *SPIRVGlobalRegistry::getImageType(
   return R;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeImage(
-    MachineIRBuilder &MIRBuilder, SPIRVType *SampledType, SPIRV::Dim::Dim Dim,
-    uint32_t Depth, uint32_t Arrayed, uint32_t Multisampled, uint32_t Sampled,
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateOpTypeImage(
+    MachineIRBuilder &MIRBuilder, SPIRVTypeInst SampledType,
+    SPIRV::Dim::Dim Dim, uint32_t Depth, uint32_t Arrayed,
+    uint32_t Multisampled, uint32_t Sampled,
     SPIRV::ImageFormat::ImageFormat ImageFormat,
     SPIRV::AccessQualifier::AccessQualifier AccessQual) {
   auto Key = SPIRV::irhandle_image(SPIRVToLLVMType.lookup(SampledType), Dim,
@@ -1619,7 +1624,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeImage(
   return NewMI;
 }
 
-SPIRVType *
+SPIRVTypeInst
 SPIRVGlobalRegistry::getOrCreateOpTypeSampler(MachineIRBuilder &MIRBuilder) {
   auto Key = SPIRV::irhandle_sampler();
   const MachineFunction *MF = &MIRBuilder.getMF();
@@ -1634,7 +1639,7 @@ SPIRVGlobalRegistry::getOrCreateOpTypeSampler(MachineIRBuilder &MIRBuilder) {
   return NewMI;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypePipe(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateOpTypePipe(
     MachineIRBuilder &MIRBuilder,
     SPIRV::AccessQualifier::AccessQualifier AccessQual) {
   auto Key = SPIRV::irhandle_pipe(AccessQual);
@@ -1650,7 +1655,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypePipe(
   return NewMI;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeDeviceEvent(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateOpTypeDeviceEvent(
     MachineIRBuilder &MIRBuilder) {
   auto Key = SPIRV::irhandle_event();
   if (const MachineInstr *MI = findMI(Key, &MIRBuilder.getMF()))
@@ -1664,8 +1669,8 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeDeviceEvent(
   return NewMI;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeSampledImage(
-    SPIRVType *ImageType, MachineIRBuilder &MIRBuilder) {
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateOpTypeSampledImage(
+    SPIRVTypeInst ImageType, MachineIRBuilder &MIRBuilder) {
   auto Key = SPIRV::irhandle_sampled_image(
       SPIRVToLLVMType.lookup(MIRBuilder.getMF().getRegInfo().getVRegDef(
           ImageType->getOperand(1).getReg())),
@@ -1682,16 +1687,17 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeSampledImage(
   return NewMI;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeCoopMatr(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateOpTypeCoopMatr(
     MachineIRBuilder &MIRBuilder, const TargetExtType *ExtensionType,
-    const SPIRVType *ElemType, uint32_t Scope, uint32_t Rows, uint32_t Columns,
+    SPIRVTypeInst ElemType, uint32_t Scope, uint32_t Rows, uint32_t Columns,
     uint32_t Use, bool EmitIR) {
   if (const MachineInstr *MI =
           findMI(ExtensionType, false, &MIRBuilder.getMF()))
     return MI;
   const MachineInstr *NewMI =
       createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
-        SPIRVType *SpvTypeInt32 = getOrCreateSPIRVIntegerType(32, MIRBuilder);
+        SPIRVTypeInst SpvTypeInt32 =
+            getOrCreateSPIRVIntegerType(32, MIRBuilder);
         const Type *ET = getTypeForSPIRVType(ElemType);
         if (ET->isIntegerTy() && ET->getIntegerBitWidth() == 4 &&
             cast<SPIRVSubtarget>(MIRBuilder.getMF().getSubtarget())
@@ -1711,7 +1717,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeCoopMatr(
   return NewMI;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeByOpcode(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateOpTypeByOpcode(
     const Type *Ty, MachineIRBuilder &MIRBuilder, unsigned Opcode) {
   if (const MachineInstr *MI = findMI(Ty, false, &MIRBuilder.getMF()))
     return MI;
@@ -1723,7 +1729,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeByOpcode(
   return NewMI;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateUnknownType(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateUnknownType(
     const Type *Ty, MachineIRBuilder &MIRBuilder, unsigned Opcode,
     const ArrayRef<MCOperand> Operands) {
   if (const MachineInstr *MI = findMI(Ty, false, &MIRBuilder.getMF()))
@@ -1748,7 +1754,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateUnknownType(
 }
 
 // Returns nullptr if unable to recognize SPIRV type name
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVTypeByName(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateSPIRVTypeByName(
     StringRef TypeStr, MachineIRBuilder &MIRBuilder, bool EmitIR,
     SPIRV::StorageClass::StorageClass SC,
     SPIRV::AccessQualifier::AccessQualifier AQ) {
@@ -1770,8 +1776,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVTypeByName(
     // Unable to recognize SPIRV type name
     return nullptr;
 
-  const SPIRVType *SpirvTy =
-      getOrCreateSPIRVType(Ty, MIRBuilder, AQ, false, true);
+  SPIRVTypeInst SpirvTy = getOrCreateSPIRVType(Ty, MIRBuilder, AQ, false, true);
 
   // Handle "type*" or  "type* vector[N]".
   if (TypeStr.consume_front("*"))
@@ -1793,7 +1798,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVTypeByName(
   return SpirvTy;
 }
 
-SPIRVType *
+SPIRVTypeInst
 SPIRVGlobalRegistry::getOrCreateSPIRVIntegerType(unsigned BitWidth,
                                                  MachineIRBuilder &MIRBuilder) {
   return getOrCreateSPIRVType(
@@ -1801,19 +1806,19 @@ SPIRVGlobalRegistry::getOrCreateSPIRVIntegerType(unsigned BitWidth,
       MIRBuilder, SPIRV::AccessQualifier::ReadWrite, false, true);
 }
 
-SPIRVType *SPIRVGlobalRegistry::finishCreatingSPIRVType(const Type *LLVMTy,
-                                                        SPIRVType *SpirvType) {
+SPIRVTypeInst
+SPIRVGlobalRegistry::finishCreatingSPIRVType(const Type *LLVMTy,
+                                             SPIRVTypeInst SpirvType) {
   assert(CurMF == SpirvType->getMF());
   VRegToTypeMap[CurMF][getSPIRVTypeID(SpirvType)] = SpirvType;
   SPIRVToLLVMType[SpirvType] = unifyPtrType(LLVMTy);
   return SpirvType;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVType(unsigned BitWidth,
-                                                     MachineInstr &I,
-                                                     const SPIRVInstrInfo &TII,
-                                                     unsigned SPIRVOPcode,
-                                                     Type *Ty) {
+SPIRVTypeInst
+SPIRVGlobalRegistry::getOrCreateSPIRVType(unsigned BitWidth, MachineInstr &I,
+                                          const SPIRVInstrInfo &TII,
+                                          unsigned SPIRVOPcode, Type *Ty) {
   if (const MachineInstr *MI = findMI(Ty, false, CurMF))
     return MI;
   MachineBasicBlock &DepMBB = I.getMF()->front();
@@ -1835,7 +1840,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVType(unsigned BitWidth,
   return finishCreatingSPIRVType(Ty, NewMI);
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVIntegerType(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateSPIRVIntegerType(
     unsigned BitWidth, MachineInstr &I, const SPIRVInstrInfo &TII) {
   // Maybe adjust bit width to keep DuplicateTracker consistent. Without
   // such an adjustment SPIRVGlobalRegistry::getOpTypeInt() could create, for
@@ -1847,7 +1852,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVIntegerType(
   return getOrCreateSPIRVType(BitWidth, I, TII, SPIRV::OpTypeInt, LLVMTy);
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVFloatType(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateSPIRVFloatType(
     unsigned BitWidth, MachineInstr &I, const SPIRVInstrInfo &TII) {
   LLVMContext &Ctx = CurMF->getFunction().getContext();
   Type *LLVMTy;
@@ -1867,7 +1872,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVFloatType(
   return getOrCreateSPIRVType(BitWidth, I, TII, SPIRV::OpTypeFloat, LLVMTy);
 }
 
-SPIRVType *
+SPIRVTypeInst
 SPIRVGlobalRegistry::getOrCreateSPIRVBoolType(MachineIRBuilder &MIRBuilder,
                                               bool EmitIR) {
   return getOrCreateSPIRVType(
@@ -1875,7 +1880,7 @@ SPIRVGlobalRegistry::getOrCreateSPIRVBoolType(MachineIRBuilder &MIRBuilder,
       MIRBuilder, SPIRV::AccessQualifier::ReadWrite, false, EmitIR);
 }
 
-SPIRVType *
+SPIRVTypeInst
 SPIRVGlobalRegistry::getOrCreateSPIRVBoolType(MachineInstr &I,
                                               const SPIRVInstrInfo &TII) {
   Type *Ty = IntegerType::get(CurMF->getFunction().getContext(), 1);
@@ -1893,8 +1898,8 @@ SPIRVGlobalRegistry::getOrCreateSPIRVBoolType(MachineInstr &I,
   return finishCreatingSPIRVType(Ty, NewMI);
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVVectorType(
-    SPIRVType *BaseType, unsigned NumElements, MachineIRBuilder &MIRBuilder,
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateSPIRVVectorType(
+    SPIRVTypeInst BaseType, unsigned NumElements, MachineIRBuilder &MIRBuilder,
     bool EmitIR) {
   return getOrCreateSPIRVType(
       FixedVectorType::get(const_cast<Type *>(getTypeForSPIRVType(BaseType)),
@@ -1902,14 +1907,15 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVVectorType(
       MIRBuilder, SPIRV::AccessQualifier::ReadWrite, false, EmitIR);
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVVectorType(
-    SPIRVType *BaseType, unsigned NumElements, MachineInstr &I,
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateSPIRVVectorType(
+    SPIRVTypeInst BaseType, unsigned NumElements, MachineInstr &I,
     const SPIRVInstrInfo &TII) {
   Type *Ty = FixedVectorType::get(
       const_cast<Type *>(getTypeForSPIRVType(BaseType)), NumElements);
   if (const MachineInstr *MI = findMI(Ty, false, CurMF))
     return MI;
-  MachineInstr *DepMI = const_cast<MachineInstr *>(BaseType);
+  MachineInstr *DepMI =
+      const_cast<MachineInstr *>(static_cast<const MachineInstr *>(BaseType));
   MachineIRBuilder MIRBuilder(*DepMI->getParent(), DepMI->getIterator());
   const MachineInstr *NewMI =
       createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
@@ -1923,50 +1929,51 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVVectorType(
   return finishCreatingSPIRVType(Ty, NewMI);
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVPointerType(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateSPIRVPointerType(
     const Type *BaseType, MachineInstr &I,
     SPIRV::StorageClass::StorageClass SC) {
   MachineIRBuilder MIRBuilder(I);
   return getOrCreateSPIRVPointerType(BaseType, MIRBuilder, SC);
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVPointerType(
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateSPIRVPointerType(
     const Type *BaseType, MachineIRBuilder &MIRBuilder,
     SPIRV::StorageClass::StorageClass SC) {
   // TODO: Need to check if EmitIr should always be true.
-  SPIRVType *SpirvBaseType = getOrCreateSPIRVType(
+  SPIRVTypeInst SpirvBaseType = getOrCreateSPIRVType(
       BaseType, MIRBuilder, SPIRV::AccessQualifier::ReadWrite,
       storageClassRequiresExplictLayout(SC), true);
   assert(SpirvBaseType);
   return getOrCreateSPIRVPointerTypeInternal(SpirvBaseType, MIRBuilder, SC);
 }
 
-SPIRVType *SPIRVGlobalRegistry::changePointerStorageClass(
-    SPIRVType *PtrType, SPIRV::StorageClass::StorageClass SC, MachineInstr &I) {
+SPIRVTypeInst SPIRVGlobalRegistry::changePointerStorageClass(
+    SPIRVTypeInst PtrType, SPIRV::StorageClass::StorageClass SC,
+    MachineInstr &I) {
   [[maybe_unused]] SPIRV::StorageClass::StorageClass OldSC =
       getPointerStorageClass(PtrType);
   assert(storageClassRequiresExplictLayout(OldSC) ==
          storageClassRequiresExplictLayout(SC));
 
-  SPIRVType *PointeeType = getPointeeType(PtrType);
+  SPIRVTypeInst PointeeType = getPointeeType(PtrType);
   MachineIRBuilder MIRBuilder(I);
   return getOrCreateSPIRVPointerTypeInternal(PointeeType, MIRBuilder, SC);
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVPointerType(
-    SPIRVType *BaseType, MachineIRBuilder &MIRBuilder,
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateSPIRVPointerType(
+    SPIRVTypeInst BaseType, MachineIRBuilder &MIRBuilder,
     SPIRV::StorageClass::StorageClass SC) {
   const Type *LLVMType = getTypeForSPIRVType(BaseType);
   assert(!storageClassRequiresExplictLayout(SC));
-  SPIRVType *R = getOrCreateSPIRVPointerType(LLVMType, MIRBuilder, SC);
+  SPIRVTypeInst R = getOrCreateSPIRVPointerType(LLVMType, MIRBuilder, SC);
   assert(
       getPointeeType(R) == BaseType &&
       "The base type was not correctly laid out for the given storage class.");
   return R;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVPointerTypeInternal(
-    SPIRVType *BaseType, MachineIRBuilder &MIRBuilder,
+SPIRVTypeInst SPIRVGlobalRegistry::getOrCreateSPIRVPointerTypeInternal(
+    SPIRVTypeInst BaseType, MachineIRBuilder &MIRBuilder,
     SPIRV::StorageClass::StorageClass SC) {
   const Type *PointerElementType = getTypeForSPIRVType(BaseType);
   unsigned AddressSpace = storageClassToAddressSpace(SC);
@@ -1988,7 +1995,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVPointerTypeInternal(
 }
 
 Register SPIRVGlobalRegistry::getOrCreateUndef(MachineInstr &I,
-                                               SPIRVType *SpvType,
+                                               SPIRVTypeInst SpvType,
                                                const SPIRVInstrInfo &TII) {
   UndefValue *UV =
       UndefValue::get(const_cast<Type *>(getTypeForSPIRVType(SpvType)));
@@ -2001,7 +2008,8 @@ Register SPIRVGlobalRegistry::getOrCreateUndef(MachineInstr &I,
   CurMF->getRegInfo().setRegClass(Res, &SPIRV::iIDRegClass);
   assignSPIRVTypeToVReg(SpvType, Res, *CurMF);
 
-  MachineInstr *DepMI = const_cast<MachineInstr *>(SpvType);
+  MachineInstr *DepMI =
+      const_cast<MachineInstr *>(static_cast<const MachineInstr *>(SpvType));
   MachineIRBuilder MIRBuilder(*DepMI->getParent(), DepMI->getIterator());
   const MachineInstr *NewMI =
       createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
@@ -2020,7 +2028,7 @@ Register SPIRVGlobalRegistry::getOrCreateUndef(MachineInstr &I,
 }
 
 const TargetRegisterClass *
-SPIRVGlobalRegistry::getRegClass(SPIRVType *SpvType) const {
+SPIRVGlobalRegistry::getRegClass(SPIRVTypeInst SpvType) const {
   unsigned Opcode = SpvType->getOpcode();
   switch (Opcode) {
   case SPIRV::OpTypeFloat:
@@ -2028,7 +2036,8 @@ SPIRVGlobalRegistry::getRegClass(SPIRVType *SpvType) const {
   case SPIRV::OpTypePointer:
     return &SPIRV::pIDRegClass;
   case SPIRV::OpTypeVector: {
-    SPIRVType *ElemType = getSPIRVTypeForVReg(SpvType->getOperand(1).getReg());
+    SPIRVTypeInst ElemType =
+        getSPIRVTypeForVReg(SpvType->getOperand(1).getReg());
     unsigned ElemOpcode = ElemType ? ElemType->getOpcode() : 0;
     if (ElemOpcode == SPIRV::OpTypeFloat)
       return &SPIRV::vfIDRegClass;
@@ -2040,13 +2049,13 @@ SPIRVGlobalRegistry::getRegClass(SPIRVType *SpvType) const {
   return &SPIRV::iIDRegClass;
 }
 
-inline unsigned getAS(SPIRVType *SpvType) {
+inline unsigned getAS(SPIRVTypeInst SpvType) {
   return storageClassToAddressSpace(
       static_cast<SPIRV::StorageClass::StorageClass>(
           SpvType->getOperand(1).getImm()));
 }
 
-LLT SPIRVGlobalRegistry::getRegType(SPIRVType *SpvType) const {
+LLT SPIRVGlobalRegistry::getRegType(SPIRVTypeInst SpvType) const {
   unsigned Opcode = SpvType ? SpvType->getOpcode() : 0;
   switch (Opcode) {
   case SPIRV::OpTypeInt:
@@ -2056,7 +2065,8 @@ LLT SPIRVGlobalRegistry::getRegType(SPIRVType *SpvType) const {
   case SPIRV::OpTypePointer:
     return LLT::pointer(getAS(SpvType), getPointerSize());
   case SPIRV::OpTypeVector: {
-    SPIRVType *ElemType = getSPIRVTypeForVReg(SpvType->getOperand(1).getReg());
+    SPIRVTypeInst ElemType =
+        getSPIRVTypeForVReg(SpvType->getOperand(1).getReg());
     LLT ET;
     switch (ElemType ? ElemType->getOpcode() : 0) {
     case SPIRV::OpTypePointer:
@@ -2222,7 +2232,7 @@ void SPIRVGlobalRegistry::addArrayStrideDecorations(
                   {SizeInBytes});
 }
 
-bool SPIRVGlobalRegistry::hasBlockDecoration(SPIRVType *Type) const {
+bool SPIRVGlobalRegistry::hasBlockDecoration(SPIRVTypeInst Type) const {
   Register Def = getSPIRVTypeID(Type);
   for (const MachineInstr &Use :
        Type->getMF()->getRegInfo().use_instructions(Def)) {

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -93,7 +93,7 @@ class SPIRVGlobalRegistry : public SPIRVIRMapping {
   DenseMap<const MachineFunction *, DenseMap<Register, SPIRVType *>>
       VRegToTypeMap;
 
-  DenseMap<SPIRVType *, const Type *> SPIRVToLLVMType;
+  DenseMap<SPIRVTypeInst, const Type *> SPIRVToLLVMType;
 
   // map a Function to its definition (as a machine instruction operand)
   DenseMap<const Function *, const MachineOperand *> FunctionToInstr;
@@ -144,13 +144,14 @@ class SPIRVGlobalRegistry : public SPIRVIRMapping {
   std::unordered_map<const MDNode *, MachineInstr *> AliasInstMDMap;
 
   // Add a new OpTypeXXX instruction without checking for duplicates.
-  SPIRVType *createSPIRVType(const Type *Type, MachineIRBuilder &MIRBuilder,
-                             SPIRV::AccessQualifier::AccessQualifier AQ,
-                             bool ExplicitLayoutRequired, bool EmitIR);
-  SPIRVType *findSPIRVType(const Type *Ty, MachineIRBuilder &MIRBuilder,
-                           SPIRV::AccessQualifier::AccessQualifier accessQual,
-                           bool ExplicitLayoutRequired, bool EmitIR);
-  SPIRVType *
+  SPIRVTypeInst createSPIRVType(const Type *Type, MachineIRBuilder &MIRBuilder,
+                                SPIRV::AccessQualifier::AccessQualifier AQ,
+                                bool ExplicitLayoutRequired, bool EmitIR);
+  SPIRVTypeInst
+  findSPIRVType(const Type *Ty, MachineIRBuilder &MIRBuilder,
+                SPIRV::AccessQualifier::AccessQualifier accessQual,
+                bool ExplicitLayoutRequired, bool EmitIR);
+  SPIRVTypeInst
   restOfCreateSPIRVType(const Type *Type, MachineIRBuilder &MIRBuilder,
                         SPIRV::AccessQualifier::AccessQualifier AccessQual,
                         bool ExplicitLayoutRequired, bool EmitIR);
@@ -334,21 +335,23 @@ public:
 
   // Get or create a SPIR-V type corresponding the given LLVM IR type,
   // and map it to the given VReg.
-  SPIRVType *assignTypeToVReg(const Type *Type, Register VReg,
-                              MachineIRBuilder &MIRBuilder,
-                              SPIRV::AccessQualifier::AccessQualifier AQ,
-                              bool EmitIR);
-  SPIRVType *assignIntTypeToVReg(unsigned BitWidth, Register VReg,
-                                 MachineInstr &I, const SPIRVInstrInfo &TII);
-  SPIRVType *assignFloatTypeToVReg(unsigned BitWidth, Register VReg,
-                                   MachineInstr &I, const SPIRVInstrInfo &TII);
-  SPIRVType *assignVectTypeToVReg(SPIRVType *BaseType, unsigned NumElements,
-                                  Register VReg, MachineInstr &I,
-                                  const SPIRVInstrInfo &TII);
+  SPIRVTypeInst assignTypeToVReg(const Type *Type, Register VReg,
+                                 MachineIRBuilder &MIRBuilder,
+                                 SPIRV::AccessQualifier::AccessQualifier AQ,
+                                 bool EmitIR);
+  SPIRVTypeInst assignIntTypeToVReg(unsigned BitWidth, Register VReg,
+                                    MachineInstr &I, const SPIRVInstrInfo &TII);
+  SPIRVTypeInst assignFloatTypeToVReg(unsigned BitWidth, Register VReg,
+                                      MachineInstr &I,
+                                      const SPIRVInstrInfo &TII);
+  SPIRVTypeInst assignVectTypeToVReg(SPIRVTypeInst BaseType,
+                                     unsigned NumElements, Register VReg,
+                                     MachineInstr &I,
+                                     const SPIRVInstrInfo &TII);
 
   // In cases where the SPIR-V type is already known, this function can be
   // used to map it to the given VReg.
-  void assignSPIRVTypeToVReg(SPIRVType *Type, Register VReg,
+  void assignSPIRVTypeToVReg(SPIRVTypeInst Type, Register VReg,
                              const MachineFunction &MF);
 
   // Either generate a new OpTypeXXX instruction or return an existing one
@@ -356,35 +359,35 @@ public:
   // EmitIR controls if we emit GMIR or SPV constants (e.g. for array sizes)
   // because this method may be called from InstructionSelector and we don't
   // want to emit extra IR instructions there.
-  SPIRVType *getOrCreateSPIRVType(const Type *Type, MachineInstr &I,
-                                  SPIRV::AccessQualifier::AccessQualifier AQ,
-                                  bool EmitIR) {
+  SPIRVTypeInst getOrCreateSPIRVType(const Type *Type, MachineInstr &I,
+                                     SPIRV::AccessQualifier::AccessQualifier AQ,
+                                     bool EmitIR) {
     MachineIRBuilder MIRBuilder(I);
     return getOrCreateSPIRVType(Type, MIRBuilder, AQ, EmitIR);
   }
 
-  SPIRVType *getOrCreateSPIRVType(const Type *Type,
-                                  MachineIRBuilder &MIRBuilder,
-                                  SPIRV::AccessQualifier::AccessQualifier AQ,
-                                  bool EmitIR) {
+  SPIRVTypeInst getOrCreateSPIRVType(const Type *Type,
+                                     MachineIRBuilder &MIRBuilder,
+                                     SPIRV::AccessQualifier::AccessQualifier AQ,
+                                     bool EmitIR) {
     return getOrCreateSPIRVType(Type, MIRBuilder, AQ, false, EmitIR);
   }
 
-  const Type *getTypeForSPIRVType(const SPIRVType *Ty) const {
+  const Type *getTypeForSPIRVType(SPIRVTypeInst Ty) const {
     auto Res = SPIRVToLLVMType.find(Ty);
     assert(Res != SPIRVToLLVMType.end());
     return Res->second;
   }
 
   // Return a pointee's type, or nullptr otherwise.
-  SPIRVType *getPointeeType(SPIRVType *PtrType);
+  SPIRVTypeInst getPointeeType(SPIRVTypeInst PtrType);
   // Return a pointee's type op code, or 0 otherwise.
   unsigned getPointeeTypeOp(Register PtrReg);
 
   // Either generate a new OpTypeXXX instruction or return an existing one
   // corresponding to the given string containing the name of the builtin type.
   // Return nullptr if unable to recognize SPIRV type name from `TypeStr`.
-  SPIRVType *getOrCreateSPIRVTypeByName(
+  SPIRVTypeInst getOrCreateSPIRVTypeByName(
       StringRef TypeStr, MachineIRBuilder &MIRBuilder, bool EmitIR,
       SPIRV::StorageClass::StorageClass SC = SPIRV::StorageClass::Function,
       SPIRV::AccessQualifier::AccessQualifier AQ =
@@ -399,7 +402,7 @@ public:
                                  const MachineFunction *MF = nullptr) const;
 
   // Return the result type of the instruction defining the register.
-  SPIRVType *getResultType(Register VReg, MachineFunction *MF = nullptr);
+  SPIRVTypeInst getResultType(Register VReg, MachineFunction *MF = nullptr);
 
   // Whether the given VReg has a SPIR-V type mapped to it yet.
   bool hasSPIRVTypeForVReg(Register VReg) const {
@@ -407,7 +410,7 @@ public:
   }
 
   // Return the VReg holding the result of the given OpTypeXXX instruction.
-  Register getSPIRVTypeID(const SPIRVType *SpirvType) const;
+  Register getSPIRVTypeID(SPIRVTypeInst SpirvType) const;
 
   // Return previous value of the current machine function
   MachineFunction *setCurrentFunc(MachineFunction &MF) {
@@ -417,7 +420,7 @@ public:
   }
 
   // Return true if the type is an aggregate type.
-  bool isAggregateType(SPIRVType *Type) const {
+  bool isAggregateType(SPIRVTypeInst Type) const {
     return Type && (Type->getOpcode() == SPIRV::OpTypeStruct &&
                     Type->getOpcode() == SPIRV::OpTypeArray);
   }
@@ -433,116 +436,117 @@ public:
 
   // Returns true if `Type` is a resource type. This could be an image type
   // or a struct for a buffer decorated with the block decoration.
-  bool isResourceType(SPIRVType *Type) const;
+  bool isResourceType(SPIRVTypeInst Type) const;
 
   // Return number of elements in a vector if the argument is associated with
   // a vector type. Return 1 for a scalar type, and 0 for a missing type.
   unsigned getScalarOrVectorComponentCount(Register VReg) const;
-  unsigned getScalarOrVectorComponentCount(SPIRVType *Type) const;
+  unsigned getScalarOrVectorComponentCount(SPIRVTypeInst Type) const;
 
   // Return the component type in a vector if the argument is associated with
   // a vector type. Returns the argument itself for other types, and nullptr
   // for a missing type.
-  SPIRVType *getScalarOrVectorComponentType(Register VReg) const;
-  SPIRVType *getScalarOrVectorComponentType(SPIRVType *Type) const;
+  SPIRVTypeInst getScalarOrVectorComponentType(SPIRVTypeInst Type) const;
 
   // For vectors or scalars of booleans, integers and floats, return the scalar
   // type's bitwidth. Otherwise calls llvm_unreachable().
-  unsigned getScalarOrVectorBitWidth(const SPIRVType *Type) const;
+  unsigned getScalarOrVectorBitWidth(SPIRVTypeInst Type) const;
 
   // For vectors or scalars of integers and floats, return total bitwidth of the
   // argument. Otherwise returns 0.
-  unsigned getNumScalarOrVectorTotalBitWidth(const SPIRVType *Type) const;
+  unsigned getNumScalarOrVectorTotalBitWidth(SPIRVTypeInst Type) const;
 
   // Returns either pointer to integer type, that may be a type of vector
   // elements or an original type, or nullptr if the argument is niether
   // an integer scalar, nor an integer vector
-  const SPIRVType *retrieveScalarOrVectorIntType(const SPIRVType *Type) const;
+  SPIRVTypeInst retrieveScalarOrVectorIntType(SPIRVTypeInst Type) const;
 
   // For integer vectors or scalars, return whether the integers are signed.
-  bool isScalarOrVectorSigned(const SPIRVType *Type) const;
+  bool isScalarOrVectorSigned(SPIRVTypeInst Type) const;
 
   // Gets the storage class of the pointer type assigned to this vreg.
   SPIRV::StorageClass::StorageClass getPointerStorageClass(Register VReg) const;
   SPIRV::StorageClass::StorageClass
-  getPointerStorageClass(const SPIRVType *Type) const;
+  getPointerStorageClass(SPIRVTypeInst Type) const;
 
   // Return the number of bits SPIR-V pointers and size_t variables require.
   unsigned getPointerSize() const { return PointerSize; }
 
   // Returns true if two types are defined and are compatible in a sense of
   // OpBitcast instruction
-  bool isBitcastCompatible(const SPIRVType *Type1,
-                           const SPIRVType *Type2) const;
+  bool isBitcastCompatible(SPIRVTypeInst Type1, SPIRVTypeInst Type2) const;
 
   // Informs about removal of the machine instruction and invalidates data
   // structures referring this instruction.
   void invalidateMachineInstr(MachineInstr *MI);
 
 private:
-  SPIRVType *getOpTypeBool(MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst getOpTypeBool(MachineIRBuilder &MIRBuilder);
 
   const Type *adjustIntTypeByWidth(const Type *Ty) const;
   unsigned adjustOpTypeIntWidth(unsigned Width) const;
 
-  SPIRVType *getOrCreateSPIRVType(const Type *Type,
-                                  MachineIRBuilder &MIRBuilder,
-                                  SPIRV::AccessQualifier::AccessQualifier AQ,
-                                  bool ExplicitLayoutRequired, bool EmitIR);
+  SPIRVTypeInst getOrCreateSPIRVType(const Type *Type,
+                                     MachineIRBuilder &MIRBuilder,
+                                     SPIRV::AccessQualifier::AccessQualifier AQ,
+                                     bool ExplicitLayoutRequired, bool EmitIR);
 
-  SPIRVType *getOpTypeInt(unsigned Width, MachineIRBuilder &MIRBuilder,
-                          bool IsSigned = false);
+  SPIRVTypeInst getOpTypeInt(unsigned Width, MachineIRBuilder &MIRBuilder,
+                             bool IsSigned = false);
 
-  SPIRVType *getOpTypeFloat(uint32_t Width, MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst getOpTypeFloat(uint32_t Width, MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeFloat(uint32_t Width, MachineIRBuilder &MIRBuilder,
-                            SPIRV::FPEncoding::FPEncoding FPEncode);
+  SPIRVTypeInst getOpTypeFloat(uint32_t Width, MachineIRBuilder &MIRBuilder,
+                               SPIRV::FPEncoding::FPEncoding FPEncode);
 
-  SPIRVType *getOpTypeVoid(MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst getOpTypeVoid(MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeVector(uint32_t NumElems, SPIRVType *ElemType,
-                             MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst getOpTypeVector(uint32_t NumElems, SPIRVTypeInst ElemType,
+                                MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeArray(uint32_t NumElems, SPIRVType *ElemType,
-                            MachineIRBuilder &MIRBuilder,
-                            bool ExplicitLayoutRequired, bool EmitIR);
+  SPIRVTypeInst getOpTypeArray(uint32_t NumElems, SPIRVTypeInst ElemType,
+                               MachineIRBuilder &MIRBuilder,
+                               bool ExplicitLayoutRequired, bool EmitIR);
 
-  SPIRVType *getOpTypeOpaque(const StructType *Ty,
-                             MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst getOpTypeOpaque(const StructType *Ty,
+                                MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeStruct(const StructType *Ty, MachineIRBuilder &MIRBuilder,
-                             SPIRV::AccessQualifier::AccessQualifier AccQual,
-                             StructOffsetDecorator Decorator, bool EmitIR);
+  SPIRVTypeInst getOpTypeStruct(const StructType *Ty,
+                                MachineIRBuilder &MIRBuilder,
+                                SPIRV::AccessQualifier::AccessQualifier AccQual,
+                                StructOffsetDecorator Decorator, bool EmitIR);
 
-  SPIRVType *getOpTypePointer(SPIRV::StorageClass::StorageClass SC,
-                              SPIRVType *ElemType, MachineIRBuilder &MIRBuilder,
-                              Register Reg);
+  SPIRVTypeInst getOpTypePointer(SPIRV::StorageClass::StorageClass SC,
+                                 SPIRVTypeInst ElemType,
+                                 MachineIRBuilder &MIRBuilder, Register Reg);
 
-  SPIRVType *getOpTypeForwardPointer(SPIRV::StorageClass::StorageClass SC,
-                                     MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst getOpTypeForwardPointer(SPIRV::StorageClass::StorageClass SC,
+                                        MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeFunction(const FunctionType *Ty, SPIRVType *RetType,
-                               const SmallVectorImpl<SPIRVType *> &ArgTypes,
-                               MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst
+  getOpTypeFunction(const FunctionType *Ty, SPIRVTypeInst RetType,
+                    const SmallVectorImpl<SPIRVTypeInst> &ArgTypes,
+                    MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *
+  SPIRVTypeInst
   getOrCreateSpecialType(const Type *Ty, MachineIRBuilder &MIRBuilder,
                          SPIRV::AccessQualifier::AccessQualifier AccQual);
 
-  SPIRVType *finishCreatingSPIRVType(const Type *LLVMTy, SPIRVType *SpirvType);
+  SPIRVTypeInst finishCreatingSPIRVType(const Type *LLVMTy,
+                                        SPIRVTypeInst SpirvType);
   Register getOrCreateBaseRegister(Constant *Val, MachineInstr &I,
-                                   SPIRVType *SpvType,
+                                   SPIRVTypeInst SpvType,
                                    const SPIRVInstrInfo &TII, unsigned BitWidth,
                                    bool ZeroAsNull);
   Register getOrCreateCompositeOrNull(Constant *Val, MachineInstr &I,
-                                      SPIRVType *SpvType,
+                                      SPIRVTypeInst SpvType,
                                       const SPIRVInstrInfo &TII, Constant *CA,
                                       unsigned BitWidth, unsigned ElemCnt,
                                       bool ZeroAsNull = true);
 
   Register getOrCreateIntCompositeOrNull(uint64_t Val,
                                          MachineIRBuilder &MIRBuilder,
-                                         SPIRVType *SpvType, bool EmitIR,
+                                         SPIRVTypeInst SpvType, bool EmitIR,
                                          Constant *CA, unsigned BitWidth,
                                          unsigned ElemCnt);
 
@@ -550,8 +554,8 @@ private:
   // storage class. It is the responsibility of the caller to make sure the
   // decorations on the base type are valid for the given storage class. For
   // example, it has the correct offset and stride decorations.
-  SPIRVType *
-  getOrCreateSPIRVPointerTypeInternal(SPIRVType *BaseType,
+  SPIRVTypeInst
+  getOrCreateSPIRVPointerTypeInternal(SPIRVTypeInst BaseType,
                                       MachineIRBuilder &MIRBuilder,
                                       SPIRV::StorageClass::StorageClass SC);
 
@@ -559,165 +563,172 @@ private:
                                   MachineIRBuilder &MIRBuilder);
   void addArrayStrideDecorations(Register Reg, Type *ElementType,
                                  MachineIRBuilder &MIRBuilder);
-  bool hasBlockDecoration(SPIRVType *Type) const;
+  bool hasBlockDecoration(SPIRVTypeInst Type) const;
 
-  SPIRVType *
-  getOrCreateOpTypeImage(MachineIRBuilder &MIRBuilder, SPIRVType *SampledType,
-                         SPIRV::Dim::Dim Dim, uint32_t Depth, uint32_t Arrayed,
+  SPIRVTypeInst
+  getOrCreateOpTypeImage(MachineIRBuilder &MIRBuilder,
+                         SPIRVTypeInst SampledType, SPIRV::Dim::Dim Dim,
+                         uint32_t Depth, uint32_t Arrayed,
                          uint32_t Multisampled, uint32_t Sampled,
                          SPIRV::ImageFormat::ImageFormat ImageFormat,
                          SPIRV::AccessQualifier::AccessQualifier AccQual);
 
 public:
   Register buildConstantInt(uint64_t Val, MachineIRBuilder &MIRBuilder,
-                            SPIRVType *SpvType, bool EmitIR,
+                            SPIRVTypeInst SpvType, bool EmitIR,
                             bool ZeroAsNull = true);
   Register getOrCreateConstInt(uint64_t Val, MachineInstr &I,
-                               SPIRVType *SpvType, const SPIRVInstrInfo &TII,
+                               SPIRVTypeInst SpvType, const SPIRVInstrInfo &TII,
                                bool ZeroAsNull = true);
   Register getOrCreateConstInt(const APInt &Val, MachineInstr &I,
-                               const SPIRVType *SpvType,
-                               const SPIRVInstrInfo &TII,
+                               SPIRVTypeInst SpvType, const SPIRVInstrInfo &TII,
                                bool ZeroAsNull = true);
   Register createConstInt(const ConstantInt *CI, MachineInstr &I,
-                          SPIRVType *SpvType, const SPIRVInstrInfo &TII,
+                          SPIRVTypeInst SpvType, const SPIRVInstrInfo &TII,
                           bool ZeroAsNull);
-  Register getOrCreateConstFP(APFloat Val, MachineInstr &I, SPIRVType *SpvType,
-                              const SPIRVInstrInfo &TII,
+  Register getOrCreateConstFP(APFloat Val, MachineInstr &I,
+                              SPIRVTypeInst SpvType, const SPIRVInstrInfo &TII,
                               bool ZeroAsNull = true);
   Register createConstFP(const ConstantFP *CF, MachineInstr &I,
-                         SPIRVType *SpvType, const SPIRVInstrInfo &TII,
+                         SPIRVTypeInst SpvType, const SPIRVInstrInfo &TII,
                          bool ZeroAsNull);
   Register buildConstantFP(APFloat Val, MachineIRBuilder &MIRBuilder,
-                           SPIRVType *SpvType = nullptr);
+                           SPIRVTypeInst SpvType = nullptr);
 
   Register getOrCreateConstVector(uint64_t Val, MachineInstr &I,
-                                  SPIRVType *SpvType, const SPIRVInstrInfo &TII,
+                                  SPIRVTypeInst SpvType,
+                                  const SPIRVInstrInfo &TII,
                                   bool ZeroAsNull = true);
   Register getOrCreateConstVector(const APInt &Val, MachineInstr &I,
-                                  const SPIRVType *SpvType,
+                                  SPIRVTypeInst SpvType,
                                   const SPIRVInstrInfo &TII,
                                   bool ZeroAsNull = true);
   Register getOrCreateConstVector(APFloat Val, MachineInstr &I,
-                                  SPIRVType *SpvType, const SPIRVInstrInfo &TII,
+                                  SPIRVTypeInst SpvType,
+                                  const SPIRVInstrInfo &TII,
                                   bool ZeroAsNull = true);
   Register getOrCreateConstIntArray(uint64_t Val, size_t Num, MachineInstr &I,
-                                    SPIRVType *SpvType,
+                                    SPIRVTypeInst SpvType,
                                     const SPIRVInstrInfo &TII);
   Register getOrCreateConsIntVector(uint64_t Val, MachineIRBuilder &MIRBuilder,
-                                    SPIRVType *SpvType, bool EmitIR);
+                                    SPIRVTypeInst SpvType, bool EmitIR);
   Register getOrCreateConstNullPtr(MachineIRBuilder &MIRBuilder,
-                                   SPIRVType *SpvType);
+                                   SPIRVTypeInst SpvType);
   Register buildConstantSampler(Register Res, unsigned AddrMode, unsigned Param,
                                 unsigned FilerMode,
                                 MachineIRBuilder &MIRBuilder);
-  Register getOrCreateUndef(MachineInstr &I, SPIRVType *SpvType,
+  Register getOrCreateUndef(MachineInstr &I, SPIRVTypeInst SpvType,
                             const SPIRVInstrInfo &TII);
   Register buildGlobalVariable(
-      Register Reg, SPIRVType *BaseType, StringRef Name, const GlobalValue *GV,
-      SPIRV::StorageClass::StorageClass Storage, const MachineInstr *Init,
-      bool IsConst,
+      Register Reg, SPIRVTypeInst BaseType, StringRef Name,
+      const GlobalValue *GV, SPIRV::StorageClass::StorageClass Storage,
+      const MachineInstr *Init, bool IsConst,
       const std::optional<SPIRV::LinkageType::LinkageType> &LinkageType,
       MachineIRBuilder &MIRBuilder, bool IsInstSelector);
-  Register getOrCreateGlobalVariableWithBinding(const SPIRVType *VarType,
+  Register getOrCreateGlobalVariableWithBinding(SPIRVTypeInst VarType,
                                                 uint32_t Set, uint32_t Binding,
                                                 StringRef Name,
                                                 MachineIRBuilder &MIRBuilder);
 
   // Convenient helpers for getting types with check for duplicates.
-  SPIRVType *getOrCreateSPIRVIntegerType(unsigned BitWidth,
-                                         MachineIRBuilder &MIRBuilder);
-  SPIRVType *getOrCreateSPIRVIntegerType(unsigned BitWidth, MachineInstr &I,
+  SPIRVTypeInst getOrCreateSPIRVIntegerType(unsigned BitWidth,
+                                            MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst getOrCreateSPIRVIntegerType(unsigned BitWidth, MachineInstr &I,
+                                            const SPIRVInstrInfo &TII);
+  SPIRVTypeInst getOrCreateSPIRVType(unsigned BitWidth, MachineInstr &I,
+                                     const SPIRVInstrInfo &TII,
+                                     unsigned SPIRVOPcode, Type *LLVMTy);
+  SPIRVTypeInst getOrCreateSPIRVFloatType(unsigned BitWidth, MachineInstr &I,
+                                          const SPIRVInstrInfo &TII);
+  SPIRVTypeInst getOrCreateSPIRVBoolType(MachineIRBuilder &MIRBuilder,
+                                         bool EmitIR);
+  SPIRVTypeInst getOrCreateSPIRVBoolType(MachineInstr &I,
                                          const SPIRVInstrInfo &TII);
-  SPIRVType *getOrCreateSPIRVType(unsigned BitWidth, MachineInstr &I,
-                                  const SPIRVInstrInfo &TII,
-                                  unsigned SPIRVOPcode, Type *LLVMTy);
-  SPIRVType *getOrCreateSPIRVFloatType(unsigned BitWidth, MachineInstr &I,
-                                       const SPIRVInstrInfo &TII);
-  SPIRVType *getOrCreateSPIRVBoolType(MachineIRBuilder &MIRBuilder,
-                                      bool EmitIR);
-  SPIRVType *getOrCreateSPIRVBoolType(MachineInstr &I,
-                                      const SPIRVInstrInfo &TII);
-  SPIRVType *getOrCreateSPIRVVectorType(SPIRVType *BaseType,
-                                        unsigned NumElements,
-                                        MachineIRBuilder &MIRBuilder,
-                                        bool EmitIR);
-  SPIRVType *getOrCreateSPIRVVectorType(SPIRVType *BaseType,
-                                        unsigned NumElements, MachineInstr &I,
-                                        const SPIRVInstrInfo &TII);
+  SPIRVTypeInst getOrCreateSPIRVVectorType(SPIRVTypeInst BaseType,
+                                           unsigned NumElements,
+                                           MachineIRBuilder &MIRBuilder,
+                                           bool EmitIR);
+  SPIRVTypeInst getOrCreateSPIRVVectorType(SPIRVTypeInst BaseType,
+                                           unsigned NumElements,
+                                           MachineInstr &I,
+                                           const SPIRVInstrInfo &TII);
 
   // Returns a pointer to a SPIR-V pointer type with the given base type and
   // storage class. The base type will be translated to a SPIR-V type, and the
   // appropriate layout decorations will be added to the base type.
-  SPIRVType *getOrCreateSPIRVPointerType(const Type *BaseType,
-                                         MachineIRBuilder &MIRBuilder,
-                                         SPIRV::StorageClass::StorageClass SC);
-  SPIRVType *getOrCreateSPIRVPointerType(const Type *BaseType, MachineInstr &I,
-                                         SPIRV::StorageClass::StorageClass SC);
+  SPIRVTypeInst
+  getOrCreateSPIRVPointerType(const Type *BaseType,
+                              MachineIRBuilder &MIRBuilder,
+                              SPIRV::StorageClass::StorageClass SC);
+  SPIRVTypeInst
+  getOrCreateSPIRVPointerType(const Type *BaseType, MachineInstr &I,
+                              SPIRV::StorageClass::StorageClass SC);
 
   // Returns a pointer to a SPIR-V pointer type with the given base type and
   // storage class. It is the responsibility of the caller to make sure the
   // decorations on the base type are valid for the given storage class. For
   // example, it has the correct offset and stride decorations.
-  SPIRVType *getOrCreateSPIRVPointerType(SPIRVType *BaseType,
-                                         MachineIRBuilder &MIRBuilder,
-                                         SPIRV::StorageClass::StorageClass SC);
+  SPIRVTypeInst
+  getOrCreateSPIRVPointerType(SPIRVTypeInst BaseType,
+                              MachineIRBuilder &MIRBuilder,
+                              SPIRV::StorageClass::StorageClass SC);
 
   // Returns a pointer to a SPIR-V pointer type that is the same as `PtrType`
   // except the stroage class has been changed to `SC`. It is the responsibility
   // of the caller to be sure that the original and new storage class have the
   // same layout requirements.
-  SPIRVType *changePointerStorageClass(SPIRVType *PtrType,
-                                       SPIRV::StorageClass::StorageClass SC,
-                                       MachineInstr &I);
+  SPIRVTypeInst changePointerStorageClass(SPIRVTypeInst PtrType,
+                                          SPIRV::StorageClass::StorageClass SC,
+                                          MachineInstr &I);
 
-  SPIRVType *getOrCreateVulkanBufferType(MachineIRBuilder &MIRBuilder,
-                                         Type *ElemType,
-                                         SPIRV::StorageClass::StorageClass SC,
-                                         bool IsWritable, bool EmitIr = false);
+  SPIRVTypeInst
+  getOrCreateVulkanBufferType(MachineIRBuilder &MIRBuilder, Type *ElemType,
+                              SPIRV::StorageClass::StorageClass SC,
+                              bool IsWritable, bool EmitIr = false);
 
-  SPIRVType *getOrCreatePaddingType(MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst getOrCreatePaddingType(MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOrCreateVulkanPushConstantType(MachineIRBuilder &MIRBuilder,
-                                               Type *ElemType);
+  SPIRVTypeInst getOrCreateVulkanPushConstantType(MachineIRBuilder &MIRBuilder,
+                                                  Type *ElemType);
 
-  SPIRVType *getOrCreateLayoutType(MachineIRBuilder &MIRBuilder,
-                                   const TargetExtType *T, bool EmitIr = false);
+  SPIRVTypeInst getOrCreateLayoutType(MachineIRBuilder &MIRBuilder,
+                                      const TargetExtType *T,
+                                      bool EmitIr = false);
 
-  SPIRVType *
+  SPIRVTypeInst
   getImageType(const TargetExtType *ExtensionType,
                const SPIRV::AccessQualifier::AccessQualifier Qualifier,
                MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOrCreateOpTypeSampler(MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst getOrCreateOpTypeSampler(MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOrCreateOpTypeSampledImage(SPIRVType *ImageType,
-                                           MachineIRBuilder &MIRBuilder);
-  SPIRVType *getOrCreateOpTypeCoopMatr(MachineIRBuilder &MIRBuilder,
-                                       const TargetExtType *ExtensionType,
-                                       const SPIRVType *ElemType,
-                                       uint32_t Scope, uint32_t Rows,
-                                       uint32_t Columns, uint32_t Use,
-                                       bool EmitIR);
-  SPIRVType *
+  SPIRVTypeInst getOrCreateOpTypeSampledImage(SPIRVTypeInst ImageType,
+                                              MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst getOrCreateOpTypeCoopMatr(MachineIRBuilder &MIRBuilder,
+                                          const TargetExtType *ExtensionType,
+                                          SPIRVTypeInst ElemType,
+                                          uint32_t Scope, uint32_t Rows,
+                                          uint32_t Columns, uint32_t Use,
+                                          bool EmitIR);
+  SPIRVTypeInst
   getOrCreateOpTypePipe(MachineIRBuilder &MIRBuilder,
                         SPIRV::AccessQualifier::AccessQualifier AccQual);
-  SPIRVType *getOrCreateOpTypeDeviceEvent(MachineIRBuilder &MIRBuilder);
-  SPIRVType *getOrCreateOpTypeFunctionWithArgs(
-      const Type *Ty, SPIRVType *RetType,
-      const SmallVectorImpl<SPIRVType *> &ArgTypes,
+  SPIRVTypeInst getOrCreateOpTypeDeviceEvent(MachineIRBuilder &MIRBuilder);
+  SPIRVTypeInst getOrCreateOpTypeFunctionWithArgs(
+      const Type *Ty, SPIRVTypeInst RetType,
+      const SmallVectorImpl<SPIRVTypeInst> &ArgTypes,
       MachineIRBuilder &MIRBuilder);
-  SPIRVType *getOrCreateOpTypeByOpcode(const Type *Ty,
+  SPIRVTypeInst getOrCreateOpTypeByOpcode(const Type *Ty,
+                                          MachineIRBuilder &MIRBuilder,
+                                          unsigned Opcode);
+
+  SPIRVTypeInst getOrCreateUnknownType(const Type *Ty,
                                        MachineIRBuilder &MIRBuilder,
-                                       unsigned Opcode);
+                                       unsigned Opcode,
+                                       const ArrayRef<MCOperand> Operands);
 
-  SPIRVType *getOrCreateUnknownType(const Type *Ty,
-                                    MachineIRBuilder &MIRBuilder,
-                                    unsigned Opcode,
-                                    const ArrayRef<MCOperand> Operands);
-
-  const TargetRegisterClass *getRegClass(SPIRVType *SpvType) const;
-  LLT getRegType(SPIRVType *SpvType) const;
+  const TargetRegisterClass *getRegClass(SPIRVTypeInst SpvType) const;
+  LLT getRegType(SPIRVTypeInst SpvType) const;
 
   MachineInstr *getOrAddMemAliasingINTELInst(MachineIRBuilder &MIRBuilder,
                                              const MDNode *AliasingListMD);

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -160,7 +160,7 @@ inline Register getTypeReg(MachineRegisterInfo *MRI, Register OpReg) {
 static void doInsertBitcast(const SPIRVSubtarget &STI, MachineRegisterInfo *MRI,
                             SPIRVGlobalRegistry &GR, MachineInstr &I,
                             Register OpReg, unsigned OpIdx,
-                            SPIRVType *NewPtrType) {
+                            SPIRVTypeInst NewPtrType) {
   MachineIRBuilder MIB(I);
   Register NewReg = createVirtualRegister(NewPtrType, &GR, MRI, MIB.getMF());
   MIB.buildInstr(SPIRV::OpBitcast)
@@ -172,14 +172,15 @@ static void doInsertBitcast(const SPIRVSubtarget &STI, MachineRegisterInfo *MRI,
   I.getOperand(OpIdx).setReg(NewReg);
 }
 
-static SPIRVType *createNewPtrType(SPIRVGlobalRegistry &GR, MachineInstr &I,
-                                   SPIRVType *OpType, bool ReuseType,
-                                   SPIRVType *ResType, const Type *ResTy) {
+static SPIRVTypeInst createNewPtrType(SPIRVGlobalRegistry &GR, MachineInstr &I,
+                                      SPIRVTypeInst OpType, bool ReuseType,
+                                      SPIRVTypeInst ResType,
+                                      const Type *ResTy) {
   SPIRV::StorageClass::StorageClass SC =
       static_cast<SPIRV::StorageClass::StorageClass>(
           OpType->getOperand(1).getImm());
   MachineIRBuilder MIB(I);
-  SPIRVType *NewBaseType =
+  SPIRVTypeInst NewBaseType =
       ReuseType ? ResType
                 : GR.getOrCreateSPIRVType(
                       ResTy, MIB, SPIRV::AccessQualifier::ReadWrite, false);
@@ -191,7 +192,8 @@ static SPIRVType *createNewPtrType(SPIRVGlobalRegistry &GR, MachineInstr &I,
 static void validatePtrTypes(const SPIRVSubtarget &STI,
                              MachineRegisterInfo *MRI, SPIRVGlobalRegistry &GR,
                              MachineInstr &I, unsigned OpIdx,
-                             SPIRVType *ResType, const Type *ResTy = nullptr) {
+                             SPIRVTypeInst ResType,
+                             const Type *ResTy = nullptr) {
   // Get operand type
   MachineFunction *MF = I.getParent()->getParent();
   Register OpReg = I.getOperand(OpIdx).getReg();
@@ -201,7 +203,7 @@ static void validatePtrTypes(const SPIRVSubtarget &STI,
     return;
   // Get operand's pointee type
   Register ElemTypeReg = OpType->getOperand(2).getReg();
-  SPIRVType *ElemType = GR.getSPIRVTypeForVReg(ElemTypeReg, MF);
+  SPIRVTypeInst ElemType = GR.getSPIRVTypeForVReg(ElemTypeReg, MF);
   if (!ElemType)
     return;
   // Check if we need a bitcast to make a statement valid
@@ -212,7 +214,7 @@ static void validatePtrTypes(const SPIRVSubtarget &STI,
     return;
   // There is a type mismatch between results and operand types
   // and we insert a bitcast before the instruction to keep SPIR-V code valid
-  SPIRVType *NewPtrType =
+  SPIRVTypeInst NewPtrType =
       createNewPtrType(GR, I, OpType, IsSameMF, ResType, ResTy);
   if (!GR.isBitcastCompatible(NewPtrType, OpType))
     report_fatal_error(
@@ -230,15 +232,16 @@ static void validateGroupWaitEventsPtr(const SPIRVSubtarget &STI,
   MachineFunction *MF = I.getParent()->getParent();
   Register OpReg = I.getOperand(OpIdx).getReg();
   Register OpTypeReg = getTypeReg(MRI, OpReg);
-  SPIRVType *OpType = GR.getSPIRVTypeForVReg(OpTypeReg, MF);
+  SPIRVTypeInst OpType = GR.getSPIRVTypeForVReg(OpTypeReg, MF);
   if (!OpType || OpType->getOpcode() != SPIRV::OpTypePointer)
     return;
-  SPIRVType *ElemType = GR.getSPIRVTypeForVReg(OpType->getOperand(2).getReg());
+  SPIRVTypeInst ElemType =
+      GR.getSPIRVTypeForVReg(OpType->getOperand(2).getReg());
   if (!ElemType || ElemType->getOpcode() == SPIRV::OpTypeEvent)
     return;
   // Insert a bitcast before the instruction to keep SPIR-V code valid.
   LLVMContext &Context = MF->getFunction().getContext();
-  SPIRVType *NewPtrType =
+  SPIRVTypeInst NewPtrType =
       createNewPtrType(GR, I, OpType, false, nullptr,
                        TargetExtType::get(Context, "spirv.Event"));
   doInsertBitcast(STI, MRI, GR, I, OpReg, OpIdx, NewPtrType);
@@ -250,8 +253,8 @@ static void validateLifetimeStart(const SPIRVSubtarget &STI,
   Register PtrReg = I.getOperand(0).getReg();
   MachineFunction *MF = I.getParent()->getParent();
   Register PtrTypeReg = getTypeReg(MRI, PtrReg);
-  SPIRVType *PtrType = GR.getSPIRVTypeForVReg(PtrTypeReg, MF);
-  SPIRVType *PonteeElemType = PtrType ? GR.getPointeeType(PtrType) : nullptr;
+  SPIRVTypeInst PtrType = GR.getSPIRVTypeForVReg(PtrTypeReg, MF);
+  SPIRVTypeInst PonteeElemType = PtrType ? GR.getPointeeType(PtrType) : nullptr;
   if (!PonteeElemType || PonteeElemType->getOpcode() == SPIRV::OpTypeVoid ||
       (PonteeElemType->getOpcode() == SPIRV::OpTypeInt &&
        PonteeElemType->getOperand(1).getImm() == 8))
@@ -262,7 +265,7 @@ static void validateLifetimeStart(const SPIRVSubtarget &STI,
           PtrType->getOperand(1).getImm());
   MachineIRBuilder MIB(I);
   LLVMContext &Context = MF->getFunction().getContext();
-  SPIRVType *NewPtrType =
+  SPIRVTypeInst NewPtrType =
       GR.getOrCreateSPIRVPointerType(IntegerType::getInt8Ty(Context), MIB, SC);
   doInsertBitcast(STI, MRI, GR, I, PtrReg, 0, NewPtrType);
 }
@@ -274,15 +277,16 @@ static void validatePtrUnwrapStructField(const SPIRVSubtarget &STI,
   MachineFunction *MF = I.getParent()->getParent();
   Register OpReg = I.getOperand(OpIdx).getReg();
   Register OpTypeReg = getTypeReg(MRI, OpReg);
-  SPIRVType *OpType = GR.getSPIRVTypeForVReg(OpTypeReg, MF);
+  SPIRVTypeInst OpType = GR.getSPIRVTypeForVReg(OpTypeReg, MF);
   if (!OpType || OpType->getOpcode() != SPIRV::OpTypePointer)
     return;
-  SPIRVType *ElemType = GR.getSPIRVTypeForVReg(OpType->getOperand(2).getReg());
+  SPIRVTypeInst ElemType =
+      GR.getSPIRVTypeForVReg(OpType->getOperand(2).getReg());
   if (!ElemType || ElemType->getOpcode() != SPIRV::OpTypeStruct ||
       ElemType->getNumOperands() != 2)
     return;
   // It's a structure-wrapper around another type with a single member field.
-  SPIRVType *MemberType =
+  SPIRVTypeInst MemberType =
       GR.getSPIRVTypeForVReg(ElemType->getOperand(1).getReg());
   if (!MemberType)
     return;
@@ -296,7 +300,8 @@ static void validatePtrUnwrapStructField(const SPIRVSubtarget &STI,
       static_cast<SPIRV::StorageClass::StorageClass>(
           OpType->getOperand(1).getImm());
   MachineIRBuilder MIB(I);
-  SPIRVType *NewPtrType = GR.getOrCreateSPIRVPointerType(MemberType, MIB, SC);
+  SPIRVTypeInst NewPtrType =
+      GR.getOrCreateSPIRVPointerType(MemberType, MIB, SC);
   doInsertBitcast(STI, MRI, GR, I, OpReg, OpIdx, NewPtrType);
 }
 
@@ -320,8 +325,9 @@ void validateFunCallMachineDef(const SPIRVSubtarget &STI,
        FunDef && FunDef->getOpcode() == SPIRV::OpFunctionParameter &&
        OpIdx < FunCall.getNumOperands();
        FunDef = FunDef->getNextNode(), OpIdx++) {
-    SPIRVType *DefPtrType = DefMRI->getVRegDef(FunDef->getOperand(1).getReg());
-    SPIRVType *DefElemType =
+    SPIRVTypeInst DefPtrType =
+        DefMRI->getVRegDef(FunDef->getOperand(1).getReg());
+    SPIRVTypeInst DefElemType =
         DefPtrType && DefPtrType->getOpcode() == SPIRV::OpTypePointer
             ? GR.getSPIRVTypeForVReg(DefPtrType->getOperand(2).getReg(),
                                      DefPtrType->getParent()->getParent())
@@ -376,9 +382,9 @@ void validateForwardCalls(const SPIRVSubtarget &STI,
 // Validation of an access chain.
 void validateAccessChain(const SPIRVSubtarget &STI, MachineRegisterInfo *MRI,
                          SPIRVGlobalRegistry &GR, MachineInstr &I) {
-  SPIRVType *BaseTypeInst = GR.getSPIRVTypeForVReg(I.getOperand(0).getReg());
+  SPIRVTypeInst BaseTypeInst = GR.getSPIRVTypeForVReg(I.getOperand(0).getReg());
   if (BaseTypeInst && BaseTypeInst->getOpcode() == SPIRV::OpTypePointer) {
-    SPIRVType *BaseElemType =
+    SPIRVTypeInst BaseElemType =
         GR.getSPIRVTypeForVReg(BaseTypeInst->getOperand(2).getReg());
     validatePtrTypes(STI, MRI, GR, I, 2, BaseElemType);
   }
@@ -508,7 +514,7 @@ void SPIRVTargetLowering::finalizeLowering(MachineFunction &MF) const {
         validateGroupWaitEventsPtr(STI, MRI, GR, MI);
         break;
       case SPIRV::OpConstantI: {
-        SPIRVType *Type = GR.getSPIRVTypeForVReg(MI.getOperand(1).getReg());
+        SPIRVTypeInst Type = GR.getSPIRVTypeForVReg(MI.getOperand(1).getReg());
         if (Type->getOpcode() != SPIRV::OpTypeInt && MI.getOperand(2).isImm() &&
             MI.getOperand(2).getImm() == 0) {
           // Validate the null constant of a target extension type
@@ -523,9 +529,9 @@ void SPIRVTargetLowering::finalizeLowering(MachineFunction &MF) const {
         // doesn't dominate all uses. Let's place the type definition
         // instruction at the end of the predecessor.
         MachineBasicBlock *Curr = MI.getParent();
-        SPIRVType *Type = GR.getSPIRVTypeForVReg(MI.getOperand(1).getReg());
+        SPIRVTypeInst Type = GR.getSPIRVTypeForVReg(MI.getOperand(1).getReg());
         if (Type->getParent() == Curr && !Curr->pred_empty())
-          ToMove.insert(const_cast<MachineInstr *>(Type));
+          ToMove.insert(const_cast<MachineInstr *>(&*Type));
       } break;
       case SPIRV::OpExtInst: {
         // prefetch
@@ -539,8 +545,8 @@ void SPIRVTargetLowering::finalizeLowering(MachineFunction &MF) const {
           // The last operand must be of a pointer to i32 or vector of i32
           // values.
           MachineIRBuilder MIB(MI);
-          SPIRVType *Int32Type = GR.getOrCreateSPIRVIntegerType(32, MIB);
-          SPIRVType *RetType = MRI->getVRegDef(MI.getOperand(1).getReg());
+          SPIRVTypeInst Int32Type = GR.getOrCreateSPIRVIntegerType(32, MIB);
+          SPIRVTypeInst RetType = MRI->getVRegDef(MI.getOperand(1).getReg());
           assert(RetType && "Expected return type");
           validatePtrTypes(STI, MRI, GR, MI, MI.getNumOperands() - 1,
                            RetType->getOpcode() != SPIRV::OpTypeVector
@@ -589,9 +595,9 @@ void SPIRVTargetLowering::finalizeLowering(MachineFunction &MF) const {
 bool SPIRVTargetLowering::enforcePtrTypeCompatibility(
     MachineInstr &I, unsigned int PtrOpIdx, unsigned int OpIdx) const {
   SPIRVGlobalRegistry &GR = *STI.getSPIRVGlobalRegistry();
-  SPIRVType *PtrType = GR.getResultType(I.getOperand(PtrOpIdx).getReg());
-  SPIRVType *PointeeType = GR.getPointeeType(PtrType);
-  SPIRVType *OpType = GR.getResultType(I.getOperand(OpIdx).getReg());
+  SPIRVTypeInst PtrType = GR.getResultType(I.getOperand(PtrOpIdx).getReg());
+  SPIRVTypeInst PointeeType = GR.getPointeeType(PtrType);
+  SPIRVTypeInst OpType = GR.getResultType(I.getOperand(OpIdx).getReg());
 
   if (PointeeType == OpType)
     return true;
@@ -611,7 +617,7 @@ bool SPIRVTargetLowering::enforcePtrTypeCompatibility(
 }
 
 bool SPIRVTargetLowering::insertLogicalCopyOnResult(
-    MachineInstr &I, SPIRVType *NewResultType) const {
+    MachineInstr &I, SPIRVTypeInst NewResultType) const {
   MachineRegisterInfo *MRI = &I.getMF()->getRegInfo();
   SPIRVGlobalRegistry &GR = *STI.getSPIRVGlobalRegistry();
 

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
@@ -74,7 +74,7 @@ public:
   bool enforcePtrTypeCompatibility(MachineInstr &I, unsigned PtrOpIdx,
                                    unsigned OpIdx) const;
   bool insertLogicalCopyOnResult(MachineInstr &I,
-                                 SPIRVType *NewResultType) const;
+                                 SPIRVTypeInst NewResultType) const;
 
   AtomicExpansionKind
   shouldExpandAtomicRMWInIR(const AtomicRMWInst *RMW) const override;

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -113,28 +113,28 @@ private:
 
   // All instruction-specific selection that didn't happen in "select()".
   // Is basically a large Switch/Case delegating to all other select method.
-  bool spvSelect(Register ResVReg, const SPIRVType *ResType,
+  bool spvSelect(Register ResVReg, SPIRVTypeInst ResType,
                  MachineInstr &I) const;
 
-  bool selectFirstBitHigh(Register ResVReg, const SPIRVType *ResType,
+  bool selectFirstBitHigh(Register ResVReg, SPIRVTypeInst ResType,
                           MachineInstr &I, bool IsSigned) const;
 
-  bool selectFirstBitLow(Register ResVReg, const SPIRVType *ResType,
+  bool selectFirstBitLow(Register ResVReg, SPIRVTypeInst ResType,
                          MachineInstr &I) const;
 
-  bool selectFirstBitSet16(Register ResVReg, const SPIRVType *ResType,
+  bool selectFirstBitSet16(Register ResVReg, SPIRVTypeInst ResType,
                            MachineInstr &I, unsigned ExtendOpcode,
                            unsigned BitSetOpcode) const;
 
-  bool selectFirstBitSet32(Register ResVReg, const SPIRVType *ResType,
+  bool selectFirstBitSet32(Register ResVReg, SPIRVTypeInst ResType,
                            MachineInstr &I, Register SrcReg,
                            unsigned BitSetOpcode) const;
 
-  bool selectFirstBitSet64(Register ResVReg, const SPIRVType *ResType,
+  bool selectFirstBitSet64(Register ResVReg, SPIRVTypeInst ResType,
                            MachineInstr &I, Register SrcReg,
                            unsigned BitSetOpcode, bool SwapPrimarySide) const;
 
-  bool selectFirstBitSet64Overflow(Register ResVReg, const SPIRVType *ResType,
+  bool selectFirstBitSet64Overflow(Register ResVReg, SPIRVTypeInst ResType,
                                    MachineInstr &I, Register SrcReg,
                                    unsigned BitSetOpcode,
                                    bool SwapPrimarySide) const;
@@ -142,21 +142,21 @@ private:
   bool selectGlobalValue(Register ResVReg, MachineInstr &I,
                          const MachineInstr *Init = nullptr) const;
 
-  bool selectOpWithSrcs(Register ResVReg, const SPIRVType *ResType,
+  bool selectOpWithSrcs(Register ResVReg, SPIRVTypeInst ResType,
                         MachineInstr &I, std::vector<Register> SrcRegs,
                         unsigned Opcode) const;
 
-  bool selectUnOp(Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
+  bool selectUnOp(Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
                   unsigned Opcode) const;
 
-  bool selectBitcast(Register ResVReg, const SPIRVType *ResType,
+  bool selectBitcast(Register ResVReg, SPIRVTypeInst ResType,
                      MachineInstr &I) const;
 
-  bool selectLoad(Register ResVReg, const SPIRVType *ResType,
+  bool selectLoad(Register ResVReg, SPIRVTypeInst ResType,
                   MachineInstr &I) const;
   bool selectStore(MachineInstr &I) const;
 
-  bool selectStackSave(Register ResVReg, const SPIRVType *ResType,
+  bool selectStackSave(Register ResVReg, SPIRVTypeInst ResType,
                        MachineInstr &I) const;
   bool selectStackRestore(MachineInstr &I) const;
 
@@ -165,229 +165,225 @@ private:
   bool selectCopyMemory(MachineInstr &I, Register SrcReg) const;
   bool selectCopyMemorySized(MachineInstr &I, Register SrcReg) const;
 
-  bool selectAtomicRMW(Register ResVReg, const SPIRVType *ResType,
-                       MachineInstr &I, unsigned NewOpcode,
-                       unsigned NegateOpcode = 0) const;
+  bool selectAtomicRMW(Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
+                       unsigned NewOpcode, unsigned NegateOpcode = 0) const;
 
-  bool selectAtomicCmpXchg(Register ResVReg, const SPIRVType *ResType,
+  bool selectAtomicCmpXchg(Register ResVReg, SPIRVTypeInst ResType,
                            MachineInstr &I) const;
 
   bool selectFence(MachineInstr &I) const;
 
-  bool selectAddrSpaceCast(Register ResVReg, const SPIRVType *ResType,
+  bool selectAddrSpaceCast(Register ResVReg, SPIRVTypeInst ResType,
                            MachineInstr &I) const;
 
-  bool selectAnyOrAll(Register ResVReg, const SPIRVType *ResType,
-                      MachineInstr &I, unsigned OpType) const;
+  bool selectAnyOrAll(Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
+                      unsigned OpType) const;
 
-  bool selectAll(Register ResVReg, const SPIRVType *ResType,
+  bool selectAll(Register ResVReg, SPIRVTypeInst ResType,
                  MachineInstr &I) const;
 
-  bool selectAny(Register ResVReg, const SPIRVType *ResType,
+  bool selectAny(Register ResVReg, SPIRVTypeInst ResType,
                  MachineInstr &I) const;
 
-  bool selectBitreverse(Register ResVReg, const SPIRVType *ResType,
+  bool selectBitreverse(Register ResVReg, SPIRVTypeInst ResType,
                         MachineInstr &I) const;
 
-  bool selectBuildVector(Register ResVReg, const SPIRVType *ResType,
+  bool selectBuildVector(Register ResVReg, SPIRVTypeInst ResType,
                          MachineInstr &I) const;
-  bool selectSplatVector(Register ResVReg, const SPIRVType *ResType,
+  bool selectSplatVector(Register ResVReg, SPIRVTypeInst ResType,
                          MachineInstr &I) const;
 
-  bool selectCmp(Register ResVReg, const SPIRVType *ResType,
+  bool selectCmp(Register ResVReg, SPIRVTypeInst ResType,
                  unsigned comparisonOpcode, MachineInstr &I) const;
-  bool selectDiscard(Register ResVReg, const SPIRVType *ResType,
+  bool selectDiscard(Register ResVReg, SPIRVTypeInst ResType,
                      MachineInstr &I) const;
 
-  bool selectICmp(Register ResVReg, const SPIRVType *ResType,
+  bool selectICmp(Register ResVReg, SPIRVTypeInst ResType,
                   MachineInstr &I) const;
-  bool selectFCmp(Register ResVReg, const SPIRVType *ResType,
-                  MachineInstr &I) const;
-
-  bool selectSign(Register ResVReg, const SPIRVType *ResType,
+  bool selectFCmp(Register ResVReg, SPIRVTypeInst ResType,
                   MachineInstr &I) const;
 
-  bool selectFloatDot(Register ResVReg, const SPIRVType *ResType,
+  bool selectSign(Register ResVReg, SPIRVTypeInst ResType,
+                  MachineInstr &I) const;
+
+  bool selectFloatDot(Register ResVReg, SPIRVTypeInst ResType,
                       MachineInstr &I) const;
 
-  bool selectOverflowArith(Register ResVReg, const SPIRVType *ResType,
+  bool selectOverflowArith(Register ResVReg, SPIRVTypeInst ResType,
                            MachineInstr &I, unsigned Opcode) const;
-  bool selectDebugTrap(Register ResVReg, const SPIRVType *ResType,
+  bool selectDebugTrap(Register ResVReg, SPIRVTypeInst ResType,
                        MachineInstr &I) const;
 
-  bool selectIntegerDot(Register ResVReg, const SPIRVType *ResType,
+  bool selectIntegerDot(Register ResVReg, SPIRVTypeInst ResType,
                         MachineInstr &I, bool Signed) const;
 
-  bool selectIntegerDotExpansion(Register ResVReg, const SPIRVType *ResType,
+  bool selectIntegerDotExpansion(Register ResVReg, SPIRVTypeInst ResType,
                                  MachineInstr &I) const;
 
-  bool selectOpIsInf(Register ResVReg, const SPIRVType *ResType,
+  bool selectOpIsInf(Register ResVReg, SPIRVTypeInst ResType,
                      MachineInstr &I) const;
 
-  bool selectOpIsNan(Register ResVReg, const SPIRVType *ResType,
+  bool selectOpIsNan(Register ResVReg, SPIRVTypeInst ResType,
                      MachineInstr &I) const;
 
   template <bool Signed>
-  bool selectDot4AddPacked(Register ResVReg, const SPIRVType *ResType,
+  bool selectDot4AddPacked(Register ResVReg, SPIRVTypeInst ResType,
                            MachineInstr &I) const;
   template <bool Signed>
-  bool selectDot4AddPackedExpansion(Register ResVReg, const SPIRVType *ResType,
+  bool selectDot4AddPackedExpansion(Register ResVReg, SPIRVTypeInst ResType,
                                     MachineInstr &I) const;
 
-  bool selectWavePrefixBitCount(Register ResVReg, const SPIRVType *ResType,
+  bool selectWavePrefixBitCount(Register ResVReg, SPIRVTypeInst ResType,
                                 MachineInstr &I) const;
 
   template <typename PickOpcodeFn>
-  bool selectWaveReduce(Register ResVReg, const SPIRVType *ResType,
+  bool selectWaveReduce(Register ResVReg, SPIRVTypeInst ResType,
                         MachineInstr &I, bool IsUnsigned,
                         PickOpcodeFn &&PickOpcode) const;
 
-  bool selectWaveReduceMax(Register ResVReg, const SPIRVType *ResType,
+  bool selectWaveReduceMax(Register ResVReg, SPIRVTypeInst ResType,
                            MachineInstr &I, bool IsUnsigned) const;
 
-  bool selectWaveReduceMin(Register ResVReg, const SPIRVType *ResType,
+  bool selectWaveReduceMin(Register ResVReg, SPIRVTypeInst ResType,
                            MachineInstr &I, bool IsUnsigned) const;
 
-  bool selectWaveReduceSum(Register ResVReg, const SPIRVType *ResType,
+  bool selectWaveReduceSum(Register ResVReg, SPIRVTypeInst ResType,
                            MachineInstr &I) const;
 
   template <typename PickOpcodeFn>
-  bool selectWaveExclusiveScan(Register ResVReg, const SPIRVType *ResType,
+  bool selectWaveExclusiveScan(Register ResVReg, SPIRVTypeInst ResType,
                                MachineInstr &I, bool IsUnsigned,
                                PickOpcodeFn &&PickOpcode) const;
 
-  bool selectWaveExclusiveScanSum(Register ResVReg, const SPIRVType *ResType,
+  bool selectWaveExclusiveScanSum(Register ResVReg, SPIRVTypeInst ResType,
                                   MachineInstr &I) const;
 
-  bool selectConst(Register ResVReg, const SPIRVType *ResType,
+  bool selectConst(Register ResVReg, SPIRVTypeInst ResType,
                    MachineInstr &I) const;
 
-  bool selectSelect(Register ResVReg, const SPIRVType *ResType,
+  bool selectSelect(Register ResVReg, SPIRVTypeInst ResType,
                     MachineInstr &I) const;
-  bool selectSelectDefaultArgs(Register ResVReg, const SPIRVType *ResType,
+  bool selectSelectDefaultArgs(Register ResVReg, SPIRVTypeInst ResType,
                                MachineInstr &I, bool IsSigned) const;
-  bool selectIToF(Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
+  bool selectIToF(Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
                   bool IsSigned, unsigned Opcode) const;
-  bool selectExt(Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
+  bool selectExt(Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
                  bool IsSigned) const;
 
-  bool selectTrunc(Register ResVReg, const SPIRVType *ResType,
+  bool selectTrunc(Register ResVReg, SPIRVTypeInst ResType,
                    MachineInstr &I) const;
 
-  bool selectSUCmp(Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
+  bool selectSUCmp(Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
                    bool IsSigned) const;
 
   bool selectIntToBool(Register IntReg, Register ResVReg, MachineInstr &I,
-                       const SPIRVType *intTy, const SPIRVType *boolTy) const;
+                       SPIRVTypeInst intTy, SPIRVTypeInst boolTy) const;
 
-  bool selectOpUndef(Register ResVReg, const SPIRVType *ResType,
+  bool selectOpUndef(Register ResVReg, SPIRVTypeInst ResType,
                      MachineInstr &I) const;
-  bool selectFreeze(Register ResVReg, const SPIRVType *ResType,
+  bool selectFreeze(Register ResVReg, SPIRVTypeInst ResType,
                     MachineInstr &I) const;
-  bool selectIntrinsic(Register ResVReg, const SPIRVType *ResType,
+  bool selectIntrinsic(Register ResVReg, SPIRVTypeInst ResType,
                        MachineInstr &I) const;
-  bool selectExtractVal(Register ResVReg, const SPIRVType *ResType,
+  bool selectExtractVal(Register ResVReg, SPIRVTypeInst ResType,
                         MachineInstr &I) const;
-  bool selectInsertVal(Register ResVReg, const SPIRVType *ResType,
+  bool selectInsertVal(Register ResVReg, SPIRVTypeInst ResType,
                        MachineInstr &I) const;
-  bool selectExtractElt(Register ResVReg, const SPIRVType *ResType,
+  bool selectExtractElt(Register ResVReg, SPIRVTypeInst ResType,
                         MachineInstr &I) const;
-  bool selectInsertElt(Register ResVReg, const SPIRVType *ResType,
+  bool selectInsertElt(Register ResVReg, SPIRVTypeInst ResType,
                        MachineInstr &I) const;
-  bool selectGEP(Register ResVReg, const SPIRVType *ResType,
+  bool selectGEP(Register ResVReg, SPIRVTypeInst ResType,
                  MachineInstr &I) const;
 
-  bool selectFrameIndex(Register ResVReg, const SPIRVType *ResType,
+  bool selectFrameIndex(Register ResVReg, SPIRVTypeInst ResType,
                         MachineInstr &I) const;
-  bool selectAllocaArray(Register ResVReg, const SPIRVType *ResType,
+  bool selectAllocaArray(Register ResVReg, SPIRVTypeInst ResType,
                          MachineInstr &I) const;
 
   bool selectBranch(MachineInstr &I) const;
   bool selectBranchCond(MachineInstr &I) const;
 
-  bool selectPhi(Register ResVReg, const SPIRVType *ResType,
+  bool selectPhi(Register ResVReg, SPIRVTypeInst ResType,
                  MachineInstr &I) const;
 
-  bool selectExtInst(Register ResVReg, const SPIRVType *RestType,
-                     MachineInstr &I, GL::GLSLExtInst GLInst) const;
-  bool selectExtInst(Register ResVReg, const SPIRVType *ResType,
-                     MachineInstr &I, CL::OpenCLExtInst CLInst) const;
-  bool selectExtInst(Register ResVReg, const SPIRVType *ResType,
-                     MachineInstr &I, CL::OpenCLExtInst CLInst,
+  bool selectExtInst(Register ResVReg, SPIRVTypeInst RestType, MachineInstr &I,
                      GL::GLSLExtInst GLInst) const;
-  bool selectExtInst(Register ResVReg, const SPIRVType *ResType,
-                     MachineInstr &I, const ExtInstList &ExtInsts) const;
-  bool selectExtInstForLRound(Register ResVReg, const SPIRVType *ResType,
+  bool selectExtInst(Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
+                     CL::OpenCLExtInst CLInst) const;
+  bool selectExtInst(Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
+                     CL::OpenCLExtInst CLInst, GL::GLSLExtInst GLInst) const;
+  bool selectExtInst(Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
+                     const ExtInstList &ExtInsts) const;
+  bool selectExtInstForLRound(Register ResVReg, SPIRVTypeInst ResType,
                               MachineInstr &I, CL::OpenCLExtInst CLInst,
                               GL::GLSLExtInst GLInst) const;
-  bool selectExtInstForLRound(Register ResVReg, const SPIRVType *ResType,
+  bool selectExtInstForLRound(Register ResVReg, SPIRVTypeInst ResType,
                               MachineInstr &I,
                               const ExtInstList &ExtInsts) const;
 
-  bool selectLog10(Register ResVReg, const SPIRVType *ResType,
+  bool selectLog10(Register ResVReg, SPIRVTypeInst ResType,
                    MachineInstr &I) const;
 
-  bool selectSaturate(Register ResVReg, const SPIRVType *ResType,
+  bool selectSaturate(Register ResVReg, SPIRVTypeInst ResType,
                       MachineInstr &I) const;
 
-  bool selectWaveOpInst(Register ResVReg, const SPIRVType *ResType,
+  bool selectWaveOpInst(Register ResVReg, SPIRVTypeInst ResType,
                         MachineInstr &I, unsigned Opcode) const;
 
-  bool selectWaveActiveCountBits(Register ResVReg, const SPIRVType *ResType,
+  bool selectWaveActiveCountBits(Register ResVReg, SPIRVTypeInst ResType,
                                  MachineInstr &I) const;
 
   bool selectUnmergeValues(MachineInstr &I) const;
 
-  bool selectHandleFromBinding(Register &ResVReg, const SPIRVType *ResType,
+  bool selectHandleFromBinding(Register &ResVReg, SPIRVTypeInst ResType,
                                MachineInstr &I) const;
 
-  bool selectCounterHandleFromBinding(Register &ResVReg,
-                                      const SPIRVType *ResType,
+  bool selectCounterHandleFromBinding(Register &ResVReg, SPIRVTypeInst ResType,
                                       MachineInstr &I) const;
 
-  bool selectReadImageIntrinsic(Register &ResVReg, const SPIRVType *ResType,
+  bool selectReadImageIntrinsic(Register &ResVReg, SPIRVTypeInst ResType,
                                 MachineInstr &I) const;
-  bool selectSampleBasicIntrinsic(Register &ResVReg, const SPIRVType *ResType,
+  bool selectSampleBasicIntrinsic(Register &ResVReg, SPIRVTypeInst ResType,
                                   MachineInstr &I) const;
-  bool selectSampleBiasIntrinsic(Register &ResVReg, const SPIRVType *ResType,
+  bool selectSampleBiasIntrinsic(Register &ResVReg, SPIRVTypeInst ResType,
                                  MachineInstr &I) const;
-  bool selectSampleGradIntrinsic(Register &ResVReg, const SPIRVType *ResType,
+  bool selectSampleGradIntrinsic(Register &ResVReg, SPIRVTypeInst ResType,
                                  MachineInstr &I) const;
-  bool selectSampleLevelIntrinsic(Register &ResVReg, const SPIRVType *ResType,
+  bool selectSampleLevelIntrinsic(Register &ResVReg, SPIRVTypeInst ResType,
                                   MachineInstr &I) const;
-  bool selectSampleCmpIntrinsic(Register &ResVReg, const SPIRVType *ResType,
+  bool selectSampleCmpIntrinsic(Register &ResVReg, SPIRVTypeInst ResType,
                                 MachineInstr &I) const;
   bool selectSampleCmpLevelZeroIntrinsic(Register &ResVReg,
-                                         const SPIRVType *ResType,
+                                         SPIRVTypeInst ResType,
                                          MachineInstr &I) const;
   bool selectImageWriteIntrinsic(MachineInstr &I) const;
-  bool selectResourceGetPointer(Register &ResVReg, const SPIRVType *ResType,
+  bool selectResourceGetPointer(Register &ResVReg, SPIRVTypeInst ResType,
                                 MachineInstr &I) const;
-  bool selectPushConstantGetPointer(Register &ResVReg, const SPIRVType *ResType,
+  bool selectPushConstantGetPointer(Register &ResVReg, SPIRVTypeInst ResType,
                                     MachineInstr &I) const;
-  bool selectResourceNonUniformIndex(Register &ResVReg,
-                                     const SPIRVType *ResType,
+  bool selectResourceNonUniformIndex(Register &ResVReg, SPIRVTypeInst ResType,
                                      MachineInstr &I) const;
-  bool selectModf(Register ResVReg, const SPIRVType *ResType,
+  bool selectModf(Register ResVReg, SPIRVTypeInst ResType,
                   MachineInstr &I) const;
-  bool selectUpdateCounter(Register &ResVReg, const SPIRVType *ResType,
+  bool selectUpdateCounter(Register &ResVReg, SPIRVTypeInst ResType,
                            MachineInstr &I) const;
-  bool selectFrexp(Register ResVReg, const SPIRVType *ResType,
+  bool selectFrexp(Register ResVReg, SPIRVTypeInst ResType,
                    MachineInstr &I) const;
-  bool selectSincos(Register ResVReg, const SPIRVType *ResType,
+  bool selectSincos(Register ResVReg, SPIRVTypeInst ResType,
                     MachineInstr &I) const;
-  bool selectDerivativeInst(Register ResVReg, const SPIRVType *ResType,
+  bool selectDerivativeInst(Register ResVReg, SPIRVTypeInst ResType,
                             MachineInstr &I, const unsigned DPdOpCode) const;
   // Utilities
   Register buildI32Constant(uint32_t Val, MachineInstr &I,
-                            const SPIRVType *ResType = nullptr) const;
+                            SPIRVTypeInst ResType = nullptr) const;
 
-  Register buildZerosVal(const SPIRVType *ResType, MachineInstr &I) const;
+  Register buildZerosVal(SPIRVTypeInst ResType, MachineInstr &I) const;
   bool isScalarOrVectorIntConstantZero(Register Reg) const;
-  Register buildZerosValF(const SPIRVType *ResType, MachineInstr &I) const;
-  Register buildOnesVal(bool AllOnes, const SPIRVType *ResType,
+  Register buildZerosValF(SPIRVTypeInst ResType, MachineInstr &I) const;
+  Register buildOnesVal(bool AllOnes, SPIRVTypeInst ResType,
                         MachineInstr &I) const;
-  Register buildOnesValF(const SPIRVType *ResType, MachineInstr &I) const;
+  Register buildOnesValF(SPIRVTypeInst ResType, MachineInstr &I) const;
 
   bool wrapIntoSpecConstantOp(MachineInstr &I,
                               SmallVector<Register> &CompositeArgs) const;
@@ -398,31 +394,31 @@ private:
                                           Register Src, Register DestType,
                                           uint32_t Opcode) const;
   MachineInstrBuilder buildConstGenericPtr(MachineInstr &I, Register SrcPtr,
-                                           SPIRVType *SrcPtrTy) const;
-  Register buildPointerToResource(const SPIRVType *ResType,
+                                           SPIRVTypeInst SrcPtrTy) const;
+  Register buildPointerToResource(SPIRVTypeInst ResType,
                                   SPIRV::StorageClass::StorageClass SC,
                                   uint32_t Set, uint32_t Binding,
                                   uint32_t ArraySize, Register IndexReg,
                                   StringRef Name,
                                   MachineIRBuilder MIRBuilder) const;
-  SPIRVType *widenTypeToVec4(const SPIRVType *Type, MachineInstr &I) const;
-  bool extractSubvector(Register &ResVReg, const SPIRVType *ResType,
+  SPIRVTypeInst widenTypeToVec4(SPIRVTypeInst Type, MachineInstr &I) const;
+  bool extractSubvector(Register &ResVReg, SPIRVTypeInst ResType,
                         Register &ReadReg, MachineInstr &InsertionPoint) const;
-  bool generateImageReadOrFetch(Register &ResVReg, const SPIRVType *ResType,
+  bool generateImageReadOrFetch(Register &ResVReg, SPIRVTypeInst ResType,
                                 Register ImageReg, Register IdxReg,
                                 DebugLoc Loc, MachineInstr &Pos) const;
-  bool generateSampleImage(Register ResVReg, const SPIRVType *ResType,
+  bool generateSampleImage(Register ResVReg, SPIRVTypeInst ResType,
                            Register ImageReg, Register SamplerReg,
                            Register CoordinateReg, const ImageOperands &ImOps,
                            DebugLoc Loc, MachineInstr &I) const;
   bool BuildCOPY(Register DestReg, Register SrcReg, MachineInstr &I) const;
   bool loadVec3BuiltinInputID(SPIRV::BuiltIn::BuiltIn BuiltInValue,
-                              Register ResVReg, const SPIRVType *ResType,
+                              Register ResVReg, SPIRVTypeInst ResType,
                               MachineInstr &I) const;
   bool loadBuiltinInputID(SPIRV::BuiltIn::BuiltIn BuiltInValue,
-                          Register ResVReg, const SPIRVType *ResType,
+                          Register ResVReg, SPIRVTypeInst ResType,
                           MachineInstr &I) const;
-  bool loadHandleBeforePosition(Register &HandleReg, const SPIRVType *ResType,
+  bool loadHandleBeforePosition(Register &HandleReg, SPIRVTypeInst ResType,
                                 GIntrinsic &HandleDef, MachineInstr &Pos) const;
   void decorateUsesAsNonUniform(Register &NonUniformReg) const;
   void errorIfInstrOutsideShader(MachineInstr &I) const;
@@ -839,7 +835,7 @@ bool SPIRVInstructionSelector::select(MachineInstr &I) {
   // from parent occurs here. Instr-specific selection happens in spvSelect().
   bool HasDefs = I.getNumDefs() > 0;
   Register ResVReg = HasDefs ? I.getOperand(0).getReg() : Register(0);
-  SPIRVType *ResType = HasDefs ? GR.getSPIRVTypeForVReg(ResVReg) : nullptr;
+  SPIRVTypeInst ResType = HasDefs ? GR.getSPIRVTypeForVReg(ResVReg) : nullptr;
   assert(!HasDefs || ResType || I.getOpcode() == TargetOpcode::G_GLOBAL_VALUE ||
          I.getOpcode() == TargetOpcode::G_IMPLICIT_DEF);
   if (spvSelect(ResVReg, ResType, I)) {
@@ -879,7 +875,7 @@ bool SPIRVInstructionSelector::BuildCOPY(Register DestReg, Register SrcReg,
 }
 
 bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
-                                         const SPIRVType *ResType,
+                                         SPIRVTypeInst ResType,
                                          MachineInstr &I) const {
   const unsigned Opcode = I.getOpcode();
   if (mayApplyGenericSelection(Opcode))
@@ -1173,9 +1169,9 @@ bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
     }
     MachineBasicBlock &BB = *I.getParent();
     if (!IsGVInit) {
-      SPIRVType *GVType = GR.getSPIRVTypeForVReg(GV);
-      SPIRVType *GVPointeeType = GR.getPointeeType(GVType);
-      SPIRVType *ResPointeeType = GR.getPointeeType(ResType);
+      SPIRVTypeInst GVType = GR.getSPIRVTypeForVReg(GV);
+      SPIRVTypeInst GVPointeeType = GR.getPointeeType(GVType);
+      SPIRVTypeInst ResPointeeType = GR.getPointeeType(ResType);
       if (GVPointeeType && ResPointeeType && GVPointeeType != ResPointeeType) {
         // Build a new virtual register that is associated with the required
         // data type.
@@ -1296,7 +1292,7 @@ bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectDebugTrap(Register ResVReg,
-                                               const SPIRVType *ResType,
+                                               SPIRVTypeInst ResType,
                                                MachineInstr &I) const {
   unsigned Opcode = SPIRV::OpNop;
   MachineBasicBlock &BB = *I.getParent();
@@ -1306,7 +1302,7 @@ bool SPIRVInstructionSelector::selectDebugTrap(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
-                                             const SPIRVType *ResType,
+                                             SPIRVTypeInst ResType,
                                              MachineInstr &I,
                                              GL::GLSLExtInst GLInst) const {
   if (!STI.canUseExtInstSet(
@@ -1322,7 +1318,7 @@ bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
-                                             const SPIRVType *ResType,
+                                             SPIRVTypeInst ResType,
                                              MachineInstr &I,
                                              CL::OpenCLExtInst CLInst) const {
   return selectExtInst(ResVReg, ResType, I,
@@ -1330,7 +1326,7 @@ bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
-                                             const SPIRVType *ResType,
+                                             SPIRVTypeInst ResType,
                                              MachineInstr &I,
                                              CL::OpenCLExtInst CLInst,
                                              GL::GLSLExtInst GLInst) const {
@@ -1340,7 +1336,7 @@ bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
-                                             const SPIRVType *ResType,
+                                             SPIRVTypeInst ResType,
                                              MachineInstr &I,
                                              const ExtInstList &Insts) const {
 
@@ -1370,7 +1366,7 @@ bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
   return false;
 }
 bool SPIRVInstructionSelector::selectExtInstForLRound(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
     CL::OpenCLExtInst CLInst, GL::GLSLExtInst GLInst) const {
   ExtInstList ExtInsts = {{SPIRV::InstructionSet::OpenCL_std, CLInst},
                           {SPIRV::InstructionSet::GLSL_std_450, GLInst}};
@@ -1378,7 +1374,7 @@ bool SPIRVInstructionSelector::selectExtInstForLRound(
 }
 
 bool SPIRVInstructionSelector::selectExtInstForLRound(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
     const ExtInstList &Insts) const {
   for (const auto &Ex : Insts) {
     SPIRV::InstructionSet::InstructionSet Set = Ex.first;
@@ -1406,7 +1402,7 @@ bool SPIRVInstructionSelector::selectExtInstForLRound(
 }
 
 bool SPIRVInstructionSelector::selectFrexp(Register ResVReg,
-                                           const SPIRVType *ResType,
+                                           SPIRVTypeInst ResType,
                                            MachineInstr &I) const {
   ExtInstList ExtInsts = {{SPIRV::InstructionSet::OpenCL_std, CL::frexp},
                           {SPIRV::InstructionSet::GLSL_std_450, GL::Frexp}};
@@ -1417,8 +1413,8 @@ bool SPIRVInstructionSelector::selectFrexp(Register ResVReg,
       continue;
 
     MachineIRBuilder MIRBuilder(I);
-    SPIRVType *PointeeTy = GR.getSPIRVTypeForVReg(I.getOperand(1).getReg());
-    const SPIRVType *PointerType = GR.getOrCreateSPIRVPointerType(
+    SPIRVTypeInst PointeeTy = GR.getSPIRVTypeForVReg(I.getOperand(1).getReg());
+    const SPIRVTypeInst PointerType = GR.getOrCreateSPIRVPointerType(
         PointeeTy, MIRBuilder, SPIRV::StorageClass::Function);
     Register PointerVReg =
         createVirtualRegister(PointerType, &GR, MRI, MRI->getMF());
@@ -1450,7 +1446,7 @@ bool SPIRVInstructionSelector::selectFrexp(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectSincos(Register ResVReg,
-                                            const SPIRVType *ResType,
+                                            SPIRVTypeInst ResType,
                                             MachineInstr &I) const {
   Register CosResVReg = I.getOperand(1).getReg();
   unsigned SrcIdx = I.getNumExplicitDefs();
@@ -1459,7 +1455,7 @@ bool SPIRVInstructionSelector::selectSincos(Register ResVReg,
   if (STI.canUseExtInstSet(SPIRV::InstructionSet::OpenCL_std)) {
     // OpenCL.std sincos(x, cosval*) -> returns sin(x), writes cos(x) to ptr.
     MachineIRBuilder MIRBuilder(I);
-    const SPIRVType *PointerType = GR.getOrCreateSPIRVPointerType(
+    const SPIRVTypeInst PointerType = GR.getOrCreateSPIRVPointerType(
         ResType, MIRBuilder, SPIRV::StorageClass::Function);
     Register PointerVReg =
         createVirtualRegister(PointerType, &GR, MRI, MRI->getMF());
@@ -1506,7 +1502,7 @@ bool SPIRVInstructionSelector::selectSincos(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectOpWithSrcs(Register ResVReg,
-                                                const SPIRVType *ResType,
+                                                SPIRVTypeInst ResType,
                                                 MachineInstr &I,
                                                 std::vector<Register> Srcs,
                                                 unsigned Opcode) const {
@@ -1521,7 +1517,7 @@ bool SPIRVInstructionSelector::selectOpWithSrcs(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectUnOp(Register ResVReg,
-                                          const SPIRVType *ResType,
+                                          SPIRVTypeInst ResType,
                                           MachineInstr &I,
                                           unsigned Opcode) const {
   if (STI.isPhysicalSPIRV() && I.getOperand(1).isReg()) {
@@ -1571,10 +1567,11 @@ bool SPIRVInstructionSelector::selectUnOp(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectBitcast(Register ResVReg,
-                                             const SPIRVType *ResType,
+                                             SPIRVTypeInst ResType,
                                              MachineInstr &I) const {
   Register OpReg = I.getOperand(1).getReg();
-  SPIRVType *OpType = OpReg.isValid() ? GR.getSPIRVTypeForVReg(OpReg) : nullptr;
+  SPIRVTypeInst OpType =
+      OpReg.isValid() ? GR.getSPIRVTypeForVReg(OpReg) : nullptr;
   if (!GR.isBitcastCompatible(ResType, OpType))
     report_fatal_error("incompatible result and operand types in a bitcast");
   return selectUnOp(ResVReg, ResType, I, SPIRV::OpBitcast);
@@ -1634,7 +1631,7 @@ static void addMemoryOperands(uint64_t Flags, MachineInstrBuilder &MIB) {
 }
 
 bool SPIRVInstructionSelector::selectLoad(Register ResVReg,
-                                          const SPIRVType *ResType,
+                                          SPIRVTypeInst ResType,
                                           MachineInstr &I) const {
   unsigned OpOffset = isa<GIntrinsic>(I) ? 1 : 0;
   Register Ptr = I.getOperand(1 + OpOffset).getReg();
@@ -1644,7 +1641,7 @@ bool SPIRVInstructionSelector::selectLoad(Register ResVReg,
   if (IntPtrDef &&
       IntPtrDef->getIntrinsicID() == Intrinsic::spv_resource_getpointer) {
     Register HandleReg = IntPtrDef->getOperand(2).getReg();
-    SPIRVType *HandleType = GR.getSPIRVTypeForVReg(HandleReg);
+    SPIRVTypeInst HandleType = GR.getSPIRVTypeForVReg(HandleReg);
     if (HandleType->getOpcode() == SPIRV::OpTypeImage) {
       Register NewHandleReg =
           MRI->createVirtualRegister(MRI->getRegClass(HandleReg));
@@ -1689,7 +1686,7 @@ bool SPIRVInstructionSelector::selectStore(MachineInstr &I) const {
     Register NewHandleReg =
         MRI->createVirtualRegister(MRI->getRegClass(HandleReg));
     auto *HandleDef = cast<GIntrinsic>(getVRegDef(*MRI, HandleReg));
-    SPIRVType *HandleType = GR.getSPIRVTypeForVReg(HandleReg);
+    SPIRVTypeInst HandleType = GR.getSPIRVTypeForVReg(HandleReg);
     if (!loadHandleBeforePosition(NewHandleReg, HandleType, *HandleDef, I)) {
       return false;
     }
@@ -1729,7 +1726,7 @@ bool SPIRVInstructionSelector::selectStore(MachineInstr &I) const {
 }
 
 bool SPIRVInstructionSelector::selectStackSave(Register ResVReg,
-                                               const SPIRVType *ResType,
+                                               SPIRVTypeInst ResType,
                                                MachineInstr &I) const {
   if (!STI.canUseExtension(SPIRV::Extension::SPV_INTEL_variable_length_array))
     report_fatal_error(
@@ -1775,10 +1772,10 @@ SPIRVInstructionSelector::getOrCreateMemSetGlobal(MachineInstr &I) const {
 
   Type *ValTy = Type::getInt8Ty(I.getMF()->getFunction().getContext());
   Type *ArrTy = ArrayType::get(ValTy, Num);
-  SPIRVType *VarTy = GR.getOrCreateSPIRVPointerType(
+  SPIRVTypeInst VarTy = GR.getOrCreateSPIRVPointerType(
       ArrTy, MIRBuilder, SPIRV::StorageClass::UniformConstant);
 
-  SPIRVType *SpvArrTy = GR.getOrCreateSPIRVType(
+  SPIRVTypeInst SpvArrTy = GR.getOrCreateSPIRVType(
       ArrTy, MIRBuilder, SPIRV::AccessQualifier::None, false);
 
   unsigned Val = getIConstVal(I.getOperand(1).getReg(), MRI);
@@ -1804,12 +1801,12 @@ bool SPIRVInstructionSelector::selectCopyMemory(MachineInstr &I,
                                                 Register SrcReg) const {
   MachineBasicBlock &BB = *I.getParent();
   Register DstReg = I.getOperand(0).getReg();
-  SPIRVType *DstTy = GR.getSPIRVTypeForVReg(DstReg);
-  SPIRVType *SrcTy = GR.getSPIRVTypeForVReg(SrcReg);
+  SPIRVTypeInst DstTy = GR.getSPIRVTypeForVReg(DstReg);
+  SPIRVTypeInst SrcTy = GR.getSPIRVTypeForVReg(SrcReg);
   if (GR.getPointeeType(DstTy) != GR.getPointeeType(SrcTy))
     report_fatal_error("OpCopyMemory requires operands to have the same type");
   uint64_t CopySize = getIConstVal(I.getOperand(2).getReg(), MRI);
-  SPIRVType *PointeeTy = GR.getPointeeType(DstTy);
+  SPIRVTypeInst PointeeTy = GR.getPointeeType(DstTy);
   const Type *LLVMPointeeTy = GR.getTypeForSPIRVType(PointeeTy);
   if (!LLVMPointeeTy)
     report_fatal_error(
@@ -1852,7 +1849,7 @@ bool SPIRVInstructionSelector::selectMemOperation(Register ResVReg,
     if (!VarReg.isValid())
       return false;
     Type *ValTy = Type::getInt8Ty(I.getMF()->getFunction().getContext());
-    SPIRVType *SourceTy = GR.getOrCreateSPIRVPointerType(
+    SPIRVTypeInst SourceTy = GR.getOrCreateSPIRVPointerType(
         ValTy, I, SPIRV::StorageClass::UniformConstant);
     SrcReg = MRI->createGenericVirtualRegister(LLT::scalar(64));
     if (!selectOpWithSrcs(SrcReg, SourceTy, I, {VarReg}, SPIRV::OpBitcast))
@@ -1872,7 +1869,7 @@ bool SPIRVInstructionSelector::selectMemOperation(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectAtomicRMW(Register ResVReg,
-                                               const SPIRVType *ResType,
+                                               SPIRVTypeInst ResType,
                                                MachineInstr &I,
                                                unsigned NewOpcode,
                                                unsigned NegateOpcode) const {
@@ -1914,19 +1911,19 @@ bool SPIRVInstructionSelector::selectUnmergeValues(MachineInstr &I) const {
   unsigned ArgI = I.getNumOperands() - 1;
   Register SrcReg =
       I.getOperand(ArgI).isReg() ? I.getOperand(ArgI).getReg() : Register(0);
-  SPIRVType *SrcType =
+  SPIRVTypeInst SrcType =
       SrcReg.isValid() ? GR.getSPIRVTypeForVReg(SrcReg) : nullptr;
   if (!SrcType || SrcType->getOpcode() != SPIRV::OpTypeVector)
     report_fatal_error(
         "cannot select G_UNMERGE_VALUES with a non-vector argument");
 
-  SPIRVType *ScalarType =
+  SPIRVTypeInst ScalarType =
       GR.getSPIRVTypeForVReg(SrcType->getOperand(1).getReg());
   MachineBasicBlock &BB = *I.getParent();
   unsigned CurrentIndex = 0;
   for (unsigned i = 0; i < I.getNumDefs(); ++i) {
     Register ResVReg = I.getOperand(i).getReg();
-    SPIRVType *ResType = GR.getSPIRVTypeForVReg(ResVReg);
+    SPIRVTypeInst ResType = GR.getSPIRVTypeForVReg(ResVReg);
     if (!ResType) {
       LLT ResLLT = MRI->getType(ResVReg);
       assert(ResLLT.isValid());
@@ -1985,7 +1982,7 @@ bool SPIRVInstructionSelector::selectFence(MachineInstr &I) const {
 }
 
 bool SPIRVInstructionSelector::selectOverflowArith(Register ResVReg,
-                                                   const SPIRVType *ResType,
+                                                   SPIRVTypeInst ResType,
                                                    MachineInstr &I,
                                                    unsigned Opcode) const {
   Type *ResTy = nullptr;
@@ -2002,10 +1999,10 @@ bool SPIRVInstructionSelector::selectOverflowArith(Register ResVReg,
   ResTy = StructType::get(ResElemTy, ResElemTy);
   // Build SPIR-V types and constant(s) if needed.
   MachineIRBuilder MIRBuilder(I);
-  SPIRVType *StructType = GR.getOrCreateSPIRVType(
+  SPIRVTypeInst StructType = GR.getOrCreateSPIRVType(
       ResTy, MIRBuilder, SPIRV::AccessQualifier::ReadWrite, false);
   assert(I.getNumDefs() > 1 && "Not enought operands");
-  SPIRVType *BoolType = GR.getOrCreateSPIRVBoolType(I, TII);
+  SPIRVTypeInst BoolType = GR.getOrCreateSPIRVBoolType(I, TII);
   unsigned N = GR.getScalarOrVectorComponentCount(ResType);
   if (N > 1)
     BoolType = GR.getOrCreateSPIRVVectorType(BoolType, N, I, TII);
@@ -2050,7 +2047,7 @@ bool SPIRVInstructionSelector::selectOverflowArith(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectAtomicCmpXchg(Register ResVReg,
-                                                   const SPIRVType *ResType,
+                                                   SPIRVTypeInst ResType,
                                                    MachineInstr &I) const {
   Register ScopeReg;
   Register MemSemEqReg;
@@ -2083,7 +2080,7 @@ bool SPIRVInstructionSelector::selectAtomicCmpXchg(Register ResVReg,
 
   Register Cmp = I.getOperand(3).getReg();
   Register Val = I.getOperand(4).getReg();
-  SPIRVType *SpvValTy = GR.getSPIRVTypeForVReg(Val);
+  SPIRVTypeInst SpvValTy = GR.getSPIRVTypeForVReg(Val);
   Register ACmpRes = createVirtualRegister(SpvValTy, &GR, MRI, *I.getMF());
   const DebugLoc &DL = I.getDebugLoc();
   BuildMI(*I.getParent(), I, DL, TII.get(SPIRV::OpAtomicCompareExchange))
@@ -2096,7 +2093,7 @@ bool SPIRVInstructionSelector::selectAtomicCmpXchg(Register ResVReg,
       .addUse(Val)
       .addUse(Cmp)
       .constrainAllUses(TII, TRI, RBI);
-  SPIRVType *BoolTy = GR.getOrCreateSPIRVBoolType(I, TII);
+  SPIRVTypeInst BoolTy = GR.getOrCreateSPIRVBoolType(I, TII);
   Register CmpSuccReg = createVirtualRegister(BoolTy, &GR, MRI, *I.getMF());
   BuildMI(*I.getParent(), I, DL, TII.get(SPIRV::OpIEqual))
       .addDef(CmpSuccReg)
@@ -2167,8 +2164,8 @@ SPIRVInstructionSelector::buildSpecConstantOp(MachineInstr &I, Register Dest,
 
 MachineInstrBuilder
 SPIRVInstructionSelector::buildConstGenericPtr(MachineInstr &I, Register SrcPtr,
-                                               SPIRVType *SrcPtrTy) const {
-  SPIRVType *GenericPtrTy =
+                                               SPIRVTypeInst SrcPtrTy) const {
+  SPIRVTypeInst GenericPtrTy =
       GR.changePointerStorageClass(SrcPtrTy, SPIRV::StorageClass::Generic, I);
   Register Tmp = MRI->createVirtualRegister(&SPIRV::pIDRegClass);
   MRI->setType(Tmp, LLT::pointer(storageClassToAddressSpace(
@@ -2189,13 +2186,13 @@ SPIRVInstructionSelector::buildConstGenericPtr(MachineInstr &I, Register SrcPtr,
 // Workgroup to Function by going via a Generic pointer as an intermediary. All
 // other combinations can only be done by a bitcast, and are probably not safe.
 bool SPIRVInstructionSelector::selectAddrSpaceCast(Register ResVReg,
-                                                   const SPIRVType *ResType,
+                                                   SPIRVTypeInst ResType,
                                                    MachineInstr &I) const {
   MachineBasicBlock &BB = *I.getParent();
   const DebugLoc &DL = I.getDebugLoc();
 
   Register SrcPtr = I.getOperand(1).getReg();
-  SPIRVType *SrcPtrTy = GR.getSPIRVTypeForVReg(SrcPtr);
+  SPIRVTypeInst SrcPtrTy = GR.getSPIRVTypeForVReg(SrcPtr);
 
   // don't generate a cast for a null that may be represented by OpTypeInt
   if (SrcPtrTy->getOpcode() != SPIRV::OpTypePointer ||
@@ -2254,7 +2251,7 @@ bool SPIRVInstructionSelector::selectAddrSpaceCast(Register ResVReg,
     return selectUnOp(ResVReg, ResType, I, SPIRV::OpGenericCastToPtr);
   // Casting between 2 eligible pointers using Generic as an intermediary.
   if (isGenericCastablePtr(SrcSC) && isGenericCastablePtr(DstSC)) {
-    SPIRVType *GenericPtrTy =
+    SPIRVTypeInst GenericPtrTy =
         GR.changePointerStorageClass(SrcPtrTy, SPIRV::StorageClass::Generic, I);
     Register Tmp = createVirtualRegister(GenericPtrTy, &GR, MRI, MRI->getMF());
     BuildMI(BB, I, DL, TII.get(SPIRV::OpPtrCastToGeneric))
@@ -2404,14 +2401,14 @@ static APFloat getOneFP(const Type *LLVMFloatTy) {
 }
 
 bool SPIRVInstructionSelector::selectAnyOrAll(Register ResVReg,
-                                              const SPIRVType *ResType,
+                                              SPIRVTypeInst ResType,
                                               MachineInstr &I,
                                               unsigned OpAnyOrAll) const {
   assert(I.getNumOperands() == 3);
   assert(I.getOperand(2).isReg());
   MachineBasicBlock &BB = *I.getParent();
   Register InputRegister = I.getOperand(2).getReg();
-  SPIRVType *InputType = GR.getSPIRVTypeForVReg(InputRegister);
+  SPIRVTypeInst InputType = GR.getSPIRVTypeForVReg(InputRegister);
 
   if (!InputType)
     report_fatal_error("Input Type could not be determined.");
@@ -2426,8 +2423,8 @@ bool SPIRVInstructionSelector::selectAnyOrAll(Register ResVReg,
   bool IsFloatTy = GR.isScalarOrVectorOfType(InputRegister, SPIRV::OpTypeFloat);
   unsigned SpirvNotEqualId =
       IsFloatTy ? SPIRV::OpFOrdNotEqual : SPIRV::OpINotEqual;
-  SPIRVType *SpvBoolScalarTy = GR.getOrCreateSPIRVBoolType(I, TII);
-  SPIRVType *SpvBoolTy = SpvBoolScalarTy;
+  SPIRVTypeInst SpvBoolScalarTy = GR.getOrCreateSPIRVBoolType(I, TII);
+  SPIRVTypeInst SpvBoolTy = SpvBoolScalarTy;
   Register NotEqualReg = ResVReg;
 
   if (IsVectorTy) {
@@ -2460,33 +2457,33 @@ bool SPIRVInstructionSelector::selectAnyOrAll(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectAll(Register ResVReg,
-                                         const SPIRVType *ResType,
+                                         SPIRVTypeInst ResType,
                                          MachineInstr &I) const {
   return selectAnyOrAll(ResVReg, ResType, I, SPIRV::OpAll);
 }
 
 bool SPIRVInstructionSelector::selectAny(Register ResVReg,
-                                         const SPIRVType *ResType,
+                                         SPIRVTypeInst ResType,
                                          MachineInstr &I) const {
   return selectAnyOrAll(ResVReg, ResType, I, SPIRV::OpAny);
 }
 
 // Select the OpDot instruction for the given float dot
 bool SPIRVInstructionSelector::selectFloatDot(Register ResVReg,
-                                              const SPIRVType *ResType,
+                                              SPIRVTypeInst ResType,
                                               MachineInstr &I) const {
   assert(I.getNumOperands() == 4);
   assert(I.getOperand(2).isReg());
   assert(I.getOperand(3).isReg());
 
-  [[maybe_unused]] SPIRVType *VecType =
+  [[maybe_unused]] SPIRVTypeInst VecType =
       GR.getSPIRVTypeForVReg(I.getOperand(2).getReg());
 
   assert(VecType->getOpcode() == SPIRV::OpTypeVector &&
          GR.getScalarOrVectorComponentCount(VecType) > 1 &&
          "dot product requires a vector of at least 2 components");
 
-  [[maybe_unused]] SPIRVType *EltType =
+  [[maybe_unused]] SPIRVTypeInst EltType =
       GR.getSPIRVTypeForVReg(VecType->getOperand(1).getReg());
 
   assert(EltType->getOpcode() == SPIRV::OpTypeFloat);
@@ -2502,7 +2499,7 @@ bool SPIRVInstructionSelector::selectFloatDot(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectIntegerDot(Register ResVReg,
-                                                const SPIRVType *ResType,
+                                                SPIRVTypeInst ResType,
                                                 MachineInstr &I,
                                                 bool Signed) const {
   assert(I.getNumOperands() == 4);
@@ -2523,7 +2520,7 @@ bool SPIRVInstructionSelector::selectIntegerDot(Register ResVReg,
 // Since pre-1.6 SPIRV has no integer dot implementation,
 // expand by piecewise multiplying and adding the results
 bool SPIRVInstructionSelector::selectIntegerDotExpansion(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
   assert(I.getNumOperands() == 4);
   assert(I.getOperand(2).isReg());
   assert(I.getOperand(3).isReg());
@@ -2533,7 +2530,7 @@ bool SPIRVInstructionSelector::selectIntegerDotExpansion(
   Register Vec0 = I.getOperand(2).getReg();
   Register Vec1 = I.getOperand(3).getReg();
   Register TmpVec = MRI->createVirtualRegister(GR.getRegClass(ResType));
-  SPIRVType *VecType = GR.getSPIRVTypeForVReg(Vec0);
+  SPIRVTypeInst VecType = GR.getSPIRVTypeForVReg(Vec0);
 
   BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpIMulV))
       .addDef(TmpVec)
@@ -2581,7 +2578,7 @@ bool SPIRVInstructionSelector::selectIntegerDotExpansion(
 }
 
 bool SPIRVInstructionSelector::selectOpIsInf(Register ResVReg,
-                                             const SPIRVType *ResType,
+                                             SPIRVTypeInst ResType,
                                              MachineInstr &I) const {
   MachineBasicBlock &BB = *I.getParent();
   BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpIsInf))
@@ -2593,7 +2590,7 @@ bool SPIRVInstructionSelector::selectOpIsInf(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectOpIsNan(Register ResVReg,
-                                             const SPIRVType *ResType,
+                                             SPIRVTypeInst ResType,
                                              MachineInstr &I) const {
   MachineBasicBlock &BB = *I.getParent();
   BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpIsNan))
@@ -2606,7 +2603,7 @@ bool SPIRVInstructionSelector::selectOpIsNan(Register ResVReg,
 
 template <bool Signed>
 bool SPIRVInstructionSelector::selectDot4AddPacked(Register ResVReg,
-                                                   const SPIRVType *ResType,
+                                                   SPIRVTypeInst ResType,
                                                    MachineInstr &I) const {
   assert(I.getNumOperands() == 5);
   assert(I.getOperand(2).isReg());
@@ -2642,7 +2639,7 @@ bool SPIRVInstructionSelector::selectDot4AddPacked(Register ResVReg,
 // to the accumulator.
 template <bool Signed>
 bool SPIRVInstructionSelector::selectDot4AddPackedExpansion(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
   assert(I.getNumOperands() == 5);
   assert(I.getOperand(2).isReg());
   assert(I.getOperand(3).isReg());
@@ -2653,7 +2650,7 @@ bool SPIRVInstructionSelector::selectDot4AddPackedExpansion(
   Register X = I.getOperand(3).getReg();
   Register Y = I.getOperand(4).getReg();
 
-  SPIRVType *EltType = GR.getOrCreateSPIRVIntegerType(8, I, TII);
+  SPIRVTypeInst EltType = GR.getOrCreateSPIRVIntegerType(8, I, TII);
   auto ExtractOp =
       Signed ? SPIRV::OpBitFieldSExtract : SPIRV::OpBitFieldUExtract;
 
@@ -2718,7 +2715,7 @@ bool SPIRVInstructionSelector::selectDot4AddPackedExpansion(
 /// Transform saturate(x) to clamp(x, 0.0f, 1.0f) as SPIRV
 /// does not have a saturate builtin.
 bool SPIRVInstructionSelector::selectSaturate(Register ResVReg,
-                                              const SPIRVType *ResType,
+                                              SPIRVTypeInst ResType,
                                               MachineInstr &I) const {
   assert(I.getNumOperands() == 3);
   assert(I.getOperand(2).isReg());
@@ -2739,13 +2736,13 @@ bool SPIRVInstructionSelector::selectSaturate(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectSign(Register ResVReg,
-                                          const SPIRVType *ResType,
+                                          SPIRVTypeInst ResType,
                                           MachineInstr &I) const {
   assert(I.getNumOperands() == 3);
   assert(I.getOperand(2).isReg());
   MachineBasicBlock &BB = *I.getParent();
   Register InputRegister = I.getOperand(2).getReg();
-  SPIRVType *InputType = GR.getSPIRVTypeForVReg(InputRegister);
+  SPIRVTypeInst InputType = GR.getSPIRVTypeForVReg(InputRegister);
   auto &DL = I.getDebugLoc();
 
   if (!InputType)
@@ -2784,11 +2781,11 @@ bool SPIRVInstructionSelector::selectSign(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectWaveOpInst(Register ResVReg,
-                                                const SPIRVType *ResType,
+                                                SPIRVTypeInst ResType,
                                                 MachineInstr &I,
                                                 unsigned Opcode) const {
   MachineBasicBlock &BB = *I.getParent();
-  SPIRVType *IntTy = GR.getOrCreateSPIRVIntegerType(32, I, TII);
+  SPIRVTypeInst IntTy = GR.getOrCreateSPIRVIntegerType(32, I, TII);
 
   auto BMI = BuildMI(BB, I, I.getDebugLoc(), TII.get(Opcode))
                  .addDef(ResVReg)
@@ -2805,10 +2802,10 @@ bool SPIRVInstructionSelector::selectWaveOpInst(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectWaveActiveCountBits(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
 
-  SPIRVType *IntTy = GR.getOrCreateSPIRVIntegerType(32, I, TII);
-  SPIRVType *BallotType = GR.getOrCreateSPIRVVectorType(IntTy, 4, I, TII);
+  SPIRVTypeInst IntTy = GR.getOrCreateSPIRVIntegerType(32, I, TII);
+  SPIRVTypeInst BallotType = GR.getOrCreateSPIRVVectorType(IntTy, 4, I, TII);
   Register BallotReg = MRI->createVirtualRegister(GR.getRegClass(BallotType));
   if (!selectWaveOpInst(BallotReg, BallotType, I,
                         SPIRV::OpGroupNonUniformBallot))
@@ -2828,8 +2825,9 @@ bool SPIRVInstructionSelector::selectWaveActiveCountBits(
   return true;
 }
 
-bool SPIRVInstructionSelector::selectWavePrefixBitCount(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+bool SPIRVInstructionSelector::selectWavePrefixBitCount(Register ResVReg,
+                                                        SPIRVTypeInst ResType,
+                                                        MachineInstr &I) const {
 
   assert(I.getNumOperands() == 3);
 
@@ -2840,7 +2838,7 @@ bool SPIRVInstructionSelector::selectWavePrefixBitCount(
   DebugLoc DL = I.getDebugLoc();
 
   Register InputRegister = Op.getReg();
-  SPIRVType *InputType = GR.getSPIRVTypeForVReg(InputRegister);
+  SPIRVTypeInst InputType = GR.getSPIRVTypeForVReg(InputRegister);
 
   if (!InputType)
     report_fatal_error("Input Type could not be determined.");
@@ -2849,11 +2847,11 @@ bool SPIRVInstructionSelector::selectWavePrefixBitCount(
     report_fatal_error("WavePrefixBitCount requires boolean input");
 
   // Types
-  SPIRVType *Int32Ty = GR.getOrCreateSPIRVIntegerType(32, I, TII);
+  SPIRVTypeInst Int32Ty = GR.getOrCreateSPIRVIntegerType(32, I, TII);
 
   // Ballot result type: vector<uint32>
   // Match DXC: %v4uint for Subgroup size
-  SPIRVType *BallotTy = GR.getOrCreateSPIRVVectorType(Int32Ty, 4, I, TII);
+  SPIRVTypeInst BallotTy = GR.getOrCreateSPIRVVectorType(Int32Ty, 4, I, TII);
 
   // Create a vreg for the ballot result
   Register BallotVReg = MRI->createVirtualRegister(&SPIRV::IDRegClass);
@@ -2879,7 +2877,7 @@ bool SPIRVInstructionSelector::selectWavePrefixBitCount(
 }
 
 bool SPIRVInstructionSelector::selectWaveReduceMax(Register ResVReg,
-                                                   const SPIRVType *ResType,
+                                                   SPIRVTypeInst ResType,
                                                    MachineInstr &I,
                                                    bool IsUnsigned) const {
   return selectWaveReduce(
@@ -2894,7 +2892,7 @@ bool SPIRVInstructionSelector::selectWaveReduceMax(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectWaveReduceMin(Register ResVReg,
-                                                   const SPIRVType *ResType,
+                                                   SPIRVTypeInst ResType,
                                                    MachineInstr &I,
                                                    bool IsUnsigned) const {
   return selectWaveReduce(
@@ -2909,7 +2907,7 @@ bool SPIRVInstructionSelector::selectWaveReduceMin(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectWaveReduceSum(Register ResVReg,
-                                                   const SPIRVType *ResType,
+                                                   SPIRVTypeInst ResType,
                                                    MachineInstr &I) const {
   return selectWaveReduce(ResVReg, ResType, I, /*IsUnsigned*/ false,
                           [&](Register InputRegister, bool IsUnsigned) {
@@ -2922,18 +2920,18 @@ bool SPIRVInstructionSelector::selectWaveReduceSum(Register ResVReg,
 
 template <typename PickOpcodeFn>
 bool SPIRVInstructionSelector::selectWaveReduce(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
-    bool IsUnsigned, PickOpcodeFn &&PickOpcode) const {
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I, bool IsUnsigned,
+    PickOpcodeFn &&PickOpcode) const {
   assert(I.getNumOperands() == 3);
   assert(I.getOperand(2).isReg());
   MachineBasicBlock &BB = *I.getParent();
   Register InputRegister = I.getOperand(2).getReg();
-  SPIRVType *InputType = GR.getSPIRVTypeForVReg(InputRegister);
+  SPIRVTypeInst InputType = GR.getSPIRVTypeForVReg(InputRegister);
 
   if (!InputType)
     report_fatal_error("Input Type could not be determined.");
 
-  SPIRVType *IntTy = GR.getOrCreateSPIRVIntegerType(32, I, TII);
+  SPIRVTypeInst IntTy = GR.getOrCreateSPIRVIntegerType(32, I, TII);
   const unsigned Opcode = PickOpcode(InputRegister, IsUnsigned);
   BuildMI(BB, I, I.getDebugLoc(), TII.get(Opcode))
       .addDef(ResVReg)
@@ -2947,7 +2945,7 @@ bool SPIRVInstructionSelector::selectWaveReduce(
 }
 
 bool SPIRVInstructionSelector::selectWaveExclusiveScanSum(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
   return selectWaveExclusiveScan(ResVReg, ResType, I, /*IsUnsigned*/ false,
                                  [&](Register InputRegister, bool IsUnsigned) {
                                    bool IsFloatTy = GR.isScalarOrVectorOfType(
@@ -2960,18 +2958,18 @@ bool SPIRVInstructionSelector::selectWaveExclusiveScanSum(
 
 template <typename PickOpcodeFn>
 bool SPIRVInstructionSelector::selectWaveExclusiveScan(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
-    bool IsUnsigned, PickOpcodeFn &&PickOpcode) const {
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I, bool IsUnsigned,
+    PickOpcodeFn &&PickOpcode) const {
   assert(I.getNumOperands() == 3);
   assert(I.getOperand(2).isReg());
   MachineBasicBlock &BB = *I.getParent();
   Register InputRegister = I.getOperand(2).getReg();
-  SPIRVType *InputType = GR.getSPIRVTypeForVReg(InputRegister);
+  SPIRVTypeInst InputType = GR.getSPIRVTypeForVReg(InputRegister);
 
   if (!InputType)
     report_fatal_error("Input Type could not be determined.");
 
-  SPIRVType *IntTy = GR.getOrCreateSPIRVIntegerType(32, I, TII);
+  SPIRVTypeInst IntTy = GR.getOrCreateSPIRVIntegerType(32, I, TII);
   const unsigned Opcode = PickOpcode(InputRegister, IsUnsigned);
   BuildMI(BB, I, I.getDebugLoc(), TII.get(Opcode))
       .addDef(ResVReg)
@@ -2985,7 +2983,7 @@ bool SPIRVInstructionSelector::selectWaveExclusiveScan(
 }
 
 bool SPIRVInstructionSelector::selectBitreverse(Register ResVReg,
-                                                const SPIRVType *ResType,
+                                                SPIRVTypeInst ResType,
                                                 MachineInstr &I) const {
   MachineBasicBlock &BB = *I.getParent();
   BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpBitReverse))
@@ -2997,7 +2995,7 @@ bool SPIRVInstructionSelector::selectBitreverse(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectFreeze(Register ResVReg,
-                                            const SPIRVType *ResType,
+                                            SPIRVTypeInst ResType,
                                             MachineInstr &I) const {
   // There is no way to implement `freeze` correctly without support on SPIR-V
   // standard side, but we may at least address a simple (static) case when
@@ -3040,7 +3038,7 @@ bool SPIRVInstructionSelector::selectFreeze(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectBuildVector(Register ResVReg,
-                                                 const SPIRVType *ResType,
+                                                 SPIRVTypeInst ResType,
                                                  MachineInstr &I) const {
   unsigned N = 0;
   if (ResType->getOpcode() == SPIRV::OpTypeVector)
@@ -3076,7 +3074,7 @@ bool SPIRVInstructionSelector::selectBuildVector(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectSplatVector(Register ResVReg,
-                                                 const SPIRVType *ResType,
+                                                 SPIRVTypeInst ResType,
                                                  MachineInstr &I) const {
   unsigned N = 0;
   if (ResType->getOpcode() == SPIRV::OpTypeVector)
@@ -3111,7 +3109,7 @@ bool SPIRVInstructionSelector::selectSplatVector(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectDiscard(Register ResVReg,
-                                             const SPIRVType *ResType,
+                                             SPIRVTypeInst ResType,
                                              MachineInstr &I) const {
 
   unsigned Opcode;
@@ -3136,8 +3134,7 @@ bool SPIRVInstructionSelector::selectDiscard(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectCmp(Register ResVReg,
-                                         const SPIRVType *ResType,
-                                         unsigned CmpOpc,
+                                         SPIRVTypeInst ResType, unsigned CmpOpc,
                                          MachineInstr &I) const {
   Register Cmp0 = I.getOperand(2).getReg();
   Register Cmp1 = I.getOperand(3).getReg();
@@ -3155,7 +3152,7 @@ bool SPIRVInstructionSelector::selectCmp(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectICmp(Register ResVReg,
-                                          const SPIRVType *ResType,
+                                          SPIRVTypeInst ResType,
                                           MachineInstr &I) const {
   auto Pred = I.getOperand(1).getPredicate();
   unsigned CmpOpc;
@@ -3172,9 +3169,9 @@ bool SPIRVInstructionSelector::selectICmp(Register ResVReg,
 
 Register
 SPIRVInstructionSelector::buildI32Constant(uint32_t Val, MachineInstr &I,
-                                           const SPIRVType *ResType) const {
+                                           SPIRVTypeInst ResType) const {
   Type *LLVMTy = IntegerType::get(GR.CurMF->getFunction().getContext(), 32);
-  const SPIRVType *SpvI32Ty =
+  SPIRVTypeInst SpvI32Ty =
       ResType ? ResType : GR.getOrCreateSPIRVIntegerType(32, I, TII);
   // Find a constant in DT or build a new one.
   auto ConstInt = ConstantInt::get(LLVMTy, Val);
@@ -3198,13 +3195,13 @@ SPIRVInstructionSelector::buildI32Constant(uint32_t Val, MachineInstr &I,
 }
 
 bool SPIRVInstructionSelector::selectFCmp(Register ResVReg,
-                                          const SPIRVType *ResType,
+                                          SPIRVTypeInst ResType,
                                           MachineInstr &I) const {
   unsigned CmpOp = getFCmpOpcode(I.getOperand(1).getPredicate());
   return selectCmp(ResVReg, ResType, CmpOp, I);
 }
 
-Register SPIRVInstructionSelector::buildZerosVal(const SPIRVType *ResType,
+Register SPIRVInstructionSelector::buildZerosVal(SPIRVTypeInst ResType,
                                                  MachineInstr &I) const {
   // OpenCL uses nulls for Zero. In HLSL we don't use null constants.
   bool ZeroAsNull = !STI.isShader();
@@ -3215,10 +3212,10 @@ Register SPIRVInstructionSelector::buildZerosVal(const SPIRVType *ResType,
 
 bool SPIRVInstructionSelector::isScalarOrVectorIntConstantZero(
     Register Reg) const {
-  SPIRVType *Type = GR.getSPIRVTypeForVReg(Reg);
+  SPIRVTypeInst Type = GR.getSPIRVTypeForVReg(Reg);
   if (!Type)
     return false;
-  SPIRVType *CompType = GR.getScalarOrVectorComponentType(Type);
+  SPIRVTypeInst CompType = GR.getScalarOrVectorComponentType(Type);
   if (!CompType || CompType->getOpcode() != SPIRV::OpTypeInt)
     return false;
 
@@ -3259,7 +3256,7 @@ bool SPIRVInstructionSelector::isScalarOrVectorIntConstantZero(
   return false;
 }
 
-Register SPIRVInstructionSelector::buildZerosValF(const SPIRVType *ResType,
+Register SPIRVInstructionSelector::buildZerosValF(SPIRVTypeInst ResType,
                                                   MachineInstr &I) const {
   // OpenCL uses nulls for Zero. In HLSL we don't use null constants.
   bool ZeroAsNull = !STI.isShader();
@@ -3269,7 +3266,7 @@ Register SPIRVInstructionSelector::buildZerosValF(const SPIRVType *ResType,
   return GR.getOrCreateConstFP(VZero, I, ResType, TII, ZeroAsNull);
 }
 
-Register SPIRVInstructionSelector::buildOnesValF(const SPIRVType *ResType,
+Register SPIRVInstructionSelector::buildOnesValF(SPIRVTypeInst ResType,
                                                  MachineInstr &I) const {
   // OpenCL uses nulls for Zero. In HLSL we don't use null constants.
   bool ZeroAsNull = !STI.isShader();
@@ -3280,7 +3277,7 @@ Register SPIRVInstructionSelector::buildOnesValF(const SPIRVType *ResType,
 }
 
 Register SPIRVInstructionSelector::buildOnesVal(bool AllOnes,
-                                                const SPIRVType *ResType,
+                                                SPIRVTypeInst ResType,
                                                 MachineInstr &I) const {
   unsigned BitWidth = GR.getScalarOrVectorBitWidth(ResType);
   APInt One =
@@ -3291,7 +3288,7 @@ Register SPIRVInstructionSelector::buildOnesVal(bool AllOnes,
 }
 
 bool SPIRVInstructionSelector::selectSelect(Register ResVReg,
-                                            const SPIRVType *ResType,
+                                            SPIRVTypeInst ResType,
                                             MachineInstr &I) const {
   Register SelectFirstArg = I.getOperand(2).getReg();
   Register SelectSecondArg = I.getOperand(3).getReg();
@@ -3336,7 +3333,7 @@ bool SPIRVInstructionSelector::selectSelect(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectSelectDefaultArgs(Register ResVReg,
-                                                       const SPIRVType *ResType,
+                                                       SPIRVTypeInst ResType,
                                                        MachineInstr &I,
                                                        bool IsSigned) const {
   // To extend a bool, we need to use OpSelect between constants.
@@ -3357,7 +3354,7 @@ bool SPIRVInstructionSelector::selectSelectDefaultArgs(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectIToF(Register ResVReg,
-                                          const SPIRVType *ResType,
+                                          SPIRVTypeInst ResType,
                                           MachineInstr &I, bool IsSigned,
                                           unsigned Opcode) const {
   Register SrcReg = I.getOperand(1).getReg();
@@ -3365,7 +3362,7 @@ bool SPIRVInstructionSelector::selectIToF(Register ResVReg,
   // however the translator generates OpSelect+OpConvert*ToF, so we do the same.
   if (GR.isScalarOrVectorOfType(I.getOperand(1).getReg(), SPIRV::OpTypeBool)) {
     unsigned BitWidth = GR.getScalarOrVectorBitWidth(ResType);
-    SPIRVType *TmpType = GR.getOrCreateSPIRVIntegerType(BitWidth, I, TII);
+    SPIRVTypeInst TmpType = GR.getOrCreateSPIRVIntegerType(BitWidth, I, TII);
     if (ResType->getOpcode() == SPIRV::OpTypeVector) {
       const unsigned NumElts = ResType->getOperand(2).getImm();
       TmpType = GR.getOrCreateSPIRVVectorType(TmpType, NumElts, I, TII);
@@ -3377,14 +3374,14 @@ bool SPIRVInstructionSelector::selectIToF(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectExt(Register ResVReg,
-                                         const SPIRVType *ResType,
-                                         MachineInstr &I, bool IsSigned) const {
+                                         SPIRVTypeInst ResType, MachineInstr &I,
+                                         bool IsSigned) const {
   Register SrcReg = I.getOperand(1).getReg();
   if (GR.isScalarOrVectorOfType(SrcReg, SPIRV::OpTypeBool))
     return selectSelectDefaultArgs(ResVReg, ResType, I, IsSigned);
 
-  SPIRVType *SrcType = GR.getSPIRVTypeForVReg(SrcReg);
-  if (SrcType == ResType)
+  SPIRVTypeInst SrcType = GR.getSPIRVTypeForVReg(SrcReg);
+  if (ResType == SrcType)
     return BuildCOPY(ResVReg, SrcReg, I);
 
   unsigned Opcode = IsSigned ? SPIRV::OpSConvert : SPIRV::OpUConvert;
@@ -3392,14 +3389,14 @@ bool SPIRVInstructionSelector::selectExt(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectSUCmp(Register ResVReg,
-                                           const SPIRVType *ResType,
+                                           SPIRVTypeInst ResType,
                                            MachineInstr &I,
                                            bool IsSigned) const {
   MachineIRBuilder MIRBuilder(I);
   MachineRegisterInfo *MRI = MIRBuilder.getMRI();
   MachineBasicBlock &BB = *I.getParent();
   // Ensure we have bool.
-  SPIRVType *BoolType = GR.getOrCreateSPIRVBoolType(I, TII);
+  SPIRVTypeInst BoolType = GR.getOrCreateSPIRVBoolType(I, TII);
   unsigned N = GR.getScalarOrVectorComponentCount(ResType);
   if (N > 1)
     BoolType = GR.getOrCreateSPIRVVectorType(BoolType, N, I, TII);
@@ -3455,8 +3452,8 @@ bool SPIRVInstructionSelector::selectSUCmp(Register ResVReg,
 bool SPIRVInstructionSelector::selectIntToBool(Register IntReg,
                                                Register ResVReg,
                                                MachineInstr &I,
-                                               const SPIRVType *IntTy,
-                                               const SPIRVType *BoolTy) const {
+                                               SPIRVTypeInst IntTy,
+                                               SPIRVTypeInst BoolTy) const {
   // To truncate to a bool, we use OpBitwiseAnd 1 and OpINotEqual to zero.
   Register BitIntReg = createVirtualRegister(IntTy, &GR, MRI, MRI->getMF());
   bool IsVectorTy = IntTy->getOpcode() == SPIRV::OpTypeVector;
@@ -3480,10 +3477,10 @@ bool SPIRVInstructionSelector::selectIntToBool(Register IntReg,
 }
 
 bool SPIRVInstructionSelector::selectTrunc(Register ResVReg,
-                                           const SPIRVType *ResType,
+                                           SPIRVTypeInst ResType,
                                            MachineInstr &I) const {
   Register IntReg = I.getOperand(1).getReg();
-  const SPIRVType *ArgType = GR.getSPIRVTypeForVReg(IntReg);
+  const SPIRVTypeInst ArgType = GR.getSPIRVTypeForVReg(IntReg);
   if (GR.isScalarOrVectorOfType(ResVReg, SPIRV::OpTypeBool))
     return selectIntToBool(IntReg, ResVReg, I, ArgType, ResType);
   if (ArgType == ResType)
@@ -3494,7 +3491,7 @@ bool SPIRVInstructionSelector::selectTrunc(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectConst(Register ResVReg,
-                                           const SPIRVType *ResType,
+                                           SPIRVTypeInst ResType,
                                            MachineInstr &I) const {
   unsigned Opcode = I.getOpcode();
   unsigned TpOpcode = ResType->getOpcode();
@@ -3516,7 +3513,7 @@ bool SPIRVInstructionSelector::selectConst(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectOpUndef(Register ResVReg,
-                                             const SPIRVType *ResType,
+                                             SPIRVTypeInst ResType,
                                              MachineInstr &I) const {
   BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(SPIRV::OpUndef))
       .addDef(ResVReg)
@@ -3526,7 +3523,7 @@ bool SPIRVInstructionSelector::selectOpUndef(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectInsertVal(Register ResVReg,
-                                               const SPIRVType *ResType,
+                                               SPIRVTypeInst ResType,
                                                MachineInstr &I) const {
   MachineBasicBlock &BB = *I.getParent();
   auto MIB = BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpCompositeInsert))
@@ -3543,7 +3540,7 @@ bool SPIRVInstructionSelector::selectInsertVal(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectExtractVal(Register ResVReg,
-                                                const SPIRVType *ResType,
+                                                SPIRVTypeInst ResType,
                                                 MachineInstr &I) const {
   Type *MaybeResTy = nullptr;
   StringRef ResName;
@@ -3567,7 +3564,7 @@ bool SPIRVInstructionSelector::selectExtractVal(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectInsertElt(Register ResVReg,
-                                               const SPIRVType *ResType,
+                                               SPIRVTypeInst ResType,
                                                MachineInstr &I) const {
   if (getImm(I.getOperand(4), MRI))
     return selectInsertVal(ResVReg, ResType, I);
@@ -3583,7 +3580,7 @@ bool SPIRVInstructionSelector::selectInsertElt(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectExtractElt(Register ResVReg,
-                                                const SPIRVType *ResType,
+                                                SPIRVTypeInst ResType,
                                                 MachineInstr &I) const {
   if (getImm(I.getOperand(3), MRI))
     return selectExtractVal(ResVReg, ResType, I);
@@ -3598,7 +3595,7 @@ bool SPIRVInstructionSelector::selectExtractElt(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectGEP(Register ResVReg,
-                                         const SPIRVType *ResType,
+                                         SPIRVTypeInst ResType,
                                          MachineInstr &I) const {
   const bool IsGEPInBounds = I.getOperand(2).getImm();
 
@@ -3640,7 +3637,7 @@ bool SPIRVInstructionSelector::wrapIntoSpecConstantOp(
   for (unsigned i = I.getNumExplicitDefs() + 1; i < Lim; ++i) {
     Register OpReg = I.getOperand(i).getReg();
     MachineInstr *OpDefine = MRI->getVRegDef(OpReg);
-    SPIRVType *OpType = GR.getSPIRVTypeForVReg(OpReg);
+    SPIRVTypeInst OpType = GR.getSPIRVTypeForVReg(OpReg);
     SmallPtrSet<SPIRVType *, 4> Visited;
     if (!OpDefine || !OpType || isConstReg(MRI, OpDefine, Visited) ||
         OpDefine->getOpcode() == TargetOpcode::G_ADDRSPACE_CAST ||
@@ -3676,7 +3673,7 @@ bool SPIRVInstructionSelector::wrapIntoSpecConstantOp(
 }
 
 bool SPIRVInstructionSelector::selectDerivativeInst(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
     const unsigned DPdOpCode) const {
   // TODO: This should check specifically for Fragment Execution Model, but STI
   // doesn't provide that information yet. See #167562
@@ -3686,7 +3683,7 @@ bool SPIRVInstructionSelector::selectDerivativeInst(
   // conversions to float
   // This case occurs because a half arg/result is legal in HLSL but not spirv.
   Register SrcReg = I.getOperand(2).getReg();
-  SPIRVType *SrcType = GR.getSPIRVTypeForVReg(SrcReg);
+  SPIRVTypeInst SrcType = GR.getSPIRVTypeForVReg(SrcReg);
   unsigned BitWidth = std::min(GR.getScalarOrVectorBitWidth(SrcType),
                                GR.getScalarOrVectorBitWidth(ResType));
   if (BitWidth == 32)
@@ -3697,7 +3694,7 @@ bool SPIRVInstructionSelector::selectDerivativeInst(
 
   MachineIRBuilder MIRBuilder(I);
   unsigned componentCount = GR.getScalarOrVectorComponentCount(SrcType);
-  SPIRVType *F32ConvertTy = GR.getOrCreateSPIRVFloatType(32, I, TII);
+  SPIRVTypeInst F32ConvertTy = GR.getOrCreateSPIRVFloatType(32, I, TII);
   if (componentCount != 1)
     F32ConvertTy = GR.getOrCreateSPIRVVectorType(F32ConvertTy, componentCount,
                                                  MIRBuilder, false);
@@ -3725,7 +3722,7 @@ bool SPIRVInstructionSelector::selectDerivativeInst(
 }
 
 bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
-                                               const SPIRVType *ResType,
+                                               SPIRVTypeInst ResType,
                                                MachineInstr &I) const {
   MachineBasicBlock &BB = *I.getParent();
   Intrinsic::ID IID = cast<GIntrinsic>(I).getIntrinsicID();
@@ -3746,7 +3743,7 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
     return selectGEP(ResVReg, ResType, I);
   case Intrinsic::spv_bitcast: {
     Register OpReg = I.getOperand(2).getReg();
-    SPIRVType *OpType =
+    SPIRVTypeInst OpType =
         OpReg.isValid() ? GR.getSPIRVTypeForVReg(OpReg) : nullptr;
     if (!GR.isBitcastCompatible(ResType, OpType))
       report_fatal_error("incompatible result and operand types in a bitcast");
@@ -4182,7 +4179,7 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectHandleFromBinding(Register &ResVReg,
-                                                       const SPIRVType *ResType,
+                                                       SPIRVTypeInst ResType,
                                                        MachineInstr &I) const {
   // The images need to be loaded in the same basic block as their use. We defer
   // loading the image to the intrinsic that uses it.
@@ -4194,7 +4191,7 @@ bool SPIRVInstructionSelector::selectHandleFromBinding(Register &ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectCounterHandleFromBinding(
-    Register &ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register &ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
   auto &Intr = cast<GIntrinsic>(I);
   assert(Intr.getIntrinsicID() ==
          Intrinsic::spv_resource_counterhandlefrombinding);
@@ -4215,15 +4212,16 @@ bool SPIRVInstructionSelector::selectCounterHandleFromBinding(
 
   // Create the counter variable.
   MachineIRBuilder MIRBuilder(I);
-  Register CounterVarReg = buildPointerToResource(
-      GR.getPointeeType(ResType), GR.getPointerStorageClass(ResType), Set,
-      Binding, ArraySize, IndexReg, CounterName, MIRBuilder);
+  Register CounterVarReg =
+      buildPointerToResource(SPIRVTypeInst(GR.getPointeeType(ResType)),
+                             GR.getPointerStorageClass(ResType), Set, Binding,
+                             ArraySize, IndexReg, CounterName, MIRBuilder);
 
   return BuildCOPY(ResVReg, CounterVarReg, I);
 }
 
 bool SPIRVInstructionSelector::selectUpdateCounter(Register &ResVReg,
-                                                   const SPIRVType *ResType,
+                                                   SPIRVTypeInst ResType,
                                                    MachineInstr &I) const {
   auto &Intr = cast<GIntrinsic>(I);
   assert(Intr.getIntrinsicID() == Intrinsic::spv_resource_updatecounter);
@@ -4235,8 +4233,8 @@ bool SPIRVInstructionSelector::selectUpdateCounter(Register &ResVReg,
   // containing an i32). We need to get a pointer to that i32 member to do the
   // atomic operation.
 #ifndef NDEBUG
-  SPIRVType *CounterVarType = GR.getSPIRVTypeForVReg(CounterHandleReg);
-  SPIRVType *CounterVarPointeeType = GR.getPointeeType(CounterVarType);
+  SPIRVTypeInst CounterVarType = GR.getSPIRVTypeForVReg(CounterHandleReg);
+  SPIRVTypeInst CounterVarPointeeType = GR.getPointeeType(CounterVarType);
   assert(CounterVarPointeeType &&
          CounterVarPointeeType->getOpcode() == SPIRV::OpTypeStruct &&
          "Counter variable must be a struct");
@@ -4245,7 +4243,7 @@ bool SPIRVInstructionSelector::selectUpdateCounter(Register &ResVReg,
          "Counter variable must be in the storage buffer storage class");
   assert(CounterVarPointeeType->getNumOperands() == 2 &&
          "Counter variable must have exactly 1 member in the struct");
-  const SPIRVType *MemberType =
+  const SPIRVTypeInst MemberType =
       GR.getSPIRVTypeForVReg(CounterVarPointeeType->getOperand(1).getReg());
   assert(MemberType->getOpcode() == SPIRV::OpTypeInt &&
          "Counter variable struct must have a single i32 member");
@@ -4256,7 +4254,7 @@ bool SPIRVInstructionSelector::selectUpdateCounter(Register &ResVReg,
   const Type *LLVMIntType =
       Type::getInt32Ty(I.getMF()->getFunction().getContext());
 
-  SPIRVType *IntPtrType = GR.getOrCreateSPIRVPointerType(
+  SPIRVTypeInst IntPtrType = GR.getOrCreateSPIRVPointerType(
       LLVMIntType, MIRBuilder, SPIRV::StorageClass::StorageBuffer);
 
   Register Zero = buildI32Constant(0, I);
@@ -4304,8 +4302,9 @@ bool SPIRVInstructionSelector::selectUpdateCounter(Register &ResVReg,
       .constrainAllUses(TII, TRI, RBI);
   return true;
 }
-bool SPIRVInstructionSelector::selectReadImageIntrinsic(
-    Register &ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+bool SPIRVInstructionSelector::selectReadImageIntrinsic(Register &ResVReg,
+                                                        SPIRVTypeInst ResType,
+                                                        MachineInstr &I) const {
 
   // If the load of the image is in a different basic block, then
   // this will generate invalid code. A proper solution is to move
@@ -4330,7 +4329,7 @@ bool SPIRVInstructionSelector::selectReadImageIntrinsic(
 }
 
 bool SPIRVInstructionSelector::generateSampleImage(
-    Register ResVReg, const SPIRVType *ResType, Register ImageReg,
+    Register ResVReg, SPIRVTypeInst ResType, Register ImageReg,
     Register SamplerReg, Register CoordinateReg, const ImageOperands &ImOps,
     DebugLoc Loc, MachineInstr &Pos) const {
   auto *ImageDef = cast<GIntrinsic>(getVRegDef(*MRI, ImageReg));
@@ -4350,7 +4349,7 @@ bool SPIRVInstructionSelector::generateSampleImage(
   }
 
   MachineIRBuilder MIRBuilder(Pos);
-  SPIRVType *SampledImageType = GR.getOrCreateOpTypeSampledImage(
+  SPIRVTypeInst SampledImageType = GR.getOrCreateOpTypeSampledImage(
       GR.getSPIRVTypeForVReg(ImageReg), MIRBuilder);
   Register SampledImageReg =
       MRI->createVirtualRegister(GR.getRegClass(SampledImageType));
@@ -4419,7 +4418,7 @@ bool SPIRVInstructionSelector::generateSampleImage(
 }
 
 bool SPIRVInstructionSelector::selectSampleBasicIntrinsic(
-    Register &ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register &ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
   Register ImageReg = I.getOperand(2).getReg();
   Register SamplerReg = I.getOperand(3).getReg();
   Register CoordinateReg = I.getOperand(4).getReg();
@@ -4433,7 +4432,7 @@ bool SPIRVInstructionSelector::selectSampleBasicIntrinsic(
 }
 
 bool SPIRVInstructionSelector::selectSampleBiasIntrinsic(
-    Register &ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register &ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
   Register ImageReg = I.getOperand(2).getReg();
   Register SamplerReg = I.getOperand(3).getReg();
   Register CoordinateReg = I.getOperand(4).getReg();
@@ -4448,7 +4447,7 @@ bool SPIRVInstructionSelector::selectSampleBiasIntrinsic(
 }
 
 bool SPIRVInstructionSelector::selectSampleGradIntrinsic(
-    Register &ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register &ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
   Register ImageReg = I.getOperand(2).getReg();
   Register SamplerReg = I.getOperand(3).getReg();
   Register CoordinateReg = I.getOperand(4).getReg();
@@ -4464,7 +4463,7 @@ bool SPIRVInstructionSelector::selectSampleGradIntrinsic(
 }
 
 bool SPIRVInstructionSelector::selectSampleLevelIntrinsic(
-    Register &ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register &ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
   Register ImageReg = I.getOperand(2).getReg();
   Register SamplerReg = I.getOperand(3).getReg();
   Register CoordinateReg = I.getOperand(4).getReg();
@@ -4476,8 +4475,9 @@ bool SPIRVInstructionSelector::selectSampleLevelIntrinsic(
                              CoordinateReg, ImOps, I.getDebugLoc(), I);
 }
 
-bool SPIRVInstructionSelector::selectSampleCmpIntrinsic(
-    Register &ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+bool SPIRVInstructionSelector::selectSampleCmpIntrinsic(Register &ResVReg,
+                                                        SPIRVTypeInst ResType,
+                                                        MachineInstr &I) const {
   Register ImageReg = I.getOperand(2).getReg();
   Register SamplerReg = I.getOperand(3).getReg();
   Register CoordinateReg = I.getOperand(4).getReg();
@@ -4492,7 +4492,7 @@ bool SPIRVInstructionSelector::selectSampleCmpIntrinsic(
 }
 
 bool SPIRVInstructionSelector::selectSampleCmpLevelZeroIntrinsic(
-    Register &ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register &ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
   Register ImageReg = I.getOperand(2).getReg();
   Register SamplerReg = I.getOperand(3).getReg();
   Register CoordinateReg = I.getOperand(4).getReg();
@@ -4500,16 +4500,16 @@ bool SPIRVInstructionSelector::selectSampleCmpLevelZeroIntrinsic(
   ImOps.Compare = I.getOperand(5).getReg();
   if (I.getNumOperands() > 6)
     ImOps.Offset = I.getOperand(6).getReg();
-  SPIRVType *FloatTy = GR.getOrCreateSPIRVFloatType(32, I, TII);
+  SPIRVTypeInst FloatTy = GR.getOrCreateSPIRVFloatType(32, I, TII);
   ImOps.Lod = GR.getOrCreateConstFP(APFloat(0.0f), I, FloatTy, TII);
   return generateSampleImage(ResVReg, ResType, ImageReg, SamplerReg,
                              CoordinateReg, ImOps, I.getDebugLoc(), I);
 }
 
 bool SPIRVInstructionSelector::generateImageReadOrFetch(
-    Register &ResVReg, const SPIRVType *ResType, Register ImageReg,
+    Register &ResVReg, SPIRVTypeInst ResType, Register ImageReg,
     Register IdxReg, DebugLoc Loc, MachineInstr &Pos) const {
-  SPIRVType *ImageType = GR.getSPIRVTypeForVReg(ImageReg);
+  SPIRVTypeInst ImageType = GR.getSPIRVTypeForVReg(ImageReg);
   assert(ImageType && ImageType->getOpcode() == SPIRV::OpTypeImage &&
          "ImageReg is not an image type.");
 
@@ -4536,7 +4536,7 @@ bool SPIRVInstructionSelector::generateImageReadOrFetch(
     return true;
   }
 
-  SPIRVType *ReadType = widenTypeToVec4(ResType, Pos);
+  SPIRVTypeInst ReadType = widenTypeToVec4(ResType, Pos);
   Register ReadReg = MRI->createVirtualRegister(GR.getRegClass(ReadType));
   auto BMI =
       BuildMI(*Pos.getParent(), Pos, Loc,
@@ -4561,10 +4561,11 @@ bool SPIRVInstructionSelector::generateImageReadOrFetch(
   return extractSubvector(ResVReg, ResType, ReadReg, Pos);
 }
 
-bool SPIRVInstructionSelector::selectResourceGetPointer(
-    Register &ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+bool SPIRVInstructionSelector::selectResourceGetPointer(Register &ResVReg,
+                                                        SPIRVTypeInst ResType,
+                                                        MachineInstr &I) const {
   Register ResourcePtr = I.getOperand(2).getReg();
-  SPIRVType *RegType = GR.getSPIRVTypeForVReg(ResourcePtr, I.getMF());
+  SPIRVTypeInst RegType = GR.getSPIRVTypeForVReg(ResourcePtr, I.getMF());
   if (RegType->getOpcode() == SPIRV::OpTypeImage) {
     // For texel buffers, the index into the image is part of the OpImageRead or
     // OpImageWrite instructions. So we will do nothing in this case. This
@@ -4590,13 +4591,13 @@ bool SPIRVInstructionSelector::selectResourceGetPointer(
 }
 
 bool SPIRVInstructionSelector::selectPushConstantGetPointer(
-    Register &ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register &ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
   MRI->replaceRegWith(ResVReg, I.getOperand(2).getReg());
   return true;
 }
 
 bool SPIRVInstructionSelector::selectResourceNonUniformIndex(
-    Register &ResVReg, const SPIRVType *ResType, MachineInstr &I) const {
+    Register &ResVReg, SPIRVTypeInst ResType, MachineInstr &I) const {
   Register ObjReg = I.getOperand(2).getReg();
   if (!BuildCOPY(ResVReg, ObjReg, I))
     return false;
@@ -4644,9 +4645,9 @@ void SPIRVInstructionSelector::decorateUsesAsNonUniform(
 }
 
 bool SPIRVInstructionSelector::extractSubvector(
-    Register &ResVReg, const SPIRVType *ResType, Register &ReadReg,
+    Register &ResVReg, SPIRVTypeInst ResType, Register &ReadReg,
     MachineInstr &InsertionPoint) const {
-  SPIRVType *InputType = GR.getResultType(ReadReg);
+  SPIRVTypeInst InputType = GR.getResultType(ReadReg);
   [[maybe_unused]] uint64_t InputSize =
       GR.getScalarOrVectorComponentCount(InputType);
   uint64_t ResultSize = GR.getScalarOrVectorComponentCount(ResType);
@@ -4655,7 +4656,7 @@ bool SPIRVInstructionSelector::extractSubvector(
   assert(ResultSize < InputSize &&
          "Cannot extract more element than there are in the input.");
   SmallVector<Register> ComponentRegisters;
-  SPIRVType *ScalarType = GR.getScalarOrVectorComponentType(ResType);
+  SPIRVTypeInst ScalarType = GR.getScalarOrVectorComponentType(ResType);
   const TargetRegisterClass *ScalarRegClass = GR.getRegClass(ScalarType);
   for (uint64_t I = 0; I < ResultSize; I++) {
     Register ComponentReg = MRI->createVirtualRegister(ScalarRegClass);
@@ -4710,12 +4711,12 @@ bool SPIRVInstructionSelector::selectImageWriteIntrinsic(
 }
 
 Register SPIRVInstructionSelector::buildPointerToResource(
-    const SPIRVType *SpirvResType, SPIRV::StorageClass::StorageClass SC,
+    SPIRVTypeInst SpirvResType, SPIRV::StorageClass::StorageClass SC,
     uint32_t Set, uint32_t Binding, uint32_t ArraySize, Register IndexReg,
     StringRef Name, MachineIRBuilder MIRBuilder) const {
   const Type *ResType = GR.getTypeForSPIRVType(SpirvResType);
   if (ArraySize == 1) {
-    SPIRVType *PtrType =
+    SPIRVTypeInst PtrType =
         GR.getOrCreateSPIRVPointerType(ResType, MIRBuilder, SC);
     assert(GR.getPointeeType(PtrType) == SpirvResType &&
            "SpirvResType did not have an explicit layout.");
@@ -4724,12 +4725,12 @@ Register SPIRVInstructionSelector::buildPointerToResource(
   }
 
   const Type *VarType = ArrayType::get(const_cast<Type *>(ResType), ArraySize);
-  SPIRVType *VarPointerType =
+  SPIRVTypeInst VarPointerType =
       GR.getOrCreateSPIRVPointerType(VarType, MIRBuilder, SC);
   Register VarReg = GR.getOrCreateGlobalVariableWithBinding(
       VarPointerType, Set, Binding, Name, MIRBuilder);
 
-  SPIRVType *ResPointerType =
+  SPIRVTypeInst ResPointerType =
       GR.getOrCreateSPIRVPointerType(ResType, MIRBuilder, SC);
   Register AcReg = MRI->createVirtualRegister(GR.getRegClass(ResPointerType));
 
@@ -4743,7 +4744,7 @@ Register SPIRVInstructionSelector::buildPointerToResource(
 }
 
 bool SPIRVInstructionSelector::selectFirstBitSet16(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I,
     unsigned ExtendOpcode, unsigned BitSetOpcode) const {
   Register ExtReg = MRI->createVirtualRegister(GR.getRegClass(ResType));
   if (!selectOpWithSrcs(ExtReg, ResType, I, {I.getOperand(2).getReg()},
@@ -4754,8 +4755,8 @@ bool SPIRVInstructionSelector::selectFirstBitSet16(
 }
 
 bool SPIRVInstructionSelector::selectFirstBitSet32(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
-    Register SrcReg, unsigned BitSetOpcode) const {
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I, Register SrcReg,
+    unsigned BitSetOpcode) const {
   BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(SPIRV::OpExtInst))
       .addDef(ResVReg)
       .addUse(GR.getSPIRVTypeID(ResType))
@@ -4767,8 +4768,8 @@ bool SPIRVInstructionSelector::selectFirstBitSet32(
 }
 
 bool SPIRVInstructionSelector::selectFirstBitSet64Overflow(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
-    Register SrcReg, unsigned BitSetOpcode, bool SwapPrimarySide) const {
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I, Register SrcReg,
+    unsigned BitSetOpcode, bool SwapPrimarySide) const {
 
   // SPIR-V allow vectors of size 2,3,4 only. Calling with a larger vectors
   // requires creating a param register and return register with an invalid
@@ -4778,11 +4779,11 @@ bool SPIRVInstructionSelector::selectFirstBitSet64Overflow(
   assert(ComponentCount < 5 && "Vec 5+ will generate invalid SPIR-V ops");
 
   MachineIRBuilder MIRBuilder(I);
-  SPIRVType *BaseType = GR.retrieveScalarOrVectorIntType(ResType);
-  SPIRVType *I64Type = GR.getOrCreateSPIRVIntegerType(64, MIRBuilder);
-  SPIRVType *I64x2Type =
+  SPIRVTypeInst BaseType = GR.retrieveScalarOrVectorIntType(ResType);
+  SPIRVTypeInst I64Type = GR.getOrCreateSPIRVIntegerType(64, MIRBuilder);
+  SPIRVTypeInst I64x2Type =
       GR.getOrCreateSPIRVVectorType(I64Type, 2, MIRBuilder, false);
-  SPIRVType *Vec2ResType =
+  SPIRVTypeInst Vec2ResType =
       GR.getOrCreateSPIRVVectorType(BaseType, 2, MIRBuilder, false);
 
   std::vector<Register> PartialRegs;
@@ -4844,10 +4845,10 @@ bool SPIRVInstructionSelector::selectFirstBitSet64Overflow(
 }
 
 bool SPIRVInstructionSelector::selectFirstBitSet64(
-    Register ResVReg, const SPIRVType *ResType, MachineInstr &I,
-    Register SrcReg, unsigned BitSetOpcode, bool SwapPrimarySide) const {
+    Register ResVReg, SPIRVTypeInst ResType, MachineInstr &I, Register SrcReg,
+    unsigned BitSetOpcode, bool SwapPrimarySide) const {
   unsigned ComponentCount = GR.getScalarOrVectorComponentCount(ResType);
-  SPIRVType *BaseType = GR.retrieveScalarOrVectorIntType(ResType);
+  SPIRVTypeInst BaseType = GR.retrieveScalarOrVectorIntType(ResType);
   bool ZeroAsNull = !STI.isShader();
   Register ConstIntZero =
       GR.getOrCreateConstInt(0, I, BaseType, TII, ZeroAsNull);
@@ -4865,7 +4866,7 @@ bool SPIRVInstructionSelector::selectFirstBitSet64(
 
   // 1. Split int64 into 2 pieces using a bitcast
   MachineIRBuilder MIRBuilder(I);
-  SPIRVType *PostCastType = GR.getOrCreateSPIRVVectorType(
+  SPIRVTypeInst PostCastType = GR.getOrCreateSPIRVVectorType(
       BaseType, 2 * ComponentCount, MIRBuilder, false);
   Register BitcastReg =
       MRI->createVirtualRegister(GR.getRegClass(PostCastType));
@@ -4926,7 +4927,7 @@ bool SPIRVInstructionSelector::selectFirstBitSet64(
 
   // 4. Check the result. When primary bits == -1 use secondary, otherwise use
   // primary
-  SPIRVType *BoolType = GR.getOrCreateSPIRVBoolType(I, TII);
+  SPIRVTypeInst BoolType = GR.getOrCreateSPIRVBoolType(I, TII);
   Register NegOneReg;
   Register Reg0;
   Register Reg32;
@@ -4987,12 +4988,12 @@ bool SPIRVInstructionSelector::selectFirstBitSet64(
 }
 
 bool SPIRVInstructionSelector::selectFirstBitHigh(Register ResVReg,
-                                                  const SPIRVType *ResType,
+                                                  SPIRVTypeInst ResType,
                                                   MachineInstr &I,
                                                   bool IsSigned) const {
   // FindUMsb and FindSMsb intrinsics only support 32 bit integers
   Register OpReg = I.getOperand(2).getReg();
-  SPIRVType *OpType = GR.getSPIRVTypeForVReg(OpReg);
+  SPIRVTypeInst OpType = GR.getSPIRVTypeForVReg(OpReg);
   // zero or sign extend
   unsigned ExtendOpcode = IsSigned ? SPIRV::OpSConvert : SPIRV::OpUConvert;
   unsigned BitSetOpcode = IsSigned ? GL::FindSMsb : GL::FindUMsb;
@@ -5012,11 +5013,11 @@ bool SPIRVInstructionSelector::selectFirstBitHigh(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectFirstBitLow(Register ResVReg,
-                                                 const SPIRVType *ResType,
+                                                 SPIRVTypeInst ResType,
                                                  MachineInstr &I) const {
   // FindILsb intrinsic only supports 32 bit integers
   Register OpReg = I.getOperand(2).getReg();
-  SPIRVType *OpType = GR.getSPIRVTypeForVReg(OpReg);
+  SPIRVTypeInst OpType = GR.getSPIRVTypeForVReg(OpReg);
   // OpUConvert treats the operand bits as an unsigned i16 and zero extends it
   // to an unsigned i32. As this leaves all the least significant bits unchanged
   // so the first set bit from the LSB side doesn't change.
@@ -5037,7 +5038,7 @@ bool SPIRVInstructionSelector::selectFirstBitLow(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectAllocaArray(Register ResVReg,
-                                                 const SPIRVType *ResType,
+                                                 SPIRVTypeInst ResType,
                                                  MachineInstr &I) const {
   // there was an allocation size parameter to the allocation instruction
   // that is not 1
@@ -5055,7 +5056,7 @@ bool SPIRVInstructionSelector::selectAllocaArray(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectFrameIndex(Register ResVReg,
-                                                const SPIRVType *ResType,
+                                                SPIRVTypeInst ResType,
                                                 MachineInstr &I) const {
   // Change order of instructions if needed: all OpVariable instructions in a
   // function must be the first instructions in the first block
@@ -5123,7 +5124,7 @@ bool SPIRVInstructionSelector::selectBranchCond(MachineInstr &I) const {
 }
 
 bool SPIRVInstructionSelector::selectPhi(Register ResVReg,
-                                         const SPIRVType *ResType,
+                                         SPIRVTypeInst ResType,
                                          MachineInstr &I) const {
   auto MIB = BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(SPIRV::OpPhi))
                  .addDef(ResVReg)
@@ -5176,7 +5177,7 @@ bool SPIRVInstructionSelector::selectGlobalValue(
           STI.canUseExtension(SPIRV::Extension::SPV_INTEL_function_pointers)
               ? dyn_cast<Function>(GV)
               : nullptr;
-      SPIRVType *ResType = GR.getOrCreateSPIRVPointerType(
+      SPIRVTypeInst ResType = GR.getOrCreateSPIRVPointerType(
           GVType, I,
           GVFun ? SPIRV::StorageClass::CodeSectionINTEL
                 : addressSpaceToStorageClass(GV->getAddressSpace(), STI));
@@ -5231,7 +5232,8 @@ bool SPIRVInstructionSelector::selectGlobalValue(
   const unsigned AddrSpace = GV->getAddressSpace();
   SPIRV::StorageClass::StorageClass StorageClass =
       addressSpaceToStorageClass(AddrSpace, STI);
-  SPIRVType *ResType = GR.getOrCreateSPIRVPointerType(GVType, I, StorageClass);
+  SPIRVTypeInst ResType =
+      GR.getOrCreateSPIRVPointerType(GVType, I, StorageClass);
   Register Reg = GR.buildGlobalVariable(
       ResVReg, ResType, GlobalIdent, GV, StorageClass, Init,
       GlobalVar->isConstant(), LnkType, MIRBuilder, true);
@@ -5251,7 +5253,7 @@ bool SPIRVInstructionSelector::selectGlobalValue(
 }
 
 bool SPIRVInstructionSelector::selectLog10(Register ResVReg,
-                                           const SPIRVType *ResType,
+                                           SPIRVTypeInst ResType,
                                            MachineInstr &I) const {
   if (STI.canUseExtInstSet(SPIRV::InstructionSet::OpenCL_std)) {
     return selectExtInst(ResVReg, ResType, I, CL::log10);
@@ -5279,10 +5281,10 @@ bool SPIRVInstructionSelector::selectLog10(Register ResVReg,
   assert(ResType->getOpcode() == SPIRV::OpTypeVector ||
          ResType->getOpcode() == SPIRV::OpTypeFloat);
   // TODO: Add matrix implementation once supported by the HLSL frontend.
-  const SPIRVType *SpirvScalarType =
-      ResType->getOpcode() == SPIRV::OpTypeVector
-          ? GR.getSPIRVTypeForVReg(ResType->getOperand(1).getReg())
-          : ResType;
+  SPIRVTypeInst SpirvScalarType = ResType->getOpcode() == SPIRV::OpTypeVector
+                                      ? SPIRVTypeInst(GR.getSPIRVTypeForVReg(
+                                            ResType->getOperand(1).getReg()))
+                                      : ResType;
   Register ScaleReg =
       GR.buildConstantFP(APFloat(0.30103f), MIRBuilder, SpirvScalarType);
 
@@ -5300,7 +5302,7 @@ bool SPIRVInstructionSelector::selectLog10(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectModf(Register ResVReg,
-                                          const SPIRVType *ResType,
+                                          SPIRVTypeInst ResType,
                                           MachineInstr &I) const {
   // llvm.modf has a single arg --the number to be decomposed-- and returns a
   // struct { restype, restype }, while OpenCLLIB::modf has two args --the
@@ -5319,7 +5321,7 @@ bool SPIRVInstructionSelector::selectModf(Register ResVReg,
   if (STI.canUseExtInstSet(SPIRV::InstructionSet::OpenCL_std)) {
     MachineIRBuilder MIRBuilder(I);
     // Get pointer type for alloca variable.
-    const SPIRVType *PtrType = GR.getOrCreateSPIRVPointerType(
+    const SPIRVTypeInst PtrType = GR.getOrCreateSPIRVPointerType(
         ResType, MIRBuilder, SPIRV::StorageClass::Function);
     // Create new register for the pointer type of alloca variable.
     Register PtrTyReg =
@@ -5382,11 +5384,11 @@ bool SPIRVInstructionSelector::selectModf(Register ResVReg,
 
 bool SPIRVInstructionSelector::loadVec3BuiltinInputID(
     SPIRV::BuiltIn::BuiltIn BuiltInValue, Register ResVReg,
-    const SPIRVType *ResType, MachineInstr &I) const {
+    SPIRVTypeInst ResType, MachineInstr &I) const {
   MachineIRBuilder MIRBuilder(I);
-  const SPIRVType *Vec3Ty =
+  const SPIRVTypeInst Vec3Ty =
       GR.getOrCreateSPIRVVectorType(ResType, 3, MIRBuilder, false);
-  const SPIRVType *PtrType = GR.getOrCreateSPIRVPointerType(
+  const SPIRVTypeInst PtrType = GR.getOrCreateSPIRVPointerType(
       Vec3Ty, MIRBuilder, SPIRV::StorageClass::Input);
 
   // Create new register for the input ID builtin variable.
@@ -5434,9 +5436,9 @@ bool SPIRVInstructionSelector::loadVec3BuiltinInputID(
 // Like LocalInvocationIndex
 bool SPIRVInstructionSelector::loadBuiltinInputID(
     SPIRV::BuiltIn::BuiltIn BuiltInValue, Register ResVReg,
-    const SPIRVType *ResType, MachineInstr &I) const {
+    SPIRVTypeInst ResType, MachineInstr &I) const {
   MachineIRBuilder MIRBuilder(I);
-  const SPIRVType *PtrType = GR.getOrCreateSPIRVPointerType(
+  const SPIRVTypeInst PtrType = GR.getOrCreateSPIRVPointerType(
       ResType, MIRBuilder, SPIRV::StorageClass::Input);
 
   // Create new register for the input ID builtin variable.
@@ -5465,8 +5467,8 @@ bool SPIRVInstructionSelector::loadBuiltinInputID(
   return true;
 }
 
-SPIRVType *SPIRVInstructionSelector::widenTypeToVec4(const SPIRVType *Type,
-                                                     MachineInstr &I) const {
+SPIRVTypeInst SPIRVInstructionSelector::widenTypeToVec4(SPIRVTypeInst Type,
+                                                        MachineInstr &I) const {
   MachineIRBuilder MIRBuilder(I);
   if (Type->getOpcode() != SPIRV::OpTypeVector)
     return GR.getOrCreateSPIRVVectorType(Type, 4, MIRBuilder, false);
@@ -5476,12 +5478,12 @@ SPIRVType *SPIRVInstructionSelector::widenTypeToVec4(const SPIRVType *Type,
     return Type;
 
   Register ScalarTypeReg = Type->getOperand(1).getReg();
-  const SPIRVType *ScalarType = GR.getSPIRVTypeForVReg(ScalarTypeReg);
+  const SPIRVTypeInst ScalarType = GR.getSPIRVTypeForVReg(ScalarTypeReg);
   return GR.getOrCreateSPIRVVectorType(ScalarType, 4, MIRBuilder, false);
 }
 
 bool SPIRVInstructionSelector::loadHandleBeforePosition(
-    Register &HandleReg, const SPIRVType *ResType, GIntrinsic &HandleDef,
+    Register &HandleReg, SPIRVTypeInst ResType, GIntrinsic &HandleDef,
     MachineInstr &Pos) const {
 
   assert(HandleDef.getIntrinsicID() ==
@@ -5495,7 +5497,7 @@ bool SPIRVInstructionSelector::loadHandleBeforePosition(
 
   bool IsStructuredBuffer = ResType->getOpcode() == SPIRV::OpTypePointer;
   MachineIRBuilder MIRBuilder(HandleDef);
-  SPIRVType *VarType = ResType;
+  SPIRVTypeInst VarType = ResType;
   SPIRV::StorageClass::StorageClass SC = SPIRV::StorageClass::UniformConstant;
 
   if (IsStructuredBuffer) {
@@ -5503,8 +5505,9 @@ bool SPIRVInstructionSelector::loadHandleBeforePosition(
     SC = GR.getPointerStorageClass(ResType);
   }
 
-  Register VarReg = buildPointerToResource(VarType, SC, Set, Binding, ArraySize,
-                                           IndexReg, Name, MIRBuilder);
+  Register VarReg =
+      buildPointerToResource(SPIRVTypeInst(VarType), SC, Set, Binding,
+                             ArraySize, IndexReg, Name, MIRBuilder);
 
   // The handle for the buffer is the pointer to the resource. For an image, the
   // handle is the image object. So images get an extra load.

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -529,7 +529,7 @@ static bool legalizeInsertVectorElt(LegalizerHelper &Helper, MachineInstr &MI,
   return true;
 }
 
-static Register convertPtrToInt(Register Reg, LLT ConvTy, SPIRVType *SpvType,
+static Register convertPtrToInt(Register Reg, LLT ConvTy, SPIRVTypeInst SpvType,
                                 LegalizerHelper &Helper,
                                 MachineRegisterInfo &MRI,
                                 SPIRVGlobalRegistry *GR) {
@@ -683,7 +683,7 @@ bool SPIRVLegalizerInfo::legalizeCustom(
       LLT ConvT = LLT::scalar(ST->getPointerSize());
       Type *LLVMTy = IntegerType::get(MI.getMF()->getFunction().getContext(),
                                       ST->getPointerSize());
-      SPIRVType *SpirvTy = GR->getOrCreateSPIRVType(
+      SPIRVTypeInst SpirvTy = GR->getOrCreateSPIRVType(
           LLVMTy, Helper.MIRBuilder, SPIRV::AccessQualifier::ReadWrite, true);
       Op0.setReg(convertPtrToInt(Reg0, ConvT, SpirvTy, Helper, MRI, GR));
       Op1.setReg(convertPtrToInt(Reg1, ConvT, SpirvTy, Helper, MRI, GR));
@@ -709,14 +709,14 @@ createStackTemporaryForVector(LegalizerHelper &Helper, SPIRVGlobalRegistry *GR,
       TypeSize::getFixed(SrcTy.getSizeInBytes()), VecAlign, PtrInfo);
 
   // Set the type of StackTemp to a pointer to an array of the element type.
-  SPIRVType *SpvSrcTy = GR->getSPIRVTypeForVReg(SrcReg);
-  SPIRVType *EltSpvTy = GR->getScalarOrVectorComponentType(SpvSrcTy);
+  SPIRVTypeInst SpvSrcTy = GR->getSPIRVTypeForVReg(SrcReg);
+  SPIRVTypeInst EltSpvTy = GR->getScalarOrVectorComponentType(SpvSrcTy);
   const Type *LLVMEltTy = GR->getTypeForSPIRVType(EltSpvTy);
   const Type *LLVMArrTy =
       ArrayType::get(const_cast<Type *>(LLVMEltTy), SrcTy.getNumElements());
-  SPIRVType *ArrSpvTy = GR->getOrCreateSPIRVType(
+  SPIRVTypeInst ArrSpvTy = GR->getOrCreateSPIRVType(
       LLVMArrTy, MIRBuilder, SPIRV::AccessQualifier::ReadWrite, true);
-  SPIRVType *PtrToArrSpvTy = GR->getOrCreateSPIRVPointerType(
+  SPIRVTypeInst PtrToArrSpvTy = GR->getOrCreateSPIRVPointerType(
       ArrSpvTy, MIRBuilder, SPIRV::StorageClass::Function);
 
   Register StackReg = StackTemp.getReg(0);
@@ -768,7 +768,7 @@ static bool legalizeSpvInsertElt(LegalizerHelper &Helper, MachineInstr &MI,
       uint64_t IdxVal = foldImm(IdxOperand, &MRI);
       if (IdxVal < SrcTy.getNumElements()) {
         SmallVector<Register, 8> Regs;
-        SPIRVType *ElementType =
+        SPIRVTypeInst ElementType =
             GR->getScalarOrVectorComponentType(GR->getSPIRVTypeForVReg(DstReg));
         LLT ElementLLTTy = GR->getRegType(ElementType);
         for (unsigned I = 0, E = SrcTy.getNumElements(); I < E; ++I) {
@@ -833,7 +833,7 @@ static bool legalizeSpvExtractElt(LegalizerHelper &Helper, MachineInstr &MI,
       if (IdxVal < SrcTy.getNumElements()) {
         LLT DstTy = MRI.getType(DstReg);
         SmallVector<Register, 8> Regs;
-        SPIRVType *DstSpvTy = GR->getSPIRVTypeForVReg(DstReg);
+        SPIRVTypeInst DstSpvTy = GR->getSPIRVTypeForVReg(DstReg);
         for (unsigned I = 0, E = SrcTy.getNumElements(); I < E; ++I) {
           if (I == IdxVal) {
             Regs.push_back(DstReg);
@@ -896,8 +896,8 @@ static bool legalizeSpvConstComposite(LegalizerHelper &Helper, MachineInstr &MI,
     // The "null" case: no values are attached.
     LLT EltTy = DstTy.getElementType();
     auto Zero = MIRBuilder.buildConstant(EltTy, 0);
-    SPIRVType *SpvDstTy = GR->getSPIRVTypeForVReg(DstReg);
-    SPIRVType *SpvEltTy = GR->getScalarOrVectorComponentType(SpvDstTy);
+    SPIRVTypeInst SpvDstTy = GR->getSPIRVTypeForVReg(DstReg);
+    SPIRVTypeInst SpvEltTy = GR->getScalarOrVectorComponentType(SpvDstTy);
     GR->assignSPIRVTypeToVReg(SpvEltTy, Zero.getReg(0), MIRBuilder.getMF());
     for (unsigned i = 0; i < DstTy.getNumElements(); ++i)
       SrcRegs.push_back(Zero.getReg(0));
@@ -960,7 +960,7 @@ bool SPIRVLegalizerInfo::legalizeIsFPClass(
       IntegerType::get(MIRBuilder.getContext(), DstTy.getScalarSizeInBits());
   if (DstTy.isVector())
     LLVMDstTy = VectorType::get(LLVMDstTy, DstTy.getElementCount());
-  SPIRVType *SPIRVDstTy = GR->getOrCreateSPIRVType(
+  SPIRVTypeInst SPIRVDstTy = GR->getOrCreateSPIRVType(
       LLVMDstTy, MIRBuilder, SPIRV::AccessQualifier::ReadWrite,
       /*EmitIR*/ true);
 
@@ -973,7 +973,7 @@ bool SPIRVLegalizerInfo::legalizeIsFPClass(
     IntTy = LLT::vector(SrcTy.getElementCount(), IntTy);
     LLVMIntTy = VectorType::get(LLVMIntTy, SrcTy.getElementCount());
   }
-  SPIRVType *SPIRVIntTy = GR->getOrCreateSPIRVType(
+  SPIRVTypeInst SPIRVIntTy = GR->getOrCreateSPIRVType(
       LLVMIntTy, MIRBuilder, SPIRV::AccessQualifier::ReadWrite,
       /*EmitIR*/ true);
 
@@ -986,7 +986,7 @@ bool SPIRVLegalizerInfo::legalizeIsFPClass(
     LLT MITy = MRI.getType(MI.getReg(0));
     assert((MITy == IntTy || MITy == DstTyCopy) &&
            "Unexpected LLT type while lowering G_IS_FPCLASS");
-    auto *SPVTy = MITy == IntTy ? SPIRVIntTy : SPIRVDstTy;
+    SPIRVTypeInst SPVTy = MITy == IntTy ? SPIRVIntTy : SPIRVDstTy;
     GR->assignSPIRVTypeToVReg(SPVTy, MI.getReg(0), MF);
     return MI;
   };
@@ -998,7 +998,7 @@ bool SPIRVLegalizerInfo::legalizeIsFPClass(
     auto ScalarC = MIRBuilder.buildConstant(Ty.getScalarType(), C);
     assert((Ty == IntTy || Ty == DstTyCopy) &&
            "Unexpected LLT type while lowering constant for G_IS_FPCLASS");
-    SPIRVType *VecEltTy = GR->getOrCreateSPIRVType(
+    SPIRVTypeInst VecEltTy = GR->getOrCreateSPIRVType(
         (Ty == IntTy ? LLVMIntTy : LLVMDstTy)->getScalarType(), MIRBuilder,
         SPIRV::AccessQualifier::ReadWrite,
         /*EmitIR*/ true);

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1064,7 +1064,7 @@ static void addOpTypeImageReqs(const MachineInstr &MI,
   }
 }
 
-static bool isBFloat16Type(const SPIRVType *TypeDef) {
+static bool isBFloat16Type(SPIRVTypeInst TypeDef) {
   return TypeDef && TypeDef->getNumOperands() == 3 &&
          TypeDef->getOpcode() == SPIRV::OpTypeFloat &&
          TypeDef->getOperand(1).getImm() == 16 &&
@@ -1078,7 +1078,7 @@ static bool isBFloat16Type(const SPIRVType *TypeDef) {
 static void AddAtomicVectorFloatRequirements(const MachineInstr &MI,
                                              SPIRV::RequirementHandler &Reqs,
                                              const SPIRVSubtarget &ST) {
-  SPIRVType *VecTypeDef =
+  SPIRVTypeInst VecTypeDef =
       MI.getMF()->getRegInfo().getVRegDef(MI.getOperand(1).getReg());
 
   const unsigned Rank = VecTypeDef->getOperand(2).getImm();
@@ -1086,7 +1086,7 @@ static void AddAtomicVectorFloatRequirements(const MachineInstr &MI,
     reportFatalUsageError("Result type of an atomic vector float instruction "
                           "must be a 2-component or 4 component vector");
 
-  SPIRVType *EltTypeDef =
+  SPIRVTypeInst EltTypeDef =
       MI.getMF()->getRegInfo().getVRegDef(VecTypeDef->getOperand(1).getReg());
 
   if (EltTypeDef->getOpcode() != SPIRV::OpTypeFloat ||
@@ -1114,7 +1114,7 @@ static void AddAtomicFloatRequirements(const MachineInstr &MI,
   assert(MI.getOperand(1).isReg() &&
          "Expect register operand in atomic float instruction");
   Register TypeReg = MI.getOperand(1).getReg();
-  SPIRVType *TypeDef = MI.getMF()->getRegInfo().getVRegDef(TypeReg);
+  SPIRVTypeInst TypeDef = MI.getMF()->getRegInfo().getVRegDef(TypeReg);
 
   if (TypeDef->getOpcode() == SPIRV::OpTypeVector)
     return AddAtomicVectorFloatRequirements(MI, Reqs, ST);
@@ -1334,7 +1334,7 @@ void addOpAccessChainReqs(const MachineInstr &Instr,
   }
 }
 
-static bool isImageTypeWithUnknownFormat(SPIRVType *TypeInst) {
+static bool isImageTypeWithUnknownFormat(SPIRVTypeInst TypeInst) {
   if (TypeInst->getOpcode() != SPIRV::OpTypeImage)
     return false;
   assert(TypeInst->getOperand(7).isImm() && "The image format must be an imm.");
@@ -1356,12 +1356,13 @@ static void AddDotProductRequirements(const MachineInstr &MI,
   assert(Input->getOperand(1).isReg() && "Unexpected operand in dot input");
   Register InputReg = Input->getOperand(1).getReg();
 
-  SPIRVType *TypeDef = MRI.getVRegDef(InputReg);
+  SPIRVTypeInst TypeDef = MRI.getVRegDef(InputReg);
   if (TypeDef->getOpcode() == SPIRV::OpTypeInt) {
     assert(TypeDef->getOperand(1).getImm() == 32);
     Reqs.addCapability(SPIRV::Capability::DotProductInput4x8BitPacked);
   } else if (TypeDef->getOpcode() == SPIRV::OpTypeVector) {
-    SPIRVType *ScalarTypeDef = MRI.getVRegDef(TypeDef->getOperand(1).getReg());
+    SPIRVTypeInst ScalarTypeDef =
+        MRI.getVRegDef(TypeDef->getOperand(1).getReg());
     assert(ScalarTypeDef->getOpcode() == SPIRV::OpTypeInt);
     if (ScalarTypeDef->getOperand(1).getImm() == 8) {
       assert(TypeDef->getOperand(2).getImm() == 4 &&
@@ -1377,7 +1378,7 @@ void addPrintfRequirements(const MachineInstr &MI,
                            SPIRV::RequirementHandler &Reqs,
                            const SPIRVSubtarget &ST) {
   SPIRVGlobalRegistry *GR = ST.getSPIRVGlobalRegistry();
-  const SPIRVType *PtrType = GR->getSPIRVTypeForVReg(MI.getOperand(4).getReg());
+  SPIRVTypeInst PtrType = GR->getSPIRVTypeForVReg(MI.getOperand(4).getReg());
   if (PtrType) {
     MachineOperand ASOp = PtrType->getOperand(1);
     if (ASOp.isImm()) {
@@ -1467,7 +1468,7 @@ void addInstrRequirements(const MachineInstr &MI,
   }
   case SPIRV::OpDot: {
     const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
-    SPIRVType *TypeDef = MRI.getVRegDef(MI.getOperand(1).getReg());
+    SPIRVTypeInst TypeDef = MRI.getVRegDef(MI.getOperand(1).getReg());
     if (isBFloat16Type(TypeDef))
       Reqs.addCapability(SPIRV::Capability::BFloat16DotProductKHR);
     break;
@@ -1506,7 +1507,7 @@ void addInstrRequirements(const MachineInstr &MI,
       break;
     assert(MI.getOperand(2).isReg());
     const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
-    SPIRVType *TypeDef = MRI.getVRegDef(MI.getOperand(2).getReg());
+    SPIRVTypeInst TypeDef = MRI.getVRegDef(MI.getOperand(2).getReg());
     if ((TypeDef->getNumOperands() == 2) &&
         (TypeDef->getOpcode() == SPIRV::OpTypeFloat) &&
         (TypeDef->getOperand(1).getImm() == 16))
@@ -1619,7 +1620,7 @@ void addInstrRequirements(const MachineInstr &MI,
     }
     assert(InstrPtr->getOperand(1).isReg() && "Unexpected operand in atomic");
     Register TypeReg = InstrPtr->getOperand(1).getReg();
-    SPIRVType *TypeDef = MRI.getVRegDef(TypeReg);
+    SPIRVTypeInst TypeDef = MRI.getVRegDef(TypeReg);
     if (TypeDef->getOpcode() == SPIRV::OpTypeInt) {
       unsigned BitWidth = TypeDef->getOperand(1).getImm();
       if (BitWidth == 64)
@@ -1901,7 +1902,7 @@ void addInstrRequirements(const MachineInstr &MI,
     Reqs.addExtension(SPIRV::Extension::SPV_KHR_cooperative_matrix);
     Reqs.addCapability(SPIRV::Capability::CooperativeMatrixKHR);
     const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
-    SPIRVType *TypeDef = MRI.getVRegDef(MI.getOperand(1).getReg());
+    SPIRVTypeInst TypeDef = MRI.getVRegDef(MI.getOperand(1).getReg());
     if (isBFloat16Type(TypeDef))
       Reqs.addCapability(SPIRV::Capability::BFloat16CooperativeMatrixKHR);
     break;
@@ -2070,7 +2071,7 @@ void addInstrRequirements(const MachineInstr &MI,
                          false);
     SPIRVGlobalRegistry *GR = ST.getSPIRVGlobalRegistry();
     SPIRV::AddressingModel::AddressingModel AddrModel = MAI.Addr;
-    SPIRVType *TyDef = GR->getSPIRVTypeForVReg(MI.getOperand(1).getReg());
+    SPIRVTypeInst TyDef = GR->getSPIRVTypeForVReg(MI.getOperand(1).getReg());
     if (MI.getOpcode() == SPIRV::OpConvertHandleToImageINTEL &&
         TyDef->getOpcode() != SPIRV::OpTypeImage) {
       report_fatal_error("Incorrect return type for the instruction "
@@ -2087,7 +2088,7 @@ void addInstrRequirements(const MachineInstr &MI,
                          "OpConvertHandleToSampledImageINTEL",
                          false);
     }
-    SPIRVType *SpvTy = GR->getSPIRVTypeForVReg(MI.getOperand(2).getReg());
+    SPIRVTypeInst SpvTy = GR->getSPIRVTypeForVReg(MI.getOperand(2).getReg());
     unsigned Bitwidth = GR->getScalarOrVectorBitWidth(SpvTy);
     if (!(Bitwidth == 32 && AddrModel == SPIRV::AddressingModel::Physical32) &&
         !(Bitwidth == 64 && AddrModel == SPIRV::AddressingModel::Physical64)) {
@@ -2163,7 +2164,7 @@ void addInstrRequirements(const MachineInstr &MI,
     break;
   case SPIRV::OpImageRead: {
     Register ImageReg = MI.getOperand(2).getReg();
-    SPIRVType *TypeDef = ST.getSPIRVGlobalRegistry()->getResultType(
+    SPIRVTypeInst TypeDef = ST.getSPIRVGlobalRegistry()->getResultType(
         ImageReg, const_cast<MachineFunction *>(MI.getMF()));
     // OpImageRead and OpImageWrite can use Unknown Image Formats
     // when the Kernel capability is declared. In the OpenCL environment we are
@@ -2177,7 +2178,7 @@ void addInstrRequirements(const MachineInstr &MI,
   }
   case SPIRV::OpImageWrite: {
     Register ImageReg = MI.getOperand(0).getReg();
-    SPIRVType *TypeDef = ST.getSPIRVGlobalRegistry()->getResultType(
+    SPIRVTypeInst TypeDef = ST.getSPIRVGlobalRegistry()->getResultType(
         ImageReg, const_cast<MachineFunction *>(MI.getMF()));
     // OpImageRead and OpImageWrite can use Unknown Image Formats
     // when the Kernel capability is declared. In the OpenCL environment we are
@@ -2310,7 +2311,7 @@ void addInstrRequirements(const MachineInstr &MI,
   case SPIRV::OpFRemV:
   case SPIRV::OpFNegateV: {
     const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
-    SPIRVType *TypeDef = MRI.getVRegDef(MI.getOperand(1).getReg());
+    SPIRVTypeInst TypeDef = MRI.getVRegDef(MI.getOperand(1).getReg());
     if (TypeDef->getOpcode() == SPIRV::OpTypeVector)
       TypeDef = MRI.getVRegDef(TypeDef->getOperand(1).getReg());
     if (isBFloat16Type(TypeDef)) {
@@ -2340,7 +2341,7 @@ void addInstrRequirements(const MachineInstr &MI,
   case SPIRV::OpFUnordGreaterThanEqual: {
     const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
     MachineInstr *OperandDef = MRI.getVRegDef(MI.getOperand(2).getReg());
-    SPIRVType *TypeDef = MRI.getVRegDef(OperandDef->getOperand(1).getReg());
+    SPIRVTypeInst TypeDef = MRI.getVRegDef(OperandDef->getOperand(1).getReg());
     if (TypeDef->getOpcode() == SPIRV::OpTypeVector)
       TypeDef = MRI.getVRegDef(TypeDef->getOperand(1).getReg());
     if (isBFloat16Type(TypeDef)) {
@@ -2612,7 +2613,7 @@ static void handleMIFlagDecoration(
     Register ResReg = I.getOpcode() == SPIRV::OpExtInst
                           ? I.getOperand(1).getReg()
                           : I.getOperand(2).getReg();
-    SPIRVType *ResType = GR->getSPIRVTypeForVReg(ResReg, I.getMF());
+    SPIRVTypeInst ResType = GR->getSPIRVTypeForVReg(ResReg, I.getMF());
     const Type *Ty = GR->getTypeForSPIRVType(ResType);
     Ty = Ty->isVectorTy() ? cast<VectorType>(Ty)->getElementType() : Ty;
 

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -96,7 +96,7 @@ addConstantsToTrack(MachineFunction &MF, SPIRVGlobalRegistry *GR,
             if (Const->isNullValue()) {
               MachineBasicBlock &DepMBB = MF.front();
               MachineIRBuilder MIB(DepMBB, DepMBB.getFirstNonPHI());
-              SPIRVType *ExtType = GR->getOrCreateSPIRVType(
+              SPIRVTypeInst ExtType = GR->getOrCreateSPIRVType(
                   Const->getType(), MIB, SPIRV::AccessQualifier::ReadWrite,
                   true);
               assert(SrcMI && "Expected source instruction to be valid");
@@ -175,8 +175,8 @@ static MachineInstr *findAssignTypeInstr(Register Reg,
 
 static void buildOpBitcast(SPIRVGlobalRegistry *GR, MachineIRBuilder &MIB,
                            Register ResVReg, Register OpReg) {
-  SPIRVType *ResType = GR->getSPIRVTypeForVReg(ResVReg);
-  SPIRVType *OpType = GR->getSPIRVTypeForVReg(OpReg);
+  SPIRVTypeInst ResType = GR->getSPIRVTypeForVReg(ResVReg);
+  SPIRVTypeInst OpType = GR->getSPIRVTypeForVReg(OpReg);
   assert(ResType && OpType && "Operand types are expected");
   if (!GR->isBitcastCompatible(ResType, OpType))
     report_fatal_error("incompatible result and operand types in a bitcast");
@@ -211,11 +211,11 @@ static void lowerBitcasts(MachineFunction &MF, SPIRVGlobalRegistry *GR,
       if (isSpvIntrinsic(MI, Intrinsic::spv_bitcast)) {
         Register DstReg = MI.getOperand(0).getReg();
         Register SrcReg = MI.getOperand(2).getReg();
-        SPIRVType *DstType = GR->getSPIRVTypeForVReg(DstReg);
+        SPIRVTypeInst DstType = GR->getSPIRVTypeForVReg(DstReg);
         assert(
             DstType &&
             "Expected destination SPIR-V type to have been assigned already.");
-        SPIRVType *SrcType = GR->getSPIRVTypeForVReg(SrcReg);
+        SPIRVTypeInst SrcType = GR->getSPIRVTypeForVReg(SrcReg);
         assert(SrcType &&
                "Expected source SPIR-V type to have been assigned already.");
         if (DstType == SrcType) {
@@ -261,7 +261,7 @@ static void insertBitcasts(MachineFunction &MF, SPIRVGlobalRegistry *GR,
           isa<FunctionType>(ElemTy)
               ? SPIRV::StorageClass::CodeSectionINTEL
               : addressSpaceToStorageClass(MI.getOperand(4).getImm(), *ST);
-      SPIRVType *AssignedPtrType =
+      SPIRVTypeInst AssignedPtrType =
           GR->getOrCreateSPIRVPointerType(ElemTy, MI, SC);
 
       // If the ptrcast would be redundant, replace all uses with the source
@@ -299,10 +299,11 @@ static void insertBitcasts(MachineFunction &MF, SPIRVGlobalRegistry *GR,
 //
 // Set SPIRVType for GV, propagate it from GV to other instructions,
 // also set register classes.
-static SPIRVType *propagateSPIRVType(MachineInstr *MI, SPIRVGlobalRegistry *GR,
-                                     MachineRegisterInfo &MRI,
-                                     MachineIRBuilder &MIB) {
-  SPIRVType *SpvType = nullptr;
+static SPIRVTypeInst propagateSPIRVType(MachineInstr *MI,
+                                        SPIRVGlobalRegistry *GR,
+                                        MachineRegisterInfo &MRI,
+                                        MachineIRBuilder &MIB) {
+  SPIRVTypeInst SpvType = nullptr;
   assert(MI && "Machine instr is expected");
   if (MI->getOperand(0).isReg()) {
     Register Reg = MI->getOperand(0).getReg();
@@ -333,7 +334,8 @@ static SPIRVType *propagateSPIRVType(MachineInstr *MI, SPIRVGlobalRegistry *GR,
         if (MI->getOperand(1).isReg()) {
           if (MachineInstr *DefInstr =
                   MRI.getVRegDef(MI->getOperand(1).getReg())) {
-            if (SPIRVType *Def = propagateSPIRVType(DefInstr, GR, MRI, MIB)) {
+            if (SPIRVTypeInst Def =
+                    propagateSPIRVType(DefInstr, GR, MRI, MIB)) {
               unsigned CurrentBW = GR->getScalarOrVectorBitWidth(Def);
               unsigned ExpectedBW =
                   std::max(MRI.getType(Reg).getScalarSizeInBits(), CurrentBW);
@@ -428,7 +430,7 @@ static void setInsertPtAfterDef(MachineIRBuilder &MIB, MachineInstr *Def) {
 }
 
 namespace llvm {
-void updateRegType(Register Reg, Type *Ty, SPIRVType *SpvType,
+void updateRegType(Register Reg, Type *Ty, SPIRVTypeInst SpvType,
                    SPIRVGlobalRegistry *GR, MachineIRBuilder &MIB,
                    MachineRegisterInfo &MRI) {
   assert((Ty || SpvType) && "Either LLVM or SPIRV type is expected.");
@@ -446,13 +448,13 @@ void updateRegType(Register Reg, Type *Ty, SPIRVType *SpvType,
 
 void processInstr(MachineInstr &MI, MachineIRBuilder &MIB,
                   MachineRegisterInfo &MRI, SPIRVGlobalRegistry *GR,
-                  SPIRVType *KnownResType) {
+                  SPIRVTypeInst KnownResType) {
   MIB.setInsertPt(*MI.getParent(), MI.getIterator());
   for (auto &Op : MI.operands()) {
     if (!Op.isReg() || Op.isDef())
       continue;
     Register OpReg = Op.getReg();
-    SPIRVType *SpvType = GR->getSPIRVTypeForVReg(OpReg);
+    SPIRVTypeInst SpvType = GR->getSPIRVTypeForVReg(OpReg);
     if (!SpvType && KnownResType) {
       SpvType = KnownResType;
       GR->assignSPIRVTypeToVReg(KnownResType, OpReg, *MI.getMF());
@@ -508,7 +510,7 @@ generateAssignInstrs(MachineFunction &MF, SPIRVGlobalRegistry *GR,
         Register Reg = MI.getOperand(1).getReg();
         MIB.setInsertPt(*MI.getParent(), MI.getIterator());
         Type *ElementTy = getMDOperandAsType(MI.getOperand(2).getMetadata(), 0);
-        SPIRVType *AssignedPtrType = GR->getOrCreateSPIRVPointerType(
+        SPIRVTypeInst AssignedPtrType = GR->getOrCreateSPIRVPointerType(
             ElementTy, MI,
             addressSpaceToStorageClass(MI.getOperand(3).getImm(), *ST));
         MachineInstr *Def = MRI.getVRegDef(Reg);
@@ -552,7 +554,7 @@ generateAssignInstrs(MachineFunction &MF, SPIRVGlobalRegistry *GR,
         // %rc = G_CONSTANT ty Val
         // Ensure %rc has a valid SPIR-V type assigned in the Global Registry.
         Register Reg = MI.getOperand(0).getReg();
-        bool NeedAssignType = GR->getSPIRVTypeForVReg(Reg) == nullptr;
+        bool NeedAssignType = !GR->getSPIRVTypeForVReg(Reg);
         Type *Ty = nullptr;
         if (MIOp == TargetOpcode::G_CONSTANT) {
           auto TargetExtIt = TargetExtConstTypes.find(&MI);
@@ -594,7 +596,7 @@ generateAssignInstrs(MachineFunction &MF, SPIRVGlobalRegistry *GR,
           } else if (ElemMI->getOpcode() == TargetOpcode::G_FCONSTANT) {
             ElemTy = ElemMI->getOperand(1).getFPImm()->getType();
           } else {
-            if (const SPIRVType *ElemSpvType =
+            if (SPIRVTypeInst ElemSpvType =
                     GR->getSPIRVTypeForVReg(MI.getOperand(1).getReg(), &MF))
               ElemTy = const_cast<Type *>(GR->getTypeForSPIRVType(ElemSpvType));
           }
@@ -707,14 +709,14 @@ insertInlineAsmProcess(MachineFunction &MF, SPIRVGlobalRegistry *GR,
     // create types
     const MDNode *IAMD = I1->getOperand(1).getMetadata();
     FunctionType *FTy = cast<FunctionType>(getMDOperandAsType(IAMD, 0));
-    SmallVector<SPIRVType *, 4> ArgTypes;
+    SmallVector<SPIRVTypeInst, 4> ArgTypes;
     for (const auto &ArgTy : FTy->params())
       ArgTypes.push_back(GR->getOrCreateSPIRVType(
           ArgTy, MIRBuilder, SPIRV::AccessQualifier::ReadWrite, true));
-    SPIRVType *RetType =
+    SPIRVTypeInst RetType =
         GR->getOrCreateSPIRVType(FTy->getReturnType(), MIRBuilder,
                                  SPIRV::AccessQualifier::ReadWrite, true);
-    SPIRVType *FuncType = GR->getOrCreateOpTypeFunctionWithArgs(
+    SPIRVTypeInst FuncType = GR->getOrCreateOpTypeFunctionWithArgs(
         FTy, RetType, ArgTypes, MIRBuilder);
 
     // define vendor specific assembly instructions string
@@ -745,7 +747,7 @@ insertInlineAsmProcess(MachineFunction &MF, SPIRVGlobalRegistry *GR,
     if (!DefReg.isValid()) {
       DefReg = MRI.createGenericVirtualRegister(LLT::scalar(32));
       MRI.setRegClass(DefReg, &SPIRV::iIDRegClass);
-      SPIRVType *VoidType = GR->getOrCreateSPIRVType(
+      SPIRVTypeInst VoidType = GR->getOrCreateSPIRVType(
           Type::getVoidTy(MF.getFunction().getContext()), MIRBuilder,
           SPIRV::AccessQualifier::ReadWrite, true);
       GR->assignSPIRVTypeToVReg(VoidType, DefReg, MF);


### PR DESCRIPTION
Second part of https://github.com/llvm/llvm-project/pull/179947 where we use `SPIRVTypeInst` as much as we can.