### PR TITLE
[clang][test] Try to fix Sema/format-strings.c on i686

### DIFF
--- a/clang/test/Sema/format-strings.c
+++ b/clang/test/Sema/format-strings.c
@@ -986,12 +986,9 @@ void test_promotion(void) {
 
 void test_bool(_Bool b, _Bool* bp)
 {
-#ifndef __arm__
+#if __SIZEOF_INT__ != __SIZEOF_SIZE_T__
   printf("%zu", b); // expected-warning-re{{format specifies type 'size_t' (aka '{{.+}}') but the argument has type '_Bool'}}
   printf("%td", b); // expected-warning-re{{format specifies type 'ptrdiff_t' (aka '{{.+}}') but the argument has type '_Bool'}}
-#else
-  printf("%zu", b); // no-warning
-  printf("%td", b); // no-warning
 #endif
   printf("%jd", b); // expected-warning-re{{format specifies type 'intmax_t' (aka '{{.+}}') but the argument has type '_Bool'}}
   printf("%lld", b); // expected-warning{{format specifies type 'long long' but the argument has type '_Bool'}}


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/180566 did this for 32bit arm, but this still breaks for us downstream on i686 with:
```
# .---command stderr------------
# | error: 'expected-warning' diagnostics expected but not seen: 
# |   File /builddir/build/BUILD/llvm-project/clang/test/Sema/format-strings.c Line 990: format specifies type 'size_t' (aka '{{.+}}') but the argument has type '_Bool'
# |   File /builddir/build/BUILD/llvm-project/clang/test/Sema/format-strings.c Line 991: format specifies type 'ptrdiff_t' (aka '{{.+}}') but the argument has type '_Bool'
# | 2 errors generated.
# `-----------------------------
```