### PR TITLE
[mlir] Reject dense_resource blobs with zero alignment

### DIFF
--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -2699,7 +2699,7 @@ public:
     }
     llvm::support::ulittle32_t align;
     memcpy(&align, blobData->data(), sizeof(uint32_t));
-    if (align && !llvm::isPowerOf2_32(align)) {
+    if (align==0 || !llvm::isPowerOf2_32(align)) {
       return p.emitError(value.getLoc(),
                          "expected hex string blob for key '" + key +
                              "' to encode alignment in first 4 bytes, but got "

--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -2699,7 +2699,7 @@ public:
     }
     llvm::support::ulittle32_t align;
     memcpy(&align, blobData->data(), sizeof(uint32_t));
-    if (align==0 || !llvm::isPowerOf2_32(align)) {
+    if (align == 0 || !llvm::isPowerOf2_32(align)) {
       return p.emitError(value.getLoc(),
                          "expected hex string blob for key '" + key +
                              "' to encode alignment in first 4 bytes, but got "

--- a/mlir/test/IR/dense-resource-elements-attr-invalid-alignment.mlir
+++ b/mlir/test/IR/dense-resource-elements-attr-invalid-alignment.mlir
@@ -1,0 +1,12 @@
+// RUN: mlir-opt -allow-unregistered-dialect %s -verify-diagnostics
+
+"test.user_op"() {attr = dense_resource<double_data> : tensor<2xf64>} : () -> ()
+
+{-#
+  dialect_resources: {
+    builtin: {
+      // expected-error @+1 {{expected hex string blob for key 'double_data' to encode alignment in first 4 bytes, but got non-power-of-2 value: 0}}
+      double_data: "0x000000000000F03F0000000000000040"
+    }
+  }
+#-}


### PR DESCRIPTION
### What's the problem 

mlir-opt could abort with “LLVM ERROR: out of memory” when parsing dense_resource blobs whose first 4 bytes encode alignment=0.

### Why it happened

The parser allowed alignment=0 due to a missing validation check, leading to invalid allocator calls.

### Whats the Fix

Reject alignment=0 (and non-power-of-2 values) with a proper diagnostic and add a regression test.

Fixes #181266
