### PR TITLE
[lldb][macOS] Don't fetch settings in Host, to keep layering

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -68,6 +68,29 @@ static constexpr OptionEnumValueElement g_auto_download_enum_values[] = {
     },
 };
 
+static constexpr OptionEnumValueElement g_shared_cache_use_enum_values[] = {
+    {
+        lldb::eSymbolSharedCacheUseHostLLDBMemory,
+        "host-lldb-memory",
+        "Get binaries from the host lldb in-memory shared cache.",
+    },
+    {
+        lldb::eSymbolSharedCacheUseHostSharedCache,
+        "host-shared-cache",
+        "Get binaries from the host shared cache.",
+    },
+    {
+        lldb::eSymbolSharedCacheUseHostAndInferiorSharedCache,
+        "host-and-inferior-shared-cache",
+        "Get binaries from the host and inferior's shared caches.",
+    },
+    {
+        lldb::eSymbolSharedCacheUseInferiorSharedCacheOnly,
+        "inferior-shared-cache-only",
+        "Get binaries from inferior's shared cache only.",
+    },
+};
+
 class ModuleListProperties : public Properties {
   mutable llvm::sys::RWMutex m_symlink_paths_mutex;
   PathMappingList m_symlink_paths;
@@ -81,8 +104,7 @@ public:
   bool SetClangModulesCachePath(const FileSpec &path);
   bool GetEnableExternalLookup() const;
   bool SetEnableExternalLookup(bool new_value);
-  bool GetSharedCacheBinaryLoading() const;
-  bool SetSharedCacheBinaryLoading(bool new_value);
+  lldb::SymbolSharedCacheUse GetSharedCacheBinaryLoading() const;
   bool GetEnableLLDBIndexCache() const;
   bool SetEnableLLDBIndexCache(bool new_value);
   uint64_t GetLLDBIndexCacheMaxByteSize();

--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -192,7 +192,7 @@ public:
   ///     Host.
   static SharedCacheImageInfo
   GetSharedCacheImageInfo(llvm::StringRef image_name,
-                          bool use_sc_binary_directly) {
+                          lldb::SymbolDownload sc_mode) {
     return {};
   }
 
@@ -206,7 +206,7 @@ public:
   ///     Host.
   static SharedCacheImageInfo
   GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid,
-                          bool use_sc_binary_directly) {
+                          lldb::SymbolDownload sc_mode) {
     return {};
   }
 
@@ -214,7 +214,8 @@ public:
   /// on the debug host.
   /// Returns false if the shared cache filepath did not exist, or uuid
   /// did not match.
-  static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid) {
+  static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid,
+                                    lldb::SymbolDownload sc_mode) {
     return false;
   }
 

--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -192,7 +192,7 @@ public:
   ///     Host.
   static SharedCacheImageInfo
   GetSharedCacheImageInfo(llvm::StringRef image_name,
-                          lldb::SymbolDownload sc_mode) {
+                          lldb::SymbolSharedCacheUse sc_mode) {
     return {};
   }
 
@@ -206,7 +206,7 @@ public:
   ///     Host.
   static SharedCacheImageInfo
   GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid,
-                          lldb::SymbolDownload sc_mode) {
+                          lldb::SymbolSharedCacheUse sc_mode) {
     return {};
   }
 
@@ -215,7 +215,7 @@ public:
   /// Returns false if the shared cache filepath did not exist, or uuid
   /// did not match.
   static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid,
-                                    lldb::SymbolDownload sc_mode) {
+                                    lldb::SymbolSharedCacheUse sc_mode) {
     return false;
   }
 

--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -185,16 +185,28 @@ public:
 
   /// Return information about module \p image_name if it is loaded in
   /// the current process's address space.
