### PR TITLE
[SPIR-V] Add spirv-use-user-semantic-for-linkage option

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -418,6 +418,7 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
     buildOpDecorate(FuncVReg, MIRBuilder, SPIRV::Decoration::LinkageAttributes,
                     {static_cast<uint32_t>(*LnkTy)}, F.getName());
   }
+  emitLinkageAsUserSemantic(FuncVReg, F, MIRBuilder);
 
   // Handle function pointers decoration
   bool hasFunctionPointers =

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -5237,6 +5237,7 @@ bool SPIRVInstructionSelector::selectGlobalValue(
   Register Reg = GR.buildGlobalVariable(
       ResVReg, ResType, GlobalIdent, GV, StorageClass, Init,
       GlobalVar->isConstant(), LnkType, MIRBuilder, true);
+  emitLinkageAsUserSemantic(Reg, *GV, MIRBuilder);
   // TODO: For AMDGCN, we pipe externally_initialized through via
   // HostAccessINTEL, with ReadWrite (3) access, which is we then handle during
   // reverse translation. We should remove this once SPIR-V gains the ability to

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -24,8 +24,17 @@
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/IntrinsicsSPIRV.h"
+#include "llvm/Support/CommandLine.h"
 #include <queue>
 #include <vector>
+
+static llvm::cl::opt<bool> SPVEmitLinkageUserSemantic(
+    "spirv-use-user-semantic-for-linkage",
+    llvm::cl::desc("Emit UserSemantic decoration with \"linkage:<type>\" "
+                   "string on functions and globals whose linkage has no "
+                   "native SPIR-V representation (note: it's an experimental "
+                   "flag)."),
+    llvm::cl::Optional, llvm::cl::init(false));
 
 namespace llvm {
 namespace SPIRV {
@@ -1193,6 +1202,41 @@ Type *reconstitutePeeledArrayType(Type *Ty) {
     ResultTy = NewTy;
   }
   return ResultTy;
+}
+
+void emitLinkageAsUserSemantic(Register Reg, const GlobalValue &GV,
+                               MachineIRBuilder &MIRBuilder) {
+  if (!SPVEmitLinkageUserSemantic)
+    return;
+
+  const char *LinkageName = nullptr;
+  switch (GV.getLinkage()) {
+  case GlobalValue::WeakAnyLinkage:
+    LinkageName = "weak";
+    break;
+  case GlobalValue::WeakODRLinkage:
+    LinkageName = "weak_odr";
+    break;
+  case GlobalValue::LinkOnceAnyLinkage:
+    LinkageName = "linkonce";
+    break;
+  case GlobalValue::AvailableExternallyLinkage:
+    LinkageName = "available_externally";
+    break;
+  case GlobalValue::CommonLinkage:
+    LinkageName = "common";
+    break;
+  case GlobalValue::AppendingLinkage:
+    LinkageName = "appending";
+    break;
+  case GlobalValue::ExternalWeakLinkage:
+    LinkageName = "extern_weak";
+    break;
+  default:
+    return;
+  }
+  buildOpDecorate(Reg, MIRBuilder, SPIRV::Decoration::UserSemantic, {},
+                  std::string("linkage:") + LinkageName);
 }
 
 std::optional<SPIRV::LinkageType::LinkageType>

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -1220,9 +1220,6 @@ void emitLinkageAsUserSemantic(Register Reg, const GlobalValue &GV,
   case GlobalValue::LinkOnceAnyLinkage:
     LinkageName = "linkonce";
     break;
-  case GlobalValue::AvailableExternallyLinkage:
-    LinkageName = "available_externally";
-    break;
   case GlobalValue::CommonLinkage:
     LinkageName = "common";
     break;

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -584,6 +584,9 @@ unsigned getArrayComponentCount(const MachineRegisterInfo *MRI,
 MachineBasicBlock::iterator
 getFirstValidInstructionInsertPoint(MachineBasicBlock &BB);
 
+void emitLinkageAsUserSemantic(Register Reg, const GlobalValue &GV,
+                               MachineIRBuilder &MIRBuilder);
+
 std::optional<SPIRV::LinkageType::LinkageType>
 getSpirvLinkageTypeFor(const SPIRVSubtarget &ST, const GlobalValue &GV);
 } // namespace llvm

--- a/llvm/test/CodeGen/SPIRV/linkage/linkage-user-semantic.ll
+++ b/llvm/test/CodeGen/SPIRV/linkage/linkage-user-semantic.ll
@@ -1,0 +1,48 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown --spirv-use-user-semantic-for-linkage %s -o - | FileCheck %s --check-prefix=CHECK-ON
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-OFF
+
+; FIXME: currently spirv-val is not erroring out when UserSemantic decoration
+; is applied to a function, but it actually should.
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-use-user-semantic-for-linkage %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Test that --spirv-use-user-semantic-for-linkage emits UserSemantic decorations
+; for LLVM linkage types with no native SPIR-V representation.
+
+; CHECK-ON-DAG: OpName %[[#WEAK_FN:]] "weak_func"
+; CHECK-ON-DAG: OpName %[[#WEAK:]] "weak_var"
+; CHECK-ON-DAG: OpName %[[#WEAK_ODR:]] "weak_odr_var"
+; CHECK-ON-DAG: OpName %[[#LINKONCE:]] "linkonce_var"
+; CHECK-ON-DAG: OpName %[[#COMMON:]] "common_var"
+; CHECK-ON-DAG: OpName %[[#AE:]] "ae_var"
+; CHECK-ON-DAG: OpName %[[#EW:]] "ew_func"
+
+; CHECK-ON-DAG: OpDecorate %[[#WEAK_FN]] UserSemantic "linkage:weak"
+; CHECK-ON-DAG: OpDecorate %[[#WEAK]] UserSemantic "linkage:weak"
+; CHECK-ON-DAG: OpDecorate %[[#WEAK_ODR]] UserSemantic "linkage:weak_odr"
+; CHECK-ON-DAG: OpDecorate %[[#LINKONCE]] UserSemantic "linkage:linkonce"
+; CHECK-ON-DAG: OpDecorate %[[#COMMON]] UserSemantic "linkage:common"
+; CHECK-ON-DAG: OpDecorate %[[#AE]] UserSemantic "linkage:available_externally"
+; CHECK-ON-DAG: OpDecorate %[[#EW]] UserSemantic "linkage:extern_weak"
+
+; CHECK-OFF-NOT: UserSemantic "linkage:
+
+@weak_var = weak addrspace(1) global i32 0, align 4
+@weak_odr_var = weak_odr addrspace(1) global i32 0, align 4
+@linkonce_var = linkonce addrspace(1) global i32 0, align 4
+@common_var = common addrspace(1) global i32 0, align 4
+@ae_var = available_externally addrspace(1) global i32 79, align 4
+
+declare extern_weak spir_func void @ew_func()
+
+define weak spir_func i32 @weak_func(i32 %x) {
+entry:
+  ret i32 %x
+}
+
+define spir_func void @caller() {
+entry:
+  %val = call i32 @weak_func(i32 42)
+  call spir_func void @ew_func()
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/linkage/linkage-user-semantic.ll
+++ b/llvm/test/CodeGen/SPIRV/linkage/linkage-user-semantic.ll
@@ -14,7 +14,6 @@
 ; CHECK-ON-DAG: OpName %[[#WEAK_ODR:]] "weak_odr_var"
 ; CHECK-ON-DAG: OpName %[[#LINKONCE:]] "linkonce_var"
 ; CHECK-ON-DAG: OpName %[[#COMMON:]] "common_var"
-; CHECK-ON-DAG: OpName %[[#AE:]] "ae_var"
 ; CHECK-ON-DAG: OpName %[[#EW:]] "ew_func"
 
 ; CHECK-ON-DAG: OpDecorate %[[#WEAK_FN]] UserSemantic "linkage:weak"
@@ -22,7 +21,6 @@
 ; CHECK-ON-DAG: OpDecorate %[[#WEAK_ODR]] UserSemantic "linkage:weak_odr"
 ; CHECK-ON-DAG: OpDecorate %[[#LINKONCE]] UserSemantic "linkage:linkonce"
 ; CHECK-ON-DAG: OpDecorate %[[#COMMON]] UserSemantic "linkage:common"
-; CHECK-ON-DAG: OpDecorate %[[#AE]] UserSemantic "linkage:available_externally"
 ; CHECK-ON-DAG: OpDecorate %[[#EW]] UserSemantic "linkage:extern_weak"
 
 ; CHECK-OFF-NOT: UserSemantic "linkage:
@@ -31,7 +29,6 @@
 @weak_odr_var = weak_odr addrspace(1) global i32 0, align 4
 @linkonce_var = linkonce addrspace(1) global i32 0, align 4
 @common_var = common addrspace(1) global i32 0, align 4
-@ae_var = available_externally addrspace(1) global i32 79, align 4
 
 declare extern_weak spir_func void @ew_func()
 


### PR DESCRIPTION
when enabled, LLVM linkage types that have no SPIR-V counterparts are translated as UserSemantic "linkage:%type%" decoration, where %type% can be weak, weak_odr etc.

Ideal solution is to have new extension(s) for this, but we don't have them. Using UserSemantic is not correct, but it doesn't worsen the current situation, which is:
if in 2 modules there is a weak function, and these modules are linked together after llvm-spirv roundtrip, then llvm-link errors out because functions from both modules become extern.

So with this patch, if linkage type is preserved via UserSemantic we won't see this error, and if UserSemantic is ignored (which SPIR-V consumer has right to do) - the linkage error remains.