### PR TITLE
[clang][layout] Fix unsigned char overflow in ms_struct bitfield layout

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -49,6 +49,11 @@ C++ Specific Potentially Breaking Changes
 ABI Changes in This Version
 ---------------------------
 
+- Fixed incorrect struct layout for ``_BitInt`` bitfields wider than 255 bits
+  on MSVC targets. Internal bitfield tracking fields were changed from
+  ``unsigned char`` to ``uint64_t`` to prevent overflow. This might be an ABI
+  break for such structs compared to earlier Clang versions.
+
 AST Dumping Potentially Breaking Changes
 ----------------------------------------
 

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -615,11 +615,11 @@ protected:
   /// this contains the number of bits in the last unit that can be used for
   /// an adjacent bitfield if necessary.  The unit in question is usually
   /// a byte, but larger units are used if IsMsStruct.
-  unsigned char UnfilledBitsInLastUnit;
+  uint64_t UnfilledBitsInLastUnit;
 
   /// LastBitfieldStorageUnitSize - If IsMsStruct, represents the size of the
   /// storage unit of the previous field if it was a bitfield.
-  unsigned char LastBitfieldStorageUnitSize;
+  uint64_t LastBitfieldStorageUnitSize;
 
   /// MaxFieldAlignment - The maximum allowed field alignment. This is set by
   /// #pragma pack.

--- a/clang/test/Layout/ms-x86-bitfields-overflow.c
+++ b/clang/test/Layout/ms-x86-bitfields-overflow.c
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fms-extensions -fdump-record-layouts -fsyntax-only %s 2>/dev/null \
+// RUN:            | FileCheck %s
+
+// Test that large _BitInt fields do not overflow the internal storage unit tracker (previously unsigned char).
+// If the bug exists, this struct splits into two units.
+// If fixed, f1 and f2 are packed into a single unit.
+
+#pragma ms_struct on
+
+struct __attribute__((packed, aligned(1))) A {
+  _BitInt(250) f1 : 2;
+  _BitInt(250) f2 : 2;
+};
+
+struct __attribute__((packed, aligned(1))) B {
+  _BitInt(500) f1 : 2;
+  _BitInt(500) f2 : 255;
+};
+
+// CHECK-LABEL:   0 | struct A{{$}}
+// CHECK-NEXT:0:0-1 |   _BitInt(250) f1
+// CHECK-NEXT:0:2-3 |   _BitInt(250) f2
+// CHECK-NEXT:      | [sizeof=32, align=32]
+
+// CHECK-LABEL:   0 | struct B{{$}}
+// CHECK-NEXT:0:0-1 |   _BitInt(500) f1
+// CHECK-NEXT:0:2-256 |   _BitInt(500) f2
+// CHECK-NEXT:      | [sizeof=64, align=64]
+
+int x[sizeof(struct A)];
+int y[sizeof(struct B)];


### PR DESCRIPTION
Fixes #161511

When using MS-struct layout rules (`#pragma ms_struct`), Clang produces incorrect memory layouts when encountering large `_BitInt` bit-fields. The reason was that `LastBitfieldStorageUnitSize` variable was declared as `unsigned char`, which caused it to overflow when the values used with `_BitInt` exceeded `255`, so I changed it from `unsigned char` to `uint64_t`.

In the added test, we can clearly see that `f2` and `f3` are both packed in the same 256-bit unit.