### PR TITLE
[mlir][tosa] Fix dense_resource data alignment in tosa-narrow-* tests

### DIFF
--- a/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32-aggressive.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32-aggressive.mlir
@@ -84,7 +84,7 @@ func.func @test_dense_ressource_f64() -> tensor<1x2xf64> {
   dialect_resources: {
     builtin: {
       // COMMON: resource: "0x04000000DB0F4940EAD6FCBD"
-      resource: "0x04000000182D4454FB21094059F64637DD9ABFBF"
+      resource: "0x08000000182D4454FB21094059F64637DD9ABFBF"
     }
   }
 #-}

--- a/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32.mlir
@@ -194,7 +194,7 @@ func.func @test_dense_ressource_f64() -> tensor<1x2xf64> {
   dialect_resources: {
     builtin: {
       // COMMON: resource: "0x040000000000803F000080BF"
-      resource: "0x04000000000000000000F03F000000000000F0BF"
+      resource: "0x08000000000000000000F03F000000000000F0BF"
     }
   }
 #-}

--- a/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32-aggressive.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32-aggressive.mlir
@@ -104,7 +104,7 @@ func.func @test_dense_ressource_i64() -> tensor<1x2xi64> {
   dialect_resources: {
     builtin: {
       // COMMON: resource: "0x04000000FFFFFF7F00000080"
-      resource: "0x04000000000000000800000000000000F8FFFFFF"
+      resource: "0x08000000000000000800000000000000F8FFFFFF"
     }
   }
 #-}

--- a/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32.mlir
@@ -215,7 +215,7 @@ func.func @test_dense_ressource_i64() -> tensor<1x2xi64> {
   dialect_resources: {
     builtin: {
       // COMMON: resource: "0x04000000FEFFFF7F905AE75A"
-      resource: "0x04000000FEFFFF7F00000000905AE75A00000000"
+      resource: "0x08000000FEFFFF7F00000000905AE75A00000000"
     }
   }
 #-}


### PR DESCRIPTION
The alignment of int64 and float64 dense resource should be 8 and not 4