### PR TITLE
[analyzer][Z3][NFCI] Simplify getExpr* functions by taking a RetTy reference

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SMTConstraintManager.h
@@ -53,7 +53,7 @@ public:
     bool hasComparison;
 
     llvm::SMTExprRef Exp =
-        SMTConv::getExpr(Solver, Ctx, Sym, &RetTy, &hasComparison);
+        SMTConv::getExpr(Solver, Ctx, Sym, RetTy, &hasComparison);
 
     // Create zero comparison for implicit boolean cast, with reversed
     // assumption
@@ -89,7 +89,7 @@ public:
 
     QualType RetTy;
     // The expression may be casted, so we cannot call getZ3DataExpr() directly
-    llvm::SMTExprRef VarExp = SMTConv::getExpr(Solver, Ctx, Sym, &RetTy);
+    llvm::SMTExprRef VarExp = SMTConv::getExpr(Solver, Ctx, Sym, RetTy);
     llvm::SMTExprRef Exp =
         SMTConv::getZeroExpr(Solver, Ctx, VarExp, RetTy, /*Assumption=*/true);
 


### PR DESCRIPTION
Let me start by: This is some ancient code and was never really uphold to the greatest quality standards.

It turns out the `RetTy` was almost always provided, and in the cases when it wasn't, we could just pass a dummy and discard the result.

Probably the APIs could be refactored, but I decided not to. The code mostly works, let's not stir up the mud.

Addresses https://github.com/llvm/llvm-project/pull/168034#discussion_r2785236941