### PR TITLE
[AMDGPU] Tune 8-pass MFMA resource usage

### DIFF
--- a/llvm/lib/Target/AMDGPU/SISchedule.td
+++ b/llvm/lib/Target/AMDGPU/SISchedule.td
@@ -186,7 +186,7 @@ multiclass SICommonWriteRes {
   def : HWWriteRes<Write2PassMAI,  [HWXDL], 2>;
   let ReleaseAtCycles = [4] in
   def : HWWriteRes<Write4PassMAI,  [HWXDL], 4>;
-  let ReleaseAtCycles = [8] in
+  let ReleaseAtCycles = [7] in
   def : HWWriteRes<Write8PassMAI,  [HWXDL], 8>;
   let ReleaseAtCycles = [16] in
   def : HWWriteRes<Write16PassMAI, [HWXDL], 16>;

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.iglp.opt.exp.large.mir
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.iglp.opt.exp.large.mir
@@ -16,7 +16,7 @@
   ; GCN-NEXT:    ; implicit-def: $sgpr8_sgpr9_sgpr10_sgpr11
   ; GCN-NEXT:    s_lshl_b32 s18, s17, 7
   ; GCN-NEXT:    ; implicit-def: $vgpr18
-  ; GCN-NEXT:    v_add_lshl_u32 v230, v18, s18, 1
+  ; GCN-NEXT:    v_add_lshl_u32 v228, v18, s18, 1
   ; GCN-NEXT:    v_lshl_add_u32 v25, s17, 4, v25
   ; GCN-NEXT:    v_mul_lo_u32 v25, v25, s6
   ; GCN-NEXT:    v_add_lshl_u32 v226, v25, v17, 1
@@ -28,173 +28,172 @@
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_add_u32_e32 v72, 64, v17
-  ; GCN-NEXT:    ; implicit-def: $vgpr213
-  ; GCN-NEXT:    ; implicit-def: $vgpr152_vgpr153_vgpr154_vgpr155
-  ; GCN-NEXT:    ; implicit-def: $vgpr246
-  ; GCN-NEXT:    v_add_u32_e32 v188, 0x80, v17
-  ; GCN-NEXT:    ; implicit-def: $vgpr156_vgpr157_vgpr158_vgpr159
-  ; GCN-NEXT:    ; implicit-def: $vgpr144_vgpr145_vgpr146_vgpr147
+  ; GCN-NEXT:    ; implicit-def: $vgpr205
+  ; GCN-NEXT:    ; implicit-def: $vgpr148_vgpr149_vgpr150_vgpr151
+  ; GCN-NEXT:    ; implicit-def: $vgpr238
+  ; GCN-NEXT:    v_add_u32_e32 v168, 0x80, v17
+  ; GCN-NEXT:    ; implicit-def: $vgpr176_vgpr177_vgpr178_vgpr179
+  ; GCN-NEXT:    ; implicit-def: $vgpr180_vgpr181_vgpr182_vgpr183
   ; GCN-NEXT:    ; implicit-def: $vgpr19
   ; GCN-NEXT:    ; implicit-def: $vgpr26
   ; GCN-NEXT:    ; implicit-def: $vgpr27
-  ; GCN-NEXT:    v_add_u32_e32 v227, 0xc0, v17
-  ; GCN-NEXT:    v_add_u32_e32 v231, v19, v26
-  ; GCN-NEXT:    v_add_u32_e32 v232, v19, v27
-  ; GCN-NEXT:    ; implicit-def: $sgpr0_sgpr1_sgpr2_sgpr3
   ; GCN-NEXT:    ; implicit-def: $vgpr28
   ; GCN-NEXT:    ; implicit-def: $vgpr29
-  ; GCN-NEXT:    v_add_u32_e32 v233, v19, v28
-  ; GCN-NEXT:    v_add_u32_e32 v234, v19, v29
+  ; GCN-NEXT:    v_add_u32_e32 v227, 0xc0, v17
+  ; GCN-NEXT:    v_add_u32_e32 v229, v19, v26
+  ; GCN-NEXT:    v_add_u32_e32 v230, v19, v27
+  ; GCN-NEXT:    v_add_u32_e32 v231, v19, v28
+  ; GCN-NEXT:    v_add_u32_e32 v232, v19, v29
+  ; GCN-NEXT:    ; implicit-def: $vgpr144_vgpr145_vgpr146_vgpr147
+  ; GCN-NEXT:    ; implicit-def: $sgpr0_sgpr1_sgpr2_sgpr3
   ; GCN-NEXT:    ; implicit-def: $vgpr140_vgpr141_vgpr142_vgpr143
   ; GCN-NEXT:    ; implicit-def: $sgpr5
   ; GCN-NEXT:    ; implicit-def: $sgpr7
-  ; GCN-NEXT:    ; implicit-def: $vgpr148_vgpr149_vgpr150_vgpr151
   ; GCN-NEXT:    ; implicit-def: $vgpr136_vgpr137_vgpr138_vgpr139
   ; GCN-NEXT:    ; implicit-def: $vgpr132_vgpr133_vgpr134_vgpr135
+  ; GCN-NEXT:    ; implicit-def: $vgpr128_vgpr129_vgpr130_vgpr131
+  ; GCN-NEXT:    ; implicit-def: $sgpr14
   ; GCN-NEXT:    ; implicit-def: $vgpr20
   ; GCN-NEXT:    v_add_u32_e32 v18, s17, v20
   ; GCN-NEXT:    v_and_b32_e32 v18, 0x1fffffff, v18
   ; GCN-NEXT:    ; implicit-def: $sgpr16
   ; GCN-NEXT:    v_mul_lo_u32 v18, v18, s16
   ; GCN-NEXT:    ; implicit-def: $vgpr21
-  ; GCN-NEXT:    v_add_lshl_u32 v199, v21, v18, 1
+  ; GCN-NEXT:    v_add_lshl_u32 v191, v21, v18, 1
   ; GCN-NEXT:    ; implicit-def: $vgpr22
-  ; GCN-NEXT:    v_lshl_add_u32 v200, v22, 1, v199
+  ; GCN-NEXT:    v_lshl_add_u32 v192, v22, 1, v191
   ; GCN-NEXT:    ; implicit-def: $vgpr23
-  ; GCN-NEXT:    v_lshl_add_u32 v201, v23, 1, v200
+  ; GCN-NEXT:    v_lshl_add_u32 v193, v23, 1, v192
   ; GCN-NEXT:    ; implicit-def: $vgpr24
-  ; GCN-NEXT:    v_lshl_add_u32 v202, v24, 1, v201
+  ; GCN-NEXT:    v_lshl_add_u32 v194, v24, 1, v193
   ; GCN-NEXT:    ; implicit-def: $vgpr16
   ; GCN-NEXT:    ; implicit-def: $vgpr18
   ; GCN-NEXT:    ; implicit-def: $vgpr20
   ; GCN-NEXT:    ; implicit-def: $vgpr24
-  ; GCN-NEXT:    v_add_u32_e32 v247, v19, v24
-  ; GCN-NEXT:    v_add_u32_e32 v248, v19, v16
-  ; GCN-NEXT:    v_add_u32_e32 v249, v19, v18
-  ; GCN-NEXT:    v_add_u32_e32 v250, v19, v20
-  ; GCN-NEXT:    ; implicit-def: $vgpr128_vgpr129_vgpr130_vgpr131
-  ; GCN-NEXT:    ; implicit-def: $sgpr14
-  ; GCN-NEXT:    ; implicit-def: $vgpr196
+  ; GCN-NEXT:    v_add_u32_e32 v239, v19, v24
+  ; GCN-NEXT:    v_add_u32_e32 v240, v19, v16
+  ; GCN-NEXT:    v_add_u32_e32 v241, v19, v18
+  ; GCN-NEXT:    v_add_u32_e32 v242, v19, v20
+  ; GCN-NEXT:    ; implicit-def: $vgpr188
   ; GCN-NEXT:    ; implicit-def: $sgpr12_sgpr13
-  ; GCN-NEXT:    ; implicit-def: $vgpr211
-  ; GCN-NEXT:    v_max_f32_e32 v212, v211, v211
-  ; GCN-NEXT:    ; implicit-def: $vgpr198
+  ; GCN-NEXT:    ; implicit-def: $vgpr203
+  ; GCN-NEXT:    v_max_f32_e32 v204, v203, v203
+  ; GCN-NEXT:    ; implicit-def: $vgpr190
   ; GCN-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15
   ; GCN-NEXT:    ; implicit-def: $vgpr32
   ; GCN-NEXT:    ; implicit-def: $vgpr33
   ; GCN-NEXT:    ; implicit-def: $vgpr34
-  ; GCN-NEXT:    v_add_u32_e32 v210, v19, v34
-  ; GCN-NEXT:    v_add_u32_e32 v206, v19, v33
-  ; GCN-NEXT:    v_add_u32_e32 v205, v19, v32
+  ; GCN-NEXT:    v_add_u32_e32 v201, v19, v34
+  ; GCN-NEXT:    v_add_u32_e32 v197, v19, v33
+  ; GCN-NEXT:    v_add_u32_e32 v196, v19, v32
   ; GCN-NEXT:    ; implicit-def: $vgpr32_vgpr33_vgpr34_vgpr35_vgpr36_vgpr37_vgpr38_vgpr39_vgpr40_vgpr41_vgpr42_vgpr43_vgpr44_vgpr45_vgpr46_vgpr47
   ; GCN-NEXT:    ; implicit-def: $vgpr21
   ; GCN-NEXT:    ; implicit-def: $vgpr22
   ; GCN-NEXT:    ; implicit-def: $vgpr23
   ; GCN-NEXT:    ; implicit-def: $vgpr30
   ; GCN-NEXT:    ; implicit-def: $vgpr31
-  ; GCN-NEXT:    v_add_u32_e32 v207, v19, v21
-  ; GCN-NEXT:    v_add_u32_e32 v208, v19, v22
-  ; GCN-NEXT:    v_add_u32_e32 v209, v19, v23
-  ; GCN-NEXT:    v_add_u32_e32 v203, v19, v30
-  ; GCN-NEXT:    v_add_u32_e32 v204, v19, v31
+  ; GCN-NEXT:    v_add_u32_e32 v202, v19, v21
+  ; GCN-NEXT:    v_add_u32_e32 v199, v19, v22
+  ; GCN-NEXT:    v_add_u32_e32 v200, v19, v23
+  ; GCN-NEXT:    v_add_u32_e32 v198, v19, v30
+  ; GCN-NEXT:    v_add_u32_e32 v195, v19, v31
   ; GCN-NEXT:    ; kill: killed $vgpr17
   ; GCN-NEXT:    ; implicit-def: $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23_vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31
   ; GCN-NEXT:    ; implicit-def: $vgpr48_vgpr49_vgpr50_vgpr51_vgpr52_vgpr53_vgpr54_vgpr55_vgpr56_vgpr57_vgpr58_vgpr59_vgpr60_vgpr61_vgpr62_vgpr63
-  ; GCN-NEXT:    ; implicit-def: $vgpr197
+  ; GCN-NEXT:    ; implicit-def: $vgpr189
   ; GCN-NEXT:    ; iglp_opt mask(0x00000002)
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    ds_write_b128 v230, v[64:67]
+  ; GCN-NEXT:    ds_write_b128 v228, v[64:67]
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b128 v230, v[68:71] offset:1024
+  ; GCN-NEXT:    ds_write_b128 v228, v[68:71] offset:1024
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    buffer_load_dwordx4 v[160:163], v226, s[8:11], 0 offen offset:64 sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx4 v[152:155], v226, s[8:11], 0 offen offset:64 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx4 v[164:167], v72, s[8:11], 0 offen sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx4 v[156:159], v72, s[8:11], 0 offen sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
-  ; GCN-NEXT:    ds_read_b128 v[64:67], v213
+  ; GCN-NEXT:    ds_read_b128 v[64:67], v205
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[64:65], v[152:153], 0
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[66:67], v[154:155], v[112:127]
-  ; GCN-NEXT:    ds_read_b128 v[64:67], v213 offset:512
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[64:65], v[148:149], 0
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[66:67], v[150:151], v[112:127]
+  ; GCN-NEXT:    ds_read_b128 v[64:67], v205 offset:512
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[64:65], v[152:153], 0
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[66:67], v[154:155], v[96:111]
-  ; GCN-NEXT:    ds_read_b128 v[64:67], v213 offset:1024
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[64:65], v[148:149], 0
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[66:67], v[150:151], v[96:111]
+  ; GCN-NEXT:    ds_read_b128 v[64:67], v205 offset:1024
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[168:171], v213 offset:1536
+  ; GCN-NEXT:    ds_read_b128 v[160:163], v205 offset:1536
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[172:175], v246
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[64:65], v[148:149], 0
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[66:67], v[150:151], v[80:95]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[160:161], v[148:149], 0
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[162:163], v[150:151], v[64:79]
+  ; GCN-NEXT:    ds_read_b128 v[148:151], v238
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[176:179], v246 offset:512
+  ; GCN-NEXT:    ds_read_b128 v[160:163], v238 offset:512
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[180:183], v246 offset:1024
+  ; GCN-NEXT:    ds_read_b128 v[164:167], v238 offset:1024
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[184:187], v246 offset:1536
+  ; GCN-NEXT:    ds_read_b128 v[184:187], v238 offset:1536
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[64:65], v[152:153], 0
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    ds_write_b128 v230, v[160:163]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[66:67], v[154:155], v[80:95]
+  ; GCN-NEXT:    ds_write_b128 v228, v[152:155]
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b128 v230, v[164:167] offset:1024
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[168:169], v[152:153], 0
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[170:171], v[154:155], v[64:79]
+  ; GCN-NEXT:    ds_write_b128 v228, v[156:159] offset:1024
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_load_dwordx4 v[152:155], v226, s[8:11], 0 offen offset:128 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx4 v[160:163], v188, s[8:11], 0 offen sc0 sc1
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[148:149], v[176:177], v[112:127]
+  ; GCN-NEXT:    buffer_load_dwordx4 v[168:171], v168, s[8:11], 0 offen sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
-  ; GCN-NEXT:    ds_read_b128 v[188:191], v213
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[150:151], v[178:179], v[112:127]
+  ; GCN-NEXT:    ds_read_b128 v[148:151], v205
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[192:195], v213 offset:512
+  ; GCN-NEXT:    ds_read_b128 v[172:175], v205 offset:512
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[164:167], v213 offset:1024
+  ; GCN-NEXT:    ds_read_b128 v[206:209], v205 offset:1024
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[214:217], v213 offset:1536
+  ; GCN-NEXT:    ds_read_b128 v[210:213], v205 offset:1536
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[172:173], v[156:157], v[112:127]
-  ; GCN-NEXT:    ds_read_b128 v[218:221], v246
+  ; GCN-NEXT:    ds_read_b128 v[214:217], v238
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[222:225], v246 offset:512
+  ; GCN-NEXT:    ds_read_b128 v[218:221], v238 offset:512
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[168:171], v246 offset:1024
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[148:149], v[180:181], v[112:127]
+  ; GCN-NEXT:    ds_read_b128 v[222:225], v238 offset:1024
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[174:175], v[158:159], v[112:127]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[188:189], v[144:145], v[112:127]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[190:191], v[146:147], v[112:127]
-  ; GCN-NEXT:    ds_read_b128 v[188:191], v246 offset:1536
+  ; GCN-NEXT:    ds_read_b128 v[156:159], v238 offset:1536
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    ;;#ASMSTART
@@ -202,81 +201,90 @@
   ; GCN-NEXT:    ;;#ASMEND
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    ds_write_b128 v230, v[152:155]
+  ; GCN-NEXT:    ds_write_b128 v228, v[152:155]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[150:151], v[182:183], v[112:127]
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b128 v230, v[160:163] offset:1024
+  ; GCN-NEXT:    ds_write_b128 v228, v[168:171] offset:1024
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    buffer_load_dwordx4 v[152:155], v226, s[8:11], 0 offen offset:192 sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx4 v[148:151], v226, s[8:11], 0 offen offset:192 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[184:185], v[156:157], v[64:79]
-  ; GCN-NEXT:    buffer_load_dwordx4 v[226:229], v227, s[8:11], 0 offen sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx4 v[152:155], v227, s[8:11], 0 offen sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx2 v[160:161], v231, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx2 v[168:169], v229, s[0:3], 0 offen sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx2 v[162:163], v232, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx2 v[170:171], v230, s[0:3], 0 offen sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx2 v[172:173], v233, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    v_perm_b32 v230, v170, v168, s5
+  ; GCN-NEXT:    buffer_load_dwordx2 v[226:227], v231, s[0:3], 0 offen sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx2 v[174:175], v234, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[214:215], v[144:145], v[112:127]
+  ; GCN-NEXT:    buffer_load_dwordx2 v[214:215], v232, s[0:3], 0 offen sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[186:187], v[158:159], v[64:79]
-  ; GCN-NEXT:    v_perm_b32 v238, v162, v160, s5
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[218:219], v[140:141], v[112:127]
-  ; GCN-NEXT:    v_perm_b32 v240, v162, v160, s7
-  ; GCN-NEXT:    v_perm_b32 v242, v163, v161, s5
-  ; GCN-NEXT:    v_perm_b32 v244, v163, v161, s7
-  ; GCN-NEXT:    ds_read_b128 v[160:163], v213
+  ; GCN-NEXT:    v_perm_b32 v232, v170, v168, s7
+  ; GCN-NEXT:    v_perm_b32 v234, v171, v169, s5
+  ; GCN-NEXT:    v_perm_b32 v236, v171, v169, s7
+  ; GCN-NEXT:    v_perm_b32 v231, v214, v226, s5
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[160:161], v[176:177], v[96:111]
+  ; GCN-NEXT:    v_perm_b32 v233, v214, v226, s7
+  ; GCN-NEXT:    v_perm_b32 v235, v215, v227, s5
+  ; GCN-NEXT:    v_perm_b32 v237, v215, v227, s7
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[164:165], v[176:177], v[80:95]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[162:163], v[178:179], v[96:111]
+  ; GCN-NEXT:    ds_read_b128 v[160:163], v205
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_perm_b32 v239, v174, v172, s5
-  ; GCN-NEXT:    v_perm_b32 v241, v174, v172, s7
-  ; GCN-NEXT:    v_perm_b32 v243, v175, v173, s5
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[214:215], v[144:145], v[64:79]
-  ; GCN-NEXT:    v_perm_b32 v245, v175, v173, s7
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[176:177], v[156:157], v[96:111]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[220:221], v[142:143], v[112:127]
-  ; GCN-NEXT:    ds_read_b128 v[218:221], v213 offset:512
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[166:167], v[178:179], v[80:95]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[172:173], v[180:181], v[96:111]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[184:185], v[176:177], v[64:79]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[206:207], v[180:181], v[80:95]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[174:175], v[182:183], v[96:111]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[186:187], v[178:179], v[64:79]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[208:209], v[182:183], v[80:95]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[216:217], v[146:147], v[112:127]
+  ; GCN-NEXT:    ds_read_b128 v[214:217], v205 offset:512
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[172:175], v213 offset:1024
+  ; GCN-NEXT:    ds_read_b128 v[164:167], v205 offset:1024
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[216:217], v[146:147], v[64:79]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[178:179], v[158:159], v[96:111]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[160:161], v[148:149], v[112:127]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[188:189], v[140:141], v[64:79]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[192:193], v[144:145], v[96:111]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[162:163], v[150:151], v[112:127]
-  ; GCN-NEXT:    ds_read_b128 v[160:163], v213 offset:1536
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[218:219], v[144:145], v[96:111]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[210:211], v[180:181], v[64:79]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[222:223], v[144:145], v[80:95]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[160:161], v[140:141], v[112:127]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[220:221], v[146:147], v[96:111]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[212:213], v[182:183], v[64:79]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[224:225], v[146:147], v[80:95]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[162:163], v[142:143], v[112:127]
+  ; GCN-NEXT:    ds_read_b128 v[160:163], v205 offset:1536
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[184:187], v246
+  ; GCN-NEXT:    ds_read_b128 v[206:209], v238
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[214:217], v246 offset:512
+  ; GCN-NEXT:    ds_read_b128 v[222:225], v238 offset:512
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[176:179], v246 offset:1024
+  ; GCN-NEXT:    ds_read_b128 v[168:171], v238 offset:1024
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[190:191], v[142:143], v[64:79]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[194:195], v[146:147], v[96:111]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[160:161], v[148:149], v[64:79]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[180:181], v[156:157], v[80:95]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[184:185], v[136:137], v[112:127]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[222:223], v[140:141], v[96:111]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[162:163], v[150:151], v[64:79]
-  ; GCN-NEXT:    ds_read_b128 v[160:163], v246 offset:1536
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[214:215], v[140:141], v[96:111]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[156:157], v[144:145], v[64:79]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[164:165], v[140:141], v[80:95]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[206:207], v[136:137], v[112:127]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[216:217], v[142:143], v[96:111]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[158:159], v[146:147], v[64:79]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[166:167], v[142:143], v[80:95]
+  ; GCN-NEXT:    ds_read_b128 v[164:167], v238 offset:1536
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    ;;#ASMSTART
@@ -284,187 +292,179 @@
   ; GCN-NEXT:    ;;#ASMEND
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    ds_write_b128 v230, v[152:155]
+  ; GCN-NEXT:    ds_write_b128 v228, v[148:151]
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b128 v230, v[226:229] offset:1024
+  ; GCN-NEXT:    ds_write_b128 v228, v[152:155] offset:1024
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[182:183], v[158:159], v[80:95]
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    ds_read_b128 v[156:159], v213
-  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[226:229], v213 offset:512
+  ; GCN-NEXT:    ds_read_b128 v[148:151], v205
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[180:183], v213 offset:1024
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[208:209], v[138:139], v[112:127]
+  ; GCN-NEXT:    ds_read_b128 v[218:221], v205 offset:512
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[152:155], v213 offset:1536
+  ; GCN-NEXT:    ds_read_b128 v[172:175], v205 offset:1024
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[230:233], v246
+  ; GCN-NEXT:    ds_read_b128 v[152:155], v205 offset:1536
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[234:237], v246 offset:512
+  ; GCN-NEXT:    ds_read_b128 v[206:209], v238
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[186:187], v[138:139], v[112:127]
-  ; GCN-NEXT:    ds_read_b128 v[184:187], v246 offset:1024
+  ; GCN-NEXT:    ds_read_b128 v[226:229], v238 offset:512
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[224:225], v[142:143], v[96:111]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[156:157], v[132:133], v[112:127]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[218:219], v[148:149], v[96:111]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[158:159], v[134:135], v[112:127]
-  ; GCN-NEXT:    ds_read_b128 v[156:159], v246 offset:1536
+  ; GCN-NEXT:    ds_read_b128 v[176:179], v238 offset:1024
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ;;#ASMSTART
-  ; GCN-NEXT:    s_waitcnt vmcnt(8)
-  ; GCN-NEXT:    ;;#ASMEND
-  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v199, v[238:239]
-  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v200, v[240:241]
-  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v201, v[242:243]
-  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v202, v[244:245]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[222:223], v[136:137], v[96:111]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[160:161], v[140:141], v[64:79]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[148:149], v[132:133], v[112:127]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[224:225], v[138:139], v[96:111]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[168:169], v[136:137], v[80:95]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[162:163], v[142:143], v[64:79]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[150:151], v[134:135], v[112:127]
+  ; GCN-NEXT:    ds_read_b128 v[148:151], v238 offset:1536
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    buffer_load_dwordx2 v[192:193], v247, s[0:3], 0 offen sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[220:221], v[150:151], v[96:111]
-  ; GCN-NEXT:    buffer_load_dwordx2 v[194:195], v248, s[0:3], 0 offen sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx2 v[218:219], v249, s[0:3], 0 offen sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx2 v[220:221], v250, s[0:3], 0 offen sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
-  ; GCN-NEXT:    v_perm_b32 v188, v194, v192, s5
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[164:165], v[144:145], v[80:95]
-  ; GCN-NEXT:    v_perm_b32 v189, v220, v218, s5
-  ; GCN-NEXT:    v_perm_b32 v191, v220, v218, s7
-  ; GCN-NEXT:    v_perm_b32 v190, v194, v192, s7
-  ; GCN-NEXT:    v_perm_b32 v192, v195, v193, s5
-  ; GCN-NEXT:    v_perm_b32 v194, v195, v193, s7
-  ; GCN-NEXT:    v_perm_b32 v193, v221, v219, s5
-  ; GCN-NEXT:    v_perm_b32 v195, v221, v219, s7
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[166:167], v[146:147], v[80:95]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[168:169], v[140:141], v[80:95]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[170:171], v[142:143], v[80:95]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[172:173], v[148:149], v[80:95]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[214:215], v[136:137], v[96:111]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[174:175], v[150:151], v[80:95]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[216:217], v[138:139], v[96:111]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[176:177], v[136:137], v[80:95]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[226:227], v[132:133], v[96:111]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[178:179], v[138:139], v[80:95]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[160:161], v[136:137], v[64:79]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[230:231], v[128:129], v[112:127]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[228:229], v[134:135], v[96:111]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[180:181], v[132:133], v[80:95]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[162:163], v[138:139], v[64:79]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[232:233], v[130:131], v[112:127]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[234:235], v[128:129], v[96:111]
+  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    ds_write_b64 v191, v[230:231]
+  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+  ; GCN-NEXT:    ds_write_b64 v192, v[232:233]
+  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+  ; GCN-NEXT:    ds_write_b64 v193, v[234:235]
+  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+  ; GCN-NEXT:    ds_write_b64 v194, v[236:237]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[218:219], v[132:133], v[96:111]
+  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
+  ; GCN-NEXT:    buffer_load_dwordx2 v[184:185], v239, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx2 v[186:187], v240, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx2 v[210:211], v241, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx2 v[212:213], v242, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    ;;#ASMSTART
+  ; GCN-NEXT:    s_waitcnt vmcnt(8)
+  ; GCN-NEXT:    ;;#ASMEND
+  ; GCN-NEXT:    v_perm_b32 v180, v186, v184, s5
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[170:171], v[138:139], v[80:95]
+  ; GCN-NEXT:    v_perm_b32 v182, v186, v184, s7
+  ; GCN-NEXT:    v_perm_b32 v181, v212, v210, s5
+  ; GCN-NEXT:    v_perm_b32 v183, v212, v210, s7
+  ; GCN-NEXT:    v_perm_b32 v184, v187, v185, s5
+  ; GCN-NEXT:    v_perm_b32 v186, v187, v185, s7
+  ; GCN-NEXT:    v_perm_b32 v185, v213, v211, s5
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[164:165], v[136:137], v[64:79]
+  ; GCN-NEXT:    v_perm_b32 v187, v213, v211, s7
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[206:207], v[128:129], v[112:127]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[220:221], v[134:135], v[96:111]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[172:173], v[132:133], v[80:95]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[166:167], v[138:139], v[64:79]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[112:127], v[208:209], v[130:131], v[112:127]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[226:227], v[128:129], v[96:111]
   ; GCN-NEXT:    s_nop 9
-  ; GCN-NEXT:    v_mul_f32_e32 v213, s4, v112
-  ; GCN-NEXT:    v_mul_f32_e32 v218, s4, v113
-  ; GCN-NEXT:    v_max3_f32 v213, v213, s14, v218
-  ; GCN-NEXT:    v_mul_f32_e32 v218, s4, v114
-  ; GCN-NEXT:    v_mul_f32_e32 v219, s4, v115
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v218, v219
-  ; GCN-NEXT:    v_mul_f32_e32 v218, s4, v116
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[182:183], v[134:135], v[80:95]
-  ; GCN-NEXT:    v_mul_f32_e32 v219, s4, v117
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v218, v219
-  ; GCN-NEXT:    v_mul_f32_e32 v218, s4, v118
-  ; GCN-NEXT:    v_mul_f32_e32 v219, s4, v119
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v218, v219
-  ; GCN-NEXT:    v_mul_f32_e32 v218, s4, v120
-  ; GCN-NEXT:    v_mul_f32_e32 v219, s4, v121
+  ; GCN-NEXT:    v_mul_f32_e32 v205, s4, v112
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v113
+  ; GCN-NEXT:    v_max3_f32 v205, v205, s14, v206
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v114
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v115
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[174:175], v[134:135], v[80:95]
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v116
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v117
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v118
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v119
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[152:153], v[132:133], v[64:79]
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v218, v219
-  ; GCN-NEXT:    v_mul_f32_e32 v218, s4, v122
-  ; GCN-NEXT:    v_mul_f32_e32 v219, s4, v123
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v218, v219
-  ; GCN-NEXT:    v_mul_f32_e32 v218, s4, v124
-  ; GCN-NEXT:    v_mul_f32_e32 v219, s4, v125
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v218, v219
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[236:237], v[130:131], v[96:111]
-  ; GCN-NEXT:    v_mul_f32_e32 v218, s4, v126
-  ; GCN-NEXT:    v_mul_f32_e32 v219, s4, v127
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v218, v219
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[184:185], v[128:129], v[80:95]
-  ; GCN-NEXT:    s_nop 6
-  ; GCN-NEXT:    v_mul_f32_e32 v214, s4, v96
-  ; GCN-NEXT:    v_mul_f32_e32 v215, s4, v97
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v214, v215
-  ; GCN-NEXT:    v_mul_f32_e32 v214, s4, v98
-  ; GCN-NEXT:    v_mul_f32_e32 v215, s4, v99
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v214, v215
-  ; GCN-NEXT:    v_mul_f32_e32 v214, s4, v100
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v120
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v121
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v122
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v123
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[96:111], v[228:229], v[130:131], v[96:111]
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v124
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v125
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v126
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v127
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[176:177], v[128:129], v[80:95]
+  ; GCN-NEXT:    s_nop 3
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v96
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v97
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v98
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v99
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[154:155], v[134:135], v[64:79]
-  ; GCN-NEXT:    v_mul_f32_e32 v215, s4, v101
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v214, v215
-  ; GCN-NEXT:    v_mul_f32_e32 v214, s4, v102
-  ; GCN-NEXT:    v_mul_f32_e32 v215, s4, v103
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v214, v215
-  ; GCN-NEXT:    v_mul_f32_e32 v214, s4, v104
-  ; GCN-NEXT:    v_mul_f32_e32 v215, s4, v105
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[186:187], v[130:131], v[80:95]
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v214, v215
-  ; GCN-NEXT:    v_mul_f32_e32 v214, s4, v106
-  ; GCN-NEXT:    v_mul_f32_e32 v215, s4, v107
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v214, v215
-  ; GCN-NEXT:    v_mul_f32_e32 v214, s4, v108
-  ; GCN-NEXT:    v_mul_f32_e32 v215, s4, v109
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v214, v215
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[156:157], v[128:129], v[64:79]
-  ; GCN-NEXT:    v_mul_f32_e32 v214, s4, v110
-  ; GCN-NEXT:    v_mul_f32_e32 v215, s4, v111
-  ; GCN-NEXT:    v_max3_f32 v213, v213, v214, v215
-  ; GCN-NEXT:    v_mul_f32_e32 v140, s4, v80
-  ; GCN-NEXT:    v_mul_f32_e32 v141, s4, v81
-  ; GCN-NEXT:    v_max3_f32 v140, v213, v140, v141
-  ; GCN-NEXT:    v_mul_f32_e32 v141, s4, v82
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[158:159], v[130:131], v[64:79]
-  ; GCN-NEXT:    v_mul_f32_e32 v142, s4, v83
-  ; GCN-NEXT:    v_max3_f32 v140, v140, v141, v142
-  ; GCN-NEXT:    v_mul_f32_e32 v141, s4, v84
-  ; GCN-NEXT:    v_mul_f32_e32 v142, s4, v85
-  ; GCN-NEXT:    v_max3_f32 v140, v140, v141, v142
-  ; GCN-NEXT:    v_mul_f32_e32 v141, s4, v86
-  ; GCN-NEXT:    v_mul_f32_e32 v142, s4, v87
-  ; GCN-NEXT:    v_max3_f32 v140, v140, v141, v142
-  ; GCN-NEXT:    v_mul_f32_e32 v141, s4, v88
-  ; GCN-NEXT:    v_mul_f32_e32 v142, s4, v89
-  ; GCN-NEXT:    v_max3_f32 v140, v140, v141, v142
-  ; GCN-NEXT:    v_mul_f32_e32 v141, s4, v90
-  ; GCN-NEXT:    v_mul_f32_e32 v142, s4, v91
-  ; GCN-NEXT:    v_max3_f32 v140, v140, v141, v142
-  ; GCN-NEXT:    v_mul_f32_e32 v141, s4, v92
-  ; GCN-NEXT:    v_mul_f32_e32 v142, s4, v93
-  ; GCN-NEXT:    v_max3_f32 v140, v140, v141, v142
-  ; GCN-NEXT:    v_mul_f32_e32 v141, s4, v94
-  ; GCN-NEXT:    v_mul_f32_e32 v142, s4, v95
-  ; GCN-NEXT:    v_max3_f32 v140, v140, v141, v142
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v100
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v101
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v102
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v103
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[80:95], v[178:179], v[130:131], v[80:95]
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v104
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v105
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v106
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v107
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[148:149], v[128:129], v[64:79]
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v108
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v109
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mul_f32_e32 v206, s4, v110
+  ; GCN-NEXT:    v_mul_f32_e32 v207, s4, v111
+  ; GCN-NEXT:    v_max3_f32 v205, v205, v206, v207
+  ; GCN-NEXT:    v_mul_f32_e32 v168, s4, v80
+  ; GCN-NEXT:    v_mul_f32_e32 v169, s4, v81
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[64:79], v[150:151], v[130:131], v[64:79]
+  ; GCN-NEXT:    v_max3_f32 v168, v205, v168, v169
+  ; GCN-NEXT:    v_mul_f32_e32 v169, s4, v82
+  ; GCN-NEXT:    v_mul_f32_e32 v170, s4, v83
+  ; GCN-NEXT:    v_max3_f32 v168, v168, v169, v170
+  ; GCN-NEXT:    v_mul_f32_e32 v169, s4, v84
+  ; GCN-NEXT:    v_mul_f32_e32 v170, s4, v85
+  ; GCN-NEXT:    v_max3_f32 v168, v168, v169, v170
+  ; GCN-NEXT:    v_mul_f32_e32 v169, s4, v86
+  ; GCN-NEXT:    v_mul_f32_e32 v170, s4, v87
+  ; GCN-NEXT:    v_max3_f32 v168, v168, v169, v170
+  ; GCN-NEXT:    v_mul_f32_e32 v169, s4, v88
+  ; GCN-NEXT:    v_mul_f32_e32 v170, s4, v89
+  ; GCN-NEXT:    v_max3_f32 v168, v168, v169, v170
+  ; GCN-NEXT:    v_mul_f32_e32 v169, s4, v90
+  ; GCN-NEXT:    v_mul_f32_e32 v170, s4, v91
+  ; GCN-NEXT:    v_max3_f32 v168, v168, v169, v170
+  ; GCN-NEXT:    v_mul_f32_e32 v169, s4, v92
+  ; GCN-NEXT:    v_mul_f32_e32 v170, s4, v93
+  ; GCN-NEXT:    v_max3_f32 v168, v168, v169, v170
+  ; GCN-NEXT:    v_mul_f32_e32 v169, s4, v94
+  ; GCN-NEXT:    v_mul_f32_e32 v170, s4, v95
+  ; GCN-NEXT:    v_max3_f32 v168, v168, v169, v170
   ; GCN-NEXT:    v_mul_f32_e32 v128, s4, v64
   ; GCN-NEXT:    v_mul_f32_e32 v129, s4, v65
-  ; GCN-NEXT:    v_max3_f32 v128, v140, v128, v129
+  ; GCN-NEXT:    v_max3_f32 v128, v168, v128, v129
   ; GCN-NEXT:    v_mul_f32_e32 v129, s4, v66
   ; GCN-NEXT:    v_mul_f32_e32 v130, s4, v67
   ; GCN-NEXT:    v_max3_f32 v128, v128, v129, v130
@@ -486,21 +486,21 @@
   ; GCN-NEXT:    v_mul_f32_e32 v129, s4, v78
   ; GCN-NEXT:    v_mul_f32_e32 v130, s4, v79
   ; GCN-NEXT:    v_max3_f32 v128, v128, v129, v130
-  ; GCN-NEXT:    ds_bpermute_b32 v129, v196, v128
+  ; GCN-NEXT:    ds_bpermute_b32 v129, v188, v128
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    ds_read_b128 v[130:133], v198
+  ; GCN-NEXT:    ds_read_b128 v[130:133], v190
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[134:137], v198 offset:576
+  ; GCN-NEXT:    ds_read_b128 v[134:137], v190 offset:576
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_max_f32_e32 v129, v129, v129
   ; GCN-NEXT:    v_max_f32_e32 v128, v128, v129
-  ; GCN-NEXT:    ds_bpermute_b32 v129, v196, v128
+  ; GCN-NEXT:    ds_bpermute_b32 v129, v188, v128
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    v_cndmask_b32_e64 v128, v129, v128, s[12:13]
   ; GCN-NEXT:    v_max_f32_e32 v128, v128, v128
-  ; GCN-NEXT:    v_max_f32_e32 v128, v212, v128
+  ; GCN-NEXT:    v_max_f32_e32 v128, v204, v128
   ; GCN-NEXT:    v_fma_f32 v113, s4, v113, -v128
   ; GCN-NEXT:    v_mul_f32_e32 v138, 0x3fb8aa3b, v113
   ; GCN-NEXT:    v_fma_f32 v113, s4, v114, -v128
@@ -532,10 +532,10 @@
   ; GCN-NEXT:    v_exp_f32_e32 v113, v112
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v119, v114
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v121, v116
-  ; GCN-NEXT:    v_sub_f32_e32 v129, v211, v128
+  ; GCN-NEXT:    v_sub_f32_e32 v129, v203, v128
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v112, v113
   ; GCN-NEXT:    v_mul_f32_e32 v129, 0x3fb8aa3b, v129
-  ; GCN-NEXT:    ds_read_b128 v[138:141], v198 offset:1152
+  ; GCN-NEXT:    ds_read_b128 v[138:141], v190 offset:1152
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_fma_f32 v122, s4, v123, -v128
@@ -561,7 +561,7 @@
   ; GCN-NEXT:    v_pk_mul_f32 v[34:35], v[34:35], v[112:113] op_sel_hi:[1,0]
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[130:131], v[146:147], v[0:15]
   ; GCN-NEXT:    v_exp_f32_e32 v119, v143
-  ; GCN-NEXT:    ds_read_b128 v[142:145], v198 offset:1728
+  ; GCN-NEXT:    ds_read_b128 v[142:145], v190 offset:1728
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_pk_mul_f32 v[36:37], v[36:37], v[112:113] op_sel_hi:[1,0]
@@ -577,8 +577,7 @@
   ; GCN-NEXT:    v_mul_f32_e64 v21, v21, v112
   ; GCN-NEXT:    v_mul_f32_e64 v22, v22, v112
   ; GCN-NEXT:    v_mul_f32_e64 v23, v23, v112
-  ; GCN-NEXT:    v_mul_f32_e64 v24, v24, v112
-  ; GCN-NEXT:    v_mul_f32_e64 v25, v25, v112
+  ; GCN-NEXT:    v_pk_mul_f32 v[24:25], v[24:25], v[112:113] op_sel_hi:[1,0]
   ; GCN-NEXT:    v_pk_mul_f32 v[26:27], v[26:27], v[112:113] op_sel_hi:[1,0]
   ; GCN-NEXT:    v_pk_mul_f32 v[28:29], v[28:29], v[112:113] op_sel_hi:[1,0]
   ; GCN-NEXT:    v_pk_mul_f32 v[30:31], v[30:31], v[112:113] op_sel_hi:[1,0]
@@ -602,23 +601,23 @@
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v126, v121
   ; GCN-NEXT:    v_mul_f32_e32 v125, 0x3fb8aa3b, v125
   ; GCN-NEXT:    v_fma_f32 v139, s4, v96, -v128
-  ; GCN-NEXT:    v_fma_f32 v127, s4, v127, -v128
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[142:143], v[146:147], v[48:63]
   ; GCN-NEXT:    v_exp_f32_e32 v123, v150
+  ; GCN-NEXT:    v_fma_f32 v127, s4, v127, -v128
   ; GCN-NEXT:    v_mul_f32_e32 v127, 0x3fb8aa3b, v127
-  ; GCN-NEXT:    v_fma_f32 v143, s4, v101, -v128
+  ; GCN-NEXT:    v_fma_f32 v153, s4, v104, -v128
   ; GCN-NEXT:    v_fma_f32 v64, s4, v64, -v128
   ; GCN-NEXT:    v_fma_f32 v65, s4, v65, -v128
-  ; GCN-NEXT:    v_fma_f32 v68, s4, v68, -v128
-  ; GCN-NEXT:    v_fma_f32 v69, s4, v69, -v128
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[132:133], v[134:135], v[0:15]
   ; GCN-NEXT:    v_exp_f32_e32 v124, v151
-  ; GCN-NEXT:    ds_read_b128 v[130:133], v197
+  ; GCN-NEXT:    ds_read_b128 v[130:133], v189
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[146:149], v197 offset:576
+  ; GCN-NEXT:    ds_read_b128 v[146:149], v189 offset:576
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    v_fma_f32 v68, s4, v68, -v128
+  ; GCN-NEXT:    v_fma_f32 v69, s4, v69, -v128
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[136:137], v[134:135], v[32:47]
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v136, v122
   ; GCN-NEXT:    v_exp_f32_e32 v96, v129
@@ -636,12 +635,12 @@
   ; GCN-NEXT:    v_fma_f32 v135, s4, v99, -v128
   ; GCN-NEXT:    v_exp_f32_e32 v98, v138
   ; GCN-NEXT:    v_exp_f32_e32 v99, v127
-  ; GCN-NEXT:    v_mul_f32_e32 v150, 0x3fb8aa3b, v135
+  ; GCN-NEXT:    v_mul_f32_e32 v143, 0x3fb8aa3b, v135
   ; GCN-NEXT:    v_pack_b32_f16 v127, v136, v134
-  ; GCN-NEXT:    ds_read_b128 v[134:137], v197 offset:1152
+  ; GCN-NEXT:    ds_read_b128 v[134:137], v189 offset:1152
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[138:141], v197 offset:1728
+  ; GCN-NEXT:    ds_read_b128 v[138:141], v189 offset:1728
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[130:131], v[126:127], v[0:15]
@@ -655,89 +654,89 @@
   ; GCN-NEXT:    ;;#ASMEND
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v199, v[188:189]
+  ; GCN-NEXT:    ds_write_b64 v191, v[180:181]
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v200, v[190:191]
+  ; GCN-NEXT:    ds_write_b64 v192, v[182:183]
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v201, v[192:193]
+  ; GCN-NEXT:    ds_write_b64 v193, v[184:185]
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v202, v[194:195]
+  ; GCN-NEXT:    ds_write_b64 v194, v[186:187]
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[146:147], v[126:127], v[32:47]
+  ; GCN-NEXT:    v_fma_f32 v144, s4, v101, -v128
   ; GCN-NEXT:    v_exp_f32_e32 v101, v125
   ; GCN-NEXT:    v_pack_b32_f16 v146, v130, v131
-  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    buffer_load_dwordx2 v[130:131], v210, s[0:3], 0 offen sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mul_f32_e32 v125, 0x3fb8aa3b, v143
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v147, v98
+  ; GCN-NEXT:    v_fma_f32 v131, s4, v102, -v128
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v130, v98
+  ; GCN-NEXT:    v_mul_f32_e32 v156, 0x3fb8aa3b, v131
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[134:135], v[126:127], v[16:31]
-  ; GCN-NEXT:    v_fma_f32 v134, s4, v102, -v128
-  ; GCN-NEXT:    v_mul_f32_e32 v156, 0x3fb8aa3b, v134
-  ; GCN-NEXT:    buffer_load_dwordx2 v[134:135], v207, s[0:3], 0 offen sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_exp_f32_e32 v102, v142
-  ; GCN-NEXT:    buffer_load_dwordx2 v[142:143], v208, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
+  ; GCN-NEXT:    buffer_load_dwordx2 v[134:135], v201, s[0:3], 0 offen sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx2 v[144:145], v209, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx2 v[150:151], v202, s[0:3], 0 offen sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v131, v99
+  ; GCN-NEXT:    v_fma_f32 v142, s4, v103, -v128
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v152, v100
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[138:139], v[126:127], v[48:63]
+  ; GCN-NEXT:    buffer_load_dwordx2 v[126:127], v199, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx2 v[138:139], v200, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    v_pack_b32_f16 v147, v130, v131
+  ; GCN-NEXT:    v_exp_f32_e32 v103, v143
+  ; GCN-NEXT:    v_mul_f32_e32 v125, 0x3fb8aa3b, v144
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[138:139], v[126:127], v[48:63]
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v126, v99
-  ; GCN-NEXT:    v_fma_f32 v127, s4, v103, -v128
-  ; GCN-NEXT:    v_exp_f32_e32 v103, v150
-  ; GCN-NEXT:    v_fma_f32 v139, s4, v105, -v128
-  ; GCN-NEXT:    v_pack_b32_f16 v147, v147, v126
-  ; GCN-NEXT:    v_mul_f32_e32 v138, 0x3fb8aa3b, v127
-  ; GCN-NEXT:    v_perm_b32 v152, v135, v131, s5
-  ; GCN-NEXT:    v_perm_b32 v154, v135, v131, s7
-  ; GCN-NEXT:    v_fma_f32 v135, s4, v104, -v128
-  ; GCN-NEXT:    v_perm_b32 v126, v134, v130, s5
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[132:133], v[146:147], v[0:15]
-  ; GCN-NEXT:    v_perm_b32 v150, v134, v130, s7
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v134, v100
   ; GCN-NEXT:    v_exp_f32_e32 v104, v129
-  ; GCN-NEXT:    v_mul_f32_e32 v129, 0x3fb8aa3b, v135
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v135, v101
-  ; GCN-NEXT:    ds_read_b128 v[130:133], v198
+  ; GCN-NEXT:    v_mul_f32_e32 v129, 0x3fb8aa3b, v153
+  ; GCN-NEXT:    ds_read_b128 v[130:133], v190
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_perm_b32 v127, v144, v142, s5
+  ; GCN-NEXT:    v_mul_f32_e32 v157, 0x3fb8aa3b, v142
+  ; GCN-NEXT:    ds_read_b128 v[142:145], v190 offset:576
+  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    v_perm_b32 v154, v150, v134, s7
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[148:149], v[146:147], v[32:47]
-  ; GCN-NEXT:    v_pack_b32_f16 v148, v134, v135
-  ; GCN-NEXT:    v_fma_f32 v135, s4, v106, -v128
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v148, v101
+  ; GCN-NEXT:    v_fma_f32 v149, s4, v105, -v128
   ; GCN-NEXT:    v_exp_f32_e32 v105, v125
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v134, v102
-  ; GCN-NEXT:    v_perm_b32 v151, v144, v142, s7
-  ; GCN-NEXT:    v_perm_b32 v153, v145, v143, s5
-  ; GCN-NEXT:    v_perm_b32 v155, v145, v143, s7
+  ; GCN-NEXT:    v_mul_f32_e32 v125, 0x3fb8aa3b, v149
+  ; GCN-NEXT:    v_pack_b32_f16 v148, v152, v148
+  ; GCN-NEXT:    v_perm_b32 v152, v150, v134, s5
+  ; GCN-NEXT:    v_perm_b32 v150, v151, v135, s5
+  ; GCN-NEXT:    v_perm_b32 v153, v138, v126, s5
+  ; GCN-NEXT:    v_perm_b32 v155, v138, v126, s7
+  ; GCN-NEXT:    v_perm_b32 v126, v151, v135, s7
+  ; GCN-NEXT:    v_fma_f32 v135, s4, v106, -v128
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[136:137], v[146:147], v[16:31]
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v134, v102
   ; GCN-NEXT:    v_exp_f32_e32 v106, v156
   ; GCN-NEXT:    v_mul_f32_e32 v156, 0x3fb8aa3b, v135
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v135, v103
   ; GCN-NEXT:    v_fma_f32 v136, s4, v107, -v128
-  ; GCN-NEXT:    ds_read_b128 v[142:145], v198 offset:576
-  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mul_f32_e32 v125, 0x3fb8aa3b, v139
-  ; GCN-NEXT:    v_pack_b32_f16 v149, v134, v135
+  ; GCN-NEXT:    v_perm_b32 v151, v139, v127, s5
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[140:141], v[146:147], v[48:63]
   ; GCN-NEXT:    v_mul_f32_e32 v146, 0x3fb8aa3b, v136
-  ; GCN-NEXT:    ds_read_b128 v[134:137], v198 offset:1152
+  ; GCN-NEXT:    v_pack_b32_f16 v149, v134, v135
+  ; GCN-NEXT:    ds_read_b128 v[134:137], v190 offset:1152
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_exp_f32_e32 v107, v138
-  ; GCN-NEXT:    ds_read_b128 v[138:141], v198 offset:1728
+  ; GCN-NEXT:    v_perm_b32 v127, v139, v127, s7
+  ; GCN-NEXT:    ds_read_b128 v[138:141], v190 offset:1728
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    v_exp_f32_e32 v107, v157
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[130:131], v[148:149], v[0:15]
   ; GCN-NEXT:    v_fma_f32 v131, s4, v108, -v128
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v130, v104
@@ -764,14 +763,14 @@
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v138, v108
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[132:133], v[142:143], v[0:15]
   ; GCN-NEXT:    v_exp_f32_e32 v80, v129
-  ; GCN-NEXT:    ds_read_b128 v[130:133], v197
-  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[146:149], v197 offset:576
-  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_mul_f32_e32 v129, 0x3fb8aa3b, v139
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v139, v109
+  ; GCN-NEXT:    ds_read_b128 v[130:133], v189
+  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    ds_read_b128 v[146:149], v189 offset:576
+  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[144:145], v[142:143], v[32:47]
   ; GCN-NEXT:    v_fma_f32 v144, s4, v81, -v128
   ; GCN-NEXT:    v_exp_f32_e32 v81, v125
@@ -784,133 +783,133 @@
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v134, v111
   ; GCN-NEXT:    v_mul_f32_e32 v156, 0x3fb8aa3b, v137
   ; GCN-NEXT:    v_fma_f32 v137, s4, v83, -v128
-  ; GCN-NEXT:    v_mul_f32_e32 v157, 0x3fb8aa3b, v137
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[140:141], v[142:143], v[48:63]
   ; GCN-NEXT:    v_exp_f32_e32 v83, v135
+  ; GCN-NEXT:    v_mul_f32_e32 v142, 0x3fb8aa3b, v137
   ; GCN-NEXT:    v_pack_b32_f16 v145, v136, v134
-  ; GCN-NEXT:    ds_read_b128 v[134:137], v197 offset:1152
+  ; GCN-NEXT:    ds_read_b128 v[134:137], v189 offset:1152
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[138:141], v197 offset:1728
+  ; GCN-NEXT:    ds_read_b128 v[138:141], v189 offset:1728
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
-  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v199, v[126:127]
-  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v200, v[150:151]
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[130:131], v[144:145], v[0:15]
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v201, v[152:153]
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    ds_write_b64 v191, v[152:153]
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v202, v[154:155]
+  ; GCN-NEXT:    ds_write_b64 v192, v[154:155]
+  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+  ; GCN-NEXT:    ds_write_b64 v193, v[150:151]
+  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+  ; GCN-NEXT:    ds_write_b64 v194, v[126:127]
+  ; GCN-NEXT:    v_fma_f32 v130, s4, v85, -v128
   ; GCN-NEXT:    v_fma_f32 v127, s4, v84, -v128
   ; GCN-NEXT:    v_exp_f32_e32 v84, v129
-  ; GCN-NEXT:    v_fma_f32 v130, s4, v85, -v128
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v126, v80
-  ; GCN-NEXT:    v_mul_f32_e32 v129, 0x3fb8aa3b, v127
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[146:147], v[144:145], v[32:47]
   ; GCN-NEXT:    v_exp_f32_e32 v85, v125
   ; GCN-NEXT:    v_mul_f32_e32 v125, 0x3fb8aa3b, v130
-  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    buffer_load_dwordx2 v[130:131], v206, s[0:3], 0 offen sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    v_fma_f32 v130, s4, v86, -v128
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v126, v80
+  ; GCN-NEXT:    v_mul_f32_e32 v129, 0x3fb8aa3b, v127
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v127, v81
-  ; GCN-NEXT:    v_pack_b32_f16 v126, v126, v127
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[134:135], v[144:145], v[16:31]
-  ; GCN-NEXT:    v_fma_f32 v134, s4, v86, -v128
-  ; GCN-NEXT:    v_mul_f32_e32 v158, 0x3fb8aa3b, v134
-  ; GCN-NEXT:    buffer_load_dwordx2 v[134:135], v203, s[0:3], 0 offen sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx2 v[142:143], v204, s[0:3], 0 offen sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx2 v[146:147], v205, s[0:3], 0 offen sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v127, v82
   ; GCN-NEXT:    v_exp_f32_e32 v86, v156
+  ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
+  ; GCN-NEXT:    buffer_load_dwordx2 v[134:135], v197, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx2 v[146:147], v198, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    v_pack_b32_f16 v126, v126, v127
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v127, v82
+  ; GCN-NEXT:    v_mul_f32_e32 v158, 0x3fb8aa3b, v130
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[138:139], v[144:145], v[48:63]
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v138, v83
+  ; GCN-NEXT:    buffer_load_dwordx2 v[138:139], v195, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx2 v[150:151], v196, s[0:3], 0 offen sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0)
+  ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v130, v83
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
-  ; GCN-NEXT:    v_fma_f32 v139, s4, v87, -v128
-  ; GCN-NEXT:    v_exp_f32_e32 v87, v157
-  ; GCN-NEXT:    v_pack_b32_f16 v127, v127, v138
-  ; GCN-NEXT:    v_fma_f32 v138, s4, v89, -v128
-  ; GCN-NEXT:    v_mul_f32_e32 v139, 0x3fb8aa3b, v139
+  ; GCN-NEXT:    v_fma_f32 v131, s4, v87, -v128
+  ; GCN-NEXT:    v_exp_f32_e32 v87, v142
+  ; GCN-NEXT:    v_pack_b32_f16 v127, v127, v130
+  ; GCN-NEXT:    v_mul_f32_e32 v159, 0x3fb8aa3b, v131
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v152, v84
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[132:133], v[126:127], v[0:15]
-  ; GCN-NEXT:    ; implicit-def: $sgpr0
-  ; GCN-NEXT:    v_perm_b32 v154, v135, v131, s5
-  ; GCN-NEXT:    v_perm_b32 v156, v135, v131, s7
-  ; GCN-NEXT:    v_fma_f32 v135, s4, v88, -v128
-  ; GCN-NEXT:    v_perm_b32 v150, v134, v130, s5
-  ; GCN-NEXT:    v_perm_b32 v152, v134, v130, s7
-  ; GCN-NEXT:    ds_read_b128 v[130:133], v198
+  ; GCN-NEXT:    ds_read_b128 v[130:133], v190
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v134, v84
+  ; GCN-NEXT:    v_fma_f32 v153, s4, v88, -v128
   ; GCN-NEXT:    v_exp_f32_e32 v88, v129
