### PR TITLE
[DO NOT SUBMIT][LV] Propagate branch weights in VPlan

### DIFF
--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -1060,7 +1060,8 @@ void llvm::getMetadataToPropagate(
       LLVMContext::MD_tbaa,         LLVMContext::MD_alias_scope,
       LLVMContext::MD_noalias,      LLVMContext::MD_fpmath,
       LLVMContext::MD_nontemporal,  LLVMContext::MD_invariant_load,
-      LLVMContext::MD_access_group, LLVMContext::MD_mmra};
+      LLVMContext::MD_access_group, LLVMContext::MD_mmra,
+      LLVMContext::MD_prof};
 
   // Remove any unsupported metadata kinds from Metadata.
   for (unsigned Idx = 0; Idx != Metadata.size();) {
@@ -1111,6 +1112,8 @@ Instruction *llvm::propagateMetadata(Instruction *Inst, ArrayRef<Value *> VL) {
         break;
       case LLVMContext::MD_access_group:
         MD = intersectAccessGroups(Inst, IJ);
+        break;
+      case LLVMContext::MD_prof:
         break;
       default:
         llvm_unreachable("unhandled metadata");

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -27,6 +27,7 @@
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/MDBuilder.h"
+#include "llvm/IR/ProfDataUtils.h"
 #include "llvm/Transforms/Utils/LoopUtils.h"
 #include "llvm/Transforms/Utils/LoopVersioning.h"
 
@@ -467,8 +468,11 @@ static void addCanonicalIVRecipes(VPlan &Plan, VPBasicBlock *HeaderVPBB,
   // We are about to replace the branch to exit the region. Remove the original
   // BranchOnCond, if there is any.
   DebugLoc LatchDL = DL;
+  MDNode *BW = nullptr;
   if (!LatchVPBB->empty() && match(&LatchVPBB->back(), m_BranchOnCond())) {
     LatchDL = LatchVPBB->getTerminator()->getDebugLoc();
+    if (auto *VPI = dyn_cast<VPInstruction>(LatchVPBB->getTerminator()))
+      BW = VPI->getMetadata(LLVMContext::MD_prof);
     LatchVPBB->getTerminator()->eraseFromParent();
   }
 
@@ -480,10 +484,12 @@ static void addCanonicalIVRecipes(VPlan &Plan, VPBasicBlock *HeaderVPBB,
       CanonicalIVPHI, &Plan.getVFxUF(), DL, "index.next", {true, false});
   CanonicalIVPHI->addOperand(CanonicalIVIncrement);
 
+  VPIRMetadata Metadata;
+  Metadata.setMetadata(LLVMContext::MD_prof, BW);
   // Add the BranchOnCount VPInstruction to the latch.
   Builder.createNaryOp(VPInstruction::BranchOnCount,
                        {CanonicalIVIncrement, &Plan.getVectorTripCount()},
-                       LatchDL);
+                       nullptr, {}, Metadata, LatchDL);
 }
 
 /// Creates extracts for values in \p Plan defined in a loop region and used

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -29,6 +29,7 @@
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/ProfDataUtils.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"
 #include "llvm/Support/Casting.h"
@@ -3614,8 +3615,10 @@ void VPBranchOnMaskRecipe::execute(VPTransformState &State) {
   auto *CurrentTerminator = State.CFG.PrevBB->getTerminator();
   assert(isa<UnreachableInst>(CurrentTerminator) &&
          "Expected to replace unreachable terminator with conditional branch.");
-  auto CondBr =
+  auto *CondBr =
       State.Builder.CreateCondBr(ConditionBit, State.CFG.PrevBB, nullptr);
+  if (auto *W = dyn_cast<VPWidenRecipe>(BlockInMask))
+    CondBr->setMetadata(LLVMContext::MD_prof, W->getMetadata(1000));
   CondBr->setSuccessor(0, nullptr);
   CurrentTerminator->eraseFromParent();
 }


### PR DESCRIPTION
using `Transforms/LoopVectorize/skip-iterations.ll` as example - the idea is to capture and propagate somehow probabilities known pre-VPlan, through VPlan, and then use when generating the new IR, for controlflow within the loop body being vectorized.