### PR TITLE
Revert "[clang] Fix some static initialization race-conditions"

### DIFF
--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -40,7 +40,6 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <cstring>
 #include <optional>
@@ -58,23 +57,25 @@ using namespace clang;
 #define ABSTRACT_STMT(STMT)
 #include "clang/AST/StmtNodes.inc"
 
-struct StmtClassNameTable {
+static struct StmtClassNameTable {
   const char *Name;
   unsigned Counter;
   unsigned Size;
-};
+} StmtClassInfo[Stmt::lastStmtConstant+1];
 
 static StmtClassNameTable &getStmtInfoTableEntry(Stmt::StmtClass E) {
-  static std::array<StmtClassNameTable, Stmt::lastStmtConstant + 1>
-      StmtClassInfo = [] {
-        std::array<StmtClassNameTable, Stmt::lastStmtConstant + 1> Table;
+  static bool Initialized = false;
+  if (Initialized)
+    return StmtClassInfo[E];
+
+  // Initialize the table on the first use.
+  Initialized = true;
 #define ABSTRACT_STMT(STMT)
-#define STMT(CLASS, PARENT)                                                    \
-  Table[static_cast<unsigned>(Stmt::CLASS##Class)].Name = #CLASS;              \
-  Table[static_cast<unsigned>(Stmt::CLASS##Class)].Size = sizeof(CLASS);
+#define STMT(CLASS, PARENT) \
+  StmtClassInfo[(unsigned)Stmt::CLASS##Class].Name = #CLASS;    \
+  StmtClassInfo[(unsigned)Stmt::CLASS##Class].Size = sizeof(CLASS);
 #include "clang/AST/StmtNodes.inc"
-        return Table;
-      }();
+
   return StmtClassInfo[E];
 }
 
@@ -84,7 +85,7 @@ void *Stmt::operator new(size_t bytes, const ASTContext& C,
 }
 
 const char *Stmt::getStmtClassName() const {
-  return getStmtInfoTableEntry(static_cast<StmtClass>(StmtBits.sClass)).Name;
+  return getStmtInfoTableEntry((StmtClass) StmtBits.sClass).Name;
 }
 
 // Check that no statement / expression class is polymorphic. LLVM style RTTI
@@ -112,25 +113,19 @@ void Stmt::PrintStats() {
   unsigned sum = 0;
   llvm::errs() << "\n*** Stmt/Expr Stats:\n";
   for (int i = 0; i != Stmt::lastStmtConstant+1; i++) {
-    const StmtClassNameTable &Entry =
-        getStmtInfoTableEntry(static_cast<Stmt::StmtClass>(i));
-    if (Entry.Name == nullptr)
-      continue;
-    sum += Entry.Counter;
+    if (StmtClassInfo[i].Name == nullptr) continue;
+    sum += StmtClassInfo[i].Counter;
   }
   llvm::errs() << "  " << sum << " stmts/exprs total.\n";
   sum = 0;
   for (int i = 0; i != Stmt::lastStmtConstant+1; i++) {
-    const StmtClassNameTable &Entry =
-        getStmtInfoTableEntry(static_cast<Stmt::StmtClass>(i));
-    if (Entry.Name == nullptr)
-      continue;
-    if (Entry.Counter == 0)
-      continue;
-    llvm::errs() << "    " << Entry.Counter << " " << Entry.Name << ", "
-                 << Entry.Size << " each (" << Entry.Counter * Entry.Size
+    if (StmtClassInfo[i].Name == nullptr) continue;
+    if (StmtClassInfo[i].Counter == 0) continue;
+    llvm::errs() << "    " << StmtClassInfo[i].Counter << " "
+                 << StmtClassInfo[i].Name << ", " << StmtClassInfo[i].Size
+                 << " each (" << StmtClassInfo[i].Counter*StmtClassInfo[i].Size
                  << " bytes)\n";
-    sum += Entry.Counter * Entry.Size;
+    sum += StmtClassInfo[i].Counter*StmtClassInfo[i].Size;
   }
 
   llvm::errs() << "Total bytes = " << sum << "\n";

--- a/clang/lib/Basic/ParsedAttrInfo.cpp
+++ b/clang/lib/Basic/ParsedAttrInfo.cpp
@@ -20,16 +20,13 @@ using namespace clang;
 
 LLVM_INSTANTIATE_REGISTRY(ParsedAttrInfoRegistry)
 
-static std::list<std::unique_ptr<ParsedAttrInfo>> instantiateEntries() {
-  std::list<std::unique_ptr<ParsedAttrInfo>> Instances;
-  for (const auto &It : ParsedAttrInfoRegistry::entries())
-    Instances.emplace_back(It.instantiate());
-  return Instances;
-}
-
 const std::list<std::unique_ptr<ParsedAttrInfo>> &
 clang::getAttributePluginInstances() {
-  static std::list<std::unique_ptr<ParsedAttrInfo>> Instances =
-      instantiateEntries();
-  return Instances;
+  static llvm::ManagedStatic<std::list<std::unique_ptr<ParsedAttrInfo>>>
+      PluginAttrInstances;
+  if (PluginAttrInstances->empty())
+    for (const auto &It : ParsedAttrInfoRegistry::entries())
+      PluginAttrInstances->emplace_back(It.instantiate());
+
+  return *PluginAttrInstances;
 }

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -248,8 +248,6 @@ void BackendConsumer::HandleTranslationUnit(ASTContext &C) {
   LLVMContext &Ctx = getModule()->getContext();
   std::unique_ptr<DiagnosticHandler> OldDiagnosticHandler =
     Ctx.getDiagnosticHandler();
-  llvm::scope_exit RestoreDiagnosticHandler(
-      [&]() { Ctx.setDiagnosticHandler(std::move(OldDiagnosticHandler)); });
   Ctx.setDiagnosticHandler(std::make_unique<ClangDiagnosticHandler>(
       CodeGenOpts, this));
 
@@ -312,6 +310,8 @@ void BackendConsumer::HandleTranslationUnit(ASTContext &C) {
   emitBackendOutput(CI, CI.getCodeGenOpts(),
                     C.getTargetInfo().getDataLayoutString(), getModule(),
                     Action, FS, std::move(AsmOutStream), this);
+
+  Ctx.setDiagnosticHandler(std::move(OldDiagnosticHandler));
 
   if (OptRecordFile)
     OptRecordFile->keep();

--- a/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BasicObjCFoundationChecks.cpp
@@ -70,12 +70,16 @@ enum FoundationClass {
 
 static FoundationClass findKnownClass(const ObjCInterfaceDecl *ID,
                                       bool IncludeSuperclasses = true) {
-  static const llvm::StringMap<FoundationClass> Classes{
-      {"NSArray", FC_NSArray},           {"NSDictionary", FC_NSDictionary},
-      {"NSEnumerator", FC_NSEnumerator}, {"NSNull", FC_NSNull},
-      {"NSOrderedSet", FC_NSOrderedSet}, {"NSSet", FC_NSSet},
-      {"NSString", FC_NSString},
-  };
+  static llvm::StringMap<FoundationClass> Classes;
+  if (Classes.empty()) {
+    Classes["NSArray"] = FC_NSArray;
+    Classes["NSDictionary"] = FC_NSDictionary;
+    Classes["NSEnumerator"] = FC_NSEnumerator;
+    Classes["NSNull"] = FC_NSNull;
+    Classes["NSOrderedSet"] = FC_NSOrderedSet;
+    Classes["NSSet"] = FC_NSSet;
+    Classes["NSString"] = FC_NSString;
+  }
 
   // FIXME: Should we cache this at all?
   FoundationClass result = Classes.lookup(ID->getIdentifier()->getName());


### PR DESCRIPTION
Reverts llvm/llvm-project#181367

This is causing crashes in tests on a Windows bot https://lab.llvm.org/buildbot/#/builders/46/builds/30854.