### PR TITLE
[Verifier] Add checks for loop metadata nodes

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -546,6 +546,7 @@ private:
   void visitAccessGroupMetadata(const MDNode *MD);
   void visitCapturesMetadata(Instruction &I, const MDNode *Captures);
   void visitAllocTokenMetadata(Instruction &I, MDNode *MD);
+  void verifyLoopMetadata(const MDNode *LoopID);
 
   template <class Ty> bool isValidMetadataArray(const MDTuple &N);
 #define HANDLE_SPECIALIZED_MDNODE_LEAF(CLASS) void visit##CLASS(const CLASS &N);
@@ -1143,6 +1144,60 @@ void Verifier::visitMDNode(const MDNode &MD, AreDebugLocsAllowed AllowLocs) {
   // Check these last, so we diagnose problems in operands first.
   Check(!MD.isTemporary(), "Expected no forward declarations!", &MD);
   Check(MD.isResolved(), "All nodes should be resolved!", &MD);
+}
+
+// Loop attributes that require exactly two operands (name + i1).
+static const char *const LoopBooleanAttributeNames[] = {
+    "llvm.loop.distribute.enable",
+    "llvm.loop.vectorize.enable",
+};
+
+// Loop attributes that allow only a single operand (just the name).
+// TODO: This is not an exhaustive list and can also include attributes
+//       like llvm.loop.licm_versioning.disable.
+static const char *const LoopSingleOperandAttributeNames[] = {
+    "llvm.loop.unroll.disable",
+    "llvm.loop.unroll.enable",
+    "llvm.loop.unroll.full",
+    "llvm.loop.unroll_and_jam.enable",
+    "llvm.loop.unroll_and_jam.disable",
+};
+
+void Verifier::verifyLoopMetadata(const MDNode *LoopID) {
+  // Allow empty loop metadata (!{}) so the verifier does not crash on malformed
+  // IR; skip further checks.
+  if (LoopID->getNumOperands() == 0)
+    return;
+  Check(LoopID->getNumOperands() >= 1,
+        "llvm.loop metadata must have at least one operand", LoopID);
+  for (const MDOperand &Op : llvm::drop_begin(LoopID->operands())) {
+    MDNode *Option = dyn_cast<MDNode>(Op);
+    if (!Option || Option->getNumOperands() < 1)
+      continue;
+    MDString *Name = dyn_cast<MDString>(Option->getOperand(0));
+    if (!Name)
+      continue;
+    StringRef AttrName = Name->getString();
+
+    // Verify single-operand attributes.
+    if (llvm::is_contained(LoopSingleOperandAttributeNames, AttrName)) {
+      Check(Option->getNumOperands() == 1,
+            "llvm.loop attribute must have exactly one operand", Option);
+      continue;
+    }
+
+    // Verify boolean attributes.
+    if (llvm::is_contained(LoopBooleanAttributeNames, AttrName)) {
+      // Boolean loop attribute: exactly 2 operands (name + i1).
+      Check(Option->getNumOperands() == 2,
+            "llvm.loop boolean attribute must have exactly two operands", Option);
+      auto *Val =
+          mdconst::dyn_extract_or_null<ConstantInt>(Option->getOperand(1));
+      Check(Val && Val->getType()->isIntegerTy(1),
+            "llvm.loop boolean attribute second operand must be i1", Option);
+      continue;
+    }
+  }
 }
 
 void Verifier::visitValueAsMetadata(const ValueAsMetadata &MD, Function *F) {
@@ -5831,6 +5886,8 @@ void Verifier::visitInstruction(Instruction &I) {
             ? AreDebugLocsAllowed::Yes
             : AreDebugLocsAllowed::No;
     visitMDNode(*Attachment.second, AllowLocs);
+    if (Kind == LLVMContext::MD_loop)
+      verifyLoopMetadata(Attachment.second);
   }
 
   InstsInThisBlock.insert(&I);

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -1190,7 +1190,8 @@ void Verifier::verifyLoopMetadata(const MDNode *LoopID) {
     if (llvm::is_contained(LoopBooleanAttributeNames, AttrName)) {
       // Boolean loop attribute: exactly 2 operands (name + i1).
       Check(Option->getNumOperands() == 2,
-            "llvm.loop boolean attribute must have exactly two operands", Option);
+            "llvm.loop boolean attribute must have exactly two operands",
+            Option);
       auto *Val =
           mdconst::dyn_extract_or_null<ConstantInt>(Option->getOperand(1));
       Check(Val && Val->getType()->isIntegerTy(1),

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -1147,7 +1147,7 @@ void Verifier::visitMDNode(const MDNode &MD, AreDebugLocsAllowed AllowLocs) {
 }
 
 // Loop attributes that require exactly two operands (name + i1).
-static const char *const LoopBooleanAttributeNames[] = {
+static const StringRef LoopBooleanAttributeNames[] = {
     "llvm.loop.distribute.enable",
     "llvm.loop.vectorize.enable",
 };
@@ -1155,7 +1155,7 @@ static const char *const LoopBooleanAttributeNames[] = {
 // Loop attributes that allow only a single operand (just the name).
 // TODO: This is not an exhaustive list and can also include attributes
 //       like llvm.loop.licm_versioning.disable.
-static const char *const LoopSingleOperandAttributeNames[] = {
+static const StringRef LoopSingleOperandAttributeNames[] = {
     "llvm.loop.unroll.disable",
     "llvm.loop.unroll.enable",
     "llvm.loop.unroll.full",
@@ -1169,7 +1169,7 @@ void Verifier::verifyLoopMetadata(const MDNode *LoopID) {
   if (LoopID->getNumOperands() == 0)
     return;
   Check(LoopID->getNumOperands() >= 1,
-        "llvm.loop metadata must have at least one operand", LoopID);
+        "llvm.loop metadata must have at least one operand.", LoopID);
   for (const MDOperand &Op : llvm::drop_begin(LoopID->operands())) {
     MDNode *Option = dyn_cast<MDNode>(Op);
     if (!Option || Option->getNumOperands() < 1)
@@ -1182,7 +1182,7 @@ void Verifier::verifyLoopMetadata(const MDNode *LoopID) {
     // Verify single-operand attributes.
     if (llvm::is_contained(LoopSingleOperandAttributeNames, AttrName)) {
       Check(Option->getNumOperands() == 1,
-            "llvm.loop attribute must have exactly one operand", Option);
+            "llvm.loop metadata must have exactly one operand.", Option);
       continue;
     }
 
@@ -1190,12 +1190,11 @@ void Verifier::verifyLoopMetadata(const MDNode *LoopID) {
     if (llvm::is_contained(LoopBooleanAttributeNames, AttrName)) {
       // Boolean loop attribute: exactly 2 operands (name + i1).
       Check(Option->getNumOperands() == 2,
-            "llvm.loop boolean attribute must have exactly two operands",
-            Option);
+            "llvm.loop metadata must have exactly two operands.", Option);
       auto *Val =
           mdconst::dyn_extract_or_null<ConstantInt>(Option->getOperand(1));
       Check(Val && Val->getType()->isIntegerTy(1),
-            "llvm.loop boolean attribute second operand must be i1", Option);
+            "llvm.loop metadata's second operand must be of type i1.", Option);
       continue;
     }
   }

--- a/llvm/test/Transforms/IndVarSimplify/pr68260.ll
+++ b/llvm/test/Transforms/IndVarSimplify/pr68260.ll
@@ -49,4 +49,4 @@ exit:
 }
 
 !0 = distinct !{!0, !1}
-!1 = !{!"llvm.loop.unroll.disable", i1 true}
+!1 = !{!"llvm.loop.unroll.disable"}

--- a/llvm/test/Transforms/LoopDistribute/disable_nonforced_enable.ll
+++ b/llvm/test/Transforms/LoopDistribute/disable_nonforced_enable.ll
@@ -43,4 +43,4 @@ for.end:
   ret void
 }
 
-!0 = distinct !{!0, !{!"llvm.loop.disable_nonforced"}, !{!"llvm.loop.distribute.enable", i32 1}}
+!0 = distinct !{!0, !{!"llvm.loop.disable_nonforced"}, !{!"llvm.loop.distribute.enable", i1 1}}

--- a/llvm/test/Transforms/LoopDistribute/malformed-metadata.ll
+++ b/llvm/test/Transforms/LoopDistribute/malformed-metadata.ll
@@ -1,11 +1,8 @@
-; RUN: opt -passes=transform-warning -disable-output -pass-remarks-missed=transform-warning -pass-remarks-analysis=transform-warning < %s 2>&1 | FileCheck -allow-empty %s
+; RUN: not opt -passes=verify -S < %s 2>&1 | FileCheck %s
 ;
-; Verify that no transformation warnings are emitted for functions with
-; 'optnone' attribute.
-;
-target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+; CHECK: llvm.loop boolean attribute must have exactly two operands
 
-define void @func(ptr nocapture %A, ptr nocapture readonly %B, i32 %Length) #0 {
+define void @test(ptr nocapture %A, ptr nocapture readonly %B, i32 %Length) {
 entry:
   %cmp9 = icmp sgt i32 %Length, 0
   br i1 %cmp9, label %for.body.preheader, label %for.end
@@ -25,7 +22,7 @@ for.body:
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %lftr.wideiv = trunc i64 %indvars.iv.next to i32
   %exitcond = icmp eq i32 %lftr.wideiv, %Length
-  br i1 %exitcond, label %for.end.loopexit, label %for.body, !llvm.loop !0
+  br i1 %exitcond, label %for.end.loopexit, label %for.body, !llvm.loop !50
 
 for.end.loopexit:
   br label %for.end
@@ -34,13 +31,4 @@ for.end:
   ret void
 }
 
-attributes #0 = { noinline optnone }
-
-!0 = distinct !{!0, !1, !2, !3}
-!1 = !{!"llvm.loop.unroll.enable"}
-!2 = !{!"llvm.loop.distribute.enable", i1 1}
-!3 = !{!"llvm.loop.unroll_and_jam.enable"}
-!4 = !{!"llvm.loop.vectorize.enable", i1 1}
-
-
-; CHECK-NOT: warning
+!50 = !{!50, !{!"llvm.loop.distribute.enable"}}

--- a/llvm/test/Transforms/LoopDistribute/malformed-metadata.ll
+++ b/llvm/test/Transforms/LoopDistribute/malformed-metadata.ll
@@ -1,28 +1,14 @@
-; RUN: not opt -passes=verify -S < %s 2>&1 | FileCheck %s
+; RUN: not opt -passes=loop-distribute -S < %s 2>&1 | FileCheck %s
 ;
-; CHECK: llvm.loop boolean attribute must have exactly two operands
+; CHECK: llvm.loop metadata must have exactly two operands.
 
-define void @test(ptr nocapture %A, ptr nocapture readonly %B, i32 %Length) {
+;define void @test(ptr nocapture %A, ptr nocapture readonly %B, i32 %Length) {
+define void @test(i1 %exitcond) {
 entry:
-  %cmp9 = icmp sgt i32 %Length, 0
-  br i1 %cmp9, label %for.body.preheader, label %for.end
+  br label %loop
 
-for.body.preheader:
-  br label %for.body
-
-for.body:
-  %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %for.body.preheader ]
-  %arrayidx = getelementptr inbounds i32, ptr %B, i64 %indvars.iv
-  %0 = load i32, ptr %arrayidx, align 4
-  %idxprom1 = sext i32 %0 to i64
-  %arrayidx2 = getelementptr inbounds i32, ptr %A, i64 %idxprom1
-  %1 = load i32, ptr %arrayidx2, align 4
-  %arrayidx4 = getelementptr inbounds i32, ptr %A, i64 %indvars.iv
-  store i32 %1, ptr %arrayidx4, align 4
-  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
-  %lftr.wideiv = trunc i64 %indvars.iv.next to i32
-  %exitcond = icmp eq i32 %lftr.wideiv, %Length
-  br i1 %exitcond, label %for.end.loopexit, label %for.body, !llvm.loop !50
+loop:
+  br i1 %exitcond, label %for.end.loopexit, label %loop, !llvm.loop !0
 
 for.end.loopexit:
   br label %for.end
@@ -31,4 +17,4 @@ for.end:
   ret void
 }
 
-!50 = !{!50, !{!"llvm.loop.distribute.enable"}}
+!0 = !{!0, !{!"llvm.loop.distribute.enable"}}

--- a/llvm/test/Transforms/LoopTransformWarning/distribution-remarks-missed.ll
+++ b/llvm/test/Transforms/LoopTransformWarning/distribution-remarks-missed.ll
@@ -90,4 +90,4 @@ for.end:
 !45 = !DILocation(line: 27, column: 21, scope: !37)
 !46 = distinct !DISubprogram(name: "test_multiple_failures", line: 26, isLocal: false, isDefinition: true, virtualIndex: 6, flags: DIFlagPrototyped, isOptimized: true, unit: !0, scopeLine: 26, file: !1, scope: !5, type: !6, retainedNodes: !2)
 
-!50 = !{!50, !{!"llvm.loop.distribute.enable"}}
+!50 = !{!50, !{!"llvm.loop.distribute.enable", i1 true}}

--- a/llvm/test/Transforms/LoopUnroll/malformed-metadata.ll
+++ b/llvm/test/Transforms/LoopUnroll/malformed-metadata.ll
@@ -1,0 +1,17 @@
+; RUN: not opt -passes=verify -S < %s 2>&1 | FileCheck %s
+;
+; CHECK: llvm.loop attribute must have exactly one operand
+
+define void @test(ptr nocapture %A, i32 %N) {
+entry:
+  br label %loop
+loop:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+  %i.next = add i32 %i, 1
+  %cond = icmp slt i32 %i.next, %N
+  br i1 %cond, label %loop, label %exit, !llvm.loop !0
+exit:
+  ret void
+}
+
+!0 = !{!0, !{!"llvm.loop.unroll.disable", i1 0}}

--- a/llvm/test/Transforms/LoopUnroll/malformed-metadata.ll
+++ b/llvm/test/Transforms/LoopUnroll/malformed-metadata.ll
@@ -1,15 +1,12 @@
-; RUN: not opt -passes=verify -S < %s 2>&1 | FileCheck %s
+; RUN: not opt -passes=loop-unroll -S < %s 2>&1 | FileCheck %s
 ;
-; CHECK: llvm.loop attribute must have exactly one operand
+; CHECK: llvm.loop metadata must have exactly one operand.
 
-define void @test(ptr nocapture %A, i32 %N) {
+define void @test(i1 %exitcond) {
 entry:
   br label %loop
 loop:
-  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
-  %i.next = add i32 %i, 1
-  %cond = icmp slt i32 %i.next, %N
-  br i1 %cond, label %loop, label %exit, !llvm.loop !0
+  br i1 %exitcond, label %loop, label %exit, !llvm.loop !0
 exit:
   ret void
 }

--- a/llvm/test/Transforms/LoopUnrollAndJam/malformed-metadata.ll
+++ b/llvm/test/Transforms/LoopUnrollAndJam/malformed-metadata.ll
@@ -1,0 +1,17 @@
+; RUN: not opt -passes=verify -S < %s 2>&1 | FileCheck %s
+;
+; CHECK: llvm.loop attribute must have exactly one operand
+
+define void @test(ptr nocapture %A, i32 %N) {
+entry:
+  br label %loop
+loop:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+  %i.next = add i32 %i, 1
+  %cond = icmp slt i32 %i.next, %N
+  br i1 %cond, label %loop, label %exit, !llvm.loop !0
+exit:
+  ret void
+}
+
+!0 = !{!0, !{!"llvm.loop.unroll_and_jam.enable", i1 1}}

--- a/llvm/test/Transforms/LoopUnrollAndJam/malformed-metadata.ll
+++ b/llvm/test/Transforms/LoopUnrollAndJam/malformed-metadata.ll
@@ -1,15 +1,12 @@
-; RUN: not opt -passes=verify -S < %s 2>&1 | FileCheck %s
+; RUN: not opt -passes=loop-unroll-and-jam -S < %s 2>&1 | FileCheck %s
 ;
-; CHECK: llvm.loop attribute must have exactly one operand
+; CHECK: llvm.loop metadata must have exactly one operand.
 
-define void @test(ptr nocapture %A, i32 %N) {
+define void @test(i1 %exitcond) {
 entry:
   br label %loop
 loop:
-  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
-  %i.next = add i32 %i, 1
-  %cond = icmp slt i32 %i.next, %N
-  br i1 %cond, label %loop, label %exit, !llvm.loop !0
+  br i1 %exitcond, label %exit, label %loop, !llvm.loop !0
 exit:
   ret void
 }

--- a/llvm/test/Transforms/LoopVectorize/disable_nonforced_enable.ll
+++ b/llvm/test/Transforms/LoopVectorize/disable_nonforced_enable.ll
@@ -26,4 +26,4 @@ for.end:
   ret void
 }
 
-!0 = !{!0, !{!"llvm.loop.disable_nonforced"}, !{!"llvm.loop.vectorize.enable", i32 1}}
+!0 = !{!0, !{!"llvm.loop.disable_nonforced"}, !{!"llvm.loop.vectorize.enable", i1 true}}

--- a/llvm/test/Transforms/LoopVectorize/remove_metadata.ll
+++ b/llvm/test/Transforms/LoopVectorize/remove_metadata.ll
@@ -25,7 +25,7 @@ for.end:
   ret void
 }
 
-!0 = !{!0, !{!"llvm.loop.vectorize.some_property"}, !{!"llvm.loop.vectorize.enable", i32 1}}
+!0 = !{!0, !{!"llvm.loop.vectorize.some_property"}, !{!"llvm.loop.vectorize.enable", i1 true}}
 
 ; CHECK-NOT: llvm.loop.vectorize.
 ; CHECK: {!"llvm.loop.isvectorized", i32 1}


### PR DESCRIPTION
This patch adds checks in verifier to error if loop metadata enable and disable nodes are not following the syntax as per LangRef.

Particualrly, the below metadata must have name and i1.
    "llvm.loop.distribute.enable"
    "llvm.loop.vectorize.enable"

e.g.
!0 = !{!"llvm.loop.distribute.enable", i1 0}

and the below ones should have just the name.
    "llvm.loop.unroll.disable"
    "llvm.loop.unroll.enable"
    "llvm.loop.unroll.full"
    "llvm.loop.unroll_and_jam.enable"
    "llvm.loop.unroll_and_jam.disable"

e.g.
    !0 = !{!"llvm.loop.unroll.disable"}

This patch also fixes inconsistencies in the exisiting tests and adds malformed IR tests which should not go beyond verifier.

Fixes #156685