### PR TITLE
[flang][FIR] allow mem2reg over fir.declare

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3399,6 +3399,9 @@ def fir_DeclareOp
                          MemoryEffects<[MemAlloc<DebuggingResource>]>,
                          DeclareOpInterfaceMethods<
                              fir_FortranVariableStorageOpInterface>,
+                         DeclareOpInterfaceMethods<PromotableOpInterface,
+                                                   ["requiresReplacedValues",
+                                                    "visitReplacedValues"]>,
                          fir_FortranObjectViewOpInterface]> {
   let summary = "declare a variable";
 
@@ -3468,6 +3471,35 @@ def fir_DeclareOp
     // FortranObjectViewOpInterface methods:
     mlir::Value getViewSource(mlir::OpResult) { return getMemref(); }
     std::optional<std::int64_t> getViewOffset(mlir::OpResult) { return 0; }
+  }];
+
+  let hasVerifier = 1;
+}
+
+def fir_DeclareValueOp
+    : fir_Op<"declare_value", [MemoryEffects<[MemAlloc<DebuggingResource>]>]> {
+  let summary = "declare a value";
+
+  let description = [{
+    Tie the properties of a simple scalar Fortran variable to a value.
+    The value must be a scalar integer, real, complex, or logical.
+    This is the value based version of fir.declare. It is used to keep track
+    of variable properties and debug info after mem2reg promotion.
+  }];
+
+  let arguments = (ins AnyType:$value,
+      Optional<fir_DummyScopeType>:$dummy_scope,
+      Builtin_StringAttr:$uniq_name,
+      OptionalAttr<fir_FortranVariableFlagsAttr>:$fortran_attrs,
+      OptionalAttr<cuf_DataAttributeAttr>:$data_attr,
+      OptionalAttr<UI32Attr>:$dummy_arg_no);
+
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $value
+    (`dummy_scope` $dummy_scope^ (`arg` $dummy_arg_no^)?)?
+    attr-dict `:` type($value)
   }];
 
   let hasVerifier = 1;

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3485,6 +3485,13 @@ def fir_DeclareValueOp
     The value must be a scalar integer, real, complex, or logical.
     This is the value based version of fir.declare. It is used to keep track
     of variable properties and debug info after mem2reg promotion.
+
+    Note that there is currently nothing that allows pinning this operation
+    relatively to the operation using the value of the variable,
+    this means that the when a mem2reg variable was assigned several
+    values, the variable value printed in the debugger at a given code
+    point main not be the actual value the variable had at that code point
+    if instructions using the value were moved above the fir.declare_value.
   }];
 
   let arguments = (ins AnyType:$value,

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -237,6 +237,27 @@ public:
     return mlir::success();
   }
 };
