### PR TITLE
[clang-doc] Improve complexity of Index construction

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -805,8 +805,9 @@ static Error serializeIndex(const ClangDocContext &CDCtx, StringRef RootDir) {
 
   if (IndexCopy.Children.empty()) {
     // If the index is empty, default to displaying the global namespace.
-    IndexCopy.Children.try_emplace(toStringRef(GlobalNamespaceID), GlobalNamespaceID, "",
-                                    InfoType::IT_namespace, "GlobalNamespace");
+    IndexCopy.Children.try_emplace(toStringRef(GlobalNamespaceID),
+                                   GlobalNamespaceID, "",
+                                   InfoType::IT_namespace, "GlobalNamespace");
   } else {
     IndexArrayRef.reserve(CDCtx.Idx.Children.size());
   }

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -805,19 +805,25 @@ static Error serializeIndex(const ClangDocContext &CDCtx, StringRef RootDir) {
 
   if (IndexCopy.Children.empty()) {
     // If the index is empty, default to displaying the global namespace.
-    IndexCopy.Children.emplace_back(GlobalNamespaceID, "",
+    IndexCopy.Children.try_emplace(toStringRef(GlobalNamespaceID), GlobalNamespaceID, "",
                                     InfoType::IT_namespace, "GlobalNamespace");
   } else {
     IndexArrayRef.reserve(CDCtx.Idx.Children.size());
   }
 
-  for (auto &Idx : IndexCopy.Children) {
-    if (Idx.Children.empty())
+  llvm::SmallVector<const Index *> Children;
+  Children.reserve(IndexCopy.Children.size());
+  for (const auto &[_, Idx] : IndexCopy.Children)
+    Children.push_back(&Idx);
+  llvm::sort(Children, [](const Index *A, const Index *B) { return *A < *B; });
+
+  for (const auto *Idx : Children) {
+    if (Idx->Children.empty())
       continue;
-    std::string TypeStr = infoTypeToString(Idx.RefType);
+    std::string TypeStr = infoTypeToString(Idx->RefType);
     json::Value IdxVal = Object();
     auto &IdxObj = *IdxVal.getAsObject();
-    serializeReference(Idx, IdxObj);
+    serializeReference(*Idx, IdxObj);
     IndexArrayRef.push_back(IdxVal);
   }
   Obj["Index"] = IndexArray;

--- a/clang-tools-extra/clang-doc/MDGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDGenerator.cpp
@@ -314,7 +314,8 @@ static void genMarkdown(const ClangDocContext &CDCtx, const TypedefInfo &I,
   // TODO support typedefs in markdown.
 }
 
-static void serializeReference(llvm::raw_fd_ostream &OS, const Index &I, int Level) {
+static void serializeReference(llvm::raw_fd_ostream &OS, const Index &I,
+                               int Level) {
   // Write out the heading level starting at ##
   OS << "##" << std::string(Level, '#') << " ";
   writeNameLink("", I, OS);

--- a/clang-tools-extra/clang-doc/MDGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDGenerator.cpp
@@ -314,7 +314,7 @@ static void genMarkdown(const ClangDocContext &CDCtx, const TypedefInfo &I,
   // TODO support typedefs in markdown.
 }
 
-static void serializeReference(llvm::raw_fd_ostream &OS, Index &I, int Level) {
+static void serializeReference(llvm::raw_fd_ostream &OS, const Index &I, int Level) {
   // Write out the heading level starting at ##
   OS << "##" << std::string(Level, '#') << " ";
   writeNameLink("", I, OS);
@@ -338,8 +338,14 @@ static llvm::Error serializeIndex(ClangDocContext &CDCtx) {
     OS << " for " << CDCtx.ProjectName;
   OS << "\n\n";
 
-  for (auto C : CDCtx.Idx.Children)
-    serializeReference(OS, C, 0);
+  std::vector<const Index *> Children;
+  Children.reserve(CDCtx.Idx.Children.size());
+  for (const auto &[_, C] : CDCtx.Idx.Children)
+    Children.push_back(&C);
+  llvm::sort(Children, [](const Index *A, const Index *B) { return *A < *B; });
+
+  for (const auto *C : Children)
+    serializeReference(OS, *C, 0);
 
   return llvm::Error::success();
 }
@@ -356,10 +362,15 @@ static llvm::Error genIndex(ClangDocContext &CDCtx) {
                                        FileErr.message());
   CDCtx.Idx.sort();
   OS << "# " << CDCtx.ProjectName << " C/C++ Reference\n\n";
-  for (auto C : CDCtx.Idx.Children) {
-    if (!C.Children.empty()) {
+  std::vector<const Index *> Children;
+  Children.reserve(CDCtx.Idx.Children.size());
+  for (const auto &[_, C] : CDCtx.Idx.Children)
+    Children.push_back(&C);
+  llvm::sort(Children, [](const Index *A, const Index *B) { return *A < *B; });
+  for (const auto *C : Children) {
+    if (!C->Children.empty()) {
       const char *Type;
-      switch (C.RefType) {
+      switch (C->RefType) {
       case InfoType::IT_namespace:
         Type = "Namespace";
         break;
@@ -387,10 +398,10 @@ static llvm::Error genIndex(ClangDocContext &CDCtx) {
       case InfoType::IT_default:
         Type = "Other";
       }
-      OS << "* " << Type << ": [" << C.Name << "](";
-      if (!C.Path.empty())
-        OS << C.Path << "/";
-      OS << C.Name << ")\n";
+      OS << "* " << Type << ": [" << C->Name << "](";
+      if (!C->Path.empty())
+        OS << C->Path << "/";
+      OS << C->Name << ")\n";
     }
   }
   return llvm::Error::success();

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -473,8 +473,7 @@ bool Index::operator<(const Index &Other) const {
 }
 
 void Index::sort() {
-  llvm::sort(Children);
-  for (auto &C : Children)
+  for (auto &[_,C] : Children)
     C.sort();
 }
 

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -473,7 +473,7 @@ bool Index::operator<(const Index &Other) const {
 }
 
 void Index::sort() {
-  for (auto &[_,C] : Children)
+  for (auto &[_, C] : Children)
     C.sort();
 }
 

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -18,6 +18,7 @@
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Tooling/Execution.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include <array>
 #include <optional>
@@ -611,7 +612,7 @@ struct Index : public Reference {
   bool operator<(const Index &Other) const;
 
   std::optional<SmallString<16>> JumpToSection;
-  std::vector<Index> Children;
+  llvm::StringMap<Index> Children;
 
   void sort();
 };

--- a/clang-tools-extra/clang-doc/YAMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/YAMLGenerator.cpp
@@ -109,15 +109,15 @@ template <unsigned U> struct ScalarTraits<SmallString<U>> {
   static QuotingType mustQuote(StringRef) { return QuotingType::Single; }
 };
 
-template <> struct ScalarTraits<std::array<unsigned char, 20>> {
+template <> struct ScalarTraits<SymbolID> {
 
-  static void output(const std::array<unsigned char, 20> &S, void *,
+  static void output(const SymbolID &S, void *,
                      llvm::raw_ostream &OS) {
     OS << toHex(toStringRef(S));
   }
 
   static StringRef input(StringRef Scalar, void *,
-                         std::array<unsigned char, 20> &Value) {
+                         SymbolID &Value) {
     if (Scalar.size() != 40)
       return "Error: Incorrect scalar size for USR.";
     Value = stringToSymbol(Scalar);

--- a/clang-tools-extra/clang-doc/YAMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/YAMLGenerator.cpp
@@ -111,13 +111,11 @@ template <unsigned U> struct ScalarTraits<SmallString<U>> {
 
 template <> struct ScalarTraits<SymbolID> {
 
-  static void output(const SymbolID &S, void *,
-                     llvm::raw_ostream &OS) {
+  static void output(const SymbolID &S, void *, llvm::raw_ostream &OS) {
     OS << toHex(toStringRef(S));
   }
 
-  static StringRef input(StringRef Scalar, void *,
-                         SymbolID &Value) {
+  static StringRef input(StringRef Scalar, void *, SymbolID &Value) {
     if (Scalar.size() != 40)
       return "Error: Incorrect scalar size for USR.";
     Value = stringToSymbol(Scalar);

--- a/clang-tools-extra/unittests/clang-doc/ClangDocTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/ClangDocTest.cpp
@@ -247,8 +247,8 @@ void CheckBaseRecordInfo(BaseRecordInfo *Expected, BaseRecordInfo *Actual) {
 void CheckIndex(Index &Expected, Index &Actual) {
   CheckReference(Expected, Actual);
   ASSERT_EQ(Expected.Children.size(), Actual.Children.size());
-  for (size_t Idx = 0; Idx < Actual.Children.size(); ++Idx)
-    CheckIndex(Expected.Children[Idx], Actual.Children[Idx]);
+  for (auto &[_, C] : Expected.Children)
+    CheckIndex(C, Actual.Children.find(llvm::toStringRef(C.USR))->second);
 }
 
 } // namespace doc

--- a/clang-tools-extra/unittests/clang-doc/GeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/GeneratorTest.cpp
@@ -46,45 +46,99 @@ TEST(GeneratorTest, emitIndex) {
   Index ExpectedIdx;
   Index IndexA;
   IndexA.Name = "A";
-  ExpectedIdx.Children.emplace_back(std::move(IndexA));
+  IndexA.USR = serialize::hashUSR("1");
+  ExpectedIdx.Children.try_emplace(llvm::toStringRef(IndexA.USR),
+                                   std::move(IndexA));
   Index IndexB;
   IndexB.Name = "B";
+  IndexB.USR = serialize::hashUSR("2");
   Index IndexC;
   IndexC.Name = "C";
-  IndexB.Children.emplace_back(std::move(IndexC));
-  ExpectedIdx.Children.emplace_back(std::move(IndexB));
+  IndexC.USR = serialize::hashUSR("3");
+  IndexB.Children.try_emplace(llvm::toStringRef(IndexC.USR), std::move(IndexC));
+  ExpectedIdx.Children.try_emplace(llvm::toStringRef(IndexB.USR),
+                                   std::move(IndexB));
   Index IndexD;
   IndexD.Name = "D";
+  IndexD.USR = serialize::hashUSR("4");
   Index IndexE;
   IndexE.Name = "E";
+  IndexE.USR = serialize::hashUSR("5");
   Index IndexF;
   IndexF.Name = "F";
-  IndexE.Children.emplace_back(std::move(IndexF));
-  IndexD.Children.emplace_back(std::move(IndexE));
-  ExpectedIdx.Children.emplace_back(std::move(IndexD));
+  IndexF.USR = serialize::hashUSR("6");
+  IndexE.Children.try_emplace(llvm::toStringRef(IndexF.USR), std::move(IndexF));
+  IndexD.Children.try_emplace(llvm::toStringRef(IndexE.USR), std::move(IndexE));
+  ExpectedIdx.Children.try_emplace(llvm::toStringRef(IndexD.USR),
+                                   std::move(IndexD));
   Index IndexG;
   IndexG.Name = "GlobalNamespace";
   IndexG.RefType = InfoType::IT_namespace;
-  ExpectedIdx.Children.emplace_back(std::move(IndexG));
+  ExpectedIdx.Children.try_emplace(llvm::toStringRef(IndexG.USR),
+                                   std::move(IndexG));
 
   CheckIndex(ExpectedIdx, Idx);
 }
 
 TEST(GeneratorTest, sortIndex) {
   Index Idx;
-  Idx.Children.emplace_back("b");
-  Idx.Children.emplace_back("aA");
-  Idx.Children.emplace_back("aa");
-  Idx.Children.emplace_back("A");
-  Idx.Children.emplace_back("a");
+  Index IndexA;
+  IndexA.Name = "a";
+  IndexA.USR = serialize::hashUSR("1");
+  Idx.Children.try_emplace(llvm::toStringRef(IndexA.USR), std::move(IndexA));
+
+  Index IndexB;
+  IndexB.Name = "A";
+  IndexB.USR = serialize::hashUSR("2");
+  Idx.Children.try_emplace(llvm::toStringRef(IndexB.USR), std::move(IndexB));
+
+  Index IndexC;
+  IndexC.Name = "aa";
+  IndexC.USR = serialize::hashUSR("3");
+  Idx.Children.try_emplace(llvm::toStringRef(IndexC.USR), std::move(IndexC));
+
+  Index IndexD;
+  IndexD.Name = "aA";
+  IndexD.USR = serialize::hashUSR("4");
+  Idx.Children.try_emplace(llvm::toStringRef(IndexD.USR), std::move(IndexD));
+
+  Index IndexE;
+  IndexE.Name = "b";
+  IndexE.USR = serialize::hashUSR("5");
+  Idx.Children.try_emplace(llvm::toStringRef(IndexE.USR), std::move(IndexE));
+
   Idx.sort();
 
   Index ExpectedIdx;
-  ExpectedIdx.Children.emplace_back("a");
-  ExpectedIdx.Children.emplace_back("A");
-  ExpectedIdx.Children.emplace_back("aa");
-  ExpectedIdx.Children.emplace_back("aA");
-  ExpectedIdx.Children.emplace_back("b");
+  Index IndexAExp;
+  IndexAExp.Name = "a";
+  IndexAExp.USR = serialize::hashUSR("1");
+  ExpectedIdx.Children.try_emplace(llvm::toStringRef(IndexAExp.USR),
+                                   std::move(IndexAExp));
+
+  Index IndexBExp;
+  IndexBExp.Name = "A";
+  IndexBExp.USR = serialize::hashUSR("2");
+  ExpectedIdx.Children.try_emplace(llvm::toStringRef(IndexBExp.USR),
+                                   std::move(IndexBExp));
+
+  Index IndexCExp;
+  IndexCExp.Name = "aa";
+  IndexCExp.USR = serialize::hashUSR("3");
+  ExpectedIdx.Children.try_emplace(llvm::toStringRef(IndexCExp.USR),
+                                   std::move(IndexCExp));
+
+  Index IndexDExp;
+  IndexDExp.Name = "aA";
+  IndexDExp.USR = serialize::hashUSR("4");
+  ExpectedIdx.Children.try_emplace(llvm::toStringRef(IndexDExp.USR),
+                                   std::move(IndexDExp));
+
+  Index IndexEExp;
+  IndexEExp.Name = "b";
+  IndexEExp.USR = serialize::hashUSR("5");
+  ExpectedIdx.Children.try_emplace(llvm::toStringRef(IndexEExp.USR),
+                                   std::move(IndexEExp));
 
   CheckIndex(ExpectedIdx, Idx);
 }


### PR DESCRIPTION
The existing implementation ends up with an O(N^2) algorithm due to
repeated linear scans during index construction. Switching to a
StringMap allows us to reduce this to O(N), since we no longer need to
search the vector.

The `BM_Index_Insertion` benchmark measures the time taken to insert N
unique records into the index.

| Scale (N Items) | Baseline (ns) | Patched (ns) | Speedup | Change |
|----------------:|--------------:|-------------:|--------:|-------:|
| 10              | 9,977         | 11,004       | 0.91x   | +10.3% |
| 64              | 69,249        | 69,166       | 1.00x   | -0.1%  |
| 512             | 1,932,714     | 525,877      | 3.68x   | -72.8% |
| 4,096           | 92,411,535    | 4,589,030    | 20.1x   | -95.0% |
| 10,000          | 577,384,945   | 12,998,039   | 44.4x   | -97.7% |

The patch delivers significant improvements to scalability. At 10,000
items, index construction is **~44 times faster**, confirming the
complexity reduction from O(N^2) to O(N). The crossover point where the
new map-based approach beats the vector-based approach appears to be
around N=64.

Since the index is typically larger than 64 for files of non trivial
complexity, and users will typically be building documentation for an
entire project with many files, all normal usage should benefit from
this change.

Other benchmarks show minor regressions, though in a typical build of
LLVM documentation index construction takes up a larger amount of
runtime than any of these other components.