### PR TITLE
[MLIR] Make the verification order fixed in DynamicOpTraitList

### DIFF
--- a/mlir/include/mlir/IR/ExtensibleDialect.h
+++ b/mlir/include/mlir/IR/ExtensibleDialect.h
@@ -395,7 +395,7 @@ public:
   }
 
 private:
-  DenseMap<TypeID, std::unique_ptr<DynamicOpTrait>> traits;
+  llvm::MapVector<TypeID, std::unique_ptr<DynamicOpTrait>> traits;
 };
 
 template <template <typename T> class Trait>


### PR DESCRIPTION
Currently we use `DenseMap` in `DynamicOpTraitList` to store traits and iterate over the `DenseMap`, and we found that the order is not fixed and we also cannot control verification order.

In this PR we use `MapVector` to preserve the insertion order so that the verification order over traits can be fixed and users can tune the verification order.