### PR TITLE
[WebKit Checkers] Trivial analysis should check destructors of function parameters and local variables

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/NoDeleteChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/NoDeleteChecker.cpp
@@ -92,7 +92,18 @@ public:
       return;
 
     auto Body = FD->getBody();
-    if (!Body || TFA.isTrivial(Body))
+    if (!Body)
+      return;
+
+    bool ParamHaveTrivialDtors = true;
+    for (auto* Param : FD->parameters()) {
+      if (!TFA.hasTrivialDtor(Param)) {
+        ParamHaveTrivialDtors = false;
+        break;
+      }
+    }
+
+    if (ParamHaveTrivialDtors && TFA.isTrivial(Body))
       return;
 
     SmallString<100> Buf;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/NoDeleteChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/NoDeleteChecker.cpp
@@ -95,15 +95,8 @@ public:
     if (!Body)
       return;
 
-    bool ParamHaveTrivialDtors = true;
-    for (auto *Param : FD->parameters()) {
-      if (!TFA.hasTrivialDtor(Param)) {
-        ParamHaveTrivialDtors = false;
-        break;
-      }
-    }
-
-    if (ParamHaveTrivialDtors && TFA.isTrivial(Body))
+    auto hasTrivialDtor = [&](VarDecl *D) { return TFA.hasTrivialDtor(D); };
+    if (llvm::all_of(FD->parameters(), hasTrivialDtor) && TFA.isTrivial(Body))
       return;
 
     SmallString<100> Buf;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/NoDeleteChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/NoDeleteChecker.cpp
@@ -96,7 +96,7 @@ public:
       return;
 
     bool ParamHaveTrivialDtors = true;
