### PR TITLE
[lldb] Scaffolding for synthetic variable support.

### DIFF
--- a/lldb/include/lldb/API/SBVariablesOptions.h
+++ b/lldb/include/lldb/API/SBVariablesOptions.h
@@ -46,6 +46,10 @@ public:
 
   void SetIncludeStatics(bool);
 
+  bool GetIncludeSynthetic() const;
+
+  void SetIncludeSynthetic(bool);
+
   bool GetInScopeOnly() const;
 
   void SetInScopeOnly(bool);

--- a/lldb/include/lldb/Interpreter/OptionGroupVariable.h
+++ b/lldb/include/lldb/Interpreter/OptionGroupVariable.h
@@ -33,8 +33,9 @@ public:
       show_args : 1, // Frame option only (include_frame_options == true)
       show_recognized_args : 1, // Frame option only (include_frame_options ==
                                 // true)
-      show_locals : 1,  // Frame option only (include_frame_options == true)
-      show_globals : 1, // Frame option only (include_frame_options == true)
+      show_locals : 1,    // Frame option only (include_frame_options == true)
+      show_globals : 1,   // Frame option only (include_frame_options == true)
+      show_synthetic : 1, // Frame option only (include_frame_options == true)
       use_regex : 1, show_scope : 1, show_decl : 1;
   OptionValueString summary;        // the name of a named summary
   OptionValueString summary_string; // a summary string

--- a/lldb/include/lldb/Utility/ValueType.h
+++ b/lldb/include/lldb/Utility/ValueType.h
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_UTILITY_VALUETYPE_H
+#define LLDB_UTILITY_VALUETYPE_H
+
+#include "lldb/lldb-enumerations.h"
+
+namespace lldb_private {
+/// Get the base value type - for when we don't care if the value is synthetic
+/// or not, or when we've already handled that case.
+constexpr lldb::ValueType GetBaseValueType(lldb::ValueType vt) {
+  return lldb::ValueType(vt & ~lldb::ValueTypeSyntheticMask);
+}
+
+/// Given a base value type, return a version that carries the synthetic bit.
+constexpr lldb::ValueType GetSyntheticValueType(lldb::ValueType base) {
+  return lldb::ValueType(base | lldb::ValueTypeSyntheticMask);
+}
+
+/// Return true if vt represents a synthetic value, false if not.
+constexpr bool IsSyntheticValueType(lldb::ValueType vt) {
+  return vt & lldb::ValueTypeSyntheticMask;
+}
+} // namespace lldb_private
+
+#endif // LLDB_UTILITY_VALUETYPE_H

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -344,6 +344,12 @@ enum ValueType {
   eValueTypeVTableEntry = 10, ///< function pointer in virtual function table
 };
 
