### PR TITLE
[alpha.webkit.NoDeleteChecker] Account for MacroQualifiedType

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -414,7 +414,10 @@ enum class WebKitAnnotation : uint8_t {
 
 static WebKitAnnotation typeAnnotationForReturnType(const FunctionDecl *FD) {
   auto RetType = FD->getReturnType();
-  auto *Attr = dyn_cast_or_null<AttributedType>(RetType.getTypePtrOrNull());
+  auto *Type = RetType.getTypePtrOrNull();
+  if (auto *MacroQualified = dyn_cast_or_null<MacroQualifiedType>(Type))
+    Type = MacroQualified->desugar().getTypePtrOrNull();
+  auto *Attr = dyn_cast_or_null<AttributedType>(Type);
   if (!Attr)
     return WebKitAnnotation::None;
   auto *AnnotateType = dyn_cast_or_null<AnnotateTypeAttr>(Attr->getAttr());

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -14,6 +14,13 @@ void [[clang::annotate_type("webkit.nodelete")]] callsUnsafe() {
   someFunction();
 }
 
+#define EXPORT_IMPORT __attribute__((visibility("default")))
+EXPORT_IMPORT unsigned [[clang::annotate_type("webkit.nodelete")]] safeFunctionWithAttr();
+
+void [[clang::annotate_type("webkit.nodelete")]] callsSafeWithAttribute() {
+  unsigned r = safeFunctionWithAttr();
+}
+
 void [[clang::annotate_type("webkit.nodelete")]] callsSafe() {
   safeFunction();
 }


### PR DESCRIPTION
This PR fixes typeAnnotationForReturnType to account for MacroQualifiedType.