### PR TITLE
[mlir] Avoid ASan ODR violation in mlir-src-sharder with LLVM dylib

### DIFF
--- a/mlir/tools/mlir-src-sharder/CMakeLists.txt
+++ b/mlir/tools/mlir-src-sharder/CMakeLists.txt
@@ -1,14 +1,11 @@
 set(LLVM_LINK_COMPONENTS Support)
 set(LIBS MLIRSupport)
 
-add_tablegen(mlir-src-sharder MLIR_SRC_SHARDER
-  mlir-src-sharder.cpp
-
-  DEPENDS
-  ${LIBS}
-  )
+add_llvm_executable(mlir-src-sharder mlir-src-sharder.cpp)
 
 set_target_properties(mlir-src-sharder PROPERTIES FOLDER "MLIR/Tablegenning")
 target_link_libraries(mlir-src-sharder PRIVATE ${LIBS})
+
+set(MLIR_SRC_SHARDER_TABLEGEN_EXE mlir-src-sharder PARENT_SCOPE)
 
 mlir_check_all_link_libraries(mlir-src-sharder)


### PR DESCRIPTION
Build mlir-src-sharder via add_llvm_executable instead of add_tablegen
to avoid embedding a second copy of LLVM Support when linking against
libLLVM.so. Fixes ASan ODR violation for DisableABIBreakingChecks 

Tested with ASan + LLVM dylib configuration; tool runs without abort.
Fixes #180911