### PR TITLE
[windows][x86][asm] fix nullptr deref in WinCOFFWriter::recordRelocation

### DIFF
--- a/llvm/lib/MC/WinCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/WinCOFFObjectWriter.cpp
@@ -840,9 +840,12 @@ void WinCOFFWriter::executePostLayoutBinding() {
 
 void WinCOFFWriter::recordRelocation(const MCFragment &F, const MCFixup &Fixup,
                                      MCValue Target, uint64_t &FixedValue) {
-  assert(Target.getAddSym() && "Relocation must reference a symbol!");
+  auto *SymA = Target.getAddSym();
 
-  const MCSymbol &A = *Target.getAddSym();
+  if (!SymA)
+    return;
+
+  const MCSymbol &A = *SymA;
   if (!A.isRegistered()) {
     getContext().reportError(Fixup.getLoc(), Twine("symbol '") + A.getName() +
                                                  "' can not be undefined");


### PR DESCRIPTION
This fixes llvm segfaulting when trying to compile this LLVM IR for MSVC with Intel syntax:

https://godbolt.org/z/a3bqj85rK

```llvm
target triple = "x86_64-pc-windows-msvc"

module asm ".intel_syntax"
module asm "jz [0x6]"
module asm "ret"
module asm ".att_syntax"
```

I encountered this issue going through rust issues regarding MSVC assembly (https://github.com/rust-lang/rust/issues/135362) and wanted to look into this as my first contribution to llvm. With this patch the behavior matches what happens on linux when `getAddSym` returns null and will simply return early from `recordRelocation`. Though I am unsure what the purpose of the assert was, since this technically can output valid assembly, and is also not present in the linux/ELF counterpart: https://github.com/llvm/llvm-project/blob/742af32b67c0d70ced4837fbde778ee5ea6529b4/llvm/lib/MC/ELFObjectWriter.cpp#L1319-L1325

I am still not exactly sure if this relative addressing should be allowed in general due to it *very* easily triggering UB, preferably labels should be used. Let me know what you think! ^-^