### PR TITLE
Re-enable MSVC C4709 diagnostic; NFC

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -757,10 +757,6 @@ if (MSVC)
           # Update 1. Re-evaluate the usefulness of this diagnostic with Update 2.
       -wd4592 # Suppress ''var': symbol will be dynamically initialized (implementation limitation)
       -wd4319 # Suppress ''operator' : zero extending 'type' to 'type' of greater size'
-          # C4709 is disabled because of a bug with Visual Studio 2017 as of
-          # v15.8.8. Re-evaluate the usefulness of this diagnostic when the bug
-          # is fixed.
-      -wd4709 # Suppress comma operator within array index expression
 
       # We'd like this warning to be enabled, but it triggers from code in
       # WinBase.h that we don't have control over.


### PR DESCRIPTION
From MSDN:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4709?view=msvc-170

> comma operator within array index expression

This is a useful diagnostic to have enabled in general. It was disabled in 02e1f1915f94413a64efd295fa3dc63d40046fcf because of false positives, but those appear to have been resolved. Enabling the diagnostic locally does not emit any diagnostics.