### PR TITLE
[ThreadSafety][NFC] Cleanup indentation and unnecessary comments

### DIFF
--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -1727,9 +1727,6 @@ class BuildLockset : public ConstStmtVisitor<BuildLockset> {
   FactSet FSet;
   // The fact set for the function on exit.
   const FactSet &FunctionExitFSet;
-  // Use `LVarCtx` to keep track of the context at each program point, which
-  // will be used to translate variables (by `SExprBuilder::translateVariable`)
-  // to their canonical definitions:
   LocalVariableMap::Context LVarCtx;
   unsigned CtxIndex;
 

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -7487,20 +7487,20 @@ void testPointerAliasEscapeAndReset(Foo *f) {
 // A function that may do anything to the objects referred to by the inputs.
 void escapeAliasMultiple(void *, void *, void *);
 void testPointerAliasEscapeMultiple(Foo *F) {
-    Foo *L;
-    F->mu.Lock(); // expected-note{{mutex acquired here}}
-    Foo *Fp = F;
-    escapeAliasMultiple(&L, &L, &Fp);
-    Fp->mu.Unlock(); // expected-warning{{releasing mutex 'Fp->mu' that was not held}}
+  Foo *L;
+  F->mu.Lock(); // expected-note{{mutex acquired here}}
+  Foo *Fp = F;
+  escapeAliasMultiple(&L, &L, &Fp);
+  Fp->mu.Unlock(); // expected-warning{{releasing mutex 'Fp->mu' that was not held}}
 } // expected-warning{{mutex 'F->mu' is still held at the end of function}}
 
 void unlockFooWithEscapablePointer(Foo **Fp) EXCLUSIVE_UNLOCK_FUNCTION((*Fp)->mu);
 void testEscapeInvalidationHappensRightAfterTheCall(Foo* F) {
-    Foo* L;
-    L = F;
-    L->mu.Lock();
-    // Release the lock held by 'L' before clearing its definition.
-    unlockFooWithEscapablePointer(&L);
+  Foo* L;
+  L = F;
+  L->mu.Lock();
+  // Release the lock held by 'L' before clearing its definition.
+  unlockFooWithEscapablePointer(&L);
 }
 
 void testEscapeInvalidationHappensRightAfterTheCtorCall(Foo* F) {


### PR DESCRIPTION
This is a follow-up commit to #178952 for indentation and comments cleanups.