### PR TITLE
[BOLT] Add --clone-at-origin option

### DIFF
--- a/bolt/include/bolt/Passes/CreateClonesAtOrigin.h
+++ b/bolt/include/bolt/Passes/CreateClonesAtOrigin.h
@@ -1,0 +1,38 @@
+//===- bolt/Passes/CreateClonesAtOrigin.h -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Pass for creating clones at origin of functions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BOLT_PASSES_CREATE_CLONES_AT_ORIGIN_H
+#define BOLT_PASSES_CREATE_CLONES_AT_ORIGIN_H
+
+#include "bolt/Passes/BinaryPasses.h"
+
+namespace llvm {
+namespace bolt {
+
+/// Pass for creating clones at origin of functions.
+///
+/// This pass creates clones at the original function addresses and runs
+/// scanExternalRefs() to update references from clone code to relocated
+/// functions. Unlike patching (which redirects execution from original to
+/// optimized code), cloning keeps the original code executable.
+class CreateClonesAtOrigin : public BinaryFunctionPass {
+public:
+  explicit CreateClonesAtOrigin() : BinaryFunctionPass(false) {}
+
+  const char *getName() const override { return "create-clones-at-origin"; }
+  Error runOnFunctions(BinaryContext &BC) override;
+};
+
+} // namespace bolt
+} // namespace llvm
+
+#endif

--- a/bolt/include/bolt/Utils/CommandLineOpts.h
+++ b/bolt/include/bolt/Utils/CommandLineOpts.h
@@ -80,6 +80,7 @@ extern llvm::cl::opt<bool> DiffOnly;
 extern llvm::cl::opt<bool> EnableBAT;
 extern llvm::cl::opt<bool> EqualizeBBCounts;
 extern llvm::cl::opt<bool> ForcePatch;
+extern llvm::cl::opt<bool> CloneAtOrigin;
 extern llvm::cl::opt<bool> RemoveSymtab;
 extern llvm::cl::opt<unsigned> ExecutionCountThreshold;
 extern llvm::cl::opt<HeatmapBlockSizes, false, HeatmapBlockSpecParser>

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -104,7 +104,7 @@ JumpTables("jump-tables",
   cl::ZeroOrMore,
   cl::cat(BoltOptCategory));
 