-  ; GCN-NEXT:    v_mul_f32_e32 v129, 0x3fb8aa3b, v135
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v135, v85
-  ; GCN-NEXT:    v_perm_b32 v151, v146, v142, s5
-  ; GCN-NEXT:    v_perm_b32 v153, v146, v142, s7
-  ; GCN-NEXT:    v_perm_b32 v155, v147, v143, s5
-  ; GCN-NEXT:    v_perm_b32 v157, v147, v143, s7
-  ; GCN-NEXT:    ds_read_b128 v[142:145], v198 offset:576
+  ; GCN-NEXT:    ds_read_b128 v[142:145], v190 offset:576
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    v_mul_f32_e32 v129, 0x3fb8aa3b, v153
+  ; GCN-NEXT:    ; implicit-def: $sgpr0
+  ; GCN-NEXT:    v_perm_b32 v154, v146, v134, s7
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[148:149], v[126:127], v[32:47]
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v148, v85
+  ; GCN-NEXT:    v_fma_f32 v149, s4, v89, -v128
   ; GCN-NEXT:    v_exp_f32_e32 v89, v125
-  ; GCN-NEXT:    v_pack_b32_f16 v146, v134, v135
+  ; GCN-NEXT:    v_perm_b32 v156, v147, v135, s5
+  ; GCN-NEXT:    v_pack_b32_f16 v148, v152, v148
+  ; GCN-NEXT:    v_perm_b32 v152, v146, v134, s5
+  ; GCN-NEXT:    v_perm_b32 v153, v150, v138, s5
+  ; GCN-NEXT:    v_perm_b32 v155, v150, v138, s7
+  ; GCN-NEXT:    v_perm_b32 v150, v147, v135, s7
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[136:137], v[126:127], v[16:31]
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v134, v86
   ; GCN-NEXT:    v_fma_f32 v135, s4, v90, -v128
