### PR TITLE
[CIR] Add verifier for CIR try op

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6279,6 +6279,7 @@ def CIR_TryOp : CIR_Op<"try",[
     }]>
   ];
 
+  let hasVerifier = 1;
   let hasLLVMLowering = false;
 }
 

--- a/clang/test/CIR/IR/invalid-try-catch.cir
+++ b/clang/test/CIR/IR/invalid-try-catch.cir
@@ -136,6 +136,51 @@ cir.func dso_local @invalid_catch_all_with_type_info() {
 
 // -----
 
+!u8i = !cir.int<u, 8>
+!void = !cir.void
+
+module {
+
+cir.global "private" constant external @_ZTIi : !cir.ptr<!u8i>
+
+cir.func dso_local @catch_handler_missing_catch_param() {
+  cir.scope {
+    // expected-error @below {{catch handler region must start with 'cir.catch_param'}}
+    cir.try {
+      cir.yield
+    } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] {
+      cir.yield
+    } unwind {
+      cir.resume
+    }
+  }
+  cir.return
+}
+
+}
+
+// -----
+
+!void = !cir.void
+
+module {
+
+cir.func dso_local @catch_all_handler_missing_catch_param() {
+  cir.scope {
+    // expected-error @below {{catch handler region must start with 'cir.catch_param'}}
+    cir.try {
+      cir.yield
+    } catch all {
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+}
+
+// -----
+
 module {
 
 cir.func dso_local @invalid_unwind_with_catch_all() {

--- a/clang/test/CIR/IR/try-catch.cir
+++ b/clang/test/CIR/IR/try-catch.cir
@@ -1,6 +1,8 @@
 // RUN: cir-opt %s --verify-roundtrip | FileCheck %s
 
 !u8i = !cir.int<u, 8>
+!s32i = !cir.int<s, 32>
+!void = !cir.void
 
 module {
 
@@ -12,6 +14,7 @@ cir.func dso_local @empty_try_block_with_catch_all() {
     cir.try {
       cir.yield
     } catch all {
+      %0 = cir.catch_param : !cir.ptr<!void>
       cir.yield
     }
   }
@@ -23,6 +26,7 @@ cir.func dso_local @empty_try_block_with_catch_all() {
 // CHECK:     cir.try {
 // CHECK:       cir.yield
 // CHECK:     } catch all {
+// CHECK:       %[[CP:.*]] = cir.catch_param : !cir.ptr<!void>
 // CHECK:       cir.yield
 // CHECK:     }
 // CHECK:   }
@@ -56,8 +60,10 @@ cir.func dso_local @empty_try_block_with_catch_ist() {
     cir.try {
       cir.yield
     } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] {
+      %0 = cir.catch_param : !cir.ptr<!s32i>
       cir.yield
     } catch [type #cir.global_view<@_ZTIPKc> : !cir.ptr<!u8i>] {
+      %0 = cir.catch_param : !cir.ptr<!cir.ptr<!u8i>>
       cir.yield
     } unwind {
       cir.yield
@@ -71,8 +77,10 @@ cir.func dso_local @empty_try_block_with_catch_ist() {
 // CHECK:     cir.try {
 // CHECK:       cir.yield
 // CHECK:     } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] {
+// CHECK:       %[[CP1:.*]] = cir.catch_param : !cir.ptr<!s32i>
 // CHECK:       cir.yield
 // CHECK:     } catch [type #cir.global_view<@_ZTIPKc> : !cir.ptr<!u8i>] {
+// CHECK:       %[[CP2:.*]] = cir.catch_param : !cir.ptr<!cir.ptr<!u8i>>
 // CHECK:       cir.yield
 // CHECK:     } unwind {
 // CHECK:       cir.yield


### PR DESCRIPTION
This adds a verifier to enforce the requirement that every catch handler in a cir.try operation must begin with a cir.catch_param operation.