### PR TITLE
[vim] Set commentstring for TableGen files

### DIFF
--- a/llvm/utils/vim/ftplugin/tablegen.vim
+++ b/llvm/utils/vim/ftplugin/tablegen.vim
@@ -10,3 +10,4 @@ let b:did_ftplugin = 1
 setlocal matchpairs+=<:>
 setlocal softtabstop=2 shiftwidth=2
 setlocal expandtab
+setlocal commentstring=//\ %s


### PR DESCRIPTION
Neovim supports [commenting and uncommenting lines](https://neovim.io/doc/user/various.html#commenting) based on what the 'commentstring' option is set to, but this isn't set for TableGen files. The filetype plugin for C++ built into both vim and neovim sets 'commentstring' to `// %s`, so use that in the TableGen filetype plugin as well.