### PR TITLE
[clangd] Add abseil-unchecked-statusor-access to list of ignored checks

### DIFF
--- a/clang-tools-extra/clangd/TidyProvider.cpp
+++ b/clang-tools-extra/clangd/TidyProvider.cpp
@@ -222,7 +222,8 @@ TidyProvider disableUnusableChecks(llvm::ArrayRef<std::string> ExtraBadChecks) {
       "-hicpp-invalid-access-moved",
       // Check uses dataflow analysis, which might hang/crash unexpectedly on
       // incomplete code.
-      "-bugprone-unchecked-optional-access");
+      "-bugprone-unchecked-optional-access",
+      "-abseil-unchecked-statusor-access");
 
   size_t Size = BadChecks.size();
   for (const std::string &Str : ExtraBadChecks) {


### PR DESCRIPTION
This [check](https://clang.llvm.org/extra/clang-tidy/checks/abseil/unchecked-statusor-access.html) also depends on dataflow framework.