### PR TITLE
[RISCV] Remove srl from (srl (and X, (1 << C)), C) used as czero.eqz/nez condition.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -21681,6 +21681,7 @@ SDValue RISCVTargetLowering::PerformDAGCombine(SDNode *N,
   case RISCVISD::CZERO_NEZ: {
     SDValue Val = N->getOperand(0);
     SDValue Cond = N->getOperand(1);
+    MVT VT = N->getSimpleValueType(0);
 
     unsigned Opc = N->getOpcode();
 
@@ -21697,7 +21698,7 @@ SDValue RISCVTargetLowering::PerformDAGCombine(SDNode *N,
       SDValue NewCond = Cond.getOperand(0);
       APInt Mask = APInt::getBitsSetFrom(NewCond.getValueSizeInBits(), 1);
       if (DAG.MaskedValueIsZero(NewCond, Mask))
-        return DAG.getNode(InvOpc, SDLoc(N), N->getValueType(0), Val, NewCond);
+        return DAG.getNode(InvOpc, SDLoc(N), VT, Val, NewCond);
     }
     // czero_eqz x, (setcc y, 0, ne) -> czero_eqz x, y
     // czero_nez x, (setcc y, 0, ne) -> czero_nez x, y
@@ -21706,8 +21707,24 @@ SDValue RISCVTargetLowering::PerformDAGCombine(SDNode *N,
     if (Cond.getOpcode() == ISD::SETCC && isNullConstant(Cond.getOperand(1))) {
       ISD::CondCode CCVal = cast<CondCodeSDNode>(Cond.getOperand(2))->get();
       if (ISD::isIntEqualitySetCC(CCVal))
-        return DAG.getNode(CCVal == ISD::SETNE ? Opc : InvOpc, SDLoc(N),
-                           N->getValueType(0), Val, Cond.getOperand(0));
+        return DAG.getNode(CCVal == ISD::SETNE ? Opc : InvOpc, SDLoc(N), VT,
+                           Val, Cond.getOperand(0));
+    }
+
+    // Remove SRL from bittest patterns (srl (and X, (1 << C), C)) if the and
+    // is an ANDI. Because only 1 bit can be set after the AND, it doesn't
+    // matter if we shift it.
+    if (Cond.getOpcode() == ISD::SRL &&
+        isa<ConstantSDNode>(Cond.getOperand(1)) &&
+        Cond.getOperand(0).getOpcode() == ISD::AND) {
+      const APInt &ShAmt = Cond.getConstantOperandAPInt(1);
+      unsigned BitWidth = VT.getSizeInBits();
+      SDValue And = Cond.getOperand(0);
+      if (ShAmt.ult(BitWidth) && isa<ConstantSDNode>(And.getOperand(1))) {
+        uint64_t AndConst = And.getConstantOperandVal(1);
+        if (AndConst == (1ULL << ShAmt.getZExtValue()) && isInt<12>(AndConst))
+          return DAG.getNode(Opc, DL, VT, Val, And);
+      }
     }
 
     // czero_nez (setcc X, Y, CC), (setcc X, Y, eq) -> (setcc X, Y, CC)

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -21711,7 +21711,7 @@ SDValue RISCVTargetLowering::PerformDAGCombine(SDNode *N,
                            Val, Cond.getOperand(0));
     }
 
-    // Remove SRL from bittest patterns (srl (and X, (1 << C), C)) if the and
+    // Remove SRL from bittest patterns (srl (and X, (1 << C)), C) if the and
     // is an ANDI. Because only 1 bit can be set after the AND, it doesn't
     // matter if we shift it.
     if (Cond.getOpcode() == ISD::SRL &&

--- a/llvm/test/CodeGen/RISCV/condops.ll
+++ b/llvm/test/CodeGen/RISCV/condops.ll
@@ -4442,7 +4442,7 @@ define i64 @single_bit4(i64 %x) {
 ;
 ; RV64XVENTANACONDOPS-LABEL: single_bit4:
 ; RV64XVENTANACONDOPS:       # %bb.0: # %entry
-; RV64XVENTANACONDOPS-NEXT:    bexti a1, a0, 10
+; RV64XVENTANACONDOPS-NEXT:    andi a1, a0, 1024
 ; RV64XVENTANACONDOPS-NEXT:    vt.maskcn a0, a0, a1
 ; RV64XVENTANACONDOPS-NEXT:    ret
 ;
@@ -4461,7 +4461,7 @@ define i64 @single_bit4(i64 %x) {
 ;
 ; RV64ZICOND-LABEL: single_bit4:
 ; RV64ZICOND:       # %bb.0: # %entry
-; RV64ZICOND-NEXT:    bexti a1, a0, 10
+; RV64ZICOND-NEXT:    andi a1, a0, 1024
 ; RV64ZICOND-NEXT:    czero.nez a0, a0, a1
 ; RV64ZICOND-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/RISCV/condops.ll
+++ b/llvm/test/CodeGen/RISCV/condops.ll
@@ -4416,3 +4416,111 @@ entry:
   %cond = select i1 %tobool.not, i64 0, i64 %y
   ret i64 %cond
 }
+
+define i64 @single_bit4(i64 %x) {
+; RV32I-LABEL: single_bit4:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:    bexti a2, a0, 10
+; RV32I-NEXT:    addi a2, a2, -1
+; RV32I-NEXT:    and a0, a2, a0
+; RV32I-NEXT:    and a1, a2, a1
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: single_bit4:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:    bexti a1, a0, 10
+; RV64I-NEXT:    addi a1, a1, -1
+; RV64I-NEXT:    and a0, a1, a0
+; RV64I-NEXT:    ret
+;
+; RV32XVENTANACONDOPS-LABEL: single_bit4:
+; RV32XVENTANACONDOPS:       # %bb.0: # %entry
+; RV32XVENTANACONDOPS-NEXT:    bexti a2, a0, 10
+; RV32XVENTANACONDOPS-NEXT:    vt.maskcn a0, a0, a2
+; RV32XVENTANACONDOPS-NEXT:    vt.maskcn a1, a1, a2
+; RV32XVENTANACONDOPS-NEXT:    ret
+;
+; RV64XVENTANACONDOPS-LABEL: single_bit4:
+; RV64XVENTANACONDOPS:       # %bb.0: # %entry
+; RV64XVENTANACONDOPS-NEXT:    bexti a1, a0, 10
+; RV64XVENTANACONDOPS-NEXT:    vt.maskcn a0, a0, a1
+; RV64XVENTANACONDOPS-NEXT:    ret
+;
+; RV64XTHEADCONDMOV-LABEL: single_bit4:
+; RV64XTHEADCONDMOV:       # %bb.0: # %entry
+; RV64XTHEADCONDMOV-NEXT:    th.tst a1, a0, 10
+; RV64XTHEADCONDMOV-NEXT:    th.mvnez a0, zero, a1
+; RV64XTHEADCONDMOV-NEXT:    ret
+;
+; RV32ZICOND-LABEL: single_bit4:
+; RV32ZICOND:       # %bb.0: # %entry
+; RV32ZICOND-NEXT:    bexti a2, a0, 10
+; RV32ZICOND-NEXT:    czero.nez a0, a0, a2
+; RV32ZICOND-NEXT:    czero.nez a1, a1, a2
+; RV32ZICOND-NEXT:    ret
+;
+; RV64ZICOND-LABEL: single_bit4:
+; RV64ZICOND:       # %bb.0: # %entry
+; RV64ZICOND-NEXT:    bexti a1, a0, 10
+; RV64ZICOND-NEXT:    czero.nez a0, a0, a1
+; RV64ZICOND-NEXT:    ret
+entry:
+  %and = and i64 %x, 1024
+  %tobool.not = icmp ne i64 %and, 0
+  %cond = select i1 %tobool.not, i64 0, i64 %x
+  ret i64 %cond
+}
+
+define i64 @single_bit5(i64 %x) {
+; RV32I-LABEL: single_bit5:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:    bexti a2, a0, 11
+; RV32I-NEXT:    addi a2, a2, -1
+; RV32I-NEXT:    and a0, a2, a0
+; RV32I-NEXT:    and a1, a2, a1
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: single_bit5:
+; RV64I:       # %bb.0: # %entry
+; RV64I-NEXT:    bexti a1, a0, 11
+; RV64I-NEXT:    addi a1, a1, -1
+; RV64I-NEXT:    and a0, a1, a0
+; RV64I-NEXT:    ret
+;
+; RV32XVENTANACONDOPS-LABEL: single_bit5:
+; RV32XVENTANACONDOPS:       # %bb.0: # %entry
+; RV32XVENTANACONDOPS-NEXT:    bexti a2, a0, 11
+; RV32XVENTANACONDOPS-NEXT:    vt.maskcn a0, a0, a2
+; RV32XVENTANACONDOPS-NEXT:    vt.maskcn a1, a1, a2
+; RV32XVENTANACONDOPS-NEXT:    ret
+;
+; RV64XVENTANACONDOPS-LABEL: single_bit5:
+; RV64XVENTANACONDOPS:       # %bb.0: # %entry
+; RV64XVENTANACONDOPS-NEXT:    bexti a1, a0, 11
+; RV64XVENTANACONDOPS-NEXT:    vt.maskcn a0, a0, a1
+; RV64XVENTANACONDOPS-NEXT:    ret
+;
+; RV64XTHEADCONDMOV-LABEL: single_bit5:
+; RV64XTHEADCONDMOV:       # %bb.0: # %entry
+; RV64XTHEADCONDMOV-NEXT:    th.tst a1, a0, 11
+; RV64XTHEADCONDMOV-NEXT:    th.mvnez a0, zero, a1
+; RV64XTHEADCONDMOV-NEXT:    ret
+;
+; RV32ZICOND-LABEL: single_bit5:
+; RV32ZICOND:       # %bb.0: # %entry
+; RV32ZICOND-NEXT:    bexti a2, a0, 11
+; RV32ZICOND-NEXT:    czero.nez a0, a0, a2
+; RV32ZICOND-NEXT:    czero.nez a1, a1, a2
+; RV32ZICOND-NEXT:    ret
+;
+; RV64ZICOND-LABEL: single_bit5:
+; RV64ZICOND:       # %bb.0: # %entry
+; RV64ZICOND-NEXT:    bexti a1, a0, 11
+; RV64ZICOND-NEXT:    czero.nez a0, a0, a1
+; RV64ZICOND-NEXT:    ret
+entry:
+  %and = and i64 %x, 2048
+  %tobool.not = icmp ne i64 %and, 0
+  %cond = select i1 %tobool.not, i64 0, i64 %x
+  ret i64 %cond
+}

--- a/llvm/test/CodeGen/RISCV/select.ll
+++ b/llvm/test/CodeGen/RISCV/select.ll
@@ -3009,3 +3009,60 @@ entry:
   store ptr %4, ptr %1, align 8
   ret void
 }
+
+define i64 @single_bit_condition(i64 %x) {
+; RV32IM-LABEL: single_bit_condition:
+; RV32IM:       # %bb.0: # %entry
+; RV32IM-NEXT:    slli a2, a0, 21
+; RV32IM-NEXT:    srli a2, a2, 31
+; RV32IM-NEXT:    addi a2, a2, -1
+; RV32IM-NEXT:    and a0, a2, a0
+; RV32IM-NEXT:    and a1, a2, a1
+; RV32IM-NEXT:    ret
+;
+; RV64IM-LABEL: single_bit_condition:
+; RV64IM:       # %bb.0: # %entry
+; RV64IM-NEXT:    slli a1, a0, 53
+; RV64IM-NEXT:    srli a1, a1, 63
+; RV64IM-NEXT:    addi a1, a1, -1
+; RV64IM-NEXT:    and a0, a1, a0
+; RV64IM-NEXT:    ret
+;
+; RV64IMXVTCONDOPS-LABEL: single_bit_condition:
+; RV64IMXVTCONDOPS:       # %bb.0: # %entry
+; RV64IMXVTCONDOPS-NEXT:    slli a1, a0, 53
+; RV64IMXVTCONDOPS-NEXT:    srli a1, a1, 63
+; RV64IMXVTCONDOPS-NEXT:    vt.maskcn a0, a0, a1
+; RV64IMXVTCONDOPS-NEXT:    ret
+;
+; RV32IMZICOND-LABEL: single_bit_condition:
+; RV32IMZICOND:       # %bb.0: # %entry
+; RV32IMZICOND-NEXT:    slli a2, a0, 21
+; RV32IMZICOND-NEXT:    srli a2, a2, 31
+; RV32IMZICOND-NEXT:    czero.nez a0, a0, a2
+; RV32IMZICOND-NEXT:    czero.nez a1, a1, a2
+; RV32IMZICOND-NEXT:    ret
+;
+; RV64IMZICOND-LABEL: single_bit_condition:
+; RV64IMZICOND:       # %bb.0: # %entry
+; RV64IMZICOND-NEXT:    slli a1, a0, 53
+; RV64IMZICOND-NEXT:    srli a1, a1, 63
+; RV64IMZICOND-NEXT:    czero.nez a0, a0, a1
+; RV64IMZICOND-NEXT:    ret
+;
+; RV32IXQCI-LABEL: single_bit_condition:
+; RV32IXQCI:       # %bb.0: # %entry
+; RV32IXQCI-NEXT:    slli a2, a0, 21
+; RV32IXQCI-NEXT:    srli a2, a2, 31
+; RV32IXQCI-NEXT:    mv a3, a2
+; RV32IXQCI-NEXT:    qc.selectieqi a2, 0, a1, 0
+; RV32IXQCI-NEXT:    qc.selectieqi a3, 0, a0, 0
+; RV32IXQCI-NEXT:    mv a0, a3
+; RV32IXQCI-NEXT:    mv a1, a2
+; RV32IXQCI-NEXT:    ret
+entry:
+  %and = and i64 %x, 1024
+  %tobool.not = icmp ne i64 %and, 0
+  %cond = select i1 %tobool.not, i64 0, i64 %x
+  ret i64 %cond
+}

--- a/llvm/test/CodeGen/RISCV/select.ll
+++ b/llvm/test/CodeGen/RISCV/select.ll
@@ -3030,8 +3030,7 @@ define i64 @single_bit_condition(i64 %x) {
 ;
 ; RV64IMXVTCONDOPS-LABEL: single_bit_condition:
 ; RV64IMXVTCONDOPS:       # %bb.0: # %entry
-; RV64IMXVTCONDOPS-NEXT:    slli a1, a0, 53
-; RV64IMXVTCONDOPS-NEXT:    srli a1, a1, 63
+; RV64IMXVTCONDOPS-NEXT:    andi a1, a0, 1024
 ; RV64IMXVTCONDOPS-NEXT:    vt.maskcn a0, a0, a1
 ; RV64IMXVTCONDOPS-NEXT:    ret
 ;
@@ -3045,8 +3044,7 @@ define i64 @single_bit_condition(i64 %x) {
 ;
 ; RV64IMZICOND-LABEL: single_bit_condition:
 ; RV64IMZICOND:       # %bb.0: # %entry
-; RV64IMZICOND-NEXT:    slli a1, a0, 53
-; RV64IMZICOND-NEXT:    srli a1, a1, 63
+; RV64IMZICOND-NEXT:    andi a1, a0, 1024
 ; RV64IMZICOND-NEXT:    czero.nez a0, a0, a1
 ; RV64IMZICOND-NEXT:    ret
 ;


### PR DESCRIPTION
(setne (and X, 1 << C), 0) is canonicalized to (srl (and X, (1 << C)), C).
If this is later used as a czero.eqz/nez condition, we can remove
the srl if the and can be represented as an ANDI.