### PR TITLE
[NFC][OpenCL] Fix test function-scope-local-return.cl

### DIFF
--- a/clang/test/SemaOpenCL/function-scope-local-return.cl
+++ b/clang/test/SemaOpenCL/function-scope-local-return.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -verify -pedantic -fsyntax-only -cl-std=CL3.0
+// RUN: %clang_cc1 -triple spir64-unknown-unknown -verify -pedantic -fsyntax-only -cl-std=CL3.0 %s
 
 // Check that returning a pointer to a local address space variable does not
 // trigger -Wreturn-stack-address.


### PR DESCRIPTION
Add `-triple spir64-unknown-unknown` to fix error on arm and aarch64: unsupported OpenCL extension '__cl_clang_function_scope_local_variables'