### PR TITLE
[AMDGPU] Add missing assert requirement to unit test

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/misched-remat-revert.ll
+++ b/llvm/test/CodeGen/AMDGPU/misched-remat-revert.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -O3 -debug-only=machine-scheduler 2>&1 < %s | FileCheck -check-prefix=DEBUG %s
+; REQUIRES: asserts
 
 ; This testcase hit a situation where reverting scheduling after the scheduler's
 ; rematerialization stage would cause incoherent MI and slot orders, hitting an


### PR DESCRIPTION
`-debug-only` is only available when asserts are enabled. The test currently fails on builds without asserts.