### PR TITLE
[offload][lit] Enable/disable tests on Level Zero when using DeviceRTL

### DIFF
--- a/offload/test/api/assert.c
+++ b/offload/test/api/assert.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <assert.h>
 #include <stdio.h>

--- a/offload/test/api/omp_device_managed_memory.c
+++ b/offload/test/api/omp_device_managed_memory.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_device_managed_memory_alloc.c
+++ b/offload/test/api/omp_device_managed_memory_alloc.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_device_memory.c
+++ b/offload/test/api/omp_device_memory.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_device_uid.c
+++ b/offload/test/api/omp_device_uid.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_env_vars.c
+++ b/offload/test/api/omp_env_vars.c
@@ -2,7 +2,6 @@
 // RUN: env OMP_NUM_TEAMS=1 OMP_TEAMS_THREAD_LIMIT=1 LIBOMPTARGET_INFO=16 \
 // RUN:   %libomptarget-run-generic 2>&1 | %fcheck-generic
 // REQUIRES: gpu
-// XFAIL: intelgpu
 
 #define N 256
 

--- a/offload/test/api/omp_get_device_num.c
+++ b/offload/test/api/omp_get_device_num.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_get_num_devices.c
+++ b/offload/test/api/omp_get_num_devices.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_host_call.c
+++ b/offload/test/api/omp_host_call.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/api/omp_host_pinned_memory.c
+++ b/offload/test/api/omp_host_pinned_memory.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_host_pinned_memory_alloc.c
+++ b/offload/test/api/omp_host_pinned_memory_alloc.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/ompx_3d.c
+++ b/offload/test/api/ompx_3d.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <ompx.h>

--- a/offload/test/api/ompx_3d.cpp
+++ b/offload/test/api/ompx_3d.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <ompx.h>

--- a/offload/test/api/ompx_sync.c
+++ b/offload/test/api/ompx_sync.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <ompx.h>

--- a/offload/test/api/ompx_sync.cpp
+++ b/offload/test/api/ompx_sync.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <ompx.h>

--- a/offload/test/env/omp_target_debug.c
+++ b/offload/test/env/omp_target_debug.c
@@ -2,7 +2,6 @@
 // RUN: %libomptarget-compile-generic && env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 | %fcheck-generic -allow-empty -check-prefix=DEBUG
 // RUN: %libomptarget-compile-generic && env LIBOMPTARGET_DEBUG=0 %libomptarget-run-generic 2>&1 | %fcheck-generic -allow-empty -check-prefix=NDEBUG
 // REQUIRES: libomptarget-debug