+  ///
+  /// \param[in] use_sc_binary_directly
+  ///     Flag to control if this method can try to read a shared
+  ///     cache binary blob directly, needed to keep user settings out of
+  ///     Host.
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(llvm::StringRef image_name) {
+  GetSharedCacheImageInfo(llvm::StringRef image_name,
+                          bool use_sc_binary_directly) {
     return {};
   }
 
   /// Return information about module \p image_name if it is loaded in
   /// the current process's address space using shared cache \p uuid.
   /// The shared cache UUID must have been previously indexed.
+  ///
+  /// \param[in] use_sc_binary_directly
+  ///     Flag to control if this method can try to read a shared
+  ///     cache binary blob directly, needed to keep user settings out of
+  ///     Host.
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid) {
+  GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid,
+                          bool use_sc_binary_directly) {
     return {};
   }
 

--- a/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
+++ b/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
@@ -44,13 +44,14 @@ public:
   /// Shared cache utilities
   static SharedCacheImageInfo
   GetSharedCacheImageInfo(llvm::StringRef image_name,
-                          bool use_sc_binary_directly);
+                          lldb::SymbolSharedCacheUse sc_mode);
 
   static SharedCacheImageInfo
   GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid,
-                          bool use_sc_binary_directly);
+                          lldb::SymbolSharedCacheUse sc_mode);
 
-  static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid);
+  static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid,
+                                    lldb::SymbolSharedCacheUse sc_mode);
 
 protected:
   static bool ComputeSupportExeDirectory(FileSpec &file_spec);

--- a/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
+++ b/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
@@ -43,10 +43,12 @@ public:
 
   /// Shared cache utilities
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(llvm::StringRef image_name);
+  GetSharedCacheImageInfo(llvm::StringRef image_name,
+                          bool use_sc_binary_directly);
 
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid);
+  GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid,
+                          bool use_sc_binary_directly);
 
   static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid);
 

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1353,6 +1353,13 @@ enum SymbolDownload {
   eSymbolDownloadForeground = 2,
 };
 
+enum SymbolSharedCacheUse {
+  eSymbolSharedCacheUseHostLLDBMemory = 1,
+  eSymbolSharedCacheUseHostSharedCache = 2,
+  eSymbolSharedCacheUseHostAndInferiorSharedCache = 3,
+  eSymbolSharedCacheUseInferiorSharedCacheOnly = 4,
+};
+
 /// Used in the SBProcess AddressMask/FixAddress methods.
 enum AddressMaskType {
   eAddressMaskTypeCode = 0,

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -14,10 +14,11 @@ let Definition = "modulelist", Path = "symbols" in {
     DefaultEnumValue<"eSymbolDownloadOff">,
     EnumValues<"OptionEnumValues(g_auto_download_enum_values)">,
     Desc<"On macOS, automatically download symbols with dsymForUUID (or an equivalent script/binary) for relevant images in the debug session.">;
-  def SharedCacheBinaryLoading: Property<"shared-cache-binary-loading", "Boolean">,
+  def SharedCacheBinaryLoading: Property<"shared-cache-binary-loading", "Enum">,
     Global,
-    DefaultTrue,
-    Desc<"On macOS, load the binaries from a shared cache blob directly, instead of loading them from lldb's own in-process shared cache.">;
+    DefaultEnumValue<"eSymbolSharedCacheUseHostAndInferiorSharedCache">,
+    EnumValues<"OptionEnumValues(g_shared_cache_use_enum_values)">,
+    Desc<"On macOS, lldb can use its own in-memory shared cache, or operate on shared cache binaries directly, this setting controls which are used.">;
   def ClangModulesCachePath: Property<"clang-modules-cache-path", "FileSpec">,
     Global,
     DefaultStringValue<"">,

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -118,14 +118,11 @@ SymbolDownload ModuleListProperties::GetSymbolAutoDownload() const {
                g_modulelist_properties[idx].default_uint_value));
 }
 
