### PR TITLE
[lldb][test] TestQuitWithProcess: Increase timeout to fix ARM flakiness

### DIFF
--- a/lldb/test/API/driver/quit_speed/TestQuitWithProcess.py
+++ b/lldb/test/API/driver/quit_speed/TestQuitWithProcess.py
@@ -32,7 +32,7 @@ class DriverQuitSpeedTest(PExpectTest):
         print("Got launch message")
         child.sendline("quit")
         print("sent quit")
-        child.expect(pexpect.EOF, timeout=15)
+        child.expect(pexpect.EOF, timeout=30)
 
     @skipIfAsan
     def test_run_quit_with_prompt(self):
@@ -57,4 +57,4 @@ class DriverQuitSpeedTest(PExpectTest):
         child.expect(r".*LLDB will kill one or more processes.*")
         # add trailing space to the confirmation.
         child.sendline("yEs ")
-        child.expect(pexpect.EOF, timeout=15)
+        child.expect(pexpect.EOF, timeout=30)


### PR DESCRIPTION
TestQuitWithProcess.py is randomly failing on Arm Linux buildbot. The test validates LLDB's ability to quit cleanly killing active processes with a timeout value set to 15 seconds which could be insufficient for any resource limited platforms under heavy load.

This patch increase the timeout to 30 seconds to accommodate any resource limits.

https://lab.llvm.org/buildbot/#/builders/18/builds/24801