### PR TITLE
[LLDB] Fix KDP plugin path

### DIFF
--- a/lldb/source/Plugins/Process/MacOSX-Kernel/ProcessKDPProperties.td
+++ b/lldb/source/Plugins/Process/MacOSX-Kernel/ProcessKDPProperties.td
@@ -1,6 +1,6 @@
 include "../../../../include/lldb/Core/PropertiesBase.td"
 
-let Definition = "processkdp", Path = "plugin.process.kdp" in {
+let Definition = "processkdp", Path = "plugin.process.kdp-remote" in {
   def KDPPacketTimeout: Property<"packet-timeout", "UInt64">,
     Global,
     DefaultUnsignedValue<5>,


### PR DESCRIPTION
This should fix a failure on the macOS buildbots (see https://github.com/llvm/llvm-project/pull/179524#issuecomment-3882784085). I can't test this, but the only plugins not enabled on Linux and Windows are `ProcessKDP`, `PlatformDarwin`, and `PlatformDarwinKernel`. Looking at the path for KDP, it uses `GetPluginNameStatic` as the last name in the path. This is `kdp-remote` instead of `kdp`.