### PR TITLE
[Hexagon] Fix UB from left shift of negative in SelectSHL

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
@@ -594,7 +594,8 @@ void HexagonDAGToDAGISel::SelectSHL(SDNode *N) {
     SDValue Mul_1 = Shl_0.getOperand(1); // Const
     // RHS of mul is const.
     if (ConstantSDNode *C = dyn_cast<ConstantSDNode>(Mul_1)) {
-      int32_t ValConst = C->getSExtValue() << ShlConst;
+      int32_t ValConst = static_cast<int32_t>(
+          static_cast<uint32_t>(C->getSExtValue()) << ShlConst);
       if (isInt<9>(ValConst)) {
         SDValue Val = CurDAG->getTargetConstant(ValConst, dl, MVT::i32);
         SDNode *Result = CurDAG->getMachineNode(Hexagon::M2_mpysmi, dl,
@@ -615,7 +616,8 @@ void HexagonDAGToDAGISel::SelectSHL(SDNode *N) {
       SDValue Shl2_0 = Sub_1.getOperand(0); // Val
       SDValue Shl2_1 = Sub_1.getOperand(1); // Const
       if (ConstantSDNode *C2 = dyn_cast<ConstantSDNode>(Shl2_1)) {
-        int32_t ValConst = 1 << (ShlConst + C2->getSExtValue());
+        int32_t ValConst =
+            static_cast<int32_t>(1U << (ShlConst + C2->getSExtValue()));
         if (isInt<9>(-ValConst)) {
           SDValue Val =
               CurDAG->getSignedTargetConstant(-ValConst, dl, MVT::i32);

--- a/llvm/test/CodeGen/Hexagon/isel-shl-neg-const.ll
+++ b/llvm/test/CodeGen/Hexagon/isel-shl-neg-const.ll
@@ -1,0 +1,31 @@
+; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+
+; Verify that SelectSHL handles (shl (mul val, const), const) with negative
+; multiply constants. The left shift of the negative constant must be done in
+; unsigned arithmetic to avoid undefined behavior.
+
+; The multiply constant 0xAAAAAAAB shifted left by 1 does not fit in a signed
+; 9-bit immediate, so this should not be folded into M2_mpysmi.
+define i32 @shl_mul_neg_large(i32 %x) #0 {
+; CHECK-LABEL: shl_mul_neg_large:
+; CHECK: +mpyi(r0,##1431655766)
+; CHECK: jumpr r31
+entry:
+  %m = mul i32 %x, u0xAAAAAAAB
+  %s = shl i32 %m, 1
+  ret i32 %s
+}
+
+; A small negative multiply constant (-3) shifted left by 1 gives -6, which
+; fits in a signed 9-bit immediate. This should be folded into M2_mpysmi.
+define i32 @shl_mul_neg_small(i32 %x) #0 {
+; CHECK-LABEL: shl_mul_neg_small:
+; CHECK: -mpyi(r0,#6)
+; CHECK: jumpr r31
+entry:
+  %m = mul i32 %x, -3
+  %s = shl i32 %m, 1
+  ret i32 %s
+}
+
+attributes #0 = { nounwind "target-cpu"="hexagonv60" }


### PR DESCRIPTION
Perform left shifts in unsigned arithmetic in SelectSHL to avoid undefined behavior when the multiply constant is negative. The result is cast back to int32_t for the subsequent isInt<9> range check.

Also fix a similar issue where shifting 1 by up to 31 could shift into the sign bit.

This fixes the UBSan issue in ISelDAGtoDAG:

    /local/mnt/workspace/bcain-20260212_105837/llvm-project/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp:597
      :44: runtime error: left shift of negative value -1431655765
      SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
      /local/mnt/workspace/bcain-20260212_105837/llvm-project/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp:597:44 in