### PR TITLE
[HLSL] Introduce vector- and matrix-specific versions of diagnostic warnings

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4389,7 +4389,7 @@ def warn_unknown_sanitizer_ignored : Warning<
 
 def warn_impcast_matrix_scalar : Warning<
   "implicit conversion turns matrix to scalar: %0 to %1">,
-  InGroup<MatrixConversion>;
+  InGroup<Conversion>, DefaultIgnore;
 def warn_impcast_vector_scalar : Warning<
   "implicit conversion turns vector to scalar: %0 to %1">,
   InGroup<Conversion>, DefaultIgnore;
@@ -4401,13 +4401,6 @@ def err_impcast_complex_scalar : Error<
 def warn_impcast_float_precision : Warning<
   "implicit conversion loses floating-point precision: %0 to %1">,
   InGroup<ImplicitFloatConversion>, DefaultIgnore;
-def warn_impcast_vector_float_precision : Warning<
-  "implicit conversion loses floating-point precision: %0 to %1">,
-  InGroup<VectorConversion>;
-def warn_impcast_matrix_float_precision : Warning<
-  "implicit conversion loses floating-point precision: %0 to %1">,
-  InGroup<MatrixConversion>;
-
 def warn_impcast_float_result_precision : Warning<
   "implicit conversion when assigning computation result loses floating-point precision: %0 to %1">,
   InGroup<ImplicitFloatConversion>, DefaultIgnore;
@@ -4417,24 +4410,12 @@ def warn_impcast_double_promotion : Warning<
 def warn_impcast_integer_sign : Warning<
   "implicit conversion changes signedness: %0 to %1">,
   InGroup<SignConversion>, DefaultIgnore;
-def warn_impcast_vector_integer_sign : Warning<
-  "implicit conversion changes signedness: %0 to %1">,
-  InGroup<VectorConversion>;
-def warn_impcast_matrix_integer_sign : Warning<
-  "implicit conversion changes signedness: %0 to %1">,
-  InGroup<MatrixConversion>;
 def warn_impcast_integer_sign_conditional : Warning<
   "operand of ? changes signedness: %0 to %1">,
   InGroup<SignConversion>, DefaultIgnore;
 def warn_impcast_integer_precision : Warning<
   "implicit conversion loses integer precision: %0 to %1">,
   InGroup<ImplicitIntConversion>, DefaultIgnore;
-def warn_impcast_vector_integer_precision : Warning<
-  "implicit conversion loses integer precision: %0 to %1">,
-  InGroup<VectorConversion>;
-def warn_impcast_matrix_integer_precision : Warning<
-  "implicit conversion loses integer precision: %0 to %1">,
-  InGroup<MatrixConversion>;
 def warn_impcast_integer_precision_on_negation : Warning<
   "implicit conversion loses integer precision: %0 to %1 on negation">,
   InGroup<ImplicitIntConversionOnNegation>, DefaultIgnore;
@@ -4474,12 +4455,6 @@ def warn_impcast_literal_float_to_integer_out_of_range : Warning<
 def warn_impcast_float_integer : Warning<
   "implicit conversion turns floating-point number into integer: %0 to %1">,
   InGroup<FloatConversion>, DefaultIgnore;
-def warn_impcast_vector_float_integer : Warning<
-  "implicit conversion turns floating-point numbers into integers: %0 to %1">,
-  InGroup<VectorConversion>;
-def warn_impcast_matrix_float_integer : Warning<
-  "implicit conversion turns floating-point numbers into integers: %0 to %1">,
-  InGroup<MatrixConversion>;
 def warn_impcast_float_to_objc_signed_char_bool : Warning<
   "implicit conversion from floating-point type %0 to 'BOOL'">,
   InGroup<ObjCSignedCharBoolImplicitFloatConversion>;
@@ -4491,12 +4466,6 @@ def warn_impcast_int_to_objc_signed_char_bool : Warning<
 def warn_impcast_integer_float_precision : Warning<
   "implicit conversion from %0 to %1 may lose precision">,
   InGroup<ImplicitIntFloatConversion>, DefaultIgnore;
