### PR TITLE
[AMDGPU][SIInsertWaitcnts][NFC] Drop MaxCounter member variable

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -3013,9 +3013,10 @@ bool WaitcntBrackets::mergeAsyncMarks(ArrayRef<MergeInfo> MergeInfos,
   unsigned OurSize = AsyncMarks.size();
   unsigned MergeCount = std::min(OtherSize, OurSize);
   assert(OurSize == MaxSize);
+  const InstCounterType MaxCounter =
+      getMaxCounter(*Context->ST, Context->IsExpertMode);
   for (unsigned Idx = 1; Idx <= MergeCount; ++Idx) {
-    for (auto T : inst_counter_types(
-             getMaxCounter(*Context->ST, Context->IsExpertMode))) {
+    for (auto T : inst_counter_types(MaxCounter)) {
       StrictDom |= mergeScore(MergeInfos[T], AsyncMarks[OurSize - Idx][T],
                               OtherMarks[OtherSize - Idx][T]);
     }


### PR DESCRIPTION
`MaxCounter` can be trivially computed from MF and IsExpertMode. So keeping it as a member variable is kind of redundant. So this patch uses `IsExpertMode` as the main state for both and will compute `MaxCounter` when needed using `IsExpertMode`.
