### PR TITLE
[lldb] Drop incomplete non-8-bit bytes support

### DIFF
--- a/lldb/bindings/interface/SBSectionDocstrings.i
+++ b/lldb/bindings/interface/SBSectionDocstrings.i
@@ -25,13 +25,3 @@ produces: ::
 
 See also :py:class:`SBModule` ."
 ) lldb::SBSection;
-
-%feature("docstring", "
-    Return the size of a target's byte represented by this section
-    in numbers of host bytes. Note that certain architectures have
-    varying minimum addressable unit (i.e. byte) size for their
-    CODE or DATA buses.
-
-    @return
-        The number of host (8-bit) bytes needed to hold a target byte"
-) lldb::SBSection::GetTargetByteSize;

--- a/lldb/bindings/interface/SBSectionDocstrings.i
+++ b/lldb/bindings/interface/SBSectionDocstrings.i
@@ -25,3 +25,6 @@ produces: ::
 
 See also :py:class:`SBModule` ."
 ) lldb::SBSection;
+
+%feature("docstring", "Deprecated. Always returns 1."
+) lldb::SBSection::GetTargetByteSize;

--- a/lldb/bindings/interface/SBSectionExtensions.i
+++ b/lldb/bindings/interface/SBSectionExtensions.i
@@ -27,7 +27,6 @@ STRING_EXTENSION_OUTSIDE(SBSection)
         file_size = property(GetFileByteSize, None, doc='''A read only property that returns the file size in bytes of this section as an integer.''')
         data = property(GetSectionData, None, doc='''A read only property that returns an lldb object that represents the bytes for this section (lldb.SBData) for this section.''')
         type = property(GetSectionType, None, doc='''A read only property that returns an lldb enumeration value (see enumerations that start with "lldb.eSectionType") that represents the type of this section (code, data, etc.).''')
-        target_byte_size = property(GetTargetByteSize, None, doc='''A read only property that returns the size of a target byte represented by this section as a number of host bytes.''')
         alignment = property(GetAlignment, None, doc='''A read only property that returns the alignment of this section as a number of host bytes.''')
     %}
 #endif

--- a/lldb/bindings/interface/SBSectionExtensions.i
+++ b/lldb/bindings/interface/SBSectionExtensions.i
@@ -27,6 +27,7 @@ STRING_EXTENSION_OUTSIDE(SBSection)
         file_size = property(GetFileByteSize, None, doc='''A read only property that returns the file size in bytes of this section as an integer.''')
         data = property(GetSectionData, None, doc='''A read only property that returns an lldb object that represents the bytes for this section (lldb.SBData) for this section.''')
         type = property(GetSectionType, None, doc='''A read only property that returns an lldb enumeration value (see enumerations that start with "lldb.eSectionType") that represents the type of this section (code, data, etc.).''')
+        target_byte_size = property(GetTargetByteSize, None, doc='''Deprecated. Always returns 1.''')
         alignment = property(GetAlignment, None, doc='''A read only property that returns the alignment of this section as a number of host bytes.''')
     %}
 #endif

--- a/lldb/bindings/interface/SBTargetDocstrings.i
+++ b/lldb/bindings/interface/SBTargetDocstrings.i
@@ -250,6 +250,12 @@ produces: ::
     :rtype: SBSymbolContextList"
 ) lldb::SBTarget::FindCompileUnits;
 
+%feature("docstring", "Deprecated. Always returns 1."
+) lldb::SBTarget::GetDataByteSize;
+
+%feature("docstring", "Deprecated. Always returns 1."
+) lldb::SBTarget::GetCodeByteSize;
+
 %feature("docstring", "
     Find functions by name.
 

--- a/lldb/bindings/interface/SBTargetDocstrings.i
+++ b/lldb/bindings/interface/SBTargetDocstrings.i
@@ -251,22 +251,6 @@ produces: ::
 ) lldb::SBTarget::FindCompileUnits;
 
 %feature("docstring", "
-    Architecture data byte width accessor
-
-    :return: The size in 8-bit (host) bytes of a minimum addressable unit from the Architecture's data bus.
-
-    "
-) lldb::SBTarget::GetDataByteSize;
-
-%feature("docstring", "
-    Architecture code byte width accessor.
-
-    :return: The size in 8-bit (host) bytes of a minimum addressable unit from the Architecture's code bus.
-
-    "
-) lldb::SBTarget::GetCodeByteSize;
-
-%feature("docstring", "
     Find functions by name.
 
     :param name: The name of the function we are looking for.

--- a/lldb/bindings/interface/SBTargetExtensions.i
+++ b/lldb/bindings/interface/SBTargetExtensions.i
@@ -191,6 +191,8 @@ STRING_EXTENSION_LEVEL_OUTSIDE(SBTarget, lldb::eDescriptionLevelBrief)
         addr_size = property(GetAddressByteSize, None, doc='''A read only property that returns the size in bytes of an address for this target.''')
         triple = property(GetTriple, None, doc='''A read only property that returns the target triple (arch-vendor-os) for this target as a string.''')
         arch_name = property(GetArchName, None, doc='''A read only property that returns the architecture name for this target as a string.''')
+        data_byte_size = property(GetDataByteSize, None, doc='''Deprecated. Always returns 1.''')
+        code_byte_size = property(GetCodeByteSize, None, doc='''Deprecated. Always returns 1.''')
         platform = property(GetPlatform, None, doc='''A read only property that returns the platform associated with with this target.''')
     %}
 #endif

