### PR TITLE
[lldb][bazel] Add HighlighterDefault, rename ClangHighlighter targets

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -14,7 +14,18 @@ package(
 licenses(["notice"])
 
 cc_library(
-    name = "PluginClangHighlighter",
+    name = "PluginHighlighterDefault",
+    srcs = glob(["Highlighter/Default/*.cpp"]),
+    hdrs = glob(["Highlighter/Default/*.h"]),
+    includes = [".."],
+    deps = [
+        "//lldb:CoreHeaders",
+        "//lldb:Utility",
+    ],
+)
+
+cc_library(
+    name = "PluginHighlighterClang",
     srcs = glob(["Highlighter/Clang/*.cpp"]),
     hdrs = glob(["Highlighter/Clang/*.h"]),
     includes = [".."],
@@ -34,8 +45,8 @@ cc_library(
     hdrs = glob(["Language/ObjC/*.h"]),
     includes = [".."],
     deps = [
-        ":PluginClangHighlighter",
         ":PluginExpressionParserClangHeaders",
+        ":PluginHighlighterClang",
         "//lldb:CoreHeaders",
     ],
 )
@@ -782,7 +793,7 @@ cc_library(
     includes = [".."],
     deps = [
         ":PluginCPPRuntime",
-        ":PluginClangHighlighter",
+        ":PluginHighlighterClang",
         ":PluginTypeSystemClang",
         "//lldb:Core",
         "//lldb:DataFormatters",
@@ -868,7 +879,7 @@ cc_library(
     hdrs = glob(["Language/ObjCPlusPlus/*.h"]),
     includes = [".."],
     deps = [
-        ":PluginClangHighlighter",
+        ":PluginHighlighterClang",
         "//lldb:Core",
         "//lldb:Headers",
         "//lldb:Target",
@@ -894,8 +905,8 @@ cc_library(
     hdrs = glob(["Language/CPlusPlus/*.h"]),
     includes = [".."],
     deps = [
-        ":PluginClangHighlighter",
         ":PluginExpressionParserClangHeaders",
+        ":PluginHighlighterClang",
         "//lldb:CoreHeaders",
     ],
 )
@@ -908,8 +919,8 @@ cc_library(
         ":LanguageCPlusPlusProperties",
         ":PluginCPPRuntime",
         ":PluginCPlusPlusLanguageHeaders",
-        ":PluginClangHighlighter",
         ":PluginExpressionParserClangHeaders",
+        ":PluginHighlighterClang",
         ":PluginTypeSystemClang",
         ":PluginTypeSystemClangHeaders",
         "//clang:basic",

--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
@@ -25,6 +25,8 @@ DEFAULT_PLUGINS = [
     "CPlusPlusLanguage",
     "CXXItaniumABI",
     "DisassemblerLLVMC",
+    "HighlighterClang",
+    "HighlighterDefault",
     "DynamicLoaderDarwinKernel",
     "DynamicLoaderHexagonDYLD",
     "DynamicLoaderMacOSXDYLD",


### PR DESCRIPTION
Rename `PluginClangHighlighter` to `PluginHighlighterClang` for consistency with the directory-based naming convention, add the new `PluginHighlighterDefault` library, and register both `HighlighterClang` and `HighlighterDefault` in `DEFAULT_PLUGINS`.