### PR TITLE
[RISCV] Add RISCVII::getTWidenOpNum. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -341,6 +341,11 @@ static inline bool hasTMOp(uint64_t TSFlags) { return TSFlags & HasTMOpMask; }
 
 static inline bool hasTKOp(uint64_t TSFlags) { return TSFlags & HasTKOpMask; }
 
+static inline unsigned getTWidenOpNum(const MCInstrDesc &Desc) {
+  assert(hasTWidenOp(Desc.TSFlags));
+  return Desc.getNumOperands() - 1;
+}
+
 static inline unsigned getTNOpNum(const MCInstrDesc &Desc) {
   const uint64_t TSFlags = Desc.TSFlags;
   assert(hasTWidenOp(TSFlags) && hasVLOp(TSFlags));

--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -64,8 +64,8 @@ static VNInfo *getVNInfoFromReg(Register Reg, const MachineInstr &MI,
   return LI.getVNInfoBefore(SI);
 }
 
-static unsigned getVLOpNum(const MachineInstr &MI) {
-  return RISCVII::getVLOpNum(MI.getDesc());
+static MachineOperand &getVLOp(MachineInstr &MI) {
+  return MI.getOperand(RISCVII::getVLOpNum(MI.getDesc()));
 }
 
 struct BlockData {
@@ -575,7 +575,7 @@ void RISCVInsertVSETVLI::emitVSETVLIs(MachineBasicBlock &MBB) {
       }
 
       if (RISCVII::hasVLOp(TSFlags)) {
-        MachineOperand &VLOp = MI.getOperand(getVLOpNum(MI));
+        MachineOperand &VLOp = getVLOp(MI);
         if (VLOp.isReg()) {
           Register Reg = VLOp.getReg();
 


### PR DESCRIPTION
Rewrite get*OpNum helpers in RISCVVSETVLIInfoAnalysis to return the MachineOperand& which is what the callers really wanted.