### PR TITLE
[lldb] Export *all* private symbols when using LLDB_EXPORT_ALL_SYMBOLS

### DIFF
--- a/lldb/source/API/liblldb-private.exports
+++ b/lldb/source/API/liblldb-private.exports
@@ -2,6 +2,10 @@ _ZN4lldb*
 _ZNK4lldb*
 _ZN12lldb_private*
 _ZNK12lldb_private*
+_ZTVN12lldb_private*
+_ZN4llvm*
+_ZNK4llvm*
+_ZTVN4llvm*
 init_lld*
 PyInit__lldb*
 luaopen_lldb*


### PR DESCRIPTION
Export *all* private symbols, from both LLDB and LLVM. The motivation for this is to be able to create dynamically linked LLDB plugins. These plugins cannot link any LLDB or LLVM code statically as that results in duplicated symbols, and instead have to use the ones from libLLDB.