### PR TITLE
[libc][math] Refactor bf16divf implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -32,6 +32,7 @@
 #include "math/atanhf16.h"
 #include "math/bf16add.h"
 #include "math/bf16addf128.h"
+#include "math/bf16divf.h"
 #include "math/canonicalize.h"
 #include "math/canonicalizebf16.h"
 #include "math/canonicalizef.h"

--- a/libc/shared/math/bf16divf.h
+++ b/libc/shared/math/bf16divf.h
@@ -1,4 +1,4 @@
-//===-- Implementation of bf16divf function -------------------------------===//
+//===-- Shared bf16divf function --------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,13 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/bf16divf.h"
+#ifndef LLVM_LIBC_SHARED_MATH_BF16DIVF_H
+#define LLVM_LIBC_SHARED_MATH_BF16DIVF_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/bf16divf.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(bfloat16, bf16divf, (float x, float y)) {
-  return math::bf16divf(x, y);
-}
+using math::bf16divf;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_BF16DIVF_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -351,6 +351,17 @@ add_header_library(
     libc.src.__support.FPUtil.generic.add_sub
     libc.src.__support.macros.config
 )
+
+add_header_library(
+  bf16divf
+  HDRS
+    bf16divf.h
+  DEPENDS
+    libc.src.__support.FPUtil.bfloat16
+    libc.src.__support.FPUtil.generic.div
+    libc.src.__support.macros.config
+)
+
 add_header_library(
   canonicalize
   HDRS

--- a/libc/src/__support/math/bf16divf.h
+++ b/libc/src/__support/math/bf16divf.h
@@ -1,0 +1,28 @@
+//===-- Implementation header for bf16divf ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_BF16DIVF_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_BF16DIVF_H
+
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/FPUtil/generic/div.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE constexpr bfloat16 bf16divf(float x, float y) {
+  return fputil::generic::div<bfloat16>(x, y);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_BF16DIVF_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -5192,11 +5192,7 @@ add_entrypoint_object(
   HDRS
     ../bf16divf.h
   DEPENDS
-    libc.src.__support.common
-    libc.src.__support.FPUtil.bfloat16
-    libc.src.__support.FPUtil.generic.div
-    libc.src.__support.macros.config
-    libc.src.__support.macros.properties.types
+    libc.src.__support.math.bf16divf
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -28,6 +28,7 @@ add_fp_unittest(
     libc.src.__support.math.atanhf16
     libc.src.__support.math.bf16add
     libc.src.__support.math.bf16addf128
+    libc.src.__support.math.bf16divf
     libc.src.__support.math.canonicalize
     libc.src.__support.math.canonicalizebf16
     libc.src.__support.math.canonicalizef

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -230,6 +230,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
 
 TEST(LlvmLibcSharedMathTest, AllBFloat16) {
   EXPECT_FP_EQ(bfloat16(5.0), LIBC_NAMESPACE::shared::bf16add(2.0, 3.0));
+  EXPECT_FP_EQ(bfloat16(2.0f), LIBC_NAMESPACE::shared::bf16divf(4.0f, 2.0f));
 
   bfloat16 canonicalizebf16_cx = bfloat16(0.0);
   bfloat16 canonicalizebf16_x = bfloat16(0.0);

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2656,6 +2656,16 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_bf16divf",
+    hdrs = ["src/__support/math/bf16divf.h"],
+    deps = [
+        ":__support_fputil_basic_operations",
+        ":__support_fputil_bfloat16",
+        ":__support_macros_config",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_canonicalize",
     hdrs = ["src/__support/math/canonicalize.h"],
     deps = [
@@ -4422,6 +4432,13 @@ libc_math_function(
     name = "canonicalize",
     additional_deps = [
         ":__support_math_canonicalize",
+    ],
+)
+
+libc_math_function(
+    name = "bf16divf",
+    additional_deps = [
+        ":__support_math_bf16divf",
     ],
 )
 


### PR DESCRIPTION
Move bf16divf implementation to a LIBC_INLINE constexpr header-only function
in src/__support/math/bf16divf.h. The entrypoint in src/math/generic/bf16divf.cpp
now delegates to math::bf16divf(). CMake targets updated accordingly.