### PR TITLE
[SystemZ] Handle indirect symbols

### DIFF
--- a/llvm/include/llvm/MC/MCGOFFAttributes.h
+++ b/llvm/include/llvm/MC/MCGOFFAttributes.h
@@ -82,6 +82,7 @@ struct PRAttr {
 
 // Attributes for ER symbols.
 struct ERAttr {
+  bool IsIndirectReference = false;
   GOFF::ESDExecutable Executable = GOFF::ESD_EXE_Unspecified;
   GOFF::ESDBindingStrength BindingStrength = GOFF::ESD_BST_Strong;
   GOFF::ESDLinkageType Linkage = GOFF::ESD_LT_XPLink;

--- a/llvm/lib/MC/GOFFObjectWriter.cpp
+++ b/llvm/lib/MC/GOFFObjectWriter.cpp
@@ -278,6 +278,7 @@ public:
     BehavAttrs.setLinkageType(Attr.Linkage);
     BehavAttrs.setAmode(Attr.Amode);
     BehavAttrs.setBindingScope(Attr.BindingScope);
+    BehavAttrs.setIndirectReference(Attr.IsIndirectReference);
   }
 };
 
@@ -358,10 +359,11 @@ void GOFFWriter::defineLabel(const MCSymbolGOFF &Symbol) {
 }
 
 void GOFFWriter::defineExtern(const MCSymbolGOFF &Symbol) {
-  GOFFSymbol ER(Symbol.getName(), Symbol.getIndex(), RootSD->getOrdinal(),
-                GOFF::ERAttr{Symbol.getCodeData(), Symbol.getBindingStrength(),
-                             Symbol.getLinkage(), GOFF::ESD_AMODE_64,
-                             Symbol.getBindingScope()});
+  GOFFSymbol ER(Symbol.getNameInObjectFile(), Symbol.getIndex(),
+                RootSD->getOrdinal(),
+                GOFF::ERAttr{Symbol.isIndirect(), Symbol.getCodeData(),
+                             Symbol.getBindingStrength(), Symbol.getLinkage(),
+                             GOFF::ESD_AMODE_64, Symbol.getBindingScope()});
   writeSymbol(ER);
 }
 

--- a/llvm/lib/MC/MCSymbolGOFF.cpp
+++ b/llvm/lib/MC/MCSymbolGOFF.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/MC/MCSymbolGOFF.h"
 #include "llvm/BinaryFormat/GOFF.h"
+#include "llvm/MC/MCContext.h"
 #include "llvm/Support/ErrorHandling.h"
 
 using namespace llvm;
@@ -66,4 +67,18 @@ bool MCSymbolGOFF::setSymbolAttribute(MCSymbolAttr Attribute) {
   }
 
   return true;
