### PR TITLE
[Github] Account for cross-repo PRs in prune-unused-branches

### DIFF
--- a/.github/workflows/prune-unused-branches.py
+++ b/.github/workflows/prune-unused-branches.py
@@ -75,6 +75,7 @@ def get_branches_from_open_prs(github_token) -> list[str]:
         else:
             assert pr["baseRefName"].startswith("users/")
             user_branches.append(pr["baseRefName"])
+    # Convert to a set to ensure we have no duplicates.
     return list(set(user_branches))
 
 

--- a/.github/workflows/prune-unused-branches.py
+++ b/.github/workflows/prune-unused-branches.py
@@ -73,7 +73,10 @@ def get_branches_from_open_prs(github_token) -> list[str]:
                 user_branches.append(pr["baseRefName"])
             user_branches.append(pr["headRefName"])
         else:
-            assert pr["baseRefName"].startswith("users/")
+            # We want to skip cross-repo PRs where someone has simply used a
+            # users/ branch naming scheme for a branch in their fork.
+            if pr["baseRefName"] == "main":
+                continue
             user_branches.append(pr["baseRefName"])
     # Convert to a set to ensure we have no duplicates.
     return list(set(user_branches))

--- a/.github/workflows/prune-unused-branches.py
+++ b/.github/workflows/prune-unused-branches.py
@@ -22,26 +22,26 @@ def get_branches() -> list[str]:
     return [branch.replace("remotes/origin/", "") for branch in filtered_branches]
 
 
-def query_prs(github_token, extra_query_criteria):
+def query_prs(github_token, extra_query_criteria) -> list[str]:
     gh = github.Github(auth=github.Auth.Token(github_token))
     query_template = """
-  query ($after: String) {
-    search(query: "is:pr repo:llvm/llvm-project is:open {extra_query_criteria}", type: ISSUE, first: 100, after: $after) {
-      nodes {
-        ... on PullRequest {
-          baseRefName
-          headRefName
-          isCrossRepository
-          number
-        }
-      }
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-    }
-  }"""
-    query = query_template.format(extra_query_criteria=extra_query_criteria)
+    query ($after: String) {{
+        search(query: "is:pr repo:llvm/llvm-project is:open {query_param}", type: ISSUE, first: 100, after: $after) {{
+        nodes {{
+            ... on PullRequest {{
+            baseRefName
+            headRefName
+            isCrossRepository
+            number
+            }}
+        }}
+        pageInfo {{
+            hasNextPage
+            endCursor
+        }}
+        }}
+    }}"""
+    query = query_template.format(query_param=extra_query_criteria)
     pr_data = []
     has_next_page = True
     variables = {"after": None}


### PR DESCRIPTION
Some users (as reported in the discourse thread) use user branches purely as a diff base for cross repo pull requests. This patch makes it so that we do not delete branches that are used in this way.