### PR TITLE
[flang][docs] Correct time of Flang OpenMP call and add link to calendar

### DIFF
--- a/flang/docs/GettingInvolved.md
+++ b/flang/docs/GettingInvolved.md
@@ -52,7 +52,7 @@ Contributions to Flang are done using GitHub Pull Requests and follow the
 -   Join the [Flang Biweekly Call](https://lanl-us.webex.com/lanl-us/j.php?MTID=mdce13c9bd55202e8071d8128fb953614)
     - If you prefer to join using a meeting number and password, those can be
       found in this [Google Doc](https://docs.google.com/document/d/1Z2U5UAtJ-Dag5wlMaLaW1KRmNgENNAYynJqLW2j2AZQ/). Alternative methods of joining, such as call-in numbers, are also available there.
--   Time: Every other Wednesday, 8:30 a.m. Pacific Time
+-   Time: Every other Wednesday, 8:30 a.m. Pacific Time. Please check the [LLVM Community Calendar](https://calendar.google.com/calendar/u/0/embed?src=calendar@llvm.org) for the next scheduled call.
 -   Calendar invite: https://drive.google.com/file/d/1rkfWCtIvQFcxN0Uz8YVwQGoX_BbzT8oc/view?usp=drive_link
 -   Meeting minutes are available in this [Google Doc](https://docs.google.com/document/d/18DHhXjdzPQP20rmQiDsWbv1tHfqz8TjJiSPwI-wYbY8/edit).
 -   Minutes from older meetings were posted on the [Flang forum](https://discourse.llvm.org/c/subprojects/flang). Search for `Flang Biweekly Sync - Notes`.
@@ -68,7 +68,7 @@ Contributions to Flang are done using GitHub Pull Requests and follow the
 
 -   Development updates on OpenMP and OpenACC in the Flang Project.
 -   Join [OpenMP in Flang Technical Call](https://bit.ly/39eQW3o)
--   Time: Biweekly call on Thursdays 8:00 AM Pacific time.
+-   Time: Biweekly call on Thursdays 7:30 AM Pacific time. Please check the [LLVM Community Calendar](https://calendar.google.com/calendar/u/0/embed?src=calendar@llvm.org) for the next scheduled call.
 -   Meeting minutes are [here](https://docs.google.com/document/d/1yA-MeJf6RYY-ZXpdol0t7YoDoqtwAyBhFLr5thu5pFI).
 -   Status tracking [page](https://docs.google.com/spreadsheets/d/1FvHPuSkGbl4mQZRAwCIndvQx9dQboffiD-xD0oqxgU0/edit#gid=0).
 


### PR DESCRIPTION
The time in flang/docs/GettingInvolved.md says 8:00 a.m. Pacific, but the scheduled meeting occurs at 7:30 a.m. Pacific. A link to the LLVM community calendar was also added to both this and the entry for the main biweekly flang call since it is not clear when the calls actually happen.