### PR TITLE
[MLIR][NVVM] Enable result type inference

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -21,6 +21,7 @@ include "mlir/Dialect/Ptr/IR/MemorySpaceInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.td"
 include "mlir/Interfaces/InferIntRangeInterface.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Dialect/LLVMIR/LLVMTypes.td"
 include "mlir/IR/CommonAttrConstraints.td"
 

--- a/mlir/test/python/dialects/nvvm.py
+++ b/mlir/test/python/dialects/nvvm.py
@@ -172,13 +172,13 @@ def test_reductions():
                     nvvm.ReductionKind.UMIN,
                     nvvm.ReductionKind.XOR,
                 ):
-                    nvvm.redux_sync(i32, vi32, kind, vi32)
+                    nvvm.redux_sync(vi32, kind, vi32)
 
                 for kind in (
                     nvvm.ReductionKind.FMIN,
                     nvvm.ReductionKind.FMAX,
                 ):
-                    nvvm.redux_sync(f32, vf32, kind, vi32, abs=abs, nan=nan)
+                    nvvm.redux_sync(vf32, kind, vi32, abs=abs, nan=nan)
 
 
 # CHECK-LABEL:   func.func @reductions(


### PR DESCRIPTION
Includes `InferOpTypeInterface.td` in `NVVMOps.td` enabling result type inference for NVVM operations.

Fixes a test for `nvvm.redux.sync` in `nvvm.py` due to a resulting change in the python binding for the operation.