### PR TITLE
Fix crash in clang_getUnaryOperatorKindSpelling()

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -394,6 +394,7 @@ clang-format
 
 libclang
 --------
+- Fix crash in clang_getBinaryOperatorKindSpelling and clang_getUnaryOperatorKindSpelling
 
 Code Completion
 ---------------

--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -6932,7 +6932,8 @@ enum CXUnaryOperatorKind {
   /** __extension__ marker operator. */
   CXUnaryOperator_Extension,
   /** C++ co_await operator. */
-  CXUnaryOperator_Coawait
+  CXUnaryOperator_Coawait,
+  CXUnaryOperator_Last = CXUnaryOperator_Coawait
 };
 
 /**

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -10173,7 +10173,7 @@ cxindex::Logger::~Logger() {
 }
 
 CXString clang_getBinaryOperatorKindSpelling(enum CXBinaryOperatorKind kind) {
-  if (kind > CXBinaryOperator_Last)
+  if (kind <= CXBinaryOperator_Invalid || kind > CXBinaryOperator_Last)
     return cxstring::createEmpty();
 
   return cxstring::createDup(
@@ -10195,6 +10195,9 @@ enum CXBinaryOperatorKind clang_getCursorBinaryOperatorKind(CXCursor cursor) {
 }
 
 CXString clang_getUnaryOperatorKindSpelling(enum CXUnaryOperatorKind kind) {
+  if (kind <= CXUnaryOperator_Invalid || kind > CXUnaryOperator_Last)
+    return cxstring::createEmpty();
+
   return cxstring::createRef(
       UnaryOperator::getOpcodeStr(static_cast<UnaryOperatorKind>(kind - 1)));
 }


### PR DESCRIPTION
When clang_getUnaryOperatorKindSpelling() is called with CXUnaryOperator_Invalid as argument, UnaryOperator::getOpcodeStr() gets called with an invalid Opcode of -1, leading to a crash.

Fix it by checking for the last valid opcode as is done in clang_getBinaryOperatorKindSpelling().

Do the same for clang_getBinaryOperatorKindSpelling(), as its logic is the same.