### PR TITLE
[Flang][OpenMP] Fix for threadprivate check in copyin clause

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -3465,10 +3465,9 @@ void ResolveOmpParts(
 }
 
 static bool IsSymbolThreadprivate(const Symbol &symbol) {
-  if (const auto *details{symbol.detailsIf<HostAssocDetails>()}) {
-    return details->symbol().test(Symbol::Flag::OmpThreadprivate);
-  }
-  return symbol.test(Symbol::Flag::OmpThreadprivate);
+  const Symbol &ultimate{symbol.GetUltimate()};
+
+  return ultimate.test(Symbol::Flag::OmpThreadprivate);
 }
 
 static bool IsSymbolPrivate(const Symbol &symbol) {

--- a/flang/test/Semantics/OpenMP/common-block_copyin.f90
+++ b/flang/test/Semantics/OpenMP/common-block_copyin.f90
@@ -1,0 +1,12 @@
+!RUN: %python %S/../test_errors.py %s %flang -fopenmp
+
+program main
+  common /cmn/ k1
+!$omp threadprivate(/cmn/)
+contains
+  subroutine ss1
+  k1 = 1
+!$omp parallel copyin (k1)
+!$omp end parallel
+  end subroutine ss1
+end program main


### PR DESCRIPTION
Use the ultimate symbol in the threadprivate check

Fixes #180094