### PR TITLE
[LLVM] [Support] Assume ANSI escape support if $TERM is set.

### DIFF
--- a/llvm/lib/Support/Unix/Process.inc
+++ b/llvm/lib/Support/Unix/Process.inc
@@ -344,20 +344,11 @@ unsigned Process::StandardErrColumns() {
 }
 
 static bool terminalHasColors() {
-  // Check if the current terminal is one of terminals that are known to support
-  // ANSI color escape codes.
-  if (const char *TermStr = std::getenv("TERM")) {
-    return StringSwitch<bool>(TermStr)
-        .Case("ansi", true)
-        .Case("cygwin", true)
-        .Case("linux", true)
-        .StartsWith("screen", true)
-        .StartsWith("xterm", true)
-        .StartsWith("vt100", true)
-        .StartsWith("rxvt", true)
-        .EndsWith("color", true)
-        .Default(false);
-  }
+  // If TERM is defined in the environment, assume it supports ANSI color escape
+  // codes. This matches GCC.
+  if (const char *TermStr = std::getenv("TERM"))
+    // emacs M-x shell is a known exception and sets TERM="dumb".
+    return std::strcmp(TermStr, "dumb");
 
   return false;
 }


### PR DESCRIPTION
The current method to decide on color output is to check `$TERM` against a list of known good values/patterns; this conservative behavior incorrectly assumes some terminals are incapable of interpreting ANSI color escape codes. Such as the foot terminal, which sets TERM=foot.

This aligns with GCC's current method, which assumes any value of $TERM means a tty will accept color, except for known exceptions, currently only the emacs M-x shell.