### PR TITLE
[CIR] Fix undeclared variadic function prototype and no-proto call handling

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunctionInfo.h
@@ -117,7 +117,7 @@ public:
                       RequiredArgs required, CanQualType resultType,
                       llvm::ArrayRef<CanQualType> argTypes) {
     id.AddBoolean(info.getNoReturn());
-    id.AddBoolean(required.getOpaqueData());
+    id.AddInteger(required.getOpaqueData());
     resultType.Profile(id);
     for (const CanQualType &arg : argTypes)
       arg.Profile(id);

--- a/clang/test/CIR/CodeGen/no-prototype-variadic.c
+++ b/clang/test/CIR/CodeGen/no-prototype-variadic.c
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=gnu89 -Wno-implicit-function-declaration -fclangir -emit-cir %s -o - | FileCheck %s
+
+int foo(const char *);
+
+int bar(void) {
+  int t = foo("x");
+  printf("Hello %d\n", t);
+  printf("Hi\n");
+  return 0;
+}
+
+// CHECK: cir.func private @printf(!cir.ptr<!s8i>, ...) -> !s32i


### PR DESCRIPTION


- Allows calls through unprototyped functions instead of errorNYI when the  target permits variadic no-proto calls.
- In arrangeFunctionDeclaration, when isNoProtoCallVariadic() is true, emit   no-proto functions as variadic with zero fixed parameters so multiple call sites with different arities do not cause CIR verification failures.
- In arrangeFreeFunctionLikeCall, do not force RequiredArgs(0) for no-proto;  use the call-site argument types so the cast matches the promoted args  (e.g. noProto3).
- In emitCallArgs, set isVariadic for no-proto so arguments use promoted  vararg types.
- Fix CIRGenFunctionInfo::Profile to use AddInteger for RequiredArgs so FoldingSet distinguishes RequiredArgs(0) from RequiredArgs::All.
- Update no-prototype.c tests and add no-prototype-variadic.c for the implicit printf / undeclared variadic case.

Fixes #182175

@andykaylor 