### PR TITLE
[NFC][TableGen] Use `bit` instead of `int` for some Target flags

### DIFF
--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -2042,7 +2042,7 @@ class Target {
   // post-register-allocation renaming of registers. This is done by
   // setting hasExtraDefRegAllocReq and hasExtraSrcRegAllocReq to 1
   // for all opcodes if this flag is set to 0.
-  int AllowRegisterRenaming = 0;
+  bit AllowRegisterRenaming = 0;
 
   // RegistersAreIntervals - Controls whether registers units must form
   // contiguous intervals for each register.
@@ -2055,7 +2055,7 @@ class Target {
   //
   // This enables interval-based representation of register units, which can
   // improve data structure representations in target backends.
-  int RegistersAreIntervals = 0;
+  bit RegistersAreIntervals = 0;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -2040,9 +2040,9 @@ class Target {
 
   // AllowRegisterRenaming - Controls whether this target allows
   // post-register-allocation renaming of registers. This is done by
-  // setting hasExtraDefRegAllocReq and hasExtraSrcRegAllocReq to 1
-  // for all opcodes if this flag is set to 0.
-  bit AllowRegisterRenaming = 0;
+  // setting hasExtraDefRegAllocReq and hasExtraSrcRegAllocReq to true
+  // for all opcodes if this flag is set to false.
+  bit AllowRegisterRenaming = false;
 
   // RegistersAreIntervals - Controls whether registers units must form
   // contiguous intervals for each register.
@@ -2055,7 +2055,7 @@ class Target {
   //
   // This enables interval-based representation of register units, which can
   // improve data structure representations in target backends.
-  bit RegistersAreIntervals = 0;
+  bit RegistersAreIntervals = false;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -116,11 +116,11 @@ const Record *CodeGenTarget::getInstructionSet() const {
 }
 
 bool CodeGenTarget::getAllowRegisterRenaming() const {
-  return TargetRec->getValueAsInt("AllowRegisterRenaming");
+  return TargetRec->getValueAsBit("AllowRegisterRenaming");
 }
 
 bool CodeGenTarget::getRegistersAreIntervals() const {
-  return TargetRec->getValueAsInt("RegistersAreIntervals");
+  return TargetRec->getValueAsBit("RegistersAreIntervals");
 }
 
 /// getAsmParser - Return the AssemblyParser definition for this target.


### PR DESCRIPTION
Change `AllowRegisterRenaming` and `RegistersAreIntervals` to a bit instead of int as they are just a bool flag.