### PR TITLE
[MemCpyOptimizer] Prevent Merging a Store Into Memset of an `undef`

### DIFF
--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -411,8 +411,10 @@ Instruction *MemCpyOptPass::tryMergingIntoMemset(Instruction *StartInst,
 
       // Check to see if this stored value is of the same byte-splattable value.
       Value *StoredByte = isBytewiseValue(StoredVal, DL);
-      if (isa<UndefValue>(ByteVal) && StoredByte)
-        ByteVal = StoredByte;
+      // We can blindly merge this store into `StartInst` if it's being filled
+      // with an undef value but we don't because:
+      // 1. `StartInst` can be removed since it's storing an `undef`.
+      // 2. The resulting memset will be much larger than it needs to be.
       if (ByteVal != StoredByte)
         break;
 

--- a/llvm/test/Transforms/MemCpyOpt/memcpy.ll
+++ b/llvm/test/Transforms/MemCpyOpt/memcpy.ll
@@ -8,6 +8,7 @@ target triple = "i686-apple-darwin9"
 %1 = type { i32, i32 }
 
 @C = external constant [0 x i8]
+@undef = private constant [4000 x i8] undef, align 4
 
 declare void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) nocapture, ptr nocapture, i64, i1) nounwind
 declare void @llvm.memcpy.p0.p1.i64(ptr nocapture, ptr addrspace(1) nocapture, i64, i1) nounwind
@@ -923,6 +924,22 @@ define void @test(ptr noalias writable dereferenceable(4) %p) {
   call void @llvm.memcpy(ptr align 4 %p, ptr %a, i64 4, i1 false)
   ret void
 }
+
+; MemCpyOptimizer need not merge a store into a memset of undef value since
+; it will be removed by subsequent passes.
+define void @prevent_memsetting_a_undef_store(ptr %result) {
+; CHECK-LABEL: @prevent_memsetting_a_undef_store(
+; CHECK-NEXT:    [[RESULT_4000:%.*]] = getelementptr inbounds nuw i8, ptr [[RESULT:%.*]], i64 4000
+; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr [[RESULT]], i8 0, i64 4008, i1 false)
+; CHECK-NEXT:    ret void
+;
+  call void @llvm.memcpy.p0.p0.i64(ptr %result, ptr @undef, i64 4000, i1 false)
+  %result.4000 = getelementptr inbounds nuw i8, ptr %result, i64 4000
+  store i64 0, ptr %result.4000, align 8
+  ret void
+}
+
+
 
 !0 = !{!0}
 !1 = !{!1, !0}

--- a/llvm/test/Transforms/MemCpyOpt/memcpy.ll
+++ b/llvm/test/Transforms/MemCpyOpt/memcpy.ll
@@ -929,8 +929,9 @@ define void @test(ptr noalias writable dereferenceable(4) %p) {
 ; it will be removed by subsequent passes.
 define void @prevent_memsetting_a_undef_store(ptr %result) {
 ; CHECK-LABEL: @prevent_memsetting_a_undef_store(
-; CHECK-NEXT:    [[RESULT_4000:%.*]] = getelementptr inbounds nuw i8, ptr [[RESULT:%.*]], i64 4000
-; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr [[RESULT]], i8 0, i64 4008, i1 false)
+; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr [[RESULT:%.*]], i8 undef, i64 4000, i1 false)
+; CHECK-NEXT:    [[RESULT_4000:%.*]] = getelementptr inbounds nuw i8, ptr [[RESULT]], i64 4000
+; CHECK-NEXT:    store i64 0, ptr [[RESULT_4000]], align 8
 ; CHECK-NEXT:    ret void
 ;
   call void @llvm.memcpy.p0.p0.i64(ptr %result, ptr @undef, i64 4000, i1 false)


### PR DESCRIPTION
MemCopyOptimizer was merging a store instruction into a memset of an
`undef` value and emitted a large memset for the memset and store combined.

This PR prevents MemCopyOptimizer from merging a store instruction into a
memset of an `undef` value since it can be removed by subsequent cleanup
passes.

Helps https://github.com/rust-lang/rust/issues/152541