### PR TITLE
[clang-tidy] Add readability-pointer-to-ref check

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/readability/CMakeLists.txt
@@ -37,6 +37,7 @@ add_clang_library(clangTidyReadabilityModule STATIC
   NamespaceCommentCheck.cpp
   NonConstParameterCheck.cpp
   OperatorsRepresentationCheck.cpp
+  PointerToRefCheck.cpp
   QualifiedAutoCheck.cpp
   ReadabilityTidyModule.cpp
   RedundantAccessSpecifiersCheck.cpp

--- a/clang-tools-extra/clang-tidy/readability/PointerToRefCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/PointerToRefCheck.cpp
@@ -1,0 +1,224 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PointerToRefCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include <cassert>
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::readability {
+
+namespace {
+
+/// Visitor that classifies how a pointer parameter is used in a function body.
+/// It detects:
+///   - Dereferences (operator*, operator->)
+///   - Null checks (if(ptr), ptr != nullptr, assert(ptr), etc.)
+///   - Pointer arithmetic
+///   - Being passed to other functions as a pointer
+///   - Address-of or array subscript usage
+class PointerUsageVisitor : public RecursiveASTVisitor<PointerUsageVisitor> {
+public:
+  PointerUsageVisitor(const ParmVarDecl *Param, ASTContext &Ctx)
+      : Param(Param), Ctx(Ctx) {}
+
+  bool isDereferenced() const { return Dereferenced; }
+  bool isNullChecked() const { return NullChecked; }
+  bool isUsedAsPointer() const { return UsedAsPointer; }
+
+  bool VisitUnaryOperator(const UnaryOperator *UO) {
+    const Expr *SubExpr = UO->getSubExpr();
+    if (UO->getOpcode() == UO_Deref && refersToParam(SubExpr))
+      Dereferenced = true;
+    if (UO->getOpcode() == UO_AddrOf && refersToParam(SubExpr))
+      UsedAsPointer = true;
+    return true;
+  }
+
+  bool VisitMemberExpr(const MemberExpr *ME) {
+    if (ME->isArrow() && refersToParam(ME->getBase()))
+      Dereferenced = true;
+    return true;
+  }
+
+  // Detect null checks: if(ptr), ptr == nullptr, !ptr, etc.
+  bool VisitImplicitCastExpr(const ImplicitCastExpr *ICE) {
+    if (ICE->getCastKind() == CK_PointerToBoolean &&
+        refersToParam(ICE->getSubExpr()))
+      NullChecked = true;
+    return true;
+  }
+
+  bool VisitBinaryOperator(const BinaryOperator *BO) {
+    const Expr *LHS = BO->getLHS()->IgnoreImplicit();
+    const Expr *RHS = BO->getRHS()->IgnoreImplicit();
+
+    // ptr == nullptr, nullptr == ptr, ptr != nullptr, etc.
+    if (BO->isEqualityOp()) {
+      const bool LHSIsParam = refersToParam(LHS);
+      const bool RHSIsParam = refersToParam(RHS);
+      if ((LHSIsParam && RHS->isNullPointerConstant(
+                             Ctx, Expr::NPC_ValueDependentIsNotNull)) ||
+          (RHSIsParam &&
+           LHS->isNullPointerConstant(Ctx, Expr::NPC_ValueDependentIsNotNull)))
+        NullChecked = true;
+      // Comparing pointer to another non-null pointer (e.g. p == q).
+      else if (LHSIsParam || RHSIsParam)
+        UsedAsPointer = true;
+    }
+
+    // Pointer comparison (relational).
+    if (BO->isRelationalOp() && (refersToParam(LHS) || refersToParam(RHS)))
+      UsedAsPointer = true;
+
+    // Pointer arithmetic: ptr + n, ptr - n.
+    if ((BO->getOpcode() == BO_Add || BO->getOpcode() == BO_Sub) &&
+        (refersToParam(LHS) || refersToParam(RHS)))
+      UsedAsPointer = true;
+
+    // Reassignment: ptr = something.
+    if (BO->getOpcode() == BO_Assign && refersToParam(LHS))
+      UsedAsPointer = true;
+
+    return true;
+  }
+
+  // Detect being passed to a function expecting a pointer.
+  bool VisitCallExpr(const CallExpr *CE) {
+    for (unsigned I = 0; I < CE->getNumArgs(); ++I)
+      if (refersToParam(CE->getArg(I)->IgnoreImplicit()))
+        UsedAsPointer = true;
+    return true;
+  }
+
+  // Detect array subscript: ptr[i]
+  bool VisitArraySubscriptExpr(const ArraySubscriptExpr *ASE) {
+    if (refersToParam(ASE->getBase()->IgnoreImplicit()))
+      UsedAsPointer = true;
+    return true;
+  }
+
+  // Detect delete expression: delete ptr.
+  bool VisitCXXDeleteExpr(const CXXDeleteExpr *DE) {
+    if (refersToParam(DE->getArgument()))
+      UsedAsPointer = true;
+    return true;
+  }
+
+  // Detect return of pointer value.
+  bool VisitReturnStmt(const ReturnStmt *RS) {
+    if (RS->getRetValue() && refersToParam(RS->getRetValue()))
+      UsedAsPointer = true;
+    return true;
+  }
+
+  // Detect pointer stored to a variable: int *q = ptr;
+  bool VisitVarDecl(const VarDecl *VD) {
+    if (VD != Param && VD->hasInit() && refersToParam(VD->getInit()))
+      UsedAsPointer = true;
+    return true;
+  }
+
+  // Detect pointer passed to constructor: SomeClass obj(ptr);
+  bool VisitCXXConstructExpr(const CXXConstructExpr *CE) {
+    for (unsigned I = 0; I < CE->getNumArgs(); ++I)
+      if (refersToParam(CE->getArg(I)))
+        UsedAsPointer = true;
+    return true;
+  }
+
+  // Detect pointer captured by lambda.
+  bool TraverseLambdaExpr(LambdaExpr *LE) {
+    for (const LambdaCapture &Capture : LE->captures())
+      if (Capture.capturesVariable() && Capture.getCapturedVar() == Param)
+        UsedAsPointer = true;
+    // Don't descend into the lambda body -- it's a different scope.
+    return true;
+  }
+
+  // Skip unevaluated contexts like sizeof/alignof.
+  bool TraverseUnaryExprOrTypeTraitExpr(UnaryExprOrTypeTraitExpr *E) {
+    return true;
+  }
+
+  // Skip unevaluated context: decltype(P).
+  bool TraverseDecltypeTypeLoc(DecltypeTypeLoc TL, bool = false) {
+    return true;
+  }
+
+private:
+  bool refersToParam(const Expr *E) const {
+    if (!E)
+      return false;
+    const auto *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts());
+    return DRE && DRE->getDecl() == Param;
+  }
+
+  const ParmVarDecl *Param;
+  ASTContext &Ctx;
+  bool Dereferenced = false;
+  bool NullChecked = false;
+  bool UsedAsPointer = false;
+};
+
+AST_MATCHER(CXXMethodDecl, isOverloadedOperator) {
+  return Node.isOverloadedOperator();
+}
+
+AST_MATCHER(NamedDecl, hasIdentifier) {
+  return Node.getIdentifier() != nullptr;
+}
+
+AST_MATCHER(ParmVarDecl, pointsToCompleteType) {
+  const auto *PT = Node.getType()->getAs<PointerType>();
+  return PT && !PT->getPointeeType()->isIncompleteType();
+}
+
+} // namespace
+
+void PointerToRefCheck::registerMatchers(MatchFinder *Finder) {
+  // Match pointer parameters in non-trivial function definitions,
+  // excluding void pointers and function pointers.
+  const auto PointerParam = parmVarDecl(
+      hasIdentifier(), pointsToCompleteType(),
+      hasType(pointerType(pointee(unless(voidType()), unless(functionType())))),
+      decl().bind("param"));
+  Finder->addMatcher(functionDecl(isDefinition(), unless(isImplicit()),
+                                  unless(isDeleted()), unless(isMain()),
+                                  unless(isExternC()),
+                                  unless(cxxMethodDecl(isVirtual())),
+                                  unless(cxxMethodDecl(isOverloadedOperator())),
+                                  has(typeLoc(forEach(PointerParam))))
+                         .bind("func"),
+                     this);
+}
+
+void PointerToRefCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *Func = Result.Nodes.getNodeAs<FunctionDecl>("func");
+  const auto *Param = Result.Nodes.getNodeAs<ParmVarDecl>("param");
+  assert(Func && Param && Func->hasBody());
+
+  // Analyze usage in the body.
+  PointerUsageVisitor Visitor(Param, *Result.Context);
+  Visitor.TraverseStmt(Func->getBody());
+
+  // Only flag if the pointer is dereferenced but never null-checked
+  // and not used as a raw pointer (arithmetic, passed to functions, etc.).
+  if (Visitor.isDereferenced() && !Visitor.isNullChecked() &&
+      !Visitor.isUsedAsPointer()) {
+    diag(Param->getLocation(),
+         "pointer parameter '%0' can be a reference; it is always "
+         "dereferenced but never checked for null")
+        << Param->getName();
+  }
+}
+
+} // namespace clang::tidy::readability

