### PR TITLE
[flang][OpenMP] Implement iterator that flattens BLOCK constructs

### DIFF
--- a/flang/include/flang/Parser/openmp-utils.h
+++ b/flang/include/flang/Parser/openmp-utils.h
@@ -270,8 +270,8 @@ struct ExecutionPartIterator {
     Construct(IteratorType b, IteratorType e,
         const ExecutionPartConstruct *c = nullptr)
         : range(b, e), owner(c) {}
-    template <typename C>
-    Construct(C &&r, const ExecutionPartConstruct *c = nullptr)
+    template <typename R>
+    Construct(const R &r, const ExecutionPartConstruct *c = nullptr)
         : range(r), owner(c) {}
     Construct(const Construct &c) = default;
     IteratorRange range;
@@ -286,8 +286,8 @@ struct ExecutionPartIterator {
     stack_.emplace_back(b, e, c);
     adjust();
   }
-  template <typename C>
-  ExecutionPartIterator(C &&range, Step stepping = Step::Default,
+  template <typename R>
+  ExecutionPartIterator(const R &range, Step stepping = Step::Default,
       const ExecutionPartConstruct *construct = nullptr)
       : ExecutionPartIterator(range.begin(), range.end(), stepping, construct) {
   }
@@ -344,7 +344,8 @@ template <typename Iterator = ExecutionPartIterator> struct ExecutionPartRange {
       Step stepping = Step::Default,
       const ExecutionPartConstruct *owner = nullptr)
       : begin_(begin, end, stepping, owner), end_() {}
-  ExecutionPartRange(const Block &range, Step stepping = Step::Default,
+  template <typename R>
+  ExecutionPartRange(const R &range, Step stepping = Step::Default,
       const ExecutionPartConstruct *owner = nullptr)
       : ExecutionPartRange(range.begin(), range.end(), stepping, owner) {}
 

--- a/flang/include/flang/Parser/openmp-utils.h
+++ b/flang/include/flang/Parser/openmp-utils.h
@@ -263,31 +263,31 @@ struct ExecutionPartIterator {
     Default = Into,
   };
 
-  using IteratorType = parser::Block::const_iterator;
+  using IteratorType = Block::const_iterator;
   using IteratorRange = llvm::iterator_range<IteratorType>;
 
   struct Construct {
     Construct(IteratorType b, IteratorType e,
-        const parser::ExecutionPartConstruct *c = nullptr)
+        const ExecutionPartConstruct *c = nullptr)
         : range(b, e), owner(c) {}
     template <typename C>
-    Construct(C &&r, const parser::ExecutionPartConstruct *c = nullptr)
+    Construct(C &&r, const ExecutionPartConstruct *c = nullptr)
         : range(r), owner(c) {}
     IteratorRange range;
-    const parser::ExecutionPartConstruct *owner = nullptr;
+    const ExecutionPartConstruct *owner = nullptr;
   };
 
   ExecutionPartIterator() = default;
 
   ExecutionPartIterator(IteratorType b, IteratorType e, Step s = Step::Default,
-      const parser::ExecutionPartConstruct *c = nullptr)
+      const ExecutionPartConstruct *c = nullptr)
       : stepping_(s) {
     stack_.emplace_back(b, e, c);
     adjust();
   }
   template <typename C>
   ExecutionPartIterator(C &&range, Step stepping = Step::Default,
-      const parser::ExecutionPartConstruct *construct = nullptr)
+      const ExecutionPartConstruct *construct = nullptr)
       : ExecutionPartIterator(range.begin(), range.end(), stepping, construct) {
   }
 
