### PR TITLE
[CIR][ARM] Refactor argument handling in `emitAArch64BuiltinExpr` (NFC)

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -249,8 +249,8 @@ static unsigned getSVEMinEltCount(clang::SVETypeFlags::EltType sveType) {
 static bool hasExtraNeonArgument(unsigned builtinID) {
   // Required by the headers included below, but not in this particular
   // function.
-  int PtrArgNum = -1;
-  bool HasConstPtr = false;
+  [[maybe_unused]] int PtrArgNum = -1;
+  [[maybe_unused]] bool HasConstPtr = false;
 
   // The mask encodes the type. We don't care about the actual value. Instead,
   // we just check whether its been set.


### PR DESCRIPTION
Port recent argument-handling refactors from
CodeGen/TargetBuiltins/ARM.cpp into
CIR/CodeGen/CIRGenBuiltinAArch64.cpp to keep the CIR
implementation in sync with Clang CodeGen.

In particular, mirror the updated handling of Sema-only NEON
discriminator arguments and the common argument emission logic
used to populate the `Ops` vector.

This is a mechanical port of the following changes:

  * https://github.com/llvm/llvm-project/pull/181974
  * https://github.com/llvm/llvm-project/pull/181794

No functional change intended.