### PR TITLE
[Clang][Driver][SPIRV] Support LTO through the llvm-lto tool

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9307,7 +9307,8 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
 
       // For SPIR-V some functions will be defined by the runtime so allow
       // unresolved symbols.
-      if (TC->getTriple().isSPIRV())
+      if (TC->getTriple().isSPIRV() && !C.getDriver().isUsingLTO() &&
+          !C.getDriver().isUsingOffloadLTO())
         LinkerArgs.emplace_back("--allow-partial-linkage");
 
       // Forward all of these to the appropriate toolchain.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9306,7 +9306,8 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         LinkerArgs.emplace_back("-lompdevice");
 
       // For SPIR-V some functions will be defined by the runtime so allow
-      // unresolved symbols.
+      // unresolved symbols in `spirv-link`. `spirv-link` isn't called in LTO
+      // mode so restrict this flag to normal compilation.
       if (TC->getTriple().isSPIRV() && !C.getDriver().isUsingLTO() &&
           !C.getDriver().isUsingOffloadLTO())
         LinkerArgs.emplace_back("--allow-partial-linkage");

--- a/clang/lib/Driver/ToolChains/SPIRV.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRV.cpp
@@ -152,6 +152,7 @@ void SPIRV::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   CmdArgs.push_back("-o");
   CmdArgs.push_back(Output.getFilename());
 
