### PR TITLE
[SafeStack] Use ptrmask instead of ptrtoint+and+inttoptr

### DIFF
--- a/llvm/test/Transforms/SafeStack/X86/byval.ll
+++ b/llvm/test/Transforms/SafeStack/X86/byval.ll
@@ -55,8 +55,7 @@ define i32 @ByValUnsafeAligned(ptr byval(%struct.S) nocapture readonly align 64 
 entry:
   ; CHECK-LABEL: @ByValUnsafeAligned
   ; CHECK: %[[A:.*]] = load {{.*}} @__safestack_unsafe_stack_ptr
-  ; CHECK: %[[B:.*]] = ptrtoint ptr %[[A]] to i64
-  ; CHECK: and i64 %[[B]], -64
+  ; CHECK: call ptr @llvm.ptrmask.p0.i64(ptr %[[A]], i64 -64)
   ; CHECK: ret i32
   %0 = load i32, ptr %zzz, align 64
   %arrayidx2 = getelementptr inbounds %struct.S, ptr %zzz, i64 0, i32 0, i64 %idx

--- a/llvm/test/Transforms/SafeStack/X86/setjmp2.ll
+++ b/llvm/test/Transforms/SafeStack/X86/setjmp2.ll
@@ -21,13 +21,12 @@ define i32 @foo(i32 %size) nounwind uwtable safestack {
 ; I386-NEXT:    store ptr [[UNSAFE_STACK_PTR]], ptr [[UNSAFE_STACK_DYNAMIC_PTR]], align 4
 ; I386-NEXT:    [[TMP0:%.*]] = mul i32 [[SIZE]], 4
 ; I386-NEXT:    [[TMP1:%.*]] = load ptr, ptr @__safestack_unsafe_stack_ptr, align 4
-; I386-NEXT:    [[TMP2:%.*]] = ptrtoint ptr [[TMP1]] to i32
-; I386-NEXT:    [[TMP3:%.*]] = sub i32 [[TMP2]], [[TMP0]]
-; I386-NEXT:    [[TMP4:%.*]] = and i32 [[TMP3]], -16
-; I386-NEXT:    [[A:%.*]] = inttoptr i32 [[TMP4]] to ptr
+; I386-NEXT:    [[TMP2:%.*]] = sub i32 0, [[TMP0]]
+; I386-NEXT:    [[TMP3:%.*]] = getelementptr i8, ptr [[TMP1]], i32 [[TMP2]]
+; I386-NEXT:    [[A:%.*]] = call ptr @llvm.ptrmask.p0.i32(ptr [[TMP3]], i32 -16)
 ; I386-NEXT:    store ptr [[A]], ptr @__safestack_unsafe_stack_ptr, align 4
 ; I386-NEXT:    store ptr [[A]], ptr [[UNSAFE_STACK_DYNAMIC_PTR]], align 4
-; I386-NEXT:    [[CALL:%.*]] = call i32 @_setjmp(ptr @buf) #[[ATTR1:[0-9]+]]
+; I386-NEXT:    [[CALL:%.*]] = call i32 @_setjmp(ptr @buf) #[[ATTR2:[0-9]+]]
 ; I386-NEXT:    [[TMP5:%.*]] = load ptr, ptr [[UNSAFE_STACK_DYNAMIC_PTR]], align 4
 ; I386-NEXT:    store ptr [[TMP5]], ptr @__safestack_unsafe_stack_ptr, align 4
 ; I386-NEXT:    call void @funcall(ptr [[A]])
@@ -43,13 +42,12 @@ define i32 @foo(i32 %size) nounwind uwtable safestack {
 ; X86-64-NEXT:    [[TMP0:%.*]] = zext i32 [[SIZE]] to i64
 ; X86-64-NEXT:    [[TMP1:%.*]] = mul i64 [[TMP0]], 4
 ; X86-64-NEXT:    [[TMP2:%.*]] = load ptr, ptr @__safestack_unsafe_stack_ptr, align 8
-; X86-64-NEXT:    [[TMP3:%.*]] = ptrtoint ptr [[TMP2]] to i64
-; X86-64-NEXT:    [[TMP4:%.*]] = sub i64 [[TMP3]], [[TMP1]]
-; X86-64-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], -16
-; X86-64-NEXT:    [[A:%.*]] = inttoptr i64 [[TMP5]] to ptr
+; X86-64-NEXT:    [[TMP3:%.*]] = sub i64 0, [[TMP1]]
+; X86-64-NEXT:    [[TMP4:%.*]] = getelementptr i8, ptr [[TMP2]], i64 [[TMP3]]
+; X86-64-NEXT:    [[A:%.*]] = call ptr @llvm.ptrmask.p0.i64(ptr [[TMP4]], i64 -16)
 ; X86-64-NEXT:    store ptr [[A]], ptr @__safestack_unsafe_stack_ptr, align 8
 ; X86-64-NEXT:    store ptr [[A]], ptr [[UNSAFE_STACK_DYNAMIC_PTR]], align 8
-; X86-64-NEXT:    [[CALL:%.*]] = call i32 @_setjmp(ptr @buf) #[[ATTR1:[0-9]+]]
+; X86-64-NEXT:    [[CALL:%.*]] = call i32 @_setjmp(ptr @buf) #[[ATTR2:[0-9]+]]
 ; X86-64-NEXT:    [[TMP6:%.*]] = load ptr, ptr [[UNSAFE_STACK_DYNAMIC_PTR]], align 8
 ; X86-64-NEXT:    store ptr [[TMP6]], ptr @__safestack_unsafe_stack_ptr, align 8
 ; X86-64-NEXT:    call void @funcall(ptr [[A]])


### PR DESCRIPTION
Use the provenance-preserving ptrmask intrinsic instead of ptrtoint+and+inttoptr for pointer alignment.