### PR TITLE
Re-enable MSVC C4091 diagnostic; NFC

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -754,7 +754,6 @@ if (MSVC)
       -wd4805 # Suppress 'unsafe mix of type <type> and type <type> in operation'
       -wd4204 # Suppress 'nonstandard extension used : non-constant aggregate initializer'
       -wd4577 # Suppress 'noexcept used with no exception handling mode specified; termination on exception is not guaranteed'
-      -wd4091 # Suppress 'typedef: ignored on left of '' when no variable is declared'
           # C4592 is disabled because of false positives in Visual Studio 2015
           # Update 1. Re-evaluate the usefulness of this diagnostic with Update 2.
       -wd4592 # Suppress ''var': symbol will be dynamically initialized (implementation limitation)


### PR DESCRIPTION
From MSDN:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4091?view=msvc-170

> 'keyword': ignored on left of 'type' when no variable is declared

This diagnostic was disabled in 0cba642a05ad0675f313e55fce29ce5273340a59 because the diagnostic was being hit in system headers under MSVC 2015. That no longer appears to be the case from my local testing; this diagnostic does not appear to be emitted.