### PR TITLE
Move MyDeveloperDay to the inactive maintainers list

### DIFF
--- a/clang/Maintainers.md
+++ b/clang/Maintainers.md
@@ -205,9 +205,6 @@ umbrella or components used to support such tools.
 
 ### clang-format
 
-MyDeveloperDay \
-mydeveloperday@gmail.com (email), MyDeveloperDay (Phabricator), [MyDeveloperDay](https://github.com/MyDeveloperDay) (GitHub)
-
 Owen Pan \
 owenpiano@gmail.com (email), owenpan (Phabricator), [owenca](https://github.com/owenca) (GitHub)
 
@@ -355,3 +352,4 @@ Dmitri Gribenko (gribozavr@gmail.com (email), gribozavr (Phabricator), [gribozav
 Tom Honermann (tom@honermann.net (email), tahonermann (Phabricator), [tahonermann](https://github.com/tahonermann) (GitHub)) \-- Text Encodings \
 John McCall (rjmccall@apple.com (email), rjmccall (Phabricator), [rjmccall](https://github.com/rjmccall) (GitHub)) \-- Clang LLVM IR generation, Objective-C/C++ conformance, Itanium ABI \
 John Ericson (git@johnericson.me (email), Ericson2314 (Phabricator), [Ericson2314](https://github.com/Ericson2314) (GitHub)) \-- CMake Integration
+MyDeveloperDay (mydeveloperday@gmail.com (email), MyDeveloperDay (Phabricator), [MyDeveloperDay](https://github.com/MyDeveloperDay) (GitHub)) -- clang-format


### PR DESCRIPTION
During the maintainers refresh for Clang, I was unable to reach MyDeveloperDay via email or GitHub to determine if they still wished to be listed as an active maintainer. Because the deadline passed for a response, this moves them to the inactive maintainer list.

However, they are still involved in the community and doing occasional reviews, so this PR may be unnecessary or only a temporary change. As with any inactive maintainer, they can resume maintainership easily enough in the future.