### PR TITLE
[lldb][windows] fix link issue when building with dylibs

### DIFF
--- a/lldb/source/Host/windows/PythonPathSetup/CMakeLists.txt
+++ b/lldb/source/Host/windows/PythonPathSetup/CMakeLists.txt
@@ -1,8 +1,5 @@
 add_lldb_library(lldbHostPythonPathSetup STATIC
   PythonPathSetup.cpp
-
-  LINK_LIBS
-    LLVMSupport
 )
 
 if(DEFINED LLDB_PYTHON_DLL_RELATIVE_PATH)


### PR DESCRIPTION
Fix a link issue which was introduced by https://github.com/llvm/llvm-project/pull/179306 when building with dylibs (with MinGW).

LLVMSupport is not needed by `PythonPathSetup`. It's safe to remove it.