### PR TITLE
[lld][ELF] Fix SIGSEGV in updateAllocSize at SyntheticSections.cpp

### DIFF
--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -617,6 +617,8 @@ bool EhFrameHeader::updateAllocSize(Ctx &ctx) {
   // .relr.dyn, this function will not change the size and assignAddresses
   // will not need another iteration.
   EhFrameSection *ehFrame = getPartition(ctx).ehFrame.get();
+  if (!ehFrame->getParent())
+    return false;
   uint64_t hdrVA = getVA();
   int64_t ehFramePtr = ehFrame->getParent()->addr - hdrVA - 4;
   // Determine if 64-bit encodings are needed.

--- a/lld/test/ELF/linkerscript/eh-frame-hdr-discard.s
+++ b/lld/test/ELF/linkerscript/eh-frame-hdr-discard.s
@@ -1,0 +1,15 @@
+# REQUIRES: x86
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t.o
+# RUN: echo "SECTIONS { /DISCARD/ : { *(.eh_frame) } }" > %t.script
+# XFAIL: *
+# RUN: ld.lld --eh-frame-hdr --script %t.script %t.o -o %t
+
+.global _start
+_start:
+ nop
+
+.section .foo,"ax",@progbits
+.cfi_startproc
+ nop
+.cfi_endproc

--- a/lld/test/ELF/linkerscript/eh-frame-hdr-discard.s
+++ b/lld/test/ELF/linkerscript/eh-frame-hdr-discard.s
@@ -2,7 +2,6 @@
 
 # RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t.o
 # RUN: echo "SECTIONS { /DISCARD/ : { *(.eh_frame) } }" > %t.script
-# XFAIL: *
 # RUN: ld.lld --eh-frame-hdr --script %t.script %t.o -o %t
 
 .global _start


### PR DESCRIPTION
Fix crash reported by users in https://github.com/llvm/llvm-project/pull/179089
Example: https://compiler-explorer.com/z/M4GGxW8oh
```
Process 300674 launched: '/usr/local/google/home/leonardchan/llvm-projects/llvm-project-build-1/bin/ld.lld' (x86_64)
Process 300674 stopped
* thread #1, name = 'ld.lld', stop reason = signal SIGSEGV: address not mapped to object (fault address=0x68)
    frame #0: 0x00005555595adf50 ld.lld`lld::elf::EhFrameHeader::updateAllocSize(this=0x0000555563ba7570, ctx=0x0000555563a189e0) at SyntheticSections.cpp:621:46
Likely cause: lld::elf::InputSection::getParent() const()->addr accessed 0x68
(lldb) bt
* thread #1, name = 'ld.lld', stop reason = signal SIGSEGV: address not mapped to object (fault address=0x68)
  * frame #0: 0x00005555595adf50 ld.lld`lld::elf::EhFrameHeader::updateAllocSize(this=0x0000555563ba7570, ctx=0x0000555563a189e0) at SyntheticSections.cpp:621:46
    frame #1: 0x00005555596b3944 ld.lld`(anonymous namespace)::Writer<llvm::object::ELFType<(llvm::endianness)1, true>>::finalizeAddressDependentContent(this=0x00007fffffffb030) at Writer.cpp:1607:37
    frame #2: 0x00005555596ae640 ld.lld`(anonymous namespace)::Writer<llvm::object::ELFType<(llvm::endianness)1, true>>::finalizeSections(this=0x00007fffffffb030) at Writer.cpp:2159:3
    frame #3: 0x000055555968695f ld.lld`(anonymous namespace)::Writer<llvm::object::ELFType<(llvm::endianness)1, true>>::run(this=0x00007fffffffb030) at Writer.cpp:323:3
    frame #4: 0x00005555596c690b ld.lld`void lld::elf::writeResult<llvm::object::ELFType<(llvm::endianness)1, true>>(ctx=0x0000555563a189e0) at Writer.cpp:100:21
    frame #5: 0x00005555593866ac ld.lld`void lld::elf::LinkerDriver::link<llvm::object::ELFType<(llvm::endianness)1, true>>(this=0x0000555563a191f0, args=0x00007fffffffbc68) at Driver.cpp:3514:3
    frame #6: 0x0000555559360cab ld.lld`lld::elf::LinkerDriver::linkerMain(this=0x0000555563a191f0, argsArr=ArrayRef<const char *> @ 0x00007fffffffbeb0) at Driver.cpp:731:16
    frame #7: 0x000055555936052d ld.lld`lld::elf::link(args=ArrayRef<const char *> @ 0x00007fffffffc130, stdoutOS=0x0000555563974d30, stderrOS=0x0000555563974db0, exitEarly=true, disableOutput=false) at Driver.cpp:140:14
    frame #8: 0x00005555591c7d70 ld.lld`lld::unsafeLldMain(args=ArrayRef<const char *> @ 0x00007fffffffc9e0, stdoutOS=0x0000555563974d30, stderrOS=0x0000555563974db0, drivers=ArrayRef<lld::DriverDef> @ 0x00007fffffffc9d0, exitEarly=true) at DriverDispatcher.cpp:163:12
    frame #9: 0x0000555558cc4730 ld.lld`lld_main(argc=2, argv=0x00007fffffffd7b8, (null)=0x00007fffffffd040) at lld.cpp:90:9
    frame #10: 0x00005555591c72cc ld.lld`findTool(Argc=2, Argv=0x00007fffffffd7b8, Argv0="/usr/local/google/home/leonardchan/llvm-projects/llvm-project-build-1/bin/ld.lld") at LLVMDriverTools.def:32:1
    frame #11: 0x00005555591c6265 ld.lld`main(Argc=2, Argv=0x00007fffffffd7b8) at llvm-driver.cpp:85:10
    frame #12: 0x00007ffff7cd8ca8 libc.so.6`__libc_start_call_main(main=(ld.lld`main at llvm-driver.cpp:83), argc=2, argv=0x00007fffffffd7b8) at libc_start_call_main.h:58:16
    frame #13: 0x00007ffff7cd8d65 libc.so.6`__libc_start_main_impl(main=(ld.lld`main at llvm-driver.cpp:83), argc=2, argv=0x00007fffffffd7b8, init=<unavailable>, fini=<unavailable>, rtld_fini=<unavailable>, stack_end=0x00007fffffffd7a8) at libc-start.c:360:3
    frame #14: 0x0000555558ca5f29 ld.lld`_start + 41
```

Add a safeguard in the `EhFrameHeader::updateAllocSize` function to prevent errors when the `.eh_frame` section is discarded and add a new test to verify this behavior. 

I have split the test into a separate commit where it's expected to fail verifying the fix.