### PR TITLE
[clang] put indirect parameters in the target-requested AS, if appplicable

### DIFF
--- a/clang/include/clang/AST/CharUnits.h
+++ b/clang/include/clang/AST/CharUnits.h
@@ -42,7 +42,7 @@ namespace clang {
     private:
       QuantityType Quantity = 0;
 
-      explicit CharUnits(QuantityType C) : Quantity(C) {}
+      constexpr explicit CharUnits(QuantityType C) : Quantity(C) {}
 
     public:
 
@@ -50,17 +50,13 @@ namespace clang {
       CharUnits() = default;
 
       /// Zero - Construct a CharUnits quantity of zero.
-      static CharUnits Zero() {
-        return CharUnits(0);
-      }
+      static constexpr CharUnits Zero() { return CharUnits(0); }
 
       /// One - Construct a CharUnits quantity of one.
-      static CharUnits One() {
-        return CharUnits(1);
-      }
+      static constexpr CharUnits One() { return CharUnits(1); }
 
       /// fromQuantity - Construct a CharUnits quantity from a raw integer type.
-      static CharUnits fromQuantity(QuantityType Quantity) {
+      static constexpr CharUnits fromQuantity(QuantityType Quantity) {
         return CharUnits(Quantity);
       }
 

--- a/clang/include/clang/CodeGen/CGFunctionInfo.h
+++ b/clang/include/clang/CodeGen/CGFunctionInfo.h
@@ -15,12 +15,13 @@
 #ifndef LLVM_CLANG_CODEGEN_CGFUNCTIONINFO_H
 #define LLVM_CLANG_CODEGEN_CGFUNCTIONINFO_H
 
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/CanonicalType.h"
 #include "clang/AST/CharUnits.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Type.h"
-#include "llvm/IR/DerivedTypes.h"
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/Support/TrailingObjects.h"
 #include <cassert>
 
@@ -222,6 +223,16 @@ public:
     AI.setPaddingType(Padding);
     AI.setIndirectAddrSpace(AddrSpace);
     return AI;
+  }
+
+  // This argument cannot be copied, so it must use the addrspace of Ty
+  static ABIArgInfo getNaturalIndirectNoCopy(ASTContext &Ctx, QualType Ty,
+                                             bool ByVal = true,
+                                             bool Realign = false,
+                                             llvm::Type *Padding = nullptr) {
+    unsigned AS = Ctx.getTargetAddressSpace(Ty.getAddressSpace());
+    return ABIArgInfo::getIndirect(Ctx.getTypeAlignInChars(Ty), AS, ByVal,
+                                   Realign, Padding);
   }
 
   /// Pass this in memory using the IR byref attribute.

--- a/clang/lib/CodeGen/ABIInfo.cpp
+++ b/clang/lib/CodeGen/ABIInfo.cpp
@@ -170,11 +170,20 @@ bool ABIInfo::isPromotableIntegerTypeForABI(QualType Ty) const {
   return false;
 }
 
-ABIArgInfo ABIInfo::getNaturalAlignIndirect(QualType Ty, unsigned AddrSpace,
-                                            bool ByVal, bool Realign,
-                                            llvm::Type *Padding) const {
+unsigned ABIInfo::getNaturalAddrSpace(QualType Ty) const {
+  // Choose the most natural address space, which is either something specific
+  // from Sema (to avoid copy+addrspacecast) or a basic alloca (so the callee
+  // can see the addrspacecast must be from a local).
+  return Ty.hasAddressSpace()
+             ? getContext().getTargetAddressSpace(Ty.getAddressSpace())
+             : getDataLayout().getAllocaAddrSpace();
+}
+
+ABIArgInfo ABIInfo::getNaturalIndirect(QualType Ty, bool ByVal, bool Realign,
+                                       llvm::Type *Padding) const {
   return ABIArgInfo::getIndirect(getContext().getTypeAlignInChars(Ty),
-                                 AddrSpace, ByVal, Realign, Padding);
+                                 getNaturalAddrSpace(Ty), ByVal, Realign,
+                                 Padding);
 }
 
 ABIArgInfo ABIInfo::getNaturalAlignIndirectInReg(QualType Ty,

--- a/clang/lib/CodeGen/ABIInfo.h
+++ b/clang/lib/CodeGen/ABIInfo.h
@@ -108,11 +108,12 @@ public:
   bool isPromotableIntegerTypeForABI(QualType Ty) const;
 
   /// A convenience method to return an indirect ABIArgInfo with an
-  /// expected alignment equal to the ABI alignment of the given type.
-  CodeGen::ABIArgInfo
-  getNaturalAlignIndirect(QualType Ty, unsigned AddrSpace, bool ByVal = true,
-                          bool Realign = false,
-                          llvm::Type *Padding = nullptr) const;
+  /// expected alignment equal to the ABI alignment of the given type
+  /// and an natural choice of addrspace for optimization.
+  CodeGen::ABIArgInfo getNaturalIndirect(QualType Ty, bool ByVal = true,
+                                         bool Realign = false,
+                                         llvm::Type *Padding = nullptr) const;
+  unsigned getNaturalAddrSpace(QualType Ty) const;
 
   CodeGen::ABIArgInfo getNaturalAlignIndirectInReg(QualType Ty,
                                                    bool Realign = false) const;

--- a/clang/lib/CodeGen/ABIInfoImpl.cpp
+++ b/clang/lib/CodeGen/ABIInfoImpl.cpp
@@ -21,10 +21,9 @@ ABIArgInfo DefaultABIInfo::classifyArgumentType(QualType Ty) const {
     // Records with non-trivial destructors/copy-constructors should not be
     // passed by value.
     if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI()))
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     RAA == CGCXXABI::RAA_DirectInMemory);
+      return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
 
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace());
+    return getNaturalIndirect(Ty);
   }
 
   // Treat an enum type as its underlying type.
