### PR TITLE
[SYCL][Driver] Fix #174877 test to be driver-path-agnostic.

### DIFF
--- a/clang/test/Driver/sycl-offload-jit.cpp
+++ b/clang/test/Driver/sycl-offload-jit.cpp
@@ -31,13 +31,13 @@
 
 // Check if path to libsycl.so is passed to clang-linker-wrapper tool by default for SYCL compilation.
 // The test also checks if SYCL header include paths are added to the SYCL host and device compilation.
-// RUN: DRIVER_DIR="$(echo %clang | sed 's|/[^/]*$||; s|.*/||')"
-// RUN: echo DRIVER_DIR=$DRIVER_DIR
+// RUN: CLANG_DIR=%clang_dir
+// RUN: echo CLANG_DIR=$CLANG_DIR
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1    \
-// RUN:   | FileCheck -DDRIVER_DIR=${DRIVER_DIR} -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
-// CHECK-SYCL-HEADERS-DEVICE: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}include"
-// CHECK-SYCL-HEADERS-HOST: "-fsycl-is-host"{{.*}} "-internal-isystem" "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}include"
-// CHECK-LSYCL: clang-linker-wrapper{{.*}} "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}lib{{[/\\]+}}libsycl.so"
+// RUN:   | FileCheck -DCLANG_DIR=${CLANG_DIR} -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
+// CHECK-SYCL-HEADERS-DEVICE: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}[[CLANG_DIR]]{{[/\\]+}}..{{[/\\]+}}include"
+// CHECK-SYCL-HEADERS-HOST: "-fsycl-is-host"{{.*}} "-internal-isystem" "{{.*}}[[CLANG_DIR]]{{[/\\]+}}..{{[/\\]+}}include"
+// CHECK-LSYCL: clang-linker-wrapper{{.*}} "{{.*}}[[CLANG_DIR]]{{[/\\]+}}..{{[/\\]+}}lib{{[/\\]+}}libsycl.so"
 
 /// Check -fsycl-is-device is passed when compiling for the device.
 /// Check -fsycl-is-host is passed when compiling for host.

--- a/clang/test/Driver/sycl-offload-jit.cpp
+++ b/clang/test/Driver/sycl-offload-jit.cpp
@@ -31,7 +31,8 @@
 
 // Check if path to libsycl.so is passed to clang-linker-wrapper tool by default for SYCL compilation.
 // The test also checks if SYCL header include paths are added to the SYCL host and device compilation.
-// RUN: DRIVER_DIR="$(basename $(dirname %clang))"
+// RUN: DRIVER_DIR="$(echo %clang | sed 's|/[^/]*$||; s|.*/||')"
+// RUN: echo DRIVER_DIR=$DRIVER_DIR
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1    \
 // RUN:   | FileCheck -DDRIVER_DIR=${DRIVER_DIR} -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
 // CHECK-SYCL-HEADERS-DEVICE: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}include"

--- a/clang/test/Driver/sycl-offload-jit.cpp
+++ b/clang/test/Driver/sycl-offload-jit.cpp
@@ -32,7 +32,7 @@
 // Check if path to libsycl.so is passed to clang-linker-wrapper tool by default for SYCL compilation.
 // The test also checks if SYCL header include paths are added to the SYCL host and device compilation.
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1    \
-// RUN:   | FileCheck -DDRIVER_DIR=$(basename $(dirname %clang)) -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
+// RUN:   | FileCheck -DDRIVER_DIR="$(basename $(dirname %clang))" -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
 // CHECK-SYCL-HEADERS-DEVICE: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}include"
 // CHECK-SYCL-HEADERS-HOST: "-fsycl-is-host"{{.*}} "-internal-isystem" "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}include"
 // CHECK-LSYCL: clang-linker-wrapper{{.*}} "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}lib{{[/\\]+}}libsycl.so"

--- a/clang/test/Driver/sycl-offload-jit.cpp
+++ b/clang/test/Driver/sycl-offload-jit.cpp
@@ -31,7 +31,7 @@
 
 // Check if path to libsycl.so is passed to clang-linker-wrapper tool by default for SYCL compilation.
 // The test also checks if SYCL header include paths are added to the SYCL host and device compilation.
