### PR TITLE
[RISCV] Use bits<1> for AltFmt in RISCVVPseudo.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
@@ -564,7 +564,7 @@ class RISCVVPseudo<dag outs, dag ins, list<dag> pattern = [],
   Instruction BaseInstr = !cast<Instruction>(PseudoToVInst<NAME>.VInst);
   // SEW = 0 is used to denote that the Pseudo is not SEW specific (or unknown).
   bits<8> SEW = 0;
-  bit IsAltFmt = !eq(AltFmtType.Value, IS_ALTFMT.Value);
+  bits<1> IsAltFmt = !eq(AltFmtType.Value, IS_ALTFMT.Value);
   bit IncludeInInversePseudoTable = 1;
 
   let UseNamedOperandTable = true;


### PR DESCRIPTION
This makes the searchable table emitter use uint8_t instead of bool in the KeyType struct. This is needed to allow us to use a bitfield in the PseudoInfo struct and avoid a compare between a bool and uint16_t. We already use this same bits<1> trick in other searchable tables.

Fixes #182485