### PR TITLE
[MLIR] Remove deprecated setting usePropertiesForAttributes

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/CUF/CUFDialect.td
+++ b/flang/include/flang/Optimizer/Dialect/CUF/CUFDialect.td
@@ -29,7 +29,6 @@ def CUFDialect : Dialect {
   }];
 
   let useDefaultAttributePrinterParser = 1;
-  let usePropertiesForAttributes = 1;
   let cppNamespace = "::cuf";
   let dependentDialects = ["fir::FIROpsDialect"];
 

--- a/flang/include/flang/Optimizer/Dialect/FIRCG/CGOps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRCG/CGOps.td
@@ -22,7 +22,6 @@ include "mlir/IR/BuiltinAttributes.td"
 def fircg_Dialect : Dialect {
   let name = "fircg";
   let cppNamespace = "::fir::cg";
-  let usePropertiesForAttributes = 1;
 }
 
 // Base class for FIR CG operations.

--- a/flang/include/flang/Optimizer/Dialect/FIRDialect.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRDialect.td
@@ -26,7 +26,6 @@ def FIROpsDialect : Dialect {
   let cppNamespace = "::fir";
   let useDefaultTypePrinterParser = 0;
   let useDefaultAttributePrinterParser = 0;
-  let usePropertiesForAttributes = 1;
   let dependentDialects = [
     // Arith dialect provides FastMathFlagsAttr
     // supported by some FIR operations.

--- a/flang/include/flang/Optimizer/HLFIR/HLFIROpBase.td
+++ b/flang/include/flang/Optimizer/HLFIR/HLFIROpBase.td
@@ -39,7 +39,6 @@ def hlfir_Dialect : Dialect {
   }];
 
   let useDefaultTypePrinterParser = 1;
-  let usePropertiesForAttributes = 1;
   let cppNamespace = "hlfir";
   let dependentDialects = ["fir::FIROpsDialect"];
 }

--- a/mlir/include/mlir/IR/DialectBase.td
+++ b/mlir/include/mlir/IR/DialectBase.td
@@ -92,9 +92,6 @@ class Dialect {
 
   // If this dialect can be extended at runtime with new operations or types.
   bit isExtensible = 0;
-
-  // Whether inherent Attributes defined in ODS will be stored as Properties.
-  bit usePropertiesForAttributes = 1;
 }
 
 #endif // DIALECTBASE_TD

--- a/mlir/include/mlir/TableGen/Dialect.h
+++ b/mlir/include/mlir/TableGen/Dialect.h
@@ -88,10 +88,6 @@ public:
   /// operations or types.
   bool isExtensible() const;
 
-  /// Default to use properties for storing Attributes for operations in this
-  /// dialect.
-  bool usePropertiesForAttributes() const;
-
   const llvm::DagInit *getDiscardableAttributes() const;
 
   const llvm::Record *getDef() const { return def; }

--- a/mlir/lib/TableGen/Dialect.cpp
+++ b/mlir/lib/TableGen/Dialect.cpp
@@ -102,10 +102,6 @@ bool Dialect::isExtensible() const {
   return def->getValueAsBit("isExtensible");
 }
 
-bool Dialect::usePropertiesForAttributes() const {
-  return def->getValueAsBit("usePropertiesForAttributes");
-}
-
 const llvm::DagInit *Dialect::getDiscardableAttributes() const {
   return def->getValueAsDag("discardableAttrs");
 }

