### PR TITLE
[lldb] Allow tests to share a single build

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbinline.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbinline.py
@@ -210,4 +210,5 @@ def MakeInlineTest(__file, __globals, decorators=None, name=None, build_dict=Non
     # correctly in test results.
     test_class.test_filename = __file
     test_class.mydir = TestBase.compute_mydir(__file)
+    test_class.SHARED_BUILD_TESTCASE = False
     return test_class

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -569,7 +569,7 @@ class Base(unittest.TestCase):
     # Can be overridden by the LLDB_TIME_WAIT_NEXT_LAUNCH environment variable.
     timeWaitNextLaunch = 1.0
 
-    # Some test case classes require a separate build directory for test
+    # Some test case classes require a separate build directory for each test
     # function. Subclasses can set this to False in those cases. This slows down
     # the test, but provides isolation where needed.
     SHARED_BUILD_TESTCASE = True

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -758,7 +758,7 @@ class Base(unittest.TestCase):
         return os.path.join(configuration.test_src_root, self.mydir)
 
     def getBuildDirBasename(self):
-        if self.__class__.SHARED_BUILD_TESTCASE:
+        if self.SHARED_BUILD_TESTCASE:
             return self.__class__.__module__
         else:
             return self.__class__.__module__ + "." + self.testMethodName
@@ -770,10 +770,10 @@ class Base(unittest.TestCase):
         )
 
     def makeBuildDir(self):
-        """Create the test-specific working directory, deleting any previous
-        contents."""
+        """Create the test-specific working directory, optionally deleting any
+        previous contents."""
         bdir = self.getBuildDir()
-        if os.path.isdir(bdir):
+        if os.path.isdir(bdir) and not self.SHARED_BUILD_TESTCASE:
             shutil.rmtree(bdir)
         lldbutil.mkdir_p(bdir)
 

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -569,8 +569,9 @@ class Base(unittest.TestCase):
     # Can be overridden by the LLDB_TIME_WAIT_NEXT_LAUNCH environment variable.
     timeWaitNextLaunch = 1.0
 
-    # Subclasses can set this to True to avoid repeated building of the test
-    # source (by default, a separate build happens for each test function).
+    # Some test case classes require a separate build directory for test
+    # function. Subclasses can set this to False in those cases. This slows down
+    # the test, but provides isolation where needed.
     SHARED_BUILD_TESTCASE = True
 
     @staticmethod

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -571,7 +571,7 @@ class Base(unittest.TestCase):
 
     # Subclasses can set this to True to avoid repeated building of the test
     # source (by default, a separate build happens for each test function).
-    SHARED_BUILD_TESTCASE = False
+    SHARED_BUILD_TESTCASE = True
 
     @staticmethod
     def compute_mydir(test_file):

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -569,6 +569,8 @@ class Base(unittest.TestCase):
     # Can be overridden by the LLDB_TIME_WAIT_NEXT_LAUNCH environment variable.
     timeWaitNextLaunch = 1.0
 
