### PR TITLE
[RISCV][NFC] Remove redundant defvar in SiFive7 SchedModel

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
@@ -1566,7 +1566,6 @@ multiclass SiFive7SchedResources<int vlen, bit dualVALU,
   defvar SiFive7VA1OrVA2 = !if (dualVALU,
                             !cast<ProcResGroup>(NAME # SiFive7VA1OrVA2),
                             !cast<ProcResource>(NAME # SiFive7VA));
-  defvar SiFive7VA = !cast<ProcResource>(NAME # SiFive7VA);
   defvar SiFive7VL = !cast<ProcResource>(NAME # SiFive7VL);
   defvar SiFive7VS = !cast<ProcResource>(NAME # SiFive7VS);
   defvar SiFive7VCQ = !cast<ProcResource>(NAME # SiFive7VCQ);


### PR DESCRIPTION
The defvar `SiFive7VA` inside `SiFive7SchedResources` is never used. More surprisingly, `NAME # SiFive7VA` -- the record it's supposed to point at -- is not even _defined_ when there are two VALUs (i.e. `dualVALU` is true). But I guess since that defvar is never used, TableGen parser simply ignores it and thus we never saw any error message.

NFC.