### PR TITLE
[libc] Add <sys/un.h> header.

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -49,6 +49,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_syscall
     libc.include.sys_time
     libc.include.sys_types
+    libc.include.sys_un
     libc.include.sys_utsname
     libc.include.sys_wait
     libc.include.sysexits

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -51,6 +51,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_syscall
     libc.include.sys_time
     libc.include.sys_types
+    libc.include.sys_un
     libc.include.sys_utsname
     libc.include.sys_wait
     libc.include.sysexits

--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -150,6 +150,15 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  sys_socket_macros
+  HDRS
+    sys_socket_macros.h
+  FULL_BUILD_DEPENDS
+    libc.include.sys_socket
+    libc.include.llvm-libc-macros.sys_socket_macros
+)
+
+add_proxy_header_library(
   sys_stat_macros
   HDRS
     sys_stat_macros.h

--- a/libc/hdr/sys_socket_macros.h
+++ b/libc/hdr/sys_socket_macros.h
@@ -1,0 +1,22 @@
+//===-- Definition of macros from sys/socket.h ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_SYS_SOCKET_MACROS_H
+#define LLVM_LIBC_HDR_SYS_SOCKET_MACROS_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-macros/sys-socket-macros.h"
+
+#else // Overlay mode
+
+#include <sys/socket.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_SYS_SOCKET_MACROS_H

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -372,6 +372,15 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  struct_sockaddr_un
+  HDRS
+    struct_sockaddr_un.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.struct_sockaddr_un
+    libc.include.sys_socket
+)
+
+add_proxy_header_library(
   socklen_t
   HDRS
     socklen_t.h

--- a/libc/hdr/types/struct_sockaddr_un.h
+++ b/libc/hdr/types/struct_sockaddr_un.h
@@ -1,0 +1,21 @@
+//===-- Proxy for struct sockaddr_un  -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_HDR_TYPES_STRUCT_SOCKADDR_UN_H
+#define LLVM_LIBC_HDR_TYPES_STRUCT_SOCKADDR_UN_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/struct_sockaddr_un.h"
+
+#else
+
+#include <sys/un.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_STRUCT_SOCKADDR_UN_H

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -680,7 +680,6 @@ add_header_macro(
     .llvm-libc-types.struct_iovec
     .llvm-libc-types.struct_msghdr
     .llvm-libc-types.struct_sockaddr
-    .llvm-libc-types.struct_sockaddr_un
 )
 
 add_header_macro(
@@ -757,6 +756,15 @@ add_header_macro(
     .llvm_libc_common_h
     .llvm-libc-types.struct_iovec
     .llvm-libc-types.ssize_t
+)
+
+add_header_macro(
+  sys_un
+  ../libc/include/sys/un.yaml
+  sys/un.h
+  DEPENDS
+    .llvm_libc_common_h
+    .llvm-libc-types.struct_sockaddr_un
 )
 
 add_header_macro(

--- a/libc/include/sys/socket.yaml
+++ b/libc/include/sys/socket.yaml
@@ -2,7 +2,6 @@ header: sys/socket.h
 header_template: socket.h.def
 macros: []
 types:
-  - type_name: struct_sockaddr_un
   - type_name: struct_sockaddr
   - type_name: socklen_t
   - type_name: sa_family_t

--- a/libc/include/sys/un.yaml
+++ b/libc/include/sys/un.yaml
@@ -1,0 +1,5 @@
+header: sys/un.h
+standards:
+  - posix
+types:
+  - type_name: struct_sockaddr_un

--- a/libc/test/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/test/src/sys/socket/linux/CMakeLists.txt
@@ -23,6 +23,8 @@ add_libc_unittest(
     bind_test.cpp
   DEPENDS
     libc.include.sys_socket
+    libc.hdr.sys_socket_macros
+    libc.hdr.types.struct_sockaddr_un
     libc.src.errno.errno
     libc.src.sys.socket.socket
     libc.src.sys.socket.bind

--- a/libc/test/src/sys/socket/linux/bind_test.cpp
+++ b/libc/test/src/sys/socket/linux/bind_test.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_socket_macros.h"
+#include "hdr/types/struct_sockaddr_un.h"
 #include "src/sys/socket/bind.h"
 #include "src/sys/socket/socket.h"
 
@@ -15,8 +17,6 @@
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
-
-#include <sys/socket.h> // For AF_UNIX and SOCK_DGRAM
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 using LlvmLibcBindTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;


### PR DESCRIPTION
`sockaddr_un` structure is supposed to be provided by the `<sys/un.h>` header. Add this header to llvm-libc, and move the declaration of `sockaddr_un` there from `<sys/socket.h>`. See https://man7.org/linux/man-pages/man0/sys_un.h.0p.html

Add proxy headers for the `<sys/socket.h>` macro (like `AF_UNIX`) and for the `struct sockaddr_un` so that the tests can be more hermetic and avoid system header inclusion.