### PR TITLE
[Github][libc] Also build arm container

### DIFF
--- a/.github/workflows/build-libc-container.yml
+++ b/.github/workflows/build-libc-container.yml
@@ -19,7 +19,12 @@ jobs:
   build-libc-container:
     name: Build libc container
     if: github.repository_owner == 'llvm'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
Some of the libc full build tests also run on AArch64 machines. We need to build an ARM container or otherwise the container fails to start and we never end up running anything.