### PR TITLE
[clang][deps] Don't treat the 'P1689' output format specially

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningService.h
@@ -91,6 +91,8 @@ struct DependencyScanningServiceOptions {
   ScanningOutputFormat Format = ScanningOutputFormat::Full;
   /// How to optimize resulting explicit module command lines.
   ScanningOptimizations OptimizeArgs = ScanningOptimizations::Default;
+  /// Whether to make reported file paths absolute.
+  bool ReportAbsolutePaths = true;
   /// Whether the resulting command lines should load explicit PCMs eagerly.
   bool EagerLoadModules = false;
   /// Whether to trace VFS accesses during the scan.

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -794,17 +794,11 @@ bool DependencyScanningAction::runInvocation(
       Service, *OriginalInvocation, Controller, *MaybePrebuiltModulesASTMap,
       StableDirs);
 
-  std::unique_ptr<FrontendAction> Action;
-
-  if (Service.getOpts().Format == ScanningOutputFormat::P1689)
-    Action = std::make_unique<PreprocessOnlyAction>();
-  else
-    Action = std::make_unique<ReadPCHAndPreprocessAction>();
-
   if (ScanInstance.getDiagnostics().hasErrorOccurred())
     return false;
 
-  const bool Result = ScanInstance.ExecuteAction(*Action);
+  ReadPCHAndPreprocessAction Action;
+  const bool Result = ScanInstance.ExecuteAction(Action);
 
   // ExecuteAction is responsible for calling finish.
   DiagConsumerFinished = true;

--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -960,9 +960,7 @@ static StringRef makeAbsoluteAndPreferred(CompilerInstance &CI, StringRef Path,
 }
 
 void ModuleDepCollector::addFileDep(StringRef Path) {
-  if (Service.getOpts().Format == ScanningOutputFormat::P1689) {
-    // Within P1689 format, we don't want all the paths to be absolute path
-    // since it may violate the traditional make style dependencies info.
+  if (!Service.getOpts().ReportAbsolutePaths) {
     FileDeps.emplace_back(Path);
     return;
   }

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1142,6 +1142,9 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
   Opts.Mode = ScanMode;
   Opts.Format = Format;
   Opts.OptimizeArgs = OptimizeArgs;
+  // Within P1689 format, we don't want all the paths to be absolute path
+  // since it may violate the traditional make style dependencies info.
+  Opts.ReportAbsolutePaths = Format != ScanningOutputFormat::P1689;
   Opts.EagerLoadModules = EagerLoadModules;
   Opts.TraceVFS = Verbose;
   Opts.AsyncScanModules = AsyncScanModules;


### PR DESCRIPTION
This patch essentially reverts 62fec3d2 which was an NFC, and replaces the remaining check for the output format with more generic scanning service option that controls whether we report absolute or relative file paths. Along with #182063 this makes the scanner implementation entirely independent of the desired output format.