### PR TITLE
[RISCV] Separate VMConstraint from RVVConstraint. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrFormats.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormats.td
@@ -61,26 +61,20 @@ def InstFormatNDS_BRANCH_10 : InstFormat<27>;
 def InstFormatOther         : InstFormat<31>;
 
 
-// Indicates which operands cannot be the same as the Vd operand. This is used
+// Indicates whether Vs1/Vs2 can be the same as the Vd operand. This is used
 // by the assembler to provide some checking of the RVV overlap rules. We can't
 // check all overlap rules. Narrowing instructions allow overlap in the first
 // part of the register group, but not the later parts. We are not able to check
 // this in the assembler as we do not know how big the register group is since
 // that is controlled dynamically with vtype.
-class RISCVVConstraint<bit VS2 = 0, bit VS1 = 0, bit VM = 0> {
-  bits<3> Value = {VM, VS1, VS2};
+class RISCVVConstraint<bit VS2 = 0, bit VS1 = 0> {
+  bits<2> Value = {VS1, VS2};
 }
 def NoConstraint  : RISCVVConstraint<>;
 def VS2Constraint : RISCVVConstraint<VS2 = 1>;
 def VS1Constraint : RISCVVConstraint<VS1 = 1>;
-def VMConstraint  : RISCVVConstraint<VM = 1>;
 
 // Illegal instructions:
-//
-// * The destination vector register group for a masked vector instruction
-// cannot overlap the source mask register (v0), unless the destination vector
-// register is being written with a mask value (e.g., comparisons) or the
-// scalar result of a reduction.
 //
 // * Widening: The destination EEW is greater than the source EEW, the source
 // EMUL is at least 1. The destination vector register group cannot overlap
@@ -93,10 +87,9 @@ def VMConstraint  : RISCVVConstraint<VM = 1>;
 // group.
 //
 // * vmsbf.m/vmsif.m/vmsof.m: The destination register cannot overlap the
-// source register and, if masked, cannot overlap the mask register ('v0').
+// source register.
 //
-// * viota: The destination register cannot overlap the source register and,
-// if masked, cannot overlap the mask register ('v0').
+// * viota: The destination register cannot overlap the source register.
 //
 // * v[f]slide[1]up: The destination vector register group for vslideup cannot
 // overlap the source vector register group.
@@ -105,15 +98,14 @@ def VMConstraint  : RISCVVConstraint<VM = 1>;
 // source vector register groups.
 //
 // * vcompress: The destination vector register group cannot overlap the
-// source vector register group or the source mask register
-def WidenVNoMask : RISCVVConstraint<VS2 = 1, VS1 = 1>;
-def WidenV       : RISCVVConstraint<VS2 = 1, VS1 = 1, VM = 1>;
-def WidenW       : RISCVVConstraint<VS1 = 1, VM = 1>;
-def WidenCvt     : RISCVVConstraint<VS2 = 1, VM = 1>;
-def Iota         : RISCVVConstraint<VS2 = 1, VM = 1>;
-def SlideUp      : RISCVVConstraint<VS2 = 1, VM = 1>;
-def Vrgather     : RISCVVConstraint<VS2 = 1, VS1 = 1, VM = 1>;
-def Vcompress    : RISCVVConstraint<VS2 = 1, VS1 = 1>;
+// source vector register group.
+def WidenV         : RISCVVConstraint<VS2 = 1, VS1 = 1>;
+def WidenW         : RISCVVConstraint<VS1 = 1>;
+def WidenCvt       : RISCVVConstraint<VS2 = 1>;
+def Iota           : RISCVVConstraint<VS2 = 1>;
+def SlideUp        : RISCVVConstraint<VS2 = 1>;
+def Vrgather       : RISCVVConstraint<VS2 = 1, VS1 = 1>;
+def Vcompress      : RISCVVConstraint<VS2 = 1, VS1 = 1>;
 def Sha2Constraint : RISCVVConstraint<VS2 = 1, VS1 = 1>;
 
 // The following opcode names match those given in Table 19.1 in the
@@ -203,9 +195,13 @@ class RVInstCommon<dag outs, dag ins, string opcodestr, string argstr,
 
   let TSFlags{4-0} = Format.Value;
 
-  // Defaults
+  // Indicates when Vd and Vs1/Vs2 cannot be the same register.
   RISCVVConstraint RVVConstraint = NoConstraint;
-  let TSFlags{7-5} = RVVConstraint.Value;
+  let TSFlags{6-5} = RVVConstraint.Value;
+
+  // Indicates that the destination and the VM operand cannot both be V0.
+  bit VMConstraint = 0;
+  let TSFlags{7} = VMConstraint;
 
   bits<3> VLMul = 0;
   let TSFlags{10-8} = VLMul;

--- a/llvm/lib/Target/RISCV/RISCVInstrFormatsV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormatsV.td
@@ -101,7 +101,7 @@ class RVInstVBase<bits<6> funct6, RISCVVFormat opv, dag outs, dag ins,
   let Inst{6-0} = OPC_OP_V.Value;
 
   let Uses = [VL, VTYPE];
-  let RVVConstraint = VMConstraint;
+  let VMConstraint = true;
 
   let UseNamedOperandTable = true;
 }
