### PR TITLE
[Hexagon] Fix UB from signed left shift overflow in evaluateEXTRACTi

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonConstPropagation.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonConstPropagation.cpp
@@ -1773,12 +1773,13 @@ bool MachineConstEvaluator::evaluateEXTRACTi(const APInt &A1, unsigned Bits,
     return true;
   }
   if (BW <= 64) {
-    int64_t V = A1.getZExtValue();
-    V <<= (64-Bits-Offset);
+    uint64_t U = A1.getZExtValue();
+    U <<= (64 - Bits - Offset);
+    int64_t V;
     if (Signed)
-      V >>= (64-Bits);
+      V = static_cast<int64_t>(U) >> (64 - Bits);
     else
-      V = static_cast<uint64_t>(V) >> (64-Bits);
+      V = static_cast<int64_t>(U >> (64 - Bits));
     Result = APInt(BW, V, Signed);
     return true;
   }

--- a/llvm/test/CodeGen/Hexagon/constp-extract-pair.ll
+++ b/llvm/test/CodeGen/Hexagon/constp-extract-pair.ll
@@ -1,0 +1,42 @@
+; Verify constant propagation of 64-bit extract operations. The internal left
+; shift used to position the bitfield must use unsigned arithmetic to avoid
+; undefined behavior when high bits in the source value cause signed overflow.
+; RUN: llc -mtriple=hexagon -O2 < %s | FileCheck %s
+
+target triple = "hexagon"
+
+@g0 = common global i64 0, align 8
+@g1 = common global i64 0, align 8
+
+; extractup(0xC00000, 15, 8): extract 15 unsigned bits at offset 8.
+; The source value 0xC00000 has bit 23 set (outside the [8,23) extraction
+; window), which triggers a left shift of the value by 41 that would overflow
+; int64_t. Bits [22:8] = 0x4000 = 16384.
+define void @test_extractup() #0 {
+; CHECK-LABEL: test_extractup:
+; CHECK: 16384
+; CHECK-NOT: = extractu
+entry:
+  %0 = call i64 @llvm.hexagon.S2.extractup(i64 12582912, i32 15, i32 8)
+  store i64 %0, ptr @g0, align 8
+  ret void
+}
+
+; extractp(0xC00000, 15, 8): extract 15 signed bits at offset 8.
+; Bits [22:8] = 0x4000; bit 14 of the 15-bit field is set (sign bit),
+; so the result is sign-extended to -16384.
+define void @test_extractp() #0 {
+; CHECK-LABEL: test_extractp:
+; CHECK: -16384
+; CHECK-NOT: = extract
+entry:
+  %0 = call i64 @llvm.hexagon.S4.extractp(i64 12582912, i32 15, i32 8)
+  store i64 %0, ptr @g1, align 8
+  ret void
+}
+
+declare i64 @llvm.hexagon.S2.extractup(i64, i32, i32) #1
+declare i64 @llvm.hexagon.S4.extractp(i64, i32, i32) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "frame-pointer"="all" }
+attributes #1 = { nounwind readnone }


### PR DESCRIPTION
The evaluateEXTRACTi function in HexagonConstPropagation uses a left shift to position a bitfield at the top of a 64-bit word before extracting it with a right shift. When the source value has high bits set, the left shift of the int64_t value overflows, which is undefined behavior.

Fix by performing the left shift in uint64_t, then casting to int64_t only for the subsequent arithmetic right shift (signed extract case).