### PR TITLE
[SPIRV] Do not eliminate `OpPointerType` even if unused

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -729,6 +729,12 @@ bool isDead(const MachineInstr &MI, const MachineRegisterInfo &MRI) {
   }
 
   if (isOpcodeWithNoSideEffects(MI.getOpcode())) {
+    // We cannot safely remove an unused type from the MachineFunction.
+    // The types may still be referenced through SPIRVGlobalRegistry.
+    // This is a horrible hack.
+    if (MI.getOpcode() == SPIRV::OpTypePointer)
+      return false;
+
     LLVM_DEBUG(dbgs() << "Dead: known opcode with no side effects\n");
     return true;
   }

--- a/llvm/test/CodeGen/SPIRV/pointers/fun-ptr-to-itself.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/fun-ptr-to-itself.ll
@@ -1,4 +1,3 @@
-; XFAIL: asan
 ; RUN: llc -mtriple=spirv32-unknown-unknown < %s --spirv-ext=+SPV_INTEL_function_pointers | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -mtriple=spirv32-unknown-unknown < %s -filetype=obj | not spirv-val 2>&1 | FileCheck --check-prefix=SPIRV-VAL %s %}
 

--- a/llvm/test/CodeGen/SPIRV/remove-dead-type-intrinsics.ll
+++ b/llvm/test/CodeGen/SPIRV/remove-dead-type-intrinsics.ll
@@ -12,11 +12,19 @@
   %A
 }
 
-; Make sure all struct types are removed.
-; CHECK-NOT: OpTypeStruct
+; The pointer types and the struct types could be removed,
+; but we fail to do so due to issues with `validatePtrTypes` function.
+; CHECK-DAG: %[[#Void:]] = OpTypeVoid
+; CHECK-DAG: %[[#FnTy:]] = OpTypeFunction %[[#Void]]
+; CHECK-DAG: %[[#Int32:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#Int32Ptr:]] = OpTypePointer Function %[[#Int32]]
+; CHECK-DAG: %[[#A:]] = OpTypeStruct %[[#Int32]] %[[#Int32]]
+; CHECK-DAG: %[[#APtr:]] = OpTypePointer Function %[[#A]]
+; CHECK-DAG: %[[#B:]] = OpTypeStruct %[[#A]] %[[#Int32]] %[[#A]]
+; CHECK-DAG: %[[#BPtr:]] = OpTypePointer Function %[[#B]]
 
 ; Make sure the GEPs and the function scope variable are removed.
-; CHECK: OpFunction
+; CHECK: OpFunction %[[#Void]] None %[[#FnTy]]
 ; CHECK-NEXT: OpLabel
 ; CHECK-NEXT: OpReturn
 ; CHECK-NEXT: OpFunctionEnd


### PR DESCRIPTION
Our backend implementation is currently very unpractical.
We keep a dictionary that maps registers to their type.

If the register type and instruction result type do not match,
`validatePtrTypes` will insert bitcasts and fix the situation.

However, when no instruction references the type in the dictionary,
we may remove it. Even if it is needed later.

This patch prevents this from happening for `OpPointerType`.
This is far from a good solution... But it gives us time to:
* reland https://github.com/llvm/llvm-project/pull/178143 and fix
  https://github.com/llvm/llvm-project/issues/170339 which unblocks some
  of the backend's users
* explore a better solution than the hidden inconsistent global state that we currently have

Stacked PRs:
 * #182552
 * __->__#182551
 * #182550
 * #182549