### PR TITLE
[AMDGPU] AMDGPUIGroupLP: Avoid repeating reachability checks in greedy algorithm

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -755,7 +755,10 @@ void PipelineSolver::greedyFind(
 
   if (BestGroupID != -1) {
     BestGroup->add(*CurrSU.first);
-    AddedEdges.splice(AddedEdges.end(), BestEdges);
+    if (AddedEdges.empty())
+      AddedEdges = BestEdges;
+    else
+      AddedEdges.splice(std::prev(AddedEdges.cend()), BestEdges);
     std::for_each(BestEdges.begin(), BestEdges.end(),
                   [this](std::pair<SUnit *, SUnit *> E) {
                     if (!tryAddEdge(DAG, E.first, E.second))

--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -115,12 +115,10 @@ public:
 
 using SUnitsToCandidateSGsMap = DenseMap<SUnit *, SmallVector<int, 4>>;
 
-namespace {
 /// Try to add and edge from SU \p A to SU \p B to the \p DAG.
-bool tryAddEdge(ScheduleDAGInstrs *DAG, SUnit *A, SUnit *B) {
+static bool tryAddEdge(ScheduleDAGInstrs *DAG, SUnit *A, SUnit *B) {
   return A != B && DAG->addEdge(B, SDep(A, SDep::Artificial));
 }
-} // namespace
 
 // Classify instructions into groups to enable fine tuned control over the
 // scheduler. These groups may be more specific than current SchedModel
@@ -761,8 +759,8 @@ void PipelineSolver::greedyFind(
 
     for (auto &E : BestEdges) {
       AddedEdges.push_back(E);
-      [[maybe_unused]] bool Added = tryAddEdge(DAG, E.first, E.second);
-      assert(Added && "Edges known to be insertable.");
+      if (!tryAddEdge(DAG, E.first, E.second))
+        llvm_unreachable("Edges known to be insertable.");
     }
 
     LLVM_DEBUG(dbgs() << "Best Group has ID: " << BestGroupID << " and Mask"

--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -115,11 +115,6 @@ public:
 
 using SUnitsToCandidateSGsMap = DenseMap<SUnit *, SmallVector<int, 4>>;
 
-/// Try to add and edge from SU \p A to SU \p B to the \p DAG.
-static bool tryAddEdge(ScheduleDAGInstrs *DAG, SUnit *A, SUnit *B) {
-  return A != B && DAG->addEdge(B, SDep(A, SDep::Artificial));
-}
-
 // Classify instructions into groups to enable fine tuned control over the
 // scheduler. These groups may be more specific than current SchedModel
 // instruction classes.
@@ -146,9 +141,6 @@ private:
   // Count of the number of created SchedGroups, used to initialize SGID.
   static unsigned NumSchedGroups;
 
-  // Try to add and edge from SU A to SU B.
-  bool tryAddEdge(SUnit *A, SUnit *B);
-
   // Use SGMask to determine whether we can classify MI as a member of this
   // SchedGroup object.
   bool canAddMI(const MachineInstr &MI) const;
@@ -159,6 +151,9 @@ public:
 
   ScheduleDAGInstrs *DAG;
   const SIInstrInfo *TII;
+
+  // Try to add and edge from SU A to SU B.
+  bool tryAddEdge(SUnit *A, SUnit *B);
 
   // Returns true if SU can be added to this SchedGroup.
   bool canAddSU(SUnit &SU) const;
@@ -746,8 +741,6 @@ void PipelineSolver::greedyFind(
 
       if (BestNodeCost == 0)
         break;
-
-      removeEdges(BestEdges);
     }
 
     removeEdges(TempEdges);
@@ -760,8 +753,8 @@ void PipelineSolver::greedyFind(
     else
       AddedEdges.splice(std::prev(AddedEdges.cend()), BestEdges);
     std::for_each(BestEdges.begin(), BestEdges.end(),
-                  [this](std::pair<SUnit *, SUnit *> E) {
-                    if (!tryAddEdge(DAG, E.first, E.second))
+                  [BestGroup](std::pair<SUnit *, SUnit *> E) {
+                    if (!BestGroup->tryAddEdge(E.first, E.second))
                       llvm_unreachable("Edges known to be insertable.");
                   });
 
@@ -2402,7 +2395,7 @@ public:
 unsigned SchedGroup::NumSchedGroups = 0;
 
 bool SchedGroup::tryAddEdge(SUnit *A, SUnit *B) {
-  return ::tryAddEdge(DAG, A, B);
+  return A != B && DAG->addEdge(B, SDep(A, SDep::Artificial));
 }
 
 bool SchedGroup::canAddMI(const MachineInstr &MI) const {

--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -752,11 +752,11 @@ void PipelineSolver::greedyFind(
       AddedEdges = BestEdges;
     else
       AddedEdges.splice(std::prev(AddedEdges.cend()), BestEdges);
-    std::for_each(BestEdges.begin(), BestEdges.end(),
-                  [BestGroup](std::pair<SUnit *, SUnit *> E) {
-                    if (!BestGroup->tryAddEdge(E.first, E.second))
-                      llvm_unreachable("Edges known to be insertable.");
-                  });
+
+    for (const std::pair<SUnit *, SUnit *> &E : BestEdges) {
+      if (!BestGroup->tryAddEdge(E.first, E.second))
+        llvm_unreachable("Edges known to be insertable.");
+    }
 
     LLVM_DEBUG(dbgs() << "Best Group has ID: " << BestGroupID << " and Mask"
                       << (int)BestGroup->getMask() << "\n");


### PR DESCRIPTION
In the greedy pipeline solver, the group cost is found using the addEdges function and the edges must be removed from the DAG after processing each group. The best group edges are then re-inserted using the same function. This repeats the costly reachability checks inside the function which become problematic for pipelines with many SchedGroups.

The algorithm is changed to remember the best group edges instead of recomputing them.  Additionally, SchedGroup::tryAddEdge is refactored to avoid a redundant cycle check which is already performed by DAG->addEdge.