### PR TITLE
[ASan][Windows] Fix false positive for zero sized rtl allocations

### DIFF
--- a/compiler-rt/lib/asan/asan_malloc_win.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_win.cpp
@@ -55,9 +55,10 @@ using namespace __asan;
 
 #  if SANITIZER_WINDOWS
 // Marks an allocation as originally zero-size. Must be called on allocations
-// that were changed from size 0 to 1 outside of Allocate() (e.g. SharedReAlloc).
+// that were changed from size 0 to 1 outside of Allocate() (e.g.
+// SharedReAlloc).
 namespace __asan {
-void asan_mark_zero_allocation(void *ptr);
+void asan_mark_zero_allocation(void* ptr);
 }
 #  endif
 

--- a/compiler-rt/lib/asan/asan_malloc_win.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_win.cpp
@@ -53,14 +53,12 @@ BOOL WINAPI HeapValidate(HANDLE hHeap, DWORD dwFlags, LPCVOID lpMem);
 
 using namespace __asan;
 
-#  if SANITIZER_WINDOWS
 // Marks an allocation as originally zero-size. Must be called on allocations
 // that were changed from size 0 to 1 outside of Allocate() (e.g.
 // SharedReAlloc).
 namespace __asan {
 void asan_mark_zero_allocation(void* ptr);
 }
-#  endif
 
 // MT: Simply defining functions with the same signature in *.obj
 // files overrides the standard functions in the CRT.

--- a/compiler-rt/lib/asan/asan_malloc_win.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_win.cpp
@@ -53,6 +53,14 @@ BOOL WINAPI HeapValidate(HANDLE hHeap, DWORD dwFlags, LPCVOID lpMem);
 
 using namespace __asan;
 
+#  if SANITIZER_WINDOWS
+// Marks an allocation as originally zero-size. Must be called on allocations
+// that were changed from size 0 to 1 outside of Allocate() (e.g. SharedReAlloc).
+namespace __asan {
+void asan_mark_zero_allocation(void *ptr);
+}
+#  endif
+
 // MT: Simply defining functions with the same signature in *.obj
 // files overrides the standard functions in the CRT.
 // MD: Memory allocation functions are defined in the CRT .dll,
