### PR TITLE
[lldb] replace usage of $(RM) in Makefile

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -730,7 +730,7 @@ clean::
 ifeq "$(findstring lldb-test-build.noindex, $(BUILDDIR))" ""
 	$(error Trying to invoke the clean rule, but not using the default build tree layout)
 else
-	$(RM) -r $(wildcard $(BUILDDIR)/*)
+	$(call RM_RF,$(wildcard $(BUILDDIR)/*))
 endif
 
 #----------------------------------------------------------------------

--- a/lldb/test/API/functionalities/disassembler-variables/Makefile
+++ b/lldb/test/API/functionalities/disassembler-variables/Makefile
@@ -27,6 +27,6 @@ all: $(ASM_OBJS) $(EXE)
 
 # Keeping things tidy.
 clean::
-	$(RM) -f $(ASM_OBJS) dummy_main.c
+	$(call RM_RF,$(ASM_OBJS) dummy_main.c)
 
 include Makefile.rules

--- a/lldb/test/API/functionalities/module_cache/bsd/Makefile
+++ b/lldb/test/API/functionalities/module_cache/bsd/Makefile
@@ -9,7 +9,7 @@ a.out: main.o libfoo.a
 
 lib_ab.a: a.o b.o
 	$(AR) $(ARFLAGS) $@ $^
-	$(RM) $^
+	$(call RM,$^)
 
 # Here we make a .a file that has two a.o files with different modification
 # times and different content by first creating libfoo.a with only a.o and b.o,
@@ -22,6 +22,6 @@ libfoo.a: lib_ab.a c.o
 	touch c.o
 	mv c.o a.o
 	$(AR) $(ARFLAGS) $@ lib_ab.a a.o
-	$(RM) a.o
+	$(call RM,a.o)
 
 include Makefile.rules

--- a/lldb/test/API/linux/sepdebugsymlink/Makefile
+++ b/lldb/test/API/linux/sepdebugsymlink/Makefile
@@ -3,13 +3,13 @@ C_SOURCES := main.c
 all: dirsymlink
 
 dirreal: a.out
-	$(RM) -r $@
+	$(call RM_RF,$@)
 	mkdir $@
 	$(OBJCOPY) --only-keep-debug $< $@/stripped.debug
 	$(OBJCOPY) --strip-all --add-gnu-debuglink=$@/stripped.debug $< $@/stripped.out
 
 dirsymlink: dirreal
-	$(RM) -r $@
+	$(call RM_RF,$@)
 	mkdir $@
 	ln -s ../$</stripped.out $@/stripped.symlink
 


### PR DESCRIPTION
This patch replaces the usages of `$(RM)` with cross platform `$(call RM,...)` calls which was added in https://github.com/llvm/llvm-project/pull/180224.