### PR TITLE
[OpenACC] add acc.reduction_combine operation

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -21,7 +21,7 @@
 // types and definitions from that file.
 
 //===----------------------------------------------------------------------===//
-// acc.combine
+// acc.reduction_combine
 //===----------------------------------------------------------------------===//
 
 def OpenACC_ReductionCombineOp: OpenACC_Op<"reduction_combine", 

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -24,7 +24,8 @@
 // acc.combine
 //===----------------------------------------------------------------------===//
 
-def OpenACC_ReductionCombineOp: OpenACC_Op<"reduction_combine", [SameTypeOperands, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def OpenACC_ReductionCombineOp: OpenACC_Op<"reduction_combine", 
+    [SameTypeOperands, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "Combine a reduction partial sum with its original value";
   let description = [{
     This operation is a composite to do a typical update of a reduction

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -21,6 +21,47 @@
 // types and definitions from that file.
 
 //===----------------------------------------------------------------------===//
+// acc.combine
+//===----------------------------------------------------------------------===//
+
+def OpenACC_CombineOp: OpenACC_Op<"combine", [SameTypeOperands, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "Combine a reduction partial sum with its original value";
+  let description = [{
+    This operation is a composite to do a typical update of a reduction
+    variable. The intention of this operator is to facilitate codegen
+    decisions (such as generate an atomic update). E.g.
+
+    ```
+      lro.combine %src into %dest <addi> : memref<i32>
+    ```
+
+    Might lower to something similar to
+
+    ```
+      %loadSrc = memref.load %src[] : memref<i32>
+      %loadDest = memref.load %dest[] : memref<i32>
+      %combine = arith.addi %loadSrc, %loadDest : i32
+      memref.store %combine, %dest[] : memref<i32>
+    ```
+    
+    The $destMemref operand is a "pointer" to the original reduction 
+    variable (typically shared). The $srcMemref operand is a "pointer"
+    to the partial sum of the reduction (typically private).
+
+    The $kind is the OpenACC reduction operator that determines how to 
+    accumulate the two values.
+  }];
+
+  let arguments = (ins AnyType:$destMemref,
+                       AnyType:$srcMemref,
+                       OpenACC_ReductionOperatorAttr:$reductionOperator);
+  
+  let assemblyFormat = [{
+    $srcMemref `into` $destMemref $reductionOperator `:` type($destMemref) attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // acc.kernel_environment
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -24,7 +24,7 @@
 // acc.combine
 //===----------------------------------------------------------------------===//
 
-def OpenACC_CombineOp: OpenACC_Op<"combine", [SameTypeOperands, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def OpenACC_ReductionCombineOp: OpenACC_Op<"reduction_combine", [SameTypeOperands, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "Combine a reduction partial sum with its original value";
   let description = [{
     This operation is a composite to do a typical update of a reduction
@@ -32,7 +32,7 @@ def OpenACC_CombineOp: OpenACC_Op<"combine", [SameTypeOperands, DeclareOpInterfa
     decisions (such as generate an atomic update). E.g.
 
     ```
-      lro.combine %src into %dest <addi> : memref<i32>
+      acc.reduction_combine %src into %dest <addi> : memref<i32>
     ```
 
     Might lower to something similar to
@@ -52,8 +52,8 @@ def OpenACC_CombineOp: OpenACC_Op<"combine", [SameTypeOperands, DeclareOpInterfa
     accumulate the two values.
   }];
 
-  let arguments = (ins AnyType:$destMemref,
-                       AnyType:$srcMemref,
+  let arguments = (ins OpenACC_AnyPointerOrMappableType:$destMemref,
+                       OpenACC_AnyPointerOrMappableType:$srcMemref,
                        OpenACC_ReductionOperatorAttr:$reductionOperator);
   
   let assemblyFormat = [{

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -5129,6 +5129,23 @@ LogicalResult acc::WaitOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// CombineOp
+//===----------------------------------------------------------------------===//
+void acc::CombineOp::getEffects(
+    llvm::SmallVectorImpl<
+        mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(mlir::MemoryEffects::Read::get(), &getSrcMemrefMutable(),
+                       mlir::SideEffects::DefaultResource::get());
+  effects.emplace_back(mlir::MemoryEffects::Read::get(),
+                       &getDestMemrefMutable(),
+                       mlir::SideEffects::DefaultResource::get());
+  effects.emplace_back(mlir::MemoryEffects::Write::get(),
+                       &getDestMemrefMutable(),
+                       mlir::SideEffects::DefaultResource::get());
+}
+
 #define GET_OP_CLASSES
 #include "mlir/Dialect/OpenACC/OpenACCOps.cpp.inc"
 

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -5130,9 +5130,9 @@ LogicalResult acc::WaitOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// CombineOp
+// ReductionCombineOp
 //===----------------------------------------------------------------------===//
-void acc::CombineOp::getEffects(
+void acc::ReductionCombineOp::getEffects(
     llvm::SmallVectorImpl<
         mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>>
         &effects) {

--- a/mlir/test/Dialect/OpenACC/ops.mlir
+++ b/mlir/test/Dialect/OpenACC/ops.mlir
@@ -2497,10 +2497,10 @@ func.func @test_kernel_environment_with_async(%arg0: memref<1024xf32>) {
 
 // -----
 
-func.func @test_acc_combine(%arg0 : memref<i32>, %arg1 : memref<i32>) {
-  acc.combine %arg0 into %arg1 <add> : memref<i32>
+func.func @test_acc_reduction_combine(%arg0 : memref<i32>, %arg1 : memref<i32>) {
+  acc.reduction_combine %arg0 into %arg1 <add> : memref<i32>
   return
 }
 
-// CHECK-LABEL: func @test_acc_combine
-// CHECK:       acc.combine %arg0 into %arg1 <add> : memref<i32>
+// CHECK-LABEL: func @test_acc_reduction_combine
+// CHECK:       acc.reduction_combine %arg0 into %arg1 <add> : memref<i32>

--- a/mlir/test/Dialect/OpenACC/ops.mlir
+++ b/mlir/test/Dialect/OpenACC/ops.mlir
@@ -2494,3 +2494,13 @@ func.func @test_kernel_environment_with_async(%arg0: memref<1024xf32>) {
 // CHECK:           gpu.launch
 // CHECK:             memref.store %{{.*}}, %[[CREATE]]
 // CHECK:         acc.copyout accPtr(%[[CREATE]] : memref<1024xf32>) async(%[[ASYNC]] : i32) to varPtr(%{{.*}} : memref<1024xf32>)
+
+// -----
+
+func.func @test_acc_combine(%arg0 : memref<i32>, %arg1 : memref<i32>) {
+  acc.combine %arg0 into %arg1 <add> : memref<i32>
+  return
+}
+
+// CHECK-LABEL: func @test_acc_combine
+// CHECK:       acc.combine %arg0 into %arg1 <add> : memref<i32>


### PR DESCRIPTION
To facilitate codegen decisions, we need to create an operation that can abstract the final update of the original and partial sum from a reduction. This is represented within the combiner recipes. Having an operator allows future lowering to clearly identify how to handle the final accumulation. This is currently an NFC.

The format of this operation is:

```
  acc.reduction_combine %srcMemref into %destMemref <reductionOperator> : type
```