### PR TITLE
[NFC][WebAssembly] Add Fast-ISel test for load-ext

### DIFF
--- a/llvm/test/CodeGen/WebAssembly/load-ext.ll
+++ b/llvm/test/CodeGen/WebAssembly/load-ext.ll
@@ -1,11 +1,20 @@
-; RUN: llc < %s --mtriple=wasm32-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers | FileCheck %s
-; RUN: llc < %s --mtriple=wasm64-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers | FileCheck %s
+; RUN: llc < %s --mtriple=wasm32-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers | FileCheck %s --check-prefixes=CHECK,SLOW
+; RUN: llc < %s --mtriple=wasm32-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers -fast-isel -fast-isel-abort=1 | FileCheck %s --check-prefixes=CHECK,FAST
+; RUN: llc < %s --mtriple=wasm64-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers | FileCheck %s --check-prefixes=CHECK,SLOW
+; RUN: llc < %s --mtriple=wasm64-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers -fast-isel -fast-isel-abort=1 | FileCheck %s --check-prefixes=CHECK,FAST
 
 ; Test that extending loads are assembled properly.
 
 ; CHECK-LABEL: sext_i8_i32:
-; CHECK: i32.load8_s $push0=, 0($0){{$}}
-; CHECK-NEXT: return $pop0{{$}}
+; SLOW: i32.load8_s $push0=, 0($0){{$}}
+; SLOW-NEXT: return $pop0{{$}}
+; FAST:        i32.load8_u $push[[NUM1:[0-9]+]]=, 0($0)
+; FAST-NEXT:        i32.const   $push[[NUM2:[0-9]+]]=, 24
+; FAST-NEXT:        i32.shl     $push[[NUM3:[0-9]+]]=, $pop[[NUM1]], $pop[[NUM2]]
+; FAST-NEXT:        i32.const   $push[[NUM4:[0-9]+]]=, 24
+; FAST-NEXT:        i32.shr_s   $push[[NUM5:[0-9]+]]=, $pop[[NUM3]], $pop[[NUM4]]
+; FAST-NEXT:        return      $pop[[NUM5]]
+; CHECK:       end_function
 define i32 @sext_i8_i32(ptr %p) {
   %v = load i8, ptr %p
   %e = sext i8 %v to i32
@@ -13,8 +22,12 @@ define i32 @sext_i8_i32(ptr %p) {
 }
 
 ; CHECK-LABEL: zext_i8_i32:
-; CHECK: i32.load8_u $push0=, 0($0){{$}}
-; CHECK-NEXT: return $pop0{{$}}
+; SLOW: i32.load8_u $push0=, 0($0){{$}}
+; SLOW-NEXT: return $pop0{{$}}
+; FAST:       i32.load8_u $push[[L:[0-9]+]]=, 0($0)
+; FAST-NEXT:       i32.const   $push[[C:[0-9]+]]=, 255
+; FAST-NEXT:       i32.and     $push[[R:[0-9]+]]=, $pop[[L]], $pop[[C]]
+; FAST-NEXT:       return      $pop[[R]]
 define i32 @zext_i8_i32(ptr %p) {
   %v = load i8, ptr %p
   %e = zext i8 %v to i32
@@ -22,8 +35,14 @@ define i32 @zext_i8_i32(ptr %p) {
 }
 
 ; CHECK-LABEL: sext_i16_i32:
-; CHECK: i32.load16_s $push0=, 0($0){{$}}
-; CHECK-NEXT: return $pop0{{$}}
+; SLOW: i32.load16_s $push0=, 0($0){{$}}
+; SLOW-NEXT: return $pop0{{$}}
+; FAST:      i32.load16_u $push[[L:[0-9]+]]=, 0($0)
+; FAST-NEXT: i32.const    $push[[C1:[0-9]+]]=, 16
+; FAST-NEXT: i32.shl      $push[[SHL:[0-9]+]]=, $pop[[L]], $pop[[C1]]
+; FAST-NEXT: i32.const    $push[[C2:[0-9]+]]=, 16
+; FAST-NEXT: i32.shr_s    $push[[SHR:[0-9]+]]=, $pop[[SHL]], $pop[[C2]]
+; FAST-NEXT: return       $pop[[SHR]]
 define i32 @sext_i16_i32(ptr %p) {
   %v = load i16, ptr %p
   %e = sext i16 %v to i32
@@ -31,8 +50,12 @@ define i32 @sext_i16_i32(ptr %p) {
 }
 
 ; CHECK-LABEL: zext_i16_i32:
-; CHECK: i32.load16_u $push0=, 0($0){{$}}
-; CHECK-NEXT: return $pop0{{$}}
+; SLOW: i32.load16_u $push0=, 0($0){{$}}
+; SLOW-NEXT: return $pop0{{$}}
+; FAST:      i32.load16_u $push[[L:[0-9]+]]=, 0($0)
+; FAST-NEXT: i32.const    $push[[C:[0-9]+]]=, 65535
+; FAST-NEXT: i32.and      $push[[R:[0-9]+]]=, $pop[[L]], $pop[[C]]
+; FAST-NEXT: return       $pop[[R]]
 define i32 @zext_i16_i32(ptr %p) {
   %v = load i16, ptr %p
   %e = zext i16 %v to i32
@@ -40,8 +63,15 @@ define i32 @zext_i16_i32(ptr %p) {
 }
 
 ; CHECK-LABEL: sext_i8_i64:
-; CHECK: i64.load8_s $push0=, 0($0){{$}}
-; CHECK-NEXT: return $pop0{{$}}
+; SLOW: i64.load8_s $push0=, 0($0){{$}}
+; SLOW-NEXT: return $pop0{{$}}
+; FAST:      i32.load8_u      $push[[L:[0-9]+]]=, 0($0)
+; FAST-NEXT: i32.const        $push[[C1:[0-9]+]]=, 24
+; FAST-NEXT: i32.shl          $push[[SHL:[0-9]+]]=, $pop[[L]], $pop[[C1]]
+; FAST-NEXT: i32.const        $push[[C2:[0-9]+]]=, 24
+; FAST-NEXT: i32.shr_s        $push[[SHR:[0-9]+]]=, $pop[[SHL]], $pop[[C2]]
+; FAST-NEXT: i64.extend_i32_s $push[[EXT:[0-9]+]]=, $pop[[SHR]]
+; FAST-NEXT: return           $pop[[EXT]]
 define i64 @sext_i8_i64(ptr %p) {
   %v = load i8, ptr %p
   %e = sext i8 %v to i64
@@ -49,8 +79,13 @@ define i64 @sext_i8_i64(ptr %p) {
 }
 
 ; CHECK-LABEL: zext_i8_i64:
-; CHECK: i64.load8_u $push0=, 0($0){{$}}
-; CHECK-NEXT: return $pop0{{$}}
+; SLOW: i64.load8_u $push0=, 0($0){{$}}
+; SLOW-NEXT: return $pop0{{$}}
+; FAST:      i32.load8_u      $push[[L:[0-9]+]]=, 0($0)
+; FAST-NEXT: i32.const        $push[[C:[0-9]+]]=, 255
+; FAST-NEXT: i32.and          $push[[AND:[0-9]+]]=, $pop[[L]], $pop[[C]]
+; FAST-NEXT: i64.extend_i32_u $push[[EXT:[0-9]+]]=, $pop[[AND]]
+; FAST-NEXT: return           $pop[[EXT]]
 define i64 @zext_i8_i64(ptr %p) {
   %v = load i8, ptr %p
   %e = zext i8 %v to i64
@@ -58,8 +93,15 @@ define i64 @zext_i8_i64(ptr %p) {
 }
 
 ; CHECK-LABEL: sext_i16_i64:
-; CHECK: i64.load16_s $push0=, 0($0){{$}}
-; CHECK-NEXT: return $pop0{{$}}
+; SLOW: i64.load16_s $push0=, 0($0){{$}}
+; SLOW-NEXT: return $pop0{{$}}
+; FAST:      i32.load16_u     $push[[L:[0-9]+]]=, 0($0)
+; FAST-NEXT: i32.const        $push[[C1:[0-9]+]]=, 16
+; FAST-NEXT: i32.shl          $push[[SHL:[0-9]+]]=, $pop[[L]], $pop[[C1]]
+; FAST-NEXT: i32.const        $push[[C2:[0-9]+]]=, 16
+; FAST-NEXT: i32.shr_s        $push[[SHR:[0-9]+]]=, $pop[[SHL]], $pop[[C2]]
+; FAST-NEXT: i64.extend_i32_s $push[[EXT:[0-9]+]]=, $pop[[SHR]]
+; FAST-NEXT: return           $pop[[EXT]]
 define i64 @sext_i16_i64(ptr %p) {
   %v = load i16, ptr %p
   %e = sext i16 %v to i64
@@ -67,8 +109,13 @@ define i64 @sext_i16_i64(ptr %p) {
 }
 
 ; CHECK-LABEL: zext_i16_i64:
-; CHECK: i64.load16_u $push0=, 0($0){{$}}
-; CHECK-NEXT: return $pop0{{$}}
+; SLOW: i64.load16_u $push0=, 0($0){{$}}
+; SLOW-NEXT: return $pop0{{$}}
+; FAST:      i32.load16_u     $push[[L:[0-9]+]]=, 0($0)
+; FAST-NEXT: i32.const        $push[[C:[0-9]+]]=, 65535
+; FAST-NEXT: i32.and          $push[[AND:[0-9]+]]=, $pop[[L]], $pop[[C]]
+; FAST-NEXT: i64.extend_i32_u $push[[EXT:[0-9]+]]=, $pop[[AND]]
+; FAST-NEXT: return           $pop[[EXT]]
 define i64 @zext_i16_i64(ptr %p) {
   %v = load i16, ptr %p
   %e = zext i16 %v to i64
@@ -76,8 +123,11 @@ define i64 @zext_i16_i64(ptr %p) {
 }
 
 ; CHECK-LABEL: sext_i32_i64:
-; CHECK: i64.load32_s $push0=, 0($0){{$}}
-; CHECK-NEXT: return $pop0{{$}}
+; SLOW: i64.load32_s $push0=, 0($0){{$}}
+; SLOW-NEXT: return $pop0{{$}}
+; FAST:      i32.load         $push[[L:[0-9]+]]=, 0($0)
+; FAST-NEXT: i64.extend_i32_s $push[[EXT:[0-9]+]]=, $pop[[L]]
+; FAST-NEXT: return           $pop[[EXT]]
 define i64 @sext_i32_i64(ptr %p) {
   %v = load i32, ptr %p
   %e = sext i32 %v to i64
@@ -85,8 +135,11 @@ define i64 @sext_i32_i64(ptr %p) {
 }
 
 ; CHECK-LABEL: zext_i32_i64:
-; CHECK: i64.load32_u $push0=, 0($0){{$}}
-; CHECK: return $pop0{{$}}
+; SLOW: i64.load32_u $push0=, 0($0){{$}}
+; SLOW-NEXT: return $pop0{{$}}
+; FAST:      i32.load         $push[[L:[0-9]+]]=, 0($0)
+; FAST-NEXT: i64.extend_i32_u $push[[EXT:[0-9]+]]=, $pop[[L]]
+; FAST-NEXT: return           $pop[[EXT]]
 define i64 @zext_i32_i64(ptr %p) {
   %v = load i32, ptr %p
   %e = zext i32 %v to i64

--- a/llvm/test/CodeGen/WebAssembly/load-ext.ll
+++ b/llvm/test/CodeGen/WebAssembly/load-ext.ll
@@ -1,13 +1,13 @@
-; RUN: llc < %s --mtriple=wasm32-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers | FileCheck %s --check-prefixes=CHECK,SLOW
+; RUN: llc < %s --mtriple=wasm32-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers | FileCheck %s --check-prefixes=CHECK,DAG
 ; RUN: llc < %s --mtriple=wasm32-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers -fast-isel -fast-isel-abort=1 | FileCheck %s --check-prefixes=CHECK,FAST
-; RUN: llc < %s --mtriple=wasm64-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers | FileCheck %s --check-prefixes=CHECK,SLOW
+; RUN: llc < %s --mtriple=wasm64-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers | FileCheck %s --check-prefixes=CHECK,DAG
 ; RUN: llc < %s --mtriple=wasm64-unknown-unknown -asm-verbose=false -disable-wasm-fallthrough-return-opt -wasm-disable-explicit-locals -wasm-keep-registers -fast-isel -fast-isel-abort=1 | FileCheck %s --check-prefixes=CHECK,FAST
 
 ; Test that extending loads are assembled properly.
 
 ; CHECK-LABEL: sext_i8_i32:
-; SLOW: i32.load8_s $push0=, 0($0){{$}}
-; SLOW-NEXT: return $pop0{{$}}
+; DAG: i32.load8_s $push0=, 0($0){{$}}
+; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load8_u   $push[[L:[0-9]+]]=, 0($0)
 ; FAST-NEXT: i32.extend8_s $push[[EXT:[0-9]+]]=, $pop[[L]]
 ; FAST-NEXT: return        $pop[[EXT]]
@@ -18,8 +18,8 @@ define i32 @sext_i8_i32(ptr %p) {
 }
 
 ; CHECK-LABEL: zext_i8_i32:
-; SLOW: i32.load8_u $push0=, 0($0){{$}}
-; SLOW-NEXT: return $pop0{{$}}
+; DAG: i32.load8_u $push0=, 0($0){{$}}
+; DAG-NEXT: return $pop0{{$}}
 ; FAST:       i32.load8_u $push[[L:[0-9]+]]=, 0($0)
 ; FAST-NEXT:       i32.const   $push[[C:[0-9]+]]=, 255
 ; FAST-NEXT:       i32.and     $push[[R:[0-9]+]]=, $pop[[L]], $pop[[C]]
@@ -31,8 +31,8 @@ define i32 @zext_i8_i32(ptr %p) {
 }
 
 ; CHECK-LABEL: sext_i16_i32:
-; SLOW: i32.load16_s $push0=, 0($0){{$}}
-; SLOW-NEXT: return $pop0{{$}}
+; DAG: i32.load16_s $push0=, 0($0){{$}}
+; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load16_u   $push[[L:[0-9]+]]=, 0($0)
 ; FAST-NEXT: i32.extend16_s $push[[EXT:[0-9]+]]=, $pop[[L]]
 ; FAST-NEXT: return         $pop[[EXT]]
@@ -43,8 +43,8 @@ define i32 @sext_i16_i32(ptr %p) {
 }
 
 ; CHECK-LABEL: zext_i16_i32:
-; SLOW: i32.load16_u $push0=, 0($0){{$}}
-; SLOW-NEXT: return $pop0{{$}}
+; DAG: i32.load16_u $push0=, 0($0){{$}}
+; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load16_u $push[[L:[0-9]+]]=, 0($0)
 ; FAST-NEXT: i32.const    $push[[C:[0-9]+]]=, 65535
 ; FAST-NEXT: i32.and      $push[[R:[0-9]+]]=, $pop[[L]], $pop[[C]]
@@ -56,8 +56,8 @@ define i32 @zext_i16_i32(ptr %p) {
 }
 
 ; CHECK-LABEL: sext_i8_i64:
-; SLOW: i64.load8_s $push0=, 0($0){{$}}
-; SLOW-NEXT: return $pop0{{$}}
+; DAG: i64.load8_s $push0=, 0($0){{$}}
+; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load8_u      $push[[L:[0-9]+]]=, 0($0)
 ; FAST-NEXT: i64.extend_i32_u $push[[EXT32:[0-9]+]]=, $pop[[L]]
 ; FAST-NEXT: i64.extend8_s    $push[[EXT8:[0-9]+]]=, $pop[[EXT32]]
@@ -69,8 +69,8 @@ define i64 @sext_i8_i64(ptr %p) {
 }
 
 ; CHECK-LABEL: zext_i8_i64:
-; SLOW: i64.load8_u $push0=, 0($0){{$}}
-; SLOW-NEXT: return $pop0{{$}}
+; DAG: i64.load8_u $push0=, 0($0){{$}}
+; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load8_u      $push[[L:[0-9]+]]=, 0($0)
 ; FAST-NEXT: i32.const        $push[[C:[0-9]+]]=, 255
 ; FAST-NEXT: i32.and          $push[[AND:[0-9]+]]=, $pop[[L]], $pop[[C]]
@@ -83,8 +83,8 @@ define i64 @zext_i8_i64(ptr %p) {
 }
 
 ; CHECK-LABEL: sext_i16_i64:
-; SLOW: i64.load16_s $push0=, 0($0){{$}}
-; SLOW-NEXT: return $pop0{{$}}
+; DAG: i64.load16_s $push0=, 0($0){{$}}
+; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load16_u     $push[[L:[0-9]+]]=, 0($0)
 ; FAST-NEXT: i64.extend_i32_u $push[[EXT32:[0-9]+]]=, $pop[[L]]
 ; FAST-NEXT: i64.extend16_s   $push[[EXT16:[0-9]+]]=, $pop[[EXT32]]
@@ -96,8 +96,8 @@ define i64 @sext_i16_i64(ptr %p) {
 }
 
 ; CHECK-LABEL: zext_i16_i64:
-; SLOW: i64.load16_u $push0=, 0($0){{$}}
-; SLOW-NEXT: return $pop0{{$}}
+; DAG: i64.load16_u $push0=, 0($0){{$}}
+; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load16_u     $push[[L:[0-9]+]]=, 0($0)
 ; FAST-NEXT: i32.const        $push[[C:[0-9]+]]=, 65535
 ; FAST-NEXT: i32.and          $push[[AND:[0-9]+]]=, $pop[[L]], $pop[[C]]
@@ -110,8 +110,8 @@ define i64 @zext_i16_i64(ptr %p) {
 }
 
 ; CHECK-LABEL: sext_i32_i64:
-; SLOW: i64.load32_s $push0=, 0($0){{$}}
-; SLOW-NEXT: return $pop0{{$}}
+; DAG: i64.load32_s $push0=, 0($0){{$}}
+; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load         $push[[L:[0-9]+]]=, 0($0)
 ; FAST-NEXT: i64.extend_i32_s $push[[EXT:[0-9]+]]=, $pop[[L]]
 ; FAST-NEXT: return           $pop[[EXT]]
@@ -122,8 +122,8 @@ define i64 @sext_i32_i64(ptr %p) {
 }
 
 ; CHECK-LABEL: zext_i32_i64:
-; SLOW: i64.load32_u $push0=, 0($0){{$}}
-; SLOW-NEXT: return $pop0{{$}}
+; DAG: i64.load32_u $push0=, 0($0){{$}}
+; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load         $push[[L:[0-9]+]]=, 0($0)
 ; FAST-NEXT: i64.extend_i32_u $push[[EXT:[0-9]+]]=, $pop[[L]]
 ; FAST-NEXT: return           $pop[[EXT]]

--- a/llvm/test/CodeGen/WebAssembly/load-ext.ll
+++ b/llvm/test/CodeGen/WebAssembly/load-ext.ll
@@ -8,13 +8,9 @@
 ; CHECK-LABEL: sext_i8_i32:
 ; SLOW: i32.load8_s $push0=, 0($0){{$}}
 ; SLOW-NEXT: return $pop0{{$}}
-; FAST:        i32.load8_u $push[[NUM1:[0-9]+]]=, 0($0)
-; FAST-NEXT:        i32.const   $push[[NUM2:[0-9]+]]=, 24
-; FAST-NEXT:        i32.shl     $push[[NUM3:[0-9]+]]=, $pop[[NUM1]], $pop[[NUM2]]
-; FAST-NEXT:        i32.const   $push[[NUM4:[0-9]+]]=, 24
-; FAST-NEXT:        i32.shr_s   $push[[NUM5:[0-9]+]]=, $pop[[NUM3]], $pop[[NUM4]]
-; FAST-NEXT:        return      $pop[[NUM5]]
-; CHECK:       end_function
+; FAST:      i32.load8_u   $push[[L:[0-9]+]]=, 0($0)
+; FAST-NEXT: i32.extend8_s $push[[EXT:[0-9]+]]=, $pop[[L]]
+; FAST-NEXT: return        $pop[[EXT]]
 define i32 @sext_i8_i32(ptr %p) {
   %v = load i8, ptr %p
   %e = sext i8 %v to i32
@@ -37,12 +33,9 @@ define i32 @zext_i8_i32(ptr %p) {
 ; CHECK-LABEL: sext_i16_i32:
 ; SLOW: i32.load16_s $push0=, 0($0){{$}}
 ; SLOW-NEXT: return $pop0{{$}}
-; FAST:      i32.load16_u $push[[L:[0-9]+]]=, 0($0)
-; FAST-NEXT: i32.const    $push[[C1:[0-9]+]]=, 16
-; FAST-NEXT: i32.shl      $push[[SHL:[0-9]+]]=, $pop[[L]], $pop[[C1]]
-; FAST-NEXT: i32.const    $push[[C2:[0-9]+]]=, 16
-; FAST-NEXT: i32.shr_s    $push[[SHR:[0-9]+]]=, $pop[[SHL]], $pop[[C2]]
-; FAST-NEXT: return       $pop[[SHR]]
+; FAST:      i32.load16_u   $push[[L:[0-9]+]]=, 0($0)
+; FAST-NEXT: i32.extend16_s $push[[EXT:[0-9]+]]=, $pop[[L]]
+; FAST-NEXT: return         $pop[[EXT]]
 define i32 @sext_i16_i32(ptr %p) {
   %v = load i16, ptr %p
   %e = sext i16 %v to i32
@@ -66,12 +59,9 @@ define i32 @zext_i16_i32(ptr %p) {
 ; SLOW: i64.load8_s $push0=, 0($0){{$}}
 ; SLOW-NEXT: return $pop0{{$}}
 ; FAST:      i32.load8_u      $push[[L:[0-9]+]]=, 0($0)
-; FAST-NEXT: i32.const        $push[[C1:[0-9]+]]=, 24
-; FAST-NEXT: i32.shl          $push[[SHL:[0-9]+]]=, $pop[[L]], $pop[[C1]]
-; FAST-NEXT: i32.const        $push[[C2:[0-9]+]]=, 24
-; FAST-NEXT: i32.shr_s        $push[[SHR:[0-9]+]]=, $pop[[SHL]], $pop[[C2]]
-; FAST-NEXT: i64.extend_i32_s $push[[EXT:[0-9]+]]=, $pop[[SHR]]
-; FAST-NEXT: return           $pop[[EXT]]
+; FAST-NEXT: i64.extend_i32_u $push[[EXT32:[0-9]+]]=, $pop[[L]]
+; FAST-NEXT: i64.extend8_s    $push[[EXT8:[0-9]+]]=, $pop[[EXT32]]
+; FAST-NEXT: return           $pop[[EXT8]]
 define i64 @sext_i8_i64(ptr %p) {
   %v = load i8, ptr %p
   %e = sext i8 %v to i64
@@ -96,12 +86,9 @@ define i64 @zext_i8_i64(ptr %p) {
 ; SLOW: i64.load16_s $push0=, 0($0){{$}}
 ; SLOW-NEXT: return $pop0{{$}}
 ; FAST:      i32.load16_u     $push[[L:[0-9]+]]=, 0($0)
-; FAST-NEXT: i32.const        $push[[C1:[0-9]+]]=, 16
-; FAST-NEXT: i32.shl          $push[[SHL:[0-9]+]]=, $pop[[L]], $pop[[C1]]
-; FAST-NEXT: i32.const        $push[[C2:[0-9]+]]=, 16
-; FAST-NEXT: i32.shr_s        $push[[SHR:[0-9]+]]=, $pop[[SHL]], $pop[[C2]]
-; FAST-NEXT: i64.extend_i32_s $push[[EXT:[0-9]+]]=, $pop[[SHR]]
-; FAST-NEXT: return           $pop[[EXT]]
+; FAST-NEXT: i64.extend_i32_u $push[[EXT32:[0-9]+]]=, $pop[[L]]
+; FAST-NEXT: i64.extend16_s   $push[[EXT16:[0-9]+]]=, $pop[[EXT32]]
+; FAST-NEXT: return           $pop[[EXT16]]
 define i64 @sext_i16_i64(ptr %p) {
   %v = load i16, ptr %p
   %e = sext i16 %v to i64


### PR DESCRIPTION
In relation to issue #179672, updating load-ext.ll to enable testing of Fast-isel.