@@ -184,7 +184,7 @@ class RVInstVLoadBase<bits<3> nf, RISCVWidth width, RISCVMOP mop,
   let Inst{6-0} = OPC_LOAD_FP.Value;
 
   let Uses = [VL, VTYPE];
-  let RVVConstraint = VMConstraint;
+  let VMConstraint = true;
 
   let UseNamedOperandTable = true;
 }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
@@ -354,7 +354,7 @@ class VWholeLoad<int lmul, RISCVWidth width, string opcodestr, RegisterClass VRC
   let vm = 1;
 
   let Uses = [];
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 // unit-stride mask load vd, (rs1)
@@ -363,7 +363,7 @@ class VUnitStrideMaskLoad<string opcodestr>
                 (ins GPRMemZeroOffset:$rs1), opcodestr, "$vd, $rs1"> {
   let vm = 1;
 
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 // unit-stride fault-only-first load vd, (rs1), vm
@@ -515,7 +515,7 @@ class VALUVVNoVm<bits<6> funct6, RISCVVFormat opv, string opcodestr>
                opcodestr, "$vd, $vs2, $vs1"> {
   let vm = 1;
 
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 // op vd, vs2, rs1, vm
@@ -549,7 +549,7 @@ class VALUVXNoVm<bits<6> funct6, RISCVVFormat opv, string opcodestr>
                opcodestr, "$vd, $vs2, $rs1"> {
   let vm = 1;
 
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 // op vd, vs2, imm, vm
@@ -573,7 +573,7 @@ class VALUVINoVm<bits<6> funct6, string opcodestr, Operand optype = simm5>
                 opcodestr, "$vd, $vs2, $imm"> {
   let vm = 1;
 
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 // op vd, vs2, rs1, vm (Float)
@@ -699,7 +699,7 @@ multiclass VMRG_IV_V_X_I<string opcodestr, bits<6> funct6> {
 }
 
 multiclass VMV_IV_V_X_I<string opcodestr, bits<6> funct6> {
-  let vs2 = 0, vm = 1, RVVConstraint = NoConstraint in {
+  let vs2 = 0, vm = 1, VMConstraint = false in {
     def _V : RVInstVV<funct6, OPIVV, (outs VR:$vd),
                      (ins VR:$vs1), opcodestr # ".v", "$vd, $vs1">,
              SchedUnaryMC<"WriteVIMovV", "ReadVIMovV", forceMasked=0>;
@@ -1217,13 +1217,13 @@ def VSEXT_VF2 : VEXT_MV_VS2<"vsext.vf2", 0b010010, 0b00111>;
 // Vector Integer Add-with-Carry / Subtract-with-Borrow Instructions
 defm VADC_V : VALUm_IV_V_X_I<"vadc", 0b010000>;
 defm VSBC_V : VALUm_IV_V_X<"vsbc", 0b010010>;
-let Constraints = "@earlyclobber $vd", RVVConstraint = NoConstraint,
+let Constraints = "@earlyclobber $vd", VMConstraint = false,
     DestEEW = EEW1 in {
 defm VMADC_V : VALUm_IV_V_X_I<"vmadc", 0b010001>;
 defm VMADC_V : VALUNoVm_IV_V_X_I<"vmadc", 0b010001>;
 defm VMSBC_V : VALUm_IV_V_X<"vmsbc", 0b010011>;
 defm VMSBC_V : VALUNoVm_IV_V_X<"vmsbc", 0b010011>;
-} // Constraints = "@earlyclobber $vd", RVVConstraint = NoConstraint, DestEEW = EEW1
+} // Constraints = "@earlyclobber $vd", VMConstraint = false, DestEEW = EEW1
 
 // Vector Bitwise Logical Instructions
 defm VAND_V : VALU_IV_V_X_I<"vand", 0b001001>;
@@ -1256,7 +1256,7 @@ def : InstAlias<"vncvt.x.x.w $vd, $vs",
                 (VNSRL_WX VR:$vd, VR:$vs, X0, zero_reg)>;
 
 // Vector Integer Comparison Instructions
-let RVVConstraint = NoConstraint, DestEEW = EEW1 in {
+let VMConstraint = false, DestEEW = EEW1 in {
 defm VMSEQ_V : VCMP_IV_V_X_I<"vmseq", 0b011000>;
 defm VMSNE_V : VCMP_IV_V_X_I<"vmsne", 0b011001>;
 defm VMSLTU_V : VCMP_IV_V_X<"vmsltu", 0b011010>;
@@ -1265,7 +1265,7 @@ defm VMSLEU_V : VCMP_IV_V_X_I<"vmsleu", 0b011100>;
 defm VMSLE_V : VCMP_IV_V_X_I<"vmsle", 0b011101>;
 defm VMSGTU_V : VCMP_IV_X_I<"vmsgtu", 0b011110>;
 defm VMSGT_V : VCMP_IV_X_I<"vmsgt", 0b011111>;
-} // RVVConstraint = NoConstraint, DestEEW = EEW1
+} // VMConstraint = false, DestEEW = EEW1
 
 def : InstAlias<"vmsgtu.vv $vd, $va, $vb$vm",
                 (VMSLTU_VV VR:$vd, VR:$vb, VR:$va, VMaskOp:$vm), 0>;
@@ -1484,14 +1484,14 @@ def : InstAlias<"vfabs.v $vd, $vs",
                 (VFSGNJX_VV VR:$vd, VR:$vs, VR:$vs, zero_reg)>;
 
 // Vector Floating-Point Compare Instructions
-let RVVConstraint = NoConstraint, mayRaiseFPException = true, DestEEW = EEW1 in {
+let VMConstraint = false, mayRaiseFPException = true, DestEEW = EEW1 in {
 defm VMFEQ_V : VCMP_FV_V_F<"vmfeq", 0b011000>;
 defm VMFNE_V : VCMP_FV_V_F<"vmfne", 0b011100>;
 defm VMFLT_V : VCMP_FV_V_F<"vmflt", 0b011011>;
 defm VMFLE_V : VCMP_FV_V_F<"vmfle", 0b011001>;
 defm VMFGT_V : VCMP_FV_F<"vmfgt", 0b011101>;
 defm VMFGE_V : VCMP_FV_F<"vmfge", 0b011111>;
-} // RVVConstraint = NoConstraint, mayRaiseFPException = true, DestEEW = EEW1
+} // VMConstraint = false, mayRaiseFPException = true, DestEEW = EEW1
 
 def : InstAlias<"vmfgt.vv $vd, $va, $vb$vm",
                 (VMFLT_VV VR:$vd, VR:$vb, VR:$va, VMaskOp:$vm), 0>;
@@ -1518,7 +1518,7 @@ def VFMV_V_F : RVInstVX<0b010111, OPFVF, (outs VR:$vd),
   let vm = 1;
   let vs2 = 0;
 
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 } // hasSideEffects = 0, mayLoad = 0, mayStore = 0
@@ -1571,7 +1571,7 @@ def VFNCVT_ROD_F_F_W : VNCVTF_FV_VS2<"vfncvt.rod.f.f.w", 0b010010, 0b10101>;
 let Predicates = [HasVInstructions] in {
 
 // Vector Single-Width Integer Reduction Instructions
-let RVVConstraint = NoConstraint, ElementsDependOn = EltDepsVLMask in {
+let VMConstraint = false, ElementsDependOn = EltDepsVLMask in {
 defm VREDSUM  : VRED_MV_V<"vredsum", 0b000000>;
 defm VREDMAXU : VREDMINMAX_MV_V<"vredmaxu", 0b000110>;
 defm VREDMAX  : VREDMINMAX_MV_V<"vredmax", 0b000111>;
@@ -1580,23 +1580,24 @@ defm VREDMIN  : VREDMINMAX_MV_V<"vredmin", 0b000101>;
 defm VREDAND  : VRED_MV_V<"vredand", 0b000001>;
 defm VREDOR   : VRED_MV_V<"vredor", 0b000010>;
 defm VREDXOR  : VRED_MV_V<"vredxor", 0b000011>;
-} // RVVConstraint = NoConstraint, ElementsDependOn = EltDepsVLMask
+} // VMConstraint = false, ElementsDependOn = EltDepsVLMask
 
 // Vector Widening Integer Reduction Instructions
-let Constraints = "@earlyclobber $vd", RVVConstraint = NoConstraint, ElementsDependOn = EltDepsVLMask, DestEEW = EEWSEWx2 in {
+let Constraints = "@earlyclobber $vd", VMConstraint = false,
+    ElementsDependOn = EltDepsVLMask, DestEEW = EEWSEWx2 in {
 // Set earlyclobber for following instructions for second and mask operands.
 // This has the downside that the earlyclobber constraint is too coarse and
 // will impose unnecessary restrictions by not allowing the destination to
 // overlap with the first (wide) operand.
 defm VWREDSUMU : VWRED_IV_V<"vwredsumu", 0b110000>;
 defm VWREDSUM : VWRED_IV_V<"vwredsum", 0b110001>;
-} // Constraints = "@earlyclobber $vd", RVVConstraint = NoConstraint, ElementsDependOn = EltDepsVLMask, DestEEW = EEWSEWx2
+} // Constraints = "@earlyclobber $vd", VMConstraint = false, ElementsDependOn = EltDepsVLMask, DestEEW = EEWSEWx2
 
 } // Predicates = [HasVInstructions]
 
 let Predicates = [HasVInstructionsAnyF] in {
 // Vector Single-Width Floating-Point Reduction Instructions
-let RVVConstraint = NoConstraint, ElementsDependOn = EltDepsVLMask in {
+let VMConstraint = false, ElementsDependOn = EltDepsVLMask in {
 let Uses = [FRM, VL, VTYPE], mayRaiseFPException = true in {
 defm VFREDOSUM : VREDO_FV_V<"vfredosum", 0b000011>;
 defm VFREDUSUM : VRED_FV_V<"vfredusum", 0b000001>;
@@ -1605,12 +1606,12 @@ let mayRaiseFPException = true in {
 defm VFREDMAX : VREDMINMAX_FV_V<"vfredmax", 0b000111>;
 defm VFREDMIN : VREDMINMAX_FV_V<"vfredmin", 0b000101>;
 }
-} // RVVConstraint = NoConstraint, ElementsDependOn = EltDepsVLMask
+} // VMConstraint = false, ElementsDependOn = EltDepsVLMask
 
 def : MnemonicAlias<"vfredsum.vs", "vfredusum.vs">;
 
 // Vector Widening Floating-Point Reduction Instructions
-let Constraints = "@earlyclobber $vd", RVVConstraint = NoConstraint, ElementsDependOn = EltDepsVLMask, DestEEW = EEWSEWx2 in {
+let Constraints = "@earlyclobber $vd", VMConstraint = false, ElementsDependOn = EltDepsVLMask, DestEEW = EEWSEWx2 in {
 // Set earlyclobber for following instructions for second and mask operands.
 // This has the downside that the earlyclobber constraint is too coarse and
 // will impose unnecessary restrictions by not allowing the destination to
@@ -1619,14 +1620,14 @@ let Uses = [FRM, VL, VTYPE], mayRaiseFPException = true in {
 defm VFWREDOSUM : VWREDO_FV_V<"vfwredosum", 0b110011>;
 defm VFWREDUSUM : VWRED_FV_V<"vfwredusum", 0b110001>;
 }
-} // Constraints = "@earlyclobber $vd", RVVConstraint = NoConstraint, ElementsDependOn = EltDepsVLMask, DestEEW = EEWSEWx2
+} // Constraints = "@earlyclobber $vd", VMConstraint = false, ElementsDependOn = EltDepsVLMask, DestEEW = EEWSEWx2
 
 def : MnemonicAlias<"vfwredsum.vs", "vfwredusum.vs">;
 } // Predicates = [HasVInstructionsAnyF]
 
 let Predicates = [HasVInstructions] in {
 // Vector Mask-Register Logical Instructions
-let RVVConstraint = NoConstraint, DestEEW = EEW1 in {
+let VMConstraint = false, DestEEW = EEW1 in {
 defm VMAND_M : VMALU_MV_Mask<"vmand", 0b011001, "m">;
 defm VMNAND_M : VMALU_MV_Mask<"vmnand", 0b011101, "m">;
 defm VMANDN_M : VMALU_MV_Mask<"vmandn", 0b011000, "m">;
@@ -1664,7 +1665,7 @@ def VFIRST_M : RVInstVUnaryRd<0b010000, 0b10001, OPMVV, (outs GPR:$rd),
                               "vfirst.m", "$rd, $vs2$vm">,
               SchedUnaryMC<"WriteVMFFSV", "ReadVMFFSV">;
 
-} // hasSideEffects = 0, mayLoad = 0, mayStore = 0, RVVConstraint = NoConstraint, ElementsDependOn = EltDepsVLMask
+} // hasSideEffects = 0, mayLoad = 0, mayStore = 0, VMConstraint = false, ElementsDependOn = EltDepsVLMask
 
 def : MnemonicAlias<"vpopc.m", "vcpop.m">;
 
@@ -1706,7 +1707,7 @@ def VMV_S_X : RVInstVX<0b010000, OPMVX, (outs VR:$vd_wb),
   let vs2 = 0;
 
   let Constraints = "$vd = $vd_wb";
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 } // hasSideEffects = 0, mayLoad = 0, mayStore = 0
@@ -1728,7 +1729,7 @@ def VFMV_S_F : RVInstVX<0b010000, OPFVF, (outs VR:$vd_wb),
   let vs2 = 0;
 
   let Constraints = "$vd = $vd_wb";
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 } // hasSideEffects = 0, mayLoad = 0, mayStore = 0, vm = 1
@@ -1780,7 +1781,7 @@ foreach n = [1, 2, 4, 8] in {
     let Uses = [VTYPE];
     let vm = 1;
 
-    let RVVConstraint = NoConstraint;
+    let VMConstraint = false;
   }
 }
 } // hasSideEffects = 0, mayLoad = 0, mayStore = 0

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXAndes.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXAndes.td
@@ -402,7 +402,7 @@ class NDSRVInstVSINTCvt<bits<5> fucnt5, string opcodestr>
   let mayLoad = 0;
   let mayStore = 0;
   let Uses = [FRM, VL, VTYPE];
-  let RVVConstraint = VMConstraint;
+  let VMConstraint = true;
 
   let UseNamedOperandTable = true;
 }
@@ -438,7 +438,7 @@ class NDSRVInstVFPMAD<bits<6> funct6, string opcodestr>
   let mayLoad = 0;
   let mayStore = 0;
 
-  let RVVConstraint = VMConstraint;
+  let VMConstraint = true;
 
   let UseNamedOperandTable = true;
 }
@@ -463,7 +463,7 @@ class NDSRVInstVD4DOT<bits<6> funct6, string opcodestr>
   let mayLoad = 0;
   let mayStore = 0;
 
-  let RVVConstraint = VMConstraint;
+  let VMConstraint = true;
 
   let UseNamedOperandTable = true;
 }
