### PR TITLE
[lldb][windows] fix a race condition when closing the ConPTY

### DIFF
--- a/lldb/include/lldb/Core/ThreadedCommunication.h
+++ b/lldb/include/lldb/Core/ThreadedCommunication.h
@@ -216,6 +216,12 @@ public:
   ///
   void SynchronizeWithReadThread();
 
+  /// Interrupts the current read.
+  ///
+  /// Unlike SynchronizeWithReadThread, this does not wait for the read loop to
+  /// finish processing outstanding data.
+  void InterruptRead();
+
   static llvm::StringRef GetStaticBroadcasterClass();
 
   llvm::StringRef GetBroadcasterClass() const override {

--- a/lldb/include/lldb/Host/ProcessLaunchInfo.h
+++ b/lldb/include/lldb/Host/ProcessLaunchInfo.h
@@ -136,6 +136,8 @@ public:
   /// always true on non Windows.
   bool ShouldUsePTY() const {
 #ifdef _WIN32
+    if (!m_pty)
+      return false;
     return GetPTY().GetPseudoTerminalHandle() != ((HANDLE)(long long)-1) &&
            GetNumFileActions() == 0;
 #else

--- a/lldb/include/lldb/Host/windows/ConnectionConPTYWindows.h
+++ b/lldb/include/lldb/Host/windows/ConnectionConPTYWindows.h
@@ -1,4 +1,4 @@
-//===-- ConnectionConPTY.h ------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/include/lldb/Host/windows/ConnectionConPTYWindows.h
+++ b/lldb/include/lldb/Host/windows/ConnectionConPTYWindows.h
@@ -1,0 +1,50 @@
+//===-- ConnectionConPTY.h ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_HOST_WINDOWS_CONNECTIONCONPTYWINDOWS_H
+#define LLDB_HOST_WINDOWS_CONNECTIONCONPTYWINDOWS_H
+
+#include "lldb/Host/windows/ConnectionGenericFileWindows.h"
+#include "lldb/Host/windows/PseudoConsole.h"
+#include "lldb/Host/windows/windows.h"
+#include "lldb/Utility/Connection.h"
+#include "lldb/lldb-types.h"
+#include <mutex>
+
+namespace lldb_private {
+
+/// A read only Connection implementation for the Windows ConPTY.
+class ConnectionConPTY : public ConnectionGenericFile {
+public:
+  ConnectionConPTY(std::shared_ptr<PseudoConsole> pty);
+
+  ~ConnectionConPTY();
+
+  lldb::ConnectionStatus Connect(llvm::StringRef s, Status *error_ptr) override;
+
+  lldb::ConnectionStatus Disconnect(Status *error_ptr) override;
+
+  /// Read from the ConPTY's pipe.
+  ///
+  /// Before reading, check if the ConPTY is closing and wait for it to close
+  /// before reading. This prevents race conditions when closing the ConPTY
+  /// during a read. After reading, remove the ConPTY VT init sequence if
+  /// present.
+  size_t Read(void *dst, size_t dst_len, const Timeout<std::micro> &timeout,
+              lldb::ConnectionStatus &status, Status *error_ptr) override;
+
+  size_t Write(const void *src, size_t src_len, lldb::ConnectionStatus &status,
+               Status *error_ptr) override;
+
+protected:
+  std::shared_ptr<PseudoConsole> m_pty;
+  bool m_pty_vt_sequence_was_stripped = false;
+};
+} // namespace lldb_private
+
+#endif

--- a/lldb/include/lldb/Host/windows/PseudoConsole.h
+++ b/lldb/include/lldb/Host/windows/PseudoConsole.h
@@ -49,10 +49,6 @@ public:
   void ClosePipes();
 
   /// Returns whether the ConPTY and its pipes are currently open and valid.
-  ///
-  /// \return
-  ///     True if the ConPTY handle, STDIN write handle, and STDOUT read handle
-  ///     are all valid, false otherwise.
   bool IsConnected() const;
 
   /// The ConPTY HPCON handle accessor.

--- a/lldb/include/lldb/Host/windows/PseudoConsole.h
+++ b/lldb/include/lldb/Host/windows/PseudoConsole.h
@@ -102,7 +102,7 @@ public:
   ///     A reference to the atomic bool that is set to true when the ConPTY
   ///     is stopping. Callers should check this in their read/write loops to
   ///     exit gracefully.
-  const std::atomic<bool> &IsStopping() const { return m_stopping; };
+  const bool &IsStopping() const { return m_stopping; };
 
   /// Sets the stopping flag to \p value, signalling to threads waiting on the
   /// ConPTY that they should stop.

--- a/lldb/include/lldb/Host/windows/PseudoConsole.h
+++ b/lldb/include/lldb/Host/windows/PseudoConsole.h
@@ -102,7 +102,7 @@ public:
   ///     A reference to the atomic bool that is set to true when the ConPTY
   ///     is stopping. Callers should check this in their read/write loops to
   ///     exit gracefully.
-  const bool &IsStopping() const { return m_stopping; };
+  bool IsStopping() const { return m_stopping.load(); };
 
   /// Sets the stopping flag to \p value, signalling to threads waiting on the
   /// ConPTY that they should stop.

--- a/lldb/source/Core/ThreadedCommunication.cpp
+++ b/lldb/source/Core/ThreadedCommunication.cpp
@@ -360,6 +360,10 @@ void ThreadedCommunication::SetReadThreadBytesReceivedCallback(
   m_callback_baton = callback_baton;
 }
 
+void ThreadedCommunication::InterruptRead() {
+  m_connection_sp->InterruptRead();
+}
+
 void ThreadedCommunication::SynchronizeWithReadThread() {
   // Only one thread can do the synchronization dance at a time.
   std::lock_guard<std::mutex> guard(m_synchronize_mutex);
@@ -374,7 +378,7 @@ void ThreadedCommunication::SynchronizeWithReadThread() {
     return;
 
   // Notify the read thread.
-  m_connection_sp->InterruptRead();
+  InterruptRead();
 
   // Wait for the synchronization event.
   EventSP event_sp;

--- a/lldb/source/Host/CMakeLists.txt
+++ b/lldb/source/Host/CMakeLists.txt
@@ -67,6 +67,7 @@ add_host_subdirectory(posix
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
   add_subdirectory(windows/PythonPathSetup)
   add_host_subdirectory(windows
+    windows/ConnectionConPTYWindows.cpp
     windows/ConnectionGenericFileWindows.cpp
     windows/FileSystem.cpp
     windows/Host.cpp

--- a/lldb/source/Host/common/ProcessLaunchInfo.cpp
+++ b/lldb/source/Host/common/ProcessLaunchInfo.cpp
@@ -33,7 +33,11 @@ using namespace lldb_private;
 
 ProcessLaunchInfo::ProcessLaunchInfo()
     : ProcessInfo(), m_working_dir(), m_plugin_name(), m_flags(0),
-      m_file_actions(), m_pty(new PTY), m_monitor_callback(nullptr) {}
+      m_file_actions(), m_monitor_callback(nullptr) {
+#ifndef _WIN32
+  m_pty = std::make_shared<PTY>();
+#endif
+}
 
 ProcessLaunchInfo::ProcessLaunchInfo(const FileSpec &stdin_file_spec,
                                      const FileSpec &stdout_file_spec,
@@ -41,7 +45,10 @@ ProcessLaunchInfo::ProcessLaunchInfo(const FileSpec &stdin_file_spec,
                                      const FileSpec &working_directory,
                                      uint32_t launch_flags)
     : ProcessInfo(), m_working_dir(), m_plugin_name(), m_flags(launch_flags),
-      m_file_actions(), m_pty(new PTY) {
+      m_file_actions() {
+#ifndef _WIN32
+  m_pty = std::make_shared<PTY>();
+#endif
   if (stdin_file_spec) {
     FileAction file_action;
     const bool read = true;

--- a/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
+++ b/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
@@ -1,0 +1,84 @@
+//===-- ConnectionConPTY.cpp ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Host/windows/ConnectionConPTYWindows.h"
+#include "lldb/Utility/Status.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+/// Strips the ConPTY initialization sequences that Windows unconditionally
+/// emits when a process is first attached to a pseudo console.
+///
+/// These are emitted by ConPTY's host process (conhost.exe) at process attach
+/// time, not by the debuggee. They are always the first bytes on the output
+/// pipe and are always present as a contiguous prefix.
+///
+/// \param dst  Buffer containing the data read from the ConPTY output pipe.
+///             Modified in place: if the initialization sequences are present
+///             as a prefix, they are removed by shifting the remaining bytes
+///             to the front of the buffer.
+/// \param len  On input, the number of valid bytes in \p dst. On output,
+///             reduced by the number of bytes stripped.
+/// \return
+///     \p true if the sequence was found and stripped.
+static bool StripConPTYInitSequences(void *dst, size_t &len) {
+  static const char sequences[] = "\x1b[?9001l\x1b[?1004l";
+  static const size_t sequences_len = sizeof(sequences) - 1;
+
+  char *buf = static_cast<char *>(dst);
+  if (len >= sequences_len && memcmp(buf, sequences, sequences_len) == 0) {
+    memmove(buf, buf + sequences_len, len - sequences_len);
+    len -= sequences_len;
+    return true;
+  }
+  return false;
+}
+
+ConnectionConPTY::ConnectionConPTY(std::shared_ptr<PseudoConsole> pty)
+    : m_pty(pty), ConnectionGenericFile(pty->GetSTDOUTHandle(), false) {};
+
+ConnectionConPTY::~ConnectionConPTY() {}
+
+lldb::ConnectionStatus ConnectionConPTY::Connect(llvm::StringRef s,
+                                                 Status *error_ptr) {
+  if (m_pty->IsConnected())
+    return eConnectionStatusSuccess;
+  return eConnectionStatusNoConnection;
+}
+
+lldb::ConnectionStatus ConnectionConPTY::Disconnect(Status *error_ptr) {
+  m_pty->Close();
+  return eConnectionStatusSuccess;
+}
+
+size_t ConnectionConPTY::Read(void *dst, size_t dst_len,
+                              const Timeout<std::micro> &timeout,
+                              lldb::ConnectionStatus &status,
+                              Status *error_ptr) {
+  std::unique_lock<std::mutex> guard(m_pty->GetMutex());
+  if (m_pty->IsStopping().load()) {
+    m_pty->GetCV().wait(guard, [this] { return !m_pty->IsStopping().load(); });
+  }
+
+  size_t bytes_read =
+      ConnectionGenericFile::Read(dst, dst_len, timeout, status, error_ptr);
+
+  if (bytes_read > 0 && !m_pty_vt_sequence_was_stripped) {
+    if (StripConPTYInitSequences(dst, bytes_read))
+      m_pty_vt_sequence_was_stripped = true;
+  }
+
+  return bytes_read;
+}
+
+size_t ConnectionConPTY::Write(const void *src, size_t src_len,
+                               lldb::ConnectionStatus &status,
+                               Status *error_ptr) {
+  llvm_unreachable("not implemented");
+}

--- a/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
+++ b/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
@@ -1,4 +1,4 @@
-//===-- ConnectionConPTY.cpp ----------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
+++ b/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
@@ -31,14 +31,14 @@ using namespace lldb_private;
 static bool StripConPTYInitSequences(void *dst, size_t dst_len, size_t &len) {
   static const char sequences[] = "\x1b[?9001l\x1b[?1004l";
   static const size_t sequences_len = sizeof(sequences) - 1;
-
-  assert(dst_len >= len - sequences_len);
-
   char *buf = static_cast<char *>(dst);
-  if (len >= sequences_len && memcmp(buf, sequences, sequences_len) == 0) {
-    memmove(buf, buf + sequences_len, len - sequences_len);
-    len -= sequences_len;
-    return true;
+  if (len >= sequences_len) {
+    assert(dst_len >= len - sequences_len);
+    if (memcmp(buf, sequences, sequences_len) == 0) {
+      memmove(buf, buf + sequences_len, len - sequences_len);
+      len -= sequences_len;
+      return true;
+    }
   }
   return false;
 }

--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -124,7 +124,6 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
   startupinfoex.StartupInfo.cb = sizeof(STARTUPINFOEXW);
   startupinfoex.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
 
-  HPCON hPC = launch_info.GetPTY().GetPseudoTerminalHandle();
   bool use_pty = launch_info.ShouldUsePTY();
 
   HANDLE stdin_handle = GetStdioHandle(launch_info, STDIN_FILENO);
@@ -148,6 +147,7 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
 
   std::vector<HANDLE> inherited_handles;
   if (use_pty) {
+    HPCON hPC = launch_info.GetPTY().GetPseudoTerminalHandle();
     if (auto err = attributelist.SetupPseudoConsole(hPC)) {
       error = Status::FromError(std::move(err));
       return HostProcess();

--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -65,7 +65,10 @@ private:
 
 static Kernel32 kernel32;
 
-PseudoConsole::~PseudoConsole() { Close(); }
+PseudoConsole::~PseudoConsole() {
+  Close();
+  ClosePipes();
+}
 
 llvm::Error PseudoConsole::OpenPseudoConsole() {
   if (!kernel32.IsConPTYAvailable())
@@ -128,19 +131,28 @@ llvm::Error PseudoConsole::OpenPseudoConsole() {
   return llvm::Error::success();
 }
 
+bool PseudoConsole::IsConnected() const {
+  return m_conpty_handle != INVALID_HANDLE_VALUE &&
+         m_conpty_input != INVALID_HANDLE_VALUE &&
+         m_conpty_output != INVALID_HANDLE_VALUE;
+}
+
 void PseudoConsole::Close() {
-  Sleep(50); // FIXME: This mitigates a race condition when closing the
-             // PseudoConsole. It's possible that there is still data in the
-             // pipe when we try to close it. We should wait until the data has
-             // been consumed.
+  SetStopping(true);
+  std::unique_lock<std::mutex> guard(m_mutex);
   if (m_conpty_handle != INVALID_HANDLE_VALUE)
     kernel32.ClosePseudoConsole(m_conpty_handle);
+  m_conpty_handle = INVALID_HANDLE_VALUE;
+  SetStopping(false);
+  m_cv.notify_all();
+}
+
+void PseudoConsole::ClosePipes() {
   if (m_conpty_input != INVALID_HANDLE_VALUE)
     CloseHandle(m_conpty_input);
   if (m_conpty_output != INVALID_HANDLE_VALUE)
     CloseHandle(m_conpty_output);
 
-  m_conpty_handle = INVALID_HANDLE_VALUE;
   m_conpty_input = INVALID_HANDLE_VALUE;
   m_conpty_output = INVALID_HANDLE_VALUE;
 }


### PR DESCRIPTION
This patch fixes a race condition when closing the ConPTY of a process on Windows.

The read operation in `ConnectionGenericFile::Read` is asynchronous because the ConPTY does not work with synchronous reads. However, this is prone to a race condition if the ConPTY is closed between the `ReadFile` and the `WaitForMultipleObjects`. This eventually leads to the data being truncated, i.e some of the STDOUT is missing.

The fix is to introduce a mutex which prevents the ConPTY from closing while a Read loop is in progress.

At the end of the pipe, `WaitForMultipleObjects` hangs until it receives a `ERROR_BROKEN_PIPE` event, which is signaled when closing the ConPTY. It's important to close the Read thread before closing the ConPTY, otherwise the thread deadlocks waiting for the `ERROR_BROKEN_PIPE` which is never sent because the ConPTY is waiting for the thread to exit before closing.

All of this logic is encapsulated in the `ConnectionConPTY` class which is a subclass of `ConnectionGenericFile`. `ConnectionConPTY` only supports reading from the ConPTY. To write to it, `IOHandlerProcessSTDIOWindows` should be used instead.

This patch depends on:
- https://github.com/llvm/llvm-project/pull/182536

This patch replaces https://github.com/llvm/llvm-project/pull/182109.