### PR TITLE
[lldb] Disable shared build for TestGdbRemoteCompletion.py

### DIFF
--- a/lldb/test/API/tools/lldb-server/TestGdbRemoteCompletion.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemoteCompletion.py
@@ -6,6 +6,8 @@ from lldbgdbserverutils import *
 
 
 class GdbRemoteCompletionTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def init_lldb_server(self):
         self.debug_monitor_exe = get_lldb_server_exe()
         if not self.debug_monitor_exe:


### PR DESCRIPTION
Follow up to #181720. Based on [this
failure](https://lab.llvm.org/buildbot/#/builders/162/builds/41328)