-  ; GCN-NEXT:    v_mul_f32_e32 v125, 0x3fb8aa3b, v138
-  ; GCN-NEXT:    v_mul_f32_e32 v148, 0x3fb8aa3b, v135
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[136:137], v[126:127], v[16:31]
   ; GCN-NEXT:    v_exp_f32_e32 v90, v158
-  ; GCN-NEXT:    v_mul_f32_e32 v158, 0x3fb8aa3b, v64
+  ; GCN-NEXT:    v_mul_f32_e32 v125, 0x3fb8aa3b, v149
+  ; GCN-NEXT:    v_perm_b32 v157, v151, v139, s5
+  ; GCN-NEXT:    v_perm_b32 v151, v151, v139, s7
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[140:141], v[126:127], v[48:63]
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v126, v87
+  ; GCN-NEXT:    v_mul_f32_e32 v146, 0x3fb8aa3b, v135
   ; GCN-NEXT:    v_fma_f32 v127, s4, v91, -v128
-  ; GCN-NEXT:    v_exp_f32_e32 v91, v139
-  ; GCN-NEXT:    v_mul_f32_e32 v127, 0x3fb8aa3b, v127
-  ; GCN-NEXT:    v_pack_b32_f16 v147, v134, v126
-  ; GCN-NEXT:    ds_read_b128 v[134:137], v198 offset:1152
+  ; GCN-NEXT:    v_exp_f32_e32 v91, v159
+  ; GCN-NEXT:    v_pack_b32_f16 v149, v134, v126
+  ; GCN-NEXT:    ds_read_b128 v[134:137], v190 offset:1152
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[138:141], v198 offset:1728
+  ; GCN-NEXT:    ds_read_b128 v[138:141], v190 offset:1728
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[130:131], v[146:147], v[0:15]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[130:131], v[148:149], v[0:15]
   ; GCN-NEXT:    v_fma_f32 v130, s4, v92, -v128
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v126, v88
   ; GCN-NEXT:    v_exp_f32_e32 v92, v129
   ; GCN-NEXT:    v_mul_f32_e32 v129, 0x3fb8aa3b, v130
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v130, v89
   ; GCN-NEXT:    v_fma_f32 v131, s4, v93, -v128
