### PR TITLE
[Clang][Lexer][Performance] Optimize Lexer whitespace skipping logic

### DIFF
--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -2533,8 +2533,8 @@ bool Lexer::SkipWhitespace(Token &Result, const char *CurPtr,
 
   // Skip consecutive spaces efficiently.
   while (true) {
-    // Skip horizontal whitespace very aggressively.
-    while (isHorizontalWhitespace(Char))
+    // Skip horizontal whitespace, especially space, very aggressively.
+    while (LLVM_LIKELY(Char == ' ') || isHorizontalWhitespace(Char))
       Char = *++CurPtr;
 
     // Otherwise if we have something other than whitespace, we're done.
@@ -3756,10 +3756,10 @@ LexStart:
   const char *CurPtr = BufferPtr;
 
   // Small amounts of horizontal whitespace is very common between tokens.
-  if (isHorizontalWhitespace(*CurPtr)) {
+  if (LLVM_LIKELY(*CurPtr == ' ') || isHorizontalWhitespace(*CurPtr)) {
     do {
       ++CurPtr;
-    } while (isHorizontalWhitespace(*CurPtr));
+    } while (LLVM_LIKELY(*CurPtr == ' ') || isHorizontalWhitespace(*CurPtr));
 
     // If we are keeping whitespace and other tokens, just return what we just
     // skipped.  The next lexer invocation will return the token after the

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -2534,7 +2534,7 @@ bool Lexer::SkipWhitespace(Token &Result, const char *CurPtr,
   // Skip consecutive spaces efficiently.
   while (true) {
     // Skip horizontal whitespace, especially space, very aggressively.
-    while (LLVM_LIKELY(Char == ' ') || isHorizontalWhitespace(Char))
+    while (Char == ' ' || isHorizontalWhitespace(Char))
       Char = *++CurPtr;
 
     // Otherwise if we have something other than whitespace, we're done.
@@ -3756,10 +3756,12 @@ LexStart:
   const char *CurPtr = BufferPtr;
 
   // Small amounts of horizontal whitespace is very common between tokens.
-  if (LLVM_LIKELY(*CurPtr == ' ') || isHorizontalWhitespace(*CurPtr)) {
+  // Check for space character separately to skip the expensive
+  // isHorizontalWhitespace() check
+  if (*CurPtr == ' ' || isHorizontalWhitespace(*CurPtr)) {
     do {
       ++CurPtr;
-    } while (LLVM_LIKELY(*CurPtr == ' ') || isHorizontalWhitespace(*CurPtr));
+    } while (*CurPtr == ' ' || isHorizontalWhitespace(*CurPtr));
 
     // If we are keeping whitespace and other tokens, just return what we just
     // skipped.  The next lexer invocation will return the token after the


### PR DESCRIPTION
... by extracting the check for space character. This increases performance because the space is by far the most common horizontal character, so in most cases, this change allows to replace a lookup table check with a simple comparison, reducing latency and helping the cache.

This does not reduce instruction count, as a lookup table and a comparison are both a single instruction. However, it _does_ reduce cycles in a consistent manner, around `0.2` - `0.3`%: [benchmark](https://llvm-compile-time-tracker.com/compare.php?from=3192fe2c7b08912cc72c86471a593165b615dc28&to=faa899a6ce518c1176f2bf59f199eb42e59d840e&stat=cycles). I tested this locally and am able to confirm this is not noise (at least not entirely, it does feel weird that this impacts `O3` more than `O0`...), as I achieved almost `2`% faster PP speed in my tests.