### PR TITLE
[lldb/docs] Update Scripted Symbol Locator tutorial title (NFC)

### DIFF
--- a/lldb/docs/use/python-reference.rst
+++ b/lldb/docs/use/python-reference.rst
@@ -28,4 +28,4 @@ The following tutorials and documentation demonstrate various Python capabilitie
    tutorials/implementing-standalone-scripts
    tutorials/custom-frame-recognizers
    tutorials/extending-target-stop-hooks
-   tutorials/hunting-down-symbols
+   tutorials/custom-symbol-resolution

--- a/lldb/docs/use/tutorials/custom-symbol-resolution.md
+++ b/lldb/docs/use/tutorials/custom-symbol-resolution.md
@@ -1,4 +1,4 @@
-# Hunting down symbols with Scripted Symbol Locator
+# Finding Symbols With a Scripted Symbol Locator
 
 The **Scripted Symbol Locator** lets you write a Python class that tells LLDB
 where to find executables, symbol files, and source files for your debug


### PR DESCRIPTION
This patch addresses some post-merge comments from llvm-project#181594, where the tutorial name for Scripted Symbol Locator was missing a word and wasn't capitalized properly.