### PR TITLE
[libc++][NFC] Use std::has_single_bit instead of std::popcount(v) == 1

### DIFF
--- a/libcxx/include/__stop_token/atomic_unique_lock.h
+++ b/libcxx/include/__stop_token/atomic_unique_lock.h
@@ -10,7 +10,7 @@
 #ifndef _LIBCPP___STOP_TOKEN_ATOMIC_UNIQUE_LOCK_H
 #define _LIBCPP___STOP_TOKEN_ATOMIC_UNIQUE_LOCK_H
 
-#include <__bit/popcount.h>
+#include <__bit/has_single_bit.h>
 #include <__config>
 #include <atomic>
 
@@ -28,7 +28,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // and LockedBit is the value of State when the lock bit is set, e.g  1 << 2
 template <class _State, _State _LockedBit>
 class __atomic_unique_lock {
-  static_assert(std::__popcount(static_cast<unsigned long long>(_LockedBit)) == 1,
+  static_assert(std::has_single_bit(static_cast<unsigned long long>(_LockedBit)),
                 "LockedBit must be an integer where only one bit is set");
 
   std::atomic<_State>& __state_;


### PR DESCRIPTION
We have a function that specifically checks if a single bit is set. Use that instad of a `popcount`.
