### PR TITLE
[clang-tidy] Teach `performance-faster-string-find` about `starts_with`, `ends_with`, and `contains`

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -224,6 +224,11 @@ Changes in existing checks
 
   - Improved the ignore list to correctly handle ``typedef`` and  ``enum``.
 
+- Improved :doc:`performance-faster-string-find
+  <clang-tidy/checks/performance/faster-string-find>` check to
+  analyze calls to the ``starts_with``, ``ends_with``, and ``contains``
+  string member functions.
+
 - Improved :doc:`performance-inefficient-vector-operation
   <clang-tidy/checks/performance/inefficient-vector-operation>` check by
   correctly handling vector-like classes when ``push_back``/``emplace_back`` are

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/faster-string-find.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/faster-string-find.rst
@@ -24,6 +24,7 @@ Options
 
    Semicolon-separated list of names of string-like classes. By default only
    ``::std::basic_string`` and ``::std::basic_string_view`` are considered.
-   The check will only consider member functions named ``find``, ``rfind``,
-   ``find_first_of``, ``find_first_not_of``, ``find_last_of``, or
-   ``find_last_not_of`` within these classes.
+   Within these classes, the check will only consider member functions named
+   ``find``, ``rfind``, ``find_first_of``, ``find_first_not_of``,
+   ``find_last_of``, ``find_last_not_of``, ``starts_with``, ``ends_with``, or
+   ``contains``.

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/faster-string-find.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/faster-string-find.cpp
@@ -14,6 +14,9 @@ struct basic_string {
   int find_first_not_of(const Char *) const;
   int find_last_of(const Char *) const;
   int find_last_not_of(const Char *) const;
+  bool starts_with(const Char *) const;
+  bool ends_with(const Char *) const;
+  bool contains(const Char *) const;
 };
 
 typedef basic_string<char> string;
@@ -28,6 +31,9 @@ struct basic_string_view {
   int find_first_not_of(const Char *) const;
   int find_last_of(const Char *) const;
   int find_last_not_of(const Char *) const;
+  bool starts_with(const Char *) const;
+  bool ends_with(const Char *) const;
+  bool contains(const Char *) const;
 };
 
 typedef basic_string_view<char> string_view;
@@ -87,6 +93,15 @@ void StringFind() {
   Str.find_last_not_of("a");
   // CHECK-MESSAGES: [[@LINE-1]]:24: warning: 'find_last_not_of' called with a
   // CHECK-FIXES: Str.find_last_not_of('a');
+  Str.starts_with("a");
+  // CHECK-MESSAGES: [[@LINE-1]]:19: warning: 'starts_with' called with a
+  // CHECK-FIXES: Str.starts_with('a');
+  Str.ends_with("a");
+  // CHECK-MESSAGES: [[@LINE-1]]:17: warning: 'ends_with' called with a string
+  // CHECK-FIXES: Str.ends_with('a');
+  Str.contains("a");
+  // CHECK-MESSAGES: [[@LINE-1]]:16: warning: 'contains' called with a
+  // CHECK-FIXES: Str.contains('a');
 
   // std::wstring should work.
   std::wstring WStr;


### PR DESCRIPTION
These aren't "find" functions per se, so they don't totally match the check name, but the same optimization is applicable to them (for example, see https://en.cppreference.com/w/cpp/string/basic_string_view/starts_with.html). This optimization could be expanded to `operator+=` as well, but that's a bit more involved, so I'm not doing it in this PR.