### PR TITLE
Re-enable MSVC C4706 diagnostic; NFC

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -763,7 +763,6 @@ if (MSVC)
       -wd4510 # Suppress 'default constructor could not be generated'
       -wd4702 # Suppress 'unreachable code'
       -wd4245 # Suppress ''conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch'
-      -wd4706 # Suppress 'assignment within conditional expression'
       -wd4310 # Suppress 'cast truncates constant value'
       -wd4701 # Suppress 'potentially uninitialized local variable'
       -wd4703 # Suppress 'potentially uninitialized local pointer variable'


### PR DESCRIPTION
From MSDN:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4706?view=msvc-170

> assignment used as a condition

This diagnostic was disabled as part of enabling /W4 use in 5c73e1f85c5d37a5b037c70f3c112eec5646acb3 where there were hundreds of instances of the diagnostic being triggered. However, local testing suggests we now are adding the parentheses required to silence the diagnostic, and so I believe this can be enabled again.