### PR TITLE
[LTO] Refactor LTO link optimization remarks handling (NFC)

### DIFF
--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -427,6 +427,21 @@ public:
     LTOK_UnifiedThin,
   };
 
+  /// RAII guard for optimization remarks and LTO-link diagnostics.
+  struct DiagnosticSession {
+    /// The LTO object that owns the diagnostic resources.
+    LTO &Parent;
+
+    DiagnosticSession(LTO &L) : Parent(L) {}
+
+    /// Factory method to initialize a diagnostic session. This sets up the
+    /// remark streamer.
+    static Expected<std::unique_ptr<DiagnosticSession>> create(LTO &L);
+
+    /// Finalizes optimization remarks.
+    ~DiagnosticSession();
+  };
+
   /// Create an LTO object. A default constructed LTO object has a reasonable
   /// production configuration, but you can customize it by passing arguments to
   /// this constructor.
@@ -643,6 +658,10 @@ private:
   LLVMRemarkFileHandle DiagnosticOutputFile;
 
 public:
+  /// Helper to emit an optimization remark during the LTO link when outside of
+  /// the standard optimization pass pipeline.
+  void emitRemark(OptimizationRemark &Remark);
+
   virtual Expected<std::shared_ptr<lto::InputFile>>
   addInput(std::unique_ptr<lto::InputFile> InputPtr) {
     return std::shared_ptr<lto::InputFile>(InputPtr.release());

--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -427,21 +427,6 @@ public:
     LTOK_UnifiedThin,
   };
 
-  /// RAII guard for optimization remarks and LTO-link diagnostics.
-  struct DiagnosticSession {
-    /// The LTO object that owns the diagnostic resources.
-    LTO &Parent;
-
-    DiagnosticSession(LTO &L) : Parent(L) {}
-
-    /// Factory method to initialize a diagnostic session. This sets up the
-    /// remark streamer.
-    static Expected<std::unique_ptr<DiagnosticSession>> create(LTO &L);
-
-    /// Finalizes optimization remarks.
-    ~DiagnosticSession();
-  };
-
   /// Create an LTO object. A default constructed LTO object has a reasonable
   /// production configuration, but you can customize it by passing arguments to
   /// this constructor.
@@ -483,7 +468,7 @@ protected:
   virtual Error serializeInputsForDistribution() { return Error::success(); }
 
   // Called before returning from run().
-  virtual void cleanup() {}
+  virtual void cleanup();
 
 private:
   Config Conf;
@@ -656,6 +641,9 @@ private:
 
   // Diagnostic optimization remarks file
   LLVMRemarkFileHandle DiagnosticOutputFile;
+
+  // Setup optimization remarks according to the provided configuration.
+  Error setupOptimizationRemarks();
 
 public:
   /// Helper to emit an optimization remark during the LTO link when outside of

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -81,12 +81,10 @@ Error LTO::setupOptimizationRemarks() {
     return DiagFileOrErr.takeError();
 
   DiagnosticOutputFile = std::move(*DiagFileOrErr);
-
   return Error::success();
 }
 
 void LTO::emitRemark(OptimizationRemark &Remark) {
-
   const Function &F = Remark.getFunction();
   OptimizationRemarkEmitter ORE(const_cast<Function *>(&F));
   ORE.emit(Remark);


### PR DESCRIPTION
Centralize the setup and finalization of optimization remarks for LTO link actions
outside of the pass pipeline. This ensures that remarks are correctly captured across
all exit paths from the LTO pipeline. 

The motivation for this refactoring is to provide a cleaner and more robust
interface for managing diagnostics, and to enable easier remark emission during
the thin link phase in a follow-on PR.

Key changes:
- Added a setupOptimizationRemarks on the LTO class. Call it from LTO::run
  and remove the existing setup from runRegularLTO.
- Added a unified diagnostic API to the LTO class (emitRemark) and use that
  in linkRegularLTO.
- Centralize the finalizeOptimizationRemarks call in LTO::cleanup, which is already
  invoked by LTO::run's scope_exit handler.
