### PR TITLE
[Demangle] Prevent Node::Kind from being overwritten by copy/move assignment

### DIFF
--- a/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
+++ b/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
@@ -278,6 +278,11 @@ struct Node {
   explicit Node(NodeKind K) : Kind(K) {}
   virtual ~Node() = default;
 
+  // Kind represents the node's dynamic type and must not be overwritten by
+  // copy/move assignment (e.g. when slicing a derived node into a base).
+  Node &operator=(const Node &) { return *this; }
+  Node &operator=(Node &&) { return *this; }
+
   NodeKind kind() const { return Kind; }
 
   virtual void output(OutputBuffer &OB, OutputFlags Flags) const = 0;

--- a/llvm/lib/Demangle/MicrosoftDemangle.cpp
+++ b/llvm/lib/Demangle/MicrosoftDemangle.cpp
@@ -1983,6 +1983,9 @@ Demangler::demangleFunctionEncoding(std::string_view &MangledName) {
     return nullptr;
 
   if (TTN) {
+    // Copy the FunctionSignatureNode fields into the ThunkSignatureNode.
+    // Node::operator= intentionally does not copy Kind, so TTN retains its
+    // ThunkSignature kind through this slice assignment.
     *static_cast<FunctionSignatureNode *>(TTN) = *FSN;
     FSN = TTN;
   }

--- a/llvm/unittests/Demangle/CMakeLists.txt
+++ b/llvm/unittests/Demangle/CMakeLists.txt
@@ -7,6 +7,7 @@ add_llvm_unittest(DemangleTests
   DemangleTest.cpp
   DLangDemangleTest.cpp
   ItaniumDemangleTest.cpp
+  MicrosoftDemangleTest.cpp
   OutputBufferTest.cpp
   PartialDemangleTest.cpp
   RustDemangleTest.cpp

--- a/llvm/unittests/Demangle/MicrosoftDemangleTest.cpp
+++ b/llvm/unittests/Demangle/MicrosoftDemangleTest.cpp
@@ -1,0 +1,37 @@
+//===-- MicrosoftDemangleTest.cpp -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Demangle/MicrosoftDemangle.h"
+#include "llvm/Demangle/MicrosoftDemangleNodes.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::ms_demangle;
+
+// After demangling a thunk function, the Signature node should retain
+// NodeKind::ThunkSignature. A base-class slice assignment in
+// demangleFunctionEncoding() currently overwrites the Kind field,
+// causing it to become NodeKind::FunctionSignature instead.
+TEST(MicrosoftDemangle, ThunkSignaturePreservesNodeKind) {
+  // ?f@C@@WBA@EAAHXZ demangles to:
+  //   [thunk]: public: virtual int __cdecl C::f`adjustor{16}'(void)
+  // 'W' = FC_Public | FC_Virtual | FC_StaticThisAdjust
+  Demangler D;
+  std::string_view MangledName = "?f@C@@WBA@EAAHXZ";
+  SymbolNode *S = D.parse(MangledName);
+  ASSERT_FALSE(D.Error);
+  ASSERT_NE(S, nullptr);
+  ASSERT_EQ(S->kind(), NodeKind::FunctionSymbol);
+
+  auto *FSN = static_cast<FunctionSymbolNode *>(S);
+  ASSERT_NE(FSN->Signature, nullptr);
+
+  // This is the key assertion: the signature must identify as a
+  // ThunkSignature, not a plain FunctionSignature.
+  EXPECT_EQ(FSN->Signature->kind(), NodeKind::ThunkSignature);
+}


### PR DESCRIPTION
In `Demangler::demangleFunctionEncoding`, a `ThunkSignatureNode` is populated by slice-copying a `FunctionSignatureNode` into it. The default copy assignment operator copies all base class fields including the private `Node::Kind`, which changes the node's kind from `ThunkSignature` to `FunctionSignature`.

Fix this by defining custom copy/move assignment operators for `Node` that preserve `Kind`. This field represents the node's dynamic type and should never be overwritten by assignment.