### PR TITLE
[clang-tidy] Fix readability-else-after-return for if statements appear in unbraced switch case labels

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ElseAfterReturnCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ElseAfterReturnCheck.cpp
@@ -177,12 +177,17 @@ void ElseAfterReturnCheck::registerMatchers(MatchFinder *Finder) {
              hasElse(stmt().bind("else")))
           .bind("if");
 
-  Finder->addMatcher(
-      compoundStmt(
-          forEach(stmt(anyOf(IfWithInterruptingThenElse,
-                             switchCase(has(IfWithInterruptingThenElse))))))
-          .bind("cs"),
-      this);
+  const auto SwitchCaseWithTargetIf = switchCase(anyOf(
+      switchCase(has(IfWithInterruptingThenElse)),
+      switchCase(hasDescendant(switchCase(has(IfWithInterruptingThenElse))))));
+
+  const auto LabelWithTargetIf = labelStmt(has(IfWithInterruptingThenElse));
+
+  Finder->addMatcher(compoundStmt(forEach(stmt(anyOf(IfWithInterruptingThenElse,
+                                                     SwitchCaseWithTargetIf,
+                                                     LabelWithTargetIf))))
+                         .bind("cs"),
+                     this);
 }
 
 static bool hasPreprocessorBranchEndBetweenLocations(

--- a/clang-tools-extra/clang-tidy/readability/ElseAfterReturnCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ElseAfterReturnCheck.cpp
@@ -39,6 +39,12 @@ private:
   const SourceManager &SM;
 };
 
+AST_MATCHER_P(Stmt, stripLabelLikeStatements,
+              ast_matchers::internal::Matcher<Stmt>, InnerMatcher) {
+  const Stmt *S = Node.stripLabelLikeStatements();
+  return InnerMatcher.matches(*S, Finder, Builder);
+}
+
 } // namespace
 
 static constexpr char InterruptingStr[] = "interrupting";
@@ -177,15 +183,8 @@ void ElseAfterReturnCheck::registerMatchers(MatchFinder *Finder) {
              hasElse(stmt().bind("else")))
           .bind("if");
 
