### PR TITLE
[flang-rt] Temporarily disable destructor call in OwningPtr::delete_ptr.

### DIFF
--- a/flang-rt/include/flang-rt/runtime/memory.h
+++ b/flang-rt/include/flang-rt/runtime/memory.h
@@ -110,7 +110,28 @@ public:
 
 private:
   RT_API_ATTRS void delete_ptr(pointer_type p) {
+#if RT_USE_LIBCUDACXX && defined(RT_DEVICE_COMPILATION)
+    // FIXME: Calling the destructor here introduces an SCC call chain
+    // like this:
+    //
+    // |------------|
+    // |            V
+    // |    ChildIo::~ChildIo()
+    // |            |
+    // |            V
+    // | -> OwningPtr<Fortran::runtime::io::ChildIo>::~OwningPtr()
+    // |            |
+    // |            V
+    // | OwningPtr<Fortran::runtime::io::ChildIo>::delete_ptr(
+    // |   Fortran::runtime::io::ChildIo*)
+    // |____________|
+    //
+    // This prevents computing static stack size in CUDA kernels.
+    // This code is temporarily disabled for RT_USE_LIBCUDACXX builds
+    // on the device.
+#else
     p->~A();
+#endif
     FreeMemory(p);
   }
   pointer_type ptr_{};


### PR DESCRIPTION
This is causing failures in CUF testing, because the device compiler
cannot identify the static stack size for kernels.
