### PR TITLE
workflows/commit-access-reivew: Use concurrency to speed up script

### DIFF
--- a/.github/workflows/commit-access-review.py
+++ b/.github/workflows/commit-access-review.py
@@ -264,6 +264,7 @@ def count_prs(gh: github.Github, triage_list: dict, start_date: datetime.datetim
                 variables["after"] = data["search"]["pageInfo"]["endCursor"]
         date_begin = date_end
 
+
 # 4 because that's how many cores the default github runners have.  Also, if we
 # make this too high, we risk hitting some of GitHub's secondary rate limits.
 THREAD_POOL_MAX_WORKERS = 4

--- a/.github/workflows/commit-access-review.py
+++ b/.github/workflows/commit-access-review.py
@@ -295,7 +295,12 @@ def main():
 
     # 4 because that's how many cores the default github runners have.
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
-        executor.map(lambda user:triage_list[user].add_reviewed(get_review_count(gh, user, one_year_ago)), list(triage_list.keys()))
+        executor.map(
+            lambda user: triage_list[user].add_reviewed(
+                get_review_count(gh, user, one_year_ago)
+            ),
+            list(triage_list.keys()),
+        )
 
     print("After Reviews:", len(triage_list), "triagers")
 
@@ -306,7 +311,12 @@ def main():
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
         # Override the total number of commits to not double count commits and
         # authored PRs.
-        executor.map(lambda user: triage_list[user].set_authored(get_num_commits(gh, user, one_year_ago)),list(triage_list.keys()))
+        executor.map(
+            lambda user: triage_list[user].set_authored(
+                get_num_commits(gh, user, one_year_ago)
+            ),
+            list(triage_list.keys()),
+        )
 
     print("After Commits:", len(triage_list), "triagers")
 

--- a/.github/workflows/commit-access-review.py
+++ b/.github/workflows/commit-access-review.py
@@ -297,7 +297,9 @@ def main():
 
     # Step 2 check for reviews
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=THREAD_POOL_MAX_WORKERS) as executor:
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=THREAD_POOL_MAX_WORKERS
+    ) as executor:
         executor.map(
             lambda user: triage_list[user].add_reviewed(
                 get_review_count(gh, user, one_year_ago)
@@ -311,7 +313,9 @@ def main():
         sys.exit(0)
 
     # Step 3 check for number of commits
-    with concurrent.futures.ThreadPoolExecutor(max_workers=THREAD_POOL_MAX_WORKERS) as executor:
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=THREAD_POOL_MAX_WORKERS
+    ) as executor:
         # Override the total number of commits to not double count commits and
         # authored PRs.
         executor.map(

--- a/.github/workflows/commit-access-review.py
+++ b/.github/workflows/commit-access-review.py
@@ -9,6 +9,7 @@
 #
 # ===------------------------------------------------------------------------===#
 
+import concurrent.futures
 import datetime
 import github
 import re
@@ -291,9 +292,10 @@ def main():
         sys.exit(0)
 
     # Step 2 check for reviews
-    for user in list(triage_list.keys()):
-        review_count = get_review_count(gh, user, one_year_ago)
-        triage_list[user].add_reviewed(review_count)
+
+    # 4 because that's how many cores the default github runners have.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        executor.map(lambda user:triage_list[user].add_reviewed(get_review_count(gh, user, one_year_ago)), list(triage_list.keys()))
 
     print("After Reviews:", len(triage_list), "triagers")
 
@@ -301,11 +303,10 @@ def main():
         sys.exit(0)
 
     # Step 3 check for number of commits
-    for user in list(triage_list.keys()):
-        num_commits = get_num_commits(gh, user, one_year_ago)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
         # Override the total number of commits to not double count commits and
         # authored PRs.
-        triage_list[user].set_authored(num_commits)
+        executor.map(lambda user: triage_list[user].set_authored(get_num_commits(gh, user, one_year_ago)),list(triage_list.keys()))
 
     print("After Commits:", len(triage_list), "triagers")
 


### PR DESCRIPTION
Making some of the graphql queries in parallel cuts the runtime of the script from ~60 minutes to ~40 minutes.