### PR TITLE
AMDGPU: Try to fix leak in AMDGPULibFunc

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULibFunc.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibFunc.cpp
@@ -1176,6 +1176,8 @@ AMDGPULibFunc::AMDGPULibFunc(const AMDGPULibFunc &F) {
 AMDGPULibFunc &AMDGPULibFunc::operator=(const AMDGPULibFunc &F) {
   if (this == &F)
     return *this;
+
+  this->~AMDGPULibFunc();
   new (this) AMDGPULibFunc(F);
   return *this;
 }


### PR DESCRIPTION
I don't know why this was trying to do placement do. I guess
this was overriding the unique_ptr, bypassing its destructor.