### PR TITLE
[lldb-dap][NFC] Modernize events handling in tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -287,10 +287,7 @@ class DebugCommunication(object):
         self.terminated: bool = False
         self.events: List[Event] = []
         self.progress_events: List[Event] = []
-        self.invalidated_event: Optional[Event] = None
-        self.memory_event: Optional[Event] = None
         self.reverse_requests: List[Request] = []
-        self.module_events: List[Dict] = []
         self.sequence: int = 1
         self.output: Dict[str, str] = {}
         self.reverse_process: Optional[subprocess.Popen] = None
@@ -555,10 +552,6 @@ class DebugCommunication(object):
         elif event == "capabilities" and body:
             # Update the capabilities with new ones from the event.
             self.capabilities.update(body["capabilities"])
-        elif event == "invalidated":
-            self.invalidated_event = packet
-        elif event == "memory":
-            self.memory_event = packet
 
     def _handle_reverse_request(self, request: Request) -> None:
         if request in self.reverse_requests:
@@ -744,6 +737,18 @@ class DebugCommunication(object):
         event_dict = self.wait_for_event(["terminated"])
         if event_dict is None:
             raise ValueError("didn't get terminated event")
+        return event_dict
+
+    def wait_for_invalidated(self):
+        event_dict = self.wait_for_event(["invalidated"])
+        if event_dict is None:
+            raise ValueError("didn't get invalidated event")
+        return event_dict
+
+    def wait_for_memory(self):
+        event_dict = self.wait_for_event(["memory"])
+        if event_dict is None:
+            raise ValueError("didn't get memory event")
         return event_dict
 
     def get_capability(self, key: str):

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -265,21 +265,6 @@ class DAPTestCaseBase(TestBase):
                 f"Command '{flavor}' - '{cmd}' not found in output: {output}",
             )
 
-    def verify_invalidated_event(self, expected_areas):
-        event = self.dap_server.invalidated_event
-        self.dap_server.invalidated_event = None
-        self.assertIsNotNone(event)
-        areas = event["body"].get("areas", [])
-        self.assertEqual(set(expected_areas), set(areas))
-
-    def verify_memory_event(self, memoryReference):
-        if memoryReference is None:
-            self.assertIsNone(self.dap_server.memory_event)
-        event = self.dap_server.memory_event
-        self.dap_server.memory_event = None
-        self.assertIsNotNone(event)
-        self.assertEqual(memoryReference, event["body"].get("memoryReference"))
-
     def get_dict_value(self, d: Mapping[str, Any], key_path: List[str]) -> Any:
         """Verify each key in the key_path array is in contained in each
         dictionary within "d". Assert if any key isn't in the
@@ -380,8 +365,13 @@ class DAPTestCaseBase(TestBase):
         """Set a variable."""
         response = self.dap_server.request_setVariable(varRef, name, str(value), id=id)
         if response["success"]:
-            self.verify_invalidated_event(["variables"])
-            self.verify_memory_event(response["body"].get("memoryReference"))
+            invalidated_event = self.dap_server.wait_for_invalidated()
+            self.assertEqual(invalidated_event["body"].get("areas"), ["variables"])
+            memory_event = self.dap_server.wait_for_memory()
+            self.assertEqual(
+                memory_event["body"].get("memoryReference"),
+                response["body"].get("memoryReference"),
+            )
         return response
 
     def set_local(self, name, value, id=None):
@@ -658,5 +648,6 @@ class DAPTestCaseBase(TestBase):
             memoryReference, encodedData, offset=offset, allowPartial=allowPartial
         )
         if response["success"]:
-            self.verify_invalidated_event(["all"])
+            invalidated_event = self.dap_server.wait_for_invalidated()
+            self.assertEqual(invalidated_event["body"].get("areas"), ["all"])
         return response


### PR DESCRIPTION
Migrated `initialized` and `memory` events to new style handling.