### PR TITLE
[X86] Emit ISD::ADD instead of X86ISD::ADD from combineSubSetcc. NFC

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -59503,7 +59503,7 @@ static SDValue combineSubSetcc(SDNode *N, SelectionDAG &DAG) {
     SDLoc DL(Op1);
     SDValue NewSetCC = getSETCC(NewCC, SetCC.getOperand(1), DL, DAG);
     NewSetCC = DAG.getNode(ISD::ZERO_EXTEND, DL, VT, NewSetCC);
-    return DAG.getNode(X86ISD::ADD, DL, DAG.getVTList(VT, VT), NewSetCC,
+    return DAG.getNode(ISD::ADD, DL, VT, NewSetCC,
                        DAG.getConstant(NewImm, DL, VT));
   }
 


### PR DESCRIPTION
The flag result isn't used so the X86ISD::ADD would be converted to ISD::ADD by a DAGCombine immediately after.

Prior to this we could create a X86ISD::ADD with an illegal type and we were using the wrong VT for the flag result.