+    SHARED_BUILD_TESTCASE = False
+
     @staticmethod
     def compute_mydir(test_file):
         """Subclasses should call this function to correctly calculate the
@@ -754,7 +756,10 @@ class Base(unittest.TestCase):
         return os.path.join(configuration.test_src_root, self.mydir)
 
     def getBuildDirBasename(self):
-        return self.__class__.__module__ + "." + self.testMethodName
+        if self.__class__.SHARED_BUILD_TESTCASE:
+            return self.__class__.__module__
+        else:
+            return self.__class__.__module__ + "." + self.testMethodName
 
     def getBuildDir(self):
         """Return the full path to the current test."""

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -569,6 +569,8 @@ class Base(unittest.TestCase):
     # Can be overridden by the LLDB_TIME_WAIT_NEXT_LAUNCH environment variable.
     timeWaitNextLaunch = 1.0
 
+    # Subclasses can set this to True to avoid repeated building of the test
+    # source (by default, a separate build happens for each test function).
     SHARED_BUILD_TESTCASE = False
 
     @staticmethod

--- a/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
@@ -10,8 +10,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    SHARED_BUILD_TESTCASE = True
-
     def _run_cmd(self, cmd: str) -> str:
         """Run the given lldb command and return its output."""
         result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
@@ -10,6 +10,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = True
+
     def _run_cmd(self, cmd: str) -> str:
         """Run the given lldb command and return its output."""
         result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/commands/dwim-print/objc/TestDWIMPrintObjC.py
+++ b/lldb/test/API/commands/dwim-print/objc/TestDWIMPrintObjC.py
@@ -9,6 +9,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = True
+
     @skipUnlessDarwin
     def test(self):
         self.build()

--- a/lldb/test/API/commands/dwim-print/objc/TestDWIMPrintObjC.py
+++ b/lldb/test/API/commands/dwim-print/objc/TestDWIMPrintObjC.py
@@ -9,8 +9,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    SHARED_BUILD_TESTCASE = True
-
     @skipUnlessDarwin
     def test(self):
         self.build()

--- a/lldb/test/API/commands/frame/var/TestFrameVar.py
+++ b/lldb/test/API/commands/frame/var/TestFrameVar.py
@@ -16,6 +16,7 @@ class TestFrameVar(TestBase):
     # set this to true.  That way it won't be run once for
     # each debug info format.
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def test_frame_var(self):
         self.build()

--- a/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
+++ b/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 
 class TestPlatformProcessConnect(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     @skipIfRemote
     @expectedFailureAll(hostoslist=["windows"], triple=".*-android")

--- a/lldb/test/API/commands/platform/launchgdbserver/TestPlatformLaunchGDBServer.py
+++ b/lldb/test/API/commands/platform/launchgdbserver/TestPlatformLaunchGDBServer.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestPlatformProcessLaunchGDBServer(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def _launch_and_connect(self, exe):
         hostname = socket.getaddrinfo("localhost", 0, proto=socket.IPPROTO_TCP)[0][4][0]

--- a/lldb/test/API/commands/process/launch/TestProcessLaunch.py
+++ b/lldb/test/API/commands/process/launch/TestProcessLaunch.py
@@ -9,7 +9,6 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 from pathlib import Path
-import re
 
 
 class ProcessLaunchTestCase(TestBase):

--- a/lldb/test/API/commands/process/launch/TestProcessLaunch.py
+++ b/lldb/test/API/commands/process/launch/TestProcessLaunch.py
@@ -9,10 +9,12 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 from pathlib import Path
+import re
 
 
 class ProcessLaunchTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/settings/use_source_cache/TestUseSourceCache.py
+++ b/lldb/test/API/commands/settings/use_source_cache/TestUseSourceCache.py
@@ -12,6 +12,7 @@ from shutil import copy
 
 class SettingsUseSourceCacheTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def test_set_use_source_cache_false(self):
         """Test that after 'set use-source-cache false', files are not locked."""

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def test_enable_disable(self):
         """

--- a/lldb/test/API/commands/target/auto-install-main-executable/TestAutoInstallMainExecutable.py
+++ b/lldb/test/API/commands/target/auto-install-main-executable/TestAutoInstallMainExecutable.py
@@ -9,8 +9,6 @@ import lldbgdbserverutils
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
-import lldb
-import os
 
 
 class TestAutoInstallMainExecutable(TestBase):

