### PR TITLE
[Clang][CodeGen] Fix __builtin_counted_by_ref for nested struct FAMs (#182575)

### DIFF
--- a/clang/test/CodeGen/attr-counted-by-pr88931.c
+++ b/clang/test/CodeGen/attr-counted-by-pr88931.c
@@ -15,7 +15,12 @@ void init(void * __attribute__((pass_dynamic_object_size(0))));
 // CHECK-SAME: ptr noundef [[P:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[ARRAY:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 4
-// CHECK-NEXT:    tail call void @init(ptr noundef nonnull [[ARRAY]], i64 noundef -1) #[[ATTR2:[0-9]+]]
+// CHECK-NEXT:    [[COUNTED_BY_LOAD:%.*]] = load i32, ptr [[P]], align 4
+// CHECK-NEXT:    [[COUNT:%.*]] = sext i32 [[COUNTED_BY_LOAD]] to i64
+// CHECK-NEXT:    [[FLEXIBLE_ARRAY_MEMBER_SIZE:%.*]] = shl nsw i64 [[COUNT]], 2
+// CHECK-NEXT:    [[TMP0:%.*]] = icmp sgt i32 [[COUNTED_BY_LOAD]], -1
+// CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[TMP0]], i64 [[FLEXIBLE_ARRAY_MEMBER_SIZE]], i64 0
+// CHECK-NEXT:    tail call void @init(ptr noundef nonnull [[ARRAY]], i64 noundef [[TMP1]]) #[[ATTR2:[0-9]+]]
 // CHECK-NEXT:    ret void
 //
 void test1(struct bar *p) {


### PR DESCRIPTION
GetCountedByFieldExprGEP() used getOuterLexicalRecordContext() to find the RecordDecl containing the counted_by count field. This walks up through all lexically enclosing records to find the outermost one, which is wrong when a struct with a counted_by FAM is defined nested inside another named struct.

For example, when struct inner (containing the FAM) is defined inside struct outer, getOuterLexicalRecordContext() resolves to struct outer instead of struct inner. The StructAccessBase visitor then fails to match the base expression type (struct inner *) against the expected record (struct outer), returning nullptr. This nullptr propagates back as the GEP result, and the subsequent dereference in *__builtin_counted_by_ref() triggers an assertion failure in Address::getBasePointer().

Replace getOuterLexicalRecordContext() with a walk that only traverses anonymous structs and unions, which are transparent in C and must be walked past. Named nested structs are independently-addressable types, so the walk stops at them.

Add a regression test for a FAM struct defined nested inside another struct.

This also fixes __builtin_dynamic_object_size() for FAMs in nested structs, which was silently returning -1 (unknown) instead of computing the correct size. Update the attr-counted-by-pr88931.c test to reflect the now-correct dynamic object size calculation.

Fixes #182575