### PR TITLE
[LAA] Get conflicts in loop-invariant addresses

### DIFF
--- a/llvm/include/llvm/Analysis/LoopAccessAnalysis.h
+++ b/llvm/include/llvm/Analysis/LoopAccessAnalysis.h
@@ -775,6 +775,12 @@ public:
     return StoresToInvariantAddresses;
   }
 
+  /// Returns conflicts between loads and stores to invariant addresses.
+  ArrayRef<std::pair<LoadInst *, StoreInst *>>
+  getInvariantAddressConflicts() const {
+    return InvariantAddressConflicts;
+  }
+
   /// Used to add runtime SCEV checks. Simplifies SCEV expressions and converts
   /// them to a more usable form.  All SCEV expressions during the analysis
   /// should be re-written (and therefore simplified) according to PSE.
@@ -852,6 +858,9 @@ private:
 
   /// List of stores to invariant addresses.
   SmallVector<StoreInst *> StoresToInvariantAddresses;
+
+  /// List of conflict pair due to accessing the same loop-invariant address.
+  SmallVector<std::pair<LoadInst *, StoreInst *>> InvariantAddressConflicts;
 
   /// The diagnostics report generated for the analysis.  E.g. why we
   /// couldn't analyze the loop.


### PR DESCRIPTION
This is part of the work tracked in #168312.
In preparation to #165312, add the ability to gather the pairs of load and store that conflicts by accessing the same IV address.

Co-Authored-By: Felipe Magno de Almeida <felipe@expertise.dev>