### PR TITLE
[lld][RISCV] More fine-grained __global_pointer$ placement

### DIFF
--- a/lld/test/ELF/riscv-relax-hi20-lo12.s
+++ b/lld/test/ELF/riscv-relax-hi20-lo12.s
@@ -9,6 +9,36 @@
 # RUN: llvm-objdump -td -M no-aliases --no-show-raw-insn rv32 | FileCheck %s
 # RUN: llvm-objdump -td -M no-aliases --no-show-raw-insn rv64 | FileCheck %s
 
+
+# RUN: sed 's/\.sdata/\.data/g' a.s > a2.s && sed 's/\.sdata/\.data/g' lds > lds2
+# RUN: llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=+relax a2.s -o rv32.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64-unknown-elf -mattr=+relax a2.s -o rv64.o
+
+# RUN: ld.lld --relax-gp --undefined=__global_pointer$ --defsym baz=420 rv32.o lds2 -o rv32
+# RUN: ld.lld --relax-gp --undefined=__global_pointer$ --defsym baz=420 rv64.o lds2 -o rv64
+# RUN: llvm-objdump -td -M no-aliases --no-show-raw-insn rv32 | FileCheck %s
+# RUN: llvm-objdump -td -M no-aliases --no-show-raw-insn rv64 | FileCheck %s
+
+
+# RUN: sed 's/\.sdata/\.sbss/g' a.s > a3.s && sed 's/\.sdata/\.sbss/g' lds > lds3
+# RUN: llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=+relax a3.s -o rv32.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64-unknown-elf -mattr=+relax a3.s -o rv64.o
+
+# RUN: ld.lld --relax-gp --undefined=__global_pointer$ --defsym baz=420 rv32.o lds3 -o rv32
+# RUN: ld.lld --relax-gp --undefined=__global_pointer$ --defsym baz=420 rv64.o lds3 -o rv64
+# RUN: llvm-objdump -td -M no-aliases --no-show-raw-insn rv32 | FileCheck %s
+# RUN: llvm-objdump -td -M no-aliases --no-show-raw-insn rv64 | FileCheck %s
+
+
+# RUN: sed 's/\.sdata/\.bss/g' a.s > a4.s && sed 's/\.sdata/\.bss/g' lds > lds4
+# RUN: llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=+relax a4.s -o rv32.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64-unknown-elf -mattr=+relax a4.s -o rv64.o
+
+# RUN: ld.lld --relax-gp --undefined=__global_pointer$ --defsym baz=420 rv32.o lds4 -o rv32
+# RUN: ld.lld --relax-gp --undefined=__global_pointer$ --defsym baz=420 rv64.o lds4 -o rv64
+# RUN: llvm-objdump -td -M no-aliases --no-show-raw-insn rv32 | FileCheck %s
+# RUN: llvm-objdump -td -M no-aliases --no-show-raw-insn rv64 | FileCheck %s
+
 # CHECK: 00000040 l       .text {{0*}}0 a
 
 # CHECK-NOT:  lui

--- a/lld/test/ELF/riscv-section-layout.s
+++ b/lld/test/ELF/riscv-section-layout.s
@@ -25,14 +25,12 @@
 # NOSDATA-NEXT: .data    PROGBITS [[#%x,DATA:]]
 # NOSDATA-NEXT: .bss     NOBITS   [[#%x,BSS:]]
 
-## If there is an undefined reference to __global_pointer$ but .sdata doesn't
-## exist, define __global_pointer$ and set its st_shndx arbitrarily to 1.
-## The symbol value should not be used by the program.
+## If .sdata doesn't exist but .data exists, define __global_pointer$ at DATA_BEGIN+0x800
 
 # NOSDATA-DAG:  [[#]]: {{.*}}                 0 NOTYPE  GLOBAL DEFAULT [[#]] (.text) _etext
 # NOSDATA-DAG:  [[#]]: {{0*}}[[#BSS]]         0 NOTYPE  GLOBAL DEFAULT [[#]] (.data) _edata
 # NOSDATA-DAG:  [[#]]: {{0*}}[[#BSS]]         0 NOTYPE  GLOBAL DEFAULT [[#]] (.bss) __bss_start
-# NOSDATA-DAG:  [[#]]: {{0*}}800              0 NOTYPE  GLOBAL DEFAULT  1 (.dynsym) __global_pointer$
+# NOSDATA-DAG:  [[#]]: {{0*}}[[#DATA+0x800]]  0 NOTYPE  GLOBAL DEFAULT [[#]] (.data) __global_pointer$
 
 # CHECK:      .rodata    PROGBITS
 # CHECK-NEXT: .srodata   PROGBITS


### PR DESCRIPTION
Placing `__global_pointer$` more wisely by looking at other meaningful section anchors, which can help us do gp-relax even if `.sdata` section does not exist.

This is related to the discussion here: https://github.com/llvm/llvm-project/issues/107069

GNU-LD calculates its address in the default link script:
```
__global_pointer$ = MIN(__SDATA_BEGIN__ + 0x800,
                        MAX(__DATA_BEGIN__ + 0x800, __BSS_END__ - 0x800));
```
LLD has a different structure and would have difficulty to be exactly the same behavior as GNU-LD (and I guess we do not have to). For now, It looks for `.sdata` section and places it at `begin_section(.sdata)+0x800`. If `.sdata` does not exist (in some extremely small benchmarks), gp-relax will not take effect. So things can be better here:

Our proposal is based on the current placement strategy. If there is no `.sdata`, we look for `.data`, then `.sbss`, then `.bss`, trying to find a more meaningful place for it, instead of just a non-interesting `elfhead+0x800`.