### PR TITLE
[alpha.webkit.NoDeleteChecker] Fundamental types are trivially destructive

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -524,7 +524,7 @@ class TrivialFunctionAnalysisVisitor
       return true;
 
     // Fundamental types (integral, nullptr_t, etc...) don't have destructors.
-    if (Ty->isFundamentalType())
+    if (Ty->isFundamentalType() || Ty->isIntegralOrEnumerationType())
       return true;
 
     if (const auto *R = Ty->getAsCXXRecordDecl()) {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -523,8 +523,8 @@ class TrivialFunctionAnalysisVisitor
     if (Ty->isPointerOrReferenceType())
       return true;
 
-    // Primitive types don't have destructors.
-    if (Ty->isIntegralOrEnumerationType())
+    // Fundamental types (integral, nullptr_t, etc...) don't have destructors.
+    if (Ty->isFundamentalType())
       return true;
 
     if (const auto *R = Ty->getAsCXXRecordDecl()) {

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -204,3 +204,23 @@ void [[clang::annotate_type("webkit.nodelete")]] makeSubData() {
   // expected-warning@-1{{A function 'makeSubData' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
   SubData::create()->doSomething();
 }
+
+struct ObjectWithConstructor {
+  ObjectWithConstructor(double x) { }
+  ObjectWithConstructor(float x) { }
+  ObjectWithConstructor(decltype(nullptr)) { }
+  ObjectWithConstructor(void*) { }
+  ObjectWithConstructor(int x[3]) { }
+  ObjectWithConstructor(void* x[2]) { }
+};
+
+void [[clang::annotate_type("webkit.nodelete")]] makeObjectWithConstructor() {
+  ObjectWithConstructor obj1(nullptr);
+  ObjectWithConstructor obj2(0.5);
+  double x = 0.7;
+  ObjectWithConstructor obj3(x);
+  int ints[] = { 1, 2, 3 };
+  ObjectWithConstructor obj4(ints);
+  void* ptrs[] = { nullptr, nullptr };
+  ObjectWithConstructor obj5(ptrs);
+}

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -212,6 +212,8 @@ struct ObjectWithConstructor {
   ObjectWithConstructor(void*) { }
   ObjectWithConstructor(int x[3]) { }
   ObjectWithConstructor(void* x[2]) { }
+  enum class E { V1, V2 };
+  ObjectWithConstructor(E) { }
 };
 
 void [[clang::annotate_type("webkit.nodelete")]] makeObjectWithConstructor() {
@@ -223,4 +225,5 @@ void [[clang::annotate_type("webkit.nodelete")]] makeObjectWithConstructor() {
   ObjectWithConstructor obj4(ints);
   void* ptrs[] = { nullptr, nullptr };
   ObjectWithConstructor obj5(ptrs);
+  ObjectWithConstructor obj6(ObjectWithConstructor::E::V1);
 }


### PR DESCRIPTION
This PR fixes the bug in the "trivial function analysis" that CanTriviallyDestruct returns false for some fundamental types such as float and nullptr_t. Return true for these types instead as they are trivally destructive.