### PR TITLE
[Clang] Add additional tests for constexpr initialization

### DIFF
--- a/clang/test/Sema/constexpr.c
+++ b/clang/test/Sema/constexpr.c
@@ -313,6 +313,12 @@ constexpr int *V84 = 42;
 constexpr int *V85 = nullptr;
 constexpr int *V91 = 0.0; 
 // expected-error@-1 {{initializing 'int *const' with an expression of incompatible type 'double'}}
+constexpr int *V92 = 0.0f;
+// expected-error@-1 {{initializing 'int *const' with an expression of incompatible type 'float'}}
+constexpr int *V93 = 0e0;
+// expected-error@-1 {{initializing 'int *const' with an expression of incompatible type 'double'}}
+constexpr int *V94 = 0x0p0;
+// expected-error@-1 {{initializing 'int *const' with an expression of incompatible type 'double'}}
 
 // Check that constexpr variables should not be VLAs.
 void f6(const int P1) {


### PR DESCRIPTION
Add constexpr initialization tests for 0.0f, 0e0, 0x0p0.