### PR TITLE
[AVR] Fix SETUGT during 128b -> 64b lowering

### DIFF
--- a/llvm/lib/Target/AVR/AVRISelLowering.cpp
+++ b/llvm/lib/Target/AVR/AVRISelLowering.cpp
@@ -714,15 +714,17 @@ SDValue AVRTargetLowering::getAVRCmp(SDValue LHS, SDValue RHS, ISD::CondCode CC,
     break;
   }
   case ISD::SETUGT: {
-    // Turn lhs < rhs with lhs constant into rhs >= lhs+1, this allows us to
-    // fold the constant into the cmp instruction.
+    // Turn `lhs > rhs` with constant rhs into `lhs >= rhs + 1`, because this
+    // allows us to fold the constant into the cmp instruction.
     if (const ConstantSDNode *C = dyn_cast<ConstantSDNode>(RHS)) {
-      // Doing a "icmp ugt i16 65535, %0" comparison should have been converted
-      // already to something else. Assert to make sure this assumption holds.
-      assert((!C->isAllOnes()) && "integer overflow in comparison transform");
-      RHS = DAG.getConstant(C->getZExtValue() + 1, DL, VT);
-      CC = ISD::SETUGE;
-      break;
+      if (C->getConstantIntValue()->isMaxValue(false)) {
+        // Applying this optimization requires calculating rhs+1, which we can't
+        // do if that overflows; it can happen during i128->i64 lowering.
+      } else {
+        RHS = DAG.getConstant(C->getZExtValue() + 1, DL, VT);
+        CC = ISD::SETUGE;
+        break;
+      }
     }
     // Swap operands and reverse the branching condition.
     std::swap(LHS, RHS);

--- a/llvm/test/CodeGen/AVR/cmp.ll
+++ b/llvm/test/CodeGen/AVR/cmp.ll
@@ -313,3 +313,21 @@ if.then:
 if.else:
   ret void
 }
+
+define i1 @cmp_issue181504(i128 %0) {
+; See: https://github.com/llvm/llvm-project/issues/181504
+;
+; This generates too much code to reasonably assert, so this test exists mostly
+; to make sure we don't crash.
+;
+; CHECK-LABEL: cmp_issue181504
+; CHECK:      ldi r30, -1
+; CHECK-NEXT: ldi r26, 255
+; CHECK-NEXT: ldi r27, 255
+; CHECK-NEXT: ldi r31, 1
+; CHECK-NEXT: cp r30, r10
+bb0:
+  %1 = icmp ugt i128 %0, 18446744073709551615 ; 2^64-1
+
+  ret i1 %1
+}


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/181504.