--- a/mlir/test/mlir-tblgen/op-attribute.td
+++ b/mlir/test/mlir-tblgen/op-attribute.td
@@ -469,53 +469,6 @@ def EOp : NS_Op<"e_op", []> {
 // DECL-LABEL: EOp declarations
 // DECL: static void build({{.*}}, uint32_t i32_attr, uint32_t dv_i32_attr, ::llvm::APFloat f64_attr, ::llvm::APFloat dv_f64_attr, ::llvm::StringRef str_attr, ::llvm::StringRef dv_str_attr, bool bool_attr, bool dv_bool_attr, ::SomeI32Enum enum_attr, ::SomeI32Enum dv_enum_attr = ::SomeI32Enum::case5)
 
-// Test verifyInvariantsImpl for op in dialect with `usePropertiesForAttributes = 0` set.
-// ---
-
-def Test3_Dialect : Dialect {
-  let name = "test3";
-  let cppNamespace = "foobar3";
-  let usePropertiesForAttributes = 0;
-}
-def FOp : Op<Test3_Dialect, "f_op", []> {
-  let arguments = (ins
-      SomeAttr:$aAttr,
-      DefaultValuedOptionalAttr<SomeAttr, "4.2">:$bAttr,
-      OptionalAttr<SomeAttr>:$cAttr
-  );
-}
-
-// DEF-LABEL: FOp definitions
-// DEF: ::llvm::LogicalResult FOp::verifyInvariantsImpl() {
-// DEF:   auto namedAttrRange = (*this)->getAttrs();
-// DEF:   auto namedAttrIt = namedAttrRange.begin();
-// DEF:   ::mlir::Attribute tblgen_aAttr;
-
-// DEF:   while (true) {
-// DEF:     if (namedAttrIt == namedAttrRange.end())
-// DEF:       return emitOpError("requires attribute 'aAttr'");
-// DEF:     if (namedAttrIt->getName() == getAAttrAttrName()) {
-// DEF:       tblgen_aAttr = namedAttrIt->getValue();
-// DEF:       break;
-// DEF:     }
-// DEF:     ++namedAttrIt;
-// DEF:   }
-
-// DEF:   ::mlir::Attribute tblgen_bAttr;
-// DEF:   ::mlir::Attribute tblgen_cAttr;
-// DEF:   while (true) {
-// DEF:     if (namedAttrIt == namedAttrRange.end()) {
-// DEF:       break;
-// DEF:     }
-// DEF:     else if (namedAttrIt->getName() == getBAttrAttrName()) {
-// DEF:       tblgen_bAttr = namedAttrIt->getValue();
-// DEF:     }
-// DEF:     else if (namedAttrIt->getName() == getCAttrAttrName()) {
-// DEF:       tblgen_cAttr = namedAttrIt->getValue();
-// DEF:     }
-// DEF:     ++namedAttrIt;
-// DEF:   }
-
 // Test proper namespacing for AttrDef
 // ---
 

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -60,6 +60,8 @@ static const char *const tblgenNamePrefix = "tblgen_";
 static const char *const generatedArgName = "odsArg";
 static const char *const odsBuilder = "odsBuilder";
 static const char *const builderOpState = "odsState";
+static const char *const builderOpStateProperties =
+    "odsState.getOrAddProperties<Properties>()";
 static const char *const propertyStorage = "propStorage";
 static const char *const propertyValue = "propValue";
 static const char *const propertyAttr = "propAttr";
@@ -123,19 +125,8 @@ static const char *const attrSizedSegmentValueRangeCalcCode = R"(
 /// The code snippet to initialize the sizes for the value range calculation.
 ///
 /// {0}: The code to get the attribute.
-static const char *const adapterSegmentSizeAttrInitCode = R"(
-  assert({0} && "missing segment size attribute for op");
-  auto sizeAttr = ::llvm::cast<::mlir::DenseI32ArrayAttr>({0});
-)";
 static const char *const adapterSegmentSizeAttrInitCodeProperties = R"(
   ::llvm::ArrayRef<int32_t> sizeAttr = {0};
-)";
-
-/// The code snippet to initialize the sizes for the value range calculation.
-///
-/// {0}: The code to get the attribute.
-static const char *const opSegmentSizeAttrInitCode = R"(
-  auto sizeAttr = ::llvm::cast<::mlir::DenseI32ArrayAttr>({0});
 )";
 
 /// The logic to calculate the actual value range for a declared operand
@@ -431,8 +422,6 @@ public:
   bool hasProperties() const {
     if (!op.getProperties().empty())
       return true;
-    if (!op.getDialect().usePropertiesForAttributes())
-      return false;
     return true;
   }
 
