### PR TITLE
Reland "[lldb] Fix TSan report"

### DIFF
--- a/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
@@ -88,8 +88,18 @@ extern "C"
     // TODO: dlsym won't work on Windows.
     void *dlsym(void* handle, const char* symbol);
     int (*ptr__tsan_get_report_loc_object_type)(void *report, unsigned long idx, const char **object_type);
-}
+)"
+#if defined(__linux__)
+                                                           R"(
+    void *const RTLD_DEFAULT = (void *)0;
+  }
 )";
+#else
+                                                           R"(
+    void *const RTLD_DEFAULT = (void *)-2;
+  }
+)";
+#endif
 
 const char *thread_sanitizer_retrieve_report_data_command = R"(
 
@@ -161,7 +171,7 @@ struct {
     } unique_tids[REPORT_ARRAY_SIZE];
 } t = {0};
 
-ptr__tsan_get_report_loc_object_type = (typeof(ptr__tsan_get_report_loc_object_type))(void *)dlsym((void*)-2 /*RTLD_DEFAULT*/, "__tsan_get_report_loc_object_type");
+ptr__tsan_get_report_loc_object_type = (typeof(ptr__tsan_get_report_loc_object_type))(void *)dlsym(RTLD_DEFAULT, "__tsan_get_report_loc_object_type");
 
 t.report = __tsan_get_current_report();
 __tsan_get_report_data(t.report, &t.description, &t.report_count, &t.stack_count, &t.mop_count, &t.loc_count, &t.mutex_count, &t.thread_count, &t.unique_tid_count, t.sleep_trace, REPORT_TRACE_SIZE);

--- a/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
@@ -88,18 +88,13 @@ extern "C"
     // TODO: dlsym won't work on Windows.
     void *dlsym(void* handle, const char* symbol);
     int (*ptr__tsan_get_report_loc_object_type)(void *report, unsigned long idx, const char **object_type);
-)"
 #if defined(__linux__)
-                                                           R"(
-    void *const RTLD_DEFAULT = (void *)0;
-  }
-)";
+#define RTLD_DEFAULT	((void *) 0)
 #else
-                                                           R"(
-    void *const RTLD_DEFAULT = (void *)-2;
+#define RTLD_DEFAULT	((void *) -2)
+#endif
   }
 )";
-#endif
 
 const char *thread_sanitizer_retrieve_report_data_command = R"(
 

--- a/lldb/test/API/functionalities/tsan/cpp_global_location/TestTsanCPPGlobalLocation.py
+++ b/lldb/test/API/functionalities/tsan/cpp_global_location/TestTsanCPPGlobalLocation.py
@@ -10,10 +10,6 @@ import json
 
 
 class TsanCPPGlobalLocationTestCase(TestBase):
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="non-core functionality, need to reenable and fix later (DES 2014.11.07)",
-    )
     @expectedFailureNetBSD
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @skipIfRemote

--- a/lldb/test/API/functionalities/tsan/global_location/TestTsanGlobalLocation.py
+++ b/lldb/test/API/functionalities/tsan/global_location/TestTsanGlobalLocation.py
@@ -10,10 +10,6 @@ import json
 
 
 class TsanGlobalLocationTestCase(TestBase):
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="non-core functionality, need to reenable and fix later (DES 2014.11.07)",
-    )
     @expectedFailureNetBSD
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @skipIfRemote

--- a/lldb/test/API/functionalities/tsan/multiple/TestTsanMultiple.py
+++ b/lldb/test/API/functionalities/tsan/multiple/TestTsanMultiple.py
@@ -10,10 +10,6 @@ import json
 
 
 class TsanMultipleTestCase(TestBase):
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="non-core functionality, need to reenable and fix later (DES 2014.11.07)",
-    )
     @expectedFailureNetBSD
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @skipIfRemote

--- a/lldb/test/API/functionalities/tsan/thread_leak/TestTsanThreadLeak.py
+++ b/lldb/test/API/functionalities/tsan/thread_leak/TestTsanThreadLeak.py
@@ -9,10 +9,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TsanThreadLeakTestCase(TestBase):
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="non-core functionality, need to reenable and fix later (DES 2014.11.07)",
-    )
     @expectedFailureNetBSD
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @skipIfRemote

--- a/lldb/test/API/functionalities/tsan/thread_numbers/TestTsanThreadNumbers.py
+++ b/lldb/test/API/functionalities/tsan/thread_numbers/TestTsanThreadNumbers.py
@@ -10,10 +10,6 @@ import json
 
 
 class TsanThreadNumbersTestCase(TestBase):
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="non-core functionality, need to reenable and fix later (DES 2014.11.07)",
-    )
     @expectedFailureNetBSD
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @skipIfRemote


### PR DESCRIPTION
Reland "[lldb] Fix TSan report".

I investigated problems with TSan.

Tests `cpp_global_location` and `global_location` fails on my machine because TSan can not find `llvm-symbolizer` (e.g. `PATH=$PATH:$PWD/bin ./bin/lldb-dotest /home/sergei/llvm-project/lldb/test/API/functionalities/tsan` solves this problem). Can we add bin dir to PATH to make these tests more robuts?

Test `basic` has more problems. `GetSelectedFrame` returns `::OutputReport()` instead of `__tsan_on_report`, but in C++ `GetSelectedFrame(DoNoSelectMostRelevantFrame)` returns correct ones. And after `continue` TSan calls `exit(66)` without `SIGABORT` and `pthread_kill` on my machine, so I don't know how to enable this test on Linux.

