### PR TITLE
[lldb] Automatically discover and load dynamic LLDB Plugins

### DIFF
--- a/lldb/include/lldb/Utility/FileSpec.h
+++ b/lldb/include/lldb/Utility/FileSpec.h
@@ -243,7 +243,6 @@ public:
   /// Clear the directory in this object.
   void ClearDirectory();
 
-
   /// Filename string const get accessor.
   ///
   /// \return
@@ -424,11 +423,7 @@ protected:
   /// state in this object.
   void PathWasModified() { m_absolute = Absolute::Calculate; }
 
-  enum class Absolute : uint8_t {
-    Calculate,
-    Yes,
-    No
-  };
+  enum class Absolute : uint8_t { Calculate, Yes, No };
 
   /// The unique'd directory path.
   ConstString m_directory;
@@ -471,6 +466,30 @@ template <> struct format_provider<lldb_private::FileSpec> {
   static void format(const lldb_private::FileSpec &F, llvm::raw_ostream &Stream,
                      StringRef Style);
 };
+
+/// DenseMapInfo implementation.
+/// \{
+template <> struct DenseMapInfo<lldb_private::FileSpec> {
+  static inline lldb_private::FileSpec getEmptyKey() {
+    return lldb_private::FileSpec();
+  }
+  static inline lldb_private::FileSpec getTombstoneKey() {
+    return lldb_private::FileSpec();
+  }
+  static unsigned getHashValue(lldb_private::FileSpec file_spec) {
+    return llvm::hash_combine(
+        DenseMapInfo<lldb_private::ConstString>::getHashValue(
+            file_spec.GetDirectory()),
+        DenseMapInfo<lldb_private::ConstString>::getHashValue(
+            file_spec.GetFilename()),
+        DenseMapInfo<llvm::sys::path::Style>::getHashValue(
+            file_spec.GetPathStyle()));
+  }
+  static bool isEqual(lldb_private::FileSpec LHS, lldb_private::FileSpec RHS) {
+    return LHS == RHS;
+  }
+};
+/// \}
 
 } // namespace llvm
 


### PR DESCRIPTION
LLDB's architecture is heavily centered around plugins. Its primary purpose is abstraction and modularity, more so than extensibility. For example, all the in-tree plugins are linked in statically. However, it is possible to load modules dynamically, though that's mostly aimed at plugins that built on top of the stable public SB API.

I'm working on support for loading modules dynamically, specifically in-tree modules that use the LLDB_PLUGIN_DEFINE macro and the corresponding CMake machinery.

This PR adds support for initializing modules using the symbols generated by the aforementioned macro. This makes it possible to convert plugins to shared libraries with minimal changes: is:

 - Replace PLUGIN with SHARED in the plugin's CMakeLists.txt.
 - Link against libLLDB instead of linking statically against LLVM and LLDB libraries.
 - Re-export all private symbols from libLLDB with `-DLLDB_EXPORT_ALL_SYMBOLS=ON`.