### PR TITLE
[SlotIndexes] Further pack indices to improve spill placement time

### DIFF
--- a/llvm/lib/CodeGen/SlotIndexes.cpp
+++ b/llvm/lib/CodeGen/SlotIndexes.cpp
@@ -182,6 +182,13 @@ void SlotIndexes::renumberIndexes(IndexList::iterator curItr) {
 
   LLVM_DEBUG(dbgs() << "\n*** Renumbered SlotIndexes " << startItr->getIndex()
                     << '-' << index << " ***\n");
+
+  // If we repack all the way to the end, add spacing in between the
+  // instructions so that future renumberings are able to catch up
+  // without also renumbering all the way to the end.
+  if (index == getLastIndex().getIndex())
+    packIndexes();
+
   ++NumLocalRenum;
 }
 

--- a/llvm/lib/CodeGen/SlotIndexes.cpp
+++ b/llvm/lib/CodeGen/SlotIndexes.cpp
@@ -174,6 +174,7 @@ void SlotIndexes::renumberIndexes(IndexList::iterator curItr) {
 
   IndexList::iterator startItr = std::prev(curItr);
   unsigned index = startItr->getIndex();
+  unsigned BeginIndex = index;
   do {
     curItr->setIndex(index += Space);
     ++curItr;
@@ -183,10 +184,11 @@ void SlotIndexes::renumberIndexes(IndexList::iterator curItr) {
   LLVM_DEBUG(dbgs() << "\n*** Renumbered SlotIndexes " << startItr->getIndex()
                     << '-' << index << " ***\n");
 
-  // If we repack all the way to the end, add spacing in between the
+  // If we repack more than 20% of a function, add spacing in between the
   // instructions so that future renumberings are able to catch up
-  // without also renumbering all the way to the end.
-  if (index == getLastIndex().getIndex())
+  // without also renumbering so much.
+  if (index - BeginIndex >
+      (getLastIndex().getIndex() - getZeroIndex().getIndex()) / 5)
     packIndexes();
 
   ++NumLocalRenum;

--- a/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-01.mir
+++ b/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-01.mir
@@ -1665,32 +1665,32 @@ body:             |
 # CHECK-NEXT: SU(12) [TopReadyCycle = 0, BottomReadyCycle = 3]:   $q1 = COPY %12:fpr128
 # CHECK-EMPTY:
 # CHECK-NEXT: ********** INTERVALS **********
-# CHECK-NEXT: B0 [0B,48r:0)[192r,224r:1) 0@0B-phi 1@192r
-# CHECK-NEXT: B1 [0B,88r:0)[208r,224r:1) 0@0B-phi 1@208r
-# CHECK-NEXT: B2 [0B,96r:0) 0@0B-phi
-# CHECK-NEXT: B0_HI [0B,48r:0)[192r,224r:1) 0@0B-phi 1@192r
-# CHECK-NEXT: H0_HI [0B,48r:0)[192r,224r:1) 0@0B-phi 1@192r
-# CHECK-NEXT: S0_HI [0B,48r:0)[192r,224r:1) 0@0B-phi 1@192r
-# CHECK-NEXT: B1_HI [0B,88r:0)[208r,224r:1) 0@0B-phi 1@208r
-# CHECK-NEXT: H1_HI [0B,88r:0)[208r,224r:1) 0@0B-phi 1@208r
-# CHECK-NEXT: S1_HI [0B,88r:0)[208r,224r:1) 0@0B-phi 1@208r
-# CHECK-NEXT: B2_HI [0B,96r:0) 0@0B-phi
-# CHECK-NEXT: H2_HI [0B,96r:0) 0@0B-phi
-# CHECK-NEXT: S2_HI [0B,96r:0) 0@0B-phi
-# CHECK-NEXT: D0_HI [0B,48r:0)[192r,224r:1) 0@0B-phi 1@192r
-# CHECK-NEXT: D1_HI [0B,88r:0)[208r,224r:1) 0@0B-phi 1@208r
-# CHECK-NEXT: D2_HI [0B,96r:0) 0@0B-phi
-# CHECK-NEXT: %0 [48r,168r:0) 0@48r  weight:0.000000e+00
-# CHECK-NEXT: %1 [88r,120r:0) 0@88r  weight:0.000000e+00
-# CHECK-NEXT: %2 [96r,128r:0) 0@96r  weight:0.000000e+00
-# CHECK-NEXT: %3 [104r,176r:0) 0@104r  weight:0.000000e+00
-# CHECK-NEXT: %6 [80r,128r:0) 0@80r  weight:0.000000e+00
-# CHECK-NEXT: %7 [128r,160r:0) 0@128r  weight:0.000000e+00
-# CHECK-NEXT: %8 [120r,136r:0) 0@120r  weight:0.000000e+00
-# CHECK-NEXT: %9 [136r,168r:0) 0@136r  weight:0.000000e+00
-# CHECK-NEXT: %10 [168r,192r:0) 0@168r  weight:0.000000e+00
-# CHECK-NEXT: %11 [160r,176r:0) 0@160r  weight:0.000000e+00
-# CHECK-NEXT: %12 [176r,208r:0) 0@176r  weight:0.000000e+00
+# CHECK-NEXT: B0 [0B,48r:0)[272r,304r:1) 0@0B-phi 1@272r
+# CHECK-NEXT: B1 [0B,96r:0)[288r,304r:1) 0@0B-phi 1@288r
+# CHECK-NEXT: B2 [0B,112r:0) 0@0B-phi
+# CHECK-NEXT: B0_HI [0B,48r:0)[272r,304r:1) 0@0B-phi 1@272r
+# CHECK-NEXT: H0_HI [0B,48r:0)[272r,304r:1) 0@0B-phi 1@272r
+# CHECK-NEXT: S0_HI [0B,48r:0)[272r,304r:1) 0@0B-phi 1@272r
+# CHECK-NEXT: B1_HI [0B,96r:0)[288r,304r:1) 0@0B-phi 1@288r
+# CHECK-NEXT: H1_HI [0B,96r:0)[288r,304r:1) 0@0B-phi 1@288r
+# CHECK-NEXT: S1_HI [0B,96r:0)[288r,304r:1) 0@0B-phi 1@288r
+# CHECK-NEXT: B2_HI [0B,112r:0) 0@0B-phi
+# CHECK-NEXT: H2_HI [0B,112r:0) 0@0B-phi
+# CHECK-NEXT: S2_HI [0B,112r:0) 0@0B-phi
+# CHECK-NEXT: D0_HI [0B,48r:0)[272r,304r:1) 0@0B-phi 1@272r
+# CHECK-NEXT: D1_HI [0B,96r:0)[288r,304r:1) 0@0B-phi 1@288r
+# CHECK-NEXT: D2_HI [0B,112r:0) 0@0B-phi
+# CHECK-NEXT: %0 [48r,240r:0) 0@48r  weight:0.000000e+00
+# CHECK-NEXT: %1 [96r,160r:0) 0@96r  weight:0.000000e+00
+# CHECK-NEXT: %2 [112r,176r:0) 0@112r  weight:0.000000e+00
+# CHECK-NEXT: %3 [128r,256r:0) 0@128r  weight:0.000000e+00
+# CHECK-NEXT: %6 [80r,176r:0) 0@80r  weight:0.000000e+00
+# CHECK-NEXT: %7 [176r,224r:0) 0@176r  weight:0.000000e+00
+# CHECK-NEXT: %8 [160r,192r:0) 0@160r  weight:0.000000e+00
+# CHECK-NEXT: %9 [192r,240r:0) 0@192r  weight:0.000000e+00
+# CHECK-NEXT: %10 [240r,272r:0) 0@240r  weight:0.000000e+00
+# CHECK-NEXT: %11 [224r,256r:0) 0@224r  weight:0.000000e+00
+# CHECK-NEXT: %12 [256r,288r:0) 0@256r  weight:0.000000e+00
 # CHECK-NEXT: RegMasks:
 # CHECK-NEXT: ********** MACHINEINSTRS **********
 # CHECK-NEXT: # Machine code for function umull_and_v8i32: IsSSA, NoPHIs, TracksLiveness
@@ -1700,17 +1700,17 @@ body:             |
 # CHECK-NEXT: 	  liveins: $q0, $q1, $q2
 # CHECK-NEXT: 48B	  %0:fpr128 = COPY $q0
 # CHECK-NEXT: 80B	  %6:fpr128 = MOVIv2d_ns 17
-# CHECK-NEXT: 88B	  %1:fpr128 = COPY $q1
-# CHECK-NEXT: 96B	  %2:fpr128 = COPY $q2
-# CHECK-NEXT: 104B	  %3:fpr128 = EXTv16i8 %0:fpr128, %0:fpr128, 8
-# CHECK-NEXT: 120B	  %8:fpr128 = ANDv16i8 %1:fpr128, %6:fpr128
-# CHECK-NEXT: 128B	  %7:fpr128 = ANDv16i8 %2:fpr128, %6:fpr128
-# CHECK-NEXT: 136B	  %9:fpr64 = XTNv4i16 %8:fpr128
-# CHECK-NEXT: 160B	  %11:fpr64 = XTNv4i16 %7:fpr128
-# CHECK-NEXT: 168B	  %10:fpr128 = UMULLv4i16_v4i32 %0.dsub:fpr128, %9:fpr64
-# CHECK-NEXT: 176B	  %12:fpr128 = UMULLv4i16_v4i32 %3.dsub:fpr128, %11:fpr64
-# CHECK-NEXT: 192B	  $q0 = COPY %10:fpr128
-# CHECK-NEXT: 208B	  $q1 = COPY %12:fpr128
-# CHECK-NEXT: 224B	  RET_ReallyLR implicit $q0, implicit $q1
+# CHECK-NEXT: 96B	  %1:fpr128 = COPY $q1
+# CHECK-NEXT: 112B	  %2:fpr128 = COPY $q2
+# CHECK-NEXT: 128B	  %3:fpr128 = EXTv16i8 %0:fpr128, %0:fpr128, 8
+# CHECK-NEXT: 160B	  %8:fpr128 = ANDv16i8 %1:fpr128, %6:fpr128
+# CHECK-NEXT: 176B	  %7:fpr128 = ANDv16i8 %2:fpr128, %6:fpr128
+# CHECK-NEXT: 192B	  %9:fpr64 = XTNv4i16 %8:fpr128
+# CHECK-NEXT: 224B	  %11:fpr64 = XTNv4i16 %7:fpr128
+# CHECK-NEXT: 240B	  %10:fpr128 = UMULLv4i16_v4i32 %0.dsub:fpr128, %9:fpr64
+# CHECK-NEXT: 256B	  %12:fpr128 = UMULLv4i16_v4i32 %3.dsub:fpr128, %11:fpr64
+# CHECK-NEXT: 272B	  $q0 = COPY %10:fpr128
+# CHECK-NEXT: 288B	  $q1 = COPY %12:fpr128
+# CHECK-NEXT: 304B	  RET_ReallyLR implicit $q0, implicit $q1
 # CHECK-EMPTY:
 # CHECK-NEXT: # End machine code for function umull_and_v8i32.

--- a/llvm/test/CodeGen/AMDGPU/remat-sop.mir
+++ b/llvm/test/CodeGen/AMDGPU/remat-sop.mir
@@ -615,9 +615,9 @@ body:             |
     ; GCN-NEXT: renamable $sgpr1 = COPY killed renamable $sgpr3
     ; GCN-NEXT: SI_SPILL_S32_SAVE killed renamable $sgpr1, %stack.2, implicit $exec, implicit $sp_reg :: (store (s32) into %stack.2, addrspace 5)
     ; GCN-NEXT: renamable $sgpr0_sgpr1 = S_GETPC_B64_pseudo
-    ; GCN-NEXT: SI_SPILL_S32_SAVE killed renamable $sgpr0, %stack.5, implicit $exec, implicit $sp_reg :: (store (s32) into %stack.5, addrspace 5)
-    ; GCN-NEXT: renamable $sgpr0 = COPY killed renamable $sgpr1
     ; GCN-NEXT: SI_SPILL_S32_SAVE killed renamable $sgpr0, %stack.4, implicit $exec, implicit $sp_reg :: (store (s32) into %stack.4, addrspace 5)
+    ; GCN-NEXT: renamable $sgpr0 = COPY killed renamable $sgpr1
+    ; GCN-NEXT: SI_SPILL_S32_SAVE killed renamable $sgpr0, %stack.5, implicit $exec, implicit $sp_reg :: (store (s32) into %stack.5, addrspace 5)
     ; GCN-NEXT: renamable $sgpr0 = SI_SPILL_S32_RESTORE %stack.1, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.1, addrspace 5)
     ; GCN-NEXT: renamable $sgpr1 = SI_SPILL_S32_RESTORE %stack.3, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.3, addrspace 5)
     ; GCN-NEXT: dead renamable $sgpr0 = S_ADD_U32 killed renamable $sgpr1, killed renamable $sgpr0, implicit-def $scc
@@ -625,16 +625,16 @@ body:             |
     ; GCN-NEXT: renamable $sgpr1 = SI_SPILL_S32_RESTORE %stack.2, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.2, addrspace 5)
     ; GCN-NEXT: dead renamable $sgpr0 = S_ADDC_U32 killed renamable $sgpr0, killed renamable $sgpr1, implicit-def $scc, implicit $scc
     ; GCN-NEXT: renamable $sgpr0 = SI_SPILL_S32_RESTORE %stack.3, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.3, addrspace 5)
