### PR TITLE
[KnownBits] Remove unneccessary calls to std::optional<bool> constructor. NFC

### DIFF
--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -632,31 +632,31 @@ KnownBits KnownBits::clmul(const KnownBits &LHS, const KnownBits &RHS) {
 
 std::optional<bool> KnownBits::eq(const KnownBits &LHS, const KnownBits &RHS) {
   if (LHS.isConstant() && RHS.isConstant())
-    return std::optional<bool>(LHS.getConstant() == RHS.getConstant());
+    return LHS.getConstant() == RHS.getConstant();
   if (LHS.One.intersects(RHS.Zero) || RHS.One.intersects(LHS.Zero))
-    return std::optional<bool>(false);
+    return false;
   return std::nullopt;
 }
 
 std::optional<bool> KnownBits::ne(const KnownBits &LHS, const KnownBits &RHS) {
   if (std::optional<bool> KnownEQ = eq(LHS, RHS))
-    return std::optional<bool>(!*KnownEQ);
+    return !*KnownEQ;
   return std::nullopt;
 }
 
 std::optional<bool> KnownBits::ugt(const KnownBits &LHS, const KnownBits &RHS) {
   // LHS >u RHS -> false if umax(LHS) <= umax(RHS)
   if (LHS.getMaxValue().ule(RHS.getMinValue()))
-    return std::optional<bool>(false);
+    return false;
   // LHS >u RHS -> true if umin(LHS) > umax(RHS)
   if (LHS.getMinValue().ugt(RHS.getMaxValue()))
-    return std::optional<bool>(true);
+    return true;
   return std::nullopt;
 }
 
 std::optional<bool> KnownBits::uge(const KnownBits &LHS, const KnownBits &RHS) {
   if (std::optional<bool> IsUGT = ugt(RHS, LHS))
-    return std::optional<bool>(!*IsUGT);
+    return !*IsUGT;
   return std::nullopt;
 }
 
@@ -671,16 +671,16 @@ std::optional<bool> KnownBits::ule(const KnownBits &LHS, const KnownBits &RHS) {
 std::optional<bool> KnownBits::sgt(const KnownBits &LHS, const KnownBits &RHS) {
   // LHS >s RHS -> false if smax(LHS) <= smax(RHS)
   if (LHS.getSignedMaxValue().sle(RHS.getSignedMinValue()))
-    return std::optional<bool>(false);
+    return false;
   // LHS >s RHS -> true if smin(LHS) > smax(RHS)
   if (LHS.getSignedMinValue().sgt(RHS.getSignedMaxValue()))
-    return std::optional<bool>(true);
+    return true;
   return std::nullopt;
 }
 
 std::optional<bool> KnownBits::sge(const KnownBits &LHS, const KnownBits &RHS) {
   if (std::optional<bool> KnownSGT = sgt(RHS, LHS))
-    return std::optional<bool>(!*KnownSGT);
+    return !*KnownSGT;
   return std::nullopt;
 }
 


### PR DESCRIPTION
We can return a bool and let the compiler insert the constructor call.