### PR TITLE
[TableGen] Rename TheMatcher->TheMatcherList. NFC

### DIFF
--- a/llvm/utils/TableGen/DAGISelEmitter.cpp
+++ b/llvm/utils/TableGen/DAGISelEmitter.cpp
@@ -196,7 +196,7 @@ void DAGISelEmitter::run(raw_ostream &OS) {
   SmallVector<MatcherList, 0> PatternMatchers;
   for (const PatternToMatch *PTM : Patterns) {
     for (unsigned Variant = 0;; ++Variant) {
-      MatcherList ML = ConvertPatternToMatcher(*PTM, Variant, CGP);
+      MatcherList ML = ConvertPatternToMatcherList(*PTM, Variant, CGP);
       if (ML.empty())
         break;
       PatternMatchers.push_back(std::move(ML));
@@ -209,7 +209,7 @@ void DAGISelEmitter::run(raw_ostream &OS) {
   Timer.startTimer("Optimize matchers");
   OptimizeMatcher(Matchers, CGP);
 
-  // Matcher->dump();
+  // Matchers->dump();
 
   Timer.startTimer("Emit matcher table");
   EmitMatcherTable(Matchers, CGP, OS);

--- a/llvm/utils/TableGen/DAGISelMatcher.h
+++ b/llvm/utils/TableGen/DAGISelMatcher.h
@@ -35,9 +35,9 @@ class SDNodeInfo;
 class TreePredicateFn;
 class TreePattern;
 
-MatcherList ConvertPatternToMatcher(const PatternToMatch &Pattern,
-                                    unsigned Variant,
-                                    const CodeGenDAGPatterns &CGP);
+MatcherList ConvertPatternToMatcherList(const PatternToMatch &Pattern,
+                                        unsigned Variant,
+                                        const CodeGenDAGPatterns &CGP);
 void OptimizeMatcher(MatcherList &ML, const CodeGenDAGPatterns &CGP);
 void EmitMatcherTable(MatcherList &ML, const CodeGenDAGPatterns &CGP,
                       raw_ostream &OS);

--- a/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
@@ -87,7 +87,7 @@ class MatcherTableEmitter {
   }
 
 public:
-  MatcherTableEmitter(const MatcherList &TheMatcher,
+  MatcherTableEmitter(const MatcherList &TheMatcherList,
                       const CodeGenDAGPatterns &cgp)
       : CGP(cgp), OpcodeCounts(Matcher::HighestKind + 1, 0),
         OperandTable(std::nullopt) {
@@ -131,7 +131,7 @@ public:
             }
           }
         };
-    Statistic(TheMatcher);
+    Statistic(TheMatcherList);
 
     OperandTable.layout();
 
@@ -1526,7 +1526,7 @@ void MatcherTableEmitter::EmitHistogram(raw_ostream &OS) {
   OS << '\n';
 }
 
-void llvm::EmitMatcherTable(MatcherList &TheMatcher,
+void llvm::EmitMatcherTable(MatcherList &TheMatcherList,
                             const CodeGenDAGPatterns &CGP, raw_ostream &OS) {
   OS << "#if defined(GET_DAGISEL_DECL) && defined(GET_DAGISEL_BODY)\n";
   OS << "#error GET_DAGISEL_DECL and GET_DAGISEL_BODY cannot be both defined, ";
@@ -1558,7 +1558,7 @@ void llvm::EmitMatcherTable(MatcherList &TheMatcher,
   OS << "#endif\n\n";
 
   BeginEmitFunction(OS, "void", "SelectCode(SDNode *N)", false /*AddOverride*/);
-  MatcherTableEmitter MatcherEmitter(TheMatcher, CGP);
+  MatcherTableEmitter MatcherEmitter(TheMatcherList, CGP);
 
   // First we size all the children of the three kinds of matchers that have
   // them. This is done by sharing the code in EmitMatcher(). but we don't
@@ -1566,7 +1566,7 @@ void llvm::EmitMatcherTable(MatcherList &TheMatcher,
   bool SaveOmitComments = OmitComments;
   OmitComments = true;
   raw_null_ostream NullOS;
-  unsigned TotalSize = MatcherEmitter.SizeMatcherList(TheMatcher, NullOS);
+  unsigned TotalSize = MatcherEmitter.SizeMatcherList(TheMatcherList, NullOS);
   OmitComments = SaveOmitComments;
 
   // Now that the matchers are sized, we can emit the code for them to the
@@ -1579,7 +1579,7 @@ void llvm::EmitMatcherTable(MatcherList &TheMatcher,
   OS << "  #define COVERAGE_IDX_VAL(X) X & 255, (unsigned(X) >> 8) & 255, ";
   OS << "(unsigned(X) >> 16) & 255, (unsigned(X) >> 24) & 255\n";
   OS << "  static const uint8_t MatcherTable[] = {\n";
-  TotalSize = MatcherEmitter.EmitMatcherList(TheMatcher, 1, 0, OS);
+  TotalSize = MatcherEmitter.EmitMatcherList(TheMatcherList, 1, 0, OS);
   OS << "  }; // Total Array size is " << TotalSize << " bytes\n\n";
 
   MatcherEmitter.EmitHistogram(OS);

--- a/llvm/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherGen.cpp
@@ -93,7 +93,7 @@ class MatcherGen {
   SmallVector<std::pair<const Record *, unsigned>, 2> PhysRegInputs;
 
   /// This is the top level of the generated matcher, the result.
-  MatcherList TheMatcher;
+  MatcherList TheMatcherList;
 
   /// As we emit matcher nodes, this points to the latest check which should
   /// have future checks inserted after it.
@@ -105,7 +105,7 @@ public:
   bool EmitMatcherCode(unsigned Variant);
   void EmitResultCode();
 
-  MatcherList GetMatcher() { return std::move(TheMatcher); }
+  MatcherList GetMatcherList() { return std::move(TheMatcherList); }
 
 private:
   void AddMatcher(Matcher *NewNode);
@@ -146,7 +146,7 @@ private:
 
 MatcherGen::MatcherGen(const PatternToMatch &pattern,
                        const CodeGenDAGPatterns &cgp)
-    : Pattern(pattern), CGP(cgp), InsertPt(TheMatcher.before_begin()) {
+    : Pattern(pattern), CGP(cgp), InsertPt(TheMatcherList.before_begin()) {
   // We need to produce the matcher tree for the patterns source pattern.  To
   // do this we need to match the structure as well as the types.  To do the
   // type matching, we want to figure out the fewest number of type checks we
@@ -184,7 +184,7 @@ void MatcherGen::InferPossibleTypes() {
 
 /// AddMatcher - Add a matcher node to the current graph we're building.
 void MatcherGen::AddMatcher(Matcher *NewNode) {
-  InsertPt = TheMatcher.insert_after(InsertPt, NewNode);
+  InsertPt = TheMatcherList.insert_after(InsertPt, NewNode);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1051,12 +1051,11 @@ void MatcherGen::EmitResultCode() {
   AddMatcher(new CompleteMatchMatcher(Results, Pattern));
 }
 
-/// ConvertPatternToMatcher - Create the matcher for the specified pattern with
-/// the specified variant.  If the variant number is invalid, this returns an
-/// empty MatcherList.
-MatcherList llvm::ConvertPatternToMatcher(const PatternToMatch &Pattern,
-                                          unsigned Variant,
-                                          const CodeGenDAGPatterns &CGP) {
+/// Create the matcher for the specified pattern with the specified variant.
+/// If the variant number is invalid, this returns an empty MatcherList.
+MatcherList llvm::ConvertPatternToMatcherList(const PatternToMatch &Pattern,
+                                              unsigned Variant,
+                                              const CodeGenDAGPatterns &CGP) {
   MatcherGen Gen(Pattern, CGP);
 
   // Generate the code for the matcher.
@@ -1072,5 +1071,5 @@ MatcherList llvm::ConvertPatternToMatcher(const PatternToMatch &Pattern,
   Gen.EmitResultCode();
 
   // Unconditional match.
-  return Gen.GetMatcher();
+  return Gen.GetMatcherList();
 }


### PR DESCRIPTION
After 8d971c0360f91729cc5120ffd361f7b55e97f2ab, there is a linked list container object called MatcherList. We no long hold a pointer directly to the first Matcher in the list.

Rename the variables to make this clearer.