@@ -509,7 +509,7 @@ class NDSRVInstVLN<bits<5> funct5, string opcodestr>
   let mayStore = 0;
 
   let Uses = [VL, VTYPE];
-  let RVVConstraint = VMConstraint;
+  let VMConstraint = true;
 
   let UseNamedOperandTable = true;
 }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXRivos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXRivos.td
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 class CustomRivosVXI<bits<6> funct6, RISCVVFormat opv, dag outs, dag ins,
-                string opcodestr, string argstr>
+                     string opcodestr, string argstr>
     : RVInst<outs, ins, opcodestr, argstr, [], InstFormatR> {
   bits<5> imm;
   bits<5> rs1;
@@ -27,7 +27,7 @@ class CustomRivosVXI<bits<6> funct6, RISCVVFormat opv, dag outs, dag ins,
   let Inst{6-0} = OPC_CUSTOM_2.Value;
 
   let Uses = [VL, VTYPE];
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
   let Constraints = "$vd = $vd_wb";
 
   let UseNamedOperandTable = true;
@@ -50,7 +50,7 @@ class CustomRivosXVI<bits<6> funct6, RISCVVFormat opv, dag outs, dag ins,
   let Inst{6-0} = OPC_CUSTOM_2.Value;
 
   let Uses = [VL, VTYPE];
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 
   let UseNamedOperandTable = true;
 }
