### PR TITLE
[openmp] Allow to build doxygen-openmp in the stand alone mode

### DIFF
--- a/openmp/docs/CMakeLists.txt
+++ b/openmp/docs/CMakeLists.txt
@@ -1,4 +1,8 @@
 
+if (OPENMP_STANDALONE_BUILD)
+  include(HandleDoxygen)
+endif()
+
 if (DOXYGEN_FOUND)
 if (LLVM_ENABLE_DOXYGEN)
   set(abs_srcdir ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
doxygen-openmp can be built in 30 sec but it takes 30 min because of LLVM tools dependencies added by llvm-project/runtimes/CMakeLists.txt. Currently doxygen-openmp requires to build LLVM and clang. We can remove clang dependency adding `if (LLVM_INCLUDE_TESTS)` in 2 CMakeLists.txt files inside openmp but it will not remove LLVM tools dependency. After this patch we can use the stand alone mode to build doxygen-openmp in seconds.