### PR TITLE
[lldb] Flatten GetCompilerType-MaybeCalculateCompleteType (NFC)

### DIFF
--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -349,7 +349,7 @@ public:
 
   void SetNeedsUpdate();
 
-  CompilerType GetCompilerType() { return MaybeCalculateCompleteType(); }
+  CompilerType GetCompilerType();
 
   // this vends a TypeImpl that is useful at the SB API layer
   virtual TypeImpl GetTypeImpl() { return TypeImpl(GetCompilerType()); }
@@ -1105,7 +1105,6 @@ protected:
   virtual void DoUpdateChildrenAddressType(ValueObject &valobj) {};
 
 private:
-  virtual CompilerType MaybeCalculateCompleteType();
   void UpdateChildrenAddressType() {
     GetRoot()->DoUpdateChildrenAddressType(*this);
   }

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -249,7 +249,7 @@ void ValueObject::ClearDynamicTypeInformation() {
   SetSyntheticChildren(lldb::SyntheticChildrenSP());
 }
 
-CompilerType ValueObject::MaybeCalculateCompleteType() {
+CompilerType ValueObject::GetCompilerType() {
   CompilerType compiler_type(GetCompilerTypeImpl());
 
   if (m_flags.m_did_calculate_complete_objc_class_type) {


### PR DESCRIPTION
`MaybeCalculateCompleteType` is not overridden anywhere, and is called only from `GetCompilerType`.