### PR TITLE
[DWARFLinker] Link itself against LLVM_ATOMIC_LIB

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/CMakeLists.txt
+++ b/llvm/lib/DWARFLinker/Parallel/CMakeLists.txt
@@ -19,6 +19,7 @@ add_llvm_component_library(LLVMDWARFLinkerParallel
 
   LINK_LIBS
   ${LLVM_PTHREAD_LIB}
+  ${LLVM_ATOMIC_LIB}
 
   LINK_COMPONENTS
   AsmPrinter


### PR DESCRIPTION
Avoid such link error when building on RISC-V:

```
FAILED: lib/libLLVMDWARFLinkerParallel.so.21.1
<artificial>:(.text._ZN4llvm12dwarf_linker8parallel17DependencyTracker28markParentsAsKeepingChildrenERKNS1_15UnitEntryPairTyE+0x1b4):
 undefined reference to __atomic_compare_exchange_2'
```