### PR TITLE
[libc][math][test] add missed mpfr test for `ceilf128`

### DIFF
--- a/libc/test/src/math/CMakeLists.txt
+++ b/libc/test/src/math/CMakeLists.txt
@@ -400,6 +400,21 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
+  ceilf128_test
+  NEED_MPFR
+  SUITE
+    libc-math-unittests
+  SRCS
+    ceilf128_test.cpp
+  HDRS
+    CeilTest.h
+  DEPENDS
+    libc.src.math.ceilf128
+    libc.src.__support.CPP.algorithm
+    libc.src.__support.FPUtil.fp_bits
+)
+
+add_fp_unittest(
   ceilf_test
   NEED_MPFR
   SUITE

--- a/libc/test/src/math/ceilf128_test.cpp
+++ b/libc/test/src/math/ceilf128_test.cpp
@@ -1,0 +1,13 @@
+//===-- Unittests for ceilf128 --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CeilTest.h"
+
+#include "src/math/ceilf128.h"
+
+LIST_CEIL_TESTS(float128, LIBC_NAMESPACE::ceilf128)


### PR DESCRIPTION
This PR adds an MPFR test for `ceilf128` that was missed.