-    ; GCN-NEXT: renamable $sgpr1 = SI_SPILL_S32_RESTORE %stack.5, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.5, addrspace 5)
+    ; GCN-NEXT: renamable $sgpr1 = SI_SPILL_S32_RESTORE %stack.4, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.4, addrspace 5)
     ; GCN-NEXT: dead renamable $sgpr0 = S_ADD_U32 killed renamable $sgpr0, killed renamable $sgpr1, implicit-def $scc
     ; GCN-NEXT: renamable $sgpr0 = SI_SPILL_S32_RESTORE %stack.0, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.0, addrspace 5)
-    ; GCN-NEXT: renamable $sgpr1 = SI_SPILL_S32_RESTORE %stack.4, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.4, addrspace 5)
+    ; GCN-NEXT: renamable $sgpr1 = SI_SPILL_S32_RESTORE %stack.5, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.5, addrspace 5)
     ; GCN-NEXT: dead renamable $sgpr0 = S_ADDC_U32 killed renamable $sgpr0, killed renamable $sgpr1, implicit-def $scc, implicit $scc
     ; GCN-NEXT: renamable $sgpr0 = SI_SPILL_S32_RESTORE %stack.1, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.1, addrspace 5)
-    ; GCN-NEXT: renamable $sgpr1 = SI_SPILL_S32_RESTORE %stack.5, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.5, addrspace 5)
+    ; GCN-NEXT: renamable $sgpr1 = SI_SPILL_S32_RESTORE %stack.4, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.4, addrspace 5)
     ; GCN-NEXT: dead renamable $sgpr0 = S_ADD_U32 killed renamable $sgpr0, killed renamable $sgpr1, implicit-def $scc
     ; GCN-NEXT: renamable $sgpr0 = SI_SPILL_S32_RESTORE %stack.2, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.2, addrspace 5)
