### PR TITLE
[flang][nfc] fix typo in fir.declare_value description

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3490,7 +3490,7 @@ def fir_DeclareValueOp
     relatively to the operation using the value of the variable,
     this means that the when a mem2reg variable was assigned several
     values, the variable value printed in the debugger at a given code
-    point main not be the actual value the variable had at that code point
+    point may not be the actual value the variable had at that code point
     if instructions using the value were moved above the fir.declare_value.
   }];
 


### PR DESCRIPTION
Fix typo from https://github.com/llvm/llvm-project/pull/181848#discussion_r2832803471

Thanks for the review of the previous PR @abidh. 