### PR TITLE
[llvm][.gitignore] Add instructions.md to coding assistants section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ autoconf/autom4te.cache
 /cmake-build*
 # Coding assistants' stuff
 /CLAUDE.md
+/instructions.md
 .claude/
 /GEMINI.md
 .gemini/


### PR DESCRIPTION
Similar to CLAUDE.md and GEMINI.md, instructions.md is a local guidance file used by AI coding assistants. Add it to the existing "Coding assistants' stuff" section to prevent accidental commits.