--- a/lldb/bindings/interface/SBTargetExtensions.i
+++ b/lldb/bindings/interface/SBTargetExtensions.i
@@ -191,8 +191,6 @@ STRING_EXTENSION_LEVEL_OUTSIDE(SBTarget, lldb::eDescriptionLevelBrief)
         addr_size = property(GetAddressByteSize, None, doc='''A read only property that returns the size in bytes of an address for this target.''')
         triple = property(GetTriple, None, doc='''A read only property that returns the target triple (arch-vendor-os) for this target as a string.''')
         arch_name = property(GetArchName, None, doc='''A read only property that returns the architecture name for this target as a string.''')
-        data_byte_size = property(GetDataByteSize, None, doc='''A read only property that returns the size in host bytes of a byte in the data address space for this target.''')
-        code_byte_size = property(GetCodeByteSize, None, doc='''A read only property that returns the size in host bytes of a byte in the code address space for this target.''')
         platform = property(GetPlatform, None, doc='''A read only property that returns the platform associated with with this target.''')
     %}
 #endif

--- a/lldb/include/lldb/API/SBSection.h
+++ b/lldb/include/lldb/API/SBSection.h
@@ -67,6 +67,9 @@ public:
   uint32_t
   GetPermissions() const;
 
+  LLDB_DEPRECATED("Always returns 1.")
+  uint32_t GetTargetByteSize();
+
   /// Return the alignment of the section in bytes
   ///
   /// \return

--- a/lldb/include/lldb/API/SBSection.h
+++ b/lldb/include/lldb/API/SBSection.h
@@ -67,15 +67,6 @@ public:
   uint32_t
   GetPermissions() const;
 
-  /// Return the size of a target's byte represented by this section
-  /// in numbers of host bytes. Note that certain architectures have
-  /// varying minimum addressable unit (i.e. byte) size for their
-  /// CODE or DATA buses.
-  ///
-  /// \return
-  ///     The number of host (8-bit) bytes needed to hold a target byte
-  uint32_t GetTargetByteSize();
-
   /// Return the alignment of the section in bytes
   ///
   /// \return

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -397,6 +397,12 @@ public:
   /// The maximum size in 8-bit (host) bytes of an opcode.
   uint32_t GetMaximumOpcodeByteSize() const;
 
+  LLDB_DEPRECATED("Always returns 1.")
+  uint32_t GetDataByteSize();
+
+  LLDB_DEPRECATED("Always returns 1.")
+  uint32_t GetCodeByteSize();
+
   /// Gets the target.max-children-count value
   /// It should be used to limit the number of
   /// children of large data structures to be displayed.

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -397,20 +397,6 @@ public:
   /// The maximum size in 8-bit (host) bytes of an opcode.
   uint32_t GetMaximumOpcodeByteSize() const;
 
-  /// Architecture data byte width accessor
-  ///
-  /// \return
-  /// The size in 8-bit (host) bytes of a minimum addressable
-  /// unit from the Architecture's data bus
-  uint32_t GetDataByteSize();
-
-  /// Architecture code byte width accessor
-  ///
-  /// \return
-  /// The size in 8-bit (host) bytes of a minimum addressable
-  /// unit from the Architecture's code bus
-  uint32_t GetCodeByteSize();
-
   /// Gets the target.max-children-count value
   /// It should be used to limit the number of
   /// children of large data structures to be displayed.

--- a/lldb/include/lldb/Core/Section.h
+++ b/lldb/include/lldb/Core/Section.h
@@ -146,8 +146,7 @@ public:
           lldb::user_id_t sect_id, ConstString name,
           lldb::SectionType sect_type, lldb::addr_t file_vm_addr,
           lldb::addr_t vm_size, lldb::offset_t file_offset,
