### PR TITLE
[AggressiveInstCombine] Create zext during store merge

### DIFF
--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
@@ -915,7 +915,7 @@ static bool mergeConsecutivePartStores(ArrayRef<PartStore> Parts,
   Value *Val = First.Val;
   if (First.ValOffset != 0)
     Val = Builder.CreateLShr(Val, First.ValOffset);
-  Val = Builder.CreateTrunc(Val, NewTy);
+  Val = Builder.CreateZExtOrTrunc(Val, NewTy);
   StoreInst *Store = Builder.CreateAlignedStore(
       Val, First.Store->getPointerOperand(), First.Store->getAlign());
 

--- a/llvm/test/Transforms/AggressiveInstCombine/X86/store-merge.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/X86/store-merge.ll
@@ -881,6 +881,23 @@ define void @test_store_same_parts_twice(i32 %x, ptr %p) {
   ret void
 }
 
+; A case where the resulting store requires a zext.
+define void @test_zext_store(i56 %arg, ptr %p) {
+; CHECK-LABEL: define void @test_zext_store(
+; CHECK-SAME: i56 [[ARG:%.*]], ptr [[P:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = zext i56 [[ARG]] to i64
+; CHECK-NEXT:    store i64 [[TMP1]], ptr [[P]], align 4
+; CHECK-NEXT:    ret void
+;
+  %lo = trunc i56 %arg to i32
+  store i32 %lo, ptr %p, align 4
+  %shr = lshr i56 %arg, 32
+  %hi = trunc i56 %shr to i32
+  %p.4 = getelementptr i8, ptr %p, i64 4
+  store i32 %hi, ptr %p.4, align 4
+  ret void
+}
+
 !0 = !{!1}
 !1 = !{!1, !2}
 !2 = !{!2}


### PR DESCRIPTION
The top extracted value can include shifted-in zero bits. In that case we should emit a zext before the new store.

Fixes https://github.com/llvm/llvm-project/issues/181117.