### PR TITLE
[TargetLowering][RISCV] Disable the special illegal type expansion of ISD::AVGFLOORU on RV32

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -10014,7 +10014,9 @@ SDValue TargetLowering::expandAVG(SDNode *N, SelectionDAG &DAG) const {
   }
 
   // avgflooru(lhs, rhs) -> or(lshr(add(lhs, rhs),1),shl(overflow, typesize-1))
-  if (Opc == ISD::AVGFLOORU && VT.isScalarInteger() && !isTypeLegal(VT)) {
+  if (Opc == ISD::AVGFLOORU && VT.isScalarInteger() && !isTypeLegal(VT) &&
+      isOperationLegalOrCustom(
+          ISD::UADDO, getLegalTypeToTransformTo(*DAG.getContext(), VT))) {
     SDValue UAddWithOverflow =
         DAG.getNode(ISD::UADDO, dl, DAG.getVTList(VT, MVT::i1), {RHS, LHS});
 

--- a/llvm/test/CodeGen/RISCV/avgflooru.ll
+++ b/llvm/test/CodeGen/RISCV/avgflooru.ll
@@ -164,20 +164,18 @@ define i32 @test_ext_i32(i32 %a0, i32 %a1) nounwind {
 define i64 @test_fixed_i64(i64 %a0, i64 %a1) nounwind {
 ; RV32I-LABEL: test_fixed_i64:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    add a1, a3, a1
-; RV32I-NEXT:    add a0, a2, a0
-; RV32I-NEXT:    sltu a2, a0, a2
-; RV32I-NEXT:    add a1, a1, a2
-; RV32I-NEXT:    beq a1, a3, .LBB6_2
-; RV32I-NEXT:  # %bb.1:
-; RV32I-NEXT:    sltu a2, a1, a3
-; RV32I-NEXT:  .LBB6_2:
-; RV32I-NEXT:    slli a2, a2, 31
+; RV32I-NEXT:    and a4, a1, a3
+; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    srli a3, a1, 1
-; RV32I-NEXT:    slli a4, a1, 31
-; RV32I-NEXT:    srli a0, a0, 1
-; RV32I-NEXT:    or a1, a3, a2
-; RV32I-NEXT:    or a0, a0, a4
+; RV32I-NEXT:    add a3, a4, a3
+; RV32I-NEXT:    xor a4, a0, a2
+; RV32I-NEXT:    slli a1, a1, 31
+; RV32I-NEXT:    srli a4, a4, 1
+; RV32I-NEXT:    or a1, a4, a1
+; RV32I-NEXT:    and a2, a0, a2
+; RV32I-NEXT:    add a0, a2, a1
+; RV32I-NEXT:    sltu a1, a0, a2
+; RV32I-NEXT:    add a1, a3, a1
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: test_fixed_i64:
@@ -197,20 +195,18 @@ define i64 @test_fixed_i64(i64 %a0, i64 %a1) nounwind {
 define i64 @test_ext_i64(i64 %a0, i64 %a1) nounwind {
 ; RV32I-LABEL: test_ext_i64:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    add a1, a3, a1
-; RV32I-NEXT:    add a0, a2, a0
-; RV32I-NEXT:    sltu a2, a0, a2
-; RV32I-NEXT:    add a1, a1, a2
-; RV32I-NEXT:    beq a1, a3, .LBB7_2
-; RV32I-NEXT:  # %bb.1:
-; RV32I-NEXT:    sltu a2, a1, a3
-; RV32I-NEXT:  .LBB7_2:
-; RV32I-NEXT:    slli a2, a2, 31
+; RV32I-NEXT:    and a4, a1, a3
+; RV32I-NEXT:    xor a1, a1, a3
 ; RV32I-NEXT:    srli a3, a1, 1
-; RV32I-NEXT:    slli a4, a1, 31
-; RV32I-NEXT:    srli a0, a0, 1
-; RV32I-NEXT:    or a1, a3, a2
-; RV32I-NEXT:    or a0, a0, a4
+; RV32I-NEXT:    add a3, a4, a3
+; RV32I-NEXT:    xor a4, a0, a2
+; RV32I-NEXT:    slli a1, a1, 31
+; RV32I-NEXT:    srli a4, a4, 1
+; RV32I-NEXT:    or a1, a4, a1
+; RV32I-NEXT:    and a2, a0, a2
+; RV32I-NEXT:    add a0, a2, a1
+; RV32I-NEXT:    sltu a1, a0, a2
+; RV32I-NEXT:    add a1, a3, a1
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: test_ext_i64:


### PR DESCRIPTION
RISC-V doesn't have a carry flag which makes the UADDO expansion expensive to emulate.

I've disabled the code by checking if UADDO is not supported for the type that will be legalized too. Unfortunatley, we have custom lowering of UADDO on RV64 so this doesn't disable this code there.

I'm open to suggestions for better ways to disable this.