### PR TITLE
[clang-tidy] perf-str-view-conv improvement: support c_str/data fixing

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/performance/string-view-conversions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/string-view-conversions.rst
@@ -15,6 +15,10 @@ Before:
         foo(42, std::string(sv), 3.14); // conversion to std::string is
                                         // redundant as std::string_view
                                         // is expected
+        foo(42, std::string(sv).c_str(), 2.71); // conversion to std::string and
+                                                // then to char* is redundant
+                                                // as std::string_view
+                                                // is expected
         foo(42, std::string("foo"), 3.14); // conversion to std::string is
                                            // redundant as std::string_view
                                            // is expected
@@ -27,5 +31,34 @@ After:
     void foo(int p1, std::string_view p2, double p3);
     void bar(std::string_view sv) {
         foo(42, sv, 3.14);
+        foo(42, sv, 2.71);
         foo(42, "foo", 3.14);
+    }
+
+Please note
+-----------
+
+Pattern ``std::string(sv).c_str()`` can be used intentionally to copy
+the given string up to the null byte. If so, you may use ``NOLINT``
+or rewrite your code:
+
+Before:
+
+.. code-block:: c++
+
+    void foo(int p1, std::string_view p2, double p3);
+    void bar(std::string_view sv) {
+        foo(42, std::string(sv).c_str(), 2.71); // warning is emitted
+    }
+
+After:
+
+.. code-block:: c++
+
+    void foo(int p1, std::string_view p2, double p3);
+    void bar(std::string_view sv) {
+        std::string s(sv);
+        // No warning emitted for the next 2 lines
+        foo(42, s.c_str(), 2.71); // explicit std::string variable used
+        foo(42, std::string(sv).c_str(), 2.71); // NOLINT(performance-string-view-conversions)
     }

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/string-view-conversions.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/string-view-conversions.cpp
@@ -49,6 +49,14 @@ void positive(std::string_view sv, std::wstring_view wsv) {
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: redundant conversion to 'std::string' (aka 'basic_string<char>') and then back to 'basic_string_view<char, std::char_traits<char>>' [performance-string-view-conversions]
   // CHECK-FIXES: foo_sv(42, sv, 3.14);
 
+  foo_sv(42, std::string(sv).c_str(), 3.14);
+  // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: redundant conversion to 'const std::basic_string<char>' and calling .c_str() and then back to 'std::string_view' (aka 'basic_string_view<char>') [performance-string-view-conversions]
+  // CHECK-FIXES: foo_sv(42, sv, 3.14);
+
+  foo_sv(42, std::string(sv).data(), 3.14);
+  // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: redundant conversion to 'const std::basic_string<char>' and calling .data() and then back to 'std::string_view' (aka 'basic_string_view<char>') [performance-string-view-conversions]
+  // CHECK-FIXES: foo_sv(42, sv, 3.14);
+
   foo_sv(42, std::string("Hello, world"), 3.14);
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: redundant  conversion to 'std::string' (aka 'basic_string<char>') and then back to 'basic_string_view<char, std::char_traits<char>>' [performance-string-view-conversions]
   // CHECK-FIXES: foo_sv(42, "Hello, world", 3.14);
@@ -93,6 +101,10 @@ void positive(std::string_view sv, std::wstring_view wsv) {
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: redundant conversion to 'std::wstring' (aka 'basic_string<wchar_t>') and then back to 'basic_string_view<wchar_t, std::char_traits<wchar_t>>' [performance-string-view-conversions]
   // CHECK-FIXES: foo_wsv(42, wsv, 3.14);
 
+  foo_wsv(42, std::wstring(wsv).c_str(), 3.14);
+  // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: redundant conversion to 'const std::basic_string<wchar_t>' and calling .c_str() and then back to 'std::wstring_view' (aka 'basic_string_view<wchar_t>') [performance-string-view-conversions]
+  // CHECK-FIXES: foo_wsv(42, wsv, 3.14);
+
   const wchar_t *wptr = L"Hello, world";
   foo_wsv(42, std::wstring(wptr), 3.14);
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: redundant conversion to 'std::wstring' (aka 'basic_string<wchar_t>') and then back to 'basic_string_view<wchar_t, std::char_traits<wchar_t>>' [performance-string-view-conversions]
@@ -117,7 +129,6 @@ void negative(std::string_view sv, std::wstring_view wsv) {
   foo_sv(42, std::string(5, 'a'), 3.14);
   foo_sv(42, std::string("foo").append("bar"), 3.14);
   foo_sv(42, std::string(sv).substr(0, 5), 3.14);
-  foo_sv(42, std::string(sv).c_str(), 3.14);
 
   // No warnings expected: string parameter, not string-view
   foo_str(42, std::string(sv), 3.14);


### PR DESCRIPTION
Handle new cases:
```
foo_sv(42, std::string(sv).c_str(), 3.14);  -> foo_sv(42, sv, 3.14);
foo_sv(42, std::string(sv).data(), 2.71);  -> foo_sv(42, sv, 2.71);
```