### PR TITLE
[flang][openmp] Add support for ordered regions in SIMD directives

### DIFF
--- a/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
@@ -702,6 +702,11 @@ bool ClauseProcessor::processSimdlen(
   return false;
 }
 
+bool ClauseProcessor::processSimd(
+    mlir::omp::OrderedRegionOperands &result) const {
+  return markClauseOccurrence<omp::clause::Simd>(result.parLevelSimd);
+}
+
 bool ClauseProcessor::processThreadLimit(
     lower::StatementContext &stmtCtx,
     mlir::omp::ThreadLimitClauseOps &result) const {

--- a/flang/lib/Lower/OpenMP/ClauseProcessor.h
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.h
@@ -113,6 +113,7 @@ public:
   bool processSchedule(lower::StatementContext &stmtCtx,
                        mlir::omp::ScheduleClauseOps &result) const;
   bool processSimdlen(mlir::omp::SimdlenClauseOps &result) const;
+  bool processSimd(mlir::omp::OrderedRegionOperands &result) const;
   bool processThreadLimit(lower::StatementContext &stmtCtx,
                           mlir::omp::ThreadLimitClauseOps &result) const;
   bool processUntied(mlir::omp::UntiedClauseOps &result) const;

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -1589,7 +1589,7 @@ genOrderedRegionClauses(lower::AbstractConverter &converter,
                         const List<Clause> &clauses, mlir::Location loc,
                         mlir::omp::OrderedRegionOperands &clauseOps) {
   ClauseProcessor cp(converter, semaCtx, clauses);
-  cp.processTODO<clause::Simd>(loc, llvm::omp::Directive::OMPD_ordered);
+  cp.processSimd(clauseOps);
 }
 
 static void genParallelClauses(

--- a/flang/test/Lower/OpenMP/ordered-simd.f90
+++ b/flang/test/Lower/OpenMP/ordered-simd.f90
@@ -1,5 +1,6 @@
 ! This test checks lowering of SIMD constructs with ordered regions.
 ! RUN: bbc -fopenmp -emit-hlfir %s -o - | FileCheck %s
+! RUN: %flang_fc1 -fopenmp -emit-hlfir %s -o - | FileCheck %s
 
 ! Test that ordered regions inside SIMD have par_level_simd attribute
 subroutine ordered_simd(n)

--- a/flang/test/Lower/OpenMP/ordered-simd.f90
+++ b/flang/test/Lower/OpenMP/ordered-simd.f90
@@ -1,0 +1,56 @@
+! This test checks lowering of SIMD constructs with ordered regions.
+! RUN: bbc -fopenmp -emit-hlfir %s -o - | FileCheck %s
+
+! Test that ordered regions inside SIMD have par_level_simd attribute
+subroutine ordered_simd(n)
+  integer :: n, a(n), b(n), c(n), i
+
+! CHECK-LABEL: func @_QPordered_simd
+! CHECK:         omp.simd linear({{.*}}) private({{.*}}) {
+! CHECK:           omp.loop_nest (%{{.*}}) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) {
+! CHECK:             omp.ordered.region par_level_simd {
+! CHECK:               omp.terminator
+! CHECK:             }
+! CHECK:             omp.yield
+! CHECK:           }
+! CHECK:         } {linear_var_types = [i32]}
+
+  !$omp simd
+  do i = 1, n
+    a(i) = b(i) * 10
+    !$omp ordered simd
+    print *, a(i)
+    !$omp end ordered
+    c(i) = a(i) * 2
+  end do
+  !$omp end simd
+
+end subroutine
+
+! Test that ordered regions inside DO SIMD have par_level_simd attribute
+subroutine ws_ordered_simd(n)
+  integer :: n, a(n), b(n), c(n), i
+
+! CHECK-LABEL: func @_QPws_ordered_simd
+! CHECK:         omp.wsloop ordered(0) {
+! CHECK:           omp.simd linear({{.*}}) private({{.*}}) {
+! CHECK:             omp.loop_nest (%{{.*}}) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) {
+! CHECK:               omp.ordered.region par_level_simd {
+! CHECK:                 omp.terminator
+! CHECK:               }
+! CHECK:               omp.yield
+! CHECK:             }
+! CHECK:           } {linear_var_types = [i32], omp.composite}
+! CHECK:         } {omp.composite}
+
+  !$omp do simd ordered
+  do i = 1, n
+    a(i) = b(i) * 10
+    !$omp ordered simd
+    print *, a(i)
+    !$omp end ordered
+    c(i) = a(i) * 2
+  end do
+  !$omp end do simd
+
+end subroutine

