### PR TITLE
[clang][bytecode] Only reject function types in Pointer::toRValue()

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -938,8 +938,7 @@ std::optional<APValue> Pointer::toRValue(const Context &Ctx,
   };
 
   // Can't return functions as rvalues.
-  if (ResultType->isFunctionType() || ResultType->isFunctionPointerType() ||
-      ResultType->isFunctionReferenceType())
+  if (ResultType->isFunctionType())
     return std::nullopt;
 
   // Invalid to read from.


### PR DESCRIPTION
No test because I'm not sure how to reproduce this, but this patch fixes `CodeGen/ptrauth-qualifier-function.c`.

For function pointer types and function reference types, we use `Pointer`s these days, so we _can_ return them.