### PR TITLE
[clang-tidy] Add IgnoreMacros option to modernize-pass-by-value

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.h
@@ -29,6 +29,7 @@ public:
 private:
   utils::IncludeInserter Inserter;
   const bool ValuesOnly;
+  const bool IgnoreMacros;
 };
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -199,6 +199,10 @@ Changes in existing checks
   - Added support for analyzing function parameters with the `AnalyzeParameters`
     option.
 
+- Improved :doc:`modernize-pass-by-value
+  <clang-tidy/checks/modernize/pass-by-value>` check by adding `IgnoreMacros`
+  option to suppress warnings in macros.
+
 - Improved :doc:`modernize-use-std-format
   <clang-tidy/checks/modernize/use-std-format>` check by fixing a crash
   when an argument is part of a macro expansion.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/pass-by-value.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/pass-by-value.rst
@@ -164,3 +164,8 @@ Options
 
    When `true`, the check only warns about copied parameters that are already
    passed by value. Default is `false`.
+
+.. option:: IgnoreMacros
+
+   When `true`, the check will not give warnings inside macros. Default is
+   `false`.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value-ignore-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value-ignore-macros.cpp
@@ -1,0 +1,24 @@
+// RUN: %check_clang_tidy -check-suffixes=DEFAULT %s modernize-pass-by-value %t -- -config="{CheckOptions: {modernize-pass-by-value.IgnoreMacros: false}}"
+// RUN: %check_clang_tidy -check-suffixes=IGNORE %s modernize-pass-by-value %t -- -config="{CheckOptions: {modernize-pass-by-value.IgnoreMacros: true}}"
+
+struct A {
+  A(const A &);
+  A(A &&);
+};
+
+#define MACRO_CTOR(TYPE) \
+struct TYPE { \
+  TYPE(const A &a) : a(a) {} \
+  A a; \
+};
+// CHECK-MESSAGES-DEFAULT: :[[@LINE+3]]:1: warning: pass by value and use std::move [modernize-pass-by-value]
+// CHECK-MESSAGES-IGNORE-NOT: warning: pass by value and use std::move
+
+MACRO_CTOR(B)
+
+struct C {
+  C(const A &a) : a(a) {}
+  A a;
+};
+// CHECK-MESSAGES-DEFAULT: :[[@LINE-3]]:5: warning: pass by value and use std::move [modernize-pass-by-value]
+// CHECK-MESSAGES-IGNORE: :[[@LINE-4]]:5: warning: pass by value and use std::move [modernize-pass-by-value]


### PR DESCRIPTION
We need this option to address #156153