### PR TITLE
[AArch64][clang] Use DenseSet for target feature lookup (NFC)

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -15,6 +15,7 @@
 
 #include "OSTargets.h"
 #include "clang/Basic/TargetBuiltins.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/TargetParser/AArch64TargetParser.h"
 #include <optional>
 
@@ -53,6 +54,8 @@ static const unsigned ARM64AddrSpaceMap[] = {
     // as it is only enabled for Wasm targets.
     20, // wasm_funcref
 };
+
+using AArch64FeatureSet = llvm::SmallDenseSet<StringRef, 32>;
 
 class LLVM_LIBRARY_VISIBILITY AArch64TargetInfo : public TargetInfo {
   static const TargetInfo::GCCRegAlias GCCRegAliases[];
@@ -142,6 +145,10 @@ class LLVM_LIBRARY_VISIBILITY AArch64TargetInfo : public TargetInfo {
   bool HasSME2p2 = false;
 
   const llvm::AArch64::ArchInfo *ArchInfo = &llvm::AArch64::ARMV8A;
+
+  AArch64FeatureSet HasFeatureLookup;
+
+  void computeFeatureLookup();
 
 protected:
   std::string ABI;


### PR DESCRIPTION
This resolves a recent AArch64 compile-time regression triggered by #176755, which inadvertently grew the feature lookup `StringSwitch` too large. This patch replaces the `StringSwitch` with a `DenseSet` of target features. This is built with a new `FeatureLookupBuilder` helper, which allows reusing all the existing cases (to avoid unintentionally changing any of them). 

Compiler-time impact: https://llvm-compile-time-tracker.com/compare.php?from=c9753859d19b07315c5a9a493efaa4df18db84ab&to=cb0684b602d5c741ca99b22bb3bc5f902b7a5a7e&stat=instructions:u