### PR TITLE
workflows/release-documentation: Add release environment

### DIFF
--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -36,6 +36,7 @@ on:
 jobs:
   release-documentation:
     name: Build and Upload Release Documentation
+    environment: release
     runs-on: ubuntu-24.04
     env:
       upload: ${{ inputs.upload && !contains(inputs.release-version, 'rc') }}

--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -54,10 +54,6 @@ jobs:
     with:
       release-version: ${{ needs.validate-tag.outputs.release-version }}
       upload: true
-    # Called workflows don't have access to secrets by default, so we need to explicitly pass secrets that we use.
-    secrets:
-      LLVMBOT_WWW_RELEASES_PUSH: ${{ secrets.LLVMBOT_WWW_RELEASES_PUSH }}
-      WWW_RELEASES_TOKEN: ${{ secrets.WWW_RELEASES_TOKEN }}
 
   release-doxygen:
     name: Build and Upload Release Doxygen


### PR DESCRIPTION
This way we can limit access to the secrets to the main and release branches.

This is a partial re-commit of b6ee085068972a41f3b2735a9f7e3ca48eab0f00