### PR TITLE
[LLDB][Docs] Fix warnings when building HTML docs

### DIFF
--- a/lldb/bindings/interface/SBFrameDocstrings.i
+++ b/lldb/bindings/interface/SBFrameDocstrings.i
@@ -83,7 +83,7 @@ See also SBThread."
     sets that exist for this thread.  
     Each SBValue in the SBValueList represents one register-set. 
     The first register-set will be the general purpose registers -- 
-    the registers printed by the `register read` command-line in lldb, with 
+    the registers printed by the ``register read`` command-line in lldb, with 
     no additional arguments.  
     The register-set SBValue will have a name, e.g. 
     SBFrame::GetRegisters().GetValueAtIndex(0).GetName() 

--- a/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
+++ b/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
@@ -1,10 +1,8 @@
 %feature("docstring",
 "API clients can get information about memory regions in processes.
 
-For Python users, `len()` is overriden to output the size of the memory region in bytes.
-For Python users, `str()` is overriden with the results of the GetDescription function-
-        produces a formatted string that describes a memory range in the form: 
-        [Hex start - Hex End) with associated permissions (RWX)"
+For Python users, ``len()``  is overriden to output the size of the memory region in bytes.
+For Python users, ``str()`` is overriden with the results of the `GetDescription` function."
 ) lldb::SBMemoryRegionInfo;
 
 %feature("docstring", "

--- a/lldb/docs/conf.py
+++ b/lldb/docs/conf.py
@@ -154,6 +154,10 @@ pygments_style = "friendly"
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
 
+suppress_warnings = [
+    # "WARNING: 'any' reference target not found"
+    "ref.any"
+]
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/lldb/docs/use/lldbdap.md
+++ b/lldb/docs/use/lldbdap.md
@@ -26,7 +26,7 @@ such as [Variable Pretty-Printing](https://lldb.llvm.org/use/variable.html),
 and [Python Scripting](https://lldb.llvm.org/use/python.html) are available
 also in `lldb-dap`.
 
-#### Links to IDE Extensions
+### Links to IDE Extensions
 
 - Visual Studio Code -
 [LLDB DAP Extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.lldb-dap)

--- a/lldb/examples/python/templates/operating_system.py
+++ b/lldb/examples/python/templates/operating_system.py
@@ -56,14 +56,14 @@ class OperatingSystem(ScriptedThread):
         """Lazily create an operating system thread using a thread information
         dictionary and an optional operating system thread context address.
         This method is called manually, using the SBAPI
-        `lldb.SBProcess.CreateOSPluginThread` affordance.
+        ``lldb.SBProcess.CreateOSPluginThread`` affordance.
 
         Args:
-            tid (int): Thread ID to get `thread_info` dictionary for.
+            tid (int): Thread ID to get ``thread_info`` dictionary for.
             context (int): Address of the operating system thread struct.
 
         Returns:
-            Dict: The `thread_info` dictionary containing the various information
+            Dict: The ``thread_info`` dictionary containing the various information
             for lldb to create a Thread object and add it to the process thread list.
         """
         return None
@@ -75,10 +75,10 @@ class OperatingSystem(ScriptedThread):
         thread list.
 
         Returns:
-            List[thread_info]: A list of `os_thread` dictionaries
+            List[thread_info]: A list of ``os_thread`` dictionaries
                 containing at least for each entry, the thread id, it's name,
                 queue, state, stop reason. It can also contain a
-                `register_data_addr`. The list can be empty.
+                ``register_data_addr``. The list can be empty.
         """
         pass
 

--- a/lldb/examples/python/templates/scripted_frame_provider.py
+++ b/lldb/examples/python/templates/scripted_frame_provider.py
@@ -16,7 +16,7 @@ class ScriptedFrameProvider(metaclass=ABCMeta):
     - Adding diagnostic or synthetic frames for debugging
     - Visualizing state machines or async execution contexts
 
-    Most of the base class methods are `@abstractmethod` that need to be
+    Most of the base class methods are ``@abstractmethod`` that need to be
     overwritten by the inheriting class.
 
     The constructor of this class sets up the following attributes:
@@ -49,10 +49,10 @@ class ScriptedFrameProvider(metaclass=ABCMeta):
             debugger.HandleCommand(f"target frame-provider register -C {__name__}.MyFrameProvider")
 
         if __name__ == '__main__':
-            print("This script should be loaded from LLDB using `command script import <filename>`")
+            print("This script should be loaded from LLDB using ``command script import <filename>``")
 
     You can register your frame provider either via the CLI command ``target frame-provider register`` or
-    via the API ``SBThread.RegisterScriptedFrameProvider``.
+    via the API ``lldb.SBThread.RegisterScriptedFrameProvider``.
     """
 
     @staticmethod

--- a/lldb/examples/python/templates/scripted_platform.py
+++ b/lldb/examples/python/templates/scripted_platform.py
@@ -8,7 +8,7 @@ class ScriptedPlatform(metaclass=ABCMeta):
     """
     The base class for a scripted platform.
 
-    Most of the base class methods are `@abstractmethod` that need to be
+    Most of the base class methods are ``@abstractmethod`` that need to be
     overwritten by the inheriting class.
     """
 

--- a/lldb/examples/python/templates/scripted_process.py
+++ b/lldb/examples/python/templates/scripted_process.py
@@ -8,7 +8,7 @@ class ScriptedProcess(metaclass=ABCMeta):
     """
     The base class for a scripted process.
 
-    Most of the base class methods are `@abstractmethod` that need to be
+    Most of the base class methods are ``@abstractmethod`` that need to be
     overwritten by the inheriting class.
     """
 
@@ -90,7 +90,7 @@ class ScriptedProcess(metaclass=ABCMeta):
             error (lldb.SBError): Error object.
 
         Returns:
-            lldb.SBData: An `lldb.SBData` buffer with the target byte size and
+            lldb.SBData: An :py:class:`lldb.SBData` buffer with the target byte size and
                 byte order storing the memory read.
         """
         pass
@@ -100,7 +100,7 @@ class ScriptedProcess(metaclass=ABCMeta):
 
         Args:
             addr (int): Address from which we should start reading.
-            data (lldb.SBData): An `lldb.SBData` buffer to write to the process
+            data (lldb.SBData): An :py:class:`lldb.SBData` buffer to write to the process
             memory.
             error (lldb.SBError): Error object.
 
@@ -124,7 +124,7 @@ class ScriptedProcess(metaclass=ABCMeta):
             }
 
         Returns:
-            List[scripted_image]: A list of `scripted_image` dictionaries
+            List[scripted_image]: A list of ``scripted_image`` dictionaries
                 containing for each entry the library UUID or its file path
                 and its load address.
                 None if the list is empty.
@@ -143,7 +143,7 @@ class ScriptedProcess(metaclass=ABCMeta):
         """Simulate the scripted process launch.
 
         Returns:
-            lldb.SBError: An `lldb.SBError` with error code 0.
+            lldb.SBError: An :py:class:`lldb.SBError` with error code 0.
         """
         return lldb.SBError()
 
@@ -155,7 +155,7 @@ class ScriptedProcess(metaclass=ABCMeta):
             process we're attaching to.
 
         Returns:
-            lldb.SBError: An `lldb.SBError` with error code 0.
+            lldb.SBError: An :py:class:`lldb.SBError` with error code 0.
         """
         return lldb.SBError()
 
@@ -167,7 +167,7 @@ class ScriptedProcess(metaclass=ABCMeta):
             state to stopped after running it.
 
         Returns:
-            lldb.SBError: An `lldb.SBError` with error code 0.
+            lldb.SBError: An :py:class:`lldb.SBError` with error code 0.
         """
         process = self.target.GetProcess()
         if not process:
@@ -229,7 +229,7 @@ class ScriptedThread(metaclass=ABCMeta):
     """
     The base class for a scripted thread.
 
-    Most of the base class methods are `@abstractmethod` that need to be
+    Most of the base class methods are ``@abstractmethod`` that need to be
     overwritten by the inheriting class.
     """
 
@@ -344,7 +344,7 @@ class ScriptedThread(metaclass=ABCMeta):
             }
 
         Returns:
-            List[scripted_frame]: A list of `scripted_frame` dictionaries
+            List[scripted_frame]: A list of ``scripted_frame`` dictionaries
                 containing at least for each entry, the frame index and
                 the program counter value for that frame.
                 The list can be empty.
@@ -398,7 +398,7 @@ class ScriptedFrame(metaclass=ABCMeta):
     """
     The base class for a scripted frame.
 
-    Most of the base class methods are `@abstractmethod` that need to be
+    Most of the base class methods are ``@abstractmethod`` that need to be
     overwritten by the inheriting class.
     """
 

--- a/lldb/examples/python/templates/scripted_thread_plan.py
+++ b/lldb/examples/python/templates/scripted_thread_plan.py
@@ -13,7 +13,7 @@ class ScriptedThreadPlan:
         """Initialization needs a valid lldb.SBThreadPlan object. This plug-in will get created after a live process is valid and has stopped.
 
         Args:
-            thread_plan (lldb.SBThreadPlan): The underlying `ThreadPlan` that is pushed onto the plan stack.
+            thread_plan (lldb.SBThreadPlan): The underlying ``ThreadPlan`` that is pushed onto the plan stack.
         """
         self.thread_plan = thread_plan
 
@@ -24,8 +24,8 @@ class ScriptedThreadPlan:
             event (lldb.SBEvent): The process stop event.
 
         Returns:
-            bool: `True` if this stop could be claimed by this thread plan, `False` otherwise.
-            Defaults to `True`.
+            bool: ``True`` if this stop could be claimed by this thread plan, ``False`` otherwise.
+            Defaults to ``True``.
         """
         return True
 
@@ -33,8 +33,8 @@ class ScriptedThreadPlan:
         """If your plan is no longer relevant (for instance, you were stepping in a particular stack frame, but some other operation pushed that frame off the stack) return True and your plan will get popped.
 
         Returns:
-            bool: `True` if this thread plan is stale, `False` otherwise.
-            Defaults to `False`.
+            bool: ``True`` if this thread plan is stale, ``False`` otherwise.
+            Defaults to ``False``.
         """
         return False
 
@@ -46,8 +46,8 @@ class ScriptedThreadPlan:
             event (lldb.SBEvent): The process stop event.
 
         Returns:
-            bool: `True` if this plan wants to stop and return control to the user at this point, `False` otherwise.
-            Defaults to `False`.
+            bool: ``True`` if this plan wants to stop and return control to the user at this point, ``False`` otherwise.
+            Defaults to ``False``.
         """
         self.thread_plan.SetPlanComplete(True)
         return True
@@ -56,8 +56,8 @@ class ScriptedThreadPlan:
         """Whether this thread plan should instruction step one instruction, or continue till the next breakpoint is hit.
 
         Returns:
-            bool: `True` if this plan will instruction step one instruction, `False` otherwise.
-            Defaults to `True`.
+            bool: ``True`` if this plan will instruction step one instruction, ``False`` otherwise.
+            Defaults to ``True``.
         """
         return True
 

--- a/lldb/include/lldb/API/SBAttachInfo.h
+++ b/lldb/include/lldb/API/SBAttachInfo.h
@@ -183,7 +183,7 @@ public:
   /// By default a process have no shadow event listener.
   /// Calling this function allows public process events to be broadcasted to an
   /// additional listener on top of the default process event listener.
-  /// If the ``listener`` argument is invalid (SBListener::IsValid() will
+  /// If the `listener` argument is invalid (SBListener::IsValid() will
   /// return false), this will clear the shadow listener.
   void SetShadowListener(SBListener &listener);
 

--- a/lldb/include/lldb/API/SBAttachInfo.h
+++ b/lldb/include/lldb/API/SBAttachInfo.h
@@ -183,7 +183,7 @@ public:
   /// By default a process have no shadow event listener.
   /// Calling this function allows public process events to be broadcasted to an
   /// additional listener on top of the default process event listener.
-  /// If the `listener` argument is invalid (SBListener::IsValid() will
+  /// If the ``listener`` argument is invalid (SBListener::IsValid() will
   /// return false), this will clear the shadow listener.
   void SetShadowListener(SBListener &listener);
 

--- a/lldb/include/lldb/API/SBCommandInterpreter.h
+++ b/lldb/include/lldb/API/SBCommandInterpreter.h
@@ -329,7 +329,7 @@ public:
   /// - "timestampInEpochSeconds" (int): The timestamp when the command is
   ///   executed.
   ///
-  /// Turn on settings ``interpreter.save-transcript`` for LLDB to populate
+  /// Turn on settings `interpreter.save-transcript` for LLDB to populate
   /// this list. Otherwise this list is empty.
   SBStructuredData GetTranscript();
 

--- a/lldb/include/lldb/API/SBCommandInterpreter.h
+++ b/lldb/include/lldb/API/SBCommandInterpreter.h
@@ -316,8 +316,10 @@ public:
 
   SBStructuredData GetStatistics();
 
-  /// Returns a list of handled commands, output and error. Each element in
-  /// the list is a dictionary with the following keys/values:
+  /// Returns a list of handled commands, output and error.
+  ///
+  /// Each element in the list is a dictionary with the following keys/values:
+  ///
   /// - "command" (string): The command that was given by the user.
   /// - "commandName" (string): The name of the executed command.
   /// - "commandArguments" (string): The arguments of the executed command.
@@ -327,7 +329,7 @@ public:
   /// - "timestampInEpochSeconds" (int): The timestamp when the command is
   ///   executed.
   ///
-  /// Turn on settings `interpreter.save-transcript` for LLDB to populate
+  /// Turn on settings ``interpreter.save-transcript`` for LLDB to populate
   /// this list. Otherwise this list is empty.
   SBStructuredData GetTranscript();
 

--- a/lldb/include/lldb/API/SBEnvironment.h
+++ b/lldb/include/lldb/API/SBEnvironment.h
@@ -60,16 +60,20 @@ public:
   ///     pointer to an empty string will be returned.
   const char *GetValueAtIndex(size_t index);
 
-  /// Return all environment variables contained in this object. Each variable
-  /// is returned as a string with the following format
+  /// Return all environment variables contained in this object.
+  ///
+  /// Each variable is returned as a string with the following format
+  ///
   ///     name=value
   ///
   /// \return
   ///     Return an lldb::SBStringList object with the environment variables.
   SBStringList GetEntries();
 
-  /// Add or replace an existing environment variable. The input must be a
-  /// string with the format
+  /// Add or replace an existing environment variable.
+  ///
+  /// The input must be a string with the format
+  ///
   ///     name=value
   ///
   /// \param [in] name_and_value

--- a/lldb/include/lldb/API/SBInstruction.h
+++ b/lldb/include/lldb/API/SBInstruction.h
@@ -74,7 +74,9 @@ public:
   bool TestEmulation(lldb::SBStream &output_stream, const char *test_file);
 
   /// Get variable annotations for this instruction as structured data.
+  ///
   /// Returns an array of dictionaries, each containing:
+  ///
   /// - "variable_name": string name of the variable
   /// - "location_description": string description of where variable is stored
   ///   ("RDI", "R15", "undef", etc.)
@@ -83,7 +85,7 @@ public:
   /// - "end_address": unsigned integer address where this annotation becomes
   ///   invalid
   /// - "register_kind": unsigned integer indicating the register numbering
-  /// scheme
+  ///   scheme
   /// - "decl_file": string path to the file where variable is declared
   /// - "decl_line": unsigned integer line number where variable is declared
   /// - "type_name": string type name of the variable

--- a/lldb/include/lldb/API/SBLaunchInfo.h
+++ b/lldb/include/lldb/API/SBLaunchInfo.h
@@ -107,7 +107,7 @@ public:
   /// By default a process have no shadow event listener.
   /// Calling this function allows public process events to be broadcasted to an
   /// additional listener on top of the default process event listener.
-  /// If the `listener` argument is invalid (SBListener::IsValid() will
+  /// If the ``listener`` argument is invalid (SBListener::IsValid() will
   /// return false), this will clear the shadow listener.
   void SetShadowListener(SBListener &listener);
 
@@ -129,8 +129,7 @@ public:
   ///
   /// \param [in] envp
   ///     The new environment variables as a list of strings with the following
-  ///     format
-  ///         name=value
+  ///     format: ``name=value``
   ///
   /// \param [in] append
   ///     Flag that controls whether to replace the existing environment.

--- a/lldb/include/lldb/API/SBLaunchInfo.h
+++ b/lldb/include/lldb/API/SBLaunchInfo.h
@@ -107,7 +107,7 @@ public:
   /// By default a process have no shadow event listener.
   /// Calling this function allows public process events to be broadcasted to an
   /// additional listener on top of the default process event listener.
-  /// If the ``listener`` argument is invalid (SBListener::IsValid() will
+  /// If the `listener` argument is invalid (SBListener::IsValid() will
   /// return false), this will clear the shadow listener.
   void SetShadowListener(SBListener &listener);
 
@@ -129,7 +129,7 @@ public:
   ///
   /// \param [in] envp
   ///     The new environment variables as a list of strings with the following
-  ///     format: ``name=value``
+  ///     format: `name=value`
   ///
   /// \param [in] append
   ///     Flag that controls whether to replace the existing environment.

--- a/lldb/include/lldb/API/SBModule.h
+++ b/lldb/include/lldb/API/SBModule.h
@@ -265,8 +265,8 @@ public:
   ///     this value is zero, then the return value will indicate
   ///     how many version numbers there are in total so another call
   ///     to this function can be make with adequate storage in
-  ///     \a versions to get all of the version numbers. If \a
-  ///     num_versions is less than the actual number of version
+  ///     \a versions to get all of the version numbers. If
+  ///     \a num_versions is less than the actual number of version
   ///     numbers in this object file, only \a num_versions will be
   ///     filled into \a versions (if \a versions is non-NULL).
   ///

--- a/lldb/include/lldb/API/SBProcess.h
+++ b/lldb/include/lldb/API/SBProcess.h
@@ -364,25 +364,25 @@ public:
 
   /// Save the state of the process in a core file.
   ///
-  /// \param[in] file_name - The name of the file to save the core file to.
+  /// \param[in] file_name The name of the file to save the core file to.
   ///
-  /// \param[in] flavor - Specify the flavor of a core file plug-in to save.
-  /// Currently supported flavors include "mach-o" and "minidump"
+  /// \param[in] flavor Specify the flavor of a core file plug-in to save.
+  ///     Currently supported flavors include "mach-o" and "minidump"
   ///
-  /// \param[in] core_style - Specify the style of a core file to save.
+  /// \param[in] core_style Specify the style of a core file to save.
   lldb::SBError SaveCore(const char *file_name, const char *flavor,
                          SaveCoreStyle core_style);
 
   /// Save the state of the process with the a flavor that matches the
   /// current process' main executable (if supported).
   ///
-  /// \param[in] file_name - The name of the file to save the core file to.
+  /// \param[in] file_name The name of the file to save the core file to.
   lldb::SBError SaveCore(const char *file_name);
 
   /// Save the state of the process with the desired settings
   /// as defined in the options object.
   ///
-  /// \param[in] options - The options to use when saving the core file.
+  /// \param[in] options The options to use when saving the core file.
   lldb::SBError SaveCore(SBSaveCoreOptions &options);
 
   /// Query the address load_addr and store the details of the memory

--- a/lldb/include/lldb/API/SBStatisticsOptions.h
+++ b/lldb/include/lldb/API/SBStatisticsOptions.h
@@ -23,8 +23,8 @@ public:
   const SBStatisticsOptions &operator=(const lldb::SBStatisticsOptions &rhs);
 
   /// If true, dump only high-level summary statistics. Exclude details like
-  /// targets, modules, breakpoints, etc. This turns off `IncludeTargets`,
-  /// `IncludeModules` and `IncludeTranscript` by default.
+  /// targets, modules, breakpoints, etc. This turns off ``IncludeTargets``,
+  /// ``IncludeModules`` and ``IncludeTranscript`` by default.
   ///
   /// Defaults to false.
   void SetSummaryOnly(bool b);
@@ -33,11 +33,11 @@ public:
   /// If true, dump statistics for the targets, including breakpoints,
   /// expression evaluations, frame variables, etc.
   ///
-  /// Defaults to true, unless the `SummaryOnly` mode is enabled, in which case
-  /// this is turned off unless specified.
+  /// Defaults to true, unless the ``SummaryOnly`` mode is enabled, in which
+  /// case this is turned off unless specified.
   ///
-  /// If both `IncludeTargets` and `IncludeModules` are true, a list of module
-  /// identifiers will be added to the "targets" section.
+  /// If both ``IncludeTargets`` and ``IncludeModules`` are true, a list of
+  /// module identifiers will be added to the "targets" section.
   void SetIncludeTargets(bool b);
   bool GetIncludeTargets() const;
 
@@ -45,17 +45,17 @@ public:
   /// various aspects of the module and debug information, type system, path,
   /// etc.
   ///
-  /// Defaults to true, unless the `SummaryOnly` mode is enabled, in which case
-  /// this is turned off unless specified.
+  /// Defaults to true, unless the ``SummaryOnly`` mode is enabled, in which
+  /// case this is turned off unless specified.
   ///
-  /// If both `IncludeTargets` and `IncludeModules` are true, a list of module
-  /// identifiers will be added to the "targets" section.
+  /// If both ``IncludeTargets` and ``IncludeModules`` are true, a list of
+  /// module identifiers will be added to the "targets" section.
   void SetIncludeModules(bool b);
   bool GetIncludeModules() const;
 
-  /// If true and the setting `interpreter.save-transcript` is enabled, include
-  /// a JSON array with all commands the user and/or scripts executed during a
-  /// debug session.
+  /// If true and the setting ``interpreter.save-transcript`` is enabled,
+  /// include a JSON array with all commands the user and/or scripts executed
+  /// during a debug session.
   ///
   /// Defaults to false.
   void SetIncludeTranscript(bool b);

--- a/lldb/include/lldb/API/SBStatisticsOptions.h
+++ b/lldb/include/lldb/API/SBStatisticsOptions.h
@@ -23,8 +23,8 @@ public:
   const SBStatisticsOptions &operator=(const lldb::SBStatisticsOptions &rhs);
 
   /// If true, dump only high-level summary statistics. Exclude details like
-  /// targets, modules, breakpoints, etc. This turns off ``IncludeTargets``,
-  /// ``IncludeModules`` and ``IncludeTranscript`` by default.
+  /// targets, modules, breakpoints, etc. This turns off `IncludeTargets`,
+  /// `IncludeModules` and `IncludeTranscript` by default.
   ///
   /// Defaults to false.
   void SetSummaryOnly(bool b);
@@ -33,10 +33,10 @@ public:
   /// If true, dump statistics for the targets, including breakpoints,
   /// expression evaluations, frame variables, etc.
   ///
-  /// Defaults to true, unless the ``SummaryOnly`` mode is enabled, in which
+  /// Defaults to true, unless the `SummaryOnly` mode is enabled, in which
   /// case this is turned off unless specified.
   ///
-  /// If both ``IncludeTargets`` and ``IncludeModules`` are true, a list of
+  /// If both `IncludeTargets` and `IncludeModules` are true, a list of
   /// module identifiers will be added to the "targets" section.
   void SetIncludeTargets(bool b);
   bool GetIncludeTargets() const;
@@ -45,15 +45,15 @@ public:
   /// various aspects of the module and debug information, type system, path,
   /// etc.
   ///
-  /// Defaults to true, unless the ``SummaryOnly`` mode is enabled, in which
+  /// Defaults to true, unless the `SummaryOnly` mode is enabled, in which
   /// case this is turned off unless specified.
   ///
-  /// If both ``IncludeTargets` and ``IncludeModules`` are true, a list of
+  /// If both `IncludeTargets` and `IncludeModules` are true, a list of
   /// module identifiers will be added to the "targets" section.
   void SetIncludeModules(bool b);
   bool GetIncludeModules() const;
 
-  /// If true and the setting ``interpreter.save-transcript`` is enabled,
+  /// If true and the setting `interpreter.save-transcript` is enabled,
   /// include a JSON array with all commands the user and/or scripts executed
   /// during a debug session.
   ///

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -426,7 +426,7 @@ public:
   ///     The base address for the section.
   ///
   /// \return
-  ///      An error to indicate success, fail, and any reason for
+  ///     An error to indicate success, fail, and any reason for
   ///     failure.
   lldb::SBError SetSectionLoadAddress(lldb::SBSection section,
                                       lldb::addr_t section_base_addr);
@@ -438,7 +438,7 @@ public:
   ///     this target.
   ///
   /// \return
-  ///      An error to indicate success, fail, and any reason for
+  ///     An error to indicate success, fail, and any reason for
   ///     failure.
   lldb::SBError ClearSectionLoadAddress(lldb::SBSection section);
 

--- a/lldb/include/lldb/API/SBTraceCursor.h
+++ b/lldb/include/lldb/API/SBTraceCursor.h
@@ -72,13 +72,14 @@ public:
   /// it.
   ///
   /// Requirements:
+  ///
   /// - For a given thread, no two instructions have the same id.
   /// - In terms of efficiency, moving the cursor to a given id should be as
   ///   fast as possible, but not necessarily O(1). That's why the recommended
-  ///   way to traverse sequential instructions is to use the \a
-  ///   SBTraceCursor::Next() method and only use \a SBTraceCursor::GoToId(id)
-  ///   sparingly.
-
+  ///   way to traverse sequential instructions is to use the
+  ///   \a SBTraceCursor::Next() method and only use
+  ///   \a SBTraceCursor::GoToId(id) sparingly.
+  ///
   /// Make the cursor point to the item whose identifier is \p id.
   ///
   /// \return
@@ -88,8 +89,8 @@ public:
   bool GoToId(lldb::user_id_t id);
 
   /// \return
-  ///     \b true if and only if there's an instruction item with the given \p
-  ///     id.
+  ///     \b true if and only if there's an instruction item with the given
+  ///     \p id.
   bool HasId(lldb::user_id_t id) const;
 
   /// \return
@@ -109,9 +110,9 @@ public:
   ///
   /// \param[in] offset
   ///     How many items to move forwards (if positive) or backwards (if
-  ///     negative) from the given origin point. For example, if origin is \b
-  ///     End, then a negative offset would move backward in the trace, but a
-  ///     positive offset would move past the trace to an invalid item.
+  ///     negative) from the given origin point. For example, if origin is
+  ///     \b End, then a negative offset would move backward in the trace, but
+  ///     a positive offset would move past the trace to an invalid item.
   ///
   /// \param[in] origin
   ///     The reference point to use when moving the cursor.

--- a/lldb/include/lldb/API/SBValue.h
+++ b/lldb/include/lldb/API/SBValue.h
@@ -273,8 +273,8 @@ public:
   /// doing any expensive type completion.
   ///
   /// \return
-  ///     Returns \b true if the SBValue might have children, or \b
-  ///     false otherwise.
+  ///     Returns \b true if the SBValue might have children, or
+  ///     \b false otherwise.
   bool MightHaveChildren();
 
   bool IsRuntimeSupportValue();


### PR DESCRIPTION
When building the HTML docs, the following warnings showed up that were fixed here:

- "ERROR: Unexpected indentation" (7x)
  Sphinx expects a blank line after literal blocks. Fixed by adding the blank line. This is usually at the start of the paragraph, while the error may be reported on one of the next lines.
- "WARNING: Block quote ends without a blank line; unexpected unindent" (11x)    
  Similar to the other error, sphinx expects blank lines around most blocks.
- "WARNING: 'any' reference target not found..." (37x)
  The doc comments are parsed as RST, where singe backticks are interpreted as references - unlike in Markdown. To get the same effect as in Markdown, two backticks have to be used.
- "WARNING: more than one target found for 'any' cross-reference..." (7x)
  When referencing classes from the SB API, we have to be explicit. These warnings were all in the format "could be :doc:`SBSomething` or :py:class:`lldb.SBSomething`". Here, I used `:py:class:` as the role.
  