### PR TITLE
[WebAssembly][FastISel] Emit signed loads for sext of i8/i16/i32

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -171,6 +171,8 @@ private:
   unsigned getRegForPromotedValue(const Value *V, bool IsSigned);
   unsigned notValue(unsigned Reg);
   unsigned copyValue(unsigned Reg);
+  bool WebAssemblyEmitLoad(unsigned Opc, Register &ResultReg, Address &Addr,
+                           MachineMemOperand *MMO);
 
   // Backend specific FastISel code.
   Register fastMaterializeAlloca(const AllocaInst *AI) override;
@@ -204,6 +206,15 @@ public:
   }
 
   bool fastSelectInstruction(const Instruction *I) override;
+  /// This callback is invoked by the FastISel framework when it detects that
+  /// an operand (specified by OpNo) of the given MachineInstr (MI) is a
+  /// virtual register produced by a LoadInst (LI).
+  ///
+  /// The goal of this function is to determine if the operation of MI can be
+  /// folded together with the load into a single, optimized target-specific
+  /// memory instruction, and if possible, to actually perform the folding.
+  bool tryToFoldLoadIntoMI(MachineInstr *MI, unsigned OpNo,
+                           const LoadInst *LI) override;
 
 #include "WebAssemblyGenFastISel.inc"
 };
@@ -1093,6 +1104,24 @@ bool WebAssemblyFastISel::selectZExt(const Instruction *I) {
   return true;
 }
 
