### PR TITLE
[lldb] Enable caching for BytecodeSyntheticChildren::FrontEnd::Update

### DIFF
--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -293,12 +293,33 @@ lldb::ChildCacheState BytecodeSyntheticChildren::FrontEnd::Update() {
     return ChildCacheState::eRefetch;
   }
 
+  std::optional<ChildCacheState> can_reuse = std::nullopt;
+  const FormatterBytecode::DataStackElement &top = data.back();
+  if (auto *u = std::get_if<uint64_t>(&top))
+    if (*u == 0 || *u == 1)
+      can_reuse = static_cast<ChildCacheState>(*u);
+  if (auto *i = std::get_if<int64_t>(&top))
+    if (*i == 0 || *i == 1)
+      can_reuse = static_cast<ChildCacheState>(*i);
+
+  if (can_reuse) {
+    data.pop_back();
+    LLDB_LOG(
+        GetLog(LLDBLog::DataFormatters),
+        "Bytecode formatter can reuse @update: {0} (type: `{1}`, name: `{2}`)",
+        can_reuse ? "true" : "false", m_backend.GetDisplayTypeName(),
+        m_backend.GetName());
+  } else {
+    LLDB_LOG(GetLog(LLDBLog::DataFormatters),
+             "Bytecode formatter did not return a valid reuse response from "
+             "@update (type: `{1}`, name: `{2}`)",
+             m_backend.GetDisplayTypeName(), m_backend.GetName());
+  }
+
   if (data.size() > 0)
     m_self = std::move(data);
 
-  // At this time it is assumed that synthetic bytecode formatters can always
-  // reuse the work performed in `update`.
-  return ChildCacheState::eReuse;
+  return can_reuse.value_or(ChildCacheState::eRefetch);
 }
 
 llvm::Expected<uint32_t>

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -22,7 +22,6 @@
 #include "lldb/Utility/StreamString.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
-#include <optional>
 
 using namespace lldb;
 using namespace lldb_private;
@@ -294,41 +293,12 @@ lldb::ChildCacheState BytecodeSyntheticChildren::FrontEnd::Update() {
     return ChildCacheState::eRefetch;
   }
 
-  // If the top of the stack is a 0 or 1, that value is popped of the stack and
-  // treated as a return value of eRefetch or eReuse respectively. If the top of
-  // the stack is any other value, it stays on the stack and becomes part of
-  // `self`.
-  //
-  // This dynamic logic can lead to errors for synthetic formatter authors.
-  // Consider the case where an `update` implementation places the number of
-  // children last on the stack. LLDB will _sometimes_ (but not always) consume
-  // that value as a ChildCacheState value. This would cause downstream problems
-  // in `num_children`, because the count won't be on the stack.
-  //
-  // Bytecode authors are encouraged to explicitly push a ChildCacheState value
-  // on to the stack.
-  std::optional<ChildCacheState> cache_state = std::nullopt;
-  const FormatterBytecode::DataStackElement &top = data.back();
-  if (auto *u = std::get_if<uint64_t>(&top))
-    if (*u == 0 || *u == 1)
-      cache_state = static_cast<ChildCacheState>(*u);
-  if (auto *i = std::get_if<int64_t>(&top))
-    if (*i == 0 || *i == 1)
-      cache_state = static_cast<ChildCacheState>(*i);
-
-  if (cache_state) {
-    data.pop_back();
-    if (cache_state == ChildCacheState::eReuse)
-      LLDB_LOG(GetLog(LLDBLog::DataFormatters),
-               "Bytecode formatter returned eReuse from `update` (type: `{0}`, "
-               "name: `{1}`)",
-               m_backend.GetDisplayTypeName(), m_backend.GetName());
-  }
-
   if (data.size() > 0)
     m_self = std::move(data);
 
-  return cache_state.value_or(ChildCacheState::eRefetch);
+  // At this time it is assumed that synthetic bytecode formatters can always
+  // reuse the work performed in `update`.
+  return ChildCacheState::eReuse;
 }
 
 llvm::Expected<uint32_t>

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -22,6 +22,7 @@
 #include "lldb/Utility/StreamString.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
+#include <optional>
 
 using namespace lldb;
 using namespace lldb_private;
@@ -293,10 +294,41 @@ lldb::ChildCacheState BytecodeSyntheticChildren::FrontEnd::Update() {
     return ChildCacheState::eRefetch;
   }
 
+  // If the top of the stack is a 0 or 1, that value is popped of the stack and
+  // treated as a return value of eRefetch or eReuse respectively. If the top of
+  // the stack is any other value, it stays on the stack and becomes part of
+  // `self`.
+  //
+  // This dynamic logic can lead to errors for synthetic formatter authors.
+  // Consider the case where an `update` implementation places the number of
+  // children last on the stack. LLDB will _sometimes_ (but not always) consume
+  // that value as a ChildCacheState value. This would cause downstream problems
+  // in `num_children`, because the count won't be on the stack.
+  //
+  // Bytecode authors are encouraged to explicitly push a ChildCacheState value
+  // on to the stack.
+  std::optional<ChildCacheState> cache_state = std::nullopt;
+  const FormatterBytecode::DataStackElement &top = data.back();
+  if (auto *u = std::get_if<uint64_t>(&top))
+    if (*u == 0 || *u == 1)
+      cache_state = static_cast<ChildCacheState>(*u);
+  if (auto *i = std::get_if<int64_t>(&top))
+    if (*i == 0 || *i == 1)
+      cache_state = static_cast<ChildCacheState>(*i);
+
+  if (cache_state) {
+    data.pop_back();
+    if (cache_state == ChildCacheState::eReuse)
+      LLDB_LOG(GetLog(LLDBLog::DataFormatters),
+               "Bytecode formatter returned eReuse from `update` (type: `{0}`, "
+               "name: `{1}`)",
+               m_backend.GetDisplayTypeName(), m_backend.GetName());
+  }
+
   if (data.size() > 0)
     m_self = std::move(data);
 
