### PR TITLE
[CIR] Handle Type::OverflowBehavior in CIRGenItaniumCXXABI

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -67,6 +67,7 @@ cir::TypeEvaluationKind CIRGenFunction::getEvaluationKind(QualType type) {
     case Type::ObjCObjectPointer:
     case Type::Pipe:
     case Type::BitInt:
+    case Type::OverflowBehavior:
     case Type::HLSLAttributedResource:
     case Type::HLSLInlineSpirv:
       return cir::TEK_Scalar;
@@ -1372,6 +1373,7 @@ void CIRGenFunction::emitVariablyModifiedType(QualType type) {
     case Type::ObjCInterface:
     case Type::ObjCObjectPointer:
     case Type::BitInt:
+    case Type::OverflowBehavior:
       llvm_unreachable("type class is never variably-modified!");
 
     case Type::Adjusted:

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -960,6 +960,7 @@ const char *vTableClassNameForType(const CIRGenModule &cgm, const Type *ty) {
 
   case Type::Builtin:
   case Type::BitInt:
+  case Type::OverflowBehavior:
   // GCC treats vector and complex types as fundamental types.
   case Type::Vector:
   case Type::ExtVector:
@@ -1386,6 +1387,9 @@ mlir::Attribute CIRGenItaniumRTTIBuilder::buildTypeInfo(
     break;
 
   case Type::BitInt:
+    break;
+
+  case Type::OverflowBehavior:
     break;
 
   case Type::ConstantArray:


### PR DESCRIPTION
This PR adds OverflowBehavior  case to CIRGenItaniumCXXABI. 
Fixes CI failures in clangIR introduced by https://github.com/llvm/llvm-project/pull/148914

Failure:
/home/gha/actions-runner/_work/llvm-project/llvm-project/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp:938:11: error: enumeration value 'OverflowBehavior' not handled in switch [-Werror,-Wswitch]
938 |   switch (ty->getTypeClass()) {
|           ^~~~~~~~~~~~~~~~~~
/home/gha/actions-runner/_work/llvm-project/llvm-project/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp:1357:11: error: enumeration value 'OverflowBehavior' not handled in switch [-Werror,-Wswitch]
1357 |   switch (ty->getTypeClass()) {