### PR TITLE
[ThinLTO] Distinguish symbols that are promoted

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -387,7 +387,7 @@ static FunctionSummary *calculatePrevailingSummary(
       }
       Local = FS;
     } else if (GlobalValue::isExternalLinkage(Linkage)) {
-      assert(IsPrevailing(VI.getGUID(), GVS.get()));
+      assert(IsPrevailing(VI.getGUID(), GVS.get()) || GVS->wasPromoted());
       Prevailing = FS;
       break;
     } else if (GlobalValue::isWeakODRLinkage(Linkage) ||

--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -2106,7 +2106,7 @@ static bool doImportingForModuleForTest(
   for (auto &I : *Index) {
     for (auto &S : I.second.getSummaryList()) {
       if (GlobalValue::isLocalLinkage(S->linkage()))
-        S->setLinkage(GlobalValue::ExternalLinkage);
+        S->setExternalLinkageForTest();
     }
   }
 

--- a/llvm/test/ThinLTO/X86/Inputs/export2.ll
+++ b/llvm/test/ThinLTO/X86/Inputs/export2.ll
@@ -1,0 +1,9 @@
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @main() {
+entry:
+  call void @callstaticfunc()
+  ret i32 0
+}
+
+declare void @callstaticfunc()

--- a/llvm/test/ThinLTO/X86/export2.ll
+++ b/llvm/test/ThinLTO/X86/export2.ll
@@ -1,0 +1,27 @@
+; Do setup work for all below tests: generate bitcode and combined index
+; RUN: opt -module-summary %s -o %t1.bc
+; RUN: opt -module-summary %p/Inputs/export2.ll -o %t2.bc
+; 
+; RUN: llvm-lto2 run %t1.bc %t2.bc -o %t3 \
+; RUN:  -thinlto-distributed-indexes \
+; RUN:  -r=%t1.bc,callstaticfunc,px \
+; RUN:  -r=%t2.bc,main,px \
+; RUN:  -r=%t2.bc,callstaticfunc,
+
+; both functions must appear as external linkage in the index.
+; RUN: llvm-dis %t1.bc.thinlto.bc -o - | FileCheck %s
+; CHECK: linkage: external
+; CHECK: linkage: external
+
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @callstaticfunc() {
+entry:
+  call void @staticfunc()
+  ret void
+}
+
+define internal void @staticfunc() {
+entry:
+  ret void
+}

--- a/llvm/test/ThinLTO/X86/funcattrs-prop-exported-internal.ll
+++ b/llvm/test/ThinLTO/X86/funcattrs-prop-exported-internal.ll
@@ -27,7 +27,7 @@ define void @importer() {
 
 ; If somehow the caller doesn't get the attributes, we
 ; shouldn't propagate from the internal callee.
-; CHECK: define void @importer_noattr() {
+; CHECK: define void @importer_noattr() #0 {
 define void @importer_noattr() {
   call void @caller_noattr()
   ret void

--- a/llvm/test/ThinLTO/X86/module_asm2.ll
+++ b/llvm/test/ThinLTO/X86/module_asm2.ll
@@ -9,7 +9,7 @@
 ; RUN:  llvm-nm %t2.bc.thinlto.o | FileCheck  %s --check-prefix=NM1
 
 ; RUN: llvm-lto2 run %t1.bc %t2.bc -o %t.o -save-temps \
-; RUN:     -r=%t1.bc,foo,plx \
+; RUN:     -r=%t1.bc,foo,lx \
 ; RUN:     -r=%t1.bc,globalfunc,plx \
 ; RUN:     -r=%t1.bc,globalfunc,lx \
 ; RUN:     -r=%t1.bc,weakfunc,plx \

--- a/llvm/tools/llvm-link/llvm-link.cpp
+++ b/llvm/tools/llvm-link/llvm-link.cpp
@@ -422,7 +422,7 @@ static bool linkFiles(const char *argv0, LLVMContext &Context, Linker &L,
       for (auto &I : *Index) {
         for (auto &S : I.second.getSummaryList()) {
           if (GlobalValue::isLocalLinkage(S->linkage()))
-            S->setLinkage(GlobalValue::ExternalLinkage);
+            S->setExternalLinkageForTest();
         }
       }
 


### PR DESCRIPTION
Thinlink may decide some symbols with internal linkage should get promoted to external. Such a symbol, when being imported, would have its name changed by appending a suffix (`.llvm.<a hash>`) to avoid collisions - since internal linkage symbols have non-unique names.

Later, still during Thinlink, in `thinLTOResolvePrevailingGUID`, the fact that this symbol was promoted is not considered and we set its linkage to `AvailableExternally`(when reading `thinLTOResolvePrevailingGUID`, note that "prevailing-ness" is not a concept that the original symbol would have participated in)



This should result in a final (native) link error, because the symbol's definition may be elided. But we get lucky: in the post-thinlink backend, during import, in `llvm::thinLTOFinalizeInModule`, after this symbol's name was changed and its linkage also changed to `External` (see `FunctionImportGlobalProcessing::processGlobalForThinLTO`), we try to find it in the `DefinedGlobals`, fail (because its guid is computed from its changed name)) and leave its linkage as-is. Which happens to be correct.

This patch makes this outcome intentional rather than accidental. It becomes critical once we land [this RFC](https://discourse.llvm.org/t/rfc-keep-globalvalue-guids-stable/84801).

As a side-benefit, the extra attribute propagations that weren't happening in `llvm::thinLTOFinalizeInModule` now do.