### PR TITLE
[clang][Driver][Darwin] Turn on -gsimple-template-names for Darwin by default

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -615,6 +615,10 @@ public:
   // i.e. a value of 'true' does not imply that debugging is wanted.
   virtual bool GetDefaultStandaloneDebug() const { return false; }
 
+  /// Returns true if this toolchain adds '-gsimple-template-names=simple'
+  /// by default when generating debug-info.
+  virtual bool getDefaultDebugSimpleTemplateNames() const { return false; }
+
   // Return the default debugger "tuning."
   virtual llvm::DebuggerKind getDefaultDebuggerTuning() const {
     return llvm::DebuggerKind::GDB;

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1369,6 +1369,21 @@ unsigned DarwinClang::GetDefaultDwarfVersion() const {
   return 5;
 }
 
+bool DarwinClang::getDefaultDebugSimpleTemplateNames() const {
+  // Default to an OS version on which LLDB supports debugging
+  // -gsimple-template-names programs.
+  if ((isTargetMacOSBased() && isMacosxVersionLT(26)) ||
+      (isTargetIOSBased() && isIPhoneOSVersionLT(26)) ||
+      (isTargetWatchOSBased() && TargetVersion < llvm::VersionTuple(26)) ||
+      (isTargetXROS() && TargetVersion < llvm::VersionTuple(26)) ||
+      (isTargetDriverKit() && TargetVersion < llvm::VersionTuple(25)) ||
+      (isTargetMacOSBased() &&
+       TargetVersion.empty())) // apple-darwin, no version.
+    return false;
+
+  return true;
+}
+
 void MachO::AddLinkRuntimeLib(const ArgList &Args, ArgStringList &CmdArgs,
                               StringRef Component, RuntimeLinkOptions Opts,
                               bool IsShared) const {

--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -693,6 +693,8 @@ public:
     return llvm::DebuggerKind::LLDB;
   }
 
+  bool getDefaultDebugSimpleTemplateNames() const override;
+
   /// }
 
 private:

--- a/clang/test/DebugInfo/CXX/fn-template.cpp
+++ b/clang/test/DebugInfo/CXX/fn-template.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -emit-llvm -g -S %s -o - | FileCheck %s
+// RUN: %clang -emit-llvm -g -gno-simple-template-names -S %s -o - | FileCheck %s
 
 template<typename T>
 struct XF {

--- a/clang/test/Driver/debug-options.c
+++ b/clang/test/Driver/debug-options.c
@@ -486,12 +486,27 @@
 // DIRECTORY-NOT: "-fno-dwarf-directory-asm"
 // NODIRECTORY: "-fno-dwarf-directory-asm"
 
-// RUN: %clang -### -target x86_64 -c -g -gsimple-template-names %s 2>&1 | FileCheck --check-prefixes=SIMPLE_TMPL_NAMES,FWD_TMPL_PARAMS %s
+// RUN: %clang -### -target x86_64-linux -c -g -gsimple-template-names %s 2>&1 | FileCheck --check-prefixes=SIMPLE_TMPL_NAMES,FWD_TMPL_PARAMS %s
+// RUN: %clang -### -target x86_64-apple-macosx26.0 -c -g %s 2>&1 | FileCheck --check-prefixes=SIMPLE_TMPL_NAMES,FWD_TMPL_PARAMS %s
+// RUN: %clang -### -target x86_64-apple-ios26.0 -c -g %s 2>&1 | FileCheck --check-prefixes=SIMPLE_TMPL_NAMES,FWD_TMPL_PARAMS %s
+// RUN: %clang -### -target x86_64-apple-tvos26.0 -c -g %s 2>&1 | FileCheck --check-prefixes=SIMPLE_TMPL_NAMES,FWD_TMPL_PARAMS %s
+// RUN: %clang -### -target x86_64-apple-xros26.0 -c -g %s 2>&1 | FileCheck --check-prefixes=SIMPLE_TMPL_NAMES,FWD_TMPL_PARAMS %s
+// RUN: %clang -### -target x86_64-apple-watchos26.0 -c -g %s 2>&1 | FileCheck --check-prefixes=SIMPLE_TMPL_NAMES,FWD_TMPL_PARAMS %s
+// RUN: %clang -### -target x86_64-apple-driverkit25.0 -c -g %s 2>&1 | FileCheck --check-prefixes=SIMPLE_TMPL_NAMES,FWD_TMPL_PARAMS %s
+// RUN: %clang -### -target x86_64-apple-macosx10.11 -c -g %s 2>&1 | FileCheck --implicit-check-not=-gsimple-template-names --implicit-check-not=-debug-forward-template-params %s
+// RUN: %clang -### -target x86_64-apple-ios10.11 -c -g %s 2>&1 | FileCheck --implicit-check-not=-gsimple-template-names --implicit-check-not=-debug-forward-template-params %s
+// RUN: %clang -### -target x86_64-apple-tvos10.11 -c -g %s 2>&1 | FileCheck --implicit-check-not=-gsimple-template-names --implicit-check-not=-debug-forward-template-params %s
+// RUN: %clang -### -target x86_64-apple-xros1 -c -g %s 2>&1 | FileCheck --implicit-check-not=-gsimple-template-names --implicit-check-not=-debug-forward-template-params %s
+// RUN: %clang -### -target x86_64-apple-watchos10.11 -c -g %s 2>&1 | FileCheck --implicit-check-not=-gsimple-template-names --implicit-check-not=-debug-forward-template-params %s
+// RUN: %clang -### -target x86_64-apple-driverkit19.11 -c -g %s 2>&1 | FileCheck --implicit-check-not=-gsimple-template-names --implicit-check-not=-debug-forward-template-params %s
+
 // SIMPLE_TMPL_NAMES: -gsimple-template-names=simple
 // FWD_TMPL_PARAMS-DAG: -debug-forward-template-params
-// RUN: not %clang -### -target x86_64 -c -g -gsimple-template-names=mangled %s 2>&1 | FileCheck --check-prefix=MANGLED_TEMP_NAMES %s
+
+// RUN: not %clang -### -target x86_64-linux -c -g -gsimple-template-names=mangled %s 2>&1 | FileCheck --check-prefix=MANGLED_TEMP_NAMES %s
 // MANGLED_TEMP_NAMES: error: unknown argument '-gsimple-template-names=mangled'; did you mean '-Xclang -gsimple-template-names=mangled'
-// RUN: %clang -### -target x86_64 -c -g %s 2>&1 | FileCheck --check-prefix=FULL_TEMP_NAMES --implicit-check-not=debug-forward-template-params %s
+
+// RUN: %clang -### -target x86_64-linux -c -g %s 2>&1 | FileCheck --check-prefix=FULL_TEMP_NAMES --implicit-check-not=debug-forward-template-params %s
 // FULL_TEMP_NAMES-NOT: -gsimple-template-names
 
 //// Test -g[no-]template-alias (enabled by default with SCE debugger tuning and DWARF version >= 4).


### PR DESCRIPTION
Enables `-gsimple-template-names=simple` when targeting recent Apple platforms (26 or later, except `DriverKit` which is at 25). Those are platforms where the associated LLDB is capable of debugging `simple-template-names` debug-info.

The two main affects on debug-info are:
1. forward declarations for structures now have `DW_TAG_type_template_parameter`s (since this is required to reconstruct the template names if just given a forward declaration
2. `DW_AT_name` of templates will not include template parameters anymore (except for a few cases where the name is not reconstitutible from the template parameter DIE names)

While the `.debug_str` section is reduced in size (due to shorter `DW_AT_name`s), this is somewhat offset by having to include template parameter DIEs on forward declarations.