### PR TITLE
[LLDB][NFCI] Teach LLDB to read the DW_AT_LLVM_tag_offset attribute for variables

### DIFF
--- a/lldb/include/lldb/Symbol/Variable.h
+++ b/lldb/include/lldb/Symbol/Variable.h
@@ -34,7 +34,8 @@ public:
            SymbolContextScope *owner_scope, const RangeList &scope_range,
            Declaration *decl, const DWARFExpressionList &location,
            bool external, bool artificial, bool location_is_constant_data,
-           bool static_member = false);
+           bool static_member = false,
+           std::optional<uint64_t> tag_offset = std::nullopt);
 
   virtual ~Variable();
 
@@ -78,6 +79,10 @@ public:
   const DWARFExpressionList &LocationExpressionList() const {
     return m_location_list;
   }
+
+  uint64_t GetTagOffset() const { return m_tag_offset.value(); }
+
+  bool HasTagOffset() const { return m_tag_offset.has_value(); }
 
   // When given invalid address, it dumps all locations. Otherwise it only dumps
   // the location that contains this address.
@@ -143,6 +148,8 @@ protected:
   unsigned m_loc_is_const_data : 1;
   /// Non-zero if variable is static member of a class or struct.
   unsigned m_static_member : 1;
+  // The value of DW_AT_LLVM_tag_offset if present.
+  std::optional<uint64_t> m_tag_offset;
 
 private:
   Variable(const Variable &rhs) = delete;

--- a/lldb/include/lldb/Symbol/Variable.h
+++ b/lldb/include/lldb/Symbol/Variable.h
@@ -148,7 +148,7 @@ protected:
   unsigned m_loc_is_const_data : 1;
   /// Non-zero if variable is static member of a class or struct.
   unsigned m_static_member : 1;
-  // The value of DW_AT_LLVM_tag_offset if present.
+  /// The value of DW_AT_LLVM_tag_offset if present.
   std::optional<uint64_t> m_tag_offset;
 
 private:

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -3574,6 +3574,7 @@ VariableSP SymbolFileDWARF::ParseVariableDIE(const SymbolContext &sc,
   DWARFFormValue type_die_form;
   bool is_external = false;
   bool is_artificial = false;
+  std::optional<uint64_t> tag_offset = std::nullopt;
   DWARFFormValue const_value_form, location_form;
   Variable::RangeList scope_ranges;
 
@@ -3584,6 +3585,9 @@ VariableSP SymbolFileDWARF::ParseVariableDIE(const SymbolContext &sc,
     if (!attributes.ExtractFormValueAtIndex(i, form_value))
       continue;
     switch (attr) {
+    case DW_AT_LLVM_tag_offset:
+      tag_offset = form_value.Unsigned();
+      break;
     case DW_AT_decl_file:
       decl.SetFile(
           attributes.CompileUnitAtIndex(i)->GetFile(form_value.Unsigned()));
@@ -3824,7 +3828,7 @@ VariableSP SymbolFileDWARF::ParseVariableDIE(const SymbolContext &sc,
   return std::make_shared<Variable>(
       die.GetID(), name, mangled, type_sp, scope, symbol_context_scope,
       scope_ranges, &decl, location_list, is_external, is_artificial,
-      location_is_const_value_data, is_static_member);
+      location_is_const_value_data, is_static_member, tag_offset);
 }
 
 DWARFDIE

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -44,14 +44,14 @@ Variable::Variable(lldb::user_id_t uid, const char *name, const char *mangled,
                    const RangeList &scope_range, Declaration *decl_ptr,
                    const DWARFExpressionList &location_list, bool external,
                    bool artificial, bool location_is_constant_data,
-                   bool static_member)
+                   bool static_member, std::optional<uint64_t> tag_offset)
     : UserID(uid), m_name(name), m_mangled(ConstString(mangled)),
       m_symfile_type_sp(symfile_type_sp), m_scope(scope),
       m_owner_scope(context), m_scope_range(scope_range),
       m_declaration(decl_ptr), m_location_list(location_list),
       m_external(external), m_artificial(artificial),
       m_loc_is_const_data(location_is_constant_data),
-      m_static_member(static_member) {
+      m_static_member(static_member), m_tag_offset(tag_offset) {
 #ifndef NDEBUG
   if (TestingProperties::GetGlobalTestingProperties()
           .GetInjectVarLocListError())


### PR DESCRIPTION
LLVM added support for emitting the tagging offset of a variable for hwasan/memtag-stack using the DW_AT_LLVM_tag_offset attribute in dabd262. This patch teaches LLDB to read this attribute.