### PR TITLE
[lldb][windows] deactivate unicode tests on Windows

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -452,6 +452,10 @@ def unicode_test(func):
     previous value afterwards.
     """
 
+    if sys.platform == "win32":
+        # Unicode support on Windows is flaky in CI.
+        return expectedFailureWindows
+
     def unicode_wrapped(*args, **kwargs):
         import os
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/181143 introduced a regression in Windows build bots, which is due to some Unicode characters not being rendered properly.

The proper fix is to be able to configure the characters that are rendered, and to force them to be ascii characters.