### PR TITLE
[Sema] Fix crash on invalid operator template-id

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -321,6 +321,7 @@ Bug Fixes to C++ Support
   when used inside decltype in the return type. (#GH180460)
 - Fixed a crash when evaluating uninitialized GCC vector/ext_vector_type vectors in ``constexpr``. (#GH180044)
 - Fixed a crash on ``typeid`` of incomplete local types during template instantiation. (#GH63242), (#GH176397)
+- Fixed a crash when handling invalid template-ids during error recovery in C++ code. (#GH177549)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -6101,6 +6101,10 @@ Sema::GetNameFromUnqualifiedId(const UnqualifiedId &Name) {
   }
 
   case UnqualifiedIdKind::IK_TemplateId: {
+
+    if (Name.TemplateId->isInvalid())
+      return DeclarationNameInfo();
+
     TemplateName TName = Name.TemplateId->Template.get();
     SourceLocation TNameLoc = Name.TemplateId->TemplateNameLoc;
     return Context.getNameForTemplate(TName, TNameLoc);

--- a/clang/test/SemaCXX/crash-invalid-operator-template.cpp
+++ b/clang/test/SemaCXX/crash-invalid-operator-template.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+typedef(( operator | <> ) ) ( class { private: }); 
+// expected-error@-1 {{cannot be defined in a parameter type}}
+// expected-error@-2 {{type specifier is required}}
+// expected-error@-3 {{typedef name must be an identifier}}
+


### PR DESCRIPTION
Add checks in GetNameFromUnqualifiedId to handle invalid TemplateId cases safely. This avoids a crash when handling an invalid template-id during error recovery and allows normal error reporting to continue. 

Fixes #177549 