@@ -37,7 +36,7 @@ ABIArgInfo DefaultABIInfo::classifyArgumentType(QualType Ty) const {
         Context.getTypeSize(Context.getTargetInfo().hasInt128Type()
                                 ? Context.Int128Ty
                                 : Context.LongLongTy))
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace());
+      return getNaturalIndirect(Ty);
 
   return (isPromotableIntegerTypeForABI(Ty)
               ? ABIArgInfo::getExtend(Ty, CGT.ConvertType(Ty))
@@ -49,7 +48,7 @@ ABIArgInfo DefaultABIInfo::classifyReturnType(QualType RetTy) const {
     return ABIArgInfo::getIgnore();
 
   if (isAggregateTypeForABI(RetTy))
-    return getNaturalAlignIndirect(RetTy, getDataLayout().getAllocaAddrSpace());
+    return getNaturalIndirect(RetTy);
 
   // Treat an enum type as its underlying type.
   if (const auto *ED = RetTy->getAsEnumDecl())
@@ -60,8 +59,7 @@ ABIArgInfo DefaultABIInfo::classifyReturnType(QualType RetTy) const {
         getContext().getTypeSize(getContext().getTargetInfo().hasInt128Type()
                                      ? getContext().Int128Ty
                                      : getContext().LongLongTy))
-      return getNaturalAlignIndirect(RetTy,
-                                     getDataLayout().getAllocaAddrSpace());
+      return getNaturalIndirect(RetTy);
 
   return (isPromotableIntegerTypeForABI(RetTy) ? ABIArgInfo::getExtend(RetTy)
                                                : ABIArgInfo::getDirect());
@@ -126,8 +124,7 @@ bool CodeGen::classifyReturnType(const CGCXXABI &CXXABI, CGFunctionInfo &FI,
 
   if (const auto *RD = Ty->getAsRecordDecl();
       RD && !isa<CXXRecordDecl>(RD) && !RD->canPassInRegisters()) {
-    FI.getReturnInfo() = Info.getNaturalAlignIndirect(
-        Ty, Info.getDataLayout().getAllocaAddrSpace());
+    FI.getReturnInfo() = Info.getNaturalIndirect(Ty);
     return true;
   }
 

--- a/clang/lib/CodeGen/CGBlocks.cpp
+++ b/clang/lib/CodeGen/CGBlocks.cpp
@@ -1170,7 +1170,7 @@ llvm::Type *CodeGenModule::getGenericBlockLiteralType() {
 
 RValue CodeGenFunction::EmitBlockCallExpr(const CallExpr *E,
                                           llvm::CallBase **CallOrInvoke,
-                                          ReturnSlotFn ReturnSlotWrapper) {
+                                          ReturnSlotFn WithReturnValueSlot) {
   const auto *BPT = E->getCallee()->getType()->castAs<BlockPointerType>();
   llvm::Value *BlockPtr = EmitScalarExpr(E->getCallee());
   llvm::Type *GenBlockTy = CGM.getGenericBlockLiteralType();
@@ -1240,8 +1240,8 @@ RValue CodeGenFunction::EmitBlockCallExpr(const CallExpr *E,
   auto doEmitCall = [&](ReturnValueSlot Slot) {
     return EmitCall(FnInfo, Callee, Slot, Args, CallOrInvoke);
   };
-  return ReturnSlotWrapper ? ReturnSlotWrapper(FnInfo, doEmitCall)
-                           : doEmitCall(ReturnValueSlot());
+  return WithReturnValueSlot ? WithReturnValueSlot(FnInfo, doEmitCall)
+                             : doEmitCall(ReturnValueSlot());
 }
 
 Address CodeGenFunction::GetAddrOfBlockDecl(const VarDecl *variable) {

--- a/clang/lib/CodeGen/CGBlocks.cpp
+++ b/clang/lib/CodeGen/CGBlocks.cpp
@@ -1169,8 +1169,8 @@ llvm::Type *CodeGenModule::getGenericBlockLiteralType() {
 }
 
 RValue CodeGenFunction::EmitBlockCallExpr(const CallExpr *E,
-                                          ReturnValueSlot ReturnValue,
-                                          llvm::CallBase **CallOrInvoke) {
+                                          llvm::CallBase **CallOrInvoke,
+                                          ReturnSlotFn ReturnSlotWrapper) {
   const auto *BPT = E->getCallee()->getType()->castAs<BlockPointerType>();
   llvm::Value *BlockPtr = EmitScalarExpr(E->getCallee());
   llvm::Type *GenBlockTy = CGM.getGenericBlockLiteralType();
@@ -1236,8 +1236,12 @@ RValue CodeGenFunction::EmitBlockCallExpr(const CallExpr *E,
 
   CGCallee Callee(CGCalleeInfo(), Func, PointerAuth);
 
-  // And call the block.
-  return EmitCall(FnInfo, Callee, ReturnValue, Args, CallOrInvoke);
+  // And call the block, applying the wrapper (if any) after EmitCallArgs above.
+  auto doEmitCall = [&](ReturnValueSlot Slot) {
+    return EmitCall(FnInfo, Callee, Slot, Args, CallOrInvoke);
+  };
+  return ReturnSlotWrapper ? ReturnSlotWrapper(FnInfo, doEmitCall)
+                           : doEmitCall(ReturnValueSlot());
 }
 
 Address CodeGenFunction::GetAddrOfBlockDecl(const VarDecl *variable) {

--- a/clang/lib/CodeGen/CGBlocks.cpp
+++ b/clang/lib/CodeGen/CGBlocks.cpp
@@ -1236,7 +1236,7 @@ RValue CodeGenFunction::EmitBlockCallExpr(const CallExpr *E,
 
   CGCallee Callee(CGCalleeInfo(), Func, PointerAuth);
 
-  // And call the block, applying the wrapper (if any) after EmitCallArgs above.
+  // And call the block.
   auto doEmitCall = [&](ReturnValueSlot Slot) {
     return EmitCall(FnInfo, Callee, Slot, Args, CallOrInvoke);
   };

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -800,7 +800,7 @@ static RValue emitLibraryCall(CodeGenFunction &CGF, const FunctionDecl *FD,
   CGCallee callee = CGCallee::forDirect(calleeValue, GlobalDecl(FD));
   llvm::CallBase *callOrInvoke = nullptr;
   CGFunctionInfo const *FnInfo = nullptr;
-  return CGF.EmitCall(E->getCallee()->getType(), callee, E, ReturnValueSlot(),
+  return CGF.EmitCall(E->getCallee()->getType(), callee, E,
                       /*Chain=*/nullptr, &callOrInvoke, &FnInfo);
 }
 
@@ -2929,7 +2929,7 @@ private:
 
 RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
                                         const CallExpr *E,
-                                        ReturnValueSlot ReturnValue) {
+                                        ReturnSlotFn ReturnSlotWrapper) {
   assert(!getContext().BuiltinInfo.isImmediate(BuiltinID) &&
          "Should not codegen for consteval builtins");
 
@@ -6153,9 +6153,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_call_with_static_chain: {
     const CallExpr *Call = cast<CallExpr>(E->getArg(0));
     const Expr *Chain = E->getArg(1);
-    return EmitCall(Call->getCallee()->getType(),
-                    EmitCallee(Call->getCallee()), Call, ReturnValue,
-                    EmitScalarExpr(Chain));
+    return EmitCall(Call->getCallee()->getType(), EmitCallee(Call->getCallee()),
+                    Call, EmitScalarExpr(Chain));
   }
   case Builtin::BI_InterlockedExchange8:
   case Builtin::BI_InterlockedExchange16:
@@ -7083,55 +7082,64 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     return RValue::get(V);
   }
 
-  // Some target-specific builtins can have aggregate return values, e.g.
-  // __builtin_arm_mve_vld2q_u32. So if the result is an aggregate, force
-  // ReturnValue to be non-null, so that the target-specific emission code can
-  // always just emit into it.
   TypeEvaluationKind EvalKind = getEvaluationKind(E->getType());
-  if (EvalKind == TEK_Aggregate && ReturnValue.isNull()) {
-    Address DestPtr = CreateMemTemp(E->getType(), "agg.tmp");
-    ReturnValue = ReturnValueSlot(DestPtr, false);
-  }
-
-  // Now see if we can emit a target-specific builtin.
-  if (Value *V = EmitTargetBuiltinExpr(BuiltinID, E, ReturnValue)) {
-    switch (EvalKind) {
-    case TEK_Scalar:
-      if (V->getType()->isVoidTy())
-        return RValue::get(nullptr);
-      return RValue::get(V);
-    case TEK_Aggregate:
-      return RValue::getAggregate(ReturnValue.getAddress(),
-                                  ReturnValue.isVolatile());
-    case TEK_Complex:
-      llvm_unreachable("No current target builtin returns complex");
+  auto doEmitTargetBuiltin = [&](ReturnValueSlot ReturnValue) -> RValue {
+    // Some target-specific builtins can have aggregate return values, e.g.
+    // __builtin_arm_mve_vld2q_u32. So if the result is an aggregate, force
+    // ReturnValue to be non-null, so that the target-specific emission code can
+    // always just emit into it.
+    if (EvalKind == TEK_Aggregate && ReturnValue.isNull()) {
+      Address DestPtr = CreateMemTemp(E->getType(), "agg.tmp");
+      ReturnValue = ReturnValueSlot(DestPtr, false);
     }
-    llvm_unreachable("Bad evaluation kind in EmitBuiltinExpr");
-  }
 
-  // EmitHLSLBuiltinExpr will check getLangOpts().HLSL
-  if (Value *V = EmitHLSLBuiltinExpr(BuiltinID, E, ReturnValue)) {
-    switch (EvalKind) {
-    case TEK_Scalar:
-      if (V->getType()->isVoidTy())
-        return RValue::get(nullptr);
-      return RValue::get(V);
-    case TEK_Aggregate:
-      return RValue::getAggregate(ReturnValue.getAddress(),
-                                  ReturnValue.isVolatile());
-    case TEK_Complex:
-      llvm_unreachable("No current hlsl builtin returns complex");
+    // Now see if we can emit a target-specific builtin.
+    if (Value *V = EmitTargetBuiltinExpr(BuiltinID, E, ReturnValue)) {
+      switch (EvalKind) {
+      case TEK_Scalar:
+        if (V->getType()->isVoidTy())
+          return RValue::get(nullptr);
+        return RValue::get(V);
+      case TEK_Aggregate:
+        return RValue::getAggregate(ReturnValue.getAddress(),
+                                    ReturnValue.isVolatile());
+      case TEK_Complex:
+        llvm_unreachable("No current target builtin returns complex");
+      }
+      llvm_unreachable("Bad evaluation kind in EmitBuiltinExpr");
     }
-    llvm_unreachable("Bad evaluation kind in EmitBuiltinExpr");
-  }
 
-  if (getLangOpts().HIPStdPar && getLangOpts().CUDAIsDevice)
-    return EmitHipStdParUnsupportedBuiltin(this, FD);
+    // EmitHLSLBuiltinExpr will check getLangOpts().HLSL
+    if (Value *V = EmitHLSLBuiltinExpr(BuiltinID, E, ReturnValue)) {
+      switch (EvalKind) {
+      case TEK_Scalar:
+        if (V->getType()->isVoidTy())
+          return RValue::get(nullptr);
+        return RValue::get(V);
+      case TEK_Aggregate:
+        return RValue::getAggregate(ReturnValue.getAddress(),
+                                    ReturnValue.isVolatile());
+      case TEK_Complex:
+        llvm_unreachable("No current hlsl builtin returns complex");
+      }
+      llvm_unreachable("Bad evaluation kind in EmitBuiltinExpr");
+    }
 
-  ErrorUnsupported(E, "builtin function");
+    if (getLangOpts().HIPStdPar && getLangOpts().CUDAIsDevice)
+      return EmitHipStdParUnsupportedBuiltin(this, FD);
 
-  // Unknown builtin, for now just dump it out and return undef.
-  return GetUndefRValue(E->getType());
+    ErrorUnsupported(E, "builtin function");
+
+    // Unknown builtin, for now just dump it out and return undef.
+    return GetUndefRValue(E->getType());
+  };
+
+  if (ReturnSlotWrapper) {
+    const CGFunctionInfo &FnInfo =
+        CGM.getTypes().arrangeFunctionDeclaration(FD);
+    return ReturnSlotWrapper(FnInfo, doEmitTargetBuiltin);
+  } else
+    return doEmitTargetBuiltin(ReturnValueSlot());
 }
 
 namespace {

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -2929,7 +2929,7 @@ private:
 
 RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
                                         const CallExpr *E,
-                                        ReturnSlotFn ReturnSlotWrapper) {
+                                        ReturnSlotFn WithReturnValueSlot) {
   assert(!getContext().BuiltinInfo.isImmediate(BuiltinID) &&
          "Should not codegen for consteval builtins");
 
@@ -7134,10 +7134,10 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     return GetUndefRValue(E->getType());
   };
 
-  if (ReturnSlotWrapper) {
+  if (WithReturnValueSlot) {
     const CGFunctionInfo &FnInfo =
         CGM.getTypes().arrangeFunctionDeclaration(FD);
-    return ReturnSlotWrapper(FnInfo, doEmitTargetBuiltin);
+    return WithReturnValueSlot(FnInfo, doEmitTargetBuiltin);
   } else
     return doEmitTargetBuiltin(ReturnValueSlot());
 }

--- a/clang/lib/CodeGen/CGCUDARuntime.cpp
+++ b/clang/lib/CodeGen/CGCUDARuntime.cpp
@@ -59,9 +59,10 @@ static llvm::Value *emitGetParamBuf(CodeGenFunction &CGF,
   return Ret.getScalarVal();
 }
 
-RValue CGCUDARuntime::EmitCUDADeviceKernelCallExpr(
-    CodeGenFunction &CGF, const CUDAKernelCallExpr *E,
-    ReturnValueSlot ReturnValue, llvm::CallBase **CallOrInvoke) {
+RValue
+CGCUDARuntime::EmitCUDADeviceKernelCallExpr(CodeGenFunction &CGF,
+                                            const CUDAKernelCallExpr *E,
+                                            llvm::CallBase **CallOrInvoke) {
   assert(CGM.getContext().getcudaLaunchDeviceDecl() ==
          E->getConfig()->getDirectCallee());
 
@@ -110,14 +111,14 @@ RValue CGCUDARuntime::EmitCUDADeviceKernelCallExpr(
   CGF.EmitCallArgs(LaunchCallArgs,
                    LaunchCalleeFuncTy->getAs<FunctionProtoType>(),
                    LaunchCall->arguments(), LaunchCall->getDirectCallee());
-  // Replace func and paramterbuffer arguments.
+  // Replace func and parameterbuffer arguments.
   LaunchCallArgs[0] = CallArg(RValue::get(KernelCallee.getFunctionPointer()),
                               CGM.getContext().VoidPtrTy);
   LaunchCallArgs[1] = CallArg(RValue::get(Config), CGM.getContext().VoidPtrTy);
   const CGFunctionInfo &LaunchCallInfo = CGM.getTypes().arrangeFreeFunctionCall(
       LaunchCallArgs, LaunchCalleeFuncTy->getAs<FunctionProtoType>(),
       /*ChainCall=*/false);
-  CGF.EmitCall(LaunchCallInfo, LaunchCallee, ReturnValue, LaunchCallArgs,
+  CGF.EmitCall(LaunchCallInfo, LaunchCallee, ReturnValueSlot(), LaunchCallArgs,
                CallOrInvoke,
                /*IsMustTail=*/false, E->getExprLoc());
   CGF.EmitBranch(ContBlock);
@@ -130,7 +131,6 @@ RValue CGCUDARuntime::EmitCUDADeviceKernelCallExpr(
 
 RValue CGCUDARuntime::EmitCUDAKernelCallExpr(CodeGenFunction &CGF,
                                              const CUDAKernelCallExpr *E,
-                                             ReturnValueSlot ReturnValue,
                                              llvm::CallBase **CallOrInvoke) {
   llvm::BasicBlock *ConfigOKBlock = CGF.createBasicBlock("kcall.configok");
   llvm::BasicBlock *ContBlock = CGF.createBasicBlock("kcall.end");
@@ -141,7 +141,7 @@ RValue CGCUDARuntime::EmitCUDAKernelCallExpr(CodeGenFunction &CGF,
 
   eval.begin(CGF);
   CGF.EmitBlock(ConfigOKBlock);
-  CGF.EmitSimpleCallExpr(E, ReturnValue, CallOrInvoke);
+  CGF.EmitSimpleCallExpr(E, CallOrInvoke);
   CGF.EmitBranch(ContBlock);
 
   CGF.EmitBlock(ContBlock);

--- a/clang/lib/CodeGen/CGCUDARuntime.h
+++ b/clang/lib/CodeGen/CGCUDARuntime.h
@@ -85,12 +85,12 @@ public:
 
   virtual RValue
   EmitCUDAKernelCallExpr(CodeGenFunction &CGF, const CUDAKernelCallExpr *E,
-                         ReturnValueSlot ReturnValue,
                          llvm::CallBase **CallOrInvoke = nullptr);
 
-  virtual RValue EmitCUDADeviceKernelCallExpr(
-      CodeGenFunction &CGF, const CUDAKernelCallExpr *E,
-      ReturnValueSlot ReturnValue, llvm::CallBase **CallOrInvoke = nullptr);
+  virtual RValue
+  EmitCUDADeviceKernelCallExpr(CodeGenFunction &CGF,
+                               const CUDAKernelCallExpr *E,
+                               llvm::CallBase **CallOrInvoke = nullptr);
 
   /// Emits a kernel launch stub.
   virtual void emitDeviceStub(CodeGenFunction &CGF, FunctionArgList &Args) = 0;

--- a/clang/lib/CodeGen/CGCall.h
+++ b/clang/lib/CodeGen/CGCall.h
@@ -37,6 +37,7 @@ class TargetOptions;
 class VarDecl;
 
 namespace CodeGen {
+class CGFunctionInfo;
 
 /// Abstract information about a function or function prototype.
 class CGCalleeInfo {
@@ -440,6 +441,45 @@ struct DisableDebugLocationUpdates {
   DisableDebugLocationUpdates(const DisableDebugLocationUpdates &) = delete;
   DisableDebugLocationUpdates &
   operator=(const DisableDebugLocationUpdates &) = delete;
+};
+
+/// Callback type for wrapping the innermost EmitCall(FnInfo,...) in
+/// withReturnValueSlot logic. Receives the resolved CGFunctionInfo and an
+/// inner function_ref (ReturnValueSlot → RValue); must call it exactly once.
+struct ReturnSlotFn {
+  bool IsResultUnused = false;
+
+  ReturnSlotFn() = default;
+  ReturnSlotFn(std::nullptr_t) {}
+
+  /// Bind a member function as the callback. MemFn must be a non-type template
+  /// argument so the trampoline is a stateless (convertible-to-fptr) lambda.
+  template <auto MemFn, typename T>
+  static ReturnSlotFn make(T *Obj, bool IsResultUnused) {
+    ReturnSlotFn R;
+    R.IsResultUnused = IsResultUnused;
+    R.Obj = Obj;
+    R.Trampoline =
+        [](void *O, const CGFunctionInfo &FI,
+           llvm::function_ref<RValue(ReturnValueSlot)> EC) -> RValue {
+      return (static_cast<T *>(O)->*MemFn)(FI, EC);
+    };
+    return R;
+  }
+
+  RValue
+  operator()(const CGFunctionInfo &FnInfo,
+             llvm::function_ref<RValue(ReturnValueSlot)> EmitCall) const {
+    return Trampoline(Obj, FnInfo, EmitCall);
+  }
+
+  explicit operator bool() const { return Obj != nullptr; }
+
+private:
+  using TrampolineFn = RValue(void *, const CGFunctionInfo &,
+                              llvm::function_ref<RValue(ReturnValueSlot)>);
+  void *Obj = nullptr;
+  TrampolineFn *Trampoline = nullptr;
 };
 
 } // end namespace CodeGen

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1358,9 +1358,6 @@ bool CodeGenFunction::EmitLifetimeStart(llvm::Value *Addr) {
   if (!ShouldEmitLifetimeMarkers)
     return false;
 
-  assert(Addr->getType()->getPointerAddressSpace() ==
-             CGM.getDataLayout().getAllocaAddrSpace() &&
-         "Pointer should be in alloca address space");
   llvm::CallInst *C = Builder.CreateCall(CGM.getLLVMLifetimeStartFn(), {Addr});
   C->setDoesNotThrow();
   return true;
@@ -1370,9 +1367,6 @@ void CodeGenFunction::EmitLifetimeEnd(llvm::Value *Addr) {
   if (!ShouldEmitLifetimeMarkers)
     return;
 
-  assert(Addr->getType()->getPointerAddressSpace() ==
-             CGM.getDataLayout().getAllocaAddrSpace() &&
-         "Pointer should be in alloca address space");
   llvm::CallInst *C = Builder.CreateCall(CGM.getLLVMLifetimeEndFn(), {Addr});
   C->setDoesNotThrow();
 }
@@ -2684,8 +2678,6 @@ void CodeGenFunction::EmitParmDecl(const VarDecl &D, ParamValue Arg,
     Arg.getAnyValue()->setName(D.getName());
 
   QualType Ty = D.getType();
-  assert((getLangOpts().OpenCL || Ty.getAddressSpace() == LangAS::Default) &&
-         "parameter has non-default address space in non-OpenCL mode");
 
   // Use better IR generation for certain implicit parameters.
   if (auto IPD = dyn_cast<ImplicitParamDecl>(&D)) {

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -216,8 +216,7 @@ RawAddress CodeGenFunction::CreateMemTemp(QualType Ty, CharUnits Align,
     }
     auto *VectorTy = llvm::FixedVectorType::get(ArrayElementTy, ArrayElements);
 
-    Result = Address(Result.getPointer(), VectorTy, Result.getAlignment(),
-                     KnownNonNull);
+    Result = Result.withElementType(VectorTy);
   }
   return Result;
 }

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -6450,8 +6450,8 @@ RValue CodeGenFunction::EmitRValueForField(LValue LV,
 //===--------------------------------------------------------------------===//
 
 RValue CodeGenFunction::EmitCallExpr(const CallExpr *E,
-                                     ReturnValueSlot ReturnValue,
-                                     llvm::CallBase **CallOrInvoke) {
+                                     llvm::CallBase **CallOrInvoke,
+                                     ReturnSlotFn ReturnSlotWrapper) {
   llvm::CallBase *CallOrInvokeStorage;
   if (!CallOrInvoke) {
     CallOrInvoke = &CallOrInvokeStorage;
@@ -6465,15 +6465,18 @@ RValue CodeGenFunction::EmitCallExpr(const CallExpr *E,
     }
   });
 
-  // Builtins never have block type.
+  // Thread the wrapper into EmitBlockCallExpr so it can be applied after
+  // EmitCallArgs inside that function.
   if (E->getCallee()->getType()->isBlockPointerType())
-    return EmitBlockCallExpr(E, ReturnValue, CallOrInvoke);
+    return EmitBlockCallExpr(E, CallOrInvoke, ReturnSlotWrapper);
 
   if (const auto *CE = dyn_cast<CXXMemberCallExpr>(E))
-    return EmitCXXMemberCallExpr(CE, ReturnValue, CallOrInvoke);
+    return EmitCXXMemberCallExpr(CE, CallOrInvoke, ReturnSlotWrapper);
 
-  if (const auto *CE = dyn_cast<CUDAKernelCallExpr>(E))
-    return EmitCUDAKernelCallExpr(CE, ReturnValue, CallOrInvoke);
+  if (const auto *CE = dyn_cast<CUDAKernelCallExpr>(E)) {
+    assert(!ReturnSlotWrapper && "CUDA kernel calls cannot return aggregates");
+    return EmitCUDAKernelCallExpr(CE, CallOrInvoke);
+  }
 
   // A CXXOperatorCallExpr is created even for explicit object methods, but
   // these should be treated like static function call.
@@ -6481,29 +6484,30 @@ RValue CodeGenFunction::EmitCallExpr(const CallExpr *E,
     if (const auto *MD =
             dyn_cast_if_present<CXXMethodDecl>(CE->getCalleeDecl());
         MD && MD->isImplicitObjectMemberFunction())
-      return EmitCXXOperatorMemberCallExpr(CE, MD, ReturnValue, CallOrInvoke);
+      return EmitCXXOperatorMemberCallExpr(CE, MD, CallOrInvoke,
+                                           ReturnSlotWrapper);
 
   CGCallee callee = EmitCallee(E->getCallee());
 
-  if (callee.isBuiltin()) {
-    return EmitBuiltinExpr(callee.getBuiltinDecl(), callee.getBuiltinID(),
-                           E, ReturnValue);
-  }
+  if (callee.isBuiltin())
+    return EmitBuiltinExpr(callee.getBuiltinDecl(), callee.getBuiltinID(), E,
+                           ReturnSlotWrapper);
 
-  if (callee.isPseudoDestructor()) {
+  if (callee.isPseudoDestructor())
     return EmitCXXPseudoDestructorExpr(callee.getPseudoDestructorExpr());
-  }
 
-  return EmitCall(E->getCallee()->getType(), callee, E, ReturnValue,
-                  /*Chain=*/nullptr, CallOrInvoke);
+  // For the regular call path, thread the wrapper through to EmitCall so it
+  // is applied just after EmitCallArgs inside that function.
+  return EmitCall(E->getCallee()->getType(), callee, E,
+                  /*Chain=*/nullptr, CallOrInvoke, /*ResolvedFnInfo=*/nullptr,
+                  ReturnSlotWrapper);
 }
 
 /// Emit a CallExpr without considering whether it might be a subclass.
 RValue CodeGenFunction::EmitSimpleCallExpr(const CallExpr *E,
-                                           ReturnValueSlot ReturnValue,
                                            llvm::CallBase **CallOrInvoke) {
   CGCallee Callee = EmitCallee(E->getCallee());
-  return EmitCall(E->getCallee()->getType(), Callee, E, ReturnValue,
+  return EmitCall(E->getCallee()->getType(), Callee, E,
                   /*Chain=*/nullptr, CallOrInvoke);
 }
 
@@ -6789,7 +6793,7 @@ LValue CodeGenFunction::EmitHLSLArrayAssignLValue(const BinaryOperator *E) {
 
 LValue CodeGenFunction::EmitCallExprLValue(const CallExpr *E,
                                            llvm::CallBase **CallOrInvoke) {
-  RValue RV = EmitCallExpr(E, ReturnValueSlot(), CallOrInvoke);
+  RValue RV = EmitCallExpr(E, CallOrInvoke);
 
   if (!RV.isScalar())
     return MakeAddrLValue(RV.getAggregateAddress(), E->getType(),
@@ -6914,10 +6918,10 @@ LValue CodeGenFunction::EmitStmtExprLValue(const StmtExpr *E) {
 
 RValue CodeGenFunction::EmitCall(QualType CalleeType,
                                  const CGCallee &OrigCallee, const CallExpr *E,
-                                 ReturnValueSlot ReturnValue,
                                  llvm::Value *Chain,
                                  llvm::CallBase **CallOrInvoke,
-                                 CGFunctionInfo const **ResolvedFnInfo) {
+                                 CGFunctionInfo const **ResolvedFnInfo,
+                                 ReturnSlotFn ReturnSlotWrapper) {
   // Get the actual function type. The callee type will always be a pointer to
   // function type or a block pointer type.
   assert(CalleeType->isFunctionPointerType() &&
@@ -7149,8 +7153,12 @@ RValue CodeGenFunction::EmitCall(QualType CalleeType,
   }
 
   llvm::CallBase *LocalCallOrInvoke = nullptr;
-  RValue Call = EmitCall(FnInfo, Callee, ReturnValue, Args, &LocalCallOrInvoke,
-                         E == MustTailCall, E->getExprLoc());
+  auto doEmitCall = [&](ReturnValueSlot Slot) {
+    return EmitCall(FnInfo, Callee, Slot, Args, &LocalCallOrInvoke,
+                    E == MustTailCall, E->getExprLoc());
+  };
+  RValue Call = ReturnSlotWrapper ? ReturnSlotWrapper(FnInfo, doEmitCall)
+                                  : doEmitCall(ReturnValueSlot());
 
   if (auto *CalleeDecl = dyn_cast_or_null<FunctionDecl>(TargetDecl)) {
     if (CalleeDecl->hasAttr<RestrictAttr>() ||

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -6451,7 +6451,7 @@ RValue CodeGenFunction::EmitRValueForField(LValue LV,
 
 RValue CodeGenFunction::EmitCallExpr(const CallExpr *E,
                                      llvm::CallBase **CallOrInvoke,
-                                     ReturnSlotFn ReturnSlotWrapper) {
+                                     ReturnSlotFn WithReturnValueSlot) {
   llvm::CallBase *CallOrInvokeStorage;
   if (!CallOrInvoke) {
     CallOrInvoke = &CallOrInvokeStorage;
@@ -6467,13 +6467,14 @@ RValue CodeGenFunction::EmitCallExpr(const CallExpr *E,
 
   // Builtins never have block type.
   if (E->getCallee()->getType()->isBlockPointerType())
-    return EmitBlockCallExpr(E, CallOrInvoke, ReturnSlotWrapper);
+    return EmitBlockCallExpr(E, CallOrInvoke, WithReturnValueSlot);
 
   if (const auto *CE = dyn_cast<CXXMemberCallExpr>(E))
-    return EmitCXXMemberCallExpr(CE, CallOrInvoke, ReturnSlotWrapper);
+    return EmitCXXMemberCallExpr(CE, CallOrInvoke, WithReturnValueSlot);
 
   if (const auto *CE = dyn_cast<CUDAKernelCallExpr>(E)) {
-    assert(!ReturnSlotWrapper && "CUDA kernel calls cannot return aggregates");
+    assert(!WithReturnValueSlot &&
+           "CUDA kernel calls cannot return aggregates");
     return EmitCUDAKernelCallExpr(CE, CallOrInvoke);
   }
 
@@ -6484,20 +6485,20 @@ RValue CodeGenFunction::EmitCallExpr(const CallExpr *E,
             dyn_cast_if_present<CXXMethodDecl>(CE->getCalleeDecl());
         MD && MD->isImplicitObjectMemberFunction())
       return EmitCXXOperatorMemberCallExpr(CE, MD, CallOrInvoke,
-                                           ReturnSlotWrapper);
+                                           WithReturnValueSlot);
 
   CGCallee callee = EmitCallee(E->getCallee());
 
   if (callee.isBuiltin())
     return EmitBuiltinExpr(callee.getBuiltinDecl(), callee.getBuiltinID(), E,
-                           ReturnSlotWrapper);
+                           WithReturnValueSlot);
 
   if (callee.isPseudoDestructor())
     return EmitCXXPseudoDestructorExpr(callee.getPseudoDestructorExpr());
 
   return EmitCall(E->getCallee()->getType(), callee, E,
                   /*Chain=*/nullptr, CallOrInvoke, /*ResolvedFnInfo=*/nullptr,
-                  ReturnSlotWrapper);
+                  WithReturnValueSlot);
 }
 
 /// Emit a CallExpr without considering whether it might be a subclass.
@@ -6918,7 +6919,7 @@ RValue CodeGenFunction::EmitCall(QualType CalleeType,
                                  llvm::Value *Chain,
                                  llvm::CallBase **CallOrInvoke,
                                  CGFunctionInfo const **ResolvedFnInfo,
-                                 ReturnSlotFn ReturnSlotWrapper) {
+                                 ReturnSlotFn WithReturnValueSlot) {
   // Get the actual function type. The callee type will always be a pointer to
   // function type or a block pointer type.
   assert(CalleeType->isFunctionPointerType() &&
@@ -7154,8 +7155,8 @@ RValue CodeGenFunction::EmitCall(QualType CalleeType,
     return EmitCall(FnInfo, Callee, Slot, Args, &LocalCallOrInvoke,
                     E == MustTailCall, E->getExprLoc());
   };
-  RValue Call = ReturnSlotWrapper ? ReturnSlotWrapper(FnInfo, doEmitCall)
-                                  : doEmitCall(ReturnValueSlot());
+  RValue Call = WithReturnValueSlot ? WithReturnValueSlot(FnInfo, doEmitCall)
+                                    : doEmitCall(ReturnValueSlot());
 
   if (auto *CalleeDecl = dyn_cast_or_null<FunctionDecl>(TargetDecl)) {
     if (CalleeDecl->hasAttr<RestrictAttr>() ||

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -6465,8 +6465,7 @@ RValue CodeGenFunction::EmitCallExpr(const CallExpr *E,
     }
   });
 
-  // Thread the wrapper into EmitBlockCallExpr so it can be applied after
-  // EmitCallArgs inside that function.
+  // Builtins never have block type.
   if (E->getCallee()->getType()->isBlockPointerType())
     return EmitBlockCallExpr(E, CallOrInvoke, ReturnSlotWrapper);
 
@@ -6496,8 +6495,6 @@ RValue CodeGenFunction::EmitCallExpr(const CallExpr *E,
   if (callee.isPseudoDestructor())
     return EmitCXXPseudoDestructorExpr(callee.getPseudoDestructorExpr());
 
-  // For the regular call path, thread the wrapper through to EmitCall so it
-  // is applied just after EmitCallArgs inside that function.
   return EmitCall(E->getCallee()->getType(), callee, E,
                   /*Chain=*/nullptr, CallOrInvoke, /*ResolvedFnInfo=*/nullptr,
                   ReturnSlotWrapper);

--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -62,8 +62,13 @@ class AggExprEmitter : public StmtVisitor<AggExprEmitter> {
   //
   // The given function should take a ReturnValueSlot, and return an RValue that
   // points to said slot.
-  void withReturnValueSlot(const Expr *E,
-                           llvm::function_ref<RValue(ReturnValueSlot)> Fn);
+  RValue withReturnValueSlot(const CGFunctionInfo &FnInfo,
+                             llvm::function_ref<RValue(ReturnValueSlot)> Fn);
+
+  ReturnSlotFn makeReturnSlotFn() {
+    return ReturnSlotFn::make<&AggExprEmitter::withReturnValueSlot>(
+        this, IsResultUnused);
+  }
 
   void DoZeroInitPadding(uint64_t &PaddingStart, uint64_t PaddingEnd,
                          const FieldDecl *NextField);
@@ -312,9 +317,10 @@ static bool EmitLifetimeStartOnAlloca(CodeGenFunction &CGF, llvm::Value *Ptr) {
   return false;
 }
 
-void AggExprEmitter::withReturnValueSlot(
-    const Expr *E, llvm::function_ref<RValue(ReturnValueSlot)> EmitCall) {
-  QualType RetTy = E->getType();
+RValue AggExprEmitter::withReturnValueSlot(
+    const CGFunctionInfo &FnInfo,
+    llvm::function_ref<RValue(ReturnValueSlot)> EmitCall) {
+  QualType RetTy = FnInfo.getReturnType();
 
   // If it makes no observable difference, save a memcpy + temporary.
   // This is not just an optimization: avoiding the copy may be mandatory in
@@ -382,11 +388,11 @@ void AggExprEmitter::withReturnValueSlot(
                                Dest.isExternallyDestructed()));
 
   if (NoCopy)
-    return;
+    return Src;
 
-  assert(Dest.isIgnored() || Dest.emitRawPointer(CGF) !=
-                                 Src.getAggregatePointer(E->getType(), CGF));
-  EmitFinalDestCopy(E->getType(), Src);
+  assert(Dest.isIgnored() ||
+         Dest.emitRawPointer(CGF) != Src.getAggregatePointer(RetTy, CGF));
+  EmitFinalDestCopy(RetTy, Src);
 
   if (!RequiresDestruction && LifetimeStartInst) {
     // If there's no dtor to run, the copy was the last use of our temporary.
@@ -395,6 +401,7 @@ void AggExprEmitter::withReturnValueSlot(
     CGF.DeactivateCleanupBlock(LifetimeEndBlock, LifetimeStartInst);
     CGF.EmitLifetimeEnd(LifetimeStartInst->getArgOperand(0));
   }
+  return Src;
 }
 
 /// EmitFinalDestCopy - Perform the final copy to DestPtr, if desired.
@@ -1128,14 +1135,11 @@ void AggExprEmitter::VisitCallExpr(const CallExpr *E) {
     return;
   }
 
-  withReturnValueSlot(
-      E, [&](ReturnValueSlot Slot) { return CGF.EmitCallExpr(E, Slot); });
+  CGF.EmitCallExpr(E, /*CallOrInvoke=*/nullptr, makeReturnSlotFn());
 }
 
 void AggExprEmitter::VisitObjCMessageExpr(ObjCMessageExpr *E) {
-  withReturnValueSlot(E, [&](ReturnValueSlot Slot) {
-    return CGF.EmitObjCMessageExpr(E, Slot);
-  });
+  CGF.EmitObjCMessageExpr(E, makeReturnSlotFn());
 }
 
 void AggExprEmitter::VisitBinComma(const BinaryOperator *E) {

--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -283,30 +283,47 @@ void AggExprEmitter::withReturnValueSlot(
 
   // If it makes no observable difference, save a memcpy + temporary.
   //
-  // We need to always provide our own temporary if destruction is required.
+  // We need to always provide an address if destruction is required.
   // Otherwise, EmitCall will emit its own, notice that it's "unused", and end
   // its lifetime before we have the chance to emit a proper destructor call.
-  //
-  // We also need a temporary if the destination is in a different address space
-  // from the sret AS. Use the target hook to get the actual sret AS for this
-  // return type.
   const CXXRecordDecl *RD = RetTy->getAsCXXRecordDecl();
-  LangAS SRetLangAS = CGF.CGM.getTargetCodeGenInfo().getSRetAddrSpace(RD);
-  unsigned SRetAS = CGF.getContext().getTargetAddressSpace(SRetLangAS);
-  bool CanAggregateCopy =
-      RD ? (RD->hasTrivialCopyConstructor() ||
-            RD->hasTrivialMoveConstructor() || RD->hasTrivialCopyAssignment() ||
-            RD->hasTrivialMoveAssignment() || RD->hasAttr<TrivialABIAttr>() ||
-            RD->isUnion())
-         : RetTy.isTriviallyCopyableType(CGF.getContext());
-  bool DestASMismatch = !Dest.isIgnored() && CanAggregateCopy &&
-                        Dest.getAddress()
-                                .getBasePointer()
-                                ->stripPointerCasts()
-                                ->getType()
-                                ->getPointerAddressSpace() != SRetAS;
-  bool UseTemp = Dest.isPotentiallyAliased() || Dest.requiresGCollection() ||
-                 (RequiresDestruction && Dest.isIgnored()) || DestASMismatch;
+  // Initially assume we will need to pass through the destination memory.
+  unsigned SRetAS =
+      CGF.getContext().getTargetAddressSpace(RetTy.getAddressSpace());
+  bool DestASMismatch = false;
+  // However, ABIInfo might be permitted to make this return indirect. If it
+  // does, and RetTy doesn't specify an address space, it is also permitted (but
+  // not required) to change the ABI addrspace to alloca. We don't yet know what
+  // it will decide, so make a copy here for the optimizer to remove if it can
+  // prove it unnecessary later.
+  if (!RD || RD->canPassInRegisters()) {
+    if (!RetTy.hasAddressSpace()) {
+      SRetAS = CGF.CGM.getDataLayout().getAllocaAddrSpace();
+      // This will now require a copy unless we can find an underlying object
+      // with the correct addrspace to use for dest.
+      if (!Dest.isIgnored()) {
+        llvm::Value *DestV = Dest.getAddress().getBasePointer();
+        if (DestV->getType()->getPointerAddressSpace() != SRetAS) {
+          DestV = DestV->stripPointerCasts();
+          if (DestV->getType()->getPointerAddressSpace() != SRetAS)
+            DestASMismatch = true;
+        }
+      }
+    }
+  }
+  // Decide if a copy is possibly legal, in which case ABIInfo might later
+  // decide this copy is required. Be careful not to try to use a copy in cases
+  // where it wouldn't be legal, in which case ABIInfo also should not expect
+  // a copy either.
+  bool UseTemp =
+      // Copy okay by construction (see note on AggValueSlot::AliasedFlag)
+      Dest.isPotentiallyAliased()
+      // Copy permitted by ObjC semantics
+      || Dest.requiresGCollection()
+      // No actual copy is performed, since there is no Dest
+      || (RequiresDestruction && Dest.isIgnored())
+      // ABIInfo only requests a copy if it is legal
+      || DestASMismatch;
 
   Address RetAddr = Address::invalid();
 

--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -279,44 +279,6 @@ bool AggExprEmitter::TypeRequiresGCollection(QualType T) {
   return Record->hasObjectMember();
 }
 
-static bool mightABIExpectAllocaAndNotAlloca(const Address RetAddr,
-                                             QualType RetTy,
-                                             const llvm::DataLayout &DL) {
-  const CXXRecordDecl *RD = RetTy->getAsCXXRecordDecl();
-  // ABIInfo might be permitted to make this return indirect. If it does, and
-  // RetTy doesn't specify an address space, it is also permitted (but not
-  // required) to change the ABI addrspace to alloca (adding an addrspacecase).
-  // We don't yet know what it will decide (awkwardly this query runs just
-  // before ABIInfo decides how to pass this sret parameter), so this may need
-  // to make a copy here, which maybe the optimizer could remove later, if it
-  // can still prove it unnecessary.
-  if (!RetAddr.isValid())
-    return false;
-  if (RetTy.hasAddressSpace())
-    return false;
-  if (RD && !RD->canPassInRegisters())
-    return false;
-  unsigned AllocaAS = DL.getAllocaAddrSpace();
-  // This will require a copy to ensure it is in the alloca (ABIInfo's
-  // indirect) addrspace unless we can find that the underlying object was
-  // already in alloca addrspace.
-  llvm::Value *DestV = RetAddr.getBasePointer();
-  if (DestV->getType()->getPointerAddressSpace() == AllocaAS)
-    return false;
-  DestV = DestV->stripPointerCasts();
-  if (DestV->getType()->getPointerAddressSpace() == AllocaAS)
-    return false;
-  return true;
-}
-
-static bool EmitLifetimeStartOnAlloca(CodeGenFunction &CGF, llvm::Value *Ptr) {
-  // Lifetime start is only valid on alloca
-  Ptr = Ptr->stripPointerCasts();
-  if (isa<llvm::AllocaInst>(Ptr))
-    return CGF.EmitLifetimeStart(Ptr);
-  return false;
-}
-
 RValue AggExprEmitter::withReturnValueSlot(
     const CGFunctionInfo &FnInfo,
     llvm::function_ref<RValue(ReturnValueSlot)> EmitCall) {
@@ -329,14 +291,32 @@ RValue AggExprEmitter::withReturnValueSlot(
   // We need to always provide an address if destruction is required.
   // Otherwise, EmitCall will emit its own, notice that it's "unused", and end
   // its lifetime before we have the chance to emit a proper destructor call.
-  //
-  // Decide if a copy is possibly legal, in which case ABIInfo might later
-  // decide this copy is required. Be careful not to try to use a copy in cases
-  // where it wouldn't be legal, in which case ABIInfo also should not expect
-  // a copy (not require an alloca) either.
   bool RequiresDestruction =
       !Dest.isExternallyDestructed() &&
       RetTy.isDestructedType() == QualType::DK_nontrivial_c_struct;
+
+  // Determine the addrspace the ABI requires for the sret pointer, using the
+  // actual ABI decision from FnInfo rather than guessing from the QualType.
+  const ABIArgInfo &RetInfo = FnInfo.getReturnInfo();
+  bool ABIReturnsIndirect = RetInfo.isIndirect() || RetInfo.isIndirectAliased();
+  unsigned SRetAS =
+      ABIReturnsIndirect
+          ? RetInfo.getIndirectAddrSpace()
+          : CGF.getContext().getTargetAddressSpace(RetTy.getAddressSpace());
+
+  // Check whether a copy is required because the destination is not in the
+  // addrspace the ABI requires for the sret pointer (and a simple cast won't
+  // suffice because the underlying alloc is in a different addrspace).
+  Address DestAddr = Dest.getAddress();
+  bool addrspaceMismatch = [&] {
+    if (!ABIReturnsIndirect || !DestAddr.isValid())
+      return false;
+    if (DestAddr.getAddressSpace() == SRetAS)
+      return false;
+    llvm::Value *V = DestAddr.getBasePointer()->stripPointerCasts();
+    return V->getType()->getPointerAddressSpace() != SRetAS;
+  }();
+
   bool NoCopy =
       // Copy okay by construction (see note on AggValueSlot::AliasedFlag)
       !Dest.isPotentiallyAliased()
@@ -344,14 +324,10 @@ RValue AggExprEmitter::withReturnValueSlot(
       && !Dest.requiresGCollection()
       // No actual copy is performed, since there is no Dest
       && !(RequiresDestruction && Dest.isIgnored())
-      // ABIInfo only requests a copy if it is legal
-      && !mightABIExpectAllocaAndNotAlloca(Dest.getAddress(), RetTy,
-                                           CGF.CGM.getDataLayout());
+      // ABI sret addrspace requirement is satisfiable with a cast, not a copy
+      && !addrspaceMismatch;
 
   Address RetAddr = Address::invalid();
-  unsigned SRetAS =
-      CGF.getContext().getTargetAddressSpace(RetTy.getAddressSpace());
-
   EHScopeStack::stable_iterator LifetimeEndBlock;
   llvm::IntrinsicInst *LifetimeStartInst = nullptr;
   if (NoCopy)
@@ -359,20 +335,16 @@ RValue AggExprEmitter::withReturnValueSlot(
   else
     RetAddr = CGF.CreateMemTempWithoutCast(RetTy, "tmp");
   if (NoCopy && RetAddr.isValid() && RetAddr.getAddressSpace() != SRetAS) {
-    // n.b. If possibly copying, assume the ABI will do this cast to the right
-    // addrspace if needed from the alloca, otherwise assume it might not?
-    // It is really awkward that this decides if it is going to make this copy
-    // just before clang asks ABIInfo if it even needs a copy to be made.
     llvm::Type *SRetPtrTy =
         llvm::PointerType::get(CGF.getLLVMContext(), SRetAS);
     RetAddr = RetAddr.withPointer(
         CGF.performAddrSpaceCast(RetAddr.getBasePointer(), SRetPtrTy),
         RetAddr.isKnownNonNull());
   }
-  if (!NoCopy && RetAddr.isValid() &&
-      EmitLifetimeStartOnAlloca(CGF, RetAddr.getBasePointer())) {
+  if (!NoCopy && RetAddr.isValid()) {
     // n.b. If not copying, the caller often already emitted the lifetime start,
     // so emitting it again is unnecessary.
+    CGF.EmitLifetimeStart(RetAddr.getBasePointer());
     LifetimeStartInst =
         cast<llvm::IntrinsicInst>(std::prev(Builder.GetInsertPoint()));
     assert(LifetimeStartInst->getIntrinsicID() ==

--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -334,17 +334,10 @@ RValue AggExprEmitter::withReturnValueSlot(
     RetAddr = Dest.getAddress();
   else
     RetAddr = CGF.CreateMemTempWithoutCast(RetTy, "tmp");
-  if (NoCopy && RetAddr.isValid() && RetAddr.getAddressSpace() != SRetAS) {
-    llvm::Type *SRetPtrTy =
-        llvm::PointerType::get(CGF.getLLVMContext(), SRetAS);
-    RetAddr = RetAddr.withPointer(
-        CGF.performAddrSpaceCast(RetAddr.getBasePointer(), SRetPtrTy),
-        RetAddr.isKnownNonNull());
-  }
-  if (!NoCopy && RetAddr.isValid()) {
+  if (!NoCopy && RetAddr.isValid() &&
+      CGF.EmitLifetimeStart(RetAddr.getBasePointer())) {
     // n.b. If not copying, the caller often already emitted the lifetime start,
-    // so emitting it again is unnecessary.
-    CGF.EmitLifetimeStart(RetAddr.getBasePointer());
+    // so emitting it again is unnecessary, though would be semantically valid.
     LifetimeStartInst =
         cast<llvm::IntrinsicInst>(std::prev(Builder.GetInsertPoint()));
     assert(LifetimeStartInst->getIntrinsicID() ==
@@ -354,6 +347,13 @@ RValue AggExprEmitter::withReturnValueSlot(
     CGF.pushFullExprCleanup<CodeGenFunction::CallLifetimeEnd>(
         NormalEHLifetimeMarker, RetAddr);
     LifetimeEndBlock = CGF.EHStack.stable_begin();
+  }
+  if (NoCopy && RetAddr.isValid() && RetAddr.getAddressSpace() != SRetAS) {
+    llvm::Type *SRetPtrTy =
+        llvm::PointerType::get(CGF.getLLVMContext(), SRetAS);
+    RetAddr = RetAddr.withPointer(
+        CGF.performAddrSpaceCast(RetAddr.getBasePointer(), SRetPtrTy),
+        RetAddr.isKnownNonNull());
   }
   RValue Src =
       EmitCall(ReturnValueSlot(RetAddr, Dest.isVolatile(), IsResultUnused,

--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -274,90 +274,114 @@ bool AggExprEmitter::TypeRequiresGCollection(QualType T) {
   return Record->hasObjectMember();
 }
 
+static bool mightABIExpectAllocaAndNotAlloca(const Address RetAddr,
+                                             QualType RetTy,
+                                             const llvm::DataLayout &DL) {
+  const CXXRecordDecl *RD = RetTy->getAsCXXRecordDecl();
+  // ABIInfo might be permitted to make this return indirect. If it does, and
+  // RetTy doesn't specify an address space, it is also permitted (but not
+  // required) to change the ABI addrspace to alloca (adding an addrspacecase).
+  // We don't yet know what it will decide (awkwardly this query runs just
+  // before ABIInfo decides how to pass this sret parameter), so this may need
+  // to make a copy here, which maybe the optimizer could remove later, if it
+  // can still prove it unnecessary.
+  if (!RetAddr.isValid())
+    return false;
+  if (RetTy.hasAddressSpace())
+    return false;
+  if (RD && !RD->canPassInRegisters())
+    return false;
+  unsigned AllocaAS = DL.getAllocaAddrSpace();
+  // This will require a copy to ensure it is in the alloca (ABIInfo's
+  // indirect) addrspace unless we can find that the underlying object was
+  // already in alloca addrspace.
+  llvm::Value *DestV = RetAddr.getBasePointer();
+  if (DestV->getType()->getPointerAddressSpace() == AllocaAS)
+    return false;
+  DestV = DestV->stripPointerCasts();
+  if (DestV->getType()->getPointerAddressSpace() == AllocaAS)
+    return false;
+  return true;
+}
+
+static bool EmitLifetimeStartOnAlloca(CodeGenFunction &CGF, llvm::Value *Ptr) {
+  // Lifetime start is only valid on alloca
+  Ptr = Ptr->stripPointerCasts();
+  if (isa<llvm::AllocaInst>(Ptr))
+    return CGF.EmitLifetimeStart(Ptr);
+  return false;
+}
+
 void AggExprEmitter::withReturnValueSlot(
     const Expr *E, llvm::function_ref<RValue(ReturnValueSlot)> EmitCall) {
   QualType RetTy = E->getType();
-  bool RequiresDestruction =
-      !Dest.isExternallyDestructed() &&
-      RetTy.isDestructedType() == QualType::DK_nontrivial_c_struct;
 
   // If it makes no observable difference, save a memcpy + temporary.
+  // This is not just an optimization: avoiding the copy may be mandatory in
+  // cases where it would make an observable difference.
   //
   // We need to always provide an address if destruction is required.
   // Otherwise, EmitCall will emit its own, notice that it's "unused", and end
   // its lifetime before we have the chance to emit a proper destructor call.
-  const CXXRecordDecl *RD = RetTy->getAsCXXRecordDecl();
-  // Initially assume we will need to pass through the destination memory.
-  unsigned SRetAS =
-      CGF.getContext().getTargetAddressSpace(RetTy.getAddressSpace());
-  bool DestASMismatch = false;
-  // However, ABIInfo might be permitted to make this return indirect. If it
-  // does, and RetTy doesn't specify an address space, it is also permitted (but
-  // not required) to change the ABI addrspace to alloca. We don't yet know what
-  // it will decide, so make a copy here for the optimizer to remove if it can
-  // prove it unnecessary later.
-  if (!RD || RD->canPassInRegisters()) {
-    if (!RetTy.hasAddressSpace()) {
-      SRetAS = CGF.CGM.getDataLayout().getAllocaAddrSpace();
-      // This will now require a copy unless we can find an underlying object
-      // with the correct addrspace to use for dest.
-      if (!Dest.isIgnored()) {
-        llvm::Value *DestV = Dest.getAddress().getBasePointer();
-        if (DestV->getType()->getPointerAddressSpace() != SRetAS) {
-          DestV = DestV->stripPointerCasts();
-          if (DestV->getType()->getPointerAddressSpace() != SRetAS)
-            DestASMismatch = true;
-        }
-      }
-    }
-  }
+  //
   // Decide if a copy is possibly legal, in which case ABIInfo might later
   // decide this copy is required. Be careful not to try to use a copy in cases
   // where it wouldn't be legal, in which case ABIInfo also should not expect
-  // a copy either.
-  bool UseTemp =
+  // a copy (not require an alloca) either.
+  bool RequiresDestruction =
+      !Dest.isExternallyDestructed() &&
+      RetTy.isDestructedType() == QualType::DK_nontrivial_c_struct;
+  bool NoCopy =
       // Copy okay by construction (see note on AggValueSlot::AliasedFlag)
-      Dest.isPotentiallyAliased()
+      !Dest.isPotentiallyAliased()
       // Copy permitted by ObjC semantics
-      || Dest.requiresGCollection()
+      && !Dest.requiresGCollection()
       // No actual copy is performed, since there is no Dest
-      || (RequiresDestruction && Dest.isIgnored())
+      && !(RequiresDestruction && Dest.isIgnored())
       // ABIInfo only requests a copy if it is legal
-      || DestASMismatch;
+      && !mightABIExpectAllocaAndNotAlloca(Dest.getAddress(), RetTy,
+                                           CGF.CGM.getDataLayout());
 
   Address RetAddr = Address::invalid();
+  unsigned SRetAS =
+      CGF.getContext().getTargetAddressSpace(RetTy.getAddressSpace());
 
   EHScopeStack::stable_iterator LifetimeEndBlock;
   llvm::IntrinsicInst *LifetimeStartInst = nullptr;
-  if (!UseTemp) {
+  if (NoCopy)
     RetAddr = Dest.getAddress();
-    if (RetAddr.isValid() && RetAddr.getAddressSpace() != SRetAS) {
-      llvm::Type *SRetPtrTy =
-          llvm::PointerType::get(CGF.getLLVMContext(), SRetAS);
-      RetAddr = RetAddr.withPointer(
-          CGF.performAddrSpaceCast(RetAddr.getBasePointer(), SRetPtrTy),
-          RetAddr.isKnownNonNull());
-    }
-  } else {
+  else
     RetAddr = CGF.CreateMemTempWithoutCast(RetTy, "tmp");
-    if (CGF.EmitLifetimeStart(RetAddr.getBasePointer())) {
-      LifetimeStartInst =
-          cast<llvm::IntrinsicInst>(std::prev(Builder.GetInsertPoint()));
-      assert(LifetimeStartInst->getIntrinsicID() ==
-                 llvm::Intrinsic::lifetime_start &&
-             "Last insertion wasn't a lifetime.start?");
-
-      CGF.pushFullExprCleanup<CodeGenFunction::CallLifetimeEnd>(
-          NormalEHLifetimeMarker, RetAddr);
-      LifetimeEndBlock = CGF.EHStack.stable_begin();
-    }
+  if (NoCopy && RetAddr.isValid() && RetAddr.getAddressSpace() != SRetAS) {
+    // n.b. If possibly copying, assume the ABI will do this cast to the right
+    // addrspace if needed from the alloca, otherwise assume it might not?
+    // It is really awkward that this decides if it is going to make this copy
+    // just before clang asks ABIInfo if it even needs a copy to be made.
+    llvm::Type *SRetPtrTy =
+        llvm::PointerType::get(CGF.getLLVMContext(), SRetAS);
+    RetAddr = RetAddr.withPointer(
+        CGF.performAddrSpaceCast(RetAddr.getBasePointer(), SRetPtrTy),
+        RetAddr.isKnownNonNull());
   }
+  if (!NoCopy && RetAddr.isValid() &&
+      EmitLifetimeStartOnAlloca(CGF, RetAddr.getBasePointer())) {
+    // n.b. If not copying, the caller often already emitted the lifetime start,
+    // so emitting it again is unnecessary.
+    LifetimeStartInst =
+        cast<llvm::IntrinsicInst>(std::prev(Builder.GetInsertPoint()));
+    assert(LifetimeStartInst->getIntrinsicID() ==
+               llvm::Intrinsic::lifetime_start &&
+           "Last insertion wasn't a lifetime.start?");
 
+    CGF.pushFullExprCleanup<CodeGenFunction::CallLifetimeEnd>(
+        NormalEHLifetimeMarker, RetAddr);
+    LifetimeEndBlock = CGF.EHStack.stable_begin();
+  }
   RValue Src =
       EmitCall(ReturnValueSlot(RetAddr, Dest.isVolatile(), IsResultUnused,
                                Dest.isExternallyDestructed()));
 
-  if (!UseTemp)
+  if (NoCopy)
     return;
 
   assert(Dest.isIgnored() || Dest.emitRawPointer(CGF) !=
@@ -369,7 +393,7 @@ void AggExprEmitter::withReturnValueSlot(
     // Since we're not guaranteed to be in an ExprWithCleanups, clean up
     // eagerly.
     CGF.DeactivateCleanupBlock(LifetimeEndBlock, LifetimeStartInst);
-    CGF.EmitLifetimeEnd(RetAddr.getBasePointer());
+    CGF.EmitLifetimeEnd(LifetimeStartInst->getArgOperand(0));
   }
 }
 

--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -83,19 +83,23 @@ commonEmitCXXMemberOrOperatorCall(CodeGenFunction &CGF, GlobalDecl GD,
 }
 
 RValue CodeGenFunction::EmitCXXMemberOrOperatorCall(
-    const CXXMethodDecl *MD, const CGCallee &Callee,
-    ReturnValueSlot ReturnValue, llvm::Value *This, llvm::Value *ImplicitParam,
-    QualType ImplicitParamTy, const CallExpr *CE, CallArgList *RtlArgs,
-    llvm::CallBase **CallOrInvoke) {
+    const CXXMethodDecl *MD, const CGCallee &Callee, llvm::Value *This,
+    llvm::Value *ImplicitParam, QualType ImplicitParamTy, const CallExpr *CE,
+    CallArgList *RtlArgs, llvm::CallBase **CallOrInvoke,
+    ReturnSlotFn ReturnSlotWrapper) {
   const FunctionProtoType *FPT = MD->getType()->castAs<FunctionProtoType>();
   CallArgList Args;
   MemberCallInfo CallInfo = commonEmitCXXMemberOrOperatorCall(
       *this, MD, This, ImplicitParam, ImplicitParamTy, CE, Args, RtlArgs);
   auto &FnInfo = CGM.getTypes().arrangeCXXMethodCall(
       Args, FPT, CallInfo.ReqArgs, CallInfo.PrefixSize);
-  return EmitCall(FnInfo, Callee, ReturnValue, Args, CallOrInvoke,
-                  CE && CE == MustTailCall,
-                  CE ? CE->getExprLoc() : SourceLocation());
+  auto doEmitCall = [&](ReturnValueSlot Slot) {
+    return EmitCall(FnInfo, Callee, Slot, Args, CallOrInvoke,
+                    CE && CE == MustTailCall,
+                    CE ? CE->getExprLoc() : SourceLocation());
+  };
+  return ReturnSlotWrapper ? ReturnSlotWrapper(FnInfo, doEmitCall)
+                           : doEmitCall(ReturnValueSlot());
 }
 
 RValue CodeGenFunction::EmitCXXDestructorCall(
@@ -186,12 +190,12 @@ static CXXRecordDecl *getCXXRecord(const Expr *E) {
 // Note: This function also emit constructor calls to support a MSVC
 // extensions allowing explicit constructor function call.
 RValue CodeGenFunction::EmitCXXMemberCallExpr(const CXXMemberCallExpr *CE,
-                                              ReturnValueSlot ReturnValue,
-                                              llvm::CallBase **CallOrInvoke) {
+                                              llvm::CallBase **CallOrInvoke,
+                                              ReturnSlotFn ReturnSlotWrapper) {
   const Expr *callee = CE->getCallee()->IgnoreParens();
 
   if (isa<BinaryOperator>(callee))
-    return EmitCXXMemberPointerCallExpr(CE, ReturnValue, CallOrInvoke);
+    return EmitCXXMemberPointerCallExpr(CE, CallOrInvoke, ReturnSlotWrapper);
 
   const MemberExpr *ME = cast<MemberExpr>(callee);
   const CXXMethodDecl *MD = cast<CXXMethodDecl>(ME->getMemberDecl());
@@ -201,7 +205,8 @@ RValue CodeGenFunction::EmitCXXMemberCallExpr(const CXXMemberCallExpr *CE,
     CGCallee callee =
         CGCallee::forDirect(CGM.GetAddrOfFunction(MD), GlobalDecl(MD));
     return EmitCall(getContext().getPointerType(MD->getType()), callee, CE,
-                    ReturnValue, /*Chain=*/nullptr, CallOrInvoke);
+                    /*Chain=*/nullptr, CallOrInvoke,
+                    /*ResolvedFnInfo=*/nullptr, ReturnSlotWrapper);
   }
 
   bool HasQualifier = ME->hasQualifier();
@@ -209,15 +214,15 @@ RValue CodeGenFunction::EmitCXXMemberCallExpr(const CXXMemberCallExpr *CE,
   bool IsArrow = ME->isArrow();
   const Expr *Base = ME->getBase();
 
-  return EmitCXXMemberOrOperatorMemberCallExpr(CE, MD, ReturnValue,
-                                               HasQualifier, Qualifier, IsArrow,
-                                               Base, CallOrInvoke);
+  return EmitCXXMemberOrOperatorMemberCallExpr(CE, MD, HasQualifier, Qualifier,
+                                               IsArrow, Base, CallOrInvoke,
+                                               ReturnSlotWrapper);
 }
 
 RValue CodeGenFunction::EmitCXXMemberOrOperatorMemberCallExpr(
-    const CallExpr *CE, const CXXMethodDecl *MD, ReturnValueSlot ReturnValue,
-    bool HasQualifier, NestedNameSpecifier Qualifier, bool IsArrow,
-    const Expr *Base, llvm::CallBase **CallOrInvoke) {
+    const CallExpr *CE, const CXXMethodDecl *MD, bool HasQualifier,
+    NestedNameSpecifier Qualifier, bool IsArrow, const Expr *Base,
+    llvm::CallBase **CallOrInvoke, ReturnSlotFn ReturnSlotWrapper) {
   assert(isa<CXXMemberCallExpr>(CE) || isa<CXXOperatorCallExpr>(CE));
 
   // Compute the object pointer.
@@ -292,7 +297,6 @@ RValue CodeGenFunction::EmitCXXMemberOrOperatorMemberCallExpr(
     // This is the MSVC p->Ctor::Ctor(...) extension. We assume that's
     // constructing a new complete object of type Ctor.
     assert(!RtlArgs);
-    assert(ReturnValue.isNull() && "Constructor shouldn't have return value");
     CallArgList Args;
     commonEmitCXXMemberOrOperatorCall(
         *this, {Ctor, Ctor_Complete}, This.getPointer(*this),
@@ -373,7 +377,6 @@ RValue CodeGenFunction::EmitCXXMemberOrOperatorMemberCallExpr(
   if (const CXXDestructorDecl *Dtor = dyn_cast<CXXDestructorDecl>(CalleeDecl)) {
     assert(CE->arguments().empty() &&
            "Destructor shouldn't have explicit parameters");
-    assert(ReturnValue.isNull() && "Destructor shouldn't have return value");
     if (UseVirtualCall) {
       CGM.getCXXABI().EmitVirtualDestructorCall(
           *this, Dtor, Dtor_Complete, This.getAddress(),
@@ -434,15 +437,15 @@ RValue CodeGenFunction::EmitCXXMemberOrOperatorMemberCallExpr(
     This.setAddress(NewThisAddr);
   }
 
-  return EmitCXXMemberOrOperatorCall(
-      CalleeDecl, Callee, ReturnValue, This.getPointer(*this),
-      /*ImplicitParam=*/nullptr, QualType(), CE, RtlArgs, CallOrInvoke);
+  return EmitCXXMemberOrOperatorCall(CalleeDecl, Callee, This.getPointer(*this),
+                                     /*ImplicitParam=*/nullptr, QualType(), CE,
+                                     RtlArgs, CallOrInvoke, ReturnSlotWrapper);
 }
 
 RValue
 CodeGenFunction::EmitCXXMemberPointerCallExpr(const CXXMemberCallExpr *E,
-                                              ReturnValueSlot ReturnValue,
-                                              llvm::CallBase **CallOrInvoke) {
+                                              llvm::CallBase **CallOrInvoke,
+                                              ReturnSlotFn ReturnSlotWrapper) {
   const BinaryOperator *BO =
       cast<BinaryOperator>(E->getCallee()->IgnoreParens());
   const Expr *BaseExpr = BO->getLHS();
@@ -482,32 +485,34 @@ CodeGenFunction::EmitCXXMemberPointerCallExpr(const CXXMemberCallExpr *E,
 
   // And the rest of the call args
   EmitCallArgs(Args, FPT, E->arguments());
-  return EmitCall(CGM.getTypes().arrangeCXXMethodCall(Args, FPT, required,
-                                                      /*PrefixSize=*/0),
-                  Callee, ReturnValue, Args, CallOrInvoke, E == MustTailCall,
-                  E->getExprLoc());
+  auto &FnInfo = CGM.getTypes().arrangeCXXMethodCall(Args, FPT, required,
+                                                     /*PrefixSize=*/0);
+  auto doEmitCall = [&](ReturnValueSlot Slot) {
+    return EmitCall(FnInfo, Callee, Slot, Args, CallOrInvoke, E == MustTailCall,
+                    E->getExprLoc());
+  };
+  return ReturnSlotWrapper ? ReturnSlotWrapper(FnInfo, doEmitCall)
+                           : doEmitCall(ReturnValueSlot());
 }
 
 RValue CodeGenFunction::EmitCXXOperatorMemberCallExpr(
     const CXXOperatorCallExpr *E, const CXXMethodDecl *MD,
-    ReturnValueSlot ReturnValue, llvm::CallBase **CallOrInvoke) {
+    llvm::CallBase **CallOrInvoke, ReturnSlotFn ReturnSlotWrapper) {
   assert(MD->isImplicitObjectMemberFunction() &&
          "Trying to emit a member call expr on a static method!");
   return EmitCXXMemberOrOperatorMemberCallExpr(
-      E, MD, ReturnValue, /*HasQualifier=*/false, /*Qualifier=*/std::nullopt,
-      /*IsArrow=*/false, E->getArg(0), CallOrInvoke);
+      E, MD, /*HasQualifier=*/false, /*Qualifier=*/std::nullopt,
+      /*IsArrow=*/false, E->getArg(0), CallOrInvoke, ReturnSlotWrapper);
 }
 
 RValue CodeGenFunction::EmitCUDAKernelCallExpr(const CUDAKernelCallExpr *E,
-                                               ReturnValueSlot ReturnValue,
                                                llvm::CallBase **CallOrInvoke) {
   // Emit as a device kernel call if CUDA device code is to be generated.
   // TODO: implement for HIP
   if (!getLangOpts().HIP && getLangOpts().CUDAIsDevice)
-    return CGM.getCUDARuntime().EmitCUDADeviceKernelCallExpr(
-        *this, E, ReturnValue, CallOrInvoke);
-  return CGM.getCUDARuntime().EmitCUDAKernelCallExpr(*this, E, ReturnValue,
-                                                     CallOrInvoke);
+    return CGM.getCUDARuntime().EmitCUDADeviceKernelCallExpr(*this, E,
+                                                             CallOrInvoke);
+  return CGM.getCUDARuntime().EmitCUDAKernelCallExpr(*this, E, CallOrInvoke);
 }
 
 static void EmitNullBaseClassInitialization(CodeGenFunction &CGF,

--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -86,7 +86,7 @@ RValue CodeGenFunction::EmitCXXMemberOrOperatorCall(
     const CXXMethodDecl *MD, const CGCallee &Callee, llvm::Value *This,
     llvm::Value *ImplicitParam, QualType ImplicitParamTy, const CallExpr *CE,
     CallArgList *RtlArgs, llvm::CallBase **CallOrInvoke,
-    ReturnSlotFn ReturnSlotWrapper) {
+    ReturnSlotFn WithReturnValueSlot) {
   const FunctionProtoType *FPT = MD->getType()->castAs<FunctionProtoType>();
   CallArgList Args;
   MemberCallInfo CallInfo = commonEmitCXXMemberOrOperatorCall(
@@ -98,8 +98,8 @@ RValue CodeGenFunction::EmitCXXMemberOrOperatorCall(
                     CE && CE == MustTailCall,
                     CE ? CE->getExprLoc() : SourceLocation());
   };
-  return ReturnSlotWrapper ? ReturnSlotWrapper(FnInfo, doEmitCall)
-                           : doEmitCall(ReturnValueSlot());
+  return WithReturnValueSlot ? WithReturnValueSlot(FnInfo, doEmitCall)
+                             : doEmitCall(ReturnValueSlot());
 }
 
 RValue CodeGenFunction::EmitCXXDestructorCall(
@@ -189,13 +189,14 @@ static CXXRecordDecl *getCXXRecord(const Expr *E) {
 
 // Note: This function also emit constructor calls to support a MSVC
 // extensions allowing explicit constructor function call.
-RValue CodeGenFunction::EmitCXXMemberCallExpr(const CXXMemberCallExpr *CE,
-                                              llvm::CallBase **CallOrInvoke,
-                                              ReturnSlotFn ReturnSlotWrapper) {
+RValue
+CodeGenFunction::EmitCXXMemberCallExpr(const CXXMemberCallExpr *CE,
+                                       llvm::CallBase **CallOrInvoke,
+                                       ReturnSlotFn WithReturnValueSlot) {
   const Expr *callee = CE->getCallee()->IgnoreParens();
 
   if (isa<BinaryOperator>(callee))
-    return EmitCXXMemberPointerCallExpr(CE, CallOrInvoke, ReturnSlotWrapper);
+    return EmitCXXMemberPointerCallExpr(CE, CallOrInvoke, WithReturnValueSlot);
 
   const MemberExpr *ME = cast<MemberExpr>(callee);
   const CXXMethodDecl *MD = cast<CXXMethodDecl>(ME->getMemberDecl());
@@ -206,7 +207,7 @@ RValue CodeGenFunction::EmitCXXMemberCallExpr(const CXXMemberCallExpr *CE,
         CGCallee::forDirect(CGM.GetAddrOfFunction(MD), GlobalDecl(MD));
     return EmitCall(getContext().getPointerType(MD->getType()), callee, CE,
                     /*Chain=*/nullptr, CallOrInvoke,
-                    /*ResolvedFnInfo=*/nullptr, ReturnSlotWrapper);
+                    /*ResolvedFnInfo=*/nullptr, WithReturnValueSlot);
   }
 
   bool HasQualifier = ME->hasQualifier();
@@ -216,13 +217,13 @@ RValue CodeGenFunction::EmitCXXMemberCallExpr(const CXXMemberCallExpr *CE,
 
   return EmitCXXMemberOrOperatorMemberCallExpr(CE, MD, HasQualifier, Qualifier,
                                                IsArrow, Base, CallOrInvoke,
-                                               ReturnSlotWrapper);
+                                               WithReturnValueSlot);
 }
 
 RValue CodeGenFunction::EmitCXXMemberOrOperatorMemberCallExpr(
     const CallExpr *CE, const CXXMethodDecl *MD, bool HasQualifier,
     NestedNameSpecifier Qualifier, bool IsArrow, const Expr *Base,
-    llvm::CallBase **CallOrInvoke, ReturnSlotFn ReturnSlotWrapper) {
+    llvm::CallBase **CallOrInvoke, ReturnSlotFn WithReturnValueSlot) {
   assert(isa<CXXMemberCallExpr>(CE) || isa<CXXOperatorCallExpr>(CE));
 
   // Compute the object pointer.
@@ -439,13 +440,13 @@ RValue CodeGenFunction::EmitCXXMemberOrOperatorMemberCallExpr(
 
   return EmitCXXMemberOrOperatorCall(CalleeDecl, Callee, This.getPointer(*this),
                                      /*ImplicitParam=*/nullptr, QualType(), CE,
-                                     RtlArgs, CallOrInvoke, ReturnSlotWrapper);
+                                     RtlArgs, CallOrInvoke,
+                                     WithReturnValueSlot);
 }
 
-RValue
-CodeGenFunction::EmitCXXMemberPointerCallExpr(const CXXMemberCallExpr *E,
-                                              llvm::CallBase **CallOrInvoke,
-                                              ReturnSlotFn ReturnSlotWrapper) {
+RValue CodeGenFunction::EmitCXXMemberPointerCallExpr(
+    const CXXMemberCallExpr *E, llvm::CallBase **CallOrInvoke,
+    ReturnSlotFn WithReturnValueSlot) {
   const BinaryOperator *BO =
       cast<BinaryOperator>(E->getCallee()->IgnoreParens());
   const Expr *BaseExpr = BO->getLHS();
@@ -491,18 +492,18 @@ CodeGenFunction::EmitCXXMemberPointerCallExpr(const CXXMemberCallExpr *E,
     return EmitCall(FnInfo, Callee, Slot, Args, CallOrInvoke, E == MustTailCall,
                     E->getExprLoc());
   };
-  return ReturnSlotWrapper ? ReturnSlotWrapper(FnInfo, doEmitCall)
-                           : doEmitCall(ReturnValueSlot());
+  return WithReturnValueSlot ? WithReturnValueSlot(FnInfo, doEmitCall)
+                             : doEmitCall(ReturnValueSlot());
 }
 
 RValue CodeGenFunction::EmitCXXOperatorMemberCallExpr(
     const CXXOperatorCallExpr *E, const CXXMethodDecl *MD,
-    llvm::CallBase **CallOrInvoke, ReturnSlotFn ReturnSlotWrapper) {
+    llvm::CallBase **CallOrInvoke, ReturnSlotFn WithReturnValueSlot) {
   assert(MD->isImplicitObjectMemberFunction() &&
          "Trying to emit a member call expr on a static method!");
   return EmitCXXMemberOrOperatorMemberCallExpr(
       E, MD, /*HasQualifier=*/false, /*Qualifier=*/std::nullopt,
-      /*IsArrow=*/false, E->getArg(0), CallOrInvoke, ReturnSlotWrapper);
+      /*IsArrow=*/false, E->getArg(0), CallOrInvoke, WithReturnValueSlot);
 }
 
 RValue CodeGenFunction::EmitCUDAKernelCallExpr(const CUDAKernelCallExpr *E,

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2682,19 +2682,7 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     llvm::Type *SrcTy = Src->getType();
     llvm::Type *DstTy = ConvertType(DestTy);
 
-    // FIXME: this is a gross but seemingly necessary workaround for an issue
-    // manifesting when a target uses a non-default AS for indirect sret args,
-    // but the source HLL is generic, wherein a valid C-cast or reinterpret_cast
-    // on the address of a local struct that gets returned by value yields an
-    // invalid bitcast from the a pointer to the IndirectAS to a pointer to the
-    // DefaultAS. We can only do this subversive thing because sret args are
-    // manufactured and them residing in the IndirectAS is a target specific
-    // detail, and doing an AS cast here still retains the semantics the user
-    // expects. It is desirable to remove this iff a better solution is found.
-    if (auto A = dyn_cast<llvm::Argument>(Src); A && A->hasStructRetAttr())
-      return CGF.performAddrSpaceCast(Src, DstTy);
-
-    // FIXME: Similarly to the sret case above, we need to handle BitCasts that
+    // FIXME: We need to handle BitCasts that
     // involve implicit address space conversions. This arises when the source
     // language lacks explicit address spaces, but the target's data layout
     // assigns different address spaces (e.g., program address space for

--- a/clang/lib/CodeGen/CGObjC.cpp
+++ b/clang/lib/CodeGen/CGObjC.cpp
@@ -454,7 +454,7 @@ static std::optional<llvm::Value *> tryGenerateSpecializedMessageSend(
 }
 
 CodeGen::RValue CGObjCRuntime::GeneratePossiblySpecializedMessageSend(
-    CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType ResultType,
+    CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot, QualType ResultType,
     Selector Sel, llvm::Value *Receiver, const CallArgList &Args,
     const ObjCInterfaceDecl *OID, const ObjCMethodDecl *Method,
     bool isClassMessage) {
@@ -463,8 +463,8 @@ CodeGen::RValue CGObjCRuntime::GeneratePossiblySpecializedMessageSend(
                                             Sel, Method, isClassMessage)) {
     return RValue::get(*SpecializedResult);
   }
-  return GenerateMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel, Receiver,
-                             Args, OID, Method);
+  return GenerateMessageSend(CGF, WithReturnValueSlot, ResultType, Sel,
+                             Receiver, Args, OID, Method);
 }
 
 static void AppendFirstImpliedRuntimeProtocols(
@@ -589,7 +589,7 @@ tryEmitSpecializedAllocInit(CodeGenFunction &CGF, const ObjCMessageExpr *OME) {
 }
 
 RValue CodeGenFunction::EmitObjCMessageExpr(const ObjCMessageExpr *E,
-                                            ReturnSlotFn ReturnSlotWrapper) {
+                                            ReturnSlotFn WithReturnValueSlot) {
   // Only the lookup mechanism and first two arguments of the method
   // implementation vary between runtimes.  We can get the receiver and
   // arguments in generic code.
@@ -704,14 +704,14 @@ RValue CodeGenFunction::EmitObjCMessageExpr(const ObjCMessageExpr *E,
     const ObjCMethodDecl *OMD = cast<ObjCMethodDecl>(CurFuncDecl);
     bool isCategoryImpl = isa<ObjCCategoryImplDecl>(OMD->getDeclContext());
     result = Runtime.GenerateMessageSendSuper(
-        *this, ReturnSlotWrapper, ResultType, E->getSelector(),
+        *this, WithReturnValueSlot, ResultType, E->getSelector(),
         OMD->getClassInterface(), isCategoryImpl, Receiver, isClassMessage,
         Args, method);
   } else {
     // Call runtime methods directly if we can.
     result = Runtime.GeneratePossiblySpecializedMessageSend(
-        *this, ReturnSlotWrapper, ResultType, E->getSelector(), Receiver, Args,
-        OID, method, isClassMessage);
+        *this, WithReturnValueSlot, ResultType, E->getSelector(), Receiver,
+        Args, OID, method, isClassMessage);
   }
 
   // For delegate init calls in ARC, implicitly store the result of

--- a/clang/lib/CodeGen/CGObjC.cpp
+++ b/clang/lib/CodeGen/CGObjC.cpp
@@ -122,9 +122,9 @@ CodeGenFunction::EmitObjCBoxedExpr(const ObjCBoxedExpr *E) {
     Args.add(EmitAnyExpr(SubExpr), ArgQT);
   }
 
-  RValue result = Runtime.GenerateMessageSend(
-      *this, ReturnValueSlot(), BoxingMethod->getReturnType(), Sel, Receiver,
-      Args, ClassDecl, BoxingMethod);
+  RValue result =
+      Runtime.GenerateMessageSend(*this, nullptr, BoxingMethod->getReturnType(),
+                                  Sel, Receiver, Args, ClassDecl, BoxingMethod);
   return Builder.CreateBitCast(result.getScalarVal(),
                                ConvertType(E->getType()));
 }
@@ -247,8 +247,8 @@ llvm::Value *CodeGenFunction::EmitObjCCollectionLiteral(const Expr *E,
 
   // Generate the message send.
   RValue result = Runtime.GenerateMessageSend(
-      *this, ReturnValueSlot(), MethodWithObjects->getReturnType(), Sel,
-      Receiver, Args, Class, MethodWithObjects);
+      *this, nullptr, MethodWithObjects->getReturnType(), Sel, Receiver, Args,
+      Class, MethodWithObjects);
 
   // The above message send needs these objects, but in ARC they are
   // passed in a buffer that is essentially __unsafe_unretained.
@@ -454,7 +454,7 @@ static std::optional<llvm::Value *> tryGenerateSpecializedMessageSend(
 }
 
 CodeGen::RValue CGObjCRuntime::GeneratePossiblySpecializedMessageSend(
-    CodeGenFunction &CGF, ReturnValueSlot Return, QualType ResultType,
+    CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType ResultType,
     Selector Sel, llvm::Value *Receiver, const CallArgList &Args,
     const ObjCInterfaceDecl *OID, const ObjCMethodDecl *Method,
     bool isClassMessage) {
@@ -463,8 +463,8 @@ CodeGen::RValue CGObjCRuntime::GeneratePossiblySpecializedMessageSend(
                                             Sel, Method, isClassMessage)) {
     return RValue::get(*SpecializedResult);
   }
-  return GenerateMessageSend(CGF, Return, ResultType, Sel, Receiver, Args, OID,
-                             Method);
+  return GenerateMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel, Receiver,
+                             Args, OID, Method);
 }
 
 static void AppendFirstImpliedRuntimeProtocols(
@@ -589,7 +589,7 @@ tryEmitSpecializedAllocInit(CodeGenFunction &CGF, const ObjCMessageExpr *OME) {
 }
 
 RValue CodeGenFunction::EmitObjCMessageExpr(const ObjCMessageExpr *E,
-                                            ReturnValueSlot Return) {
+                                            ReturnSlotFn ReturnSlotWrapper) {
   // Only the lookup mechanism and first two arguments of the method
   // implementation vary between runtimes.  We can get the receiver and
   // arguments in generic code.
@@ -703,19 +703,15 @@ RValue CodeGenFunction::EmitObjCMessageExpr(const ObjCMessageExpr *E,
     // super is only valid in an Objective-C method
     const ObjCMethodDecl *OMD = cast<ObjCMethodDecl>(CurFuncDecl);
     bool isCategoryImpl = isa<ObjCCategoryImplDecl>(OMD->getDeclContext());
-    result = Runtime.GenerateMessageSendSuper(*this, Return, ResultType,
-                                              E->getSelector(),
-                                              OMD->getClassInterface(),
-                                              isCategoryImpl,
-                                              Receiver,
-                                              isClassMessage,
-                                              Args,
-                                              method);
+    result = Runtime.GenerateMessageSendSuper(
+        *this, ReturnSlotWrapper, ResultType, E->getSelector(),
+        OMD->getClassInterface(), isCategoryImpl, Receiver, isClassMessage,
+        Args, method);
   } else {
     // Call runtime methods directly if we can.
     result = Runtime.GeneratePossiblySpecializedMessageSend(
-        *this, Return, ResultType, E->getSelector(), Receiver, Args, OID,
-        method, isClassMessage);
+        *this, ReturnSlotWrapper, ResultType, E->getSelector(), Receiver, Args,
+        OID, method, isClassMessage);
   }
 
   // For delegate init calls in ARC, implicitly store the result of
@@ -751,15 +747,10 @@ struct FinishARCDealloc final : EHScopeStack::Cleanup {
     llvm::Value *self = CGF.LoadObjCSelf();
 
     CallArgList args;
-    CGF.CGM.getObjCRuntime().GenerateMessageSendSuper(CGF, ReturnValueSlot(),
-                                                      CGF.getContext().VoidTy,
-                                                      method->getSelector(),
-                                                      iface,
-                                                      isCategory,
-                                                      self,
-                                                      /*is class msg*/ false,
-                                                      args,
-                                                      method);
+    CGF.CGM.getObjCRuntime().GenerateMessageSendSuper(
+        CGF, nullptr, CGF.getContext().VoidTy, method->getSelector(), iface,
+        isCategory, self,
+        /*is class msg*/ false, args, method);
   }
 };
 }
@@ -1911,10 +1902,9 @@ void CodeGenFunction::EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S){
   Args.add(RValue::get(Count), getContext().getNSUIntegerType());
 
   // Start the enumeration.
-  RValue CountRV =
-      CGM.getObjCRuntime().GenerateMessageSend(*this, ReturnValueSlot(),
-                                               getContext().getNSUIntegerType(),
-                                               FastEnumSel, Collection, Args);
+  RValue CountRV = CGM.getObjCRuntime().GenerateMessageSend(
+      *this, nullptr, getContext().getNSUIntegerType(), FastEnumSel, Collection,
+      Args);
 
   // The initial number of objects that were returned in the buffer.
   llvm::Value *initialBufferLimit = CountRV.getScalarVal();
@@ -2056,9 +2046,8 @@ void CodeGenFunction::EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S){
       IsKindOfClassArgs.add(RValue::get(Cls), C.getObjCClassType());
       llvm::Value *IsClass =
           CGM.getObjCRuntime()
-              .GenerateMessageSend(*this, ReturnValueSlot(), C.BoolTy,
-                                   IsKindOfClassSel, CurrentItem,
-                                   IsKindOfClassArgs)
+              .GenerateMessageSend(*this, nullptr, C.BoolTy, IsKindOfClassSel,
+                                   CurrentItem, IsKindOfClassArgs)
               .getScalarVal();
       llvm::Constant *StaticData[] = {
           EmitCheckSourceLocation(S.getBeginLoc()),
@@ -2121,10 +2110,9 @@ void CodeGenFunction::EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S){
   // Otherwise, we have to fetch more elements.
   EmitBlock(FetchMoreBB);
 
-  CountRV =
-      CGM.getObjCRuntime().GenerateMessageSend(*this, ReturnValueSlot(),
-                                               getContext().getNSUIntegerType(),
-                                               FastEnumSel, Collection, Args);
+  CountRV = CGM.getObjCRuntime().GenerateMessageSend(
+      *this, nullptr, getContext().getNSUIntegerType(), FastEnumSel, Collection,
+      Args);
 
   // If we got a zero count, we're done.
   llvm::Value *refetchCount = CountRV.getScalarVal();
@@ -2800,19 +2788,15 @@ llvm::Value *CodeGenFunction::EmitObjCMRRAutoreleasePoolPush() {
   const IdentifierInfo *II = &CGM.getContext().Idents.get("alloc");
   Selector AllocSel = getContext().Selectors.getSelector(0, &II);
   CallArgList Args;
-  RValue AllocRV =
-    Runtime.GenerateMessageSend(*this, ReturnValueSlot(),
-                                getContext().getObjCIdType(),
-                                AllocSel, Receiver, Args);
+  RValue AllocRV = Runtime.GenerateMessageSend(
+      *this, nullptr, getContext().getObjCIdType(), AllocSel, Receiver, Args);
 
   // [Receiver init]
   Receiver = AllocRV.getScalarVal();
   II = &CGM.getContext().Idents.get("init");
   Selector InitSel = getContext().Selectors.getSelector(0, &II);
-  RValue InitRV =
-    Runtime.GenerateMessageSend(*this, ReturnValueSlot(),
-                                getContext().getObjCIdType(),
-                                InitSel, Receiver, Args);
+  RValue InitRV = Runtime.GenerateMessageSend(
+      *this, nullptr, getContext().getObjCIdType(), InitSel, Receiver, Args);
   return InitRV.getScalarVal();
 }
 
@@ -2847,8 +2831,8 @@ void CodeGenFunction::EmitObjCMRRAutoreleasePoolPop(llvm::Value *Arg) {
   const IdentifierInfo *II = &CGM.getContext().Idents.get("drain");
   Selector DrainSel = getContext().Selectors.getSelector(0, &II);
   CallArgList Args;
-  CGM.getObjCRuntime().GenerateMessageSend(*this, ReturnValueSlot(),
-                              getContext().VoidTy, DrainSel, Arg, Args);
+  CGM.getObjCRuntime().GenerateMessageSend(*this, nullptr, getContext().VoidTy,
+                                           DrainSel, Arg, Args);
 }
 
 void CodeGenFunction::destroyARCStrongPrecise(CodeGenFunction &CGF,
@@ -3995,12 +3979,10 @@ CodeGenFunction::EmitBlockCopyAndAutorelease(llvm::Value *Block, QualType Ty) {
   CGObjCRuntime &Runtime = CGM.getObjCRuntime();
   llvm::Value *Val = Block;
   RValue Result;
-  Result = Runtime.GenerateMessageSend(*this, ReturnValueSlot(),
-                                       Ty, CopySelector,
-                                       Val, CallArgList(), nullptr, nullptr);
+  Result = Runtime.GenerateMessageSend(*this, nullptr, Ty, CopySelector, Val,
+                                       CallArgList(), nullptr, nullptr);
   Val = Result.getScalarVal();
-  Result = Runtime.GenerateMessageSend(*this, ReturnValueSlot(),
-                                       Ty, AutoreleaseSelector,
+  Result = Runtime.GenerateMessageSend(*this, nullptr, Ty, AutoreleaseSelector,
                                        Val, CallArgList(), nullptr, nullptr);
   Val = Result.getScalarVal();
   return Val;

--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -579,16 +579,16 @@ public:
       override;
 
   RValue GenerateMessageSend(CodeGenFunction &CGF,
-                             ReturnSlotFn ReturnSlotWrapper,
+                             ReturnSlotFn WithReturnValueSlot,
                              QualType ResultType, Selector Sel,
                              llvm::Value *Receiver, const CallArgList &CallArgs,
                              const ObjCInterfaceDecl *Class,
                              const ObjCMethodDecl *Method) override;
   RValue GenerateMessageSendSuper(
-      CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType ResultType,
-      Selector Sel, const ObjCInterfaceDecl *Class, bool isCategoryImpl,
-      llvm::Value *Receiver, bool IsClassMessage, const CallArgList &CallArgs,
-      const ObjCMethodDecl *Method) override;
+      CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
+      QualType ResultType, Selector Sel, const ObjCInterfaceDecl *Class,
+      bool isCategoryImpl, llvm::Value *Receiver, bool IsClassMessage,
+      const CallArgList &CallArgs, const ObjCMethodDecl *Method) override;
   llvm::Value *GetClass(CodeGenFunction &CGF,
                         const ObjCInterfaceDecl *OID) override;
   llvm::Value *GetSelector(CodeGenFunction &CGF, Selector Sel) override;
@@ -2775,7 +2775,7 @@ ConstantAddress CGObjCGNU::GenerateConstantDictionary(
 ///send to self with special delivery semantics indicating which class's method
 ///should be called.
 RValue CGObjCGNU::GenerateMessageSendSuper(
-    CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType ResultType,
+    CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot, QualType ResultType,
     Selector Sel, const ObjCInterfaceDecl *Class, bool isCategoryImpl,
     llvm::Value *Receiver, bool IsClassMessage, const CallArgList &CallArgs,
     const ObjCMethodDecl *Method) {
@@ -2881,8 +2881,8 @@ RValue CGObjCGNU::GenerateMessageSendSuper(
     CapturedSlot = Slot;
     return CGF.EmitCall(MSI.CallInfo, callee, Slot, ActualArgs, &call);
   };
-  RValue msgRet = ReturnSlotWrapper
-                      ? ReturnSlotWrapper(MSI.CallInfo, doEmitCall)
+  RValue msgRet = WithReturnValueSlot
+                      ? WithReturnValueSlot(MSI.CallInfo, doEmitCall)
                       : doEmitCall(ReturnValueSlot());
   call->setMetadata(msgSendMDKind, node);
   return msgRet;
@@ -2890,7 +2890,7 @@ RValue CGObjCGNU::GenerateMessageSendSuper(
 
 /// Generate code for a message send expression.
 RValue CGObjCGNU::GenerateMessageSend(
-    CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType ResultType,
+    CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot, QualType ResultType,
     Selector Sel, llvm::Value *Receiver, const CallArgList &CallArgs,
     const ObjCInterfaceDecl *Class, const ObjCMethodDecl *Method) {
   CGBuilderTy &Builder = CGF.Builder;
@@ -2970,7 +2970,7 @@ RValue CGObjCGNU::GenerateMessageSend(
     // If the return value isn't flagged as unused, and the result
     // type isn't in our narrow set where we assume compatibility,
     // we need a nil check to ensure a nil value.
-    if (!ReturnSlotWrapper.IsResultUnused) {
+    if (!WithReturnValueSlot.IsResultUnused) {
       if (ResultType->isVoidType()) {
         // void results are definitely okay.
       } else if (ResultType->hasPointerRepresentation() &&
@@ -3079,8 +3079,8 @@ RValue CGObjCGNU::GenerateMessageSend(
     CapturedSlot = Slot;
     return CGF.EmitCall(MSI.CallInfo, callee, Slot, ActualArgs, &call);
   };
-  RValue msgRet = ReturnSlotWrapper
-                      ? ReturnSlotWrapper(MSI.CallInfo, doEmitCall)
+  RValue msgRet = WithReturnValueSlot
+                      ? WithReturnValueSlot(MSI.CallInfo, doEmitCall)
                       : doEmitCall(ReturnValueSlot());
   if (!isDirect)
     call->setMetadata(msgSendMDKind, node);

--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -578,19 +578,17 @@ public:
       ArrayRef<std::pair<llvm::Constant *, llvm::Constant *>> KeysAndObjects)
       override;
 
-  RValue
-  GenerateMessageSend(CodeGenFunction &CGF, ReturnValueSlot Return,
-                      QualType ResultType, Selector Sel,
-                      llvm::Value *Receiver, const CallArgList &CallArgs,
-                      const ObjCInterfaceDecl *Class,
-                      const ObjCMethodDecl *Method) override;
-  RValue
-  GenerateMessageSendSuper(CodeGenFunction &CGF, ReturnValueSlot Return,
-                           QualType ResultType, Selector Sel,
-                           const ObjCInterfaceDecl *Class,
-                           bool isCategoryImpl, llvm::Value *Receiver,
-                           bool IsClassMessage, const CallArgList &CallArgs,
-                           const ObjCMethodDecl *Method) override;
+  RValue GenerateMessageSend(CodeGenFunction &CGF,
+                             ReturnSlotFn ReturnSlotWrapper,
+                             QualType ResultType, Selector Sel,
+                             llvm::Value *Receiver, const CallArgList &CallArgs,
+                             const ObjCInterfaceDecl *Class,
+                             const ObjCMethodDecl *Method) override;
+  RValue GenerateMessageSendSuper(
+      CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType ResultType,
+      Selector Sel, const ObjCInterfaceDecl *Class, bool isCategoryImpl,
+      llvm::Value *Receiver, bool IsClassMessage, const CallArgList &CallArgs,
+      const ObjCMethodDecl *Method) override;
   llvm::Value *GetClass(CodeGenFunction &CGF,
                         const ObjCInterfaceDecl *OID) override;
   llvm::Value *GetSelector(CodeGenFunction &CGF, Selector Sel) override;
@@ -2280,9 +2278,9 @@ protected:
       //
       // We should find a way to eliminate this unnecessary initialization in
       // such cases in LLVM.
-      result = GeneratePossiblySpecializedMessageSend(
-          CGF, ReturnValueSlot(), ResultType, SelfSel, selfValue, Args, OID,
-          nullptr, true);
+      result = GeneratePossiblySpecializedMessageSend(CGF, nullptr, ResultType,
+                                                      SelfSel, selfValue, Args,
+                                                      OID, nullptr, true);
       Builder.CreateStore(result.getScalarVal(), selfAddr);
 
       // Nullable `Class` expressions cannot be messaged with a direct method
@@ -2776,17 +2774,11 @@ ConstantAddress CGObjCGNU::GenerateConstantDictionary(
 ///Generates a message send where the super is the receiver.  This is a message
 ///send to self with special delivery semantics indicating which class's method
 ///should be called.
-RValue
-CGObjCGNU::GenerateMessageSendSuper(CodeGenFunction &CGF,
-                                    ReturnValueSlot Return,
-                                    QualType ResultType,
-                                    Selector Sel,
-                                    const ObjCInterfaceDecl *Class,
-                                    bool isCategoryImpl,
-                                    llvm::Value *Receiver,
-                                    bool IsClassMessage,
-                                    const CallArgList &CallArgs,
-                                    const ObjCMethodDecl *Method) {
+RValue CGObjCGNU::GenerateMessageSendSuper(
+    CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType ResultType,
+    Selector Sel, const ObjCInterfaceDecl *Class, bool isCategoryImpl,
+    llvm::Value *Receiver, bool IsClassMessage, const CallArgList &CallArgs,
+    const ObjCMethodDecl *Method) {
   CGBuilderTy &Builder = CGF.Builder;
   if (CGM.getLangOpts().getGC() == LangOptions::GCOnly) {
     if (Sel == RetainSel || Sel == AutoreleaseSel) {
@@ -2884,21 +2876,23 @@ CGObjCGNU::GenerateMessageSendSuper(CodeGenFunction &CGF,
   CGCallee callee(CGCalleeInfo(), imp);
 
   llvm::CallBase *call;
-  RValue msgRet = CGF.EmitCall(MSI.CallInfo, callee, Return, ActualArgs, &call);
+  ReturnValueSlot CapturedSlot;
+  auto doEmitCall = [&](ReturnValueSlot Slot) {
+    CapturedSlot = Slot;
+    return CGF.EmitCall(MSI.CallInfo, callee, Slot, ActualArgs, &call);
+  };
+  RValue msgRet = ReturnSlotWrapper
+                      ? ReturnSlotWrapper(MSI.CallInfo, doEmitCall)
+                      : doEmitCall(ReturnValueSlot());
   call->setMetadata(msgSendMDKind, node);
   return msgRet;
 }
 
 /// Generate code for a message send expression.
-RValue
-CGObjCGNU::GenerateMessageSend(CodeGenFunction &CGF,
-                               ReturnValueSlot Return,
-                               QualType ResultType,
-                               Selector Sel,
-                               llvm::Value *Receiver,
-                               const CallArgList &CallArgs,
-                               const ObjCInterfaceDecl *Class,
-                               const ObjCMethodDecl *Method) {
+RValue CGObjCGNU::GenerateMessageSend(
+    CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType ResultType,
+    Selector Sel, llvm::Value *Receiver, const CallArgList &CallArgs,
+    const ObjCInterfaceDecl *Class, const ObjCMethodDecl *Method) {
   CGBuilderTy &Builder = CGF.Builder;
 
   // Strip out message sends to retain / release in GC mode
@@ -2976,7 +2970,7 @@ CGObjCGNU::GenerateMessageSend(CodeGenFunction &CGF,
     // If the return value isn't flagged as unused, and the result
     // type isn't in our narrow set where we assume compatibility,
     // we need a nil check to ensure a nil value.
-    if (!Return.isUnused()) {
+    if (!ReturnSlotWrapper.IsResultUnused) {
       if (ResultType->isVoidType()) {
         // void results are definitely okay.
       } else if (ResultType->hasPointerRepresentation() &&
@@ -3080,7 +3074,14 @@ CGObjCGNU::GenerateMessageSend(CodeGenFunction &CGF,
 
   llvm::CallBase *call;
   CGCallee callee(CGCalleeInfo(), imp);
-  RValue msgRet = CGF.EmitCall(MSI.CallInfo, callee, Return, ActualArgs, &call);
+  ReturnValueSlot CapturedSlot;
+  auto doEmitCall = [&](ReturnValueSlot Slot) {
+    CapturedSlot = Slot;
+    return CGF.EmitCall(MSI.CallInfo, callee, Slot, ActualArgs, &call);
+  };
+  RValue msgRet = ReturnSlotWrapper
+                      ? ReturnSlotWrapper(MSI.CallInfo, doEmitCall)
+                      : doEmitCall(ReturnValueSlot());
   if (!isDirect)
     call->setMetadata(msgSendMDKind, node);
 

--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -1105,7 +1105,7 @@ public:
 
 protected:
   CodeGen::RValue EmitMessageSend(CodeGen::CodeGenFunction &CGF,
-                                  ReturnSlotFn ReturnSlotWrapper,
+                                  ReturnSlotFn WithReturnValueSlot,
                                   QualType ResultType, Selector Sel,
                                   llvm::Value *Arg0, QualType Arg0Ty,
                                   bool IsSuper, const CallArgList &CallArgs,
@@ -1469,7 +1469,7 @@ public:
   llvm::Function *ModuleInitFunction() override;
 
   CodeGen::RValue GenerateMessageSend(CodeGen::CodeGenFunction &CGF,
-                                      ReturnSlotFn ReturnSlotWrapper,
+                                      ReturnSlotFn WithReturnValueSlot,
                                       QualType ResultType, Selector Sel,
                                       llvm::Value *Receiver,
                                       const CallArgList &CallArgs,
@@ -1477,7 +1477,7 @@ public:
                                       const ObjCMethodDecl *Method) override;
 
   CodeGen::RValue GenerateMessageSendSuper(
-      CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+      CodeGen::CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
       QualType ResultType, Selector Sel, const ObjCInterfaceDecl *Class,
       bool isCategoryImpl, llvm::Value *Receiver, bool IsClassMessage,
       const CallArgList &CallArgs, const ObjCMethodDecl *Method) override;
@@ -1624,7 +1624,7 @@ private:
                                    ObjCProtocolDecl::protocol_iterator end);
 
   CodeGen::RValue EmitVTableMessageSend(
-      CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+      CodeGen::CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
       QualType ResultType, Selector Sel, llvm::Value *Receiver, QualType Arg0Ty,
       bool IsSuper, const CallArgList &CallArgs, const ObjCMethodDecl *Method);
 
@@ -1757,7 +1757,7 @@ public:
   llvm::Function *ModuleInitFunction() override;
 
   CodeGen::RValue GenerateMessageSend(CodeGen::CodeGenFunction &CGF,
-                                      ReturnSlotFn ReturnSlotWrapper,
+                                      ReturnSlotFn WithReturnValueSlot,
                                       QualType ResultType, Selector Sel,
                                       llvm::Value *Receiver,
                                       const CallArgList &CallArgs,
@@ -1765,7 +1765,7 @@ public:
                                       const ObjCMethodDecl *Method) override;
 
   CodeGen::RValue GenerateMessageSendSuper(
-      CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+      CodeGen::CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
       QualType ResultType, Selector Sel, const ObjCInterfaceDecl *Class,
       bool isCategoryImpl, llvm::Value *Receiver, bool IsClassMessage,
       const CallArgList &CallArgs, const ObjCMethodDecl *Method) override;
@@ -2672,7 +2672,7 @@ enum { kCFTaggedObjectID_Integer = (1 << 1) + 1 };
 /// a message send to self with special delivery semantics indicating
 /// which class's method should be called.
 CodeGen::RValue CGObjCMac::GenerateMessageSendSuper(
-    CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+    CodeGen::CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
     QualType ResultType, Selector Sel, const ObjCInterfaceDecl *Class,
     bool isCategoryImpl, llvm::Value *Receiver, bool IsClassMessage,
     const CodeGen::CallArgList &CallArgs, const ObjCMethodDecl *Method) {
@@ -2722,24 +2722,24 @@ CodeGen::RValue CGObjCMac::GenerateMessageSendSuper(
       CGM.getTypes().ConvertType(CGF.getContext().getObjCClassType());
   Target = CGF.Builder.CreateBitCast(Target, ClassTy);
   CGF.Builder.CreateStore(Target, CGF.Builder.CreateStructGEP(ObjCSuper, 1));
-  return EmitMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel,
+  return EmitMessageSend(CGF, WithReturnValueSlot, ResultType, Sel,
                          ObjCSuper.getPointer(), ObjCTypes.SuperPtrCTy, true,
                          CallArgs, Method, Class, ObjCTypes);
 }
 
 /// Generate code for a message send expression.
 CodeGen::RValue CGObjCMac::GenerateMessageSend(
-    CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+    CodeGen::CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
     QualType ResultType, Selector Sel, llvm::Value *Receiver,
     const CallArgList &CallArgs, const ObjCInterfaceDecl *Class,
     const ObjCMethodDecl *Method) {
-  return EmitMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel, Receiver,
+  return EmitMessageSend(CGF, WithReturnValueSlot, ResultType, Sel, Receiver,
                          CGF.getContext().getObjCIdType(), false, CallArgs,
                          Method, Class, ObjCTypes);
 }
 
 CodeGen::RValue CGObjCCommonMac::EmitMessageSend(
-    CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+    CodeGen::CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
     QualType ResultType, Selector Sel, llvm::Value *Arg0, QualType Arg0Ty,
     bool IsSuper, const CallArgList &CallArgs, const ObjCMethodDecl *Method,
     const ObjCInterfaceDecl *ClassReceiver,
@@ -2834,7 +2834,7 @@ CodeGen::RValue CGObjCCommonMac::EmitMessageSend(
 
   // We don't need to emit a null check to zero out an indirect result if the
   // result is ignored.
-  if (ReturnSlotWrapper.IsResultUnused)
+  if (WithReturnValueSlot.IsResultUnused)
     RequiresNullCheck = false;
 
   // Emit a null-check if there's a consumed argument other than the receiver.
@@ -2886,8 +2886,8 @@ CodeGen::RValue CGObjCCommonMac::EmitMessageSend(
     return nullReturn.complete(CGF, Slot, rvalue, ResultType, CallArgs,
                                RequiresNullCheck ? Method : nullptr);
   };
-  return ReturnSlotWrapper ? ReturnSlotWrapper(MSI.CallInfo, doEmitCall)
-                           : doEmitCall(ReturnValueSlot());
+  return WithReturnValueSlot ? WithReturnValueSlot(MSI.CallInfo, doEmitCall)
+                             : doEmitCall(ReturnValueSlot());
 }
 
 static Qualifiers::GC GetGCAttrTypeForType(ASTContext &Ctx, QualType FQT,
@@ -8160,7 +8160,7 @@ static void appendSelectorForMessageRefTable(std::string &buffer,
 /// which tail-calls objc_msgSend.  Both stubs adjust the selector
 /// argument to correctly point to the selector.
 RValue CGObjCNonFragileABIMac::EmitVTableMessageSend(
-    CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType resultType,
+    CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot, QualType resultType,
     Selector selector, llvm::Value *arg0, QualType arg0Type, bool isSuper,
     const CallArgList &formalArgs, const ObjCMethodDecl *method) {
   // Compute the actual arguments.
@@ -8263,23 +8263,23 @@ RValue CGObjCNonFragileABIMac::EmitVTableMessageSend(
     return nullReturn.complete(CGF, Slot, result, resultType, formalArgs,
                                requiresnullCheck ? method : nullptr);
   };
-  RValue result = ReturnSlotWrapper
-                      ? ReturnSlotWrapper(MSI.CallInfo, doEmitCall)
+  RValue result = WithReturnValueSlot
+                      ? WithReturnValueSlot(MSI.CallInfo, doEmitCall)
                       : doEmitCall(ReturnValueSlot());
   return result;
 }
 
 /// Generate code for a message send expression in the nonfragile abi.
 CodeGen::RValue CGObjCNonFragileABIMac::GenerateMessageSend(
-    CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+    CodeGen::CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
     QualType ResultType, Selector Sel, llvm::Value *Receiver,
     const CallArgList &CallArgs, const ObjCInterfaceDecl *Class,
     const ObjCMethodDecl *Method) {
   return isVTableDispatchedSelector(Sel)
-             ? EmitVTableMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel,
+             ? EmitVTableMessageSend(CGF, WithReturnValueSlot, ResultType, Sel,
                                      Receiver, CGF.getContext().getObjCIdType(),
                                      false, CallArgs, Method)
-             : EmitMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel,
+             : EmitMessageSend(CGF, WithReturnValueSlot, ResultType, Sel,
                                Receiver, CGF.getContext().getObjCIdType(),
                                false, CallArgs, Method, Class, ObjCTypes);
 }
@@ -8463,7 +8463,7 @@ llvm::Value *CGObjCNonFragileABIMac::GetClass(CodeGenFunction &CGF,
 /// a message send to self with special delivery semantics indicating
 /// which class's method should be called.
 CodeGen::RValue CGObjCNonFragileABIMac::GenerateMessageSendSuper(
-    CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+    CodeGen::CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
     QualType ResultType, Selector Sel, const ObjCInterfaceDecl *Class,
     bool isCategoryImpl, llvm::Value *Receiver, bool IsClassMessage,
     const CodeGen::CallArgList &CallArgs, const ObjCMethodDecl *Method) {
@@ -8493,11 +8493,11 @@ CodeGen::RValue CGObjCNonFragileABIMac::GenerateMessageSendSuper(
   CGF.Builder.CreateStore(Target, CGF.Builder.CreateStructGEP(ObjCSuper, 1));
 
   return (isVTableDispatchedSelector(Sel))
-             ? EmitVTableMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel,
+             ? EmitVTableMessageSend(CGF, WithReturnValueSlot, ResultType, Sel,
                                      ObjCSuper.getPointer(),
                                      ObjCTypes.SuperPtrCTy, true, CallArgs,
                                      Method)
-             : EmitMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel,
+             : EmitMessageSend(CGF, WithReturnValueSlot, ResultType, Sel,
                                ObjCSuper.getPointer(), ObjCTypes.SuperPtrCTy,
                                true, CallArgs, Method, Class, ObjCTypes);
 }

--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -1105,10 +1105,10 @@ public:
 
 protected:
   CodeGen::RValue EmitMessageSend(CodeGen::CodeGenFunction &CGF,
-                                  ReturnValueSlot Return, QualType ResultType,
-                                  Selector Sel, llvm::Value *Arg0,
-                                  QualType Arg0Ty, bool IsSuper,
-                                  const CallArgList &CallArgs,
+                                  ReturnSlotFn ReturnSlotWrapper,
+                                  QualType ResultType, Selector Sel,
+                                  llvm::Value *Arg0, QualType Arg0Ty,
+                                  bool IsSuper, const CallArgList &CallArgs,
                                   const ObjCMethodDecl *OMD,
                                   const ObjCInterfaceDecl *ClassReceiver,
                                   const ObjCCommonTypesHelper &ObjCTypes);
@@ -1469,7 +1469,7 @@ public:
   llvm::Function *ModuleInitFunction() override;
 
   CodeGen::RValue GenerateMessageSend(CodeGen::CodeGenFunction &CGF,
-                                      ReturnValueSlot Return,
+                                      ReturnSlotFn ReturnSlotWrapper,
                                       QualType ResultType, Selector Sel,
                                       llvm::Value *Receiver,
                                       const CallArgList &CallArgs,
@@ -1477,7 +1477,7 @@ public:
                                       const ObjCMethodDecl *Method) override;
 
   CodeGen::RValue GenerateMessageSendSuper(
-      CodeGen::CodeGenFunction &CGF, ReturnValueSlot Return,
+      CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
       QualType ResultType, Selector Sel, const ObjCInterfaceDecl *Class,
       bool isCategoryImpl, llvm::Value *Receiver, bool IsClassMessage,
       const CallArgList &CallArgs, const ObjCMethodDecl *Method) override;
@@ -1624,7 +1624,7 @@ private:
                                    ObjCProtocolDecl::protocol_iterator end);
 
   CodeGen::RValue EmitVTableMessageSend(
-      CodeGen::CodeGenFunction &CGF, ReturnValueSlot Return,
+      CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
       QualType ResultType, Selector Sel, llvm::Value *Receiver, QualType Arg0Ty,
       bool IsSuper, const CallArgList &CallArgs, const ObjCMethodDecl *Method);
 
@@ -1757,7 +1757,7 @@ public:
   llvm::Function *ModuleInitFunction() override;
 
   CodeGen::RValue GenerateMessageSend(CodeGen::CodeGenFunction &CGF,
-                                      ReturnValueSlot Return,
+                                      ReturnSlotFn ReturnSlotWrapper,
                                       QualType ResultType, Selector Sel,
                                       llvm::Value *Receiver,
                                       const CallArgList &CallArgs,
@@ -1765,7 +1765,7 @@ public:
                                       const ObjCMethodDecl *Method) override;
 
   CodeGen::RValue GenerateMessageSendSuper(
-      CodeGen::CodeGenFunction &CGF, ReturnValueSlot Return,
+      CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
       QualType ResultType, Selector Sel, const ObjCInterfaceDecl *Class,
       bool isCategoryImpl, llvm::Value *Receiver, bool IsClassMessage,
       const CallArgList &CallArgs, const ObjCMethodDecl *Method) override;
@@ -2672,9 +2672,9 @@ enum { kCFTaggedObjectID_Integer = (1 << 1) + 1 };
 /// a message send to self with special delivery semantics indicating
 /// which class's method should be called.
 CodeGen::RValue CGObjCMac::GenerateMessageSendSuper(
-    CodeGen::CodeGenFunction &CGF, ReturnValueSlot Return, QualType ResultType,
-    Selector Sel, const ObjCInterfaceDecl *Class, bool isCategoryImpl,
-    llvm::Value *Receiver, bool IsClassMessage,
+    CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+    QualType ResultType, Selector Sel, const ObjCInterfaceDecl *Class,
+    bool isCategoryImpl, llvm::Value *Receiver, bool IsClassMessage,
     const CodeGen::CallArgList &CallArgs, const ObjCMethodDecl *Method) {
   // Create and init a super structure; this is a (receiver, class)
   // pair we will pass to objc_msgSendSuper.
@@ -2722,25 +2722,26 @@ CodeGen::RValue CGObjCMac::GenerateMessageSendSuper(
       CGM.getTypes().ConvertType(CGF.getContext().getObjCClassType());
   Target = CGF.Builder.CreateBitCast(Target, ClassTy);
   CGF.Builder.CreateStore(Target, CGF.Builder.CreateStructGEP(ObjCSuper, 1));
-  return EmitMessageSend(CGF, Return, ResultType, Sel, ObjCSuper.getPointer(),
-                         ObjCTypes.SuperPtrCTy, true, CallArgs, Method, Class,
-                         ObjCTypes);
+  return EmitMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel,
+                         ObjCSuper.getPointer(), ObjCTypes.SuperPtrCTy, true,
+                         CallArgs, Method, Class, ObjCTypes);
 }
 
 /// Generate code for a message send expression.
 CodeGen::RValue CGObjCMac::GenerateMessageSend(
-    CodeGen::CodeGenFunction &CGF, ReturnValueSlot Return, QualType ResultType,
-    Selector Sel, llvm::Value *Receiver, const CallArgList &CallArgs,
-    const ObjCInterfaceDecl *Class, const ObjCMethodDecl *Method) {
-  return EmitMessageSend(CGF, Return, ResultType, Sel, Receiver,
+    CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+    QualType ResultType, Selector Sel, llvm::Value *Receiver,
+    const CallArgList &CallArgs, const ObjCInterfaceDecl *Class,
+    const ObjCMethodDecl *Method) {
+  return EmitMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel, Receiver,
                          CGF.getContext().getObjCIdType(), false, CallArgs,
                          Method, Class, ObjCTypes);
 }
 
 CodeGen::RValue CGObjCCommonMac::EmitMessageSend(
-    CodeGen::CodeGenFunction &CGF, ReturnValueSlot Return, QualType ResultType,
-    Selector Sel, llvm::Value *Arg0, QualType Arg0Ty, bool IsSuper,
-    const CallArgList &CallArgs, const ObjCMethodDecl *Method,
+    CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+    QualType ResultType, Selector Sel, llvm::Value *Arg0, QualType Arg0Ty,
+    bool IsSuper, const CallArgList &CallArgs, const ObjCMethodDecl *Method,
     const ObjCInterfaceDecl *ClassReceiver,
     const ObjCCommonTypesHelper &ObjCTypes) {
   CodeGenTypes &Types = CGM.getTypes();
@@ -2833,7 +2834,7 @@ CodeGen::RValue CGObjCCommonMac::EmitMessageSend(
 
   // We don't need to emit a null check to zero out an indirect result if the
   // result is ignored.
-  if (Return.isUnused())
+  if (ReturnSlotWrapper.IsResultUnused)
     RequiresNullCheck = false;
 
   // Emit a null-check if there's a consumed argument other than the receiver.
@@ -2872,19 +2873,21 @@ CodeGen::RValue CGObjCCommonMac::EmitMessageSend(
     ActualArgs[1] = CallArg(RValue::get(SelValue), selTy);
   }
 
-  llvm::CallBase *CallSite;
   CGCallee Callee = CGCallee::forDirect(BitcastFn);
-  RValue rvalue =
-      CGF.EmitCall(MSI.CallInfo, Callee, Return, ActualArgs, &CallSite);
-
-  // Mark the call as noreturn if the method is marked noreturn and the
-  // receiver cannot be null.
-  if (Method && Method->hasAttr<NoReturnAttr>() && !ReceiverCanBeNull) {
-    CallSite->setDoesNotReturn();
-  }
-
-  return nullReturn.complete(CGF, Return, rvalue, ResultType, CallArgs,
-                             RequiresNullCheck ? Method : nullptr);
+  auto doEmitCall = [&](ReturnValueSlot Slot) {
+    llvm::CallBase *CallSite;
+    RValue rvalue =
+        CGF.EmitCall(MSI.CallInfo, Callee, Slot, ActualArgs, &CallSite);
+    // Mark the call as noreturn if the method is marked noreturn and the
+    // receiver cannot be null.
+    if (Method && Method->hasAttr<NoReturnAttr>() && !ReceiverCanBeNull) {
+      CallSite->setDoesNotReturn();
+    }
+    return nullReturn.complete(CGF, Slot, rvalue, ResultType, CallArgs,
+                               RequiresNullCheck ? Method : nullptr);
+  };
+  return ReturnSlotWrapper ? ReturnSlotWrapper(MSI.CallInfo, doEmitCall)
+                           : doEmitCall(ReturnValueSlot());
 }
 
 static Qualifiers::GC GetGCAttrTypeForType(ASTContext &Ctx, QualType FQT,
@@ -4878,8 +4881,7 @@ CGObjCCommonMac::GenerateClassRealization(CodeGenFunction &CGF,
   CallArgList Args;
 
   RValue result = GeneratePossiblySpecializedMessageSend(
-      CGF, ReturnValueSlot(), ResultType, SelfSel, classObject, Args, OID,
-      nullptr, true);
+      CGF, nullptr, ResultType, SelfSel, classObject, Args, OID, nullptr, true);
 
   return result.getScalarVal();
 }
@@ -8158,7 +8160,7 @@ static void appendSelectorForMessageRefTable(std::string &buffer,
 /// which tail-calls objc_msgSend.  Both stubs adjust the selector
 /// argument to correctly point to the selector.
 RValue CGObjCNonFragileABIMac::EmitVTableMessageSend(
-    CodeGenFunction &CGF, ReturnValueSlot returnSlot, QualType resultType,
+    CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType resultType,
     Selector selector, llvm::Value *arg0, QualType arg0Type, bool isSuper,
     const CallArgList &formalArgs, const ObjCMethodDecl *method) {
   // Compute the actual arguments.
@@ -8256,23 +8258,30 @@ RValue CGObjCNonFragileABIMac::EmitVTableMessageSend(
   calleePtr = CGF.Builder.CreateBitCast(calleePtr, MSI.MessengerType);
   CGCallee callee(CGCalleeInfo(), calleePtr);
 
-  RValue result = CGF.EmitCall(MSI.CallInfo, callee, returnSlot, args);
-  return nullReturn.complete(CGF, returnSlot, result, resultType, formalArgs,
-                             requiresnullCheck ? method : nullptr);
+  auto doEmitCall = [&](ReturnValueSlot Slot) {
+    RValue result = CGF.EmitCall(MSI.CallInfo, callee, Slot, args);
+    return nullReturn.complete(CGF, Slot, result, resultType, formalArgs,
+                               requiresnullCheck ? method : nullptr);
+  };
+  RValue result = ReturnSlotWrapper
+                      ? ReturnSlotWrapper(MSI.CallInfo, doEmitCall)
+                      : doEmitCall(ReturnValueSlot());
+  return result;
 }
 
 /// Generate code for a message send expression in the nonfragile abi.
 CodeGen::RValue CGObjCNonFragileABIMac::GenerateMessageSend(
-    CodeGen::CodeGenFunction &CGF, ReturnValueSlot Return, QualType ResultType,
-    Selector Sel, llvm::Value *Receiver, const CallArgList &CallArgs,
-    const ObjCInterfaceDecl *Class, const ObjCMethodDecl *Method) {
+    CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+    QualType ResultType, Selector Sel, llvm::Value *Receiver,
+    const CallArgList &CallArgs, const ObjCInterfaceDecl *Class,
+    const ObjCMethodDecl *Method) {
   return isVTableDispatchedSelector(Sel)
-             ? EmitVTableMessageSend(CGF, Return, ResultType, Sel, Receiver,
-                                     CGF.getContext().getObjCIdType(), false,
-                                     CallArgs, Method)
-             : EmitMessageSend(CGF, Return, ResultType, Sel, Receiver,
-                               CGF.getContext().getObjCIdType(), false,
-                               CallArgs, Method, Class, ObjCTypes);
+             ? EmitVTableMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel,
+                                     Receiver, CGF.getContext().getObjCIdType(),
+                                     false, CallArgs, Method)
+             : EmitMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel,
+                               Receiver, CGF.getContext().getObjCIdType(),
+                               false, CallArgs, Method, Class, ObjCTypes);
 }
 
 llvm::Constant *
@@ -8454,9 +8463,9 @@ llvm::Value *CGObjCNonFragileABIMac::GetClass(CodeGenFunction &CGF,
 /// a message send to self with special delivery semantics indicating
 /// which class's method should be called.
 CodeGen::RValue CGObjCNonFragileABIMac::GenerateMessageSendSuper(
-    CodeGen::CodeGenFunction &CGF, ReturnValueSlot Return, QualType ResultType,
-    Selector Sel, const ObjCInterfaceDecl *Class, bool isCategoryImpl,
-    llvm::Value *Receiver, bool IsClassMessage,
+    CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+    QualType ResultType, Selector Sel, const ObjCInterfaceDecl *Class,
+    bool isCategoryImpl, llvm::Value *Receiver, bool IsClassMessage,
     const CodeGen::CallArgList &CallArgs, const ObjCMethodDecl *Method) {
   // ...
   // Create and init a super structure; this is a (receiver, class)
@@ -8484,10 +8493,11 @@ CodeGen::RValue CGObjCNonFragileABIMac::GenerateMessageSendSuper(
   CGF.Builder.CreateStore(Target, CGF.Builder.CreateStructGEP(ObjCSuper, 1));
 
   return (isVTableDispatchedSelector(Sel))
-             ? EmitVTableMessageSend(
-                   CGF, Return, ResultType, Sel, ObjCSuper.getPointer(),
-                   ObjCTypes.SuperPtrCTy, true, CallArgs, Method)
-             : EmitMessageSend(CGF, Return, ResultType, Sel,
+             ? EmitVTableMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel,
+                                     ObjCSuper.getPointer(),
+                                     ObjCTypes.SuperPtrCTy, true, CallArgs,
+                                     Method)
+             : EmitMessageSend(CGF, ReturnSlotWrapper, ResultType, Sel,
                                ObjCSuper.getPointer(), ObjCTypes.SuperPtrCTy,
                                true, CallArgs, Method, Class, ObjCTypes);
 }

--- a/clang/lib/CodeGen/CGObjCRuntime.h
+++ b/clang/lib/CodeGen/CGObjCRuntime.h
@@ -177,7 +177,7 @@ public:
   /// \param Method - The method being called, this may be null if synthesizing
   /// a property setter or getter.
   virtual CodeGen::RValue GenerateMessageSend(
-      CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+      CodeGen::CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
       QualType ResultType, Selector Sel, llvm::Value *Receiver,
       const CallArgList &CallArgs, const ObjCInterfaceDecl *Class = nullptr,
       const ObjCMethodDecl *Method = nullptr) = 0;
@@ -187,10 +187,10 @@ public:
   /// This variant allows for the call to be substituted with an optimized
   /// variant.
   CodeGen::RValue GeneratePossiblySpecializedMessageSend(
-      CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType ResultType,
-      Selector Sel, llvm::Value *Receiver, const CallArgList &Args,
-      const ObjCInterfaceDecl *OID, const ObjCMethodDecl *Method,
-      bool isClassMessage);
+      CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
+      QualType ResultType, Selector Sel, llvm::Value *Receiver,
+      const CallArgList &Args, const ObjCInterfaceDecl *OID,
+      const ObjCMethodDecl *Method, bool isClassMessage);
 
   /// Generate an Objective-C message send operation to the super
   /// class initiated in a method for Class and with the given Self
@@ -199,7 +199,7 @@ public:
   /// \param Method - The method being called, this may be null if synthesizing
   /// a property setter or getter.
   virtual CodeGen::RValue GenerateMessageSendSuper(
-      CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+      CodeGen::CodeGenFunction &CGF, ReturnSlotFn WithReturnValueSlot,
       QualType ResultType, Selector Sel, const ObjCInterfaceDecl *Class,
       bool isCategoryImpl, llvm::Value *Self, bool IsClassMessage,
       const CallArgList &CallArgs, const ObjCMethodDecl *Method = nullptr) = 0;

--- a/clang/lib/CodeGen/CGObjCRuntime.h
+++ b/clang/lib/CodeGen/CGObjCRuntime.h
@@ -176,19 +176,18 @@ public:
   ///
   /// \param Method - The method being called, this may be null if synthesizing
   /// a property setter or getter.
-  virtual CodeGen::RValue
-  GenerateMessageSend(CodeGen::CodeGenFunction &CGF, ReturnValueSlot ReturnSlot,
-                      QualType ResultType, Selector Sel, llvm::Value *Receiver,
-                      const CallArgList &CallArgs,
-                      const ObjCInterfaceDecl *Class = nullptr,
-                      const ObjCMethodDecl *Method = nullptr) = 0;
+  virtual CodeGen::RValue GenerateMessageSend(
+      CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
+      QualType ResultType, Selector Sel, llvm::Value *Receiver,
+      const CallArgList &CallArgs, const ObjCInterfaceDecl *Class = nullptr,
+      const ObjCMethodDecl *Method = nullptr) = 0;
 
   /// Generate an Objective-C message send operation.
   ///
   /// This variant allows for the call to be substituted with an optimized
   /// variant.
   CodeGen::RValue GeneratePossiblySpecializedMessageSend(
-      CodeGenFunction &CGF, ReturnValueSlot Return, QualType ResultType,
+      CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper, QualType ResultType,
       Selector Sel, llvm::Value *Receiver, const CallArgList &Args,
       const ObjCInterfaceDecl *OID, const ObjCMethodDecl *Method,
       bool isClassMessage);
@@ -200,7 +199,7 @@ public:
   /// \param Method - The method being called, this may be null if synthesizing
   /// a property setter or getter.
   virtual CodeGen::RValue GenerateMessageSendSuper(
-      CodeGen::CodeGenFunction &CGF, ReturnValueSlot ReturnSlot,
+      CodeGen::CodeGenFunction &CGF, ReturnSlotFn ReturnSlotWrapper,
       QualType ResultType, Selector Sel, const ObjCInterfaceDecl *Class,
       bool isCategoryImpl, llvm::Value *Self, bool IsClassMessage,
       const CallArgList &CallArgs, const ObjCMethodDecl *Method = nullptr) = 0;

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -4578,7 +4578,6 @@ public:
   //                         Scalar Expression Emission
   //===--------------------------------------------------------------------===//
 
-  // Defined in CGCall.h (shared with CGObjCRuntime.h).
   using ReturnSlotFn = CodeGen::ReturnSlotFn;
 
   /// EmitCall - Generate a call of the given function, expecting the given

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -4578,6 +4578,9 @@ public:
   //                         Scalar Expression Emission
   //===--------------------------------------------------------------------===//
 
+  // Defined in CGCall.h (shared with CGObjCRuntime.h).
+  using ReturnSlotFn = CodeGen::ReturnSlotFn;
+
   /// EmitCall - Generate a call of the given function, expecting the given
   /// result type, and using the given argument list which specifies both the
   /// LLVM arguments and the types they were derived from.
@@ -4594,16 +4597,17 @@ public:
                     IsMustTail, SourceLocation());
   }
   RValue EmitCall(QualType FnType, const CGCallee &Callee, const CallExpr *E,
-                  ReturnValueSlot ReturnValue, llvm::Value *Chain = nullptr,
+                  llvm::Value *Chain = nullptr,
                   llvm::CallBase **CallOrInvoke = nullptr,
-                  CGFunctionInfo const **ResolvedFnInfo = nullptr);
+                  CGFunctionInfo const **ResolvedFnInfo = nullptr,
+                  ReturnSlotFn ReturnSlotWrapper = nullptr);
 
   // If a Call or Invoke instruction was emitted for this CallExpr, this method
   // writes the pointer to `CallOrInvoke` if it's not null.
   RValue EmitCallExpr(const CallExpr *E,
-                      ReturnValueSlot ReturnValue = ReturnValueSlot(),
-                      llvm::CallBase **CallOrInvoke = nullptr);
-  RValue EmitSimpleCallExpr(const CallExpr *E, ReturnValueSlot ReturnValue,
+                      llvm::CallBase **CallOrInvoke = nullptr,
+                      ReturnSlotFn ReturnSlotWrapper = nullptr);
+  RValue EmitSimpleCallExpr(const CallExpr *E,
                             llvm::CallBase **CallOrInvoke = nullptr);
   CGCallee EmitCallee(const Expr *E);
 
@@ -4738,47 +4742,47 @@ public:
   void callCStructCopyAssignmentOperator(LValue Dst, LValue Src);
   void callCStructMoveAssignmentOperator(LValue Dst, LValue Src);
 
-  RValue EmitCXXMemberOrOperatorCall(
-      const CXXMethodDecl *Method, const CGCallee &Callee,
-      ReturnValueSlot ReturnValue, llvm::Value *This,
-      llvm::Value *ImplicitParam, QualType ImplicitParamTy, const CallExpr *E,
-      CallArgList *RtlArgs, llvm::CallBase **CallOrInvoke);
+  RValue EmitCXXMemberOrOperatorCall(const CXXMethodDecl *Method,
+                                     const CGCallee &Callee, llvm::Value *This,
+                                     llvm::Value *ImplicitParam,
+                                     QualType ImplicitParamTy,
+                                     const CallExpr *E, CallArgList *RtlArgs,
+                                     llvm::CallBase **CallOrInvoke,
+                                     ReturnSlotFn ReturnSlotWrapper = nullptr);
   RValue EmitCXXDestructorCall(GlobalDecl Dtor, const CGCallee &Callee,
                                llvm::Value *This, QualType ThisTy,
                                llvm::Value *ImplicitParam,
                                QualType ImplicitParamTy, const CallExpr *E,
                                llvm::CallBase **CallOrInvoke = nullptr);
   RValue EmitCXXMemberCallExpr(const CXXMemberCallExpr *E,
-                               ReturnValueSlot ReturnValue,
-                               llvm::CallBase **CallOrInvoke = nullptr);
+                               llvm::CallBase **CallOrInvoke = nullptr,
+                               ReturnSlotFn ReturnSlotWrapper = nullptr);
   RValue EmitCXXMemberOrOperatorMemberCallExpr(
-      const CallExpr *CE, const CXXMethodDecl *MD, ReturnValueSlot ReturnValue,
-      bool HasQualifier, NestedNameSpecifier Qualifier, bool IsArrow,
-      const Expr *Base, llvm::CallBase **CallOrInvoke);
+      const CallExpr *CE, const CXXMethodDecl *MD, bool HasQualifier,
+      NestedNameSpecifier Qualifier, bool IsArrow, const Expr *Base,
+      llvm::CallBase **CallOrInvoke, ReturnSlotFn ReturnSlotWrapper = nullptr);
   // Compute the object pointer.
   Address EmitCXXMemberDataPointerAddress(
       const Expr *E, Address base, llvm::Value *memberPtr,
       const MemberPointerType *memberPtrType, bool IsInBounds,
       LValueBaseInfo *BaseInfo = nullptr, TBAAAccessInfo *TBAAInfo = nullptr);
   RValue EmitCXXMemberPointerCallExpr(const CXXMemberCallExpr *E,
-                                      ReturnValueSlot ReturnValue,
-                                      llvm::CallBase **CallOrInvoke);
+                                      llvm::CallBase **CallOrInvoke,
+                                      ReturnSlotFn ReturnSlotWrapper = nullptr);
 
-  RValue EmitCXXOperatorMemberCallExpr(const CXXOperatorCallExpr *E,
-                                       const CXXMethodDecl *MD,
-                                       ReturnValueSlot ReturnValue,
-                                       llvm::CallBase **CallOrInvoke);
+  RValue EmitCXXOperatorMemberCallExpr(
+      const CXXOperatorCallExpr *E, const CXXMethodDecl *MD,
+      llvm::CallBase **CallOrInvoke, ReturnSlotFn ReturnSlotWrapper = nullptr);
   RValue EmitCXXPseudoDestructorExpr(const CXXPseudoDestructorExpr *E);
 
   RValue EmitCUDAKernelCallExpr(const CUDAKernelCallExpr *E,
-                                ReturnValueSlot ReturnValue,
                                 llvm::CallBase **CallOrInvoke);
 
   RValue EmitNVPTXDevicePrintfCallExpr(const CallExpr *E);
   RValue EmitAMDGPUDevicePrintfCallExpr(const CallExpr *E);
 
   RValue EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
-                         const CallExpr *E, ReturnValueSlot ReturnValue);
+                         const CallExpr *E, ReturnSlotFn ReturnSlotWrapper);
 
   RValue emitRotate(const CallExpr *E, bool IsRotateRight);
 
@@ -4801,8 +4805,8 @@ public:
       const analyze_os_log::OSLogBufferLayout &Layout,
       CharUnits BufferAlignment);
 
-  RValue EmitBlockCallExpr(const CallExpr *E, ReturnValueSlot ReturnValue,
-                           llvm::CallBase **CallOrInvoke);
+  RValue EmitBlockCallExpr(const CallExpr *E, llvm::CallBase **CallOrInvoke,
+                           ReturnSlotFn ReturnSlotWrapper = nullptr);
 
   /// EmitTargetBuiltinExpr - Emit the given builtin call. Returns 0 if the call
   /// is unhandled by the current target.
@@ -4995,7 +4999,7 @@ public:
                             const ObjCMethodDecl *MethodWithObjects);
   llvm::Value *EmitObjCSelectorExpr(const ObjCSelectorExpr *E);
   RValue EmitObjCMessageExpr(const ObjCMessageExpr *E,
-                             ReturnValueSlot Return = ReturnValueSlot());
+                             ReturnSlotFn ReturnSlotWrapper = nullptr);
 
   /// Retrieves the default cleanup kind for an ARC cleanup.
   /// Except under -fobjc-arc-eh, ARC cleanups are normal-only.

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -2953,7 +2953,7 @@ public:
                            RawAddress *Alloca = nullptr);
 
   /// CreateMemTemp - Create a temporary memory object of the given type, with
-  /// appropriate alignmen without casting it to the default address space.
+  /// appropriate alignment without casting it to the default address space.
   RawAddress CreateMemTempWithoutCast(QualType T, const Twine &Name = "tmp");
   RawAddress CreateMemTempWithoutCast(QualType T, CharUnits Align,
                                       const Twine &Name = "tmp");

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -4599,13 +4599,13 @@ public:
                   llvm::Value *Chain = nullptr,
                   llvm::CallBase **CallOrInvoke = nullptr,
                   CGFunctionInfo const **ResolvedFnInfo = nullptr,
-                  ReturnSlotFn ReturnSlotWrapper = nullptr);
+                  ReturnSlotFn WithReturnValueSlot = nullptr);
 
   // If a Call or Invoke instruction was emitted for this CallExpr, this method
   // writes the pointer to `CallOrInvoke` if it's not null.
   RValue EmitCallExpr(const CallExpr *E,
                       llvm::CallBase **CallOrInvoke = nullptr,
-                      ReturnSlotFn ReturnSlotWrapper = nullptr);
+                      ReturnSlotFn WithReturnValueSlot = nullptr);
   RValue EmitSimpleCallExpr(const CallExpr *E,
                             llvm::CallBase **CallOrInvoke = nullptr);
   CGCallee EmitCallee(const Expr *E);
@@ -4741,13 +4741,11 @@ public:
   void callCStructCopyAssignmentOperator(LValue Dst, LValue Src);
   void callCStructMoveAssignmentOperator(LValue Dst, LValue Src);
 
-  RValue EmitCXXMemberOrOperatorCall(const CXXMethodDecl *Method,
-                                     const CGCallee &Callee, llvm::Value *This,
-                                     llvm::Value *ImplicitParam,
-                                     QualType ImplicitParamTy,
-                                     const CallExpr *E, CallArgList *RtlArgs,
-                                     llvm::CallBase **CallOrInvoke,
-                                     ReturnSlotFn ReturnSlotWrapper = nullptr);
+  RValue EmitCXXMemberOrOperatorCall(
+      const CXXMethodDecl *Method, const CGCallee &Callee, llvm::Value *This,
+      llvm::Value *ImplicitParam, QualType ImplicitParamTy, const CallExpr *E,
+      CallArgList *RtlArgs, llvm::CallBase **CallOrInvoke,
+      ReturnSlotFn WithReturnValueSlot = nullptr);
   RValue EmitCXXDestructorCall(GlobalDecl Dtor, const CGCallee &Callee,
                                llvm::Value *This, QualType ThisTy,
                                llvm::Value *ImplicitParam,
@@ -4755,23 +4753,27 @@ public:
                                llvm::CallBase **CallOrInvoke = nullptr);
   RValue EmitCXXMemberCallExpr(const CXXMemberCallExpr *E,
                                llvm::CallBase **CallOrInvoke = nullptr,
-                               ReturnSlotFn ReturnSlotWrapper = nullptr);
+                               ReturnSlotFn WithReturnValueSlot = nullptr);
   RValue EmitCXXMemberOrOperatorMemberCallExpr(
       const CallExpr *CE, const CXXMethodDecl *MD, bool HasQualifier,
       NestedNameSpecifier Qualifier, bool IsArrow, const Expr *Base,
-      llvm::CallBase **CallOrInvoke, ReturnSlotFn ReturnSlotWrapper = nullptr);
+      llvm::CallBase **CallOrInvoke,
+      ReturnSlotFn WithReturnValueSlot = nullptr);
   // Compute the object pointer.
   Address EmitCXXMemberDataPointerAddress(
       const Expr *E, Address base, llvm::Value *memberPtr,
       const MemberPointerType *memberPtrType, bool IsInBounds,
       LValueBaseInfo *BaseInfo = nullptr, TBAAAccessInfo *TBAAInfo = nullptr);
-  RValue EmitCXXMemberPointerCallExpr(const CXXMemberCallExpr *E,
-                                      llvm::CallBase **CallOrInvoke,
-                                      ReturnSlotFn ReturnSlotWrapper = nullptr);
+  RValue
+  EmitCXXMemberPointerCallExpr(const CXXMemberCallExpr *E,
+                               llvm::CallBase **CallOrInvoke,
+                               ReturnSlotFn WithReturnValueSlot = nullptr);
 
-  RValue EmitCXXOperatorMemberCallExpr(
-      const CXXOperatorCallExpr *E, const CXXMethodDecl *MD,
-      llvm::CallBase **CallOrInvoke, ReturnSlotFn ReturnSlotWrapper = nullptr);
+  RValue
+  EmitCXXOperatorMemberCallExpr(const CXXOperatorCallExpr *E,
+                                const CXXMethodDecl *MD,
+                                llvm::CallBase **CallOrInvoke,
+                                ReturnSlotFn WithReturnValueSlot = nullptr);
   RValue EmitCXXPseudoDestructorExpr(const CXXPseudoDestructorExpr *E);
 
   RValue EmitCUDAKernelCallExpr(const CUDAKernelCallExpr *E,
@@ -4781,7 +4783,7 @@ public:
   RValue EmitAMDGPUDevicePrintfCallExpr(const CallExpr *E);
 
   RValue EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
-                         const CallExpr *E, ReturnSlotFn ReturnSlotWrapper);
+                         const CallExpr *E, ReturnSlotFn WithReturnValueSlot);
 
   RValue emitRotate(const CallExpr *E, bool IsRotateRight);
 
@@ -4805,7 +4807,7 @@ public:
       CharUnits BufferAlignment);
 
   RValue EmitBlockCallExpr(const CallExpr *E, llvm::CallBase **CallOrInvoke,
-                           ReturnSlotFn ReturnSlotWrapper = nullptr);
+                           ReturnSlotFn WithReturnValueSlot = nullptr);
 
   /// EmitTargetBuiltinExpr - Emit the given builtin call. Returns 0 if the call
   /// is unhandled by the current target.
@@ -4998,7 +5000,7 @@ public:
                             const ObjCMethodDecl *MethodWithObjects);
   llvm::Value *EmitObjCSelectorExpr(const ObjCSelectorExpr *E);
   RValue EmitObjCMessageExpr(const ObjCMessageExpr *E,
-                             ReturnSlotFn ReturnSlotWrapper = nullptr);
+                             ReturnSlotFn WithReturnValueSlot = nullptr);
 
   /// Retrieves the default cleanup kind for an ARC cleanup.
   /// Except under -fobjc-arc-eh, ARC cleanups are normal-only.

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -1377,18 +1377,15 @@ ItaniumCXXABI::EmitMemberPointerIsNotNull(CodeGenFunction &CGF,
 }
 
 bool ItaniumCXXABI::classifyReturnType(CGFunctionInfo &FI) const {
-  const CXXRecordDecl *RD = FI.getReturnType()->getAsCXXRecordDecl();
+  QualType RetTy = FI.getReturnType();
+  const CXXRecordDecl *RD = RetTy->getAsCXXRecordDecl();
   if (!RD)
     return false;
 
-  // If C++ prohibits us from making a copy, return by address using the target
-  // hook getSRetAddrSpace to decide the AS.
+  // If C++ prohibits us from making a copy, return by address.
   if (!RD->canPassInRegisters()) {
-    auto Align = CGM.getContext().getTypeAlignInChars(FI.getReturnType());
-    LangAS SRetAS = CGM.getTargetCodeGenInfo().getSRetAddrSpace(RD);
-    unsigned AS = CGM.getContext().getTargetAddressSpace(SRetAS);
-    FI.getReturnInfo() =
-        ABIArgInfo::getIndirect(Align, /*AddrSpace=*/AS, /*ByVal=*/false);
+    FI.getReturnInfo() = ABIArgInfo::getNaturalIndirectNoCopy(
+        getContext(), RetTy, /*ByVal=*/false);
     return true;
   }
   return false;

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -1185,22 +1185,20 @@ static bool isTrivialForMSVC(const CXXRecordDecl *RD, QualType Ty,
 }
 
 bool MicrosoftCXXABI::classifyReturnType(CGFunctionInfo &FI) const {
-  const CXXRecordDecl *RD = FI.getReturnType()->getAsCXXRecordDecl();
+  QualType RetTy = FI.getReturnType();
+  const CXXRecordDecl *RD = RetTy->getAsCXXRecordDecl();
   if (!RD)
     return false;
 
-  bool isTrivialForABI = RD->canPassInRegisters() &&
-                         isTrivialForMSVC(RD, FI.getReturnType(), CGM);
+  bool isTrivialForABI =
+      RD->canPassInRegisters() && isTrivialForMSVC(RD, RetTy, CGM);
 
   // MSVC always returns structs indirectly from C++ instance methods.
   bool isIndirectReturn = !isTrivialForABI || FI.isInstanceMethod();
 
   if (isIndirectReturn) {
-    CharUnits Align = CGM.getContext().getTypeAlignInChars(FI.getReturnType());
-    LangAS SRetAS = CGM.getTargetCodeGenInfo().getSRetAddrSpace(RD);
-    unsigned AS = CGM.getContext().getTargetAddressSpace(SRetAS);
-    FI.getReturnInfo() =
-        ABIArgInfo::getIndirect(Align, /*AddrSpace=*/AS, /*ByVal=*/false);
+    FI.getReturnInfo() = ABIArgInfo::getNaturalIndirectNoCopy(
+        getContext(), RetTy, /*ByVal=*/false);
 
     // MSVC always passes `this` before the `sret` parameter.
     FI.getReturnInfo().setSRetAfterThis(FI.isInstanceMethod());

--- a/clang/lib/CodeGen/TargetInfo.h
+++ b/clang/lib/CodeGen/TargetInfo.h
@@ -319,12 +319,6 @@ public:
   virtual LangAS getGlobalVarAddressSpace(CodeGenModule &CGM,
                                           const VarDecl *D) const;
 
-  /// Get the address space for an indirect (sret) return of the given type.
-  /// The default falls back to the alloca AS.
-  virtual LangAS getSRetAddrSpace(const CXXRecordDecl *RD) const {
-    return LangAS::Default;
-  }
-
   /// Get address space of pointer parameter for __cxa_atexit.
   virtual LangAS getAddrSpaceOfCxaAtexitPtrParam() const {
     return LangAS::Default;

--- a/clang/lib/CodeGen/Targets/AArch64.cpp
+++ b/clang/lib/CodeGen/Targets/AArch64.cpp
@@ -336,8 +336,7 @@ ABIArgInfo AArch64ABIInfo::coerceIllegalVector(QualType Ty, unsigned &NSRN,
     return ABIArgInfo::getDirect(ResType);
   }
 
-  return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                 /*ByVal=*/false);
+  return getNaturalIndirect(Ty, /*ByVal=*/false);
 }
 
 ABIArgInfo AArch64ABIInfo::coerceAndExpandPureScalableAggregate(
@@ -345,8 +344,7 @@ ABIArgInfo AArch64ABIInfo::coerceAndExpandPureScalableAggregate(
     const SmallVectorImpl<llvm::Type *> &UnpaddedCoerceToSeq, unsigned &NSRN,
     unsigned &NPRN) const {
   if (!IsNamedArg || NSRN + NVec > 8 || NPRN + NPred > 4)
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   /*ByVal=*/false);
+    return getNaturalIndirect(Ty, /*ByVal=*/false);
   NSRN += NVec;
   NPRN += NPred;
 
@@ -392,8 +390,7 @@ ABIArgInfo AArch64ABIInfo::classifyArgumentType(QualType Ty, bool IsVariadicFn,
 
     if (const auto *EIT = Ty->getAs<BitIntType>())
       if (EIT->getNumBits() > 128)
-        return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                       false);
+        return getNaturalIndirect(Ty, false);
 
     if (Ty->isVectorType())
       NSRN = std::min(NSRN + 1, 8u);
@@ -432,9 +429,8 @@ ABIArgInfo AArch64ABIInfo::classifyArgumentType(QualType Ty, bool IsVariadicFn,
   // Structures with either a non-trivial destructor or a non-trivial
   // copy constructor are always indirect.
   if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI())) {
-    return getNaturalAlignIndirect(
-        Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-        /*ByVal=*/RAA == CGCXXABI::RAA_DirectInMemory);
+    return getNaturalIndirect(Ty,
+                              /*ByVal=*/RAA == CGCXXABI::RAA_DirectInMemory);
   }
 
   // Empty records:
@@ -542,8 +538,7 @@ ABIArgInfo AArch64ABIInfo::classifyArgumentType(QualType Ty, bool IsVariadicFn,
                           : llvm::ArrayType::get(BaseTy, Size / Alignment));
   }
 
-  return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                 /*ByVal=*/false);
+  return getNaturalIndirect(Ty, /*ByVal=*/false);
 }
 
 ABIArgInfo AArch64ABIInfo::classifyReturnType(QualType RetTy,
@@ -561,7 +556,7 @@ ABIArgInfo AArch64ABIInfo::classifyReturnType(QualType RetTy,
 
   // Large vector types should be returned via memory.
   if (RetTy->isVectorType() && getContext().getTypeSize(RetTy) > 128)
-    return getNaturalAlignIndirect(RetTy, getDataLayout().getAllocaAddrSpace());
+    return getNaturalIndirect(RetTy);
 
   if (!passAsAggregateType(RetTy)) {
     // Treat an enum type as its underlying type.
@@ -570,8 +565,7 @@ ABIArgInfo AArch64ABIInfo::classifyReturnType(QualType RetTy,
 
     if (const auto *EIT = RetTy->getAs<BitIntType>())
       if (EIT->getNumBits() > 128)
-        return getNaturalAlignIndirect(RetTy,
-                                       getDataLayout().getAllocaAddrSpace());
+        return getNaturalIndirect(RetTy);
 
     return (isPromotableIntegerTypeForABI(RetTy) && isDarwinPCS()
                 ? ABIArgInfo::getExtend(RetTy)
@@ -630,7 +624,7 @@ ABIArgInfo AArch64ABIInfo::classifyReturnType(QualType RetTy,
     return ABIArgInfo::getDirect(llvm::IntegerType::get(getVMContext(), Size));
   }
 
-  return getNaturalAlignIndirect(RetTy, getDataLayout().getAllocaAddrSpace());
+  return getNaturalIndirect(RetTy);
 }
 
 /// isIllegalVectorType - check whether the vector type is legal for AArch64.

--- a/clang/lib/CodeGen/Targets/AMDGPU.cpp
+++ b/clang/lib/CodeGen/Targets/AMDGPU.cpp
@@ -230,8 +230,7 @@ ABIArgInfo AMDGPUABIInfo::classifyArgumentType(QualType Ty, bool Variadic,
     // Records with non-trivial destructors/copy-constructors should not be
     // passed by value.
     if (auto RAA = getRecordArgABI(Ty, getCXXABI()))
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     RAA == CGCXXABI::RAA_DirectInMemory);
+      return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
 
     // Ignore empty structs/unions.
     if (isEmptyRecord(getContext(), Ty, true))
@@ -304,8 +303,6 @@ public:
 
   llvm::Constant *getNullPointer(const CodeGen::CodeGenModule &CGM,
       llvm::PointerType *T, QualType QT) const override;
-
-  LangAS getSRetAddrSpace(const CXXRecordDecl *RD) const override;
 
   LangAS getGlobalVarAddressSpace(CodeGenModule &CGM,
                                   const VarDecl *D) const override;
@@ -464,16 +461,6 @@ llvm::Constant *AMDGPUTargetCodeGenInfo::getNullPointer(
       PT->getContext(), Ctx.getTargetAddressSpace(LangAS::opencl_generic));
   return llvm::ConstantExpr::getAddrSpaceCast(
       llvm::ConstantPointerNull::get(NPT), PT);
-}
-
-LangAS
-AMDGPUTargetCodeGenInfo::getSRetAddrSpace(const CXXRecordDecl *RD) const {
-  // Types with no viable copy/move must be constructed in-place , use the
-  // default AS so the sret pointer matches the "this" convention.
-  if (RD && !RD->canPassInRegisters())
-    return LangAS::Default;
-  return getLangASFromTargetAS(
-      getABIInfo().getDataLayout().getAllocaAddrSpace());
 }
 
 LangAS

--- a/clang/lib/CodeGen/Targets/ARC.cpp
+++ b/clang/lib/CodeGen/Targets/ARC.cpp
@@ -70,17 +70,15 @@ public:
 
 ABIArgInfo ARCABIInfo::getIndirectByRef(QualType Ty, bool HasFreeRegs) const {
   return HasFreeRegs ? getNaturalAlignIndirectInReg(Ty)
-                     : getNaturalAlignIndirect(
-                           Ty, getDataLayout().getAllocaAddrSpace(), false);
+                     : getNaturalIndirect(Ty, false);
 }
 
 ABIArgInfo ARCABIInfo::getIndirectByValue(QualType Ty) const {
   // Compute the byval alignment.
-  const unsigned MinABIStackAlignInBytes = 4;
-  unsigned TypeAlign = getContext().getTypeAlign(Ty) / 8;
+  const CharUnits MinABIStackAlignInBytes = CharUnits::fromQuantity(4);
+  CharUnits TypeAlign = getContext().getTypeAlignInChars(Ty);
   return ABIArgInfo::getIndirect(
-      CharUnits::fromQuantity(4),
-      /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
+      CharUnits::fromQuantity(4), getNaturalAddrSpace(Ty),
       /*ByVal=*/true, TypeAlign > MinABIStackAlignInBytes);
 }
 

--- a/clang/lib/CodeGen/Targets/ARM.cpp
+++ b/clang/lib/CodeGen/Targets/ARM.cpp
@@ -304,9 +304,7 @@ ABIArgInfo ARMABIInfo::coerceIllegalVector(QualType Ty) const {
         llvm::Type::getInt32Ty(getVMContext()), Size / 32);
     return ABIArgInfo::getDirect(ResType);
   }
-  return getNaturalAlignIndirect(
-      Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-      /*ByVal=*/false);
+  return getNaturalIndirect(Ty, /*ByVal=*/false);
 }
 
 ABIArgInfo ARMABIInfo::classifyHomogeneousAggregate(QualType Ty,
@@ -387,9 +385,7 @@ ABIArgInfo ARMABIInfo::classifyArgumentType(QualType Ty, bool isVariadic,
 
     if (const auto *EIT = Ty->getAs<BitIntType>())
       if (EIT->getNumBits() > 64)
-        return getNaturalAlignIndirect(
-            Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-            /*ByVal=*/true);
+        return getNaturalIndirect(Ty, /*ByVal=*/true);
 
     return (isPromotableIntegerTypeForABI(Ty)
                 ? ABIArgInfo::getExtend(Ty, CGT.ConvertType(Ty))
@@ -397,8 +393,7 @@ ABIArgInfo ARMABIInfo::classifyArgumentType(QualType Ty, bool isVariadic,
   }
 
   if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI())) {
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   RAA == CGCXXABI::RAA_DirectInMemory);
+    return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
   }
 
   // Empty records are either ignored completely or passed as if they were a
@@ -437,9 +432,7 @@ ABIArgInfo ARMABIInfo::classifyArgumentType(QualType Ty, bool isVariadic,
     // WatchOS is adopting the 64-bit AAPCS rule on composite types: if they're
     // bigger than 128-bits, they get placed in space allocated by the caller,
     // and a pointer is passed.
-    return ABIArgInfo::getIndirect(
-        CharUnits::fromQuantity(getContext().getTypeAlign(Ty) / 8),
-        getDataLayout().getAllocaAddrSpace(), false);
+    return getNaturalIndirect(Ty, false);
   }
 
   // Support byval for ARM.
@@ -458,8 +451,7 @@ ABIArgInfo ARMABIInfo::classifyArgumentType(QualType Ty, bool isVariadic,
   if (getContext().getTypeSizeInChars(Ty) > CharUnits::fromQuantity(64)) {
     assert(getABIKind() != ARMABIKind::AAPCS16_VFP && "unexpected byval");
     return ABIArgInfo::getIndirect(
-        CharUnits::fromQuantity(ABIAlign),
-        /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
+        CharUnits::fromQuantity(ABIAlign), getNaturalAddrSpace(Ty),
         /*ByVal=*/true, /*Realign=*/TyAlign > ABIAlign);
   }
 
@@ -577,8 +569,7 @@ ABIArgInfo ARMABIInfo::classifyReturnType(QualType RetTy, bool isVariadic,
   if (const VectorType *VT = RetTy->getAs<VectorType>()) {
     // Large vector types should be returned via memory.
     if (getContext().getTypeSize(RetTy) > 128)
-      return getNaturalAlignIndirect(RetTy,
-                                     getDataLayout().getAllocaAddrSpace());
+      return getNaturalIndirect(RetTy);
     // TODO: FP16/BF16 vectors should be converted to integer vectors
     // This check is similar  to isIllegalVectorType - refactor?
     if ((!getTarget().hasFastHalfType() &&
@@ -596,9 +587,7 @@ ABIArgInfo ARMABIInfo::classifyReturnType(QualType RetTy, bool isVariadic,
 
     if (const auto *EIT = RetTy->getAs<BitIntType>())
       if (EIT->getNumBits() > 64)
-        return getNaturalAlignIndirect(
-            RetTy, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-            /*ByVal=*/false);
+        return getNaturalIndirect(RetTy, /*ByVal=*/false);
 
     return isPromotableIntegerTypeForABI(RetTy) ? ABIArgInfo::getExtend(RetTy)
                                                 : ABIArgInfo::getDirect();
@@ -629,7 +618,7 @@ ABIArgInfo ARMABIInfo::classifyReturnType(QualType RetTy, bool isVariadic,
     }
 
     // Otherwise return in memory.
-    return getNaturalAlignIndirect(RetTy, getDataLayout().getAllocaAddrSpace());
+    return getNaturalIndirect(RetTy);
   }
 
   // Otherwise this is an AAPCS variant.
@@ -667,7 +656,7 @@ ABIArgInfo ARMABIInfo::classifyReturnType(QualType RetTy, bool isVariadic,
     return ABIArgInfo::getDirect(CoerceTy);
   }
 
-  return getNaturalAlignIndirect(RetTy, getDataLayout().getAllocaAddrSpace());
+  return getNaturalIndirect(RetTy);
 }
 
 /// isIllegalVector - check whether Ty is an illegal vector type.

--- a/clang/lib/CodeGen/Targets/AVR.cpp
+++ b/clang/lib/CodeGen/Targets/AVR.cpp
@@ -45,7 +45,7 @@ public:
     // stack slot, along with a pointer as the function's implicit argument.
     if (getContext().getTypeSize(Ty) > RetRegs * 8) {
       LargeRet = true;
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace());
+      return getNaturalIndirect(Ty);
     }
     // An i8 return value should not be extended to i16, since AVR has 8-bit
     // registers.
@@ -79,7 +79,7 @@ public:
     // memory. Since there are not enough registers left, current argument
     // and all other unprocessed arguments should be passed in memory.
     // However we still need to return `ABIArgInfo::getDirect()` other than
-    // `ABIInfo::getNaturalAlignIndirect(Ty)`, otherwise an extra stack slot
+    // `ABIInfo::getNaturalIndirect(Ty)`, otherwise an extra stack slot
     // will be allocated, so the stack frame layout will be incompatible with
     // avr-gcc.
     NumRegs = 0;

--- a/clang/lib/CodeGen/Targets/BPF.cpp
+++ b/clang/lib/CodeGen/Targets/BPF.cpp
@@ -42,8 +42,7 @@ public:
         }
         return ABIArgInfo::getDirect(CoerceTy);
       } else {
-        return getNaturalAlignIndirect(Ty,
-                                       getDataLayout().getAllocaAddrSpace());
+        return getNaturalIndirect(Ty);
       }
     }
 
@@ -53,8 +52,7 @@ public:
     ASTContext &Context = getContext();
     if (const auto *EIT = Ty->getAs<BitIntType>())
       if (EIT->getNumBits() > Context.getTypeSize(Context.Int128Ty))
-        return getNaturalAlignIndirect(Ty,
-                                       getDataLayout().getAllocaAddrSpace());
+        return getNaturalIndirect(Ty);
 
     return (isPromotableIntegerTypeForABI(Ty) ? ABIArgInfo::getExtend(Ty)
                                               : ABIArgInfo::getDirect());
@@ -65,8 +63,7 @@ public:
       return ABIArgInfo::getIgnore();
 
     if (isAggregateTypeForABI(RetTy))
-      return getNaturalAlignIndirect(RetTy,
-                                     getDataLayout().getAllocaAddrSpace());
+      return getNaturalIndirect(RetTy);
 
     // Treat an enum type as its underlying type.
     if (const auto *ED = RetTy->getAsEnumDecl())
@@ -75,8 +72,7 @@ public:
     ASTContext &Context = getContext();
     if (const auto *EIT = RetTy->getAs<BitIntType>())
       if (EIT->getNumBits() > Context.getTypeSize(Context.Int128Ty))
-        return getNaturalAlignIndirect(RetTy,
-                                       getDataLayout().getAllocaAddrSpace());
+        return getNaturalIndirect(RetTy);
 
     // Caller will do necessary sign/zero extension.
     return ABIArgInfo::getDirect();

--- a/clang/lib/CodeGen/Targets/CSKY.cpp
+++ b/clang/lib/CodeGen/Targets/CSKY.cpp
@@ -82,9 +82,8 @@ ABIArgInfo CSKYABIInfo::classifyArgumentType(QualType Ty, int &ArgGPRsLeft,
   if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI())) {
     if (ArgGPRsLeft)
       ArgGPRsLeft -= 1;
-    return getNaturalAlignIndirect(
-        Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-        /*ByVal=*/RAA == CGCXXABI::RAA_DirectInMemory);
+    return getNaturalIndirect(Ty,
+                              /*ByVal=*/RAA == CGCXXABI::RAA_DirectInMemory);
   }
 
   // Ignore empty structs/unions.
@@ -145,8 +144,7 @@ ABIArgInfo CSKYABIInfo::classifyArgumentType(QualType Ty, int &ArgGPRsLeft,
           llvm::IntegerType::get(getVMContext(), XLen), (Size + 31) / XLen));
     }
   }
-  return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                 /*ByVal=*/false);
+  return getNaturalIndirect(Ty, /*ByVal=*/false);
 }
 
 ABIArgInfo CSKYABIInfo::classifyReturnType(QualType RetTy) const {

--- a/clang/lib/CodeGen/Targets/Hexagon.cpp
+++ b/clang/lib/CodeGen/Targets/Hexagon.cpp
@@ -105,16 +105,14 @@ ABIArgInfo HexagonABIInfo::classifyArgumentType(QualType Ty,
       HexagonAdjustRegsLeft(Size, RegsLeft);
 
     if (Size > 64 && Ty->isBitIntType())
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     /*ByVal=*/true);
+      return getNaturalIndirect(Ty, /*ByVal=*/true);
 
     return isPromotableIntegerTypeForABI(Ty) ? ABIArgInfo::getExtend(Ty)
                                              : ABIArgInfo::getDirect();
   }
 
   if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI()))
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   RAA == CGCXXABI::RAA_DirectInMemory);
+    return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
 
   // Ignore empty records.
   if (isEmptyRecord(getContext(), Ty, true))
@@ -124,8 +122,7 @@ ABIArgInfo HexagonABIInfo::classifyArgumentType(QualType Ty,
   unsigned Align = getContext().getTypeAlign(Ty);
 
   if (Size > 64)
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   /*ByVal=*/true);
+    return getNaturalIndirect(Ty, /*ByVal=*/true);
 
   if (HexagonAdjustRegsLeft(Size, RegsLeft))
     Align = Size <= 32 ? 32 : 64;
@@ -154,8 +151,7 @@ ABIArgInfo HexagonABIInfo::classifyReturnType(QualType RetTy) const {
     }
     // Large vector types should be returned via memory.
     if (Size > 64)
-      return getNaturalAlignIndirect(RetTy,
-                                     getDataLayout().getAllocaAddrSpace());
+      return getNaturalIndirect(RetTy);
   }
 
   if (!isAggregateTypeForABI(RetTy)) {
@@ -164,8 +160,7 @@ ABIArgInfo HexagonABIInfo::classifyReturnType(QualType RetTy) const {
       RetTy = ED->getIntegerType();
 
     if (Size > 64 && RetTy->isBitIntType())
-      return getNaturalAlignIndirect(
-          RetTy, getDataLayout().getAllocaAddrSpace(), /*ByVal=*/false);
+      return getNaturalIndirect(RetTy, /*ByVal=*/false);
 
     return isPromotableIntegerTypeForABI(RetTy) ? ABIArgInfo::getExtend(RetTy)
                                                 : ABIArgInfo::getDirect();
@@ -181,8 +176,7 @@ ABIArgInfo HexagonABIInfo::classifyReturnType(QualType RetTy) const {
     Size = llvm::bit_ceil(Size);
     return ABIArgInfo::getDirect(llvm::Type::getIntNTy(getVMContext(), Size));
   }
-  return getNaturalAlignIndirect(RetTy, getDataLayout().getAllocaAddrSpace(),
-                                 /*ByVal=*/true);
+  return getNaturalIndirect(RetTy, /*ByVal=*/true);
 }
 
 Address HexagonABIInfo::EmitVAArgFromMemory(CodeGenFunction &CGF,

--- a/clang/lib/CodeGen/Targets/Lanai.cpp
+++ b/clang/lib/CodeGen/Targets/Lanai.cpp
@@ -89,11 +89,10 @@ ABIArgInfo LanaiABIInfo::classifyArgumentType(QualType Ty,
   const RecordType *RT = Ty->getAsCanonical<RecordType>();
   if (RT) {
     CGCXXABI::RecordArgABI RAA = getRecordArgABI(RT, getCXXABI());
-    if (RAA == CGCXXABI::RAA_Indirect) {
+    if (RAA == CGCXXABI::RAA_Indirect)
       return getIndirectResult(Ty, /*ByVal=*/false, State);
-    } else if (RAA == CGCXXABI::RAA_DirectInMemory) {
+    if (RAA == CGCXXABI::RAA_DirectInMemory)
       return getNaturalIndirect(Ty, /*ByVal=*/true);
-    }
   }
 
   if (isAggregateTypeForABI(Ty)) {

--- a/clang/lib/CodeGen/Targets/Lanai.cpp
+++ b/clang/lib/CodeGen/Targets/Lanai.cpp
@@ -72,16 +72,14 @@ ABIArgInfo LanaiABIInfo::getIndirectResult(QualType Ty, bool ByVal,
       --State.FreeRegs; // Non-byval indirects just use one pointer.
       return getNaturalAlignIndirectInReg(Ty);
     }
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   false);
+    return getNaturalIndirect(Ty, false);
   }
 
   // Compute the byval alignment.
-  const unsigned MinABIStackAlignInBytes = 4;
-  unsigned TypeAlign = getContext().getTypeAlign(Ty) / 8;
+  const CharUnits MinABIStackAlignInBytes = CharUnits::fromQuantity(4);
+  CharUnits TypeAlign = getContext().getTypeAlignInChars(Ty);
   return ABIArgInfo::getIndirect(
-      CharUnits::fromQuantity(4),
-      /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(), /*ByVal=*/true,
+      CharUnits::fromQuantity(4), getNaturalAddrSpace(Ty), /*ByVal=*/true,
       /*Realign=*/TypeAlign > MinABIStackAlignInBytes);
 }
 
@@ -94,9 +92,7 @@ ABIArgInfo LanaiABIInfo::classifyArgumentType(QualType Ty,
     if (RAA == CGCXXABI::RAA_Indirect) {
       return getIndirectResult(Ty, /*ByVal=*/false, State);
     } else if (RAA == CGCXXABI::RAA_DirectInMemory) {
-      return getNaturalAlignIndirect(
-          Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-          /*ByVal=*/true);
+      return getNaturalIndirect(Ty, /*ByVal=*/true);
     }
   }
 

--- a/clang/lib/CodeGen/Targets/LoongArch.cpp
+++ b/clang/lib/CodeGen/Targets/LoongArch.cpp
@@ -303,9 +303,8 @@ ABIArgInfo LoongArchABIInfo::classifyArgumentType(QualType Ty, bool IsFixed,
   if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI())) {
     if (GARsLeft)
       GARsLeft -= 1;
-    return getNaturalAlignIndirect(
-        Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-        /*ByVal=*/RAA == CGCXXABI::RAA_DirectInMemory);
+    return getNaturalIndirect(Ty,
+                              /*ByVal=*/RAA == CGCXXABI::RAA_DirectInMemory);
   }
 
   uint64_t Size = getContext().getTypeSize(Ty);
@@ -380,9 +379,7 @@ ABIArgInfo LoongArchABIInfo::classifyArgumentType(QualType Ty, bool IsFixed,
       if (EIT->getNumBits() > 128 ||
           (!getContext().getTargetInfo().hasInt128Type() &&
            EIT->getNumBits() > 64))
-        return getNaturalAlignIndirect(
-            Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-            /*ByVal=*/false);
+        return getNaturalIndirect(Ty, /*ByVal=*/false);
     }
 
     return ABIArgInfo::getDirect();
@@ -405,9 +402,7 @@ ABIArgInfo LoongArchABIInfo::classifyArgumentType(QualType Ty, bool IsFixed,
     return ABIArgInfo::getDirect(
         llvm::ArrayType::get(llvm::IntegerType::get(getVMContext(), GRLen), 2));
   }
-  return getNaturalAlignIndirect(
-      Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-      /*ByVal=*/false);
+  return getNaturalIndirect(Ty, /*ByVal=*/false);
 }
 
 ABIArgInfo LoongArchABIInfo::classifyReturnType(QualType RetTy) const {

--- a/clang/lib/CodeGen/Targets/Mips.cpp
+++ b/clang/lib/CodeGen/Targets/Mips.cpp
@@ -226,8 +226,7 @@ MipsABIInfo::classifyArgumentType(QualType Ty, uint64_t &Offset) const {
 
     if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI())) {
       Offset = OrigOffset + MinABIStackAlignInBytes;
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     RAA == CGCXXABI::RAA_DirectInMemory);
+      return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
     }
 
     // If we have reached here, aggregates are passed directly by coercing to
@@ -249,7 +248,7 @@ MipsABIInfo::classifyArgumentType(QualType Ty, uint64_t &Offset) const {
     if (EIT->getNumBits() > 128 ||
         (EIT->getNumBits() > 64 &&
          !getContext().getTargetInfo().hasInt128Type()))
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace());
+      return getNaturalIndirect(Ty);
 
   // All integral types are promoted to the GPR width.
   if (Ty->isIntegralOrEnumerationType())
@@ -328,7 +327,7 @@ ABIArgInfo MipsABIInfo::classifyReturnType(QualType RetTy) const {
       }
     }
 
-    return getNaturalAlignIndirect(RetTy, getDataLayout().getAllocaAddrSpace());
+    return getNaturalIndirect(RetTy);
   }
 
   // Treat an enum type as its underlying type.
@@ -340,8 +339,7 @@ ABIArgInfo MipsABIInfo::classifyReturnType(QualType RetTy) const {
     if (EIT->getNumBits() > 128 ||
         (EIT->getNumBits() > 64 &&
          !getContext().getTargetInfo().hasInt128Type()))
-      return getNaturalAlignIndirect(RetTy,
-                                     getDataLayout().getAllocaAddrSpace());
+      return getNaturalIndirect(RetTy);
 
   if (isPromotableIntegerTypeForABI(RetTy))
     return ABIArgInfo::getExtend(RetTy);

--- a/clang/lib/CodeGen/Targets/NVPTX.cpp
+++ b/clang/lib/CodeGen/Targets/NVPTX.cpp
@@ -197,18 +197,14 @@ ABIArgInfo NVPTXABIInfo::classifyArgumentType(QualType Ty) const {
         return ABIArgInfo::getDirect(
             CGInfo.getCUDADeviceBuiltinTextureDeviceType());
     }
-    return getNaturalAlignIndirect(
-        Ty, /* AddrSpace */ getDataLayout().getAllocaAddrSpace(),
-        /* byval */ true);
+    return getNaturalIndirect(Ty, /* byval */ true);
   }
 
   if (const auto *EIT = Ty->getAs<BitIntType>()) {
     if ((EIT->getNumBits() > 128) ||
         (!getContext().getTargetInfo().hasInt128Type() &&
          EIT->getNumBits() > 64))
-      return getNaturalAlignIndirect(
-          Ty, /* AddrSpace */ getDataLayout().getAllocaAddrSpace(),
-          /* byval */ true);
+      return getNaturalIndirect(Ty, /* byval */ true);
   }
 
   return (isPromotableIntegerTypeForABI(Ty) ? ABIArgInfo::getExtend(Ty)

--- a/clang/lib/CodeGen/Targets/NVPTX.cpp
+++ b/clang/lib/CodeGen/Targets/NVPTX.cpp
@@ -197,14 +197,14 @@ ABIArgInfo NVPTXABIInfo::classifyArgumentType(QualType Ty) const {
         return ABIArgInfo::getDirect(
             CGInfo.getCUDADeviceBuiltinTextureDeviceType());
     }
-    return getNaturalIndirect(Ty, /* byval */ true);
+    return getNaturalIndirect(Ty, /*byval=*/true);
   }
 
   if (const auto *EIT = Ty->getAs<BitIntType>()) {
     if ((EIT->getNumBits() > 128) ||
         (!getContext().getTargetInfo().hasInt128Type() &&
          EIT->getNumBits() > 64))
-      return getNaturalIndirect(Ty, /* byval */ true);
+      return getNaturalIndirect(Ty, /*byval=*/true);
   }
 
   return (isPromotableIntegerTypeForABI(Ty) ? ABIArgInfo::getExtend(Ty)

--- a/clang/lib/CodeGen/Targets/PPC.cpp
+++ b/clang/lib/CodeGen/Targets/PPC.cpp
@@ -219,7 +219,7 @@ ABIArgInfo AIXABIInfo::classifyReturnType(QualType RetTy) const {
     return ABIArgInfo::getIgnore();
 
   if (isAggregateTypeForABI(RetTy))
-    return getNaturalAlignIndirect(RetTy, getDataLayout().getAllocaAddrSpace());
+    return getNaturalIndirect(RetTy);
 
   return (isPromotableTypeForABI(RetTy) ? ABIArgInfo::getExtend(RetTy)
                                         : ABIArgInfo::getDirect());
@@ -238,16 +238,14 @@ ABIArgInfo AIXABIInfo::classifyArgumentType(QualType Ty) const {
     // Records with non-trivial destructors/copy-constructors should not be
     // passed by value.
     if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI()))
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     RAA == CGCXXABI::RAA_DirectInMemory);
+      return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
 
     CharUnits CCAlign = getParamTypeAlignment(Ty);
     CharUnits TyAlign = getContext().getTypeAlignInChars(Ty);
 
-    return ABIArgInfo::getIndirect(
-        CCAlign, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-        /*ByVal=*/true,
-        /*Realign=*/TyAlign > CCAlign);
+    return ABIArgInfo::getIndirect(CCAlign, getNaturalAddrSpace(Ty),
+                                   /*ByVal=*/true,
+                                   /*Realign=*/TyAlign > CCAlign);
   }
 
   return (isPromotableTypeForABI(Ty)
@@ -865,8 +863,7 @@ PPC64_SVR4_ABIInfo::classifyArgumentType(QualType Ty) const {
   if (Ty->isVectorType()) {
     uint64_t Size = getContext().getTypeSize(Ty);
     if (Size > 128)
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     /*ByVal=*/false);
+      return getNaturalIndirect(Ty, /*ByVal=*/false);
     else if (Size < 128) {
       llvm::Type *CoerceTy = llvm::IntegerType::get(getVMContext(), Size);
       return ABIArgInfo::getDirect(CoerceTy);
@@ -875,13 +872,11 @@ PPC64_SVR4_ABIInfo::classifyArgumentType(QualType Ty) const {
 
   if (const auto *EIT = Ty->getAs<BitIntType>())
     if (EIT->getNumBits() > 128)
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     /*ByVal=*/true);
+      return getNaturalIndirect(Ty, /*ByVal=*/true);
 
   if (isAggregateTypeForABI(Ty)) {
     if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI()))
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     RAA == CGCXXABI::RAA_DirectInMemory);
+      return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
 
     uint64_t ABIAlign = getParamTypeAlignment(Ty).getQuantity();
     uint64_t TyAlign = getContext().getTypeAlignInChars(Ty).getQuantity();
@@ -923,8 +918,7 @@ PPC64_SVR4_ABIInfo::classifyArgumentType(QualType Ty) const {
 
     // All other aggregates are passed ByVal.
     return ABIArgInfo::getIndirect(
-        CharUnits::fromQuantity(ABIAlign),
-        /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
+        CharUnits::fromQuantity(ABIAlign), getNaturalAddrSpace(Ty),
         /*ByVal=*/true, /*Realign=*/TyAlign > ABIAlign);
   }
 
@@ -946,8 +940,7 @@ PPC64_SVR4_ABIInfo::classifyReturnType(QualType RetTy) const {
   if (RetTy->isVectorType()) {
     uint64_t Size = getContext().getTypeSize(RetTy);
     if (Size > 128)
-      return getNaturalAlignIndirect(RetTy,
-                                     getDataLayout().getAllocaAddrSpace());
+      return getNaturalIndirect(RetTy);
     else if (Size < 128) {
       llvm::Type *CoerceTy = llvm::IntegerType::get(getVMContext(), Size);
       return ABIArgInfo::getDirect(CoerceTy);
@@ -956,8 +949,7 @@ PPC64_SVR4_ABIInfo::classifyReturnType(QualType RetTy) const {
 
   if (const auto *EIT = RetTy->getAs<BitIntType>())
     if (EIT->getNumBits() > 128)
-      return getNaturalAlignIndirect(
-          RetTy, getDataLayout().getAllocaAddrSpace(), /*ByVal=*/false);
+      return getNaturalIndirect(RetTy, /*ByVal=*/false);
 
   if (isAggregateTypeForABI(RetTy)) {
     // ELFv2 homogeneous aggregates are returned as array types.
@@ -987,7 +979,7 @@ PPC64_SVR4_ABIInfo::classifyReturnType(QualType RetTy) const {
     }
 
     // All other aggregates are returned indirectly.
-    return getNaturalAlignIndirect(RetTy, getDataLayout().getAllocaAddrSpace());
+    return getNaturalIndirect(RetTy);
   }
 
   return (isPromotableTypeForABI(RetTy) ? ABIArgInfo::getExtend(RetTy)

--- a/clang/lib/CodeGen/Targets/RISCV.cpp
+++ b/clang/lib/CodeGen/Targets/RISCV.cpp
@@ -566,9 +566,7 @@ ABIArgInfo RISCVABIInfo::coerceVLSVector(QualType Ty, unsigned ABIVLen) const {
   } else {
     // Check registers needed <= 8.
     if ((EltType->getScalarSizeInBits() * NumElts / ABIVLen) > 8)
-      return getNaturalAlignIndirect(
-          Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-          /*ByVal=*/false);
+      return getNaturalIndirect(Ty, /*ByVal=*/false);
 
     // Generic vector
     // The number of elements needs to be at least 1.
@@ -609,9 +607,8 @@ ABIArgInfo RISCVABIInfo::classifyArgumentType(QualType Ty, bool IsFixed,
   if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI())) {
     if (ArgGPRsLeft)
       ArgGPRsLeft -= 1;
-    return getNaturalAlignIndirect(
-        Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-        /*ByVal=*/RAA == CGCXXABI::RAA_DirectInMemory);
+    return getNaturalIndirect(Ty,
+                              /*ByVal=*/RAA == CGCXXABI::RAA_DirectInMemory);
   }
 
   uint64_t Size = getContext().getTypeSize(Ty);
@@ -694,9 +691,7 @@ ABIArgInfo RISCVABIInfo::classifyArgumentType(QualType Ty, bool IsFixed,
 
       if (EIT->getNumBits() <= 2 * XLen)
         return ABIArgInfo::getExtend(Ty, CGT.ConvertType(Ty));
-      return getNaturalAlignIndirect(
-          Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-          /*ByVal=*/false);
+      return getNaturalIndirect(Ty, /*ByVal=*/false);
     }
 
     // All integral types are promoted to XLen width
@@ -741,9 +736,7 @@ ABIArgInfo RISCVABIInfo::classifyArgumentType(QualType Ty, bool IsFixed,
     return ABIArgInfo::getDirect(
         llvm::ArrayType::get(llvm::IntegerType::get(getVMContext(), XLen), 2));
   }
-  return getNaturalAlignIndirect(
-      Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-      /*ByVal=*/false);
+  return getNaturalIndirect(Ty, /*ByVal=*/false);
 }
 
 ABIArgInfo RISCVABIInfo::classifyReturnType(QualType RetTy,

--- a/clang/lib/CodeGen/Targets/SPIR.cpp
+++ b/clang/lib/CodeGen/Targets/SPIR.cpp
@@ -140,8 +140,6 @@ public:
     return getABIInfo().getTarget().getTriple().getVendor() !=
            llvm::Triple::AMD;
   }
-
-  LangAS getSRetAddrSpace(const CXXRecordDecl *RD) const override;
 };
 } // End anonymous namespace.
 
@@ -171,10 +169,10 @@ ABIArgInfo SPIRVABIInfo::classifyKernelArgumentType(QualType Ty) const {
     // copied to be valid on the device.
     // This behavior follows the CUDA spec
     // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#global-function-argument-processing,
-    // and matches the NVPTX implementation. TODO: hardcoding to 0 should be
+    // and matches the NVPTX implementation. TODO: AddrSpace should be
     // revisited if HIPSPV / byval starts making use of the AS of an indirect
     // arg.
-    return getNaturalAlignIndirect(Ty, /*AddrSpace=*/0, /*byval=*/true);
+    return getNaturalIndirect(Ty, /*byval=*/true);
   }
   return classifyArgumentType(Ty);
 }
@@ -340,8 +338,7 @@ ABIArgInfo AMDGCNSPIRVABIInfo::classifyArgumentType(QualType Ty) const {
   // Records with non-trivial destructors/copy-constructors should not be
   // passed by value.
   if (auto RAA = getRecordArgABI(Ty, getCXXABI()))
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   RAA == CGCXXABI::RAA_DirectInMemory);
+    return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
 
   // Ignore empty structs/unions.
   if (isEmptyRecord(getContext(), Ty, true))
@@ -441,15 +438,6 @@ void computeSPIRKernelABIInfo(CodeGenModule &CGM, CGFunctionInfo &FI) {
 
 unsigned CommonSPIRTargetCodeGenInfo::getDeviceKernelCallingConv() const {
   return llvm::CallingConv::SPIR_KERNEL;
-}
-
-LangAS SPIRVTargetCodeGenInfo::getSRetAddrSpace(const CXXRecordDecl *RD) const {
-  // Types with no viable copy/move must be constructed in-place, use the
-  // default AS so the sret pointer matches the "this" convention.
-  if (RD && !RD->canPassInRegisters())
-    return LangAS::Default;
-  return getLangASFromTargetAS(
-      getABIInfo().getDataLayout().getAllocaAddrSpace());
 }
 
 void SPIRVTargetCodeGenInfo::setCUDAKernelCallingConvention(

--- a/clang/lib/CodeGen/Targets/Sparc.cpp
+++ b/clang/lib/CodeGen/Targets/Sparc.cpp
@@ -44,8 +44,7 @@ ABIArgInfo SparcV8ABIInfo::classifyReturnType(QualType Ty) const {
                         : ABIArgInfo::getDirect();
 
   if (IsLongDouble)
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   /*ByVal=*/false);
+    return getNaturalIndirect(Ty, /*ByVal=*/false);
 
   return DefaultABIInfo::classifyReturnType(Ty);
 }
@@ -53,7 +52,7 @@ ABIArgInfo SparcV8ABIInfo::classifyReturnType(QualType Ty) const {
 ABIArgInfo SparcV8ABIInfo::classifyArgumentType(QualType Ty) const {
   if (const auto *BT = Ty->getAs<BuiltinType>();
       BT && BT->getKind() == BuiltinType::LongDouble)
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace());
+    return getNaturalIndirect(Ty);
 
   return DefaultABIInfo::classifyArgumentType(Ty);
 }
@@ -256,9 +255,7 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
   // pointer / sret pointer.
   if (Size > SizeLimit) {
     RegOffset += 1;
-    return getNaturalAlignIndirect(
-        Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-        /*ByVal=*/false);
+    return getNaturalIndirect(Ty, /*ByVal=*/false);
   }
 
   // Treat an enum type as its underlying type.
@@ -287,8 +284,7 @@ ABIArgInfo SparcV9ABIInfo::classifyType(QualType Ty, unsigned SizeLimit,
   // destructor, it is passed with an explicit indirect pointer / sret pointer.
   if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI())) {
     RegOffset += 1;
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   RAA == CGCXXABI::RAA_DirectInMemory);
+    return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
   }
 
   // This is a small aggregate type that should be passed in registers.

--- a/clang/lib/CodeGen/Targets/SystemZ.cpp
+++ b/clang/lib/CodeGen/Targets/SystemZ.cpp
@@ -764,7 +764,7 @@ ABIArgInfo ZOSXPLinkABIInfo::classifyReturnType(QualType RetTy,
   // For non-C calling convention, indirect by value for structs and complex.
   if ((CallConv != llvm::CallingConv::C) &&
       (isAggregateTypeForABI(RetTy) || RetTy->isAnyComplexType())) {
-    return getNaturalAlignIndirect(RetTy, getDataLayout().getAllocaAddrSpace());
+    return getNaturalIndirect(RetTy);
   }
 
   // Vectors are returned directly.
@@ -800,8 +800,7 @@ ABIArgInfo ZOSXPLinkABIInfo::classifyReturnType(QualType RetTy,
       CoerceTy = llvm::ArrayType::get(CoerceTy, NumElements);
       return ABIArgInfo::getDirectInReg(CoerceTy);
     } else
-      return getNaturalAlignIndirect(RetTy,
-                                     getDataLayout().getAllocaAddrSpace());
+      return getNaturalIndirect(RetTy);
   }
   return (isPromotableIntegerTypeForABI(RetTy)
               ? ABIArgInfo::getExtend(RetTy, CGT.ConvertType(RetTy))
@@ -815,8 +814,7 @@ ABIArgInfo ZOSXPLinkABIInfo::classifyArgumentType(QualType Ty, bool IsNamedArg,
 
   // Handle the generic C++ ABI.
   if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI()))
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   RAA == CGCXXABI::RAA_DirectInMemory);
+    return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
 
   // Integers and enums are extended to full register width.
   if (isPromotableIntegerTypeForABI(Ty))
@@ -824,8 +822,7 @@ ABIArgInfo ZOSXPLinkABIInfo::classifyArgumentType(QualType Ty, bool IsNamedArg,
 
   // For non-C calling conventions, compound types passed by address copy.
   if ((CallConv != llvm::CallingConv::C) && isCompoundType(Ty))
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   /*ByVal=*/false);
+    return getNaturalIndirect(Ty, /*ByVal=*/false);
 
   // Complex types are passed by value as per the XPLINK docs.
   // If place available, their members will be placed in FPRs.
@@ -889,8 +886,7 @@ ABIArgInfo ZOSXPLinkABIInfo::classifyArgumentType(QualType Ty, bool IsNamedArg,
 
   // Non-structure compounds are passed indirectly, i.e. arrays.
   if (isCompoundType(Ty))
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   /*ByVal=*/false);
+    return getNaturalIndirect(Ty, /*ByVal=*/false);
 
   return ABIArgInfo::getDirect();
 }

--- a/clang/lib/CodeGen/Targets/SystemZ.cpp
+++ b/clang/lib/CodeGen/Targets/SystemZ.cpp
@@ -417,7 +417,7 @@ ABIArgInfo SystemZABIInfo::classifyReturnType(QualType RetTy) const {
   if (isVectorArgumentType(RetTy))
     return ABIArgInfo::getDirect();
   if (isCompoundType(RetTy) || getContext().getTypeSize(RetTy) > 64)
-    return getNaturalAlignIndirect(RetTy, getDataLayout().getAllocaAddrSpace());
+    return getNaturalIndirect(RetTy);
   return (isPromotableIntegerTypeForABI(RetTy) ? ABIArgInfo::getExtend(RetTy)
                                                : ABIArgInfo::getDirect());
 }
@@ -428,8 +428,7 @@ ABIArgInfo SystemZABIInfo::classifyArgumentType(QualType Ty) const {
 
   // Handle the generic C++ ABI.
   if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI()))
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   RAA == CGCXXABI::RAA_DirectInMemory);
+    return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
 
   // Integers and enums are extended to full register width.
   if (isPromotableIntegerTypeForABI(Ty))
@@ -446,16 +445,14 @@ ABIArgInfo SystemZABIInfo::classifyArgumentType(QualType Ty) const {
 
   // Values that are not 1, 2, 4 or 8 bytes in size are passed indirectly.
   if (Size != 8 && Size != 16 && Size != 32 && Size != 64)
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   /*ByVal=*/false);
+    return getNaturalIndirect(Ty, /*ByVal=*/false);
 
   // Handle small structures.
   if (const auto *RD = Ty->getAsRecordDecl()) {
     // Structures with flexible arrays have variable length, so really
     // fail the size test above.
     if (RD->hasFlexibleArrayMember())
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     /*ByVal=*/false);
+      return getNaturalIndirect(Ty, /*ByVal=*/false);
 
     // The structure is passed as an unextended integer, a half, a float,
     // or a double.
@@ -471,8 +468,7 @@ ABIArgInfo SystemZABIInfo::classifyArgumentType(QualType Ty) const {
 
   // Non-structure compounds are passed indirectly.
   if (isCompoundType(Ty))
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   /*ByVal=*/false);
+    return getNaturalIndirect(Ty, /*ByVal=*/false);
 
   return ABIArgInfo::getDirect(nullptr);
 }

--- a/clang/lib/CodeGen/Targets/WebAssembly.cpp
+++ b/clang/lib/CodeGen/Targets/WebAssembly.cpp
@@ -103,8 +103,7 @@ ABIArgInfo WebAssemblyABIInfo::classifyArgumentType(QualType Ty) const {
     // Records with non-trivial destructors/copy-constructors should not be
     // passed by value.
     if (auto RAA = getRecordArgABI(Ty, getCXXABI()))
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     RAA == CGCXXABI::RAA_DirectInMemory);
+      return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
     // Ignore empty structs/unions.
     if (isEmptyRecord(getContext(), Ty, true))
       return ABIArgInfo::getIgnore();

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -105,7 +105,8 @@ class X86_32ABIInfo : public ABIInfo {
     Float
   };
 
-  static const unsigned MinABIStackAlignInBytes = 4;
+  static constexpr CharUnits MinABIStackAlignInBytes =
+      CharUnits::fromQuantity(4);
 
   bool IsDarwinVectorABI;
   bool IsRetSmallStructInRegABI;
@@ -139,7 +140,7 @@ class X86_32ABIInfo : public ABIInfo {
   ABIArgInfo getIndirectReturnResult(QualType Ty, CCState &State) const;
 
   /// Return the alignment to use for the given type on the stack.
-  unsigned getTypeStackAlignInBytes(QualType Ty, unsigned Align) const;
+  CharUnits getTypeStackAlignInBytes(QualType Ty, CharUnits Align) const;
 
   Class classify(QualType Ty) const;
   ABIArgInfo classifyReturnType(QualType RetTy, CCState &State) const;
@@ -470,9 +471,7 @@ ABIArgInfo X86_32ABIInfo::getIndirectReturnResult(QualType RetTy, CCState &State
     if (!IsMCUABI)
       return getNaturalAlignIndirectInReg(RetTy);
   }
-  return getNaturalAlignIndirect(
-      RetTy, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-      /*ByVal=*/false);
+  return getNaturalIndirect(RetTy, /*ByVal=*/false);
 }
 
 ABIArgInfo X86_32ABIInfo::classifyReturnType(QualType RetTy,
@@ -571,19 +570,21 @@ ABIArgInfo X86_32ABIInfo::classifyReturnType(QualType RetTy,
                                                : ABIArgInfo::getDirect());
 }
 
-unsigned X86_32ABIInfo::getTypeStackAlignInBytes(QualType Ty,
-                                                 unsigned Align) const {
+CharUnits X86_32ABIInfo::getTypeStackAlignInBytes(QualType Ty,
+                                                  CharUnits Align) const {
   // Otherwise, if the alignment is less than or equal to the minimum ABI
   // alignment, just use the default; the backend will handle this.
   if (Align <= MinABIStackAlignInBytes)
-    return 0; // Use default alignment.
+    return CharUnits::Zero(); // Use default alignment.
 
   if (IsLinuxABI) {
     // Exclude other System V OS (e.g Darwin, PS4 and FreeBSD) since we don't
     // want to spend any effort dealing with the ramifications of ABI breaks.
     //
     // If the vector type is __m128/__m256/__m512, return the default alignment.
-    if (Ty->isVectorType() && (Align == 16 || Align == 32 || Align == 64))
+    if (Ty->isVectorType() &&
+        (Align.getQuantity() == 16 || Align.getQuantity() == 32 ||
+         Align.getQuantity() == 64))
       return Align;
   }
   // On non-Darwin, the stack type alignment is always 4.
@@ -593,9 +594,10 @@ unsigned X86_32ABIInfo::getTypeStackAlignInBytes(QualType Ty,
   }
 
   // Otherwise, if the type contains an SSE vector type, the alignment is 16.
-  if (Align >= 16 && (isSIMDVectorType(getContext(), Ty) ||
-                      isRecordWithSIMDVectorType(getContext(), Ty)))
-    return 16;
+  if (Align >= CharUnits::fromQuantity(16) &&
+      (isSIMDVectorType(getContext(), Ty) ||
+       isRecordWithSIMDVectorType(getContext(), Ty)))
+    return CharUnits::fromQuantity(16);
 
   return MinABIStackAlignInBytes;
 }
@@ -608,26 +610,21 @@ ABIArgInfo X86_32ABIInfo::getIndirectResult(QualType Ty, bool ByVal,
       if (!IsMCUABI)
         return getNaturalAlignIndirectInReg(Ty);
     }
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   false);
+    return getNaturalIndirect(Ty, false);
   }
 
   // Compute the byval alignment.
-  unsigned TypeAlign = getContext().getTypeAlign(Ty) / 8;
-  unsigned StackAlign = getTypeStackAlignInBytes(Ty, TypeAlign);
-  if (StackAlign == 0)
-    return ABIArgInfo::getIndirect(
-        CharUnits::fromQuantity(4),
-        /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-        /*ByVal=*/true);
+  CharUnits TypeAlign = getContext().getTypeAlignInChars(Ty);
+  CharUnits StackAlign = getTypeStackAlignInBytes(Ty, TypeAlign);
+  if (StackAlign.isZero())
+    return ABIArgInfo::getIndirect(CharUnits::fromQuantity(4),
+                                   getNaturalAddrSpace(Ty), /*ByVal=*/true);
 
   // If the stack alignment is less than the type alignment, realign the
   // argument.
   bool Realign = TypeAlign > StackAlign;
-  return ABIArgInfo::getIndirect(
-      CharUnits::fromQuantity(StackAlign),
-      /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(), /*ByVal=*/true,
-      Realign);
+  return ABIArgInfo::getIndirect(StackAlign, getNaturalAddrSpace(Ty),
+                                 /*ByVal=*/true, Realign);
 }
 
 X86_32ABIInfo::Class X86_32ABIInfo::classify(QualType Ty) const {
@@ -1088,8 +1085,7 @@ RValue X86_32ABIInfo::EmitVAArg(CodeGenFunction &CGF, Address VAListAddr,
   //
   // Just messing with TypeInfo like this works because we never pass
   // anything indirectly.
-  TypeInfo.Align = CharUnits::fromQuantity(
-                getTypeStackAlignInBytes(Ty, TypeInfo.Align.getQuantity()));
+  TypeInfo.Align = getTypeStackAlignInBytes(Ty, TypeInfo.Align);
 
   return emitVoidPtrVAArg(CGF, VAListAddr, Ty, /*Indirect*/ false, TypeInfo,
                           CharUnits::fromQuantity(4),
@@ -2188,14 +2184,14 @@ ABIArgInfo X86_64ABIInfo::getIndirectReturnResult(QualType Ty) const {
       Ty = ED->getIntegerType();
 
     if (Ty->isBitIntType())
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace());
+      return getNaturalIndirect(Ty);
 
     llvm::Type *IRTy = CGT.ConvertType(Ty);
     return (isPromotableIntegerTypeForABI(Ty) ? ABIArgInfo::getExtend(Ty, IRTy)
                                               : ABIArgInfo::getDirect(IRTy));
   }
 
-  return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace());
+  return getNaturalIndirect(Ty);
 }
 
 bool X86_64ABIInfo::IsIllegalVectorType(QualType Ty) const {
@@ -2236,12 +2232,12 @@ ABIArgInfo X86_64ABIInfo::getIndirectResult(QualType Ty,
   }
 
   if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI()))
-    return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                   RAA == CGCXXABI::RAA_DirectInMemory);
+    return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
 
   // Compute the byval alignment. We specify the alignment of the byval in all
   // cases so that the mid-level optimizer knows the alignment of the byval.
-  unsigned Align = std::max(getContext().getTypeAlign(Ty) / 8, 8U);
+  CharUnits Align = std::max(getContext().getTypeAlignInChars(Ty),
+                             CharUnits::fromQuantity(8));
 
   // Attempt to avoid passing indirect results using byval when possible. This
   // is important for good codegen.
@@ -2269,13 +2265,12 @@ ABIArgInfo X86_64ABIInfo::getIndirectResult(QualType Ty,
 
     // If this type fits in an eightbyte, coerce it into the matching integral
     // type, which will end up on the stack (with alignment 8).
-    if (Align == 8 && Size <= 64)
+    if (Align.getQuantity() == 8 && Size <= 64)
       return ABIArgInfo::getDirect(llvm::IntegerType::get(getVMContext(),
                                                           Size));
   }
 
-  return ABIArgInfo::getIndirect(CharUnits::fromQuantity(Align),
-                                 getDataLayout().getAllocaAddrSpace());
+  return ABIArgInfo::getIndirect(Align, getNaturalAddrSpace(Ty));
 }
 
 /// The ABI specifies that a value should be passed in a full vector XMM/YMM
@@ -3355,13 +3350,11 @@ ABIArgInfo WinX86_64ABIInfo::classify(QualType Ty, unsigned &FreeSSERegs,
   if (RT) {
     if (!IsReturnType) {
       if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(RT, getCXXABI()))
-        return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                       RAA == CGCXXABI::RAA_DirectInMemory);
+        return getNaturalIndirect(Ty, RAA == CGCXXABI::RAA_DirectInMemory);
     }
 
     if (RT->getDecl()->getDefinitionOrSelf()->hasFlexibleArrayMember())
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     /*ByVal=*/false);
+      return getNaturalIndirect(Ty, /*ByVal=*/false);
   }
 
   const Type *Base = nullptr;
@@ -3377,9 +3370,8 @@ ABIArgInfo WinX86_64ABIInfo::classify(QualType Ty, unsigned &FreeSSERegs,
           return ABIArgInfo::getDirect();
         return ABIArgInfo::getExpand();
       }
-      return ABIArgInfo::getIndirect(
-          Align, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-          /*ByVal=*/false);
+      return ABIArgInfo::getIndirect(Align, getNaturalAddrSpace(Ty),
+                                     /*ByVal=*/false);
     } else if (IsVectorCall) {
       if (FreeSSERegs >= NumElts &&
           (IsReturnType || Ty->isBuiltinType() || Ty->isVectorType())) {
@@ -3389,9 +3381,8 @@ ABIArgInfo WinX86_64ABIInfo::classify(QualType Ty, unsigned &FreeSSERegs,
         return ABIArgInfo::getExpand();
       } else if (!Ty->isBuiltinType() && !Ty->isVectorType()) {
         // HVAs are delayed and reclassified in the 2nd step.
-        return ABIArgInfo::getIndirect(
-            Align, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-            /*ByVal=*/false);
+        return ABIArgInfo::getIndirect(Align, getNaturalAddrSpace(Ty),
+                                       /*ByVal=*/false);
       }
     }
   }
@@ -3408,8 +3399,7 @@ ABIArgInfo WinX86_64ABIInfo::classify(QualType Ty, unsigned &FreeSSERegs,
     // MS x64 ABI requirement: "Any argument that doesn't fit in 8 bytes, or is
     // not 1, 2, 4, or 8 bytes, must be passed by reference."
     if (Width > 64 || !llvm::isPowerOf2_64(Width))
-      return getNaturalAlignIndirect(Ty, getDataLayout().getAllocaAddrSpace(),
-                                     /*ByVal=*/false);
+      return getNaturalIndirect(Ty, /*ByVal=*/false);
 
     // Otherwise, coerce it to a small integer.
     return ABIArgInfo::getDirect(llvm::IntegerType::get(getVMContext(), Width));
@@ -3428,9 +3418,8 @@ ABIArgInfo WinX86_64ABIInfo::classify(QualType Ty, unsigned &FreeSSERegs,
       if (IsMingw64) {
         const llvm::fltSemantics *LDF = &getTarget().getLongDoubleFormat();
         if (LDF == &llvm::APFloat::x87DoubleExtended())
-          return ABIArgInfo::getIndirect(
-              Align, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-              /*ByVal=*/false);
+          return ABIArgInfo::getIndirect(Align, getNaturalAddrSpace(Ty),
+                                         /*ByVal=*/false);
       }
       break;
 
@@ -3443,9 +3432,8 @@ ABIArgInfo WinX86_64ABIInfo::classify(QualType Ty, unsigned &FreeSSERegs,
       // than 8 bytes are passed indirectly. GCC follows it. We follow it too,
       // even though it isn't particularly efficient.
       if (!IsReturnType)
-        return ABIArgInfo::getIndirect(
-            Align, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-            /*ByVal=*/false);
+        return ABIArgInfo::getIndirect(Align, getNaturalAddrSpace(Ty),
+                                       /*ByVal=*/false);
 
       // Mingw64 GCC returns i128 in XMM0. Coerce to v2i64 to handle that.
       // Clang matches them for compatibility.
@@ -3467,9 +3455,8 @@ ABIArgInfo WinX86_64ABIInfo::classify(QualType Ty, unsigned &FreeSSERegs,
     // the power of 2.
     if (Width <= 64)
       return ABIArgInfo::getDirect();
-    return ABIArgInfo::getIndirect(
-        Align, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
-        /*ByVal=*/false);
+    return ABIArgInfo::getIndirect(Align, getNaturalAddrSpace(Ty),
+                                   /*ByVal=*/false);
   }
 
   return ABIArgInfo::getDirect();

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -760,18 +760,18 @@ ABIArgInfo X86_32ABIInfo::classifyArgumentType(QualType Ty, CCState &State,
   const RecordType *RT = Ty->getAsCanonical<RecordType>();
   if (RT) {
     CGCXXABI::RecordArgABI RAA = getRecordArgABI(RT, getCXXABI());
-    if (RAA == CGCXXABI::RAA_Indirect) {
+    if (RAA == CGCXXABI::RAA_Indirect)
       return getIndirectResult(Ty, false, State);
-    } else if (State.IsDelegateCall) {
+    if (State.IsDelegateCall) {
       // Avoid having different alignments on delegate call args by always
       // setting the alignment to 4, which is what we do for inallocas.
       ABIArgInfo Res = getIndirectResult(Ty, false, State);
       Res.setIndirectAlign(CharUnits::fromQuantity(4));
       return Res;
-    } else if (RAA == CGCXXABI::RAA_DirectInMemory) {
+    }
+    if (RAA == CGCXXABI::RAA_DirectInMemory)
       // The field index doesn't matter, we'll fix it up later.
       return ABIArgInfo::getInAlloca(/*FieldIndex=*/0);
-    }
   }
 
   // Regcall uses the concept of a homogenous vector aggregate, similar
@@ -3377,13 +3377,13 @@ ABIArgInfo WinX86_64ABIInfo::classify(QualType Ty, unsigned &FreeSSERegs,
           (IsReturnType || Ty->isBuiltinType() || Ty->isVectorType())) {
         FreeSSERegs -= NumElts;
         return ABIArgInfo::getDirect();
-      } else if (IsReturnType) {
+      }
+      if (IsReturnType)
         return ABIArgInfo::getExpand();
-      } else if (!Ty->isBuiltinType() && !Ty->isVectorType()) {
+      if (!Ty->isBuiltinType() && !Ty->isVectorType())
         // HVAs are delayed and reclassified in the 2nd step.
         return ABIArgInfo::getIndirect(Align, getNaturalAddrSpace(Ty),
                                        /*ByVal=*/false);
-      }
     }
   }
 

--- a/clang/test/CodeGen/aggregate-assign-call.c
+++ b/clang/test/CodeGen/aggregate-assign-call.c
@@ -60,9 +60,6 @@ struct S baz(int i, volatile int *j) {
 
   do {
     // O1: call void @llvm.lifetime.start.p0(ptr %[[TMP1_ALLOCA]])
-    //
-    // O1: call void @llvm.lifetime.end.p0(ptr %[[TMP1_ALLOCA]])
-    //
     // O1: call void @foo_int(ptr dead_on_unwind writable sret(%struct.S) align 4 %[[TMP1_ALLOCA]],
     // O1: call void @llvm.memcpy
     // O1: call void @llvm.lifetime.end.p0(ptr %[[TMP1_ALLOCA]])


### PR DESCRIPTION
This makes 3 related changes:
  - DRY the getAllocaAddrSpace calls in ABIArgInfo
  - Respect the pointer address space, if given, when making an indirect argument, instead of forcing it into an alloca
  - Simplify the CanCopy predicate to use the same decision logic as ItaniumCXXABI

The goal here is to better respect Sema choices, since there are times where Sema specifies an address space, and copying the value or making an alloca in a different space won't be legal. It isn't expected to change results on any current target, but the goal is to make the current logic more consistent.

~~Previously, it put this in the target-requested AS only if the parameter
ABI was indirect and otherwise in the generic AS. That led to needless
memcpy calls and other IR noise.~~

~~Disable this change on OpenMP, since there the frontend extracts locals
into offload functions, but currently neglects to remove the addrspace
type qualifier. Disable this change for OpenCL, since it changes some
error printing and dispatch: notably though since an array itself cannot
be marked with addrspace in Sema currently (only CVR are supported to be
marked on an array pointer after semantic decay).~~

Remove virtual getASTAllocaAddressSpace, since all consumers now get
their info from Sema or DataLayout directly.

(My eventual goal with this is to support WebAssembly Sema to properly mark that `__externref` pointers are in `wasm_ref` address space, similar to OpenCL inferring `__private` for many of its arguments.)

Similar to https://github.com/llvm/llvm-project/pull/179327

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>