### PR TITLE
[InstCombine] Allow simplifying FP selects of cmpxchg instructions.

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -2765,12 +2765,33 @@ static Value *foldSelectCmpXchg(SelectInst &SI) {
   // to I. If such conditions are true, the helper returns the cmpxchg
   // instruction; otherwise, a nullptr is returned.
   auto isExtractFromCmpXchg = [](Value *V, unsigned I) -> AtomicCmpXchgInst * {
+    // When extracting the value loaded by a cmpxchg, allow peeking through a
+    // bitcast. These are inserted for floating-point cmpxchg, for example:
+    //   %bc = bitcast float %compare to i32
+    //   %cmpxchg = cmpxchg ptr %ptr, i32 %bc, i32 %new_value seq_cst seq_cst
+    //   %val = extractvalue { i32, i1 } %cmpxchg, 0
+    //   %success = extractvalue { i32, i1 } %cmpxchg, 1
+    //   %val.bc = bitcast i32 %val to float
+    //   %sel = select i1 %success, float %compare, float %val.bc
+    if (I == 0 && isa<BitCastInst>(V))
+      V = cast<BitCastInst>(V)->getOperand(0);
     auto *Extract = dyn_cast<ExtractValueInst>(V);
     if (!Extract)
       return nullptr;
     if (Extract->getIndices()[0] != I)
       return nullptr;
     return dyn_cast<AtomicCmpXchgInst>(Extract->getAggregateOperand());
+  };
+
+  // Check if the compare value of a cmpxchg matches another value.
+  auto isCompareSameAsValue = [](Value *C, Value *V) {
+    // The values match if they are the same or %C = bitcast %V (see above).
+    if (C == V || match(C, m_BitCast(m_Specific(V))))
+      return true;
+    // For FP constants, the value may have been bitcast to Int directly.
+    auto *IntC = dyn_cast<ConstantInt>(C);
+    auto *FpC = dyn_cast<ConstantFP>(V);
+    return IntC && FpC && IntC->getValue() == FpC->getValue().bitcastToAPInt();
   };
 
   // If the select has a single user, and this user is a select instruction that
@@ -2791,14 +2812,16 @@ static Value *foldSelectCmpXchg(SelectInst &SI) {
   // value of the same cmpxchg used by the condition, and the false value is the
   // cmpxchg instruction's compare operand.
   if (auto *X = isExtractFromCmpXchg(SI.getTrueValue(), 0))
-    if (X == CmpXchg && X->getCompareOperand() == SI.getFalseValue())
+    if (X == CmpXchg &&
+        isCompareSameAsValue(X->getCompareOperand(), SI.getFalseValue()))
       return SI.getFalseValue();
 
   // Check the false value case: The false value of the select is the returned
   // value of the same cmpxchg used by the condition, and the true value is the
   // cmpxchg instruction's compare operand.
   if (auto *X = isExtractFromCmpXchg(SI.getFalseValue(), 0))
-    if (X == CmpXchg && X->getCompareOperand() == SI.getTrueValue())
+    if (X == CmpXchg &&
+        isCompareSameAsValue(X->getCompareOperand(), SI.getTrueValue()))
       return SI.getFalseValue();
 
   return nullptr;

--- a/llvm/test/Transforms/InstCombine/select-cmpxchg.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmpxchg.ll
@@ -38,3 +38,76 @@ define i64 @cmpxchg_2(ptr %ptr, i64 %compare, i64 %new_value) {
   %t4 = select i1 %t1, i64 %t3, i64 %compare
   ret i64 %t4
 }
+
+define double @cmpxchg_fp(ptr %ptr, double %compare, i64 %new_value) {
+; CHECK-LABEL: @cmpxchg_fp(
+; CHECK-NEXT:    [[BC:%.*]] = bitcast double [[COMPARE:%.*]] to i64
+; CHECK-NEXT:    [[T0:%.*]] = cmpxchg ptr [[PTR:%.*]], i64 [[BC]], i64 [[NEW_VALUE:%.*]] acq_rel monotonic, align 8
+; CHECK-NEXT:    [[T1:%.*]] = extractvalue { i64, i1 } [[T0]], 1
+; CHECK-NEXT:    [[T2:%.*]] = extractvalue { i64, i1 } [[T0]], 0
+; CHECK-NEXT:    [[T3:%.*]] = bitcast i64 [[T2]] to double
+; CHECK-NEXT:    [[T4:%.*]] = select i1 [[T1]], double [[COMPARE]], double [[T3]]
+; CHECK-NEXT:    ret double [[T4]]
+;
+  %bc = bitcast double %compare to i64
+  %t0 = cmpxchg ptr %ptr, i64 %bc, i64 %new_value acq_rel monotonic
+  %t1 = extractvalue { i64, i1 } %t0, 1
+  %t2 = extractvalue { i64, i1 } %t0, 0
+  %t3 = bitcast i64 %t2 to double
+  %t4 = select i1 %t1, double %compare, double %t3
+  ret double %t4
+}
+
+define double @cmpxchg_fp_const(ptr %ptr, i64 %new_value) {
+; CHECK-LABEL: @cmpxchg_fp_const(
+; CHECK-NEXT:    [[T0:%.*]] = cmpxchg ptr [[PTR:%.*]], i64 0, i64 [[NEW_VALUE:%.*]] acq_rel monotonic, align 8
+; CHECK-NEXT:    [[T1:%.*]] = extractvalue { i64, i1 } [[T0]], 1
+; CHECK-NEXT:    [[T2:%.*]] = extractvalue { i64, i1 } [[T0]], 0
+; CHECK-NEXT:    [[T3:%.*]] = bitcast i64 [[T2]] to double
+; CHECK-NEXT:    [[T4:%.*]] = select i1 [[T1]], double 0.000000e+00, double [[T3]]
+; CHECK-NEXT:    ret double [[T4]]
+;
+  %t0 = cmpxchg ptr %ptr, i64 0, i64 %new_value acq_rel monotonic
+  %t1 = extractvalue { i64, i1 } %t0, 1
+  %t2 = extractvalue { i64, i1 } %t0, 0
+  %t3 = bitcast i64 %t2 to double
+  %t4 = select i1 %t1, double 0., double %t3
+  ret double %t4
+}
+
+define <2 x i32> @cmpxchg_v2i32(ptr %ptr, <2 x i32> %compare, i64 %new_value) {
+; CHECK-LABEL: @cmpxchg_v2i32(
+; CHECK-NEXT:    [[BC:%.*]] = bitcast <2 x i32> [[COMPARE:%.*]] to i64
+; CHECK-NEXT:    [[T0:%.*]] = cmpxchg ptr [[PTR:%.*]], i64 [[BC]], i64 [[NEW_VALUE:%.*]] acq_rel monotonic, align 8
+; CHECK-NEXT:    [[T1:%.*]] = extractvalue { i64, i1 } [[T0]], 1
+; CHECK-NEXT:    [[T2:%.*]] = extractvalue { i64, i1 } [[T0]], 0
+; CHECK-NEXT:    [[T3:%.*]] = bitcast i64 [[T2]] to <2 x i32>
+; CHECK-NEXT:    [[T4:%.*]] = select i1 [[T1]], <2 x i32> [[COMPARE]], <2 x i32> [[T3]]
+; CHECK-NEXT:    ret <2 x i32> [[T4]]
+;
+  %bc = bitcast <2 x i32> %compare to i64
+  %t0 = cmpxchg ptr %ptr, i64 %bc, i64 %new_value acq_rel monotonic
+  %t1 = extractvalue { i64, i1 } %t0, 1
+  %t2 = extractvalue { i64, i1 } %t0, 0
+  %t3 = bitcast i64 %t2 to <2 x i32>
+  %t4 = select i1 %t1, <2 x i32> %compare, <2 x i32> %t3
+  ret <2 x i32> %t4
+}
+
+; Currently not supported.
+define <2 x i32> @cmpxchg_v2i32_const(ptr %ptr, i64 %new_value) {
+; CHECK-LABEL: @cmpxchg_v2i32_const(
+; CHECK-NEXT:    [[T0:%.*]] = cmpxchg ptr [[PTR:%.*]], i64 0, i64 [[NEW_VALUE:%.*]] acq_rel monotonic, align 8
+; CHECK-NEXT:    [[T1:%.*]] = extractvalue { i64, i1 } [[T0]], 1
+; CHECK-NEXT:    [[T2:%.*]] = extractvalue { i64, i1 } [[T0]], 0
+; CHECK-NEXT:    [[T3:%.*]] = bitcast i64 [[T2]] to <2 x i32>
+; CHECK-NEXT:    [[T4:%.*]] = select i1 [[T1]], <2 x i32> zeroinitializer, <2 x i32> [[T3]]
+; CHECK-NEXT:    ret <2 x i32> [[T4]]
+;
+  %t0 = cmpxchg ptr %ptr, i64 0, i64 %new_value acq_rel monotonic
+  %t1 = extractvalue { i64, i1 } %t0, 1
+  %t2 = extractvalue { i64, i1 } %t0, 0
+  %t3 = bitcast i64 %t2 to <2 x i32>
+  %t4 = select i1 %t1, <2 x i32> <i32 0, i32 0>, <2 x i32> %t3
+  ret <2 x i32> %t4
+}

--- a/llvm/test/Transforms/InstCombine/select-cmpxchg.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmpxchg.ll
@@ -43,11 +43,9 @@ define double @cmpxchg_fp(ptr %ptr, double %compare, i64 %new_value) {
 ; CHECK-LABEL: @cmpxchg_fp(
 ; CHECK-NEXT:    [[BC:%.*]] = bitcast double [[COMPARE:%.*]] to i64
 ; CHECK-NEXT:    [[T0:%.*]] = cmpxchg ptr [[PTR:%.*]], i64 [[BC]], i64 [[NEW_VALUE:%.*]] acq_rel monotonic, align 8
-; CHECK-NEXT:    [[T1:%.*]] = extractvalue { i64, i1 } [[T0]], 1
 ; CHECK-NEXT:    [[T2:%.*]] = extractvalue { i64, i1 } [[T0]], 0
 ; CHECK-NEXT:    [[T3:%.*]] = bitcast i64 [[T2]] to double
-; CHECK-NEXT:    [[T4:%.*]] = select i1 [[T1]], double [[COMPARE]], double [[T3]]
-; CHECK-NEXT:    ret double [[T4]]
+; CHECK-NEXT:    ret double [[T3]]
 ;
   %bc = bitcast double %compare to i64
   %t0 = cmpxchg ptr %ptr, i64 %bc, i64 %new_value acq_rel monotonic
@@ -61,11 +59,9 @@ define double @cmpxchg_fp(ptr %ptr, double %compare, i64 %new_value) {
 define double @cmpxchg_fp_const(ptr %ptr, i64 %new_value) {
 ; CHECK-LABEL: @cmpxchg_fp_const(
 ; CHECK-NEXT:    [[T0:%.*]] = cmpxchg ptr [[PTR:%.*]], i64 0, i64 [[NEW_VALUE:%.*]] acq_rel monotonic, align 8
-; CHECK-NEXT:    [[T1:%.*]] = extractvalue { i64, i1 } [[T0]], 1
 ; CHECK-NEXT:    [[T2:%.*]] = extractvalue { i64, i1 } [[T0]], 0
 ; CHECK-NEXT:    [[T3:%.*]] = bitcast i64 [[T2]] to double
-; CHECK-NEXT:    [[T4:%.*]] = select i1 [[T1]], double 0.000000e+00, double [[T3]]
-; CHECK-NEXT:    ret double [[T4]]
+; CHECK-NEXT:    ret double [[T3]]
 ;
   %t0 = cmpxchg ptr %ptr, i64 0, i64 %new_value acq_rel monotonic
   %t1 = extractvalue { i64, i1 } %t0, 1
@@ -79,11 +75,9 @@ define <2 x i32> @cmpxchg_v2i32(ptr %ptr, <2 x i32> %compare, i64 %new_value) {
 ; CHECK-LABEL: @cmpxchg_v2i32(
 ; CHECK-NEXT:    [[BC:%.*]] = bitcast <2 x i32> [[COMPARE:%.*]] to i64
 ; CHECK-NEXT:    [[T0:%.*]] = cmpxchg ptr [[PTR:%.*]], i64 [[BC]], i64 [[NEW_VALUE:%.*]] acq_rel monotonic, align 8
-; CHECK-NEXT:    [[T1:%.*]] = extractvalue { i64, i1 } [[T0]], 1
 ; CHECK-NEXT:    [[T2:%.*]] = extractvalue { i64, i1 } [[T0]], 0
 ; CHECK-NEXT:    [[T3:%.*]] = bitcast i64 [[T2]] to <2 x i32>
-; CHECK-NEXT:    [[T4:%.*]] = select i1 [[T1]], <2 x i32> [[COMPARE]], <2 x i32> [[T3]]
-; CHECK-NEXT:    ret <2 x i32> [[T4]]
+; CHECK-NEXT:    ret <2 x i32> [[T3]]
 ;
   %bc = bitcast <2 x i32> %compare to i64
   %t0 = cmpxchg ptr %ptr, i64 %bc, i64 %new_value acq_rel monotonic


### PR DESCRIPTION
We already simplify selects that test the flag returned by a cmpxchg and select between the value the cmpxchg loaded and the compare operand.

This patch extends the fold to FP (and vector) compare-exchange operations, where the compare operand and loaded value are bitcast.