-    for (auto* Param : FD->parameters()) {
+    for (auto *Param : FD->parameters()) {
       if (!TFA.hasTrivialDtor(Param)) {
         ParamHaveTrivialDtors = false;
         break;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -516,7 +516,7 @@ class TrivialFunctionAnalysisVisitor
     return Result;
   }
 
-  bool CanTriviallyDestruct(const Type* T) {
+  bool CanTriviallyDestruct(const Type *T) {
     if (T->isIntegralOrEnumerationType())
       return true;
     if (isa<PointerType>(T) || T->isNullPtrType())
@@ -800,7 +800,7 @@ public:
     return IsFunctionTrivial(CE->getConstructor());
   }
 
-  bool VisitCXXDeleteExpr(const CXXDeleteExpr* DE) {
+  bool VisitCXXDeleteExpr(const CXXDeleteExpr *DE) {
     auto *Type = DE->getDestroyedType().getTypePtrOrNull();
     return Type && CanTriviallyDestruct(Type);
   }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -527,7 +527,7 @@ public:
         return true;
       if (FnDecl->isVirtualAsWritten())
         return false;
-      for (auto* Param : FnDecl->parameters()) {
+      for (auto *Param : FnDecl->parameters()) {
         if (!HasTrivialDestructor(Param))
           return false;
       }
@@ -545,7 +545,7 @@ public:
       return Visit(Body);
     });
   }
-  
+
   bool HasTrivialDestructor(const VarDecl *VD) {
     auto QT = VD->getType();
     if (QT.isPODType(VD->getASTContext()))
@@ -556,7 +556,7 @@ public:
     const CXXRecordDecl *R = Type->getAsCXXRecordDecl();
     if (!R) {
       if (isa<LValueReferenceType>(Type))
-          return true; // T& does not run its destructor.
+        return true; // T& does not run its destructor.
       if (auto *RT = dyn_cast<RValueReferenceType>(Type)) {
         // For T&&, we evaluate the destructor of T.
         QT = RT->getPointeeType();
@@ -572,8 +572,8 @@ public:
         Type = QT.getTypePtrOrNull();
         if (!Type)
           return false;
-        if (isa<PointerType>(Type)) // An array of pointer does not have a destructor.
-          return true;
+        if (isa<PointerType>(Type))
+          return true; // An array of pointers doesn't run a destructor.
         R = Type->getAsCXXRecordDecl();
       }
     }
@@ -623,7 +623,7 @@ public:
   }
 
   bool VisitDeclStmt(const DeclStmt *DS) {
-    for (auto& Decl : DS->decls()) {
+    for (auto &Decl : DS->decls()) {
       if (auto *VD = dyn_cast<VarDecl>(Decl)) {
         if (!HasTrivialDestructor(VD))
           return false;
@@ -782,7 +782,7 @@ public:
     return true;
   }
 
-  bool VisitCXXDefaultInitExpr(const CXXDefaultInitExpr* E) {
+  bool VisitCXXDefaultInitExpr(const CXXDefaultInitExpr *E) {
     return Visit(E->getExpr());
   }
 
@@ -912,8 +912,8 @@ bool TrivialFunctionAnalysis::isTrivialImpl(
   return V.IsStatementTrivial(S);
 }
 
-bool TrivialFunctionAnalysis::hasTrivialDtorImpl(
-    const VarDecl *VD, CacheTy &Cache) {
+bool TrivialFunctionAnalysis::hasTrivialDtorImpl(const VarDecl *VD,
+                                                 CacheTy &Cache) {
   TrivialFunctionAnalysisVisitor V(Cache);
   return V.HasTrivialDestructor(VD);
 }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -541,7 +541,7 @@ public:
       if (auto *FnDecl = dyn_cast<FunctionDecl>(D)) {
         if (isNoDeleteFunction(FnDecl))
           return true;
-        if (FnDecl->isVirtualAsWritten())
+        if (auto *MD = dyn_cast<CXXMethodDecl>(D); MD && MD->isVirtual())
           return false;
         for (auto *Param : FnDecl->parameters()) {
           if (!HasTrivialDestructor(Param))

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -522,8 +522,6 @@ class TrivialFunctionAnalysisVisitor
       return false;
     if (T->isIntegralOrEnumerationType())
       return true;
-    if (isa<PointerType>(T) || T->isNullPtrType())
-      return true;
     auto *R = T->getAsCXXRecordDecl();
     if (!R)
       return false;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
@@ -170,7 +170,7 @@ public:
   /// \returns true if \p D is a "trivial" function.
   bool isTrivial(const Decl *D) const { return isTrivialImpl(D, TheCache); }
   bool isTrivial(const Stmt *S) const { return isTrivialImpl(S, TheCache); }
-  bool hasTrivialDtor(const VarDecl* VD) const {
+  bool hasTrivialDtor(const VarDecl *VD) const {
     return hasTrivialDtorImpl(VD, TheCache);
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
@@ -28,6 +28,7 @@ class Stmt;
 class TranslationUnitDecl;
 class Type;
 class TypedefDecl;
+class VarDecl;
 
 // Ref-countability of a type is implicitly defined by Ref<T> and RefPtr<T>
 // implementation. It can be modeled as: type T having public methods ref() and
@@ -169,6 +170,9 @@ public:
   /// \returns true if \p D is a "trivial" function.
   bool isTrivial(const Decl *D) const { return isTrivialImpl(D, TheCache); }
   bool isTrivial(const Stmt *S) const { return isTrivialImpl(S, TheCache); }
+  bool hasTrivialDtor(const VarDecl* VD) const {
+    return hasTrivialDtorImpl(VD, TheCache);
+  }
 
 private:
   friend class TrivialFunctionAnalysisVisitor;
@@ -179,6 +183,7 @@ private:
 
   static bool isTrivialImpl(const Decl *D, CacheTy &Cache);
   static bool isTrivialImpl(const Stmt *S, CacheTy &Cache);
+  static bool hasTrivialDtorImpl(const VarDecl *VD, CacheTy &Cache);
 };
 
 } // namespace clang

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -227,12 +227,19 @@ template <typename T> bool operator!=(const RefPtr<T> &, T &) { return false; }
 struct RefCountable {
   static Ref<RefCountable> create();
   static std::unique_ptr<RefCountable> makeUnique();
-  void ref() {}
-  void deref() {}
+  void ref() { ++m_refCount; }
+  void deref() {
+    --m_refCount;
+    if (!--m_refCount)
+      delete this;
+  }
   void method();
   void constMethod() const;
   int trivial() { return 123; }
   RefCountable* next();
+  
+private:
+  unsigned m_refCount { 0 };
 };
 
 template <typename T> T *downcast(T *t) { return t; }
@@ -280,11 +287,14 @@ public:
 
 class CheckedObj {
 public:
-  void incrementCheckedPtrCount();
-  void decrementCheckedPtrCount();
+  void incrementCheckedPtrCount() { ++m_ptrCount; }
+  void decrementCheckedPtrCount() { --m_ptrCount; }
   void method();
   int trivial() { return 123; }
   CheckedObj* next();
+
+private:
+  unsigned m_ptrCount { 0 };
 };
 
 class RefCountableAndCheckable {

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -173,13 +173,34 @@ struct Data {
       delete this;
   }
 
+  virtual void doSomething() { }
+
   int a[3] { 0 };
   
+protected:
+  Data() = default;
+
 private:
   unsigned refCount { 0 };
+};
+
+struct SubData : Data {
+  static Ref<SubData> create() {
+    return adoptRef(*new SubData);
+  }
+
+  void doSomething() override { }
+
+private:
+  SubData() = default;
 };
 
 void [[clang::annotate_type("webkit.nodelete")]] makeData() {
   RefPtr<Data> constantData[2] = { Data::create() };
   RefPtr<Data> data[] = { Data::create() };
+}
+
+void [[clang::annotate_type("webkit.nodelete")]] makeSubData() {
+  // expected-warning@-1{{A function 'makeSubData' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+  SubData::create()->doSomething();
 }

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -103,6 +103,12 @@ public:
     // expected-warning@-1{{A function 'deposeArgPtr' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
   }
 
+  enum class E : unsigned char { V1, V2 };
+  bool [[clang::annotate_type("webkit.nodelete")]] deposeArgEnum() {
+    E&& e = E::V1;
+    return e != E::V2;
+  }
+
   void [[clang::annotate_type("webkit.nodelete")]] deposeLocal() {
     // expected-warning@-1{{A function 'deposeLocal' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
     RefPtr<RefCountable> obj = std::move(m_obj);

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -51,6 +51,7 @@ private:
 
 class SomeClass {
 public:
+
   void [[clang::annotate_type("webkit.nodelete")]] someMethod();
   void [[clang::annotate_type("webkit.nodelete")]] unsafeMethod() {
     // expected-warning@-1{{A function 'unsafeMethod' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
@@ -124,6 +125,11 @@ public:
 
   RefPtr<WeakRefCountable> [[clang::annotate_type("webkit.nodelete")]] getWeakPtr() {
     return m_weakObj.get();
+  }
+
+  WeakRefCountable* [[clang::annotate_type("webkit.nodelete")]] useWeakPtr() {
+    WeakPtr localWeak = m_weakObj.get();
+    return localWeak.get();
   }
 
 private:

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -63,7 +63,12 @@ void foo4() {
 void foo5() {
   RefPtr<RefCountable> foo;
   auto* bar = foo.get();
+  // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
   bar->trivial();
+  {
+    auto* baz = foo.get();
+    baz->trivial();
+  }
 }
 
 void foo6() {

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -26,6 +26,7 @@ void foo_ref() {
 void foo_ref_trivial() {
   RefCountable automatic;
   RefCountable &bar = automatic;
+  // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
 }
 
 void bar_ref(RefCountable &) {}


### PR DESCRIPTION
This PR fixes the bug in TrivialFunctionAnalysisVisitor that it wasn't checking the triviality of destructors of function parameters and local variables. This meant that code calls a non-trivial desturctors such as RefPtr<T>::~RefPtr<T> which calls T::~T to be incorrectly treated as trivial, resulting in false negatives.

To do this, we manually visit every function parameter and local variable declaration and check the triviality of its destructor recursively.

Also fix a bug that we were checking isVirtualAsWritten instead of isVirtual in IsFunctionTrivial.