### PR TITLE
[lldb][tests/FreeBSDKernel] Skip tests on non-FreeBSD hosts

### DIFF
--- a/lldb/test/API/functionalities/postmortem/FreeBSDKernel/TestFreeBSDKernelVMCore.py
+++ b/lldb/test/API/functionalities/postmortem/FreeBSDKernel/TestFreeBSDKernelVMCore.py
@@ -8,7 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skipIfFBSDVMCoreSupportMissing
+@skipUnlessPlatform(["freebsd"])
 class FreeBSDKernelVMCoreTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     maxDiff = None


### PR DESCRIPTION
#181283 removed fvc but it still remains in tests. This causes testing on non-FreeBSD hosts. Thus add `skipUnlessPlatform` decorator.