### PR TITLE
[LLDB] Fix tablegen paths for KDP and IntelPT properties

### DIFF
--- a/lldb/source/Plugins/Process/MacOSX-Kernel/ProcessKDPProperties.td
+++ b/lldb/source/Plugins/Process/MacOSX-Kernel/ProcessKDPProperties.td
@@ -1,6 +1,6 @@
 include "../../../../include/lldb/Core/PropertiesBase.td"
 
-let Definition = "processkdp", Parent = "plugin.process.kdp" in {
+let Definition = "processkdp", Path = "plugin.process.kdp" in {
   def KDPPacketTimeout: Property<"packet-timeout", "UInt64">,
     Global,
     DefaultUnsignedValue<5>,

--- a/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTProperties.td
+++ b/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTProperties.td
@@ -1,6 +1,6 @@
 include "../../../../include/lldb/Core/PropertiesBase.td"
 
-let Definition = "traceintelpt", Parent = "plugin.trace.intel-pt" in {
+let Definition = "traceintelpt", Path = "plugin.trace.intel-pt" in {
   def InfiniteDecodingLoopVerificationThreshold:
       Property<"infinite-decoding-loop-verification-threshold", "UInt64">,
     Global,


### PR DESCRIPTION
Fixes the build errors from #179524. Initially I used `Parent` as the name but switched to `Path` later and forgot to update these files.