### PR TITLE
[CI][ScriptedBuilder] Avoid python 3.12-only option

### DIFF
--- a/.ci/buildbot/worker.py
+++ b/.ci/buildbot/worker.py
@@ -148,7 +148,7 @@ def rmtree(path):
     Taken from official Python docs
     https://docs.python.org/3/library/shutil.html#rmtree-example
     """
-    shutil.rmtree(path, onexc=_remove_readonly)
+    shutil.rmtree(path, onerror=_remove_readonly)
 
 
 def try_delete(path):


### PR DESCRIPTION
The shutil.rmtree(onexc=) parameter was only added in Python 3.12. Use onerror= instead whose callback signature takes a different third parameter which is ignored anyway.