### PR TITLE
[lldb][windows] mitigate a race condition when closing the ConPTY

### DIFF
--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -129,7 +129,10 @@ llvm::Error PseudoConsole::OpenPseudoConsole() {
 }
 
 void PseudoConsole::Close() {
-  Sleep(50);
+  Sleep(50); // FIXME: This mitigates a race condition when closing the
+             // PseudoConsole. It's possible that there is still data in the
+             // pipe when we try to close it. We should wait until the data has
+             // been consumed.
   if (m_conpty_handle != INVALID_HANDLE_VALUE)
     kernel32.ClosePseudoConsole(m_conpty_handle);
   if (m_conpty_input != INVALID_HANDLE_VALUE)

--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -129,6 +129,7 @@ llvm::Error PseudoConsole::OpenPseudoConsole() {
 }
 
 void PseudoConsole::Close() {
+  Sleep(50);
   if (m_conpty_handle != INVALID_HANDLE_VALUE)
     kernel32.ClosePseudoConsole(m_conpty_handle);
   if (m_conpty_input != INVALID_HANDLE_VALUE)


### PR DESCRIPTION
This patch mitigates a race condition when closing the ConPTY of a process on Windows.

This is a temporary solution, I am working on a better one. This would however unlock the [lldb-aarch64-windows](https://lab.llvm.org/buildbot/#/builders/141/builds/15535) bot while still keeping STDIN and STDOUT support in lldb.

The race condition happens because the ConPTY is closed when a process exits, however the data was not fully received yet from the process.
I think the correct solution would be to close the ConPTY when we receive the EOF in `ConnectionGenericFile::Read`.