### PR TITLE
[flang][OpenMP]Fix versioning for implicit linear clause

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2443,7 +2443,7 @@ void OmpAttributeVisitor::PrivatizeAssociatedLoopIndexAndCheckLoopLevel(
   unsigned version{context_.langOptions().OpenMPVersion};
   if (!llvm::omp::allSimdSet.test(GetContext().directive)) {
     ivDSA = Symbol::Flag::OmpPrivate;
-  } else if (level == 1 && version <= 45) {
+  } else if (level == 1 && version < 60) {
     ivDSA = Symbol::Flag::OmpLinear;
   } else {
     ivDSA = Symbol::Flag::OmpLastPrivate;

--- a/flang/test/Lower/OpenMP/order-clause.f90
+++ b/flang/test/Lower/OpenMP/order-clause.f90
@@ -1,6 +1,8 @@
 ! This test checks lowering of OpenMP order clause.
 
-!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=50 %s -o - | FileCheck %s
+! To prevent testing for unrelated clauses like implicit linear clause and focusing on the
+! clauses of interest here, the OpenMP version is 6.0
+!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=60 %s -o - | FileCheck %s
 
 !CHECK-LABEL:   func.func @_QPsimd_order() {
 subroutine simd_order

--- a/flang/test/Lower/OpenMP/simd-linear.f90
+++ b/flang/test/Lower/OpenMP/simd-linear.f90
@@ -1,7 +1,7 @@
 ! This test checks lowering of OpenMP SIMD Directive
 ! with linear clause
 
-! RUN: %flang_fc1 -fopenmp -emit-hlfir -fopenmp-version=50 %s -o - 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -fopenmp -emit-hlfir -fopenmp-version=60 %s -o - 2>&1 | FileCheck %s
 ! RUN: %flang_fc1 -fopenmp -emit-hlfir -fopenmp-version=45 %s -o - 2>&1 | FileCheck %s --check-prefix=IMPLICIT
 
 !CHECK: %[[X_alloca:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFsimple_linearEx"}

--- a/flang/test/Lower/OpenMP/simd.f90
+++ b/flang/test/Lower/OpenMP/simd.f90
@@ -1,8 +1,11 @@
 ! Tests for 2.9.3.1 Simd
 
 ! The "if" clause was added to the "simd" directive in OpenMP 5.0.
-! RUN: %flang_fc1 -flang-experimental-hlfir -emit-hlfir -fopenmp -fopenmp-version=50 %s -o - | FileCheck %s
-! RUN: bbc -hlfir -emit-hlfir -fopenmp -fopenmp-version=50 %s -o - | FileCheck %s
+
+! To prevent testing for unrelated clauses like implicit linear clause and focusing on the
+! clauses of interest here, the OpenMP version is 6.0
+! RUN: %flang_fc1 -flang-experimental-hlfir -emit-hlfir -fopenmp -fopenmp-version=60 %s -o - | FileCheck %s
+! RUN: bbc -hlfir -emit-hlfir -fopenmp -fopenmp-version=60 %s -o - | FileCheck %s
 
 !CHECK: omp.declare_reduction @[[REDUCER:.*]] : i32
 

--- a/flang/test/Semantics/OpenMP/implicit_linear_symbols.f90
+++ b/flang/test/Semantics/OpenMP/implicit_linear_symbols.f90
@@ -1,0 +1,15 @@
+!RUN: %flang_fc1 -fopenmp -fopenmp-version=52 -fdebug-dump-symbols %s 2>&1 | FileCheck %s --check-prefix=IMPLICIT
+!RUN: %flang_fc1 -fopenmp -fopenmp-version=60 -fdebug-dump-symbols %s 2>&1 | FileCheck %s --check-prefix=NOIMPLICIT
+
+
+!IMPLICIT: k2 (OmpLinear, OmpPreDetermined): {{.*}}
+!NOIMPLICIT: k2 (OmpLastPrivate, OmpPreDetermined): {{.*}}
+subroutine implicit_linear
+  integer :: k1, k2
+
+  !$omp simd
+  do k2=1,10
+  do k1=1,10
+  end do
+  end do
+end subroutine


### PR DESCRIPTION
The versioning of the implicit linear clause was set at OpenMP 4.5. However, versions v5.0 and v5.2 also allow implicit linearisation, which was missed earlier. This PR fixes this.

OpenMP v5.0 (2.19.1.1) :  "_The loop iteration variable in the associated do-loop of a simd construct with just one associated do-loop is linear with a linear-step that is the increment of the associated do-loop_."

OpenMP v5.2 (5.1.1) : "_The loop iteration variable in the associated loop of a simd construct with just one associated loop is linear with a linear-step that is the increment of the associated loop_"

OpenMP v6.0 (7.1.1) : "_The loop-iteration variable in any affected loop of a loop or simd construct is lastprivate_."


Fixes: https://github.com/llvm/llvm-project/issues/179345