### PR TITLE
[SemaHLSL] Warn when a local resource is re-assigned to non-unique global resource

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1852,6 +1852,9 @@ def HLSLMixPackOffset : DiagGroup<"mix-packoffset">;
 // Warning for implicit resource bindings.
 def HLSLImplicitBinding : DiagGroup<"hlsl-implicit-binding">;
 
+// Warning for explicit resource bindings.
+def HLSLExplicitBinding : DiagGroup<"hlsl-explicit-binding">;
+
 // Warnings for DXIL validation
 def DXILValidation : DiagGroup<"dxil-validation">;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13585,6 +13585,9 @@ def err_hlsl_incomplete_resource_array_in_function_param: Error<
   "incomplete resource array in a function parameter">;
 def err_hlsl_assign_to_global_resource: Error<
   "assignment to global resource variable %0 is not allowed">;
+def warn_hlsl_assigning_local_resource_is_not_unique
+    : Warning<"assignment of %0 to local resource %1 is not to the same "
+              "unique global resource">;
 
 def err_hlsl_push_constant_unique
     : Error<"cannot have more than one push constant block">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13587,7 +13587,8 @@ def err_hlsl_assign_to_global_resource: Error<
   "assignment to global resource variable %0 is not allowed">;
 def warn_hlsl_assigning_local_resource_is_not_unique
     : Warning<"assignment of %0 to local resource %1 is not to the same "
-              "unique global resource">;
+              "unique global resource">,
+      InGroup<HLSLExplicitBinding>;
 
 def err_hlsl_push_constant_unique
     : Error<"cannot have more than one push constant block">;

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -329,8 +329,7 @@ private:
   // a reference to the global binding info.
   std::optional<const DeclBindingInfo *> inferGlobalBinding(Expr *E);
 
-  // Returns true if no diagnostic is reported
-  bool trackLocalResource(VarDecl *VDecl, Expr *E);
+  void trackLocalResource(VarDecl *VDecl, Expr *E);
 };
 
 } // namespace clang

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -132,6 +132,8 @@ public:
   bool ActOnUninitializedVarDecl(VarDecl *D);
   void ActOnEndOfTranslationUnit(TranslationUnitDecl *TU);
   void CheckEntryPoint(FunctionDecl *FD);
+
+  // Return true if everything is ok; returns false if there was an error.
   bool CheckResourceBinOp(BinaryOperatorKind Opc, Expr *LHSExpr, Expr *RHSExpr,
                           SourceLocation Loc);
 
@@ -234,6 +236,12 @@ private:
   // List of all resource bindings
   ResourceBindings Bindings;
 
+  // Map of local resource variables to their assigned global resources.
+  //
+  // The binding can be a nullptr, in which case, the variable has yet to be
+  // initialized or assigned to.
+  llvm::DenseMap<const VarDecl *, const DeclBindingInfo *> Assigns;
+
   // Global declaration collected for the $Globals default constant
   // buffer which will be created at the end of the translation unit.
   llvm::SmallVector<Decl *> DefaultCBufferDecls;
@@ -313,6 +321,16 @@ private:
 
   bool initGlobalResourceDecl(VarDecl *VD);
   bool initGlobalResourceArrayDecl(VarDecl *VD);
+
+  // Infer a common global binding info for an Expr
+  //
+  // Returns std::nullopt if the expr refers to non-unique global bindings.
+  // Returns nullptr if it refer to any global binding, otherwise it returns
+  // a reference to the global binding info.
+  std::optional<const DeclBindingInfo *> inferGlobalBinding(Expr *E);
+
+  // Returns true if no diagnostic is reported
+  bool trackLocalResource(VarDecl *VDecl, Expr *E);
 };
 
 } // namespace clang

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4686,7 +4686,67 @@ bool SemaHLSL::ActOnUninitializedVarDecl(VarDecl *VD) {
   return false;
 }
 
