### PR TITLE
[lldb] Fix pid_t redefinition on Windows in ScriptInterpreterPythonInterfaces

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptInterpreterPythonInterfaces.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptInterpreterPythonInterfaces.cpp
@@ -11,6 +11,10 @@
 
 #if LLDB_ENABLE_PYTHON
 
+// Include lldb-python.h first to define NO_PID_T on Windows before any
+// LLDB header transitively pulls in PosixApi.h.
+#include "../lldb-python.h"
+
 #include "ScriptInterpreterPythonInterfaces.h"
 
 #include "lldb/Core/PluginManager.h"


### PR DESCRIPTION
## Summary
Include `lldb-python.h` as the first include inside the `LLDB_ENABLE_PYTHON` block in `ScriptInterpreterPythonInterfaces.cpp`, matching the pattern used by every other Python interface `.cpp` file in this directory.

On Windows, `lldb-python.h` defines `NO_PID_T` before including `Python.h`. This prevents `PosixApi.h` (transitively included via `lldb-private.h`) from redefining `pid_t` with a conflicting type (`uint32_t` vs `int`).

The issue was introduced by #181334 (ScriptedSymbolLocator plugin), which added a new header whose include chain transitively reaches `PosixApi.h`.

Fixes Windows build failures on lldb-aarch64-windows, lldb-x86_64-win, and lldb-remote-linux-win.