@@ -339,12 +339,12 @@ private:
 template <typename Iterator = ExecutionPartIterator> struct ExecutionPartRange {
   using Step = typename Iterator::Step;
 
-  ExecutionPartRange(parser::Block::const_iterator begin,
-      parser::Block::const_iterator end, Step stepping = Step::Default,
-      const parser::ExecutionPartConstruct *owner = nullptr)
+  ExecutionPartRange(Block::const_iterator begin, Block::const_iterator end,
+      Step stepping = Step::Default,
+      const ExecutionPartConstruct *owner = nullptr)
       : begin_(begin, end, stepping, owner), end_() {}
-  ExecutionPartRange(const parser::Block &range, Step stepping = Step::Default,
-      const parser::ExecutionPartConstruct *owner = nullptr)
+  ExecutionPartRange(const Block &range, Step stepping = Step::Default,
+      const ExecutionPartConstruct *owner = nullptr)
       : ExecutionPartRange(range.begin(), range.end(), stepping, owner) {}
 
   Iterator begin() const { return begin_; }
@@ -357,7 +357,7 @@ private:
 struct LoopNestIterator : public ExecutionPartIterator {
   LoopNestIterator() = default;
   LoopNestIterator(IteratorType b, IteratorType e, Step s = Step::Default,
-      const parser::ExecutionPartConstruct *c = nullptr)
+      const ExecutionPartConstruct *c = nullptr)
       : ExecutionPartIterator(b, e, s, c) {
     adjust();
   }
@@ -369,7 +369,7 @@ struct LoopNestIterator : public ExecutionPartIterator {
   }
 
 private:
-  static bool isLoop(const parser::ExecutionPartConstruct &c);
+  static bool isLoop(const ExecutionPartConstruct &c);
 
   void adjust() {
     while (valid() && !isLoop(**this)) {

--- a/flang/include/flang/Parser/openmp-utils.h
+++ b/flang/include/flang/Parser/openmp-utils.h
@@ -268,15 +268,14 @@ struct ExecutionPartIterator {
   using IteratorRange = llvm::iterator_range<IteratorType>;
 
   struct Construct {
-    Construct(IteratorType b, IteratorType e,
-        const ExecutionPartConstruct *c = nullptr)
+    Construct(IteratorType b, IteratorType e, const ExecutionPartConstruct *c)
         : range(b, e), owner(c) {}
     template <typename R>
-    Construct(const R &r, const ExecutionPartConstruct *c = nullptr)
+    Construct(const R &r, const ExecutionPartConstruct *c)
         : range(r), owner(c) {}
     Construct(const Construct &c) = default;
     IteratorRange range;
-    const ExecutionPartConstruct *owner = nullptr;
+    const ExecutionPartConstruct *owner;
   };
 
   ExecutionPartIterator() = default;

--- a/flang/include/flang/Parser/openmp-utils.h
+++ b/flang/include/flang/Parser/openmp-utils.h
@@ -286,7 +286,9 @@ struct ExecutionPartIterator {
     stack_.emplace_back(b, e, c);
     adjust();
   }
-  template <typename R>
+  template <typename R, //
+      typename = decltype(std::declval<R>().begin()),
+      typename = decltype(std::declval<R>().end())>
   ExecutionPartIterator(const R &range, Step stepping = Step::Default,
       const ExecutionPartConstruct *construct = nullptr)
       : ExecutionPartIterator(range.begin(), range.end(), stepping, construct) {
@@ -356,7 +358,9 @@ template <typename Iterator = ExecutionPartIterator> struct ExecutionPartRange {
       Step stepping = Step::Default,
       const ExecutionPartConstruct *owner = nullptr)
       : begin_(begin, end, stepping, owner), end_() {}
-  template <typename R>
+  template <typename R,
+      typename = decltype(std::declval<R>().begin()),
+      typename = decltype(std::declval<R>().end())>
   ExecutionPartRange(const R &range, Step stepping = Step::Default,
       const ExecutionPartConstruct *owner = nullptr)
       : ExecutionPartRange(range.begin(), range.end(), stepping, owner) {}
@@ -370,11 +374,18 @@ private:
 
 struct LoopNestIterator : public ExecutionPartIterator {
   LoopNestIterator() = default;
+
   LoopNestIterator(IteratorType b, IteratorType e, Step s = Step::Default,
       const ExecutionPartConstruct *c = nullptr)
       : ExecutionPartIterator(b, e, s, c) {
     adjust();
   }
+  template <typename R, //
+      typename = decltype(std::declval<R>().begin()),
+      typename = decltype(std::declval<R>().end())>
+  LoopNestIterator(const R &range, Step stepping = Step::Default,
+      const ExecutionPartConstruct *construct = nullptr)
+      : LoopNestIterator(range.begin(), range.end(), stepping, construct) {}
 
   LoopNestIterator &operator++() {
     ExecutionPartIterator::operator++();

--- a/flang/include/flang/Parser/openmp-utils.h
+++ b/flang/include/flang/Parser/openmp-utils.h
@@ -368,7 +368,7 @@ template <typename Iterator = ExecutionPartIterator> struct ExecutionPartRange {
       Step stepping = Step::Default,
       const ExecutionPartConstruct *owner = nullptr)
       : begin_(begin, end, stepping, owner), end_() {}
-  template <typename R,
+  template <typename R, //
       typename = decltype(std::declval<R>().begin()),
       typename = decltype(std::declval<R>().end())>
   ExecutionPartRange(const R &range, Step stepping = Step::Default,

--- a/flang/include/flang/Parser/openmp-utils.h
+++ b/flang/include/flang/Parser/openmp-utils.h
@@ -273,6 +273,7 @@ struct ExecutionPartIterator {
     template <typename C>
     Construct(C &&r, const ExecutionPartConstruct *c = nullptr)
         : range(r), owner(c) {}
+    Construct(const Construct &c) = default;
     IteratorRange range;
     const ExecutionPartConstruct *owner = nullptr;
   };

--- a/flang/include/flang/Parser/openmp-utils.h
+++ b/flang/include/flang/Parser/openmp-utils.h
@@ -243,17 +243,27 @@ OmpAllocateInfo SplitOmpAllocate(const OmpAllocateDirective &x);
 // of the range is reached, the iterator becomes invalid.
 // Treat BLOCK constructs as if they were transparent, i.e. as if the
 // BLOCK/ENDBLOCK statements, and the specification part contained within
-// were removed. For example, given the range:
-//   stmt1
-//   block
-//     integer :: x
-//     stmt2
-//     block
-//     end block
-//   end block
-//   stmt3
-// the iterator will return stmt1, stmt2, stmt3 in that order, then will
-// become invalid.
+// were removed. The stepping determines whether the iterator steps "into"
+// DO loops and OpenMP loop constructs, or steps "over" them.
+//
+// Example: consecutive locations of the iterator:
+//
+//    Step::Into                  Step::Over
+//          block                       block
+//    1 =>    stmt1               1 =>    stmt1
+//            block                       block
+//              integer :: x                integer :: x
+//    2 =>      stmt2             2 =>      stmt2
+//              block                       block
+//              end block                   end block
+//            end block                   end block
+//    3 =>    do i = 1, n         3 =>    do i = 1, n
+//    4 =>      continue                    continue
+//            end do                      end do
+//    5 =>    stmt3               4 =>    stmt3
+//          end block                   end block
+//
+//    6 =>  <invalid>             5 =>  <invalid>
 //
 // The iterator is in a legal state (position) if it's at an
 // ExecutionPartConstruct that is not a BlockConstruct, or is invalid.

--- a/flang/include/flang/Parser/openmp-utils.h
+++ b/flang/include/flang/Parser/openmp-utils.h
@@ -20,6 +20,7 @@
 #include "llvm/Frontend/OpenMP/OMP.h"
 
 #include <cassert>
+#include <iterator>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -326,6 +327,18 @@ struct ExecutionPartIterator {
     return *this;
   }
 
+  ExecutionPartIterator operator++(int) {
+    ExecutionPartIterator copy{*this};
+    operator++();
+    return copy;
+  }
+
+  using difference_type = IteratorType::difference_type;
+  using value_type = IteratorType::value_type;
+  using reference = IteratorType::reference;
+  using pointer = IteratorType::pointer;
+  using iterator_category = std::forward_iterator_tag;
+
 private:
   IteratorType at() const { return stack_.back().range.begin(); };
 
@@ -368,6 +381,12 @@ struct LoopNestIterator : public ExecutionPartIterator {
     ExecutionPartIterator::operator++();
     adjust();
     return *this;
+  }
+
+  LoopNestIterator operator++(int) {
+    LoopNestIterator copy{*this};
+    operator++();
+    return copy;
   }
 
 private:

--- a/flang/include/flang/Parser/openmp-utils.h
+++ b/flang/include/flang/Parser/openmp-utils.h
@@ -369,10 +369,7 @@ struct LoopNestIterator : public ExecutionPartIterator {
   }
 
 private:
-  static bool isLoop(const parser::ExecutionPartConstruct &c) {
-    return parser::Unwrap<parser::OpenMPLoopConstruct>(c) != nullptr ||
-        parser::Unwrap<parser::DoConstruct>(c) != nullptr;
-  }
+  static bool isLoop(const parser::ExecutionPartConstruct &c);
 
   void adjust() {
     while (valid() && !isLoop(**this)) {

--- a/flang/lib/Parser/openmp-utils.cpp
+++ b/flang/lib/Parser/openmp-utils.cpp
@@ -211,53 +211,49 @@ OmpAllocateInfo SplitOmpAllocate(const OmpAllocateDirective &x) {
   return info;
 }
 
-template <bool IsConst> LoopRange<IsConst>::LoopRange(QualReference x) {
-  if (auto *doLoop{Unwrap<DoConstruct>(x)}) {
-    Initialize(std::get<Block>(doLoop->t));
-  } else if (auto *omp{Unwrap<OpenMPLoopConstruct>(x)}) {
-    Initialize(std::get<Block>(omp->t));
+void ExecutionPartIterator::step() {
+  // Advance the iterator to the next legal position. If the current
+  // position is a DO-loop or a loop construct, step into it.
+  if (valid()) {
+    IteratorType where{at()};
+    if (auto *loop{parser::omp::GetOmpLoop(*where)}) {
+      stack_.emplace_back(std::get<parser::Block>(loop->t), &*where);
+    } else if (auto *loop{parser::omp::GetDoConstruct(*where)}) {
+      stack_.emplace_back(std::get<parser::Block>(loop->t), &*where);
+    } else {
+      stack_.back().range =
+          IteratorRange(std::next(where), stack_.back().range.end());
+    }
+    adjust();
   }
 }
 
-template <bool IsConst> void LoopRange<IsConst>::Initialize(QualBlock &body) {
-  using QualIterator = decltype(std::declval<QualBlock>().begin());
-  auto makeRange{[](auto &container) {
-    return llvm::make_range(container.begin(), container.end());
-  }};
+void ExecutionPartIterator::next() {
+  // Advance the iterator to the next legal position. If the current
+  // position is a DO-loop or a loop construct, step over it.
+  if (valid()) {
+    stack_.back().range =
+        IteratorRange(std::next(at()), stack_.back().range.end());
+    adjust();
+  }
+}
 
-  std::vector<llvm::iterator_range<QualIterator>> nest{makeRange(body)};
-  do {
-    auto at{nest.back().begin()};
-    auto end{nest.back().end()};
-    nest.pop_back();
-    while (at != end) {
-      if (auto *block{Unwrap<BlockConstruct>(*at)}) {
-        nest.push_back(llvm::make_range(std::next(at), end));
-        nest.push_back(makeRange(std::get<Block>(block->t)));
-        break;
-      } else if (Unwrap<DoConstruct>(*at) || Unwrap<OpenMPLoopConstruct>(*at)) {
-        items.push_back(&*at);
+void ExecutionPartIterator::adjust() {
+  // If the iterator is not at a legal location, keep advancing it until
+  // it lands at a legal location or becomes invalid.
+  while (valid()) {
+    if (stack_.back().range.empty()) {
+      stack_.pop_back();
+      if (valid()) {
+        stack_.back().range =
+            IteratorRange(std::next(at()), stack_.back().range.end());
       }
-      ++at;
+    } else if (auto *block{parser::omp::GetFortranBlockConstruct(*at())}) {
+      stack_.emplace_back(std::get<parser::Block>(block->t), &*at());
+    } else {
+      break;
     }
-  } while (!nest.empty());
+  }
 }
-
-template <bool IsConst>
-auto LoopRange<IsConst>::iterator::operator++(int) -> iterator {
-  auto old = *this;
-  ++*this;
-  return old;
-}
-
-template <bool IsConst>
-auto LoopRange<IsConst>::iterator::operator--(int) -> iterator {
-  auto old = *this;
-  --*this;
-  return old;
-}
-
-template struct LoopRange<false>;
-template struct LoopRange<true>;
 
 } // namespace Fortran::parser::omp

--- a/flang/lib/Parser/openmp-utils.cpp
+++ b/flang/lib/Parser/openmp-utils.cpp
@@ -216,10 +216,10 @@ void ExecutionPartIterator::step() {
   // position is a DO-loop or a loop construct, step into it.
   if (valid()) {
     IteratorType where{at()};
-    if (auto *loop{parser::omp::GetOmpLoop(*where)}) {
-      stack_.emplace_back(std::get<parser::Block>(loop->t), &*where);
-    } else if (auto *loop{parser::omp::GetDoConstruct(*where)}) {
-      stack_.emplace_back(std::get<parser::Block>(loop->t), &*where);
+    if (auto *loop{GetOmpLoop(*where)}) {
+      stack_.emplace_back(std::get<Block>(loop->t), &*where);
+    } else if (auto *loop{GetDoConstruct(*where)}) {
+      stack_.emplace_back(std::get<Block>(loop->t), &*where);
     } else {
       stack_.back().range =
           IteratorRange(std::next(where), stack_.back().range.end());
@@ -248,17 +248,17 @@ void ExecutionPartIterator::adjust() {
         stack_.back().range =
             IteratorRange(std::next(at()), stack_.back().range.end());
       }
-    } else if (auto *block{parser::omp::GetFortranBlockConstruct(*at())}) {
-      stack_.emplace_back(std::get<parser::Block>(block->t), &*at());
+    } else if (auto *block{GetFortranBlockConstruct(*at())}) {
+      stack_.emplace_back(std::get<Block>(block->t), &*at());
     } else {
       break;
     }
   }
 }
 
-bool LoopNestIterator::isLoop(const parser::ExecutionPartConstruct &c) {
-  return parser::Unwrap<parser::OpenMPLoopConstruct>(c) != nullptr ||
-      parser::Unwrap<parser::DoConstruct>(c) != nullptr;
+bool LoopNestIterator::isLoop(const ExecutionPartConstruct &c) {
+  return Unwrap<OpenMPLoopConstruct>(c) != nullptr ||
+      Unwrap<DoConstruct>(c) != nullptr;
 }
 
 } // namespace Fortran::parser::omp

--- a/flang/lib/Parser/openmp-utils.cpp
+++ b/flang/lib/Parser/openmp-utils.cpp
@@ -256,4 +256,9 @@ void ExecutionPartIterator::adjust() {
   }
 }
 
+bool LoopNestIterator::isLoop(const parser::ExecutionPartConstruct &c) {
+  return parser::Unwrap<parser::OpenMPLoopConstruct>(c) != nullptr ||
+      parser::Unwrap<parser::DoConstruct>(c) != nullptr;
+}
+
 } // namespace Fortran::parser::omp


### PR DESCRIPTION
In OpenMP a canonical loop nest may be enclosed in a BLOCK construct. Specifically, the two loops below are considered to form a valid loop sequence:
```f90
  do i = 1, n
  end do
  block
    do j = 1, m
    end do
  end block
```
Implement an extension to parser::Block::iterator that will treat the example above as
```f90
  do i = 1, n
  end do
  do j = 1, m
  end do
```
that is, as if the BLOCK/ENDBLOCK statement were deleted. This will make the analysis of loop nests easier, since any such code will not have to deal with BLOCK constructs itself.