### PR TITLE
[clang-repl] Fix incorrect "included multiple times" notes

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -4949,7 +4949,7 @@ void Sema::notePreviousDefinition(const NamedDecl *Old, SourceLocation New) {
 
   // Is it the same file and same offset? Provide more information on why
   // this leads to a redefinition error.
-  if (FNew == FOld && FNewDecLoc.second == FOldDecLoc.second) {
+  if (FNew && FNew == FOld && FNewDecLoc.second == FOldDecLoc.second) {
     SourceLocation OldIncLoc = SrcMgr.getIncludeLoc(FOldDecLoc.first);
     SourceLocation NewIncLoc = SrcMgr.getIncludeLoc(FNewDecLoc.first);
     bool EmittedDiag =

--- a/clang/test/Interpreter/execute.c
+++ b/clang/test/Interpreter/execute.c
@@ -17,4 +17,7 @@ run();
 // CHECK: i = 42
 // CHECK-NEXT: S[f=1.000000, m=0x0]
 
+const char* a = "test"; // expected-note {{previous definition is here}}
+const char* a = ""; // expected-error {{redefinition of 'a'}}
+
 %quit


### PR DESCRIPTION
In clang-repl (using in-memory buffers), redefinitions were incorrectly diagnosed with "included multiple times" notes instead of "previous definition is here".

This occurred because the check in `Sema::notePreviousDefinition` compared null FileEntry pointers, treating all in-memory buffers as the same file.

Before:
```
clang-repl> int a;
clang-repl> int a;
In file included from <<< inputs >>>:1:
input_line_2:1:5: error: redefinition of 'a'
    1 | int a;
      |     ^
<<< inputs >>>:1:1: note: '' included multiple times, additional include site here
<<< inputs >>>:1:1: note: '' included multiple times, additional include site here
error: Parsing failed.
```

After:
```
clang-repl> int a;
clang-repl> int a;
In file included from <<< inputs >>>:1:
input_line_2:1:5: error: redefinition of 'a'
    1 | int a;
      |     ^
input_line_1:1:5: note: previous definition is here
    1 | int a;
      |     ^
error: Parsing failed.
```