### PR TITLE
Suppress GCC dangling-pointer false positive for RAII listener pattern

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -324,7 +324,15 @@ public:
 
     explicit DAGUpdateListener(SelectionDAG &D)
       : Next(D.UpdateListeners), DAG(D) {
+      // False positive - RAII pattern, destructor cleans up.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
       DAG.UpdateListeners = this;
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
     }
 
     virtual ~DAGUpdateListener() {


### PR DESCRIPTION
GCC warns about storing `this` here but the destructor cleans it up, so it's a false positive. Suppress with a pragma.

Built with ToT clang and GCC 13.3.0 on Linux x86_64. All existing tests pass.