### PR TITLE
[CodeGen][NewPM] Name parameters in buildCodeGenPipeline

### DIFF
--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -485,10 +485,12 @@ public:
     return nullptr;
   }
 
-  virtual Error buildCodeGenPipeline(ModulePassManager &, raw_pwrite_stream &,
-                                     raw_pwrite_stream *, CodeGenFileType,
-                                     const CGPassBuilderOption &,
-                                     PassInstrumentationCallbacks *) {
+  virtual Error buildCodeGenPipeline(ModulePassManager &MPM,
+                                     raw_pwrite_stream &Out,
+                                     raw_pwrite_stream *DwoOut,
+                                     CodeGenFileType FileType,
+                                     const CGPassBuilderOption &Opt,
+                                     PassInstrumentationCallbacks *PIC) {
     return make_error<StringError>("buildCodeGenPipeline is not overridden",
                                    inconvertibleErrorCode());
   }

--- a/llvm/lib/Target/X86/X86TargetMachine.h
+++ b/llvm/lib/Target/X86/X86TargetMachine.h
@@ -71,10 +71,11 @@ public:
 
   void registerPassBuilderCallbacks(PassBuilder &PB) override;
 
-  Error buildCodeGenPipeline(ModulePassManager &, raw_pwrite_stream &,
-                             raw_pwrite_stream *, CodeGenFileType,
-                             const CGPassBuilderOption &,
-                             PassInstrumentationCallbacks *) override;
+  Error buildCodeGenPipeline(ModulePassManager &MPM, raw_pwrite_stream &Out,
+                             raw_pwrite_stream *DwoOut,
+                             CodeGenFileType FileType,
+                             const CGPassBuilderOption &Opt,
+                             PassInstrumentationCallbacks *PIC) override;
 
   bool isJIT() const { return IsJIT; }
 


### PR DESCRIPTION
This is consistent with the coding style, and makes things consistent
between the various header files/improves readability slightly.
