### PR TITLE
[Offload][test] Use just-compiled lld and llvm-symbolizer

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -95,9 +95,9 @@ config.test_flags = " -I " + config.test_source_root + \
     " -L " + config.llvm_library_intdir + \
     " -L " + config.llvm_lib_directory
 
-# The offload driver requires lld as a linker. In a bootstrapping build with
-# LLVM_ENABLE_PROJECTS=lld it will be in the LLVM bin directory. Search this dir
-# before falling back to a system-installed lld.
+# The jit tests require lld to execute. In a bootstrapping build with
+# LLVM_ENABLE_PROJECTS=lld it will be in the LLVM bin directory. Search this
+# dir before falling back to a system-installed lld.
 prepend_executable_path(config.bin_llvm_tools_dir)
 
 # compiler specific flags

--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -95,9 +95,14 @@ config.test_flags = " -I " + config.test_source_root + \
     " -L " + config.llvm_library_intdir + \
     " -L " + config.llvm_lib_directory
 
-# The jit tests require lld to execute. In a bootstrapping build with
-# LLVM_ENABLE_PROJECTS=lld it will be in the LLVM bin directory. Search this
-# dir before falling back to a system-installed lld.
+# Some tests require LLVM tools to execute. These include:
+#
+#  * lld by JIT tests
+#  * llvm-symbolizer by sanitizer tests
+#
+# Add the tools bin dir to the search path so they can find theses executables.
+# Prefer the tools from the configured LLVM install or bootstrapping build over
+# system-installed versions which might be too old or not exist.
 prepend_executable_path(config.bin_llvm_tools_dir)
 
 # compiler specific flags

--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -56,6 +56,11 @@ def append_dynamic_library_path(name, value, sep):
     else:
         config.environment[name] = value
 
+def prepend_executable_path(path):
+    oldsearchpath = config.environment.get('PATH')
+    newsearchpath = f'{path}{os.path.pathsep}{oldsearchpath}' if oldsearchpath else path
+    config.environment['PATH'] = newsearchpath
+
 # Evaluate the environment variable which is a string boolean value.
 def evaluate_bool_env(env):
     env = env.lower()
@@ -89,6 +94,11 @@ config.test_flags = " -I " + config.test_source_root + \
     " -L " + config.library_dir + \
     " -L " + config.llvm_library_intdir + \
     " -L " + config.llvm_lib_directory
+
+# The offload driver requires lld as a linker. In a bootstrapping build with
+# LLVM_ENABLE_PROJECTS=lld it will be in the LLVM bin directory. Search this dir
+# before falling back to a system-installed lld.
+prepend_executable_path(config.bin_llvm_tools_dir)
 
 # compiler specific flags
 config.test_flags_clang = ""


### PR DESCRIPTION
In a bootstrapping build with LLVM_ENABLE_PROJECTS=lld, the lld executable will be found in LLVM's bin/ directory. But `check-offload` will currently ignore it because the JIT plugin will look for `lld` in `$PATH`. Similarly, the sanitizer tests require llvm-symbolizer during execution to FileCheck the expected stack trace.

Add the llvm tools directory to `$PATH` so tests can use lld and llvm-symbolizer in it. It should be prefered over a system-installed lld/llvm-symbolizer.

Fixes the JIT and sanitizer tests of the [openmp-offload-amdgpu-clang-flang](https://lab.llvm.org/staging/#/builders/105).