### PR TITLE
[libc][math] Refactor dsub family to header-only

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -94,6 +94,8 @@
 #include "math/dmulf128.h"
 #include "math/dmull.h"
 #include "math/dsqrtl.h"
+#include "math/dsubf128.h"
+#include "math/dsubl.h"
 #include "math/erfcf16.h"
 #include "math/erff.h"
 #include "math/erff16.h"

--- a/libc/shared/math/dsubf128.h
+++ b/libc/shared/math/dsubf128.h
@@ -1,0 +1,29 @@
+//===-- Shared dsubf128 function --------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_MATH_DSUBF128_H
+#define LLVM_LIBC_SHARED_MATH_DSUBF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "shared/libc_common.h"
+#include "src/__support/math/dsubf128.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using math::dsubf128;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SHARED_MATH_DSUBF128_H

--- a/libc/shared/math/dsubl.h
+++ b/libc/shared/math/dsubl.h
@@ -1,4 +1,4 @@
-//===-- Implementation of dsubl function ----------------------------------===//
+//===-- Shared dsubl function -----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,13 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/dsubl.h"
+#ifndef LLVM_LIBC_SHARED_MATH_DSUBL_H
+#define LLVM_LIBC_SHARED_MATH_DSUBL_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/dsubl.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(double, dsubl, (long double x, long double y)) {
-  return math::dsubl(x, y);
-}
+using math::dsubl;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_DSUBL_H

