### PR TITLE
[mlir][tosa] Use 0 values for the dense resource in tosa-narrow-* tests

### DIFF
--- a/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32-aggressive.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32-aggressive.mlir
@@ -83,8 +83,8 @@ func.func @test_dense_ressource_f64() -> tensor<1x2xf64> {
 {-#
   dialect_resources: {
     builtin: {
-      // COMMON: resource: "0x04000000DB0F4940EAD6FCBD"
-      resource: "0x08000000182D4454FB21094059F64637DD9ABFBF"
+      // COMMON: resource: "0x040000000000000000000000"
+      resource: "0x0800000000000000000000000000000000000000"
     }
   }
 #-}

--- a/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-f64-to-f32.mlir
@@ -193,8 +193,8 @@ func.func @test_dense_ressource_f64() -> tensor<1x2xf64> {
 {-#
   dialect_resources: {
     builtin: {
-      // COMMON: resource: "0x040000000000803F000080BF"
-      resource: "0x08000000000000000000F03F000000000000F0BF"
+      // COMMON: resource: "0x040000000000000000000000"
+      resource: "0x0800000000000000000000000000000000000000"
     }
   }
 #-}

--- a/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32-aggressive.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32-aggressive.mlir
@@ -103,8 +103,8 @@ func.func @test_dense_ressource_i64() -> tensor<1x2xi64> {
 {-#
   dialect_resources: {
     builtin: {
-      // COMMON: resource: "0x04000000FFFFFF7F00000080"
-      resource: "0x08000000000000000800000000000000F8FFFFFF"
+      // COMMON: resource: "0x040000000000000000000000"
+      resource: "0x0800000000000000000000000000000000000000"
     }
   }
 #-}

--- a/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-narrow-i64-to-i32.mlir
@@ -214,8 +214,8 @@ func.func @test_dense_ressource_i64() -> tensor<1x2xi64> {
 {-#
   dialect_resources: {
     builtin: {
-      // COMMON: resource: "0x04000000FEFFFF7F905AE75A"
-      resource: "0x08000000FEFFFF7F00000000905AE75A00000000"
+      // COMMON: resource: "0x040000000000000000000000"
+      resource: "0x0800000000000000000000000000000000000000"
     }
   }
 #-}


### PR DESCRIPTION
For the test portability between little-endian and big-endian, just use zeros as the dense resource values. It doesn't test the actual narrowing but tests that the other conversions went well.