--- a/mlir/test/Target/LLVMIR/openmp-simd-ordered.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-simd-ordered.mlir
@@ -15,16 +15,9 @@
 //     c(i) = a(i) * 2
 // end do
 // !$omp end simd
-// !$omp end do simd
 
 module {
   omp.private {type = private} @i_private_i32 : i32
-
-  llvm.func @_FortranAioBeginExternalListOutput(i32, !llvm.ptr, i32) -> !llvm.ptr
-  llvm.func @_FortranAioOutputInteger32(!llvm.ptr, i32) -> i1
-  llvm.func @_FortranAioEndIoStatement(!llvm.ptr) -> i32
-
-  llvm.mlir.global internal constant @str("test.f90\00") {addr_space = 0 : i32}
 
   // CHECK-LABEL: define void @simd_ordered_linear
   llvm.func @simd_ordered_linear() {
@@ -34,8 +27,6 @@ module {
     %c10_i32 = llvm.mlir.constant(10 : i32) : i32
     %c10_val = llvm.mlir.constant(10 : i32) : i32
     %c2 = llvm.mlir.constant(2 : i32) : i32
-    %c6 = llvm.mlir.constant(6 : i32) : i32
-    %c18 = llvm.mlir.constant(18 : i32) : i32
 
     // Allocate arrays and loop variable
     %c100_i64 = llvm.mlir.constant(100 : i64) : i64
@@ -72,11 +63,6 @@ module {
           %i_ord_off = llvm.sub %i_ord_idx, %c1_i64 : i64
           %a_ord_ptr = llvm.getelementptr %a[%i_ord_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
           %a_ord_val = llvm.load %a_ord_ptr : !llvm.ptr -> i32
-
-          %str_ptr = llvm.mlir.addressof @str : !llvm.ptr
-          %io = llvm.call @_FortranAioBeginExternalListOutput(%c6, %str_ptr, %c18) : (i32, !llvm.ptr, i32) -> !llvm.ptr
-          %result = llvm.call @_FortranAioOutputInteger32(%io, %a_ord_val) : (!llvm.ptr, i32) -> i1
-          %end = llvm.call @_FortranAioEndIoStatement(%io) : (!llvm.ptr) -> i32
           omp.terminator
         }
 

--- a/mlir/test/Target/LLVMIR/openmp-simd-ordered.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-simd-ordered.mlir
@@ -1,0 +1,100 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+// Test that linear variables in SIMD loops with ordered regions
+// are correctly rewritten to use .linear_result in:
+// 1. The ordered region (omp.ordered.region)
+// 2. Code after the ordered region (omp_region.finalize)
+//
+// This tests "omp ordered simd" nested in  "omp simd ordered"
+// !$omp simd
+// do i = 1, n
+//     a(i) = b(i) * 10
+//         !$omp ordered simd
+//             print *, a(i)
+//         !$omp end ordered
+//     c(i) = a(i) * 2
+// end do
+// !$omp end simd
+// !$omp end do simd
+
+module {
+  omp.private {type = private} @i_private_i32 : i32
+
+  llvm.func @_FortranAioBeginExternalListOutput(i32, !llvm.ptr, i32) -> !llvm.ptr
+  llvm.func @_FortranAioOutputInteger32(!llvm.ptr, i32) -> i1
+  llvm.func @_FortranAioEndIoStatement(!llvm.ptr) -> i32
+
+  llvm.mlir.global internal constant @str("test.f90\00") {addr_space = 0 : i32}
+
+  // CHECK-LABEL: define void @simd_ordered_linear
+  llvm.func @simd_ordered_linear() {
+    %c0_i64 = llvm.mlir.constant(0 : i64) : i64
+    %c1_i64 = llvm.mlir.constant(1 : i64) : i64
+    %c1_i32 = llvm.mlir.constant(1 : i32) : i32
+    %c10_i32 = llvm.mlir.constant(10 : i32) : i32
+    %c10_val = llvm.mlir.constant(10 : i32) : i32
+    %c2 = llvm.mlir.constant(2 : i32) : i32
+    %c6 = llvm.mlir.constant(6 : i32) : i32
+    %c18 = llvm.mlir.constant(18 : i32) : i32
+
+    // Allocate arrays and loop variable
+    %c100_i64 = llvm.mlir.constant(100 : i64) : i64
+    %a = llvm.alloca %c100_i64 x i32 : (i64) -> !llvm.ptr
+    %b = llvm.alloca %c100_i64 x i32 : (i64) -> !llvm.ptr
+    %c = llvm.alloca %c100_i64 x i32 : (i64) -> !llvm.ptr
+    %i = llvm.alloca %c1_i64 x i32 {bindc_name = "i"} : (i64) -> !llvm.ptr
+
+    // CHECK: %.linear_var = alloca i32
+    // CHECK: %.linear_result = alloca i32
+
+    omp.simd linear(%i = %c1_i32 : !llvm.ptr) private(@i_private_i32 %i -> %arg0 : !llvm.ptr) {
+      omp.loop_nest (%iv) : i32 = (%c1_i32) to (%c10_i32) inclusive step (%c1_i32) {
+        // CHECK: omp.loop_nest.region:
+        // CHECK: load i32, ptr %.linear_result
+        llvm.store %iv, %arg0 : i32, !llvm.ptr
+
+        // Compute a[i] = b[i] * 10
+        %i_val = llvm.load %arg0 : !llvm.ptr -> i32
+        %i_idx = llvm.sext %i_val : i32 to i64
+        %i_off = llvm.sub %i_idx, %c1_i64 : i64
+        %b_ptr = llvm.getelementptr %b[%i_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+        %b_val = llvm.load %b_ptr : !llvm.ptr -> i32
+        %a_val = llvm.mul %b_val, %c10_val : i32
+        %a_ptr = llvm.getelementptr %a[%i_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+        llvm.store %a_val, %a_ptr : i32, !llvm.ptr
+
+        // Ordered region
+        omp.ordered.region par_level_simd {
+          // CHECK: omp.ordered.region:
+          // CHECK: load i32, ptr %.linear_result
+          %i_ord = llvm.load %arg0 : !llvm.ptr -> i32
+          %i_ord_idx = llvm.sext %i_ord : i32 to i64
+          %i_ord_off = llvm.sub %i_ord_idx, %c1_i64 : i64
+          %a_ord_ptr = llvm.getelementptr %a[%i_ord_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+          %a_ord_val = llvm.load %a_ord_ptr : !llvm.ptr -> i32
+
+          %str_ptr = llvm.mlir.addressof @str : !llvm.ptr
+          %io = llvm.call @_FortranAioBeginExternalListOutput(%c6, %str_ptr, %c18) : (i32, !llvm.ptr, i32) -> !llvm.ptr
+          %result = llvm.call @_FortranAioOutputInteger32(%io, %a_ord_val) : (!llvm.ptr, i32) -> i1
+          %end = llvm.call @_FortranAioEndIoStatement(%io) : (!llvm.ptr) -> i32
+          omp.terminator
+        }
+
+        // Compute c[i] = a[i] * 2 (code after ordered region)
+        // CHECK: omp_region.finalize:
+        // CHECK: load i32, ptr %.linear_result
+        %i_post = llvm.load %arg0 : !llvm.ptr -> i32
+        %i_post_idx = llvm.sext %i_post : i32 to i64
+        %i_post_off = llvm.sub %i_post_idx, %c1_i64 : i64
+        %a_post_ptr = llvm.getelementptr %a[%i_post_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+        %a_post_val = llvm.load %a_post_ptr : !llvm.ptr -> i32
+        %c_val = llvm.mul %a_post_val, %c2 : i32
+        %c_ptr = llvm.getelementptr %c[%i_post_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+        llvm.store %c_val, %c_ptr : i32, !llvm.ptr
+
+        omp.yield
+      }
+    } {linear_var_types = [i32]}
+    llvm.return
+  }
+}

--- a/mlir/test/Target/LLVMIR/openmp-simd-ordered.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-simd-ordered.mlir
@@ -97,4 +97,5 @@ module {
     } {linear_var_types = [i32]}
     llvm.return
   }
+  // CHECK: !{!"llvm.loop.vectorize.enable", i1 true}
 }

--- a/mlir/test/Target/LLVMIR/openmp-todo.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-todo.mlir
@@ -52,17 +52,6 @@ llvm.func @distribute_order(%lb : i32, %ub : i32, %step : i32) {
 
 // -----
 
-llvm.func @ordered_region_par_level_simd() {
-  // expected-error@below {{not yet implemented: Unhandled clause parallelization-level in omp.ordered.region operation}}
-  // expected-error@below {{LLVM Translation failed for operation: omp.ordered.region}}
-  omp.ordered.region par_level_simd {
-    omp.terminator
-  }
-  llvm.return
-}
-
-// -----
-
 llvm.func @parallel_allocate(%x : !llvm.ptr) {
   // expected-error@below {{not yet implemented: Unhandled clause allocate in omp.parallel operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.parallel}}

--- a/mlir/test/Target/LLVMIR/openmp-wsloop-simd-ordered.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-wsloop-simd-ordered.mlir
@@ -19,12 +19,6 @@
 module {
   omp.private {type = private} @i_private_i32 : i32
 
-  llvm.func @_FortranAioBeginExternalListOutput(i32, !llvm.ptr, i32) -> !llvm.ptr
-  llvm.func @_FortranAioOutputInteger32(!llvm.ptr, i32) -> i1
-  llvm.func @_FortranAioEndIoStatement(!llvm.ptr) -> i32
-
-  llvm.mlir.global internal constant @str("test.f90\00") {addr_space = 0 : i32}
-
   // CHECK-LABEL: define void @wsloop_simd_ordered_linear
   llvm.func @wsloop_simd_ordered_linear() {
     %c0_i64 = llvm.mlir.constant(0 : i64) : i64
@@ -33,8 +27,6 @@ module {
     %c100_i32 = llvm.mlir.constant(100 : i32) : i32
     %c10_val = llvm.mlir.constant(10 : i32) : i32
     %c2 = llvm.mlir.constant(2 : i32) : i32
-    %c6 = llvm.mlir.constant(6 : i32) : i32
-    %c18 = llvm.mlir.constant(18 : i32) : i32
 
     // Allocate arrays and loop variable
     %c100_i64 = llvm.mlir.constant(100 : i64) : i64
@@ -73,10 +65,6 @@ module {
             %a_ord_ptr = llvm.getelementptr %a[%i_ord_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
             %a_ord_val = llvm.load %a_ord_ptr : !llvm.ptr -> i32
 
-            %str_ptr = llvm.mlir.addressof @str : !llvm.ptr
-            %io = llvm.call @_FortranAioBeginExternalListOutput(%c6, %str_ptr, %c18) : (i32, !llvm.ptr, i32) -> !llvm.ptr
-            %result = llvm.call @_FortranAioOutputInteger32(%io, %a_ord_val) : (!llvm.ptr, i32) -> i1
-            %end = llvm.call @_FortranAioEndIoStatement(%io) : (!llvm.ptr) -> i32
             omp.terminator
           }
 

--- a/mlir/test/Target/LLVMIR/openmp-wsloop-simd-ordered.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-wsloop-simd-ordered.mlir
@@ -1,0 +1,101 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+// Test that linear variables in worksharing+SIMD loops with ordered regions
+// are correctly rewritten to use .linear_result in:
+// 1. The ordered region (omp.ordered.region)
+// 2. Code after the ordered region (omp_region.finalize)
+//
+// This tests "omp ordered simd" nested in  "omp do simd ordered" case
+// !$omp do simd ordered
+// do i = 1, n
+//     a(i) = b(i) * 10
+//         !$omp ordered simd
+//             print *, a(i)
+//         !$omp end ordered
+//     c(i) = a(i) * 2
+// end do
+// !$omp end do simd
+
+module {
+  omp.private {type = private} @i_private_i32 : i32
+
+  llvm.func @_FortranAioBeginExternalListOutput(i32, !llvm.ptr, i32) -> !llvm.ptr
+  llvm.func @_FortranAioOutputInteger32(!llvm.ptr, i32) -> i1
+  llvm.func @_FortranAioEndIoStatement(!llvm.ptr) -> i32
+
+  llvm.mlir.global internal constant @str("test.f90\00") {addr_space = 0 : i32}
+
+  // CHECK-LABEL: define void @wsloop_simd_ordered_linear
+  llvm.func @wsloop_simd_ordered_linear() {
+    %c0_i64 = llvm.mlir.constant(0 : i64) : i64
+    %c1_i64 = llvm.mlir.constant(1 : i64) : i64
+    %c1_i32 = llvm.mlir.constant(1 : i32) : i32
+    %c100_i32 = llvm.mlir.constant(100 : i32) : i32
+    %c10_val = llvm.mlir.constant(10 : i32) : i32
+    %c2 = llvm.mlir.constant(2 : i32) : i32
+    %c6 = llvm.mlir.constant(6 : i32) : i32
+    %c18 = llvm.mlir.constant(18 : i32) : i32
+
+    // Allocate arrays and loop variable
+    %c100_i64 = llvm.mlir.constant(100 : i64) : i64
+    %a = llvm.alloca %c100_i64 x i32 : (i64) -> !llvm.ptr
+    %b = llvm.alloca %c100_i64 x i32 : (i64) -> !llvm.ptr
+    %c = llvm.alloca %c100_i64 x i32 : (i64) -> !llvm.ptr
+    %i = llvm.alloca %c1_i64 x i32 {bindc_name = "i"} : (i64) -> !llvm.ptr
+
+    // CHECK: %.linear_var = alloca i32
+    // CHECK: %.linear_result = alloca i32
+
+    omp.wsloop ordered(0) {
+      omp.simd linear(%i = %c1_i32 : !llvm.ptr) private(@i_private_i32 %i -> %arg0 : !llvm.ptr) {
+        omp.loop_nest (%iv) : i32 = (%c1_i32) to (%c100_i32) inclusive step (%c1_i32) {
+          // CHECK: omp.loop_nest.region:
+          // CHECK: load i32, ptr %.linear_result
+          llvm.store %iv, %arg0 : i32, !llvm.ptr
+
+          // Compute a[i] = b[i] * 10
+          %i_val = llvm.load %arg0 : !llvm.ptr -> i32
+          %i_idx = llvm.sext %i_val : i32 to i64
+          %i_off = llvm.sub %i_idx, %c1_i64 : i64
+          %b_ptr = llvm.getelementptr %b[%i_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+          %b_val = llvm.load %b_ptr : !llvm.ptr -> i32
+          %a_val = llvm.mul %b_val, %c10_val : i32
+          %a_ptr = llvm.getelementptr %a[%i_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+          llvm.store %a_val, %a_ptr : i32, !llvm.ptr
+
+          // Ordered region
+          omp.ordered.region par_level_simd {
+            // CHECK: omp.ordered.region:
+            // CHECK: load i32, ptr %.linear_result
+            %i_ord = llvm.load %arg0 : !llvm.ptr -> i32
+            %i_ord_idx = llvm.sext %i_ord : i32 to i64
+            %i_ord_off = llvm.sub %i_ord_idx, %c1_i64 : i64
+            %a_ord_ptr = llvm.getelementptr %a[%i_ord_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+            %a_ord_val = llvm.load %a_ord_ptr : !llvm.ptr -> i32
+
+            %str_ptr = llvm.mlir.addressof @str : !llvm.ptr
+            %io = llvm.call @_FortranAioBeginExternalListOutput(%c6, %str_ptr, %c18) : (i32, !llvm.ptr, i32) -> !llvm.ptr
+            %result = llvm.call @_FortranAioOutputInteger32(%io, %a_ord_val) : (!llvm.ptr, i32) -> i1
+            %end = llvm.call @_FortranAioEndIoStatement(%io) : (!llvm.ptr) -> i32
+            omp.terminator
+          }
+
+          // Compute c[i] = a[i] * 2 (code after ordered region)
+          // CHECK: omp_region.finalize:
+          // CHECK: load i32, ptr %.linear_result
+          %i_post = llvm.load %arg0 : !llvm.ptr -> i32
+          %i_post_idx = llvm.sext %i_post : i32 to i64
+          %i_post_off = llvm.sub %i_post_idx, %c1_i64 : i64
+          %a_post_ptr = llvm.getelementptr %a[%i_post_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+          %a_post_val = llvm.load %a_post_ptr : !llvm.ptr -> i32
+          %c_val = llvm.mul %a_post_val, %c2 : i32
+          %c_ptr = llvm.getelementptr %c[%i_post_off] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+          llvm.store %c_val, %c_ptr : i32, !llvm.ptr
+
+          omp.yield
+        }
+      } {linear_var_types = [i32], omp.composite}
+    } {omp.composite}
+    llvm.return
+  }
+}

--- a/mlir/test/Target/LLVMIR/openmp-wsloop-simd-ordered.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-wsloop-simd-ordered.mlir
@@ -98,4 +98,5 @@ module {
     } {omp.composite}
     llvm.return
   }
+  // CHECK: !{!"llvm.loop.vectorize.enable", i1 true}
 }


### PR DESCRIPTION
Add support for ordered regions within SIMD directives (!$omp simd ordered and !$omp do simd ordered). This initial implementation matches Clang's behavior.

In SIMD directives, loop induction variables have an implicit linear clause with deferred store semantics (storing to .linear_result). To properly support ordered regions, the LinearClauseProcessor rewrites variable references to use .linear_result in:
- omp.ordered.region: Code inside ordered blocks
- omp_region.finalize: Code after ordered blocks

Note: The vectorizer cannot currently vectorize loops with ordered regions. Future enhancement would require generating lane loops or unrolling ordered regions across SIMD lanes while maintaining ordering semantics.