### PR TITLE
[clang][Modules] Handle relocated modules during implicit module builds

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSerializationKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSerializationKinds.td
@@ -101,6 +101,13 @@ def remark_module_validation : Remark<
   "validating %0 input files in module '%1' from '%2'">,
   ShowInSystemHeader,
   InGroup<ModuleValidation>;
+def remark_module_check_relocation
+    : Remark<"checking if module '%0' from '%1' has relocated">,
+      ShowInSystemHeader,
+      InGroup<ModuleValidation>;
+def remark_module_relocated : Remark<"module '%0' relocated from '%1' to '%2'">,
+                              ShowInSystemHeader,
+                              InGroup<ModuleValidation>;
 
 def err_imported_module_not_found : Error<
     "module '%0' in precompiled file '%1' %select{(imported by precompiled file '%2') |}4"

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -1591,12 +1591,20 @@ private:
   llvm::Error ReadSourceManagerBlock(ModuleFile &F);
   SourceLocation getImportLocation(ModuleFile *F);
 
-  /// If a relocation check happened, the optional holds a pointer to the
-  /// discovered Module. The second element determines whether to emit related
-  /// validation errors.
-  using RelocationCheckResult = std::pair<std::optional<Module *>, bool>;
-  RelocationCheckResult checkIfModuleRelocated(ModuleFile &F,
-                                               bool DirectoryCheck = false);
+  /// The first element is `std::nullopt` if relocation check should be skipped.
+  /// Otherwise, the optional holds a pointer to the discovered module.
+  /// The pointer can be `nullptr` if the discovery was unsuccessful.
+  /// The second element determines whether to emit related errors.
+  using RelocationResult = std::pair<std::optional<Module *>, bool>;
+
+  /// Determine whether a relocation check for a module should be performed
+  /// by attempting to resolve the same module via lookup.
+  /// If so, also determine whether to emit errors for the relocation.
+  /// A relocated module is defined as a module that is either no longer
+  /// resolvable from the modulemap or search path it originally compiled it's
+  /// definition from.
+  RelocationResult getModuleForRelocationChecks(ModuleFile &F,
+                                                bool DirectoryCheck = false);
   ASTReadResult ReadModuleMapFileBlock(RecordData &Record, ModuleFile &F,
                                        const ModuleFile *ImportedBy,
                                        unsigned ClientLoadCapabilities);

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -1590,6 +1590,13 @@ private:
   void ParseLineTable(ModuleFile &F, const RecordData &Record);
   llvm::Error ReadSourceManagerBlock(ModuleFile &F);
   SourceLocation getImportLocation(ModuleFile *F);
+
+  /// If a relocation check happened, the optional holds a pointer to the
+  /// discovered Module. The second element determines whether to emit related
+  /// validation errors.
+  using RelocationCheckResult = std::pair<std::optional<Module *>, bool>;
+  RelocationCheckResult checkIfModuleRelocated(ModuleFile &F,
+                                               bool DirectoryCheck = false);
   ASTReadResult ReadModuleMapFileBlock(RecordData &Record, ModuleFile &F,
                                        const ModuleFile *ImportedBy,
                                        unsigned ClientLoadCapabilities);

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -470,9 +470,6 @@ createScanCompilerInvocation(const CompilerInvocation &Invocation,
       true;
   ScanInvocation->getHeaderSearchOpts().ModulesForceValidateUserHeaders = false;
 
-  // Avoid some checks and module map parsing when loading PCM files.
-  ScanInvocation->getPreprocessorOpts().ModulesCheckRelocated = false;
-
   // Ensure that the scanner does not create new dependency collectors,
   // and thus won't write out the extra '.d' files to disk.
   ScanInvocation->getDependencyOutputOpts() = {};

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -3162,6 +3162,49 @@ ASTReader::ASTReadResult ASTReader::ReadOptionsBlock(
   }
 }
 
