### PR TITLE
[Clang] [MinGW] Handle `-nolibc` argument

### DIFF
--- a/clang/test/Driver/mingw.cpp
+++ b/clang/test/Driver/mingw.cpp
@@ -96,3 +96,13 @@
 // RUN: %clang --target=i686-windows-gnu -fms-hotpatch -### -- %s 2>&1 \
 // RUN:    | FileCheck %s --check-prefix=FUNCTIONPADMIN
 // FUNCTIONPADMIN: "--functionpadmin"
+
+// RUN: %clang --target=x86_64-pc-windows-gnu -nolibc -### %s 2>&1 | FileCheck -check-prefix=CHECK_MINGW_NOLIBC %s
+// CHECK_MINGW_NOLIBC-NOT: "-ladvapi32"
+// CHECK_MINGW_NOLIBC-NOT: "-lkernel32"
+// CHECK_MINGW_NOLIBC-NOT: "-lmingw32"
+// CHECK_MINGW_NOLIBC-NOT: "-lmingwex"
+// CHECK_MINGW_NOLIBC-NOT: "-lmoldname"
+// CHECK_MINGW_NOLIBC-NOT: "-lmsvcrt"
+// CHECK_MINGW_NOLIBC-NOT: "-lshell32"
+// CHECK_MINGW_NOLIBC-NOT: "-luser32"


### PR DESCRIPTION
This implementation differs from GCC, but arguably more in line with Unix systems, because it stops linking of default Win32 system libraries.

On GCC it works like this:
```
❯ /ucrt64/bin/gcc -### /dev/null -nolibc 2>&1 | tr ' ' '\n' | rg '^\-l' | sort -u
-lgcc
-lgcc_eh
-lkernel32
-lmingw32
-lmingwex
-lmsvcrt

❯ /ucrt64/bin/gcc -### /dev/null 2>&1 | tr ' ' '\n' | rg '^\-l' | sort -u
-ladvapi32
-lgcc
-lgcc_eh
-lkernel32
-lmingw32
-lmingwex
-lmsvcrt
-lpthread
-lshell32
-luser32
```
Clang with this PR:
```
❯ ./bin/clang -### /dev/null -nolibc 2>&1 | tr ' ' '\n' | rg '^"\-l' | sort -u
"-lgcc"
"-lgcc_eh"
```

The motivation for supporting this argument comes from Rust, which wants to control what is linked, but still utilize compiler builtins. With GCC that is done by supplying `-nodefaultlibs` and `-lgcc`, but LLVM's compiler-rt cannot be added back as easily.
`-nolibc --unwindlib=none` that skips Win32 libs would give the parity with GCC's `-nodefaultlibs -lgcc`.