### PR TITLE
Fix ICE on invalid when defining a friend function in a template

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -284,6 +284,7 @@ Bug Fixes to C++ Support
 - Fixed a crash when a default argument is passed to an explicit object parameter. (#GH176639)
 - Fixed a crash when diagnosing an invalid static member function with an explicit object parameter (#GH177741)
 - Fixed a crash when evaluating uninitialized GCC vector/ext_vector_type vectors in ``constexpr``. (#GH180044)
+- Fixed a crash when defining an invalid friend template specialisation inside a template struct. (#GH181603)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -5894,14 +5894,18 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
                                 return cast<FunctionTemplateDecl>(RTD)
                                     ->isCompatibleWithDefinition();
                               });
-      assert(It != Primary->redecls().end() &&
-             "Should't get here without a definition");
-      if (FunctionDecl *Def = cast<FunctionTemplateDecl>(*It)
-                                  ->getTemplatedDecl()
-                                  ->getDefinition())
-        DC = Def->getLexicalDeclContext();
-      else
-        DC = (*It)->getLexicalDeclContext();
+      if (It != Primary->redecls().end()) {
+        if (FunctionDecl *Def = cast<FunctionTemplateDecl>(*It)
+                                    ->getTemplatedDecl()
+                                    ->getDefinition())
+          DC = Def->getLexicalDeclContext();
+        else
+          DC = (*It)->getLexicalDeclContext();
+      } else {
+        assert((Function->getFriendObjectKind() != Decl::FOK_None &&
+                Function->isThisDeclarationADefinition()) &&
+               "Should't get here without a definition");
+      }
       Innermost.emplace(Function->getTemplateSpecializationArgs()->asArray());
     }
     MultiLevelTemplateArgumentList TemplateArgs = getTemplateInstantiationArgs(

--- a/clang/test/SemaTemplate/GH55509.cpp
+++ b/clang/test/SemaTemplate/GH55509.cpp
@@ -110,6 +110,19 @@ namespace regression2 {
   }
   template void A<void>::f<long>();
 } // namespace regression2
+namespace regression3 {
+  template<int f>
+  void h();
+  template<int a>
+  struct b {
+      friend void h<1>(){} 
+      // expected-error@-1 {{friend function specialization cannot be defined}}
+  };
+  template struct b<5>;
+  void d(){
+    h<1>();
+  }
+} // namespace regression3
 
 namespace GH139226 {
 


### PR DESCRIPTION
This PR fixes #181603 

The logic added in #125266 failed to account for cases where a function template is instantiated from a friend definition that is not a TSK_ExplicitSpecialization. In these scenarios the find_if search on the primary template redeclaration chain would fail because the definition is hidden within the lexical context of the class.

Updated the assertion logic to check if the function is a friend object and isThisDeclarationADefinition() returns true before asserting.

ICE is fixed and all clang tests pass