### PR TITLE
[clang][modules] Remove fno-modules-check-relocated as a driver option

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -3645,10 +3645,6 @@ defm implicit_modules : BoolFOption<"implicit-modules",
   NegFlag<SetFalse, [], [ClangOption, CC1Option]>,
   PosFlag<SetTrue>, BothFlags<
           [NoXarchOption], [ClangOption, CLOption]>>;
-def fno_modules_check_relocated : Joined<["-"], "fno-modules-check-relocated">,
-  Group<f_Group>, Visibility<[ClangOption, CC1Option]>,
-  HelpText<"Skip checks for relocated modules when loading PCM files">,
-  MarshallingInfoNegativeFlag<PreprocessorOpts<"ModulesCheckRelocated">>;
 def fretain_comments_from_system_headers : Flag<["-"], "fretain-comments-from-system-headers">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,
   MarshallingInfoFlag<LangOpts<"RetainCommentsFromSystemHeaders">>;
@@ -8988,6 +8984,11 @@ def disable_pragma_debug_crash : Flag<["-"], "disable-pragma-debug-crash">,
 def source_date_epoch : Separate<["-"], "source-date-epoch">,
   MetaVarName<"<time since Epoch in seconds>">,
   HelpText<"Time to be used in __DATE__, __TIME__, and __TIMESTAMP__ macros">;
+def fno_modules_check_relocated
+    : Joined<["-"], "fno-modules-check-relocated">,
+      Group<f_Group>,
+      HelpText<"Skip checks for relocated modules when loading PCM files">,
+      MarshallingInfoNegativeFlag<PreprocessorOpts<"ModulesCheckRelocated">>;
 
 } // let Visibility = [CC1Option]
 

--- a/clang/test/Driver/unsupported-option.c
+++ b/clang/test/Driver/unsupported-option.c
@@ -6,6 +6,10 @@
 // RUN: FileCheck %s --check-prefix=DID-YOU-MEAN
 // DID-YOU-MEAN: error: unknown argument '--hell'; did you mean '--help'?
 
+// RUN: not %clang %s -fno-modules-check-relocated -### 2>&1 | \
+// RUN: FileCheck %s --check-prefix=DID-YOU-MEAN-CC1
+// DID-YOU-MEAN-CC1: error: unknown argument '-fno-modules-check-relocated'; did you mean '-Xclang -fno-modules-check-relocated'?
+
 // RUN: not %clang --target=powerpc-ibm-aix %s -mlong-double-128 2>&1 | \
 // RUN: FileCheck %s --check-prefix=AIX-LONGDOUBLE128-ERR
 // AIX-LONGDOUBLE128-ERR: error: unsupported option '-mlong-double-128' for target 'powerpc-ibm-aix'


### PR DESCRIPTION
This preprocessor option is only ever respected as a CC1 option because it's never handled in the driver. One gets warnings like `argument unused during compilation: '-fno-modules-check-relocated'` when not passed directly to CC1.

Move the option definition into the Preprocessor CC1 only visibility section.