### PR TITLE
[NFC][SPIRV] Move `SPIRVTypeInst` to its own header

### DIFF
--- a/llvm/lib/Target/SPIRV/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/CMakeLists.txt
@@ -49,6 +49,7 @@ add_llvm_target(SPIRVCodeGen
   SPIRVSubtarget.cpp
   SPIRVTargetMachine.cpp
   SPIRVTargetTransformInfo.cpp
+  SPIRVTypeInst.cpp
   SPIRVUtils.cpp
   SPIRVEmitNonSemanticDI.cpp
   SPIRVCBufferAccess.cpp

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.cpp
@@ -1,0 +1,26 @@
+//===-- SPIRVTypeInst.cpp - SPIR-V Type Instruction -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementation associated to SPIRVTypeInst.h.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SPIRVTypeInst.h"
+#include "SPIRVInstrInfo.h"
+
+namespace llvm {
+static bool definesATypeRegister(const MachineInstr &MI) {
+  const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
+  return MRI.getRegClass(MI.getOperand(0).getReg()) == &SPIRV::TYPERegClass;
+}
+
+SPIRVTypeInst::SPIRVTypeInst(const MachineInstr *MI) : MI(MI) {
+  // A SPIRV Type whose result is not a type is invalid.
+  assert(!MI || definesATypeRegister(*MI));
+}
+} // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
@@ -1,0 +1,77 @@
+//===-- SPIRVTypeInst.h - SPIR-V Type Instruction ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// SPIRVTypeInst is used to represent a SPIR-V type instruction.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_SPIRV_SPIRVTYPEINST_H
+#define LLVM_LIB_TARGET_SPIRV_SPIRVTYPEINST_H
+
+#include "llvm/ADT/DenseMapInfo.h"
+
+namespace llvm {
+class MachineInstr;
+class MachineRegisterInfo;
+
+/// @deprecated Use SPIRVTypeInst instead
+/// SPIRVType is supposed to represent a MachineInstr that defines a SPIRV Type
+/// (e.g. an OpTypeInt intruction). It is misused in several places and we're
+/// getting rid of it.
+using SPIRVType = const MachineInstr;
+
+class SPIRVTypeInst {
+  const MachineInstr *MI;
+
+  // Used by DenseMapInfo to bypass the assertion. The thombstone and empty keys
+  // are not null. They are -1 and -2 aligned to the appropiate pointer size.
+  struct UncheckedConstructor {};
+  SPIRVTypeInst(const MachineInstr *MI, UncheckedConstructor) : MI(MI) {};
+
+public:
+  SPIRVTypeInst(const MachineInstr &MI) : SPIRVTypeInst(&MI) {}
+  SPIRVTypeInst(const MachineInstr *MI);
+
+  // No need to verify the register since it's already verified by the copied
+  // object.
+  SPIRVTypeInst(const SPIRVTypeInst &Other) = default;
+  SPIRVTypeInst &operator=(const SPIRVTypeInst &Other) = default;
+
+  const MachineInstr &operator*() const { return *MI; }
+  const MachineInstr *operator->() const { return MI; }
+  operator const MachineInstr *() const { return MI; }
+
+  bool operator==(const SPIRVTypeInst &Other) const { return MI == Other.MI; }
+  bool operator!=(const SPIRVTypeInst &Other) const { return MI != Other.MI; }
+
+  bool operator==(const MachineInstr *Other) const { return MI == Other; }
+  bool operator!=(const MachineInstr *Other) const { return MI != Other; }
+
+  operator bool() const { return MI; }
+
+  friend struct DenseMapInfo<SPIRVTypeInst>;
+};
+
+template <> struct DenseMapInfo<SPIRVTypeInst> {
+  using MIInfo = DenseMapInfo<MachineInstr *>;
+  static SPIRVTypeInst getEmptyKey() {
+    return {MIInfo::getEmptyKey(), SPIRVTypeInst::UncheckedConstructor()};
+  }
+  static SPIRVTypeInst getTombstoneKey() {
+    return {MIInfo::getTombstoneKey(), SPIRVTypeInst::UncheckedConstructor()};
+  }
+  static unsigned getHashValue(SPIRVTypeInst Ty) {
+    return MIInfo::getHashValue(Ty.MI);
+  }
+  static bool isEqual(SPIRVTypeInst Ty1, SPIRVTypeInst Ty2) {
+    return Ty1 == Ty2;
+  }
+};
+
+} // namespace llvm
+#endif

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -25,6 +25,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "SPIRVTypeInst.h"
+
 namespace llvm {
 class MCInst;
 class MachineFunction;


### PR DESCRIPTION
Move `SPIRVTypeInst` outside of `SPIRVGlobalRegistry.h`.