### PR TITLE
[openmp] Allow testing OpenMP without a full clang build tree

### DIFF
--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -41,20 +41,26 @@ else()
       "Path where built OpenMP libraries should be installed.")
 endif()
 
+set(OPENMP_TEST_C_COMPILER_default "${LLVM_TOOLS_BINARY_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}")
+set(OPENMP_TEST_CXX_COMPILER_default "${LLVM_TOOLS_BINARY_DIR}/clang++${CMAKE_EXECUTABLE_SUFFIX}")
+set(OPENMP_TEST_Fortran_COMPILER_default "${LLVM_TOOLS_BINARY_DIR}/flang${CMAKE_EXECUTABLE_SUFFIX}")
 if (NOT TARGET "clang")
-  set(OPENMP_TEST_C_COMPILER ${CMAKE_C_COMPILER} CACHE STRING
-    "C compiler to use for testing OpenMP runtime libraries.")
-  set(OPENMP_TEST_CXX_COMPILER ${CMAKE_CXX_COMPILER} CACHE STRING
-    "C++ compiler to use for testing OpenMP runtime libraries.")
-else()
-  if (NOT MSVC)
-    set(OPENMP_TEST_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
-    set(OPENMP_TEST_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++)
+  set(OPENMP_TEST_C_COMPILER_default "${CMAKE_C_COMPILER}")
+  set(OPENMP_TEST_CXX_COMPILER_default "${CMAKE_CXX_COMPILER}")
+endif()
+if (NOT TARGET "flang")
+  if (CMAKE_Fortran_COMPILER)
+    set(OPENMP_TEST_Fortran_COMPILER_default "${CMAKE_Fortran_COMPILER}")
   else()
-    set(OPENMP_TEST_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang.exe)
-    set(OPENMP_TEST_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++.exe)
+    unset(OPENMP_TEST_Fortran_COMPILER_default)
   endif()
 endif()
+set(OPENMP_TEST_C_COMPILER "${OPENMP_TEST_C_COMPILER_default}" CACHE STRING
+  "C compiler to use for testing OpenMP runtime libraries.")
+set(OPENMP_TEST_CXX_COMPILER "${OPENMP_TEST_CXX_COMPILER_default}" CACHE STRING
+  "C++ compiler to use for testing OpenMP runtime libraries.")
+set(OPENMP_TEST_Fortran_COMPILER "${OPENMP_TEST_Fortran_COMPILER_default}" CACHE STRING
+  "Fortran compiler to use for testing OpenMP runtime libraries.")
 
 # Set fortran test compiler if flang is found
 if (EXISTS "${OPENMP_TEST_Fortran_COMPILER}")
@@ -91,14 +97,6 @@ math(EXPR LIBOMP_VERSION_BUILD_MONTH_DAY "${LIBOMP_VERSION_BUILD}%10000")
 # Currently don't record any timestamps
 set(LIBOMP_BUILD_DATE "No_Timestamp")
 
-
-# Check for flang
-set(OPENMP_TEST_Fortran_COMPILER_default "")
-if (CMAKE_Fortran_COMPILER)
-  set(OPENMP_TEST_Fortran_COMPILER_default "${CMAKE_Fortran_COMPILER}")
-endif ()
-set(OPENMP_TEST_Fortran_COMPILER "${OPENMP_TEST_Fortran_COMPILER_default}" CACHE STRING
-  "Fortran compiler to use for testing OpenMP runtime libraries.")
 
 set(LIBOMP_FORTRAN_MODULES FALSE CACHE BOOL
   "Create Fortran module files? (requires fortran compiler)")

--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -41,12 +41,19 @@ else()
       "Path where built OpenMP libraries should be installed.")
 endif()
 
