### PR TITLE
[modules] Fix warning: missing submodule 'LLVM_IR.FunctionProperties'

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -276,6 +276,7 @@ module LLVM_IR {
   // These are intended for (repeated) textual inclusion.
   textual header "llvm/IR/ConstrainedOps.def"
   textual header "llvm/IR/DebugInfoFlags.def"
+  textual header "llvm/IR/FunctionProperties.def"
   textual header "llvm/IR/Instruction.def"
   textual header "llvm/IR/Metadata.def"
   textual header "llvm/IR/FixedMetadataKinds.def"


### PR DESCRIPTION
When compiling LLVM with LLVM_ENABLE_MODULES=ON, I get the warning

```
warning: missing submodule 'LLVM_IR.FunctionProperties' [-Wincomplete-umbrella]
```

Fix is to add file `FunctionProperties.def` to the module map.