### PR TITLE
[lldb/docs] Add Scripted Symbol Locator to website documentation

### DIFF
--- a/lldb/docs/CMakeLists.txt
+++ b/lldb/docs/CMakeLists.txt
@@ -33,6 +33,7 @@ if (LLDB_ENABLE_PYTHON AND SPHINX_FOUND)
       COMMAND "${CMAKE_COMMAND}" -E copy "${LLDB_SOURCE_DIR}/examples/python/templates/scripted_platform.py" "${CMAKE_CURRENT_BINARY_DIR}/lldb/plugins/"
       COMMAND "${CMAKE_COMMAND}" -E copy "${LLDB_SOURCE_DIR}/examples/python/templates/operating_system.py" "${CMAKE_CURRENT_BINARY_DIR}/lldb/plugins/"
       COMMAND "${CMAKE_COMMAND}" -E copy "${LLDB_SOURCE_DIR}/examples/python/templates/scripted_thread_plan.py" "${CMAKE_CURRENT_BINARY_DIR}/lldb/plugins/"
+      COMMAND "${CMAKE_COMMAND}" -E copy "${LLDB_SOURCE_DIR}/examples/python/templates/scripted_symbol_locator.py" "${CMAKE_CURRENT_BINARY_DIR}/lldb/plugins/"
       COMMENT "Copying lldb.py to pretend its a Python package.")
 
     add_dependencies(lldb-python-doc-package swig_wrapper_python)

--- a/lldb/docs/python_extensions.rst
+++ b/lldb/docs/python_extensions.rst
@@ -45,3 +45,10 @@ Scripted Thread Plan Plugins
     :no-heading:
     :no-inheritance-diagram:
 
+Scripted Symbol Locator Plugins
+-------------------------------
+
+.. automodapi:: lldb.plugins.scripted_symbol_locator
+    :no-heading:
+    :skip: ABCMeta, LocalCacheSymbolLocator
+    :no-inheritance-diagram:

--- a/lldb/docs/use/python-reference.rst
+++ b/lldb/docs/use/python-reference.rst
@@ -28,4 +28,4 @@ The following tutorials and documentation demonstrate various Python capabilitie
    tutorials/implementing-standalone-scripts
    tutorials/custom-frame-recognizers
    tutorials/extending-target-stop-hooks
-   tutorials/scripted-symbol-locator
+   tutorials/hunting-down-symbols

--- a/lldb/docs/use/tutorials/hunting-down-symbols.md
+++ b/lldb/docs/use/tutorials/hunting-down-symbols.md
@@ -1,4 +1,4 @@
-# Scripted Symbol Locator Tutorial
+# Hunting down symbols with Scripted Symbol Locator
 
 The **Scripted Symbol Locator** lets you write a Python class that tells LLDB
 where to find executables, symbol files, and source files for your debug


### PR DESCRIPTION
This patch adds documentation for the Scripted Symbol Locator plugin system, including tutorial (renamed to hunting-down-symbols.md to match other tutorial naming conventions) and cleans up API reference for the website.