### PR TITLE
[clang] Clean up large clang binaries copied into test temp directories

### DIFF
--- a/clang/test/Driver/darwin-header-search-libcxx-2.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx-2.cpp
@@ -62,3 +62,6 @@
 // RUN:               -DSYSROOT=%S/Inputs/basic_darwin_sdk_no_libcxx \
 // RUN:               --check-prefix=CHECK-TOOLCHAIN-NO-SYSROOT %s
 // CHECK-TOOLCHAIN-NO-SYSROOT: "-internal-isystem" "[[TOOLCHAIN]]/bin/../include/c++/v1"
+
+// Clean up copy of large binary copied into temp directory to avoid bloat.
+// RUN: rm -f %t/install/bin/clang || true

--- a/clang/test/Driver/rocm-detect-lib-llvm.hip
+++ b/clang/test/Driver/rocm-detect-lib-llvm.hip
@@ -26,3 +26,6 @@
 //
 // ROCM-LIB-LLVM: ROCm installation search path: {{.*sysroot/opt/rocm$}}
 // ROCM-LIB-LLVM-NOT: ROCm installation search path: {{.*sysroot/opt/rocm/lib$}}
+
+// Clean up copy of large binary copied into temp directory to avoid bloat.
+// RUN: rm -f %t/sysroot/opt/rocm/lib/llvm/bin/clang || true


### PR DESCRIPTION
I noticed a couple of tests leave behind copies of clang binaries they
copy into their temp directories. Replicate the cleanup from another
test (clang/test/Driver/clang_f_opts_withspaces.c) to remove these.
