### PR TITLE
[Tablegen] Fix condition to report when lanemask overflows

### DIFF
--- a/llvm/test/TableGen/SubRegsLaneBitmask.td
+++ b/llvm/test/TableGen/SubRegsLaneBitmask.td
@@ -1,0 +1,12 @@
+// RUN: not llvm-tblgen -gen-register-info -register-info-debug -I %p/../../include %s -o - 2>&1  | FileCheck %s
+include "llvm/Target/Target.td"
+def TestTarget : Target;
+
+foreach Index = 0...64 in {
+  def sub#Index : SubRegIndex<32, !shl(Index, 5)>;
+}
+
+def A : Register<"">;
+def TestRC : RegisterClass<"Test", [i32], 0, (add A)>;
+
+// CHECK: error: Ran out of lanemask bits to represent subregister sub64

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -1516,7 +1516,7 @@ void CodeGenRegBank::computeSubRegLaneMasks() {
   CoveringLanes = LaneBitmask::getAll();
   for (CodeGenSubRegIndex &Idx : SubRegIndices) {
     if (Idx.getComposites().empty()) {
-      if (Bit > LaneBitmask::BitWidth) {
+      if (Bit >= LaneBitmask::BitWidth) {
         PrintFatalError(
             Twine("Ran out of lanemask bits to represent subregister ") +
             Idx.getName());


### PR DESCRIPTION
This PR:

Fixes a slight off-by-one error in the check for how many bits are allocated for subreg lane masks. If 65 subreg lanes are used, it fails later, but the error message is not clear as to what has occured.