### PR TITLE
[mlir][nfc] Fix assertion text in IndexingUtils

### DIFF
--- a/mlir/include/mlir/Dialect/Utils/IndexingUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/IndexingUtils.h
@@ -63,7 +63,7 @@ int64_t computeProduct(ArrayRef<int64_t> basis);
 /// Return the number of elements of basis (i.e. the max linear index).
 /// Return `0` if `basis` is empty.
 ///
-/// `basis` elements are asserted to be non-negative.
+/// `basis` elements are asserted to be positive.
 ///
 /// Return `0` if `basis` is empty.
 inline int64_t computeMaxLinearIndex(ArrayRef<int64_t> basis) {
@@ -72,12 +72,12 @@ inline int64_t computeMaxLinearIndex(ArrayRef<int64_t> basis) {
 
 /// Return the linearized index of 'offsets' w.r.t. 'basis'.
 ///
-/// `basis` elements are asserted to be non-negative.
+/// `basis` elements are asserted to be positive.
 int64_t linearize(ArrayRef<int64_t> offsets, ArrayRef<int64_t> basis);
 
 /// Given the strides together with a linear index in the dimension space,
 /// return the vector-space offsets in each dimension for a de-linearized index.
-/// `strides` elements are asserted to be non-negative.
+/// `strides` elements are asserted to be positive.
 ///
 /// Let `li = linearIndex`, assuming `strides` are `[s0, .. sn]`, return the
 /// vector of int64_t
@@ -89,7 +89,7 @@ SmallVector<int64_t> delinearize(int64_t linearIndex,
 /// dimensions of `shape`. This represents how many times `subShape` fits
 /// within `shape`. If integral division is not possible, return std::nullopt.
 /// The trailing `subShape.size()` entries of both shapes are assumed (and
-/// enforced) to only contain non-negative values.
+/// enforced) to only contain positive values.
 ///
 /// Examples:
 ///   - shapeRatio({3, 5, 8}, {2, 5, 2}) returns {3, 2, 1}.

--- a/mlir/lib/Dialect/Utils/IndexingUtils.cpp
+++ b/mlir/lib/Dialect/Utils/IndexingUtils.cpp
@@ -83,13 +83,13 @@ SmallVector<int64_t> mlir::computeElementwiseMul(ArrayRef<int64_t> v1,
 
 int64_t mlir::computeProduct(ArrayRef<int64_t> basis) {
   assert(llvm::all_of(basis, [](int64_t s) { return s > 0; }) &&
-         "basis must be nonnegative");
+         "basis must be positive");
   return llvm::product_of(basis);
 }
 
 int64_t mlir::linearize(ArrayRef<int64_t> offsets, ArrayRef<int64_t> basis) {
   assert(llvm::all_of(basis, [](int64_t s) { return s > 0; }) &&
-         "basis must be nonnegative");
+         "basis must be positive");
   int64_t zero = 0;
   return linearizeImpl(offsets, basis, zero);
 }

--- a/mlir/lib/Dialect/Utils/IndexingUtils.cpp
+++ b/mlir/lib/Dialect/Utils/IndexingUtils.cpp
@@ -97,7 +97,7 @@ int64_t mlir::linearize(ArrayRef<int64_t> offsets, ArrayRef<int64_t> basis) {
 SmallVector<int64_t> mlir::delinearize(int64_t linearIndex,
                                        ArrayRef<int64_t> strides) {
   assert(llvm::all_of(strides, [](int64_t s) { return s > 0; }) &&
-         "strides must be nonnegative");
+         "strides must be positive");
   return delinearizeImpl(linearIndex, strides,
                          [](int64_t e1, int64_t e2) { return e1 / e2; });
 }
@@ -107,9 +107,9 @@ mlir::computeShapeRatio(ArrayRef<int64_t> shape, ArrayRef<int64_t> subShape) {
   if (shape.size() < subShape.size())
     return std::nullopt;
   assert(llvm::all_of(shape, [](int64_t s) { return s > 0; }) &&
-         "shape must be nonnegative");
+         "shape must be positive");
   assert(llvm::all_of(subShape, [](int64_t s) { return s > 0; }) &&
-         "subShape must be nonnegative");
+         "subShape must be positive");
 
   // Starting from the end, compute the integer divisors.
   std::vector<int64_t> result;


### PR DESCRIPTION
Update the assertion text to match the actual code behavior.
Some functions enforce strictly positive values, whereas the error message incorrectly mentioned "nonnegative".