### PR TITLE
[Support] Fix symbolizer markup backtrace; reenable test

### DIFF
--- a/llvm/lib/Support/Unix/Signals.inc
+++ b/llvm/lib/Support/Unix/Signals.inc
@@ -569,11 +569,13 @@ public:
 
   /// Print llvm-symbolizer markup describing the layout of the given DSO.
   void printDSOMarkup(dl_phdr_info *Info) {
+    bool WasFirst = IsFirst;
+    IsFirst = false;
     ArrayRef<uint8_t> BuildID = findBuildID(Info);
     if (BuildID.empty())
       return;
     OS << format("{{{module:%d:%s:elf:", ModuleCount,
-                 IsFirst ? MainExecutableName : Info->dlpi_name);
+                 WasFirst ? MainExecutableName : Info->dlpi_name);
     for (uint8_t X : BuildID)
       OS << format("%02x", X);
     OS << "}}}\n";
@@ -589,7 +591,6 @@ public:
                    Phdr->p_memsz, ModuleCount, &ModeStr[0],
                    ModuleRelativeAddress);
     }
-    IsFirst = false;
     ModuleCount++;
   }
 

--- a/llvm/unittests/Support/SignalsTest.cpp
+++ b/llvm/unittests/Support/SignalsTest.cpp
@@ -36,13 +36,14 @@ using testing::Not;
 // note, which is not universally enabled by default (even when using Clang).
 // Disable until we can reliably detect whether this is the case and skip it if
 // not. See https://github.com/llvm/llvm-project/issues/168891.
-#if 0
 TEST(SignalsTest, PrintsSymbolizerMarkup) {
   scope_exit Exit([]() { unsetenv("LLVM_ENABLE_SYMBOLIZER_MARKUP"); });
   setenv("LLVM_ENABLE_SYMBOLIZER_MARKUP", "1", 1);
   std::string Res;
   raw_string_ostream RawStream(Res);
   PrintStackTrace(RawStream);
+  if (!StringRef(Res).contains("SupportTests"))
+    GTEST_SKIP() << "build ID could not be found for the main binary";
   EXPECT_THAT(Res, MatchesRegex(TAG_BEGIN "reset" TAG_END ".*"));
   // Module line for main binary
   EXPECT_THAT(Res,
@@ -55,7 +56,6 @@ TEST(SignalsTest, PrintsSymbolizerMarkup) {
   // Backtrace line
   EXPECT_THAT(Res, MatchesRegex(".*" TAG_BEGIN "bt:0:" P_REGEX ".*"));
 }
-#endif
 
 TEST(SignalsTest, SymbolizerMarkupDisabled) {
   scope_exit Exit([]() { unsetenv("LLVM_DISABLE_SYMBOLIZATION"); });


### PR DESCRIPTION
The symbolizer markup backtrace test depended on the binary having a build ID; this isn't a given. Instead, we check to see if the binary name is anywhere in the output string; if not, we skip the test. This isn't perfect of course, but determining whether the binary under test overlaps contains a build ID overlaps too much with the implementation of the feature; this at least keeps the tests independent.

The above fix uncovered an issue: the build ID of another DSO would be misattributed to the main DSO if the main DSO had no build ID. This issue has been corrected also.

Fixes #168891