### PR TITLE
[SPIR-V] Stop emitting FPRoundingMode for arithmetic constrained intrinsics

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -3032,8 +3032,21 @@ bool SPIRVEmitIntrinsics::runOnFunction(Function &Func) {
     if (Postpone && !GR->findAssignPtrTypeInstr(I))
       insertAssignPtrTypeIntrs(I, B, true);
 
-    if (auto *FPI = dyn_cast<ConstrainedFPIntrinsic>(I))
-      useRoundingMode(FPI, B);
+    if (auto *FPI = dyn_cast<ConstrainedFPIntrinsic>(I)) {
+      // FPRoundingMode can only be applied to conversion instructions.
+      switch (FPI->getIntrinsicID()) {
+      case Intrinsic::experimental_constrained_fptosi:
+      case Intrinsic::experimental_constrained_fptoui:
+      case Intrinsic::experimental_constrained_sitofp:
+      case Intrinsic::experimental_constrained_uitofp:
+      case Intrinsic::experimental_constrained_fptrunc:
+      case Intrinsic::experimental_constrained_fpext:
+        useRoundingMode(FPI, B);
+        break;
+      default:
+        break;
+      }
+    }
   }
 
   // Pass backward: use instructions results to specify/update/cast operands

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/constrained-arithmetic.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/constrained-arithmetic.ll
@@ -1,6 +1,5 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
-; TODO: re-enable validator FPRoundingMode is placed correctly
-; RUNx: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-DAG: %[[#r1:]] = OpFAdd %[[#]] %[[#]]
 ; CHECK-DAG: %[[#r2:]] = OpFDiv %[[#]] %[[#]]
@@ -9,14 +8,7 @@
 ; CHECK-DAG: %[[#r5:]] = OpExtInst %[[#]] %[[#]] fma %[[#]] %[[#]] %[[#]]
 ; CHECK-DAG: %[[#r6:]] = OpFRem
 
-; CHECK-DAG: OpDecorate %[[#r1]] FPRoundingMode RTE
-; CHECK-DAG: OpDecorate %[[#r2]] FPRoundingMode RTZ
-; CHECK-DAG: OpDecorate %[[#r4]] FPRoundingMode RTN
-; CHECK-DAG: OpDecorate %[[#r3]] FPRoundingMode RTP
-
-; CHECK-NOT: OpDecorate %[[#r5]] FPRoundingMode
-; CHECK-NOT: OpDecorate %[[#r6]] FPRoundingMode
-
+; CHECK-NOT: OpDecorate %[[#]] FPRoundingMode
 
 @G_r1 = global float 0.0
 @G_r2 = global float 0.0

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/constrained-fmuladd.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/constrained-fmuladd.ll
@@ -1,30 +1,34 @@
 ; RUN: llc -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
-; TODO: re-enable validator FPRoundingMode is placed correctly
-; RUNx: %if spirv-tools %{ llc -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; CHECK-DAG: OpDecorate %[[#]] FPRoundingMode RTE
-; CHECK-DAG: OpDecorate %[[#]] FPRoundingMode RTZ
-; CHECK-DAG: OpDecorate %[[#]] FPRoundingMode RTP
-; CHECK-DAG: OpDecorate %[[#]] FPRoundingMode RTN
-; CHECK-DAG: OpDecorate %[[#]] FPRoundingMode RTE
+; CHECK-NOT: FPRoundingMode
 
 ; CHECK: OpFMul %[[#]] %[[#]] %[[#]]
 ; CHECK: OpFAdd %[[#]] %[[#]] %[[#]]
+
+@G_f32 = global float 0.0
+@G_f64 = global double 0.0
+@G_v2f32 = global <2 x float> zeroinitializer
+@G_v4f32 = global <4 x float> zeroinitializer
+@G_v2f64 = global <2 x double> zeroinitializer
+
 define spir_kernel void @test_f32(float %a) {
 entry:
   %r = tail call float @llvm.experimental.constrained.fmuladd.f32(
               float %a, float %a, float %a,
               metadata !"round.tonearest", metadata !"fpexcept.strict")
+  store float %r, ptr @G_f32
   ret void
 }
 
-; CHECK: OpFMul %[[#]] %[[#]] %[[#]] 
+; CHECK: OpFMul %[[#]] %[[#]] %[[#]]
 ; CHECK: OpFAdd %[[#]] %[[#]] %[[#]]
 define spir_kernel void @test_f64(double %a) {
 entry:
   %r = tail call double @llvm.experimental.constrained.fmuladd.f64(
               double %a, double %a, double %a,
               metadata !"round.towardzero", metadata !"fpexcept.strict")
+  store double %r, ptr @G_f64
   ret void
 }
 
@@ -35,6 +39,7 @@ entry:
   %r = tail call <2 x float> @llvm.experimental.constrained.fmuladd.v2f32(
               <2 x float> %a, <2 x float> %a, <2 x float> %a,
               metadata !"round.upward", metadata !"fpexcept.strict")
+  store <2 x float> %r, ptr @G_v2f32
   ret void
 }
 
@@ -45,6 +50,7 @@ entry:
   %r = tail call <4 x float> @llvm.experimental.constrained.fmuladd.v4f32(
               <4 x float> %a, <4 x float> %a, <4 x float> %a,
               metadata !"round.downward", metadata !"fpexcept.strict")
+  store <4 x float> %r, ptr @G_v4f32
   ret void
 }
 
@@ -55,6 +61,7 @@ entry:
   %r = tail call <2 x double> @llvm.experimental.constrained.fmuladd.v2f64(
               <2 x double> %a, <2 x double> %a, <2 x double> %a,
               metadata !"round.tonearest", metadata !"fpexcept.strict")
+  store <2 x double> %r, ptr @G_v2f64
   ret void
 }
 


### PR DESCRIPTION
Addresses https://github.com/llvm/llvm-project/issues/180936