-bool ModuleListProperties::GetSharedCacheBinaryLoading() const {
+SymbolSharedCacheUse ModuleListProperties::GetSharedCacheBinaryLoading() const {
   const uint32_t idx = ePropertySharedCacheBinaryLoading;
-  return GetPropertyAtIndexAs<bool>(
-      idx, g_modulelist_properties[idx].default_uint_value != 0);
-}
-
-bool ModuleListProperties::SetSharedCacheBinaryLoading(bool new_value) {
-  return SetPropertyAtIndex(ePropertySharedCacheBinaryLoading, new_value);
+  return GetPropertyAtIndexAs<lldb::SymbolSharedCacheUse>(
+      idx, static_cast<lldb::SymbolSharedCacheUse>(
+               g_modulelist_properties[idx].default_uint_value));
 }
 
 FileSpec ModuleListProperties::GetClangModulesCachePath() const {

--- a/lldb/source/Host/macosx/objcxx/CMakeLists.txt
+++ b/lldb/source/Host/macosx/objcxx/CMakeLists.txt
@@ -14,7 +14,6 @@ add_lldb_library(lldbHostMacOSXObjCXX NO_PLUGIN_DEPENDENCIES
     Support
     TargetParser
   LINK_LIBS
-    lldbCore
     lldbUtility
     ${EXTRA_LIBS}
   )

--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -701,7 +701,7 @@ public:
   /// system, open it and add all of the binary images to m_caches.
   bool CreateSharedCacheImageList(UUID uuid, std::string filepath);
 
-  SharedCacheInfo(bool use_sc_binary_directly);
+  SharedCacheInfo(SymbolSharedCacheUse sc_mode);
 
 private:
   bool CreateSharedCacheInfoWithInstrospectionSPIs();
@@ -720,7 +720,7 @@ private:
 
 } // namespace
 
-SharedCacheInfo::SharedCacheInfo(bool use_sc_binary_directly) {
+SharedCacheInfo::SharedCacheInfo(SymbolSharedCacheUse sc_mode) {
   // macOS 26.4 and newer
   m_dyld_image_retain_4HWTrace =
       (void (*)(void *))dlsym(RTLD_DEFAULT, "dyld_image_retain_4HWTrace");
@@ -734,12 +734,25 @@ SharedCacheInfo::SharedCacheInfo(bool use_sc_binary_directly) {
   _dyld_get_shared_cache_uuid(dsc_uuid);
   m_host_uuid = UUID(dsc_uuid);
 
-  if (use_sc_binary_directly && CreateHostSharedCacheImageList())
+  // Don't scan/index lldb's own shared cache at all, in-memory or
+  // via libdyld SPI.
+  if (sc_mode == eSymbolSharedCacheUseInferiorSharedCacheOnly)
     return;
 
+  // Check if the settings allow the use of the libdyld SPI.
+  bool use_libdyld_spi =
+      sc_mode == eSymbolSharedCacheUseHostSharedCache ||
+      sc_mode == eSymbolSharedCacheUseHostAndInferiorSharedCache;
+  if (use_libdyld_spi && CreateHostSharedCacheImageList())
+    return;
+
+  // Scan lldb's shared cache memory if we're built against the
+  // internal SDK and have those headers.
   if (CreateSharedCacheInfoWithInstrospectionSPIs())
     return;
 
+  // Scan lldb's shared cache memory if we're built against the public
+  // SDK.
   CreateSharedCacheInfoLLDBsVirtualMemory();
 }
 
@@ -970,35 +983,38 @@ void SharedCacheInfo::CreateSharedCacheInfoLLDBsVirtualMemory() {
       });
 }
 
-SharedCacheInfo &GetSharedCacheSingleton(bool use_sc_binary_directly) {
-  static SharedCacheInfo g_shared_cache_info(use_sc_binary_directly);
+SharedCacheInfo &GetSharedCacheSingleton(SymbolSharedCacheUse sc_mode) {
+  static SharedCacheInfo g_shared_cache_info(sc_mode);
   return g_shared_cache_info;
 }
 
 SharedCacheImageInfo
 HostInfoMacOSX::GetSharedCacheImageInfo(llvm::StringRef image_name,
-                                        bool use_sc_binary_directly) {
-  return GetSharedCacheSingleton(use_sc_binary_directly)
-      .GetImages()
-      .lookup(image_name);
+                                        SymbolSharedCacheUse sc_mode) {
+  return GetSharedCacheSingleton(sc_mode).GetImages().lookup(image_name);
 }
 
-SharedCacheImageInfo HostInfoMacOSX::GetSharedCacheImageInfo(
-    llvm::StringRef image_name, const UUID &uuid, bool use_sc_binary_directly) {
+SharedCacheImageInfo
+HostInfoMacOSX::GetSharedCacheImageInfo(llvm::StringRef image_name,
+                                        const UUID &uuid,
+                                        SymbolSharedCacheUse sc_mode) {
   llvm::StringMap<SharedCacheImageInfo> *shared_cache_info;
-  if (GetSharedCacheSingleton(use_sc_binary_directly)
-          .GetImages(&shared_cache_info, uuid))
+  if (GetSharedCacheSingleton(sc_mode).GetImages(&shared_cache_info, uuid))
     return shared_cache_info->lookup(image_name);
   return {};
 }
 
-bool HostInfoMacOSX::SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid) {
+bool HostInfoMacOSX::SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid,
+                                           SymbolSharedCacheUse sc_mode) {
+  if (sc_mode == eSymbolSharedCacheUseHostLLDBMemory)
+    return false;
+
   // There is a libdyld SPI to iterate over all installed shared caches,
   // but it can have performance problems if an older Simulator SDK shared
   // cache is installed.  So require that we are given a filepath of
   // the shared cache.
   if (FileSystem::Instance().Exists(filepath))
-    return GetSharedCacheSingleton(/*use_sc_binary_directly=*/true)
-        .CreateSharedCacheImageList(uuid, filepath.GetPath());
+    return GetSharedCacheSingleton(sc_mode).CreateSharedCacheImageList(
+        uuid, filepath.GetPath());
   return false;
 }

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -141,14 +141,16 @@ ModuleSP DynamicLoaderDarwin::FindTargetModuleForImageInfo(
     LazyBool using_sc;
     LazyBool private_sc;
     FileSpec sc_path;
+    bool use_sc_binary_directly = ModuleList::GetGlobalModuleListProperties()
+                                      .GetSharedCacheBinaryLoading();
     if (GetSharedCacheInformation(sc_base_addr, sc_uuid, using_sc, private_sc,
                                   sc_path) &&
         sc_uuid)
       image_info = HostInfo::GetSharedCacheImageInfo(
-          module_spec.GetFileSpec().GetPath(), sc_uuid);
+          module_spec.GetFileSpec().GetPath(), sc_uuid, use_sc_binary_directly);
     else
       image_info = HostInfo::GetSharedCacheImageInfo(
-          module_spec.GetFileSpec().GetPath());
+          module_spec.GetFileSpec().GetPath(), use_sc_binary_directly);
 
     // If we found it and it has the correct UUID, let's proceed with
     // creating a module from the memory contents.

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -141,16 +141,16 @@ ModuleSP DynamicLoaderDarwin::FindTargetModuleForImageInfo(
     LazyBool using_sc;
     LazyBool private_sc;
     FileSpec sc_path;
-    bool use_sc_binary_directly = ModuleList::GetGlobalModuleListProperties()
-                                      .GetSharedCacheBinaryLoading();
+    SymbolSharedCacheUse sc_mode = ModuleList::GetGlobalModuleListProperties()
+                                       .GetSharedCacheBinaryLoading();
     if (GetSharedCacheInformation(sc_base_addr, sc_uuid, using_sc, private_sc,
                                   sc_path) &&
         sc_uuid)
       image_info = HostInfo::GetSharedCacheImageInfo(
-          module_spec.GetFileSpec().GetPath(), sc_uuid, use_sc_binary_directly);
+          module_spec.GetFileSpec().GetPath(), sc_uuid, sc_mode);
     else
       image_info = HostInfo::GetSharedCacheImageInfo(
-          module_spec.GetFileSpec().GetPath(), use_sc_binary_directly);
+          module_spec.GetFileSpec().GetPath(), sc_mode);
 
     // If we found it and it has the correct UUID, let's proceed with
     // creating a module from the memory contents.

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
@@ -319,6 +319,8 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
     // exist on the filesystem, so let's use the images in our own memory
     // to create the modules.
 
