### PR TITLE
[Support][NFC] Use direct initialization for JSON deserialization result

### DIFF
--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -808,7 +808,7 @@ bool fromJSON(const Value &E, std::optional<T> &Out, Path P) {
     Out = std::nullopt;
     return true;
   }
-  T Result = {};
+  T Result{};
   if (!fromJSON(E, Result, P))
     return false;
   Out = std::move(Result);


### PR DESCRIPTION
The previous initialization forces the struct to have non explicit constructor