-  ; GCN-NEXT:    v_pack_b32_f16 v130, v126, v130
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[142:143], v[146:147], v[32:47]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[142:143], v[148:149], v[32:47]
   ; GCN-NEXT:    v_exp_f32_e32 v93, v125
+  ; GCN-NEXT:    v_pack_b32_f16 v130, v126, v130
   ; GCN-NEXT:    v_fma_f32 v126, s4, v94, -v128
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v125, v90
   ; GCN-NEXT:    v_mul_f32_e32 v143, 0x3fb8aa3b, v126
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v126, v91
+  ; GCN-NEXT:    v_mul_f32_e32 v127, 0x3fb8aa3b, v127
   ; GCN-NEXT:    v_mul_f32_e32 v142, 0x3fb8aa3b, v131
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[134:135], v[148:149], v[16:31]
+  ; GCN-NEXT:    v_exp_f32_e32 v94, v146
   ; GCN-NEXT:    v_fma_f32 v131, s4, v95, -v128
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[134:135], v[146:147], v[16:31]
-  ; GCN-NEXT:    v_exp_f32_e32 v94, v148
+  ; GCN-NEXT:    v_mul_f32_e32 v158, 0x3fb8aa3b, v64
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v64, v93
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[138:139], v[146:147], v[48:63]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[138:139], v[148:149], v[48:63]
   ; GCN-NEXT:    v_exp_f32_e32 v95, v127
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v127, v92
   ; GCN-NEXT:    v_mul_f32_e32 v138, 0x3fb8aa3b, v131
