### PR TITLE
[clang] Fix init_priority attribute by delaying type checks after the type is deduced

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -275,6 +275,7 @@ Bug Fixes to Compiler Builtins
 Bug Fixes to Attribute Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed a behavioral discrepancy between deleted functions and private members when checking the ``enable_if`` attribute. (#GH175895)
+- Fixed ``init_priority`` attribute by delaying type checks until after the type is deduced.
 
 Bug Fixes to C++ Support
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3275,6 +3275,7 @@ def InitPriority : InheritableAttr, TargetSpecificAttr<TargetSupportsInitPriorit
   let Args = [UnsignedArgument<"Priority">];
   let Subjects = SubjectList<[Var], ErrorDiag>;
   let Documentation = [InitPriorityDocs];
+  let IsTypeDependent = 1;
 }
 
 def Section : InheritableAttr {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -15577,6 +15577,7 @@ public:
   ActOnEffectExpression(Expr *CondExpr, StringRef AttributeName);
 
   void ActOnCleanupAttr(Decl *D, const Attr *A);
+  void ActOnInitPriorityAttr(Decl *D, const Attr *A);
 
 private:
   /// The implementation of RequireCompleteType

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8660,6 +8660,5 @@ void Sema::ActOnInitPriorityAttr(Decl *D, const Attr *A) {
   if (!T->isRecordType()) {
     this->Diag(A->getLoc(), diag::err_init_priority_object_attr);
     D->dropAttr<InitPriorityAttr>();
-    return;
   }
 }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3834,14 +3834,6 @@ static void handleInitPriorityAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     AL.setInvalid();
     return;
   }
-  QualType T = cast<VarDecl>(D)->getType();
-  if (S.Context.getAsArrayType(T))
-    T = S.Context.getBaseElementType(T);
-  if (!T->isRecordType()) {
-    S.Diag(AL.getLoc(), diag::err_init_priority_object_attr);
-    AL.setInvalid();
-    return;
-  }
 
   Expr *E = AL.getArgAsExpr(0);
   uint32_t prioritynum;
@@ -8657,6 +8649,17 @@ void Sema::ActOnCleanupAttr(Decl *D, const Attr *A) {
                diag::err_attribute_cleanup_func_arg_incompatible_type)
         << NI.getName() << ParamTy << Ty;
     D->dropAttr<CleanupAttr>();
+    return;
+  }
+}
+
+void Sema::ActOnInitPriorityAttr(Decl *D, const Attr *A) {
+  QualType T = cast<VarDecl>(D)->getType();
+  if (this->Context.getAsArrayType(T))
+    T = this->Context.getBaseElementType(T);
+  if (!T->isRecordType()) {
+    this->Diag(A->getLoc(), diag::err_init_priority_object_attr);
+    D->dropAttr<InitPriorityAttr>();
     return;
   }
 }

--- a/clang/test/Sema/type-dependent-attrs.cpp
+++ b/clang/test/Sema/type-dependent-attrs.cpp
@@ -8,4 +8,15 @@ namespace InitPriorityAttribute {
   [[gnu::init_priority(1000)]] S2 invalid_var = s1; // expected-error {{no viable conversion from 'struct S1' to 'S2'}} \
                                                        expected-note@#S2_INIT_PRIORITY {{candidate constructor (the implicit copy constructor) not viable: no known conversion from 'struct S1' to 'const S2 &' for 1st argument}} \
                                                        expected-note@#S2_INIT_PRIORITY {{candidate constructor (the implicit move constructor) not viable: no known conversion from 'struct S1' to 'S2 &&' for 1st argument}}
+
+  template<typename T>
+  struct ST { // #ST_INIT_PRIORITY
+    T inner;
+  };
+
+  [[gnu::init_priority(2000)]] auto auto_t_var = ST<int>{0};
+  [[gnu::init_priority(2000)]] ST<int> struct_t_var = ST<int>{0};
+  [[gnu::init_priority(2000)]] ST<float> invalid_t_var = ST<int>{0}; // expected-error {{no viable conversion from 'ST<int>' to 'ST<float>'}} \
+                                                                             expected-note@#ST_INIT_PRIORITY {{candidate constructor (the implicit copy constructor) not viable: no known conversion from 'ST<int>' to 'const ST<float> &' for 1st argument}} \
+                                                                             expected-note@#ST_INIT_PRIORITY {{candidate constructor (the implicit move constructor) not viable: no known conversion from 'ST<int>' to 'ST<float> &&' for 1st argument}}
 }

--- a/clang/test/Sema/type-dependent-attrs.cpp
+++ b/clang/test/Sema/type-dependent-attrs.cpp
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+namespace InitPriorityAttribute {
+  struct S1 {} s1;
+  struct S2 {} s2; // #S2_INIT_PRIORITY
+  [[gnu::init_priority(1000)]] auto auto_var = s1;
+  [[gnu::init_priority(1000)]] S1 struct_var = s1;
+  [[gnu::init_priority(1000)]] S2 invalid_var = s1; // expected-error {{no viable conversion from 'struct S1' to 'S2'}} \
+                                                       expected-note@#S2_INIT_PRIORITY {{candidate constructor (the implicit copy constructor) not viable: no known conversion from 'struct S1' to 'const S2 &' for 1st argument}} \
+                                                       expected-note@#S2_INIT_PRIORITY {{candidate constructor (the implicit move constructor) not viable: no known conversion from 'struct S1' to 'S2 &&' for 1st argument}}
+}

--- a/clang/test/SemaCXX/init-priority-attr.cpp
+++ b/clang/test/SemaCXX/init-priority-attr.cpp
@@ -65,3 +65,9 @@ int main() {
   Two foo __attribute__((init_priority(1001))); // expected-error {{can only use 'init_priority' attribute on file-scope definitions of objects of class type}}
 // unknown-warning@-1 {{unknown attribute 'init_priority' ignored}}
 }
+
+struct S1 {} s1;
+[[gnu::init_priority(1001)]] auto auto_var = s1;
+// unknown-warning@-1 {{unknown attribute 'gnu::init_priority' ignored}}
+[[gnu::init_priority(1001)]] S1 struct_var = s1;
+// unknown-warning@-1 {{unknown attribute 'gnu::init_priority' ignored}}


### PR DESCRIPTION
This PR fixes the way we are dealing with type checks for the `init_priority`
attribute, by delaying these checks after we are deducing the type.

It is a follow up from the list of affected attributes in PR #164440.