### PR TITLE
[Github] Do not fail on unknown branches

### DIFF
--- a/.github/workflows/prune-unused-branches.py
+++ b/.github/workflows/prune-unused-branches.py
@@ -75,6 +75,7 @@ def get_user_branches_to_remove(
                 "was not found in the repository. This is likely because "
                 "the PR was created after this workflow cloned the repository."
             )
+            continue
         user_branches_to_remove.remove(pr_user_branch)
     return list(user_branches_to_remove)
 

--- a/.github/workflows/prune-unused-branches.py
+++ b/.github/workflows/prune-unused-branches.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 import os
+import logging
 
 import github
 
@@ -68,6 +69,12 @@ def get_user_branches_to_remove(
 ) -> list[str]:
     user_branches_to_remove = set(user_branches)
     for pr_user_branch in set(user_branches_from_prs):
+        if pr_user_branch not in user_branches_to_remove:
+            logging.warning(
+                f"Found branch {pr_user_branch} attached to a PR, but it "
+                "was not found in the repository. This is likely because "
+                "the PR was created after this workflow cloned the repository."
+            )
         user_branches_to_remove.remove(pr_user_branch)
     return list(user_branches_to_remove)
 


### PR DESCRIPTION
If someone creates user branches and a PR after we start cloning the repository, but before we collect PRs, we can end up with branches that do not exist in the repository. In one case this was causing workflow failures because we expected this to be an invariant.