### PR TITLE
[clang-doc] Add button toggle for light/dark theme

### DIFF
--- a/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
+++ b/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
@@ -1,7 +1,7 @@
 /* css for clang-doc mustache backend */
 @import "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap";
 
-*,*::before *::after {
+*,*::before, *::after {
     box-sizing:border-box
 }
 * {
@@ -88,6 +88,7 @@ html, body {
     margin: 0;
     padding: 0;
     width: 100%;
+    overflow-x: scroll;
 }
 
 .container {
@@ -177,6 +178,13 @@ header {
     margin-left:0;
     grid-column:2;
     justify-self:center
+}
+
+#theme-toggle {
+    grid-column: 3;
+    justify-self: end;
+    color: var(--text1);
+    border: none;
 }
 
 @media(max-width:768px) {

--- a/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
+++ b/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
@@ -180,7 +180,7 @@ header {
     justify-self:center
 }
 
-#theme-toggle {
+#themeToggle {
     grid-column: 3;
     justify-self: end;
     color: var(--text1);

--- a/clang-tools-extra/clang-doc/assets/head-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/head-template.mustache
@@ -8,8 +8,9 @@
         <script src="{{.}}"></script>
     {{/Scripts}}
     {{! Highlight.js dependency for syntax highlighting }}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" media="(prefers-color-scheme: light)">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/dark.min.css" media="(prefers-color-scheme: dark)">
+    <link id="hljs-light-theme" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" />
+    <link id="hljs-dark-theme" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/dark.min.css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=routine" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/cpp.min.js"></script>
 </head>

--- a/clang-tools-extra/clang-doc/assets/head-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/head-template.mustache
@@ -10,6 +10,51 @@
     {{! Highlight.js dependency for syntax highlighting }}
     <link id="hljs-light-theme" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" />
     <link id="hljs-dark-theme" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/dark.min.css" />
+    <script>
+      const root = document.documentElement;
+      const toggle = document.getElementById("theme-toggle");
+      const hlLight = document.getElementById("hljs-light-theme");
+      const hlDark = document.getElementById("hljs-dark-theme");
+
+      function changeHighlightJS(theme) {
+        if (theme === "dark") {
+          hlDark.disabled = false;
+          hlLight.disabled = true;
+        } else {
+          hlDark.disabled = true;
+          hlLight.disabled = false;
+        }
+      }
+
+      const savedTheme = localStorage.getItem("theme");
+      const themeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+      if (savedTheme !== null) {
+        root.setAttribute("color-scheme", savedTheme);
+        changeHighlightJS(savedTheme);
+      } else {
+        let initialTheme;
+        if (themeQuery.matches) {
+          initialTheme = "dark";
+        } else {
+          initialTheme = "light";
+        }
+        root.setAttribute("color-scheme", initialTheme);
+        changeHighlightJS(initialTheme);
+      }
+
+      // Listen to system theme changes.
+      // If the user manually toggles the theme, the theme wont change according
+      // to system changes.
+      themeQuery.addEventListener("change", (event) => {
+        if (savedTheme === null) {
+          return;
+        } else if (event.matches) {
+          changeHighlightJS("dark");
+        } else {
+          changeHighlightJS("light");
+        }
+      });
+    </script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=routine" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/cpp.min.js"></script>

--- a/clang-tools-extra/clang-doc/assets/head-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/head-template.mustache
@@ -1,6 +1,15 @@
 <head>
     <meta charset="utf-8"/>
     <title>{{Name}}</title>
+    <script data-cfasync="false">
+      (function() {
+        const root = document.documentElement;
+        const savedTheme = localStorage.getItem("theme");
+        const theme = savedTheme || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+        root.setAttribute("color-scheme", theme);
+        window.__clangDocTheme = theme;
+      })();
+    </script>
     {{#Stylesheets}}
         <link rel="stylesheet" type="text/css" href="{{.}}"/>
     {{/Stylesheets}}
@@ -12,7 +21,6 @@
     <link id="hljs-dark-theme" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/dark.min.css" />
     <script>
       const root = document.documentElement;
-      const toggle = document.getElementById("theme-toggle");
       const hlLight = document.getElementById("hljs-light-theme");
       const hlDark = document.getElementById("hljs-dark-theme");
 
@@ -26,33 +34,19 @@
         }
       }
 
-      const savedTheme = localStorage.getItem("theme");
+      changeHighlightJS(window.__clangDocTheme);
       const themeQuery = window.matchMedia("(prefers-color-scheme: dark)");
-      if (savedTheme !== null) {
-        root.setAttribute("color-scheme", savedTheme);
-        changeHighlightJS(savedTheme);
-      } else {
-        let initialTheme;
-        if (themeQuery.matches) {
-          initialTheme = "dark";
-        } else {
-          initialTheme = "light";
-        }
-        root.setAttribute("color-scheme", initialTheme);
-        changeHighlightJS(initialTheme);
-      }
-
       // Listen to system theme changes.
       // If the user manually toggles the theme, the theme wont change according
       // to system changes.
       themeQuery.addEventListener("change", (event) => {
-        if (savedTheme === null) {
+        if (localStorage.getItem("theme") !== null) {
           return;
-        } else if (event.matches) {
-          changeHighlightJS("dark");
-        } else {
-          changeHighlightJS("light");
         }
+
+        const theme = event.matches ? "dark" : "light";
+        root.setAttribute("color-scheme", theme);
+        changeHighlightJS(theme);
       });
     </script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=routine" />

--- a/clang-tools-extra/clang-doc/assets/navbar-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/navbar-template.mustache
@@ -12,6 +12,7 @@
                 </li>
             </ul>
         </div>
+        <button id="theme-toggle"><span class="material-symbols-rounded">routine</span></button>
     </div>
     {{#HasContexts}}
     <div class="navbar-breadcrumb-container">
@@ -21,3 +22,53 @@
     </div>
     {{/HasContexts}}
 </nav>
+<script>
+    const root = document.documentElement;
+    const toggle = document.getElementById("theme-toggle");
+    const hlLight = document.getElementById("hljs-light-theme");
+    const hlDark = document.getElementById("hljs-dark-theme");
+
+    function changeHighlightJS(theme) {
+      if (theme === "dark") {
+        hlDark.disabled = false;
+        hlLight.disabled = true;
+      } else {
+        hlDark.disabled = true;
+        hlLight.disabled = false;
+      }
+    }
+
+    // Listen to system theme changes.
+    // If the user manually toggles the theme, the theme wont change according
+    // to system changes.
+    const themeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    themeQuery.addEventListener("change", (event) => {
+      if (savedTheme === null) {
+        return;
+      } else if (event.matches) {
+        changeHighlightJS("dark");
+      } else {
+        changeHighlightJS("light");
+      }
+    });
+
+    toggle.onclick = () => {
+      const currentTheme = root.getAttribute("color-scheme");
+      const next = currentTheme === "dark" ? "light" : "dark";
+      changeHighlightJS(next);
+      root.setAttribute("color-scheme", next);
+      localStorage.setItem("theme", next);
+    };
+
+    document.addEventListener("DOMContentLoaded", () => {
+      const savedTheme = localStorage.getItem("theme");
+      const currentTheme = root.getAttribute("color-scheme");
+      if (savedTheme !== null) {
+        root.setAttribute("color-scheme", savedTheme);
+        changeHighlightJS(savedTheme);
+      } else {
+        root.setAttribute("color-scheme", currentTheme);
+        changeHighlightJS(currentTheme);
+      }
+    });
+</script>

--- a/clang-tools-extra/clang-doc/assets/navbar-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/navbar-template.mustache
@@ -12,7 +12,7 @@
                 </li>
             </ul>
         </div>
-        <button id="theme-toggle"><span class="material-symbols-rounded">routine</span></button>
+        <button id="themeToggle"><span class="material-symbols-rounded">routine</span></button>
     </div>
     {{#HasContexts}}
     <div class="navbar-breadcrumb-container">
@@ -23,52 +23,11 @@
     {{/HasContexts}}
 </nav>
 <script>
-    const root = document.documentElement;
-    const toggle = document.getElementById("theme-toggle");
-    const hlLight = document.getElementById("hljs-light-theme");
-    const hlDark = document.getElementById("hljs-dark-theme");
-
-    function changeHighlightJS(theme) {
-      if (theme === "dark") {
-        hlDark.disabled = false;
-        hlLight.disabled = true;
-      } else {
-        hlDark.disabled = true;
-        hlLight.disabled = false;
-      }
-    }
-
-    // Listen to system theme changes.
-    // If the user manually toggles the theme, the theme wont change according
-    // to system changes.
-    const themeQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    themeQuery.addEventListener("change", (event) => {
-      if (savedTheme === null) {
-        return;
-      } else if (event.matches) {
-        changeHighlightJS("dark");
-      } else {
-        changeHighlightJS("light");
-      }
-    });
-
-    toggle.onclick = () => {
+    themeToggle.onclick = () => {
       const currentTheme = root.getAttribute("color-scheme");
       const next = currentTheme === "dark" ? "light" : "dark";
       changeHighlightJS(next);
       root.setAttribute("color-scheme", next);
       localStorage.setItem("theme", next);
     };
-
-    document.addEventListener("DOMContentLoaded", () => {
-      const savedTheme = localStorage.getItem("theme");
-      const currentTheme = root.getAttribute("color-scheme");
-      if (savedTheme !== null) {
-        root.setAttribute("color-scheme", savedTheme);
-        changeHighlightJS(savedTheme);
-      } else {
-        root.setAttribute("color-scheme", currentTheme);
-        changeHighlightJS(currentTheme);
-      }
-    });
 </script>

--- a/clang-tools-extra/test/clang-doc/basic-project.mustache.test
+++ b/clang-tools-extra/test/clang-doc/basic-project.mustache.test
@@ -28,7 +28,8 @@ HTML-SHAPE:                     <a href="../index.html" class="navbar__link">Hom
 HTML-SHAPE:           <div class="navbar-breadcrumb-container">
 HTML-SHAPE-NEXT:          <a href="./index.html"><div class="navbar-breadcrumb-item">Global Namespace</div></a>
 HTML-SHAPE:       </nav>
-HTML-SHAPE-NEXT: </header>
+HTML-SHAPE-NEXT: <script>
+HTML-SHAPE:      </header>
 HTML-SHAPE-LABEL:<main>
 HTML-SHAPE-NEXT:    <div class="container">
 HTML-SHAPE-NEXT:         <div class="sidebar">
@@ -126,7 +127,8 @@ HTML-CALC:                     <a href="../index.html" class="navbar__link">Home
 HTML-CALC:           <div class="navbar-breadcrumb-container">
 HTML-CALC-NEXT:          <a href="./index.html"><div class="navbar-breadcrumb-item">Global Namespace</div></a>
 HTML-CALC:       </nav>
-HTML-CALC-NEXT: </header>
+HTML-CALC-NEXT: <script>
+HTML-CALC:      </header>
 HTML-CALC-LABEL:<main>
 HTML-CALC-NEXT:     <div class="container">
 HTML-CALC-NEXT:         <div class="sidebar">
@@ -331,7 +333,8 @@ HTML-RECTANGLE:                     <a href="../index.html" class="navbar__link"
 HTML-RECTANGLE:           <div class="navbar-breadcrumb-container">
 HTML-RECTANGLE-NEXT:          <a href="./index.html"><div class="navbar-breadcrumb-item">Global Namespace</div></a>
 HTML-RECTANGLE:       </nav>
-HTML-RECTANGLE-NEXT: </header>
+HTML-RECTANGLE-NEXT: <script>
+HTML-RECTANGLE:      </header>
 HTML-RECTANGLE-LABEL:<main>
 HTML-RECTANGLE-NEXT:    <div class="container">
 HTML-RECTANGLE-NEXT:         <div class="sidebar">
@@ -436,7 +439,8 @@ HTML-CIRCLE:                     <a href="../index.html" class="navbar__link">Ho
 HTML-CIRCLE:           <div class="navbar-breadcrumb-container">
 HTML-CIRCLE-NEXT:          <a href="./index.html"><div class="navbar-breadcrumb-item">Global Namespace</div></a>
 HTML-CIRCLE:       </nav>
-HTML-CIRCLE-NEXT: </header>
+HTML-CIRCLE-NEXT: <script>
+HTML-CIRCLE:      </header>
 HTML-CIRCLE-LABEL:<main>
 HTML-CIRCLE-NEXT:     <div class="container">
 HTML-CIRCLE-NEXT:         <div class="sidebar">


### PR DESCRIPTION
The user can now manually toggle the light or dark theme instead of waiting for the system theme to change.

Also fixes a typo that caused some overflow issues even when there was no content to cause an overflow.