### PR TITLE
Re-enable MSVC C5105 diagnostic; NFC

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -769,10 +769,6 @@ if (MSVC)
           # is fixed.
       -wd4709 # Suppress comma operator within array index expression
 
-      # We'd like this warning to be enabled, but it triggers from code in
-      # WinBase.h that we don't have control over.
-      -wd5105 # Suppress macro expansion producing 'defined' has undefined behavior
-
       # Ideally, we'd like this warning to be enabled, but even MSVC 2019 doesn't
       # support the 'aligned' attribute in the way that clang sources requires (for
       # any code that uses the LLVM_ALIGNAS macro), so this is must be disabled to


### PR DESCRIPTION
From MSDN:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5105?view=msvc-170

> macro expansion producing 'defined' has undefined behavior

This diagnostic was disabled in 9a708855daeb6f70bbde7c2bc63e061ebaf072df due to it triggering in system headers like WinBase.h. From my local testing, the issue seems to have either been resolved in the system headers or in MSVC, because enabling the warning does not trigger any diagnostics for me.