### PR TITLE
[libc] Use internal standard stream declarations for baremetal

### DIFF
--- a/libc/src/__support/File/baremetal/CMakeLists.txt
+++ b/libc/src/__support/File/baremetal/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_header_library(
+  file
+  HDRS
+    file.h
+  DEPENDS
+    libc.hdr.types.FILE
+)

--- a/libc/src/__support/File/baremetal/file.h
+++ b/libc/src/__support/File/baremetal/file.h
@@ -1,0 +1,29 @@
+//===--- A platform independent file data structure -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_FILE_BAREMETAL_FILE_H
+#define LLVM_LIBC_SRC___SUPPORT_FILE_BAREMETAL_FILE_H
+
+#include "hdr/types/FILE.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// For internal libc uses it is preferable to use these declarations over the
+// public header ones in hdr/stdio_macros.h to ensure these have the internal
+// visibility and avoid the GOT relocations.
+
+// TODO: We should eventually consolidate this header with File/file.h.
+
+extern FILE *stdin;
+extern FILE *stdout;
+extern FILE *stderr;
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_FILE_BAREMETAL_FILE_H

--- a/libc/src/stdio/baremetal/CMakeLists.txt
+++ b/libc/src/stdio/baremetal/CMakeLists.txt
@@ -174,6 +174,7 @@ add_entrypoint_object(
     .file_internal
     libc.hdr.types.FILE
     libc.src.errno.errno
+    libc.src.__support.File.baremetal.file
 )
 
 add_entrypoint_object(
@@ -194,8 +195,8 @@ add_entrypoint_object(
     ../printf.h
   DEPENDS
     .vfprintf_internal
-    libc.hdr.stdio_macros
     libc.src.__support.arg_list
+    libc.src.__support.File.baremetal.file
 )
 
 add_entrypoint_object(
@@ -207,6 +208,7 @@ add_entrypoint_object(
   DEPENDS
     .file_internal
     libc.hdr.stdio_macros
+    libc.src.__support.File.baremetal.file
     libc.src.errno.errno
 )
 
@@ -220,6 +222,7 @@ add_entrypoint_object(
     .file_internal
     libc.hdr.stdio_macros
     libc.hdr.types.FILE
+    libc.src.__support.File.baremetal.file
     libc.src.errno.errno
 )
 
@@ -232,6 +235,7 @@ add_entrypoint_object(
   DEPENDS
     .file_internal
     libc.hdr.stdio_macros
+    libc.src.__support.File.baremetal.file
     libc.src.errno.errno
 )
 
@@ -246,6 +250,7 @@ add_entrypoint_object(
     libc.hdr.types.FILE
     libc.hdr.stdio_macros
     libc.src.__support.arg_list
+    libc.src.__support.File.baremetal.file
 )
 
 add_entrypoint_object(
@@ -284,6 +289,7 @@ add_entrypoint_object(
     .vfprintf_internal
     libc.hdr.stdio_macros
     libc.src.__support.arg_list
+    libc.src.__support.File.baremetal.file
 )
 
 add_entrypoint_object(
@@ -296,4 +302,5 @@ add_entrypoint_object(
     .vfscanf_internal
     libc.hdr.stdio_macros
     libc.src.__support.arg_list
+    libc.src.__support.File.baremetal.file
 )

--- a/libc/src/stdio/baremetal/getchar.cpp
+++ b/libc/src/stdio/baremetal/getchar.cpp
@@ -10,6 +10,7 @@
 
 #include "hdr/stdio_macros.h" // for EOF.
 #include "src/__support/common.h"
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"

--- a/libc/src/stdio/baremetal/getchar.cpp
+++ b/libc/src/stdio/baremetal/getchar.cpp
@@ -9,8 +9,8 @@
 #include "src/stdio/getchar.h"
 
 #include "hdr/stdio_macros.h" // for EOF.
-#include "src/__support/common.h"
 #include "src/__support/File/baremetal/file.h"
+#include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"

--- a/libc/src/stdio/baremetal/printf.cpp
+++ b/libc/src/stdio/baremetal/printf.cpp
@@ -8,9 +8,9 @@
 
 #include "src/stdio/printf.h"
 
-#include "hdr/stdio_macros.h"
 #include "src/__support/arg_list.h"
 #include "src/__support/common.h"
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfprintf_internal.h"
 

--- a/libc/src/stdio/baremetal/printf.cpp
+++ b/libc/src/stdio/baremetal/printf.cpp
@@ -8,9 +8,9 @@
 
 #include "src/stdio/printf.h"
 
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/arg_list.h"
 #include "src/__support/common.h"
-#include "src/__support/File/baremetal/file.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfprintf_internal.h"
 

--- a/libc/src/stdio/baremetal/putc.cpp
+++ b/libc/src/stdio/baremetal/putc.cpp
@@ -12,6 +12,7 @@
 #include "hdr/types/FILE.h"
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"
 

--- a/libc/src/stdio/baremetal/putc.cpp
+++ b/libc/src/stdio/baremetal/putc.cpp
@@ -10,9 +10,9 @@
 
 #include "hdr/stdio_macros.h" // for EOF
 #include "hdr/types/FILE.h"
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
-#include "src/__support/File/baremetal/file.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"
 

--- a/libc/src/stdio/baremetal/putchar.cpp
+++ b/libc/src/stdio/baremetal/putchar.cpp
@@ -9,8 +9,8 @@
 #include "src/stdio/putchar.h"
 
 #include "hdr/stdio_macros.h" // for EOF
-#include "src/__support/common.h"
 #include "src/__support/File/baremetal/file.h"
+#include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"

--- a/libc/src/stdio/baremetal/putchar.cpp
+++ b/libc/src/stdio/baremetal/putchar.cpp
@@ -10,6 +10,7 @@
 
 #include "hdr/stdio_macros.h" // for EOF
 #include "src/__support/common.h"
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"

--- a/libc/src/stdio/baremetal/puts.cpp
+++ b/libc/src/stdio/baremetal/puts.cpp
@@ -9,9 +9,9 @@
 #include "src/stdio/puts.h"
 
 #include "hdr/stdio_macros.h" // for EOF
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
-#include "src/__support/File/baremetal/file.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"
 

--- a/libc/src/stdio/baremetal/puts.cpp
+++ b/libc/src/stdio/baremetal/puts.cpp
@@ -11,6 +11,7 @@
 #include "hdr/stdio_macros.h" // for EOF
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/file_internal.h"
 

--- a/libc/src/stdio/baremetal/scanf.cpp
+++ b/libc/src/stdio/baremetal/scanf.cpp
@@ -8,8 +8,8 @@
 
 #include "src/stdio/scanf.h"
 
-#include "src/__support/arg_list.h"
 #include "src/__support/File/baremetal/file.h"
+#include "src/__support/arg_list.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfscanf_internal.h"
 

--- a/libc/src/stdio/baremetal/scanf.cpp
+++ b/libc/src/stdio/baremetal/scanf.cpp
@@ -8,8 +8,8 @@
 
 #include "src/stdio/scanf.h"
 
-#include "hdr/stdio_macros.h"
 #include "src/__support/arg_list.h"
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfscanf_internal.h"
 

--- a/libc/src/stdio/baremetal/vprintf.cpp
+++ b/libc/src/stdio/baremetal/vprintf.cpp
@@ -8,9 +8,9 @@
 
 #include "src/stdio/vprintf.h"
 
-#include "hdr/stdio_macros.h"
 #include "src/__support/arg_list.h"
 #include "src/__support/common.h"
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfprintf_internal.h"
 

--- a/libc/src/stdio/baremetal/vprintf.cpp
+++ b/libc/src/stdio/baremetal/vprintf.cpp
@@ -8,9 +8,9 @@
 
 #include "src/stdio/vprintf.h"
 
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/arg_list.h"
 #include "src/__support/common.h"
-#include "src/__support/File/baremetal/file.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfprintf_internal.h"
 

--- a/libc/src/stdio/baremetal/vscanf.cpp
+++ b/libc/src/stdio/baremetal/vscanf.cpp
@@ -8,8 +8,8 @@
 
 #include "src/stdio/vscanf.h"
 
-#include "hdr/stdio_macros.h"
 #include "src/__support/arg_list.h"
+#include "src/__support/File/baremetal/file.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfscanf_internal.h"
 

--- a/libc/src/stdio/baremetal/vscanf.cpp
+++ b/libc/src/stdio/baremetal/vscanf.cpp
@@ -8,8 +8,8 @@
 
 #include "src/stdio/vscanf.h"
 
-#include "src/__support/arg_list.h"
 #include "src/__support/File/baremetal/file.h"
+#include "src/__support/arg_list.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/baremetal/vfscanf_internal.h"
 


### PR DESCRIPTION
This matches what we do on other platforms and ensures these symbols have the correct visibility to avoid GOT relocations.