### PR TITLE
[lldb] Fix pid_t redefinition on Windows in ScriptInterpreterPythonInterfaces

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptInterpreterPythonInterfaces.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptInterpreterPythonInterfaces.cpp
@@ -6,13 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "lldb/Core/PluginManager.h"
 #include "lldb/Host/Config.h"
 #include "lldb/lldb-enumerations.h"
 
 #if LLDB_ENABLE_PYTHON
 
 #include "ScriptInterpreterPythonInterfaces.h"
+
+#include "lldb/Core/PluginManager.h"
 
 using namespace lldb;
 using namespace lldb_private;


### PR DESCRIPTION
## Summary
- Move `#include "lldb/Core/PluginManager.h"` after `#include "ScriptInterpreterPythonInterfaces.h"` so Python's `pyconfig.h` defines `pid_t` before `PosixApi.h` gets included. This fixes the `C2371: 'pid_t': redefinition; different basic types` error on all Windows builders.

Fixes CI failures from #181334 / #181488.