### PR TITLE
[TableGen] Return int32_t from InstrMapping table lookup functions. NFC.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -890,11 +890,11 @@ enum SMEMatrixType {
 #undef TSFLAG_INSTR_FLAGS
 #undef TSFLAG_SME_MATRIX_TYPE
 
-int64_t getSVEPseudoMap(uint32_t Opcode);
-int64_t getSVERevInstr(uint32_t Opcode);
-int64_t getSVENonRevInstr(uint32_t Opcode);
+int32_t getSVEPseudoMap(uint32_t Opcode);
+int32_t getSVERevInstr(uint32_t Opcode);
+int32_t getSVENonRevInstr(uint32_t Opcode);
 
-int64_t getSMEPseudoMap(uint32_t Opcode);
+int32_t getSMEPseudoMap(uint32_t Opcode);
 }
 
 } // end namespace llvm

--- a/llvm/lib/Target/AMDGPU/R600InstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/R600InstrInfo.h
@@ -326,7 +326,7 @@ public:
 
 namespace R600 {
 
-int64_t getLDSNoRetOp(uint32_t Opcode);
+int32_t getLDSNoRetOp(uint32_t Opcode);
 
 } //End namespace AMDGPU
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -1159,7 +1159,7 @@ void SIInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
 }
 
 int SIInstrInfo::commuteOpcode(unsigned Opcode) const {
-  int64_t NewOpc;
+  int32_t NewOpc;
 
   // Try to map original to commuted opcode
   NewOpc = AMDGPU::getCommuteRev(Opcode);
@@ -10377,7 +10377,7 @@ int SIInstrInfo::pseudoToMCOpcode(int Opcode) const {
       Opcode = MFMAOp;
   }
 
-  int64_t MCOp = AMDGPU::getMCOpcode(Opcode, Gen);
+  int32_t MCOp = AMDGPU::getMCOpcode(Opcode, Gen);
 
   if (MCOp == AMDGPU::INSTRUCTION_LIST_END && ST.hasGFX1250Insts())
     MCOp = AMDGPU::getMCOpcode(Opcode, SIEncodingFamily::GFX12);

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1737,86 +1737,86 @@ bool execMayBeModifiedBeforeAnyUse(const MachineRegisterInfo &MRI,
 namespace AMDGPU {
 
   LLVM_READONLY
-  int64_t getVOPe64(uint32_t Opcode);
+  int32_t getVOPe64(uint32_t Opcode);
 
   LLVM_READONLY
-  int64_t getVOPe32(uint32_t Opcode);
+  int32_t getVOPe32(uint32_t Opcode);
 
   LLVM_READONLY
-  int64_t getSDWAOp(uint32_t Opcode);
+  int32_t getSDWAOp(uint32_t Opcode);
 
   LLVM_READONLY
-  int64_t getDPPOp32(uint32_t Opcode);
+  int32_t getDPPOp32(uint32_t Opcode);
 
   LLVM_READONLY
-  int64_t getDPPOp64(uint32_t Opcode);
+  int32_t getDPPOp64(uint32_t Opcode);
 
   LLVM_READONLY
-  int64_t getBasicFromSDWAOp(uint32_t Opcode);
+  int32_t getBasicFromSDWAOp(uint32_t Opcode);
 
   LLVM_READONLY
-  int64_t getCommuteRev(uint32_t Opcode);
+  int32_t getCommuteRev(uint32_t Opcode);
 
   LLVM_READONLY
-  int64_t getCommuteOrig(uint32_t Opcode);
+  int32_t getCommuteOrig(uint32_t Opcode);
 
   LLVM_READONLY
-  int64_t getAddr64Inst(uint32_t Opcode);
+  int32_t getAddr64Inst(uint32_t Opcode);
 
   /// Check if \p Opcode is an Addr64 opcode.
   ///
   /// \returns \p Opcode if it is an Addr64 opcode, otherwise -1.
   LLVM_READONLY
-  int64_t getIfAddr64Inst(uint32_t Opcode);
+  int32_t getIfAddr64Inst(uint32_t Opcode);
 
   LLVM_READONLY
-  int64_t getSOPKOp(uint32_t Opcode);
+  int32_t getSOPKOp(uint32_t Opcode);
 
   /// \returns SADDR form of a FLAT Global instruction given an \p Opcode
   /// of a VADDR form.
   LLVM_READONLY
-  int64_t getGlobalSaddrOp(uint32_t Opcode);
+  int32_t getGlobalSaddrOp(uint32_t Opcode);
 
   /// \returns VADDR form of a FLAT Global instruction given an \p Opcode
   /// of a SADDR form.
   LLVM_READONLY
-  int64_t getGlobalVaddrOp(uint32_t Opcode);
+  int32_t getGlobalVaddrOp(uint32_t Opcode);
 
   LLVM_READONLY
-  int64_t getVCMPXNoSDstOp(uint32_t Opcode);
+  int32_t getVCMPXNoSDstOp(uint32_t Opcode);
 
   /// \returns ST form with only immediate offset of a FLAT Scratch instruction
   /// given an \p Opcode of an SS (SADDR) form.
   LLVM_READONLY
-  int64_t getFlatScratchInstSTfromSS(uint32_t Opcode);
+  int32_t getFlatScratchInstSTfromSS(uint32_t Opcode);
 
   /// \returns SV (VADDR) form of a FLAT Scratch instruction given an \p Opcode
   /// of an SVS (SADDR + VADDR) form.
   LLVM_READONLY
-  int64_t getFlatScratchInstSVfromSVS(uint32_t Opcode);
+  int32_t getFlatScratchInstSVfromSVS(uint32_t Opcode);
 
   /// \returns SS (SADDR) form of a FLAT Scratch instruction given an \p Opcode
   /// of an SV (VADDR) form.
   LLVM_READONLY
-  int64_t getFlatScratchInstSSfromSV(uint32_t Opcode);
+  int32_t getFlatScratchInstSSfromSV(uint32_t Opcode);
 
   /// \returns SV (VADDR) form of a FLAT Scratch instruction given an \p Opcode
   /// of an SS (SADDR) form.
   LLVM_READONLY
-  int64_t getFlatScratchInstSVfromSS(uint32_t Opcode);
+  int32_t getFlatScratchInstSVfromSS(uint32_t Opcode);
 
   /// \returns earlyclobber version of a MAC MFMA is exists.
   LLVM_READONLY
-  int64_t getMFMAEarlyClobberOp(uint32_t Opcode);
+  int32_t getMFMAEarlyClobberOp(uint32_t Opcode);
 
   /// \returns Version of an MFMA instruction which uses AGPRs for srcC and
   /// vdst, given an \p Opcode of an MFMA which uses VGPRs for srcC/vdst.
   LLVM_READONLY
-  int64_t getMFMASrcCVDstAGPROp(uint32_t Opcode);
+  int32_t getMFMASrcCVDstAGPROp(uint32_t Opcode);
 
   /// \returns v_cmpx version of a v_cmp instruction.
   LLVM_READONLY
-  int64_t getVCMPXOpFromVCMP(uint32_t Opcode);
+  int32_t getVCMPXOpFromVCMP(uint32_t Opcode);
 
   const uint64_t RSRC_DATA_FORMAT = 0xf00000000000LL;
   const uint64_t RSRC_ELEMENT_SIZE_SHIFT = (32 + 19);

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -812,7 +812,7 @@ unsigned mapWMMA3AddrTo2AddrOpcode(unsigned Opc) {
 // Wrapper for Tablegen'd function.  enum Subtarget is not defined in any
 // header files, so we need to wrap it in a function that takes unsigned
 // instead.
-int64_t getMCOpcode(uint32_t Opcode, unsigned Gen) {
+int32_t getMCOpcode(uint32_t Opcode, unsigned Gen) {
   return getMCOpcodeGen(Opcode, static_cast<Subtarget>(Gen));
 }
 

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -416,7 +416,7 @@ inline bool hasNamedOperand(uint64_t Opcode, OpName NamedIdx) {
 }
 
 LLVM_READONLY
-int64_t getSOPPWithRelaxation(uint32_t Opcode);
+int32_t getSOPPWithRelaxation(uint32_t Opcode);
 
 struct MIMGBaseOpcodeInfo {
   MIMGBaseOpcode BaseOpcode;
@@ -646,7 +646,7 @@ const GcnBufferFormatInfo *getGcnBufferFormatInfo(uint8_t Format,
                                                   const MCSubtargetInfo &STI);
 
 LLVM_READONLY
-int64_t getMCOpcode(uint32_t Opcode, unsigned Gen);
+int32_t getMCOpcode(uint32_t Opcode, unsigned Gen);
 
 LLVM_READONLY
 unsigned getVOPDOpcode(unsigned Opc, bool VOPD3);

--- a/llvm/lib/Target/PowerPC/PPCHazardRecognizers.cpp
+++ b/llvm/lib/Target/PowerPC/PPCHazardRecognizers.cpp
@@ -78,7 +78,11 @@ bool PPCDispatchGroupSBHazardRecognizer::isBCTRAfterSet(SUnit *SU) {
 }
 
 // FIXME: Remove this when we don't need this:
-namespace llvm { namespace PPC { extern int64_t getNonRecordFormOpcode(uint32_t); } }
+namespace llvm {
+namespace PPC {
+extern int32_t getNonRecordFormOpcode(uint32_t);
+}
+} // namespace llvm
 
 // FIXME: A lot of code in PPCDispatchGroupSBHazardRecognizer is P7 specific.
 

--- a/llvm/lib/Target/PowerPC/PPCVSXFMAMutate.cpp
+++ b/llvm/lib/Target/PowerPC/PPCVSXFMAMutate.cpp
@@ -47,7 +47,7 @@ static cl::opt<bool> DisableVSXFMAMutate(
 #define DEBUG_TYPE "ppc-vsx-fma-mutate"
 
 namespace llvm { namespace PPC {
-  int64_t getAltVSXFMAOpcode(uint32_t Opcode);
+int32_t getAltVSXFMAOpcode(uint32_t Opcode);
 } }
 
 namespace {

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
@@ -159,8 +159,8 @@ enum FusedCompareType {
 } // end namespace SystemZII
 
 namespace SystemZ {
-int64_t getTwoOperandOpcode(uint32_t Opcode);
-int64_t getTargetMemOpcode(uint32_t Opcode);
+int32_t getTwoOperandOpcode(uint32_t Opcode);
+int32_t getTargetMemOpcode(uint32_t Opcode);
 
 // Return a version of comparison CC mask CCMask in which the LT and GT
 // actions are swapped.

--- a/llvm/lib/Target/WebAssembly/TargetInfo/WebAssemblyTargetInfo.h
+++ b/llvm/lib/Target/WebAssembly/TargetInfo/WebAssemblyTargetInfo.h
@@ -25,9 +25,9 @@ Target &getTheWebAssemblyTarget64();
 
 namespace WebAssembly {
 
-int64_t getStackOpcode(uint32_t Opcode);
-int64_t getRegisterOpcode(uint32_t Opcode);
-int64_t getWasm64Opcode(uint32_t Opcode);
+int32_t getStackOpcode(uint32_t Opcode);
+int32_t getRegisterOpcode(uint32_t Opcode);
+int32_t getWasm64Opcode(uint32_t Opcode);
 
 } // namespace WebAssembly
 

--- a/llvm/utils/TableGen/CodeGenMapTable.cpp
+++ b/llvm/utils/TableGen/CodeGenMapTable.cpp
@@ -474,7 +474,7 @@ void MapTableEmitter::emitTablesWithFunc(raw_ostream &OS) {
   const ListInit *ColFields = InstrMapDesc.getColFields();
   ArrayRef<const ListInit *> ValueCols = InstrMapDesc.getValueCols();
   OS << "// " << InstrMapDesc.getName() << "\nLLVM_READONLY\n";
-  OS << "int64_t " << InstrMapDesc.getName() << "(uint32_t Opcode";
+  OS << "int32_t " << InstrMapDesc.getName() << "(uint32_t Opcode";
   if (ValueCols.size() > 1) {
     for (const Init *CF : ColFields->getElements()) {
       std::string ColName = CF->getAsUnquotedString();


### PR DESCRIPTION
Since #182059 there is only one case in which these functions return -1,
so callers no longer need to distinguish between (int64_t)-1 and
(uint32_t)-1, so we can go back to a 32-bit return value like it was
before #180954.
