### PR TITLE
[flang] OPTIONAL char dummy has no defining op; add null check

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -321,8 +321,7 @@ struct AllocaOpConversion : public fir::FIROpConversion<fir::AllocaOp> {
 
     // A value defined by a block arg, such as fir.if for a
     // optional assumed character dummy len, doesn't have a defining op.
-    if (auto *defOp = size.getDefiningOp();
-        defOp && mlir::isa<mlir::LLVM::ConstantOp>(size.getDefiningOp())) {
+    if (mlir::isa_and_nonnull<mlir::LLVM::ConstantOp>(size.getDefiningOp())) {
       // Set the Block in which the llvm alloca should be inserted.
       mlir::Operation *parentOp = rewriter.getInsertionBlock()->getParentOp();
       mlir::Region *parentRegion = rewriter.getInsertionBlock()->getParent();

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -319,7 +319,10 @@ struct AllocaOpConversion : public fir::FIROpConversion<fir::AllocaOp> {
     unsigned allocaAs = getAllocaAddressSpace(rewriter);
     unsigned programAs = getProgramAddressSpace(rewriter);
 
-    if (mlir::isa<mlir::LLVM::ConstantOp>(size.getDefiningOp())) {
+    // A value defined by a block arg, such as fir.if for a
+    // optional assumed character dummy len, doesn't have a defining op.
+    if (auto *defOp = size.getDefiningOp();
+        defOp && mlir::isa<mlir::LLVM::ConstantOp>(size.getDefiningOp())) {
       // Set the Block in which the llvm alloca should be inserted.
       mlir::Operation *parentOp = rewriter.getInsertionBlock()->getParentOp();
       mlir::Region *parentRegion = rewriter.getInsertionBlock()->getParent();


### PR DESCRIPTION
size.getDefiningOp() returns nullptr for block arguments when a OPTIONAL character length generated the conditional "fir.if". Check for a nullptr before calling mlir::isa<> to avoid the crash.

Addresses: https://github.com/llvm/llvm-project/issues/182436
Passes check-flang, check-flang-rt, and llvm-test-suite (x86_64)