### PR TITLE
[clang] Revisit tests for CWG2917 and CWG3005 after Core updates

### DIFF
--- a/clang/test/CXX/drs/cwg29xx.cpp
+++ b/clang/test/CXX/drs/cwg29xx.cpp
@@ -38,7 +38,7 @@ struct A {
 #endif
 } // namespace cwg2915
 
-namespace cwg2917 { // cwg2917: 20 review 2024-07-30
+namespace cwg2917 { // cwg2917: 20
 #if __cplusplus >= 201103L
 template <typename>
 class Foo;

--- a/clang/test/CXX/drs/cwg30xx.cpp
+++ b/clang/test/CXX/drs/cwg30xx.cpp
@@ -7,7 +7,7 @@
 // RUN: %clang_cc1 -std=c++2c -pedantic-errors -verify=expected %s
 
 
-namespace cwg3005 { // cwg3005: 21 ready 2025-09-12
+namespace cwg3005 { // cwg3005: 21
 
 void f(
     int _, // #cwg3005-first-param

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -20231,16 +20231,12 @@
     <td>Variable template partial specializations should not be declared <TT>static</TT></td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="2917">
+  <tr id="2917">
     <td><a href="https://cplusplus.github.io/CWG/issues/2917.html">2917</a></td>
     <td>[<a href="https://wg21.link/temp.pre">temp.pre</a>]</td>
-    <td>review</td>
+    <td>accepted</td>
     <td>Disallow multiple <I>friend-type-specifier</I>s for a friend template</td>
-    <td align="center">
-      <details>
-        <summary>Not resolved</summary>
-        Clang 20 implements 2024-07-30 resolution
-      </details></td>
+    <td class="full" align="center">Clang 20</td>
   </tr>
   <tr id="2918">
     <td><a href="https://cplusplus.github.io/CWG/issues/2918.html">2918</a></td>
@@ -20851,16 +20847,12 @@
     <td>Pointer arithmetic on array of unknown bound</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="3005">
+  <tr id="3005">
     <td><a href="https://cplusplus.github.io/CWG/issues/3005.html">3005</a></td>
     <td>[<a href="https://wg21.link/basic.scope.scope">basic.scope.scope</a>]</td>
-    <td>tentatively ready</td>
+    <td>accepted</td>
     <td>Function parameters should never be name-independent</td>
-    <td align="center">
-      <details>
-        <summary>Not resolved</summary>
-        Clang 21 implements 2025-09-12 resolution
-      </details></td>
+    <td class="full" align="center">Clang 21</td>
   </tr>
   <tr class="open" id="3006">
     <td><a href="https://cplusplus.github.io/CWG/issues/3006.html">3006</a></td>


### PR DESCRIPTION
This patch revisits the status of tests for two aforementioned Core issues.
I agree with the analysis in #170410, so no changes are made to CWG2917 test.
In case of CWG3005, Core approved the 2025-09-12 proposed resolution, which the test was written against in the first place.

Fixes #170410