### PR TITLE
[AArch64][PAC] Don't skip global legalization for AUTH_TCRETURN

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -10494,7 +10494,7 @@ AArch64TargetLowering::LowerCall(CallLoweringInfo &CLI,
     if (OpFlags & AArch64II::MO_GOT) {
       Callee = DAG.getTargetGlobalAddress(CalledGlobal, DL, PtrVT, 0, OpFlags);
       Callee = DAG.getNode(AArch64ISD::LOADgot, DL, PtrVT, Callee);
-    } else {
+    } else if (!CLI.PAI || !IsTailCall) {
       const GlobalValue *GV = G->getGlobal();
       Callee = DAG.getTargetGlobalAddress(GV, DL, PtrVT, 0, OpFlags);
     }

--- a/llvm/test/CodeGen/AArch64/ptrauth-tail-call-global.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-tail-call-global.ll
@@ -1,0 +1,16 @@
+; RUN: llc --mattr=+pauth -filetype=asm < %s | FileCheck %s
+
+; CHECK:         adrp    x0, :got:global
+; CHECK-NEXT:    ldr     x0, [x0, :got_lo12:global]
+; CHECK-NEXT:    braaz   x0
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-pauthtest"
+
+@global = global ptr null
+
+define dso_local void @foo() local_unnamed_addr {
+entry:
+  tail call void @global() [ "ptrauth"(i32 0, i64 0) ]
+  ret void
+}


### PR DESCRIPTION
The 77bcab835aca1 folds llvm.ptrauth.resign intrinsic in case intrinsic discriminant and key match those in call ptrauth bundle. However assertion is now fired in AArch64AsmPrinter when PAC is enabled and we're tail calling a global, because AUTH_TCRETURN expects address to be stored in register.