### PR TITLE
[mlir][OpenMP] Introduce 'omp.iterators' for OpenMP iterator modifiers

### DIFF
--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOpBase.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOpBase.td
@@ -38,6 +38,13 @@ def OpenMP_MapBoundsType : OpenMP_Type<"MapBounds", "map_bounds_ty"> {
   let summary = "Type for representing omp map clause bounds information";
 }
 
+def OpenMP_IteratedType : OpenMP_Type<"Iterated", "iterated"> {
+  let summary = "OpenMP iterator-produced list handle";
+
+  let parameters = (ins "Type":$elementType);
+  let assemblyFormat = "`<` $elementType `>`";
+}
+
 //===---------------------------------------------------------------------===//
 // OpenMP Canonical Loop Info Type
 //===---------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -818,11 +818,11 @@ def SimdOp : OpenMP_Op<"simd", traits = [
   let hasRegionVerifier = 1;
 }
 
-
-def YieldOp : OpenMP_Op<"yield",
-    [Pure, ReturnLike, Terminator,
-     ParentOneOf<["AtomicUpdateOp", "DeclareReductionOp", "LoopNestOp",
-                  "PrivateClauseOp"]>]> {
+def YieldOp
+    : OpenMP_Op<"yield", [Pure, ReturnLike, Terminator,
+                          ParentOneOf<["AtomicUpdateOp", "DeclareReductionOp",
+                                       "LoopNestOp", "PrivateClauseOp",
+                                       "IteratorsOp"]>]> {
   let summary = "loop yield and termination operation";
   let description = [{
     "omp.yield" yields SSA values from the OpenMP dialect op region and
@@ -2269,6 +2269,43 @@ def DeclareSimdOp
 
   let builders = [OpBuilder<(
       ins CArg<"const DeclareSimdOperands &">:$clauses)>];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Iterators Op
+//===----------------------------------------------------------------------===//
+
+def IteratorsOp
+    : OpenMP_Op<"iterators", [AttrSizedOperandSegments,
+                              SingleBlockImplicitTerminator<"YieldOp">]> {
+  let summary = "OpenMP iterator modifier";
+  let description = [{
+    The result of `omp.iterators` is an abstract handle of type
+    `!omp.iterated<T>`, representing the list of yielded values. This handle
+    can be directly consumed by OpenMP clauses that accept iterator modifiers,
+    such as `affinity`, `map`, `to`, `from`, or `depend`.
+
+    Example:
+      %it = omp.iterators(%i, %j) =
+        (%lb_i to %ub_i step %st_i, %lb_j to %ub_j step %st_j) {
+        %addr = ...
+        omp.yield(%addr)
+      } -> !omp.iterated<ptr>
+  }];
+
+  let arguments = (ins Variadic<IntLikeType>:$lbs, Variadic<IntLikeType>:$ubs,
+      Variadic<IntLikeType>:$steps);
+  let regions = (region SizedRegion<1>:$region);
+  let results = (outs OpenMP_IteratedType:$iterated);
+
+  let assemblyFormat = [{
+    `(` custom<IteratorsHeader>($region,
+                                $lbs, $ubs, $steps,
+                                type($lbs), type($ubs), type($steps))
+    `->` qualified(type($iterated)) attr-dict
+  }];
 
   let hasVerifier = 1;
 }

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -4561,6 +4561,114 @@ static void printAffinityClause(OpAsmPrinter &p, Operation *op,
   }
 }
 
+//===----------------------------------------------------------------------===//
+// Parser, printer, and verifier for Iterator modifier
+//===----------------------------------------------------------------------===//
+
+static ParseResult
+parseIteratorsHeader(OpAsmParser &parser, Region &region,
+                     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &lbs,
+                     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &ubs,
+                     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &steps,
+                     SmallVectorImpl<Type> &lbTypes,
+                     SmallVectorImpl<Type> &ubTypes,
+                     SmallVectorImpl<Type> &stepTypes) {
+
+  llvm::SMLoc ivLoc = parser.getCurrentLocation();
+  SmallVector<OpAsmParser::Argument> ivArgs;
+
+  // Parse induction variables: %i : i32, %j : i32
+  if (parser.parseCommaSeparatedList([&]() -> ParseResult {
+        OpAsmParser::Argument &arg = ivArgs.emplace_back();
+        if (parser.parseArgument(arg))
+          return failure();
+
+        // Optional type, default to Index if not provided
+        if (succeeded(parser.parseOptionalColon())) {
+          if (parser.parseType(arg.type))
+            return failure();
+        } else {
+          arg.type = parser.getBuilder().getIndexType();
+        }
+        return success();
+      }))
+    return failure();
+
+  // ) = (
+  if (parser.parseRParen() || parser.parseEqual() || parser.parseLParen())
+    return failure();
+
+  // Parse Ranges: (%lb to %ub step %st, ...)
+  if (parser.parseCommaSeparatedList([&]() -> ParseResult {
+        OpAsmParser::UnresolvedOperand lb, ub, st;
+        if (parser.parseOperand(lb) || parser.parseKeyword("to") ||
+            parser.parseOperand(ub) || parser.parseKeyword("step") ||
+            parser.parseOperand(st))
+          return failure();
+
+        lbs.push_back(lb);
+        ubs.push_back(ub);
+        steps.push_back(st);
+        return success();
+      }))
+    return failure();
+
+  if (parser.parseRParen())
+    return failure();
+
+  if (ivArgs.size() != lbs.size())
+    return parser.emitError(ivLoc)
+           << "mismatch: " << ivArgs.size() << " variables but " << lbs.size()
+           << " ranges";
+
+  for (auto &arg : ivArgs) {
+    lbTypes.push_back(arg.type);
+    ubTypes.push_back(arg.type);
+    stepTypes.push_back(arg.type);
+  }
+
+  return parser.parseRegion(region, ivArgs);
+}
+
+static void printIteratorsHeader(OpAsmPrinter &p, Operation *op, Region &region,
+                                 ValueRange lbs, ValueRange ubs,
+                                 ValueRange steps, TypeRange, TypeRange,
+                                 TypeRange) {
+  Block &entry = region.front();
+
+  for (unsigned i = 0, e = entry.getNumArguments(); i < e; ++i) {
+    if (i != 0)
+      p << ", ";
+    p.printRegionArgument(entry.getArgument(i));
+  }
+  p << ") = (";
+
+  // (%lb0 to %ub0 step %step0, %lb1 to %ub1 step %step1, ...)
+  for (unsigned i = 0, e = lbs.size(); i < e; ++i) {
+    if (i)
+      p << ", ";
+    p << lbs[i] << " to " << ubs[i] << " step " << steps[i];
+  }
+  p << ") ";
+
+  p.printRegion(region, /*printEntryBlockArgs=*/false,
+                /*printBlockTerminators=*/true);
+}
+
+LogicalResult IteratorsOp::verify() {
+  auto iteratedTy = llvm::dyn_cast<omp::IteratedType>(getIterated().getType());
+  if (!iteratedTy)
+    return emitOpError() << "result must be omp.iterated<entry_ty>";
+
+  Block &b = getRegion().front();
+  auto yield = llvm::dyn_cast<omp::YieldOp>(b.getTerminator());
+
+  if (!yield)
+    return emitOpError() << "region must be terminated by omp.yield";
+
+  return success();
+}
+
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/OpenMP/OpenMPOpsAttributes.cpp.inc"
 

--- a/mlir/test/Dialect/OpenMP/invalid.mlir
+++ b/mlir/test/Dialect/OpenMP/invalid.mlir
@@ -3167,3 +3167,23 @@ func.func @omp_declare_simd_branch() -> () {
   omp.declare_simd inbranch notinbranch
   return
 }
+
+// -----
+
+func.func @iterators_bad_result_type(%lb : index, %ub : index, %st : index) {
+  // expected-error@+1 {{result #0 must be OpenMP iterator-produced list handle, but got 'index'}}
+  %0 = omp.iterators(%i: index) = (%lb to %ub step %st) {
+    omp.yield(%i : index)
+  } -> index
+  return
+}
+
+// -----
+
+func.func @iterators_missing_yield(%lb : index, %ub : index, %st : index) {
+  // expected-error@+1 {{region must be terminated by omp.yield}}
+  %0 = omp.iterators(%i: index) = (%lb to %ub step %st) {
+    func.return
+  } -> !omp.iterated<index>
+  return
+}

--- a/mlir/test/Dialect/OpenMP/ops.mlir
+++ b/mlir/test/Dialect/OpenMP/ops.mlir
@@ -3550,3 +3550,32 @@ func.func @task_affinity_multi() {
   }
   return
 }
+
+// CHECK-LABEL: func.func @omp_iterators(
+func.func @omp_iterators(%lb : index, %ub : index, %step : index) -> () {
+  // CHECK: %[[IT:.*]] = omp.iterators(%[[IV:.*]]: index) = (%[[LB:.*]] to %[[UB:.*]] step %[[ST:.*]]) {
+  // CHECK:   omp.yield({{.*}} : index)
+  // CHECK: } -> !omp.iterated<!llvm.struct<(ptr, i64)>>
+  %0 = omp.iterators(%arg0: index) = (%lb to %ub step %step) {
+    omp.yield(%arg0 : index)
+  } -> !omp.iterated<!llvm.struct<(!llvm.ptr, i64)>>
+  return
+}
+
+// CHECK-LABEL: func.func @omp_iterators_2d(
+func.func @omp_iterators_2d(%lb0 : index, %ub0 : index, %st0 : index,
+                            %lb1 : index, %ub1 : index, %st1 : index) -> () {
+  // CHECK: %[[IT:.*]] = omp.iterators(%[[IV0:.*]]: index, %[[IV1:.*]]: index) =
+  // CHECK-SAME: (%[[LB0:.*]] to %[[UB0:.*]] step %[[ST0:.*]],
+  // CHECK-SAME:  %[[LB1:.*]] to %[[UB1:.*]] step %[[ST1:.*]]) {
+  // CHECK: omp.yield(%[[IV0]], %[[IV1]] : index, index)
+  // CHECK: } -> !omp.iterated<!llvm.struct<(ptr, i64)>>
+
+  %it = omp.iterators(%i0: index, %i1: index) =
+        (%lb0 to %ub0 step %st0,
+         %lb1 to %ub1 step %st1) {
+    omp.yield(%i0, %i1 : index, index)
+  } -> !omp.iterated<!llvm.struct<(!llvm.ptr, i64)>>
+
+  return
+}


### PR DESCRIPTION
`omp.iterators` provides information of induction variables and iterator range in OpenMP iterator modifier.

Example:
```
  %it = omp.iterators(%i0: index, %i1: index) =
        (%lb0 to %ub0 step %st0,
         %lb1 to %ub1 step %st1) {
    omp.yield(%i0, %i1 : index, index)
  } -> !omp.iterated<!llvm.struct<(!llvm.ptr, i64)>>
```

Here's how we can use the omp.iteraters to generate multi-dimensional loop in llvm ir:
```
  // Induction variables can be translated from the block arguments
  // in omp.iterators.
  // lbs, ubs, and steps is encoded in omp.iterators
  for (int i0 = lbs[0]; i0 < ubs[0]; i0 += steps[0]) {
      for (int i0 = lbs[1]; i1 < ubs[1]; i1 += steps[1]) {
          // the result of iterated is <ptr, i64> from the example
          iterated = omp.iterators(i, j);
      }
  }
```