### PR TITLE
[CodeGen] Improve `getLoadExtAction` and friends

### DIFF
--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -28,7 +28,6 @@
 #include "llvm/Analysis/TargetTransformInfoImpl.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/CodeGen/ISDOpcodes.h"
-#include "llvm/CodeGen/MachineMemOperand.h"
 #include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/CodeGen/ValueTypes.h"
@@ -1266,10 +1265,8 @@ public:
         if (I) {
           if (auto *LI = dyn_cast<LoadInst>(I->getOperand(0))) {
             if (DstLT.first == SrcLT.first &&
-                TLI->isLoadLegal(
-                    ExtVT, LoadVT, LI->getAlign(),
-                    TLI->getLoadMemOperandFlags(*LI, DL),
-                    LI->getPointerAddressSpace(), LType, false))
+                TLI->isLoadLegal(ExtVT, LoadVT, LI->getAlign(),
+                                 LI->getPointerAddressSpace(), LType, false))
               return 0;
           } else if (auto *II = dyn_cast<IntrinsicInst>(I->getOperand(0))) {
             switch (II->getIntrinsicID()) {
@@ -1277,17 +1274,10 @@ public:
               Type *PtrType = II->getArgOperand(0)->getType();
               assert(PtrType->isPointerTy());
 
-              auto MMOFlags = MachineMemOperand::MOLoad;
-              if (I->hasMetadata(LLVMContext::MD_nontemporal))
-                MMOFlags |= MachineMemOperand::MONonTemporal;
-              if (I->hasMetadata(LLVMContext::MD_invariant_load))
-                MMOFlags |= MachineMemOperand::MOInvariant;
-
               if (DstLT.first == SrcLT.first &&
-                  TLI->isLoadLegal(ExtVT, LoadVT,
-                                   II->getParamAlign(0).valueOrOne(), MMOFlags,
-                                   PtrType->getPointerAddressSpace(), LType,
-                                   false))
+                  TLI->isLoadLegal(
+                      ExtVT, LoadVT, II->getParamAlign(0).valueOrOne(),
+                      PtrType->getPointerAddressSpace(), LType, false))
                 return 0;
 
               break;
@@ -1588,9 +1578,8 @@ public:
       if (Opcode == Instruction::Store)
         LA = getTLI()->getTruncStoreAction(LT.second, MemVT);
       else
-        LA = getTLI()->getLoadAction(LT.second, MemVT, Alignment,
-                                     MachineMemOperand::Flags::MOLoad,
-                                     AddressSpace, ISD::EXTLOAD, false);
+        LA = getTLI()->getLoadAction(LT.second, MemVT, Alignment, AddressSpace,
+                                     ISD::EXTLOAD, false);
 
       if (LA != TargetLowering::Legal && LA != TargetLowering::Custom) {
         // This is a vector load/store for some illegal type that is scalarized.

--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -1261,7 +1261,7 @@ public:
         EVT ExtVT = EVT::getEVT(Dst);
         EVT LoadVT = EVT::getEVT(Src);
         unsigned LType =
-            ((Opcode == Instruction::ZExt) ? ISD::ZEXTLOAD : ISD::SEXTLOAD);
+            Opcode == Instruction::ZExt ? ISD::ZEXTLOAD : ISD::SEXTLOAD;
         if (I) {
           if (auto *LI = dyn_cast<LoadInst>(I->getOperand(0))) {
             if (DstLT.first == SrcLT.first &&

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -1513,28 +1513,24 @@ public:
   /// needs to be promoted to a larger size, needs to be expanded to some other
   /// code sequence, or the target has a custom expander for it.
   virtual LegalizeAction getLoadAction(EVT ValVT, EVT MemVT, Align Alignment,
-                                       MachineMemOperand::Flags MMOFlags,
                                        unsigned AddrSpace, unsigned ExtType,
                                        bool Atomic) const;
 
   /// Return true if the specified load with extension is legal on this target.
-  bool isLoadLegal(EVT ValVT, EVT MemVT, Align Alignment,
-                   MachineMemOperand::Flags MMOFlags, unsigned AddrSpace,
+  bool isLoadLegal(EVT ValVT, EVT MemVT, Align Alignment, unsigned AddrSpace,
                    unsigned ExtType, bool Atomic) const {
-    return getLoadAction(ValVT, MemVT, Alignment, MMOFlags, AddrSpace, ExtType,
-                         Atomic) == Legal;
+    return getLoadAction(ValVT, MemVT, Alignment, AddrSpace, ExtType, Atomic) ==
+           Legal;
   }
 
   /// Return true if the specified load with extension is legal or custom
   /// on this target.
   bool isLoadLegalOrCustom(EVT ValVT, EVT MemVT, Align Alignment,
-                           MachineMemOperand::Flags MMOFlags,
                            unsigned AddrSpace, unsigned ExtType,
                            bool Atomic) const {
-    return getLoadAction(ValVT, MemVT, Alignment, MMOFlags, AddrSpace, ExtType,
-                         Atomic) == Legal ||
-           getLoadAction(ValVT, MemVT, Alignment, MMOFlags, AddrSpace, ExtType,
-                         Atomic) == Custom;
+    LegalizeAction Action =
+        getLoadAction(ValVT, MemVT, Alignment, AddrSpace, ExtType, Atomic);
+    return Action == Legal || Action == Custom;
   }
 
   /// Return how this store with truncation should be treated: either it is
@@ -3164,7 +3160,6 @@ public:
     }
 
     return isLoadLegal(VT, LoadVT, Load->getAlign(),
-                       getLoadMemOperandFlags(*Load, DL),
                        Load->getPointerAddressSpace(), LType, false);
   }
 

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -1546,7 +1546,7 @@ public:
 
     if (Action == LegalizeAction::Custom) {
       return getCustomLoadAction(ValVT, MemVT, Alignment, AddrSpace, ExtType,
-                               Atomic);
+                                 Atomic);
     }
 
     return Action;

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -1509,12 +1509,48 @@ public:
     return isOperationExpand(Op, VT) || getOperationAction(Op, VT) == LibCall;
   }
 
+  /// Returns an alternative action to use when the coarser lookups (configured
+  /// through `setLoadExtAction` and `setAtomicLoadExtAction`) yield
+  /// `LegalizeAction::Custom`. Allows targets to use builtin behaviors (e.g.
+  /// Legal, Promote) specialized by Alignment and AddrSpace, rather than just
+  /// types.
+  virtual LegalizeAction
+  getCustomLoadAction(EVT ValVT, EVT MemVT, Align Alignment, unsigned AddrSpace,
+                      unsigned ExtType, bool Atomic) const {
+    return LegalizeAction::Custom;
+  }
+
   /// Return how this load with extension should be treated: either it is legal,
   /// needs to be promoted to a larger size, needs to be expanded to some other
   /// code sequence, or the target has a custom expander for it.
-  virtual LegalizeAction getLoadAction(EVT ValVT, EVT MemVT, Align Alignment,
-                                       unsigned AddrSpace, unsigned ExtType,
-                                       bool Atomic) const;
+  LegalizeAction getLoadAction(EVT ValVT, EVT MemVT, Align Alignment,
+                               unsigned AddrSpace, unsigned ExtType,
+                               bool Atomic) const {
+    if (ValVT.isExtended() || MemVT.isExtended())
+      return Expand;
+    unsigned ValI = (unsigned)ValVT.getSimpleVT().SimpleTy;
+    unsigned MemI = (unsigned)MemVT.getSimpleVT().SimpleTy;
+    assert(ExtType < ISD::LAST_LOADEXT_TYPE && ValI < MVT::VALUETYPE_SIZE &&
+           MemI < MVT::VALUETYPE_SIZE && "Table isn't big enough!");
+    unsigned Shift = 4 * ExtType;
+
+    LegalizeAction Action;
+    if (Atomic) {
+      Action =
+          (LegalizeAction)((AtomicLoadExtActions[ValI][MemI] >> Shift) & 0xf);
+      assert((Action == Legal || Action == Expand) &&
+             "Unsupported atomic load extension action.");
+    } else {
+      Action = (LegalizeAction)((LoadExtActions[ValI][MemI] >> Shift) & 0xf);
+    }
+
+    if (Action == LegalizeAction::Custom) {
+      return getCustomLoadAction(ValVT, MemVT, Alignment, AddrSpace, ExtType,
+                               Atomic);
+    }
+
+    return Action;
+  }
 
   /// Return true if the specified load with extension is legal on this target.
   bool isLoadLegal(EVT ValVT, EVT MemVT, Align Alignment, unsigned AddrSpace,

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -7516,7 +7516,6 @@ bool CodeGenPrepare::optimizeLoadExt(LoadInst *Load) {
   // Reject cases that won't be matched as extloads.
   if (!LoadResultVT.bitsGT(TruncVT) || !TruncVT.isRound() ||
       !TLI->isLoadLegal(LoadResultVT, TruncVT, Load->getAlign(),
-                        TLI->getLoadMemOperandFlags(*Load, *DL),
                         Load->getPointerAddressSpace(), ISD::ZEXTLOAD, false))
     return false;
 

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -14937,8 +14937,8 @@ SDValue DAGCombiner::foldSextSetcc(SDNode *N) {
         LoadSDNode *Ld = cast<LoadSDNode>(V.getNode());
 
         if (!Ld->isSimple() ||
-              !TLI.isLoadLegal(VT, V.getValueType(), Ld->getAlign(),
-                              Ld->getAddressSpace(), LoadOpcode, false))
+            !TLI.isLoadLegal(VT, V.getValueType(), Ld->getAlign(),
+                             Ld->getAddressSpace(), LoadOpcode, false))
           return false;
 
         // Non-chain users of this value must either be the setcc in this

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -7048,7 +7048,6 @@ bool DAGCombiner::isAndLoadExtLoad(ConstantSDNode *AndC, LoadSDNode *LoadN,
   if (ExtVT == LoadedVT &&
       (!LegalOperations ||
        TLI.isLoadLegal(LoadResultTy, ExtVT, LoadN->getAlign(),
-                       LoadN->getMemOperand()->getFlags(),
                        LoadN->getAddressSpace(), ISD::ZEXTLOAD, false))) {
     // ZEXTLOAD will match without needing to change the size of the value being
     // loaded.
@@ -7066,7 +7065,6 @@ bool DAGCombiner::isAndLoadExtLoad(ConstantSDNode *AndC, LoadSDNode *LoadN,
 
   if (LegalOperations &&
       !TLI.isLoadLegal(LoadResultTy, ExtVT, LoadN->getAlign(),
-                       LoadN->getMemOperand()->getFlags(),
                        LoadN->getAddressSpace(), ISD::ZEXTLOAD, false))
     return false;
 
@@ -7131,7 +7129,6 @@ bool DAGCombiner::isLegalNarrowLdSt(LSBaseSDNode *LDST,
 
     if (LegalOperations &&
         !TLI.isLoadLegal(Load->getValueType(0), MemVT, Load->getAlign(),
-                         Load->getMemOperand()->getFlags(),
                          Load->getAddressSpace(), ExtType, false))
       return false;
 
@@ -7645,7 +7642,6 @@ SDValue DAGCombiner::visitAND(SDNode *N) {
     if (MLoad && MLoad->getExtensionType() == ISD::EXTLOAD && Splat) {
       EVT MemVT = MLoad->getMemoryVT();
       if (TLI.isLoadLegal(VT, MemVT, MLoad->getAlign(),
-                          MLoad->getMemOperand()->getFlags(),
                           MLoad->getAddressSpace(), ISD::ZEXTLOAD, false)) {
         // For this AND to be a zero extension of the masked load the elements
         // of the BuildVec must mask the bottom bits of the extended element
@@ -7793,10 +7789,9 @@ SDValue DAGCombiner::visitAND(SDNode *N) {
     // If we want to change an EXTLOAD to a ZEXTLOAD, ensure a ZEXTLOAD is
     // actually legal and isn't going to get expanded, else this is a false
     // optimisation.
-    bool CanZextLoadProfitably =
-        TLI.isLoadLegal(Load->getValueType(0), Load->getMemoryVT(),
-                        Load->getAlign(), Load->getMemOperand()->getFlags(),
-                        Load->getAddressSpace(), ISD::ZEXTLOAD, false);
+    bool CanZextLoadProfitably = TLI.isLoadLegal(
+        Load->getValueType(0), Load->getMemoryVT(), Load->getAlign(),
+        Load->getAddressSpace(), ISD::ZEXTLOAD, false);
 
     // Resize the constant to the same size as the original memory access before
     // extension. If it is still the AllOnesValue then this AND is completely
@@ -7988,9 +7983,8 @@ SDValue DAGCombiner::visitAND(SDNode *N) {
     APInt ExtBits = APInt::getHighBitsSet(ExtBitSize, ExtBitSize - MemBitSize);
     if (DAG.MaskedValueIsZero(N1, ExtBits) &&
         ((!LegalOperations && LN0->isSimple()) ||
-         TLI.isLoadLegal(VT, MemVT, LN0->getAlign(),
-                         LN0->getMemOperand()->getFlags(),
-                         LN0->getAddressSpace(), ISD::ZEXTLOAD, false))) {
+         TLI.isLoadLegal(VT, MemVT, LN0->getAlign(), LN0->getAddressSpace(),
+                         ISD::ZEXTLOAD, false))) {
       SDValue ExtLoad =
           DAG.getExtLoad(ISD::ZEXTLOAD, SDLoc(N0), VT, LN0->getChain(),
                          LN0->getBasePtr(), MemVT, LN0->getMemOperand());
@@ -9914,8 +9908,7 @@ SDValue DAGCombiner::MatchLoadCombine(SDNode *N) {
   // patterns to a couple of i32 loads on 32 bit targets.
   if (LegalOperations) {
     for (auto *L : Loads) {
-      if (!TLI.isLoadLegal(VT, MemVT, L->getAlign(),
-                           L->getMemOperand()->getFlags(), L->getAddressSpace(),
+      if (!TLI.isLoadLegal(VT, MemVT, L->getAlign(), L->getAddressSpace(),
                            NeedsZext ? ISD::ZEXTLOAD : ISD::NON_EXTLOAD,
                            false)) {
 
@@ -13806,7 +13799,6 @@ SDValue DAGCombiner::visitVSELECT(SDNode *N) {
         LoadSDNode *Ld = cast<LoadSDNode>(LHS);
 
         if (TLI.isLoadLegalOrCustom(WideVT, NarrowVT, Ld->getAlign(),
-                                    Ld->getMemOperand()->getFlags(),
                                     Ld->getAddressSpace(), LoadExtOpcode,
                                     false)) {
           // Both compare operands can be widened for free. The LHS can use an
@@ -14256,10 +14248,8 @@ static SDValue tryToFoldExtendSelectLoad(SDNode *N, const TargetLowering &TLI,
   LoadSDNode *Load1 = cast<LoadSDNode>(Op1);
   LoadSDNode *Load2 = cast<LoadSDNode>(Op2);
   if (!TLI.isLoadLegal(VT, Load1->getMemoryVT(), Load1->getAlign(),
-                       Load1->getMemOperand()->getFlags(),
                        Load1->getAddressSpace(), ExtLoadOpcode, false) ||
       !TLI.isLoadLegal(VT, Load2->getMemoryVT(), Load2->getAlign(),
-                       Load2->getMemOperand()->getFlags(),
                        Load2->getAddressSpace(), ExtLoadOpcode, false) ||
       (N0->getOpcode() == ISD::VSELECT && Level >= AfterLegalizeTypes &&
        TLI.getOperationAction(ISD::VSELECT, VT) != TargetLowering::Legal))
@@ -14485,7 +14475,6 @@ SDValue DAGCombiner::CombineExtLoad(SDNode *N) {
   EVT SplitSrcVT = SrcVT;
   EVT SplitDstVT = DstVT;
   while (!TLI.isLoadLegalOrCustom(SplitDstVT, SplitSrcVT, LN0->getAlign(),
-                                  LN0->getMemOperand()->getFlags(),
                                   LN0->getAddressSpace(), ExtType, false) &&
          SplitSrcVT.getVectorNumElements() > 1) {
     SplitDstVT = DAG.GetSplitDestVTs(SplitDstVT).first;
@@ -14493,7 +14482,6 @@ SDValue DAGCombiner::CombineExtLoad(SDNode *N) {
   }
 
   if (!TLI.isLoadLegalOrCustom(SplitDstVT, SplitSrcVT, LN0->getAlign(),
-                               LN0->getMemOperand()->getFlags(),
                                LN0->getAddressSpace(), ExtType, false))
     return SDValue();
 
@@ -14567,9 +14555,8 @@ SDValue DAGCombiner::CombineZExtLogicopShiftLoad(SDNode *N) {
     return SDValue();
   LoadSDNode *Load = cast<LoadSDNode>(N1.getOperand(0));
   EVT MemVT = Load->getMemoryVT();
-  if (!TLI.isLoadLegal(VT, MemVT, Load->getAlign(),
-                          Load->getMemOperand()->getFlags(),
-                          Load->getAddressSpace(), ISD::ZEXTLOAD, false) ||
+  if (!TLI.isLoadLegal(VT, MemVT, Load->getAlign(), Load->getAddressSpace(),
+                       ISD::ZEXTLOAD, false) ||
       Load->getExtensionType() == ISD::SEXTLOAD || Load->isIndexed())
     return SDValue();
 
@@ -14683,7 +14670,6 @@ static SDValue tryToFoldExtOfExtload(SelectionDAG &DAG, DAGCombiner &Combiner,
   EVT MemVT = OldExtLoad->getMemoryVT();
   if ((LegalOperations || !OldExtLoad->isSimple() || VT.isVector()) &&
       !TLI.isLoadLegal(VT, MemVT, OldExtLoad->getAlign(),
-                       OldExtLoad->getMemOperand()->getFlags(),
                        OldExtLoad->getAddressSpace(), ExtLoadType, false))
     return SDValue();
 
@@ -14745,7 +14731,6 @@ static SDValue tryToFoldExtOfLoad(SelectionDAG &DAG, DAGCombiner &Combiner,
   // isVectorLoadExtDesirable().
   if ((LegalOperations || VT.isFixedLengthVector() || !Load->isSimple()) &&
       !TLI.isLoadLegal(VT, Load->getValueType(0), Load->getAlign(),
-                       Load->getMemOperand()->getFlags(),
                        Load->getAddressSpace(), ExtLoadType, false))
     return {};
 
@@ -14803,7 +14788,6 @@ tryToFoldExtOfMaskedLoad(SelectionDAG &DAG, const TargetLowering &TLI, EVT VT,
 
   if ((LegalOperations || !cast<MaskedLoadSDNode>(N0)->isSimple()) &&
       !TLI.isLoadLegalOrCustom(VT, Ld->getValueType(0), Ld->getAlign(),
-                               Ld->getMemOperand()->getFlags(),
                                Ld->getAddressSpace(), ExtLoadType, false))
     return SDValue();
 
@@ -14829,7 +14813,8 @@ static SDValue tryToFoldExtOfAtomicLoad(SelectionDAG &DAG,
   if (!ALoad || ALoad->getOpcode() != ISD::ATOMIC_LOAD)
     return {};
   EVT MemoryVT = ALoad->getMemoryVT();
-  if (!TLI.isLoadLegal(VT, MemoryVT, ALoad->getAlign(), ALoad->getMemOperand()->getFlags(), ALoad->getAddressSpace(), ExtLoadType, true))
+  if (!TLI.isLoadLegal(VT, MemoryVT, ALoad->getAlign(),
+                       ALoad->getAddressSpace(), ExtLoadType, true))
     return {};
   // Can't fold into ALoad if it is already extending differently.
   ISD::LoadExtType ALoadExtTy = ALoad->getExtensionType();
@@ -14951,10 +14936,9 @@ SDValue DAGCombiner::foldSextSetcc(SDNode *N) {
 
         LoadSDNode *Ld = cast<LoadSDNode>(V.getNode());
 
-        if (!(Ld->isSimple() &&
-              TLI.isLoadLegal(VT, V.getValueType(), Ld->getAlign(),
-                              Ld->getMemOperand()->getFlags(),
-                              Ld->getAddressSpace(), LoadOpcode, false)))
+        if (!Ld->isSimple() ||
+              !TLI.isLoadLegal(VT, V.getValueType(), Ld->getAlign(),
+                              Ld->getAddressSpace(), LoadOpcode, false))
           return false;
 
         // Non-chain users of this value must either be the setcc in this
@@ -15151,9 +15135,8 @@ SDValue DAGCombiner::visitSIGN_EXTEND(SDNode *N) {
       (!LegalOperations && TLI.isOperationLegal(N0.getOpcode(), VT))) {
     LoadSDNode *LN00 = cast<LoadSDNode>(N0.getOperand(0));
     EVT MemVT = LN00->getMemoryVT();
-    if (TLI.isLoadLegal(VT, MemVT, LN00->getAlign(),
-                        LN00->getMemOperand()->getFlags(),
-                        LN00->getAddressSpace(), ISD::SEXTLOAD, false) &&
+    if (TLI.isLoadLegal(VT, MemVT, LN00->getAlign(), LN00->getAddressSpace(),
+                        ISD::SEXTLOAD, false) &&
         LN00->getExtensionType() != ISD::ZEXTLOAD && LN00->isUnindexed()) {
       SmallVector<SDNode*, 4> SetCCs;
       bool DoXform = ExtendUsesToFormExtLoad(VT, N0.getNode(), N0.getOperand(0),
@@ -15471,9 +15454,8 @@ SDValue DAGCombiner::visitZERO_EXTEND(SDNode *N) {
       (!LegalOperations && TLI.isOperationLegal(N0.getOpcode(), VT))) {
     LoadSDNode *LN00 = cast<LoadSDNode>(N0.getOperand(0));
     EVT MemVT = LN00->getMemoryVT();
-    if (TLI.isLoadLegal(VT, MemVT, LN00->getAlign(),
-                        LN00->getMemOperand()->getFlags(),
-                        LN00->getAddressSpace(), ISD::ZEXTLOAD, false) &&
+    if (TLI.isLoadLegal(VT, MemVT, LN00->getAlign(), LN00->getAddressSpace(),
+                        ISD::ZEXTLOAD, false) &&
         LN00->getExtensionType() != ISD::SEXTLOAD && LN00->isUnindexed()) {
       bool DoXform = true;
       SmallVector<SDNode*, 4> SetCCs;
@@ -15706,7 +15688,6 @@ SDValue DAGCombiner::visitANY_EXTEND(SDNode *N) {
              ISD::isUNINDEXEDLoad(N0.getNode())) {
     LoadSDNode *LN0 = cast<LoadSDNode>(N0);
     if (TLI.isLoadLegalOrCustom(VT, N0.getValueType(), LN0->getAlign(),
-                                LN0->getMemOperand()->getFlags(),
                                 LN0->getAddressSpace(), ISD::EXTLOAD, false)) {
       bool DoXform = true;
       SmallVector<SDNode *, 4> SetCCs;
@@ -15743,9 +15724,8 @@ SDValue DAGCombiner::visitANY_EXTEND(SDNode *N) {
     ISD::LoadExtType ExtType = LN0->getExtensionType();
     EVT MemVT = LN0->getMemoryVT();
     if (!LegalOperations ||
-        TLI.isLoadLegal(VT, MemVT, LN0->getAlign(),
-                        LN0->getMemOperand()->getFlags(),
-                        LN0->getAddressSpace(), ExtType, false)) {
+        TLI.isLoadLegal(VT, MemVT, LN0->getAlign(), LN0->getAddressSpace(),
+                        ExtType, false)) {
       SDValue ExtLoad =
           DAG.getExtLoad(ExtType, DL, VT, LN0->getChain(), LN0->getBasePtr(),
                          MemVT, LN0->getMemOperand());
@@ -16060,7 +16040,6 @@ SDValue DAGCombiner::reduceLoadWidth(SDNode *N) {
         // If the mask is smaller, recompute the type.
         if ((ExtVT.getScalarSizeInBits() > MaskedVT.getScalarSizeInBits()) &&
             TLI.isLoadLegal(SRL.getValueType(), MaskedVT, LN->getAlign(),
-                            LN->getMemOperand()->getFlags(),
                             LN->getAddressSpace(), ExtType, false))
           ExtVT = MaskedVT;
       } else if (ExtType == ISD::ZEXTLOAD &&
@@ -16071,7 +16050,6 @@ SDValue DAGCombiner::reduceLoadWidth(SDNode *N) {
         // the trailing zeros.
         if (((Offset + ActiveBits) <= ExtVT.getScalarSizeInBits()) &&
             TLI.isLoadLegal(SRL.getValueType(), MaskedVT, LN->getAlign(),
-                            LN->getMemOperand()->getFlags(),
                             LN->getAddressSpace(), ExtType, false)) {
           ExtVT = MaskedVT;
           ShAmt = Offset + ShAmt;
@@ -16298,9 +16276,8 @@ SDValue DAGCombiner::visitSIGN_EXTEND_INREG(SDNode *N) {
     auto *LN0 = cast<LoadSDNode>(N0);
     if (ExtVT == LN0->getMemoryVT() &&
         ((!LegalOperations && LN0->isSimple() && N0.hasOneUse()) ||
-         TLI.isLoadLegal(VT, ExtVT, LN0->getAlign(),
-                         LN0->getMemOperand()->getFlags(),
-                         LN0->getAddressSpace(), ISD::SEXTLOAD, false))) {
+         TLI.isLoadLegal(VT, ExtVT, LN0->getAlign(), LN0->getAddressSpace(),
+                         ISD::SEXTLOAD, false))) {
       SDValue ExtLoad =
           DAG.getExtLoad(ISD::SEXTLOAD, DL, VT, LN0->getChain(),
                          LN0->getBasePtr(), ExtVT, LN0->getMemOperand());
@@ -16317,9 +16294,8 @@ SDValue DAGCombiner::visitSIGN_EXTEND_INREG(SDNode *N) {
 
     if (N0.hasOneUse() && ExtVT == LN0->getMemoryVT() &&
         ((!LegalOperations && LN0->isSimple()) &&
-         TLI.isLoadLegal(VT, ExtVT, LN0->getAlign(),
-                         LN0->getMemOperand()->getFlags(),
-                         LN0->getAddressSpace(), ISD::SEXTLOAD, false))) {
+         TLI.isLoadLegal(VT, ExtVT, LN0->getAlign(), LN0->getAddressSpace(),
+                         ISD::SEXTLOAD, false))) {
       SDValue ExtLoad =
           DAG.getExtLoad(ISD::SEXTLOAD, DL, VT, LN0->getChain(),
                          LN0->getBasePtr(), ExtVT, LN0->getMemOperand());
@@ -16335,8 +16311,7 @@ SDValue DAGCombiner::visitSIGN_EXTEND_INREG(SDNode *N) {
   if (auto *Ld = dyn_cast<MaskedLoadSDNode>(Frozen ? N0.getOperand(0) : N0)) {
     if (ExtVT == Ld->getMemoryVT() && Ld->hasNUsesOfValue(1, 0) &&
         Ld->getExtensionType() != ISD::LoadExtType::NON_EXTLOAD &&
-        TLI.isLoadLegal(VT, ExtVT, Ld->getAlign(),
-                        Ld->getMemOperand()->getFlags(), Ld->getAddressSpace(),
+        TLI.isLoadLegal(VT, ExtVT, Ld->getAlign(), Ld->getAddressSpace(),
                         ISD::SEXTLOAD, false)) {
       SDValue ExtMaskedLoad = DAG.getMaskedLoad(
           VT, DL, Ld->getChain(), Ld->getBasePtr(), Ld->getOffset(),
@@ -19798,7 +19773,6 @@ SDValue DAGCombiner::visitFP_EXTEND(SDNode *N) {
   if (ISD::isNormalLoad(N0.getNode()) && N0.hasOneUse()) {
     LoadSDNode *LN0 = cast<LoadSDNode>(N0);
     if (TLI.isLoadLegalOrCustom(VT, N0.getValueType(), LN0->getAlign(),
-                                LN0->getMemOperand()->getFlags(),
                                 LN0->getAddressSpace(), ISD::EXTLOAD, false)) {
       SDValue ExtLoad = DAG.getExtLoad(ISD::EXTLOAD, DL, VT, LN0->getChain(),
                                        LN0->getBasePtr(), N0.getValueType(),
@@ -22900,18 +22874,15 @@ bool DAGCombiner::tryStoreMergeOfLoads(SmallVectorImpl<MemOpLink> &StoreNodes,
         if (TLI.isTruncStoreLegal(LegalizedStoredValTy, StoreTy) &&
             TLI.canMergeStoresTo(FirstStoreAS, LegalizedStoredValTy,
                                  DAG.getMachineFunction()) &&
-            TLI.isLoadLegal(
-                LegalizedStoredValTy, StoreTy, FirstLoad->getAlign(),
-                FirstLoad->getMemOperand()->getFlags(),
-                FirstLoad->getAddressSpace(), ISD::ZEXTLOAD, false) &&
-            TLI.isLoadLegal(
-                LegalizedStoredValTy, StoreTy, FirstLoad->getAlign(),
-                FirstLoad->getMemOperand()->getFlags(),
-                FirstLoad->getAddressSpace(), ISD::SEXTLOAD, false) &&
-            TLI.isLoadLegal(
-                LegalizedStoredValTy, StoreTy, FirstLoad->getAlign(),
-                FirstLoad->getMemOperand()->getFlags(),
-                FirstLoad->getAddressSpace(), ISD::EXTLOAD, false) &&
+            TLI.isLoadLegal(LegalizedStoredValTy, StoreTy,
+                            FirstLoad->getAlign(), FirstLoad->getAddressSpace(),
+                            ISD::ZEXTLOAD, false) &&
+            TLI.isLoadLegal(LegalizedStoredValTy, StoreTy,
+                            FirstLoad->getAlign(), FirstLoad->getAddressSpace(),
+                            ISD::SEXTLOAD, false) &&
+            TLI.isLoadLegal(LegalizedStoredValTy, StoreTy,
+                            FirstLoad->getAlign(), FirstLoad->getAddressSpace(),
+                            ISD::EXTLOAD, false) &&
             TLI.allowsMemoryAccess(Context, DL, StoreTy,
                                    *FirstInChain->getMemOperand(), &IsFastSt) &&
             IsFastSt &&

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -9903,20 +9903,6 @@ SDValue DAGCombiner::MatchLoadCombine(SDNode *N) {
   if (!MemVT.isSimple())
     return SDValue();
 
-  // Before legalize we can introduce too wide illegal loads which will be later
-  // split into legal sized loads. This enables us to combine i64 load by i8
-  // patterns to a couple of i32 loads on 32 bit targets.
-  if (LegalOperations) {
-    for (auto *L : Loads) {
-      if (!TLI.isLoadLegal(VT, MemVT, L->getAlign(), L->getAddressSpace(),
-                           NeedsZext ? ISD::ZEXTLOAD : ISD::NON_EXTLOAD,
-                           false)) {
-
-        return SDValue();
-      }
-    }
-  }
-
   // Check if the bytes of the OR we are looking at match with either big or
   // little endian value load
   std::optional<bool> IsBigEndian = isBigEndian(
@@ -9931,6 +9917,18 @@ SDValue DAGCombiner::MatchLoadCombine(SDNode *N) {
   if (MemoryByteOffset(*FirstByteProvider) != 0)
     return SDValue();
   auto *FirstLoad = cast<LoadSDNode>(FirstByteProvider->Src.value());
+
+  // Before legalize we can introduce too wide illegal loads which will be later
+  // split into legal sized loads. This enables us to combine i64 load by i8
+  // patterns to a couple of i32 loads on 32 bit targets.
+  if (LegalOperations) {
+    if (!TLI.isLoadLegal(VT, MemVT, FirstLoad->getAlign(),
+                         FirstLoad->getAddressSpace(),
+                         NeedsZext ? ISD::ZEXTLOAD : ISD::NON_EXTLOAD, false)) {
+
+      return SDValue();
+    }
+  }
 
   // The node we are looking at matches with the pattern, check if we can
   // replace it with a single (possibly zero-extended) load and bswap + shift if

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -9918,17 +9918,15 @@ SDValue DAGCombiner::MatchLoadCombine(SDNode *N) {
     return SDValue();
   auto *FirstLoad = cast<LoadSDNode>(FirstByteProvider->Src.value());
 
-  // Before legalize we can introduce too wide illegal loads which will be later
-  // split into legal sized loads. This enables us to combine i64 load by i8
-  // patterns to a couple of i32 loads on 32 bit targets.
-  if (LegalOperations) {
-    if (!TLI.isLoadLegal(VT, MemVT, FirstLoad->getAlign(),
-                         FirstLoad->getAddressSpace(),
-                         NeedsZext ? ISD::ZEXTLOAD : ISD::NON_EXTLOAD, false)) {
-
-      return SDValue();
-    }
-  }
+  // Before legalization we allow introducing loads that are wider than legal,
+  // which will later be split into legally sized loads. This enables us to
+  // combine, for example, i8 loads forming an i64 into an i64 load, which get
+  // then gets split up into couple of i32 loads on 32 bit targets.
+  if (LegalOperations &&
+      !TLI.isLoadLegal(VT, MemVT, FirstLoad->getAlign(),
+                       FirstLoad->getAddressSpace(),
+                       NeedsZext ? ISD::ZEXTLOAD : ISD::NON_EXTLOAD, false))
+    return SDValue();
 
   // The node we are looking at matches with the pattern, check if we can
   // replace it with a single (possibly zero-extended) load and bswap + shift if

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
@@ -353,8 +353,9 @@ SelectionDAGLegalize::ExpandConstantFP(ConstantFPSDNode *CFP, bool UseCP) {
           // Only do this if the target has a native EXTLOAD instruction from
           // smaller type.
           TLI.isLoadLegal(
-              OrigVT, SVT, Align(DAG.getDataLayout().getPrefTypeAlign(SVT.getTypeForEVT(*DAG.getContext()))),
-              MachineMemOperand::Flags::MOLoad,
+              OrigVT, SVT,
+              Align(DAG.getDataLayout().getPrefTypeAlign(
+                  SVT.getTypeForEVT(*DAG.getContext()))),
               MachinePointerInfo::getConstantPool(DAG.getMachineFunction())
                   .getAddrSpace(),
               ISD::EXTLOAD, false) &&
@@ -750,8 +751,8 @@ void SelectionDAGLegalize::LegalizeLoadOps(SDNode *Node) {
       // Until such a way is found, don't insist on promoting i1 here.
       (SrcVT != MVT::i1 ||
        TLI.getLoadAction(Node->getValueType(0), MVT::i1, LD->getAlign(),
-                         LD->getMemOperand()->getFlags(), LD->getAddressSpace(),
-                         ExtType, false) == TargetLowering::Promote)) {
+                         LD->getAddressSpace(), ExtType,
+                         false) == TargetLowering::Promote)) {
     // Promote to a byte-sized load if not loading an integral number of
     // bytes.  For example, promote EXTLOAD:i20 -> EXTLOAD:i24.
     unsigned NewWidth = SrcVT.getStoreSizeInBits();
@@ -862,8 +863,8 @@ void SelectionDAGLegalize::LegalizeLoadOps(SDNode *Node) {
   } else {
     bool isCustom = false;
     switch (TLI.getLoadAction(Node->getValueType(0), SrcVT.getSimpleVT(),
-                              LD->getAlign(), LD->getMemOperand()->getFlags(),
-                              LD->getAddressSpace(), ExtType, false)) {
+                              LD->getAlign(), LD->getAddressSpace(), ExtType,
+                              false)) {
     default:
       llvm_unreachable("This action is not supported yet!");
     case TargetLowering::Custom:
@@ -892,16 +893,14 @@ void SelectionDAGLegalize::LegalizeLoadOps(SDNode *Node) {
 
     case TargetLowering::Expand: {
       EVT DestVT = Node->getValueType(0);
-      if (!TLI.isLoadLegal(DestVT, SrcVT, LD->getAlign(),
-                           LD->getMemOperand()->getFlags(),
-                           LD->getAddressSpace(), ISD::EXTLOAD, false)) {
+      if (!TLI.isLoadLegal(DestVT, SrcVT, LD->getAlign(), LD->getAddressSpace(),
+                           ISD::EXTLOAD, false)) {
         // If the source type is not legal, see if there is a legal extload to
         // an intermediate type that we can then extend further.
         EVT LoadVT = TLI.getRegisterType(SrcVT.getSimpleVT());
         if ((LoadVT.isFloatingPoint() == SrcVT.isFloatingPoint()) &&
             (TLI.isTypeLegal(SrcVT) || // Same as SrcVT == LoadVT?
              TLI.isLoadLegal(LoadVT, SrcVT, LD->getAlign(),
-                             LD->getMemOperand()->getFlags(),
                              LD->getAddressSpace(), ExtType, false))) {
           // If we are loading a legal type, this is a non-extload followed by a
           // full extend.
@@ -1865,9 +1864,9 @@ SDValue SelectionDAGLegalize::EmitStackConvert(SDValue SrcOp, EVT SlotVT,
   if ((SrcVT.bitsGT(SlotVT) &&
        !TLI.isTruncStoreLegalOrCustom(SrcOp.getValueType(), SlotVT)) ||
       (SlotVT.bitsLT(DestVT) &&
-       !TLI.isLoadLegalOrCustom(
-           DestVT, SlotVT, DestAlign, MachineMemOperand::Flags::MOLoad,
-           DAG.getDataLayout().getAllocaAddrSpace(), ISD::EXTLOAD, false)))
+       !TLI.isLoadLegalOrCustom(DestVT, SlotVT, DestAlign,
+                                DAG.getDataLayout().getAllocaAddrSpace(),
+                                ISD::EXTLOAD, false)))
     return SDValue();
 
   // Create the stack frame object.

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
@@ -298,7 +298,9 @@ SDValue VectorLegalizer::LegalizeOp(SDValue Op) {
     ISD::LoadExtType ExtType = LD->getExtensionType();
     EVT LoadedVT = LD->getMemoryVT();
     if (LoadedVT.isVector() && ExtType != ISD::NON_EXTLOAD)
-      Action = TLI.getLoadExtAction(ExtType, LD->getValueType(0), LoadedVT);
+      Action = TLI.getLoadAction(LD->getValueType(0), LoadedVT, LD->getAlign(),
+                                 LD->getMemOperand()->getFlags(),
+                                 LD->getAddressSpace(), ExtType, false);
     break;
   }
   case ISD::STORE: {

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
@@ -299,7 +299,6 @@ SDValue VectorLegalizer::LegalizeOp(SDValue Op) {
     EVT LoadedVT = LD->getMemoryVT();
     if (LoadedVT.isVector() && ExtType != ISD::NON_EXTLOAD)
       Action = TLI.getLoadAction(LD->getValueType(0), LoadedVT, LD->getAlign(),
-                                 LD->getMemOperand()->getFlags(),
                                  LD->getAddressSpace(), ExtType, false);
     break;
   }

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -12731,9 +12731,12 @@ SDValue TargetLowering::scalarizeExtractedVectorLoad(EVT ResultVT,
   if (ResultVT.bitsGT(VecEltVT)) {
     // If the result type of vextract is wider than the load, then issue an
     // extending load instead.
-    ISD::LoadExtType ExtType = isLoadExtLegal(ISD::ZEXTLOAD, ResultVT, VecEltVT)
-                                   ? ISD::ZEXTLOAD
-                                   : ISD::EXTLOAD;
+    ISD::LoadExtType ExtType =
+        isLoadLegal(ResultVT, VecEltVT, Alignment,
+                    OriginalLoad->getMemOperand()->getFlags(),
+                    OriginalLoad->getAddressSpace(), ISD::ZEXTLOAD, false)
+            ? ISD::ZEXTLOAD
+            : ISD::EXTLOAD;
     Load = DAG.getExtLoad(ExtType, DL, ResultVT, OriginalLoad->getChain(),
                           NewPtr, MPI, VecEltVT, Alignment,
                           OriginalLoad->getMemOperand()->getFlags(),

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -12733,7 +12733,6 @@ SDValue TargetLowering::scalarizeExtractedVectorLoad(EVT ResultVT,
     // extending load instead.
     ISD::LoadExtType ExtType =
         isLoadLegal(ResultVT, VecEltVT, Alignment,
-                    OriginalLoad->getMemOperand()->getFlags(),
                     OriginalLoad->getAddressSpace(), ISD::ZEXTLOAD, false)
             ? ISD::ZEXTLOAD
             : ISD::EXTLOAD;

--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -2030,9 +2030,10 @@ MVT TargetLoweringBase::getPreferredSwitchConditionType(LLVMContext &Context,
   return getRegisterType(Context, ConditionVT);
 }
 
-TargetLoweringBase::LegalizeAction TargetLoweringBase::getLoadAction(
-    EVT ValVT, EVT MemVT, Align Alignment, MachineMemOperand::Flags MMOFlags,
-    unsigned AddrSpace, unsigned ExtType, bool Atomic) const {
+TargetLoweringBase::LegalizeAction
+TargetLoweringBase::getLoadAction(EVT ValVT, EVT MemVT, Align Alignment,
+                                  unsigned AddrSpace, unsigned ExtType,
+                                  bool Atomic) const {
   if (ValVT.isExtended() || MemVT.isExtended())
     return Expand;
   unsigned ValI = (unsigned)ValVT.getSimpleVT().SimpleTy;

--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -20,7 +20,6 @@
 #include "llvm/Analysis/Loads.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/CodeGen/Analysis.h"
-#include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
 #include "llvm/CodeGen/ISDOpcodes.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
@@ -2028,29 +2027,6 @@ bool TargetLoweringBase::isSuitableForJumpTable(const SwitchInst *SI,
 MVT TargetLoweringBase::getPreferredSwitchConditionType(LLVMContext &Context,
                                                         EVT ConditionVT) const {
   return getRegisterType(Context, ConditionVT);
-}
-
-TargetLoweringBase::LegalizeAction
-TargetLoweringBase::getLoadAction(EVT ValVT, EVT MemVT, Align Alignment,
-                                  unsigned AddrSpace, unsigned ExtType,
-                                  bool Atomic) const {
-  if (ValVT.isExtended() || MemVT.isExtended())
-    return Expand;
-  unsigned ValI = (unsigned)ValVT.getSimpleVT().SimpleTy;
-  unsigned MemI = (unsigned)MemVT.getSimpleVT().SimpleTy;
-  assert(ExtType < ISD::LAST_LOADEXT_TYPE && ValI < MVT::VALUETYPE_SIZE &&
-         MemI < MVT::VALUETYPE_SIZE && "Table isn't big enough!");
-  unsigned Shift = 4 * ExtType;
-
-  if (Atomic) {
-    LegalizeAction Action =
-        (LegalizeAction)((AtomicLoadExtActions[ValI][MemI] >> Shift) & 0xf);
-    assert((Action == Legal || Action == Expand) &&
-           "Unsupported atomic load extension action.");
-    return Action;
-  }
-
-  return (LegalizeAction)((LoadExtActions[ValI][MemI] >> Shift) & 0xf);
 }
 
 /// Get the EVTs and ArgFlags collections that represent the legalized return

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -7045,7 +7045,9 @@ bool AArch64TargetLowering::isVectorLoadExtDesirable(SDValue ExtVal) const {
   // results in just one set of predicate unpacks at the start, instead of
   // multiple sets of vector unpacks after each load.
   if (auto *Ld = dyn_cast<MaskedLoadSDNode>(ExtVal->getOperand(0))) {
-    if (!isLoadExtLegalOrCustom(ISD::ZEXTLOAD, ExtVT, Ld->getValueType(0))) {
+    if (!isLoadLegalOrCustom(ExtVT, Ld->getValueType(0), Ld->getAlign(),
+                             Ld->getMemOperand()->getFlags(),
+                             Ld->getAddressSpace(), ISD::ZEXTLOAD, false)) {
       // Disable extending masked loads for fixed-width for now, since the code
       // quality doesn't look great.
       if (!ExtVT.isScalableVector())

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -7046,7 +7046,6 @@ bool AArch64TargetLowering::isVectorLoadExtDesirable(SDValue ExtVal) const {
   // multiple sets of vector unpacks after each load.
   if (auto *Ld = dyn_cast<MaskedLoadSDNode>(ExtVal->getOperand(0))) {
     if (!isLoadLegalOrCustom(ExtVT, Ld->getValueType(0), Ld->getAlign(),
-                             Ld->getMemOperand()->getFlags(),
                              Ld->getAddressSpace(), ISD::ZEXTLOAD, false)) {
       // Disable extending masked loads for fixed-width for now, since the code
       // quality doesn't look great.

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -61640,7 +61640,9 @@ static SDValue combineEXTEND_VECTOR_INREG(SDNode *N, SelectionDAG &DAG,
                                  ? ISD::SEXTLOAD
                                  : ISD::ZEXTLOAD;
       EVT MemVT = VT.changeVectorElementType(*DAG.getContext(), SVT);
-      if (TLI.isLoadExtLegal(Ext, VT, MemVT)) {
+      if (TLI.isLoadLegal(VT, MemVT, Ld->getAlign(),
+                          Ld->getMemOperand()->getFlags(),
+                          Ld->getAddressSpace(), Ext, false)) {
         SDValue Load = DAG.getExtLoad(
             Ext, DL, VT, Ld->getChain(), Ld->getBasePtr(), Ld->getPointerInfo(),
             MemVT, Ld->getBaseAlign(), Ld->getMemOperand()->getFlags());

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -61640,9 +61640,8 @@ static SDValue combineEXTEND_VECTOR_INREG(SDNode *N, SelectionDAG &DAG,
                                  ? ISD::SEXTLOAD
                                  : ISD::ZEXTLOAD;
       EVT MemVT = VT.changeVectorElementType(*DAG.getContext(), SVT);
-      if (TLI.isLoadLegal(VT, MemVT, Ld->getAlign(),
-                          Ld->getMemOperand()->getFlags(),
-                          Ld->getAddressSpace(), Ext, false)) {
+      if (TLI.isLoadLegal(VT, MemVT, Ld->getAlign(), Ld->getAddressSpace(), Ext,
+                          false)) {
         SDValue Load = DAG.getExtLoad(
             Ext, DL, VT, Ld->getChain(), Ld->getBasePtr(), Ld->getPointerInfo(),
             MemVT, Ld->getBaseAlign(), Ld->getMemOperand()->getFlags());


### PR DESCRIPTION
Alternative approach to the same goals as #162407

This takes `TargetLoweringBase::getLoadExtAction`, renames it to `TargetLoweringBase::getLoadAction`, merges `getAtomicLoadExtAction` into it, and adds more inputs for relavent information (alignment, address space).

The `isLoadExtLegal[OrCustom]` helpers are also modified in a matching manner.

This is fully backwards compatible, with the existing `setLoadExtAction` working as before. But this allows targets to override a new hook to allow the query to make more use of the information. The hook `getCustomLoadAction` is called with all the parameters whenever the table lookup yields `LegalizeAction::Custom`, and can return any other action it wants.