### PR TITLE
[lldb] Fix Windows build and remote test failure for ScriptedSymbolLocator

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1712,11 +1712,7 @@ public:
                                        StructuredData::DictionarySP args_sp);
   void ClearScriptedSymbolLocator();
   lldb::ScriptedSymbolLocatorInterfaceSP GetScriptedSymbolLocatorInterface();
-  llvm::StringRef GetScriptedSymbolLocatorClassName() const {
-    return m_scripted_symbol_locator_metadata_sp
-               ? m_scripted_symbol_locator_metadata_sp->GetClassName()
-               : "";
-  }
+  llvm::StringRef GetScriptedSymbolLocatorClassName() const;
 
   /// Look up a previously cached source file resolution result.
   /// Returns true if a cached entry exists (even if the result is nullopt).

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3493,6 +3493,12 @@ ScriptedSymbolLocatorInterfaceSP Target::GetScriptedSymbolLocatorInterface() {
   return m_scripted_symbol_locator_interface_sp;
 }
 
+llvm::StringRef Target::GetScriptedSymbolLocatorClassName() const {
+  return m_scripted_symbol_locator_metadata_sp
+             ? m_scripted_symbol_locator_metadata_sp->GetClassName()
+             : "";
+}
+
 bool Target::LookupScriptedSourceFileCache(
     llvm::StringRef key, std::optional<FileSpec> &result) const {
   auto it = m_scripted_source_file_cache.find(key);

--- a/lldb/test/API/functionalities/scripted_symbol_locator/TestScriptedSymbolLocator.py
+++ b/lldb/test/API/functionalities/scripted_symbol_locator/TestScriptedSymbolLocator.py
@@ -70,11 +70,9 @@ class ScriptedSymbolLocatorTestCase(TestBase):
 
         # Launch and stop at the breakpoint so ApplyFileMappings runs on
         # the main thread via StackFrame::GetSymbolContext.
-        process = target.LaunchSimple(None, None, os.getcwd())
-        self.assertIsNotNone(process)
-        self.assertState(process.GetState(), lldb.eStateStopped)
-
-        thread = process.GetSelectedThread()
+        (target, process, thread, bkpt) = lldbutil.run_to_breakpoint_do_run(
+            self, target, bp
+        )
         frame = thread.GetSelectedFrame()
         line_entry = frame.GetLineEntry()
         self.assertTrue(line_entry and line_entry.IsValid(), "Line entry is valid")


### PR DESCRIPTION
## Summary
- Move `GetScriptedSymbolLocatorClassName()` from inline in `Target.h` to out-of-line in `Target.cpp` to avoid collision with Windows `winuser.h` `#define GetClassName GetClassNameW` macro.
- Replace `LaunchSimple(None, None, os.getcwd())` with `lldbutil.run_to_breakpoint_do_run()` in `test_locate_source_file` to fix test failure on remote platforms where the local working directory doesn't exist.

Fixes CI failures from #181334.

## Test plan
- [ ] Windows (aarch64-windows) build passes
- [ ] remote-linux-win test passes
- [ ] Existing ScriptedSymbolLocator tests pass on local platforms