### PR TITLE
[clang][bytecode] Strip atomicity in Descriptor::getElemQualType()

### DIFF
--- a/clang/lib/AST/ByteCode/Descriptor.cpp
+++ b/clang/lib/AST/ByteCode/Descriptor.cpp
@@ -388,6 +388,8 @@ QualType Descriptor::getType() const {
 QualType Descriptor::getElemQualType() const {
   assert(isArray());
   QualType T = getType();
+  if (const auto *AT = T->getAs<AtomicType>())
+    T = AT->getValueType();
   if (T->isPointerOrReferenceType())
     T = T->getPointeeType();
 

--- a/clang/test/AST/ByteCode/vectors.cpp
+++ b/clang/test/AST/ByteCode/vectors.cpp
@@ -39,6 +39,10 @@ static_assert(arr4[1][0] == 0, "");
 
 constexpr VI4 B = __extension__(A);
 
+/// Can initialize atomic vectors.
+typedef char vs4 __attribute__((vector_size(4)));
+constexpr _Atomic vs4 foo = (vs4)0xDEADBEEF;
+
 /// From constant-expression-cxx11.cpp
 namespace Vector {
   typedef int __attribute__((vector_size(16))) VI4;


### PR DESCRIPTION
The later check for VectorType fails otherwise.