### PR TITLE
[flang] Downgrade error to warning for IGNORE_TKR case

### DIFF
--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -81,7 +81,8 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
     NullActualForDefaultIntentAllocatable, UseAssociationIntoSameNameSubprogram,
     HostAssociatedIntentOutInSpecExpr, NonVolatilePointerToVolatile,
     RealConstantWidening, VolatileOrAsynchronousTemporary, UnusedVariable,
-    UsedUndefinedVariable, BadValueInDeadCode, AssumedTypeSizeDummy)
+    UsedUndefinedVariable, BadValueInDeadCode, AssumedTypeSizeDummy,
+    MisplacedIgnoreTKR)
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -10239,16 +10239,18 @@ void ResolveNamesVisitor::Post(const parser::CompilerDirective &x) {
   }
   if (const auto *tkr{
           std::get_if<std::list<parser::CompilerDirective::IgnoreTKR>>(&x.u)}) {
-    if (currScope().IsTopLevel() ||
-        GetProgramUnitContaining(currScope()).kind() !=
-            Scope::Kind::Subprogram) {
+    if (currScope().IsTopLevel()) {
       Say(x.source,
-          "!DIR$ IGNORE_TKR directive must appear in a subroutine or function"_err_en_US);
+          "!DIR$ IGNORE_TKR directive must appear in a program unit"_err_en_US);
       return;
-    }
-    if (!inSpecificationPart_) {
-      Say(x.source,
-          "!DIR$ IGNORE_TKR directive must appear in the specification part"_err_en_US);
+    } else if (GetProgramUnitContaining(currScope()).kind() !=
+        Scope::Kind::Subprogram) {
+      context().Warn(common::UsageWarning::MisplacedIgnoreTKR, x.source,
+          "!DIR$ IGNORE_TKR directive should appear in a subroutine or function"_warn_en_US);
+      return;
+    } else if (!inSpecificationPart_) {
+      context().Warn(common::UsageWarning::MisplacedIgnoreTKR, x.source,
+          "!DIR$ IGNORE_TKR directive should appear in the specification part"_warn_en_US);
       return;
     }
     if (tkr->empty()) {

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -152,6 +152,7 @@ LanguageFeatureControl::LanguageFeatureControl() {
   warnLanguage_.set(LanguageFeature::SavedLocalInSpecExpr);
   warnLanguage_.set(LanguageFeature::NullActualForAllocatable);
   warnUsage_.set(UsageWarning::BadValueInDeadCode);
+  warnUsage_.set(UsageWarning::MisplacedIgnoreTKR);
 }
 
 std::optional<LanguageControlFlag> LanguageFeatureControl::FindWarning(

--- a/flang/test/Semantics/OpenMP/compiler-directive.f90
+++ b/flang/test/Semantics/OpenMP/compiler-directive.f90
@@ -1,7 +1,7 @@
 ! RUN: %python %S/../test_errors.py %s %flang -fopenmp
 ! CompilerDirective with openmp tests
 
-!ERROR: !DIR$ IGNORE_TKR directive must appear in a subroutine or function
+!ERROR: !DIR$ IGNORE_TKR directive must appear in a program unit
 !dir$ ignore_tkr
 
 program main

--- a/flang/test/Semantics/ignore_tkr01.f90
+++ b/flang/test/Semantics/ignore_tkr01.f90
@@ -1,12 +1,12 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 ! !DIR$ IGNORE_TKR tests
 
-!ERROR: !DIR$ IGNORE_TKR directive must appear in a subroutine or function
+!ERROR: !DIR$ IGNORE_TKR directive must appear in a program unit
 !dir$ ignore_tkr
 
 module m
 
-!ERROR: !DIR$ IGNORE_TKR directive must appear in a subroutine or function
+!WARNING: !DIR$ IGNORE_TKR directive should appear in a subroutine or function [-Wmisplaced-ignore-tkr]
 !dir$ ignore_tkr
 
   interface
@@ -115,7 +115,7 @@ module m
   subroutine t17(x)
     real x
     x = x + 1.
-!ERROR: !DIR$ IGNORE_TKR directive must appear in the specification part
+!WARNING: !DIR$ IGNORE_TKR directive should appear in the specification part [-Wmisplaced-ignore-tkr]
 !dir$ ignore_tkr x
   end
 
@@ -173,7 +173,7 @@ end
 
 program test
 
-!ERROR: !DIR$ IGNORE_TKR directive must appear in a subroutine or function
+!WARNING: !DIR$ IGNORE_TKR directive should appear in a subroutine or function [-Wmisplaced-ignore-tkr]
 !dir$ ignore_tkr
 
   use m


### PR DESCRIPTION
The IGNORE_TKR directive has meaning only in the specification part of a subroutine or function subprogram or interface. Presently, it is an error when the directive appears elsewhere.

At user request, this patch softens the error to a warning for when this directive appears in a program unit other than a subroutine or function, and when it appears in a subroutine or function subprogram outside the specification part of its top scope.