### PR TITLE
workflows/release-binaries: Use free arm Windows runners for PRs

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -176,7 +176,11 @@ jobs:
             test_runs_on=$build_runs_on
             ;;
           windows-11-arm)
-            build_runs_on="windows-11-arm-16core"
+            if [ "$GITHUB_EVENT_NAME" = "pull_request" ] || [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+              build_runs_on="${{ inputs.runs-on }}"
+            else
+              build_runs_on="windows-11-arm-16core"
+            fi
             test_runs_on=$build_runs_on
             ;;
           macos-14)


### PR DESCRIPTION
We are running low on budget, so we need to disable this temporarily.