### PR TITLE
[clang][analyzer] Added Abstract VAList region normalization into MemRegionManager

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -133,6 +133,10 @@ public:
     return dyn_cast<MemSpace>(getRawMemorySpace());
   }
 
+  /// Strips ElementRegion wrappers from VA lists
+  /// Returning canonical base region.
+  MemRegion *getVAListRegion(const MemRegion *Reg);
+
   /// Returns the most specific memory space for this memory region in the given
   /// ProgramStateRef. We may infer a more accurate memory space for unknown
   /// space regions and associate this in the State.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -133,10 +133,6 @@ public:
     return dyn_cast<MemSpace>(getRawMemorySpace());
   }
 
-  /// Strips ElementRegion wrappers from VA lists
-  /// Returning canonical base region.
-  MemRegion *getVAListRegion(const MemRegion *Reg);
-
   /// Returns the most specific memory space for this memory region in the given
   /// ProgramStateRef. We may infer a more accurate memory space for unknown
   /// space regions and associate this in the State.
@@ -1607,6 +1603,10 @@ public:
   const CXXDerivedObjectRegion *
   getCXXDerivedObjectRegion(const CXXRecordDecl *BaseClass,
                             const SubRegion *Super);
+
+  /// Strips ElementRegion wrappers from VA lists
+  /// Returning canonical base region.
+  MemRegion *getVAListRegion(const MemRegion *Reg);
 
   const FunctionCodeRegion *getFunctionCodeRegion(const NamedDecl *FD);
   const BlockCodeRegion *getBlockCodeRegion(const BlockDecl *BD,

--- a/clang/lib/StaticAnalyzer/Checkers/VAListChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/VAListChecker.cpp
@@ -177,10 +177,8 @@ const MemRegion *VAListChecker::getVAListAsRegion(SVal SV, const Expr *E,
   if (!Reg)
     return nullptr;
 
-  return C.getAnalysisManager()
-      .getRegionStore()
-      .getMemRegionManager()
-      .getVAListRegion(Reg);
+  MemRegionManager &MRMgr = Reg->getMemRegionManager();
+  return MRMgr.getVAListRegion(Reg);
 }
 
 void VAListChecker::checkPreStmt(const VAArgExpr *VAA,

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1888,3 +1888,19 @@ bool RegionAndSymbolInvalidationTraits::hasTrait(const MemRegion *MR,
 
   return false;
 }
+
+MemRegion *MemRegionManager::getVAListRegion(const MemRegion *Reg) {
+  if (!Reg) return nullptr;
+
+  if (const ElementRegion *EReg = dyn_cast<ElementRegion>(Reg)) {
+    return getVAListRegion(EReg->getSuperRegion());
+  }
+
+  if (const DeclRegion *DeclReg = dyn_cast<DeclRegion>(Reg)) {
+    if (isa<ParmVarDecl>(DeclReg->getDecl())) {
+      return const_cast<MemRegion*>(Reg);
+    }
+  }
+
+  return const_cast<MemRegion*>(Reg);
+}


### PR DESCRIPTION
# Added Abstract VAList region normalization into MemRegionManager
Component: `clang` `static analyzer`

The Clang Static Analyzer's `VAListChecker` currently contains **checker-local logic** to normalize va_list memory regions (handling ElementRegion wrappers). This logic is marked with:


> TODO: In the future this should be abstracted away by the analyzer.

At [VAListChecker.cpp](https://github.com/llvm/llvm-project/blob/main/clang/lib/StaticAnalyzer/Checkers/VAListChecker.cpp#L179)

I implemented a small abstraction in MemRegionManager and adjusted VAListChecker to use it. The change compiles and basic analyzer runs with --analyze work as expected.

## Changes

- New helper in MemRegionManager

In `clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h`

```cpp
/// Strips ElementRegion wrappers from VA lists
/// Returning canonical base region.
MemRegion *getVAListRegion(const MemRegion *Reg);
```

In `clang/lib/StaticAnalyzer/Core/MemRegion.cpp`:

```cpp
MemRegion *MemRegionManager::getVAListRegion(const MemRegion *Reg) {
  if (!Reg) return nullptr;

  if (const ElementRegion *EReg = dyn_cast<ElementRegion>(Reg)) {
    return getVAListRegion(EReg->getSuperRegion());
  }

  if (const DeclRegion *DeclReg = dyn_cast<DeclRegion>(Reg)) {
    if (isa<ParmVarDecl>(DeclReg->getDecl())) {
      return const_cast<MemRegion*>(Reg);
    }
  }

  return const_cast<MemRegion*>(Reg);
}
```

- And now VAListChecker uses engine helper method

In clang/lib/StaticAnalyzer/Checkers/VAListChecker.cpp:

```cpp
const MemRegion *VAListChecker::getVAListAsRegion(SVal SV, const Expr *E,
                                                  CheckerContext &C) const {
  const MemRegion *Reg = SV.getAsRegion();
  if (!Reg)
    return nullptr;

  MemRegionManager &MRMgr = Reg->getMemRegionManager();
  return MRMgr.getVAListRegion(Reg);
}
```

The previous checker-local logic that inspected `CastExpr`, `ParmVarDecl`, and `ElementRegion` has been removed.

## Small test cases

I used a small `va_list`-based example to test the new getVAListRegion logic:

```cpp
#include <stdarg.h>

void test_array_model(va_list ap) {
  char *p = (char *)ap;
  *p = 0;
}

void foo(va_list args) {
  char *p = (char *)args;
  *p = 0;
}

void test_nested(va_list ap) {
  char (*arr)[1] = (char (*)[1])ap;
  (*arr)[0] = 0;
}

int main() {
  return 0;
}
```

Built and analyzed with my patched Clang:

```bash
./bin/clang --analyze va_list_test.c
```

The analyzer runs successfully on this test, and the VAList-related code paths work without crashes or unexpected diagnostics.