### PR TITLE
[NFC] `CfiFunctions` are relevant when promoting from the original module only

### DIFF
--- a/llvm/lib/Transforms/IPO/ThinLTOBitcodeWriter.cpp
+++ b/llvm/lib/Transforms/IPO/ThinLTOBitcodeWriter.cpp
@@ -411,7 +411,11 @@ void splitAndWriteThinLTOBitcode(
     return true;
   });
 
-  promoteInternals(*MergedM, M, ModuleId, CfiFunctions);
+  // CfiFunctions contains only symbols from M. promoteInternals tries to find
+  // match values from its first argument (the "exporting module") in
+  // CfiFunctions. So we only need CfiFunctions for the second promotion (M ->
+  // MergedM)
+  promoteInternals(*MergedM, M, ModuleId, {});
   promoteInternals(M, *MergedM, ModuleId, CfiFunctions);
 
   auto &Ctx = MergedM->getContext();


### PR DESCRIPTION
`CfiFunctions` contains only pointers to IR objects in the original `Module`. When we `promoteInternals`, we try to find such pointers from the first (exporting) module in the `CfiFunctions` set. That will always fail (as in, no values will be found) in the first case, when the exporting module is the merged module. This PR makes it more obvious that the `CfiFunctions` set is only relevant for the second promotion.