### PR TITLE
[MLIR][XeGPU] Relax the slice layout check for broadcast operand in subgroup distribution

### DIFF
--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSubgroupDistribute.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUSubgroupDistribute.cpp
@@ -1511,9 +1511,8 @@ struct VectorBroadcastDistribution : public gpu::WarpDistributionPattern {
         // Case 1: source is lower-rank than result.
         bool isSliceOf = sourceLayout.isSliceOf(resultLayout);
         if (!isSliceOf)
-          return rewriter.notifyMatchFailure(
-              warpOp,
-              "Broadcast input layout must be a slice of result layout.");
+          broadcastOp.emitWarning()
+              << "Broadcast input layout must be a slice of result layout.";
       }
       // case 2: source and result have same rank
       if (rankDiff == 0) {


### PR DESCRIPTION
This PR relaxes the operand layout check in broadcast op in subgroup distribution. Instead of failing the pattern match, it issues a warning and proceed the distribution.  The layout could be non-slice layout but still support valid subgroup distribution. 