+    bool use_sc_binary_directly = ModuleList::GetGlobalModuleListProperties()
+                                      .GetSharedCacheBinaryLoading();
     SharedCacheImageInfo image_info;
     if (process && process->GetDynamicLoader()) {
       addr_t sc_base_addr;
@@ -328,12 +330,13 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
       if (process->GetDynamicLoader()->GetSharedCacheInformation(
               sc_base_addr, sc_uuid, using_sc, private_sc, sc_path))
         image_info = HostInfo::GetSharedCacheImageInfo(
-            module_spec.GetFileSpec().GetPath(), sc_uuid);
+            module_spec.GetFileSpec().GetPath(), sc_uuid,
+            use_sc_binary_directly);
     }
 
     if (!image_info.GetUUID())
       image_info = HostInfo::GetSharedCacheImageInfo(
-          module_spec.GetFileSpec().GetPath());
+          module_spec.GetFileSpec().GetPath(), use_sc_binary_directly);
 
     // If we found it and it has the correct UUID, let's proceed with
     // creating a module from the memory contents.

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
@@ -319,8 +319,8 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
     // exist on the filesystem, so let's use the images in our own memory
     // to create the modules.
 
-    bool use_sc_binary_directly = ModuleList::GetGlobalModuleListProperties()
-                                      .GetSharedCacheBinaryLoading();
+    SymbolSharedCacheUse sc_mode = ModuleList::GetGlobalModuleListProperties()
+                                       .GetSharedCacheBinaryLoading();
     SharedCacheImageInfo image_info;
     if (process && process->GetDynamicLoader()) {
       addr_t sc_base_addr;
@@ -330,13 +330,12 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
       if (process->GetDynamicLoader()->GetSharedCacheInformation(
               sc_base_addr, sc_uuid, using_sc, private_sc, sc_path))
         image_info = HostInfo::GetSharedCacheImageInfo(
-            module_spec.GetFileSpec().GetPath(), sc_uuid,
-            use_sc_binary_directly);
+            module_spec.GetFileSpec().GetPath(), sc_uuid, sc_mode);
     }
 
     if (!image_info.GetUUID())
       image_info = HostInfo::GetSharedCacheImageInfo(
-          module_spec.GetFileSpec().GetPath(), use_sc_binary_directly);
+          module_spec.GetFileSpec().GetPath(), sc_mode);
 
     // If we found it and it has the correct UUID, let's proceed with
     // creating a module from the memory contents.

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -4375,13 +4375,12 @@ StructuredData::ObjectSP ProcessGDBRemote::GetSharedCacheInfo() {
         FileSpec sc_path(
             dict->GetValueForKey("shared_cache_path")->GetStringValue());
 
-        bool use_sc_binary_directly =
-            ModuleList::GetGlobalModuleListProperties()
-                .GetSharedCacheBinaryLoading();
         // Attempt to open the shared cache at sc_path, and
         // if the uuid matches, index all the files.
-        if (use_sc_binary_directly)
-          HostInfo::SharedCacheIndexFiles(sc_path, uuid);
+        HostInfo::SharedCacheIndexFiles(
+            sc_path, uuid,
+            ModuleList::GetGlobalModuleListProperties()
+                .GetSharedCacheBinaryLoading());
       }
       m_shared_cache_info_sp = response_sp;
     }

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -4375,9 +4375,13 @@ StructuredData::ObjectSP ProcessGDBRemote::GetSharedCacheInfo() {
         FileSpec sc_path(
             dict->GetValueForKey("shared_cache_path")->GetStringValue());
 
+        bool use_sc_binary_directly =
+            ModuleList::GetGlobalModuleListProperties()
+                .GetSharedCacheBinaryLoading();
         // Attempt to open the shared cache at sc_path, and
         // if the uuid matches, index all the files.
-        HostInfo::SharedCacheIndexFiles(sc_path, uuid);
+        if (use_sc_binary_directly)
+          HostInfo::SharedCacheIndexFiles(sc_path, uuid);
       }
       m_shared_cache_info_sp = response_sp;
     }

