### PR TITLE
[NFC][lldb][Process/FreeBSDKernel] Reorder class member functions

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSDKernel/ProcessFreeBSDKernel.h
+++ b/lldb/source/Plugins/Process/FreeBSDKernel/ProcessFreeBSDKernel.h
@@ -37,23 +37,23 @@ public:
 
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 
-  lldb_private::Status DoDestroy() override;
-
   bool CanDebug(lldb::TargetSP target_sp,
                 bool plugin_specified_by_name) override;
-
-  void RefreshStateAfterStop() override;
 
   lldb_private::Status DoLoadCore() override;
 
   lldb_private::DynamicLoader *GetDynamicLoader() override;
 
-  size_t DoReadMemory(lldb::addr_t addr, void *buf, size_t size,
-                      lldb_private::Status &error) override;
+  lldb_private::Status DoDestroy() override;
+
+  void RefreshStateAfterStop() override;
 
 protected:
   bool DoUpdateThreadList(lldb_private::ThreadList &old_thread_list,
                           lldb_private::ThreadList &new_thread_list) override;
+
+  size_t DoReadMemory(lldb::addr_t addr, void *buf, size_t size,
+                      lldb_private::Status &error) override;
 
   lldb::addr_t FindSymbol(const char *name);
 

--- a/lldb/source/Plugins/Process/FreeBSDKernel/ThreadFreeBSDKernel.h
+++ b/lldb/source/Plugins/Process/FreeBSDKernel/ThreadFreeBSDKernel.h
@@ -20,11 +20,6 @@ public:
 
   void RefreshStateAfterStop() override;
 
-  lldb::RegisterContextSP GetRegisterContext() override;
-
-  lldb::RegisterContextSP
-  CreateRegisterContextForFrame(lldb_private::StackFrame *frame) override;
-
   const char *GetName() override {
     if (m_thread_name.empty())
       return nullptr;
@@ -38,9 +33,13 @@ public:
       m_thread_name.clear();
   }
 
+  lldb::RegisterContextSP GetRegisterContext() override;
+
+  lldb::RegisterContextSP
+  CreateRegisterContextForFrame(lldb_private::StackFrame *frame) override;
+
   void SetIsCrashedThread(bool is_crashed) { m_is_crashed = is_crashed; }
 
-protected:
   bool CalculateStopInfo() override;
 
 private:


### PR DESCRIPTION
This reorders member functions of `ProcessFreeBSDKernel` and `ThreadFreeBSDKernel` to facilitate referencing their parent classes when adding, modifying, or removing member functions. There are two member scope changes to follow parent class definitions: `ProcessFreeBSDKernel::DoReadMemory()` becomes protected and `ThreadFreeBSDKernel::CalculateStopInfo()` becomes public.