### PR TITLE
libclc: Fix broken symlinks

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -458,9 +458,11 @@ function(add_libclc_builtin_set)
   endif()
 
   foreach( a IN LISTS ARG_ALIASES )
+    set(target_output_dir ${LIBCLC_OUTPUT_LIBRARY_DIR}/${ARG_TRIPLE}/${a})
+
     if(CMAKE_HOST_UNIX OR LLVM_USE_SYMLINKS)
       cmake_path(RELATIVE_PATH libclc_builtins_lib
-        BASE_DIRECTORY ${LIBCLC_OUTPUT_LIBRARY_DIR}
+        BASE_DIRECTORY ${target_output_dir}
         OUTPUT_VARIABLE LIBCLC_LINK_OR_COPY_SOURCE)
       set(LIBCLC_LINK_OR_COPY create_symlink)
     else()
@@ -468,8 +470,9 @@ function(add_libclc_builtin_set)
       set(LIBCLC_LINK_OR_COPY copy)
     endif()
 
-    file( MAKE_DIRECTORY ${LIBCLC_OUTPUT_LIBRARY_DIR}/${ARG_TRIPLE}/${a} )
-    set( libclc_alias_lib ${LIBCLC_OUTPUT_LIBRARY_DIR}/${ARG_TRIPLE}/${a}/${LIBCLC_OUTPUT_FILENAME}.bc )
+    file( MAKE_DIRECTORY ${target_output_dir} )
+    set( libclc_alias_lib ${target_output_dir}/${LIBCLC_OUTPUT_FILENAME}.bc )
+
     add_custom_command(
       OUTPUT ${libclc_alias_lib}
       COMMAND ${CMAKE_COMMAND} -E ${LIBCLC_LINK_OR_COPY} ${LIBCLC_LINK_OR_COPY_SOURCE} ${libclc_alias_lib}


### PR DESCRIPTION
Create the symlink relative to the target output directory
instead of the top level output. These were pointing to the wrong
place. I think this was broken by 295d5484c09943d2af2c45c764157dc045d4a0d9