### PR TITLE
[clang] CodeGen: fix ConstantExpr LValue emission

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -1706,14 +1706,6 @@ LValue CodeGenFunction::EmitLValue(const Expr *E,
   return LV;
 }
 
-static QualType getConstantExprReferredType(const FullExpr *E,
-                                            const ASTContext &Ctx) {
-  const Expr *SE = E->getSubExpr()->IgnoreImplicit();
-  if (isa<OpaqueValueExpr>(SE))
-    return SE->getType();
-  return cast<CallExpr>(SE)->getCallReturnType(Ctx)->getPointeeType();
-}
-
 LValue CodeGenFunction::EmitLValueHelper(const Expr *E,
                                          KnownNonNull_t IsKnownNonNull) {
   ApplyDebugLocation DL(*this, E);
@@ -1751,10 +1743,8 @@ LValue CodeGenFunction::EmitLValueHelper(const Expr *E,
     return EmitDeclRefLValue(cast<DeclRefExpr>(E));
   case Expr::ConstantExprClass: {
     const ConstantExpr *CE = cast<ConstantExpr>(E);
-    if (llvm::Value *Result = ConstantEmitter(*this).tryEmitConstantExpr(CE)) {
-      QualType RetType = getConstantExprReferredType(CE, getContext());
-      return MakeNaturalAlignAddrLValue(Result, RetType);
-    }
+    if (llvm::Value *Result = ConstantEmitter(*this).tryEmitConstantExpr(CE))
+      return MakeNaturalAlignPointeeAddrLValue(Result, CE->getType());
     return EmitLValue(cast<ConstantExpr>(E)->getSubExpr(), IsKnownNonNull);
   }
   case Expr::ParenExprClass:

--- a/clang/test/CodeGenCXX/template-cxx20.cpp
+++ b/clang/test/CodeGenCXX/template-cxx20.cpp
@@ -20,5 +20,16 @@ namespace GH161029_regression1 {
   void h() {
     g<decltype([](auto) -> void { s.U(); }), 0>();
   }
-  // CHECK: call void @_ZN20GH161029_regression11SINS_6TagSetINS_1EELS2_0EEEE1UEv
+  // CHECK-DAG: call void @_ZN20GH161029_regression11SINS_6TagSetINS_1EELS2_0EEEE1UEv
+}
+
+namespace GH177807 {
+  template<int &G> void foo() {
+    [](auto ...A) {
+      (((void)A, G), ...) = 1234;
+    }(0);
+  }
+  int i = 0;
+  template void foo<i>();
+  // CHECK-DAG: store i32 1234, ptr @_ZN8GH1778071iE, align 4
 }


### PR DESCRIPTION
This fixes a regression introduced in #161029, though not the fault of that patch, only by incidental changes regarding the preservation of constant expression nodes.

The LValue emission of ConstantExpr was doing strange things with regards to what type corresponds to the result of the constant expression, which are not justified by any tests or in the discussions of the relevant patches.

See
https://github.com/llvm/llvm-project/commit/09669e6c5fa1e8db9c1091cc264640fb0377d6b6 and https://github.com/llvm/llvm-project/pull/78041 and https://github.com/llvm/llvm-project/commit/51e4aa87e05c45bebf9658a47980b1934c88be31

This simplifies it to just use the expression type.

Since this regression was never released, there are no release notes.

Fixes #177807