### PR TITLE
[flang] fix do while lowering to SCF after unstructured context

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2540,7 +2540,6 @@ private:
       // PFT branch analysis), allowing the loop to exit only when the condition
       // becomes false.
       if (!unstructuredContext) {
-        maybeStartBlock(preheaderBlock); // no block or empty block
         genDoWhileAsSCFWhile(*whileCondition, eval, doStmtEval);
         return;
       }

--- a/flang/test/Lower/do-while-to-scf-while.f90
+++ b/flang/test/Lower/do-while-to-scf-while.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-fir -hlfir=false -lower-do-while-to-scf-while %s -o - | FileCheck %s
+! RUN: bbc -emit-hlfir -lower-do-while-to-scf-while %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func.func @_QPsimple_do_while()
 ! CHECK: scf.while
@@ -85,3 +85,20 @@ subroutine do_while_goto_internal_backedge()
   print *, "sum=", sum
 end subroutine do_while_goto_internal_backedge
 
+! CHECK-LABEL:   func.func @_QPtest_after_unstructured(
+! CHECK:  scf.while
+! CHECK-NOT: cf.br
+! CHECK: return
+subroutine test_after_unstructured(cdt, switch)
+  logical :: cdt, eval
+  integer :: switch, i = 1
+  if (cdt) then
+    select case (switch)
+      case (0)
+        call print1()
+    end select
+  end if
+  do while(eval(i))
+    call incr(i)
+  end do
+end subroutine


### PR DESCRIPTION
`maybeStartBlock(preheaderBlock);` should not be called when lowering a DO WHILE in a structured fashion, it is meant to insert branches in unstructured contexts lowering.

This had the side effect of inserting a back edge to the block containing the scf for DO WHILE after a construct lowered in an unstructured fashion because blocks may be unterminated after unstructured lowering, and `maybeStartBlock` created a `cf.br` to its argument when the current block is unterminated (and here, the argument and current block where the same, creating an infinite loop).