### PR TITLE
[NFCI][analyzer] Add a clean way to generate nodes

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -273,9 +273,7 @@ public:
   ExplodedNode *generateNode(const ProgramPoint &PP,
                              ProgramStateRef State,
                              ExplodedNode *Pred) {
-    return generateNodeImpl(
-        PP, State, Pred,
-        /*MarkAsSink=*/State->isPosteriorlyOverconstrained());
+    return generateNodeImpl(PP, State, Pred);
   }
 
   /// Generates a sink in the ExplodedGraph.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -259,11 +259,6 @@ protected:
   /// the builder dies.
   ExplodedNodeSet &Frontier;
 
-  ExplodedNode *generateNodeImpl(const ProgramPoint &PP,
-                                 ProgramStateRef State,
-                                 ExplodedNode *Pred,
-                                 bool MarkAsSink = false);
-
 public:
   NodeBuilder(ExplodedNodeSet &DstSet, const NodeBuilderContext &Ctx)
       : C(Ctx), Frontier(DstSet) {}
@@ -281,13 +276,8 @@ public:
   }
 
   /// Generates a node in the ExplodedGraph.
-  /// TODO: This is a useless wrapper layer, rename `generateNodeImpl` to
-  /// `generateNode`.
-  ExplodedNode *generateNode(const ProgramPoint &PP,
-                             ProgramStateRef State,
-                             ExplodedNode *Pred) {
-    return generateNodeImpl(PP, State, Pred);
-  }
+  ExplodedNode *generateNode(const ProgramPoint &PP, ProgramStateRef State,
+                             ExplodedNode *Pred, bool MarkAsSink = false);
 
   /// Generates a sink in the ExplodedGraph.
   ///
