### PR TITLE
[ClangLinkerWrapper] Forward --allow-multiple-definition to linker.

### DIFF
--- a/clang/test/Driver/linker-wrapper-allow-multiple-definition.c
+++ b/clang/test/Driver/linker-wrapper-allow-multiple-definition.c
@@ -1,0 +1,19 @@
+// UNSUPPORTED: system-windows
+// REQUIRES: x86-registered-target
+// REQUIRES: amdgpu-registered-target
+
+// An externally visible variable so static libraries extract.
+__attribute__((visibility("protected"), used)) int x;
+
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.elf.o
+// RUN: %clang -cc1 %s -triple amdgcn-amd-amdhsa -emit-llvm-bc -o %t.amdgpu.bc
+
+// RUN: llvm-offload-binary -o %t.out \
+// RUN:   --image=file=%t.amdgpu.bc,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx908
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t.o -fembed-offload-object=%t.out
+// RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
+// RUN:   --linker-path=/usr/bin/ld.lld --allow-multiple-definition \
+// RUN:   %t.o -o a.out 2>&1 | FileCheck %s
+
+// CHECK: clang{{.*}} -Wl,--allow-multiple-definition
+// CHECK: /usr/bin/ld.lld{{.*}} --allow-multiple-definition

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -574,6 +574,9 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
   if (Args.hasArg(OPT_embed_bitcode))
     CmdArgs.push_back("-Wl,--lto-emit-llvm");
 
+  if (Args.hasArg(OPT_allow_multiple_definition))
+    CmdArgs.push_back("-Wl,--allow-multiple-definition");
+
   // For linking device code with the SYCL offload kind, special handling is
   // required. Passing --sycl-link to clang results in a call to
   // clang-sycl-linker. Additional linker flags required by clang-sycl-linker

--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -34,6 +34,8 @@ def verbose : Flag<["--"], "wrapper-verbose">,
 def embed_bitcode : Flag<["--"], "embed-bitcode">,
                     Flags<[WrapperOnlyOption]>,
                     HelpText<"Embed linked bitcode in the module">;
+def allow_multiple_definition : Flag<["--"], "allow-multiple-definition">,
+                    HelpText<"Allow multiple definitions">;
 def print_wrapped_module : Flag<["--"], "print-wrapped-module">,
   Flags<[WrapperOnlyOption]>,
   HelpText<"Print the wrapped module's IR for testing">;


### PR DESCRIPTION
When `-Wl,--allow-multiple-definition` is given on `flang` command line, it reaches `clang-linker-wrapper` but it ignores `--allow-multiple-definition` option and does not forward it to linker. This can cause a build which was passing otherwise to fail with --offload-arch=. This PR fixes the issue by forwarding the option so that it reaches the linker.