### PR TITLE
[OpenCL] Suppress -Wreturn-stack-address for function-scope local variable

### DIFF
--- a/clang/lib/Sema/CheckExprLifetime.cpp
+++ b/clang/lib/Sema/CheckExprLifetime.cpp
@@ -1337,6 +1337,13 @@ checkExprLifetimeImpl(Sema &SemaRef, const InitializedEntity *InitEntity,
         // expression.
         if (LK == LK_StmtExprResult)
           return false;
+        if (auto *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
+          if (VD->getType().getAddressSpace() == LangAS::opencl_local &&
+              SemaRef.getOpenCLOptions().isAvailableOption(
+                  "__cl_clang_function_scope_local_variables",
+                  SemaRef.getLangOpts()))
+            return false;
+        }
         SemaRef.Diag(DiagLoc, diag::warn_ret_stack_addr_ref)
             << InitEntity->getType()->isReferenceType() << DRE->getDecl()
             << isa<ParmVarDecl>(DRE->getDecl()) << (LK == LK_MustTail)

--- a/clang/lib/Sema/CheckExprLifetime.cpp
+++ b/clang/lib/Sema/CheckExprLifetime.cpp
@@ -1337,13 +1337,9 @@ checkExprLifetimeImpl(Sema &SemaRef, const InitializedEntity *InitEntity,
         // expression.
         if (LK == LK_StmtExprResult)
           return false;
-        if (auto *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
-          if (VD->getType().getAddressSpace() == LangAS::opencl_local &&
-              SemaRef.getOpenCLOptions().isAvailableOption(
-                  "__cl_clang_function_scope_local_variables",
-                  SemaRef.getLangOpts()))
+        if (auto *VD = dyn_cast<VarDecl>(DRE->getDecl()))
+          if (VD->getType().getAddressSpace() == LangAS::opencl_local)
             return false;
-        }
         SemaRef.Diag(DiagLoc, diag::warn_ret_stack_addr_ref)
             << InitEntity->getType()->isReferenceType() << DRE->getDecl()
             << isa<ParmVarDecl>(DRE->getDecl()) << (LK == LK_MustTail)

--- a/clang/test/SemaOpenCL/function-scope-local-return.cl
+++ b/clang/test/SemaOpenCL/function-scope-local-return.cl
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=CL3.0
+
+// Check returning a pointer to a local address space variable does not warn
+// if __cl_clang_function_scope_local_variables extension is enabled.
+
+// expected-no-diagnostics
+
+#pragma OPENCL EXTENSION __cl_clang_function_scope_local_variables : enable
+
+local int* get_group_scratch() {
+  local int data[64];
+  return data;
+}

--- a/clang/test/SemaOpenCL/function-scope-local-return.cl
+++ b/clang/test/SemaOpenCL/function-scope-local-return.cl
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=CL3.0
 
-// Check tjat returning a pointer to a local address space variable does not
+// Check that returning a pointer to a local address space variable does not
 // trigger -Wreturn-stack-address.
 
 // expected-no-diagnostics

--- a/clang/test/SemaOpenCL/function-scope-local-return.cl
+++ b/clang/test/SemaOpenCL/function-scope-local-return.cl
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=CL3.0
 
-// Check returning a pointer to a local address space variable does not warn
-// if __cl_clang_function_scope_local_variables extension is enabled.
+// Check tjat returning a pointer to a local address space variable does not
+// trigger -Wreturn-stack-address.
 
 // expected-no-diagnostics
 


### PR DESCRIPTION
OpenCL local variable has lifetime of work-group, not function call stack.