### PR TITLE
[AArch64] -aarch64-enable-global-isel-at-O=-1 should disable GISel

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -397,7 +397,7 @@ AArch64TargetMachine::AArch64TargetMachine(const Target &T, const Triple &TT,
 
   // Enable GlobalISel at or below EnableGlobalISelAt0, unless this is
   // MachO/CodeModel::Large, which GlobalISel does not support.
-  if (TargetSupportsGISel &&
+  if (TargetSupportsGISel && EnableGlobalISelAtO != -1 &&
       (static_cast<int>(getOptLevel()) <= EnableGlobalISelAtO ||
        (!GlobalISelFlag && !Options.EnableGlobalISel))) {
     setGlobalISel(true);

--- a/llvm/test/CodeGen/AArch64/GlobalISel/gisel-commandline-option-fastisel.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/gisel-commandline-option-fastisel.ll
@@ -5,6 +5,11 @@
 ; RUN:   | FileCheck %s --check-prefixes=DISABLED,FASTISEL
 
 ; RUN: llc -mtriple=aarch64-- -debug-pass=Structure %s -o /dev/null 2>&1 \
+; RUN:   -verify-machineinstrs=0 -O0 -aarch64-enable-global-isel-at-O=-1 \
+; RUN:   -debug-only=isel \
+; RUN:   | FileCheck %s --check-prefixes=DISABLED,FASTISEL
+
+; RUN: llc -mtriple=aarch64-- -debug-pass=Structure %s -o /dev/null 2>&1 \
 ; RUN:   -verify-machineinstrs=0 -O1 -global-isel=false -debug-only=isel \
 ; RUN:   | FileCheck %s --check-prefixes=DISABLED,NOFASTISEL
 

--- a/llvm/test/CodeGen/AArch64/GlobalISel/gisel-commandline-option.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/gisel-commandline-option.ll
@@ -41,7 +41,7 @@
 ; RUN: llc -mtriple=aarch64-- -debug-pass=Structure %s -o /dev/null 2>&1 \
 ; RUN:   --debugify-and-strip-all-safe=0 \
 ; RUN:   -verify-machineinstrs=0 -aarch64-enable-global-isel-at-O=-1 \
-; RUN:   | FileCheck %s --check-prefix NOT-ENABLED
+; RUN:   | FileCheck %s --check-prefix DISABLED
 
 ; RUN: llc -mtriple=aarch64-- -debug-pass=Structure %s -o /dev/null 2>&1 \
 ; RUN:   --debugify-and-strip-all-safe=0 \


### PR DESCRIPTION
Recent changes in #174746 to use GISel for optnone functions broke this. Now at O3 -aarch64-enable-global-isel-at-O=-1 is having the opposite affect of actually enabling GISel instead of SDAG and at O0 FastISel is no longer used. I've added a check for if this is disabled.