-def warn_impcast_vector_integer_float_precision : Warning<
-  "implicit conversion from %0 to %1 may lose precision">,
-  InGroup<VectorConversion>;
-def warn_impcast_matrix_integer_float_precision : Warning<
-  "implicit conversion from %0 to %1 may lose precision">,
-  InGroup<MatrixConversion>;
 def warn_impcast_integer_float_precision_constant : Warning<
   "implicit conversion from %2 to %3 changes value from %0 to %1">,
   InGroup<ImplicitConstIntFloatConversion>;
@@ -13453,6 +13422,50 @@ def warn_hlsl_impcast_matrix_truncation : Warning<
 def warn_hlsl_impcast_vector_scalar : Warning<
   "implicit conversion turns vector to scalar: %0 to %1">,
   InGroup<VectorConversion>;
+
+def warn_hlsl_impcast_matrix_scalar : Warning<
+  "implicit conversion turns matrix to scalar: %0 to %1">,
+  InGroup<MatrixConversion>;
+
+def warn_hlsl_impcast_vector_float_precision : Warning<
+  "implicit conversion loses floating-point precision: %0 to %1">,
+  InGroup<VectorConversion>;
+
+def warn_hlsl_impcast_matrix_float_precision : Warning<
+  "implicit conversion loses floating-point precision: %0 to %1">,
+  InGroup<MatrixConversion>;
+
+def warn_hlsl_impcast_vector_integer_sign : Warning<
+  "implicit conversion changes signedness: %0 to %1">,
+  InGroup<VectorConversion>;
+
+def warn_hlsl_impcast_matrix_integer_sign : Warning<
+  "implicit conversion changes signedness: %0 to %1">,
+  InGroup<MatrixConversion>;
+
+def warn_hlsl_impcast_vector_integer_precision : Warning<
+  "implicit conversion loses integer precision: %0 to %1">,
+  InGroup<VectorConversion>;
+
+def warn_hlsl_impcast_matrix_integer_precision : Warning<
+  "implicit conversion loses integer precision: %0 to %1">,
+  InGroup<MatrixConversion>;
+
+def warn_hlsl_impcast_vector_float_integer : Warning<
+  "implicit conversion turns floating-point numbers into integers: %0 to %1">,
+  InGroup<VectorConversion>;
+
+def warn_hlsl_impcast_matrix_float_integer : Warning<
+  "implicit conversion turns floating-point numbers into integers: %0 to %1">,
+  InGroup<MatrixConversion>;
+
+def warn_hlsl_impcast_vector_integer_float_precision : Warning<
+  "implicit conversion from %0 to %1 may lose precision">,
+  InGroup<VectorConversion>;
+
+def warn_hlsl_impcast_matrix_integer_float_precision : Warning<
+  "implicit conversion from %0 to %1 may lose precision">,
+  InGroup<MatrixConversion>;
 
 def warn_hlsl_availability : Warning<
   "%0 is only available %select{|in %4 environment }3on %1 %2 or newer">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4401,6 +4401,13 @@ def err_impcast_complex_scalar : Error<
 def warn_impcast_float_precision : Warning<
   "implicit conversion loses floating-point precision: %0 to %1">,
   InGroup<ImplicitFloatConversion>, DefaultIgnore;
+def warn_impcast_vector_float_precision : Warning<
+  "implicit conversion loses floating-point precision: %0 to %1">,
+  InGroup<VectorConversion>;
+def warn_impcast_matrix_float_precision : Warning<
+  "implicit conversion loses floating-point precision: %0 to %1">,
+  InGroup<MatrixConversion>;
+
 def warn_impcast_float_result_precision : Warning<
   "implicit conversion when assigning computation result loses floating-point precision: %0 to %1">,
   InGroup<ImplicitFloatConversion>, DefaultIgnore;
@@ -4410,12 +4417,24 @@ def warn_impcast_double_promotion : Warning<
 def warn_impcast_integer_sign : Warning<
   "implicit conversion changes signedness: %0 to %1">,
   InGroup<SignConversion>, DefaultIgnore;
