### PR TITLE
draft: [Hexagon] Fix compile-time blowup with partially-reserved physregs

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonRDFOpt.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonRDFOpt.cpp
@@ -45,6 +45,7 @@ static cl::opt<unsigned>
              cl::init(std::numeric_limits<unsigned>::max()));
 
 extern cl::opt<unsigned> RDFFuncBlockLimit;
+extern cl::opt<unsigned> RDFFuncInstrLimit;
 
 static cl::opt<bool> RDFDump("hexagon-rdf-dump", cl::Hidden);
 static cl::opt<bool> RDFTrackReserved("hexagon-rdf-track-reserved", cl::Hidden);
@@ -285,6 +286,16 @@ bool HexagonRDFOpt::runOnMachineFunction(MachineFunction &MF) {
   if (MF.size() > RDFFuncBlockLimit) {
     if (RDFDump)
       dbgs() << "Skipping " << getPassName() << ": too many basic blocks\n";
+    return false;
+  }
+
+  unsigned InstrCount = 0;
+  for (const MachineBasicBlock &MBB : MF)
+    InstrCount += MBB.size();
+  if (InstrCount > RDFFuncInstrLimit) {
+    if (RDFDump)
+      dbgs() << "Skipping " << getPassName() << ": too many instructions ("
+             << InstrCount << ")\n";
     return false;
   }
 

--- a/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
@@ -43,6 +43,10 @@ cl::opt<unsigned> RDFFuncBlockLimit(
     "rdf-bb-limit", cl::Hidden, cl::init(1000),
     cl::desc("Basic block limit for a function for RDF optimizations"));
 
+cl::opt<unsigned> RDFFuncInstrLimit(
+    "rdf-instr-limit", cl::Hidden, cl::init(6000),
+    cl::desc("Instruction limit for a function for RDF optimizations"));
+
 static cl::opt<bool>
     DisableHardwareLoops("disable-hexagon-hwloops", cl::Hidden,
                          cl::desc("Disable Hardware Loops for Hexagon target"));

--- a/llvm/test/CodeGen/Hexagon/amode-opt-instr-limit.mir
+++ b/llvm/test/CodeGen/Hexagon/amode-opt-instr-limit.mir
@@ -1,0 +1,34 @@
+# RUN: llc -mtriple=hexagon -run-pass amode-opt -rdf-instr-limit=1 \
+# RUN:   -debug-only=opt-addr-mode %s -o - 2>&1 | FileCheck -check-prefix=SKIP %s
+# RUN: llc -mtriple=hexagon -run-pass amode-opt \
+# RUN:   -debug-only=opt-addr-mode %s -o - 2>&1 | FileCheck -check-prefix=OPT %s
+# REQUIRES: asserts
+#
+# Regression test for a compile-time blowup in amode-opt (issue #178535).
+#
+# HexagonOptAddrMode builds an RDF dataflow graph whose use-traversal is
+# quadratic in the number of instructions when a single register has many
+# uses.  Functions with few basic blocks but thousands of instructions
+# (e.g. kernel drivers after register allocation) can hang.
+#
+# Verify that the instruction-count limit (-rdf-instr-limit) causes the
+# pass to bail out early, and that the pass runs normally when the limit
+# is not exceeded.
+#
+# SKIP: Skipping Optimize addressing mode of load/store: too many instructions
+# OPT: [RefMap#]
+
+--- |
+  define void @test() { ret void }
+...
+---
+name: test
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $r0, $r1
+    $r2 = A2_tfrsi 255
+    S2_storerb_io $r0, 0, $r1
+    S2_storerb_io $r0, 1, $r2
+    PS_jmpret $r31, implicit-def $pc
+...


### PR DESCRIPTION
canJoinPhys checks isReserved on the super-register but joinReservedPhysReg additionally requires every register-unit root to be reserved.  When a target reserves only part of a super-register (e.g. Hexagon -ffixed-r19 reserves R19 and D9, but not R18), the mismatch causes joinReservedPhysReg to fail, reMaterializeDef to fail, and the copy to be unconditionally retried (Again = true) every worklist round.  In large functions this O(N^2) retry behaviour leads to multi-hour compile times.

Add the same regunit-root-reserved check to canJoinPhys so that it returns false early, routing through the !canJoinPhys path where Again is only set when IsDefCopy is true.