### PR TITLE
[Clang][OpenMP] Fix crash with captured pointer-to-VLA in outlined regions

### DIFF
--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -860,6 +860,24 @@ llvm::Function *CodeGenFunction::GenerateOpenMPCapturedStmtFunction(
   (void)LocalScope.Privatize();
   for (const auto &VLASizePair : WrapperVLASizes)
     VLASizeMap[VLASizePair.second.first] = VLASizePair.second.second;
+
+  for (const CapturedStmt::Capture &Cap : S.captures()) {
+    if (!Cap.capturesVariable())
+      continue;
+
+    const VarDecl *VD = Cap.getCapturedVar();
+    QualType Ty = VD->getType();
+
+    if (Ty->isReferenceType())
+      Ty = Ty->getPointeeType();
+
+    if (const PointerType *PT = Ty->getAs<PointerType>()) {
+      QualType PointeeTy = PT->getPointeeType();
+      if (PointeeTy->isVariablyModifiedType())
+        EmitVariablyModifiedType(PointeeTy);
+    }
+  }
+
   PGO->assignRegionCounters(GlobalDecl(CD), F);
   CapturedStmtInfo->EmitBody(*this, CD->getBody());
   LocalScope.ForceCleanup();

--- a/clang/test/OpenMP/parallel-pointer-to-vla-auto-ref.cpp
+++ b/clang/test/OpenMP/parallel-pointer-to-vla-auto-ref.cpp
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -std=c++20 -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -fopenmp -std=c++20 -emit-llvm %s -o %t.ll
+
+void bar(int N, int (*arr_)[N][N]) {
+  auto &ref = arr_;  // reference to pointer-to-VLA
+  #pragma omp parallel for
+  for (int i = 0; i < N; ++i)
+    (*ref)[i][i] = 1;
+}
+
+// Direct VLA capture.
+void direct_vla(int N) {
+  int arr[N];
+
+  #pragma omp parallel for
+  for (int i = 0; i < N; ++i)
+    arr[i] = i;
+}
+
+// Lvalue reference to VLA.
+void lvalue_ref_vla(int N, int (&arr)[N]) {
+  auto &ref = arr;
+
+  #pragma omp parallel for
+  for (int i = 0; i < N; ++i)
+    ref[i] = i;
+}
+
+// Rvalue reference to VLA.
+void rvalue_ref_vla(int N, int (&&arr)[N]) {
+  auto &&ref = arr;
+
+  #pragma omp parallel for
+  for (int i = 0; i < N; ++i)
+    ref[i] = i;
+}
+
+// Pointer to 2D VLA.
+void ptr_to_2d_vla(int N, int M, int (*p)[N][M]) {
+  auto &ref = p;
+
+  #pragma omp parallel for
+  for (int i = 0; i < N; ++i)
+    (*ref)[i][i % M] = i;
+}
+

--- a/clang/test/OpenMP/parallel-pointer-to-vla-auto.c
+++ b/clang/test/OpenMP/parallel-pointer-to-vla-auto.c
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -std=c23 -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -fopenmp -std=c23 -emit-llvm %s -o %t.ll
+
+// Case 1: C23 auto
+void foo1(int N, int (*arr_)[N][N]) {
+  auto arr = arr_;
+  #pragma omp parallel for
+  for (int n = 0; n < N; ++n)
+    (*arr)[n][n] = 1;
+}
+
+// Case 2: GNU __auto_type
+void foo2(int N, int (*arr_)[N][N]) {
+  __auto_type arr = arr_;
+  #pragma omp parallel for
+  for (int n = 0; n < N; ++n)
+    (*arr)[n][n] = 1;
+}
+
+// Case 3: auto with explicit cast
+void foo3(int N, int (*arr_)[N][N]) {
+  auto arr = (int (*)[N][N])arr_;
+  #pragma omp parallel for
+  for (int n = 0; n < N; ++n)
+    (*arr)[n][n] = 1;
+}


### PR DESCRIPTION
Ensure VLA size expressions are emitted for captured pointer-to-VLA variables (including reference cases) before outlining. Previously this could trigger an assertion in getVLASize() during code generation.

Add regression tests for C23 auto, __auto_type, explicit casts, and C++ reference cases.

Fixes #177608