### PR TITLE
[SPIRV] Add Intermediate cast when Vector From/To types are of different element size and type

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -67,9 +67,35 @@ class SPIRVLegalizePointerCast : public FunctionPass {
     GR->addAssignPtrTypeInstr(Arg, AssignCI);
   }
 
+  static FixedVectorType *makeVectorFromTotalBits(Type *ElemTy,
+                                                  TypeSize TotalBits) {
+    unsigned ElemBits = ElemTy->getScalarSizeInBits();
+    assert(ElemBits && TotalBits % ElemBits == 0 &&
+           "TotalBits must be divisible by element bit size");
+    return FixedVectorType::get(ElemTy, TotalBits / ElemBits);
+  }
+
+  Value *resizeVectorBitsWithShuffle(IRBuilder<> &B, Value *V,
+                                     FixedVectorType *DstTy) {
+    auto *SrcTy = cast<FixedVectorType>(V->getType());
+    assert(SrcTy->getElementType() == DstTy->getElementType() &&
+           "shuffle resize expects identical element types");
+
+    const unsigned NumNeeded = DstTy->getNumElements();
+    const unsigned NumSource = SrcTy->getNumElements();
+
+    SmallVector<int> Mask(NumNeeded);
+    for (unsigned I = 0; I < NumNeeded; ++I)
+      Mask[I] = (I < NumSource) ? static_cast<int>(I) : -1;
+
+    Value *Resized = B.CreateShuffleVector(V, V, Mask);
+    buildAssignType(B, DstTy, Resized);
+    return Resized;
+  }
+
   // Loads parts of the vector of type |SourceType| from the pointer |Source|
   // and create a new vector of type |TargetType|. |TargetType| must be a vector