+def warn_impcast_vector_integer_sign : Warning<
+  "implicit conversion changes signedness: %0 to %1">,
+  InGroup<VectorConversion>;
+def warn_impcast_matrix_integer_sign : Warning<
+  "implicit conversion changes signedness: %0 to %1">,
+  InGroup<MatrixConversion>;
 def warn_impcast_integer_sign_conditional : Warning<
   "operand of ? changes signedness: %0 to %1">,
   InGroup<SignConversion>, DefaultIgnore;
 def warn_impcast_integer_precision : Warning<
   "implicit conversion loses integer precision: %0 to %1">,
   InGroup<ImplicitIntConversion>, DefaultIgnore;
+def warn_impcast_vector_integer_precision : Warning<
+  "implicit conversion loses integer precision: %0 to %1">,
+  InGroup<VectorConversion>;
+def warn_impcast_matrix_integer_precision : Warning<
+  "implicit conversion loses integer precision: %0 to %1">,
+  InGroup<MatrixConversion>;
 def warn_impcast_integer_precision_on_negation : Warning<
   "implicit conversion loses integer precision: %0 to %1 on negation">,
   InGroup<ImplicitIntConversionOnNegation>, DefaultIgnore;
@@ -4455,6 +4474,12 @@ def warn_impcast_literal_float_to_integer_out_of_range : Warning<
 def warn_impcast_float_integer : Warning<
   "implicit conversion turns floating-point number into integer: %0 to %1">,
   InGroup<FloatConversion>, DefaultIgnore;
+def warn_impcast_vector_float_integer : Warning<
+  "implicit conversion turns floating-point numbers into integers: %0 to %1">,
+  InGroup<VectorConversion>;
+def warn_impcast_matrix_float_integer : Warning<
+  "implicit conversion turns floating-point numbers into integers: %0 to %1">,
+  InGroup<MatrixConversion>;
 def warn_impcast_float_to_objc_signed_char_bool : Warning<
   "implicit conversion from floating-point type %0 to 'BOOL'">,
   InGroup<ObjCSignedCharBoolImplicitFloatConversion>;
@@ -4466,6 +4491,12 @@ def warn_impcast_int_to_objc_signed_char_bool : Warning<
 def warn_impcast_integer_float_precision : Warning<
   "implicit conversion from %0 to %1 may lose precision">,
   InGroup<ImplicitIntFloatConversion>, DefaultIgnore;
+def warn_impcast_vector_integer_float_precision : Warning<
+  "implicit conversion from %0 to %1 may lose precision">,
+  InGroup<VectorConversion>;
+def warn_impcast_matrix_integer_float_precision : Warning<
+  "implicit conversion from %0 to %1 may lose precision">,
+  InGroup<MatrixConversion>;
 def warn_impcast_integer_float_precision_constant : Warning<
   "implicit conversion from %2 to %3 changes value from %0 to %1">,
   InGroup<ImplicitConstIntFloatConversion>;
@@ -13418,6 +13449,10 @@ def warn_hlsl_impcast_vector_truncation : Warning<
 
 def warn_hlsl_impcast_matrix_truncation : Warning<
   "implicit conversion truncates matrix: %0 to %1">, InGroup<MatrixConversion>;
+
+def warn_hlsl_impcast_vector_scalar : Warning<
+  "implicit conversion turns vector to scalar: %0 to %1">,
+  InGroup<VectorConversion>;
 
 def warn_hlsl_availability : Warning<
   "%0 is only available %select{|in %4 environment }3on %1 %2 or newer">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4389,7 +4389,7 @@ def warn_unknown_sanitizer_ignored : Warning<
 
 def warn_impcast_matrix_scalar : Warning<
   "implicit conversion turns matrix to scalar: %0 to %1">,
-  InGroup<Conversion>, DefaultIgnore;
+  InGroup<MatrixConversion>;
 def warn_impcast_vector_scalar : Warning<
   "implicit conversion turns vector to scalar: %0 to %1">,
   InGroup<Conversion>, DefaultIgnore;
@@ -4398,6 +4398,9 @@ def warn_impcast_complex_scalar : Warning<
   InGroup<Conversion>, DefaultIgnore;
 def err_impcast_complex_scalar : Error<
   "implicit conversion from %0 to %1 is not permitted in C++">;
