### PR TITLE
[SampleProf] Add option to populate profile symbol list from probes

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -1699,16 +1699,12 @@ public:
   }
 
   void merge(const ProfileSymbolList &List) {
+    assert(UseMD5 == List.useMD5() &&
+           "Cannot merge profile symbol lists with different formats");
     if (UseMD5) {
-      if (List.useMD5()) {
-        for (auto Sym : List.HashSyms)
-          HashSyms.insert(Sym);
-      } else {
-        for (auto Sym : List.Syms)
-          HashSyms.insert(MD5Hash(Sym));
-      }
+      for (auto Sym : List.HashSyms)
+        HashSyms.insert(Sym);
     } else {
-      assert(List.useMD5() == false && "Can't merge MD5 list with string list");
       for (auto Sym : List.Syms)
         add(Sym, true);
     }

--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -801,7 +801,7 @@ protected:
                                    SampleProfileMap &Profiles);
   std::error_code readNameTableSec(bool IsMD5, bool FixedLengthMD5);
   std::error_code readCSNameTableSec();
-  std::error_code readProfileSymbolList();
+  std::error_code readProfileSymbolList(bool IsMD5 = false);
 
   std::error_code readHeader() override;
   std::error_code verifySPMagic(uint64_t Magic) override = 0;

--- a/llvm/lib/ProfileData/SampleProf.cpp
+++ b/llvm/lib/ProfileData/SampleProf.cpp
@@ -400,8 +400,8 @@ const FunctionSamples *FunctionSamples::findFunctionSamplesAt(
 LLVM_DUMP_METHOD void FunctionSamples::dump() const { print(dbgs(), 0); }
 #endif
 
-std::error_code ProfileSymbolList::read(const uint8_t *Data,
-                                        uint64_t ListSize, bool IsMD5) {
+std::error_code ProfileSymbolList::read(const uint8_t *Data, uint64_t ListSize,
+                                        bool IsMD5) {
   if (IsMD5) {
     // New format: array of little-endian uint64_t hashes.
     UseMD5 = true;

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -903,10 +903,13 @@ std::error_code SampleProfileReaderExtBinaryBase::readOneSection(
       return EC;
     break;
   }
-  case SecProfileSymbolList:
-    if (std::error_code EC = readProfileSymbolList())
+  case SecProfileSymbolList: {
+    bool IsMD5 =
+        hasSecFlag(Entry, SecProfileSymbolListFlags::SecFlagMD5);
+    if (std::error_code EC = readProfileSymbolList(IsMD5))
       return EC;
     break;
+  }
   default:
     if (std::error_code EC = readCustomSection(Entry))
       return EC;
@@ -1134,11 +1137,12 @@ std::error_code SampleProfileReaderExtBinaryBase::readFuncProfiles() {
   return sampleprof_error::success;
 }
 
-std::error_code SampleProfileReaderExtBinaryBase::readProfileSymbolList() {
+std::error_code
+SampleProfileReaderExtBinaryBase::readProfileSymbolList(bool IsMD5) {
   if (!ProfSymList)
     ProfSymList = std::make_unique<ProfileSymbolList>();
 
-  if (std::error_code EC = ProfSymList->read(Data, End - Data))
+  if (std::error_code EC = ProfSymList->read(Data, End - Data, IsMD5))
     return EC;
 
   Data = End;

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -1591,6 +1591,10 @@ static std::string getSecFlagsStr(const SecHdrTableEntry &Entry) {
     if (hasSecFlag(Entry, SecFuncMetadataFlags::SecFlagHasAttribute))
       Flags.append("attr,");
     break;
+  case SecProfileSymbolList:
+    if (hasSecFlag(Entry, SecProfileSymbolListFlags::SecFlagMD5))
+      Flags.append("md5,");
+    break;
   default:
     break;
   }

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -904,8 +904,7 @@ std::error_code SampleProfileReaderExtBinaryBase::readOneSection(
     break;
   }
   case SecProfileSymbolList: {
-    bool IsMD5 =
-        hasSecFlag(Entry, SecProfileSymbolListFlags::SecFlagMD5);
+    bool IsMD5 = hasSecFlag(Entry, SecProfileSymbolListFlags::SecFlagMD5);
     if (std::error_code EC = readProfileSymbolList(IsMD5))
       return EC;
     break;

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -429,6 +429,9 @@ std::error_code SampleProfileWriterExtBinaryBase::writeOneSection(
   // The setting of SecFlagCompress should happen before markSectionStart.
   if (Type == SecProfileSymbolList && ProfSymList && ProfSymList->toCompress())
     setToCompressSection(SecProfileSymbolList);
+  if (Type == SecProfileSymbolList && ProfSymList && ProfSymList->useMD5())
+    addSectionFlag(SecProfileSymbolList,
+                   SecProfileSymbolListFlags::SecFlagMD5);
   if (Type == SecFuncMetadata && FunctionSamples::ProfileIsProbeBased)
     addSectionFlag(SecFuncMetadata, SecFuncMetadataFlags::SecFlagIsProbeBased);
   if (Type == SecFuncMetadata &&

--- a/llvm/lib/ProfileData/SampleProfWriter.cpp
+++ b/llvm/lib/ProfileData/SampleProfWriter.cpp
@@ -430,8 +430,7 @@ std::error_code SampleProfileWriterExtBinaryBase::writeOneSection(
   if (Type == SecProfileSymbolList && ProfSymList && ProfSymList->toCompress())
     setToCompressSection(SecProfileSymbolList);
   if (Type == SecProfileSymbolList && ProfSymList && ProfSymList->useMD5())
-    addSectionFlag(SecProfileSymbolList,
-                   SecProfileSymbolListFlags::SecFlagMD5);
+    addSectionFlag(SecProfileSymbolList, SecProfileSymbolListFlags::SecFlagMD5);
   if (Type == SecFuncMetadata && FunctionSamples::ProfileIsProbeBased)
     addSectionFlag(SecFuncMetadata, SecFuncMetadataFlags::SecFlagIsProbeBased);
   if (Type == SecFuncMetadata &&

--- a/llvm/test/tools/llvm-profgen/populate-profile-symbol-list-from-probes.test
+++ b/llvm/test/tools/llvm-profgen/populate-profile-symbol-list-from-probes.test
@@ -1,0 +1,26 @@
+; Test --populate-profile-symbol-list-from-probes flag for llvm-profgen.
+; This flag populates the profile symbol list from pseudo probe descriptors
+; using MD5 hashes instead of strings.
+
+; Generate extbinary profile with probe-based symbol list.
+; RUN: llvm-profgen --format=extbinary --perfscript=%S/Inputs/noinline-cs-pseudoprobe.perfscript --binary=%S/Inputs/noinline-cs-pseudoprobe.perfbin --output=%t --populate-profile-symbol-list-from-probes
+
+; Verify the ProfileSymbolListSection has the md5 flag set and is non-empty.
+; RUN: llvm-profdata show -sample -show-sec-info-only %t | FileCheck %s --check-prefix=CHECK-SEC
+; CHECK-SEC: ProfileSymbolListSection {{.*}} Size: {{[1-9][0-9]*}}, Flags: {md5}
+
+; Show the MD5-based symbol list and verify it contains hex hashes (one per source function).
+; RUN: llvm-profdata show -sample -show-prof-sym-list %t | FileCheck %s --check-prefix=CHECK-SYMLIST
+; CHECK-SYMLIST: ======== Dump profile symbol list ========
+; CHECK-SYMLIST-NEXT: 0x{{[0-9a-f]+}}
+; CHECK-SYMLIST-NEXT: 0x{{[0-9a-f]+}}
+; CHECK-SYMLIST-NEXT: 0x{{[0-9a-f]+}}
+
+; Test round-trip: merge the extbinary profile and verify the symbol list is preserved.
+; RUN: llvm-profdata merge --sample --extbinary %t -o %t.merged
+; RUN: llvm-profdata show -sample -show-prof-sym-list %t.merged | FileCheck %s --check-prefix=CHECK-SYMLIST
+
+; Verify --drop-profile-symbol-list removes the symbol list.
+; RUN: llvm-profdata merge --sample --extbinary --drop-profile-symbol-list %t -o %t.dropped
+; RUN: llvm-profdata show -sample -show-sec-info-only %t.dropped | FileCheck %s --check-prefix=CHECK-DROPPED
+; CHECK-DROPPED: ProfileSymbolListSection {{.*}} Size: 0

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -1655,8 +1655,17 @@ static void mergeSampleProfile(const WeightedFileVector &Inputs,
     if (!DropProfileSymbolList) {
       std::unique_ptr<sampleprof::ProfileSymbolList> ReaderList =
           Reader->getProfileSymbolList();
-      if (ReaderList)
+      if (ReaderList) {
+        if (WriterList.size() == 0) {
+          WriterList.setUseMD5(ReaderList->useMD5());
+        } else if (ReaderList->useMD5() != WriterList.useMD5()) {
+          exitWithError(
+              "cannot merge profile symbol lists with different formats "
+              "(MD5 vs string); use --drop-profile-symbol-list to drop them",
+              Input.Filename);
+        }
         WriterList.merge(*ReaderList);
+      }
     }
   }
 

--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -1091,6 +1091,17 @@ void ProfiledBinary::populateSymbolListFromDWARF(
     SymbolList.add(I.second.getFuncName());
 }
 
+void ProfiledBinary::populateSymbolListFromProbes(
+    ProfileSymbolList &SymbolList) {
+  // Pseudo probe descriptors contain all source functions including those
+  // that were fully inlined and have no outlined copy in the binary. Use
+  // them as they provide the most complete symbol list.
+  // Use MD5 hashes for efficiency.
+  SymbolList.setUseMD5(true);
+  for (const auto &I : ProbeDecoder.getGUID2FuncDescMap())
+    SymbolList.add(I.FuncGUID); // GUID = MD5Hash(FuncName)
+}
+
 symbolize::LLVMSymbolizer::Options ProfiledBinary::getSymbolizerOpts() const {
   symbolize::LLVMSymbolizer::Options SymbolizerOpts;
   SymbolizerOpts.PrintFunctions =

--- a/llvm/tools/llvm-profgen/ProfiledBinary.h
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.h
@@ -578,6 +578,9 @@ public:
   // Load the symbols from debug table and populate into symbol list.
   void populateSymbolListFromDWARF(ProfileSymbolList &SymbolList);
 
+  // Populate symbol list from pseudo probe descriptors (MD5 hashes).
+  void populateSymbolListFromProbes(ProfileSymbolList &SymbolList);
+
   SampleContextFrameVector
   getFrameLocationStack(uint64_t Address, bool UseProbeDiscriminator = false) {
     InstructionPointer IP(this, Address);

--- a/llvm/unittests/ProfileData/SampleProfTest.cpp
+++ b/llvm/unittests/ProfileData/SampleProfTest.cpp
@@ -455,6 +455,78 @@ TEST_F(SampleProfTest, sample_overflow_saturation) {
   ASSERT_EQ(BodySamples.get(), Max);
 }
 
+TEST_F(SampleProfTest, md5_profile_symbol_list_roundtrip) {
+  // Test that an MD5-based ProfileSymbolList round-trips through
+  // write and read in ExtBinary format.
+  TempFile ProfileFile("profile", "", "", /*Unique*/ true);
+  createWriter(SampleProfileFormat::SPF_Ext_Binary, ProfileFile.path());
+
+  StringRef FooName("_Z3fooi");
+  FunctionSamples FooSamples;
+  FooSamples.setFunction(FunctionId(FooName));
+  FooSamples.addTotalSamples(100);
+  FooSamples.addHeadSamples(10);
+  FooSamples.addBodySamples(1, 0, 100);
+
+  SampleProfileMap Profiles;
+  Profiles[FooName] = std::move(FooSamples);
+
+  Module M("my_module", Context);
+  FunctionType *FnType = FunctionType::get(Type::getVoidTy(Context), {}, false);
+  M.getOrInsertFunction(FooName, FnType);
+
+  // Create an MD5-based ProfileSymbolList using pre-computed hashes,
+  // matching the path used by populateSymbolListFromProbes.
+  ProfileSymbolList List;
+  List.setUseMD5(true);
+  uint64_t ZooHash = MD5Hash("zoo");
+  uint64_t MooHash = MD5Hash("moo");
+  uint64_t FooHash = MD5Hash("_Z3fooi");
+  List.add(ZooHash);
+  List.add(MooHash);
+  List.add(FooHash);
+  Writer->setProfileSymbolList(&List);
+
+  std::error_code EC;
+  EC = Writer->write(Profiles);
+  ASSERT_TRUE(NoError(EC));
+  Writer->getOutputStream().flush();
+
+  // Read back and verify.
+  readProfile(M, ProfileFile.path());
+  EC = Reader->read();
+  ASSERT_TRUE(NoError(EC));
+
+  std::unique_ptr<ProfileSymbolList> ReaderList =
+      Reader->getProfileSymbolList();
+  ASSERT_TRUE(ReaderList != nullptr);
+  ASSERT_TRUE(ReaderList->useMD5());
+  ASSERT_EQ(3u, ReaderList->size());
+  ASSERT_TRUE(ReaderList->contains("zoo"));
+  ASSERT_TRUE(ReaderList->contains("moo"));
+  ASSERT_TRUE(ReaderList->contains("_Z3fooi"));
+  ASSERT_FALSE(ReaderList->contains("nonexistent"));
+}
+
+TEST_F(SampleProfTest, md5_profile_symbol_list_merge) {
+  // Test that merging two MD5-based ProfileSymbolLists works correctly.
+  ProfileSymbolList List1;
+  List1.setUseMD5(true);
+  List1.add("foo");
+  List1.add("bar");
+
+  ProfileSymbolList List2;
+  List2.setUseMD5(true);
+  List2.add("bar");
+  List2.add("baz");
+
+  List1.merge(List2);
+  ASSERT_EQ(3u, List1.size());
+  ASSERT_TRUE(List1.contains("foo"));
+  ASSERT_TRUE(List1.contains("bar"));
+  ASSERT_TRUE(List1.contains("baz"));
+}
+
 TEST_F(SampleProfTest, default_suffix_elision_text) {
   // Default suffix elision policy: strip everything after first dot.
   // This implies that all suffix variants will map to "foo", so


### PR DESCRIPTION
Add a new flag `--populate-profile-symbol-list-from-probes` that populates the profile symbol list from pseudo probe descriptors instead of DWARF.

Pseudo probe descriptors contain all source functions including those that were fully inlined and have no outlined copy in the binary. This provides a more complete symbol list for distinguishing cold functions from newly added ones.

Because this significantly increases the number of symbols (e.g., 7X increase for some mid-sized target), the probe-based symbol list uses GUID (MD5) instead of strings to control profile size (e.g., 824MB with strings -> 64MB with MD5 hashes). A special flag is added to the section header to indicate the MD5 format.

Backward compatibility:
Updated compiler can parse both the old and new format. Un-updated compiler cannot parse the new format.  

The two flags work independently:
- Existing `--populate-profile-symbol-list`: Populates from DWARF (string-based)
- New `--populate-profile-symbol-list-from-probes`: Populates from pseudo probe descriptors (MD5 hash-based)