### PR TITLE
[clang-tidy][NFC] Work around vfs bug in tests

### DIFF
--- a/clang-tools-extra/test/clang-tidy/infrastructure/Inputs/custom-query-check/vfsoverlay.yaml
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/Inputs/custom-query-check/vfsoverlay.yaml
@@ -6,19 +6,19 @@ roots:
       - name: .clang-tidy
         type: file
         external-contents: INPUT_DIR/root-clang-tidy.yml
-      - name: main.cpp
+      - name: cqc-main.cpp
         type: file
         external-contents: MAIN_FILE
       - name: subdir
         type: directory
         contents:
-          - name: main.cpp
+          - name: cqc-main.cpp
             type: file
             external-contents: MAIN_FILE
       - name: subdir-override
         type: directory
         contents:
-          - name: main.cpp
+          - name: cqc-main.cpp
             type: file
             external-contents: MAIN_FILE
           - name: .clang-tidy
@@ -27,7 +27,7 @@ roots:
       - name: subdir-empty
         type: directory
         contents:
-          - name: main.cpp
+          - name: cqc-main.cpp
             type: file
             external-contents: MAIN_FILE
           - name: .clang-tidy
@@ -36,7 +36,7 @@ roots:
       - name: subdir-append
         type: directory
         contents:
-          - name: main.cpp
+          - name: cqc-main.cpp
             type: file
             external-contents: MAIN_FILE
           - name: .clang-tidy

--- a/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
@@ -2,14 +2,16 @@
 // UNSUPPORTED: system-windows
 // REQUIRES: custom-check
 
+// Using cqc-main.cpp in the hope that we don't have a file with that name in
+// our source tree. See: https://github.com/llvm/llvm-project/issues/182526
 // RUN: sed -e "s:INPUT_DIR:%S/Inputs/custom-query-check:g" -e "s:OUT_DIR:%t:g" -e "s:MAIN_FILE:%s:g" %S/Inputs/custom-query-check/vfsoverlay.yaml > %t.yaml
-// RUN: clang-tidy --experimental-custom-checks %t/main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK-SAME-DIR
-// RUN: clang-tidy --experimental-custom-checks %t/subdir/main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK-SUB-DIR-BASE
-// RUN: clang-tidy --experimental-custom-checks %t/subdir-override/main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK-SUB-DIR-OVERRIDE
-// RUN: clang-tidy --experimental-custom-checks %t/subdir-empty/main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml --allow-no-checks | FileCheck %s --check-prefix=CHECK-SUB-DIR-EMPTY
-// RUN: clang-tidy --experimental-custom-checks %t/subdir-append/main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK-SUB-DIR-APPEND
-// RUN: clang-tidy --experimental-custom-checks %t/subdir-append/main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml --list-checks | FileCheck %s --check-prefix=LIST-CHECK
-// RUN: clang-tidy --experimental-custom-checks %t/subdir-append/main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml --dump-config | FileCheck %s --check-prefix=DUMP-CONFIG
+// RUN: clang-tidy --experimental-custom-checks %t/cqc-main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK-SAME-DIR
+// RUN: clang-tidy --experimental-custom-checks %t/subdir/cqc-main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK-SUB-DIR-BASE
+// RUN: clang-tidy --experimental-custom-checks %t/subdir-override/cqc-main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK-SUB-DIR-OVERRIDE
+// RUN: clang-tidy --experimental-custom-checks %t/subdir-empty/cqc-main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml --allow-no-checks | FileCheck %s --check-prefix=CHECK-SUB-DIR-EMPTY
+// RUN: clang-tidy --experimental-custom-checks %t/subdir-append/cqc-main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK-SUB-DIR-APPEND
+// RUN: clang-tidy --experimental-custom-checks %t/subdir-append/cqc-main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml --list-checks | FileCheck %s --check-prefix=LIST-CHECK
+// RUN: clang-tidy --experimental-custom-checks %t/subdir-append/cqc-main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml --dump-config | FileCheck %s --check-prefix=DUMP-CONFIG
 
 
 long V;


### PR DESCRIPTION
Work around #182526 after #176420 by renaming virtual file from main.cpp (which sometimes collides with a file in our build tree) to cqc-main.cpp (which is hopefully unique).