### PR TITLE
[mlir][NFC] Remove unused deprecated API wrappers

### DIFF
--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -802,8 +802,6 @@ public:
   using size_type = size_t;
 
   NamedAttrList() : dictionarySorted({}, true) {}
-  LLVM_DEPRECATED("Use NamedAttrList() instead", "NamedAttrList()")
-  NamedAttrList(std::nullopt_t none) : NamedAttrList() {}
   NamedAttrList(ArrayRef<NamedAttribute> attributes);
   NamedAttrList(DictionaryAttr attributes);
   NamedAttrList(const_iterator inStart, const_iterator inEnd);
@@ -1176,8 +1174,6 @@ private:
 class OpPrintingFlags {
 public:
   OpPrintingFlags();
-  LLVM_DEPRECATED("Use OpPrintingFlags() instead", "OpPrintingFlags()")
-  OpPrintingFlags(std::nullopt_t) : OpPrintingFlags() {}
 
   /// Enables the elision of large elements attributes by printing a lexically
   /// valid but otherwise meaningless form instead of the element data. The

--- a/mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h
+++ b/mlir/include/mlir/Transforms/GreedyPatternRewriteDriver.h
@@ -177,18 +177,6 @@ LogicalResult
 applyPatternsGreedily(Region &region, const FrozenRewritePatternSet &patterns,
                       GreedyRewriteConfig config = GreedyRewriteConfig(),
                       bool *changed = nullptr);
-/// Same as `applyPatternsAndGreedily` above with folding.
-/// FIXME: Remove this once transition to above is completed.
-LLVM_DEPRECATED("Use applyPatternsGreedily() instead", "applyPatternsGreedily")
-inline LogicalResult
-applyPatternsAndFoldGreedily(Region &region,
-                             const FrozenRewritePatternSet &patterns,
-                             GreedyRewriteConfig config = GreedyRewriteConfig(),
-                             bool *changed = nullptr) {
-  config.enableFolding();
-  return applyPatternsGreedily(region, patterns, config, changed);
-}
-
 /// Rewrite ops nested under the given operation, which must be isolated from
 /// above, by repeatedly applying the highest benefit patterns in a greedy
 /// worklist driven manner until a fixpoint is reached.
@@ -229,18 +217,6 @@ applyPatternsGreedily(Operation *op, const FrozenRewritePatternSet &patterns,
     *changed = anyRegionChanged;
   return failure(failed);
 }
-/// Same as `applyPatternsGreedily` above with folding.
-/// FIXME: Remove this once transition to above is complieted.
-LLVM_DEPRECATED("Use applyPatternsGreedily() instead", "applyPatternsGreedily")
-inline LogicalResult
-applyPatternsAndFoldGreedily(Operation *op,
-                             const FrozenRewritePatternSet &patterns,
-                             GreedyRewriteConfig config = GreedyRewriteConfig(),
-                             bool *changed = nullptr) {
-  config.enableFolding();
-  return applyPatternsGreedily(op, patterns, config, changed);
-}
-
 /// Rewrite the specified ops by repeatedly applying the highest benefit
 /// patterns in a greedy worklist driven manner until a fixpoint is reached.
 ///
@@ -274,19 +250,6 @@ applyOpPatternsGreedily(ArrayRef<Operation *> ops,
                         const FrozenRewritePatternSet &patterns,
                         GreedyRewriteConfig config = GreedyRewriteConfig(),
                         bool *changed = nullptr, bool *allErased = nullptr);
-/// Same as `applyOpPatternsGreedily` with folding.
-/// FIXME: Remove this once transition to above is complieted.
-LLVM_DEPRECATED("Use applyOpPatternsGreedily() instead",
-                "applyOpPatternsGreedily")
-inline LogicalResult
-applyOpPatternsAndFold(ArrayRef<Operation *> ops,
-                       const FrozenRewritePatternSet &patterns,
-                       GreedyRewriteConfig config = GreedyRewriteConfig(),
-                       bool *changed = nullptr, bool *allErased = nullptr) {
-  config.enableFolding();
-  return applyOpPatternsGreedily(ops, patterns, config, changed, allErased);
-}
-
 } // namespace mlir
 
 #endif // MLIR_TRANSFORMS_GREEDYPATTERNREWRITEDRIVER_H_


### PR DESCRIPTION
Remove deprecated functions and constructors that have zero callers in the monorepo: `applyPatternsAndFoldGreedily`,  `applyOpPatternsAndFold`, `NamedAttrList(std::nullopt_t)`, and `OpPrintingFlags(std::nullopt_t)`.

These had FIXME comments requesting their removal.