### PR TITLE
[AArch64] materialized neon reg with movi

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1465,6 +1465,12 @@ def fpimm16XForm : SDNodeXForm<fpimm, [{
       return CurDAG->getTargetConstant(Enc, SDLoc(N), MVT::i32);
     }]>;
 
+def fpimm16SIMDModImmType5XForm : SDNodeXForm<fpimm, [{
+      uint64_t Enc = N->getValueAPF().bitcastToAPInt().getZExtValue();
+      uint32_t Imm8 = AArch64_AM::encodeFpImm16FittedAdvSIMDModImmType5(Enc);
+      return CurDAG->getTargetConstant(Imm8, SDLoc(N), MVT::i32);
+    }]>;
+
 def fpimm32XForm : SDNodeXForm<fpimm, [{
       uint32_t Enc = AArch64_AM::getFP32Imm(N->getValueAPF());
       return CurDAG->getTargetConstant(Enc, SDLoc(N), MVT::i32);
@@ -1507,6 +1513,14 @@ def fpimm32SIMDModImmType4 : FPImmLeaf<f32, [{
       uint64_t Enc = Imm.bitcastToAPInt().getZExtValue();
       return Enc != 0 && AArch64_AM::isAdvSIMDModImmType4(Enc << 32 | Enc);
     }], fpimm32SIMDModImmType4XForm> {
+}
+
+def fpimm16SIMDModImmType5 : FPImmLeaf<f16, [{
+      uint64_t Enc = Imm.bitcastToAPInt().getZExtValue();
+      if (Enc == 0)
+        return false;
+      return AArch64_AM::isFpImm16FittedAdvSIMDModImmType5(Enc);
+    }], fpimm16SIMDModImmType5XForm> {
 }
 
 def fpimm64 : Operand<f64>,

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -8715,7 +8715,7 @@ let Predicates = [HasNEON] in {
                                        (i32 24)),
                             ssub)>;
 
-  // Using MOVI to materialize select FP16 bit patterns (where one byte is 0).
+  // Using MOVI to materialize select FP16 bit patterns
   def : Pat<(f16 fpimm16SIMDModImmType5:$in),
             (EXTRACT_SUBREG (MOVIv4i16 (fpimm16SIMDModImmType5XForm f16:$in),
                                        (i32 0)),

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -8714,6 +8714,12 @@ let Predicates = [HasNEON] in {
             (EXTRACT_SUBREG (MOVIv2i32 (fpimm32SIMDModImmType4XForm f32:$in),
                                        (i32 24)),
                             ssub)>;
+
+  // Using MOVI to materialize select FP16 bit patterns (where one byte is 0).
+  def : Pat<(f16 fpimm16SIMDModImmType5:$in),
+            (EXTRACT_SUBREG (MOVIv4i16 (fpimm16SIMDModImmType5XForm f16:$in),
+                                       (i32 0)),
+                            hsub)>;
 }
 
 let Predicates = [HasNEON] in {

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AddressingModes.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AddressingModes.h
@@ -523,6 +523,14 @@ static inline uint64_t decodeAdvSIMDModImmType5(uint8_t Imm) {
   return (EncVal << 48) | (EncVal << 32) | (EncVal << 16) | EncVal;
 }
 
+static inline bool isFpImm16FittedAdvSIMDModImmType5(uint16_t Imm) {
+  return (Imm & 0xffULL) == Imm;
+}
+
+static inline uint8_t encodeFpImm16FittedAdvSIMDModImmType5(uint16_t Imm) {
+  return (Imm & 0xffULL);
+}
+
 // abcdefgh 0x00 abcdefgh 0x00 abcdefgh 0x00 abcdefgh 0x00
 static inline bool isAdvSIMDModImmType6(uint64_t Imm) {
   return ((Imm >> 32) == (Imm & 0xffffffffULL)) &&

--- a/llvm/test/CodeGen/AArch64/fp16-movi-imm.ll
+++ b/llvm/test/CodeGen/AArch64/fp16-movi-imm.ll
@@ -1,0 +1,44 @@
+; NOTE: This test checks materialization of select scalar f16 constants via
+; AdvSIMD MOVI, avoiding constant pools when NEON is available.
+;
+; RUN: llc -mtriple=aarch64-unknown-linux-gnu -O3 %s -o - | FileCheck %s --check-prefix=NEON
+; RUN: llc -mtriple=aarch64-unknown-linux-gnu -mattr=-neon -O3 %s -o - | FileCheck %s --check-prefix=NONEON
+
+define half @ret_half_0001() {
+; NEON-LABEL: ret_half_0001:
+; NEON:       movi    v0.4h, #1
+; NEON-NEXT:  ret
+;
+; NONEON-LABEL: ret_half_0001:
+; NONEON:       adrp
+; NONEON:       ldr     h0
+; NONEON-NEXT:  ret
+entry:
+  ret half 0xH0001
+}
+
+define half @ret_half_001f() {
+; NEON-LABEL: ret_half_001f:
+; NEON:       movi    v0.4h, #31
+; NEON-NEXT:  ret
+;
+; NONEON-LABEL: ret_half_001f:
+; NONEON:       adrp
+; NONEON:       ldr     h0
+; NONEON-NEXT:  ret
+entry:
+  ret half 0xH001f
+}
+
+; special case: zero should be materialized specially
+define half @ret_half_0000() {
+; NEON-LABEL: ret_half_0000:
+; NEON:       movi    d0, #0000000000000000
+; NEON-NEXT:  ret
+;
+; NONEON-LABEL: ret_half_0000:
+; NONEON:       fmov    s0, wzr
+; NONEON-NEXT:  ret
+entry:
+  ret half 0xH0000
+}

--- a/llvm/test/CodeGen/AArch64/fp16-movi-imm.ll
+++ b/llvm/test/CodeGen/AArch64/fp16-movi-imm.ll
@@ -1,8 +1,8 @@
 ; NOTE: This test checks materialization of select scalar f16 constants via
 ; AdvSIMD MOVI, avoiding constant pools when NEON is available.
 ;
-; RUN: llc -mtriple=aarch64-unknown-linux-gnu -O3 %s -o - | FileCheck %s --check-prefix=NEON
-; RUN: llc -mtriple=aarch64-unknown-linux-gnu -mattr=-neon -O3 %s -o - | FileCheck %s --check-prefix=NONEON
+; RUN: llc -mtriple=aarch64-unknown-linux-gnu -mattr=+neon,+fullfp16 -O3 %s -o - | FileCheck %s --check-prefix=NEON
+; RUN: llc -mtriple=aarch64-unknown-linux-gnu -mattr=-neon,+fullfp16 -O3 %s -o - | FileCheck %s --check-prefix=NONEON
 
 define half @ret_half_0001() {
 ; NEON-LABEL: ret_half_0001:
@@ -37,7 +37,7 @@ define half @ret_half_0000() {
 ; NEON-NEXT:  ret
 ;
 ; NONEON-LABEL: ret_half_0000:
-; NONEON:       fmov    s0, wzr
+; NONEON:       fmov    h0, wzr
 ; NONEON-NEXT:  ret
 entry:
   ret half 0xH0000


### PR DESCRIPTION
This PR adds support for materializing certain scalar FP16 constants using NEON AdvSIMD MOVI instructions on AArch64 targets. This optimization allows select FP16 immediate values to be loaded directly into registers, instead of using constant pools.

Part of #182427. I don't add all patterns in this PR because I am not so family with td file, If it is fine, I will all the other similar pattern later.