### PR TITLE
[Reassociate][DebugInfo] Salvage debug info before rewriting expression

### DIFF
--- a/llvm/lib/Transforms/Scalar/Reassociate.cpp
+++ b/llvm/lib/Transforms/Scalar/Reassociate.cpp
@@ -744,13 +744,6 @@ void ReassociatePass::RewriteExprTree(BinaryOperator *I,
       if (ExpressionChangedStart == I)
         break;
 
-      // Discard any debug info related to the expressions that has changed (we
-      // can leave debug info related to the root and any operation that didn't
-      // change, since the result of the expression tree should be the same
-      // even after reassociation).
-      if (ClearFlags)
-        replaceDbgUsesWithUndef(ExpressionChangedStart);
-
       ExpressionChangedStart->moveBefore(I->getIterator());
       ExpressionChangedStart =
           cast<BinaryOperator>(*ExpressionChangedStart->user_begin());

--- a/llvm/lib/Transforms/Scalar/Reassociate.cpp
+++ b/llvm/lib/Transforms/Scalar/Reassociate.cpp
@@ -636,12 +636,14 @@ void ReassociatePass::RewriteExprTree(BinaryOperator *I,
         BinaryOperator *BO = isReassociableOp(OldLHS, Opcode);
         if (BO && !NotRewritable.count(BO))
           NodesToRewrite.push_back(BO);
+        salvageDebugInfo(*Op);
         Op->setOperand(0, NewLHS);
       }
       if (NewRHS != OldRHS) {
         BinaryOperator *BO = isReassociableOp(OldRHS, Opcode);
         if (BO && !NotRewritable.count(BO))
           NodesToRewrite.push_back(BO);
+        salvageDebugInfo(*Op);
         Op->setOperand(1, NewRHS);
       }
       LLVM_DEBUG(dbgs() << "TO: " << *Op << '\n');
@@ -669,6 +671,7 @@ void ReassociatePass::RewriteExprTree(BinaryOperator *I,
         BinaryOperator *BO = isReassociableOp(Op->getOperand(1), Opcode);
         if (BO && !NotRewritable.count(BO))
           NodesToRewrite.push_back(BO);
+        salvageDebugInfo(*Op);
         Op->setOperand(1, NewRHS);
         ExpressionChangedStart = Op;
         if (!ExpressionChangedEnd)
@@ -707,6 +710,7 @@ void ReassociatePass::RewriteExprTree(BinaryOperator *I,
     }
 
     LLVM_DEBUG(dbgs() << "RA: " << *Op << '\n');
+    salvageDebugInfo(*Op);
     Op->setOperand(0, NewOp);
     LLVM_DEBUG(dbgs() << "TO: " << *Op << '\n');
     ExpressionChangedStart = Op;

--- a/llvm/test/Transforms/Reassociate/reassociate-decrement-dbgvalue.ll
+++ b/llvm/test/Transforms/Reassociate/reassociate-decrement-dbgvalue.ll
@@ -1,0 +1,59 @@
+; RUN: opt < %s -passes=reassociate -S | FileCheck %s
+
+; Reduced from issue #60532. The Reassociate pass rearranges the decrement
+; of 'day', verify that the debug value for 'day' is salvaged using a
+; DIArgList expression rather than dropped to poison.
+
+; CHECK-LABEL: @example(
+; CHECK:         #dbg_value(i32 %mday, ![[DAY:[0-9]+]], !DIExpression(),
+; CHECK:         #dbg_value(!DIArgList(i32 -1, i32 %mday), ![[DAY]], !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_plus, DW_OP_stack_value),
+; CHECK-NOT:     #dbg_value(i32 poison,
+; CHECK:       ![[DAY]] = !DILocalVariable(name: "day"
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@b = internal constant [2 x i32] [i32 9, i32 4], align 4
+
+define dso_local i64 @example(i32 noundef %year, i32 noundef %mon, i32 noundef %mday) !dbg !7 {
+entry:
+  %idxprom = sext i32 %mon to i64, !dbg !22
+  %arrayidx = getelementptr inbounds i32, ptr @b, i64 %idxprom, !dbg !22
+  %0 = load i32, ptr %arrayidx, align 4, !dbg !22
+  call void @llvm.dbg.value(metadata i32 %mday, metadata !16, metadata !DIExpression()), !dbg !23
+  %dec = add nsw i32 %mday, -1, !dbg !24
+  call void @llvm.dbg.value(metadata i32 %dec, metadata !16, metadata !DIExpression()), !dbg !23
+  %add = add nsw i32 %year, %0, !dbg !25
+  %add1 = add nsw i32 %add, %dec, !dbg !26
+  %conv = sext i32 %add1 to i64, !dbg !27
+  ret i64 %conv, !dbg !28
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "example.c", directory: "/tmp")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!7 = distinct !DISubprogram(name: "example", scope: !1, file: !1, line: 3, type: !8, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(types: !9)
+!9 = !{!10, !6, !6, !6}
+!10 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!11 = !{!12, !13, !14, !16}
+!12 = !DILocalVariable(name: "year", arg: 1, scope: !7, file: !1, line: 3, type: !6)
+!13 = !DILocalVariable(name: "mon", arg: 2, scope: !7, file: !1, line: 3, type: !6)
+!14 = !DILocalVariable(name: "mday", arg: 3, scope: !7, file: !1, line: 3, type: !6)
+!16 = !DILocalVariable(name: "day", scope: !7, file: !1, line: 6, type: !6)
+!22 = !DILocation(line: 8, column: 14, scope: !7)
+!23 = !DILocation(line: 6, column: 7, scope: !7)
+!24 = !DILocation(line: 7, column: 6, scope: !7)
+!25 = !DILocation(line: 8, column: 12, scope: !7)
+!26 = !DILocation(line: 8, column: 20, scope: !7)
+!27 = !DILocation(line: 8, column: 10, scope: !7)
+!28 = !DILocation(line: 8, column: 3, scope: !7)

--- a/llvm/test/Transforms/Reassociate/reassociate_dbgvalue_discard.ll
+++ b/llvm/test/Transforms/Reassociate/reassociate_dbgvalue_discard.ll
@@ -11,14 +11,14 @@ target triple = "x86_64-unknown-linux-gnu"
 define dso_local i32 @test1(i32 %a, i32 %b, i32 %c, i32 %d) local_unnamed_addr #0 !dbg !7 {
 ; CHECK-LABEL: @test1(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:      #dbg_value(i32 poison, [[META16:![0-9]+]], !DIExpression(), [[META20:![0-9]+]])
-; CHECK-NEXT:      #dbg_value(i32 poison, [[META17:![0-9]+]], !DIExpression(), [[META21:![0-9]+]])
-; CHECK-NEXT:    [[M1:%.*]] = mul i32 [[D:%.*]], [[C:%.*]], !dbg [[DBG22:![0-9]+]]
-; CHECK-NEXT:    [[M3:%.*]] = mul i32 [[M1]], [[A:%.*]], !dbg [[DBG23:![0-9]+]]
-; CHECK-NEXT:      #dbg_value(i32 [[M3]], [[META18:![0-9]+]], !DIExpression(), [[META24:![0-9]+]])
+; CHECK-NEXT:      #dbg_value(!DIArgList(i32 [[A:%.*]], i32 [[C:%.*]]), [[META16:![0-9]+]], !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_mul, DW_OP_stack_value), [[META20:![0-9]+]])
+; CHECK-NEXT:      #dbg_value(!DIArgList(i32 [[B:%.*]], i32 [[C]]), [[META17:![0-9]+]], !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_mul, DW_OP_stack_value), [[META21:![0-9]+]])
+; CHECK-NEXT:    [[M1:%.*]] = mul i32 [[D:%.*]], [[C]], !dbg [[DBG22:![0-9]+]]
+; CHECK-NEXT:    [[M3:%.*]] = mul i32 [[M1]], [[A]], !dbg [[DBG23:![0-9]+]]
+; CHECK-NEXT:      #dbg_value(!DIArgList(i32 [[A]], i32 [[D]], i32 [[C]]), [[META18:![0-9]+]], !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 2, DW_OP_mul, DW_OP_LLVM_arg, 1, DW_OP_mul, DW_OP_stack_value), [[META24:![0-9]+]])
 ; CHECK-NEXT:    [[M2:%.*]] = mul i32 [[D]], [[C]], !dbg [[DBG25:![0-9]+]]
-; CHECK-NEXT:    [[M4:%.*]] = mul i32 [[M2]], [[B:%.*]], !dbg [[DBG26:![0-9]+]]
-; CHECK-NEXT:      #dbg_value(i32 [[M4]], [[META19:![0-9]+]], !DIExpression(), [[META27:![0-9]+]])
+; CHECK-NEXT:    [[M4:%.*]] = mul i32 [[M2]], [[B]], !dbg [[DBG26:![0-9]+]]
+; CHECK-NEXT:      #dbg_value(!DIArgList(i32 [[B]], i32 [[D]], i32 [[C]]), [[META19:![0-9]+]], !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 2, DW_OP_mul, DW_OP_LLVM_arg, 1, DW_OP_mul, DW_OP_stack_value), [[META27:![0-9]+]])
 ; CHECK-NEXT:    [[RES:%.*]] = xor i32 [[M3]], [[M4]]
 ; CHECK-NEXT:    ret i32 [[RES]], !dbg [[DBG28:![0-9]+]]
 ;

--- a/llvm/test/Transforms/Reassociate/reassociate_dbgvalue_salvage.ll
+++ b/llvm/test/Transforms/Reassociate/reassociate_dbgvalue_salvage.ll
@@ -2,7 +2,8 @@
 ; RUN: opt < %s -passes=reassociate -S -o - | FileCheck %s
 
 ; After reassociation m1 and m2 aren't calculated as m1=c*a and m2=c*b any longer.
-; So let's verify that the dbg.value nodes for m1 and m3 are invalidated.
+; So let's verify that the dbg.value nodes for m1 and m2 are salvaged
+; using DIArgList expressions that reference the original operands.
 
 source_filename = "reassociate_dbgvalue_discard.c"
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"


### PR DESCRIPTION
When RewriteExprTree modifies instruction operands, call `salvageDebugInfo()` before `setOperand()` so debug value expressions are rewritten while original operands are still intact. This preserves variable accessibility in debuggers instead of dropping values to poison.

Fixes #60532
Fixes #61272