--- a/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
+++ b/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
@@ -203,11 +203,11 @@ std::optional<ModuleSpec> SymbolLocatorDebugSymbols::LocateExecutableObjectFile(
 
           // Check if the requested image is in our shared cache.
           if (!success) {
-            bool use_sc_binary_directly =
+            SymbolSharedCacheUse sc_mode =
                 ModuleList::GetGlobalModuleListProperties()
                     .GetSharedCacheBinaryLoading();
             SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-                module_spec.GetFileSpec().GetPath(), use_sc_binary_directly);
+                module_spec.GetFileSpec().GetPath(), sc_mode);
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.
@@ -649,11 +649,11 @@ static int LocateMacOSXFilesUsingDebugSymbols(const ModuleSpec &module_spec,
 
           // Check if the requested image is in our shared cache.
           if (!success) {
-            bool use_sc_binary_directly =
+            SymbolSharedCacheUse sc_mode =
                 ModuleList::GetGlobalModuleListProperties()
                     .GetSharedCacheBinaryLoading();
             SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-                module_spec.GetFileSpec().GetPath(), use_sc_binary_directly);
+                module_spec.GetFileSpec().GetPath(), sc_mode);
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.

--- a/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
+++ b/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
@@ -203,8 +203,11 @@ std::optional<ModuleSpec> SymbolLocatorDebugSymbols::LocateExecutableObjectFile(
 
           // Check if the requested image is in our shared cache.
           if (!success) {
+            bool use_sc_binary_directly =
+                ModuleList::GetGlobalModuleListProperties()
+                    .GetSharedCacheBinaryLoading();
             SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-                module_spec.GetFileSpec().GetPath());
+                module_spec.GetFileSpec().GetPath(), use_sc_binary_directly);
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.
@@ -646,8 +649,11 @@ static int LocateMacOSXFilesUsingDebugSymbols(const ModuleSpec &module_spec,
 
           // Check if the requested image is in our shared cache.
           if (!success) {
+            bool use_sc_binary_directly =
+                ModuleList::GetGlobalModuleListProperties()
+                    .GetSharedCacheBinaryLoading();
             SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-                module_spec.GetFileSpec().GetPath());
+                module_spec.GetFileSpec().GetPath(), use_sc_binary_directly);
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.

