### PR TITLE
[mlir] Add option to ignore commutativity in OperationEquality

### DIFF
--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -1331,7 +1331,11 @@ struct OperationEquivalence {
     // When provided, the properties attached to the operation are ignored.
     IgnoreProperties = 4,
 
-    LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue = */ IgnoreProperties)
+    // When provided, the commutativity of the operation is ignored, and
+    // operands are compared in an order-sensitive way.
+    IgnoreCommutativity = 8,
+
+    LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue = */ IgnoreCommutativity)
   };
 
   /// Compute a hash for the given operation.

--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -1348,8 +1348,8 @@ struct OperationEquivalence {
   /// Helper that can be used with `computeHash` above to ignore operation
   /// operands/result mapping.
   static llvm::hash_code ignoreHashValue(Value) { return llvm::hash_code{}; }
-  /// Helper that can be used with `computeHash` above to ignore operation
-  /// operands/result mapping.
+  /// Helper that can be used with `computeHash` to compute the hash value
+  /// of operands/results directly.
   static llvm::hash_code directHashValue(Value v) { return hash_value(v); }
 
   /// Compare two operations (including their regions) and return if they are

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -689,7 +689,8 @@ llvm::hash_code OperationEquivalence::computeHash(
     hash = llvm::hash_combine(hash, op->getLoc());
 
   //   - Operands
-  if (op->hasTrait<mlir::OpTrait::IsCommutative>() &&
+  if (!(flags & Flags::IgnoreCommutativity) &&
+      op->hasTrait<mlir::OpTrait::IsCommutative>() &&
       op->getNumOperands() > 0) {
     size_t operandHash = hashOperands(op->getOperand(0));
     for (auto operand : op->getOperands().drop_front())
@@ -854,7 +855,7 @@ OperationEquivalence::isRegionEquivalentTo(Region *lhs, Region *rhs,
     return false;
 
   // 2. Compare operands.
-  if (checkCommutativeEquivalent &&
+  if (!(flags & IgnoreCommutativity) && checkCommutativeEquivalent &&
       lhs->hasTrait<mlir::OpTrait::IsCommutative>()) {
     auto lhsRange = lhs->getOperands();
     auto rhsRange = rhs->getOperands();

--- a/mlir/test/IR/operation-equality.mlir
+++ b/mlir/test/IR/operation-equality.mlir
@@ -184,3 +184,18 @@
   %0:2 = "test.producer"() : () -> (i32, i32)
   "test.consumer"(%0#1, %0#0) : (i32, i32) -> ()
   }) : () -> ()
+
+// -----
+
+// CHECK-LABEL: test.ignore_commutatively_equal_permutation
+// CHECK-SAME: compares NOT equals
+
+builtin.module attributes {test.includes_setup} {
+  %0:2 = "test.producer"() : () -> (i32, i32)
+  "test.ignore_commutatively_equal_permutation"() ({
+    arith.addi %0#0, %0#1 : i32
+  }) { ignore_commutativity } : () -> ()
+  "test.ignore_commutatively_equal_permutation"() ({
+    arith.addi %0#1, %0#0 : i32
+  }) { ignore_commutativity } : () -> ()
+}

--- a/mlir/test/lib/IR/TestOperationEquals.cpp
+++ b/mlir/test/lib/IR/TestOperationEquals.cpp
@@ -35,6 +35,8 @@ struct TestOperationEqualPass
     OperationEquivalence::Flags flags{};
     if (!first->hasAttr("strict_loc_check"))
       flags |= OperationEquivalence::IgnoreLocations;
+    if (first->hasAttr("ignore_commutativity"))
+      flags |= OperationEquivalence::IgnoreCommutativity;
     if (OperationEquivalence::isEquivalentTo(first, &module.getBody()->back(),
                                              flags))
       llvm::outs() << " compares equals.\n";

--- a/mlir/test/lib/IR/TestOperationEquals.cpp
+++ b/mlir/test/lib/IR/TestOperationEquals.cpp
@@ -23,13 +23,21 @@ struct TestOperationEqualPass
     ModuleOp module = getOperation();
     // Expects two operations at the top-level:
     int opCount = module.getBody()->getOperations().size();
-    if (opCount != 2) {
+    if (module->hasAttr("test.includes_setup")) {
+      if (opCount < 2) {
+        module.emitError()
+            << "expected at least 2 top-level ops in the module, got "
+            << opCount;
+        return signalPassFailure();
+      }
+    } else if (opCount != 2) {
       module.emitError() << "expected 2 top-level ops in the module, got "
                          << opCount;
       return signalPassFailure();
     }
+    Operation *second = &module.getBody()->back();
+    Operation *first = second->getPrevNode();
 
-    Operation *first = &module.getBody()->front();
     llvm::outs() << first->getName().getStringRef() << " with attr "
                  << first->getDiscardableAttrDictionary();
     OperationEquivalence::Flags flags{};


### PR DESCRIPTION
This adds a new flag, `IgnoreCommutativity`, to the OperationEquivalence flags. When toggled, regular equivalence and hashing will be used instead of calls to `checkCommutativeEquivalent` and commutative-invariant hashing.
This means that commutative operations will not be considered equivalent when their operands are in a different order (i.e. `arith.addi(%a, %b)` vs. `arith.addi(%b, %a)`).