### PR TITLE
[lldb-dap] Adjusting multi-stopped event order.

### DIFF
--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -181,9 +181,10 @@ void SendProcessEvent(DAP &dap, LaunchMethod launch_method) {
 static void SendStoppedEvent(DAP &dap, lldb::SBThread &thread, bool on_entry,
                              bool all_threads_stopped, bool preserve_focus) {
   protocol::StoppedEventBody body;
+  body.reason = protocol::eStoppedReasonPause;
   if (on_entry) {
     body.reason = protocol::eStoppedReasonEntry;
-  } else {
+  } else if (thread.IsValid()) {
     switch (thread.GetStopReason()) {
     case lldb::eStopReasonTrace:
     case lldb::eStopReasonPlanComplete:
@@ -235,13 +236,14 @@ static void SendStoppedEvent(DAP &dap, lldb::SBThread &thread, bool on_entry,
     case lldb::eStopReasonThreadExiting:
     case lldb::eStopReasonInvalid:
     case lldb::eStopReasonNone:
-      return;
+      break;
     }
+
+    lldb::SBStream description;
+    thread.GetStopDescription(description);
+    body.description = {description.GetData(), description.GetSize()};
   }
   lldb::tid_t tid = thread.GetThreadID();
-  lldb::SBStream description;
-  thread.GetStopDescription(description);
-  body.description = {description.GetData(), description.GetSize()};
   body.threadId = tid;
   body.allThreadsStopped = all_threads_stopped;
   body.preserveFocusHint = preserve_focus;
@@ -266,7 +268,8 @@ llvm::Error SendThreadStoppedEvent(DAP &dap, bool on_entry) {
   llvm::DenseSet<lldb::tid_t> old_thread_ids;
   old_thread_ids.swap(dap.thread_ids);
 
-  lldb::tid_t focused_tid = LLDB_INVALID_THREAD_ID;
+  lldb::SBThread focused_thread;
+  std::vector<lldb::SBThread> stopped_threads;
   for (auto thread : process) {
     // Collect all known thread ids for sending thread events.
     dap.thread_ids.insert(thread.GetThreadID());
@@ -274,22 +277,29 @@ llvm::Error SendThreadStoppedEvent(DAP &dap, bool on_entry) {
     if (!ThreadHasStopReason(thread))
       continue;
 
-    // When we stop, report allThreadsStopped for the *first* stopped thread to
-    // ensure the list of stopped threads is up to date.
-    bool first_stop = focused_tid == LLDB_INVALID_THREAD_ID;
-    SendStoppedEvent(dap, thread, on_entry, /*all_threads_stopped=*/first_stop,
-                     /*preserve_focus=*/!first_stop);
-
-    // Default focus to the first stopped thread.
-    if (focused_tid == LLDB_INVALID_THREAD_ID)
-      focused_tid = thread.GetThreadID();
+    // Focus on the first stopped thread
+    if (!focused_thread.IsValid())
+      focused_thread = thread;
+    else
+      stopped_threads.push_back(thread);
   }
 
-  if (focused_tid == LLDB_INVALID_THREAD_ID)
+  // If no stopped threads were detected, fallback to the selected thread.
+  if (!focused_thread)
+    focused_thread = process.GetSelectedThread();
+
+  if (!focused_thread)
     return make_error<DAPError>("no stopped threads");
 
+  // Send stopped events for each thread thats stopped.
+  for (auto thread : stopped_threads)
+    SendStoppedEvent(dap, thread, on_entry, false, true);
+
+  // Notify the focused thread last to ensure the UI is focused correctly.
+  SendStoppedEvent(dap, focused_thread, on_entry, true, false);
+
   // Update focused thread.
-  dap.focus_tid = focused_tid;
+  dap.focus_tid = focused_thread.GetThreadID();
 
   for (const auto &tid : old_thread_ids)
     if (!dap.thread_ids.contains(tid))

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -293,10 +293,12 @@ llvm::Error SendThreadStoppedEvent(DAP &dap, bool on_entry) {
 
   // Send stopped events for each thread thats stopped.
   for (auto thread : stopped_threads)
-    SendStoppedEvent(dap, thread, on_entry, false, true);
+    SendStoppedEvent(dap, thread, on_entry, /*all_threads_stopped=*/false,
+                     /*preserve_focus=*/true);
 
   // Notify the focused thread last to ensure the UI is focused correctly.
-  SendStoppedEvent(dap, focused_thread, on_entry, true, false);
+  SendStoppedEvent(dap, focused_thread, on_entry, /*all_threads_stopped=*/true,
+                   /*preserve_focus=*/false);
 
   // Update focused thread.
   dap.focus_tid = focused_thread.GetThreadID();


### PR DESCRIPTION
When multiple stopped events are detected we should send the `"allThreadsStopped":true` last.

Currently, if there are multiple stopped threads and we attempt to step around the 'allThreadsStopped' ends up with multiple stops highlighted in the UI.

Reporting the focused thread last fixes this while still correctly updating the thread state of all stopped threads.

This fixes an issue reported in https://github.com/llvm/llvm-project/pull/176273#discussion_r2775979486