### PR TITLE
[CodeGen] Fix liveness tracking removing live sibling sub-registers

### DIFF
--- a/llvm/test/CodeGen/ARM/constant-island-movwt.mir
+++ b/llvm/test/CodeGen/ARM/constant-island-movwt.mir
@@ -900,12 +900,13 @@ body:             |
 # CHECK-NEXT:   bb.2.entry (align 2):
 # CHECK-NEXT:   liveins: $s26, $s27, $r10, $r9, $r8, $d13, $s24, $s25,
 # CHECK-SAME:            $d12, $d15, $s30, $s31, $d14, $s28, $s29, $lr,
-# CHECK-SAME:            $d21, $q10, $r7, $r0, $d20, $d17, $r2, $q12,
-# CHECK-SAME:            $q11, $d22, $d23, $r1, $q8, $d16, $d30, $q14,
-# CHECK-SAME:            $d28, $d29, $d19, $s17, $r4, $d8, $r6, $r3,
-# CHECK-SAME:            $s16, $d25, $q9, $d18, $s0, $d31, $s3, $q15,
-# CHECK-SAME:            $r12, $d0, $s1, $d24, $d1, $s2, $q0, $s5, $d2,
-# CHECK-SAME:            $q1, $s4, $s7, $d3, $s6, $d9, $s18, $s19, $q4
+# CHECK-SAME:            $q1, $d22, $q10, $d16, $d4, $d20, $r3, $d21,
+# CHECK-SAME:            $d19, $d29, $r0, $d17, $r2, $s9, $q11, $d23,
+# CHECK-SAME:            $s1, $q8, $d31, $q14, $d28, $d18, $s16, $d24,
+# CHECK-SAME:            $r6, $d8, $s4, $q9, $r1, $s0, $d25, $d2,
+# CHECK-SAME:            $q15, $q4, $r12, $d0, $q12, $d30, $q0, $s6,
+# CHECK-SAME:            $d3, $s5, $s3, $s7, $d1, $s2, $s17, $s8,
+# CHECK-SAME:            $r7, $d9, $s18, $s19, $r4
 # CHECK-NEXT: {{^  $}}
 # CHECK-NEXT:     $r5 = t2MOVi16 target-flags(arm-lo16) @.str.84, 14 /* CC::al */, $noreg
 # CHECK-NEXT:     $r5 = t2MOVTi16 $r5, target-flags(arm-hi16) @.str.84, 14 /* CC::al */, $noreg

--- a/llvm/test/CodeGen/Hexagon/dead-mi-superreg-def.mir
+++ b/llvm/test/CodeGen/Hexagon/dead-mi-superreg-def.mir
@@ -1,0 +1,39 @@
+# RUN: llc -mtriple=hexagon -run-pass dead-mi-elimination \
+# RUN:   -verify-machineinstrs -o - %s | FileCheck %s
+
+# LiveRegUnits::stepBackward() walks backward through instructions,
+# removing defined registers from a LiveRegUnits set. When an
+# instruction defines a sub-register ($r1) and has an implicit-def of
+# its super-register ($d0), removeReg($d0) clears the register units
+# of all sub-registers of $d0 — including siblings like $r0 that may
+# still be live. This causes available($r0) to incorrectly return
+# true, and dead MI elimination deletes the instruction defining $r0.
+#
+# In this test, A2_tfrsi defines $r1 with an implicit-def of $d0. The
+# subsequent J2_call uses both $r0 and $r1 as implicit operands, so
+# $r0 must remain live and "$r0 = A2_tfrsi @g" must not be deleted.
+
+# CHECK-LABEL: name: test_dead_mi_superreg
+# CHECK: $r0 = A2_tfrsi @g
+# CHECK: $r1 = A2_tfrsi 42, implicit-def $d0
+# CHECK: J2_call @foo
+
+--- |
+  @g = external global i32
+  define void @test_dead_mi_superreg() {
+    ret void
+  }
+  declare void @foo(ptr, i32)
+...
+
+---
+name: test_dead_mi_superreg
+tracksRegLiveness: true
+body: |
+  bb.0:
+    $r0 = A2_tfrsi @g
+    $r1 = A2_tfrsi 42, implicit-def $d0
+    J2_call @foo, implicit $r0, implicit $r1, implicit-def $r0, implicit-def $r1, implicit-def $d0
+    $r0 = A2_tfrsi 0
+    PS_jmpret $r31, implicit-def dead $pc, implicit $r0
+...

