### PR TITLE
[DirectX][ResourceAccess] Resolve resource handles at access

### DIFF
--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -33,8 +33,21 @@ using namespace llvm;
 static void diagnoseNonUniqueResourceAccess(Instruction *I,
                                             ArrayRef<IntrinsicInst *> Handles) {
   LLVMContext &Context = I->getContext();
+  std::string InstStr;
+  raw_string_ostream InstOS(InstStr);
+  I->print(InstOS);
+  Context.diagnose(
+      DiagnosticInfoGeneric("At resource access:" + Twine(InstStr), DS_Note));
+
+  for (auto *Handle : Handles) {
+    std::string HandleStr;
+    raw_string_ostream HandleOS(HandleStr);
+    Handle->print(HandleOS);
+    Context.diagnose(DiagnosticInfoGeneric(
+        "Uses resource handle:" + Twine(HandleStr), DS_Note));
+  }
   Context.diagnose(DiagnosticInfoGeneric(
-      "Resource access is not guarenteed to map to a unique global resource"));
+      "Resource access is not guaranteed to map to a unique global resource"));
 }
 
 static Value *traverseGEPOffsets(const DataLayout &DL, IRBuilder<> &Builder,

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -546,9 +546,9 @@ getAccessIndices(Instruction *I, SmallSetVector<Instruction *, 16> &DeadInsts) {
     PHINode *HandlePhi = PHINode::Create(Builder.getInt32Ty(), NumEdges);
 
     bool HasGetPtr = true;
-    for (unsigned I = 0; I < NumEdges; I++) {
-      auto *BB = Phi->getIncomingBlock(I);
-      auto *V = dyn_cast<Instruction>(Phi->getIncomingValue(I));
+    for (unsigned Idx = 0; Idx < NumEdges; Idx++) {
+      auto *BB = Phi->getIncomingBlock(Idx);
+      auto *V = dyn_cast<Instruction>(Phi->getIncomingValue(Idx));
       auto AccessIdx = getAccessIndices(V, DeadInsts);
       HasGetPtr &= AccessIdx.hasGetPtrIdx();
       if (HasGetPtr)

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -487,6 +487,7 @@ static hlsl::Binding getHandleIntrinsicBinding(IntrinsicInst *Handle,
 
   return hlsl::Binding(Class, Space, LowerBound, UpperBound, nullptr);
 }
+
 namespace {
 /// Helper for propagating the current handle and ptr indices.
 struct AccessIndices {
@@ -494,6 +495,7 @@ struct AccessIndices {
   Value *HandleIdx;
 
   bool hasGetPtrIdx() { return GetPtrIdx != nullptr; }
+  bool hasHandleIdx() { return HandleIdx != nullptr; }
 };
 } // namespace
 
@@ -581,6 +583,9 @@ static void
 replaceHandleWithIndices(Instruction *Ptr, IntrinsicInst *OldHandle,
                          SmallSetVector<Instruction *, 16> &DeadInsts) {
   auto AccessIdx = getAccessIndices(Ptr, DeadInsts);
+  assert(AccessIdx.hasGetPtrIdx() && AccessIdx.hasHandleIdx() &&
+         "Couldn't retrieve indices. This should be guaranteed by "
+         "collectUsedHandles");
 
   IRBuilder<> Builder(Ptr);
   IntrinsicInst *Handle = cast<IntrinsicInst>(OldHandle->clone());

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -495,8 +495,8 @@ static hlsl::Binding getHandleIntrinsicBinding(IntrinsicInst *Handle,
   uint32_t Space = cast<ConstantInt>(Handle->getArgOperand(0))->getZExtValue();
   uint32_t LowerBound =
       cast<ConstantInt>(Handle->getArgOperand(1))->getZExtValue();
-  int32_t Size = cast<ConstantInt>(Handle->getArgOperand(2))->getZExtValue();
-  uint32_t UpperBound = Size < 0 ? UINT32_MAX : LowerBound + Size - 1;
+  uint32_t Size = cast<ConstantInt>(Handle->getArgOperand(2))->getZExtValue();
+  uint32_t UpperBound = Size == UINT32_MAX ? UINT32_MAX : LowerBound + Size - 1;
 
   return hlsl::Binding(Class, Space, LowerBound, UpperBound, nullptr);
 }

--- a/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILResourceAccess.cpp
@@ -597,8 +597,7 @@ replaceHandleWithIndices(Instruction *Ptr, IntrinsicInst *OldHandle,
                          SmallSetVector<Instruction *, 16> &DeadInsts) {
   auto AccessIdx = getAccessIndices(Ptr, DeadInsts);
   assert(AccessIdx.hasGetPtrIdx() && AccessIdx.hasHandleIdx() &&
-         "Couldn't retrieve indices. This should be guaranteed by "
-         "collectUsedHandles");
+         "Couldn't retrieve indices. This is guaranteed by getAccessIndices");
 
   IRBuilder<> Builder(Ptr);
   IntrinsicInst *Handle = cast<IntrinsicInst>(OldHandle->clone());
@@ -619,8 +618,8 @@ replaceHandleWithIndices(Instruction *Ptr, IntrinsicInst *OldHandle,
 //
 // If it can't be transformed to be legal then:
 //
-// Reports an error if a resource access is not guaranteed to be into a unique
-// global resource.
+// Reports an error if a resource access is not guaranteed into a unique global
+// resource.
 //
 // Returns true if any changes are made.
 static bool legalizeResourceHandles(Function &F, DXILResourceTypeMap &DRTM) {
@@ -649,11 +648,13 @@ static bool legalizeResourceHandles(Function &F, DXILResourceTypeMap &DRTM) {
     }
   }
 
-  bool MadeChanges = DeadInsts.size() > 0;
+  bool MadeChanges = false;
 
   for (auto *I : llvm::reverse(DeadInsts))
-    if (I->hasNUses(0)) // Handle maybe used elsewhere aside from replaced path
+    if (I->hasNUses(0)) { // Handle can still be used outside of replaced path
       I->eraseFromParent();
+      MadeChanges = true;
+    }
 
   return MadeChanges;
 }

--- a/llvm/test/CodeGen/DirectX/ResourceAccess/handle-cases.ll
+++ b/llvm/test/CodeGen/DirectX/ResourceAccess/handle-cases.ll
@@ -1,0 +1,107 @@
+; RUN: opt -S -dxil-resource-type -dxil-resource-access -disable-verify \
+; RUN:  -mtriple=dxil-pc-shadermodel6.3-library %s | FileCheck %s
+
+; The file contains examples of hlsl snippets that will generate invalid
+; looking resource access, either through code-gen or by optimization.
+; These can be legalized by replacing the handles with indicies into the
+; same global resource.
+
+; NOTE: The below resources are generated with:
+;
+;   RWBuffer<int> In : register(u0);
+;   RWStructuredBuffer<int> Out0 : register(u1);
+;   RWStructuredBuffer<int> Out1 : register(u2);
+;   RWStructuredBuffer<int> OutArr[];
+
+;   cbuffer c {
+;       bool cond;
+;   };
+
+%__cblayout_c = type <{ i32 }>
+
+@.str = internal unnamed_addr constant [3 x i8] c"In\00", align 1
+@.str.2 = internal unnamed_addr constant [5 x i8] c"Out0\00", align 1
+@.str.3 = internal unnamed_addr constant [5 x i8] c"Out1\00", align 1
+@c.cb = local_unnamed_addr global target("dx.CBuffer", %__cblayout_c) poison
+@c.str = internal unnamed_addr constant [2 x i8] c"c\00", align 1
+@OutArr.str = internal unnamed_addr constant [7 x i8] c"OutArr\00", align 1
+
+; Local select into global resource array:
+;
+;   RWStructuredBuffer<int> Out = cond ? OutArr[0] : OutArr[1];
+;   Out[GI] = WaveActiveMax(In[GI]);
+;
+; CHECK-LABEL: @select_global_resource_array()
+define void @select_global_resource_array() {
+entry:
+  %c.cb_h.i.i = tail call target("dx.CBuffer", %__cblayout_c) @llvm.dx.resource.handlefromimplicitbinding.tdx.CBuffer_s___cblayout_cst(i32 4, i32 0, i32 1, i32 0, ptr nonnull @c.str)
+  store target("dx.CBuffer", %__cblayout_c) %c.cb_h.i.i, ptr @c.cb, align 4
+  %c.cb = load target("dx.CBuffer", %__cblayout_c), ptr @c.cb, align 4
+  %0 = call ptr addrspace(2) @llvm.dx.resource.getpointer.p2.tdx.CBuffer_s___cblayout_cst(target("dx.CBuffer", %__cblayout_c) %c.cb, i32 0)
+  %1 = load i32, ptr addrspace(2) %0, align 4
+  %loadedv.i = trunc nuw i32 %1 to i1
+  br i1 %loadedv.i, label %cond.true.i, label %cond.false.i
+
+cond.true.i:
+; CHECK:      cond.true.i:
+; CHECK-NEXT:   br label %cond.end.i
+  %2 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 0, ptr nonnull @OutArr.str)
+  br label %cond.end.i
+
+cond.false.i:
+; CHECK:      cond.false.i:
+; CHECK-NEXT:   br label %cond.end.i
+  %3 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 1, ptr nonnull @OutArr.str)
+  br label %cond.end.i
+
+cond.end.i:
+; CHECK:     cond.end.i
+; CHECK-NEXT:  %[[HANDLE_IDX:.*]] = phi i32 [ 0, %cond.true.i ], [ 1, %cond.false.i ]
+; CHECK:       %[[TID:.*]] = tail call i32 @llvm.dx.flattened.thread.id.in.group()
+; CHECK:       %[[WAVE_MAX:.*]] = tail call i32 @llvm.dx.wave.reduce.max.i32(i32 %{{.*}})
+; CHECK-NEXT:  %[[HANDLE:.*]] = tail call target("dx.RawBuffer", i32, 1, 0)
+; CHECK-SAME:    @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 %[[HANDLE_IDX]], ptr nonnull @OutArr.str)
+; CHECK-NEXT:  call void @llvm.dx.resource.store.rawbuffer.tdx.RawBuffer_i32_1_0t.i32(target("dx.RawBuffer", i32, 1, 0) %[[HANDLE]], i32 %[[TID]], i32 0, i32 %[[WAVE_MAX]])
+; CHECK-NEXT:  ret void
+  %cond.i.sroa.speculated = phi target("dx.RawBuffer", i32, 1, 0) [ %2, %cond.true.i ], [ %3, %cond.false.i ]
+  %4 = tail call target("dx.TypedBuffer", i32, 1, 0, 1) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0_1t(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str)
+  %5 = tail call i32 @llvm.dx.flattened.thread.id.in.group()
+  %6 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0_1t(target("dx.TypedBuffer", i32, 1, 0, 1) %4, i32 %5)
+  %7 = load i32, ptr %6, align 4
+  %hlsl.wave.active.max.i = tail call i32 @llvm.dx.wave.reduce.max.i32(i32 %7)
+  %8 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i32_1_0t(target("dx.RawBuffer", i32, 1, 0) %cond.i.sroa.speculated, i32 %5)
+  store i32 %hlsl.wave.active.max.i, ptr %8, align 4
+  ret void
+}
+
+; Using a local array of global resources
+;
+;   RWStructuredBuffer<int> Outs[2] = {OutArr[0], OutArr[1]};
+;   Outs[cond ? 0 : 1][GI] = In[GI];
+;
+; CHECK-LABEL: @local_array_of_global_resources()
+define void @local_array_of_global_resources() {
+entry:
+  %0 = tail call target("dx.TypedBuffer", i32, 1, 0, 1) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0_1t(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str)
+  %c.cb_h.i.i = tail call target("dx.CBuffer", %__cblayout_c) @llvm.dx.resource.handlefromimplicitbinding.tdx.CBuffer_s___cblayout_cst(i32 4, i32 0, i32 1, i32 0, ptr nonnull @c.str)
+  store target("dx.CBuffer", %__cblayout_c) %c.cb_h.i.i, ptr @c.cb, align 4
+  %1 = tail call i32 @llvm.dx.flattened.thread.id.in.group()
+  %2 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 0, ptr nonnull @OutArr.str)
+  %3 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 1, ptr nonnull @OutArr.str)
+  %4 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0_1t(target("dx.TypedBuffer", i32, 1, 0, 1) %0, i32 %1)
+  %5 = load i32, ptr %4, align 4
+  %c.cb = load target("dx.CBuffer", %__cblayout_c), ptr @c.cb, align 4
+  %6 = call ptr addrspace(2) @llvm.dx.resource.getpointer.p2.tdx.CBuffer_s___cblayout_cst(target("dx.CBuffer", %__cblayout_c) %c.cb, i32 0)
+  %7 = load i32, ptr addrspace(2) %6, align 4
+  %loadedv.i = trunc nuw i32 %7 to i1
+
+; CHECK:       %[[TID:.*]] = tail call i32 @llvm.dx.flattened.thread.id.in.group()
+; CHECK:       %[[HANDLE_IDX:.*]] = select i1 %loadedv.i, i32 0, i32 1
+; CHECK-NEXT:  %[[HANDLE:.*]] = tail call target("dx.RawBuffer", i32, 1, 0)
+; CHECK-SAME:    @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 %[[HANDLE_IDX]], ptr nonnull @OutArr.str)
+; CHECK-NEXT:  call void @llvm.dx.resource.store.rawbuffer.tdx.RawBuffer_i32_1_0t.i32(target("dx.RawBuffer", i32, 1, 0) %[[HANDLE]], i32 %[[TID]], i32 0, i32 {{.*}})
+  %.sroa.speculated = select i1 %loadedv.i, target("dx.RawBuffer", i32, 1, 0) %2, target("dx.RawBuffer", i32, 1, 0) %3
+  %8 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i32_1_0t(target("dx.RawBuffer", i32, 1, 0) %.sroa.speculated, i32 %1)
+  store i32 %5, ptr %8, align 4
+  ret void
+}

