### PR TITLE
[lldb-dap] Add hex format in setVariable request

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1597,7 +1597,7 @@ class DebugCommunication(object):
         }
         return self._send_recv(command_dict)
 
-    def request_setVariable(self, containingVarRef, name, value, id=None):
+    def request_setVariable(self, containingVarRef, name, value, id=None, is_hex=None):
         args_dict = {
             "variablesReference": containingVarRef,
             "name": name,
@@ -1605,6 +1605,8 @@ class DebugCommunication(object):
         }
         if id is not None:
             args_dict["id"] = id
+        if is_hex is not None:
+            args_dict["format"] = {"hex": is_hex}
         command_dict = {
             "command": "setVariable",
             "type": "request",

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1581,7 +1581,7 @@ class DebugCommunication(object):
         return response
 
     def request_variables(
-        self, variablesReference, start=None, count=None, is_hex=None
+        self, variablesReference, start=None, count=None, is_hex: Optional[bool] = None
     ):
         args_dict = {"variablesReference": variablesReference}
         if start is not None:

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -375,7 +375,7 @@ class DAPTestCaseBase(TestBase):
         else:
             return int(value)
 
-    def set_variable(self, varRef, name, value, id=None, is_hex=None):
+    def set_variable(self, varRef, name, value, id=None, is_hex: Optional[bool] = None):
         """Set a variable."""
         response = self.dap_server.request_setVariable(
             varRef, name, str(value), id=id, is_hex=is_hex
@@ -385,7 +385,7 @@ class DAPTestCaseBase(TestBase):
             self.verify_memory_event(response["body"].get("memoryReference"))
         return response
 
-    def set_local(self, name, value, id=None, is_hex=None):
+    def set_local(self, name, value, id=None, is_hex: Optional[bool] = None):
         """Set a top level local variable only."""
         # Get the locals scope reference dynamically
         locals_ref = self.get_locals_scope_reference()

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -375,21 +375,23 @@ class DAPTestCaseBase(TestBase):
         else:
             return int(value)
 
-    def set_variable(self, varRef, name, value, id=None):
+    def set_variable(self, varRef, name, value, id=None, is_hex=None):
         """Set a variable."""
-        response = self.dap_server.request_setVariable(varRef, name, str(value), id=id)
+        response = self.dap_server.request_setVariable(
+            varRef, name, str(value), id=id, is_hex=is_hex
+        )
         if response["success"]:
             self.verify_invalidated_event(["variables"])
             self.verify_memory_event(response["body"].get("memoryReference"))
         return response
 
-    def set_local(self, name, value, id=None):
+    def set_local(self, name, value, id=None, is_hex=None):
         """Set a top level local variable only."""
         # Get the locals scope reference dynamically
         locals_ref = self.get_locals_scope_reference()
         if locals_ref is None:
             return None
-        return self.set_variable(locals_ref, name, str(value), id=id)
+        return self.set_variable(locals_ref, name, str(value), id=id, is_hex=is_hex)
 
     def get_locals_scope_reference(self):
         """Get the variablesReference for the locals scope."""

--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -306,6 +306,16 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
             argv, 0x1234, "verify argv was set to 0x1234 (0x1234 != %#x)" % (argv)
         )
 
+        # Test hexadecimal format
+        response = self.set_local("argc", 42, is_hex=True)
+        verify_response = {
+            "type": "int",
+            "value": "0x0000002a",
+        }
+        for key, value in verify_response.items():
+            self.assertEqual(value, response["body"][key])
+        self.set_local("argc", 123)
+
         # Set a variable value whose name is synthetic, like a variable index
         # and verify the value by reading it
         variable_value = 100

--- a/lldb/tools/lldb-dap/Handler/SetVariableRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetVariableRequestHandler.cpp
@@ -54,8 +54,9 @@ SetVariableRequestHandler::Run(const SetVariableArguments &args) const {
   if (!success)
     return llvm::make_error<DAPError>(error.GetCString());
 
+  const bool hex = args.format ? args.format->hex : false;
   VariableDescription desc(variable,
-                           dap.configuration.enableAutoVariableSummaries);
+                           dap.configuration.enableAutoVariableSummaries, hex);
 
   SetVariableResponseBody body;
   body.value = desc.display_value;

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -444,7 +444,7 @@ struct SetVariableArguments {
   std::string value;
 
   /// Specifies details on how to format the response value.
-  ValueFormat format;
+  std::optional<ValueFormat> format;
 };
 bool fromJSON(const llvm::json::Value &, SetVariableArguments &,
               llvm::json::Path);

--- a/lldb/unittests/DAP/ProtocolRequestsTest.cpp
+++ b/lldb/unittests/DAP/ProtocolRequestsTest.cpp
@@ -423,7 +423,7 @@ TEST(ProtocolRequestsTest, SetVariableArguments) {
     "value": "12345"
   })");
   ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
-  EXPECT_EQ(expected->variablesReference, 42U);
+  EXPECT_EQ(expected->variablesReference.AsUInt32(), 42U);
   EXPECT_EQ(expected->name, "test");
   EXPECT_EQ(expected->value, "12345");
   EXPECT_EQ(expected->format, std::nullopt);

--- a/lldb/unittests/DAP/ProtocolRequestsTest.cpp
+++ b/lldb/unittests/DAP/ProtocolRequestsTest.cpp
@@ -11,6 +11,7 @@
 #include "TestingSupport/TestUtilities.h"
 #include "llvm/Testing/Support/Error.h"
 #include <gtest/gtest.h>
+#include <optional>
 
 using namespace llvm;
 using namespace lldb_dap::protocol;
@@ -412,4 +413,23 @@ TEST(ProtocolRequestsTest, StackTraceResponseBody) {
 
   ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
   EXPECT_EQ(PrettyPrint(*expected), PrettyPrint(body));
+}
+
+TEST(ProtocolRequestsTest, SetVariableArguments) {
+  llvm::Expected<SetVariableArguments> expected =
+      parse<SetVariableArguments>(R"({
+    "variablesReference": 42,
+    "name": "test",
+    "value": "12345"
+  })");
+  ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
+  EXPECT_EQ(expected->variablesReference, 42U);
+  EXPECT_EQ(expected->name, "test");
+  EXPECT_EQ(expected->value, "12345");
+  EXPECT_EQ(expected->format, std::nullopt);
+
+  // Check required keys.
+  EXPECT_THAT_EXPECTED(
+      parse<SetVariableArguments>(R"({})"),
+      FailedWithMessage("missing value at (root).variablesReference"));
 }


### PR DESCRIPTION
Added hex format support in `setVariable` request according to DAP specification.