### PR TITLE
[lldb] A few small code modernizations and cleanups [NFC]

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1203,9 +1203,7 @@ ObjectFile *Module::GetObjectFile() {
         m_did_load_objfile = true;
         // FindPlugin will modify its extractor_sp argument. Do not let it
         // modify our m_extractor_sp member.
-        DataExtractorSP extractor_sp;
-        if (m_extractor_sp)
-          extractor_sp = m_extractor_sp;
+        DataExtractorSP extractor_sp = m_extractor_sp;
         m_objfile_sp = ObjectFile::FindPlugin(
             shared_from_this(), &m_file, m_object_offset,
             file_size - m_object_offset, extractor_sp, data_offset);

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.h
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.h
@@ -84,12 +84,6 @@ protected:
 
     void Clear();
 
-    lldb::offset_t ExtractFromThin(const lldb_private::DataExtractor &extractor,
-                                   lldb::offset_t offset,
-                                   llvm::StringRef stringTable);
-
-    lldb::offset_t Extract(const lldb_private::DataExtractor &extractor,
-                           lldb::offset_t offset);
     /// Object name in the archive.
     lldb_private::ConstString ar_name;
 
@@ -108,10 +102,12 @@ protected:
     void Dump() const;
   };
 
+  class Archive;
+  typedef std::shared_ptr<Archive> ArchiveSP;
+
   class Archive {
   public:
-    typedef std::shared_ptr<Archive> shared_ptr;
-    typedef std::multimap<lldb_private::FileSpec, shared_ptr> Map;
+    typedef std::multimap<lldb_private::FileSpec, ArchiveSP> Map;
 
     Archive(const lldb_private::ArchSpec &arch,
             const llvm::sys::TimePoint<> &mod_time, lldb::offset_t file_offset,
@@ -123,11 +119,12 @@ protected:
 
     static std::recursive_mutex &GetArchiveCacheMutex();
 
-    static Archive::shared_ptr FindCachedArchive(
-        const lldb_private::FileSpec &file, const lldb_private::ArchSpec &arch,
-        const llvm::sys::TimePoint<> &mod_time, lldb::offset_t file_offset);
+    static ArchiveSP FindCachedArchive(const lldb_private::FileSpec &file,
+                                       const lldb_private::ArchSpec &arch,
+                                       const llvm::sys::TimePoint<> &mod_time,
+                                       lldb::offset_t file_offset);
 
-    static Archive::shared_ptr ParseAndCacheArchiveForFile(
+    static ArchiveSP ParseAndCacheArchiveForFile(
         const lldb_private::FileSpec &file, const lldb_private::ArchSpec &arch,
         const llvm::sys::TimePoint<> &mod_time, lldb::offset_t file_offset,
         lldb::DataExtractorSP extractor_sp, ArchiveType archive_type);
@@ -157,7 +154,7 @@ protected:
 
     bool HasNoExternalReferences() const;
 
-    lldb_private::DataExtractor &GetData() { return *m_extractor_sp.get(); }
+    lldb_private::DataExtractor &GetData() { return *m_extractor_sp; }
     lldb::DataExtractorSP &GetDataSP() { return m_extractor_sp; }
 
     ArchiveType GetArchiveType() { return m_archive_type; }
@@ -176,9 +173,9 @@ protected:
     ArchiveType m_archive_type;
   };
 
-  void SetArchive(Archive::shared_ptr &archive_sp);
+  void SetArchive(ArchiveSP &archive_sp);
 
-  Archive::shared_ptr m_archive_sp;
+  ArchiveSP m_archive_sp;
 
   ArchiveType m_archive_type;
 };

--- a/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.cpp
@@ -199,7 +199,7 @@ bool ObjectContainerMachOFileset::ParseHeader() {
 
   std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
 
-  std::optional<mach_header> header = ParseMachOHeader(*m_extractor_sp.get());
+  std::optional<mach_header> header = ParseMachOHeader(*m_extractor_sp);
   if (!header)
     return false;
 
@@ -216,7 +216,7 @@ bool ObjectContainerMachOFileset::ParseHeader() {
     m_extractor_sp->SetData(data_sp);
   }
 
-  return ParseFileset(*m_extractor_sp.get(), *header, m_entries, m_memory_addr);
+  return ParseFileset(*m_extractor_sp, *header, m_entries, m_memory_addr);
 }
 
 size_t ObjectContainerMachOFileset::GetModuleSpecifications(

--- a/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
@@ -74,9 +74,10 @@ ObjectContainerUniversalMachO::ObjectContainerUniversalMachO(
 ObjectContainerUniversalMachO::~ObjectContainerUniversalMachO() = default;
 
 bool ObjectContainerUniversalMachO::ParseHeader() {
-  bool success = ParseHeader(*m_extractor_sp.get(), m_header, m_fat_archs);
+  bool success = ParseHeader(*m_extractor_sp, m_header, m_fat_archs);
   // We no longer need any data, we parsed all we needed to parse and cached it
-  // in m_header and m_fat_archs
+  // in m_header and m_fat_archs.  Need to have an empty DataExtractor for code
+  // that assumes it is non-null.
   m_extractor_sp = std::make_shared<DataExtractor>();
   return success;
 }

--- a/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
+++ b/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
@@ -70,7 +70,7 @@ ObjectFile *ObjectFileBreakpad::CreateInstance(const ModuleSP &module_sp,
     extractor_sp = std::make_shared<DataExtractor>(data_sp);
     data_offset = 0;
   }
-  // If this is opearting on a VirtualDataExtractor, it can have
+  // If this is operating on a VirtualDataExtractor, it can have
   // gaps between valid bytes in the DataBuffer. We extract an
   // ArrayRef of the raw bytes, and can segfault.
   DataExtractorSP contiguous_extractor_sp =


### PR DESCRIPTION
I was reading through ObjectContainerBSDArchive and came across some dead method decls, a less-than-completely-clear `shared_ptr` typedef in `ObjectContainerBSDArchive::Archive` for a shared_ptr<Archive> which was a little unclear when reading a decl like `shared_ptr archive_sp;` for a local variable.