### PR TITLE
[RISCV] Correct the LMUL operand for __riscv_sf_vc_i_se_u8mf4 and __riscv_sf_vc_i_se_u8mf2 intrinsics.

### DIFF
--- a/clang/lib/Headers/sifive_vector.h
+++ b/clang/lib/Headers/sifive_vector.h
@@ -47,9 +47,9 @@
   __riscv_sf_vc_x_se(p27_26, p24_20, p11_7, (uint32_t)rs1, 32, 3, vl)
 
 #define __riscv_sf_vc_i_se_u8mf4(p27_26, p24_20, p11_7, simm5, vl)             \
-  __riscv_sf_vc_i_se(p27_26, p24_20, p11_7, simm5, 8, 7, vl)
-#define __riscv_sf_vc_i_se_u8mf2(p27_26, p24_20, p11_7, simm5, vl)             \
   __riscv_sf_vc_i_se(p27_26, p24_20, p11_7, simm5, 8, 6, vl)
+#define __riscv_sf_vc_i_se_u8mf2(p27_26, p24_20, p11_7, simm5, vl)             \
+  __riscv_sf_vc_i_se(p27_26, p24_20, p11_7, simm5, 8, 7, vl)
 #define __riscv_sf_vc_i_se_u8m1(p27_26, p24_20, p11_7, simm5, vl)              \
   __riscv_sf_vc_i_se(p27_26, p24_20, p11_7, simm5, 8, 0, vl)
 #define __riscv_sf_vc_i_se_u8m2(p27_26, p24_20, p11_7, simm5, vl)              \

--- a/clang/test/CodeGen/RISCV/sifive-intrinsics/non-policy/non-overloaded/xsfvcp-x.c
+++ b/clang/test/CodeGen/RISCV/sifive-intrinsics/non-policy/non-overloaded/xsfvcp-x.c
@@ -782,12 +782,12 @@ void test_sf_vc_i_se_u8mf8(size_t vl) {
 
 // CHECK-RV32-LABEL: @test_sf_vc_i_se_u8mf4(
 // CHECK-RV32-NEXT:  entry:
-// CHECK-RV32-NEXT:    call void @llvm.riscv.sf.vc.i.se.i32.i32.i32(i32 3, i32 31, i32 31, i32 10, i32 8, i32 7, i32 [[VL:%.*]])
+// CHECK-RV32-NEXT:    call void @llvm.riscv.sf.vc.i.se.i32.i32.i32(i32 3, i32 31, i32 31, i32 10, i32 8, i32 6, i32 [[VL:%.*]])
 // CHECK-RV32-NEXT:    ret void
 //
 // CHECK-RV64-LABEL: @test_sf_vc_i_se_u8mf4(
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    call void @llvm.riscv.sf.vc.i.se.i64.i64.i64(i64 3, i64 31, i64 31, i64 10, i64 8, i64 7, i64 [[VL:%.*]])
+// CHECK-RV64-NEXT:    call void @llvm.riscv.sf.vc.i.se.i64.i64.i64(i64 3, i64 31, i64 31, i64 10, i64 8, i64 6, i64 [[VL:%.*]])
 // CHECK-RV64-NEXT:    ret void
 //
 void test_sf_vc_i_se_u8mf4(size_t vl) {
@@ -796,12 +796,12 @@ void test_sf_vc_i_se_u8mf4(size_t vl) {
 
 // CHECK-RV32-LABEL: @test_sf_vc_i_se_u8mf2(
 // CHECK-RV32-NEXT:  entry:
-// CHECK-RV32-NEXT:    call void @llvm.riscv.sf.vc.i.se.i32.i32.i32(i32 3, i32 31, i32 31, i32 10, i32 8, i32 6, i32 [[VL:%.*]])
+// CHECK-RV32-NEXT:    call void @llvm.riscv.sf.vc.i.se.i32.i32.i32(i32 3, i32 31, i32 31, i32 10, i32 8, i32 7, i32 [[VL:%.*]])
 // CHECK-RV32-NEXT:    ret void
 //
 // CHECK-RV64-LABEL: @test_sf_vc_i_se_u8mf2(
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    call void @llvm.riscv.sf.vc.i.se.i64.i64.i64(i64 3, i64 31, i64 31, i64 10, i64 8, i64 6, i64 [[VL:%.*]])
+// CHECK-RV64-NEXT:    call void @llvm.riscv.sf.vc.i.se.i64.i64.i64(i64 3, i64 31, i64 31, i64 10, i64 8, i64 7, i64 [[VL:%.*]])
 // CHECK-RV64-NEXT:    ret void
 //
 void test_sf_vc_i_se_u8mf2(size_t vl) {


### PR DESCRIPTION
mf2 is should 7 (-1 in 3 bits). mf4 should be 6 (-2 in 3 bits).