+def warn_impcast_matrix_float_precision : Warning<
+  "implicit conversion loses floating-point precision: %0 to %1">,
+  InGroup<MatrixConversion>;
 def warn_impcast_float_precision : Warning<
   "implicit conversion loses floating-point precision: %0 to %1">,
   InGroup<ImplicitFloatConversion>, DefaultIgnore;
@@ -4407,12 +4410,18 @@ def warn_impcast_float_result_precision : Warning<
 def warn_impcast_double_promotion : Warning<
   "implicit conversion increases floating-point precision: %0 to %1">,
   InGroup<DoublePromotion>, DefaultIgnore;
+def warn_impcast_matrix_integer_sign : Warning<
+  "implicit conversion changes signedness: %0 to %1">,
+  InGroup<MatrixConversion>;
 def warn_impcast_integer_sign : Warning<
   "implicit conversion changes signedness: %0 to %1">,
   InGroup<SignConversion>, DefaultIgnore;
 def warn_impcast_integer_sign_conditional : Warning<
   "operand of ? changes signedness: %0 to %1">,
   InGroup<SignConversion>, DefaultIgnore;
+def warn_impcast_matrix_integer_precision : Warning<
+  "implicit conversion loses integer precision: %0 to %1">,
+  InGroup<MatrixConversion>;
 def warn_impcast_integer_precision : Warning<
   "implicit conversion loses integer precision: %0 to %1">,
   InGroup<ImplicitIntConversion>, DefaultIgnore;
@@ -4452,6 +4461,9 @@ def warn_impcast_literal_float_to_integer : Warning<
 def warn_impcast_literal_float_to_integer_out_of_range : Warning<
   "implicit conversion of out of range value from %0 to %1 is undefined">,
   InGroup<LiteralConversion>;
+def warn_impcast_matrix_float_integer : Warning<
+  "implicit conversion turns floating-point numbers into integers: %0 to %1">,
+  InGroup<MatrixConversion>;
 def warn_impcast_float_integer : Warning<
   "implicit conversion turns floating-point number into integer: %0 to %1">,
   InGroup<FloatConversion>, DefaultIgnore;
@@ -4463,6 +4475,9 @@ def warn_impcast_int_to_objc_signed_char_bool : Warning<
   InGroup<ObjCSignedCharBoolImplicitIntConversion>, DefaultIgnore;
 
 // Implicit int -> float conversion precision loss warnings.
+def warn_impcast_matrix_integer_float_precision : Warning<
+  "implicit conversion from %0 to %1 may lose precision">,
+  InGroup<MatrixConversion>;
 def warn_impcast_integer_float_precision : Warning<
   "implicit conversion from %0 to %1 may lose precision">,
   InGroup<ImplicitIntFloatConversion>, DefaultIgnore;
@@ -13423,49 +13438,25 @@ def warn_hlsl_impcast_vector_scalar : Warning<
   "implicit conversion turns vector to scalar: %0 to %1">,
   InGroup<VectorConversion>;
 
-def warn_hlsl_impcast_matrix_scalar : Warning<
-  "implicit conversion turns matrix to scalar: %0 to %1">,
-  InGroup<MatrixConversion>;
-
 def warn_hlsl_impcast_vector_float_precision : Warning<
   "implicit conversion loses floating-point precision: %0 to %1">,
   InGroup<VectorConversion>;
-
-def warn_hlsl_impcast_matrix_float_precision : Warning<
-  "implicit conversion loses floating-point precision: %0 to %1">,
-  InGroup<MatrixConversion>;
 
 def warn_hlsl_impcast_vector_integer_sign : Warning<
   "implicit conversion changes signedness: %0 to %1">,
   InGroup<VectorConversion>;
 
-def warn_hlsl_impcast_matrix_integer_sign : Warning<
-  "implicit conversion changes signedness: %0 to %1">,
-  InGroup<MatrixConversion>;
-
 def warn_hlsl_impcast_vector_integer_precision : Warning<
   "implicit conversion loses integer precision: %0 to %1">,
   InGroup<VectorConversion>;
