### PR TITLE
[clang] Fix some static initialization race-conditions

### DIFF
--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -40,6 +40,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstring>
 #include <optional>
@@ -64,11 +65,16 @@ struct StmtClassNameTable {
 };
 
 static StmtClassNameTable &getStmtInfoTableEntry(Stmt::StmtClass E) {
-  static StmtClassNameTable stmtClassInfo[Stmt::lastStmtConstant + 1] = {
+  static std::array<StmtClassNameTable, Stmt::lastStmtConstant + 1>
+      stmtClassInfo = []() {
+        std::array<StmtClassNameTable, Stmt::lastStmtConstant + 1> table;
 #define ABSTRACT_STMT(STMT)
-#define STMT(CLASS, PARENT) {#CLASS, 0, sizeof(CLASS)},
+#define STMT(CLASS, PARENT)                                                    \
+  table[static_cast<unsigned>(Stmt::CLASS##Class)].Name = #CLASS;              \
+  table[static_cast<unsigned>(Stmt::CLASS##Class)].Size = sizeof(CLASS);
 #include "clang/AST/StmtNodes.inc"
-  };
+        return table;
+      }();
   return stmtClassInfo[E];
 }
 

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -66,16 +66,16 @@ struct StmtClassNameTable {
 
 static StmtClassNameTable &getStmtInfoTableEntry(Stmt::StmtClass E) {
   static std::array<StmtClassNameTable, Stmt::lastStmtConstant + 1>
-      stmtClassInfo = []() {
-        std::array<StmtClassNameTable, Stmt::lastStmtConstant + 1> table;
+      StmtClassInfo = []() {
+        std::array<StmtClassNameTable, Stmt::lastStmtConstant + 1> Table;
 #define ABSTRACT_STMT(STMT)
 #define STMT(CLASS, PARENT)                                                    \
-  table[static_cast<unsigned>(Stmt::CLASS##Class)].Name = #CLASS;              \
-  table[static_cast<unsigned>(Stmt::CLASS##Class)].Size = sizeof(CLASS);
+  Table[static_cast<unsigned>(Stmt::CLASS##Class)].Name = #CLASS;              \
+  Table[static_cast<unsigned>(Stmt::CLASS##Class)].Size = sizeof(CLASS);
 #include "clang/AST/StmtNodes.inc"
-        return table;
+        return Table;
       }();
-  return stmtClassInfo[E];
+  return StmtClassInfo[E];
 }
 
 void *Stmt::operator new(size_t bytes, const ASTContext& C,
@@ -112,25 +112,25 @@ void Stmt::PrintStats() {
   unsigned sum = 0;
   llvm::errs() << "\n*** Stmt/Expr Stats:\n";
   for (int i = 0; i != Stmt::lastStmtConstant+1; i++) {
-    const StmtClassNameTable &entry =
+    const StmtClassNameTable &Entry =
         getStmtInfoTableEntry(static_cast<Stmt::StmtClass>(i));
-    if (entry.Name == nullptr)
+    if (Entry.Name == nullptr)
       continue;
-    sum += entry.Counter;
+    sum += Entry.Counter;
   }
   llvm::errs() << "  " << sum << " stmts/exprs total.\n";
   sum = 0;
   for (int i = 0; i != Stmt::lastStmtConstant+1; i++) {
-    const StmtClassNameTable &entry =
+    const StmtClassNameTable &Entry =
         getStmtInfoTableEntry(static_cast<Stmt::StmtClass>(i));
-    if (entry.Name == nullptr)
+    if (Entry.Name == nullptr)
       continue;
-    if (entry.Counter == 0)
+    if (Entry.Counter == 0)
       continue;
-    llvm::errs() << "    " << entry.Counter << " " << entry.Name << ", "
-                 << entry.Size << " each (" << entry.Counter * entry.Size
+    llvm::errs() << "    " << Entry.Counter << " " << Entry.Name << ", "
+                 << Entry.Size << " each (" << Entry.Counter * Entry.Size
                  << " bytes)\n";
-    sum += entry.Counter * entry.Size;
+    sum += Entry.Counter * Entry.Size;
   }
 
   llvm::errs() << "Total bytes = " << sum << "\n";

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -66,7 +66,7 @@ struct StmtClassNameTable {
 
 static StmtClassNameTable &getStmtInfoTableEntry(Stmt::StmtClass E) {
   static std::array<StmtClassNameTable, Stmt::lastStmtConstant + 1>
-      StmtClassInfo = []() {
+      StmtClassInfo = [] {
         std::array<StmtClassNameTable, Stmt::lastStmtConstant + 1> Table;
 #define ABSTRACT_STMT(STMT)
 #define STMT(CLASS, PARENT)                                                    \

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -106,7 +106,7 @@ void Stmt::PrintStats() {
   unsigned sum = 0;
   llvm::errs() << "\n*** Stmt/Expr Stats:\n";
   for (int i = 0; i != Stmt::lastStmtConstant+1; i++) {
-    StmtClassNameTable &entry =
+    const StmtClassNameTable &entry =
         getStmtInfoTableEntry(static_cast<Stmt::StmtClass>(i));
     if (entry.Name == nullptr)
       continue;
@@ -115,7 +115,7 @@ void Stmt::PrintStats() {
   llvm::errs() << "  " << sum << " stmts/exprs total.\n";
   sum = 0;
   for (int i = 0; i != Stmt::lastStmtConstant+1; i++) {
-    StmtClassNameTable &entry =
+    const StmtClassNameTable &entry =
         getStmtInfoTableEntry(static_cast<Stmt::StmtClass>(i));
     if (entry.Name == nullptr)
       continue;

--- a/clang/lib/Basic/ParsedAttrInfo.cpp
+++ b/clang/lib/Basic/ParsedAttrInfo.cpp
@@ -20,13 +20,16 @@ using namespace clang;
 
 LLVM_INSTANTIATE_REGISTRY(ParsedAttrInfoRegistry)
 
+static std::list<std::unique_ptr<ParsedAttrInfo>> instantiateEntries() {
+  std::list<std::unique_ptr<ParsedAttrInfo>> Instances;
+  for (const auto &It : ParsedAttrInfoRegistry::entries())
+    Instances.emplace_back(It.instantiate());
+  return Instances;
+}
+
 const std::list<std::unique_ptr<ParsedAttrInfo>> &
 clang::getAttributePluginInstances() {
-  static llvm::ManagedStatic<std::list<std::unique_ptr<ParsedAttrInfo>>>
-      PluginAttrInstances;
-  if (PluginAttrInstances->empty())
-    for (const auto &It : ParsedAttrInfoRegistry::entries())
-      PluginAttrInstances->emplace_back(It.instantiate());
-
-  return *PluginAttrInstances;
+  static std::list<std::unique_ptr<ParsedAttrInfo>> Instances =
+      instantiateEntries();
+  return Instances;
 }

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -248,6 +248,8 @@ void BackendConsumer::HandleTranslationUnit(ASTContext &C) {
   LLVMContext &Ctx = getModule()->getContext();
   std::unique_ptr<DiagnosticHandler> OldDiagnosticHandler =
     Ctx.getDiagnosticHandler();
+  llvm::scope_exit RestoreDiagnosticHandler(
+      [&]() { Ctx.setDiagnosticHandler(std::move(OldDiagnosticHandler)); });
   Ctx.setDiagnosticHandler(std::make_unique<ClangDiagnosticHandler>(
       CodeGenOpts, this));
 
@@ -310,8 +312,6 @@ void BackendConsumer::HandleTranslationUnit(ASTContext &C) {
   emitBackendOutput(CI, CI.getCodeGenOpts(),
                     C.getTargetInfo().getDataLayoutString(), getModule(),
                     Action, FS, std::move(AsmOutStream), this);
-
-  Ctx.setDiagnosticHandler(std::move(OldDiagnosticHandler));
 
   if (OptRecordFile)
     OptRecordFile->keep();

--- a/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
@@ -70,7 +70,7 @@ enum FoundationClass {
 
 static FoundationClass findKnownClass(const ObjCInterfaceDecl *ID,
                                       bool IncludeSuperclasses = true) {
-  static llvm::StringMap<FoundationClass> Classes{
+  static const llvm::StringMap<FoundationClass> Classes{
       {"NSArray", FC_NSArray},           {"NSDictionary", FC_NSDictionary},
       {"NSEnumerator", FC_NSEnumerator}, {"NSNull", FC_NSNull},
       {"NSOrderedSet", FC_NSOrderedSet}, {"NSSet", FC_NSSet},

--- a/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
@@ -70,16 +70,12 @@ enum FoundationClass {
 
 static FoundationClass findKnownClass(const ObjCInterfaceDecl *ID,
                                       bool IncludeSuperclasses = true) {
-  static llvm::StringMap<FoundationClass> Classes;
-  if (Classes.empty()) {
-    Classes["NSArray"] = FC_NSArray;
-    Classes["NSDictionary"] = FC_NSDictionary;
-    Classes["NSEnumerator"] = FC_NSEnumerator;
-    Classes["NSNull"] = FC_NSNull;
-    Classes["NSOrderedSet"] = FC_NSOrderedSet;
-    Classes["NSSet"] = FC_NSSet;
-    Classes["NSString"] = FC_NSString;
-  }
+  static llvm::StringMap<FoundationClass> Classes{
+      {"NSArray", FC_NSArray},           {"NSDictionary", FC_NSDictionary},
+      {"NSEnumerator", FC_NSEnumerator}, {"NSNull", FC_NSNull},
+      {"NSOrderedSet", FC_NSOrderedSet}, {"NSSet", FC_NSSet},
+      {"NSString", FC_NSString},
+  };
 
   // FIXME: Should we cache this at all?
   FoundationClass result = Classes.lookup(ID->getIdentifier()->getName());


### PR DESCRIPTION
These problems were found when I was investigating why using different CompilerInstances in different threads causes crashes. I didn't find the root cause of my problem, but I spotted these potential problems.

See individual commits.