### PR TITLE
[alpha.webkit.UncountedLocalVarsChecker] Handle null Type in CanTriviallyDestruct

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -517,7 +517,8 @@ class TrivialFunctionAnalysisVisitor
   }
 
   bool CanTriviallyDestruct(QualType Ty) {
-    assert(!Ty.isNull());
+    if (Ty.isNull())
+      return false;
 
     // T*, T& or T&& does not run its destructor.
     if (Ty->isPointerOrReferenceType())

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -530,7 +530,7 @@ class TrivialFunctionAnalysisVisitor
 
     if (const auto *R = Ty->getAsCXXRecordDecl()) {
       // C++ trivially destructible classes are fine.
-      if (R->hasTrivialDestructor())
+      if (R->hasDefinition() && R->hasTrivialDestructor())
         return true;
 
       // For Webkit, side-effects are fine as long as we don't delete objects,

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -554,4 +554,19 @@ namespace delete_unresolved_type {
     }
   };
 
+  template <class T>
+  struct helper {
+    static void f(typename T::inner __sp) { }
+  };
+
+  template <class T> struct traits;
+  template <> struct traits<char> {
+    using inner = struct inner;
+  };
+
+  template <typename T>
+  void g(typename T::inner __sp) {
+    helper<traits<char>>::f(__sp);
+  }
+
 }

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -544,3 +544,14 @@ namespace vardecl_in_if_condition {
   }
 
 }
+
+namespace delete_unresolved_type {
+
+  template <class T>
+  struct Foo {
+    static void bar(T& obj) {
+      delete &obj;
+    }
+  };
+
+}


### PR DESCRIPTION
Added an early exit for when CanTriviallyDestruct encounters a QualType without a Type.