### PR TITLE
[AIX] [PowerPC] Auto-enable modern-aix-as feature by default with integrated assembler.

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/PPC.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/PPC.cpp
@@ -76,6 +76,13 @@ void ppc::getPPCTargetFeatures(const Driver &D, const llvm::Triple &Triple,
       !(Triple.isOSAIX() && Triple.isArch64Bit()))
     D.Diag(diag::err_opt_not_valid_on_target)
         << "-maix-shared-lib-tls-model-opt";
+
+  // The integrated assembler counts as a "modern AIX assembler" for the
+  // purposes of the modern-aix-as.
+  if (Args.hasFlag(options::OPT_fintegrated_as, options::OPT_fno_integrated_as,
+                   true) &&
+      Triple.isOSAIX())
+    Features.push_back("+modern-aix-as");
 }
 
 ppc::ReadGOTPtrMode ppc::getPPCReadGOTPtrMode(const Driver &D, const llvm::Triple &Triple,

--- a/clang/test/Driver/aix-as.c
+++ b/clang/test/Driver/aix-as.c
@@ -94,3 +94,25 @@
 // CHECK-NOIAS: InstalledDir
 // CHECK-NOIAS: -no-integrated-as
 // CHECK-NOIAS: "-a64"
+
+// Check that modern-aix-as feature is enabled with integrated assembler (default).
+// RUN: %clang %s -### -c 2>&1 \
+// RUN:         --target=powerpc-ibm-aix7.1.0.0 \
+// RUN:   | FileCheck --check-prefixes=CHECK-MODERN-AS-ENABLED %s
+
+// RUN: %clang %s -### -c 2>&1 \
+// RUN:         --target=powerpc64-ibm-aix7.1.0.0 \
+// RUN:   | FileCheck --check-prefixes=CHECK-MODERN-AS-ENABLED %s
+
+// Check that modern-aix-as feature is enabled by default with explicit -fintegrated-as.
+// RUN: %clang %s -### -c -fintegrated-as 2>&1 \
+// RUN:         --target=powerpc-ibm-aix7.1.0.0 \
+// RUN:   | FileCheck --check-prefixes=CHECK-MODERN-AS-ENABLED %s
+
+// Check that modern-aix-as feature is not enabled with -fno-integrated-as.
+// RUN: %clang %s -### -c -fno-integrated-as 2>&1 \
+// RUN:         --target=powerpc-ibm-aix7.1.0.0 \
+// RUN:   | FileCheck --check-prefixes=CHECK-MODERN-AS-DISABLED %s
+
+// CHECK-MODERN-AS-ENABLED: "-target-feature" "+modern-aix-as"
+// CHECK-MODERN-AS-DISABLED-NOT: "+modern-aix-as"


### PR DESCRIPTION
**Issue**:
Certain instruction aliases (e.g. `mfsprg`) defined in PowerPC tablegen as InstAlias are gated behind the ModernAs predicate as InstAlias.

Without the `+modern-aix-as` target feature enabled, the `ModernAs` predicate is not satisfied and these instructions aliases are unavailable. This caused assembly failures on AIX unless user manually specify below options.
   `-Xclang -target-feature -Xclang +modern-aix-as`

**Solution**:
Automatically enable the` +modern-aix-as` target feature when:
 - The target triple is AIX.
 - The integrated assembler is being used (default or -`fintegrated-as`).

This feature is not enabled when `-fno-integrated-as` is specified.