### PR TITLE
[ClangLinkerWrapper] Remove OPT_linker_arg_EQ and OPT_compiler_arg_EQ options from ClangLinkerWrapper

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -876,7 +876,7 @@ DerivedArgList getLinkerArgs(ArrayRef<OffloadFile> Input,
   for (Arg *A : Args) {
     if (!A->getOption().matches(OPT_device_linker_args_EQ) &&
         !A->getOption().matches(OPT_device_compiler_args_EQ))
-        DAL.append(A);
+      DAL.append(A);
   }
 
   // Set the subarchitecture and target triple for this compilation.

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -79,12 +79,6 @@ def triple_EQ : Joined<["--"], "triple=">,
 def whole_program : Flag<["--"], "whole-program">,
   Flags<[DeviceOnlyOption, HelpHidden]>,
   HelpText<"LTO has visibility of all input files">;
-def linker_arg_EQ : Joined<["--"], "linker-arg=">,
-  Flags<[DeviceOnlyOption, HelpHidden]>,
-  HelpText<"An extra argument to be passed to the linker">;
-def compiler_arg_EQ : Joined<["--"], "compiler-arg=">,
-  Flags<[DeviceOnlyOption, HelpHidden]>,
-  HelpText<"An extra argument to be passed to the compiler">;
 
 // Arguments for the LLVM backend.
 def mllvm : Separate<["-"], "mllvm">, Flags<[WrapperOnlyOption]>,


### PR DESCRIPTION
This patch removes the use of `OPT_compiler_arg_EQ` and `OPT_linker_arg_EQ` in `clang-linker-wrapper`. The following changes are made:
1. Use `OPT_device_compiler_args_EQ` and `OPT_device_linker_args_EQ` to store parsed compiler and linker options in `ClangLinkerWrapper.cpp`, replacing `OPT_compiler_arg_EQ` and `OPT_linker_arg_EQ`.
2. Remove `OPT_compiler_arg_EQ` and `OPT_linker_arg_EQ` from `LinkerWrapperOpts.td`.