### PR TITLE
[clang-format] Fix BeforeLambdaBody causing incorrect argument wrapping

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -767,6 +767,13 @@ void ContinuationIndenter::addTokenOnCurrentLine(LineState &State, bool DryRun,
       return false;
     }
 
+    // When BeforeLambdaBody is set, lambda bodies are intentionally expanded
+    // onto their own lines. Do not prevent line breaks in the parent scope,
+    // as that would force all arguments (including those before the lambda)
+    // to be wrapped to new lines.
+    if (Style.BraceWrapping.BeforeLambdaBody)
+      return false;
+
     // For example, `/*Newline=*/false`.
     if (Previous.is(TT_BlockComment) && Current.SpacesRequiredBefore == 0)
       return false;

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -441,7 +441,7 @@ bool ContinuationIndenter::mustBreak(const LineState &State) {
   if (Style.BraceWrapping.BeforeLambdaBody && Current.CanBreakBefore &&
       Current.is(TT_LambdaLBrace) && Previous.isNot(TT_LineComment)) {
     auto LambdaBodyLength = getLengthToMatchingParen(Current, State.Stack);
-    return LambdaBodyLength > getColumnLimit(State);
+    return Current.MustBreakBefore || LambdaBodyLength > getColumnLimit(State);
   }
   if (Current.MustBreakBefore ||
       (Current.is(TT_InlineASMColon) &&
@@ -767,13 +767,6 @@ void ContinuationIndenter::addTokenOnCurrentLine(LineState &State, bool DryRun,
       return false;
     }
 
-    // When BeforeLambdaBody is set, lambda bodies are intentionally expanded
-    // onto their own lines. Do not prevent line breaks in the parent scope,
-    // as that would force all arguments (including those before the lambda)
-    // to be wrapped to new lines.
-    if (Style.BraceWrapping.BeforeLambdaBody)
-      return false;
-
     // For example, `/*Newline=*/false`.
     if (Previous.is(TT_BlockComment) && Current.SpacesRequiredBefore == 0)
       return false;
@@ -787,6 +780,15 @@ void ContinuationIndenter::addTokenOnCurrentLine(LineState &State, bool DryRun,
 
     if (Prev->BlockParameterCount == 0)
       return false;
+
+    // If any lambda brace in the argument list has MustBreakBefore set
+    // (e.g. for Allman-style BeforeLambdaBody), the "all arguments on one
+    // line" strategy is impossible, so allow natural line wrapping.
+    for (const auto *Tok = Prev->Next; Tok && Tok != Prev->MatchingParen;
+         Tok = Tok->Next) {
+      if (Tok->is(TT_LambdaLBrace) && Tok->MustBreakBefore)
+        return false;
+    }
 
     // Multiple lambdas in the same function call.
     if (Prev->BlockParameterCount > 1)

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -24325,6 +24325,64 @@ TEST_F(FormatTest, FormatsLambdas) {
                "  })));\n"
                "}",
                Style);
+
+  // Verify that BeforeLambdaBody does not cause arguments before the lambda to
+  // be wrapped to a new line when the lambda is not the last argument.
+  FormatStyle BeforeLambdaBodyStyle = getLLVMStyle();
+  BeforeLambdaBodyStyle.BreakBeforeBraces = FormatStyle::BS_Custom;
+  BeforeLambdaBodyStyle.BraceWrapping.BeforeLambdaBody = true;
+  BeforeLambdaBodyStyle.AllowShortLambdasOnASingleLine =
+      FormatStyle::ShortLambdaStyle::SLS_None;
+
+  // Lambda followed by another argument: args before lambda stay on first line.
+  verifyFormat("void test() {\n"
+               "  func(a, b,\n"
+               "       [](int x)\n"
+               "       {\n"
+               "         return x;\n"
+               "       },\n"
+               "       c);\n"
+               "}",
+               BeforeLambdaBodyStyle);
+  // Two lambdas as arguments: args before lambdas stay on first line.
+  verifyFormat("void test() {\n"
+               "  func(a, b,\n"
+               "       [](int x)\n"
+               "       {\n"
+               "         return x;\n"
+               "       },\n"
+               "       [](int y)\n"
+               "       {\n"
+               "         return y;\n"
+               "       });\n"
+               "}",
+               BeforeLambdaBodyStyle);
+
+  BeforeLambdaBodyStyle.AllowShortLambdasOnASingleLine =
+      FormatStyle::ShortLambdaStyle::SLS_Empty;
+  // With SLS_Empty, lambda followed by another argument.
+  verifyFormat("void test() {\n"
+               "  func(a, b,\n"
+               "       [](int x)\n"
+               "       {\n"
+               "         return x;\n"
+               "       },\n"
+               "       c);\n"
+               "}",
+               BeforeLambdaBodyStyle);
+  // With SLS_Empty, two lambdas as arguments.
+  verifyFormat("void test() {\n"
+               "  func(a, b,\n"
+               "       [](int x)\n"
+               "       {\n"
+               "         return x;\n"
+               "       },\n"
+               "       [](int y)\n"
+               "       {\n"
+               "         return y;\n"
+               "       });\n"
+               "}",
+               BeforeLambdaBodyStyle);
 }
 
 TEST_F(FormatTest, LambdaWithLineComments) {


### PR DESCRIPTION
Fix #182274