### PR TITLE
[lldb][windows] handle ERROR_INVALID_HANDLE error

### DIFF
--- a/lldb/source/Core/ThreadedCommunication.cpp
+++ b/lldb/source/Core/ThreadedCommunication.cpp
@@ -296,13 +296,15 @@ lldb::thread_result_t ThreadedCommunication::ReadThread() {
         disconnect = GetCloseOnEOF();
         done = true;
       }
-      #ifdef _WIN32
-      if (error.GetType() == eErrorTypeWin32 && error.GetError() == ERROR_INVALID_HANDLE) {
-        // ERROR_INVALID_HANDLE on a pipe is usually caused by a remote shutdown of the pipe's ConPTY
+#ifdef _WIN32
+      if (error.GetType() == eErrorTypeWin32 &&
+          error.GetError() == ERROR_INVALID_HANDLE) {
+        // ERROR_INVALID_HANDLE on a pipe is usually caused by a remote shutdown
+        // of the pipe's ConPTY
         disconnect = GetCloseOnEOF();
         done = true;
       }
-      #endif
+#endif
       if (error.Fail())
         LLDB_LOG(log, "error: {0}, status = {1}", error,
                  ThreadedCommunication::ConnectionStatusAsString(status));

--- a/lldb/source/Core/ThreadedCommunication.cpp
+++ b/lldb/source/Core/ThreadedCommunication.cpp
@@ -16,6 +16,9 @@
 #include "lldb/Utility/Listener.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Status.h"
+#ifdef _WIN32
+#include "lldb/Host/windows/windows.h"
+#endif
 
 #include "llvm/Support/Compiler.h"
 
@@ -293,12 +296,13 @@ lldb::thread_result_t ThreadedCommunication::ReadThread() {
         disconnect = GetCloseOnEOF();
         done = true;
       }
-      if (error.GetType() == eErrorTypeWin32 && error.GetError() == ENXIO) {
-        // ENXIO on a pipe is usually caused by a remote shutdown of the
-        // attached ConPTY
+      #ifdef _WIN32
+      if (error.GetType() == eErrorTypeWin32 && error.GetError() == ERROR_INVALID_HANDLE) {
+        // ERROR_INVALID_HANDLE on a pipe is usually caused by a remote shutdown of the pipe's ConPTY
         disconnect = GetCloseOnEOF();
         done = true;
       }
+      #endif
       if (error.Fail())
         LLDB_LOG(log, "error: {0}, status = {1}", error,
                  ThreadedCommunication::ConnectionStatusAsString(status));

--- a/lldb/source/Core/ThreadedCommunication.cpp
+++ b/lldb/source/Core/ThreadedCommunication.cpp
@@ -293,6 +293,12 @@ lldb::thread_result_t ThreadedCommunication::ReadThread() {
         disconnect = GetCloseOnEOF();
         done = true;
       }
+      if (error.GetType() == eErrorTypeWin32 && error.GetError() == ENXIO) {
+        // ENXIO on a pipe is usually caused by a remote shutdown of the
+        // attached ConPTY
+        disconnect = GetCloseOnEOF();
+        done = true;
+      }
       if (error.Fail())
         LLDB_LOG(log, "error: {0}, status = {1}", error,
                  ThreadedCommunication::ConnectionStatusAsString(status));


### PR DESCRIPTION
On Windows, `ThreadedCommunication::ReadThread` can fail with `ERROR_INVALID_HANDLE` when the ConPTY is closed. Currently it's not caught, causing the `ReadThread` to continue forever because `done` is never set to `true`. This causes an infinite hang.