### PR TITLE
[lldb] Pass the frame's language type to the highlighter

### DIFF
--- a/lldb/include/lldb/Core/SourceManager.h
+++ b/lldb/include/lldb/Core/SourceManager.h
@@ -48,7 +48,7 @@ public:
     size_t DisplaySourceLines(
         uint32_t line, std::optional<size_t> column, uint32_t context_before,
         uint32_t context_after, Stream *s,
-        std::optional<lldb::LanguageType> language_type = std::nullopt);
+        lldb::LanguageType language_type = lldb::eLanguageTypeUnknown);
     void FindLinesMatchingRegex(RegularExpression &regex, uint32_t start_line,
                                 uint32_t end_line,
                                 std::vector<uint32_t> &match_lines);
@@ -168,19 +168,19 @@ public:
       uint32_t context_before, uint32_t context_after,
       const char *current_line_cstr, Stream *s,
       const SymbolContextList *bp_locs = nullptr,
-      std::optional<lldb::LanguageType> language_type = std::nullopt);
+      lldb::LanguageType language_type = lldb::eLanguageTypeUnknown);
 
   // This variant uses the last file we visited.
   size_t DisplaySourceLinesWithLineNumbersUsingLastFile(
       uint32_t start_line, uint32_t count, uint32_t curr_line, uint32_t column,
       const char *current_line_cstr, Stream *s,
       const SymbolContextList *bp_locs = nullptr,
-      std::optional<lldb::LanguageType> language_type = std::nullopt);
+      lldb::LanguageType language_type = lldb::eLanguageTypeUnknown);
 
   size_t DisplayMoreWithLineNumbers(
       Stream *s, uint32_t count, bool reverse,
       const SymbolContextList *bp_locs = nullptr,
-      std::optional<lldb::LanguageType> language_type = std::nullopt);
+      lldb::LanguageType language_type = lldb::eLanguageTypeUnknown);
 
   bool SetDefaultFileAndLine(SupportFileNSP support_file_nsp, uint32_t line);
 

--- a/lldb/include/lldb/Core/SourceManager.h
+++ b/lldb/include/lldb/Core/SourceManager.h
@@ -45,9 +45,10 @@ public:
     bool ModificationTimeIsStale() const;
     bool PathRemappingIsStale() const;
 
-    size_t DisplaySourceLines(uint32_t line, std::optional<size_t> column,
-                              uint32_t context_before, uint32_t context_after,
-                              Stream *s);
+    size_t DisplaySourceLines(
+        uint32_t line, std::optional<size_t> column, uint32_t context_before,
+        uint32_t context_after, Stream *s,
+        std::optional<lldb::LanguageType> language_type = std::nullopt);
     void FindLinesMatchingRegex(RegularExpression &regex, uint32_t start_line,
                                 uint32_t end_line,
                                 std::vector<uint32_t> &match_lines);
@@ -166,16 +167,20 @@ public:
       SupportFileNSP support_file_nsp, uint32_t line, uint32_t column,
       uint32_t context_before, uint32_t context_after,
       const char *current_line_cstr, Stream *s,
-      const SymbolContextList *bp_locs = nullptr);
+      const SymbolContextList *bp_locs = nullptr,
+      std::optional<lldb::LanguageType> language_type = std::nullopt);
 
   // This variant uses the last file we visited.
   size_t DisplaySourceLinesWithLineNumbersUsingLastFile(
       uint32_t start_line, uint32_t count, uint32_t curr_line, uint32_t column,
       const char *current_line_cstr, Stream *s,
-      const SymbolContextList *bp_locs = nullptr);
+      const SymbolContextList *bp_locs = nullptr,
+      std::optional<lldb::LanguageType> language_type = std::nullopt);
 
-  size_t DisplayMoreWithLineNumbers(Stream *s, uint32_t count, bool reverse,
-                                    const SymbolContextList *bp_locs = nullptr);
+  size_t DisplayMoreWithLineNumbers(
+      Stream *s, uint32_t count, bool reverse,
+      const SymbolContextList *bp_locs = nullptr,
+      std::optional<lldb::LanguageType> language_type = std::nullopt);
 
   bool SetDefaultFileAndLine(SupportFileNSP support_file_nsp, uint32_t line);
 

