### PR TITLE
[lldb][ARM] Support reading the thread pointer register on ARM Linux

### DIFF
--- a/lldb/include/lldb/Host/linux/Ptrace.h
+++ b/lldb/include/lldb/Host/linux/Ptrace.h
@@ -38,9 +38,16 @@ typedef int __ptrace_request;
 #ifndef PTRACE_SETREGSET
 #define PTRACE_SETREGSET 0x4205
 #endif
+
 #ifndef PTRACE_GET_THREAD_AREA
+#ifdef __arm__
+// Arm has a different value, see arch/arm/include/uapi/asm/ptrace.h.
+#define PTRACE_GET_THREAD_AREA 22
+#else
 #define PTRACE_GET_THREAD_AREA 25
-#endif
+#endif // __arm__
+#endif // PTRACE_GET_THREAD_AREA
+
 #ifndef PTRACE_ARCH_PRCTL
 #define PTRACE_ARCH_PRCTL 30
 #endif

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.h
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.h
@@ -58,21 +58,30 @@ protected:
 
   Status WriteFPR() override;
 
+  Status ReadTLS();
+
   void *GetGPRBuffer() override { return &m_gpr_arm; }
 
   void *GetFPRBuffer() override { return &m_fpr; }
 
   size_t GetFPRSize() override { return sizeof(m_fpr); }
 
+  void *GetTLSBuffer() { return &m_tls; }
+
+  size_t GetTLSSize() { return sizeof(m_tls); }
+
 private:
   uint32_t m_gpr_arm[k_num_gpr_registers_arm];
   RegisterInfoPOSIX_arm::FPU m_fpr;
+  RegisterInfoPOSIX_arm::TLS m_tls;
 
   bool m_refresh_hwdebug_info;
 
   bool IsGPR(unsigned reg) const;
 
   bool IsFPR(unsigned reg) const;
+
+  bool IsTLS(unsigned reg) const;
 
   llvm::Error ReadHardwareDebugInfo() override;
 

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm.h
@@ -15,7 +15,7 @@
 
 class RegisterInfoPOSIX_arm : public lldb_private::RegisterInfoAndSetInterface {
 public:
-  enum { GPRegSet = 0, FPRegSet};
+  enum { GPRegSet = 0, FPRegSet, TLSRegSet };
 
   struct GPR {
     uint32_t r[16]; // R0-R15
@@ -40,6 +40,10 @@ public:
     uint32_t far; /* Virtual Fault Address */
   };
 
+  struct TLS {
+    uint32_t tpidruro;
+  };
+
   struct DBG {
     uint32_t bvr[16];
     uint32_t bcr[16];
@@ -47,7 +51,8 @@ public:
     uint32_t wcr[16];
   };
 
-  RegisterInfoPOSIX_arm(const lldb_private::ArchSpec &target_arch);
+  RegisterInfoPOSIX_arm(const lldb_private::ArchSpec &target_arch,
+                        bool has_tls_reg = false);
 
   size_t GetGPRSize() const override;
 
@@ -67,6 +72,9 @@ public:
 private:
   const lldb_private::RegisterInfo *m_register_info_p;
   uint32_t m_register_info_count;
+  // Only provide information about the TLS register to users of this class that
+  // can handle it. Currently, only `NativeRegisterContextLinux_arm` reads it.
+  bool m_has_tls_reg;
 };
 
 #endif // LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERINFOPOSIX_ARM_H

--- a/lldb/source/Plugins/Process/Utility/RegisterInfos_arm.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfos_arm.h
@@ -32,6 +32,10 @@ using namespace lldb_private;
 #error FPSCR_OFFSET must be defined before including this header file
 #endif
 
+#ifndef TLS_OFFSET
+#error TLS_OFFSET must be defined before including this header file
+#endif
+
 #ifndef EXC_OFFSET
 #error EXC_OFFSET_NAME must be defined before including this header file
 #endif
