### PR TITLE
[NFC][SPIRV] Remove last uses of `SPIRVType`

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -1263,7 +1263,7 @@ SPIRVTypeInst SPIRVGlobalRegistry::restOfCreateSPIRVType(
   return SpirvType;
 }
 
-SPIRVType *
+SPIRVTypeInst
 SPIRVGlobalRegistry::getSPIRVTypeForVReg(Register VReg,
                                          const MachineFunction *MF) const {
   auto t = VRegToTypeMap.find(MF ? MF : CurMF);

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -102,11 +102,13 @@ class SPIRVGlobalRegistry : public SPIRVIRMapping {
                         SPIRV::AccessQualifier::AccessQualifier AccessQual,
                         bool ExplicitLayoutRequired, bool EmitIR);
 
-  // Internal function creating the an OpType at the correct position in the
-  // function by tweaking the passed "MIRBuilder" insertion point and restoring
-  // it to the correct position. "Op" should be the function creating the
-  // specific OpType you need, and should return the newly created instruction.
-  SPIRVType *createOpType(MachineIRBuilder &MIRBuilder,
+  // Internal function creating the an Types/Constants at the correct position
+  // in the function by tweaking the passed "MIRBuilder" insertion point and
+  // restoring it to the correct position. "Op" should be the function creating
+  // the specific operation you need, and should return the newly created
+  // instruction.
+  const MachineInstr *
+  createOpAtFunctionEntry(MachineIRBuilder &MIRBuilder,
                           std::function<MachineInstr *(MachineIRBuilder &)> Op);
 
 public:

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -36,7 +36,7 @@ class SPIRVGlobalRegistry : public SPIRVIRMapping {
   // where Reg = OpType...
   // while VRegToTypeMap tracks SPIR-V type assigned to other regs (i.e. not
   // type-declaring ones).
-  DenseMap<const MachineFunction *, DenseMap<Register, SPIRVType *>>
+  DenseMap<const MachineFunction *, DenseMap<Register, SPIRVTypeInst>>
       VRegToTypeMap;
 
   DenseMap<SPIRVTypeInst, const Type *> SPIRVToLLVMType;
@@ -58,7 +58,7 @@ class SPIRVGlobalRegistry : public SPIRVIRMapping {
   DenseMap<MachineInstr *, std::pair<Type *, std::string>> ValueAttrs;
 
   SmallPtrSet<const Type *, 4> TypesInProcessing;
-  DenseMap<const Type *, SPIRVType *> ForwardPointerTypes;
+  DenseMap<const Type *, SPIRVTypeInst> ForwardPointerTypes;
 
   // Stores for each function the last inserted SPIR-V Type.
   // See: SPIRVGlobalRegistry::createOpType.
@@ -344,8 +344,8 @@ public:
   // allows to search for the association in a context of the machine functions
   // than the current one, without switching between different "current" machine
   // functions.
-  SPIRVType *getSPIRVTypeForVReg(Register VReg,
-                                 const MachineFunction *MF = nullptr) const;
+  SPIRVTypeInst getSPIRVTypeForVReg(Register VReg,
+                                    const MachineFunction *MF = nullptr) const;
 
   // Return the result type of the instruction defining the register.
   SPIRVTypeInst getResultType(Register VReg, MachineFunction *MF = nullptr);

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -102,14 +102,14 @@ class SPIRVGlobalRegistry : public SPIRVIRMapping {
                         SPIRV::AccessQualifier::AccessQualifier AccessQual,
                         bool ExplicitLayoutRequired, bool EmitIR);
 
-  // Internal function creating the an Types/Constants at the correct position
+  // Internal function creating the Types/Constants at the correct position
   // in the function by tweaking the passed "MIRBuilder" insertion point and
   // restoring it to the correct position. "Op" should be the function creating
   // the specific operation you need, and should return the newly created
   // instruction.
-  const MachineInstr *
-  createOpAtFunctionEntry(MachineIRBuilder &MIRBuilder,
-                          std::function<MachineInstr *(MachineIRBuilder &)> Op);
+  const MachineInstr *createConstOrTypeAtFunctionEntry(
+      MachineIRBuilder &MIRBuilder,
+      std::function<MachineInstr *(MachineIRBuilder &)> Op);
 
 public:
   SPIRVGlobalRegistry(unsigned PointerSize);

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -151,9 +151,9 @@ SPIRVTargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
 }
 
 inline Register getTypeReg(MachineRegisterInfo *MRI, Register OpReg) {
-  SPIRVType *TypeInst = MRI->getVRegDef(OpReg);
-  return TypeInst && TypeInst->getOpcode() == SPIRV::OpFunctionParameter
-             ? TypeInst->getOperand(1).getReg()
+  const MachineInstr *Inst = MRI->getVRegDef(OpReg);
+  return Inst && Inst->getOpcode() == SPIRV::OpFunctionParameter
+             ? Inst->getOperand(1).getReg()
              : OpReg;
 }
 
@@ -198,7 +198,7 @@ static void validatePtrTypes(const SPIRVSubtarget &STI,
   MachineFunction *MF = I.getParent()->getParent();
   Register OpReg = I.getOperand(OpIdx).getReg();
   Register OpTypeReg = getTypeReg(MRI, OpReg);
-  SPIRVType *OpType = GR.getSPIRVTypeForVReg(OpTypeReg, MF);
+  const MachineInstr *OpType = GR.getSPIRVTypeForVReg(OpTypeReg, MF);
   if (!ResType || !OpType || OpType->getOpcode() != SPIRV::OpTypePointer)
     return;
   // Get operand's pointee type

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
@@ -35,7 +35,7 @@ class SPIRVTypeInst {
 
 public:
   SPIRVTypeInst(const MachineInstr &MI) : SPIRVTypeInst(&MI) {}
-  SPIRVTypeInst(const MachineInstr *MI);
+  SPIRVTypeInst(const MachineInstr *MI = nullptr);
 
   // No need to verify the register since it's already verified by the copied
   // object.

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
@@ -19,12 +19,6 @@ namespace llvm {
 class MachineInstr;
 class MachineRegisterInfo;
 
-/// @deprecated Use SPIRVTypeInst instead
-/// SPIRVType is supposed to represent a MachineInstr that defines a SPIRV Type
-/// (e.g. an OpTypeInt intruction). It is misused in several places and we're
-/// getting rid of it.
-using SPIRVType = const MachineInstr;
-
 class SPIRVTypeInst {
   const MachineInstr *MI;
 


### PR DESCRIPTION
This patch:

* Replaces some `SPIRVType` uses with `SPIRVTypeInst`
* Replaces cases where this replacement is impossible with `const MachineInstr*`
* For consistency renames some functions / variables

This patch depends on https://github.com/llvm/llvm-project/pull/181668
This patch closes https://github.com/llvm/llvm-project/issues/180788

Approved in https://github.com/llvm/llvm-project/pull/182098 but had to close/reopen due to a Github glitch.