### PR TITLE
[libc] Fix unit test dependency and respect LIBC_INCLUDE_BENCHMARKS

### DIFF
--- a/libc/benchmarks/CMakeLists.txt
+++ b/libc/benchmarks/CMakeLists.txt
@@ -1,10 +1,10 @@
-if(LIBC_TARGET_OS_IS_GPU)
-  add_subdirectory(gpu)
+# The CPU build depends on Google benchmark.
+if(NOT LIBC_INCLUDE_BENCHMARKS)
   return()
 endif()
 
-# The CPU build depends on Google benchmark.
-if(NOT LIBC_INCLUDE_BENCHMARKS)
+if(LIBC_TARGET_OS_IS_GPU)
+  add_subdirectory(gpu)
   return()
 endif()
 

--- a/libc/benchmarks/gpu/CMakeLists.txt
+++ b/libc/benchmarks/gpu/CMakeLists.txt
@@ -33,7 +33,49 @@ function(add_benchmark benchmark_name)
   add_dependencies(gpu-benchmark ${fq_target_name})
 endfunction(add_benchmark)
 
-add_unittest_framework_library(
+function(add_benchmark_framework_library name)
+  cmake_parse_arguments(
+    "TEST_LIB"
+    "" # No optional arguments
+    "" # No single value arguments
+    "SRCS;HDRS;DEPENDS" # Multi value arguments
+    ${ARGN}
+  )
+  if(NOT TEST_LIB_SRCS)
+    message(FATAL_ERROR "'add_benchmark_framework_library' requires SRCS; for "
+                        "header only libraries, use 'add_header_library'")
+  endif()
+
+  foreach(lib IN ITEMS ${name}.hermetic)
+    add_library(
+      ${lib}
+      STATIC
+      EXCLUDE_FROM_ALL
+      ${TEST_LIB_SRCS}
+      ${TEST_LIB_HDRS}
+    )
+    target_include_directories(${lib} PRIVATE ${LIBC_SOURCE_DIR})
+    if(TARGET libc.src.time.clock)
+      target_compile_definitions(${lib} PRIVATE TARGET_SUPPORTS_CLOCK)
+    endif()
+  endforeach()
+
+  _get_hermetic_test_compile_options(compile_options "")
+  target_include_directories(${name}.hermetic PRIVATE ${LIBC_INCLUDE_DIR})
+  target_compile_options(${name}.hermetic PRIVATE ${compile_options} -nostdinc++)
+
+  if(TEST_LIB_DEPENDS)
+    foreach(dep IN ITEMS ${TEST_LIB_DEPENDS})
+      if(TARGET ${dep}.hermetic)
+        add_dependencies(${name}.hermetic ${dep}.hermetic)
+      else()
+        add_dependencies(${name}.hermetic ${dep})
+      endif()
+    endforeach()
+  endif()
+endfunction()
+
+add_benchmark_framework_library(
   LibcGpuBenchmark
   SRCS
     LibcGpuBenchmark.cpp


### PR DESCRIPTION
Summary:
The unittest framework function is defined in another CMake file which
may not be present if the uesr disabled tests, provide a smaller version
here to keep this private. Also respesct the LIBC_INCLUDE_BENCHMARKS
variable.
