### PR TITLE
[clang-tidy][NFC] Clean up traversal mode handling in `modernize-redundant-void-arg`

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/RedundantVoidArgCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/RedundantVoidArgCheck.cpp
@@ -16,12 +16,9 @@ namespace clang::tidy::modernize {
 
 void RedundantVoidArgCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
-      traverse(TK_IgnoreUnlessSpelledInSource,
-               functionTypeLoc(unless(hasParent(functionDecl(isExternC()))))
-                   .bind("fn")),
+      functionTypeLoc(unless(hasParent(functionDecl(isExternC())))).bind("fn"),
       this);
-  Finder->addMatcher(
-      traverse(TK_IgnoreUnlessSpelledInSource, lambdaExpr().bind("fn")), this);
+  Finder->addMatcher(lambdaExpr().bind("fn"), this);
 }
 
 void RedundantVoidArgCheck::check(const MatchFinder::MatchResult &Result) {

--- a/clang-tools-extra/clang-tidy/modernize/RedundantVoidArgCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/RedundantVoidArgCheck.h
@@ -31,6 +31,9 @@ public:
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus;
   }
+  std::optional<TraversalKind> getCheckTraversalKind() const override {
+    return TK_IgnoreUnlessSpelledInSource;
+  }
 
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
 


### PR DESCRIPTION
#173340 added a bit of code to this check to work around #170953. Now that the latter PR is merged, we can remove the workaround.