### PR TITLE
[NFC] Re-enable MSVC C4351 diagnostic

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -733,7 +733,6 @@ if (MSVC)
       -wd4244 # Suppress ''argument' : conversion from 'type1' to 'type2', possible loss of data'
       -wd4267 # Suppress ''var' : conversion from 'size_t' to 'type', possible loss of data'
       -wd4291 # Suppress ''declaration' : no matching operator delete found; memory will not be freed if initialization throws an exception'
-      -wd4351 # Suppress 'new behavior: elements of array 'array' will be default initialized'
       -wd4456 # Suppress 'declaration of 'var' hides local variable'
       -wd4457 # Suppress 'declaration of 'var' hides function parameter'
       -wd4458 # Suppress 'declaration of 'var' hides class member'


### PR DESCRIPTION
From MSDN:
https://learn.microsoft.com/en-us/previous-versions/1ywe7hcy(v=vs.140)

This diagnostic is no longer documented in MSDN and from my local testing, the diagnostic is not emitted in our source. I believe we no longer need to disable this diagnostic.