### PR TITLE
[TableGen] Add OPC_EmitIntegerByHwMode0 and OPC_CheckChildXTypeByHwMode0. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGISel.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGISel.h
@@ -249,6 +249,15 @@ public:
     OPC_CheckChild6TypeByHwMode,
     OPC_CheckChild7TypeByHwMode,
 
+    OPC_CheckChild0TypeByHwMode0,
+    OPC_CheckChild1TypeByHwMode0,
+    OPC_CheckChild2TypeByHwMode0,
+    OPC_CheckChild3TypeByHwMode0,
+    OPC_CheckChild4TypeByHwMode0,
+    OPC_CheckChild5TypeByHwMode0,
+    OPC_CheckChild6TypeByHwMode0,
+    OPC_CheckChild7TypeByHwMode0,
+
     OPC_CheckInteger,
     OPC_CheckChild0Integer,
     OPC_CheckChild1Integer,
@@ -280,6 +289,7 @@ public:
     OPC_EmitIntegerI32,
     OPC_EmitIntegerI64,
     OPC_EmitIntegerByHwMode,
+    OPC_EmitIntegerByHwMode0,
     OPC_EmitRegister,
     OPC_EmitRegisterI32,
     OPC_EmitRegisterI64,

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -3233,7 +3233,15 @@ static size_t IsPredicateKnownToFail(
   case SelectionDAGISel::OPC_CheckChild4TypeByHwMode:
   case SelectionDAGISel::OPC_CheckChild5TypeByHwMode:
   case SelectionDAGISel::OPC_CheckChild6TypeByHwMode:
-  case SelectionDAGISel::OPC_CheckChild7TypeByHwMode: {
+  case SelectionDAGISel::OPC_CheckChild7TypeByHwMode:
+  case SelectionDAGISel::OPC_CheckChild0TypeByHwMode0:
+  case SelectionDAGISel::OPC_CheckChild1TypeByHwMode0:
+  case SelectionDAGISel::OPC_CheckChild2TypeByHwMode0:
+  case SelectionDAGISel::OPC_CheckChild3TypeByHwMode0:
+  case SelectionDAGISel::OPC_CheckChild4TypeByHwMode0:
+  case SelectionDAGISel::OPC_CheckChild5TypeByHwMode0:
+  case SelectionDAGISel::OPC_CheckChild6TypeByHwMode0:
+  case SelectionDAGISel::OPC_CheckChild7TypeByHwMode0: {
     MVT VT;
     unsigned ChildNo;
     if (Opcode >= SelectionDAGISel::OPC_CheckChild0TypeI32 &&
@@ -3248,6 +3256,10 @@ static size_t IsPredicateKnownToFail(
                Opcode <= SelectionDAGISel::OPC_CheckChild7TypeByHwMode) {
       VT = getHwModeVT(Table, Index, SDISel);
       ChildNo = Opcode - SelectionDAGISel::OPC_CheckChild0TypeByHwMode;
+    } else if (Opcode >= SelectionDAGISel::OPC_CheckChild0TypeByHwMode0 &&
+               Opcode <= SelectionDAGISel::OPC_CheckChild7TypeByHwMode0) {
+      VT = SDISel.getValueTypeForHwMode(0);
+      ChildNo = Opcode - SelectionDAGISel::OPC_CheckChild0TypeByHwMode0;
     } else {
       VT = getSimpleVT(Table, Index);
       ChildNo = Opcode - SelectionDAGISel::OPC_CheckChild0Type;
@@ -3909,9 +3921,25 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
     case OPC_CheckChild4TypeByHwMode:
     case OPC_CheckChild5TypeByHwMode:
     case OPC_CheckChild6TypeByHwMode:
-    case OPC_CheckChild7TypeByHwMode: {
-      MVT VT = getHwModeVT(MatcherTable, MatcherIndex, *this);
-      unsigned ChildNo = Opcode - OPC_CheckChild0TypeByHwMode;
+    case OPC_CheckChild7TypeByHwMode:
+    case OPC_CheckChild0TypeByHwMode0:
+    case OPC_CheckChild1TypeByHwMode0:
+    case OPC_CheckChild2TypeByHwMode0:
+    case OPC_CheckChild3TypeByHwMode0:
+    case OPC_CheckChild4TypeByHwMode0:
+    case OPC_CheckChild5TypeByHwMode0:
+    case OPC_CheckChild6TypeByHwMode0:
+    case OPC_CheckChild7TypeByHwMode0: {
+      MVT VT;
+      unsigned ChildNo;
+      if (Opcode >= OPC_CheckChild0TypeByHwMode0 &&
+          Opcode <= OPC_CheckChild7TypeByHwMode0) {
+        VT = getValueTypeForHwMode(0);
+        ChildNo = Opcode - OPC_CheckChild0TypeByHwMode0;
+      } else {
+        VT = getHwModeVT(MatcherTable, MatcherIndex, *this);
+        ChildNo = Opcode - OPC_CheckChild0TypeByHwMode;
+      }
       if (!::CheckChildType(VT.SimpleTy, N, TLI, CurDAG->getDataLayout(),
                             ChildNo))
         break;
@@ -3986,7 +4014,8 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
     case OPC_EmitIntegerI16:
     case OPC_EmitIntegerI32:
     case OPC_EmitIntegerI64:
-    case OPC_EmitIntegerByHwMode: {
+    case OPC_EmitIntegerByHwMode:
+    case OPC_EmitIntegerByHwMode0: {
       MVT VT;
       switch (Opcode) {
       case OPC_EmitIntegerI8:
@@ -4003,6 +4032,9 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
         break;
       case OPC_EmitIntegerByHwMode:
         VT = getHwModeVT(MatcherTable, MatcherIndex, *this);
+        break;
+      case OPC_EmitIntegerByHwMode0:
+        VT = getValueTypeForHwMode(0);
         break;
       default:
         VT = getSimpleVT(MatcherTable, MatcherIndex);

--- a/llvm/test/TableGen/RegClassByHwMode.td
+++ b/llvm/test/TableGen/RegClassByHwMode.td
@@ -207,7 +207,7 @@ include "Common/RegClassByHwModeCommon.td"
 // ISEL-SDAG-NEXT: OPC_RecordChild1, // #1 = $val
 // ISEL-SDAG-NEXT: OPC_CheckChild1TypeByHwMode, /*{(*:i64),(m1:i64),(m2:i64)}*/1,
 // ISEL-SDAG-NEXT: OPC_RecordChild2, // #2 = $src
-// ISEL-SDAG-NEXT: OPC_CheckChild2TypeByHwMode, /*{(*:i32),(m3:i64)}*/0,
+// ISEL-SDAG-NEXT: OPC_CheckChild2TypeByHwMode0/*{(*:i32),(m3:i64)}*/,
 // ISEL-SDAG-NEXT: OPC_CheckPredicate0,  // Predicate_unindexedstore
 // ISEL-SDAG-NEXT: OPC_CheckPredicate1,  // Predicate_store
 // ISEL-SDAG-NEXT: OPC_EmitMergeInputChains1_0,
@@ -218,7 +218,7 @@ include "Common/RegClassByHwModeCommon.td"
 // ISEL-SDAG-NEXT: OPC_RecordMemRef,
 // ISEL-SDAG-NEXT: OPC_RecordNode, // #0 = 'ld' chained node
 // ISEL-SDAG-NEXT: OPC_RecordChild1, // #1 = $src
-// ISEL-SDAG-NEXT: OPC_CheckChild1TypeByHwMode, /*{(*:i32),(m3:i64)}*/0,
+// ISEL-SDAG-NEXT: OPC_CheckChild1TypeByHwMode0/*{(*:i32),(m3:i64)}*/,
 // ISEL-SDAG-NEXT: OPC_CheckPredicate2,  // Predicate_unindexedload
 // ISEL-SDAG-NEXT: OPC_CheckPredicate3,  // Predicate_load
 // ISEL-SDAG-NEXT: OPC_CheckTypeI64,


### PR DESCRIPTION
Add versions of these opcodes that implicitly call getValueTypeForHwMode with index 0.

This reduces llc size by ~100K.