### PR TITLE
[Offload] Always check/consume Error

### DIFF
--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -879,8 +879,10 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
   /// in notifyDataMapped, this function should unlock it.
   Error notifyDataUnmapped(void *HstPtr) {
     auto Err = PinnedAllocs.unregisterMemory(HstPtr, LockMappedBuffers);
-    if (IgnoreLockMappedFailures)
+    if (IgnoreLockMappedFailures) {
+      consumeError(std::move(Err));
       return Plugin::success();
+    }
     return Err;
   }
 


### PR DESCRIPTION
This fixes an issue introduced in https://github.com/llvm/llvm-project/pull/172226 where an llvm::Error is not checked in the "good" code path.