### PR TITLE
[Flang-RT][unittests] Fix buffer over-read

### DIFF
--- a/flang-rt/unittests/Runtime/Reduction.cpp
+++ b/flang-rt/unittests/Runtime/Reduction.cpp
@@ -676,15 +676,15 @@ TEST(Reductions, ReduceInt4Dim) {
 TEST(Reductions, InfSums) {
   auto inf{std::numeric_limits<float>::infinity()};
   auto inf0{MakeArray<TypeCategory::Real, 4>(
-      std::vector<int>{2, 3}, std::vector<float>{inf, 0.0f})};
+      std::vector<int>{2}, std::vector<float>{inf, 0.0f})};
   auto t1{RTNAME(SumReal4)(*inf0, __FILE__, __LINE__)};
   EXPECT_EQ(t1, inf) << t1;
   auto infMinusInf{MakeArray<TypeCategory::Real, 4>(
-      std::vector<int>{2, 3}, std::vector<float>{inf, -inf})};
+      std::vector<int>{2}, std::vector<float>{inf, -inf})};
   auto t2{RTNAME(SumReal4)(*infMinusInf, __FILE__, __LINE__)};
   EXPECT_NE(t2, t2) << t2;
   auto minusInfInf{MakeArray<TypeCategory::Real, 4>(
-      std::vector<int>{2, 3}, std::vector<float>{-inf, inf})};
+      std::vector<int>{2}, std::vector<float>{-inf, inf})};
   auto t3{RTNAME(SumReal4)(*infMinusInf, __FILE__, __LINE__)};
   EXPECT_NE(t3, t3) << t3;
 }


### PR DESCRIPTION
The unittests `Reductions.InfSums` defines a test array descriptor with shape 2x3 (i.e. 6 elements), but only provides values for 2 elements. The result is access of likely uninitialized memory when accessing the additional 4 elements. In most cases the additional values get gobbled up by the infinity, but if it happens to be NaN or the negated infinity, the result becomes NaN and fails the test.

Fix by reducing the shabe of the test array to 2. Fixes the flakyness of the test of the [flang-x86_64-windows](https://lab.llvm.org/buildbot/#/builders/166) buildbot.