### PR TITLE
[Codegen] Add missing pointer flag propagation to GetReturnInfo

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -2065,6 +2065,12 @@ void llvm::GetReturnInfo(CallingConv::ID CC, Type *ReturnType,
     if (attr.hasRetAttr(Attribute::InReg))
       Flags.setInReg();
 
+    if (Ty->isPointerTy()) {
+      Flags.setPointer();
+      Flags.setPointerAddrSpace(
+          cast<PointerType>(Ty)->getAddressSpace());
+    }
+
     // Propagate extension type if any
     if (attr.hasRetAttr(Attribute::SExt))
       Flags.setSExt();

--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -2067,8 +2067,7 @@ void llvm::GetReturnInfo(CallingConv::ID CC, Type *ReturnType,
 
     if (Ty->isPointerTy()) {
       Flags.setPointer();
-      Flags.setPointerAddrSpace(
-          cast<PointerType>(Ty)->getAddressSpace());
+      Flags.setPointerAddrSpace(cast<PointerType>(Ty)->getAddressSpace());
     }
 
     // Propagate extension type if any


### PR DESCRIPTION
Code added in 9db00f7e5b346 propagates a new flag, IsPointer. This change was spread among the points where it would matter, such as SelectionDAGBuilder::visitRet and TargetLowering::LowerCallTo. However, this flag is not set as part of llvm::GetReturnInfo, even though the body of that function is mostly a copy-paste of visitRet.