@@ -87,7 +87,7 @@ multiclass RIVPseudoVALU_VV {
 }
 
 let Predicates = [HasVendorXRivosVizip],
-  Constraints = "@earlyclobber $rd, $rd = $passthru" in {
+    Constraints = "@earlyclobber $rd, $rd = $passthru" in {
 defm PseudoRI_VZIPEVEN   : RIVPseudoVALU_VV;
 defm PseudoRI_VZIPODD   : RIVPseudoVALU_VV;
 defm PseudoRI_VZIP2A   : RIVPseudoVALU_VV;
@@ -129,7 +129,7 @@ def RI_VZERO : RVInstVUnary<0b000000, 0b00000, OPCFG, (outs VR:$vd),
 
   let Inst{6-0} = OPC_CUSTOM_2.Value;
 
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 def RI_VINSERT : CustomRivosVXI<0b010000, OPMVX, (outs VR:$vd_wb),

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXSf.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXSf.td
@@ -233,7 +233,7 @@ class CustomSiFiveVMACC<bits<6> funct6, RISCVVFormat opv, string opcodestr>
   let Inst{6-0} = OPC_CUSTOM_2.Value;
 
   let Constraints = "$vd = $vd_wb";
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
   let ElementsDependOn = EltDepsVLMask;
   let ReadsPastVL = true;
 }
@@ -264,7 +264,7 @@ let Predicates = [HasVendorXSfvqmaccdod], DecoderNamespace = "XSfvector",
 }
 
 let Predicates = [HasVendorXSfvqmaccqoq], DecoderNamespace = "XSfvector",
