### PR TITLE
[Clang] fix nested-name-specifier error recovery with ordinary lookup fallback results

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -268,6 +268,7 @@ Bug Fixes in This Version
 - Clang now outputs relative paths of embeds for dependency output. (#GH161950)
 - Fixed an assertion failure when evaluating ``_Countof`` on invalid ``void``-typed operands. (#GH180893)
 - Fixed a ``-Winvalid-noreturn`` false positive for unreachable ``try`` blocks following an unconditional ``throw``. (#GH174822)
+- Fixed an assertion failure caused by error recovery while extending a nested name specifier with results from ordinary lookup. (#GH181470)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -792,7 +792,8 @@ bool Sema::BuildCXXNestedNameSpecifier(Scope *S, NestedNameSpecInfo &IdInfo,
           << IdInfo.Identifier << getLangOpts().CPlusPlus;
       return true;
     }
-    if (::ExtendNestedNameSpecifier(*this, SS, ND, IdInfo.IdentifierLoc,
+    if (Found.getLookupKind() == LookupNestedNameSpecifierName &&
+        ::ExtendNestedNameSpecifier(*this, SS, ND, IdInfo.IdentifierLoc,
                                     IdInfo.CCLoc)) {
       const Type *T = SS.getScopeRep().getAsType();
       Diag(IdInfo.IdentifierLoc, diag::err_expected_class_or_namespace)

--- a/clang/test/SemaCXX/nested-name-spec.cpp
+++ b/clang/test/SemaCXX/nested-name-spec.cpp
@@ -476,7 +476,8 @@ namespace A {
 class B {
   typedef C D; // expected-error{{unknown type name 'C'}}
   A::D::F;
-  // expected-error@-1{{'A::D' (aka 'int') is not a class, namespace, or enumeration}}
+  // expected-error@-1{{'D' is not a class, namespace, or enumeration}}
+  // expected-note@-3 {{'D' declared here}}
 };
 }
 }
@@ -515,4 +516,11 @@ struct S : V<> {
   using S::V; // expected-error {{using declaration refers to its own class}}
   V<> v; // no crash
 };
+}
+
+namespace GH181470 {
+namespace N {}
+bar;                           // expected-error {{a type specifier is required for all declarations}}
+template <class T> N::T::bar;  // expected-error {{'T' is not a class, namespace, or enumeration}} \
+                               // expected-note {{'T' declared here}}
 }


### PR DESCRIPTION
Fixes #181470

--- 

This patch addresses the regression caused by f3dcec0ee73fee6a33fcfb422e04297e4d466de6. The assertion occurs when nested-name-specifier error recovery tries to extend a nested name specifier with a result found via ordinary lookup fallback

https://github.com/llvm/llvm-project/blob/75aa83c0c035a7a10f0f48355c93858f003b8e4e/clang/lib/Sema/SemaCXXScopeSpec.cpp#L725-L728

which can hit `getTypeDeclType` qualifier assertions

https://github.com/llvm/llvm-project/blob/75aa83c0c035a7a10f0f48355c93858f003b8e4e/clang/lib/Sema/SemaCXXScopeSpec.cpp#L420

https://github.com/llvm/llvm-project/blob/4f92cf9599c4077c08b7fac0a21624e55da572f9/clang/lib/AST/ASTContext.cpp#L5162-L5176

