### PR TITLE
[BPF] Fix crash on unsupported atomic operations

### DIFF
--- a/llvm/lib/Target/BPF/BPFISelLowering.cpp
+++ b/llvm/lib/Target/BPF/BPFISelLowering.cpp
@@ -339,9 +339,15 @@ void BPFTargetLowering::ReplaceNodeResults(
   }
 
   SDLoc DL(N);
-  // We'll still produce a fatal error downstream, but this diagnostic is more
-  // user-friendly.
   fail(DL, DAG, Msg);
+
+  // Provide dummy results so that compilation can terminate gracefully
+  // after emitting the diagnostic, instead of crashing in instruction
+  // selection.
+  for (unsigned I = 0, E = N->getNumValues(); I != E; ++I) {
+    EVT VT = N->getValueType(I);
+    Results.push_back(VT == MVT::Other ? N->getOperand(0) : DAG.getUNDEF(VT));
+  }
 }
 
 SDValue BPFTargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const {

--- a/llvm/test/CodeGen/BPF/atomics_i8_error.ll
+++ b/llvm/test/CodeGen/BPF/atomics_i8_error.ll
@@ -1,0 +1,8 @@
+; RUN: not llc -mtriple=bpf < %s 2> %t1
+; RUN: FileCheck %s < %t1
+; CHECK: unsupported atomic operation, please use 32/64 bit version
+
+define i8 @test(ptr %p) {
+  %val = atomicrmw add ptr %p, i8 1 seq_cst
+  ret i8 %val
+}

--- a/llvm/test/CodeGen/BPF/atomics_w32_error.ll
+++ b/llvm/test/CodeGen/BPF/atomics_w32_error.ll
@@ -1,0 +1,8 @@
+; RUN: not llc -mtriple=bpf -mcpu=v1 < %s 2> %t1
+; RUN: FileCheck %s < %t1
+; CHECK: unsupported atomic operation, please use 64 bit version
+
+define i32 @test(ptr %p) {
+  %val = atomicrmw and ptr %p, i32 1 seq_cst
+  ret i32 %val
+}


### PR DESCRIPTION
ReplaceNodeResults() emits a diagnostic for unsupported atomic operations on i8/i16 types (and i32 without ALU32) but does not populate the Results vector. This leads to a fatal crash in instruction selection.

Provide dummy undef results after the diagnostic so that compilation terminates gracefully with an error and no diagnostic.

Also add two tests for these error cases.