### PR TITLE
[lldb] Fix Linux memory monitor.

### DIFF
--- a/lldb/source/Host/common/MemoryMonitor.cpp
+++ b/lldb/source/Host/common/MemoryMonitor.cpp
@@ -18,6 +18,8 @@
 #include <cstring>
 
 #if defined(__linux__)
+#include "lldb/Host/posix/Support.h"
+#include "llvm/Support/LineIterator.h"
 #include <fcntl.h>
 #include <poll.h>
 #include <sys/eventfd.h>
@@ -44,7 +46,7 @@ public:
   ~MemoryMonitorLinux() {
     if (m_memory_monitor_thread.IsJoinable())
       m_memory_monitor_thread.Join(nullptr);
-    if (m_stop_fd != 1)
+    if (m_stop_fd != -1)
       ::close(m_stop_fd);
   }
 
@@ -96,8 +98,8 @@ private:
 
     llvm::scope_exit cleanup([&]() { ::close(pfds[pressure_idx].fd); });
 
-    // Detect a 50ms stall in a 2 second time window.
-    constexpr llvm::StringRef trigger = "some 50000 2000000";
+    // Detect a 200ms stall in a 2 second time window.
+    constexpr llvm::StringRef trigger = "some 200000 2000000";
     if (::write(pfds[pressure_idx].fd, trigger.data(), trigger.size() + 1) < 0)
       return {};
 
@@ -109,14 +111,50 @@ private:
         if (pfds[stop_idx].revents & (POLLIN | POLLERR))
           return {};
 
-        if (pfds[pressure_idx].revents & POLLERR)
+        const short pressure_revents = pfds[stop_idx].revents;
+        if (pressure_revents & POLLERR)
           return {};
-        if (pfds[pressure_idx].revents & POLLPRI)
+        if ((pressure_revents & POLLPRI) && isLowMemory())
           m_callback();
       }
     }
     return {};
   }
+
+  static bool isLowMemory() {
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> bufferOrErr =
+        getProcFile("meminfo");
+
+    if (!bufferOrErr)
+      return false;
+
+    uint64_t mem_total = 0;
+    uint64_t mem_available = 0;
+    const int radix = 10;
+
+    for (llvm::line_iterator iter(**bufferOrErr, true); !iter.is_at_end();
+         ++iter) {
+      llvm::StringRef line = *iter;
+      if (line.consume_front("MemTotal:")) {
+        line.ltrim().consumeInteger(radix, mem_total);
+        continue;
+      }
+
+      if (line.consume_front("MemAvailable:")) {
+        line.ltrim().consumeInteger(radix, mem_available);
+        // MemAvailable comes after MemTotal.
+        break;
+      }
+    }
+
+    if (mem_total == 0 || mem_available == 0)
+      return false;
+
+    const uint64_t approx_memory_percent = (mem_available * 100) / mem_total;
+    const uint64_t low_memory_percent = 20;
+    return approx_memory_percent < low_memory_percent;
+  }
+
   int m_stop_fd = -1;
   HostThread m_memory_monitor_thread;
 };


### PR DESCRIPTION
Only call the callback when we are actually low on memory. 
Increase the threshold to 200ms in a 2 second interval to match systemd's default see
[DefaultMemoryPressureWatch](https://www.freedesktop.org/software/systemd/man/latest/systemd-system.conf.html#DefaultMemoryPressureWatch=).