### PR TITLE
[RISCV] Calculate max call frame size in RISCVTargetLowering::finalizeLowering.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -26161,6 +26161,11 @@ bool RISCVTargetLowering::isIntDivCheap(EVT VT, AttributeList Attr) const {
          VT.getSizeInBits() <= getMaxDivRemBitWidthSupported();
 }
 
+void RISCVTargetLowering::finalizeLowering(MachineFunction &MF) const {
+  MF.getFrameInfo().computeMaxCallFrameSize(MF);
+  TargetLoweringBase::finalizeLowering(MF);
+}
+
 bool RISCVTargetLowering::preferScalarizeSplat(SDNode *N) const {
   // Scalarize zero_ext and sign_ext might stop match to widening instruction in
   // some situation.

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.h
@@ -71,6 +71,8 @@ public:
 
   bool preferScalarizeSplat(SDNode *N) const override;
 
+  void finalizeLowering(MachineFunction &MF) const override;
+
   /// Customize the preferred legalization strategy for certain types.
   LegalizeTypeAction getPreferredVectorAction(MVT VT) const override;
 

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-extract.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-extract.ll
@@ -883,16 +883,16 @@ define i32 @extractelt_v32i32_idx(ptr %x, i32 zeroext %idx) nounwind {
 ; RV32NOM-NEXT:    addi sp, sp, -256
 ; RV32NOM-NEXT:    sw ra, 252(sp) # 4-byte Folded Spill
 ; RV32NOM-NEXT:    sw s0, 248(sp) # 4-byte Folded Spill
-; RV32NOM-NEXT:    sw s2, 244(sp) # 4-byte Folded Spill
+; RV32NOM-NEXT:    sw s1, 244(sp) # 4-byte Folded Spill
 ; RV32NOM-NEXT:    addi s0, sp, 256
 ; RV32NOM-NEXT:    andi sp, sp, -128
-; RV32NOM-NEXT:    mv s2, a0
+; RV32NOM-NEXT:    mv s1, a0
 ; RV32NOM-NEXT:    andi a0, a1, 31
 ; RV32NOM-NEXT:    li a1, 4
 ; RV32NOM-NEXT:    call __mulsi3
 ; RV32NOM-NEXT:    li a1, 32
 ; RV32NOM-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; RV32NOM-NEXT:    vle32.v v8, (s2)
+; RV32NOM-NEXT:    vle32.v v8, (s1)
 ; RV32NOM-NEXT:    mv a1, sp
 ; RV32NOM-NEXT:    add a0, a1, a0
 ; RV32NOM-NEXT:    vadd.vv v8, v8, v8
@@ -901,7 +901,7 @@ define i32 @extractelt_v32i32_idx(ptr %x, i32 zeroext %idx) nounwind {
 ; RV32NOM-NEXT:    addi sp, s0, -256
 ; RV32NOM-NEXT:    lw ra, 252(sp) # 4-byte Folded Reload
 ; RV32NOM-NEXT:    lw s0, 248(sp) # 4-byte Folded Reload
-; RV32NOM-NEXT:    lw s2, 244(sp) # 4-byte Folded Reload
+; RV32NOM-NEXT:    lw s1, 244(sp) # 4-byte Folded Reload
 ; RV32NOM-NEXT:    addi sp, sp, 256
 ; RV32NOM-NEXT:    ret
 ;
@@ -933,16 +933,16 @@ define i32 @extractelt_v32i32_idx(ptr %x, i32 zeroext %idx) nounwind {
 ; RV64NOM-NEXT:    addi sp, sp, -256
 ; RV64NOM-NEXT:    sd ra, 248(sp) # 8-byte Folded Spill
 ; RV64NOM-NEXT:    sd s0, 240(sp) # 8-byte Folded Spill
-; RV64NOM-NEXT:    sd s2, 232(sp) # 8-byte Folded Spill
+; RV64NOM-NEXT:    sd s1, 232(sp) # 8-byte Folded Spill
 ; RV64NOM-NEXT:    addi s0, sp, 256
 ; RV64NOM-NEXT:    andi sp, sp, -128
-; RV64NOM-NEXT:    mv s2, a0
+; RV64NOM-NEXT:    mv s1, a0
 ; RV64NOM-NEXT:    andi a0, a1, 31
 ; RV64NOM-NEXT:    li a1, 4
 ; RV64NOM-NEXT:    call __muldi3
 ; RV64NOM-NEXT:    li a1, 32
 ; RV64NOM-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; RV64NOM-NEXT:    vle32.v v8, (s2)
+; RV64NOM-NEXT:    vle32.v v8, (s1)
 ; RV64NOM-NEXT:    mv a1, sp
 ; RV64NOM-NEXT:    add a0, a1, a0
 ; RV64NOM-NEXT:    vadd.vv v8, v8, v8
@@ -951,7 +951,7 @@ define i32 @extractelt_v32i32_idx(ptr %x, i32 zeroext %idx) nounwind {
 ; RV64NOM-NEXT:    addi sp, s0, -256
 ; RV64NOM-NEXT:    ld ra, 248(sp) # 8-byte Folded Reload
 ; RV64NOM-NEXT:    ld s0, 240(sp) # 8-byte Folded Reload
-; RV64NOM-NEXT:    ld s2, 232(sp) # 8-byte Folded Reload
+; RV64NOM-NEXT:    ld s1, 232(sp) # 8-byte Folded Reload
 ; RV64NOM-NEXT:    addi sp, sp, 256
 ; RV64NOM-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fp-setcc.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fp-setcc.ll
@@ -2120,11 +2120,11 @@ define void @fcmp_ugt_vv_v64f16_nonans(ptr %x, ptr %y, ptr %z) {
 ; RV32ZVFHMIN-NEXT:    sb t2, 105(sp)
 ; RV32ZVFHMIN-NEXT:    lh a1, 336(sp)
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a0
-; RV32ZVFHMIN-NEXT:    lh t3, 208(sp)
+; RV32ZVFHMIN-NEXT:    lh t2, 208(sp)
 ; RV32ZVFHMIN-NEXT:    flt.h a0, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a1
-; RV32ZVFHMIN-NEXT:    vmv.x.s t2, v23
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, t3
+; RV32ZVFHMIN-NEXT:    vmv.x.s t3, v23
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, t2
 ; RV32ZVFHMIN-NEXT:    flt.h a1, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a5
 ; RV32ZVFHMIN-NEXT:    sb a1, 104(sp)
@@ -2133,7 +2133,7 @@ define void @fcmp_ugt_vv_v64f16_nonans(ptr %x, ptr %y, ptr %z) {
 ; RV32ZVFHMIN-NEXT:    flt.h a1, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    lh a7, 206(sp)
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a5
-; RV32ZVFHMIN-NEXT:    vmv.x.s t3, v22
+; RV32ZVFHMIN-NEXT:    vmv.x.s t2, v22
 ; RV32ZVFHMIN-NEXT:    vslidedown.vi v22, v16, 11
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a7
 ; RV32ZVFHMIN-NEXT:    flt.h a5, fa4, fa5
@@ -2158,10 +2158,10 @@ define void @fcmp_ugt_vv_v64f16_nonans(ptr %x, ptr %y, ptr %z) {
 ; RV32ZVFHMIN-NEXT:    vslidedown.vi v24, v16, 10
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, t0
 ; RV32ZVFHMIN-NEXT:    flt.h t0, fa4, fa5
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, t2
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, t3
 ; RV32ZVFHMIN-NEXT:    sb t0, 101(sp)
 ; RV32ZVFHMIN-NEXT:    lh t0, 328(sp)
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, t3
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, t2
 ; RV32ZVFHMIN-NEXT:    lh t1, 200(sp)
 ; RV32ZVFHMIN-NEXT:    flt.h t2, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, t0
@@ -2270,76 +2270,76 @@ define void @fcmp_ugt_vv_v64f16_nonans(ptr %x, ptr %y, ptr %z) {
 ; RV32ZVFHMIN-NEXT:    lh a6, 240(sp)
 ; RV32ZVFHMIN-NEXT:    flt.h a1, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a4
-; RV32ZVFHMIN-NEXT:    vmv.x.s a7, v6
+; RV32ZVFHMIN-NEXT:    vmv.x.s a4, v6
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a6
-; RV32ZVFHMIN-NEXT:    flt.h a4, fa4, fa5
+; RV32ZVFHMIN-NEXT:    flt.h a6, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, t0
-; RV32ZVFHMIN-NEXT:    sb a4, 120(sp)
+; RV32ZVFHMIN-NEXT:    sb a6, 120(sp)
 ; RV32ZVFHMIN-NEXT:    lh a6, 366(sp)
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, t1
-; RV32ZVFHMIN-NEXT:    lh t0, 238(sp)
-; RV32ZVFHMIN-NEXT:    flt.h a4, fa4, fa5
+; RV32ZVFHMIN-NEXT:    lh a7, 238(sp)
+; RV32ZVFHMIN-NEXT:    flt.h t0, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a6
 ; RV32ZVFHMIN-NEXT:    vmv.x.s a6, v24
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, t0
-; RV32ZVFHMIN-NEXT:    flt.h t0, fa4, fa5
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a7
+; RV32ZVFHMIN-NEXT:    flt.h a7, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, t2
-; RV32ZVFHMIN-NEXT:    sb t0, 119(sp)
-; RV32ZVFHMIN-NEXT:    lh t0, 364(sp)
+; RV32ZVFHMIN-NEXT:    sb a7, 119(sp)
+; RV32ZVFHMIN-NEXT:    lh a7, 364(sp)
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, t3
 ; RV32ZVFHMIN-NEXT:    lh t1, 236(sp)
 ; RV32ZVFHMIN-NEXT:    flt.h t2, fa4, fa5
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, t0
-; RV32ZVFHMIN-NEXT:    vmv.x.s t0, v30
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a7
+; RV32ZVFHMIN-NEXT:    vmv.x.s a7, v30
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, t1
 ; RV32ZVFHMIN-NEXT:    flt.h t1, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a5
 ; RV32ZVFHMIN-NEXT:    sb t1, 118(sp)
 ; RV32ZVFHMIN-NEXT:    lh a5, 362(sp)
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a7
-; RV32ZVFHMIN-NEXT:    lh a7, 234(sp)
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a4
+; RV32ZVFHMIN-NEXT:    lh a4, 234(sp)
 ; RV32ZVFHMIN-NEXT:    flt.h t1, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a5
 ; RV32ZVFHMIN-NEXT:    vmv.x.s a5, v26
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a7
-; RV32ZVFHMIN-NEXT:    flt.h a7, fa4, fa5
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a4
+; RV32ZVFHMIN-NEXT:    flt.h a4, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a6
-; RV32ZVFHMIN-NEXT:    sb a7, 117(sp)
-; RV32ZVFHMIN-NEXT:    lh a6, 360(sp)
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, t0
-; RV32ZVFHMIN-NEXT:    lh a7, 232(sp)
-; RV32ZVFHMIN-NEXT:    flt.h t0, fa4, fa5
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a6
-; RV32ZVFHMIN-NEXT:    vmv.x.s a6, v28
+; RV32ZVFHMIN-NEXT:    sb a4, 117(sp)
+; RV32ZVFHMIN-NEXT:    lh a4, 360(sp)
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a7
+; RV32ZVFHMIN-NEXT:    lh a6, 232(sp)
 ; RV32ZVFHMIN-NEXT:    flt.h a7, fa4, fa5
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a5
-; RV32ZVFHMIN-NEXT:    sb a7, 116(sp)
-; RV32ZVFHMIN-NEXT:    lh a5, 358(sp)
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a6
-; RV32ZVFHMIN-NEXT:    lh a6, 230(sp)
-; RV32ZVFHMIN-NEXT:    flt.h a7, fa4, fa5
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a5
-; RV32ZVFHMIN-NEXT:    vmv.x.s a5, v16
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a4
+; RV32ZVFHMIN-NEXT:    vmv.x.s a4, v28
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a6
 ; RV32ZVFHMIN-NEXT:    flt.h a6, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a5
+; RV32ZVFHMIN-NEXT:    sb a6, 116(sp)
+; RV32ZVFHMIN-NEXT:    lh a5, 358(sp)
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a4
+; RV32ZVFHMIN-NEXT:    lh a4, 230(sp)
+; RV32ZVFHMIN-NEXT:    flt.h a6, fa4, fa5
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a5
+; RV32ZVFHMIN-NEXT:    vmv.x.s a5, v16
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a4
+; RV32ZVFHMIN-NEXT:    flt.h a4, fa4, fa5
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a5
 ; RV32ZVFHMIN-NEXT:    vmv.x.s a5, v8
 ; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a5
-; RV32ZVFHMIN-NEXT:    sb a6, 115(sp)
-; RV32ZVFHMIN-NEXT:    lh a5, 356(sp)
-; RV32ZVFHMIN-NEXT:    lh a6, 228(sp)
+; RV32ZVFHMIN-NEXT:    sb a4, 115(sp)
+; RV32ZVFHMIN-NEXT:    lh a4, 356(sp)
+; RV32ZVFHMIN-NEXT:    lh a5, 228(sp)
 ; RV32ZVFHMIN-NEXT:    sb t2, 76(sp)
-; RV32ZVFHMIN-NEXT:    sb a4, 77(sp)
+; RV32ZVFHMIN-NEXT:    sb t0, 77(sp)
 ; RV32ZVFHMIN-NEXT:    sb a1, 78(sp)
 ; RV32ZVFHMIN-NEXT:    sb a0, 79(sp)
 ; RV32ZVFHMIN-NEXT:    flt.h a0, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    sb a0, 72(sp)
-; RV32ZVFHMIN-NEXT:    sb a7, 73(sp)
-; RV32ZVFHMIN-NEXT:    sb t0, 74(sp)
+; RV32ZVFHMIN-NEXT:    sb a6, 73(sp)
+; RV32ZVFHMIN-NEXT:    sb a7, 74(sp)
 ; RV32ZVFHMIN-NEXT:    sb t1, 75(sp)
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a5
-; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a6
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa5, a4
+; RV32ZVFHMIN-NEXT:    fmv.h.x fa4, a5
 ; RV32ZVFHMIN-NEXT:    flt.h a0, fa4, fa5
 ; RV32ZVFHMIN-NEXT:    sb a0, 114(sp)
 ; RV32ZVFHMIN-NEXT:    addi a0, sp, 64
@@ -2571,11 +2571,11 @@ define void @fcmp_ugt_vv_v64f16_nonans(ptr %x, ptr %y, ptr %z) {
 ; RV64ZVFHMIN-NEXT:    sb t2, 105(sp)
 ; RV64ZVFHMIN-NEXT:    lh a1, 336(sp)
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a0
-; RV64ZVFHMIN-NEXT:    lh t3, 208(sp)
+; RV64ZVFHMIN-NEXT:    lh t2, 208(sp)
 ; RV64ZVFHMIN-NEXT:    flt.h a0, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a1
-; RV64ZVFHMIN-NEXT:    vmv.x.s t2, v23
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, t3
+; RV64ZVFHMIN-NEXT:    vmv.x.s t3, v23
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, t2
 ; RV64ZVFHMIN-NEXT:    flt.h a1, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a5
 ; RV64ZVFHMIN-NEXT:    sb a1, 104(sp)
@@ -2584,7 +2584,7 @@ define void @fcmp_ugt_vv_v64f16_nonans(ptr %x, ptr %y, ptr %z) {
 ; RV64ZVFHMIN-NEXT:    flt.h a1, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    lh a7, 206(sp)
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a5
-; RV64ZVFHMIN-NEXT:    vmv.x.s t3, v22
+; RV64ZVFHMIN-NEXT:    vmv.x.s t2, v22
 ; RV64ZVFHMIN-NEXT:    vslidedown.vi v22, v16, 11
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a7
 ; RV64ZVFHMIN-NEXT:    flt.h a5, fa4, fa5
@@ -2609,10 +2609,10 @@ define void @fcmp_ugt_vv_v64f16_nonans(ptr %x, ptr %y, ptr %z) {
 ; RV64ZVFHMIN-NEXT:    vslidedown.vi v24, v16, 10
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, t0
 ; RV64ZVFHMIN-NEXT:    flt.h t0, fa4, fa5
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, t2
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, t3
 ; RV64ZVFHMIN-NEXT:    sb t0, 101(sp)
 ; RV64ZVFHMIN-NEXT:    lh t0, 328(sp)
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, t3
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, t2
 ; RV64ZVFHMIN-NEXT:    lh t1, 200(sp)
 ; RV64ZVFHMIN-NEXT:    flt.h t2, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, t0
@@ -2721,76 +2721,76 @@ define void @fcmp_ugt_vv_v64f16_nonans(ptr %x, ptr %y, ptr %z) {
 ; RV64ZVFHMIN-NEXT:    lh a6, 240(sp)
 ; RV64ZVFHMIN-NEXT:    flt.h a1, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a4
-; RV64ZVFHMIN-NEXT:    vmv.x.s a7, v6
+; RV64ZVFHMIN-NEXT:    vmv.x.s a4, v6
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a6
-; RV64ZVFHMIN-NEXT:    flt.h a4, fa4, fa5
+; RV64ZVFHMIN-NEXT:    flt.h a6, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, t0
-; RV64ZVFHMIN-NEXT:    sb a4, 120(sp)
+; RV64ZVFHMIN-NEXT:    sb a6, 120(sp)
 ; RV64ZVFHMIN-NEXT:    lh a6, 366(sp)
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, t1
-; RV64ZVFHMIN-NEXT:    lh t0, 238(sp)
-; RV64ZVFHMIN-NEXT:    flt.h a4, fa4, fa5
+; RV64ZVFHMIN-NEXT:    lh a7, 238(sp)
+; RV64ZVFHMIN-NEXT:    flt.h t0, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a6
 ; RV64ZVFHMIN-NEXT:    vmv.x.s a6, v24
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, t0
-; RV64ZVFHMIN-NEXT:    flt.h t0, fa4, fa5
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a7
+; RV64ZVFHMIN-NEXT:    flt.h a7, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, t2
-; RV64ZVFHMIN-NEXT:    sb t0, 119(sp)
-; RV64ZVFHMIN-NEXT:    lh t0, 364(sp)
+; RV64ZVFHMIN-NEXT:    sb a7, 119(sp)
+; RV64ZVFHMIN-NEXT:    lh a7, 364(sp)
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, t3
 ; RV64ZVFHMIN-NEXT:    lh t1, 236(sp)
 ; RV64ZVFHMIN-NEXT:    flt.h t2, fa4, fa5
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, t0
-; RV64ZVFHMIN-NEXT:    vmv.x.s t0, v30
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a7
+; RV64ZVFHMIN-NEXT:    vmv.x.s a7, v30
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, t1
 ; RV64ZVFHMIN-NEXT:    flt.h t1, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a5
 ; RV64ZVFHMIN-NEXT:    sb t1, 118(sp)
 ; RV64ZVFHMIN-NEXT:    lh a5, 362(sp)
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a7
-; RV64ZVFHMIN-NEXT:    lh a7, 234(sp)
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a4
+; RV64ZVFHMIN-NEXT:    lh a4, 234(sp)
 ; RV64ZVFHMIN-NEXT:    flt.h t1, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a5
 ; RV64ZVFHMIN-NEXT:    vmv.x.s a5, v26
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a7
-; RV64ZVFHMIN-NEXT:    flt.h a7, fa4, fa5
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a4
+; RV64ZVFHMIN-NEXT:    flt.h a4, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a6
-; RV64ZVFHMIN-NEXT:    sb a7, 117(sp)
-; RV64ZVFHMIN-NEXT:    lh a6, 360(sp)
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, t0
-; RV64ZVFHMIN-NEXT:    lh a7, 232(sp)
-; RV64ZVFHMIN-NEXT:    flt.h t0, fa4, fa5
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a6
-; RV64ZVFHMIN-NEXT:    vmv.x.s a6, v28
+; RV64ZVFHMIN-NEXT:    sb a4, 117(sp)
+; RV64ZVFHMIN-NEXT:    lh a4, 360(sp)
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a7
+; RV64ZVFHMIN-NEXT:    lh a6, 232(sp)
 ; RV64ZVFHMIN-NEXT:    flt.h a7, fa4, fa5
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a5
-; RV64ZVFHMIN-NEXT:    sb a7, 116(sp)
-; RV64ZVFHMIN-NEXT:    lh a5, 358(sp)
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a6
-; RV64ZVFHMIN-NEXT:    lh a6, 230(sp)
-; RV64ZVFHMIN-NEXT:    flt.h a7, fa4, fa5
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a5
-; RV64ZVFHMIN-NEXT:    vmv.x.s a5, v16
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a4
+; RV64ZVFHMIN-NEXT:    vmv.x.s a4, v28
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a6
 ; RV64ZVFHMIN-NEXT:    flt.h a6, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a5
+; RV64ZVFHMIN-NEXT:    sb a6, 116(sp)
+; RV64ZVFHMIN-NEXT:    lh a5, 358(sp)
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a4
+; RV64ZVFHMIN-NEXT:    lh a4, 230(sp)
+; RV64ZVFHMIN-NEXT:    flt.h a6, fa4, fa5
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a5
+; RV64ZVFHMIN-NEXT:    vmv.x.s a5, v16
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a4
+; RV64ZVFHMIN-NEXT:    flt.h a4, fa4, fa5
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a5
 ; RV64ZVFHMIN-NEXT:    vmv.x.s a5, v8
 ; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a5
-; RV64ZVFHMIN-NEXT:    sb a6, 115(sp)
-; RV64ZVFHMIN-NEXT:    lh a5, 356(sp)
-; RV64ZVFHMIN-NEXT:    lh a6, 228(sp)
+; RV64ZVFHMIN-NEXT:    sb a4, 115(sp)
+; RV64ZVFHMIN-NEXT:    lh a4, 356(sp)
+; RV64ZVFHMIN-NEXT:    lh a5, 228(sp)
 ; RV64ZVFHMIN-NEXT:    sb t2, 76(sp)
-; RV64ZVFHMIN-NEXT:    sb a4, 77(sp)
+; RV64ZVFHMIN-NEXT:    sb t0, 77(sp)
 ; RV64ZVFHMIN-NEXT:    sb a1, 78(sp)
 ; RV64ZVFHMIN-NEXT:    sb a0, 79(sp)
 ; RV64ZVFHMIN-NEXT:    flt.h a0, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    sb a0, 72(sp)
-; RV64ZVFHMIN-NEXT:    sb a7, 73(sp)
-; RV64ZVFHMIN-NEXT:    sb t0, 74(sp)
+; RV64ZVFHMIN-NEXT:    sb a6, 73(sp)
+; RV64ZVFHMIN-NEXT:    sb a7, 74(sp)
 ; RV64ZVFHMIN-NEXT:    sb t1, 75(sp)
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a5
-; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a6
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa5, a4
+; RV64ZVFHMIN-NEXT:    fmv.h.x fa4, a5
 ; RV64ZVFHMIN-NEXT:    flt.h a0, fa4, fa5
 ; RV64ZVFHMIN-NEXT:    sb a0, 114(sp)
 ; RV64ZVFHMIN-NEXT:    addi a0, sp, 64

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fpowi.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-fpowi.ll
@@ -605,55 +605,55 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    addi sp, sp, -272
 ; RV32-NEXT:    sw ra, 268(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sw s0, 264(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s2, 260(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s1, 260(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    addi s0, sp, 272
 ; RV32-NEXT:    csrr a1, vlenb
 ; RV32-NEXT:    slli a1, a1, 2
 ; RV32-NEXT:    sub sp, sp, a1
 ; RV32-NEXT:    andi sp, sp, -64
-; RV32-NEXT:    mv s2, a0
+; RV32-NEXT:    mv s1, a0
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vs4r.v v8, (a0) # vscale x 32-byte Folded Spill
 ; RV32-NEXT:    addi a0, sp, 64
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV32-NEXT:    vse32.v v8, (a0)
 ; RV32-NEXT:    flw fa0, 124(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 188(sp)
 ; RV32-NEXT:    flw fa0, 120(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 184(sp)
 ; RV32-NEXT:    flw fa0, 116(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 180(sp)
 ; RV32-NEXT:    flw fa0, 112(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 176(sp)
 ; RV32-NEXT:    flw fa0, 108(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 172(sp)
 ; RV32-NEXT:    flw fa0, 104(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 168(sp)
 ; RV32-NEXT:    flw fa0, 100(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 164(sp)
 ; RV32-NEXT:    flw fa0, 96(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 160(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 128(sp)
 ; RV32-NEXT:    addi a0, sp, 256
@@ -661,7 +661,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
 ; RV32-NEXT:    vslidedown.vi v8, v8, 3
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 140(sp)
 ; RV32-NEXT:    addi a0, sp, 256
@@ -669,7 +669,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
 ; RV32-NEXT:    vslidedown.vi v8, v8, 2
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 136(sp)
 ; RV32-NEXT:    addi a0, sp, 256
@@ -677,7 +677,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
 ; RV32-NEXT:    vslidedown.vi v8, v8, 1
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 132(sp)
 ; RV32-NEXT:    addi a0, sp, 256
@@ -685,7 +685,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
 ; RV32-NEXT:    vslidedown.vi v8, v8, 7
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 156(sp)
 ; RV32-NEXT:    addi a0, sp, 256
@@ -693,7 +693,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
 ; RV32-NEXT:    vslidedown.vi v8, v8, 6
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 152(sp)
 ; RV32-NEXT:    addi a0, sp, 256
@@ -701,7 +701,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
 ; RV32-NEXT:    vslidedown.vi v8, v8, 5
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 148(sp)
 ; RV32-NEXT:    addi a0, sp, 256
@@ -709,7 +709,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
 ; RV32-NEXT:    vslidedown.vi v8, v8, 4
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powisf2
 ; RV32-NEXT:    fsw fa0, 144(sp)
 ; RV32-NEXT:    addi a0, sp, 128
@@ -718,7 +718,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV32-NEXT:    addi sp, s0, -272
 ; RV32-NEXT:    lw ra, 268(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    lw s0, 264(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s2, 260(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s1, 260(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    addi sp, sp, 272
 ; RV32-NEXT:    ret
 ;
@@ -727,7 +727,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    addi sp, sp, -272
 ; RV64-NEXT:    sd ra, 264(sp) # 8-byte Folded Spill
 ; RV64-NEXT:    sd s0, 256(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s2, 248(sp) # 8-byte Folded Spill
+; RV64-NEXT:    sd s1, 248(sp) # 8-byte Folded Spill
 ; RV64-NEXT:    addi s0, sp, 272
 ; RV64-NEXT:    csrr a1, vlenb
 ; RV64-NEXT:    slli a1, a1, 2
@@ -739,43 +739,43 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV64-NEXT:    vse32.v v8, (a1)
 ; RV64-NEXT:    flw fa0, 124(sp)
-; RV64-NEXT:    sext.w s2, a0
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    sext.w s1, a0
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 188(sp)
 ; RV64-NEXT:    flw fa0, 120(sp)
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 184(sp)
 ; RV64-NEXT:    flw fa0, 116(sp)
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 180(sp)
 ; RV64-NEXT:    flw fa0, 112(sp)
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 176(sp)
 ; RV64-NEXT:    flw fa0, 108(sp)
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 172(sp)
 ; RV64-NEXT:    flw fa0, 104(sp)
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 168(sp)
 ; RV64-NEXT:    flw fa0, 100(sp)
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 164(sp)
 ; RV64-NEXT:    flw fa0, 96(sp)
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 160(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 128(sp)
 ; RV64-NEXT:    addi a0, sp, 240
@@ -783,7 +783,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
 ; RV64-NEXT:    vslidedown.vi v8, v8, 3
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 140(sp)
 ; RV64-NEXT:    addi a0, sp, 240
@@ -791,7 +791,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
 ; RV64-NEXT:    vslidedown.vi v8, v8, 2
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 136(sp)
 ; RV64-NEXT:    addi a0, sp, 240
@@ -799,7 +799,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
 ; RV64-NEXT:    vslidedown.vi v8, v8, 1
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 132(sp)
 ; RV64-NEXT:    addi a0, sp, 240
@@ -807,7 +807,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
 ; RV64-NEXT:    vslidedown.vi v8, v8, 7
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 156(sp)
 ; RV64-NEXT:    addi a0, sp, 240
@@ -815,7 +815,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
 ; RV64-NEXT:    vslidedown.vi v8, v8, 6
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 152(sp)
 ; RV64-NEXT:    addi a0, sp, 240
@@ -823,7 +823,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
 ; RV64-NEXT:    vslidedown.vi v8, v8, 5
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 148(sp)
 ; RV64-NEXT:    addi a0, sp, 240
@@ -831,7 +831,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
 ; RV64-NEXT:    vslidedown.vi v8, v8, 4
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powisf2
 ; RV64-NEXT:    fsw fa0, 144(sp)
 ; RV64-NEXT:    addi a0, sp, 128
@@ -840,7 +840,7 @@ define <16 x float> @powi_v16f32(<16 x float> %x, i32 %y) nounwind {
 ; RV64-NEXT:    addi sp, s0, -272
 ; RV64-NEXT:    ld ra, 264(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    ld s0, 256(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s2, 248(sp) # 8-byte Folded Reload
+; RV64-NEXT:    ld s1, 248(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    addi sp, sp, 272
 ; RV64-NEXT:    ret
   %a = call <16 x float> @llvm.powi.v16f32.i32(<16 x float> %x, i32 %y)
@@ -1094,39 +1094,39 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV32-NEXT:    addi sp, sp, -272
 ; RV32-NEXT:    sw ra, 268(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    sw s0, 264(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s2, 260(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s1, 260(sp) # 4-byte Folded Spill
 ; RV32-NEXT:    addi s0, sp, 272
 ; RV32-NEXT:    csrr a1, vlenb
 ; RV32-NEXT:    slli a1, a1, 2
 ; RV32-NEXT:    sub sp, sp, a1
 ; RV32-NEXT:    andi sp, sp, -64
-; RV32-NEXT:    mv s2, a0
+; RV32-NEXT:    mv s1, a0
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vs4r.v v8, (a0) # vscale x 32-byte Folded Spill
 ; RV32-NEXT:    addi a0, sp, 64
 ; RV32-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV32-NEXT:    vse64.v v8, (a0)
 ; RV32-NEXT:    fld fa0, 120(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
 ; RV32-NEXT:    fsd fa0, 184(sp)
 ; RV32-NEXT:    fld fa0, 112(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
 ; RV32-NEXT:    fsd fa0, 176(sp)
 ; RV32-NEXT:    fld fa0, 104(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
 ; RV32-NEXT:    fsd fa0, 168(sp)
 ; RV32-NEXT:    fld fa0, 96(sp)
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
 ; RV32-NEXT:    fsd fa0, 160(sp)
 ; RV32-NEXT:    addi a0, sp, 256
 ; RV32-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV32-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
 ; RV32-NEXT:    fsd fa0, 128(sp)
 ; RV32-NEXT:    addi a0, sp, 256
@@ -1134,7 +1134,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
 ; RV32-NEXT:    vslidedown.vi v8, v8, 1
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
 ; RV32-NEXT:    fsd fa0, 136(sp)
 ; RV32-NEXT:    addi a0, sp, 256
@@ -1142,7 +1142,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
 ; RV32-NEXT:    vslidedown.vi v8, v8, 3
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
 ; RV32-NEXT:    fsd fa0, 152(sp)
 ; RV32-NEXT:    addi a0, sp, 256
@@ -1150,7 +1150,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV32-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
 ; RV32-NEXT:    vslidedown.vi v8, v8, 2
 ; RV32-NEXT:    vfmv.f.s fa0, v8
-; RV32-NEXT:    mv a0, s2
+; RV32-NEXT:    mv a0, s1
 ; RV32-NEXT:    call __powidf2
 ; RV32-NEXT:    fsd fa0, 144(sp)
 ; RV32-NEXT:    addi a0, sp, 128
@@ -1159,7 +1159,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV32-NEXT:    addi sp, s0, -272
 ; RV32-NEXT:    lw ra, 268(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    lw s0, 264(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s2, 260(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s1, 260(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    addi sp, sp, 272
 ; RV32-NEXT:    ret
 ;
@@ -1168,7 +1168,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV64-NEXT:    addi sp, sp, -272
 ; RV64-NEXT:    sd ra, 264(sp) # 8-byte Folded Spill
 ; RV64-NEXT:    sd s0, 256(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s2, 248(sp) # 8-byte Folded Spill
+; RV64-NEXT:    sd s1, 248(sp) # 8-byte Folded Spill
 ; RV64-NEXT:    addi s0, sp, 272
 ; RV64-NEXT:    csrr a1, vlenb
 ; RV64-NEXT:    slli a1, a1, 2
@@ -1180,27 +1180,27 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 8, e64, m4, ta, ma
 ; RV64-NEXT:    vse64.v v8, (a1)
 ; RV64-NEXT:    fld fa0, 120(sp)
-; RV64-NEXT:    sext.w s2, a0
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    sext.w s1, a0
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
 ; RV64-NEXT:    fsd fa0, 184(sp)
 ; RV64-NEXT:    fld fa0, 112(sp)
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
 ; RV64-NEXT:    fsd fa0, 176(sp)
 ; RV64-NEXT:    fld fa0, 104(sp)
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
 ; RV64-NEXT:    fsd fa0, 168(sp)
 ; RV64-NEXT:    fld fa0, 96(sp)
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
 ; RV64-NEXT:    fsd fa0, 160(sp)
 ; RV64-NEXT:    addi a0, sp, 240
 ; RV64-NEXT:    vl4r.v v8, (a0) # vscale x 32-byte Folded Reload
 ; RV64-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
 ; RV64-NEXT:    fsd fa0, 128(sp)
 ; RV64-NEXT:    addi a0, sp, 240
@@ -1208,7 +1208,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 1, e64, m1, ta, ma
 ; RV64-NEXT:    vslidedown.vi v8, v8, 1
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
 ; RV64-NEXT:    fsd fa0, 136(sp)
 ; RV64-NEXT:    addi a0, sp, 240
@@ -1216,7 +1216,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
 ; RV64-NEXT:    vslidedown.vi v8, v8, 3
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
 ; RV64-NEXT:    fsd fa0, 152(sp)
 ; RV64-NEXT:    addi a0, sp, 240
@@ -1224,7 +1224,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV64-NEXT:    vsetivli zero, 1, e64, m2, ta, ma
 ; RV64-NEXT:    vslidedown.vi v8, v8, 2
 ; RV64-NEXT:    vfmv.f.s fa0, v8
-; RV64-NEXT:    mv a0, s2
+; RV64-NEXT:    mv a0, s1
 ; RV64-NEXT:    call __powidf2
 ; RV64-NEXT:    fsd fa0, 144(sp)
 ; RV64-NEXT:    addi a0, sp, 128
@@ -1233,7 +1233,7 @@ define <8 x double> @powi_v8f64(<8 x double> %x, i32 %y) nounwind {
 ; RV64-NEXT:    addi sp, s0, -272
 ; RV64-NEXT:    ld ra, 264(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    ld s0, 256(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s2, 248(sp) # 8-byte Folded Reload
+; RV64-NEXT:    ld s1, 248(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    addi sp, sp, 272
 ; RV64-NEXT:    ret
   %a = call <8 x double> @llvm.powi.v8f64.i32(<8 x double> %x, i32 %y)

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-masked-gather.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-masked-gather.ll
@@ -14706,28 +14706,30 @@ define <32 x i64> @mgather_strided_split(ptr %base) {
 ; RV32ZVE32F-NEXT:    .cfi_def_cfa_offset 512
 ; RV32ZVE32F-NEXT:    sw ra, 508(sp) # 4-byte Folded Spill
 ; RV32ZVE32F-NEXT:    sw s0, 504(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    sw s2, 500(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    sw s3, 496(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    sw s4, 492(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    sw s5, 488(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    sw s6, 484(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    sw s7, 480(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    sw s8, 476(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    sw s9, 472(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    sw s10, 468(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    sw s11, 464(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw s1, 500(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw s2, 496(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw s3, 492(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw s4, 488(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw s5, 484(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw s6, 480(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw s7, 476(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw s8, 472(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw s9, 468(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw s10, 464(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw s11, 460(sp) # 4-byte Folded Spill
 ; RV32ZVE32F-NEXT:    .cfi_offset ra, -4
 ; RV32ZVE32F-NEXT:    .cfi_offset s0, -8
-; RV32ZVE32F-NEXT:    .cfi_offset s2, -12
-; RV32ZVE32F-NEXT:    .cfi_offset s3, -16
-; RV32ZVE32F-NEXT:    .cfi_offset s4, -20
-; RV32ZVE32F-NEXT:    .cfi_offset s5, -24
-; RV32ZVE32F-NEXT:    .cfi_offset s6, -28
-; RV32ZVE32F-NEXT:    .cfi_offset s7, -32
-; RV32ZVE32F-NEXT:    .cfi_offset s8, -36
-; RV32ZVE32F-NEXT:    .cfi_offset s9, -40
-; RV32ZVE32F-NEXT:    .cfi_offset s10, -44
-; RV32ZVE32F-NEXT:    .cfi_offset s11, -48
+; RV32ZVE32F-NEXT:    .cfi_offset s1, -12
+; RV32ZVE32F-NEXT:    .cfi_offset s2, -16
+; RV32ZVE32F-NEXT:    .cfi_offset s3, -20
+; RV32ZVE32F-NEXT:    .cfi_offset s4, -24
+; RV32ZVE32F-NEXT:    .cfi_offset s5, -28
+; RV32ZVE32F-NEXT:    .cfi_offset s6, -32
+; RV32ZVE32F-NEXT:    .cfi_offset s7, -36
+; RV32ZVE32F-NEXT:    .cfi_offset s8, -40
+; RV32ZVE32F-NEXT:    .cfi_offset s9, -44
+; RV32ZVE32F-NEXT:    .cfi_offset s10, -48
+; RV32ZVE32F-NEXT:    .cfi_offset s11, -52
 ; RV32ZVE32F-NEXT:    addi s0, sp, 512
 ; RV32ZVE32F-NEXT:    .cfi_def_cfa s0, 0
 ; RV32ZVE32F-NEXT:    andi sp, sp, -128
@@ -14761,7 +14763,7 @@ define <32 x i64> @mgather_strided_split(ptr %base) {
 ; RV32ZVE32F-NEXT:    sw t2, 196(sp) # 4-byte Folded Spill
 ; RV32ZVE32F-NEXT:    lw a1, 4(a1)
 ; RV32ZVE32F-NEXT:    sw a1, 192(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    lw ra, 0(a4)
+; RV32ZVE32F-NEXT:    lw s11, 0(a4)
 ; RV32ZVE32F-NEXT:    lw a1, 4(a4)
 ; RV32ZVE32F-NEXT:    sw a1, 172(sp) # 4-byte Folded Spill
 ; RV32ZVE32F-NEXT:    lw a1, 0(a5)
@@ -14838,18 +14840,18 @@ define <32 x i64> @mgather_strided_split(ptr %base) {
 ; RV32ZVE32F-NEXT:    sw a1, 120(sp) # 4-byte Folded Spill
 ; RV32ZVE32F-NEXT:    lw a1, 4(a2)
 ; RV32ZVE32F-NEXT:    sw a1, 116(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    lw s8, 0(a3)
-; RV32ZVE32F-NEXT:    lw s9, 4(a3)
-; RV32ZVE32F-NEXT:    lw s10, 0(a4)
-; RV32ZVE32F-NEXT:    lw s11, 4(a4)
+; RV32ZVE32F-NEXT:    lw s7, 0(a3)
+; RV32ZVE32F-NEXT:    lw s8, 4(a3)
+; RV32ZVE32F-NEXT:    lw s9, 0(a4)
+; RV32ZVE32F-NEXT:    lw s10, 4(a4)
 ; RV32ZVE32F-NEXT:    lw a1, 336(sp)
 ; RV32ZVE32F-NEXT:    lw a2, 340(sp)
 ; RV32ZVE32F-NEXT:    lw a3, 344(sp)
 ; RV32ZVE32F-NEXT:    lw a4, 348(sp)
 ; RV32ZVE32F-NEXT:    lw t5, 0(a1)
 ; RV32ZVE32F-NEXT:    lw t6, 4(a1)
-; RV32ZVE32F-NEXT:    lw s2, 0(a2)
-; RV32ZVE32F-NEXT:    lw s3, 4(a2)
+; RV32ZVE32F-NEXT:    lw s1, 0(a2)
+; RV32ZVE32F-NEXT:    lw s2, 4(a2)
 ; RV32ZVE32F-NEXT:    lw a5, 0(a3)
 ; RV32ZVE32F-NEXT:    lw a6, 4(a3)
 ; RV32ZVE32F-NEXT:    lw a7, 0(a4)
@@ -14860,16 +14862,15 @@ define <32 x i64> @mgather_strided_split(ptr %base) {
 ; RV32ZVE32F-NEXT:    lw a4, 364(sp)
 ; RV32ZVE32F-NEXT:    lw t1, 0(a1)
 ; RV32ZVE32F-NEXT:    sw t1, 112(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    lw a1, 4(a1)
-; RV32ZVE32F-NEXT:    sw a1, 108(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    lw ra, 4(a1)
 ; RV32ZVE32F-NEXT:    lw a1, 0(a2)
-; RV32ZVE32F-NEXT:    sw a1, 104(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    sw a1, 108(sp) # 4-byte Folded Spill
 ; RV32ZVE32F-NEXT:    lw a1, 4(a2)
-; RV32ZVE32F-NEXT:    sw a1, 100(sp) # 4-byte Folded Spill
-; RV32ZVE32F-NEXT:    lw s4, 0(a3)
-; RV32ZVE32F-NEXT:    lw s5, 4(a3)
-; RV32ZVE32F-NEXT:    lw s6, 0(a4)
-; RV32ZVE32F-NEXT:    lw s7, 4(a4)
+; RV32ZVE32F-NEXT:    sw a1, 104(sp) # 4-byte Folded Spill
+; RV32ZVE32F-NEXT:    lw s3, 0(a3)
+; RV32ZVE32F-NEXT:    lw s4, 4(a3)
+; RV32ZVE32F-NEXT:    lw s5, 0(a4)
+; RV32ZVE32F-NEXT:    lw s6, 4(a4)
 ; RV32ZVE32F-NEXT:    lw a1, 368(sp)
 ; RV32ZVE32F-NEXT:    lw a2, 372(sp)
 ; RV32ZVE32F-NEXT:    lw a3, 376(sp)
@@ -14882,41 +14883,41 @@ define <32 x i64> @mgather_strided_split(ptr %base) {
 ; RV32ZVE32F-NEXT:    lw a2, 4(a3)
 ; RV32ZVE32F-NEXT:    lw a3, 0(a4)
 ; RV32ZVE32F-NEXT:    lw a4, 4(a4)
-; RV32ZVE32F-NEXT:    sw ra, 16(a0)
-; RV32ZVE32F-NEXT:    lw ra, 172(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw ra, 20(a0)
-; RV32ZVE32F-NEXT:    lw ra, 168(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw ra, 24(a0)
-; RV32ZVE32F-NEXT:    lw ra, 164(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw ra, 28(a0)
-; RV32ZVE32F-NEXT:    lw ra, 236(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw ra, 0(a0)
-; RV32ZVE32F-NEXT:    lw ra, 232(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw ra, 4(a0)
-; RV32ZVE32F-NEXT:    lw ra, 196(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw ra, 8(a0)
-; RV32ZVE32F-NEXT:    lw ra, 192(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw ra, 12(a0)
-; RV32ZVE32F-NEXT:    lw ra, 188(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw ra, 48(a0)
-; RV32ZVE32F-NEXT:    lw ra, 184(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw ra, 52(a0)
-; RV32ZVE32F-NEXT:    lw ra, 180(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw ra, 56(a0)
-; RV32ZVE32F-NEXT:    lw ra, 176(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw ra, 60(a0)
+; RV32ZVE32F-NEXT:    sw s11, 16(a0)
+; RV32ZVE32F-NEXT:    lw s11, 172(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    sw s11, 20(a0)
+; RV32ZVE32F-NEXT:    lw s11, 168(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    sw s11, 24(a0)
+; RV32ZVE32F-NEXT:    lw s11, 164(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    sw s11, 28(a0)
+; RV32ZVE32F-NEXT:    lw s11, 236(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    sw s11, 0(a0)
+; RV32ZVE32F-NEXT:    lw s11, 232(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    sw s11, 4(a0)
+; RV32ZVE32F-NEXT:    lw s11, 196(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    sw s11, 8(a0)
+; RV32ZVE32F-NEXT:    lw s11, 192(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    sw s11, 12(a0)
+; RV32ZVE32F-NEXT:    lw s11, 188(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    sw s11, 48(a0)
+; RV32ZVE32F-NEXT:    lw s11, 184(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    sw s11, 52(a0)
+; RV32ZVE32F-NEXT:    lw s11, 180(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    sw s11, 56(a0)
+; RV32ZVE32F-NEXT:    lw s11, 176(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    sw s11, 60(a0)
 ; RV32ZVE32F-NEXT:    sw a5, 176(a0)
 ; RV32ZVE32F-NEXT:    sw a6, 180(a0)
 ; RV32ZVE32F-NEXT:    sw a7, 184(a0)
 ; RV32ZVE32F-NEXT:    sw t0, 188(a0)
 ; RV32ZVE32F-NEXT:    sw t5, 160(a0)
 ; RV32ZVE32F-NEXT:    sw t6, 164(a0)
-; RV32ZVE32F-NEXT:    sw s2, 168(a0)
-; RV32ZVE32F-NEXT:    sw s3, 172(a0)
-; RV32ZVE32F-NEXT:    sw s8, 144(a0)
-; RV32ZVE32F-NEXT:    sw s9, 148(a0)
-; RV32ZVE32F-NEXT:    sw s10, 152(a0)
-; RV32ZVE32F-NEXT:    sw s11, 156(a0)
+; RV32ZVE32F-NEXT:    sw s1, 168(a0)
+; RV32ZVE32F-NEXT:    sw s2, 172(a0)
+; RV32ZVE32F-NEXT:    sw s7, 144(a0)
+; RV32ZVE32F-NEXT:    sw s8, 148(a0)
+; RV32ZVE32F-NEXT:    sw s9, 152(a0)
+; RV32ZVE32F-NEXT:    sw s10, 156(a0)
 ; RV32ZVE32F-NEXT:    lw a5, 128(sp) # 4-byte Folded Reload
 ; RV32ZVE32F-NEXT:    sw a5, 128(a0)
 ; RV32ZVE32F-NEXT:    lw a5, 124(sp) # 4-byte Folded Reload
@@ -14965,17 +14966,16 @@ define <32 x i64> @mgather_strided_split(ptr %base) {
 ; RV32ZVE32F-NEXT:    sw t2, 228(a0)
 ; RV32ZVE32F-NEXT:    sw t3, 232(a0)
 ; RV32ZVE32F-NEXT:    sw t4, 236(a0)
-; RV32ZVE32F-NEXT:    sw s4, 208(a0)
-; RV32ZVE32F-NEXT:    sw s5, 212(a0)
-; RV32ZVE32F-NEXT:    sw s6, 216(a0)
-; RV32ZVE32F-NEXT:    sw s7, 220(a0)
+; RV32ZVE32F-NEXT:    sw s3, 208(a0)
+; RV32ZVE32F-NEXT:    sw s4, 212(a0)
+; RV32ZVE32F-NEXT:    sw s5, 216(a0)
+; RV32ZVE32F-NEXT:    sw s6, 220(a0)
 ; RV32ZVE32F-NEXT:    lw a1, 112(sp) # 4-byte Folded Reload
 ; RV32ZVE32F-NEXT:    sw a1, 192(a0)
+; RV32ZVE32F-NEXT:    sw ra, 196(a0)
 ; RV32ZVE32F-NEXT:    lw a1, 108(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    sw a1, 196(a0)
-; RV32ZVE32F-NEXT:    lw a1, 104(sp) # 4-byte Folded Reload
 ; RV32ZVE32F-NEXT:    sw a1, 200(a0)
-; RV32ZVE32F-NEXT:    lw a1, 100(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw a1, 104(sp) # 4-byte Folded Reload
 ; RV32ZVE32F-NEXT:    sw a1, 204(a0)
 ; RV32ZVE32F-NEXT:    lw a1, 252(sp) # 4-byte Folded Reload
 ; RV32ZVE32F-NEXT:    sw a1, 32(a0)
@@ -14989,18 +14989,20 @@ define <32 x i64> @mgather_strided_split(ptr %base) {
 ; RV32ZVE32F-NEXT:    .cfi_def_cfa sp, 512
 ; RV32ZVE32F-NEXT:    lw ra, 508(sp) # 4-byte Folded Reload
 ; RV32ZVE32F-NEXT:    lw s0, 504(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    lw s2, 500(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    lw s3, 496(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    lw s4, 492(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    lw s5, 488(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    lw s6, 484(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    lw s7, 480(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    lw s8, 476(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    lw s9, 472(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    lw s10, 468(sp) # 4-byte Folded Reload
-; RV32ZVE32F-NEXT:    lw s11, 464(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw s1, 500(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw s2, 496(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw s3, 492(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw s4, 488(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw s5, 484(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw s6, 480(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw s7, 476(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw s8, 472(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw s9, 468(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw s10, 464(sp) # 4-byte Folded Reload
+; RV32ZVE32F-NEXT:    lw s11, 460(sp) # 4-byte Folded Reload
 ; RV32ZVE32F-NEXT:    .cfi_restore ra
 ; RV32ZVE32F-NEXT:    .cfi_restore s0
+; RV32ZVE32F-NEXT:    .cfi_restore s1
 ; RV32ZVE32F-NEXT:    .cfi_restore s2
 ; RV32ZVE32F-NEXT:    .cfi_restore s3
 ; RV32ZVE32F-NEXT:    .cfi_restore s4

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-setcc-fp-vp.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-setcc-fp-vp.ll
@@ -1098,33 +1098,35 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ;
 ; ZVFHMIN32-LABEL: fcmp_oeq_vv_v128f16:
 ; ZVFHMIN32:       # %bb.0:
-; ZVFHMIN32-NEXT:    addi sp, sp, -896
-; ZVFHMIN32-NEXT:    .cfi_def_cfa_offset 896
-; ZVFHMIN32-NEXT:    sw ra, 892(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    sw s0, 888(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    sw s2, 884(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    sw s3, 880(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    sw s4, 876(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    sw s5, 872(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    sw s6, 868(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    sw s7, 864(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    sw s8, 860(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    sw s9, 856(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    sw s10, 852(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    sw s11, 848(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    addi sp, sp, -912
+; ZVFHMIN32-NEXT:    .cfi_def_cfa_offset 912
+; ZVFHMIN32-NEXT:    sw ra, 908(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s0, 904(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s1, 900(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s2, 896(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s3, 892(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s4, 888(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s5, 884(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s6, 880(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s7, 876(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s8, 872(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s9, 868(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s10, 864(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    sw s11, 860(sp) # 4-byte Folded Spill
 ; ZVFHMIN32-NEXT:    .cfi_offset ra, -4
 ; ZVFHMIN32-NEXT:    .cfi_offset s0, -8
-; ZVFHMIN32-NEXT:    .cfi_offset s2, -12
-; ZVFHMIN32-NEXT:    .cfi_offset s3, -16
-; ZVFHMIN32-NEXT:    .cfi_offset s4, -20
-; ZVFHMIN32-NEXT:    .cfi_offset s5, -24
-; ZVFHMIN32-NEXT:    .cfi_offset s6, -28
-; ZVFHMIN32-NEXT:    .cfi_offset s7, -32
-; ZVFHMIN32-NEXT:    .cfi_offset s8, -36
-; ZVFHMIN32-NEXT:    .cfi_offset s9, -40
-; ZVFHMIN32-NEXT:    .cfi_offset s10, -44
-; ZVFHMIN32-NEXT:    .cfi_offset s11, -48
-; ZVFHMIN32-NEXT:    addi s0, sp, 896
+; ZVFHMIN32-NEXT:    .cfi_offset s1, -12
+; ZVFHMIN32-NEXT:    .cfi_offset s2, -16
+; ZVFHMIN32-NEXT:    .cfi_offset s3, -20
+; ZVFHMIN32-NEXT:    .cfi_offset s4, -24
+; ZVFHMIN32-NEXT:    .cfi_offset s5, -28
+; ZVFHMIN32-NEXT:    .cfi_offset s6, -32
+; ZVFHMIN32-NEXT:    .cfi_offset s7, -36
+; ZVFHMIN32-NEXT:    .cfi_offset s8, -40
+; ZVFHMIN32-NEXT:    .cfi_offset s9, -44
+; ZVFHMIN32-NEXT:    .cfi_offset s10, -48
+; ZVFHMIN32-NEXT:    .cfi_offset s11, -52
+; ZVFHMIN32-NEXT:    addi s0, sp, 912
 ; ZVFHMIN32-NEXT:    .cfi_def_cfa s0, 0
 ; ZVFHMIN32-NEXT:    csrr a1, vlenb
 ; ZVFHMIN32-NEXT:    li a2, 29
@@ -1290,12 +1292,6 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    sb a0, 219(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 564(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 308(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN32-NEXT:    sb a0, 218(sp)
-; ZVFHMIN32-NEXT:    lh a0, 562(sp)
-; ZVFHMIN32-NEXT:    lh a1, 306(sp)
 ; ZVFHMIN32-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
 ; ZVFHMIN32-NEXT:    vslidedown.vi v10, v8, 7
 ; ZVFHMIN32-NEXT:    csrr a2, vlenb
@@ -1359,35 +1355,35 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    vslidedown.vi v26, v8, 10
 ; ZVFHMIN32-NEXT:    vslidedown.vi v22, v8, 9
 ; ZVFHMIN32-NEXT:    vslidedown.vi v20, v8, 8
-; ZVFHMIN32-NEXT:    vmv.x.s a4, v16
+; ZVFHMIN32-NEXT:    vmv.x.s t5, v16
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN32-NEXT:    sb a0, 217(sp)
-; ZVFHMIN32-NEXT:    lh a0, 560(sp)
-; ZVFHMIN32-NEXT:    lh a1, 304(sp)
+; ZVFHMIN32-NEXT:    sb a0, 218(sp)
+; ZVFHMIN32-NEXT:    lh a0, 562(sp)
+; ZVFHMIN32-NEXT:    lh a1, 306(sp)
 ; ZVFHMIN32-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
 ; ZVFHMIN32-NEXT:    vslidedown.vi v21, v16, 7
-; ZVFHMIN32-NEXT:    vslidedown.vi v23, v16, 6
-; ZVFHMIN32-NEXT:    vslidedown.vi v29, v16, 5
-; ZVFHMIN32-NEXT:    vslidedown.vi v31, v16, 4
-; ZVFHMIN32-NEXT:    vslidedown.vi v8, v16, 3
-; ZVFHMIN32-NEXT:    addi a2, sp, 848
-; ZVFHMIN32-NEXT:    vs1r.v v8, (a2) # vscale x 8-byte Folded Spill
-; ZVFHMIN32-NEXT:    vslidedown.vi v27, v16, 2
-; ZVFHMIN32-NEXT:    vslidedown.vi v8, v16, 1
+; ZVFHMIN32-NEXT:    vslidedown.vi v31, v16, 6
+; ZVFHMIN32-NEXT:    vslidedown.vi v23, v16, 5
+; ZVFHMIN32-NEXT:    vslidedown.vi v27, v16, 4
+; ZVFHMIN32-NEXT:    vslidedown.vi v29, v16, 3
+; ZVFHMIN32-NEXT:    vslidedown.vi v8, v16, 2
 ; ZVFHMIN32-NEXT:    csrr a2, vlenb
 ; ZVFHMIN32-NEXT:    li a3, 19
 ; ZVFHMIN32-NEXT:    mul a2, a2, a3
 ; ZVFHMIN32-NEXT:    add a2, sp, a2
 ; ZVFHMIN32-NEXT:    addi a2, a2, 848
 ; ZVFHMIN32-NEXT:    vs1r.v v8, (a2) # vscale x 8-byte Folded Spill
+; ZVFHMIN32-NEXT:    vslidedown.vi v8, v16, 1
+; ZVFHMIN32-NEXT:    addi a2, sp, 848
+; ZVFHMIN32-NEXT:    vs1r.v v8, (a2) # vscale x 8-byte Folded Spill
 ; ZVFHMIN32-NEXT:    vsetivli zero, 1, e16, m2, ta, ma
-; ZVFHMIN32-NEXT:    vslidedown.vi v14, v16, 15
-; ZVFHMIN32-NEXT:    vslidedown.vi v12, v16, 14
-; ZVFHMIN32-NEXT:    vslidedown.vi v8, v16, 13
-; ZVFHMIN32-NEXT:    vslidedown.vi v18, v16, 12
-; ZVFHMIN32-NEXT:    vslidedown.vi v10, v16, 11
+; ZVFHMIN32-NEXT:    vslidedown.vi v18, v16, 15
+; ZVFHMIN32-NEXT:    vslidedown.vi v14, v16, 14
+; ZVFHMIN32-NEXT:    vslidedown.vi v12, v16, 13
+; ZVFHMIN32-NEXT:    vslidedown.vi v10, v16, 12
+; ZVFHMIN32-NEXT:    vslidedown.vi v8, v16, 11
 ; ZVFHMIN32-NEXT:    vslidedown.vi v6, v16, 10
 ; ZVFHMIN32-NEXT:    csrr a2, vlenb
 ; ZVFHMIN32-NEXT:    li a3, 20
@@ -1412,17 +1408,17 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN32-NEXT:    sb a0, 216(sp)
-; ZVFHMIN32-NEXT:    lh a0, 558(sp)
-; ZVFHMIN32-NEXT:    lh a1, 302(sp)
+; ZVFHMIN32-NEXT:    sb a0, 217(sp)
+; ZVFHMIN32-NEXT:    lh a0, 560(sp)
+; ZVFHMIN32-NEXT:    lh a1, 304(sp)
 ; ZVFHMIN32-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; ZVFHMIN32-NEXT:    vslidedown.vi v9, v0, 7
-; ZVFHMIN32-NEXT:    vslidedown.vi v19, v0, 6
-; ZVFHMIN32-NEXT:    vslidedown.vi v3, v0, 5
-; ZVFHMIN32-NEXT:    vslidedown.vi v13, v0, 4
-; ZVFHMIN32-NEXT:    vslidedown.vi v15, v0, 3
-; ZVFHMIN32-NEXT:    vslidedown.vi v16, v0, 2
-; ZVFHMIN32-NEXT:    vslidedown.vi v11, v0, 1
+; ZVFHMIN32-NEXT:    vslidedown.vi v3, v0, 7
+; ZVFHMIN32-NEXT:    vslidedown.vi v9, v0, 6
+; ZVFHMIN32-NEXT:    vslidedown.vi v15, v0, 5
+; ZVFHMIN32-NEXT:    vslidedown.vi v19, v0, 4
+; ZVFHMIN32-NEXT:    vslidedown.vi v11, v0, 3
+; ZVFHMIN32-NEXT:    vslidedown.vi v13, v0, 2
+; ZVFHMIN32-NEXT:    vslidedown.vi v16, v0, 1
 ; ZVFHMIN32-NEXT:    vsetivli zero, 1, e16, m2, ta, ma
 ; ZVFHMIN32-NEXT:    vslidedown.vi v6, v0, 15
 ; ZVFHMIN32-NEXT:    csrr a2, vlenb
@@ -1472,9 +1468,9 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN32-NEXT:    sb a0, 215(sp)
-; ZVFHMIN32-NEXT:    lh a0, 556(sp)
-; ZVFHMIN32-NEXT:    lh a1, 300(sp)
+; ZVFHMIN32-NEXT:    sb a0, 216(sp)
+; ZVFHMIN32-NEXT:    lh a0, 558(sp)
+; ZVFHMIN32-NEXT:    lh a1, 302(sp)
 ; ZVFHMIN32-NEXT:    csrr a2, vlenb
 ; ZVFHMIN32-NEXT:    add a2, sp, a2
 ; ZVFHMIN32-NEXT:    addi a2, a2, 848
@@ -1484,65 +1480,81 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
+; ZVFHMIN32-NEXT:    sb a0, 215(sp)
+; ZVFHMIN32-NEXT:    lh a0, 556(sp)
+; ZVFHMIN32-NEXT:    lh a1, 300(sp)
+; ZVFHMIN32-NEXT:    vmv.x.s t1, v30
+; ZVFHMIN32-NEXT:    vmv.x.s t0, v28
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb a0, 214(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 554(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 298(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s t1, v30
-; ZVFHMIN32-NEXT:    vmv.x.s t0, v28
+; ZVFHMIN32-NEXT:    vmv.x.s a7, v26
+; ZVFHMIN32-NEXT:    vmv.x.s a6, v22
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb a0, 213(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 552(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 296(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s a7, v26
-; ZVFHMIN32-NEXT:    vmv.x.s a6, v22
+; ZVFHMIN32-NEXT:    vmv.x.s a5, v20
+; ZVFHMIN32-NEXT:    vmv.x.s a2, v18
+; ZVFHMIN32-NEXT:    sw a2, 108(sp) # 4-byte Folded Spill
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb a0, 212(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 550(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 294(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s a5, v20
 ; ZVFHMIN32-NEXT:    vmv.x.s a2, v14
 ; ZVFHMIN32-NEXT:    sw a2, 112(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    vmv.x.s a2, v12
+; ZVFHMIN32-NEXT:    sw a2, 116(sp) # 4-byte Folded Spill
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb a0, 211(sp)
-; ZVFHMIN32-NEXT:    lh a1, 548(sp)
-; ZVFHMIN32-NEXT:    lh t5, 292(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s a0, v12
-; ZVFHMIN32-NEXT:    sw a0, 116(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    vmv.x.s a0, v8
-; ZVFHMIN32-NEXT:    sw a0, 124(sp) # 4-byte Folded Spill
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, t5
-; ZVFHMIN32-NEXT:    feq.h a1, fa5, fa4
-; ZVFHMIN32-NEXT:    sb a1, 210(sp)
-; ZVFHMIN32-NEXT:    lh a1, 546(sp)
-; ZVFHMIN32-NEXT:    lh t5, 290(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, a4
-; ZVFHMIN32-NEXT:    vmv.x.s a4, v24
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, t5
-; ZVFHMIN32-NEXT:    feq.h a1, fa4, fa3
-; ZVFHMIN32-NEXT:    sb a1, 209(sp)
-; ZVFHMIN32-NEXT:    lh a1, 544(sp)
-; ZVFHMIN32-NEXT:    lh t5, 288(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a4
-; ZVFHMIN32-NEXT:    feq.h a4, fa5, fa4
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, t5
-; ZVFHMIN32-NEXT:    feq.h a1, fa5, fa4
-; ZVFHMIN32-NEXT:    sb a4, 192(sp)
-; ZVFHMIN32-NEXT:    sb a1, 208(sp)
-; ZVFHMIN32-NEXT:    lh t5, 738(sp)
-; ZVFHMIN32-NEXT:    lh t6, 482(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s a0, v18
-; ZVFHMIN32-NEXT:    sw a0, 108(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    lh t6, 548(sp)
+; ZVFHMIN32-NEXT:    lh s1, 292(sp)
 ; ZVFHMIN32-NEXT:    vmv.x.s a0, v10
 ; ZVFHMIN32-NEXT:    sw a0, 120(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    vmv.x.s a0, v8
+; ZVFHMIN32-NEXT:    sw a0, 124(sp) # 4-byte Folded Spill
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, t6
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s1
+; ZVFHMIN32-NEXT:    feq.h t6, fa5, fa4
+; ZVFHMIN32-NEXT:    sb t6, 210(sp)
+; ZVFHMIN32-NEXT:    lh t6, 546(sp)
+; ZVFHMIN32-NEXT:    lh s1, 290(sp)
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, t5
+; ZVFHMIN32-NEXT:    vmv.x.s t5, v24
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, t6
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, s1
+; ZVFHMIN32-NEXT:    feq.h t6, fa4, fa3
+; ZVFHMIN32-NEXT:    sb t6, 209(sp)
+; ZVFHMIN32-NEXT:    lh t6, 544(sp)
+; ZVFHMIN32-NEXT:    lh s1, 288(sp)
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, t5
+; ZVFHMIN32-NEXT:    feq.h t5, fa5, fa4
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, t6
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s1
+; ZVFHMIN32-NEXT:    feq.h t6, fa5, fa4
+; ZVFHMIN32-NEXT:    sb t5, 192(sp)
+; ZVFHMIN32-NEXT:    sb t6, 208(sp)
+; ZVFHMIN32-NEXT:    lh t5, 738(sp)
+; ZVFHMIN32-NEXT:    lh t6, 482(sp)
+; ZVFHMIN32-NEXT:    csrr a0, vlenb
+; ZVFHMIN32-NEXT:    li a1, 28
+; ZVFHMIN32-NEXT:    mul a0, a0, a1
+; ZVFHMIN32-NEXT:    add a0, sp, a0
+; ZVFHMIN32-NEXT:    lh s7, 848(a0) # 8-byte Folded Reload
+; ZVFHMIN32-NEXT:    csrr a0, vlenb
+; ZVFHMIN32-NEXT:    li a1, 27
+; ZVFHMIN32-NEXT:    mul a0, a0, a1
+; ZVFHMIN32-NEXT:    add a0, sp, a0
+; ZVFHMIN32-NEXT:    lh s5, 848(a0) # 8-byte Folded Reload
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, t5
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, t6
 ; ZVFHMIN32-NEXT:    feq.h t5, fa5, fa4
@@ -1550,12 +1562,12 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    lh t5, 736(sp)
 ; ZVFHMIN32-NEXT:    lh t6, 480(sp)
 ; ZVFHMIN32-NEXT:    csrr a0, vlenb
-; ZVFHMIN32-NEXT:    li a1, 28
+; ZVFHMIN32-NEXT:    li a1, 26
 ; ZVFHMIN32-NEXT:    mul a0, a0, a1
 ; ZVFHMIN32-NEXT:    add a0, sp, a0
-; ZVFHMIN32-NEXT:    lh s5, 848(a0) # 8-byte Folded Reload
+; ZVFHMIN32-NEXT:    lh s8, 848(a0) # 8-byte Folded Reload
 ; ZVFHMIN32-NEXT:    csrr a0, vlenb
-; ZVFHMIN32-NEXT:    li a1, 27
+; ZVFHMIN32-NEXT:    li a1, 25
 ; ZVFHMIN32-NEXT:    mul a0, a0, a1
 ; ZVFHMIN32-NEXT:    add a0, sp, a0
 ; ZVFHMIN32-NEXT:    lh s6, 848(a0) # 8-byte Folded Reload
@@ -1565,22 +1577,6 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    sb t5, 176(sp)
 ; ZVFHMIN32-NEXT:    lh t5, 734(sp)
 ; ZVFHMIN32-NEXT:    lh t6, 478(sp)
-; ZVFHMIN32-NEXT:    csrr a0, vlenb
-; ZVFHMIN32-NEXT:    li a1, 26
-; ZVFHMIN32-NEXT:    mul a0, a0, a1
-; ZVFHMIN32-NEXT:    add a0, sp, a0
-; ZVFHMIN32-NEXT:    lh s7, 848(a0) # 8-byte Folded Reload
-; ZVFHMIN32-NEXT:    csrr a0, vlenb
-; ZVFHMIN32-NEXT:    li a1, 25
-; ZVFHMIN32-NEXT:    mul a0, a0, a1
-; ZVFHMIN32-NEXT:    add a0, sp, a0
-; ZVFHMIN32-NEXT:    lh s8, 848(a0) # 8-byte Folded Reload
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, t5
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, t6
-; ZVFHMIN32-NEXT:    feq.h t5, fa5, fa4
-; ZVFHMIN32-NEXT:    sb t5, 175(sp)
-; ZVFHMIN32-NEXT:    lh t5, 732(sp)
-; ZVFHMIN32-NEXT:    lh t6, 476(sp)
 ; ZVFHMIN32-NEXT:    csrr a0, vlenb
 ; ZVFHMIN32-NEXT:    li a1, 24
 ; ZVFHMIN32-NEXT:    mul a0, a0, a1
@@ -1594,22 +1590,30 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, t5
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, t6
 ; ZVFHMIN32-NEXT:    feq.h t5, fa5, fa4
-; ZVFHMIN32-NEXT:    sb t5, 174(sp)
-; ZVFHMIN32-NEXT:    lh t6, 730(sp)
-; ZVFHMIN32-NEXT:    lh s9, 474(sp)
+; ZVFHMIN32-NEXT:    sb t5, 175(sp)
+; ZVFHMIN32-NEXT:    lh t5, 732(sp)
+; ZVFHMIN32-NEXT:    lh t6, 476(sp)
 ; ZVFHMIN32-NEXT:    csrr a0, vlenb
 ; ZVFHMIN32-NEXT:    li a1, 22
 ; ZVFHMIN32-NEXT:    mul a0, a0, a1
 ; ZVFHMIN32-NEXT:    add a0, sp, a0
 ; ZVFHMIN32-NEXT:    lh s2, 848(a0) # 8-byte Folded Reload
-; ZVFHMIN32-NEXT:    vmv.x.s t5, v21
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, t6
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, s9
-; ZVFHMIN32-NEXT:    feq.h t6, fa5, fa4
-; ZVFHMIN32-NEXT:    sb t6, 173(sp)
+; ZVFHMIN32-NEXT:    vmv.x.s s1, v21
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, t5
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, t6
+; ZVFHMIN32-NEXT:    feq.h t5, fa5, fa4
+; ZVFHMIN32-NEXT:    sb t5, 174(sp)
+; ZVFHMIN32-NEXT:    lh s9, 730(sp)
+; ZVFHMIN32-NEXT:    lh s10, 474(sp)
+; ZVFHMIN32-NEXT:    vmv.x.s t6, v31
+; ZVFHMIN32-NEXT:    vmv.x.s t5, v23
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, s9
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s10
+; ZVFHMIN32-NEXT:    feq.h s9, fa5, fa4
+; ZVFHMIN32-NEXT:    sb s9, 173(sp)
 ; ZVFHMIN32-NEXT:    lh s9, 728(sp)
 ; ZVFHMIN32-NEXT:    lh s10, 472(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s t6, v23
+; ZVFHMIN32-NEXT:    vmv.x.s s11, v3
 ; ZVFHMIN32-NEXT:    vmv.x.s ra, v9
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, s9
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, s10
@@ -1617,257 +1621,255 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    sb s9, 172(sp)
 ; ZVFHMIN32-NEXT:    lh s9, 726(sp)
 ; ZVFHMIN32-NEXT:    lh s10, 470(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s a2, v19
-; ZVFHMIN32-NEXT:    vmv.x.s a3, v3
+; ZVFHMIN32-NEXT:    vmv.x.s a2, v15
+; ZVFHMIN32-NEXT:    vmv.x.s a3, v19
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, s9
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, s10
 ; ZVFHMIN32-NEXT:    feq.h s9, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb s9, 171(sp)
-; ZVFHMIN32-NEXT:    lh s10, 724(sp)
-; ZVFHMIN32-NEXT:    lh s11, 468(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s a4, v13
-; ZVFHMIN32-NEXT:    vmv.x.s s9, v15
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, s10
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, s11
-; ZVFHMIN32-NEXT:    feq.h s10, fa5, fa4
-; ZVFHMIN32-NEXT:    sb s10, 170(sp)
+; ZVFHMIN32-NEXT:    lh s9, 724(sp)
+; ZVFHMIN32-NEXT:    lh a0, 468(sp)
+; ZVFHMIN32-NEXT:    vmv.x.s a4, v11
+; ZVFHMIN32-NEXT:    vmv.x.s s10, v13
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, s9
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
+; ZVFHMIN32-NEXT:    sb a0, 170(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 722(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 466(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s s10, v16
-; ZVFHMIN32-NEXT:    vmv.x.s s11, v11
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
+; ZVFHMIN32-NEXT:    vmv.x.s s9, v16
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, s7
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN32-NEXT:    sb a0, 169(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 720(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 464(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, s5
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, s6
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN32-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s5
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, s8
+; ZVFHMIN32-NEXT:    fmv.h.x fa2, a0
+; ZVFHMIN32-NEXT:    fmv.h.x fa1, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa2, fa1
 ; ZVFHMIN32-NEXT:    sb a0, 168(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 718(sp)
+; ZVFHMIN32-NEXT:    fmv.h.x fa2, s6
 ; ZVFHMIN32-NEXT:    lh a1, 462(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, s7
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, s8
-; ZVFHMIN32-NEXT:    fmv.h.x fa1, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa0, a1
-; ZVFHMIN32-NEXT:    feq.h a0, fa1, fa0
-; ZVFHMIN32-NEXT:    fmv.h.x fa1, ra
+; ZVFHMIN32-NEXT:    fmv.h.x fa1, s11
+; ZVFHMIN32-NEXT:    fmv.h.x fa0, a0
+; ZVFHMIN32-NEXT:    feq.h s5, fa5, fa1
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa0, fa5
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, ra
 ; ZVFHMIN32-NEXT:    sb a0, 167(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 716(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa0, a2
+; ZVFHMIN32-NEXT:    fmv.h.x fa1, a2
 ; ZVFHMIN32-NEXT:    lh a1, 460(sp)
-; ZVFHMIN32-NEXT:    feq.h s5, fa5, fa1
+; ZVFHMIN32-NEXT:    feq.h a2, fa4, fa5
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN32-NEXT:    feq.h a0, fa4, fa0
+; ZVFHMIN32-NEXT:    feq.h a0, fa3, fa1
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a1, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, s4
 ; ZVFHMIN32-NEXT:    sb a1, 166(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 714(sp)
-; ZVFHMIN32-NEXT:    lh a2, 458(sp)
+; ZVFHMIN32-NEXT:    lh s4, 458(sp)
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a3
-; ZVFHMIN32-NEXT:    feq.h a3, fa3, fa4
+; ZVFHMIN32-NEXT:    feq.h a3, fa2, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, a2
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, s4
 ; ZVFHMIN32-NEXT:    feq.h a1, fa4, fa3
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, s3
 ; ZVFHMIN32-NEXT:    sb a1, 165(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 712(sp)
-; ZVFHMIN32-NEXT:    lh a2, 456(sp)
+; ZVFHMIN32-NEXT:    lh s3, 456(sp)
 ; ZVFHMIN32-NEXT:    fmv.h.x fa3, a4
-; ZVFHMIN32-NEXT:    feq.h a4, fa2, fa3
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, a1
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, a2
-; ZVFHMIN32-NEXT:    feq.h a1, fa3, fa2
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, s2
+; ZVFHMIN32-NEXT:    feq.h a4, fa5, fa3
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, s3
+; ZVFHMIN32-NEXT:    feq.h a1, fa5, fa3
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, s2
 ; ZVFHMIN32-NEXT:    sb a1, 164(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 710(sp)
-; ZVFHMIN32-NEXT:    lh a2, 454(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, s9
-; ZVFHMIN32-NEXT:    feq.h s2, fa5, fa2
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, a2
-; ZVFHMIN32-NEXT:    feq.h a1, fa5, fa2
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, s10
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, s11
+; ZVFHMIN32-NEXT:    lh s2, 454(sp)
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, s10
+; ZVFHMIN32-NEXT:    feq.h s3, fa4, fa3
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, s2
+; ZVFHMIN32-NEXT:    feq.h a1, fa4, fa3
 ; ZVFHMIN32-NEXT:    sb a1, 163(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 708(sp)
-; ZVFHMIN32-NEXT:    lh a2, 452(sp)
-; ZVFHMIN32-NEXT:    feq.h s3, fa4, fa5
-; ZVFHMIN32-NEXT:    feq.h s4, fa3, fa2
+; ZVFHMIN32-NEXT:    lh s2, 452(sp)
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s9
+; ZVFHMIN32-NEXT:    feq.h s4, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s2
 ; ZVFHMIN32-NEXT:    feq.h a1, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb a1, 162(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 706(sp)
-; ZVFHMIN32-NEXT:    lh a2, 450(sp)
+; ZVFHMIN32-NEXT:    lh s2, 450(sp)
 ; ZVFHMIN32-NEXT:    sb s4, 129(sp)
 ; ZVFHMIN32-NEXT:    sb s3, 130(sp)
-; ZVFHMIN32-NEXT:    sb s2, 131(sp)
-; ZVFHMIN32-NEXT:    sb a4, 132(sp)
+; ZVFHMIN32-NEXT:    sb a4, 131(sp)
+; ZVFHMIN32-NEXT:    sb a3, 132(sp)
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s2
 ; ZVFHMIN32-NEXT:    feq.h a1, fa5, fa4
-; ZVFHMIN32-NEXT:    sb a3, 133(sp)
-; ZVFHMIN32-NEXT:    sb a0, 134(sp)
+; ZVFHMIN32-NEXT:    sb a0, 133(sp)
+; ZVFHMIN32-NEXT:    sb a2, 134(sp)
 ; ZVFHMIN32-NEXT:    sb s5, 135(sp)
 ; ZVFHMIN32-NEXT:    sb a1, 161(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 610(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 354(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s s6, v29
-; ZVFHMIN32-NEXT:    vmv.x.s s5, v31
+; ZVFHMIN32-NEXT:    vmv.x.s s5, v27
+; ZVFHMIN32-NEXT:    vmv.x.s s4, v29
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb a0, 241(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 608(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 352(sp)
-; ZVFHMIN32-NEXT:    lh s4, 848(sp) # 8-byte Folded Reload
-; ZVFHMIN32-NEXT:    vmv.x.s s3, v27
+; ZVFHMIN32-NEXT:    csrr a2, vlenb
+; ZVFHMIN32-NEXT:    li a3, 19
+; ZVFHMIN32-NEXT:    mul a2, a2, a3
+; ZVFHMIN32-NEXT:    add a2, sp, a2
+; ZVFHMIN32-NEXT:    lh s3, 848(a2) # 8-byte Folded Reload
+; ZVFHMIN32-NEXT:    lh s2, 848(sp) # 8-byte Folded Reload
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb a0, 240(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 606(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 350(sp)
-; ZVFHMIN32-NEXT:    csrr a2, vlenb
-; ZVFHMIN32-NEXT:    li a3, 19
-; ZVFHMIN32-NEXT:    mul a2, a2, a3
-; ZVFHMIN32-NEXT:    add a2, sp, a2
-; ZVFHMIN32-NEXT:    lh s2, 848(a2) # 8-byte Folded Reload
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, t5
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, s1
+; ZVFHMIN32-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 7
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa3, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN32-NEXT:    sb a0, 239(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 604(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 348(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, t6
-; ZVFHMIN32-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 7
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN32-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN32-NEXT:    vmv.x.s a2, v8
+; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 6
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN32-NEXT:    sb a0, 238(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 602(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 346(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s a2, v8
-; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 6
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN32-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN32-NEXT:    vmv.x.s a3, v8
+; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 5
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN32-NEXT:    sb a0, 237(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 600(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 344(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s a3, v8
-; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 5
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN32-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN32-NEXT:    vmv.x.s a4, v8
+; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 4
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN32-NEXT:    sb a0, 236(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 598(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 342(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s a4, v8
-; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 4
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN32-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN32-NEXT:    vmv.x.s s6, v8
+; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 3
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN32-NEXT:    sb a0, 235(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 596(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 340(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s s8, v8
-; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 3
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN32-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN32-NEXT:    vmv.x.s s7, v8
+; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 2
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN32-NEXT:    sb a0, 234(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 594(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 338(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s s9, v8
-; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 2
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN32-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN32-NEXT:    vmv.x.s s8, v8
+; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 1
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN32-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN32-NEXT:    sb a0, 233(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 592(sp)
-; ZVFHMIN32-NEXT:    vmv.x.s a1, v8
-; ZVFHMIN32-NEXT:    lh t5, 336(sp)
-; ZVFHMIN32-NEXT:    vslidedown.vi v8, v24, 1
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN32-NEXT:    lh a1, 336(sp)
+; ZVFHMIN32-NEXT:    vmv.x.s a2, v8
 ; ZVFHMIN32-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN32-NEXT:    vmv.x.s s7, v8
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, t5
-; ZVFHMIN32-NEXT:    feq.h a0, fa3, fa2
-; ZVFHMIN32-NEXT:    fmv.h.x fa3, a2
+; ZVFHMIN32-NEXT:    feq.h s1, fa5, fa4
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa3, fa5
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, t6
 ; ZVFHMIN32-NEXT:    sb a0, 232(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 590(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa2, a3
-; ZVFHMIN32-NEXT:    lh a2, 334(sp)
-; ZVFHMIN32-NEXT:    feq.h t5, fa5, fa3
+; ZVFHMIN32-NEXT:    lh a1, 334(sp)
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a3
+; ZVFHMIN32-NEXT:    feq.h t6, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN32-NEXT:    feq.h t6, fa4, fa2
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, s6
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, t5
 ; ZVFHMIN32-NEXT:    sb a0, 231(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 588(sp)
-; ZVFHMIN32-NEXT:    lh a2, 332(sp)
+; ZVFHMIN32-NEXT:    lh a1, 332(sp)
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a4
 ; ZVFHMIN32-NEXT:    feq.h a3, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, s5
 ; ZVFHMIN32-NEXT:    sb a0, 230(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 586(sp)
-; ZVFHMIN32-NEXT:    lh a2, 330(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, s8
+; ZVFHMIN32-NEXT:    lh a1, 330(sp)
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s6
 ; ZVFHMIN32-NEXT:    feq.h a4, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, s4
 ; ZVFHMIN32-NEXT:    sb a0, 229(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 584(sp)
-; ZVFHMIN32-NEXT:    lh a2, 328(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, s9
-; ZVFHMIN32-NEXT:    feq.h s4, fa5, fa4
+; ZVFHMIN32-NEXT:    lh a1, 328(sp)
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s7
+; ZVFHMIN32-NEXT:    feq.h t5, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, s3
 ; ZVFHMIN32-NEXT:    sb a0, 228(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 582(sp)
-; ZVFHMIN32-NEXT:    lh a2, 326(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN32-NEXT:    feq.h a1, fa5, fa4
+; ZVFHMIN32-NEXT:    lh a1, 326(sp)
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s8
+; ZVFHMIN32-NEXT:    feq.h s3, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, s2
 ; ZVFHMIN32-NEXT:    sb a0, 227(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 580(sp)
-; ZVFHMIN32-NEXT:    lh a2, 324(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, s7
-; ZVFHMIN32-NEXT:    feq.h s2, fa5, fa4
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
+; ZVFHMIN32-NEXT:    lh a1, 324(sp)
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN32-NEXT:    feq.h a2, fa5, fa4
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb a0, 226(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 578(sp)
-; ZVFHMIN32-NEXT:    lh a2, 322(sp)
-; ZVFHMIN32-NEXT:    sb s2, 193(sp)
-; ZVFHMIN32-NEXT:    sb a1, 194(sp)
-; ZVFHMIN32-NEXT:    sb s4, 195(sp)
+; ZVFHMIN32-NEXT:    lh a1, 322(sp)
+; ZVFHMIN32-NEXT:    sb a2, 193(sp)
+; ZVFHMIN32-NEXT:    sb s3, 194(sp)
+; ZVFHMIN32-NEXT:    sb t5, 195(sp)
 ; ZVFHMIN32-NEXT:    sb a4, 196(sp)
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb a3, 197(sp)
 ; ZVFHMIN32-NEXT:    sb t6, 198(sp)
-; ZVFHMIN32-NEXT:    sb t5, 199(sp)
+; ZVFHMIN32-NEXT:    sb s1, 199(sp)
 ; ZVFHMIN32-NEXT:    sb a0, 225(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 766(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 510(sp)
@@ -1877,7 +1879,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    add a2, sp, a2
 ; ZVFHMIN32-NEXT:    addi a2, a2, 848
 ; ZVFHMIN32-NEXT:    vl2r.v v8, (a2) # vscale x 16-byte Folded Reload
-; ZVFHMIN32-NEXT:    vmv.x.s s2, v8
+; ZVFHMIN32-NEXT:    vmv.x.s s1, v8
 ; ZVFHMIN32-NEXT:    csrr a2, vlenb
 ; ZVFHMIN32-NEXT:    slli a3, a2, 4
 ; ZVFHMIN32-NEXT:    sub a2, a3, a2
@@ -1919,8 +1921,8 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    vl2r.v v8, (a3) # vscale x 16-byte Folded Reload
 ; ZVFHMIN32-NEXT:    vmv.x.s a3, v8
 ; ZVFHMIN32-NEXT:    csrr a4, vlenb
-; ZVFHMIN32-NEXT:    slli s3, a4, 2
-; ZVFHMIN32-NEXT:    add a4, s3, a4
+; ZVFHMIN32-NEXT:    slli s2, a4, 2
+; ZVFHMIN32-NEXT:    add a4, s2, a4
 ; ZVFHMIN32-NEXT:    add a4, sp, a4
 ; ZVFHMIN32-NEXT:    addi a4, a4, 848
 ; ZVFHMIN32-NEXT:    vl2r.v v8, (a4) # vscale x 16-byte Folded Reload
@@ -1931,34 +1933,34 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    sb a0, 189(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 760(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 504(sp)
-; ZVFHMIN32-NEXT:    csrr s3, vlenb
-; ZVFHMIN32-NEXT:    li s4, 11
-; ZVFHMIN32-NEXT:    mul s3, s3, s4
-; ZVFHMIN32-NEXT:    add s3, sp, s3
-; ZVFHMIN32-NEXT:    addi s3, s3, 848
-; ZVFHMIN32-NEXT:    vl2r.v v8, (s3) # vscale x 16-byte Folded Reload
-; ZVFHMIN32-NEXT:    vmv.x.s s6, v8
-; ZVFHMIN32-NEXT:    csrr s3, vlenb
-; ZVFHMIN32-NEXT:    slli s4, s3, 3
-; ZVFHMIN32-NEXT:    add s3, s4, s3
-; ZVFHMIN32-NEXT:    add s3, sp, s3
-; ZVFHMIN32-NEXT:    addi s3, s3, 848
-; ZVFHMIN32-NEXT:    vl2r.v v8, (s3) # vscale x 16-byte Folded Reload
-; ZVFHMIN32-NEXT:    vmv.x.s s4, v8
+; ZVFHMIN32-NEXT:    csrr s2, vlenb
+; ZVFHMIN32-NEXT:    li s3, 11
+; ZVFHMIN32-NEXT:    mul s2, s2, s3
+; ZVFHMIN32-NEXT:    add s2, sp, s2
+; ZVFHMIN32-NEXT:    addi s2, s2, 848
+; ZVFHMIN32-NEXT:    vl2r.v v8, (s2) # vscale x 16-byte Folded Reload
+; ZVFHMIN32-NEXT:    vmv.x.s s5, v8
+; ZVFHMIN32-NEXT:    csrr s2, vlenb
+; ZVFHMIN32-NEXT:    slli s3, s2, 3
+; ZVFHMIN32-NEXT:    add s2, s3, s2
+; ZVFHMIN32-NEXT:    add s2, sp, s2
+; ZVFHMIN32-NEXT:    addi s2, s2, 848
+; ZVFHMIN32-NEXT:    vl2r.v v8, (s2) # vscale x 16-byte Folded Reload
+; ZVFHMIN32-NEXT:    vmv.x.s s3, v8
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb a0, 188(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 758(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 502(sp)
-; ZVFHMIN32-NEXT:    csrr s3, vlenb
-; ZVFHMIN32-NEXT:    slli s5, s3, 4
-; ZVFHMIN32-NEXT:    add s3, s5, s3
-; ZVFHMIN32-NEXT:    add s3, sp, s3
-; ZVFHMIN32-NEXT:    addi s3, s3, 848
-; ZVFHMIN32-NEXT:    vl2r.v v8, (s3) # vscale x 16-byte Folded Reload
-; ZVFHMIN32-NEXT:    vmv.x.s s5, v8
-; ZVFHMIN32-NEXT:    vmv.x.s s3, v6
+; ZVFHMIN32-NEXT:    csrr s2, vlenb
+; ZVFHMIN32-NEXT:    slli s4, s2, 4
+; ZVFHMIN32-NEXT:    add s2, s4, s2
+; ZVFHMIN32-NEXT:    add s2, sp, s2
+; ZVFHMIN32-NEXT:    addi s2, s2, 848
+; ZVFHMIN32-NEXT:    vl2r.v v8, (s2) # vscale x 16-byte Folded Reload
+; ZVFHMIN32-NEXT:    vmv.x.s s4, v8
+; ZVFHMIN32-NEXT:    vmv.x.s s2, v6
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
@@ -1993,7 +1995,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    sb a0, 184(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 750(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 494(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, s6
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s5
 ; ZVFHMIN32-NEXT:    feq.h a2, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
@@ -2002,7 +2004,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    sb a0, 183(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 748(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 492(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, s4
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s3
 ; ZVFHMIN32-NEXT:    feq.h a3, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
@@ -2011,7 +2013,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    sb a0, 182(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 746(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 490(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, s5
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s4
 ; ZVFHMIN32-NEXT:    feq.h a4, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
@@ -2020,7 +2022,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    sb a0, 181(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 744(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 488(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, s3
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, s2
 ; ZVFHMIN32-NEXT:    feq.h a6, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
@@ -2100,37 +2102,37 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN32-NEXT:    lw a1, 112(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw a1, 108(sp) # 4-byte Folded Reload
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
 ; ZVFHMIN32-NEXT:    sb a0, 250(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 626(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 370(sp)
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a5
+; ZVFHMIN32-NEXT:    feq.h a4, fa5, fa4
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
+; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
+; ZVFHMIN32-NEXT:    lw a1, 112(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
+; ZVFHMIN32-NEXT:    sb a0, 249(sp)
+; ZVFHMIN32-NEXT:    lh a0, 624(sp)
+; ZVFHMIN32-NEXT:    lh a1, 368(sp)
+; ZVFHMIN32-NEXT:    fmv.h.x fa4, t3
 ; ZVFHMIN32-NEXT:    feq.h a3, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN32-NEXT:    lw a1, 116(sp) # 4-byte Folded Reload
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN32-NEXT:    sb a0, 249(sp)
-; ZVFHMIN32-NEXT:    lh a0, 624(sp)
-; ZVFHMIN32-NEXT:    lh a1, 368(sp)
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, t3
-; ZVFHMIN32-NEXT:    feq.h a2, fa5, fa4
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN32-NEXT:    lw a1, 124(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
 ; ZVFHMIN32-NEXT:    sb a0, 248(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 622(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 366(sp)
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, t2
-; ZVFHMIN32-NEXT:    feq.h a4, fa5, fa4
+; ZVFHMIN32-NEXT:    feq.h a2, fa5, fa4
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN32-NEXT:    lw a1, 108(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw a1, 120(sp) # 4-byte Folded Reload
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
 ; ZVFHMIN32-NEXT:    sb a0, 247(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 620(sp)
@@ -2140,7 +2142,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN32-NEXT:    lw a1, 120(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw a1, 124(sp) # 4-byte Folded Reload
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a1
 ; ZVFHMIN32-NEXT:    sb a0, 246(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 618(sp)
@@ -2150,7 +2152,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN32-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN32-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN32-NEXT:    fmv.h.x fa5, s2
+; ZVFHMIN32-NEXT:    fmv.h.x fa5, s1
 ; ZVFHMIN32-NEXT:    sb a0, 245(sp)
 ; ZVFHMIN32-NEXT:    lh a0, 616(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 360(sp)
@@ -2176,9 +2178,9 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    lh a0, 612(sp)
 ; ZVFHMIN32-NEXT:    lh a1, 356(sp)
 ; ZVFHMIN32-NEXT:    sb a5, 204(sp)
-; ZVFHMIN32-NEXT:    sb a4, 205(sp)
-; ZVFHMIN32-NEXT:    sb a2, 206(sp)
-; ZVFHMIN32-NEXT:    sb a3, 207(sp)
+; ZVFHMIN32-NEXT:    sb a2, 205(sp)
+; ZVFHMIN32-NEXT:    sb a3, 206(sp)
+; ZVFHMIN32-NEXT:    sb a4, 207(sp)
 ; ZVFHMIN32-NEXT:    feq.h a2, fa5, fa4
 ; ZVFHMIN32-NEXT:    sb a2, 200(sp)
 ; ZVFHMIN32-NEXT:    sb a6, 201(sp)
@@ -2194,22 +2196,24 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    vle8.v v8, (a0)
 ; ZVFHMIN32-NEXT:    vand.vi v8, v8, 1
 ; ZVFHMIN32-NEXT:    vmsne.vi v0, v8, 0
-; ZVFHMIN32-NEXT:    addi sp, s0, -896
-; ZVFHMIN32-NEXT:    .cfi_def_cfa sp, 896
-; ZVFHMIN32-NEXT:    lw ra, 892(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    lw s0, 888(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    lw s2, 884(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    lw s3, 880(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    lw s4, 876(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    lw s5, 872(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    lw s6, 868(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    lw s7, 864(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    lw s8, 860(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    lw s9, 856(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    lw s10, 852(sp) # 4-byte Folded Reload
-; ZVFHMIN32-NEXT:    lw s11, 848(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    addi sp, s0, -912
+; ZVFHMIN32-NEXT:    .cfi_def_cfa sp, 912
+; ZVFHMIN32-NEXT:    lw ra, 908(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s0, 904(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s1, 900(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s2, 896(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s3, 892(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s4, 888(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s5, 884(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s6, 880(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s7, 876(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s8, 872(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s9, 868(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s10, 864(sp) # 4-byte Folded Reload
+; ZVFHMIN32-NEXT:    lw s11, 860(sp) # 4-byte Folded Reload
 ; ZVFHMIN32-NEXT:    .cfi_restore ra
 ; ZVFHMIN32-NEXT:    .cfi_restore s0
+; ZVFHMIN32-NEXT:    .cfi_restore s1
 ; ZVFHMIN32-NEXT:    .cfi_restore s2
 ; ZVFHMIN32-NEXT:    .cfi_restore s3
 ; ZVFHMIN32-NEXT:    .cfi_restore s4
@@ -2220,39 +2224,41 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN32-NEXT:    .cfi_restore s9
 ; ZVFHMIN32-NEXT:    .cfi_restore s10
 ; ZVFHMIN32-NEXT:    .cfi_restore s11
-; ZVFHMIN32-NEXT:    addi sp, sp, 896
+; ZVFHMIN32-NEXT:    addi sp, sp, 912
 ; ZVFHMIN32-NEXT:    .cfi_def_cfa_offset 0
 ; ZVFHMIN32-NEXT:    ret
 ;
 ; ZVFHMIN64-LABEL: fcmp_oeq_vv_v128f16:
 ; ZVFHMIN64:       # %bb.0:
-; ZVFHMIN64-NEXT:    addi sp, sp, -896
-; ZVFHMIN64-NEXT:    .cfi_def_cfa_offset 896
-; ZVFHMIN64-NEXT:    sd ra, 888(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    sd s0, 880(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    sd s2, 872(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    sd s3, 864(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    sd s4, 856(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    sd s5, 848(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    sd s6, 840(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    sd s7, 832(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    sd s8, 824(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    sd s9, 816(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    sd s10, 808(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    sd s11, 800(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    addi sp, sp, -912
+; ZVFHMIN64-NEXT:    .cfi_def_cfa_offset 912
+; ZVFHMIN64-NEXT:    sd ra, 904(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s0, 896(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s1, 888(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s2, 880(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s3, 872(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s4, 864(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s5, 856(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s6, 848(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s7, 840(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s8, 832(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s9, 824(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s10, 816(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    sd s11, 808(sp) # 8-byte Folded Spill
 ; ZVFHMIN64-NEXT:    .cfi_offset ra, -8
 ; ZVFHMIN64-NEXT:    .cfi_offset s0, -16
-; ZVFHMIN64-NEXT:    .cfi_offset s2, -24
-; ZVFHMIN64-NEXT:    .cfi_offset s3, -32
-; ZVFHMIN64-NEXT:    .cfi_offset s4, -40
-; ZVFHMIN64-NEXT:    .cfi_offset s5, -48
-; ZVFHMIN64-NEXT:    .cfi_offset s6, -56
-; ZVFHMIN64-NEXT:    .cfi_offset s7, -64
-; ZVFHMIN64-NEXT:    .cfi_offset s8, -72
-; ZVFHMIN64-NEXT:    .cfi_offset s9, -80
-; ZVFHMIN64-NEXT:    .cfi_offset s10, -88
-; ZVFHMIN64-NEXT:    .cfi_offset s11, -96
-; ZVFHMIN64-NEXT:    addi s0, sp, 896
+; ZVFHMIN64-NEXT:    .cfi_offset s1, -24
+; ZVFHMIN64-NEXT:    .cfi_offset s2, -32
+; ZVFHMIN64-NEXT:    .cfi_offset s3, -40
+; ZVFHMIN64-NEXT:    .cfi_offset s4, -48
+; ZVFHMIN64-NEXT:    .cfi_offset s5, -56
+; ZVFHMIN64-NEXT:    .cfi_offset s6, -64
+; ZVFHMIN64-NEXT:    .cfi_offset s7, -72
+; ZVFHMIN64-NEXT:    .cfi_offset s8, -80
+; ZVFHMIN64-NEXT:    .cfi_offset s9, -88
+; ZVFHMIN64-NEXT:    .cfi_offset s10, -96
+; ZVFHMIN64-NEXT:    .cfi_offset s11, -104
+; ZVFHMIN64-NEXT:    addi s0, sp, 912
 ; ZVFHMIN64-NEXT:    .cfi_def_cfa s0, 0
 ; ZVFHMIN64-NEXT:    csrr a1, vlenb
 ; ZVFHMIN64-NEXT:    li a2, 29
@@ -2418,12 +2424,6 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    sb a0, 219(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 564(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 308(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN64-NEXT:    sb a0, 218(sp)
-; ZVFHMIN64-NEXT:    lh a0, 562(sp)
-; ZVFHMIN64-NEXT:    lh a1, 306(sp)
 ; ZVFHMIN64-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
 ; ZVFHMIN64-NEXT:    vslidedown.vi v10, v8, 7
 ; ZVFHMIN64-NEXT:    csrr a2, vlenb
@@ -2487,35 +2487,35 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    vslidedown.vi v26, v8, 10
 ; ZVFHMIN64-NEXT:    vslidedown.vi v22, v8, 9
 ; ZVFHMIN64-NEXT:    vslidedown.vi v20, v8, 8
-; ZVFHMIN64-NEXT:    vmv.x.s a4, v16
+; ZVFHMIN64-NEXT:    vmv.x.s t5, v16
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN64-NEXT:    sb a0, 217(sp)
-; ZVFHMIN64-NEXT:    lh a0, 560(sp)
-; ZVFHMIN64-NEXT:    lh a1, 304(sp)
+; ZVFHMIN64-NEXT:    sb a0, 218(sp)
+; ZVFHMIN64-NEXT:    lh a0, 562(sp)
+; ZVFHMIN64-NEXT:    lh a1, 306(sp)
 ; ZVFHMIN64-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
 ; ZVFHMIN64-NEXT:    vslidedown.vi v21, v16, 7
-; ZVFHMIN64-NEXT:    vslidedown.vi v23, v16, 6
-; ZVFHMIN64-NEXT:    vslidedown.vi v29, v16, 5
-; ZVFHMIN64-NEXT:    vslidedown.vi v31, v16, 4
-; ZVFHMIN64-NEXT:    vslidedown.vi v8, v16, 3
-; ZVFHMIN64-NEXT:    addi a2, sp, 800
-; ZVFHMIN64-NEXT:    vs1r.v v8, (a2) # vscale x 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    vslidedown.vi v27, v16, 2
-; ZVFHMIN64-NEXT:    vslidedown.vi v8, v16, 1
+; ZVFHMIN64-NEXT:    vslidedown.vi v31, v16, 6
+; ZVFHMIN64-NEXT:    vslidedown.vi v23, v16, 5
+; ZVFHMIN64-NEXT:    vslidedown.vi v27, v16, 4
+; ZVFHMIN64-NEXT:    vslidedown.vi v29, v16, 3
+; ZVFHMIN64-NEXT:    vslidedown.vi v8, v16, 2
 ; ZVFHMIN64-NEXT:    csrr a2, vlenb
 ; ZVFHMIN64-NEXT:    li a3, 19
 ; ZVFHMIN64-NEXT:    mul a2, a2, a3
 ; ZVFHMIN64-NEXT:    add a2, sp, a2
 ; ZVFHMIN64-NEXT:    addi a2, a2, 800
 ; ZVFHMIN64-NEXT:    vs1r.v v8, (a2) # vscale x 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    vslidedown.vi v8, v16, 1
+; ZVFHMIN64-NEXT:    addi a2, sp, 800
+; ZVFHMIN64-NEXT:    vs1r.v v8, (a2) # vscale x 8-byte Folded Spill
 ; ZVFHMIN64-NEXT:    vsetivli zero, 1, e16, m2, ta, ma
-; ZVFHMIN64-NEXT:    vslidedown.vi v14, v16, 15
-; ZVFHMIN64-NEXT:    vslidedown.vi v12, v16, 14
-; ZVFHMIN64-NEXT:    vslidedown.vi v8, v16, 13
-; ZVFHMIN64-NEXT:    vslidedown.vi v18, v16, 12
-; ZVFHMIN64-NEXT:    vslidedown.vi v10, v16, 11
+; ZVFHMIN64-NEXT:    vslidedown.vi v18, v16, 15
+; ZVFHMIN64-NEXT:    vslidedown.vi v14, v16, 14
+; ZVFHMIN64-NEXT:    vslidedown.vi v12, v16, 13
+; ZVFHMIN64-NEXT:    vslidedown.vi v10, v16, 12
+; ZVFHMIN64-NEXT:    vslidedown.vi v8, v16, 11
 ; ZVFHMIN64-NEXT:    vslidedown.vi v6, v16, 10
 ; ZVFHMIN64-NEXT:    csrr a2, vlenb
 ; ZVFHMIN64-NEXT:    li a3, 20
@@ -2540,17 +2540,17 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN64-NEXT:    sb a0, 216(sp)
-; ZVFHMIN64-NEXT:    lh a0, 558(sp)
-; ZVFHMIN64-NEXT:    lh a1, 302(sp)
+; ZVFHMIN64-NEXT:    sb a0, 217(sp)
+; ZVFHMIN64-NEXT:    lh a0, 560(sp)
+; ZVFHMIN64-NEXT:    lh a1, 304(sp)
 ; ZVFHMIN64-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; ZVFHMIN64-NEXT:    vslidedown.vi v9, v0, 7
-; ZVFHMIN64-NEXT:    vslidedown.vi v19, v0, 6
-; ZVFHMIN64-NEXT:    vslidedown.vi v3, v0, 5
-; ZVFHMIN64-NEXT:    vslidedown.vi v13, v0, 4
-; ZVFHMIN64-NEXT:    vslidedown.vi v15, v0, 3
-; ZVFHMIN64-NEXT:    vslidedown.vi v16, v0, 2
-; ZVFHMIN64-NEXT:    vslidedown.vi v11, v0, 1
+; ZVFHMIN64-NEXT:    vslidedown.vi v3, v0, 7
+; ZVFHMIN64-NEXT:    vslidedown.vi v9, v0, 6
+; ZVFHMIN64-NEXT:    vslidedown.vi v15, v0, 5
+; ZVFHMIN64-NEXT:    vslidedown.vi v19, v0, 4
+; ZVFHMIN64-NEXT:    vslidedown.vi v11, v0, 3
+; ZVFHMIN64-NEXT:    vslidedown.vi v13, v0, 2
+; ZVFHMIN64-NEXT:    vslidedown.vi v16, v0, 1
 ; ZVFHMIN64-NEXT:    vsetivli zero, 1, e16, m2, ta, ma
 ; ZVFHMIN64-NEXT:    vslidedown.vi v6, v0, 15
 ; ZVFHMIN64-NEXT:    csrr a2, vlenb
@@ -2600,9 +2600,9 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN64-NEXT:    sb a0, 215(sp)
-; ZVFHMIN64-NEXT:    lh a0, 556(sp)
-; ZVFHMIN64-NEXT:    lh a1, 300(sp)
+; ZVFHMIN64-NEXT:    sb a0, 216(sp)
+; ZVFHMIN64-NEXT:    lh a0, 558(sp)
+; ZVFHMIN64-NEXT:    lh a1, 302(sp)
 ; ZVFHMIN64-NEXT:    csrr a2, vlenb
 ; ZVFHMIN64-NEXT:    add a2, sp, a2
 ; ZVFHMIN64-NEXT:    addi a2, a2, 800
@@ -2612,65 +2612,81 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
+; ZVFHMIN64-NEXT:    sb a0, 215(sp)
+; ZVFHMIN64-NEXT:    lh a0, 556(sp)
+; ZVFHMIN64-NEXT:    lh a1, 300(sp)
+; ZVFHMIN64-NEXT:    vmv.x.s t1, v30
+; ZVFHMIN64-NEXT:    vmv.x.s t0, v28
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb a0, 214(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 554(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 298(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s t1, v30
-; ZVFHMIN64-NEXT:    vmv.x.s t0, v28
+; ZVFHMIN64-NEXT:    vmv.x.s a7, v26
+; ZVFHMIN64-NEXT:    vmv.x.s a6, v22
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb a0, 213(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 552(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 296(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s a7, v26
-; ZVFHMIN64-NEXT:    vmv.x.s a6, v22
+; ZVFHMIN64-NEXT:    vmv.x.s a5, v20
+; ZVFHMIN64-NEXT:    vmv.x.s a2, v18
+; ZVFHMIN64-NEXT:    sd a2, 88(sp) # 8-byte Folded Spill
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb a0, 212(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 550(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 294(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s a5, v20
 ; ZVFHMIN64-NEXT:    vmv.x.s a2, v14
 ; ZVFHMIN64-NEXT:    sd a2, 96(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    vmv.x.s a2, v12
+; ZVFHMIN64-NEXT:    sd a2, 104(sp) # 8-byte Folded Spill
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb a0, 211(sp)
-; ZVFHMIN64-NEXT:    lh a1, 548(sp)
-; ZVFHMIN64-NEXT:    lh t5, 292(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s a0, v12
-; ZVFHMIN64-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    vmv.x.s a0, v8
-; ZVFHMIN64-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, t5
-; ZVFHMIN64-NEXT:    feq.h a1, fa5, fa4
-; ZVFHMIN64-NEXT:    sb a1, 210(sp)
-; ZVFHMIN64-NEXT:    lh a1, 546(sp)
-; ZVFHMIN64-NEXT:    lh t5, 290(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, a4
-; ZVFHMIN64-NEXT:    vmv.x.s a4, v24
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, t5
-; ZVFHMIN64-NEXT:    feq.h a1, fa4, fa3
-; ZVFHMIN64-NEXT:    sb a1, 209(sp)
-; ZVFHMIN64-NEXT:    lh a1, 544(sp)
-; ZVFHMIN64-NEXT:    lh t5, 288(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a4
-; ZVFHMIN64-NEXT:    feq.h a4, fa5, fa4
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, t5
-; ZVFHMIN64-NEXT:    feq.h a1, fa5, fa4
-; ZVFHMIN64-NEXT:    sb a4, 192(sp)
-; ZVFHMIN64-NEXT:    sb a1, 208(sp)
-; ZVFHMIN64-NEXT:    lh t5, 738(sp)
-; ZVFHMIN64-NEXT:    lh t6, 482(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s a0, v18
-; ZVFHMIN64-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    lh t6, 548(sp)
+; ZVFHMIN64-NEXT:    lh s1, 292(sp)
 ; ZVFHMIN64-NEXT:    vmv.x.s a0, v10
 ; ZVFHMIN64-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    vmv.x.s a0, v8
+; ZVFHMIN64-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, t6
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s1
+; ZVFHMIN64-NEXT:    feq.h t6, fa5, fa4
+; ZVFHMIN64-NEXT:    sb t6, 210(sp)
+; ZVFHMIN64-NEXT:    lh t6, 546(sp)
+; ZVFHMIN64-NEXT:    lh s1, 290(sp)
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, t5
+; ZVFHMIN64-NEXT:    vmv.x.s t5, v24
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, t6
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, s1
+; ZVFHMIN64-NEXT:    feq.h t6, fa4, fa3
+; ZVFHMIN64-NEXT:    sb t6, 209(sp)
+; ZVFHMIN64-NEXT:    lh t6, 544(sp)
+; ZVFHMIN64-NEXT:    lh s1, 288(sp)
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, t5
+; ZVFHMIN64-NEXT:    feq.h t5, fa5, fa4
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, t6
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s1
+; ZVFHMIN64-NEXT:    feq.h t6, fa5, fa4
+; ZVFHMIN64-NEXT:    sb t5, 192(sp)
+; ZVFHMIN64-NEXT:    sb t6, 208(sp)
+; ZVFHMIN64-NEXT:    lh t5, 738(sp)
+; ZVFHMIN64-NEXT:    lh t6, 482(sp)
+; ZVFHMIN64-NEXT:    csrr a0, vlenb
+; ZVFHMIN64-NEXT:    li a1, 28
+; ZVFHMIN64-NEXT:    mul a0, a0, a1
+; ZVFHMIN64-NEXT:    add a0, sp, a0
+; ZVFHMIN64-NEXT:    lh s7, 800(a0) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    csrr a0, vlenb
+; ZVFHMIN64-NEXT:    li a1, 27
+; ZVFHMIN64-NEXT:    mul a0, a0, a1
+; ZVFHMIN64-NEXT:    add a0, sp, a0
+; ZVFHMIN64-NEXT:    lh s5, 800(a0) # 8-byte Folded Reload
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, t5
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, t6
 ; ZVFHMIN64-NEXT:    feq.h t5, fa5, fa4
@@ -2678,12 +2694,12 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    lh t5, 736(sp)
 ; ZVFHMIN64-NEXT:    lh t6, 480(sp)
 ; ZVFHMIN64-NEXT:    csrr a0, vlenb
-; ZVFHMIN64-NEXT:    li a1, 28
+; ZVFHMIN64-NEXT:    li a1, 26
 ; ZVFHMIN64-NEXT:    mul a0, a0, a1
 ; ZVFHMIN64-NEXT:    add a0, sp, a0
-; ZVFHMIN64-NEXT:    lh s5, 800(a0) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    lh s8, 800(a0) # 8-byte Folded Reload
 ; ZVFHMIN64-NEXT:    csrr a0, vlenb
-; ZVFHMIN64-NEXT:    li a1, 27
+; ZVFHMIN64-NEXT:    li a1, 25
 ; ZVFHMIN64-NEXT:    mul a0, a0, a1
 ; ZVFHMIN64-NEXT:    add a0, sp, a0
 ; ZVFHMIN64-NEXT:    lh s6, 800(a0) # 8-byte Folded Reload
@@ -2693,22 +2709,6 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    sb t5, 176(sp)
 ; ZVFHMIN64-NEXT:    lh t5, 734(sp)
 ; ZVFHMIN64-NEXT:    lh t6, 478(sp)
-; ZVFHMIN64-NEXT:    csrr a0, vlenb
-; ZVFHMIN64-NEXT:    li a1, 26
-; ZVFHMIN64-NEXT:    mul a0, a0, a1
-; ZVFHMIN64-NEXT:    add a0, sp, a0
-; ZVFHMIN64-NEXT:    lh s7, 800(a0) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    csrr a0, vlenb
-; ZVFHMIN64-NEXT:    li a1, 25
-; ZVFHMIN64-NEXT:    mul a0, a0, a1
-; ZVFHMIN64-NEXT:    add a0, sp, a0
-; ZVFHMIN64-NEXT:    lh s8, 800(a0) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, t5
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, t6
-; ZVFHMIN64-NEXT:    feq.h t5, fa5, fa4
-; ZVFHMIN64-NEXT:    sb t5, 175(sp)
-; ZVFHMIN64-NEXT:    lh t5, 732(sp)
-; ZVFHMIN64-NEXT:    lh t6, 476(sp)
 ; ZVFHMIN64-NEXT:    csrr a0, vlenb
 ; ZVFHMIN64-NEXT:    li a1, 24
 ; ZVFHMIN64-NEXT:    mul a0, a0, a1
@@ -2722,22 +2722,30 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, t5
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, t6
 ; ZVFHMIN64-NEXT:    feq.h t5, fa5, fa4
-; ZVFHMIN64-NEXT:    sb t5, 174(sp)
-; ZVFHMIN64-NEXT:    lh t6, 730(sp)
-; ZVFHMIN64-NEXT:    lh s9, 474(sp)
+; ZVFHMIN64-NEXT:    sb t5, 175(sp)
+; ZVFHMIN64-NEXT:    lh t5, 732(sp)
+; ZVFHMIN64-NEXT:    lh t6, 476(sp)
 ; ZVFHMIN64-NEXT:    csrr a0, vlenb
 ; ZVFHMIN64-NEXT:    li a1, 22
 ; ZVFHMIN64-NEXT:    mul a0, a0, a1
 ; ZVFHMIN64-NEXT:    add a0, sp, a0
 ; ZVFHMIN64-NEXT:    lh s2, 800(a0) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    vmv.x.s t5, v21
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, t6
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, s9
-; ZVFHMIN64-NEXT:    feq.h t6, fa5, fa4
-; ZVFHMIN64-NEXT:    sb t6, 173(sp)
+; ZVFHMIN64-NEXT:    vmv.x.s s1, v21
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, t5
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, t6
+; ZVFHMIN64-NEXT:    feq.h t5, fa5, fa4
+; ZVFHMIN64-NEXT:    sb t5, 174(sp)
+; ZVFHMIN64-NEXT:    lh s9, 730(sp)
+; ZVFHMIN64-NEXT:    lh s10, 474(sp)
+; ZVFHMIN64-NEXT:    vmv.x.s t6, v31
+; ZVFHMIN64-NEXT:    vmv.x.s t5, v23
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, s9
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s10
+; ZVFHMIN64-NEXT:    feq.h s9, fa5, fa4
+; ZVFHMIN64-NEXT:    sb s9, 173(sp)
 ; ZVFHMIN64-NEXT:    lh s9, 728(sp)
 ; ZVFHMIN64-NEXT:    lh s10, 472(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s t6, v23
+; ZVFHMIN64-NEXT:    vmv.x.s s11, v3
 ; ZVFHMIN64-NEXT:    vmv.x.s ra, v9
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, s9
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, s10
@@ -2745,257 +2753,255 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    sb s9, 172(sp)
 ; ZVFHMIN64-NEXT:    lh s9, 726(sp)
 ; ZVFHMIN64-NEXT:    lh s10, 470(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s a2, v19
-; ZVFHMIN64-NEXT:    vmv.x.s a3, v3
+; ZVFHMIN64-NEXT:    vmv.x.s a2, v15
+; ZVFHMIN64-NEXT:    vmv.x.s a3, v19
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, s9
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, s10
 ; ZVFHMIN64-NEXT:    feq.h s9, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb s9, 171(sp)
-; ZVFHMIN64-NEXT:    lh s10, 724(sp)
-; ZVFHMIN64-NEXT:    lh s11, 468(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s a4, v13
-; ZVFHMIN64-NEXT:    vmv.x.s s9, v15
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, s10
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, s11
-; ZVFHMIN64-NEXT:    feq.h s10, fa5, fa4
-; ZVFHMIN64-NEXT:    sb s10, 170(sp)
+; ZVFHMIN64-NEXT:    lh s9, 724(sp)
+; ZVFHMIN64-NEXT:    lh a0, 468(sp)
+; ZVFHMIN64-NEXT:    vmv.x.s a4, v11
+; ZVFHMIN64-NEXT:    vmv.x.s s10, v13
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, s9
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
+; ZVFHMIN64-NEXT:    sb a0, 170(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 722(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 466(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s s10, v16
-; ZVFHMIN64-NEXT:    vmv.x.s s11, v11
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
+; ZVFHMIN64-NEXT:    vmv.x.s s9, v16
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, s7
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN64-NEXT:    sb a0, 169(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 720(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 464(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, s5
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, s6
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN64-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s5
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, s8
+; ZVFHMIN64-NEXT:    fmv.h.x fa2, a0
+; ZVFHMIN64-NEXT:    fmv.h.x fa1, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa2, fa1
 ; ZVFHMIN64-NEXT:    sb a0, 168(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 718(sp)
+; ZVFHMIN64-NEXT:    fmv.h.x fa2, s6
 ; ZVFHMIN64-NEXT:    lh a1, 462(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, s7
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, s8
-; ZVFHMIN64-NEXT:    fmv.h.x fa1, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa0, a1
-; ZVFHMIN64-NEXT:    feq.h a0, fa1, fa0
-; ZVFHMIN64-NEXT:    fmv.h.x fa1, ra
+; ZVFHMIN64-NEXT:    fmv.h.x fa1, s11
+; ZVFHMIN64-NEXT:    fmv.h.x fa0, a0
+; ZVFHMIN64-NEXT:    feq.h s5, fa5, fa1
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa0, fa5
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, ra
 ; ZVFHMIN64-NEXT:    sb a0, 167(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 716(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa0, a2
+; ZVFHMIN64-NEXT:    fmv.h.x fa1, a2
 ; ZVFHMIN64-NEXT:    lh a1, 460(sp)
-; ZVFHMIN64-NEXT:    feq.h s5, fa5, fa1
+; ZVFHMIN64-NEXT:    feq.h a2, fa4, fa5
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN64-NEXT:    feq.h a0, fa4, fa0
+; ZVFHMIN64-NEXT:    feq.h a0, fa3, fa1
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a1, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, s4
 ; ZVFHMIN64-NEXT:    sb a1, 166(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 714(sp)
-; ZVFHMIN64-NEXT:    lh a2, 458(sp)
+; ZVFHMIN64-NEXT:    lh s4, 458(sp)
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a3
-; ZVFHMIN64-NEXT:    feq.h a3, fa3, fa4
+; ZVFHMIN64-NEXT:    feq.h a3, fa2, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, a2
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, s4
 ; ZVFHMIN64-NEXT:    feq.h a1, fa4, fa3
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, s3
 ; ZVFHMIN64-NEXT:    sb a1, 165(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 712(sp)
-; ZVFHMIN64-NEXT:    lh a2, 456(sp)
+; ZVFHMIN64-NEXT:    lh s3, 456(sp)
 ; ZVFHMIN64-NEXT:    fmv.h.x fa3, a4
-; ZVFHMIN64-NEXT:    feq.h a4, fa2, fa3
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, a1
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, a2
-; ZVFHMIN64-NEXT:    feq.h a1, fa3, fa2
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, s2
+; ZVFHMIN64-NEXT:    feq.h a4, fa5, fa3
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, s3
+; ZVFHMIN64-NEXT:    feq.h a1, fa5, fa3
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, s2
 ; ZVFHMIN64-NEXT:    sb a1, 164(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 710(sp)
-; ZVFHMIN64-NEXT:    lh a2, 454(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, s9
-; ZVFHMIN64-NEXT:    feq.h s2, fa5, fa2
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, a2
-; ZVFHMIN64-NEXT:    feq.h a1, fa5, fa2
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, s10
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, s11
+; ZVFHMIN64-NEXT:    lh s2, 454(sp)
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, s10
+; ZVFHMIN64-NEXT:    feq.h s3, fa4, fa3
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, s2
+; ZVFHMIN64-NEXT:    feq.h a1, fa4, fa3
 ; ZVFHMIN64-NEXT:    sb a1, 163(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 708(sp)
-; ZVFHMIN64-NEXT:    lh a2, 452(sp)
-; ZVFHMIN64-NEXT:    feq.h s3, fa4, fa5
-; ZVFHMIN64-NEXT:    feq.h s4, fa3, fa2
+; ZVFHMIN64-NEXT:    lh s2, 452(sp)
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s9
+; ZVFHMIN64-NEXT:    feq.h s4, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s2
 ; ZVFHMIN64-NEXT:    feq.h a1, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb a1, 162(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 706(sp)
-; ZVFHMIN64-NEXT:    lh a2, 450(sp)
+; ZVFHMIN64-NEXT:    lh s2, 450(sp)
 ; ZVFHMIN64-NEXT:    sb s4, 129(sp)
 ; ZVFHMIN64-NEXT:    sb s3, 130(sp)
-; ZVFHMIN64-NEXT:    sb s2, 131(sp)
-; ZVFHMIN64-NEXT:    sb a4, 132(sp)
+; ZVFHMIN64-NEXT:    sb a4, 131(sp)
+; ZVFHMIN64-NEXT:    sb a3, 132(sp)
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s2
 ; ZVFHMIN64-NEXT:    feq.h a1, fa5, fa4
-; ZVFHMIN64-NEXT:    sb a3, 133(sp)
-; ZVFHMIN64-NEXT:    sb a0, 134(sp)
+; ZVFHMIN64-NEXT:    sb a0, 133(sp)
+; ZVFHMIN64-NEXT:    sb a2, 134(sp)
 ; ZVFHMIN64-NEXT:    sb s5, 135(sp)
 ; ZVFHMIN64-NEXT:    sb a1, 161(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 610(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 354(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s s6, v29
-; ZVFHMIN64-NEXT:    vmv.x.s s5, v31
+; ZVFHMIN64-NEXT:    vmv.x.s s5, v27
+; ZVFHMIN64-NEXT:    vmv.x.s s4, v29
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb a0, 241(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 608(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 352(sp)
-; ZVFHMIN64-NEXT:    lh s4, 800(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    vmv.x.s s3, v27
+; ZVFHMIN64-NEXT:    csrr a2, vlenb
+; ZVFHMIN64-NEXT:    li a3, 19
+; ZVFHMIN64-NEXT:    mul a2, a2, a3
+; ZVFHMIN64-NEXT:    add a2, sp, a2
+; ZVFHMIN64-NEXT:    lh s3, 800(a2) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    lh s2, 800(sp) # 8-byte Folded Reload
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb a0, 240(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 606(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 350(sp)
-; ZVFHMIN64-NEXT:    csrr a2, vlenb
-; ZVFHMIN64-NEXT:    li a3, 19
-; ZVFHMIN64-NEXT:    mul a2, a2, a3
-; ZVFHMIN64-NEXT:    add a2, sp, a2
-; ZVFHMIN64-NEXT:    lh s2, 800(a2) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, t5
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, s1
+; ZVFHMIN64-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 7
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa3, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN64-NEXT:    sb a0, 239(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 604(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 348(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, t6
-; ZVFHMIN64-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 7
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN64-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN64-NEXT:    vmv.x.s a2, v8
+; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 6
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN64-NEXT:    sb a0, 238(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 602(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 346(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s a2, v8
-; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 6
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN64-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN64-NEXT:    vmv.x.s a3, v8
+; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 5
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN64-NEXT:    sb a0, 237(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 600(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 344(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s a3, v8
-; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 5
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN64-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN64-NEXT:    vmv.x.s a4, v8
+; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 4
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN64-NEXT:    sb a0, 236(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 598(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 342(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s a4, v8
-; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 4
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN64-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN64-NEXT:    vmv.x.s s6, v8
+; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 3
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN64-NEXT:    sb a0, 235(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 596(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 340(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s s8, v8
-; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 3
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN64-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN64-NEXT:    vmv.x.s s7, v8
+; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 2
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN64-NEXT:    sb a0, 234(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 594(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 338(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s s9, v8
-; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 2
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, a1
-; ZVFHMIN64-NEXT:    feq.h a0, fa3, fa2
+; ZVFHMIN64-NEXT:    vmv.x.s s8, v8
+; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 1
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a0
+; ZVFHMIN64-NEXT:    fmv.h.x fa3, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa4, fa3
 ; ZVFHMIN64-NEXT:    sb a0, 233(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 592(sp)
-; ZVFHMIN64-NEXT:    vmv.x.s a1, v8
-; ZVFHMIN64-NEXT:    lh t5, 336(sp)
-; ZVFHMIN64-NEXT:    vslidedown.vi v8, v24, 1
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN64-NEXT:    lh a1, 336(sp)
+; ZVFHMIN64-NEXT:    vmv.x.s a2, v8
 ; ZVFHMIN64-NEXT:    fmv.h.x fa3, a0
-; ZVFHMIN64-NEXT:    vmv.x.s s7, v8
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, t5
-; ZVFHMIN64-NEXT:    feq.h a0, fa3, fa2
-; ZVFHMIN64-NEXT:    fmv.h.x fa3, a2
+; ZVFHMIN64-NEXT:    feq.h s1, fa5, fa4
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa3, fa5
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, t6
 ; ZVFHMIN64-NEXT:    sb a0, 232(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 590(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa2, a3
-; ZVFHMIN64-NEXT:    lh a2, 334(sp)
-; ZVFHMIN64-NEXT:    feq.h t5, fa5, fa3
+; ZVFHMIN64-NEXT:    lh a1, 334(sp)
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a3
+; ZVFHMIN64-NEXT:    feq.h t6, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN64-NEXT:    feq.h t6, fa4, fa2
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, s6
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, t5
 ; ZVFHMIN64-NEXT:    sb a0, 231(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 588(sp)
-; ZVFHMIN64-NEXT:    lh a2, 332(sp)
+; ZVFHMIN64-NEXT:    lh a1, 332(sp)
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a4
 ; ZVFHMIN64-NEXT:    feq.h a3, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, s5
 ; ZVFHMIN64-NEXT:    sb a0, 230(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 586(sp)
-; ZVFHMIN64-NEXT:    lh a2, 330(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, s8
+; ZVFHMIN64-NEXT:    lh a1, 330(sp)
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s6
 ; ZVFHMIN64-NEXT:    feq.h a4, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, s4
 ; ZVFHMIN64-NEXT:    sb a0, 229(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 584(sp)
-; ZVFHMIN64-NEXT:    lh a2, 328(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, s9
-; ZVFHMIN64-NEXT:    feq.h s4, fa5, fa4
+; ZVFHMIN64-NEXT:    lh a1, 328(sp)
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s7
+; ZVFHMIN64-NEXT:    feq.h t5, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, s3
 ; ZVFHMIN64-NEXT:    sb a0, 228(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 582(sp)
-; ZVFHMIN64-NEXT:    lh a2, 326(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN64-NEXT:    feq.h a1, fa5, fa4
+; ZVFHMIN64-NEXT:    lh a1, 326(sp)
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s8
+; ZVFHMIN64-NEXT:    feq.h s3, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, s2
 ; ZVFHMIN64-NEXT:    sb a0, 227(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 580(sp)
-; ZVFHMIN64-NEXT:    lh a2, 324(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, s7
-; ZVFHMIN64-NEXT:    feq.h s2, fa5, fa4
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
+; ZVFHMIN64-NEXT:    lh a1, 324(sp)
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN64-NEXT:    feq.h a2, fa5, fa4
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb a0, 226(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 578(sp)
-; ZVFHMIN64-NEXT:    lh a2, 322(sp)
-; ZVFHMIN64-NEXT:    sb s2, 193(sp)
-; ZVFHMIN64-NEXT:    sb a1, 194(sp)
-; ZVFHMIN64-NEXT:    sb s4, 195(sp)
+; ZVFHMIN64-NEXT:    lh a1, 322(sp)
+; ZVFHMIN64-NEXT:    sb a2, 193(sp)
+; ZVFHMIN64-NEXT:    sb s3, 194(sp)
+; ZVFHMIN64-NEXT:    sb t5, 195(sp)
 ; ZVFHMIN64-NEXT:    sb a4, 196(sp)
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a2
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb a3, 197(sp)
 ; ZVFHMIN64-NEXT:    sb t6, 198(sp)
-; ZVFHMIN64-NEXT:    sb t5, 199(sp)
+; ZVFHMIN64-NEXT:    sb s1, 199(sp)
 ; ZVFHMIN64-NEXT:    sb a0, 225(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 766(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 510(sp)
@@ -3005,7 +3011,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    add a2, sp, a2
 ; ZVFHMIN64-NEXT:    addi a2, a2, 800
 ; ZVFHMIN64-NEXT:    vl2r.v v8, (a2) # vscale x 16-byte Folded Reload
-; ZVFHMIN64-NEXT:    vmv.x.s s2, v8
+; ZVFHMIN64-NEXT:    vmv.x.s s1, v8
 ; ZVFHMIN64-NEXT:    csrr a2, vlenb
 ; ZVFHMIN64-NEXT:    slli a3, a2, 4
 ; ZVFHMIN64-NEXT:    sub a2, a3, a2
@@ -3047,8 +3053,8 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    vl2r.v v8, (a3) # vscale x 16-byte Folded Reload
 ; ZVFHMIN64-NEXT:    vmv.x.s a3, v8
 ; ZVFHMIN64-NEXT:    csrr a4, vlenb
-; ZVFHMIN64-NEXT:    slli s3, a4, 2
-; ZVFHMIN64-NEXT:    add a4, s3, a4
+; ZVFHMIN64-NEXT:    slli s2, a4, 2
+; ZVFHMIN64-NEXT:    add a4, s2, a4
 ; ZVFHMIN64-NEXT:    add a4, sp, a4
 ; ZVFHMIN64-NEXT:    addi a4, a4, 800
 ; ZVFHMIN64-NEXT:    vl2r.v v8, (a4) # vscale x 16-byte Folded Reload
@@ -3059,34 +3065,34 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    sb a0, 189(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 760(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 504(sp)
-; ZVFHMIN64-NEXT:    csrr s3, vlenb
-; ZVFHMIN64-NEXT:    li s4, 11
-; ZVFHMIN64-NEXT:    mul s3, s3, s4
-; ZVFHMIN64-NEXT:    add s3, sp, s3
-; ZVFHMIN64-NEXT:    addi s3, s3, 800
-; ZVFHMIN64-NEXT:    vl2r.v v8, (s3) # vscale x 16-byte Folded Reload
-; ZVFHMIN64-NEXT:    vmv.x.s s6, v8
-; ZVFHMIN64-NEXT:    csrr s3, vlenb
-; ZVFHMIN64-NEXT:    slli s4, s3, 3
-; ZVFHMIN64-NEXT:    add s3, s4, s3
-; ZVFHMIN64-NEXT:    add s3, sp, s3
-; ZVFHMIN64-NEXT:    addi s3, s3, 800
-; ZVFHMIN64-NEXT:    vl2r.v v8, (s3) # vscale x 16-byte Folded Reload
-; ZVFHMIN64-NEXT:    vmv.x.s s4, v8
+; ZVFHMIN64-NEXT:    csrr s2, vlenb
+; ZVFHMIN64-NEXT:    li s3, 11
+; ZVFHMIN64-NEXT:    mul s2, s2, s3
+; ZVFHMIN64-NEXT:    add s2, sp, s2
+; ZVFHMIN64-NEXT:    addi s2, s2, 800
+; ZVFHMIN64-NEXT:    vl2r.v v8, (s2) # vscale x 16-byte Folded Reload
+; ZVFHMIN64-NEXT:    vmv.x.s s5, v8
+; ZVFHMIN64-NEXT:    csrr s2, vlenb
+; ZVFHMIN64-NEXT:    slli s3, s2, 3
+; ZVFHMIN64-NEXT:    add s2, s3, s2
+; ZVFHMIN64-NEXT:    add s2, sp, s2
+; ZVFHMIN64-NEXT:    addi s2, s2, 800
+; ZVFHMIN64-NEXT:    vl2r.v v8, (s2) # vscale x 16-byte Folded Reload
+; ZVFHMIN64-NEXT:    vmv.x.s s3, v8
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb a0, 188(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 758(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 502(sp)
-; ZVFHMIN64-NEXT:    csrr s3, vlenb
-; ZVFHMIN64-NEXT:    slli s5, s3, 4
-; ZVFHMIN64-NEXT:    add s3, s5, s3
-; ZVFHMIN64-NEXT:    add s3, sp, s3
-; ZVFHMIN64-NEXT:    addi s3, s3, 800
-; ZVFHMIN64-NEXT:    vl2r.v v8, (s3) # vscale x 16-byte Folded Reload
-; ZVFHMIN64-NEXT:    vmv.x.s s5, v8
-; ZVFHMIN64-NEXT:    vmv.x.s s3, v6
+; ZVFHMIN64-NEXT:    csrr s2, vlenb
+; ZVFHMIN64-NEXT:    slli s4, s2, 4
+; ZVFHMIN64-NEXT:    add s2, s4, s2
+; ZVFHMIN64-NEXT:    add s2, sp, s2
+; ZVFHMIN64-NEXT:    addi s2, s2, 800
+; ZVFHMIN64-NEXT:    vl2r.v v8, (s2) # vscale x 16-byte Folded Reload
+; ZVFHMIN64-NEXT:    vmv.x.s s4, v8
+; ZVFHMIN64-NEXT:    vmv.x.s s2, v6
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
@@ -3121,7 +3127,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    sb a0, 184(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 750(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 494(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, s6
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s5
 ; ZVFHMIN64-NEXT:    feq.h a2, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
@@ -3130,7 +3136,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    sb a0, 183(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 748(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 492(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, s4
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s3
 ; ZVFHMIN64-NEXT:    feq.h a3, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
@@ -3139,7 +3145,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    sb a0, 182(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 746(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 490(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, s5
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s4
 ; ZVFHMIN64-NEXT:    feq.h a4, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
@@ -3148,7 +3154,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    sb a0, 181(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 744(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 488(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, s3
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, s2
 ; ZVFHMIN64-NEXT:    feq.h a6, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
@@ -3228,37 +3234,37 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN64-NEXT:    ld a1, 96(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld a1, 88(sp) # 8-byte Folded Reload
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
 ; ZVFHMIN64-NEXT:    sb a0, 250(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 626(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 370(sp)
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a5
+; ZVFHMIN64-NEXT:    feq.h a4, fa5, fa4
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
+; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
+; ZVFHMIN64-NEXT:    ld a1, 96(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
+; ZVFHMIN64-NEXT:    sb a0, 249(sp)
+; ZVFHMIN64-NEXT:    lh a0, 624(sp)
+; ZVFHMIN64-NEXT:    lh a1, 368(sp)
+; ZVFHMIN64-NEXT:    fmv.h.x fa4, t3
 ; ZVFHMIN64-NEXT:    feq.h a3, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
 ; ZVFHMIN64-NEXT:    ld a1, 104(sp) # 8-byte Folded Reload
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
-; ZVFHMIN64-NEXT:    sb a0, 249(sp)
-; ZVFHMIN64-NEXT:    lh a0, 624(sp)
-; ZVFHMIN64-NEXT:    lh a1, 368(sp)
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, t3
-; ZVFHMIN64-NEXT:    feq.h a2, fa5, fa4
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
-; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
-; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN64-NEXT:    ld a1, 120(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
 ; ZVFHMIN64-NEXT:    sb a0, 248(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 622(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 366(sp)
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, t2
-; ZVFHMIN64-NEXT:    feq.h a4, fa5, fa4
+; ZVFHMIN64-NEXT:    feq.h a2, fa5, fa4
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN64-NEXT:    ld a1, 88(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld a1, 112(sp) # 8-byte Folded Reload
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
 ; ZVFHMIN64-NEXT:    sb a0, 247(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 620(sp)
@@ -3268,7 +3274,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN64-NEXT:    ld a1, 112(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld a1, 120(sp) # 8-byte Folded Reload
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a1
 ; ZVFHMIN64-NEXT:    sb a0, 246(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 618(sp)
@@ -3278,7 +3284,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    fmv.h.x fa5, a0
 ; ZVFHMIN64-NEXT:    fmv.h.x fa4, a1
 ; ZVFHMIN64-NEXT:    feq.h a0, fa5, fa4
-; ZVFHMIN64-NEXT:    fmv.h.x fa5, s2
+; ZVFHMIN64-NEXT:    fmv.h.x fa5, s1
 ; ZVFHMIN64-NEXT:    sb a0, 245(sp)
 ; ZVFHMIN64-NEXT:    lh a0, 616(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 360(sp)
@@ -3304,9 +3310,9 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    lh a0, 612(sp)
 ; ZVFHMIN64-NEXT:    lh a1, 356(sp)
 ; ZVFHMIN64-NEXT:    sb a5, 204(sp)
-; ZVFHMIN64-NEXT:    sb a4, 205(sp)
-; ZVFHMIN64-NEXT:    sb a2, 206(sp)
-; ZVFHMIN64-NEXT:    sb a3, 207(sp)
+; ZVFHMIN64-NEXT:    sb a2, 205(sp)
+; ZVFHMIN64-NEXT:    sb a3, 206(sp)
+; ZVFHMIN64-NEXT:    sb a4, 207(sp)
 ; ZVFHMIN64-NEXT:    feq.h a2, fa5, fa4
 ; ZVFHMIN64-NEXT:    sb a2, 200(sp)
 ; ZVFHMIN64-NEXT:    sb a6, 201(sp)
@@ -3322,22 +3328,24 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    vle8.v v8, (a0)
 ; ZVFHMIN64-NEXT:    vand.vi v8, v8, 1
 ; ZVFHMIN64-NEXT:    vmsne.vi v0, v8, 0
-; ZVFHMIN64-NEXT:    addi sp, s0, -896
-; ZVFHMIN64-NEXT:    .cfi_def_cfa sp, 896
-; ZVFHMIN64-NEXT:    ld ra, 888(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    ld s0, 880(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    ld s2, 872(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    ld s3, 864(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    ld s4, 856(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    ld s5, 848(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    ld s6, 840(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    ld s7, 832(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    ld s8, 824(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    ld s9, 816(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    ld s10, 808(sp) # 8-byte Folded Reload
-; ZVFHMIN64-NEXT:    ld s11, 800(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    addi sp, s0, -912
+; ZVFHMIN64-NEXT:    .cfi_def_cfa sp, 912
+; ZVFHMIN64-NEXT:    ld ra, 904(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s0, 896(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s1, 888(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s2, 880(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s3, 872(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s4, 864(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s5, 856(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s6, 848(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s7, 840(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s8, 832(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s9, 824(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s10, 816(sp) # 8-byte Folded Reload
+; ZVFHMIN64-NEXT:    ld s11, 808(sp) # 8-byte Folded Reload
 ; ZVFHMIN64-NEXT:    .cfi_restore ra
 ; ZVFHMIN64-NEXT:    .cfi_restore s0
+; ZVFHMIN64-NEXT:    .cfi_restore s1
 ; ZVFHMIN64-NEXT:    .cfi_restore s2
 ; ZVFHMIN64-NEXT:    .cfi_restore s3
 ; ZVFHMIN64-NEXT:    .cfi_restore s4
@@ -3348,7 +3356,7 @@ define <128 x i1> @fcmp_oeq_vv_v128f16(<128 x half> %va, <128 x half> %vb, <128 
 ; ZVFHMIN64-NEXT:    .cfi_restore s9
 ; ZVFHMIN64-NEXT:    .cfi_restore s10
 ; ZVFHMIN64-NEXT:    .cfi_restore s11
-; ZVFHMIN64-NEXT:    addi sp, sp, 896
+; ZVFHMIN64-NEXT:    addi sp, sp, 912
 ; ZVFHMIN64-NEXT:    .cfi_def_cfa_offset 0
 ; ZVFHMIN64-NEXT:    ret
   %v = call <128 x i1> @llvm.vp.fcmp.v128f16(<128 x half> %va, <128 x half> %vb, metadata !"oeq", <128 x i1> %m, i32 %evl)

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-deinterleave2.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-deinterleave2.ll
@@ -1401,14 +1401,14 @@ define <16 x i64> @unzip2a_dual_v16i64(<16 x i64> %a, <16 x i64> %b) {
 ; ZVE32F-NEXT:    .cfi_def_cfa_offset 256
 ; ZVE32F-NEXT:    sd ra, 248(sp) # 8-byte Folded Spill
 ; ZVE32F-NEXT:    sd s0, 240(sp) # 8-byte Folded Spill
-; ZVE32F-NEXT:    sd s2, 232(sp) # 8-byte Folded Spill
-; ZVE32F-NEXT:    sd s3, 224(sp) # 8-byte Folded Spill
-; ZVE32F-NEXT:    sd s4, 216(sp) # 8-byte Folded Spill
+; ZVE32F-NEXT:    sd s1, 232(sp) # 8-byte Folded Spill
+; ZVE32F-NEXT:    sd s2, 224(sp) # 8-byte Folded Spill
+; ZVE32F-NEXT:    sd s3, 216(sp) # 8-byte Folded Spill
 ; ZVE32F-NEXT:    .cfi_offset ra, -8
 ; ZVE32F-NEXT:    .cfi_offset s0, -16
-; ZVE32F-NEXT:    .cfi_offset s2, -24
-; ZVE32F-NEXT:    .cfi_offset s3, -32
-; ZVE32F-NEXT:    .cfi_offset s4, -40
+; ZVE32F-NEXT:    .cfi_offset s1, -24
+; ZVE32F-NEXT:    .cfi_offset s2, -32
+; ZVE32F-NEXT:    .cfi_offset s3, -40
 ; ZVE32F-NEXT:    addi s0, sp, 256
 ; ZVE32F-NEXT:    .cfi_def_cfa s0, 0
 ; ZVE32F-NEXT:    andi sp, sp, -128
@@ -1425,16 +1425,16 @@ define <16 x i64> @unzip2a_dual_v16i64(<16 x i64> %a, <16 x i64> %b) {
 ; ZVE32F-NEXT:    ld t4, 32(a2)
 ; ZVE32F-NEXT:    ld t3, 48(a2)
 ; ZVE32F-NEXT:    ld t6, 64(a2)
-; ZVE32F-NEXT:    ld s2, 80(a2)
-; ZVE32F-NEXT:    ld s3, 96(a2)
+; ZVE32F-NEXT:    ld s1, 80(a2)
+; ZVE32F-NEXT:    ld s2, 96(a2)
 ; ZVE32F-NEXT:    ld a2, 112(a2)
-; ZVE32F-NEXT:    srli s4, t5, 32
+; ZVE32F-NEXT:    srli s3, t5, 32
 ; ZVE32F-NEXT:    sw t5, 0(sp)
-; ZVE32F-NEXT:    sw s4, 4(sp)
+; ZVE32F-NEXT:    sw s3, 4(sp)
 ; ZVE32F-NEXT:    srli t5, t2, 32
 ; ZVE32F-NEXT:    sw t2, 8(sp)
-; ZVE32F-NEXT:    srli t2, s3, 32
-; ZVE32F-NEXT:    sw s3, 112(sp)
+; ZVE32F-NEXT:    srli t2, s2, 32
+; ZVE32F-NEXT:    sw s2, 112(sp)
 ; ZVE32F-NEXT:    sw t2, 116(sp)
 ; ZVE32F-NEXT:    srli t2, a2, 32
 ; ZVE32F-NEXT:    sw a2, 120(sp)
@@ -1442,8 +1442,8 @@ define <16 x i64> @unzip2a_dual_v16i64(<16 x i64> %a, <16 x i64> %b) {
 ; ZVE32F-NEXT:    srli a2, t6, 32
 ; ZVE32F-NEXT:    sw t6, 96(sp)
 ; ZVE32F-NEXT:    sw a2, 100(sp)
-; ZVE32F-NEXT:    srli a2, s2, 32
-; ZVE32F-NEXT:    sw s2, 104(sp)
+; ZVE32F-NEXT:    srli a2, s1, 32
+; ZVE32F-NEXT:    sw s1, 104(sp)
 ; ZVE32F-NEXT:    sw a2, 108(sp)
 ; ZVE32F-NEXT:    srli a2, t4, 32
 ; ZVE32F-NEXT:    sw t4, 80(sp)
@@ -1485,14 +1485,14 @@ define <16 x i64> @unzip2a_dual_v16i64(<16 x i64> %a, <16 x i64> %b) {
 ; ZVE32F-NEXT:    .cfi_def_cfa sp, 256
 ; ZVE32F-NEXT:    ld ra, 248(sp) # 8-byte Folded Reload
 ; ZVE32F-NEXT:    ld s0, 240(sp) # 8-byte Folded Reload
-; ZVE32F-NEXT:    ld s2, 232(sp) # 8-byte Folded Reload
-; ZVE32F-NEXT:    ld s3, 224(sp) # 8-byte Folded Reload
-; ZVE32F-NEXT:    ld s4, 216(sp) # 8-byte Folded Reload
+; ZVE32F-NEXT:    ld s1, 232(sp) # 8-byte Folded Reload
+; ZVE32F-NEXT:    ld s2, 224(sp) # 8-byte Folded Reload
+; ZVE32F-NEXT:    ld s3, 216(sp) # 8-byte Folded Reload
 ; ZVE32F-NEXT:    .cfi_restore ra
 ; ZVE32F-NEXT:    .cfi_restore s0
+; ZVE32F-NEXT:    .cfi_restore s1
 ; ZVE32F-NEXT:    .cfi_restore s2
 ; ZVE32F-NEXT:    .cfi_restore s3
-; ZVE32F-NEXT:    .cfi_restore s4
 ; ZVE32F-NEXT:    addi sp, sp, 256
 ; ZVE32F-NEXT:    .cfi_def_cfa_offset 0
 ; ZVE32F-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-exact-vlen.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-exact-vlen.ll
@@ -246,10 +246,10 @@ define i64 @extract_any_extend_vector_inreg_v16i64(<16 x i64> %a0, i32 %a1) vsca
 ; RV64-NEXT:    .cfi_def_cfa_offset 256
 ; RV64-NEXT:    sd ra, 248(sp) # 8-byte Folded Spill
 ; RV64-NEXT:    sd s0, 240(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s2, 232(sp) # 8-byte Folded Spill
+; RV64-NEXT:    sd s1, 232(sp) # 8-byte Folded Spill
 ; RV64-NEXT:    .cfi_offset ra, -8
 ; RV64-NEXT:    .cfi_offset s0, -16
-; RV64-NEXT:    .cfi_offset s2, -24
+; RV64-NEXT:    .cfi_offset s1, -24
 ; RV64-NEXT:    addi s0, sp, 256
 ; RV64-NEXT:    .cfi_def_cfa s0, 0
 ; RV64-NEXT:    andi sp, sp, -128
@@ -259,21 +259,21 @@ define i64 @extract_any_extend_vector_inreg_v16i64(<16 x i64> %a0, i32 %a1) vsca
 ; RV64-NEXT:    vmv.v.i v16, 0
 ; RV64-NEXT:    vsetivli zero, 2, e64, m1, ta, mu
 ; RV64-NEXT:    vslidedown.vi v18, v15, 1, v0.t
-; RV64-NEXT:    mv s2, sp
-; RV64-NEXT:    vs8r.v v16, (s2)
+; RV64-NEXT:    mv s1, sp
+; RV64-NEXT:    vs8r.v v16, (s1)
 ; RV64-NEXT:    andi a0, a0, 15
 ; RV64-NEXT:    li a1, 8
 ; RV64-NEXT:    call __muldi3
-; RV64-NEXT:    add a0, s2, a0
+; RV64-NEXT:    add a0, s1, a0
 ; RV64-NEXT:    ld a0, 0(a0)
 ; RV64-NEXT:    addi sp, s0, -256
 ; RV64-NEXT:    .cfi_def_cfa sp, 256
 ; RV64-NEXT:    ld ra, 248(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    ld s0, 240(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s2, 232(sp) # 8-byte Folded Reload
+; RV64-NEXT:    ld s1, 232(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    .cfi_restore ra
 ; RV64-NEXT:    .cfi_restore s0
-; RV64-NEXT:    .cfi_restore s2
+; RV64-NEXT:    .cfi_restore s1
 ; RV64-NEXT:    addi sp, sp, 256
 ; RV64-NEXT:    .cfi_def_cfa_offset 0
 ; RV64-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-rotate.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-rotate.ll
@@ -933,12 +933,12 @@ define <8 x i64> @shuffle_v8i64_as_i128(<8 x i64> %v) {
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_def_cfa_offset 128
 ; RV32ZVKB-ZVE32X-NEXT:    sw ra, 124(sp) # 4-byte Folded Spill
 ; RV32ZVKB-ZVE32X-NEXT:    sw s0, 120(sp) # 4-byte Folded Spill
-; RV32ZVKB-ZVE32X-NEXT:    sw s2, 116(sp) # 4-byte Folded Spill
-; RV32ZVKB-ZVE32X-NEXT:    sw s3, 112(sp) # 4-byte Folded Spill
+; RV32ZVKB-ZVE32X-NEXT:    sw s1, 116(sp) # 4-byte Folded Spill
+; RV32ZVKB-ZVE32X-NEXT:    sw s2, 112(sp) # 4-byte Folded Spill
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset ra, -4
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset s0, -8
-; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset s2, -12
-; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset s3, -16
+; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset s1, -12
+; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset s2, -16
 ; RV32ZVKB-ZVE32X-NEXT:    addi s0, sp, 128
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_def_cfa s0, 0
 ; RV32ZVKB-ZVE32X-NEXT:    andi sp, sp, -64
@@ -955,17 +955,17 @@ define <8 x i64> @shuffle_v8i64_as_i128(<8 x i64> %v) {
 ; RV32ZVKB-ZVE32X-NEXT:    lw t4, 56(a1)
 ; RV32ZVKB-ZVE32X-NEXT:    lw t5, 60(a1)
 ; RV32ZVKB-ZVE32X-NEXT:    lw t6, 32(a1)
-; RV32ZVKB-ZVE32X-NEXT:    lw s2, 36(a1)
-; RV32ZVKB-ZVE32X-NEXT:    lw s3, 40(a1)
+; RV32ZVKB-ZVE32X-NEXT:    lw s1, 36(a1)
+; RV32ZVKB-ZVE32X-NEXT:    lw s2, 40(a1)
 ; RV32ZVKB-ZVE32X-NEXT:    lw a1, 44(a1)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t4, 48(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t5, 52(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t2, 56(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t3, 60(sp)
-; RV32ZVKB-ZVE32X-NEXT:    sw s3, 32(sp)
+; RV32ZVKB-ZVE32X-NEXT:    sw s2, 32(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw a1, 36(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t6, 40(sp)
-; RV32ZVKB-ZVE32X-NEXT:    sw s2, 44(sp)
+; RV32ZVKB-ZVE32X-NEXT:    sw s1, 44(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t0, 16(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t1, 20(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw a6, 24(sp)
@@ -982,12 +982,12 @@ define <8 x i64> @shuffle_v8i64_as_i128(<8 x i64> %v) {
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_def_cfa sp, 128
 ; RV32ZVKB-ZVE32X-NEXT:    lw ra, 124(sp) # 4-byte Folded Reload
 ; RV32ZVKB-ZVE32X-NEXT:    lw s0, 120(sp) # 4-byte Folded Reload
-; RV32ZVKB-ZVE32X-NEXT:    lw s2, 116(sp) # 4-byte Folded Reload
-; RV32ZVKB-ZVE32X-NEXT:    lw s3, 112(sp) # 4-byte Folded Reload
+; RV32ZVKB-ZVE32X-NEXT:    lw s1, 116(sp) # 4-byte Folded Reload
+; RV32ZVKB-ZVE32X-NEXT:    lw s2, 112(sp) # 4-byte Folded Reload
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_restore ra
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_restore s0
+; RV32ZVKB-ZVE32X-NEXT:    .cfi_restore s1
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_restore s2
-; RV32ZVKB-ZVE32X-NEXT:    .cfi_restore s3
 ; RV32ZVKB-ZVE32X-NEXT:    addi sp, sp, 128
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_def_cfa_offset 0
 ; RV32ZVKB-ZVE32X-NEXT:    ret
@@ -998,12 +998,12 @@ define <8 x i64> @shuffle_v8i64_as_i128(<8 x i64> %v) {
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_def_cfa_offset 128
 ; RV64ZVKB-ZVE32X-NEXT:    sd ra, 120(sp) # 8-byte Folded Spill
 ; RV64ZVKB-ZVE32X-NEXT:    sd s0, 112(sp) # 8-byte Folded Spill
-; RV64ZVKB-ZVE32X-NEXT:    sd s2, 104(sp) # 8-byte Folded Spill
-; RV64ZVKB-ZVE32X-NEXT:    sd s3, 96(sp) # 8-byte Folded Spill
+; RV64ZVKB-ZVE32X-NEXT:    sd s1, 104(sp) # 8-byte Folded Spill
+; RV64ZVKB-ZVE32X-NEXT:    sd s2, 96(sp) # 8-byte Folded Spill
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset ra, -8
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset s0, -16
-; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset s2, -24
-; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset s3, -32
+; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset s1, -24
+; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset s2, -32
 ; RV64ZVKB-ZVE32X-NEXT:    addi s0, sp, 128
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_def_cfa s0, 0
 ; RV64ZVKB-ZVE32X-NEXT:    andi sp, sp, -64
@@ -1021,12 +1021,12 @@ define <8 x i64> @shuffle_v8i64_as_i128(<8 x i64> %v) {
 ; RV64ZVKB-ZVE32X-NEXT:    srli t4, a4, 32
 ; RV64ZVKB-ZVE32X-NEXT:    srli t5, a7, 32
 ; RV64ZVKB-ZVE32X-NEXT:    srli t6, a6, 32
-; RV64ZVKB-ZVE32X-NEXT:    srli s2, a1, 32
-; RV64ZVKB-ZVE32X-NEXT:    srli s3, t0, 32
+; RV64ZVKB-ZVE32X-NEXT:    srli s1, a1, 32
+; RV64ZVKB-ZVE32X-NEXT:    srli s2, t0, 32
 ; RV64ZVKB-ZVE32X-NEXT:    sw a1, 48(sp)
-; RV64ZVKB-ZVE32X-NEXT:    sw s2, 52(sp)
+; RV64ZVKB-ZVE32X-NEXT:    sw s1, 52(sp)
 ; RV64ZVKB-ZVE32X-NEXT:    sw t0, 56(sp)
-; RV64ZVKB-ZVE32X-NEXT:    sw s3, 60(sp)
+; RV64ZVKB-ZVE32X-NEXT:    sw s2, 60(sp)
 ; RV64ZVKB-ZVE32X-NEXT:    sw a7, 32(sp)
 ; RV64ZVKB-ZVE32X-NEXT:    sw t5, 36(sp)
 ; RV64ZVKB-ZVE32X-NEXT:    sw a6, 40(sp)
@@ -1047,12 +1047,12 @@ define <8 x i64> @shuffle_v8i64_as_i128(<8 x i64> %v) {
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_def_cfa sp, 128
 ; RV64ZVKB-ZVE32X-NEXT:    ld ra, 120(sp) # 8-byte Folded Reload
 ; RV64ZVKB-ZVE32X-NEXT:    ld s0, 112(sp) # 8-byte Folded Reload
-; RV64ZVKB-ZVE32X-NEXT:    ld s2, 104(sp) # 8-byte Folded Reload
-; RV64ZVKB-ZVE32X-NEXT:    ld s3, 96(sp) # 8-byte Folded Reload
+; RV64ZVKB-ZVE32X-NEXT:    ld s1, 104(sp) # 8-byte Folded Reload
+; RV64ZVKB-ZVE32X-NEXT:    ld s2, 96(sp) # 8-byte Folded Reload
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_restore ra
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_restore s0
+; RV64ZVKB-ZVE32X-NEXT:    .cfi_restore s1
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_restore s2
-; RV64ZVKB-ZVE32X-NEXT:    .cfi_restore s3
 ; RV64ZVKB-ZVE32X-NEXT:    addi sp, sp, 128
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_def_cfa_offset 0
 ; RV64ZVKB-ZVE32X-NEXT:    ret
@@ -1210,12 +1210,12 @@ define <8 x i64> @shuffle_v8i64_as_i256(<8 x i64> %v) {
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_def_cfa_offset 128
 ; RV32ZVKB-ZVE32X-NEXT:    sw ra, 124(sp) # 4-byte Folded Spill
 ; RV32ZVKB-ZVE32X-NEXT:    sw s0, 120(sp) # 4-byte Folded Spill
-; RV32ZVKB-ZVE32X-NEXT:    sw s2, 116(sp) # 4-byte Folded Spill
-; RV32ZVKB-ZVE32X-NEXT:    sw s3, 112(sp) # 4-byte Folded Spill
+; RV32ZVKB-ZVE32X-NEXT:    sw s1, 116(sp) # 4-byte Folded Spill
+; RV32ZVKB-ZVE32X-NEXT:    sw s2, 112(sp) # 4-byte Folded Spill
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset ra, -4
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset s0, -8
-; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset s2, -12
-; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset s3, -16
+; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset s1, -12
+; RV32ZVKB-ZVE32X-NEXT:    .cfi_offset s2, -16
 ; RV32ZVKB-ZVE32X-NEXT:    addi s0, sp, 128
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_def_cfa s0, 0
 ; RV32ZVKB-ZVE32X-NEXT:    andi sp, sp, -64
@@ -1232,15 +1232,15 @@ define <8 x i64> @shuffle_v8i64_as_i256(<8 x i64> %v) {
 ; RV32ZVKB-ZVE32X-NEXT:    lw t4, 40(a1)
 ; RV32ZVKB-ZVE32X-NEXT:    lw t5, 44(a1)
 ; RV32ZVKB-ZVE32X-NEXT:    lw t6, 48(a1)
-; RV32ZVKB-ZVE32X-NEXT:    lw s2, 52(a1)
-; RV32ZVKB-ZVE32X-NEXT:    lw s3, 56(a1)
+; RV32ZVKB-ZVE32X-NEXT:    lw s1, 52(a1)
+; RV32ZVKB-ZVE32X-NEXT:    lw s2, 56(a1)
 ; RV32ZVKB-ZVE32X-NEXT:    lw a1, 60(a1)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t2, 48(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t3, 52(sp)
-; RV32ZVKB-ZVE32X-NEXT:    sw s3, 56(sp)
+; RV32ZVKB-ZVE32X-NEXT:    sw s2, 56(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw a1, 60(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t6, 32(sp)
-; RV32ZVKB-ZVE32X-NEXT:    sw s2, 36(sp)
+; RV32ZVKB-ZVE32X-NEXT:    sw s1, 36(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t4, 40(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw t5, 44(sp)
 ; RV32ZVKB-ZVE32X-NEXT:    sw a2, 16(sp)
@@ -1259,12 +1259,12 @@ define <8 x i64> @shuffle_v8i64_as_i256(<8 x i64> %v) {
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_def_cfa sp, 128
 ; RV32ZVKB-ZVE32X-NEXT:    lw ra, 124(sp) # 4-byte Folded Reload
 ; RV32ZVKB-ZVE32X-NEXT:    lw s0, 120(sp) # 4-byte Folded Reload
-; RV32ZVKB-ZVE32X-NEXT:    lw s2, 116(sp) # 4-byte Folded Reload
-; RV32ZVKB-ZVE32X-NEXT:    lw s3, 112(sp) # 4-byte Folded Reload
+; RV32ZVKB-ZVE32X-NEXT:    lw s1, 116(sp) # 4-byte Folded Reload
+; RV32ZVKB-ZVE32X-NEXT:    lw s2, 112(sp) # 4-byte Folded Reload
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_restore ra
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_restore s0
+; RV32ZVKB-ZVE32X-NEXT:    .cfi_restore s1
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_restore s2
-; RV32ZVKB-ZVE32X-NEXT:    .cfi_restore s3
 ; RV32ZVKB-ZVE32X-NEXT:    addi sp, sp, 128
 ; RV32ZVKB-ZVE32X-NEXT:    .cfi_def_cfa_offset 0
 ; RV32ZVKB-ZVE32X-NEXT:    ret
@@ -1275,12 +1275,12 @@ define <8 x i64> @shuffle_v8i64_as_i256(<8 x i64> %v) {
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_def_cfa_offset 128
 ; RV64ZVKB-ZVE32X-NEXT:    sd ra, 120(sp) # 8-byte Folded Spill
 ; RV64ZVKB-ZVE32X-NEXT:    sd s0, 112(sp) # 8-byte Folded Spill
-; RV64ZVKB-ZVE32X-NEXT:    sd s2, 104(sp) # 8-byte Folded Spill
-; RV64ZVKB-ZVE32X-NEXT:    sd s3, 96(sp) # 8-byte Folded Spill
+; RV64ZVKB-ZVE32X-NEXT:    sd s1, 104(sp) # 8-byte Folded Spill
+; RV64ZVKB-ZVE32X-NEXT:    sd s2, 96(sp) # 8-byte Folded Spill
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset ra, -8
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset s0, -16
-; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset s2, -24
-; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset s3, -32
+; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset s1, -24
+; RV64ZVKB-ZVE32X-NEXT:    .cfi_offset s2, -32
 ; RV64ZVKB-ZVE32X-NEXT:    addi s0, sp, 128
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_def_cfa s0, 0
 ; RV64ZVKB-ZVE32X-NEXT:    andi sp, sp, -64
@@ -1298,12 +1298,12 @@ define <8 x i64> @shuffle_v8i64_as_i256(<8 x i64> %v) {
 ; RV64ZVKB-ZVE32X-NEXT:    srli t4, a5, 32
 ; RV64ZVKB-ZVE32X-NEXT:    srli t5, t0, 32
 ; RV64ZVKB-ZVE32X-NEXT:    srli t6, a7, 32
-; RV64ZVKB-ZVE32X-NEXT:    srli s2, a6, 32
-; RV64ZVKB-ZVE32X-NEXT:    srli s3, a1, 32
+; RV64ZVKB-ZVE32X-NEXT:    srli s1, a6, 32
+; RV64ZVKB-ZVE32X-NEXT:    srli s2, a1, 32
 ; RV64ZVKB-ZVE32X-NEXT:    sw a6, 48(sp)
-; RV64ZVKB-ZVE32X-NEXT:    sw s2, 52(sp)
+; RV64ZVKB-ZVE32X-NEXT:    sw s1, 52(sp)
 ; RV64ZVKB-ZVE32X-NEXT:    sw a1, 56(sp)
-; RV64ZVKB-ZVE32X-NEXT:    sw s3, 60(sp)
+; RV64ZVKB-ZVE32X-NEXT:    sw s2, 60(sp)
 ; RV64ZVKB-ZVE32X-NEXT:    sw t0, 32(sp)
 ; RV64ZVKB-ZVE32X-NEXT:    sw t5, 36(sp)
 ; RV64ZVKB-ZVE32X-NEXT:    sw a7, 40(sp)
@@ -1324,12 +1324,12 @@ define <8 x i64> @shuffle_v8i64_as_i256(<8 x i64> %v) {
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_def_cfa sp, 128
 ; RV64ZVKB-ZVE32X-NEXT:    ld ra, 120(sp) # 8-byte Folded Reload
 ; RV64ZVKB-ZVE32X-NEXT:    ld s0, 112(sp) # 8-byte Folded Reload
-; RV64ZVKB-ZVE32X-NEXT:    ld s2, 104(sp) # 8-byte Folded Reload
-; RV64ZVKB-ZVE32X-NEXT:    ld s3, 96(sp) # 8-byte Folded Reload
+; RV64ZVKB-ZVE32X-NEXT:    ld s1, 104(sp) # 8-byte Folded Reload
+; RV64ZVKB-ZVE32X-NEXT:    ld s2, 96(sp) # 8-byte Folded Reload
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_restore ra
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_restore s0
+; RV64ZVKB-ZVE32X-NEXT:    .cfi_restore s1
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_restore s2
-; RV64ZVKB-ZVE32X-NEXT:    .cfi_restore s3
 ; RV64ZVKB-ZVE32X-NEXT:    addi sp, sp, 128
 ; RV64ZVKB-ZVE32X-NEXT:    .cfi_def_cfa_offset 0
 ; RV64ZVKB-ZVE32X-NEXT:    ret


### PR DESCRIPTION
I want to enable the frame pointer when the call frame size is too large to access emergency spill slots. To do that I need to know the call frame size early enough to reserve FP.

The code here is copied from AArch64. ARM does the same. I did not check other targets.

Splitting this off separately because it stops us from unnecessarily reserving the base pointer in the some RVV tests. That appears to due to this check

          (!hasReservedCallFrame(MF) && (!MFI.isMaxCallFrameSizeComputed() ||
                                         MFI.getMaxCallFrameSize() != 0))) &&

By calculating early !MFI.isMaxCallFrameSizeComputed() is no longer true and the size is zero.