-          lldb::offset_t file_size, uint32_t log2align, uint32_t flags,
-          uint32_t target_byte_size = 1);
+          lldb::offset_t file_size, uint32_t log2align, uint32_t flags);
 
   // Create a section that is a child of parent_section_sp
   Section(const lldb::SectionSP &parent_section_sp, // NULL for top level
@@ -157,8 +156,7 @@ public:
           lldb::user_id_t sect_id, ConstString name,
           lldb::SectionType sect_type, lldb::addr_t file_vm_addr,
           lldb::addr_t vm_size, lldb::offset_t file_offset,
-          lldb::offset_t file_size, uint32_t log2align, uint32_t flags,
-          uint32_t target_byte_size = 1);
+          lldb::offset_t file_size, uint32_t log2align, uint32_t flags);
 
   ~Section();
 
@@ -272,9 +270,6 @@ public:
 
   void SetLog2Align(uint32_t align) { m_log2align = align; }
 
-  // Get the number of host bytes required to hold a target byte
-  uint32_t GetTargetByteSize() const { return m_target_byte_size; }
-
   bool IsRelocated() const { return m_relocated; }
 
   void SetIsRelocated(bool b) { m_relocated = b; }
@@ -311,15 +306,12 @@ protected:
       // children contains an address. This allows for gaps between the
       // children that are contained in the address range for this section, but
       // do not produce hits unless the children contain the address.
-      m_encrypted : 1,         // Set to true if the contents are encrypted
-      m_thread_specific : 1,   // This section is thread specific
-      m_readable : 1,          // If this section has read permissions
-      m_writable : 1,          // If this section has write permissions
-      m_executable : 1,        // If this section has executable permissions
-      m_relocated : 1;         // If this section has had relocations applied
-  uint32_t m_target_byte_size; // Some architectures have non-8-bit byte size.
-                               // This is specified as
-                               // as a multiple number of a host bytes
+      m_encrypted : 1,       // Set to true if the contents are encrypted
+      m_thread_specific : 1, // This section is thread specific
+      m_readable : 1,        // If this section has read permissions
+      m_writable : 1,        // If this section has write permissions
+      m_executable : 1,      // If this section has executable permissions
+      m_relocated : 1;       // If this section has had relocations applied
 private:
   Section(const Section &) = delete;
   const Section &operator=(const Section &) = delete;

--- a/lldb/include/lldb/Utility/ArchSpec.h
+++ b/lldb/include/lldb/Utility/ArchSpec.h
@@ -450,18 +450,6 @@ public:
 
   uint32_t GetMachOCPUSubType() const;
 
-  /// Architecture data byte width accessor
-  ///
-  /// \return the size in 8-bit (host) bytes of a minimum addressable unit
-  /// from the Architecture's data bus
-  uint32_t GetDataByteSize() const;
-
-  /// Architecture code byte width accessor
-  ///
-  /// \return the size in 8-bit (host) bytes of a minimum addressable unit
-  /// from the Architecture's code bus
-  uint32_t GetCodeByteSize() const;
-
   /// Architecture triple accessor.
   ///
   /// \return A triple describing this ArchSpec.

--- a/lldb/include/lldb/Utility/DataExtractor.h
+++ b/lldb/include/lldb/Utility/DataExtractor.h
@@ -83,12 +83,8 @@ public:
   ///
   /// \param[in] addr_size
   ///     A new address byte size value.
-  ///
-  /// \param[in] target_byte_size
-  ///     A size of a target byte in 8-bit host bytes
   DataExtractor(const void *data, lldb::offset_t data_length,
-                lldb::ByteOrder byte_order, uint32_t addr_size,
-                uint32_t target_byte_size = 1);
+                lldb::ByteOrder byte_order, uint32_t addr_size);
 
   /// Construct with shared data.
   ///
@@ -105,11 +101,8 @@ public:
   ///
   /// \param[in] addr_size
   ///     A new address byte size value.
-  ///
-  /// \param[in] target_byte_size
-  ///     A size of a target byte in 8-bit host bytes
   DataExtractor(const lldb::DataBufferSP &data_sp, lldb::ByteOrder byte_order,
-                uint32_t addr_size, uint32_t target_byte_size = 1);
+                uint32_t addr_size);
 
   /// Construct with shared data, but byte-order & addr-size are unspecified.
   ///
@@ -120,8 +113,7 @@ public:
   ///
   /// \param[in] data_sp
   ///     A shared pointer to data.
-  DataExtractor(const lldb::DataBufferSP &data_sp,
-                uint32_t target_byte_size = 1);
+  explicit DataExtractor(const lldb::DataBufferSP &data_sp);
 
   /// Construct with a subset of \a data.
   ///
@@ -142,11 +134,8 @@ public:
   ///
   /// \param[in] length
   ///     The length in bytes of the subset of data.
-  ///
-  /// \param[in] target_byte_size
-  ///     A size of a target byte in 8-bit host bytes
   DataExtractor(const DataExtractor &data, lldb::offset_t offset,
-                lldb::offset_t length, uint32_t target_byte_size = 1);
+                lldb::offset_t length);
 
   /// Copy constructor.
   ///
