### PR TITLE
[CIR] Upstream support for function/call calling conventions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -41,6 +41,7 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getNoThrowAttrName() { return "nothrow"; }
     static llvm::StringRef getNoReturnAttrName() { return "noreturn"; }
     static llvm::StringRef getSideEffectAttrName() { return "side_effect"; }
+    static llvm::StringRef getCallingConvAttrName() { return "calling_conv"; }
     static llvm::StringRef getReturnsTwiceAttrName() { return "returns_twice"; }
     static llvm::StringRef getColdAttrName() { return "cold"; }
     static llvm::StringRef getHotAttrName() { return "hot"; }

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3091,9 +3091,16 @@ def CIR_OptionalPriorityAttr : OptionalAttr<
   >
 >;
 
-// TODO(CIR): CallingConv is a placeholder here so we can use it in
-// infrastructure calls, but it currently has no values.
-def CIR_CallingConv : CIR_I32EnumAttr<"CallingConv", "calling convention", []>;
+// The enumeration values are not necessarily in sync with `clang::CallingConv`
+// or `llvm::CallingConv`.
+def CIR_CallingConv : CIR_I32EnumAttr<"CallingConv", "calling convention", [
+  I32EnumAttrCase<"C", 1, "c">,
+  I32EnumAttrCase<"SpirKernel", 2, "spir_kernel">,
+  I32EnumAttrCase<"SpirFunction", 3, "spir_function">,
+  I32EnumAttrCase<"OpenCLKernel", 4, "opencl_kernel">,
+  I32EnumAttrCase<"PTXKernel", 5, "ptx_kernel">,
+  I32EnumAttrCase<"AMDGPUKernel", 6, "amdgpu_kernel">
+]>;
 
 def CIR_FuncOp : CIR_Op<"func", [
   AutomaticAllocationScope, CallableOpInterface, FunctionOpInterface,
@@ -3108,6 +3115,9 @@ def CIR_FuncOp : CIR_Op<"func", [
 
     The function linkage information is specified by `linkage`, as defined by
     `GlobalLinkageKind` attribute.
+
+    The `calling_conv` attribute specifies the calling convention of the
+    function. The default calling convention is `CallingConv::C`.
 
     A compiler builtin function must be marked as `builtin` for further
     processing when lowering from CIR.
@@ -3178,6 +3188,9 @@ def CIR_FuncOp : CIR_Op<"func", [
       CIR_GlobalLinkageKind,
       "cir::GlobalLinkageKind::ExternalLinkage"
     >:$linkage,
+    DefaultValuedAttr<
+      CIR_CallingConv, "CallingConv::C"
+    >:$calling_conv,
     OptionalAttr<StrAttr>:$sym_visibility,
     UnitAttr:$comdat,
     OptionalAttr<DictArrayAttr>:$arg_attrs,
@@ -3364,6 +3377,7 @@ class CIR_CallOpBase<string mnemonic, list<Trait> extra_traits = []>
 
   dag commonArgs = (ins OptionalAttr<FlatSymbolRefAttr>:$callee,
       Variadic<CIR_AnyType>:$args,
+      DefaultValuedAttr<CIR_CallingConv, "CallingConv::C">:$calling_conv,
       UnitAttr:$nothrow,
       DefaultValuedAttr<CIR_SideEffect, "SideEffect::All">:$side_effect);
 }

--- a/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/CIROpInterfaces.td
@@ -34,6 +34,9 @@ let cppNamespace = "::cir" in {
           "Return the number of operands, accounts for indirect call or "
           "exception info",
           "unsigned", "getNumArgOperands", (ins)>,
+      InterfaceMethod<
+          "Return the calling convention of the call operation",
+          "cir::CallingConv", "getCallingConv", (ins)>,
       InterfaceMethod<"Return whether the callee is nothrow",
                       "bool", "getNothrow", (ins)>,
       InterfaceMethod<"Return the side effects of the call operation",

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -71,7 +71,7 @@ struct MissingFeatures {
   static bool opFuncArmNewAttr() { return false; }
   static bool opFuncArmStreamingAttr() { return false; }
   static bool opFuncAstDeclAttr() { return false; }
-  static bool opFuncCallingConv() { return false; }
+  static bool opFuncCallingConv() { return true; }
   static bool opFuncColdHotAttr() { return false; }
   static bool opFuncCPUAndFeaturesAttributes() { return false; }
   static bool opFuncExceptions() { return false; }
@@ -103,7 +103,7 @@ struct MissingFeatures {
   static bool opCallImplicitObjectSizeArgs() { return false; }
   static bool opCallReturn() { return false; }
   static bool opCallArgEvaluationOrder() { return false; }
-  static bool opCallCallConv() { return false; }
+  static bool opCallCallConv() { return true; }
   static bool opCallSideEffect() { return false; }
   static bool opCallMustTail() { return false; }
   static bool opCallInAlloca() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -1891,18 +1891,12 @@ mlir::Value CIRGenItaniumCXXABI::getVirtualBaseClassOffset(
 static cir::FuncOp getBadCastFn(CIRGenFunction &cgf) {
   // Prototype: void __cxa_bad_cast();
 
-  // TODO(cir): set the calling convention of the runtime function.
-  assert(!cir::MissingFeatures::opFuncCallingConv());
-
   cir::FuncType fnTy =
       cgf.getBuilder().getFuncType({}, cgf.getBuilder().getVoidTy());
   return cgf.cgm.createRuntimeFunction(fnTy, "__cxa_bad_cast");
 }
 
 static void emitCallToBadCast(CIRGenFunction &cgf, mlir::Location loc) {
-  // TODO(cir): set the calling convention to the runtime function.
-  assert(!cir::MissingFeatures::opFuncCallingConv());
-
   cgf.emitRuntimeCall(loc, getBadCastFn(cgf));
   cir::UnreachableOp::create(cgf.getBuilder(), loc);
   cgf.getBuilder().clearInsertionPoint();
@@ -1980,9 +1974,6 @@ static cir::FuncOp getItaniumDynamicCastFn(CIRGenFunction &cgf) {
   assert(!cir::MissingFeatures::opFuncNoUnwind());
   assert(!cir::MissingFeatures::opFuncWillReturn());
   assert(!cir::MissingFeatures::opFuncReadOnly());
-
-  // TODO(cir): set the calling convention of the runtime function.
-  assert(!cir::MissingFeatures::opFuncCallingConv());
 
   cir::FuncType FTy = cgf.getBuilder().getFuncType(
       {voidPtrTy, rttiPtrTy, rttiPtrTy, ptrDiffTy}, voidPtrTy);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2232,11 +2232,7 @@ void CIRGenModule::setCIRFunctionAttributes(GlobalDecl globalDecl,
 
   // TODO(cir): Check X86_VectorCall incompatibility wiht WinARM64EC
 
-  // TODO(cir): typically the calling conv is set right here, but since
-  // cir::CallingConv is empty and we've not yet added calling-conv to FuncOop,
-  // this isn't really useful here.  This should call func.setCallingConv/etc
-  // later.
-  assert(!cir::MissingFeatures::opFuncCallingConv());
+  func.setCallingConv(callingConv);
 }
 
 void CIRGenModule::setFunctionAttributes(GlobalDecl globalDecl,
@@ -2638,7 +2634,6 @@ cir::FuncOp CIRGenModule::createRuntimeFunction(cir::FuncType ty,
   if (entry) {
     // TODO(cir): set the attributes of the function.
     assert(!cir::MissingFeatures::setLLVMFunctionFEnvAttributes());
-    assert(!cir::MissingFeatures::opFuncCallingConv());
     setWindowsItaniumDLLImport(*this, isLocal, entry, name);
     entry.setDSOLocal(true);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.h
@@ -120,6 +120,9 @@ public:
 
   const CIRGenRecordLayout &getCIRGenRecordLayout(const clang::RecordDecl *rd);
 
+  /// Convert clang calling convention to CIR calling convention.
+  cir::CallingConv ClangCallConvToCIRCallConv(clang::CallingConv cc);
+
   /// Convert type T into an mlir::Type. This differs from convertType in that
   /// it is used to convert to the memory representation for a type. For
   /// example, the scalar representation for bool is i1, but the memory

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -67,6 +67,10 @@ class NVPTXTargetCIRGenInfo : public TargetCIRGenInfo {
 public:
   NVPTXTargetCIRGenInfo(CIRGenTypes &cgt)
       : TargetCIRGenInfo(std::make_unique<NVPTXABIInfo>(cgt)) {}
+
+  cir::CallingConv getDeviceKernelCallingConv() const override {
+    return cir::CallingConv::PTXKernel;
+  }
 };
 } // namespace
 

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -52,6 +52,11 @@ public:
     return {};
   }
 
+  /// Get CIR calling convention for functions using CC_DeviceKernel.
+  virtual cir::CallingConv getDeviceKernelCallingConv() const {
+    return cir::CallingConv::C;
+  }
+
   /// Determine whether a call to an unprototyped functions under
   /// the given calling convention should use the variadic
   /// convention or the non-variadic convention.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -189,7 +189,8 @@ convertCallingConv(cir::CallingConv callingConv) {
   case CIR::SpirFunction:
     return LLVM::SPIR_FUNC;
   case CIR::OpenCLKernel:
-    llvm_unreachable("NYI");
+    // TODO(cir): Implement OpenCL kernel calling convention lowering.
+    return std::nullopt;
   case CIR::PTXKernel:
     return LLVM::PTX_Kernel;
   case CIR::AMDGPUKernel:

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -27,8 +27,6 @@ mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::Attribute attr,
                                 mlir::ConversionPatternRewriter &rewriter,
                                 const mlir::TypeConverter *converter);
 
-mlir::LLVM::Linkage convertLinkage(cir::GlobalLinkageKind linkage);
-
 void convertSideEffectForCall(mlir::Operation *callOp, bool isNothrow,
                               cir::SideEffect sideEffect,
                               mlir::LLVM::MemoryEffectsAttr &memoryEffect,

--- a/clang/test/CIR/CodeGen/call-conv-device-kernel.c
+++ b/clang/test/CIR/CodeGen/call-conv-device-kernel.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x c -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x c -fclangir -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c -fclangir -emit-cir %s -o %t.x86.cir
+// RUN: FileCheck --input-file=%t.x86.cir %s --check-prefix=X86-CIR --implicit-check-not='cc(spir_kernel)'
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c -fclangir -emit-llvm %s -o %t.x86.ll
+// RUN: FileCheck --input-file=%t.x86.ll %s --check-prefix=X86-LLVM --implicit-check-not=spir_kernel
+
+__attribute__((device_kernel)) void k(void) {}
+
+// CIR: cir.func {{.*}} @k() cc(ptx_kernel)
+// LLVM: define{{.*}} ptx_kernel void @k()
+// X86-CIR: cir.func {{.*}} @k()
+// X86-LLVM: define{{.*}} void @k()

--- a/clang/test/CIR/CodeGen/call-conv-unsupported.c
+++ b/clang/test/CIR/CodeGen/call-conv-unsupported.c
@@ -1,0 +1,5 @@
+// RUN: not %clang_cc1 -triple i686-unknown-linux-gnu -fclangir -emit-cir %s -o /dev/null 2>&1 | FileCheck %s
+
+int __attribute__((stdcall)) foo(int x) { return x; }
+
+// CHECK: error: ClangIR code gen Not Yet Implemented: unsupported calling convention: stdcall

--- a/clang/test/CIR/IR/call-op-call-conv.cir
+++ b/clang/test/CIR/IR/call-op-call-conv.cir
@@ -1,0 +1,19 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!fnptr = !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+
+module {
+  cir.func @my_add(%a: !s32i, %b: !s32i) -> !s32i cc(spir_function) {
+    %c = cir.binop(add, %a, %b) : !s32i
+    cir.return %c : !s32i
+  }
+
+  // CHECK: %{{[0-9]+}} = cir.call %{{.*}}(%{{.*}}) : (!cir.ptr<!cir.func<(!s32i) -> !s32i>>, !s32i) -> !s32i cc(spir_kernel)
+  // CHECK: %{{[0-9]+}} = cir.call %{{.*}}(%{{.*}}) : (!cir.ptr<!cir.func<(!s32i) -> !s32i>>, !s32i) -> !s32i cc(spir_function)
+  cir.func @ind(%fnptr: !fnptr, %a : !s32i) {
+    %1 = cir.call %fnptr(%a) : (!fnptr, !s32i) -> !s32i cc(spir_kernel)
+    %2 = cir.call %fnptr(%a) : (!fnptr, !s32i) -> !s32i cc(spir_function)
+    cir.return
+  }
+}

--- a/clang/test/CIR/IR/func-call-conv.cir
+++ b/clang/test/CIR/IR/func-call-conv.cir
@@ -1,0 +1,23 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+
+module {
+  // CHECK: cir.func @foo()
+  cir.func @foo() cc(c) {
+    cir.return
+  }
+
+  // CHECK: cir.func @bar() cc(spir_kernel)
+  cir.func @bar() cc(spir_kernel) {
+    cir.return
+  }
+
+  // CHECK: cir.func @bar_alias() alias(@bar) cc(spir_kernel)
+  cir.func @bar_alias() alias(@bar) cc(spir_kernel)
+
+  // CHECK: cir.func no_inline @baz() cc(spir_function)
+  cir.func no_inline @baz() cc(spir_function) {
+    cir.return
+  }
+}

--- a/clang/test/CIR/IR/invalid-func.cir
+++ b/clang/test/CIR/IR/invalid-func.cir
@@ -1,4 +1,4 @@
-// RUN: cir-opt %s -verify-diagnostics
+// RUN: cir-opt %s -verify-diagnostics -split-input-file
 
 module {
   cir.func @l0() {
@@ -6,6 +6,29 @@ module {
   }
 
   cir.func @l1() alias(@l0) { // expected-error {{function alias shall not have a body}}
+    cir.return
+  }
+}
+
+// -----
+
+module {
+  cir.func @subroutine() cc(spir_function) {
+    cir.return
+  }
+
+  cir.func @call_conv_mismatch() {
+    // expected-error @+1 {{'cir.call' op calling convention mismatch: expected spir_function, but provided spir_kernel}}
+    cir.call @subroutine() : () -> () cc(spir_kernel)
+    cir.return
+  }
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{unknown calling convention}}
+  cir.func @foo() cc(foobar) {
     cir.return
   }
 }

--- a/clang/test/CIR/Lowering/call-conv-opencl-kernel.cir
+++ b/clang/test/CIR/Lowering/call-conv-opencl-kernel.cir
@@ -1,0 +1,9 @@
+// RUN: cir-opt %s --cir-to-llvm -verify-diagnostics
+
+module {
+  // expected-error @below {{'cir.func' op unsupported calling convention for LLVM lowering: opencl_kernel}}
+  // expected-error @below {{failed to legalize operation 'cir.func' that was explicitly marked illegal}}
+  cir.func @kernel() cc(opencl_kernel) {
+    cir.return
+  }
+}

--- a/clang/test/CIR/Lowering/call-op-call-conv.cir
+++ b/clang/test/CIR/Lowering/call-op-call-conv.cir
@@ -1,0 +1,19 @@
+// RUN: cir-translate -cir-to-llvmir --disable-cc-lowering %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
+
+!s32i = !cir.int<s, 32>
+!fnptr = !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+
+module {
+  cir.func private @my_add(%a: !s32i, %b: !s32i) -> !s32i cc(spir_function)
+
+  cir.func @ind(%fnptr: !fnptr, %a : !s32i) {
+    // LLVM: %{{[0-9]+}} = call spir_func i32 %{{[0-9]+}}(i32 %{{[0-9]+}})
+    %1 = cir.call %fnptr(%a) : (!fnptr, !s32i) -> !s32i cc(spir_function)
+
+    // LLVM: %{{[0-9]+}} = call spir_func i32 @my_add(i32 %{{[0-9]+}}, i32 %{{[0-9]+}})
+    %2 = cir.call @my_add(%1, %1) : (!s32i, !s32i) -> !s32i cc(spir_function)
+
+    cir.return
+  }
+}

--- a/clang/test/CIR/Lowering/func-call-conv.cir
+++ b/clang/test/CIR/Lowering/func-call-conv.cir
@@ -1,0 +1,18 @@
+// RUN: cir-opt %s --cir-to-llvm | FileCheck %s
+
+module {
+  // CHECK: llvm.func @foo()
+  cir.func @foo() cc(c) {
+    cir.return
+  }
+
+  // CHECK: llvm.func{{( spir_kernelcc @bar\(\)| @bar\(\).*spir_kernelcc)}}
+  cir.func @bar() cc(spir_kernel) {
+    cir.return
+  }
+
+  // CHECK: llvm.func{{( spir_funccc @baz\(\)| @baz\(\).*spir_funccc)}}
+  cir.func @baz() cc(spir_function) {
+    cir.return
+  }
+}


### PR DESCRIPTION
related: https://github.com/llvm/llvm-project/issues/175871, https://github.com/llvm/llvm-project/issues/179278

Add CIR calling convention enum values and propagate `calling_conv` through `cir.func` and `cir.call`.
Propagate AST calling conventions in CIR codegen (including device kernel mapping).
Lower supported calling conventions to LLVM for both functions and calls.
Add IR/CodeGen/Lowering tests for both supported and unsupported cases.