### PR TITLE
[Flang] Fix finding the Flang runtime for the GPU

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9403,13 +9403,17 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
             "--device-linker=" + TC.getTripleString() + "=" + "-lm"));
       }
       auto HasCompilerRT = getToolChain().getVFS().exists(
-          TC.getCompilerRT(Args, "builtins", ToolChain::FT_Static));
+          TC.getCompilerRT(Args, "builtins", ToolChain::FT_Static,
+                           /*IsFortran=*/false));
       if (HasCompilerRT)
         CmdArgs.push_back(
             Args.MakeArgString("--device-linker=" + TC.getTripleString() + "=" +
                                "-lclang_rt.builtins"));
-      bool HasFlangRT = HasCompilerRT && C.getDriver().IsFlangMode();
-      if (HasFlangRT)
+
+      bool HasFlangRT = getToolChain().getVFS().exists(
+          TC.getCompilerRT(Args, "runtime", ToolChain::FT_Static,
+                           /*IsFortran=*/true));
+      if (HasFlangRT && C.getDriver().IsFlangMode())
         CmdArgs.push_back(
             Args.MakeArgString("--device-linker=" + TC.getTripleString() + "=" +
                                "-lflang_rt.runtime"));

--- a/clang/test/Driver/offload.f90
+++ b/clang/test/Driver/offload.f90
@@ -1,0 +1,5 @@
+// RUN: %clang -### --driver-mode=flang --target=x86_64-unknown-linux-gnu \
+// RUN:   -resource-dir %S/Inputs/resource_dir_with_per_target_subdir \
+// RUN:   --rocm-path=%S/Inputs/rocm -fopenmp --offload-arch=gfx908 \
+// RUN: %s 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG-RT
+// CHECK-FLANG-RT: clang-linker-wrapper{{.*}}"--device-linker=amdgcn-amd-amdhsa=-lflang_rt.runtime"{{.*}}"-lflang_rt.runtime"


### PR DESCRIPTION
Summary:
We were looking for `flang_rt.builtins` instead of `flang_rt.runtime`.
Also adds a test so we know that it actually works.