+
+struct DeclareValueOpConversion
+    : public fir::FIROpConversion<fir::DeclareValueOp> {
+public:
+  using FIROpConversion::FIROpConversion;
+  llvm::LogicalResult
+  matchAndRewrite(fir::DeclareValueOp declareOp, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto value = adaptor.getOperands()[0];
+    if (auto fusedLoc = mlir::dyn_cast<mlir::FusedLoc>(declareOp.getLoc())) {
+      if (auto varAttr =
+              mlir::dyn_cast_or_null<mlir::LLVM::DILocalVariableAttr>(
+                  fusedLoc.getMetadata())) {
+        mlir::LLVM::DbgValueOp::create(rewriter, value.getLoc(), value, varAttr,
+                                       nullptr);
+      }
+    }
+    rewriter.eraseOp(declareOp);
+    return mlir::success();
+  }
+};
 } // namespace
 
 namespace {
@@ -4528,7 +4549,7 @@ void fir::populateFIRToLLVMConversionPatterns(
       BoxTypeCodeOpConversion, BoxTypeDescOpConversion, CallOpConversion,
       CmpcOpConversion, VolatileCastOpConversion, ConvertOpConversion,
       CoordinateOpConversion, CopyOpConversion, DTEntryOpConversion,
-      DeclareOpConversion,
+      DeclareOpConversion, DeclareValueOpConversion,
       DoConcurrentSpecifierOpConversion<fir::LocalitySpecifierOp>,
       DoConcurrentSpecifierOpConversion<fir::DeclareReductionOp>,
       DivcOpConversion, EmboxOpConversion, EmboxCharOpConversion,

--- a/flang/test/Fir/declare_value-codegen.fir
+++ b/flang/test/Fir/declare_value-codegen.fir
@@ -1,0 +1,17 @@
+// RUN: fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s | FileCheck %s
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<>} {
+  func.func @test_codegen(%arg0: i32) {
+    fir.declare_value %arg0 {uniq_name = "test"} : i32 loc(#loc1)
+    return
+  }
+}
+
+#di_file = #llvm.di_file<"test.f90" in "">
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_Fortran95, file = #di_file, producer = "Flang", isOptimized = false, emissionKind = Full>
+#di_subprogram = #llvm.di_subprogram<compileUnit = #di_compile_unit, scope = #di_file, name = "test_codegen", file = #di_file, subprogramFlags = Definition>
+#di_local_variable = #llvm.di_local_variable<scope = #di_subprogram, name = "test", file = #di_file, line = 1, arg = 1, alignInBits = 0, type = #llvm.di_basic_type<tag = DW_TAG_base_type, name = "integer", sizeInBits = 32, encoding = DW_ATE_signed>>
+#loc1 = loc(fused<#di_local_variable>["test.f90":1:1])
+
+// CHECK-LABEL: llvm.func @test_codegen
+// CHECK: llvm.intr.dbg.value

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -1048,3 +1048,15 @@ func.func @test_if_weights(%cond: i1) {
   }
   return
 }
+
+// CHECK-LABEL: func @test_declare_value(
+// CHECK-SAME: %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: !fir.dscope) {
+func.func @test_declare_value(%arg0: i32, %scope: !fir.dscope) {
+// CHECK: fir.declare_value %[[VAL_0]] {uniq_name = "test"} : i32
+  fir.declare_value %arg0 {uniq_name = "test"} : i32
+// CHECK: fir.declare_value %[[VAL_0]] dummy_scope %[[VAL_1]] {uniq_name = "test"} : i32
+  fir.declare_value %arg0 dummy_scope %scope {uniq_name = "test"} : i32
+// CHECK: fir.declare_value %[[VAL_0]] dummy_scope %[[VAL_1]] arg 1 {uniq_name = "test"} : i32
+  fir.declare_value %arg0 dummy_scope %scope arg 1 {uniq_name = "test"} : i32
+  return
+}

--- a/flang/test/Fir/invalid.fir
+++ b/flang/test/Fir/invalid.fir
@@ -1483,3 +1483,11 @@ func.func @fir_declare_bad_storage_offset(%arg0: !fir.ref<i8>, %arg1: !fir.ref<!
   %decl = fir.declare %arg0 storage (%arg1[2]) {uniq_name = "a"} : (!fir.ref<i8>, !fir.ref<!fir.array<1xi8>>) -> !fir.ref<i8>
   return
 }
+
+// -----
+
+func.func @bad_declare_value(%arg0: !fir.ref<i32>) {
+  // expected-error@+1 {{'fir.declare_value' op value must be a simple scalar (integer, real, complex, or logical)}}
+  fir.declare_value %arg0 {uniq_name = "test"} : !fir.ref<i32>
+  return
+}

--- a/flang/test/Fir/mem2reg.mlir
+++ b/flang/test/Fir/mem2reg.mlir
@@ -66,3 +66,120 @@ func.func @cycle(%arg0: i64, %arg1: i1, %arg2: i64) {
 ^bb2:
   cf.br ^bb1
 }
+
+// -----
+
+// CHECK-LABEL: func.func @test_simple_declare(%arg0: !fir.ref<i32> {fir.bindc_name = "i"}) {
+// CHECK: %[[C42:.*]] = arith.constant 42 : i32
+// CHECK: %[[SCOPE:.*]] = fir.dummy_scope : !fir.dscope
+// CHECK: %[[ARG_DECL:.*]] = fir.declare %arg0 dummy_scope %[[SCOPE]] arg 1 {uniq_name = "_QFfooEi"} : (!fir.ref<i32>, !fir.dscope) -> !fir.ref<i32>
+// CHECK: fir.declare_value %[[C42]] {uniq_name = "_QFfooEj"} : i32
+// CHECK: fir.store %[[C42]] to %[[ARG_DECL]] : !fir.ref<i32>
+func.func @test_simple_declare(%arg0: !fir.ref<i32> {fir.bindc_name = "i"}) {
+    %c42_i32 = arith.constant 42 : i32
+    %0 = fir.dummy_scope : !fir.dscope
+    %1 = fir.declare %arg0 dummy_scope %0 arg 1 {uniq_name = "_QFfooEi"} : (!fir.ref<i32>, !fir.dscope) -> !fir.ref<i32>
+    %2 = fir.alloca i32 {bindc_name = "j", uniq_name = "_QFfooEj"}
+    %3 = fir.declare %2 {uniq_name = "_QFfooEj"} : (!fir.ref<i32>) -> !fir.ref<i32>
+    fir.store %c42_i32 to %3 : !fir.ref<i32>
+    %4 = fir.load %3 : !fir.ref<i32>
+    fir.store %4 to %1 : !fir.ref<i32>
+    return
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @test_two_values(
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 43 : i32
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 42 : i32
+// CHECK:           fir.declare_value %[[CONSTANT_1]] {uniq_name = "_QFfooEjlocal"} : i32
+// CHECK:           fir.store %[[CONSTANT_1]] to %{{.*}} : !fir.ref<i32>
+// CHECK:           fir.declare_value %[[CONSTANT_0]] {uniq_name = "_QFfooEjlocal"} : i32
+// CHECK:           fir.store %[[CONSTANT_0]] to %{{.*}} : !fir.ref<i32>
+
+func.func @test_two_values(%arg0: !fir.ref<i32> {fir.bindc_name = "i"}, %arg1: !fir.ref<i32> {fir.bindc_name = "j"}) {
+  %c43_i32 = arith.constant 43 : i32
+  %c42_i32 = arith.constant 42 : i32
+  %0 = fir.dummy_scope : !fir.dscope
+  %1 = fir.declare %arg0 dummy_scope %0 arg 1 {uniq_name = "_QFfooEi"} : (!fir.ref<i32>, !fir.dscope) -> !fir.ref<i32>
+  %2 = fir.declare %arg1 dummy_scope %0 arg 2 {uniq_name = "_QFfooEj"} : (!fir.ref<i32>, !fir.dscope) -> !fir.ref<i32>
+  %3 = fir.alloca i32 {bindc_name = "jlocal", uniq_name = "_QFfooEjlocal"}
+  %4 = fir.declare %3 {uniq_name = "_QFfooEjlocal"} : (!fir.ref<i32>) -> !fir.ref<i32>
+  fir.store %c42_i32 to %4 : !fir.ref<i32>
+  %5 = fir.load %4 : !fir.ref<i32>
+  fir.store %5 to %1 : !fir.ref<i32>
+  fir.store %c43_i32 to %4 : !fir.ref<i32>
+  %6 = fir.load %4 : !fir.ref<i32>
+  fir.store %6 to %2 : !fir.ref<i32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @array_val_not_mem2reg(
+// CHECK:           fir.alloca !fir.array<2xi32>
+// CHECK:           fir.store
+// CHECK:           fir.load
+// CHECK:           fir.store
+
+func.func @array_val_not_mem2reg(%arg0: !fir.ref<!fir.array<2xi32>> {fir.bindc_name = "i"}, %arg1: !fir.ref<i32> {fir.bindc_name = "j"}, %arrayval : !fir.array<2xi32>) {
+  %c2 = arith.constant 2 : index
+  %0 = fir.dummy_scope : !fir.dscope
+  %1 = fir.shape %c2 : (index) -> !fir.shape<1>
+  %2 = fir.declare %arg0(%1) dummy_scope %0 arg 1 {uniq_name = "_QFarrayEi"} : (!fir.ref<!fir.array<2xi32>>, !fir.shape<1>, !fir.dscope) -> !fir.ref<!fir.array<2xi32>>
+  %3 = fir.declare %arg1 dummy_scope %0 arg 2 {uniq_name = "_QFarrayEj"} : (!fir.ref<i32>, !fir.dscope) -> !fir.ref<i32>
+  %4 = fir.alloca !fir.array<2xi32> {bindc_name = "jlocal", uniq_name = "_QFarrayEjlocal"}
+  %5 = fir.declare %4(%1) {uniq_name = "_QFarrayEjlocal"} : (!fir.ref<!fir.array<2xi32>>, !fir.shape<1>) -> !fir.ref<!fir.array<2xi32>>
+  fir.store %arrayval to %5 : !fir.ref<!fir.array<2xi32>>
+  %val_load = fir.load %5 : !fir.ref<!fir.array<2xi32>>
+  fir.store %val_load to %2 : !fir.ref<!fir.array<2xi32>>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @box_not_mem2reg(
+// CHECK:           fir.alloca !fir.box<f32>
+// CHECK:           fir.store
+// CHECK:           fir.load
+// CHECK:           fir.store
+
+func.func @box_not_mem2reg(%arg0: !fir.ref<!fir.box<f32>> {fir.bindc_name = "i"}, %arg1: !fir.ref<i32> {fir.bindc_name = "j"}, %arrayval : !fir.box<f32>) {
+  %0 = fir.dummy_scope : !fir.dscope
+  %2 = fir.declare %arg0 dummy_scope %0 arg 1 {uniq_name = "_QFarrayEi"} : (!fir.ref<!fir.box<f32>>, !fir.dscope) -> !fir.ref<!fir.box<f32>>
+  %3 = fir.declare %arg1 dummy_scope %0 arg 2 {uniq_name = "_QFarrayEj"} : (!fir.ref<i32>, !fir.dscope) -> !fir.ref<i32>
+  %4 = fir.alloca !fir.box<f32> {bindc_name = "jlocal", uniq_name = "_QFarrayEjlocal"}
+  %5 = fir.declare %4 {uniq_name = "_QFarrayEjlocal"} : (!fir.ref<!fir.box<f32>>) -> !fir.ref<!fir.box<f32>>
+  fir.store %arrayval to %5 : !fir.ref<!fir.box<f32>>
+  %val_load = fir.load %5 : !fir.ref<!fir.box<f32>>
+  fir.store %val_load to %2 : !fir.ref<!fir.box<f32>>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @block_argument_value(
+// CHECK-SAME:      %[[ARG0:.*]]: i32,
+// CHECK-SAME:      %[[ARG1:.*]]: i1) -> i32 {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 42 : i32
+// CHECK:           fir.declare_value %[[CONSTANT_0]] {uniq_name = "_QFfooEjlocal"} : i32
+// CHECK:           llvm.cond_br %[[ARG1]], ^bb1, ^bb2
+// CHECK:         ^bb1:
+// CHECK:           fir.declare_value %[[ARG0]] {uniq_name = "_QFfooEjlocal"} : i32
+// CHECK:           llvm.br ^bb2
+// CHECK:         ^bb2:
+// CHECK:           return %[[CONSTANT_0]] : i32
+// CHECK:         }
+func.func @block_argument_value(%arg0: i32, %cdt: i1) -> i32 {
+  %c42_i32 = arith.constant 42 : i32
+  %3 = fir.alloca i32 {bindc_name = "jlocal", uniq_name = "_QFfooEjlocal"}
+  %4 = fir.declare %3 {uniq_name = "_QFfooEjlocal"} : (!fir.ref<i32>) -> !fir.ref<i32>
+  fir.store %c42_i32 to %4 : !fir.ref<i32>
+  llvm.cond_br %cdt, ^bb1, ^bb2
+^bb1:
+  fir.store %arg0 to %4 : !fir.ref<i32>
+  llvm.br ^bb2
+^bb2:
+  %6 = fir.load %4 : !fir.ref<i32>
+  return %6 : i32
+}


### PR DESCRIPTION
This patch adds the possibility for MLIR mem2reg to work over fir.declare.
Note that mem2reg is not part of FIR pipeline, and this is just part of work to be able to leverage it.

The patch:
- Adds a fir.declare_value operation
- Implements the PromotableOpInterface for fir.declare simple scalars and replace it by fir.declare_value.
- Generates llvm.dbg.debug_value from it (when a FusedLoc with a DILocalVariableAttr is created for it in AddDebugInfo, like for fir.declare).