--- a/llvm/test/CodeGen/Hexagon/livephysregs-superreg-def.mir
+++ b/llvm/test/CodeGen/Hexagon/livephysregs-superreg-def.mir
@@ -1,0 +1,67 @@
+# RUN: llc -mtriple=hexagon -run-pass branch-folder \
+# RUN:   -verify-machineinstrs -o - %s | FileCheck %s
+
+# LivePhysRegs::removeDefs() has the same super-register implicit def
+# issue as LiveRegUnits::stepBackward() and ScheduleDAGInstrs::fixupKills():
+# when an instruction defines a sub-register ($r1) and has an implicit-def
+# of its super-register ($d0), removeReg($d0) clears the register units of
+# all sub-registers — including siblings like $r0 that may still be live.
+#
+# This test has two blocks (bb.1 and bb.2) with a common tail. The common
+# tail includes "$r1 = A2_tfrsi 42, implicit-def $d0" followed by a call
+# that uses both $r0 and $r1. The branch folder merges the common tails.
+# After merging, the common tail block's live-in computation must include
+# $r0, because it is used by the call instruction.
+#
+# Without the fix to LivePhysRegs::removeDefs(), stepBackward over
+# "$r1 = A2_tfrsi 42, implicit-def $d0" incorrectly removes $r0 from the
+# live set, so $r0 would not appear in the merged block's live-ins.
+
+# CHECK-LABEL: name: test_livephysregs_superreg
+
+# The common tail block (merged from bb.1/bb.2 tails) must have
+# $r0 in its live-ins since J2_call uses it.
+# CHECK: liveins: $r0
+# CHECK: $r1 = A2_tfrsi 42, implicit-def $d0
+# CHECK-NEXT: J2_call @foo
+
+--- |
+  @g = external global i32
+  define void @test_livephysregs_superreg() {
+    ret void
+  }
+  declare void @foo(ptr, i32)
+...
+
+---
+name: test_livephysregs_superreg
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $r0, $r31
+    successors: %bb.1, %bb.2
+    J2_jumpt undef $p0, %bb.2, implicit-def $pc
+    J2_jump %bb.1, implicit-def $pc
+
+  bb.1:
+    liveins: $r0, $r31
+    successors: %bb.3
+    $r2 = A2_tfrsi 1
+    $r1 = A2_tfrsi 42, implicit-def $d0
+    J2_call @foo, implicit $r0, implicit $r1, implicit-def $r0, implicit-def $r1, implicit-def $d0
+    $r0 = A2_tfrsi 0
+    J2_jump %bb.3, implicit-def $pc
+
+  bb.2:
+    liveins: $r0, $r31
+    successors: %bb.3
+    $r2 = A2_tfrsi 2
+    $r1 = A2_tfrsi 42, implicit-def $d0
+    J2_call @foo, implicit $r0, implicit $r1, implicit-def $r0, implicit-def $r1, implicit-def $d0
+    $r0 = A2_tfrsi 0
+    J2_jump %bb.3, implicit-def $pc
+
+  bb.3:
+    liveins: $r0, $r31
+    PS_jmpret $r31, implicit-def dead $pc, implicit $r0
+...

--- a/llvm/test/CodeGen/Hexagon/post-ra-kill-superreg-def.mir
+++ b/llvm/test/CodeGen/Hexagon/post-ra-kill-superreg-def.mir
@@ -1,0 +1,36 @@
+# RUN: llc -mtriple=hexagon -mcpu=hexagonv60 -run-pass post-RA-sched \
+# RUN:   -verify-machineinstrs -o - %s | FileCheck %s
+
+# The fixupKills() function in ScheduleDAGInstrs walks backward through
+# instructions, maintaining a LiveRegUnits bitvector. When an instruction
+# defines a sub-register ($r1) and has an implicit-def of a super-register
+# ($d0), the def processing calls removeReg($d0), which clears the register
+# units of all sub-registers of $d0 — including $r0. If $r0 is live (used
+# by a subsequent instruction), its liveness is incorrectly cleared, causing
+# available($r0) to return true and a wrong kill flag to be set.
+#
+# In this test, A2_abs defines $r1 with an implicit-def of $d0. The
+# subsequent A2_add uses both $r0 and $r1, so $r0 must not be killed
+# on the A2_abs instruction.
+
+# CHECK-LABEL: name: test_kill_superreg_def
+# CHECK: $r1 = A2_abs $r0, implicit-def $d0
+# CHECK-NEXT: $r0 = A2_add killed $r0, killed $r1
+
+--- |
+  define void @test_kill_superreg_def() {
+    ret void
+  }
+...
+
+---
+name: test_kill_superreg_def
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $r0
+
+    $r1 = A2_abs $r0, implicit-def $d0
+    $r0 = A2_add $r0, $r1
+    PS_jmpret $r31, implicit-def dead $pc, implicit $r0
+...

