### PR TITLE
Reapply "[msan] Switch switch() from strict handling to (icmp eq)-style handling" (#180636)

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -2497,6 +2497,9 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
 
     Value *ShadowCases = nullptr;
     for (auto Case : SI.cases()) {
+      if (casesToConsider <= 0)
+        break;
+
       Value *Comparator = Case.getCaseValue();
       // TODO: some simplification is possible when comparing multiple cases
       // simultaneously.
@@ -2509,8 +2512,6 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
         ShadowCases = ComparisonShadow;
 
       casesToConsider--;
-      if (casesToConsider <= 0)
-        break;
     }
 
     if (ShadowCases)

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -2460,6 +2460,47 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     return Si;
   }
 
+  // Instrument:
+  //     switch i32 %Val, label %else [ i32 0, label %A
+  //                                    i32 1, label %B
+  //                                    i32 2, label %C ]
+  //
+  // Typically, the switch input value (%Val) is fully initialized.
+  //
+  // Sometimes the compiler may convert (icmp + br) into a switch statement.
+  // MSan allows icmp eq/ne with partly initialized inputs to still result in a
+  // fully initialized output, if there exists a bit that is initialized in
+  // both inputs with a differing value. For compatibility, we support this in
+  // the switch instrumentation as well. Note that this edge case only applies
+  // if the switch input value does not match *any* of the cases (matching any
+  // of the cases requires an exact, fully initialized match).
+  //
+  //     ShadowCases =   0
+  //                   | propagateEqualityComparison(Val, 0)
+  //                   | propagateEqualityComparison(Val, 1)
+  //                   | propagateEqualityComparison(Val, 2))
+  void visitSwitchInst(SwitchInst &SI) {
+    IRBuilder<> IRB(&SI);
+
+    Value *Val = SI.getCondition();
+    Value *ShadowVal = getShadow(Val);
+
+    Value *ShadowCases = nullptr;
+    for (auto Case : SI.cases()) {
+      Value *Comparator = Case.getCaseValue();
+      Value *ComparisonShadow = propagateEqualityComparison(
+          IRB, Val, Comparator, ShadowVal, getShadow(Comparator));
+
+      if (ShadowCases)
+        ShadowCases = IRB.CreateOr(ShadowCases, ComparisonShadow);
+      else
+        ShadowCases = ComparisonShadow;
+    }
+
+    if (ShadowCases)
+      insertCheckShadow(ShadowCases, getOrigin(Val), &SI);
+  }
+
   // Vector manipulation.
   void visitExtractElementInst(ExtractElementInst &I) {
     insertCheckShadowOf(I.getOperand(1), &I);

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -299,6 +299,15 @@ static cl::opt<bool>
                       cl::desc("exact handling of relational integer ICmp"),
                       cl::Hidden, cl::init(true));
 
+static cl::opt<int> ClSwitchPrecision(
+    "msan-switch-precision",
+    cl::desc("Controls the number of cases considered by MSan for LLVM switch "
+             "instructions. 0 means no UUMs detected. Higher values lead to "
+             "fewer false negatives but may impact compiler and/or "
+             "application performance. N.B. LLVM switch instructions do not "
+             "correspond exactly to C++ switch statements."),
+    cl::Hidden, cl::init(99));
+
 static cl::opt<bool> ClHandleLifetimeIntrinsics(
     "msan-handle-lifetime-intrinsics",
     cl::desc(
@@ -2493,7 +2502,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     // stack overflow or excessive runtime. We limit the number of cases
     // considered, with the tradeoff of niche false negatives.
     // TODO: figure out a better solution.
-    int casesToConsider = 99;
+    int casesToConsider = ClSwitchPrecision;
 
     Value *ShadowCases = nullptr;
     for (auto Case : SI.cases()) {


### PR DESCRIPTION
This reverts https://github.com/llvm/llvm-project/pull/180636 i.e., relands https://github.com/llvm/llvm-project/pull/179851.

It was originally reverted because of buildbot failures. When compiling switch statements with many cases (e.g., AMDGPUGenMCCodeEmitter.inc has >30,000 cases), MSan's instrumentation created an extremely long chained expression for the shadow computation. Although that was legal LLVM IR, it caused the subsequent JumpThreadingPass to have a stack overflow.

This reland avoids the issue by limiting the number of cases considered (`-msan-switch-precision`), with the tradeoff of niche false negatives (only in the case where the condition is partly uninitialized and the first x cases still have a defined comparison, but a case # > x does not have a fully-defined comparison).

This reland also adds some TODOs for possible improvements.

----

Original commit message:

Currently, the SwitchInst:
```
switch i32 %Val, label %else [ i32 0, label %A
                               i32 1, label %B
                               i32 2, label %C ]
```
is strictly handled i.e., MSan will check that %Val is fully initialized. This is appropriate nearly all the time.

However, sometimes the compiler may convert (icmp + br) into a switch statement. (icmp + br) has different semantics: MSan allows icmp eq/ne with partly initialized inputs to still result in a fully initialized output, if there exists a bit that is initialized in both inputs with a differing value e.g., suppose:
```
%A   = 00000000 00001010
%B   = 00000000 00000110
%C   = 00000000 00000011

%Val = 00000001 ???????? (where ? denotes an uninitialized bit)
```
Even though %Val has uninitialized bits, the initialized '1' bit immediately to the left, compared to the corresponding initialized '0' bit in %A/%B/%C suffices to prove that %Val does not match any of those cases. This is similar to a real-world case with std::optional (where the has_value bit may be initialized but the value is not).

This patch adds this relaxed icmp logic to the switch instrumentation as well, to make MSan's behavior equivalent under optimization.

Note that this edge case only applies if the switch input value definitively does not match *any* of the cases (matching any of the cases requires an exact, fully initialized match). If it is uncertain whether the switch input value could, depending on the uninitialized bits, match one of the cases or not, MSan will report use-of-uninitialized memory.