### PR TITLE
[WebAssembly] Allow use of the common FixIrreducible pass

### DIFF
--- a/llvm/lib/Transforms/Utils/FixIrreducible.cpp
+++ b/llvm/lib/Transforms/Utils/FixIrreducible.cpp
@@ -169,6 +169,7 @@ INITIALIZE_PASS_BEGIN(FixIrreducible, "fix-irreducible",
                       "Convert irreducible control-flow into natural loops",
                       false /* Only looks at CFG */, false /* Analysis Pass */)
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(CycleInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(LoopInfoWrapperPass)
 INITIALIZE_PASS_END(FixIrreducible, "fix-irreducible",
                     "Convert irreducible control-flow into natural loops",


### PR DESCRIPTION
This allows experimentation with the common FixIrreducible pass instead of the
existing WebAssemblyFixIrreducibleControlFlow pass (and may allow trying other
options before we converge on a single one).
Repurpose the existing CL debug flag which previously allowed disabling the pass
entirely.
