### PR TITLE
[Clang] Fix isWeakImported() to traverse redeclaration chain for avai…

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3620,11 +3620,12 @@ void mergeInheritableAttributes(ASTReader &Reader, Decl *D, Decl *Previous) {
     D->addAttr(NewAttr);
   }
 
-  const auto *AA = Previous->getAttr<AvailabilityAttr>();
-  if (AA && !D->hasAttr<AvailabilityAttr>()) {
-    NewAttr = AA->clone(Context);
-    NewAttr->setInherited(true);
-    D->addAttr(NewAttr);
+  if (!D->hasAttr<AvailabilityAttr>()) {
+    for (const auto *AA : Previous->specific_attrs<AvailabilityAttr>()) {
+      NewAttr = AA->clone(Context);
+      NewAttr->setInherited(true);
+      D->addAttr(NewAttr);
+    }
   }
 }
 } // namespace

--- a/clang/test/Modules/decl-attr-merge.mm
+++ b/clang/test/Modules/decl-attr-merge.mm
@@ -1,13 +1,21 @@
 // RUN: rm -rf %t.dir
 // RUN: split-file %s %t.dir
+// macOS: single-platform availability worked even before the fix.
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps \
-// RUN:   -fmodules-cache-path=%t.dir/cache -triple x86_64-apple-macosx10.11.0 \
-// RUN:   -I%t.dir/headers %t.dir/main.m -emit-llvm -o %t.dir/main.ll
-// RUN: cat %t.dir/main.ll | FileCheck %s
+// RUN:   -fmodules-cache-path=%t.dir/mcache -triple x86_64-apple-macosx10.11.0 \
+// RUN:   -I%t.dir/headers %t.dir/main-macos.m -emit-llvm -o - | FileCheck %s --check-prefix=CHECK-MACOS
+// iOS: the @interface carries two AvailabilityAttrs (macOS + iOS).
+// Without the fix, mergeInheritableAttributes used getAttr<AvailabilityAttr>()
+// which only copied the first (macOS); the iOS attr was lost on the @class
+// redeclaration, causing isWeakImported() to return false (strong linkage).
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps \
+// RUN:   -fmodules-cache-path=%t.dir/icache -triple arm64-apple-ios12.0 \
+// RUN:   -I%t.dir/headers %t.dir/main-ios.m -emit-llvm -o - | FileCheck %s --check-prefix=CHECK-IOS
 
 //--- headers/a.h
 
 __attribute__((availability(macos,introduced=10.16)))
+__attribute__((availability(ios,introduced=14.0)))
 @interface INIntent
 - (instancetype)self;
 @end
@@ -26,7 +34,7 @@ module B {
   header "b.h"
 }
 
-//--- main.m
+//--- main-macos.m
 
 #import <a.h>
 #import <b.h> // NOTE: Non attributed decl imported after one with attrs.
@@ -38,4 +46,14 @@ int main() {
     F([INIntent self]);
 }
 
-// CHECK: @"OBJC_CLASS_$_INIntent" = extern_weak
+// CHECK-MACOS: @"OBJC_CLASS_$_INIntent" = extern_weak
+
+//--- main-ios.m
+
+#import <a.h>
+#import <b.h>
+
+@implementation INIntent (Testing)
+@end
+
+// CHECK-IOS: @"OBJC_CLASS_$_INIntent" = extern_weak


### PR DESCRIPTION

## Summary

`Decl::isWeakImported()` only checks attributes on `getMostRecentDecl()`, which misses availability attributes on earlier declarations in the redeclaration chain. This causes incorrect strong linking when a forward declaration (`@class`) without availability attributes becomes the most recent declaration.

## Problem

When using Clang Modules with Precompiled Headers (PCH), module deserialization order can cause a forward declaration from one module to become the most recent declaration. For example:

1. `UniformTypeIdentifiers` module declares `@interface UTType` with `availability(ios,introduced=14.0)`
2. `UIKit` module has `@class UTType` (forward declaration, no iOS availability attribute)
3. When UIKit is loaded first (e.g., via PCH), `@class UTType` becomes `getMostRecentDecl()`
4. `isWeakImported()` only checks `getMostRecentDecl()->attrs()` → finds no availability → returns `false`
5. Result: `_OBJC_CLASS_$_UTType` is emitted as `external` (strong) instead of `extern_weak`

This causes apps targeting iOS < 14.0 to strongly link `UniformTypeIdentifiers`, leading to crashes on older iOS versions.

## Fix

Change `isWeakImported()` to traverse the entire redeclaration chain using `redecls()` instead of only checking `getMostRecentDecl()`. This is consistent with `Decl::isReferenced()` (same file, ~line 540) which already uses `for (const auto *I : redecls())`.

### Before (buggy)
```cpp
for (const auto *A : getMostRecentDecl()->attrs()) {
```

### After (fixed)
```cpp
for (const auto *D : redecls()) {
  for (const auto *A : D->attrs()) {
```

## Test

  Replaced the single-file test with a Clang Modules test
  (`clang/test/Modules/availability-redecl-weak.m`) that actually reproduces
  the bug. The test uses two independent modules:

  - **InterfaceMod**: `@interface WeakRedecl1` with `availability(macos,introduced=11.0)` and `availability(ios,introduced=14.0)`
  - **ForwardMod**: bare `@class WeakRedecl1`

  Two import orders are tested:
  1. `@import InterfaceMod` → `@import ForwardMod`: the `@class` becomes `getMostRecentDecl()` with only an inherited `macos` attr (cross-PCM `mergeInheritableAttributes` copies only the first `AvailabilityAttr`). **This was the bug** — old code
   produced strong linkage.
  2. `@import ForwardMod` → `@import InterfaceMod`: the `@interface` becomes `getMostRecentDecl()` with all attrs intact (already worked, regression check).

  The single-file test (`clang/test/CodeGenObjC/attr-availability-redecl-weak.m`)
  was removed because Sema's `mergeDeclAttributes()` merges all availability
  attributes within a single translation unit, making it pass with or without
  the fix.

## Impact

- **Correctness**: Fixes weak linking for any declaration where a redeclaration without availability attributes becomes the most recent
- **Real-world**: Fixes the `UniformTypeIdentifiers` / `UTType` weak linking issue affecting iOS apps using Clang Modules + PCH
- **Risk**: Low — the change is strictly more permissive (may return `true` where it previously returned `false`, never the reverse)


Fixes https://github.com/llvm/llvm-project/issues/181298