### PR TITLE
[Github] Add libc container

### DIFF
--- a/.github/workflows/build-libc-container.yml
+++ b/.github/workflows/build-libc-container.yml
@@ -1,0 +1,53 @@
+name: Build libc Container
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/build-libc-container.yml
+      - '.github/workflows/containers/libc/**'
+  pull_request:
+    paths:
+      - .github/workflows/build-libc-container.yml
+      - '.github/workflows/containers/libc/**'
+
+jobs:
+  build-libc-container:
+    name: Build libc container
+    if: github.repository_owner == 'llvm'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout LLVM
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: |
+            .github/workflows/containers/libc/
+            .github/actions/build-container
+      - name: Build Container
+        uses: ./.github/actions/build-container
+        with:
+          container-name: libc-ubuntu-24.04
+          dockerfile: .github/workflows/containers/libc/Dockerfile
+          target: ''
+          test-command: ${{ matrix.test-command }}
+  push-libc-container:
+    if: github.event_name == 'push'
+    needs:
+      - build-libc-container
+    permissions:
+      packages: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout LLVM
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: |
+            .github/actions/push-container
+
+      - uses: ./.github/actions/push-container
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/containers/libc/Dockerfile
+++ b/.github/workflows/containers/libc/Dockerfile
@@ -1,0 +1,24 @@
+FROM docker.io/library/ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y \
+    libmpfr-dev \
+    libgmp-dev \
+    libmpc-dev \
+    ninja-build \
+    sudo \
+    sccache \
+    wget \
+    lsb-release \
+    software-properties-common \
+    gnupg \
+    linux-libc-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    sudo ./llvm.sh 21 && \
+    rm llvm.sh
+
+RUN ln -sf /usr/include/$(uname -p)-linux-gnu/asm /usr/include/asm


### PR DESCRIPTION
This will let us run the libc full build tests inside of a container which means that we have same time by not having to install dependencies on every run in addition to not running into issues due to dependencies failing to install particularly around LLVM releases with the llvm.sh script.