### PR TITLE
[clang-format] Add C language support for IntegerLiteralSeparator

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -4751,8 +4751,8 @@ the configuration (without a prefix: ``Auto``).
 .. _IntegerLiteralSeparator:
 
 **IntegerLiteralSeparator** (``IntegerLiteralSeparatorStyle``) :versionbadge:`clang-format 16` :ref:`¶ <IntegerLiteralSeparator>`
-  Format integer literal separators (``'`` for C++ and ``_`` for C#, Java,
-  and JavaScript).
+  Format integer literal separators (``'`` for C, C++ and ``_`` for C#, Java,
+  and JavaScript).  Note that using the separator with C requires a C23+ compiler.
 
   Nested configuration flags:
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -4751,8 +4751,8 @@ the configuration (without a prefix: ``Auto``).
 .. _IntegerLiteralSeparator:
 
 **IntegerLiteralSeparator** (``IntegerLiteralSeparatorStyle``) :versionbadge:`clang-format 16` :ref:`¶ <IntegerLiteralSeparator>`
-  Format integer literal separators (``'`` for C, C++ and ``_`` for C#, Java,
-  and JavaScript).  Note that using the separator with C requires a C23+ compiler.
+  Format integer literal separators (``'`` for C/C++ and ``_`` for C#, Java,
+  and JavaScript).
 
   Nested configuration flags:
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3395,7 +3395,7 @@ struct FormatStyle {
     }
   };
 
-  /// Format integer literal separators (``'`` for C++ and ``_`` for C#, Java,
+  /// Format integer literal separators (``'`` for C/C++ and ``_`` for C#, Java,
   /// and JavaScript).
   /// \version 16
   IntegerLiteralSeparatorStyle IntegerLiteralSeparator;

