### PR TITLE
Reapply x2 "[Offload][lit] Link against SPIR-V DeviceRTL if present"

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -166,7 +166,8 @@ elif config.operating_system == 'Darwin':
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
 else: # Unices
-    if config.libomptarget_current_target != "nvptx64-nvidia-cuda":
+    if config.libomptarget_current_target != "nvptx64-nvidia-cuda" and \
+       not config.libomptarget_current_target.startswith('spirv'):
         config.test_flags += " -nogpulib"
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
@@ -214,7 +215,7 @@ def add_libraries(source):
     if "gpu" not in config.available_features:
         return source
     if "intelgpu" in config.available_features:
-        # There is no DeviceRTL for Intel yet and libc doesn't work.
+        # SPIR-V uses an out-of-tree linker and libc doesn't work.
         return source
     if config.libomptarget_has_libc:
         return source + " -Xoffload-linker -lc " + \

--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -166,7 +166,6 @@ elif config.operating_system == 'Darwin':
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
 else: # Unices
-        config.test_flags += " -nogpulib"
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
     config.test_flags += " -Wl,-rpath," + config.llvm_library_intdir

--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -166,8 +166,6 @@ elif config.operating_system == 'Darwin':
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
 else: # Unices
-    if config.libomptarget_current_target != "nvptx64-nvidia-cuda" and \
-       not config.libomptarget_current_target.startswith('spirv'):
         config.test_flags += " -nogpulib"
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory


### PR DESCRIPTION
The change to `llvm-zorg` to start building the DeviceRTL for SPIR-V on our builder finally got taken by the infra, so we can merge this now.