+ASTReader::RelocationCheckResult
+ASTReader::checkIfModuleRelocated(ModuleFile &F, bool DirectoryCheck) {
+  // Don't emit module relocation errors if we have -fno-validate-pch.
+  const bool IgnoreError =
+      bool(PP.getPreprocessorOpts().DisablePCHOrModuleValidation &
+           DisableValidationForModuleKind::Module);
+
+  if (!PP.getPreprocessorOpts().ModulesCheckRelocated)
+    return {std::nullopt, IgnoreError};
+
+  const bool IsImplicitModule = F.Kind == MK_ImplicitModule;
+
+  if (!DirectoryCheck &&
+      (!IsImplicitModule || ModuleMgr.begin()->Kind == MK_MainFile))
+    return {std::nullopt, IgnoreError};
+
+  const HeaderSearchOptions &HSOpts =
+      PP.getHeaderSearchInfo().getHeaderSearchOpts();
+
+  // When only validating modules once per build session,
+  // Skip check if the timestamp is up to date or module was built in same build
+  // session.
+  if (HSOpts.ModulesValidateOncePerBuildSession && IsImplicitModule) {
+    if (F.InputFilesValidationTimestamp >= HSOpts.BuildSessionTimestamp)
+      return {std::nullopt, IgnoreError};
+    if (static_cast<uint64_t>(F.File.getModificationTime()) >=
+        HSOpts.BuildSessionTimestamp)
+      return {std::nullopt, IgnoreError};
+  }
+
+  Diag(diag::remark_module_check_relocation) << F.ModuleName << F.FileName;
+
+  // If we've already loaded a module map file covering this module, we may
+  // have a better path for it (relative to the current build if doing directory
+  // check).
+  Module *M = PP.getHeaderSearchInfo().lookupModule(
+      F.ModuleName, DirectoryCheck ? SourceLocation() : F.ImportLoc,
+      /*AllowSearch=*/DirectoryCheck,
+      /*AllowExtraModuleMapSearch=*/DirectoryCheck);
+
+  return {M, IgnoreError};
+}
+
 ASTReader::ASTReadResult
 ASTReader::ReadControlBlock(ModuleFile &F,
                             SmallVectorImpl<ImportedModule> &Loaded,
@@ -3561,31 +3604,36 @@ ASTReader::ReadControlBlock(ModuleFile &F,
       assert(!F.ModuleName.empty() &&
              "MODULE_DIRECTORY found before MODULE_NAME");
       F.BaseDirectory = std::string(Blob);
-      if (!PP.getPreprocessorOpts().ModulesCheckRelocated)
+
+      auto [MaybeM, IgnoreError] =
+          checkIfModuleRelocated(F, /*DirectoryCheck=*/true);
+      if (!MaybeM.has_value())
         break;
-      // If we've already loaded a module map file covering this module, we may
-      // have a better path for it (relative to the current build).
-      Module *M = PP.getHeaderSearchInfo().lookupModule(
-          F.ModuleName, SourceLocation(), /*AllowSearch*/ true,
-          /*AllowExtraModuleMapSearch*/ true);
-      if (M && M->Directory) {
-        // If we're implicitly loading a module, the base directory can't
-        // change between the build and use.
-        // Don't emit module relocation error if we have -fno-validate-pch
-        if (!bool(PP.getPreprocessorOpts().DisablePCHOrModuleValidation &
-                  DisableValidationForModuleKind::Module) &&
-            F.Kind != MK_ExplicitModule && F.Kind != MK_PrebuiltModule) {
-          auto BuildDir = PP.getFileManager().getOptionalDirectoryRef(Blob);
-          if (!BuildDir || *BuildDir != M->Directory) {
-            if (!canRecoverFromOutOfDate(F.FileName, ClientLoadCapabilities))
-              Diag(diag::err_imported_module_relocated)
-                  << F.ModuleName << Blob << M->Directory->getName();
-            return OutOfDate;
-          }
-        }
+
+      Module *M = MaybeM.value();
+      if (!M || !M->Directory)
+        break;
+      if (IgnoreError) {
         F.BaseDirectory = std::string(M->Directory->getName());
+        break;
       }
-      break;
+      if ((F.Kind == MK_ExplicitModule) || (F.Kind == MK_PrebuiltModule))
+        break;
+
+      // If we're implicitly loading a module, the base directory can't
+      // change between the build and use.
+      auto BuildDir = PP.getFileManager().getOptionalDirectoryRef(Blob);
+      if (BuildDir && (*BuildDir == M->Directory)) {
+        F.BaseDirectory = std::string(M->Directory->getName());
+        break;
+      }
+      Diag(diag::remark_module_relocated)
+          << F.ModuleName << Blob << M->Directory->getName();
+
+      if (!canRecoverFromOutOfDate(F.FileName, ClientLoadCapabilities))
+        Diag(diag::err_imported_module_relocated)
+            << F.ModuleName << Blob << M->Directory->getName();
+      return OutOfDate;
     }
 
     case MODULE_MAP_FILE:
@@ -4578,19 +4626,20 @@ ASTReader::ReadModuleMapFileBlock(RecordData &Record, ModuleFile &F,
   // usable header search context.
   assert(!F.ModuleName.empty() &&
          "MODULE_NAME should come before MODULE_MAP_FILE");
-  if (PP.getPreprocessorOpts().ModulesCheckRelocated &&
-      F.Kind == MK_ImplicitModule && ModuleMgr.begin()->Kind != MK_MainFile) {
+  auto [MaybeM, IgnoreError] =
+      checkIfModuleRelocated(F, /*DirectoryCheck=*/false);
+  if (MaybeM.has_value()) {
     // An implicitly-loaded module file should have its module listed in some
     // module map file that we've already loaded.
-    Module *M =
-        PP.getHeaderSearchInfo().lookupModule(F.ModuleName, F.ImportLoc);
+    Module *M = MaybeM.value();
     auto &Map = PP.getHeaderSearchInfo().getModuleMap();
     OptionalFileEntryRef ModMap =
         M ? Map.getModuleMapFileForUniquing(M) : std::nullopt;
-    // Don't emit module relocation error if we have -fno-validate-pch
-    if (!bool(PP.getPreprocessorOpts().DisablePCHOrModuleValidation &
-              DisableValidationForModuleKind::Module) &&
-        !ModMap) {
+    if (!IgnoreError && !ModMap) {
+      if (M && M->Directory)
+        Diag(diag::remark_module_relocated)
+            << F.ModuleName << F.BaseDirectory << M->Directory->getName();
+
       if (!canRecoverFromOutOfDate(F.FileName, ClientLoadCapabilities)) {
         if (auto ASTFE = M ? M->getASTFile() : std::nullopt) {
           // This module was defined by an imported (explicit) module.

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -3162,8 +3162,8 @@ ASTReader::ASTReadResult ASTReader::ReadOptionsBlock(
   }
 }
 
-ASTReader::RelocationCheckResult
-ASTReader::checkIfModuleRelocated(ModuleFile &F, bool DirectoryCheck) {
+ASTReader::RelocationResult
+ASTReader::getModuleForRelocationChecks(ModuleFile &F, bool DirectoryCheck) {
   // Don't emit module relocation errors if we have -fno-validate-pch.
   const bool IgnoreError =
       bool(PP.getPreprocessorOpts().DisablePCHOrModuleValidation &
@@ -3606,7 +3606,7 @@ ASTReader::ReadControlBlock(ModuleFile &F,
       F.BaseDirectory = std::string(Blob);
 
       auto [MaybeM, IgnoreError] =
-          checkIfModuleRelocated(F, /*DirectoryCheck=*/true);
+          getModuleForRelocationChecks(F, /*DirectoryCheck=*/true);
       if (!MaybeM.has_value())
         break;
 
@@ -4627,7 +4627,7 @@ ASTReader::ReadModuleMapFileBlock(RecordData &Record, ModuleFile &F,
   assert(!F.ModuleName.empty() &&
          "MODULE_NAME should come before MODULE_MAP_FILE");
   auto [MaybeM, IgnoreError] =
-      checkIfModuleRelocated(F, /*DirectoryCheck=*/false);
+      getModuleForRelocationChecks(F, /*DirectoryCheck=*/false);
   if (MaybeM.has_value()) {
     // An implicitly-loaded module file should have its module listed in some
     // module map file that we've already loaded.

--- a/clang/test/ClangScanDeps/build-session-validation-relocated-modules.c
+++ b/clang/test/ClangScanDeps/build-session-validation-relocated-modules.c
@@ -12,19 +12,22 @@
 // RUN: split-file %s %t
 // RUN: sed -e "s|DIR|%/t|g" %t/compile-commands.json.in > %t/compile-commands.json
 
-
 // RUN: touch %t/session.timestamp
 // RUN: clang-scan-deps -format experimental-full -j 1 \
-// RUN:   -compilation-database %t/compile-commands.json 2>&1 | FileCheck %s --check-prefix=DEPS1 
+// RUN:   -compilation-database %t/compile-commands.json -o %t/deps1.json 
+// RUN: cat %t/deps1.json | FileCheck %s --check-prefix=DEPS1 
 
 // Model update where same framework appears in earlier search path.
 // This can occur on an incremental build where dependency relationships are updated.
+// RUN: touch %t/session.timestamp
+// RUN: sleep 1
 // RUN: mkdir %t/preferred_frameworks/
 // RUN: cp -r %t/fallback_frameworks/MovedDep.framework %t/preferred_frameworks/
 // RUN: touch %t/fallback_frameworks/InvalidatedDep.framework/Modules/module.modulemap
 
 // RUN: clang-scan-deps -format experimental-full -j 1 \
-// RUN:   -compilation-database %t/compile-commands.json 2>&1 | FileCheck %s --check-prefix=DEPS2
+// RUN:   -compilation-database %t/compile-commands.json -o %t/deps2.json
+// RUN: cat %t/deps2.json | FileCheck %s --check-prefix=DEPS2
 
 // DEPS1: "clang-module-deps": [],
 // DEPS1-NEXT: "clang-modulemap-file": "{{.*}}fallback_frameworks{{.*}}MovedDep.framework

--- a/clang/test/ClangScanDeps/build-session-validation-relocated-modules.c
+++ b/clang/test/ClangScanDeps/build-session-validation-relocated-modules.c
@@ -1,0 +1,68 @@
+// Check that a relocated module is rebuilt and no error occurs. 
+// This is required when a incremental build adds a newer version of an 
+//    already built library into a preexisting search path.
+// In this example, on the second scan, `DepThatLoadsOldPCMs` is resolved first and 
+//    populates `MovedDep` into memory. 
+//  Then when `InvalidatedDep` is loaded, it's input file is out of date 
+//    and requires a rebuild.
+// When that happens the compiler notices `MovedDep` is in a earlier search path.
+
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/compile-commands.json.in > %t/compile-commands.json
+
+
+// RUN: touch %t/session.timestamp
+// RUN: clang-scan-deps -format experimental-full -j 1 \
+// RUN:   -compilation-database %t/compile-commands.json 2>&1 | FileCheck %s --check-prefix=DEPS1 
+
+// Model update where same framework appears in earlier search path.
+// This can occur on an incremental build where dependency relationships are updated.
+// RUN: mkdir %t/preferred_frameworks/
+// RUN: cp -r %t/fallback_frameworks/MovedDep.framework %t/preferred_frameworks/
+// RUN: touch %t/fallback_frameworks/InvalidatedDep.framework/Modules/module.modulemap
+
+// RUN: clang-scan-deps -format experimental-full -j 1 \
+// RUN:   -compilation-database %t/compile-commands.json 2>&1 | FileCheck %s --check-prefix=DEPS2
+
+// DEPS1: "clang-module-deps": [],
+// DEPS1-NEXT: "clang-modulemap-file": "{{.*}}fallback_frameworks{{.*}}MovedDep.framework
+// DEPS1: "name": "MovedDep"
+
+// DEPS2: "clang-module-deps": [],
+// DEPS2-NEXT: "clang-modulemap-file": "{{.*}}preferred_frameworks{{.*}}MovedDep.framework
+// DEPS2: "name": "MovedDep"
+
+//--- compile-commands.json.in
+[
+{
+  "directory": "DIR",
+  "command": "clang -c DIR/tu1.c -fmodules -fmodules-cache-path=DIR/cache -FDIR/preferred_frameworks -FDIR/fallback_frameworks  -fbuild-session-file=DIR/session.timestamp -fmodules-validate-once-per-build-session -o DIR/tu1.o ",
+  "file": "DIR/tu1.c"                                                                       
+}
+]
+
+//--- fallback_frameworks/MovedDep.framework/Modules/module.modulemap
+framework module MovedDep { header "MovedDep.h" }
+//--- fallback_frameworks/MovedDep.framework/Headers/MovedDep.h
+int foo(void);
+
+//--- fallback_frameworks/InvalidatedDep.framework/Modules/module.modulemap
+framework module InvalidatedDep { header "InvalidatedDep.h" }
+//--- fallback_frameworks/InvalidatedDep.framework/Headers/InvalidatedDep.h
+#include <MovedDep/MovedDep.h>
+
+//--- fallback_frameworks/DirectDep.framework/Modules/module.modulemap
+framework module DirectDep { header "DirectDep.h" }
+//--- fallback_frameworks/DirectDep.framework/Headers/DirectDep.h
+#include <DepThatLoadsOldPCMs/DepThatLoadsOldPCMs.h>
+#include <InvalidatedDep/InvalidatedDep.h>
+
+//--- fallback_frameworks/DepThatLoadsOldPCMs.framework/Modules/module.modulemap
+framework module DepThatLoadsOldPCMs { header "DepThatLoadsOldPCMs.h" }
+//--- fallback_frameworks/DepThatLoadsOldPCMs.framework/Headers/DepThatLoadsOldPCMs.h
+#include <MovedDep/MovedDep.h>
+
+//--- tu1.c
+#include <DirectDep/DirectDep.h>

--- a/clang/test/ClangScanDeps/modules-symlink-dir-from-module.c
+++ b/clang/test/ClangScanDeps/modules-symlink-dir-from-module.c
@@ -10,6 +10,8 @@
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json
 // RUN: ln -s module %t/include/symlink-to-module
 
+// RUN: touch %t/session.timestamp
+
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -j 1 \
 // RUN:   -format experimental-full  -mode=preprocess-dependency-directives \
 // RUN:   -optimize-args=all -module-files-dir %t/build > %t/deps.json
@@ -28,7 +30,7 @@
 //--- cdb.json.in
 [{
   "directory": "DIR",
-  "command": "clang -fsyntax-only DIR/test.c -F DIR/Frameworks -I DIR/include -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache",
+  "command": "clang -fsyntax-only DIR/test.c -F DIR/Frameworks -I DIR/include -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -fbuild-session-file=DIR/session.timestamp -fmodules-validate-once-per-build-session",
   "file": "DIR/test.c"
 }]
 

--- a/clang/test/Modules/build-session-validation-relocated-modules.c
+++ b/clang/test/Modules/build-session-validation-relocated-modules.c
@@ -1,0 +1,55 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: touch %t/session.timestamp
+// RUN: %clang -fmodules -fimplicit-module-maps  -fsyntax-only %t/tu1.c \
+// RUN:   -fmodules-cache-path=%t/cache -F%t/preferred_frameworks -F%t/fallback_frameworks \
+// RUN:   -fbuild-session-file=%t/session.timestamp -fmodules-validate-once-per-build-session \
+// RUN:   -Rmodule-validation 2>&1 | FileCheck %s --check-prefix=NO_RELOC
+
+// NO_RELOC-NOT: checking if module {{.*}} has relocated
+
+// RUN: mkdir %t/preferred_frameworks/
+// RUN: cp -r %t/fallback_frameworks/IndirectDep.framework %t/preferred_frameworks/
+
+// Verify no relocation checks happen because pcms are newer than timestamp.
+// RUN: %clang -fmodules -fimplicit-module-maps  -fsyntax-only %t/tu1.c \
+// RUN:   -fmodules-cache-path=%t/cache -F%t/preferred_frameworks -F%t/fallback_frameworks \
+// RUN:   -fbuild-session-file=%t/session.timestamp -fmodules-validate-once-per-build-session \
+// RUN:   -Rmodule-validation 2>&1 | FileCheck %s --check-prefix=NO_RELOC
+
+// Verify no relocation checks happen even when the build session is new because it is explicitly
+// disabled.
+// RUN: touch %t/session.timestamp
+// RUN: %clang -fmodules -fimplicit-module-maps  -fsyntax-only %t/tu1.c \
+// RUN:   -fmodules-cache-path=%t/cache -F%t/preferred_frameworks -F%t/fallback_frameworks \
+// RUN:   -fbuild-session-file=%t/session.timestamp -fmodules-validate-once-per-build-session \
+// RUN:   -Xclang -fno-modules-check-relocated -Rmodule-validation 2>&1 | FileCheck %s --check-prefix=NO_RELOC
+
+// Ensure future new timestamp doesn't have same time as older one.
+// RUN: sleep 1
+
+// Now remove the disablement and check.
+// RUN: touch %t/session.timestamp
+// RUN: %clang -fmodules -fimplicit-module-maps  -fsyntax-only %t/tu1.c \
+// RUN:   -fmodules-cache-path=%t/cache -F%t/preferred_frameworks -F%t/fallback_frameworks \
+// RUN:   -fbuild-session-file=%t/session.timestamp -fmodules-validate-once-per-build-session \
+// RUN:   -Rmodule-validation 2>&1 | FileCheck %s --check-prefix=RELOC
+
+// NO_RELOC-NOT: checking if module {{.*}} has relocated
+
+// RELOC: checking if module {{.*}} has relocated
+// RELOC: module 'IndirectDep' relocated from {{.*}}fallback_frameworks{{.*}} to {{.*}}preferred_frameworks
+
+//--- fallback_frameworks/DirectDep.framework/Modules/module.modulemap
+framework module DirectDep { header "DirectDep.h" }
+//--- fallback_frameworks/DirectDep.framework/Headers/DirectDep.h
+#include <IndirectDep/IndirectDep.h>
+
+//--- fallback_frameworks/IndirectDep.framework/Modules/module.modulemap
+framework module IndirectDep { header "IndirectDep.h" }
+//--- fallback_frameworks/IndirectDep.framework/Headers/IndirectDep.h
+int foo(void);
+
+//--- tu1.c
+#include <DirectDep/DirectDep.h>


### PR DESCRIPTION
* To avoid the build time overhead of checking for relocated modules,
  only check it once per build session.
* Enable relocated module checks in the dependency scanner.
* Add remarks to know when this is happening with `-Rmodule-validation`

This check is necessary to be able to handle new libraries appearing in
earlier search paths. This is a valid scenario when dependency info
changes between incremental builds of the same scheme, thus new build sessions.
It is still malformed to expect new versions of libraries to be added within
the same build session.

resolves: rdar://169174750