### PR TITLE
[libc][math] change bf16fmal to be header-only and constexpr-compat

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -36,6 +36,7 @@
 #include "math/bf16divf.h"
 #include "math/bf16divl.h"
 #include "math/bf16fmaf.h"
+#include "math/bf16fmal.h"
 #include "math/canonicalize.h"
 #include "math/canonicalizebf16.h"
 #include "math/canonicalizef.h"

--- a/libc/shared/math/bf16fmal.h
+++ b/libc/shared/math/bf16fmal.h
@@ -1,4 +1,4 @@
-//===-- Implementation of bf16fmal function -------------------------------===//
+//===-- Shared bf16fmal function --------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,14 +6,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/bf16fmal.h"
+#ifndef LLVM_LIBC_SHARED_MATH_BF16FMAL_H
+#define LLVM_LIBC_SHARED_MATH_BF16FMAL_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/bf16fmal.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(bfloat16, bf16fmal,
-                   (long double x, long double y, long double z)) {
-  return math::bf16fmal(x, y, z);
-}
+namespace shared {
+
+using math::bf16fmal;
+
+} // namespace shared
 
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_BF16FMAL_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -897,6 +897,16 @@ add_header_library(
 )
 
 add_header_library(
+  bf16fmal
+  HDRS
+    bf16fmal.h
+  DEPENDS
+    libc.src.__support.macros.config
+    libc.src.__support.FPUtil.fma
+    libc.src.__support.FPUtil.bfloat16
+)
+
+add_header_library(
   ilogb
   HDRS
     ilogb.h

--- a/libc/src/__support/math/bf16fmal.h
+++ b/libc/src/__support/math/bf16fmal.h
@@ -1,0 +1,26 @@
+//===-- Implementation header for bf16fmal ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_BF16FMAL_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_BF16FMAL_H
+
+#include "src/__support/FPUtil/FMA.h"
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace math {
+
+LIBC_INLINE bfloat16 bf16fmal(long double x, long double y, long double z) {
+  return fputil::fma<bfloat16>(x, y, z);
+}
+
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_BF16FMAL_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -5219,11 +5219,7 @@ add_entrypoint_object(
   HDRS
     ../bf16fmal.h
   DEPENDS
-    libc.src.__support.common
-    libc.src.__support.FPUtil.bfloat16
-    libc.src.__support.FPUtil.fma
-    libc.src.__support.macros.config
-    libc.src.__support.macros.properties.types
+    libc.src.__support.math.bf16fmal
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -32,6 +32,7 @@ add_fp_unittest(
     libc.src.__support.math.bf16divf
     libc.src.__support.math.bf16divl
     libc.src.__support.math.bf16fmaf
+    libc.src.__support.math.bf16fmal
     libc.src.__support.math.canonicalize
     libc.src.__support.math.canonicalizebf16
     libc.src.__support.math.canonicalizef

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -246,6 +246,8 @@ TEST(LlvmLibcSharedMathTest, AllBFloat16) {
   EXPECT_FP_EQ(bfloat16(5.0), LIBC_NAMESPACE::shared::bf16add(2.0, 3.0));
   EXPECT_FP_EQ(bfloat16(2.0f), LIBC_NAMESPACE::shared::bf16divf(4.0f, 2.0f));
   EXPECT_FP_EQ(bfloat16(2.0), LIBC_NAMESPACE::shared::bf16divl(6.0L, 3.0L));
+  EXPECT_FP_EQ(bfloat16(10.0),
+               LIBC_NAMESPACE::shared::bf16fmal(2.0L, 3.0L, 4.0L));
 
   bfloat16 canonicalizebf16_cx = bfloat16(0.0);
   bfloat16 canonicalizebf16_x = bfloat16(0.0);

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2696,6 +2696,16 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_bf16fmal",
+    hdrs = ["src/__support/math/bf16fmal.h"],
+    deps = [
+        ":__support_fputil_bfloat16",
+        ":__support_fputil_fma",
+        ":__support_macros_config",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_canonicalize",
     hdrs = ["src/__support/math/canonicalize.h"],
     deps = [
@@ -4586,6 +4596,11 @@ libc_math_function(
 libc_math_function(
     name = "bf16fmaf",
     additional_deps = [":__support_math_bf16fmaf"],
+)
+
+libc_math_function(
+    name = "bf16fmal",
+    additional_deps = [":__support_math_bf16fmal"],
 )
 
 libc_math_function(


### PR DESCRIPTION
i have been working on refactoring  bf16fmal so it’s header-only and can be used in constexpr contexts
Since we're prepping for the C++23 Constexpr Math RFC, I also enabled  constexpr in the underlying FPUtil logic that 
bf16fmal depends on (like FMA and software fallbacks)
Closes: #181628 
Part of: #147386