### PR TITLE
[mlir][test-ir-visitors] Fix noSkipBlockErasure for blocks providing global context

### DIFF
--- a/mlir/test/IR/visitors.mlir
+++ b/mlir/test/IR/visitors.mlir
@@ -382,3 +382,20 @@ func.func @unordered_cfg_with_loop() {
 // CHECK:       Cannot erase block ^bb2 from region 0 from operation 'regionOp0', still has uses
 // CHECK:       Cannot erase block ^bb3 from region 0 from operation 'regionOp0', still has uses
 // CHECK:       Cannot erase block ^bb4 from region 0 from operation 'regionOp0', still has uses
+
+// -----
+
+// The following test should not crash while visiting the intra-op blocks (inside the top level 
+// function in this case). We are testing that the intra-block ops are erased after dropping their
+// uses from ops with same parent region.
+// CHECK-LABEL: func.func @test_no_skip_block_erasure
+func.func @test_no_skip_block_erasure() {
+  %c0 = arith.constant 0 : index
+  %c3 = arith.constant 3 : index
+  cf.br ^bb1
+^bb1:
+  %cond = arith.cmpi eq, %c0, %c3 : index
+  cf.br ^bb4
+^bb4:
+  return
+}


### PR DESCRIPTION
The pass checks if something is pointing to the current block in testNoSkipErasureCallbacks() inside noSkipBlockErasure() callback and erases it if no one is pointing to it. However, it doesn't consider the case where
the current block might be providing global context to other blocks in the same parent region even if no one is pointing to it (see the attached test for an example of this). Erasing this block would then lead to invalid IR. We solve this by dropping intra-block op uses from ops within the same parent region.

Fixes https://github.com/llvm/llvm-project/issues/178099