### PR TITLE
[LLVM][ADT] Add some more `starts_with`, `ends_with`, and `contains` overloads to `SmallString`

### DIFF
--- a/llvm/include/llvm/ADT/SmallString.h
+++ b/llvm/include/llvm/ADT/SmallString.h
@@ -121,10 +121,24 @@ public:
     return str().starts_with(Prefix);
   }
 
+  /// starts_with - Check if this string starts with the given character \p C.
+  [[nodiscard]] bool starts_with(char C) const { return str().starts_with(C); }
+
   /// ends_with - Check if this string ends with the given \p Suffix.
   [[nodiscard]] bool ends_with(StringRef Suffix) const {
     return str().ends_with(Suffix);
   }
+
+  /// ends_with - Check if this string ends with the given character \p C.
+  [[nodiscard]] bool ends_with(char C) const { return str().ends_with(C); }
+
+  /// contains - Check if \p Other is a substring of this string.
+  [[nodiscard]] bool contains(StringRef Other) const {
+    return str().contains(Other);
+  }
+
+  /// contains - Check if this string contains the character \p C.
+  [[nodiscard]] bool contains(char C) const { return str().contains(C); }
 
   /// @}
   /// @name String Searching

--- a/llvm/unittests/ADT/SmallStringTest.cpp
+++ b/llvm/unittests/ADT/SmallStringTest.cpp
@@ -27,7 +27,7 @@ protected:
 
   StringType theString;
 
