### PR TITLE
[lldb] Disable shared build dir for TestDataFormatterStdMap.py

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/map/TestDataFormatterStdMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/map/TestDataFormatterStdMap.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 class StdMapDataFormatterTestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         TestBase.setUp(self)


### PR DESCRIPTION
Follow up to #181720. This test failed on builder lldb-x86_64-debian.