### PR TITLE
[llvm-mc-assemble-fuzzer] Fix Triple passing

### DIFF
--- a/llvm/tools/llvm-mc-assemble-fuzzer/llvm-mc-assemble-fuzzer.cpp
+++ b/llvm/tools/llvm-mc-assemble-fuzzer/llvm-mc-assemble-fuzzer.cpp
@@ -155,7 +155,7 @@ int AssembleOneInput(const uint8_t *Data, size_t Size) {
     abort();
   }
 
-  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TheTriple));
   if (!MRI) {
     errs() << "Unable to create target register info!\n";
     abort();
@@ -163,14 +163,14 @@ int AssembleOneInput(const uint8_t *Data, size_t Size) {
 
   MCTargetOptions MCOptions = mc::InitMCTargetOptionsFromFlags();
   std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!MAI) {
     errs() << "Unable to create target asm info!\n";
     abort();
   }
 
   std::unique_ptr<MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TripleName, MCPU, FeaturesStr));
+      TheTarget->createMCSubtargetInfo(TheTriple, MCPU, FeaturesStr));
   if (!STI) {
     errs() << "Unable to create subtargettarget info!\n";
     abort();


### PR DESCRIPTION
The following PR removed deprecated `StringRef` triple APIs, that broke `llvm-mc-assemble-fuzzer`: https://github.com/llvm/llvm-project/pull/180448