### PR TITLE
[InstCombine] Do not perform fcmp -> icmp transformation if denormal inputs may be flushed

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8905,7 +8905,9 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
   // Ignore signbit of bitcasted int when comparing equality to FP 0.0:
   // fcmp oeq/une (bitcast X), 0.0 --> (and X, SignMaskC) ==/!= 0
   if (match(Op1, m_PosZeroFP()) &&
-      match(Op0, m_OneUse(m_ElementWiseBitCast(m_Value(X))))) {
+      match(Op0, m_OneUse(m_ElementWiseBitCast(m_Value(X)))) &&
+      !F.getDenormalMode(Op1->getType()->getScalarType()->getFltSemantics())
+           .inputsMayBeZero()) {
     ICmpInst::Predicate IntPred = ICmpInst::BAD_ICMP_PREDICATE;
     if (Pred == FCmpInst::FCMP_OEQ)
       IntPred = ICmpInst::ICMP_EQ;

--- a/llvm/test/Transforms/InstCombine/fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp.ll
@@ -1285,10 +1285,10 @@ define <1 x i1> @bitcast_1vec_eq0(i32 %x) {
   ret <1 x i1> %cmp
 }
 
-; negative test - denormal inputs flushed to zero
+; negative test - denormal inputs flushed to zero (positivezero)
 
-define i1 @bitcast_eq0_denorm_positivezero(i32 %x) denormal_fpenv(positivezero) {
-; CHECK-LABEL: @bitcast_eq0_denorm_positivezero(
+define i1 @bitcast_eq0_denorm_positivezero_input(i32 %x) denormal_fpenv(positivezero) {
+; CHECK-LABEL: @bitcast_eq0_denorm_positivezero_input(
 ; CHECK-NEXT:    [[F:%.*]] = bitcast i32 [[X:%.*]] to float
 ; CHECK-NEXT:    [[R:%.*]] = fcmp oeq float [[F]], 0.000000e+00
 ; CHECK-NEXT:    ret i1 [[R]]
@@ -1298,19 +1298,44 @@ define i1 @bitcast_eq0_denorm_positivezero(i32 %x) denormal_fpenv(positivezero) 
   ret i1 %r
 }
 
-; negative test - denormal inputs flushed to zero
+; negative test - denormal inputs flushed to zero (positivezero), outputs are not (ieee)
 
-define <2 x i1> @bitcast_ne0_denorm_positivezero(<2 x i32> %x) denormal_fpenv(positivezero) {
-; CHECK-LABEL: @bitcast_ne0_denorm_positivezero(
+define i1 @bitcast_eq0_denorm_positivezero_input_ieee_output(i32 %x) denormal_fpenv(ieee|positivezero) {
+; CHECK-LABEL: @bitcast_eq0_denorm_positivezero_input_ieee_output(
+; CHECK-NEXT:    [[F:%.*]] = bitcast i32 [[X:%.*]] to float
+; CHECK-NEXT:    [[R:%.*]] = fcmp oeq float [[F]], 0.000000e+00
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %f = bitcast i32 %x to float
+  %r = fcmp oeq float %f, 0.0
+  ret i1 %r
+}
+
+; negative test - denormal inputs flushed to zero (preservesign)
+
+define <2 x i1> @bitcast_ne0_denorm_preservesign_input(<2 x i32> %x) denormal_fpenv(preservesign) {
+; CHECK-LABEL: @bitcast_ne0_denorm_preservesign_input(
 ; CHECK-NEXT:    [[F:%.*]] = bitcast <2 x i32> [[X:%.*]] to <2 x float>
 ; CHECK-NEXT:    [[R:%.*]] = fcmp une <2 x float> [[F]], zeroinitializer
 ; CHECK-NEXT:    ret <2 x i1> [[R]]
 ;
   %f = bitcast <2 x i32> %x to <2 x float>
-  %r = fcmp une <2 x float> %f, <float 0.0, float 0.0>
+  %r = fcmp une <2 x float> %f, zeroinitializer
   ret <2 x i1> %r
 }
 
+; negative test - denormal inputs flushed to zero (dynamic)
+
+define <2 x i1> @bitcast_ne0_denorm_dynamic_input(<2 x i32> %x) denormal_fpenv(dynamic) {
+; CHECK-LABEL: @bitcast_ne0_denorm_dynamic_input(
+; CHECK-NEXT:    [[F:%.*]] = bitcast <2 x i32> [[X:%.*]] to <2 x float>
+; CHECK-NEXT:    [[R:%.*]] = fcmp une <2 x float> [[F]], zeroinitializer
+; CHECK-NEXT:    ret <2 x i1> [[R]]
+;
+  %f = bitcast <2 x i32> %x to <2 x float>
+  %r = fcmp une <2 x float> %f, zeroinitializer
+  ret <2 x i1> %r
+}
 
 ; Simplify fcmp (x + 0.0), y => fcmp x, y
 

--- a/llvm/test/Transforms/InstCombine/fcmp.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp.ll
@@ -1285,6 +1285,33 @@ define <1 x i1> @bitcast_1vec_eq0(i32 %x) {
   ret <1 x i1> %cmp
 }
 
+; negative test - denormal inputs flushed to zero
+
+define i1 @bitcast_eq0_denorm_positivezero(i32 %x) denormal_fpenv(positivezero) {
+; CHECK-LABEL: @bitcast_eq0_denorm_positivezero(
+; CHECK-NEXT:    [[F:%.*]] = bitcast i32 [[X:%.*]] to float
+; CHECK-NEXT:    [[R:%.*]] = fcmp oeq float [[F]], 0.000000e+00
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %f = bitcast i32 %x to float
+  %r = fcmp oeq float %f, 0.0
+  ret i1 %r
+}
+
+; negative test - denormal inputs flushed to zero
+
+define <2 x i1> @bitcast_ne0_denorm_positivezero(<2 x i32> %x) denormal_fpenv(positivezero) {
+; CHECK-LABEL: @bitcast_ne0_denorm_positivezero(
+; CHECK-NEXT:    [[F:%.*]] = bitcast <2 x i32> [[X:%.*]] to <2 x float>
+; CHECK-NEXT:    [[R:%.*]] = fcmp une <2 x float> [[F]], zeroinitializer
+; CHECK-NEXT:    ret <2 x i1> [[R]]
+;
+  %f = bitcast <2 x i32> %x to <2 x float>
+  %r = fcmp une <2 x float> %f, <float 0.0, float 0.0>
+  ret <2 x i1> %r
+}
+
+
 ; Simplify fcmp (x + 0.0), y => fcmp x, y
 
 define i1 @fcmp_fadd_zero_ugt(float %x, float %y) {


### PR DESCRIPTION
Commit 4827771234276 added the following transformation:

  fcmp oeq/une (bitcast X), 0.0 --> (and X, SignMaskC) ==/!= 0

This transformation is only valid if denormal inputs are preserved. If they are flushed, the two comparisons can return different results.