### PR TITLE
[mlir] Fix #181286 Remove redundant SideEffectInterfaces from CAPIIR

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -542,7 +542,6 @@ mlir_c_api_cc_library(
         ":IRDLDialect",
         ":InferTypeOpInterface",
         ":Parser",
-        ":SideEffectInterfaces",
         ":TransformsPassIncGen",
     ],
 )


### PR DESCRIPTION
Remove redundant SideEffectInterfaces from CAPIIR. It's introduced in #181286 due to merge.