+}
+
+MCSymbolGOFF *MCSymbolGOFF::getOrCreateIndirectSymbol(MCContext &Ctx) {
+  if (IndirectSym)
+    return IndirectSym;
+
+  IndirectSym = static_cast<MCSymbolGOFF *>(
+      Ctx.getOrCreateSymbol(Twine(getName()).concat("@indirect")));
+  IndirectSym->setHidden(false);
+  IndirectSym->setCodeData(getCodeData());
+  IndirectSym->setExternal(isExternal());
+  IndirectSym->setExternalName(getName());
+  IndirectSym->setIndirect(true);
+  return IndirectSym;
 }

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
@@ -201,9 +201,25 @@ static void emitXATTR(raw_ostream &OS, StringRef Name, bool IsIndirectReference,
   OS << Name << " XATTR ";
   OS << Sep << "LINKAGE(" << (Linkage == GOFF::ESD_LT_OS ? "OS" : "XPLINK")
      << ")";
-  if (Executable != GOFF::ESD_EXE_Unspecified)
-    OS << Sep << "REFERENCE("
-       << (Executable == GOFF::ESD_EXE_CODE ? "CODE" : "DATA") << ")";
+
+  const bool NotUnspecified = (Executable != GOFF::ESD_EXE_Unspecified);
+  if (NotUnspecified || IsIndirectReference) {
+    OS << Sep << "REFERENCE(";
+    bool RequiresComma = false;
+
+    if (NotUnspecified) {
+      OS << (Executable == GOFF::ESD_EXE_CODE ? "CODE" : "DATA");
+      RequiresComma = true;
+    }
+
+    if (IsIndirectReference) {
+      if (RequiresComma)
+        OS << ",";
+      OS << "INDIRECT";
+    }
+
+    OS << ")";
+  }
   if (BindingScope != GOFF::ESD_BSC_Unspecified) {
     OS << Sep << "SCOPE(";
     switch (BindingScope) {

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1244,16 +1244,15 @@ void SystemZAsmPrinter::emitADASection() {
       EmittedBytes += PointerSize;
       break;
     case SystemZII::MO_ADA_INDIRECT_FUNC_DESC: {
-      MCSymbol *Alias = OutContext.createTempSymbol(
-          Twine(Sym->getName()).concat("@indirect"));
-      OutStreamer->emitAssignment(Alias,
-                                  MCSymbolRefExpr::create(Sym, OutContext));
-      OutStreamer->emitSymbolAttribute(Alias, MCSA_IndirectSymbol);
 
       EMIT_COMMENT("pointer to function descriptor");
+      MCSymbolGOFF *GOFFSym =
+          static_cast<llvm::MCSymbolGOFF *>(const_cast<llvm::MCSymbol *>(Sym));
       OutStreamer->emitValue(
-          MCSpecifierExpr::create(MCSymbolRefExpr::create(Alias, OutContext),
-                                  SystemZ::S_VCon, OutContext),
+          MCSpecifierExpr::create(
+              MCSymbolRefExpr::create(
+                  GOFFSym->getOrCreateIndirectSymbol(OutContext), OutContext),
+              SystemZ::S_VCon, OutContext),
           PointerSize);
       EmittedBytes += PointerSize;
       break;

--- a/llvm/test/CodeGen/SystemZ/zos-ada-relocations.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ada-relocations.ll
@@ -1,8 +1,9 @@
 ; Test the ADA section in the assembly output for all cases.
 ;
-; RUN: llc < %s -mtriple=s390x-ibm-zos | FileCheck %s
+; RUN: llc < %s -mtriple=s390x-ibm-zos -emit-gnuas-syntax-on-zos=false | \
+; RUN: FileCheck %s
 
-; CHECK-LABEL: DoIt:
+; CHECK-LABEL: DoIt
 ; CHECK:    stmg    6,7,1840(4)
 ; CHECK:    aghi    4,-224
 ; CHECK:    lg  1,0(5)
@@ -25,7 +26,7 @@ entry:
 declare void @DoFunc()
 declare void @Caller(ptr noundef)
 
-; CHECK-LABEL: get_i:
+; CHECK-LABEL: get_i
 ; CHECK:    stmg    6,8,1872(4)
 ; CHECK:    aghi    4,-192
 ; CHECK:    lg  1,24(5)
@@ -56,14 +57,21 @@ entry:
 declare signext i32 @callout(i32 signext)
 
 ; CHECK: stdin#C CSECT
-; CHECK: C_WSA64 CATTR ALIGN(4),FILL(0),DEFLOAD,NOTEXECUTABLE,RMODE(64),PART(stdin#S)
+; CHECK: C_WSA64 CATTR ALIGN(4),FILL(0),DEFLOAD,NOTEXECUTABLE,RMODE(64),PART(stdi
+; CHECK:               in#S)
 ; CHECK: stdin#S XATTR LINKAGE(XPLINK),REFERENCE(DATA),SCOPE(SECTION)
-; CHECK:  .set L#DoFunc@indirect0, DoFunc
-; CHECK:      .indirect_symbol   L#DoFunc@indirect0
-; CHECK:  .quad VD(L#DoFunc@indirect0)         * Offset 0 pointer to function descriptor DoFunc
-; CHECK:  .quad RD(Caller)                     * Offset 8 function descriptor of Caller
-; CHECK:  .quad VD(Caller)
-; CHECK:  .quad AD(i2)                          * Offset 24 pointer to data symbol i2
-; CHECK:  .quad AD(i)                           * Offset 32 pointer to data symbol i
-; CHECK:  .quad RD(callout)                     * Offset 40 function descriptor of callout
-; CHECK:  .quad VD(callout)
+; CHECK: * Offset 0 pointer to function descriptor DoFunc
+; CHECK: DC VD(DoFunc@indirect)
+; CHECK: * Offset 8 function descriptor of Caller
+; CHECK: DC RD(Caller)
+; CHECK: DC VD(Caller)
+; CHECK: * Offset 24 pointer to data symbol i2
+; CHECK:  DC AD(i2)
+; CHECK: * Offset 32 pointer to data symbol i
+; CHECK:  DC AD(i)
+; CHECK: * Offset 40 function descriptor of callout
+; CHECK:  DC RD(callout)
+; CHECK:  DC VD(callout)
+; CHECK: EXTRN DoFunc@indirect
+; CHECK: DoFunc@indirect XATTR LINKAGE(XPLINK),REFERENCE(INDIRECT),SCOPE(EXPORT)
+; CHECK: DoFunc@indirect ALIAS "DoFunc"


### PR DESCRIPTION
This PR adds handling for indirect symbols on z/OS. Specifically, it connects indirect symbols to
the original symbol, and makes it easier to create/find indirect symbols in general.

Furthermore, indirect symbols are accommodate in the emission of the `XATTR` and `ALIAS` instructions,
as seen in the `llvm/test/CodeGen/SystemZ/zos-ada-relocations.ll` test case output.
