### PR TITLE
[lldb] Add test for Swift syntax highligher plugin

### DIFF
--- a/lldb/unittests/Highlighter/HighlighterTest.cpp
+++ b/lldb/unittests/Highlighter/HighlighterTest.cpp
@@ -57,6 +57,10 @@ TEST_F(HighlighterTest, HighlighterSelectionType) {
   EXPECT_EQ(getName(lldb::eLanguageTypeObjC), "clang");
   EXPECT_EQ(getName(lldb::eLanguageTypeObjC_plus_plus), "clang");
 
+#if LLDB_ENABLE_TREESITTER
+  EXPECT_EQ(getName(lldb::eLanguageTypeSwift), "tree-sitter-swift");
+#endif
+
   EXPECT_EQ(getName(lldb::eLanguageTypeUnknown), "none");
   EXPECT_EQ(getName(lldb::eLanguageTypeJulia), "none");
   EXPECT_EQ(getName(lldb::eLanguageTypeHaskell), "none");


### PR DESCRIPTION
Check that if tree-sitter support is enabled, the tree-sitter-swift plugin is used for eLanguageTypeSwift. This part of the test accidentally got lost during a conflict resolution.