### PR TITLE
[Toolchains][FreeBSD] Honor system libgcc

### DIFF
--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -511,3 +511,18 @@ SanitizerMask FreeBSD::getSupportedSanitizers() const {
   }
   return Res;
 }
+
+std::string FreeBSD::getCompilerRT(const llvm::opt::ArgList &Args,
+                                   StringRef Component, FileType Type,
+                                   bool IsFortran) const {
+  if (Component == "builtins") {
+    std::string DetectedPath =
+        ToolChain::getCompilerRT(Args, Component, Type, IsFortran);
+    if (getVFS().exists(DetectedPath))
+      return DetectedPath;
+    SmallString<128> Path(getDriver().SysRoot);
+    llvm::sys::path::append(Path, "/usr/lib/libgcc.a");
+    return std::string(Path);
+  }
+  return ToolChain::getCompilerRT(Args, Component, Type, IsFortran);
+}

--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -520,6 +520,12 @@ std::string FreeBSD::getCompilerRT(const llvm::opt::ArgList &Args,
         ToolChain::getCompilerRT(Args, Component, Type, IsFortran);
     if (getVFS().exists(DetectedPath))
       return DetectedPath;
+    for (const auto &FilePath : getFilePaths()) {
+      SmallString<128> Path(FilePath);
+      llvm::sys::path::append(Path, "libgcc.a");
+      if (getVFS().exists(Path))
+        return std::string(Path);
+    }
     SmallString<128> Path(getDriver().SysRoot);
     llvm::sys::path::append(Path, "/usr/lib/libgcc.a");
     return std::string(Path);

--- a/clang/lib/Driver/ToolChains/FreeBSD.h
+++ b/clang/lib/Driver/ToolChains/FreeBSD.h
@@ -91,6 +91,8 @@ public:
   // Until dtrace (via CTF) and LLDB can deal with distributed debug info,
   // FreeBSD defaults to standalone/full debug info.
   bool GetDefaultStandaloneDebug() const override { return true; }
+  std::string getCompilerRT(const llvm::opt::ArgList &Args, StringRef Component,
+                            FileType Type, bool IsFortran) const override;
 
 protected:
   Tool *buildAssembler() const override;

--- a/clang/test/Driver/freebsd.cpp
+++ b/clang/test/Driver/freebsd.cpp
@@ -9,6 +9,10 @@
 // CHECK-DEFAULT: "-lc++" "-lm"
 // CHECK-STDLIBCXX: "-lstdc++" "-lm"
 
+// RUN: %clangxx %s --print-libgcc-file-name --target=amd64-unknown-freebsd 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-BUILTIN %s
+// CHECK-BUILTIN: /usr/lib/libgcc.a
+
 // RUN: %clangxx %s -### -pg --target=amd64-unknown-freebsd -stdlib=platform 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-PG-DEFAULT %s
 // RUN: %clangxx %s -### -pg --target=amd64-unknown-freebsd14.0 -stdlib=platform 2>&1 \


### PR DESCRIPTION
On Linux, the system libgcc may act as the compiler runtime, and Clang
provides -rtlib=compiler-rt to switch implementations.

FreeBSD ships libcompiler_rt.a (LLVM’s builtins) in the base system,
with libgcc.a as a symlink to it. These libraries are linked via -L and
-lgcc.

An interesting detail is that even if the Clang resource directory
(llvm-xx/lib/clang/xx) appears before the system path in the search
order, it is still not used. This is because the linker looks for
libgcc.a rather than libclang_rt.builtins.a.

Since FreeBSD does not currently support -rtlib, honor the system libgcc
by hardcoding its path. Detect and handle cases where a custom
compiler-rt is injected via -L as an override workaround.