### PR TITLE
Reapply "[MC][TableGen] Expand Opcode field of MCInstrDesc" (#180321)

### DIFF
--- a/llvm/docs/HowToUseInstrMappings.rst
+++ b/llvm/docs/HowToUseInstrMappings.rst
@@ -61,7 +61,7 @@ Sample Example
 --------------
 
 Let's say that we want to have a function
-``int getPredOpcode(uint16_t Opcode, enum PredSense inPredSense)`` which
+``int getPredOpcode(uint32_t Opcode, enum PredSense inPredSense)`` which
 takes a non-predicated instruction and returns its predicated true or false form
 depending on some input flag, ``inPredSense``. The first step in the process is
 to define a relationship model that relates predicated instructions to their
@@ -107,7 +107,7 @@ instruction since they are the ones used to query the interface function.
 TableGen uses the above relationship model to emit relation table that maps
 non-predicated instructions with their predicated forms. It also outputs the
 interface function
-``int getPredOpcode(uint16_t Opcode, enum PredSense inPredSense)`` to query
+``int getPredOpcode(uint32_t Opcode, enum PredSense inPredSense)`` to query
 the table. Here, Function ``getPredOpcode`` takes two arguments, opcode of the
 current instruction and PredSense of the desired instruction, and returns
 predicated form of the instruction, if found in the relation table.

--- a/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h
@@ -1058,7 +1058,7 @@ bool GIMatchTableExecutor::executeMatchTable(
     case GIR_MutateOpcode: {
       uint64_t OldInsnID = readULEB();
       uint64_t NewInsnID = readULEB();
-      uint16_t NewOpcode = readU16();
+      uint32_t NewOpcode = readU16();
       if (NewInsnID >= OutMIs.size())
         OutMIs.resize(NewInsnID + 1);
 
@@ -1079,7 +1079,7 @@ bool GIMatchTableExecutor::executeMatchTable(
     case GIR_BuildRootMI:
     case GIR_BuildMI: {
       uint64_t NewInsnID = (MatcherOpcode == GIR_BuildRootMI) ? 0 : readULEB();
-      uint16_t Opcode = readU16();
+      uint32_t Opcode = readU16();
       if (NewInsnID >= OutMIs.size())
         OutMIs.resize(NewInsnID + 1);
 

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -156,7 +156,7 @@ private:
   uint8_t AsmPrinterFlags;
 
   /// Cached opcode from MCID.
-  uint16_t Opcode;
+  uint32_t Opcode;
 
   /// Unique instruction number. Used by DBG_INSTR_REFs to refer to the values
   /// defined by this instruction.

--- a/llvm/include/llvm/MC/MCInstrDesc.h
+++ b/llvm/include/llvm/MC/MCInstrDesc.h
@@ -203,17 +203,17 @@ public:
   // the <Target>Insts table because they rely on knowing their own address to
   // find other information elsewhere in the same table.
 
-  unsigned short Opcode;         // The opcode number
-  unsigned short NumOperands;    // Num of args (may be more if variable_ops)
-  unsigned char NumDefs;         // Num of args that are definitions
-  unsigned char Size;            // Number of bytes in encoding.
-  unsigned short SchedClass;     // enum identifying instr sched class
-  unsigned char NumImplicitUses; // Num of regs implicitly used
-  unsigned char NumImplicitDefs; // Num of regs implicitly defined
-  unsigned short OpInfoOffset;   // Offset to info about operands
-  unsigned short ImplicitOffset; // Offset to start of implicit op list
-  uint64_t Flags;                // Flags identifying machine instr class
-  uint64_t TSFlags;              // Target Specific Flag values
+  uint32_t Opcode;         // The opcode number.
+  uint16_t NumOperands;    // Num of args (may be more if variable_ops)
+  uint8_t NumDefs;         // Num of args that are definitions
+  uint8_t Size;            // Number of bytes in encoding.
+  uint16_t SchedClass;     // enum identifying instr sched class
+  uint8_t NumImplicitUses; // Num of regs implicitly used
+  uint8_t NumImplicitDefs; // Num of regs implicitly defined
+  uint16_t OpInfoOffset;   // Offset to info about operands
+  uint16_t ImplicitOffset; // Offset to start of implicit op list
+  uint64_t Flags;          // Flags identifying machine instr class
+  uint64_t TSFlags;        // Target Specific Flag values
 
   /// Returns the value of the specified operand constraint if
   /// it is present. Returns -1 if it is not present.

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -4227,8 +4227,8 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
     case OPC_MorphNodeTo2GlueInput:
     case OPC_MorphNodeTo1GlueOutput:
     case OPC_MorphNodeTo2GlueOutput: {
-      uint16_t TargetOpc = MatcherTable[MatcherIndex++];
-      TargetOpc |= static_cast<uint16_t>(MatcherTable[MatcherIndex++]) << 8;
+      uint32_t TargetOpc = MatcherTable[MatcherIndex++];
+      TargetOpc |= (MatcherTable[MatcherIndex++] << 8);
       unsigned EmitNodeInfo;
       if (Opcode >= OPC_EmitNode1None && Opcode <= OPC_EmitNode2Chain) {
         if (Opcode >= OPC_EmitNode0Chain && Opcode <= OPC_EmitNode2Chain)

--- a/llvm/lib/MCA/InstrBuilder.cpp
+++ b/llvm/lib/MCA/InstrBuilder.cpp
@@ -563,7 +563,7 @@ InstrBuilder::createInstrDescImpl(const MCInst &MCI,
          "Itineraries are not yet supported!");
 
   // Obtain the instruction descriptor from the opcode.
-  unsigned short Opcode = MCI.getOpcode();
+  unsigned Opcode = MCI.getOpcode();
   const MCInstrDesc &MCDesc = MCII.get(Opcode);
   const MCSchedModel &SM = STI.getSchedModel();
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -890,11 +890,11 @@ enum SMEMatrixType {
 #undef TSFLAG_INSTR_FLAGS
 #undef TSFLAG_SME_MATRIX_TYPE
 
-int getSVEPseudoMap(uint16_t Opcode);
-int getSVERevInstr(uint16_t Opcode);
-int getSVENonRevInstr(uint16_t Opcode);
+int64_t getSVEPseudoMap(uint32_t Opcode);
+int64_t getSVERevInstr(uint32_t Opcode);
+int64_t getSVENonRevInstr(uint32_t Opcode);
 
-int getSMEPseudoMap(uint16_t Opcode);
+int64_t getSMEPseudoMap(uint32_t Opcode);
 }
 
 } // end namespace llvm

--- a/llvm/lib/Target/AMDGPU/MCA/AMDGPUCustomBehaviour.cpp
+++ b/llvm/lib/Target/AMDGPU/MCA/AMDGPUCustomBehaviour.cpp
@@ -322,13 +322,13 @@ bool AMDGPUCustomBehaviour::hasModifiersSet(
 }
 
 // taken from SIInstrInfo::isGWS()
-bool AMDGPUCustomBehaviour::isGWS(uint16_t Opcode) const {
+bool AMDGPUCustomBehaviour::isGWS(uint32_t Opcode) const {
   const MCInstrDesc &MCID = MCII.get(Opcode);
   return MCID.TSFlags & SIInstrFlags::GWS;
 }
 
 // taken from SIInstrInfo::isAlwaysGDS()
-bool AMDGPUCustomBehaviour::isAlwaysGDS(uint16_t Opcode) const {
+bool AMDGPUCustomBehaviour::isAlwaysGDS(uint32_t Opcode) const {
   return Opcode == AMDGPU::DS_ORDERED_COUNT ||
          Opcode == AMDGPU::DS_ADD_GS_REG_RTN ||
          Opcode == AMDGPU::DS_SUB_GS_REG_RTN || isGWS(Opcode);

--- a/llvm/lib/Target/AMDGPU/MCA/AMDGPUCustomBehaviour.h
+++ b/llvm/lib/Target/AMDGPU/MCA/AMDGPUCustomBehaviour.h
@@ -68,9 +68,9 @@ class AMDGPUCustomBehaviour : public CustomBehaviour {
   bool hasModifiersSet(const std::unique_ptr<Instruction> &Inst,
                        AMDGPU::OpName OpName) const;
   /// Helper function used in generateWaitCntInfo()
-  bool isGWS(uint16_t Opcode) const;
+  bool isGWS(uint32_t Opcode) const;
   /// Helper function used in generateWaitCntInfo()
-  bool isAlwaysGDS(uint16_t Opcode) const;
+  bool isAlwaysGDS(uint32_t Opcode) const;
   /// Helper function used in generateWaitCntInfo()
   bool isVMEM(const MCInstrDesc &MCID);
   /// This method gets called from checkCustomHazard when mca is attempting to

--- a/llvm/lib/Target/AMDGPU/R600InstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/R600InstrInfo.h
@@ -326,7 +326,7 @@ public:
 
 namespace R600 {
 
-int getLDSNoRetOp(uint16_t Opcode);
+int64_t getLDSNoRetOp(uint32_t Opcode);
 
 } //End namespace AMDGPU
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -1159,7 +1159,7 @@ void SIInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
 }
 
 int SIInstrInfo::commuteOpcode(unsigned Opcode) const {
-  int NewOpc;
+  int64_t NewOpc;
 
   // Try to map original to commuted opcode
   NewOpc = AMDGPU::getCommuteRev(Opcode);
@@ -4513,7 +4513,7 @@ bool SIInstrInfo::isSchedulingBoundary(const MachineInstr &MI,
          changesVGPRIndexingMode(MI);
 }
 
-bool SIInstrInfo::isAlwaysGDS(uint16_t Opcode) const {
+bool SIInstrInfo::isAlwaysGDS(uint32_t Opcode) const {
   return Opcode == AMDGPU::DS_ORDERED_COUNT ||
          Opcode == AMDGPU::DS_ADD_GS_REG_RTN ||
          Opcode == AMDGPU::DS_SUB_GS_REG_RTN || isGWS(Opcode);
@@ -5141,7 +5141,7 @@ bool SIInstrInfo::verifyCopy(const MachineInstr &MI,
 
 bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
                                     StringRef &ErrInfo) const {
-  uint16_t Opcode = MI.getOpcode();
+  uint32_t Opcode = MI.getOpcode();
   const MachineFunction *MF = MI.getMF();
   const MachineRegisterInfo &MRI = MF->getRegInfo();
 
@@ -5398,7 +5398,7 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
       }
     }
 
-    uint16_t BasicOpcode = AMDGPU::getBasicFromSDWAOp(Opcode);
+    uint32_t BasicOpcode = AMDGPU::getBasicFromSDWAOp(Opcode);
     if (isVOPC(BasicOpcode)) {
       if (!ST.hasSDWASdst() && DstIdx != -1) {
         // Only vcc allowed as dst on VI for VOPC
@@ -9956,7 +9956,7 @@ unsigned SIInstrInfo::getLiveRangeSplitOpcode(Register SrcReg,
 }
 
 bool SIInstrInfo::canAddToBBProlog(const MachineInstr &MI) const {
-  uint16_t Opcode = MI.getOpcode();
+  uint32_t Opcode = MI.getOpcode();
   // Check if it is SGPR spill or wwm-register spill Opcode.
   if (isSGPRSpill(Opcode) || isWWMRegSpillOpcode(Opcode))
     return true;
@@ -10357,9 +10357,9 @@ int SIInstrInfo::pseudoToMCOpcode(int Opcode) const {
       Opcode = MFMAOp;
   }
 
-  int MCOp = AMDGPU::getMCOpcode(Opcode, Gen);
+  int64_t MCOp = AMDGPU::getMCOpcode(Opcode, Gen);
 
-  if (MCOp == (uint16_t)-1 && ST.hasGFX1250Insts())
+  if (MCOp == (uint32_t)-1 && ST.hasGFX1250Insts())
     MCOp = AMDGPU::getMCOpcode(Opcode, SIEncodingFamily::GFX12);
 
   // -1 means that Opcode is already a native instruction.
@@ -10367,20 +10367,20 @@ int SIInstrInfo::pseudoToMCOpcode(int Opcode) const {
     return Opcode;
 
   if (ST.hasGFX90AInsts()) {
-    uint16_t NMCOp = (uint16_t)-1;
+    uint32_t NMCOp = (uint32_t)-1;
     if (ST.hasGFX940Insts())
       NMCOp = AMDGPU::getMCOpcode(Opcode, SIEncodingFamily::GFX940);
-    if (NMCOp == (uint16_t)-1)
+    if (NMCOp == (uint32_t)-1)
       NMCOp = AMDGPU::getMCOpcode(Opcode, SIEncodingFamily::GFX90A);
-    if (NMCOp == (uint16_t)-1)
+    if (NMCOp == (uint32_t)-1)
       NMCOp = AMDGPU::getMCOpcode(Opcode, SIEncodingFamily::GFX9);
-    if (NMCOp != (uint16_t)-1)
+    if (NMCOp != (uint32_t)-1)
       MCOp = NMCOp;
   }
 
-  // (uint16_t)-1 means that Opcode is a pseudo instruction that has
+  // (uint32_t)-1 means that Opcode is a pseudo instruction that has
   // no encoding in the given subtarget generation.
-  if (MCOp == (uint16_t)-1)
+  if (MCOp == (uint32_t)-1)
     return -1;
 
   if (isAsmOnlyOpcode(MCOp))

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -466,7 +466,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::SALU;
   }
 
-  bool isSALU(uint16_t Opcode) const {
+  bool isSALU(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::SALU;
   }
 
@@ -474,7 +474,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::VALU;
   }
 
-  bool isVALU(uint16_t Opcode) const {
+  bool isVALU(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::VALU;
   }
 
@@ -482,7 +482,7 @@ public:
     return isMIMG(MI) || isVSAMPLE(MI) || isVIMAGE(MI);
   }
 
-  bool isImage(uint16_t Opcode) const {
+  bool isImage(uint32_t Opcode) const {
     return isMIMG(Opcode) || isVSAMPLE(Opcode) || isVIMAGE(Opcode);
   }
 
@@ -490,7 +490,7 @@ public:
     return isMUBUF(MI) || isMTBUF(MI) || isImage(MI) || isFLAT(MI);
   }
 
-  bool isVMEM(uint16_t Opcode) const {
+  bool isVMEM(uint32_t Opcode) const {
     return isMUBUF(Opcode) || isMTBUF(Opcode) || isImage(Opcode);
   }
 
@@ -498,7 +498,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::SOP1;
   }
 
-  bool isSOP1(uint16_t Opcode) const {
+  bool isSOP1(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::SOP1;
   }
 
@@ -506,7 +506,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::SOP2;
   }
 
-  bool isSOP2(uint16_t Opcode) const {
+  bool isSOP2(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::SOP2;
   }
 
@@ -514,7 +514,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::SOPC;
   }
 
-  bool isSOPC(uint16_t Opcode) const {
+  bool isSOPC(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::SOPC;
   }
 
@@ -522,7 +522,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::SOPK;
   }
 
-  bool isSOPK(uint16_t Opcode) const {
+  bool isSOPK(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::SOPK;
   }
 
@@ -530,7 +530,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::SOPP;
   }
 
-  bool isSOPP(uint16_t Opcode) const {
+  bool isSOPP(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::SOPP;
   }
 
@@ -538,7 +538,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::IsPacked;
   }
 
-  bool isPacked(uint16_t Opcode) const {
+  bool isPacked(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::IsPacked;
   }
 
@@ -546,7 +546,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::VOP1;
   }
 
-  bool isVOP1(uint16_t Opcode) const {
+  bool isVOP1(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::VOP1;
   }
 
@@ -554,7 +554,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::VOP2;
   }
 
-  bool isVOP2(uint16_t Opcode) const {
+  bool isVOP2(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::VOP2;
   }
 
@@ -564,13 +564,13 @@ public:
 
   static bool isVOP3(const MachineInstr &MI) { return isVOP3(MI.getDesc()); }
 
-  bool isVOP3(uint16_t Opcode) const { return isVOP3(get(Opcode)); }
+  bool isVOP3(uint32_t Opcode) const { return isVOP3(get(Opcode)); }
 
   static bool isSDWA(const MachineInstr &MI) {
     return MI.getDesc().TSFlags & SIInstrFlags::SDWA;
   }
 
-  bool isSDWA(uint16_t Opcode) const {
+  bool isSDWA(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::SDWA;
   }
 
@@ -578,7 +578,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::VOPC;
   }
 
-  bool isVOPC(uint16_t Opcode) const {
+  bool isVOPC(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::VOPC;
   }
 
@@ -586,7 +586,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::MUBUF;
   }
 
-  bool isMUBUF(uint16_t Opcode) const {
+  bool isMUBUF(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::MUBUF;
   }
 
@@ -594,7 +594,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::MTBUF;
   }
 
-  bool isMTBUF(uint16_t Opcode) const {
+  bool isMTBUF(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::MTBUF;
   }
 
@@ -606,7 +606,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::SMRD;
   }
 
-  bool isSMRD(uint16_t Opcode) const {
+  bool isSMRD(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::SMRD;
   }
 
@@ -616,7 +616,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::DS;
   }
 
-  bool isDS(uint16_t Opcode) const {
+  bool isDS(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::DS;
   }
 
@@ -625,7 +625,7 @@ public:
            (MI.getDesc().TSFlags & SIInstrFlags::TENSOR_CNT);
   }
 
-  bool isLDSDMA(uint16_t Opcode) {
+  bool isLDSDMA(uint32_t Opcode) {
     return (isVALU(Opcode) && (isMUBUF(Opcode) || isFLAT(Opcode))) ||
            (get(Opcode).TSFlags & SIInstrFlags::TENSOR_CNT);
   }
@@ -634,17 +634,17 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::GWS;
   }
 
-  bool isGWS(uint16_t Opcode) const {
+  bool isGWS(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::GWS;
   }
 
-  bool isAlwaysGDS(uint16_t Opcode) const;
+  bool isAlwaysGDS(uint32_t Opcode) const;
 
   static bool isMIMG(const MachineInstr &MI) {
     return MI.getDesc().TSFlags & SIInstrFlags::MIMG;
   }
 
-  bool isMIMG(uint16_t Opcode) const {
+  bool isMIMG(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::MIMG;
   }
 
@@ -652,7 +652,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::VIMAGE;
   }
 
-  bool isVIMAGE(uint16_t Opcode) const {
+  bool isVIMAGE(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::VIMAGE;
   }
 
@@ -660,7 +660,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::VSAMPLE;
   }
 
-  bool isVSAMPLE(uint16_t Opcode) const {
+  bool isVSAMPLE(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::VSAMPLE;
   }
 
@@ -668,7 +668,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::Gather4;
   }
 
-  bool isGather4(uint16_t Opcode) const {
+  bool isGather4(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::Gather4;
   }
 
@@ -683,7 +683,7 @@ public:
     return Flags & (SIInstrFlags::FlatGlobal | SIInstrFlags::FlatScratch);
   }
 
-  bool isSegmentSpecificFLAT(uint16_t Opcode) const {
+  bool isSegmentSpecificFLAT(uint32_t Opcode) const {
     auto Flags = get(Opcode).TSFlags;
     return Flags & (SIInstrFlags::FlatGlobal | SIInstrFlags::FlatScratch);
   }
@@ -692,7 +692,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::FlatGlobal;
   }
 
-  bool isFLATGlobal(uint16_t Opcode) const {
+  bool isFLATGlobal(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::FlatGlobal;
   }
 
@@ -700,12 +700,12 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::FlatScratch;
   }
 
-  bool isFLATScratch(uint16_t Opcode) const {
+  bool isFLATScratch(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::FlatScratch;
   }
 
   // Any FLAT encoded instruction, including global_* and scratch_*.
-  bool isFLAT(uint16_t Opcode) const {
+  bool isFLAT(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::FLAT;
   }
 
@@ -721,7 +721,7 @@ public:
   /// \returns true for FLAT instructions that can access LDS.
   bool mayAccessLDSThroughFlat(const MachineInstr &MI) const;
 
-  static bool isBlockLoadStore(uint16_t Opcode) {
+  static bool isBlockLoadStore(uint32_t Opcode) {
     switch (Opcode) {
     case AMDGPU::SI_BLOCK_SPILL_V1024_SAVE:
     case AMDGPU::SI_BLOCK_SPILL_V1024_RESTORE:
@@ -793,7 +793,7 @@ public:
            Target == AMDGPU::Exp::ET_DUAL_SRC_BLEND1;
   }
 
-  bool isEXP(uint16_t Opcode) const {
+  bool isEXP(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::EXP;
   }
 
@@ -801,7 +801,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::IsAtomicNoRet;
   }
 
-  bool isAtomicNoRet(uint16_t Opcode) const {
+  bool isAtomicNoRet(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::IsAtomicNoRet;
   }
 
@@ -809,7 +809,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::IsAtomicRet;
   }
 
-  bool isAtomicRet(uint16_t Opcode) const {
+  bool isAtomicRet(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::IsAtomicRet;
   }
 
@@ -818,7 +818,7 @@ public:
                                    SIInstrFlags::IsAtomicNoRet);
   }
 
-  bool isAtomic(uint16_t Opcode) const {
+  bool isAtomic(uint32_t Opcode) const {
     return get(Opcode).TSFlags & (SIInstrFlags::IsAtomicRet |
                                   SIInstrFlags::IsAtomicNoRet);
   }
@@ -847,7 +847,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::WQM;
   }
 
-  bool isWQM(uint16_t Opcode) const {
+  bool isWQM(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::WQM;
   }
 
@@ -855,7 +855,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::DisableWQM;
   }
 
-  bool isDisableWQM(uint16_t Opcode) const {
+  bool isDisableWQM(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::DisableWQM;
   }
 
@@ -870,7 +870,7 @@ public:
            (isSpill(MI) && isVALU(MI));
   }
 
-  bool isVGPRSpill(uint16_t Opcode) const {
+  bool isVGPRSpill(uint32_t Opcode) const {
     return Opcode != AMDGPU::SI_SPILL_S32_TO_VGPR &&
            Opcode != AMDGPU::SI_RESTORE_S32_FROM_VGPR &&
            (isSpill(Opcode) && isVALU(Opcode));
@@ -882,13 +882,13 @@ public:
            (isSpill(MI) && isSALU(MI));
   }
 
-  bool isSGPRSpill(uint16_t Opcode) const {
+  bool isSGPRSpill(uint32_t Opcode) const {
     return Opcode == AMDGPU::SI_SPILL_S32_TO_VGPR ||
            Opcode == AMDGPU::SI_RESTORE_S32_FROM_VGPR ||
            (isSpill(Opcode) && isSALU(Opcode));
   }
 
-  bool isSpill(uint16_t Opcode) const {
+  bool isSpill(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::Spill;
   }
 
@@ -898,7 +898,7 @@ public:
 
   static bool isSpill(const MachineInstr &MI) { return isSpill(MI.getDesc()); }
 
-  static bool isWWMRegSpillOpcode(uint16_t Opcode) {
+  static bool isWWMRegSpillOpcode(uint32_t Opcode) {
     return Opcode == AMDGPU::SI_SPILL_WWM_V32_SAVE ||
            Opcode == AMDGPU::SI_SPILL_WWM_AV32_SAVE ||
            Opcode == AMDGPU::SI_SPILL_WWM_V32_RESTORE ||
@@ -914,7 +914,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::DPP;
   }
 
-  bool isDPP(uint16_t Opcode) const {
+  bool isDPP(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::DPP;
   }
 
@@ -922,7 +922,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::TRANS;
   }
 
-  bool isTRANS(uint16_t Opcode) const {
+  bool isTRANS(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::TRANS;
   }
 
@@ -930,7 +930,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::VOP3P;
   }
 
-  bool isVOP3P(uint16_t Opcode) const {
+  bool isVOP3P(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::VOP3P;
   }
 
@@ -938,7 +938,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::VINTRP;
   }
 
-  bool isVINTRP(uint16_t Opcode) const {
+  bool isVINTRP(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::VINTRP;
   }
 
@@ -948,14 +948,14 @@ public:
 
   static bool isMAI(const MachineInstr &MI) { return isMAI(MI.getDesc()); }
 
-  bool isMAI(uint16_t Opcode) const { return isMAI(get(Opcode)); }
+  bool isMAI(uint32_t Opcode) const { return isMAI(get(Opcode)); }
 
   static bool isMFMA(const MachineInstr &MI) {
     return isMAI(MI) && MI.getOpcode() != AMDGPU::V_ACCVGPR_WRITE_B32_e64 &&
            MI.getOpcode() != AMDGPU::V_ACCVGPR_READ_B32_e64;
   }
 
-  bool isMFMA(uint16_t Opcode) const {
+  bool isMFMA(uint32_t Opcode) const {
     return isMAI(Opcode) && Opcode != AMDGPU::V_ACCVGPR_WRITE_B32_e64 &&
            Opcode != AMDGPU::V_ACCVGPR_READ_B32_e64;
   }
@@ -968,7 +968,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::IsWMMA;
   }
 
-  bool isWMMA(uint16_t Opcode) const {
+  bool isWMMA(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::IsWMMA;
   }
 
@@ -976,7 +976,7 @@ public:
     return isMFMA(MI) || isWMMA(MI) || isSWMMAC(MI);
   }
 
-  bool isMFMAorWMMA(uint16_t Opcode) const {
+  bool isMFMAorWMMA(uint32_t Opcode) const {
     return isMFMA(Opcode) || isWMMA(Opcode) || isSWMMAC(Opcode);
   }
 
@@ -984,11 +984,11 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::IsSWMMAC;
   }
 
-  bool isSWMMAC(uint16_t Opcode) const {
+  bool isSWMMAC(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::IsSWMMAC;
   }
 
-  bool isDOT(uint16_t Opcode) const {
+  bool isDOT(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::IsDOT;
   }
 
@@ -1002,7 +1002,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::LDSDIR;
   }
 
-  bool isLDSDIR(uint16_t Opcode) const {
+  bool isLDSDIR(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::LDSDIR;
   }
 
@@ -1010,7 +1010,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::VINTERP;
   }
 
-  bool isVINTERP(uint16_t Opcode) const {
+  bool isVINTERP(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::VINTERP;
   }
 
@@ -1030,7 +1030,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::ASYNC_CNT;
   }
 
-  bool usesASYNC_CNT(uint16_t Opcode) const {
+  bool usesASYNC_CNT(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::ASYNC_CNT;
   }
 
@@ -1050,7 +1050,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::SCALAR_STORE;
   }
 
-  bool isScalarStore(uint16_t Opcode) const {
+  bool isScalarStore(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::SCALAR_STORE;
   }
 
@@ -1058,7 +1058,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::FIXED_SIZE;
   }
 
-  bool isFixedSize(uint16_t Opcode) const {
+  bool isFixedSize(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::FIXED_SIZE;
   }
 
@@ -1066,7 +1066,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::FPClamp;
   }
 
-  bool hasFPClamp(uint16_t Opcode) const {
+  bool hasFPClamp(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::FPClamp;
   }
 
@@ -1086,7 +1086,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::FPDPRounding;
   }
 
-  bool usesFPDPRounding(uint16_t Opcode) const {
+  bool usesFPDPRounding(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::FPDPRounding;
   }
 
@@ -1094,7 +1094,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::FPAtomic;
   }
 
-  bool isFPAtomic(uint16_t Opcode) const {
+  bool isFPAtomic(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::FPAtomic;
   }
 
@@ -1139,7 +1139,7 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::TiedSourceNotRead;
   }
 
-  bool doesNotReadTiedSource(uint16_t Opcode) const {
+  bool doesNotReadTiedSource(uint32_t Opcode) const {
     return get(Opcode).TSFlags & SIInstrFlags::TiedSourceNotRead;
   }
 
@@ -1382,7 +1382,7 @@ public:
 
   /// Return the size in bytes of the operand OpNo on the given
   // instruction opcode.
-  unsigned getOpSize(uint16_t Opcode, unsigned OpNo) const {
+  unsigned getOpSize(uint32_t Opcode, unsigned OpNo) const {
     const MCOperandInfo &OpInfo = get(Opcode).operands()[OpNo];
 
     if (OpInfo.RegClass == -1) {
@@ -1737,86 +1737,86 @@ bool execMayBeModifiedBeforeAnyUse(const MachineRegisterInfo &MRI,
 namespace AMDGPU {
 
   LLVM_READONLY
-  int getVOPe64(uint16_t Opcode);
+  int64_t getVOPe64(uint32_t Opcode);
 
   LLVM_READONLY
-  int getVOPe32(uint16_t Opcode);
+  int64_t getVOPe32(uint32_t Opcode);
 
   LLVM_READONLY
-  int getSDWAOp(uint16_t Opcode);
+  int64_t getSDWAOp(uint32_t Opcode);
 
   LLVM_READONLY
-  int getDPPOp32(uint16_t Opcode);
+  int64_t getDPPOp32(uint32_t Opcode);
 
   LLVM_READONLY
-  int getDPPOp64(uint16_t Opcode);
+  int64_t getDPPOp64(uint32_t Opcode);
 
   LLVM_READONLY
-  int getBasicFromSDWAOp(uint16_t Opcode);
+  int64_t getBasicFromSDWAOp(uint32_t Opcode);
 
   LLVM_READONLY
-  int getCommuteRev(uint16_t Opcode);
+  int64_t getCommuteRev(uint32_t Opcode);
 
   LLVM_READONLY
-  int getCommuteOrig(uint16_t Opcode);
+  int64_t getCommuteOrig(uint32_t Opcode);
 
   LLVM_READONLY
-  int getAddr64Inst(uint16_t Opcode);
+  int64_t getAddr64Inst(uint32_t Opcode);
 
   /// Check if \p Opcode is an Addr64 opcode.
   ///
   /// \returns \p Opcode if it is an Addr64 opcode, otherwise -1.
   LLVM_READONLY
-  int getIfAddr64Inst(uint16_t Opcode);
+  int64_t getIfAddr64Inst(uint32_t Opcode);
 
   LLVM_READONLY
-  int getSOPKOp(uint16_t Opcode);
+  int64_t getSOPKOp(uint32_t Opcode);
 
   /// \returns SADDR form of a FLAT Global instruction given an \p Opcode
   /// of a VADDR form.
   LLVM_READONLY
-  int getGlobalSaddrOp(uint16_t Opcode);
+  int64_t getGlobalSaddrOp(uint32_t Opcode);
 
   /// \returns VADDR form of a FLAT Global instruction given an \p Opcode
   /// of a SADDR form.
   LLVM_READONLY
-  int getGlobalVaddrOp(uint16_t Opcode);
+  int64_t getGlobalVaddrOp(uint32_t Opcode);
 
   LLVM_READONLY
-  int getVCMPXNoSDstOp(uint16_t Opcode);
+  int64_t getVCMPXNoSDstOp(uint32_t Opcode);
 
   /// \returns ST form with only immediate offset of a FLAT Scratch instruction
   /// given an \p Opcode of an SS (SADDR) form.
   LLVM_READONLY
-  int getFlatScratchInstSTfromSS(uint16_t Opcode);
+  int64_t getFlatScratchInstSTfromSS(uint32_t Opcode);
 
   /// \returns SV (VADDR) form of a FLAT Scratch instruction given an \p Opcode
   /// of an SVS (SADDR + VADDR) form.
   LLVM_READONLY
-  int getFlatScratchInstSVfromSVS(uint16_t Opcode);
+  int64_t getFlatScratchInstSVfromSVS(uint32_t Opcode);
 
   /// \returns SS (SADDR) form of a FLAT Scratch instruction given an \p Opcode
   /// of an SV (VADDR) form.
   LLVM_READONLY
-  int getFlatScratchInstSSfromSV(uint16_t Opcode);
+  int64_t getFlatScratchInstSSfromSV(uint32_t Opcode);
 
   /// \returns SV (VADDR) form of a FLAT Scratch instruction given an \p Opcode
   /// of an SS (SADDR) form.
   LLVM_READONLY
-  int getFlatScratchInstSVfromSS(uint16_t Opcode);
+  int64_t getFlatScratchInstSVfromSS(uint32_t Opcode);
 
   /// \returns earlyclobber version of a MAC MFMA is exists.
   LLVM_READONLY
-  int getMFMAEarlyClobberOp(uint16_t Opcode);
+  int64_t getMFMAEarlyClobberOp(uint32_t Opcode);
 
   /// \returns Version of an MFMA instruction which uses AGPRs for srcC and
   /// vdst, given an \p Opcode of an MFMA which uses VGPRs for srcC/vdst.
   LLVM_READONLY
-  int getMFMASrcCVDstAGPROp(uint16_t Opcode);
+  int64_t getMFMASrcCVDstAGPROp(uint32_t Opcode);
 
   /// \returns v_cmpx version of a v_cmp instruction.
   LLVM_READONLY
-  int getVCMPXOpFromVCMP(uint16_t Opcode);
+  int64_t getVCMPXOpFromVCMP(uint32_t Opcode);
 
   const uint64_t RSRC_DATA_FORMAT = 0xf00000000000LL;
   const uint64_t RSRC_ELEMENT_SIZE_SHIFT = (32 + 19);

--- a/llvm/lib/Target/AMDGPU/SIPreEmitPeephole.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPreEmitPeephole.cpp
@@ -66,11 +66,11 @@ private:
   // this transformation.
   void performF32Unpacking(MachineInstr &I);
   // Select corresponding unpacked instruction
-  uint16_t mapToUnpackedOpcode(MachineInstr &I);
+  uint32_t mapToUnpackedOpcode(MachineInstr &I);
   // Creates the unpacked instruction to be inserted. Adds source modifiers to
   // the unpacked instructions based on the source modifiers in the packed
   // instruction.
-  MachineInstrBuilder createUnpackedMI(MachineInstr &I, uint16_t UnpackedOpcode,
+  MachineInstrBuilder createUnpackedMI(MachineInstr &I, uint32_t UnpackedOpcode,
                                        bool IsHiBits);
   // Process operands/source modifiers from packed instructions and insert the
   // appropriate source modifers and operands into the unpacked instructions.
@@ -508,7 +508,7 @@ bool SIPreEmitPeephole::canUnpackingClobberRegister(const MachineInstr &MI) {
   return false;
 }
 
-uint16_t SIPreEmitPeephole::mapToUnpackedOpcode(MachineInstr &I) {
+uint32_t SIPreEmitPeephole::mapToUnpackedOpcode(MachineInstr &I) {
   unsigned Opcode = I.getOpcode();
   // Use 64 bit encoding to allow use of VOP3 instructions.
   // VOP3 e64 instructions allow source modifiers
@@ -521,7 +521,7 @@ uint16_t SIPreEmitPeephole::mapToUnpackedOpcode(MachineInstr &I) {
   case AMDGPU::V_PK_FMA_F32:
     return AMDGPU::V_FMA_F32_e64;
   default:
-    return std::numeric_limits<uint16_t>::max();
+    return std::numeric_limits<uint32_t>::max();
   }
   llvm_unreachable("Fully covered switch");
 }
@@ -592,9 +592,9 @@ void SIPreEmitPeephole::collectUnpackingCandidates(
 
   for (auto I = std::next(BeginMI.getIterator()); I != E; ++I) {
     MachineInstr &Instr = *I;
-    uint16_t UnpackedOpCode = mapToUnpackedOpcode(Instr);
+    uint32_t UnpackedOpCode = mapToUnpackedOpcode(Instr);
     bool IsUnpackable =
-        !(UnpackedOpCode == std::numeric_limits<uint16_t>::max());
+        !(UnpackedOpCode == std::numeric_limits<uint32_t>::max());
     if (Instr.isMetaInstruction())
       continue;
     if ((Instr.isTerminator()) ||
@@ -642,8 +642,8 @@ void SIPreEmitPeephole::collectUnpackingCandidates(
 void SIPreEmitPeephole::performF32Unpacking(MachineInstr &I) {
   const MachineOperand &DstOp = I.getOperand(0);
 
-  uint16_t UnpackedOpcode = mapToUnpackedOpcode(I);
-  assert(UnpackedOpcode != std::numeric_limits<uint16_t>::max() &&
+  uint32_t UnpackedOpcode = mapToUnpackedOpcode(I);
+  assert(UnpackedOpcode != std::numeric_limits<uint32_t>::max() &&
          "Unsupported Opcode");
 
   MachineInstrBuilder Op0LOp1L =
@@ -666,7 +666,7 @@ void SIPreEmitPeephole::performF32Unpacking(MachineInstr &I) {
 }
 
 MachineInstrBuilder SIPreEmitPeephole::createUnpackedMI(MachineInstr &I,
-                                                        uint16_t UnpackedOpcode,
+                                                        uint32_t UnpackedOpcode,
                                                         bool IsHiBits) {
   MachineBasicBlock &MBB = *I.getParent();
   const DebugLoc &DL = I.getDebugLoc();

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -359,8 +359,8 @@ unsigned getAddrSizeMIMGOp(const MIMGBaseOpcodeInfo *BaseOpcode,
 }
 
 struct MUBUFInfo {
-  uint16_t Opcode;
-  uint16_t BaseOpcode;
+  uint32_t Opcode;
+  uint32_t BaseOpcode;
   uint8_t elements;
   bool has_vaddr;
   bool has_srsrc;
@@ -370,8 +370,8 @@ struct MUBUFInfo {
 };
 
 struct MTBUFInfo {
-  uint16_t Opcode;
-  uint16_t BaseOpcode;
+  uint32_t Opcode;
+  uint32_t BaseOpcode;
   uint8_t elements;
   bool has_vaddr;
   bool has_srsrc;
@@ -379,25 +379,25 @@ struct MTBUFInfo {
 };
 
 struct SMInfo {
-  uint16_t Opcode;
+  uint32_t Opcode;
   bool IsBuffer;
 };
 
 struct VOPInfo {
-  uint16_t Opcode;
+  uint32_t Opcode;
   bool IsSingle;
 };
 
 struct VOPC64DPPInfo {
-  uint16_t Opcode;
+  uint32_t Opcode;
 };
 
 struct VOPCDPPAsmOnlyInfo {
-  uint16_t Opcode;
+  uint32_t Opcode;
 };
 
 struct VOP3CDPPAsmOnlyInfo {
-  uint16_t Opcode;
+  uint32_t Opcode;
 };
 
 struct VOPDComponentInfo {
@@ -408,7 +408,7 @@ struct VOPDComponentInfo {
 };
 
 struct VOPDInfo {
-  uint16_t Opcode;
+  uint32_t Opcode;
   uint16_t OpX;
   uint16_t OpY;
   uint16_t Subtarget;
@@ -416,7 +416,7 @@ struct VOPDInfo {
 };
 
 struct VOPTrue16Info {
-  uint16_t Opcode;
+  uint32_t Opcode;
   bool IsTrue16;
 };
 
@@ -424,12 +424,12 @@ struct VOPTrue16Info {
 #define GET_FP4FP8DstByteSelTable_IMPL
 
 struct DPMACCInstructionInfo {
-  uint16_t Opcode;
+  uint32_t Opcode;
   bool IsDPMACCInstruction;
 };
 
 struct FP4FP8DstByteSelInfo {
-  uint16_t Opcode;
+  uint32_t Opcode;
   bool HasFP8DstByteSel;
   bool HasFP4DstByteSel;
 };
@@ -812,7 +812,7 @@ unsigned mapWMMA3AddrTo2AddrOpcode(unsigned Opc) {
 // Wrapper for Tablegen'd function.  enum Subtarget is not defined in any
 // header files, so we need to wrap it in a function that takes unsigned
 // instead.
-int getMCOpcode(uint16_t Opcode, unsigned Gen) {
+int64_t getMCOpcode(uint32_t Opcode, unsigned Gen) {
   return getMCOpcodeGen(Opcode, static_cast<Subtarget>(Gen));
 }
 

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -98,7 +98,7 @@ struct GcnBufferFormatInfo {
 };
 
 struct MAIInstInfo {
-  uint16_t Opcode;
+  uint32_t Opcode;
   bool is_dgemm;
   bool is_gfx940_xdl;
 };
@@ -121,7 +121,7 @@ struct True16D16Info {
 };
 
 struct WMMAInstInfo {
-  uint16_t Opcode;
+  uint32_t Opcode;
   bool is_wmma_xdl;
 };
 
@@ -416,7 +416,7 @@ inline bool hasNamedOperand(uint64_t Opcode, OpName NamedIdx) {
 }
 
 LLVM_READONLY
-int getSOPPWithRelaxation(uint16_t Opcode);
+int64_t getSOPPWithRelaxation(uint32_t Opcode);
 
 struct MIMGBaseOpcodeInfo {
   MIMGBaseOpcode BaseOpcode;
@@ -522,8 +522,8 @@ unsigned getAddrSizeMIMGOp(const MIMGBaseOpcodeInfo *BaseOpcode,
                            bool IsG16Supported);
 
 struct MIMGInfo {
-  uint16_t Opcode;
-  uint16_t BaseOpcode;
+  uint32_t Opcode;
+  uint32_t BaseOpcode;
   uint8_t MIMGEncoding;
   uint8_t VDataDwords;
   uint8_t VAddrDwords;
@@ -646,7 +646,7 @@ const GcnBufferFormatInfo *getGcnBufferFormatInfo(uint8_t Format,
                                                   const MCSubtargetInfo &STI);
 
 LLVM_READONLY
-int getMCOpcode(uint16_t Opcode, unsigned Gen);
+int64_t getMCOpcode(uint32_t Opcode, unsigned Gen);
 
 LLVM_READONLY
 unsigned getVOPDOpcode(unsigned Opc, bool VOPD3);

--- a/llvm/lib/Target/PowerPC/PPCHazardRecognizers.cpp
+++ b/llvm/lib/Target/PowerPC/PPCHazardRecognizers.cpp
@@ -78,7 +78,7 @@ bool PPCDispatchGroupSBHazardRecognizer::isBCTRAfterSet(SUnit *SU) {
 }
 
 // FIXME: Remove this when we don't need this:
-namespace llvm { namespace PPC { extern int getNonRecordFormOpcode(uint16_t); } }
+namespace llvm { namespace PPC { extern int64_t getNonRecordFormOpcode(uint32_t); } }
 
 // FIXME: A lot of code in PPCDispatchGroupSBHazardRecognizer is P7 specific.
 

--- a/llvm/lib/Target/PowerPC/PPCVSXFMAMutate.cpp
+++ b/llvm/lib/Target/PowerPC/PPCVSXFMAMutate.cpp
@@ -47,7 +47,7 @@ static cl::opt<bool> DisableVSXFMAMutate(
 #define DEBUG_TYPE "ppc-vsx-fma-mutate"
 
 namespace llvm { namespace PPC {
-  int getAltVSXFMAOpcode(uint16_t Opcode);
+  int64_t getAltVSXFMAOpcode(uint32_t Opcode);
 } }
 
 namespace {

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
@@ -159,8 +159,8 @@ enum FusedCompareType {
 } // end namespace SystemZII
 
 namespace SystemZ {
-int getTwoOperandOpcode(uint16_t Opcode);
-int getTargetMemOpcode(uint16_t Opcode);
+int64_t getTwoOperandOpcode(uint32_t Opcode);
+int64_t getTargetMemOpcode(uint32_t Opcode);
 
 // Return a version of comparison CC mask CCMask in which the LT and GT
 // actions are swapped.

--- a/llvm/lib/Target/WebAssembly/TargetInfo/WebAssemblyTargetInfo.h
+++ b/llvm/lib/Target/WebAssembly/TargetInfo/WebAssemblyTargetInfo.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_LIB_TARGET_WEBASSEMBLY_TARGETINFO_WEBASSEMBLYTARGETINFO_H
 #define LLVM_LIB_TARGET_WEBASSEMBLY_TARGETINFO_WEBASSEMBLYTARGETINFO_H
 
+#include <cstdint>
+
 namespace llvm {
 
 class Target;
@@ -23,9 +25,9 @@ Target &getTheWebAssemblyTarget64();
 
 namespace WebAssembly {
 
-int getStackOpcode(unsigned short Opcode);
-int getRegisterOpcode(unsigned short Opcode);
-int getWasm64Opcode(unsigned short Opcode);
+int64_t getStackOpcode(uint32_t Opcode);
+int64_t getRegisterOpcode(uint32_t Opcode);
+int64_t getWasm64Opcode(uint32_t Opcode);
 
 } // namespace WebAssembly
 

--- a/llvm/test/TableGen/get-named-operand-idx.td
+++ b/llvm/test/TableGen/get-named-operand-idx.td
@@ -64,8 +64,8 @@ defm : RemapAllTargetPseudoPointerOperands<RegClass>;
 // CHECK-NEXT:    NUM_OPERAND_NAMES = 5,
 // CHECK-NEXT:  }; // enum class OpName
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_READONLY int16_t getNamedOperandIdx(uint16_t Opcode, OpName Name);
-// CHECK-NEXT:  LLVM_READONLY OpName getOperandIdxName(uint16_t Opcode, int16_t Idx);
+// CHECK-NEXT:  LLVM_READONLY int16_t getNamedOperandIdx(uint32_t Opcode, OpName Name);
+// CHECK-NEXT:  LLVM_READONLY OpName getOperandIdxName(uint32_t Opcode, int16_t Idx);
 // CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace llvm::MyNamespace
 // CHECK-EMPTY:
@@ -76,7 +76,7 @@ defm : RemapAllTargetPseudoPointerOperands<RegClass>;
 // CHECK-EMPTY:
 // CHECK-NEXT:  namespace llvm::MyNamespace {
 // CHECK-EMPTY:
-// CHECK-NEXT:  LLVM_READONLY static uint8_t getInstructionIndexForOpLookup(uint16_t Opcode) {
+// CHECK-NEXT:  LLVM_READONLY static uint8_t getInstructionIndexForOpLookup(uint32_t Opcode) {
 // CHECK-NEXT:    static constexpr uint8_t InstructionIndex[] = {
 // CHECK-NEXT:      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 // CHECK-NEXT:      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -102,7 +102,7 @@ defm : RemapAllTargetPseudoPointerOperands<RegClass>;
 // CHECK-NEXT:    };
 // CHECK-NEXT:    return InstructionIndex[Opcode];
 // CHECK-NEXT:  }
-// CHECK-NEXT:  LLVM_READONLY int16_t getNamedOperandIdx(uint16_t Opcode, OpName Name) {
+// CHECK-NEXT:  LLVM_READONLY int16_t getNamedOperandIdx(uint32_t Opcode, OpName Name) {
 // CHECK-NEXT:    assert(Name != OpName::NUM_OPERAND_NAMES);
 // CHECK-NEXT:    static constexpr int8_t OperandMap[][5] = {
 // CHECK-NEXT:      {-1, -1, -1, -1, -1, },
@@ -112,7 +112,7 @@ defm : RemapAllTargetPseudoPointerOperands<RegClass>;
 // CHECK-NEXT:    unsigned InstrIdx = getInstructionIndexForOpLookup(Opcode);
 // CHECK-NEXT:    return OperandMap[InstrIdx][(unsigned)Name];
 // CHECK-NEXT:  }
-// CHECK-NEXT:  LLVM_READONLY OpName getOperandIdxName(uint16_t Opcode, int16_t Idx) {
+// CHECK-NEXT:  LLVM_READONLY OpName getOperandIdxName(uint32_t Opcode, int16_t Idx) {
 // CHECK-NEXT:    assert(Idx >= 0 && Idx < 3);
 // CHECK-NEXT:    static constexpr OpName OperandMap[][3] = {
 // CHECK-NEXT:      {OpName::NUM_OPERAND_NAMES, OpName::NUM_OPERAND_NAMES, OpName::NUM_OPERAND_NAMES, },

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -3609,7 +3609,7 @@ void AsmMatcherEmitter::run(raw_ostream &OS) {
   OS << "namespace {\n";
   OS << "  struct MatchEntry {\n";
   OS << "    " << getMinimalTypeForRange(MaxMnemonicIndex) << " Mnemonic;\n";
-  OS << "    uint16_t Opcode;\n";
+  OS << "    uint32_t Opcode;\n";
   OS << "    " << getMinimalTypeForRange(NumConverters) << " ConvertFn;\n";
   OS << "    " << getMinimalTypeForRange(FeatureBitsets.size())
      << " RequiredFeaturesIdx;\n";

--- a/llvm/utils/TableGen/CodeGenMapTable.cpp
+++ b/llvm/utils/TableGen/CodeGenMapTable.cpp
@@ -25,7 +25,7 @@
 // CodeGenMapTable parses this map and generates a table in XXXGenInstrInfo.inc
 // file that contains the instructions modeling this relationship. This table
 // is defined in the function
-// "int getPredOpcode(uint16_t Opcode, enum PredSense inPredSense)"
+// "int getPredOpcode(uint32_t Opcode, enum PredSense inPredSense)"
 // that can be used to retrieve the predicated form of the instruction by
 // passing its opcode value and the predicate sense (true/false) of the desired
 // instruction as arguments.
@@ -381,13 +381,13 @@ unsigned MapTableEmitter::emitBinSearchTable(raw_ostream &OS) {
         OutStr += ", ";
         OutStr += ColInstr->getName();
       } else {
-        OutStr += ", (uint16_t)-1U";
+        OutStr += ", (uint32_t)-1U";
       }
     }
 
     if (RelExists) {
       if (TableSize == 0)
-        OS << "  static constexpr uint16_t Table[][" << NumCol + 1 << "] = {\n";
+        OS << "  static constexpr uint32_t Table[][" << NumCol + 1 << "] = {\n";
       OS << "    { " << CurInstr->getName() << OutStr << " },\n";
       ++TableSize;
     }
@@ -455,7 +455,7 @@ void MapTableEmitter::emitMapFuncBody(raw_ostream &OS, unsigned TableSize) {
       OS << ")\n";
       OS << "    return Table[mid][" << I + 1 << "];\n";
     }
-    OS << "  return -1;";
+    OS << "  return (uint32_t)-1U;";
   } else {
     OS << "  return Table[mid][1];\n";
   }
@@ -474,7 +474,7 @@ void MapTableEmitter::emitTablesWithFunc(raw_ostream &OS) {
   const ListInit *ColFields = InstrMapDesc.getColFields();
   ArrayRef<const ListInit *> ValueCols = InstrMapDesc.getValueCols();
   OS << "// " << InstrMapDesc.getName() << "\nLLVM_READONLY\n";
-  OS << "int " << InstrMapDesc.getName() << "(uint16_t Opcode";
+  OS << "int64_t " << InstrMapDesc.getName() << "(uint32_t Opcode";
   if (ValueCols.size() > 1) {
     for (const Init *CF : ColFields->getElements()) {
       std::string ColName = CF->getAsUnquotedString();

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -261,7 +261,7 @@ static void emitGetInstructionIndexForOpLookup(
     ArrayRef<unsigned> InstructionIndex) {
   StringRef Type = OperandMap.size() <= UINT8_MAX + 1 ? "uint8_t" : "uint16_t";
   OS << "LLVM_READONLY static " << Type
-     << " getInstructionIndexForOpLookup(uint16_t Opcode) {\n"
+     << " getInstructionIndexForOpLookup(uint32_t Opcode) {\n"
         "  static constexpr "
      << Type << " InstructionIndex[] = {";
   for (auto [TableIndex, Entry] : enumerate(InstructionIndex))
@@ -275,7 +275,7 @@ static void
 emitGetNamedOperandIdx(raw_ostream &OS,
                        const MapVector<SmallVector<int>, unsigned> &OperandMap,
                        unsigned MaxOperandNo, unsigned NumOperandNames) {
-  OS << "LLVM_READONLY int16_t getNamedOperandIdx(uint16_t Opcode, OpName "
+  OS << "LLVM_READONLY int16_t getNamedOperandIdx(uint32_t Opcode, OpName "
         "Name) {\n";
   OS << "  assert(Name != OpName::NUM_OPERAND_NAMES);\n";
   if (!NumOperandNames) {
@@ -307,7 +307,7 @@ emitGetOperandIdxName(raw_ostream &OS,
                       const MapVector<StringRef, unsigned> &OperandNameToID,
                       const MapVector<SmallVector<int>, unsigned> &OperandMap,
                       unsigned MaxNumOperands, unsigned NumOperandNames) {
-  OS << "LLVM_READONLY OpName getOperandIdxName(uint16_t Opcode, int16_t Idx) "
+  OS << "LLVM_READONLY OpName getOperandIdxName(uint32_t Opcode, int16_t Idx) "
         "{\n";
   OS << "  assert(Idx >= 0 && Idx < " << MaxNumOperands << ");\n";
   if (!MaxNumOperands) {
@@ -347,11 +347,11 @@ emitGetOperandIdxName(raw_ostream &OS,
 /// - An enum in the llvm::TargetNamespace::OpName namespace, with one entry
 ///   for each operand name.
 /// - A 2-dimensional table for mapping OpName enum values to operand indices.
-/// - A function called getNamedOperandIdx(uint16_t Opcode, OpName Name)
+/// - A function called getNamedOperandIdx(uint32_t Opcode, OpName Name)
 ///   for looking up the operand index for an instruction, given a value from
 ///   OpName enum
 /// - A 2-dimensional table for mapping operand indices to OpName enum values.
-/// - A function called getOperandIdxName(uint16_t Opcode, int16_t Idx)
+/// - A function called getOperandIdxName(uint32_t Opcode, int16_t Idx)
 ///   for looking up the OpName enum for an instruction, given the operand
 ///   index. This is the inverse of getNamedOperandIdx().
 ///
@@ -414,9 +414,9 @@ void InstrInfoEmitter::emitOperandNameMappings(
     OS << "  NUM_OPERAND_NAMES = " << NumOperandNames << ",\n";
     OS << "}; // enum class OpName\n\n";
 
-    OS << "LLVM_READONLY int16_t getNamedOperandIdx(uint16_t Opcode, OpName "
+    OS << "LLVM_READONLY int16_t getNamedOperandIdx(uint32_t Opcode, OpName "
           "Name);\n";
-    OS << "LLVM_READONLY OpName getOperandIdxName(uint16_t Opcode, int16_t "
+    OS << "LLVM_READONLY OpName getOperandIdxName(uint32_t Opcode, int16_t "
           "Idx);\n";
   }
 
@@ -476,7 +476,7 @@ void InstrInfoEmitter::emitOperandTypeMappings(
     IfDefEmitter IfDef(OS, "GET_INSTRINFO_OPERAND_TYPE");
     NamespaceEmitter NS(OS, ("llvm::" + Namespace).str());
     OS << "LLVM_READONLY\n";
-    OS << "static int getOperandType(uint16_t Opcode, uint16_t OpIdx) {\n";
+    OS << "static int getOperandType(uint32_t Opcode, uint16_t OpIdx) {\n";
     auto getInstrName = [&](int I) -> StringRef {
       return NumberedInstructions[I]->getName();
     };
@@ -604,7 +604,7 @@ void InstrInfoEmitter::emitLogicalOperandSizeMappings(
   IfDefEmitter IfDef(OS, "GET_INSTRINFO_LOGICAL_OPERAND_SIZE_MAP");
   NamespaceEmitter NS(OS, ("llvm::" + Namespace).str());
   OS << "LLVM_READONLY static unsigned\n";
-  OS << "getLogicalOperandSize(uint16_t Opcode, uint16_t LogicalOpIdx) {\n";
+  OS << "getLogicalOperandSize(uint32_t Opcode, uint16_t LogicalOpIdx) {\n";
   if (!InstMap.empty()) {
     std::vector<const std::vector<unsigned> *> LogicalOpSizeList(
         LogicalOpSizeMap.size());
@@ -644,7 +644,7 @@ void InstrInfoEmitter::emitLogicalOperandSizeMappings(
   OS << "}\n";
 
   OS << "LLVM_READONLY static inline unsigned\n";
-  OS << "getLogicalOperandIdx(uint16_t Opcode, uint16_t LogicalOpIdx) {\n";
+  OS << "getLogicalOperandIdx(uint32_t Opcode, uint16_t LogicalOpIdx) {\n";
   OS << "  auto S = 0U;\n";
   OS << "  for (auto i = 0U; i < LogicalOpIdx; ++i)\n";
   OS << "    S += getLogicalOperandSize(Opcode, i);\n";


### PR DESCRIPTION
Difference from the previous version is that this one doesn't actually encode opcodes in matcher tables as 32 bits, but still as 16 bits. Hopefully since inc files don't increase, this won't cause OOM issues.

For amdgpu, this is ok because it only uses pseudo instructions for matcher tables and opcode enum is sorted so that pseudo instructions always come first.

@vvereschaka could you check if the issue still reproduces with this version?