### PR TITLE
[CIR] Fix handling of boolean builtin expressions

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -901,8 +901,13 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   if (e->isPRValue() && !getContext().BuiltinInfo.isImmediate(builtinID) &&
       e->EvaluateAsRValue(result, cgm.getASTContext()) &&
       !result.hasSideEffects()) {
-    if (result.Val.isInt())
+    if (result.Val.isInt()) {
+      QualType type = e->getType();
+      if (type->isBooleanType())
+        return RValue::get(
+            builder.getBool(result.Val.getInt().getBoolValue(), loc));
       return RValue::get(builder.getConstInt(loc, result.Val.getInt()));
+    }
     if (result.Val.isFloat()) {
       // Note: we are using result type of CallExpr to determine the type of
       // the constant. Classic codegen uses the result value to determine the

--- a/clang/test/CIR/CodeGenBuiltins/builtin_call.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin_call.cpp
@@ -23,22 +23,23 @@ constexpr extern long double cx_var_ld = __builtin_huge_vall();
 // LLVM: @cx_var_ld = {{.*}} x86_fp80 0xK7FFF8000000000000000
 // OGCG: @cx_var_ld = {{.*}} x86_fp80 0xK7FFF8000000000000000
 
-int is_constant_evaluated() {
+bool is_constant_evaluated() {
   return __builtin_is_constant_evaluated();
 }
 
-// CIR: cir.func{{.*}} @_Z21is_constant_evaluatedv() -> (!s32i{{.*}})
-// CIR: %[[ZERO:.+]] = cir.const #cir.int<0>
+// CIR: cir.func{{.*}} @_Z21is_constant_evaluatedv() -> (!cir.bool{{.*}})
+// CIR: %[[FALSE:.+]] = cir.const #false
 
-// LLVM: define {{.*}}i32 @_Z21is_constant_evaluatedv()
-// LLVM: %[[MEM:.+]] = alloca i32
-// LLVM: store i32 0, ptr %[[MEM]]
-// LLVM: %[[RETVAL:.+]] = load i32, ptr %[[MEM]]
-// LLVM: ret i32 %[[RETVAL]]
+// LLVM: define {{.*}}i1 @_Z21is_constant_evaluatedv()
+// LLVM: %[[MEM:.+]] = alloca i8
+// LLVM: store i8 0, ptr %[[MEM]]
+// LLVM: %[[RETVAL:.+]] = load i8, ptr %[[MEM]]
+// LLVM: %[[BOOL:.+]] = trunc i8 %[[RETVAL]] to i1
+// LLVM: ret i1 %[[BOOL]]
 // LLVM: }
 
-// OGCG: define {{.*}}i32 @_Z21is_constant_evaluatedv()
-// OGCG: ret i32 0
+// OGCG: define {{.*}}i1 @_Z21is_constant_evaluatedv()
+// OGCG: ret i1 false
 // OGCG: }
 
 long double constant_fp_builtin_ld() {


### PR DESCRIPTION
Previously we were generating a signed 1-bit integer constant for builtin expressions that returned a boolean value. This caused a verification error of mismatched types when we tried to store this constant result to a pointer-to-bool location. This change adds a check for boolean types.