--- a/llvm/test/CodeGen/SystemZ/int-ssub-06.ll
+++ b/llvm/test/CodeGen/SystemZ/int-ssub-06.ll
@@ -73,7 +73,7 @@ define zeroext i1 @f4(i32 %dummy, i32 %a, ptr %res) {
 ; and must use a register.
 define zeroext i1 @f5(i32 %dummy, i32 %a, ptr %res) {
 ; CHECK-LABEL: f5:
-; CHECK: llilh [[REG1:%r[0-5]]], 32768
+; CHECK: iilf [[REG1:%r[0-5]]], 2147483648
 ; CHECK: sr %r3, [[REG1]]
 ; CHECK-DAG: st %r3, 0(%r4)
 ; CHECK-DAG: ipm [[REG:%r[0-5]]]
@@ -171,7 +171,7 @@ define zeroext i1 @f10(i32 %dummy, i32 %a, ptr %res) {
 ; Check the next value down, which must use a register.
 define zeroext i1 @f11(i32 %dummy, i32 %a, ptr %res) {
 ; CHECK-LABEL: f11:
-; CHECK: llilh [[REG1:%r[0-5]]], 32768
+; CHECK: iilf [[REG1:%r[0-5]]], 2147483648
 ; CHECK: sr %r3, [[REG1]]
 ; CHECK-DAG: st %r3, 0(%r4)
 ; CHECK-DAG: ipm [[REG:%r[0-5]]]

--- a/llvm/test/CodeGen/SystemZ/int-ssub-06.ll
+++ b/llvm/test/CodeGen/SystemZ/int-ssub-06.ll
@@ -73,7 +73,7 @@ define zeroext i1 @f4(i32 %dummy, i32 %a, ptr %res) {
 ; and must use a register.
 define zeroext i1 @f5(i32 %dummy, i32 %a, ptr %res) {
 ; CHECK-LABEL: f5:
-; CHECK: iilf [[REG1:%r[0-5]]], 2147483648
+; CHECK: llilh [[REG1:%r[0-5]]], 32768
 ; CHECK: sr %r3, [[REG1]]
 ; CHECK-DAG: st %r3, 0(%r4)
 ; CHECK-DAG: ipm [[REG:%r[0-5]]]
@@ -171,7 +171,7 @@ define zeroext i1 @f10(i32 %dummy, i32 %a, ptr %res) {
 ; Check the next value down, which must use a register.
 define zeroext i1 @f11(i32 %dummy, i32 %a, ptr %res) {
 ; CHECK-LABEL: f11:
-; CHECK: iilf [[REG1:%r[0-5]]], 2147483648
+; CHECK: llilh [[REG1:%r[0-5]]], 32768
 ; CHECK: sr %r3, [[REG1]]
 ; CHECK-DAG: st %r3, 0(%r4)
 ; CHECK-DAG: ipm [[REG:%r[0-5]]]

--- a/llvm/test/CodeGen/Thumb2/LowOverheadLoops/lstp-insertion-position.mir
+++ b/llvm/test/CodeGen/Thumb2/LowOverheadLoops/lstp-insertion-position.mir
@@ -162,7 +162,7 @@ body:             |
   ; CHECK-NEXT:   renamable $lr = nuw nsw t2ADDrs killed renamable $r3, killed renamable $r12, 19, 14 /* CC::al */, $noreg, $noreg
   ; CHECK-NEXT:   renamable $r3 = tLDRpci %const.0, 14 /* CC::al */, $noreg :: (load (s32) from constant-pool)
   ; CHECK-NEXT:   renamable $q1 = MVE_VDUP32 killed renamable $r3, 0, $noreg, $noreg, undef renamable $q1
-  ; CHECK-NEXT:   $s4 = VMOVS killed $s0, 14 /* CC::al */, $noreg, implicit killed $q1, implicit-def $q1
+  ; CHECK-NEXT:   $s4 = VMOVS killed $s0, 14 /* CC::al */, $noreg, implicit $q1, implicit-def $q1
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.vector.body:
   ; CHECK-NEXT:   successors: %bb.2(0x7c000000), %bb.3(0x04000000)
@@ -303,7 +303,7 @@ body:             |
   ; CHECK-NEXT:   renamable $r3 = tLDRpci %const.0, 14 /* CC::al */, $noreg :: (load (s32) from constant-pool)
   ; CHECK-NEXT:   renamable $q1 = MVE_VDUP32 killed renamable $r3, 0, $noreg, $noreg, undef renamable $q1
   ; CHECK-NEXT:   renamable $r2, dead $cpsr = tLSRri killed renamable $r2, 2, 14 /* CC::al */, $noreg
-  ; CHECK-NEXT:   $s4 = VMOVS killed $s0, 14 /* CC::al */, $noreg, implicit killed $q1, implicit-def $q1
+  ; CHECK-NEXT:   $s4 = VMOVS killed $s0, 14 /* CC::al */, $noreg, implicit $q1, implicit-def $q1
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.vector.body:
   ; CHECK-NEXT:   successors: %bb.2(0x7c000000), %bb.3(0x04000000)

--- a/llvm/test/CodeGen/Thumb2/LowOverheadLoops/vaddv.mir
+++ b/llvm/test/CodeGen/Thumb2/LowOverheadLoops/vaddv.mir
@@ -1902,7 +1902,7 @@ body:             |
   ; CHECK-LABEL: name: illegal_vaddva_s16
   ; CHECK: bb.0.entry:
   ; CHECK-NEXT:   successors: %bb.4(0x30000000), %bb.1(0x50000000)
-  ; CHECK-NEXT:   liveins: $lr, $r0, $r1, $r2, $r3, $r4
+  ; CHECK-NEXT:   liveins: $lr, $d1, $r0, $r1, $r2, $r3, $r4
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   frame-setup tPUSH 14 /* CC::al */, $noreg, killed $r4, killed $lr, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   frame-setup CFI_INSTRUCTION def_cfa_offset 8
@@ -1912,14 +1912,14 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1.vector.ph:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
-  ; CHECK-NEXT:   liveins: $r0, $r1, $r2, $r3
+  ; CHECK-NEXT:   liveins: $d1, $r0, $r1, $r2, $r3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   renamable $d0 = VMOVDRR killed renamable $r2, killed renamable $r3, 14 /* CC::al */, $noreg, implicit-def $q0
   ; CHECK-NEXT:   renamable $r2, dead $cpsr = tADDi3 renamable $r1, 3, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   renamable $r2 = t2BICri killed renamable $r2, 3, 14 /* CC::al */, $noreg, $noreg
   ; CHECK-NEXT:   renamable $r3, dead $cpsr = tMOVi8 1, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   renamable $r2, dead $cpsr = tSUBi8 killed renamable $r2, 4, 14 /* CC::al */, $noreg
-  ; CHECK-NEXT:   renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit killed $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
+  ; CHECK-NEXT:   renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
   ; CHECK-NEXT:   renamable $r2 = nuw nsw t2ADDrs killed renamable $r3, killed renamable $r2, 19, 14 /* CC::al */, $noreg, $noreg
   ; CHECK-NEXT:   renamable $r3, dead $cpsr = tMOVi8 0, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   dead $lr = t2DLS renamable $r2
@@ -1969,7 +1969,7 @@ body:             |
     renamable $r2 = t2BICri killed renamable $r2, 3, 14 /* CC::al */, $noreg, $noreg
     renamable $r3, dead $cpsr = tMOVi8 1, 14 /* CC::al */, $noreg
     renamable $r2, dead $cpsr = tSUBi8 killed renamable $r2, 4, 14 /* CC::al */, $noreg
-    renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit killed $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
+    renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
     renamable $r2 = nuw nsw t2ADDrs killed renamable $r3, killed renamable $r2, 19, 14 /* CC::al */, $noreg, $noreg
     renamable $r3, dead $cpsr = tMOVi8 0, 14 /* CC::al */, $noreg
     $lr = t2DoLoopStart renamable $r2
@@ -2169,7 +2169,7 @@ body:             |
   ; CHECK-LABEL: name: illegal_vaddva_u16
   ; CHECK: bb.0.entry:
   ; CHECK-NEXT:   successors: %bb.4(0x30000000), %bb.1(0x50000000)
-  ; CHECK-NEXT:   liveins: $lr, $r0, $r1, $r2, $r3, $r4
+  ; CHECK-NEXT:   liveins: $lr, $d1, $r0, $r1, $r2, $r3, $r4
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   frame-setup tPUSH 14 /* CC::al */, $noreg, killed $r4, killed $lr, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   frame-setup CFI_INSTRUCTION def_cfa_offset 8
@@ -2179,14 +2179,14 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1.vector.ph:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
-  ; CHECK-NEXT:   liveins: $r0, $r1, $r2, $r3
+  ; CHECK-NEXT:   liveins: $d1, $r0, $r1, $r2, $r3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   renamable $d0 = VMOVDRR killed renamable $r2, killed renamable $r3, 14 /* CC::al */, $noreg, implicit-def $q0
   ; CHECK-NEXT:   renamable $r2, dead $cpsr = tADDi3 renamable $r1, 3, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   renamable $r2 = t2BICri killed renamable $r2, 3, 14 /* CC::al */, $noreg, $noreg
   ; CHECK-NEXT:   renamable $r3, dead $cpsr = tMOVi8 1, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   renamable $r2, dead $cpsr = tSUBi8 killed renamable $r2, 4, 14 /* CC::al */, $noreg
-  ; CHECK-NEXT:   renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit killed $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
+  ; CHECK-NEXT:   renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
   ; CHECK-NEXT:   renamable $r2 = nuw nsw t2ADDrs killed renamable $r3, killed renamable $r2, 19, 14 /* CC::al */, $noreg, $noreg
   ; CHECK-NEXT:   renamable $r3, dead $cpsr = tMOVi8 0, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   dead $lr = t2DLS renamable $r2
@@ -2236,7 +2236,7 @@ body:             |
     renamable $r2 = t2BICri killed renamable $r2, 3, 14 /* CC::al */, $noreg, $noreg
     renamable $r3, dead $cpsr = tMOVi8 1, 14 /* CC::al */, $noreg
     renamable $r2, dead $cpsr = tSUBi8 killed renamable $r2, 4, 14 /* CC::al */, $noreg
-    renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit killed $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
+    renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
     renamable $r2 = nuw nsw t2ADDrs killed renamable $r3, killed renamable $r2, 19, 14 /* CC::al */, $noreg, $noreg
     renamable $r3, dead $cpsr = tMOVi8 0, 14 /* CC::al */, $noreg
     $lr = t2DoLoopStart renamable $r2
@@ -2436,7 +2436,7 @@ body:             |
   ; CHECK-LABEL: name: illegal_vaddva_s8
   ; CHECK: bb.0.entry:
   ; CHECK-NEXT:   successors: %bb.4(0x30000000), %bb.1(0x50000000)
-  ; CHECK-NEXT:   liveins: $lr, $r0, $r1, $r2, $r3, $r4
+  ; CHECK-NEXT:   liveins: $lr, $d1, $r0, $r1, $r2, $r3, $r4
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   frame-setup tPUSH 14 /* CC::al */, $noreg, killed $r4, killed $lr, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   frame-setup CFI_INSTRUCTION def_cfa_offset 8
@@ -2446,14 +2446,14 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1.vector.ph:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
-  ; CHECK-NEXT:   liveins: $r0, $r1, $r2, $r3
+  ; CHECK-NEXT:   liveins: $d1, $r0, $r1, $r2, $r3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   renamable $d0 = VMOVDRR killed renamable $r2, killed renamable $r3, 14 /* CC::al */, $noreg, implicit-def $q0
   ; CHECK-NEXT:   renamable $r2, dead $cpsr = tADDi3 renamable $r1, 7, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   renamable $r2 = t2BICri killed renamable $r2, 7, 14 /* CC::al */, $noreg, $noreg
   ; CHECK-NEXT:   renamable $r3, dead $cpsr = tMOVi8 1, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   renamable $r2, dead $cpsr = tSUBi8 killed renamable $r2, 7, 14 /* CC::al */, $noreg
-  ; CHECK-NEXT:   renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit killed $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
+  ; CHECK-NEXT:   renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
   ; CHECK-NEXT:   renamable $r2 = nuw nsw t2ADDrs killed renamable $r3, killed renamable $r2, 27, 14 /* CC::al */, $noreg, $noreg
   ; CHECK-NEXT:   renamable $r3, dead $cpsr = tMOVi8 0, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   dead $lr = t2DLS renamable $r2
@@ -2503,7 +2503,7 @@ body:             |
     renamable $r2 = t2BICri killed renamable $r2, 7, 14 /* CC::al */, $noreg, $noreg
     renamable $r3, dead $cpsr = tMOVi8 1, 14 /* CC::al */, $noreg
     renamable $r2, dead $cpsr = tSUBi8 killed renamable $r2, 7, 14 /* CC::al */, $noreg
-    renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit killed $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
+    renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
     renamable $r2 = nuw nsw t2ADDrs killed renamable $r3, killed renamable $r2, 27, 14 /* CC::al */, $noreg, $noreg
     renamable $r3, dead $cpsr = tMOVi8 0, 14 /* CC::al */, $noreg
     $lr = t2DoLoopStart renamable $r2
@@ -2703,7 +2703,7 @@ body:             |
   ; CHECK-LABEL: name: illegal_vaddva_u8
   ; CHECK: bb.0.entry:
   ; CHECK-NEXT:   successors: %bb.4(0x30000000), %bb.1(0x50000000)
-  ; CHECK-NEXT:   liveins: $lr, $r0, $r1, $r2, $r3, $r4
+  ; CHECK-NEXT:   liveins: $lr, $d1, $r0, $r1, $r2, $r3, $r4
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   frame-setup tPUSH 14 /* CC::al */, $noreg, killed $r4, killed $lr, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   frame-setup CFI_INSTRUCTION def_cfa_offset 8
@@ -2713,14 +2713,14 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1.vector.ph:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
-  ; CHECK-NEXT:   liveins: $r0, $r1, $r2, $r3
+  ; CHECK-NEXT:   liveins: $d1, $r0, $r1, $r2, $r3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   renamable $d0 = VMOVDRR killed renamable $r2, killed renamable $r3, 14 /* CC::al */, $noreg, implicit-def $q0
   ; CHECK-NEXT:   renamable $r2, dead $cpsr = tADDi3 renamable $r1, 7, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   renamable $r2 = t2BICri killed renamable $r2, 7, 14 /* CC::al */, $noreg, $noreg
   ; CHECK-NEXT:   renamable $r3, dead $cpsr = tMOVi8 1, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   renamable $r2, dead $cpsr = tSUBi8 killed renamable $r2, 7, 14 /* CC::al */, $noreg
-  ; CHECK-NEXT:   renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit killed $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
+  ; CHECK-NEXT:   renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
   ; CHECK-NEXT:   renamable $r2 = nuw nsw t2ADDrs killed renamable $r3, killed renamable $r2, 27, 14 /* CC::al */, $noreg, $noreg
   ; CHECK-NEXT:   renamable $r3, dead $cpsr = tMOVi8 0, 14 /* CC::al */, $noreg
   ; CHECK-NEXT:   dead $lr = t2DLS renamable $r2
@@ -2770,7 +2770,7 @@ body:             |
     renamable $r2 = t2BICri killed renamable $r2, 7, 14 /* CC::al */, $noreg, $noreg
     renamable $r3, dead $cpsr = tMOVi8 1, 14 /* CC::al */, $noreg
     renamable $r2, dead $cpsr = tSUBi8 killed renamable $r2, 7, 14 /* CC::al */, $noreg
-    renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit killed $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
+    renamable $d1 = VLDRD $sp, 2, 14 /* CC::al */, $noreg, implicit $q0, implicit-def $q0 :: (load (s64) from %fixed-stack.0)
     renamable $r2 = nuw nsw t2ADDrs killed renamable $r3, killed renamable $r2, 27, 14 /* CC::al */, $noreg, $noreg
     renamable $r3, dead $cpsr = tMOVi8 0, 14 /* CC::al */, $noreg
     $lr = t2DoLoopStart renamable $r2

--- a/llvm/test/CodeGen/X86/anyext.ll
+++ b/llvm/test/CodeGen/X86/anyext.ll
@@ -30,7 +30,7 @@ define i32 @foo(i32 %p, i8 zeroext %x) nounwind {
 define i32 @bar(i32 %p, i16 zeroext %x) nounwind {
 ; X86-LABEL: bar:
 ; X86:       # %bb.0:
-; X86-NEXT:    movzwl {{[0-9]+}}(%esp), %eax
+; X86-NEXT:    movw {{[0-9]+}}(%esp), %ax
 ; X86-NEXT:    xorl %edx, %edx
 ; X86-NEXT:    divw {{[0-9]+}}(%esp)
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax

--- a/llvm/test/CodeGen/X86/bittest-big-integer.ll
+++ b/llvm/test/CodeGen/X86/bittest-big-integer.ll
@@ -1413,7 +1413,7 @@ define i1 @sequence_i128(ptr %word, i32 %pos0, i32 %pos1, i32 %pos2) nounwind {
 ; AVX2-NEXT:    cmovneq %r8, %rsi
 ; AVX2-NEXT:    cmovneq %r9, %r8
 ; AVX2-NEXT:    xorl %r11d, %r11d
-; AVX2-NEXT:    movl %eax, %ecx
+; AVX2-NEXT:    movb %al, %cl
 ; AVX2-NEXT:    shldq %cl, %r10, %r11
 ; AVX2-NEXT:    shlxq %rax, %r10, %r10
 ; AVX2-NEXT:    testb $64, %al
@@ -1449,7 +1449,7 @@ define i1 @sequence_i128(ptr %word, i32 %pos0, i32 %pos1, i32 %pos2) nounwind {
 ; AVX512-NEXT:    cmovneq %r8, %rsi
 ; AVX512-NEXT:    cmovneq %r10, %r8
 ; AVX512-NEXT:    xorl %r11d, %r11d
-; AVX512-NEXT:    movl %eax, %ecx
+; AVX512-NEXT:    movb %al, %cl
 ; AVX512-NEXT:    shldq %cl, %r9, %r11
 ; AVX512-NEXT:    shlxq %rax, %r9, %r9
 ; AVX512-NEXT:    testb $64, %al

--- a/llvm/test/CodeGen/X86/cmov.ll
+++ b/llvm/test/CodeGen/X86/cmov.ll
@@ -102,7 +102,7 @@ define i1 @test4() nounwind {
 ; CHECK-NEXT:    testb %bl, %bl
 ; CHECK-NEXT:    jne .LBB3_5
 ; CHECK-NEXT:  # %bb.4: # %bb.i.i
-; CHECK-NEXT:    movzbl g_100(%rip), %ecx
+; CHECK-NEXT:    movb g_100(%rip), %cl
 ; CHECK-NEXT:    xorl %ebx, %ebx
 ; CHECK-NEXT:    movl %eax, %ecx
 ; CHECK-NEXT:  .LBB3_5: # %func_1.exit

--- a/llvm/test/CodeGen/X86/scmp.ll
+++ b/llvm/test/CodeGen/X86/scmp.ll
@@ -2830,7 +2830,7 @@ define <7 x i117> @scmp_uncommon_vectors(<7 x i7> %x, <7 x i7> %y) nounwind {
 ; AVX-NEXT:    movq %rdi, %rax
 ; AVX-NEXT:    movzbl {{[0-9]+}}(%rsp), %edi
 ; AVX-NEXT:    movzbl {{[0-9]+}}(%rsp), %r10d
-; AVX-NEXT:    movzbl {{[0-9]+}}(%rsp), %r11d
+; AVX-NEXT:    movb {{[0-9]+}}(%rsp), %r11b
 ; AVX-NEXT:    movzbl {{[0-9]+}}(%rsp), %ebx
 ; AVX-NEXT:    movzbl {{[0-9]+}}(%rsp), %ebp
 ; AVX-NEXT:    movzbl {{[0-9]+}}(%rsp), %r15d
@@ -2904,7 +2904,7 @@ define <7 x i117> @scmp_uncommon_vectors(<7 x i7> %x, <7 x i7> %y) nounwind {
 ; AVX-NEXT:    sarq $63, %r10
 ; AVX-NEXT:    addb %dil, %dil
 ; AVX-NEXT:    sarb %dil
-; AVX-NEXT:    movzbl {{[0-9]+}}(%rsp), %r11d
+; AVX-NEXT:    movb {{[0-9]+}}(%rsp), %r11b
 ; AVX-NEXT:    addb %r11b, %r11b
 ; AVX-NEXT:    sarb %r11b
 ; AVX-NEXT:    cmpb %dil, %r11b

--- a/llvm/test/CodeGen/X86/sdiv_fix.ll
+++ b/llvm/test/CodeGen/X86/sdiv_fix.ll
@@ -131,7 +131,7 @@ define i16 @func3(i15 %x, i8 %y) nounwind {
 ; X64-NEXT:    movswl %si, %ecx
 ; X64-NEXT:    addl %edi, %edi
 ; X64-NEXT:    shrl $4, %ecx
-; X64-NEXT:    movl %edi, %eax
+; X64-NEXT:    movw %di, %ax
 ; X64-NEXT:    cwtd
 ; X64-NEXT:    idivw %cx
 ; X64-NEXT:    # kill: def $ax killed $ax def $rax
@@ -161,7 +161,7 @@ define i16 @func3(i15 %x, i8 %y) nounwind {
 ; X86-NEXT:    movswl %ax, %esi
 ; X86-NEXT:    addl %ecx, %ecx
 ; X86-NEXT:    shrl $4, %esi
-; X86-NEXT:    movl %ecx, %eax
+; X86-NEXT:    movw %cx, %ax
 ; X86-NEXT:    cwtd
 ; X86-NEXT:    idivw %si
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax

--- a/llvm/test/CodeGen/X86/sdiv_fix_sat.ll
+++ b/llvm/test/CodeGen/X86/sdiv_fix_sat.ll
@@ -154,7 +154,7 @@ define i16 @func3(i15 %x, i8 %y) nounwind {
 ; X64-NEXT:    movswl %si, %ecx
 ; X64-NEXT:    addl %edi, %edi
 ; X64-NEXT:    shrl $4, %ecx
-; X64-NEXT:    movl %edi, %eax
+; X64-NEXT:    movw %di, %ax
 ; X64-NEXT:    cwtd
 ; X64-NEXT:    idivw %cx
 ; X64-NEXT:    # kill: def $ax killed $ax def $rax
@@ -189,7 +189,7 @@ define i16 @func3(i15 %x, i8 %y) nounwind {
 ; X86-NEXT:    movswl %ax, %esi
 ; X86-NEXT:    addl %ecx, %ecx
 ; X86-NEXT:    shrl $4, %esi
-; X86-NEXT:    movl %ecx, %eax
+; X86-NEXT:    movw %cx, %ax
 ; X86-NEXT:    cwtd
 ; X86-NEXT:    idivw %si
 ; X86-NEXT:    # kill: def $ax killed $ax def $eax


### PR DESCRIPTION
When an instruction defines a sub-register (e.g. $r1) and has an           
implicit-def of its super-register (e.g. $d0), removing the                                              
super-register from the live set clears the liveness of ALL                
sub-registers of $d0 — including siblings like $r0 that may still be
live. This same bug exists in three places:

- ScheduleDAGInstrs::fixupKills(): removeReg($d0) causes available($r0) to incorrectly return true, setting wrong kill flags.

- LiveRegUnits::stepBackward(): removeReg($d0) clears register units for all sub-registers, causing DeadMachineInstructionElim to incorrectly consider definitions of siblings as dead and delete them.

- LivePhysRegs::removeDefs(): removeReg($d0) clears the liveness of all sub-registers, causing incorrect live-in computation in passes that use LivePhysRegs (branch-folder, register scavenging, liveness recomputation, etc.), leading to downstream miscompilation or crashes.

Fix all three by skipping removeReg for implicit defs of
super-registers when the instruction also defines one of their
sub-registers. The implicit def in this case is an annotation of
partial modification, not a full redefinition of the super-register.