### PR TITLE
[clang][diagnostics] Refactor `warn_doc_function_method_decl_mismatch` to use enum_select

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCommentKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommentKinds.td
@@ -77,7 +77,9 @@ def warn_doc_param_not_attached_to_a_function_decl : Warning<
   InGroup<Documentation>, DefaultIgnore;
 
 def warn_doc_function_method_decl_mismatch : Warning<
-  "'%select{\\|@}0%select{function|functiongroup|method|methodgroup|callback}1' "
+  "'%select{\\|@}0%enum_select<CallableKind>{"
+  "%Function{function}|%FunctionGroup{functiongroup}|"
+  "%Method{method}|%MethodGroup{methodgroup}|%Callback{callback}}1' "
   "command should be used in a comment attached to "
   "%select{a function|a function|an Objective-C method|an Objective-C method|"
   "a pointer to function}2 declaration">,

--- a/clang/lib/AST/CommentSema.cpp
+++ b/clang/lib/AST/CommentSema.cpp
@@ -100,32 +100,33 @@ void Sema::checkFunctionDeclVerbatimLine(const BlockCommandComment *Comment) {
   if (!Info->IsFunctionDeclarationCommand)
     return;
 
-  unsigned DiagSelect;
+  std::optional<unsigned> DiagSelect;
   switch (Comment->getCommandID()) {
     case CommandTraits::KCI_function:
-      DiagSelect = (!isAnyFunctionDecl() && !isFunctionTemplateDecl())? 1 : 0;
+      if (!isAnyFunctionDecl() && !isFunctionTemplateDecl())
+        DiagSelect = diag::CallableKind::Function;
       break;
     case CommandTraits::KCI_functiongroup:
-      DiagSelect = (!isAnyFunctionDecl() && !isFunctionTemplateDecl())? 2 : 0;
+      if (!isAnyFunctionDecl() && !isFunctionTemplateDecl())
+        DiagSelect = diag::CallableKind::FunctionGroup;
       break;
     case CommandTraits::KCI_method:
-      DiagSelect = !isObjCMethodDecl() ? 3 : 0;
+      DiagSelect = diag::CallableKind::Method;
       break;
     case CommandTraits::KCI_methodgroup:
-      DiagSelect = !isObjCMethodDecl() ? 4 : 0;
+      DiagSelect = diag::CallableKind::MethodGroup;
       break;
     case CommandTraits::KCI_callback:
-      DiagSelect = !isFunctionPointerVarDecl() ? 5 : 0;
+      DiagSelect = diag::CallableKind::Callback;
       break;
     default:
-      DiagSelect = 0;
+      DiagSelect = std::nullopt;
       break;
   }
   if (DiagSelect)
     Diag(Comment->getLocation(), diag::warn_doc_function_method_decl_mismatch)
-    << Comment->getCommandMarker()
-    << (DiagSelect-1) << (DiagSelect-1)
-    << Comment->getSourceRange();
+        << Comment->getCommandMarker() << (*DiagSelect) << (*DiagSelect)
+        << Comment->getSourceRange();
 }
 
 void Sema::checkContainerDeclVerbatimLine(const BlockCommandComment *Comment) {

--- a/clang/lib/AST/CommentSema.cpp
+++ b/clang/lib/AST/CommentSema.cpp
@@ -119,9 +119,6 @@ void Sema::checkFunctionDeclVerbatimLine(const BlockCommandComment *Comment) {
     case CommandTraits::KCI_callback:
       DiagSelect = diag::CallableKind::Callback;
       break;
-    default:
-      DiagSelect = std::nullopt;
-      break;
   }
   if (DiagSelect)
     Diag(Comment->getLocation(), diag::warn_doc_function_method_decl_mismatch)


### PR DESCRIPTION
Related: https://github.com/llvm/llvm-project/issues/123121

This patch refactors the `warn_doc_function_method_decl_mismatch` diagnostic to use `enum_select` instead of `select`. This gets rid of magic numbers in its caller and improves readability.