### PR TITLE
[AMDGPU][GlobalISel][NFC] Filter getCandidatesForLowering to only process G_PHI

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
@@ -103,9 +103,13 @@ void DivergenceLoweringHelper::getCandidatesForLowering(
     SmallVectorImpl<MachineInstr *> &Vreg1Phis) const {
   LLT S1 = LLT::scalar(1);
 
-  // Add divergent i1 phis to the list
+  // Add divergent i1 G_PHIs to the list. Only consider G_PHI instructions,
+  // not PHI instructions that may have been created by earlier lowering stages
+  // (e.g., lowerTemporalDivergenceI1).
   for (MachineBasicBlock &MBB : *MF) {
     for (MachineInstr &MI : MBB.phis()) {
+      if (MI.getOpcode() != TargetOpcode::G_PHI)
+        continue;
       Register Dst = MI.getOperand(0).getReg();
       if (MRI->getType(Dst) == S1 && MUI->isDivergent(Dst))
         Vreg1Phis.push_back(&MI);


### PR DESCRIPTION
The divergence-lowering pass runs in three stages:
1. lowerTemporalDivergence()
2. lowerTemporalDivergenceI1() — creates PHI instructions via SSAUpdater
3. lowerPhis() — lowers divergent i1 G_PHIs into lane mask PHIs

getCandidatesForLowering() in stage 3 iterates over all PHIs via MBB.phis() and checks isDivergent() on their destination registers. This includes PHI instructions already created by stage 2, whose registers were never part of the original uniformity analysis.

Today, this works by accident — isDivergent() returns false for unknown registers, so these PHIs are skipped. But this relies on isDivergent() behavior for unanalyzed registers, which is not guaranteed. If isDivergent() were to return true for unknown registers (e.g., as a conservative default), lowerPhis() would re-process already-lowered PHIs, adding redundant COPY instructions(EX: https://github.com/llvm/llvm-project/pull/180509). This would not be a correctness issue, but would produce unnecessary code.
