### PR TITLE
[NCFI][OpenMPIRBuilderTest] remove some trivial uses of getAllocatedType

### DIFF
--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -654,12 +654,12 @@ TEST_F(OpenMPIRBuilderTest, ParallelSimpleGPU) {
     ++NumBodiesGenerated;
 
     Builder.restoreIP(AllocaIP);
-    PrivAI = Builder.CreateAlloca(F->arg_begin()->getType());
+    Type *PrivType = F->arg_begin()->getType();
+    PrivAI = Builder.CreateAlloca(PrivType);
     Builder.CreateStore(F->arg_begin(), PrivAI);
 
     Builder.restoreIP(CodeGenIP);
-    Value *PrivLoad =
-        Builder.CreateLoad(PrivAI->getAllocatedType(), PrivAI, "local.use");
+    Value *PrivLoad = Builder.CreateLoad(PrivType, PrivAI, "local.use");
     Value *Cmp = Builder.CreateICmpNE(F->arg_begin(), PrivLoad);
     Instruction *ThenTerm, *ElseTerm;
     SplitBlockAndInsertIfThenElse(Cmp, CodeGenIP.getBlock()->getTerminator(),
@@ -767,12 +767,12 @@ TEST_F(OpenMPIRBuilderTest, ParallelSimple) {
     ++NumBodiesGenerated;
 
     Builder.restoreIP(AllocaIP);
-    PrivAI = Builder.CreateAlloca(F->arg_begin()->getType());
+    Type *PrivType = F->arg_begin()->getType();
+    PrivAI = Builder.CreateAlloca(PrivType);
     Builder.CreateStore(F->arg_begin(), PrivAI);
 
     Builder.restoreIP(CodeGenIP);
-    Value *PrivLoad =
-        Builder.CreateLoad(PrivAI->getAllocatedType(), PrivAI, "local.use");
+    Value *PrivLoad = Builder.CreateLoad(PrivType, PrivAI, "local.use");
     Value *Cmp = Builder.CreateICmpNE(F->arg_begin(), PrivLoad);
     Instruction *ThenTerm, *ElseTerm;
     SplitBlockAndInsertIfThenElse(Cmp, CodeGenIP.getBlock()->getTerminator(),
@@ -1097,12 +1097,12 @@ TEST_F(OpenMPIRBuilderTest, ParallelIfCond) {
     ++NumBodiesGenerated;
 
     Builder.restoreIP(AllocaIP);
-    PrivAI = Builder.CreateAlloca(F->arg_begin()->getType());
+    Type *PrivType = F->arg_begin()->getType();
+    PrivAI = Builder.CreateAlloca(PrivType);
     Builder.CreateStore(F->arg_begin(), PrivAI);
 
     Builder.restoreIP(CodeGenIP);
-    Value *PrivLoad =
-        Builder.CreateLoad(PrivAI->getAllocatedType(), PrivAI, "local.use");
+    Value *PrivLoad = Builder.CreateLoad(PrivType, PrivAI, "local.use");
     Value *Cmp = Builder.CreateICmpNE(F->arg_begin(), PrivLoad);
     Instruction *ThenTerm, *ElseTerm;
     SplitBlockAndInsertIfThenElse(Cmp, &*Builder.GetInsertPoint(), &ThenTerm,
@@ -1995,9 +1995,9 @@ TEST_F(OpenMPIRBuilderTest, ApplySimdCustomAligned) {
   IRBuilder<> Builder(BB);
   const int AlignmentValue = 32;
   llvm::BasicBlock *sourceBlock = Builder.GetInsertBlock();
-  AllocaInst *Alloc1 =
-      Builder.CreateAlloca(Builder.getPtrTy(), Builder.getInt64(1));
-  LoadInst *Load1 = Builder.CreateLoad(Alloc1->getAllocatedType(), Alloc1);
+  Type *Alloc1Ty = Builder.getPtrTy();
+  AllocaInst *Alloc1 = Builder.CreateAlloca(Alloc1Ty, Builder.getInt64(1));
+  LoadInst *Load1 = Builder.CreateLoad(Alloc1Ty, Alloc1);
   MapVector<Value *, Value *> AlignedVars;
   AlignedVars.insert({Load1, Builder.getInt64(AlignmentValue)});
 
@@ -2208,8 +2208,8 @@ TEST_F(OpenMPIRBuilderTest, ApplySimdIf) {
   // Generation of if condition
   Builder.CreateStore(ConstantInt::get(Type::getInt32Ty(Ctx), 0U), Alloc1);
   Builder.CreateStore(ConstantInt::get(Type::getInt32Ty(Ctx), 1U), Alloc2);
-  LoadInst *Load1 = Builder.CreateLoad(Alloc1->getAllocatedType(), Alloc1);
-  LoadInst *Load2 = Builder.CreateLoad(Alloc2->getAllocatedType(), Alloc2);
+  LoadInst *Load1 = Builder.CreateLoad(Builder.getInt32Ty(), Alloc1);
+  LoadInst *Load2 = Builder.CreateLoad(Builder.getInt32Ty(), Alloc2);
 
   Value *IfCmp = Builder.CreateICmpNE(Load1, Load2);
 
@@ -2866,7 +2866,8 @@ TEST_F(OpenMPIRBuilderTest, MasterDirective) {
       Builder.restoreIP(AllocaIP);
     else
       Builder.SetInsertPoint(&*(F->getEntryBlock().getFirstInsertionPt()));
-    PrivAI = Builder.CreateAlloca(F->arg_begin()->getType());
+    Type *PrivType = F->arg_begin()->getType();
+    PrivAI = Builder.CreateAlloca(PrivType);
     Builder.CreateStore(F->arg_begin(), PrivAI);
 
     llvm::BasicBlock *CodeGenIPBB = CodeGenIP.getBlock();
@@ -2880,8 +2881,7 @@ TEST_F(OpenMPIRBuilderTest, MasterDirective) {
     EntryBB = ThenBB->getUniquePredecessor();
 
     // simple instructions for body
-    Value *PrivLoad =
-        Builder.CreateLoad(PrivAI->getAllocatedType(), PrivAI, "local.use");
+    Value *PrivLoad = Builder.CreateLoad(PrivType, PrivAI, "local.use");
     Builder.CreateICmpNE(F->arg_begin(), PrivLoad);
   };
 
@@ -2948,7 +2948,8 @@ TEST_F(OpenMPIRBuilderTest, MaskedDirective) {
       Builder.restoreIP(AllocaIP);
     else
       Builder.SetInsertPoint(&*(F->getEntryBlock().getFirstInsertionPt()));
-    PrivAI = Builder.CreateAlloca(F->arg_begin()->getType());
+    Type *PrivType = F->arg_begin()->getType();
+    PrivAI = Builder.CreateAlloca(PrivType);
     Builder.CreateStore(F->arg_begin(), PrivAI);
 
     llvm::BasicBlock *CodeGenIPBB = CodeGenIP.getBlock();
@@ -2962,8 +2963,7 @@ TEST_F(OpenMPIRBuilderTest, MaskedDirective) {
     EntryBB = ThenBB->getUniquePredecessor();
 
     // simple instructions for body
-    Value *PrivLoad =
-        Builder.CreateLoad(PrivAI->getAllocatedType(), PrivAI, "local.use");
+    Value *PrivLoad = Builder.CreateLoad(PrivType, PrivAI, "local.use");
     Builder.CreateICmpNE(F->arg_begin(), PrivLoad);
   };
 
@@ -3021,7 +3021,8 @@ TEST_F(OpenMPIRBuilderTest, CriticalDirective) {
 
   OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
 
-  AllocaInst *PrivAI = Builder.CreateAlloca(F->arg_begin()->getType());
+  Type *PrivType = F->arg_begin()->getType();
+  AllocaInst *PrivAI = Builder.CreateAlloca(PrivType);
 
   auto BodyGenCB = [&](InsertPointTy AllocaIP, InsertPointTy CodeGenIP) {
     // actual start for bodyCB
@@ -3032,8 +3033,7 @@ TEST_F(OpenMPIRBuilderTest, CriticalDirective) {
     // body begin
     Builder.restoreIP(CodeGenIP);
     Builder.CreateStore(F->arg_begin(), PrivAI);
-    Value *PrivLoad =
-        Builder.CreateLoad(PrivAI->getAllocatedType(), PrivAI, "local.use");
+    Value *PrivLoad = Builder.CreateLoad(PrivType, PrivAI, "local.use");
     Builder.CreateICmpNE(F->arg_begin(), PrivLoad);
   };
 
@@ -3274,8 +3274,8 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveThreads) {
 
   OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
 
-  AllocaInst *PrivAI =
-      Builder.CreateAlloca(F->arg_begin()->getType(), nullptr, "priv.inst");
+  Type *PrivType = F->arg_begin()->getType();
+  AllocaInst *PrivAI = Builder.CreateAlloca(PrivType, nullptr, "priv.inst");
 
   auto BodyGenCB = [&](InsertPointTy AllocaIP, InsertPointTy CodeGenIP) {
     llvm::BasicBlock *CodeGenIPBB = CodeGenIP.getBlock();
@@ -3284,8 +3284,7 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveThreads) {
 
     Builder.restoreIP(CodeGenIP);
     Builder.CreateStore(F->arg_begin(), PrivAI);
-    Value *PrivLoad =
-        Builder.CreateLoad(PrivAI->getAllocatedType(), PrivAI, "local.use");
+    Value *PrivLoad = Builder.CreateLoad(PrivType, PrivAI, "local.use");
     Builder.CreateICmpNE(F->arg_begin(), PrivLoad);
   };
 
@@ -3351,8 +3350,8 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveSimd) {
 
   OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
 
-  AllocaInst *PrivAI =
-      Builder.CreateAlloca(F->arg_begin()->getType(), nullptr, "priv.inst");
+  Type *PrivType = F->arg_begin()->getType();
+  AllocaInst *PrivAI = Builder.CreateAlloca(PrivType, nullptr, "priv.inst");
 
   auto BodyGenCB = [&](InsertPointTy AllocaIP, InsertPointTy CodeGenIP) {
     llvm::BasicBlock *CodeGenIPBB = CodeGenIP.getBlock();
@@ -3361,8 +3360,7 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveSimd) {
 
     Builder.restoreIP(CodeGenIP);
     Builder.CreateStore(F->arg_begin(), PrivAI);
-    Value *PrivLoad =
-        Builder.CreateLoad(PrivAI->getAllocatedType(), PrivAI, "local.use");
+    Value *PrivLoad = Builder.CreateLoad(PrivType, PrivAI, "local.use");
     Builder.CreateICmpNE(F->arg_begin(), PrivLoad);
   };
 
@@ -3466,7 +3464,8 @@ TEST_F(OpenMPIRBuilderTest, SingleDirective) {
       Builder.restoreIP(AllocaIP);
     else
       Builder.SetInsertPoint(&*(F->getEntryBlock().getFirstInsertionPt()));
-    PrivAI = Builder.CreateAlloca(F->arg_begin()->getType());
+    Type *PrivType = F->arg_begin()->getType();
+    PrivAI = Builder.CreateAlloca(PrivType);
     Builder.CreateStore(F->arg_begin(), PrivAI);
 
     llvm::BasicBlock *CodeGenIPBB = CodeGenIP.getBlock();
@@ -3480,8 +3479,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirective) {
     EntryBB = ThenBB->getUniquePredecessor();
 
     // simple instructions for body
-    Value *PrivLoad =
-        Builder.CreateLoad(PrivAI->getAllocatedType(), PrivAI, "local.use");
+    Value *PrivLoad = Builder.CreateLoad(PrivType, PrivAI, "local.use");
     Builder.CreateICmpNE(F->arg_begin(), PrivLoad);
   };
 
@@ -3560,7 +3558,8 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveNowait) {
       Builder.restoreIP(AllocaIP);
     else
       Builder.SetInsertPoint(&*(F->getEntryBlock().getFirstInsertionPt()));
-    PrivAI = Builder.CreateAlloca(F->arg_begin()->getType());
+    Type *PrivType = F->arg_begin()->getType();
+    PrivAI = Builder.CreateAlloca(PrivType);
     Builder.CreateStore(F->arg_begin(), PrivAI);
 
     llvm::BasicBlock *CodeGenIPBB = CodeGenIP.getBlock();
@@ -3574,8 +3573,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveNowait) {
     EntryBB = ThenBB->getUniquePredecessor();
 
     // simple instructions for body
-    Value *PrivLoad =
-        Builder.CreateLoad(PrivAI->getAllocatedType(), PrivAI, "local.use");
+    Value *PrivLoad = Builder.CreateLoad(PrivType, PrivAI, "local.use");
     Builder.CreateICmpNE(F->arg_begin(), PrivLoad);
   };
 
@@ -3682,7 +3680,8 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveCopyPrivate) {
       Builder.restoreIP(AllocaIP);
     else
       Builder.SetInsertPoint(&*(F->getEntryBlock().getFirstInsertionPt()));
-    PrivAI = Builder.CreateAlloca(F->arg_begin()->getType());
+    Type *PrivType = F->arg_begin()->getType();
+    PrivAI = Builder.CreateAlloca(PrivType);
     Builder.CreateStore(F->arg_begin(), PrivAI);
 
     llvm::BasicBlock *CodeGenIPBB = CodeGenIP.getBlock();
@@ -3696,8 +3695,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveCopyPrivate) {
     EntryBB = ThenBB->getUniquePredecessor();
 
     // simple instructions for body
-    Value *PrivLoad =
-        Builder.CreateLoad(PrivAI->getAllocatedType(), PrivAI, "local.use");
+    Value *PrivLoad = Builder.CreateLoad(PrivType, PrivAI, "local.use");
     Builder.CreateICmpNE(F->arg_begin(), PrivLoad);
   };
 
@@ -4632,11 +4630,11 @@ TEST_F(OpenMPIRBuilderTest, CreateTeams) {
     Builder.restoreIP(CodeGenIP);
     // Loading and storing captured pointer and values
     Builder.CreateStore(Val128, Local128);
-    Value *Val32 = Builder.CreateLoad(ValPtr32->getAllocatedType(), ValPtr32,
-                                      "bodygen.load32");
+    Value *Val32 =
+        Builder.CreateLoad(Builder.getInt32Ty(), ValPtr32, "bodygen.load32");
 
-    LoadInst *PrivLoad128 = Builder.CreateLoad(
-        Local128->getAllocatedType(), Local128, "bodygen.local.load128");
+    LoadInst *PrivLoad128 = Builder.CreateLoad(Builder.getInt128Ty(), Local128,
+                                               "bodygen.local.load128");
     Value *Cmp = Builder.CreateICmpNE(
         Val32, Builder.CreateTrunc(PrivLoad128, Val32->getType()));
     Instruction *ThenTerm, *ElseTerm;
@@ -7164,11 +7162,11 @@ TEST_F(OpenMPIRBuilderTest, CreateTask) {
     Builder.restoreIP(CodeGenIP);
     // Loading and storing captured pointer and values
     Builder.CreateStore(Val128, Local128);
-    Value *Val32 = Builder.CreateLoad(ValPtr32->getAllocatedType(), ValPtr32,
-                                      "bodygen.load32");
+    Value *Val32 =
+        Builder.CreateLoad(Builder.getInt32Ty(), ValPtr32, "bodygen.load32");
 
-    LoadInst *PrivLoad128 = Builder.CreateLoad(
-        Local128->getAllocatedType(), Local128, "bodygen.local.load128");
+    LoadInst *PrivLoad128 = Builder.CreateLoad(Builder.getInt128Ty(), Local128,
+                                               "bodygen.local.load128");
     Value *Cmp = Builder.CreateICmpNE(
         Val32, Builder.CreateTrunc(PrivLoad128, Val32->getType()));
     Instruction *ThenTerm, *ElseTerm;
@@ -7580,10 +7578,10 @@ TEST_F(OpenMPIRBuilderTest, CreateTaskgroup) {
     Builder.restoreIP(CodeGenIP);
     // Loading and storing captured pointer and values
     InternalStoreInst = Builder.CreateStore(Val128, Local128);
-    InternalLoad32 = Builder.CreateLoad(ValPtr32->getAllocatedType(), ValPtr32,
-                                        "bodygen.load32");
+    InternalLoad32 =
+        Builder.CreateLoad(Builder.getInt32Ty(), ValPtr32, "bodygen.load32");
 
-    InternalLoad128 = Builder.CreateLoad(Local128->getAllocatedType(), Local128,
+    InternalLoad128 = Builder.CreateLoad(Builder.getInt128Ty(), Local128,
                                          "bodygen.local.load128");
     InternalIfCmp = Builder.CreateICmpNE(
         InternalLoad32,
@@ -7671,8 +7669,7 @@ TEST_F(OpenMPIRBuilderTest, CreateTaskgroupWithTasks) {
     Builder.restoreIP(CodeGenIP);
     auto TaskBodyGenCB1 = [&](InsertPointTy AllocaIP, InsertPointTy CodeGenIP) {
       Builder.restoreIP(CodeGenIP);
-      LoadInst *LoadValue =
-          Builder.CreateLoad(Alloca64->getAllocatedType(), Alloca64);
+      LoadInst *LoadValue = Builder.CreateLoad(Builder.getInt64Ty(), Alloca64);
       Value *AddInst = Builder.CreateAdd(LoadValue, Builder.getInt64(64));
       Builder.CreateStore(AddInst, Alloca64);
       return Error::success();
@@ -7684,8 +7681,7 @@ TEST_F(OpenMPIRBuilderTest, CreateTaskgroupWithTasks) {
 
     auto TaskBodyGenCB2 = [&](InsertPointTy AllocaIP, InsertPointTy CodeGenIP) {
       Builder.restoreIP(CodeGenIP);
-      LoadInst *LoadValue =
-          Builder.CreateLoad(Alloca32->getAllocatedType(), Alloca32);
+      LoadInst *LoadValue = Builder.CreateLoad(Builder.getInt32Ty(), Alloca32);
       Value *AddInst = Builder.CreateAdd(LoadValue, Builder.getInt32(32));
       Builder.CreateStore(AddInst, Alloca32);
       return Error::success();


### PR DESCRIPTION
These are the required uses of the alloca type, but have trivial access to the expected result of that API call. The remaining uses in unittests are for testing the LLVM API itself.