### PR TITLE
[NFC] Re-enable MSVC C4611 diagnostic

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -754,7 +754,6 @@ if (MSVC)
       -wd4701 # Suppress 'potentially uninitialized local variable'
       -wd4703 # Suppress 'potentially uninitialized local pointer variable'
       -wd4389 # Suppress 'signed/unsigned mismatch'
-      -wd4611 # Suppress 'interaction between '_setjmp' and C++ object destruction is non-portable'
       -wd4805 # Suppress 'unsafe mix of type <type> and type <type> in operation'
       -wd4204 # Suppress 'nonstandard extension used : non-constant aggregate initializer'
       -wd4577 # Suppress 'noexcept used with no exception handling mode specified; termination on exception is not guaranteed'


### PR DESCRIPTION
From MSDN:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4611?view=msvc-170

I do not believe this diagnostic happens in our code base any longer. This diagnostic was disabled in 5c73e1f85c5d37a5b037c70f3c112eec5646acb3 and the review for it (https://reviews.llvm.org/D8572) says there were two instances of the diagnostic as of 2015. But because this is about interaction between `setjmp` and C++ object destruction, I don't think we need to disable this diagnostic across the entire monorepo; we can silence it for the project using setjmp if it still exists.

I enabled the diagnostic locally and my build was warning-free but I'd like to see how pre- (and post-)commit CI do with this one.