### PR TITLE
[libc++] Remove hardcoded -O3 from adjacent_view benchmark

### DIFF
--- a/libcxx/test/benchmarks/adjacent_view_begin.bench.cpp
+++ b/libcxx/test/benchmarks/adjacent_view_begin.bench.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
-// ADDITIONAL_COMPILE_FLAGS: -O3
+
 #include <algorithm>
 #include <deque>
 #include <ranges>


### PR DESCRIPTION
We don't hardcode optimization flags in the benchmarks, because we want to be able to run the benchmarks with any optimization level. Instead, we set the optimization level when running Lit via the --param optimization=<speed|size|...> flag.