@@ -537,36 +526,22 @@ void OpOrAdaptorHelper::computeAttrMetadata() {
   };
   // Include key attributes from several traits as implicitly registered.
   if (op.getTrait("::mlir::OpTrait::AttrSizedOperandSegments")) {
-    if (op.getDialect().usePropertiesForAttributes()) {
-      operandSegmentsSizeStorage =
-          llvm::formatv("std::array<int32_t, {0}>", op.getNumOperands());
-      operandSegmentsSizeParser =
-          llvm::formatv(parseTextualSegmentSizeFormat, op.getNumOperands());
-      operandSegmentsSize = {
-          "operandSegmentSizes",
-          makeProperty(operandSegmentsSizeStorage, operandSegmentsSizeParser)};
-    } else {
-      attrMetadata.insert(
-          {operandSegmentAttrName, AttributeMetadata{operandSegmentAttrName,
-                                                     /*isRequired=*/true,
-                                                     /*attr=*/std::nullopt}});
-    }
+    operandSegmentsSizeStorage =
+        llvm::formatv("std::array<int32_t, {0}>", op.getNumOperands());
+    operandSegmentsSizeParser =
+        llvm::formatv(parseTextualSegmentSizeFormat, op.getNumOperands());
+    operandSegmentsSize = {
+        "operandSegmentSizes",
+        makeProperty(operandSegmentsSizeStorage, operandSegmentsSizeParser)};
   }
   if (op.getTrait("::mlir::OpTrait::AttrSizedResultSegments")) {
-    if (op.getDialect().usePropertiesForAttributes()) {
-      resultSegmentsSizeStorage =
-          llvm::formatv("std::array<int32_t, {0}>", op.getNumResults());
-      resultSegmentsSizeParser =
-          llvm::formatv(parseTextualSegmentSizeFormat, op.getNumResults());
-      resultSegmentsSize = {
-          "resultSegmentSizes",
-          makeProperty(resultSegmentsSizeStorage, resultSegmentsSizeParser)};
-    } else {
-      attrMetadata.insert(
-          {resultSegmentAttrName,
-           AttributeMetadata{resultSegmentAttrName, /*isRequired=*/true,
-                             /*attr=*/std::nullopt}});
-    }
+    resultSegmentsSizeStorage =
+        llvm::formatv("std::array<int32_t, {0}>", op.getNumResults());
+    resultSegmentsSizeParser =
+        llvm::formatv(parseTextualSegmentSizeFormat, op.getNumResults());
+    resultSegmentsSize = {
+        "resultSegmentSizes",
+        makeProperty(resultSegmentsSizeStorage, resultSegmentsSizeParser)};
   }
 
   // Store the metadata in sorted order.
@@ -865,43 +840,6 @@ static void populateSubstitutions(const OpOrAdaptorHelper &emitHelper,
   }
 }
 
-/// Generate verification on native traits requiring attributes.
-static void genNativeTraitAttrVerifier(MethodBody &body,
-                                       const OpOrAdaptorHelper &emitHelper) {
-  // Check that the variadic segment sizes attribute exists and contains the
-  // expected number of elements.
-  //
-  // {0}: Attribute name.
-  // {1}: Expected number of elements.
-  // {2}: "operand" or "result".
-  // {3}: Emit error prefix.
-  const char *const checkAttrSizedValueSegmentsCode = R"(
-  {
-    auto sizeAttr = ::llvm::cast<::mlir::DenseI32ArrayAttr>(tblgen_{0});
-    auto numElements = sizeAttr.asArrayRef().size();
-    if (numElements != {1})
-      return {3}"'{0}' attribute for specifying {2} segments must have {1} "
-                "elements, but got ") << numElements;
-  }
-  )";
-
-  // Verify a few traits first so that we can use getODSOperands() and
-  // getODSResults() in the rest of the verifier.
-  auto &op = emitHelper.getOp();
-  if (!op.getDialect().usePropertiesForAttributes()) {
-    if (op.getTrait("::mlir::OpTrait::AttrSizedOperandSegments")) {
-      body << formatv(checkAttrSizedValueSegmentsCode, operandSegmentAttrName,
-                      op.getNumOperands(), "operand",
-                      emitHelper.emitErrorPrefix());
-    }
-    if (op.getTrait("::mlir::OpTrait::AttrSizedResultSegments")) {
-      body << formatv(checkAttrSizedValueSegmentsCode, resultSegmentAttrName,
-                      op.getNumResults(), "result",
-                      emitHelper.emitErrorPrefix());
-    }
-  }
-}
-
 // Return true if a verifier can be emitted for the attribute: it is not a
 // derived attribute, it has a predicate, its condition is not empty, and, for
 // adaptors, the condition does not reference the op.
