### PR TITLE
[clang-tidy] Add none_of suggestion to readability-use-anyofallof

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/UseAnyOfAllOfCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/UseAnyOfAllOfCheck.cpp
@@ -84,6 +84,26 @@ static bool isViableLoop(const CXXForRangeStmt &S, ASTContext &Context) {
   });
 }
 
+/// For the all_of_loop pattern (returns false inside, true after), check
+/// whether the if-condition is negated. If it is, the loop is an all_of;
+/// otherwise it is a none_of.
+static bool isNoneOfPattern(const CXXForRangeStmt &Loop) {
+  const Stmt *Body = Loop.getBody();
+  const IfStmt *If = nullptr;
+  if (const auto *Compound = dyn_cast<CompoundStmt>(Body)) {
+    if (Compound->size() == 1)
+      If = dyn_cast<IfStmt>(Compound->body_front());
+  } else {
+    If = dyn_cast<IfStmt>(Body);
+  }
+  if (!If)
+    return false;
+  // If the condition is not negated (no leading !), it's a none_of pattern.
+  const Expr *Cond = If->getCond()->IgnoreParenImpCasts();
+  const auto *UO = dyn_cast<UnaryOperator>(Cond);
+  return !UO || UO->getOpcode() != UO_LNot;
+}
+
 void UseAnyOfAllOfCheck::check(const MatchFinder::MatchResult &Result) {
   if (const auto *S = Result.Nodes.getNodeAs<CXXForRangeStmt>("any_of_loop")) {
     if (!isViableLoop(*S, *Result.Context))
@@ -96,8 +116,13 @@ void UseAnyOfAllOfCheck::check(const MatchFinder::MatchResult &Result) {
     if (!isViableLoop(*S, *Result.Context))
       return;
 
-    diag(S->getForLoc(), "replace loop by 'std%select{|::ranges}0::all_of()'")
-        << getLangOpts().CPlusPlus20;
+    if (isNoneOfPattern(*S))
+      diag(S->getForLoc(),
+           "replace loop by 'std%select{|::ranges}0::none_of()'")
+          << getLangOpts().CPlusPlus20;
+    else
+      diag(S->getForLoc(), "replace loop by 'std%select{|::ranges}0::all_of()'")
+          << getLangOpts().CPlusPlus20;
   }
 }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -255,6 +255,10 @@ Changes in existing checks
   <clang-tidy/checks/readability/suspicious-call-argument>` check by avoiding a
   crash from invalid ``Abbreviations`` option.
 
+- Improved :doc:`readability-use-anyofallof
+  <clang-tidy/checks/readability/use-anyofallof>` check by adding support for
+  ``std::none_of`` suggestions when the loop condition is not negated.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/use-anyofallof.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/use-anyofallof.rst
@@ -4,8 +4,9 @@ readability-use-anyofallof
 ==========================
 
 Finds range-based for loops that can be replaced by a call to
-``std::any_of`` or ``std::all_of``. In C++20 mode, suggests
-``std::ranges::any_of`` or ``std::ranges::all_of``.
+``std::any_of``, ``std::all_of``, or ``std::none_of``. In C++20 mode, suggests
+``std::ranges::any_of``, ``std::ranges::all_of``, or
+``std::ranges::none_of``.
 
 Example:
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/use-anyofallof-cpp20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/use-anyofallof-cpp20.cpp
@@ -9,11 +9,22 @@ bool good_any_of() {
   return false;
 }
 
+bool good_none_of() {
+  int v[] = {1, 2, 3};
+  // CHECK-MESSAGES: :[[@LINE+1]]:3: warning: replace loop by 'std::ranges::none_of()'
+  for (int i : v)
+    if (i)
+      return false;
+  return true;
+}
+
+bool cond(int i);
+
 bool good_all_of() {
   int v[] = {1, 2, 3};
   // CHECK-MESSAGES: :[[@LINE+1]]:3: warning: replace loop by 'std::ranges::all_of()'
   for (int i : v)
-    if (i)
+    if (!cond(i))
       return false;
   return true;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/use-anyofallof.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/use-anyofallof.cpp
@@ -174,11 +174,20 @@ bool bad_any_of7() {
   return false;
 }
 
+bool good_none_of() {
+  int v[] = {1, 2, 3};
+  // CHECK-MESSAGES: :[[@LINE+1]]:3: warning: replace loop by 'std::none_of()' [readability-use-anyofallof]
+  for (int i : v)
+    if (i)
+      return false;
+  return true;
+}
+
 bool good_all_of() {
   int v[] = {1, 2, 3};
   // CHECK-MESSAGES: :[[@LINE+1]]:3: warning: replace loop by 'std::all_of()' [readability-use-anyofallof]
   for (int i : v)
-    if (i)
+    if (!cond(i))
       return false;
   return true;
 }


### PR DESCRIPTION
Add `std::none_of` support to `readability-use-anyofallof`.

When the loop body contains `if (cond) return false; ... return true;` with a non-negated condition, the check now suggests `std::none_of` instead of `std::all_of`. Negated conditions (`if (!cond)`) continue to suggest `std::all_of`.

Changes:
- Add `isNoneOfPattern()` helper to distinguish `none_of` vs `all_of` patterns.
- Add test cases for both `none_of` and `all_of` (negated condition).
- Update docs and release notes.