### PR TITLE
[clang-tidy] Fix `performance-unnecessary-value-param` FN when passing `std::function` rvalue into `std::map::try_emplace`

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.h
+++ b/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.h
@@ -61,6 +61,11 @@ bool isCopyConstructorArgument(const DeclRefExpr &DeclRef, const Decl &Decl,
 bool isCopyAssignmentArgument(const DeclRefExpr &DeclRef, const Decl &Decl,
                               ASTContext &Context);
 
+/// Returns ``true`` if ``DeclRefExpr`` is perfectly forwarded to a call
+/// expression within ``Decl``.
+bool isPerfectlyForwardedArgument(const DeclRefExpr &DeclRef, const Decl &Decl,
+                                  ASTContext &Context);
+
 } // namespace clang::tidy::utils::decl_ref_expr
 
 #endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_UTILS_DECLREFEXPRUTILS_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -172,6 +172,10 @@ Changes in existing checks
   <clang-tidy/checks/performance/move-const-arg>` check by avoiding false
   positives on trivially copyable types with a non-public copy constructor.
 
+- Improved :doc:`performance-unnecessary-value-param
+  <clang-tidy/checks/performance/unnecessary-value-param>` check to suggest
+  moving arguments that are passed to perfectly forwarding parameters.
+
 - Improved :doc:`readability-enum-initial-value
   <clang-tidy/checks/readability/enum-initial-value>` check: the warning message
   now uses separate note diagnostics for each uninitialized enumerator, making

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
@@ -32,7 +32,7 @@ Example:
     ExpensiveToCopy Copy(Value);
   }
 
-If the parameter is not const, and only copied or assigned once, the check will
+If the parameter is not ``const``, and only copied or assigned once, the check will
 suggest a move in the following scenarios:
 
 1. the parameter has a non-trivial move-constructor or move-assignment operator

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
@@ -32,8 +32,8 @@ Example:
     ExpensiveToCopy Copy(Value);
   }
 
-If the parameter is not ``const``, and only copied or assigned once, the check will
-suggest a move in the following scenarios:
+If the parameter is not ``const``, and only copied or assigned once, the check
+will suggest a move in the following scenarios:
 
 1. the parameter has a non-trivial move-constructor or move-assignment operator
    respectively;

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
@@ -32,9 +32,12 @@ Example:
     ExpensiveToCopy Copy(Value);
   }
 
-If the parameter is not const, only copied or assigned once and has a
-non-trivial move-constructor or move-assignment operator respectively the check
-will suggest to move it.
+If the parameter is not const, and only copied or assigned once, the check will
+suggest a move in the following scenarios:
+
+1. the parameter has a non-trivial move-constructor or move-assignment operator
+   respectively;
+2. the parameter is passed to a function accepting it as a universal reference.
 
 Example:
 
@@ -52,6 +55,34 @@ Will become:
 
   void setValue(string Value) {
     Field = std::move(Value);
+  }
+
+Example:
+
+.. code-block:: c++
+
+  template <typename T>
+  void setValue(T &&Value) {
+    Field = std::forward<T>(Value);
+  }
+
+  void bar(string Value) {
+    setValue(Value);
+  }
+
+Will become:
+
+.. code-block:: c++
+
+  #include <utility>
+
+  template <typename T>
+  void setValue(T &&Value) {
+    Field = std::forward<T>(Value);
+  }
+
+  void bar(string Value) {
+    setValue(std::move(Value);
   }
 
 Because the fix-it needs to change the signature of the function, it may break

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
@@ -82,7 +82,7 @@ Will become:
   }
 
   void bar(string Value) {
-    setValue(std::move(Value);
+    setValue(std::move(Value));
   }
 
 Because the fix-it needs to change the signature of the function, it may break


### PR DESCRIPTION
Add a check for handling a move fix when the argument is trivially movable and perfectly forwarded.
Add a `utils::decl_ref_expr::isPerfectlyForwardedArgument`.
Add a `PositiveMoveOnPassAsUniversalReference` test.

Fix #179090