### PR TITLE
[libc++] Build the library with C++26

### DIFF
--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -504,9 +504,9 @@ remove_flags(-Wno-pedantic -pedantic-errors -pedantic)
 # Required flags ==============================================================
 function(cxx_add_basic_build_flags target)
 
-  # Use C++23 for all targets.
+  # Use C++26 for all targets.
   set_target_properties(${target} PROPERTIES
-    CXX_STANDARD 23
+    CXX_STANDARD 26
     CXX_STANDARD_REQUIRED OFF # TODO: Make this REQUIRED once we don't need to accommodate the LLVM documentation builders using an ancient CMake
     CXX_EXTENSIONS NO)
 

--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -506,7 +506,7 @@ function(cxx_add_basic_build_flags target)
 
   # Use C++26 for all targets. Note that we don't use CXX_STANDARD or cxx_std_foo
   # since that requires a newer CMake than is available.
-  target_compile_options(${target} PRIVATE -std=c++26)
+  target_compile_options(${target} PRIVATE $<IF:$<CXX_COMPILER_ID:MSVC>,/std:c++26,-std=c++26>)
 
   # When building the dylib, don't warn for unavailable aligned allocation
   # functions based on the deployment target -- they are always available

--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -504,11 +504,9 @@ remove_flags(-Wno-pedantic -pedantic-errors -pedantic)
 # Required flags ==============================================================
 function(cxx_add_basic_build_flags target)
 
-  # Use C++26 for all targets.
-  set_target_properties(${target} PROPERTIES
-    CXX_STANDARD 26
-    CXX_STANDARD_REQUIRED OFF # TODO: Make this REQUIRED once we don't need to accommodate the LLVM documentation builders using an ancient CMake
-    CXX_EXTENSIONS NO)
+  # Use C++26 for all targets. Note that we don't use CXX_STANDARD or cxx_std_foo
+  # since that requires a newer CMake than is available.
+  target_compile_options(${target} PRIVATE -std=c++26)
 
   # When building the dylib, don't warn for unavailable aligned allocation
   # functions based on the deployment target -- they are always available

--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -506,7 +506,11 @@ function(cxx_add_basic_build_flags target)
 
   # Use C++26 for all targets. Note that we don't use CXX_STANDARD or cxx_std_foo
   # since that requires a newer CMake than is available.
-  target_compile_options(${target} PRIVATE $<IF:$<CXX_COMPILER_ID:MSVC>,/std:c++26,-std=c++26>)
+  if (LIBCXX_TARGETING_CLANG_CL)
+    target_compile_options(${target} PRIVATE /std:c++latest)
+  else()
+    target_compile_options(${target} PRIVATE -std=c++26)
+  endif()
 
   # When building the dylib, don't warn for unavailable aligned allocation
   # functions based on the deployment target -- they are always available

--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -4,6 +4,12 @@
 cmake_minimum_required(VERSION 3.20.0)
 set(LLVM_SUBPROJECT_TITLE "libc++")
 
+# Unset the C++ Standard: other projects sometimes override this global property, which
+# is incompatible with libc++ (since we set our own standard via other means).
+# TODO: Figure out which other part of the build is setting this and resolve the issue
+#       at the root.
+unset(CMAKE_CXX_STANDARD)
+
 set(LLVM_COMMON_CMAKE_UTILS "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 
 # Add path for custom modules

--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -8,7 +8,7 @@ set(LLVM_SUBPROJECT_TITLE "libc++")
 # is incompatible with libc++ (since we set our own standard via other means).
 # TODO: Figure out which other part of the build is setting this and resolve the issue
 #       at the root.
-unset(CMAKE_CXX_STANDARD)
+unset(CMAKE_CXX_STANDARD CACHE)
 
 set(LLVM_COMMON_CMAKE_UTILS "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 

--- a/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
+++ b/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
@@ -25,8 +25,6 @@ endif()
 
 message(STATUS "Found system-installed LLVM ${LLVM_PACKAGE_VERSION} with headers in ${LLVM_INCLUDE_DIRS}")
 
-set(CMAKE_CXX_STANDARD 20)
-
 # Link only against clangTidy itself, not anything that clangTidy uses; otherwise we run setup code multiple times
 # which results in clang-tidy crashing
 set_target_properties(clangTidy PROPERTIES INTERFACE_LINK_LIBRARIES "")


### PR DESCRIPTION
All supported compilers support C++26. This allows simplifying some of the upcoming <text_encoding> implementation.