### PR TITLE
[lldb] Update the calling convention of BytecodeSyntheticChildren::Update

### DIFF
--- a/lldb/docs/resources/formatterbytecode.rst
+++ b/lldb/docs/resources/formatterbytecode.rst
@@ -223,7 +223,7 @@ Signature    Mnemonic                Stack Effect
   0x03      ``@get_child_index``      ``(Object+ String -> UInt)``
   0x04      ``@get_child_at_index``   ``(Object+ UInt -> Object)``
   0x05      ``@get_value``            ``(Object+ -> String)``
-  0x06      ``@update``               ``(Object+ -> Object+)``
+  0x06      ``@update``               ``(Object -> Object+)``
 =========  ========================= ==============================
 
 If not specified, the init function defaults to an empty function that just passes the Object along. Its results may be cached and allow common prep work to be done for an Object that can be reused by subsequent calls to the other methods. This way subsequent calls to ``@get_child_at_index`` can avoid recomputing shared information, for example.

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -503,8 +503,16 @@ private:
     llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
   private:
+    /// The data stack representing "self". The value of "self" is the results
+    /// of `init` combined with the results of `update`. Together, these values
+    /// are placed on the stack when calling `num_children`,
+    /// `get_child_at_index`, etc.
+    FormatterBytecode::DataStack GetSelf();
+
+  private:
     const SyntheticBytecodeImplementation &m_impl;
-    FormatterBytecode::DataStack m_self;
+    FormatterBytecode::DataStack m_init_results;
+    FormatterBytecode::DataStack m_update_results;
   };
 
 public:

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -503,16 +503,9 @@ private:
     llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
   private:
-    /// The data stack representing "self". The value of "self" is the results
-    /// of `init` combined with the results of `update`. Together, these values
-    /// are placed on the stack when calling `num_children`,
-    /// `get_child_at_index`, etc.
-    FormatterBytecode::DataStack GetSelf();
-
-  private:
     const SyntheticBytecodeImplementation &m_impl;
     FormatterBytecode::DataStack m_init_results;
-    FormatterBytecode::DataStack m_update_results;
+    FormatterBytecode::DataStack m_self;
   };
 
 public:

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -260,11 +260,13 @@ std::string ScriptedSyntheticChildren::GetDescription() {
 BytecodeSyntheticChildren::FrontEnd::FrontEnd(
     ValueObject &backend, SyntheticBytecodeImplementation &impl)
     : SyntheticChildrenFrontEnd(backend), m_impl(impl) {
-  if (!m_impl.init)
+  FormatterBytecode::DataStack data = {backend.GetSP()};
+  if (!m_impl.init) {
+    m_init_results = std::move(data);
     return;
+  }
 
   FormatterBytecode::ControlStack control = {m_impl.init->getBuffer()};
-  FormatterBytecode::DataStack data = {backend.GetSP()};
   llvm::Error error =
       FormatterBytecode::Interpret(control, data, FormatterBytecode::sig_init);
   if (error) {
@@ -279,10 +281,10 @@ BytecodeSyntheticChildren::FrontEnd::FrontEnd(
 
 lldb::ChildCacheState BytecodeSyntheticChildren::FrontEnd::Update() {
   if (!m_impl.update)
-    return ChildCacheState::eRefetch;
+    return ChildCacheState::eReuse;
 
   FormatterBytecode::ControlStack control = {m_impl.update->getBuffer()};
-  FormatterBytecode::DataStack data = {m_backend.GetSP()};
+  FormatterBytecode::DataStack data = m_init_results;
   llvm::Error error = FormatterBytecode::Interpret(
       control, data, FormatterBytecode::sig_update);
   if (error) {

--- a/lldb/source/DataFormatters/TypeSynthetic.cpp
+++ b/lldb/source/DataFormatters/TypeSynthetic.cpp
@@ -20,10 +20,8 @@
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/StreamString.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
-#include <iterator>
 
 using namespace lldb;
 using namespace lldb_private;
@@ -294,7 +292,7 @@ lldb::ChildCacheState BytecodeSyntheticChildren::FrontEnd::Update() {
   }
 
   if (data.size() > 0)
-    m_update_results = std::move(data);
+    m_self = std::move(data);
 
   return ChildCacheState::eRefetch;
 }
@@ -305,7 +303,7 @@ BytecodeSyntheticChildren::FrontEnd::CalculateNumChildren() {
     return 0;
 
   FormatterBytecode::ControlStack control = {m_impl.num_children->getBuffer()};
-  FormatterBytecode::DataStack data = GetSelf();
+  FormatterBytecode::DataStack data = m_self;
   llvm::Error error = FormatterBytecode::Interpret(
       control, data, FormatterBytecode::sig_get_num_children);
   if (error)
@@ -337,7 +335,7 @@ BytecodeSyntheticChildren::FrontEnd::GetChildAtIndex(uint32_t idx) {
 
   FormatterBytecode::ControlStack control = {
       m_impl.get_child_at_index->getBuffer()};
-  FormatterBytecode::DataStack data = GetSelf();
+  FormatterBytecode::DataStack data = m_self;
   data.emplace_back((uint64_t)idx);
   llvm::Error error = FormatterBytecode::Interpret(
       control, data, FormatterBytecode::sig_get_child_at_index);
@@ -367,7 +365,7 @@ BytecodeSyntheticChildren::FrontEnd::GetIndexOfChildWithName(ConstString name) {
 
   FormatterBytecode::ControlStack control = {
       m_impl.get_child_index->getBuffer()};
-  FormatterBytecode::DataStack data = GetSelf();
+  FormatterBytecode::DataStack data = m_self;
   data.emplace_back(name.GetString());
   llvm::Error error = FormatterBytecode::Interpret(
       control, data, FormatterBytecode::sig_get_child_index);
@@ -391,16 +389,6 @@ BytecodeSyntheticChildren::FrontEnd::GetIndexOfChildWithName(ConstString name) {
   }
 
   return llvm::createStringError("@get_child_index returned invalid value");
-}
-
-FormatterBytecode::DataStack BytecodeSyntheticChildren::FrontEnd::GetSelf() {
-  FormatterBytecode::DataStack self;
-  llvm::copy(m_init_results, std::back_inserter(self));
-  llvm::copy(m_update_results, std::back_inserter(self));
-  if (self.empty())
-    // As a fallback, "self" is just the valobj.
-    self.emplace_back(m_backend.GetSP());
-  return self;
 }
 
 std::string BytecodeSyntheticChildren::GetDescription() {


### PR DESCRIPTION
This changes the inputs to `update`. It's now the data stack that was the result of `@init`. This makes `update` more predictable, as its inputs are the same between the first call and the Nth call.