### PR TITLE
[LV] Fix strict weak ordering violation in handleUncountableEarlyExits sort

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -4080,7 +4080,7 @@ void VPlanTransforms::handleUncountableEarlyExits(VPlan &Plan,
   assert(!Exits.empty() && "must have at least one early exit");
   // Sort exits by dominance to get the correct program order.
   llvm::sort(Exits, [&VPDT](const EarlyExitInfo &A, const EarlyExitInfo &B) {
-    return VPDT.dominates(A.EarlyExitingVPBB, B.EarlyExitingVPBB);
+    return VPDT.properlyDominates(A.EarlyExitingVPBB, B.EarlyExitingVPBB);
   });
 
   // Build the AnyOf condition for the latch terminator using logical OR


### PR DESCRIPTION
The sort comparator used VPDT.dominates() which returns true for dominates(A, A), violating the irreflexivity requirement of strict weak ordering. With _GLIBCXX_DEBUG enabled (LLVM_ENABLE_EXPENSIVE_CHECKS=ON), std::sort validates this property and aborts:

  Error: comparison doesn't meet irreflexive requirements, assert(!(a < a)).

Use properlyDominates() instead, which correctly returns false for equal inputs while preserving the intended dominance-based ordering.

This fixes a crash introduced by ede1a9626b89 ("[LV] Vectorize early exit loops with multiple exits.").