### PR TITLE
[NFC][analyzer] Remove NodeBuilder::iterator

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -293,13 +293,6 @@ public:
 
   const ExplodedNodeSet &getResults() { return Frontier; }
 
-  using iterator = ExplodedNodeSet::iterator;
-
-  /// Iterators through the results frontier.
-  iterator begin() { return Frontier.begin(); }
-
-  iterator end() { return Frontier.end(); }
-
   const NodeBuilderContext &getContext() { return C; }
   bool hasGeneratedNodes() { return HasGeneratedNodes; }
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCXX.cpp
@@ -689,11 +689,10 @@ void ExprEngine::handleConstructor(const Expr *E,
                                    "Prepare for object construction");
     ExplodedNodeSet DstPrepare;
     StmtNodeBuilder BldrPrepare(Pred, DstPrepare, *currBldrCtx);
-    BldrPrepare.generateNode(E, Pred, State, &T, ProgramPoint::PreStmtKind);
-    assert(DstPrepare.size() <= 1);
-    if (DstPrepare.size() == 0)
+    Pred =
+        BldrPrepare.generateNode(E, Pred, State, &T, ProgramPoint::PreStmtKind);
+    if (!Pred)
       return;
-    Pred = *BldrPrepare.begin();
   }
 
   const MemRegion *TargetRegion = Target.getAsRegion();


### PR DESCRIPTION
This iterator class was used only once and even there it was easily replaced by a more appropriate solution.

This commit is motivated by the fact that my recent commit 320d0b5467b9586a188e06dd2620126f5cb99318 turned
`IndirectGotoNodeBuilder` and `SwitchNodeBuilder` into subclasses of `NodeBuilder` and those classes have their own (slightly more useful) `::iterator`s with very different behavior.