### PR TITLE
[lldb] Check the shared cache binary provider for Simulator sessions

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -421,11 +421,17 @@ Status PlatformAppleSimulator::GetSymbolFile(const FileSpec &platform_file,
 Status PlatformAppleSimulator::GetSharedModule(
     const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
     llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr) {
+
+  Status error;
+  error = GetModuleFromSharedCaches(module_spec, process, module_sp,
+                                    old_modules, did_create_ptr);
+  if (module_sp)
+    return error;
+
   // For iOS/tvOS/watchOS, the SDK files are all cached locally on the
   // host system. So first we ask for the file in the cached SDK, then
   // we attempt to get a shared module for the right architecture with
   // the right UUID.
-  Status error;
   ModuleSpec platform_module_spec(module_spec);
   const FileSpec &platform_file = module_spec.GetFileSpec();
   error = GetSymbolFile(platform_file, module_spec.GetUUIDPtr(),

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -76,6 +76,12 @@ public:
                          llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
                          bool *did_create_ptr) override;
 
+  Status
+  GetModuleFromSharedCaches(const ModuleSpec &module_spec, Process *process,
+                            lldb::ModuleSP &module_sp,
+                            llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
+                            bool *did_create_ptr);
+
   size_t GetSoftwareBreakpointTrapOpcode(Target &target,
                                          BreakpointSite *bp_site) override;
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
@@ -314,49 +314,11 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
   Status err;
 
   if (CheckLocalSharedCache()) {
-
-    SymbolSharedCacheUse sc_mode = ModuleList::GetGlobalModuleListProperties()
-                                       .GetSharedCacheBinaryLoading();
-    SharedCacheImageInfo image_info;
-    if (process && process->GetDynamicLoader()) {
-      addr_t sc_base_addr;
-      UUID sc_uuid;
-      LazyBool using_sc, private_sc;
-      FileSpec sc_path;
-      if (process->GetDynamicLoader()->GetSharedCacheInformation(
-              sc_base_addr, sc_uuid, using_sc, private_sc, sc_path)) {
-        if (module_spec.GetUUID())
-          image_info = HostInfo::GetSharedCacheImageInfo(module_spec.GetUUID(),
-                                                         sc_uuid, sc_mode);
-        else
-          image_info = HostInfo::GetSharedCacheImageInfo(
-              module_spec.GetFileSpec().GetPathAsConstString(), sc_uuid,
-              sc_mode);
-      }
-    }
-
-    // Fall back to looking for the file in lldb's own shared cache.
-    if (!image_info.GetUUID())
-      image_info = HostInfo::GetSharedCacheImageInfo(
-          module_spec.GetFileSpec().GetPathAsConstString(), sc_mode);
-
-    // If we found it and it has the correct UUID, let's proceed with
-    // creating a module from the memory contents.
-    if (image_info.GetUUID() &&
-        (!module_spec.GetUUID() ||
-         module_spec.GetUUID() == image_info.GetUUID())) {
-      ModuleSpec shared_cache_spec(module_spec.GetFileSpec(),
-                                   image_info.GetUUID(),
-                                   image_info.GetExtractor());
-      err = ModuleList::GetSharedModule(shared_cache_spec, module_sp,
-                                        old_modules, did_create_ptr);
-      if (module_sp) {
-        LLDB_LOGF(log, "[%s] module %s was found in the in-memory shared cache",
-                  (IsHost() ? "host" : "remote"),
-                  module_spec.GetFileSpec().GetPath().c_str());
-        return err;
-      }
-    }
+    err = GetModuleFromSharedCaches(module_spec, process, module_sp,
+                                    old_modules, did_create_ptr);
+    if (module_sp)
+      return err;
+  }
 
     // We failed to find the module in our shared cache. Let's see if we have a
     // copy in our device support directory.
@@ -378,7 +340,6 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
                   local_spec.GetFileSpec().GetPath().c_str());
         return err;
       }
-    }
   }
 
   err = ModuleList::GetSharedModule(module_spec, module_sp, old_modules,


### PR DESCRIPTION
The code to check with the shared cache binary provider was previously in the native host platform (PlatformDarwinDevice), but it also needs to be called from PlatformAppleSimulator for simulator debug sessions.  Move the code to the base class PlatformDarwin and call it from both subclasses.  No changes to the code itself, just moving it to the base class.

rdar://170693756