### PR TITLE
[Clang][Sema] Fix crash in containsUnexpandedParameterPacks

### DIFF
--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -1215,12 +1215,13 @@ bool Sema::containsUnexpandedParameterPacks(Declarator &D) {
       break;
     case DeclaratorChunk::Function:
       for (unsigned i = 0, e = Chunk.Fun.NumParams; i != e; ++i) {
-        ParmVarDecl *Param = cast<ParmVarDecl>(Chunk.Fun.Params[i].Param);
+        auto *Param = dyn_cast_or_null<ParmVarDecl>(Chunk.Fun.Params[i].Param);
+        if (!Param)
+          continue;
         QualType ParamTy = Param->getType();
-        assert(!ParamTy.isNull() && "Couldn't parse type?");
-        if (ParamTy->containsUnexpandedParameterPack()) return true;
+        if (!ParamTy.isNull() && ParamTy->containsUnexpandedParameterPack())
+          return true;
       }
-
       if (Chunk.Fun.getExceptionSpecType() == EST_Dynamic) {
         for (unsigned i = 0; i != Chunk.Fun.getNumExceptions(); ++i) {
           if (Chunk.Fun.Exceptions[i]

--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -1215,7 +1215,8 @@ bool Sema::containsUnexpandedParameterPacks(Declarator &D) {
       break;
     case DeclaratorChunk::Function:
       for (unsigned i = 0, e = Chunk.Fun.NumParams; i != e; ++i) {
-        ParmVarDecl *Param = cast_or_null<ParmVarDecl>(Chunk.Fun.Params[i].Param);
+        ParmVarDecl *Param =
+            cast_or_null<ParmVarDecl>(Chunk.Fun.Params[i].Param);
         if (!Param)
           continue;
         QualType ParamTy = Param->getType();

--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -1215,7 +1215,7 @@ bool Sema::containsUnexpandedParameterPacks(Declarator &D) {
       break;
     case DeclaratorChunk::Function:
       for (unsigned i = 0, e = Chunk.Fun.NumParams; i != e; ++i) {
-        auto *Param = dyn_cast_or_null<ParmVarDecl>(Chunk.Fun.Params[i].Param);
+        ParmVarDecl *Param = cast_or_null<ParmVarDecl>(Chunk.Fun.Params[i].Param);
         if (!Param)
           continue;
         QualType ParamTy = Param->getType();

--- a/clang/test/Sema/function.c
+++ b/clang/test/Sema/function.c
@@ -118,3 +118,11 @@ void const Bar (void); // ok on decl
 void const Bar (void) // expected-warning {{function cannot return qualified void type 'const void'}}
 {
 }
+
+// issue 182154
+int gh182154_g(int);
+int gh182154_h(int);
+int gh182154_x = 0;
+gh182154_g(gh182154_h(gh182154_x)...); // expected-error 2{{type specifier missing, defaults to 'int'}} \
+                                       // expected-error {{a parameter list without types is only allowed in a function definition}} \
+                                       // expected-error {{requires a comma prior to the ellipsis}}

--- a/clang/test/Sema/function.c
+++ b/clang/test/Sema/function.c
@@ -119,7 +119,7 @@ void const Bar (void) // expected-warning {{function cannot return qualified voi
 {
 }
 
-// issue 182154
+// PR #182484
 int gh182154_g(int);
 int gh182154_h(int);
 int gh182154_x = 0;


### PR DESCRIPTION
what this PR does : -

Prevent a crash in containsUnexpandedParameterPacks when parsing K&R-style identifier-list function declarators during error recovery.
Add a null-safe guard so invalid ellipsis constructs produce diagnostics instead of crashing.

Fixes #182154