### PR TITLE
[SPIR-V] Don't emit alignment decoration for non-kernel SPIR-V

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
+++ b/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
@@ -1690,7 +1690,7 @@ multiclass MemoryOperandOperand<bits<32> value, bits<32> minVersion, bits<32> ma
 
 defm None : MemoryOperandOperand<0x0, 0, 0, [], []>;
 defm Volatile : MemoryOperandOperand<0x1, 0, 0, [], []>;
-defm Aligned : MemoryOperandOperand<0x2, 0, 0, [], []>;
+defm Aligned : MemoryOperandOperand<0x2, 0, 0, [], [Kernel]>;
 defm Nontemporal : MemoryOperandOperand<0x4, 0, 0, [], []>;
 defm MakePointerAvailableKHR : MemoryOperandOperand<0x8, 0, 0, [], [VulkanMemoryModelKHR]>;
 defm MakePointerVisibleKHR : MemoryOperandOperand<0x10, 0, 0, [], [VulkanMemoryModelKHR]>;

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/vk-ext-builtin-input.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/vk-ext-builtin-input.ll
@@ -1,7 +1,6 @@
 ; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-vulkan-unknown %s -o - | FileCheck %s
 
-; FIXME(138268): Alignment decoration is emitted.
-; FIXME: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-DAG:        OpDecorate %[[#WorkgroupId:]] BuiltIn WorkgroupId
 
@@ -16,7 +15,7 @@
 define i32 @foo() {
 entry:
 ; CHECK: %[[#ptr:]] = OpAccessChain %[[#ptr_Input_uint]] %[[#WorkgroupId]] %[[#uint_0]]
-; CHECK: %[[#res:]] = OpLoad %[[#uint]] %[[#ptr]] Aligned 16
+; CHECK: %[[#res:]] = OpLoad %[[#uint]] %[[#ptr]]
 ; CHECK:              OpReturnValue %[[#res]]
   %0 = load i32, ptr addrspace(7) @var, align 16
   ret i32 %0

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/NonUniformIdx/RWStructuredBufferNonUniformIdx.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/NonUniformIdx/RWStructuredBufferNonUniformIdx.ll
@@ -21,7 +21,7 @@ entry:
   %4 = load <4 x i32>, ptr addrspace(11) %3, align 16
   %vecins.i = insertelement <4 x i32> %4, i32 99, i64 0
 ; CHECK: %[[#access1]] = OpAccessChain {{.*}}
-; CHECK: OpStore %[[#access1]] {{%[0-9]+}} Aligned 16
+; CHECK: OpStore %[[#access1]] {{%[0-9]+}}
   store <4 x i32> %vecins.i, ptr addrspace(11) %3, align 16
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/StructuredBuffer.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/StructuredBuffer.ll
@@ -44,7 +44,7 @@ entry:
 ; CHECK: [[AC:%.+]] = OpAccessChain {{.*}} [[BufferHandle]] [[zero]] [[one]]
   %0 = tail call noundef nonnull align 4 dereferenceable(4) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i32_12_0t(target("spirv.VulkanBuffer", [0 x i32], 12, 0) %BufferHandle,  i32 1)
 
-; CHECK: [[LD:%.+]] = OpLoad [[int]] [[AC]] Aligned 4
+; CHECK: [[LD:%.+]] = OpLoad [[int]] [[AC]]
   %1 = load i32, ptr addrspace(11) %0, align 4, !tbaa !3
 
 ; CHECK: [[AC:%.+]] = OpAccessChain {{.*}} [[RWBufferHandle]] [[zero]] [[zero]]
@@ -56,7 +56,7 @@ entry:
 ; CHECK: [[AC:%.+]] = OpAccessChain {{.*}} [[BufferHandle2]] [[zero]] [[two]]
   %3 = tail call noundef nonnull align 4 dereferenceable(4) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0i32_12_0t(target("spirv.VulkanBuffer", [0 x i32], 12, 0) %BufferHandle2,  i32 2)
 
-; CHECK: [[LD:%.+]] = OpLoad [[int]] [[AC]] Aligned 4
+; CHECK: [[LD:%.+]] = OpLoad [[int]] [[AC]]
   %4 = load i32, ptr addrspace(11) %3, align 4, !tbaa !3
 
 ; CHECK: [[AC:%.+]] = OpAccessChain {{.*}} [[RWBufferHandle]] [[zero]] [[zero]]

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-array.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-array.ll
@@ -48,7 +48,7 @@ entry:
 
   %0 = tail call target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 1) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f32_12_1t(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str)
 
-; CHECK: %[[VAL_INT:[0-9]+]] = OpLoad %[[INT]] %[[PTR_INT_ACCESS]] Aligned 4
+; CHECK: %[[VAL_INT:[0-9]+]] = OpLoad %[[INT]] %[[PTR_INT_ACCESS]]
   %1 = load i32, ptr addrspace(12) @index, align 4
 
 ; CHECK: %[[VAL_INT64:[0-9]+]] = OpSConvert %[[INT64]] %[[VAL_INT]]
@@ -57,10 +57,10 @@ entry:
 ; CHECK: %[[PTR_ELEM:[0-9]+]] = OpInBoundsAccessChain %[[PTR_VEC4]] %[[PTR_ARRAY_ACCESS]] %[[VAL_INT64]]
   %arrayidx.i = getelementptr inbounds <4 x float>, ptr addrspace(12) @colors, i64 %idxprom.i
 
-; CHECK: %[[VAL_ELEM:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_ELEM]] Aligned 16
+; CHECK: %[[VAL_ELEM:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_ELEM]]
   %2 = load <4 x float>, ptr addrspace(12) %arrayidx.i, align 16
 
-; CHECK: OpStore {{%[0-9]+}} %[[VAL_ELEM]] Aligned 16
+; CHECK: OpStore {{%[0-9]+}} %[[VAL_ELEM]]
   %3 = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f32_12_1t(target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 1) %0, i32 0)
   store <4 x float> %2, ptr addrspace(11) %3, align 16
   ret void

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-peeled-array-minimal.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-peeled-array-minimal.ll
@@ -63,7 +63,7 @@ entry:
   %cbufferidx.i = getelementptr <{ %OrigType, target("spirv.Padding", 12) }>, ptr addrspace(12) @myArray, i64 %idxprom.i
 
 ; CHECK: %[[PTR_FIELD:[0-9]+]] = OpAccessChain {{%[0-9]+}} %[[PTR_ELEM]] %[[ZERO]] %[[ZERO]]
-; CHECK: %[[VAL_FLOAT:[0-9]+]] = OpLoad %[[FLOAT]] %[[PTR_FIELD]] Aligned 4
+; CHECK: %[[VAL_FLOAT:[0-9]+]] = OpLoad %[[FLOAT]] %[[PTR_FIELD]]
   %2 = load float, ptr addrspace(12) %cbufferidx.i, align 4
 
   %val = load i64, ptr addrspace(10) getelementptr (%__cblayout_MyCBuffer2, ptr addrspace(10) @myPrivateVar, i32 0, i32 1), align 8

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-peeled-array.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-peeled-array.ll
@@ -53,7 +53,7 @@ entry:
   %cbufferidx.i = getelementptr <{ <3 x float>, target("spirv.Padding", 4) }>, ptr addrspace(12) @myArray, i64 %idxprom.i
 
 ; CHECK: %[[PTR_FIELD:[0-9]+]] = OpAccessChain {{%[0-9]+}} %[[PTR_ELEM]] {{.*}}
-; CHECK: %[[VAL_VEC3:[0-9]+]] = OpLoad %[[VEC3]] %[[PTR_FIELD]] Aligned 16
+; CHECK: %[[VAL_VEC3:[0-9]+]] = OpLoad %[[VEC3]] %[[PTR_FIELD]]
   %2 = load <3 x float>, ptr addrspace(12) %cbufferidx.i, align 16
 
   %3 = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v3f32_12_1t(target("spirv.VulkanBuffer", [0 x <3 x float>], 12, 1) %0, i32 %1)

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-simple.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-simple.ll
@@ -45,11 +45,11 @@ entry:
   %3 = insertelement <4 x float> <float poison, float poison, float 0.000000e+00, float 1.000000e+00>, float %conv.i, i64 0
   %vecinit5.i = insertelement <4 x float> %3, float %conv2.i, i64 1
 
-; CHECK: %[[VAL_VEC4:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_VEC4_ACCESS]] Aligned 16
+; CHECK: %[[VAL_VEC4:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_VEC4_ACCESS]]
   %4 = load <4 x float>, ptr addrspace(12) @color, align 16
   %mul.i = fmul reassoc nnan ninf nsz arcp afn <4 x float> %vecinit5.i, %4
 
-; CHECK: %[[VAL_FLOAT:[0-9]+]] = OpLoad %[[FLOAT]] %[[PTR_FLOAT_ACCESS]] Aligned 4
+; CHECK: %[[VAL_FLOAT:[0-9]+]] = OpLoad %[[FLOAT]] %[[PTR_FLOAT_ACCESS]]
   %5 = load float, ptr addrspace(12) @factor, align 4
 
   %splat.splatinsert.i = insertelement <4 x float> poison, float %5, i64 0

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/cbuffer-struct.ll
@@ -70,15 +70,15 @@ entry:
   %3 = insertelement <4 x float> poison, float %conv.i, i64 0
 
 ; CHECK: %[[PTR_M0_V0:[0-9]+]] = OpAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[ZERO]] %[[ZERO]]
-; CHECK: %[[VAL_M0_V0:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M0_V0]] Aligned 16
+; CHECK: %[[VAL_M0_V0:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M0_V0]]
   %4 = load <4 x float>, ptr addrspace(12) @transforms, align 16
 
 ; CHECK: %[[PTR_M0_V1:[0-9]+]] = OpInBoundsAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[ZERO_64]] %[[ONE_64]]
-; CHECK: %[[VAL_M0_V1:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M0_V1]] Aligned 16
+; CHECK: %[[VAL_M0_V1:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M0_V1]]
   %5 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 16), align 16
 
 ; CHECK: %[[PTR_M0_V3:[0-9]+]] = OpInBoundsAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[ZERO_64]] %[[THREE_64]]
-; CHECK: %[[VAL_M0_V3:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M0_V3]] Aligned 16
+; CHECK: %[[VAL_M0_V3:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M0_V3]]
   %6 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 48), align 16
 
   %splat.splat.i18.i = shufflevector <4 x float> %3, <4 x float> poison, <4 x i32> zeroinitializer
@@ -89,16 +89,16 @@ entry:
   %9 = fadd reassoc nnan ninf nsz arcp afn <4 x float> %8, %6
 ; CHECK: %[[PTR_M1:[0-9]+]] = OpInBoundsAccessChain %[[PTR_MATRIX]] %[[PTR_STRUCT]] %[[ONE_64]]
 ; CHECK: %[[PTR_M1_V0:[0-9]+]] = OpAccessChain %[[PTR_VEC4]] %[[PTR_M1]] %[[ZERO]]
-; CHECK: %[[VAL_M1_V0:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M1_V0]] Aligned 16
+; CHECK: %[[VAL_M1_V0:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M1_V0]]
   %10 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 64), align 16
 ; CHECK: %[[PTR_M1_V1:[0-9]+]] = OpInBoundsAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[ONE_64]] %[[ONE_64]]
-; CHECK: %[[VAL_M1_V1:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M1_V1]] Aligned 16
+; CHECK: %[[VAL_M1_V1:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M1_V1]]
   %11 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 80), align 16
 ; CHECK: %[[PTR_M1_V2:[0-9]+]] = OpInBoundsAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[ONE_64]] %[[TWO_64]]
-; CHECK: %[[VAL_M1_V2:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M1_V2]] Aligned 16
+; CHECK: %[[VAL_M1_V2:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M1_V2]]
   %12 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 96), align 16
 ; CHECK: %[[PTR_M1_V3:[0-9]+]] = OpInBoundsAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[ONE_64]] %[[THREE_64]]
-; CHECK: %[[VAL_M1_V3:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M1_V3]] Aligned 16
+; CHECK: %[[VAL_M1_V3:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M1_V3]]
   %13 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 112), align 16
   %splat.splat.i13.i = shufflevector <4 x float> %9, <4 x float> poison, <4 x i32> zeroinitializer
   %splat.splat2.i14.i = shufflevector <4 x float> %9, <4 x float> poison, <4 x i32> <i32 1, i32 1, i32 1, i32 1>
@@ -110,16 +110,16 @@ entry:
   %16 = tail call reassoc nnan ninf nsz arcp afn noundef <4 x float> @llvm.fmuladd.v4f32(<4 x float> %splat.splat7.i17.i, <4 x float> nofpclass(nan inf) %13, <4 x float> %15)
 ; CHECK: %[[PTR_M2:[0-9]+]] = OpInBoundsAccessChain %[[PTR_MATRIX]] %[[PTR_STRUCT]] %[[TWO_64]]
 ; CHECK: %[[PTR_M2_V0:[0-9]+]] = OpAccessChain %[[PTR_VEC4]] %[[PTR_M2]] %[[ZERO]]
-; CHECK: %[[VAL_M2_V0:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M2_V0]] Aligned 16
+; CHECK: %[[VAL_M2_V0:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M2_V0]]
   %17 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 128), align 16
 ; CHECK: %[[PTR_M2_V1:[0-9]+]] = OpInBoundsAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[TWO_64]] %[[ONE_64]]
-; CHECK: %[[VAL_M2_V1:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M2_V1]] Aligned 16
+; CHECK: %[[VAL_M2_V1:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M2_V1]]
   %18 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 144), align 16
 ; CHECK: %[[PTR_M2_V2:[0-9]+]] = OpInBoundsAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[TWO_64]] %[[TWO_64]]
