### PR TITLE
[Maintainers] Fix broken clang link (NFC)

### DIFF
--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -501,7 +501,7 @@ Some subprojects maintain their own list of per-component maintainers.
 
 [BOLT maintainers](https://github.com/llvm/llvm-project/blob/main/bolt/Maintainers.md)
 
-[Clang maintainers](https://github.com/llvm/llvm-project/blob/main/clang/Maintainers.rst)
+[Clang maintainers](https://github.com/llvm/llvm-project/blob/main/clang/Maintainers.md)
 
 [Clang-tools-extra maintainers](https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/Maintainers.rst)
 


### PR DESCRIPTION
Was recently converted to .md (44f248499616).