### PR TITLE
[ReleaseNotes] Create subheader for LLDB/FreeBSD

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -182,9 +182,18 @@ Changes to the LLVM tools
 Changes to LLDB
 ---------------
 
-* Support for FreeBSD on MIPS64 has been removed.
-* The minimum assumed version of FreeBSD is now 14. The effect of which is that watchpoints are
+### FreeBSD
+
+#### Userspace Debugging
+
+* Support for MIPS64 has been removed.
+* The minimum assumed FreeBSD version is now 14. The effect of which is that watchpoints are
   assumed to be supported.
+
+#### Kernel Debugging
+
+* The crashed thread is now automatically selected on start.
+* Threads are listed in incrmental order by pid then by tid.
 
 Changes to BOLT
 ---------------


### PR DESCRIPTION
Since there will be many changes to LLDB on FreeBSD support in 23, create subheaders for FreeBSD to separate related changes into relevant subheaders.

This also adds #178069 and #178306 in the release note.