### PR TITLE
[WinEH] Only emit err_seh_object_unwinding when CXXExceptions are enabled

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -2228,8 +2228,10 @@ void CodeGenFunction::EmitAutoVarCleanups(const AutoVarEmission &emission) {
 
   // Check the type for a cleanup.
   if (QualType::DestructionKind dtorKind = D.needsDestruction(getContext())) {
-    // Check if we're in a SEH block with EHa, prevent it
-    if (getLangOpts().EHAsynch && currentFunctionUsesSEHTry())
+    // Check if we're in a SEH block with /EH, prevent it
+    // TODO: /EHs* differs from /EHa, the former may not be executed to this
+    // point.
+    if (getLangOpts().CXXExceptions && currentFunctionUsesSEHTry())
       getContext().getDiagnostics().Report(D.getLocation(),
                                            diag::err_seh_object_unwinding);
     emitAutoVarTypeCleanup(emission, dtorKind);

--- a/clang/test/CodeGenCXX/exceptions-seh.cpp
+++ b/clang/test/CodeGenCXX/exceptions-seh.cpp
@@ -12,6 +12,8 @@
 // RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR3
 // RUN: %clang_cc1 -triple x86_64-windows -fcxx-exceptions -fexceptions \
 // RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR4
+// RUN: %clang_cc1 -triple x86_64-windows \
+// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR5
 
 extern "C" unsigned long _exception_code();
 extern "C" void might_throw();
@@ -206,6 +208,13 @@ void seh_unwinding() {
   }
 }
 #elif defined(ERR4)
+void seh_unwinding() {
+  __try {
+    HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
+  } __except (1) {
+  }
+}
+#elif defined(ERR5)
 void seh_unwinding() {
   __try {
     HasCleanup x; // expected-no-diagnostics

--- a/clang/test/CodeGenCXX/exceptions-seh.cpp
+++ b/clang/test/CodeGenCXX/exceptions-seh.cpp
@@ -13,7 +13,7 @@
 // RUN: %clang_cc1 -triple x86_64-windows -fcxx-exceptions -fexceptions \
 // RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR4
 // RUN: %clang_cc1 -triple x86_64-windows \
-// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DERR5
+// RUN:         -fms-extensions -x c++ -emit-llvm-only -verify %s -DNOERR
 
 extern "C" unsigned long _exception_code();
 extern "C" void might_throw();
@@ -214,7 +214,7 @@ void seh_unwinding() {
   } __except (1) {
   }
 }
-#elif defined(ERR5)
+#elif defined(NOERR)
 void seh_unwinding() {
   __try {
     HasCleanup x; // expected-no-diagnostics


### PR DESCRIPTION
Based on the PR(https://github.com/llvm/llvm-project/pull/180108) discussion, it has been modified to check when `/EH*` is enabled.

Although `/EHsc` `/EHs` are slightly different from `/EHa`, and the changes here have different effects than `/EHa` when these two switches are enabled, we are still considering supporting this situation, and we will improve support for `/EHs*` in the future.

