### PR TITLE
Correcting sanitizer-ld test to expect `-lstdc++` or `-lc++`

### DIFF
--- a/clang/test/Driver/sanitizer-ld.c
+++ b/clang/test/Driver/sanitizer-ld.c
@@ -1400,4 +1400,6 @@
 // RUN:     --sysroot=%S/Inputs/basic_linux_tree \
 // RUN:   | FileCheck %s --check-prefix=CHECK-FUZZER-WITH-SHARED-ASAN-ORDER
 //
-// CHECK-FUZZER-WITH-SHARED-ASAN-ORDER: "{{.*}}libclang_rt.asan.so" "--whole-archive" "{{.*}}libclang_rt.fuzzer.a" "--no-whole-archive" "-lstdc++"
+// CHECK-FUZZER-WITH-SHARED-ASAN-ORDER: "{{.*}}libclang_rt.asan.so"
+// CHECK-FUZZER-WITH-SHARED-ASAN-ORDER-SAME: "--whole-archive" "{{.*}}libclang_rt.fuzzer.a" "--no-whole-archive"
+// CHECK-FUZZER-WITH-SHARED-ASAN-ORDER-SAME: "-l{{(std)?}}c++"


### PR DESCRIPTION
 #164842 introduced a new testcase which failed in the following test-builders:
 - [fuchsia-x86_64-linux](https://lab.llvm.org/buildbot/#/builders/11/builds/33349)
 - [llvm-clang-win-x-aarch](https://lab.llvm.org/buildbot/#/builders/193/builds/14309)
 - [llvm-clang-win-x-armv7l](https://lab.llvm.org/buildbot/#/builders/38/builds/7708)

 In these setups `-lc++` is expected instead of `-lstdc++`.