### PR TITLE
[clang-tidy] Extend modernize-pass-by-value to handle function body local copies

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -207,7 +207,9 @@ Changes in existing checks
 
 - Improved :doc:`modernize-pass-by-value
   <clang-tidy/checks/modernize/pass-by-value>` check by adding `IgnoreMacros`
-  option to suppress warnings in macros.
+  option to suppress warnings in macros. Also extended the check to handle
+  ``const T&`` function parameters that are copied into local variables in
+  function bodies, not just constructor member initializer lists.
 
 - Improved :doc:`modernize-use-std-format
   <clang-tidy/checks/modernize/use-std-format>` check by fixing a crash

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/pass-by-value.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/pass-by-value.rst
@@ -107,8 +107,8 @@ The check only triggers when:
 
 .. note::
 
-   This transformation is not applied when ``ValuesOnly`` is set to `true`,
-   or in dependent (template) contexts.
+   This transformation is not applied when :option:`ValuesOnly` is set to
+   `true`, or in dependent (template) contexts.
 
 Limitations
 -----------

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value-local-copy.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value-local-copy.cpp
@@ -1,0 +1,114 @@
+// RUN: %check_clang_tidy %s modernize-pass-by-value %t -- -- -fno-delayed-template-parsing
+
+namespace std {
+template <typename T>
+struct remove_reference { typedef T type; };
+template <typename T>
+struct remove_reference<T &> { typedef T type; };
+template <typename T>
+struct remove_reference<T &&> { typedef T type; };
+
+template <typename T>
+typename remove_reference<T>::type &&move(T &&) noexcept;
+} // namespace std
+
+struct Movable {
+  int a, b, c;
+  Movable() = default;
+  Movable(const Movable &) {}
+  Movable(Movable &&) {}
+};
+
+struct NotMovable {
+  NotMovable() = default;
+  NotMovable(const NotMovable &) = default;
+  NotMovable(NotMovable &&) = delete;
+  int a, b, c;
+};
+
+// POD types are trivially move constructible.
+struct POD {
+  int a, b, c;
+};
+
+// Positive: const string-like ref copied into local variable in free function.
+void take_movable(const Movable &M) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: pass by value and use std::move [modernize-pass-by-value]
+  // CHECK-FIXES: void take_movable(Movable M) {
+  Movable Local = M;
+  // CHECK-FIXES: Movable Local = std::move(M);
+  (void)Local;
+}
+
+// Positive: const ref copied in a method.
+struct MyClass {
+  void process(const Movable &M) {
+    // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: pass by value and use std::move [modernize-pass-by-value]
+    // CHECK-FIXES: void process(Movable M) {
+    Movable Copy = M;
+    // CHECK-FIXES: Movable Copy = std::move(M);
+    (void)Copy;
+  }
+};
+
+// Positive: separate declaration and definition.
+void with_decl(const Movable &M);
+// CHECK-FIXES: void with_decl(Movable M);
+void with_decl(const Movable &M) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: pass by value and use std::move [modernize-pass-by-value]
+  // CHECK-FIXES: void with_decl(Movable M) {
+  Movable Local = M;
+  // CHECK-FIXES: Movable Local = std::move(M);
+  (void)Local;
+}
+
+// Negative: trivially copyable type.
+void take_pod(const POD &P) {
+  POD Local = P;
+  (void)Local;
+}
+
+// Negative: no copy, just using the reference.
+void use_ref(const Movable &M) {
+  (void)M.a;
+}
+
+// Negative: type has no move constructor (deleted).
+void take_nomove(const NotMovable &N) {
+  NotMovable Local = N;
+  (void)Local;
+}
+
+// Negative: parameter used more than once.
+void multi_use(const Movable &M) {
+  Movable Local = M;
+  (void)Local;
+  (void)M.a;
+}
+
+// Negative: parameter is not const ref.
+void take_value(Movable M) {
+  Movable Local = M;
+  (void)Local;
+}
+
+// Negative: not a parameter, just a local.
+void local_copy() {
+  Movable A;
+  Movable B = A;
+  (void)B;
+}
+
+// Negative: rvalue overload exists.
+void with_rvalue_overload(const Movable &M) {
+  Movable Local = M;
+  (void)Local;
+}
+void with_rvalue_overload(Movable &&M);
+
+// Negative: template function (dependent context).
+template <typename T>
+void take_template(const T &M) {
+  T Local = M;
+  (void)Local;
+}


### PR DESCRIPTION
Extends the existing `modernize-pass-by-value` check to detect `const T&` function parameters that are unconditionally copied into local variables in function bodies, not just constructor member initializer lists.

When a `const T&` parameter is always copied, passing by value instead allows callers with rvalues to avoid the copy entirely through move construction.

```cpp
// Before
void process(const std::string &s) {
  std::string local = s;
  // use local...
}

// After
void process(std::string s) {
  std::string local = std::move(s);
  // use local...
}
```

The check only triggers when:
- The parameter type is a non-trivially-copyable class or struct
- The type has a non-deleted move constructor
- The parameter is used exactly once (in the copy)
- There is no overload taking an rvalue reference for the same parameter

As part of this change, the helper functions `paramReferredExactlyOnce`, `hasRValueOverload`, and `collectParamDecls` were generalized from `CXXConstructorDecl` to `FunctionDecl`, and the parameter rewriting logic was extracted into a shared `rewriteParamDeclsToValue` helper.

This was originally proposed as a separate `performance-const-ref-copy` check, but per reviewer feedback it was merged into the existing `modernize-pass-by-value` check since the docs explicitly welcome contributions for non-constructor cases and the logic is shared.

Fixes #94798.