### PR TITLE
[lldb] NFC: Use standard comment for lldb-python.h include

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptInterpreterPythonInterfaces.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptInterpreterPythonInterfaces.cpp
@@ -11,8 +11,7 @@
 
 #if LLDB_ENABLE_PYTHON
 
-// Include lldb-python.h first to define NO_PID_T on Windows before any
-// LLDB header transitively pulls in PosixApi.h.
+// LLDB Python header must be included first.
 #include "../lldb-python.h"
 
 #include "ScriptInterpreterPythonInterfaces.h"


### PR DESCRIPTION
## Summary
Use the standard `// LLDB Python header must be included first.` comment to match every other Python interface `.cpp` file in this directory, as suggested by @JDevlieghere.

## Test plan
NFC - comment only change.