### PR TITLE
[NFC][CodeGen] Add Register guard to ARMMaterializeFP.

### DIFF
--- a/llvm/lib/Target/ARM/ARMFastISel.cpp
+++ b/llvm/lib/Target/ARM/ARMFastISel.cpp
@@ -440,6 +440,9 @@ Register ARMFastISel::ARMMoveToIntReg(MVT VT, Register SrcReg) {
 // (the high and the low) into integer registers then use a move to get
 // the combined constant into an FP reg.
 Register ARMFastISel::ARMMaterializeFP(const ConstantFP *CFP, MVT VT) {
+  if (VT != MVT::f32 && VT != MVT::f64)
+    return Register();
+
   const APFloat Val = CFP->getValueAPF();
   bool is64bit = VT == MVT::f64;
 


### PR DESCRIPTION
This does not directly fix any issue because the implementation indirectly ensures the correct behaviour. However, all the other "<Tgt>Materialize" functions (Int and FP across all targets, including ARMMaterializeInt) have explicit Register guards so for peace of mind I figured it's worth added them.