### PR TITLE
[ORC] Make RedirectionManager::redirect asynchronous

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/IndirectionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/IndirectionUtils.h
@@ -308,7 +308,8 @@ public:
   virtual Error updatePointer(StringRef Name, ExecutorAddr NewAddr) = 0;
 
   /// --- RedirectableSymbolManager implementation ---
-  Error redirect(JITDylib &JD, const SymbolMap &NewDests) override;
+  void redirect(JITDylib &JD, SymbolMap NewDests,
+                unique_function<void(Error)> OnComplete) override;
 
   void
   emitRedirectableSymbols(std::unique_ptr<MaterializationResponsibility> MR,

--- a/llvm/include/llvm/ExecutionEngine/Orc/JITLinkRedirectableSymbolManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/JITLinkRedirectableSymbolManager.h
@@ -54,7 +54,8 @@ public:
   void emitRedirectableSymbols(std::unique_ptr<MaterializationResponsibility> R,
                                SymbolMap InitialDests) override;
 
-  Error redirect(JITDylib &JD, const SymbolMap &NewDests) override;
+  void redirect(JITDylib &JD, SymbolMap NewDests,
+                unique_function<void(Error)> OnComplete) override;
 
 private:
   ObjectLinkingLayer &ObjLinkingLayer;

--- a/llvm/include/llvm/ExecutionEngine/Orc/RedirectionManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/RedirectionManager.h
@@ -27,7 +27,11 @@ public:
 
   /// Change the redirection destination of given symbols to new destination
   /// symbols.
-  virtual Error redirect(JITDylib &JD, const SymbolMap &NewDests) = 0;
+  virtual void redirect(JITDylib &JD, SymbolMap NewDests,
+                        unique_function<void(Error)> OnComplete) = 0;
+
+  /// Blocking version of redirect.
+  Error redirect(JITDylib &JD, SymbolMap NewDests);
 
   /// Change the redirection destination of given symbol to new destination
   /// symbol.

--- a/llvm/lib/ExecutionEngine/Orc/IndirectionUtils.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/IndirectionUtils.cpp
@@ -112,11 +112,12 @@ JITCompileCallbackManager::executeCompileCallback(ExecutorAddr TrampolineAddr) {
   }
 }
 
-Error IndirectStubsManager::redirect(JITDylib &JD, const SymbolMap &NewDests) {
+void IndirectStubsManager::redirect(JITDylib &JD, SymbolMap NewDests,
+                                    unique_function<void(Error)> OnComplete) {
   for (auto &[Name, Dest] : NewDests)
     if (auto Err = updatePointer(*Name, Dest.getAddress()))
-      return Err;
-  return Error::success();
+      return OnComplete(std::move(Err));
+  OnComplete(Error::success());
 }
 
 void IndirectStubsManager::emitRedirectableSymbols(

--- a/llvm/lib/ExecutionEngine/Orc/RedirectionManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/RedirectionManager.cpp
@@ -13,6 +13,14 @@
 using namespace llvm;
 using namespace llvm::orc;
 
+Error RedirectionManager::redirect(JITDylib &JD, SymbolMap NewDests) {
+  std::promise<MSVCPError> P;
+  redirect(JD, std::move(NewDests),
+           [&P](Error E) { P.set_value(std::move(E)); });
+  auto F = P.get_future();
+  return F.get();
+}
+
 void RedirectionManager::anchor() {}
 
 Error RedirectableSymbolManager::createRedirectableSymbols(


### PR DESCRIPTION
Adds an OnComplete argument to RedirectionManager::redirect, so implementations can call the non-blocking version of ExecutionSession::lookup.  The old signature is implemented as a wrapper around the asynchronous version that creates a promise and waits on it.

This change also updates LazyReexportsManager::resolve to use the asynchronous redirect.

CC: @lhames, @vtjnash 
(We'd like to use this in Julia, and can't use the version of `LazyReexportsManager::resolve` that blocks.)