### PR TITLE
[libcxx] Run std::pop_heap() benchmarks on heap-ordered inputs only

### DIFF
--- a/libcxx/test/benchmarks/algorithms/pop_heap.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/pop_heap.bench.cpp
@@ -13,7 +13,7 @@
 #include "common.h"
 
 namespace {
-template <class ValueType>
+template <class ValueType, class Order>
 struct PopHeap {
   size_t Quantity;
 
@@ -25,6 +25,8 @@ struct PopHeap {
     });
   }
 
+  bool skip() const { return Order() != ::Order::Heap; }
+
   std::string name() const { return "BM_PopHeap" + ValueType::name() + "_" + std::to_string(Quantity); };
 };
 } // namespace
@@ -33,6 +35,6 @@ int main(int argc, char** argv) {
   benchmark::Initialize(&argc, argv);
   if (benchmark::ReportUnrecognizedArguments(argc, argv))
     return 1;
-  makeCartesianProductBenchmark<PopHeap, AllValueTypes>(Quantities);
+  makeCartesianProductBenchmark<PopHeap, AllValueTypes, AllOrders>(Quantities);
   benchmark::RunSpecifiedBenchmarks();
 }

--- a/libcxx/test/benchmarks/algorithms/ranges_pop_heap.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/ranges_pop_heap.bench.cpp
@@ -13,7 +13,7 @@
 #include "common.h"
 
 namespace {
-template <class ValueType>
+template <class ValueType, class Order>
 struct RangesPopHeap {
   size_t Quantity;
 
@@ -25,6 +25,8 @@ struct RangesPopHeap {
     });
   }
 
+  bool skip() const { return Order() != ::Order::Heap; }
+
   std::string name() const { return "BM_RangesPopHeap" + ValueType::name() + "_" + std::to_string(Quantity); };
 };
 } // namespace
@@ -33,6 +35,6 @@ int main(int argc, char** argv) {
   benchmark::Initialize(&argc, argv);
   if (benchmark::ReportUnrecognizedArguments(argc, argv))
     return 1;
-  makeCartesianProductBenchmark<RangesPopHeap, AllValueTypes>(Quantities);
+  makeCartesianProductBenchmark<RangesPopHeap, AllValueTypes, AllOrders>(Quantities);
   benchmark::RunSpecifiedBenchmarks();
 }


### PR DESCRIPTION
 * std::pop_heap() Standard specification requires it to run on heap-ordered inputs only.
   However, it looks like the current version runs it on randomly-ordered inputs,
   which makes the benchmark results a bit questionable.