### PR TITLE
[RISCV] Remove VMConstraint from VAESKF1_VI/VAESKF2_VI.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvk.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvk.td
@@ -168,10 +168,12 @@ let Predicates = [HasStdExtZvkned] in {
   defm VAESDM     : VAES_MV_V_S<0b101000, 0b101001, 0b00000, OPMVV, "vaesdm">;
   defm VAESEF     : VAES_MV_V_S<0b101000, 0b101001, 0b00011, OPMVV, "vaesef">;
   defm VAESEM     : VAES_MV_V_S<0b101000, 0b101001, 0b00010, OPMVV, "vaesem">;
-  def  VAESKF1_VI : PALUVINoVm<0b100010, "vaeskf1.vi", uimm5>,
-                    SchedUnaryMC<"WriteVAESKF1V", "ReadVAESKF1V">;
-  def  VAESKF2_VI : PALUVINoVmBinary<0b101010, "vaeskf2.vi", uimm5>,
-                    SchedBinaryMC<"WriteVAESKF2V", "ReadVAESKF2V", "ReadVAESKF2V">;
+  let RVVConstraint = NoConstraint in {
+    def  VAESKF1_VI : PALUVINoVm<0b100010, "vaeskf1.vi", uimm5>,
+                      SchedUnaryMC<"WriteVAESKF1V", "ReadVAESKF1V">;
+    def  VAESKF2_VI : PALUVINoVmBinary<0b101010, "vaeskf2.vi", uimm5>,
+                      SchedBinaryMC<"WriteVAESKF2V", "ReadVAESKF2V", "ReadVAESKF2V">;
+  }
   let RVVConstraint = VS2Constraint in
   def  VAESZ_VS   : PALUVs2NoVmBinary<0b101001, 0b00111, OPMVV, "vaesz.vs">,
                     SchedBinaryMC<"WriteVAESZV", "ReadVAESZV", "ReadVAESZV">;

--- a/llvm/test/MC/RISCV/rvv/zvkned.s
+++ b/llvm/test/MC/RISCV/rvv/zvkned.s
@@ -68,6 +68,12 @@ vaeskf1.vi v10, v9, 31
 # CHECK-ERROR: instruction requires the following: 'Zvkned' (Vector AES Encryption & Decryption (Single Round)){{$}}
 # CHECK-UNKNOWN: 8a9fa577 <unknown>
 
+vaeskf1.vi v0, v9, 1
+# CHECK-INST: vaeskf1.vi v0, v9, 1
+# CHECK-ENCODING: [0x77,0xa0,0x90,0x8a]
+# CHECK-ERROR: instruction requires the following: 'Zvkned' (Vector AES Encryption & Decryption (Single Round)){{$}}
+# CHECK-UNKNOWN: 8a90a077 <unknown>
+
 vaeskf2.vi v10, v9, 2
 # CHECK-INST: vaeskf2.vi v10, v9, 2
 # CHECK-ENCODING: [0x77,0x25,0x91,0xaa]
@@ -79,6 +85,12 @@ vaeskf2.vi v10, v9, 31
 # CHECK-ENCODING: [0x77,0xa5,0x9f,0xaa]
 # CHECK-ERROR: instruction requires the following: 'Zvkned' (Vector AES Encryption & Decryption (Single Round)){{$}}
 # CHECK-UNKNOWN: aa9fa577 <unknown>
+
+vaeskf2.vi v0, v9, 2
+# CHECK-INST: vaeskf2.vi v0, v9, 2
+# CHECK-ENCODING: [0x77,0x20,0x91,0xaa]
+# CHECK-ERROR: instruction requires the following: 'Zvkned' (Vector AES Encryption & Decryption (Single Round)){{$}}
+# CHECK-UNKNOWN: aa912077 <unknown>
 
 vaesz.vs v10, v9
 # CHECK-INST: vaesz.vs v10, v9


### PR DESCRIPTION
These instructions don't have a VM operand. If these instruction use a V0 destination, the VMConstraint code calls getReg() on the the last operand which is an immmediate. This triggers an assertion. Not sure what happens on a release build. It probably treats the immediate as a value in the RISCV register info enum.