@@ -145,6 +149,8 @@ enum {
   fpu_q13,
   fpu_q14,
   fpu_q15,
+
+  tls_tpidruro,
 
   exc_exception,
   exc_fsr,
@@ -681,6 +687,20 @@ static RegisterInfo g_register_infos_arm[] = {
     FPU_QREG(q13, 52),
     FPU_QREG(q14, 56),
     FPU_QREG(q15, 60),
+
+    {
+        "tpidruro",
+        nullptr,
+        4,
+        TLS_OFFSET,
+        eEncodingUint,
+        eFormatHex,
+        {LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM, LLDB_REGNUM_GENERIC_TP,
+         LLDB_INVALID_REGNUM, tls_tpidruro},
+        nullptr,
+        nullptr,
+        nullptr,
+    },
 
     {
         "exception",

--- a/lldb/source/Plugins/Process/Windows/Common/arm/RegisterContextWindows_arm.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/arm/RegisterContextWindows_arm.cpp
@@ -25,6 +25,7 @@ using namespace lldb_private;
 #define GPR_OFFSET(idx) 0
 #define FPU_OFFSET(idx) 0
 #define FPSCR_OFFSET 0
+#define TLS_OFFSET 0
 #define EXC_OFFSET(reg) 0
 #define DBG_OFFSET_NAME(reg) 0
 

--- a/lldb/test/API/linux/arm/tls_register/Makefile
+++ b/lldb/test/API/linux/arm/tls_register/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/linux/arm/tls_register/TestArmLinuxTLSRegister.py
+++ b/lldb/test/API/linux/arm/tls_register/TestArmLinuxTLSRegister.py
@@ -13,7 +13,7 @@ from lldbsuite.test import lldbutil
 class ArmLinuxTLSRegister(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    def test_tls_reg_read(self):
+    def test_tls_reg_access(self):
         self.build()
         (_, _, thread, _) = lldbutil.run_to_source_breakpoint(
             self, "// Set breakpoint here.", lldb.SBFileSpec("main.c")
@@ -33,11 +33,6 @@ class ArmLinuxTLSRegister(TestBase):
         self.assertEqual(tpidruro_reg.GetValueAsUnsigned(), val)
         self.expect("reg read tp", substrs=[hex(val)])
 
-    def test_tls_reg_write(self):
-        self.build()
-        lldbutil.run_to_source_breakpoint(
-            self, "// Set breakpoint here.", lldb.SBFileSpec("main.c")
-        )
         self.expect(
             "register write tpidruro 0x1234",
             error=True,

--- a/lldb/test/API/linux/arm/tls_register/TestArmLinuxTLSRegister.py
+++ b/lldb/test/API/linux/arm/tls_register/TestArmLinuxTLSRegister.py
@@ -1,0 +1,45 @@
+"""
+Test lldb's ability to read the Arm TLS register.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+@skipUnlessArch("arm")
+@skipUnlessPlatform(["linux"])
+class ArmLinuxTLSRegister(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_tls_reg_read(self):
+        self.build()
+        (_, _, thread, _) = lldbutil.run_to_source_breakpoint(
+            self, "// Set breakpoint here.", lldb.SBFileSpec("main.c")
+        )
+        frame = thread.GetFrameAtIndex(0)
+
+        tpidruro_var = frame.FindVariable("tpidruro")
+        self.assertTrue(tpidruro_var.IsValid())
+
+        regs = frame.GetRegisters()
+        tls_regs = regs.GetFirstValueByName("Thread Local Storage Registers")
+        self.assertTrue(tls_regs.IsValid(), "No TLS registers found.")
+        tpidruro_reg = tls_regs.GetChildMemberWithName("tpidruro")
+        self.assertTrue(tpidruro_reg.IsValid(), "tpidruro register not found.")
+
+        val = tpidruro_var.GetValueAsUnsigned()
+        self.assertEqual(tpidruro_reg.GetValueAsUnsigned(), val)
+        self.expect("reg read tp", substrs=[hex(val)])
+
+    def test_tls_reg_write(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// Set breakpoint here.", lldb.SBFileSpec("main.c")
+        )
+        self.expect(
+            "register write tpidruro 0x1234",
+            error=True,
+            substrs=["Failed to write register 'tpidruro'"],
+        )

--- a/lldb/test/API/linux/arm/tls_register/main.c
+++ b/lldb/test/API/linux/arm/tls_register/main.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+
+int main(int argc, char *argv[]) {
+  uint32_t tpidruro = 0;
+  __asm__ volatile("mrc p15, 0, %0, c13, c0, 3" : "=r"(tpidruro));
+  return 0; // Set breakpoint here.
+}

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -213,6 +213,10 @@ Changes to LLDB
 * The crashed thread is now automatically selected on start.
 * Threads are listed in incrmental order by pid then by tid.
 
+### Linux
+
+* On Arm Linux, the tpidruro register can now be read. Writing to this register is not supported.
+
 Changes to BOLT
 ---------------
 


### PR DESCRIPTION
This implements reading the TPIDRURO register, which serves as the thread pointer register on ARM Linux. Note that the register is not displayed for core files because it is not included in the dump.