### PR TITLE
[WebAssembly] Use generic CPU by default in llvm-mc

### DIFF
--- a/lld/test/wasm/call-indirect.s
+++ b/lld/test/wasm/call-indirect.s
@@ -1,5 +1,5 @@
-# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
-# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %p/Inputs/call-indirect.s -o %t2.o
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -mcpu=mvp -o %t.o %s
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -mcpu=mvp %p/Inputs/call-indirect.s -o %t2.o
 # RUN: wasm-ld --export-dynamic -o %t.wasm %t2.o %t.o
 # RUN: obj2yaml %t.wasm | FileCheck %s
 

--- a/lld/test/wasm/invalid-mvp-table-use.s
+++ b/lld/test/wasm/invalid-mvp-table-use.s
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -mcpu=mvp -o %t.o %s
 #
 # If any table is defined or declared besides the __indirect_function_table,
 # the compilation unit should be compiled with -mattr=+call-indirect-overlong,

--- a/lld/test/wasm/multi-table.s
+++ b/lld/test/wasm/multi-table.s
@@ -1,6 +1,6 @@
-# RUN: not llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.a1.o %s 2>&1 | FileCheck %s --check-prefix=MVP
+# RUN: not llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -mcpu=mvp -o %t.a1.o %s 2>&1 | FileCheck %s --check-prefix=MVP
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -mattr=+reference-types -o %t.a1.rt.o %s
-# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %p/Inputs/call-indirect.s -o %t.a2.o
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -mcpu=mvp %p/Inputs/call-indirect.s -o %t.a2.o
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -mattr=+reference-types %p/Inputs/call-indirect.s -o %t.a2.rt.o
 # RUN: not wasm-ld --allow-undefined --export-dynamic --no-entry -o %t.wasm %t.a1.rt.o %t.a2.o 2>&1 | FileCheck %s --check-prefix=RT-MVP
 # RUN: wasm-ld --allow-undefined --export-dynamic --no-entry -o- %t.a1.rt.o %t.a2.rt.o | obj2yaml | FileCheck %s

--- a/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyMCTargetDesc.cpp
+++ b/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyMCTargetDesc.cpp
@@ -77,6 +77,8 @@ static MCAsmBackend *createAsmBackend(const Target & /*T*/,
 
 static MCSubtargetInfo *createMCSubtargetInfo(const Triple &TT, StringRef CPU,
                                               StringRef FS) {
+  if (CPU.empty())
+    CPU = "generic";
   return createWebAssemblyMCSubtargetInfoImpl(TT, CPU, /*TuneCPU*/ CPU, FS);
 }
 

--- a/llvm/test/MC/WebAssembly/reloc-code.s
+++ b/llvm/test/MC/WebAssembly/reloc-code.s
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -triple=wasm32-unknown-unknown -filetype=obj %s -o - | llvm-readobj -r --expand-relocs - | FileCheck %s
+# RUN: llvm-mc -triple=wasm32-unknown-unknown -mcpu=mvp -filetype=obj %s -o - | llvm-readobj -r --expand-relocs - | FileCheck %s
 # RUN: llvm-mc -triple=wasm32-unknown-unknown -mattr=+reference-types -filetype=obj %s -o - | llvm-readobj -r --expand-relocs - | FileCheck --check-prefix=REF %s
 
 # External functions

--- a/llvm/test/MC/WebAssembly/reloc-pic.s
+++ b/llvm/test/MC/WebAssembly/reloc-pic.s
@@ -1,4 +1,4 @@
-# RUN: sed -e '/^REF-/d' %s | llvm-mc -triple=wasm32-unknown-unknown -filetype=obj | obj2yaml | FileCheck %s
+# RUN: sed -e '/^REF-/d' %s | llvm-mc -triple=wasm32-unknown-unknown -mcpu=mvp -filetype=obj | obj2yaml | FileCheck %s
 # RUN: sed -e 's/^REF-//g' %s | llvm-mc -triple=wasm32-unknown-unknown -mattr=+reference-types -filetype=obj | obj2yaml | FileCheck --check-prefix=REF %s
 
 # Verify that @GOT relocation entryes result in R_WASM_GLOBAL_INDEX_LEB against

--- a/llvm/test/MC/WebAssembly/reloc-pic64.s
+++ b/llvm/test/MC/WebAssembly/reloc-pic64.s
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -triple=wasm64-unknown-unknown -filetype=obj < %s | obj2yaml | FileCheck %s
+# RUN: llvm-mc -triple=wasm64-unknown-unknown -mcpu=mvp -filetype=obj < %s | obj2yaml | FileCheck %s
 # RUN: llvm-mc -triple=wasm64-unknown-unknown -mattr=+reference-types -filetype=obj < %s | obj2yaml | FileCheck --check-prefix=REF %s
 
 # Verify that @GOT relocation entries result in R_WASM_GLOBAL_INDEX_LEB against

--- a/llvm/test/MC/WebAssembly/tail-call-encodings.s
+++ b/llvm/test/MC/WebAssembly/tail-call-encodings.s
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -show-encoding -triple=wasm32-unknown-unknown -mattr=+tail-call < %s | FileCheck %s
+# RUN: llvm-mc -show-encoding -triple=wasm32-unknown-unknown -mcpu=mvp -mattr=+tail-call < %s | FileCheck %s
 # RUN: llvm-mc -show-encoding -triple=wasm32-unknown-unknown -mattr=+reference-types,+tail-call < %s | FileCheck --check-prefix=REF %s
 
 bar1:

--- a/llvm/test/MC/WebAssembly/weak-alias.s
+++ b/llvm/test/MC/WebAssembly/weak-alias.s
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -triple=wasm32-unknown-unknown -filetype=obj < %s | obj2yaml | FileCheck --check-prefix=CHECK %s
+# RUN: llvm-mc -triple=wasm32-unknown-unknown -mcpu=mvp -filetype=obj < %s | obj2yaml | FileCheck --check-prefix=CHECK %s
 # RUN: llvm-mc -triple=wasm32-unknown-unknown -mattr=+reference-types -filetype=obj < %s | obj2yaml | FileCheck --check-prefix=REF %s
 
 # 'foo_alias()' is weak alias of function 'foo()'


### PR DESCRIPTION
Other tools, such as `llc`, use `generic` cpu by default, if you don't give any `-mcpu`:
https://github.com/llvm/llvm-project/blob/75f738b0b2a15281c6f285380ea947e973a6e02f/llvm/lib/Target/WebAssembly/WebAssemblySubtarget.cpp#L38-L39

But `llvm-mc` didn't do that. This makes `generic` also the default CPU for `llvm-mc`.