### PR TITLE
[llvm-isel-fuzzer] Fix crash in `IRMutator::getEffectiveTerminator`

### DIFF
--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -124,7 +124,8 @@ static inline Instruction *getEffectiveTerminator(BasicBlock &BB) {
     // Certain intrinsics, such as @llvm.amdgcn.cs.chain, must be immediately
     // followed by an unreachable instruction..
     if (UnreachableInst *UI = dyn_cast<UnreachableInst>(BB.getTerminator())) {
-      if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(UI->getPrevNode())) {
+      if (IntrinsicInst *II =
+              dyn_cast_if_present<IntrinsicInst>(UI->getPrevNode())) {
         return II;
       }
     }


### PR DESCRIPTION
`IRMutator::getEffectiveTerminator` would assume that when an UnreachableInst is the terminator of a block, that there is always a previous instruction. This is not the case (you can have a unreachable isolated in a block).

This swaps `dyn_cast` with `dyn_cast_if_present` accordingly.