### PR TITLE
[lldb][CommandObjectType] Print name of Python class when emitting warning about invalid synthetic provider

### DIFF
--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -2181,10 +2181,12 @@ bool CommandObjectTypeSynthAdd::Execute_PythonClass(
 
   ScriptInterpreter *interpreter = GetDebugger().GetScriptInterpreter();
 
-  if (interpreter &&
-      !interpreter->CheckObjectExists(impl->GetPythonClassName()))
-    result.AppendWarning("The provided class does not exist - please define it "
-                         "before attempting to use this synthetic provider");
+  const char *python_class_name = impl->GetPythonClassName();
+  if (interpreter && !interpreter->CheckObjectExists(python_class_name))
+    result.AppendWarningWithFormatv(
+        "The provided class '{0}' does not exist - please define it "
+        "before attempting to use this synthetic provider",
+        llvm::StringRef(python_class_name));
 
   // now I have a valid provider, let's add it to every type
 

--- a/lldb/test/Shell/Commands/command-type-synthetic-add.test
+++ b/lldb/test/Shell/Commands/command-type-synthetic-add.test
@@ -1,0 +1,6 @@
+# REQUIRES: python
+
+# RUN: %lldb -b -o 'type synthetic add --python-class blah blah-name' 2>&1 | FileCheck %s
+
+# CHECK:      (lldb) type synthetic
+# CHECK-NEXT: The provided class 'blah' does not exist


### PR DESCRIPTION
Before:
```
(lldb) type synthetic add -l blah foo
warning: The provided class does not exist - please define it before attempting to use this synthetic provider
```

After:
```
(lldb) type synthetic add -l blah foo
warning: The provided class 'blah' does not exist - please define it before attempting to use this synthetic provider
```

Useful when many of these registration commands happen as part of `~/.lldbinit`. Previously it wasn't immediately obvious which of those commands failed.