### PR TITLE
[OpenMP] Make isPrivatizingClause version-sensitive

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/ConstructDecompositionT.h
+++ b/llvm/include/llvm/Frontend/OpenMP/ConstructDecompositionT.h
@@ -497,7 +497,7 @@ bool ConstructDecompositionT<C, H>::applyClause(
   // [5.2:340:33]
   bool applied = applyIf(input, [&](const auto &leaf) {
     return llvm::any_of(leaf.clauses, [&](const ClauseTy *n) {
-      return llvm::omp::isPrivatizingClause(n->id);
+      return llvm::omp::isPrivatizingClause(n->id, version);
     });
   });
 

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -49,20 +49,21 @@ static constexpr inline bool canHaveIterator(Clause C) {
 }
 
 // Can clause C create a private copy of a variable.
-static constexpr inline bool isPrivatizingClause(Clause C) {
+static constexpr inline bool isPrivatizingClause(Clause C, unsigned Version) {
   switch (C) {
-  case OMPC_detach:
   case OMPC_firstprivate:
-  // TODO case OMPC_induction:
   case OMPC_in_reduction:
-  case OMPC_is_device_ptr:
   case OMPC_lastprivate:
   case OMPC_linear:
   case OMPC_private:
   case OMPC_reduction:
   case OMPC_task_reduction:
-  case OMPC_use_device_ptr:
     return true;
+  case OMPC_detach:
+  case OMPC_induction:
+  case OMPC_is_device_ptr:
+  case OMPC_use_device_ptr:
+    return Version >= 60;
   default:
     return false;
   }

--- a/llvm/lib/Frontend/OpenMP/OMP.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMP.cpp
@@ -83,7 +83,7 @@ collectPrivatizingConstructs(llvm::SmallSet<Directive, 16> &Constructs,
   llvm::SmallSet<Clause, 16> Privatizing;
   for (auto C :
        llvm::enum_seq_inclusive<Clause>(Clause::First_, Clause::Last_)) {
-    if (isPrivatizingClause(C))
+    if (isPrivatizingClause(C, Version))
       Privatizing.insert(C);
   }
 


### PR DESCRIPTION
Some pre-existing clauses (e.g. use_device_ptr) are privatizing in OpenMP 6.0, but not in 5.2. Make the check more accurate by considering the effective spec version.