### PR TITLE
[NFC][emacs] Fix emacs lints in the LLVM and MLIR modes

### DIFF
--- a/llvm/utils/emacs/llvm-mir-mode.el
+++ b/llvm/utils/emacs/llvm-mir-mode.el
@@ -1,7 +1,9 @@
-;;; llvm-mir-mode.el --- Major mode for LLVM Machine IR
+;;; llvm-mir-mode.el --- Major mode for LLVM Machine IR -*- lexical-binding: t -*-
 
 ;; Maintainer:  The LLVM team, http://llvm.org/
 ;; Version: 1.0
+;; Homepage: http://llvm.org/
+;; Package-Requires: ((emacs "24.3"))
 
 ;;; Commentary:
 

--- a/llvm/utils/emacs/llvm-mode.el
+++ b/llvm/utils/emacs/llvm-mode.el
@@ -2,7 +2,7 @@
 
 ;; Maintainer:  The LLVM team, http://llvm.org/
 ;; Version: 1.0
-;; Homepage: http://llvm.org/y
+;; Homepage: http://llvm.org/
 ;; Package-Requires: ((emacs "24.3"))
 
 ;;; Commentary:

--- a/llvm/utils/emacs/llvm-mode.el
+++ b/llvm/utils/emacs/llvm-mode.el
@@ -1,7 +1,9 @@
-;;; llvm-mode.el --- Major mode for the LLVM assembler language.
+;;; llvm-mode.el --- Major mode for the LLVM assembler language -*- lexical-binding: t -*-
 
 ;; Maintainer:  The LLVM team, http://llvm.org/
 ;; Version: 1.0
+;; Homepage: http://llvm.org/y
+;; Package-Requires: ((emacs "24.3"))
 
 ;;; Commentary:
 

--- a/mlir/utils/emacs/mlir-mode.el
+++ b/mlir/utils/emacs/mlir-mode.el
@@ -1,4 +1,4 @@
-;;; mlir-mode.el --- Major mode for the MLIR assembler language.
+;;; mlir-mode.el --- Major mode for the MLIR assembler language -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2019 The MLIR Authors.
 ;;
@@ -14,7 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; Version: 0.1.0
+;; Version: 0.2.0
+;; Homepage: https://mlir.llvm.org/
+;; Package-Requires: ((emacs "24.3"))
 
 ;;; Commentary:
 
@@ -58,14 +60,8 @@
          "br" "ceildiv" "func" "cond_br" "else" "extfunc" "false" "floordiv" "for" "if" "mod" "return" "size" "step" "to" "true" "??" ) 'symbols) . font-lock-keyword-face))
   "Syntax highlighting for MLIR.")
 
-;; Emacs 23 compatibility.
-(defalias 'mlir-mode-prog-mode
-  (if (fboundp 'prog-mode)
-      'prog-mode
-    'fundamental-mode))
-
 ;;;###autoload
-(define-derived-mode mlir-mode mlir-mode-prog-mode "MLIR"
+(define-derived-mode mlir-mode prog-mode "MLIR"
   "Major mode for editing MLIR source files.
 \\{mlir-mode-map}
   Runs `mlir-mode-hook' on startup."


### PR DESCRIPTION
This mainly involved explicitly declaring minimum emacs versions for setq-local and adding a lexical-binding annotaton.

The commit also removes some workarounds from the MLIR mode for Emacs 23 (!).