### PR TITLE
[libc] Add backwards-compatibility macro to struct stat.

### DIFF
--- a/libc/include/llvm-libc-types/struct_stat.h
+++ b/libc/include/llvm-libc-types/struct_stat.h
@@ -34,11 +34,11 @@ struct stat {
   struct timespec st_ctim;
   blksize_t st_blksize;
   blkcnt_t st_blocks;
-  // Backwards compatibility macros for older kernel/standards
-  // that recorded timestamps in stat with one-second precision.
-  #define st_atime st_atim.tv_sec
-  #define st_mtime st_mtim.tv_sec
-  #define st_ctime st_ctim.tv_sec
+// Backwards compatibility macros for older kernel/standards
+// that recorded timestamps in stat with one-second precision.
+#define st_atime st_atim.tv_sec
+#define st_mtime st_mtim.tv_sec
+#define st_ctime st_ctim.tv_sec
 };
 
 #endif // LLVM_LIBC_TYPES_STRUCT_STAT_H

--- a/libc/include/llvm-libc-types/struct_stat.h
+++ b/libc/include/llvm-libc-types/struct_stat.h
@@ -34,6 +34,11 @@ struct stat {
   struct timespec st_ctim;
   blksize_t st_blksize;
   blkcnt_t st_blocks;
+  // Backwards compatibility macros for older kernel/standards
+  // that recorded timestamps in stat with one-second precision.
+  #define st_atime st_atim.tv_sec
+  #define st_mtime st_mtim.tv_sec
+  #define st_ctime st_ctim.tv_sec
 };
 
 #endif // LLVM_LIBC_TYPES_STRUCT_STAT_H

--- a/libc/test/src/sys/time/utimes_test.cpp
+++ b/libc/test/src/sys/time/utimes_test.cpp
@@ -57,6 +57,10 @@ TEST_F(LlvmLibcUtimesTest, ChangeTimesSpecific) {
   ASSERT_EQ(statbuf.st_mtim.tv_nsec,
             static_cast<long>(times[1].tv_usec * 1000));
 
+  // legacy way to check seconds
+  ASSERT_EQ(statbuf.st_atime, times[0].tv_sec);
+  ASSERT_EQ(statbuf.st_mtime, times[1].tv_sec);
+
   ASSERT_THAT(LIBC_NAMESPACE::remove(TEST_FILE), Succeeds(0));
 }
 

--- a/libc/test/src/sys/time/utimes_test.cpp
+++ b/libc/test/src/sys/time/utimes_test.cpp
@@ -50,6 +50,7 @@ TEST_F(LlvmLibcUtimesTest, ChangeTimesSpecific) {
   // seconds
   ASSERT_EQ(statbuf.st_atim.tv_sec, times[0].tv_sec);
   ASSERT_EQ(statbuf.st_mtim.tv_sec, times[1].tv_sec);
+  ASSERT_GT(statbuf.st_ctim.tv_sec, 0L);
 
   // microseconds
   ASSERT_EQ(statbuf.st_atim.tv_nsec,
@@ -60,6 +61,7 @@ TEST_F(LlvmLibcUtimesTest, ChangeTimesSpecific) {
   // legacy way to check seconds
   ASSERT_EQ(statbuf.st_atime, times[0].tv_sec);
   ASSERT_EQ(statbuf.st_mtime, times[1].tv_sec);
+  ASSERT_GT(statbuf.st_ctime, 0L);
 
   ASSERT_THAT(LIBC_NAMESPACE::remove(TEST_FILE), Succeeds(0));
 }


### PR DESCRIPTION
Older code may use `st_atime` which recorded timestamps with one-second precision, instead of `struct timespec st_atim` that is available in later POSIX versions.

Add `#define st_atime` (& friends) to type declaration as suggested in https://man7.org/linux/man-pages/man3/stat.3type.html