### PR TITLE
[mlir][ArmSME] Replace nested-region assertion in tile allocation with diagnostic

### DIFF
--- a/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
+++ b/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
@@ -367,7 +367,7 @@ generateOperationNumbering(FunctionOpInterface function) {
       operationToIndexMap.try_emplace(&op, index++);
     }
   }
-    
+
   return operationToIndexMap;
 }
 

--- a/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
+++ b/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
@@ -363,14 +363,11 @@ generateOperationNumbering(FunctionOpInterface function) {
         sawNestedArmSMEOp = true;
       });
       if (sawNestedArmSMEOp)
-        break;
+        return failure();
       operationToIndexMap.try_emplace(&op, index++);
     }
-    if (sawNestedArmSMEOp)
-      break;
   }
-  if (sawNestedArmSMEOp)
-    return failure();
+    
   return operationToIndexMap;
 }
 

--- a/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
+++ b/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
@@ -52,7 +52,6 @@
 #include "mlir/Dialect/ArmSME/Transforms/Transforms.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/TypeSwitch.h"

--- a/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
+++ b/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
@@ -352,15 +352,16 @@ generateOperationNumbering(FunctionOpInterface function) {
   for (Block *block : blocks) {
     index++; // We want block args to have their own number.
     for (Operation &op : block->getOperations()) {
-      WalkResult walkResult = op.walk([&](ArmSMETileOpInterface nestedOp) -> WalkResult {
-        if (&op == nestedOp.getOperation())
-          return WalkResult::advance();
-        nestedOp.emitError(
-            "ArmSME tile allocation requires flattened control flow; run "
-            "-convert-scf-to-cf before this pass (e.g. via "
-            "convert-arm-sme-to-llvm pipeline)");
-        return WalkResult::interrupt();
-      });
+      WalkResult walkResult =
+          op.walk([&](ArmSMETileOpInterface nestedOp) -> WalkResult {
+            if (&op == nestedOp.getOperation())
+              return WalkResult::advance();
+            nestedOp.emitError(
+                "ArmSME tile allocation requires flattened control flow; run "
+                "-convert-scf-to-cf before this pass (e.g. via "
+                "convert-arm-sme-to-llvm pipeline)");
+            return WalkResult::interrupt();
+          });
       if (walkResult.wasInterrupted())
         return failure();
       operationToIndexMap.try_emplace(&op, index++);

--- a/mlir/test/Dialect/ArmSME/tile-allocation-nested-regions.mlir
+++ b/mlir/test/Dialect/ArmSME/tile-allocation-nested-regions.mlir
@@ -1,39 +1,25 @@
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(test-arm-sme-tile-allocation))" -split-input-file -verify-diagnostics
 
-module {
-  func.func @arm_sme_tile_load_hor_f16(%arg0: memref<?x?xf16>) {
-    %c0 = arith.constant 0 : index
-    %0 = arm_sme.get_tile : vector<[8]x[8]xf16>
-    %c8 = arith.constant 8 : index
-    %vscale = vector.vscale
-    %c8_vscale = arith.muli %c8, %vscale : index
-    %cst = arith.constant dense<true> : vector<[8]xi1>
-    %c0_0 = arith.constant 0 : index
-    %c64 = arith.constant 64 : index
-
-    %1 = scf.for %arg1 = %c0_0 to %c64 step %c8 iter_args(%arg2 = %0) -> (vector<[8]x[8]xf16>) {
-      %2 = arith.addi %arg1, %c8 : index
-      // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass}}
-      %3 = arm_sme.load_tile_slice %arg0[%2, %arg1], %cst, %arg2, %arg1
-           : memref<?x?xf16>, vector<[8]xi1>, vector<[8]x[8]xf16>
-      scf.yield %3 : vector<[8]x[8]xf16>
-    }
-    return
+func.func @nested_index_switch_requires_flat_cf(%cond: index) {
+  scf.index_switch %cond -> vector<[8]x[8]xi16> default {
+    // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass}}
+    %inner = arm_sme.get_tile : vector<[8]x[8]xi16>
+    scf.yield %inner : vector<[8]x[8]xi16>
   }
+  return
 }
 
 // -----
 
-module {
-  func.func @main() {
-    %0 = index.constant 0
-    %1 = arm_sme.get_tile : vector<[8]x[8]xi16>
-
-    %2 = scf.index_switch %0 -> vector<[8]x[8]xi16> default {
-      // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass}}
-      %3 = arm_sme.get_tile : vector<[8]x[8]xi16>
-      scf.yield %3 : vector<[8]x[8]xi16>
-    }
-    return
+func.func @nested_scf_for_requires_flat_cf(%ub: index) {
+  %init = arm_sme.get_tile : vector<[8]x[8]xi16>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  scf.for %i = %c0 to %ub step %c1 iter_args(%t = %init)
+      -> (vector<[8]x[8]xi16>) {
+    // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass}}
+    %inner = arm_sme.get_tile : vector<[8]x[8]xi16>
+    scf.yield %inner : vector<[8]x[8]xi16>
   }
+  return
 }

--- a/mlir/test/Dialect/ArmSME/tile-allocation-nested-regions.mlir
+++ b/mlir/test/Dialect/ArmSME/tile-allocation-nested-regions.mlir
@@ -1,0 +1,36 @@
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(test-arm-sme-tile-allocation))" -split-input-file -verify-diagnostics
+
+module {
+  func.func @arm_sme_tile_load_hor_f16(%arg0: memref<?x?xf16>) {
+    %c0 = arith.constant 0 : index
+    %0 = arm_sme.get_tile : vector<[8]x[8]xf16>
+    %c8 = arith.constant 8 : index
+    %vscale = vector.vscale
+    %c8_vscale = arith.muli %c8, %vscale : index
+    %cst = arith.constant dense<true> : vector<[8]xi1>
+    %c0_0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass (e.g. via convert-arm-sme-to-llvm pipeline)}}
+    %1 = scf.for %arg1 = %c0_0 to %c64 step %c8 iter_args(%arg2 = %0) -> (vector<[8]x[8]xf16>) {
+      %2 = arith.addi %arg1, %c8 : index
+      %3 = arm_sme.load_tile_slice %arg0[%2, %arg1], %cst, %arg2, %arg1 : memref<?x?xf16>, vector<[8]xi1>, vector<[8]x[8]xf16>
+      scf.yield %3 : vector<[8]x[8]xf16>
+    }
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @main() {
+    %0 = index.constant 0
+    %1 = arm_sme.get_tile : vector<[8]x[8]xi16>
+    // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass (e.g. via convert-arm-sme-to-llvm pipeline)}}
+    %2 = scf.index_switch %0 -> vector<[8]x[8]xi16> default {
+      %3 = arm_sme.get_tile : vector<[8]x[8]xi16>
+      scf.yield %3 : vector<[8]x[8]xi16>
+    }
+    return
+  }
+}

--- a/mlir/test/Dialect/ArmSME/tile-allocation-nested-regions.mlir
+++ b/mlir/test/Dialect/ArmSME/tile-allocation-nested-regions.mlir
@@ -1,8 +1,8 @@
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(test-arm-sme-tile-allocation))" -split-input-file -verify-diagnostics
 
 func.func @nested_index_switch_requires_flat_cf(%cond: index) {
+  // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass}}
   scf.index_switch %cond -> vector<[8]x[8]xi16> default {
-    // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass}}
     %inner = arm_sme.get_tile : vector<[8]x[8]xi16>
     scf.yield %inner : vector<[8]x[8]xi16>
   }
@@ -15,9 +15,9 @@ func.func @nested_scf_for_requires_flat_cf(%ub: index) {
   %init = arm_sme.get_tile : vector<[8]x[8]xi16>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
+  // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass}}
   scf.for %i = %c0 to %ub step %c1 iter_args(%t = %init)
       -> (vector<[8]x[8]xi16>) {
-    // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass}}
     %inner = arm_sme.get_tile : vector<[8]x[8]xi16>
     scf.yield %inner : vector<[8]x[8]xi16>
   }

--- a/mlir/test/Dialect/ArmSME/tile-allocation-nested-regions.mlir
+++ b/mlir/test/Dialect/ArmSME/tile-allocation-nested-regions.mlir
@@ -10,10 +10,12 @@ module {
     %cst = arith.constant dense<true> : vector<[8]xi1>
     %c0_0 = arith.constant 0 : index
     %c64 = arith.constant 64 : index
-    // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass (e.g. via convert-arm-sme-to-llvm pipeline)}}
+
     %1 = scf.for %arg1 = %c0_0 to %c64 step %c8 iter_args(%arg2 = %0) -> (vector<[8]x[8]xf16>) {
       %2 = arith.addi %arg1, %c8 : index
-      %3 = arm_sme.load_tile_slice %arg0[%2, %arg1], %cst, %arg2, %arg1 : memref<?x?xf16>, vector<[8]xi1>, vector<[8]x[8]xf16>
+      // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass}}
+      %3 = arm_sme.load_tile_slice %arg0[%2, %arg1], %cst, %arg2, %arg1
+           : memref<?x?xf16>, vector<[8]xi1>, vector<[8]x[8]xf16>
       scf.yield %3 : vector<[8]x[8]xf16>
     }
     return
@@ -26,8 +28,9 @@ module {
   func.func @main() {
     %0 = index.constant 0
     %1 = arm_sme.get_tile : vector<[8]x[8]xi16>
-    // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass (e.g. via convert-arm-sme-to-llvm pipeline)}}
+
     %2 = scf.index_switch %0 -> vector<[8]x[8]xi16> default {
+      // expected-error @+1 {{ArmSME tile allocation requires flattened control flow; run -convert-scf-to-cf before this pass}}
       %3 = arm_sme.get_tile : vector<[8]x[8]xi16>
       scf.yield %3 : vector<[8]x[8]xi16>
     }


### PR DESCRIPTION
Replace the nested-region assertion in ArmSME tile allocation with a proper diagnostic and graceful failure.

Fixes #181593