### PR TITLE
[NFC][CodeGen] Refactor subregister index verification for MIR

### DIFF
--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -2824,10 +2824,9 @@ MachineVerifier::visitMachineOperand(const MachineOperand *MO, unsigned MONum) {
       if (!DRC)
         break;
 
-      // If SubIdx is used, validate that RC with SubIdx can be used for an
+      // If SubIdx is used, verify that RC with SubIdx can be used for an
       // operand of class DRC. This is valid if for every register in RC, the
-      // register obtained by applying SubIdx to it is in DRC, i.e.,
-      // getMatchingSuperRegClass(RC, DRC, SubIdx) returns RC.
+      // register obtained by applying SubIdx to it is in DRC.
       if (SubIdx && TRI->getMatchingSuperRegClass(RC, DRC, SubIdx) != RC) {
         report("Illegal virtual register for instruction", MO, MONum);
         OS << TRI->getRegClassName(RC) << "." << TRI->getSubRegIndexName(SubIdx)
@@ -2835,7 +2834,7 @@ MachineVerifier::visitMachineOperand(const MachineOperand *MO, unsigned MONum) {
            << " operands.";
       }
 
-      // If no SubIdx is used, just that that RC is a sub-class of DRC.
+      // If no SubIdx is used, verify that RC is a sub-class of DRC.
       if (!SubIdx && !RC->hasSuperClassEq(DRC)) {
         report("Illegal virtual register for instruction", MO, MONum);
         OS << "Expected a " << TRI->getRegClassName(DRC)

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -2818,28 +2818,29 @@ MachineVerifier::visitMachineOperand(const MachineOperand *MO, unsigned MONum) {
           return;
         }
       }
-      if (MONum < MCID.getNumOperands()) {
-        if (const TargetRegisterClass *DRC = TII->getRegClass(MCID, MONum)) {
-          if (SubIdx) {
-            const TargetRegisterClass *SuperRC =
-                TRI->getLargestLegalSuperClass(RC, *MF);
-            if (!SuperRC) {
-              report("No largest legal super class exists.", MO, MONum);
-              return;
-            }
-            DRC = TRI->getMatchingSuperRegClass(SuperRC, DRC, SubIdx);
-            if (!DRC) {
-              report("No matching super-reg register class.", MO, MONum);
-              return;
-            }
-          }
-          if (!RC->hasSuperClassEq(DRC)) {
-            report("Illegal virtual register for instruction", MO, MONum);
-            OS << "Expected a " << TRI->getRegClassName(DRC)
-               << " register, but got a " << TRI->getRegClassName(RC)
-               << " register\n";
-          }
-        }
+      if (MONum >= MCID.getNumOperands())
+        break;
+      const TargetRegisterClass *DRC = TII->getRegClass(MCID, MONum);
+      if (!DRC)
+        break;
+
+      // If SubIdx is used, validate that RC with SubIdx can be used for an
+      // operand of class DRC. This is valid if for every register in RC, the
+      // register obtained by applying SubIdx to it is in DRC, i.e.,
+      // getMatchingSuperRegClass(RC, DRC, SubIdx) returns RC.
+      if (SubIdx && TRI->getMatchingSuperRegClass(RC, DRC, SubIdx) != RC) {
+        report("Illegal virtual register for instruction", MO, MONum);
+        OS << TRI->getRegClassName(RC) << "." << TRI->getSubRegIndexName(SubIdx)
+           << " cannot be used for " << TRI->getRegClassName(DRC)
+           << " operands.";
+      }
+
+      // If no SubIdx is used, just that that RC is a sub-class of DRC.
+      if (!SubIdx && !RC->hasSuperClassEq(DRC)) {
+        report("Illegal virtual register for instruction", MO, MONum);
+        OS << "Expected a " << TRI->getRegClassName(DRC)
+           << " register, but got a " << TRI->getRegClassName(RC)
+           << " register\n";
       }
     }
     break;

--- a/llvm/test/MachineVerifier/AMDGPU/unsupported-subreg-index-aligned-vgpr-check.mir
+++ b/llvm/test/MachineVerifier/AMDGPU/unsupported-subreg-index-aligned-vgpr-check.mir
@@ -36,6 +36,17 @@ body:             |
     ; CHECK-NEXT: Register class VReg_512 does not support subreg index sub16_sub17_sub18_sub19
     S_NOP 0, implicit-def %2:vreg_512
     GLOBAL_STORE_DWORDX4_SADDR %0, %2.sub16_sub17_sub18_sub19, undef $sgpr8_sgpr9, 80, 0, implicit $exec :: (store (s128), addrspace 1)
+
+    ; Test valid subregister index, but invalid effective register class.
+    ; CHECK: *** Bad machine code: Illegal virtual register for instruction ***
+    ; CHECK-NEXT: - function:    uses_invalid_subregister_for_regclass
+    ; CHECK-NEXT: - basic block: %bb.0
+    ; CHECK-NEXT: - instruction: GLOBAL_STORE_DWORDX4_SADDR %0:vgpr_32, %2.sub0:vreg_512, undef $sgpr8_sgpr9, 80, 0, implicit $exec :: (store (s128), addrspace 1)
+    ; CHECK-NEXT: - operand 1:   %2.sub0:vreg_512
+    ; CHECK-NEXT: VReg_512.sub0 cannot be used for AV_128_Align2 operands.
+    %3:sreg_32 = COPY %0
+    GLOBAL_STORE_DWORDX4_SADDR %0, %2.sub0, undef $sgpr8_sgpr9, 80, 0, implicit $exec :: (store (s128), addrspace 1)
+
     S_ENDPGM 0
 
 ...


### PR DESCRIPTION
Refactor register class/subreg-index verification against the instruction specified class:
- Avoid inflating the register's class (i.e., no need to call `getLargestLegalSuperClass`).
- Check validity with `getMatchingSuperRegClass(RC, DRC, SubIdx) == RC`.
- Add some explanatory comments for this check.
- Extended a unit test to exercise this verification failure.