### PR TITLE
[GlobalISel] Fix type mismatch in LegalizerHelper ternary

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -6326,8 +6326,9 @@ Register LegalizerHelper::buildVariableShiftPart(unsigned Opcode,
   // For G_ASHR, individual parts don't have their own sign bit, only the
   // complete value does. So we use LSHR for the main operand shift in ASHR
   // context.
-  unsigned MainOpcode =
-      (Opcode == TargetOpcode::G_ASHR) ? TargetOpcode::G_LSHR : Opcode;
+  unsigned MainOpcode = (Opcode == TargetOpcode::G_ASHR)
+                            ? static_cast<unsigned>(TargetOpcode::G_LSHR)
+                            : Opcode;
 
   // Perform the primary shift on the main operand
   Register MainShifted =


### PR DESCRIPTION
### Summary

Fix type mismatch in ternary expression that causes GCC `-Werror=extra` to fail.

### Details

GCC's `-Werror=extra` enforces stricter type consistency in ternary expressions, in this case unsigned and an enum literal. 

### Tested

- Built with ToT clang and GCC 13.3.0 on Linux x86_64 (not really because there are other warnings, but this one is gone).
- All existing tests pass