### PR TITLE
[libc][math] Refactor bf16divf128 to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math/bf16divf128.h
+++ b/libc/shared/math/bf16divf128.h
@@ -1,0 +1,29 @@
+//===-- Shared bf16divf128 function -----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_MATH_BF16DIVF128_H
+#define LLVM_LIBC_SHARED_MATH_BF16DIVF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "shared/libc_common.h"
+#include "src/__support/math/bf16divf128.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using math::bf16divf128;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SHARED_MATH_BF16DIVF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1928,6 +1928,18 @@ add_header_library(
 )
 
 add_header_library(
+  bf16divf128
+  HDRS
+    bf16divf128.h
+  DEPENDS
+    libc.src.__support.FPUtil.bfloat16
+    libc.src.__support.FPUtil.generic.div
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.include.llvm-libc-types.float128
+)
+
+add_header_library(
   tan
   HDRS
     tan.h

--- a/libc/src/__support/math/bf16divf128.h
+++ b/libc/src/__support/math/bf16divf128.h
@@ -1,0 +1,32 @@
+//===-- Implementation header for bf16divf128 -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_BF16DIVF128_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_BF16DIVF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/FPUtil/generic/div.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace math {
+
+LIBC_INLINE static bfloat16 bf16divf128(float128 x, float128 y) {
+  return fputil::generic::div<bfloat16>(x, y);
+}
+
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_BF16DIVF128_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -5181,11 +5181,7 @@ add_entrypoint_object(
   HDRS
     ../bf16divf128.h
   DEPENDS
-    libc.src.__support.common
-    libc.src.__support.FPUtil.bfloat16
-    libc.src.__support.FPUtil.generic.div
-    libc.src.__support.macros.config
-    libc.src.__support.macros.properties.types
+    libc.src.__support.math.bf16divf128
 )
 
 add_entrypoint_object(

--- a/libc/src/math/generic/bf16divf128.cpp
+++ b/libc/src/math/generic/bf16divf128.cpp
@@ -7,15 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/bf16divf128.h"
-#include "src/__support/FPUtil/bfloat16.h"
-#include "src/__support/FPUtil/generic/div.h"
-#include "src/__support/common.h"
-#include "src/__support/macros/config.h"
+#include "src/__support/math/bf16divf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(bfloat16, bf16divf128, (float128 x, float128 y)) {
-  return fputil::generic::div<bfloat16>(x, y);
+  return math::bf16divf128(x, y);
 }
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
Move the [bf16divf128](cci:1://file:///d:/OpenSource/llvm-project/libc/src/__support/math/bf16divf128.h:23:0-25:1) implementation to a header-only function in
[src/__support/math/bf16divf128.h](cci:7://file:///d:/OpenSource/llvm-project/libc/src/__support/math/bf16divf128.h:0:0-0:0) and expose it via [shared/math/bf16divf128.h](cci:7://file:///d:/OpenSource/llvm-project/libc/shared/math/bf16divf128.h:0:0-0:0).
The original [src/math/generic/bf16divf128.cpp](cci:7://file:///d:/OpenSource/llvm-project/libc/src/math/generic/bf16divf128.cpp:0:0-0:0) is updated to delegate to
the new header-only implementation.

Part of the effort to make libc math functions header-only for C++23
constexpr math support.

Closes #181024