### PR TITLE
[AMDGPU][SIInsertWaitcnts][NFC] Make Waitcnt members private

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -1447,7 +1447,7 @@ bool GCNHazardRecognizer::fixSMEMtoVectorWriteHazards(MachineInstr *MI) {
         const int64_t Imm = MI.getOperand(0).getImm();
         AMDGPU::Waitcnt Decoded = AMDGPU::decodeWaitcnt(IV, Imm);
         // DsCnt corresponds to LGKMCnt here.
-        return (Decoded.DsCnt == 0);
+        return (Decoded.get(AMDGPU::DS_CNT) == 0);
       }
       default:
         assert((!SIInstrInfo::isWaitcnt(MI.getOpcode()) ||

--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -1447,7 +1447,7 @@ bool GCNHazardRecognizer::fixSMEMtoVectorWriteHazards(MachineInstr *MI) {
         const int64_t Imm = MI.getOperand(0).getImm();
         AMDGPU::Waitcnt Decoded = AMDGPU::decodeWaitcnt(IV, Imm);
         // DsCnt corresponds to LGKMCnt here.
-        return (Decoded.get(AMDGPU::DS_CNT) == 0);
+        return Decoded.get(AMDGPU::DS_CNT) == 0;
       }
       default:
         assert((!SIInstrInfo::isWaitcnt(MI.getOpcode()) ||

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1853,9 +1853,9 @@ void decodeWaitcnt(const IsaVersion &Version, unsigned Waitcnt, unsigned &Vmcnt,
 
 Waitcnt decodeWaitcnt(const IsaVersion &Version, unsigned Encoded) {
   Waitcnt Decoded;
-  Decoded.LoadCnt = decodeVmcnt(Version, Encoded);
-  Decoded.ExpCnt = decodeExpcnt(Version, Encoded);
-  Decoded.DsCnt = decodeLgkmcnt(Version, Encoded);
+  Decoded.set(LOAD_CNT, decodeVmcnt(Version, Encoded));
+  Decoded.set(EXP_CNT, decodeExpcnt(Version, Encoded));
+  Decoded.set(DS_CNT, decodeLgkmcnt(Version, Encoded));
   return Decoded;
 }
 
@@ -1890,7 +1890,8 @@ unsigned encodeWaitcnt(const IsaVersion &Version, unsigned Vmcnt,
 }
 
 unsigned encodeWaitcnt(const IsaVersion &Version, const Waitcnt &Decoded) {
-  return encodeWaitcnt(Version, Decoded.LoadCnt, Decoded.ExpCnt, Decoded.DsCnt);
+  return encodeWaitcnt(Version, Decoded.get(LOAD_CNT), Decoded.get(EXP_CNT),
+                       Decoded.get(DS_CNT));
 }
 
 static unsigned getCombinedCountBitMask(const IsaVersion &Version,
@@ -1909,21 +1910,21 @@ static unsigned getCombinedCountBitMask(const IsaVersion &Version,
 
 Waitcnt decodeLoadcntDscnt(const IsaVersion &Version, unsigned LoadcntDscnt) {
   Waitcnt Decoded;
-  Decoded.LoadCnt =
-      unpackBits(LoadcntDscnt, getLoadcntStorecntBitShift(Version.Major),
-                 getLoadcntBitWidth(Version.Major));
-  Decoded.DsCnt = unpackBits(LoadcntDscnt, getDscntBitShift(Version.Major),
-                             getDscntBitWidth(Version.Major));
+  Decoded.set(LOAD_CNT, unpackBits(LoadcntDscnt,
+                                   getLoadcntStorecntBitShift(Version.Major),
+                                   getLoadcntBitWidth(Version.Major)));
+  Decoded.set(DS_CNT, unpackBits(LoadcntDscnt, getDscntBitShift(Version.Major),
+                                 getDscntBitWidth(Version.Major)));
   return Decoded;
 }
 
 Waitcnt decodeStorecntDscnt(const IsaVersion &Version, unsigned StorecntDscnt) {
   Waitcnt Decoded;
-  Decoded.StoreCnt =
-      unpackBits(StorecntDscnt, getLoadcntStorecntBitShift(Version.Major),
-                 getStorecntBitWidth(Version.Major));
-  Decoded.DsCnt = unpackBits(StorecntDscnt, getDscntBitShift(Version.Major),
-                             getDscntBitWidth(Version.Major));
+  Decoded.set(STORE_CNT, unpackBits(StorecntDscnt,
+                                    getLoadcntStorecntBitShift(Version.Major),
+                                    getStorecntBitWidth(Version.Major)));
+  Decoded.set(DS_CNT, unpackBits(StorecntDscnt, getDscntBitShift(Version.Major),
+                                 getDscntBitWidth(Version.Major)));
   return Decoded;
 }
 
@@ -1954,7 +1955,8 @@ static unsigned encodeLoadcntDscnt(const IsaVersion &Version, unsigned Loadcnt,
 }
 
 unsigned encodeLoadcntDscnt(const IsaVersion &Version, const Waitcnt &Decoded) {
-  return encodeLoadcntDscnt(Version, Decoded.LoadCnt, Decoded.DsCnt);
+  return encodeLoadcntDscnt(Version, Decoded.get(LOAD_CNT),
+                            Decoded.get(DS_CNT));
 }
 
 static unsigned encodeStorecntDscnt(const IsaVersion &Version,
@@ -1967,7 +1969,8 @@ static unsigned encodeStorecntDscnt(const IsaVersion &Version,
 
 unsigned encodeStorecntDscnt(const IsaVersion &Version,
                              const Waitcnt &Decoded) {
-  return encodeStorecntDscnt(Version, Decoded.StoreCnt, Decoded.DsCnt);
+  return encodeStorecntDscnt(Version, Decoded.get(STORE_CNT),
+                             Decoded.get(DS_CNT));
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -1111,7 +1111,7 @@ namespace AMDGPU {
 ///
 /// Large values (including the maximum possible integer) can be used to
 /// represent "don't care" waits.
-struct Waitcnt {
+class Waitcnt {
   unsigned LoadCnt = ~0u; // Corresponds to Vmcnt prior to gfx12.
   unsigned ExpCnt = ~0u;
   unsigned DsCnt = ~0u;     // Corresponds to LGKMcnt prior to gfx12.
@@ -1123,6 +1123,7 @@ struct Waitcnt {
   unsigned VaVdst = ~0u;    // gfx12+ expert scheduling mode only.
   unsigned VmVsrc = ~0u;    // gfx12+ expert scheduling mode only.
 
+public:
   unsigned get(InstCounterType T) const {
     switch (T) {
     case LOAD_CNT:


### PR DESCRIPTION
This patch makes Waitcnt member variables private and replaces their accesses with calls to set() or get(). This will help us change the implementation to an a array in the followup patch.