### PR TITLE
[clang][ssaf] Fix UB caused by missing virtual dtor of FormatInfoEntry

### DIFF
--- a/clang/include/clang/Analysis/Scalable/Serialization/SerializationFormat.h
+++ b/clang/include/clang/Analysis/Scalable/Serialization/SerializationFormat.h
@@ -56,6 +56,7 @@ template <class SerializerFn, class DeserializerFn> struct FormatInfoEntry {
                   DeserializerFn Deserialize)
       : ForSummary(ForSummary), Serialize(Serialize), Deserialize(Deserialize) {
   }
+  virtual ~FormatInfoEntry() = default;
 
   SummaryName ForSummary;
   SerializerFn Serialize;

--- a/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
+++ b/clang/unittests/Analysis/Scalable/Registries/FancyAnalysisData.cpp
@@ -44,7 +44,7 @@ deserializeFancyAnalysis(const SpecialFileRepresentation &File,
 
 namespace {
 using FormatInfo = MockSerializationFormat::FormatInfo;
-struct FancyAnalysisFormatInfo : FormatInfo {
+struct FancyAnalysisFormatInfo final : FormatInfo {
   FancyAnalysisFormatInfo()
       : FormatInfo{
             SummaryName("FancyAnalysis"),

--- a/clang/unittests/Analysis/Scalable/Serialization/JSONFormatTest.cpp
+++ b/clang/unittests/Analysis/Scalable/Serialization/JSONFormatTest.cpp
@@ -93,7 +93,8 @@ deserializePairsEntitySummaryForJSONFormatTest(
   return std::move(Result);
 }
 
-struct PairsEntitySummaryForJSONFormatTestFormatInfo : JSONFormat::FormatInfo {
+struct PairsEntitySummaryForJSONFormatTestFormatInfo final
+    : JSONFormat::FormatInfo {
   PairsEntitySummaryForJSONFormatTestFormatInfo()
       : JSONFormat::FormatInfo(
             SummaryName("PairsEntitySummaryForJSONFormatTest"),

--- a/llvm/include/llvm/Support/Registry.h
+++ b/llvm/include/llvm/Support/Registry.h
@@ -141,6 +141,7 @@ public:
     node Node;
 
     static std::unique_ptr<T> CtorFn(CtorParamTypes &&...Params) {
+      static_assert(std::has_virtual_destructor_v<T>);
       return std::make_unique<V>(std::forward<CtorParamTypes>(Params)...);
     }
 


### PR DESCRIPTION
In the `llvm::Registry` the `Add` will create a `unique_ptr` of the desired derived type on the heap; then it puts it into the linked list of base pointers.
Consequently, when destructing the registry, it needs to call the matching dtor for the object, so that must be virtual.

In this patch, I fix it by marking it virtual, and also put a static assert to prevent future mistakes of this kind.

FYI: The static assert must be in dependent context to ensure that `T` is complete by the time hitting the static assert.

Fixes https://github.com/Quuxplusone/llvm-project/issues/51