### PR TITLE
Disable shared builds for tests failing on Windows

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/optional/TestDataFormatterGenericOptional.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/optional/TestDataFormatterGenericOptional.py
@@ -6,6 +6,7 @@ from lldbsuite.test import lldbutil
 
 class GenericOptionalDataFormatterTestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def do_test_with_run_command(self):
         """Test that that file and class static variables display correctly."""

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def do_test(self):
         """Test `frame variable` output for `std::shared_ptr` types."""

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/span/TestDataFormatterStdSpan.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/span/TestDataFormatterStdSpan.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 class StdSpanDataFormatterTestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def findVariable(self, name):
         var = self.frame().FindVariable(name)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/string_view/TestDataFormatterStdStringView.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/string_view/TestDataFormatterStdStringView.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 
 class StdStringViewDataFormatterTestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/u8string/TestDataFormatterStdU8String.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/u8string/TestDataFormatterStdU8String.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 
 class StdU8StringDataFormatterTestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def do_test(self):
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/u8string_view/TestDataFormatterStdU8StringView.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/u8string_view/TestDataFormatterStdU8StringView.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 
 class StdU8StringViewDataFormatterTestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def do_test(self):
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def do_test(self):
         """Test `frame variable` output for `std::unique_ptr` types."""

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unordered/TestDataFormatterGenericUnordered.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unordered/TestDataFormatterGenericUnordered.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 
 class GenericUnorderedDataFormatterTestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/variant/TestDataFormatterStdVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/variant/TestDataFormatterStdVariant.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 class StdVariantDataFormatterTestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def do_test(self):
         """Test that that file and class static variables display correctly."""

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vector/TestDataFormatterStdVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vector/TestDataFormatterStdVector.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 class StdVectorDataFormatterTestCase(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def check_numbers(self, var_name, show_ptr=False):
         patterns = []

--- a/lldb/test/API/test_utils/pdb/TestPdb.py
+++ b/lldb/test/API/test_utils/pdb/TestPdb.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 
 class TestBuildMethod(TestBase):
     TEST_WITH_PDB_DEBUG_INFO = True
+    SHARED_BUILD_TESTCASE = False
 
     def test(self):
         self.build()


### PR DESCRIPTION
PR #181720 introduced shared builds for LLDB API tests to improve test efficiency. But several data formatter tests requiring PDB debug info are failing on Windows x64 and AArch64 platforms.

This patch disables shared builds for these tests by setting SHARED_BUILD_TESTCASE = False

The shared build optimization breaks these tests because they reuse build artifacts between test methods
The test runs may could use multiple methods with different debug formats or compiler flags. When a test runs first it builds with one set of flags, but then it runs again but **make** sees the source unchanged so it skips rebuilding and reuses the same old binary instead of rebuilding with correct flags.