### PR TITLE
[MLIR][Python] Add C and Python API for `mlir::DynamicAttr`

### DIFF
--- a/mlir/include/mlir-c/ExtensibleDialect.h
+++ b/mlir/include/mlir-c/ExtensibleDialect.h
@@ -33,6 +33,7 @@ extern "C" {
 
 DEFINE_C_API_STRUCT(MlirDynamicOpTrait, void);
 DEFINE_C_API_STRUCT(MlirDynamicTypeDefinition, void);
+DEFINE_C_API_STRUCT(MlirDynamicAttrDefinition, void);
 
 #undef DEFINE_C_API_STRUCT
 
@@ -112,6 +113,42 @@ mlirDynamicTypeDefinitionGetName(MlirDynamicTypeDefinition typeDef);
 /// Get the dialect that the given dynamic type definition belongs to.
 MLIR_CAPI_EXPORTED MlirDialect
 mlirDynamicTypeDefinitionGetDialect(MlirDynamicTypeDefinition typeDef);
+
+/// Look up a registered attribute definition by attribute name in the given
+/// dialect. Note that the dialect must be an extensible dialect.
+MLIR_CAPI_EXPORTED MlirDynamicAttrDefinition
+mlirExtensibleDialectLookupAttrDefinition(MlirDialect dialect,
+                                          MlirStringRef attrName);
+
+/// Check if the given attribute is a dynamic attribute.
+MLIR_CAPI_EXPORTED bool mlirAttributeIsADynamicAttr(MlirAttribute attr);
+
+/// Get the type ID of a dynamic attribute.
+MLIR_CAPI_EXPORTED MlirTypeID mlirDynamicAttrGetTypeID(void);
+
+/// Get a dynamic attribute by instantiating the given attribute definition with
+/// the provided attributes.
+MLIR_CAPI_EXPORTED MlirAttribute mlirDynamicAttrGet(
+    MlirDynamicAttrDefinition attrDef, MlirAttribute *attrs, intptr_t numAttrs);
+
+/// Get the number of parameters in the given dynamic attribute.
+MLIR_CAPI_EXPORTED intptr_t mlirDynamicAttrGetNumParams(MlirAttribute attr);
+
+/// Get the parameter at the given index in the provided dynamic attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirDynamicAttrGetParam(MlirAttribute attr,
+                                                         intptr_t index);
+
+/// Get the attribute definition of the given dynamic attribute.
+MLIR_CAPI_EXPORTED MlirDynamicAttrDefinition
+mlirDynamicAttrGetAttrDef(MlirAttribute attr);
+
+/// Get the name of the given dynamic attribute definition.
+MLIR_CAPI_EXPORTED MlirStringRef
+mlirDynamicAttrDefinitionGetName(MlirDynamicAttrDefinition attrDef);
+
+/// Get the dialect that the given dynamic attribute definition belongs to.
+MLIR_CAPI_EXPORTED MlirDialect
+mlirDynamicAttrDefinitionGetDialect(MlirDynamicAttrDefinition attrDef);
 
 #ifdef __cplusplus
 }

--- a/mlir/include/mlir/Bindings/Python/IRAttributes.h
+++ b/mlir/include/mlir/Bindings/Python/IRAttributes.h
@@ -588,6 +588,18 @@ public:
   static void bindDerived(ClassTy &c);
 };
 
+class MLIR_PYTHON_API_EXPORTED PyDynamicAttribute
+    : public PyConcreteAttribute<PyDynamicAttribute> {
+public:
+  static constexpr IsAFunctionTy isaFunction = mlirAttributeIsADynamicAttr;
+  static constexpr const char *pyClassName = "DynamicAttr";
+  using PyConcreteAttribute::PyConcreteAttribute;
+  static constexpr GetTypeIDFunctionTy getTypeIdFunction =
+      mlirDynamicAttrGetTypeID;
+
+  static void bindDerived(ClassTy &c);
+};
+
 MLIR_PYTHON_API_EXPORTED void populateIRAttributes(nanobind::module_ &m);
 } // namespace MLIR_BINDINGS_PYTHON_DOMAIN
 } // namespace python

--- a/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
+++ b/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
@@ -16,6 +16,7 @@ using namespace mlir;
 
 DEFINE_C_API_PTR_METHODS(MlirDynamicOpTrait, DynamicOpTrait)
 DEFINE_C_API_PTR_METHODS(MlirDynamicTypeDefinition, DynamicTypeDefinition)
+DEFINE_C_API_PTR_METHODS(MlirDynamicAttrDefinition, DynamicAttrDefinition)
 
 bool mlirDynamicOpTraitAttach(MlirDynamicOpTrait dynamicOpTrait,
                               MlirStringRef opName, MlirContext context) {
@@ -136,4 +137,51 @@ mlirDynamicTypeDefinitionGetName(MlirDynamicTypeDefinition typeDef) {
 MlirDialect
 mlirDynamicTypeDefinitionGetDialect(MlirDynamicTypeDefinition typeDef) {
   return wrap(unwrap(typeDef)->getDialect());
+}
+
+MlirDynamicAttrDefinition
+mlirExtensibleDialectLookupAttrDefinition(MlirDialect dialect,
+                                          MlirStringRef attrName) {
+  return wrap(llvm::cast<mlir::ExtensibleDialect>(unwrap(dialect))
+                  ->lookupAttrDefinition(unwrap(attrName)));
+}
+
+bool mlirAttributeIsADynamicAttr(MlirAttribute attr) {
+  return llvm::isa<mlir::DynamicAttr>(unwrap(attr));
+}
+
+MlirTypeID mlirDynamicAttrGetTypeID(void) {
+  return wrap(mlir::DynamicAttr::getTypeID());
+}
+
+MlirAttribute mlirDynamicAttrGet(MlirDynamicAttrDefinition attrDef,
+                                 MlirAttribute *attrs, intptr_t numAttrs) {
+  llvm::SmallVector<mlir::Attribute> attributes;
+  attributes.reserve(numAttrs);
+  for (intptr_t i = 0; i < numAttrs; ++i)
+    attributes.push_back(unwrap(attrs[i]));
+
+  return wrap(mlir::DynamicAttr::get(unwrap(attrDef), attributes));
+}
+
+intptr_t mlirDynamicAttrGetNumParams(MlirAttribute attr) {
+  return llvm::cast<mlir::DynamicAttr>(unwrap(attr)).getParams().size();
+}
+
+MlirAttribute mlirDynamicAttrGetParam(MlirAttribute attr, intptr_t index) {
+  return wrap(llvm::cast<mlir::DynamicAttr>(unwrap(attr)).getParams()[index]);
+}
+
+MlirDynamicAttrDefinition mlirDynamicAttrGetAttrDef(MlirAttribute attr) {
+  return wrap(llvm::cast<mlir::DynamicAttr>(unwrap(attr)).getAttrDef());
+}
+
+MlirStringRef
+mlirDynamicAttrDefinitionGetName(MlirDynamicAttrDefinition attrDef) {
+  return wrap(unwrap(attrDef)->getName());
+}
+
+MlirDialect
+mlirDynamicAttrDefinitionGetDialect(MlirDynamicAttrDefinition attrDef) {
+  return wrap(unwrap(attrDef)->getDialect());
 }


### PR DESCRIPTION
This PR adds C and Python API support for `mlir::DynamicAttr`. It primarily enables attributes in dialects that are dynamically generated via IRDL to be constructed in Python, and allows retrieving the parameters contained in a dynamic attribute from Python.

This PR is quite similiar to #182751, so I use tab to autocomplete some code via github copilot, but manually verified.