### PR TITLE
[Clang] Fixed an assertion in constant evaluation of EmbedExpr inside array initializers.

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -14770,8 +14770,7 @@ bool ArrayExprEvaluator::VisitCXXParenListOrInitListExpr(
         Value = SL->getCodeUnit(I);
         if (DestTy->isIntegerType()) {
           Result.getArrayInitializedElt(ArrayIndex) = APValue(Value);
-        } else {
-          assert(DestTy->isFloatingType() && "unexpected type");
+        } else if (DestTy->isFloatingType()) {
           const FPOptions FPO =
               Init->getFPFeaturesInEffect(Info.Ctx.getLangOpts());
           APFloat FValue(0.0);
@@ -14779,6 +14778,8 @@ bool ArrayExprEvaluator::VisitCXXParenListOrInitListExpr(
                                     DestTy, FValue))
             return false;
           Result.getArrayInitializedElt(ArrayIndex) = APValue(FValue);
+        } else {
+          return false;
         }
         ArrayIndex++;
       }

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -14770,7 +14770,7 @@ bool ArrayExprEvaluator::VisitCXXParenListOrInitListExpr(
         Value = SL->getCodeUnit(I);
         if (DestTy->isIntegerType()) {
           Result.getArrayInitializedElt(ArrayIndex) = APValue(Value);
-        } else if (DestTy->isFloatingType()) {
+        } else if (DestTy->isRealFloatingType()) {
           const FPOptions FPO =
               Init->getFPFeaturesInEffect(Info.Ctx.getLangOpts());
           APFloat FValue(0.0);

--- a/clang/test/Sema/embed_compound_literal.c
+++ b/clang/test/Sema/embed_compound_literal.c
@@ -1,6 +1,7 @@
-// RUN: %clang_cc1 -std=c23 -fsyntax-only -verify %s
-// RUN: %clang_cc1 -fsyntax-only -verify -x c++ -Wno-c23-extensions %s
-// expected-no-diagnostics
+// RUN: %clang_cc1 -std=c23 -fsyntax-only -verify=ok %s
+// RUN: %clang_cc1 -fsyntax-only -verify=ok -x c++ -Wno-c23-extensions %s
+// RUN: %clang_cc1 -std=c23 -fsyntax-only -verify -DNEGATIVE %s
+// ok-no-diagnostics
 
 char *p1 = (char[]){
 #embed __FILE__
@@ -13,3 +14,37 @@ int *p2 = (int[]){
 int *p3 = (int[30]){
 #embed __FILE__ limit(30)
 };
+
+
+#ifdef NEGATIVE
+
+// Pointer element type
+char *bad_ptr = (int (*[5]) 0){ // expected-error {{expected ')'}}
+                                  // expected-note@-1 {{to match this '('}}
+// expected-error@-2 {{incompatible pointer types initializing}}
+// expected-error@-3 {{initializer element is not a compile-time constant}}
+#embed __FILE__
+// expected-error@-1 {{incompatible integer to pointer conversion}}
+// expected-warning@-2 {{excess elements in array initializer}}
+};
+
+
+// Struct element type
+struct S { int x; };
+struct S bad_struct = (struct S[5]){ // expected-error {{initializing 'struct S'}}
+
+#embed __FILE__
+// expected-warning@-1 {{excess elements in array initializer}}
+};
+
+
+// Enum element type
+enum E { A };
+enum E bad_enum = (enum E[5]){ // expected-error {{incompatible pointer to integer conversion}}
+// expected-error@-1 {{initializer element is not a compile-time constant}}
+
+#embed __FILE__
+// expected-warning@-1 {{excess elements in array initializer}}
+};
+
+#endif


### PR DESCRIPTION
`ArrayExprEvaluator::VisitCXXParenListOrInitListExpr` assumed that when handling an `EmbedExpr`, the destination array element type must be either integer or floating. However, EmbedExpr may appear in array initializers whose element type is non-arithmetic (for example, pointer types).

When this occurs, the evaluator hit an `assertion (DestTy->isFloatingType() && "unexpected type")`, resulting in an internal compiler error.

Instead of asserting, the evaluator should treat unsupported element types as non-constant and return false, allowing normal semantic diagnostics to be emitted.

This change removes the assertion and ensures that invalid code produces diagnostics rather than crashing the compiler.

Fixes #182212