### PR TITLE
[flang-rt] Add support for formatted I/O on the GPU

### DIFF
--- a/flang-rt/lib/runtime/io-api-gpu.h
+++ b/flang-rt/lib/runtime/io-api-gpu.h
@@ -20,18 +20,21 @@ constexpr std::uint32_t MakeOpcode(std::uint32_t base) {
 // Opcodes shared between the client and server for each function we support.
 enum RPCOpcodes : std::uint32_t {
   BeginExternalListOutput_Opcode = MakeOpcode(0),
-  EndIoStatement_Opcode = MakeOpcode(1),
-  OutputInteger8_Opcode = MakeOpcode(2),
-  OutputInteger16_Opcode = MakeOpcode(3),
-  OutputInteger32_Opcode = MakeOpcode(4),
-  OutputInteger64_Opcode = MakeOpcode(5),
-  OutputInteger128_Opcode = MakeOpcode(6),
-  OutputReal32_Opcode = MakeOpcode(7),
-  OutputReal64_Opcode = MakeOpcode(8),
-  OutputComplex32_Opcode = MakeOpcode(9),
-  OutputComplex64_Opcode = MakeOpcode(10),
-  OutputAscii_Opcode = MakeOpcode(11),
-  OutputLogical_Opcode = MakeOpcode(12),
+  BeginExternalFormattedOutput_Opcode = MakeOpcode(1),
+  EnableHandlers_Opcode = MakeOpcode(2),
+  EndIoStatement_Opcode = MakeOpcode(3),
+  OutputInteger8_Opcode = MakeOpcode(4),
+  OutputInteger16_Opcode = MakeOpcode(5),
+  OutputInteger32_Opcode = MakeOpcode(6),
+  OutputInteger64_Opcode = MakeOpcode(7),
+  OutputInteger128_Opcode = MakeOpcode(8),
+  OutputReal32_Opcode = MakeOpcode(9),
+  OutputReal64_Opcode = MakeOpcode(10),
+  OutputComplex32_Opcode = MakeOpcode(11),
+  OutputComplex64_Opcode = MakeOpcode(12),
+  OutputAscii_Opcode = MakeOpcode(13),
+  OutputCharacter_Opcode = MakeOpcode(14),
+  OutputLogical_Opcode = MakeOpcode(15),
 };
 
 } // namespace Fortran::runtime::io

--- a/offload/test/offloading/fortran/formatted-io.f90
+++ b/offload/test/offloading/fortran/formatted-io.f90
@@ -1,0 +1,67 @@
+! REQUIRES: flang, libc
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+
+program formatted_io_test
+  implicit none
+
+  integer :: i, ios
+  real :: r
+  complex :: c
+  logical :: l
+  character(len=5) :: s
+
+  i = 42
+  r = 3.14
+  c = (1.0, -1.0)
+  l = .true.
+  s = "Hello"
+
+  ! CHECK: i=  42
+  !$omp target
+    write(*, '(A,I4)') "i=", i
+  !$omp end target
+
+  ! CHECK: r= 3.14
+  !$omp target
+    write(*, '(A,F5.2)') "r=", r
+  !$omp end target
+
+  ! CHECK: s=Hello
+  !$omp target map(to : s)
+    write(*, '(A,A)') "s=", s
+  !$omp end target
+
+  ! CHECK: l=T
+  !$omp target
+    write(*, '(A,L1)') "l=", l
+  !$omp end target
+
+  ! CHECK: c=(  1.00, -1.00)
+  !$omp target
+    write(*, '(A,A,F6.2,A,F6.2,A)') "c=", "(", real(c), ",", aimag(c), ")"
+  !$omp end target
+
+  ! CHECK: mixed: Hello   42 3.14 T
+  !$omp target map(to : s)
+    write(*, '(A,A,I5,F5.2,L2)') "mixed: ", s, i, r, l
+  !$omp end target
+
+  ! Test IOSTAT handling
+  ! CHECK: iostat:           0
+  !$omp target
+    write(*, '(A)', iostat=ios) "dummy"
+    write(*, '(A,I12)') "iostat:", ios
+  !$omp end target
+
+  ! Test formatted output from multiple teams.
+  ! CHECK: val=  42
+  ! CHECK: val=  42
+  ! CHECK: val=  42
+  ! CHECK: val=  42
+  !$omp target teams num_teams(4)
+  !$omp parallel num_threads(1)
+    write(*, '(A,I4)') "val=", i
+  !$omp end parallel
+  !$omp end target teams
+
+end program formatted_io_test


### PR DESCRIPTION
Summary:
Expands on the previous support to enable formatted output, characters,
and checking basic iostat. We intentionally do not handle cases where
the descriptor is non-null as this is a non-trivial class that cannot
easily be shepherded across the wire.