@@ -297,7 +287,7 @@ public:
   ExplodedNode *generateSink(const ProgramPoint &PP,
                              ProgramStateRef State,
                              ExplodedNode *Pred) {
-    return generateNodeImpl(PP, State, Pred, true);
+    return generateNode(PP, State, Pred, true);
   }
 
   ExplodedNode *generateNode(const Stmt *S,

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -238,6 +238,17 @@ public:
 /// be propagated to the next step / builder. They are the nodes which have been
 /// added to the builder (either as the input node set or as the newly
 /// constructed nodes) but did not have any outgoing transitions added.
+///
+/// TODO: This "main benefit" is often useless, in fact the only significant
+/// use is within `CheckerManager::ExpandGraphWithCheckers`. There this logic
+/// ensures that if a checker performs multiple transitions on the same path,
+/// then only the last of them is "built upon" by other checkers or the engine.
+///
+/// However, there are also many short-lived temporary `NodeBuilder` instances
+/// where the `generateNode` is called in a very predictable manner (once, or
+/// once for each source node) and the frontier management is overkill.
+/// These locations should be gradually simplified by using the method
+/// `CoreEngine::makeNode()` instead of the temporary `NodeBuilder`s.
 class NodeBuilder {
 protected:
   const NodeBuilderContext &C;
@@ -270,6 +281,8 @@ public:
   }
 
   /// Generates a node in the ExplodedGraph.
+  /// TODO: This is a useless wrapper layer, rename `generateNodeImpl` to
+  /// `generateNode`.
   ExplodedNode *generateNode(const ProgramPoint &PP,
                              ProgramStateRef State,
                              ExplodedNode *Pred) {

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -176,6 +176,9 @@ public:
 
   auto aborted_blocks() const { return llvm::iterator_range(blocksAborted); }
 
+  ExplodedNode *makeNode(const ProgramPoint &Loc, ProgramStateRef State,
+                             ExplodedNode *Pred, bool MarkAsSink = false) const;
+
   /// Enqueue the given set of nodes onto the work list.
   void enqueue(ExplodedNodeSet &Set);
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -177,7 +177,7 @@ public:
   auto aborted_blocks() const { return llvm::iterator_range(blocksAborted); }
 
   ExplodedNode *makeNode(const ProgramPoint &Loc, ProgramStateRef State,
-                             ExplodedNode *Pred, bool MarkAsSink = false) const;
+                         ExplodedNode *Pred, bool MarkAsSink = false) const;
 
   /// Enqueue the given set of nodes onto the work list.
   void enqueue(ExplodedNodeSet &Set);

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
@@ -78,7 +78,6 @@ private:
   friend class ProgramStateManager;
   friend class ExplodedGraph;
   friend class ExplodedNode;
-  friend class NodeBuilder;
 
   ProgramStateManager *stateMgr;
   Environment Env;           // Maps a Stmt to its current SVal.
@@ -116,6 +115,11 @@ private:
   // overconstrained-related functions. We want to keep this API inaccessible
   // for Checkers.
   friend class ConstraintManager;
+  // The CoreEngine also needs to be a friend to mark nodes as sinks if they
+  // are generated with a PosteriorlyOverconstrained state.
+  // FIXME: Perform this check in the relevant methods of `ExplodedGraph` and
+  // remove this `friend` declaration.
+  friend class CoreEngine;
   bool isPosteriorlyOverconstrained() const {
     return PosteriorlyOverconstrained;
   }

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -577,6 +577,9 @@ ExplodedNode *CoreEngine::makeNode(const ProgramPoint &Loc,
 
 /// generateNode - Utility method to generate nodes, hook up successors,
 ///  and add nodes to the worklist.
+/// TODO: This and other similar methods should call CoreEngine::makeNode()
+/// instead of duplicating its logic. This would also fix that currently these
+/// can generate non-sink nodes with PosteriorlyOverconstrained state.
 void CoreEngine::generateNode(const ProgramPoint &Loc,
                               ProgramStateRef State,
                               ExplodedNode *Pred) {

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -710,8 +710,7 @@ ExplodedNode* NodeBuilder::generateNodeImpl(const ProgramPoint &Loc,
   Frontier.erase(FromN);
   ExplodedNode *N = C.getEngine().makeNode(Loc, State, FromN, MarkAsSink);
 
-  if (N && !MarkAsSink)
-    Frontier.Add(N);
+  Frontier.Add(N);
 
   return N;
 }

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -706,10 +706,9 @@ void CoreEngine::enqueueEndOfFunction(ExplodedNodeSet &Set, const ReturnStmt *RS
   }
 }
 
-ExplodedNode* NodeBuilder::generateNodeImpl(const ProgramPoint &Loc,
-                                            ProgramStateRef State,
-                                            ExplodedNode *FromN,
-                                            bool MarkAsSink) {
+ExplodedNode *NodeBuilder::generateNode(const ProgramPoint &Loc,
+                                        ProgramStateRef State,
+                                        ExplodedNode *FromN, bool MarkAsSink) {
   HasGeneratedNodes = true;
   Frontier.erase(FromN);
   ExplodedNode *N = C.getEngine().makeNode(Loc, State, FromN, MarkAsSink);
@@ -729,7 +728,7 @@ ExplodedNode *BranchNodeBuilder::generateNode(ProgramStateRef State,
 
   ProgramPoint Loc =
       BlockEdge(C.getBlock(), Dst, NodePred->getLocationContext());
-  ExplodedNode *Succ = generateNodeImpl(Loc, State, NodePred);
+  ExplodedNode *Succ = NodeBuilder::generateNode(Loc, State, NodePred);
   return Succ;
 }
 

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -563,6 +563,8 @@ ExplodedNode *CoreEngine::makeNode(const ProgramPoint &Loc,
                                        ProgramStateRef State,
                                        ExplodedNode *Pred,
                                        bool MarkAsSink) const {
+  MarkAsSink = MarkAsSink || State->isPosteriorlyOverconstrained();
+
   bool IsNew;
   ExplodedNode *N = G.getNode(Loc, State, MarkAsSink, &IsNew);
   N->addPredecessor(Pred, G);
@@ -706,8 +708,6 @@ ExplodedNode* NodeBuilder::generateNodeImpl(const ProgramPoint &Loc,
                                             ProgramStateRef State,
                                             ExplodedNode *FromN,
                                             bool MarkAsSink) {
-  MarkAsSink = MarkAsSink || State->isPosteriorlyOverconstrained();
-
   HasGeneratedNodes = true;
   Frontier.erase(FromN);
   ExplodedNode *N = C.getEngine().makeNode(Loc, State, FromN, MarkAsSink);

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -560,9 +560,8 @@ void CoreEngine::HandleVirtualBaseBranch(const CFGBlock *B,
 }
 
 ExplodedNode *CoreEngine::makeNode(const ProgramPoint &Loc,
-                                       ProgramStateRef State,
-                                       ExplodedNode *Pred,
-                                       bool MarkAsSink) const {
+                                   ProgramStateRef State, ExplodedNode *Pred,
+                                   bool MarkAsSink) const {
   MarkAsSink = MarkAsSink || State->isPosteriorlyOverconstrained();
 
   bool IsNew;

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -706,6 +706,8 @@ ExplodedNode* NodeBuilder::generateNodeImpl(const ProgramPoint &Loc,
                                             ProgramStateRef State,
                                             ExplodedNode *FromN,
                                             bool MarkAsSink) {
+  MarkAsSink = MarkAsSink || State->isPosteriorlyOverconstrained();
+
   HasGeneratedNodes = true;
   Frontier.erase(FromN);
   ExplodedNode *N = C.getEngine().makeNode(Loc, State, FromN, MarkAsSink);

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -568,10 +568,7 @@ ExplodedNode *CoreEngine::makeNode(const ProgramPoint &Loc,
   ExplodedNode *N = G.getNode(Loc, State, MarkAsSink, &IsNew);
   N->addPredecessor(Pred, G);
 
-  if (!IsNew)
-    return nullptr;
-
-  return N;
+  return IsNew ? N : nullptr;
 }
 
 /// generateNode - Utility method to generate nodes, hook up successors,


### PR DESCRIPTION
Currently the most common way for generating nodes is a complicated and confusing boilerplate approach, which appears in many places:
- A `NodeBuilderContext` is constructed from a `CoreEngine &` and two other irrelevant arguments.
- A short-lived temporary `NodeBuilder` is constructed from the `NodeBuilderContext` and some almost irrelevant node sets.
- `NodeBuilder::generateNode()` is invoked once and accesses the graph through the `CoreEngine &` to generate the node.

To simplify this, I'm cutting out the wrapper layers and extracting the "main logic" of the method `NodeBuilder::generateNode()` to a new method called `CoreEngine::makeNode()`. Eventually I intend to replace most use of `NodeBuilder`s with direct calls to this method.

To ensure that this new `makeNode()` doesn't generate non-sink nodes with `PosteriorlyOverconstrained` state, I moved the `isPosteriorlyOverconstrained()` check from `CoreEngine::generateNode()` to `makeNode()`.

This is technically speaking not an NFC change, because it prevents `BranchNodeBuilder::generateNode()` from generating non-sink nodes with `PosteriorlyOverconstrained` state (previously it was able to do so because it calls `NodeBuilder::generateNodeImpl()` instead of `NodeBuilder::generateNode()`).

However I labelled this as an NFCI change, as I'm fairly confident that this won't lead to any observable changes because:
- `PosteriorlyOverconstrained` states are very rare.
- A state derived from a  `PosteriorlyOverconstrained` state is also posteriorly overconstrained, so if `BranchNodeBuilder` fails to sink the execution path, it will be sunk anyway at the next transition which is done by a plain `NodeBuilder`.

Note that simulated paths with a `PosteriorlyOverconstrained` state do not correspond to real paths that can occur during the actual execution of the program, so the analyzer should stop following them as soon as possible. For more explanation see the doc-comment above the data member `bool PosteriorlyOverconstrained` within `ProgramState`.

-------

## Notes for reviewers

I structured this PR into five small patches to simplify the review. Each of them has detailed patch notes (EDIT: probably too detailed, given that most of the content is also copied to the main description of the PR), I hope that you will see that most of them are indeed NFC and the last one does what I claim.

I uploaded these in a single PR because I wanted you to see the logical connections between them, but I'm open to merging some of them separately.

Note that I picked the name `makeNode()` because:
- `CoreEngine::generateNode()` already exists as a barely used method. I intend to eliminate it later (because it will be natural to replace it with `makeNode()` calls), but immediately "taking over" its name could have led to confusion, especially on downstream forks.
- Although the lower-level method is named `ExplodedGraph::getNode()`, I didn't want to reuse that name because `getXXX` would imply a getter method (and this is not a getter).
- I rejected `addNode` because we are not adding an existing node, but making a new node.
- I felt that `buildNode` would be another acceptable choice, but I think `make` is more common than `build`.