+static bool isSignedExtLoad(unsigned Opc) {
+  switch (Opc) {
+  default:
+    return false;
+  case WebAssembly::LOAD8_S_I32_A32:
+  case WebAssembly::LOAD8_S_I32_A64:
+  case WebAssembly::LOAD16_S_I32_A32:
+  case WebAssembly::LOAD16_S_I32_A64:
+  case WebAssembly::LOAD8_S_I64_A32:
+  case WebAssembly::LOAD8_S_I64_A64:
+  case WebAssembly::LOAD16_S_I64_A32:
+  case WebAssembly::LOAD16_S_I64_A64:
+  case WebAssembly::LOAD32_S_I64_A32:
+  case WebAssembly::LOAD32_S_I64_A64:
+    return true;
+  }
+}
+
 bool WebAssemblyFastISel::selectSExt(const Instruction *I) {
   const auto *SExt = cast<SExtInst>(I);
 
@@ -1102,6 +1131,16 @@ bool WebAssemblyFastISel::selectSExt(const Instruction *I) {
   Register In = getRegForValue(Op);
   if (In == 0)
     return false;
+
+  MachineInstr *MI = MRI.getUniqueVRegDef(In);
+  if (MI && isSignedExtLoad(MI->getOpcode())) {
+    // The load instruction has already been folded into a signed load
+    // by selectLoad, so we don't need to emit any extension instruction.
+    // Just map the result of this SExt to the signed load register.
+    updateValueMap(I, In);
+    return true;
+  }
+
   unsigned Reg = signExtend(In, Op, From, To);
   if (Reg == 0)
     return false;
@@ -1264,6 +1303,61 @@ bool WebAssemblyFastISel::selectBitCast(const Instruction *I) {
   assert(Iter->isBitcast());
   Iter->setPhysRegsDeadExcept(ArrayRef<Register>(), TRI);
   updateValueMap(I, Reg);
+  return true;
+}
+
+static unsigned getSExtLoadOpcode(unsigned Opc, bool A64) {
+  switch (Opc) {
+  default:
+    return false;
+  case WebAssembly::I32_EXTEND8_S_I32:
+    Opc = A64 ? WebAssembly::LOAD8_S_I32_A64 : WebAssembly::LOAD8_S_I32_A32;
+    break;
+  case WebAssembly::I32_EXTEND16_S_I32:
+    Opc = A64 ? WebAssembly::LOAD16_S_I32_A64 : WebAssembly::LOAD16_S_I32_A32;
+    break;
+  case WebAssembly::I64_EXTEND8_S_I64:
+    Opc = A64 ? WebAssembly::LOAD8_S_I64_A64 : WebAssembly::LOAD8_S_I64_A32;
+    break;
+  case WebAssembly::I64_EXTEND16_S_I64:
+    Opc = A64 ? WebAssembly::LOAD16_S_I64_A64 : WebAssembly::LOAD16_S_I64_A32;
+    break;
+  case WebAssembly::I64_EXTEND32_S_I64:
+  case WebAssembly::I64_EXTEND_S_I32:
+    Opc = A64 ? WebAssembly::LOAD32_S_I64_A64 : WebAssembly::LOAD32_S_I64_A32;
+    break;
+  }
+
+  return Opc;
+}
+
+bool WebAssemblyFastISel::WebAssemblyEmitLoad(unsigned Opc, Register &ResultReg,
+                                              Address &Addr,
+                                              MachineMemOperand *MMO) {
+  MachineInstrBuilder MIB =
+      BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD, TII.get(Opc), ResultReg);
+  addLoadStoreOperands(Addr, MIB, MMO);
+  return true;
+}
+
+bool WebAssemblyFastISel::tryToFoldLoadIntoMI(MachineInstr *MI, unsigned OpNo,
+                                              const LoadInst *LI) {
+  bool A64 = Subtarget->hasAddr64();
+  unsigned TargetOpc;
+  if (!(TargetOpc = getSExtLoadOpcode(MI->getOpcode(), A64)))
+    return false;
+
+  Address Addr;
+  if (!computeAddress(LI->getPointerOperand(), Addr))
+    return false;
+
+  Register ResultReg = MI->getOperand(0).getReg();
+  if (!WebAssemblyEmitLoad(TargetOpc, ResultReg, Addr,
+                           createMachineMemOperandFor(LI)))
+    return false;
+
+  MachineBasicBlock::iterator Iter(MI);
+  removeDeadCode(Iter, std::next(Iter));
   return true;
 }
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -1104,24 +1104,6 @@ bool WebAssemblyFastISel::selectZExt(const Instruction *I) {
   return true;
 }
 
-static bool isSignedExtLoad(unsigned Opc) {
-  switch (Opc) {
-  default:
-    return false;
-  case WebAssembly::LOAD8_S_I32_A32:
-  case WebAssembly::LOAD8_S_I32_A64:
-  case WebAssembly::LOAD16_S_I32_A32:
-  case WebAssembly::LOAD16_S_I32_A64:
-  case WebAssembly::LOAD8_S_I64_A32:
-  case WebAssembly::LOAD8_S_I64_A64:
-  case WebAssembly::LOAD16_S_I64_A32:
-  case WebAssembly::LOAD16_S_I64_A64:
-  case WebAssembly::LOAD32_S_I64_A32:
-  case WebAssembly::LOAD32_S_I64_A64:
-    return true;
-  }
-}
-
 bool WebAssemblyFastISel::selectSExt(const Instruction *I) {
   const auto *SExt = cast<SExtInst>(I);
 
@@ -1131,15 +1113,6 @@ bool WebAssemblyFastISel::selectSExt(const Instruction *I) {
   Register In = getRegForValue(Op);
   if (In == 0)
     return false;
-
-  MachineInstr *MI = MRI.getUniqueVRegDef(In);
-  if (MI && isSignedExtLoad(MI->getOpcode())) {
-    // The load instruction has already been folded into a signed load
-    // by selectLoad, so we don't need to emit any extension instruction.
-    // Just map the result of this SExt to the signed load register.
-    updateValueMap(I, In);
-    return true;
-  }
 
   unsigned Reg = signExtend(In, Op, From, To);
   if (Reg == 0)

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -1282,7 +1282,7 @@ bool WebAssemblyFastISel::selectBitCast(const Instruction *I) {
 static unsigned getSExtLoadOpcode(unsigned Opc, bool A64) {
   switch (Opc) {
   default:
-    return 0;
+    return WebAssembly::INSTRUCTION_LIST_END;
   case WebAssembly::I32_EXTEND8_S_I32:
     Opc = A64 ? WebAssembly::LOAD8_S_I32_A64 : WebAssembly::LOAD8_S_I32_A32;
     break;
@@ -1316,8 +1316,9 @@ bool WebAssemblyFastISel::WebAssemblyEmitLoad(unsigned Opc, Register &ResultReg,
 bool WebAssemblyFastISel::tryToFoldLoadIntoMI(MachineInstr *MI, unsigned OpNo,
                                               const LoadInst *LI) {
   bool A64 = Subtarget->hasAddr64();
-  unsigned TargetOpc;
-  if (!(TargetOpc = getSExtLoadOpcode(MI->getOpcode(), A64)))
+  unsigned NewOpc;
+  if ((NewOpc = getSExtLoadOpcode(MI->getOpcode(), A64)) ==
+      WebAssembly::INSTRUCTION_LIST_END)
     return false;
 
   Address Addr;
@@ -1325,7 +1326,7 @@ bool WebAssemblyFastISel::tryToFoldLoadIntoMI(MachineInstr *MI, unsigned OpNo,
     return false;
 
   Register ResultReg = MI->getOperand(0).getReg();
-  if (!WebAssemblyEmitLoad(TargetOpc, ResultReg, Addr,
+  if (!WebAssemblyEmitLoad(NewOpc, ResultReg, Addr,
                            createMachineMemOperandFor(LI)))
     return false;
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -1309,7 +1309,7 @@ bool WebAssemblyFastISel::selectBitCast(const Instruction *I) {
 static unsigned getSExtLoadOpcode(unsigned Opc, bool A64) {
   switch (Opc) {
   default:
-    return false;
+    return 0;
   case WebAssembly::I32_EXTEND8_S_I32:
     Opc = A64 ? WebAssembly::LOAD8_S_I32_A64 : WebAssembly::LOAD8_S_I32_A32;
     break;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -1296,15 +1296,6 @@ static unsigned getSExtLoadOpcode(unsigned Opc, bool A64) {
   return Opc;
 }
 
-bool WebAssemblyFastISel::WebAssemblyEmitLoad(unsigned Opc, Register &ResultReg,
-                                              Address &Addr,
-                                              MachineMemOperand *MMO) {
-  MachineInstrBuilder MIB =
-      BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD, TII.get(Opc), ResultReg);
-  addLoadStoreOperands(Addr, MIB, MMO);
-  return true;
-}
-
 bool WebAssemblyFastISel::tryToFoldLoadIntoMI(MachineInstr *MI, unsigned OpNo,
                                               const LoadInst *LI) {
   bool A64 = Subtarget->hasAddr64();
@@ -1318,10 +1309,9 @@ bool WebAssemblyFastISel::tryToFoldLoadIntoMI(MachineInstr *MI, unsigned OpNo,
     return false;
 
   Register ResultReg = MI->getOperand(0).getReg();
-  if (!WebAssemblyEmitLoad(NewOpc, ResultReg, Addr,
-                           createMachineMemOperandFor(LI)))
-    return false;
-
+  MachineInstrBuilder MIB = BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD,
+                                    TII.get(NewOpc), ResultReg);
+  addLoadStoreOperands(Addr, MIB, createMachineMemOperandFor(LI));
   MachineBasicBlock::iterator Iter(MI);
   removeDeadCode(Iter, std::next(Iter));
   return true;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -171,8 +171,6 @@ private:
   unsigned getRegForPromotedValue(const Value *V, bool IsSigned);
   unsigned notValue(unsigned Reg);
   unsigned copyValue(unsigned Reg);
-  bool WebAssemblyEmitLoad(unsigned Opc, Register &ResultReg, Address &Addr,
-                           MachineMemOperand *MMO);
 
   // Backend specific FastISel code.
   Register fastMaterializeAlloca(const AllocaInst *AI) override;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -206,13 +206,6 @@ public:
   }
 
   bool fastSelectInstruction(const Instruction *I) override;
-  /// This callback is invoked by the FastISel framework when it detects that
-  /// an operand (specified by OpNo) of the given MachineInstr (MI) is a
-  /// virtual register produced by a LoadInst (LI).
-  ///
-  /// The goal of this function is to determine if the operation of MI can be
-  /// folded together with the load into a single, optimized target-specific
-  /// memory instruction, and if possible, to actually perform the folding.
   bool tryToFoldLoadIntoMI(MachineInstr *MI, unsigned OpNo,
                            const LoadInst *LI) override;
 
@@ -1113,7 +1106,6 @@ bool WebAssemblyFastISel::selectSExt(const Instruction *I) {
   Register In = getRegForValue(Op);
   if (In == 0)
     return false;
-
   unsigned Reg = signExtend(In, Op, From, To);
   if (Reg == 0)
     return false;

--- a/llvm/test/CodeGen/WebAssembly/load-ext.ll
+++ b/llvm/test/CodeGen/WebAssembly/load-ext.ll
@@ -26,8 +26,7 @@ define i32 @sext_i8_i32(ptr %p) {
 ; WASM32-FAST-LABEL: sext_i8_i32:
 ; WASM32-FAST:         .functype sext_i8_i32 (i32) -> (i32)
 ; WASM32-FAST-NEXT:  # %bb.0:
-; WASM32-FAST-NEXT:    i32.load8_u $push1=, 0($0)
-; WASM32-FAST-NEXT:    i32.extend8_s $push0=, $pop1
+; WASM32-FAST-NEXT:    i32.load8_s $push0=, 0($0)
 ; WASM32-FAST-NEXT:    return $pop0
 ;
 ; WASM32-FAST-MVP-LABEL: sext_i8_i32:
@@ -55,8 +54,7 @@ define i32 @sext_i8_i32(ptr %p) {
 ; WASM64-FAST-LABEL: sext_i8_i32:
 ; WASM64-FAST:         .functype sext_i8_i32 (i64) -> (i32)
 ; WASM64-FAST-NEXT:  # %bb.0:
-; WASM64-FAST-NEXT:    i32.load8_u $push1=, 0($0)
-; WASM64-FAST-NEXT:    i32.extend8_s $push0=, $pop1
+; WASM64-FAST-NEXT:    i32.load8_s $push0=, 0($0)
 ; WASM64-FAST-NEXT:    return $pop0
 ;
 ; WASM64-FAST-MVP-LABEL: sext_i8_i32:
@@ -150,8 +148,7 @@ define i32 @sext_i16_i32(ptr %p) {
 ; WASM32-FAST-LABEL: sext_i16_i32:
 ; WASM32-FAST:         .functype sext_i16_i32 (i32) -> (i32)
 ; WASM32-FAST-NEXT:  # %bb.0:
-; WASM32-FAST-NEXT:    i32.load16_u $push1=, 0($0)
-; WASM32-FAST-NEXT:    i32.extend16_s $push0=, $pop1
+; WASM32-FAST-NEXT:    i32.load16_s $push0=, 0($0)
 ; WASM32-FAST-NEXT:    return $pop0
 ;
 ; WASM32-FAST-MVP-LABEL: sext_i16_i32:
@@ -179,8 +176,7 @@ define i32 @sext_i16_i32(ptr %p) {
 ; WASM64-FAST-LABEL: sext_i16_i32:
 ; WASM64-FAST:         .functype sext_i16_i32 (i64) -> (i32)
 ; WASM64-FAST-NEXT:  # %bb.0:
-; WASM64-FAST-NEXT:    i32.load16_u $push1=, 0($0)
-; WASM64-FAST-NEXT:    i32.extend16_s $push0=, $pop1
+; WASM64-FAST-NEXT:    i32.load16_s $push0=, 0($0)
 ; WASM64-FAST-NEXT:    return $pop0
 ;
 ; WASM64-FAST-MVP-LABEL: sext_i16_i32:
@@ -538,8 +534,7 @@ define i64 @sext_i32_i64(ptr %p) {
 ; WASM32-FAST-LABEL: sext_i32_i64:
 ; WASM32-FAST:         .functype sext_i32_i64 (i32) -> (i64)
 ; WASM32-FAST-NEXT:  # %bb.0:
-; WASM32-FAST-NEXT:    i32.load $push1=, 0($0)
-; WASM32-FAST-NEXT:    i64.extend_i32_s $push0=, $pop1
+; WASM32-FAST-NEXT:    i64.load32_s $push0=, 0($0)
 ; WASM32-FAST-NEXT:    return $pop0
 ;
 ; WASM32-FAST-MVP-LABEL: sext_i32_i64:
@@ -564,8 +559,7 @@ define i64 @sext_i32_i64(ptr %p) {
 ; WASM64-FAST-LABEL: sext_i32_i64:
 ; WASM64-FAST:         .functype sext_i32_i64 (i64) -> (i64)
 ; WASM64-FAST-NEXT:  # %bb.0:
-; WASM64-FAST-NEXT:    i32.load $push1=, 0($0)
-; WASM64-FAST-NEXT:    i64.extend_i32_s $push0=, $pop1
+; WASM64-FAST-NEXT:    i64.load32_s $push0=, 0($0)
 ; WASM64-FAST-NEXT:    return $pop0
 ;
 ; WASM64-FAST-MVP-LABEL: sext_i32_i64:

--- a/llvm/test/CodeGen/WebAssembly/offset-fastisel.ll
+++ b/llvm/test/CodeGen/WebAssembly/offset-fastisel.ll
@@ -121,8 +121,7 @@ define i32 @load_i8_s_with_folded_offset(ptr %p) {
 ; DEFAULT-LABEL: load_i8_s_with_folded_offset:
 ; DEFAULT:         .functype load_i8_s_with_folded_offset (i32) -> (i32)
 ; DEFAULT-NEXT:  # %bb.0:
-; DEFAULT-NEXT:    i32.load8_u $push1=, 24($0)
-; DEFAULT-NEXT:    i32.extend8_s $push0=, $pop1
+; DEFAULT-NEXT:    i32.load8_s $push0=, 24($0)
 ; DEFAULT-NEXT:    # fallthrough-return
 ;
 ; MVP-LABEL: load_i8_s_with_folded_offset:


### PR DESCRIPTION
FastISel currently defaults to unsigned loads for i8/i16/i32 types, leaving any sign-extension to be handled by a separate instruction. This patch optimizes this by folding the SExtInst into the LoadInst, directly emitting a signed load (e.g., i32.load8_s).

When a load has a single SExtInst use, selectLoad emits a signed load and safely removes the redundantly emitted SExtInst.

Fixed: #180783