### PR TITLE
Revert "workflows: Use main-branch-only environment when using ISSUE_SUBSCRIBER_TOKEN (#179990)"

### DIFF
--- a/.github/workflows/issue-subscriber.yml
+++ b/.github/workflows/issue-subscriber.yml
@@ -10,7 +10,6 @@ permissions:
 
 jobs:
   auto-subscribe:
-    environment: main-branch-only
     runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -10,7 +10,6 @@ jobs:
   automate-issues-labels:
     permissions:
       issues: write
-    environment: main-branch-only
     runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:

--- a/.github/workflows/new-prs.yml
+++ b/.github/workflows/new-prs.yml
@@ -55,8 +55,6 @@ jobs:
   automate-prs-labels:
     # Greet first so that only the author gets that notification.
     needs: greeter
-    # See https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/
-    environment: main-branch-only
     runs-on: ubuntu-24.04
     # Ignore PRs with more than 10 commits.  Pull requests with a lot of
     # commits tend to be accidents usually when someone made a mistake while trying

--- a/.github/workflows/pr-subscriber.yml
+++ b/.github/workflows/pr-subscriber.yml
@@ -10,8 +10,6 @@ permissions:
 
 jobs:
   auto-subscribe:
-    # See https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/
-    environment: main-branch-only
     runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:

--- a/.github/workflows/release-asset-audit.yml
+++ b/.github/workflows/release-asset-audit.yml
@@ -45,7 +45,6 @@ jobs:
 
   notify-audit-failed:
     name: "Notify Audit Failed"
-    environment: main-branch-only
     runs-on: ubuntu-24.04
     if: >-
       github.repository == 'llvm/llvm-project' &&


### PR DESCRIPTION
This reverts commit 31f31dd9d0460834f2ae67247d3886fec4931d6d.

This commit was causing PRs to be spammed with messages like:

"llvmbot temporarily deployed to main-branch-only — with GitHub Actions Inactive"

This was causing confusion, and is not worth the marginal security benefit.  I also think this can be avoided by using called workflows, but I still need to investigate this.