### PR TITLE
[mlir] Improve dialect conversion failure diagnostics

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -25,9 +25,7 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/ScopedPrinter.h"
-#include "llvm/Support/raw_ostream.h"
 #include <optional>
-#include <string>
 #include <utility>
 
 using namespace mlir;

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -3339,9 +3339,9 @@ LogicalResult OperationConverter::convert(Operation *op,
                                           bool isRecursiveLegalization) {
   const ConversionConfig &config = rewriter.getConfig();
   auto emitFailedToLegalizeDiag = [&](bool wasExplicitlyIllegal) {
-    InFlightDiagnostic diag =
-        op->emitError() << "failed to legalize operation '" << op->getName()
-                        << "'";
+    InFlightDiagnostic diag = op->emitError()
+                              << "failed to legalize operation '"
+                              << op->getName() << "'";
     if (wasExplicitlyIllegal)
       diag << " that was explicitly marked illegal";
 

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2452,7 +2452,7 @@ public:
 
   /// Returns the most recently attempted conversion pattern on this operation
   /// that failed to match.
-  std::optional<StringRef> getLastFailurePattern(Operation *op) const;
+  const Pattern *getLastFailurePattern(Operation *op) const;
 
   /// Returns the conversion target in use by the legalizer.
   const ConversionTarget &getTarget() { return target; }
@@ -2532,7 +2532,7 @@ private:
   PatternApplicator applicator;
 
   /// The last conversion pattern that failed to match for a given op.
-  DenseMap<Operation *, std::string> failedPatternByOp;
+  DenseMap<Operation *, const Pattern *> failedPatternByOp;
 };
 } // namespace
 
@@ -2553,12 +2553,11 @@ bool OperationLegalizer::isIllegal(Operation *op) const {
   return target.isIllegal(op);
 }
 
