### PR TITLE
[clang-doc]: Enable horizontal wrapping on longer function definitions

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -452,8 +452,7 @@ static void serializeArray(const Container &Records, Object &Obj,
     json::Value ItemVal = Object();
     auto &ItemObj = *ItemVal.getAsObject();
     SerializeInfo(Records[Index], ItemObj);
-    if (Index == Records.size() - 1)
-      ItemObj["End"] = true;
+    ItemObj["End"] = (Index == Records.size() - 1);
     RecordsArrayRef.push_back(ItemVal);
   }
   Obj[Key] = RecordsArray;
@@ -536,10 +535,14 @@ static void serializeInfo(const FunctionInfo &F, json::Object &Obj,
                           const std::optional<StringRef> RepositoryLine) {
   serializeCommonAttributes(F, Obj, RepositoryURL, RepositoryLine);
   Obj["IsStatic"] = F.IsStatic;
+  size_t ParamLen = F.Name.size() + 1;
 
   auto ReturnTypeObj = Object();
   serializeInfo(F.ReturnType, ReturnTypeObj);
   Obj["ReturnType"] = std::move(ReturnTypeObj);
+  ParamLen += F.ReturnType.Type.Name.size();
+  ParamLen += 2;
+  Obj["ParamLength"] = ParamLen;
 
   if (!F.Params.empty())
     serializeArray(F.Params, Obj, "Params", SerializeInfoLambda);

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -34,10 +34,10 @@ static void serializeInfo(const RecordInfo &I, Object &Obj,
 static void serializeReference(const Reference &Ref, Object &ReferenceObj);
 
 template <typename Container, typename SerializationFunc>
-static void
-serializeArray(const Container &Records, Object &Obj, const StringRef Key,
-               SerializationFunc SerializeInfo, const StringRef EndKey = "End",
-               void (*Customizer)(Object &Obj, size_t Size) = nullptr);
+static void serializeArray(
+    const Container &Records, Object &Obj, const StringRef Key,
+    SerializationFunc SerializeInfo, const StringRef EndKey = "End",
+    function_ref<void(Object &)> UpdateJson = [](Object &Obj) {});
 
 // Convenience lambda to pass to serializeArray.
 // If a serializeInfo needs a RepositoryUrl, create a local lambda that captures
@@ -442,14 +442,10 @@ serializeCommonChildren(const ScopeChildren &Children, json::Object &Obj,
   }
 }
 
-static void customize(Object &Obj, size_t Size) {
-  Obj["VerticalDisplay"] = Size > 2;
-}
-
 template <typename Container, typename SerializationFunc>
 static void serializeArray(const Container &Records, Object &Obj, StringRef Key,
                            SerializationFunc SerializeInfo, StringRef EndKey,
-                           void (*Customize)(Object &Obj, size_t Size)) {
+                           function_ref<void(Object &)> UpdateJson) {
   json::Value RecordsArray = Array();
   auto &RecordsArrayRef = *RecordsArray.getAsArray();
   RecordsArrayRef.reserve(Records.size());
@@ -462,8 +458,7 @@ static void serializeArray(const Container &Records, Object &Obj, StringRef Key,
     RecordsArrayRef.push_back(ItemVal);
   }
   Obj[Key] = RecordsArray;
-  if (Customize)
-    Customize(Obj, Records.size());
+  UpdateJson(Obj);
 }
 
 static void serializeInfo(const ConstraintInfo &I, Object &Obj) {
@@ -471,40 +466,38 @@ static void serializeInfo(const ConstraintInfo &I, Object &Obj) {
   Obj["Expression"] = I.ConstraintExpr;
 }
 
-static void serializeInfo(const ArrayRef<TemplateParamInfo> &Params,
-                          Object &Obj) {
-  json::Value ParamsArray = Array();
-  auto &ParamsArrayRef = *ParamsArray.getAsArray();
-  ParamsArrayRef.reserve(Params.size());
-  for (size_t Idx = 0; Idx < Params.size(); ++Idx) {
-    json::Value ParamObjVal = Object();
-    Object &ParamObj = *ParamObjVal.getAsObject();
-
-    ParamObj["Param"] = Params[Idx].Contents;
-    if (Idx == Params.size() - 1)
-      ParamObj["End"] = true;
-    ParamsArrayRef.push_back(ParamObjVal);
-  }
-  Obj["Parameters"] = ParamsArray;
-  customize(Obj, Params.size());
-}
-
 static void serializeInfo(const TemplateInfo &Template, Object &Obj) {
   json::Value TemplateVal = Object();
   auto &TemplateObj = *TemplateVal.getAsObject();
+  auto SerializeTemplateParam = [](const TemplateParamInfo &Param,
+                                   Object &JsonObj) {
+    JsonObj["Param"] = Param.Contents;
+  };
 
   if (Template.Specialization) {
     json::Value TemplateSpecializationVal = Object();
     auto &TemplateSpecializationObj = *TemplateSpecializationVal.getAsObject();
     TemplateSpecializationObj["SpecializationOf"] =
         toHex(toStringRef(Template.Specialization->SpecializationOf));
-    if (!Template.Specialization->Params.empty())
-      serializeInfo(Template.Specialization->Params, TemplateSpecializationObj);
+    if (!Template.Specialization->Params.empty()) {
+      bool VerticalDisplay = Template.Specialization->Params.size() > 2;
+      serializeArray(Template.Specialization->Params, TemplateSpecializationObj,
+                     "Parameters", SerializeTemplateParam, "End",
+                     [VerticalDisplay](Object &JsonObj) {
+                       JsonObj["VerticalDisplay"] = VerticalDisplay;
+                     });
+    }
     TemplateObj["Specialization"] = TemplateSpecializationVal;
   }
 
-  if (!Template.Params.empty())
-    serializeInfo(Template.Params, TemplateObj);
+  if (!Template.Params.empty()) {
+    bool VerticalDisplay = Template.Params.size() > 2;
+    serializeArray(Template.Params, TemplateObj, "Parameters",
+                   SerializeTemplateParam, "End",
+                   [VerticalDisplay](Object &JsonObj) {
+                     JsonObj["VerticalDisplay"] = VerticalDisplay;
+                   });
+  }
 
   if (!Template.Constraints.empty())
     serializeArray(Template.Constraints, TemplateObj, "Constraints",
@@ -549,9 +542,13 @@ static void serializeInfo(const FunctionInfo &F, json::Object &Obj,
   serializeInfo(F.ReturnType, ReturnTypeObj);
   Obj["ReturnType"] = std::move(ReturnTypeObj);
 
-  if (!F.Params.empty())
+  if (!F.Params.empty()) {
+    const bool VerticalDisplay = F.Params.size() > 2;
     serializeArray(F.Params, Obj, "Params", SerializeInfoLambda, "ParamEnd",
-                   customize);
+                   [VerticalDisplay](Object &JsonObj) {
+                     JsonObj["VerticalDisplay"] = VerticalDisplay;
+                   });
+  }
 
   if (F.Template)
     serializeInfo(F.Template.value(), Obj);

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -458,7 +458,8 @@ serializeArray(const Container &Records, Object &Obj, const std::string &Key,
     RecordsArrayRef.push_back(ItemVal);
   }
   Obj[Key] = RecordsArray;
-  Obj["VerticalDisplay"] = Records.size() > 2;
+  if (Key == "Params")
+    Obj["VerticalDisplay"] = Records.size() > 2;
 }
 
 static void serializeInfo(const ConstraintInfo &I, Object &Obj) {

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -452,7 +452,8 @@ static void serializeArray(const Container &Records, Object &Obj,
     json::Value ItemVal = Object();
     auto &ItemObj = *ItemVal.getAsObject();
     SerializeInfo(Records[Index], ItemObj);
-    ItemObj["End"] = (Index == Records.size() - 1);
+    if (Index == Records.size() - 1)
+      ItemObj["End"] = true;
     RecordsArrayRef.push_back(ItemVal);
   }
   Obj[Key] = RecordsArray;
@@ -535,14 +536,10 @@ static void serializeInfo(const FunctionInfo &F, json::Object &Obj,
                           const std::optional<StringRef> RepositoryLine) {
   serializeCommonAttributes(F, Obj, RepositoryURL, RepositoryLine);
   Obj["IsStatic"] = F.IsStatic;
-  size_t ParamLen = F.Name.size() + 1;
 
   auto ReturnTypeObj = Object();
   serializeInfo(F.ReturnType, ReturnTypeObj);
   Obj["ReturnType"] = std::move(ReturnTypeObj);
-  ParamLen += F.ReturnType.Type.Name.size();
-  ParamLen += 2;
-  Obj["ParamLength"] = ParamLen;
 
   if (!F.Params.empty())
     serializeArray(F.Params, Obj, "Params", SerializeInfoLambda);

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -39,6 +39,8 @@ static void serializeArray(
     SerializationFunc SerializeInfo, const StringRef EndKey = "End",
     function_ref<void(Object &)> UpdateJson = [](Object &Obj) {});
 
+constexpr static unsigned getMaxParamWrapLimit() { return 2; }
+
 // Convenience lambda to pass to serializeArray.
 // If a serializeInfo needs a RepositoryUrl, create a local lambda that captures
 // the optional.
@@ -480,7 +482,8 @@ static void serializeInfo(const TemplateInfo &Template, Object &Obj) {
     TemplateSpecializationObj["SpecializationOf"] =
         toHex(toStringRef(Template.Specialization->SpecializationOf));
     if (!Template.Specialization->Params.empty()) {
-      bool VerticalDisplay = Template.Specialization->Params.size() > 2;
+      bool VerticalDisplay =
+          Template.Specialization->Params.size() > getMaxParamWrapLimit();
       serializeArray(Template.Specialization->Params, TemplateSpecializationObj,
                      "Parameters", SerializeTemplateParam, "End",
                      [VerticalDisplay](Object &JsonObj) {
@@ -491,7 +494,7 @@ static void serializeInfo(const TemplateInfo &Template, Object &Obj) {
   }
 
   if (!Template.Params.empty()) {
-    bool VerticalDisplay = Template.Params.size() > 2;
+    bool VerticalDisplay = Template.Params.size() > getMaxParamWrapLimit();
     serializeArray(Template.Params, TemplateObj, "Parameters",
                    SerializeTemplateParam, "End",
                    [VerticalDisplay](Object &JsonObj) {
@@ -543,7 +546,7 @@ static void serializeInfo(const FunctionInfo &F, json::Object &Obj,
   Obj["ReturnType"] = std::move(ReturnTypeObj);
 
   if (!F.Params.empty()) {
-    const bool VerticalDisplay = F.Params.size() > 2;
+    const bool VerticalDisplay = F.Params.size() > getMaxParamWrapLimit();
     serializeArray(F.Params, Obj, "Params", SerializeInfoLambda, "ParamEnd",
                    [VerticalDisplay](Object &JsonObj) {
                      JsonObj["VerticalDisplay"] = VerticalDisplay;

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -455,6 +455,24 @@ static void serializeArray(const Container &Records, Object &Obj,
     ItemObj["End"] = (Index == Records.size() - 1);
     RecordsArrayRef.push_back(ItemVal);
   }
+  if (Key == "Params") {
+    size_t TotalLength = 0;
+    for (const auto &Val : RecordsArrayRef) {
+      if (const auto *ItemObj = Val.getAsObject()) {
+        if (const auto *Type = ItemObj->get("Type"))
+          if(const auto *TypeObj = Type->getAsObject())
+            if(auto Name = TypeObj->getString("QualName"))
+              TotalLength += Name->size();
+        if (auto Name = ItemObj->getString("Name"))
+          TotalLength += Name->size();
+        TotalLength += 2; // For ', '
+      }
+    }
+    size_t ParamLen;
+    if(auto Length = Obj.getInteger("ParamLength"))
+      ParamLen = *Length;
+    Obj["IsLong"] = (TotalLength + ParamLen > 80);
+  }
   Obj[Key] = RecordsArray;
 }
 
@@ -542,11 +560,12 @@ static void serializeInfo(const FunctionInfo &F, json::Object &Obj,
   ParamLen += F.ReturnType.Type.Name.size();
   ParamLen += 2;
   Obj["ParamLength"] = ParamLen;
-  if(ParamLen >= 40)
-    Obj["ParamLength"] = 35;
 
   if (!F.Params.empty())
     serializeArray(F.Params, Obj, "Params", SerializeInfoLambda);
+
+  if(ParamLen >= 40)
+    Obj["ParamLength"] = 35;
 
   if (F.Template)
     serializeInfo(F.Template.value(), Obj);

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -36,7 +36,8 @@ static void serializeReference(const Reference &Ref, Object &ReferenceObj);
 template <typename Container, typename SerializationFunc>
 static void serializeArray(const Container &Records, Object &Obj,
                            const std::string &Key,
-                           SerializationFunc SerializeInfo);
+                           SerializationFunc SerializeInfo,
+                           const std::string &EndKey = "End");
 
 // Convenience lambda to pass to serializeArray.
 // If a serializeInfo needs a RepositoryUrl, create a local lambda that captures
@@ -442,9 +443,9 @@ serializeCommonChildren(const ScopeChildren &Children, json::Object &Obj,
 }
 
 template <typename Container, typename SerializationFunc>
-static void serializeArray(const Container &Records, Object &Obj,
-                           const std::string &Key,
-                           SerializationFunc SerializeInfo) {
+static void
+serializeArray(const Container &Records, Object &Obj, const std::string &Key,
+               SerializationFunc SerializeInfo, const std::string &EndKey) {
   json::Value RecordsArray = Array();
   auto &RecordsArrayRef = *RecordsArray.getAsArray();
   RecordsArrayRef.reserve(Records.size());
@@ -453,10 +454,11 @@ static void serializeArray(const Container &Records, Object &Obj,
     auto &ItemObj = *ItemVal.getAsObject();
     SerializeInfo(Records[Index], ItemObj);
     if (Index == Records.size() - 1)
-      ItemObj["End"] = true;
+      ItemObj[EndKey] = true;
     RecordsArrayRef.push_back(ItemVal);
   }
   Obj[Key] = RecordsArray;
+  Obj["VerticalDisplay"] = Records.size() > 2;
 }
 
 static void serializeInfo(const ConstraintInfo &I, Object &Obj) {
@@ -479,6 +481,7 @@ static void serializeInfo(const ArrayRef<TemplateParamInfo> &Params,
     ParamsArrayRef.push_back(ParamObjVal);
   }
   Obj["Parameters"] = ParamsArray;
+  Obj["VerticalDisplay"] = Params.size() > 2;
 }
 
 static void serializeInfo(const TemplateInfo &Template, Object &Obj) {
@@ -542,7 +545,7 @@ static void serializeInfo(const FunctionInfo &F, json::Object &Obj,
   Obj["ReturnType"] = std::move(ReturnTypeObj);
 
   if (!F.Params.empty())
-    serializeArray(F.Params, Obj, "Params", SerializeInfoLambda);
+    serializeArray(F.Params, Obj, "Params", SerializeInfoLambda, "ParamEnd");
 
   if (F.Template)
     serializeInfo(F.Template.value(), Obj);

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -455,24 +455,6 @@ static void serializeArray(const Container &Records, Object &Obj,
     ItemObj["End"] = (Index == Records.size() - 1);
     RecordsArrayRef.push_back(ItemVal);
   }
-  if (Key == "Params") {
-    size_t TotalLength = 0;
-    for (const auto &Val : RecordsArrayRef) {
-      if (const auto *ItemObj = Val.getAsObject()) {
-        if (const auto *Type = ItemObj->get("Type"))
-          if(const auto *TypeObj = Type->getAsObject())
-            if(auto Name = TypeObj->getString("QualName"))
-              TotalLength += Name->size();
-        if (auto Name = ItemObj->getString("Name"))
-          TotalLength += Name->size();
-        TotalLength += 2; // For ', '
-      }
-    }
-    size_t ParamLen;
-    if(auto Length = Obj.getInteger("ParamLength"))
-      ParamLen = *Length;
-    Obj["IsLong"] = (TotalLength + ParamLen > 80);
-  }
   Obj[Key] = RecordsArray;
 }
 
@@ -491,7 +473,8 @@ static void serializeInfo(const ArrayRef<TemplateParamInfo> &Params,
     Object &ParamObj = *ParamObjVal.getAsObject();
 
     ParamObj["Param"] = Params[Idx].Contents;
-    ParamObj["End"] = (Idx == Params.size() - 1);
+    if (Idx == Params.size() - 1)
+      ParamObj["End"] = true;
     ParamsArrayRef.push_back(ParamObjVal);
   }
   Obj["Parameters"] = ParamsArray;
@@ -563,9 +546,6 @@ static void serializeInfo(const FunctionInfo &F, json::Object &Obj,
 
   if (!F.Params.empty())
     serializeArray(F.Params, Obj, "Params", SerializeInfoLambda);
-
-  if(ParamLen >= 40)
-    Obj["ParamLength"] = 35;
 
   if (F.Template)
     serializeInfo(F.Template.value(), Obj);

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -34,10 +34,10 @@ static void serializeInfo(const RecordInfo &I, Object &Obj,
 static void serializeReference(const Reference &Ref, Object &ReferenceObj);
 
 template <typename Container, typename SerializationFunc>
-static void serializeArray(const Container &Records, Object &Obj,
-                           const std::string &Key,
-                           SerializationFunc SerializeInfo,
-                           const std::string &EndKey = "End");
+static void
+serializeArray(const Container &Records, Object &Obj, const StringRef Key,
+               SerializationFunc SerializeInfo, const StringRef EndKey = "End",
+               void (*Customizer)(Object &Obj, size_t Size) = nullptr);
 
 // Convenience lambda to pass to serializeArray.
 // If a serializeInfo needs a RepositoryUrl, create a local lambda that captures
@@ -442,10 +442,14 @@ serializeCommonChildren(const ScopeChildren &Children, json::Object &Obj,
   }
 }
 
+static void customize(Object &Obj, size_t Size) {
+  Obj["VerticalDisplay"] = Size > 2;
+}
+
 template <typename Container, typename SerializationFunc>
-static void
-serializeArray(const Container &Records, Object &Obj, const std::string &Key,
-               SerializationFunc SerializeInfo, const std::string &EndKey) {
+static void serializeArray(const Container &Records, Object &Obj, StringRef Key,
+                           SerializationFunc SerializeInfo, StringRef EndKey,
+                           void (*Customize)(Object &Obj, size_t Size)) {
   json::Value RecordsArray = Array();
   auto &RecordsArrayRef = *RecordsArray.getAsArray();
   RecordsArrayRef.reserve(Records.size());
@@ -458,8 +462,8 @@ serializeArray(const Container &Records, Object &Obj, const std::string &Key,
     RecordsArrayRef.push_back(ItemVal);
   }
   Obj[Key] = RecordsArray;
-  if (Key == "Params")
-    Obj["VerticalDisplay"] = Records.size() > 2;
+  if (Customize)
+    Customize(Obj, Records.size());
 }
 
 static void serializeInfo(const ConstraintInfo &I, Object &Obj) {
@@ -482,7 +486,7 @@ static void serializeInfo(const ArrayRef<TemplateParamInfo> &Params,
     ParamsArrayRef.push_back(ParamObjVal);
   }
   Obj["Parameters"] = ParamsArray;
-  Obj["VerticalDisplay"] = Params.size() > 2;
+  customize(Obj, Params.size());
 }
 
 static void serializeInfo(const TemplateInfo &Template, Object &Obj) {
@@ -546,7 +550,8 @@ static void serializeInfo(const FunctionInfo &F, json::Object &Obj,
   Obj["ReturnType"] = std::move(ReturnTypeObj);
 
   if (!F.Params.empty())
-    serializeArray(F.Params, Obj, "Params", SerializeInfoLambda, "ParamEnd");
+    serializeArray(F.Params, Obj, "Params", SerializeInfoLambda, "ParamEnd",
+                   customize);
 
   if (F.Template)
     serializeInfo(F.Template.value(), Obj);

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -39,7 +39,8 @@ static void serializeArray(
     SerializationFunc SerializeInfo, const StringRef EndKey = "End",
     function_ref<void(Object &)> UpdateJson = [](Object &Obj) {});
 
-// TODO(issue URL): Wrapping logic for HTML should probably use a more sophisticated heuristic than number of parameters.
+// TODO(issue URL): Wrapping logic for HTML should probably use a more
+// sophisticated heuristic than number of parameters.
 constexpr static unsigned getMaxParamWrapLimit() { return 2; }
 
 // Convenience lambda to pass to serializeArray.

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -39,6 +39,7 @@ static void serializeArray(
     SerializationFunc SerializeInfo, const StringRef EndKey = "End",
     function_ref<void(Object &)> UpdateJson = [](Object &Obj) {});
 
+// TODO(issue URL): Wrapping logic for HTML should probably use a more sophisticated heuristic than number of parameters.
 constexpr static unsigned getMaxParamWrapLimit() { return 2; }
 
 // Convenience lambda to pass to serializeArray.

--- a/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
+++ b/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
@@ -520,3 +520,12 @@ a, a:visited, a:hover, a:active {
   overflow: hidden;
   padding: 10px;
 }
+
+.param {
+    display: block;
+    padding-left: 4ch;
+}
+
+.param-container {
+    display: block;
+}

--- a/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
+++ b/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
@@ -521,12 +521,10 @@ a, a:visited, a:hover, a:active {
   padding: 10px;
 }
 
-
 .params-vertical {
     display: flex;
     flex-wrap: wrap;
 }
-
 
 .param {
     display: block;

--- a/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
+++ b/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
@@ -520,3 +520,25 @@ a, a:visited, a:hover, a:active {
   overflow: hidden;
   padding: 10px;
 }
+
+
+.params-vertical {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+
+.param {
+    display: block;
+    margin-right: 5px;
+    padding-left: 100px;
+}
+
+.format-text {
+    color: #800;    
+}
+
+.format-title {
+    color: #800;
+    font-weight: bold;
+}

--- a/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
+++ b/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
@@ -531,7 +531,6 @@ a, a:visited, a:hover, a:active {
 .param {
     display: block;
     margin-right: 5px;
-    padding-left: 100px;
 }
 
 .format-text {

--- a/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
+++ b/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
@@ -531,6 +531,7 @@ a, a:visited, a:hover, a:active {
 .param {
     display: block;
     margin-right: 5px;
+    padding-left: 100px;
 }
 
 .format-text {

--- a/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
+++ b/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
@@ -521,10 +521,12 @@ a, a:visited, a:hover, a:active {
   padding: 10px;
 }
 
+
 .params-vertical {
     display: flex;
     flex-wrap: wrap;
 }
+
 
 .param {
     display: block;

--- a/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
+++ b/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
@@ -520,25 +520,3 @@ a, a:visited, a:hover, a:active {
   overflow: hidden;
   padding: 10px;
 }
-
-
-.params-vertical {
-    display: flex;
-    flex-wrap: wrap;
-}
-
-
-.param {
-    display: block;
-    margin-right: 5px;
-    padding-left: 100px;
-}
-
-.format-text {
-    color: #800;    
-}
-
-.format-title {
-    color: #800;
-    font-weight: bold;
-}

--- a/clang-tools-extra/clang-doc/assets/function-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/function-template.mustache
@@ -7,10 +7,10 @@
 }}
 <div id="{{USR}}" class="delimiter-container">
         {{#Template}}
-        <pre><code class="language-cpp code-clang-doc">template &lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;</code></pre>
+        <pre><code class="language-cpp code-clang-doc">template &lt;{{^VerticalDisplay}}{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}{{/VerticalDisplay}}</code>{{#VerticalDisplay}}<span class="param-container">{{#Parameters}}<span class="param"><code class="language-cpp code-clang-doc">{{Param}}{{^End}}, {{/End}}</code></span>{{/Parameters}}</span>{{/VerticalDisplay}}<code class="language-cpp code-clang-doc">&gt;</code></pre>
         {{/Template}}
         {{! Function Prototype }}
-        <pre><code class="language-cpp code-clang-doc">{{ReturnType.QualName}} {{Name}}{{#Template}}{{#Specialization}}&lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;{{/Specialization}}{{/Template}} ({{#Params}}{{Type.QualName}} {{Name}}{{^End}}, {{/End}}{{/Params}})</code></pre>
+        <pre><code class="language-cpp code-clang-doc">{{ReturnType.QualName}} {{Name}}{{#Template}}{{#Specialization}}&lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;{{/Specialization}}{{/Template}} ({{^VerticalDisplay}}{{#Params}}{{Type.QualName}} {{Name}}{{^ParamEnd}}, {{/ParamEnd}}{{/Params}}){{/VerticalDisplay}}</code>{{#VerticalDisplay}}<span class="param-container">{{#Params}}<span class="param"><code class="language-cpp code-clang-doc">{{Type.QualName}}</code> <code class="language-cpp code-clang-doc">{{Name}}{{^ParamEnd}}, {{/ParamEnd}}</code></span>{{/Params}}</span><code class="language-cpp code-clang-doc">)</code>{{/VerticalDisplay}}</pre>
         {{! Function Comments }}
         {{#Description}}
         <div class="doc-card">

--- a/clang-tools-extra/clang-doc/assets/function-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/function-template.mustache
@@ -10,8 +10,7 @@
         <pre><code class="language-cpp code-clang-doc">template &lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;</code></pre>
         {{/Template}}
         {{! Function Prototype }}
-        <pre><code class="language-cpp code-clang-doc">{{ReturnType.QualName}} {{Name}}{{#Template}}{{#Specialization}}&lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;{{/Specialization}}{{/Template}} ({{#Params}}{{Type.QualName}} {{Name}}{{^End}}, {{/End}}{{/Params}})</code></pre>
-        {{! Function Comments }}
+        <pre><code class="nohighlight code-clang-doc"><span class="format-text">{{ReturnType.QualName}}</span> <span class="format-title">{{Name}}</span> (<span class="params-vertical" style="padding-left: {{ParamLength}}ch;">{{#Params}}<span class="param"><span class="format-text">{{Type.QualName}}</span> {{Name}}{{^End}}, {{/End}}</span>{{/Params}}</span><span class="params-vertical" style="padding-left: {{ParamLength}}ch;">)</span></code></pre>
         {{#Description}}
         <div class="doc-card">
             {{>Comments}}

--- a/clang-tools-extra/clang-doc/assets/function-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/function-template.mustache
@@ -10,7 +10,7 @@
         <pre><code class="language-cpp code-clang-doc">template &lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;</code></pre>
         {{/Template}}
         {{! Function Prototype }}
-        <pre><code class="nohighlight code-clang-doc"><span class="format-text">{{ReturnType.QualName}}</span> <span class="format-title">{{Name}}</span> (<span class="params-vertical" style="padding-left: {{ParamLength}}ch;">{{#Params}}<span class="param"><span class="format-text">{{Type.QualName}}</span> {{Name}}{{^End}}, {{/End}}</span>{{/Params}}</span><span class="params-vertical" style="padding-left: {{ParamLength}}ch;">)</span></code></pre>
+        <pre><code class="nohighlight code-clang-doc"><span class="format-text">{{ReturnType.QualName}}</span> <span class="format-title">{{Name}}</span> ({{#IsLong}}<span class="params-vertical" style="padding-left: {{ParamLength}}ch;">{{#Params}}<span class="param"><span class="format-text">{{Type.QualName}}</span> {{Name}}{{^End}}, {{/End}}</span>{{/Params}}</span><span class="param" style="padding-left: calc({{ParamLength}}ch - 1ch);">)</span>{{/IsLong}}{{^IsLong}}{{#Params}}{{Type.QualName}} {{Name}}{{^End}}, {{/End}}{{/Params}}){{/IsLong}}</code></pre>
         {{#Description}}
         <div class="doc-card">
             {{>Comments}}

--- a/clang-tools-extra/clang-doc/assets/function-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/function-template.mustache
@@ -10,7 +10,7 @@
         <pre><code class="language-cpp code-clang-doc">template &lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;</code></pre>
         {{/Template}}
         {{! Function Prototype }}
-        <pre><code class="nohighlight code-clang-doc"><span class="format-text">{{ReturnType.QualName}}</span> <span class="format-title">{{Name}}</span> ({{#IsLong}}<span class="params-vertical" style="padding-left: {{ParamLength}}ch;">{{#Params}}<span class="param"><span class="format-text">{{Type.QualName}}</span> {{Name}}{{^End}}, {{/End}}</span>{{/Params}}</span><span class="param" style="padding-left: calc({{ParamLength}}ch - 1ch);">)</span>{{/IsLong}}{{^IsLong}}{{#Params}}{{Type.QualName}} {{Name}}{{^End}}, {{/End}}{{/Params}}){{/IsLong}}</code></pre>
+        <pre><code class="nohighlight code-clang-doc"><span class="format-text">{{ReturnType.QualName}}</span> <span class="format-title">{{Name}}</span> (<span class="params-vertical" style="padding-left: {{ParamLength}}ch;">{{#Params}}<span class="param"><span class="format-text">{{Type.QualName}}</span> {{Name}}{{^End}}, {{/End}}</span>{{/Params}}</span><span class="param" style="padding-left: calc({{ParamLength}}ch - 1ch);">)</span></code></pre>
         {{#Description}}
         <div class="doc-card">
             {{>Comments}}

--- a/clang-tools-extra/clang-doc/assets/function-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/function-template.mustache
@@ -10,7 +10,7 @@
         <pre><code class="language-cpp code-clang-doc">template &lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;</code></pre>
         {{/Template}}
         {{! Function Prototype }}
-        <pre><code class="nohighlight code-clang-doc"><span class="format-text">{{ReturnType.QualName}}</span> <span class="format-title">{{Name}}</span> ({{#IsLong}}<span class="params-vertical" style="padding-left: {{ParamLength}}ch;">{{#Params}}<span class="param"><span class="format-text">{{Type.QualName}}</span> {{Name}}{{^End}}, {{/End}}</span>{{/Params}}</span><span class="param" style="padding-left: calc({{ParamLength}}ch - 1ch);">)</span>{{/IsLong}}{{^IsLong}}{{#Params}}{{Type.QualName}} {{Name}}{{^End}}, {{/End}}{{/Params}}){{/IsLong}}</code></pre>
+        <pre><code class="nohighlight code-clang-doc"><span class="format-text">{{ReturnType.QualName}}</span> <span class="format-title">{{Name}}</span> (<span class="params-vertical" style="padding-left: {{ParamLength}}ch;">{{#Params}}<span class="param"><span class="format-text">{{Type.QualName}}</span> {{Name}}{{^End}}, {{/End}}</span>{{/Params}}</span><span class="params-vertical" style="padding-left: {{ParamLength}}ch;">)</span></code></pre>
         {{#Description}}
         <div class="doc-card">
             {{>Comments}}

--- a/clang-tools-extra/clang-doc/assets/function-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/function-template.mustache
@@ -10,7 +10,8 @@
         <pre><code class="language-cpp code-clang-doc">template &lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;</code></pre>
         {{/Template}}
         {{! Function Prototype }}
-        <pre><code class="nohighlight code-clang-doc"><span class="format-text">{{ReturnType.QualName}}</span> <span class="format-title">{{Name}}</span> (<span class="params-vertical" style="padding-left: {{ParamLength}}ch;">{{#Params}}<span class="param"><span class="format-text">{{Type.QualName}}</span> {{Name}}{{^End}}, {{/End}}</span>{{/Params}}</span><span class="params-vertical" style="padding-left: {{ParamLength}}ch;">)</span></code></pre>
+        <pre><code class="language-cpp code-clang-doc">{{ReturnType.QualName}} {{Name}}{{#Template}}{{#Specialization}}&lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;{{/Specialization}}{{/Template}} ({{#Params}}{{Type.QualName}} {{Name}}{{^End}}, {{/End}}{{/Params}})</code></pre>
+        {{! Function Comments }}
         {{#Description}}
         <div class="doc-card">
             {{>Comments}}

--- a/clang-tools-extra/clang-doc/assets/function-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/function-template.mustache
@@ -10,7 +10,7 @@
         <pre><code class="language-cpp code-clang-doc">template &lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;</code></pre>
         {{/Template}}
         {{! Function Prototype }}
-        <pre><code class="nohighlight code-clang-doc"><span class="format-text">{{ReturnType.QualName}}</span> <span class="format-title">{{Name}}</span> (<span class="params-vertical" style="padding-left: {{ParamLength}}ch;">{{#Params}}<span class="param"><span class="format-text">{{Type.QualName}}</span> {{Name}}{{^End}}, {{/End}}</span>{{/Params}}</span><span class="param" style="padding-left: calc({{ParamLength}}ch - 1ch);">)</span></code></pre>
+        <pre><code class="nohighlight code-clang-doc"><span class="format-text">{{ReturnType.QualName}}</span> <span class="format-title">{{Name}}</span> ({{#IsLong}}<span class="params-vertical" style="padding-left: {{ParamLength}}ch;">{{#Params}}<span class="param"><span class="format-text">{{Type.QualName}}</span> {{Name}}{{^End}}, {{/End}}</span>{{/Params}}</span><span class="param" style="padding-left: calc({{ParamLength}}ch - 1ch);">)</span>{{/IsLong}}{{^IsLong}}{{#Params}}{{Type.QualName}} {{Name}}{{^End}}, {{/End}}{{/Params}}){{/IsLong}}</code></pre>
         {{#Description}}
         <div class="doc-card">
             {{>Comments}}

--- a/clang-tools-extra/clang-doc/assets/mustache-index.js
+++ b/clang-tools-extra/clang-doc/assets/mustache-index.js
@@ -21,6 +21,38 @@ document.addEventListener("DOMContentLoaded", function() {
     el.classList.remove("hljs");
   });
 
+  function getCharSize() {
+    const testChar = document.createElement('span');
+    testChar.className = "code-clang-doc"
+    testChar.style.visibility = 'hidden';
+    testChar.innerText = 'a';
+    document.body.appendChild(testChar);
+    const charWidth = testChar.getBoundingClientRect().width;
+    document.body.removeChild(testChar);
+    return charWidth;
+  }
+
+  function revertToSingleLine(func) {
+    const paramsContainer = func.querySelectorAll('.params-vertical')
+    const params = func.querySelectorAll('.param')
+    paramsContainer.forEach(params => {
+      params.style.display = "inline";
+      params.style.paddingLeft = "0px";
+    });
+    params.forEach(param => {
+      param.style.display = "inline";
+      param.style.paddingLeft = "0px";
+    });
+  }
+
+  const functions = document.querySelectorAll('.code-clang-doc');
+  const content = document.querySelector('.content')
+  const charSize = getCharSize();
+  functions.forEach(func => {
+    if(func.textContent.trim().length * charSize < content.clientWidth - 20)
+      revertToSingleLine(func)
+  });
+
   document.querySelectorAll('.sidebar-item-container').forEach(item => {
     item.addEventListener('click', function() {
       const anchor = item.getElementsByTagName("a");

--- a/clang-tools-extra/clang-doc/assets/mustache-index.js
+++ b/clang-tools-extra/clang-doc/assets/mustache-index.js
@@ -21,38 +21,6 @@ document.addEventListener("DOMContentLoaded", function() {
     el.classList.remove("hljs");
   });
 
-  function getCharSize() {
-    const testChar = document.createElement('span');
-    testChar.className = "code-clang-doc"
-    testChar.style.visibility = 'hidden';
-    testChar.innerText = 'a';
-    document.body.appendChild(testChar);
-    const charWidth = testChar.getBoundingClientRect().width;
-    document.body.removeChild(testChar);
-    return charWidth;
-  }
-
-  function revertToSingleLine(func) {
-    const paramsContainer = func.querySelectorAll('.params-vertical')
-    const params = func.querySelectorAll('.param')
-    paramsContainer.forEach(params => {
-      params.style.display = "inline";
-      params.style.paddingLeft = "0px";
-    });
-    params.forEach(param => {
-      param.style.display = "inline";
-      param.style.paddingLeft = "0px";
-    });
-  }
-
-  const functions = document.querySelectorAll('.code-clang-doc');
-  const content = document.querySelector('.content')
-  const charSize = getCharSize();
-  functions.forEach(func => {
-    if(func.textContent.trim().length * charSize < content.clientWidth - 20)
-      revertToSingleLine(func)
-  });
-
   document.querySelectorAll('.sidebar-item-container').forEach(item => {
     item.addEventListener('click', function() {
       const anchor = item.getElementsByTagName("a");

--- a/clang-tools-extra/test/clang-doc/json/class-requires.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-requires.cpp
@@ -32,6 +32,7 @@ struct MyClass;
 // CHECK-NEXT:        "End": true,
 // CHECK-NEXT:        "typename T"
 // CHECK-NEXT:      }
-// CHECK-NEXT:    ]
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "VerticalDisplay": false
 // CHECK-NEXT:  },
 // CHECK-NEXT:  "USR": "{{[0-9A-F]*}}"

--- a/clang-tools-extra/test/clang-doc/json/class-specialization.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-specialization.cpp
@@ -20,7 +20,8 @@ template<> struct MyClass<int> {};
 // BASE-NEXT:        "End": true,
 // BASE-NEXT:        "Param": "typename T"
 // BASE-NEXT:      }
-// BASE-NEXT:    ]
+// BASE-NEXT:    ],
+// BASE-NEXT:    "VerticalDisplay": false
 // BASE-NEXT:  },
 
 // SPECIALIZATION:       "MangledName": "_ZTV7MyClassIiE",
@@ -38,6 +39,7 @@ template<> struct MyClass<int> {};
 // SPECIALIZATION-NEXT:          "Param": "int"
 // SPECIALIZATION-NEXT:        }
 // SPECIALIZATION-NEXT:      ],
-// SPECIALIZATION-NEXT:      "SpecializationOf": "{{[0-9A-F]*}}"
+// SPECIALIZATION-NEXT:      "SpecializationOf": "{{[0-9A-F]*}}",
+// SPECIALIZATION-NEXT:      "VerticalDisplay": false
 // SPECIALIZATION-NEXT:    }
 // SPECIALIZATION-NEXT:  },

--- a/clang-tools-extra/test/clang-doc/json/class-template.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-template.cpp
@@ -18,8 +18,8 @@ template<typename T> struct MyClass {
 // CHECK:         "Name": "method",
 // CHECK:         "Params": [
 // CHECK-NEXT:      {
-// CHECK-NEXT:        "End": true,
 // CHECK-NEXT:        "Name": "Param",
+// CHECK-NEXT:        "ParamEnd": true,
 // CHECK-NEXT:        "Type": {
 // CHECK-NEXT:          "Name": "T",
 // CHECK-NEXT:          "QualName": "T",
@@ -39,4 +39,6 @@ template<typename T> struct MyClass {
 // CHECK-NEXT:          "End": true,
 // CHECK-NEXT:          "Param": "typename T"
 // CHECK-NEXT:        }
-// CHECK-NEXT:      ] 
+// CHECK-NEXT:      ],
+// CHECK-NEXT:      "VerticalDisplay": false
+// CHECK-NEXT:    } 

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -139,9 +139,11 @@ private:
 // CHECK-NEXT:              "End": true,
 // CHECK-NEXT:              "Param": "typename T"
 // CHECK-NEXT:            }
-// CHECK-NEXT:          ]
+// CHECK-NEXT:          ],
+// CHECK-NEXT:          "VerticalDisplay": false
 // CHECK-NEXT:        }
-// CHECK-NEXT:        "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:        "USR": "0000000000000000000000000000000000000000",
+// CHECK-NEXT:        "VerticalDisplay": false
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "Description": {
@@ -239,8 +241,8 @@ private:
 // CHECK-NEXT:        ],
 // CHECK-NEXT:        "Params": [
 // CHECK-NEXT:          {
-// CHECK-NEXT:            "End": true,
 // CHECK-NEXT:            "Name": "MyParam",
+// CHECK-NEXT:            "ParamEnd": true,
 // CHECK-NEXT:            "Type": {
 // CHECK-NEXT:              "Name": "int",
 // CHECK-NEXT:              "QualName": "int",
@@ -255,7 +257,8 @@ private:
 // CHECK-NEXT:          "QualName": "int",
 // CHECK-NEXT:          "USR": "{{[0-9A-F]*}}"
 // CHECK-NEXT:        },
-// CHECK-NEXT:        "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:        "USR": "{{[0-9A-F]*}}",
+// CHECK-NEXT:        "VerticalDisplay": false
 // CHECK-NEXT:      },
 // CHECK:             "IsStatic": true,
 // CHECK:             "Name": "getConst",

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -142,8 +142,7 @@ private:
 // CHECK-NEXT:          ],
 // CHECK-NEXT:          "VerticalDisplay": false
 // CHECK-NEXT:        }
-// CHECK-NEXT:        "USR": "0000000000000000000000000000000000000000",
-// CHECK-NEXT:        "VerticalDisplay": false
+// CHECK-NEXT:        "USR": "0000000000000000000000000000000000000000"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "Description": {

--- a/clang-tools-extra/test/clang-doc/json/concept.cpp
+++ b/clang-tools-extra/test/clang-doc/json/concept.cpp
@@ -34,6 +34,7 @@ concept Incrementable = requires(T x) {
 // CHECK-NEXT:              "Param": "typename T"
 // CHECK-NEXT:            }
 // CHECK-NEXT:          ]
+// CHECK-NEXT:        "VerticalDisplay": false
 // CHECK-NEXT:        },
 // CHECK-NEXT:        "USR": "{{[0-9A-F]*}}"
 // CHECK-NEXT:      }

--- a/clang-tools-extra/test/clang-doc/json/function-requires.cpp
+++ b/clang-tools-extra/test/clang-doc/json/function-requires.cpp
@@ -19,8 +19,8 @@ template<Incrementable T> Incrementable auto incrementTwo(T t);
 // CHECK-NEXT:      "Name": "increment",
 // CHECK-NEXT:      "Params": [
 // CHECK-NEXT:        {
-// CHECK-NEXT:          "End": true,
 // CHECK-NEXT:          "Name": "t",
+// CHECK-NEXT:          "ParamEnd": true
 // CHECK-NEXT:          "Type": {
 // CHECK-NEXT:            "Name": "T",
 // CHECK-NEXT:            "QualName": "T",
@@ -50,9 +50,11 @@ template<Incrementable T> Incrementable auto incrementTwo(T t);
 // CHECK-NEXT:            "End": true,
 // CHECK-NEXT:            "Param": "typename T"
 // CHECK-NEXT:          }
-// CHECK-NEXT:        ]
+// CHECK-NEXT:        ],
+// CHECK-NEXT:        "VerticalDisplay": false
 // CHECK-NEXT:      },
-// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}" 
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}",
+// CHECK-NEXT:      "VerticalDisplay": false
 // CHECK-NEXT:    },
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "End": true,
@@ -61,8 +63,8 @@ template<Incrementable T> Incrementable auto incrementTwo(T t);
 // CHECK-NEXT:      "Name": "incrementTwo",
 // CHECK-NEXT:      "Params": [
 // CHECK-NEXT:        {
-// CHECK-NEXT:          "End": true,
 // CHECK-NEXT:          "Name": "t",
+// CHECK-NEXT:          "ParamEnd": true
 // CHECK-NEXT:          "Type": {
 // CHECK-NEXT:            "Name": "T",
 // CHECK-NEXT:            "QualName": "T",
@@ -92,7 +94,9 @@ template<Incrementable T> Incrementable auto incrementTwo(T t);
 // CHECK-NEXT:            "End": true,
 // CHECK-NEXT:            "Param": "Incrementable T"
 // CHECK-NEXT:          }
-// CHECK-NEXT:        ]
+// CHECK-NEXT:        ],
+// CHECK-NEXT:        "VerticalDisplay": false
 // CHECK-NEXT:      },
-// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}",
+// CHECK-NEXT:      "VerticalDisplay": false
 // CHECK-NEXT:    }

--- a/clang-tools-extra/test/clang-doc/json/method-template.cpp
+++ b/clang-tools-extra/test/clang-doc/json/method-template.cpp
@@ -22,8 +22,8 @@ struct MyClass {
 // CHECK-NEXT:          ],
 // CHECK-NEXT:          "Params": [
 // CHECK-NEXT:            {
-// CHECK-NEXT:              "End": true,
 // CHECK-NEXT:              "Name": "param",
+// CHECK-NEXT:              "ParamEnd": true,
 // CHECK-NEXT:              "Type": {
 // CHECK-NEXT:                "Name": "T",
 // CHECK-NEXT:                "QualName": "T",
@@ -44,6 +44,7 @@ struct MyClass {
 // CHECK-NEXT:                "End": true,
 // CHECK-NEXT:                "Param": "class T"
 // CHECK-NEXT:              }
-// CHECK-NEXT:            ]
+// CHECK-NEXT:            ],
+// CHECK-NEXT:          "VerticalDisplay": false
 // CHECK-NEXT:          },
 // CHECK-NEXT:          "USR": "{{[0-9A-F]*}}"

--- a/clang-tools-extra/test/clang-doc/json/namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/json/namespace.cpp
@@ -58,8 +58,8 @@ typedef int MyTypedef;
 // CHECK-NEXT:       "Name": "myFunction",
 // CHECK-NEXT:       "Params": [
 // CHECK-NEXT:         {
-// CHECK-NEXT:           "End": true,
 // CHECK-NEXT:           "Name": "Param",
+// CHECK-NEXT:           "ParamEnd": true,
 // CHECK-NEXT:           "Type": {
 // CHECK-NEXT:             "Name": "int",
 // CHECK-NEXT:             "QualName": "int",
@@ -74,7 +74,8 @@ typedef int MyTypedef;
 // CHECK-NEXT:         "QualName": "void",
 // CHECK-NEXT:         "USR": "0000000000000000000000000000000000000000"
 // CHECK-NEXT:       },
-// CHECK-NEXT:       "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:       "USR": "{{[0-9A-F]*}}",
+// CHECK-NEXT:       "VerticalDisplay": false
 // CHECK-NEXT:     }
 // CHECK-NEXT:   ],
 // CHECK-NEXT:   "HasEnums": true,

--- a/clang-tools-extra/test/clang-doc/templates.cpp
+++ b/clang-tools-extra/test/clang-doc/templates.cpp
@@ -144,6 +144,131 @@ void function(T x) {}
 // HTML-NEXT:      <p>Defined at line [[# @LINE - 59]] of file {{.*}}templates.cpp</p>
 // HTML-NEXT:  </div>
 
+template <typename A, typename B, typename C, typename D, typename E>
+void longFunction(A a, B b, C c, D d, E e) {}
+
+// YAML-NEXT:   - USR:             '{{([0-9A-F]{40})}}'
+// YAML-NEXT:     Name:            'longFunction'
+// YAML-NEXT:     DefLocation:
+// YAML-NEXT:       LineNumber:      [[# @LINE - 5]]
+// YAML-NEXT:       Filename:        '{{.*}}'
+// YAML-NEXT:     Params:
+// YAML-NEXT:       - Type:
+// YAML-NEXT:           Name:            'A'
+// YAML-NEXT:           QualName:        'A'
+// YAML-NEXT:         Name:            'a'
+// YAML-NEXT:       - Type:
+// YAML-NEXT:           Name:            'B'
+// YAML-NEXT:           QualName:        'B'
+// YAML-NEXT:         Name:            'b'
+// YAML-NEXT:       - Type:
+// YAML-NEXT:           Name:            'C'
+// YAML-NEXT:           QualName:        'C'
+// YAML-NEXT:         Name:            'c'
+// YAML-NEXT:       - Type:
+// YAML-NEXT:           Name:            'D'
+// YAML-NEXT:           QualName:        'D'
+// YAML-NEXT:         Name:            'd'
+// YAML-NEXT:       - Type:
+// YAML-NEXT:           Name:            'E'
+// YAML-NEXT:           QualName:        'E'
+// YAML-NEXT:         Name:            'e'
+// YAML-NEXT:     ReturnType:
+// YAML-NEXT:       Type:
+// YAML-NEXT:         Name:            'void'
+// YAML-NEXT:         QualName:        'void'
+// YAML-NEXT:     Template:
+// YAML-NEXT:         Params:
+// YAML-NEXT:           - Contents:        'typename A'
+// YAML-NEXT:           - Contents:        'typename B'
+// YAML-NEXT:           - Contents:        'typename C'
+// YAML-NEXT:           - Contents:        'typename D'
+// YAML-NEXT:           - Contents:        'typename E'
+
+// MD: ### longFunction
+// MD: *void longFunction(A a, B b, C c, D d, E e)*
+// MD: *Defined at {{.*}}templates.cpp#[[# @LINE - 42]]*
+
+// JSON:           "Name": "longFunction",
+// JSON-NEXT:      "Params": [
+// JSON-NEXT:        {
+// JSON-NEXT:          "Name": "a",
+// JSON-NEXT:          "Type": {
+// JSON-NEXT:            "Name": "A",
+// JSON-NEXT:            "QualName": "A",
+// JSON-NEXT:            "USR": "0000000000000000000000000000000000000000"
+// JSON-NEXT:          }
+// JSON-NEXT:        },
+// JSON-NEXT:        {
+// JSON-NEXT:          "Name": "b",
+// JSON-NEXT:          "Type": {
+// JSON-NEXT:            "Name": "B",
+// JSON-NEXT:            "QualName": "B",
+// JSON-NEXT:            "USR": "0000000000000000000000000000000000000000"
+// JSON-NEXT:          }
+// JSON-NEXT:        },
+// JSON-NEXT:        {
+// JSON-NEXT:          "Name": "c",
+// JSON-NEXT:          "Type": {
+// JSON-NEXT:            "Name": "C",
+// JSON-NEXT:            "QualName": "C",
+// JSON-NEXT:            "USR": "0000000000000000000000000000000000000000"
+// JSON-NEXT:          }
+// JSON-NEXT:        },
+// JSON-NEXT:       {
+// JSON-NEXT:          "Name": "d",
+// JSON-NEXT:          "Type": {
+// JSON-NEXT:            "Name": "D",
+// JSON-NEXT:            "QualName": "D",
+// JSON-NEXT:            "USR": "0000000000000000000000000000000000000000"
+// JSON-NEXT:          }
+// JSON-NEXT:        },
+// JSON-NEXT:        {
+// JSON-NEXT:          "Name": "e",
+// JSON-NEXT:          "ParamEnd": true,
+// JSON-NEXT:          "Type": {
+// JSON-NEXT:            "Name": "E",
+// JSON-NEXT:            "QualName": "E",
+// JSON-NEXT:            "USR": "0000000000000000000000000000000000000000"
+// JSON-NEXT:          }
+// JSON-NEXT:        }
+// JSON-NEXT:      ],
+// JSON-NEXT:      "ReturnType": {
+// JSON-NEXT:        "IsBuiltIn": true,
+// JSON-NEXT:        "IsTemplate": false,
+// JSON-NEXT:        "Name": "void",
+// JSON-NEXT:        "QualName": "void",
+// JSON-NEXT:        "USR": "0000000000000000000000000000000000000000"
+// JSON-NEXT:      },
+// JSON-NEXT:      "Template": {
+// JSON-NEXT:          "Parameters": [
+// JSON-NEXT:            {
+// JSON-NEXT:              "Param": "typename A"
+// JSON-NEXT:            },
+// JSON-NEXT:            {
+// JSON-NEXT:              "Param": "typename B"
+// JSON-NEXT:            },
+// JSON-NEXT:            {
+// JSON-NEXT:              "Param": "typename C"
+// JSON-NEXT:            },
+// JSON-NEXT:            {
+// JSON-NEXT:              "Param": "typename D"
+// JSON-NEXT:            },
+// JSON-NEXT:            {
+// JSON-NEXT:              "End": true,
+// JSON-NEXT:              "Param": "typename E"
+// JSON-NEXT:            }
+// JSON-NEXT:          ],
+// JSON-NEXT:          "VerticalDisplay": true
+// JSON-NEXT:        },
+// JSON-NEXT:        "USR": "{{([0-9A-F]{40})}}",
+// JSON-NEXT:        "VerticalDisplay": true
+// JSON-NEXT:      }
+
+// HTML:           <pre><code class="language-cpp code-clang-doc">template &lt;</code><span class="param-container"><span class="param"><code class="language-cpp code-clang-doc">typename A, </code></span><span class="param"><code class="language-cpp code-clang-doc">typename B, </code></span><span class="param"><code class="language-cpp code-clang-doc">typename C, </code></span><span class="param"><code class="language-cpp code-clang-doc">typename D, </code></span><span class="param"><code class="language-cpp code-clang-doc">typename E</code></span></span><code class="language-cpp code-clang-doc">&gt;</code></pre>
+// HTML-NEXT:      <pre><code class="language-cpp code-clang-doc">void longFunction (</code><span class="param-container"><span class="param"><code class="language-cpp code-clang-doc">A</code> <code class="language-cpp code-clang-doc">a, </code></span><span class="param"><code class="language-cpp code-clang-doc">B</code> <code class="language-cpp code-clang-doc">b, </code></span><span class="param"><code class="language-cpp code-clang-doc">C</code> <code class="language-cpp code-clang-doc">c, </code></span><span class="param"><code class="language-cpp code-clang-doc">D</code> <code class="language-cpp code-clang-doc">d, </code></span><span class="param"><code class="language-cpp code-clang-doc">E</code> <code class="language-cpp code-clang-doc">e</code></span></span><code class="language-cpp code-clang-doc">)</code></pre>
+// HTML-NEXT:      <p>Defined at line [[# @LINE - 122]] of file {{.*}}templates.cpp</p>
+// HTML-NEXT:  </div>
 
 template <>
 void function<bool, 0>(bool x) {}

--- a/clang-tools-extra/test/clang-doc/templates.cpp
+++ b/clang-tools-extra/test/clang-doc/templates.cpp
@@ -52,8 +52,8 @@ void ParamPackFunction(T... args);
 // JSON:           "Name": "ParamPackFunction",
 // JSON-NEXT:      "Params": [
 // JSON-NEXT:        {
-// JSON-NEXT:          "End": true,
 // JSON-NEXT:          "Name": "args",
+// JSON-NEXT:          "ParamEnd": true,
 // JSON-NEXT:          "Type": {
 // JSON-NEXT:            "Name": "T...",
 // JSON-NEXT:            "QualName": "T...",
@@ -74,10 +74,11 @@ void ParamPackFunction(T... args);
 // JSON-NEXT:            "End": true, 
 // JSON-NEXT:            "Param": "class... T"
 // JSON-NEXT:          }
-// JSON-NEXT:        ]
+// JSON-NEXT:        ],
+// JSON-NEXT:        "VerticalDisplay": false
 // JSON-NEXT:      },
 
-// HTML:        <pre><code class="language-cpp code-clang-doc">template &lt;class... T&gt;</code></pre>
+// HTML:        <pre><code class="language-cpp code-clang-doc">template &lt;class... T</code><code class="language-cpp code-clang-doc">&gt;</code></pre>
 // HTML-NEXT:   <pre><code class="language-cpp code-clang-doc">void ParamPackFunction (T... args)</code></pre>
 
 template <typename T, int U = 1>
@@ -109,8 +110,8 @@ void function(T x) {}
 // JSON:           "Name": "function",
 // JSON-NEXT:      "Params": [
 // JSON-NEXT:        {
-// JSON-NEXT:          "End": true,
 // JSON-NEXT:          "Name": "x",
+// JSON-NEXT:          "ParamEnd": true,
 // JSON-NEXT:          "Type": {
 // JSON-NEXT:            "Name": "T",
 // JSON-NEXT:            "QualName": "T",
@@ -134,12 +135,13 @@ void function(T x) {}
 // JSON-NEXT:            "End": true, 
 // JSON-NEXT:            "Param": "int U = 1"
 // JSON-NEXT:          }
-// JSON-NEXT:        ]
+// JSON-NEXT:        ],
+// JSON-NEXT:        "VerticalDisplay": false
 // JSON-NEXT:      }
 
-// HTML:           <pre><code class="language-cpp code-clang-doc">template &lt;typename T, int U = 1&gt;</code></pre>
+// HTML:           <pre><code class="language-cpp code-clang-doc">template &lt;typename T, int U = 1</code><code class="language-cpp code-clang-doc">&gt;</code></pre>
 // HTML-NEXT:      <pre><code class="language-cpp code-clang-doc">void function (T x)</code></pre>
-// HTML-NEXT:      <p>Defined at line [[# @LINE - 58]] of file {{.*}}templates.cpp</p>
+// HTML-NEXT:      <p>Defined at line [[# @LINE - 59]] of file {{.*}}templates.cpp</p>
 // HTML-NEXT:  </div>
 
 
@@ -174,8 +176,8 @@ void function<bool, 0>(bool x) {}
 // JSON:           "Name": "function",
 // JSON-NEXT:      "Params": [
 // JSON-NEXT:        {
-// JSON-NEXT:          "End": true,
 // JSON-NEXT:          "Name": "x",
+// JSON-NEXT:          "ParamEnd": true,
 // JSON-NEXT:          "Type": {
 // JSON-NEXT:            "Name": "bool",
 // JSON-NEXT:            "QualName": "bool",
@@ -201,13 +203,14 @@ void function<bool, 0>(bool x) {}
 // JSON-NEXT:              "Param": "0"
 // JSON-NEXT:            }
 // JSON-NEXT:          ],
-// JSON-NEXT:          "SpecializationOf": "{{([0-9A-F]{40})}}"
+// JSON-NEXT:          "SpecializationOf": "{{([0-9A-F]{40})}}",
+// JSON-NEXT:          "VerticalDisplay": false
 // JSON-NEXT:        }
 // JSON-NEXT:      },
 
-// HTML:           <pre><code class="language-cpp code-clang-doc">template &lt;&gt;</code></pre>
+// HTML:           <pre><code class="language-cpp code-clang-doc">template &lt;</code><code class="language-cpp code-clang-doc">&gt;</code></pre>
 // HTML-NEXT:      <pre><code class="language-cpp code-clang-doc">void function&lt;bool, 0&gt; (bool x)</code></pre>
-// HTML-NEXT:      <p>Defined at line [[# @LINE - 64]] of file {{.*}}templates.cpp</p>
+// HTML-NEXT:      <p>Defined at line [[# @LINE - 65]] of file {{.*}}templates.cpp</p>
 // HTML-NEXT:  </div>
 
 /// A Tuple type
@@ -286,8 +289,8 @@ tuple<int, int, bool> func_with_tuple_param(tuple<int, int, bool> t) { return t;
 // JSON:           "Name": "func_with_tuple_param",
 // JSON-NEXT:      "Params": [
 // JSON-NEXT:        {
-// JSON-NEXT:          "End": true,
 // JSON-NEXT:          "Name": "t",
+// JSON-NEXT:          "ParamEnd": true,
 // JSON-NEXT:          "Type": {
 // JSON-NEXT:            "Name": "tuple",
 // JSON-NEXT:            "Path": "GlobalNamespace",

--- a/clang-tools-extra/test/clang-doc/templates.cpp
+++ b/clang-tools-extra/test/clang-doc/templates.cpp
@@ -265,9 +265,29 @@ void longFunction(A a, B b, C c, D d, E e) {}
 // JSON-NEXT:        "VerticalDisplay": true
 // JSON-NEXT:      }
 
-// HTML:           <pre><code class="language-cpp code-clang-doc">template &lt;</code><span class="param-container"><span class="param"><code class="language-cpp code-clang-doc">typename A, </code></span><span class="param"><code class="language-cpp code-clang-doc">typename B, </code></span><span class="param"><code class="language-cpp code-clang-doc">typename C, </code></span><span class="param"><code class="language-cpp code-clang-doc">typename D, </code></span><span class="param"><code class="language-cpp code-clang-doc">typename E</code></span></span><code class="language-cpp code-clang-doc">&gt;</code></pre>
-// HTML-NEXT:      <pre><code class="language-cpp code-clang-doc">void longFunction (</code><span class="param-container"><span class="param"><code class="language-cpp code-clang-doc">A</code> <code class="language-cpp code-clang-doc">a, </code></span><span class="param"><code class="language-cpp code-clang-doc">B</code> <code class="language-cpp code-clang-doc">b, </code></span><span class="param"><code class="language-cpp code-clang-doc">C</code> <code class="language-cpp code-clang-doc">c, </code></span><span class="param"><code class="language-cpp code-clang-doc">D</code> <code class="language-cpp code-clang-doc">d, </code></span><span class="param"><code class="language-cpp code-clang-doc">E</code> <code class="language-cpp code-clang-doc">e</code></span></span><code class="language-cpp code-clang-doc">)</code></pre>
-// HTML-NEXT:      <p>Defined at line [[# @LINE - 122]] of file {{.*}}templates.cpp</p>
+// HTML:           <pre>
+// HTML-SAME:        <code class="language-cpp code-clang-doc">template &lt;</code>
+// HTML-SAME:        <span class="param-container">
+// HTML-SAME:          <span class="param"><code class="language-cpp code-clang-doc">typename A, </code></span>
+// HTML-SAME:          <span class="param"><code class="language-cpp code-clang-doc">typename B, </code></span>
+// HTML-SAME:          <span class="param"><code class="language-cpp code-clang-doc">typename C, </code></span>
+// HTML-SAME:          <span class="param"><code class="language-cpp code-clang-doc">typename D, </code></span>
+// HTML-SAME:          <span class="param"><code class="language-cpp code-clang-doc">typename E</code></span>
+// HTML-SAME:        </span>
+// HTML-SAME:        <code class="language-cpp code-clang-doc">&gt;</code>
+// HTML-SAME:      </pre>
+// HTML-NEXT:      <pre>
+// HTML-SAME:        <code class="language-cpp code-clang-doc">void longFunction (</code>
+// HTML-SAME:        <span class="param-container">
+// HTML-SAME:          <span class="param"><code class="language-cpp code-clang-doc">A</code> <code class="language-cpp code-clang-doc">a, </code></span>
+// HTML-SAME:          <span class="param"><code class="language-cpp code-clang-doc">B</code> <code class="language-cpp code-clang-doc">b, </code></span>
+// HTML-SAME:          <span class="param"><code class="language-cpp code-clang-doc">C</code> <code class="language-cpp code-clang-doc">c, </code></span>
+// HTML-SAME:          <span class="param"><code class="language-cpp code-clang-doc">D</code> <code class="language-cpp code-clang-doc">d, </code></span>
+// HTML-SAME:          <span class="param"><code class="language-cpp code-clang-doc">E</code> <code class="language-cpp code-clang-doc">e</code></span>
+// HTML-SAME:        </span>
+// HTML-SAME:        <code class="language-cpp code-clang-doc">)</code>
+// HTML-SAME:      </pre>
+// HTML-NEXT:      <p>Defined at line [[# @LINE - 142]] of file {{.*}}templates.cpp</p>
 // HTML-NEXT:  </div>
 
 template <>

--- a/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
@@ -179,7 +179,8 @@ TEST_F(JSONGeneratorTest, emitRecordJSON) {
         "End": true,
         "Param": "class T"
       }
-    ]
+    ],
+    "VerticalDisplay": false
   },
   "USR": "0000000000000000000000000000000000000000",
   "VirtualParents": [


### PR DESCRIPTION
This patch enables wrapping for longer function and template definitions in the generated HTML.
Currently uses the no. of parameters to determine the need to wrap the function.
If a function or template has > 2 parameters, they are printed one per line.
Also fixes a styling bug where a trailing comma was left after the last parameter.