### PR TITLE
[libsycl] Fix build after olInit change

### DIFF
--- a/libsycl/src/detail/offload/offload_topology.cpp
+++ b/libsycl/src/detail/offload/offload_topology.cpp
@@ -56,7 +56,7 @@ void OffloadTopology::registerNewPlatformsAndDevices(
 }
 
 void discoverOffloadDevices() {
-  callAndThrow(olInit);
+  callAndThrow(olInit, nullptr);
 
   // liboffload returns devices sorted by backend + platform. We rely on this
   // behavior during device enumeration.


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/181872 the function takes an argument. Pass `nullptr` to have it do the same thing as before.

This wasn't caught because the only builder that builds `libsycl` is not in the production builder area at the moment.