### PR TITLE
[Metal][HLSL] Add support for dumping reflection

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -835,6 +835,8 @@ def err_drv_dxc_invalid_matrix_layout : Error<
   "cannot specify /Zpr and /Zpc together">;
 def err_drv_dxc_missing_target_profile : Error<
   "target profile option (-T) is missing">;
+def err_drv_dxc_Fre_requires_Fo_metal
+    : Error<"-Fre option requires -Fo option when targeting Metal">;
 def err_drv_hlsl_unsupported_target : Error<
   "HLSL code generation is unsupported for target '%0'">;
 def err_drv_hlsl_bad_shader_required_in_target : Error<

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9726,6 +9726,8 @@ def dxc_no_stdinc : DXCFlag<"hlsl-no-stdinc">,
   HelpText<"HLSL only. Disables all standard includes containing non-native compiler types and functions.">;
 def dxc_Fo : DXCJoinedOrSeparate<"Fo">,
   HelpText<"Output object file">;
+def dxc_Fre : DXCJoinedOrSeparate<"Fre">,
+              HelpText<"Set output file name for reflection files">;
 def dxc_Fc : DXCJoinedOrSeparate<"Fc">,
   HelpText<"Output assembly listing file">;
 def dxc_Frs : DXCJoinedOrSeparate<"Frs">,

--- a/clang/test/Driver/HLSL/fre-errors.hlsl
+++ b/clang/test/Driver/HLSL/fre-errors.hlsl
@@ -1,0 +1,8 @@
+// These are placeholder errors since we do not currently support -Fre to
+// generate reflection data for DXIL or SPIRV targets.
+
+// RUN: env PATH="" not %clang_dxc -T cs_6_0 %s -Fre blah.json -Vd -### 2>&1 | FileCheck --check-prefix=FRE_DXIL %s
+// FRE_DXIL: error: unsupported option '-Fre' for target 'dxilv1.0'
+
+// RUN: env PATH="" not %clang_dxc -T cs_6_0 %s -spirv -Fre blah.json -Vd -### 2>&1 | FileCheck --check-prefix=FRE_SPV %s
+// FRE_SPV: error: unsupported option '-Fre' for target 'spirv1.6'

--- a/clang/test/Driver/HLSL/metal-converter.hlsl
+++ b/clang/test/Driver/HLSL/metal-converter.hlsl
@@ -6,6 +6,14 @@
 // RUN: env PATH="" %clang_dxc -T cs_6_0 %s --dxv-path=%t.dir -metal -Vd -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=NO_DXV %s
 // NO_DXV: "{{.*}}metal-shaderconverter{{(.exe)?}}" "{{.*}}.obj" "-o" "{{.*}}.mtl"
 
+// RUN: env PATH="" %clang_dxc -T cs_6_0 %s -metal -Fre blah.json -Vd -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=FRE %s
+// FRE: "{{.*}}metal-shaderconverter{{(.exe)?}}" "{{.*}}.obj" "-o" "{{.*}}.mtl" "--output-reflection-file=blah.json"
+
+// RUN: env PATH="" not %clang_dxc -T cs_6_0 %s -metal -Fre blah.json -Vd -### 2>&1 | FileCheck --check-prefix=FRE_ERR %s
+// FRE_ERR: error: -Fre option requires -Fo option when targeting Metal
+
+// Does not generate the metal IR when the output file is not specified since we
+// cannot disassemble the metal IR reliably.
 // RUN: %clang_dxc -T cs_6_0 %s -metal -### 2>&1 | FileCheck --check-prefix=NO_MTL %s
 // NO_MTL-NOT: metal-shaderconverter
 


### PR DESCRIPTION
The Metal Shader converter can output shader reflection information into a JSON file. This connects the -Fre flag (DXC's flag for reflection) to the Metal Shader Converter tool step to produce the JSON file. As a temporary state the -Fre flag will error when used without the -metal flag.

This is required to address https://github.com/llvm/offload-test-suite/issues/452