### PR TITLE
[lldb] Fix Windows linker error for MakeSBModuleSpec in lldb-server

### DIFF
--- a/lldb/source/Interpreter/ScriptInterpreter.cpp
+++ b/lldb/source/Interpreter/ScriptInterpreter.cpp
@@ -191,12 +191,6 @@ lldb::ModuleSP ScriptInterpreter::GetOpaqueTypeFromSBModule(
   return module.m_opaque_sp;
 }
 
-std::unique_ptr<lldb::SBModuleSpec>
-ScriptInterpreter::MakeSBModuleSpec(const ModuleSpec &module_spec) const {
-  return std::unique_ptr<lldb::SBModuleSpec>(
-      new lldb::SBModuleSpec(module_spec));
-}
-
 lldb::ScriptLanguage
 ScriptInterpreter::StringToLanguage(const llvm::StringRef &language) {
   if (language.equals_insensitive(LanguageToString(eScriptLanguageNone)))

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
@@ -378,4 +378,14 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::ModuleSP>(
   return {};
 }
 
+// MakeSBModuleSpec is defined here rather than in ScriptInterpreter.cpp
+// because it constructs an SBModuleSpec, whose symbols live in liblldb.
+// ScriptInterpreter.cpp is part of lldbInterpreter which is also linked
+// into lldb-server, which does not link the API library.
+std::unique_ptr<lldb::SBModuleSpec>
+ScriptInterpreter::MakeSBModuleSpec(const ModuleSpec &module_spec) const {
+  return std::unique_ptr<lldb::SBModuleSpec>(
+      new lldb::SBModuleSpec(module_spec));
+}
+
 #endif


### PR DESCRIPTION
## Summary
Move the definition of `ScriptInterpreter::MakeSBModuleSpec` from `ScriptInterpreter.cpp` to `ScriptedPythonInterface.cpp`.

`MakeSBModuleSpec` constructs an `SBModuleSpec`, whose symbols live in the API library (`liblldb`). `ScriptInterpreter.cpp` is part of `lldbInterpreter`, which is also linked into `lldb-server` — and `lldb-server` does not link the API library. On Windows, this causes `LNK2019: unresolved external symbol` for `SBModuleSpec`'s constructor and destructor.

`ScriptedPythonInterface.cpp` is part of the Python plugin library, which only links into `liblldb` where the API symbols are available. The method retains friend access to `SBModuleSpec` since it is still a member of `ScriptInterpreter` regardless of which `.cpp` file defines it.

Fixes Windows linker failure from #181334.

## Test plan
- [ ] Existing ScriptedSymbolLocator tests pass