### PR TITLE
[lldb] generalize the GDBRemoteCommunicationClient::GetVContSupported method

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -493,19 +493,18 @@ bool GDBRemoteCommunicationClient::GetVContSupported(llvm::StringRef flavor) {
     m_supports_vCont_S = eLazyBoolNo;
     if (SendPacketAndWaitForResponse("vCont?", response) ==
         PacketResult::Success) {
-      std::string response_str(response.GetStringRef());
-      response_str += ';';
-      if (response_str.find(";c;") != std::string::npos)
-        m_supports_vCont_c = eLazyBoolYes;
-
-      if (response_str.find(";C;") != std::string::npos)
-        m_supports_vCont_C = eLazyBoolYes;
-
-      if (response_str.find(";s;") != std::string::npos)
-        m_supports_vCont_s = eLazyBoolYes;
-
-      if (response_str.find(";S;") != std::string::npos)
-        m_supports_vCont_S = eLazyBoolYes;
+      llvm::SmallVector<llvm::StringRef> flavors;
+      response.GetStringRef().split(";").second.split(flavors, ';');
+      for (llvm::StringRef flavor : flavors) {
+        if (flavor == "c")
+          m_supports_vCont_c = eLazyBoolYes;
+        if (flavor == "C")
+          m_supports_vCont_C = eLazyBoolYes;
+        if (flavor == "s")
+          m_supports_vCont_s = eLazyBoolYes;
+        if (flavor == "S")
+          m_supports_vCont_S = eLazyBoolYes;
+      }
 
       if (m_supports_vCont_c == eLazyBoolYes &&
           m_supports_vCont_C == eLazyBoolYes &&

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -493,9 +493,7 @@ bool GDBRemoteCommunicationClient::GetVContSupported(llvm::StringRef flavor) {
     m_supports_vCont_S = eLazyBoolNo;
     if (SendPacketAndWaitForResponse("vCont?", response) ==
         PacketResult::Success) {
-      llvm::SmallVector<llvm::StringRef> flavors;
-      response.GetStringRef().split(";").second.split(flavors, ';');
-      for (llvm::StringRef flavor : flavors) {
+      for (llvm::StringRef flavor : llvm::split(response.GetStringRef(), ';')) {
         if (flavor == "c")
           m_supports_vCont_c = eLazyBoolYes;
         if (flavor == "C")

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -493,14 +493,14 @@ bool GDBRemoteCommunicationClient::GetVContSupported(llvm::StringRef flavor) {
     m_supports_vCont_S = eLazyBoolNo;
     if (SendPacketAndWaitForResponse("vCont?", response) ==
         PacketResult::Success) {
-      for (llvm::StringRef flavor : llvm::split(response.GetStringRef(), ';')) {
-        if (flavor == "c")
+      for (llvm::StringRef token : llvm::split(response.GetStringRef(), ';')) {
+        if (token == "c")
           m_supports_vCont_c = eLazyBoolYes;
-        if (flavor == "C")
+        if (token == "C")
           m_supports_vCont_C = eLazyBoolYes;
-        if (flavor == "s")
+        if (token == "s")
           m_supports_vCont_s = eLazyBoolYes;
-        if (flavor == "S")
+        if (token == "S")
           m_supports_vCont_S = eLazyBoolYes;
       }
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -482,7 +482,7 @@ bool GDBRemoteCommunicationClient::GetThreadSuffixSupported() {
 }
 
 bool GDBRemoteCommunicationClient::GetVContSupported(llvm::StringRef flavor) {
-  assert(flavor.size() > 0);
+  assert(!flavor.empty());
   if (m_supports_vCont_c == eLazyBoolCalculate) {
     StringExtractorGDBRemote response;
     m_supports_vCont_any = eLazyBoolNo;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
@@ -214,7 +214,7 @@ public:
 
   void GetRemoteQSupported();
 
-  bool GetVContSupported(char flavor);
+  bool GetVContSupported(llvm::StringRef flavor);
 
   bool GetpPacketSupported(lldb::tid_t tid);
 
@@ -262,9 +262,9 @@ public:
 
   bool GetGroupName(uint32_t gid, std::string &name);
 
-  bool HasFullVContSupport() { return GetVContSupported('A'); }
+  bool HasFullVContSupport() { return GetVContSupported("A"); }
 
-  bool HasAnyVContSupport() { return GetVContSupported('a'); }
+  bool HasAnyVContSupport() { return GetVContSupported("a"); }
 
   bool GetStopReply(StringExtractorGDBRemote &response);
 

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -925,7 +925,7 @@ Status ProcessGDBRemote::ConnectToDebugserver(llvm::StringRef connect_url) {
   m_gdb_comm.GetThreadSuffixSupported();
   m_gdb_comm.GetListThreadsInStopReplySupported();
   m_gdb_comm.GetHostInfo();
-  m_gdb_comm.GetVContSupported('c');
+  m_gdb_comm.GetVContSupported("c");
   m_gdb_comm.GetVAttachOrWaitSupported();
   m_gdb_comm.EnableErrorStringInPacket();
 
@@ -1305,7 +1305,7 @@ Status ProcessGDBRemote::DoResume(RunDirection direction) {
         continue_packet.PutCString("vCont");
 
         if (!m_continue_c_tids.empty()) {
-          if (m_gdb_comm.GetVContSupported('c')) {
+          if (m_gdb_comm.GetVContSupported("c")) {
             for (tid_collection::const_iterator
                      t_pos = m_continue_c_tids.begin(),
                      t_end = m_continue_c_tids.end();
@@ -1316,7 +1316,7 @@ Status ProcessGDBRemote::DoResume(RunDirection direction) {
         }
 
         if (!continue_packet_error && !m_continue_C_tids.empty()) {
-          if (m_gdb_comm.GetVContSupported('C')) {
+          if (m_gdb_comm.GetVContSupported("C")) {
             for (tid_sig_collection::const_iterator
                      s_pos = m_continue_C_tids.begin(),
                      s_end = m_continue_C_tids.end();
@@ -1328,7 +1328,7 @@ Status ProcessGDBRemote::DoResume(RunDirection direction) {
         }
 
         if (!continue_packet_error && !m_continue_s_tids.empty()) {
-          if (m_gdb_comm.GetVContSupported('s')) {
+          if (m_gdb_comm.GetVContSupported("s")) {
             for (tid_collection::const_iterator
                      t_pos = m_continue_s_tids.begin(),
                      t_end = m_continue_s_tids.end();
@@ -1339,7 +1339,7 @@ Status ProcessGDBRemote::DoResume(RunDirection direction) {
         }
 
         if (!continue_packet_error && !m_continue_S_tids.empty()) {
-          if (m_gdb_comm.GetVContSupported('S')) {
+          if (m_gdb_comm.GetVContSupported("S")) {
             for (tid_sig_collection::const_iterator
                      s_pos = m_continue_S_tids.begin(),
                      s_end = m_continue_S_tids.end();

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -77,6 +77,48 @@ protected:
   MockServer server;
 };
 
+TEST_F(GDBRemoteCommunicationClientTest, vCont_c) {
+  std::future<bool> write_result = std::async(std::launch::async, [&] {
+    return client.GetVContSupported("c");
+  });
+  HandlePacket(server, "vCont?", "$vCont;c#16");
+  ASSERT_TRUE(write_result.get());
+  ASSERT_FALSE(client.GetVContSupported("C"));
+  ASSERT_FALSE(client.GetVContSupported("s"));
+  ASSERT_FALSE(client.GetVContSupported("S"));
+  ASSERT_TRUE(client.GetVContSupported("a"));
+  ASSERT_FALSE(client.GetVContSupported("A"));
+  return;
+}
+
+TEST_F(GDBRemoteCommunicationClientTest, vCont_C) {
+  std::future<bool> write_result = std::async(std::launch::async, [&] {
+    return client.GetVContSupported("c");
+  });
+  HandlePacket(server, "vCont?", "$vCont;C#16");
+  ASSERT_FALSE(write_result.get());
+  ASSERT_TRUE(client.GetVContSupported("C"));
+  ASSERT_FALSE(client.GetVContSupported("s"));
+  ASSERT_FALSE(client.GetVContSupported("S"));
+  ASSERT_TRUE(client.GetVContSupported("a"));
+  ASSERT_FALSE(client.GetVContSupported("A"));
+  return;
+}
+
+TEST_F(GDBRemoteCommunicationClientTest, vCont_cC) {
+  std::future<bool> write_result = std::async(std::launch::async, [&] {
+    return client.GetVContSupported("c");
+  });
+  HandlePacket(server, "vCont?", "$vCont;c;C#16");
+  ASSERT_TRUE(write_result.get());
+  ASSERT_TRUE(client.GetVContSupported("C"));
+  ASSERT_FALSE(client.GetVContSupported("s"));
+  ASSERT_FALSE(client.GetVContSupported("S"));
+  ASSERT_TRUE(client.GetVContSupported("a"));
+  ASSERT_FALSE(client.GetVContSupported("A"));
+  return;
+}
+
 TEST_F(GDBRemoteCommunicationClientTest, WriteRegister) {
   const lldb::tid_t tid = 0x47;
   const uint32_t reg_num = 4;

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -113,7 +113,6 @@ TEST_F(GDBRemoteCommunicationClientTest, vCont_cC) {
   ASSERT_FALSE(client.GetVContSupported("S"));
   ASSERT_TRUE(client.GetVContSupported("a"));
   ASSERT_FALSE(client.GetVContSupported("A"));
-  return;
 }
 
 TEST_F(GDBRemoteCommunicationClientTest, WriteRegister) {

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -78,9 +78,8 @@ protected:
 };
 
 TEST_F(GDBRemoteCommunicationClientTest, vCont_c) {
-  std::future<bool> write_result = std::async(std::launch::async, [&] {
-    return client.GetVContSupported("c");
-  });
+  std::future<bool> write_result = std::async(
+      std::launch::async, [&] { return client.GetVContSupported("c"); });
   HandlePacket(server, "vCont?", "$vCont;c#16");
   ASSERT_TRUE(write_result.get());
   ASSERT_FALSE(client.GetVContSupported("C"));
@@ -92,9 +91,8 @@ TEST_F(GDBRemoteCommunicationClientTest, vCont_c) {
 }
 
 TEST_F(GDBRemoteCommunicationClientTest, vCont_C) {
-  std::future<bool> write_result = std::async(std::launch::async, [&] {
-    return client.GetVContSupported("c");
-  });
+  std::future<bool> write_result = std::async(
+      std::launch::async, [&] { return client.GetVContSupported("c"); });
   HandlePacket(server, "vCont?", "$vCont;C#16");
   ASSERT_FALSE(write_result.get());
   ASSERT_TRUE(client.GetVContSupported("C"));
@@ -106,9 +104,8 @@ TEST_F(GDBRemoteCommunicationClientTest, vCont_C) {
 }
 
 TEST_F(GDBRemoteCommunicationClientTest, vCont_cC) {
-  std::future<bool> write_result = std::async(std::launch::async, [&] {
-    return client.GetVContSupported("c");
-  });
+  std::future<bool> write_result = std::async(
+      std::launch::async, [&] { return client.GetVContSupported("c"); });
   HandlePacket(server, "vCont?", "$vCont;c;C#16");
   ASSERT_TRUE(write_result.get());
   ASSERT_TRUE(client.GetVContSupported("C"));

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -87,7 +87,6 @@ TEST_F(GDBRemoteCommunicationClientTest, vCont_c) {
   ASSERT_FALSE(client.GetVContSupported("S"));
   ASSERT_TRUE(client.GetVContSupported("a"));
   ASSERT_FALSE(client.GetVContSupported("A"));
-  return;
 }
 
 TEST_F(GDBRemoteCommunicationClientTest, vCont_C) {
@@ -100,7 +99,6 @@ TEST_F(GDBRemoteCommunicationClientTest, vCont_C) {
   ASSERT_FALSE(client.GetVContSupported("S"));
   ASSERT_TRUE(client.GetVContSupported("a"));
   ASSERT_FALSE(client.GetVContSupported("A"));
-  return;
 }
 
 TEST_F(GDBRemoteCommunicationClientTest, vCont_cC) {

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -101,7 +101,7 @@ TEST_F(GDBRemoteCommunicationClientTest, vCont_C) {
   ASSERT_FALSE(client.GetVContSupported("A"));
 }
 
-TEST_F(GDBRemoteCommunicationClientTest, vCont_cC) {
+TEST_F(GDBRemoteCommunicationClientTest, vCont_c_C) {
   std::future<bool> write_result = std::async(
       std::launch::async, [&] { return client.GetVContSupported("c"); });
   HandlePacket(server, "vCont?", "$vCont;c;C#16");
@@ -110,6 +110,18 @@ TEST_F(GDBRemoteCommunicationClientTest, vCont_cC) {
   ASSERT_FALSE(client.GetVContSupported("s"));
   ASSERT_FALSE(client.GetVContSupported("S"));
   ASSERT_TRUE(client.GetVContSupported("a"));
+  ASSERT_FALSE(client.GetVContSupported("A"));
+}
+
+TEST_F(GDBRemoteCommunicationClientTest, vCont_cC_notAFeature) {
+  std::future<bool> write_result = std::async(
+      std::launch::async, [&] { return client.GetVContSupported("c"); });
+  HandlePacket(server, "vCont?", "$vCont;cC;notAFeature#16");
+  ASSERT_FALSE(write_result.get());
+  ASSERT_FALSE(client.GetVContSupported("C"));
+  ASSERT_FALSE(client.GetVContSupported("s"));
+  ASSERT_FALSE(client.GetVContSupported("S"));
+  ASSERT_FALSE(client.GetVContSupported("a"));
   ASSERT_FALSE(client.GetVContSupported("A"));
 }
 


### PR DESCRIPTION
This is a conservative generalization of the `GDBRemoteCommunicationClient::GetVContSupported` method so that:
- the new version of this method handles the reply to the `vCont?` packet the same way as the original version of this method
- the new version of this method can be easily adapted to situation when the actions are represented by multiple letters.

Imagine that, in addition to the [existing actions](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Packets.html#vCont-packet):
- `c`
- `C`
- `s`
- `S`
- `t`
- `r`

the other party would also advertise that it supports (e.g.) `sc` action
(meaning e.g. that we can ask the other party to step into microcode).

The new version of this method can be easily adapted to handle such a case without compromising correct handling of the original actions represented by single characters.