@@ -180,8 +169,6 @@ public:
   /// count on the data will be decremented, and if zero, the data will be
   /// freed.
   virtual ~DataExtractor();
-
-  uint32_t getTargetByteSize() const { return m_target_byte_size; }
 
   /// Clears the object state.
   ///
@@ -1077,8 +1064,6 @@ protected:
   uint32_t m_addr_size; ///< The address size to use when extracting addresses.
   /// The shared pointer to data that can be shared among multiple instances
   lldb::DataBufferSP m_data_sp;
-  /// Making it const would require implementation of move assignment operator.
-  uint32_t m_target_byte_size = 1;
 };
 
 } // namespace lldb_private

--- a/lldb/source/API/SBSection.cpp
+++ b/lldb/source/API/SBSection.cpp
@@ -208,6 +208,12 @@ uint32_t SBSection::GetPermissions() const {
   return 0;
 }
 
+uint32_t SBSection::GetTargetByteSize() {
+  LLDB_INSTRUMENT_VA(this);
+
+  return 1;
+}
+
 uint32_t SBSection::GetAlignment() {
   LLDB_INSTRUMENT_VA(this);
 

--- a/lldb/source/API/SBSection.cpp
+++ b/lldb/source/API/SBSection.cpp
@@ -208,15 +208,6 @@ uint32_t SBSection::GetPermissions() const {
   return 0;
 }
 
-uint32_t SBSection::GetTargetByteSize() {
-  LLDB_INSTRUMENT_VA(this);
-
-  SectionSP section_sp(GetSP());
-  if (section_sp.get())
-    return section_sp->GetTargetByteSize();
-  return 0;
-}
-
 uint32_t SBSection::GetAlignment() {
   LLDB_INSTRUMENT_VA(this);
 

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -1698,6 +1698,18 @@ uint32_t SBTarget::GetMaximumOpcodeByteSize() const {
   return 0;
 }
 
+uint32_t SBTarget::GetDataByteSize() {
+  LLDB_INSTRUMENT_VA(this);
+
+  return 1;
+}
+
+uint32_t SBTarget::GetCodeByteSize() {
+  LLDB_INSTRUMENT_VA(this);
+
+  return 1;
+}
+
 uint32_t SBTarget::GetMaximumNumberOfChildrenToDisplay() const {
   LLDB_INSTRUMENT_VA(this);
 

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -1698,22 +1698,6 @@ uint32_t SBTarget::GetMaximumOpcodeByteSize() const {
   return 0;
 }
 
-uint32_t SBTarget::GetDataByteSize() {
-  LLDB_INSTRUMENT_VA(this);
-
-  if (TargetSP target_sp = GetSP())
-    return target_sp->GetArchitecture().GetDataByteSize();
-  return 0;
-}
-
-uint32_t SBTarget::GetCodeByteSize() {
-  LLDB_INSTRUMENT_VA(this);
-
-  if (TargetSP target_sp = GetSP())
-    return target_sp->GetArchitecture().GetCodeByteSize();
-  return 0;
-}
-
 uint32_t SBTarget::GetMaximumNumberOfChildrenToDisplay() const {
   LLDB_INSTRUMENT_VA(this);
 

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -565,16 +565,8 @@ protected:
     }
 
     size_t item_count = m_format_options.GetCountValue().GetCurrentValue();
-
-    // TODO For non-8-bit byte addressable architectures this needs to be
-    // revisited to fully support all lldb's range of formatting options.
-    // Furthermore code memory reads (for those architectures) will not be
-    // correctly formatted even w/o formatting options.
     size_t item_byte_size =
-        target->GetArchitecture().GetDataByteSize() > 1
-            ? target->GetArchitecture().GetDataByteSize()
-            : m_format_options.GetByteSizeValue().GetCurrentValue();
-
+        m_format_options.GetByteSizeValue().GetCurrentValue();
     const size_t num_per_line =
         m_memory_options.m_num_per_line.GetCurrentValue();
 
@@ -834,8 +826,7 @@ protected:
 
     result.SetStatus(eReturnStatusSuccessFinishResult);
     DataExtractor data(data_sp, target->GetArchitecture().GetByteOrder(),
-                       target->GetArchitecture().GetAddressByteSize(),
-                       target->GetArchitecture().GetDataByteSize());
+                       target->GetArchitecture().GetAddressByteSize());
 
     Format format = m_format_options.GetFormat();
     if (((format == eFormatChar) || (format == eFormatCharPrintable)) &&
@@ -860,10 +851,10 @@ protected:
     }
 
     assert(output_stream_p);
-    size_t bytes_dumped = DumpDataExtractor(
-        data, output_stream_p, 0, format, item_byte_size, item_count,
-        num_per_line / target->GetArchitecture().GetDataByteSize(), addr, 0, 0,
-        exe_scope, m_memory_tag_options.GetShowTags().GetCurrentValue());
+    size_t bytes_dumped =
+        DumpDataExtractor(data, output_stream_p, 0, format, item_byte_size,
+                          item_count, num_per_line, addr, 0, 0, exe_scope,
+                          m_memory_tag_options.GetShowTags().GetCurrentValue());
     m_next_addr = addr + bytes_dumped;
     output_stream_p->EOL();
   }

--- a/lldb/source/Core/DumpDataExtractor.cpp
+++ b/lldb/source/Core/DumpDataExtractor.cpp
@@ -401,8 +401,7 @@ lldb::offset_t lldb_private::DumpDataExtractor(
         if (base_addr != LLDB_INVALID_ADDRESS && memory_tag_map) {
           size_t line_len = offset - line_start_offset;
           lldb::addr_t line_base =
-              base_addr +
-              (offset - start_offset - line_len) / DE.getTargetByteSize();
+              base_addr + (offset - start_offset - line_len);
           printMemoryTags(DE, s, line_base, line_len, memory_tag_map);
         }
 
@@ -410,8 +409,7 @@ lldb::offset_t lldb_private::DumpDataExtractor(
       }
       if (base_addr != LLDB_INVALID_ADDRESS)
         s->Printf("0x%8.8" PRIx64 ": ",
-                  (uint64_t)(base_addr +
-                             (offset - start_offset) / DE.getTargetByteSize()));
+                  (uint64_t)(base_addr + (offset - start_offset)));
 
       line_start_offset = offset;
     } else if (item_format != eFormatChar &&
@@ -897,8 +895,7 @@ lldb::offset_t lldb_private::DumpDataExtractor(
 
     if (base_addr != LLDB_INVALID_ADDRESS && memory_tag_map) {
       size_t line_len = offset - line_start_offset;
-      lldb::addr_t line_base = base_addr + (offset - start_offset - line_len) /
-                                               DE.getTargetByteSize();
+      lldb::addr_t line_base = base_addr + (offset - start_offset - line_len);
       printMemoryTags(DE, s, line_base, line_len, memory_tag_map);
     }
   }

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -164,31 +164,27 @@ const char *Section::GetTypeAsCString() const {
 Section::Section(const ModuleSP &module_sp, ObjectFile *obj_file,
                  user_id_t sect_id, ConstString name, SectionType sect_type,
                  addr_t file_addr, addr_t byte_size, lldb::offset_t file_offset,
-                 lldb::offset_t file_size, uint32_t log2align, uint32_t flags,
-                 uint32_t target_byte_size /*=1*/)
+                 lldb::offset_t file_size, uint32_t log2align, uint32_t flags)
     : ModuleChild(module_sp), UserID(sect_id), Flags(flags),
       m_obj_file(obj_file), m_type(sect_type), m_parent_wp(), m_name(name),
       m_file_addr(file_addr), m_byte_size(byte_size),
       m_file_offset(file_offset), m_file_size(file_size),
       m_log2align(log2align), m_children(), m_fake(false), m_encrypted(false),
       m_thread_specific(false), m_readable(false), m_writable(false),
-      m_executable(false), m_relocated(false),
-      m_target_byte_size(target_byte_size) {}
+      m_executable(false), m_relocated(false) {}
 
 Section::Section(const lldb::SectionSP &parent_section_sp,
                  const ModuleSP &module_sp, ObjectFile *obj_file,
                  user_id_t sect_id, ConstString name, SectionType sect_type,
                  addr_t file_addr, addr_t byte_size, lldb::offset_t file_offset,
-                 lldb::offset_t file_size, uint32_t log2align, uint32_t flags,
-                 uint32_t target_byte_size /*=1*/)
+                 lldb::offset_t file_size, uint32_t log2align, uint32_t flags)
     : ModuleChild(module_sp), UserID(sect_id), Flags(flags),
       m_obj_file(obj_file), m_type(sect_type), m_parent_wp(), m_name(name),
       m_file_addr(file_addr), m_byte_size(byte_size),
       m_file_offset(file_offset), m_file_size(file_size),
       m_log2align(log2align), m_children(), m_fake(false), m_encrypted(false),
       m_thread_specific(false), m_readable(false), m_writable(false),
