### PR TITLE
[RISCV] Use getNamedOperandIdx in getFRMOpNum/getVXRMOpNum. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -25,6 +25,113 @@
 
 namespace llvm {
 
+namespace RISCVOp {
+enum OperandType : unsigned {
+  OPERAND_FIRST_RISCV_IMM = MCOI::OPERAND_FIRST_TARGET,
+  OPERAND_UIMM1 = OPERAND_FIRST_RISCV_IMM,
+  OPERAND_UIMM2,
+  OPERAND_UIMM2_LSB0,
+  OPERAND_UIMM3,
+  OPERAND_UIMM4,
+  OPERAND_UIMM5,
+  OPERAND_UIMM5_NONZERO,
+  OPERAND_UIMM5_GT3,
+  OPERAND_UIMM5_PLUS1,
+  OPERAND_UIMM5_GE6_PLUS1,
+  OPERAND_UIMM5_LSB0,
+  OPERAND_UIMM5_SLIST,
+  OPERAND_UIMM6,
+  OPERAND_UIMM6_LSB0,
+  OPERAND_UIMM7,
+  OPERAND_UIMM7_LSB00,
+  OPERAND_UIMM7_LSB000,
+  OPERAND_UIMM8_LSB00,
+  OPERAND_UIMM8,
+  OPERAND_UIMM8_LSB000,
+  OPERAND_UIMM8_GE32,
+  OPERAND_UIMM9_LSB000,
+  OPERAND_UIMM9,
+  OPERAND_UIMM10,
+  OPERAND_UIMM10_LSB00_NONZERO,
+  OPERAND_UIMM11,
+  OPERAND_UIMM12,
+  OPERAND_UIMM14_LSB00,
+  OPERAND_UIMM16,
+  OPERAND_UIMM16_NONZERO,
+  OPERAND_UIMMLOG2XLEN,
+  OPERAND_UIMMLOG2XLEN_NONZERO,
+  OPERAND_UIMM32,
+  OPERAND_UIMM48,
+  OPERAND_UIMM64,
+  OPERAND_THREE,
+  OPERAND_FOUR,
+  OPERAND_IMM5_ZIBI,
+  OPERAND_SIMM5,
+  OPERAND_SIMM5_NONZERO,
+  OPERAND_SIMM5_PLUS1,
+  OPERAND_SIMM6,
+  OPERAND_SIMM6_NONZERO,
+  OPERAND_SIMM8_UNSIGNED,
+  OPERAND_SIMM10,
+  OPERAND_SIMM10_LSB0000_NONZERO,
+  OPERAND_SIMM10_UNSIGNED,
+  OPERAND_SIMM11,
+  OPERAND_SIMM12_LSB00000,
+  OPERAND_SIMM16,
+  OPERAND_SIMM16_NONZERO,
+  OPERAND_SIMM20,
+  OPERAND_SIMM20_LI,
+  OPERAND_SIMM26,
+  OPERAND_CLUI_IMM,
+  OPERAND_VTYPEI10,
+  OPERAND_VTYPEI11,
+  OPERAND_RVKRNUM,
+  OPERAND_RVKRNUM_0_7,
+  OPERAND_RVKRNUM_1_10,
+  OPERAND_RVKRNUM_2_14,
+  OPERAND_RLIST,
+  OPERAND_RLIST_S0,
+  OPERAND_STACKADJ,
+  // Operand is a 3-bit rounding mode, '111' indicates FRM register.
+  // Represents 'frm' argument passing to floating-point operations.
+  OPERAND_FRMARG,
+  // Operand is a 3-bit rounding mode where only RTZ is valid.
+  OPERAND_RTZARG,
+  // Condition code used by select and short forward branch pseudos.
+  OPERAND_COND_CODE,
+  // Ordering for atomic pseudos.
+  OPERAND_ATOMIC_ORDERING,
+  // Vector policy operand.
+  OPERAND_VEC_POLICY,
+  // Vector SEW operand. Stores in log2(SEW).
+  OPERAND_SEW,
+  // Special SEW for mask only instructions. Always 0.
+  OPERAND_SEW_MASK,
+  // Vector rounding mode for VXRM or FRM.
+  OPERAND_VEC_RM,
+  // Vtype operand for XSfmm extension.
+  OPERAND_XSFMM_VTYPE,
+  // XSfmm twiden operand.
+  OPERAND_XSFMM_TWIDEN,
+  OPERAND_LAST_RISCV_IMM = OPERAND_XSFMM_TWIDEN,
+
+  OPERAND_UIMM20_LUI,
+  OPERAND_UIMM20_AUIPC,
+
+  // Simm12 or constant pool, global, basicblock, etc.
+  OPERAND_SIMM12_LO,
+
+  OPERAND_BARE_SIMM32,
+
+  // Operand is either a register or uimm5, this is used by V extension pseudo
+  // instructions to represent a value that be passed as AVL to either vsetvli
+  // or vsetivli.
+  OPERAND_AVL,
+
+  OPERAND_VMASK,
+};
+} // namespace RISCVOp
+
 // RISCVII - This namespace holds all of the target specific flags that
 // instruction info tracks. All definitions must match RISCVInstrFormats.td.
 namespace RISCVII {
@@ -300,15 +407,12 @@ static inline int getFRMOpNum(const MCInstrDesc &Desc) {
   if (!hasRoundModeOp(TSFlags) || usesVXRM(TSFlags))
     return -1;
 
-  if (hasTWidenOp(TSFlags) && hasTMOp(TSFlags))
-    return getTMOpNum(Desc) - 1;
+  int Idx = RISCV::getNamedOperandIdx(Desc.getOpcode(), RISCV::OpName::rm);
+  assert(Idx >= 0 && "No rm operand?");
+  assert(Desc.operands()[Idx].OperandType == RISCVOp::OPERAND_VEC_RM &&
+         "Operand has wrong type");
 
-  // The operand order
-  // --------------------------------------
-  // | n-1 (if any)   | n-2  | n-3 | n-4 |
-  // | policy         | sew  | vl  | frm |
-  // --------------------------------------
-  return getVLOpNum(Desc) - 1;
+  return Idx;
 }
 
 /// \returns  the index to the rounding mode immediate value if any, otherwise
@@ -317,12 +421,13 @@ static inline int getVXRMOpNum(const MCInstrDesc &Desc) {
   const uint64_t TSFlags = Desc.TSFlags;
   if (!hasRoundModeOp(TSFlags) || !usesVXRM(TSFlags))
     return -1;
-  // The operand order
-  // --------------------------------------
-  // | n-1 (if any)   | n-2  | n-3 | n-4  |
-  // | policy         | sew  | vl  | vxrm |
-  // --------------------------------------
-  return getVLOpNum(Desc) - 1;
+
+  int Idx = RISCV::getNamedOperandIdx(Desc.getOpcode(), RISCV::OpName::rm);
+  assert(Idx >= 0 && "No rm operand?");
+  assert(Desc.operands()[Idx].OperandType == RISCVOp::OPERAND_VEC_RM &&
+         "Operand has wrong type");
+
+  return Idx;
 }
 
 // Is the first def operand tied to the first use operand. This is true for
@@ -359,113 +464,6 @@ enum {
   MO_DIRECT_FLAG_MASK = 31
 };
 } // namespace RISCVII
-
-namespace RISCVOp {
-enum OperandType : unsigned {
-  OPERAND_FIRST_RISCV_IMM = MCOI::OPERAND_FIRST_TARGET,
-  OPERAND_UIMM1 = OPERAND_FIRST_RISCV_IMM,
-  OPERAND_UIMM2,
-  OPERAND_UIMM2_LSB0,
-  OPERAND_UIMM3,
-  OPERAND_UIMM4,
-  OPERAND_UIMM5,
-  OPERAND_UIMM5_NONZERO,
-  OPERAND_UIMM5_GT3,
-  OPERAND_UIMM5_PLUS1,
-  OPERAND_UIMM5_GE6_PLUS1,
-  OPERAND_UIMM5_LSB0,
-  OPERAND_UIMM5_SLIST,
-  OPERAND_UIMM6,
-  OPERAND_UIMM6_LSB0,
-  OPERAND_UIMM7,
-  OPERAND_UIMM7_LSB00,
-  OPERAND_UIMM7_LSB000,
-  OPERAND_UIMM8_LSB00,
-  OPERAND_UIMM8,
-  OPERAND_UIMM8_LSB000,
-  OPERAND_UIMM8_GE32,
-  OPERAND_UIMM9_LSB000,
-  OPERAND_UIMM9,
-  OPERAND_UIMM10,
-  OPERAND_UIMM10_LSB00_NONZERO,
-  OPERAND_UIMM11,
-  OPERAND_UIMM12,
-  OPERAND_UIMM14_LSB00,
-  OPERAND_UIMM16,
-  OPERAND_UIMM16_NONZERO,
-  OPERAND_UIMMLOG2XLEN,
-  OPERAND_UIMMLOG2XLEN_NONZERO,
-  OPERAND_UIMM32,
-  OPERAND_UIMM48,
-  OPERAND_UIMM64,
-  OPERAND_THREE,
-  OPERAND_FOUR,
-  OPERAND_IMM5_ZIBI,
-  OPERAND_SIMM5,
-  OPERAND_SIMM5_NONZERO,
-  OPERAND_SIMM5_PLUS1,
-  OPERAND_SIMM6,
-  OPERAND_SIMM6_NONZERO,
-  OPERAND_SIMM8_UNSIGNED,
-  OPERAND_SIMM10,
-  OPERAND_SIMM10_LSB0000_NONZERO,
-  OPERAND_SIMM10_UNSIGNED,
-  OPERAND_SIMM11,
-  OPERAND_SIMM12_LSB00000,
-  OPERAND_SIMM16,
-  OPERAND_SIMM16_NONZERO,
-  OPERAND_SIMM20,
-  OPERAND_SIMM20_LI,
-  OPERAND_SIMM26,
-  OPERAND_CLUI_IMM,
-  OPERAND_VTYPEI10,
-  OPERAND_VTYPEI11,
-  OPERAND_RVKRNUM,
-  OPERAND_RVKRNUM_0_7,
-  OPERAND_RVKRNUM_1_10,
-  OPERAND_RVKRNUM_2_14,
-  OPERAND_RLIST,
-  OPERAND_RLIST_S0,
-  OPERAND_STACKADJ,
-  // Operand is a 3-bit rounding mode, '111' indicates FRM register.
-  // Represents 'frm' argument passing to floating-point operations.
-  OPERAND_FRMARG,
-  // Operand is a 3-bit rounding mode where only RTZ is valid.
-  OPERAND_RTZARG,
-  // Condition code used by select and short forward branch pseudos.
-  OPERAND_COND_CODE,
-  // Ordering for atomic pseudos.
-  OPERAND_ATOMIC_ORDERING,
-  // Vector policy operand.
-  OPERAND_VEC_POLICY,
-  // Vector SEW operand. Stores in log2(SEW).
-  OPERAND_SEW,
-  // Special SEW for mask only instructions. Always 0.
-  OPERAND_SEW_MASK,
-  // Vector rounding mode for VXRM or FRM.
-  OPERAND_VEC_RM,
-  // Vtype operand for XSfmm extension.
-  OPERAND_XSFMM_VTYPE,
-  // XSfmm twiden operand.
-  OPERAND_XSFMM_TWIDEN,
-  OPERAND_LAST_RISCV_IMM = OPERAND_XSFMM_TWIDEN,
-
-  OPERAND_UIMM20_LUI,
-  OPERAND_UIMM20_AUIPC,
-
-  // Simm12 or constant pool, global, basicblock, etc.
-  OPERAND_SIMM12_LO,
-
-  OPERAND_BARE_SIMM32,
-
-  // Operand is either a register or uimm5, this is used by V extension pseudo
-  // instructions to represent a value that be passed as AVL to either vsetvli
-  // or vsetivli.
-  OPERAND_AVL,
-
-  OPERAND_VMASK,
-};
-} // namespace RISCVOp
 
 // Describes the predecessor/successor bits used in the FENCE instruction.
 namespace RISCVFenceField {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
@@ -566,6 +566,8 @@ class RISCVVPseudo<dag outs, dag ins, list<dag> pattern = [],
   bits<8> SEW = 0;
   bit IsAltFmt = !eq(AltFmtType.Value, IS_ALTFMT.Value);
   bit IncludeInInversePseudoTable = 1;
+
+  let UseNamedOperandTable = true;
 }
 
 // The actual table.


### PR DESCRIPTION
Rather than relying on complex rules about the order of operands.