### PR TITLE
[flang] Let FIR AA:getModRef recognize Fortran user procedures late.

### DIFF
--- a/flang/include/flang/Optimizer/Analysis/AliasAnalysis.h
+++ b/flang/include/flang/Optimizer/Analysis/AliasAnalysis.h
@@ -248,6 +248,15 @@ private:
   bool symbolMayHaveTargetAttr(mlir::SymbolRefAttr symbol,
                                mlir::Operation *from);
 
+  /// Return true if the given operation is a call to a Fortran user
+  /// procedure.
+  bool isCallToFortranUserProcedure(mlir::Operation *op);
+
+  /// Returns the modify-reference behavior of the given call
+  /// operation `op` on `var`. If `op` is not a fir.call, then
+  /// it returns the conservative ModAndRef result.
+  mlir::ModRefResult getCallModRef(mlir::Operation *op, mlir::Value var);
+
   /// A map between operations with OpTrait::SymbolTable
   /// and the SymbolTable objects associated with them.
   /// TODO: it might be better to initialize just a single SymbolTable

--- a/flang/test/Analysis/AliasAnalysis/modref-call-after-external-name-conversion.fir
+++ b/flang/test/Analysis/AliasAnalysis/modref-call-after-external-name-conversion.fir
@@ -1,0 +1,16 @@
+// RUN:  fir-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
+// RUN:  --mlir-disable-threading %s -o /dev/null 2>&1 | FileCheck %s
+
+// Test that fir.call modref can recognize Fortran user procedures
+// after ExternalNameConversion pass.
+
+// CHECK-LABEL: Testing : "test_modref_"
+// CHECK: callee_procedure -> xx#0: NoModRef
+func.func @test_modref_() {
+  %0 = fir.dummy_scope : !fir.dscope
+  %1 = fir.alloca f32 {bindc_name = "xx", uniq_name = "_QFtest_modrefExx"}
+  %2 = fir.declare %1 {test.ptr = "xx", uniq_name = "_QFtest_modrefExx"} : (!fir.ref<f32>) -> !fir.ref<f32>
+  fir.call @callee_() {test.ptr = "callee_procedure"} : () -> ()
+  return
+}
+func.func private @callee_() attributes {fir.internal_name = "_QPcallee"}


### PR DESCRIPTION
In order to use FIR AA::getModRef() after `ExternalNameConversion`
pass we have to teach it to recognize Fortran user procedures
that have already been renamed.