@@ -918,10 +917,10 @@
   ; GCN-NEXT:    s_nop 1
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[132:133], v[130:131], v[0:15]
   ; GCN-NEXT:    v_exp_f32_e32 v125, v129
-  ; GCN-NEXT:    ds_read_b128 v[132:135], v197
+  ; GCN-NEXT:    ds_read_b128 v[132:135], v189
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[146:149], v197 offset:576
+  ; GCN-NEXT:    ds_read_b128 v[146:149], v189 offset:576
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[144:145], v[130:131], v[32:47]
@@ -939,10 +938,10 @@
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[140:141], v[130:131], v[48:63]
   ; GCN-NEXT:    v_exp_f32_e32 v129, v138
   ; GCN-NEXT:    v_mul_f32_e32 v141, 0x3fb8aa3b, v66
-  ; GCN-NEXT:    ds_read_b128 v[64:67], v197 offset:1152
+  ; GCN-NEXT:    ds_read_b128 v[64:67], v189 offset:1152
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[136:139], v197 offset:1728
+  ; GCN-NEXT:    ds_read_b128 v[136:139], v189 offset:1728
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    ;;#ASMSTART
@@ -950,19 +949,19 @@
   ; GCN-NEXT:    ;;#ASMEND
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v199, v[150:151]
-  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v200, v[152:153]
+  ; GCN-NEXT:    ds_write_b64 v191, v[152:153]
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[132:133], v[142:143], v[0:15]
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v132, v125
   ; GCN-NEXT:    v_exp_f32_e32 v130, v158
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v201, v[154:155]
+  ; GCN-NEXT:    ds_write_b64 v192, v[154:155]
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b64 v202, v[156:157]
+  ; GCN-NEXT:    ds_write_b64 v193, v[156:157]
+  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+  ; GCN-NEXT:    ds_write_b64 v194, v[150:151]
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
@@ -973,20 +972,19 @@
   ; GCN-NEXT:    v_mul_f32_e32 v144, 0x3fb8aa3b, v69
   ; GCN-NEXT:    v_fma_f32 v69, s4, v71, -v128
   ; GCN-NEXT:    v_pack_b32_f16 v140, v132, v68
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v68, v129
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[64:65], v[142:143], v[16:31]
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v64, v127
   ; GCN-NEXT:    v_exp_f32_e32 v132, v145
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v68, v129
   ; GCN-NEXT:    v_fma_f32 v65, s4, v70, -v128
   ; GCN-NEXT:    v_mul_f32_e32 v65, 0x3fb8aa3b, v65
   ; GCN-NEXT:    v_fma_f32 v145, s4, v73, -v128
-  ; GCN-NEXT:    v_mul_f32_e32 v147, 0x3fb8aa3b, v145
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[136:137], v[142:143], v[48:63]
   ; GCN-NEXT:    v_exp_f32_e32 v133, v141
   ; GCN-NEXT:    v_mul_f32_e32 v142, 0x3fb8aa3b, v69
   ; GCN-NEXT:    v_pack_b32_f16 v141, v64, v68
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    ds_read_b128 v[68:71], v198
+  ; GCN-NEXT:    ds_read_b128 v[68:71], v190
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_fma_f32 v143, s4, v72, -v128
@@ -995,9 +993,10 @@
   ; GCN-NEXT:    v_exp_f32_e32 v72, v146
   ; GCN-NEXT:    v_mul_f32_e32 v146, 0x3fb8aa3b, v143
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v143, v131
-  ; GCN-NEXT:    ds_read_b128 v[134:137], v198 offset:576
+  ; GCN-NEXT:    ds_read_b128 v[134:137], v190 offset:576
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    v_mul_f32_e32 v147, 0x3fb8aa3b, v145
   ; GCN-NEXT:    v_pack_b32_f16 v64, v64, v143
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[148:149], v[140:141], v[32:47]
   ; GCN-NEXT:    v_exp_f32_e32 v73, v144
@@ -1012,10 +1011,10 @@
   ; GCN-NEXT:    v_fma_f32 v138, s4, v75, -v128
   ; GCN-NEXT:    v_exp_f32_e32 v75, v142
   ; GCN-NEXT:    v_mul_f32_e32 v148, 0x3fb8aa3b, v138
-  ; GCN-NEXT:    ds_read_b128 v[138:141], v198 offset:1152
+  ; GCN-NEXT:    ds_read_b128 v[138:141], v190 offset:1152
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[142:145], v198 offset:1728
+  ; GCN-NEXT:    ds_read_b128 v[142:145], v190 offset:1728
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v66, v72
@@ -1044,10 +1043,10 @@
   ; GCN-NEXT:    s_nop 1
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[70:71], v[134:135], v[0:15]
   ; GCN-NEXT:    v_exp_f32_e32 v142, v146
-  ; GCN-NEXT:    ds_read_b128 v[68:71], v197
+  ; GCN-NEXT:    ds_read_b128 v[68:71], v189
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[64:67], v197 offset:576
+  ; GCN-NEXT:    ds_read_b128 v[64:67], v189 offset:576
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[136:137], v[134:135], v[32:47]
@@ -1105,28 +1104,28 @@
   ; GCN-NEXT:    v_add_f32_e32 v53, v87, v53
   ; GCN-NEXT:    v_add_f32_e32 v53, v88, v53
   ; GCN-NEXT:    v_add_f32_e32 v53, v89, v53
-  ; GCN-NEXT:    v_pack_b32_f16 v49, v140, v49
   ; GCN-NEXT:    v_add_f32_e32 v53, v90, v53
   ; GCN-NEXT:    v_add_f32_e32 v53, v91, v53
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[68:69], v[48:49], v[0:15]
   ; GCN-NEXT:    v_add_f32_e32 v53, v92, v53
   ; GCN-NEXT:    v_add_f32_e32 v53, v93, v53
   ; GCN-NEXT:    v_add_f32_e32 v53, v94, v53
   ; GCN-NEXT:    v_add_f32_e32 v53, v95, v53
+  ; GCN-NEXT:    v_pack_b32_f16 v49, v140, v49
   ; GCN-NEXT:    v_add_f32_e32 v53, v125, v53
   ; GCN-NEXT:    v_add_f32_e32 v53, v126, v53
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[68:69], v[48:49], v[0:15]
   ; GCN-NEXT:    v_add_f32_e32 v53, v127, v53
   ; GCN-NEXT:    v_add_f32_e32 v53, v129, v53
+  ; GCN-NEXT:    v_add_f32_e32 v53, v130, v53
+  ; GCN-NEXT:    v_add_f32_e32 v53, v131, v53
+  ; GCN-NEXT:    v_add_f32_e32 v53, v132, v53
+  ; GCN-NEXT:    v_add_f32_e32 v53, v133, v53
+  ; GCN-NEXT:    v_add_f32_e32 v53, v72, v53
+  ; GCN-NEXT:    v_add_f32_e32 v53, v73, v53
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[70:71], v[50:51], v[0:15]
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[64:65], v[48:49], v[32:47]
   ; GCN-NEXT:    s_nop 9
-  ; GCN-NEXT:    v_add_f32_e32 v0, v130, v53
-  ; GCN-NEXT:    v_add_f32_e32 v0, v131, v0
-  ; GCN-NEXT:    v_add_f32_e32 v0, v132, v0
-  ; GCN-NEXT:    v_add_f32_e32 v0, v133, v0
-  ; GCN-NEXT:    v_add_f32_e32 v0, v72, v0
-  ; GCN-NEXT:    v_add_f32_e32 v0, v73, v0
-  ; GCN-NEXT:    v_add_f32_e32 v0, v74, v0
+  ; GCN-NEXT:    v_add_f32_e32 v0, v74, v53
   ; GCN-NEXT:    v_add_f32_e32 v0, v75, v0
   ; GCN-NEXT:    v_add_f32_e32 v0, v76, v0
   ; GCN-NEXT:    v_add_f32_e32 v0, v77, v0
@@ -1136,19 +1135,19 @@
   ; GCN-NEXT:    v_add_f32_e32 v0, v137, v0
   ; GCN-NEXT:    v_add_f32_e32 v0, v138, v0
   ; GCN-NEXT:    v_add_f32_e32 v4, v52, v0
-  ; GCN-NEXT:    ds_bpermute_b32 v5, v196, v4
+  ; GCN-NEXT:    ds_bpermute_b32 v5, v188, v4
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    ds_read_b128 v[0:3], v197 offset:1152
+  ; GCN-NEXT:    ds_read_b128 v[0:3], v189 offset:1152
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[0:1], v[48:49], v[16:31]
   ; GCN-NEXT:    v_add_f32_e32 v2, v4, v5
-  ; GCN-NEXT:    ds_bpermute_b32 v3, v196, v2
+  ; GCN-NEXT:    ds_bpermute_b32 v3, v188, v2
   ; GCN-NEXT:    ; implicit-def: $vgpr4
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    v_cndmask_b32_e64 v0, v3, v2, s[12:13]
-  ; GCN-NEXT:    v_fmac_f32_e32 v0, v4, v112
-  ; GCN-NEXT:    ds_read_b128 v[0:3], v197 offset:1728
+  ; GCN-NEXT:    v_cndmask_b32_e64 v2, v3, v2, s[12:13]
+  ; GCN-NEXT:    v_fmac_f32_e32 v2, v4, v112
+  ; GCN-NEXT:    ds_read_b128 v[0:3], v189 offset:1728
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    ;;#ASMSTART

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.iglp.opt.exp.small.mir
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.iglp.opt.exp.small.mir
@@ -19,15 +19,18 @@
   ; GCN-NEXT:    ; implicit-def: $vgpr40_vgpr41_vgpr42_vgpr43
   ; GCN-NEXT:    ; implicit-def: $vgpr51
   ; GCN-NEXT:    ; implicit-def: $vgpr62_vgpr63_vgpr64_vgpr65
-  ; GCN-NEXT:    ; implicit-def: $vgpr76
-  ; GCN-NEXT:    ; implicit-def: $vgpr77
   ; GCN-NEXT:    ; implicit-def: $vgpr78
   ; GCN-NEXT:    ; implicit-def: $vgpr79
   ; GCN-NEXT:    ; implicit-def: $vgpr80
+  ; GCN-NEXT:    ; implicit-def: $vgpr81
+  ; GCN-NEXT:    ; implicit-def: $vgpr82
+  ; GCN-NEXT:    ; implicit-def: $vgpr76
+  ; GCN-NEXT:    ; implicit-def: $vgpr77
+  ; GCN-NEXT:    v_max_f32_e32 v83, v77, v77
   ; GCN-NEXT:    ; implicit-def: $vgpr91
   ; GCN-NEXT:    ; kill: killed $sgpr16_sgpr17_sgpr18_sgpr19
   ; GCN-NEXT:    ; iglp_opt mask(0x00000002)
-  ; GCN-NEXT:    s_nop 1
+  ; GCN-NEXT:    s_nop 0
   ; GCN-NEXT:    v_lshl_add_u32 v2, s20, 4, v3
   ; GCN-NEXT:    v_mad_u64_u32 v[4:5], s[4:5], s4, v2, v[0:1]
   ; GCN-NEXT:    buffer_load_dwordx4 v[0:3], v4, s[0:3], 0 offen sc0 sc1
@@ -36,8 +39,6 @@
   ; GCN-NEXT:    s_lshl_b32 s4, s20, 7
   ; GCN-NEXT:    ; implicit-def: $vgpr5
   ; GCN-NEXT:    v_add_lshl_u32 v48, v5, s4, 1
-  ; GCN-NEXT:    v_add_u32_e32 v76, s20, v76
-  ; GCN-NEXT:    v_and_b32_e32 v76, 0x1fffffff, v76
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    ds_write_b128 v48, v[0:3]
@@ -69,14 +70,9 @@
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[36:37], v[40:41], 0
   ; GCN-NEXT:    ; kill: killed $vgpr1
   ; GCN-NEXT:    ; kill: killed $vgpr0
-  ; GCN-NEXT:    v_mul_lo_u32 v76, v76, s6
-  ; GCN-NEXT:    v_add_lshl_u32 v76, v77, v76, 1
-  ; GCN-NEXT:    v_lshl_add_u32 v77, v78, 1, v76
   ; GCN-NEXT:    ; implicit-def: $sgpr5
-  ; GCN-NEXT:    v_lshl_add_u32 v78, v79, 1, v77
   ; GCN-NEXT:    ; implicit-def: $sgpr2
   ; GCN-NEXT:    ; implicit-def: $sgpr3
-  ; GCN-NEXT:    v_lshl_add_u32 v79, v80, 1, v78
   ; GCN-NEXT:    ; implicit-def: $sgpr0_sgpr1
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[44:45], v[40:41], 0
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[38:39], v[42:43], v[16:31]
@@ -115,10 +111,10 @@
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[32:33], v[36:37], v[16:31]
   ; GCN-NEXT:    ; implicit-def: $vgpr32
   ; GCN-NEXT:    ; implicit-def: $vgpr33
