### PR TITLE
[lldb-dap ext] truncate lldb-dap server restart dialog

### DIFF
--- a/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
@@ -4,6 +4,77 @@ import { isDeepStrictEqual } from "util";
 import * as vscode from "vscode";
 
 /**
+ * The information needed to spawn a lldb-dap process: e.g. arguments, binary
+ * path, etc.
+ */
+class ServerSpawnInfo {
+  constructor(
+    readonly path: string,
+    readonly args: string[],
+    readonly env: { [key: string]: string },
+  ) {}
+
+  static create(
+    path: string,
+    args: string[],
+    env: NodeJS.ProcessEnv | { [key: string]: string } | undefined,
+  ): ServerSpawnInfo {
+    // Convert env to a plain object for later comparison. We filter out
+    // `LLDBDAP_LOG` because we ignore it when considering reusing lldb-dap
+    // server.
+    const normalizedEnv: { [key: string]: string } = {};
+    for (const [key, value] of Object.entries(env ?? {})) {
+      if (key !== "LLDBDAP_LOG") {
+        normalizedEnv[key] = String(value);
+      }
+    }
+    return new ServerSpawnInfo(path, args, normalizedEnv);
+  }
+
+  /**
+   * Compares this spawn info with another for equality.
+   */
+  equals(other: ServerSpawnInfo): boolean {
+    return isDeepStrictEqual(
+      [this.path, this.args, this.env],
+      [other.path, other.args, other.env],
+    );
+  }
+
+  /**
+   * Returns a human-readable string representation of this spawn info.
+   */
+  toDisplay(): string {
+    const cmd = [this.path, ...this.args];
+
+    const env = Object.entries(this.env)
+      .map(([k, v]) => `${k}=${v}`)
+      // Sort to make it easier to compare. Sorting isn't necessary for the
+      // `isDeepStrictEqual` check.
+      .sort()
+      .join("\n");
+
+    let display = cmd.join(" ");
+    if (env) {
+      display += `\n${env}`;
+    }
+
+    return display;
+  }
+
+  /**
+   * Returns a truncated representation of `toDisplay`.
+   */
+  toDisplayTruncated(maxLength: number = 300): string {
+    const full = this.toDisplay();
+    if (full.length <= maxLength) {
+      return full;
+    }
+    return full.substring(0, maxLength) + "...";
+  }
+}
+
+/**
  * Represents a running lldb-dap process that is accepting connections (i.e. in "server mode").
  *
  * Handles startup of the process if it isn't running already as well as prompting the user
@@ -12,7 +83,7 @@ import * as vscode from "vscode";
 export class LLDBDapServer implements vscode.Disposable {
   private serverProcess?: child_process.ChildProcessWithoutNullStreams;
   private serverInfo?: Promise<{ host: string; port: number }>;
-  private serverSpawnInfo?: string[];
+  private serverSpawnInfo?: ServerSpawnInfo;
   // Detects changes to the lldb-dap executable file since the server's startup.
   private serverFileWatcher?: FSWatcher;
   // Indicates whether the lldb-dap executable file has changed since the server's startup.
@@ -87,7 +158,7 @@ export class LLDBDapServer implements vscode.Disposable {
         }
       });
       this.serverProcess = process;
-      this.serverSpawnInfo = this.getSpawnInfo(dapPath, dapArgs, options?.env);
+      this.serverSpawnInfo = ServerSpawnInfo.create(dapPath, dapArgs, options?.env);
       this.serverFileChanged = false;
       this.serverFileWatcher = chokidarWatch(dapPath);
       this.serverFileWatcher
@@ -127,17 +198,17 @@ export class LLDBDapServer implements vscode.Disposable {
       changeTLDR.push("an old binary");
     }
 
-    const newSpawnInfo = this.getSpawnInfo(dapPath, args, env);
-    if (!isDeepStrictEqual(this.serverSpawnInfo, newSpawnInfo)) {
+    const newSpawnInfo = ServerSpawnInfo.create(dapPath, args, env);
+    if (!this.serverSpawnInfo.equals(newSpawnInfo)) {
       changeTLDR.push("different arguments");
       changeDetails.push(`
 The previous lldb-dap server was started with:
 
-${this.serverSpawnInfo.join(" ")}
+${this.serverSpawnInfo.toDisplayTruncated()}
 
 The new lldb-dap server will be started with:
 
-${newSpawnInfo.join(" ")}
+${newSpawnInfo.toDisplayTruncated()}
 `);
     }
 
@@ -157,6 +228,7 @@ Restarting the server will interrupt any existing debug sessions and start a new
       },
       "Restart",
       "Use Existing",
+      "Show Full Details",
     );
     switch (userInput) {
       case "Restart":
@@ -164,6 +236,9 @@ Restarting the server will interrupt any existing debug sessions and start a new
         return true;
       case "Use Existing":
         return true;
+      case "Show Full Details":
+        await this.showFullSpawnInfoComparison(this.serverSpawnInfo, newSpawnInfo);
+        return false;
       case undefined:
         return false;
     }
@@ -191,20 +266,27 @@ Restarting the server will interrupt any existing debug sessions and start a new
     }
   }
 
-  getSpawnInfo(
-    path: string,
-    args: string[],
-    env: NodeJS.ProcessEnv | { [key: string]: string } | undefined,
-  ): string[] {
-    return [
-      path,
-      ...args,
-      ...Object.entries(env ?? {})
-        // Filter and sort to avoid restarting the server just because the
-        // order of env changed or the log path changed.
-        .filter((entry) => String(entry[0]) !== "LLDBDAP_LOG")
-        .sort()
-        .map((entry) => String(entry[0]) + "=" + String(entry[1])),
-    ];
+  private async showFullSpawnInfoComparison(
+    oldSpawnInfo: ServerSpawnInfo,
+    newSpawnInfo: ServerSpawnInfo,
+  ): Promise<void> {
+    const content = `Comparing lldb-dap env and args
+===============================
+Each section contains the binary and args on the first line, and then env on the
+following lines.
+
+Existing
+--------
+${oldSpawnInfo.toDisplay()}
+
+New
+--------
+${newSpawnInfo.toDisplay()}
+`;
+    const doc = await vscode.workspace.openTextDocument({
+      content,
+      language: "text",
+    });
+    await vscode.window.showTextDocument(doc, { preview: true });
   }
 }

--- a/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
@@ -52,7 +52,9 @@ class ServerSpawnInfo {
       // Sort to make it easier to compare. Sorting isn't necessary for the
       // `isDeepStrictEqual` check.
       .sort()
-      .join("\n");
+      // Joining with newlines makes it difficult to truncate by string length,
+      // so we opt for space.
+      .join(" ");
 
     let display = cmd.join(" ");
     if (env) {

--- a/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/extension/src/lldb-dap-server.ts
@@ -64,16 +64,6 @@ class ServerSpawnInfo {
     return display;
   }
 
-  /**
-   * Returns a truncated representation of `toDisplay`.
-   */
-  toDisplayTruncated(maxLength: number = 300): string {
-    const full = this.toDisplay();
-    if (full.length <= maxLength) {
-      return full;
-    }
-    return full.substring(0, maxLength) + "...";
-  }
 }
 
 /**
@@ -194,7 +184,6 @@ export class LLDBDapServer implements vscode.Disposable {
     }
 
     const changeTLDR = [];
-    const changeDetails = [];
 
     if (this.serverFileChanged) {
       changeTLDR.push("an old binary");
@@ -202,16 +191,7 @@ export class LLDBDapServer implements vscode.Disposable {
 
     const newSpawnInfo = ServerSpawnInfo.create(dapPath, args, env);
     if (!this.serverSpawnInfo.equals(newSpawnInfo)) {
-      changeTLDR.push("different arguments");
-      changeDetails.push(`
-The previous lldb-dap server was started with:
-
-${this.serverSpawnInfo.toDisplayTruncated()}
-
-The new lldb-dap server will be started with:
-
-${newSpawnInfo.toDisplayTruncated()}
-`);
+      changeTLDR.push("different configuration (args, env)");
     }
 
     // If the server hasn't changed, continue startup without killing it.
@@ -225,8 +205,10 @@ ${newSpawnInfo.toDisplayTruncated()}
       {
         modal: true,
         detail: `An existing lldb-dap server (${this.serverProcess.pid}) is running with ${changeTLDR.map((s) => `*${s}*`).join(" and ")}.
-${changeDetails.join("\n")}
-Restarting the server will interrupt any existing debug sessions and start a new server.`,
+
+Restarting the server will interrupt any existing debug sessions and start a new server.
+
+Click "Show Full Details" to see the differences between the existing and new server configuration.`,
       },
       "Restart",
       "Use Existing",


### PR DESCRIPTION
We recently added an internal change that passes all of the shell's environment variables onto the lldb-dap process that is launched. This caused our dialogs to blow up. Something like this:
<img width="630" height="1052" alt="Screenshot 2026-02-13 at 4 20 36 PM" src="https://github.com/user-attachments/assets/a276e1cc-e3fa-4ed5-a9b1-506fa14b3a3f" />
Note how users wouldn't be able to see the bottom buttons to respond.

**This PR mainly does 2 things**:
1. Truncate the run args (I arbitrarily set it to ~300 characters) in the dialog message so that users would typically be able to see the options.
2. Provide a new button to "Show Full Details", which opens a new VSCode buffer containing the full args. So, like the below examples:

<img width="630" height="480" alt="Screenshot 2026-02-13 at 4 32 08 PM" src="https://github.com/user-attachments/assets/3d92b973-9c3f-4c69-af2b-af4372fd30de" />

It then opens a new buffer in VSCode with text like so:
```
Comparing lldb-dap env and args
===============================
Each section contains the binary and args on the first line, and then env on the
following lines.

Existing
--------
/opt/llvm/bin/lldb-dap a b c --connection listen://localhost:0
A1= A=1 B=1 C=1 D=1 E=1 ENV_VAR_001=value_001 ENV_VAR_002=value_002 ENV_VAR_003=value_003 ENV_VAR_004=value_004 ENV_VAR_005=value_005 ENV_VAR_006=value_006 ENV_VAR_007=value_007 ENV_VAR_008=value_008 ENV_VAR_009=value_009 ENV_VAR_010=value_010 ENV_VAR_011=value_011 ENV_VAR_012=value_012 ENV_VAR_013=value_013 ENV_VAR_014=value_014 ENV_VAR_015=value_015 ENV_VAR_016=value_016 ENV_VAR_017=value_017 ENV_VAR_018=value_018 ENV_VAR_019=value_019 ENV_VAR_020=value_020 ENV_VAR_021=value_021 ENV_VAR_022=value_022 ENV_VAR_023=value_023 ENV_VAR_024=value_024 ENV_VAR_025=value_025 ENV_VAR_026=value_026 ENV_VAR_027=value_027 ENV_VAR_028=value_028 ENV_VAR_029=value_029 ENV_VAR_030=value_030 ENV_VAR_031=value_031 ENV_VAR_032=value_032 ENV_VAR_033=value_033 ENV_VAR_034=value_034 ENV_VAR_035=value_035 ENV_VAR_036=value_036 ENV_VAR_037=value_037 ENV_VAR_038=value_038 ENV_VAR_039=value_039 ENV_VAR_040=value_040 ENV_VAR_041=value_041 ENV_VAR_042=value_042 ENV_VAR_043=value_043 ENV_VAR_044=value_044 ENV_VAR_045=value_045 ENV_VAR_046=value_046 ENV_VAR_047=value_047 ENV_VAR_048=value_048 ENV_VAR_049=value_049 ENV_VAR_050=value_050 ENV_VAR_051=value_051 ENV_VAR_052=value_052 ENV_VAR_053=value_053 ENV_VAR_054=value_054 ENV_VAR_055=value_055 ENV_VAR_056=value_056 ENV_VAR_057=value_057 ENV_VAR_058=value_058 ENV_VAR_059=value_059 ENV_VAR_060=value_060 ENV_VAR_061=value_061 ENV_VAR_062=value_062 ENV_VAR_063=value_063 ENV_VAR_064=value_064 ENV_VAR_065=value_065 ENV_VAR_066=value_066 ENV_VAR_067=value_067 ENV_VAR_068=value_068 ENV_VAR_069=value_069 ENV_VAR_070=value_070 ENV_VAR_071=value_071 ENV_VAR_072=value_072 ENV_VAR_073=value_073 ENV_VAR_074=value_074 ENV_VAR_075=value_075 ENV_VAR_076=value_076 ENV_VAR_077=value_077 ENV_VAR_078=value_078 ENV_VAR_079=value_079 ENV_VAR_080=value_080 ENV_VAR_081=value_081 ENV_VAR_082=value_082 ENV_VAR_083=value_083 ENV_VAR_084=value_084 ENV_VAR_085=value_085 ENV_VAR_086=value_086 ENV_VAR_087=value_087 ENV_VAR_088=value_088 ENV_VAR_089=value_089 ENV_VAR_090=value_090 ENV_VAR_091=value_091 ENV_VAR_092=value_092 ENV_VAR_093=value_093 ENV_VAR_094=value_094 ENV_VAR_095=value_095 ENV_VAR_096=value_096 ENV_VAR_097=value_097 ENV_VAR_098=value_098 ENV_VAR_099=value_099 ENV_VAR_100=value_100 F=1 G=1 H=1 I=1 J=1 K=1 L=1 M=1 N=1 O=1 P=1 Q=1 R=1 S=1 T=1 U=1 V=1 W=1 X=1 Y=1 Z=1

New
--------
/opt/llvm/bin/lldb-dap a b c --connection listen://localhost:0
A1A= A=1 B=1 C=1 D=1 E=1 ENV_VAR_001=value_001 ENV_VAR_002=value_002 ENV_VAR_003=value_003 ENV_VAR_004=value_004 ENV_VAR_005=value_005 ENV_VAR_006=value_006 ENV_VAR_007=value_007 ENV_VAR_008=value_008 ENV_VAR_009=value_009 ENV_VAR_010=value_010 ENV_VAR_011=value_011 ENV_VAR_012=value_012 ENV_VAR_013=value_013 ENV_VAR_014=value_014 ENV_VAR_015=value_015 ENV_VAR_016=value_016 ENV_VAR_017=value_017 ENV_VAR_018=value_018 ENV_VAR_019=value_019 ENV_VAR_020=value_020 ENV_VAR_021=value_021 ENV_VAR_022=value_022 ENV_VAR_023=value_023 ENV_VAR_024=value_024 ENV_VAR_025=value_025 ENV_VAR_026=value_026 ENV_VAR_027=value_027 ENV_VAR_028=value_028 ENV_VAR_029=value_029 ENV_VAR_030=value_030 ENV_VAR_031=value_031 ENV_VAR_032=value_032 ENV_VAR_033=value_033 ENV_VAR_034=value_034 ENV_VAR_035=value_035 ENV_VAR_036=value_036 ENV_VAR_037=value_037 ENV_VAR_038=value_038 ENV_VAR_039=value_039 ENV_VAR_040=value_040 ENV_VAR_041=value_041 ENV_VAR_042=value_042 ENV_VAR_043=value_043 ENV_VAR_044=value_044 ENV_VAR_045=value_045 ENV_VAR_046=value_046 ENV_VAR_047=value_047 ENV_VAR_048=value_048 ENV_VAR_049=value_049 ENV_VAR_050=value_050 ENV_VAR_051=value_051 ENV_VAR_052=value_052 ENV_VAR_053=value_053 ENV_VAR_054=value_054 ENV_VAR_055=value_055 ENV_VAR_056=value_056 ENV_VAR_057=value_057 ENV_VAR_058=value_058 ENV_VAR_059=value_059 ENV_VAR_060=value_060 ENV_VAR_061=value_061 ENV_VAR_062=value_062 ENV_VAR_063=value_063 ENV_VAR_064=value_064 ENV_VAR_065=value_065 ENV_VAR_066=value_066 ENV_VAR_067=value_067 ENV_VAR_068=value_068 ENV_VAR_069=value_069 ENV_VAR_070=value_070 ENV_VAR_071=value_071 ENV_VAR_072=value_072 ENV_VAR_073=value_073 ENV_VAR_074=value_074 ENV_VAR_075=value_075 ENV_VAR_076=value_076 ENV_VAR_077=value_077 ENV_VAR_078=value_078 ENV_VAR_079=value_079 ENV_VAR_080=value_080 ENV_VAR_081=value_081 ENV_VAR_082=value_082 ENV_VAR_083=value_083 ENV_VAR_084=value_084 ENV_VAR_085=value_085 ENV_VAR_086=value_086 ENV_VAR_087=value_087 ENV_VAR_088=value_088 ENV_VAR_089=value_089 ENV_VAR_090=value_090 ENV_VAR_091=value_091 ENV_VAR_092=value_092 ENV_VAR_093=value_093 ENV_VAR_094=value_094 ENV_VAR_095=value_095 ENV_VAR_096=value_096 ENV_VAR_097=value_097 ENV_VAR_098=value_098 ENV_VAR_099=value_099 ENV_VAR_100=value_100 F=1 G=1 H=1 I=1 J=1 K=1 L=1 M=1 N=1 O=1 P=1 Q=1 R=1 S=1 T=1 U=1 V=1 W=1 X=1 Y=1 Z=1
```

# Testing plan

I manually tested this, unfortunately. I don't know if it's practical to come up with some unit tests that we could automate. I created a launch.json, and played around with the "debugAdapterArgs" and "debugAdapterEnv", and I made sure to enable lldb dap extension's "Server Mode" setting.