### PR TITLE
[SelectionDAG] Emit error instead of asserting for unsupported FP_EXTEND

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
@@ -655,7 +655,12 @@ SDValue DAGTypeLegalizer::SoftenFloatRes_FP_EXTEND(SDNode *N) {
   }
 
   RTLIB::Libcall LC = RTLIB::getFPEXT(Op.getValueType(), N->getValueType(0));
-  assert(LC != RTLIB::UNKNOWN_LIBCALL && "Unsupported FP_EXTEND!");
+  if (LC == RTLIB::UNKNOWN_LIBCALL) {
+    DAG.getContext()->emitError("do not know how to soften fp_extend");
+    if (IsStrict)
+      ReplaceValueWith(SDValue(N, 1), Chain);
+    return DAG.getPOISON(NVT);
+  }
   TargetLowering::MakeLibCallOptions CallOptions;
   EVT OpVT = N->getOperand(IsStrict ? 1 : 0).getValueType();
   CallOptions.setTypeListBeforeSoften(OpVT, N->getValueType(0));

--- a/llvm/test/CodeGen/AArch64/unsupported-fpext-x86-fp80.ll
+++ b/llvm/test/CodeGen/AArch64/unsupported-fpext-x86-fp80.ll
@@ -1,0 +1,12 @@
+; RUN: not llc -mtriple=aarch64-unknown-linux-gnu < %s 2>&1 | FileCheck %s
+
+; Verify that we get a user-friendly error instead of an assertion failure
+; when trying to fpext to x86_fp80 on AArch64 (which has no libcall for it).
+; See: https://github.com/llvm/llvm-project/issues/182449
+
+; CHECK: error: do not know how to soften fp_extend
+
+define x86_fp80 @test_fpext_double_to_x86_fp80(double %x) {
+  %ext = fpext double %x to x86_fp80
+  ret x86_fp80 %ext
+}


### PR DESCRIPTION
Replace the assertion failure in `DAGTypeLegalizer::SoftenFloatRes_FP_EXTEND` with a user-friendly error when no libcall is available for the requested 

Fix
Replace the `assert` with an `emitError` call that reports the unsupported 
conversion gracefully and returns a poison value


Fixes: #182449