### PR TITLE
[clang][bytecode] Fix __builtin_nan* for non-primitive arrays

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -411,7 +411,8 @@ static bool interp__builtin_nan(InterpState &S, CodePtr OpPC,
   if (!CheckLoad(S, OpPC, Arg))
     return false;
 
-  assert(Arg.getFieldDesc()->isPrimitiveArray());
+  if (!Arg.getFieldDesc()->isPrimitiveArray())
+    return Invalid(S, OpPC);
 
   // Convert the given string to an integer using StringRef's API.
   llvm::APInt Fill;

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -391,6 +391,10 @@ namespace floating_comparison {
   static_assert(UNORDERED(__builtin_nanf(""), __builtin_inff()));
   static_assert(UNORDERED(__builtin_nanl(""), 1.0L));
   static_assert(UNORDERED(__builtin_nanl(""), __builtin_infl()));
+
+  struct {
+  } const s;
+  static_assert(__builtin_nan((const char *)&s) == 0); // both-error {{not an integral constant expression}}
 }
 
 namespace fpclassify {


### PR DESCRIPTION
They might've been casted, so we need t check for it, not assert.