-  ; GCN-NEXT:    v_add_u32_e32 v82, v32, v50
-  ; GCN-NEXT:    v_add_u32_e32 v83, v33, v50
-  ; GCN-NEXT:    ; kill: killed $vgpr82
-  ; GCN-NEXT:    ; kill: killed $vgpr83
+  ; GCN-NEXT:    v_add_u32_e32 v84, v32, v50
+  ; GCN-NEXT:    v_add_u32_e32 v85, v33, v50
+  ; GCN-NEXT:    ; kill: killed $vgpr85
+  ; GCN-NEXT:    ; kill: killed $vgpr84
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[34:35], v[38:39], v[16:31]
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[40:41], v[36:37], v[0:15]
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[68:69], v[62:63], v[16:31]
@@ -131,38 +127,38 @@
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[42:43], v[38:39], v[0:15]
   ; GCN-NEXT:    ; implicit-def: $vgpr32_vgpr33_vgpr34_vgpr35_vgpr36_vgpr37_vgpr38_vgpr39_vgpr40_vgpr41_vgpr42_vgpr43_vgpr44_vgpr45_vgpr46_vgpr47
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[66:67], v[62:63], v[0:15]
-  ; GCN-NEXT:    ; implicit-def: $vgpr66
-  ; GCN-NEXT:    ; implicit-def: $vgpr67
-  ; GCN-NEXT:    v_max_f32_e32 v81, v67, v67
-  ; GCN-NEXT:    ; implicit-def: $vgpr48_vgpr49_vgpr50_vgpr51_vgpr52_vgpr53_vgpr54_vgpr55_vgpr56_vgpr57_vgpr58_vgpr59_vgpr60_vgpr61_vgpr62_vgpr63
+  ; GCN-NEXT:    v_add_u32_e32 v66, s20, v78
+  ; GCN-NEXT:    v_and_b32_e32 v66, 0x1fffffff, v66
+  ; GCN-NEXT:    v_mul_lo_u32 v66, v66, s6
+  ; GCN-NEXT:    v_add_lshl_u32 v78, v79, v66, 1
+  ; GCN-NEXT:    v_perm_b32 v66, v74, v72, s2
+  ; GCN-NEXT:    v_perm_b32 v67, v74, v72, s3
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[16:31], v[70:71], v[64:65], v[16:31]
-  ; GCN-NEXT:    v_perm_b32 v70, v74, v72, s2
-  ; GCN-NEXT:    v_perm_b32 v71, v74, v72, s3
+  ; GCN-NEXT:    v_lshl_add_u32 v70, v80, 1, v78
+  ; GCN-NEXT:    v_lshl_add_u32 v71, v81, 1, v70
+  ; GCN-NEXT:    v_lshl_add_u32 v79, v82, 1, v71
   ; GCN-NEXT:    v_perm_b32 v72, v75, v73, s2
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    ds_write_b32 v76, v70
+  ; GCN-NEXT:    ds_write_b32 v78, v66
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b32 v77, v71
-  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b32 v78, v72
-  ; GCN-NEXT:    v_mul_f32_e32 v74, s4, v20
+  ; GCN-NEXT:    ds_write_b32 v70, v67
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[0:15], v[68:69], v[64:65], v[0:15]
   ; GCN-NEXT:    v_mul_f32_e32 v64, s4, v16
   ; GCN-NEXT:    v_mul_f32_e32 v65, s4, v17
   ; GCN-NEXT:    v_mul_f32_e32 v68, s4, v18
   ; GCN-NEXT:    v_mul_f32_e32 v69, s4, v19
   ; GCN-NEXT:    v_max3_f32 v64, v64, s5, v65
+  ; GCN-NEXT:    v_mul_f32_e32 v74, s4, v20
   ; GCN-NEXT:    v_mul_f32_e32 v80, s4, v21
   ; GCN-NEXT:    v_max3_f32 v64, v64, v68, v69
-  ; GCN-NEXT:    v_mul_f32_e32 v84, s4, v22
-  ; GCN-NEXT:    v_mul_f32_e32 v85, s4, v23
+  ; GCN-NEXT:    v_mul_f32_e32 v81, s4, v22
+  ; GCN-NEXT:    v_mul_f32_e32 v82, s4, v23
   ; GCN-NEXT:    v_max3_f32 v64, v64, v74, v80
   ; GCN-NEXT:    v_mul_f32_e32 v86, s4, v24
   ; GCN-NEXT:    v_mul_f32_e32 v87, s4, v25
-  ; GCN-NEXT:    v_max3_f32 v64, v64, v84, v85
+  ; GCN-NEXT:    v_max3_f32 v64, v64, v81, v82
   ; GCN-NEXT:    v_mul_f32_e32 v65, s4, v26
   ; GCN-NEXT:    v_mul_f32_e32 v68, s4, v27
   ; GCN-NEXT:    v_max3_f32 v64, v64, v86, v87
@@ -170,26 +166,26 @@
   ; GCN-NEXT:    v_mul_f32_e32 v74, s4, v29
   ; GCN-NEXT:    v_max3_f32 v64, v64, v65, v68
   ; GCN-NEXT:    v_mul_f32_e32 v80, s4, v30
-  ; GCN-NEXT:    v_mul_f32_e32 v84, s4, v31
+  ; GCN-NEXT:    v_mul_f32_e32 v81, s4, v31
   ; GCN-NEXT:    v_max3_f32 v64, v64, v69, v74
-  ; GCN-NEXT:    v_mul_f32_e32 v85, s4, v0
+  ; GCN-NEXT:    v_mul_f32_e32 v82, s4, v0
   ; GCN-NEXT:    v_mul_f32_e32 v86, s4, v1
-  ; GCN-NEXT:    v_max3_f32 v64, v64, v80, v84
+  ; GCN-NEXT:    v_max3_f32 v64, v64, v80, v81
   ; GCN-NEXT:    v_mul_f32_e32 v87, s4, v2
   ; GCN-NEXT:    v_mul_f32_e32 v65, s4, v3
-  ; GCN-NEXT:    v_max3_f32 v64, v64, v85, v86
+  ; GCN-NEXT:    v_max3_f32 v64, v64, v82, v86
   ; GCN-NEXT:    v_mul_f32_e32 v68, s4, v4
   ; GCN-NEXT:    v_mul_f32_e32 v69, s4, v5
   ; GCN-NEXT:    v_max3_f32 v64, v64, v87, v65
   ; GCN-NEXT:    v_mul_f32_e32 v74, s4, v6
   ; GCN-NEXT:    v_mul_f32_e32 v80, s4, v7
   ; GCN-NEXT:    v_max3_f32 v64, v64, v68, v69
-  ; GCN-NEXT:    v_mul_f32_e32 v84, s4, v8
-  ; GCN-NEXT:    v_mul_f32_e32 v85, s4, v9
+  ; GCN-NEXT:    v_mul_f32_e32 v81, s4, v8
+  ; GCN-NEXT:    v_mul_f32_e32 v82, s4, v9
   ; GCN-NEXT:    v_max3_f32 v64, v64, v74, v80
   ; GCN-NEXT:    v_mul_f32_e32 v86, s4, v10
   ; GCN-NEXT:    v_mul_f32_e32 v65, s4, v11
-  ; GCN-NEXT:    v_max3_f32 v64, v64, v84, v85
+  ; GCN-NEXT:    v_max3_f32 v64, v64, v81, v82
   ; GCN-NEXT:    v_mul_f32_e32 v87, s4, v12
   ; GCN-NEXT:    v_mul_f32_e32 v68, s4, v13
   ; GCN-NEXT:    v_max3_f32 v64, v64, v86, v65
@@ -197,29 +193,33 @@
   ; GCN-NEXT:    v_mul_f32_e32 v74, s4, v15
   ; GCN-NEXT:    v_max3_f32 v64, v64, v87, v68
   ; GCN-NEXT:    v_max3_f32 v64, v64, v69, v74
-  ; GCN-NEXT:    ds_bpermute_b32 v65, v66, v64
+  ; GCN-NEXT:    ds_bpermute_b32 v65, v76, v64
   ; GCN-NEXT:    v_perm_b32 v68, v75, v73, s3
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+  ; GCN-NEXT:    ds_write_b32 v71, v72
+  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
   ; GCN-NEXT:    ds_write_b32 v79, v68
-  ; GCN-NEXT:    ; implicit-def: $vgpr84
+  ; GCN-NEXT:    ; implicit-def: $vgpr48_vgpr49_vgpr50_vgpr51_vgpr52_vgpr53_vgpr54_vgpr55_vgpr56_vgpr57_vgpr58_vgpr59_vgpr60_vgpr61_vgpr62_vgpr63
   ; GCN-NEXT:    v_max_f32_e32 v65, v65, v65
-  ; GCN-NEXT:    v_max_f32_e32 v70, v64, v65
+  ; GCN-NEXT:    v_max_f32_e32 v69, v64, v65
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    buffer_load_dwordx2 v[64:65], v82, s[16:19], 0 offen sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx2 v[64:65], v84, s[16:19], 0 offen sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    buffer_load_dwordx2 v[68:69], v83, s[16:19], 0 offen sc0 sc1
+  ; GCN-NEXT:    buffer_load_dwordx2 v[66:67], v85, s[16:19], 0 offen sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_bpermute_b32 v71, v66, v70
+  ; GCN-NEXT:    ds_bpermute_b32 v73, v76, v69
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
+  ; GCN-NEXT:    ; implicit-def: $vgpr84
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    v_cndmask_b32_e64 v70, v71, v70, s[0:1]
-  ; GCN-NEXT:    v_max_f32_e32 v70, v70, v70
-  ; GCN-NEXT:    v_max_f32_e32 v72, v81, v70
+  ; GCN-NEXT:    v_cndmask_b32_e64 v68, v73, v69, s[0:1]
+  ; GCN-NEXT:    v_max_f32_e32 v68, v68, v68
+  ; GCN-NEXT:    v_max_f32_e32 v72, v83, v68
   ; GCN-NEXT:    v_fma_f32 v16, s4, v16, -v72
   ; GCN-NEXT:    v_fma_f32 v18, s4, v18, -v72
   ; GCN-NEXT:    v_fma_f32 v19, s4, v19, -v72
@@ -248,11 +248,11 @@
   ; GCN-NEXT:    v_mul_f32_e32 v17, 0x3fb8aa3b, v17
   ; GCN-NEXT:    v_mul_f32_e32 v23, 0x3fb8aa3b, v23
   ; GCN-NEXT:    v_fma_f32 v26, s4, v26, -v72
-  ; GCN-NEXT:    v_pack_b32_f16 v71, v21, v22
+  ; GCN-NEXT:    v_pack_b32_f16 v69, v21, v22
   ; GCN-NEXT:    v_mul_f32_e32 v22, 0x3fb8aa3b, v18
-  ; GCN-NEXT:    v_sub_f32_e32 v24, v67, v72
+  ; GCN-NEXT:    v_sub_f32_e32 v24, v77, v72
   ; GCN-NEXT:    v_exp_f32_e32 v83, v23
-  ; GCN-NEXT:    v_fma_f32 v67, s4, v27, -v72
+  ; GCN-NEXT:    v_fma_f32 v77, s4, v27, -v72
   ; GCN-NEXT:    v_exp_f32_e32 v85, v22
   ; GCN-NEXT:    v_exp_f32_e32 v17, v17
   ; GCN-NEXT:    v_mul_f32_e32 v24, 0x3fb8aa3b, v24
@@ -261,7 +261,7 @@
   ; GCN-NEXT:    v_fma_f32 v87, s4, v29, -v72
   ; GCN-NEXT:    v_exp_f32_e32 v88, v23
   ; GCN-NEXT:    v_fma_f32 v0, s4, v0, -v72
-  ; GCN-NEXT:    v_pack_b32_f16 v70, v16, v19
+  ; GCN-NEXT:    v_pack_b32_f16 v68, v16, v19
   ; GCN-NEXT:    ds_read_b128 v[18:21], v84
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
@@ -285,14 +285,13 @@
   ; GCN-NEXT:    v_pk_mul_f32 v[42:43], v[42:43], v[16:17] op_sel_hi:[1,0]
   ; GCN-NEXT:    v_pk_mul_f32 v[44:45], v[44:45], v[16:17] op_sel_hi:[1,0]
   ; GCN-NEXT:    v_pk_mul_f32 v[46:47], v[46:47], v[16:17] op_sel_hi:[1,0]
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[18:19], v[70:71], v[48:63]
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[18:19], v[68:69], v[48:63]
   ; GCN-NEXT:    v_add_f32_e32 v18, 0, v73
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v89, v83
   ; GCN-NEXT:    v_fma_f32 v73, s4, v28, -v72
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v19, v80
   ; GCN-NEXT:    v_fma_f32 v1, s4, v1, -v72
-  ; GCN-NEXT:    v_perm_b32 v90, v69, v65, s2
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[22:23], v[70:71], v[32:47]
+  ; GCN-NEXT:    v_perm_b32 v89, v67, v65, s2
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[22:23], v[68:69], v[32:47]
   ; GCN-NEXT:    v_add_f32_e32 v17, v17, v18
   ; GCN-NEXT:    v_mul_f32_e32 v18, 0x3fb8aa3b, v26
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v86, v81
@@ -300,13 +299,13 @@
   ; GCN-NEXT:    v_exp_f32_e32 v30, v18
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v22, v82
   ; GCN-NEXT:    v_fma_f32 v18, s4, v31, -v72
-  ; GCN-NEXT:    v_perm_b32 v31, v68, v64, s2
-  ; GCN-NEXT:    v_perm_b32 v64, v68, v64, s3
-  ; GCN-NEXT:    v_perm_b32 v65, v69, v65, s3
+  ; GCN-NEXT:    v_perm_b32 v31, v66, v64, s2
+  ; GCN-NEXT:    v_perm_b32 v69, v66, v64, s3
+  ; GCN-NEXT:    v_perm_b32 v90, v67, v65, s3
   ; GCN-NEXT:    ds_read_b128 v[26:29], v91
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    ds_read_b128 v[68:71], v91 offset:576
+  ; GCN-NEXT:    ds_read_b128 v[64:67], v91 offset:576
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
   ; GCN-NEXT:    ;;#ASMSTART
@@ -314,101 +313,104 @@
   ; GCN-NEXT:    ;;#ASMEND
   ; GCN-NEXT:    buffer_wbl2 sc0 sc1
   ; GCN-NEXT:    s_waitcnt vmcnt(0)
-  ; GCN-NEXT:    ds_write_b32 v76, v31
-  ; GCN-NEXT:    v_mul_f32_e32 v31, 0x3fb8aa3b, v67
+  ; GCN-NEXT:    ds_write_b32 v78, v31
+  ; GCN-NEXT:    v_mul_f32_e32 v31, 0x3fb8aa3b, v77
   ; GCN-NEXT:    v_exp_f32_e32 v31, v31