-; CHECK: %[[VAL_M2_V2:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M2_V2]] Aligned 16
+; CHECK: %[[VAL_M2_V2:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M2_V2]]
   %19 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 160), align 16
 ; CHECK: %[[PTR_M2_V3:[0-9]+]] = OpInBoundsAccessChain %[[PTR_VEC4]] %[[PTR_STRUCT]] %[[TWO_64]] %[[THREE_64]]
-; CHECK: %[[VAL_M2_V3:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M2_V3]] Aligned 16
+; CHECK: %[[VAL_M2_V3:[0-9]+]] = OpLoad %[[VEC4]] %[[PTR_M2_V3]]
   %20 = load <4 x float>, ptr addrspace(12) getelementptr inbounds nuw (i8, ptr addrspace(12) @transforms, i64 176), align 16
   %splat.splat.i.i = shufflevector <4 x float> %16, <4 x float> poison, <4 x i32> zeroinitializer
   %splat.splat2.i.i = shufflevector <4 x float> %16, <4 x float> poison, <4 x i32> <i32 1, i32 1, i32 1, i32 1>
@@ -130,7 +130,7 @@ entry:
   %splat.splat7.i.i = shufflevector <4 x float> %16, <4 x float> poison, <4 x i32> <i32 3, i32 3, i32 3, i32 3>
   %23 = tail call reassoc nnan ninf nsz arcp afn noundef <4 x float> @llvm.fmuladd.v4f32(<4 x float> %splat.splat7.i.i, <4 x float> nofpclass(nan inf) %20, <4 x float> %22)
   %24 = load float, ptr addrspace(12) @blend, align 4
-; CHECK: %[[VAL_FLOAT:[0-9]+]] = OpLoad %[[FLOAT]] %[[PTR_FLOAT_VAL]] Aligned 4
+; CHECK: %[[VAL_FLOAT:[0-9]+]] = OpLoad %[[FLOAT]] %[[PTR_FLOAT_VAL]]
 ; CHECK: %[[SPLAT_INS:[0-9]+]] = OpCompositeInsert %[[VEC4]] %[[VAL_FLOAT]] {{.*}} 0
 ; CHECK: %[[SPLAT:[0-9]+]] = OpVectorShuffle %[[VEC4]] %[[SPLAT_INS]] {{.*}} 0 0 0 0
 ; CHECK: %[[RES:[0-9]+]] = OpFMul %[[VEC4]] {{%[0-9]+}} %[[SPLAT]]
@@ -139,7 +139,7 @@ entry:
   %mul.i = fmul reassoc nnan ninf nsz arcp afn <4 x float> %23, %splat.splat.i
   %25 = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f32_12_1t(target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 1) %0, i32 0)
   store <4 x float> %mul.i, ptr addrspace(11) %25, align 16