--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -226,8 +226,8 @@ static bool should_show_stop_line_with_ansi(DebuggerSP debugger_sp) {
 
 size_t SourceManager::DisplaySourceLinesWithLineNumbersUsingLastFile(
     uint32_t start_line, uint32_t count, uint32_t curr_line, uint32_t column,
-    const char *current_line_cstr, Stream *s,
-    const SymbolContextList *bp_locs) {
+    const char *current_line_cstr, Stream *s, const SymbolContextList *bp_locs,
+    std::optional<lldb::LanguageType> language_type) {
   if (count == 0)
     return 0;
 
@@ -288,8 +288,8 @@ size_t SourceManager::DisplaySourceLinesWithLineNumbersUsingLastFile(
       if (line == curr_line && column)
         columnToHighlight = column - 1;
 
-      size_t this_line_size =
-          last_file_sp->DisplaySourceLines(line, columnToHighlight, 0, 0, s);
+      size_t this_line_size = last_file_sp->DisplaySourceLines(
+          line, columnToHighlight, 0, 0, s, language_type);
       if (column != 0 && line == curr_line &&
           should_show_stop_column_with_caret(debugger_sp)) {
         // Display caret cursor.
@@ -326,8 +326,8 @@ size_t SourceManager::DisplaySourceLinesWithLineNumbersUsingLastFile(
 size_t SourceManager::DisplaySourceLinesWithLineNumbers(
     SupportFileNSP support_file_nsp, uint32_t line, uint32_t column,
     uint32_t context_before, uint32_t context_after,
-    const char *current_line_cstr, Stream *s,
-    const SymbolContextList *bp_locs) {
+    const char *current_line_cstr, Stream *s, const SymbolContextList *bp_locs,
+    std::optional<lldb::LanguageType> language_type) {
   assert(support_file_nsp && "SupportFile must be valid");
   FileSP file_sp(GetFile(support_file_nsp));
 
@@ -346,11 +346,13 @@ size_t SourceManager::DisplaySourceLinesWithLineNumbers(
   }
 
   return DisplaySourceLinesWithLineNumbersUsingLastFile(
-      start_line, count, line, column, current_line_cstr, s, bp_locs);
+      start_line, count, line, column, current_line_cstr, s, bp_locs,
+      language_type);
 }
 
 size_t SourceManager::DisplayMoreWithLineNumbers(
-    Stream *s, uint32_t count, bool reverse, const SymbolContextList *bp_locs) {
+    Stream *s, uint32_t count, bool reverse, const SymbolContextList *bp_locs,
+    std::optional<lldb::LanguageType> language_type) {
   // If we get called before anybody has set a default file and line, then try
   // to figure it out here.
   FileSP last_file_sp(GetLastFile());
@@ -383,7 +385,8 @@ size_t SourceManager::DisplayMoreWithLineNumbers(
 
     const uint32_t column = 0;
     return DisplaySourceLinesWithLineNumbersUsingLastFile(
-        m_last_line, m_last_count, UINT32_MAX, column, "", s, bp_locs);
+        m_last_line, m_last_count, UINT32_MAX, column, "", s, bp_locs,
+        language_type);
   }
   return 0;
 }
@@ -673,11 +676,10 @@ bool SourceManager::File::PathRemappingIsStale() const {
   return false;
 }
 
-size_t SourceManager::File::DisplaySourceLines(uint32_t line,
-                                               std::optional<size_t> column,
-                                               uint32_t context_before,
-                                               uint32_t context_after,
-                                               Stream *s) {
+size_t SourceManager::File::DisplaySourceLines(
+    uint32_t line, std::optional<size_t> column, uint32_t context_before,
+    uint32_t context_after, Stream *s,
+    std::optional<lldb::LanguageType> language_type) {
   // Nothing to write if there's no stream.
   if (!s)
     return 0;
@@ -706,7 +708,8 @@ size_t SourceManager::File::DisplaySourceLines(uint32_t line,
       GetSupportFile()->GetSpecOnly().GetPath(/*denormalize*/ false);
   // FIXME: Find a way to get the definitive language this file was written in
   // and pass it to the highlighter.
-  const auto &h = mgr.getHighlighterFor(lldb::eLanguageTypeUnknown, path);
+  const auto &h = mgr.getHighlighterFor(
+      language_type.value_or(lldb::eLanguageTypeUnknown), path);
 
   const uint32_t start_line =
       line <= context_before ? 1 : line - context_before;

--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -227,7 +227,7 @@ static bool should_show_stop_line_with_ansi(DebuggerSP debugger_sp) {
 size_t SourceManager::DisplaySourceLinesWithLineNumbersUsingLastFile(
     uint32_t start_line, uint32_t count, uint32_t curr_line, uint32_t column,
     const char *current_line_cstr, Stream *s, const SymbolContextList *bp_locs,
-    std::optional<lldb::LanguageType> language_type) {
+    lldb::LanguageType language_type) {
   if (count == 0)
     return 0;
 
@@ -327,7 +327,7 @@ size_t SourceManager::DisplaySourceLinesWithLineNumbers(
     SupportFileNSP support_file_nsp, uint32_t line, uint32_t column,
     uint32_t context_before, uint32_t context_after,
     const char *current_line_cstr, Stream *s, const SymbolContextList *bp_locs,
-    std::optional<lldb::LanguageType> language_type) {
+    lldb::LanguageType language_type) {
   assert(support_file_nsp && "SupportFile must be valid");
   FileSP file_sp(GetFile(support_file_nsp));
 
@@ -352,7 +352,7 @@ size_t SourceManager::DisplaySourceLinesWithLineNumbers(
 
 size_t SourceManager::DisplayMoreWithLineNumbers(
     Stream *s, uint32_t count, bool reverse, const SymbolContextList *bp_locs,
-    std::optional<lldb::LanguageType> language_type) {
+    lldb::LanguageType language_type) {
   // If we get called before anybody has set a default file and line, then try
   // to figure it out here.
   FileSP last_file_sp(GetLastFile());
@@ -678,8 +678,7 @@ bool SourceManager::File::PathRemappingIsStale() const {
 
 size_t SourceManager::File::DisplaySourceLines(
     uint32_t line, std::optional<size_t> column, uint32_t context_before,
-    uint32_t context_after, Stream *s,
-    std::optional<lldb::LanguageType> language_type) {
+    uint32_t context_after, Stream *s, lldb::LanguageType language_type) {
   // Nothing to write if there's no stream.
   if (!s)
     return 0;
@@ -708,8 +707,7 @@ size_t SourceManager::File::DisplaySourceLines(
       GetSupportFile()->GetSpecOnly().GetPath(/*denormalize*/ false);
   // FIXME: Find a way to get the definitive language this file was written in
   // and pass it to the highlighter.
-  const auto &h = mgr.getHighlighterFor(
-      language_type.value_or(lldb::eLanguageTypeUnknown), path);
+  const auto &h = mgr.getHighlighterFor(language_type, path);
 
   const uint32_t start_line =
       line <= context_before ? 1 : line - context_before;

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -2076,7 +2076,8 @@ bool StackFrame::GetStatus(Stream &strm, bool show_frame_info, bool show_source,
           size_t num_lines =
               target->GetSourceManager().DisplaySourceLinesWithLineNumbers(
                   source_file_sp, start_line, m_sc.line_entry.column,
-                  source_lines_before, source_lines_after, "->", &strm);
+                  source_lines_before, source_lines_after, "->", &strm,
+                  /*bp_locs=*/nullptr, GetLanguage().AsLanguageType());
           if (num_lines != 0)
             have_source = true;
           // TODO: Give here a one time warning if source file is missing.


### PR DESCRIPTION
This threads the frame's language type through the source manager to the highlighter. Previously, we'd always pass "unknown" as the language type and rely on the language plugin to figure out the language based on the file extension.

This change is motivated by #170250. For languages like Swift or Rust that don't have an upstream language plugin, we need the frame's language for syntax highlighting.