+/// A mask that we can use to check if the value type is synthetic or not.
+// NOTE: This limits the number of value types to 31, but that's 3x more than
+// what we currently have now. See lldb/Utility/ValueType.h for helpers for
+// working with synthetic value types.
+static constexpr unsigned ValueTypeSyntheticMask = 0x20;
+
 /// Token size/granularities for Input Readers.
 
 enum InputReaderGranularity {

--- a/lldb/source/API/SBVariablesOptions.cpp
+++ b/lldb/source/API/SBVariablesOptions.cpp
@@ -20,8 +20,8 @@ class VariablesOptionsImpl {
 public:
   VariablesOptionsImpl()
       : m_include_arguments(false), m_include_locals(false),
-        m_include_statics(false), m_in_scope_only(false),
-        m_include_runtime_support_values(false) {}
+        m_include_statics(false), m_include_synthetic(false),
+        m_in_scope_only(false), m_include_runtime_support_values(false) {}
 
   VariablesOptionsImpl(const VariablesOptionsImpl &) = default;
 
@@ -51,6 +51,10 @@ public:
 
   void SetIncludeStatics(bool b) { m_include_statics = b; }
 
+  bool GetIncludeSynthetic() const { return m_include_synthetic; }
+
+  void SetIncludeSynthetic(bool b) { m_include_synthetic = b; }
+
   bool GetInScopeOnly() const { return m_in_scope_only; }
 
   void SetInScopeOnly(bool b) { m_in_scope_only = b; }
@@ -71,6 +75,7 @@ private:
   bool m_include_arguments : 1;
   bool m_include_locals : 1;
   bool m_include_statics : 1;
+  bool m_include_synthetic : 1;
   bool m_in_scope_only : 1;
   bool m_include_runtime_support_values : 1;
   LazyBool m_include_recognized_arguments =
@@ -155,6 +160,18 @@ void SBVariablesOptions::SetIncludeStatics(bool statics) {
   LLDB_INSTRUMENT_VA(this, statics);
 
   m_opaque_up->SetIncludeStatics(statics);
+}
+
+bool SBVariablesOptions::GetIncludeSynthetic() const {
+  LLDB_INSTRUMENT_VA(this);
+
+  return m_opaque_up->GetIncludeSynthetic();
+}
+
+void SBVariablesOptions::SetIncludeSynthetic(bool synthetic) {
+  LLDB_INSTRUMENT_VA(this, synthetic);
+
+  m_opaque_up->SetIncludeSynthetic(synthetic);
 }
 
 bool SBVariablesOptions::GetInScopeOnly() const {

--- a/lldb/source/Interpreter/OptionGroupVariable.cpp
+++ b/lldb/source/Interpreter/OptionGroupVariable.cpp
@@ -62,6 +62,16 @@ static constexpr OptionDefinition g_variable_options[] = {
      "Show the current frame source file global and static variables."},
     {LLDB_OPT_SET_1 | LLDB_OPT_SET_2,
      false,
+     "no-synthetic",
+     'e', // Use 'e' for synthEtic - s and y are both taken.
+     OptionParser::eNoArgument,
+     nullptr,
+     {},
+     0,
+     eArgTypeNone,
+     "Omit synthetic variables."},
+    {LLDB_OPT_SET_1 | LLDB_OPT_SET_2,
+     false,
      "show-declaration",
      'c',
      OptionParser::eNoArgument,
@@ -140,8 +150,9 @@ static Status ValidateSummaryString(const char *str, void *) {
 OptionGroupVariable::OptionGroupVariable(bool show_frame_options)
     : include_frame_options(show_frame_options), show_args(false),
       show_recognized_args(false), show_locals(false), show_globals(false),
-      use_regex(false), show_scope(false), show_decl(false),
-      summary(ValidateNamedSummary), summary_string(ValidateSummaryString) {}
+      show_synthetic(true), use_regex(false), show_scope(false),
+      show_decl(false), summary(ValidateNamedSummary),
+      summary_string(ValidateSummaryString) {}
 
 Status
 OptionGroupVariable::SetOptionValue(uint32_t option_idx,
@@ -163,6 +174,9 @@ OptionGroupVariable::SetOptionValue(uint32_t option_idx,
     break;
   case 'g':
     show_globals = true;
+    break;
+  case 'e':
+    show_synthetic = false;
     break;
   case 'c':
     show_decl = true;
@@ -192,6 +206,7 @@ void OptionGroupVariable::OptionParsingStarting(
   show_recognized_args = true; // Frame option only
   show_locals = true;          // Frame option only
   show_globals = false;        // Frame option only
+  show_synthetic = true;       // Frame option only
   show_decl = false;
   use_regex = false;
   show_scope = false;


### PR DESCRIPTION
Stacked PRs:
 * #181501
 * __->__#181500


--- --- ---

### [lldb] Scaffolding for synthetic variable support.


This patch handles most of the scaffolding for synthetic variable support that isn't directly tied to functional changes. This patch will be used by one following patch that actually modifies the lldb_private::StackFrame API to allow us to fetch synthetic variables.

There were a couple important/interesting decisions made in this patch that should be noted:
- Any value type may be synthetic, which is why it's a mask applied over the top of another value type.
- When printing frame variables with `fr v`, default to showing synthetic variables.

This new value type mask makes some of the ValueType handling more interesting, but since nothing generates objects with this mask until the next patch, we can land the concept in this patch in some amount of isolation.
