### PR TITLE
[OFFLOAD] Allow partial linkage when using spirv linker

### DIFF
--- a/clang/lib/Driver/ToolChains/SPIRV.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRV.cpp
@@ -149,6 +149,7 @@ void SPIRV::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   ArgStringList CmdArgs;
   AddLinkerInputs(getToolChain(), Inputs, Args, CmdArgs, JA);
 
+  CmdArgs.push_back("--allow-partial-linkage");
   CmdArgs.push_back("-o");
   CmdArgs.push_back(Output.getFilename());
 

--- a/clang/test/Driver/spirv-toolchain.cl
+++ b/clang/test/Driver/spirv-toolchain.cl
@@ -64,7 +64,7 @@
 // SPLINK-SAME: "-o" [[SPV1:".*o"]]
 // SPLINK: "-cc1" "-triple" "spirv64"
 // SPLINK-SAME: "-o" [[SPV2:".*o"]]
-// SPLINK: {{spirv-link.*"}} [[SPV1]] [[SPV2]] "-o" "a.out"
+// SPLINK: {{spirv-link.*"}} [[SPV1]] [[SPV2]] "--allow-partial-linkage" "-o" "a.out"
 
 //-----------------------------------------------------------------------------
 // Check bindings when linking when multiple input files are passed.

--- a/clang/test/Driver/sycl-link-spirv-target.cpp
+++ b/clang/test/Driver/sycl-link-spirv-target.cpp
@@ -8,4 +8,4 @@
 // RUN: %clangxx -### --target=spirv64 --sycl-link -Xlinker -triple=spirv64 -Xlinker --library-path=/tmp \
 // RUN:   -Xlinker --device-libs=lib1.bc,lib2.bc %t.bc 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=XLINKEROPTS
-// XLINKEROPTS: "{{.*}}clang-sycl-linker{{.*}}" "-triple=spirv64" "--library-path=/tmp" "--device-libs=lib1.bc,lib2.bc" "{{.*}}.bc" "-o" "a.out"
+// XLINKEROPTS: "{{.*}}clang-sycl-linker{{.*}}" "-triple=spirv64" "--library-path=/tmp" "--device-libs=lib1.bc,lib2.bc" "{{.*}}.bc" "--allow-partial-linkage" "-o" "a.out"


### PR DESCRIPTION
The purpose of this change is to fix an issue occurring when spirv linker is used to build offload kernels. For these kernels i is common that some of function implementations are provided by GPU driver and not contained in the kernel itself, causing linker to fail. This change will let the linker compile the kernels when some of the functions implemented by the GPU driver