### PR TITLE
[MLIR][Python] Remove partial LLVM APIs in python bindings (6/6)

### DIFF
--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -474,7 +474,6 @@ function(add_mlir_python_modules name)
         MLIR_BINDINGS_PYTHON_NB_DOMAIN ${ARG_MLIR_BINDINGS_PYTHON_NB_DOMAIN}
         _PRIVATE_SUPPORT_LIB
         LINK_LIBS PRIVATE
-          LLVMSupport
           ${sources_target}
           ${ARG_COMMON_CAPI_LINK_LIBS}
       )

--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -474,6 +474,10 @@ function(add_mlir_python_modules name)
         MLIR_BINDINGS_PYTHON_NB_DOMAIN ${ARG_MLIR_BINDINGS_PYTHON_NB_DOMAIN}
         _PRIVATE_SUPPORT_LIB
         LINK_LIBS PRIVATE
+        # LLVMSupport is intentionally removed to avoid introducing an LLVM dependency
+        # for the mlir-python bindings. Do not add new dependencies on the C++ LLVM/MLIR
+        # libraries; use the C++ standard library instead, or wrap LLVM functionality in
+        # the C API first.
           ${sources_target}
           ${ARG_COMMON_CAPI_LINK_LIBS}
       )

--- a/mlir/include/mlir-c/Support.h
+++ b/mlir/include/mlir-c/Support.h
@@ -156,6 +156,10 @@ MLIR_CAPI_EXPORTED MlirLlvmThreadPool mlirLlvmThreadPoolCreate(void);
 /// Destroy an LLVM thread pool.
 MLIR_CAPI_EXPORTED void mlirLlvmThreadPoolDestroy(MlirLlvmThreadPool pool);
 
+/// Returns the maximum number of threads in the thread pool.
+MLIR_CAPI_EXPORTED int
+mlirLlvmThreadPoolGetMaxConcurrency(MlirLlvmThreadPool pool);
+
 //===----------------------------------------------------------------------===//
 // MlirLlvmRawFdOStream.
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Bindings/Python/Globals.h
+++ b/mlir/include/mlir/Bindings/Python/Globals.h
@@ -22,9 +22,6 @@
 #include "mlir/Bindings/Python/NanobindUtils.h"
 #include "mlir/CAPI/Support.h"
 
-#include "llvm/ADT/StringExtras.h"
-#include "llvm/Support/Regex.h"
-
 namespace mlir {
 namespace python {
 namespace MLIR_BINDINGS_PYTHON_DOMAIN {

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -31,8 +31,6 @@
 #include "mlir/Bindings/Python/Nanobind.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 
-#include "llvm/Support/ThreadPool.h"
-
 namespace mlir {
 namespace python {
 namespace MLIR_BINDINGS_PYTHON_DOMAIN {
@@ -183,16 +181,17 @@ private:
 class MLIR_PYTHON_API_EXPORTED PyThreadPool {
 public:
   PyThreadPool();
+  ~PyThreadPool();
   PyThreadPool(const PyThreadPool &) = delete;
   PyThreadPool(PyThreadPool &&) = delete;
 
-  int getMaxConcurrency() const { return ownedThreadPool->getMaxConcurrency(); }
-  MlirLlvmThreadPool get() { return wrap(ownedThreadPool.get()); }
+  int getMaxConcurrency() const;
+  MlirLlvmThreadPool get() { return threadPool; }
 
   std::string _mlir_thread_pool_ptr() const;
 
 private:
-  std::unique_ptr<llvm::ThreadPoolInterface> ownedThreadPool;
+  MlirLlvmThreadPool threadPool;
 };
 
 /// Wrapper around MlirContext.

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -440,9 +440,7 @@ void PyOpOperandIterator::bind(nb::module_ &m) {
 // PyThreadPool
 //------------------------------------------------------------------------------
 
-PyThreadPool::PyThreadPool() {
-  threadPool = mlirLlvmThreadPoolCreate();
-}
+PyThreadPool::PyThreadPool() { threadPool = mlirLlvmThreadPoolCreate(); }
 
 PyThreadPool::~PyThreadPool() {
   if (threadPool.ptr)

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -20,6 +20,7 @@
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
 
+#include <array>
 #include <functional>
 #include <optional>
 #include <string>

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -441,12 +441,21 @@ void PyOpOperandIterator::bind(nb::module_ &m) {
 //------------------------------------------------------------------------------
 
 PyThreadPool::PyThreadPool() {
-  ownedThreadPool = std::make_unique<llvm::DefaultThreadPool>();
+  threadPool = mlirLlvmThreadPoolCreate();
+}
+
+PyThreadPool::~PyThreadPool() {
+  if (threadPool.ptr)
+    mlirLlvmThreadPoolDestroy(threadPool);
+}
+
+int PyThreadPool::getMaxConcurrency() const {
+  return mlirLlvmThreadPoolGetMaxConcurrency(threadPool);
 }
 
 std::string PyThreadPool::_mlir_thread_pool_ptr() const {
   std::stringstream ss;
-  ss << ownedThreadPool.get();
+  ss << threadPool.ptr;
   return ss.str();
 }
 

--- a/mlir/lib/CAPI/IR/Support.cpp
+++ b/mlir/lib/CAPI/IR/Support.cpp
@@ -35,6 +35,10 @@ void mlirLlvmThreadPoolDestroy(MlirLlvmThreadPool threadPool) {
   delete unwrap(threadPool);
 }
 
+int mlirLlvmThreadPoolGetMaxConcurrency(MlirLlvmThreadPool threadPool) {
+  return unwrap(threadPool)->getMaxConcurrency();
+}
+
 //===----------------------------------------------------------------------===//
 // LLVM raw_fd_ostream API.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This PR completed work from https://github.com/llvm/llvm-project/pull/178290.
Switched the last few python bindings that still relied on LLVM over to the C API, and dropped `LLVMsupport` dependency from MLIR cmake.