### PR TITLE
[SandboxIR][Region] Replace exit() with reportFatalUsageError()

### DIFF
--- a/llvm/lib/SandboxIR/Region.cpp
+++ b/llvm/lib/SandboxIR/Region.cpp
@@ -174,7 +174,7 @@ Region::createRegionsFromMD(Function &F, TargetTransformInfo &TTI) {
         auto Idx = cast<llvm::ConstantInt>(IdxC)->getSExtValue();
         if (R == nullptr) {
           errs() << "No region specified for Aux: '" << *LLVMI << "'\n";
-          exit(1);
+          reportFatalUsageError("No region specified for Aux!");
         }
         R->setAux(Idx, &Inst);
       }

--- a/llvm/unittests/SandboxIR/RegionTest.cpp
+++ b/llvm/unittests/SandboxIR/RegionTest.cpp
@@ -443,6 +443,8 @@ define void @foo(i8 %v) {
   auto *F = Ctx.createFunction(LLVMF);
   EXPECT_DEATH(sandboxir::Region::createRegionsFromMD(*F, *TTI), "No region.*");
 #endif
+  EXPECT_DEATH(sandboxir::Region::createRegionsFromMD(*F, *TTI),
+               "No region specified for Aux!");
 }
 
 TEST_F(RegionTest, AuxRoundTrip) {


### PR DESCRIPTION
`Region::createRegionsFromMD()` parses the IR and the corresponding metadata and forms one or more Regions. If an instruction is tagged as being part of the "auxiliary" vector of the region, then a check enforces that it should also be part of a region, i.e., it should have both `!sandboxaux` and `!sandboxvec` metadata, not just `!sandboxaux`.

The check used to `exit(1)` after printing an error, but it's better to abort using LLVM's error handling functions. Since the user can write the IR by hand I think it makes sense to report this as a usage error with `reportFatalUsageError()`, and not as an internal error.