-// Return true if everything is ok; returns false if there was an error.
+std::optional<const DeclBindingInfo *> SemaHLSL::inferGlobalBinding(Expr *E) {
+  if (auto *Ternary = dyn_cast<ConditionalOperator>(E)) {
+    auto TrueInfo = inferGlobalBinding(Ternary->getTrueExpr());
+    auto FalseInfo = inferGlobalBinding(Ternary->getFalseExpr());
+    if (!TrueInfo || !FalseInfo)
+      return std::nullopt;
+    if (*TrueInfo != *FalseInfo)
+      return std::nullopt;
+    return TrueInfo;
+  }
+
+  if (auto *ASE = dyn_cast<ArraySubscriptExpr>(E))
+    E = ASE->getBase()->IgnoreParenImpCasts();
+
+  if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParens()))
+    if (VarDecl *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
+      const Type *Ty = VD->getType()->getUnqualifiedDesugaredType();
+      if (Ty->isArrayType())
+        Ty = Ty->getArrayElementTypeNoTypeQual();
+
+      if (const auto *AttrResType =
+              HLSLAttributedResourceType::findHandleTypeOnResource(Ty)) {
+        ResourceClass RC = AttrResType->getAttrs().ResourceClass;
+        return Bindings.getDeclBindingInfo(VD, RC);
+      }
+    }
+
+  return nullptr;
+}
+
+bool SemaHLSL::trackLocalResource(VarDecl *VD, Expr *E) {
+  std::optional<const DeclBindingInfo *> ExprBinding = inferGlobalBinding(E);
+  if (!ExprBinding) {
+    SemaRef.Diag(E->getBeginLoc(),
+                 diag::warn_hlsl_assigning_local_resource_is_not_unique)
+        << E << VD;
+    return false;
+  }
+
+  if (*ExprBinding == nullptr)
+    return true; // No binding could be inferred to track, return without error
+
+  auto PrevBinding = Assigns.find(VD);
+  if (PrevBinding == Assigns.end()) {
+    // No previous binding recorded, simply record the new assignment
+    Assigns.insert({VD, *ExprBinding});
+    return true;
+  }
+
+  // Otherwise, warn if the assignment implies different resource bindings
+  if (*ExprBinding != PrevBinding->second) {
+    SemaRef.Diag(E->getBeginLoc(),
+                 diag::warn_hlsl_assigning_local_resource_is_not_unique)
+        << E << VD;
+    SemaRef.Diag(VD->getLocation(), diag::note_var_declared_here) << VD;
+    return false;
+  }
+
+  return true;
+}
+
 bool SemaHLSL::CheckResourceBinOp(BinaryOperatorKind Opc, Expr *LHSExpr,
                                   Expr *RHSExpr, SourceLocation Loc) {
   assert((LHSExpr->getType()->isHLSLResourceRecord() ||
@@ -4709,6 +4769,8 @@ bool SemaHLSL::CheckResourceBinOp(BinaryOperatorKind Opc, Expr *LHSExpr,
         SemaRef.Diag(VD->getLocation(), diag::note_var_declared_here) << VD;
         return false;
       }
+
+      trackLocalResource(VD, RHSExpr);
     }
   }
   return true;
@@ -5315,6 +5377,10 @@ QualType SemaHLSL::checkMatrixComponent(Sema &S, QualType baseType,
 }
 
 bool SemaHLSL::handleInitialization(VarDecl *VDecl, Expr *&Init) {
+  // If initializing a local resource, track the resource binding it is using
+  if (VDecl->getType()->isHLSLResourceRecord() && !VDecl->hasGlobalStorage())
+    trackLocalResource(VDecl, Init);
+
   const HLSLVkConstantIdAttr *ConstIdAttr =
       VDecl->getAttr<HLSLVkConstantIdAttr>();
   if (!ConstIdAttr)

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4716,23 +4716,23 @@ std::optional<const DeclBindingInfo *> SemaHLSL::inferGlobalBinding(Expr *E) {
   return nullptr;
 }
 
-bool SemaHLSL::trackLocalResource(VarDecl *VD, Expr *E) {
+void SemaHLSL::trackLocalResource(VarDecl *VD, Expr *E) {
   std::optional<const DeclBindingInfo *> ExprBinding = inferGlobalBinding(E);
   if (!ExprBinding) {
     SemaRef.Diag(E->getBeginLoc(),
                  diag::warn_hlsl_assigning_local_resource_is_not_unique)
         << E << VD;
-    return false;
+    return; // Expr use multiple resources
   }
 
   if (*ExprBinding == nullptr)
-    return true; // No binding could be inferred to track, return without error
+    return; // No binding could be inferred to track, return without error
 
   auto PrevBinding = Assigns.find(VD);
   if (PrevBinding == Assigns.end()) {
     // No previous binding recorded, simply record the new assignment
     Assigns.insert({VD, *ExprBinding});
-    return true;
+    return;
   }
 
   // Otherwise, warn if the assignment implies different resource bindings
@@ -4741,10 +4741,10 @@ bool SemaHLSL::trackLocalResource(VarDecl *VD, Expr *E) {
                  diag::warn_hlsl_assigning_local_resource_is_not_unique)
         << E << VD;
     SemaRef.Diag(VD->getLocation(), diag::note_var_declared_here) << VD;
-    return false;
+    return;
   }
 
-  return true;
+  return;
 }
 
 bool SemaHLSL::CheckResourceBinOp(BinaryOperatorKind Opc, Expr *LHSExpr,

--- a/clang/test/SemaHLSL/local_resource_bindings.hlsl
+++ b/clang/test/SemaHLSL/local_resource_bindings.hlsl
@@ -19,6 +19,12 @@ void no_initial_assignment(int idx) {
     Out[idx] = In[idx];
 }
 
+void assignment_to_uninitialized(int idx) {
+    RWStructuredBuffer<int> Out;
+    Out = Out;
+    Out[idx] = In[idx];
+}
+
 void same_assignment(int idx) {
     RWStructuredBuffer<int> Out = Out1;
     if (cond) {

--- a/clang/test/SemaHLSL/local_resource_bindings.hlsl
+++ b/clang/test/SemaHLSL/local_resource_bindings.hlsl
@@ -1,0 +1,56 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -verify %s
+
+// expected-no-diagnostics
+
+RWBuffer<int> In : register(u0);
+RWStructuredBuffer<int> Out0 : register(u1);
+RWStructuredBuffer<int> Out1 : register(u2);
+RWStructuredBuffer<int> OutArr[];
+
+cbuffer c {
+    bool cond;
+};
+
+void no_initial_assignment(int idx) {
+    RWStructuredBuffer<int> Out;
+    if (cond) {
+        Out = Out1;
+    }
+    Out[idx] = In[idx];
+}
+
+void same_assignment(int idx) {
+    RWStructuredBuffer<int> Out = Out1;
+    if (cond) {
+        Out = Out1;
+    }
+    Out[idx] = In[idx];
+}
+
+void conditional_initialization_with_index(int idx) {
+    RWStructuredBuffer<int> Out = cond ? OutArr[0] : OutArr[1];
+    Out[idx] = In[idx];
+}
+
+void conditional_assignment_with_index(int idx) {
+    RWStructuredBuffer<int> Out;
+	if (cond) {
+		Out = OutArr[0];
+	} else {
+		Out = OutArr[1];
+	}
+    Out[idx] = In[idx];
+}
+
+void reassignment(int idx) {
+    RWStructuredBuffer<int> Out = Out0;
+	if (cond) {
+		Out = Out0;
+	}
+	Out[idx] = In[idx];
+}
+
+void conditional_result_in_same(int idx) {
+    RWStructuredBuffer<int> Out = cond ? Out0 : Out0;
+	Out[idx] = In[idx];
+}

--- a/clang/test/SemaHLSL/local_resource_bindings.hlsl
+++ b/clang/test/SemaHLSL/local_resource_bindings.hlsl
@@ -1,45 +1,45 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -finclude-default-header -verify %s
 
 // expected-no-diagnostics
 
-RWBuffer<int> In : register(u0);
-RWStructuredBuffer<int> Out0 : register(u1);
-RWStructuredBuffer<int> Out1 : register(u2);
-RWStructuredBuffer<int> OutArr[];
+RWBuffer<uint> In : register(u0);
+RWStructuredBuffer<uint> Out0 : register(u1);
+RWStructuredBuffer<uint> Out1 : register(u2);
+RWStructuredBuffer<uint> OutArr[];
 
 cbuffer c {
     bool cond;
 };
 
-void no_initial_assignment(int idx) {
-    RWStructuredBuffer<int> Out;
+void no_initial_assignment(uint idx) {
+    RWStructuredBuffer<uint> Out;
     if (cond) {
         Out = Out1;
     }
     Out[idx] = In[idx];
 }
 
-void assignment_to_uninitialized(int idx) {
-    RWStructuredBuffer<int> Out;
+void assignment_to_uninitialized(uint idx) {
+    RWStructuredBuffer<uint> Out;
     Out = Out;
     Out[idx] = In[idx];
 }
 
-void same_assignment(int idx) {
-    RWStructuredBuffer<int> Out = Out1;
+void same_assignment(uint idx) {
+    RWStructuredBuffer<uint> Out = Out1;
     if (cond) {
         Out = Out1;
     }
     Out[idx] = In[idx];
 }
 
-void conditional_initialization_with_index(int idx) {
-    RWStructuredBuffer<int> Out = cond ? OutArr[0] : OutArr[1];
+void conditional_initialization_with_index(uint idx) {
+    RWStructuredBuffer<uint> Out = cond ? OutArr[0] : OutArr[1];
     Out[idx] = In[idx];
 }
 
-void conditional_assignment_with_index(int idx) {
-    RWStructuredBuffer<int> Out;
+void conditional_assignment_with_index(uint idx) {
+    RWStructuredBuffer<uint> Out;
 	if (cond) {
 		Out = OutArr[0];
 	} else {
@@ -48,15 +48,15 @@ void conditional_assignment_with_index(int idx) {
     Out[idx] = In[idx];
 }
 
-void reassignment(int idx) {
-    RWStructuredBuffer<int> Out = Out0;
+void reassignment(uint idx) {
+    RWStructuredBuffer<uint> Out = Out0;
 	if (cond) {
 		Out = Out0;
 	}
 	Out[idx] = In[idx];
 }
 
-void conditional_result_in_same(int idx) {
-    RWStructuredBuffer<int> Out = cond ? Out0 : Out0;
+void conditional_result_in_same(uint idx) {
+    RWStructuredBuffer<uint> Out = cond ? Out0 : Out0;
 	Out[idx] = In[idx];
 }

--- a/clang/test/SemaHLSL/local_resource_bindings_errs.hlsl
+++ b/clang/test/SemaHLSL/local_resource_bindings_errs.hlsl
@@ -1,0 +1,49 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -verify %s
+
+RWBuffer<int> In : register(u0);
+RWStructuredBuffer<int> Out0 : register(u1);
+RWStructuredBuffer<int> Out1 : register(u2);
+RWStructuredBuffer<int> OutArr[];
+
+cbuffer c {
+    bool cond;
+};
+
+void conditional_initialization(int idx) {
+    // expected-warning@+1 {{assignment of 'cond ? Out0 : Out1' to local resource 'Out' is not to the same unique global resource}}
+    RWStructuredBuffer<int> Out = cond ? Out0 : Out1;
+    Out[idx] = In[idx];
+}
+
+void branched_assignment(int idx) {
+    RWStructuredBuffer<int> Out = Out0; // expected-note {{variable 'Out' is declared here}}
+    if (cond) {
+        // expected-warning@+1 {{assignment of 'Out1' to local resource 'Out' is not to the same unique global resource}}
+        Out = Out1;
+    }
+    Out[idx] = In[idx];
+}
+
+void branched_assignment_with_array(int idx) {
+    RWStructuredBuffer<int> Out = Out0; // expected-note {{variable 'Out' is declared here}}
+    if (cond) {
+        // expected-warning@+1 {{assignment of 'OutArr[0]' to local resource 'Out' is not to the same unique global resource}}
+        Out = OutArr[0];
+    }
+    Out[idx] = In[idx];
+}
+
+void conditional_assignment(int idx) {
+    RWStructuredBuffer<int> Out;
+    // expected-warning@+1 {{assignment of 'cond ? Out0 : Out1' to local resource 'Out' is not to the same unique global resource}}
+    Out = cond ? Out0 : Out1;
+    Out[idx] = In[idx];
+}
+
+static RWStructuredBuffer<int> StaticOut;
+
+void static_conditional_assignment(int idx) {
+    // expected-warning@+1 {{assignment of 'cond ? Out0 : Out1' to local resource 'StaticOut' is not to the same unique global resource}}
+    StaticOut = cond ? Out0 : Out1;
+    StaticOut[idx] = In[idx];
+}

--- a/clang/test/SemaHLSL/local_resource_bindings_errs.hlsl
+++ b/clang/test/SemaHLSL/local_resource_bindings_errs.hlsl
@@ -1,22 +1,22 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -finclude-default-header -verify %s
 
-RWBuffer<int> In : register(u0);
-RWStructuredBuffer<int> Out0 : register(u1);
-RWStructuredBuffer<int> Out1 : register(u2);
-RWStructuredBuffer<int> OutArr[];
+RWBuffer<uint> In : register(u0);
+RWStructuredBuffer<uint> Out0 : register(u1);
+RWStructuredBuffer<uint> Out1 : register(u2);
+RWStructuredBuffer<uint> OutArr[];
 
 cbuffer c {
     bool cond;
 };
 
-void conditional_initialization(int idx) {
+void conditional_initialization(uint idx) {
     // expected-warning@+1 {{assignment of 'cond ? Out0 : Out1' to local resource 'Out' is not to the same unique global resource}}
-    RWStructuredBuffer<int> Out = cond ? Out0 : Out1;
+    RWStructuredBuffer<uint> Out = cond ? Out0 : Out1;
     Out[idx] = In[idx];
 }
 
-void branched_assignment(int idx) {
-    RWStructuredBuffer<int> Out = Out0; // expected-note {{variable 'Out' is declared here}}
+void branched_assignment(uint idx) {
+    RWStructuredBuffer<uint> Out = Out0; // expected-note {{variable 'Out' is declared here}}
     if (cond) {
         // expected-warning@+1 {{assignment of 'Out1' to local resource 'Out' is not to the same unique global resource}}
         Out = Out1;
@@ -24,8 +24,8 @@ void branched_assignment(int idx) {
     Out[idx] = In[idx];
 }
 
-void branched_assignment_with_array(int idx) {
-    RWStructuredBuffer<int> Out = Out0; // expected-note {{variable 'Out' is declared here}}
+void branched_assignment_with_array(uint idx) {
+    RWStructuredBuffer<uint> Out = Out0; // expected-note {{variable 'Out' is declared here}}
     if (cond) {
         // expected-warning@+1 {{assignment of 'OutArr[0]' to local resource 'Out' is not to the same unique global resource}}
         Out = OutArr[0];
@@ -33,16 +33,16 @@ void branched_assignment_with_array(int idx) {
     Out[idx] = In[idx];
 }
 
-void conditional_assignment(int idx) {
-    RWStructuredBuffer<int> Out;
+void conditional_assignment(uint idx) {
+    RWStructuredBuffer<uint> Out;
     // expected-warning@+1 {{assignment of 'cond ? Out0 : Out1' to local resource 'Out' is not to the same unique global resource}}
     Out = cond ? Out0 : Out1;
     Out[idx] = In[idx];
 }
 
-static RWStructuredBuffer<int> StaticOut;
+static RWStructuredBuffer<uint> StaticOut;
 
-void static_conditional_assignment(int idx) {
+void static_conditional_assignment(uint idx) {
     // expected-warning@+1 {{assignment of 'cond ? Out0 : Out1' to local resource 'StaticOut' is not to the same unique global resource}}
     StaticOut = cond ? Out0 : Out1;
     StaticOut[idx] = In[idx];


### PR DESCRIPTION
Generate a warning whenever a local resource is (re-)assigned such that it is not guaranteed to map to a single unique global resource.

An error is not generated during sema because simple DCE or constant folding might resolve the assignment to be to a unique global resource. Instead, an error will be reported when trying to resolve the resource access in the `dxil-resource-access` pass, implemented [here](https://github.com/llvm/llvm-project/pull/182106).

Resolves https://github.com/llvm/llvm-project/issues/179303.