### PR TITLE
[lldb][windows] fix undeclared identifier error GetModulePath

### DIFF
--- a/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
+++ b/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
@@ -19,7 +19,6 @@
 
 using namespace llvm;
 
-#ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
 static std::string GetModulePath(HMODULE module) {
   std::vector<WCHAR> buffer(MAX_PATH);
   while (buffer.size() <= PATHCCH_MAX_CCH) {
@@ -41,6 +40,7 @@ static std::string GetModulePath(HMODULE module) {
 /// Returns the full path to the lldb.exe executable.
 static std::string GetPathToExecutable() { return GetModulePath(NULL); }
 
+#ifdef LLDB_PYTHON_DLL_RELATIVE_PATH
 bool AddPythonDLLToSearchPath() {
   std::string path_str = GetPathToExecutable();
   if (path_str.empty())


### PR DESCRIPTION
`LLDB_PYTHON_DLL_RELATIVE_PATH` can be unset while `LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME` is, since it's set automatically by CMake. This situation causes a build failure which this patch fixes.

This issue was introduced in https://github.com/llvm/llvm-project/pull/180784.