### PR TITLE
[RISCV] Remove VMConstraint from ri.vzero.v

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXRivos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXRivos.td
@@ -117,10 +117,16 @@ defm : RIVPatBinaryVL_VV<ri_vunzip2b_vl, "PseudoRI_VUNZIP2B">;
 let Predicates = [HasVendorXRivosVisni], DecoderNamespace = "XRivos",
   mayLoad = false, mayStore = false, hasSideEffects = false in {
 
-let vm = 0, vs2=0, Inst<6-0> = OPC_CUSTOM_2.Value,
-    isReMaterializable = 1, isAsCheapAsAMove = 1 in
+let isReMaterializable = 1, isAsCheapAsAMove = 1 in
 def RI_VZERO : RVInstVUnary<0b000000, 0b00000, OPCFG, (outs VR:$vd),
-                            (ins), "ri.vzero.v", "$vd">;
+                            (ins), "ri.vzero.v", "$vd"> {
+  let vm = 0;
+  let vs2 = 0;
+
+  let Inst{6-0} = OPC_CUSTOM_2.Value;
+
+  let RVVConstraint = NoConstraint;
+}
 
 def RI_VINSERT : CustomRivosVXI<0b010000, OPMVX, (outs VR:$vd_wb),
                                 (ins VR:$vd, GPR:$rs1, uimm5:$imm),

--- a/llvm/test/MC/RISCV/xrivosvisni-valid.s
+++ b/llvm/test/MC/RISCV/xrivosvisni-valid.s
@@ -9,8 +9,8 @@
 # RUN:     | llvm-objdump --mattr=+experimental-xrivosvisni -M no-aliases --no-print-imm-hex -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
-# CHECK-ASM-AND-OBJ: ri.vzero.v v1
-# CHECK-ASM: encoding: [0xdb,0x70,0x00,0x00]
+# CHECK-ASM-AND-OBJ: ri.vzero.v v0
+# CHECK-ASM: encoding: [0x5b,0x70,0x00,0x00]
 ri.vzero.v v0
 # CHECK-ASM-AND-OBJ: ri.vzero.v v1
 # CHECK-ASM: encoding: [0xdb,0x70,0x00,0x00]

--- a/llvm/test/MC/RISCV/xrivosvisni-valid.s
+++ b/llvm/test/MC/RISCV/xrivosvisni-valid.s
@@ -11,6 +11,9 @@
 
 # CHECK-ASM-AND-OBJ: ri.vzero.v v1
 # CHECK-ASM: encoding: [0xdb,0x70,0x00,0x00]
+ri.vzero.v v0
+# CHECK-ASM-AND-OBJ: ri.vzero.v v1
+# CHECK-ASM: encoding: [0xdb,0x70,0x00,0x00]
 ri.vzero.v v1
 # CHECK-ASM-AND-OBJ: ri.vzero.v v2
 # CHECK-ASM: encoding: [0x5b,0x71,0x00,0x00]


### PR DESCRIPTION
This instruction doesn't have a VM operand.

It only has 1 operand, VD. The way the VMConstraint check is implemented, if VD is V0 it would compare the last operand to V0. Since the last operand is VD, this would always match and generate an error.

While I was here, move the encoding related let statements into the class body for consistency with RISCVInstrInfoV.td.