### PR TITLE
[CMake][MSVC] Add /Zi to release flags

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -626,7 +626,14 @@ if( MSVC )
   # PDBs without changing codegen.
   option(LLVM_ENABLE_PDB OFF)
   if (LLVM_ENABLE_PDB AND uppercase_CMAKE_BUILD_TYPE STREQUAL "RELEASE")
-    append("/Zi" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    # Add /Zi to CMAKE_*_FLAGS_RELEASE instead of CMAKE_*_FLAGS, because CMake
+    # runs additional logic when PCH are enabled, but only extracts flags from
+    # these variables. See:
+    # https://gitlab.kitware.com/cmake/cmake/-/blob/315042dfd0d/Source/cmLocalGenerator.cxx#L2811-2813
+    #
+    # For CMake 3.25+, this should change according to:
+    # https://cmake.org/cmake/help/latest/policy/CMP0141.html
+    append("/Zi" CMAKE_C_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELEASE)
     # /DEBUG disables linker GC and ICF, but we want those in Release mode.
     append("/DEBUG /OPT:REF /OPT:ICF"
           CMAKE_EXE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS


### PR DESCRIPTION
Try to fix MSVC error C2859, which complains about an outdated PDB file. CMake appears to copy the PDB file for this reason, but it only looks in one specific place for the /Zi flag.