### PR TITLE
[ADT] Allow member pointers in map_range and map_to_vector

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -348,7 +348,7 @@ public:
   const FuncTy &getFunction() const { return F; }
 
   ReferenceTy operator*() const {
-    return llvm::invoke(getFunction(), *this->I);
+    return std::invoke(getFunction(), *this->I);
   }
 
 private:

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -347,9 +347,7 @@ public:
 
   const FuncTy &getFunction() const { return F; }
 
-  ReferenceTy operator*() const {
-    return std::invoke(getFunction(), *this->I);
-  }
+  ReferenceTy operator*() const { return std::invoke(F, *this->I); }
 
 private:
   callable_detail::Callable<FuncTy> F{};

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -347,7 +347,7 @@ public:
 
   const FuncTy &getFunction() const { return F; }
 
-  ReferenceTy operator*() const { F(*this->I); }
+  ReferenceTy operator*() const { return F(*this->I); }
 
 private:
   callable_detail::Callable<FuncTy> F{};

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -219,13 +219,13 @@ public:
   template <typename... Pn,
             std::enable_if_t<std::is_invocable_v<T, Pn...>, int> = 0>
   decltype(auto) operator()(Pn &&...Params) {
-    return (*Obj)(std::forward<Pn>(Params)...);
+    return std::invoke(*Obj, std::forward<Pn>(Params)...);
   }
 
   template <typename... Pn,
             std::enable_if_t<std::is_invocable_v<T const, Pn...>, int> = 0>
   decltype(auto) operator()(Pn &&...Params) const {
-    return (*Obj)(std::forward<Pn>(Params)...);
+    return std::invoke(*Obj, std::forward<Pn>(Params)...);
   }
 
   bool valid() const { return Obj != std::nullopt; }
@@ -347,7 +347,7 @@ public:
 
   const FuncTy &getFunction() const { return F; }
 
-  ReferenceTy operator*() const { return std::invoke(F, *this->I); }
+  ReferenceTy operator*() const { F(*this->I); }
 
 private:
   callable_detail::Callable<FuncTy> F{};

--- a/llvm/include/llvm/ADT/SmallVectorExtras.h
+++ b/llvm/include/llvm/ADT/SmallVectorExtras.h
@@ -34,6 +34,7 @@ auto filter_to_vector(ContainerTy &&C, PredicateFn &&Pred) {
 }
 
 /// Map a range to a SmallVector with element types deduced from the mapping.
+/// \p F can be a function, lambda, or member pointer.
 template <unsigned Size, class ContainerTy, class FuncTy>
 auto map_to_vector(ContainerTy &&C, FuncTy &&F) {
   return to_vector<Size>(
@@ -41,6 +42,7 @@ auto map_to_vector(ContainerTy &&C, FuncTy &&F) {
 }
 
 /// Map a range to a SmallVector with element types deduced from the mapping.
+/// \p F can be a function, lambda, or member pointer.
 template <class ContainerTy, class FuncTy>
 auto map_to_vector(ContainerTy &&C, FuncTy &&F) {
   return to_vector(

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -835,6 +835,22 @@ TEST(STLExtrasTest, DropEndDefaultTest) {
   EXPECT_THAT(drop_end(vec), ElementsAre(0, 1, 2, 3));
 }
 
+TEST(STLExtrasTest, CallableMemberPointer) {
+  struct S {
+    int X;
+    int getX() const { return X; }
+  };
+  S Obj{42};
+
+  // Data member pointer.
+  callable_detail::Callable<int S::*> DataMember(&S::X);
+  EXPECT_EQ(DataMember(Obj), 42);
+
+  // Member function pointer.
+  callable_detail::Callable<int (S::*)() const> MemFn(&S::getX);
+  EXPECT_EQ(MemFn(Obj), 42);
+}
+
 TEST(STLExtrasTest, MapRangeTest) {
   SmallVector<int, 5> Vec{0, 1, 2};
   EXPECT_THAT(map_range(Vec, [](int V) { return V + 1; }),

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -845,6 +845,17 @@ TEST(STLExtrasTest, MapRangeTest) {
   some_namespace::some_struct S;
   S.data = {3, 4, 5};
   EXPECT_THAT(map_range(S, [](int V) { return V * 2; }), ElementsAre(6, 8, 10));
+
+  // Pointer to data member.
+  struct MapRangeStruct {
+    int X;
+    int getX() const { return X; }
+  };
+  std::vector<MapRangeStruct> Structs = {{1}, {2}, {3}};
+  EXPECT_THAT(map_range(Structs, &MapRangeStruct::X), ElementsAre(1, 2, 3));
+
+  // Pointer to member function.
+  EXPECT_THAT(map_range(Structs, &MapRangeStruct::getX), ElementsAre(1, 2, 3));
 }
 
 TEST(STLExtrasTest, EarlyIncrementTest) {

--- a/llvm/unittests/ADT/SmallVectorExtrasTest.cpp
+++ b/llvm/unittests/ADT/SmallVectorExtrasTest.cpp
@@ -22,6 +22,25 @@ using testing::ElementsAre;
 namespace llvm {
 namespace {
 
+TEST(SmallVectorExtrasTest, MapToVector) {
+  std::vector<int> Numbers = {1, 2, 3};
+  auto Doubled = map_to_vector(Numbers, [](int X) { return X * 2; });
+  EXPECT_THAT(Doubled, ElementsAre(2, 4, 6));
+
+  // Pointer to data member.
+  struct MapToVectorStruct {
+    int X;
+    int getX() const { return X; }
+  };
+  std::vector<MapToVectorStruct> Structs = {{1}, {2}, {3}};
+  EXPECT_THAT(map_to_vector(Structs, &MapToVectorStruct::X),
+              ElementsAre(1, 2, 3));
+
+  // Pointer to member function.
+  EXPECT_THAT(map_to_vector(Structs, &MapToVectorStruct::getX),
+              ElementsAre(1, 2, 3));
+}
+
 TEST(SmallVectorExtrasTest, FilterToVector) {
   std::vector<int> Numbers = {0, 1, 2, 3, 4};
   auto Odd = filter_to_vector<2>(Numbers, [](int X) { return (X % 2) != 0; });

--- a/llvm/unittests/ADT/SmallVectorExtrasTest.cpp
+++ b/llvm/unittests/ADT/SmallVectorExtrasTest.cpp
@@ -27,7 +27,7 @@ TEST(SmallVectorExtrasTest, MapToVector) {
   auto Doubled = map_to_vector(Numbers, [](int X) { return X * 2; });
   EXPECT_THAT(Doubled, ElementsAre(2, 4, 6));
 
-  // Pointer to data member.
+  // Member pointer.
   struct MapToVectorStruct {
     int X;
     int getX() const { return X; }
@@ -36,7 +36,7 @@ TEST(SmallVectorExtrasTest, MapToVector) {
   EXPECT_THAT(map_to_vector(Structs, &MapToVectorStruct::X),
               ElementsAre(1, 2, 3));
 
-  // Pointer to member function.
+  // Member function pointer.
   EXPECT_THAT(map_to_vector(Structs, &MapToVectorStruct::getX),
               ElementsAre(1, 2, 3));
 }


### PR DESCRIPTION
This is for when all we need is to access a field or call a getter: no need to write a lambda just to extract these.

Assisted-by: claude