### PR TITLE
[clang-tidy] Fix erroneous warning to make deleted function public

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseEqualsDeleteCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseEqualsDeleteCheck.cpp
@@ -39,6 +39,21 @@ AST_MATCHER(CXXMethodDecl, isSpecialFunction) {
   return isa<CXXDestructorDecl>(Node) || Node.isCopyAssignmentOperator() ||
          Node.isMoveAssignmentOperator();
 }
+
+AST_MATCHER(CXXMethodDecl, hasPublicOverload) {
+  const DeclContext::lookup_result LookupResult =
+      Node.getParent()->lookup(Node.getNameInfo().getName());
+
+  if (LookupResult.isSingleResult())
+    return false; // No overloads
+
+  static constexpr auto IsPublicOverload = [](const Decl *Overload) {
+    return isa<CXXMethodDecl, FunctionTemplateDecl>(Overload) &&
+           Overload->getAccess() == AS_public;
+  };
+
+  return llvm::any_of(LookupResult, IsPublicOverload);
+}
 } // namespace
 
 static constexpr char SpecialFunction[] = "SpecialFunction";
@@ -66,8 +81,12 @@ void UseEqualsDeleteCheck::registerMatchers(MatchFinder *Finder) {
           .bind(SpecialFunction),
       this);
 
+  // Add a matcher for deleted private member functions, with a public overload,
+  // to recommend moving them to the public section.
   Finder->addMatcher(
-      cxxMethodDecl(isDeleted(), unless(isPublic())).bind(DeletedNotPublic),
+      cxxMethodDecl(isDeleted(), unless(isPublic()),
+                    anyOf(hasPublicOverload(), isSpecialFunction()))
+          .bind(DeletedNotPublic),
       this);
 }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -212,6 +212,11 @@ Changes in existing checks
 - Improved :doc:`modernize-redundant-void-arg
   <clang-tidy/checks/modernize/redundant-void-arg>` check to work in C23.
 
+- Improved :doc:`modernize-use-equals-delete
+  <clang-tidy/checks/modernize/use-equals-delete>` check by only warning on
+  private deleted functions, if they do not have a public overload or are a
+  special member function.
+
 - Improved :doc:`modernize-use-std-format
   <clang-tidy/checks/modernize/use-std-format>` check by fixing a crash
   when an argument is part of a macro expansion.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-delete.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-delete.cpp
@@ -194,28 +194,73 @@ private:
 
 namespace PR33759 {
 
-  class Number {
-    private:
-      Number();
-      ~Number();
+class Number {
+  private:
+    Number();
+    ~Number();
 
-    public:
-      static Number& getNumber() {
-        static Number number;
-        return number;
-      }
+  public:
+    static Number& getNumber() {
+      static Number number;
+      return number;
+    }
 
-      int getIntValue() { return (int)someFloat; }
-      float getFloatValue() { return someFloat; }
-    private:
-      float someFloat;
-  };
+    int getIntValue() { return (int)someFloat; }
+    float getFloatValue() { return someFloat; }
+  private:
+    float someFloat;
+};
 
-  class Number2 {
-    private:
-      Number2();
-      ~Number2();
-    public:
-      static Number& getNumber();
-  };
+class Number2 {
+  private:
+    Number2();
+    ~Number2();
+  public:
+    static Number& getNumber();
+};
+}
+
+namespace PR54276 {
+
+class PrivateDeletedFunctionWithPublicOverload {
+  public:
+    void foo() {}
+  private:
+    void foo(int) = delete;
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: deleted member function should be public [modernize-use-equals-delete]
+};
+
+class PrivateDeletedFunctionWithPrivateOverload {
+  private:
+    void foo() {}
+    void foo(int) = delete;
+};
+
+class PrivateDeletedFunctionTemplateWithPublicOverload {
+  public:
+    template<typename T>
+    void foo(T) {}
+  private:
+    template<typename T>
+    void foo(T, int) = delete;
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: deleted member function should be public [modernize-use-equals-delete]
+};
+
+class PrivateDeletedFunctionTemplateWithPrivateOverload {
+  private:
+    template<typename T>
+    void foo(T) {}
+    template<typename T>
+    void foo(T, int) = delete;
+};
+
+class PrivateDeletedFunctionTemplateWithProtectedOverload {
+  protected:
+    template<typename T>
+    void foo(T) {}
+  private:
+    template<typename T>
+    void foo(T, int) = delete;
+};
+
 }


### PR DESCRIPTION
This PR fixes #54276 and fixes #135249 by only matching private deleted functions with a public overload or special member functions.
Please let me know if there's a better way one could do this!