### PR TITLE
[clang][bytecode] Don't use throw as invalid in c++26

### DIFF
--- a/clang/test/AST/ByteCode/cxx26.cpp
+++ b/clang/test/AST/ByteCode/cxx26.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -std=c++26 -fsyntax-only -fcxx-exceptions -verify=ref,both %s
-// RUN: %clang_cc1 -std=c++26 -fsyntax-only -fcxx-exceptions -verify=expected,both %s -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -std=c++26 -fsyntax-only -verify=ref,both      %s
+// RUN: %clang_cc1 -std=c++26 -fsyntax-only -verify=expected,both %s -fexperimental-new-constant-interpreter
 
 namespace std {
   using size_t = decltype(sizeof(0));
@@ -49,7 +49,7 @@ static_assert(*f == 12);
 namespace ExplicitThisInBacktrace {
   struct S {
     constexpr void foo(this const S& self) {
-      throw; // both-note {{not valid in a constant expression}}
+      __builtin_abort(); // both-note {{not valid in a constant expression}}
     }
   };
 

--- a/clang/test/AST/ByteCode/placement-new.cpp
+++ b/clang/test/AST/ByteCode/placement-new.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -std=c++2c -fcxx-exceptions -fexperimental-new-constant-interpreter -verify=expected,both %s -DBYTECODE
-// RUN: %clang_cc1 -std=c++2c -fcxx-exceptions -verify=ref,both %s
+// RUN: %clang_cc1 -std=c++2c -fexperimental-new-constant-interpreter -verify=expected,both %s -DBYTECODE
+// RUN: %clang_cc1 -std=c++2c                                         -verify=ref,both %s
 
 typedef __INT64_TYPE__ int64_t;
 namespace std {
@@ -239,7 +239,7 @@ namespace records {
   /// Destructor is NOT called.
   struct A {
     bool b;
-    constexpr ~A() { if (b) throw; }
+    constexpr ~A() { if (b) __builtin_abort(); }
   };
 
   constexpr int foo() {


### PR DESCRIPTION
Don't pass a combination of `-std=c++26` and `-fcxx-exceptions` to tests and then try to use `throw` as an invalid statement. C++26 actually has working exceptions at compile time, even if that is currently not implemented.