### PR TITLE
[lldb][RISCV] Make char an unsigned type for RISC-V by default

### DIFF
--- a/lldb/source/Utility/ArchSpec.cpp
+++ b/lldb/source/Utility/ArchSpec.cpp
@@ -721,6 +721,8 @@ bool ArchSpec::CharIsSignedByDefault() const {
   case llvm::Triple::ppc64:
     return m_triple.isOSDarwin();
 
+  case llvm::Triple::riscv64:
+  case llvm::Triple::riscv32:
   case llvm::Triple::ppc64le:
   case llvm::Triple::systemz:
   case llvm::Triple::xcore:


### PR DESCRIPTION
According to RISC-V ELF psABI, Section 4.3 (C/C++ Type Representations) "char is unsigned".

This patch makes plain `char` unsigned by default on RISC-V. Also this fixes TestConstStaticIntegralMember.py on RISC-V