### PR TITLE
[lldb-dap][vscode][windows] check if Python is installed properly before starting lldb-dap

### DIFF
--- a/lldb/tools/lldb-dap/extension/src/debug-configuration-provider.ts
+++ b/lldb/tools/lldb-dap/extension/src/debug-configuration-provider.ts
@@ -1,6 +1,7 @@
 import * as child_process from "child_process";
 import * as util from "util";
 import * as vscode from "vscode";
+import * as os from "os";
 import { createDebugAdapterExecutable } from "./debug-adapter-factory";
 import { LLDBDapServer } from "./lldb-dap-server";
 import { LogFilePathProvider } from "./logging";
@@ -76,8 +77,7 @@ export function getDefaultConfigKey(
 }
 
 export class LLDBDapConfigurationProvider
-  implements vscode.DebugConfigurationProvider
-{
+  implements vscode.DebugConfigurationProvider {
   constructor(
     private readonly server: LLDBDapServer,
     private readonly logger: vscode.LogOutputChannel,
@@ -116,7 +116,7 @@ export class LLDBDapConfigurationProvider
     );
     this.logger.debug(
       "Initial debug configuration:\n" +
-        JSON.stringify(debugConfiguration, undefined, 2),
+      JSON.stringify(debugConfiguration, undefined, 2),
     );
     let config = vscode.workspace.getConfiguration("lldb-dap");
     for (const [key, cfg] of Object.entries(configurations)) {
@@ -201,6 +201,22 @@ export class LLDBDapConfigurationProvider
           return undefined;
         }
 
+        if (os.platform() === "win32") {
+          const pythonCheckProcess = child_process.spawnSync(executable.command, [
+            "--check-python",
+          ]);
+          if (pythonCheckProcess.status !== 0) {
+            await vscode.window.showErrorMessage(
+              "Python is not installed correctly. Please install it to use lldb-dap.",
+              {
+                modal: true,
+                detail: pythonCheckProcess.stderr?.toString() ?? "",
+              },
+            );
+            return undefined;
+          }
+        }
+
         // Server mode needs to be handled here since DebugAdapterDescriptorFactory
         // will show an unhelpful error if it returns undefined. We'd rather show a
         // nicer error message here and allow stopping the debug session gracefully.
@@ -233,7 +249,7 @@ export class LLDBDapConfigurationProvider
 
       this.logger.info(
         "Resolved debug configuration:\n" +
-          JSON.stringify(debugConfiguration, undefined, 2),
+        JSON.stringify(debugConfiguration, undefined, 2),
       );
 
       return debugConfiguration;

--- a/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
@@ -2,6 +2,7 @@ import { FSWatcher, watch as chokidarWatch } from "chokidar";
 import * as child_process from "node:child_process";
 import { isDeepStrictEqual } from "util";
 import * as vscode from "vscode";
+import * as os from "os";
 
 /**
  * Represents a running lldb-dap process that is accepting connections (i.e. in "server mode").
@@ -60,6 +61,15 @@ export class LLDBDapServer implements vscode.Disposable {
     }
 
     this.serverInfo = new Promise((resolve, reject) => {
+      if (os.platform() === "win32") {
+        const pythonCheckProcess = child_process.spawnSync(dapPath, ["--check-python"]);
+        if (pythonCheckProcess.stderr) {
+          vscode.window.showErrorMessage(
+            `Python is not installed correctly. Please install it to use lldb-dap.\n${pythonCheckProcess.stderr}`
+          );
+          return;
+        }
+      }
       const process = child_process.spawn(dapPath, dapArgs, options);
       process.on("error", (error) => {
         reject(error);

--- a/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
@@ -60,16 +60,23 @@ export class LLDBDapServer implements vscode.Disposable {
       return this.serverInfo;
     }
 
-    this.serverInfo = new Promise((resolve, reject) => {
-      if (os.platform() === "win32") {
-        const pythonCheckProcess = child_process.spawnSync(dapPath, ["--check-python"]);
-        if (pythonCheckProcess.stderr) {
-          vscode.window.showErrorMessage(
-            `Python is not installed correctly. Please install it to use lldb-dap.\n${pythonCheckProcess.stderr}`
-          );
-          return;
-        }
+    if (os.platform() === "win32") {
+      const pythonCheckProcess = child_process.spawnSync(dapPath, [
+        "--check-python",
+      ]);
+      if (pythonCheckProcess.status !== 0) {
+        await vscode.window.showErrorMessage(
+          "Python is not installed correctly. Please install it to use lldb-dap.",
+          {
+            modal: true,
+            detail: pythonCheckProcess.stderr?.toString() ?? "",
+          },
+        );
+        return undefined;
       }
+    }
+
+    this.serverInfo = new Promise((resolve, reject) => {
       const process = child_process.spawn(dapPath, dapArgs, options);
       process.on("error", (error) => {
         reject(error);

--- a/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
@@ -2,7 +2,6 @@ import { FSWatcher, watch as chokidarWatch } from "chokidar";
 import * as child_process from "node:child_process";
 import { isDeepStrictEqual } from "util";
 import * as vscode from "vscode";
-import * as os from "os";
 
 /**
  * Represents a running lldb-dap process that is accepting connections (i.e. in "server mode").
@@ -58,22 +57,6 @@ export class LLDBDapServer implements vscode.Disposable {
 
     if (this.serverInfo) {
       return this.serverInfo;
-    }
-
-    if (os.platform() === "win32") {
-      const pythonCheckProcess = child_process.spawnSync(dapPath, [
-        "--check-python",
-      ]);
-      if (pythonCheckProcess.status !== 0) {
-        await vscode.window.showErrorMessage(
-          "Python is not installed correctly. Please install it to use lldb-dap.",
-          {
-            modal: true,
-            detail: pythonCheckProcess.stderr?.toString() ?? "",
-          },
-        );
-        return undefined;
-      }
     }
 
     this.serverInfo = new Promise((resolve, reject) => {

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -669,7 +669,7 @@ int main(int argc, char *argv[]) {
 #ifdef _WIN32
   if (input_args.hasArg(OPT_check_python)) {
 #ifndef LLDB_ENABLE_PYTHON
-    llvm::outs() << "lldb-dap was not built with Python support" << '\n';
+    llvm::errs() << "lldb-dap was not built with Python support" << '\n';
     return EXIT_SUCCESS;
 #endif
     auto python_path_or_err = SetupPythonRuntimeLibrary();

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -668,6 +668,10 @@ int main(int argc, char *argv[]) {
 
 #ifdef _WIN32
   if (input_args.hasArg(OPT_check_python)) {
+#ifndef LLDB_ENABLE_PYTHON
+    llvm::outs() << "lldb-dap was not built with Python support" << '\n';
+    return EXIT_SUCCESS;
+#endif
     auto python_path_or_err = SetupPythonRuntimeLibrary();
     if (!python_path_or_err) {
       llvm::WithColor::error()


### PR DESCRIPTION
This patch runs the `lldb-dap.exe --check-python` command before attempting to start lldb-dap in VSCode.

If the command fails, the extension will display an error as a modal windows.

If lldb-dap was built without Python support, the `lldb-dap.exe --check-python` command now returns 0.

# Example

<img width="961" height="472" alt="Screenshot 2026-05-01 at 17 15 15" src="https://github.com/user-attachments/assets/0351809a-1876-4a88-95e0-ddb6a0bfac18" />

rdar://170221975