--- a/llvm/test/CodeGen/DirectX/ResourceAccess/handle-cases.ll
+++ b/llvm/test/CodeGen/DirectX/ResourceAccess/handle-cases.ll
@@ -31,6 +31,12 @@
 ;   RWStructuredBuffer<int> Out = cond ? OutArr[0] : OutArr[1];
 ;   Out[GI] = WaveActiveMax(In[GI]);
 ;
+; This will ensure that the index is propogated through phi branching
+; correctly. We see that two different handles are generated in the different
+; branches, so we will ensure that the handle generation is removed from
+; the branches and that the `phi i32` node is used to distinguish the index.
+; Then that index is used to generate the handle.
+;
 ; CHECK-LABEL: @select_global_resource_array()
 define void @select_global_resource_array() {
 entry:
@@ -78,6 +84,10 @@ cond.end.i:
 ;
 ;   RWStructuredBuffer<int> Outs[2] = {OutArr[0], OutArr[1]};
 ;   Outs[cond ? 0 : 1][GI] = In[GI];
+;
+; This will ensure that the index is propogated through the select of two
+; resources. So we want to check that the `select i1` is based on the handle
+; indices, and that this index is used to generate the handle.
 ;
 ; CHECK-LABEL: @local_array_of_global_resources()
 define void @local_array_of_global_resources() {

--- a/llvm/test/CodeGen/DirectX/ResourceAccess/handle-to-index.ll
+++ b/llvm/test/CodeGen/DirectX/ResourceAccess/handle-to-index.ll
@@ -1,0 +1,161 @@
+; RUN: opt -S -dxil-resource-type -dxil-resource-access -disable-verify \
+; RUN:  -mtriple=dxil-pc-shadermodel6.3-library %s | FileCheck %s
+
+@OutArr.str = internal unnamed_addr constant [7 x i8] c"OutArr\00", align 1
+
+; CHECK-LABEL: handle_phi_load(
+; CHECK-SAME:   i1 %[[COND:.*]], i32 %[[A:.*]], i32 %[[B:.*]])
+define i32 @handle_phi_load(i1 %cond, i32 %a, i32 %b) {
+; CHECK-NOT: handlefromimplicitbinding
+; CHECK:     main:
+; CHECK-NEXT:  %[[IDX:.*]] = phi i32 [ 0, %entry ], [ 1, %if.then.i ]
+; CHECK-NEXT:  %[[C:.*]] = phi i32 [ %[[A]], %entry ], [ %[[B]], %if.then.i ]
+; CHECK-NEXT:  %[[HANDLE:.*]] = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 %[[IDX]], ptr nonnull @OutArr.str)
+; CHECK-NEXT:  %[[LOAD:.*]] = call { i32, i1 } @llvm.dx.resource.load.rawbuffer.i32.tdx.RawBuffer_i32_1_0t(target("dx.RawBuffer", i32, 1, 0) %[[HANDLE]], i32 %[[C]], i32 0)
+; CHECK-NEXT:  %[[X:.*]] = extractvalue { i32, i1 } %[[LOAD]], 0
+; CHECK-NEXT:  ret i32 %[[X]]
+entry:
+  %handle0 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 0, ptr nonnull @OutArr.str)
+  br i1 %cond, label %if.then.i, label %main
+
+if.then.i:
+  %handle1 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 1, ptr nonnull @OutArr.str)
+  br label %main
+
+main:
+  %handle_phi = phi target("dx.RawBuffer", i32, 1, 0) [ %handle0, %entry ], [ %handle1, %if.then.i ]
+  %c = phi i32 [ %a, %entry ], [ %b, %if.then.i ]
+  %ptr = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i32_1_0t(target("dx.RawBuffer", i32, 1, 0) %handle_phi, i32 %c)
+  %x = load i32, ptr %ptr, align 4
+  ret i32 %x
+}
+
+; CHECK-LABEL: handle_select_store(
+; CHECK-SAME:   i32 %[[X:.*]], i1 %[[COND:.*]], i32 %[[A:.*]], i32 %[[B:.*]])
+define void @handle_select_store(i32 %x, i1 %cond, i32 %a, i32 %b) {
+; CHECK-NOT: handlefromimplicitbinding
+; CHECK:     entry:
+; CHECK-NEXT:  %[[IDX:.*]] = select i1 %[[COND]], i32 0, i32 1
+; CHECK-NEXT:  %[[C:.*]] = select i1 %cond, i32 %[[A]], i32 %[[B]]
+; CHECK-NEXT:  %[[HANDLE:.*]] = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 %[[IDX]], ptr nonnull @OutArr.str)
+; CHECK-NEXT:  call void @llvm.dx.resource.store.rawbuffer.tdx.RawBuffer_i32_1_0t.i32(target("dx.RawBuffer", i32, 1, 0) %[[HANDLE]], i32 %[[C]], i32 0, i32 %[[X]])
+; CHECK-NEXT:  ret void
+entry:
+  %handle0 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 0, ptr nonnull @OutArr.str)
+  %handle1 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 1, ptr nonnull @OutArr.str)
+  %handle = select i1 %cond, target("dx.RawBuffer", i32, 1, 0) %handle0, target("dx.RawBuffer", i32, 1, 0) %handle1
+  %c = select i1 %cond, i32 %a, i32 %b
+  %ptr = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i32_1_0t(target("dx.RawBuffer", i32, 1, 0) %handle, i32 %c)
+  store i32 %x, ptr %ptr, align 4
+  ret void
+}
+
+; CHECK-LABEL: ptr_phi_store(
+; CHECK-SAME:   i32 %[[X:.*]], i1 %[[COND:.*]], i32 %[[A:.*]], i32 %[[B:.*]])
+define void @ptr_phi_store(i32 %x, i1 %cond, i32 %a, i32 %b) {
+; CHECK-NOT: handlefromimplicitbinding
+; CHECK:     main:
+; CHECK-NEXT:  %[[C:.*]] = phi i32 [ %[[A]], %entry ], [ %[[B]], %if.then.i ]
+; CHECK-NEXT:  %[[IDX:.*]] = phi i32 [ 0, %entry ], [ 1, %if.then.i ]
+; CHECK-NEXT:  %[[HANDLE:.*]] = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 %[[IDX]], ptr nonnull @OutArr.str)
+; CHECK-NEXT:  call void @llvm.dx.resource.store.rawbuffer.tdx.RawBuffer_i32_1_0t.i32(target("dx.RawBuffer", i32, 1, 0) %[[HANDLE]], i32 %[[C]], i32 0, i32 %[[X]])
+; CHECK-NEXT:  ret void
+entry:
+  %handle0 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 0, ptr nonnull @OutArr.str)
+  %ptr0 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i32_1_0t(target("dx.RawBuffer", i32, 1, 0) %handle0, i32 %a)
+  br i1 %cond, label %if.then.i, label %main
+
+if.then.i:
+  %handle1 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 1, ptr nonnull @OutArr.str)
+  %ptr1 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i32_1_0t(target("dx.RawBuffer", i32, 1, 0) %handle1, i32 %b)
+  br label %main
+
+main:
+  %ptr_phi = phi ptr [ %ptr0, %entry ], [ %ptr1, %if.then.i ]
+  store i32 %x, ptr %ptr_phi, align 4
+  ret void
+}
+
+; CHECK-LABEL: ptr_select_load(
+; CHECK-SAME:   i1 %[[COND:.*]], i32 %[[A:.*]], i32 %[[B:.*]])
+define i32 @ptr_select_load(i1 %cond, i32 %a, i32 %b) {
+; CHECK-NOT: handlefromimplicitbinding
+; CHECK:     entry:
+; CHECK-NEXT:  %[[C:.*]] = select i1 %[[COND]], i32 %[[A]], i32 %[[B]]
+; CHECK-NEXT:  %[[IDX:.*]] = select i1 %[[COND]], i32 0, i32 1
+; CHECK-NEXT:  %[[HANDLE:.*]] = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 %[[IDX]], ptr nonnull @OutArr.str)
+; CHECK-NEXT:  %[[LOAD:.*]] = call { i32, i1 } @llvm.dx.resource.load.rawbuffer.i32.tdx.RawBuffer_i32_1_0t(target("dx.RawBuffer", i32, 1, 0) %[[HANDLE]], i32 %[[C]], i32 0)
+; CHECK-NEXT:  %[[X:.*]] = extractvalue { i32, i1 } %[[LOAD]], 0
+; CHECK-NEXT:  ret i32 %[[X]]
+entry:
+  %handle0 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 0, ptr nonnull @OutArr.str)
+  %ptr0 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i32_1_0t(target("dx.RawBuffer", i32, 1, 0) %handle0, i32 %a)
+  %handle1 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefromimplicitbinding.tdx.RawBuffer_i32_1_0t(i32 2, i32 0, i32 -1, i32 1, ptr nonnull @OutArr.str)
+  %ptr1 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i32_1_0t(target("dx.RawBuffer", i32, 1, 0) %handle1, i32 %b)
+  %ptr = select i1 %cond, ptr %ptr0, ptr %ptr1
+  %x = load i32, ptr %ptr, align 4
+  ret i32 %x
+}
+
+; CHECK-LABEL: gvn_ptr_store
+; CHECK-SAME:   i32 %[[X:.*]], i1 %[[COND:.*]], i32 %[[A:.*]], i32 %[[B:.*]])
+define void @gvn_ptr_store(i32 %x, i1 %cond, i32 %a, i32 %b) {
+; CHECK-NOT: handlefromimplicitbinding
+; CHECK:     main:
+; CHECK-NEXT:  %[[C:.*]] = phi i32 [ %a, %entry ], [ %b, %if.then.i ]
+; CHECK-NEXT:  %[[IDX:.*]] = phi i32 [ 0, %entry ], [ 0, %if.then.i ]
+; CHECK-NEXT:  %[[HANDLE:.*]] = tail call target("dx.TypedBuffer", i32, 1, 0, 1) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0_1t(i32 2, i32 0, i32 1, i32 %[[IDX]], ptr nonnull @OutArr.str)
+; CHECK-NEXT:  call void @llvm.dx.resource.store.typedbuffer.tdx.TypedBuffer_i32_1_0_1t.i32(target("dx.TypedBuffer", i32, 1, 0, 1) %[[HANDLE]], i32 %[[C]], i32 %[[X]])
+; CHECK-NEXT:  ret void
+entry:
+  %handle0 = tail call target("dx.TypedBuffer", i32, 1, 0, 1) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0t(i32 2, i32 0, i32 1, i32 0, ptr nonnull @OutArr.str)
+  %ptr0 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0t(target("dx.TypedBuffer", i32, 1, 0, 1) %handle0, i32 %a)
+  br i1 %cond, label %if.then.i, label %main
+
+if.then.i:
+  %handle1 = tail call target("dx.TypedBuffer", i32, 1, 0, 1) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0t(i32 2, i32 0, i32 1, i32 0, ptr nonnull @OutArr.str)
+  %ptr1 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0t(target("dx.TypedBuffer", i32, 1, 0, 1) %handle1, i32 %b)
+  br label %main
+
+main:
+  %ptr = phi ptr [ %ptr0, %entry ], [ %ptr1, %if.then.i ]
+  store i32 %x, ptr %ptr, align 4
+  ret void
+}
+
+; CHECK-LABEL: multiple_use_handle
+; CHECK-SAME:   i32 %[[X:.*]], i1 %[[COND:.*]], i32 %[[A:.*]], i32 %[[B:.*]])
+define void @multiple_use_handle(i32 %x, i1 %cond, i32 %a, i32 %b) {
+;   %3 = call { i32, i1 } @llvm.dx.resource.load.typedbuffer.i32.tdx.TypedBuffer_i32_1_0_1t(target("dx.TypedBuffer", i32, 1, 0, 1) %2, i32 %1)
+;   %4 = extractvalue { i32, i1 } %3, 0
+;   %add = add i32 %4, %x
+;   call void @llvm.dx.resource.store.typedbuffer.tdx.TypedBuffer_i32_1_0_1t.i32(target("dx.TypedBuffer", i32, 1, 0, 1) %handle0, i32 %a, i32 %add)
+;   ret void
+; CHECK:     entry:
+; CHECK-NEXT:  %[[HANDLE0:.*]] = tail call target("dx.TypedBuffer", i32, 1, 0, 1) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0_1t(i32 2, i32 0, i32 1, i32 0, ptr nonnull @OutArr.str)
+; CHECK:     main:
+; CHECK-NEXT:  %[[C:.*]] = phi i32 [ %[[A]], %entry ], [ %[[B]], %if.then.i ]
+; CHECK-NEXT:  %[[IDX:.*]] = phi i32 [ 0, %entry ], [ 0, %if.then.i ]
+; CHECK-NEXT:  %[[HANDLE1:.*]] = tail call target("dx.TypedBuffer", i32, 1, 0, 1) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0_1t(i32 2, i32 0, i32 1, i32 %[[IDX]], ptr nonnull @OutArr.str)
+; CHECK-NEXT:  %[[LOAD:.*]] = call { i32, i1 } @llvm.dx.resource.load.typedbuffer.i32.tdx.TypedBuffer_i32_1_0_1t(target("dx.TypedBuffer", i32, 1, 0, 1) %[[HANDLE1]], i32 %[[C]])
+; CHECK-NEXT:  %[[Y:.*]] = extractvalue { i32, i1 } %[[LOAD]], 0
+; CHECK-NEXT:  %[[ADD:.*]] = add i32 %[[Y]], %[[X]]
+; CHECK-NEXT:  call void @llvm.dx.resource.store.typedbuffer.tdx.TypedBuffer_i32_1_0_1t.i32(target("dx.TypedBuffer", i32, 1, 0, 1) %[[HANDLE0]], i32 %[[A]], i32 %[[ADD]])
+; CHECK-NEXT:  ret void
+entry:
+  %handle0 = tail call target("dx.TypedBuffer", i32, 1, 0, 1) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0t(i32 2, i32 0, i32 1, i32 0, ptr nonnull @OutArr.str)
+  %ptr0 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0t(target("dx.TypedBuffer", i32, 1, 0, 1) %handle0, i32 %a)
+  br i1 %cond, label %if.then.i, label %main
+
+if.then.i:
+  %handle1 = tail call target("dx.TypedBuffer", i32, 1, 0, 1) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0t(i32 2, i32 0, i32 1, i32 0, ptr nonnull @OutArr.str)
+  %ptr1 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0t(target("dx.TypedBuffer", i32, 1, 0, 1) %handle1, i32 %b)
+  br label %main
+
+main:
+  %ptr = phi ptr [ %ptr0, %entry ], [ %ptr1, %if.then.i ]
+  %y = load i32, ptr %ptr, align 4
+  %add = add i32 %y, %x
+  store i32 %add, ptr %ptr0, align 4
+  ret void
+}

