### PR TITLE
Update mailmap entry

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -32,7 +32,7 @@
 Min Hsu <min.hsu@sifive.com> <min@myhsu.dev>
 Min Hsu <min.hsu@sifive.com> <minyihh@uci.edu>
 <qcf@ecnelises.com> <qiucofan@cn.ibm.com> <qiucf@cn.ibm.com>
-<rnk@llvm.org> <rnk@nvidia.com> <rnk@google.com> <reid@kleckner.net>
+<rnk@llvm.org> <rkleckner@nvidia.com> <rnk@google.com> <reid@kleckner.net>
 <thakis@chromium.org> <nicolasweber@gmx.de>
 Jianjian GUAN <jacquesguan@me.com>
 Jianjian GUAN <jacquesguan@me.com> <Jianjian.Guan@streamcomputing.com>


### PR DESCRIPTION
4a0a2057a8f317836fa60f63fa9a0794faa32873 added the rnk@nvidia.com to the mailmap, but this seems like a typo. The address does not exist and rkleckner@nvidia.com is what has been showing up in the commit logs.

(Found while Petr was trying to reach out to setup the Infra area team meeting).