-// XFAIL: intelgpu
 // clang-format on
 
 int main(void) {

--- a/offload/test/libc/malloc_parallel.c
+++ b/offload/test/libc/malloc_parallel.c
@@ -1,6 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
-// XFAIL: intelgpu
+// REQUIRES: libc
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/libc/malloc_parallel.c
+++ b/offload/test/libc/malloc_parallel.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
-// REQUIRES: libc
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/declare_mapper_target.cpp
+++ b/offload/test/mapping/declare_mapper_target.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <cstdio>
 #include <cstdlib>

--- a/offload/test/mapping/declare_mapper_target_data.cpp
+++ b/offload/test/mapping/declare_mapper_target_data.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <cstdio>
 #include <cstdlib>

--- a/offload/test/mapping/declare_mapper_target_data_enter_exit.cpp
+++ b/offload/test/mapping/declare_mapper_target_data_enter_exit.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <cstdio>
 #include <cstdlib>

--- a/offload/test/mapping/declare_mapper_target_update.cpp
+++ b/offload/test/mapping/declare_mapper_target_update.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <cstdio>
 #include <cstdlib>

--- a/offload/test/mapping/delete_inf_refcount.c
+++ b/offload/test/mapping/delete_inf_refcount.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/firstprivate_aligned.cpp
+++ b/offload/test/mapping/firstprivate_aligned.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compilexx-generic -O3 && %libomptarget-run-generic
-// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/has_device_addr.cpp
+++ b/offload/test/mapping/has_device_addr.cpp
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compilexx-generic -fopenmp-version=51
 // RUN: %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic
-// XFAIL: intelgpu
 
 #include <assert.h>
 #include <iostream>

--- a/offload/test/mapping/is_accessible.cpp
+++ b/offload/test/mapping/is_accessible.cpp
@@ -8,7 +8,6 @@
 
 // REQUIRES: unified_shared_memory
 // XFAIL: nvptx
-// XFAIL: intelgpu
 
 // CHECK: SUCCESS
 // NO_USM: Not accessible

--- a/offload/test/mapping/is_device_ptr.cpp
+++ b/offload/test/mapping/is_device_ptr.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <assert.h>
 #include <iostream>

--- a/offload/test/mapping/lambda_by_value.cpp
+++ b/offload/test/mapping/lambda_by_value.cpp
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compileopt-generic -fno-exceptions
 // RUN: %libomptarget-run-generic 2>&1 | %fcheck-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <stdint.h>
 #include <stdio.h>

--- a/offload/test/mapping/ompx_hold/target.c
+++ b/offload/test/mapping/ompx_hold/target.c
@@ -1,6 +1,5 @@
 // RUN: %libomptarget-compile-generic -fopenmp-extensions
 // RUN: %libomptarget-run-generic | %fcheck-generic -strict-whitespace
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/prelock.cpp
+++ b/offload/test/mapping/prelock.cpp
@@ -4,7 +4,6 @@
 // REQUIRES: gpu
 // UNSUPPORTED: nvidiagpu
 // UNSUPPORTED: amdgpu
-// XFAIL: intelgpu
 
 #include <cstdio>
 

--- a/offload/test/mapping/present/target.c
+++ b/offload/test/mapping/present/target.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-run-fail-generic 2>&1 \
 // RUN: | %fcheck-generic
-// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/present/target_array_extension.c
+++ b/offload/test/mapping/present/target_array_extension.c
@@ -15,7 +15,6 @@
 // RUN:   -DEXTENDS=AFTER
 // RUN: %libomptarget-run-fail-generic 2>&1 \
 // RUN: | %fcheck-generic
-// XFAIL: intelgpu
 
 // END.
 

--- a/offload/test/mapping/present/unified_shared_memory.c
+++ b/offload/test/mapping/present/unified_shared_memory.c
@@ -3,7 +3,6 @@
 // RUN: | %fcheck-generic
 
 // REQUIRES: unified_shared_memory
-// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/present/zero_length_array_section.c
+++ b/offload/test/mapping/present/zero_length_array_section.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-run-fail-generic 2>&1 \
 // RUN: | %fcheck-generic
-// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/private_mapping.c
+++ b/offload/test/mapping/private_mapping.c
@@ -1,6 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // UNSUPPORTED: amdgcn-amd-amdhsa
-// XFAIL: intelgpu
 
 #include <assert.h>
 #include <stdio.h>

--- a/offload/test/mapping/reduction_implicit_map.cpp
+++ b/offload/test/mapping/reduction_implicit_map.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/target_implicit_partial_map.c
+++ b/offload/test/mapping/target_implicit_partial_map.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic
-// XFAIL: intelgpu
 
 // END.
 

--- a/offload/test/mapping/use_device_addr/target_use_device_addr.c
+++ b/offload/test/mapping/use_device_addr/target_use_device_addr.c
@@ -1,7 +1,8 @@
 // RUN: %libomptarget-compile-generic -fopenmp-version=51
 // RUN: %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 int main() {

--- a/offload/test/offloading/assert.cpp
+++ b/offload/test/offloading/assert.cpp
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compilexx-generic && %libomptarget-run-fail-generic
 // RUN: %libomptarget-compileoptxx-generic && %libomptarget-run-fail-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 int main(int argc, char *argv[]) {
 #pragma omp target

--- a/offload/test/offloading/back2back_distribute.c
+++ b/offload/test/offloading/back2back_distribute.c
@@ -1,6 +1,7 @@
 // clang-format off
 // RUN: %libomptarget-compile-generic -O3 && %libomptarget-run-generic | %fcheck-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 // clang-format on
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/bug49334.cpp
+++ b/offload/test/offloading/bug49334.cpp
@@ -8,7 +8,8 @@
 // REQUIRES: gpu
 // UNSUPPORTED: nvidiagpu
 // UNSUPPORTED: amdgpu
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <cassert>
 #include <cmath>

--- a/offload/test/offloading/bug51982.c
+++ b/offload/test/offloading/bug51982.c
@@ -1,7 +1,8 @@
 // RUN: %libomptarget-compile-generic -O2 && %libomptarget-run-generic
 // -O2 to run openmp-opt
 // RUN: %libomptarget-compileopt-generic -O2 && %libomptarget-run-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 int main(void) {
   long int aa = 0;

--- a/offload/test/offloading/bug64959.c
+++ b/offload/test/offloading/bug64959.c
@@ -6,7 +6,6 @@
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/bug64959_compile_only.c
+++ b/offload/test/offloading/bug64959_compile_only.c
@@ -1,6 +1,5 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-compileopt-generic
-// XFAIL: intelgpu
 
 #include <stdio.h>
 #define N 10

--- a/offload/test/offloading/bug74582.c
+++ b/offload/test/offloading/bug74582.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-generic && %libomptarget-run-generic
 // RUN: %libomptarget-compileopt-generic && %libomptarget-run-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 // Verify we do not read bits in the image that are not there (nobits section).
 

--- a/offload/test/offloading/ctor_dtor_api.cpp
+++ b/offload/test/offloading/ctor_dtor_api.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
+// https://github.com/llvm/llvm-project/issues/182119
 // UNSUPPORTED: intelgpu
 
 #include <cstdio>

--- a/offload/test/offloading/ctor_dtor_lazy.cpp
+++ b/offload/test/offloading/ctor_dtor_lazy.cpp
@@ -4,7 +4,8 @@
 // RUN: %not --crash %libomptarget-run-generic
 // RUN: %libomptarget-compilexx-generic -DCTOR_API
 // RUN: %not --crash %libomptarget-run-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <cstdio>
 #include <omp.h>

--- a/offload/test/offloading/dynamic_module.c
+++ b/offload/test/offloading/dynamic_module.c
@@ -5,7 +5,8 @@
 // RUN: %libomptarget-compileopt-generic %t.so && %libomptarget-run-generic 2>&1 | %fcheck-generic
 //
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 // clang-format on
 
 #ifdef SHARED

--- a/offload/test/offloading/dynamic_module_load.c
+++ b/offload/test/offloading/dynamic_module_load.c
@@ -1,6 +1,5 @@
 // clang-format off
 // RUN: %libomptarget-compile-generic -DSHARED -fPIC -shared -o %t.so && %clang %flags %s -o %t -ldl && %libomptarget-run-generic %t.so 2>&1 | %fcheck-generic
-// XFAIL: intelgpu
 // clang-format on
 #ifdef SHARED
 #include <stdio.h>

--- a/offload/test/offloading/high_trip_count_block_limit.cpp
+++ b/offload/test/offloading/high_trip_count_block_limit.cpp
@@ -2,10 +2,11 @@
 // RUN: %libomptarget-compilexx-generic && env LIBOMPTARGET_REUSE_BLOCKS_FOR_HIGH_TRIP_COUNT=False %libomptarget-run-generic 2>&1 | %fcheck-generic
 // RUN: %libomptarget-compilexx-generic && %libomptarget-run-generic 2>&1 | %fcheck-generic --check-prefix=DEFAULT
 
-// UNSUPPORTED: aarch64-unknown-linux-gnu 
-// UNSUPPORTED: x86_64-unknown-linux-gnu 
-// UNSUPPORTED: s390x-ibm-linux-gnu 
-// XFAIL: intelgpu
+// UNSUPPORTED: aarch64-unknown-linux-gnu
+// UNSUPPORTED: x86_64-unknown-linux-gnu
+// UNSUPPORTED: s390x-ibm-linux-gnu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/offloading/looptripcnt.c
+++ b/offload/test/offloading/looptripcnt.c
@@ -1,7 +1,6 @@
 // clang-format off
 // RUN: %libomptarget-compile-generic && env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 | %fcheck-generic -allow-empty -check-prefix=DEBUG
 // REQUIRES: libomptarget-debug
-// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/offloading/malloc.c
+++ b/offload/test/offloading/malloc.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-generic && %libomptarget-run-generic
 // RUN: %libomptarget-compileopt-generic && %libomptarget-run-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/memory_manager.cpp
+++ b/offload/test/offloading/memory_manager.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/offloading/multiple_reductions_simple.c
+++ b/offload/test/offloading/multiple_reductions_simple.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/offloading_success.c
+++ b/offload/test/offloading/offloading_success.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/offloading_success.cpp
+++ b/offload/test/offloading/offloading_success.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/ompx_bare.c
+++ b/offload/test/offloading/ompx_bare.c
@@ -3,7 +3,6 @@
 // RUN:   %fcheck-generic
 //
 // REQUIRES: gpu
-// XFAIL: intelgpu
 
 #include <assert.h>
 #include <ompx.h>

--- a/offload/test/offloading/ompx_coords.c
+++ b/offload/test/offloading/ompx_coords.c
@@ -1,7 +1,8 @@
 // RUN: %libomptarget-compileopt-run-and-check-generic
 //
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <ompx.h>

--- a/offload/test/offloading/ompx_saxpy_mixed.c
+++ b/offload/test/offloading/ompx_saxpy_mixed.c
@@ -1,7 +1,8 @@
 // RUN: %libomptarget-compileopt-run-and-check-generic
 //
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <math.h>
 #include <omp.h>

--- a/offload/test/offloading/parallel_offloading_map.cpp
+++ b/offload/test/offloading/parallel_offloading_map.cpp
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 
 // REQUIRES: gpu
-// XFAIL: intelgpu
 
 #include <cassert>
 #include <iostream>

--- a/offload/test/offloading/parallel_target_teams_reduction.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction.cpp
@@ -3,7 +3,8 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <iostream>
 #include <vector>

--- a/offload/test/offloading/parallel_target_teams_reduction_max.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction_max.cpp
@@ -3,7 +3,8 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 // This test validates that the OpenMP target reductions to find a maximum work
 // as intended for a few common data types.

--- a/offload/test/offloading/parallel_target_teams_reduction_min.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction_min.cpp
@@ -3,7 +3,8 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 // This test validates that the OpenMP target reductions to find a minimum work
 // as intended for a few common data types.

--- a/offload/test/offloading/requires.c
+++ b/offload/test/offloading/requires.c
@@ -1,7 +1,6 @@
 // clang-format off
 // RUN: %libomptarget-compile-generic -DREQ=1 && %libomptarget-run-generic 2>&1 | %fcheck-generic -check-prefix=GOOD
 // RUN: %libomptarget-compile-generic -DREQ=2 && %not --crash %libomptarget-run-generic 2>&1 | %fcheck-generic -check-prefix=BAD
-// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/offloading/small_trip_count.c
+++ b/offload/test/offloading/small_trip_count.c
@@ -6,7 +6,6 @@
 // RUN:   %libomptarget-run-generic 2>&1 | %fcheck-generic --check-prefix=EIGHT
 
 // REQUIRES: gpu
-// XFAIL: intelgpu
 
 #define N 128
 

--- a/offload/test/offloading/small_trip_count_thread_limit.cpp
+++ b/offload/test/offloading/small_trip_count_thread_limit.cpp
@@ -4,7 +4,6 @@
 // RUN:   %libomptarget-run-generic 2>&1 | %fcheck-generic
 
 // REQUIRES: gpu
-// XFAIL: intelgpu
 
 int main(int argc, char *argv[]) {
   constexpr const int block_size = 256;

--- a/offload/test/offloading/spmdization.c
+++ b/offload/test/offloading/spmdization.c
@@ -9,7 +9,8 @@
 // clang-format on
 
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/target-teams-atomic.c
+++ b/offload/test/offloading/target-teams-atomic.c
@@ -3,7 +3,6 @@
 // default.
 
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdbool.h>

--- a/offload/test/offloading/target_constexpr_mapping.cpp
+++ b/offload/test/offloading/target_constexpr_mapping.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/target_critical_region.cpp
+++ b/offload/test/offloading/target_critical_region.cpp
@@ -4,7 +4,8 @@
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 // UNSUPPORTED: amdgcn-amd-amdhsa
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/target_map_for_member_data.cpp
+++ b/offload/test/offloading/target_map_for_member_data.cpp
@@ -3,7 +3,6 @@
 // clang-format on
 
 // REQUIRES: libomptarget-debug
-// XFAIL: intelgpu
 
 struct DataTy {
   float a;

--- a/offload/test/offloading/task_in_reduction_target.c
+++ b/offload/test/offloading/task_in_reduction_target.c
@@ -1,6 +1,5 @@
 // RUN: %libomptarget-compile-generic && \
 // RUN: %libomptarget-run-generic
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/taskloop_offload_nowait.cpp
+++ b/offload/test/offloading/taskloop_offload_nowait.cpp
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compilexx-and-run-generic
 
 // REQUIRES: gpu
-// XFAIL: intelgpu
 
 #include <cmath>
 #include <cstdlib>

--- a/offload/test/offloading/wtime.c
+++ b/offload/test/offloading/wtime.c
@@ -1,7 +1,8 @@
 // RUN: %libomptarget-compileopt-and-run-generic
 
 // UNSUPPORTED: amdgcn-amd-amdhsa
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/ompt/veccopy.c
+++ b/offload/test/ompt/veccopy.c
@@ -2,7 +2,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
-// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_data.c
+++ b/offload/test/ompt/veccopy_data.c
@@ -2,7 +2,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
-// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_disallow_both.c
+++ b/offload/test/ompt/veccopy_disallow_both.c
@@ -2,7 +2,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
-// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_emi.c
+++ b/offload/test/ompt/veccopy_emi.c
@@ -2,7 +2,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
-// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_emi_map.c
+++ b/offload/test/ompt/veccopy_emi_map.c
@@ -2,7 +2,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
-// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_map.c
+++ b/offload/test/ompt/veccopy_map.c
@@ -2,7 +2,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
-// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_no_device_init.c
+++ b/offload/test/ompt/veccopy_no_device_init.c
@@ -1,7 +1,6 @@
 // clang-format off
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
-// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_wrong_return.c
+++ b/offload/test/ompt/veccopy_wrong_return.c
@@ -1,7 +1,6 @@
 // clang-format off
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
-// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/sanitizer/double_free.c
+++ b/offload/test/sanitizer/double_free.c
@@ -8,7 +8,6 @@
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu
-// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/double_free_racy.c
+++ b/offload/test/sanitizer/double_free_racy.c
@@ -8,6 +8,7 @@
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu
+// https://github.com/llvm/llvm-project/issues/182119
 // UNSUPPORTED: intelgpu
 
 #include <omp.h>

--- a/offload/test/sanitizer/free_host_ptr.c
+++ b/offload/test/sanitizer/free_host_ptr.c
@@ -8,7 +8,6 @@
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu
-// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/free_wrong_ptr_kind.c
+++ b/offload/test/sanitizer/free_wrong_ptr_kind.c
@@ -8,7 +8,6 @@
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu
-// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/free_wrong_ptr_kind.cpp
+++ b/offload/test/sanitizer/free_wrong_ptr_kind.cpp
@@ -8,7 +8,6 @@
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu
-// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/ptr_outside_alloc_1.c
+++ b/offload/test/sanitizer/ptr_outside_alloc_1.c
@@ -9,7 +9,8 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/ptr_outside_alloc_2.c
+++ b/offload/test/sanitizer/ptr_outside_alloc_2.c
@@ -7,7 +7,8 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
-// XFAIL: intelgpu
+// https://github.com/llvm/llvm-project/issues/182119
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/unified_shared_memory/close_manual.c
+++ b/offload/test/unified_shared_memory/close_manual.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 
 // REQUIRES: unified_shared_memory
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
Since we can now build the DeviceRTL with SPIR-V, redo the `XFAIL/UNSUPPORTED` specifications for the tests we see passing/failing on the Level Zero backend with the DeviceRTL being used.

The tests marked `UNSUPPORTED` hang or sporadically fail and those are tracked in https://github.com/llvm/llvm-project/issues/182119.

This change will allow us to enable CI testing with the DeviceRTL.

Here are the full test results with this change applied, running only the `spirv64-intel` `check-offload` tests:

```
Total Discovered Tests: 453
  Unsupported      : 206 (45.47%)
  Passed           : 141 (31.13%)
  Expectedly Failed: 106 (23.40%)
```

31% is not a bad start.
