### PR TITLE
clang/AMDGPU: Remove dead code in RocmInstallationDetector

### DIFF
--- a/clang/include/clang/Driver/RocmInstallationDetector.h
+++ b/clang/include/clang/Driver/RocmInstallationDetector.h
@@ -177,8 +177,7 @@ private:
 public:
   RocmInstallationDetector(const Driver &D, const llvm::Triple &HostTriple,
                            const llvm::opt::ArgList &Args,
-                           bool DetectHIPRuntime = true,
-                           bool DetectDeviceLib = false);
+                           bool DetectHIPRuntime = true);
 
   /// Get file paths of default bitcode libraries common to AMDGPU based
   /// toolchains.

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -323,7 +323,7 @@ RocmInstallationDetector::getInstallationPathCandidates() {
 
 RocmInstallationDetector::RocmInstallationDetector(
     const Driver &D, const llvm::Triple &HostTriple,
-    const llvm::opt::ArgList &Args, bool DetectHIPRuntime, bool DetectDeviceLib)
+    const llvm::opt::ArgList &Args, bool DetectHIPRuntime)
     : D(D) {
   Verbose = Args.hasArg(options::OPT_v);
   RocmPathArg = Args.getLastArgValue(options::OPT_rocm_path_EQ);
@@ -377,8 +377,6 @@ RocmInstallationDetector::RocmInstallationDetector(
 
   if (DetectHIPRuntime)
     detectHIPRuntime();
-  if (DetectDeviceLib)
-    detectDeviceLibrary();
 }
 
 void RocmInstallationDetector::detectDeviceLibrary() {


### PR DESCRIPTION
The defaulted constructor argument isn't used anywhere, so
this path is unreachable.