-    DestEEW = EEWSEWx4, RVVConstraint=WidenVNoMask in {
+    DestEEW = EEWSEWx4, RVVConstraint=WidenV in {
   def SF_VQMACCU_4x8x4  : CustomSiFiveVMACC<0b111100, OPMVV, "sf.vqmaccu.4x8x4">;
   def SF_VQMACC_4x8x4   : CustomSiFiveVMACC<0b111101, OPMVV, "sf.vqmacc.4x8x4">;
   def SF_VQMACCUS_4x8x4 : CustomSiFiveVMACC<0b111110, OPMVV, "sf.vqmaccus.4x8x4">;
@@ -272,7 +272,7 @@ let Predicates = [HasVendorXSfvqmaccqoq], DecoderNamespace = "XSfvector",
 }
 
 let Predicates = [HasVendorXSfvfwmaccqqq], DecoderNamespace = "XSfvector",
-    DestEEW = EEWSEWx2, RVVConstraint=WidenVNoMask in {
+    DestEEW = EEWSEWx2, RVVConstraint=WidenV in {
   def SF_VFWMACC_4x4x4 : CustomSiFiveVMACC<0b111100, OPFVV, "sf.vfwmacc.4x4x4">;
 }
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvk.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvk.td
@@ -65,7 +65,7 @@ class PALUVVNoVmTernary<bits<6> funct6, RISCVVFormat opv, string opcodestr>
   let vm = 1;
   let Inst{6-0} = OPC_OP_VE.Value;
 
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 // op vd, vs2, imm
@@ -85,7 +85,7 @@ class PALUVINoVmBinary<bits<6> funct6, string opcodestr, Operand optype>
   let Inst{6-0} = OPC_OP_VE.Value;
   let Inst{14-12} = OPMVV.Value;
 
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 // op vd, vs2 (use vs1 as instruction encoding) where vd is also a source
@@ -98,7 +98,7 @@ class PALUVs2NoVmBinary<bits<6> funct6, bits<5> vs1, RISCVVFormat opv,
   let vm = 1;
   let Inst{6-0} = OPC_OP_VE.Value;
 
-  let RVVConstraint = NoConstraint;
+  let VMConstraint = false;
 }
 
 multiclass VAES_MV_V_S<bits<6> funct6_vv, bits<6> funct6_vs, bits<5> vs1,


### PR DESCRIPTION
VMConstraint is true for most vector instructions by default. Almost every time we set the Vs1/Vs2 bits we had to redundantly set the VM bit.

There were a few cases where the base class had already removed the default VMConstraint with RVVConstraint=NoConstraint and an instantiation had to make sure not to set it again when adding Vs1 and/or Vs2 constraints.

By separating them we can manage them more independently.

I will probably rename RVVConstraint in a followup.