### PR TITLE
[lldb][windows] print an error if Python fails to initialize

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -95,10 +95,12 @@ namespace {
 // save off initial state at the beginning, and restore it at the end
 struct InitializePythonRAII {
 public:
-  void DoInitialize() {
+  llvm::Error DoInitialize() {
+    const bool was_initialized = Py_IsInitialized();
+
     // The table of built-in modules can only be extended before Python is
     // initialized.
-    if (!Py_IsInitialized()) {
+    if (!was_initialized) {
 #ifdef LLDB_USE_LIBEDIT_READLINE_COMPAT_MODULE
       // Python's readline is incompatible with libedit being linked into lldb.
       // Provide a patched version local to the embedded interpreter.
@@ -110,53 +112,63 @@ public:
     }
 
 #if LLDB_EMBED_PYTHON_HOME
-    PyConfig config;
-    PyConfig_InitPythonConfig(&config);
+    if (!was_initialized) {
+      PyConfig config;
+      PyConfig_InitPythonConfig(&config);
 
-    static std::string g_python_home = []() -> std::string {
-      if (llvm::sys::path::is_absolute(LLDB_PYTHON_HOME))
-        return LLDB_PYTHON_HOME;
+      static std::string g_python_home = []() -> std::string {
+        if (llvm::sys::path::is_absolute(LLDB_PYTHON_HOME))
+          return LLDB_PYTHON_HOME;
 
-      FileSpec spec = HostInfo::GetShlibDir();
-      if (!spec)
-        return {};
-      spec.AppendPathComponent(LLDB_PYTHON_HOME);
-      return spec.GetPath();
-    }();
-    if (!g_python_home.empty()) {
-      PyStatus status =
-          PyConfig_SetBytesString(&config, &config.home, g_python_home.c_str());
+        FileSpec spec = HostInfo::GetShlibDir();
+        if (!spec)
+          return {};
+        spec.AppendPathComponent(LLDB_PYTHON_HOME);
+        return spec.GetPath();
+      }();
+      if (!g_python_home.empty()) {
+        PyStatus status = PyConfig_SetBytesString(&config, &config.home,
+                                                  g_python_home.c_str());
+        if (PyStatus_Exception(status)) {
+          PyConfig_Clear(&config);
+          return llvm::createStringError(
+              "failed to set the Python config: '%s'", status.err_msg);
+        }
+      }
+
+      config.install_signal_handlers = 0;
+      PyStatus status = Py_InitializeFromConfig(&config);
+      PyConfig_Clear(&config);
       if (PyStatus_Exception(status))
-        llvm::report_fatal_error(
-            llvm::Twine("failed to set the Python config: '") + status.err_msg +
-            "'");
+        return llvm::createStringError("Python failed to initialize: '%s'",
+                                       status.err_msg);
     }
-
-    config.install_signal_handlers = 0;
-    PyStatus status = Py_InitializeFromConfig(&config);
-    PyConfig_Clear(&config);
-    if (PyStatus_Exception(status))
-      llvm::report_fatal_error(llvm::Twine("Python failed to initialize: '") +
-                               status.err_msg + "'");
 #else
-    Py_InitializeEx(/*install_sigs=*/0);
+    if (!was_initialized)
+      Py_InitializeEx(/*install_sigs=*/0);
     if (!Py_IsInitialized())
-      llvm::report_fatal_error("python failed to initialize");
+      return llvm::createStringError("Python failed to initialize");
 #endif
+
+    m_python_initialized = true;
 
     // The only case we should go further and acquire the GIL: it is unlocked.
     PyGILState_STATE gil_state = PyGILState_Ensure();
     if (gil_state != PyGILState_UNLOCKED)
-      return;
+      return llvm::Error::success();
 
     m_was_already_initialized = true;
     m_gil_state = gil_state;
     LLDB_LOG_VERBOSE(
         GetLog(LLDBLog::Script), "Ensured PyGILState. Previous state = {0}",
         m_gil_state == PyGILState_UNLOCKED ? "unlocked" : "locked");
+    return llvm::Error::success();
   }
 
   ~InitializePythonRAII() {
+    if (!m_python_initialized)
+      return;
+
     if (m_was_already_initialized) {
       LLDB_LOG_VERBOSE(GetLog(LLDBLog::Script),
                        "Releasing PyGILState. Returning to state = {0}",
@@ -172,6 +184,7 @@ public:
 private:
   PyGILState_STATE m_gil_state = PyGILState_UNLOCKED;
   bool m_was_already_initialized = false;
+  bool m_python_initialized = false;
 };
 
 #if LLDB_USE_PYTHON_SET_INTERRUPT
@@ -687,11 +700,20 @@ void ScriptInterpreterPython::Initialize() {
   HostInfo::SetSharedLibraryDirectoryHelper(
       ScriptInterpreterPython::SharedLibraryDirectoryHelper);
 #endif
+
+  // Bring the interpreter up before registering, so a Python that refuses to
+  // initialize leaves no plugin claiming eScriptLanguagePython behind.
+  // GetScriptInterpreterForLanguage then hands out ScriptInterpreterNone and
+  // the rest of lldb keeps working without scripting.
+  if (llvm::Error error = ScriptInterpreterPythonImpl::Initialize()) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Script), std::move(error), "{0}");
+    return;
+  }
+
   PluginManager::RegisterPlugin(
       GetPluginNameStatic(), GetPluginDescriptionStatic(),
       lldb::eScriptLanguagePython, ScriptInterpreterPythonImpl::CreateInstance,
       ScriptInterpreterPythonImpl::GetPythonDir);
-  ScriptInterpreterPythonImpl::Initialize();
   ScriptInterpreterPythonInterfaces::Initialize();
 }
 
@@ -2815,7 +2837,7 @@ ScriptInterpreterPythonImpl::AcquireInterpreterLock() {
   return py_lock;
 }
 
-void ScriptInterpreterPythonImpl::Initialize() {
+llvm::Error ScriptInterpreterPythonImpl::Initialize() {
   LLDB_SCOPED_TIMER();
 
   // RAII-based initialization which correctly handles multiple-initialization,
@@ -2823,7 +2845,8 @@ void ScriptInterpreterPythonImpl::Initialize() {
   // restoring various other pieces of state that can get mucked with during
   // initialization.
   InitializePythonRAII initialize_guard;
-  initialize_guard.DoInitialize();
+  if (llvm::Error error = initialize_guard.DoInitialize())
+    return error;
 
   LLDBSwigPyInit();
 
@@ -2865,6 +2888,7 @@ void ScriptInterpreterPythonImpl::Initialize() {
                   "lldb_setup_sigint_handler();\n"
                   "del lldb_setup_sigint_handler\n");
 #endif
+  return llvm::Error::success();
 }
 
 void ScriptInterpreterPythonImpl::AddToSysPath(AddLocation location,

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -95,7 +95,7 @@ namespace {
 // save off initial state at the beginning, and restore it at the end
 struct InitializePythonRAII {
 public:
-  InitializePythonRAII() {
+  void DoInitialize() {
     // The table of built-in modules can only be extended before Python is
     // initialized.
     if (!Py_IsInitialized()) {
@@ -124,14 +124,24 @@ public:
       return spec.GetPath();
     }();
     if (!g_python_home.empty()) {
-      PyConfig_SetBytesString(&config, &config.home, g_python_home.c_str());
+      PyStatus status =
+          PyConfig_SetBytesString(&config, &config.home, g_python_home.c_str());
+      if (PyStatus_Exception(status))
+        llvm::report_fatal_error(
+            llvm::Twine("failed to set the Python config: '") + status.err_msg +
+            "'");
     }
 
     config.install_signal_handlers = 0;
-    Py_InitializeFromConfig(&config);
+    PyStatus status = Py_InitializeFromConfig(&config);
     PyConfig_Clear(&config);
+    if (PyStatus_Exception(status))
+      llvm::report_fatal_error(llvm::Twine("Python failed to initialize: '") +
+                               status.err_msg + "'");
 #else
     Py_InitializeEx(/*install_sigs=*/0);
+    if (!Py_IsInitialized())
+      llvm::report_fatal_error("python failed to initialize");
 #endif
 
     // The only case we should go further and acquire the GIL: it is unlocked.
@@ -2813,6 +2823,7 @@ void ScriptInterpreterPythonImpl::Initialize() {
   // restoring various other pieces of state that can get mucked with during
   // initialization.
   InitializePythonRAII initialize_guard;
+  initialize_guard.DoInitialize();
 
   LLDBSwigPyInit();
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
@@ -273,7 +273,7 @@ public:
   static bool WatchpointCallbackFunction(void *baton,
                                          StoppointCallbackContext *context,
                                          lldb::user_id_t watch_id);
-  static void Initialize();
+  static llvm::Error Initialize();
 
   class SynchronicityHandler {
   private:


### PR DESCRIPTION
Add checks around the `Py_init*` calls to check if Python was initialized correctly. If any of the calls fails, print an error and return early.

Python will fail to initialize if `%SystemRoot%` is not defined which causes lldb to crash. This patch prints an error if the initialization fails and returns early. lldb still crashes but gives a clue as to why that's the case.

rdar://168004280