### PR TITLE
[Clang][Parse] Fix crash on stmt-expr ending with 'extern void;'

### DIFF
--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -76,8 +76,11 @@ StmtResult Sema::ActOnDeclStmt(DeclGroupPtrTy dg, SourceLocation StartLoc,
                                SourceLocation EndLoc) {
   DeclGroupRef DG = dg.get();
 
-  // If we have an invalid decl, just return an error.
-  if (DG.isNull()) return StmtError();
+  if (DG.isNull()) {
+    if (!getDiagnostics().hasErrorOccurred())
+      return StmtEmpty();
+    return StmtError();
+  }
 
   return new (Context) DeclStmt(DG, StartLoc, EndLoc);
 }

--- a/clang/test/Sema/stmt-expr-void.c
+++ b/clang/test/Sema/stmt-expr-void.c
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -emit-llvm-only -verify %s
+
+void test_benign_null_declgroup(void) {
+    // expected-warning@+1 {{declaration does not declare anything}}
+    (void)({ extern void; });
+}
+
+extern int bar(int); // expected-note {{passing argument to parameter here}}
+
+int foo(int x) {
+  // expected-error@+1 {{passing 'void' to parameter of incompatible type 'int'}}
+  return 1 + bar(({
+    switch (x) { default: break; }
+    // expected-warning@+1 {{declaration does not declare anything}}
+    extern void;
+  }));
+}


### PR DESCRIPTION
When a benign empty declaration like extern void; is parsed, it doesn't log any hard errors but produces a null because no variables are actually declared. Historically, `Sema::ActOnDeclStmt` unconditionally returned `StmtError() `for a null group. When this happens inside a statement expression, the Parser is misled into thinking the expression is structurally broken and wraps it in a RecoveryExpr with a dependent type. Since no actual hard errors were ever emitted to the user, the compilation continues, and CodeGen eventually crashes when it tries to translate that RecoveryExpr.


Fix:
Refined the logic in `Sema::ActOnDeclStmt`. If we get a null DeclGroup but no actual errors have occurred globally `(!getDiagnostics().hasErrorOccurred())`, we now simply return a `StmtEmpty()` instead of `StmtError().`


Reproducer:
```
extern int bar(int);
int foo(int x) {
  return 1 + bar(({
    switch (x) { default: break; }
    extern void;
  }));
}
```

**Before:** crash with UNREACHABLE executed at CodeGenTypes.cpp: Unexpected placeholder builtin type! **After:** clean semantic error passing 'void' to parameter of incompatible type 'int'

LLVM policy:
The base minimal test `test_benign_null_declgroup` and the fix code were generated using AI (Gemini 3.1) for convenience, but the analysis and intervention were entirely human-led.
