### PR TITLE
[LangRef] Clarify nsz semantics

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -4162,9 +4162,9 @@ following flags to enable otherwise unsafe floating-point transformations.
    produces a :ref:`poison value <poisonvalues>` instead.
 
 ``nsz``
-   No Signed Zeros - Allow optimizations to treat the sign of a zero
-   argument or zero result as insignificant. This does not imply that -0.0
-   is poison and/or guaranteed to not exist in the operation.
+   No Signed Zeros - Unless otherwise mentioned, the sign bit of 0.0 or -0.0
+   input operands can be non-deterministically flipped. This does not imply
+   that -0.0 is poison and/or guaranteed to not exist in the operation.
 
 Note: For :ref:`phi <i_phi>`, :ref:`select <i_select>`, and :ref:`call <i_call>`
 instructions, the following return types are considered to be floating-point

--- a/llvm/test/Transforms/InstCombine/intrinsic-select.ll
+++ b/llvm/test/Transforms/InstCombine/intrinsic-select.ll
@@ -337,7 +337,7 @@ define double @test_fabs_select_fmf1(i1 %cond, double %a) {
 define double @test_fabs_select_fmf2(i1 %cond, double %a) {
 ; CHECK-LABEL: @test_fabs_select_fmf2(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call double @llvm.fabs.f64(double [[A:%.*]])
-; CHECK-NEXT:    [[SEL1:%.*]] = select nnan ninf nsz i1 [[COND:%.*]], double 0.000000e+00, double [[TMP1]]
+; CHECK-NEXT:    [[SEL1:%.*]] = select nnan ninf i1 [[COND:%.*]], double 0.000000e+00, double [[TMP1]]
 ; CHECK-NEXT:    ret double [[SEL1]]
 ;
   %sel1 = select i1 %cond, double 0.0, double %a


### PR DESCRIPTION
The current LangRef wording says that the sign of a zero argument or result is "insignificant", which is not really clear on what this means.

Alive2 models this as non-deterministically flipping the zero sign bits for both inputs and outputs.

This PR proposes to specify this flag as non-deterministically flipping inputs only. A consequence of this is that fabs is guaranteed to have an unset sign bit even if the input is zero (that is, https://alive2.llvm.org/ce/z/irCftQ is no longer a valid transform), and that the copysign result sign only depends on the second operand (that is, https://alive2.llvm.org/ce/z/VnHdfh is no longer a valid transform).

These rules are still more liberal than we'd really like them to be, but at least avoid some of the issues with nsz.

This is based on the discussion in:
https://discourse.llvm.org/t/rfc-clarify-the-behavior-of-fp-operations-on-bit-strings-with-nsz-flag/85981