### PR TITLE
[OFFLOAD] Add GPU wrappers for headers currently supported by SPIRV built libc

### DIFF
--- a/clang/lib/Headers/llvm_libc_wrappers/ctype.h
+++ b/clang/lib/Headers/llvm_libc_wrappers/ctype.h
@@ -9,13 +9,14 @@
 #ifndef __CLANG_LLVM_LIBC_WRAPPERS_CTYPE_H__
 #define __CLANG_LLVM_LIBC_WRAPPERS_CTYPE_H__
 
-#if !defined(_OPENMP) && !defined(__HIP__) && !defined(__CUDA__)
+#if !defined(_OPENMP) && !defined(__HIP__) && !defined(__CUDA__) &&            \
+    !defined(__SPIRV__)
 #error "This file is for GPU offloading compilation only"
 #endif
 
 #include_next <ctype.h>
 
-#if defined(__HIP__) || defined(__CUDA__)
+#if defined(__HIP__) || defined(__CUDA__) || defined(__SPIRV__)
 #define __LIBC_ATTRS __attribute__((device))
 #else
 #define __LIBC_ATTRS

--- a/clang/lib/Headers/llvm_libc_wrappers/string.h
+++ b/clang/lib/Headers/llvm_libc_wrappers/string.h
@@ -9,13 +9,14 @@
 #ifndef __CLANG_LLVM_LIBC_WRAPPERS_STRING_H__
 #define __CLANG_LLVM_LIBC_WRAPPERS_STRING_H__
 
-#if !defined(_OPENMP) && !defined(__HIP__) && !defined(__CUDA__)
+#if !defined(_OPENMP) && !defined(__HIP__) && !defined(__CUDA__) &&            \
+    !defined(__SPIRV__)
 #error "This file is for GPU offloading compilation only"
 #endif
 
 #include_next <string.h>
 
-#if defined(__HIP__) || defined(__CUDA__)
+#if defined(__HIP__) || defined(__CUDA__) || defined(__SPIRV__)
 #define __LIBC_ATTRS __attribute__((device))
 #else
 #define __LIBC_ATTRS


### PR DESCRIPTION
This is to add GPU wrappers for headers that are currently supported by libc built for SPIRV. 