### PR TITLE
Fix a thinko in calculating the hash for a StopCondition.

### DIFF
--- a/lldb/include/lldb/Breakpoint/StopCondition.h
+++ b/lldb/include/lldb/Breakpoint/StopCondition.h
@@ -30,7 +30,7 @@ public:
   void SetText(std::string text) {
     static std::hash<std::string> hasher;
     m_text = std::move(text);
-    m_hash = hasher(text);
+    m_hash = hasher(m_text);
   }
 
   size_t GetHash() const { return m_hash; }


### PR DESCRIPTION
Don't use variables after a std::move...

We didn't have a test asserting that changing the condition actually works, so I also added that.