### PR TITLE
[lldb] Remove redundant nullptr check (NFC)

### DIFF
--- a/lldb/source/Target/RegisterContext.cpp
+++ b/lldb/source/Target/RegisterContext.cpp
@@ -98,12 +98,8 @@ uint64_t RegisterContext::GetPC(uint64_t fail_value) {
   uint64_t pc = ReadRegisterAsUnsigned(reg, fail_value);
 
   if (pc != fail_value) {
-    TargetSP target_sp = m_thread.CalculateTarget();
-    if (target_sp) {
-      Target *target = target_sp.get();
-      if (target)
-        pc = target->GetOpcodeLoadAddress(pc, AddressClass::eCode);
-    }
+    if (TargetSP target_sp = m_thread.CalculateTarget())
+      pc = target_sp->GetOpcodeLoadAddress(pc, AddressClass::eCode);
   }
 
   return pc;


### PR DESCRIPTION
`target` cannot be null because `target_sp` is non-null.