### PR TITLE
[Multilib] Expose shadow call stack as multilib flags for RISC-V

### DIFF
--- a/clang/test/Driver/print-multi-selection-flags.c
+++ b/clang/test/Driver/print-multi-selection-flags.c
@@ -86,6 +86,12 @@
 // RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=aarch64-none-elf -mbig-endian | FileCheck --check-prefix=CHECK-BIG-ENDIAN %s
 // CHECK-BIG-ENDIAN: -mbig-endian
 
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf -fsanitize=shadow-call-stack | FileCheck --check-prefix=CHECK-SHADOW-CALL-STACK %s
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf -fno-sanitize=shadow-call-stack | FileCheck --check-prefix=CHECK-NO-SHADOW-CALL-STACK %s
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf | FileCheck --check-prefix=CHECK-NO-SHADOW-CALL-STACK %s
+// CHECK-SHADOW-CALL-STACK: -fsanitize=shadow-call-stack
+// CHECK-NO-SHADOW-CALL-STACK: -fno-sanitize=shadow-call-stack
+
 // RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv32-none-elf -march=rv32g | FileCheck --check-prefix=CHECK-RV32 %s
 // CHECK-RV32: --target=riscv32-unknown-none-elf
 // CHECK-RV32: -mabi=ilp32d


### PR DESCRIPTION
This allows multilib selection based on shadow call stack for RISC-V.