-  ; GCN-NEXT:    v_mul_f32_e32 v67, 0x3fb8aa3b, v18
-  ; GCN-NEXT:    v_pack_b32_f16 v18, v19, v86
-  ; GCN-NEXT:    v_pack_b32_f16 v19, v22, v89
-  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b32 v77, v64
-  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b32 v78, v90
-  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
-  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-  ; GCN-NEXT:    ds_write_b32 v79, v65
-  ; GCN-NEXT:    v_mul_f32_e32 v64, 0x3fb8aa3b, v73
-  ; GCN-NEXT:    v_mul_f32_e32 v65, 0x3fb8aa3b, v87
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[20:21], v[18:19], v[48:63]
   ; GCN-NEXT:    v_add_f32_e32 v17, v74, v17
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v20, v85
-  ; GCN-NEXT:    v_fma_f32 v2, s4, v2, -v72
-  ; GCN-NEXT:    v_exp_f32_e32 v22, v64
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v21, v88
-  ; GCN-NEXT:    v_exp_f32_e32 v64, v65
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v68, v83
+  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+  ; GCN-NEXT:    ds_write_b32 v70, v69
+  ; GCN-NEXT:    v_mul_f32_e32 v69, 0x3fb8aa3b, v73
+  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+  ; GCN-NEXT:    ds_write_b32 v71, v89
+  ; GCN-NEXT:    v_mul_f32_e32 v70, 0x3fb8aa3b, v87
   ; GCN-NEXT:    v_mul_f32_e32 v23, 0x3fb8aa3b, v23
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[24:25], v[18:19], v[32:47]
-  ; GCN-NEXT:    v_add_f32_e32 v17, v75, v17
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v18, v30
-  ; GCN-NEXT:    v_fma_f32 v24, s4, v3, -v72
+  ; GCN-NEXT:    v_mul_f32_e32 v71, 0x3fb8aa3b, v18
+  ; GCN-NEXT:    v_pack_b32_f16 v18, v19, v86
+  ; GCN-NEXT:    v_pack_b32_f16 v19, v22, v68
+  ; GCN-NEXT:    v_fma_f32 v2, s4, v2, -v72
+  ; GCN-NEXT:    v_exp_f32_e32 v22, v69
+  ; GCN-NEXT:    v_mul_f32_e32 v69, 0x3fb8aa3b, v1
+  ; GCN-NEXT:    v_exp_f32_e32 v68, v70
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[20:21], v[18:19], v[48:63]
+  ; GCN-NEXT:    v_fma_f32 v70, s4, v5, -v72
   ; GCN-NEXT:    v_exp_f32_e32 v23, v23
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v19, v31
-  ; GCN-NEXT:    v_mul_f32_e32 v3, 0x3fb8aa3b, v0
-  ; GCN-NEXT:    v_mul_f32_e32 v65, 0x3fb8aa3b, v1
-  ; GCN-NEXT:    v_pack_b32_f16 v0, v20, v21
-  ; GCN-NEXT:    v_pack_b32_f16 v1, v18, v19
-  ; GCN-NEXT:    v_fma_f32 v6, s4, v6, -v72
-  ; GCN-NEXT:    v_exp_f32_e32 v25, v67
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[26:27], v[0:1], v[48:63]
-  ; GCN-NEXT:    v_add_f32_e32 v17, v80, v17
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v18, v22
-  ; GCN-NEXT:    v_fma_f32 v26, s4, v4, -v72
-  ; GCN-NEXT:    v_exp_f32_e32 v27, v3
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v4, v64
-  ; GCN-NEXT:    v_fma_f32 v67, s4, v5, -v72
-  ; GCN-NEXT:    v_exp_f32_e32 v65, v65
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[68:69], v[0:1], v[32:47]
+  ; GCN-NEXT:    v_exp_f32_e32 v69, v69
+  ; GCN-NEXT:    buffer_wbl2 sc0 sc1
+  ; GCN-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+  ; GCN-NEXT:    ds_write_b32 v79, v90
   ; GCN-NEXT:    v_mul_f32_e32 v2, 0x3fb8aa3b, v2
-  ; GCN-NEXT:    v_add_f32_e32 v17, v81, v17
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v5, v23
-  ; GCN-NEXT:    v_fma_f32 v7, s4, v7, -v72
-  ; GCN-NEXT:    v_exp_f32_e32 v68, v2
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v19, v25
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[24:25], v[18:19], v[32:47]
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v20, v85
+  ; GCN-NEXT:    v_fma_f32 v24, s4, v3, -v72
+  ; GCN-NEXT:    v_exp_f32_e32 v25, v71
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v21, v88
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v18, v30
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v19, v31
+  ; GCN-NEXT:    v_mul_f32_e32 v3, 0x3fb8aa3b, v0
+  ; GCN-NEXT:    v_pack_b32_f16 v0, v20, v21
   ; GCN-NEXT:    v_mul_f32_e32 v24, 0x3fb8aa3b, v24
+  ; GCN-NEXT:    v_pack_b32_f16 v1, v18, v19
+  ; GCN-NEXT:    ; implicit-def: $sgpr2
+  ; GCN-NEXT:    s_nop 1
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[26:27], v[0:1], v[48:63]
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v19, v25
+  ; GCN-NEXT:    v_fma_f32 v26, s4, v4, -v72
+  ; GCN-NEXT:    v_exp_f32_e32 v27, v3
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v18, v22
+  ; GCN-NEXT:    v_mul_f32_e32 v26, 0x3fb8aa3b, v26
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[64:65], v[0:1], v[32:47]
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v4, v68
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v5, v23
+  ; GCN-NEXT:    v_mul_f32_e32 v65, 0x3fb8aa3b, v70
+  ; GCN-NEXT:    v_exp_f32_e32 v65, v65
+  ; GCN-NEXT:    v_pack_b32_f16 v4, v18, v4
+  ; GCN-NEXT:    v_pack_b32_f16 v5, v5, v19
+  ; GCN-NEXT:    s_nop 1
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[28:29], v[4:5], v[48:63]
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v28, v27
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[66:67], v[4:5], v[32:47]
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v29, v69
+  ; GCN-NEXT:    v_pack_b32_f16 v4, v28, v29
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v28, v65
+  ; GCN-NEXT:    v_add_f32_e32 v17, v75, v17
+  ; GCN-NEXT:    v_fma_f32 v6, s4, v6, -v72
+  ; GCN-NEXT:    v_add_f32_e32 v17, v80, v17
+  ; GCN-NEXT:    v_fma_f32 v7, s4, v7, -v72
+  ; GCN-NEXT:    v_exp_f32_e32 v24, v24
+  ; GCN-NEXT:    v_add_f32_e32 v17, v81, v17
+  ; GCN-NEXT:    v_mul_f32_e32 v6, 0x3fb8aa3b, v6
+  ; GCN-NEXT:    v_mul_f32_e32 v7, 0x3fb8aa3b, v7
+  ; GCN-NEXT:    v_exp_f32_e32 v6, v6
+  ; GCN-NEXT:    v_exp_f32_e32 v7, v7
+  ; GCN-NEXT:    v_add_f32_e32 v17, v82, v17
+  ; GCN-NEXT:    v_fma_f32 v10, s4, v10, -v72
+  ; GCN-NEXT:    v_exp_f32_e32 v26, v26
+  ; GCN-NEXT:    v_add_f32_e32 v17, v83, v17
+  ; GCN-NEXT:    v_exp_f32_e32 v64, v2
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    ds_read_b128 v[0:3], v84
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_pack_b32_f16 v4, v18, v4
-  ; GCN-NEXT:    v_pack_b32_f16 v5, v5, v19
-  ; GCN-NEXT:    v_exp_f32_e32 v24, v24
   ; GCN-NEXT:    ds_read_b128 v[18:21], v84 offset:576
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mul_f32_e32 v26, 0x3fb8aa3b, v26
-  ; GCN-NEXT:    v_mul_f32_e32 v67, 0x3fb8aa3b, v67
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[28:29], v[4:5], v[48:63]
-  ; GCN-NEXT:    v_add_f32_e32 v17, v82, v17
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v28, v27
-  ; GCN-NEXT:    v_exp_f32_e32 v26, v26
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v29, v65
-  ; GCN-NEXT:    v_fma_f32 v10, s4, v10, -v72
-  ; GCN-NEXT:    v_exp_f32_e32 v67, v67
-  ; GCN-NEXT:    v_mul_f32_e32 v6, 0x3fb8aa3b, v6
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[70:71], v[4:5], v[32:47]
-  ; GCN-NEXT:    v_add_f32_e32 v17, v83, v17
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v5, v68
-  ; GCN-NEXT:    v_exp_f32_e32 v6, v6
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v69, v24
-  ; GCN-NEXT:    v_mul_f32_e32 v7, 0x3fb8aa3b, v7
-  ; GCN-NEXT:    v_exp_f32_e32 v7, v7
-  ; GCN-NEXT:    v_pack_b32_f16 v4, v28, v29
-  ; GCN-NEXT:    v_pack_b32_f16 v5, v5, v69
-  ; GCN-NEXT:    ; implicit-def: $sgpr2
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v5, v64
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v66, v24
+  ; GCN-NEXT:    v_pack_b32_f16 v5, v5, v66
   ; GCN-NEXT:    s_nop 1
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[0:1], v[4:5], v[48:63]
   ; GCN-NEXT:    v_add_f32_e32 v0, v85, v17
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v17, v26
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v28, v67
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v1, v6
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[18:19], v[4:5], v[32:47]
   ; GCN-NEXT:    v_add_f32_e32 v4, v88, v0
   ; GCN-NEXT:    v_mul_f32_e32 v0, 0x3fb8aa3b, v10
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v1, v6
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v17, v26
   ; GCN-NEXT:    v_exp_f32_e32 v10, v0
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v0, v7
   ; GCN-NEXT:    v_pack_b32_f16 v1, v1, v0
@@ -419,76 +421,76 @@
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[20:21], v[0:1], v[32:47]
   ; GCN-NEXT:    v_add_f32_e32 v0, v31, v2
   ; GCN-NEXT:    v_add_f32_e32 v0, v22, v0
-  ; GCN-NEXT:    v_add_f32_e32 v0, v64, v0
+  ; GCN-NEXT:    v_add_f32_e32 v0, v68, v0
   ; GCN-NEXT:    v_add_f32_e32 v0, v23, v0
   ; GCN-NEXT:    v_add_f32_e32 v0, v25, v0
   ; GCN-NEXT:    v_add_f32_e32 v0, v27, v0
   ; GCN-NEXT:    v_fma_f32 v8, s4, v8, -v72
-  ; GCN-NEXT:    v_add_f32_e32 v0, v65, v0
+  ; GCN-NEXT:    v_add_f32_e32 v0, v69, v0
   ; GCN-NEXT:    v_fma_f32 v9, s4, v9, -v72
-  ; GCN-NEXT:    v_mul_f32_e32 v8, 0x3fb8aa3b, v8
-  ; GCN-NEXT:    v_add_f32_e32 v0, v68, v0
   ; GCN-NEXT:    v_fma_f32 v11, s4, v11, -v72
-  ; GCN-NEXT:    v_mul_f32_e32 v9, 0x3fb8aa3b, v9
+  ; GCN-NEXT:    v_mul_f32_e32 v8, 0x3fb8aa3b, v8
   ; GCN-NEXT:    v_fma_f32 v12, s4, v12, -v72
-  ; GCN-NEXT:    v_fma_f32 v13, s4, v13, -v72
-  ; GCN-NEXT:    v_exp_f32_e32 v8, v8
-  ; GCN-NEXT:    v_add_f32_e32 v0, v24, v0
+  ; GCN-NEXT:    v_add_f32_e32 v0, v64, v0
   ; GCN-NEXT:    v_fma_f32 v5, s4, v14, -v72
-  ; GCN-NEXT:    v_exp_f32_e32 v9, v9
-  ; GCN-NEXT:    v_add_f32_e32 v0, v26, v0
-  ; GCN-NEXT:    v_add_f32_e32 v0, v67, v0
-  ; GCN-NEXT:    v_fma_f32 v14, s4, v15, -v72
-  ; GCN-NEXT:    v_mul_f32_e32 v11, 0x3fb8aa3b, v11
+  ; GCN-NEXT:    v_exp_f32_e32 v8, v8
+  ; GCN-NEXT:    v_fma_f32 v13, s4, v13, -v72
   ; GCN-NEXT:    v_mul_f32_e32 v3, 0x3fb8aa3b, v12
-  ; GCN-NEXT:    v_mul_f32_e32 v1, 0x3fb8aa3b, v5
-  ; GCN-NEXT:    v_add_f32_e32 v0, v6, v0
-  ; GCN-NEXT:    v_exp_f32_e32 v11, v11
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v4, v8
+  ; GCN-NEXT:    v_add_f32_e32 v0, v24, v0
+  ; GCN-NEXT:    v_mul_f32_e32 v9, 0x3fb8aa3b, v9
   ; GCN-NEXT:    v_exp_f32_e32 v12, v3
   ; GCN-NEXT:    v_mul_f32_e32 v3, 0x3fb8aa3b, v13
+  ; GCN-NEXT:    v_add_f32_e32 v0, v26, v0
+  ; GCN-NEXT:    v_fma_f32 v14, s4, v15, -v72
+  ; GCN-NEXT:    v_exp_f32_e32 v15, v3
+  ; GCN-NEXT:    v_exp_f32_e32 v9, v9
+  ; GCN-NEXT:    v_add_f32_e32 v0, v65, v0
+  ; GCN-NEXT:    v_add_f32_e32 v0, v6, v0
+  ; GCN-NEXT:    v_add_f32_e32 v0, v7, v0
+  ; GCN-NEXT:    v_mul_f32_e32 v1, 0x3fb8aa3b, v5
+  ; GCN-NEXT:    v_add_f32_e32 v0, v8, v0
+  ; GCN-NEXT:    v_mul_f32_e32 v11, 0x3fb8aa3b, v11
   ; GCN-NEXT:    v_exp_f32_e32 v17, v1
   ; GCN-NEXT:    v_mul_f32_e32 v1, 0x3fb8aa3b, v14
-  ; GCN-NEXT:    v_add_f32_e32 v0, v7, v0
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v13, v9
-  ; GCN-NEXT:    v_exp_f32_e32 v15, v3
+  ; GCN-NEXT:    v_add_f32_e32 v0, v9, v0
+  ; GCN-NEXT:    v_exp_f32_e32 v11, v11
   ; GCN-NEXT:    v_exp_f32_e32 v18, v1
-  ; GCN-NEXT:    v_add_f32_e32 v6, v8, v0
+  ; GCN-NEXT:    v_add_f32_e32 v6, v10, v0
   ; GCN-NEXT:    ds_read_b128 v[0:3], v91
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v4, v8
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v13, v9
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v5, v10
   ; GCN-NEXT:    v_cvt_f16_f32_e32 v14, v11
-  ; GCN-NEXT:    v_add_f32_e32 v6, v9, v6
-  ; GCN-NEXT:    v_pack_b32_f16 v8, v4, v13
-  ; GCN-NEXT:    v_add_f32_e32 v6, v10, v6
-  ; GCN-NEXT:    v_pack_b32_f16 v9, v5, v14
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v7, v18
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v10, v15
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[0:1], v[8:9], v[48:63]
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v0, v17
-  ; GCN-NEXT:    v_cvt_f16_f32_e32 v4, v12
   ; GCN-NEXT:    v_add_f32_e32 v6, v11, v6
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v7, v18
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v10, v17
   ; GCN-NEXT:    v_add_f32_e32 v6, v12, v6
-  ; GCN-NEXT:    v_add_f32_e32 v1, v15, v6
-  ; GCN-NEXT:    v_add_f32_e32 v11, v17, v1
-  ; GCN-NEXT:    v_pack_b32_f16 v1, v0, v7
-  ; GCN-NEXT:    v_pack_b32_f16 v0, v4, v10
+  ; GCN-NEXT:    v_add_f32_e32 v6, v15, v6
+  ; GCN-NEXT:    v_add_f32_e32 v6, v17, v6
+  ; GCN-NEXT:    v_pack_b32_f16 v9, v5, v14
+  ; GCN-NEXT:    v_pack_b32_f16 v8, v4, v13
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v11, v12
+  ; GCN-NEXT:    v_add_f32_e32 v12, v18, v6
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[0:1], v[8:9], v[48:63]
+  ; GCN-NEXT:    v_pack_b32_f16 v1, v10, v7
   ; GCN-NEXT:    ds_read_b128 v[4:7], v91 offset:576
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    buffer_inv sc0 sc1
-  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[4:5], v[8:9], v[32:47]
+  ; GCN-NEXT:    v_cvt_f16_f32_e32 v0, v15
   ; GCN-NEXT:    ;;#ASMSTART
   ; GCN-NEXT:    s_waitcnt vmcnt(8)
   ; GCN-NEXT:    ;;#ASMEND
