### PR TITLE
[InstCombine] Transform splat before n x i1 for vec.reduce.add

### DIFF
--- a/llvm/test/Transforms/InstCombine/vector-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/vector-reductions.ll
@@ -412,12 +412,7 @@ define i64 @constant_multiplied_6xi64(i64 %0) {
 
 define i1 @constant_multiplied_8xi1(i1 %0) {
 ; CHECK-LABEL: @constant_multiplied_8xi1(
-; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <8 x i1> poison, i1 [[TMP0:%.*]], i64 0
-; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <8 x i1> [[TMP2]], <8 x i1> poison, <8 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP4:%.*]] = bitcast <8 x i1> [[TMP3]] to i8
-; CHECK-NEXT:    [[TMP5:%.*]] = call range(i8 0, 9) i8 @llvm.ctpop.i8(i8 [[TMP4]])
-; CHECK-NEXT:    [[TMP6:%.*]] = trunc i8 [[TMP5]] to i1
-; CHECK-NEXT:    ret i1 [[TMP6]]
+; CHECK-NEXT:    ret i1 false
 ;
   %2 = insertelement <8 x i1> poison, i1 %0, i32 0
   %3 = shufflevector <8 x i1> %2, <8 x i1> poison, <8 x i32> zeroinitializer


### PR DESCRIPTION
```llvm
define i1 @src(i1 %0) {
  %2 = insertelement <8 x i1> poison, i1 %0, i32 0
  %3 = shufflevector <8 x i1> %2, <8 x i1> poison, <8 x i32> zeroinitializer
  %4 = tail call i1 @llvm.vector.reduce.add.v8i1(<8 x i1> %3)
  ret i1 %4
}

define i1 @tgt(i1 %0) {
  ret i1 0
}
```

alive2: https://alive2.llvm.org/ce/z/vejxot

`vector_reduce_add(<n x i1>)` to `Trunc(ctpop(bitcast <n x i1> to in))` interferes with the `vector_reduce_add(<splat>)` to `mul`, so I exchanged their order.

Relevant PR: #161020 
