### PR TITLE
[Support] Fixup for formatting hex on 32 bit

### DIFF
--- a/llvm/unittests/Support/FormatVariadicTest.cpp
+++ b/llvm/unittests/Support/FormatVariadicTest.cpp
@@ -404,8 +404,9 @@ TEST(FormatAndFormatvTest, EquivalentHexFormatting) {
 
   // Here's the old format() way of printing a hex number with
   // dynamic width and precision, both being the same.
-  EXPECT_EQ("0x00000000ff",
-            printToString(100, format("0x%*.*x", HexDigits, HexDigits, N)));
+  EXPECT_EQ(
+      "0x00000000ff",
+      printToString(100, format("0x%*.*" PRIx64, HexDigits, HexDigits, N)));
 
   // Now, do the same with formatv()
   EXPECT_EQ("0x00000000ff",


### PR DESCRIPTION
Without the `PRIx64`, the test won't work on 32 bit architectures.

See this comment: https://github.com/llvm/llvm-project/pull/180498#issuecomment-3891979182

The issue is that `PRIx64` expands differently depending on the architecture. In the original code modified in #180498 the [macro was used](https://github.com/llvm/llvm-project/pull/180498/changes#diff-5dcf6451d2bf9e9e3a8d28b0212263a8db576045b1d4eab80cca1bfd13a3bb76L356):

```diff
-  OS << format("0x%*.*" PRIx64, HexDigits, HexDigits, Address);
+  OS << formatv("0x{0:x-}",
+                fmt_align(Address, AlignStyle::Right, HexDigits, '0'));
```

I simply didn't use it in my test because on my architecture the `PRIx64` wasn't necessary.

This is a fixup for #180498 and it should unblock the [clang-armv7-vfpv3-2stage](https://lab.llvm.org/buildbot/#/builders/135) builder.