### PR TITLE
[DDG][NFC] Colorize DDG dot graph

### DIFF
--- a/llvm/include/llvm/Analysis/DDGPrinter.h
+++ b/llvm/include/llvm/Analysis/DDGPrinter.h
@@ -64,6 +64,10 @@ struct DOTGraphTraits<const DataDependenceGraph *>
   /// will be printed when their containing pi-block is being printed.
   bool isNodeHidden(const DDGNode *Node, const DataDependenceGraph *G);
 
+  /// Return DOT attributes for a node (e.g. border and fill for pi-blocks).
+  static std::string getNodeAttributes(const DDGNode *Node,
+                                       const DataDependenceGraph *G);
+
 private:
   /// Print a DDG node in concise form.
   static std::string getSimpleNodeLabel(const DDGNode *Node,

--- a/llvm/lib/Analysis/DDGPrinter.cpp
+++ b/llvm/lib/Analysis/DDGPrinter.cpp
@@ -83,7 +83,7 @@ bool DDGDotGraphTraits::isNodeHidden(const DDGNode *Node,
 }
 
 std::string DDGDotGraphTraits::getNodeAttributes(const DDGNode *Node,
-                                                const DataDependenceGraph *) {
+                                                 const DataDependenceGraph *) {
   if (isa<PiBlockDDGNode>(Node))
     return "shape=box, style=\"rounded,filled\", fillcolor=lightyellow, "
            "color=darkorange, penwidth=3";
@@ -137,21 +137,24 @@ DDGDotGraphTraits::getVerboseNodeLabel(const DDGNode *Node,
   return OS.str();
 }
 
+// EdgeKind to DOT color mapping:
+// - MemoryDependence: red
+// - RegisterDefUse: blue
+// - Rooted/Unknown=default (no attribute).
+static void writeEdgeKindColorAttr(raw_ostream &OS, DDGEdge::EdgeKind Kind) {
+  if (Kind == DDGEdge::EdgeKind::MemoryDependence)
+    OS << ", color=red";
+  else if (Kind == DDGEdge::EdgeKind::RegisterDefUse)
+    OS << ", color=blue";
+}
+
 std::string DDGDotGraphTraits::getSimpleEdgeAttributes(
     const DDGNode *Src, const DDGEdge *Edge, const DataDependenceGraph *G) {
   std::string Str;
   raw_string_ostream OS(Str);
   DDGEdge::EdgeKind Kind = Edge->getKind();
   OS << "label=\"[" << Kind << "]\"";
-  // EdgeKind to color mapping:
-  // - MemoryDependence: red
-  // - RegisterDefUse: blue
-  // - Rooted: black
-  // - Unknown: black
-  if (Kind == DDGEdge::EdgeKind::MemoryDependence)
-    OS << ", color=red";
-  else if (Kind == DDGEdge::EdgeKind::RegisterDefUse)
-    OS << ", color=blue";
+  writeEdgeKindColorAttr(OS, Kind);
   return OS.str();
 }
 
@@ -166,14 +169,6 @@ std::string DDGDotGraphTraits::getVerboseEdgeAttributes(
   else
     OS << Kind;
   OS << "]\"";
-  // EdgeKind to color mapping:
-  // - MemoryDependence: red
-  // - RegisterDefUse: blue
-  // - Rooted: black
-  // - Unknown: black
-  if (Kind == DDGEdge::EdgeKind::MemoryDependence)
-    OS << ", color=red";
-  else if (Kind == DDGEdge::EdgeKind::RegisterDefUse)
-    OS << ", color=blue";
+  writeEdgeKindColorAttr(OS, Kind);
   return OS.str();
 }

--- a/llvm/lib/Analysis/DDGPrinter.cpp
+++ b/llvm/lib/Analysis/DDGPrinter.cpp
@@ -82,6 +82,17 @@ bool DDGDotGraphTraits::isNodeHidden(const DDGNode *Node,
   return Graph->getPiBlock(*Node) != nullptr;
 }
 
+std::string DDGDotGraphTraits::getNodeAttributes(const DDGNode *Node,
+                                                const DataDependenceGraph *) {
+  if (isa<PiBlockDDGNode>(Node))
+    return "shape=box, style=\"rounded,filled\", fillcolor=lightyellow, "
+           "color=darkorange, penwidth=3";
+  if (isa<SimpleDDGNode>(Node) &&
+      Node->getKind() == DDGNode::NodeKind::MultiInstruction)
+    return "style=filled, fillcolor=lightcyan";
+  return "";
+}
+
 std::string
 DDGDotGraphTraits::getSimpleNodeLabel(const DDGNode *Node,
                                       const DataDependenceGraph *G) {
@@ -132,6 +143,15 @@ std::string DDGDotGraphTraits::getSimpleEdgeAttributes(
   raw_string_ostream OS(Str);
   DDGEdge::EdgeKind Kind = Edge->getKind();
   OS << "label=\"[" << Kind << "]\"";
+  // EdgeKind to color mapping:
+  // - MemoryDependence: red
+  // - RegisterDefUse: blue
+  // - Rooted: black
+  // - Unknown: black
+  if (Kind == DDGEdge::EdgeKind::MemoryDependence)
+    OS << ", color=red";
+  else if (Kind == DDGEdge::EdgeKind::RegisterDefUse)
+    OS << ", color=blue";
   return OS.str();
 }
 
@@ -146,5 +166,14 @@ std::string DDGDotGraphTraits::getVerboseEdgeAttributes(
   else
     OS << Kind;
   OS << "]\"";
+  // EdgeKind to color mapping:
+  // - MemoryDependence: red
+  // - RegisterDefUse: blue
+  // - Rooted: black
+  // - Unknown: black
+  if (Kind == DDGEdge::EdgeKind::MemoryDependence)
+    OS << ", color=red";
+  else if (Kind == DDGEdge::EdgeKind::RegisterDefUse)
+    OS << ", color=blue";
   return OS.str();
 }

--- a/llvm/lib/Analysis/DDGPrinter.cpp
+++ b/llvm/lib/Analysis/DDGPrinter.cpp
@@ -137,10 +137,10 @@ DDGDotGraphTraits::getVerboseNodeLabel(const DDGNode *Node,
   return OS.str();
 }
 
-// EdgeKind to DOT color mapping:
-// - MemoryDependence: red
-// - RegisterDefUse: blue
-// - Rooted/Unknown=default (no attribute).
+/// EdgeKind to DOT color mapping:
+/// - MemoryDependence: red
+/// - RegisterDefUse: blue
+/// - Rooted/Unknown=default (no attribute).
 static void writeEdgeKindColorAttr(raw_ostream &OS, DDGEdge::EdgeKind Kind) {
   if (Kind == DDGEdge::EdgeKind::MemoryDependence)
     OS << ", color=red";

--- a/llvm/test/Analysis/DDG/print-dot-ddg.ll
+++ b/llvm/test/Analysis/DDG/print-dot-ddg.ll
@@ -22,22 +22,22 @@ target datalayout = "e-m:e-i64:64-n32:64-v256:256:256-v512:512:512"
 ; CHECK-NEXT: label="DDG for 'foo.for.body'";
 ; CHECK: {{Node0x.*}} [shape=record,label="{\<kind:root\>\nroot\n}"]
 ; CHECK: {{Node0x.*}} -> {{Node0x.*}}[label="[rooted]"]
-; CHECK-COUNT-6: {{Node0x.*}} -> {{Node0x.*}}[label="[def-use]"]
+; CHECK-COUNT-6: {{Node0x.*}} -> {{Node0x.*}}[label="[def-use]", color=blue]
 ; CHECK-NOT: {{Node0x.*}} -> {{Node0x.*}}[label="[def-use]"]
 ; CHECK: [shape=record,label="{\<kind:single-instruction\>\n  %arrayidx10 = getelementptr inbounds float, ptr %B, i64 %indvars.iv.next\n}"];
-; CHECK: [shape=record,label="{\<kind:multi-instruction\>\n  %arrayidx = getelementptr inbounds float, ptr %A, i64 %indvars.iv\n  %0 = load float, ptr %arrayidx, align 4\n}"];
-; CHECK: {{Node0x.*}} -> {{Node0x.*}}[label="[consistent anti [0|<]!, consistent input [0|<]!]"]
-; CHECK: [shape=record,label="{\<kind:pi-block\>\n--- start of nodes in pi-block ---\n\<kind:single-instruction\>\n  %1 = load float, ptr %arrayidx2, align 4\n\n\<kind:single-instruction\>\n  %add = fadd fast float %0, %1\n\n\<kind:single-instruction\>\n  store float %add, ptr %arrayidx4, align 4\n\n\<kind:multi-instruction\>\n  %2 = load float, ptr %arrayidx6, align 4\n  %add7 = fadd fast float %2, 1.000000e+00\n\n\<kind:single-instruction\>\n  store float %add7, ptr %arrayidx10, align 4\n--- end of nodes in pi-block ---\n}"];
+; CHECK: [shape=record,style=filled, fillcolor=lightcyan,label="{\<kind:multi-instruction\>\n  %arrayidx = getelementptr inbounds float, ptr %A, i64 %indvars.iv\n  %0 = load float, ptr %arrayidx, align 4\n}"];
+; CHECK: {{Node0x.*}} -> {{Node0x.*}}[label="[consistent anti [0|<]!, consistent input [0|<]!]", color=red]
+; CHECK: [shape=record,shape=box, style="rounded,filled", fillcolor=lightyellow, color=darkorange, penwidth=3,label="{\<kind:pi-block\>\n--- start of nodes in pi-block ---\n\<kind:single-instruction\>\n  %1 = load float, ptr %arrayidx2, align 4\n\n\<kind:single-instruction\>\n  %add = fadd fast float %0, %1\n\n\<kind:single-instruction\>\n  store float %add, ptr %arrayidx4, align 4\n\n\<kind:multi-instruction\>\n  %2 = load float, ptr %arrayidx6, align 4\n  %add7 = fadd fast float %2, 1.000000e+00\n\n\<kind:single-instruction\>\n  store float %add7, ptr %arrayidx10, align 4\n--- end of nodes in pi-block ---\n}"];
 
 ; CHECK-ONLY: digraph "DDG for 'foo.for.body'"
 ; CHECK-ONLY-NEXT: label="DDG for 'foo.for.body'";
-; CHECK-ONLY: [shape=record,label="{pi-block\nwith\n2 nodes\n}"];
-; CHECK-ONLY-COUNT-6: {{Node0x.*}} -> {{Node0x.*}}[label="[def-use]"];
+; CHECK-ONLY: [shape=record,shape=box, style="rounded,filled", fillcolor=lightyellow, color=darkorange, penwidth=3,label="{pi-block\nwith\n2 nodes\n}"];
+; CHECK-ONLY-COUNT-6: {{Node0x.*}} -> {{Node0x.*}}[label="[def-use]", color=blue];
 ; CHECK-NOT: {{Node0x.*}} -> {{Node0x.*}}[label="[def-use]"];
 ; CHECK-ONLY: [shape=record,label="{  %arrayidx10 = getelementptr inbounds float, ptr %B, i64 %indvars.iv.next\n}"];
-; CHECK-ONLY: [shape=record,label="{  %arrayidx = getelementptr inbounds float, ptr %A, i64 %indvars.iv\n  %0 = load float, ptr %arrayidx, align 4\n}"];
-; CHECK-ONLY: {{Node0x.*}} -> {{Node0x.*}}[label="[memory]"]
-; CHECK-ONLY: [shape=record,label="{pi-block\nwith\n5 nodes\n}"];
+; CHECK-ONLY: [shape=record,style=filled, fillcolor=lightcyan,label="{  %arrayidx = getelementptr inbounds float, ptr %A, i64 %indvars.iv\n  %0 = load float, ptr %arrayidx, align 4\n}"];
+; CHECK-ONLY: {{Node0x.*}} -> {{Node0x.*}}[label="[memory]", color=red]
+; CHECK-ONLY: [shape=record,shape=box, style="rounded,filled", fillcolor=lightyellow, color=darkorange, penwidth=3,label="{pi-block\nwith\n5 nodes\n}"];
 
 define void @foo(ptr noalias %A, ptr noalias %B, i32 signext %n) {
 entry:


### PR DESCRIPTION
All blocks and edges are currently colored black which makes it difficult to distinguish while looking at huge graph.

This simple patch implements the following colorization to make it visually more distinguishable.

1. Pi-blocks - styled to rounded, filled, light-yellow fill, dark orange border
2. Multi-instruction blocks - Light cyan fill
3. MemoryDependence edges are now colored red.
4. Register def-use edges are now colored blue.

This patch implements `getNodeAttributes()` to return the string of attributes to apply to the node.