### PR TITLE
[TableGen] Use standard name for default mode in debug printing

### DIFF
--- a/llvm/test/TableGen/HwModeBitSet.td
+++ b/llvm/test/TableGen/HwModeBitSet.td
@@ -77,22 +77,22 @@ def XPairsClass : MyClass<64, [untyped], (add XPairs)>;
 // Modes who are not controlling Register related features will be manipulated
 // the same as DefaultMode.
 // CHECK-REG-LABEL: RegisterClass XRegs:
-// CHECK-REG: SpillSize: { Default:32 TestMode:64 TestMode1:32 TestMode2:32 }
-// CHECK-REG: SpillAlignment: { Default:32 TestMode:64 TestMode1:32 TestMode2:32 }
+// CHECK-REG: SpillSize: { DefaultMode:32 TestMode:64 TestMode1:32 TestMode2:32 }
+// CHECK-REG: SpillAlignment: { DefaultMode:32 TestMode:64 TestMode1:32 TestMode2:32 }
 // CHECK-REG: Regs: X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 X12 X13 X14 X15
 
 // CHECK-REG-LABEL: RegisterClass XPairsClass:
-// CHECK-REG: SpillSize: { Default:64 TestMode:128 TestMode1:64 TestMode2:64 }
-// CHECK-REG: SpillAlignment: { Default:32 TestMode:64 TestMode1:32 TestMode2:32 }
+// CHECK-REG: SpillSize: { DefaultMode:64 TestMode:128 TestMode1:64 TestMode2:64 }
+// CHECK-REG: SpillAlignment: { DefaultMode:32 TestMode:64 TestMode1:32 TestMode2:32 }
 // CHECK-REG: CoveredBySubRegs: 1
 // CHECK-REG: Regs: X0_X1 X2_X3 X4_X5 X6_X7 X8_X9 X10_X11 X12_X13 X14_X15
 
 // CHECK-REG-LABEL: SubRegIndex sub_even:
-// CHECK-REG: Offset: { Default:0 TestMode:0 TestMode1:0 TestMode2:0 }
-// CHECK-REG: Size: { Default:32 TestMode:64 TestMode1:32 TestMode2:32 }
+// CHECK-REG: Offset: { DefaultMode:0 TestMode:0 TestMode1:0 TestMode2:0 }
+// CHECK-REG: Size: { DefaultMode:32 TestMode:64 TestMode1:32 TestMode2:32 }
 // CHECK-REG-LABEL: SubRegIndex sub_odd:
-// CHECK-REG: Offset: { Default:32 TestMode:64 TestMode1:32 TestMode2:32 }
-// CHECK-REG: Size: { Default:32 TestMode:64 TestMode1:32 TestMode2:32 }
+// CHECK-REG: Offset: { DefaultMode:32 TestMode:64 TestMode1:32 TestMode2:32 }
+// CHECK-REG: Size: { DefaultMode:32 TestMode:64 TestMode1:32 TestMode2:32 }
 
 //============================================================================//
 //--------------------- Encoding/Decoding parts ------------------------------//

--- a/llvm/test/TableGen/HwModeSubRegs.td
+++ b/llvm/test/TableGen/HwModeSubRegs.td
@@ -57,19 +57,19 @@ def XPairsClass : MyClass<64, [untyped], (add XPairs)>;
 def TestTarget : Target;
 
 // CHECK-LABEL: RegisterClass XRegs:
-// CHECK: SpillSize: { Default:32 TestMode:64 }
-// CHECK: SpillAlignment: { Default:32 TestMode:64 }
+// CHECK: SpillSize: { DefaultMode:32 TestMode:64 }
+// CHECK: SpillAlignment: { DefaultMode:32 TestMode:64 }
 // CHECK: Regs: X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 X10 X11 X12 X13 X14 X15
 
 // CHECK-LABEL: RegisterClass XPairsClass:
-// CHECK: SpillSize: { Default:64 TestMode:128 }
-// CHECK: SpillAlignment: { Default:32 TestMode:64 }
+// CHECK: SpillSize: { DefaultMode:64 TestMode:128 }
+// CHECK: SpillAlignment: { DefaultMode:32 TestMode:64 }
 // CHECK: CoveredBySubRegs: 1
 // CHECK: Regs: X0_X1 X2_X3 X4_X5 X6_X7 X8_X9 X10_X11 X12_X13 X14_X15
 
 // CHECK-LABEL: SubRegIndex sub_even:
-// CHECK: Offset: { Default:0 TestMode:0 }
-// CHECK: Size: { Default:32 TestMode:64 }
+// CHECK: Offset: { DefaultMode:0 TestMode:0 }
+// CHECK: Size: { DefaultMode:32 TestMode:64 }
 // CHECK-LABEL: SubRegIndex sub_odd:
-// CHECK: Offset: { Default:32 TestMode:64 }
-// CHECK: Size: { Default:32 TestMode:64 }
+// CHECK: Offset: { DefaultMode:32 TestMode:64 }
+// CHECK: Size: { DefaultMode:32 TestMode:64 }

--- a/llvm/utils/TableGen/RegisterBankEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterBankEmitter.cpp
@@ -271,12 +271,8 @@ void RegisterBankEmitter::emitBaseClassImplementation(
   unsigned NumModeIds = CGH.getNumModeIds();
   OS << "const unsigned " << TargetName << "GenRegisterBankInfo::Sizes[] = {\n";
   for (unsigned M = 0; M < NumModeIds; ++M) {
-    OS << "    // Mode = " << M << " (";
-    if (M == DefaultMode)
-      OS << "Default";
-    else
-      OS << CGH.getMode(M).Name;
-    OS << ")\n";
+    OS << "    // Mode = " << M << " ("
+       << CGH.getModeName(M, /*IncludeDefault=*/true) << ")\n";
     for (const auto &Bank : Banks) {
       const CodeGenRegisterClass &RC = *Bank.getRCWithLargestRegSize(M);
       unsigned Size = RC.RSI.get(M).SpillSize;

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -1314,12 +1314,8 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
        << " = {\n";
     for (unsigned M = 0; M < NumModes; ++M) {
       unsigned EV = 0;
-      OS << "  // Mode = " << M << " (";
-      if (M == 0)
-        OS << "Default";
-      else
-        OS << CGH.getMode(M).Name;
-      OS << ")\n";
+      OS << "  // Mode = " << M << " ("
+         << CGH.getModeName(M, /*IncludeDefault=*/true) << ")\n";
       for (const auto &RC : RegisterClasses) {
         assert(RC.EnumValue == EV && "Unexpected order of register classes");
         ++EV;
@@ -1894,7 +1890,7 @@ Printable RegisterInfoEmitter::printByHwMode(const InfoByHwMode<InfoTy> &Info,
 
     OS << "{";
     for (unsigned M = 0, E = CGH.getNumModeIds(); M != E; ++M)
-      OS << ' ' << (M ? CGH.getModeName(M, true) : "Default") << ':'
+      OS << ' ' << CGH.getModeName(M, /*IncludeDefault=*/true) << ':'
          << Func(Info.get(M));
     OS << " }";
   });


### PR DESCRIPTION
In comments in generated files and in -register-info-debug output, use
the standard name "DefaultMode" for consistency, instead of hard coding
an alternative name "Default".