+  // TODO: Consider moving SPIR-V linking to a separate tool.
   if (C.getDriver().isUsingLTO()) {
     // Implement limited LTO support through llvm-lto.
     if (Args.hasArg(options::OPT_sycl_link)) {

--- a/clang/test/Driver/spirv-lto.c
+++ b/clang/test/Driver/spirv-lto.c
@@ -1,0 +1,35 @@
+// Check SPIR-V support for LTO
+// RUN: mkdir -p %t
+// RUN: touch %t/a.cpp
+// RUN: touch %t/b.cpp
+// RUN: touch %t/a.o
+// RUN: touch %t/b.o
+
+// RUN: %clang -### --target=spirv64 -flto %t/a.cpp %t/b.cpp  -Xlinker --disable-verify 2>&1 | FileCheck --check-prefix=CHECK-POSITIVE-TOOL %s
+// RUN: %clang -ccc-print-phases --target=spirv64 -flto %t/a.cpp %t/b.cpp 2>&1 | FileCheck --check-prefix=CHECK-POSITIVE-PHASES %s
+// RUN: not %clang -### --target=spirv64 -flto %t/a.cpp %t/b.cpp --sycl-link 2>&1 | FileCheck --check-prefix=CHECK-ERROR %s
+
+// RUN: %clang -### --target=spirv64 -flto %t/a.o %t/b.o  -Xlinker --disable-verify 2>&1 | FileCheck --check-prefix=CHECK-POSITIVE-TOOL-OBJ %s
+// RUN: %clang -ccc-print-phases --target=spirv64 -flto %t/a.o %t/b.o 2>&1 | FileCheck --check-prefix=CHECK-POSITIVE-PHASES-OBJ %s
+// RUN: not %clang -### --target=spirv64 -flto %t/a.o %t/b.o --sycl-link 2>&1 | FileCheck --check-prefix=CHECK-ERROR %s
+
+// CHECK-POSITIVE-TOOL: llvm-lto{{.*}} "{{.*}}a-{{.*}}.o" "{{.*}}b-{{.*}}.o" "--disable-verify" "-o" "a.out" "-enable-lto-internalization=false"
+
+// CHECK-POSITIVE-PHASES: 0: input, "{{.*}}a.cpp", c++
+// CHECK-POSITIVE-PHASES: 1: preprocessor, {0}, c++-cpp-output
+// CHECK-POSITIVE-PHASES: 2: compiler, {1}, ir
+// CHECK-POSITIVE-PHASES: 3: backend, {2}, lto-bc
+// CHECK-POSITIVE-PHASES: 4: input, "{{.*}}b.cpp", c++
+// CHECK-POSITIVE-PHASES: 5: preprocessor, {4}, c++-cpp-output
+// CHECK-POSITIVE-PHASES: 6: compiler, {5}, ir
+// CHECK-POSITIVE-PHASES: 7: backend, {6}, lto-bc
+// CHECK-POSITIVE-PHASES: 8: linker, {3, 7}, image
+
+// CHECK-POSITIVE-TOOL-OBJ:  llvm-lto{{.*}} "{{.*}}a.o" "{{.*}}b.o" "--disable-verify" "-o" "a.out" "-enable-lto-internalization=false"
+
+// CHECK-POSITIVE-PHASES-OBJ: 0: input, "{{.*}}a.o", object
+// CHECK-POSITIVE-PHASES-OBJ: 1: input, "{{.*}}b.o", object
+// CHECK-POSITIVE-PHASES-OBJ: 2: linker, {0, 1}, image
+
+// CHECK-ERROR: 'spirv64': unable to pass LLVM bit-code files to linker
+

--- a/clang/test/Driver/spirv-lto.c
+++ b/clang/test/Driver/spirv-lto.c
@@ -1,13 +1,13 @@
 // Check SPIR-V support for LTO
 // RUN: mkdir -p %t
-// RUN: touch %t/a.cpp
-// RUN: touch %t/b.cpp
+// RUN: touch %t/a.c
+// RUN: touch %t/b.c
 // RUN: touch %t/a.o
 // RUN: touch %t/b.o
 
-// RUN: %clang -### --target=spirv64 -flto %t/a.cpp %t/b.cpp  -Xlinker --disable-verify 2>&1 | FileCheck --check-prefix=CHECK-POSITIVE-TOOL %s
-// RUN: %clang -ccc-print-phases --target=spirv64 -flto %t/a.cpp %t/b.cpp 2>&1 | FileCheck --check-prefix=CHECK-POSITIVE-PHASES %s
-// RUN: not %clang -### --target=spirv64 -flto %t/a.cpp %t/b.cpp --sycl-link 2>&1 | FileCheck --check-prefix=CHECK-ERROR %s
+// RUN: %clang -### --target=spirv64 -flto %t/a.c %t/b.c  -Xlinker --disable-verify 2>&1 | FileCheck --check-prefix=CHECK-POSITIVE-TOOL %s
+// RUN: %clang -ccc-print-phases --target=spirv64 -flto %t/a.c %t/b.c 2>&1 | FileCheck --check-prefix=CHECK-POSITIVE-PHASES %s
+// RUN: not %clang -### --target=spirv64 -flto %t/a.c %t/b.c --sycl-link 2>&1 | FileCheck --check-prefix=CHECK-ERROR %s
 
 // RUN: %clang -### --target=spirv64 -flto %t/a.o %t/b.o  -Xlinker --disable-verify 2>&1 | FileCheck --check-prefix=CHECK-POSITIVE-TOOL-OBJ %s
 // RUN: %clang -ccc-print-phases --target=spirv64 -flto %t/a.o %t/b.o 2>&1 | FileCheck --check-prefix=CHECK-POSITIVE-PHASES-OBJ %s
@@ -15,12 +15,12 @@
 
 // CHECK-POSITIVE-TOOL: llvm-lto{{.*}} "{{.*}}a-{{.*}}.o" "{{.*}}b-{{.*}}.o" "--disable-verify" "-o" "a.out" "-enable-lto-internalization=false"
 
-// CHECK-POSITIVE-PHASES: 0: input, "{{.*}}a.cpp", c++
-// CHECK-POSITIVE-PHASES: 1: preprocessor, {0}, c++-cpp-output
+// CHECK-POSITIVE-PHASES: 0: input, "{{.*}}a.c", c
+// CHECK-POSITIVE-PHASES: 1: preprocessor, {0}, cpp-output
 // CHECK-POSITIVE-PHASES: 2: compiler, {1}, ir
 // CHECK-POSITIVE-PHASES: 3: backend, {2}, lto-bc
-// CHECK-POSITIVE-PHASES: 4: input, "{{.*}}b.cpp", c++
-// CHECK-POSITIVE-PHASES: 5: preprocessor, {4}, c++-cpp-output
+// CHECK-POSITIVE-PHASES: 4: input, "{{.*}}b.c", c
+// CHECK-POSITIVE-PHASES: 5: preprocessor, {4}, cpp-output
 // CHECK-POSITIVE-PHASES: 6: compiler, {5}, ir
 // CHECK-POSITIVE-PHASES: 7: backend, {6}, lto-bc
 // CHECK-POSITIVE-PHASES: 8: linker, {3, 7}, image


### PR DESCRIPTION
There is no SPIR-V linker that supports LTO and a proposal to support basic SPIR-V linking in `lld` was [rejected](https://github.com/llvm/llvm-project/pull/178749), so support a basic version of LTO just by calling `llvm-lto` directly from the SPIR-V Toolchain.  `-Xlinker` can be used to specify flags to `llvm-lto`. 

This should be enough for our use case.

There is also the `llvm-lto2` tool, but that requires a list of symbol resolutions in the command line, and we can't compute that in the driver.