@@ -1076,10 +1014,6 @@ while (true) {{
     }
   }
   body.unindent();
-
-  // Emit the checks for segment attributes first so that the other
-  // constraints can call operand and result getters.
-  genNativeTraitAttrVerifier(body, emitHelper);
 
   bool isEmittingForOp = emitHelper.isEmittingForOp();
   for (const auto &namedAttr : emitHelper.getOp().getAttributes())
@@ -1275,7 +1209,6 @@ void OpEmitter::genAttrNameGetters() {
   const llvm::MapVector<StringRef, AttributeMetadata> &attributes =
       emitHelper.getAttrMetadata();
   bool hasOperandSegmentsSize =
-      op.getDialect().usePropertiesForAttributes() &&
       op.getTrait("::mlir::OpTrait::AttrSizedOperandSegments");
   // Emit the getAttributeNames method.
   {
@@ -2039,18 +1972,11 @@ void OpEmitter::genAttrGetters() {
 }
 
 void OpEmitter::genAttrSetters() {
-  bool useProperties = op.getDialect().usePropertiesForAttributes();
-
   // Generate the code to set an attribute.
   auto emitSetAttr = [&](Method *method, StringRef getterName,
                          StringRef attrName, StringRef attrVar) {
-    if (useProperties) {
-      method->body() << formatv("  getProperties().{0} = {1};", attrName,
-                                attrVar);
-    } else {
-      method->body() << formatv("  (*this)->setAttr({0}AttrName(), {1});",
-                                getterName, attrVar);
-    }
+    method->body() << formatv("  getProperties().{0} = {1};", attrName,
+                              attrVar);
   };
 
   // Generate raw named setter type. This is a wrapper class that allows setting
@@ -2110,25 +2036,15 @@ void OpEmitter::genAttrSetters() {
     // optional but not in the same way as the others (i.e. it uses bool over
     // std::optional<>).
     StringRef paramStr = isUnitAttr ? "attrValue" : "*attrValue";
-    if (!useProperties) {
-      const char *optionalCodeBody = R"(
-    if (attrValue)
-      return (*this)->setAttr({0}AttrName(), {1});
-    (*this)->removeAttr({0}AttrName());)";
-      method->body() << formatv(
-          optionalCodeBody, getterName,
-          constBuildAttrFromParam(baseAttr, fctx, paramStr));
-    } else {
-      const char *optionalCodeBody = R"(
+    const char *optionalCodeBody = R"(
     auto &odsProp = getProperties().{0};
     if (attrValue)
       odsProp = {1};
     else
       odsProp = nullptr;)";
-      method->body() << formatv(
-          optionalCodeBody, attrName,
-          constBuildAttrFromParam(baseAttr, fctx, paramStr));
-    }
+    method->body() << formatv(
+        optionalCodeBody, attrName,
+        constBuildAttrFromParam(baseAttr, fctx, paramStr));
   };
 
   for (const NamedAttribute &namedAttr : op.getAttributes()) {
@@ -2146,28 +2062,22 @@ void OpEmitter::genAttrSetters() {
 void OpEmitter::genOptionalAttrRemovers() {
   // Generate methods for removing optional attributes, instead of having to
   // use the string interface. Enables better compile time verification.
-  auto emitRemoveAttr = [&](StringRef name, bool useProperties) {
+  auto emitRemoveAttr = [&](StringRef name) {
     auto *method = opClass.addInlineMethod("::mlir::Attribute",
                                            op.getRemoverName(name) + "Attr");
     if (!method)
       return;
-    if (useProperties) {
-      method->body() << formatv(R"(
+    method->body() << formatv(R"(
     auto attr = getProperties().{0};
     getProperties().{0} = {{};
     return attr;
 )",
-                                name);
-      return;
-    }
-    method->body() << formatv("return (*this)->removeAttr({0}AttrName());",
-                              op.getGetterName(name));
+                              name);
   };
 
   for (const NamedAttribute &namedAttr : op.getAttributes())
     if (namedAttr.attr.isOptional())
-      emitRemoveAttr(namedAttr.name,
-                     op.getDialect().usePropertiesForAttributes());
+      emitRemoveAttr(namedAttr.name);
 }
 
 // Generates the code to compute the start and end index of an operand or result
@@ -2366,13 +2276,8 @@ void OpEmitter::genNamedOperandGetters() {
   // array.
   std::string attrSizeInitCode;
   if (op.getTrait("::mlir::OpTrait::AttrSizedOperandSegments")) {
-    if (op.getDialect().usePropertiesForAttributes())
-      attrSizeInitCode = formatv(adapterSegmentSizeAttrInitCodeProperties,
-                                 "getProperties().operandSegmentSizes");
-
-    else
-      attrSizeInitCode = formatv(opSegmentSizeAttrInitCode,
-                                 emitHelper.getAttr(operandSegmentAttrName));
+    attrSizeInitCode = formatv(adapterSegmentSizeAttrInitCodeProperties,
+                               "getProperties().operandSegmentSizes");
   }
 
   generateNamedOperandGetters(
@@ -2483,13 +2388,8 @@ void OpEmitter::genNamedResultGetters() {
   // Build the initializer string for the result segment size attribute.
   std::string attrSizeInitCode;
   if (attrSizedResults) {
-    if (op.getDialect().usePropertiesForAttributes())
-      attrSizeInitCode = formatv(adapterSegmentSizeAttrInitCodeProperties,
-                                 "getProperties().resultSegmentSizes");
-
-    else
-      attrSizeInitCode = formatv(opSegmentSizeAttrInitCode,
-                                 emitHelper.getAttr(resultSegmentAttrName));
+    attrSizeInitCode = formatv(adapterSegmentSizeAttrInitCodeProperties,
+                               "getProperties().resultSegmentSizes");
   }
 
   generateValueRangeStartAndEnd(
@@ -2722,14 +2622,7 @@ void OpEmitter::genSeparateArgParamBuilder() {
       // Automatically create the 'resultSegmentSizes' attribute using
       // the length of the type ranges.
       if (op.getTrait("::mlir::OpTrait::AttrSizedResultSegments")) {
-        if (op.getDialect().usePropertiesForAttributes()) {
-          body << "  ::llvm::copy(::llvm::ArrayRef<int32_t>({";
-        } else {
-          std::string getterName = op.getGetterName(resultSegmentAttrName);
-          body << " " << builderOpState << ".addAttribute(" << getterName
-               << "AttrName(" << builderOpState << ".name), "
-               << "odsBuilder.getDenseI32ArrayAttr({";
-        }
+        body << "  ::llvm::copy(::llvm::ArrayRef<int32_t>({";
         interleaveComma(
             llvm::seq<int>(0, op.getNumResults()), body, [&](int i) {
               const NamedTypeConstraint &result = op.getResult(i);
@@ -2746,13 +2639,8 @@ void OpEmitter::genSeparateArgParamBuilder() {
                 body << "static_cast<int32_t>(" << resultNames[i] << ".size())";
               }
             });
-        if (op.getDialect().usePropertiesForAttributes()) {
-          body << "}), " << builderOpState
-               << ".getOrAddProperties<Properties>()."
-                  "resultSegmentSizes.begin());\n";
-        } else {
-          body << "}));\n";
-        }
+        body << "}), " << builderOpStateProperties
+             << ".resultSegmentSizes.begin());\n";
       }
 
       return;
@@ -3501,16 +3389,9 @@ void OpEmitter::genCodeForAddingArgAndRegionForBuilder(
            << "      rangeSegments.push_back(range.size());\n"
            << "    auto rangeAttr = " << odsBuilder
            << ".getDenseI32ArrayAttr(rangeSegments);\n";
-      if (op.getDialect().usePropertiesForAttributes()) {
-        body << "    " << builderOpState << ".getOrAddProperties<Properties>()."
-             << operand.constraint.getVariadicOfVariadicSegmentSizeAttr()
-             << " = rangeAttr;";
-      } else {
-        body << "    " << builderOpState << ".addAttribute("
-             << op.getGetterName(
-                    operand.constraint.getVariadicOfVariadicSegmentSizeAttr())
-             << "AttrName(" << builderOpState << ".name), rangeAttr);";
-      }
+      body << "    " << builderOpStateProperties << "."
+           << operand.constraint.getVariadicOfVariadicSegmentSizeAttr()
+           << " = rangeAttr;";
       body << "  }\n";
       continue;
     }
@@ -3545,19 +3426,10 @@ void OpEmitter::genCodeForAddingArgAndRegionForBuilder(
   };
   if (op.getTrait("::mlir::OpTrait::AttrSizedOperandSegments")) {
     std::string sizes = op.getGetterName(operandSegmentAttrName);
-    if (op.getDialect().usePropertiesForAttributes()) {
-      body << "  ::llvm::copy(::llvm::ArrayRef<int32_t>({";
-      emitSegment();
-      body << "}), " << builderOpState
-           << ".getOrAddProperties<Properties>()."
-              "operandSegmentSizes.begin());\n";
-    } else {
-      body << "  " << builderOpState << ".addAttribute(" << sizes << "AttrName("
-           << builderOpState << ".name), "
-           << "odsBuilder.getDenseI32ArrayAttr({";
-      emitSegment();
-      body << "}));\n";
-    }
+    body << "  ::llvm::copy(::llvm::ArrayRef<int32_t>({";
+    emitSegment();
+    body << "}), " << builderOpStateProperties
+         << ".operandSegmentSizes.begin());\n";
   }
 
   // Push all properties to the result.
@@ -3566,8 +3438,8 @@ void OpEmitter::genCodeForAddingArgAndRegionForBuilder(
     // interface type (used in the builder argument) to the storage type (used
     // in the state) is not necessarily trivial.
     std::string setterName = op.getSetterName(namedProp.name);
-    body << formatv("  {0}.getOrAddProperties<Properties>().{1}({2});\n",
-                    builderOpState, setterName, namedProp.name);
+    body << formatv("  {0}.{1}({2});\n", builderOpStateProperties, setterName,
+                    namedProp.name);
   }
   // Push all attributes to the result.
   for (const auto &namedAttr : op.getAttributes()) {
@@ -3591,24 +3463,12 @@ void OpEmitter::genCodeForAddingArgAndRegionForBuilder(
       // instance.
       FmtContext fctx;
       fctx.withBuilder("odsBuilder");
-      if (op.getDialect().usePropertiesForAttributes()) {
-        body << formatv("  {0}.getOrAddProperties<Properties>().{1} = {2};\n",
-                        builderOpState, namedAttr.name,
-                        constBuildAttrFromParam(attr, fctx, namedAttr.name));
-      } else {
-        body << formatv("  {0}.addAttribute({1}AttrName({0}.name), {2});\n",
-                        builderOpState, op.getGetterName(namedAttr.name),
-                        constBuildAttrFromParam(attr, fctx, namedAttr.name));
-      }
+      body << formatv("  {0}.{1} = {2};\n", builderOpStateProperties,
+                      namedAttr.name,
+                      constBuildAttrFromParam(attr, fctx, namedAttr.name));
     } else {
-      if (op.getDialect().usePropertiesForAttributes()) {
-        body << formatv("  {0}.getOrAddProperties<Properties>().{1} = {1};\n",
-                        builderOpState, namedAttr.name);
-      } else {
-        body << formatv("  {0}.addAttribute({1}AttrName({0}.name), {2});\n",
-                        builderOpState, op.getGetterName(namedAttr.name),
-                        namedAttr.name);
-      }
+      body << formatv("  {0}.{1} = {1};\n", builderOpStateProperties,
+                      namedAttr.name);
     }
     if (emitNotNullCheck)
       body.unindent() << "  }\n";
@@ -3935,20 +3795,12 @@ void OpEmitter::genTypeInterfaceMethods() {
         } else if (auto *attr = dyn_cast<NamedAttribute *>(
                        op.getArg(arg.operandOrAttributeIndex()))) {
           body << "  ::mlir::TypedAttr odsInferredTypeAttr" << inferredTypeIdx
-               << " = ";
-          if (op.getDialect().usePropertiesForAttributes()) {
-            body << "(properties ? properties.as<Properties *>()->"
-                 << attr->name
-                 << " : "
-                    "::llvm::dyn_cast_or_null<::mlir::TypedAttr>(attributes."
-                    "get(\"" +
-                        attr->name + "\")));\n";
-          } else {
-            body << "::llvm::dyn_cast_or_null<::mlir::TypedAttr>(attributes."
-                    "get(\"" +
-                        attr->name + "\"));\n";
-          }
-          body << "  if (!odsInferredTypeAttr" << inferredTypeIdx
+               << " = (properties ? properties.as<Properties *>()->"
+               << attr->name
+               << " : ::llvm::dyn_cast_or_null<::mlir::TypedAttr>(attributes."
+                  "get(\""
+               << attr->name << "\")));\n"
+               << "  if (!odsInferredTypeAttr" << inferredTypeIdx
                << ") return ::mlir::failure();\n";
           typeStr =
               ("odsInferredTypeAttr" + Twine(inferredTypeIdx) + ".getType()")
@@ -4672,13 +4524,8 @@ OpOperandAdaptorEmitter::OpOperandAdaptorEmitter(
 
   std::string sizeAttrInit;
   if (op.getTrait("::mlir::OpTrait::AttrSizedOperandSegments")) {
-    if (op.getDialect().usePropertiesForAttributes())
-      sizeAttrInit =
-          formatv(adapterSegmentSizeAttrInitCodeProperties,
-                  llvm::formatv("getProperties().operandSegmentSizes"));
-    else
-      sizeAttrInit = formatv(adapterSegmentSizeAttrInitCode,
-                             emitHelper.getAttr(operandSegmentAttrName));
+    sizeAttrInit = formatv(adapterSegmentSizeAttrInitCodeProperties,
+                           "getProperties().operandSegmentSizes");
   }
   generateNamedOperandGetters(op, genericAdaptor,
                               /*genericAdaptorBase=*/&genericAdaptorBase,

--- a/mlir/unittests/Bytecode/BytecodeTest.cpp
+++ b/mlir/unittests/Bytecode/BytecodeTest.cpp
@@ -223,8 +223,9 @@ TEST(Bytecode, OpWithoutProperties) {
       llvm::MemoryBufferRef(bytecode, "string-buffer"), block.get(), config)));
   Operation *roundtripped = &block->front();
   EXPECT_EQ(roundtripped->getAttrs().size(), 2u);
-  EXPECT_TRUE(roundtripped->getInherentAttr("inherent_attr") != std::nullopt);
-  EXPECT_TRUE(roundtripped->getDiscardableAttr("other_attr") != Attribute());
+  EXPECT_EQ(roundtripped->getInherentAttr("inherent_attr"), std::nullopt);
+  EXPECT_NE(roundtripped->getDiscardableAttr("inherent_attr"), Attribute());
+  EXPECT_NE(roundtripped->getDiscardableAttr("other_attr"), Attribute());
 
   EXPECT_TRUE(OperationEquivalence::computeHash(op.get()) ==
               OperationEquivalence::computeHash(roundtripped));

--- a/mlir/unittests/IR/OpPropertiesTest.cpp
+++ b/mlir/unittests/IR/OpPropertiesTest.cpp
@@ -399,8 +399,9 @@ TEST(OpPropertiesTest, withoutPropertiesDiscardableAttrs) {
             "other_attr");
 
   EXPECT_EQ(op->getAttrs().size(), 2u);
-  EXPECT_TRUE(op->getInherentAttr("inherent_attr") != std::nullopt);
-  EXPECT_TRUE(op->getDiscardableAttr("other_attr") != Attribute());
+  EXPECT_EQ(op->getInherentAttr("inherent_attr"), std::nullopt);
+  EXPECT_NE(op->getDiscardableAttr("inherent_attr"), Attribute());
+  EXPECT_NE(op->getDiscardableAttr("other_attr"), Attribute());
 
   std::string output;
   llvm::raw_string_ostream os(output);


### PR DESCRIPTION
This was slotted for removal in LLVM 19 in the release notes of LLVM 17, we're way past it now.

If your dialect still has:

> let usePropertiesForAttributes = 1;

Then you can just remove this line (it was the default value).
If you were setting it to 0:

> let usePropertiesForAttributes = 0;

Then you need to adopt the new behavior, please report any issue with this
migration.
