### PR TITLE
[NFC] Re-enable* MSVC C4503 diagnostic

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -738,7 +738,6 @@ if (MSVC)
       -wd4457 # Suppress 'declaration of 'var' hides function parameter'
       -wd4458 # Suppress 'declaration of 'var' hides class member'
       -wd4459 # Suppress 'declaration of 'var' hides global declaration'
-      -wd4503 # Suppress ''identifier' : decorated name length exceeded, name was truncated'
       -wd4624 # Suppress ''derived class' : destructor could not be generated because a base class destructor is inaccessible'
       -wd4722 # Suppress 'function' : destructor never returns, potential memory leak
       -wd4100 # Suppress 'unreferenced formal parameter'


### PR DESCRIPTION
From MSDN:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4503?view=msvc-170

> This compiler warning is obsolete and is not generated in Visual
> Studio 2017 and later compilers.

We require at least MSVC 2019 at this point, so no need to keep suppressing this diagnostic. So this "re-enables" it, even though it provides no value.