### PR TITLE
[NFC][Clang] Apply Rule of Three to classes in ASTUnit.h

### DIFF
--- a/clang/include/clang/Frontend/ASTUnit.h
+++ b/clang/include/clang/Frontend/ASTUnit.h
@@ -399,6 +399,8 @@ private:
   public:
     ConcurrencyState();
     ~ConcurrencyState();
+    ConcurrencyState(const ConcurrencyState &) = delete;
+    ConcurrencyState &operator=(const ConcurrencyState &) = delete;
 
     void start();
     void finish();
@@ -950,6 +952,9 @@ public:
       SmallVectorImpl<StandaloneDiagnostic> *StandaloneDiags);
 
   ~CaptureDroppedDiagnostics();
+  CaptureDroppedDiagnostics(const CaptureDroppedDiagnostics &) = delete;
+  CaptureDroppedDiagnostics &
+  operator=(const CaptureDroppedDiagnostics &) = delete;
 };
 
 } // namespace clang


### PR DESCRIPTION
Static analysis flagged that some classes in ASTUnit.h defined a destructor but did not also define a copy constructor or copy assignment. This is a bug and I am defining them as deleted to prevent accidently copy or assigns.