### PR TITLE
[AMDGPU] Make .amdhsa_next_free_sgpr optional for GFX10+

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -6344,7 +6344,7 @@ bool AMDGPUAsmParser::ParseDirectiveAMDHSAKernel() {
   if (!Seen.contains(".amdhsa_next_free_vgpr"))
     return TokError(".amdhsa_next_free_vgpr directive is required");
 
-  if (!Seen.contains(".amdhsa_next_free_sgpr"))
+  if (!isGFX10Plus() && !Seen.contains(".amdhsa_next_free_sgpr"))
     return TokError(".amdhsa_next_free_sgpr directive is required");
 
   unsigned UserSGPRCount = ExplicitUserSGPRCount.value_or(ImpliedUserSGPRCount);

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -497,9 +497,11 @@ void AMDGPUTargetAsmStreamer::EmitAmdhsaKernelDescriptor(
   EmitMCExpr(NextVGPR);
   OS << '\n';
 
-  OS << "\t\t.amdhsa_next_free_sgpr ";
-  EmitMCExpr(NextSGPR);
-  OS << '\n';
+  if (!AMDGPU::isGFX10Plus(STI)) {
+    OS << "\t\t.amdhsa_next_free_sgpr ";
+    EmitMCExpr(NextSGPR);
+    OS << '\n';
+  }
 
   if (AMDGPU::isGFX90A(STI)) {
     // MCExpr equivalent of taking the (accum_offset + 1) * 4.

--- a/llvm/test/CodeGen/AMDGPU/large-alloca-compute.ll
+++ b/llvm/test/CodeGen/AMDGPU/large-alloca-compute.ll
@@ -39,7 +39,6 @@
 ; GCNHSA:         .amdhsa_system_sgpr_workgroup_info 0
 ; GCNHSA:         .amdhsa_system_vgpr_workitem_id 2
 ; GCNHSA:         .amdhsa_next_free_vgpr {{2|3}}
-; GCNHSA:         .amdhsa_next_free_sgpr 18
 ; GCNHSA:         .amdhsa_float_round_mode_32 0
 ; GCNHSA:         .amdhsa_float_round_mode_16_64 0
 ; GCNHSA:         .amdhsa_float_denorm_mode_32 3

--- a/llvm/test/MC/AMDGPU/hsa-diag-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-diag-v4.s
@@ -70,7 +70,8 @@
 .end_amdhsa_kernel
 
 // GCN-LABEL: warning: test_amdhsa_next_free_sgpr_missing
-// AMDHSA: error: .amdhsa_next_free_sgpr directive is required
+// PREGFX10: error: .amdhsa_next_free_sgpr directive is required
+// GFX10PLUS-NOT: error: .amdhsa_next_free_sgpr directive is required
 // NONAMDHSA: error: unknown directive
 .warning "test_amdhsa_next_free_sgpr_missing"
 .amdhsa_kernel test_amdhsa_next_free_sgpr_missing

--- a/llvm/test/MC/AMDGPU/hsa-gfx12-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx12-v4.s
@@ -87,7 +87,7 @@ disabled_user_sgpr:
 
 // ASM: .amdhsa_kernel minimal
 // ASM: .amdhsa_next_free_vgpr 0
-// ASM-NEXT: .amdhsa_next_free_sgpr 0
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM: .end_amdhsa_kernel
 
 // Test that we can specify all available directives with non-default values.
@@ -149,7 +149,7 @@ disabled_user_sgpr:
 // ASM-NEXT: .amdhsa_system_sgpr_workgroup_info 1
 // ASM-NEXT: .amdhsa_system_vgpr_workitem_id 1
 // ASM-NEXT: .amdhsa_next_free_vgpr 9
-// ASM-NEXT: .amdhsa_next_free_sgpr 27
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM-NEXT: .amdhsa_reserve_vcc 0
 // ASM-NEXT: .amdhsa_float_round_mode_32 1
 // ASM-NEXT: .amdhsa_float_round_mode_16_64 1
@@ -183,7 +183,7 @@ disabled_user_sgpr:
 
 // ASM: .amdhsa_kernel special_sgpr
 // ASM: .amdhsa_next_free_vgpr 0
-// ASM-NEXT: .amdhsa_next_free_sgpr 27
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM-NEXT: .amdhsa_reserve_vcc 0
 // ASM: .amdhsa_float_denorm_mode_16_64 0
 // ASM: .end_amdhsa_kernel
@@ -198,7 +198,7 @@ disabled_user_sgpr:
 
 // ASM: .amdhsa_kernel disabled_user_sgpr
 // ASM: .amdhsa_next_free_vgpr 0
-// ASM-NEXT: .amdhsa_next_free_sgpr 0
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM: .end_amdhsa_kernel
 
 .section .foo

--- a/llvm/test/MC/AMDGPU/hsa-gfx1250-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx1250-v4.s
@@ -110,7 +110,7 @@ max_vgprs:
 
 // ASM: .amdhsa_kernel minimal
 // ASM: .amdhsa_next_free_vgpr 0
-// ASM-NEXT: .amdhsa_next_free_sgpr 0
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM: .end_amdhsa_kernel
 
 // Test that we can specify all available directives with non-default values.
@@ -175,8 +175,8 @@ max_vgprs:
 // ASM-NEXT: .amdhsa_system_sgpr_workgroup_info 1
 // ASM-NEXT: .amdhsa_system_vgpr_workitem_id 1
 // ASM-NEXT: .amdhsa_next_free_vgpr 9
-// ASM-NEXT: .amdhsa_next_free_sgpr 32
-// ASM-NEXT: .amdhsa_named_barrier_count 3
+// ASM-NOT: .amdhsa_next_free_sgpr
+// ASM: .amdhsa_named_barrier_count 3
 // ASM-NEXT: .amdhsa_reserve_vcc 0
 // ASM-NEXT: .amdhsa_reserve_xnack_mask 1
 // ASM-NEXT: .amdhsa_float_round_mode_32 1
@@ -210,8 +210,8 @@ max_vgprs:
 
 // ASM: .amdhsa_kernel special_sgpr
 // ASM: .amdhsa_next_free_vgpr 0
-// ASM-NEXT: .amdhsa_next_free_sgpr 27
-// ASM-NEXT: .amdhsa_named_barrier_count 0
+// ASM-NOT: .amdhsa_next_free_sgpr
+// ASM: .amdhsa_named_barrier_count 0
 // ASM-NEXT: .amdhsa_reserve_vcc 0
 // ASM: .amdhsa_float_denorm_mode_16_64 0
 // ASM: .end_amdhsa_kernel
@@ -226,7 +226,7 @@ max_vgprs:
 
 // ASM: .amdhsa_kernel disabled_user_sgpr
 // ASM: .amdhsa_next_free_vgpr 0
-// ASM-NEXT: .amdhsa_next_free_sgpr 0
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM: .end_amdhsa_kernel
 
 .p2align 6

--- a/llvm/test/MC/AMDGPU/hsa-gfx1251-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx1251-v4.s
@@ -110,7 +110,7 @@ max_vgprs:
 
 // ASM: .amdhsa_kernel minimal
 // ASM: .amdhsa_next_free_vgpr 0
-// ASM-NEXT: .amdhsa_next_free_sgpr 0
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM: .end_amdhsa_kernel
 
 // Test that we can specify all available directives with non-default values.
@@ -175,8 +175,8 @@ max_vgprs:
 // ASM-NEXT: .amdhsa_system_sgpr_workgroup_info 1
 // ASM-NEXT: .amdhsa_system_vgpr_workitem_id 1
 // ASM-NEXT: .amdhsa_next_free_vgpr 9
-// ASM-NEXT: .amdhsa_next_free_sgpr 32
-// ASM-NEXT: .amdhsa_named_barrier_count 3
+// ASM-NOT: .amdhsa_next_free_sgpr
+// ASM: .amdhsa_named_barrier_count 3
 // ASM-NEXT: .amdhsa_reserve_vcc 0
 // ASM-NEXT: .amdhsa_reserve_xnack_mask 1
 // ASM-NEXT: .amdhsa_float_round_mode_32 1
@@ -210,8 +210,8 @@ max_vgprs:
 
 // ASM: .amdhsa_kernel special_sgpr
 // ASM: .amdhsa_next_free_vgpr 0
-// ASM-NEXT: .amdhsa_next_free_sgpr 27
-// ASM-NEXT: .amdhsa_named_barrier_count 0
+// ASM-NOT: .amdhsa_next_free_sgpr
+// ASM: .amdhsa_named_barrier_count 0
 // ASM-NEXT: .amdhsa_reserve_vcc 0
 // ASM: .amdhsa_float_denorm_mode_16_64 0
 // ASM: .end_amdhsa_kernel
@@ -226,7 +226,7 @@ max_vgprs:
 
 // ASM: .amdhsa_kernel disabled_user_sgpr
 // ASM: .amdhsa_next_free_vgpr 0
-// ASM-NEXT: .amdhsa_next_free_sgpr 0
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM: .end_amdhsa_kernel
 
 .p2align 6

--- a/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx10.s
+++ b/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx10.s
@@ -122,7 +122,7 @@ expr_defined:
 // ASM-NEXT: .amdhsa_system_sgpr_workgroup_info (((((((((((((((((((((((((128|(defined_2_bits<<11))&~128)|(defined_boolean<<7))&~256)|(defined_boolean<<8))&~512)|(defined_boolean<<9))&~1024)|(defined_boolean<<10))&~16777216)|(defined_boolean<<24))&~33554432)|(defined_boolean<<25))&~67108864)|(defined_boolean<<26))&~134217728)|(defined_boolean<<27))&~268435456)|(defined_boolean<<28))&~536870912)|(defined_boolean<<29))&~1073741824)|(defined_boolean<<30))&~62)&1024)>>10
 // ASM-NEXT: .amdhsa_system_vgpr_workitem_id (((((((((((((((((((((((((128|(defined_2_bits<<11))&~128)|(defined_boolean<<7))&~256)|(defined_boolean<<8))&~512)|(defined_boolean<<9))&~1024)|(defined_boolean<<10))&~16777216)|(defined_boolean<<24))&~33554432)|(defined_boolean<<25))&~67108864)|(defined_boolean<<26))&~134217728)|(defined_boolean<<27))&~268435456)|(defined_boolean<<28))&~536870912)|(defined_boolean<<29))&~1073741824)|(defined_boolean<<30))&~62)&6144)>>11
 // ASM-NEXT: .amdhsa_next_free_vgpr defined_value+4
-// ASM-NEXT: .amdhsa_next_free_sgpr defined_value+5
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM-NEXT: .amdhsa_reserve_vcc defined_boolean
 // ASM-NEXT: .amdhsa_reserve_flat_scratch defined_boolean
 // ASM-NEXT: .amdhsa_reserve_xnack_mask 1
@@ -173,7 +173,7 @@ expr_defined:
 // ASM-NEXT: .amdhsa_system_sgpr_workgroup_info 1
 // ASM-NEXT: .amdhsa_system_vgpr_workitem_id 3
 // ASM-NEXT: .amdhsa_next_free_vgpr 44
-// ASM-NEXT: .amdhsa_next_free_sgpr 45
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM-NEXT: .amdhsa_reserve_vcc 1
 // ASM-NEXT: .amdhsa_reserve_flat_scratch 1
 // ASM-NEXT: .amdhsa_reserve_xnack_mask 1

--- a/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx11.s
+++ b/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx11.s
@@ -120,7 +120,7 @@ expr_defined:
 // ASM-NEXT: .amdhsa_system_sgpr_workgroup_info (((((((((((((((((((((((((((128|(defined_2_bits<<11))&~128)|(defined_boolean<<7))&~256)|(defined_boolean<<8))&~512)|(defined_boolean<<9))&~1024)|(defined_boolean<<10))&~16777216)|(defined_boolean<<24))&~33554432)|(defined_boolean<<25))&~67108864)|(defined_boolean<<26))&~134217728)|(defined_boolean<<27))&~268435456)|(defined_boolean<<28))&~536870912)|(defined_boolean<<29))&~1073741824)|(defined_boolean<<30))&~1)|defined_boolean)&~62)&1024)>>10
 // ASM-NEXT: .amdhsa_system_vgpr_workitem_id (((((((((((((((((((((((((((128|(defined_2_bits<<11))&~128)|(defined_boolean<<7))&~256)|(defined_boolean<<8))&~512)|(defined_boolean<<9))&~1024)|(defined_boolean<<10))&~16777216)|(defined_boolean<<24))&~33554432)|(defined_boolean<<25))&~67108864)|(defined_boolean<<26))&~134217728)|(defined_boolean<<27))&~268435456)|(defined_boolean<<28))&~536870912)|(defined_boolean<<29))&~1073741824)|(defined_boolean<<30))&~1)|defined_boolean)&~62)&6144)>>11
 // ASM-NEXT: .amdhsa_next_free_vgpr defined_value+4
-// ASM-NEXT: .amdhsa_next_free_sgpr defined_value+5
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM-NEXT: .amdhsa_reserve_vcc defined_boolean
 // ASM-NEXT: .amdhsa_float_round_mode_32 (((((((((((((((((((3769368576|(defined_2_bits<<12))&~49152)|(defined_2_bits<<14))&~196608)|(defined_2_bits<<16))&~786432)|(defined_2_bits<<18))&~67108864)|(defined_boolean<<26))&~536870912)|(defined_boolean<<29))&~1073741824)|(defined_boolean<<30))&~2147483648)|(defined_boolean<<31))&~63)|((alignto(max(defined_value+4, 1), 8)/8)-1))&~960)&12288)>>12
 // ASM-NEXT: .amdhsa_float_round_mode_16_64 (((((((((((((((((((3769368576|(defined_2_bits<<12))&~49152)|(defined_2_bits<<14))&~196608)|(defined_2_bits<<16))&~786432)|(defined_2_bits<<18))&~67108864)|(defined_boolean<<26))&~536870912)|(defined_boolean<<29))&~1073741824)|(defined_boolean<<30))&~2147483648)|(defined_boolean<<31))&~63)|((alignto(max(defined_value+4, 1), 8)/8)-1))&~960)&49152)>>14
@@ -168,7 +168,7 @@ expr_defined:
 // ASM-NEXT: .amdhsa_system_sgpr_workgroup_info 1
 // ASM-NEXT: .amdhsa_system_vgpr_workitem_id 3
 // ASM-NEXT: .amdhsa_next_free_vgpr 44
-// ASM-NEXT: .amdhsa_next_free_sgpr 45
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM-NEXT: .amdhsa_reserve_vcc 1
 // ASM-NEXT: .amdhsa_float_round_mode_32 3
 // ASM-NEXT: .amdhsa_float_round_mode_16_64 3

--- a/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx12.s
+++ b/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx12.s
@@ -124,7 +124,7 @@ expr_defined:
 // ASM-NEXT: .amdhsa_system_sgpr_workgroup_info (((((((((((((((((((((((((((128|(defined_2_bits<<11))&~128)|(defined_boolean<<7))&~256)|(defined_boolean<<8))&~512)|(defined_boolean<<9))&~1024)|(defined_boolean<<10))&~16777216)|(defined_boolean<<24))&~33554432)|(defined_boolean<<25))&~67108864)|(defined_boolean<<26))&~134217728)|(defined_boolean<<27))&~268435456)|(defined_boolean<<28))&~536870912)|(defined_boolean<<29))&~1073741824)|(defined_boolean<<30))&~1)|defined_boolean)&~62)&1024)>>10
 // ASM-NEXT: .amdhsa_system_vgpr_workitem_id (((((((((((((((((((((((((((128|(defined_2_bits<<11))&~128)|(defined_boolean<<7))&~256)|(defined_boolean<<8))&~512)|(defined_boolean<<9))&~1024)|(defined_boolean<<10))&~16777216)|(defined_boolean<<24))&~33554432)|(defined_boolean<<25))&~67108864)|(defined_boolean<<26))&~134217728)|(defined_boolean<<27))&~268435456)|(defined_boolean<<28))&~536870912)|(defined_boolean<<29))&~1073741824)|(defined_boolean<<30))&~1)|defined_boolean)&~62)&6144)>>11
 // ASM-NEXT: .amdhsa_next_free_vgpr defined_value+4
-// ASM-NEXT: .amdhsa_next_free_sgpr defined_value+5
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM-NEXT: .amdhsa_reserve_vcc defined_boolean
 // ASM-NEXT: .amdhsa_float_round_mode_32 (((((((((((((((((((((3758882816|(defined_2_bits<<12))&~49152)|(defined_2_bits<<14))&~196608)|(defined_2_bits<<16))&~786432)|(defined_2_bits<<18))&~67108864)|(defined_boolean<<26))&~536870912)|(defined_boolean<<29))&~1073741824)|(defined_boolean<<30))&~2147483648)|(defined_boolean<<31))&~2097152)|(defined_boolean<<21))&~63)|((alignto(max(defined_value+4, 1), 8)/8)-1))&~960)&12288)>>12
 // ASM-NEXT: .amdhsa_float_round_mode_16_64 (((((((((((((((((((((3758882816|(defined_2_bits<<12))&~49152)|(defined_2_bits<<14))&~196608)|(defined_2_bits<<16))&~786432)|(defined_2_bits<<18))&~67108864)|(defined_boolean<<26))&~536870912)|(defined_boolean<<29))&~1073741824)|(defined_boolean<<30))&~2147483648)|(defined_boolean<<31))&~2097152)|(defined_boolean<<21))&~63)|((alignto(max(defined_value+4, 1), 8)/8)-1))&~960)&49152)>>14
@@ -170,7 +170,7 @@ expr_defined:
 // ASM-NEXT: .amdhsa_system_sgpr_workgroup_info 1
 // ASM-NEXT: .amdhsa_system_vgpr_workitem_id 3
 // ASM-NEXT: .amdhsa_next_free_vgpr 44
-// ASM-NEXT: .amdhsa_next_free_sgpr 45
+// ASM-NOT: .amdhsa_next_free_sgpr
 // ASM-NEXT: .amdhsa_reserve_vcc 1
 // ASM-NEXT: .amdhsa_float_round_mode_32 3
 // ASM-NEXT: .amdhsa_float_round_mode_16_64 3


### PR DESCRIPTION
`GRANULATED_WAVEFRONT_SGPR_COUNT` in `COMPUTE_PGM_RSRC1` is reserved (must be 0) on GFX10+. Make the directive optional: the parser no longer requires it, and the streamer no longer emits it.