### PR TITLE
[mlir][Math][SPIRV] fix `math.round` conversion for unit-dim vectors

### DIFF
--- a/mlir/lib/Conversion/MathToSPIRV/MathToSPIRV.cpp
+++ b/mlir/lib/Conversion/MathToSPIRV/MathToSPIRV.cpp
@@ -449,8 +449,13 @@ struct RoundOpPattern final : public OpConversionPattern<math::RoundOp> {
       return res;
 
     Location loc = roundOp.getLoc();
-    Value operand = roundOp.getOperand();
-    Type ty = operand.getType();
+    auto ty = getTypeConverter()->convertType(adaptor.getOperand().getType());
+    if (!ty)
+      return rewriter.notifyMatchFailure(
+          roundOp->getLoc(),
+          llvm::formatv("failed to convert type {0} for SPIR-V",
+                        roundOp.getType()));
+
     Type ety = getElementTypeOrSelf(ty);
 
     auto zero = spirv::ConstantOp::getZero(ty, loc, rewriter);
@@ -466,14 +471,15 @@ struct RoundOpPattern final : public OpConversionPattern<math::RoundOp> {
                                        rewriter.getFloatAttr(ety, 0.5));
     }
 
-    auto abs = spirv::GLFAbsOp::create(rewriter, loc, operand);
+    auto abs = spirv::GLFAbsOp::create(rewriter, loc, adaptor.getOperand());
     auto floor = spirv::GLFloorOp::create(rewriter, loc, abs);
     auto sub = spirv::FSubOp::create(rewriter, loc, abs, floor);
     auto greater =
         spirv::FOrdGreaterThanEqualOp::create(rewriter, loc, sub, half);
     auto select = spirv::SelectOp::create(rewriter, loc, greater, one, zero);
     auto add = spirv::FAddOp::create(rewriter, loc, floor, select);
-    rewriter.replaceOpWithNewOp<math::CopySignOp>(roundOp, add, operand);
+    rewriter.replaceOpWithNewOp<math::CopySignOp>(roundOp, add,
+                                                  adaptor.getOperand());
     return success();
   }
 };

--- a/mlir/lib/Conversion/MathToSPIRV/MathToSPIRV.cpp
+++ b/mlir/lib/Conversion/MathToSPIRV/MathToSPIRV.cpp
@@ -450,11 +450,12 @@ struct RoundOpPattern final : public OpConversionPattern<math::RoundOp> {
 
     Location loc = roundOp.getLoc();
     auto ty = getTypeConverter()->convertType(adaptor.getOperand().getType());
-    if (!ty)
+    if (!ty) {
       return rewriter.notifyMatchFailure(
           roundOp->getLoc(),
           llvm::formatv("failed to convert type {0} for SPIR-V",
                         roundOp.getType()));
+    }
 
     Type ety = getElementTypeOrSelf(ty);
 


### PR DESCRIPTION
In SPIR-V, unit dimensional vectors, e.g. `vector<1xf32` are legalized as scalars (vectors are 2, 3, 4, and possibly 8 and 16 dimensional). This PR fixes the `math.round` conversion pattern to legalize these vectors during conversion.

Co-authored-by: Ege Beysel <beysel@roofline.ai>