### PR TITLE
[clang][ssaf] Fix building on gcc-7 and MinGW/Cygwin

### DIFF
--- a/clang/include/clang/Analysis/Scalable/Serialization/JSONFormat.h
+++ b/clang/include/clang/Analysis/Scalable/Serialization/JSONFormat.h
@@ -14,8 +14,10 @@
 #define CLANG_ANALYSIS_SCALABLE_SERIALIZATION_JSONFORMAT_H
 
 #include "clang/Analysis/Scalable/Serialization/SerializationFormat.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/Registry.h"
 
 namespace clang::ssaf {
 
@@ -124,5 +126,10 @@ private:
 };
 
 } // namespace clang::ssaf
+
+namespace llvm {
+extern template class CLANG_TEMPLATE_ABI
+    Registry<clang::ssaf::JSONFormat::FormatInfo>;
+} // namespace llvm
 
 #endif // CLANG_ANALYSIS_SCALABLE_SERIALIZATION_JSONFORMAT_H

--- a/clang/lib/Analysis/Scalable/Serialization/JSONFormat.cpp
+++ b/clang/lib/Analysis/Scalable/Serialization/JSONFormat.cpp
@@ -15,6 +15,8 @@ using Array = llvm::json::Array;
 using Object = llvm::json::Object;
 using Value = llvm::json::Value;
 
+LLVM_INSTANTIATE_REGISTRY(llvm::Registry<JSONFormat::FormatInfo>)
+
 //----------------------------------------------------------------------------
 // ErrorBuilder - Fluent API for constructing contextual errors.
 //----------------------------------------------------------------------------
@@ -705,7 +707,7 @@ JSONFormat::entityDataMapFromJSON(const SummaryName &SN,
     }
   }
 
-  return EntityDataMap;
+  return std::move(EntityDataMap);
 }
 
 llvm::Expected<Array> JSONFormat::entityDataMapToJSON(
@@ -841,7 +843,7 @@ JSONFormat::summaryDataMapFromJSON(const Array &SummaryDataArray,
     }
   }
 
-  return SummaryDataMap;
+  return std::move(SummaryDataMap);
 }
 
 llvm::Expected<Array> JSONFormat::summaryDataMapToJSON(
@@ -866,7 +868,7 @@ llvm::Expected<Array> JSONFormat::summaryDataMapToJSON(
     Result.push_back(std::move(*ExpectedSummaryDataMapObject));
   }
 
-  return Result;
+  return std::move(Result);
 }
 
 //----------------------------------------------------------------------------
@@ -956,7 +958,7 @@ llvm::Expected<TUSummary> JSONFormat::readTUSummary(llvm::StringRef Path) {
     getData(Summary) = std::move(*ExpectedSummaryDataMap);
   }
 
-  return Summary;
+  return std::move(Summary);
 }
 
 llvm::Error JSONFormat::writeTUSummary(const TUSummary &S,

--- a/clang/unittests/Analysis/Scalable/Registries/MockSerializationFormat.cpp
+++ b/clang/unittests/Analysis/Scalable/Registries/MockSerializationFormat.cpp
@@ -27,6 +27,8 @@
 using namespace clang;
 using namespace ssaf;
 
+LLVM_INSTANTIATE_REGISTRY(llvm::Registry<MockSerializationFormat::FormatInfo>)
+
 MockSerializationFormat::MockSerializationFormat() {
   for (const auto &FormatInfoEntry : llvm::Registry<FormatInfo>::entries()) {
     std::unique_ptr<FormatInfo> Info = FormatInfoEntry.instantiate();
@@ -89,7 +91,7 @@ MockSerializationFormat::readTUSummary(llvm::StringRef Path) {
     assert(Inserted);
   }
 
-  return Summary;
+  return std::move(Summary);
 }
 
 llvm::Error MockSerializationFormat::writeTUSummary(const TUSummary &Summary,

--- a/clang/unittests/Analysis/Scalable/Registries/MockSerializationFormat.h
+++ b/clang/unittests/Analysis/Scalable/Registries/MockSerializationFormat.h
@@ -11,7 +11,9 @@
 
 #include "clang/Analysis/Scalable/Model/SummaryName.h"
 #include "clang/Analysis/Scalable/Serialization/SerializationFormat.h"
+#include "clang/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/Registry.h"
 #include <string>
 
 namespace clang::ssaf {
@@ -41,5 +43,10 @@ public:
 };
 
 } // namespace clang::ssaf
+
+namespace llvm {
+extern template class CLANG_TEMPLATE_ABI
+    Registry<clang::ssaf::MockSerializationFormat::FormatInfo>;
+} // namespace llvm
 
 #endif // LLVM_CLANG_UNITTESTS_ANALYSIS_SCALABLE_REGISTRIES_MOCKSERIALIZATIONFORMAT_H


### PR DESCRIPTION
So we had two problems:
1) gcc-7 does not fully support C++17 mandatory NRVO, so we need
   an explicit std::move in return statements to workaround this.
2) MinGW/Cygwin is picky about extern templates; this actually bit me
   once, so I'll think about how to mitigate in long term, but for now
   just add the missing declarations.

Reported in:
https://github.com/llvm/llvm-project/pull/180021#issuecomment-3912981241
https://github.com/llvm/llvm-project/pull/180021#issuecomment-3914252777