### PR TITLE
[clang-tidy] Add modernize-use-init-statement check

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
@@ -39,6 +39,7 @@ add_clang_library(clangTidyModernizeModule STATIC
   UseEmplaceCheck.cpp
   UseEqualsDefaultCheck.cpp
   UseEqualsDeleteCheck.cpp
+  UseInitStatementCheck.cpp
   UseIntegerSignComparisonCheck.cpp
   UseNodiscardCheck.cpp
   UseNoexceptCheck.cpp

--- a/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
@@ -39,6 +39,7 @@
 #include "UseEmplaceCheck.h"
 #include "UseEqualsDefaultCheck.h"
 #include "UseEqualsDeleteCheck.h"
+#include "UseInitStatementCheck.h"
 #include "UseIntegerSignComparisonCheck.h"
 #include "UseNodiscardCheck.h"
 #include "UseNoexceptCheck.h"
@@ -128,6 +129,8 @@ public:
         "modernize-use-equals-default");
     CheckFactories.registerCheck<UseEqualsDeleteCheck>(
         "modernize-use-equals-delete");
+    CheckFactories.registerCheck<UseInitStatementCheck>(
+        "modernize-use-init-statement");
     CheckFactories.registerCheck<UseNodiscardCheck>("modernize-use-nodiscard");
     CheckFactories.registerCheck<UseNoexceptCheck>("modernize-use-noexcept");
     CheckFactories.registerCheck<UseNullptrCheck>("modernize-use-nullptr");

