### PR TITLE
[AMDGPU][NFC] Enable RegistersAreIntervals

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -2181,6 +2181,7 @@ def AMDGPU : Target {
                                 VOP3_DPPAsmParserVariant];
   let AssemblyWriters = [AMDGPUAsmWriter];
   let AllowRegisterRenaming = 1;
+  let RegistersAreIntervals  = 1;
 }
 
 // Dummy Instruction itineraries for pseudo instructions


### PR DESCRIPTION
Turn on the target option added in #175823. Just turning it on is NFC, I'm planning on revisiting #174888 after some more downstream work.