### PR TITLE
[WebAssembly] Fix null Subtarget crash for addrspace(1) globals

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
@@ -198,13 +198,12 @@ void WebAssemblyAsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
     SmallVector<MVT, 1> VTs;
     Type *GlobalVT = GV->getValueType();
     if (!Subtarget) {
-      // Subtarget is only set when a function is defined, because
-      // each function can declare a different subtarget. For example,
-      // on ARM a compilation unit might have a function on ARM and
-      // another on Thumb. Therefore only if Subtarget is non-null we
-      // can actually calculate the legal VTs. Therefore, if Subtarget
-      // is null, we retrieve the default subtarget from TargetMachine
-      // to calculate the legal VTs.
+      // Subtarget is typically set when a function is processed. In modules
+      // with only global variables (no functions), Subtarget remains null.
+      // Unlike architectures that support per-function subtargets (e.g., ARM
+      // vs Thumb), WebAssembly features are coalesced module-wide before ISel.
+      // Therefore, if Subtarget is null, it is safe to retrieve the default
+      // Subtarget from TargetMachine to calculate legal VTs.
       auto &WasmTM = static_cast<const WebAssemblyTargetMachine &>(TM);
       Subtarget = WasmTM.getSubtargetImpl();
     }

--- a/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
@@ -197,18 +197,13 @@ void WebAssemblyAsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
   if (!Sym->getType()) {
     SmallVector<MVT, 1> VTs;
     Type *GlobalVT = GV->getValueType();
-    if (!Subtarget) {
-      // Subtarget is typically set when a function is processed. In modules
-      // with only global variables (no functions), Subtarget remains null.
-      // Unlike architectures that support per-function subtargets (e.g., ARM
-      // vs Thumb), WebAssembly features are coalesced module-wide before ISel.
-      // Therefore, if Subtarget is null, it is safe to retrieve the default
-      // Subtarget from TargetMachine to calculate legal VTs.
-      auto &WasmTM = static_cast<const WebAssemblyTargetMachine &>(TM);
-      Subtarget = WasmTM.getSubtargetImpl();
-    }
-
-    const WebAssemblyTargetLowering &TLI = *Subtarget->getTargetLowering();
+    // Global emission can happen when the AsmPrinter's current Subtarget is
+    // unset or corresponds to the last emitted function. For WebAssembly we
+    // coalesce module features before isel, so use the TargetMachine's
+    // module-wide subtarget here to compute legal value types.
+    auto &WasmTM = static_cast<const WebAssemblyTargetMachine &>(TM);
+    const WebAssemblySubtarget *ST = WasmTM.getSubtargetImpl();
+    const WebAssemblyTargetLowering &TLI = *ST->getTargetLowering();
     computeLegalValueVTs(TLI, GV->getParent()->getContext(),
                          GV->getDataLayout(), GlobalVT, VTs);
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
@@ -197,10 +197,9 @@ void WebAssemblyAsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
   if (!Sym->getType()) {
     SmallVector<MVT, 1> VTs;
     Type *GlobalVT = GV->getValueType();
-    // Global emission can happen when the AsmPrinter's current Subtarget is
-    // unset or corresponds to the last emitted function. For WebAssembly we
-    // coalesce module features before isel, so use the TargetMachine's
-    // module-wide subtarget here to compute legal value types.
+    // Function-specific subtargets are not needed here: WebAssembly
+    // coalesces features before isel, so use the TargetMachine's
+    // module-wide subtarget to compute legal value types.
     auto &WasmTM = static_cast<const WebAssemblyTargetMachine &>(TM);
     const WebAssemblySubtarget *ST = WasmTM.getSubtargetImpl();
     const WebAssemblyTargetLowering &TLI = *ST->getTargetLowering();

--- a/llvm/test/CodeGen/WebAssembly/global-addrspace.ll
+++ b/llvm/test/CodeGen/WebAssembly/global-addrspace.ll
@@ -1,0 +1,20 @@
+; RUN: llc < %s -mtriple=wasm32-unknown-unknown | FileCheck %s
+
+;; This test ensures that globals in addrspace(1) (Wasm-specific variables)
+;; do not cause a crash during emission when Subtarget is not set
+;; (e.g., in modules without functions) and correctly emit their initializers.
+
+; CHECK-LABEL: .globaltype wasm_var, i32
+; CHECK-NEXT: .globl wasm_var
+; CHECK-NEXT: wasm_var:
+@wasm_var = addrspace(1) global i32 42
+
+; CHECK-LABEL: .globaltype wasm_var_float, f32
+; CHECK-NEXT: .globl wasm_var_float
+; CHECK-NEXT: wasm_var_float:
+@wasm_var_float = addrspace(1) global float 0x40091EB860000000
+
+; CHECK-LABEL: .globaltype     wasm_var_i64, i64
+; CHECK-NEXT: .globl  wasm_var_i64
+; CHECK-NEXT: wasm_var_i64:
+@wasm_var_i64 = addrspace(1) global i64 1234567890

--- a/llvm/test/CodeGen/WebAssembly/global-addrspace.ll
+++ b/llvm/test/CodeGen/WebAssembly/global-addrspace.ll
@@ -4,17 +4,17 @@
 ;; do not cause a crash during emission when Subtarget is not set
 ;; (e.g., in modules without functions) and correctly emit their initializers.
 
-; CHECK-LABEL: .globaltype wasm_var, i32
-; CHECK-NEXT: .globl wasm_var
-; CHECK-NEXT: wasm_var:
+; CHECK: .globaltype wasm_var, i32
+; CHECK: .globl wasm_var
+; CHECK-LABEL: wasm_var:
 @wasm_var = addrspace(1) global i32 42
 
-; CHECK-LABEL: .globaltype wasm_var_float, f32
-; CHECK-NEXT: .globl wasm_var_float
-; CHECK-NEXT: wasm_var_float:
+; CHECK: .globaltype wasm_var_float, f32
+; CHECK: .globl wasm_var_float
+; CHECK-LABEL: wasm_var_float:
 @wasm_var_float = addrspace(1) global float 0x40091EB860000000
 
-; CHECK-LABEL: .globaltype     wasm_var_i64, i64
-; CHECK-NEXT: .globl  wasm_var_i64
-; CHECK-NEXT: wasm_var_i64:
+; CHECK: .globaltype     wasm_var_i64, i64
+; CHECK: .globl  wasm_var_i64
+; CHECK-LABEL: wasm_var_i64:
 @wasm_var_i64 = addrspace(1) global i64 1234567890

--- a/llvm/test/CodeGen/WebAssembly/global-addrspace.ll
+++ b/llvm/test/CodeGen/WebAssembly/global-addrspace.ll
@@ -18,3 +18,13 @@
 ; CHECK: .globl  wasm_var_i64
 ; CHECK-LABEL: wasm_var_i64:
 @wasm_var_i64 = addrspace(1) global i64 1234567890
+
+; CHECK: .globaltype     wasm_var_f64, f64
+; CHECK: .globl  wasm_var_f64
+; CHECK-LABEL: wasm_var_f64:
+@wasm_var_f64 = local_unnamed_addr addrspace(1) global double -0.0
+
+; CHECK: .globaltype wasm_external, i32
+; CHECK-NOT: .global wasm_external
+; CHECK-NOT: wasm_external:
+@wasm_external = external addrspace(1) global i32


### PR DESCRIPTION
If Subtarget is null during global emission, it is now retrieved
from TargetMachine to prevent crashes caused by empty VTs in
wasmSymbolSetType.

Fixed: https://github.com/llvm/llvm-project/issues/181527