### PR TITLE
[flang-rt] Add sysroot to test

### DIFF
--- a/flang-rt/test/Driver/exec.f90
+++ b/flang-rt/test/Driver/exec.f90
@@ -2,7 +2,7 @@
 
 ! Verify that flang can correctly build executables.
 
-! RUN: %flang -L"%libdir" %s -o %t
+! RUN: %flang %isysroot -L"%libdir" %s -o %t
 ! RUN: env LD_LIBRARY_PATH="$LD_LIBRARY_PATH:%libdir" %t | FileCheck %s
 
 ! CHECK: Hello, World!


### PR DESCRIPTION
This fixes the test on MacOS. Without this change the SDK sysroot is not set and so the library path is incorrect and the 'System' library cannot be found.

Test with https://github.com/llvm/llvm-project/pull/182501 so that the sysroot variable is correctly set.

Assisted-by: Codex