### PR TITLE
[lldb] Speed up SymbolContextList::AppendIfUnique

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolContext.h
+++ b/lldb/include/lldb/Symbol/SymbolContext.h
@@ -494,6 +494,7 @@ private:
   using set_type = llvm::DenseSet<SymbolContext, SymbolContextInfo>;
   using collection =
       llvm::SetVector<SymbolContext, std::vector<SymbolContext>, set_type>;
+  using const_iterator = collection::const_iterator;
 
   // Member variables.
   collection m_symbol_contexts; ///< The list of symbol contexts.
@@ -502,10 +503,10 @@ public:
   const_iterator begin() const { return m_symbol_contexts.begin(); }
   const_iterator end() const { return m_symbol_contexts.end(); }
 
-  typedef llvm::iterator_range<collection::const_iterator>
-      SymbolContextIterable;
+  typedef llvm::iterator_range<const_iterator> SymbolContextIterable;
   SymbolContextIterable SymbolContexts() {
-    return SymbolContextIterable(m_symbol_contexts);
+    return SymbolContextIterable(m_symbol_contexts.begin(),
+                                 m_symbol_contexts.end());
   }
 };
 

--- a/lldb/include/lldb/Symbol/SymbolContext.h
+++ b/lldb/include/lldb/Symbol/SymbolContext.h
@@ -486,7 +486,8 @@ public:
                       Target *target) const;
 
 private:
-  using collection = llvm::SetVector<SymbolContext, std::vector<SymbolContext>>;
+  using collection =
+      llvm::SetVector<SymbolContext, llvm::SmallVector<SymbolContext>>;
   using const_iterator = collection::const_iterator;
 
   // Member variables.

--- a/lldb/include/lldb/Symbol/SymbolContext.h
+++ b/lldb/include/lldb/Symbol/SymbolContext.h
@@ -19,6 +19,7 @@
 #include "lldb/Utility/Iterable.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/lldb-private.h"
+#include "llvm/ADT/DenseSet.h"
 
 namespace lldb_private {
 
@@ -482,6 +483,20 @@ protected:
 
   // Member variables.
   collection m_symbol_contexts; ///< The list of symbol contexts.
+
+private:
+  struct SymbolContextInfo {
+    static SymbolContext getEmptyKey();
+    static SymbolContext getTombstoneKey();
+    static unsigned getHashValue(const SymbolContext &sc);
+    static bool isEqual(const SymbolContext &lhs, const SymbolContext &rhs);
+  };
+
+  /// Threshold above which we switch from linear scan to hash-set lookup
+  /// for uniqueness checks.
+  static constexpr size_t kSetThreshold = 1024;
+
+  llvm::SmallDenseSet<SymbolContext, 1, SymbolContextInfo> m_lookup_set;
 
 public:
   const_iterator begin() const { return m_symbol_contexts.begin(); }

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -929,7 +929,7 @@ void Module::FindFunctions(const RegularExpression &regex,
                 if (pos == end)
                   sc_list.Append(sc);
                 else
-                  sc_list[pos->second].symbol = sc.symbol;
+                  sc_list.SetSymbolAtIndex(pos->second, sc.symbol);
               }
             }
           }

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -1307,7 +1307,6 @@ void SymbolContextList::Dump(Stream *s, Target *target) const {
   s->IndentMore();
 
   for (const auto &sc : m_symbol_contexts) {
-    // sc.Dump(s, target);
     sc.GetDescription(s, eDescriptionLevelVerbose, target);
   }
   s->IndentLess();


### PR DESCRIPTION
d7fb086668dff68 changed some calls from SymbolContextList::Append to SymbolContextList::AppendIfUnique. This has unfortunately caused a huge slow down in operations involving a large amount of symbol contexts (for example, trying to autocomplete from an empty input "b <TAB>" will add every function to the list), since AppendIfUnique scans the entire symbol context list. Speed this up by adding a hash set to quickly answer whether a symbol context is on the list or not.

This takes the time from running "b <TAB>" when debugging yaml2obj on my machine from 600 seconds down to 13, which is about the same as before d7fb086668dff68.

Note that AppendIfUnique has a logic error, which has been present since its introduction. This has to do with the behavior controlled by "merge_symbol_into_function", which will try to merge symbols with symbol context containing the equivalent function to that symbol.

The previous patch tried to correct this by adding CompareConsideringPossiblyNullSymbol(), which is not quite correct.

With CompareConsideringPossiblyNullSymbol(), if symbols are added in this order:

- Symbol context without symbol.
- Equivalent symbol context with symbol.

The list will have only one symbol context WITHOUT the symbol.

If we stop using CompareConsideringPossiblyNullSymbol() and instead go back to the == operator which d7fb086668dff68 introduced, with symbols added in this order, the following will happen:

- Symbol context without symbol.
- Equivalent symbol context with symbol.
- The bare symbol, with "merge_symbol_into_function = true", the list will have the same symbol twice.

This patch does not attempt to solve this, and instead focuses on the performance issue d7fb086668dff68 introduced.

rdar://170477680