### PR TITLE
[Hexagon] Fix assert on sign-bit CONST32 immediates

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonConstPropagation.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonConstPropagation.cpp
@@ -1990,7 +1990,8 @@ bool HexagonConstEvaluator::evaluate(const MachineInstr &MI,
         return false;
       IntegerType *Ty = (W == 32) ? Type::getInt32Ty(CX)
                                   : Type::getInt64Ty(CX);
-      const ConstantInt *CI = ConstantInt::get(Ty, V, true);
+      const ConstantInt *CI =
+          ConstantInt::get(Ty, V, /*IsSigned=*/true, /*ImplicitTrunc=*/true);
       LatticeCell RC = Outputs.get(DefR.Reg);
       RC.add(CI);
       Outputs.update(DefR.Reg, RC);

--- a/llvm/test/CodeGen/Hexagon/constp-const32-signbit.mir
+++ b/llvm/test/CodeGen/Hexagon/constp-const32-signbit.mir
@@ -1,0 +1,22 @@
+# RUN: llc -mtriple=hexagon -run-pass hexagon-constp %s -o - | FileCheck %s
+# REQUIRES: asserts
+
+# Check that Hexagon const-prop can handle a sign-bit CONST32 immediate without
+# crashing (e.g. 0x80000000).
+# CHECK: CONST32 {{(-2147483648|2147483648)}}
+
+--- |
+  define void @fred() {
+    ret void
+  }
+...
+
+---
+name: fred
+tracksRegLiveness: true
+body: |
+  bb.0:
+    %0:intregs = IMPLICIT_DEF
+    %1:intregs = CONST32 2147483648
+    S2_storeri_io %0, 0, killed %1
+...


### PR DESCRIPTION
This patch fixes a HexagonConstPropagation assert when evaluating sign-bit CONST32/CONST64 immediates (e.g. 0x80000000) after ConstantInt stopped implicitly truncating, by allowing truncation for that signed case.