### PR TITLE
[clang][DebugInfo] Add virtuality call-site target information in DWARF.

### DIFF
--- a/cross-project-tests/debuginfo-tests/clang_llvm_roundtrip/callsite-dwarf.cpp
+++ b/cross-project-tests/debuginfo-tests/clang_llvm_roundtrip/callsite-dwarf.cpp
@@ -1,4 +1,5 @@
-// RUN: %clang --target=x86_64-unknown-linux -c -g -O1 %s -o - | \
+// REQUIRES: x86-registered-target
+// RUN: %clang --target=x86_64-linux -c -g -O1 %s -o - | \
 // RUN: llvm-dwarfdump --debug-info - | FileCheck %s --check-prefix=CHECK
 
 // Simple base and derived class with virtual:


### PR DESCRIPTION
Add missing
  'REQUIRES: x86-registered-target'

to fix buildbot failure:
  https://lab.llvm.org/buildbot/#/builders/190/builds/36803