### PR TITLE
[libc++][NFC] Don't use copy_n to copy a single integer in __sign_combinator

### DIFF
--- a/libcxx/include/__charconv/from_chars_integral.h
+++ b/libcxx/include/__charconv/from_chars_integral.h
@@ -10,12 +10,10 @@
 #ifndef _LIBCPP___CHARCONV_FROM_CHARS_INTEGRAL_H
 #define _LIBCPP___CHARCONV_FROM_CHARS_INTEGRAL_H
 
-#include <__algorithm/copy_n.h>
 #include <__assert>
 #include <__charconv/from_chars_result.h>
 #include <__charconv/traits.h>
 #include <__config>
-#include <__memory/addressof.h>
 #include <__system_error/errc.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_integral.h>
@@ -56,8 +54,7 @@ __sign_combinator(_It __first, _It __last, _Tp& __value, _Fn __f, _Ts... __args)
 
   if (__neg) {
     if (__x <= std::__complement(std::__to_unsigned_like(__tl::min()))) {
-      __x = std::__complement(__x);
-      std::copy_n(std::addressof(__x), 1, std::addressof(__value));
+      __value = std::__complement(__x);
       return __r;
     }
   } else {


### PR DESCRIPTION
We can just assign the integer directly.