--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -37,8 +37,8 @@ TEST_F(ObjectFileMachOTest, ModuleFromSharedCacheInfo) {
 
   Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
 
-  SharedCacheImageInfo image_info =
-      HostInfo::GetSharedCacheImageInfo("/usr/lib/libobjc.A.dylib");
+  SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
+      "/usr/lib/libobjc.A.dylib", lldb::eSymbolSharedCacheUseHostSharedCache);
   EXPECT_TRUE(image_info.GetUUID());
   EXPECT_TRUE(image_info.GetExtractor());
 
@@ -86,7 +86,8 @@ TEST_F(ObjectFileMachOTest, ModuleFromSharedCacheInfo) {
 
 TEST_F(ObjectFileMachOTest, IndirectSymbolsInTheSharedCache) {
   SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-      "/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit");
+      "/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+      lldb::eSymbolSharedCacheUseHostSharedCache);
   ModuleSpec spec(FileSpec(), UUID(), image_info.GetExtractor());
   lldb::ModuleSP module = std::make_shared<Module>(spec);
 


### PR DESCRIPTION
I introduced a dependency from Host on Core without realizing it in an earlier PR, while adding a setting to disable the new shared cache binary blob scanning/reading in HostInfoMacOSX, which caused build problems.  Thanks to Alex for figuring out the build failure I caused.

Add a bool to the methods in HostInfoMacOSX, and have the callers (in Core and various plugins etc) all fetch the
symbols.shared-cache-binary-loading setting from ModuleList, and pass the result in.

The least obvious part of this is in ProcessGDBRemote where we first learn the shared cache filepath & uuid, it calls HostInfoMacOSX::SharedCacheIndexFiles() - this is only called when the shared cache binary loading is enabled, so I conditionalize the call to this method based on the setting.

rdar://148939795