### PR TITLE
[SimplifyCFG] remove misleading arrow operator

### DIFF
--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -3550,7 +3550,6 @@ protected:
 
 public:
   using CaseWeightOpt = std::optional<uint32_t>;
-  SwitchInst *raw() { return &SI; }
   SwitchInst &operator*() { return SI; }
   operator SwitchInst *() { return &SI; }
 

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -3550,7 +3550,7 @@ protected:
 
 public:
   using CaseWeightOpt = std::optional<uint32_t>;
-  SwitchInst *operator->() { return &SI; }
+  SwitchInst *raw() { return &SI; }
   SwitchInst &operator*() { return SI; }
   operator SwitchInst *() { return &SI; }
 

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -3550,8 +3550,6 @@ protected:
 
 public:
   using CaseWeightOpt = std::optional<uint32_t>;
-  SwitchInst &operator*() { return SI; }
-  operator SwitchInst *() { return &SI; }
 
   SwitchInstProfUpdateWrapper(SwitchInst &SI) : SI(SI) { init(); }
 

--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -374,7 +374,7 @@ static bool processSwitch(SwitchInst *I, LazyValueInfo *LVI,
         LVI->getConstantRangeAtUse(I->getOperandUse(0), /*UndefAllowed=*/false);
     unsigned ReachableCaseCount = 0;
 
-    for (auto CI = (*SIW).case_begin(), CE = (*SIW).case_end(); CI != CE;) {
+    for (auto CI = I->case_begin(), CE = I->case_end(); CI != CE;) {
       ConstantInt *Case = CI->getCaseValue();
       std::optional<bool> Predicate = std::nullopt;
       if (!CR.contains(Case->getValue()))
@@ -398,11 +398,11 @@ static bool processSwitch(SwitchInst *I, LazyValueInfo *LVI,
         BasicBlock *Succ = CI->getCaseSuccessor();
         Succ->removePredecessor(BB);
         CI = SIW.removeCase(CI);
-        CE = (*SIW).case_end();
+        CE = I->case_end();
 
         // The condition can be modified by removePredecessor's PHI simplification
         // logic.
-        Cond = (*SIW).getCondition();
+        Cond = I->getCondition();
 
         ++NumDeadCases;
         Changed = true;
@@ -414,8 +414,8 @@ static bool processSwitch(SwitchInst *I, LazyValueInfo *LVI,
         // This case always fires.  Arrange for the switch to be turned into an
         // unconditional branch by replacing the switch condition with the case
         // value.
-        (*SIW).setCondition(Case);
-        NumDeadCases += (*SIW).getNumCases();
+        I->setCondition(Case);
+        NumDeadCases += I->getNumCases();
         Changed = true;
         break;
       }
@@ -426,9 +426,9 @@ static bool processSwitch(SwitchInst *I, LazyValueInfo *LVI,
     }
 
     // The default dest is unreachable if all cases are covered.
-    if (!(*SIW).defaultDestUnreachable() &&
+    if (!I->defaultDestUnreachable() &&
         !CR.isSizeLargerThan(ReachableCaseCount)) {
-      BasicBlock *DefaultDest = (*SIW).getDefaultDest();
+      BasicBlock *DefaultDest = I->getDefaultDest();
       BasicBlock *NewUnreachableBB =
           BasicBlock::Create(BB->getContext(), "default.unreachable",
                              BB->getParent(), DefaultDest);
@@ -436,7 +436,7 @@ static bool processSwitch(SwitchInst *I, LazyValueInfo *LVI,
       UI->setDebugLoc(DebugLoc::getTemporary());
 
       DefaultDest->removePredecessor(BB);
-      (*SIW).setDefaultDest(NewUnreachableBB);
+      I->setDefaultDest(NewUnreachableBB);
 
       if (SuccessorsCount[DefaultDest] == 1)
         DTU.applyUpdates({{DominatorTree::Delete, BB, DefaultDest}});

--- a/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
+++ b/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
@@ -927,7 +927,7 @@ static bool unswitchTrivialSwitch(Loop &L, SwitchInst &SI, DominatorTree &DT,
   // debug location of the old switch, because it semantically replace the old
   // one.
   auto *NewSI = SwitchInst::Create(LoopCond, NewPH, ExitCases.size(), OldPH);
-  NewSI->setDebugLoc(SIW->getDebugLoc());
+  NewSI->setDebugLoc((*SIW).getDebugLoc());
   SwitchInstProfUpdateWrapper NewSIW(*NewSI);
 
   // Rewrite the IR for the unswitched basic blocks. This requires two steps.
@@ -995,7 +995,7 @@ static bool unswitchTrivialSwitch(Loop &L, SwitchInst &SI, DominatorTree &DT,
   // If the default was unswitched, re-point it and add explicit cases for
   // entering the loop.
   if (DefaultExitBB) {
-    NewSIW->setDefaultDest(DefaultExitBB);
+    (*NewSIW).setDefaultDest(DefaultExitBB);
     NewSIW.setSuccessorWeight(0, DefaultCaseWeight);
 
     // We removed all the exit cases, so we just copy the cases to the
@@ -1038,7 +1038,7 @@ static bool unswitchTrivialSwitch(Loop &L, SwitchInst &SI, DominatorTree &DT,
     }
     // Now nuke the switch and replace it with a direct branch.
     Instruction *NewBI = BranchInst::Create(CommonSuccBB, BB);
-    NewBI->setDebugLoc(SIW->getDebugLoc());
+    NewBI->setDebugLoc((*SIW).getDebugLoc());
     SIW.eraseFromParent();
   } else if (DefaultExitBB) {
     assert(SI.getNumCases() > 0 &&

--- a/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
+++ b/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp
@@ -927,7 +927,7 @@ static bool unswitchTrivialSwitch(Loop &L, SwitchInst &SI, DominatorTree &DT,
   // debug location of the old switch, because it semantically replace the old
   // one.
   auto *NewSI = SwitchInst::Create(LoopCond, NewPH, ExitCases.size(), OldPH);
-  NewSI->setDebugLoc((*SIW).getDebugLoc());
+  NewSI->setDebugLoc(SI.getDebugLoc());
   SwitchInstProfUpdateWrapper NewSIW(*NewSI);
 
   // Rewrite the IR for the unswitched basic blocks. This requires two steps.
@@ -995,7 +995,7 @@ static bool unswitchTrivialSwitch(Loop &L, SwitchInst &SI, DominatorTree &DT,
   // If the default was unswitched, re-point it and add explicit cases for
   // entering the loop.
   if (DefaultExitBB) {
-    (*NewSIW).setDefaultDest(DefaultExitBB);
+    NewSI->setDefaultDest(DefaultExitBB);
     NewSIW.setSuccessorWeight(0, DefaultCaseWeight);
 
     // We removed all the exit cases, so we just copy the cases to the
@@ -1038,7 +1038,7 @@ static bool unswitchTrivialSwitch(Loop &L, SwitchInst &SI, DominatorTree &DT,
     }
     // Now nuke the switch and replace it with a direct branch.
     Instruction *NewBI = BranchInst::Create(CommonSuccBB, BB);
-    NewBI->setDebugLoc((*SIW).getDebugLoc());
+    NewBI->setDebugLoc(SI.getDebugLoc());
     SIW.eraseFromParent();
   } else if (DefaultExitBB) {
     assert(SI.getNumCases() > 0 &&

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -431,12 +431,13 @@ bool SCCPSolver::removeNonFeasibleEdges(BasicBlock *BB, DomTreeUpdater &DTU,
     TI->eraseFromParent();
     DTU.applyUpdatesPermissive(Updates);
   } else if (FeasibleSuccessors.size() > 1) {
-    SwitchInstProfUpdateWrapper SIW(*cast<SwitchInst>(TI));
+    SwitchInst &SI = cast<SwitchInst>(*TI);
+    SwitchInstProfUpdateWrapper SIW(SI);
     SmallVector<DominatorTree::UpdateType, 8> Updates;
 
     // If the default destination is unfeasible it will never be taken. Replace
     // it with a new block with a single Unreachable instruction.
-    BasicBlock *DefaultDest = (*SIW).getDefaultDest();
+    BasicBlock *DefaultDest = SI.getDefaultDest();
     if (!FeasibleSuccessors.contains(DefaultDest)) {
       if (!NewUnreachableBB) {
         NewUnreachableBB =
@@ -448,12 +449,12 @@ bool SCCPSolver::removeNonFeasibleEdges(BasicBlock *BB, DomTreeUpdater &DTU,
       }
 
       DefaultDest->removePredecessor(BB);
-      (*SIW).setDefaultDest(NewUnreachableBB);
+      SI.setDefaultDest(NewUnreachableBB);
       Updates.push_back({DominatorTree::Delete, BB, DefaultDest});
       Updates.push_back({DominatorTree::Insert, BB, NewUnreachableBB});
     }
 
-    for (auto CI = (*SIW).case_begin(); CI != (*SIW).case_end();) {
+    for (auto CI = SI.case_begin(); CI != SI.case_end();) {
       if (FeasibleSuccessors.contains(CI->getCaseSuccessor())) {
         ++CI;
         continue;

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -1027,8 +1027,8 @@ bool SimplifyCFGOpt::simplifyEqualityComparisonWithOnlyPredecessor(
 
       return true;
     }
-
-    SwitchInstProfUpdateWrapper SIW = *cast<SwitchInst>(TI);
+    SwitchInst &SI = *cast<SwitchInst>(TI);
+    SwitchInstProfUpdateWrapper SIW{SI};
     // Okay, TI has cases that are statically dead, prune them away.
     SmallPtrSet<Constant *, 16> DeadCases;
     for (const ValueEqualityComparisonCase &Case : PredCases)
@@ -1038,8 +1038,7 @@ bool SimplifyCFGOpt::simplifyEqualityComparisonWithOnlyPredecessor(
                       << "Through successor TI: " << *TI);
 
     SmallDenseMap<BasicBlock *, int, 8> NumPerSuccessorCases;
-    for (SwitchInst::CaseIt i = (*SIW).case_end(), e = (*SIW).case_begin();
-         i != e;) {
+    for (SwitchInst::CaseIt i = SI.case_end(), e = SI.case_begin(); i != e;) {
       --i;
       auto *Successor = i->getCaseSuccessor();
       if (DTU)
@@ -5764,14 +5763,14 @@ bool SimplifyCFGOpt::simplifyUnreachable(UnreachableInst *UI) {
         Updates.push_back({DominatorTree::Delete, Predecessor, BB});
     } else if (auto *SI = dyn_cast<SwitchInst>(TI)) {
       SwitchInstProfUpdateWrapper SIW(*SI);
-      for (auto i = (*SIW).case_begin(), e = (*SIW).case_end(); i != e;) {
+      for (auto i = SI->case_begin(), e = SI->case_end(); i != e;) {
         if (i->getCaseSuccessor() != BB) {
           ++i;
           continue;
         }
-        BB->removePredecessor((*SIW).getParent());
+        BB->removePredecessor(SI->getParent());
         i = SIW.removeCase(i);
-        e = (*SIW).case_end();
+        e = SI->case_end();
         Changed = true;
       }
       // Note that the default destination can't be removed!
@@ -7713,7 +7712,7 @@ static bool simplifySwitchWhenUMin(SwitchInst *SI, DomTreeUpdater *DTU) {
 
   SmallVector<DominatorTree::UpdateType> Updates;
   SwitchInstProfUpdateWrapper SIW(*SI);
-  BasicBlock *BB = (*SIW).getParent();
+  BasicBlock *BB = SI->getParent();
 
   // Dead cases are removed even when the simplification fails.
   // A case is dead when its value is higher than the Constant.
@@ -7726,7 +7725,7 @@ static bool simplifySwitchWhenUMin(SwitchInst *SI, DomTreeUpdater *DTU) {
     DeadCaseBB->removePredecessor(BB);
     Updates.push_back({DominatorTree::Delete, BB, DeadCaseBB});
     I = SIW.removeCase(I);
-    E = (*SIW).case_end();
+    E = SI->case_end();
   }
 
   auto Case = SI->findCaseValue(Constant);
@@ -7743,7 +7742,7 @@ static bool simplifySwitchWhenUMin(SwitchInst *SI, DomTreeUpdater *DTU) {
   BasicBlock *Unreachable = SI->getDefaultDest();
   SIW.replaceDefaultDest(Case);
   SIW.removeCase(Case);
-  (*SIW).setCondition(A);
+  SI->setCondition(A);
 
   Updates.push_back({DominatorTree::Delete, BB, Unreachable});
 


### PR DESCRIPTION
arrow operator SwitchInstProfUpdateWrapper is misleading when adding or removing case. (see #182261)
this PR removes this operator