--- a/llvm/test/CodeGen/DirectX/ResourceAccess/handle-to-index.ll
+++ b/llvm/test/CodeGen/DirectX/ResourceAccess/handle-to-index.ll
@@ -126,11 +126,6 @@ main:
 ; CHECK-LABEL: multiple_use_handle
 ; CHECK-SAME:   i32 %[[X:.*]], i1 %[[COND:.*]], i32 %[[A:.*]], i32 %[[B:.*]])
 define void @multiple_use_handle(i32 %x, i1 %cond, i32 %a, i32 %b) {
-;   %3 = call { i32, i1 } @llvm.dx.resource.load.typedbuffer.i32.tdx.TypedBuffer_i32_1_0_1t(target("dx.TypedBuffer", i32, 1, 0, 1) %2, i32 %1)
-;   %4 = extractvalue { i32, i1 } %3, 0
-;   %add = add i32 %4, %x
-;   call void @llvm.dx.resource.store.typedbuffer.tdx.TypedBuffer_i32_1_0_1t.i32(target("dx.TypedBuffer", i32, 1, 0, 1) %handle0, i32 %a, i32 %add)
-;   ret void
 ; CHECK:     entry:
 ; CHECK-NEXT:  %[[HANDLE0:.*]] = tail call target("dx.TypedBuffer", i32, 1, 0, 1) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0_1t(i32 2, i32 0, i32 1, i32 0, ptr nonnull @OutArr.str)
 ; CHECK:     main:

--- a/llvm/test/CodeGen/DirectX/ResourceAccess/non-unique.ll
+++ b/llvm/test/CodeGen/DirectX/ResourceAccess/non-unique.ll
@@ -1,6 +1,9 @@
 ; RUN: not opt -S -dxil-resource-access -mtriple=dxil--shadermodel6.3-library %s 2>&1 | FileCheck %s
 
-; CHECK: error: Resource access is not guarenteed to map to a unique global resource
+; CHECK: note: At resource access:  store i32 %7, ptr %8, align 4
+; CHECK: note: Uses resource handle:  %1 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i32_1_0t(i32 0, i32 1, i32 1, i32 0, ptr nonnull @.str.2)
+; CHECK: note: Uses resource handle:  %2 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i32_1_0t(i32 0, i32 2, i32 1, i32 0, ptr nonnull @.str.4)
+; CHECK: error: Resource access is not guaranteed to map to a unique global resource
 
 %__cblayout_c = type <{ i32 }>
 

--- a/llvm/test/CodeGen/DirectX/ResourceAccess/non-unique.ll
+++ b/llvm/test/CodeGen/DirectX/ResourceAccess/non-unique.ll
@@ -1,0 +1,31 @@
+; RUN: not opt -S -dxil-resource-access -mtriple=dxil--shadermodel6.3-library %s 2>&1 | FileCheck %s
+
+; CHECK: error: Resource access is not guarenteed to map to a unique global resource
+
+%__cblayout_c = type <{ i32 }>
+
+@.str = internal unnamed_addr constant [3 x i8] c"In\00", align 1
+@.str.2 = internal unnamed_addr constant [5 x i8] c"Out0\00", align 1
+@.str.4 = internal unnamed_addr constant [5 x i8] c"Out1\00", align 1
+@c.cb = local_unnamed_addr global target("dx.CBuffer", %__cblayout_c) poison
+@c.str = internal unnamed_addr constant [2 x i8] c"c\00", align 1
+
+define void @main() local_unnamed_addr {
+entry:
+  %0 = tail call target("dx.TypedBuffer", i32, 1, 0, 1) @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0_1t(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str)
+  %1 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i32_1_0t(i32 0, i32 1, i32 1, i32 0, ptr nonnull @.str.2)
+  %2 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i32_1_0t(i32 0, i32 2, i32 1, i32 0, ptr nonnull @.str.4)
+  %c.cb_h.i.i = tail call target("dx.CBuffer", %__cblayout_c) @llvm.dx.resource.handlefromimplicitbinding.tdx.CBuffer_s___cblayout_cst(i32 4, i32 0, i32 1, i32 0, ptr nonnull @c.str)
+  store target("dx.CBuffer", %__cblayout_c) %c.cb_h.i.i, ptr @c.cb, align 4
+  %3 = tail call i32 @llvm.dx.flattened.thread.id.in.group()
+  %c.cb = load target("dx.CBuffer", %__cblayout_c), ptr @c.cb, align 4
+  %4 = call ptr addrspace(2) @llvm.dx.resource.getpointer.p2.tdx.CBuffer_s___cblayout_cst(target("dx.CBuffer", %__cblayout_c) %c.cb, i32 0)
+  %5 = load i32, ptr addrspace(2) %4, align 4
+  %loadedv.i = trunc nuw i32 %5 to i1
+  %spec.select = select i1 %loadedv.i, target("dx.RawBuffer", i32, 1, 0) %2, target("dx.RawBuffer", i32, 1, 0) %1
+  %6 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.TypedBuffer_i32_1_0_1t(target("dx.TypedBuffer", i32, 1, 0, 1) %0, i32 %3)
+  %7 = load i32, ptr %6, align 4
+  %8 = tail call noundef nonnull align 4 dereferenceable(4) ptr @llvm.dx.resource.getpointer.p0.tdx.RawBuffer_i32_1_0t(target("dx.RawBuffer", i32, 1, 0) %spec.select, i32 %3)
+  store i32 %7, ptr %8, align 4
+  ret void
+}

--- a/llvm/test/CodeGen/DirectX/ResourceAccess/non-unique.ll
+++ b/llvm/test/CodeGen/DirectX/ResourceAccess/non-unique.ll
@@ -1,5 +1,8 @@
 ; RUN: not opt -S -dxil-resource-access -mtriple=dxil--shadermodel6.3-library %s 2>&1 | FileCheck %s
 
+; Test that a error message is generated for illegal resource accesses that do
+; not access a unique global resource.
+
 ; CHECK: note: At resource access:  store i32 %7, ptr %8, align 4
 ; CHECK: note: Uses resource handle:  %1 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i32_1_0t(i32 0, i32 1, i32 1, i32 0, ptr nonnull @.str.2)
 ; CHECK: note: Uses resource handle:  %2 = tail call target("dx.RawBuffer", i32, 1, 0) @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i32_1_0t(i32 0, i32 2, i32 1, i32 0, ptr nonnull @.str.4)


### PR DESCRIPTION
This change resolves handles (or corresponding ptr) that all point into a unique global resource by propagating an index into that global resource through control flow.

If a unique global resource can't be resolved, an error is reported instead.

This specifically resolves all handles that point into the same global resource array.

Resolves: https://github.com/llvm/llvm-project/issues/165288

By reporting an error, this is part of resolving https://github.com/llvm/llvm-project/issues/179303.