### PR TITLE
[clang][NFC] Add marking to CWG2947 test

### DIFF
--- a/clang/test/CXX/drs/cwg2947.cpp
+++ b/clang/test/CXX/drs/cwg2947.cpp
@@ -32,6 +32,8 @@
 // RUN: %clang_cc1 -std=c++26 %t/cwg2947_ext2.cpp -fsyntax-only -verify
 // RUN: %clang_cc1 -std=c++26 %t/cwg2947_ext3.cpp -fsyntax-only -verify
 
+// cwg2947: 23 open 2024-10-29
+
 //--- cwg2947_example1.cpp
 // #define DOT_BAR .bar
 export module foo DOT_BAR; // error: expansion of DOT_BAR; does not begin with ; or [

--- a/clang/test/CXX/drs/cwg29xx.cpp
+++ b/clang/test/CXX/drs/cwg29xx.cpp
@@ -108,7 +108,7 @@ void test() {
   constexpr auto y = &X<false>::f;
   static_assert(__is_same(decltype(y), int(*const)(short)));
   static_assert(y(0) == 24, "");
-  
+
   constexpr auto z = &f<int>;
   static_assert(__is_same(decltype(z), int(*const)(int)));
   static_assert(z(0) == 2, "");
@@ -173,3 +173,5 @@ constexpr U _ = nondeterministic(true);
 //   since-cxx26-note@-3 {{in call to 'nondeterministic(true)'}}
 #endif
 } // namespace cwg2922
+
+// cwg2947 is in cwg2947.cpp

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -20446,7 +20446,11 @@
     <td>[<a href="https://wg21.link/cpp.module">cpp.module</a>]</td>
     <td>open</td>
     <td>Limiting macro expansion in <I>pp-module</I></td>
-    <td align="center">Not resolved</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 23 implements 2024-10-29 resolution
+      </details></td>
   </tr>
   <tr class="open" id="2948">
     <td><a href="https://cplusplus.github.io/CWG/issues/2948.html">2948</a></td>


### PR DESCRIPTION
052f2f8cd17f3ff8bcb7b53a777a232d9ac36965 accidentally changed the status of CWG2947 from "Clang 23" to "No", because the test was missing the special comment that `make_cxx_dr_status` scripts consumes. This PR adds the special comments and restores the original status of CWG2947.