### PR TITLE
[NFC][X86] Pass ConstantInt for step size in createLoop

### DIFF
--- a/llvm/lib/Target/X86/X86LowerAMXIntrinsics.cpp
+++ b/llvm/lib/Target/X86/X86LowerAMXIntrinsics.cpp
@@ -71,7 +71,7 @@ private:
   DomTreeUpdater &DTU;
   LoopInfo *LI;
   BasicBlock *createLoop(BasicBlock *Preheader, BasicBlock *Exit, Value *Bound,
-                         Value *Step, StringRef Name, IRBuilderBase &B,
+                         ConstantInt *Step, StringRef Name, IRBuilderBase &B,
                          Loop *L);
   template <bool IsTileLoad>
   Value *createTileLoadStoreLoops(BasicBlock *Start, BasicBlock *End,
@@ -103,7 +103,7 @@ private:
 
 BasicBlock *X86LowerAMXIntrinsics::createLoop(BasicBlock *Preheader,
                                               BasicBlock *Exit, Value *Bound,
-                                              Value *Step, StringRef Name,
+                                              ConstantInt *Step, StringRef Name,
                                               IRBuilderBase &B, Loop *L) {
   LLVMContext &Ctx = Preheader->getContext();
   BasicBlock *Header =


### PR DESCRIPTION
createLoop is always called with a constant step size. Propagate the
type information so that it can be used later when deriving profile
information when possible.
