### PR TITLE
[lld] Fix undefined behavior with misaligned SHT_GROUP section.

### DIFF
--- a/lld/ELF/InputSection.h
+++ b/lld/ELF/InputSection.h
@@ -299,6 +299,7 @@ public:
   template <typename T> llvm::ArrayRef<T> getDataAs() const {
     size_t s = content().size();
     assert(s % sizeof(T) == 0);
+    assert(reinterpret_cast<uintptr_t>(content().data()) % alignof(T) == 0);
     return llvm::ArrayRef<T>((const T *)content().data(), s / sizeof(T));
   }
 

--- a/lld/ELF/OutputSections.cpp
+++ b/lld/ELF/OutputSections.cpp
@@ -625,7 +625,7 @@ static void finalizeShtGroup(Ctx &ctx, OutputSection *os,
   // new size. The content will be rewritten in InputSection::copyShtGroup.
   DenseSet<uint32_t> seen;
   ArrayRef<InputSectionBase *> sections = section->file->getSections();
-  for (const uint32_t &idx : section->getDataAs<uint32_t>().slice(1))
+  for (auto &idx : section->getDataAs<std::array<char, 4>>().slice(1))
     if (OutputSection *osec = sections[read32(ctx, &idx)]->getOutputSection())
       seen.insert(osec->sectionIndex);
   os->size = (1 + seen.size()) * sizeof(uint32_t);

--- a/lld/test/ELF/linkorder-group.test
+++ b/lld/test/ELF/linkorder-group.test
@@ -31,7 +31,6 @@ Sections:
     Type:            SHT_GROUP
     Link:            .symtab
     Info:            foo
-    AddressAlign:    4
     Members:
       - SectionOrType:   GRP_COMDAT
       - SectionOrType:   .bss

--- a/lld/test/ELF/linkorder-group.test
+++ b/lld/test/ELF/linkorder-group.test
@@ -31,6 +31,8 @@ Sections:
     Type:            SHT_GROUP
     Link:            .symtab
     Info:            foo
+# Intentionally misaligned to check that lld works with unaligned SHT_GROUP
+    AddressAlign:    1
     Members:
       - SectionOrType:   GRP_COMDAT
       - SectionOrType:   .bss

--- a/lld/test/ELF/linkorder-group.test
+++ b/lld/test/ELF/linkorder-group.test
@@ -31,7 +31,7 @@ Sections:
     Type:            SHT_GROUP
     Link:            .symtab
     Info:            foo
-# Intentionally misaligned to check that lld works with unaligned SHT_GROUP
+## Intentionally misaligned to check that lld works with unaligned SHT_GROUP
     AddressAlign:    1
     Members:
       - SectionOrType:   GRP_COMDAT


### PR DESCRIPTION
read32() allows misaligned values, but a `uint32_t &` must be properly aligned even if it isn't directly read.  ubsan detects this.  To fix the issue, replace the `uint32_t &` with a value that doesn't require alignment.

Also added an assertion to catch similar misuse of getDataAs().

(Alternatively, we could make the input validation more strict, and reject files with a misaligned SHT_GROUP, but I don't see any obvious reason to require that.)