-static cl::opt<bool> NoScan(
+cl::opt<bool> NoScan(
     "no-scan",
     cl::desc(
         "do not scan cold functions for external references (may result in "
@@ -456,6 +456,8 @@ void BinaryFunction::print(raw_ostream &OS, std::string Annotation) {
     OS << "\n  Personality : " << getPersonalityFunction()->getName();
   if (IsFragment)
     OS << "\n  IsFragment  : true";
+  if (HasCloneAtOrigin)
+    OS << "\n  HasCloneAtOrigin : true";
   if (isFolded())
     OS << "\n  FoldedInto  : " << *getFoldedIntoFunction();
   for (BinaryFunction *ParentFragment : ParentFragments)

--- a/bolt/lib/Passes/CMakeLists.txt
+++ b/bolt/lib/Passes/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llvm_library(LLVMBOLTPasses
   BinaryPasses.cpp
   CMOVConversion.cpp
   CacheMetrics.cpp
+  CreateClonesAtOrigin.cpp
   DataflowAnalysis.cpp
   DataflowInfoManager.cpp
   FrameAnalysis.cpp

--- a/bolt/lib/Passes/CreateClonesAtOrigin.cpp
+++ b/bolt/lib/Passes/CreateClonesAtOrigin.cpp
@@ -29,11 +29,6 @@ Error CreateClonesAtOrigin::runOnFunctions(BinaryContext &BC) {
   if (!opts::CloneAtOrigin)
     return Error::success();
 
-  if (opts::UseOldText) {
-    BC.outs() << "BOLT-INFO: skipping clones at origin with --use-old-text\n";
-    return Error::success();
-  }
-
   if (opts::Verbosity >= 1)
     BC.outs() << "BOLT-INFO: creating clones at origin\n";
 

--- a/bolt/lib/Passes/CreateClonesAtOrigin.cpp
+++ b/bolt/lib/Passes/CreateClonesAtOrigin.cpp
@@ -1,0 +1,81 @@
+//===- bolt/Passes/CreateClonesAtOrigin.cpp -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the CreateClonesAtOrigin pass that creates clones of
+// functions at their original addresses. Unlike patching (which redirects
+// execution from original to optimized code), cloning keeps the original code
+// executable and updates its references to relocated functions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "bolt/Passes/CreateClonesAtOrigin.h"
+#include "bolt/Utils/CommandLineOpts.h"
+
+namespace opts {
+extern llvm::cl::opt<bool> NoScan;
+extern llvm::cl::opt<bool> UseOldText;
+extern llvm::cl::opt<unsigned> Verbosity;
+} // namespace opts
+
+namespace llvm {
+namespace bolt {
+
+Error CreateClonesAtOrigin::runOnFunctions(BinaryContext &BC) {
+  if (!opts::CloneAtOrigin)
+    return Error::success();
+
+  if (opts::UseOldText) {
+    BC.outs() << "BOLT-INFO: skipping clones at origin with --use-old-text\n";
+    return Error::success();
+  }
+
+  if (opts::Verbosity >= 1)
+    BC.outs() << "BOLT-INFO: creating clones at origin\n";
+
+  unsigned NumClonesCreated = 0;
+
+  // Iterate over input functions.
+  for (BinaryFunction &Function :
+       llvm::make_second_range(BC.getBinaryFunctions())) {
+
+    // Only clone functions that will be emitted (relocated).
+    if (!BC.shouldEmit(Function))
+      continue;
+
+    // Skip if already has a clone at origin.
+    if (Function.hasCloneAtOrigin())
+      continue;
+
+    // Mark the function as having a clone at origin.
+    Function.setHasCloneAtOrigin();
+
+    // Run scanExternalRefs() to update the clone's references to relocated
+    // functions.
+    const bool Success = opts::NoScan || Function.scanExternalRefs();
+    if (!Success) {
+      BC.errs()
+          << "BOLT-ERROR: internal error creating refs for emitted function\n";
+      exit(1);
+    }
+
+    ++NumClonesCreated;
+
+    if (opts::Verbosity >= 2)
+      BC.outs() << "BOLT-INFO: created clone at origin for " << Function
+                << '\n';
+  }
+
+  if (NumClonesCreated > 0)
+    BC.outs() << "BOLT-INFO: created " << NumClonesCreated
+              << " clones at origin\n";
+
+  return Error::success();
+}
+
+} // namespace bolt
+} // namespace llvm

--- a/bolt/lib/Passes/PatchEntries.cpp
+++ b/bolt/lib/Passes/PatchEntries.cpp
@@ -41,6 +41,10 @@ Error PatchEntries::runOnFunctions(BinaryContext &BC) {
       if (BF.isFolded())
         return false;
 
+      // Skip functions that already have clones at origin.
+      if (BF.hasCloneAtOrigin())
+        return false;
+
       // Patching is always needed if explicitly requested.
       if (BF.needsPatch())
         return true;
@@ -69,6 +73,10 @@ Error PatchEntries::runOnFunctions(BinaryContext &BC) {
 
     // Patch original code only for functions that will be emitted.
     if (!BC.shouldEmit(Function))
+      continue;
+
+    // Skip functions that already have clones at origin.
+    if (Function.hasCloneAtOrigin())
       continue;
 
     // Check if we can skip patching the function.

--- a/bolt/lib/Rewrite/BinaryPassManager.cpp
+++ b/bolt/lib/Rewrite/BinaryPassManager.cpp
@@ -12,6 +12,7 @@
 #include "bolt/Passes/AllocCombiner.h"
 #include "bolt/Passes/AsmDump.h"
 #include "bolt/Passes/CMOVConversion.h"
+#include "bolt/Passes/CreateClonesAtOrigin.h"
 #include "bolt/Passes/FixRISCVCallsPass.h"
 #include "bolt/Passes/FixRelaxationPass.h"
 #include "bolt/Passes/FrameOptimizer.h"
@@ -523,6 +524,12 @@ Error BinaryFunctionPassManager::runAllPasses(BinaryContext &BC) {
   // Perform reordering on data contained in one or more sections using
   // memory profiling data.
   Manager.registerPass(std::make_unique<ReorderData>());
+
+  // Create clones at origin (if --clone-at-origin is specified).
+  // This must run before PatchEntries so that cloned functions are skipped
+  // during patching.
+  if (BC.HasRelocations)
+    Manager.registerPass(std::make_unique<CreateClonesAtOrigin>());
 
   // Patch original function entries
   if (BC.HasRelocations)

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2425,6 +2425,20 @@ void RewriteInstance::adjustCommandLineOptions() {
     if (!opts::TerminalTrap.getNumOccurrences())
       opts::TerminalTrap = false;
   }
+
+  if (opts::CloneAtOrigin) {
+    if (opts::ForcePatch) {
+      BC->errs() << "BOLT-ERROR: --clone-at-origin is incompatible with "
+                    "--force-patch\n";
+      exit(1);
+    }
+
+    if (opts::UseOldText) {
+      BC->errs() << "BOLT-ERROR: --clone-at-origin is incompatible with "
+                    "--use-old-text\n";
+      exit(1);
+    }
+  }
 }
 
 namespace {

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2284,12 +2284,6 @@ Error RewriteInstance::readSpecialSections() {
 }
 
 void RewriteInstance::adjustCommandLineOptions() {
-  if (opts::CloneAtOrigin && opts::ForcePatch) {
-    BC->errs() << "BOLT-ERROR: --clone-at-origin is incompatible with "
-                  "--force-patch\n";
-    exit(1);
-  }
-
   if (BC->isAArch64() && !BC->HasRelocations)
     BC->errs() << "BOLT-WARNING: non-relocation mode for AArch64 is not fully "
                   "supported\n";

--- a/bolt/lib/Utils/CommandLineOpts.cpp
+++ b/bolt/lib/Utils/CommandLineOpts.cpp
@@ -92,6 +92,13 @@ llvm::cl::opt<bool> ForcePatch(
                    "execution follows only the new/optimized code."),
     llvm::cl::Hidden, llvm::cl::cat(BoltCategory));
 
+llvm::cl::opt<bool> CloneAtOrigin(
+    "clone-at-origin",
+    llvm::cl::desc("create clones of functions at their original addresses "
+                   "instead of patching entry points. The clone code will "
+                   "have its references to relocated functions updated."),
+    llvm::cl::Hidden, llvm::cl::cat(BoltCategory));
+
 cl::opt<bool> RemoveSymtab("remove-symtab", cl::desc("Remove .symtab section"),
                            cl::cat(BoltCategory));
 

--- a/bolt/test/AArch64/clone-at-origin-secondary-entry.s
+++ b/bolt/test/AArch64/clone-at-origin-secondary-entry.s
@@ -1,0 +1,36 @@
+## Test that --clone-at-origin creates clone symbols for secondary entry points.
+
+# REQUIRES: system-linux
+
+# RUN: %clang %cflags -nostdlib %s -o %t.exe -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt --clone-at-origin
+
+## Get the original alt_entry address.
+# RUN: llvm-nm %t.exe | grep " alt_entry$" | cut -d' ' -f1 > %t.alt_orig
+
+## Verify clone symbols exist for both main function and secondary entry point.
+# RUN: llvm-nm -n %t.bolt | FileCheck %s
+
+# CHECK: main_func.clone.0
+# CHECK: alt_entry.clone.0
+
+## Verify alt_entry clone address matches original.
+# RUN: llvm-nm %t.bolt | grep "alt_entry.clone.0" | cut -d' ' -f1 > %t.alt_clone
+# RUN: diff %t.alt_orig %t.alt_clone
+
+  .text
+  .globl main_func
+  .type main_func, %function
+main_func:
+  nop
+  .type alt_entry, %function
+alt_entry:
+  ret
+  .size main_func, .-main_func
+
+  .globl _start
+  .type _start, %function
+_start:
+  bl main_func
+  ret
+  .size _start, .-_start

--- a/bolt/test/runtime/exceptions-clone.cpp
+++ b/bolt/test/runtime/exceptions-clone.cpp
@@ -1,0 +1,107 @@
+// Test that clones at origin work correctly with C++ exception handling.
+//
+// The test creates two caller functions:
+// - caller_optimized: will be relocated/optimized by BOLT
+// - caller_skipped: will be skipped (not relocated) by BOLT
+//
+// With --no-scan, BOLT won't scan unrelocated code for references, so:
+// - caller_skipped's call to catch_exception remains at original address
+//   (clone)
+// - caller_optimized's call to catch_exception is rewritten to new address
+//
+// This tests that both versions of catch_exception work correctly.
+
+// clang-format off
+
+// REQUIRES: system-linux
+
+// RUN: %clangxx %cxxflags -no-pie -O1 -fno-inline %s -Wl,-q -o %t
+
+// Get the original catch_exception address for later verification.
+// RUN: llvm-nm %t | grep " catch_exception$" | cut -d' ' -f1 > %t.orig_addr
+
+// Run BOLT with clone-at-origin.
+// RUN: llvm-bolt %t -o %t.bolt \
+// RUN:   --skip-funcs=caller_skipped \
+// RUN:   --no-scan \
+// RUN:   --clone-at-origin \
+// RUN:   2>&1 | FileCheck %s --check-prefix=CHECK-BOLT
+
+// CHECK-BOLT: BOLT-INFO: created {{[0-9]+}} clones at origin
+
+// Verify the clone symbol exists in the output binary.
+// RUN: llvm-nm %t.bolt | grep ".clone.0" | FileCheck %s --check-prefix=CHECK-SYM
+
+// CHECK-SYM: .clone.0
+
+// Verify that the clone symbol address matches the original function address.
+// RUN: llvm-nm %t.bolt | grep "catch_exception.clone.0" | cut -d' ' -f1 > %t.clone_addr
+// RUN: diff %t.orig_addr %t.clone_addr
+
+// The relocated function should be at a DIFFERENT address than the original.
+// RUN: llvm-nm %t.bolt | grep " catch_exception$" | cut -d' ' -f1 > %t.bolt_addr
+// RUN: not diff %t.orig_addr %t.bolt_addr
+
+// Verify caller_skipped calls the clone (at original address).
+// RUN: llvm-objdump -d %t.bolt --disassemble-symbols=caller_skipped \
+// RUN:   | FileCheck %s --check-prefix=CHECK-SKIPPED-CALL
+
+// CHECK-SKIPPED-CALL: <caller_skipped>:
+// CHECK-SKIPPED-CALL: jmp{{.*}}<catch_exception.clone.0>
+
+// Verify caller_optimized calls the relocated function (not the clone).
+// RUN: llvm-objdump -d %t.bolt --disassemble-symbols=caller_optimized \
+// RUN:   | FileCheck %s --check-prefix=CHECK-OPTIMIZED-CALL
+
+// CHECK-OPTIMIZED-CALL: <caller_optimized>:
+// CHECK-OPTIMIZED-CALL: jmp{{.*}}<catch_exception>
+
+// Run the bolted binary - both callers should work:
+// - caller_skipped calls original code (clone) at original address
+// - caller_optimized calls relocated code at new address
+// RUN: %t.bolt 2>&1 | FileCheck %s --check-prefix=CHECK-EXEC
+
+// CHECK-EXEC: Testing exception handling with clones
+// CHECK-EXEC: caller_skipped -> catch_exception (original/clone):
+// CHECK-EXEC-NEXT: caught: 42
+// CHECK-EXEC: caller_optimized -> catch_exception (relocated):
+// CHECK-EXEC-NEXT: caught: 42
+// CHECK-EXEC: All exceptions handled correctly
+
+#include <cstdio>
+#include <exception>
+
+// This function will be cloned. It catches an exception.
+// Using extern "C" to avoid name mangling for easier testing.
+extern "C" __attribute__((noinline)) void catch_exception() {
+  try {
+    throw 42;
+  } catch (int e) {
+    printf("caught: %d\n", e);
+  }
+}
+
+// This caller will be SKIPPED by BOLT (not relocated).
+// Its call to catch_exception will remain pointing to the original address.
+// With --no-scan, this call won't be updated, so it calls the clone.
+extern "C" __attribute__((noinline)) void caller_skipped() {
+  printf("caller_skipped -> catch_exception (original/clone):\n");
+  catch_exception();
+}
+
+// This caller will be OPTIMIZED by BOLT (relocated).
+// Its call to catch_exception will be rewritten to the new address.
+extern "C" __attribute__((noinline)) void caller_optimized() {
+  printf("caller_optimized -> catch_exception (relocated):\n");
+  catch_exception();
+}
+
+int main() {
+  printf("Testing exception handling with clones\n");
+
+  caller_skipped();
+  caller_optimized();
+
+  printf("All exceptions handled correctly\n");
+  return 0;
+}

--- a/bolt/test/runtime/exceptions-clone.cpp
+++ b/bolt/test/runtime/exceptions-clone.cpp
@@ -47,14 +47,14 @@
 // RUN:   | FileCheck %s --check-prefix=CHECK-SKIPPED-CALL
 
 // CHECK-SKIPPED-CALL: <caller_skipped>:
-// CHECK-SKIPPED-CALL: jmp{{.*}}<catch_exception.clone.0>
+// CHECK-SKIPPED-CALL: {{.*}}<catch_exception.clone.0>
 
 // Verify caller_optimized calls the relocated function (not the clone).
 // RUN: llvm-objdump -d %t.bolt --disassemble-symbols=caller_optimized \
 // RUN:   | FileCheck %s --check-prefix=CHECK-OPTIMIZED-CALL
 
 // CHECK-OPTIMIZED-CALL: <caller_optimized>:
-// CHECK-OPTIMIZED-CALL: jmp{{.*}}<catch_exception>
+// CHECK-OPTIMIZED-CALL: {{.*}}<catch_exception>
 
 // Run the bolted binary - both callers should work:
 // - caller_skipped calls original code (clone) at original address


### PR DESCRIPTION
Add --clone-at-origin as an alternative to patching function entries. When enabled, BOLT creates clones at original addresses instead of inserting trampolines. This is useful when original function is too small for a trampoline or patching overhead is undesirable.

The clone preserves original code with references updated to point to relocated functions. Original .eh_frame/.gcc_except_table remain valid.

Debug info changes for the clone will be included in a separate patch.

Future patches will build on top of this clone functionality.