### PR TITLE
[clang-format] Add per-operator granularity for BreakBinaryOperations

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -3674,8 +3674,7 @@ the configuration (without a prefix: ``Auto``).
 
   * ``List of BinaryOperationBreakRules PerOperator`` Per-operator override rules.
 
-  * ``List of Strings Operators`` :versionbadge:`clang-format 23`
-  The list of operators this rule applies to, e.g. ``&&``, ``||``, ``|``.
+  * ``List of Strings Operators`` :versionbadge:`clang-format 23` The list of operators this rule applies to, e.g. ``&&``, ``||``, ``|``.
     Alternative spellings (e.g. ``and`` for ``&&``) are accepted.
 
   * ``BreakBinaryOperationsStyle Style``

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -3613,42 +3613,66 @@ the configuration (without a prefix: ``Auto``).
 
 .. _BreakBinaryOperations:
 
-**BreakBinaryOperations** (``BreakBinaryOperationsStyle``) :versionbadge:`clang-format 20` :ref:`¶ <BreakBinaryOperations>`
+**BreakBinaryOperations** (``BreakBinaryOperationsOptions``) :versionbadge:`clang-format 20` :ref:`¶ <BreakBinaryOperations>`
   The break binary operations style to use.
 
-  Possible values:
+  Nested configuration flags:
 
-  * ``BBO_Never`` (in configuration: ``Never``)
-    Don't break binary operations
+  Options for ``BreakBinaryOperations``.
 
-    .. code-block:: c++
+  If specified as a simple string (e.g. ``OnePerLine``), it behaves like
+  the original enum and applies to all binary operators.
 
-       aaa + bbbb * ccccc - ddddd +
-       eeeeeeeeeeeeeeee;
+  If specified as a struct, allows per-operator configuration:
 
-  * ``BBO_OnePerLine`` (in configuration: ``OnePerLine``)
-    Binary operations will either be all on the same line, or each operation
-    will have one line each.
+  .. code-block:: yaml
 
-    .. code-block:: c++
+    BreakBinaryOperations:
+      Default: Never
+      PerOperator:
+        - Operators: ['&&', '||']
+          Style: OnePerLine
+          MinChainLength: 3
 
-       aaa +
-       bbbb *
-       ccccc -
-       ddddd +
-       eeeeeeeeeeeeeeee;
+  * ``BreakBinaryOperationsStyle Default`` :versionbadge:`clang-format 23`
 
-  * ``BBO_RespectPrecedence`` (in configuration: ``RespectPrecedence``)
-    Binary operations of a particular precedence that exceed the column
-    limit will have one line each.
+    The default break style for operators not covered by ``PerOperator``.
 
-    .. code-block:: c++
+    Possible values:
 
-       aaa +
-       bbbb * ccccc -
-       ddddd +
-       eeeeeeeeeeeeeeee;
+    * ``BBO_Never`` (in configuration: ``Never``)
+      Don't break binary operations
 
+      .. code-block:: c++
+
+         aaa + bbbb * ccccc - ddddd +
+         eeeeeeeeeeeeeeee;
+
+    * ``BBO_OnePerLine`` (in configuration: ``OnePerLine``)
+      Binary operations will either be all on the same line, or each operation
+      will have one line each.
+
+      .. code-block:: c++
+
+         aaa +
+         bbbb *
+         ccccc -
+         ddddd +
+         eeeeeeeeeeeeeeee;
+
+    * ``BBO_RespectPrecedence`` (in configuration: ``RespectPrecedence``)
+      Binary operations of a particular precedence that exceed the column
+      limit will have one line each.
+
+      .. code-block:: c++
+
+         aaa +
+         bbbb * ccccc -
+         ddddd +
+         eeeeeeeeeeeeeeee;
+
+
+  * ``std::vector<BinaryOperationBreakRule> PerOperator`` Per-operator override rules.
 
 
 .. _BreakConstructorInitializers:

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -3672,7 +3672,53 @@ the configuration (without a prefix: ``Auto``).
          eeeeeeeeeeeeeeee;
 
 
