### PR TITLE
[lldb] Remove plugin loading callback from Debugger

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -104,7 +104,7 @@ public:
 
   static lldb::TargetSP FindTargetWithProcess(Process *process);
 
-  static void Initialize(LoadPluginCallbackType load_plugin_callback);
+  static void Initialize();
 
   static void Terminate();
 
@@ -392,8 +392,6 @@ public:
   bool GetShowInlineDiagnostics() const;
 
   bool SetShowInlineDiagnostics(bool);
-
-  bool LoadPlugin(const FileSpec &spec, Status &error);
 
   void RunIOHandlers();
 
@@ -777,9 +775,6 @@ protected:
   llvm::StringMap<std::weak_ptr<LogHandler>> m_stream_handlers;
   std::shared_ptr<CallbackLogHandler> m_callback_handler_sp;
   const std::string m_instance_name;
-  static LoadPluginCallbackType g_load_plugin_callback;
-  typedef std::vector<llvm::sys::DynamicLibrary> LoadedPluginsList;
-  LoadedPluginsList m_loaded_plugins;
   HostThread m_event_handler_thread;
   HostThread m_io_handler_thread;
   Broadcaster m_sync_broadcaster; ///< Private debugger synchronization.

--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -88,6 +88,10 @@ public:
 
   static void Terminate();
 
+  /// Load a plugin from a specific file path. Returns true if the plugin was
+  /// successfully loaded and initialized.
+  static bool LoadPlugin(const FileSpec &spec);
+
   // Support for enabling and disabling plugins.
 
   // Return the plugins that can be enabled or disabled by the user.

--- a/lldb/include/lldb/lldb-private-types.h
+++ b/lldb/include/lldb/lldb-private-types.h
@@ -16,21 +16,12 @@
 
 #include <type_traits>
 
-namespace llvm {
-namespace sys {
-class DynamicLibrary;
-}
-}
-
 namespace lldb_private {
 class Platform;
 class ExecutionContext;
 class RegisterFlags;
 
 typedef llvm::SmallString<256> PathSmallString;
-
-typedef llvm::sys::DynamicLibrary (*LoadPluginCallbackType)(
-    const lldb::DebuggerSP &debugger_sp, const FileSpec &spec, Status &error);
 
 /// Every register is described in detail including its name, alternate name
 /// (optional), encoding, size in bytes and the default display format.

--- a/lldb/source/API/SystemInitializerFull.cpp
+++ b/lldb/source/API/SystemInitializerFull.cpp
@@ -8,7 +8,6 @@
 
 #include "SystemInitializerFull.h"
 #include "lldb/API/SBCommandInterpreter.h"
-#include "lldb/API/SBDebugger.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Progress.h"
@@ -87,46 +86,7 @@ llvm::Error SystemInitializerFull::Initialize() {
 
   LLDB_LOG(GetLog(SystemLog::System), "{0}", GetVersion());
 
-  auto LoadPlugin = [](const lldb::DebuggerSP &debugger_sp,
-                       const FileSpec &spec,
-                       Status &error) -> llvm::sys::DynamicLibrary {
-    llvm::sys::DynamicLibrary dynlib =
-        llvm::sys::DynamicLibrary::getPermanentLibrary(spec.GetPath().c_str());
-    if (dynlib.isValid()) {
-      typedef bool (*LLDBCommandPluginInit)(lldb::SBDebugger debugger);
-
-      lldb::SBDebugger debugger_sb(debugger_sp);
-      // This calls the bool lldb::PluginInitialize(lldb::SBDebugger debugger)
-      // function.
-      // TODO: mangle this differently for your system - on OSX, the first
-      // underscore needs to be removed and the second one stays
-      LLDBCommandPluginInit init_func =
-          (LLDBCommandPluginInit)(uintptr_t)dynlib.getAddressOfSymbol(
-              "_ZN4lldb16PluginInitializeENS_10SBDebuggerE");
-      if (init_func) {
-        if (init_func(debugger_sb))
-          return dynlib;
-        else
-          error = Status::FromErrorString(
-              "plug-in refused to load "
-              "(lldb::PluginInitialize(lldb::SBDebugger) "
-              "returned false)");
-      } else {
-        error = Status::FromErrorString(
-            "plug-in is missing the required initialization: "
-            "lldb::PluginInitialize(lldb::SBDebugger)");
-      }
-    } else {
-      if (FileSystem::Instance().Exists(spec))
-        error = Status::FromErrorString(
-            "this file does not represent a loadable dylib");
-      else
-        error = Status::FromErrorString("no such file");
-    }
-    return llvm::sys::DynamicLibrary();
-  };
-
-  Debugger::Initialize(LoadPlugin);
+  Debugger::Initialize();
 
   return llvm::Error::success();
 }

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -35,16 +35,13 @@ protected:
       return;
     }
 
-    Status error;
-
     FileSpec dylib_fspec(command[0].ref());
     FileSystem::Instance().Resolve(dylib_fspec);
 
-    if (GetDebugger().LoadPlugin(dylib_fspec, error))
+    if (PluginManager::LoadPlugin(dylib_fspec))
       result.SetStatus(eReturnStatusSuccessFinishResult);
-    else {
-      result.AppendError(error.AsCString());
-    }
+    else
+      result.AppendError("failed to load plugin");
   }
 };
 

