### PR TITLE
[compiler-rt][Fuzzer] Relax reduce_inputs.test to account for non-determinism

### DIFF
--- a/compiler-rt/test/fuzzer/reduce_inputs.test
+++ b/compiler-rt/test/fuzzer/reduce_inputs.test
@@ -7,9 +7,10 @@ RUN: %cpp_compiler %S/ShrinkControlFlowTest.cpp -o %t-ShrinkControlFlowTest
 RUN: %run %t-ShrinkControlFlowSimpleTest  -exit_on_item=0eb8e4ed029b774d80f2b66408203801cb982a60   -runs=10000000 %t/C 2>&1 | FileCheck %s
 CHECK: INFO: found item with checksum '0eb8e4ed029b774d80f2b66408203801cb982a60'
 
-# Test that reduce_inputs deletes redundant files in the corpus.
+# Test that reduce_inputs deletes redundant files in the corpus (note reduce_inputs=1 by default).
 RUN: %run %t-ShrinkControlFlowSimpleTest -runs=0 %t/C 2>&1 | FileCheck %s --check-prefix=COUNT
-COUNT: seed corpus: files: 4
+# Allow 3 or 4 - sometimes the fuzzer gets lucky and gets straight from "F." to "FUZ", skipping "FU"
+COUNT: seed corpus: files: {{3|4}}
 
 # a bit longer test
 RUN: %run %t-ShrinkControlFlowTest  -exit_on_item=0eb8e4ed029b774d80f2b66408203801cb982a60  -seed=42 -runs=10000000  2>&1 | FileCheck %s


### PR DESCRIPTION
I have seen that very occasionally this test is failing on a bot, with only 3 files in the corpus. After running the test in a loop 4000+ times, I witnessed this same failure twice.

In both cases the first corpus member was some string not containing a 'F'; the second corpus member was 'F[' or 'FZ'; and the final corpus member 'FUZ'.

In a normal run there is an intermediate corpus member 'FU.' - so this test is failing in very rare cases where the fuzzer gets lucky and matches 2 branch conditions in one mutation.

This patch allows the FileCheck condition to match 3 or 4 corpus files. It may be possible for the fuzzer to reach the target in 2 files, but I think that if that is possible, it will be exceptionally rare.

rdar://170440934