### PR TITLE
[Tablegen] Patch RegUnitIntervals Initialization

### DIFF
--- a/llvm/test/TableGen/regunit-intervals.td
+++ b/llvm/test/TableGen/regunit-intervals.td
@@ -32,6 +32,9 @@ let Namespace = "Test" in {
 }
 
 // CHECK: extern const unsigned TestTargetRegUnitIntervals[][2] = {
+// Sentinel
+// CHECK-NEXT: { 0, 0 },
+// Real values
 // CHECK-NEXT: { 0, 1 },
 // CHECK-NEXT: { 1, 2 },
 // CHECK-NEXT: { 2, 3 },

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -1031,6 +1031,8 @@ void RegisterInfoEmitter::runMCDesc(raw_ostream &OS, raw_ostream &MainOS,
   if (Target.getRegistersAreIntervals()) {
     OS << "extern const unsigned " << TargetName
        << "RegUnitIntervals[][2] = {\n";
+    // Add entry for NoRegister
+    OS << "  { 0, 0 },\n";
     for (const CodeGenRegister &Reg : Regs) {
       const auto &Units = Reg.getNativeRegUnits();
       if (Units.empty()) {
@@ -1133,7 +1135,10 @@ void RegisterInfoEmitter::runMCDesc(raw_ostream &OS, raw_ostream &MainOS,
      << TargetName << "LaneMaskLists, " << TargetName << "RegStrings, "
      << TargetName << "RegClassStrings, " << TargetName << "SubRegIdxLists, "
      << (llvm::size(SubRegIndices) + 1) << ",\n"
-     << TargetName << "RegEncodingTable);\n\n";
+     << TargetName << "RegEncodingTable, "
+     << (Target.getRegistersAreIntervals() ? TargetName + "RegUnitIntervals"
+                                           : "nullptr")
+     << ");\n\n";
 
   EmitRegMapping(OS, Regs, false);
 
@@ -1670,6 +1675,8 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
   OS << "extern const MCPhysReg " << TargetName << "RegUnitRoots[][2];\n";
   OS << "extern const uint16_t " << TargetName << "SubRegIdxLists[];\n";
   OS << "extern const uint16_t " << TargetName << "RegEncodingTable[];\n";
+  if (Target.getRegistersAreIntervals())
+    OS << "extern const unsigned " << TargetName << "RegUnitIntervals[][2];\n";
 
   EmitRegMappingTables(OS, Regs, true);
 
@@ -1695,7 +1702,11 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
      << "                     " << TargetName << "RegClassStrings,\n"
      << "                     " << TargetName << "SubRegIdxLists,\n"
      << "                     " << SubRegIndicesSize + 1 << ",\n"
-     << "                     " << TargetName << "RegEncodingTable);\n\n";
+     << "                     " << TargetName << "RegEncodingTable,\n"
+     << "                     "
+     << (Target.getRegistersAreIntervals() ? TargetName + "RegUnitIntervals"
+                                           : "nullptr")
+     << ");\n\n";
 
   EmitRegMapping(OS, Regs, true);
 


### PR DESCRIPTION
There were a few places it was missing some code-generation to properly initialize it if enabled, and also it was missing the sentinel value.