### PR TITLE
[MLIR][Python] Clean remaining LLVM dependencies in MLIR-PY bindings

### DIFF
--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -8,19 +8,6 @@
 # nomenclature, adds libraries.
 ################################################################################
 
-# INTERFACE library that provides the include directories needed to compile
-# against MLIR CAPI headers. The CAPI headers (e.g., mlir/CAPI/Wrap.h)
-# transitively include LLVM headers (via mlir/Support/LLVM.h), so consumers
-# need the LLVM include paths even if they don't link against LLVMSupport.
-# Defined here (rather than in lib/CAPI/) so it is available to both in-tree
-# and external project builds that include this module.
-if(NOT TARGET MLIRCAPIHeaderDeps)
-  add_library(MLIRCAPIHeaderDeps INTERFACE)
-  target_include_directories(MLIRCAPIHeaderDeps INTERFACE
-    $<TARGET_PROPERTY:LLVMSupport,INTERFACE_INCLUDE_DIRECTORIES>
-  )
-endif()
-
 # Function: declare_mlir_python_sources
 # Declares pure python sources as part of a named grouping that can be built
 # later.
@@ -454,7 +441,6 @@ function(add_mlir_python_modules name)
         OUTPUT_DIRECTORY "${ARG_ROOT_PREFIX}/_mlir_libs"
         MLIR_BINDINGS_PYTHON_NB_DOMAIN ${ARG_MLIR_BINDINGS_PYTHON_NB_DOMAIN}
         LINK_LIBS PRIVATE
-          MLIRCAPIHeaderDeps
           ${sources_target}
           ${ARG_COMMON_CAPI_LINK_LIBS}
           ${support_libs}
@@ -488,14 +474,10 @@ function(add_mlir_python_modules name)
         MLIR_BINDINGS_PYTHON_NB_DOMAIN ${ARG_MLIR_BINDINGS_PYTHON_NB_DOMAIN}
         _PRIVATE_SUPPORT_LIB
         LINK_LIBS PRIVATE
-        # LLVMSupport is intentionally removed to avoid introducing an LLVM link
-        # dependency for the mlir-python bindings. Do not add new link dependencies
-        # on the C++ LLVM/MLIR libraries; use the C++ standard library instead, or
-        # wrap LLVM functionality in the C API first.
-        # MLIRCAPIHeaderDeps is an include-only (INTERFACE) target that provides
-        # LLVM include directories needed to compile against CAPI headers. It does
-        # not introduce any link or runtime dependency on LLVM.
-          MLIRCAPIHeaderDeps
+        # LLVMSupport is intentionally removed to avoid introducing an LLVM dependency
+        # for the mlir-python bindings. Do not add new dependencies on the C++ LLVM/MLIR
+        # libraries; use the C++ standard library instead, or wrap LLVM functionality in
+        # the C API first.
           ${sources_target}
           ${ARG_COMMON_CAPI_LINK_LIBS}
       )

--- a/mlir/include/mlir/Bindings/Python/Globals.h
+++ b/mlir/include/mlir/Bindings/Python/Globals.h
@@ -20,7 +20,6 @@
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
 #include "mlir/Bindings/Python/NanobindUtils.h"
