### PR TITLE
[lldb-dap][windows] fix lldb-dap's self.get_stdout() method

### DIFF
--- a/lldb/include/lldb/Host/ProcessLaunchInfo.h
+++ b/lldb/include/lldb/Host/ProcessLaunchInfo.h
@@ -137,8 +137,7 @@ public:
   bool ShouldUsePTY() const {
 #ifdef _WIN32
     return GetPTY().GetPseudoTerminalHandle() != ((HANDLE)(long long)-1) &&
-           GetNumFileActions() == 0 &&
-           GetFlags().Test(lldb::eLaunchFlagLaunchInTTY);
+           GetNumFileActions() == 0;
 #else
     return true;
 #endif

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -215,10 +215,6 @@ Status ProcessWindows::DoLaunch(Module *exe_module,
   if (error.Success())
     SetID(launch_info.GetProcessID());
   m_pty = launch_info.TakePTY();
-  // At this point, Process owns the ConPTY. If ProcessLaunchInfo still has a
-  // reference to it, it might get closed prematurely if another target is
-  // created.
-  assert(m_pty.use_count() == 1 && "More than one reference to the ConPTY");
   return error;
 }
 

--- a/lldb/test/API/lldbutil-tests/failed-to-hit-breakpoint/TestLLDBUtilFailedToHitBreakpoint.py
+++ b/lldb/test/API/lldbutil-tests/failed-to-hit-breakpoint/TestLLDBUtilFailedToHitBreakpoint.py
@@ -11,7 +11,6 @@ from lldbsuite.test.decorators import *
 class LLDBUtilFailedToHitBreakpointTest(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @expectedFailureAll(oslist=["windows"])
     def test_error_message(self):
         """
         Tests that run_to_source_breakpoint prints the right error message

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_args.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_args.py
@@ -11,9 +11,6 @@ class TestDAP_launch_args(lldbdap_testcase.DAPTestCaseBase):
     Tests launch of a simple program with arguments
     """
 
-    @expectedFailureWindows(
-        bugnumber="https://github.com/llvm/llvm-project/issues/137599"
-    )
     def test(self):
         program = self.getBuildArtifact("a.out")
         args = ["one", "with space", "'with single quotes'", '"with double quotes"']

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_basic.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_basic.py
@@ -12,9 +12,6 @@ class TestDAP_launch_basic(lldbdap_testcase.DAPTestCaseBase):
     environment, or anything else is specified.
     """
 
-    @expectedFailureWindows(
-        bugnumber="https://github.com/llvm/llvm-project/issues/137599"
-    )
     def test(self):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_debuggerRoot.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_debuggerRoot.py
@@ -14,9 +14,6 @@ class TestDAP_launch_debuggerRoot(lldbdap_testcase.DAPTestCaseBase):
     the lldb-dap debug adapter.
     """
 
-    @expectedFailureWindows(
-        bugnumber="https://github.com/llvm/llvm-project/issues/137599"
-    )
     def test(self):
         program = self.getBuildArtifact("a.out")
         program_parent_dir = os.path.realpath(os.path.dirname(os.path.dirname(program)))

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_environment_with_object.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_environment_with_object.py
@@ -7,9 +7,6 @@ import lldbdap_testcase
 
 
 class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
-    @expectedFailureWindows(
-        bugnumber="https://github.com/llvm/llvm-project/issues/137599"
-    )
     def test_environment_with_object(self):
         """
         Tests launch of a simple program with environment variables

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_shellExpandArguments_disabled.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_shellExpandArguments_disabled.py
@@ -13,9 +13,6 @@ class TestDAP_launch_shellExpandArguments_disabled(lldbdap_testcase.DAPTestCaseB
     disabled.
     """
 
-    @expectedFailureWindows(
-        bugnumber="https://github.com/llvm/llvm-project/issues/137599"
-    )
     def test(self):
         program = self.getBuildArtifact("a.out")
         program_dir = os.path.dirname(program)

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_shellExpandArguments_enabled.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_shellExpandArguments_enabled.py
@@ -18,7 +18,9 @@ class TestDAP_launch_shellExpandArguments_enabled(lldbdap_testcase.DAPTestCaseBa
     """
 
     @skipIfLinux  # shell argument expansion doesn't seem to work on Linux
-    @expectedFailureAll(oslist=["freebsd", "netbsd", "windows"], bugnumber="llvm.org/pr48349")
+    @expectedFailureAll(
+        oslist=["freebsd", "netbsd", "windows"], bugnumber="llvm.org/pr48349"
+    )
     def test(self):
         program = self.getBuildArtifact("a.out")
         program_dir = os.path.dirname(program)

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_shellExpandArguments_enabled.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_shellExpandArguments_enabled.py
@@ -18,10 +18,7 @@ class TestDAP_launch_shellExpandArguments_enabled(lldbdap_testcase.DAPTestCaseBa
     """
 
     @skipIfLinux  # shell argument expansion doesn't seem to work on Linux
-    @expectedFailureWindows(
-        bugnumber="https://github.com/llvm/llvm-project/issues/137599"
-    )
-    @expectedFailureAll(oslist=["freebsd", "netbsd"], bugnumber="llvm.org/pr48349")
+    @expectedFailureAll(oslist=["freebsd", "netbsd", "windows"], bugnumber="llvm.org/pr48349")
     def test(self):
         program = self.getBuildArtifact("a.out")
         program_dir = os.path.dirname(program)

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection_and_console.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection_and_console.py
@@ -19,7 +19,7 @@ class TestDAP_launch_stdio_redirection_and_console(lldbdap_testcase.DAPTestCaseB
     """
 
     @skipIfAsan
-    @skipIfWindows # https://github.com/llvm/llvm-project/issues/62336
+    @skipIfWindows  # https://github.com/llvm/llvm-project/issues/62336
     @skipIf(oslist=["linux"], archs=no_match(["x86_64"]))
     @skipIfBuildType(["debug"])
     def test(self):

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection_and_console.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_stdio_redirection_and_console.py
@@ -4,10 +4,10 @@ Test lldb-dap launch request.
 
 from lldbsuite.test.decorators import (
     skipIfAsan,
-    expectedFailureWindows,
     skipIf,
     skipIfBuildType,
     no_match,
+    skipIfWindows,
 )
 import lldbdap_testcase
 import tempfile
@@ -19,9 +19,7 @@ class TestDAP_launch_stdio_redirection_and_console(lldbdap_testcase.DAPTestCaseB
     """
 
     @skipIfAsan
-    @expectedFailureWindows(
-        bugnumber="https://github.com/llvm/llvm-project/issues/137599"
-    )
+    @skipIfWindows # https://github.com/llvm/llvm-project/issues/62336
     @skipIf(oslist=["linux"], archs=no_match(["x86_64"]))
     @skipIfBuildType(["debug"])
     def test(self):

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_version.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_version.py
@@ -13,9 +13,6 @@ class TestDAP_launch_version(lldbdap_testcase.DAPTestCaseBase):
     as the one returned by "version" command.
     """
 
-    @expectedFailureWindows(
-        bugnumber="https://github.com/llvm/llvm-project/issues/137599"
-    )
     def test(self):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)


### PR DESCRIPTION
`DAPTestCaseBase.get_stdout()` was originally not supported on Windows due to the lack of ConPTY support. https://github.com/llvm/llvm-project/pull/168729 fixed that by implenenting the ConPTY support. It was partly reverted in https://github.com/llvm/llvm-project/pull/177610 due to hard to reproduce test failures.

The tests are now fixed (see the 2 patches below) and removing the check for `GetFlags().Test(lldb::eLaunchFlagLaunchInTTY);` is the last step to re-enabling ConPTY support.

This patch requires:
- https://github.com/llvm/llvm-project/pull/181811
- https://github.com/llvm/llvm-project/pull/181809

Fixes https://github.com/llvm/llvm-project/issues/137599.

rdar://168932366