### PR TITLE
[libclc] Fix memory_scope and memory_order of *mem_fence builtins

### DIFF
--- a/libclc/opencl/lib/amdgcn/mem_fence/fence.cl
+++ b/libclc/opencl/lib/amdgcn/mem_fence/fence.cl
@@ -10,17 +10,22 @@
 #include <clc/opencl/synchronization/utils.h>
 
 _CLC_DEF _CLC_OVERLOAD void mem_fence(cl_mem_fence_flags flags) {
-  int memory_scope = __opencl_get_memory_scope(flags);
-  int memory_order = __ATOMIC_SEQ_CST;
+  int memory_scope = __MEMORY_SCOPE_WRKGRP;
+  int memory_order = __ATOMIC_ACQ_REL;
   __CLC_MemorySemantics memory_semantics = __opencl_get_memory_semantics(flags);
   __clc_mem_fence(memory_scope, memory_order, memory_semantics);
 }
 
-// We don't have separate mechanism for read and write fences
 _CLC_DEF _CLC_OVERLOAD void read_mem_fence(cl_mem_fence_flags flags) {
-  mem_fence(flags);
+  int memory_scope = __MEMORY_SCOPE_WRKGRP;
+  int memory_order = __ATOMIC_ACQUIRE;
+  __CLC_MemorySemantics memory_semantics = __opencl_get_memory_semantics(flags);
+  __clc_mem_fence(memory_scope, memory_order, memory_semantics);
 }
 
 _CLC_DEF _CLC_OVERLOAD void write_mem_fence(cl_mem_fence_flags flags) {
-  mem_fence(flags);
+  int memory_scope = __MEMORY_SCOPE_WRKGRP;
+  int memory_order = __ATOMIC_RELEASE;
+  __CLC_MemorySemantics memory_semantics = __opencl_get_memory_semantics(flags);
+  __clc_mem_fence(memory_scope, memory_order, memory_semantics);
 }

--- a/libclc/opencl/lib/ptx-nvidiacl/mem_fence/fence.cl
+++ b/libclc/opencl/lib/ptx-nvidiacl/mem_fence/fence.cl
@@ -28,5 +28,4 @@ _CLC_DEF _CLC_OVERLOAD void write_mem_fence(cl_mem_fence_flags flags) {
   int memory_order = __ATOMIC_RELEASE;
   __CLC_MemorySemantics memory_semantics = __opencl_get_memory_semantics(flags);
   __clc_mem_fence(memory_scope, memory_order, memory_semantics);
-  mem_fence(flags);
 }

--- a/libclc/opencl/lib/ptx-nvidiacl/mem_fence/fence.cl
+++ b/libclc/opencl/lib/ptx-nvidiacl/mem_fence/fence.cl
@@ -21,7 +21,6 @@ _CLC_DEF _CLC_OVERLOAD void read_mem_fence(cl_mem_fence_flags flags) {
   int memory_order = __ATOMIC_ACQUIRE;
   __CLC_MemorySemantics memory_semantics = __opencl_get_memory_semantics(flags);
   __clc_mem_fence(memory_scope, memory_order, memory_semantics);
-  mem_fence(flags);
 }
 
 _CLC_DEF _CLC_OVERLOAD void write_mem_fence(cl_mem_fence_flags flags) {

--- a/libclc/opencl/lib/ptx-nvidiacl/mem_fence/fence.cl
+++ b/libclc/opencl/lib/ptx-nvidiacl/mem_fence/fence.cl
@@ -10,17 +10,24 @@
 #include <clc/opencl/synchronization/utils.h>
 
 _CLC_DEF _CLC_OVERLOAD void mem_fence(cl_mem_fence_flags flags) {
-  int memory_scope = __opencl_get_memory_scope(flags);
-  int memory_order = __ATOMIC_SEQ_CST;
+  int memory_scope = __MEMORY_SCOPE_WRKGRP;
+  int memory_order = __ATOMIC_ACQ_REL;
   __CLC_MemorySemantics memory_semantics = __opencl_get_memory_semantics(flags);
   __clc_mem_fence(memory_scope, memory_order, memory_semantics);
 }
 
-// We do not have separate mechanism for read and write fences.
 _CLC_DEF _CLC_OVERLOAD void read_mem_fence(cl_mem_fence_flags flags) {
+  int memory_scope = __MEMORY_SCOPE_WRKGRP;
+  int memory_order = __ATOMIC_ACQUIRE;
+  __CLC_MemorySemantics memory_semantics = __opencl_get_memory_semantics(flags);
+  __clc_mem_fence(memory_scope, memory_order, memory_semantics);
   mem_fence(flags);
 }
 
 _CLC_DEF _CLC_OVERLOAD void write_mem_fence(cl_mem_fence_flags flags) {
+  int memory_scope = __MEMORY_SCOPE_WRKGRP;
+  int memory_order = __ATOMIC_RELEASE;
+  __CLC_MemorySemantics memory_semantics = __opencl_get_memory_semantics(flags);
+  __clc_mem_fence(memory_scope, memory_order, memory_semantics);
   mem_fence(flags);
 }


### PR DESCRIPTION
See OpenCL spec 6.15.12.5.
https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#fences

// Older syntax memory fences are equivalent to atomic_work_item_fence with the // same flags parameter, memory_scope_work_group scope, and ordering as follows:
void mem_fence(cl_mem_fence_flags flags)        // memory_order_acq_rel
void read_mem_fence(cl_mem_fence_flags flags)   // memory_order_acquire
void write_mem_fence(cl_mem_fence_flags flags)  // memory_order_release