### PR TITLE
[ADT][NFC] Remove `else` after `return` in APSInt.h

### DIFF
--- a/llvm/include/llvm/ADT/APSInt.h
+++ b/llvm/include/llvm/ADT/APSInt.h
@@ -113,15 +113,13 @@ public:
   APSInt extend(uint32_t width) const {
     if (IsUnsigned)
       return APSInt(zext(width), IsUnsigned);
-    else
-      return APSInt(sext(width), IsUnsigned);
+    return APSInt(sext(width), IsUnsigned);
   }
 
   APSInt extOrTrunc(uint32_t width) const {
     if (IsUnsigned)
       return APSInt(zextOrTrunc(width), IsUnsigned);
-    else
-      return APSInt(sextOrTrunc(width), IsUnsigned);
+    return APSInt(sextOrTrunc(width), IsUnsigned);
   }
 
   const APSInt &operator%=(const APSInt &RHS) {


### PR DESCRIPTION
Align with the LLVM coding standard:
* https://llvm.org/docs/CodingStandards.html#don-t-use-else-after-a-return
