### PR TITLE
[clang][TypePrinter] Introduce AnonymousTagMode enum

### DIFF
--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -215,7 +215,8 @@ std::string printQualifiedName(const NamedDecl &ND) {
   Policy.SuppressScope = true;
   // (unnamed struct), not (unnamed struct at /path/to/foo.cc:42:1).
   // In clangd, context is usually available and paths are mostly noise.
-  Policy.AnonymousTagLocations = false;
+  Policy.AnonymousTagNameStyle =
+      llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
   ND.printQualifiedName(OS, Policy);
   assert(!StringRef(QName).starts_with("::"));
   return QName;

--- a/clang-tools-extra/clangd/FindSymbols.cpp
+++ b/clang-tools-extra/clangd/FindSymbols.cpp
@@ -390,7 +390,8 @@ std::string getSymbolDetail(ASTContext &Ctx, const NamedDecl &ND) {
   PrintingPolicy P(Ctx.getPrintingPolicy());
   P.SuppressScope = true;
   P.SuppressUnwrittenScope = true;
-  P.AnonymousTagLocations = false;
+  P.AnonymousTagNameStyle =
+      llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
   P.PolishForDeclaration = true;
   std::string Detail;
   llvm::raw_string_ostream OS(Detail);

--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -70,7 +70,8 @@ namespace clangd {
 namespace {
 
 PrintingPolicy getPrintingPolicy(PrintingPolicy Base) {
-  Base.AnonymousTagLocations = false;
+  Base.AnonymousTagNameStyle =
+      llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
   Base.TerseOutput = true;
   Base.PolishForDeclaration = true;
   Base.ConstantsAsWritten = true;

--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -390,8 +390,9 @@ public:
     MainFileBuf = Invalid ? StringRef{} : Buf;
 
     TypeHintPolicy.SuppressScope = true; // keep type names short
-    TypeHintPolicy.AnonymousTagLocations =
-        false; // do not print lambda locations
+    TypeHintPolicy.AnonymousTagNameStyle = llvm::to_underlying(
+        PrintingPolicy::AnonymousTagMode::Plain); // do not print lambda
+                                                  // location
 
     // Not setting PrintCanonicalTypes for "auto" allows
     // SuppressDefaultTemplateArgs (set by default) to have an effect.

--- a/clang/include/clang/AST/PrettyPrinter.h
+++ b/clang/include/clang/AST/PrettyPrinter.h
@@ -58,6 +58,16 @@ public:
 struct PrintingPolicy {
   enum class SuppressInlineNamespaceMode : uint8_t { None, Redundant, All };
 
+  /// Dictates how anonymous/unnamed entities are printed.
+  enum class AnonymousTagMode : uint8_t {
+    /// E.g., (anonymous enum)/(unnamed struct)/etc.
+    Plain,
+
+    /// When printing an anonymous tag name, also print the location of that
+    /// entity (e.g., "enum <anonymous at t.h:10:5>").
+    SourceLocation
+  };
+
   /// Create a default printing policy for the specified language.
   PrintingPolicy(const LangOptions &LO)
       : Indentation(2), SuppressSpecifiers(false),
@@ -67,8 +77,9 @@ struct PrintingPolicy {
         SuppressInlineNamespace(
             llvm::to_underlying(SuppressInlineNamespaceMode::Redundant)),
         SuppressInitializers(false), ConstantArraySizeAsWritten(false),
-        AnonymousTagLocations(true), SuppressStrongLifetime(false),
-        SuppressLifetimeQualifiers(false),
+        AnonymousTagNameStyle(
+            llvm::to_underlying(AnonymousTagMode::SourceLocation)),
+        SuppressStrongLifetime(false), SuppressLifetimeQualifiers(false),
         SuppressTemplateArgsInCXXConstructors(false),
         SuppressDefaultTemplateArgs(true), Bool(LO.Bool),
         Nullptr(LO.CPlusPlus11 || LO.C23), NullptrTypeInNamespace(LO.CPlusPlus),
@@ -196,11 +207,8 @@ struct PrintingPolicy {
   LLVM_PREFERRED_TYPE(bool)
   unsigned ConstantArraySizeAsWritten : 1;
 
-  /// When printing an anonymous tag name, also print the location of that
-  /// entity (e.g., "enum <anonymous at t.h:10:5>"). Otherwise, just prints
-  /// "(anonymous)" for the name.
-  LLVM_PREFERRED_TYPE(bool)
-  unsigned AnonymousTagLocations : 1;
+  LLVM_PREFERRED_TYPE(AnonymousTagMode)
+  unsigned AnonymousTagNameStyle : 1;
 
   /// When true, suppress printing of the __strong lifetime qualifier in ARC.
   LLVM_PREFERRED_TYPE(bool)

--- a/clang/include/clang/AST/PrettyPrinter.h
+++ b/clang/include/clang/AST/PrettyPrinter.h
@@ -59,7 +59,7 @@ struct PrintingPolicy {
   enum class SuppressInlineNamespaceMode : uint8_t { None, Redundant, All };
 
   /// Dictates how anonymous/unnamed entities are printed.
-  enum class AnonymousTagMode : uint8_t {
+  enum class AnonymousTagMode {
     /// E.g., (anonymous enum)/(unnamed struct)/etc.
     Plain,
 

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -1800,7 +1800,8 @@ void NamedDecl::printNestedNameSpecifier(raw_ostream &OS,
       // suppress tag in name
       Copy.SuppressTagKeyword = true;
       Copy.SuppressTagKeywordInAnonNames = false;
-      Copy.AnonymousTagLocations = false;
+      Copy.AnonymousTagNameStyle =
+          llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
       RD->printName(OS, Copy);
     } else if (const auto *FD = dyn_cast<FunctionDecl>(DC)) {
       const FunctionProtoType *FT = nullptr;
@@ -4994,7 +4995,9 @@ void TagDecl::printAnonymousTagDecl(llvm::raw_ostream &OS,
   if (!SuppressTagKeywordInName)
     OS << ' ' << getKindName();
 
-  if (Policy.AnonymousTagLocations) {
+  if (Policy.AnonymousTagNameStyle ==
+          llvm::to_underlying(
+              PrintingPolicy::AnonymousTagMode::SourceLocation)) {
     PresumedLoc PLoc =
         getASTContext().getSourceManager().getPresumedLoc(getLocation());
     if (PLoc.isValid()) {

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -4996,8 +4996,7 @@ void TagDecl::printAnonymousTagDecl(llvm::raw_ostream &OS,
     OS << ' ' << getKindName();
 
   if (Policy.AnonymousTagNameStyle ==
-          llvm::to_underlying(
-              PrintingPolicy::AnonymousTagMode::SourceLocation)) {
+      llvm::to_underlying(PrintingPolicy::AnonymousTagMode::SourceLocation)) {
     PresumedLoc PLoc =
         getASTContext().getSourceManager().getPresumedLoc(getLocation());
     if (PLoc.isValid()) {

--- a/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
@@ -518,7 +518,8 @@ static StringRef getNodeName(const RecordDecl &Node,
   llvm::raw_svector_ostream OS(Scratch);
 
   PrintingPolicy Copy(Node.getASTContext().getPrintingPolicy());
-  Copy.AnonymousTagLocations = false;
+  Copy.AnonymousTagNameStyle =
+      llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
   Node.printName(OS, Copy);
 
   return OS.str();

--- a/clang/lib/ExtractAPI/ExtractAPIConsumer.cpp
+++ b/clang/lib/ExtractAPI/ExtractAPIConsumer.cpp
@@ -419,7 +419,8 @@ ExtractAPIAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
 
   // Do not include location in anonymous decls.
   PrintingPolicy Policy = CI.getASTContext().getPrintingPolicy();
-  Policy.AnonymousTagLocations = false;
+  Policy.AnonymousTagNameStyle =
+      llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
   CI.getASTContext().setPrintingPolicy(Policy);
 
   if (!CI.getFrontendOpts().ExtractAPIIgnoresFileList.empty()) {
@@ -522,7 +523,8 @@ WrappingExtractAPIAction::CreateASTConsumer(CompilerInstance &CI,
 
   // Do not include location in anonymous decls.
   PrintingPolicy Policy = CI.getASTContext().getPrintingPolicy();
-  Policy.AnonymousTagLocations = false;
+  Policy.AnonymousTagNameStyle =
+      llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
   CI.getASTContext().setPrintingPolicy(Policy);
 
   if (!CI.getFrontendOpts().ExtractAPIIgnoresFileList.empty()) {

--- a/clang/lib/Index/USRGeneration.cpp
+++ b/clang/lib/Index/USRGeneration.cpp
@@ -659,7 +659,8 @@ static void printQualifier(llvm::raw_ostream &Out, const LangOptions &LangOpts,
   PO.SuppressTagKeyword = true;
   PO.SuppressUnwrittenScope = true;
   PO.ConstantArraySizeAsWritten = false;
-  PO.AnonymousTagLocations = false;
+  PO.AnonymousTagNameStyle =
+      llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
   NNS.print(Out, PO);
 }
 

--- a/clang/lib/Interpreter/InterpreterUtils.cpp
+++ b/clang/lib/Interpreter/InterpreterUtils.cpp
@@ -107,7 +107,8 @@ std::string GetFullTypeName(ASTContext &Ctx, QualType QT) {
   QualType FQT = TypeName::getFullyQualifiedType(QT, Ctx);
   PrintingPolicy Policy(Ctx.getPrintingPolicy());
   Policy.SuppressScope = false;
-  Policy.AnonymousTagLocations = false;
+  Policy.AnonymousTagNameStyle =
+      llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
   return FQT.getAsString(Policy);
 }
 } // namespace clang

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -493,7 +493,8 @@ struct BuiltinDumpStructGenerator {
   BuiltinDumpStructGenerator(Sema &S, CallExpr *TheCall)
       : S(S), TheCall(TheCall), ErrorTracker(S.getDiagnostics()),
         Policy(S.Context.getPrintingPolicy()) {
-    Policy.AnonymousTagLocations = false;
+    Policy.AnonymousTagNameStyle =
+        llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
   }
 
   Expr *makeOpaqueValueExpr(Expr *Inner) {

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -2043,7 +2043,8 @@ static bool WantTypesInContext(SemaCodeCompletion::ParserCompletionContext CCC,
 static PrintingPolicy getCompletionPrintingPolicy(const ASTContext &Context,
                                                   const Preprocessor &PP) {
   PrintingPolicy Policy = Sema::getPrintingPolicy(Context, PP);
-  Policy.AnonymousTagLocations = false;
+  Policy.AnonymousTagNameStyle =
+      llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
   Policy.SuppressStrongLifetime = true;
   Policy.SuppressUnwrittenScope = true;
   Policy.CleanUglifiedParameters = true;

--- a/clang/lib/Tooling/ASTDiff/ASTDiff.cpp
+++ b/clang/lib/Tooling/ASTDiff/ASTDiff.cpp
@@ -260,7 +260,8 @@ struct PreorderVisitor : public RecursiveASTVisitor<PreorderVisitor> {
 
 SyntaxTree::Impl::Impl(SyntaxTree *Parent, ASTContext &AST)
     : Parent(Parent), AST(AST), TypePP(AST.getLangOpts()) {
-  TypePP.AnonymousTagLocations = false;
+  TypePP.AnonymousTagNameStyle =
+      llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
 }
 
 SyntaxTree::Impl::Impl(SyntaxTree *Parent, Decl *N, ASTContext &AST)

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -5659,7 +5659,9 @@ clang_PrintingPolicy_getProperty(CXPrintingPolicy Policy,
   case CXPrintingPolicy_ConstantArraySizeAsWritten:
     return P->ConstantArraySizeAsWritten;
   case CXPrintingPolicy_AnonymousTagLocations:
-    return P->AnonymousTagLocations;
+    return P->AnonymousTagNameStyle ==
+           llvm::to_underlying(
+               PrintingPolicy::AnonymousTagMode::SourceLocation);
   case CXPrintingPolicy_SuppressStrongLifetime:
     return P->SuppressStrongLifetime;
   case CXPrintingPolicy_SuppressLifetimeQualifiers:
@@ -5733,7 +5735,12 @@ void clang_PrintingPolicy_setProperty(CXPrintingPolicy Policy,
     P->ConstantArraySizeAsWritten = Value;
     return;
   case CXPrintingPolicy_AnonymousTagLocations:
-    P->AnonymousTagLocations = Value;
+    if (Value)
+      P->AnonymousTagNameStyle =
+          llvm::to_underlying(PrintingPolicy::AnonymousTagMode::SourceLocation);
+    else
+      P->AnonymousTagNameStyle =
+          llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
     return;
   case CXPrintingPolicy_SuppressStrongLifetime:
     P->SuppressStrongLifetime = Value;

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -5735,12 +5735,9 @@ void clang_PrintingPolicy_setProperty(CXPrintingPolicy Policy,
     P->ConstantArraySizeAsWritten = Value;
     return;
   case CXPrintingPolicy_AnonymousTagLocations:
-    if (Value)
-      P->AnonymousTagNameStyle =
-          llvm::to_underlying(PrintingPolicy::AnonymousTagMode::SourceLocation);
-    else
-      P->AnonymousTagNameStyle =
-          llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
+    P->AnonymousTagNameStyle = llvm::to_underlying(
+        Value ? PrintingPolicy::AnonymousTagMode::SourceLocation
+              : PrintingPolicy::AnonymousTagMode::Plain);
     return;
   case CXPrintingPolicy_SuppressStrongLifetime:
     P->SuppressStrongLifetime = Value;

--- a/clang/unittests/AST/TypePrinterTest.cpp
+++ b/clang/unittests/AST/TypePrinterTest.cpp
@@ -315,14 +315,16 @@ TEST(TypePrinter, NestedNameSpecifiers) {
       Code, {}, varDecl(hasName("imem"), hasType(qualType().bind("id"))),
       "struct (unnamed)", [](PrintingPolicy &Policy) {
         Policy.FullyQualifiedName = true;
-        Policy.AnonymousTagLocations = false;
+        Policy.AnonymousTagNameStyle =
+            llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
       }));
 
   ASSERT_TRUE(PrintedTypeMatches(
       Code, {}, varDecl(hasName("imem"), hasType(qualType().bind("id"))),
       "struct (unnamed)", [](PrintingPolicy &Policy) {
         Policy.FullyQualifiedName = false;
-        Policy.AnonymousTagLocations = false;
+        Policy.AnonymousTagNameStyle =
+            llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
       }));
 
   // Further levels of nesting print the entire scope.
@@ -331,14 +333,16 @@ TEST(TypePrinter, NestedNameSpecifiers) {
       "union level1()::Inner::Inner(int)::(unnamed struct)::(unnamed)",
       [](PrintingPolicy &Policy) {
         Policy.FullyQualifiedName = true;
-        Policy.AnonymousTagLocations = false;
+        Policy.AnonymousTagNameStyle =
+            llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
       }));
 
   ASSERT_TRUE(PrintedTypeMatches(
       Code, {}, fieldDecl(hasName("u"), hasType(qualType().bind("id"))),
       "union (unnamed)", [](PrintingPolicy &Policy) {
         Policy.FullyQualifiedName = false;
-        Policy.AnonymousTagLocations = false;
+        Policy.AnonymousTagNameStyle =
+            llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
       }));
 }
 
@@ -357,6 +361,7 @@ TEST(TypePrinter, NestedNameSpecifiersTypedef) {
       Code, {}, fieldDecl(hasName("bar"), hasType(qualType().bind("id"))),
       "struct foo::(anonymous struct)::(unnamed)", [](PrintingPolicy &Policy) {
         Policy.FullyQualifiedName = true;
-        Policy.AnonymousTagLocations = false;
+        Policy.AnonymousTagNameStyle =
+            llvm::to_underlying(PrintingPolicy::AnonymousTagMode::Plain);
       }));
 }

--- a/clang/unittests/Tooling/QualTypeNamesTest.cpp
+++ b/clang/unittests/Tooling/QualTypeNamesTest.cpp
@@ -22,7 +22,8 @@ struct TypeNameVisitor : TestVisitor {
     if (ExpectedName != "") {
       PrintingPolicy Policy(Context->getPrintingPolicy());
       Policy.SuppressScope = false;
-      Policy.AnonymousTagLocations = true;
+      Policy.AnonymousTagNameStyle =
+          llvm::to_underlying(PrintingPolicy::AnonymousTagMode::SourceLocation);
       Policy.PolishForDeclaration = true;
       Policy.SuppressUnwrittenScope = true;
       std::string ActualName = TypeName::getFullyQualifiedName(


### PR DESCRIPTION
As part of https://github.com/llvm/llvm-project/pull/159592, we want to emit unique lambda names into debug-info without relying on `AnonymousTagLocations` (i.e., we don't want the source files included in the names).

The plan is to implement this as a third `AnonymousTagMode`. This patch turns the existing `AnonymousTagLocations` into an enum as preparation.

(full prototype is at https://github.com/llvm/llvm-project/pull/168533)