### PR TITLE
[Clang][ssaf] Add missing instantiations of `Registry<JSONFormat::FormatInfo>`

### DIFF
--- a/clang/include/clang/Analysis/Scalable/Serialization/JSONFormat.h
+++ b/clang/include/clang/Analysis/Scalable/Serialization/JSONFormat.h
@@ -14,8 +14,10 @@
 #define CLANG_ANALYSIS_SCALABLE_SERIALIZATION_JSONFORMAT_H
 
 #include "clang/Analysis/Scalable/Serialization/SerializationFormat.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/Registry.h"
 
 namespace clang::ssaf {
 
@@ -124,5 +126,8 @@ private:
 };
 
 } // namespace clang::ssaf
+
+extern template class CLANG_TEMPLATE_ABI
+    llvm::Registry<clang::ssaf::JSONFormat::FormatInfo>;
 
 #endif // CLANG_ANALYSIS_SCALABLE_SERIALIZATION_JSONFORMAT_H

--- a/clang/lib/Analysis/Scalable/Serialization/JSONFormat.cpp
+++ b/clang/lib/Analysis/Scalable/Serialization/JSONFormat.cpp
@@ -1,5 +1,6 @@
 #include "clang/Analysis/Scalable/Serialization/JSONFormat.h"
 #include "clang/Analysis/Scalable/TUSummary/TUSummary.h"
+#include "clang/Support/Compiler.h"
 
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/FileSystem.h"
@@ -18,6 +19,9 @@ using Value = llvm::json::Value;
 //----------------------------------------------------------------------------
 // ErrorBuilder - Fluent API for constructing contextual errors.
 //----------------------------------------------------------------------------
+
+template class CLANG_EXPORT_TEMPLATE
+    llvm::Registry<clang::ssaf::JSONFormat::FormatInfo>;
 
 namespace {
 


### PR DESCRIPTION
This patch adds missing explicit template instantiation declaration/definition of `llvm::Registry<clang::ssaf::JSONFormat::FormatInfo>` introduced in #180021 .