--- a/clang/lib/Format/IntegerLiteralSeparatorFixer.cpp
+++ b/clang/lib/Format/IntegerLiteralSeparatorFixer.cpp
@@ -50,6 +50,9 @@ IntegerLiteralSeparatorFixer::process(const Environment &Env,
   case FormatStyle::LK_JavaScript:
     Separator = '_';
     break;
+  case FormatStyle::LK_C:
+      Separator = '\'';
+      break;
   case FormatStyle::LK_Cpp:
   case FormatStyle::LK_ObjC:
     if (Style.Standard >= FormatStyle::LS_Cpp14) {

--- a/clang/lib/Format/IntegerLiteralSeparatorFixer.cpp
+++ b/clang/lib/Format/IntegerLiteralSeparatorFixer.cpp
@@ -51,8 +51,6 @@ IntegerLiteralSeparatorFixer::process(const Environment &Env,
     Separator = '_';
     break;
   case FormatStyle::LK_C:
-      Separator = '\'';
-      break;
   case FormatStyle::LK_Cpp:
   case FormatStyle::LK_ObjC:
     if (Style.Standard >= FormatStyle::LS_Cpp14) {

--- a/clang/unittests/Format/IntegerLiteralSeparatorTest.cpp
+++ b/clang/unittests/Format/IntegerLiteralSeparatorTest.cpp
@@ -24,65 +24,72 @@ TEST_F(IntegerLiteralSeparatorTest, SingleQuoteAsSeparator) {
   EXPECT_EQ(Style.IntegerLiteralSeparator.Decimal, 0);
   EXPECT_EQ(Style.IntegerLiteralSeparator.Hex, 0);
 
-  constexpr StringRef Binary("b = 0b10011'11'0110'1u;");
-  verifyFormat(Binary, Style);
-  Style.IntegerLiteralSeparator.Binary = -1;
-  verifyFormat("b = 0b100111101101u;", Binary, Style);
-  Style.IntegerLiteralSeparator.Binary = 1;
-  verifyFormat("b = 0b1'0'0'1'1'1'1'0'1'1'0'1u;", Binary, Style);
-  Style.IntegerLiteralSeparator.Binary = 4;
-  verifyFormat("b = 0b1001'1110'1101u;", Binary, Style);
+  auto TestSingleQuote = [&](auto Language) {
+    Style.Language = Language;
+    
+    constexpr StringRef Binary("b = 0b10011'11'0110'1u;");
+    verifyFormat(Binary, Style);
+    Style.IntegerLiteralSeparator.Binary = -1;
+    verifyFormat("b = 0b100111101101u;", Binary, Style);
+    Style.IntegerLiteralSeparator.Binary = 1;
+    verifyFormat("b = 0b1'0'0'1'1'1'1'0'1'1'0'1u;", Binary, Style);
+    Style.IntegerLiteralSeparator.Binary = 4;
+    verifyFormat("b = 0b1001'1110'1101u;", Binary, Style);
 
-  constexpr StringRef Decimal("d = 184467'440737'0'95505'92Ull;");
-  verifyFormat(Decimal, Style);
-  Style.IntegerLiteralSeparator.Decimal = -1;
-  verifyFormat("d = 18446744073709550592Ull;", Decimal, Style);
-  Style.IntegerLiteralSeparator.Decimal = 3;
-  verifyFormat("d = 18'446'744'073'709'550'592Ull;", Decimal, Style);
+    constexpr StringRef Decimal("d = 184467'440737'0'95505'92Ull;");
+    verifyFormat(Decimal, Style);
+    Style.IntegerLiteralSeparator.Decimal = -1;
+    verifyFormat("d = 18446744073709550592Ull;", Decimal, Style);
+    Style.IntegerLiteralSeparator.Decimal = 3;
+    verifyFormat("d = 18'446'744'073'709'550'592Ull;", Decimal, Style);
 
-  constexpr StringRef Hex("h = 0xDEAD'BEEF'DE'AD'BEE'Fuz;");
-  verifyFormat(Hex, Style);
-  Style.IntegerLiteralSeparator.Hex = -1;
-  verifyFormat("h = 0xDEADBEEFDEADBEEFuz;", Hex, Style);
-  Style.IntegerLiteralSeparator.Hex = 2;
-  verifyFormat("h = 0xDE'AD'BE'EF'DE'AD'BE'EFuz;", Hex, Style);
+    constexpr StringRef Hex("h = 0xDEAD'BEEF'DE'AD'BEE'Fuz;");
+    verifyFormat(Hex, Style);
+    Style.IntegerLiteralSeparator.Hex = -1;
+    verifyFormat("h = 0xDEADBEEFDEADBEEFuz;", Hex, Style);
+    Style.IntegerLiteralSeparator.Hex = 2;
+    verifyFormat("h = 0xDE'AD'BE'EF'DE'AD'BE'EFuz;", Hex, Style);
 
-  verifyFormat("o0 = 0;\n"
-               "o1 = 07;\n"
-               "o5 = 012345;",
-               Style);
+    verifyFormat("o0 = 0;\n"
+                "o1 = 07;\n"
+                "o5 = 012345;",
+                Style);
 
-  verifyFormat("bi = 0b1'0000i;\n"
-               "dif = 1'234if;\n"
-               "hil = 0xA'BCil;",
-               "bi = 0b10000i;\n"
-               "dif = 1234if;\n"
-               "hil = 0xABCil;",
-               Style);
+    verifyFormat("bi = 0b1'0000i;\n"
+                "dif = 1'234if;\n"
+                "hil = 0xA'BCil;",
+                "bi = 0b10000i;\n"
+                "dif = 1234if;\n"
+                "hil = 0xABCil;",
+                Style);
 
-  verifyFormat("bd = 0b1'0000d;\n"
-               "dh = 1'234h;\n"
-               "dmin = 1'234min;\n"
-               "dns = 1'234ns;\n"
-               "ds = 1'234s;\n"
-               "dus = 1'234us;\n"
-               "hy = 0xA'BCy;",
-               "bd = 0b10000d;\n"
-               "dh = 1234h;\n"
-               "dmin = 1234min;\n"
-               "dns = 1234ns;\n"
-               "ds = 1234s;\n"
-               "dus = 1234us;\n"
-               "hy = 0xABCy;",
-               Style);
+    verifyFormat("bd = 0b1'0000d;\n"
+                "dh = 1'234h;\n"
+                "dmin = 1'234min;\n"
+                "dns = 1'234ns;\n"
+                "ds = 1'234s;\n"
+                "dus = 1'234us;\n"
+                "hy = 0xA'BCy;",
+                "bd = 0b10000d;\n"
+                "dh = 1234h;\n"
+                "dmin = 1234min;\n"
+                "dns = 1234ns;\n"
+                "ds = 1234s;\n"
+                "dus = 1234us;\n"
+                "hy = 0xABCy;",
+                Style);
 
-  verifyFormat("hd = 0xAB'Cd;", "hd = 0xABCd;", Style);
+    verifyFormat("hd = 0xAB'Cd;", "hd = 0xABCd;", Style);
 
-  verifyFormat("d = 5'678_km;\n"
-               "h = 0xD'EF_u16;",
-               "d = 5678_km;\n"
-               "h = 0xDEF_u16;",
-               Style);
+    verifyFormat("d = 5'678_km;\n"
+                "h = 0xD'EF_u16;",
+                "d = 5678_km;\n"
+                "h = 0xDEF_u16;",
+                Style);
+  };
+
+  TestSingleQuote(FormatStyle::LK_C);
+  TestSingleQuote(FormatStyle::LK_Cpp);
 
   Style.Standard = FormatStyle::LS_Cpp11;
   verifyFormat("ld = 1234L;", Style);

--- a/clang/unittests/Format/IntegerLiteralSeparatorTest.cpp
+++ b/clang/unittests/Format/IntegerLiteralSeparatorTest.cpp
@@ -23,7 +23,7 @@ TEST_F(IntegerLiteralSeparatorTest, SingleQuoteAsSeparator) {
   EXPECT_EQ(Style.IntegerLiteralSeparator.Binary, 0);
   EXPECT_EQ(Style.IntegerLiteralSeparator.Decimal, 0);
   EXPECT_EQ(Style.IntegerLiteralSeparator.Hex, 0);
- 
+
   constexpr StringRef Binary("b = 0b10011'11'0110'1u;");
   verifyFormat(Binary, Style);
   Style.IntegerLiteralSeparator.Binary = -1;
@@ -48,51 +48,44 @@ TEST_F(IntegerLiteralSeparatorTest, SingleQuoteAsSeparator) {
   verifyFormat("h = 0xDE'AD'BE'EF'DE'AD'BE'EFuz;", Hex, Style);
 
   verifyFormat("o0 = 0;\n"
-              "o1 = 07;\n"
-              "o5 = 012345;",
-              Style);
+               "o1 = 07;\n"
+               "o5 = 012345;",
+               Style);
 
   verifyFormat("bi = 0b1'0000i;\n"
-              "dif = 1'234if;\n"
-              "hil = 0xA'BCil;",
-              "bi = 0b10000i;\n"
-              "dif = 1234if;\n"
-              "hil = 0xABCil;",
-              Style);
+               "dif = 1'234if;\n"
+               "hil = 0xA'BCil;",
+               "bi = 0b10000i;\n"
+               "dif = 1234if;\n"
+               "hil = 0xABCil;",
+               Style);
 
   verifyFormat("bd = 0b1'0000d;\n"
-              "dh = 1'234h;\n"
-              "dmin = 1'234min;\n"
-              "dns = 1'234ns;\n"
-              "ds = 1'234s;\n"
-              "dus = 1'234us;\n"
-              "hy = 0xA'BCy;",
-              "bd = 0b10000d;\n"
-              "dh = 1234h;\n"
-              "dmin = 1234min;\n"
-              "dns = 1234ns;\n"
-              "ds = 1234s;\n"
-              "dus = 1234us;\n"
-              "hy = 0xABCy;",
-              Style);
+               "dh = 1'234h;\n"
+               "dmin = 1'234min;\n"
+               "dns = 1'234ns;\n"
+               "ds = 1'234s;\n"
+               "dus = 1'234us;\n"
+               "hy = 0xA'BCy;",
+               "bd = 0b10000d;\n"
+               "dh = 1234h;\n"
+               "dmin = 1234min;\n"
+               "dns = 1234ns;\n"
+               "ds = 1234s;\n"
+               "dus = 1234us;\n"
+               "hy = 0xABCy;",
+               Style);
 
   verifyFormat("hd = 0xAB'Cd;", "hd = 0xABCd;", Style);
 
   verifyFormat("d = 5'678_km;\n"
-              "h = 0xD'EF_u16;",
-              "d = 5678_km;\n"
-              "h = 0xDEF_u16;",
-              Style);
+               "h = 0xD'EF_u16;",
+               "d = 5678_km;\n"
+               "h = 0xDEF_u16;",
+               Style);
 
   Style.Standard = FormatStyle::LS_Cpp11;
   verifyFormat("ld = 1234L;", Style);
-
-  Style.Language = FormatStyle::LK_C;
-  Style.Standard = FormatStyle::LS_Cpp14;
-  Style.IntegerLiteralSeparator.Binary = -1;
-  verifyFormat("b = 0b100111101101u;", Binary, Style);
-  Style.IntegerLiteralSeparator.Binary = 4;
-  verifyFormat("b = 0b1001'1110'1101u;", Binary, Style);
 }
 
 TEST_F(IntegerLiteralSeparatorTest, UnderscoreAsSeparator) {

--- a/clang/unittests/Format/IntegerLiteralSeparatorTest.cpp
+++ b/clang/unittests/Format/IntegerLiteralSeparatorTest.cpp
@@ -23,76 +23,76 @@ TEST_F(IntegerLiteralSeparatorTest, SingleQuoteAsSeparator) {
   EXPECT_EQ(Style.IntegerLiteralSeparator.Binary, 0);
   EXPECT_EQ(Style.IntegerLiteralSeparator.Decimal, 0);
   EXPECT_EQ(Style.IntegerLiteralSeparator.Hex, 0);
+ 
+  constexpr StringRef Binary("b = 0b10011'11'0110'1u;");
+  verifyFormat(Binary, Style);
+  Style.IntegerLiteralSeparator.Binary = -1;
+  verifyFormat("b = 0b100111101101u;", Binary, Style);
+  Style.IntegerLiteralSeparator.Binary = 1;
+  verifyFormat("b = 0b1'0'0'1'1'1'1'0'1'1'0'1u;", Binary, Style);
+  Style.IntegerLiteralSeparator.Binary = 4;
+  verifyFormat("b = 0b1001'1110'1101u;", Binary, Style);
 
-  auto TestSingleQuote = [&](auto Language) {
-    Style.Language = Language;
-    
-    constexpr StringRef Binary("b = 0b10011'11'0110'1u;");
-    verifyFormat(Binary, Style);
-    Style.IntegerLiteralSeparator.Binary = -1;
-    verifyFormat("b = 0b100111101101u;", Binary, Style);
-    Style.IntegerLiteralSeparator.Binary = 1;
-    verifyFormat("b = 0b1'0'0'1'1'1'1'0'1'1'0'1u;", Binary, Style);
-    Style.IntegerLiteralSeparator.Binary = 4;
-    verifyFormat("b = 0b1001'1110'1101u;", Binary, Style);
+  constexpr StringRef Decimal("d = 184467'440737'0'95505'92Ull;");
+  verifyFormat(Decimal, Style);
+  Style.IntegerLiteralSeparator.Decimal = -1;
+  verifyFormat("d = 18446744073709550592Ull;", Decimal, Style);
+  Style.IntegerLiteralSeparator.Decimal = 3;
+  verifyFormat("d = 18'446'744'073'709'550'592Ull;", Decimal, Style);
 
-    constexpr StringRef Decimal("d = 184467'440737'0'95505'92Ull;");
-    verifyFormat(Decimal, Style);
-    Style.IntegerLiteralSeparator.Decimal = -1;
-    verifyFormat("d = 18446744073709550592Ull;", Decimal, Style);
-    Style.IntegerLiteralSeparator.Decimal = 3;
-    verifyFormat("d = 18'446'744'073'709'550'592Ull;", Decimal, Style);
+  constexpr StringRef Hex("h = 0xDEAD'BEEF'DE'AD'BEE'Fuz;");
+  verifyFormat(Hex, Style);
+  Style.IntegerLiteralSeparator.Hex = -1;
+  verifyFormat("h = 0xDEADBEEFDEADBEEFuz;", Hex, Style);
+  Style.IntegerLiteralSeparator.Hex = 2;
+  verifyFormat("h = 0xDE'AD'BE'EF'DE'AD'BE'EFuz;", Hex, Style);
 
-    constexpr StringRef Hex("h = 0xDEAD'BEEF'DE'AD'BEE'Fuz;");
-    verifyFormat(Hex, Style);
-    Style.IntegerLiteralSeparator.Hex = -1;
-    verifyFormat("h = 0xDEADBEEFDEADBEEFuz;", Hex, Style);
-    Style.IntegerLiteralSeparator.Hex = 2;
-    verifyFormat("h = 0xDE'AD'BE'EF'DE'AD'BE'EFuz;", Hex, Style);
+  verifyFormat("o0 = 0;\n"
+              "o1 = 07;\n"
+              "o5 = 012345;",
+              Style);
 
-    verifyFormat("o0 = 0;\n"
-                "o1 = 07;\n"
-                "o5 = 012345;",
-                Style);
+  verifyFormat("bi = 0b1'0000i;\n"
+              "dif = 1'234if;\n"
+              "hil = 0xA'BCil;",
+              "bi = 0b10000i;\n"
+              "dif = 1234if;\n"
+              "hil = 0xABCil;",
+              Style);
 
-    verifyFormat("bi = 0b1'0000i;\n"
-                "dif = 1'234if;\n"
-                "hil = 0xA'BCil;",
-                "bi = 0b10000i;\n"
-                "dif = 1234if;\n"
-                "hil = 0xABCil;",
-                Style);
+  verifyFormat("bd = 0b1'0000d;\n"
+              "dh = 1'234h;\n"
+              "dmin = 1'234min;\n"
+              "dns = 1'234ns;\n"
+              "ds = 1'234s;\n"
+              "dus = 1'234us;\n"
+              "hy = 0xA'BCy;",
+              "bd = 0b10000d;\n"
+              "dh = 1234h;\n"
+              "dmin = 1234min;\n"
+              "dns = 1234ns;\n"
+              "ds = 1234s;\n"
+              "dus = 1234us;\n"
+              "hy = 0xABCy;",
+              Style);
 
-    verifyFormat("bd = 0b1'0000d;\n"
-                "dh = 1'234h;\n"
-                "dmin = 1'234min;\n"
-                "dns = 1'234ns;\n"
-                "ds = 1'234s;\n"
-                "dus = 1'234us;\n"
-                "hy = 0xA'BCy;",
-                "bd = 0b10000d;\n"
-                "dh = 1234h;\n"
-                "dmin = 1234min;\n"
-                "dns = 1234ns;\n"
-                "ds = 1234s;\n"
-                "dus = 1234us;\n"
-                "hy = 0xABCy;",
-                Style);
+  verifyFormat("hd = 0xAB'Cd;", "hd = 0xABCd;", Style);
 
-    verifyFormat("hd = 0xAB'Cd;", "hd = 0xABCd;", Style);
-
-    verifyFormat("d = 5'678_km;\n"
-                "h = 0xD'EF_u16;",
-                "d = 5678_km;\n"
-                "h = 0xDEF_u16;",
-                Style);
-  };
-
-  TestSingleQuote(FormatStyle::LK_C);
-  TestSingleQuote(FormatStyle::LK_Cpp);
+  verifyFormat("d = 5'678_km;\n"
+              "h = 0xD'EF_u16;",
+              "d = 5678_km;\n"
+              "h = 0xDEF_u16;",
+              Style);
 
   Style.Standard = FormatStyle::LS_Cpp11;
   verifyFormat("ld = 1234L;", Style);
+
+  Style.Language = FormatStyle::LK_C;
+  Style.Standard = FormatStyle::LS_Cpp14;
+  Style.IntegerLiteralSeparator.Binary = -1;
+  verifyFormat("b = 0b100111101101u;", Binary, Style);
+  Style.IntegerLiteralSeparator.Binary = 4;
+  verifyFormat("b = 0b1001'1110'1101u;", Binary, Style);
 }
 
 TEST_F(IntegerLiteralSeparatorTest, UnderscoreAsSeparator) {


### PR DESCRIPTION
C23 language standard has added support for the C++ tick mark as a numeric separator.  Add support to clang-format so that when formatting configured for LK_C this code path is enabled.

Fixes #179686