### PR TITLE
[HLSL] make the default address space a superset of the hlsl_groupshared address space

### DIFF
--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -102,6 +102,7 @@ bool Qualifiers::isTargetAddressSpaceSupersetOf(LangAS A, LangAS B,
          (A == LangAS::Default && B == LangAS::hlsl_device) ||
          (A == LangAS::Default && B == LangAS::hlsl_input) ||
          (A == LangAS::Default && B == LangAS::hlsl_push_constant) ||
+         (A == LangAS::Default && B == LangAS::hlsl_groupshared) ||
          // Conversions from target specific address spaces may be legal
          // depending on the target information.
          Ctx.getTargetInfo().isAddressSpaceSupersetOf(A, B);

--- a/clang/test/CodeGenHLSL/group_shared.hlsl
+++ b/clang/test/CodeGenHLSL/group_shared.hlsl
@@ -12,8 +12,20 @@
 
  groupshared float a[10];
 
+ struct S {
+   uint4 x;
+ };
+// CHECK: @b = hidden addrspace(3) global %struct.S zeroinitializer, align 1
+ groupshared S b;
+
+ template<typename T>
+ struct R {
+   T t;
+ };
+// CHECK: @c = hidden addrspace(3) global %struct.R zeroinitializer, align 1
+ groupshared R<int> c;
+
  [numthreads(8,8,1)]
  void main() {
    a[0] = 1;
  }
-


### PR DESCRIPTION
Make the default address space a superset of the hlsl groupshared address space.  This lets us inititalize a groupshared struct using a default address space constructor.
Closes #158107 