### PR TITLE
[libc][math] Refactor tanpif16 to header-only

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -221,5 +221,6 @@
 #include "math/tanhf.h"
 #include "math/tanhf16.h"
 #include "math/tanpif.h"
+#include "math/tanpif16.h"
 
 #endif // LLVM_LIBC_SHARED_MATH_H

--- a/libc/shared/math/tanpif16.h
+++ b/libc/shared/math/tanpif16.h
@@ -1,4 +1,4 @@
-//===-- Half-precision tanpif function ------------------------------------===//
+//===-- Implementation header for tanpif16 ----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,23 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/tanpif16.h"
+#ifndef LLVM_LIBC_SHARED_MATH_TANPIF16_H
+#define LLVM_LIBC_SHARED_MATH_TANPIF16_H
+
+#include "shared/libc_common.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
 #include "src/__support/math/tanpif16.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(float16, tanpif16, (float16 x)) { return math::tanpif16(x); }
+using math::tanpif16;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#endif // LLVM_LIBC_SHARED_MATH_TANPIF16_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -2792,3 +2792,21 @@ add_header_library(
     libc.src.__support.macros.config
     libc.src.__support.macros.optimization
 )
+
+add_header_library(
+  tanpif16
+  HDRS
+    tanpif16.h
+  DEPENDS
+    .sincosf16_utils
+    libc.hdr.errno_macros
+    libc.hdr.fenv_macros
+    libc.include.llvm-libc-macros.float16_macros
+    libc.src.__support.FPUtil.cast
+    libc.src.__support.FPUtil.except_value_utils.h
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.multiply_add
+    libc.src.__support.macros.optimization
+    libc.src.__support.macros.properties.types
+)

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -2803,10 +2803,9 @@ add_header_library(
     libc.hdr.fenv_macros
     libc.include.llvm-libc-macros.float16_macros
     libc.src.__support.FPUtil.cast
-    libc.src.__support.FPUtil.except_value_utils.h
+    libc.src.__support.FPUtil.except_value_utils
     libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.macros.optimization
-    libc.src.__support.macros.properties.types
 )

