### PR TITLE
[Hexagon] Fix APInt assertion in getBuildVectorConstInts

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -2450,7 +2450,8 @@ HexagonTargetLowering::getBuildVectorConstInts(ArrayRef<SDValue> Values,
     // Make sure to always cast to IntTy.
     if (auto *CN = dyn_cast<ConstantSDNode>(V.getNode())) {
       const ConstantInt *CI = CN->getConstantIntValue();
-      Consts[i] = ConstantInt::getSigned(IntTy, CI->getValue().getSExtValue());
+      Consts[i] = cast<ConstantInt>(
+          ConstantInt::get(IntTy, CI->getValue().trunc(ElemWidth)));
     } else if (auto *CN = dyn_cast<ConstantFPSDNode>(V.getNode())) {
       const ConstantFP *CF = CN->getConstantFPValue();
       APInt A = CF->getValueAPF().bitcastToAPInt();

--- a/llvm/test/CodeGen/Hexagon/udiv-vector-nonuniform.ll
+++ b/llvm/test/CodeGen/Hexagon/udiv-vector-nonuniform.ll
@@ -1,0 +1,16 @@
+; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+
+; Check that non-uniform udiv of v8i16 compiles correctly.
+; The udiv expansion produces magic-number constants (e.g. 0xAAAB) that
+; don't fit in signed 16-bit, which previously triggered an APInt assertion
+; in getBuildVectorConstInts.
+
+; CHECK-LABEL: uq65656565:
+; CHECK-DAG:   vmpyh(r{{[0-9]+}},r{{[0-9]+}}):sat
+; CHECK-DAG:   vlsrh(r{{[0-9]+}}:{{[0-9]+}},#2)
+; CHECK:       jumpr r31
+define <8 x i16> @uq65656565(<8 x i16> %0) {
+entry:
+  %div = udiv <8 x i16> %0, <i16 6, i16 5, i16 6, i16 5, i16 6, i16 5, i16 6, i16 5>
+  ret <8 x i16> %div
+}


### PR DESCRIPTION
Truncate the ConstantSDNode APInt value to the element bit width before creating the ConstantInt. After type legalization, a ConstantSDNode may have a wider type than the vector element (e.g., i32 constant for an i16 element).