### PR TITLE
[lldb-dap] Fix missing ampersand in the deleted constructor

### DIFF
--- a/lldb/tools/lldb-dap/Variables.h
+++ b/lldb/tools/lldb-dap/Variables.h
@@ -58,7 +58,7 @@ public:
 
   // Not copyable.
   VariableStore(const VariableStore &) = delete;
-  VariableStore operator=(const VariableStore &) = delete;
+  VariableStore &operator=(const VariableStore &) = delete;
   VariableStore(VariableStore &&) = default;
   VariableStore &operator=(VariableStore &&) = default;
 };


### PR DESCRIPTION
Fails to compile when cross compiling