-    ; GCN-NEXT: renamable $sgpr1 = SI_SPILL_S32_RESTORE %stack.4, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.4, addrspace 5)
+    ; GCN-NEXT: renamable $sgpr1 = SI_SPILL_S32_RESTORE %stack.5, implicit $exec, implicit $sp_reg :: (load (s32) from %stack.5, addrspace 5)
     ; GCN-NEXT: dead renamable $sgpr0 = S_ADDC_U32 killed renamable $sgpr0, killed renamable $sgpr1, implicit-def $scc, implicit $scc
     ; GCN-NEXT: S_ENDPGM 0
     %0:sreg_64 = S_GETPC_B64_pseudo

--- a/llvm/test/CodeGen/PowerPC/rematerializable-instruction-machine-licm.ll
+++ b/llvm/test/CodeGen/PowerPC/rematerializable-instruction-machine-licm.ll
@@ -159,138 +159,138 @@ define zeroext i32 @test1(i64 %0, ptr %1) {
 ; CHECK-NEXT:    std 4, 488(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 488
 ; CHECK-NEXT:    ori 4, 4, 18432
-; CHECK-NEXT:    std 4, 480(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 248(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 537
+; CHECK-NEXT:    ld 22, 248(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 7168
-; CHECK-NEXT:    std 4, 472(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 240(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 36
+; CHECK-NEXT:    ld 21, 240(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 40704
-; CHECK-NEXT:    std 4, 464(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 232(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 85
+; CHECK-NEXT:    ld 20, 232(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 29440
-; CHECK-NEXT:    std 4, 456(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 480(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 134
 ; CHECK-NEXT:    ori 4, 4, 18176
 ; CHECK-NEXT:    std 4, 448(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 183
 ; CHECK-NEXT:    ori 4, 4, 6912
-; CHECK-NEXT:    std 4, 440(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 432(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 231
 ; CHECK-NEXT:    ori 4, 4, 61184
-; CHECK-NEXT:    std 4, 432(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 416(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 280
 ; CHECK-NEXT:    ori 4, 4, 49920
-; CHECK-NEXT:    std 4, 424(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 400(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 329
 ; CHECK-NEXT:    ori 4, 4, 38656
-; CHECK-NEXT:    std 4, 416(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 216(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 378
 ; CHECK-NEXT:    ori 4, 4, 27392
-; CHECK-NEXT:    std 4, 408(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 200(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 427
 ; CHECK-NEXT:    ori 4, 4, 16128
-; CHECK-NEXT:    std 4, 400(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 184(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 476
+; CHECK-NEXT:    ld 30, 184(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 4864
-; CHECK-NEXT:    std 4, 248(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 168(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 524
+; CHECK-NEXT:    ld 29, 168(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 59136
-; CHECK-NEXT:    std 4, 240(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 152(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 573
+; CHECK-NEXT:    ld 28, 152(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 47872
-; CHECK-NEXT:    std 4, 232(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 136(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 24
+; CHECK-NEXT:    ld 27, 136(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 27136
-; CHECK-NEXT:    std 4, 224(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 120(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 73
+; CHECK-NEXT:    ld 26, 120(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 15872
-; CHECK-NEXT:    std 4, 216(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 104(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 122
+; CHECK-NEXT:    ld 25, 104(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 4608
-; CHECK-NEXT:    std 4, 208(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 88(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 170
+; CHECK-NEXT:    ld 24, 88(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 58880
-; CHECK-NEXT:    std 4, 200(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 80(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 219
+; CHECK-NEXT:    ld 2, 80(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 47616
-; CHECK-NEXT:    std 4, 192(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 72(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 36352
 ; CHECK-NEXT:    lis 5, 317
-; CHECK-NEXT:    ld 30, 192(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 184(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 64(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 25088
 ; CHECK-NEXT:    lis 5, 366
-; CHECK-NEXT:    ld 29, 184(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 176(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 23, 64(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 56(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 13824
 ; CHECK-NEXT:    lis 5, 415
-; CHECK-NEXT:    ld 28, 176(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 168(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 48(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 2560
 ; CHECK-NEXT:    lis 5, 463
-; CHECK-NEXT:    ld 27, 168(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 160(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 40(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 56832
 ; CHECK-NEXT:    lis 5, 512
-; CHECK-NEXT:    ld 26, 160(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 152(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 472(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 45568
 ; CHECK-NEXT:    lis 5, 561
-; CHECK-NEXT:    ld 25, 152(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 144(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 464(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 34304
 ; CHECK-NEXT:    lis 5, 12
-; CHECK-NEXT:    ld 24, 144(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 136(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 456(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 13568
 ; CHECK-NEXT:    lis 5, 61
-; CHECK-NEXT:    ld 23, 136(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 128(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 440(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 2304
 ; CHECK-NEXT:    lis 5, 109
-; CHECK-NEXT:    std 4, 120(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 424(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 56576
 ; CHECK-NEXT:    lis 5, 158
-; CHECK-NEXT:    ld 0, 120(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 112(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 408(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 45312
 ; CHECK-NEXT:    lis 5, 207
-; CHECK-NEXT:    ld 22, 112(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 104(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 224(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 34048
 ; CHECK-NEXT:    lis 5, 256
-; CHECK-NEXT:    ld 21, 104(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 96(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 208(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 22784
-; CHECK-NEXT:    ld 5, 248(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 20, 96(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 88(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 5, 72(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 192(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 6, 11520
-; CHECK-NEXT:    ld 6, 240(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 19, 88(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 80(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 6, 48(1) # 8-byte Folded Reload
+; CHECK-NEXT:    ld 19, 192(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 176(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 7, 256
-; CHECK-NEXT:    ld 7, 232(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 18, 80(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 72(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 7, 40(1) # 8-byte Folded Reload
+; CHECK-NEXT:    ld 18, 176(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 160(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 8, 54528
 ; CHECK-NEXT:    ld 8, 224(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 17, 72(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 64(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 17, 160(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 144(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 9, 43264
 ; CHECK-NEXT:    ld 9, 216(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 16, 64(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 56(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 16, 144(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 128(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 10, 32000
 ; CHECK-NEXT:    ld 10, 208(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 15, 56(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 48(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 15, 128(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 112(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 11, 20736
 ; CHECK-NEXT:    ld 11, 200(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 14, 48(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 40(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 14, 112(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 96(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    li 4, 0
-; CHECK-NEXT:    ld 31, 40(1) # 8-byte Folded Reload
+; CHECK-NEXT:    ld 31, 96(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB0_1: # =>This Loop Header: Depth=1
 ; CHECK-NEXT:    # Child Loop BB0_2 Depth 2
@@ -298,19 +298,17 @@ define zeroext i32 @test1(i64 %0, ptr %1) {
 ; CHECK-NEXT:    li 4, 83
 ; CHECK-NEXT:    mtctr 4
 ; CHECK-NEXT:    ld 12, 256(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 4, 128(1) # 8-byte Folded Reload
+; CHECK-NEXT:    ld 4, 56(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    .p2align 5
 ; CHECK-NEXT:  .LBB0_2: # Parent Loop BB0_1 Depth=1
 ; CHECK-NEXT:    # => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    ld 2, 560(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdux 3, 12, 2
-; CHECK-NEXT:    ld 2, 552(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 5
-; CHECK-NEXT:    stdx 3, 12, 6
-; CHECK-NEXT:    stdx 3, 12, 7
-; CHECK-NEXT:    stdx 3, 12, 8
+; CHECK-NEXT:    ld 0, 560(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdux 3, 12, 0
+; CHECK-NEXT:    ld 0, 552(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 22
+; CHECK-NEXT:    stdx 3, 12, 21
+; CHECK-NEXT:    stdx 3, 12, 20
 ; CHECK-NEXT:    stdx 3, 12, 9
-; CHECK-NEXT:    stdx 3, 12, 10
 ; CHECK-NEXT:    stdx 3, 12, 11
 ; CHECK-NEXT:    stdx 3, 12, 30
 ; CHECK-NEXT:    stdx 3, 12, 29
@@ -319,12 +317,14 @@ define zeroext i32 @test1(i64 %0, ptr %1) {
 ; CHECK-NEXT:    stdx 3, 12, 26
 ; CHECK-NEXT:    stdx 3, 12, 25
 ; CHECK-NEXT:    stdx 3, 12, 24
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    stdx 3, 12, 5
 ; CHECK-NEXT:    stdx 3, 12, 23
 ; CHECK-NEXT:    stdx 3, 12, 4
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    stdx 3, 12, 22
-; CHECK-NEXT:    stdx 3, 12, 21
-; CHECK-NEXT:    stdx 3, 12, 20
+; CHECK-NEXT:    stdx 3, 12, 6
+; CHECK-NEXT:    stdx 3, 12, 7
+; CHECK-NEXT:    stdx 3, 12, 8
+; CHECK-NEXT:    stdx 3, 12, 10
 ; CHECK-NEXT:    stdx 3, 12, 19
 ; CHECK-NEXT:    stdx 3, 12, 18
 ; CHECK-NEXT:    stdx 3, 12, 17
@@ -332,45 +332,45 @@ define zeroext i32 @test1(i64 %0, ptr %1) {
 ; CHECK-NEXT:    stdx 3, 12, 15
 ; CHECK-NEXT:    stdx 3, 12, 14
 ; CHECK-NEXT:    stdx 3, 12, 31
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 544(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 536(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 528(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 520(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 512(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 504(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 496(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 488(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 480(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 472(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 464(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 456(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 448(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 440(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 432(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 424(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 416(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 408(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    ld 2, 400(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 544(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 536(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 528(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 520(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 512(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 504(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 496(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 488(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 480(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 448(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 432(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 416(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 400(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 472(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 464(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 456(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 440(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 424(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    ld 0, 408(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 0
 ; CHECK-NEXT:    bdnz .LBB0_2
 ; CHECK-NEXT:  # %bb.3:
 ; CHECK-NEXT:    ld 12, 384(1) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/PowerPC/rematerializable-instruction-machine-licm.ll
+++ b/llvm/test/CodeGen/PowerPC/rematerializable-instruction-machine-licm.ll
@@ -159,138 +159,138 @@ define zeroext i32 @test1(i64 %0, ptr %1) {
 ; CHECK-NEXT:    std 4, 488(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 488
 ; CHECK-NEXT:    ori 4, 4, 18432
-; CHECK-NEXT:    std 4, 248(1) # 8-byte Folded Spill
-; CHECK-NEXT:    lis 4, 537
-; CHECK-NEXT:    ld 22, 248(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ori 4, 4, 7168
-; CHECK-NEXT:    std 4, 240(1) # 8-byte Folded Spill
-; CHECK-NEXT:    lis 4, 36
-; CHECK-NEXT:    ld 21, 240(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ori 4, 4, 40704
-; CHECK-NEXT:    std 4, 232(1) # 8-byte Folded Spill
-; CHECK-NEXT:    lis 4, 85
-; CHECK-NEXT:    ld 20, 232(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ori 4, 4, 29440
 ; CHECK-NEXT:    std 4, 480(1) # 8-byte Folded Spill
+; CHECK-NEXT:    lis 4, 537
+; CHECK-NEXT:    ori 4, 4, 7168
+; CHECK-NEXT:    std 4, 472(1) # 8-byte Folded Spill
+; CHECK-NEXT:    lis 4, 36
+; CHECK-NEXT:    ori 4, 4, 40704
+; CHECK-NEXT:    std 4, 464(1) # 8-byte Folded Spill
+; CHECK-NEXT:    lis 4, 85
+; CHECK-NEXT:    ori 4, 4, 29440
+; CHECK-NEXT:    std 4, 456(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 134
 ; CHECK-NEXT:    ori 4, 4, 18176
 ; CHECK-NEXT:    std 4, 448(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 183
 ; CHECK-NEXT:    ori 4, 4, 6912
-; CHECK-NEXT:    std 4, 432(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 440(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 231
 ; CHECK-NEXT:    ori 4, 4, 61184
-; CHECK-NEXT:    std 4, 416(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 432(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 280
 ; CHECK-NEXT:    ori 4, 4, 49920
-; CHECK-NEXT:    std 4, 400(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 424(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 329
 ; CHECK-NEXT:    ori 4, 4, 38656
-; CHECK-NEXT:    std 4, 216(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 416(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 378
 ; CHECK-NEXT:    ori 4, 4, 27392
-; CHECK-NEXT:    std 4, 200(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 408(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 427
 ; CHECK-NEXT:    ori 4, 4, 16128
-; CHECK-NEXT:    std 4, 184(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 400(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 476
-; CHECK-NEXT:    ld 30, 184(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 4864
-; CHECK-NEXT:    std 4, 168(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 248(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 524
-; CHECK-NEXT:    ld 29, 168(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 59136
-; CHECK-NEXT:    std 4, 152(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 240(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 573
-; CHECK-NEXT:    ld 28, 152(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 47872
-; CHECK-NEXT:    std 4, 136(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 232(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 24
-; CHECK-NEXT:    ld 27, 136(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 27136
-; CHECK-NEXT:    std 4, 120(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 224(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 73
-; CHECK-NEXT:    ld 26, 120(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 15872
-; CHECK-NEXT:    std 4, 104(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 216(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 122
-; CHECK-NEXT:    ld 25, 104(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 4608
-; CHECK-NEXT:    std 4, 88(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 208(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 170
-; CHECK-NEXT:    ld 24, 88(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 58880
-; CHECK-NEXT:    std 4, 80(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 200(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    lis 4, 219
-; CHECK-NEXT:    ld 2, 80(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ori 4, 4, 47616
-; CHECK-NEXT:    std 4, 72(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 192(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 36352
 ; CHECK-NEXT:    lis 5, 317
-; CHECK-NEXT:    std 4, 64(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 30, 192(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 184(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 25088
 ; CHECK-NEXT:    lis 5, 366
-; CHECK-NEXT:    ld 23, 64(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 56(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 29, 184(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 176(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 13824
 ; CHECK-NEXT:    lis 5, 415
-; CHECK-NEXT:    std 4, 48(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 28, 176(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 168(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 2560
 ; CHECK-NEXT:    lis 5, 463
-; CHECK-NEXT:    std 4, 40(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 27, 168(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 160(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 56832
 ; CHECK-NEXT:    lis 5, 512
-; CHECK-NEXT:    std 4, 472(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 26, 160(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 152(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 45568
 ; CHECK-NEXT:    lis 5, 561
-; CHECK-NEXT:    std 4, 464(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 25, 152(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 144(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 34304
 ; CHECK-NEXT:    lis 5, 12
-; CHECK-NEXT:    std 4, 456(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 24, 144(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 136(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 13568
 ; CHECK-NEXT:    lis 5, 61
-; CHECK-NEXT:    std 4, 440(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 23, 136(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 128(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 2304
 ; CHECK-NEXT:    lis 5, 109
-; CHECK-NEXT:    std 4, 424(1) # 8-byte Folded Spill
+; CHECK-NEXT:    std 4, 120(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 56576
 ; CHECK-NEXT:    lis 5, 158
-; CHECK-NEXT:    std 4, 408(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 0, 120(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 112(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 45312
 ; CHECK-NEXT:    lis 5, 207
-; CHECK-NEXT:    std 4, 224(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 22, 112(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 104(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 34048
 ; CHECK-NEXT:    lis 5, 256
-; CHECK-NEXT:    std 4, 208(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 21, 104(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 96(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 5, 22784
-; CHECK-NEXT:    ld 5, 72(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 192(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 5, 248(1) # 8-byte Folded Reload
+; CHECK-NEXT:    ld 20, 96(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 88(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 6, 11520
-; CHECK-NEXT:    ld 6, 48(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 19, 192(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 176(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 6, 240(1) # 8-byte Folded Reload
+; CHECK-NEXT:    ld 19, 88(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 80(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 7, 256
-; CHECK-NEXT:    ld 7, 40(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 18, 176(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 160(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 7, 232(1) # 8-byte Folded Reload
+; CHECK-NEXT:    ld 18, 80(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 72(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 8, 54528
 ; CHECK-NEXT:    ld 8, 224(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 17, 160(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 144(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 17, 72(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 64(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 9, 43264
 ; CHECK-NEXT:    ld 9, 216(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 16, 144(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 128(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 16, 64(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 56(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 10, 32000
 ; CHECK-NEXT:    ld 10, 208(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 15, 128(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 112(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 15, 56(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 48(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ori 4, 11, 20736
 ; CHECK-NEXT:    ld 11, 200(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 14, 112(1) # 8-byte Folded Reload
-; CHECK-NEXT:    std 4, 96(1) # 8-byte Folded Spill
+; CHECK-NEXT:    ld 14, 48(1) # 8-byte Folded Reload
+; CHECK-NEXT:    std 4, 40(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    li 4, 0
-; CHECK-NEXT:    ld 31, 96(1) # 8-byte Folded Reload
+; CHECK-NEXT:    ld 31, 40(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB0_1: # =>This Loop Header: Depth=1
 ; CHECK-NEXT:    # Child Loop BB0_2 Depth 2
@@ -298,17 +298,19 @@ define zeroext i32 @test1(i64 %0, ptr %1) {
 ; CHECK-NEXT:    li 4, 83
 ; CHECK-NEXT:    mtctr 4
 ; CHECK-NEXT:    ld 12, 256(1) # 8-byte Folded Reload
-; CHECK-NEXT:    ld 4, 56(1) # 8-byte Folded Reload
+; CHECK-NEXT:    ld 4, 128(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    .p2align 5
 ; CHECK-NEXT:  .LBB0_2: # Parent Loop BB0_1 Depth=1
 ; CHECK-NEXT:    # => This Inner Loop Header: Depth=2
-; CHECK-NEXT:    ld 0, 560(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdux 3, 12, 0
-; CHECK-NEXT:    ld 0, 552(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 22
-; CHECK-NEXT:    stdx 3, 12, 21
-; CHECK-NEXT:    stdx 3, 12, 20
+; CHECK-NEXT:    ld 2, 560(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdux 3, 12, 2
+; CHECK-NEXT:    ld 2, 552(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 5
+; CHECK-NEXT:    stdx 3, 12, 6
+; CHECK-NEXT:    stdx 3, 12, 7
+; CHECK-NEXT:    stdx 3, 12, 8
 ; CHECK-NEXT:    stdx 3, 12, 9
+; CHECK-NEXT:    stdx 3, 12, 10
 ; CHECK-NEXT:    stdx 3, 12, 11
 ; CHECK-NEXT:    stdx 3, 12, 30
 ; CHECK-NEXT:    stdx 3, 12, 29
@@ -317,14 +319,12 @@ define zeroext i32 @test1(i64 %0, ptr %1) {
 ; CHECK-NEXT:    stdx 3, 12, 26
 ; CHECK-NEXT:    stdx 3, 12, 25
 ; CHECK-NEXT:    stdx 3, 12, 24
-; CHECK-NEXT:    stdx 3, 12, 2
-; CHECK-NEXT:    stdx 3, 12, 5
 ; CHECK-NEXT:    stdx 3, 12, 23
 ; CHECK-NEXT:    stdx 3, 12, 4
-; CHECK-NEXT:    stdx 3, 12, 6
-; CHECK-NEXT:    stdx 3, 12, 7
-; CHECK-NEXT:    stdx 3, 12, 8
-; CHECK-NEXT:    stdx 3, 12, 10
+; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    stdx 3, 12, 22
+; CHECK-NEXT:    stdx 3, 12, 21
+; CHECK-NEXT:    stdx 3, 12, 20
 ; CHECK-NEXT:    stdx 3, 12, 19
 ; CHECK-NEXT:    stdx 3, 12, 18
 ; CHECK-NEXT:    stdx 3, 12, 17
@@ -332,45 +332,45 @@ define zeroext i32 @test1(i64 %0, ptr %1) {
 ; CHECK-NEXT:    stdx 3, 12, 15
 ; CHECK-NEXT:    stdx 3, 12, 14
 ; CHECK-NEXT:    stdx 3, 12, 31
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 544(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 536(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 528(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 520(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 512(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 504(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 496(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 488(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 480(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 448(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 432(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 416(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 400(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 472(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 464(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 456(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 440(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 424(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
-; CHECK-NEXT:    ld 0, 408(1) # 8-byte Folded Reload
-; CHECK-NEXT:    stdx 3, 12, 0
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 544(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 536(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 528(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 520(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 512(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 504(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 496(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 488(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 480(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 472(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 464(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 456(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 448(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 440(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 432(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 424(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 416(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 408(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
+; CHECK-NEXT:    ld 2, 400(1) # 8-byte Folded Reload
+; CHECK-NEXT:    stdx 3, 12, 2
 ; CHECK-NEXT:    bdnz .LBB0_2
 ; CHECK-NEXT:  # %bb.3:
 ; CHECK-NEXT:    ld 12, 384(1) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/X86/statepoint-live-in.ll
+++ b/llvm/test/CodeGen/X86/statepoint-live-in.ll
@@ -372,8 +372,8 @@ define void @test10(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 
 ; CHECK-NEXT:    .cfi_offset %r14, -32
 ; CHECK-NEXT:    .cfi_offset %r15, -24
 ; CHECK-NEXT:    .cfi_offset %rbp, -16
-; CHECK-NEXT:    movl %r9d, %ebp
-; CHECK-NEXT:    movl %r8d, %ebx
+; CHECK-NEXT:    movl %r9d, %ebx
+; CHECK-NEXT:    movl %r8d, %ebp
 ; CHECK-NEXT:    movl %ecx, %r14d
 ; CHECK-NEXT:    movl %edx, %r15d
 ; CHECK-NEXT:    movl %esi, %r12d

--- a/llvm/test/CodeGen/X86/statepoint-regs.ll
+++ b/llvm/test/CodeGen/X86/statepoint-regs.ll
@@ -484,8 +484,8 @@ define void @test10(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 
 ; CHECK-NEXT:    .cfi_offset %r14, -32
 ; CHECK-NEXT:    .cfi_offset %r15, -24
 ; CHECK-NEXT:    .cfi_offset %rbp, -16
-; CHECK-NEXT:    movl %r9d, %ebp
-; CHECK-NEXT:    movl %r8d, %ebx
+; CHECK-NEXT:    movl %r9d, %ebx
+; CHECK-NEXT:    movl %r8d, %ebp
 ; CHECK-NEXT:    movl %ecx, %r14d
 ; CHECK-NEXT:    movl %edx, %r15d
 ; CHECK-NEXT:    movl %esi, %r12d


### PR DESCRIPTION
This patch makes it so that renumbering indices when inserting instructions into the SlotIndexes analysis renumbers the entire list if the list is otherwise densely packed. This fixes a case we saw on AArch64 with a lot of spills where every single spill instruction insertion required a renumbering of most of the instructions in a large function, making the operation approximately quadratic.

This is not NFC as heuristics depend on the SlotIndex numbers, although this should mostly be a wash as LRs should be extended ~equally.