### PR TITLE
[Clang][Docs] Add documentation for the address_space attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -852,7 +852,7 @@ def AbiTag : Attr {
 def AddressSpace : TypeAttr {
   let Spellings = [Clang<"address_space">];
   let Args = [IntArgument<"AddressSpace">];
-  let Documentation = [Undocumented];
+  let Documentation = [AddressSpaceDocs];
 }
 
 def Alias : Attr {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -198,13 +198,15 @@ def AddressSpaceDocs : Documentation {
   let Heading = "address_space";
   let Content = [{
 .. Note:: This attribute is mainly intended to be used by target headers
-  provided by the toolchain. End users should prefer the documented annotations
-  for their platform, such as the `OpenCL address spaces`_, ``__global__``,
-  ``__local__``, or something else.
+  provided by the toolchain. End users should prefer the documented, named
+  address space annotations for their platform, such as the
+  `OpenCL address spaces`_, ``__global__``, ``__local__``, or something else.
 
-The ``address_space`` attribute allows you to specify the address space for a
-pointer or reference type. It takes a single, non-negative integer constant
-expression identifying the address space. For example:
+The ``address_space`` attribute functions as a type qualifier that allows the
+programmer to specify the address space for a pointer or reference type.
+Qualified pointer types are considered distinct types for the purposes of
+overload resolution. The attribute takes a single, non-negative integer
+constant expression identifying the address space. For example:
 
 .. code-block:: c
 
@@ -212,23 +214,29 @@ expression identifying the address space. For example:
 
   void foo(__attribute__((address_space(2))) float *buf);
 
-The meaning of each value is defined by the target; multiple address spaces are
-used in environments such as OpenCL, CUDA, HIP, and other GPU programming
-models to distinguish global, local, constant, and private memory. See for
-example the address spaces defined in the `NVPTX Usage Guide`_ and the `AMDGPU
-Usage Guide`_.
-
-.. _`NVPTX Usage Guide`: https://llvm.org/docs/NVPTXUsage.html#address-spaces
-.. _`AMDGPU Usage Guide`: https://llvm.org/docs/AMDGPUUsage.html#address-spaces
 
 Only one address space qualifier may be applied to a given pointer or reference
 type. Where address spaces are allowed (e.g., variables, parameters, return
 types) and what values are valid depends on the target and language mode.
 
-Address spaces may partially overlap or be entirely distinct.
-The compiler may reject attempts to convert between distinct, incompatible
-address spaces. Pointer width may vary between different address spaces, so
-some explicit casts may truncate.
+The meaning of each value is defined by the target; multiple address spaces are
+used in environments such as OpenCL, CUDA, HIP, and other GPU programming
+models to distinguish global, local, constant, and private memory. See for
+example the address spaces defined in the `NVPTX Usage Guide`_ and the
+`AMDGPU Usage Guide`_.
+
+.. _`NVPTX Usage Guide`: https://llvm.org/docs/NVPTXUsage.html#address-spaces
+.. _`AMDGPU Usage Guide`: https://llvm.org/docs/AMDGPUUsage.html#address-spaces
+
+Address spaces may partially overlap or be entirely distinct. The compiler may
+reject attempts to convert between distinct, incompatible address spaces.
+Pointer width may vary between different address spaces, so some explicit casts
+may truncate.
+
+For more information, refer to `ISO TR18037`_, which covers embedded C language
+extensions. Section 5 covers named address spaces.
+
+.. _`ISO TR18037`: https://standards.iso.org/ittf/PubliclyAvailableStandards/c051126_ISO_IEC_TR_18037_2008.zip
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -216,7 +216,7 @@ The meaning of each value is defined by the target; multiple address spaces are
 used in environments such as OpenCL, CUDA, HIP, and other GPU programming
 models to distinguish global, local, constant, and private memory. See for
 example the address spaces defined in the `NVPTX Usage Guide`_ and the `AMDGPU
-Usage Guide`_
+Usage Guide`_.
 
 .. _`NVPTX Usage Guide`: https://llvm.org/docs/NVPTXUsage.html#address-spaces
 .. _`AMDGPU Usage Guide`: https://llvm.org/docs/AMDGPUUsage.html#address-spaces
@@ -224,6 +224,11 @@ Usage Guide`_
 Only one address space qualifier may be applied to a given pointer or reference
 type. Where address spaces are allowed (e.g., variables, parameters, return
 types) and what values are valid depends on the target and language mode.
+
+Address spaces may partially overlap or be entirely distinct.
+The compiler may reject attempts to convert between distinct, incompatible
+address spaces. Pointer width may vary between different address spaces, so
+some explicit casts may truncate.
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -193,6 +193,40 @@ TLS models are mutually exclusive.
   }];
 }
 
+def AddressSpaceDocs : Documentation {
+  let Category = DocCatType;
+  let Heading = "address_space";
+  let Content = [{
+.. Note:: This attribute is mainly intended to be used by target headers
+  provided by the toolchain. End users should prefer the documented annotations
+  for their platform, such as the `OpenCL address spaces`_, ``__global__``,
+  ``__local__``, or something else.
+
+The ``address_space`` attribute allows you to specify the address space for a
+pointer or reference type. It takes a single, non-negative integer constant
+expression identifying the address space. For example:
+
+.. code-block:: c
+
+  int * __attribute__((address_space(1))) ptr;
+
+  void foo(__attribute__((address_space(2))) float *buf);
+
+The meaning of each value is defined by the target; multiple address spaces are
+used in environments such as OpenCL, CUDA, HIP, and other GPU programming
+models to distinguish global, local, constant, and private memory. See for
+example the address spaces defined in the `NVPTX Usage Guide`_ and the `AMDGPU
+Usage Guide`_
+
+.. _`NVPTX Usage Guide`: https://llvm.org/docs/NVPTXUsage.html#address-spaces
+.. _`AMDGPU Usage Guide`: https://llvm.org/docs/AMDGPUUsage.html#address-spaces
+
+Only one address space qualifier may be applied to a given pointer or reference
+type. Where address spaces are allowed (e.g., variables, parameters, return
+types) and what values are valid depends on the target and language mode.
+  }];
+}
+
 def DLLExportDocs : Documentation {
   let Category = DocCatVariable;
   let Content = [{


### PR DESCRIPTION
Someone asked for docs on Discourse:
https://discourse.llvm.org/t/what-are-the-precise-semantics-of-the-address-space-attribute/89752

I was going to respond, and then I decided to respond in the form of a
PR, since I have a doc building environment set up.

I used an LLM, but I ended up rewriting most of the text.
