### PR TITLE
[CIR][NFC] Fix try-catch-tmp.cpp test

### DIFF
--- a/clang/test/CIR/CodeGen/try-catch-tmp.cpp
+++ b/clang/test/CIR/CodeGen/try-catch-tmp.cpp
@@ -15,7 +15,7 @@ void call_function_inside_try_catch_all() {
 // CIR: cir.func {{.*}} @_Z34call_function_inside_try_catch_allv() personality(@__gxx_personality_v0)
 // CIR: cir.scope {
 // CIR:   cir.try {
-// CIR:       %[[CALL:.*]] = cir.call @_Z8divisionv() : () -> !s32i
+// CIR:       %[[CALL:.*]] = cir.call @_Z8divisionv()
 // CIR:       cir.yield
 // CIR:   } catch all {
 // CIR:       %[[CATCH_PARAM:.*]] = cir.catch_param : !cir.ptr<!void>
@@ -58,7 +58,7 @@ void call_function_inside_try_catch_with_exception_type() {
 // CIR: cir.scope {
 // CIR:   %[[EXCEPTION_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["e"]
 // CIR:   cir.try {
-// CIR:     %[[CALL:.*]] = cir.call @_Z8divisionv() : () -> !s32i
+// CIR:     %[[CALL:.*]] = cir.call @_Z8divisionv()
 // CIR:     cir.yield
 // CIR:   } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] {
 // CIR:     %[[CATCH_PARAM:.*]] = cir.catch_param : !cir.ptr<!s32i>
@@ -118,7 +118,7 @@ void call_function_inside_try_catch_with_complex_exception_type() {
 // CIR: cir.scope {
 // CIR:   %[[EXCEPTION_ADDR:.*]] = cir.alloca !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>, ["e"]
 // CIR:   cir.try {
-// CIR:     %[[CALL:.*]] = cir.call @_Z8divisionv() : () -> !s32i
+// CIR:     %[[CALL:.*]] = cir.call @_Z8divisionv()
 // CIR:     cir.yield
 // CIR:   } catch [type #cir.global_view<@_ZTICi> : !cir.ptr<!u8i>] {
 // CIR:     %[[CATCH_PARAM:.*]] = cir.catch_param : !cir.ptr<!cir.complex<!s32i>>
@@ -184,7 +184,7 @@ void call_function_inside_try_catch_with_array_exception_type() {
 // CIR: cir.scope {
 // CIR:   %[[E_ADDR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["e"]
 // CIR:   cir.try {
-// CIR:     %[[CALL:.*]] = cir.call @_Z8divisionv() : () -> !s32i
+// CIR:     %[[CALL:.*]] = cir.call @_Z8divisionv()
 // CIR:     cir.yield
 // CIR:   } catch [type #cir.global_view<@_ZTIPi> : !cir.ptr<!u8i>] {
 // CIR:     %[[CATCH_PARAM:.*]] = cir.catch_param : !cir.ptr<!s32i>
@@ -243,7 +243,7 @@ void call_function_inside_try_catch_with_exception_type_and_catch_all() {
 // CIR: cir.scope {
 // CIR:   %[[EXCEPTION_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["e"]
 // CIR:   cir.try {
-// CIR:     %[[CALL:.*]] = cir.call @_Z8divisionv() : () -> !s32i
+// CIR:     %[[CALL:.*]] = cir.call @_Z8divisionv()
 // CIR:     cir.yield
 // CIR:   } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] {
 // CIR:     %[[CATCH_PARAM:.*]] = cir.catch_param : !cir.ptr<!s32i>


### PR DESCRIPTION
This test was failing due to its CI having been run before another change was committed that added attributes to return values. This removes unnecessary checks to make the test pass again.