### PR TITLE
[libclang]Introduce clang_CXXIsCoroutine()

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -409,6 +409,7 @@ clang-format
 libclang
 --------
 - Fix crash in clang_getBinaryOperatorKindSpelling and clang_getUnaryOperatorKindSpelling
+- Add clang_CXXIsCoroutine()
 
 Code Completion
 ---------------

--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -34,7 +34,7 @@
  * compatible, thus CINDEX_VERSION_MAJOR is expected to remain stable.
  */
 #define CINDEX_VERSION_MAJOR 0
-#define CINDEX_VERSION_MINOR 64
+#define CINDEX_VERSION_MINOR 65
 
 #define CINDEX_VERSION_ENCODE(major, minor) (((major) * 10000) + ((minor) * 1))
 
@@ -4882,6 +4882,12 @@ CINDEX_LINKAGE unsigned clang_EnumDecl_isScoped(CXCursor C);
  * declared 'const'.
  */
 CINDEX_LINKAGE unsigned clang_CXXMethod_isConst(CXCursor C);
+
+/**
+ * Determine if a function, member function, or lambda is a coroutine.
+ *
+ */
+CINDEX_LINKAGE int clang_CXXIsCoroutine(CXCursor cursor);
 
 /**
  * Given a cursor that represents a template, determine

--- a/clang/test/Index/coroutines.cpp
+++ b/clang/test/Index/coroutines.cpp
@@ -18,7 +18,35 @@ struct std::coroutine_traits<void> { using promise_type = promise_void; };
 void CoroutineTestRet() {
   co_return;
 }
-// CHECK: [[@LINE-3]]:25: UnexposedStmt=
-// CHECK-SAME: [[@LINE-4]]:25 - [[@LINE-2]]:2]
-// CHECK: [[@LINE-4]]:3: UnexposedStmt=
-// CHECK-SAME: [[@LINE-5]]:3 - [[@LINE-5]]:12]
+// CHECK: [[@LINE-3]]:6: FunctionDecl=CoroutineTestRet:18:6 (Definition) (coroutine) Extent=[18:1 - 20:2]
+// CHECK: [[@LINE-4]]:25: UnexposedStmt=
+// CHECK-SAME: [[@LINE-5]]:25 - [[@LINE-3]]:2]
+// CHECK: [[@LINE-5]]:3: UnexposedStmt=
+// CHECK-SAME: [[@LINE-6]]:3 - [[@LINE-6]]:12]
+
+class Coro {
+public:
+  struct promise_type {
+    Coro get_return_object();
+    suspend_always initial_suspend();
+    suspend_always final_suspend() noexcept;
+    void return_void();
+    void unhandled_exception();
+  };
+  Coro(std::coroutine_handle<promise_void>);
+};
+
+class W{
+public:
+  Coro CoroutineMemberTest() {
+    co_return;
+  }
+};
+
+// CHECK: CXXMethod=CoroutineMemberTest:41:8 (Definition) (coroutine) Extent=[41:3 - 43:4] [access=public]
+
+auto lambda = []() -> Coro {
+  co_return;
+};
+
+// CHECK: LambdaExpr= (coroutine) Extent=[48:15 - 50:2]

--- a/clang/tools/c-index-test/c-index-test.c
+++ b/clang/tools/c-index-test/c-index-test.c
@@ -964,6 +964,8 @@ static void PrintCursor(CXCursor Cursor, const char *CommentSchemaFile) {
       printf(" (explicit)");
     if (clang_CXXRecord_isAbstract(Cursor))
       printf(" (abstract)");
+    if (clang_CXXIsCoroutine(Cursor))
+      printf(" (coroutine)");
     if (clang_EnumDecl_isScoped(Cursor))
       printf(" (scoped)");
     if (clang_Cursor_isVariadic(Cursor))

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -10220,3 +10220,26 @@ enum CXUnaryOperatorKind clang_getCursorUnaryOperatorKind(CXCursor cursor) {
 
   return CXUnaryOperator_Invalid;
 }
+
+int clang_CXXIsCoroutine(CXCursor cursor) {
+  if (cursor.kind == CXCursor_FunctionDecl ||
+      cursor.kind == CXCursor_CXXMethod) {
+    if (const Decl *D = getCursorDecl(cursor)) {
+      if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
+        if (const Stmt *Body = FD->getBody())
+          return isa<CoroutineBodyStmt>(Body);
+      }
+    }
+  }
+
+  if (cursor.kind == CXCursor_LambdaExpr) {
+    if (const Expr *E = getCursorExpr(cursor)) {
+      if (const LambdaExpr *L = dyn_cast<LambdaExpr>(E)) {
+        if (const Stmt *Body = L->getBody())
+          return isa<CoroutineBodyStmt>(Body);
+      }
+    }
+  }
+
+  return 0;
+}

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -457,6 +457,11 @@ LLVM_21 {
     clang_Cursor_isGCCAssemblyVolatile;
 };
 
+LLVM_23 {
+  global:
+    clang_CXXIsCoroutine;
+};
+
 # Example of how to add a new symbol version entry.  If you do add a new symbol
 # version, please update the example to depend on the version you added.
 # LLVM_X {


### PR DESCRIPTION
Knowing whether a function is a coroutine or not is useful, this adds the clang_CXXIsCoroutine() function to get that information using the C API.