### PR TITLE
[Github] Make prune-unused-branches workflow save branch list

### DIFF
--- a/.github/workflows/prune-branches.yml
+++ b/.github/workflows/prune-branches.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Upload Branch List
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: BranchDiffs
+          name: BranchList
           retention-days: 90
           path: branches.txt

--- a/.github/workflows/prune-branches.yml
+++ b/.github/workflows/prune-branches.yml
@@ -30,10 +30,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir patches
-          python3 .github/workflows/prune-unused-branches.py patches/
+          python3 .github/workflows/prune-unused-branches.py .
       - name: Upload Patches
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: BranchDiffs
           retention-days: 90
           path: patches/*.patch
+      - name: Upload Branch List
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: BranchDiffs
+          retention-days: 90
+          path: branches.txt

--- a/.github/workflows/prune-unused-branches.py
+++ b/.github/workflows/prune-unused-branches.py
@@ -136,7 +136,9 @@ def main(github_token):
         user_branches, user_branches_from_prs
     )
     print(f"Deleting {len(user_branches_to_remove)} user branches.")
-    generate_patches_for_all_branches(user_branches_to_remove, os.path.join(output_dir, "patches"))
+    generate_patches_for_all_branches(
+        user_branches_to_remove, os.path.join(output_dir, "patches")
+    )
     delete_branches(user_branches_to_remove)
 
 

--- a/.github/workflows/prune-unused-branches.py
+++ b/.github/workflows/prune-unused-branches.py
@@ -128,7 +128,7 @@ def main(github_token):
     user_branches = get_branches()
     output_dir = sys.argv[1]
     with open(os.path.join(output_dir, "branches.txt"), "w") as branches_file:
-        branches_file.writelines(user_branches)
+        branches_file.writelines([user_branch + "\n" for user_branch in user_branches])
     user_branches_from_prs = get_branches_from_open_prs(github_token)
     print(f"Found {len(user_branches)} user branches in the repository")
     print(f"Found {len(user_branches_from_prs)} user branches associated with PRs")

--- a/.github/workflows/prune-unused-branches.py
+++ b/.github/workflows/prune-unused-branches.py
@@ -121,11 +121,14 @@ def delete_branches(branches_to_remove: list[str]):
 def main(github_token):
     if len(sys.argv) != 2:
         print(
-            "Invalid invocation. Correct usage: python3 prune-unused-branches.py <patch output diectory>"
+            "Invalid invocation. Correct usage: python3 prune-unused-branches.py <output diectory>"
         )
         sys.exit(1)
 
     user_branches = get_branches()
+    output_dir = sys.argv[1]
+    with open(os.path.join(output_dir, "branches.txt"), "w") as branches_file:
+        branches_file.writelines(user_branches)
     user_branches_from_prs = get_branches_from_open_prs(github_token)
     print(f"Found {len(user_branches)} user branches in the repository")
     print(f"Found {len(user_branches_from_prs)} user branches associated with PRs")
@@ -133,7 +136,7 @@ def main(github_token):
         user_branches, user_branches_from_prs
     )
     print(f"Deleting {len(user_branches_to_remove)} user branches.")
-    generate_patches_for_all_branches(user_branches_to_remove, sys.argv[1])
+    generate_patches_for_all_branches(user_branches_to_remove, os.path.join(output_dir, "patches"))
     delete_branches(user_branches_to_remove)
 
 


### PR DESCRIPTION
So that we can retrieve it later to only download branches that are more than a day old. This prevents unlikely but potential race conditions for tools like spr and graphite, but more importantly for people manually creating user branches where there branch getting deleted by the workflow would be surprising.