### PR TITLE
[RISCV] Check the error location in xsfvcp-invalid.s. NFC

### DIFF
--- a/llvm/test/MC/RISCV/rvv/xsfvcp-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/xsfvcp-invalid.s
@@ -1,20 +1,20 @@
 # RUN: not llvm-mc -triple=riscv32 --mattr=+v,+xsfvcp %s 2>&1 \
-# RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+# RUN:        | FileCheck %s
 # RUN: not llvm-mc -triple=riscv64 --mattr=+v,+xsfvcp %s 2>&1 \
-# RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+# RUN:        | FileCheck %s
 
 sf.vc.v.vvw 0x3, v0, v2, v0
-# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
-# CHECK-ERROR-LABEL: sf.vc.v.vvw 0x3, v0, v2, v0{{$}}
+# CHECK: :[[@LINE-1]]:18: error: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-LABEL: sf.vc.v.vvw 0x3, v0, v2, v0{{$}}
 
 sf.vc.v.xvw 0x3, v0, v0, a1
-# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
-# CHECK-ERROR-LABEL: sf.vc.v.xvw 0x3, v0, v0, a1{{$}}
+# CHECK: :[[@LINE-1]]:18: error: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-LABEL: sf.vc.v.xvw 0x3, v0, v0, a1{{$}}
 
 sf.vc.v.ivw 0x3, v0, v0, 15
-# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
-# CHECK-ERROR-LABEL: sf.vc.v.ivw 0x3, v0, v0, 15{{$}}
+# CHECK: :[[@LINE-1]]:18: error: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-LABEL: sf.vc.v.ivw 0x3, v0, v0, 15{{$}}
 
 sf.vc.v.fvw 0x1, v0, v0, fa1
-# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
-# CHECK-ERROR-LABEL: sf.vc.v.fvw 0x1, v0, v0, fa1{{$}}
+# CHECK: :[[@LINE-1]]:18: error: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-LABEL: sf.vc.v.fvw 0x1, v0, v0, fa1{{$}}


### PR DESCRIPTION
Check that the error location points to the destination operand.

I'm planning to rewrite the code that generates that error, and I want to make sure I get the location right.