### PR TITLE
[CIR] Fix type handling with TypeTraitExpr

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -870,12 +870,21 @@ public:
     return {};
   }
   mlir::Value VisitTypeTraitExpr(const TypeTraitExpr *e) {
+    // We diverge slightly from classic codegen here because CIR has stricter
+    // typing. In LLVM IR, constant folding covers up some potential type
+    // mismatches such as bool-to-int conversions that would fail the verifier
+    // in CIR. To make things work, we need to be sure we only emit a bool value
+    // if the expression type is bool.
     mlir::Location loc = cgf.getLoc(e->getExprLoc());
-    if (e->isStoredAsBoolean())
-      return builder.getBool(e->getBoolValue(), loc);
-    cgf.cgm.errorNYI(e->getSourceRange(),
-                     "ScalarExprEmitter: TypeTraitExpr stored as int");
-    return {};
+    if (e->isStoredAsBoolean()) {
+      if (e->getType()->isBooleanType())
+        return builder.getBool(e->getBoolValue(), loc);
+      assert(e->getType()->isIntegerType() &&
+             "Expected int type for TypeTraitExpr");
+      return builder.getConstInt(loc, cgf.convertType(e->getType()),
+                                 (uint64_t)e->getBoolValue());
+    }
+    return builder.getConstInt(loc, e->getAPValue().getInt());
   }
   mlir::Value
   VisitConceptSpecializationExpr(const ConceptSpecializationExpr *e) {

--- a/clang/test/CIR/CodeGenBuiltins/builtin-structured-binding-size.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-structured-binding-size.cpp
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+struct S {
+  int a;
+  double b;
+  char c;
+};
+
+int test_structured_binding_size() {
+  return __builtin_structured_binding_size(S);
+}
+
+// CIR: cir.func {{.*}} @_Z28test_structured_binding_sizev()
+// CIR:   %[[SIZE:.*]] = cir.const #cir.int<3> : !s32i
+// CIR:   cir.store %[[SIZE:.*]], %[[RETVAL:.*]]
+// CIR:   %[[RET:.*]] = cir.load %[[RETVAL:.*]]
+// CIR:   cir.return %[[RET:.*]] : !s32i
+
+// LLVM: define{{.*}} i32 @_Z28test_structured_binding_sizev()
+// LLVM:   store i32 3, ptr %[[RETVAL:.*]]
+// LLVM:   %[[RET:.*]] = load i32, ptr %[[RETVAL:.*]]
+// LLVM:   ret i32 %[[RET:.*]]
+
+// OGCG: define{{.*}} i32 @_Z28test_structured_binding_sizev()
+// OGCG:   ret i32 3

--- a/clang/test/CIR/CodeGenBuiltins/builtin-trivally-copyable.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-trivally-copyable.cpp
@@ -1,0 +1,57 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+bool g;
+void store_trivially_copyable_result() {
+  g = __is_trivially_copyable(int);
+}
+
+// CIR: cir.func {{.*}} @_Z31store_trivially_copyable_resultv()
+// CIR:   %[[TRUE:.*]] = cir.const #true
+// CIR:   %[[G_PTR:.*]] = cir.get_global @g : !cir.ptr<!cir.bool>
+// CIR:   cir.store{{.*}} %[[TRUE]], %[[G_PTR:.*]] : !cir.bool, !cir.ptr<!cir.bool>
+
+// LLVM: define{{.*}} void @_Z31store_trivially_copyable_resultv()
+// LLVM:   store i8 1, ptr @g
+
+// OGCG: define{{.*}} void @_Z31store_trivially_copyable_resultv()
+// OGCG:   store i8 1, ptr @g
+
+int test_trivially_copyable_as_bool() {
+  if (!__is_trivially_copyable(int))
+    return -1;
+  return 0;
+}
+
+// CIR: cir.func {{.*}} @_Z31test_trivially_copyable_as_boolv()
+// CIR:   %[[FALSE:.*]] = cir.const #false
+// CIR:   cir.if %[[FALSE]] {
+// CIR:     %[[NEG_ONE:.*]] = cir.const #cir.int<-1> : !s32i
+// CIR:     cir.store %[[NEG_ONE]], %[[RETVAL:.*]]
+// CIR:     %[[RET:.*]] = cir.load %[[RETVAL:.*]] : !cir.ptr<!s32i>, !s32i
+// CIR:     cir.return %[[RET:.*]] : !s32i
+// CIR:   }
+// CIR:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR:   cir.store %[[ZERO]], %[[RETVAL:.*]] : !s32i, !cir.ptr<!s32i>
+// CIR:   %[[RET:.*]] = cir.load %[[RETVAL:.*]] : !cir.ptr<!s32i>, !s32i
+// CIR:   cir.return %[[RET:.*]] : !s32i
+
+// LLVM: define{{.*}} i32 @_Z31test_trivially_copyable_as_boolv()
+// LLVM:   br i1 false, label %[[IF_THEN:.*]], label %[[IF_ELSE:.*]]
+// LLVM: [[IF_THEN]]:
+// LLVM:   store i32 -1, ptr %[[RETVAL:.*]]
+// LLVM:   %[[RET:.*]] = load i32, ptr %[[RETVAL:.*]]
+// LLVM:   ret i32 %[[RET:.*]]
+// LLVM: [[IF_ELSE]]:
+// LLVM:   br label %[[IF_END:.*]]
+// LLVM: [[IF_END]]:
+// LLVM:   store i32 0, ptr %[[RETVAL:.*]]
+// LLVM:   %[[RET:.*]] = load i32, ptr %[[RETVAL:.*]]
+// LLVM:   ret i32 %[[RET:.*]]
+
+// OGCG: define{{.*}} i32 @_Z31test_trivially_copyable_as_boolv()
+// OGCG:   ret i32 0

--- a/clang/test/CIR/CodeGenBuiltins/builtin-types-compatible.c
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-types-compatible.c
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+int g;
+void store_types_compatible_result() {
+  g = __builtin_types_compatible_p(int, const int);
+}
+
+// CIR: cir.func {{.*}} @store_types_compatible_result()
+// CIR:   %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+// CIR:   %[[G_PTR:.*]] = cir.get_global @g : !cir.ptr<!s32i>
+// CIR:   cir.store{{.*}} %[[ONE]], %[[G_PTR:.*]] : !s32i, !cir.ptr<!s32i>
+
+// LLVM: define{{.*}} void @store_types_compatible_result()
+// LLVM:   store i32 1, ptr @g
+
+// OGCG: define{{.*}} void @store_types_compatible_result()
+// OGCG:   store i32 1, ptr @g
+
+int test_convert_bool_to_int() {
+  if (!__builtin_types_compatible_p(int, const int))
+    return -1;
+  return 0;
+}
+
+// CIR: cir.func {{.*}} @test_convert_bool_to_int()
+// CIR:   %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+// CIR:   %[[BOOL:.*]] = cir.cast int_to_bool %[[ONE]] : !s32i -> !cir.bool
+// CIR:   %[[NOT:.*]] = cir.unary(not, %[[BOOL]]) : !cir.bool, !cir.bool
+// CIR:   cir.if %[[NOT]] {
+// CIR:     %[[NEG_ONE:.*]] = cir.const #cir.int<-1> : !s32i
+// CIR:     cir.store %[[NEG_ONE]], %[[RETVAL:.*]]
+// CIR:     %[[RET:.*]] = cir.load %[[RETVAL:.*]] : !cir.ptr<!s32i>, !s32i
+// CIR:     cir.return %[[RET:.*]] : !s32i
+// CIR:   }
+// CIR:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR:   cir.store %[[ZERO]], %[[RETVAL:.*]] : !s32i, !cir.ptr<!s32i>
+// CIR:   %[[RET:.*]] = cir.load %[[RETVAL:.*]] : !cir.ptr<!s32i>, !s32i
+// CIR:   cir.return %[[RET:.*]] : !s32i
+
+// LLVM: define{{.*}} i32 @test_convert_bool_to_int()
+// LLVM:   br i1 false, label %[[IF_THEN:.*]], label %[[IF_ELSE:.*]]
+// LLVM: [[IF_THEN]]:
+// LLVM:   store i32 -1, ptr %[[RETVAL:.*]]
+// LLVM:   %[[RET:.*]] = load i32, ptr %[[RETVAL:.*]]
+// LLVM:   ret i32 %[[RET:.*]]
+// LLVM: [[IF_ELSE]]:
+// LLVM:   br label %[[IF_END:.*]]
+// LLVM: [[IF_END]]:
+// LLVM:   store i32 0, ptr %[[RETVAL:.*]]
+// LLVM:   %[[RET:.*]] = load i32, ptr %[[RETVAL:.*]]
+// LLVM:   ret i32 %[[RET:.*]]
+
+// OGCG: define{{.*}} i32 @test_convert_bool_to_int()
+// OGCG:   ret i32 0


### PR DESCRIPTION
There were some cases when compiling a C program where VisitTypeTraitExpr would return a cir.bool value for a TypeTraitExpr that required an integer. This was happening because we were checking `e->isStoredAsBoolean` which returns a result that is inconsistent with the expression type for C compilation units.

This change fixes the handling and also adds support for other non-boolean type trait expressions.