-  return ChildCacheState::eRefetch;
+  return cache_state.value_or(ChildCacheState::eRefetch);
 }
 
 llvm::Expected<uint32_t>

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
@@ -5,7 +5,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-
     @skipUnlessDarwin
     def test_synthetic(self):
         self.build()

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
@@ -5,8 +5,9 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
+
     @skipUnlessDarwin
-    def test(self):
+    def test_synthetic(self):
         self.build()
         if self.TraceOn():
             self.expect("log enable -v lldb formatters")
@@ -21,3 +22,21 @@ class TestCase(TestBase):
         self.assertEqual(account.child[0].name, "username")
 
         self.expect("v acc", matching=False, substrs=["password"])
+
+    @skipUnlessDarwin
+    def test_update_reuse(self):
+        self.build()
+
+        log = self.getBuildArtifact("formatter.log")
+        self.runCmd(f"log enable lldb formatters -f {log}")
+
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        frame = thread.selected_frame
+        account = frame.var("acc")
+        self.assertEqual(account.num_children, 1)
+
+        self.filecheck(f"platform shell cat {log}", __file__)
+        # CHECK: Bytecode formatter returned eReuse from `update` (type: `Account`, name: `acc`)

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
@@ -6,7 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @skipUnlessDarwin
-    def test_synthetic(self):
+    def test(self):
         self.build()
         if self.TraceOn():
             self.expect("log enable -v lldb formatters")
@@ -21,21 +21,3 @@ class TestCase(TestBase):
         self.assertEqual(account.child[0].name, "username")
 
         self.expect("v acc", matching=False, substrs=["password"])
-
-    @skipUnlessDarwin
-    def test_update_reuse(self):
-        self.build()
-
-        log = self.getBuildArtifact("formatter.log")
-        self.runCmd(f"log enable lldb formatters -f {log}")
-
-        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec("main.cpp")
-        )
-
-        frame = thread.selected_frame
-        account = frame.var("acc")
-        self.assertEqual(account.num_children, 1)
-
-        self.filecheck(f"platform shell cat {log}", __file__)
-        # CHECK: Bytecode formatter returned eReuse from `update` (type: `Account`, name: `acc`)

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
@@ -6,7 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @skipUnlessDarwin
-    def test(self):
+    def test_synthetic(self):
         self.build()
         if self.TraceOn():
             self.expect("log enable -v lldb formatters")
@@ -21,3 +21,21 @@ class TestCase(TestBase):
         self.assertEqual(account.child[0].name, "username")
 
         self.expect("v acc", matching=False, substrs=["password"])
+
+    @skipUnlessDarwin
+    def test_update_reuse(self):
+        self.build()
+
+        log = self.getBuildArtifact("formatter.log")
+        self.runCmd(f"log enable lldb formatters -f {log}")
+
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        frame = thread.selected_frame
+        account = frame.var("acc")
+        self.assertEqual(account.num_children, 1)
+
+        self.filecheck(f"platform shell cat {log}", __file__)
+        # CHECK: Bytecode formatter can reuse @update: true (type: `Account`, name: `acc`)

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/main.cpp
@@ -16,10 +16,13 @@ int main(int argc, char **argv) {
 __attribute__((used, section("__DATA_CONST,__lldbformatters"))) unsigned char
     _Account_synthetic[] =
         "\x01"          // version
-        "\x12"          // remaining record size
+        "\x16"          // remaining record size
         "\x07"          // type name size
         "Account"       // type name
         "\x00"          // flags
+        "\x06"          // sig_update
+        "\x02"          // program size
+        "\x20\x01"      // `return eReuse`
         "\x02"          // sig_get_num_children
         "\x02"          // program size
         "\x20\x01"      // `return 1`

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/main.cpp
@@ -16,13 +16,10 @@ int main(int argc, char **argv) {
 __attribute__((used, section("__DATA_CONST,__lldbformatters"))) unsigned char
     _Account_synthetic[] =
         "\x01"          // version
-        "\x16"          // remaining record size
+        "\x12"          // remaining record size
         "\x07"          // type name size
         "Account"       // type name
         "\x00"          // flags
-        "\x06"          // sig_update
-        "\x02"          // program size
-        "\x20\x01"      // `return eReuse`
         "\x02"          // sig_get_num_children
         "\x02"          // program size
         "\x20\x01"      // `return 1`


### PR DESCRIPTION
Update `BytecodeSyntheticChildren` to support `ChildCacheState` return values from `@update` implementations.