-#include "mlir/CAPI/Support.h"
 
 namespace mlir {
 namespace python {

--- a/mlir/include/mlir/Bindings/Python/IRAttributes.h
+++ b/mlir/include/mlir/Bindings/Python/IRAttributes.h
@@ -28,17 +28,17 @@ namespace MLIR_BINDINGS_PYTHON_DOMAIN {
 
 struct nb_buffer_info {
   void *ptr = nullptr;
-  ssize_t itemsize = 0;
-  ssize_t size = 0;
+  Py_ssize_t itemsize = 0;
+  Py_ssize_t size = 0;
   const char *format = nullptr;
-  ssize_t ndim = 0;
-  std::vector<ssize_t> shape;
-  std::vector<ssize_t> strides;
+  Py_ssize_t ndim = 0;
+  std::vector<Py_ssize_t> shape;
+  std::vector<Py_ssize_t> strides;
   bool readonly = false;
 
   nb_buffer_info(
-      void *ptr, ssize_t itemsize, const char *format, ssize_t ndim,
-      std::vector<ssize_t> shape_in, std::vector<ssize_t> strides_in,
+      void *ptr, Py_ssize_t itemsize, const char *format, Py_ssize_t ndim,
+      std::vector<Py_ssize_t> shape_in, std::vector<Py_ssize_t> strides_in,
       bool readonly = false,
       std::unique_ptr<Py_buffer, void (*)(Py_buffer *)> owned_view_in =
           std::unique_ptr<Py_buffer, void (*)(Py_buffer *)>(nullptr, nullptr));
@@ -451,11 +451,11 @@ private:
     Type *data = static_cast<Type *>(
         const_cast<void *>(mlirDenseElementsAttrGetRawData(*this)));
     // Prepare the shape for the buffer_info.
-    std::vector<ssize_t> shape;
+    std::vector<Py_ssize_t> shape;
     for (intptr_t i = 0; i < rank; ++i)
       shape.push_back(mlirShapedTypeGetDimSize(shapedType, i));
     // Prepare the strides for the buffer_info.
-    std::vector<ssize_t> strides;
+    std::vector<Py_ssize_t> strides;
     if (mlirDenseElementsAttrIsSplat(*this)) {
       // Splats are special, only the single value is stored.
       strides.assign(rank, 0);

--- a/mlir/lib/Bindings/Python/DialectAMDGPU.cpp
+++ b/mlir/lib/Bindings/Python/DialectAMDGPU.cpp
@@ -14,7 +14,6 @@
 #include "nanobind/nanobind.h"
 
 namespace nb = nanobind;
-using namespace llvm;
 using namespace mlir::python::nanobind_adaptors;
 
 namespace mlir {

--- a/mlir/lib/Bindings/Python/DialectNVGPU.cpp
+++ b/mlir/lib/Bindings/Python/DialectNVGPU.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 
 namespace nb = nanobind;
-using namespace llvm;
 using namespace mlir::python::nanobind_adaptors;
 
 namespace mlir {

--- a/mlir/lib/Bindings/Python/DialectPDL.cpp
+++ b/mlir/lib/Bindings/Python/DialectPDL.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 
 namespace nb = nanobind;
-using namespace llvm;
 using namespace mlir::python::nanobind_adaptors;
 
 namespace mlir {

--- a/mlir/lib/Bindings/Python/DialectQuant.cpp
+++ b/mlir/lib/Bindings/Python/DialectQuant.cpp
@@ -17,7 +17,6 @@
 #include <mlir/Bindings/Python/IRAttributes.h>
 
 namespace nb = nanobind;
-using namespace llvm;
 using namespace mlir::python::nanobind_adaptors;
 
 namespace mlir {

--- a/mlir/lib/Bindings/Python/DialectSparseTensor.cpp
+++ b/mlir/lib/Bindings/Python/DialectSparseTensor.cpp
@@ -17,7 +17,6 @@
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 
 namespace nb = nanobind;
-using namespace llvm;
 using namespace mlir::python::nanobind_adaptors;
 
 namespace mlir {

--- a/mlir/lib/Bindings/Python/DialectTransform.cpp
+++ b/mlir/lib/Bindings/Python/DialectTransform.cpp
@@ -227,7 +227,8 @@ public:
 
     // Attach a FallbackModel, which calls into Python, to the named operation.
     mlirTransformOpInterfaceAttachFallbackModel(
-        ctx->get(), wrap(StringRef(opName.c_str())), callbacks);
+        ctx->get(), mlirStringRefCreate(opName.c_str(), opName.size()),
+        callbacks);
   }
 
   static void bindDerived(ClassTy &cls) {

--- a/mlir/lib/Bindings/Python/Globals.cpp
+++ b/mlir/lib/Bindings/Python/Globals.cpp
@@ -176,7 +176,8 @@ PyGlobals::lookupAttributeBuilder(const std::string &attributeKind) {
 std::optional<nb::callable> PyGlobals::lookupTypeCaster(MlirTypeID mlirTypeID,
                                                         MlirDialect dialect) {
   // Try to load dialect module.
-  (void)loadDialectModule(unwrap(mlirDialectGetNamespace(dialect)));
+  MlirStringRef ns = mlirDialectGetNamespace(dialect);
+  (void)loadDialectModule(std::string_view(ns.data, ns.length));
   nb::ft_lock_guard lock(mutex);
   const auto foundIt = typeCasterMap.find(mlirTypeID);
   if (foundIt != typeCasterMap.end()) {
@@ -189,7 +190,8 @@ std::optional<nb::callable> PyGlobals::lookupTypeCaster(MlirTypeID mlirTypeID,
 std::optional<nb::callable> PyGlobals::lookupValueCaster(MlirTypeID mlirTypeID,
                                                          MlirDialect dialect) {
   // Try to load dialect module.
-  (void)loadDialectModule(unwrap(mlirDialectGetNamespace(dialect)));
+  MlirStringRef ns = mlirDialectGetNamespace(dialect);
+  (void)loadDialectModule(std::string_view(ns.data, ns.length));
   nb::ft_lock_guard lock(mutex);
   const auto foundIt = valueCasterMap.find(mlirTypeID);
   if (foundIt != valueCasterMap.end()) {

--- a/mlir/lib/Bindings/Python/IRAffine.cpp
+++ b/mlir/lib/Bindings/Python/IRAffine.cpp
@@ -24,7 +24,6 @@
 // clang-format on
 #include "mlir-c/IntegerSet.h"
 #include "mlir/Bindings/Python/Nanobind.h"
-#include "mlir/Support/LLVM.h"
 
 namespace nb = nanobind;
 using namespace mlir;

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -153,15 +153,15 @@ namespace python {
 namespace MLIR_BINDINGS_PYTHON_DOMAIN {
 
 nb_buffer_info::nb_buffer_info(
-    void *ptr, ssize_t itemsize, const char *format, ssize_t ndim,
-    std::vector<ssize_t> shape_in, std::vector<ssize_t> strides_in,
+    void *ptr, Py_ssize_t itemsize, const char *format, Py_ssize_t ndim,
+    std::vector<Py_ssize_t> shape_in, std::vector<Py_ssize_t> strides_in,
     bool readonly,
     std::unique_ptr<Py_buffer, void (*)(Py_buffer *)> owned_view_in)
     : ptr(ptr), itemsize(itemsize), format(format), ndim(ndim),
       shape(std::move(shape_in)), strides(std::move(strides_in)),
       readonly(readonly), owned_view(std::move(owned_view_in)) {
   size = 1;
-  for (ssize_t i = 0; i < ndim; ++i) {
+  for (Py_ssize_t i = 0; i < ndim; ++i) {
     size *= shape[i];
   }
 }

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -513,13 +513,15 @@ void PySymbolRefAttribute::bindDerived(ClassTy &c) {
   c.def_prop_ro(
       "value",
       [](PySymbolRefAttribute &self) {
+        MlirStringRef rootRef = mlirSymbolRefAttrGetRootReference(self);
         std::vector<std::string> symbols = {
-            unwrap(mlirSymbolRefAttrGetRootReference(self)).str()};
-        for (int i = 0; i < mlirSymbolRefAttrGetNumNestedReferences(self); ++i)
-          symbols.push_back(
-              unwrap(mlirSymbolRefAttrGetRootReference(
-                         mlirSymbolRefAttrGetNestedReference(self, i)))
-                  .str());
+            std::string(rootRef.data, rootRef.length)};
+        for (int i = 0; i < mlirSymbolRefAttrGetNumNestedReferences(self);
+             ++i) {
+          MlirStringRef nestedRef = mlirSymbolRefAttrGetRootReference(
+              mlirSymbolRefAttrGetNestedReference(self, i));
+          symbols.push_back(std::string(nestedRef.data, nestedRef.length));
+        }
         return symbols;
       },
       "Returns the value of the SymbolRef attribute as a list[str]");

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2772,8 +2772,9 @@ MlirLocation tracebackToLocation(MlirContext ctx) {
         nb::cast<std::string>(nb::borrow<nb::str>(code->co_name));
     std::string_view funcName(name);
     int startLine = PyFrame_GetLineNumber(pyFrame);
-    MlirLocation loc =
-        mlirLocationFileLineColGet(ctx, wrap(fileName), startLine, 0);
+    MlirLocation loc = mlirLocationFileLineColGet(
+        ctx, mlirStringRefCreate(fileName.data(), fileName.size()), startLine,
+        0);
 #else
     std::string name =
         nb::cast<std::string>(nb::borrow<nb::str>(code->co_qualname));
@@ -2785,10 +2786,12 @@ MlirLocation tracebackToLocation(MlirContext ctx) {
       throw nb::python_error();
     }
     MlirLocation loc = mlirLocationFileLineColRangeGet(
-        ctx, wrap(fileName), startLine, startCol, endLine, endCol);
+        ctx, mlirStringRefCreate(fileName.data(), fileName.size()), startLine,
+        startCol, endLine, endCol);
 #endif
 
-    frames[count] = mlirLocationNameGet(ctx, wrap(funcName), loc);
+    frames[count] = mlirLocationNameGet(
+        ctx, mlirStringRefCreate(funcName.data(), funcName.size()), loc);
     ++count;
   }
   // When the loop breaks (after the last iter), current frame (if non-null)

--- a/mlir/lib/Bindings/Python/IRInterfaces.cpp
+++ b/mlir/lib/Bindings/Python/IRInterfaces.cpp
@@ -380,7 +380,8 @@ public:
     };
 
     mlirMemoryEffectsOpInterfaceAttachFallbackModel(
-        ctx->get(), wrap(StringRef(opName.c_str())), callbacks);
+        ctx->get(), mlirStringRefCreate(opName.c_str(), opName.size()),
+        callbacks);
   }
 
   static void bindDerived(ClassTy &cls) {

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -297,8 +297,10 @@ public:
       std::vector<MlirValue> operandsVec(operands, operands + nOperands);
       nb::object adaptorCls =
           PyGlobals::get()
-              .lookupOpAdaptorClass(
-                  unwrap(mlirIdentifierStr(mlirOperationGetName(op))))
+              .lookupOpAdaptorClass([&] {
+                MlirStringRef ref = mlirIdentifierStr(mlirOperationGetName(op));
+                return std::string_view(ref.data, ref.length);
+              }())
               .value_or(nb::borrow(nb::type<PyOpAdaptor>()));
 
       nb::object res = f(opView, adaptorCls(operandsVec, opView),


### PR DESCRIPTION
This PR fixed [issues](https://github.com/iree-org/iree/actions/runs/21956878131/job/63423389868#step:7:211) caused by dropping `LLVMSupport` in PR #180986, dropped the remaining direct llvm dependencies from mlir-python binding files.

Previously `LLVMSupport` was dropped while some uncleaned `mlir/CAPI/*` sources were still being pulled into mlir-py, and those files still directly depended on LLVM headers. The issue was masked via a global `include_directories(${LLVM_INCLUDE_DIRS})` in `mlir/CMakeLists.txt`, out-of-tree builds (e.g., IREE) that define Python module targets outside the mlir/ directory tree would fail with "no such llvm file" errors.