--- a/clang-tools-extra/clang-tidy/readability/PointerToRefCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/PointerToRefCheck.h
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_READABILITY_POINTERTOREFCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_READABILITY_POINTERTOREFCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang::tidy::readability {
+
+/// Finds function parameters that are pointers but are always dereferenced
+/// without null checks, suggesting they should be references instead.
+///
+/// For the user-facing documentation see:
+/// https://clang.llvm.org/extra/clang-tidy/checks/readability/pointer-to-ref.html
+class PointerToRefCheck : public ClangTidyCheck {
+public:
+  PointerToRefCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace clang::tidy::readability
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_READABILITY_POINTERTOREFCHECK_H

--- a/clang-tools-extra/clang-tidy/readability/ReadabilityTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ReadabilityTidyModule.cpp
@@ -39,6 +39,7 @@
 #include "NamedParameterCheck.h"
 #include "NonConstParameterCheck.h"
 #include "OperatorsRepresentationCheck.h"
+#include "PointerToRefCheck.h"
 #include "QualifiedAutoCheck.h"
 #include "RedundantAccessSpecifiersCheck.h"
 #include "RedundantCastingCheck.h"
@@ -134,6 +135,8 @@ public:
         "readability-misplaced-array-index");
     CheckFactories.registerCheck<OperatorsRepresentationCheck>(
         "readability-operators-representation");
+    CheckFactories.registerCheck<PointerToRefCheck>(
+        "readability-pointer-to-ref");
     CheckFactories.registerCheck<QualifiedAutoCheck>(
         "readability-qualified-auto");
     CheckFactories.registerCheck<RedundantAccessSpecifiersCheck>(

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -70,6 +70,9 @@ Hover
 Code completion
 ^^^^^^^^^^^^^^^
 
+- Now also provides include files without extension, if they are in a directory
+  only called ``include``.
+
 Code actions
 ^^^^^^^^^^^^
 
@@ -139,6 +142,12 @@ New checks
   Finds and removes redundant conversions from ``std::[w|u8|u16|u32]string_view`` to
   ``std::[...]string`` in call expressions expecting ``std::[...]string_view``.
 
+- New :doc:`readability-pointer-to-ref
+  <clang-tidy/checks/readability/pointer-to-ref>` check.
+
+  Finds function parameters that are pointers but are always dereferenced
+  without null checks, suggesting they should be references instead.
+
 - New :doc:`readability-trailing-comma
   <clang-tidy/checks/readability/trailing-comma>` check.
 
@@ -159,11 +168,20 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/bad-signal-to-kill-thread>` check by fixing false
   negatives when the ``SIGTERM`` macro is obtained from a precompiled header.
 
+- Improved :doc:`bugprone-casting-through-void
+  <clang-tidy/checks/bugprone/casting-through-void>` check by running only on
+  C++ files because suggested ``reinterpret_cast`` is not available in pure C.
+
 - Improved :doc:`bugprone-exception-escape
   <clang-tidy/checks/bugprone/exception-escape>` check by adding
   `TreatFunctionsWithoutSpecificationAsThrowing` option to support reporting
   for unannotated functions, enabling reporting when no explicit ``throw``
   is seen and allowing separate tuning for known and unknown implementations.
+
+- Improved :doc:`bugprone-fold-init-type
+  <clang-tidy/checks/bugprone/fold-init-type>` check by detecting precision
+  loss in overloads with transparent standard functors (e.g. ``std::plus<>``)
+  for ``std::accumulate``, ``std::reduce``, and ``std::inner_product``.
 
 - Improved :doc:`bugprone-macro-parentheses
   <clang-tidy/checks/bugprone/macro-parentheses>` check by printing the macro
@@ -205,9 +223,24 @@ Changes in existing checks
   - Added support for analyzing function parameters with the `AnalyzeParameters`
     option.
 
+  - Fixed false positive where an array of pointers to ``const`` was
+    incorrectly diagnosed as allowing the pointee to be made ``const``.
+
+- Improved :doc:`misc-unused-using-decls
+  <clang-tidy/checks/misc/unused-using-decls>` to not diagnose ``using``
+  declarations as unused if they're exported from a module.
+
 - Improved :doc:`modernize-pass-by-value
   <clang-tidy/checks/modernize/pass-by-value>` check by adding `IgnoreMacros`
   option to suppress warnings in macros.
+
+- Improved :doc:`modernize-redundant-void-arg
+  <clang-tidy/checks/modernize/redundant-void-arg>` check to work in C23.
+
+- Improved :doc:`modernize-use-equals-delete
+  <clang-tidy/checks/modernize/use-equals-delete>` check by only warning on
+  private deleted functions, if they do not have a public overload or are a
+  special member function.
 
 - Improved :doc:`modernize-use-std-format
   <clang-tidy/checks/modernize/use-std-format>` check by fixing a crash
@@ -223,6 +256,11 @@ Changes in existing checks
   - Exclude ``enum`` in ``extern "C"`` blocks.
 
   - Improved the ignore list to correctly handle ``typedef`` and  ``enum``.
+
+- Improved :doc:`performance-faster-string-find
+  <clang-tidy/checks/performance/faster-string-find>` check to
+  analyze calls to the ``starts_with``, ``ends_with``, and ``contains``
+  string member functions.
 
 - Improved :doc:`performance-inefficient-vector-operation
   <clang-tidy/checks/performance/inefficient-vector-operation>` check by

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -405,6 +405,7 @@ Clang-Tidy Checks
    :doc:`readability-named-parameter <readability/named-parameter>`, "Yes"
    :doc:`readability-non-const-parameter <readability/non-const-parameter>`, "Yes"
    :doc:`readability-operators-representation <readability/operators-representation>`, "Yes"
+   :doc:`readability-pointer-to-ref <readability/pointer-to-ref>`,
    :doc:`readability-qualified-auto <readability/qualified-auto>`, "Yes"
    :doc:`readability-redundant-access-specifiers <readability/redundant-access-specifiers>`, "Yes"
    :doc:`readability-redundant-casting <readability/redundant-casting>`, "Yes"

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/pointer-to-ref.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/pointer-to-ref.rst
@@ -1,0 +1,42 @@
+.. title:: clang-tidy - readability-pointer-to-ref
+
+readability-pointer-to-ref
+==========================
+
+Finds function parameters that are pointers but are always dereferenced without
+null checks, suggesting they should be references instead.
+
+Using references instead of pointers for non-nullable parameters makes the
+contract explicit: the caller must provide a valid object. This improves code
+readability and can help prevent null pointer bugs.
+
+.. code-block:: c++
+
+  // Before -- pointer that is never null-checked
+  void process(Foo *P) {
+    P->bar();
+    P->X = 42;
+  }
+
+  // After -- use a reference instead
+  void process(Foo &P) {
+    P.bar();
+    P.X = 42;
+  }
+
+The check will not flag a parameter if it:
+
+- is passed to another function as a pointer argument,
+- is used in pointer arithmetic or array subscript,
+- is a ``void`` pointer or pointer to an incomplete type,
+- is a parameter of a virtual method or an ``extern "C"`` function,
+- is used in a ``delete`` expression,
+- is returned from the function,
+- is stored to another variable or captured by a lambda, or
+- has its address taken (``&P``).
+
+.. note::
+
+   This check does not provide fix-its because changing a parameter from pointer
+   to reference requires updating all call sites, which may span multiple
+   translation units.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/pointer-to-ref.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/pointer-to-ref.cpp
@@ -1,0 +1,193 @@
+// RUN: %check_clang_tidy %s readability-pointer-to-ref %t
+
+struct Foo {
+  int X;
+  void bar();
+};
+
+// Positive: always dereferenced, never null-checked.
+void derefArrow(Foo *P) {
+// CHECK-MESSAGES: :[[@LINE-1]]:22: warning: pointer parameter 'P' can be a reference
+  P->bar();
+  P->X = 42;
+}
+
+// Positive: dereference via unary operator.
+int derefStar(int *P) {
+// CHECK-MESSAGES: :[[@LINE-1]]:20: warning: pointer parameter 'P' can be a reference
+  return *P + 1;
+}
+
+// Positive: multiple parameters, only the dereferenced one flagged.
+void twoParams(int *A, int *B) {
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: pointer parameter 'A' can be a reference
+  *A = 10;
+  if (B)
+    *B = 20;
+}
+
+// Positive: dereference through parentheses.
+int derefParen(int *P) {
+// CHECK-MESSAGES: :[[@LINE-1]]:21: warning: pointer parameter 'P' can be a reference
+  return *(P) + 1;
+}
+
+// Positive: (*P)->member pattern.
+struct Bar {
+  int val;
+};
+int derefThenArrow(Bar **P) {
+// CHECK-MESSAGES: :[[@LINE-1]]:26: warning: pointer parameter 'P' can be a reference
+  return (*P)->val;
+}
+
+// Negative: null-checked before use.
+void nullChecked(Foo *P) {
+  if (P)
+    P->bar();
+}
+
+// Negative: compared to nullptr.
+void comparedToNull(Foo *P) {
+  if (P != nullptr)
+    P->bar();
+}
+
+// Negative: compared using == nullptr.
+void equalNull(Foo *P) {
+  if (P == nullptr)
+    return;
+  P->bar();
+}
+
+// Negative: negation null check (!P).
+void negationCheck(Foo *P) {
+  if (!P)
+    return;
+  P->bar();
+}
+
+// Negative: passed to another function (used as raw pointer).
+void takePtr(Foo *);
+void passedAlong(Foo *P) {
+  P->bar();
+  takePtr(P);
+}
+
+// Negative: used as array (subscript).
+void asArray(int *P) {
+  P[0] = 1;
+  P[1] = 2;
+}
+
+// Negative: void pointer (too generic).
+void voidPtr(void *P) {
+}
+
+// Negative: unnamed parameter.
+void unnamed(int *) {
+}
+
+// Negative: no dereference at all.
+void noDereference(int *P) {
+}
+
+// Negative: parameter reassigned.
+void reassigned(int *P) {
+  int X = 0;
+  P = &X;
+  *P = 42;
+}
+
+// Negative: virtual method (signature must match base).
+struct Base {
+  virtual void vmethod(int *P);
+};
+
+// Negative: function pointer parameter.
+void funcPtr(void (*P)(int)) {
+  P(42);
+}
+
+// Negative: pointer arithmetic.
+void arithmetic(int *P) {
+  *(P + 1) = 0;
+}
+
+// Negative: address-of usage.
+void addressOf(int *P) {
+  int **PP = &P;
+  **PP = 42;
+}
+
+// Negative: extern "C" linkage.
+extern "C" void cLinkage(int *P) {
+  *P = 10;
+}
+
+// Negative: delete expression.
+void deletePtr(Foo *P) {
+  P->bar();
+  delete P;
+}
+
+// Negative: return pointer value.
+int *returnPtr(int *P) {
+  *P = 10;
+  return P;
+}
+
+// Negative: stored to another variable.
+void storedToVar(int *P) {
+  int *Q = P;
+  *Q = 42;
+}
+
+// Negative: passed to constructor.
+struct Wrapper {
+  Wrapper(int *P);
+};
+void passedToCtor(int *P) {
+  *P = 10;
+  Wrapper W(P);
+}
+
+// Negative: used in sizeof (unevaluated context).
+void sizeofUsage(int *P) {
+  (void)sizeof(*P);
+}
+
+// Negative: sizeof with pointer itself.
+void sizeofPtr(int *P) {
+  (void)sizeof(P);
+}
+
+// Negative: alignof in unevaluated context.
+void alignofUsage(int *P) {
+  (void)alignof(decltype(*P));
+}
+
+// Negative: decltype (unevaluated context).
+void decltypeUsage(int *P) {
+  decltype(P) Q = nullptr;
+  (void)Q;
+}
+
+// Negative: pointer compared to another pointer (not null).
+void comparedToOtherPtr(int *P, int *Q) {
+  if (P == Q)
+    return;
+  *P = 10;
+}
+
+// Negative: used in lambda capture by value (passed along).
+void lambdaCapture(int *P) {
+  *P = 10;
+  auto F = [P]() { return *P; };
+  (void)F;
+}
+
+// Negative: operator overload.
+struct MyClass {
+  bool operator==(const MyClass *Other) const;
+};


### PR DESCRIPTION
Add new clang-tidy check that finds function parameters that are pointers but are always dereferenced without null checks, suggesting they should be references instead.

Using references for non-nullable parameters makes the contract explicit and improves readability.

```cpp
// Before -- pointer that is never null-checked
void process(Foo *P) {
  P->bar();
  P->X = 42;
}

// Suggested -- use a reference
void process(Foo &P) {
  P.bar();
  P.X = 42;
}
```

The check skips parameters that are:
- null-checked (`if(ptr)`, `ptr != nullptr`, etc.)
- passed to other functions as pointers
- used in pointer arithmetic or array subscript
- void pointers or pointers to incomplete types
- parameters of virtual methods
- function pointers
- unnamed or never dereferenced

No fix-its are provided since changing the signature requires updating all call sites, which may span translation units.