### PR TITLE
[libc++][NFC] Use std::quoted in fs::path and remove the private __quoted

### DIFF
--- a/libcxx/include/__filesystem/path.h
+++ b/libcxx/include/__filesystem/path.h
@@ -882,7 +882,7 @@ public:
       __enable_if_t<is_same<_CharT, value_type>::value && is_same<_Traits, char_traits<value_type> >::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI friend basic_ostream<_CharT, _Traits>&
   operator<<(basic_ostream<_CharT, _Traits>& __os, const path& __p) {
-    __os << std::__quoted(__p.native());
+    __os << std::quoted(__p.native());
     return __os;
   }
 
@@ -892,7 +892,7 @@ public:
       __enable_if_t<!is_same<_CharT, value_type>::value || !is_same<_Traits, char_traits<value_type> >::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI friend basic_ostream<_CharT, _Traits>&
   operator<<(basic_ostream<_CharT, _Traits>& __os, const path& __p) {
-    __os << std::__quoted(__p.string<_CharT, _Traits>());
+    __os << std::quoted(__p.string<_CharT, _Traits>());
     return __os;
   }
 
@@ -900,7 +900,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI friend basic_istream<_CharT, _Traits>&
   operator>>(basic_istream<_CharT, _Traits>& __is, path& __p) {
     basic_string<_CharT, _Traits> __tmp;
-    __is >> std::__quoted(__tmp);
+    __is >> std::quoted(__tmp);
     __p = __tmp;
     return __is;
   }

--- a/libcxx/include/iomanip
+++ b/libcxx/include/iomanip
@@ -413,6 +413,8 @@ inline _LIBCPP_HIDE_FROM_ABI __iom_t10<_CharT> put_time(const tm* __tm, const _C
   return __iom_t10<_CharT>(__tm, __fmt);
 }
 
+#    if _LIBCPP_STD_VER >= 14
+
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>& __quoted_output(
     basic_ostream<_CharT, _Traits>& __os,
@@ -501,22 +503,6 @@ struct _LIBCPP_HIDDEN __quoted_proxy {
     return std::__quoted_input(__is, __p.__string_, __p.__delim_, __p.__escape_);
   }
 };
-
-template <class _CharT, class _Traits, class _Allocator>
-_LIBCPP_HIDE_FROM_ABI __quoted_output_proxy<_CharT, _Traits>
-__quoted(const basic_string<_CharT, _Traits, _Allocator>& __s,
-         _CharT __delim  = _CharT('"'),
-         _CharT __escape = _CharT('\\')) {
-  return __quoted_output_proxy<_CharT, _Traits>(__s.data(), __s.data() + __s.size(), __delim, __escape);
-}
-
-template <class _CharT, class _Traits, class _Allocator>
-_LIBCPP_HIDE_FROM_ABI __quoted_proxy<_CharT, _Traits, _Allocator>
-__quoted(basic_string<_CharT, _Traits, _Allocator>& __s, _CharT __delim = _CharT('"'), _CharT __escape = _CharT('\\')) {
-  return __quoted_proxy<_CharT, _Traits, _Allocator>(__s, __delim, __escape);
-}
-
-#    if _LIBCPP_STD_VER >= 14
 
 template <class _CharT>
 _LIBCPP_HIDE_FROM_ABI auto quoted(const _CharT* __s, _CharT __delim = _CharT('"'), _CharT __escape = _CharT('\\')) {


### PR DESCRIPTION
We've provided `std::filesystem` before C++17 in the past, but we don't anymore, so we can use `std::quoted`.
