### PR TITLE
[Index] Reflect in SymbolSubKind whether a typedef points to a struct or a class

### DIFF
--- a/clang-tools-extra/clangd/FindSymbols.cpp
+++ b/clang-tools-extra/clangd/FindSymbols.cpp
@@ -152,7 +152,7 @@ getWorkspaceSymbols(llvm::StringRef Query, int Limit,
 
     SymbolInformation Info;
     Info.name = (Sym.Name + Sym.TemplateSpecializationArgs).str();
-    Info.kind = indexSymbolKindToSymbolKind(Sym.SymInfo.Kind);
+    Info.kind = indexSymbolKindToSymbolKind(Sym.SymInfo);
     Info.location = *Loc;
     Scope.consume_back("::");
     Info.containerName = Scope.str();
@@ -233,7 +233,7 @@ std::optional<DocumentSymbol> declToSym(ASTContext &Ctx, const NamedDecl &ND) {
   index::SymbolInfo SymInfo = index::getSymbolInfo(&ND);
   // FIXME: This is not classifying constructors, destructors and operators
   // correctly.
-  SymbolKind SK = indexSymbolKindToSymbolKind(SymInfo.Kind);
+  SymbolKind SK = indexSymbolKindToSymbolKind(SymInfo);
 
   DocumentSymbol SI;
   SI.name = getSymbolName(Ctx, ND);

--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -295,8 +295,8 @@ SymbolKind adjustKindToCapability(SymbolKind Kind,
   }
 }
 
-SymbolKind indexSymbolKindToSymbolKind(index::SymbolKind Kind) {
-  switch (Kind) {
+SymbolKind indexSymbolKindToSymbolKind(const index::SymbolInfo &Info) {
+  switch (Info.Kind) {
   // FIXME: for backwards compatibility, the include directive kind is treated
   // the same as Unknown
   case index::SymbolKind::IncludeDirective:
@@ -322,8 +322,16 @@ SymbolKind indexSymbolKindToSymbolKind(index::SymbolKind Kind) {
     return SymbolKind::Interface;
   case index::SymbolKind::Union:
     return SymbolKind::Class;
-  case index::SymbolKind::TypeAlias:
-    return SymbolKind::Class;
+  case index::SymbolKind::TypeAlias: {
+    switch (Info.SubKind) {
+    case index::SymbolSubKind::UsingStruct:
+      return SymbolKind::Struct;
+    case index::SymbolSubKind::UsingClass:
+      return SymbolKind::Class;
+    default:
+      return SymbolKind::Class;
+    }
+  }
   case index::SymbolKind::Function:
     return SymbolKind::Function;
   case index::SymbolKind::Variable:

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -417,7 +417,7 @@ SymbolKind adjustKindToCapability(SymbolKind Kind,
 // Note, some are not perfect matches and should be improved when this LSP
 // issue is addressed:
 // https://github.com/Microsoft/language-server-protocol/issues/344
-SymbolKind indexSymbolKindToSymbolKind(index::SymbolKind Kind);
+SymbolKind indexSymbolKindToSymbolKind(const index::SymbolInfo &Info);
 
 // Determines the encoding used to measure offsets and lengths of source in LSP.
 enum class OffsetEncoding {

--- a/clang-tools-extra/clangd/XRefs.cpp
+++ b/clang-tools-extra/clangd/XRefs.cpp
@@ -1806,7 +1806,7 @@ declToHierarchyItem(const NamedDecl &ND, llvm::StringRef TUPath) {
   index::SymbolInfo SymInfo = index::getSymbolInfo(&ND);
   // FIXME: This is not classifying constructors, destructors and operators
   // correctly.
-  SymbolKind SK = indexSymbolKindToSymbolKind(SymInfo.Kind);
+  SymbolKind SK = indexSymbolKindToSymbolKind(SymInfo);
 
   HierarchyItem HI;
   HI.name = printName(Ctx, ND);
@@ -1863,7 +1863,7 @@ static std::optional<HierarchyItem> symbolToHierarchyItem(const Symbol &S,
   HierarchyItem HI;
   HI.name = std::string(S.Name);
   HI.detail = (S.Scope + S.Name).str();
-  HI.kind = indexSymbolKindToSymbolKind(S.SymInfo.Kind);
+  HI.kind = indexSymbolKindToSymbolKind(S.SymInfo);
   HI.selectionRange = Loc->range;
   // FIXME: Populate 'range' correctly
   // (https://github.com/clangd/clangd/issues/59).

--- a/clang-tools-extra/clangd/unittests/FindSymbolsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/FindSymbolsTests.cpp
@@ -110,6 +110,28 @@ TEST(WorkspaceSymbols, Unnamed) {
                                 withKind(SymbolKind::Field))));
 }
 
+TEST(WorkspaceSymbols, TypeAlias) {
+  TestTU TU;
+  TU.Code = R"cpp(
+    struct Struct {};
+    class Class {};
+    class Container {
+      using StructAlias = Struct;
+      using ClassAlias = Class;
+    };
+  )cpp";
+  EXPECT_THAT(
+      getSymbols(TU, "Struct"),
+      UnorderedElementsAre(AllOf(qName("Struct"), withKind(SymbolKind::Struct)),
+                           AllOf(qName("Container::StructAlias"),
+                                 withKind(SymbolKind::Struct))));
+  EXPECT_THAT(
+      getSymbols(TU, "Class"),
+      UnorderedElementsAre(
+          AllOf(qName("Class"), withKind(SymbolKind::Class)),
+          AllOf(qName("Container::ClassAlias"), withKind(SymbolKind::Class))));
+}
+
 TEST(WorkspaceSymbols, InMainFile) {
   TestTU TU;
   TU.Code = R"cpp(

--- a/clang/include/clang/Index/IndexSymbol.h
+++ b/clang/include/clang/Index/IndexSymbol.h
@@ -79,6 +79,8 @@ enum class SymbolSubKind : uint8_t {
   UsingTypename,
   UsingValue,
   UsingEnum,
+  UsingClass,
+  UsingStruct,
 };
 
 typedef uint16_t SymbolPropertySet;

--- a/clang/test/Index/Core/index-source.cpp
+++ b/clang/test/Index/Core/index-source.cpp
@@ -23,10 +23,10 @@ class Cls { public:
 // CHECK: [[@LINE+2]]:24 | class/C++ | Cls | [[Cls_USR]] | <no-cgname> | Ref,RelBase,RelCont | rel: 1
 // CHECK-NEXT: RelBase,RelCont | SubCls1 | [[SubCls1_USR]]
 class SubCls1 : public Cls {};
-// CHECK: [[@LINE+1]]:13 | type-alias/C | ClsAlias | [[ClsAlias_USR:.*]] | <no-cgname> | Def | rel: 0
+// CHECK: [[@LINE+1]]:13 | type-alias/using-class/C | ClsAlias | [[ClsAlias_USR:.*]] | <no-cgname> | Def | rel: 0
 typedef Cls ClsAlias;
 // CHECK: [[@LINE+5]]:7 | class/C++ | SubCls2 | [[SubCls2_USR:.*]] | <no-cgname> | Def | rel: 0
-// CHECK: [[@LINE+4]]:24 | type-alias/C | ClsAlias | [[ClsAlias_USR]] | <no-cgname> | Ref,RelCont | rel: 1
+// CHECK: [[@LINE+4]]:24 | type-alias/using-class/C | ClsAlias | [[ClsAlias_USR]] | <no-cgname> | Ref,RelCont | rel: 1
 // CHECK-NEXT: RelCont | SubCls2 | [[SubCls2_USR]]
 // CHECK: [[@LINE+2]]:24 | class/C++ | Cls | [[Cls_USR]] | <no-cgname> | Ref,Impl,RelBase,RelCont | rel: 1
 // CHECK-NEXT: RelBase,RelCont | SubCls2 | [[SubCls2_USR]]


### PR DESCRIPTION
Typedefs don't have their own symbol kind in the Language Server Protocol, the choices are Struct or Class. For clangd to be able to represent typedefs accurately in response to requests such as `workspace/symbol`, it needs this information surfaced in index::SymbolInfo.

Fixes https://github.com/clangd/clangd/issues/2253