### PR TITLE
[DAG] isKnownToBeAPowerOfTwo - use switch() to match against each opcode. NFC.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -4678,9 +4678,40 @@ bool SelectionDAG::isKnownToBeAPowerOfTwo(SDValue Val,
   if (ISD::matchUnaryPredicate(Val, IsPowerOfTwoOrZero))
     return true;
 
-  // A left-shift of a constant one will have exactly one bit set because
-  // shifting the bit off the end is undefined.
-  if (Val.getOpcode() == ISD::SHL) {
+  switch (Val.getOpcode()) {
+  case ISD::BUILD_VECTOR:
+    // Are all operands of a build vector constant powers of two or zero?
+    if (all_of(enumerate(Val->ops()), [&](auto P) {
+          auto *C = dyn_cast<ConstantSDNode>(P.value());
+          return !DemandedElts[P.index()] || (C && IsPowerOfTwoOrZero(C));
+        }))
+      return true;
+    break;
+
+  case ISD::SPLAT_VECTOR:
+    // Is the operand of a splat vector a constant power of two?
+    if (auto *C = dyn_cast<ConstantSDNode>(Val->getOperand(0)))
+      if (IsPowerOfTwoOrZero(C))
+        return true;
+    break;
+
+  case ISD::AND: {
+    // Looking for `x & -x` pattern:
+    // If x == 0:
+    //    x & -x -> 0
+    // If x != 0:
+    //    x & -x -> non-zero pow2
+    // so if we find the pattern return whether we know `x` is non-zero.
+    // TODO OrZero handling
+    SDValue X;
+    if (sd_match(Val, m_And(m_Value(X), m_Neg(m_Deferred(X)))))
+      return isKnownNeverZero(X, Depth);
+    break;
+  }
+
+  case ISD::SHL: {
+    // A left-shift of a constant one will have exactly one bit set because
+    // shifting the bit off the end is undefined.
     auto *C = isConstOrConstSplat(Val.getOperand(0));
     if (C && C->getAPIntValue() == 1)
       return true;
@@ -4689,9 +4720,9 @@ bool SelectionDAG::isKnownToBeAPowerOfTwo(SDValue Val,
            isKnownNeverZero(Val, Depth);
   }
 
-  // Similarly, a logical right-shift of a constant sign-bit will have exactly
-  // one bit set.
-  if (Val.getOpcode() == ISD::SRL) {
+  case ISD::SRL: {
+    // A logical right-shift of a constant sign-bit will have exactly
+    // one bit set.
     auto *C = isConstOrConstSplat(Val.getOperand(0));
     if (C && C->getAPIntValue().isSignMask())
       return true;
@@ -4700,57 +4731,38 @@ bool SelectionDAG::isKnownToBeAPowerOfTwo(SDValue Val,
            isKnownNeverZero(Val, Depth);
   }
 
-  if (Val.getOpcode() == ISD::ROTL || Val.getOpcode() == ISD::ROTR)
+  case ISD::ROTL:
+  case ISD::ROTR:
     return isKnownToBeAPowerOfTwo(Val.getOperand(0), /*OrZero=*/false,
                                   Depth + 1);
 
-  // Are all operands of a build vector constant powers of two or zero?
-  if (Val.getOpcode() == ISD::BUILD_VECTOR &&
-      all_of(enumerate(Val->ops()), [&](auto P) {
-        auto *C = dyn_cast<ConstantSDNode>(P.value());
-        return !DemandedElts[P.index()] || (C && IsPowerOfTwoOrZero(C));
-      }))
-    return true;
-
-  // Is the operand of a splat vector a constant power of two?
-  if (Val.getOpcode() == ISD::SPLAT_VECTOR)
-    if (ConstantSDNode *C = dyn_cast<ConstantSDNode>(Val->getOperand(0)))
-      if (IsPowerOfTwoOrZero(C))
-        return true;
-
-  // vscale(power-of-two) is a power-of-two for some targets
-  if (Val.getOpcode() == ISD::VSCALE &&
-      getTargetLoweringInfo().isVScaleKnownToBeAPowerOfTwo() &&
-      isKnownToBeAPowerOfTwo(Val.getOperand(0), /*OrZero=*/false, Depth + 1))
-    return true;
-
-  if (Val.getOpcode() == ISD::SMIN || Val.getOpcode() == ISD::SMAX ||
-      Val.getOpcode() == ISD::UMIN || Val.getOpcode() == ISD::UMAX)
+  case ISD::SMIN:
+  case ISD::SMAX:
+  case ISD::UMIN:
+  case ISD::UMAX:
     return isKnownToBeAPowerOfTwo(Val.getOperand(1), /*OrZero=*/false,
                                   Depth + 1) &&
            isKnownToBeAPowerOfTwo(Val.getOperand(0), /*OrZero=*/false,
                                   Depth + 1);
 
-  if (Val.getOpcode() == ISD::SELECT || Val.getOpcode() == ISD::VSELECT)
+  case ISD::SELECT:
+  case ISD::VSELECT:
     return isKnownToBeAPowerOfTwo(Val.getOperand(2), /*OrZero=*/false,
                                   Depth + 1) &&
            isKnownToBeAPowerOfTwo(Val.getOperand(1), /*OrZero=*/false,
                                   Depth + 1);
 
-  // Looking for `x & -x` pattern:
-  // If x == 0:
-  //    x & -x -> 0
-  // If x != 0:
-  //    x & -x -> non-zero pow2
-  // so if we find the pattern return whether we know `x` is non-zero.
-  // TODO OrZero handling
-  SDValue X;
-  if (sd_match(Val, m_And(m_Value(X), m_Neg(m_Deferred(X)))))
-    return isKnownNeverZero(X, Depth);
-
-  if (Val.getOpcode() == ISD::ZERO_EXTEND)
+  case ISD::ZERO_EXTEND:
     return isKnownToBeAPowerOfTwo(Val.getOperand(0), /*OrZero=*/false,
                                   Depth + 1);
+
+  case ISD::VSCALE:
+    // vscale(power-of-two) is a power-of-two for some targets
+    if (getTargetLoweringInfo().isVScaleKnownToBeAPowerOfTwo() &&
+        isKnownToBeAPowerOfTwo(Val.getOperand(0), /*OrZero=*/false, Depth + 1))
+      return true;
+    break;
+  }
 
   // More could be done here, though the above checks are enough
   // to handle some common cases.


### PR DESCRIPTION
isKnownToBeAPowerOfTwo has gotten to a size now that we should use a general switch like other value tracking helpers.