### PR TITLE
[ADT] Add is_sorted_constexpr, equivalent to C++20 std::is_sorted 

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1975,22 +1975,6 @@ template <typename R> bool is_sorted(R &&Range) {
   return std::is_sorted(adl_begin(Range), adl_end(Range));
 }
 
-/// Check if elements in a range \p R are sorted with respect to a comparator \p
-/// C. constexpr allows use in static_assert
-/// TODO: Use std::is_sorted once upgraded to Cpp20
-template <typename It, typename Cmp = std::less<>>
-constexpr bool is_sorted_constexpr(It First, It Last, Cmp C = Cmp{}) {
-  if (First == Last)
-    return true;
-  It Prev = First;
-  for (It I = std::next(First); I != Last; ++I) {
-    if (C(*I, *Prev))
-      return false;
-    Prev = I;
-  }
-  return true;
-}
-
 /// Provide wrappers to std::includes which take ranges instead of having to
 /// pass begin/end explicitly.
 /// This function checks if the sorted range \p R2 is a subsequence of the

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1975,6 +1975,14 @@ template <typename R> bool is_sorted(R &&Range) {
   return std::is_sorted(adl_begin(Range), adl_end(Range));
 }
 
+/// Check if elements in a range \p R are sorted with respect to a comparator \p
+/// C. constexpr allows use in static_assert
+/// TODO: Remove and use std::is_sorted once upgraded to Cpp20
+template <typename R, typename Cmp = std::less<>>
+constexpr bool is_sorted_constexpr(R &&Range, Cmp C = Cmp{}) {
+  return llvm::is_sorted_constexpr(adl_begin(Range), adl_end(Range), C);
+}
+
 /// Provide wrappers to std::includes which take ranges instead of having to
 /// pass begin/end explicitly.
 /// This function checks if the sorted range \p R2 is a subsequence of the

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1975,6 +1975,22 @@ template <typename R> bool is_sorted(R &&Range) {
   return std::is_sorted(adl_begin(Range), adl_end(Range));
 }
 
+/// Check if elements in a range \p R are sorted with respect to a comparator \p
+/// C. constexpr allows use in static_assert
+/// TODO: Use std::is_sorted once upgraded to Cpp20
+template <typename It, typename Cmp = std::less<>>
+constexpr bool is_sorted_constexpr(It First, It Last, Cmp C = Cmp{}) {
+  if (First == Last)
+    return true;
+  It Prev = First;
+  for (It I = std::next(First); I != Last; ++I) {
+    if (C(*I, *Prev))
+      return false;
+    Prev = I;
+  }
+  return true;
+}
+
 /// Provide wrappers to std::includes which take ranges instead of having to
 /// pass begin/end explicitly.
 /// This function checks if the sorted range \p R2 is a subsequence of the

--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -18,6 +18,7 @@
 #define LLVM_ADT_STLFORWARDCOMPAT_H
 
 #include "llvm/Support/Compiler.h"
+#include <functional>
 #include <optional>
 #include <tuple>
 #include <type_traits>
