### PR TITLE
[lldb] Disable shared build for TestModuleCacheSimple.py

### DIFF
--- a/lldb/test/API/functionalities/module_cache/simple_exe/TestModuleCacheSimple.py
+++ b/lldb/test/API/functionalities/module_cache/simple_exe/TestModuleCacheSimple.py
@@ -10,6 +10,8 @@ import time
 
 
 class ModuleCacheTestcaseSimple(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)


### PR DESCRIPTION
Follow up to #181720.