### PR TITLE
[TableGen] Add a mode for compact register/sub-register names

### DIFF
--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -2065,6 +2065,15 @@ class Target {
   // This enables interval-based representation of register units, which can
   // improve data structure representations in target backends.
   bit RegistersAreIntervals = false;
+
+  // Generate compact names for synthesized registers and sub-register indices
+  // instead of just concatenating the names of individual components.
+  // Specifically instead of generating:
+  //
+  // prefix<K>_prefix<K+S>_prefix<K+2S>...prefix<N>, we will generate
+  // prefix<K>_to_<N>_by_<S>, where [K,N] is a closed range and S is the stride.
+  // The stride will be omitted if its 1.
+  bit CompactRegisterNames = false;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/TableGen/RegisterInfoEmitter-compact-names.td
+++ b/llvm/test/TableGen/RegisterInfoEmitter-compact-names.td
@@ -1,0 +1,91 @@
+// RUN: llvm-tblgen -gen-register-info -I %p/../../include -I %p/Common %s | FileCheck %s
+
+include "llvm/Target/Target.td"
+
+class MyClass<int size, list<ValueType> types, dag registers>
+  : RegisterClass<"MyTarget", types, size, registers> {
+  let Size = size;
+}
+
+class Indexes<int N> {
+  list<int> all = [0,  1,  2,  3];
+  list<int> slice =
+    !foldl([]<int>, all, acc, cur,
+           !listconcat(acc, !if(!lt(cur, N), [cur], [])));
+}
+
+foreach Index = 0-3 in {
+  def sub#Index : SubRegIndex<32, !shl(Index, 5)>;
+}
+
+let Namespace = "MyTarget" in {
+  foreach Index = 0-15 in {
+    // Adding two cost values per register.
+    let CostPerUse = [Index, !shl(Index, 1)] in {
+      def S#Index : Register <"s"#Index>;
+    }
+  }
+} // Namespace = "MyTarget"
+
+def GPR32 : MyClass<32,  [i32], (sequence "S%u", 0, 15)>;
+
+def GPR64 : RegisterTuples<[sub0, sub1],
+                           [(decimate (shl GPR32, 0), 1),
+                            (decimate (shl GPR32, 1), 1)
+                           ]>;
+
+def GPR96 : RegisterTuples<[sub0, sub1, sub2],
+                           [(decimate (shl GPR32, 0), 1),
+                            (decimate (shl GPR32, 1), 1),
+                            (decimate (shl GPR32, 2), 1)
+                           ]>;
+
+def GPR96_Alt : RegisterTuples<[sub0, sub1, sub2],
+                           [(decimate (shl GPR32, 0), 1),
+                            (decimate (shl GPR32, 1), 1),
+                            (decimate (shl GPR32, 3), 1)
+                           ]>;
+
+def GPR128 : RegisterTuples<[sub0, sub1, sub2, sub3],
+                            [
+                             (decimate (shl GPR32, 0), 1),
+                             (decimate (shl GPR32, 1), 1),
+                             (decimate (shl GPR32, 2), 1),
+                             (decimate (shl GPR32, 3), 1)
+                            ]>;
+
+def GPR128_Evens : RegisterTuples<[sub0, sub1, sub2, sub3],
+                            [
+                             (decimate (shl GPR32, 0), 1),
+                             (decimate (shl GPR32, 2), 1),
+                             (decimate (shl GPR32, 4), 1),
+                             (decimate (shl GPR32, 6), 1)
+                            ]>;
+
+
+def GPR_64 : MyClass<64, [v2i32], (add GPR64)>;
+def GPR_96: MyClass<64, [v3i32], (add GPR96)>;
+def GPR_96_Alt: MyClass<64, [v3i32], (add GPR96_Alt)>;
+def GPR_128 : MyClass<128, [v4i32], (add GPR128)>;
+def GPR_128_Evens : MyClass<128, [v4i32], (add GPR128_Evens)>;
+
+
+def MyTarget : Target {
+  let CompactRegisterNames = true;
+}
+
+// CHECK-LABEL: NoRegister
+// CHECK: S0_to_1
+// CHECK: S1_to_2
+// CHECK: S0_S1_S3
+// CHECK: S1_S2_S4
+// CHECK: S0_to_3
+// CHECK: S1_to_4
+// CHECK: S0_to_6_by_2
+// CHECK: S1_to_7_by_2
+
+// CHECK-LABEL: NoSubRegister
+// CHECK: sub0_to_1
+// CHECK: sub0_sub1_sub3
+// CHECK: sub1_to_2
+// CHECK: sub2_to_3

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -548,13 +548,10 @@ static std::string getNameFromParts(ArrayRef<StringRef> Parts,
     StringRef First = Parts[0];
     StringRef Second = Parts[1];
 
-    // Find the first non-digit from the end. Note that the first character of
-    // each part is a non-digit, so `Index` will never underflow.
-    uint64_t Index = Parts[0].size() - 1;
-    for (; isDigit(First[Index]); --Index)
-      ;
-
-    if (Index == First.size() - 1)
+    // Find the first non-digit from the end. If not found or there is no digit
+    // at the end, fall back to regular concatenation.
+    size_t Index = First.rfind_if_not(isDigit);
+    if (Index == First.size() - 1 || Index == StringRef::npos)
       return std::nullopt;
     size_t PrefixSize = Index + 1;
     StringRef Prefix = First.take_front(PrefixSize);
@@ -633,19 +630,18 @@ struct TupleExpander : SetTheory::Expander {
     // Zip them up.
     RecordKeeper &RK = Def->getRecords();
     for (unsigned n = 0; n != Length; ++n) {
-      SmallVector<StringRef> NameParts;
-
-      const Record *Proto = Lists[0][n];
-      std::vector<Init *> Tuple;
+      SmallVector<StringRef> NameParts(Dim);
+      std::vector<Init *> Tuple(Dim);
       for (unsigned i = 0; i != Dim; ++i) {
         const Record *Reg = Lists[i][n];
-        NameParts.push_back(Reg->getName());
-        Tuple.push_back(Reg->getDefInit());
+        NameParts[i] = Reg->getName();
+        Tuple[i] = Reg->getDefInit();
       }
 
       std::string Name = getNameFromParts(NameParts, CompactNames);
 
       // Take the cost list of the first register in the tuple.
+      const Record *Proto = Lists[0][n];
       const ListInit *CostList = Proto->getValueAsListInit("CostPerUse");
       SmallVector<const Init *, 2> CostPerUse(CostList->getElements());
 
@@ -1415,11 +1411,11 @@ CodeGenSubRegIndex *CodeGenRegBank::getConcatSubRegIndex(
     return Idx;
 
   // None exists, synthesize one.
-  SmallVector<StringRef> NameParts;
+  SmallVector<StringRef> NameParts(Parts.size());
   const unsigned UnknownSize = (uint16_t)-1;
 
-  for (const CodeGenSubRegIndex *Part : Parts)
-    NameParts.push_back(Part->getName());
+  for (const auto &[Idx, Part] : enumerate(Parts))
+    NameParts[Idx] = Part->getName();
 
   std::string Name = getNameFromParts(NameParts, CompactRegisterNames);
 

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -23,6 +23,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/Twine.h"
@@ -529,6 +530,64 @@ unsigned CodeGenRegister::getWeight(const CodeGenRegBank &RegBank) const {
 //                               RegisterTuples
 //===----------------------------------------------------------------------===//
 
+static std::string getNameFromParts(ArrayRef<StringRef> Parts,
+                                    bool CompactNames) {
+  auto GetSuffix = [](StringRef Part, StringRef Prefix, uint64_t &Suffix) {
+    if (!Part.starts_with(Prefix))
+      return true;
+    return Part.drop_front(Prefix.size()).getAsInteger(10, Suffix);
+  };
+
+  auto CompactName = [&]() -> std::optional<std::string> {
+    if (Parts.size() < 2 || !CompactNames)
+      return std::nullopt;
+
+    // When joining 2 or more parts, check if we can use the compact form. For
+    // that, piece out the suffix, start, and stride from the first 2 parts, and
+    // then verify all remaining parts conform to that suffix and stride.
+    StringRef First = Parts[0];
+    StringRef Second = Parts[1];
+
+    // Find the first non-digit from the end. Note that the first character of
+    // each part is a non-digit, so `Index` will never underflow.
+    uint64_t Index = Parts[0].size() - 1;
+    for (; isDigit(First[Index]); --Index)
+      ;
+
+    if (Index == First.size() - 1)
+      return std::nullopt;
+    size_t PrefixSize = Index + 1;
+    StringRef Prefix = First.take_front(PrefixSize);
+
+    uint64_t FirstSuffix;
+    if (GetSuffix(First, Prefix, FirstSuffix))
+      return std::nullopt;
+
+    uint64_t NextSuffix;
+    if (GetSuffix(Second, Prefix, NextSuffix) || NextSuffix <= FirstSuffix)
+      return std::nullopt;
+
+    uint64_t Stride = NextSuffix - FirstSuffix;
+
+    Index = 2;
+    for (StringRef Part : Parts.drop_front(2)) {
+      if (GetSuffix(Part, Prefix, NextSuffix))
+        return std::nullopt;
+      if (NextSuffix != FirstSuffix + Index * Stride)
+        return std::nullopt;
+      ++Index;
+    }
+
+    // All checks successful.
+    std::string CompactName = Prefix.str() + std::to_string(FirstSuffix) +
+                              "_to_" + std::to_string(NextSuffix);
+    if (Stride != 1)
+      CompactName += "_by_" + std::to_string(Stride);
+    return CompactName;
+  }();
+  return CompactName ? *CompactName : llvm::join(Parts, "_");
+}
+
 // A RegisterTuples def is used to generate pseudo-registers from lists of
 // sub-registers. We provide a SetTheory expander class that returns the new
 // registers.
@@ -541,9 +600,11 @@ struct TupleExpander : SetTheory::Expander {
 
   // Track all synthesized tuple names in order to detect duplicate definitions.
   llvm::StringSet<> TupleNames;
+  bool CompactNames;
 
-  TupleExpander(std::vector<std::unique_ptr<Record>> &SynthDefs)
-      : SynthDefs(SynthDefs) {}
+  TupleExpander(std::vector<std::unique_ptr<Record>> &SynthDefs,
+                bool CompactNames)
+      : SynthDefs(SynthDefs), CompactNames(CompactNames) {}
 
   void expand(SetTheory &ST, const Record *Def,
               SetTheory::RecSet &Elts) override {
@@ -572,16 +633,17 @@ struct TupleExpander : SetTheory::Expander {
     // Zip them up.
     RecordKeeper &RK = Def->getRecords();
     for (unsigned n = 0; n != Length; ++n) {
-      std::string Name;
+      SmallVector<StringRef> NameParts;
+
       const Record *Proto = Lists[0][n];
       std::vector<Init *> Tuple;
       for (unsigned i = 0; i != Dim; ++i) {
         const Record *Reg = Lists[i][n];
-        if (i)
-          Name += '_';
-        Name += Reg->getName();
+        NameParts.push_back(Reg->getName());
         Tuple.push_back(Reg->getDefInit());
       }
+
+      std::string Name = getNameFromParts(NameParts, CompactNames);
 
       // Take the cost list of the first register in the tuple.
       const ListInit *CostList = Proto->getValueAsListInit("CostPerUse");
@@ -1113,14 +1175,16 @@ CodeGenRegisterCategory::CodeGenRegisterCategory(CodeGenRegBank &RegBank,
 
 CodeGenRegBank::CodeGenRegBank(const RecordKeeper &Records,
                                const CodeGenHwModes &Modes,
-                               const bool RegistersAreIntervals)
+                               bool RegistersAreIntervals,
+                               bool CompactRegisterNames)
     : Records(Records), CGH(Modes),
-      RegistersAreIntervals(RegistersAreIntervals) {
+      RegistersAreIntervals(RegistersAreIntervals),
+      CompactRegisterNames(CompactRegisterNames) {
   // Configure register Sets to understand register classes and tuples.
   Sets.addFieldExpander("RegisterClass", "MemberList");
   Sets.addFieldExpander("CalleeSavedRegs", "SaveList");
-  Sets.addExpander("RegisterTuples",
-                   std::make_unique<TupleExpander>(SynthDefs));
+  Sets.addExpander("RegisterTuples", std::make_unique<TupleExpander>(
+                                         SynthDefs, CompactRegisterNames));
 
   // Read in the user-defined (named) sub-register indices.
   // More indices will be synthesized later.
@@ -1351,13 +1415,13 @@ CodeGenSubRegIndex *CodeGenRegBank::getConcatSubRegIndex(
     return Idx;
 
   // None exists, synthesize one.
-  std::string Name = Parts.front()->getName();
+  SmallVector<StringRef> NameParts;
   const unsigned UnknownSize = (uint16_t)-1;
 
-  for (const CodeGenSubRegIndex *Part : ArrayRef(Parts).drop_front()) {
-    Name += '_';
-    Name += Part->getName();
-  }
+  for (const CodeGenSubRegIndex *Part : Parts)
+    NameParts.push_back(Part->getName());
+
+  std::string Name = getNameFromParts(NameParts, CompactRegisterNames);
 
   Idx = createSubRegIndex(Name, Parts.front()->getNamespace());
   Idx->ConcatenationOf.assign(Parts.begin(), Parts.end());

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.h
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.h
@@ -619,6 +619,7 @@ class CodeGenRegBank {
   const CodeGenHwModes &CGH;
 
   const bool RegistersAreIntervals;
+  const bool CompactRegisterNames;
 
   std::deque<CodeGenSubRegIndex> SubRegIndices;
   DenseMap<const Record *, CodeGenSubRegIndex *> Def2SubRegIdx;
@@ -726,7 +727,7 @@ class CodeGenRegBank {
 
 public:
   CodeGenRegBank(const RecordKeeper &, const CodeGenHwModes &,
-                 const bool RegistersAreIntervals);
+                 bool RegistersAreIntervals, bool CompactRegisterNames);
   CodeGenRegBank(CodeGenRegBank &) = delete;
 
   SetTheory &getSets() { return Sets; }

--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -123,6 +123,10 @@ bool CodeGenTarget::getRegistersAreIntervals() const {
   return TargetRec->getValueAsBit("RegistersAreIntervals");
 }
 
+bool CodeGenTarget::getCompactRegisterNames() const {
+  return TargetRec->getValueAsBit("CompactRegisterNames");
+}
+
 /// getAsmParser - Return the AssemblyParser definition for this target.
 ///
 const Record *CodeGenTarget::getAsmParser() const {
@@ -167,7 +171,8 @@ const Record *CodeGenTarget::getAsmWriter() const {
 CodeGenRegBank &CodeGenTarget::getRegBank() const {
   if (!RegBank)
     RegBank = std::make_unique<CodeGenRegBank>(Records, getHwModes(),
-                                               getRegistersAreIntervals());
+                                               getRegistersAreIntervals(),
+                                               getCompactRegisterNames());
   return *RegBank;
 }
 

--- a/llvm/utils/TableGen/Common/CodeGenTarget.h
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.h
@@ -105,6 +105,9 @@ public:
   ///
   bool getRegistersAreIntervals() const;
 
+  /// Returns the CompactRegisterNames flag value for this target.
+  bool getCompactRegisterNames() const;
+
   /// getAsmParser - Return the AssemblyParser definition for this target.
   ///
   const Record *getAsmParser() const;


### PR DESCRIPTION
Add `CompactRegisterNames` as an opt-in for targets to enable generating compact names for register and sub-register index names synthesized by TableGen. The compact name uses a range and optional stride instead of enumerating all members. This can have various benefits, including smaller MIR prints for physical registers, smaller generated .inc file, and smaller object files as well (since static tables of names will reduce in size).

As an example, for AMDGPU, the AMDGPUGenRegisterInfoEnums.inc went from 1.6M to 636k (2.5x) and AMDGPUGenRegisterInfoMCDesc.inc went from 25M to 16M (as measured by `du -h`).

