### PR TITLE
[lldb] Use C linkage for plugin initialization & termination

### DIFF
--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -29,7 +29,7 @@
 #include <vector>
 
 #define LLDB_PLUGIN_DEFINE_ADV(ClassName, PluginName)                          \
-  namespace lldb_private {                                                     \
+  extern "C" {                                                                 \
   void lldb_initialize_##PluginName() { ClassName::Initialize(); }             \
   void lldb_terminate_##PluginName() { ClassName::Terminate(); }               \
   }
@@ -39,7 +39,7 @@
 
 // FIXME: Generate me with CMake
 #define LLDB_PLUGIN_DECLARE(PluginName)                                        \
-  namespace lldb_private {                                                     \
+  extern "C" {                                                                 \
   extern void lldb_initialize_##PluginName();                                  \
   extern void lldb_terminate_##PluginName();                                   \
   }
@@ -487,8 +487,7 @@ public:
       llvm::StringRef schema,
       DebuggerInitializeCallback debugger_init_callback);
 
-  static bool
-  UnregisterPlugin(TraceCreateInstanceFromBundle create_callback);
+  static bool UnregisterPlugin(TraceCreateInstanceFromBundle create_callback);
 
   static TraceCreateInstanceFromBundle
   GetTraceCreateCallback(llvm::StringRef plugin_name);

--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -28,9 +28,14 @@
 #include <functional>
 #include <vector>
 
+// Match the PluginInitCallback and PluginTermCallback signature. The generated
+// initializer always succeeds.
 #define LLDB_PLUGIN_DEFINE_ADV(ClassName, PluginName)                          \
   extern "C" {                                                                 \
-  void lldb_initialize_##PluginName() { ClassName::Initialize(); }             \
+  bool lldb_initialize_##PluginName() {                                        \
+    ClassName::Initialize();                                                   \
+    return true;                                                               \
+  }                                                                            \
   void lldb_terminate_##PluginName() { ClassName::Terminate(); }               \
   }
 
@@ -40,7 +45,7 @@
 // FIXME: Generate me with CMake
 #define LLDB_PLUGIN_DECLARE(PluginName)                                        \
   extern "C" {                                                                 \
-  extern void lldb_initialize_##PluginName();                                  \
+  extern bool lldb_initialize_##PluginName();                                  \
   extern void lldb_terminate_##PluginName();                                   \
   }
 

--- a/lldb/source/Plugins/Highlighter/Clang/ClangHighlighter.cpp
+++ b/lldb/source/Plugins/Highlighter/Clang/ClangHighlighter.cpp
@@ -21,9 +21,9 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include <optional>
 
-LLDB_PLUGIN_DEFINE_ADV(ClangHighlighter, HighlighterClang)
-
 using namespace lldb_private;
+
+LLDB_PLUGIN_DEFINE_ADV(ClangHighlighter, HighlighterClang)
 
 bool ClangHighlighter::isKeyword(llvm::StringRef token) const {
   return keywords.contains(token);

--- a/lldb/source/Plugins/Highlighter/Default/DefaultHighlighter.cpp
+++ b/lldb/source/Plugins/Highlighter/Default/DefaultHighlighter.cpp
@@ -8,9 +8,9 @@
 
 #include "DefaultHighlighter.h"
 
-LLDB_PLUGIN_DEFINE_ADV(DefaultHighlighter, HighlighterDefault)
-
 using namespace lldb_private;
+
+LLDB_PLUGIN_DEFINE_ADV(DefaultHighlighter, HighlighterDefault)
 
 void DefaultHighlighter::Highlight(const HighlightStyle &options,
                                    llvm::StringRef line,

--- a/lldb/source/Plugins/Highlighter/TreeSitter/Rust/RustTreeSitterHighlighter.cpp
+++ b/lldb/source/Plugins/Highlighter/TreeSitter/Rust/RustTreeSitterHighlighter.cpp
@@ -10,13 +10,13 @@
 #include "HighlightQuery.h"
 #include "lldb/Target/Language.h"
 
-LLDB_PLUGIN_DEFINE_ADV(RustTreeSitterHighlighter, HighlighterTreeSitterRust)
+using namespace lldb_private;
 
 extern "C" {
 const TSLanguage *tree_sitter_rust();
 }
 
-using namespace lldb_private;
+LLDB_PLUGIN_DEFINE_ADV(RustTreeSitterHighlighter, HighlighterTreeSitterRust)
 
 const TSLanguage *RustTreeSitterHighlighter::GetLanguage() const {
   return tree_sitter_rust();

--- a/lldb/source/Plugins/Highlighter/TreeSitter/Swift/SwiftTreeSitterHighlighter.cpp
+++ b/lldb/source/Plugins/Highlighter/TreeSitter/Swift/SwiftTreeSitterHighlighter.cpp
@@ -10,13 +10,13 @@
 #include "HighlightQuery.h"
 #include "lldb/Target/Language.h"
 
+using namespace lldb_private;
+
 LLDB_PLUGIN_DEFINE_ADV(SwiftTreeSitterHighlighter, HighlighterTreeSitterSwift)
 
 extern "C" {
 const TSLanguage *tree_sitter_swift();
 }
-
-using namespace lldb_private;
 
 const TSLanguage *SwiftTreeSitterHighlighter::GetLanguage() const {
   return tree_sitter_swift();

--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
@@ -29,10 +29,10 @@
 
 #include <mutex>
 
-LLDB_PLUGIN_DEFINE(ScriptedProcess)
-
 using namespace lldb;
 using namespace lldb_private;
+
+LLDB_PLUGIN_DEFINE(ScriptedProcess)
 
 llvm::StringRef ScriptedProcess::GetPluginDescriptionStatic() {
   return "Scripted Process plug-in.";

--- a/lldb/source/Plugins/SyntheticFrameProvider/ScriptedFrameProvider/ScriptedFrameProvider.cpp
+++ b/lldb/source/Plugins/SyntheticFrameProvider/ScriptedFrameProvider/ScriptedFrameProvider.cpp
@@ -24,6 +24,8 @@
 using namespace lldb;
 using namespace lldb_private;
 
+LLDB_PLUGIN_DEFINE(ScriptedFrameProvider)
+
 void ScriptedFrameProvider::Initialize() {
   PluginManager::RegisterPlugin(GetPluginNameStatic(),
                                 "Provides synthetic frames via scripting",
@@ -216,13 +218,3 @@ ScriptedFrameProvider::GetFrameAtIndex(uint32_t idx) {
 
   return synth_frame_sp;
 }
-
-namespace lldb_private {
-void lldb_initialize_ScriptedFrameProvider() {
-  ScriptedFrameProvider::Initialize();
-}
-
-void lldb_terminate_ScriptedFrameProvider() {
-  ScriptedFrameProvider::Terminate();
-}
-} // namespace lldb_private


### PR DESCRIPTION
Use C linkage for plugin initialization & termination. I'm working on adding support for using the existing plugin infrastructure but with dynamic libraries. Using C linkage makes it easier to dlsym the initialize and terminate methods.

For example, with this patch, `__ZN12lldb_private39lldb_initialize_ScriptInterpreterPythonEv` becomes `_lldb_initialize_ScriptInterpreterPython`.