-  * ``std::vector<BinaryOperationBreakRule> PerOperator`` Per-operator override rules.
+  * ``List of BinaryOperationBreakRules PerOperator`` Per-operator override rules.
+
+  * ``std::vector<tok::TokenKind> Operators`` :versionbadge:`clang-format 23`
+  The list of operator token kinds this rule applies to.
+    Stored as ``tok::TokenKind`` so that alternative spellings
+    (e.g. ``and`` vs ``&&``) are handled automatically.
+
+  * ``BreakBinaryOperationsStyle Style``
+    The break style for these operators (defaults to ``OnePerLine``).
+
+    Possible values:
+
+    * ``BBO_Never`` (in configuration: ``Never``)
+      Don't break binary operations
+
+      .. code-block:: c++
+
+         aaa + bbbb * ccccc - ddddd +
+         eeeeeeeeeeeeeeee;
+
+    * ``BBO_OnePerLine`` (in configuration: ``OnePerLine``)
+      Binary operations will either be all on the same line, or each operation
+      will have one line each.
+
+      .. code-block:: c++
+
+         aaa +
+         bbbb *
+         ccccc -
+         ddddd +
+         eeeeeeeeeeeeeeee;
+
+    * ``BBO_RespectPrecedence`` (in configuration: ``RespectPrecedence``)
+      Binary operations of a particular precedence that exceed the column
+      limit will have one line each.
+
+      .. code-block:: c++
+
+         aaa +
+         bbbb * ccccc -
+         ddddd +
+         eeeeeeeeeeeeeeee;
+
+
+  * ``unsigned MinChainLength`` Minimum number of operands in a chain before the rule triggers.
+    For example, ``a && b && c`` is a chain of length 3.
+    ``0`` means always break (when the line is too long).
 
 
 .. _BreakConstructorInitializers:

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -3674,10 +3674,9 @@ the configuration (without a prefix: ``Auto``).
 
   * ``List of BinaryOperationBreakRules PerOperator`` Per-operator override rules.
 
-  * ``std::vector<tok::TokenKind> Operators`` :versionbadge:`clang-format 23`
-  The list of operator token kinds this rule applies to.
-    Stored as ``tok::TokenKind`` so that alternative spellings
-    (e.g. ``and`` vs ``&&``) are handled automatically.
+  * ``List of Strings Operators`` :versionbadge:`clang-format 23`
+  The list of operators this rule applies to, e.g. ``&&``, ``||``, ``|``.
+    Alternative spellings (e.g. ``and`` for ``&&``) are accepted.
 
   * ``BreakBinaryOperationsStyle Style``
     The break style for these operators (defaults to ``OnePerLine``).

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -388,6 +388,8 @@ clang-format
   '-'/'+' and the return type in Objective-C method declarations
 - Add ``AfterComma`` value to ``BreakConstructorInitializers`` to allow breaking
   constructor initializers after commas, keeping the colon on the same line.
+- Extend ``BreakBinaryOperations`` to accept a structured configuration with
+  per-operator break rules and minimum chain length gating via ``PerOperator``.
 
 libclang
 --------

--- a/clang/docs/tools/dump_format_style.py
+++ b/clang/docs/tools/dump_format_style.py
@@ -154,7 +154,7 @@ class NestedField(object):
 
     def __str__(self):
         if self.version:
-            return "\n* ``%s`` :versionbadge:`clang-format %s`\n%s" % (
+            return "\n* ``%s`` :versionbadge:`clang-format %s` %s" % (
                 self.name,
                 self.version,
                 doxygen2rst(indent(self.comment, 2, indent_first_line=False)),
@@ -401,29 +401,22 @@ class OptionsReader:
                             )
                         )
                     else:
-                        vec_match = re.match(
-                            r"std::vector<(.*)>$", field_type
-                        )
+                        vec_match = re.match(r"std::vector<(.*)>$", field_type)
                         if vec_match and vec_match.group(1) in nested_structs:
                             inner_struct = nested_structs[vec_match.group(1)]
-                            display = (
-                                "List of %ss %s"
-                                % (vec_match.group(1), field_name)
+                            display = "List of %ss %s" % (
+                                vec_match.group(1),
+                                field_name,
                             )
                             nested_struct.values.append(
                                 NestedField(display, comment, version)
                             )
                             nested_struct.values.extend(inner_struct.values)
                         else:
-                            vec_match = re.match(
-                                r"std::vector<(.*)>$", field_type
-                            )
+                            vec_match = re.match(r"std::vector<(.*)>$", field_type)
                             if vec_match:
-                                display_type = (
-                                    "List of "
-                                    + pluralize(
-                                        to_yaml_type(vec_match.group(1))
-                                    )
+                                display_type = "List of " + pluralize(
+                                    to_yaml_type(vec_match.group(1))
                                 )
                             else:
                                 display_type = field_type

--- a/clang/docs/tools/dump_format_style.py
+++ b/clang/docs/tools/dump_format_style.py
@@ -399,9 +399,27 @@ class OptionsReader:
                             )
                         )
                     else:
-                        nested_struct.values.append(
-                            NestedField(field_type + " " + field_name, comment, version)
+                        vec_match = re.match(
+                            r"std::vector<(.*)>$", field_type
                         )
+                        if vec_match and vec_match.group(1) in nested_structs:
+                            inner_struct = nested_structs[vec_match.group(1)]
+                            display = (
+                                "List of %ss %s"
+                                % (vec_match.group(1), field_name)
+                            )
+                            nested_struct.values.append(
+                                NestedField(display, comment, version)
+                            )
+                            nested_struct.values.extend(inner_struct.values)
+                        else:
+                            nested_struct.values.append(
+                                NestedField(
+                                    field_type + " " + field_name,
+                                    comment,
+                                    version,
+                                )
+                            )
                     version = None
             elif state == State.InEnum:
                 if line.startswith("///"):

--- a/clang/docs/tools/dump_format_style.py
+++ b/clang/docs/tools/dump_format_style.py
@@ -79,6 +79,8 @@ def to_yaml_type(typestr: str):
         return "Unsigned"
     elif typestr == "std::string":
         return "String"
+    elif typestr == "tok::TokenKind":
+        return "String"
 
     match = re.match(r"std::vector<(.*)>$", typestr)
     if match:
@@ -413,9 +415,21 @@ class OptionsReader:
                             )
                             nested_struct.values.extend(inner_struct.values)
                         else:
