### PR TITLE
[libc] Fix OS when using `-llvm` OS in the triple

### DIFF
--- a/libc/cmake/modules/LLVMLibCArchitectures.cmake
+++ b/libc/cmake/modules/LLVMLibCArchitectures.cmake
@@ -70,7 +70,7 @@ function(get_arch_and_system_from_triple triple arch_var sys_var)
   endif()
 
   # Setting OS name for GPU architectures.
-  list(GET triple_comps -1 gpu_target_sys)
+  list(GET triple_comps 2 gpu_target_sys)
   if(gpu_target_sys MATCHES "^amdhsa" OR gpu_target_sys MATCHES "^cuda" OR target_arch MATCHES "^spirv")
     set(target_sys "gpu")
   endif()


### PR DESCRIPTION
Summary:
We spoof the OS name for the GPU targets and used to get it form the
'end' of the triple list. Adding `-llvm` makes that now point to `-llvm`
which is not recognized so it fails. Just use the direct index, we
already guard that the triple is the correct size
