### PR TITLE
[SPIRV] Fix printf regression after #178980

### DIFF
--- a/llvm/test/CodeGen/SPIRV/printf.ll
+++ b/llvm/test/CodeGen/SPIRV/printf.ll
@@ -6,35 +6,33 @@
 
 ; CHECK: %[[#ExtImport:]] = OpExtInstImport "OpenCL.std"
 ; CHECK: %[[#Char:]] = OpTypeInt 8 0
-; CHECK: %[[#ConstCharPtr:]] = OpTypePointer UniformConstant %[[#Char]]
-; CHECK: %[[#VarargStruct:]] = OpTypeStruct %[[#Char]]
-; CHECK: %[[#VarargStructPtr:]] = OpTypePointer Function %[[#VarargStruct]]
-; CHECK: %[[#CharPtr:]] = OpTypePointer Function %[[#Char]]
-; CHECK: %[[#IntConst:]] = OpConstant %[[#Char]] 97
+; CHECK: %[[#CharPtr:]] = OpTypePointer UniformConstant %[[#Char]]
 ; CHECK: %[[#GV:]] = OpVariable %[[#]] UniformConstant %[[#]]
 ; CHECK: OpFunction
-; CHECK: %[[#Arg:]] = OpFunctionParameter
-; CHECK: %[[#VarargBuffer1:]] = OpVariable %[[#VarargStructPtr]] Function
-; CHECK: %[[#VarargBuffer2:]] = OpVariable %[[#VarargStructPtr]] Function
-; CHECK: %[[#CastedBuffer1:]] = OpBitcast %[[#CharPtr]] %[[#VarargBuffer1]]
-; CHECK: %[[#GEP1:]] = OpInBoundsPtrAccessChain %[[#CharPtr]] %[[#VarargBuffer1]]
-; CHECK: OpStore %[[#GEP1]] %[[#IntConst]] Aligned 1
-; CHECK: %[[#CastedGV:]] = OpBitcast %[[#ConstCharPtr]] %[[#GV]]
-; CHECK: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#CastedGV]] %[[#CastedBuffer1:]]
-; CHECK: %[[#CastedBuffer2:]] = OpBitcast %[[#CharPtr]] %[[#VarargBuffer2]]
-; CHECK: %[[#GEP2:]] = OpInBoundsPtrAccessChain %[[#CharPtr]] %[[#VarargBuffer2]]
-; CHECK: OpStore %[[#GEP2]] %[[#IntConst]] Aligned 1
-; CHECK: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#Arg]] %[[#CastedBuffer2:]]
+; CHECK: %[[#Arg1:]] = OpFunctionParameter
+; CHECK: %[[#Arg2:]] = OpFunctionParameter
+; CHECK: %[[#CastedGV:]] = OpBitcast %[[#CharPtr]] %[[#GV]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#CastedGV]] %[[#ArgConst:]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#CastedGV]] %[[#ArgConst]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#Arg1]] %[[#ArgConst:]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#Arg1]] %[[#ArgConst]]
+; CHECK-NEXT: %[[#CastedArg2:]] = OpBitcast %[[#CharPtr]] %[[#Arg2]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#CastedArg2]] %[[#ArgConst]]
+; CHECK-NEXT: OpExtInst %[[#]] %[[#ExtImport]] printf %[[#CastedArg2]] %[[#ArgConst]]
 ; CHECK: OpFunctionEnd
 
 %struct = type { [6 x i8] }
 
 @FmtStr = internal addrspace(2) constant [6 x i8] c"c=%c\0A\00", align 1
 
-define spir_kernel void @foo(ptr addrspace(2) %_arg_fmt) {
+define spir_kernel void @foo(ptr addrspace(2) %_arg_fmt1, ptr addrspace(2) byval(%struct) %_arg_fmt2) {
 entry:
   %r1 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z6printfPU3AS2Kcz(ptr addrspace(2) @FmtStr, i8 signext 97)
-  %r2 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2) %_arg_fmt, i8 signext 97)
+  %r2 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2) @FmtStr, i8 signext 97)
+  %r3 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z6printfPU3AS2Kcz(ptr addrspace(2) %_arg_fmt1, i8 signext 97)
+  %r4 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2) %_arg_fmt1, i8 signext 97)
+  %r5 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z6printfPU3AS2Kcz(ptr addrspace(2) %_arg_fmt2, i8 signext 97)
+  %r6 = tail call spir_func i32 (ptr addrspace(2), ...) @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2) %_arg_fmt2, i8 signext 97)
   ret void
 }
 


### PR DESCRIPTION
printf function is treated in a special way by SPIRV backend. It lowers to an SPIRV extension op instead of a function call. As such, printf should not be handled in the same way as general expand variadics. This PR restores filtering capability removed by #178980 in a more precise way to avoid false positives.
First, target triple is checked if it SPIR-V and then checks against more precise set of mangled names.
