### PR TITLE
[LLDB][NativePDB] Use pointer and not pointee size for pointer constants

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
@@ -91,7 +91,7 @@ static std::pair<size_t, bool> GetIntegralTypeInfo(TypeIndex ti,
   case LF_POINTER: {
     PointerRecord pr;
     llvm::cantFail(TypeDeserializer::deserializeAs<PointerRecord>(cvt, pr));
-    return GetIntegralTypeInfo(pr.ReferentType, tpi);
+    return {pr.getSize(), false};
   }
   case LF_ENUM: {
     EnumRecord er;


### PR DESCRIPTION
Follow-up from https://github.com/llvm/llvm-project/pull/180612#pullrequestreview-3780142672

This was introduced in 2af3416618e6 and not fundamentally changed since. The review (https://reviews.llvm.org/D54452) doesn't mention any motivation for why we would want the pointee size/signedness here. As @Nerixyz points out, only a null pointer can be `S_CONSTANT` anyway.