### PR TITLE
[llvm][cas] Validate OnDiskKeyValueDB against the corresponding OnDiskGraphDB

### DIFF
--- a/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
+++ b/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
@@ -72,11 +72,8 @@ public:
        UnifiedOnDiskCache *UnifiedCache = nullptr,
        std::shared_ptr<OnDiskCASLogger> Logger = nullptr);
 
-  using CheckValueT =
-      function_ref<Error(FileOffset Offset, ArrayRef<char> Data)>;
-  /// Validate the storage with a callback \p CheckValue to check the stored
-  /// value.
-  LLVM_ABI_FOR_TEST Error validate(CheckValueT CheckValue) const;
+  /// Validate the storage.
+  LLVM_ABI_FOR_TEST Error validate() const;
 
 private:
   OnDiskKeyValueDB(size_t ValueSize, OnDiskTrieRawHashMap Cache,

--- a/llvm/lib/CAS/ActionCaches.cpp
+++ b/llvm/lib/CAS/ActionCaches.cpp
@@ -197,11 +197,7 @@ Error OnDiskActionCache::putImpl(ArrayRef<uint8_t> Key, const CASID &Result,
       ArrayRef((const uint8_t *)Observed.data(), Observed.size()));
 }
 
-Error OnDiskActionCache::validate() const {
-  // FIXME: without the matching CAS there is nothing we can check about the
-  // cached values. The hash size is already validated by the DB validator.
-  return DB->validate(nullptr);
-}
+Error OnDiskActionCache::validate() const { return DB->validate(); }
 
 UnifiedOnDiskActionCache::UnifiedOnDiskActionCache(
     std::shared_ptr<ondisk::UnifiedOnDiskCache> UniDB)

--- a/llvm/lib/CAS/UnifiedOnDiskCache.cpp
+++ b/llvm/lib/CAS/UnifiedOnDiskCache.cpp
@@ -252,20 +252,7 @@ static Error validateOutOfProcess(StringRef LLVMCasBinary, StringRef RootPath,
 }
 
 Error UnifiedOnDiskCache::validateActionCache() const {
-  auto ValidateRef = [this](FileOffset Offset, ArrayRef<char> Value) -> Error {
-    auto ID = ondisk::UnifiedOnDiskCache::getObjectIDFromValue(Value);
-    auto formatError = [&](Twine Msg) {
-      return createStringError(
-          llvm::errc::illegal_byte_sequence,
-          "bad record at 0x" +
-              utohexstr((unsigned)Offset.get(), /*LowerCase=*/true) + ": " +
-              Msg.str());
-    };
-    if (Error E = this->getGraphDB().validateObjectID(ID))
-      return formatError(llvm::toString(std::move(E)));
-    return Error::success();
-  };
-  return getKeyValueDB().validate(ValidateRef);
+  return getKeyValueDB().validate();
 }
 
 static Error validateInProcess(StringRef RootPath, StringRef HashName,

--- a/llvm/test/tools/llvm-cas/validation.test
+++ b/llvm/test/tools/llvm-cas/validation.test
@@ -26,6 +26,13 @@ RUN:   --data - >%t/abc.casid
 RUN: llvm-cas --cas %t/ac --put-cache-key @%t/abc.casid @%t/empty.casid
 RUN: llvm-cas --cas %t/ac --validate
 
+# Check that validation passes in an upstream db.
+RUN: mkdir %t/ac/v1.2
+RUN: llvm-cas --cas %t/ac --validate
+# Fault in from upstream DB.
+RUN: llvm-cas --cas %t/ac --get-cache-result @%t/abc.casid
+RUN: llvm-cas --cas %t/ac --validate
+
 # Check that validation fails if the objects referenced are missing.
 RUN: mv %t/ac/v1.1/index.v1 %t/tmp.index.v1
 RUN: not llvm-cas --cas %t/ac --validate

--- a/llvm/unittests/CAS/OnDiskKeyValueDBTest.cpp
+++ b/llvm/unittests/CAS/OnDiskKeyValueDBTest.cpp
@@ -49,13 +49,7 @@ TEST_F(OnDiskCASTest, OnDiskKeyValueDBTest) {
   }
 
   // Validate
-  {
-    auto ValidateFunc = [](FileOffset Offset, ArrayRef<char> Data) -> Error {
-      EXPECT_EQ(Data.size(), sizeof(ValueType));
-      return Error::success();
-    };
-    ASSERT_THAT_ERROR(DB->validate(ValidateFunc), Succeeded());
-  }
+  ASSERT_THAT_ERROR(DB->validate(), Succeeded());
 
   // Size
   {


### PR DESCRIPTION
We were previously using the primary OnDiskGraphDB when validating the upstream OnDiskKeyValueDB, which is incorrect since the values being stored are direct offsets and therefore cannot be used across DBs without translating to a hash value first.

rdar://170067863