### PR TITLE
[DomFrontier] Fix precedence in assert. NFC

### DIFF
--- a/llvm/include/llvm/Analysis/DominanceFrontier.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontier.h
@@ -101,8 +101,8 @@ public:
 #endif
 
   void analyze(DomTreeT &DT) {
-    assert(IsPostDom || DT.root_size() == 1 &&
-                            "Only one entry block for forward domfronts!");
+    assert((IsPostDom || DT.root_size() == 1) &&
+           "Only one entry block for forward domfronts!");
     assert(DT.root_size() == 1 &&
            "Support for post-dom frontiers with multiple roots hasn't been "
            "implemented yet!");


### PR DESCRIPTION
This fixes the warning about parentheses around ‘&&’ within ‘||’, until DFs with multiple roots are supported.