### PR TITLE
Update IntegerLiteralSeparatorFixer.cpp

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -951,7 +951,6 @@ void ContinuationIndenter::addTokenOnCurrentLine(LineState &State, bool DryRun,
            Next->is(TT_FunctionDeclarationLParen) || IsFunctionCallParen(*Next);
   };
   if (IsOpeningBracket(Previous) &&
-      State.Column > getNewLineColumn(State).Total &&
       // Don't do this for simple (no expressions) one-argument function calls
       // as that feels like needlessly wasting whitespace, e.g.:
       //

--- a/clang/lib/Format/IntegerLiteralSeparatorFixer.cpp
+++ b/clang/lib/Format/IntegerLiteralSeparatorFixer.cpp
@@ -50,6 +50,9 @@ IntegerLiteralSeparatorFixer::process(const Environment &Env,
   case FormatStyle::LK_JavaScript:
     Separator = '_';
     break;
+  case FormatStyle::LK_C:
+    Separator = '\'';
+    break;
   case FormatStyle::LK_Cpp:
   case FormatStyle::LK_ObjC:
     if (Style.Standard >= FormatStyle::LS_Cpp14) {


### PR DESCRIPTION
Add C language support for digit separator for integer literals.  Compiler support added in C23+.

Fixes #179686