### PR TITLE
[clang][deps] Extract service config into a struct

### DIFF
--- a/clang-tools-extra/clangd/ScanningProjectModules.cpp
+++ b/clang-tools-extra/clangd/ScanningProjectModules.cpp
@@ -35,9 +35,12 @@ public:
   ModuleDependencyScanner(
       std::shared_ptr<const clang::tooling::CompilationDatabase> CDB,
       const ThreadsafeFS &TFS)
-      : CDB(CDB), TFS(TFS),
-        Service(dependencies::ScanningMode::CanonicalPreprocessing,
-                dependencies::ScanningOutputFormat::P1689) {}
+      : CDB(CDB), TFS(TFS), Service([] {
+          dependencies::DependencyScanningServiceOptions Opts;
+          Opts.Mode = dependencies::ScanningMode::CanonicalPreprocessing;
+          Opts.Format = dependencies::ScanningOutputFormat::P1689;
+          return Opts;
+        }()) {}
 
   /// The scanned modules dependency information for a specific source file.
   struct ModuleDependencyInfo {

--- a/clang/include/clang/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningService.h
@@ -12,7 +12,6 @@
 #include "clang/DependencyScanning/DependencyScanningFilesystem.h"
 #include "clang/DependencyScanning/InProcessModuleCache.h"
 #include "llvm/ADT/BitmaskEnum.h"
-#include "llvm/Support/Chrono.h"
 
 namespace clang {
 namespace dependencies {
@@ -77,29 +76,34 @@ enum class ScanningOptimizations {
 
 #undef DSS_LAST_BITMASK_ENUM
 
+/// The configuration knobs for the dependency scanning service.
+struct DependencyScanningServiceOptions {
+  DependencyScanningServiceOptions();
+
+  /// Whether to use optimized dependency directive scan or full preprocessing.
+  ScanningMode Mode = ScanningMode::DependencyDirectivesScan;
+  /// What output format are we expected to produce.
+  ScanningOutputFormat Format = ScanningOutputFormat::Full;
+  /// How to optimize resulting explicit module command lines.
+  ScanningOptimizations OptimizeArgs = ScanningOptimizations::Default;
+  /// Whether the resulting command lines should load explicit PCMs eagerly.
+  bool EagerLoadModules = false;
+  /// Whether to trace VFS accesses during the scan.
+  bool TraceVFS = false;
+  /// Whether to scan modules asynchronously.
+  bool AsyncScanModules = false;
+  /// The build session timestamp for validate-once-per-build-session logic.
+  std::time_t BuildSessionTimestamp; // = std::chrono::system_clock::now();
+};
+
 /// The dependency scanning service contains shared configuration and state that
 /// is used by the individual dependency scanning workers.
 class DependencyScanningService {
 public:
-  DependencyScanningService(
-      ScanningMode Mode, ScanningOutputFormat Format,
-      ScanningOptimizations OptimizeArgs = ScanningOptimizations::Default,
-      bool EagerLoadModules = false, bool TraceVFS = false,
-      bool AsyncScanModules = false,
-      std::time_t BuildSessionTimestamp =
-          llvm::sys::toTimeT(std::chrono::system_clock::now()));
+  explicit DependencyScanningService(DependencyScanningServiceOptions Opts)
+      : Opts(std::move(Opts)) {}
 
-  ScanningMode getMode() const { return Mode; }
-
-  ScanningOutputFormat getFormat() const { return Format; }
-
-  ScanningOptimizations getOptimizeArgs() const { return OptimizeArgs; }
-
-  bool shouldEagerLoadModules() const { return EagerLoadModules; }
-
-  bool shouldTraceVFS() const { return TraceVFS; }
-
-  bool shouldScanModulesAsynchronously() const { return AsyncScanModules; }
+  const DependencyScanningServiceOptions &getOpts() const { return Opts; }
 
   DependencyScanningFilesystemSharedCache &getSharedCache() {
     return SharedCache;
@@ -107,25 +111,13 @@ public:
 
   ModuleCacheEntries &getModuleCacheEntries() { return ModCacheEntries; }
 
-  std::time_t getBuildSessionTimestamp() const { return BuildSessionTimestamp; }
-
 private:
-  const ScanningMode Mode;
-  const ScanningOutputFormat Format;
-  /// Whether to optimize the modules' command-line arguments.
-  const ScanningOptimizations OptimizeArgs;
-  /// Whether to set up command-lines to load PCM files eagerly.
-  const bool EagerLoadModules;
-  /// Whether to trace VFS accesses.
-  const bool TraceVFS;
-  /// Whether to scan modules asynchronously.
-  const bool AsyncScanModules;
+  /// The options customizing dependency scanning behavior.
+  DependencyScanningServiceOptions Opts;
   /// The global file system cache.
   DependencyScanningFilesystemSharedCache SharedCache;
   /// The global module cache entries.
   ModuleCacheEntries ModCacheEntries;
-  /// The build session timestamp.
-  std::time_t BuildSessionTimestamp;
 };
 
 } // end namespace dependencies

--- a/clang/lib/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningService.cpp
@@ -8,14 +8,11 @@
 
 #include "clang/DependencyScanning/DependencyScanningService.h"
 
+#include "llvm/Support/Chrono.h"
+
 using namespace clang;
 using namespace dependencies;
 
-DependencyScanningService::DependencyScanningService(
-    ScanningMode Mode, ScanningOutputFormat Format,
-    ScanningOptimizations OptimizeArgs, bool EagerLoadModules, bool TraceVFS,
-    bool AsyncScanModules, std::time_t BuildSessionTimestamp)
-    : Mode(Mode), Format(Format), OptimizeArgs(OptimizeArgs),
-      EagerLoadModules(EagerLoadModules), TraceVFS(TraceVFS),
-      AsyncScanModules(AsyncScanModules),
-      BuildSessionTimestamp(BuildSessionTimestamp) {}
+DependencyScanningServiceOptions::DependencyScanningServiceOptions()
+    : BuildSessionTimestamp(
+          llvm::sys::toTimeT(std::chrono::system_clock::now())) {}

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -30,7 +30,7 @@ DependencyScanningWorker::DependencyScanningWorker(
   // The scanner itself writes only raw ast files.
   PCHContainerOps->registerWriter(std::make_unique<RawPCHContainerWriter>());
 
-  if (Service.shouldTraceVFS())
+  if (Service.getOpts().TraceVFS)
     BaseFS = llvm::makeIntrusiveRefCnt<llvm::vfs::TracingFileSystem>(
         std::move(BaseFS));
 

--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -334,7 +334,7 @@ ModuleDepCollector::getInvocationAdjustedForModuleBuildWithoutOutputs(
     // TODO: Verify this works fine when modulemap for module A is eagerly
     // loaded from A.pcm, and module map passed on the command line contains
     // definition of a submodule: "explicit module A.Private { ... }".
-    if (Service.shouldEagerLoadModules() &&
+    if (Service.getOpts().EagerLoadModules &&
         DepModuleMapFiles.contains(*ModuleMapEntry))
       continue;
 
@@ -385,7 +385,7 @@ llvm::DenseSet<const FileEntry *> ModuleDepCollector::collectModuleMapFiles(
 
 void ModuleDepCollector::addModuleMapFiles(
     CompilerInvocation &CI, ArrayRef<ModuleID> ClangModuleDeps) const {
-  if (Service.shouldEagerLoadModules())
+  if (Service.getOpts().EagerLoadModules)
     return; // Only pcm is needed for eager load.
 
   for (const ModuleID &MID : ClangModuleDeps) {
@@ -402,7 +402,7 @@ void ModuleDepCollector::addModuleFiles(
     std::string PCMPath =
         Controller.lookupModuleOutput(*MD, ModuleOutputKind::ModuleFile);
 
-    if (Service.shouldEagerLoadModules())
+    if (Service.getOpts().EagerLoadModules)
       CI.getFrontendOpts().ModuleFiles.push_back(std::move(PCMPath));
     else
       CI.getHeaderSearchOpts().PrebuiltModuleFiles.insert(
@@ -417,7 +417,7 @@ void ModuleDepCollector::addModuleFiles(
     std::string PCMPath =
         Controller.lookupModuleOutput(*MD, ModuleOutputKind::ModuleFile);
 
-    if (Service.shouldEagerLoadModules())
+    if (Service.getOpts().EagerLoadModules)
       CI.getMutFrontendOpts().ModuleFiles.push_back(std::move(PCMPath));
     else
       CI.getMutHeaderSearchOpts().PrebuiltModuleFiles.insert(
@@ -525,7 +525,7 @@ static std::string getModuleContextHash(const ModuleDeps &MD,
 void ModuleDepCollector::associateWithContextHash(
     const CowCompilerInvocation &CI, bool IgnoreCWD, ModuleDeps &Deps) {
   Deps.ID.ContextHash =
-      getModuleContextHash(Deps, CI, Service.shouldEagerLoadModules(),
+      getModuleContextHash(Deps, CI, Service.getOpts().EagerLoadModules,
                            IgnoreCWD, ScanInstance.getVirtualFileSystem());
   bool Inserted = ModuleDepsByID.insert({Deps.ID, &Deps}).second;
   (void)Inserted;
@@ -752,21 +752,21 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
   CowCompilerInvocation CI =
       MDC.getInvocationAdjustedForModuleBuildWithoutOutputs(
           MD, [&](CowCompilerInvocation &BuildInvocation) {
-            if (any(MDC.Service.getOptimizeArgs() &
+            if (any(MDC.Service.getOpts().OptimizeArgs &
                     (ScanningOptimizations::HeaderSearch |
                      ScanningOptimizations::VFS)))
               optimizeHeaderSearchOpts(BuildInvocation.getMutHeaderSearchOpts(),
                                        *MDC.ScanInstance.getASTReader(), *MF,
                                        MDC.PrebuiltModulesASTMap,
-                                       MDC.Service.getOptimizeArgs());
+                                       MDC.Service.getOpts().OptimizeArgs);
 
-            if (any(MDC.Service.getOptimizeArgs() &
+            if (any(MDC.Service.getOpts().OptimizeArgs &
                     ScanningOptimizations::SystemWarnings))
               optimizeDiagnosticOpts(
                   BuildInvocation.getMutDiagnosticOpts(),
                   BuildInvocation.getFrontendOpts().IsSystemModule);
 
-            IgnoreCWD = any(MDC.Service.getOptimizeArgs() &
+            IgnoreCWD = any(MDC.Service.getOpts().OptimizeArgs &
                             ScanningOptimizations::IgnoreCWD) &&
                         isSafeToIgnoreCWD(BuildInvocation);
             if (IgnoreCWD) {
@@ -960,7 +960,7 @@ static StringRef makeAbsoluteAndPreferred(CompilerInstance &CI, StringRef Path,
 }
 
 void ModuleDepCollector::addFileDep(StringRef Path) {
-  if (Service.getFormat() == ScanningOutputFormat::P1689) {
+  if (Service.getOpts().Format == ScanningOutputFormat::P1689) {
     // Within P1689 format, we don't want all the paths to be absolute path
     // since it may violate the traditional make style dependencies info.
     FileDeps.emplace_back(Path);

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1138,9 +1138,14 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
     });
   };
 
-  DependencyScanningService Service(ScanMode, Format, OptimizeArgs,
-                                    EagerLoadModules, /*TraceVFS=*/Verbose,
-                                    AsyncScanModules);
+  DependencyScanningServiceOptions Opts;
+  Opts.Mode = ScanMode;
+  Opts.Format = Format;
+  Opts.OptimizeArgs = OptimizeArgs;
+  Opts.EagerLoadModules = EagerLoadModules;
+  Opts.TraceVFS = Verbose;
+  Opts.AsyncScanModules = AsyncScanModules;
+  DependencyScanningService Service(std::move(Opts));
 
   llvm::Timer T;
   T.startTimer();

--- a/clang/unittests/DependencyScanning/DependencyScanningWorkerTest.cpp
+++ b/clang/unittests/DependencyScanning/DependencyScanningWorkerTest.cpp
@@ -31,8 +31,9 @@ TEST(DependencyScanner, ScanDepsWithDiagConsumer) {
                llvm::MemoryBuffer::getMemBuffer("#include \"header.h\"\n"));
   VFS->addFile(AsmPath, 0, llvm::MemoryBuffer::getMemBuffer(""));
 
-  DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
-                                    ScanningOutputFormat::Make);
+  DependencyScanningServiceOptions Opts;
+  Opts.Format = ScanningOutputFormat::Make;
+  DependencyScanningService Service(std::move(Opts));
   DependencyScanningWorker Worker(Service, VFS);
 
   llvm::DenseSet<ModuleID> AlreadySeen;

--- a/clang/unittests/Tooling/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScannerTest.cpp
@@ -228,8 +228,9 @@ TEST(DependencyScanner, ScanDepsWithFS) {
   VFS->addFile(TestPath, 0,
                llvm::MemoryBuffer::getMemBuffer("#include \"header.h\"\n"));
 
-  DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
-                                    ScanningOutputFormat::Make);
+  DependencyScanningServiceOptions Opts;
+  Opts.Format = ScanningOutputFormat::Make;
+  DependencyScanningService Service(std::move(Opts));
   DependencyScanningTool ScanTool(Service, VFS);
 
   TextDiagnosticBuffer DiagConsumer;
@@ -285,8 +286,9 @@ TEST(DependencyScanner, ScanDepsWithModuleLookup) {
 
   auto InterceptFS = llvm::makeIntrusiveRefCnt<InterceptorFS>(VFS);
 
-  DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
-                                    ScanningOutputFormat::Make);
+  DependencyScanningServiceOptions Opts;
+  Opts.Format = ScanningOutputFormat::Make;
+  DependencyScanningService Service(std::move(Opts));
   DependencyScanningTool ScanTool(Service, InterceptFS);
 
   // This will fail with "fatal error: module 'Foo' not found" but it doesn't


### PR DESCRIPTION
Adding new configuration knobs in the scanner is fairly painful now, especially with a diverging downstream. This patch extracts what was previously passed into the service constructor into a struct. This encourages one knob customization per line, reduces difficult merge conflicts, `/*ArgName=*/`-style comments with copy-pasted defaults, etc.