### PR TITLE
[llvm-otool] Fix error messages to use -p instead of --dis-symname

### DIFF
--- a/llvm/test/tools/llvm-objdump/MachO/dis-symname.test
+++ b/llvm/test/tools/llvm-objdump/MachO/dis-symname.test
@@ -19,8 +19,20 @@
 # CHECK-NOT: 0000000100000d22
 # CHECK-NOT: _main:
 
+# RUN: llvm-objdump --macho -d %p/Inputs/exeThread.macho-x86_64 --dis-symname _nonexistent 2>&1 | FileCheck --check-prefix BAD-OBJDUMP-NOTFOUND %s
+BAD-OBJDUMP-NOTFOUND: Can't find --dis-symname: _nonexistent
+
 # RUN: llvm-objdump --macho -d %p/Inputs/exeThread.macho-x86_64 --dis-symname _environ 2>&1 | FileCheck --check-prefix BAD-SYMAME-1 %s
-BAD-SYMAME-1: -dis-symname: _environ not in the section
+BAD-SYMAME-1: --dis-symname: _environ not in the section
 
 # RUN: llvm-objdump --macho -d %p/Inputs/exeThread.macho-x86_64 --dis-symname __mh_execute_header 2>&1 | FileCheck --check-prefix BAD-SYMAME-2 %s
-BAD-SYMAME-2: -dis-symname: __mh_execute_header not in any section
+BAD-SYMAME-2: --dis-symname: __mh_execute_header not in any section
+
+# RUN: llvm-otool -tV %p/Inputs/exeThread.macho-x86_64 -p _nonexistent 2>&1 | FileCheck --check-prefix BAD-OTOOL-NOTFOUND %s
+BAD-OTOOL-NOTFOUND: Can't find -p symbol: _nonexistent
+
+# RUN: llvm-otool -tV %p/Inputs/exeThread.macho-x86_64 -p _environ 2>&1 | FileCheck --check-prefix BAD-OTOOL-NOTSECTION %s
+BAD-OTOOL-NOTSECTION: -p symbol: _environ not in the section
+
+# RUN: llvm-otool -tV %p/Inputs/exeThread.macho-x86_64 -p __mh_execute_header 2>&1 | FileCheck --check-prefix BAD-OTOOL-NOSECTION %s
+BAD-OTOOL-NOSECTION: -p symbol: __mh_execute_header not in any section

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -80,6 +80,7 @@ bool objdump::DylibId;
 bool objdump::Verbose;
 bool objdump::ObjcMetaData;
 std::string objdump::DisSymName;
+bool objdump::IsOtool;
 bool objdump::SymbolicOperands;
 static std::vector<std::string> ArchFlags;
 
@@ -7508,7 +7509,8 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
       }
     }
     if (!DisSymName.empty() && !DisSymNameFound) {
-      outs() << "Can't find -dis-symname: " << DisSymName << "\n";
+      outs() << "Can't find " << (IsOtool ? "-p symbol" : "--dis-symname")
+             << ": " << DisSymName << "\n";
       return;
     }
     // Set up the block of info used by the Symbolizer call backs.
@@ -7549,7 +7551,8 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
       bool containsSym = Sections[SectIdx].containsSymbol(Symbols[SymIdx]);
       if (!containsSym) {
         if (!DisSymName.empty() && DisSymName == SymName) {
-          outs() << "-dis-symname: " << DisSymName << " not in the section\n";
+          outs() << (IsOtool ? "-p symbol" : "--dis-symname") << ": "
+                 << DisSymName << " not in the section\n";
           return;
         }
         continue;
@@ -7560,7 +7563,8 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
       // is an N_SECT symbol in the (__TEXT,__text) but its address is before the
       // start of the section in a standard MH_EXECUTE filetype.
       if (!DisSymName.empty() && DisSymName == "__mh_execute_header") {
-        outs() << "-dis-symname: __mh_execute_header not in any section\n";
+        outs() << (IsOtool ? "-p symbol" : "--dis-symname")
+               << ": __mh_execute_header not in any section\n";
         return;
       }
       // When this code is trying to disassemble a symbol at a time and in the

--- a/llvm/tools/llvm-objdump/MachODump.h
+++ b/llvm/tools/llvm-objdump/MachODump.h
@@ -40,6 +40,7 @@ enum class FunctionStartsMode { Addrs, Names, Both, None };
 extern bool Bind;
 extern bool DataInCode;
 extern std::string DisSymName;
+extern bool IsOtool;
 extern bool ChainedFixups;
 extern bool DyldInfo;
 extern bool DylibId;

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -3862,6 +3862,7 @@ int llvm_objdump_main(int argc, char **argv, const llvm::ToolContext &) {
            (I + Tool.size() == Stem.size() || !isAlnum(Stem[I + Tool.size()]));
   };
   if (Is("otool")) {
+    IsOtool = true;
     T = std::make_unique<OtoolOptTable>();
     Unknown = OTOOL_UNKNOWN;
     HelpFlag = OTOOL_help;


### PR DESCRIPTION
Also fixes llvm-objdump error messages to print --dis-symname instead of single dash option.