-  void assertEmpty(StringType & v) {
+  void assertEmpty(StringType &v) {
     // Size tests
     EXPECT_EQ(0u, v.size());
     EXPECT_TRUE(v.empty());
@@ -113,6 +113,37 @@ TEST_F(SmallStringTest, AppendStringRefs) {
   theString.append({Jkl, Mno, Pqr, Stu});
   EXPECT_EQ(21u, theString.size());
   EXPECT_STREQ("abcdefghijklmnopqrstu", theString.c_str());
+}
+
+TEST(SmallStringTest, StartsWith) {
+  SmallString<32> Str("hello");
+  EXPECT_TRUE(Str.starts_with(""));
+  EXPECT_TRUE(Str.starts_with("he"));
+  EXPECT_FALSE(Str.starts_with("helloworld"));
+  EXPECT_FALSE(Str.starts_with("hi"));
+  EXPECT_TRUE(Str.starts_with('h'));
+  EXPECT_FALSE(Str.starts_with('i'));
+}
+
+TEST(SmallStringTest, EndsWith) {
+  SmallString<32> Str("hello");
+  EXPECT_TRUE(Str.ends_with(""));
+  EXPECT_TRUE(Str.ends_with("lo"));
+  EXPECT_FALSE(Str.ends_with("helloworld"));
+  EXPECT_FALSE(Str.ends_with("worldhello"));
+  EXPECT_FALSE(Str.ends_with("so"));
+  EXPECT_TRUE(Str.ends_with('o'));
+  EXPECT_FALSE(Str.ends_with('p'));
+}
+
+TEST(SmallStringTest, Contains) {
+  SmallString<32> Str("hello");
+  EXPECT_TRUE(Str.contains(""));
+  EXPECT_TRUE(Str.contains("ell"));
+  EXPECT_TRUE(Str.contains("hello"));
+  EXPECT_FALSE(Str.contains("world"));
+  EXPECT_TRUE(Str.contains('e'));
+  EXPECT_FALSE(Str.contains('w'));
 }
 
 TEST_F(SmallStringTest, StringRefConversion) {
@@ -203,37 +234,38 @@ TEST_F(SmallStringTest, Realloc) {
 }
 
 TEST_F(SmallStringTest, Comparisons) {
-  EXPECT_GT( 0, SmallString<10>("aab").compare("aad"));
-  EXPECT_EQ( 0, SmallString<10>("aab").compare("aab"));
-  EXPECT_LT( 0, SmallString<10>("aab").compare("aaa"));
-  EXPECT_GT( 0, SmallString<10>("aab").compare("aabb"));
-  EXPECT_LT( 0, SmallString<10>("aab").compare("aa"));
-  EXPECT_LT( 0, SmallString<10>("\xFF").compare("\1"));
+  EXPECT_GT(0, SmallString<10>("aab").compare("aad"));
+  EXPECT_EQ(0, SmallString<10>("aab").compare("aab"));
+  EXPECT_LT(0, SmallString<10>("aab").compare("aaa"));
+  EXPECT_GT(0, SmallString<10>("aab").compare("aabb"));
+  EXPECT_LT(0, SmallString<10>("aab").compare("aa"));
+  EXPECT_LT(0, SmallString<10>("\xFF").compare("\1"));
 
   EXPECT_EQ(-1, SmallString<10>("AaB").compare_insensitive("aAd"));
-  EXPECT_EQ( 0, SmallString<10>("AaB").compare_insensitive("aab"));
-  EXPECT_EQ( 1, SmallString<10>("AaB").compare_insensitive("AAA"));
+  EXPECT_EQ(0, SmallString<10>("AaB").compare_insensitive("aab"));
+  EXPECT_EQ(1, SmallString<10>("AaB").compare_insensitive("AAA"));
   EXPECT_EQ(-1, SmallString<10>("AaB").compare_insensitive("aaBb"));
-  EXPECT_EQ( 1, SmallString<10>("AaB").compare_insensitive("aA"));
-  EXPECT_EQ( 1, SmallString<10>("\xFF").compare_insensitive("\1"));
+  EXPECT_EQ(1, SmallString<10>("AaB").compare_insensitive("aA"));
+  EXPECT_EQ(1, SmallString<10>("\xFF").compare_insensitive("\1"));
 
   EXPECT_EQ(-1, SmallString<10>("aab").compare_numeric("aad"));
-  EXPECT_EQ( 0, SmallString<10>("aab").compare_numeric("aab"));
-  EXPECT_EQ( 1, SmallString<10>("aab").compare_numeric("aaa"));
+  EXPECT_EQ(0, SmallString<10>("aab").compare_numeric("aab"));
+  EXPECT_EQ(1, SmallString<10>("aab").compare_numeric("aaa"));
   EXPECT_EQ(-1, SmallString<10>("aab").compare_numeric("aabb"));
-  EXPECT_EQ( 1, SmallString<10>("aab").compare_numeric("aa"));
+  EXPECT_EQ(1, SmallString<10>("aab").compare_numeric("aa"));
   EXPECT_EQ(-1, SmallString<10>("1").compare_numeric("10"));
-  EXPECT_EQ( 0, SmallString<10>("10").compare_numeric("10"));
-  EXPECT_EQ( 0, SmallString<10>("10a").compare_numeric("10a"));
-  EXPECT_EQ( 1, SmallString<10>("2").compare_numeric("1"));
-  EXPECT_EQ( 0, SmallString<10>("llvm_v1i64_ty").compare_numeric("llvm_v1i64_ty"));
-  EXPECT_EQ( 1, SmallString<10>("\xFF").compare_numeric("\1"));
-  EXPECT_EQ( 1, SmallString<10>("V16").compare_numeric("V1_q0"));
+  EXPECT_EQ(0, SmallString<10>("10").compare_numeric("10"));
+  EXPECT_EQ(0, SmallString<10>("10a").compare_numeric("10a"));
+  EXPECT_EQ(1, SmallString<10>("2").compare_numeric("1"));
+  EXPECT_EQ(0,
+            SmallString<10>("llvm_v1i64_ty").compare_numeric("llvm_v1i64_ty"));
+  EXPECT_EQ(1, SmallString<10>("\xFF").compare_numeric("\1"));
+  EXPECT_EQ(1, SmallString<10>("V16").compare_numeric("V1_q0"));
   EXPECT_EQ(-1, SmallString<10>("V1_q0").compare_numeric("V16"));
   EXPECT_EQ(-1, SmallString<10>("V8_q0").compare_numeric("V16"));
-  EXPECT_EQ( 1, SmallString<10>("V16").compare_numeric("V8_q0"));
+  EXPECT_EQ(1, SmallString<10>("V16").compare_numeric("V8_q0"));
   EXPECT_EQ(-1, SmallString<10>("V1_q0").compare_numeric("V8_q0"));
-  EXPECT_EQ( 1, SmallString<10>("V8_q0").compare_numeric("V1_q0"));
+  EXPECT_EQ(1, SmallString<10>("V8_q0").compare_numeric("V1_q0"));
 }
 
 // Check gtest prints SmallString as a string instead of a container of chars.

--- a/llvm/unittests/ADT/SmallStringTest.cpp
+++ b/llvm/unittests/ADT/SmallStringTest.cpp
@@ -27,7 +27,7 @@ protected:
 
   StringType theString;
 
-  void assertEmpty(StringType &v) {
+  void assertEmpty(StringType & v) {
     // Size tests
     EXPECT_EQ(0u, v.size());
     EXPECT_TRUE(v.empty());
@@ -234,38 +234,37 @@ TEST_F(SmallStringTest, Realloc) {
 }
 
 TEST_F(SmallStringTest, Comparisons) {
-  EXPECT_GT(0, SmallString<10>("aab").compare("aad"));
-  EXPECT_EQ(0, SmallString<10>("aab").compare("aab"));
-  EXPECT_LT(0, SmallString<10>("aab").compare("aaa"));
-  EXPECT_GT(0, SmallString<10>("aab").compare("aabb"));
-  EXPECT_LT(0, SmallString<10>("aab").compare("aa"));
-  EXPECT_LT(0, SmallString<10>("\xFF").compare("\1"));
+  EXPECT_GT( 0, SmallString<10>("aab").compare("aad"));
+  EXPECT_EQ( 0, SmallString<10>("aab").compare("aab"));
+  EXPECT_LT( 0, SmallString<10>("aab").compare("aaa"));
+  EXPECT_GT( 0, SmallString<10>("aab").compare("aabb"));
+  EXPECT_LT( 0, SmallString<10>("aab").compare("aa"));
+  EXPECT_LT( 0, SmallString<10>("\xFF").compare("\1"));
 
   EXPECT_EQ(-1, SmallString<10>("AaB").compare_insensitive("aAd"));
-  EXPECT_EQ(0, SmallString<10>("AaB").compare_insensitive("aab"));
-  EXPECT_EQ(1, SmallString<10>("AaB").compare_insensitive("AAA"));
+  EXPECT_EQ( 0, SmallString<10>("AaB").compare_insensitive("aab"));
+  EXPECT_EQ( 1, SmallString<10>("AaB").compare_insensitive("AAA"));
   EXPECT_EQ(-1, SmallString<10>("AaB").compare_insensitive("aaBb"));
-  EXPECT_EQ(1, SmallString<10>("AaB").compare_insensitive("aA"));
-  EXPECT_EQ(1, SmallString<10>("\xFF").compare_insensitive("\1"));
+  EXPECT_EQ( 1, SmallString<10>("AaB").compare_insensitive("aA"));
+  EXPECT_EQ( 1, SmallString<10>("\xFF").compare_insensitive("\1"));
 
   EXPECT_EQ(-1, SmallString<10>("aab").compare_numeric("aad"));
-  EXPECT_EQ(0, SmallString<10>("aab").compare_numeric("aab"));
-  EXPECT_EQ(1, SmallString<10>("aab").compare_numeric("aaa"));
+  EXPECT_EQ( 0, SmallString<10>("aab").compare_numeric("aab"));
+  EXPECT_EQ( 1, SmallString<10>("aab").compare_numeric("aaa"));
   EXPECT_EQ(-1, SmallString<10>("aab").compare_numeric("aabb"));
-  EXPECT_EQ(1, SmallString<10>("aab").compare_numeric("aa"));
+  EXPECT_EQ( 1, SmallString<10>("aab").compare_numeric("aa"));
   EXPECT_EQ(-1, SmallString<10>("1").compare_numeric("10"));
-  EXPECT_EQ(0, SmallString<10>("10").compare_numeric("10"));
-  EXPECT_EQ(0, SmallString<10>("10a").compare_numeric("10a"));
-  EXPECT_EQ(1, SmallString<10>("2").compare_numeric("1"));
-  EXPECT_EQ(0,
-            SmallString<10>("llvm_v1i64_ty").compare_numeric("llvm_v1i64_ty"));
-  EXPECT_EQ(1, SmallString<10>("\xFF").compare_numeric("\1"));
-  EXPECT_EQ(1, SmallString<10>("V16").compare_numeric("V1_q0"));
+  EXPECT_EQ( 0, SmallString<10>("10").compare_numeric("10"));
+  EXPECT_EQ( 0, SmallString<10>("10a").compare_numeric("10a"));
+  EXPECT_EQ( 1, SmallString<10>("2").compare_numeric("1"));
+  EXPECT_EQ( 0, SmallString<10>("llvm_v1i64_ty").compare_numeric("llvm_v1i64_ty"));
+  EXPECT_EQ( 1, SmallString<10>("\xFF").compare_numeric("\1"));
+  EXPECT_EQ( 1, SmallString<10>("V16").compare_numeric("V1_q0"));
   EXPECT_EQ(-1, SmallString<10>("V1_q0").compare_numeric("V16"));
   EXPECT_EQ(-1, SmallString<10>("V8_q0").compare_numeric("V16"));
-  EXPECT_EQ(1, SmallString<10>("V16").compare_numeric("V8_q0"));
+  EXPECT_EQ( 1, SmallString<10>("V16").compare_numeric("V8_q0"));
   EXPECT_EQ(-1, SmallString<10>("V1_q0").compare_numeric("V8_q0"));
-  EXPECT_EQ(1, SmallString<10>("V8_q0").compare_numeric("V1_q0"));
+  EXPECT_EQ( 1, SmallString<10>("V8_q0").compare_numeric("V1_q0"));
 }
 
 // Check gtest prints SmallString as a string instead of a container of chars.

--- a/llvm/unittests/ADT/SmallStringTest.cpp
+++ b/llvm/unittests/ADT/SmallStringTest.cpp
@@ -115,7 +115,7 @@ TEST_F(SmallStringTest, AppendStringRefs) {
   EXPECT_STREQ("abcdefghijklmnopqrstu", theString.c_str());
 }
 
-TEST(SmallStringTest, StartsWith) {
+TEST_F(SmallStringTest, StartsWith) {
   SmallString<32> Str("hello");
   EXPECT_TRUE(Str.starts_with(""));
   EXPECT_TRUE(Str.starts_with("he"));
@@ -125,7 +125,7 @@ TEST(SmallStringTest, StartsWith) {
   EXPECT_FALSE(Str.starts_with('i'));
 }
 
-TEST(SmallStringTest, EndsWith) {
+TEST_F(SmallStringTest, EndsWith) {
   SmallString<32> Str("hello");
   EXPECT_TRUE(Str.ends_with(""));
   EXPECT_TRUE(Str.ends_with("lo"));
@@ -136,7 +136,7 @@ TEST(SmallStringTest, EndsWith) {
   EXPECT_FALSE(Str.ends_with('p'));
 }
 
-TEST(SmallStringTest, Contains) {
+TEST_F(SmallStringTest, Contains) {
   SmallString<32> Str("hello");
   EXPECT_TRUE(Str.contains(""));
   EXPECT_TRUE(Str.contains("ell"));


### PR DESCRIPTION
This makes `SmallString` consistent with `std::string`, `std::string_view`, and `StringRef`.