+                            vec_match = re.match(
+                                r"std::vector<(.*)>$", field_type
+                            )
+                            if vec_match:
+                                display_type = (
+                                    "List of "
+                                    + pluralize(
+                                        to_yaml_type(vec_match.group(1))
+                                    )
+                                )
+                            else:
+                                display_type = field_type
                             nested_struct.values.append(
                                 NestedField(
-                                    field_type + " " + field_name,
+                                    display_type + " " + field_name,
                                     comment,
                                     version,
                                 )

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2454,9 +2454,8 @@ struct FormatStyle {
   /// A rule that specifies how to break a specific set of binary operators.
   /// \version 23
   struct BinaryOperationBreakRule {
-    /// The list of operator token kinds this rule applies to.
-    /// Stored as ``tok::TokenKind`` so that alternative spellings
-    /// (e.g. ``and`` vs ``&&``) are handled automatically.
+    /// The list of operators this rule applies to, e.g. ``&&``, ``||``, ``|``.
+    /// Alternative spellings (e.g. ``and`` for ``&&``) are accepted.
     std::vector<tok::TokenKind> Operators;
     /// The break style for these operators (defaults to ``OnePerLine``).
     BreakBinaryOperationsStyle Style;

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2460,7 +2460,8 @@ struct FormatStyle {
     std::vector<tok::TokenKind> Operators;
     /// The break style for these operators (defaults to ``OnePerLine``).
     BreakBinaryOperationsStyle Style;
-    /// Minimum number of chained operators before the rule triggers.
+    /// Minimum number of operands in a chain before the rule triggers.
+    /// For example, ``a && b && c`` is a chain of length 3.
     /// ``0`` means always break (when the line is too long).
     unsigned MinChainLength;
     bool operator==(const BinaryOperationBreakRule &R) const {

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2497,6 +2497,14 @@ struct FormatStyle {
       for (const auto &Rule : PerOperator) {
         if (llvm::find(Rule.Operators, Kind) != Rule.Operators.end())
           return &Rule;
+        // clang-format splits ">>" into two ">" tokens for template parsing.
+        // Match ">" against ">>" rules so that per-operator rules for ">>"
+        // (stream extraction / right shift) work correctly.
+        if (Kind == tok::greater &&
+            llvm::find(Rule.Operators, tok::greatergreater) !=
+                Rule.Operators.end()) {
+          return &Rule;
+        }
       }
       return nullptr;
     }

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -171,9 +171,8 @@ static bool mustBreakBinaryOperation(const FormatToken &Current,
   if (BreakBefore) {
     if (!isAlignableBinaryOperator(Current))
       return false;
-  } else {
-    if (!startsNextOperand(Current))
-      return false;
+  } else if (!startsNextOperand(Current)) {
+    return false;
   }
 
   // Look up per-operator rule or fall back to Default.

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -176,18 +176,16 @@ static bool mustBreakBinaryOperation(const FormatToken &Current,
   }
 
   // Look up per-operator rule or fall back to Default.
-  auto EffStyle =
-      Style.BreakBinaryOperations.getStyleForOperator(OpToken->TokenText);
-  if (EffStyle == FormatStyle::BBO_Never)
+  const auto OperatorBreakStyle =
+      Style.BreakBinaryOperations.getStyleForOperator(OpToken->Tok.getKind());
+  if (OperatorBreakStyle == FormatStyle::BBO_Never)
     return false;
 
   // Check MinChainLength: if the chain is too short, don't force a break.
-  unsigned MinChain = Style.BreakBinaryOperations.getMinChainLengthForOperator(
-      OpToken->TokenText);
-  if (MinChain > 0 && getChainLength(*OpToken) < MinChain)
-    return false;
-
-  return true;
+  const unsigned MinChain =
+      Style.BreakBinaryOperations.getMinChainLengthForOperator(
+          OpToken->Tok.getKind());
+  return MinChain == 0 || getChainLength(*OpToken) >= MinChain;
 }
 
 static bool opensProtoMessageField(const FormatToken &LessTok,

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -144,14 +144,50 @@ static bool startsNextOperand(const FormatToken &Current) {
   return isAlignableBinaryOperator(Previous) && !Current.isTrailingComment();
 }
 
+// Returns the number of operators in the chain containing \c Op.
+static unsigned getChainLength(const FormatToken &Op) {
+  const FormatToken *Last = &Op;
+  while (Last->NextOperator)
+    Last = Last->NextOperator;
+  return Last->OperatorIndex + 1;
+}
+
 // Returns \c true if \c Current is a binary operation that must break.
 static bool mustBreakBinaryOperation(const FormatToken &Current,
                                      const FormatStyle &Style) {
-  return Style.BreakBinaryOperations != FormatStyle::BBO_Never &&
-         Current.CanBreakBefore &&
-         (Style.BreakBeforeBinaryOperators == FormatStyle::BOS_None
-              ? startsNextOperand
-              : isAlignableBinaryOperator)(Current);
+  if (!Current.CanBreakBefore)
+    return false;
+
+  // Determine the operator token: when breaking after the operator,
+  // it is Current.Previous; when breaking before, it is Current itself.
+  bool BreakBefore = Style.BreakBeforeBinaryOperators != FormatStyle::BOS_None;
+  const FormatToken *OpToken = BreakBefore ? &Current : Current.Previous;
+
+  if (!OpToken)
+    return false;
+
+  // Check that this is an alignable binary operator.
+  if (BreakBefore) {
+    if (!isAlignableBinaryOperator(Current))
+      return false;
+  } else {
+    if (!startsNextOperand(Current))
+      return false;
+  }
+
+  // Look up per-operator rule or fall back to Default.
+  auto EffStyle =
+      Style.BreakBinaryOperations.getStyleForOperator(OpToken->TokenText);
+  if (EffStyle == FormatStyle::BBO_Never)
+    return false;
+
+  // Check MinChainLength: if the chain is too short, don't force a break.
+  unsigned MinChain = Style.BreakBinaryOperations.getMinChainLengthForOperator(
+      OpToken->TokenText);
+  if (MinChain > 0 && getChainLength(*OpToken) < MinChain)
+    return false;
+
+  return true;
 }
 
 static bool opensProtoMessageField(const FormatToken &LessTok,

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -144,12 +144,13 @@ static bool startsNextOperand(const FormatToken &Current) {
   return isAlignableBinaryOperator(Previous) && !Current.isTrailingComment();
 }
 
-// Returns the number of operators in the chain containing \c Op.
+// Returns the number of operands in the chain containing \c Op.
+// For example, `a && b && c` has 3 operands (and 2 operators).
 static unsigned getChainLength(const FormatToken &Op) {
   const FormatToken *Last = &Op;
   while (Last->NextOperator)
     Last = Last->NextOperator;
-  return Last->OperatorIndex + 1;
+  return Last->OperatorIndex + 2;
 }
 
 // Returns \c true if \c Current is a binary operation that must break.

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3282,15 +3282,11 @@ public:
         // If so, override precedence to avoid adding fake parenthesis which
         // could group operations of a different precedence level on the same
         // line.
-        auto EffStyle = Style.BreakBinaryOperations.Default;
-        if (Current) {
-          if (const auto *Rule =
-                  Style.BreakBinaryOperations.findRuleForOperator(
-                      Current->TokenText)) {
-            EffStyle = Rule->Style;
-          }
-        }
-        if (EffStyle == FormatStyle::BBO_OnePerLine)
+        const auto OperatorBreakStyle =
+            Current ? Style.BreakBinaryOperations.getStyleForOperator(
+                          Current->Tok.getKind())
+                    : Style.BreakBinaryOperations.Default;
+        if (OperatorBreakStyle == FormatStyle::BBO_OnePerLine)
           CurrentPrecedence = prec::Additive;
       }
 

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -502,7 +502,7 @@ TEST(ConfigParseTest, ParsesConfiguration) {
                    .value());
   ASSERT_EQ(Style.BreakBinaryOperations.PerOperator.size(), 1u);
   std::vector<tok::TokenKind> ExpectedShiftOps = {tok::greater,
-                                                   tok::greatergreater};
+                                                  tok::greatergreater};
   EXPECT_EQ(Style.BreakBinaryOperations.PerOperator[0].Operators,
             ExpectedShiftOps);
 

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -453,7 +453,7 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("BreakBeforeBinaryOperators: true", BreakBeforeBinaryOperators,
               FormatStyle::BOS_All);
 
-  Style.BreakBinaryOperations = {FormatStyle::BBO_Never, {}};
+  Style.BreakBinaryOperations.Default = FormatStyle::BBO_Never;
   CHECK_PARSE("BreakBinaryOperations: OnePerLine", BreakBinaryOperations,
               FormatStyle::BreakBinaryOperationsOptions(
                   {FormatStyle::BBO_OnePerLine, {}}));
@@ -465,14 +465,14 @@ TEST(ConfigParseTest, ParsesConfiguration) {
       FormatStyle::BreakBinaryOperationsOptions({FormatStyle::BBO_Never, {}}));
 
   // Structured form
-  Style.BreakBinaryOperations = {FormatStyle::BBO_Never, {}};
+  Style.BreakBinaryOperations.Default = FormatStyle::BBO_Never;
   CHECK_PARSE("BreakBinaryOperations:\n"
               "  Default: OnePerLine",
               BreakBinaryOperations,
               FormatStyle::BreakBinaryOperationsOptions(
                   {FormatStyle::BBO_OnePerLine, {}}));
 
-  Style.BreakBinaryOperations = {FormatStyle::BBO_Never, {}};
+  Style.BreakBinaryOperations.Default = FormatStyle::BBO_Never;
   EXPECT_EQ(0, parseConfiguration("BreakBinaryOperations:\n"
                                   "  Default: Never\n"
                                   "  PerOperator:\n"
@@ -488,6 +488,23 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   EXPECT_EQ(Style.BreakBinaryOperations.PerOperator[0].Style,
             FormatStyle::BBO_OnePerLine);
   EXPECT_EQ(Style.BreakBinaryOperations.PerOperator[0].MinChainLength, 3u);
+
+  // Parse ">" and ">>" which have edge cases: clang-format splits ">>" into
+  // two ">" tokens, so ">>" maps to tok::greatergreater while ">" maps to
+  // tok::greater.
+  Style.BreakBinaryOperations.Default = FormatStyle::BBO_Never;
+  EXPECT_EQ(0, parseConfiguration("BreakBinaryOperations:\n"
+                                  "  Default: Never\n"
+                                  "  PerOperator:\n"
+                                  "    - Operators: ['>', '>>']\n"
+                                  "      Style: OnePerLine",
+                                  &Style)
+                   .value());
+  ASSERT_EQ(Style.BreakBinaryOperations.PerOperator.size(), 1u);
+  std::vector<tok::TokenKind> ExpectedShiftOps = {tok::greater,
+                                                   tok::greatergreater};
+  EXPECT_EQ(Style.BreakBinaryOperations.PerOperator[0].Operators,
+            ExpectedShiftOps);
 
   Style.BreakConstructorInitializers = FormatStyle::BCIS_BeforeColon;
   CHECK_PARSE("BreakConstructorInitializers: BeforeComma",

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -483,7 +483,7 @@ TEST(ConfigParseTest, ParsesConfiguration) {
                    .value());
   EXPECT_EQ(Style.BreakBinaryOperations.Default, FormatStyle::BBO_Never);
   ASSERT_EQ(Style.BreakBinaryOperations.PerOperator.size(), 1u);
-  std::vector<std::string> ExpectedOps = {"&&", "||"};
+  std::vector<tok::TokenKind> ExpectedOps = {tok::ampamp, tok::pipepipe};
   EXPECT_EQ(Style.BreakBinaryOperations.PerOperator[0].Operators, ExpectedOps);
   EXPECT_EQ(Style.BreakBinaryOperations.PerOperator[0].Style,
             FormatStyle::BBO_OnePerLine);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28748,7 +28748,6 @@ TEST_F(FormatTest, BreakBinaryOperationsPerOperator) {
                "    packet_number >>\n"
                "    packet_scale;",
                Style);
-
 }
 
 TEST_F(FormatTest, BreakBinaryOperationsMinChainLength) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28444,7 +28444,7 @@ TEST_F(FormatTest, BreakBinaryOperations) {
                "    longOperand_3_;",
                Style);
 
-  Style.BreakBinaryOperations = {FormatStyle::BBO_OnePerLine, {}};
+  Style.BreakBinaryOperations.Default = FormatStyle::BBO_OnePerLine;
 
   // Logical operations
   verifyFormat("if (condition1 && condition2) {\n"
@@ -28529,7 +28529,7 @@ TEST_F(FormatTest, BreakBinaryOperations) {
                "    longOperand_3_;",
                Style);
 
-  Style.BreakBinaryOperations = {FormatStyle::BBO_RespectPrecedence, {}};
+  Style.BreakBinaryOperations.Default = FormatStyle::BBO_RespectPrecedence;
   verifyFormat("result = op1 + op2 * op3 - op4;", Style);
 
   verifyFormat("result = operand1 +\n"
@@ -28561,7 +28561,7 @@ TEST_F(FormatTest, BreakBinaryOperations) {
                "    longOperand_3_;",
                Style);
 
-  Style.BreakBinaryOperations = {FormatStyle::BBO_OnePerLine, {}};
+  Style.BreakBinaryOperations.Default = FormatStyle::BBO_OnePerLine;
   Style.BreakBeforeBinaryOperators = FormatStyle::BOS_NonAssignment;
 
   // Logical operations
@@ -28642,7 +28642,7 @@ TEST_F(FormatTest, BreakBinaryOperations) {
                "    >> longOperand_3_;",
                Style);
 
-  Style.BreakBinaryOperations = {FormatStyle::BBO_RespectPrecedence, {}};
+  Style.BreakBinaryOperations.Default = FormatStyle::BBO_RespectPrecedence;
   verifyFormat("result = op1 + op2 * op3 - op4;", Style);
 
   verifyFormat("result = operand1\n"
@@ -28748,6 +28748,7 @@ TEST_F(FormatTest, BreakBinaryOperationsPerOperator) {
                "    packet_number >>\n"
                "    packet_scale;",
                Style);
+
 }
 
 TEST_F(FormatTest, BreakBinaryOperationsMinChainLength) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28733,6 +28733,21 @@ TEST_F(FormatTest, BreakBinaryOperationsPerOperator) {
                "                  byte_buffer[2] << 16 |\n"
                "                  byte_buffer[3] << 24;",
                Style);
+
+  // >> (stream extraction) OnePerLine: clang-format splits >> into two >
+  // tokens, but per-operator rules for >> must still work.
+  FormatStyle::BinaryOperationBreakRule ShiftRightRule;
+  ShiftRightRule.Operators = {tok::greatergreater};
+  ShiftRightRule.Style = FormatStyle::BBO_OnePerLine;
+  ShiftRightRule.MinChainLength = 0;
+
+  Style.BreakBinaryOperations.PerOperator = {ShiftRightRule};
+  verifyFormat("in >>\n"
+               "    packet_id >>\n"
+               "    packet_version >>\n"
+               "    packet_number >>\n"
+               "    packet_scale;",
+               Style);
 }
 
 TEST_F(FormatTest, BreakBinaryOperationsMinChainLength) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28725,6 +28725,14 @@ TEST_F(FormatTest, BreakBinaryOperationsPerOperator) {
   verifyFormat("int total = unitBasePrice + shippingCostPerItem +\n"
                "            applicableTaxAmount + handlingFeePerUnit;",
                Style);
+
+  // | OnePerLine with << sub-expressions: << stays grouped.
+  Style.BreakBinaryOperations.PerOperator = {BitwiseOrRule};
+  verifyFormat("std::uint32_t a = byte_buffer[0] |\n"
+               "                  byte_buffer[1] << 8 |\n"
+               "                  byte_buffer[2] << 16 |\n"
+               "                  byte_buffer[3] << 24;",
+               Style);
 }
 
 TEST_F(FormatTest, BreakBinaryOperationsMinChainLength) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -28680,7 +28680,7 @@ TEST_F(FormatTest, BreakBinaryOperationsPerOperator) {
 
   // Per-operator override: && and || are OnePerLine, rest is Never (default).
   FormatStyle::BinaryOperationBreakRule LogicalRule;
-  LogicalRule.Operators = {"&&", "||"};
+  LogicalRule.Operators = {tok::ampamp, tok::pipepipe};
   LogicalRule.Style = FormatStyle::BBO_OnePerLine;
   LogicalRule.MinChainLength = 0;
 
@@ -28688,42 +28688,42 @@ TEST_F(FormatTest, BreakBinaryOperationsPerOperator) {
   Style.BreakBinaryOperations.PerOperator = {LogicalRule};
 
   // Logical operators break one-per-line when line is too long.
-  verifyFormat("bool x = loooooooooooooongcondition1 &&\n"
-               "         loooooooooooooongcondition2 &&\n"
-               "         loooooooooooooongcondition3;",
+  verifyFormat("bool valid = isConnectionReady() &&\n"
+               "             isSessionNotExpired() &&\n"
+               "             hasRequiredPermission();",
                Style);
 
-  // Arithmetic operators stay with default (Never) — no forced break.
-  verifyFormat("int x = loooooooooooooongop1 + looooooooongop2 +\n"
-               "        loooooooooooooooooooooongop3;",
+  // Arithmetic operators stay with default (Never).
+  verifyFormat("int total = unitBasePrice + shippingCostPerItem +\n"
+               "            applicableTaxAmount + handlingFeePerUnit;",
                Style);
 
-  // Short logical chain that fits on one line stays on one line.
+  // Short logical chain that fits stays on one line.
   verifyFormat("bool x = a && b && c;", Style);
 
   // Multiple PerOperator groups: && and || plus | operators.
   FormatStyle::BinaryOperationBreakRule BitwiseOrRule;
-  BitwiseOrRule.Operators = {"|"};
+  BitwiseOrRule.Operators = {tok::pipe};
   BitwiseOrRule.Style = FormatStyle::BBO_OnePerLine;
   BitwiseOrRule.MinChainLength = 0;
 
   Style.BreakBinaryOperations.PerOperator = {LogicalRule, BitwiseOrRule};
 
   // | operators should break one-per-line.
-  verifyFormat("int x = loooooooooooooooooongval1 |\n"
-               "        loooooooooooooooooongval2 |\n"
-               "        loooooooooooooooooongval3;",
+  verifyFormat("int flags = OPTION_VERBOSE_OUTPUT |\n"
+               "            OPTION_RECURSIVE_SCAN |\n"
+               "            OPTION_FORCE_OVERWRITE;",
                Style);
 
   // && still works in multi-group configuration.
-  verifyFormat("bool x = loooooooooooooongcondition1 &&\n"
-               "         loooooooooooooongcondition2 &&\n"
-               "         loooooooooooooongcondition3;",
+  verifyFormat("bool valid = isConnectionReady() &&\n"
+               "             isSessionNotExpired() &&\n"
+               "             hasRequiredPermission();",
                Style);
 
-  // + operators stay with default (Never) even with multi-group.
-  verifyFormat("int x = loooooooooooooongop1 + looooooooongop2 +\n"
-               "        loooooooooooooooooooooongop3;",
+  // + stays with default (Never) even with multi-group.
+  verifyFormat("int total = unitBasePrice + shippingCostPerItem +\n"
+               "            applicableTaxAmount + handlingFeePerUnit;",
                Style);
 }
 
@@ -28732,29 +28732,29 @@ TEST_F(FormatTest, BreakBinaryOperationsMinChainLength) {
 
   // MinChainLength = 3: chains shorter than 3 don't force breaks.
   FormatStyle::BinaryOperationBreakRule LogicalRule;
-  LogicalRule.Operators = {"&&", "||"};
+  LogicalRule.Operators = {tok::ampamp, tok::pipepipe};
   LogicalRule.Style = FormatStyle::BBO_OnePerLine;
   LogicalRule.MinChainLength = 3;
 
   Style.BreakBinaryOperations.Default = FormatStyle::BBO_Never;
   Style.BreakBinaryOperations.PerOperator = {LogicalRule};
 
-  // Chain of 2 — should NOT force one-per-line (below MinChainLength).
-  verifyFormat("bool x = loooooooooooooongcondition1 &&\n"
-               "         loooooooooooooongcondition2;",
+  // Chain of 2 — below MinChainLength, no forced one-per-line.
+  verifyFormat("bool ok =\n"
+               "    isConnectionReady(cfg) && isSessionNotExpired(cfg);",
                Style);
 
-  // Chain of 3 — should force one-per-line.
-  verifyFormat("bool x = loooooooooooooongcondition1 &&\n"
-               "         loooooooooooooongcondition2 &&\n"
-               "         loooooooooooooongcondition3;",
+  // Chain of 3 — meets MinChainLength, one-per-line.
+  verifyFormat("bool ok = isConnectionReady(cfg) &&\n"
+               "          isSessionNotExpired(cfg) &&\n"
+               "          hasRequiredPermission(cfg);",
                Style);
 
-  // Chain of 4 — should force one-per-line.
-  verifyFormat("bool x = looooooooooongcondition1 &&\n"
-               "         looooooooooongcondition2 &&\n"
-               "         looooooooooongcondition3 &&\n"
-               "         looooooooooongcondition4;",
+  // Chain of 4 — above MinChainLength, one-per-line.
+  verifyFormat("bool ok = isConnectionReady(cfg) &&\n"
+               "          isSessionNotExpired(cfg) &&\n"
+               "          hasRequiredPermission(cfg) &&\n"
+               "          isFeatureEnabled(cfg);",
                Style);
 }
 


### PR DESCRIPTION
## Summary

Extend `BreakBinaryOperations` to accept a structured YAML configuration with per-operator break rules and minimum chain length gating via `PerOperator`.

- **Per-operator rules**: specify break style (`Never`, `OnePerLine`, `RespectPrecedence`) for specific operator groups
- **Minimum chain length**: only trigger breaking when a chain has N or more operators
- **Fully backward-compatible**: the simple scalar form (`BreakBinaryOperations: OnePerLine`) behaves identically to the current enum value

RFC discussion: https://discourse.llvm.org/t/rfc-per-operator-granularity-for-breakbinaryoperations/89800

### New YAML syntax

```yaml
BreakBinaryOperations:
  Default: Never
  PerOperator:
    - Operators: ['&&', '||']
      Style: OnePerLine
      MinChainLength: 3
    - Operators: ['|']
      Style: OnePerLine
```

### Motivation

`BreakBinaryOperations` operates at the level of all binary operators simultaneously. Enabling `OnePerLine` for `&&`/`||` condition chains also forces it on `+`, `|`, and other operators, which may not be desired. The only workaround today is `// clang-format off`.

## Test plan

- [x] All existing `BreakBinaryOperations` unit tests updated and passing
- [x] New tests for per-operator rules (`&&`/`||` OnePerLine + default Never)
- [x] New tests for multiple operator groups (`&&`/`||` + `|`)
- [x] New tests for `MinChainLength` gating (chain of 2 vs 3+)
- [x] Config parse tests for structured YAML form
- [x] RST documentation auto-generated via `dump_format_style.py`
- [x] Release notes updated