### PR TITLE
[clang-tidy] Enable `modernize-redundant-void-arg` in C23

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/RedundantVoidArgCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/RedundantVoidArgCheck.cpp
@@ -15,10 +15,15 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::modernize {
 
 void RedundantVoidArgCheck::registerMatchers(MatchFinder *Finder) {
-  Finder->addMatcher(
-      functionTypeLoc(unless(hasParent(functionDecl(isExternC())))).bind("fn"),
-      this);
-  Finder->addMatcher(lambdaExpr().bind("fn"), this);
+  if (getLangOpts().CPlusPlus) {
+    Finder->addMatcher(
+        functionTypeLoc(unless(hasParent(functionDecl(isExternC()))))
+            .bind("fn"),
+        this);
+    Finder->addMatcher(lambdaExpr().bind("fn"), this);
+  } else {
+    Finder->addMatcher(functionTypeLoc().bind("fn"), this);
+  }
 }
 
 void RedundantVoidArgCheck::check(const MatchFinder::MatchResult &Result) {

--- a/clang-tools-extra/clang-tidy/modernize/RedundantVoidArgCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/RedundantVoidArgCheck.h
@@ -29,7 +29,7 @@ public:
       : ClangTidyCheck(Name, Context) {}
 
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
-    return LangOpts.CPlusPlus;
+    return LangOpts.CPlusPlus || LangOpts.C23;
   }
   std::optional<TraversalKind> getCheckTraversalKind() const override {
     return TK_IgnoreUnlessSpelledInSource;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -209,6 +209,9 @@ Changes in existing checks
   <clang-tidy/checks/modernize/pass-by-value>` check by adding `IgnoreMacros`
   option to suppress warnings in macros.
 
+- Improved :doc:`modernize-redundant-void-arg
+  <clang-tidy/checks/modernize/redundant-void-arg>` check to work in C23.
+
 - Improved :doc:`modernize-use-std-format
   <clang-tidy/checks/modernize/use-std-format>` check by fixing a crash
   when an argument is part of a macro expansion.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/redundant-void-arg.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/redundant-void-arg.rst
@@ -3,7 +3,8 @@
 modernize-redundant-void-arg
 ============================
 
-Find and remove redundant ``void`` argument lists.
+Finds and removes redundant ``void`` argument lists.
+Works in C++ and in C23 and up.
 
 Examples:
   ===================================  ===========================

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.c
@@ -1,4 +1,7 @@
-// RUN: clang-tidy -checks=-*,modernize-redundant-void-arg %s -- -Wno-strict-prototypes -x c | count 0
+// RUN: clang-tidy %s -checks=-*,modernize-redundant-void-arg -- -std=c99 -Wno-strict-prototypes | count 0
+// RUN: clang-tidy %s -checks=-*,modernize-redundant-void-arg -- -std=c11 -Wno-strict-prototypes | count 0
+// RUN: clang-tidy %s -checks=-*,modernize-redundant-void-arg -- -std=c17 -Wno-strict-prototypes | count 0
+// RUN: %check_clang_tidy -std=c23-or-later -check-suffixes=C23 %s modernize-redundant-void-arg %t
 
 #define NULL 0
 
@@ -11,6 +14,8 @@ int foo2() {
 int j = 1;
 
 int foo(void) {
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:9: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: int foo() {
   return 0;
 }
 
@@ -21,24 +26,47 @@ typedef void my_void;
 // A function taking void and returning a pointer to function taking void
 // and returning int.
 int (*returns_fn_void_int(void))(void);
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:27: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-MESSAGES-C23: :[[@LINE-2]]:34: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: int (*returns_fn_void_int())();
 
 typedef int (*returns_fn_void_int_t(void))(void);
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:37: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-MESSAGES-C23: :[[@LINE-2]]:44: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: typedef int (*returns_fn_void_int_t())();
 
 int (*returns_fn_void_int(void))(void) {
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:27: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-MESSAGES-C23: :[[@LINE-2]]:34: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: int (*returns_fn_void_int())() {
   return NULL;
 }
 
 // A function taking void and returning a pointer to a function taking void
 // and returning a pointer to a function taking void and returning void.
 void (*(*returns_fn_returns_fn_void_void(void))(void))(void);
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:42: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-MESSAGES-C23: :[[@LINE-2]]:49: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-MESSAGES-C23: :[[@LINE-3]]:56: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: void (*(*returns_fn_returns_fn_void_void())())();
 
 typedef void (*(*returns_fn_returns_fn_void_void_t(void))(void))(void);
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:52: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-MESSAGES-C23: :[[@LINE-2]]:59: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-MESSAGES-C23: :[[@LINE-3]]:66: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: typedef void (*(*returns_fn_returns_fn_void_void_t())())();
 
 void (*(*returns_fn_returns_fn_void_void(void))(void))(void) {
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:42: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-MESSAGES-C23: :[[@LINE-2]]:49: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-MESSAGES-C23: :[[@LINE-3]]:56: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: void (*(*returns_fn_returns_fn_void_void())())() {
   return NULL;
 }
 
 void bar(void) {
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:10: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: void bar() {
   int i;
   int *pi = NULL;
   void *pv = (void *) pi;
@@ -49,10 +77,18 @@ void bar(void) {
 }
 
 void (*f1)(void);
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:12: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: void (*f1)();
 void (*f2)(void) = NULL;
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:12: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: void (*f2)() = NULL;
 void (*f3)(void) = bar;
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:12: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: void (*f3)() = bar;
 void (*fa)();
 void (*fb)() = NULL;
 void (*fc)() = bar;
 
 typedef void (function_ptr)(void);
+// CHECK-MESSAGES-C23: :[[@LINE-1]]:29: warning: redundant void argument list [modernize-redundant-void-arg]
+// CHECK-FIXES-C23: typedef void (function_ptr)();


### PR DESCRIPTION
As suggested in [this comment](https://github.com/llvm/llvm-project/pull/173340#discussion_r2810951335)!