--- a/lldb/test/API/commands/target/auto-install-main-executable/TestAutoInstallMainExecutable.py
+++ b/lldb/test/API/commands/target/auto-install-main-executable/TestAutoInstallMainExecutable.py
@@ -9,10 +9,13 @@ import lldbgdbserverutils
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
+import lldb
+import os
 
 
 class TestAutoInstallMainExecutable(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     @skipIfRemote
     @skipIfWindows  # This test is flaky on Windows

--- a/lldb/test/API/commands/target/dump-separate-debug-info/dwo/TestDumpDwo.py
+++ b/lldb/test/API/commands/target/dump-separate-debug-info/dwo/TestDumpDwo.py
@@ -12,6 +12,7 @@ from lldbsuite.test_event.build_exception import BuildError
 
 class TestDumpDWO(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def get_dwos_from_json_output(self):
         """Returns a dictionary of `symfile` -> {`dwo_name` -> dwo_info object}."""

--- a/lldb/test/API/commands/trace/TestTraceStartStop.py
+++ b/lldb/test/API/commands/trace/TestTraceStartStop.py
@@ -3,10 +3,13 @@ from intelpt_testcase import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
+import os
 
 
 @skipIfNoIntelPT
 class TestTraceStartStop(TraceIntelPTTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def expectGenericHelpMessageForStartCommand(self):
         self.expect(
             "help thread trace start",

--- a/lldb/test/API/commands/trace/TestTraceStartStop.py
+++ b/lldb/test/API/commands/trace/TestTraceStartStop.py
@@ -3,7 +3,6 @@ from intelpt_testcase import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
-import os
 
 
 @skipIfNoIntelPT

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
@@ -14,6 +14,7 @@ import side_effect
 
 class BreakpointCommandTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24528")
     def test_breakpoint_command_sequence(self):

--- a/lldb/test/API/functionalities/breakpoint/comp_dir_symlink/TestCompDirSymLink.py
+++ b/lldb/test/API/functionalities/breakpoint/comp_dir_symlink/TestCompDirSymLink.py
@@ -16,6 +16,8 @@ _COMP_DIR_SYM_LINK_PROP = "symbols.debug-info-symlink-paths"
 
 
 class CompDirSymLinkTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/breakpoint/objc/TestObjCBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/objc/TestObjCBreakpoints.py
@@ -13,6 +13,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestObjCBreakpoints(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @add_test_categories(["objc"])
     def test_break(self):
         """Test setting Objective-C specific breakpoints (DWARF in .o files)."""

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/string/TestDataFormatterStdString.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/string/TestDataFormatterStdString.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 
 class StdStringDataFormatterTestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/gdb_remote_client/TestPty.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestPty.py
@@ -3,10 +3,13 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 from lldbsuite.test.gdbclientutils import *
 from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
+import os
 
 
 @skipIf(hostoslist=["windows"])
 class TestPty(GDBRemoteTestBase):
+    SHARED_BUILD_TESTCASE = False
+
     server_socket_class = PtyServerSocket
 
     def get_term_attrs(self):

--- a/lldb/test/API/functionalities/gdb_remote_client/TestPty.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestPty.py
@@ -3,7 +3,6 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 from lldbsuite.test.gdbclientutils import *
 from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
-import os
 
 
 @skipIf(hostoslist=["windows"])

--- a/lldb/test/API/functionalities/inferior-changed/TestInferiorChanged.py
+++ b/lldb/test/API/functionalities/inferior-changed/TestInferiorChanged.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class ChangedInferiorTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(hostoslist=["windows"])
     @no_debug_info_test
     def test_inferior_crashing(self):

--- a/lldb/test/API/functionalities/limit-debug-info/TestLimitDebugInfo.py
+++ b/lldb/test/API/functionalities/limit-debug-info/TestLimitDebugInfo.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class LimitDebugInfoTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def _check_type(self, target, name):
         exe = target.FindModule(lldb.SBFileSpec("a.out"))
         type_ = exe.FindFirstType(name)

--- a/lldb/test/API/functionalities/module_cache/bsd/TestModuleCacheBSD.py
+++ b/lldb/test/API/functionalities/module_cache/bsd/TestModuleCacheBSD.py
@@ -10,6 +10,8 @@ import time
 
 
 class ModuleCacheTestcaseBSD(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/module_cache/debug_index/TestDebugIndexCache.py
+++ b/lldb/test/API/functionalities/module_cache/debug_index/TestDebugIndexCache.py
@@ -9,6 +9,8 @@ import time
 
 
 class DebugIndexCacheTestcase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/rerun_and_expr/TestRerunAndExpr.py
+++ b/lldb/test/API/functionalities/rerun_and_expr/TestRerunAndExpr.py
@@ -11,6 +11,8 @@ from lldbsuite.test.decorators import *
 
 
 class TestRerunExpr(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     # FIXME: on Windows rebuilding the binary isn't enough to unload it
     #        on progrem restart. One will have to try hard to evict
     #        the module from the ModuleList (possibly including a call to

--- a/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
+++ b/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
@@ -26,6 +26,8 @@ def isUbuntu18_04():
 
 
 class TestRerunExprDylib(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipTestIfFn(isUbuntu18_04, bugnumber="rdar://103831050")
     @skipIfWindows
     @skipIfRemote

--- a/lldb/test/API/functionalities/thread/step_until/TestStepUntilAPI.py
+++ b/lldb/test/API/functionalities/thread/step_until/TestStepUntilAPI.py
@@ -6,6 +6,7 @@ from lldbsuite.test_event.build_exception import BuildError
 
 class TestStepUntilAPI(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    BUILD_SHARED_TESTCASE = False
 
     def setUp(self):
         super().setUp()

--- a/lldb/test/API/functionalities/thread/step_until/TestStepUntilAPI.py
+++ b/lldb/test/API/functionalities/thread/step_until/TestStepUntilAPI.py
@@ -6,7 +6,7 @@ from lldbsuite.test_event.build_exception import BuildError
 
 class TestStepUntilAPI(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
-    BUILD_SHARED_TESTCASE = False
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         super().setUp()

--- a/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
+++ b/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
@@ -3,10 +3,12 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 from lldbsuite.test_event.build_exception import BuildError
+import re
 
 
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def build_and_run(self, test_file):
         """

--- a/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
+++ b/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
@@ -3,7 +3,6 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 from lldbsuite.test_event.build_exception import BuildError
-import re
 
 
 class TestCase(TestBase):

--- a/lldb/test/API/lang/c/shared_lib_stripped_symbols/TestSharedLibStrippedSymbols.py
+++ b/lldb/test/API/lang/c/shared_lib_stripped_symbols/TestSharedLibStrippedSymbols.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class SharedLibStrippedTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @expectedFailureAll(oslist=["windows"])
     # Sometimes fails with:
     # error: Couldn't allocate space for materialized struct: Couldn't malloc: address space is full

--- a/lldb/test/API/lang/cpp/abi_tag_lookup/TestAbiTagLookup.py
+++ b/lldb/test/API/lang/cpp/abi_tag_lookup/TestAbiTagLookup.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class AbiTagLookupTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfWindows
     @expectedFailureAll(debug_info=["dwarf", "gmodules", "dwo"])
     def test_abi_tag_lookup(self):

--- a/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
+++ b/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class AbiTagStructorsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(
         compiler="clang",
         compiler_version=["<", "22"],

--- a/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expr-definition-in-dylib/TestExprDefinitionInDylib.py
+++ b/lldb/test/API/lang/cpp/expr-definition-in-dylib/TestExprDefinitionInDylib.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class ExprDefinitionInDylibTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
 
     @skipIf(
         compiler="clang",

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/TestTemplateWithSameArg.py
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/TestTemplateWithSameArg.py
@@ -27,6 +27,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestTemplateWithSameArg(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.build()

--- a/lldb/test/API/lang/cpp/namespace/TestNamespaceLookup.py
+++ b/lldb/test/API/lang/cpp/namespace/TestNamespaceLookup.py
@@ -11,6 +11,8 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test import lldbplatformutil
 
 class NamespaceLookupTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/cpp/template-alias/TestTemplateAlias.py
+++ b/lldb/test/API/lang/cpp/template-alias/TestTemplateAlias.py
@@ -5,6 +5,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class TestTemplateAlias(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, extra_flags):
         self.build(dictionary=extra_flags)
         self.main_source_file = lldb.SBFileSpec("main.cpp")

--- a/lldb/test/API/lang/cpp/template-function/TestTemplateFunctions.py
+++ b/lldb/test/API/lang/cpp/template-function/TestTemplateFunctions.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class TemplateFunctionsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test_template_function(self, add_cast):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/unique-types3/TestUniqueTypes3.py
+++ b/lldb/test/API/lang/cpp/unique-types3/TestUniqueTypes3.py
@@ -9,6 +9,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class UniqueTypesTestCase3(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, debug_flags):
         """Test that we display the correct template instantiation."""
         self.build(dictionary=debug_flags)

--- a/lldb/test/API/lang/objc/objc-struct-argument/TestObjCStructArgument.py
+++ b/lldb/test/API/lang/objc/objc-struct-argument/TestObjCStructArgument.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestObjCStructArgument(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/macosx/lc-note/firmware-corefile/TestFirmwareCorefiles.py
+++ b/lldb/test/API/macosx/lc-note/firmware-corefile/TestFirmwareCorefiles.py
@@ -12,6 +12,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestFirmwareCorefiles(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(
         debug_info=no_match(["dsym"]),
         bugnumber="This test is looking explicitly for a dSYM",

--- a/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
+++ b/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
@@ -3,10 +3,12 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 import json
+import subprocess
 
 
 class TestSimulatorPlatformLaunching(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def check_load_commands(self, expected_load_command):
         """sanity check the built binary for the expected number of load commands"""

--- a/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
+++ b/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
@@ -3,7 +3,6 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 import json
-import subprocess
 
 
 class TestSimulatorPlatformLaunching(TestBase):

--- a/lldb/test/API/macosx/skinny-corefile/TestSkinnyCorefile.py
+++ b/lldb/test/API/macosx/skinny-corefile/TestSkinnyCorefile.py
@@ -9,7 +9,6 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
-import shutil
 
 
 class TestSkinnyCorefile(TestBase):

--- a/lldb/test/API/macosx/skinny-corefile/TestSkinnyCorefile.py
+++ b/lldb/test/API/macosx/skinny-corefile/TestSkinnyCorefile.py
@@ -9,9 +9,12 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
+import shutil
 
 
 class TestSkinnyCorefile(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(
         debug_info=no_match(["dsym"]),
         bugnumber="This test is looking explicitly for a dSYM",

--- a/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
+++ b/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 class DebuggerAPITestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def test_debugger_api_boundary_condition(self):
         """Exercise SBDebugger APIs with boundary conditions."""

--- a/lldb/test/API/python_api/target-arch-from-module/TestTargetArchFromModule.py
+++ b/lldb/test/API/python_api/target-arch-from-module/TestTargetArchFromModule.py
@@ -12,6 +12,8 @@ from lldbsuite.test import lldbutil
 
 
 class TargetArchFromModule(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(
         debug_info=no_match(["dsym"]),
         bugnumber="This test is looking explicitly for a dSYM",

--- a/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
+++ b/lldb/test/API/python_api/unified_section_list/TestModuleUnifiedSectionList.py
@@ -13,6 +13,8 @@ from lldbsuite.test.lldbutil import symbol_type_to_str
 
 
 class ModuleUnifiedSectionList(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     def test_unified_section_list(self):
         self.build()

--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -30,6 +30,7 @@ def ansi_color_surround_regex(inner_regex_text):
 
 class SourceManagerTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/test_utils/base/TestBaseTest.py
+++ b/lldb/test/API/test_utils/base/TestBaseTest.py
@@ -9,6 +9,8 @@ from lldbsuite.test_event import build_exception
 
 
 class TestBuildMethod(Base):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         super().setUp()
         self._traces = []

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setBreakpoints.py
@@ -12,6 +12,8 @@ import os
 
 
 class TestDAP_setBreakpoints(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         lldbdap_testcase.DAPTestCaseBase.setUp(self)
 

--- a/lldb/test/API/tools/lldb-dap/disconnect/TestDAP_disconnect.py
+++ b/lldb/test/API/tools/lldb-dap/disconnect/TestDAP_disconnect.py
@@ -12,6 +12,8 @@ import os
 
 
 class TestDAP_disconnect(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     source = "main.cpp"
 
     def disconnect_and_assert_no_output_printed(self):

--- a/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
@@ -12,6 +12,8 @@ import json
 
 @skipIfBuildType(["debug"])
 class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def read_pid_message(self, fifo_file):
         with open(fifo_file, "r") as file:
             self.assertIn("pid", file.readline())

--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -17,6 +17,8 @@ def make_buffer_verify_dict(start_idx, count, offset=0):
 
 
 class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def verify_values(self, verify_dict, actual, varref_dict=None, expression=None):
         if "equals" in verify_dict:
             verify = verify_dict["equals"]

--- a/lldb/test/API/tools/lldb-server/TestGdbRemotePlatformFile.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemotePlatformFile.py
@@ -43,7 +43,7 @@ def uint32_trunc(x):
 
 
 class TestGdbRemotePlatformFile(GdbRemoteTestCaseBase):
-    BUILD_SHARED_TESTCASE = False
+    SHARED_BUILD_TESTCASE = False
 
     @skipIfWindows
     @add_test_categories(["llgs"])

--- a/lldb/test/API/tools/lldb-server/TestGdbRemotePlatformFile.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemotePlatformFile.py
@@ -43,6 +43,8 @@ def uint32_trunc(x):
 
 
 class TestGdbRemotePlatformFile(GdbRemoteTestCaseBase):
+    BUILD_SHARED_TESTCASE = False
+
     @skipIfWindows
     @add_test_categories(["llgs"])
     def test_platform_file_rdonly(self):

--- a/lldb/test/API/tools/lldb-server/commandline/TestGdbRemoteConnection.py
+++ b/lldb/test/API/tools/lldb-server/commandline/TestGdbRemoteConnection.py
@@ -6,9 +6,12 @@ from lldbsuite.test.lldbtest import *
 from lldbgdbserverutils import Server
 import lldbsuite.test.lldbplatformutil
 from lldbgdbserverutils import Pipe
+import lldb
 
 
 class TestGdbRemoteConnection(gdbremote_testcase.GdbRemoteTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfRemote  # reverse connect is not a supported use case for now
     def test_reverse_connect(self):
         # Reverse connect is the default connection method.

--- a/lldb/test/API/tools/lldb-server/commandline/TestGdbRemoteConnection.py
+++ b/lldb/test/API/tools/lldb-server/commandline/TestGdbRemoteConnection.py
@@ -6,7 +6,6 @@ from lldbsuite.test.lldbtest import *
 from lldbgdbserverutils import Server
 import lldbsuite.test.lldbplatformutil
 from lldbgdbserverutils import Pipe
-import lldb
 
 
 class TestGdbRemoteConnection(gdbremote_testcase.GdbRemoteTestCaseBase):

--- a/lldb/test/API/types/AbstractBase.py
+++ b/lldb/test/API/types/AbstractBase.py
@@ -22,6 +22,8 @@ class GenericTester(TestBase):
     # printf() stmts (see basic_type.cpp).
     pattern = re.compile(r" (\*?a[^=]*) = '([^=]*)'$")
 
+    SHARED_BUILD_TESTCASE = False
+
     # Assert message.
     DATA_TYPE_GROKKED = "Data type from expr parser output is parsed correctly"
 


### PR DESCRIPTION
This changes Python API tests to use a single build shared across all test functions, instead of the previous default behavior of a separate build dir for each test function.

This build behavior opt-out, tests can use the previous behavior of one individual (unshared) build directory per test function, by setting `SHARED_BUILD_TESTCASE` to False (in the test class).

The motivation is to make the test suite more efficient, by not repeatedly building the same test source. When running tests on my macOS machine, this reduces the time of `ninja check-lldb-api` by almost 60%  (sample numbers: from ~492s down to ~207s = 58%). Almost 5min time saved.

Each test function still calls `self.build()`, but only the first call will do a build, in the subsequent tests `make` will be a no-op because the sources won't have changed.