--- a/lldb/tools/lldb-test/SystemInitializerTest.cpp
+++ b/lldb/tools/lldb-test/SystemInitializerTest.cpp
@@ -51,7 +51,7 @@ llvm::Error SystemInitializerTest::Initialize() {
   // Settings must be initialized AFTER PluginManager::Initialize is called.
   Debugger::SettingsInitialize();
 
-  Debugger::Initialize(nullptr);
+  Debugger::Initialize();
 
   return llvm::Error::success();
 }

--- a/lldb/unittests/Callback/TestBreakpointSetCallback.cpp
+++ b/lldb/unittests/Callback/TestBreakpointSetCallback.cpp
@@ -47,7 +47,7 @@ public:
 protected:
   void SetUp() override {
     std::call_once(TestUtilities::g_debugger_initialize_flag,
-                   []() { Debugger::Initialize(nullptr); });
+                   []() { Debugger::Initialize(); });
   };
 
   DebuggerSP m_debugger_sp;

--- a/lldb/unittests/Core/DebuggerTest.cpp
+++ b/lldb/unittests/Core/DebuggerTest.cpp
@@ -25,7 +25,7 @@ public:
     HostInfo::Initialize();
     PlatformMacOSX::Initialize();
     std::call_once(TestUtilities::g_debugger_initialize_flag,
-                   []() { Debugger::Initialize(nullptr); });
+                   []() { Debugger::Initialize(); });
     ArchSpec arch("x86_64-apple-macosx-");
     Platform::SetHostPlatform(
         PlatformRemoteMacOSX::CreateInstance(true, &arch));

--- a/lldb/unittests/Core/DiagnosticEventTest.cpp
+++ b/lldb/unittests/Core/DiagnosticEventTest.cpp
@@ -34,7 +34,7 @@ public:
     HostInfo::Initialize();
     PlatformMacOSX::Initialize();
     std::call_once(TestUtilities::g_debugger_initialize_flag,
-                   []() { Debugger::Initialize(nullptr); });
+                   []() { Debugger::Initialize(); });
     ArchSpec arch("x86_64-apple-macosx-");
     Platform::SetHostPlatform(
         PlatformRemoteMacOSX::CreateInstance(true, &arch));

--- a/lldb/unittests/Core/ProgressReportTest.cpp
+++ b/lldb/unittests/Core/ProgressReportTest.cpp
@@ -52,7 +52,7 @@ protected:
   // here the usual way.
   void SetUp() override {
     std::call_once(TestUtilities::g_debugger_initialize_flag,
-                   []() { Debugger::Initialize(nullptr); });
+                   []() { Debugger::Initialize(); });
   };
 
   DebuggerSP m_debugger_sp;

--- a/lldb/unittests/Process/ProcessEventDataTest.cpp
+++ b/lldb/unittests/Process/ProcessEventDataTest.cpp
@@ -30,7 +30,7 @@ public:
     HostInfo::Initialize();
     PlatformMacOSX::Initialize();
     std::call_once(TestUtilities::g_debugger_initialize_flag,
-                   []() { Debugger::Initialize(nullptr); });
+                   []() { Debugger::Initialize(); });
   }
   void TearDown() override {
     PlatformMacOSX::Terminate();
@@ -187,7 +187,7 @@ TEST_F(ProcessEventDataTest, DoOnRemoval) {
                ->m_should_stop_hit_count == 0;
   ASSERT_TRUE(result);
 }
-#endif 
+#endif
 
 TEST_F(ProcessEventDataTest, ShouldStop) {
   ArchSpec arch("x86_64-apple-macosx-");

--- a/lldb/unittests/Process/elf-core/ThreadElfCoreTest.cpp
+++ b/lldb/unittests/Process/elf-core/ThreadElfCoreTest.cpp
@@ -39,7 +39,7 @@ struct ElfCoreTest : public testing::Test {
     HostInfo::Initialize();
     platform_linux::PlatformLinux::Initialize();
     std::call_once(TestUtilities::g_debugger_initialize_flag,
-                   []() { Debugger::Initialize(nullptr); });
+                   []() { Debugger::Initialize(); });
   }
   static void TearDownTestCase() {
     platform_linux::PlatformLinux::Terminate();

--- a/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
@@ -25,8 +25,7 @@ static std::once_flag debugger_initialize_flag;
 
 class DWARFASTParserClangTests : public testing::Test {
   void SetUp() override {
-    std::call_once(debugger_initialize_flag,
-                   []() { Debugger::Initialize(nullptr); });
+    std::call_once(debugger_initialize_flag, []() { Debugger::Initialize(); });
   }
 };
 

--- a/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
+++ b/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
@@ -155,8 +155,6 @@ public:
     ArchSpec arch("i386-pc-linux");
     Platform::SetHostPlatform(
         platform_linux::PlatformLinux::CreateInstance(true, &arch));
-    // std::call_once(TestUtilities::g_debugger_initialize_flag,
-    //                []() { Debugger::Initialize(nullptr); });
     m_debugger_sp = Debugger::CreateInstance();
     ASSERT_TRUE(m_debugger_sp);
     m_debugger_sp->GetTargetList().CreateTarget(*m_debugger_sp, "", arch,


### PR DESCRIPTION
Remove the plugin loading logic in the debugger and replaces it remaining uses with the one in the PluginManager. Doing this per debugger instance was not only redundant, as the filesystem scan had already happened earlier, the plugins found this way were never initialized nor used.

I've unified the plugin loading logic into a new PluginManager::LoadPlugin() helper method, that's now shared by both the PluginManager's file system scan and the `plugin load` command.