### PR TITLE
[lldb][windows] keep track of interrupted reads in ConnectionGenericFile

### DIFF
--- a/lldb/include/lldb/Host/windows/ConnectionGenericFileWindows.h
+++ b/lldb/include/lldb/Host/windows/ConnectionGenericFileWindows.h
@@ -43,6 +43,7 @@ public:
 
 protected:
   OVERLAPPED m_overlapped;
+  bool m_read_pending = false;
   HANDLE m_file;
   HANDLE m_event_handles[2];
   bool m_owns_file;

--- a/lldb/source/Host/windows/ConnectionGenericFileWindows.cpp
+++ b/lldb/source/Host/windows/ConnectionGenericFileWindows.cpp
@@ -186,7 +186,6 @@ size_t ConnectionGenericFile::Read(void *dst, size_t dst_len,
   m_overlapped.hEvent = m_event_handles[kBytesAvailableEvent];
 
   result = ::ReadFile(m_file, dst, dst_len, NULL, &m_overlapped);
-  m_read_pending = true;
   if (result || ::GetLastError() == ERROR_IO_PENDING) {
     if (!result) {
       // The expected return path.  The operation is pending.  Wait for the
@@ -242,8 +241,7 @@ size_t ConnectionGenericFile::Read(void *dst, size_t dst_len,
   goto finish;
 
 finish:
-  if (return_info.GetStatus() != eConnectionStatusInterrupted)
-    m_read_pending = false;
+  m_read_pending = return_info.GetStatus() == eConnectionStatusInterrupted;
   status = return_info.GetStatus();
   if (error_ptr)
     *error_ptr = return_info.GetError().Clone();

--- a/lldb/source/Host/windows/ConnectionGenericFileWindows.cpp
+++ b/lldb/source/Host/windows/ConnectionGenericFileWindows.cpp
@@ -176,9 +176,17 @@ size_t ConnectionGenericFile::Read(void *dst, size_t dst_len,
     goto finish;
   }
 
+  if (m_read_pending) {
+    if (::GetOverlappedResult(m_file, &m_overlapped, &bytes_read, FALSE)) {
+      m_read_pending = false;
+      return bytes_read;
+    }
+  }
+
   m_overlapped.hEvent = m_event_handles[kBytesAvailableEvent];
 
   result = ::ReadFile(m_file, dst, dst_len, NULL, &m_overlapped);
+  m_read_pending = true;
   if (result || ::GetLastError() == ERROR_IO_PENDING) {
     if (!result) {
       // The expected return path.  The operation is pending.  Wait for the
@@ -234,6 +242,8 @@ size_t ConnectionGenericFile::Read(void *dst, size_t dst_len,
   goto finish;
 
 finish:
+  if (return_info.GetStatus() != eConnectionStatusInterrupted)
+    m_read_pending = false;
   status = return_info.GetStatus();
   if (error_ptr)
     *error_ptr = return_info.GetError().Clone();


### PR DESCRIPTION
If a read is interrupted in `ConnectionGenericFile::Read`, the data that has already been read by `ReadFile` is lost.

This patch adds `m_read_pending` to mark a read as interrupted. The next read will pick up the results of the previous read and return the number of `bytes_read`.