### PR TITLE
[Clang][Driver][NFC] Capture -foffload-lto Arg before dereferencing

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5233,23 +5233,19 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-emit-llvm-uselists");
 
     if (IsUsingLTO) {
+      Arg *OffloadLTO = Args.getLastArg(options::OPT_foffload_lto,
+                                        options::OPT_foffload_lto_EQ);
       if (IsDeviceOffloadAction && !JA.isDeviceOffloading(Action::OFK_OpenMP) &&
           !Args.hasFlag(options::OPT_offload_new_driver,
                         options::OPT_no_offload_new_driver,
                         C.isOffloadingHostKind(Action::OFK_Cuda)) &&
-          !Triple.isAMDGPU()) {
+          !Triple.isAMDGPU() && OffloadLTO) {
         D.Diag(diag::err_drv_unsupported_opt_for_target)
-            << Args.getLastArg(options::OPT_foffload_lto,
-                               options::OPT_foffload_lto_EQ)
-                   ->getAsString(Args)
-            << Triple.getTriple();
+            << OffloadLTO->getAsString(Args) << Triple.getTriple();
       } else if (Triple.isNVPTX() && !IsRDCMode &&
-                 JA.isDeviceOffloading(Action::OFK_Cuda)) {
+                 JA.isDeviceOffloading(Action::OFK_Cuda) && OffloadLTO) {
         D.Diag(diag::err_drv_unsupported_opt_for_language_mode)
-            << Args.getLastArg(options::OPT_foffload_lto,
-                               options::OPT_foffload_lto_EQ)
-                   ->getAsString(Args)
-            << "-fno-gpu-rdc";
+            << OffloadLTO->getAsString(Args) << "-fno-gpu-rdc";
       } else {
         assert(LTOMode == LTOK_Full || LTOMode == LTOK_Thin);
         CmdArgs.push_back(Args.MakeArgString(


### PR DESCRIPTION
Capture the pointer returned by `getLastArg` first to ensure the argument exists before dereferencing.