### PR TITLE
[include-cleaner] Explicitly ask to define __clang_analyzer__ macro.

### DIFF
--- a/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
+++ b/clang-tools-extra/include-cleaner/tool/IncludeCleaner.cpp
@@ -12,6 +12,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Lex/Preprocessor.h"
+#include "clang/Lex/PreprocessorOptions.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
@@ -147,6 +148,8 @@ private:
     // in-development code.
     CI.getLangOpts().ModulesDeclUse = false;
     CI.getLangOpts().ModulesStrictDeclUse = false;
+    // Explicitly ask to define __clang_analyzer__ macro.
+    CI.getPreprocessorOpts().SetUpStaticAnalyzer = true;
     return true;
   }
 


### PR DESCRIPTION
This is related to issue #178284, but when I read the code it looks to me as if setting `SetUpStaticAnalyzer = true` was simply forgotten here in this particular file, so fixing this wouldn't need to wait for any consensus around how all other cases ought to be handled.