### PR TITLE
[SDPatternMatch] Support conditionally binding the value matching a sub-pattern

### DIFF
--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -278,7 +278,7 @@ template <typename PredPattern> struct Value_bind {
 inline auto m_Value(SDValue &N) {
   return Value_bind<Value_match>(N, m_Value());
 }
-/// Conditionally bind a SDValue based on the predicate.
+/// Conditionally bind an SDValue based on the predicate.
 template <typename PredPattern>
 inline auto m_Value(SDValue &N, const PredPattern &P) {
   return Value_bind<PredPattern>(N, P);

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -259,18 +259,30 @@ template <unsigned N> inline NUses_match<N, Value_match> m_NUses() {
   return NUses_match<N, Value_match>(m_Value());
 }
 
-struct Value_bind {
+template <typename PredPattern> struct Value_bind {
   SDValue &BindVal;
+  PredPattern Pred;
 
-  explicit Value_bind(SDValue &N) : BindVal(N) {}
+  Value_bind(SDValue &N, const PredPattern &P) : BindVal(N), Pred(P) {}
 
-  template <typename MatchContext> bool match(const MatchContext &, SDValue N) {
+  template <typename MatchContext>
+  bool match(const MatchContext &Ctx, SDValue N) {
+    if (!Pred.match(Ctx, N))
+      return false;
+
     BindVal = N;
     return true;
   }
 };
 
-inline Value_bind m_Value(SDValue &N) { return Value_bind(N); }
+inline auto m_Value(SDValue &N) {
+  return Value_bind<Value_match>(N, m_Value());
+}
+/// Conditionally bind a SDValue based on the predicate.
+template <typename PredPattern>
+inline auto m_Value(SDValue &N, const PredPattern &P) {
+  return Value_bind<PredPattern>(N, P);
+}
 
 template <typename Pattern, typename PredFuncT> struct TLI_pred_match {
   Pattern P;


### PR DESCRIPTION
I've seen more and more occurrences of what is essentially
```
m_AllOf(<sub pattern>, m_Value(BindVal))
```
That is, bind to the same SDValue that matches the sub-pattern. Most people won't even bother write this `m_AllOf` construct because it's too long, and instead just write another `sd_match` against the bound value.

This patch adds
```
m_Value(BindVal, <sub pattern>)
```
To replace the `m_AllOf` construct above and conditionally bind the SDValue that matches the sub-pattern.