@@ -371,7 +379,8 @@ void *SharedReAlloc(ReAllocFunction reallocFunc, SizeFunction heapSizeFunc,
   // passing a 0 size into asan_realloc will free the allocation.
   // To avoid this and keep behavior consistent, fudge the size if 0.
   // (asan_malloc already does this)
-  if (dwBytes == 0)
+  bool was_zero_size = (dwBytes == 0);
+  if (was_zero_size)
     dwBytes = 1;
 
   size_t old_size;
@@ -381,6 +390,9 @@ void *SharedReAlloc(ReAllocFunction reallocFunc, SizeFunction heapSizeFunc,
   void *ptr = asan_realloc(lpMem, dwBytes, &stack);
   if (ptr == nullptr)
     return nullptr;
+
+  if (was_zero_size)
+    asan_mark_zero_allocation(ptr);
 
   if (dwFlags & HEAP_ZERO_MEMORY) {
     size_t new_size = asan_malloc_usable_size(ptr, pc, bp);

--- a/compiler-rt/test/asan/TestCases/Windows/heaprealloc_alloc_zero.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/heaprealloc_alloc_zero.cpp
@@ -40,6 +40,7 @@ int main() {
   if (!ptr2)
     return 1;
   size_t heapsize = HeapSize(GetProcessHeap(), 0, ptr2);
+  // HeapSize will retrieve the user-defined size, not the ASan-allocated size of 1
   if (heapsize != 0) {
     std::cerr << "HeapAlloc size failure! " << heapsize << " != 0\n";
     return 1;

--- a/compiler-rt/test/asan/TestCases/Windows/heaprealloc_alloc_zero.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/heaprealloc_alloc_zero.cpp
@@ -10,29 +10,16 @@ int main() {
   if (ptr)
     std::cerr << "allocated!\n";
 
-  // Check the 'allocate 1 instead of 0' hack hasn't changed
-  // Note that as of b3452d90b043a398639e62b0ab01aa339cc649de, dereferencing
-  // the pointer will be detected as a heap-buffer-overflow.
+  // Zero-size allocations are internally upgraded to size 1.
+  // __sanitizer_get_allocated_size reports bytes reserved, not requested.
+  // Dereferencing the pointer will be detected as a heap-buffer-overflow.
   if (__sanitizer_get_allocated_size(ptr) != 1)
     return 1;
 
   free(ptr);
 
-  /*
-        HeapAlloc hack for our asan interceptor is to change 0
-        sized allocations to size 1 to avoid weird inconsistencies
-        between how realloc and heaprealloc handle 0 size allocations.
-
-        Note this test relies on these instructions being intercepted.
-        Without ASAN HeapRealloc on line 27 would return a ptr whose
-        HeapSize would be 0. This test makes sure that the underlying behavior
-        of our hack hasn't changed underneath us.
-
-        We can get rid of the test (or change it to test for the correct
-        behavior) once we fix the interceptor or write a different allocator
-        to handle 0 sized allocations properly by default.
-
-    */
+  // Zero-size HeapAlloc/HeapReAlloc should report size 0 via HeapSize,
+  // matching the originally requested size.
   ptr = HeapAlloc(GetProcessHeap(), 0, 0);
   if (!ptr)
     return 1;
@@ -40,8 +27,8 @@ int main() {
   if (!ptr2)
     return 1;
   size_t heapsize = HeapSize(GetProcessHeap(), 0, ptr2);
-  if (heapsize != 1) { // will be 0 without ASAN turned on
-    std::cerr << "HeapAlloc size failure! " << heapsize << " != 1\n";
+  if (heapsize != 0) {
+    std::cerr << "HeapAlloc size failure! " << heapsize << " != 0\n";
     return 1;
   }
   void *ptr3 = HeapReAlloc(GetProcessHeap(), 0, ptr2, 3);

--- a/compiler-rt/test/asan/TestCases/Windows/rtlsizeheap_zero.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/rtlsizeheap_zero.cpp
@@ -1,0 +1,107 @@
+// RUN: %clang_cl_asan %s %Fe%t
+// RUN: %run %t 2>&1 | FileCheck %s
+// RUN: %clang_cl_asan %s %Fe%t /DFAIL_CHECK
+// RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-FAIL
+//
+// Verify that zero-size heap allocations report size 0 through Windows heap
+// size APIs, preventing false positives when the result is used with memset.
+
+#include <malloc.h>
+#include <stdio.h>
+#include <windows.h>
+
+using AllocateFunctionPtr = PVOID(__stdcall *)(PVOID, ULONG, SIZE_T);
+using FreeFunctionPtr = BOOL(__stdcall *)(PVOID, ULONG, PVOID);
+using SizeFunctionPtr = SIZE_T(__stdcall *)(PVOID, ULONG, PVOID);
+
+int main() {
+  HMODULE NtDllHandle = GetModuleHandle("ntdll.dll");
+  if (!NtDllHandle) {
+    puts("Couldn't load ntdll");
+    return -1;
+  }
+
+  auto RtlAllocateHeap_ptr =
+      (AllocateFunctionPtr)GetProcAddress(NtDllHandle, "RtlAllocateHeap");
+  auto RtlFreeHeap_ptr =
+      (FreeFunctionPtr)GetProcAddress(NtDllHandle, "RtlFreeHeap");
+  auto RtlSizeHeap_ptr =
+      (SizeFunctionPtr)GetProcAddress(NtDllHandle, "RtlSizeHeap");
+
+  if (!RtlAllocateHeap_ptr || !RtlFreeHeap_ptr || !RtlSizeHeap_ptr) {
+    puts("Couldn't find Rtl heap functions");
+    return -1;
+  }
+
+  // Test RtlAllocateHeap with zero size
+  {
+    char *buffer =
+        (char *)RtlAllocateHeap_ptr(GetProcessHeap(), HEAP_ZERO_MEMORY, 0);
+    if (buffer) {
+      auto size = RtlSizeHeap_ptr(GetProcessHeap(), 0, buffer);
+      memset(buffer, 0, size);
+#ifdef FAIL_CHECK
+      // heap-buffer-overflow since actual size is 0
+      memset(buffer, 0, 1);
+#endif
+      RtlFreeHeap_ptr(GetProcessHeap(), 0, buffer);
+    }
+  }
+
+  // Test malloc with zero size
+  {
+    char *buffer = (char *)malloc(0);
+    if (buffer) {
+      auto size = _msize(buffer);
+      auto rtl_size = RtlSizeHeap_ptr(GetProcessHeap(), 0, buffer);
+      memset(buffer, 0, size);
+      memset(buffer, 0, rtl_size);
+      free(buffer);
+    }
+  }
+
+  // Test operator new with zero size
+  {
+    char *buffer = new char[0];
+    auto size = _msize(buffer);
+    auto rtl_size = RtlSizeHeap_ptr(GetProcessHeap(), 0, buffer);
+    memset(buffer, 0, size);
+    memset(buffer, 0, rtl_size);
+    delete[] buffer;
+  }
+
+  // Test GlobalAlloc with zero size.
+  // GlobalAlloc calls RtlAllocateHeap internally.
+  {
+    HGLOBAL hMem = GlobalAlloc(GMEM_FIXED | GMEM_ZEROINIT, 0);
+    if (hMem) {
+      char *buffer = (char *)hMem;
+      auto size = GlobalSize(hMem);
+      auto rtl_size = RtlSizeHeap_ptr(GetProcessHeap(), 0, buffer);
+      memset(buffer, 0, size);
+      memset(buffer, 0, rtl_size);
+      GlobalFree(hMem);
+    }
+  }
+
+  // Test LocalAlloc with zero size.
+  // LocalAlloc calls RtlAllocateHeap internally.
+  {
+    HLOCAL hMem = LocalAlloc(LMEM_FIXED | LMEM_ZEROINIT, 0);
+    if (hMem) {
+      char *buffer = (char *)hMem;
+      auto size = LocalSize(hMem);
+      auto rtl_size = RtlSizeHeap_ptr(GetProcessHeap(), 0, buffer);
+      memset(buffer, 0, size);
+      memset(buffer, 0, rtl_size);
+      LocalFree(hMem);
+    }
+  }
+
+  puts("Success");
+  return 0;
+}
+
+// CHECK: Success
+// CHECK-NOT: AddressSanitizer: heap-buffer-overflow
+// CHECK-FAIL: AddressSanitizer: heap-buffer-overflow

--- a/compiler-rt/test/asan/TestCases/Windows/rtlsizeheap_zero.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/rtlsizeheap_zero.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cl_asan %s %Fe%t
-// RUN: %run %t 2>&1 | FileCheck %s
+// RUN: %env_asan_opts=windows_hook_rtl_allocators=true %run %t 2>&1 | FileCheck %s
 // RUN: %clang_cl_asan %s %Fe%t /DFAIL_CHECK
-// RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-FAIL
+// RUN: %env_asan_opts=windows_hook_rtl_allocators=true not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-FAIL
 //
 // Verify that zero-size heap allocations report size 0 through Windows heap
 // size APIs, preventing false positives when the result is used with memset.


### PR DESCRIPTION
This is a follow up to #155943

On Windows, ASan's allocator internally upgrades zero-size allocation requests to size 1 (since malloc(0) must return a unique non-NULL pointer). However, when the user queries the allocation size through Windows heap APIs (RtlSizeHeap, HeapSize, \_msize, GlobalSize, LocalSize), ASan reports the internal size (1) instead of the originally requested size (0).

This causes false positive heap-buffer-overflow errors in a common pattern:

```c++
void *buf = HeapAlloc(GetProcessHeap(), 0, 0);
SIZE_T size = HeapSize(GetProcessHeap(), 0, buf);  // Returns 1, should be 0
if(size > 0) // could remove this and still be correct
    memset(buf, 0, size);  // ASan reports heap-buffer-overflow
```

The change adds a `from_zero_alloc` bit to `ChunkHeader` that tracks whether an allocation was originally zero-size. This bit fits in the existing spare capacity of the header's bitfield byte, so the 16-byte ChunkHeader size is unchanged, but it also isn't the most elegant.

The 1-byte user region of a zero-size allocation is still poisoned, so any actual access to it is correctly reported as an overflow.