-if (NOT MSVC)
-  set(OPENMP_TEST_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
-  set(OPENMP_TEST_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++)
+if (NOT TARGET "clang")
+  set(OPENMP_TEST_C_COMPILER ${CMAKE_C_COMPILER} CACHE STRING
+    "C compiler to use for testing OpenMP runtime libraries.")
+  set(OPENMP_TEST_CXX_COMPILER ${CMAKE_CXX_COMPILER} CACHE STRING
+    "C++ compiler to use for testing OpenMP runtime libraries.")
 else()
-  set(OPENMP_TEST_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang.exe)
-  set(OPENMP_TEST_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++.exe)
+  if (NOT MSVC)
+    set(OPENMP_TEST_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
+    set(OPENMP_TEST_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++)
+  else()
+    set(OPENMP_TEST_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang.exe)
+    set(OPENMP_TEST_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++.exe)
+  endif()
 endif()
 
 # Set fortran test compiler if flang is found

--- a/openmp/cmake/OpenMPTesting.cmake
+++ b/openmp/cmake/OpenMPTesting.cmake
@@ -127,19 +127,23 @@ function(add_openmp_testsuite target comment)
     set_property(GLOBAL APPEND PROPERTY OPENMP_LIT_DEPENDS ${ARG_DEPENDS})
   endif()
 
+  set(CLANG_DEPEND)
+  if (TARGET "clang")
+    set(CLANG_DEPEND clang)
+  endif()
   if (ARG_EXCLUDE_FROM_CHECK_ALL)
     add_lit_testsuite(${target}
       ${comment}
       ${ARG_UNPARSED_ARGUMENTS}
       EXCLUDE_FROM_CHECK_ALL
-      DEPENDS clang FileCheck not ${ARG_DEPENDS}
+      DEPENDS ${CLANG_DEPEND} FileCheck not ${ARG_DEPENDS}
       ARGS ${ARG_ARGS}
     )
   else()
     add_lit_testsuite(${target}
       ${comment}
       ${ARG_UNPARSED_ARGUMENTS}
-      DEPENDS clang FileCheck not ${ARG_DEPENDS}
+      DEPENDS ${CLANG_DEPEND} FileCheck not ${ARG_DEPENDS}
       ARGS ${ARG_ARGS}
     )
   endif()

--- a/openmp/cmake/OpenMPTesting.cmake
+++ b/openmp/cmake/OpenMPTesting.cmake
@@ -127,23 +127,23 @@ function(add_openmp_testsuite target comment)
     set_property(GLOBAL APPEND PROPERTY OPENMP_LIT_DEPENDS ${ARG_DEPENDS})
   endif()
 
-  set(CLANG_DEPEND)
+  unset(EXTRA_CHECK_DEPENDS)
   if (TARGET "clang")
-    set(CLANG_DEPEND clang)
+    list(APPEND EXTRA_CHECK_DEPENDS clang)
   endif()
   if (ARG_EXCLUDE_FROM_CHECK_ALL)
     add_lit_testsuite(${target}
       ${comment}
       ${ARG_UNPARSED_ARGUMENTS}
       EXCLUDE_FROM_CHECK_ALL
-      DEPENDS ${CLANG_DEPEND} FileCheck not ${ARG_DEPENDS}
+      DEPENDS ${EXTRA_CHECK_DEPENDS} FileCheck not ${ARG_DEPENDS}
       ARGS ${ARG_ARGS}
     )
   else()
     add_lit_testsuite(${target}
       ${comment}
       ${ARG_UNPARSED_ARGUMENTS}
-      DEPENDS ${CLANG_DEPEND} FileCheck not ${ARG_DEPENDS}
+      DEPENDS ${EXTRA_CHECK_DEPENDS} FileCheck not ${ARG_DEPENDS}
       ARGS ${ARG_ARGS}
     )
   endif()

--- a/openmp/cmake/OpenMPTesting.cmake
+++ b/openmp/cmake/OpenMPTesting.cmake
@@ -127,7 +127,7 @@ function(add_openmp_testsuite target comment)
     set_property(GLOBAL APPEND PROPERTY OPENMP_LIT_DEPENDS ${ARG_DEPENDS})
   endif()
 
-  unset(EXTRA_CHECK_DEPENDS)
+  set(EXTRA_CHECK_DEPENDS "")
   if (TARGET "clang")
     list(APPEND EXTRA_CHECK_DEPENDS clang)
   endif()

--- a/openmp/docs/Building.md
+++ b/openmp/docs/Building.md
@@ -136,8 +136,8 @@ is expected to have been built from the same Git commit as OpenMP. It will,
 however, use the compiler detected by CMake, usually gcc.
 To also make it use Clang, add
 `-DCMAKE_C_COMPILER=../build/bin/clang -DCMAKE_C_COMPILER=../build/bin/clang++`.
-In any case, it will use Clang from `LLVM_BINARY_DIR` for running the regression
-tests. `LLVM_BINARY_DIR` can also be omitted in which case testing
+It will use Clang from `LLVM_BINARY_DIR` for running the regression tests, if Clang is included in that build.
+`LLVM_BINARY_DIR` can also be omitted in which case testing
 (`ninja check-openmp`) is disabled.
 
 The `CMAKE_INSTALL_PREFIX` can be the same, but does not need to. Using the same

--- a/openmp/docs/Building.md
+++ b/openmp/docs/Building.md
@@ -269,6 +269,14 @@ tests.
 : Location, relative to [`CMAKE_INSTALL_PREFIX`][CMAKE_INSTALL_PREFIX], where to
 install the OpenMP libraries (`.a` and `.so`)
 
+**OPENMP_TEST_C_COMPILER**:STRING (default: Clang built in the same build configuration, or **CMAKE_C_COMPILER**)
+: C compiler to use for testing OpenMP runtime libraries.
+
+**OPENMP_TEST_CXX_COMPILER**:STRING (default: Clang built in the same build configuration, or **CMAKE_CXX_COMPILER**)
+: C++ compiler to use for testing OpenMP runtime libraries.
+
+**OPENMP_TEST_Fortran_COMPILER**:STRING (default: Flang built in the same build configuration, or **CMAKE_Fortran_COMPILER**)
+: Fortran compiler to use for testing OpenMP runtime libraries.
 
 ### Options for `libomp`
 

--- a/openmp/docs/Building.md
+++ b/openmp/docs/Building.md
@@ -136,7 +136,7 @@ is expected to have been built from the same Git commit as OpenMP. It will,
 however, use the compiler detected by CMake, usually gcc.
 To also make it use Clang, add
 `-DCMAKE_C_COMPILER=../build/bin/clang -DCMAKE_C_COMPILER=../build/bin/clang++`.
-It will use Clang from `LLVM_BINARY_DIR` for running the regression tests, if Clang is included in that build.
+Clang/Flang from `LLVM_BINARY_DIR` will be used for testing if available, otherwise `CMAKE_C_COMPILER`/`CMAKE_CXX_COMPILER`/`CMAKE_Fortran_COMPILER`. Tests are also only expected to work with Clang/Flang built from the same Git commit, so `OPENMP_TEST_C_COMPILER`/`OPENMP_TEST_CXX_COMPILER`/`OPENMP_TEST_Fortran_COMPILER` can be used to explicitly set the test compilers.
 `LLVM_BINARY_DIR` can also be omitted in which case testing
 (`ninja check-openmp`) is disabled.
 


### PR DESCRIPTION
Having a build tree with "not" and "FileCheck" is still required, but if Clang isn't configured in that build, run the tests with the same compiler CMake uses. This is how testing worked in the standalone build configurations that now have been removed.