-
-def warn_hlsl_impcast_matrix_integer_precision : Warning<
-  "implicit conversion loses integer precision: %0 to %1">,
-  InGroup<MatrixConversion>;
 
 def warn_hlsl_impcast_vector_float_integer : Warning<
   "implicit conversion turns floating-point numbers into integers: %0 to %1">,
   InGroup<VectorConversion>;
 
-def warn_hlsl_impcast_matrix_float_integer : Warning<
-  "implicit conversion turns floating-point numbers into integers: %0 to %1">,
-  InGroup<MatrixConversion>;
-
 def warn_hlsl_impcast_vector_integer_float_precision : Warning<
   "implicit conversion from %0 to %1 may lose precision">,
   InGroup<VectorConversion>;
-
-def warn_hlsl_impcast_matrix_integer_float_precision : Warning<
-  "implicit conversion from %0 to %1 may lose precision">,
-  InGroup<MatrixConversion>;
 
 def warn_hlsl_availability : Warning<
   "%0 is only available %select{|in %4 environment }3on %1 %2 or newer">,

--- a/clang/test/SemaHLSL/BuiltIns/select-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/select-errors.hlsl
@@ -2,7 +2,7 @@
 
 
 int test_select_first_arg_wrong_type(int1 p0, int t0, int f0) {
-  return select(p0, t0, f0); // No diagnostic expected.
+  return select(p0, t0, f0); // expected-warning{{implicit conversion turns vector to scalar: 'int1' (aka 'vector<int, 1>') to 'bool'}}
 }
 
 int1 test_select_bool_vals_diff_vecs(bool p0, int1 t0, int1 f0) {
@@ -15,7 +15,7 @@ int2 test_select_vector_vals_not_vecs(bool2 p0, int t0,
 }
 
 int1 test_select_vector_vals_wrong_size(bool2 p0, int1 t0, int1 f0) {
-  return select<int1>(p0, t0, f0); // No diagnostic expected.
+  return select<int1>(p0, t0, f0); // expected-warning{{implicit conversion turns vector to scalar: 'bool2' (aka 'vector<bool, 2>') to 'bool'}}
 }
 
 int test_select_no_args() {

--- a/clang/test/SemaHLSL/Language/UsualArithmeticConversions.hlsl
+++ b/clang/test/SemaHLSL/Language/UsualArithmeticConversions.hlsl
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -finclude-default-header -fnative-half-type %s -DERRORS -Wconversion -Wdouble-promotion -verify
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -std=hlsl2018 -finclude-default-header -fnative-half-type %s -DERRORS -Wconversion -Wdouble-promotion -verify
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -finclude-default-header -fnative-half-type %s -DERRORS -Wdouble-promotion -verify
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -std=hlsl2018 -finclude-default-header -fnative-half-type %s -DERRORS -Wdouble-promotion -verify
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -finclude-default-header -fnative-half-type %s -ast-dump | FileCheck %s
 
 #if __HLSL_VERSION <= 2021

--- a/clang/test/SemaHLSL/MatrixElementOverloadResolution.hlsl
+++ b/clang/test/SemaHLSL/MatrixElementOverloadResolution.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -fnative-half-type -finclude-default-header -Wconversion -verify -o - %s -DERROR=1
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -fnative-half-type -finclude-default-header -verify -o - %s -DERROR=1
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -fnative-half-type -finclude-default-header -ast-dump %s | FileCheck %s
 
 // This test verifies floating point type implicit conversion ranks for overload
@@ -239,7 +239,7 @@ void matOrVec3(float4x4 F) {}
 export void Case8(float2x3 f23, float4x4 f44, float3x3 f33, float3x2 f32) {
   int2x2 i22 = f23;
   // expected-warning@-1{{implicit conversion truncates matrix: 'float2x3' (aka 'matrix<float, 2, 3>') to 'int2x2' (aka 'matrix<int, 2, 2>')}}
-  // expected-warning@-2{{implicit conversion turns floating-point number into integer: 'float2x3' (aka 'matrix<float, 2, 3>') to 'int2x2' (aka 'matrix<int, 2, 2>')}}
+  // expected-warning@-2{{implicit conversion turns floating-point numbers into integers: 'float2x3' (aka 'matrix<float, 2, 3>') to 'int2x2' (aka 'matrix<int, 2, 2>')}}
   //CHECK: VarDecl {{.*}} i22 'int2x2':'matrix<int, 2, 2>' cinit
   //CHECK-NEXT: ImplicitCastExpr {{.*}} 'int2x2':'matrix<int, 2, 2>' <FloatingToIntegral>
   //CHECK-NEXT: ImplicitCastExpr {{.*}} 'float2x3':'matrix<float, 2, 3>' <LValueToRValue>

--- a/clang/test/SemaHLSL/SplatOverloadResolution.hlsl
+++ b/clang/test/SemaHLSL/SplatOverloadResolution.hlsl
@@ -147,7 +147,8 @@ void Case5(half3 H3, float3 F3, double3 D3, half4 H4, float4 F4, double4 D4) {
   // CHECK: CallExpr {{.*}} 'void'
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'void (*)(float2)' <FunctionToPointerDecay>
   // CHECK-NEXT: DeclRefExpr {{.*}} 'void (float2)' lvalue Function {{.*}} 'FloatV24' 'void (float2)'
-  FloatV24(D3); // expected-warning{{implicit conversion truncates vector: 'double3' (aka 'vector<double, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}
+
+  FloatV24(D3); // expected-warning{{implicit conversion truncates vector: 'double3' (aka 'vector<double, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}} expected-warning{{implicit conversion loses floating-point precision: 'double3' (aka 'vector<double, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}
 
   // CHECK: CallExpr {{.*}} 'void'
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'void (*)(float4)' <FunctionToPointerDecay>
@@ -162,5 +163,5 @@ void Case5(half3 H3, float3 F3, double3 D3, half4 H4, float4 F4, double4 D4) {
   // CHECK: CallExpr {{.*}} 'void'
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'void (*)(float4)' <FunctionToPointerDecay>
   // CHECK-NEXT: DeclRefExpr {{.*}} 'void (float4)' lvalue Function {{.*}} 'FloatV24' 'void (float4)'
-  FloatV24(D4);
+  FloatV24(D4); // expected-warning{{implicit conversion loses floating-point precision: 'double4' (aka 'vector<double, 4>') to 'vector<float, 4>' (vector of 4 'float' values)}}
 }

--- a/clang/test/SemaHLSL/Types/BuiltinMatrix/MatrixFloatPrecisionWarnings.hlsl
+++ b/clang/test/SemaHLSL/Types/BuiltinMatrix/MatrixFloatPrecisionWarnings.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -fnative-half-type -finclude-default-header -Wconversion -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -fnative-half-type -finclude-default-header -verify %s
 
 // This test verifies that the implicit conversion warning for floating-point
 // precision loss works correctly for matrix types. The IsSameFloatAfterCast

--- a/clang/test/SemaHLSL/VectorElementOverloadResolution.hlsl
+++ b/clang/test/SemaHLSL/VectorElementOverloadResolution.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -fnative-half-type -finclude-default-header -Wconversion -verify -o - %s -DERROR=1
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -fnative-half-type -finclude-default-header -verify -o - %s -DERROR=1
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -fnative-half-type -finclude-default-header -Wno-conversion -ast-dump %s | FileCheck %s
 
 // This test verifies floating point type implicit conversion ranks for overload

--- a/clang/test/SemaHLSL/standard_conversion_sequences.hlsl
+++ b/clang/test/SemaHLSL/standard_conversion_sequences.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -Wconversion -verify -o - %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -verify -o - %s
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -Wno-conversion -DNO_ERR -ast-dump %s | FileCheck %s
 
 void test() {
@@ -35,7 +35,7 @@ void test() {
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'vector<int, 2>' <FloatingToIntegral>
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'vector<float, 2>' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr {{.*}} 'vector<float, 2>' lvalue Var {{.*}} 'f2' 'vector<float, 2>'
-  // expected-warning@#i2{{mplicit conversion turns floating-point number into integer: 'vector<float, 2>' (vector of 2 'float' values) to 'vector<int, 2>' (vector of 2 'int' values)}}
+  // expected-warning@#i2{{implicit conversion turns floating-point numbers into integers: 'vector<float, 2>' (vector of 2 'float' values) to 'vector<int, 2>' (vector of 2 'int' values)}}
   vector<int,2> i2 = f2; // #i2
 
   // CHECK: VarDecl {{.*}} i2_2 'vector<int, 2>' cinit
@@ -44,7 +44,7 @@ void test() {
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'vector<double, 4>' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr {{.*}} 'vector<double, 4>' lvalue Var {{.*}} 'd4' 'vector<double, 4>'
   // expected-warning@#i2_2{{implicit conversion truncates vector: 'vector<double, 4>' (vector of 4 'double' values) to 'vector<int, 2>' (vector of 2 'int' values)}}
-  // expected-warning@#i2_2{{implicit conversion turns floating-point number into integer: 'vector<double, 4>' (vector of 4 'double' values) to 'vector<int, 2>' (vector of 2 'int' values)}}
+  // expected-warning@#i2_2{{implicit conversion turns floating-point numbers into integers: 'vector<double, 4>' (vector of 4 'double' values) to 'vector<int, 2>' (vector of 2 'int' values)}}
   vector<int,2> i2_2 = d4; // #i2_2
 
 
@@ -52,7 +52,7 @@ void test() {
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'vector<long, 4>' <FloatingToIntegral>
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'vector<double, 4>' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr {{.*}} 'vector<double, 4>' lvalue Var {{.*}} 'd4' 'vector<double, 4>'
-  // expected-warning@#i64_4{{implicit conversion turns floating-point number into integer: 'vector<double, 4>' (vector of 4 'double' values) to 'vector<long, 4>' (vector of 4 'long' values)}}
+  // expected-warning@#i64_4{{implicit conversion turns floating-point numbers into integers: 'vector<double, 4>' (vector of 4 'double' values) to 'vector<long, 4>' (vector of 4 'long' values)}}
   vector<long,4> i64_4 = d4; // #i64_4
 
   // CHECK: VarDecl {{.*}} used i2_3 'vector<int, 2>' cinit
@@ -76,7 +76,7 @@ void test() {
   // CHECK-NEXT: ImplicitCastExpr {{.*}} 'vector<double, 4>' <LValueToRValue>
   // CHECK-NEXT: DeclRefExpr {{.*}} 'vector<double, 4>' lvalue Var {{.*}} 'd4' 'vector<double, 4>'
   // expected-warning@#b2_2{{implicit conversion truncates vector: 'vector<double, 4>' (vector of 4 'double' values) to 'vector<bool, 2>' (vector of 2 'bool' values)}}
-  // expected-warning@#b2_2{{implicit conversion turns floating-point number into integer: 'vector<double, 4>' (vector of 4 'double' values) to 'vector<bool, 2>' (vector of 2 'bool' values)}}
+  // expected-warning@#b2_2{{implicit conversion turns floating-point numbers into integers: 'vector<double, 4>' (vector of 4 'double' values) to 'vector<bool, 2>' (vector of 2 'bool' values)}}
   vector<bool, 2> b2_2 = d4; // #b2_2
 }
 


### PR DESCRIPTION
Fixes #180038
Depends on #179568 being merged first

This PR introduces a set of vector- and matrix-specific diagnostic warnings under the VectorConversions and MatrixConversions groups respectively so that compiler warnings can be given when the flags -Wvector-conversions and -Wmatrix-conversions are given on the command line (which are both enabled by default for HLSL).

The specific vector- and matrix-specific diagnostics are introduced for:
- `warn_impcast_float_precision` 
- `warn_impcast_integer_sign`
- `warn_impcast_integer_precision`
- `warn_impcast_float_integer`
- `warn_impcast_integer_float_precision `

These specific ones are just to start with, as these are exercised in existing HLSL tests. More diagnostics can be added in subsequent PRs as needed.

Additionally, an HLSL-specific variant of `warn_impcast_vector_scalar` is introduced, called `warn_hlsl_impcast_vector_scalar` because existing languages expect `warn_impcast_vector_scalar` to be ignored by default, while for HLSL it should not be ignored by default.

The `DiagnoseImpCast` helper function in `SemaChecking.cpp` is modified to map diagnostics to corresponding vector- or matrix-specific variants of the diagnostic if the implicit cast source type is a vector or matrix.