### PR TITLE
[lldb] Go through the plugin interface to obtain the scripting path

### DIFF
--- a/lldb/include/lldb/API/SBHostOS.h
+++ b/lldb/include/lldb/API/SBHostOS.h
@@ -18,7 +18,10 @@ class LLDB_API SBHostOS {
 public:
   static lldb::SBFileSpec GetProgramFileSpec();
 
+  LLDB_DEPRECATED_FIXME("Use GetScriptPath instead.", "GetScriptPath()")
   static lldb::SBFileSpec GetLLDBPythonPath();
+
+  static lldb::SBFileSpec GetScriptPath(lldb::ScriptLanguage language);
 
   static lldb::SBFileSpec GetLLDBPath(lldb::PathType path_type);
 

--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -343,9 +343,11 @@ public:
   static lldb::RegisterTypeBuilderSP GetRegisterTypeBuilder(Target &target);
 
   // ScriptInterpreter
-  static bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,
-                             lldb::ScriptLanguage script_lang,
-                             ScriptInterpreterCreateInstance create_callback);
+  static bool
+  RegisterPlugin(llvm::StringRef name, llvm::StringRef description,
+                 lldb::ScriptLanguage script_lang,
+                 ScriptInterpreterCreateInstance create_callback,
+                 ScriptInterpreterGetPath get_path_callback = nullptr);
 
   static bool UnregisterPlugin(ScriptInterpreterCreateInstance create_callback);
 
@@ -355,6 +357,9 @@ public:
   static lldb::ScriptInterpreterSP
   GetScriptInterpreterForLanguage(lldb::ScriptLanguage script_lang,
                                   Debugger &debugger);
+
+  static FileSpec
+  GetScriptInterpreterLibraryPath(lldb::ScriptLanguage script_lang);
 
   // SyntheticFrameProvider
   static bool

--- a/lldb/include/lldb/lldb-private-interfaces.h
+++ b/lldb/include/lldb/lldb-private-interfaces.h
@@ -87,6 +87,7 @@ typedef lldb::RegisterTypeBuilderSP (*RegisterTypeBuilderCreateInstance)(
     Target &target);
 typedef lldb::ScriptInterpreterSP (*ScriptInterpreterCreateInstance)(
     Debugger &debugger);
+typedef FileSpec (*ScriptInterpreterGetPath)();
 typedef llvm::Expected<lldb::SyntheticFrameProviderSP> (
     *ScriptedFrameProviderCreateInstance)(
     lldb::StackFrameListSP input_frames,

--- a/lldb/source/API/SBHostOS.cpp
+++ b/lldb/source/API/SBHostOS.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/API/SBHostOS.h"
 #include "lldb/API/SBError.h"
+#include "lldb/Core/PluginManager.h"
 #include "lldb/Host/Config.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/Host.h"
@@ -19,9 +20,6 @@
 #include "lldb/Utility/Instrumentation.h"
 
 #include "Plugins/ExpressionParser/Clang/ClangHost.h"
-#if LLDB_ENABLE_PYTHON
-#include "Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.h"
-#endif
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Path.h"
@@ -40,7 +38,16 @@ SBFileSpec SBHostOS::GetProgramFileSpec() {
 SBFileSpec SBHostOS::GetLLDBPythonPath() {
   LLDB_INSTRUMENT();
 
-  return GetLLDBPath(ePathTypePythonDir);
+  return GetScriptPath(lldb::eScriptLanguagePython);
+}
+
+SBFileSpec SBHostOS::GetScriptPath(lldb::ScriptLanguage language) {
+  LLDB_INSTRUMENT();
+
+  SBFileSpec sb_fspec;
+  sb_fspec.SetFileSpec(
+      PluginManager::GetScriptInterpreterLibraryPath(language));
+  return sb_fspec;
 }
 
 SBFileSpec SBHostOS::GetLLDBPath(lldb::PathType path_type) {
@@ -58,9 +65,8 @@ SBFileSpec SBHostOS::GetLLDBPath(lldb::PathType path_type) {
     fspec = HostInfo::GetHeaderDir();
     break;
   case ePathTypePythonDir:
-#if LLDB_ENABLE_PYTHON
-    fspec = ScriptInterpreterPython::GetPythonDir();
-#endif
+    fspec = PluginManager::GetScriptInterpreterLibraryPath(
+        lldb::eScriptLanguagePython);
     break;
   case ePathTypeLLDBSystemPlugins:
     fspec = HostInfo::GetSystemPluginDir();

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -295,7 +295,8 @@ void ScriptInterpreterPython::Initialize() {
     PluginManager::RegisterPlugin(GetPluginNameStatic(),
                                   GetPluginDescriptionStatic(),
                                   lldb::eScriptLanguagePython,
-                                  ScriptInterpreterPythonImpl::CreateInstance);
+                                  ScriptInterpreterPythonImpl::CreateInstance,
+                                  ScriptInterpreterPythonImpl::GetPythonDir);
     ScriptInterpreterPythonImpl::Initialize();
   });
 }

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -400,7 +400,8 @@ SBError Driver::ProcessArgs(const opt::InputArgList &args, bool &exiting) {
   }
 
   if (m_option_data.m_print_python_path) {
-    SBFileSpec python_file_spec = SBHostOS::GetLLDBPythonPath();
+    SBFileSpec python_file_spec =
+        SBHostOS::GetScriptPath(lldb::eScriptLanguagePython);
     if (python_file_spec.IsValid()) {
       char python_path[PATH_MAX];
       size_t num_chars = python_file_spec.GetPath(python_path, PATH_MAX);


### PR DESCRIPTION
Avoid directly including `ScriptInterpreterPython.h` in `SBHostOS`, and instead go through the plugin interface to obtain the scripting path. This also deprecates the ``SBHostOS::GetLLDBPythonPath`` method in favor of the more generic GetScriptPath variant.