### PR TITLE
[Clang][Sema] Mark partial specializations invalid when not more specialized than primary

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -4229,6 +4229,9 @@ static void checkMoreSpecializedThanPrimary(Sema &S, PartialSpecDecl *Partial) {
          diag::ext_partial_spec_not_more_specialized_than_primary)
       << isa<VarTemplateDecl>(Template);
 
+  // An invalid partial specialization should not be deduced.
+  Partial->setInvalidDecl();
+
   if (Info.hasSFINAEDiagnostic()) {
     PartialDiagnosticAt Diag = {SourceLocation(),
                                 PartialDiagnostic::NullDiagnostic()};
@@ -9108,7 +9111,9 @@ DeclResult Sema::ActOnClassTemplateSpecialization(
   if (SkipBody && SkipBody->ShouldSkip)
     return SkipBody->Previous;
 
-  Specialization->setInvalidDecl(Invalid);
+  // Don't clear an invalid flag already set by earlier checks.
+  if (Invalid)
+    Specialization->setInvalidDecl();
   inferGslOwnerPointerAttribute(Specialization);
   return Specialization;
 }

--- a/clang/test/CXX/temp/temp.decls/temp.variadic/fixed-expansion.cpp
+++ b/clang/test/CXX/temp/temp.decls/temp.variadic/fixed-expansion.cpp
@@ -108,15 +108,15 @@ namespace PR9021b {
 
 namespace PartialSpecialization {
   template<typename T, typename U, typename V = U>
-  struct X0; // expected-note 2{{template is declared here}}
+  struct X0; // expected-note 4{{template is declared here}}
 
   template<typename ...Ts>
   struct X0<Ts...> { // expected-error {{class template partial specialization is not more specialized than the primary template}}
   };
 
   X0<int> x0i; // expected-error{{too few template arguments for class template 'X0'}}
-  X0<int, float> x0if;
-  X0<int, float, double> x0ifd;
+  X0<int, float> x0if; // expected-error {{implicit instantiation of undefined template 'PartialSpecialization::X0<int, float>'}}
+  X0<int, float, double> x0ifd; // expected-error {{implicit instantiation of undefined template 'PartialSpecialization::X0<int, float, double>'}}
 }
 
 namespace FixedAliasTemplate {

--- a/clang/test/SemaTemplate/partial-spec-not-more-specialized-invalid.cpp
+++ b/clang/test/SemaTemplate/partial-spec-not-more-specialized-invalid.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -std=c++20 -verify -emit-llvm-only %s
+// https://github.com/llvm/llvm-project/issues/181410
+
+template <int>
+struct integer_sequence {};
+
+template <int>
+struct array {};
+
+template <int*>
+struct MetaValuesHelper; // expected-note 2{{template is declared here}}
+
+template <typename TupleName, TupleName kValues>
+struct MetaValuesHelper<kValues> { // expected-error {{class template partial specialization is not more specialized than the primary template}}
+  template <int... Is>
+  static array<stdget<Is>(kValues)...> MetaValuesFunc(integer_sequence<Is...>);
+};
+
+int kBaseIndexRegistersUsed;
+
+array<0> u = decltype(MetaValuesHelper<&kBaseIndexRegistersUsed>::MetaValuesFunc(integer_sequence<0>{})){}; // expected-error {{implicit instantiation of undefined template 'MetaValuesHelper<&kBaseIndexRegistersUsed>'}}

--- a/clang/test/SemaTemplate/temp_arg_nontype.cpp
+++ b/clang/test/SemaTemplate/temp_arg_nontype.cpp
@@ -391,10 +391,7 @@ namespace partial_order_different_types {
   template<int N, typename T, typename U, T V> struct A<0, N, T, U, V> {}; // #P1
   template<int N, typename T, typename U, U V> struct A<0, N, T, U, V>;    // #P2
   // expected-error@-1 {{class template partial specialization is not more specialized than the primary template}}
-  A<0, 0, int, int, 0> a;
-  // expected-error@-1 {{ambiguous partial specializations}}
-  // expected-note@#P1 {{partial specialization matches}}
-  // expected-note@#P2 {{partial specialization matches}}
+  A<0, 0, int, int, 0> a; // OK: #P2 is invalid and excluded; only #P1 matches.
 }
 
 namespace partial_order_references {


### PR DESCRIPTION
Fix crash-on-invalid when a global variable's initializer remains value-dependent
due to error recovery from an invalid template partial specialization.

Fixes #181410

## Root cause

`checkMoreSpecializedThanPrimary()` emits `ext_partial_spec_not_more_specialized_than_primary`
but did not mark the partial specialization as invalid. Later,
`ActOnClassTemplateSpecialization()` unconditionally called
`Specialization->setInvalidDecl(Invalid)` where `Invalid` was `false` for partial
specializations, clearing any invalid flag set by `CheckTemplatePartialSpecialization`.

This caused the invalid partial specialization to still be selected during template
argument deduction. Instantiation through it produced `CXXUnresolvedConstructExpr`
in a non-dependent context, leading to:
```
assert(!Init->isValueDependent()) in VarDecl::evaluateValueImpl
```

## Fix

1. Add `Partial->setInvalidDecl()` in `checkMoreSpecializedThanPrimary()` after
   the diagnostic, so the partial specialization is excluded from deduction.
2. Change `ActOnClassTemplateSpecialization()` to only call `setInvalidDecl()`
   when `Invalid` is true, preventing it from clearing flags set earlier.

## Note

@zwuis pointed out a related crash where the partial specialization *is* valid
(`template <auto>` variant) but `CXXUnresolvedConstructExpr` still survives
instantiation. That appears to be a separate issue in template instantiation
itself; I'll file a separate bug for it.

AI tools were used to assist with root cause analysis and tracing the code paths
in this fix, per the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html).