--- a/libc/src/__support/math/tanpif16.h
+++ b/libc/src/__support/math/tanpif16.h
@@ -1,0 +1,126 @@
+//===-- Implementation header for tanpif16 ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_TANPIF16_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_TANPIF16_H
+#include "include/llvm-libc-macros/float16-macros.h"
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
+#include "hdr/errno_macros.h"
+#include "hdr/fenv_macros.h"
+#include "sincosf16_utils.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/cast.h"
+#include "src/__support/FPUtil/except_value_utils.h"
+#include "src/__support/FPUtil/multiply_add.h"
+#include "src/__support/macros/optimization.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+namespace tanpif16_internal {
+#ifndef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
+LIBC_INLINE_VAR constexpr size_t N_EXCEPTS = 21;
+
+LIBC_INLINE_VAR constexpr fputil::ExceptValues<float16, N_EXCEPTS>
+    TANPIF16_EXCEPTS{{
+        // (input, RZ output, RU offset, RD offset, RN offset)
+        {0x07f2, 0x0e3d, 1, 0, 0}, {0x086a, 0x0eee, 1, 0, 1},
+        {0x08db, 0x0fa0, 1, 0, 0}, {0x094c, 0x1029, 1, 0, 0},
+        {0x0b10, 0x118c, 1, 0, 0}, {0x1ce0, 0x23a8, 1, 0, 1},
+        {0x1235, 0x18e0, 1, 0, 0}, {0x2579, 0x2c4e, 1, 0, 0},
+        {0x28b2, 0x2f68, 1, 0, 1}, {0x2a43, 0x30f4, 1, 0, 1},
+        {0x31b7, 0x3907, 1, 0, 0}, {0x329d, 0x3a12, 1, 0, 1},
+        {0x34f1, 0x3dd7, 1, 0, 0}, {0x3658, 0x41ee, 1, 0, 0},
+        {0x38d4, 0xc1ee, 0, 1, 0}, {0x3d96, 0x41ee, 1, 0, 0},
+        {0x3e6a, 0xc1ee, 0, 1, 0}, {0x40cb, 0x41ee, 1, 0, 0},
+        {0x4135, 0xc1ee, 0, 1, 0}, {0x42cb, 0x41ee, 1, 0, 0},
+        {0x4335, 0xc1ee, 0, 1, 0},
+    }};
+#endif // !LIBC_MATH_HAS_SKIP_ACCURATE_PASS
+} // namespace tanpif16_internal
+
+LIBC_INLINE constexpr float16 tanpif16(float16 x) {
+  using namespace sincosf16_internal;
+  using namespace tanpif16_internal;
+  using FPBits = typename fputil::FPBits<float16>;
+  FPBits xbits(x);
+
+  uint16_t x_u = xbits.uintval();
+  uint16_t x_abs = x_u & 0x7fff;
+
+  // Handle exceptional values
+  if (LIBC_UNLIKELY(x_abs <= 0x4335)) {
+    if (LIBC_UNLIKELY(x_abs == 0U))
+      return x;
+
+#ifndef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
+    bool x_sign = x_u >> 15;
+
+    if (auto r = TANPIF16_EXCEPTS.lookup_odd(x_abs, x_sign);
+        LIBC_UNLIKELY(r.has_value()))
+      return r.value();
+#endif // !LIBC_MATH_HAS_SKIP_ACCURATE_PASS
+  }
+
+  // Numbers greater or equal to 2^10 are integers, or infinity, or NaN
+  if (LIBC_UNLIKELY(x_abs >= 0x6400)) {
+    // Check for NaN or infinity values
+    if (LIBC_UNLIKELY(x_abs >= 0x7c00)) {
+      if (xbits.is_signaling_nan()) {
+        fputil::raise_except_if_required(FE_INVALID);
+        return FPBits::quiet_nan().get_val();
+      }
+      // is inf
+      if (x_abs == 0x7c00) {
+        fputil::set_errno_if_required(EDOM);
+        fputil::raise_except_if_required(FE_INVALID);
+      }
+
+      return x + FPBits::quiet_nan().get_val();
+    }
+
+    return FPBits::zero(xbits.sign()).get_val();
+  }
+  // Range reduction:
+  // For |x| > 1/32, we perform range reduction as follows:
+  // Find k and y such that:
+  //   x = (k + y) * 1/32
+  //   k is an integer
+  //   |y| < 0.5
+  //
+  // This is done by performing:
+  //   k = round(x * 32)
+  //   y = x * 32 - k
+  //
+  // Once k and y are computed, we then deduce the answer by the formula:
+  // tan(x) = sin(x) / cos(x)
+  //        = (sin_y * cos_k + cos_y * sin_k) / (cos_y * cos_k - sin_y * sin_k)
+  float xf = x;
+  float sin_k = 0, cos_k = 0, sin_y = 0, cosm1_y = 0;
+  sincospif16_eval(xf, sin_k, cos_k, sin_y, cosm1_y);
+
+  if (LIBC_UNLIKELY(sin_y == 0 && cos_k == 0)) {
+    fputil::set_errno_if_required(EDOM);
+    fputil::raise_except_if_required(FE_DIVBYZERO);
+
+    int16_t x_mp5_u = static_cast<int16_t>(x - 0.5);
+    return ((x_mp5_u & 0x1) ? -1 : 1) * FPBits::inf().get_val();
+  }
+
+  using fputil::multiply_add;
+  return fputil::cast<float16>(
+      multiply_add(sin_y, cos_k, multiply_add(cosm1_y, sin_k, sin_k)) /
+      multiply_add(sin_y, -sin_k, multiply_add(cosm1_y, cos_k, cos_k)));
+}
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_TANPIF16_H

--- a/libc/src/__support/math/tanpif16.h
+++ b/libc/src/__support/math/tanpif16.h
@@ -5,9 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_TANPIF16_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_TANPIF16_H
+
 #include "include/llvm-libc-macros/float16-macros.h"
+
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
 #include "hdr/errno_macros.h"
