### PR TITLE
Remove control statement check ensuring line breaks shifts newline left

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -952,7 +952,6 @@ void ContinuationIndenter::addTokenOnCurrentLine(LineState &State, bool DryRun,
            Next->is(TT_FunctionDeclarationLParen) || IsFunctionCallParen(*Next);
   };
   if (IsOpeningBracket(Previous) &&
-      State.Column > getNewLineColumn(State).Total &&
       // Don't do this for simple (no expressions) one-argument function calls
       // as that feels like needlessly wasting whitespace, e.g.:
       //


### PR DESCRIPTION
Method ContinuationIndenter::addTokenOnCurrentLine contains a check "State.Column > getNewLineColumn(State).Total" (file line 954) whose purpose seems to validate that a control flow line break will result in leftward movement of the conditional check.  If breaking control flow into multiple lines does not result in leftward movement then no line break is performed.  This seems to be aberrant behavior and these four configuration settings should result in line breaks when enabled.  

E.g even with BreakAfterOpenBracketIf / BreakBeforeCloseBracketIf set to true the result will be as follows:

```c
int
function1(int parameter1, int parameter2, int parameter3) {
    if (parameter1 < parameter2 || (parameter1 > parameter3 && parameter1 != null)
        || parameter1 == 500) {
        return 1;
    }

    return 0;
}
```

Expected result is:
```c
int
function1(int parameter1, int parameter2, int parameter3) {
    if (
       parameter1 < parameter2 || (parameter1 > parameter3 && parameter1 != null)
       || parameter1 == 500
    ) {
        return 1;
    }

    return 0;
}
``` 

Fixes llvm#181293, llvm#181591