--- a/libc/src/__support/FPUtil/generic/FMA.h
+++ b/libc/src/__support/FPUtil/generic/FMA.h
@@ -275,7 +275,7 @@ fma(InType x, InType y, InType z) {
   if (prod_mant == 0) {
     // When there is exact cancellation, i.e., x*y == -z exactly, return -0.0 if
     // rounding downward and +0.0 for other rounding modes.
-    if (quick_get_round() == FE_DOWNWARD)
+    if (fputil::quick_get_round() == FE_DOWNWARD)
       prod_sign = Sign::NEG;
     else
       prod_sign = Sign::POS;

--- a/libc/src/__support/FPUtil/generic/add_sub.h
+++ b/libc/src/__support/FPUtil/generic/add_sub.h
@@ -98,7 +98,7 @@ add_or_sub(InType x, InType y) {
       if (y_bits.is_zero()) {
         if (is_effectively_add)
           return OutFPBits::zero(x_bits.sign()).get_val();
-        switch (quick_get_round()) {
+        switch (fputil::quick_get_round()) {
         case FE_DOWNWARD:
           return OutFPBits::zero(Sign::NEG).get_val();
         default:
@@ -132,7 +132,7 @@ add_or_sub(InType x, InType y) {
   InType y_abs = y_bits.abs().get_val();
 
   if (x_abs == y_abs && !is_effectively_add) {
-    switch (quick_get_round()) {
+    switch (fputil::quick_get_round()) {
     case FE_DOWNWARD:
       return OutFPBits::zero(Sign::NEG).get_val();
     default:

--- a/libc/src/__support/FPUtil/rounding_mode.h
+++ b/libc/src/__support/FPUtil/rounding_mode.h
@@ -66,8 +66,8 @@ LIBC_INLINE bool fenv_is_round_to_zero() {
 }
 
 // Quick free standing get rounding mode based on the above observations.
-LIBC_INLINE constexpr int quick_get_round() {
-  constexpr float x = 0x1.0p-24f;
+LIBC_INLINE int quick_get_round() {
+  static volatile float x = 0x1.0p-24f;
   float y = x;
   float z = (0x1.000002p0f + y) + (-1.0f - y);
 

--- a/libc/src/__support/FPUtil/rounding_mode.h
+++ b/libc/src/__support/FPUtil/rounding_mode.h
@@ -66,8 +66,8 @@ LIBC_INLINE bool fenv_is_round_to_zero() {
 }
 
 // Quick free standing get rounding mode based on the above observations.
-LIBC_INLINE int quick_get_round() {
-  static volatile float x = 0x1.0p-24f;
+LIBC_INLINE constexpr int quick_get_round() {
+  constexpr float x = 0x1.0p-24f;
   float y = x;
   float z = (0x1.000002p0f + y) + (-1.0f - y);
 

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1071,6 +1071,25 @@ add_header_library(
 )
 
 add_header_library(
+  dsubf128
+  HDRS
+    dsubf128.h
+  DEPENDS
+    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.generic.add_sub
+    libc.src.__support.macros.config
+)
+
+add_header_library(
+  dsubl
+  HDRS
+    dsubl.h
+  DEPENDS
+    libc.src.__support.FPUtil.generic.add_sub
+    libc.src.__support.macros.config
+)
+
+add_header_library(
   exp10m1f
   HDRS
     exp10m1f.h

--- a/libc/src/__support/math/dsubf128.h
+++ b/libc/src/__support/math/dsubf128.h
@@ -1,0 +1,31 @@
+//===-- Implementation header for dsubf128 ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_DSUBF128_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_DSUBF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "src/__support/FPUtil/generic/add_sub.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace math {
+
+LIBC_INLINE double dsubf128(float128 x, float128 y) {
+  return fputil::generic::sub<double>(x, y);
+}
+
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_DSUBF128_H

--- a/libc/src/__support/math/dsubf128.h
+++ b/libc/src/__support/math/dsubf128.h
@@ -19,7 +19,7 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE constexpr double dsubf128(float128 x, float128 y) {
+LIBC_INLINE double dsubf128(float128 x, float128 y) {
   return fputil::generic::sub<double>(x, y);
 }
 

--- a/libc/src/__support/math/dsubf128.h
+++ b/libc/src/__support/math/dsubf128.h
@@ -19,7 +19,7 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE double dsubf128(float128 x, float128 y) {
+LIBC_INLINE constexpr double dsubf128(float128 x, float128 y) {
   return fputil::generic::sub<double>(x, y);
 }
 

--- a/libc/src/__support/math/dsubl.h
+++ b/libc/src/__support/math/dsubl.h
@@ -1,0 +1,25 @@
+//===-- Implementation header for dsubl -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_DSUBL_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_DSUBL_H
+
+#include "src/__support/FPUtil/generic/add_sub.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace math {
+
+LIBC_INLINE double dsubl(long double x, long double y) {
+  return fputil::generic::sub<double>(x, y);
+}
+
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_DSUBL_H

--- a/libc/src/__support/math/dsubl.h
+++ b/libc/src/__support/math/dsubl.h
@@ -15,7 +15,7 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE double dsubl(long double x, long double y) {
+LIBC_INLINE constexpr double dsubl(long double x, long double y) {
   return fputil::generic::sub<double>(x, y);
 }
 

--- a/libc/src/__support/math/dsubl.h
+++ b/libc/src/__support/math/dsubl.h
@@ -15,7 +15,7 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace math {
 
-LIBC_INLINE constexpr double dsubl(long double x, long double y) {
+LIBC_INLINE double dsubl(long double x, long double y) {
   return fputil::generic::sub<double>(x, y);
 }
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -267,8 +267,7 @@ add_entrypoint_object(
   HDRS
     ../dsubf128.h
   DEPENDS
-    libc.src.__support.FPUtil.generic.add_sub
-    libc.src.__support.macros.properties.types
+    libc.src.__support.math.dsubf128
 )
 
 add_entrypoint_object(
@@ -278,7 +277,7 @@ add_entrypoint_object(
   HDRS
     ../dsubl.h
   DEPENDS
-    libc.src.__support.FPUtil.generic.add_sub
+    libc.src.__support.math.dsubl
 )
 
 add_entrypoint_object(

--- a/libc/src/math/generic/dsubf128.cpp
+++ b/libc/src/math/generic/dsubf128.cpp
@@ -7,14 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/dsubf128.h"
-#include "src/__support/FPUtil/generic/add_sub.h"
-#include "src/__support/common.h"
-#include "src/__support/macros/config.h"
+#include "src/__support/math/dsubf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(double, dsubf128, (float128 x, float128 y)) {
-  return fputil::generic::sub<double>(x, y);
+  return math::dsubf128(x, y);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -91,6 +91,8 @@ add_fp_unittest(
     libc.src.__support.math.dmulf128
     libc.src.__support.math.dmull
     libc.src.__support.math.dsqrtl
+    libc.src.__support.math.dsubf128
+    libc.src.__support.math.dsubl
     libc.src.__support.math.exp10m1f
     libc.src.__support.math.exp10m1f16
     libc.src.__support.math.erfcf16

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -306,6 +306,8 @@ add_fp_unittest(
     libc.src.__support.math.ddivl
     libc.src.__support.math.dmulf128
     libc.src.__support.math.dmull
+    libc.src.__support.math.dsubf128
+    libc.src.__support.math.dsubl
     libc.src.__support.math.floor
     libc.src.__support.math.floorbf16
     libc.src.__support.math.floorf

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -306,8 +306,6 @@ add_fp_unittest(
     libc.src.__support.math.ddivl
     libc.src.__support.math.dmulf128
     libc.src.__support.math.dmull
-    libc.src.__support.math.dsubf128
-    libc.src.__support.math.dsubl
     libc.src.__support.math.floor
     libc.src.__support.math.floorbf16
     libc.src.__support.math.floorf

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -56,8 +56,6 @@ static_assert(0.0 == LIBC_NAMESPACE::shared::ddivl(0.0L, 1.0L));
 static_assert(0.0 == LIBC_NAMESPACE::shared::dmull(0.0L, 1.0L));
 static_assert(1.0L == LIBC_NAMESPACE::shared::fabsl(-1.0L));
 static_assert(0.0L == LIBC_NAMESPACE::shared::floorl(0.0L));
-static_assert(0.0 ==
-              LIBC_NAMESPACE::shared::dsubl(0.0L, 0.0L));
 
 #endif
 
@@ -79,8 +77,6 @@ static_assert(0.0 ==
               LIBC_NAMESPACE::shared::dmulf128(float128(0.0), float128(1.0)));
 static_assert(float128(0.0) ==
               LIBC_NAMESPACE::shared::floorf128(float128(0.0)));
-static_assert(0.0 ==
-              LIBC_NAMESPACE::shared::dsubf128(float128(0.0), float128(0.0)));
 
 #endif // LIBC_TYPES_HAS_FLOAT128
 

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -56,6 +56,8 @@ static_assert(0.0 == LIBC_NAMESPACE::shared::ddivl(0.0L, 1.0L));
 static_assert(0.0 == LIBC_NAMESPACE::shared::dmull(0.0L, 1.0L));
 static_assert(1.0L == LIBC_NAMESPACE::shared::fabsl(-1.0L));
 static_assert(0.0L == LIBC_NAMESPACE::shared::floorl(0.0L));
+static_assert(0.0 ==
+              LIBC_NAMESPACE::shared::dsubl(0.0L, 0.0L));
 
 #endif
 
@@ -77,6 +79,8 @@ static_assert(0.0 ==
               LIBC_NAMESPACE::shared::dmulf128(float128(0.0), float128(1.0)));
 static_assert(float128(0.0) ==
               LIBC_NAMESPACE::shared::floorf128(float128(0.0)));
+static_assert(0.0 ==
+              LIBC_NAMESPACE::shared::dsubf128(float128(0.0), float128(0.0)));
 
 #endif // LIBC_TYPES_HAS_FLOAT128
 

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -325,6 +325,7 @@ TEST(LlvmLibcSharedMathTest, AllLongDouble) {
   EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::daddl(0.0L, 0.0L));
   EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::shared::ddivl(1.0L, 1.0L));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::dmull(0.0L, 0.0L));
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::dsubl(0.0L, 0.0L));
   EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::fabsl(0.0L));
   EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::faddl(0.0L, 0.0L));
   EXPECT_FP_EQ(0.0L, LIBC_NAMESPACE::shared::fdiml(0.0L, 0.0L));
@@ -413,6 +414,8 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                LIBC_NAMESPACE::shared::ddivf128(float128(1.0), float128(1.0)));
   EXPECT_FP_EQ(0.0,
                LIBC_NAMESPACE::shared::dmulf128(float128(0.0), float128(0.0)));
+  EXPECT_FP_EQ(0.0,
+               LIBC_NAMESPACE::shared::dsubf128(float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(float128(0.0), LIBC_NAMESPACE::shared::fabsf128(float128(0.0)));
   EXPECT_FP_EQ(float128(0.0),
                LIBC_NAMESPACE::shared::faddf128(float128(0.0), float128(0.0)));

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4113,6 +4113,25 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_dsubf128",
+    hdrs = ["src/__support/math/dsubf128.h"],
+    deps = [
+        ":__support_fputil_basic_operations",
+        ":__support_macros_config",
+        ":llvm_libc_types_float128",
+    ],
+)
+
+libc_support_library(
+    name = "__support_math_dsubl",
+    hdrs = ["src/__support/math/dsubl.h"],
+    deps = [
+        ":__support_fputil_basic_operations",
+        ":__support_macros_config",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_exp10m1f",
     hdrs = ["src/__support/math/exp10m1f.h"],
     deps = [
@@ -7297,10 +7316,18 @@ libc_math_function(
     ],
 )
 
-libc_math_function(name = "dsubl")
+libc_math_function(
+    name = "dsubl",
+    additional_deps = [
+        ":__support_math_dsubl",
+    ],
+)
 
 libc_math_function(
     name = "dsubf128",
+    additional_deps = [
+        ":__support_math_dsubf128",
+    ],
 )
 
 libc_math_function(


### PR DESCRIPTION
Refactors the dsub math family to be header-only.

Closes https://github.com/llvm/llvm-project/issues/182159

Target Functions:
  - dsubf128
  - dsubl