### PR TITLE
[MLIR|BUILD] Fix for #174590 (2)

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -2657,6 +2657,7 @@ cc_library(
         ":IR",
         ":LinalgDialect",
         ":LinalgInterfaces",
+        ":SCFDialect",
         ":Support",
         ":VectorDialect",
         ":X86VectorDialect",


### PR DESCRIPTION
Also adds the dependency to `X86VectorUtils` which was missed in the previous fix.