### PR TITLE
[llvm] Delete `codegen-plugin-loading.ll` test

### DIFF
--- a/llvm/test/Other/codegen-plugin-loading.ll
+++ b/llvm/test/Other/codegen-plugin-loading.ll
@@ -1,7 +1,0 @@
-; RUN: llc -load %llvmshlibdir/CGTestPlugin%pluginext %s -o - | FileCheck %s
-; REQUIRES: native, system-linux, llvm-dylib
-
-; CHECK: CodeGen Test Pass running on main
-define void @main() {
-  ret void
-}


### PR DESCRIPTION
It tested the `-load` command line argument that was removed in commit 6fdbcf68ba.