### PR TITLE
[clang][test] Set triple explicitly for attr-no-outline.m test

### DIFF
--- a/clang/test/CodeGenObjC/attr-no-outline.m
+++ b/clang/test/CodeGenObjC/attr-no-outline.m
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -emit-llvm %s -o - | FileCheck %s --check-prefix=OBJC
-// RUN: %clang_cc1 -emit-llvm -x objective-c++ %s -o - | FileCheck %s --check-prefix=OBJCXX
+// RUN: %clang_cc1 -emit-llvm %s -triple x86_64-unknown-linux-gnu -o - | FileCheck %s --check-prefix=OBJC
+// RUN: %clang_cc1 -emit-llvm -x objective-c++ %s -triple x86_64-unknown-linux-gnu -o - | FileCheck %s --check-prefix=OBJCXX
 
 @interface Test
 - (int)method:(int)x;


### PR DESCRIPTION
The test fails on targets that have a different LLVM IR lowering (e.g. RISC-V which produces `signext i32` for the return type). Rather than complicate the test with more complex patterns, just set the triple explicitly to x86-64 (as various other generic clang/test/CodeGen* tests do).

Test was introduced by #163666.

This fixes RISC-V CI.