--- a/clang-tools-extra/clang-tidy/modernize/UseInitStatementCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseInitStatementCheck.cpp
@@ -1,0 +1,153 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "UseInitStatementCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Lex/Lexer.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::modernize {
+
+void UseInitStatementCheck::registerMatchers(MatchFinder *Finder) {
+  // Match if/switch statements that:
+  //   - don't already have an init-statement
+  //   - are inside a compound statement
+  //   - are not in template instantiations
+  Finder->addMatcher(
+      compoundStmt(forEach(ifStmt(unless(hasInitStatement(anything())),
+                                  unless(isInTemplateInstantiation()))
+                               .bind("if")))
+          .bind("compound"),
+      this);
+
+  Finder->addMatcher(
+      compoundStmt(forEach(switchStmt(unless(hasInitStatement(anything())),
+                                      unless(isInTemplateInstantiation()))
+                               .bind("switch")))
+          .bind("compound"),
+      this);
+}
+
+/// Check if the variable declared in \p DS is referenced anywhere in the
+/// subtree rooted at \p S.
+static bool isVarReferencedIn(const VarDecl *VD, const Stmt *S,
+                              ASTContext &Ctx) {
+  return !match(findAll(declRefExpr(to(varDecl(equalsNode(VD))))), *S, Ctx)
+              .empty();
+}
+
+void UseInitStatementCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *Compound = Result.Nodes.getNodeAs<CompoundStmt>("compound");
+  const Stmt *ConditionalStmt = Result.Nodes.getNodeAs<IfStmt>("if");
+  if (!ConditionalStmt)
+    ConditionalStmt = Result.Nodes.getNodeAs<SwitchStmt>("switch");
+  if (!ConditionalStmt || !Compound)
+    return;
+
+  // Find the position of the if/switch in the compound statement.
+  const auto *PrevDeclStmt = static_cast<const DeclStmt *>(nullptr);
+  for (auto It = Compound->body_begin(), End = Compound->body_end(); It != End;
+       ++It) {
+    if (*It == ConditionalStmt) {
+      // Check if the previous statement is a DeclStmt.
+      if (It == Compound->body_begin())
+        return;
+      PrevDeclStmt = dyn_cast<DeclStmt>(*(It - 1));
+      break;
+    }
+  }
+
+  if (!PrevDeclStmt)
+    return;
+
+  // Only handle single declarations.
+  if (!PrevDeclStmt->isSingleDecl())
+    return;
+
+  const auto *VD = dyn_cast<VarDecl>(PrevDeclStmt->getSingleDecl());
+  if (!VD)
+    return;
+
+  // Variable must have an initializer.
+  if (!VD->hasInit())
+    return;
+
+  // Skip if the variable is static or extern.
+  if (VD->hasGlobalStorage())
+    return;
+
+  // The variable must be referenced in the condition of the if/switch.
+  const Expr *Condition = nullptr;
+  if (const auto *If = dyn_cast<IfStmt>(ConditionalStmt))
+    Condition = If->getCond();
+  else if (const auto *Switch = dyn_cast<SwitchStmt>(ConditionalStmt))
+    Condition = Switch->getCond();
+
+  if (!Condition || !isVarReferencedIn(VD, Condition, *Result.Context))
+    return;
+
+  // The variable must NOT be referenced after the if/switch statement.
+  bool FoundConditional = false;
+  for (const Stmt *Child : Compound->body()) {
+    if (Child == ConditionalStmt) {
+      FoundConditional = true;
+      continue;
+    }
+    if (FoundConditional && isVarReferencedIn(VD, Child, *Result.Context))
+      return;
+  }
+
+  // Skip if the DeclStmt or ConditionalStmt are in macros.
+  if (PrevDeclStmt->getBeginLoc().isMacroID() ||
+      ConditionalStmt->getBeginLoc().isMacroID())
+    return;
+
+  const bool IsIf = isa<IfStmt>(ConditionalStmt);
+  const StringRef StmtKind = IsIf ? "if" : "switch";
+
+  const SourceLocation DeclStart = PrevDeclStmt->getBeginLoc();
+
+  // Get source text of the declaration (up to the VarDecl's end, not
+  // the DeclStmt's semicolon).
+  const SourceLocation VarDeclEnd = VD->getEndLoc();
+  const StringRef DeclText = Lexer::getSourceText(
+      CharSourceRange::getTokenRange(DeclStart, VarDeclEnd),
+      *Result.SourceManager, Result.Context->getLangOpts());
+
+  // Get the location right after the opening paren/keyword of if/switch.
+  SourceLocation CondStart;
+  if (IsIf) {
+    const auto *If = cast<IfStmt>(ConditionalStmt);
+    // The LParenLoc gives us the '(' position.
+    CondStart = If->getLParenLoc().getLocWithOffset(1);
+  } else {
+    const auto *Switch = cast<SwitchStmt>(ConditionalStmt);
+    CondStart = Switch->getLParenLoc().getLocWithOffset(1);
+  }
+
+  if (!CondStart.isValid())
+    return;
+
+  auto Diag = diag(PrevDeclStmt->getBeginLoc(),
+                   "variable %0 can be declared in the '%1' init-statement")
+              << VD << StmtKind;
+
+  // Fix 1: Remove the declaration statement.
+  // Remove everything from DeclStart to just before the if/switch keyword,
+  // i.e., "int result = compute();\n  " -> leaves the if/switch in place.
+  Diag << FixItHint::CreateRemoval(
+      CharSourceRange::getCharRange(DeclStart, ConditionalStmt->getBeginLoc()));
+
+  // Fix 2: Insert "decl; " at the start of the condition.
+  const std::string InitStmt = (DeclText + "; ").str();
+  Diag << FixItHint::CreateInsertion(CondStart, InitStmt);
+}
+
+} // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseInitStatementCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseInitStatementCheck.h
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USEINITSTATEMENTCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USEINITSTATEMENTCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang::tidy::modernize {
+
+/// Finds variable declarations immediately before an ``if`` or ``switch``
+/// statement where the variable is only used inside the conditional, and
+/// suggests moving the declaration into the init-statement (C++17).
+///
+/// For example:
+/// \code
+///   auto it = map.find(key);
+///   if (it != map.end()) { use(it); }
+/// \endcode
+/// becomes:
+/// \code
+///   if (auto it = map.find(key); it != map.end()) { use(it); }
+/// \endcode
+///
+/// For the user-facing documentation see:
+/// https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-init-statement.html
+class UseInitStatementCheck : public ClangTidyCheck {
+public:
+  UseInitStatementCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus17;
+  }
+};
+
+} // namespace clang::tidy::modernize
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USEINITSTATEMENTCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -121,6 +121,13 @@ New checks
   ``llvm::to_vector(llvm::make_filter_range(...))`` that can be replaced with
   ``llvm::map_to_vector`` and ``llvm::filter_to_vector``.
 
