### PR TITLE
[mlir][vector] remove lower_multi_reduction

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/TransformOps/VectorTransformOps.td
+++ b/mlir/include/mlir/Dialect/Vector/TransformOps/VectorTransformOps.td
@@ -223,26 +223,6 @@ def ApplyMaterializeMasksPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyLowerMultiReductionPatternsOp : Op<Transform_Dialect,
-    "apply_patterns.vector.lower_multi_reduction",
-    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
-  let description = [{
-    Indicates that vector multi_reduction-like operations should be lowered to
-    finer-grained vector primitives.
-
-    This is usually a late step that is run after bufferization as part of the
-    process of lowering to e.g. LLVM or NVVM.
-  }];
-
-  let arguments = (ins DefaultValuedAttr<VectorMultiReductionLoweringAttr,
-      "vector::VectorMultiReductionLowering::InnerParallel">:$lowering_strategy
-  );
-
-  let assemblyFormat = [{
-    (`lowering_strategy` `=` $lowering_strategy^)? attr-dict
-  }];
-}
-
 def ApplyReorderAndExpandMultiReductionPatternsOp: Op<Transform_Dialect,
     "apply_patterns.vector.reorder_and_expand_multi_reduction_dims",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {

--- a/mlir/include/mlir/Dialect/Vector/Transforms/LoweringPatterns.h
+++ b/mlir/include/mlir/Dialect/Vector/Transforms/LoweringPatterns.h
@@ -103,21 +103,6 @@ void populateVectorMultiReductionUnrollingPatterns(
     RewritePatternSet &patterns, VectorMultiReductionLowering options,
     PatternBenefit benefit = 1);
 
-/// Collect a set of patterns to convert vector.multi_reduction op into
-/// a sequence of vector.reduction ops. These patterns are the ones
-/// populated by:
-///
-/// * populateVectorMultiReductionReorderAndExpandPatterns
-/// * populateVectorMultiReductionFlatteningPatterns
-/// * populateVectorMultiReductionUnrollingPatterns
-///
-/// This is just a convenience wrapper that we use in testing and is effectively
-/// deprecated.
-/// TODO: Delete.
-void populateVectorMultiReductionLoweringPatterns(
-    RewritePatternSet &patterns, VectorMultiReductionLowering options,
-    PatternBenefit benefit = 1);
-
 /// Populate the pattern set with the following patterns:
 ///
 /// [TransferReadToVectorLoadLowering]

--- a/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
+++ b/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
@@ -126,18 +126,6 @@ void transform::ApplyMaterializeMasksPatternsOp::populatePatterns(
                                             /*force32BitVectorIndices=*/false);
 }
 
-void transform::ApplyLowerMultiReductionPatternsOp::populatePatterns(
-    RewritePatternSet &patterns) {
-  vector::VectorTransformsOptions vectorTransformOptions;
-  vectorTransformOptions.setVectorMultiReductionLowering(getLoweringStrategy());
-  vector::populateVectorMultiReductionReorderAndExpandPatterns(
-      patterns, vectorTransformOptions.vectorMultiReductionLowering);
-  vector::populateVectorMultiReductionFlatteningPatterns(
-      patterns, vectorTransformOptions.vectorMultiReductionLowering);
-  vector::populateVectorMultiReductionUnrollingPatterns(
-      patterns, vectorTransformOptions.vectorMultiReductionLowering);
-}
-
 void transform::ApplyReorderAndExpandMultiReductionPatternsOp::populatePatterns(
     RewritePatternSet &patterns) {
   vector::VectorTransformsOptions vectorTransformOptions;

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorMultiReduction.cpp
@@ -549,15 +549,6 @@ void mlir::vector::populateVectorMultiReductionUnrollingPatterns(
                                                     benefit);
 }
 
