### PR TITLE
[ADT] Remove misleading is_const check in MutableArrayRef constructor

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -327,7 +327,6 @@ namespace llvm {
     template <typename C,
               typename = std::enable_if_t<
                   std::conjunction_v<
-                      std::negation<std::is_const<C>>,
                       std::is_convertible<
                           decltype(std::declval<C &>().data()) *, T *const *>,
                       std::is_integral<decltype(std::declval<C &>().size())>>,

--- a/llvm/unittests/ADT/ArrayRefTest.cpp
+++ b/llvm/unittests/ADT/ArrayRefTest.cpp
@@ -491,6 +491,10 @@ static_assert(
 static_assert(
     std::is_constructible_v<MutableArrayRef<int>, std::span<int>>,
     "should be able to construct MutableArrayRef from mutable std::span");
+static_assert(
+    std::is_constructible_v<MutableArrayRef<int>, const std::span<int>>,
+    "should be able to construct MutableArrayRef from const std::span with "
+    "mutable elements");
 #endif
 
 } // end anonymous namespace


### PR DESCRIPTION
The `std::negation<std::is_const<C>>` check here seems semantically inaccurate; we should care about whether the container provides mutable element access, not the constness of the container itself. This was already being checked but was previously being dropped prior to the change from `const C&` to `C&` in https://github.com/llvm/llvm-project/pull/181190. That was sufficient in itself to fix the referenced issue https://github.com/llvm/llvm-project/issues/181176