-  const auto SwitchCaseWithTargetIf = switchCase(anyOf(
-      switchCase(has(IfWithInterruptingThenElse)),
-      switchCase(hasDescendant(switchCase(has(IfWithInterruptingThenElse))))));
-
-  const auto LabelWithTargetIf = labelStmt(has(IfWithInterruptingThenElse));
-
-  Finder->addMatcher(compoundStmt(forEach(stmt(anyOf(IfWithInterruptingThenElse,
-                                                     SwitchCaseWithTargetIf,
-                                                     LabelWithTargetIf))))
+  Finder->addMatcher(compoundStmt(forEach(stripLabelLikeStatements(
+                                      IfWithInterruptingThenElse)))
                          .bind("cs"),
                      this);
 }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -231,6 +231,10 @@ Changes in existing checks
   <clang-tidy/checks/readability/container-size-empty>` check by fixing a crash
   when a member expression has a non-identifier name.
 
+- Improved :doc:`readability-else-after-return
+  <clang-tidy/checks/readability/else-after-return>` check by fixing missed
+  diagnostics when ``if`` statements appear in unbraced ``switch`` case labels
+
 - Improved :doc:`readability-enum-initial-value
   <clang-tidy/checks/readability/enum-initial-value>` check: the warning message
   now uses separate note diagnostics for each uninitialized enumerator, making

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -233,7 +233,7 @@ Changes in existing checks
 
 - Improved :doc:`readability-else-after-return
   <clang-tidy/checks/readability/else-after-return>` check by fixing missed
-  diagnostics when ``if`` statements appear in unbraced ``switch`` case labels
+  diagnostics when ``if`` statements appear in unbraced ``switch`` case labels.
 
 - Improved :doc:`readability-enum-initial-value
   <clang-tidy/checks/readability/enum-initial-value>` check: the warning message

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/else-after-return.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/else-after-return.cpp
@@ -312,3 +312,19 @@ void testPPConditionals() {
   }
 #endif
 }
+
+void testSwitchCaseWithoutInnerCompound(int i, bool b) {
+  switch (i) {
+  case 0:
+    if (b) {
+      return;
+    } else {
+      // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: do not use 'else' after 'return'
+      // CHECK-FIXES: {{^}}    }
+      f(0);
+    }
+    break;
+  default:
+    break;
+  }
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/else-after-return.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/else-after-return.cpp
@@ -313,18 +313,93 @@ void testPPConditionals() {
 #endif
 }
 
-void testSwitchCaseWithoutInnerCompound(int i, bool b) {
+void testSwitchCases(int i, bool b, bool b2) {
+  // Case statement without braces.
   switch (i) {
   case 0:
     if (b) {
       return;
-    } else {
+    } else { // comment-18
       // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: do not use 'else' after 'return'
-      // CHECK-FIXES: {{^}}    }
+      // CHECK-FIXES: {{^}}    } // comment-18
+      f(1);
+    }
+  }
+
+  // Fallthrough.
+  switch (i) {
+  case 0:
+  case 1:
+  case 2:
+    if (b)
+      return;
+    else // comment-19
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: do not use 'else' after 'return'
+      // CHECK-FIXES: {{^}} // comment-19
+      return;
+  }
+
+  switch (i) {
+  case 1:
+  case 2:
+    if (b)
       f(0);
+    else if (b2)
+      return;
+    else // comment-20
+      // CHECK-FIXES-NOT: {{^}}  // comment-20
+      f(1);
+  }
+
+  switch (i) {
+  case 0:
+    if (b) {
+      if (b2)
+        return;
+      else // comment-21
+        // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: do not use 'else' after 'return'
+        // CHECK-FIXES: {{^}}    // comment-21
+        f(0);
+    } else {
+      if (b && b2)
+        return;
+      else // comment-22
+        // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: do not use 'else' after 'return'
+        // CHECK-FIXES: {{^}}    // comment-22
+        f(0);
+    }
+  }
+
+  // Nested switch.
+  switch (i) {
+  case 0:
+  case 1:
+    switch (3) {
+    case 0:
+      if (b) {
+        return;
+      } else { // comment-23
+        // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: do not use 'else' after 'return'
+        // CHECK-FIXES: {{^}}      } // comment-23
+        f(0);
+      }
+      break;
+    default:
+      break;
     }
     break;
   default:
     break;
   }
+}
+
+void testLabels(bool b) {
+  goto LABEL;
+LABEL:
+  if (b)
+    return;
+  else // comment-25
+    // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: do not use 'else' after 'return'
+    // CHECK-FIXES: {{^}} // comment-25
+    return;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/else-after-return.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/else-after-return.cpp
@@ -391,15 +391,56 @@ void testSwitchCases(int i, bool b, bool b2) {
   default:
     break;
   }
+
+  switch (i) {
+  case 1:
+    if (b)
+      return;
+    else // comment-24
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: do not use 'else' after 'return'
+      // CHECK-FIXES-NOT: {{^}}   // comment-24
+      int _ = 20;
+    break;
+  case 2:
+    break;
+  }
+
+  switch (i) {
+  case 1:
+  case 2:
+  [[clang::annotate("TestWithAttributedStmt")]]
+  case 3:
+    if (b) {
+      return;
+    } else { // comment-25
+      // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: do not use 'else' after 'return'
+      // CHECK-FIXES: {{^}}      } // comment-25
+        f(0);
+    }
+  }
 }
 
 void testLabels(bool b) {
   goto LABEL;
+  goto LABEL2;
+
 LABEL:
   if (b)
     return;
-  else // comment-25
+  else // comment-26
     // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: do not use 'else' after 'return'
-    // CHECK-FIXES: {{^}} // comment-25
+    // CHECK-FIXES: {{^}} // comment-26
     return;
+
+  switch ((int)b) {
+  case 1:
+  case 2:
+  LABEL2:
+    if (0)
+      return;
+    else  // comment-27
+      // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: do not use 'else' after 'return'
+      // CHECK-FIXES: {{^}} // comment-27
+      f(0);
+  }
 }


### PR DESCRIPTION
- Updates matcher registration in ElseAfterReturnCheck to also handle switchCase(has(ifStmt(...))) patterns
- Adds a regression test for the unbraced switch-case scenario

Fixes #160033