### PR TITLE
[lldb][test] TestBatchMode.py: don't load lldbinit in --batch test

### DIFF
--- a/lldb/test/API/driver/batch_mode/TestBatchMode.py
+++ b/lldb/test/API/driver/batch_mode/TestBatchMode.py
@@ -19,7 +19,7 @@ class DriverBatchModeTest(PExpectTest):
         """--batch should immediately quit if there are no commands given."""
         try:
             proc = subprocess.run(
-                [lldbtest_config.lldbExec, "--batch"],
+                [lldbtest_config.lldbExec, "--batch", "--no-lldbinit"],
                 timeout=60,
                 stdout=subprocess.PIPE,
                 text=True,


### PR DESCRIPTION
This test was failing locally for me because I command script import statements in my `~/.lldibinit` which print to `stdout`. E.g.,:
```
Traceback (most recent call last):
  File "/Users/michaelbuch/Git/llvm-worktrees/main/lldb/test/API/driver/batch_mode/TestBatchMode.py", line 33, in test_batch_mode_no_commands_quits
    self.assertEqual(proc.stdout, "")
AssertionError: 'The "bt" python commands have been instal[326 chars]p.\n' != ''
- The "bt" python commands have been installed and are ready for use.
- The "sd" python command has been installed and is ready for use.
- The "expr" python aliases have been installed and are ready for use.
- "malloc_info", "ptr_refs", "cstr_refs", "find_variable", and "objc_refs" commands have been installed, use the "--help" options on these commands for detailed help.
```

I guess we could have a separate test for `--batch` with a test-local `.lldibinit` that confirms we actually load the lldbinit before quitting. Not sure how much value that would be. For now I just added the `--no-lldbinit` to the test