@@ -156,6 +157,22 @@ constexpr std::invoke_result_t<FnT, ArgsT...>
 invoke(FnT &&Fn, ArgsT &&...Args) { // NOLINT(readability-identifier-naming)
   return std::apply(std::forward<FnT>(Fn),
                     std::forward_as_tuple(std::forward<ArgsT>(Args)...));
+}
+
+/// Check if elements in a range \p R are sorted with respect to a comparator \p
+/// C. constexpr allows use in static_assert
+/// TODO: Use std::is_sorted once upgraded to C++20 since that becomes constexpr
+template <typename It, typename Cmp = std::less<>>
+constexpr bool is_sorted_constexpr(It First, It Last, Cmp C = Cmp{}) {
+  if (First == Last)
+    return true;
+  It Prev = First;
+  for (It I = std::next(First); I != Last; ++I) {
+    if (C(*I, *Prev))
+      return false;
+    Prev = I;
+  }
+  return true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -162,12 +162,13 @@ invoke(FnT &&Fn, ArgsT &&...Args) { // NOLINT(readability-identifier-naming)
 /// Check if elements in range \p First to \p Last are sorted with respect to a
 /// comparator \p C. constexpr allows use in static_assert
 /// TODO: Use std::is_sorted once upgraded to C++20 since that becomes constexpr
-template <typename It, typename Cmp = std::less<>>
-constexpr bool is_sorted_constexpr(It First, It Last, Cmp C = Cmp{}) {
+template <typename ForwardIterator, typename Cmp = std::less<>>
+constexpr bool is_sorted_constexpr(ForwardIterator First, ForwardIterator Last,
+                                   Cmp C = Cmp{}) {
   if (First == Last)
     return true;
-  auto Prev = First;
-  for (auto I = std::next(First); I != Last; ++I) {
+  ForwardIterator Prev = First;
+  for (ForwardIterator I = std::next(First); I != Last; ++I) {
     if (C(*I, *Prev))
       return false;
     Prev = I;

--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -164,8 +164,8 @@ invoke(FnT &&Fn, ArgsT &&...Args) { // NOLINT(readability-identifier-naming)
 /// TODO: Use std::is_sorted once upgraded to C++20 since that becomes constexpr
 template <typename R, typename Cmp = std::less<>>
 constexpr bool is_sorted_constexpr(R &&Range, Cmp C = Cmp{}) {
-  auto First = adl_begin(Range);
-  auto Last = adl_end(Range);
+  auto First = std::begin(Range);
+  auto Last = std::end(Range);
   if (First == Last)
     return true;
   auto Prev = First;

--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -162,12 +162,14 @@ invoke(FnT &&Fn, ArgsT &&...Args) { // NOLINT(readability-identifier-naming)
 /// Check if elements in a range \p R are sorted with respect to a comparator \p
 /// C. constexpr allows use in static_assert
 /// TODO: Use std::is_sorted once upgraded to C++20 since that becomes constexpr
-template <typename It, typename Cmp = std::less<>>
-constexpr bool is_sorted_constexpr(It First, It Last, Cmp C = Cmp{}) {
+template <typename R, typename Cmp = std::less<>>
+constexpr bool is_sorted_constexpr(R &&Range, Cmp C = Cmp{}) {
+  auto First = adl_begin(Range);
+  auto Last = adl_end(Range);
   if (First == Last)
     return true;
-  It Prev = First;
-  for (It I = std::next(First); I != Last; ++I) {
+  auto Prev = First;
+  for (auto I = std::next(First); I != Last; ++I) {
     if (C(*I, *Prev))
       return false;
     Prev = I;

--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -159,13 +159,11 @@ invoke(FnT &&Fn, ArgsT &&...Args) { // NOLINT(readability-identifier-naming)
                     std::forward_as_tuple(std::forward<ArgsT>(Args)...));
 }
 
-/// Check if elements in a range \p R are sorted with respect to a comparator \p
-/// C. constexpr allows use in static_assert
+/// Check if elements in range \p First to \p Last are sorted with respect to a
+/// comparator \p C. constexpr allows use in static_assert
 /// TODO: Use std::is_sorted once upgraded to C++20 since that becomes constexpr
-template <typename R, typename Cmp = std::less<>>
-constexpr bool is_sorted_constexpr(R &&Range, Cmp C = Cmp{}) {
-  auto First = std::begin(Range);
-  auto Last = std::end(Range);
+template <typename It, typename Cmp = std::less<>>
+constexpr bool is_sorted_constexpr(It First, It Last, Cmp C = Cmp{}) {
   if (First == Last)
     return true;
   auto Prev = First;

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -954,9 +954,6 @@ class BinOpSameOpcodeHelper {
   constexpr static std::initializer_list<unsigned> SupportedOp = {
       Instruction::Add,  Instruction::Sub, Instruction::Mul, Instruction::Shl,
       Instruction::AShr, Instruction::And, Instruction::Or,  Instruction::Xor};
-  static_assert(llvm::is_sorted_constexpr(SupportedOp.begin(),
-                                          SupportedOp.end()) &&
-                "SupportedOp is not sorted.");
   enum : MaskType {
     ShlBIT = 0b1,
     AShrBIT = 0b10,
@@ -1160,7 +1157,9 @@ class BinOpSameOpcodeHelper {
 public:
   BinOpSameOpcodeHelper(const Instruction *MainOp,
                         const Instruction *AltOp = nullptr)
-      : MainOp(MainOp), AltOp(AltOp) {}
+      : MainOp(MainOp), AltOp(AltOp) {
+    assert(is_sorted(SupportedOp) && "SupportedOp is not sorted.");
+  }
   bool add(const Instruction *I) {
     assert(isa<BinaryOperator>(I) &&
            "BinOpSameOpcodeHelper only accepts BinaryOperator.");

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -954,6 +954,9 @@ class BinOpSameOpcodeHelper {
   constexpr static std::initializer_list<unsigned> SupportedOp = {
       Instruction::Add,  Instruction::Sub, Instruction::Mul, Instruction::Shl,
       Instruction::AShr, Instruction::And, Instruction::Or,  Instruction::Xor};
+  static_assert(llvm::is_sorted_constexpr(SupportedOp.begin(),
+                                          SupportedOp.end()) &&
+                "SupportedOp is not sorted.");
   enum : MaskType {
     ShlBIT = 0b1,
     AShrBIT = 0b10,
@@ -1157,9 +1160,7 @@ class BinOpSameOpcodeHelper {
 public:
   BinOpSameOpcodeHelper(const Instruction *MainOp,
                         const Instruction *AltOp = nullptr)
-      : MainOp(MainOp), AltOp(AltOp) {
-    assert(is_sorted(SupportedOp) && "SupportedOp is not sorted.");
-  }
+      : MainOp(MainOp), AltOp(AltOp) {}
   bool add(const Instruction *I) {
     assert(isa<BinaryOperator>(I) &&
            "BinOpSameOpcodeHelper only accepts BinaryOperator.");

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1937,4 +1937,33 @@ TEST(STLExtrasTest, AdjacentFind) {
   EXPECT_EQ(*std::next(It13), 3);
 }
 
+// Compile-time tests for llvm::is_sorted_constexpr
+static constexpr std::array<int, 0> CEmpty{};
+static_assert(is_sorted_constexpr(CEmpty.begin(), CEmpty.end()),
+              "Empty range should be sorted");
+
+static constexpr std::array<int, 1> CSingle{{42}};
+static_assert(is_sorted_constexpr(CSingle.begin(), CSingle.end()),
+              "Single element range should be sorted");
+static_assert(is_sorted_constexpr(CSingle.begin(), CSingle.end(),
+                                  std::greater<>()),
+              "Single element range should be sorted with std::greater");
+
+static constexpr std::array<int, 5> CSorted{{1, 2, 2, 3, 5}};
+static_assert(is_sorted_constexpr(CSorted.begin(), CSorted.end()),
+              "Non-descending order with duplicates should be sorted");
+static_assert(is_sorted_constexpr(CSorted.begin(), CSorted.end(),
+                                  std::less<>()),
+              "Explicit std::less non-descending order should be sorted");
+static_assert(!is_sorted_constexpr(CSorted.begin(), CSorted.end(),
+                                   std::greater<>()),
+              "Non-descending order should not be sorted by std::greater");
+
+static constexpr std::array<int, 5> CUnsorted{{1, 3, 2, 4, 5}};
+static_assert(!is_sorted_constexpr(CUnsorted.begin(), CUnsorted.end()),
+              "Unsorted range should not be sorted");
+
+static constexpr std::array<int, 5> CDesc{{9, 7, 7, 3, 0}};
+static_assert(is_sorted_constexpr(CDesc.begin(), CDesc.end(), std::greater<>()),
+              "Non-ascending order with std::greater should be sorted");
 } // namespace

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1939,31 +1939,27 @@ TEST(STLExtrasTest, AdjacentFind) {
 
 // Compile-time tests for llvm::is_sorted_constexpr
 static constexpr std::array<int, 0> CEmpty{};
-static_assert(is_sorted_constexpr(CEmpty.begin(), CEmpty.end()),
-              "Empty range should be sorted");
+static_assert(is_sorted_constexpr(CEmpty), "Empty range should be sorted");
 
 static constexpr std::array<int, 1> CSingle{{42}};
-static_assert(is_sorted_constexpr(CSingle.begin(), CSingle.end()),
+static_assert(is_sorted_constexpr(CSingle),
               "Single element range should be sorted");
-static_assert(is_sorted_constexpr(CSingle.begin(), CSingle.end(),
-                                  std::greater<>()),
+static_assert(is_sorted_constexpr(CSingle, std::greater<>()),
               "Single element range should be sorted with std::greater");
 
 static constexpr std::array<int, 5> CSorted{{1, 2, 2, 3, 5}};
-static_assert(is_sorted_constexpr(CSorted.begin(), CSorted.end()),
+static_assert(is_sorted_constexpr(CSorted),
               "Non-descending order with duplicates should be sorted");
-static_assert(is_sorted_constexpr(CSorted.begin(), CSorted.end(),
-                                  std::less<>()),
+static_assert(is_sorted_constexpr(CSorted, std::less<>()),
               "Explicit std::less non-descending order should be sorted");
-static_assert(!is_sorted_constexpr(CSorted.begin(), CSorted.end(),
-                                   std::greater<>()),
+static_assert(!is_sorted_constexpr(CSorted, std::greater<>()),
               "Non-descending order should not be sorted by std::greater");
 
 static constexpr std::array<int, 5> CUnsorted{{1, 3, 2, 4, 5}};
-static_assert(!is_sorted_constexpr(CUnsorted.begin(), CUnsorted.end()),
+static_assert(!is_sorted_constexpr(CUnsorted),
               "Unsorted range should not be sorted");
 
 static constexpr std::array<int, 5> CDesc{{9, 7, 7, 3, 0}};
-static_assert(is_sorted_constexpr(CDesc.begin(), CDesc.end(), std::greater<>()),
+static_assert(is_sorted_constexpr(CDesc, std::greater<>()),
               "Non-ascending order with std::greater should be sorted");
 } // namespace

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1937,30 +1937,4 @@ TEST(STLExtrasTest, AdjacentFind) {
   EXPECT_EQ(*std::next(It13), 3);
 }
 
-// Compile-time tests for llvm::is_sorted_constexpr
-static constexpr std::array<int, 0> CEmpty{};
-static_assert(llvm::is_sorted_constexpr(CEmpty),
-              "Empty range should be sorted");
-
-static constexpr std::array<int, 1> CSingle{{42}};
-static_assert(llvm::is_sorted_constexpr(CSingle),
-              "Single element range should be sorted");
-static_assert(llvm::is_sorted_constexpr(CSingle, std::greater<>()),
-              "Single element range should be sorted with std::greater");
-
-static constexpr std::array<int, 5> CSorted{{1, 2, 2, 3, 5}};
-static_assert(llvm::is_sorted_constexpr(CSorted),
-              "Non-descending order with duplicates should be sorted");
-static_assert(llvm::is_sorted_constexpr(CSorted, std::less<>()),
-              "Explicit std::less non-descending order should be sorted");
-static_assert(!llvm::is_sorted_constexpr(CSorted, std::greater<>()),
-              "Non-descending order should not be sorted by std::greater");
-
-static constexpr std::array<int, 5> CUnsorted{{1, 3, 2, 4, 5}};
-static_assert(!llvm::is_sorted_constexpr(CUnsorted),
-              "Unsorted range should not be sorted");
-
-static constexpr std::array<int, 5> CDesc{{9, 7, 7, 3, 0}};
-static_assert(llvm::is_sorted_constexpr(CDesc, std::greater<>()),
-              "Non-ascending order with std::greater should be sorted");
 } // namespace

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1939,27 +1939,28 @@ TEST(STLExtrasTest, AdjacentFind) {
 
 // Compile-time tests for llvm::is_sorted_constexpr
 static constexpr std::array<int, 0> CEmpty{};
-static_assert(is_sorted_constexpr(CEmpty), "Empty range should be sorted");
+static_assert(llvm::is_sorted_constexpr(CEmpty),
+              "Empty range should be sorted");
 
 static constexpr std::array<int, 1> CSingle{{42}};
-static_assert(is_sorted_constexpr(CSingle),
+static_assert(llvm::is_sorted_constexpr(CSingle),
               "Single element range should be sorted");
-static_assert(is_sorted_constexpr(CSingle, std::greater<>()),
+static_assert(llvm::is_sorted_constexpr(CSingle, std::greater<>()),
               "Single element range should be sorted with std::greater");
 
 static constexpr std::array<int, 5> CSorted{{1, 2, 2, 3, 5}};
-static_assert(is_sorted_constexpr(CSorted),
+static_assert(llvm::is_sorted_constexpr(CSorted),
               "Non-descending order with duplicates should be sorted");
-static_assert(is_sorted_constexpr(CSorted, std::less<>()),
+static_assert(llvm::is_sorted_constexpr(CSorted, std::less<>()),
               "Explicit std::less non-descending order should be sorted");
-static_assert(!is_sorted_constexpr(CSorted, std::greater<>()),
+static_assert(!llvm::is_sorted_constexpr(CSorted, std::greater<>()),
               "Non-descending order should not be sorted by std::greater");
 
 static constexpr std::array<int, 5> CUnsorted{{1, 3, 2, 4, 5}};
-static_assert(!is_sorted_constexpr(CUnsorted),
+static_assert(!llvm::is_sorted_constexpr(CUnsorted),
               "Unsorted range should not be sorted");
 
 static constexpr std::array<int, 5> CDesc{{9, 7, 7, 3, 0}};
-static_assert(is_sorted_constexpr(CDesc, std::greater<>()),
+static_assert(llvm::is_sorted_constexpr(CDesc, std::greater<>()),
               "Non-ascending order with std::greater should be sorted");
 } // namespace

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1937,4 +1937,14 @@ TEST(STLExtrasTest, AdjacentFind) {
   EXPECT_EQ(*std::next(It13), 3);
 }
 
+// Compile-time tests for llvm::is_sorted_constexpr
+// Check to ensure range based functions as expected
+static constexpr std::array<int, 5> CSorted{{1, 2, 2, 3, 5}};
+static_assert(llvm::is_sorted_constexpr(CSorted),
+              "Non-descending order with duplicates should be sorted");
+static_assert(llvm::is_sorted_constexpr(CSorted, std::less<>()),
+              "Explicit std::less non-descending order should be sorted");
+static_assert(!llvm::is_sorted_constexpr(CSorted, std::greater<>()),
+              "Non-descending order should not be sorted by std::greater");
+
 } // namespace

--- a/llvm/unittests/ADT/STLForwardCompatTest.cpp
+++ b/llvm/unittests/ADT/STLForwardCompatTest.cpp
@@ -607,29 +607,33 @@ TEST(STLForwardCompatTest, BindFrontBindBack) {
 
 // Compile-time tests for llvm::is_sorted_constexpr
 static constexpr std::array<int, 0> CEmpty{};
-static_assert(llvm::is_sorted_constexpr(CEmpty),
+static_assert(llvm::is_sorted_constexpr(CEmpty.begin(), CEmpty.end()),
               "Empty range should be sorted");
 
 static constexpr std::array<int, 1> CSingle{{42}};
-static_assert(llvm::is_sorted_constexpr(CSingle),
+static_assert(llvm::is_sorted_constexpr(CSingle.begin(), CSingle.end()),
               "Single element range should be sorted");
-static_assert(llvm::is_sorted_constexpr(CSingle, std::greater<>()),
+static_assert(llvm::is_sorted_constexpr(CSingle.begin(), CSingle.end(),
+                                        std::greater<>()),
               "Single element range should be sorted with std::greater");
 
 static constexpr std::array<int, 5> CSorted{{1, 2, 2, 3, 5}};
-static_assert(llvm::is_sorted_constexpr(CSorted),
+static_assert(llvm::is_sorted_constexpr(CSorted.begin(), CSorted.end()),
               "Non-descending order with duplicates should be sorted");
-static_assert(llvm::is_sorted_constexpr(CSorted, std::less<>()),
+static_assert(llvm::is_sorted_constexpr(CSorted.begin(), CSorted.end(),
+                                        std::less<>()),
               "Explicit std::less non-descending order should be sorted");
-static_assert(!llvm::is_sorted_constexpr(CSorted, std::greater<>()),
+static_assert(!llvm::is_sorted_constexpr(CSorted.begin(), CSorted.end(),
+                                         std::greater<>()),
               "Non-descending order should not be sorted by std::greater");
 
 static constexpr std::array<int, 5> CUnsorted{{1, 3, 2, 4, 5}};
-static_assert(!llvm::is_sorted_constexpr(CUnsorted),
+static_assert(!llvm::is_sorted_constexpr(CUnsorted.begin(), CUnsorted.end()),
               "Unsorted range should not be sorted");
 
 static constexpr std::array<int, 5> CDesc{{9, 7, 7, 3, 0}};
-static_assert(llvm::is_sorted_constexpr(CDesc, std::greater<>()),
+static_assert(llvm::is_sorted_constexpr(CDesc.begin(), CDesc.end(),
+                                        std::greater<>()),
               "Non-ascending order with std::greater should be sorted");
 
 } // namespace

--- a/llvm/unittests/ADT/STLForwardCompatTest.cpp
+++ b/llvm/unittests/ADT/STLForwardCompatTest.cpp
@@ -10,6 +10,7 @@
 #include "CountCopyAndMove.h"
 #include "gtest/gtest.h"
 
+#include <iterator>
 #include <optional>
 #include <type_traits>
 #include <utility>
@@ -606,36 +607,38 @@ TEST(STLForwardCompatTest, BindFrontBindBack) {
 }
 
 // Compile-time tests for llvm::is_sorted_constexpr
-static constexpr std::array<int, 0> CEmpty{};
-static_assert(llvm::is_sorted_constexpr(CEmpty.begin(), CEmpty.end()),
+static constexpr int CEmptyHelper[]{-1};
+static_assert(llvm::is_sorted_constexpr(std::begin(CEmptyHelper),
+                                        std::begin(CEmptyHelper)),
               "Empty range should be sorted");
 
-static constexpr std::array<int, 1> CSingle{{42}};
-static_assert(llvm::is_sorted_constexpr(CSingle.begin(), CSingle.end()),
+static constexpr int CSingle[]{42};
+static_assert(llvm::is_sorted_constexpr(std::begin(CSingle), std::end(CSingle)),
               "Single element range should be sorted");
-static_assert(llvm::is_sorted_constexpr(CSingle.begin(), CSingle.end(),
+static_assert(llvm::is_sorted_constexpr(std::begin(CSingle), std::end(CSingle),
                                         std::greater<>()),
               "Single element range should be sorted with std::greater");
 
-static constexpr std::array<int, 5> CSorted{{1, 2, 2, 3, 5}};
-static_assert(llvm::is_sorted_constexpr(CSorted.begin(), CSorted.end()),
+static constexpr int CSorted[]{1, 2, 2, 3, 5};
+static_assert(llvm::is_sorted_constexpr(std::begin(CSorted), std::end(CSorted)),
               "Non-descending order with duplicates should be sorted");
-static_assert(llvm::is_sorted_constexpr(CSorted.begin(), CSorted.end(),
+static_assert(llvm::is_sorted_constexpr(std::begin(CSorted), std::end(CSorted),
                                         std::less<>()),
               "Explicit std::less non-descending order should be sorted");
-static_assert(!llvm::is_sorted_constexpr(CSorted.begin(), CSorted.end(),
+static_assert(!llvm::is_sorted_constexpr(std::begin(CSorted), std::end(CSorted),
                                          std::greater<>()),
               "Non-descending order should not be sorted by std::greater");
 
-static constexpr std::array<int, 5> CUnsorted{{1, 3, 2, 4, 5}};
-static_assert(!llvm::is_sorted_constexpr(CUnsorted.begin(), CUnsorted.end()),
+static constexpr int CUnsorted[]{1, 3, 2, 4, 5};
+static_assert(!llvm::is_sorted_constexpr(std::begin(CUnsorted),
+                                         std::end(CUnsorted)),
               "Unsorted range should not be sorted");
 
-static constexpr std::array<int, 5> CDesc{{9, 7, 7, 3, 0}};
-static_assert(llvm::is_sorted_constexpr(CDesc.begin(), CDesc.end(),
+static constexpr int CDesc[]{9, 7, 7, 3, 0};
+static_assert(llvm::is_sorted_constexpr(std::begin(CDesc), std::end(CDesc),
                                         std::greater<>()),
               "Non-ascending order with std::greater should be sorted");
-static_assert(llvm::is_sorted_constexpr(CDesc.rbegin(), CDesc.rend()),
+static_assert(llvm::is_sorted_constexpr(std::rbegin(CDesc), std::rend(CDesc)),
               "Reverse iterators should be supported.");
 
 } // namespace

--- a/llvm/unittests/ADT/STLForwardCompatTest.cpp
+++ b/llvm/unittests/ADT/STLForwardCompatTest.cpp
@@ -635,6 +635,8 @@ static constexpr std::array<int, 5> CDesc{{9, 7, 7, 3, 0}};
 static_assert(llvm::is_sorted_constexpr(CDesc.begin(), CDesc.end(),
                                         std::greater<>()),
               "Non-ascending order with std::greater should be sorted");
+static_assert(llvm::is_sorted_constexpr(CDesc.rbegin(), CDesc.rend()),
+              "Reverse iterators should be supported.");
 
 } // namespace
 } // namespace llvm

--- a/llvm/unittests/ADT/STLForwardCompatTest.cpp
+++ b/llvm/unittests/ADT/STLForwardCompatTest.cpp
@@ -605,5 +605,32 @@ TEST(STLForwardCompatTest, BindFrontBindBack) {
   EXPECT_TRUE(any_of(V, Spec1));
 }
 
+// Compile-time tests for llvm::is_sorted_constexpr
+static constexpr std::array<int, 0> CEmpty{};
+static_assert(llvm::is_sorted_constexpr(CEmpty),
+              "Empty range should be sorted");
+
+static constexpr std::array<int, 1> CSingle{{42}};
+static_assert(llvm::is_sorted_constexpr(CSingle),
+              "Single element range should be sorted");
+static_assert(llvm::is_sorted_constexpr(CSingle, std::greater<>()),
+              "Single element range should be sorted with std::greater");
+
+static constexpr std::array<int, 5> CSorted{{1, 2, 2, 3, 5}};
+static_assert(llvm::is_sorted_constexpr(CSorted),
+              "Non-descending order with duplicates should be sorted");
+static_assert(llvm::is_sorted_constexpr(CSorted, std::less<>()),
+              "Explicit std::less non-descending order should be sorted");
+static_assert(!llvm::is_sorted_constexpr(CSorted, std::greater<>()),
+              "Non-descending order should not be sorted by std::greater");
+
+static constexpr std::array<int, 5> CUnsorted{{1, 3, 2, 4, 5}};
+static_assert(!llvm::is_sorted_constexpr(CUnsorted),
+              "Unsorted range should not be sorted");
+
+static constexpr std::array<int, 5> CDesc{{9, 7, 7, 3, 0}};
+static_assert(llvm::is_sorted_constexpr(CDesc, std::greater<>()),
+              "Non-ascending order with std::greater should be sorted");
+
 } // namespace
 } // namespace llvm


### PR DESCRIPTION
For `constexpr` iterables we can check sorted status at compile time rather than runtime.

`std::is_sorted` is not `constexpr` until Cpp20, so had to write a custom `is_sorted_constexpr` function.

Unit tests for `is_sorted_constexpr` were generated by AI.