### PR TITLE
[clang] Reject using uninitialized reference in constant evaluation

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -263,6 +263,7 @@ Bug Fixes to C++ Support
 - Fixed a crash when instantiating ``requires`` expressions involving substitution failures in C++ concepts. (#GH176402)
 - Fixed a crash when a default argument is passed to an explicit object parameter. (#GH176639)
 - Fixed a crash when diagnosing an invalid static member function with an explicit object parameter (#GH177741)
+- Using uninitialized reference in constant evaluation is now correctly rejected.
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/AST/ByteCode/cxx23.cpp
+++ b/clang/test/AST/ByteCode/cxx23.cpp
@@ -90,11 +90,8 @@ namespace ThreadLocalStore {
   void store() { a = 42; }
 }
 
-#if __cplusplus >= 202302L
 constexpr int &b = b; // all-error {{must be initialized by a constant expression}} \
-                      // all-note {{initializer of 'b' is not a constant expression}} \
-                      // all-note {{declared here}}
-#endif
+                      // all-note {{use of reference outside its lifetime is not allowed in a constant expression}}
 
 namespace StaticLambdas {
   constexpr auto static_capture_constexpr() {

--- a/clang/test/SemaCXX/constant-expression-cxx11.cpp
+++ b/clang/test/SemaCXX/constant-expression-cxx11.cpp
@@ -2012,8 +2012,7 @@ namespace ConstexprConstructorRecovery {
 
 namespace Lifetime {
   void f() {
-    constexpr int &n = n; // expected-error {{constant expression}} cxx23-note {{reference to 'n' is not a constant expression}} cxx23-note {{address of non-static constexpr variable 'n' may differ}} expected-warning {{not yet bound to a value}}
-                          // cxx11_20-note@-1 {{use of reference outside its lifetime is not allowed in a constant expression}}
+    constexpr int &n = n; // expected-error {{constant expression}} expected-note {{use of reference outside its lifetime is not allowed in a constant expression}} expected-warning {{not yet bound to a value}}
     constexpr int m = m; // expected-error {{constant expression}} expected-note {{read of object outside its lifetime}}
   }
 
@@ -2074,6 +2073,9 @@ namespace Lifetime {
   void rf() {
     constexpr R r; // expected-error {{constant expression}} expected-note {{in call}}
   }
+
+  constexpr int k5 = 0;
+  constexpr const int &ref = (ref, k5); // expected-error {{constant expression}} expected-note {{use of reference outside its lifetime is not allowed in a constant expression}}
 }
 
 namespace Bitfields {

--- a/clang/test/SemaCXX/constant-expression-p2280r4.cpp
+++ b/clang/test/SemaCXX/constant-expression-p2280r4.cpp
@@ -216,14 +216,14 @@ namespace uninit_reference_used {
   // expected-note {{use of reference outside its lifetime is not allowed in a constant expression}}
   constexpr int &g() {
     int &x = x; // expected-warning {{reference 'x' is not yet bound to a value when used within its own initialization}} \
-    // expected-note {{use of reference outside its lifetime is not allowed in a constant expression}} \
+    // expected-note {{use of reference outside its lifetime is not allowed in a constant expression}}
     return x;
   }
   constexpr int &gg = g(); // expected-error {{must be initialized by a constant expression}} \
   // expected-note {{in call to 'g()'}}
   constexpr int g2() {
     int &x = x; // expected-warning {{reference 'x' is not yet bound to a value when used within its own initialization}} \
-    // expected-note {{use of reference outside its lifetime is not allowed in a constant expression}} \
+    // expected-note {{use of reference outside its lifetime is not allowed in a constant expression}}
     return x;
   }
   constexpr int gg2 = g2(); // expected-error {{must be initialized by a constant expression}} \
@@ -247,7 +247,7 @@ namespace uninit_reference_used {
   // expected-note {{in call to 'g4()'}}
   constexpr int g5() {
     int &x = x; // expected-warning {{reference 'x' is not yet bound to a value when used within its own initialization}} \
-    // expected-note {{use of reference outside its lifetime is not allowed in a constant expression}} \
+    // expected-note {{use of reference outside its lifetime is not allowed in a constant expression}}
     return 3;
   }
   constexpr uintptr_t gg5 = g5(); // expected-error {{must be initialized by a constant expression}} \


### PR DESCRIPTION
Evaluating uninitialized reference is undefined behaviour. So rejecting it in constant evaluation. Note that discarded-value expression IS evaluated.

```cpp
constexpr int x = 0;
// previous: accepted
// expected: reject evaluating `ref` because it is not initialized
constexpr const int &ref = (ref, x);
//                          ^^^
// undefined behaviour in runtime although the evaluation is discarded (comma operator)
```

Previously, current constant interpreter ignored that it is uninitialized, used empty `APValue` to represent the reference, and didn't reject until it wants to know what the reference refers to.

Bytecode interpreter ignored discarded `DeclRefExpr`, so it had similar issue.

This patch fixes these issues, and updates diagnostic messages of bytecode interpreter to match messages of current constant interpreter.

There are diagnostic regressions for bytecode interpreter because [P2280R4](https://wg21.link/p2280r4) is not implemented.

Fixes #157082

AI usage: Changes in Compiler.cpp is generated by AI and modified by me afterwards.

Assisted-by: GPT-5.2