### PR TITLE
[LLVM][Utils] Fix automerge in git-llvm-push

### DIFF
--- a/llvm/utils/git-llvm-push
+++ b/llvm/utils/git-llvm-push
@@ -304,6 +304,10 @@ class GitHubAPI:
 
         self.runner.print(f"Enabling auto-merge for #{pr_number}...")
         node_id = self._get_node_id(pr_number)
+        # Use the enablePullRequestAutoMerge mutation to enable auto merge
+        # through the GraphQL API as this cannot be done through the REST
+        # API. Documented in
+        # https://docs.github.com/en/graphql/reference/mutations#enablepullrequestautomerge
         graphql_mutation = """
         mutation EnableAutomergeMutation($pr_id: ID!) {
             enablePullRequestAutoMerge(input: {pullRequestId: $pr_id, mergeMethod: SQUASH}) {

--- a/llvm/utils/git-llvm-push
+++ b/llvm/utils/git-llvm-push
@@ -202,7 +202,7 @@ class GitHubAPI:
         title: str,
         body: str,
         draft: bool,
-    ) -> int:
+    ) -> tuple:
         if self.runner.dry_run:
             self.runner.print(f"[Dry Run] Would create pull request for '{head_branch}'...")
             return 0
@@ -219,7 +219,7 @@ class GitHubAPI:
             "POST", f"/repos/{LLVM_REPO}/pulls", json_payload=data
         )
         self.runner.print(f"Pull request created: {response_data.get("html_url")}")
-        return response_data.get("number")
+        return (response_data.get("node_id"), response_data.get("number"))
 
     def get_repo_settings(self) -> dict:
         return self._request_and_parse_json("GET", f"/repos/{LLVM_REPO}")
@@ -291,19 +291,12 @@ class GitHubAPI:
 
         raise LlvmPrError(f"PR was not mergeable after {MERGE_MAX_RETRIES} attempts.")
 
-    def _get_node_id(self, pr_number: int) -> str:
-        pr_data = self._request_and_parse_json(
-            "GET", f"/repos/{LLVM_REPO}/pulls/{pr_number}"
-        )
-        return pr_data["node_id"]
-
-    def enable_auto_merge(self, pr_number: int) -> None:
+    def enable_auto_merge(self, pr_number: int, node_id: str) -> None:
         if self.runner.dry_run:
             self.runner.print(f"[Dry Run] Would enable auto-merge for #{pr_number}")
             return
 
         self.runner.print(f"Enabling auto-merge for #{pr_number}...")
-        node_id = self._get_node_id(pr_number)
         # Use the enablePullRequestAutoMerge mutation to enable auto merge
         # through the GraphQL API as this cannot be done through the REST
         # API. Documented in
@@ -509,7 +502,7 @@ class LLVMPRAutomator:
         temp_branch = self._create_and_push_branch_for_commit(
             commit_hash, base_branch_name, index
         )
-        pr_number = self.github_api.create_pr(
+        pr_nodeid, pr_number = self.github_api.create_pr(
             head_branch=f"{self.config.user_login}:{temp_branch}",
             base_branch=self.config.base_branch,
             title=commit_title,
@@ -528,7 +521,7 @@ class LLVMPRAutomator:
             return
 
         if self.config.auto_merge:
-            self.github_api.enable_auto_merge(pr_number)
+            self.github_api.enable_auto_merge(pr_number, pr_nodeid)
         else:
             merged_branch = self.github_api.merge_pr(pr_number)
             if merged_branch and not self.repo_settings.get("delete_branch_on_merge"):

--- a/llvm/utils/git-llvm-push
+++ b/llvm/utils/git-llvm-push
@@ -172,6 +172,17 @@ class GitHubAPI:
             # operation was successful but there is no body.
             self._log_unexpected_status([204], response.status)
 
+    def _request_graphql(self, query: str, variables: dict):
+        output = self._request_and_parse_json(
+            "POST", "/graphql", {"query": query, "variables": variables}
+        )
+        if "errors" in output:
+            error_str = f"Error: GraphQL API returned errors: {', '.join([str(error) for error in output['errors']])}"
+            self.runner.print(
+                error_str,
+                file=sys.stderr,
+            )
+
     def _log_unexpected_status(
         self, expected_statuses: List[int], actual_status: int
     ) -> None:
@@ -280,21 +291,28 @@ class GitHubAPI:
 
         raise LlvmPrError(f"PR was not mergeable after {MERGE_MAX_RETRIES} attempts.")
 
+    def _get_node_id(self, pr_number: int) -> str:
+        pr_data = self._request_and_parse_json(
+            "GET", f"/repos/{LLVM_REPO}/pulls/{pr_number}"
+        )
+        return pr_data["node_id"]
+
     def enable_auto_merge(self, pr_number: int) -> None:
         if self.runner.dry_run:
             self.runner.print(f"[Dry Run] Would enable auto-merge for #{pr_number}")
             return
 
         self.runner.print(f"Enabling auto-merge for #{pr_number}...")
-        data = {
-            "enabled": True,
-            "merge_method": "squash",
+        node_id = self._get_node_id(pr_number)
+        graphql_mutation = """
+        mutation EnableAutomergeMutation($pr_id: ID!) {
+            enablePullRequestAutoMerge(input: {pullRequestId: $pr_id, mergeMethod: SQUASH}) {
+                clientMutationId
+            }
         }
-        self._request_no_content(
-            "PUT",
-            f"/repos/{LLVM_REPO}/pulls/{pr_number}/auto-merge",
-            json_payload=data,
-        )
+        """
+        graphql_variables = {"pr_id": node_id}
+        self._request_graphql(graphql_mutation, graphql_variables)
         self.runner.print("Auto-merge enabled.")
 
     def delete_branch(


### PR DESCRIPTION
Enabling automerge can only be done using the GraphQL API. Add in some basic GraphQL infrastructure and update the enable_automerge method to call the GraphQL API to enable automerge for a PR.

Tested locally on #181762.

Closes #181634.