### PR TITLE
[lldb] Disable shared build for TestAppleSimulatorOSType.py

### DIFF
--- a/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -10,6 +10,8 @@ import re
 
 
 class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     # Number of stderr lines to read from the simctl output.
     READ_LINES = 10
 


### PR DESCRIPTION
Follow up to #181720. Based on [this failure](https://green.lab.llvm.org/job/llvm.org/view/LLDB/job/as-lldb-cmake-os-verficiation/275/).