### PR TITLE
[MLIR][Presburger] Fix simplify() of IntegerRelation

### DIFF
--- a/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
@@ -1162,7 +1162,7 @@ bool IntegerRelation::gaussianEliminate() {
       equalities.normalizeRow(i);
     }
     for (unsigned i = 0, ineqs = getNumInequalities(); i < ineqs; ++i) {
-      eliminateFromConstraint(this, i, *pivotRow, firstVar, 0, false);
+      eliminateFromConstraint(this, i, *pivotRow, firstVar, firstVar, false);
       inequalities.normalizeRow(i);
     }
     gcdTightenInequalities();

--- a/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
@@ -741,6 +741,16 @@ TEST(IntegerRelationTest, simplify) {
   EXPECT_TRUE(rel.getNumEqualities() == 2);
 }
 
+TEST(IntegerRelationTest, simplifyRegression) {
+  IntegerRelation rel = parseRelationFromSet("(x, y, z): (2*x + z >= 5, "
+                                             "x + 3*z >= 7, 3*x + y >= 9)",
+                                             3);
+
+  auto simplified = rel;
+  simplified.simplify();
+  EXPECT_TRUE(rel.isEqual(simplified));
+}
+
 TEST(IntegerRelationTest, isFullDim) {
   IntegerRelation rel = parseRelationFromSet("(x): (1 >= 0)", 1);
   EXPECT_TRUE(rel.isFullDim());


### PR DESCRIPTION
In `simplify()`, we currently skip all columns from 0 to `firstVar` (the column of the pivot) when we eliminate inequalities. This is invalid, because unlike equalities, it is not guaranteed that these columns contain only zeroes, and a scale by `rowMultiplier` cannot be ignored. We must not skip any columns for inequalities.