### PR TITLE
[ADT] use correct iterator_facade_base for SmallSetIterator

### DIFF
--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -32,7 +32,8 @@ namespace llvm {
 template <typename T, unsigned N, typename C>
 class SmallSetIterator
     : public iterator_facade_base<SmallSetIterator<T, N, C>,
-                                  std::forward_iterator_tag, T> {
+                                  std::forward_iterator_tag, T, std::ptrdiff_t,
+                                  const T *, const T &> {
 private:
   using SetIterTy = typename std::set<T, C>::const_iterator;
   using VecIterTy = typename SmallVector<T, N>::const_iterator;


### PR DESCRIPTION
SmallSetIterator is inherently constant. Now it is properly expressed through passing const to PointerT/ReferenceT parameters of its base class. This way wrappers like make_filter_range do not try to treat SmallSetIterator as non-constant.

Fixes #179139