### PR TITLE
[LLD] Add support for statically resolved vendor-specific RISCV relocations.

### DIFF
--- a/lld/ELF/Target.cpp
+++ b/lld/ELF/Target.cpp
@@ -40,8 +40,12 @@ using namespace lld::elf;
 
 std::string elf::toStr(Ctx &ctx, RelType type) {
   StringRef s = getELFRelocationTypeName(ctx.arg.emachine, type);
-  if (s == "Unknown")
+  if (s == "Unknown") {
+    if (ctx.arg.emachine == EM_RISCV)
+      return riscvVendorRelocToStr(type);
     return ("Unknown (" + Twine(type) + ")").str();
+  }
+
   return std::string(s);
 }
 

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -261,6 +261,7 @@ template <typename ELFT> void writeARMCmseImportLib(Ctx &);
 uint64_t getLoongArchPageDelta(uint64_t dest, uint64_t pc, RelType type);
 void riscvFinalizeRelax(int passes);
 void mergeRISCVAttributesSections(Ctx &);
+std::string riscvVendorRelocToStr(RelType type);
 void mergeHexagonAttributesSections(Ctx &);
 void addArmInputSectionMappingSymbols(Ctx &);
 void addArmSyntheticSectionMappingSymbol(Defined *);

--- a/lld/test/ELF/riscv-vendor-relocations.s
+++ b/lld/test/ELF/riscv-vendor-relocations.s
@@ -9,11 +9,21 @@ TARGET:
   nop
 
 .global INVALID_VENDOR
-.reloc 1f, R_RISCV_VENDOR, INVALID_VENDOR+0
-.reloc 1f, R_RISCV_VENDOR, INVALID_VENDOR+0
-.reloc 1f, R_RISCV_CUSTOM255, TARGET
+.global QUALCOMM
+.global ANDES
 1:
   nop
 
+.reloc 1b, R_RISCV_VENDOR, INVALID_VENDOR+0
+.reloc 1b, R_RISCV_VENDOR, INVALID_VENDOR+0
+.reloc 1b, R_RISCV_CUSTOM255, TARGET
 # CHECK: error: {{.*}}:(.text+0x4): malformed consecutive R_RISCV_VENDOR relocations
 # CHECK: error: {{.*}}:(.text+0x4): unknown vendor-specific relocation (255) in namespace 'INVALID_VENDOR' against symbol 'TARGET'
+.reloc 1b, R_RISCV_VENDOR, QUALCOMM+0
+.reloc 1b, R_RISCV_CUSTOM192, TARGET
+# CHECK: error: {{.*}}:(.text+0x4): unsupported vendor-specific relocation R_RISCV_QC_ABS20_U against symbol TARGET
+.reloc 1b, R_RISCV_VENDOR, ANDES+0
+.reloc 1b, R_RISCV_CUSTOM241, TARGET
+# CHECK: error: {{.*}}:(.text+0x4): unsupported vendor-specific relocation R_RISCV_NDS_BRANCH_10 against symbol TARGET
+2:
+  nop


### PR DESCRIPTION
This is a re-land, with updates for feedback, of https://github.com/llvm/llvm-project/pull/169273
The original commit message is reproduced below the line.

The primary feedback addressed in this updated version is further effort to ensure that changes are
localized in RISCV.cpp as much as possible. Integral to this was a realization that the vendor
relocations iterator is not strictly required for this change, and hence its removal. Other, more
specific, feedback regarding the removal or relocation of other elements has also been addressed.

---

Original Commit Message:

This is achieved by using some of the bits of RelType to tag vendor namespaces.
This change also adds a relocation iterator for RISCV that folds vendor namespaces
into the RelType of the following relocation.

This patch is extracted from the implementation of RISCV vendor-specific relocations
in the CHERIoT LLVM downstream: https://github.com/CHERIoT-Platform/llvm-project/commit/3d6d6f7d9480b590731cbcf4b4817e1fa3049854
