### PR TITLE
[LoopFusion] Improve collectFusionCandidates()

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopFuse.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFuse.cpp
@@ -591,18 +591,10 @@ private:
       // FusionCandidates.
       bool FoundAdjacent = false;
       for (auto &CurrCandList : FusionCandidates) {
-        if (isStrictlyAdjacent(CurrCand, CurrCandList.front())) {
-          CurrCandList.push_front(CurrCand);
-          FoundAdjacent = true;
-#ifndef NDEBUG
-          if (VerboseFusionDebugging)
-            LLVM_DEBUG(dbgs() << "Adding " << CurrCand
-                              << " to existing candidate list\n");
-#endif
-          break;
-        } else if (isStrictlyAdjacent(CurrCandList.back(), CurrCand)) {
+        if (isStrictlyAdjacent(CurrCandList.back(), CurrCand)) {
           CurrCandList.push_back(CurrCand);
           FoundAdjacent = true;
+          NumFusionCandidates++;
 #ifndef NDEBUG
           if (VerboseFusionDebugging)
             LLVM_DEBUG(dbgs() << "Adding " << CurrCand
@@ -621,7 +613,6 @@ private:
         NewCandList.push_back(CurrCand);
         FusionCandidates.push_back(NewCandList);
       }
-      NumFusionCandidates++;
     }
   }
 


### PR DESCRIPTION
The order of visiting loops in collectFusionCandidates() guarantees that a new member can only possibly be added to the end of a set.

Also currently `NumFusionCandidates` counts any loop that is added to a candidate set. Usually large majority of candidate sets have a single members so they are not really candidates for fusion. Only the second member of a candidate set and the ones that come after that could be counted as fusion candidates.