-  // type, and element types of |TargetType| and |SourceType| must match.
+  // type.
   // Returns the loaded value.
   Value *loadVectorFromVector(IRBuilder<> &B, FixedVectorType *SourceType,
                               FixedVectorType *TargetType, Value *Source) {
@@ -80,46 +106,36 @@ class SPIRVLegalizePointerCast : public FunctionPass {
       const DataLayout &DL = B.GetInsertBlock()->getModule()->getDataLayout();
       TypeSize TargetTypeSize = DL.getTypeSizeInBits(TargetType);
       TypeSize SourceTypeSize = DL.getTypeSizeInBits(SourceType);
-      // Bitcast to a same-bitwidth vector with TargetType's element type.
-      // When sizes differ, use an intermediate type to preserve bitwidth.
-      FixedVectorType *BitcastType = TargetType;
+
+      Value *BitcastSrcVal = NewLoad;
+      FixedVectorType *BitcastSrcTy =
+          cast<FixedVectorType>(BitcastSrcVal->getType());
+      FixedVectorType *BitcastDstTy = TargetType;
+
       if (TargetTypeSize != SourceTypeSize) {
-        unsigned ElemBits = TargetType->getElementType()->getScalarSizeInBits();
-        if (SourceTypeSize % ElemBits == 0) {
-          BitcastType = FixedVectorType::get(TargetType->getElementType(),
-                                             SourceTypeSize / ElemBits);
+        unsigned TargetElemBits =
+            TargetType->getElementType()->getScalarSizeInBits();
+        if (SourceTypeSize % TargetElemBits == 0) {
+          // No Resize needed. Same total bits as source, but use target element
+          // type.
+          BitcastDstTy = makeVectorFromTotalBits(TargetType->getElementType(),
+                                                 SourceTypeSize);
         } else {
-          // Source total bits aren't evenly divisible by target element bits.
-          // Resize source (extract or pad) to match target bit width using
-          // source element type, then bitcast to target.
-          unsigned SourceElemBits =
-              SourceType->getElementType()->getScalarSizeInBits();
-          assert(TargetTypeSize % SourceElemBits == 0 &&
-                 "Target size must be a multiple of source element size");
-          unsigned NumNeeded = TargetTypeSize / SourceElemBits;
-          unsigned NumSource = SourceType->getNumElements();
-          auto *ResizedType =
-              FixedVectorType::get(SourceType->getElementType(), NumNeeded);
-          SmallVector<int> Mask(NumNeeded);
-          for (unsigned I = 0; I < NumNeeded; ++I)
-            Mask[I] = (I < NumSource) ? static_cast<int>(I) : -1;
-          Value *Resized = B.CreateShuffleVector(NewLoad, NewLoad, Mask);
-          buildAssignType(B, ResizedType, Resized);
-          AssignValue = B.CreateIntrinsic(Intrinsic::spv_bitcast,
-                                          {TargetType, ResizedType}, {Resized});
-          buildAssignType(B, TargetType, AssignValue);
-          return AssignValue;
+          // Resize source to target total bitwidth using source element type.
+          BitcastSrcTy = makeVectorFromTotalBits(SourceType->getElementType(),
+                                                 TargetTypeSize);
+          BitcastSrcVal = resizeVectorBitsWithShuffle(B, NewLoad, BitcastSrcTy);
         }
       }
-      AssignValue = B.CreateIntrinsic(Intrinsic::spv_bitcast,
-                                      {BitcastType, SourceType}, {NewLoad});
-      buildAssignType(B, BitcastType, AssignValue);
-      if (BitcastType == TargetType)
+      AssignValue =
+          B.CreateIntrinsic(Intrinsic::spv_bitcast,
+                            {BitcastDstTy, BitcastSrcTy}, {BitcastSrcVal});
+      buildAssignType(B, BitcastDstTy, AssignValue);
+      if (BitcastDstTy == TargetType)
         return AssignValue;
     }
 
-    assert(TargetType->getNumElements() <
-           cast<FixedVectorType>(AssignValue->getType())->getNumElements());
+    assert(TargetType->getNumElements() < SourceType->getNumElements());
     SmallVector<int> Mask(/* Size= */ TargetType->getNumElements());
     for (unsigned I = 0; I < TargetType->getNumElements(); ++I)
       Mask[I] = I;

--- a/llvm/test/CodeGen/SPIRV/pointers/ptrcast-bitcast.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/ptrcast-bitcast.ll
@@ -8,6 +8,9 @@
 ; CHECK-DAG:   %[[#v2_double:]] = OpTypeVector %[[#double]] 2
 ; CHECK-DAG:    %[[#v4_float:]] = OpTypeVector %[[#float]] 4
 ; CHECK-DAG:     %[[#v4_uint:]] = OpTypeVector %[[#uint]] 4
+; CHECK-DAG:       %[[#ulong:]] = OpTypeInt 64 0
+; CHECK-DAG:    %[[#v2_ulong:]] = OpTypeVector %[[#ulong]] 2
+; CHECK-DAG:     %[[#v3_uint:]] = OpTypeVector %[[#uint]] 3
 @.str = private unnamed_addr constant [3 x i8] c"In\00", align 1
 @.str.2 = private unnamed_addr constant [4 x i8] c"Out\00", align 1
 
@@ -49,8 +52,8 @@ entry:
   ret void
 }
 
-@.str.3 = private unnamed_addr constant [3 x i8] c"In\00", align 1
-@.str.4 = private unnamed_addr constant [4 x i8] c"Out\00", align 1
+@.str.3 = private unnamed_addr constant [4 x i8] c"In2\00", align 1
+@.str.4 = private unnamed_addr constant [5 x i8] c"Out2\00", align 1
 
 define void @main3() local_unnamed_addr #0 {
 entry:
@@ -59,12 +62,34 @@ entry:
 ; CHECK-NEXT:  %[[SHUFFLE3:[0-9]+]] = OpVectorShuffle %[[#v2_uint]] %[[BITCAST3]] %[[BITCAST3]] 0 1
 ; CHECK:       OpStore {{%[0-9]+}} %[[SHUFFLE3]] {{.*}}
 
-  %0 = tail call target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f32_12_0t(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str.3)
-  %1 = tail call target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v2i32_12_0t(i32 0, i32 1, i32 1, i32 0, ptr nonnull @.str.4)
+  %0 = tail call target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f32_12_0t(i32 1, i32 0, i32 1, i32 0, ptr nonnull @.str.3)
+  %1 = tail call target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v2i32_12_0t(i32 1, i32 1, i32 1, i32 0, ptr nonnull @.str.4)
   %2 = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f32_12_0t(target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 0) %0, i32 0)
   %3 = load <2 x i32>, ptr addrspace(11) %2, align 16
   %4 = tail call noundef align 8 dereferenceable(8) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v2i32_12_0t(target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) %1, i32 0)
   store <2 x i32> %3, ptr addrspace(11) %4, align 8
+  ret void
+}
+
+; Tests loading a vector where the source total bit width is not evenly
+; divisible by the target element bit width.
+
+@.str.in = private unnamed_addr constant [4 x i8] c"In3\00", align 1
+@.str.out = private unnamed_addr constant [5 x i8] c"Out3\00", align 1
+
+define void @main4() local_unnamed_addr #0 {
+entry:
+; CHECK:       %[[LOAD:[0-9]+]] = OpLoad %[[#v3_uint]] {{.*}}
+; CHECK-NEXT:  %[[SHUFFLE:[0-9]+]] = OpVectorShuffle %[[#v4_uint]] %[[LOAD]] %[[LOAD]] 0 1 2 0xFFFFFFFF{{.*}}
+; CHECK-NEXT:  %[[BITCAST:[0-9]+]] = OpBitcast %[[#v2_ulong]] %[[SHUFFLE]]{{.*}}
+; CHECK:       OpStore {{%[0-9]+}} %[[BITCAST]] {{.*}}
+
+  %0 = tail call target("spirv.VulkanBuffer", [0 x <3 x i32>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v3i32_12_0t(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str.in)
+  %1 = tail call target("spirv.VulkanBuffer", [0 x <2 x i64>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v1i64_12_0t(i32 0, i32 1, i32 1, i32 0, ptr nonnull @.str.out)
+  %2 = tail call noundef align 16 dereferenceable(12) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v3i32_12_0t(target("spirv.VulkanBuffer", [0 x <3 x i32>], 12, 0) %0, i32 0)
+  %3 = load <2 x i64>, ptr addrspace(11) %2, align 16
+  %4 = tail call noundef align 8 dereferenceable(8) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v1i64_12_0t(target("spirv.VulkanBuffer", [0 x <2 x i64>], 12, 0) %1, i32 0)
+  store <2 x i64> %3, ptr addrspace(11) %4, align 8
   ret void
 }
 

--- a/llvm/test/CodeGen/SPIRV/pointers/ptrcast-bitcast.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/ptrcast-bitcast.ll
@@ -1,10 +1,12 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s --match-full-lines
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
 
+; CHECK-DAG:       %[[#float:]] = OpTypeFloat 32
 ; CHECK-DAG:        %[[#uint:]] = OpTypeInt 32 0
 ; CHECK-DAG:     %[[#v2_uint:]] = OpTypeVector %[[#uint]] 2
 ; CHECK-DAG:      %[[#double:]] = OpTypeFloat 64
 ; CHECK-DAG:   %[[#v2_double:]] = OpTypeVector %[[#double]] 2
+; CHECK-DAG:    %[[#v4_float:]] = OpTypeVector %[[#float]] 4
 ; CHECK-DAG:     %[[#v4_uint:]] = OpTypeVector %[[#uint]] 4
 @.str = private unnamed_addr constant [3 x i8] c"In\00", align 1
 @.str.2 = private unnamed_addr constant [4 x i8] c"Out\00", align 1
@@ -44,6 +46,25 @@ entry:
   %3 = load <4 x i32>, ptr addrspace(11) %2
   %4 = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v2f64_12_1t(target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) %0, i32 1)
   store <4 x i32> %3, ptr addrspace(11) %4
+  ret void
+}
+
+@.str.3 = private unnamed_addr constant [3 x i8] c"In\00", align 1
+@.str.4 = private unnamed_addr constant [4 x i8] c"Out\00", align 1
+
+define void @main3() local_unnamed_addr #0 {
+entry:
+; CHECK:       %[[LOAD3:[0-9]+]] = OpLoad %[[#v4_float]] {{.*}}
+; CHECK-NEXT:  %[[BITCAST3:[0-9]+]] = OpBitcast %[[#v4_uint]] %[[LOAD3]]
+; CHECK-NEXT:  %[[SHUFFLE3:[0-9]+]] = OpVectorShuffle %[[#v2_uint]] %[[BITCAST3]] %[[BITCAST3]] 0 1
+; CHECK:       OpStore {{%[0-9]+}} %[[SHUFFLE3]] {{.*}}
+
+  %0 = tail call target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f32_12_0t(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str.3)
+  %1 = tail call target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v2i32_12_0t(i32 0, i32 1, i32 1, i32 0, ptr nonnull @.str.4)
+  %2 = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f32_12_0t(target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 0) %0, i32 0)
+  %3 = load <2 x i32>, ptr addrspace(11) %2, align 16
+  %4 = tail call noundef align 8 dereferenceable(8) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v2i32_12_0t(target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) %1, i32 0)
+  store <2 x i32> %3, ptr addrspace(11) %4, align 8
   ret void
 }
 

--- a/llvm/test/CodeGen/SPIRV/pointers/ptrcast-bitcast.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/ptrcast-bitcast.ll
@@ -16,19 +16,19 @@
 
 define void @main() local_unnamed_addr #0 {
 entry:
-  %0 = tail call target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v2i32_12_0t(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str)
-  %1 = tail call target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v2f64_12_1t(i32 0, i32 2, i32 1, i32 0, ptr nonnull @.str.2)
-  %2 = tail call noundef align 8 dereferenceable(8) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v2i32_12_0t(target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) %0, i32 0)
-  %3 = load <2 x i32>, ptr addrspace(11) %2, align 8
-  %4 = tail call noundef align 8 dereferenceable(8) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v2i32_12_0t(target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) %0, i32 1)
-  %5 = load <2 x i32>, ptr addrspace(11) %4, align 8
+  %in_buffer_handle = tail call target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) @llvm.spv.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str)
+  %out_buffer_handle = tail call target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) @llvm.spv.resource.handlefrombinding(i32 0, i32 2, i32 1, i32 0, ptr nonnull @.str.2)
+  %src0_ptr = tail call noundef align 8 dereferenceable(8) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) %in_buffer_handle, i32 0)
+  %src0 = load <2 x i32>, ptr addrspace(11) %src0_ptr, align 8
+  %src1_ptr = tail call noundef align 8 dereferenceable(8) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) %in_buffer_handle, i32 1)
+  %src1 = load <2 x i32>, ptr addrspace(11) %src1_ptr, align 8
 ; CHECK: %[[#tmp:]] = OpVectorShuffle %[[#v4_uint]] {{%[0-9]+}} {{%[0-9]+}} 0 2 1 3
-  %6 = shufflevector <2 x i32> %3, <2 x i32> %5, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
+  %shuffled = shufflevector <2 x i32> %src0, <2 x i32> %src1, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
 ; CHECK: %[[#access:]] = OpAccessChain {{.*}}
-  %7 = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v2f64_12_1t(target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) %1, i32 0)
+  %dst_ptr = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) %out_buffer_handle, i32 0)
 ; CHECK: %[[#bitcast:]] = OpBitcast %[[#v2_double]] %[[#tmp]]
 ; CHECK: OpStore %[[#access]] %[[#bitcast]]
-  store <4 x i32> %6, ptr addrspace(11) %7, align 16
+  store <4 x i32> %shuffled, ptr addrspace(11) %dst_ptr, align 16
   ret void
 }
 
@@ -44,11 +44,11 @@ entry:
 ; CHECK:  %[[BITCAST2:[0-9]+]] = OpBitcast %[[#v2_double]] %[[BITCAST1]]
 ; CHECK: OpStore {{%[0-9]+}} %[[BITCAST2]] {{.*}}
 
-  %0 = tail call target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v2f64_12_1t(i32 0, i32 2, i32 1, i32 0, ptr nonnull @.str.2)
-  %2 = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v2f64_12_1t(target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) %0, i32 0)
-  %3 = load <4 x i32>, ptr addrspace(11) %2
-  %4 = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v2f64_12_1t(target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) %0, i32 1)
-  store <4 x i32> %3, ptr addrspace(11) %4
+  %out_buffer_handle = tail call target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) @llvm.spv.resource.handlefrombinding(i32 0, i32 2, i32 1, i32 0, ptr nonnull @.str.2)
+  %src_ptr = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) %out_buffer_handle, i32 0)
+  %loaded_v4i32 = load <4 x i32>, ptr addrspace(11) %src_ptr
+  %dst_ptr = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) %out_buffer_handle, i32 1)
+  store <4 x i32> %loaded_v4i32, ptr addrspace(11) %dst_ptr
   ret void
 }
 
@@ -62,12 +62,12 @@ entry:
 ; CHECK-NEXT:  %[[SHUFFLE3:[0-9]+]] = OpVectorShuffle %[[#v2_uint]] %[[BITCAST3]] %[[BITCAST3]] 0 1
 ; CHECK:       OpStore {{%[0-9]+}} %[[SHUFFLE3]] {{.*}}
 
-  %0 = tail call target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f32_12_0t(i32 1, i32 0, i32 1, i32 0, ptr nonnull @.str.3)
-  %1 = tail call target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v2i32_12_0t(i32 1, i32 1, i32 1, i32 0, ptr nonnull @.str.4)
-  %2 = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f32_12_0t(target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 0) %0, i32 0)
-  %3 = load <2 x i32>, ptr addrspace(11) %2, align 16
-  %4 = tail call noundef align 8 dereferenceable(8) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v2i32_12_0t(target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) %1, i32 0)
-  store <2 x i32> %3, ptr addrspace(11) %4, align 8
+  %in_buffer_handle = tail call target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 0) @llvm.spv.resource.handlefrombinding(i32 1, i32 0, i32 1, i32 0, ptr nonnull @.str.3)
+  %out_buffer_handle = tail call target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) @llvm.spv.resource.handlefrombinding(i32 1, i32 1, i32 1, i32 0, ptr nonnull @.str.4)
+  %src_ptr = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 0) %in_buffer_handle, i32 0)
+  %loaded_v2i32 = load <2 x i32>, ptr addrspace(11) %src_ptr, align 16
+  %dst_ptr = tail call noundef align 8 dereferenceable(8) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x <2 x i32>], 12, 0) %out_buffer_handle, i32 0)
+  store <2 x i32> %loaded_v2i32, ptr addrspace(11) %dst_ptr, align 8
   ret void
 }
 
@@ -84,12 +84,12 @@ entry:
 ; CHECK-NEXT:  %[[BITCAST:[0-9]+]] = OpBitcast %[[#v2_ulong]] %[[SHUFFLE]]{{.*}}
 ; CHECK:       OpStore {{%[0-9]+}} %[[BITCAST]] {{.*}}
 
-  %0 = tail call target("spirv.VulkanBuffer", [0 x <3 x i32>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v3i32_12_0t(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str.in)
-  %1 = tail call target("spirv.VulkanBuffer", [0 x <2 x i64>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v1i64_12_0t(i32 0, i32 1, i32 1, i32 0, ptr nonnull @.str.out)
-  %2 = tail call noundef align 16 dereferenceable(12) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v3i32_12_0t(target("spirv.VulkanBuffer", [0 x <3 x i32>], 12, 0) %0, i32 0)
-  %3 = load <2 x i64>, ptr addrspace(11) %2, align 16
-  %4 = tail call noundef align 8 dereferenceable(8) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v1i64_12_0t(target("spirv.VulkanBuffer", [0 x <2 x i64>], 12, 0) %1, i32 0)
-  store <2 x i64> %3, ptr addrspace(11) %4, align 8
+  %in_buffer_handle = tail call target("spirv.VulkanBuffer", [0 x <3 x i32>], 12, 0) @llvm.spv.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str.in)
+  %out_buffer_handle = tail call target("spirv.VulkanBuffer", [0 x <2 x i64>], 12, 0) @llvm.spv.resource.handlefrombinding(i32 0, i32 1, i32 1, i32 0, ptr nonnull @.str.out)
+  %src_ptr = tail call noundef align 16 dereferenceable(12) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x <3 x i32>], 12, 0) %in_buffer_handle, i32 0)
+  %loaded_v2i64 = load <2 x i64>, ptr addrspace(11) %src_ptr, align 16
+  %dst_ptr = tail call noundef align 8 dereferenceable(8) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x <2 x i64>], 12, 0) %out_buffer_handle, i32 0)
+  store <2 x i64> %loaded_v2i64, ptr addrspace(11) %dst_ptr, align 8
   ret void
 }
 


### PR DESCRIPTION

fixes https://github.com/llvm/llvm-project/issues/177838

- Replaced assert(TargetTypeSize == SourceTypeSize) with a conditional: when sizes differ, compute a BitcastType with the target's element type but sized to match the source's total bitwidth
- Instead of unconditionally returning after bitcast, only return early if BitcastType == TargetType (same-size case), otherwise fall through to the shuffle logic
- Updated the final assert to use AssignValue->getType() since that may now be the intermediate type rather than SourceType