### PR TITLE
Do not format .td files in Clang; NFC

### DIFF
--- a/clang/.clang-format-ignore
+++ b/clang/.clang-format-ignore
@@ -1,3 +1,3 @@
 # Do not attempt to format .td files; we have too many formatting needs across
 # the various files to allow automatic formatting.
-*.td
+**/*.td

--- a/clang/.clang-format-ignore
+++ b/clang/.clang-format-ignore
@@ -1,0 +1,3 @@
+# Do not attempt to format .td files; we have too many formatting needs across
+# the various files to allow automatic formatting.
+*.td


### PR DESCRIPTION
We have varying needs for these files. e.g., a diagnostic file is a different kind of file than compiler options which is different than attributes which is different than attribute documentation, etc. So running clang-format over .td files in Clang is not going well in practice because of how often it reformats things unlike the rest of the file. This results in a poor new contributor experience because pre-commit CI tells them the changes are not clang-format clean but we don't want the changes to be clang-format clean and so a reviewer asks them to revert and ignore pre-commit CI.