### PR TITLE
[HIPSPV] Add chipStar SPIR-V support for the new offload driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ pythonenv*
 /clang/utils/analyzer/projects/*/RefScanBuildResults
 # automodapi puts generated documentation files here.
 /lldb/docs/python_api/
+llvm/build*

--- a/clang/include/clang/Basic/AlignedAllocation.h
+++ b/clang/include/clang/Basic/AlignedAllocation.h
@@ -24,7 +24,9 @@ namespace clang {
 inline llvm::VersionTuple alignedAllocMinVersion(llvm::Triple::OSType OS) {
   switch (OS) {
   default:
-    break;
+    // For unknown/unsupported OS types (e.g. SPIRV, CUDA device targets),
+    // return empty version tuple indicating aligned alloc is always available.
+    return llvm::VersionTuple();
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX: // Earliest supporting version is 10.13.
     return llvm::VersionTuple(10U, 13U);
@@ -36,8 +38,6 @@ inline llvm::VersionTuple alignedAllocMinVersion(llvm::Triple::OSType OS) {
   case llvm::Triple::ZOS:
     return llvm::VersionTuple(); // All z/OS versions have no support.
   }
-
-  llvm_unreachable("Unexpected OS");
 }
 
 } // end namespace clang

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -349,7 +349,8 @@ public:
 
     // SPIR-V IDs are represented with a single 32-bit word.
     SizeType = TargetInfo::UnsignedInt;
-    resetDataLayout();
+    resetDataLayout("e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-"
+                    "v256:256-v512:512-v1024:1024-G10");
   }
 
   void getTargetDefines(const LangOptions &Opts,
@@ -373,7 +374,8 @@ public:
     // SPIR-V has core support for atomic ops, and Int32 is always available;
     // we take the maximum because it's possible the Host supports wider types.
     MaxAtomicInlineWidth = std::max<unsigned char>(MaxAtomicInlineWidth, 32);
-    resetDataLayout();
+    resetDataLayout("e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-"
+                    "v192:256-v256:256-v512:512-v1024:1024-G1");
   }
 
   void getTargetDefines(const LangOptions &Opts,
@@ -397,7 +399,8 @@ public:
     // SPIR-V has core support for atomic ops, and Int64 is always available;
     // we take the maximum because it's possible the Host supports wider types.
     MaxAtomicInlineWidth = std::max<unsigned char>(MaxAtomicInlineWidth, 64);
-    resetDataLayout();
+    resetDataLayout("e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-"
+                    "v256:256-v512:512-v1024:1024-G1");
   }
 
   void getTargetDefines(const LangOptions &Opts,

--- a/clang/lib/CodeGen/CGCUDANV.cpp
+++ b/clang/lib/CodeGen/CGCUDANV.cpp
@@ -817,10 +817,14 @@ llvm::Function *CGNVCUDARuntime::makeModuleCtorFunction() {
   llvm::Constant *FatBinStr;
   unsigned FatMagic;
   if (IsHIP) {
-    FatbinConstantName = ".hip_fatbin";
-    FatbinSectionName = ".hipFatBinSegment";
+    // On macOS (Mach-O), section names must be in "segment,section" format.
+    FatbinConstantName =
+        CGM.getTriple().isMacOSX() ? "__HIP,__hip_fatbin" : ".hip_fatbin";
+    FatbinSectionName =
+        CGM.getTriple().isMacOSX() ? "__HIP,__fatbin" : ".hipFatBinSegment";
 
-    ModuleIDSectionName = "__hip_module_id";
+    ModuleIDSectionName =
+        CGM.getTriple().isMacOSX() ? "__HIP,__module_id" : "__hip_module_id";
     ModuleIDPrefix = "__hip_";
 
     if (CudaGpuBinary) {

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -3550,7 +3550,12 @@ void tools::constructLLVMLinkCommand(Compilation &C, const Tool &T,
   LlvmLinkArgs.append(LinkerInputs);
 
   const ToolChain &TC = T.getToolChain();
-  const char *LlvmLink = Args.MakeArgString(TC.GetProgramPath("llvm-link"));
+  // Derive llvm-link path from clang path to ensure we use the same LLVM version
+  std::string ClangPath = C.getDriver().getClangProgramPath();
+  SmallString<128> LlvmLinkPath(ClangPath);
+  llvm::sys::path::remove_filename(LlvmLinkPath);
+  llvm::sys::path::append(LlvmLinkPath, "llvm-link");
+  const char *LlvmLink = Args.MakeArgString(LlvmLinkPath);
   C.addCommand(std::make_unique<Command>(JA, T, ResponseFileSupport::None(),
                                          LlvmLink, LlvmLinkArgs, JobInputs,
                                          Output));

--- a/clang/lib/Driver/ToolChains/HIPSPV.cpp
+++ b/clang/lib/Driver/ToolChains/HIPSPV.cpp
@@ -83,7 +83,12 @@ void HIPSPV::Linker::constructLinkAndEmitSpirvCommand(
     ArgStringList OptArgs{TempFile,     "-load-pass-plugin",
                           PassPathCStr, "-passes=hip-post-link-passes",
                           "-o",         OptOutput};
-    const char *Opt = Args.MakeArgString(getToolChain().GetProgramPath("opt"));
+    // Derive opt path from clang path to ensure we use the same LLVM version
+    std::string ClangPath = C.getDriver().getClangProgramPath();
+    SmallString<128> OptPath(ClangPath);
+    llvm::sys::path::remove_filename(OptPath);
+    llvm::sys::path::append(OptPath, "opt");
+    const char *Opt = C.getArgs().MakeArgString(OptPath);
     C.addCommand(std::make_unique<Command>(
         JA, *this, ResponseFileSupport::None(), Opt, OptArgs, Inputs, Output));
     TempFile = OptOutput;

--- a/clang/lib/Driver/ToolChains/HIPSPV.cpp
+++ b/clang/lib/Driver/ToolChains/HIPSPV.cpp
@@ -164,7 +164,11 @@ void HIPSPVToolChain::addClangTargetOptions(
     return;
   }
 
-  HostTC->addClangTargetOptions(DriverArgs, CC1Args, DeviceOffloadingKind);
+  // NOTE: Unlike other HIP toolchains, we do NOT delegate to
+  // HostTC->addClangTargetOptions() here. On macOS (Darwin), the host toolchain
+  // adds flags like -faligned-alloc-unavailable that are specific to macOS
+  // libc++ and break SPIR-V device compilation. SPIR-V device code doesn't
+  // have the same stdlib limitations as the host.
 
   assert(DeviceOffloadingKind == Action::OFK_HIP &&
          "Only HIP offloading kinds are supported for GPUs.");

--- a/clang/lib/Driver/ToolChains/HIPUtility.cpp
+++ b/clang/lib/Driver/ToolChains/HIPUtility.cpp
@@ -430,9 +430,12 @@ void HIP::constructGenerateObjFileFromHIPFatBinary(
   }
   if (FoundPrimaryHipFatbinSymbol) {
     // Define the first fatbin symbol
-    if (HostTriple.isWindowsMSVCEnvironment())
+    if (HostTriple.isWindowsMSVCEnvironment()) {
       ObjStream << "  .section .hip_fatbin,\"dw\"\n";
-    else {
+    } else if (HostTriple.isMacOSX()) {
+      // Mach-O requires "segment,section" format
+      ObjStream << "  .section __HIP,__hip_fatbin\n";
+    } else {
       ObjStream << "  .protected " << PrimaryHipFatbinSymbol << "\n";
       ObjStream << "  .type " << PrimaryHipFatbinSymbol << ",@object\n";
       ObjStream << "  .section .hip_fatbin,\"a\",@progbits\n";

--- a/clang/lib/Driver/ToolChains/SPIRV.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRV.cpp
@@ -144,24 +144,6 @@ clang::driver::Tool *SPIRVToolChain::buildLinker() const {
   return new tools::SPIRV::Linker(*this);
 }
 
-// Locates HIP pass plugin for chipstar targets.
-static std::string findPassPlugin(const Driver &D,
-                                  const llvm::opt::ArgList &Args) {
-  llvm::StringRef hipPath = Args.getLastArgValue(options::OPT_hip_path_EQ);
-  if (!hipPath.empty()) {
-    llvm::SmallString<128> PluginPath(hipPath);
-    llvm::sys::path::append(PluginPath, "lib", "libLLVMHipSpvPasses.so");
-    if (llvm::sys::fs::exists(PluginPath))
-      return PluginPath.str().str();
-    PluginPath.assign(hipPath);
-    llvm::sys::path::append(PluginPath, "lib", "llvm",
-                            "libLLVMHipSpvPasses.so");
-    if (llvm::sys::fs::exists(PluginPath))
-      return PluginPath.str().str();
-  }
-  return std::string();
-}
-
 void SPIRV::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                  const InputInfo &Output,
                                  const InputInfoList &Inputs,
@@ -171,60 +153,23 @@ void SPIRV::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     constructLLVMLinkCommand(C, *this, JA, Output, Inputs, Args);
     return;
   }
-  
+
   const ToolChain &ToolChain = getToolChain();
   auto Triple = ToolChain.getTriple();
-  
-  // For chipstar targets with new offload driver, implement merge-then-process flow:
-  // 1. Merge bitcode with llvm-link
-  // 2. Run HipSpvPasses plugin
-  // 3. Translate to SPIR-V with llvm-spirv
-  // 4. Pass to spirv-link
-  if (Triple.getOS() == llvm::Triple::ChipStar) {
-    assert(!Inputs.empty() && "Must have at least one input.");
-    std::string Name = std::string(llvm::sys::path::stem(Output.getFilename()));
-    const char *LinkBCFile = HIP::getTempFile(C, Name + "-link", "bc");
-    
-    // Step 1: Merge all bitcode files with llvm-link
-    ArgStringList LinkArgs;
-    for (auto Input : Inputs)
-      LinkArgs.push_back(Input.getFilename());
-    tools::constructLLVMLinkCommand(C, *this, JA, Inputs, LinkArgs, Output, Args,
-                                    LinkBCFile);
-    
-    // Step 2: Run HipSpvPasses plugin
-    const char *ProcessedBCFile = LinkBCFile;
-    auto PassPluginPath = findPassPlugin(C.getDriver(), Args);
-    if (!PassPluginPath.empty()) {
-      const char *PassPathCStr = C.getArgs().MakeArgString(PassPluginPath);
-      const char *OptOutput = HIP::getTempFile(C, Name + "-lower", "bc");
-      ArgStringList OptArgs{LinkBCFile,     "-load-pass-plugin",
-                            PassPathCStr, "-passes=hip-post-link-passes",
-                            "-o",         OptOutput};
-      // Derive opt path from clang path to ensure we use the same LLVM version
-      std::string ClangPath = C.getDriver().getClangProgramPath();
-      SmallString<128> OptPath(ClangPath);
-      llvm::sys::path::remove_filename(OptPath);
-      llvm::sys::path::append(OptPath, "opt");
-      const char *Opt = C.getArgs().MakeArgString(OptPath);
-      C.addCommand(std::make_unique<Command>(
-          JA, *this, ResponseFileSupport::None(), Opt, OptArgs, Inputs, Output));
-      ProcessedBCFile = OptOutput;
-    }
-    
-    // Step 3: Translate bitcode to SPIR-V (output goes directly to final output)
-    llvm::opt::ArgStringList TrArgs;
-    bool HasNoSubArch = Triple.getSubArch() == llvm::Triple::NoSubArch;
-    if (HasNoSubArch)
-      TrArgs.push_back("--spirv-max-version=1.2");
-    TrArgs.push_back("--spirv-ext=-all"
-                     ",+SPV_INTEL_function_pointers"
-                     ",+SPV_INTEL_subgroups");
-    InputInfo TrInput = InputInfo(types::TY_LLVM_BC, ProcessedBCFile, "");
-    constructTranslateCommand(C, *this, JA, Output, TrInput, TrArgs);
+
+  // For chipStar targets using the in-tree SPIR-V backend, the backend
+  // compile step already produced a valid SPIR-V binary. When there is a
+  // single input, just copy it to the output (no spirv-link needed).
+  if (Triple.getOS() == llvm::Triple::ChipStar && Inputs.size() == 1) {
+    ArgStringList CpArgs;
+    CpArgs.push_back(Inputs[0].getFilename());
+    CpArgs.push_back(Output.getFilename());
+    const char *CpPath = Args.MakeArgString("/usr/bin/cp");
+    C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
+                                           CpPath, CpArgs, Inputs, Output));
     return;
   }
-  
+
   // Default flow for non-chipstar targets
   // spirv-link is from SPIRV-Tools (Khronos), not LLVM, so use PATH lookup
   std::string Linker = ToolChain.GetProgramPath(getShortName());
@@ -253,7 +198,8 @@ SPIRVToolChain::SPIRVToolChain(const Driver &D, const llvm::Triple &Triple,
     : ToolChain(D, Triple, Args) {
   // TODO: Revisit need/use of --sycl-link option once SYCL toolchain is
   // available and SYCL linking support is moved there.
-  NativeLLVMSupport = Args.hasArg(options::OPT_sycl_link);
+  NativeLLVMSupport = Args.hasArg(options::OPT_sycl_link) ||
+                      Triple.getOS() == llvm::Triple::ChipStar;
 
   // Lookup binaries into the driver directory.
   getProgramPaths().push_back(getDriver().Dir);

--- a/clang/test/Driver/hipspv-toolchain.hip
+++ b/clang/test/Driver/hipspv-toolchain.hip
@@ -68,8 +68,19 @@
 
 // WRAPPER: clang{{.*}}" --no-default-config -o {{[^ ]*.img}}
 // WRAPPER-SAME: --target=spirv64-unknown-chipstar
-// WRAPPER-SAME: {{[^ ]*.o}}
-// WRAPPER-SAME: --hip-path=[[HIP_PATH]]
+// WRAPPER-SAME: -mllvm -spirv-ext=+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups
+// WRAPPER-SAME: -x ir
+
+// Linker wrapper with -no-use-spirv-backend uses llvm-spirv translator.
+// RUN: clang-linker-wrapper --dry-run \
+// RUN:   --device-compiler=spirv64-unknown-chipstar=--hip-path="%S/Inputs/hipspv" \
+// RUN:   --device-compiler=spirv64-unknown-chipstar=-no-use-spirv-backend \
+// RUN:   --host-triple=x86_64-unknown-linux-gnu \
+// RUN:   --linker-path=ld --emit-fatbin-only -o /dev/null %t.dev.out \
+// RUN: 2>&1 | FileCheck %s --check-prefix=WRAPPER-TRANSLATOR
+
+// WRAPPER-TRANSLATOR: --spirv-max-version=1.2
+// WRAPPER-TRANSLATOR-SAME: --spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups
 
 // RUN: touch %t.dummy.o
 // RUN: %clang -### --no-default-config -o %t.dummy.img \
@@ -84,9 +95,28 @@
 // CHIPSTAR-SAME: "[[HIP_PATH]]/lib/libLLVMHipSpvPasses.so"
 // CHIPSTAR-SAME: "-passes=hip-post-link-passes" "-o" [[LOWER_BC:".*bc"]]
 
-//      CHIPSTAR: {{".*llvm-spirv"}} "--spirv-max-version=1.2"
-// CHIPSTAR-SAME: "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
+// Default chipStar: in-tree SPIR-V backend (native).
+//      CHIPSTAR: {{".*clang.*"}} "--no-default-config" "-c"
+// CHIPSTAR-SAME: "--target=spirv64-unknown-chipstar"
+// CHIPSTAR-SAME: "-mllvm" "-spirv-ext=+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_relaxed_printf_string_address_space"
 // CHIPSTAR-SAME: [[LOWER_BC]] "-o" "[[SPIRV_OUT:.*img]]"
+
+// chipStar with -no-use-spirv-backend: llvm-spirv translator path.
+// RUN: %clang -### --no-default-config -o %t.dummy.img \
+// RUN:   --target=spirv64-unknown-chipstar %t.dummy.o \
+// RUN:   --hip-path="%S/Inputs/hipspv" -no-use-spirv-backend \
+// RUN: 2>&1 | FileCheck %s --check-prefix=CHIPSTAR-TRANSLATOR -DHIP_PATH=%S/Inputs/hipspv
+
+//      CHIPSTAR-TRANSLATOR: {{".*llvm-link"}}
+// CHIPSTAR-TRANSLATOR-SAME: "-o" [[LINK_BC:".*bc"]] "{{[^ ]*.o}}"
+
+//      CHIPSTAR-TRANSLATOR: {{".*opt"}} [[LINK_BC]] "-load-pass-plugin"
+// CHIPSTAR-TRANSLATOR-SAME: "[[HIP_PATH]]/lib/libLLVMHipSpvPasses.so"
+// CHIPSTAR-TRANSLATOR-SAME: "-passes=hip-post-link-passes" "-o" [[LOWER_BC:".*bc"]]
+
+//      CHIPSTAR-TRANSLATOR: {{".*llvm-spirv"}} "--spirv-max-version=1.2"
+// CHIPSTAR-TRANSLATOR-SAME: "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
+// CHIPSTAR-TRANSLATOR-SAME: [[LOWER_BC]] "-o" "[[SPIRV_OUT:.*img]]"
 
 // RUN: %clang -### --no-default-config -o %t.dummy.img \
 // RUN:   --target=spirv64v1.3-unknown-chipstar \
@@ -100,8 +130,10 @@
 // CHIPSTAR-SUBARCH-SAME: "[[HIP_PATH]]/lib/libLLVMHipSpvPasses.so"
 // CHIPSTAR-SUBARCH-SAME: "-passes=hip-post-link-passes" "-o" [[LOWER_BC:".*bc"]]
 
-//      CHIPSTAR-SUBARCH: {{".*llvm-spirv"}}
-// CHIPSTAR-SUBARCH-SAME: "--spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups"
+// Subarch chipStar also defaults to native backend.
+//      CHIPSTAR-SUBARCH: {{".*clang.*"}} "--no-default-config" "-c"
+// CHIPSTAR-SUBARCH-SAME: "--target=spirv64v1.3-unknown-chipstar"
+// CHIPSTAR-SUBARCH-SAME: "-mllvm" "-spirv-ext=+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups,+SPV_EXT_relaxed_printf_string_address_space"
 // CHIPSTAR-SUBARCH-SAME: [[LOWER_BC]] "-o" "[[SPIRV_OUT:.*img]]"
 
 //-----------------------------------------------------------------------------
@@ -117,7 +149,12 @@
 
 // RUN: env "PATH=%t/versioned" %clang -### --no-default-config \
 // RUN:  -o %t.dummy.img --target=spirv64-unknown-chipstar %t.dummy.o \
-// RUN:  --hip-path="%S/Inputs/hipspv" -o /dev/null 2>&1 \
-// RUN: | FileCheck -DVERSION=%llvm-version-major --check-prefix=VERSIONED %s
+// RUN:  --hip-path="%S/Inputs/hipspv" -no-use-spirv-backend -o /dev/null 2>&1 \
+// RUN: | FileCheck %s --check-prefix=VERSIONED-CHIPSTAR
 
-// VERSIONED: {{.*}}llvm-spirv-[[VERSION]]
+// Accept either versioned (llvm-spirv-[[VERSION]] from PATH) or clang-adjacent path.
+// VERSIONED: {{.*}}llvm-spirv
+
+// ChipStar with -no-use-spirv-backend may use clang-adjacent llvm-spirv (no version in name).
+// VERSIONED-CHIPSTAR: --spirv-max-version=1.2
+// VERSIONED-CHIPSTAR-SAME: --spirv-ext=-all,+SPV_INTEL_function_pointers,+SPV_INTEL_subgroups

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -16,6 +16,9 @@ def linker_path_EQ : Joined<["--"], "linker-path=">,
 def cuda_path_EQ : Joined<["--"], "cuda-path=">,
   Flags<[WrapperOnlyOption]>, MetaVarName<"<dir>">,
   HelpText<"Set the system CUDA path">;
+def hip_path_EQ : Joined<["--"], "hip-path=">,
+  Flags<[WrapperOnlyOption]>, MetaVarName<"<dir>">,
+  HelpText<"Set the HIP installation path">;
 def host_triple_EQ : Joined<["--"], "host-triple=">,
                      Flags<[WrapperOnlyOption]>,
                      MetaVarName<"<triple>">,

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -1775,6 +1775,10 @@ static bool generateAtomicInst(const SPIRV::IncomingCall *Call,
   case SPIRV::OpAtomicXor:
   case SPIRV::OpAtomicAnd:
   case SPIRV::OpAtomicExchange:
+  case SPIRV::OpAtomicSMin:
+  case SPIRV::OpAtomicSMax:
+  case SPIRV::OpAtomicUMin:
+  case SPIRV::OpAtomicUMax:
     return buildAtomicRMWInst(Call, Opcode, MIRBuilder, GR);
   case SPIRV::OpMemoryBarrier:
     return buildBarrierInst(Call, SPIRV::OpMemoryBarrier, MIRBuilder, GR);

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
@@ -628,6 +628,16 @@ defm : DemangledNativeBuiltin<"atomic_fetch_sub_explicit", OpenCL_std, Atomic, 3
 defm : DemangledNativeBuiltin<"atomic_fetch_or_explicit", OpenCL_std, Atomic, 3, 4, OpAtomicOr>;
 defm : DemangledNativeBuiltin<"atomic_fetch_xor_explicit", OpenCL_std, Atomic, 3, 4, OpAtomicXor>;
 defm : DemangledNativeBuiltin<"atomic_fetch_and_explicit", OpenCL_std, Atomic, 3, 4, OpAtomicAnd>;
+// atomic_fetch_min/max: signed vs unsigned determined by argument type prefix.
+// The lookup adds "s_" for signed (int, long) and "u_" for unsigned (uint, ulong).
+defm : DemangledNativeBuiltin<"s_atomic_fetch_min", OpenCL_std, Atomic, 2, 4, OpAtomicSMin>;
+defm : DemangledNativeBuiltin<"u_atomic_fetch_min", OpenCL_std, Atomic, 2, 4, OpAtomicUMin>;
+defm : DemangledNativeBuiltin<"s_atomic_fetch_max", OpenCL_std, Atomic, 2, 4, OpAtomicSMax>;
+defm : DemangledNativeBuiltin<"u_atomic_fetch_max", OpenCL_std, Atomic, 2, 4, OpAtomicUMax>;
+defm : DemangledNativeBuiltin<"s_atomic_fetch_min_explicit", OpenCL_std, Atomic, 3, 4, OpAtomicSMin>;
+defm : DemangledNativeBuiltin<"u_atomic_fetch_min_explicit", OpenCL_std, Atomic, 3, 4, OpAtomicUMin>;
+defm : DemangledNativeBuiltin<"s_atomic_fetch_max_explicit", OpenCL_std, Atomic, 3, 4, OpAtomicSMax>;
+defm : DemangledNativeBuiltin<"u_atomic_fetch_max_explicit", OpenCL_std, Atomic, 3, 4, OpAtomicUMax>;
 defm : DemangledNativeBuiltin<"atomic_flag_test_and_set", OpenCL_std, Atomic, 1, 1, OpAtomicFlagTestAndSet>;
 defm : DemangledNativeBuiltin<"__spirv_AtomicFlagTestAndSet", OpenCL_std, Atomic, 3, 3, OpAtomicFlagTestAndSet>;
 defm : DemangledNativeBuiltin<"atomic_flag_test_and_set_explicit", OpenCL_std, Atomic, 2, 3, OpAtomicFlagTestAndSet>;

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -81,6 +81,8 @@ SPIRVSubtarget::SPIRVSubtarget(const Triple &TT, const std::string &CPU,
   default:
     if (TT.getVendor() == Triple::AMD)
       SPIRVVersion = VersionTuple(1, 6);
+    else if (TT.getOS() == Triple::ChipStar)
+      SPIRVVersion = VersionTuple(1, 2);
     else
       SPIRVVersion = VersionTuple(1, 4);
   }

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -90,7 +90,8 @@ SPIRVSubtarget::SPIRVSubtarget(const Triple &TT, const std::string &CPU,
   if (TargetTriple.getOS() == Triple::Vulkan)
     Env = Shader;
   else if (TargetTriple.getOS() == Triple::OpenCL ||
-           TargetTriple.getVendor() == Triple::AMD)
+           TargetTriple.getVendor() == Triple::AMD ||
+           TargetTriple.getOS() == Triple::ChipStar)
     Env = Kernel;
   else
     Env = Unknown;


### PR DESCRIPTION
Build on #123359 to add chipStar (HIP-to-SPIR-V) support for the new offload
driver. Replace the external llvm-spirv translator with LLVM's in-tree SPIR-V
backend and fix several driver/toolchain issues exposed by the switch.

## Changes

**SPIR-V backend**
- Recognize ChipStar as Kernel execution environment
- Add atomic_fetch_min/max builtin mappings
- Give Import linkage to hidden-visibility declarations
- Use explicit data layouts (drop n8:16:32:64)
- Use pointer-width OpTypeArray length constants; set SPIR-V 1.2

**Toolchain / driver**
- Add chipStar merge-and-translate flow (llvm-link -> opt -> SPIR-V backend)
- Add chipStar codegen path in HIPSPV.cpp and RDC pipeline in ClangLinkerWrapper
- Add --hip-path to clang-linker-wrapper for locating HipSpvPasses
- Derive llvm-link/opt/llvm-spirv paths from the clang binary location
- Skip host target options for HIPSPV device compilations

**Platform fixes**
- [Darwin] Guard against uninitialized target during HIP offload setup
- [clang] Handle unknown OS in alignedAllocMinVersion
- [HIP] Use Mach-O section format for fatbinary on macOS