### PR TITLE
[GVN] Restore the NumGVNInstr metric

### DIFF
--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -3091,7 +3091,6 @@ bool GVNPass::performScalarPRE(Instruction *CurInst) {
 
   LLVM_DEBUG(dbgs() << "GVN PRE removed: " << *CurInst << '\n');
   removeInstruction(CurInst);
-  ++NumGVNInstr;
 
   return true;
 }
@@ -3195,6 +3194,7 @@ void GVNPass::removeInstruction(Instruction *I) {
 #endif
   ICF->removeInstruction(I);
   I->eraseFromParent();
+  ++NumGVNInstr;
 }
 
 /// Verify that the specified instruction does not occur in our

--- a/llvm/test/Transforms/GVN/basic-stats.ll
+++ b/llvm/test/Transforms/GVN/basic-stats.ll
@@ -12,3 +12,4 @@ block2:
 ; CHECK: 1 gvn - Number of blocks merged
 ; CHECK: 2 gvn - Number of instructions deleted
 ; CHECK: 2 gvn - Number of instructions simplified
+

--- a/llvm/test/Transforms/GVN/basic-stats.ll
+++ b/llvm/test/Transforms/GVN/basic-stats.ll
@@ -1,5 +1,6 @@
 ; REQUIRES: asserts
-; RUN: opt < %s -stats -passes=gvn -o /dev/null 2>&1 | FileCheck %s
+; RUN: opt < %s -stats -passes=gvn -disable-output 2>&1 | FileCheck %s
+
 define i32 @main() {
 block1:
   %z1 = bitcast i32 0 to i32
@@ -9,7 +10,6 @@ block2:
   ret i32 %z2
 }
 
-; CHECK: 1 gvn - Number of blocks merged
-; CHECK: 2 gvn - Number of instructions deleted
-; CHECK: 2 gvn - Number of instructions simplified
-
+; CHECK-DAG: 1 gvn - Number of blocks merged
+; CHECK-DAG: 2 gvn - Number of instructions deleted
+; CHECK-DAG: 2 gvn - Number of instructions simplified

--- a/llvm/test/Transforms/GVN/basic-stats.ll
+++ b/llvm/test/Transforms/GVN/basic-stats.ll
@@ -1,0 +1,14 @@
+; REQUIRES: asserts
+; RUN: opt < %s -stats -passes=gvn -o /dev/null 2>&1 | FileCheck %s
+define i32 @main() {
+block1:
+  %z1 = bitcast i32 0 to i32
+  br label %block2
+block2:
+  %z2 = bitcast i32 0 to i32
+  ret i32 %z2
+}
+
+; CHECK: 1 gvn - Number of blocks merged
+; CHECK: 2 gvn - Number of instructions deleted
+; CHECK: 2 gvn - Number of instructions simplified


### PR DESCRIPTION
The NumGVNInstr metric counts the number of instructions deleted by the GVN pass. #131753 changed where the instructions were deleted in the pass, but that PR did not update the NumGVNInstr metric whenever instructions were deleted. This PR fixes that bug by updating NumGVNInstr whenever `removeInstruction(...)` is called.