### PR TITLE
[WebAssembly][FastISel] Omit redundant AND for zext of i8/i16 loads

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -465,7 +465,7 @@ unsigned WebAssemblyFastISel::zeroExtendToI32(unsigned Reg, const Value *V,
     break;
   case MVT::i8:
   case MVT::i16:
-    if (isa<LoadInst>(V))
+    if (dyn_cast_if_present<LoadInst>(V))
       return copyValue(Reg);
     break;
   case MVT::i32:

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -465,7 +465,7 @@ unsigned WebAssemblyFastISel::zeroExtendToI32(unsigned Reg, const Value *V,
     break;
   case MVT::i8:
   case MVT::i16:
-    if (dyn_cast_if_present<LoadInst>(V))
+    if (isa_and_present<LoadInst>(V))
       return copyValue(Reg);
     break;
   case MVT::i32:

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -465,6 +465,8 @@ unsigned WebAssemblyFastISel::zeroExtendToI32(unsigned Reg, const Value *V,
     break;
   case MVT::i8:
   case MVT::i16:
+    if (isa<LoadInst>(V))
+      return copyValue(Reg);
     break;
   case MVT::i32:
     return copyValue(Reg);

--- a/llvm/test/CodeGen/WebAssembly/load-ext.ll
+++ b/llvm/test/CodeGen/WebAssembly/load-ext.ll
@@ -21,9 +21,7 @@ define i32 @sext_i8_i32(ptr %p) {
 ; DAG: i32.load8_u $push0=, 0($0){{$}}
 ; DAG-NEXT: return $pop0{{$}}
 ; FAST:       i32.load8_u $push[[L:[0-9]+]]=, 0($0)
-; FAST-NEXT:       i32.const   $push[[C:[0-9]+]]=, 255
-; FAST-NEXT:       i32.and     $push[[R:[0-9]+]]=, $pop[[L]], $pop[[C]]
-; FAST-NEXT:       return      $pop[[R]]
+; FAST-NEXT:       return      $pop[[L]]
 define i32 @zext_i8_i32(ptr %p) {
   %v = load i8, ptr %p
   %e = zext i8 %v to i32
@@ -46,9 +44,7 @@ define i32 @sext_i16_i32(ptr %p) {
 ; DAG: i32.load16_u $push0=, 0($0){{$}}
 ; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load16_u $push[[L:[0-9]+]]=, 0($0)
-; FAST-NEXT: i32.const    $push[[C:[0-9]+]]=, 65535
-; FAST-NEXT: i32.and      $push[[R:[0-9]+]]=, $pop[[L]], $pop[[C]]
-; FAST-NEXT: return       $pop[[R]]
+; FAST-NEXT: return       $pop[[L]]
 define i32 @zext_i16_i32(ptr %p) {
   %v = load i16, ptr %p
   %e = zext i16 %v to i32
@@ -72,9 +68,7 @@ define i64 @sext_i8_i64(ptr %p) {
 ; DAG: i64.load8_u $push0=, 0($0){{$}}
 ; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load8_u      $push[[L:[0-9]+]]=, 0($0)
-; FAST-NEXT: i32.const        $push[[C:[0-9]+]]=, 255
-; FAST-NEXT: i32.and          $push[[AND:[0-9]+]]=, $pop[[L]], $pop[[C]]
-; FAST-NEXT: i64.extend_i32_u $push[[EXT:[0-9]+]]=, $pop[[AND]]
+; FAST-NEXT: i64.extend_i32_u $push[[EXT:[0-9]+]]=, $pop[[L]]
 ; FAST-NEXT: return           $pop[[EXT]]
 define i64 @zext_i8_i64(ptr %p) {
   %v = load i8, ptr %p
@@ -99,9 +93,7 @@ define i64 @sext_i16_i64(ptr %p) {
 ; DAG: i64.load16_u $push0=, 0($0){{$}}
 ; DAG-NEXT: return $pop0{{$}}
 ; FAST:      i32.load16_u     $push[[L:[0-9]+]]=, 0($0)
-; FAST-NEXT: i32.const        $push[[C:[0-9]+]]=, 65535
-; FAST-NEXT: i32.and          $push[[AND:[0-9]+]]=, $pop[[L]], $pop[[C]]
-; FAST-NEXT: i64.extend_i32_u $push[[EXT:[0-9]+]]=, $pop[[AND]]
+; FAST-NEXT: i64.extend_i32_u $push[[EXT:[0-9]+]]=, $pop[[L]]
 ; FAST-NEXT: return           $pop[[EXT]]
 define i64 @zext_i16_i64(ptr %p) {
   %v = load i16, ptr %p

--- a/llvm/test/CodeGen/WebAssembly/offset-fastisel.ll
+++ b/llvm/test/CodeGen/WebAssembly/offset-fastisel.ll
@@ -104,9 +104,7 @@ define i32 @load_i8_u_with_folded_offset(ptr %p) {
 ; CHECK-LABEL: load_i8_u_with_folded_offset:
 ; CHECK:         .functype load_i8_u_with_folded_offset (i32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i32.load8_u $push2=, 24($0)
-; CHECK-NEXT:    i32.const $push0=, 255
-; CHECK-NEXT:    i32.and $push1=, $pop2, $pop0
+; CHECK-NEXT:    i32.load8_u $push0=, 24($0)
 ; CHECK-NEXT:    # fallthrough-return
   %q = ptrtoint ptr %p to i32
   %r = add nuw i32 %q, 24


### PR DESCRIPTION
When zero-extending an i8 or i16 load to i32, FastISel previously emitted an explicit AND instruction to mask the upper bits. This is redundant because WebAssembly's native unsigned load instructions (load8_u and load16_u) inherently zero-extend the loaded values.

Fixes #180774