### PR TITLE
[lld][MachO] Accept prefixed boundary symbol names

### DIFF
--- a/lld/MachO/SymbolTable.cpp
+++ b/lld/MachO/SymbolTable.cpp
@@ -411,19 +411,23 @@ static void handleSegmentBoundarySymbol(const Undefined &sym, StringRef segName,
 static bool recoverFromUndefinedSymbol(const Undefined &sym) {
   // Handle start/end symbols.
   StringRef name = sym.getName();
-  if (name.consume_front("section$start$")) {
+  if (name.consume_front("section$start$") ||
+      name.consume_front("_section$start$")) {
     handleSectionBoundarySymbol(sym, name, Boundary::Start);
     return true;
   }
-  if (name.consume_front("section$end$")) {
+  if (name.consume_front("section$end$") ||
+      name.consume_front("_section$end$")) {
     handleSectionBoundarySymbol(sym, name, Boundary::End);
     return true;
   }
-  if (name.consume_front("segment$start$")) {
+  if (name.consume_front("segment$start$") ||
+      name.consume_front("_segment$start$")) {
     handleSegmentBoundarySymbol(sym, name, Boundary::Start);
     return true;
   }
-  if (name.consume_front("segment$end$")) {
+  if (name.consume_front("segment$end$") ||
+      name.consume_front("_segment$end$")) {
     handleSegmentBoundarySymbol(sym, name, Boundary::End);
     return true;
   }


### PR DESCRIPTION
Allows referencing section- and segment-boundary symbols when the referencing symbol name is prefixed with an underscore (as defined in https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/IR/DataLayout.h#L286-L300).

Since symbol names may be mangled, which they often are, when whilst resolving them, it can create situations where a compiler and/or toolchain cannot be used to reference these boundary symbols. Specifically for the LLVM-backend in Rust, this snippet cannot be linked as the symbol will never resolve correctly:
```rs
unsafe extern "C" {
    #[link_name = "section$start$__DATA$__foo"]
    static FOO_DATA: u8;
}
```

I've only used the global prefix from Mach-O (`_`) since it seems to be used in other places as well. Also, I have not added any tests since I figured the pre-existing [`start-end.s`](https://github.com/llvm/llvm-project/blob/main/lld/test/MachO/start-end.s) test-case was satisfactory - if not, I can try to add some.