-; CHECK: OpStore {{%[0-9]+}} %[[RES]] Aligned 16
+; CHECK: OpStore {{%[0-9]+}} %[[RES]]
   ret void
 }
 

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/issue-146942-ptr-cast.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/issue-146942-ptr-cast.ll
@@ -14,7 +14,7 @@
 ; CHECK-DAG: %[[#UNDEF_INT4:]] = OpUndef %[[#INT4]]
 
 define void @case1() local_unnamed_addr {
-  ; CHECK: %[[#BUFFER_LOAD:]] = OpLoad %[[#FLOAT4]] %{{[0-9]+}} Aligned 16
+  ; CHECK: %[[#BUFFER_LOAD:]] = OpLoad %[[#FLOAT4]] %{{[0-9]+}}
   ; CHECK: %[[#CAST_LOAD:]] = OpBitcast %[[#INT4]] %[[#BUFFER_LOAD]]
   %1 = tail call target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f32_12_0t(i32 0, i32 2, i32 1, i32 0, ptr nonnull @.str)
   %2 = tail call target("spirv.VulkanBuffer", [0 x <4 x i32>], 12, 1) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4i32_12_1t(i32 0, i32 5, i32 1, i32 0, ptr nonnull @.str.2)
@@ -26,7 +26,7 @@ define void @case1() local_unnamed_addr {
 }
 
 define void @case2() local_unnamed_addr {
-  ; CHECK: %[[#BUFFER_LOAD:]] = OpLoad %[[#FLOAT4]] %{{[0-9]+}} Aligned 16
+  ; CHECK: %[[#BUFFER_LOAD:]] = OpLoad %[[#FLOAT4]] %{{[0-9]+}}
   ; CHECK: %[[#CAST_LOAD:]] = OpBitcast %[[#INT4]] %[[#BUFFER_LOAD]]
   ; CHECK: %[[#VEC_TRUNCATE:]] = OpVectorShuffle %[[#INT3]] %[[#CAST_LOAD]] %[[#UNDEF_INT4]] 0 1 2
   %1 = tail call target("spirv.VulkanBuffer", [0 x <4 x float>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f32_12_0t(i32 0, i32 2, i32 1, i32 0, ptr nonnull @.str)

--- a/llvm/test/CodeGen/SPIRV/legalization/load-store-global.ll
+++ b/llvm/test/CodeGen/SPIRV/legalization/load-store-global.ll
@@ -36,71 +36,71 @@
 define spir_func void @test_load_store_global() {
 entry:
 ; CHECK-DAG: %[[#PTR0:]] = OpAccessChain %[[#ptr_int:]] %[[#G16:]] %[[#C0]]
-; CHECK-DAG: %[[#VAL0:]] = OpLoad %[[#int]] %[[#PTR0]] Aligned 4
+; CHECK-DAG: %[[#VAL0:]] = OpLoad %[[#int]] %[[#PTR0]]
 ; CHECK-DAG: %[[#PTR1:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C1]]
-; CHECK-DAG: %[[#VAL1:]] = OpLoad %[[#int]] %[[#PTR1]] Aligned 4
+; CHECK-DAG: %[[#VAL1:]] = OpLoad %[[#int]] %[[#PTR1]]
 ; CHECK-DAG: %[[#PTR2:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C2]]
-; CHECK-DAG: %[[#VAL2:]] = OpLoad %[[#int]] %[[#PTR2]] Aligned 4
+; CHECK-DAG: %[[#VAL2:]] = OpLoad %[[#int]] %[[#PTR2]]
 ; CHECK-DAG: %[[#PTR3:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C3]]
-; CHECK-DAG: %[[#VAL3:]] = OpLoad %[[#int]] %[[#PTR3]] Aligned 4
+; CHECK-DAG: %[[#VAL3:]] = OpLoad %[[#int]] %[[#PTR3]]
 ; CHECK-DAG: %[[#PTR4:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C4]]
-; CHECK-DAG: %[[#VAL4:]] = OpLoad %[[#int]] %[[#PTR4]] Aligned 4
+; CHECK-DAG: %[[#VAL4:]] = OpLoad %[[#int]] %[[#PTR4]]
 ; CHECK-DAG: %[[#PTR5:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C5]]
-; CHECK-DAG: %[[#VAL5:]] = OpLoad %[[#int]] %[[#PTR5]] Aligned 4
+; CHECK-DAG: %[[#VAL5:]] = OpLoad %[[#int]] %[[#PTR5]]
 ; CHECK-DAG: %[[#PTR6:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C6]]
-; CHECK-DAG: %[[#VAL6:]] = OpLoad %[[#int]] %[[#PTR6]] Aligned 4
+; CHECK-DAG: %[[#VAL6:]] = OpLoad %[[#int]] %[[#PTR6]]
 ; CHECK-DAG: %[[#PTR7:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C7]]
-; CHECK-DAG: %[[#VAL7:]] = OpLoad %[[#int]] %[[#PTR7]] Aligned 4
+; CHECK-DAG: %[[#VAL7:]] = OpLoad %[[#int]] %[[#PTR7]]
 ; CHECK-DAG: %[[#PTR8:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C8]]
-; CHECK-DAG: %[[#VAL8:]] = OpLoad %[[#int]] %[[#PTR8]] Aligned 4
+; CHECK-DAG: %[[#VAL8:]] = OpLoad %[[#int]] %[[#PTR8]]
 ; CHECK-DAG: %[[#PTR9:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C9]]
-; CHECK-DAG: %[[#VAL9:]] = OpLoad %[[#int]] %[[#PTR9]] Aligned 4
+; CHECK-DAG: %[[#VAL9:]] = OpLoad %[[#int]] %[[#PTR9]]
 ; CHECK-DAG: %[[#PTR10:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C10]]
-; CHECK-DAG: %[[#VAL10:]] = OpLoad %[[#int]] %[[#PTR10]] Aligned 4
+; CHECK-DAG: %[[#VAL10:]] = OpLoad %[[#int]] %[[#PTR10]]
 ; CHECK-DAG: %[[#PTR11:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C11]]
-; CHECK-DAG: %[[#VAL11:]] = OpLoad %[[#int]] %[[#PTR11]] Aligned 4
+; CHECK-DAG: %[[#VAL11:]] = OpLoad %[[#int]] %[[#PTR11]]
 ; CHECK-DAG: %[[#PTR12:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C12]]
-; CHECK-DAG: %[[#VAL12:]] = OpLoad %[[#int]] %[[#PTR12]] Aligned 4
+; CHECK-DAG: %[[#VAL12:]] = OpLoad %[[#int]] %[[#PTR12]]
 ; CHECK-DAG: %[[#PTR13:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C13]]
-; CHECK-DAG: %[[#VAL13:]] = OpLoad %[[#int]] %[[#PTR13]] Aligned 4
+; CHECK-DAG: %[[#VAL13:]] = OpLoad %[[#int]] %[[#PTR13]]
 ; CHECK-DAG: %[[#PTR14:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C14]]
-; CHECK-DAG: %[[#VAL14:]] = OpLoad %[[#int]] %[[#PTR14]] Aligned 4
+; CHECK-DAG: %[[#VAL14:]] = OpLoad %[[#int]] %[[#PTR14]]
 ; CHECK-DAG: %[[#PTR15:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C15]]
-; CHECK-DAG: %[[#VAL15:]] = OpLoad %[[#int]] %[[#PTR15]] Aligned 4
+; CHECK-DAG: %[[#VAL15:]] = OpLoad %[[#int]] %[[#PTR15]]
   %0 = load <16 x i32>, ptr addrspace(10) @G_16, align 64
  
 ; CHECK: %[[#PTR0_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C0]]
-; CHECK: OpStore %[[#PTR0_S]] %[[#VAL0]] Aligned 64
+; CHECK: OpStore %[[#PTR0_S]] %[[#VAL0]]
 ; CHECK: %[[#PTR1_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C1]]
-; CHECK: OpStore %[[#PTR1_S]] %[[#VAL1]] Aligned 4
+; CHECK: OpStore %[[#PTR1_S]] %[[#VAL1]]
 ; CHECK: %[[#PTR2_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C2]]
-; CHECK: OpStore %[[#PTR2_S]] %[[#VAL2]] Aligned 8
+; CHECK: OpStore %[[#PTR2_S]] %[[#VAL2]]
 ; CHECK: %[[#PTR3_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C3]]
-; CHECK: OpStore %[[#PTR3_S]] %[[#VAL3]] Aligned 4
+; CHECK: OpStore %[[#PTR3_S]] %[[#VAL3]]
 ; CHECK: %[[#PTR4_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C4]]
-; CHECK: OpStore %[[#PTR4_S]] %[[#VAL4]] Aligned 16
+; CHECK: OpStore %[[#PTR4_S]] %[[#VAL4]]
 ; CHECK: %[[#PTR5_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C5]]
-; CHECK: OpStore %[[#PTR5_S]] %[[#VAL5]] Aligned 4
+; CHECK: OpStore %[[#PTR5_S]] %[[#VAL5]]
 ; CHECK: %[[#PTR6_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C6]]
-; CHECK: OpStore %[[#PTR6_S]] %[[#VAL6]] Aligned 8
+; CHECK: OpStore %[[#PTR6_S]] %[[#VAL6]]
 ; CHECK: %[[#PTR7_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C7]]
-; CHECK: OpStore %[[#PTR7_S]] %[[#VAL7]] Aligned 4
+; CHECK: OpStore %[[#PTR7_S]] %[[#VAL7]]
 ; CHECK: %[[#PTR8_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C8]]
-; CHECK: OpStore %[[#PTR8_S]] %[[#VAL8]] Aligned 32
+; CHECK: OpStore %[[#PTR8_S]] %[[#VAL8]]
 ; CHECK: %[[#PTR9_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C9]]
-; CHECK: OpStore %[[#PTR9_S]] %[[#VAL9]] Aligned 4
+; CHECK: OpStore %[[#PTR9_S]] %[[#VAL9]]
 ; CHECK: %[[#PTR10_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C10]]
-; CHECK: OpStore %[[#PTR10_S]] %[[#VAL10]] Aligned 8
+; CHECK: OpStore %[[#PTR10_S]] %[[#VAL10]]
 ; CHECK: %[[#PTR11_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C11]]
-; CHECK: OpStore %[[#PTR11_S]] %[[#VAL11]] Aligned 4
+; CHECK: OpStore %[[#PTR11_S]] %[[#VAL11]]
 ; CHECK: %[[#PTR12_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C12]]
-; CHECK: OpStore %[[#PTR12_S]] %[[#VAL12]] Aligned 16
+; CHECK: OpStore %[[#PTR12_S]] %[[#VAL12]]
 ; CHECK: %[[#PTR13_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C13]]
-; CHECK: OpStore %[[#PTR13_S]] %[[#VAL13]] Aligned 4
+; CHECK: OpStore %[[#PTR13_S]] %[[#VAL13]]
 ; CHECK: %[[#PTR14_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C14]]
-; CHECK: OpStore %[[#PTR14_S]] %[[#VAL14]] Aligned 8
+; CHECK: OpStore %[[#PTR14_S]] %[[#VAL14]]
 ; CHECK: %[[#PTR15_S:]] = OpAccessChain %[[#ptr_int]] %[[#G16]] %[[#C15]]
-; CHECK: OpStore %[[#PTR15_S]] %[[#VAL15]] Aligned 4
+; CHECK: OpStore %[[#PTR15_S]] %[[#VAL15]]
   store <16 x i32> %0, ptr addrspace(10) @G_16, align 64
   ret void
 }
@@ -148,7 +148,7 @@ entry:
   ; CHECK: %[[#BITCAST5:]] = OpBitcast %[[#double]] %[[#CONSTRUCT5]]
   ; CHECK: %[[#BITCAST6:]] = OpBitcast %[[#double]] %[[#CONSTRUCT6]]
   ; CHECK: %[[#CONSTRUCT7:]] = OpCompositeConstruct %[[#v4f64]] %[[#BITCAST3]] %[[#BITCAST4]] %[[#BITCAST5]] %[[#BITCAST6]]
-  ; CHECK: OpStore %[[#global_double]] %[[#CONSTRUCT7]] Aligned 32
+  ; CHECK: OpStore %[[#global_double]] %[[#CONSTRUCT7]]
   store <8 x i32> %3, ptr addrspace(10) @G_4_double
   ret void
 }
@@ -157,7 +157,7 @@ entry:
 define spir_func void @test_double_to_int_implicit_conversion() {
 entry:
 
-; CHECK: %[[#LOAD_V4F64:]] = OpLoad %[[#V4F64_TYPE:]] %[[#GLOBAL_DOUBLE_VAR:]] Aligned 32
+; CHECK: %[[#LOAD_V4F64:]] = OpLoad %[[#V4F64_TYPE:]] %[[#GLOBAL_DOUBLE_VAR:]]
 ; CHECK: %[[#VEC_SHUF_01:]] = OpVectorShuffle %[[#V2F64_TYPE:]] %[[#LOAD_V4F64]] %[[#UNDEF_V2F64:]] 0 1
 ; CHECK: %[[#VEC_SHUF_23:]] = OpVectorShuffle %[[#V2F64_TYPE:]] %[[#LOAD_V4F64]] %[[#UNDEF_V2F64]] 2 3
 ; CHECK: %[[#BITCAST_V4I32_01:]] = OpBitcast %[[#V4I32_TYPE:]] %[[#VEC_SHUF_01]]
@@ -173,7 +173,7 @@ entry:
 ; CHECK: %[[#BITCAST_DOUBLE_1_0:]] = OpBitcast %[[#DOUBLE_TYPE]] %[[#VEC_SHUF_1_0]]
 ; CHECK: %[[#BITCAST_DOUBLE_1_1:]] = OpBitcast %[[#DOUBLE_TYPE]] %[[#VEC_SHUF_1_1]]
 ; CHECK: %[[#COMPOSITE_CONSTRUCT:]] = OpCompositeConstruct %[[#V4F64_TYPE]] %[[#BITCAST_DOUBLE_0_0]] %[[#BITCAST_DOUBLE_0_1]] %[[#BITCAST_DOUBLE_1_0]] %[[#BITCAST_DOUBLE_1_1]]
-; CHECK: OpStore %[[#GLOBAL_DOUBLE_VAR]] %[[#COMPOSITE_CONSTRUCT]] Aligned 64
+; CHECK: OpStore %[[#GLOBAL_DOUBLE_VAR]] %[[#COMPOSITE_CONSTRUCT]]
   store <8 x i32> %0, ptr addrspace(10) @G_4_double, align 64
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/legalization/vector-index-scalarization.ll
+++ b/llvm/test/CodeGen/SPIRV/legalization/vector-index-scalarization.ll
@@ -50,50 +50,50 @@ define void @test_full() #0 {
 
   ; Insertelement with dynamic index spills to stack
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c0]]
-; CHECK:  OpStore %[[#ac]] %[[#undef]] Aligned 32
+; CHECK:  OpStore %[[#ac]] %[[#undef]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c1]]
-; CHECK:  OpStore %[[#ac]] %[[#undef]] Aligned 4
+; CHECK:  OpStore %[[#ac]] %[[#undef]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c2]]
-; CHECK:  OpStore %[[#ac]] %[[#undef]] Aligned 8
+; CHECK:  OpStore %[[#ac]] %[[#undef]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c3]]
-; CHECK:  OpStore %[[#ac]] %[[#undef]] Aligned 4
+; CHECK:  OpStore %[[#ac]] %[[#undef]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c4]]
-; CHECK:  OpStore %[[#ac]] %[[#undef]] Aligned 16
+; CHECK:  OpStore %[[#ac]] %[[#undef]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c5]]
-; CHECK:  OpStore %[[#ac]] %[[#undef]] Aligned 4
+; CHECK:  OpStore %[[#ac]] %[[#undef]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#idx64]]
-; CHECK:  OpStore %[[#ac]] %[[#val_val]] Aligned 4
+; CHECK:  OpStore %[[#ac]] %[[#val_val]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c0]]
-; CHECK:  %[[#v0:]] = OpLoad %[[#int]] %[[#ac]] Aligned 32
+; CHECK:  %[[#v0:]] = OpLoad %[[#int]] %[[#ac]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c1]]
-; CHECK:  %[[#v1:]] = OpLoad %[[#int]] %[[#ac]] Aligned 4
+; CHECK:  %[[#v1:]] = OpLoad %[[#int]] %[[#ac]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c2]]
-; CHECK:  %[[#v2:]] = OpLoad %[[#int]] %[[#ac]] Aligned 8
+; CHECK:  %[[#v2:]] = OpLoad %[[#int]] %[[#ac]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c3]]
-; CHECK:  %[[#v3:]] = OpLoad %[[#int]] %[[#ac]] Aligned 4
+; CHECK:  %[[#v3:]] = OpLoad %[[#int]] %[[#ac]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c4]]
-; CHECK:  %[[#v4:]] = OpLoad %[[#int]] %[[#ac]] Aligned 16
+; CHECK:  %[[#v4:]] = OpLoad %[[#int]] %[[#ac]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ins]] %[[#c5]]
-; CHECK:  %[[#v5:]] = OpLoad %[[#int]] %[[#ac]] Aligned 4
+; CHECK:  %[[#v5:]] = OpLoad %[[#int]] %[[#ac]]
   %inserted = insertelement <6 x i32> %loaded, i32 %val, i64 %idx64
 
   ; Extractelement with dynamic index spills to stack
 
 
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ext]] %[[#c0]]
-; CHECK:  OpStore %[[#ac]] %[[#v0]] Aligned 32
+; CHECK:  OpStore %[[#ac]] %[[#v0]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ext]] %[[#c1]]
-; CHECK:  OpStore %[[#ac]] %[[#v1]] Aligned 4
+; CHECK:  OpStore %[[#ac]] %[[#v1]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ext]] %[[#c2]]
-; CHECK:  OpStore %[[#ac]] %[[#v2]] Aligned 8
+; CHECK:  OpStore %[[#ac]] %[[#v2]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ext]] %[[#c3]]
-; CHECK:  OpStore %[[#ac]] %[[#v3]] Aligned 4
+; CHECK:  OpStore %[[#ac]] %[[#v3]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ext]] %[[#c4]]
-; CHECK:  OpStore %[[#ac]] %[[#v4]] Aligned 16
+; CHECK:  OpStore %[[#ac]] %[[#v4]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ext]] %[[#c5]]
-; CHECK:  OpStore %[[#ac]] %[[#v5]] Aligned 4
+; CHECK:  OpStore %[[#ac]] %[[#v5]]
 ; CHECK:  %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_ext]] %[[#idx2_64]]
-; CHECK:  %[[#extracted:]] = OpLoad %[[#int]] %[[#ac]] Aligned 4
+; CHECK:  %[[#extracted:]] = OpLoad %[[#int]] %[[#ac]]
   %extracted = extractelement <6 x i32> %inserted, i64 %idx2_64
 
   ; CHECK: OpStore %[[#out]] %[[#extracted]]
@@ -109,21 +109,21 @@ define void @test_undef() #0 {
   ; CHECK-DAG:  %[[#val_val:]] = OpLoad %[[#int]] %[[#val]]
   ; CHECK:      %[[#idx64:]] = OpUConvert %[[#long]] %[[#idx_val]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_undef]] %[[#c0]]
-  ; CHECK:      OpStore %[[#ac]] %[[#undef]] Aligned 32
+  ; CHECK:      OpStore %[[#ac]] %[[#undef]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_undef]] %[[#c1]]
-  ; CHECK:      OpStore %[[#ac]] %[[#undef]] Aligned 4
+  ; CHECK:      OpStore %[[#ac]] %[[#undef]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_undef]] %[[#c2]]
-  ; CHECK:      OpStore %[[#ac]] %[[#undef]] Aligned 8
+  ; CHECK:      OpStore %[[#ac]] %[[#undef]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_undef]] %[[#c3]]
-  ; CHECK:      OpStore %[[#ac]] %[[#undef]] Aligned 4
+  ; CHECK:      OpStore %[[#ac]] %[[#undef]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_undef]] %[[#c4]]
-  ; CHECK:      OpStore %[[#ac]] %[[#undef]] Aligned 16
+  ; CHECK:      OpStore %[[#ac]] %[[#undef]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_undef]] %[[#c5]]
-  ; CHECK:      OpStore %[[#ac]] %[[#undef]] Aligned 4
+  ; CHECK:      OpStore %[[#ac]] %[[#undef]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_undef]] %[[#idx64]]
-  ; CHECK:      OpStore %[[#ac]] %[[#val_val]] Aligned 4
+  ; CHECK:      OpStore %[[#ac]] %[[#val_val]]
   ; CHECK:      %[[#ptr0:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_undef]] %[[#c0]]
-  ; CHECK:      %[[#res:]] = OpLoad %[[#int]] %[[#ptr0]] Aligned 32
+  ; CHECK:      %[[#res:]] = OpLoad %[[#int]] %[[#ptr0]]
   ; CHECK:      OpStore %[[#out]] %[[#res]]
   %idx = load i32, ptr addrspace(10) @idx
   %val = load i32, ptr addrspace(10) @val
@@ -142,21 +142,21 @@ define void @test_zero() #0 {
   ; CHECK-DAG:  %[[#val_val:]] = OpLoad %[[#int]] %[[#val]]
   ; CHECK:      %[[#idx64:]] = OpUConvert %[[#long]] %[[#idx_val]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_zero]] %[[#c0]]
-  ; CHECK:      OpStore %[[#ac]] %[[#c0]] Aligned 32
+  ; CHECK:      OpStore %[[#ac]] %[[#c0]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_zero]] %[[#c1]]
-  ; CHECK:      OpStore %[[#ac]] %[[#c0]] Aligned 4
+  ; CHECK:      OpStore %[[#ac]] %[[#c0]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_zero]] %[[#c2]]
-  ; CHECK:      OpStore %[[#ac]] %[[#c0]] Aligned 8
+  ; CHECK:      OpStore %[[#ac]] %[[#c0]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_zero]] %[[#c3]]
-  ; CHECK:      OpStore %[[#ac]] %[[#c0]] Aligned 4
+  ; CHECK:      OpStore %[[#ac]] %[[#c0]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_zero]] %[[#c4]]
-  ; CHECK:      OpStore %[[#ac]] %[[#c0]] Aligned 16
+  ; CHECK:      OpStore %[[#ac]] %[[#c0]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_zero]] %[[#c5]]
-  ; CHECK:      OpStore %[[#ac]] %[[#c0]] Aligned 4
+  ; CHECK:      OpStore %[[#ac]] %[[#c0]]
   ; CHECK:      %[[#ac:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_zero]] %[[#idx64]]
-  ; CHECK:      OpStore %[[#ac]] %[[#val_val]] Aligned 4
+  ; CHECK:      OpStore %[[#ac]] %[[#val_val]]
   ; CHECK:      %[[#ptr0:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#v_zero]] %[[#c0]]
-  ; CHECK:      %[[#res:]] = OpLoad %[[#int]] %[[#ptr0]] Aligned 32
+  ; CHECK:      %[[#res:]] = OpLoad %[[#int]] %[[#ptr0]]
   ; CHECK:      OpStore %[[#out]] %[[#res]]
   %idx = load i32, ptr addrspace(10) @idx
   %val = load i32, ptr addrspace(10) @val

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lifetime.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lifetime.ll
@@ -5,7 +5,8 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - | FileCheck %s --check-prefixes=VK
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val %}
+; FIXME(182779) ByVal attribute emitted for Vulkan.
+; FIXME: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val %}
 
 ; CL-DAG: %[[#Char:]] = OpTypeInt 8 0
 ; CL-DAG: %[[#PtrChar:]] = OpTypePointer Function %[[#Char]]

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lifetime.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lifetime.ll
@@ -5,8 +5,7 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - | FileCheck %s --check-prefixes=VK
-; FIXME(135165) Alignment capability emitted for Vulkan.
-; FIXME: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val %}
 
 ; CL-DAG: %[[#Char:]] = OpTypeInt 8 0
 ; CL-DAG: %[[#PtrChar:]] = OpTypePointer Function %[[#Char]]

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/logical-memcpy.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/logical-memcpy.ll
@@ -20,7 +20,7 @@
 ; Function Attrs: mustprogress nofree noinline norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none, target_mem0: none, target_mem1: none)
 define void @main() local_unnamed_addr #0 {
 entry:
-; CHECK: OpCopyMemory %[[dst_var]] %[[src_var]] Aligned 4
+; CHECK: OpCopyMemory %[[dst_var]] %[[src_var]]
   call void @llvm.memcpy.p0.p0.i64(ptr addrspace(1) align 4 @dst, ptr addrspace(1) align 4 @src, i64 20, i1 false)
   ret void
 ; CHECK: OpReturn

--- a/llvm/test/CodeGen/SPIRV/pointers/array-skips-gep.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/array-skips-gep.ll
@@ -20,7 +20,7 @@ define internal spir_func i32 @foo() #0 {
   ; Direct load from the pointer index. This requires an OpAccessChain
   %1 = load i32, ptr %array, align 4
 ; CHECK: %[[#ptr:]] = OpAccessChain %[[#int_fp]] %[[#array]] %[[#uint_0]]
-; CHECK: %[[#val:]] = OpLoad %[[#uint_ty]] %[[#ptr]] Aligned 4
+; CHECK: %[[#val:]] = OpLoad %[[#uint_ty]] %[[#ptr]]
 
   ret i32 %1
 ; CHECK: OpReturnValue %[[#val]]
@@ -32,7 +32,7 @@ define internal spir_func i32 @bar() {
   ; Direct load from the pointer index. This requires an OpAccessChain
   %1 = load i32, ptr addrspace(10) @gv
 ; CHECK: %[[#ptr:]] = OpAccessChain %[[#int_pp]] %[[#gv]] %[[#uint_0]]
-; CHECK: %[[#val:]] = OpLoad %[[#uint_ty]] %[[#ptr]] Aligned 4
+; CHECK: %[[#val:]] = OpLoad %[[#uint_ty]] %[[#ptr]]
 
   ret i32 %1
 ; CHECK: OpReturnValue %[[#val]]

--- a/llvm/test/CodeGen/SPIRV/pointers/getelementptr-downcast-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/getelementptr-downcast-struct.ll
@@ -31,7 +31,7 @@ define spir_func noundef i32 @foo(i64 noundef %index) local_unnamed_addr {
 entry:
 ; CHECK: %[[#ptr:]] = OpInBoundsAccessChain %[[#uint_pp]] %[[#global1]] %[[#uint_0]] %[[#index]]
   %ptr = getelementptr inbounds %S1, ptr addrspace(10) @global1, i64 0, i32 0, i64 %index
-; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]] Aligned 4
+; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]]
   %val = load i32, ptr addrspace(10) %ptr
   ret i32 %val
 }
@@ -41,7 +41,7 @@ define spir_func noundef i32 @bar(i64 noundef %index) local_unnamed_addr {
 entry:
 ; CHECK: %[[#ptr:]] = OpInBoundsAccessChain %[[#uint_pp]] %[[#global2]] %[[#uint_0]] %[[#uint_0]] %[[#index]] %[[#uint_1]]
   %ptr = getelementptr inbounds %S2, ptr addrspace(10) @global2, i64 0, i32 0, i32 0, i64 %index, i32 1
-; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]] Aligned 4
+; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]]
   %val = load i32, ptr addrspace(10) %ptr
   ret i32 %val
 }
@@ -51,7 +51,7 @@ define spir_func void @foos(i64 noundef %index) local_unnamed_addr {
 entry:
 ; CHECK: %[[#ptr:]] = OpInBoundsAccessChain %[[#uint_pp]] %[[#global1]] %[[#uint_0]] %[[#index]]
   %ptr = getelementptr inbounds %S1, ptr addrspace(10) @global1, i64 0, i32 0, i64 %index
-; CHECK: OpStore %[[#ptr]] %[[#uint_0]] Aligned 4
+; CHECK: OpStore %[[#ptr]] %[[#uint_0]]
   store i32 0, ptr addrspace(10) %ptr
   ret void
 }
@@ -61,7 +61,7 @@ define spir_func void @bars(i64 noundef %index) local_unnamed_addr {
 entry:
 ; CHECK: %[[#ptr:]] = OpInBoundsAccessChain %[[#uint_pp]] %[[#global2]] %[[#uint_0]] %[[#uint_0]] %[[#index]] %[[#uint_1]]
   %ptr = getelementptr inbounds %S2, ptr addrspace(10) @global2, i64 0, i32 0, i32 0, i64 %index, i32 1
-; CHECK: OpStore %[[#ptr]] %[[#uint_0]] Aligned 4
+; CHECK: OpStore %[[#ptr]] %[[#uint_0]]
   store i32 0, ptr addrspace(10) %ptr
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/getelementptr-downcast-vector.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/getelementptr-downcast-vector.ll
@@ -22,7 +22,7 @@ define internal spir_func <3 x i32> @foo(ptr addrspace(10) %a) {
 
   ; partial loading of a vector: v4 -> v3.
   %2 = load <3 x i32>, ptr addrspace(10) %1, align 16
-; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]] Aligned 16
+; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]]
 ; CHECK: %[[#val:]] = OpVectorShuffle %[[#v3]] %[[#load]] %[[#load]] 0 1 2
 
   ret <3 x i32> %2
@@ -36,7 +36,7 @@ define internal spir_func <3 x i32> @fooDefault(ptr %a) {
 
   ; partial loading of a vector: v4 -> v3.
   %2 = load <3 x i32>, ptr %1, align 16
-; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]] Aligned 16
+; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]]
 ; CHECK: %[[#val:]] = OpVectorShuffle %[[#v3]] %[[#load]] %[[#load]] 0 1 2
 
   ret <3 x i32> %2
@@ -50,7 +50,7 @@ define internal spir_func <3 x i32> @fooBounds(ptr %a) {
 
   ; partial loading of a vector: v4 -> v3.
   %2 = load <3 x i32>, ptr %1, align 16
-; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]] Aligned 16
+; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]]
 ; CHECK: %[[#val:]] = OpVectorShuffle %[[#v3]] %[[#load]] %[[#load]] 0 1 2
 
   ret <3 x i32> %2
@@ -64,7 +64,7 @@ define internal spir_func <2 x i32> @bar(ptr addrspace(10) %a) {
 
   ; partial loading of a vector: v4 -> v2.
   %2 = load <2 x i32>, ptr addrspace(10) %1, align 16
-; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]] Aligned 16
+; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]]
 ; CHECK: %[[#val:]] = OpVectorShuffle %[[#v2]] %[[#load]] %[[#load]] 0 1
 
   ret <2 x i32> %2
@@ -79,7 +79,7 @@ define internal spir_func i32 @baz(ptr addrspace(10) %a) {
   ; Loading of the first scalar of a vector: v4 -> int.
   %2 = load i32, ptr addrspace(10) %1, align 16
 ; CHECK: %[[#ptr:]] = OpAccessChain %[[#uint_pp]] %[[#tmp]] %[[#uint_0]]
-; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]] Aligned 16
+; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]]
 
   ret i32 %2
 ; CHECK: OpReturnValue %[[#val]]
@@ -93,7 +93,7 @@ define internal spir_func i32 @bazDefault(ptr %a) {
   ; Loading of the first scalar of a vector: v4 -> int.
   %2 = load i32, ptr %1, align 16
 ; CHECK: %[[#ptr:]] = OpAccessChain %[[#uint_fp]] %[[#tmp]] %[[#uint_0]]
-; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]] Aligned 16
+; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]]
 
   ret i32 %2
 ; CHECK: OpReturnValue %[[#val]]
@@ -107,7 +107,7 @@ define internal spir_func i32 @bazBounds(ptr %a) {
   ; Loading of the first scalar of a vector: v4 -> int.
   %2 = load i32, ptr %1, align 16
 ; CHECK: %[[#ptr:]]  = OpAccessChain %[[#uint_fp]] %[[#tmp]] %[[#uint_0]]
-; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]] Aligned 16
+; CHECK: %[[#val:]] = OpLoad %[[#uint]] %[[#ptr]]
 
   ret i32 %2
 ; CHECK: OpReturnValue %[[#val]]
@@ -119,14 +119,14 @@ define internal spir_func void @foos(ptr addrspace(10) %a) {
 ; CHECK: %[[#ptr:]]  = OpInBoundsAccessChain %[[#v4_pp]] %[[#]]
 
   store <3 x i32> <i32 0, i32 1, i32 2>, ptr addrspace(10) %1, align 16
-; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]] Aligned 16
+; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]]
 ; CHECK:    %[[#A:]] = OpCompositeExtract %[[#uint]] %[[#v3_012]] 0
 ; CHECK: %[[#out1:]] = OpCompositeInsert %[[#v4]] %[[#A]] %[[#out0]] 0
 ; CHECK:    %[[#B:]] = OpCompositeExtract %[[#uint]] %[[#v3_012]] 1
 ; CHECK: %[[#out2:]] = OpCompositeInsert %[[#v4]] %[[#B]] %[[#out1]] 1
 ; CHECK:    %[[#C:]] = OpCompositeExtract %[[#uint]] %[[#v3_012]] 2
 ; CHECK: %[[#out3:]] = OpCompositeInsert %[[#v4]] %[[#C]] %[[#out2]] 2
-; CHECK: OpStore %[[#ptr]] %[[#out3]] Aligned 16
+; CHECK: OpStore %[[#ptr]] %[[#out3]]
 
   ret void
 }
@@ -137,14 +137,14 @@ define internal spir_func void @foosDefault(ptr %a) {
 ; CHECK: %[[#ptr:]]  = OpInBoundsAccessChain %[[#v4_fp]] %[[#]]
 
   store <3 x i32> <i32 0, i32 1, i32 2>, ptr %1, align 16
-; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]] Aligned 16
+; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]]
 ; CHECK:    %[[#A:]] = OpCompositeExtract %[[#uint]] %[[#v3_012]] 0
 ; CHECK: %[[#out1:]] = OpCompositeInsert %[[#v4]] %[[#A]] %[[#out0]] 0
 ; CHECK:    %[[#B:]] = OpCompositeExtract %[[#uint]] %[[#v3_012]] 1
 ; CHECK: %[[#out2:]] = OpCompositeInsert %[[#v4]] %[[#B]] %[[#out1]] 1
 ; CHECK:    %[[#C:]] = OpCompositeExtract %[[#uint]] %[[#v3_012]] 2
 ; CHECK: %[[#out3:]] = OpCompositeInsert %[[#v4]] %[[#C]] %[[#out2]] 2
-; CHECK: OpStore %[[#ptr]] %[[#out3]] Aligned 16
+; CHECK: OpStore %[[#ptr]] %[[#out3]]
 
   ret void
 }
@@ -155,14 +155,14 @@ define internal spir_func void @foosBounds(ptr %a) {
 ; CHECK: %[[#ptr:]]  = OpAccessChain %[[#v4_fp]] %[[#]]
 
   store <3 x i32> <i32 0, i32 1, i32 2>, ptr %1, align 64
-; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]] Aligned 64
+; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]]
 ; CHECK:    %[[#A:]] = OpCompositeExtract %[[#uint]] %[[#v3_012]] 0
 ; CHECK: %[[#out1:]] = OpCompositeInsert %[[#v4]] %[[#A]] %[[#out0]] 0
 ; CHECK:    %[[#B:]] = OpCompositeExtract %[[#uint]] %[[#v3_012]] 1
 ; CHECK: %[[#out2:]] = OpCompositeInsert %[[#v4]] %[[#B]] %[[#out1]] 1
 ; CHECK:    %[[#C:]] = OpCompositeExtract %[[#uint]] %[[#v3_012]] 2
 ; CHECK: %[[#out3:]] = OpCompositeInsert %[[#v4]] %[[#C]] %[[#out2]] 2
-; CHECK: OpStore %[[#ptr]] %[[#out3]] Aligned 64
+; CHECK: OpStore %[[#ptr]] %[[#out3]]
 
   ret void
 }
@@ -173,12 +173,12 @@ define internal spir_func void @bars(ptr addrspace(10) %a) {
 ; CHECK: %[[#ptr:]]  = OpAccessChain %[[#v4_pp]] %[[#]]
 
   store <2 x i32> <i32 0, i32 1>, ptr addrspace(10) %1, align 16
-; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]] Aligned 16
+; CHECK: %[[#out0:]] = OpLoad %[[#v4]] %[[#ptr]]
 ; CHECK:    %[[#A:]] = OpCompositeExtract %[[#uint]] %[[#v2_01]] 0
 ; CHECK: %[[#out1:]] = OpCompositeInsert %[[#v4]] %[[#A]] %[[#out0]] 0
 ; CHECK:    %[[#B:]] = OpCompositeExtract %[[#uint]] %[[#v2_01]] 1
 ; CHECK: %[[#out2:]] = OpCompositeInsert %[[#v4]] %[[#B]] %[[#out1]] 1
-; CHECK: OpStore %[[#ptr]] %[[#out2]] Aligned 1
+; CHECK: OpStore %[[#ptr]] %[[#out2]]
 
   ret void
 }
@@ -190,7 +190,7 @@ define internal spir_func void @bazs(ptr addrspace(10) %a) {
 
   store i32 0, ptr addrspace(10) %1, align 32
 ; CHECK:  %[[#tmp:]] = OpInBoundsAccessChain %[[#uint_pp]] %[[#ptr]] %[[#uint_0]]
-; CHECK: OpStore %[[#tmp]] %[[#uint_0]] Aligned 32
+; CHECK: OpStore %[[#tmp]] %[[#uint_0]]
 
   ret void
 }
@@ -202,7 +202,7 @@ define internal spir_func void @bazsDefault(ptr %a) {
 
   store i32 0, ptr %1, align 16
 ; CHECK:  %[[#tmp:]] = OpInBoundsAccessChain %[[#uint_fp]] %[[#ptr]] %[[#uint_0]]
-; CHECK: OpStore %[[#tmp]] %[[#uint_0]] Aligned 16
+; CHECK: OpStore %[[#tmp]] %[[#uint_0]]
 
   ret void
 }
@@ -214,7 +214,7 @@ define internal spir_func void @bazsBounds(ptr %a) {
 
   store i32 0, ptr %1, align 16
 ; CHECK:  %[[#tmp:]] = OpInBoundsAccessChain %[[#uint_fp]] %[[#ptr]] %[[#uint_0]]
-; CHECK: OpStore %[[#tmp]] %[[#uint_0]] Aligned 16
+; CHECK: OpStore %[[#tmp]] %[[#uint_0]]
 
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/global-addrspacecast.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/global-addrspacecast.ll
@@ -15,7 +15,7 @@ define hidden spir_func void @Foo() {
   store i32 %v, ptr @G
   ret void
 ; CHECK:      OpLabel
-; CHECK: OpLoad %[[#type]] %[[#var]] Aligned 4
+; CHECK: OpLoad %[[#type]] %[[#var]]
 ; CHECK: OpReturn
 }
 

--- a/llvm/test/CodeGen/SPIRV/pointers/load-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/load-struct.ll
@@ -28,7 +28,7 @@ define internal spir_func float @foo() #0 {
 
   %2 = load float, ptr %1, align 4
 ; CHECK: %[[#tmp:]]  = OpAccessChain %[[#float_fp]] %[[#var]] %[[#uint_0]]
-; CHECK: %[[#val:]]  = OpLoad %[[#float]] %[[#tmp]] Aligned 4
+; CHECK: %[[#val:]]  = OpLoad %[[#float]] %[[#tmp]]
 
   ret float %2
 }
@@ -39,7 +39,7 @@ define internal spir_func i32 @bar() #0 {
 
   %2 = load i32, ptr %1, align 4
 ; CHECK: %[[#tmp:]]  = OpAccessChain %[[#uint_fp]] %[[#var]] %[[#uint_0]]
-; CHECK: %[[#val:]]  = OpLoad %[[#uint]] %[[#tmp]] Aligned 4
+; CHECK: %[[#val:]]  = OpLoad %[[#uint]] %[[#tmp]]
 
   ret i32 %2
 }
@@ -50,7 +50,7 @@ define internal spir_func float @baz() #0 {
 
   %2 = load float, ptr %1, align 4
 ; CHECK: %[[#tmp:]]  = OpAccessChain %[[#float_fp]] %[[#var]] %[[#uint_0]]
-; CHECK: %[[#val:]]  = OpLoad %[[#float]] %[[#tmp]] Aligned 4
+; CHECK: %[[#val:]]  = OpLoad %[[#float]] %[[#tmp]]
 
   ret float %2
 }
@@ -58,7 +58,7 @@ define internal spir_func float @baz() #0 {
 define internal spir_func float @biz() #0 {
   %2 = load float, ptr addrspace(10) @gsfuf, align 4
 ; CHECK: %[[#tmp:]]  = OpAccessChain %[[#float_pp]] %[[#gsfuf]] %[[#uint_0]]
-; CHECK: %[[#val:]]  = OpLoad %[[#float]] %[[#tmp]] Aligned 4
+; CHECK: %[[#val:]]  = OpLoad %[[#float]] %[[#tmp]]
 
   ret float %2
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/pointer-addrspacecast.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/pointer-addrspacecast.ll
@@ -19,7 +19,7 @@ entry:
   %casted = addrspacecast ptr addrspace(10) %ptr to ptr
   %val = load i32, ptr %casted
   store i32 %val, ptr @G
-; CHECK: %{{.*}} = OpLoad %[[#uint]] %[[#var]] Aligned 4
+; CHECK: %{{.*}} = OpLoad %[[#uint]] %[[#var]]
   ret void
 }
 
@@ -34,6 +34,6 @@ entry:
 
   %val = load i32, ptr %e
   store i32 %val, ptr @G
-; CHECK: %{{.*}} = OpLoad %[[#uint]] %[[#var]] Aligned 4
+; CHECK: %{{.*}} = OpLoad %[[#uint]] %[[#var]]
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/ptrcast-bitcast.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/ptrcast-bitcast.ll
@@ -22,7 +22,7 @@ entry:
 ; CHECK: %[[#access:]] = OpAccessChain {{.*}}
   %7 = tail call noundef align 16 dereferenceable(16) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v2f64_12_1t(target("spirv.VulkanBuffer", [0 x <2 x double>], 12, 1) %1, i32 0)
 ; CHECK: %[[#bitcast:]] = OpBitcast %[[#v2_double]] %[[#tmp]]
-; CHECK: OpStore %[[#access]] %[[#bitcast]] Aligned 16
+; CHECK: OpStore %[[#access]] %[[#bitcast]]
   store <4 x i32> %6, ptr addrspace(11) %7, align 16
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/resource-addrspacecast-2.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/resource-addrspacecast-2.ll
@@ -36,14 +36,14 @@ entry:
 ; CHECK: %[[#ptr2:]] = OpInBoundsAccessChain %[[#ptr_StorageBuffer_uint]] %[[#b:]] %[[#uint_0]] %[[#uint_0]] %[[#uint_3]] %[[#uint_1]]
   %ptr2 = getelementptr inbounds %S2, ptr %casted, i64 0, i32 0, i32 0, i32 3, i32 1
 
-; CHECK: OpStore %[[#ptr2]] %[[#uint_10]] Aligned 4
+; CHECK: OpStore %[[#ptr2]] %[[#uint_10]]
   store i32 10, ptr %ptr2, align 4
 
 ; Another store, but this time using LLVM's ability to load the first element
 ; without an explicit GEP. The backend has to determine the ptr type and
 ; generate the appropriate access chain.
 ; CHECK: %[[#ptr3:]] = OpInBoundsAccessChain %[[#ptr_StorageBuffer_uint]] %[[#b:]] %[[#uint_0]] %[[#uint_0]] %[[#uint_0]] %[[#uint_0]]
-; CHECK: OpStore %[[#ptr3]] %[[#uint_11]] Aligned 4
+; CHECK: OpStore %[[#ptr3]] %[[#uint_11]]
   store i32 11, ptr %casted, align 4
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/resource-addrspacecast.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/resource-addrspacecast.ll
@@ -26,7 +26,7 @@ entry:
 ; CHECK: %[[#c:]] = OpInBoundsAccessChain %[[#ptr_StorageBuffer_uint]] %[[#b:]] %[[#uint_0]]
   %casted = addrspacecast ptr addrspace(11) %ptr to ptr
 
-; CHECK: OpStore %[[#c]] %[[#uint_10]] Aligned 4
+; CHECK: OpStore %[[#c]] %[[#uint_10]]
   store i32 10, ptr %casted, align 4
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/sgep-array.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/sgep-array.ll
@@ -34,12 +34,12 @@ entry:
   %1 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([3 x i32]) %a, i64 2)
   %2 = load i32, ptr %1, align 4
 ; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#]] %[[#ulong_2]]
-; CHECK:	  %[[#B:]] = OpLoad %[[#uint]] %[[#A]] Aligned 4
+; CHECK:	  %[[#B:]] = OpLoad %[[#uint]] %[[#A]]
 
   %3 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([5 x i32]) %tmp, i64 3)
   store i32 %2, ptr %3, align 4
 ; CHECK:	  %[[#C:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#tmp]] %[[#ulong_3]]
-; CHECK:	             OpStore %[[#C]] %[[#B]] Aligned 4
+; CHECK:	             OpStore %[[#C]] %[[#B]]
 
   ret void
 }
@@ -55,14 +55,14 @@ entry:
   %3 = load i32, ptr %2, align 4
 ; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_S]] %[[#]] %[[#ulong_2]]
 ; CHECK:	  %[[#B:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#A]] %[[#ulong_1]]
-; CHECK:	  %[[#C:]] = OpLoad %[[#uint]] %[[#B]] Aligned 4
+; CHECK:	  %[[#C:]] = OpLoad %[[#uint]] %[[#B]]
 
   %4 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([5 x %struct.S]) %tmp, i64 3)
   %5 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S) %4, i32 0)
   store i32 %3, ptr %5, align 4
 ; CHECK:	  %[[#D:]] = OpInBoundsAccessChain %[[#ptr_S]] %[[#tmp]] %[[#ulong_3]]
 ; CHECK:	  %[[#E:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#D]] %[[#uint_0]]
-; CHECK:	             OpStore %[[#E]] %[[#C]] Aligned 4
+; CHECK:	             OpStore %[[#E]] %[[#C]]
 
   ret void
 }
@@ -76,12 +76,12 @@ entry:
   %1 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([3 x %struct.S]) %a, i64 2, i64 1)
   %2 = load i32, ptr %1, align 4
 ; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#]] %[[#ulong_2]] %[[#ulong_1]]
-; CHECK:	  %[[#B:]] = OpLoad %[[#uint]] %[[#A]] Aligned 4
+; CHECK:	  %[[#B:]] = OpLoad %[[#uint]] %[[#A]]
 
   %3 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([5 x %struct.S]) %tmp, i64 3, i32 0)
   store i32 %2, ptr %3, align 4
 ; CHECK:	  %[[#C:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#tmp]] %[[#ulong_3]] %[[#uint_0]]
-; CHECK:	             OpStore %[[#C]] %[[#B]] Aligned 4
+; CHECK:	             OpStore %[[#C]] %[[#B]]
 
   ret void
 }
@@ -99,7 +99,7 @@ entry:
 ; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_S2]] %[[#]] %[[#ulong_1]]
 ; CHECK:	  %[[#B:]] = OpInBoundsAccessChain %[[#ptr_S]] %[[#A]] %[[#ulong_1]]
 ; CHECK:	  %[[#C:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#B]] %[[#ulong_0]]
-; CHECK:	  %[[#D:]] = OpLoad %[[#uint]] %[[#C]] Aligned 4
+; CHECK:	  %[[#D:]] = OpLoad %[[#uint]] %[[#C]]
 
   %5 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([5 x %struct.S2]) %tmp, i64 3)
   %6 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S2) %5, i32 1)
@@ -108,7 +108,7 @@ entry:
 ; CHECK:	  %[[#E:]] = OpInBoundsAccessChain %[[#ptr_S2]] %[[#tmp]] %[[#ulong_3]]
 ; CHECK:	  %[[#F:]] = OpInBoundsAccessChain %[[#ptr_S]] %[[#E]] %[[#uint_1]]
 ; CHECK:	  %[[#G:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#F]] %[[#uint_0]]
-; CHECK:	             OpStore %[[#G]] %[[#D]] Aligned 4
+; CHECK:	             OpStore %[[#G]] %[[#D]]
 
   ret void
 }
@@ -122,12 +122,12 @@ entry:
   %1 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([3 x %struct.S2]) %a, i64 1, i64 1, i64 0)
   %2 = load i32, ptr %1, align 4
 ; CHECK:	  %[[#A:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#]] %[[#ulong_1]] %[[#ulong_1]] %[[#ulong_0]]
-; CHECK:	  %[[#B:]] = OpLoad %[[#uint]] %[[#A]] Aligned 4
+; CHECK:	  %[[#B:]] = OpLoad %[[#uint]] %[[#A]]
 
   %3 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([5 x %struct.S2]) %tmp, i64 3, i32 1, i32 0)
   store i32 %2, ptr %3, align 4
 ; CHECK:	  %[[#C:]] = OpInBoundsAccessChain %[[#ptr_uint]] %[[#tmp]] %[[#ulong_3]] %[[#uint_1]] %[[#uint_0]]
-; CHECK:	             OpStore %[[#C]] %[[#B]] Aligned 4
+; CHECK:	             OpStore %[[#C]] %[[#B]]
 
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/sgep-dynamic-index.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/sgep-dynamic-index.ll
@@ -18,7 +18,7 @@ entry:
   ; CHECK: %[[#ptr_elem:]] = OpInBoundsAccessChain %[[#ptr_int]] %[[#arr_var]] %[[#idx_var]]
 
   %2 = load i32, ptr %1, align 4
-  ; CHECK: %[[#val:]] = OpLoad %[[#int]] %[[#ptr_elem]] Aligned 4
+  ; CHECK: %[[#val:]] = OpLoad %[[#int]] %[[#ptr_elem]]
 
   ret i32 %2
   ; CHECK: OpReturnValue %[[#val]]
@@ -34,7 +34,7 @@ entry:
   ; CHECK: %[[#ptr_elem2:]] = OpInBoundsAccessChain %[[#ptr_int]] %[[#arr_var2]] %[[#idx_var2]]
 
   %2 = load i32, ptr %1, align 4
-  ; CHECK: %[[#val2:]] = OpLoad %[[#int]] %[[#ptr_elem2]] Aligned 4
+  ; CHECK: %[[#val2:]] = OpLoad %[[#int]] %[[#ptr_elem2]]
 
   ret i32 %2
   ; CHECK: OpReturnValue %[[#val2]]

--- a/llvm/test/CodeGen/SPIRV/pointers/sgep-nested-struct-array.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/sgep-nested-struct-array.ll
@@ -23,7 +23,7 @@ entry:
   ; CHECK: %[[#ptr_elem:]] = OpInBoundsAccessChain %[[#ptr_float]] %[[#obj_var]] %[[#]] %[[#]] %[[#]] %[[#]]
 
   %2 = load float, ptr %1, align 4
-  ; CHECK: %[[#val:]] = OpLoad %[[#float]] %[[#ptr_elem]] Aligned 4
+  ; CHECK: %[[#val:]] = OpLoad %[[#float]] %[[#ptr_elem]]
 
   ret float %2
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/sgep-runtime-array.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/sgep-runtime-array.ll
@@ -20,7 +20,7 @@ entry:
   ; CHECK: %[[#ptr_elem:]] = OpInBoundsAccessChain %[[#ptr_sb_int]] %[[#buffer]] %[[#]] %[[#]]
 
   %2 = load i32, ptr addrspace(11) %1, align 4
-  ; CHECK: %[[#val:]] = OpLoad %[[#int]] %[[#ptr_elem]] Aligned 4
+  ; CHECK: %[[#val:]] = OpLoad %[[#int]] %[[#ptr_elem]]
 
   ret i32 %2
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/sgep-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/sgep-struct.ll
@@ -21,10 +21,10 @@ entry:
   ; CHECK: %[[#ptr_field:]] = OpInBoundsAccessChain %[[#ptr_float]] %[[#s_var]] %[[#idx_1]]
 
   %2 = load float, ptr %1, align 4
-  ; CHECK: %[[#val:]] = OpLoad %[[#float]] %[[#ptr_field]] Aligned 4
+  ; CHECK: %[[#val:]] = OpLoad %[[#float]] %[[#ptr_field]]
 
   store float %2, ptr %out, align 4
-  ; CHECK: OpStore %[[#out_var]] %[[#val]] Aligned 4
+  ; CHECK: OpStore %[[#out_var]] %[[#val]]
 
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/sgep-vector.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/sgep-vector.ll
@@ -26,10 +26,10 @@ entry:
   ; CHECK: %[[#ptr_elem:]] = OpInBoundsAccessChain %[[#ptr_float]] %[[#vec_var]] %[[#idx_2]]
 
   %2 = load float, ptr %1, align 4
-  ; CHECK: %[[#val:]] = OpLoad %[[#float]] %[[#ptr_elem]] Aligned 4
+  ; CHECK: %[[#val:]] = OpLoad %[[#float]] %[[#ptr_elem]]
 
   store float %2, ptr %out, align 4
-  ; CHECK: OpStore %[[#out_var]] %[[#val]] Aligned 4
+  ; CHECK: OpStore %[[#out_var]] %[[#val]]
 
   ret void
 }
@@ -44,10 +44,10 @@ entry:
   ; CHECK: %[[#ptr_elem2:]] = OpInBoundsAccessChain %[[#ptr_float]] %[[#arr_var]] %[[#idx_1]] %[[#idx_2]]
 
   %2 = load float, ptr %1, align 4
-  ; CHECK: %[[#val2:]] = OpLoad %[[#float]] %[[#ptr_elem2]] Aligned 4
+  ; CHECK: %[[#val2:]] = OpLoad %[[#float]] %[[#ptr_elem2]]
 
   store float %2, ptr %out, align 4
-  ; CHECK: OpStore %[[#out_var2]] %[[#val2]] Aligned 4
+  ; CHECK: OpStore %[[#out_var2]] %[[#val2]]
 
   ret void
 }
@@ -62,19 +62,19 @@ entry:
   ; CHECK: %[[#ptr_elem3_0:]] = OpInBoundsAccessChain %[[#ptr_float]] %[[#arr_var3]] %[[#idx_0]]
 
   %2 = load float, ptr %1, align 4
-  ; CHECK: %[[#val3_0:]] = OpLoad %[[#float]] %[[#ptr_elem3_0]] Aligned 4
+  ; CHECK: %[[#val3_0:]] = OpLoad %[[#float]] %[[#ptr_elem3_0]]
 
   %3 = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([10 x float]) %arr, i32 5)
   ; CHECK: %[[#ptr_elem3_5:]] = OpInBoundsAccessChain %[[#ptr_float]] %[[#arr_var3]] %[[#idx_5]]
 
   %4 = load float, ptr %3, align 4
-  ; CHECK: %[[#val3_5:]] = OpLoad %[[#float]] %[[#ptr_elem3_5]] Aligned 4
+  ; CHECK: %[[#val3_5:]] = OpLoad %[[#float]] %[[#ptr_elem3_5]]
 
   %5 = fadd float %2, %4
   ; CHECK: %[[#res:]] = OpFAdd %[[#float]] %[[#val3_0]] %[[#val3_5]]
 
   store float %5, ptr %out, align 4
-  ; CHECK: OpStore %[[#out_var3]] %[[#res]] Aligned 4
+  ; CHECK: OpStore %[[#out_var3]] %[[#res]]
 
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/store-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/store-struct.ll
@@ -45,7 +45,7 @@ define internal spir_func void @foo() #0 {
 
   store float 0.0, ptr %1, align 4
 ; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#float_fp]] %[[#var]] %[[#uint_0]]
-; CHECK:               OpStore %[[#tmp]] %[[#float_0]] Aligned 4
+; CHECK:               OpStore %[[#tmp]] %[[#float_0]]
 
   ret void
 }
@@ -56,7 +56,7 @@ define internal spir_func void @bar() #0 {
 
   store i32 0, ptr %1, align 4
 ; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#uint_fp]] %[[#var]] %[[#uint_0]]
-; CHECK:               OpStore %[[#tmp]] %[[#uint_0]] Aligned 4
+; CHECK:               OpStore %[[#tmp]] %[[#uint_0]]
 
   ret void
 }
@@ -67,7 +67,7 @@ define internal spir_func void @baz() #0 {
 
   store float 0.0, ptr %1, align 4
 ; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#float_fp]] %[[#var]] %[[#uint_0]]
-; CHECK:               OpStore %[[#tmp]] %[[#float_0]] Aligned 4
+; CHECK:               OpStore %[[#tmp]] %[[#float_0]]
 
   ret void
 }
@@ -75,7 +75,7 @@ define internal spir_func void @baz() #0 {
 define internal spir_func void @biz() #0 {
   store float 0.0, ptr addrspace(10) @gsfuf, align 4
 ; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#float_pp]] %[[#gsfuf]] %[[#uint_0]]
-; CHECK:               OpStore %[[#tmp]] %[[#float_0]] Aligned 4
+; CHECK:               OpStore %[[#tmp]] %[[#float_0]]
 
   ret void
 }
@@ -86,7 +86,7 @@ define internal spir_func void @nested_store() #0 {
 
   store i32 0, ptr %1, align 4
 ; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#uint_fp]] %[[#var]] %[[#uint_0]] %[[#uint_0]]
-; CHECK:               OpStore %[[#tmp]] %[[#uint_0]] Aligned 4
+; CHECK:               OpStore %[[#tmp]] %[[#uint_0]]
 
   ret void
 }
@@ -97,7 +97,7 @@ define internal spir_func void @nested_store_vector() #0 {
 
   store i32 0, ptr %1, align 4
 ; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#uint_fp]] %[[#var]] %[[#uint_0]] %[[#uint_0]] %[[#uint_0]]
-; CHECK:               OpStore %[[#tmp]] %[[#uint_0]] Aligned 4
+; CHECK:               OpStore %[[#tmp]] %[[#uint_0]]
 
   ret void
 }
@@ -108,7 +108,7 @@ define internal spir_func void @nested_array_vector() #0 {
 
   store i32 0, ptr %1, align 4
 ; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#uint_fp]] %[[#var]] %[[#uint_0]] %[[#uint_0]] %[[#uint_0]] %[[#uint_0]] %[[#uint_0]] %[[#uint_0]]
-; CHECK:               OpStore %[[#tmp]] %[[#uint_0]] Aligned 4
+; CHECK:               OpStore %[[#tmp]] %[[#uint_0]]
 
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/pointers/structured-buffer-access.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/structured-buffer-access.ll
@@ -37,14 +37,14 @@ define void @main() local_unnamed_addr #0 {
 ; CHECK-NEXT:    %47 = OpLoad %4 %41
 ; CHECK-NEXT:    %48 = OpAccessChain %13 %45 %28 %47
 ; CHECK-NEXT:    %49 = OpInBoundsAccessChain %9 %48 %30
-; CHECK-NEXT:    %50 = OpLoad %8 %49 Aligned 1
+; CHECK-NEXT:    %50 = OpLoad %8 %49
 ; CHECK-NEXT:    %51 = OpAccessChain %11 %46 %28 %47
 ; CHECK-NEXT:    %52 = OpInBoundsAccessChain %9 %51 %28
-; CHECK-NEXT:    OpStore %52 %50 Aligned 1
+; CHECK-NEXT:    OpStore %52 %50
 ; CHECK-NEXT:    %53 = OpAccessChain %6 %48 %28
-; CHECK-NEXT:    %54 = OpLoad %5 %53 Aligned 1
+; CHECK-NEXT:    %54 = OpLoad %5 %53
 ; CHECK-NEXT:    %55 = OpInBoundsAccessChain %6 %51 %30
-; CHECK-NEXT:    OpStore %55 %54 Aligned 1
+; CHECK-NEXT:    OpStore %55 %54
 ; CHECK-NEXT:    OpReturn
 ; CHECK-NEXT:    OpFunctionEnd
 entry:

--- a/llvm/test/CodeGen/SPIRV/pointers/structured-buffer-vector-access.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/structured-buffer-vector-access.ll
@@ -22,11 +22,11 @@ define void @main() local_unnamed_addr #0 {
 ; CHECK-NEXT:    %36 = OpCopyObject %12 %31
 ; CHECK-NEXT:    %37 = OpCopyObject %10 %32
 ; CHECK-NEXT:    %38 = OpAccessChain %7 %36 %21 %21
-; CHECK-NEXT:    %39 = OpLoad %6 %38 Aligned 16
+; CHECK-NEXT:    %39 = OpLoad %6 %38
 ; CHECK-NEXT:    %40 = OpCompositeExtract %4 %39 1
 ; CHECK-NEXT:    %41 = OpAccessChain %7 %37 %21 %21
 ; CHECK-NEXT:    %42 = OpInBoundsAccessChain %5 %41 %22
-; CHECK-NEXT:    OpStore %42 %40 Aligned 4
+; CHECK-NEXT:    OpStore %42 %40
 ; CHECK-NEXT:    OpReturn
 ; CHECK-NEXT:    OpFunctionEnd
 entry:

--- a/llvm/test/CodeGen/SPIRV/semantics/position.ps.ll
+++ b/llvm/test/CodeGen/SPIRV/semantics/position.ps.ll
@@ -21,8 +21,8 @@ entry:
   store <4 x float> %0, ptr addrspace(8) @A0, align 16
   ret void
 
-; CHECK: %[[#TMP:]] = OpLoad %[[#v4]] %[[#INPUT]] Aligned 16
-; CHECK:              OpStore %[[#OUTPUT]] %[[#TMP]] Aligned 16
+; CHECK: %[[#TMP:]] = OpLoad %[[#v4]] %[[#INPUT]]
+; CHECK:              OpStore %[[#OUTPUT]] %[[#TMP]]
 }
 
 !0 = !{!1}

--- a/llvm/test/CodeGen/SPIRV/semantics/position.vs.ll
+++ b/llvm/test/CodeGen/SPIRV/semantics/position.vs.ll
@@ -21,8 +21,8 @@ entry:
   store <4 x float> %0, ptr addrspace(8) @SV_Position, align 16
   ret void
 
-; CHECK: %[[#TMP:]] = OpLoad %[[#v4]] %[[#INPUT]] Aligned 16
-; CHECK:              OpStore %[[#OUTPUT]] %[[#TMP]] Aligned 16
+; CHECK: %[[#TMP:]] = OpLoad %[[#v4]] %[[#INPUT]]
+; CHECK:              OpStore %[[#OUTPUT]] %[[#TMP]]
 }
 
 !0 = !{!1}

--- a/llvm/test/CodeGen/SPIRV/semantics/target.ps.ll
+++ b/llvm/test/CodeGen/SPIRV/semantics/target.ps.ll
@@ -21,8 +21,8 @@ entry:
   store <4 x float> %0, ptr addrspace(8) @SV_Target0, align 16
   ret void
 
-; CHECK: %[[#TMP:]] = OpLoad %[[#v4]] %[[#INPUT]] Aligned 16
-; CHECK:              OpStore %[[#OUTPUT]] %[[#TMP]] Aligned 16
+; CHECK: %[[#TMP:]] = OpLoad %[[#v4]] %[[#INPUT]]
+; CHECK:              OpStore %[[#OUTPUT]] %[[#TMP]]
 }
 
 !0 = !{!1}

--- a/llvm/test/CodeGen/SPIRV/spirv-explicit-layout.ll
+++ b/llvm/test/CodeGen/SPIRV/spirv-explicit-layout.ll
@@ -74,7 +74,7 @@ entry:
 ; CHECK-NEXT: [[ptr:%[0-9]+]] = OpAccessChain [[storagebuffer_int_ptr]] [[handle]] [[zero]] [[one]]
   %0 = tail call noundef nonnull align 4 dereferenceable(4) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x i32], 12, 0) %handle, i32 1)
 
-; CHECK-NEXT: [[ld:%[0-9]+]] = OpLoad [[uint]] [[ptr]] Aligned 4
+; CHECK-NEXT: [[ld:%[0-9]+]] = OpLoad [[uint]] [[ptr]]
   %1 = load i32, ptr addrspace(11) %0, align 4
 
 ; CHECK-NEXT: OpReturnValue [[ld]]
@@ -88,7 +88,7 @@ define external %struct.S @private_load() {
 ; CHECK-NEXT: OpLabel
 entry:
 
-; CHECK: [[ld:%[0-9]+]] = OpLoad [[S]] [[private_var]] Aligned 4
+; CHECK: [[ld:%[0-9]+]] = OpLoad [[S]] [[private_var]]
   %1 = load %struct.S, ptr addrspace(10) @private, align 4
 
 ; CHECK-NEXT: OpReturnValue [[ld]]
@@ -102,7 +102,7 @@ define external %struct.S @storage_buffer_load() {
 ; CHECK-NEXT: OpLabel
 entry:
 
-; CHECK: [[ld:%[0-9]+]] = OpLoad [[S_explicit]] [[storage_buffer]] Aligned 4
+; CHECK: [[ld:%[0-9]+]] = OpLoad [[S_explicit]] [[storage_buffer]]
 ; CHECK-NEXT: [[copy:%[0-9]+]] = OpCopyLogical [[S]] [[ld]]
   %1 = load %struct.S, ptr addrspace(11) @storage_buffer, align 4
 
@@ -122,7 +122,7 @@ entry:
 ; CHECK-NEXT: [[ptr:%[0-9]+]] = OpAccessChain [[storagebuffer_S_ptr]] [[handle]] [[zero]] [[one]]
   %0 = tail call noundef nonnull align 4 dereferenceable(4) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x %struct.S], 12, 0) %handle, i32 1)
 
-; CHECK-NEXT: [[ld:%[0-9]+]] = OpLoad [[S_explicit]] [[ptr]] Aligned 4
+; CHECK-NEXT: [[ld:%[0-9]+]] = OpLoad [[S_explicit]] [[ptr]]
 ; CHECK-NEXT: [[copy:%[0-9]+]] = OpCopyLogical [[S]] [[ld]]
   %1 = load %struct.S, ptr addrspace(11) %0, align 4
 
@@ -143,7 +143,7 @@ entry:
 ; CHECK-NEXT: [[ptr:%[0-9]+]] = OpAccessChain [[storagebuffer_S_ptr]] [[handle]] [[zero]] [[one]]
   %0 = tail call noundef nonnull align 4 dereferenceable(4) ptr addrspace(11) @llvm.spv.resource.getpointer(target("spirv.VulkanBuffer", [0 x %struct.S], 12, 0) %handle, i32 1)
 
-; CHECK-NEXT: [[ld:%[0-9]+]] = OpLoad [[S_explicit]] [[ptr]] Aligned 4
+; CHECK-NEXT: [[ld:%[0-9]+]] = OpLoad [[S_explicit]] [[ptr]]
 ; CHECK-NEXT: [[copy:%[0-9]+]] = OpCopyLogical [[S]] [[ld]]
   %1 = load %struct.S, ptr addrspace(11) %0, align 4
 

--- a/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-break.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-break.ll
@@ -17,7 +17,7 @@ define internal spir_func void @main() #0 {
 
 ; CHECK:   %[[#entry:]] = OpLabel
 ; CHECK:      %[[#idx]] = OpVariable %[[#]] Function
-; ACHECK:                 OpStore %[[#idx]] %[[#int_0]] Aligned 4
+; ACHECK:                 OpStore %[[#idx]] %[[#int_0]]
 ; CHECK:                  OpBranch %[[#while_cond:]]
 entry:
   %0 = call token @llvm.experimental.convergence.entry()
@@ -26,7 +26,7 @@ entry:
   br label %while.cond
 
 ; CHECK:   %[[#while_cond]] = OpLabel
-; CHECK:         %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]] Aligned 4
+; CHECK:         %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]]
 ; CHECK:         %[[#cmp:]] = OpINotEqual %[[#bool_ty]] %[[#tmp]] %[[#int_10]]
 ; CHECK:                      OpLoopMerge %[[#new_end:]] %[[#if_end:]] None
 ; CHECK:                      OpBranchConditional %[[#cmp]] %[[#while_body:]] %[[#new_end]]
@@ -38,9 +38,9 @@ while.cond:
   br i1 %cmp, label %while.body, label %while.end
 
 ; CHECK: %[[#while_body]] = OpLabel
-; CHECK:       %[[#tmp:]] = OpLoad %[[#]] %[[#builtin]] Aligned 1
-; CHECK:                    OpStore %[[#idx]] %[[#tmp]] Aligned 4
-; CHECK:       %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]] Aligned 4
+; CHECK:       %[[#tmp:]] = OpLoad %[[#]] %[[#builtin]]
+; CHECK:                    OpStore %[[#idx]] %[[#tmp]]
+; CHECK:       %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]]
 ; CHECK:      %[[#cmp1:]] = OpIEqual %[[#bool_ty]] %[[#tmp]] %[[#int_0]]
 ; CHECK:                    OpBranchConditional %[[#cmp1]] %[[#new_end]] %[[#if_end]]
 while.body:

--- a/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-convergence-in-break.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-convergence-in-break.ll
@@ -15,7 +15,7 @@ define internal spir_func void @main() #0 {
 
 ; CHECK:   %[[#entry:]] = OpLabel
 ; CHECK:      %[[#idx]] = OpVariable %[[#]] Function
-; CHECK:                  OpStore %[[#idx]] %[[#int_0]] Aligned 4
+; CHECK:                  OpStore %[[#idx]] %[[#int_0]]
 ; CHECK:                  OpBranch %[[#while_cond:]]
 entry:
   %0 = call token @llvm.experimental.convergence.entry()
@@ -24,7 +24,7 @@ entry:
   br label %while.cond
 
 ; CHECK:   %[[#while_cond]] = OpLabel
-; CHECK:         %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]] Aligned 4
+; CHECK:         %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]]
 ; CHECK:         %[[#cmp:]] = OpINotEqual %[[#bool_ty]] %[[#tmp]] %[[#int_10]]
 ; CHECK:                      OpLoopMerge %[[#new_end:]] %[[#if_end:]] None
 ; CHECK:                      OpBranchConditional %[[#cmp]] %[[#while_body:]] %[[#new_end]]
@@ -35,9 +35,9 @@ while.cond:
   br i1 %cmp, label %while.body, label %while.end
 
 ; CHECK:      %[[#while_body]] = OpLabel
-; CHECK-NEXT:       %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#builtin]] Aligned 1
-; CHECK-NEXT:                    OpStore %[[#idx]] %[[#tmp]] Aligned 4
-; CHECK-NEXT:       %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]] Aligned 4
+; CHECK-NEXT:       %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#builtin]]
+; CHECK-NEXT:                    OpStore %[[#idx]] %[[#tmp]]
+; CHECK-NEXT:       %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]]
 ; CHECK-NEXT:      %[[#cmp1:]] = OpIEqual %[[#bool_ty]] %[[#tmp]] %[[#int_0]]
 ; CHECK:                         OpBranchConditional %[[#cmp1]] %[[#if_then:]] %[[#if_end]]
 while.body:
@@ -51,8 +51,8 @@ while.body:
 ; CHECK:                OpBranch %[[#while_cond]]
 
 ; CHECK:      %[[#if_then]] = OpLabel
-; CHECK:         %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#builtin]] Aligned 1
-; CHECK:                      OpStore %[[#idx]] %[[#tmp]] Aligned 4
+; CHECK:         %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#builtin]]
+; CHECK:                      OpStore %[[#idx]] %[[#tmp]]
 ; CHECK:                      OpBranch %[[#new_end]]
 if.then:
   %5 = call i32 @__hlsl_wave_get_lane_index() [ "convergencectrl"(token %1) ]

--- a/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-multiple-break.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/merge-exit-multiple-break.ll
@@ -18,7 +18,7 @@ define internal spir_func void @main() #0 {
 
 ; CHECK:   %[[#entry:]] = OpLabel
 ; CHECK:      %[[#idx]] = OpVariable %[[#]] Function
-; CHECK:                  OpStore %[[#idx]] %[[#int_0]] Aligned 4
+; CHECK:                  OpStore %[[#idx]] %[[#int_0]]
 ; CHECK:                  OpBranch %[[#while_cond:]]
 entry:
   %0 = call token @llvm.experimental.convergence.entry()
@@ -27,8 +27,8 @@ entry:
   br label %while.cond
 
 ; CHECK:   %[[#while_cond]] = OpLabel
-; CHECK:                      OpStore %[[#reg_0]] %[[#]] Aligned 4
-; CHECK:         %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]] Aligned 4
+; CHECK:                      OpStore %[[#reg_0]] %[[#]]
+; CHECK:         %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]]
 ; CHECK:         %[[#cmp:]] = OpINotEqual %[[#bool_ty]] %[[#tmp]] %[[#int_10]]
 ; CHECK:                      OpLoopMerge %[[#new_end:]] %[[#if_end2:]] None
 ; CHECK:                      OpBranchConditional %[[#cmp]] %[[#while_body:]] %[[#new_end]]
@@ -39,10 +39,10 @@ while.cond:
   br i1 %cmp, label %while.body, label %while.end
 
 ; CHECK:   %[[#while_body]] = OpLabel
-; CHECK:                      OpStore %[[#reg_0]] %[[#]] Aligned 4
-; CHECK:         %[[#tmp:]] = OpLoad %[[#]] %[[#builtin]] Aligned 1
-; CHECK:                      OpStore %[[#idx]] %[[#tmp]] Aligned 4
-; CHECK:         %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]] Aligned 4
+; CHECK:                      OpStore %[[#reg_0]] %[[#]]
+; CHECK:         %[[#tmp:]] = OpLoad %[[#]] %[[#builtin]]
+; CHECK:                      OpStore %[[#idx]] %[[#tmp]]
+; CHECK:         %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]]
 ; CHECK:        %[[#cmp1:]] = OpIEqual %[[#bool_ty]] %[[#tmp]] %[[#int_0]]
 ; CHECK:                      OpBranchConditional %[[#cmp1]] %[[#new_end]] %[[#if_end:]]
 while.body:
@@ -53,10 +53,10 @@ while.body:
   br i1 %cmp1, label %if.then, label %if.end
 
 ; CHECK:               %[[#if_end]] = OpLabel
-; CHECK:                              OpStore %[[#reg_0]] %[[#]] Aligned 4
-; CHECK:                 %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#builtin]] Aligned 1
-; CHECK:                              OpStore %[[#idx]] %[[#tmp]] Aligned 4
-; CHECK:                 %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]] Aligned 4
+; CHECK:                              OpStore %[[#reg_0]] %[[#]]
+; CHECK:                 %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#builtin]]
+; CHECK:                              OpStore %[[#idx]] %[[#tmp]]
+; CHECK:                 %[[#tmp:]] = OpLoad %[[#int_ty]] %[[#idx]]
 ; CHECK:                %[[#cmp2:]] = OpIEqual %[[#bool_ty]] %[[#tmp]] %[[#int_0]]
 ; CHECK:                              OpBranchConditional %[[#cmp2]] %[[#new_end]] %[[#if_end2]]
 if.end:
@@ -72,7 +72,7 @@ if.end:
 ; TODO: this OpSwitch is useless. Improve the "remove useless branches" step of the structurizer to
 ;       cleanup those.
 ; CHECK:   %[[#new_end]] = OpLabel
-; CHECK:    %[[#route:]] = OpLoad %[[#]] %[[#reg_0]] Aligned 4
+; CHECK:    %[[#route:]] = OpLoad %[[#]] %[[#reg_0]]
 ; CHECK:                   OpSwitch %[[#route]] %[[#while_end:]] 1 %[[#while_end:]] 2 %[[#while_end:]]
 
 if.end2:

--- a/llvm/test/CodeGen/SPIRV/structurizer/return-early.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/return-early.ll
@@ -66,7 +66,7 @@ sw.bb:
 ; CHECK:                    OpBranchConditional %[[#tmp]] %[[#sw_default:]] %[[#while_end]]
 
 ; CHECK: %[[#sw_default]] = OpLabel
-; CHECK:                    OpStore %[[#]] %[[#B:]] Aligned 4
+; CHECK:                    OpStore %[[#]] %[[#B:]]
 ; CHECK:                    OpBranch %[[#for_cond:]]
 sw.default:
   store i32 0, ptr %i, align 4


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/135165