### PR TITLE
Revert "[InstCombine] Allow freezing multiple operands (#154336)"

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5199,68 +5199,63 @@ Instruction *InstCombinerImpl::visitLandingPadInst(LandingPadInst &LI) {
 Value *
 InstCombinerImpl::pushFreezeToPreventPoisonFromPropagating(FreezeInst &OrigFI) {
   // Try to push freeze through instructions that propagate but don't produce
-  // poison as far as possible. If an operand of freeze does not produce poison
-  // then push the freeze through to the operands that are not guaranteed
-  // non-poison. The actual transform is as follows.
-  //   Op1 = ...                        ; Op1 can be poison
-  //   Op0 = Inst(Op1, NonPoisonOps...)
+  // poison as far as possible.  If an operand of freeze follows three
+  // conditions 1) one-use, 2) does not produce poison, and 3) has all but one
+  // guaranteed-non-poison operands then push the freeze through to the one
+  // operand that is not guaranteed non-poison.  The actual transform is as
+  // follows.
+  //   Op1 = ...                        ; Op1 can be posion
+  //   Op0 = Inst(Op1, NonPoisonOps...) ; Op0 has only one use and only have
+  //                                    ; single guaranteed-non-poison operands
   //   ... = Freeze(Op0)
   // =>
   //   Op1 = ...
   //   Op1.fr = Freeze(Op1)
   //   ... = Inst(Op1.fr, NonPoisonOps...)
+  auto *OrigOp = OrigFI.getOperand(0);
+  auto *OrigOpInst = dyn_cast<Instruction>(OrigOp);
 
-  auto CanPushFreeze = [](Value *V) {
-    if (!isa<Instruction>(V) || isa<PHINode>(V))
-      return false;
+  // While we could change the other users of OrigOp to use freeze(OrigOp), that
+  // potentially reduces their optimization potential, so let's only do this iff
+  // the OrigOp is only used by the freeze.
+  if (!OrigOpInst || !OrigOpInst->hasOneUse() || isa<PHINode>(OrigOp))
+    return nullptr;
 
-    // We can't push the freeze through an instruction which can itself create
-    // poison.  If the only source of new poison is flags, we can simply
-    // strip them (since we know the only use is the freeze and nothing can
-    // benefit from them.)
-    return !canCreateUndefOrPoison(cast<Operator>(V),
-                                   /*ConsiderFlagsAndMetadata*/ false);
-  };
+  // We can't push the freeze through an instruction which can itself create
+  // poison.  If the only source of new poison is flags, we can simply
+  // strip them (since we know the only use is the freeze and nothing can
+  // benefit from them.)
+  if (canCreateUndefOrPoison(cast<Operator>(OrigOp),
+                             /*ConsiderFlagsAndMetadata*/ false))
+    return nullptr;
 
-  // Pushing freezes up long instruction chains can be expensive. Instead,
-  // we directly push the freeze all the way to the leaves. However, we leave
-  // deduplication of freezes on the same value for freezeOtherUses().
-  Use *OrigUse = &OrigFI.getOperandUse(0);
-  SmallPtrSet<Instruction *, 8> Visited;
-  SmallVector<Use *, 8> Worklist;
-  Worklist.push_back(OrigUse);
-  while (!Worklist.empty()) {
-    auto *U = Worklist.pop_back_val();
-    Value *V = U->get();
-    if (!CanPushFreeze(V)) {
-      // If we can't push through the original instruction, abort the transform.
-      if (U == OrigUse)
-        return nullptr;
-
-      auto *UserI = cast<Instruction>(U->getUser());
-      Builder.SetInsertPoint(UserI);
-      Value *Frozen = Builder.CreateFreeze(V, V->getName() + ".fr");
-      U->set(Frozen);
+  // If operand is guaranteed not to be poison, there is no need to add freeze
+  // to the operand. So we first find the operand that is not guaranteed to be
+  // poison.
+  Value *MaybePoisonOperand = nullptr;
+  for (Value *V : OrigOpInst->operands()) {
+    if (isa<MetadataAsValue>(V) || isGuaranteedNotToBeUndefOrPoison(V) ||
+        // Treat identical operands as a single operand.
+        (MaybePoisonOperand && MaybePoisonOperand == V))
       continue;
-    }
-
-    auto *I = cast<Instruction>(V);
-    if (!Visited.insert(I).second)
-      continue;
-
-    // reverse() to emit freezes in a more natural order.
-    for (Use &Op : reverse(I->operands())) {
-      Value *OpV = Op.get();
-      if (isa<MetadataAsValue>(OpV) || isGuaranteedNotToBeUndefOrPoison(OpV))
-        continue;
-      Worklist.push_back(&Op);
-    }
-
-    I->dropPoisonGeneratingAnnotations();
-    this->Worklist.add(I);
+    if (!MaybePoisonOperand)
+      MaybePoisonOperand = V;
+    else
+      return nullptr;
   }
 
-  return OrigUse->get();
+  OrigOpInst->dropPoisonGeneratingAnnotations();
+
+  // If all operands are guaranteed to be non-poison, we can drop freeze.
+  if (!MaybePoisonOperand)
+    return OrigOp;
+
+  Builder.SetInsertPoint(OrigOpInst);
+  Value *FrozenMaybePoisonOperand = Builder.CreateFreeze(
+      MaybePoisonOperand, MaybePoisonOperand->getName() + ".fr");
+
+  OrigOpInst->replaceUsesOfWith(MaybePoisonOperand, FrozenMaybePoisonOperand);
+  return OrigOp;
 }
 
 Instruction *InstCombinerImpl::foldFreezeIntoRecurrence(FreezeInst &FI,

--- a/llvm/test/Transforms/InstCombine/freeze-fp-ops.ll
+++ b/llvm/test/Transforms/InstCombine/freeze-fp-ops.ll
@@ -163,9 +163,8 @@ define float @freeze_sqrt(float %arg) {
 define float @freeze_powi(float %arg0, i32 %arg1) {
 ; CHECK-LABEL: define float @freeze_powi(
 ; CHECK-SAME: float [[ARG0:%.*]], i32 [[ARG1:%.*]]) {
-; CHECK-NEXT:    [[ARG0_FR:%.*]] = freeze float [[ARG0]]
-; CHECK-NEXT:    [[ARG1_FR:%.*]] = freeze i32 [[ARG1]]
-; CHECK-NEXT:    [[OP:%.*]] = call float @llvm.powi.f32.i32(float [[ARG0_FR]], i32 [[ARG1_FR]])
+; CHECK-NEXT:    [[OP1:%.*]] = call float @llvm.powi.f32.i32(float [[ARG0]], i32 [[ARG1]])
+; CHECK-NEXT:    [[OP:%.*]] = freeze float [[OP1]]
 ; CHECK-NEXT:    ret float [[OP]]
 ;
   %op = call float @llvm.powi.f32.i32(float %arg0, i32 %arg1)

--- a/llvm/test/Transforms/InstCombine/icmp.ll
+++ b/llvm/test/Transforms/InstCombine/icmp.ll
@@ -5835,9 +5835,10 @@ entry:
 define i1 @icmp_freeze_sext(i16 %x, i16 %y) {
 ; CHECK-LABEL: define i1 @icmp_freeze_sext(
 ; CHECK-SAME: i16 [[X:%.*]], i16 [[Y:%.*]]) {
-; CHECK-NEXT:    [[Y_FR:%.*]] = freeze i16 [[Y]]
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i16 [[X]]
-; CHECK-NEXT:    [[CMP2:%.*]] = icmp uge i16 [[X_FR]], [[Y_FR]]
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp uge i16 [[X]], [[Y]]
+; CHECK-NEXT:    [[CMP1_FR:%.*]] = freeze i1 [[CMP1]]
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[Y]], 0
+; CHECK-NEXT:    [[CMP2:%.*]] = or i1 [[TMP1]], [[CMP1_FR]]
 ; CHECK-NEXT:    ret i1 [[CMP2]]
 ;
   %cmp1 = icmp uge i16 %x, %y

--- a/llvm/test/Transforms/InstCombine/nsw.ll
+++ b/llvm/test/Transforms/InstCombine/nsw.ll
@@ -255,10 +255,9 @@ define i32 @sub_sub1_nsw_nsw(i32 %a, i32 %b, i32 %c) {
 
 define i8 @neg_nsw_freeze(i8 %a1, i8 %a2) {
 ; CHECK-LABEL: @neg_nsw_freeze(
-; CHECK-NEXT:    [[A1_FR:%.*]] = freeze i8 [[A1:%.*]]
-; CHECK-NEXT:    [[A2_FR:%.*]] = freeze i8 [[A2:%.*]]
-; CHECK-NEXT:    [[A_NEG:%.*]] = sub i8 [[A2_FR]], [[A1_FR]]
-; CHECK-NEXT:    ret i8 [[A_NEG]]
+; CHECK-NEXT:    [[A_NEG:%.*]] = sub nsw i8 [[A2:%.*]], [[A1:%.*]]
+; CHECK-NEXT:    [[FR_NEG:%.*]] = freeze i8 [[A_NEG]]
+; CHECK-NEXT:    ret i8 [[FR_NEG]]
 ;
   %a = sub nsw i8 %a1, %a2
   %fr = freeze i8 %a

--- a/llvm/test/Transforms/InstCombine/select-gep.ll
+++ b/llvm/test/Transforms/InstCombine/select-gep.ll
@@ -304,10 +304,9 @@ define ptr @ptr_eq_replace_freeze1(ptr %p, ptr %q) {
 
 define ptr @ptr_eq_replace_freeze2(ptr %p, ptr %q) {
 ; CHECK-LABEL: @ptr_eq_replace_freeze2(
-; CHECK-NEXT:    [[P_FR:%.*]] = freeze ptr [[P:%.*]]
-; CHECK-NEXT:    [[P_FR1:%.*]] = freeze ptr [[P1:%.*]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq ptr [[P_FR1]], [[P_FR]]
-; CHECK-NEXT:    [[SELECT_V:%.*]] = select i1 [[CMP]], ptr [[P_FR1]], ptr [[P_FR]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq ptr [[P_FR1:%.*]], [[P_FR:%.*]]
+; CHECK-NEXT:    [[CMP_FR:%.*]] = freeze i1 [[CMP]]
+; CHECK-NEXT:    [[SELECT_V:%.*]] = select i1 [[CMP_FR]], ptr [[P_FR1]], ptr [[P_FR]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = getelementptr i8, ptr [[SELECT_V]], i64 16
 ; CHECK-NEXT:    ret ptr [[SELECT]]
 ;

--- a/llvm/test/Transforms/InstCombine/select.ll
+++ b/llvm/test/Transforms/InstCombine/select.ll
@@ -2847,8 +2847,10 @@ define void @cond_freeze_multipleuses(i8 %x, i8 %y) {
 define i32 @select_freeze_icmp_eq(i32 %x, i32 %y) {
 ; CHECK-LABEL: define i32 @select_freeze_icmp_eq(
 ; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
-; CHECK-NEXT:    [[Y_FR:%.*]] = freeze i32 [[Y]]
-; CHECK-NEXT:    ret i32 [[Y_FR]]
+; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[X]], [[Y]]
+; CHECK-NEXT:    [[C_FR:%.*]] = freeze i1 [[C]]
+; CHECK-NEXT:    [[V:%.*]] = select i1 [[C_FR]], i32 [[X]], i32 [[Y]]
+; CHECK-NEXT:    ret i32 [[V]]
 ;
   %c = icmp eq i32 %x, %y
   %c.fr = freeze i1 %c
@@ -2859,8 +2861,10 @@ define i32 @select_freeze_icmp_eq(i32 %x, i32 %y) {
 define i32 @select_freeze_icmp_ne(i32 %x, i32 %y) {
 ; CHECK-LABEL: define i32 @select_freeze_icmp_ne(
 ; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X]]
-; CHECK-NEXT:    ret i32 [[X_FR]]
+; CHECK-NEXT:    [[C:%.*]] = icmp ne i32 [[X]], [[Y]]
+; CHECK-NEXT:    [[C_FR:%.*]] = freeze i1 [[C]]
+; CHECK-NEXT:    [[V:%.*]] = select i1 [[C_FR]], i32 [[X]], i32 [[Y]]
+; CHECK-NEXT:    ret i32 [[V]]
 ;
   %c = icmp ne i32 %x, %y
   %c.fr = freeze i1 %c
@@ -2871,9 +2875,9 @@ define i32 @select_freeze_icmp_ne(i32 %x, i32 %y) {
 define i32 @select_freeze_icmp_else(i32 %x, i32 %y) {
 ; CHECK-LABEL: define i32 @select_freeze_icmp_else(
 ; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
-; CHECK-NEXT:    [[Y_FR:%.*]] = freeze i32 [[Y]]
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X]]
-; CHECK-NEXT:    [[V:%.*]] = call i32 @llvm.umin.i32(i32 [[X_FR]], i32 [[Y_FR]])
+; CHECK-NEXT:    [[C:%.*]] = icmp ult i32 [[X]], [[Y]]
+; CHECK-NEXT:    [[C_FR:%.*]] = freeze i1 [[C]]
+; CHECK-NEXT:    [[V:%.*]] = select i1 [[C_FR]], i32 [[X]], i32 [[Y]]
 ; CHECK-NEXT:    ret i32 [[V]]
 ;
   %c = icmp ult i32 %x, %y
@@ -2887,9 +2891,9 @@ declare void @use_i1_i32(i1, i32)
 define void @select_freeze_icmp_multuses(i32 %x, i32 %y) {
 ; CHECK-LABEL: define void @select_freeze_icmp_multuses(
 ; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
-; CHECK-NEXT:    [[Y_FR:%.*]] = freeze i32 [[Y]]
-; CHECK-NEXT:    [[V:%.*]] = freeze i32 [[X]]
-; CHECK-NEXT:    [[C_FR:%.*]] = icmp ne i32 [[V]], [[Y_FR]]
+; CHECK-NEXT:    [[C:%.*]] = icmp ne i32 [[X]], [[Y]]
+; CHECK-NEXT:    [[C_FR:%.*]] = freeze i1 [[C]]
+; CHECK-NEXT:    [[V:%.*]] = select i1 [[C_FR]], i32 [[X]], i32 [[Y]]
 ; CHECK-NEXT:    call void @use_i1_i32(i1 [[C_FR]], i32 [[V]])
 ; CHECK-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/InstCombine/sub-of-negatible-inseltpoison.ll
+++ b/llvm/test/Transforms/InstCombine/sub-of-negatible-inseltpoison.ll
@@ -1446,9 +1446,8 @@ define i8 @dont_negate_ordinary_select(i8 %x, i8 %y, i8 %z, i1 %c) {
 define i4 @negate_freeze(i4 %x, i4 %y, i4 %z) {
 ; CHECK-LABEL: define i4 @negate_freeze(
 ; CHECK-SAME: i4 [[X:%.*]], i4 [[Y:%.*]], i4 [[Z:%.*]]) {
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i4 [[X]]
-; CHECK-NEXT:    [[Y_FR:%.*]] = freeze i4 [[Y]]
-; CHECK-NEXT:    [[T1_NEG:%.*]] = sub i4 [[Y_FR]], [[X_FR]]
+; CHECK-NEXT:    [[T0_NEG:%.*]] = sub i4 [[Y]], [[X]]
+; CHECK-NEXT:    [[T1_NEG:%.*]] = freeze i4 [[T0_NEG]]
 ; CHECK-NEXT:    [[T2:%.*]] = add i4 [[T1_NEG]], [[Z]]
 ; CHECK-NEXT:    ret i4 [[T2]]
 ;
@@ -1460,9 +1459,8 @@ define i4 @negate_freeze(i4 %x, i4 %y, i4 %z) {
 define i4 @negate_freeze_extrause(i4 %x, i4 %y, i4 %z) {
 ; CHECK-LABEL: define i4 @negate_freeze_extrause(
 ; CHECK-SAME: i4 [[X:%.*]], i4 [[Y:%.*]], i4 [[Z:%.*]]) {
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i4 [[X]]
-; CHECK-NEXT:    [[Y_FR:%.*]] = freeze i4 [[Y]]
-; CHECK-NEXT:    [[T1:%.*]] = sub i4 [[X_FR]], [[Y_FR]]
+; CHECK-NEXT:    [[T0:%.*]] = sub i4 [[X]], [[Y]]
+; CHECK-NEXT:    [[T1:%.*]] = freeze i4 [[T0]]
 ; CHECK-NEXT:    call void @use4(i4 [[T1]])
 ; CHECK-NEXT:    [[T2:%.*]] = sub i4 [[Z]], [[T1]]
 ; CHECK-NEXT:    ret i4 [[T2]]

--- a/llvm/test/Transforms/InstCombine/sub-of-negatible.ll
+++ b/llvm/test/Transforms/InstCombine/sub-of-negatible.ll
@@ -1543,9 +1543,8 @@ define <2 x i32> @negate_select_of_negation_poison(<2 x i1> %c, <2 x i32> %x) {
 define i4 @negate_freeze(i4 %x, i4 %y, i4 %z) {
 ; CHECK-LABEL: define i4 @negate_freeze(
 ; CHECK-SAME: i4 [[X:%.*]], i4 [[Y:%.*]], i4 [[Z:%.*]]) {
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i4 [[X]]
-; CHECK-NEXT:    [[Y_FR:%.*]] = freeze i4 [[Y]]
-; CHECK-NEXT:    [[T1_NEG:%.*]] = sub i4 [[Y_FR]], [[X_FR]]
+; CHECK-NEXT:    [[T0_NEG:%.*]] = sub i4 [[Y]], [[X]]
+; CHECK-NEXT:    [[T1_NEG:%.*]] = freeze i4 [[T0_NEG]]
 ; CHECK-NEXT:    [[T2:%.*]] = add i4 [[T1_NEG]], [[Z]]
 ; CHECK-NEXT:    ret i4 [[T2]]
 ;
@@ -1557,9 +1556,8 @@ define i4 @negate_freeze(i4 %x, i4 %y, i4 %z) {
 define i4 @negate_freeze_extrause(i4 %x, i4 %y, i4 %z) {
 ; CHECK-LABEL: define i4 @negate_freeze_extrause(
 ; CHECK-SAME: i4 [[X:%.*]], i4 [[Y:%.*]], i4 [[Z:%.*]]) {
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i4 [[X]]
-; CHECK-NEXT:    [[Y_FR:%.*]] = freeze i4 [[Y]]
-; CHECK-NEXT:    [[T1:%.*]] = sub i4 [[X_FR]], [[Y_FR]]
+; CHECK-NEXT:    [[T0:%.*]] = sub i4 [[X]], [[Y]]
+; CHECK-NEXT:    [[T1:%.*]] = freeze i4 [[T0]]
 ; CHECK-NEXT:    call void @use4(i4 [[T1]])
 ; CHECK-NEXT:    [[T2:%.*]] = sub i4 [[Z]], [[T1]]
 ; CHECK-NEXT:    ret i4 [[T2]]

--- a/llvm/test/Transforms/InstCombine/urem-via-cmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/urem-via-cmp-select.ll
@@ -96,11 +96,10 @@ define i8 @urem_assume_with_unexpected_const(i8 %x, i8 %n) {
 define i8 @urem_without_assume(i8 %arg, i8 %arg2) {
 ; CHECK-LABEL: define i8 @urem_without_assume(
 ; CHECK-SAME: i8 [[ARG:%.*]], i8 [[ARG2:%.*]]) {
-; CHECK-NEXT:    [[ARG2_FR:%.*]] = freeze i8 [[ARG2]]
-; CHECK-NEXT:    [[ARG_FR:%.*]] = freeze i8 [[ARG]]
-; CHECK-NEXT:    [[X_FR:%.*]] = urem i8 [[ARG_FR]], [[ARG2_FR]]
+; CHECK-NEXT:    [[X:%.*]] = urem i8 [[ARG]], [[ARG2]]
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze i8 [[X]]
 ; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X_FR]], 1
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i8 [[ADD]], [[ARG2_FR]]
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i8 [[ADD]], [[ARG2]]
 ; CHECK-NEXT:    [[OUT:%.*]] = select i1 [[TMP1]], i8 0, i8 [[ADD]]
 ; CHECK-NEXT:    ret i8 [[OUT]]
 ;

--- a/llvm/test/Transforms/LoopVectorize/forked-pointers.ll
+++ b/llvm/test/Transforms/LoopVectorize/forked-pointers.ll
@@ -17,22 +17,21 @@ target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 define dso_local void @forked_ptrs_different_base_same_offset(ptr nocapture readonly %Base1, ptr nocapture readonly %Base2, ptr nocapture %Dest, ptr nocapture readonly %Preds) {
 ; CHECK-LABEL: @forked_ptrs_different_base_same_offset(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[BASE1:%.*]] = freeze ptr [[BASE3:%.*]]
-; CHECK-NEXT:    [[BASE2:%.*]] = freeze ptr [[BASE4:%.*]]
-; CHECK-NEXT:    [[DEST:%.*]] = freeze ptr [[DEST2:%.*]]
 ; CHECK-NEXT:    br label [[VECTOR_MEMCHECK:%.*]]
 ; CHECK:       vector.memcheck:
-; CHECK-NEXT:    [[DEST1:%.*]] = ptrtoaddr ptr [[DEST]] to i64
+; CHECK-NEXT:    [[DEST1:%.*]] = ptrtoaddr ptr [[DEST:%.*]] to i64
 ; CHECK-NEXT:    [[PREDS2:%.*]] = ptrtoaddr ptr [[PREDS:%.*]] to i64
-; CHECK-NEXT:    [[BASE23:%.*]] = ptrtoaddr ptr [[BASE2]] to i64
-; CHECK-NEXT:    [[BASE15:%.*]] = ptrtoaddr ptr [[BASE1]] to i64
+; CHECK-NEXT:    [[BASE23:%.*]] = ptrtoaddr ptr [[BASE2:%.*]] to i64
+; CHECK-NEXT:    [[BASE15:%.*]] = ptrtoaddr ptr [[BASE1:%.*]] to i64
 ; CHECK-NEXT:    [[TMP0:%.*]] = sub i64 [[DEST1]], [[PREDS2]]
 ; CHECK-NEXT:    [[DIFF_CHECK:%.*]] = icmp ult i64 [[TMP0]], 16
 ; CHECK-NEXT:    [[TMP1:%.*]] = sub i64 [[DEST1]], [[BASE23]]
-; CHECK-NEXT:    [[DIFF_CHECK4:%.*]] = icmp ult i64 [[TMP1]], 16
+; CHECK-NEXT:    [[DOTFR:%.*]] = freeze i64 [[TMP1]]
+; CHECK-NEXT:    [[DIFF_CHECK4:%.*]] = icmp ult i64 [[DOTFR]], 16
 ; CHECK-NEXT:    [[CONFLICT_RDX:%.*]] = or i1 [[DIFF_CHECK]], [[DIFF_CHECK4]]
 ; CHECK-NEXT:    [[TMP2:%.*]] = sub i64 [[DEST1]], [[BASE15]]
-; CHECK-NEXT:    [[DIFF_CHECK6:%.*]] = icmp ult i64 [[TMP2]], 16
+; CHECK-NEXT:    [[DOTFR10:%.*]] = freeze i64 [[TMP2]]
+; CHECK-NEXT:    [[DIFF_CHECK6:%.*]] = icmp ult i64 [[DOTFR10]], 16
 ; CHECK-NEXT:    [[CONFLICT_RDX7:%.*]] = or i1 [[CONFLICT_RDX]], [[DIFF_CHECK6]]
 ; CHECK-NEXT:    br i1 [[CONFLICT_RDX7]], label [[SCALAR_PH:%.*]], label [[VECTOR_PH:%.*]]
 ; CHECK:       vector.ph:

--- a/llvm/test/Transforms/PGOProfile/chr.ll
+++ b/llvm/test/Transforms/PGOProfile/chr.ll
@@ -1288,7 +1288,6 @@ define i32 @test_chr_14(ptr %i, ptr %j, i32 %sum0, i1 %pred, i32 %z) !prof !14 {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[Z_FR:%.*]] = freeze i32 [[Z:%.*]]
 ; CHECK-NEXT:    [[I0:%.*]] = load i32, ptr [[I:%.*]], align 4
-; CHECK-NEXT:    [[I0_FR:%.*]] = freeze i32 [[I0]]
 ; CHECK-NEXT:    [[V1_NOT:%.*]] = icmp eq i32 [[Z_FR]], 1
 ; CHECK-NEXT:    br i1 [[V1_NOT]], label [[BB1:%.*]], label [[ENTRY_SPLIT_NONCHR:%.*]], !prof [[PROF15]]
 ; CHECK:       entry.split.nonchr:
@@ -1301,26 +1300,27 @@ define i32 @test_chr_14(ptr %i, ptr %j, i32 %sum0, i1 %pred, i32 %z) !prof !14 {
 ; CHECK-NEXT:    br label [[BB1]]
 ; CHECK:       bb1:
 ; CHECK-NEXT:    [[J0:%.*]] = load i32, ptr [[J:%.*]], align 4
-; CHECK-NEXT:    [[J0_FR:%.*]] = freeze i32 [[J0]]
-; CHECK-NEXT:    [[V6:%.*]] = and i32 [[I0_FR]], 2
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp ne i32 [[V6]], [[J0_FR]]
+; CHECK-NEXT:    [[V6:%.*]] = and i32 [[I0]], 2
+; CHECK-NEXT:    [[V4:%.*]] = icmp ne i32 [[V6]], [[J0]]
 ; CHECK-NEXT:    [[V8:%.*]] = add i32 [[SUM0:%.*]], 43
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[I0_FR]], [[J0_FR]]
+; CHECK-NEXT:    [[V5:%.*]] = icmp ne i32 [[I0]], [[J0]]
+; CHECK-NEXT:    [[TMP0:%.*]] = freeze i1 [[V4]]
+; CHECK-NEXT:    [[TMP1:%.*]] = freeze i1 [[V5]]
 ; CHECK-NEXT:    [[TMP2:%.*]] = and i1 [[TMP0]], [[TMP1]]
 ; CHECK-NEXT:    br i1 [[TMP2]], label [[BB1_SPLIT:%.*]], label [[BB1_SPLIT_NONCHR:%.*]], !prof [[PROF15]]
 ; CHECK:       bb1.split:
 ; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    [[V9:%.*]] = and i32 [[I0_FR]], 4
+; CHECK-NEXT:    [[V9:%.*]] = and i32 [[I0]], 4
 ; CHECK-NEXT:    [[V10:%.*]] = icmp eq i32 [[V9]], 0
 ; CHECK-NEXT:    br i1 [[V10]], label [[BB3:%.*]], label [[BB2:%.*]]
 ; CHECK:       bb2:
 ; CHECK-NEXT:    call void @foo()
 ; CHECK-NEXT:    br label [[BB3]]
 ; CHECK:       bb1.split.nonchr:
-; CHECK-NEXT:    [[V5_NONCHR:%.*]] = icmp eq i32 [[I0_FR]], [[J0_FR]]
+; CHECK-NEXT:    [[V5_NONCHR:%.*]] = icmp eq i32 [[I0]], [[J0]]
 ; CHECK-NEXT:    [[SUM3_NONCHR:%.*]] = select i1 [[V5_NONCHR]], i32 [[SUM0]], i32 [[V8]], !prof [[PROF17]]
 ; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    [[V9_NONCHR:%.*]] = and i32 [[I0_FR]], 4
+; CHECK-NEXT:    [[V9_NONCHR:%.*]] = and i32 [[I0]], 4
 ; CHECK-NEXT:    [[V10_NONCHR:%.*]] = icmp eq i32 [[V9_NONCHR]], 0
 ; CHECK-NEXT:    br i1 [[V10_NONCHR]], label [[BB3]], label [[BB2_NONCHR:%.*]]
 ; CHECK:       bb2.nonchr:
@@ -1328,7 +1328,7 @@ define i32 @test_chr_14(ptr %i, ptr %j, i32 %sum0, i1 %pred, i32 %z) !prof !14 {
 ; CHECK-NEXT:    br label [[BB3]]
 ; CHECK:       bb3:
 ; CHECK-NEXT:    [[TMP3:%.*]] = phi i32 [ [[V8]], [[BB2]] ], [ [[V8]], [[BB1_SPLIT]] ], [ [[SUM3_NONCHR]], [[BB2_NONCHR]] ], [ [[SUM3_NONCHR]], [[BB1_SPLIT_NONCHR]] ]
-; CHECK-NEXT:    [[V11:%.*]] = add i32 [[I0_FR]], [[TMP3]]
+; CHECK-NEXT:    [[V11:%.*]] = add i32 [[I0]], [[TMP3]]
 ; CHECK-NEXT:    ret i32 [[V11]]
 ;
 entry:
@@ -1922,18 +1922,18 @@ bb4:
 define i32 @test_chr_21(i64 %i, i64 %k, i64 %j) "instcombine-no-verify-fixpoint" !prof !14 {
 ; CHECK-LABEL: @test_chr_21(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[I_FR:%.*]] = freeze i64 [[I:%.*]]
-; CHECK-NEXT:    [[J:%.*]] = freeze i64 [[J1:%.*]]
 ; CHECK-NEXT:    [[K:%.*]] = freeze i64 [[K1:%.*]]
-; CHECK-NEXT:    [[CMP0:%.*]] = icmp ne i64 [[J]], [[K]]
-; CHECK-NEXT:    [[CMP3:%.*]] = icmp ne i64 [[J]], [[I_FR]]
-; CHECK-NEXT:    [[CMP_I:%.*]] = icmp ne i64 [[I_FR]], 86
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i64 [[J:%.*]], [[K2:%.*]]
+; CHECK-NEXT:    [[CMP0:%.*]] = freeze i1 [[CMP1]]
+; CHECK-NEXT:    [[CMP4:%.*]] = icmp ne i64 [[J]], [[K]]
+; CHECK-NEXT:    [[CMP_I:%.*]] = icmp ne i64 [[K]], 86
+; CHECK-NEXT:    [[CMP3:%.*]] = freeze i1 [[CMP4]]
 ; CHECK-NEXT:    [[TMP2:%.*]] = and i1 [[CMP0]], [[CMP3]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i1 [[TMP2]], [[CMP_I]]
 ; CHECK-NEXT:    br i1 [[TMP3]], label [[BB1:%.*]], label [[ENTRY_SPLIT_NONCHR:%.*]], !prof [[PROF15]]
 ; CHECK:       bb1:
-; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i64 [[I_FR]], 2
-; CHECK-NEXT:    switch i64 [[I_FR]], label [[BB2:%.*]] [
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i64 [[K]], 2
+; CHECK-NEXT:    switch i64 [[K]], label [[BB2:%.*]] [
 ; CHECK-NEXT:      i64 2, label [[BB3_NONCHR2:%.*]]
 ; CHECK-NEXT:      i64 86, label [[BB2_NONCHR1:%.*]]
 ; CHECK-NEXT:    ], !prof [[PROF20:![0-9]+]]
@@ -1956,13 +1956,13 @@ define i32 @test_chr_21(i64 %i, i64 %k, i64 %j) "instcombine-no-verify-fixpoint"
 ; CHECK:       entry.split.nonchr:
 ; CHECK-NEXT:    br i1 [[CMP0]], label [[BB1_NONCHR:%.*]], label [[BB10]], !prof [[PROF16]]
 ; CHECK:       bb1.nonchr:
-; CHECK-NEXT:    [[CMP2_NONCHR:%.*]] = icmp eq i64 [[I_FR]], 2
+; CHECK-NEXT:    [[CMP2_NONCHR:%.*]] = icmp eq i64 [[K]], 2
 ; CHECK-NEXT:    br i1 [[CMP2_NONCHR]], label [[BB3_NONCHR:%.*]], label [[BB2_NONCHR:%.*]], !prof [[PROF17]]
 ; CHECK:       bb3.nonchr:
-; CHECK-NEXT:    [[CMP_I_NONCHR:%.*]] = icmp eq i64 [[I_FR]], 86
+; CHECK-NEXT:    [[CMP_I_NONCHR:%.*]] = icmp eq i64 [[K]], 86
 ; CHECK-NEXT:    br i1 [[CMP_I_NONCHR]], label [[BB6_NONCHR:%.*]], label [[BB4_NONCHR:%.*]], !prof [[PROF17]]
 ; CHECK:       bb6.nonchr:
-; CHECK-NEXT:    [[CMP3_NONCHR:%.*]] = icmp eq i64 [[J]], [[I_FR]]
+; CHECK-NEXT:    [[CMP3_NONCHR:%.*]] = icmp eq i64 [[J]], [[K]]
 ; CHECK-NEXT:    br i1 [[CMP3_NONCHR]], label [[BB8_NONCHR:%.*]], label [[BB7_NONCHR:%.*]], !prof [[PROF17]]
 ; CHECK:       bb8.nonchr:
 ; CHECK-NEXT:    br i1 [[CMP_I_NONCHR]], label [[BB10]], label [[BB9_NONCHR:%.*]], !prof [[PROF17]]

--- a/llvm/test/Transforms/PhaseOrdering/X86/vector-reductions-logical.ll
+++ b/llvm/test/Transforms/PhaseOrdering/X86/vector-reductions-logical.ll
@@ -86,11 +86,11 @@ return:
 define float @test_merge_anyof_v4sf(<4 x float> %t) {
 ; CHECK-LABEL: @test_merge_anyof_v4sf(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[T:%.*]] = freeze <4 x float> [[T1:%.*]]
-; CHECK-NEXT:    [[TMP0:%.*]] = fcmp olt <4 x float> [[T]], zeroinitializer
+; CHECK-NEXT:    [[TMP0:%.*]] = fcmp olt <4 x float> [[T:%.*]], zeroinitializer
 ; CHECK-NEXT:    [[TMP1:%.*]] = fcmp ogt <4 x float> [[T]], splat (float 1.000000e+00)
 ; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <4 x i1> [[TMP1]], <4 x i1> [[TMP0]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:    [[TMP5:%.*]] = bitcast <8 x i1> [[TMP3]] to i8
+; CHECK-NEXT:    [[TMP4:%.*]] = freeze <8 x i1> [[TMP3]]
+; CHECK-NEXT:    [[TMP5:%.*]] = bitcast <8 x i1> [[TMP4]] to i8
 ; CHECK-NEXT:    [[DOTNOT:%.*]] = icmp eq i8 [[TMP5]], 0
 ; CHECK-NEXT:    [[SHIFT:%.*]] = shufflevector <4 x float> [[T]], <4 x float> poison, <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>
 ; CHECK-NEXT:    [[TMP6:%.*]] = fadd <4 x float> [[T]], [[SHIFT]]
@@ -400,11 +400,11 @@ return:
 define float @test_merge_anyof_v4si(<4 x i32> %t) {
 ; CHECK-LABEL: @test_merge_anyof_v4si(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[T:%.*]] = freeze <4 x i32> [[T1:%.*]]
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp slt <4 x i32> [[T]], splat (i32 1)
+; CHECK-NEXT:    [[TMP0:%.*]] = icmp slt <4 x i32> [[T:%.*]], splat (i32 1)
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp sgt <4 x i32> [[T]], splat (i32 255)
 ; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <4 x i1> [[TMP1]], <4 x i1> [[TMP0]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:    [[TMP5:%.*]] = bitcast <8 x i1> [[TMP3]] to i8
+; CHECK-NEXT:    [[TMP4:%.*]] = freeze <8 x i1> [[TMP3]]
+; CHECK-NEXT:    [[TMP5:%.*]] = bitcast <8 x i1> [[TMP4]] to i8
 ; CHECK-NEXT:    [[DOTNOT:%.*]] = icmp eq i8 [[TMP5]], 0
 ; CHECK-NEXT:    [[SHIFT:%.*]] = shufflevector <4 x i32> [[T]], <4 x i32> poison, <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>
 ; CHECK-NEXT:    [[TMP6:%.*]] = add nsw <4 x i32> [[T]], [[SHIFT]]


### PR DESCRIPTION
This reverts commit f8f6965ceece9e330ddb66db5f402ecfb5e3ad34.

This is causing infinte loops interacting with other transforms.  See discussion on #182647 .