### PR TITLE
[clang][Coverage] Fix crash for nested macro in system headers

### DIFF
--- a/clang/test/CoverageMapping/system_nested_macro.cpp
+++ b/clang/test/CoverageMapping/system_nested_macro.cpp
@@ -1,0 +1,22 @@
+// Check nested macro handling when including a system header.
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -std=c++11 -isystem %t -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -emit-llvm -main-file-name system_nested_macro.cpp -o - %t/system_nested_macro.cpp | FileCheck %t/system_nested_macro.cpp --check-prefixes=CHECK,X_SYS
+// RUN: %clang_cc1 -std=c++11 -isystem %t -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -mllvm -system-headers-coverage=true -emit-llvm -main-file-name system_nested_macro.cpp -o - %t/system_nested_macro.cpp | FileCheck %t/system_nested_macro.cpp --check-prefixes=CHECK,W_SYS
+
+//--- system_nested_macro.cpp
+// CHECK-LABEL: main:
+// CHECK: File 0, [[@LINE+6]]:12 -> [[@LINE+9]]:2 = #0
+// X_SYS: File 1, [[@LINE+6]]:11 -> [[@LINE+6]]:12 = #0
+// X_SYS-NOT: Expansion,
+// W_SYS: Expansion,File 0, [[@LINE+5]]:10 -> [[@LINE+5]]:11 = #0 (Expanded file = 1)
+// W_SYS: File 1, 1:1 -> 3:1 = #0
+
+int main() {
+#define X ;
+#include <nested.h>
+}
+
+//--- nested.h
+#define Y X
+Y


### PR DESCRIPTION
When coverage mapping is enabled, including a nested macro through `-isystem`
can produce source regions whose spelling locations are still in system
headers. `CoverageMappingBuilder::gatherFileIDs` asserted these regions away
instead of treating them as uncovered when system header coverage is disabled.

Replace the assert-only behavior with a real filter based on spelling
locations, and reuse the same system-header predicate in both
`gatherFileIDs` and `emitSourceRegions` to keep the policy consistent.

Fixes #179316