### PR TITLE
[NFC] Fix ctad warning in CompilerInstance

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1998,7 +1998,7 @@ CompilerInstance::loadModule(SourceLocation ImportLoc,
         PPCb->moduleLoadSkipped(Module);
       // Mark the module and its submodules as if they were loaded from a PCM.
       // This prevents emission of the "missing submodule" diagnostic below.
-      std::vector Worklist{Module};
+      std::vector<decltype(Module)> Worklist{Module};
       while (!Worklist.empty()) {
         auto *M = Worklist.back();
         Worklist.pop_back();


### PR DESCRIPTION
Fix warning:

'std::vector' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]
 2030 |       std::vector Worklist{Module};
