### PR TITLE
[mlir][tosa] Disallow inferable dim in reshape/slice validation

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.h
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.h
@@ -146,6 +146,12 @@ namespace tosa {
 
 bool isa_tosa_shape_type(mlir::Type t);
 
+/// Represents a dimension in the shape of a tensor that can be inferred
+/// based on the other provided dimensions. For example, in a reshape
+/// operation, -1 can be used to indicate a size that is the remainder
+/// of the other dimensions.
+constexpr int64_t kInferableDimSize = -1;
+
 } // namespace tosa
 
 } // namespace mlir

--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -2280,8 +2280,6 @@ LogicalResult tosa::SliceOp::verify() {
       return emitOpError("length of size is not equal to rank of input shape");
   }
 
-  constexpr int64_t kInferableDimSize = -1;
-
   SmallVector<int64_t> startValues;
   tosa::getConstShapeValues(start.getDefiningOp(), startValues);
   if (startValues.size()) {
@@ -2626,9 +2624,10 @@ llvm::LogicalResult tosa::ReshapeOp::verify() {
     return mlir::success();
   }
 
-  int missingDims = llvm::count(shapeValues, -1);
+  int missingDims = llvm::count(shapeValues, kInferableDimSize);
   if (missingDims > 1)
-    return emitOpError() << "expected at most one target dimension to be -1";
+    return emitOpError() << "expected at most one target dimension to be "
+                         << kInferableDimSize;
 
   const auto outputType = dyn_cast<RankedTensorType>(getType());
   if (!outputType)
@@ -2639,11 +2638,12 @@ llvm::LogicalResult tosa::ReshapeOp::verify() {
 
   for (auto [newShapeDim, outputShapeDim] :
        zip(shapeValues, outputType.getShape())) {
-    if (newShapeDim != -1 && newShapeDim != ShapedType::kDynamic &&
+    if (newShapeDim != kInferableDimSize &&
+        newShapeDim != ShapedType::kDynamic &&
         outputShapeDim != ShapedType::kDynamic && newShapeDim != outputShapeDim)
       return emitOpError() << "new shape is inconsistent with result shape";
 
-    if (newShapeDim != ShapedType::kDynamic && newShapeDim < -1)
+    if (newShapeDim != ShapedType::kDynamic && newShapeDim < kInferableDimSize)
       return emitOpError() << "new shape has invalid tensor dimension size "
                            << newShapeDim;
   }

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaValidation.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaValidation.cpp
@@ -1220,15 +1220,16 @@ LogicalResult checkErrorIfReshape(Operation *op) {
   if (!reshapeOp)
     return success();
 
-  constexpr int64_t kInferableDim = -1;
   SmallVector<int64_t> shapeValues;
   if (!tosa::getConstShapeValues(reshapeOp.getShape().getDefiningOp(),
                                  shapeValues))
     return success();
 
-  if (llvm::is_contained(shapeValues, kInferableDim))
-    return op->emitOpError("shape input contains inferable dimension (-1) "
-                           "which does not conform to the TOSA specification");
+  if (llvm::is_contained(shapeValues, kInferableDimSize))
+    return op->emitOpError("shape input contains inferable dimension (")
+           << kInferableDimSize
+           << ") "
+              "which does not conform to the TOSA specification";
 
   return success();
 }
@@ -1238,7 +1239,6 @@ LogicalResult checkErrorIfSlice(Operation *op) {
   if (!sliceOp)
     return success();
 
-  constexpr int64_t kInferableDim = -1;
   SmallVector<int64_t> startValues;
   SmallVector<int64_t> sizeValues;
   const bool hasStartValues = tosa::getConstShapeValues(
@@ -1246,12 +1246,15 @@ LogicalResult checkErrorIfSlice(Operation *op) {
   const bool hasSizeValues =
       tosa::getConstShapeValues(sliceOp.getSize().getDefiningOp(), sizeValues);
 
-  if (hasStartValues && llvm::is_contained(startValues, kInferableDim))
-    return op->emitOpError("start input contains inferable dimension (-1) "
-                           "which does not conform to the TOSA specification");
-  if (hasSizeValues && llvm::is_contained(sizeValues, kInferableDim))
-    return op->emitOpError("size input contains inferable dimension (-1) which "
-                           "does not conform to the TOSA specification");
+  if (hasStartValues && llvm::is_contained(startValues, kInferableDimSize))
+    return op->emitOpError("start input contains inferable dimension (")
+           << kInferableDimSize
+           << ") which does not conform to the TOSA specification";
+  if (hasSizeValues && llvm::is_contained(sizeValues, kInferableDimSize))
+    return op->emitOpError("size input contains inferable dimension (")
+           << kInferableDimSize
+           << ") which "
+              "does not conform to the TOSA specification";
 
   return success();
 }

--- a/mlir/test/Dialect/Tosa/error_if_check.mlir
+++ b/mlir/test/Dialect/Tosa/error_if_check.mlir
@@ -86,6 +86,38 @@ func.func @test_resize_invalid_boarder_x(%arg0: tensor<1x8x8x8xf32>) -> tensor<?
 
 // -----
 
+// CHECK-LABEL: test_reshape_inferable_dim
+func.func @test_reshape_inferable_dim(%arg0: tensor<4xf32>) -> tensor<?x2xf32> {
+  %shape = tosa.const_shape { values = dense<[-1, 2]> : tensor<2xindex> } : () -> !tosa.shape<2>
+  // expected-error@+1 {{'tosa.reshape' op shape input contains inferable dimension (-1) which does not conform to the TOSA specification}}
+  %0 = tosa.reshape %arg0, %shape : (tensor<4xf32>, !tosa.shape<2>) -> tensor<?x2xf32>
+  return %0 : tensor<?x2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_slice_inferable_start
+func.func @test_slice_inferable_start(%arg0: tensor<4x4xf32>) -> tensor<2x2xf32> {
+  %start = tosa.const_shape { values = dense<[-1, 1]> : tensor<2xindex> } : () -> !tosa.shape<2>
+  %size = tosa.const_shape { values = dense<[2, 2]> : tensor<2xindex> } : () -> !tosa.shape<2>
+  // expected-error@+1 {{'tosa.slice' op start input contains inferable dimension (-1) which does not conform to the TOSA specification}}
+  %0 = tosa.slice %arg0, %start, %size : (tensor<4x4xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<2x2xf32>
+  return %0 : tensor<2x2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_slice_inferable_size
+func.func @test_slice_inferable_size(%arg0: tensor<4x4xf32>) -> tensor<?x2xf32> {
+  %start = tosa.const_shape { values = dense<[0, 1]> : tensor<2xindex> } : () -> !tosa.shape<2>
+  %size = tosa.const_shape { values = dense<[-1, 2]> : tensor<2xindex> } : () -> !tosa.shape<2>
+  // expected-error@+1 {{'tosa.slice' op size input contains inferable dimension (-1) which does not conform to the TOSA specification}}
+  %0 = tosa.slice %arg0, %start, %size : (tensor<4x4xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<?x2xf32>
+  return %0 : tensor<?x2xf32>
+}
+
+// -----
+
 // CHECK-LABEL: test_mul_negative_shift
 func.func @test_mul_negative_shift(%arg0: tensor<1x8x8x8xi32>, %arg1: tensor<1x8x8x8xi32>) -> tensor<1x8x8x8xi32> {
   %shift = "tosa.const" () { values = dense<-1> : tensor<1xi8> } : () -> tensor<1xi8>


### PR DESCRIPTION
This commit ensures that the validation pass checks for the presence of inferable dimensions (represented by -1) in reshape and slice operations. These are not compliant with the TOSA specification. If such dimensions are found, an error message is emitted indicating that they do not conform to the TOSA specification.