### PR TITLE
[MC] Support specifying unwind handler in Masm proc directive

### DIFF
--- a/llvm/lib/MC/MCParser/COFFMasmParser.cpp
+++ b/llvm/lib/MC/MCParser/COFFMasmParser.cpp
@@ -472,6 +472,13 @@ bool COFFMasmParser::parseDirectiveProc(StringRef Directive, SMLoc Loc) {
     Framed = true;
     getStreamer().emitWinCFIStartProc(Sym, Loc);
   }
+  if (Framed && getLexer().is(AsmToken::Colon)) {
+    Lex();
+    MCSymbol *HandlerSym;
+    if (getParser().parseSymbol(HandlerSym))
+      return Error(Loc, "expected identifier for unwind handler");
+    getStreamer().emitWinEHHandler(HandlerSym, true, true, Loc);
+  }
   getStreamer().emitLabel(Sym, Loc);
 
   CurrentProcedures.push_back(Sym->getName());

--- a/llvm/test/tools/llvm-ml/proc_frame_ehandler.asm
+++ b/llvm/test/tools/llvm-ml/proc_frame_ehandler.asm
@@ -1,0 +1,30 @@
+; RUN: llvm-ml64 -filetype=s %s /Fo - | FileCheck %s
+
+.code
+
+t1 PROC FRAME: ehandler
+  push rbp
+  .pushreg rbp
+  mov rbp, rsp
+  .setframe rbp, 0
+  pushfq
+  .allocstack 8
+  .endprolog
+  ret
+t1 ENDP
+
+; CHECK: .seh_proc t1
+; CHECK: .seh_handler ehandler, @unwind, @except
+
+; CHECK: t1:
+; CHECK: push rbp
+; CHECK: .seh_pushreg rbp
+; CHECK: mov rbp, rsp
+; CHECK: .seh_setframe rbp, 0
+; CHECK: pushfq
+; CHECK: .seh_stackalloc 8
+; CHECK: .seh_endprologue
+; CHECK: ret
+; CHECK: .seh_endproc
+
+END


### PR DESCRIPTION
Add support for `PROC FRAME: ehandler` syntax used to specify the seh unwind/exception handler for a function in Masm.