### PR TITLE
[lldb-dap][windows] add --check-python command

### DIFF
--- a/lldb/include/lldb/Host/windows/PythonPathSetup/PythonPathSetup.h
+++ b/lldb/include/lldb/Host/windows/PythonPathSetup/PythonPathSetup.h
@@ -42,6 +42,11 @@ bool AddPythonDLLToSearchPath();
 ///   can be loaded. If successful, returns immediately. Otherwise, attempts to
 ///   resolve the relative path and add it to the DLL search path, then checks
 ///   again if python3xx.dll can be loaded.
-llvm::Error SetupPythonRuntimeLibrary();
+///
+/// \return If LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME is defined, return the
+/// absolute path of the Python shared library which was resolved or an error if
+/// it could not be found. If LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME and
+/// LLDB_PYTHON_DLL_RELATIVE_PATH are not defined, return an empty string.
+llvm::Expected<std::string> SetupPythonRuntimeLibrary();
 
 #endif // LLDB_SOURCE_HOST_PYTHONPATHSETUP_H

--- a/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
+++ b/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
@@ -20,7 +20,7 @@
 using namespace llvm;
 
 #ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
-static std::wstring GetModulePathW(HMODULE module) {
+static std::string GetModulePath(HMODULE module) {
   std::vector<WCHAR> buffer(MAX_PATH);
   while (buffer.size() <= PATHCCH_MAX_CCH) {
     DWORD len = GetModuleFileNameW(module, buffer.data(), buffer.size());
@@ -39,7 +39,7 @@ static std::wstring GetModulePathW(HMODULE module) {
 }
 
 /// Returns the full path to the lldb.exe executable.
-static std::wstring GetPathToExecutableW() { return GetModulePathW(NULL); }
+static std::string GetPathToExecutable() { return GetModulePath(NULL); }
 
 bool AddPythonDLLToSearchPath() {
   std::string path_str = GetPathToExecutable();
@@ -69,13 +69,10 @@ std::optional<std::string> GetPythonDLLPath() {
   if (!h)
     return std::nullopt;
 
-  std::wstring path = GetModulePathW(h);
+  std::string path = GetModulePath(h);
   FreeLibrary(h);
 
-  std::string utf8_path;
-  if (!convertWideToUTF8(path, utf8_path))
-    return std::nullopt;
-  return utf8_path;
+  return path;
 #undef WIDEN2
 #undef WIDEN
 }

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -737,8 +737,10 @@ int main(int argc, char const *argv[]) {
 #endif
 
 #ifdef _WIN32
-  if (llvm::Error error = SetupPythonRuntimeLibrary())
-    llvm::WithColor::error() << llvm::toString(std::move(error)) << '\n';
+  auto python_path_or_err = SetupPythonRuntimeLibrary();
+  if (!python_path_or_err)
+    llvm::WithColor::error()
+        << llvm::toString(python_path_or_err.takeError()) << '\n';
 #endif
 
   // Parse arguments.

--- a/lldb/tools/lldb-dap/tool/Options.td
+++ b/lldb/tools/lldb-dap/tool/Options.td
@@ -17,6 +17,10 @@ def: Flag<["-"], "v">,
   Alias<version>,
   HelpText<"Alias for --version">;
 
+def check_python : F<"check-python">,
+                   HelpText<"Prints the path to the resolved Python DLL. 0 if "
+                            "Python was not resolved (windows only).">;
+
 def wait_for_debugger: F<"wait-for-debugger">,
   HelpText<"Pause the program at startup.">;
 def: Flag<["-"], "g">,

--- a/lldb/tools/lldb-dap/tool/Options.td
+++ b/lldb/tools/lldb-dap/tool/Options.td
@@ -18,8 +18,8 @@ def: Flag<["-"], "v">,
   HelpText<"Alias for --version">;
 
 def check_python : F<"check-python">,
-                   HelpText<"Prints the path to the resolved Python DLL. 0 if "
-                            "Python was not resolved (windows only).">;
+                   HelpText<"Prints the path to the resolved Python DLL. "
+                            "(Windows only).">;
 
 def wait_for_debugger: F<"wait-for-debugger">,
   HelpText<"Pause the program at startup.">;

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -542,6 +542,7 @@ int main(int argc, char *argv[]) {
     return EXIT_SUCCESS;
   }
 
+#ifdef _WIN32
   if (input_args.hasArg(OPT_check_python)) {
     auto python_path_or_err = SetupPythonRuntimeLibrary();
     if (!python_path_or_err) {
@@ -553,7 +554,6 @@ int main(int argc, char *argv[]) {
     return EXIT_SUCCESS;
   }
 
-#ifdef _WIN32
   auto python_path_or_err = SetupPythonRuntimeLibrary();
   if (!python_path_or_err)
     llvm::WithColor::error()

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -523,11 +523,6 @@ int main(int argc, char *argv[]) {
                         "~/Library/Logs/DiagnosticReports/.\n");
 #endif
 
-#ifdef _WIN32
-  if (llvm::Error error = SetupPythonRuntimeLibrary())
-    llvm::WithColor::error() << llvm::toString(std::move(error)) << '\n';
-#endif
-
   llvm::SmallString<256> program_path(argv[0]);
   llvm::sys::fs::make_absolute(program_path);
   DAP::debug_adapter_path = program_path;
@@ -546,6 +541,24 @@ int main(int argc, char *argv[]) {
     PrintVersion();
     return EXIT_SUCCESS;
   }
+
+  if (input_args.hasArg(OPT_check_python)) {
+    auto python_path_or_err = SetupPythonRuntimeLibrary();
+    if (!python_path_or_err) {
+      llvm::WithColor::error()
+          << llvm::toString(python_path_or_err.takeError()) << '\n';
+      return EXIT_FAILURE;
+    }
+    llvm::outs() << *python_path_or_err << '\n';
+    return EXIT_SUCCESS;
+  }
+
+#ifdef _WIN32
+  auto python_path_or_err = SetupPythonRuntimeLibrary();
+  if (!python_path_or_err)
+    llvm::WithColor::error()
+        << llvm::toString(python_path_or_err.takeError()) << '\n';
+#endif
 
   if (input_args.hasArg(OPT_client)) {
     if (llvm::Error error = LaunchClient(input_args)) {

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -550,7 +550,13 @@ int main(int argc, char *argv[]) {
           << llvm::toString(python_path_or_err.takeError()) << '\n';
       return EXIT_FAILURE;
     }
-    llvm::outs() << *python_path_or_err << '\n';
+    std::string python_path = *python_path_or_err;
+    if (python_path.empty()) {
+      llvm::WithColor::error()
+          << "unable to look for the Python shared library" << '\n';
+      return EXIT_FAILURE;
+    }
+    llvm::outs() << python_path << '\n';
     return EXIT_SUCCESS;
   }
 


### PR DESCRIPTION
Implement [`[RFC] Add a Python check command to lldb-dap and lldb`](https://discourse.llvm.org/t/rfc-add-a-python-check-command-to-lldb-dap-and-lldb/88972).

This patch adds the `--check-python` flag to `lldb-dap` on Windows, to allow dap clients to verify the correct Python version is available before trying to start `lldb-dap`.

Depends on:
- https://github.com/llvm/llvm-project/pull/180786

rdar://165442474