### PR TITLE
[clang-tidy] Avoid assert failure on non-identifier names in `readability-container-size-empty`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ContainerSizeEmptyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerSizeEmptyCheck.cpp
@@ -116,11 +116,15 @@ AST_POLYMORPHIC_MATCHER_P(
     matchMemberName,
     AST_POLYMORPHIC_SUPPORTED_TYPES(MemberExpr, CXXDependentScopeMemberExpr),
     std::string, MemberName) {
-  if (const auto *E = dyn_cast<MemberExpr>(&Node))
-    return E->getMemberDecl()->getName() == MemberName;
+  if (const auto *E = dyn_cast<MemberExpr>(&Node)) {
+    const IdentifierInfo *II = E->getMemberDecl()->getIdentifier();
+    return II && II->getName() == MemberName;
+  }
 
-  if (const auto *E = dyn_cast<CXXDependentScopeMemberExpr>(&Node))
-    return E->getMember().getAsString() == MemberName;
+  if (const auto *E = dyn_cast<CXXDependentScopeMemberExpr>(&Node)) {
+    const IdentifierInfo *II = E->getMember().getAsIdentifierInfo();
+    return II && II->getName() == MemberName;
+  }
 
   return false;
 }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -218,6 +218,10 @@ Changes in existing checks
   <clang-tidy/checks/performance/move-const-arg>` check by avoiding false
   positives on trivially copyable types with a non-public copy constructor.
 
+- Improved :doc:`readability-container-size-empty
+  <clang-tidy/checks/readability/container-size-empty>` check by fixing a crash
+  when a member expression has a non-identifier name.
+
 - Improved :doc:`readability-enum-initial-value
   <clang-tidy/checks/readability/enum-initial-value>` check: the warning message
   now uses separate note diagnostics for each uninitialized enumerator, making

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-size-empty.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-size-empty.cpp
@@ -985,3 +985,18 @@ public:
     }
   }
 };
+
+namespace GH181552 {
+struct DestructorContainer {
+  unsigned long size() const;
+  bool empty() const;
+  ~DestructorContainer();
+};
+
+struct DestructorUser {
+  DestructorContainer Indexes;
+  ~DestructorUser() {
+    Indexes.~DestructorContainer();
+  }
+};
+}


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/181552