### PR TITLE
[ASan] Enable __SANITIZER_DISABLE_CONTAINER_OVERFLOW__ tests

### DIFF
--- a/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.cpp
+++ b/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.cpp
@@ -11,8 +11,6 @@
 // overflow checks at compile time.
 // RUN: %clangxx_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ -O %s -o %t-no-overflow
 // RUN: %run %t-no-overflow 2>&1 | FileCheck --check-prefix=CHECK-NOCRASH %s
-//
-// UNSUPPORTED: true
 
 #include <assert.h>
 #include <stdio.h>

--- a/compiler-rt/test/asan/TestCases/stack_container_dynamic_lib.cpp
+++ b/compiler-rt/test/asan/TestCases/stack_container_dynamic_lib.cpp
@@ -19,8 +19,6 @@
 // RUN: %clangxx_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ %s -c -o %t-main.o
 // RUN: %clangxx_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ -o %t %t-main.o %t-object.o %libdl
 // RUN: %run %t 2>&1 | FileCheck --check-prefix=CHECK-NO-CONTAINER-OVERFLOW %s
-//
-// UNSUPPORTED: true
 
 #include <assert.h>
 #include <sanitizer/common_interface_defs.h>


### PR DESCRIPTION
Now that the corresponding libcxx change has landed, these tests should be passing on some platforms.

This patch re-enables them for all platforms, so that we can see which bots these do not work on and mark them unsupported accordingly.

rdar://167946476