### PR TITLE
[mlir][tosa] Add support for dense_resource in tosa-narrow-* passes

### DIFF
--- a/mlir/lib/Dialect/Tosa/Transforms/TosaFolders.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaFolders.cpp
@@ -15,10 +15,10 @@
 
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"
+#include "mlir/Dialect/Tosa/Utils/ConversionUtils.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/DialectResourceBlobManager.h"
 #include "mlir/IR/Matchers.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -173,27 +173,6 @@ DenseElementsAttr transposeType(const RangeType &data, ShapedType inputType,
 
   return DenseElementsAttr::get(outputType,
                                 llvm::ArrayRef<ElementType>(outputValues));
-}
-
-// Try to get the values of a DenseResourceElementsAttr construct
-template <typename T>
-std::optional<ArrayRef<T>> tryGetDenseResourceValues(ElementsAttr attr) {
-  if (auto denseResource = dyn_cast<DenseResourceElementsAttr>(attr)) {
-    // Check that the resource memory blob exists
-    AsmResourceBlob *blob = denseResource.getRawHandle().getBlob();
-    if (!blob)
-      return std::nullopt;
-
-    // Check that the data are in a valid form
-    if (!DenseElementsAttr::isValidRawBuffer(attr.getShapedType(),
-                                             blob->getData())) {
-      return std::nullopt;
-    }
-
-    return blob->template getDataAs<T>();
-  }
-
-  return std::nullopt;
 }
 
 // A type specialized transposition of an ElementsAttr.

--- a/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32-aggressive.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32-aggressive.mlir
@@ -68,3 +68,23 @@ func.func @test_f64_const() -> tensor<2xf64> {
   // FUNCBOUND: return %[[CONST]] : tensor<2xf32>
   return %0 : tensor<2xf64>
 }
+
+// -----
+
+// CHECK-LABEL: test_dense_ressource_f64
+func.func @test_dense_ressource_f64() -> tensor<1x2xf64> {
+  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xf32>}> : () -> tensor<1x2xf32>
+  %0 = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xf64>}> : () -> tensor<1x2xf64>
+  // DEFAULT: %[[OUT_CAST:.*]] = tosa.cast %[[CONST]] : (tensor<1x2xf32>) -> tensor<1x2xf64>
+  // DEFAULT: return %[[OUT_CAST]] : tensor<1x2xf64>
+  // FUNCBOUND: return %[[CONST]] : tensor<1x2xf32>
+  return %0 : tensor<1x2xf64>
+}
+{-#
+  dialect_resources: {
+    builtin: {
+      // COMMON: resource: "0x04000000DB0F4940EAD6FCBD"
+      resource: "0x04000000182D4454FB21094059F64637DD9ABFBF"
+    }
+  }
+#-}

--- a/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32.mlir
@@ -178,3 +178,23 @@ func.func @test_f64_add_diagnostic(%arg0: tensor<13x21x1xf64>, %arg1: tensor<13x
   return %0 : tensor<13x21x3xf64>
 }
 }
+
+// -----
+
+// CHECK-LABEL: test_dense_ressource_f64
+func.func @test_dense_ressource_f64() -> tensor<1x2xf64> {
+  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xf32>}> : () -> tensor<1x2xf32>
+  %0 = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xf64>}> : () -> tensor<1x2xf64>
+  // DEFAULT: %[[OUT_CAST:.*]] = tosa.cast %[[CONST]] : (tensor<1x2xf32>) -> tensor<1x2xf64>
+  // DEFAULT: return %[[OUT_CAST]] : tensor<1x2xf64>
+  // FUNCBOUND: return %[[CONST]] : tensor<1x2xf32>
+  return %0 : tensor<1x2xf64>
+}
+{-#
+  dialect_resources: {
+    builtin: {
+      // COMMON: resource: "0x040000000000803F000080BF"
+      resource: "0x04000000000000000000F03F000000000000F0BF"
+    }
+  }
+#-}

--- a/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32-aggressive.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32-aggressive.mlir
@@ -88,3 +88,23 @@ func.func @test_clamp_trunc(%arg0: tensor<100xi64>) -> tensor<100xi64> {
   %1 = tosa.clamp %arg0 {max_val = 3000000000 : i64, min_val = -2147483648 : i64} : (tensor<100xi64>) -> tensor<100xi64>
   return %1 : tensor<100xi64>
 }
+
+// -----
+
+// CHECK-LABEL: test_dense_ressource_i64
+func.func @test_dense_ressource_i64() -> tensor<1x2xi64> {
+  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xi32>}> : () -> tensor<1x2xi32>
+  %1 = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xi64>}> : () -> tensor<1x2xi64>
+  // DEFAULT: %[[OUT_CAST:.*]] = tosa.cast %[[CONST]] : (tensor<1x2xi32>) -> tensor<1x2xi64>
+  // DEFAULT: return %[[OUT_CAST]] : tensor<1x2xi64>
+  // FUNCBOUND: return %[[CONST]] : tensor<1x2xi32>
+  return %1 : tensor<1x2xi64>
+}
+{-#
+  dialect_resources: {
+    builtin: {
+      // COMMON: resource: "0x04000000FFFFFF7F00000080"
+      resource: "0x04000000000000000800000000000000F8FFFFFF"
+    }
+  }
+#-}

--- a/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32.mlir
@@ -199,3 +199,23 @@ func.func @test_clamp_min_outside_i32_range(%arg0: tensor<100xi64>) -> tensor<10
   %1 = tosa.clamp %arg0 {max_val = 2147483647 : i64, min_val = -2147483649 : i64} : (tensor<100xi64>) -> tensor<100xi64>
   return %1 : tensor<100xi64>
 }
+
+// -----
+
+// CHECK-LABEL: test_dense_ressource_i64
+func.func @test_dense_ressource_i64() -> tensor<1x2xi64> {
+  // COMMON: %[[CONST:.*]] = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xi32>}> : () -> tensor<1x2xi32>
+  %1 = "tosa.const"() <{values = dense_resource<resource> : tensor<1x2xi64>}> : () -> tensor<1x2xi64>
+  // DEFAULT: %[[OUT_CAST:.*]] = tosa.cast %[[CONST]] : (tensor<1x2xi32>) -> tensor<1x2xi64>
+  // DEFAULT: return %[[OUT_CAST]] : tensor<1x2xi64>
+  // FUNCBOUND: return %[[CONST]] : tensor<1x2xi32>
+  return %1 : tensor<1x2xi64>
+}
+{-#
+  dialect_resources: {
+    builtin: {
+      // COMMON: resource: "0x04000000FEFFFF7F905AE75A"
+      resource: "0x04000000FEFFFF7F00000000905AE75A00000000"
+    }
+  }
+#-}


### PR DESCRIPTION
Add support for `dense_resource` in `tosa-narrow-f64-to-f32` and `tosa-narrow-i64-to-i32` passes.