+- New :doc:`modernize-use-init-statement
+  <clang-tidy/checks/modernize/use-init-statement>` check.
+
+  Finds variable declarations immediately before ``if`` or ``switch``
+  statements where the variable is only used inside the conditional,
+  and suggests moving it into the C++17 init-statement.
+
 - New :doc:`modernize-use-string-view
   <clang-tidy/checks/modernize/use-string-view>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -319,6 +319,7 @@ Clang-Tidy Checks
    :doc:`modernize-use-emplace <modernize/use-emplace>`, "Yes"
    :doc:`modernize-use-equals-default <modernize/use-equals-default>`, "Yes"
    :doc:`modernize-use-equals-delete <modernize/use-equals-delete>`, "Yes"
+   :doc:`modernize-use-init-statement <modernize/use-init-statement>`, "Yes"
    :doc:`modernize-use-integer-sign-comparison <modernize/use-integer-sign-comparison>`, "Yes"
    :doc:`modernize-use-nodiscard <modernize/use-nodiscard>`, "Yes"
    :doc:`modernize-use-noexcept <modernize/use-noexcept>`, "Yes"

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-init-statement.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-init-statement.rst
@@ -1,0 +1,53 @@
+.. title:: clang-tidy - modernize-use-init-statement
+
+modernize-use-init-statement
+============================
+
+Finds variable declarations immediately before ``if`` or ``switch``
+statements where the variable is only used inside the conditional,
+and suggests moving the declaration into the C++17 init-statement.
+
+This reduces the scope of the variable to the minimum necessary,
+improving readability and reducing the risk of accidental reuse.
+
+For example:
+
+.. code-block:: c++
+
+  auto it = m.find(key);
+  if (it != m.end()) {
+    use(it);
+  }
+
+  // transforms to:
+
+  if (auto it = m.find(key); it != m.end()) {
+    use(it);
+  }
+
+Similarly for ``switch`` statements:
+
+.. code-block:: c++
+
+  Color c = getColor();
+  switch (c) {
+  case Red: break;
+  case Green: break;
+  }
+
+  // transforms to:
+
+  switch (Color c = getColor(); c) {
+  case Red: break;
+  case Green: break;
+  }
+
+The check only triggers when all of the following are true:
+
+- The variable declaration immediately precedes the ``if``/``switch``.
+- The declaration has a single variable with an initializer.
+- The variable is referenced in the condition.
+- The variable is not referenced after the ``if``/``switch``.
+- The ``if``/``switch`` does not already have an init-statement.
+- Neither the declaration nor the conditional is in a macro.
+- The variable does not have static or extern storage.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-init-statement.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-init-statement.cpp
@@ -1,0 +1,111 @@
+// RUN: %check_clang_tidy -std=c++17-or-later %s modernize-use-init-statement %t
+
+int compute();
+
+// Positive: simple int variable used in if condition
+void test_if_simple_int() {
+  int x = 42;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: variable 'x' can be declared in the 'if' init-statement [modernize-use-init-statement]
+  // CHECK-FIXES: if (int x = 42; x > 0) {
+  if (x > 0) {
+    int y = x + 1;
+  }
+}
+
+// Positive: function call result used in if condition
+void test_if_function_call() {
+  int result = compute();
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: variable 'result' can be declared in the 'if' init-statement [modernize-use-init-statement]
+  // CHECK-FIXES: if (int result = compute(); result != 0) {
+  if (result != 0) {
+    int y = result;
+  }
+}
+
+// Positive: variable only used in condition, not in body
+void test_if_only_in_condition() {
+  int x = 10;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: variable 'x' can be declared in the 'if' init-statement [modernize-use-init-statement]
+  // CHECK-FIXES: if (int x = 10; x > 5) {
+  if (x > 5) {
+  }
+}
+
+enum Color { Red, Green, Blue };
+Color getColor();
+
+// Positive: switch statement
+void test_switch() {
+  Color c = getColor();
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: variable 'c' can be declared in the 'switch' init-statement [modernize-use-init-statement]
+  // CHECK-FIXES: switch (Color c = getColor(); c) {
+  switch (c) {
+  case Red:
+    break;
+  case Green:
+    break;
+  default:
+    break;
+  }
+}
+
+// Negative: variable used after if
+void test_used_after_if() {
+  int it = compute();
+  if (it != 0) {
+    int y = it;
+  }
+  int z = it; // Used after if - should not move
+}
+
+// Negative: variable modified after if
+void test_used_in_else_and_after() {
+  int x = compute();
+  if (x > 0) {
+    int y = x;
+  }
+  x = 0; // Modified after if
+}
+
+// Negative: no initializer
+void test_no_init() {
+  int x;
+  if (x > 0) {
+  }
+}
+
+// Negative: already has init-statement
+void test_already_has_init() {
+  if (int x = compute(); x > 0) {
+  }
+}
+
+// Negative: multiple declarations
+void test_multiple_decls() {
+  int x = 1, y = 2;
+  if (x > 0) {
+  }
+}
+
+// Negative: variable not referenced in condition
+void test_not_in_condition() {
+  int x = 10;
+  if (true) {
+    int y = x;
+  }
+}
+
+// Negative: static variable
+void test_static_var() {
+  static int x = 42;
+  if (x > 0) {
+  }
+}
+
+// Negative: previous stmt is not the variable declaration
+void test_not_previous_stmt() {
+  int x = 10;
+  int y = 20;
+  if (x > 0) {
+  }
+}


### PR DESCRIPTION
Add new clang-tidy check that suggests moving variable declarations into C++17 `if`/`switch` init-statements when the variable is only used inside the conditional.

This reduces variable scope to the minimum necessary, improving readability and reducing the risk of accidental reuse.

For example:
```cpp
auto it = m.find(key);
if (it != m.end()) { use(it); }

// transforms to:

if (auto it = m.find(key); it != m.end()) { use(it); }
```

The check only triggers when the declaration immediately precedes the `if`/`switch`, has a single initialized variable referenced in the condition, and the variable is not used after the conditional.