### PR TITLE
[LLVM][CodeGen] Consolidate sub-register index names into a single string

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -257,7 +257,8 @@ public:
 
 private:
   const TargetRegisterInfoDesc *InfoDesc;     // Extra desc array for codegen
-  const char *const *SubRegIndexNames;        // Names of subreg indexes.
+  const char *SubRegIndexStrings;             // Names of subreg indexes.
+  ArrayRef<uint32_t> SubRegIndexNameOffsets;
   const SubRegCoveredBits *SubRegIdxRanges;   // Pointer to the subreg covered
                                               // bit ranges array.
 
@@ -272,7 +273,8 @@ private:
 
 protected:
   TargetRegisterInfo(const TargetRegisterInfoDesc *ID, regclass_iterator RCB,
-                     regclass_iterator RCE, const char *const *SRINames,
+                     regclass_iterator RCE, const char *SRIStrings,
+                     ArrayRef<uint32_t> SRINameOffsets,
                      const SubRegCoveredBits *SubIdxRanges,
                      const LaneBitmask *SRILaneMasks, LaneBitmask CoveringLanes,
                      const RegClassInfo *const RCIs,
@@ -403,12 +405,12 @@ public:
     return InfoDesc->InAllocatableClass[RegNo];
   }
 
-  /// Return the human-readable symbolic target-specific
-  /// name for the specified SubRegIndex.
+  /// Return the human-readable symbolic target-specific name for the specified
+  /// SubRegIndex.
   const char *getSubRegIndexName(unsigned SubIdx) const {
     assert(SubIdx && SubIdx < getNumSubRegIndices() &&
            "This is not a subregister index");
-    return SubRegIndexNames[SubIdx-1];
+    return SubRegIndexStrings + SubRegIndexNameOffsets[SubIdx - 1];
   }
 
   /// Get the size of the bit range covered by a sub-register index.

--- a/llvm/lib/CodeGen/TargetRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/TargetRegisterInfo.cpp
@@ -51,11 +51,13 @@ static cl::opt<unsigned>
 
 TargetRegisterInfo::TargetRegisterInfo(
     const TargetRegisterInfoDesc *ID, regclass_iterator RCB,
-    regclass_iterator RCE, const char *const *SRINames,
-    const SubRegCoveredBits *SubIdxRanges, const LaneBitmask *SRILaneMasks,
-    LaneBitmask SRICoveringLanes, const RegClassInfo *const RCIs,
-    const MVT::SimpleValueType *const RCVTLists, unsigned Mode)
-    : InfoDesc(ID), SubRegIndexNames(SRINames), SubRegIdxRanges(SubIdxRanges),
+    regclass_iterator RCE, const char *SRIStrings,
+    ArrayRef<uint32_t> SRINameOffsets, const SubRegCoveredBits *SubIdxRanges,
+    const LaneBitmask *SRILaneMasks, LaneBitmask SRICoveringLanes,
+    const RegClassInfo *const RCIs, const MVT::SimpleValueType *const RCVTLists,
+    unsigned Mode)
+    : InfoDesc(ID), SubRegIndexStrings(SRIStrings),
+      SubRegIndexNameOffsets(SRINameOffsets), SubRegIdxRanges(SubIdxRanges),
       SubRegIndexLaneMasks(SRILaneMasks), RegClassBegin(RCB), RegClassEnd(RCE),
       CoveringLanes(SRICoveringLanes), RCInfos(RCIs), RCVTLists(RCVTLists),
       HwMode(Mode) {}