-// RUN: DRIVER_DIR=$(basename $(dirname %clang))
+// RUN: DRIVER_DIR="$(basename $(dirname %clang))"
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1    \
 // RUN:   | FileCheck -DDRIVER_DIR=${DRIVER_DIR} -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
 // CHECK-SYCL-HEADERS-DEVICE: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}include"

--- a/clang/test/Driver/sycl-offload-jit.cpp
+++ b/clang/test/Driver/sycl-offload-jit.cpp
@@ -31,8 +31,9 @@
 
 // Check if path to libsycl.so is passed to clang-linker-wrapper tool by default for SYCL compilation.
 // The test also checks if SYCL header include paths are added to the SYCL host and device compilation.
+// RUN: DRIVER_DIR=$(basename $(dirname %clang))
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1    \
-// RUN:   | FileCheck -DDRIVER_DIR="$(basename $(dirname %clang))" -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
+// RUN:   | FileCheck -DDRIVER_DIR=${DRIVER_DIR} -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
 // CHECK-SYCL-HEADERS-DEVICE: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}include"
 // CHECK-SYCL-HEADERS-HOST: "-fsycl-is-host"{{.*}} "-internal-isystem" "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}include"
 // CHECK-LSYCL: clang-linker-wrapper{{.*}} "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}lib{{[/\\]+}}libsycl.so"

--- a/clang/test/Driver/sycl-offload-jit.cpp
+++ b/clang/test/Driver/sycl-offload-jit.cpp
@@ -31,11 +31,11 @@
 
 // Check if path to libsycl.so is passed to clang-linker-wrapper tool by default for SYCL compilation.
 // The test also checks if SYCL header include paths are added to the SYCL host and device compilation.
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
-// CHECK-SYCL-HEADERS-DEVICE: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
-// CHECK-SYCL-HEADERS-HOST: "-fsycl-is-host"{{.*}} "-internal-isystem" "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}include"
-// CHECK-LSYCL: clang-linker-wrapper{{.*}} "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}lib{{[/\\]+}}libsycl.so"
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1    \
+// RUN:   | FileCheck -DDRIVER_DIR=$(basename $(dirname %clang)) -check-prefixes=CHECK-LSYCL,CHECK-SYCL-HEADERS-HOST,CHECK-SYCL-HEADERS-DEVICE %s
+// CHECK-SYCL-HEADERS-DEVICE: "-fsycl-is-device"{{.*}} "-internal-isystem" "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}include"
+// CHECK-SYCL-HEADERS-HOST: "-fsycl-is-host"{{.*}} "-internal-isystem" "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}include"
+// CHECK-LSYCL: clang-linker-wrapper{{.*}} "{{.*}}[[DRIVER_DIR]]{{[/\\]+}}..{{[/\\]+}}lib{{[/\\]+}}libsycl.so"
 
 /// Check -fsycl-is-device is passed when compiling for the device.
 /// Check -fsycl-is-host is passed when compiling for host.

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -786,7 +786,7 @@ class LLVMConfig(object):
             ]
             self.add_tool_substitutions(tool_substitutions)
             self.config.substitutions.append(("%resource_dir", builtin_include_dir))
-            self.config.substitutions.append(("%clang_dir", os.path.dirname(self.config.clang))
+            self.config.substitutions.append(("%clang_dir", os.path.dirname(self.config.clang)))
 
         # FIXME: Find nicer way to prohibit this.
         def prefer(this, to):

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -786,7 +786,9 @@ class LLVMConfig(object):
             ]
             self.add_tool_substitutions(tool_substitutions)
             self.config.substitutions.append(("%resource_dir", builtin_include_dir))
-            self.config.substitutions.append(("%clang_dir", os.path.dirname(self.config.clang)))
+            self.config.substitutions.append(
+                ("%clang_dir", os.path.dirname(self.config.clang))
+            )
 
         # FIXME: Find nicer way to prohibit this.
         def prefer(this, to):

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -786,6 +786,7 @@ class LLVMConfig(object):
             ]
             self.add_tool_substitutions(tool_substitutions)
             self.config.substitutions.append(("%resource_dir", builtin_include_dir))
+            self.config.substitutions.append(("%clang_dir", os.path.dirname(self.config.clang))
 
         # FIXME: Find nicer way to prohibit this.
         def prefer(this, to):


### PR DESCRIPTION
The driver path was assumed to end in "bin", but the path is actually dependent on the framework used to run the tests. The change is to extract the relevant piece of the driver path from %clang.