### PR TITLE
Re-enable MSVC C4204 diagnostic; NFC

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -754,7 +754,6 @@ if (MSVC)
       -wd4703 # Suppress 'potentially uninitialized local pointer variable'
       -wd4389 # Suppress 'signed/unsigned mismatch'
       -wd4805 # Suppress 'unsafe mix of type <type> and type <type> in operation'
-      -wd4204 # Suppress 'nonstandard extension used : non-constant aggregate initializer'
       -wd4577 # Suppress 'noexcept used with no exception handling mode specified; termination on exception is not guaranteed'
       -wd4091 # Suppress 'typedef: ignored on left of '' when no variable is declared'
           # C4592 is disabled because of false positives in Visual Studio 2015


### PR DESCRIPTION
From MSDN:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4204?view=msvc-170

> nonstandard extension used : non-constant aggregate initializer

This is an ANSI compatibility diagnostic which isn't useful for us to disable. In my local testing, this diagnostic is not emitted.