+  ; GCN-NEXT:    v_pack_b32_f16 v0, v11, v0
+  ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[4:5], v[8:9], v[32:47]
   ; GCN-NEXT:    v_mov_b32_e32 v4, 0
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[32:47], v[6:7], v[0:1], v[32:47]
   ; GCN-NEXT:    v_mfma_f32_32x32x8_f16 v[48:63], v[2:3], v[0:1], v[48:63]
-  ; GCN-NEXT:    v_add_f32_e32 v2, v18, v11
-  ; GCN-NEXT:    ds_bpermute_b32 v3, v66, v2
+  ; GCN-NEXT:    ds_bpermute_b32 v2, v76, v12
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-  ; GCN-NEXT:    v_add_f32_e32 v2, v2, v3
-  ; GCN-NEXT:    ds_bpermute_b32 v3, v66, v2
+  ; GCN-NEXT:    v_add_f32_e32 v2, v12, v2
+  ; GCN-NEXT:    ds_bpermute_b32 v3, v76, v2
   ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
   ; GCN-NEXT:    v_cndmask_b32_e64 v2, v3, v2, s[0:1]
   ; GCN-NEXT:    v_fmac_f32_e32 v2, v4, v16

--- a/llvm/test/CodeGen/AMDGPU/neighboring-mfma-padding.mir
+++ b/llvm/test/CodeGen/AMDGPU/neighboring-mfma-padding.mir
@@ -221,22 +221,22 @@ body: |
     ;
     ; gfx908-PAD25-LABEL: name: mfma_padding_8_pass
     ; gfx908-PAD25: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
-    ; gfx908-PAD25-NEXT: S_NOP 1
+    ; gfx908-PAD25-NEXT: S_NOP 0
     ; gfx908-PAD25-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx908-PAD50-LABEL: name: mfma_padding_8_pass
     ; gfx908-PAD50: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
-    ; gfx908-PAD50-NEXT: S_NOP 3
+    ; gfx908-PAD50-NEXT: S_NOP 2
     ; gfx908-PAD50-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx908-PAD75-LABEL: name: mfma_padding_8_pass
     ; gfx908-PAD75: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
-    ; gfx908-PAD75-NEXT: S_NOP 5
+    ; gfx908-PAD75-NEXT: S_NOP 4
     ; gfx908-PAD75-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx908-PAD100-LABEL: name: mfma_padding_8_pass
     ; gfx908-PAD100: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
-    ; gfx908-PAD100-NEXT: S_NOP 7
+    ; gfx908-PAD100-NEXT: S_NOP 6
     ; gfx908-PAD100-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx90a-DEFAULT-LABEL: name: mfma_padding_8_pass
@@ -245,12 +245,12 @@ body: |
     ;
     ; gfx90a-PAD50-LABEL: name: mfma_padding_8_pass
     ; gfx90a-PAD50: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
-    ; gfx90a-PAD50-NEXT: S_NOP 3
+    ; gfx90a-PAD50-NEXT: S_NOP 2
     ; gfx90a-PAD50-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx90a-PAD100-LABEL: name: mfma_padding_8_pass
     ; gfx90a-PAD100: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
-    ; gfx90a-PAD100-NEXT: S_NOP 7
+    ; gfx90a-PAD100-NEXT: S_NOP 6
     ; gfx90a-PAD100-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx942-DEFAULT-LABEL: name: mfma_padding_8_pass
@@ -259,12 +259,12 @@ body: |
     ;
     ; gfx942-PAD50-LABEL: name: mfma_padding_8_pass
     ; gfx942-PAD50: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
-    ; gfx942-PAD50-NEXT: S_NOP 3
+    ; gfx942-PAD50-NEXT: S_NOP 2
     ; gfx942-PAD50-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx942-PAD100-LABEL: name: mfma_padding_8_pass
     ; gfx942-PAD100: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
-    ; gfx942-PAD100-NEXT: S_NOP 7
+    ; gfx942-PAD100-NEXT: S_NOP 6
     ; gfx942-PAD100-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
@@ -290,21 +290,21 @@ body: |
     ; gfx908-PAD50: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ; gfx908-PAD50-NEXT: $vgpr2 = V_MOV_B32_e32 1, implicit $exec
     ; gfx908-PAD50-NEXT: $vgpr3 = V_MOV_B32_e32 1, implicit $exec
-    ; gfx908-PAD50-NEXT: S_NOP 1
+    ; gfx908-PAD50-NEXT: S_NOP 0
     ; gfx908-PAD50-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx908-PAD75-LABEL: name: mfma_padding_8_pass_2_intervening_valu
     ; gfx908-PAD75: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ; gfx908-PAD75-NEXT: $vgpr2 = V_MOV_B32_e32 1, implicit $exec
     ; gfx908-PAD75-NEXT: $vgpr3 = V_MOV_B32_e32 1, implicit $exec
-    ; gfx908-PAD75-NEXT: S_NOP 3
+    ; gfx908-PAD75-NEXT: S_NOP 2
     ; gfx908-PAD75-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx908-PAD100-LABEL: name: mfma_padding_8_pass_2_intervening_valu
     ; gfx908-PAD100: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ; gfx908-PAD100-NEXT: $vgpr2 = V_MOV_B32_e32 1, implicit $exec
     ; gfx908-PAD100-NEXT: $vgpr3 = V_MOV_B32_e32 1, implicit $exec
-    ; gfx908-PAD100-NEXT: S_NOP 5
+    ; gfx908-PAD100-NEXT: S_NOP 4
     ; gfx908-PAD100-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx90a-DEFAULT-LABEL: name: mfma_padding_8_pass_2_intervening_valu
@@ -317,14 +317,14 @@ body: |
     ; gfx90a-PAD50: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ; gfx90a-PAD50-NEXT: $vgpr2 = V_MOV_B32_e32 1, implicit $exec
     ; gfx90a-PAD50-NEXT: $vgpr3 = V_MOV_B32_e32 1, implicit $exec
-    ; gfx90a-PAD50-NEXT: S_NOP 1
+    ; gfx90a-PAD50-NEXT: S_NOP 0
     ; gfx90a-PAD50-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx90a-PAD100-LABEL: name: mfma_padding_8_pass_2_intervening_valu
     ; gfx90a-PAD100: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ; gfx90a-PAD100-NEXT: $vgpr2 = V_MOV_B32_e32 1, implicit $exec
     ; gfx90a-PAD100-NEXT: $vgpr3 = V_MOV_B32_e32 1, implicit $exec
-    ; gfx90a-PAD100-NEXT: S_NOP 5
+    ; gfx90a-PAD100-NEXT: S_NOP 4
     ; gfx90a-PAD100-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx942-DEFAULT-LABEL: name: mfma_padding_8_pass_2_intervening_valu
@@ -337,14 +337,14 @@ body: |
     ; gfx942-PAD50: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ; gfx942-PAD50-NEXT: $vgpr2 = V_MOV_B32_e32 1, implicit $exec
     ; gfx942-PAD50-NEXT: $vgpr3 = V_MOV_B32_e32 1, implicit $exec
-    ; gfx942-PAD50-NEXT: S_NOP 1
+    ; gfx942-PAD50-NEXT: S_NOP 0
     ; gfx942-PAD50-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ;
     ; gfx942-PAD100-LABEL: name: mfma_padding_8_pass_2_intervening_valu
     ; gfx942-PAD100: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     ; gfx942-PAD100-NEXT: $vgpr2 = V_MOV_B32_e32 1, implicit $exec
     ; gfx942-PAD100-NEXT: $vgpr3 = V_MOV_B32_e32 1, implicit $exec
-    ; gfx942-PAD100-NEXT: S_NOP 5
+    ; gfx942-PAD100-NEXT: S_NOP 4
     ; gfx942-PAD100-NEXT: early-clobber $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15 = V_MFMA_F32_16X16X1F32_e64 $vgpr1, $vgpr0, $agpr0_agpr1_agpr2_agpr3_agpr4_agpr5_agpr6_agpr7_agpr8_agpr9_agpr10_agpr11_agpr12_agpr13_agpr14_agpr15, 0, 0, 0, implicit $mode, implicit $exec
     $vgpr2 = V_MOV_B32_e32 1, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/schedule-pending-queue.mir
+++ b/llvm/test/CodeGen/AMDGPU/schedule-pending-queue.mir
@@ -4,7 +4,7 @@
 # Check that cycle counts are consistent with hazards.
 
 # CHECK: Cycle: 3 TopQ.A
-# CHECK: hazard:  SU(6) HWXDL[0]=9c, is later than CurrCycle = 3c
+# CHECK: hazard:  SU(6) HWXDL[0]=8c, is later than CurrCycle = 3c
 # CHECK-NOT: Cycle: 9 TopQ.A
 # CHECK: Cycle: 83 TopQ.A
 # CHECK: Checking pending node SU(6)

--- a/llvm/test/CodeGen/AMDGPU/unpack-non-coissue-insts-post-ra-scheduler.mir
+++ b/llvm/test/CodeGen/AMDGPU/unpack-non-coissue-insts-post-ra-scheduler.mir
@@ -326,8 +326,7 @@ body:             |
     ; GFX950-NEXT: $vgpr3 = nofpexcept V_ADD_F32_e64 0, killed $sgpr3, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
     ; GFX950-NEXT: $vgpr6 = nofpexcept V_ADD_F32_e64 0, killed $sgpr6, 0, $vgpr0, 0, 0, implicit $mode, implicit $exec
     ; GFX950-NEXT: $vgpr7 = nofpexcept V_ADD_F32_e64 0, killed $sgpr7, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
-    ; GFX950-NEXT: $vgpr4 = nofpexcept V_ADD_F32_e64 0, killed $sgpr4, 0, $vgpr0, 0, 0, implicit $mode, implicit $exec
-    ; GFX950-NEXT: $vgpr5 = nofpexcept V_ADD_F32_e64 0, killed $sgpr5, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    ; GFX950-NEXT: renamable $vgpr4_vgpr5 = nofpexcept V_PK_ADD_F32 8, killed $sgpr4_sgpr5, 8, $vgpr0_vgpr1, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     ; GFX950-NEXT: renamable $vgpr10_vgpr11 = nofpexcept V_PK_ADD_F32 8, killed $sgpr10_sgpr11, 8, $vgpr0_vgpr1, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     ; GFX950-NEXT: S_ENDPGM 0
     ;
@@ -365,8 +364,7 @@ body:             |
     ; GFX942-NEXT: $vgpr3 = nofpexcept V_ADD_F32_e64 0, killed $sgpr3, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
     ; GFX942-NEXT: $vgpr6 = nofpexcept V_ADD_F32_e64 0, killed $sgpr6, 0, $vgpr0, 0, 0, implicit $mode, implicit $exec
     ; GFX942-NEXT: $vgpr7 = nofpexcept V_ADD_F32_e64 0, killed $sgpr7, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
-    ; GFX942-NEXT: $vgpr4 = nofpexcept V_ADD_F32_e64 0, killed $sgpr4, 0, $vgpr0, 0, 0, implicit $mode, implicit $exec
-    ; GFX942-NEXT: $vgpr5 = nofpexcept V_ADD_F32_e64 0, killed $sgpr5, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    ; GFX942-NEXT: renamable $vgpr4_vgpr5 = nofpexcept V_PK_ADD_F32 8, killed $sgpr4_sgpr5, 8, $vgpr0_vgpr1, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     ; GFX942-NEXT: renamable $vgpr10_vgpr11 = nofpexcept V_PK_ADD_F32 8, killed $sgpr10_sgpr11, 8, $vgpr0_vgpr1, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     ; GFX942-NEXT: S_ENDPGM 0
     ;
@@ -740,8 +738,7 @@ body:             |
     ; GFX950-NEXT: $vgpr5 = V_MOV_B32_e32 $sgpr15, implicit $exec, implicit $exec
     ; GFX950-NEXT: $vgpr6 = V_MOV_B32_e32 killed $sgpr14, implicit $exec, implicit $exec
     ; GFX950-NEXT: $vgpr7 = V_MOV_B32_e32 killed $sgpr15, implicit $exec, implicit $exec
-    ; GFX950-NEXT: $vgpr16 = nofpexcept V_FMA_F32_e64 0, $sgpr30, 0, $vgpr5, 0, killed $vgpr6, 0, 0, implicit $mode, implicit $exec
-    ; GFX950-NEXT: $vgpr17 = nofpexcept V_FMA_F32_e64 0, killed $sgpr30, 0, killed $vgpr5, 0, killed $vgpr7, 0, 0, implicit $mode, implicit $exec
+    ; GFX950-NEXT: renamable $vgpr16_vgpr17 = nofpexcept V_PK_FMA_F32 0, killed $sgpr30_sgpr31, 12, killed $vgpr4_vgpr5, 8, killed $vgpr6_vgpr7, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     ; GFX950-NEXT: S_ENDPGM 0
     ;
     ; GFX942-LABEL: name: test_opsel_register_is_correctly_marked_as_killed
@@ -762,8 +759,7 @@ body:             |
     ; GFX942-NEXT: $vgpr5 = V_MOV_B32_e32 $sgpr15, implicit $exec, implicit $exec
     ; GFX942-NEXT: $vgpr6 = V_MOV_B32_e32 killed $sgpr14, implicit $exec, implicit $exec
     ; GFX942-NEXT: $vgpr7 = V_MOV_B32_e32 killed $sgpr15, implicit $exec, implicit $exec
-    ; GFX942-NEXT: $vgpr16 = nofpexcept V_FMA_F32_e64 0, $sgpr30, 0, $vgpr5, 0, killed $vgpr6, 0, 0, implicit $mode, implicit $exec
-    ; GFX942-NEXT: $vgpr17 = nofpexcept V_FMA_F32_e64 0, killed $sgpr30, 0, killed $vgpr5, 0, killed $vgpr7, 0, 0, implicit $mode, implicit $exec
+    ; GFX942-NEXT: renamable $vgpr16_vgpr17 = nofpexcept V_PK_FMA_F32 0, killed $sgpr30_sgpr31, 12, killed $vgpr4_vgpr5, 8, killed $vgpr6_vgpr7, 0, 0, 0, 0, 0, implicit $mode, implicit $exec
     ; GFX942-NEXT: S_ENDPGM 0
     ;
     ; GFX90A-LABEL: name: test_opsel_register_is_correctly_marked_as_killed


### PR DESCRIPTION
Reduced the `HWXDL` resource reservation cycles for `Write8PassMAI` from 8 to 7. This allows the scheduler to issue the next MFMA one cycle earlier, limiting the number of co-executing VALU instructions to 6 instead of 7 to better match the desired hardware behavior.