### PR TITLE
[SLP][NFC] Update partial_vec_invalid_cost() test to avoid breakage by #181731

### DIFF
--- a/llvm/test/Transforms/SLPVectorizer/RISCV/partial-vec-invalid-cost.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/partial-vec-invalid-cost.ll
@@ -7,12 +7,13 @@ define void @partial_vec_invalid_cost() #0 {
 ; CHECK-LABEL: define void @partial_vec_invalid_cost(
 ; CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[LSHR_1:%.*]] = lshr i96 0, 0
+; CHECK-NEXT:    [[LSHR_1:%.*]] = lshr i96 0, 1
 ; CHECK-NEXT:    [[LSHR_2:%.*]] = lshr i96 0, 0
+; CHECK-NEXT:    [[ADD_1:%.*]] = add i96 -1, 1
 ; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <4 x i96> poison, i96 [[LSHR_1]], i32 0
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <4 x i96> [[TMP0]], i96 [[LSHR_2]], i32 1
 ; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x i96> [[TMP1]], i96 0, i32 2
-; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <4 x i96> [[TMP2]], i96 0, i32 3
+; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <4 x i96> [[TMP2]], i96 [[ADD_1]], i32 3
 ; CHECK-NEXT:    [[TMP4:%.*]] = trunc <4 x i96> [[TMP3]] to <4 x i32>
 ; CHECK-NEXT:    [[RDX_OP:%.*]] = or <4 x i32> zeroinitializer, [[TMP4]]
 ; CHECK-NEXT:    [[OP_RDX3:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[RDX_OP]])
@@ -22,10 +23,10 @@ define void @partial_vec_invalid_cost() #0 {
 ;
 entry:
 
-  %lshr.1 = lshr i96 0, 0 ; These ops
+  %lshr.1 = lshr i96 0, 1 ; These ops
   %lshr.2 = lshr i96 0, 0 ; return an
   %add.0 = add i96 0, 0   ; invalid
-  %add.1 = add i96 0, 0   ; vector cost.
+  %add.1 = add i96 -1, 1   ; vector cost.
 
   %trunc.i96.1 = trunc i96 %lshr.1 to i32 ; These ops
   %trunc.i96.2 = trunc i96 %lshr.2 to i32 ; return an


### PR DESCRIPTION
This test creates an invalid vector cost, but #181731 allows transforming of lshr 0, 0 -> add 0, 0 which in turn allows costing of the following TreeEntry since is will be considered as 4 `ADD` operations.
```
%lshr.1 = lshr i96 0, 0
%lshr.2 = lshr i96 0, 0
%add.0 = add i96 0, 0
%add.1 = add i96 0, 0
```
This commit adjusts the operands to ensure an invalid cost is still generated after #181731.

This test was originally added in 4652ec0e291ca4ba4ddef3fd59b202646e9a6694.