### PR TITLE
[TableGen] Assert that InstrMapping column values are valid

### DIFF
--- a/llvm/utils/TableGen/CodeGenMapTable.cpp
+++ b/llvm/utils/TableGen/CodeGenMapTable.cpp
@@ -455,7 +455,7 @@ void MapTableEmitter::emitMapFuncBody(raw_ostream &OS, unsigned TableSize) {
       OS << ")\n";
       OS << "    return Table[mid][" << I + 1 << "];\n";
     }
-    OS << "  return (uint32_t)-1U;";
+    OS << "  llvm_unreachable(\"Unrecognized column value!\");\n";
   } else {
     OS << "  return Table[mid][1];\n";
   }


### PR DESCRIPTION
For an InstrMapping table with multiple ValueCols, assert that the
column value passed into the generated map functions matches one of the
columns.

This functionality is only used a few times by a few in-tree targets and
they all seem fine with this change.
