### PR TITLE
[MLIR][VectorDistribute] Preserve 'scf.if' op attributes in 'WarpOpScfIfOp' pattern

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
@@ -1900,6 +1900,7 @@ struct WarpOpScfIfOp : public WarpDistributionPattern {
         rewriter, ifOp.getLoc(), newIfOpDistResTypes,
         newWarpOp.getResult(newIndices[0]), static_cast<bool>(ifOp.thenBlock()),
         static_cast<bool>(ifOp.elseBlock()));
+    newIfOp->setAttrs(ifOp->getAttrDictionary());
     auto encloseRegionInWarpOp =
         [&](Block *oldIfBranch, Block *newIfBranch,
             llvm::SmallSetVector<Value, 32> &escapingValues,

--- a/mlir/test/Dialect/Vector/vector-warp-distribute.mlir
+++ b/mlir/test/Dialect/Vector/vector-warp-distribute.mlir
@@ -1935,7 +1935,7 @@ func.func @warp_scf_if_no_yield_distribute(%buffer: memref<128xindex>, %pred : i
     %seq = vector.step : vector<32xindex>
     scf.if %pred {
       vector.store %seq, %buffer[%c0] : memref<128xindex>, vector<32xindex>
-    }
+    } {my_attr = 42 : i64}
     gpu.yield
   }
   return
@@ -1947,6 +1947,7 @@ func.func @warp_scf_if_no_yield_distribute(%buffer: memref<128xindex>, %pred : i
 //       CHECK-PROP:   gpu.warp_execute_on_lane_0(%{{.*}})[32] args(%{{.*}} : vector<1xindex>) {
 //       CHECK-PROP:   ^bb0(%[[ARG2:.+]]: vector<32xindex>):
 //       CHECK-PROP:   vector.store %[[ARG2]], %[[ARG0]][%{{.*}}] : memref<128xindex>, vector<32xindex>
+//       CHECK-PROP:   } {my_attr = 42 : i64}
 
 // -----
 
@@ -1963,7 +1964,7 @@ func.func @warp_scf_if_distribute(%pred : i1)  {
     } else {
       %2 = "other_op"(%seq2) : (vector<32xindex>) -> (vector<32xf32>)
       scf.yield %2 : vector<32xf32>
-    }
+    } {my_attr = 42 : i64}
     gpu.yield %0 : vector<32xf32>
   }
   "some_use"(%0) : (vector<1xf32>) -> ()
@@ -1989,7 +1990,7 @@ func.func @warp_scf_if_distribute(%pred : i1)  {
 //       CHECK-PROP:        gpu.yield %{{.*}} : vector<32xf32>
 //       CHECK-PROP:      }
 //       CHECK-PROP:      scf.yield %[[ELSE_DIST]] : vector<1xf32>
-//       CHECK-PROP:    }
+//       CHECK-PROP:    } {my_attr = 42 : i64}
 //       CHECK-PROP:    "some_use"(%[[IF_YIELD_DIST]]) : (vector<1xf32>) -> ()
 //       CHECK-PROP:    return
 //       CHECK-PROP:  }


### PR DESCRIPTION
The PR changes the `WarpOpScfIfOp` distribution pattern to preserve the `scf.if` op attributes after it was re-created.

This is required for xegpu-pipeline that may rely on `sg_id_range` attribute of `scf.if` ops in `xegpu-to-xevm` pass that is ran after the warp-op distribution.