-void mlir::vector::populateVectorMultiReductionLoweringPatterns(
-    RewritePatternSet &patterns, VectorMultiReductionLowering options,
-    PatternBenefit benefit) {
-  populateVectorMultiReductionReorderAndExpandPatterns(patterns, options,
-                                                       benefit);
-  populateVectorMultiReductionFlatteningPatterns(patterns, options, benefit);
-  populateVectorMultiReductionUnrollingPatterns(patterns, options, benefit);
-}
-
 std::unique_ptr<Pass> vector::createLowerVectorMultiReductionPass(
     vector::VectorMultiReductionLowering option) {
   return std::make_unique<LowerVectorMultiReductionPass>(option);

--- a/mlir/test/Dialect/LLVM/transform-e2e.mlir
+++ b/mlir/test/Dialect/LLVM/transform-e2e.mlir
@@ -30,7 +30,9 @@ module attributes {transform.with_named_sequence} {
     transform.apply_patterns to %f {
       transform.apply_patterns.vector.lower_contraction lowering_strategy = "outerproduct"
       transform.apply_patterns.vector.transfer_permutation_patterns
-      transform.apply_patterns.vector.lower_multi_reduction lowering_strategy = "innerparallel"
+      transform.apply_patterns.vector.reorder_and_expand_multi_reduction_dims lowering_strategy = "innerparallel"
+      transform.apply_patterns.vector.multi_reduction_flattening lowering_strategy = "innerparallel"
+      transform.apply_patterns.vector.multi_reduction_unrolling lowering_strategy = "innerparallel"
       transform.apply_patterns.vector.split_transfer_full_partial split_transfer_strategy = "linalg-copy"
       transform.apply_patterns.vector.transfer_to_scf max_transfer_rank = 1 full_unroll = true
       transform.apply_patterns.vector.lower_transfer max_transfer_rank = 1

--- a/mlir/test/Dialect/Vector/transform-vector.mlir
+++ b/mlir/test/Dialect/Vector/transform-vector.mlir
@@ -39,7 +39,9 @@ module attributes {transform.with_named_sequence} {
     } : !transform.any_op
 
     transform.apply_patterns to %f {
-      transform.apply_patterns.vector.lower_multi_reduction lowering_strategy = "innerparallel"
+      transform.apply_patterns.vector.reorder_and_expand_multi_reduction_dims lowering_strategy = "innerparallel"
+      transform.apply_patterns.vector.multi_reduction_flattening lowering_strategy = "innerparallel"
+      transform.apply_patterns.vector.multi_reduction_unrolling lowering_strategy = "innerparallel"
     } : !transform.any_op
 
     transform.apply_patterns to %f {

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSVE/reduce_1d.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSVE/reduce_1d.mlir
@@ -150,7 +150,9 @@ module attributes {transform.with_named_sequence} {
     // Step 3: Lower vector.multi_reduction
     transform.apply_patterns to %func {
       transform.apply_patterns.vector.lower_masked_transfers
-      transform.apply_patterns.vector.lower_multi_reduction lowering_strategy = "innerreduction"
+      transform.apply_patterns.vector.reorder_and_expand_multi_reduction_dims lowering_strategy = "innerreduction"
+      transform.apply_patterns.vector.multi_reduction_flattening lowering_strategy = "innerreduction"
+      transform.apply_patterns.vector.multi_reduction_unrolling lowering_strategy = "innerreduction"
     } : !transform.op<"func.func">
 
     transform.yield

--- a/mlir/test/Integration/Dialect/Linalg/CPU/ArmSVE/reduce_2d.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/ArmSVE/reduce_2d.mlir
@@ -155,7 +155,9 @@ module attributes {transform.with_named_sequence} {
     // Step 3: Lower vector.multi_reduction
     transform.apply_patterns to %func {
       transform.apply_patterns.vector.lower_masked_transfers
-      transform.apply_patterns.vector.lower_multi_reduction lowering_strategy = "innerreduction"
+      transform.apply_patterns.vector.reorder_and_expand_multi_reduction_dims lowering_strategy = "innerreduction"
+      transform.apply_patterns.vector.multi_reduction_flattening lowering_strategy = "innerreduction"
+      transform.apply_patterns.vector.multi_reduction_unrolling lowering_strategy = "innerreduction"
     } : !transform.op<"func.func">
 
     transform.yield

--- a/mlir/test/Integration/Dialect/Linalg/CPU/test-matmul-masked-vec.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/test-matmul-masked-vec.mlir
@@ -53,7 +53,9 @@ module attributes {transform.with_named_sequence} {
     %func_op = transform.get_parent_op %0 : (!transform.any_op) -> !transform.op<"func.func">
     transform.structured.vectorize %0 vector_sizes [4, 4, 2] : !transform.any_op
     transform.apply_patterns to %func_op {
-      transform.apply_patterns.vector.lower_multi_reduction lowering_strategy = "innerreduction"
+      transform.apply_patterns.vector.reorder_and_expand_multi_reduction_dims lowering_strategy = "innerreduction"
+      transform.apply_patterns.vector.multi_reduction_flattening lowering_strategy = "innerreduction"
+      transform.apply_patterns.vector.multi_reduction_unrolling lowering_strategy = "innerreduction"
     } : !transform.op<"func.func">
     transform.yield
   }

--- a/mlir/test/python/dialects/transform_vector_ext.py
+++ b/mlir/test/python/dialects/transform_vector_ext.py
@@ -87,19 +87,6 @@ def enum_configurable_patterns():
         lowering_strategy=vector.VectorContractLowering.ParallelArith
     )
 
-    # CHECK: transform.apply_patterns.vector.lower_multi_reduction
-    vector.ApplyLowerMultiReductionPatternsOp()
-    # CHECK: transform.apply_patterns.vector.lower_multi_reduction
-    # This is the default mode, not printed.
-    vector.ApplyLowerMultiReductionPatternsOp(
-        lowering_strategy=vector.VectorMultiReductionLowering.InnerParallel
-    )
-    # CHECK: transform.apply_patterns.vector.lower_multi_reduction
-    # CHECK-SAME: lowering_strategy = innerreduction
-    vector.ApplyLowerMultiReductionPatternsOp(
-        lowering_strategy=vector.VectorMultiReductionLowering.InnerReduction
-    )
-
     # CHECK: transform.apply_patterns.vector.reorder_and_expand_multi_reduction_dims
     vector.ApplyReorderAndExpandMultiReductionPatternsOp()
     # CHECK: transform.apply_patterns.vector.reorder_and_expand_multi_reduction_dims


### PR DESCRIPTION
* Removes `ApplyLowerMultiReductionPatternsOp` (`apply_patterns.vector.lower_multi_reduction`)
* Updates uses of `apply_patterns.vector.lower_multi_reduction` in tests to use:
  *  reorder_and_expand_multi_reduction_dims
  * multi_reduction_flattening
   * multi_reduction_unrolling
* Removes `populateVectorMultiReductionLoweringPatterns` (unused)

If this affects downstream projects, just replace lower_multi_reduction with the other three populate methods / transform ops.

