### PR TITLE
[lldb][Target][NFC] Update error messages according to LLVM-coding style

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5380,13 +5380,13 @@ llvm::Error
 EvaluateExpressionOptions::SetBooleanLanguageOption(llvm::StringRef option_name,
                                                     bool value) {
   if (option_name.empty())
-    return llvm::createStringError("Can't set an option with an empty name.");
+    return llvm::createStringError("can't set an option with an empty name");
 
   if (StructuredData::ObjectSP existing_sp =
           GetLanguageOptions().GetValueForKey(option_name);
       existing_sp && existing_sp->GetType() != eStructuredDataTypeBoolean)
-    return llvm::createStringErrorV("Trying to override existing option '{0}' "
-                                    "of type '{1}' with a boolean value.",
+    return llvm::createStringErrorV("trying to override existing option '{0}' "
+                                    "of type '{1}' with a boolean value",
                                     option_name, existing_sp->GetType());
 
   GetLanguageOptions().AddBooleanItem(option_name, value);
@@ -5399,12 +5399,11 @@ llvm::Expected<bool> EvaluateExpressionOptions::GetBooleanLanguageOption(
   const StructuredData::Dictionary &opts = GetLanguageOptions();
 
   if (!opts.HasKey(option_name))
-    return llvm::createStringErrorV("Option '{0}' does not exist.",
-                                    option_name);
+    return llvm::createStringErrorV("option '{0}' does not exist", option_name);
 
   bool result;
   if (!opts.GetValueForKeyAsBoolean(option_name, result))
-    return llvm::createStringErrorV("Failed to get option '{0}' as boolean.",
+    return llvm::createStringErrorV("failed to get option '{0}' as boolean",
                                     option_name);
 
   return result;

--- a/lldb/unittests/Expression/ExpressionTest.cpp
+++ b/lldb/unittests/Expression/ExpressionTest.cpp
@@ -162,7 +162,7 @@ TEST(ExpressionTests, ExpressionOptions_Basic) {
                        llvm::FailedWithMessage("option '' does not exist"));
   EXPECT_THAT_ERROR(
       options.SetBooleanLanguageOption("", true),
-      llvm::FailedWithMessage("Can't set an option with an empty name"));
+      llvm::FailedWithMessage("can't set an option with an empty name"));
   EXPECT_THAT_EXPECTED(options.GetBooleanLanguageOption(""),
                        llvm::FailedWithMessage("option '' does not exist"));
 }

--- a/lldb/unittests/Expression/ExpressionTest.cpp
+++ b/lldb/unittests/Expression/ExpressionTest.cpp
@@ -133,9 +133,9 @@ TEST(ExpressionTests, ExpressionOptions_Basic) {
   EvaluateExpressionOptions options;
 
   EXPECT_THAT_EXPECTED(options.GetBooleanLanguageOption("foo"),
-                       llvm::FailedWithMessage("Option 'foo' does not exist."));
+                       llvm::FailedWithMessage("option 'foo' does not exist"));
   EXPECT_THAT_EXPECTED(options.GetBooleanLanguageOption("bar"),
-                       llvm::FailedWithMessage("Option 'bar' does not exist."));
+                       llvm::FailedWithMessage("option 'bar' does not exist"));
 
   EXPECT_THAT_ERROR(options.SetBooleanLanguageOption("foo", true),
                     llvm::Succeeded());
@@ -159,10 +159,10 @@ TEST(ExpressionTests, ExpressionOptions_Basic) {
 
   // Empty option names not allowed.
   EXPECT_THAT_EXPECTED(options.GetBooleanLanguageOption(""),
-                       llvm::FailedWithMessage("Option '' does not exist."));
+                       llvm::FailedWithMessage("option '' does not exist"));
   EXPECT_THAT_ERROR(
       options.SetBooleanLanguageOption("", true),
-      llvm::FailedWithMessage("Can't set an option with an empty name."));
+      llvm::FailedWithMessage("Can't set an option with an empty name"));
   EXPECT_THAT_EXPECTED(options.GetBooleanLanguageOption(""),
-                       llvm::FailedWithMessage("Option '' does not exist."));
+                       llvm::FailedWithMessage("option '' does not exist"));
 }


### PR DESCRIPTION
The [LLVM coding style guide](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) says:

> start the first sentence with a lowercase letter, and finish the last sentence
> without a period

This patch updates the erorr messages added in https://github.com/llvm/llvm-project/pull/179208 accordingly.

(addresses https://github.com/llvm/llvm-project/pull/179208#issuecomment-3912273053)