### PR TITLE
[lldb] Implement DenseMapInfo for UUID

### DIFF
--- a/lldb/include/lldb/Utility/UUID.h
+++ b/lldb/include/lldb/Utility/UUID.h
@@ -115,4 +115,26 @@ private:
 };
 } // namespace lldb_private
 
+namespace llvm {
+
+/// DenseMapInfo implementation.
+/// \{
+template <> struct DenseMapInfo<lldb_private::UUID> {
+  static inline lldb_private::UUID getEmptyKey() {
+    return lldb_private::UUID();
+  }
+  static inline lldb_private::UUID getTombstoneKey() {
+    return lldb_private::UUID();
+  }
+  static unsigned getHashValue(lldb_private::UUID uuid) {
+    return DenseMapInfo<llvm::ArrayRef<uint8_t>>::getHashValue(uuid.GetBytes());
+  }
+  static bool isEqual(lldb_private::UUID LHS, lldb_private::UUID RHS) {
+    return LHS == RHS;
+  }
+};
+/// \}
+
+} // namespace llvm
+
 #endif // LLDB_UTILITY_UUID_H

--- a/lldb/unittests/Utility/UUIDTest.cpp
+++ b/lldb/unittests/Utility/UUIDTest.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Utility/UUID.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 
@@ -93,4 +95,43 @@ TEST(UUIDTest, Generate) {
 
   UUID u20 = UUID::Generate(20);
   EXPECT_EQ(u20.GetBytes().size(), 20UL);
+}
+
+TEST(UUIDTest, DenseMap) {
+  llvm::DenseMap<UUID, uint8_t> uuid_map;
+
+  const UUID a16 = UUID("1234567890123456", 16);
+  const UUID b16 = UUID("1234567890123457", 16);
+  const UUID a20 = UUID("12345678901234567890", 20);
+  const UUID b20 = UUID("12345678900987654321", 20);
+
+  uuid_map[a16] = 0;
+  uuid_map[b16] = 1;
+  uuid_map[a20] = 2;
+  uuid_map[b20] = 3;
+
+  EXPECT_EQ(uuid_map[a16], 0);
+  EXPECT_EQ(uuid_map[b16], 1);
+  EXPECT_EQ(uuid_map[a20], 2);
+  EXPECT_EQ(uuid_map[b20], 3);
+}
+
+TEST(UUIDTest, DenseSet) {
+  llvm::DenseSet<UUID> uuid_set;
+
+  const UUID a16 = UUID("1234567890123456", 16);
+  const UUID b16 = UUID("1234567890123457", 16);
+  const UUID a20 = UUID("12345678901234567890", 20);
+  const UUID b20 = UUID("12345678900987654321", 20);
+
+  EXPECT_TRUE(uuid_set.insert(a16).second);
+  EXPECT_FALSE(uuid_set.insert(a16).second);
+
+  EXPECT_TRUE(uuid_set.insert(a20).second);
+
+  EXPECT_TRUE(uuid_set.contains(a16));
+  EXPECT_TRUE(uuid_set.contains(a20));
+
+  EXPECT_FALSE(uuid_set.contains(b16));
+  EXPECT_FALSE(uuid_set.contains(b20));
 }


### PR DESCRIPTION
Implement DenseMapInfo for UUID so that we can use UUIDs as keys in DenseMap and DenseSet.