### PR TITLE
[gsymutil] Verify output string table size and address info offsets do not exceed 32-bit max

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
@@ -169,11 +169,25 @@ llvm::Error GsymCreator::encode(FileWriter &O) const {
   const off_t StrtabSize = O.tell() - StrtabOffset;
   std::vector<uint32_t> AddrInfoOffsets;
 
+  // Verify that the size of the string table does not exceed 32-bit max.
+  // This means the offsets in the string table will not exceed 32-bit max.
+  if (StrtabSize > UINT32_MAX) {
+    return createStringError(std::errc::invalid_argument,
+                             "string table size exceeded 32-bit max");
+  }
+
   // Write out the address infos for each function info.
   for (const auto &FuncInfo : Funcs) {
-    if (Expected<uint64_t> OffsetOrErr = FuncInfo.encode(O))
-      AddrInfoOffsets.push_back(OffsetOrErr.get());
-    else
+    if (Expected<uint64_t> OffsetOrErr = FuncInfo.encode(O)) {
+      // Verify that the address info offsets do not exceed 32-bit max.
+      uint64_t Offset = OffsetOrErr.get();
+      if (Offset > UINT32_MAX) {
+        return createStringError(std::errc::invalid_argument,
+                                 "address info offset exceeded 32-bit max");
+      }
+
+      AddrInfoOffsets.push_back(Offset);
+    } else
       return OffsetOrErr.takeError();
   }
   // Fixup the string table offset and size in the header


### PR DESCRIPTION
Previously, https://github.com/llvm/llvm-project/pull/165940 fixed llvm-dwarfdump and llvm-gsymutil so that they can correctly **consume** >4GB dSYM. However, if the dSYM is large enough, `llvm-gsymutil` can still **produce** invalid gSYM.

This change add validation into gsymutil, so that it will fail when the output string table or address info offsets will exceed 32-bit max.

Similar to https://github.com/llvm/llvm-project/pull/165940, it may be difficult to auto-test this change.  For manual testing, I cannot find a large enough dSYM for which the gSYM would hit the limits (I have a 9GB dSYM which produces a 1.7GB gSYM).  I'm open to ideas if anyone has any.