--- a/llvm/unittests/CodeGen/MFCommon.inc
+++ b/llvm/unittests/CodeGen/MFCommon.inc
@@ -26,8 +26,8 @@ class BogusRegisterInfo : public TargetRegisterInfo {
 public:
   BogusRegisterInfo()
       : TargetRegisterInfo(nullptr, BogusRegisterClasses, BogusRegisterClasses,
-                           nullptr, nullptr, nullptr, LaneBitmask(~0u), nullptr,
-                           nullptr) {
+                           nullptr, {}, nullptr, nullptr, LaneBitmask(~0u),
+                           nullptr, nullptr) {
     InitMCRegisterInfo(nullptr, 0, 0, 0, nullptr, 0, nullptr, 0, nullptr,
                        nullptr, nullptr, nullptr, nullptr, 0, nullptr);
   }

--- a/llvm/utils/TableGen/Basic/SequenceToOffsetTable.h
+++ b/llvm/utils/TableGen/Basic/SequenceToOffsetTable.h
@@ -134,10 +134,10 @@ public:
   /// `EmitLongStrLiterals` is false
   void emitStringLiteralDef(raw_ostream &OS, const Twine &Decl) const {
     assert(IsLaidOut && "Call layout() before emitStringLiteralDef()");
-    if (!EmitLongStrLiterals) {
+    if (!EmitLongStrLiterals || Size == 0) {
       OS << Decl << " = {\n";
       emit(OS, printChar);
-      OS << "  0\n};\n\n";
+      OS << "};\n\n";
       return;
     }
 

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -990,7 +990,7 @@ void RegisterInfoEmitter::runMCDesc(raw_ostream &OS, raw_ostream &MainOS,
 
   NamespaceEmitter LlvmNS(OS, "llvm");
 
-  const std::string &TargetName = Target.getName().str();
+  StringRef TargetName = Target.getName();
 
   // Emit the shared table of differential lists.
   OS << "extern const int16_t " << TargetName << "RegDiffLists[] = {\n";
@@ -1329,14 +1329,24 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
   VTSeqs.emit(OS, printSimpleValueType);
   OS << "};\n";
 
+  StringRef TargetName = Target.getName();
   // Emit SubRegIndex names, skipping 0.
-  OS << "\nstatic const char *SubRegIndexNameTable[] = { \"";
+  SequenceToOffsetTable<std::string> SubRegIndexStrings;
+  for (const auto &Idx : SubRegIndices)
+    SubRegIndexStrings.add(Idx.getName());
+  SubRegIndexStrings.layout();
 
-  for (const auto &Idx : SubRegIndices) {
-    OS << Idx.getName();
-    OS << "\", \"";
-  }
-  OS << "\" };\n\n";
+  SubRegIndexStrings.emitStringLiteralDef(OS, Twine("static constexpr char ") +
+                                                  TargetName +
+                                                  "SubRegIndexStrings[]");
+
+  OS << "\nstatic constexpr uint32_t " << TargetName
+     << "SubRegIndexNameOffsets[] = {\n";
+  for (const auto &Idx : SubRegIndices)
+    OS << "  " << SubRegIndexStrings.get(Idx.getName()) << ", \n";
+  if (SubRegIndices.empty())
+    OS << "  /* dummy */ 0\n";
+  OS << "};\n\n";
 
   // Emit the table of sub-register index sizes.
   OS << "static const TargetRegisterInfo::SubRegCoveredBits "
@@ -1524,7 +1534,6 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
   }
 
   // Emit extra information about registers.
-  const std::string &TargetName = Target.getName().str();
   const auto &Regs = RegBank.getRegisters();
   unsigned NumRegCosts = 1;
   for (const auto &Reg : Regs)
@@ -1722,15 +1731,16 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
 
   EmitRegMappingTables(OS, Regs, true);
 
-  OS << ClassName << "::\n"
-     << ClassName
-     << "(unsigned RA, unsigned DwarfFlavour, unsigned EHFlavour,\n"
-        "      unsigned PC, unsigned HwMode)\n"
-     << "  : TargetRegisterInfo(&" << TargetName << "RegInfoDesc"
-     << ", RegisterClasses, RegisterClasses+" << RegisterClasses.size() << ",\n"
-     << "             SubRegIndexNameTable, SubRegIdxRangeTable, "
-        "SubRegIndexLaneMaskTable,\n"
-     << "             ";
+  OS << formatv(R"(
+{0}::
+{0}(unsigned RA, unsigned DwarfFlavour, unsigned EHFlavour,
+    unsigned PC, unsigned HwMode)
+  : TargetRegisterInfo(&{1}RegInfoDesc, RegisterClasses, RegisterClasses+{2},
+      {1}SubRegIndexStrings, {1}SubRegIndexNameOffsets,
+      SubRegIdxRangeTable, SubRegIndexLaneMaskTable,
+
+  )",
+                ClassName, TargetName, RegisterClasses.size());
   printMask(OS, RegBank.CoveringLanes);
   OS << ", RegClassInfos, VTLists, HwMode) {\n"
      << "  InitMCRegisterInfo(" << TargetName << "RegDesc, " << Regs.size() + 1


### PR DESCRIPTION
Use `SequenceToOffsetTable` to emit a consolidated string for sub-register index names and use a table of offsets to source these names.  This follows the same scheme used for register names and help the static storage for this data (64-bit pointer to 32-bit int per subregister-index).

Additionally, fix a small bug in `SequenceToOffsetTable` for empty tables on Windows (i.e, when `EmitLongStrLiterals` = false). When the table is empty, we would generate `0 \n 0` as the table contents and fail compilation for Windows. Fixed that omitting the extra `0` after the call to `emit` in that case. Also force using this logic when Size == 0 to avoid modifying the `EmitLongStrLiterals = true` case to handle empty tables.