-std::optional<StringRef>
-OperationLegalizer::getLastFailurePattern(Operation *op) const {
+const Pattern *OperationLegalizer::getLastFailurePattern(Operation *op) const {
   auto it = failedPatternByOp.find(op);
   if (it == failedPatternByOp.end())
-    return std::nullopt;
-  return StringRef(it->second);
+    return nullptr;
+  return it->second;
 }
 
 LogicalResult OperationLegalizer::legalize(Operation *op) {
@@ -2793,7 +2792,7 @@ LogicalResult OperationLegalizer::legalizeWithPattern(Operation *op) {
   RewriterState curState = rewriterImpl.getCurrentState();
   auto onFailure = [&](const Pattern &pattern) {
     assert(rewriterImpl.pendingRootUpdates.empty() && "dangling root updates");
-    failedPatternByOp[op] = formatPatternForDiagnostics(pattern);
+    failedPatternByOp[op] = &pattern;
     if (!rewriterImpl.config.allowPatternRollback) {
       // Erase all unresolved materializations.
       for (auto op : rewriterImpl.patternMaterializations) {
@@ -3348,9 +3347,9 @@ LogicalResult OperationConverter::convert(Operation *op,
 
     diag << "; operands (" << op->getOperandTypes() << "), results ("
          << op->getResultTypes() << ")";
-    if (std::optional<StringRef> pattern =
-            opLegalizer.getLastFailurePattern(op)) {
-      diag << "; rejected by conversion pattern '" << *pattern << "'";
+    if (const Pattern *pattern = opLegalizer.getLastFailurePattern(op)) {
+      diag << "; rejected by conversion pattern '"
+           << formatPatternForDiagnostics(*pattern) << "'";
     } else {
       diag << "; no conversion pattern matched";
     }

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -59,20 +59,6 @@ static void logFailure(llvm::ScopedPrinter &os, StringRef fmt, Args &&...args) {
   });
 }
 
-/// Format a conversion pattern as "root-op -> (generated-op, ...)".
-static std::string formatPatternForDiagnostics(const Pattern &pattern) {
-  std::string patternStr;
-  llvm::raw_string_ostream os(patternStr);
-  if (std::optional<OperationName> root = pattern.getRootKind())
-    os << root->getStringRef();
-  else
-    os << "*";
-  os << " -> (";
-  llvm::interleaveComma(pattern.getGeneratedOps(), os);
-  os << ")";
-  return patternStr;
-}
-
 /// Helper function that computes an insertion point where the given value is
 /// defined and can be used without a dominance violation.
 static OpBuilder::InsertPoint computeInsertPoint(Value value) {
@@ -2450,10 +2436,6 @@ public:
   /// was legalized, failure otherwise.
   LogicalResult legalize(Operation *op);
 
-  /// Returns the most recently attempted conversion pattern on this operation
-  /// that failed to match.
-  const Pattern *getLastFailurePattern(Operation *op) const;
-
   /// Returns the conversion target in use by the legalizer.
   const ConversionTarget &getTarget() { return target; }
 
@@ -2530,9 +2512,6 @@ private:
 
   /// The pattern applicator to use for conversions.
   PatternApplicator applicator;
-
-  /// The last conversion pattern that failed to match for a given op.
-  DenseMap<Operation *, const Pattern *> failedPatternByOp;
 };
 } // namespace
 
@@ -2549,16 +2528,7 @@ OperationLegalizer::OperationLegalizer(ConversionPatternRewriter &rewriter,
   computeLegalizationGraphBenefit(anyOpLegalizerPatterns, legalizerPatterns);
 }
 
-bool OperationLegalizer::isIllegal(Operation *op) const {
-  return target.isIllegal(op);
-}
-
-const Pattern *OperationLegalizer::getLastFailurePattern(Operation *op) const {
-  auto it = failedPatternByOp.find(op);
-  if (it == failedPatternByOp.end())
-    return nullptr;
-  return it->second;
-}
+bool OperationLegalizer::isIllegal(Operation *op) const { return target.isIllegal(op); }
 
 LogicalResult OperationLegalizer::legalize(Operation *op) {
 #ifndef NDEBUG
@@ -2570,7 +2540,6 @@ LogicalResult OperationLegalizer::legalize(Operation *op) {
 
   // Check to see if the operation is ignored and doesn't need to be converted.
   bool isIgnored = rewriter.getImpl().isOpIgnored(op);
-  failedPatternByOp.erase(op);
 
   LLVM_DEBUG({
     logger.getOStream() << "\n";
@@ -2792,7 +2761,6 @@ LogicalResult OperationLegalizer::legalizeWithPattern(Operation *op) {
   RewriterState curState = rewriterImpl.getCurrentState();
   auto onFailure = [&](const Pattern &pattern) {
     assert(rewriterImpl.pendingRootUpdates.empty() && "dangling root updates");
-    failedPatternByOp[op] = &pattern;
     if (!rewriterImpl.config.allowPatternRollback) {
       // Erase all unresolved materializations.
       for (auto op : rewriterImpl.patternMaterializations) {
@@ -2856,8 +2824,6 @@ LogicalResult OperationLegalizer::legalizeWithPattern(Operation *op) {
     }
     if (config.listener)
       config.listener->notifyPatternEnd(pattern, result);
-    if (succeeded(result))
-      failedPatternByOp.erase(op);
     return result;
   };
 
@@ -3339,20 +3305,10 @@ LogicalResult OperationConverter::convert(Operation *op,
                                           bool isRecursiveLegalization) {
   const ConversionConfig &config = rewriter.getConfig();
   auto emitFailedToLegalizeDiag = [&](bool wasExplicitlyIllegal) {
-    InFlightDiagnostic diag = op->emitError()
-                              << "failed to legalize operation '"
-                              << op->getName() << "'";
+    InFlightDiagnostic diag = op->emitError() << "failed to legalize operation";
     if (wasExplicitlyIllegal)
       diag << " that was explicitly marked illegal";
-
-    diag << "; operands (" << op->getOperandTypes() << "), results ("
-         << op->getResultTypes() << ")";
-    if (const Pattern *pattern = opLegalizer.getLastFailurePattern(op)) {
-      diag << "; rejected by conversion pattern '"
-           << formatPatternForDiagnostics(*pattern) << "'";
-    } else {
-      diag << "; no conversion pattern matched";
-    }
+    diag << ": " << OpWithFlags(op, OpPrintingFlags().skipRegions());
   };
 
   // Legalize the given operation.

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2528,7 +2528,9 @@ OperationLegalizer::OperationLegalizer(ConversionPatternRewriter &rewriter,
   computeLegalizationGraphBenefit(anyOpLegalizerPatterns, legalizerPatterns);
 }
 
-bool OperationLegalizer::isIllegal(Operation *op) const { return target.isIllegal(op); }
+bool OperationLegalizer::isIllegal(Operation *op) const {
+  return target.isIllegal(op);
+}
 
 LogicalResult OperationLegalizer::legalize(Operation *op) {
 #ifndef NDEBUG
@@ -3305,7 +3307,9 @@ LogicalResult OperationConverter::convert(Operation *op,
                                           bool isRecursiveLegalization) {
   const ConversionConfig &config = rewriter.getConfig();
   auto emitFailedToLegalizeDiag = [&](bool wasExplicitlyIllegal) {
-    InFlightDiagnostic diag = op->emitError() << "failed to legalize operation";
+    InFlightDiagnostic diag = op->emitError()
+                              << "failed to legalize operation '"
+                              << op->getName() << "'";
     if (wasExplicitlyIllegal)
       diag << " that was explicitly marked illegal";
     diag << ": " << OpWithFlags(op, OpPrintingFlags().skipRegions());

--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -432,7 +432,7 @@ func.func @test_lookup_without_converter() {
 // expected-remark@-1 {{applyPartialConversion failed}}
 
 func.func @test_skip_1to1_pattern(%arg0: f32) {
-  // expected-error@+1 {{failed to legalize operation 'test.type_consumer'}}
+  // expected-error@+1 {{failed to legalize operation 'test.type_consumer'.*operands \(f32\), results \(\).*rejected by conversion pattern 'test.type_consumer -> \(\)'}}
   "test.type_consumer"(%arg0) : (f32) -> ()
   return
 }

--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -432,7 +432,7 @@ func.func @test_lookup_without_converter() {
 // expected-remark@-1 {{applyPartialConversion failed}}
 
 func.func @test_skip_1to1_pattern(%arg0: f32) {
-  // expected-error@+1 {{failed to legalize operation 'test.type_consumer'.*operands \(f32\), results \(\).*rejected by conversion pattern 'test.type_consumer -> \(\)'}}
+  // expected-error@+1 {{failed to legalize operation 'test.type_consumer' that was explicitly marked illegal; operands ('f32'), results (); rejected by conversion pattern 'test.type_consumer -> ()'}}
   "test.type_consumer"(%arg0) : (f32) -> ()
   return
 }

--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -224,7 +224,7 @@ func.func @bounded_recursion() {
 builtin.module {
 
   func.func @fail_to_convert_illegal_op() -> i32 {
-    // expected-error@+1 {{failed to legalize operation 'test.illegal_op_f'}}
+    // expected-error@+1 {{failed to legalize operation 'test.illegal_op_f'; operands (), results ('i32'); no conversion pattern matched}}
     %result = "test.illegal_op_f"() : () -> (i32)
     return %result : i32
   }

--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -224,7 +224,7 @@ func.func @bounded_recursion() {
 builtin.module {
 
   func.func @fail_to_convert_illegal_op() -> i32 {
-    // expected-error@+1 {{failed to legalize operation 'test.illegal_op_f'; operands (), results ('i32'); no conversion pattern matched}}
+    // expected-error@+1 {{failed to legalize operation 'test.illegal_op_f' that was explicitly marked illegal; operands (), results ('i32'); no conversion pattern matched}}
     %result = "test.illegal_op_f"() : () -> (i32)
     return %result : i32
   }

--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -432,7 +432,7 @@ func.func @test_lookup_without_converter() {
 // expected-remark@-1 {{applyPartialConversion failed}}
 
 func.func @test_skip_1to1_pattern(%arg0: f32) {
-  // expected-error@+1 {{failed to legalize operation 'test.type_consumer' that was explicitly marked illegal: "test.type_consumer"(<<UNKNOWN SSA VALUE>>) : (f32) -> ()}}
+  // expected-error@+1 {{failed to legalize operation 'test.type_consumer' that was explicitly marked illegal: "test.type_consumer"\((%[0-9]+|<<UNKNOWN SSA VALUE>>)\) : \(f32\) -> \(\)}}
   "test.type_consumer"(%arg0) : (f32) -> ()
   return
 }

--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -432,7 +432,7 @@ func.func @test_lookup_without_converter() {
 // expected-remark@-1 {{applyPartialConversion failed}}
 
 func.func @test_skip_1to1_pattern(%arg0: f32) {
-  // expected-error@+1 {{failed to legalize operation 'test.type_consumer' that was explicitly marked illegal: "test.type_consumer"\((%[0-9]+|<<UNKNOWN SSA VALUE>>)\) : \(f32\) -> \(\)}}
+  // expected-error@+1 {{failed to legalize operation 'test.type_consumer' that was explicitly marked illegal}}
   "test.type_consumer"(%arg0) : (f32) -> ()
   return
 }

--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -224,7 +224,7 @@ func.func @bounded_recursion() {
 builtin.module {
 
   func.func @fail_to_convert_illegal_op() -> i32 {
-    // expected-error@+1 {{failed to legalize operation that was explicitly marked illegal: .*"test.illegal_op_f".*i32.*}}
+    // expected-error@+1 {{failed to legalize operation 'test.illegal_op_f' that was explicitly marked illegal: %0 = "test.illegal_op_f"() : () -> i32}}
     %result = "test.illegal_op_f"() : () -> (i32)
     return %result : i32
   }
@@ -432,7 +432,7 @@ func.func @test_lookup_without_converter() {
 // expected-remark@-1 {{applyPartialConversion failed}}
 
 func.func @test_skip_1to1_pattern(%arg0: f32) {
-  // expected-error@+1 {{failed to legalize operation that was explicitly marked illegal: .*"test.type_consumer".*f32.*}}
+  // expected-error@+1 {{failed to legalize operation 'test.type_consumer' that was explicitly marked illegal: "test.type_consumer"(<<UNKNOWN SSA VALUE>>) : (f32) -> ()}}
   "test.type_consumer"(%arg0) : (f32) -> ()
   return
 }

--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -224,7 +224,7 @@ func.func @bounded_recursion() {
 builtin.module {
 
   func.func @fail_to_convert_illegal_op() -> i32 {
-    // expected-error@+1 {{failed to legalize operation 'test.illegal_op_f' that was explicitly marked illegal; operands (), results ('i32'); no conversion pattern matched}}
+    // expected-error@+1 {{failed to legalize operation that was explicitly marked illegal: .*"test.illegal_op_f".*i32.*}}
     %result = "test.illegal_op_f"() : () -> (i32)
     return %result : i32
   }
@@ -432,7 +432,7 @@ func.func @test_lookup_without_converter() {
 // expected-remark@-1 {{applyPartialConversion failed}}
 
 func.func @test_skip_1to1_pattern(%arg0: f32) {
-  // expected-error@+1 {{failed to legalize operation 'test.type_consumer' that was explicitly marked illegal; operands ('f32'), results (); rejected by conversion pattern 'test.type_consumer -> ()'}}
+  // expected-error@+1 {{failed to legalize operation that was explicitly marked illegal: .*"test.type_consumer".*f32.*}}
   "test.type_consumer"(%arg0) : (f32) -> ()
   return
 }


### PR DESCRIPTION
This PR improves MLIR dialect conversion failure diagnostics when legalization fails.

Previously, the diagnostic mostly included the operation name (and in partial conversion, whether it was explicitly marked illegal). This change keeps that prefix and appends the printed failing operation. This provides immediate operand/result/type context directly in the same error line.

### Example

Before:
```
failed to legalize operation 'test.type_consumer' that was explicitly marked illegal
```

After:
```
failed to legalize operation 'test.type_consumer' that was explicitly marked illegal: "test.type_consumer"(%arg0) : (f32) -> ()
```

### Tests
- Updated `mlir/test/Transforms/test-legalizer.mlir` expectations for the richer emitted diagnostic.