@@ -21,15 +24,25 @@
 #include "src/__support/macros/optimization.h"
 
 namespace LIBC_NAMESPACE_DECL {
-
 namespace math {
 
-namespace tanpif16_internal {
-#ifndef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
-LIBC_INLINE_VAR constexpr size_t N_EXCEPTS = 21;
+LIBC_INLINE float16 tanpif16(float16 x) {
+  using namespace sincosf16_internal;
+  using FPBits = typename fputil::FPBits<float16>;
+  FPBits xbits(x);
 
-LIBC_INLINE_VAR constexpr fputil::ExceptValues<float16, N_EXCEPTS>
-    TANPIF16_EXCEPTS{{
+  uint16_t x_u = xbits.uintval();
+  uint16_t x_abs = x_u & 0x7fff;
+
+  // Handle exceptional values
+  if (LIBC_UNLIKELY(x_abs <= 0x4335)) {
+    if (LIBC_UNLIKELY(x_abs == 0U))
+      return x;
+
+#ifndef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
+    constexpr size_t N_EXCEPTS = 21;
+
+    constexpr fputil::ExceptValues<float16, N_EXCEPTS> TANPIF16_EXCEPTS{{
         // (input, RZ output, RU offset, RD offset, RN offset)
         {0x07f2, 0x0e3d, 1, 0, 0}, {0x086a, 0x0eee, 1, 0, 1},
         {0x08db, 0x0fa0, 1, 0, 0}, {0x094c, 0x1029, 1, 0, 0},
@@ -43,24 +56,7 @@ LIBC_INLINE_VAR constexpr fputil::ExceptValues<float16, N_EXCEPTS>
         {0x4135, 0xc1ee, 0, 1, 0}, {0x42cb, 0x41ee, 1, 0, 0},
         {0x4335, 0xc1ee, 0, 1, 0},
     }};
-#endif // !LIBC_MATH_HAS_SKIP_ACCURATE_PASS
-} // namespace tanpif16_internal
 
-LIBC_INLINE constexpr float16 tanpif16(float16 x) {
-  using namespace sincosf16_internal;
-  using namespace tanpif16_internal;
-  using FPBits = typename fputil::FPBits<float16>;
-  FPBits xbits(x);
-
-  uint16_t x_u = xbits.uintval();
-  uint16_t x_abs = x_u & 0x7fff;
-
-  // Handle exceptional values
-  if (LIBC_UNLIKELY(x_abs <= 0x4335)) {
-    if (LIBC_UNLIKELY(x_abs == 0U))
-      return x;
-
-#ifndef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
     bool x_sign = x_u >> 15;
 
     if (auto r = TANPIF16_EXCEPTS.lookup_odd(x_abs, x_sign);
@@ -119,8 +115,10 @@ LIBC_INLINE constexpr float16 tanpif16(float16 x) {
       multiply_add(sin_y, cos_k, multiply_add(cosm1_y, sin_k, sin_k)) /
       multiply_add(sin_y, -sin_k, multiply_add(cosm1_y, cos_k, cos_k)));
 }
+
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LIBC_TYPES_HAS_FLOAT16
+
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_TANPIF16_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -457,15 +457,7 @@ add_entrypoint_object(
   HDRS
     ../tanpif16.h
   DEPENDS
-    libc.hdr.errno_macros
-    libc.hdr.fenv_macros
-    libc.src.__support.FPUtil.cast
-    libc.src.__support.FPUtil.fenv_impl
-    libc.src.__support.FPUtil.fp_bits
-    libc.src.__support.FPUtil.except_value_utils
-    libc.src.__support.FPUtil.multiply_add
-    libc.src.__support.macros.optimization
-    libc.src.__support.math.sincosf16_utils
+    libc.src.__support.math.tanpif16
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -219,4 +219,5 @@ add_fp_unittest(
     libc.src.__support.math.tanhf
     libc.src.__support.math.tanhf16
     libc.src.__support.math.tanpif
+    libc.src.__support.math.tanpif16
 )

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -99,6 +99,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat16) {
   EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::tanf16(0.0f16));
   EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::sinpif16(0.0f16));
   EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::tanhf16(0.0f16));
+  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::tanpif16(0.0f16));
 
   float16 canonicalizef16_cx = 0.0f16;
   float16 canonicalizef16_x = 0.0f16;

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5378,6 +5378,23 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_tanpif16",
+    hdrs = ["src/__support/math/tanpif16.h"],
+    deps = [
+        ":__support_fputil_cast",
+        ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
+        ":__support_macros_optimization",
+        ":__support_math_sincosf16_utils",
+        ":hdr_errno_macros",
+        ":hdr_fenv_macros",
+        ":llvm_libc_macros_float16_macros",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_tanhf",
     hdrs = ["src/__support/math/tanhf.h"],
     deps = [
@@ -7670,14 +7687,7 @@ libc_math_function(
 
 libc_math_function(
     name = "tanpif16",
-    additional_deps = [
-        ":__support_macros_optimization",
-        ":__support_math_sincosf16_utils",
-        ":hdr_errno_macros",
-        ":hdr_fenv_macros",
-        ":__support_fputil_cast",
-        ":__support_fputil_multiply_add",
-    ],
+    additional_deps = [":__support_math_tanpif16"],
 )
 
 libc_math_function(name = "totalorder")


### PR DESCRIPTION
Part of #147386

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450

Closes #181207