### PR TITLE
[NFC][LFI] Reduce includes due to c-t impact

### DIFF
--- a/llvm/include/llvm/MC/MCLFI.h
+++ b/llvm/include/llvm/MC/MCLFI.h
@@ -11,7 +11,6 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
 
 namespace llvm {

--- a/llvm/include/llvm/MC/MCLFIRewriter.h
+++ b/llvm/include/llvm/MC/MCLFIRewriter.h
@@ -15,12 +15,12 @@
 #ifndef LLVM_MC_MCLFIREWRITER_H
 #define LLVM_MC_MCLFIREWRITER_H
 
-#include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/Support/Compiler.h"
 
 namespace llvm {
+class MCContext;
 class MCInst;
 class MCSubtargetInfo;
 class MCStreamer;

--- a/llvm/include/llvm/MC/MCParser/MCAsmParserExtension.h
+++ b/llvm/include/llvm/MC/MCParser/MCAsmParserExtension.h
@@ -11,13 +11,13 @@
 
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/MC/MCLFIRewriter.h"
 #include "llvm/MC/MCParser/MCAsmParser.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/SMLoc.h"
 
 namespace llvm {
 
+class MCLFIRewriter;
 class Twine;
 
 /// Generic interface for extending the MCAsmParser,

--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -19,7 +19,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCDirectives.h"
 #include "llvm/MC/MCDwarf.h"
-#include "llvm/MC/MCLFIRewriter.h"
 #include "llvm/MC/MCLinkerOptimizationHint.h"
 #include "llvm/MC/MCPseudoProbe.h"
 #include "llvm/MC/MCSection.h"
@@ -44,6 +43,7 @@ class APInt;
 class AssemblerConstantPools;
 class MCAsmBackend;
 class MCAssembler;
+class MCLFIRewriter;
 class MCContext;
 class MCExpr;
 class MCInst;
@@ -311,9 +311,7 @@ public:
     return StartTokLocPtr ? *StartTokLocPtr : SMLoc();
   }
 
-  void setLFIRewriter(std::unique_ptr<MCLFIRewriter> Rewriter) {
-    LFIRewriter = std::move(Rewriter);
-  }
+  void setLFIRewriter(std::unique_ptr<MCLFIRewriter> Rewriter);
 
   MCLFIRewriter *getLFIRewriter() { return LFIRewriter.get(); }
 

--- a/llvm/lib/MC/MCLFI.cpp
+++ b/llvm/lib/MC/MCLFI.cpp
@@ -14,11 +14,13 @@
 #include "llvm/MC/MCLFI.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCContext.h"
-#include "llvm/MC/MCLFIRewriter.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/Alignment.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/TargetParser/Triple.h"
 
 static const char NoteNamespace[] = "LFI";

--- a/llvm/lib/MC/MCLFIRewriter.cpp
+++ b/llvm/lib/MC/MCLFIRewriter.cpp
@@ -13,9 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/MC/MCLFIRewriter.h"
+#include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstrInfo.h"
-#include "llvm/MC/MCRegisterInfo.h"
 
 namespace llvm {
 

--- a/llvm/lib/MC/MCParser/LFIAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/LFIAsmParser.cpp
@@ -13,7 +13,6 @@
 
 #include "llvm/MC/MCLFIRewriter.h"
 #include "llvm/MC/MCParser/MCAsmParserExtension.h"
-#include "llvm/MC/MCStreamer.h"
 
 using namespace llvm;
 

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -20,6 +20,7 @@
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCLFIRewriter.h"
 #include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/MC/MCPseudoProbe.h"
 #include "llvm/MC/MCRegister.h"
@@ -95,6 +96,10 @@ MCStreamer::MCStreamer(MCContext &Ctx)
 }
 
 MCStreamer::~MCStreamer() = default;
+
+void MCStreamer::setLFIRewriter(std::unique_ptr<MCLFIRewriter> Rewriter) {
+  LFIRewriter = std::move(Rewriter);
+}
 
 void MCStreamer::reset() {
   DwarfFrameInfos.clear();


### PR DESCRIPTION
Removes header includes that don't need to be made at the top-level by moving transitive dependencies directly into source files and using forward declarations. Biggest impact is that we no longer include `MCLFIRewriter.h` in `MCStreamer.h` and `MCAsmParserExtension.h`.