### PR TITLE
[MLIR][XeGPU] Distribute `vector.step` with sliced layout

### DIFF
--- a/mlir/lib/Dialect/XeGPU/IR/XeGPUDialect.cpp
+++ b/mlir/lib/Dialect/XeGPU/IR/XeGPUDialect.cpp
@@ -699,8 +699,6 @@ FailureOr<SmallVector<SmallVector<Value>>>
 SliceAttr::computeDistributedCoords(OpBuilder &builder, Location loc,
                                     Value linearId, ArrayRef<int64_t> shape) {
   assert(getRank() == static_cast<int64_t>(shape.size()) && "invalid shape.");
-  if (!isForWorkgroup())
-    return failure();
 
   SmallVector<int64_t> layout;
   SmallVector<int64_t> subShape;

--- a/mlir/test/Dialect/XeGPU/subgroup-distribute-unit.mlir
+++ b/mlir/test/Dialect/XeGPU/subgroup-distribute-unit.mlir
@@ -1133,10 +1133,11 @@ gpu.func
   }
 
 // CHECK-LABEL: gpu.func @vector_step_slice
-// CHECK:         (%[[SG_ID:[0-9a-zA-Z]+]]: index) {
-// CHECK-NEXT:    %[[SG_ID_IN_SLICED_DIM:.*]] = affine.apply #map()[%[[SG_ID]]]
-// CHECK-NEXT:    %[[SG_ID_IN_SLICED_DIM_VEC:.*]] = vector.broadcast %[[SG_ID_IN_SLICED_DIM]] : index to vector<1xindex>
-// CHECK-NEXT:    "some_use"(%[[SG_ID_IN_SLICED_DIM_VEC]]) : (vector<1xindex>) -> ()
+// CHECK:         (%[[LANE_ID:[0-9a-zA-Z]+]]: index) {
+// CHECK:         %[[LANE_ID_IN_SLICED_DIM:.*]] = arith.remui %[[LANE_ID]], %c16 : index
+// CHECK-NEXT:    %[[LANE_ID_IN_SLICED_DIM1:.*]] = arith.remui %[[LANE_ID_IN_SLICED_DIM]], %c16 : index
+// CHECK-NEXT:    %[[LANE_ID_IN_SLICED_DIM_VEC:.*]] = vector.broadcast %[[LANE_ID_IN_SLICED_DIM1]] : index to vector<1xindex>
+// CHECK-NEXT:    "some_use"(%[[LANE_ID_IN_SLICED_DIM_VEC]]) : (vector<1xindex>) -> ()
   gpu.func @vector_step_slice(%arg0: index) {
     %0 = gpu.warp_execute_on_lane_0(%arg0)[16] -> (vector<1xindex>) {
       %5 = vector.step {layout_result_0 = #xegpu.slice<#xegpu.layout<lane_layout = [1, 1, 1, 16], lane_data = [1, 1, 1, 1]>, dims = [0, 1, 2]>} : vector<16xindex>
@@ -1147,15 +1148,44 @@ gpu.func
   }
 
   // CHECK-LABEL: gpu.func @vector_step_slice_unit
-  // CHECK:         (%[[SG_ID:[0-9a-zA-Z]+]]: index) {
-  // CHECK-NEXT:    %[[SG_ID_IN_SLICED_DIM_VEC:.*]] = arith.constant dense<0> : vector<1xindex>
-  // CHECK-NEXT:    "some_use"(%[[SG_ID_IN_SLICED_DIM_VEC]]) : (vector<1xindex>) -> ()
+  // CHECK:         (%[[LANE_ID:[0-9a-zA-Z]+]]: index) {
+  // CHECK-NEXT:    %[[LANE_ID_IN_SLICED_DIM_VEC:.*]] = arith.constant dense<0> : vector<1xindex>
+  // CHECK-NEXT:    "some_use"(%[[LANE_ID_IN_SLICED_DIM_VEC]]) : (vector<1xindex>) -> ()
   gpu.func @vector_step_slice_unit(%arg0: index) {
     %0 = gpu.warp_execute_on_lane_0(%arg0)[16] -> (vector<1xindex>) {
       %5 = vector.step {layout_result_0 = #xegpu.slice<#xegpu.layout<lane_layout = [1, 1, 1, 16], lane_data = [1, 1, 1, 1]>, dims = [0, 1, 3]>} : vector<1xindex>
       gpu.yield %5 : vector<1xindex>
     }
     "some_use"(%0) : (vector<1xindex>) -> ()
+    gpu.return
+  }
+
+  // CHECK-LABEL: gpu.func @vector_step_slice_multi_dist_unit
+  // CHECK:         (%[[LANE_ID:[0-9a-zA-Z]+]]: index) {
+  // CHECK-DAG:    %[[C1:.*]] = arith.constant 1 : index
+  // CHECK-DAG:    %[[DIST_UNIT_SIZE:.*]] = arith.constant 8 : index
+  // CHECK-DAG:    %[[SG_LEVEL_VECSIZE:.*]] = arith.constant 16 : index
+  // CHECK-DAG:    %[[LANE_LAYOUT:.*]] = arith.constant 4 : index
+  // CHECK-DAG:    %[[LANE_DATA:.*]] = arith.constant 2 : index
+  // CHECK-DAG:    %[[LANE_DIST_UNIT_START_IDX:.*]] = arith.divui %[[LANE_ID]], %[[LANE_DATA]] : index
+  // CHECK-DAG:    %[[DIST_UNIT_0_IDX:.*]] = arith.remui %[[LANE_DIST_UNIT_START_IDX]], %[[LANE_LAYOUT]] : index
+  // CHECK-DAG:    %[[DIST_UNIT_0_OFFSET:.*]] = arith.muli %[[DIST_UNIT_0_IDX]], %[[LANE_DATA]] : index
+  // CHECK-DAG:    %[[DIST_UNIT_0_SUBRANGE_START:.*]] = arith.remui %[[DIST_UNIT_0_OFFSET]], %[[SG_LEVEL_VECSIZE]] : index
+  // CHECK-DAG:    %[[DIST_UNIT_1_OFFSET:.*]] = arith.addi %[[DIST_UNIT_0_OFFSET]], %[[DIST_UNIT_SIZE]] : index
+  // CHECK-DAG:    %[[DIST_UNIT_1_SUBRANGE_START:.*]] = arith.remui %[[DIST_UNIT_1_OFFSET]], %[[SG_LEVEL_VECSIZE]] : index
+  // CHECK-DAG:    %[[V6:.*]] = arith.addi %[[DIST_UNIT_0_SUBRANGE_START]], %[[C1]] : index
+  // CHECK-DAG:    %[[V7:.*]] = arith.addi %[[DIST_UNIT_1_SUBRANGE_START]], %[[C1]] : index
+  // CHECK-DAG:    %[[VEC:.*]] = vector.from_elements
+  // CHECK-SAME:     %[[DIST_UNIT_0_SUBRANGE_START]], %[[V6]],
+  // CHECK-SAME:     %[[DIST_UNIT_1_SUBRANGE_START]], %[[V7]]
+  // CHECK-SAME:     : vector<4xindex>
+  // CHECK-NEXT:    "some_use"(%[[VEC]]) : (vector<4xindex>) -> ()
+  gpu.func @vector_step_slice_multi_dist_unit(%arg0: index) {
+    %0 = gpu.warp_execute_on_lane_0(%arg0)[4] -> (vector<4xindex>) {
+      %5 = vector.step {layout_result_0 = #xegpu.slice<#xegpu.layout<lane_layout = [2, 4, 2], lane_data = [1,2,1]>, dims = [0, 2]>} : vector<16xindex>
+      gpu.yield %5 : vector<16xindex>
+    }
+    "some_use"(%0) : (vector<4xindex>) -> ()
     gpu.return
   }
 


### PR DESCRIPTION
It is possible that `vector.step` operation results will be broadcasted to dimensions of lane layouts that have 1 or more lanes. \
The upstream distribution passes have no notion of lane layouts or their slices, so the pattern is added as a xegpu-specific one.

The logic is outlined in the comment above the pattern:
```
/// The sliced layout must have exactly 1 effective lane dimension.
/// The lane id is delinearized into the parent layout coordinate and only
/// the effective dim coordinate is used.
```