-      m_executable(false), m_relocated(false),
-      m_target_byte_size(target_byte_size) {
+      m_executable(false), m_relocated(false) {
   if (parent_section_sp)
     m_parent_wp = parent_section_sp;
 }
@@ -270,7 +266,7 @@ bool Section::ContainsFileAddress(addr_t vm_addr) const {
   const addr_t file_addr = GetFileAddress();
   if (file_addr != LLDB_INVALID_ADDRESS && !IsThreadSpecific()) {
     if (file_addr <= vm_addr) {
-      const addr_t offset = (vm_addr - file_addr) * m_target_byte_size;
+      const addr_t offset = vm_addr - file_addr;
       return offset < GetByteSize();
     }
   }

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -1747,18 +1747,6 @@ SectionType ObjectFileELF::GetSectionType(const ELFSectionHeaderInfo &H) const {
   return GetSectionTypeFromName(H.section_name.GetStringRef());
 }
 
-static uint32_t GetTargetByteSize(SectionType Type, const ArchSpec &arch) {
-  switch (Type) {
-  case eSectionTypeData:
-  case eSectionTypeZeroFill:
-    return arch.GetDataByteSize();
-  case eSectionTypeCode:
-    return arch.GetCodeByteSize();
-  default:
-    return 1;
-  }
-}
-
 static Permissions GetPermissions(const ELFSectionHeader &H) {
   Permissions Perm = Permissions(0);
   if (H.sh_flags & SHF_ALLOC)
@@ -1974,9 +1962,6 @@ void ObjectFileELF::CreateSections(SectionList &unified_section_list) {
 
     SectionType sect_type = GetSectionType(header);
 
-    const uint32_t target_bytes_size =
-        GetTargetByteSize(sect_type, m_arch_spec);
-
     elf::elf_xword log2align =
         (header.sh_addralign == 0) ? 0 : llvm::Log2_64(header.sh_addralign);
 
@@ -1990,10 +1975,9 @@ void ObjectFileELF::CreateSections(SectionList &unified_section_list) {
         InfoOr->Range.GetRangeBase(), // VM address.
         InfoOr->Range.GetByteSize(),  // VM size in bytes of this section.
         header.sh_offset,             // Offset of this section in the file.
-        file_size,           // Size of the section as found in the file.
-        log2align,           // Alignment of the section
-        header.sh_flags,     // Flags for this section.
-        target_bytes_size)); // Number of host bytes per target byte
+        file_size,         // Size of the section as found in the file.
+        log2align,         // Alignment of the section
+        header.sh_flags)); // Flags for this section.
 
     section_sp->SetPermissions(GetPermissions(header));
     section_sp->SetIsThreadSpecific(header.sh_flags & SHF_TLS);

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -626,8 +626,7 @@ void ObjectFileWasm::CreateSections(SectionList &unified_section_list) {
         file_offset,    // Offset of this section in the file.
         sect_info.size, // Size of the section as found in the file.
         0,              // Alignment of the section
-        0,              // Flags for this section.
-        1);             // Number of host bytes per target byte
+        0);             // Flags for this section.
     m_sections_up->AddSection(section_sp);
     unified_section_list.AddSection(section_sp);
   }

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -355,7 +355,7 @@ DataExtractor ProcessMinidump::GetAuxvData() {
     return DataExtractor();
 
   return DataExtractor(auxv->data(), auxv->size(), GetByteOrder(),
-                       GetAddressByteSize(), GetAddressByteSize());
+                       GetAddressByteSize());
 }
 
 bool ProcessMinidump::IsLLDBMinidump() {

--- a/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
+++ b/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
@@ -865,7 +865,6 @@ static DWARFExpression CreateDWARFExpression(ModuleSP module_sp,
   const ArchSpec &architecture = module_sp->GetArchitecture();
   ByteOrder byte_order = architecture.GetByteOrder();
   uint32_t address_size = architecture.GetAddressByteSize();
-  uint32_t byte_size = architecture.GetDataByteSize();
 
   StreamBuffer<32> stream(Stream::eBinary, address_size, byte_order);
   stream.PutHex8(llvm::dwarf::DW_OP_addr);
@@ -873,8 +872,7 @@ static DWARFExpression CreateDWARFExpression(ModuleSP module_sp,
 
   DataBufferSP buffer =
       std::make_shared<DataBufferHeap>(stream.GetData(), stream.GetSize());
-  lldb_private::DataExtractor extractor(buffer, byte_order, address_size,
-                                        byte_size);
+  lldb_private::DataExtractor extractor(buffer, byte_order, address_size);
   DWARFExpression result(extractor);
   result.SetRegisterKind(eRegisterKindDWARF);
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
@@ -110,7 +110,6 @@ static DWARFExpression MakeLocationExpressionInternal(lldb::ModuleSP module,
   const ArchSpec &architecture = module->GetArchitecture();
   ByteOrder byte_order = architecture.GetByteOrder();
   uint32_t address_size = architecture.GetAddressByteSize();
-  uint32_t byte_size = architecture.GetDataByteSize();
   if (byte_order == eByteOrderInvalid || address_size == 0)
     return DWARFExpression();
 
@@ -122,7 +121,7 @@ static DWARFExpression MakeLocationExpressionInternal(lldb::ModuleSP module,
 
   DataBufferSP buffer =
       std::make_shared<DataBufferHeap>(stream.GetData(), stream.GetSize());
-  DataExtractor extractor(buffer, byte_order, address_size, byte_size);
+  DataExtractor extractor(buffer, byte_order, address_size);
   DWARFExpression result(extractor);
   result.SetRegisterKind(register_kind);
 

--- a/lldb/source/Plugins/SymbolFile/PDB/PDBLocationToDWARFExpression.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/PDBLocationToDWARFExpression.cpp
@@ -76,7 +76,6 @@ DWARFExpression ConvertPDBLocationToDWARFExpression(
   llvm::Triple::ArchType arch_type = architecture.GetMachine();
   ByteOrder byte_order = architecture.GetByteOrder();
   uint32_t address_size = architecture.GetAddressByteSize();
-  uint32_t byte_size = architecture.GetDataByteSize();
   if (byte_order == eByteOrderInvalid || address_size == 0)
     return DWARFExpression();
 
@@ -174,7 +173,7 @@ DWARFExpression ConvertPDBLocationToDWARFExpression(
 
   DataBufferSP buffer =
       std::make_shared<DataBufferHeap>(stream.GetData(), stream.GetSize());
-  DataExtractor extractor(buffer, byte_order, address_size, byte_size);
+  DataExtractor extractor(buffer, byte_order, address_size);
   DWARFExpression result(extractor);
   result.SetRegisterKind(register_kind);
 

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -514,7 +514,6 @@ size_t ObjectFile::ReadSectionData(Section *section,
                                    lldb::offset_t section_offset, void *dst,
                                    size_t dst_len) {
   assert(section);
-  section_offset *= section->GetTargetByteSize();
 
   // If some other objectfile owns this data, pass this to them.
   if (section->GetObjectFile() != this)

--- a/lldb/source/Utility/ArchSpec.cpp
+++ b/lldb/source/Utility/ArchSpec.cpp
@@ -670,10 +670,6 @@ uint32_t ArchSpec::GetMachOCPUSubType() const {
   return LLDB_INVALID_CPUTYPE;
 }
 
-uint32_t ArchSpec::GetDataByteSize() const { return 1; }
-
-uint32_t ArchSpec::GetCodeByteSize() const { return 1; }
-
 llvm::Triple::ArchType ArchSpec::GetMachine() const {
   const CoreDefinition *core_def = FindCoreDefinition(m_core);
   if (core_def)

--- a/lldb/source/Utility/DataExtractor.cpp
+++ b/lldb/source/Utility/DataExtractor.cpp
@@ -127,12 +127,10 @@ DataExtractor::DataExtractor()
 // This constructor allows us to use data that is owned by someone else. The
 // data must stay around as long as this object is valid.
 DataExtractor::DataExtractor(const void *data, offset_t length,
-                             ByteOrder endian, uint32_t addr_size,
-                             uint32_t target_byte_size /*=1*/)
+                             ByteOrder endian, uint32_t addr_size)
     : m_start(const_cast<uint8_t *>(static_cast<const uint8_t *>(data))),
       m_end(const_cast<uint8_t *>(static_cast<const uint8_t *>(data)) + length),
-      m_byte_order(endian), m_addr_size(addr_size), m_data_sp(),
-      m_target_byte_size(target_byte_size) {
+      m_byte_order(endian), m_addr_size(addr_size), m_data_sp() {
   assert(addr_size >= 1 && addr_size <= 8);
 }
 
@@ -141,19 +139,16 @@ DataExtractor::DataExtractor(const void *data, offset_t length,
 // shared data reference will ensure the data lives as long as any
 // DataExtractor objects exist that have a reference to this data.
 DataExtractor::DataExtractor(const DataBufferSP &data_sp, ByteOrder endian,
-                             uint32_t addr_size,
-                             uint32_t target_byte_size /*=1*/)
-    : m_byte_order(endian), m_addr_size(addr_size), m_data_sp(),
-      m_target_byte_size(target_byte_size) {
+                             uint32_t addr_size)
+    : m_byte_order(endian), m_addr_size(addr_size), m_data_sp() {
   assert(addr_size >= 1 && addr_size <= 8);
   SetData(data_sp);
 }
 
 // Make a shared pointer reference to the shared data in "data_sp".
-DataExtractor::DataExtractor(const DataBufferSP &data_sp,
-                             uint32_t target_byte_size)
+DataExtractor::DataExtractor(const DataBufferSP &data_sp)
     : m_byte_order(endian::InlHostByteOrder()), m_addr_size(sizeof(void *)),
-      m_data_sp(data_sp), m_target_byte_size(target_byte_size) {
+      m_data_sp(data_sp) {
   if (data_sp)
     SetData(data_sp);
 }
@@ -164,9 +159,9 @@ DataExtractor::DataExtractor(const DataBufferSP &data_sp,
 // to that data. The endian swap and address size settings are copied from
 // "data".
 DataExtractor::DataExtractor(const DataExtractor &data, offset_t offset,
-                             offset_t length, uint32_t target_byte_size /*=1*/)
+                             offset_t length)
     : m_byte_order(data.m_byte_order), m_addr_size(data.m_addr_size),
-      m_data_sp(), m_target_byte_size(target_byte_size) {
+      m_data_sp() {
   assert(m_addr_size >= 1 && m_addr_size <= 8);
   if (data.ValidOffset(offset)) {
     offset_t bytes_available = data.GetByteSize() - offset;
@@ -178,8 +173,7 @@ DataExtractor::DataExtractor(const DataExtractor &data, offset_t offset,
 
 DataExtractor::DataExtractor(const DataExtractor &rhs)
     : m_start(rhs.m_start), m_end(rhs.m_end), m_byte_order(rhs.m_byte_order),
-      m_addr_size(rhs.m_addr_size), m_data_sp(rhs.m_data_sp),
-      m_target_byte_size(rhs.m_target_byte_size) {
+      m_addr_size(rhs.m_addr_size), m_data_sp(rhs.m_data_sp) {
   assert(m_addr_size >= 1 && m_addr_size <= 8);
 }
 

--- a/lldb/test/API/python_api/section/TestSectionAPI.py
+++ b/lldb/test/API/python_api/section/TestSectionAPI.py
@@ -11,35 +11,6 @@ from lldbsuite.test import lldbutil
 class SectionAPITestCase(TestBase):
     @no_debug_info_test
     @skipIfXmlSupportMissing
-    def test_get_target_byte_size(self):
-        d = {"EXE": "b.out"}
-        self.build(dictionary=d)
-        self.setTearDownCleanup(dictionary=d)
-        exe = self.getBuildArtifact("b.out")
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        # find the .data section of the main module
-        mod = target.GetModuleAtIndex(0)
-        data_section = None
-        for s in mod.sections:
-            sect_type = s.GetSectionType()
-            if sect_type == lldb.eSectionTypeData:
-                data_section = s
-                break
-            elif sect_type == lldb.eSectionTypeContainer:
-                for i in range(s.GetNumSubSections()):
-                    ss = s.GetSubSectionAtIndex(i)
-                    sect_type = ss.GetSectionType()
-                    if sect_type == lldb.eSectionTypeData:
-                        data_section = ss
-                        break
-
-        self.assertIsNotNone(data_section)
-        self.assertEqual(data_section.target_byte_size, 1)
-
-    @no_debug_info_test
-    @skipIfXmlSupportMissing
     def test_get_alignment(self):
         exe = self.getBuildArtifact("aligned.out")
         self.yaml2obj("aligned.yaml", exe)

--- a/lldb/test/API/python_api/target/TestTargetAPI.py
+++ b/lldb/test/API/python_api/target/TestTargetAPI.py
@@ -69,20 +69,6 @@ class TargetAPITestCase(TestBase):
         platform = target.platform
         self.assertTrue(platform, VALID_PLATFORM)
 
-    def test_get_data_byte_size(self):
-        d = {"EXE": "b.out"}
-        self.build(dictionary=d)
-        self.setTearDownCleanup(dictionary=d)
-        target = self.create_simple_target("b.out")
-        self.assertEqual(target.data_byte_size, 1)
-
-    def test_get_code_byte_size(self):
-        d = {"EXE": "b.out"}
-        self.build(dictionary=d)
-        self.setTearDownCleanup(dictionary=d)
-        target = self.create_simple_target("b.out")
-        self.assertEqual(target.code_byte_size, 1)
-
     def test_resolve_file_address(self):
         d = {"EXE": "b.out"}
         self.build(dictionary=d)

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -189,6 +189,11 @@ Changes to the LLVM tools
 Changes to LLDB
 ---------------
 
+### Deprecated APIs
+
+* ``SBTarget::GetDataByteSize()``, ``SBTarget::GetCodeByteSize()``, and ``SBSection::GetTargetByteSize()``
+  have been deprecated. They always return 1, as before.
+
 ### FreeBSD
 
 #### Userspace Debugging


### PR DESCRIPTION
This was originally introduced to support kalimba DSPs featuring 24-bit bytes by f03e6d84 and also c928de3e, but the kalimba support was mostly removed by f8819bd5. This change removes the rest of the support, which was far from complete.
