### PR TITLE
[Clang] Support `-falign-loops=N` for LTO

### DIFF
--- a/clang/include/clang/Driver/CommonArgs.h
+++ b/clang/include/clang/Driver/CommonArgs.h
@@ -93,6 +93,8 @@ bool getStaticPIE(const llvm::opt::ArgList &Args, const ToolChain &TC);
 unsigned ParseFunctionAlignment(const ToolChain &TC,
                                 const llvm::opt::ArgList &Args);
 
+unsigned ParseLoopAlignment(const Driver &D, const llvm::opt::ArgList &Args);
+
 void addDebugInfoKind(llvm::opt::ArgStringList &CmdArgs,
                       llvm::codegenoptions::DebugInfoKind DebugInfoKind);
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5492,21 +5492,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(Args.MakeArgString(std::to_string(FunctionAlignment)));
   }
 
-  // We support -falign-loops=N where N is a power of 2. GCC supports more
-  // forms.
-  if (const Arg *A = Args.getLastArg(options::OPT_falign_loops_EQ)) {
-    unsigned Value = 0;
-    if (StringRef(A->getValue()).getAsInteger(10, Value) || Value > 65536)
-      TC.getDriver().Diag(diag::err_drv_invalid_int_value)
-          << A->getAsString(Args) << A->getValue();
-    else if (Value & (Value - 1))
-      TC.getDriver().Diag(diag::err_drv_alignment_not_power_of_two)
-          << A->getAsString(Args) << A->getValue();
-    // Treat =0 as unspecified (use the target preference).
-    if (Value)
-      CmdArgs.push_back(Args.MakeArgString("-falign-loops=" +
-                                           Twine(std::min(Value, 65536u))));
-  }
+  unsigned LoopAlignment = ParseLoopAlignment(TC.getDriver(), Args);
+  if (LoopAlignment)
+    CmdArgs.push_back(
+        Args.MakeArgString("-falign-loops=" + Twine(LoopAlignment)));
 
   if (Triple.isOSzOS()) {
     // On z/OS some of the system header feature macros need to

--- a/clang/test/Driver/falign-loops.c
+++ b/clang/test/Driver/falign-loops.c
@@ -1,14 +1,14 @@
+// UNSUPPORTED: system-windows
+
 /// Treat -falign-loops=0 as not specifying the option.
 // RUN: %clang -### -falign-loops=0 %s 2>&1 | FileCheck %s --check-prefix=CHECK_NO
-// RUN: %clang -### -falign-loops=1 %s 2>&1 | FileCheck %s --check-prefix=CHECK_1
-// RUN: %clang -### -falign-loops=4 %s 2>&1 | FileCheck %s --check-prefix=CHECK_4
+// RUN: %clang -### -falign-loops=1 %s 2>&1 | FileCheck %s --check-prefixes=CHECK_1,OBJ
+// RUN: %clang -### -falign-loops=4 -flto %s 2>&1 | FileCheck %s --check-prefixes=CHECK_4,LTO
 /// Only powers of 2 are supported for now.
 // RUN: not %clang -### -falign-loops=5 %s 2>&1 | FileCheck %s --check-prefix=CHECK_5
 // RUN: %clang -### -falign-loops=65536 %s 2>&1 | FileCheck %s --check-prefix=CHECK_65536
 // RUN: not %clang -### -falign-loops=65537 %s 2>&1 | FileCheck %s --check-prefix=CHECK_65537
 // RUN: not %clang -### -falign-loops=a %s 2>&1 | FileCheck %s --check-prefix=CHECK_ERR_A
-// RUN: %clang -### -falign-loops=2 -fuse-ld=lld %s 2>&1 | FileCheck --check-prefixes=CC1,OBJ %s
-// RUN: %clang -### -falign-loops=2 -fuse-ld=lld -flto %s 2>&1 | FileCheck --check-prefixes=CC1,LTO %s
 
 // CHECK_NO-NOT: "-falign-loops=
 // CHECK_1: "-falign-loops=1"
@@ -18,11 +18,5 @@
 // CHECK_65537: error: invalid integral value '65537' in '-falign-loops=65537'
 // CHECK_ERR_A: error: invalid integral value 'a' in '-falign-loops=a'
 
-// CC1: -cc1
-// CC1: "-falign-loops=2"
-
-// OBJ: lld
-// OBJ-NOT: -align-loops=2
-
-// LTO: lld
-// LTO: "-plugin-opt=-align-loops=2"
+// OBJ-NOT: -plugin-opt=-align-loops=
+// LTO: -plugin-opt=-align-loops=

--- a/clang/test/Driver/falign-loops.c
+++ b/clang/test/Driver/falign-loops.c
@@ -7,6 +7,8 @@
 // RUN: %clang -### -falign-loops=65536 %s 2>&1 | FileCheck %s --check-prefix=CHECK_65536
 // RUN: not %clang -### -falign-loops=65537 %s 2>&1 | FileCheck %s --check-prefix=CHECK_65537
 // RUN: not %clang -### -falign-loops=a %s 2>&1 | FileCheck %s --check-prefix=CHECK_ERR_A
+// RUN: %clang -### -falign-loops=2 -fuse-ld=lld %s 2>&1 | FileCheck --check-prefixes=CC1,OBJ %s
+// RUN: %clang -### -falign-loops=2 -fuse-ld=lld -flto %s 2>&1 | FileCheck --check-prefixes=CC1,LTO %s
 
 // CHECK_NO-NOT: "-falign-loops=
 // CHECK_1: "-falign-loops=1"
@@ -15,3 +17,12 @@
 // CHECK_65536: "-falign-loops=65536"
 // CHECK_65537: error: invalid integral value '65537' in '-falign-loops=65537'
 // CHECK_ERR_A: error: invalid integral value 'a' in '-falign-loops=a'
+
+// CC1: -cc1
+// CC1: "-falign-loops=2"
+
+// OBJ: lld
+// OBJ-NOT: -align-loops=2
+
+// LTO: lld
+// LTO: "-plugin-opt=-align-loops=2"


### PR DESCRIPTION
This commit adds forwarding of the option to LTO build. This behavior is aligned with GCC. Without it users have to use `-Wl,-mllvm,--align-loops=N` and from my practice they usually forget/are not aware of it.