### PR TITLE
InstCombine: Fix broken insert point for fdiv replacement

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2632,6 +2632,8 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
     Value *Y = I->getOperand(1);
     if (X == Y && isGuaranteedNotToBeUndef(X, SQ.AC, CxtI, SQ.DT, Depth + 1)) {
       // If the source is 0, inf or nan, the result is a nan
+      IRBuilderBase::InsertPointGuard Guard(Builder);
+      Builder.SetInsertPoint(I);
 
       Value *IsZeroOrNan = Builder.CreateFCmpFMF(
           FCmpInst::FCMP_UEQ, I->getOperand(0), ConstantFP::getZero(VTy), FMF);

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fdiv.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fdiv.ll
@@ -2324,6 +2324,25 @@ define nofpclass(snan) half @qnan_result_demands_snan_src_rhs(i1 %cond, half %un
   ret half %div
 }
 
+; Make sure the replacement for fdiv is inserted at the fdiv, and not
+; the use fmul
+define float @fdiv_replacement_insert_point_regression(i1 %cmp, float %x, float noundef %y, float noundef %z) {
+; CHECK-LABEL: define float @fdiv_replacement_insert_point_regression(
+; CHECK-SAME: i1 [[CMP:%.*]], float [[X:%.*]], float noundef [[Y:%.*]], float noundef [[Z:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[TMP0:%.*]] = call i1 @llvm.is.fpclass.f32(float [[Y]], i32 615)
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[TMP0]], float 0x7FF8000000000000, float 1.000000e+00
+; CHECK-NEXT:    [[SCALE_0:%.*]] = select i1 [[CMP]], float [[TMP1]], float [[Y]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[SCALE_0]], [[X]]
+; CHECK-NEXT:    ret float [[MUL]]
+;
+entry:
+  %div = fdiv float %y, %y
+  %scale.0 = select i1 %cmp, float %div, float %y
+  %mul = fmul float %scale.0, %x
+  ret float %mul
+}
+
 attributes #0 = { denormal_fpenv(preservesign) }
 attributes #1 = { denormal_fpenv(dynamic) }
 attributes #2 = { denormal_fpenv(ieee|preservesign) }


### PR DESCRIPTION
SimplifyDemandedFPClass isn't properly adjusting the IRBuilder
insert point, so this could insert at the wrong point if the simplification
happens in one of the recursive calls. There are a few more of these
to fix.