### PR TITLE
[MachinePipeliner] Fix crash during prolog peeling

### DIFF
--- a/llvm/lib/CodeGen/MachineLoopUtils.cpp
+++ b/llvm/lib/CodeGen/MachineLoopUtils.cpp
@@ -10,6 +10,7 @@
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
+#include <iterator>
 using namespace llvm;
 
 namespace {
@@ -111,7 +112,9 @@ MachineBasicBlock *llvm::PeelSingleBlockLoop(LoopPeelDirection Direction,
     Preheader->ReplaceUsesOfBlockWith(Loop, NewBB);
     NewBB->addSuccessor(Loop);
     Loop->replacePhiUsesWith(Preheader, NewBB);
-    Preheader->updateTerminator(Loop);
+    if (auto PreheaderLayoutSuccessor = std::next(Preheader->getIterator());
+        PreheaderLayoutSuccessor != Preheader->getParent()->end())
+      Preheader->updateTerminator(&*PreheaderLayoutSuccessor);
     TII->removeBranch(*NewBB);
     TII->insertBranch(*NewBB, Loop, nullptr, {}, DL);
   } else {

--- a/llvm/test/CodeGen/Hexagon/swp-peel-prolog-crash.mir
+++ b/llvm/test/CodeGen/Hexagon/swp-peel-prolog-crash.mir
@@ -1,0 +1,57 @@
+# RUN: llc -mtriple=hexagon -run-pass pipeliner -pipeliner-experimental-cg=true %s -o /dev/null
+# REQUIRES: asserts
+
+# Test that the pipeliner does not crash during prolog peeling when the
+# preheader terminates with a fallthrough conditional branch.
+
+...
+---
+name:            test
+tracksRegLiveness: true
+
+body:             |
+  bb.0:
+    successors: %bb.3, %bb.1
+    liveins: $r0, $r1, $r2
+
+    %14:intregs = COPY $r2
+    %13:intregs = COPY $r1
+    %12:intregs = COPY $r0
+    %16:predregs = C2_cmpeqi %14, 2
+    %15:intregs = A2_tfrsi 0
+    J2_jumpt killed %16, %bb.3, implicit-def dead $pc
+    J2_jump %bb.1, implicit-def dead $pc
+
+  bb.1:
+    successors: %bb.2
+
+    %0:intregs = A2_addi %14, -2
+    %1:intregs = A2_addi %12, 10
+    %2:intregs = A2_addi %13, 4
+    %17:intregs = A2_tfrsi 0
+    %23:intregs = COPY %0
+    %24:predregs = IMPLICIT_DEF
+    J2_loop0r %bb.2, %23, implicit-def $lc0, implicit-def $sa0, implicit-def $usr
+    J2_jumpt %24, %bb.2, implicit-def dead $pc
+
+  bb.2 (machine-block-address-taken):
+    successors: %bb.3, %bb.2
+
+    %3:intregs = PHI %2, %bb.1, %10, %bb.2
+    %4:intregs = PHI %1, %bb.1, %9, %bb.2
+    %21:intregs = PHI %1, %bb.1, %22, %bb.2
+    %6:intregs = PHI %17, %bb.1, %7, %bb.2
+    %18:intregs, %10:intregs = L2_loadrh_pi %3, 2 :: (load (s16))
+    %19:intregs, %22:intregs = L2_loadrh_pi %21, 2 :: (load (s16))
+    %20:intregs = A2_addi %18, 10
+    %9:intregs = S2_storerh_pi %4, 2, killed %20 :: (store (s16))
+    %7:intregs = M2_acci %19, %6, %18
+    ENDLOOP0 %bb.2, implicit-def $pc, implicit-def $lc0, implicit $sa0, implicit $lc0
+    J2_jump %bb.3, implicit-def dead $pc
+
+  bb.3:
+    %11:intregs = PHI %15, %bb.0, %7, %bb.2
+    $r0 = COPY %11
+    PS_jmpret $r31, implicit-def dead $pc, implicit $r0
+
+...


### PR DESCRIPTION
Fix crash during prolog peeling when loop preheader terminates with a fallthrough conditional branch

The crash was happening due to the wrong preheader layout successor being passed to `updateTerminator`; in general, the loop kernel will not be the layout successor after prolog peeling. Fix this by passing the right layout successor.