### PR TITLE
[modules] Move diagnostic about specific mtime/size change into a note from an error.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSerializationKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSerializationKinds.td
@@ -19,9 +19,10 @@ def err_fe_pch_malformed_block : Error<
     "malformed block record in PCH file: '%0'">, DefaultFatal;
 def err_fe_ast_file_modified : Error<
     "file '%0' has been modified since the "
-    "%select{precompiled header|module file|precompiled file}1 '%2' was built"
-    ": %select{size|mtime|content}3 changed%select{| (was %5, now %6)}4">,
+    "%select{precompiled header|module file|precompiled file}1 '%2' was built">,
     DefaultFatal;
+def note_fe_ast_file_modified : Note<
+    "%select{size|mtime|content}0 changed%select{| from expected %2 to %3}1">;
 def err_fe_pch_file_overridden : Error<
     "file '%0' from the precompiled header has been overridden">;
 def note_ast_file_required_by : Note<"'%0' required by '%1'">;

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -2985,8 +2985,9 @@ InputFile ASTReader::getInputFile(ModuleFile &F, unsigned ID, bool Complain) {
       StringRef TopLevelASTFileName(ImportStack.back()->FileName);
       Diag(diag::err_fe_ast_file_modified)
           << *Filename << moduleKindForDiagnostic(ImportStack.back()->Kind)
-          << TopLevelASTFileName << FileChange.Kind
-          << (FileChange.Old && FileChange.New)
+          << TopLevelASTFileName;
+      Diag(diag::note_fe_ast_file_modified)
+          << FileChange.Kind << (FileChange.Old && FileChange.New)
           << llvm::itostr(FileChange.Old.value_or(0))
           << llvm::itostr(FileChange.New.value_or(0));
 

--- a/clang/test/Modules/validate-file-content.m
+++ b/clang/test/Modules/validate-file-content.m
@@ -24,7 +24,8 @@
 // RUN: not %clang_cc1 -fsyntax-only -fmodules-cache-path=%t/cache -fmodules -fimplicit-module-maps -I %t -include-pch %t/a.pch %s -fvalidate-ast-input-files-content 2> %t/stderr
 // RUN: FileCheck %s < %t/stderr
 //
-// CHECK: file '[[M_H:.*[/\\]m\.h]]' has been modified since the precompiled header '[[A_PCH:.*[/\\]a\.pch]]' was built: content changed
+// CHECK: file '[[M_H:.*[/\\]m\.h]]' has been modified since the precompiled header '[[A_PCH:.*[/\\]a\.pch]]' was built
+// CHECK: note: content changed
 // CHECK: '[[M_H]]' required by '[[M_PCM:.*[/\\]m.*\.pcm]]'
 // CHECK: '[[M_PCM]]' required by '[[A_PCH]]'
 // CHECK: please rebuild precompiled file '[[A_PCH]]'

--- a/clang/test/PCH/include-timestamp.cpp
+++ b/clang/test/PCH/include-timestamp.cpp
@@ -31,4 +31,5 @@ void g() { f(); }
 // CHECK-BITCODE-TIMESTAMP-ON: <INPUT_FILE abbrevid={{.*}} op0={{.*}} op1={{.*}} op2={{[^0]}}
 // CHECK-BITCODE-TIMESTAMP-OFF: <INPUT_FILE abbrevid={{.*}} op0={{.*}} op1={{.*}} op2={{[0]}}
 
-// CHECK-TIMESTAMP: fatal error: file {{.*}} has been modified since the precompiled header {{.*}} was built: mtime changed (was {{.*}}, now {{.*}})
+// CHECK-TIMESTAMP: fatal error: file {{.*}} has been modified since the precompiled header {{.*}} was built
+// CHECK-TIMESTAMP: note: mtime changed from expected {{.*}} to {{.*}}

--- a/clang/test/PCH/validate-file-content.m
+++ b/clang/test/PCH/validate-file-content.m
@@ -22,6 +22,7 @@
 // RUN: not %clang_cc1 -fsyntax-only -I %t -include-pch %t/a.pch %s -fvalidate-ast-input-files-content 2> %t/stderr
 // RUN: FileCheck %s < %t/stderr
 //
-// CHECK: file '[[M_H:.*[/\\]m\.h]]' has been modified since the precompiled header '[[A_PCH:.*[/\\]a\.pch]]' was built: content changed
+// CHECK: file '[[M_H:.*[/\\]m\.h]]' has been modified since the precompiled header '[[A_PCH:.*[/\\]a\.pch]]' was built
+// CHECK: note: content changed
 // CHECK: please rebuild precompiled file '[[A_PCH]]'
 // expected-no-diagnostics

--- a/clang/test/PCH/verify_pch.m
+++ b/clang/test/PCH/verify_pch.m
@@ -17,7 +17,8 @@
 // RUN: echo ' ' >> %t.h
 // RUN: not %clang_cc1 -isystem %t/usr/include -verify-pch %t.pch 2> %t.log.2
 // RUN: FileCheck -check-prefix=CHECK-STALE-DEP %s < %t.log.2
-// CHECK-STALE-DEP: file '{{.*}}.h' has been modified since the precompiled header '{{.*}}.pch' was built: size changed (was {{.*}}, now {{.*}})
+// CHECK-STALE-DEP: file '{{.*}}.h' has been modified since the precompiled header '{{.*}}.pch' was built
+// CHECK-STALE-DEP: note: size changed from expected {{.*}} to {{.*}}
 
 // Stale dependency in system header
 // RUN: %clang_cc1 -isystem %t/usr/include -x objective-c-header -emit-pch -o %t.pch %t.h


### PR DESCRIPTION
So far higher visibility is more confusing than actionable. Keep the information available but make it less prominent.

rdar://159857416