### PR TITLE
[clang] Mark `PrivateFieldNames.def` as textual header in module map

### DIFF
--- a/clang/include/module.modulemap
+++ b/clang/include/module.modulemap
@@ -8,6 +8,7 @@ module Clang_Analysis {
   umbrella "clang/Analysis"
 
   textual header "clang/Analysis/Analyses/ThreadSafetyOps.def"
+  textual header "clang/Analysis/Scalable/Model/PrivateFieldNames.def"
 
   module * { export * }
 


### PR DESCRIPTION
When building with modules enabled (`LLVM_ENABLE_MODULES=ON`), the module system attempts to transform the inclusion of `PrivateFieldNames.def` into a module import. Since this `#include` appears inside the `SerializationFormat` class definition (to generate accessor methods via macros), the resulting module import violates C++ modules rules that imports must appear at file scope. The fix is to mark `PrivateFieldNames.def` as a textual header in the `Clang_Analysis` module to ensure the file is processed as a traditional textual include.

rdar://170257449