### PR TITLE
[tsan] Only init AdaptiveDelay if enabled

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_adaptive_delay.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_adaptive_delay.cpp
@@ -260,11 +260,7 @@ struct AdaptiveDelayImpl {
   DelaySpec atomic_delay_;
   DelaySpec sync_delay_;
 
-  void Init() {
-    InitTls();
-
-    AdaptiveDelay::is_adaptive_delay_enabled = flags()->enable_adaptive_delay;
-  }
+  void Init() { InitTls(); }
 
   void InitTls() {
     TLS()->bucket_start_ns_ = NanoTime();
@@ -414,7 +410,13 @@ AdaptiveDelayImpl& GetImpl() {
 
 bool AdaptiveDelay::is_adaptive_delay_enabled;
 
-void AdaptiveDelay::InitImpl() { GetImpl().Init(); }
+void AdaptiveDelay::InitImpl() {
+  AdaptiveDelay::is_adaptive_delay_enabled = flags()->enable_adaptive_delay;
+  if (!AdaptiveDelay::is_adaptive_delay_enabled)
+    return;
+
+  GetImpl().Init();
+}
 
 void AdaptiveDelay::SyncOpImpl() { GetImpl().SyncOp(); }
 void AdaptiveDelay::AtomicOpFenceImpl(int mo) { GetImpl().AtomicOpFence(mo); }

--- a/compiler-rt/lib/tsan/rtl/tsan_adaptive_delay.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_adaptive_delay.h
@@ -82,8 +82,6 @@ struct AdaptiveDelay {
   static void BeforeChildThreadRunsImpl();
 
   static bool is_adaptive_delay_enabled;
-
-  friend struct AdaptiveDelayImpl;
 };
 
 // The runtime defines cur_thread() to retrieve TLS thread state, and it


### PR DESCRIPTION
In #178836, while refactoring from a virtual class design to a non-virtual design, the logic ended up such that AdaptiveDelayImpl was always constructed, even if the adaptive delay feature was not enabled. Adaptive delay itself was always disabled if the flag was off, this just prevents the ctor from running at all.

@dvyukov