### PR TITLE
[InstCombine] Restrict foldICmpOfVectorReduce to one-use

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -7540,9 +7540,11 @@ static Instruction *foldICmpOfVectorReduce(ICmpInst &I, const DataLayout &DL,
   // with a bitcast.
   Value *Vec;
   if ((match(Const, m_ZeroInt()) &&
-       match(Op, m_Intrinsic<Intrinsic::vector_reduce_or>(m_Value(Vec)))) ||
+       match(Op, m_OneUse(m_Intrinsic<Intrinsic::vector_reduce_or>(
+                     m_Value(Vec))))) ||
       (match(Const, m_AllOnes()) &&
-       match(Op, m_Intrinsic<Intrinsic::vector_reduce_and>(m_Value(Vec))))) {
+       match(Op, m_OneUse(m_Intrinsic<Intrinsic::vector_reduce_and>(
+                     m_Value(Vec)))))) {
     auto *VecTy = dyn_cast<FixedVectorType>(Vec->getType());
     if (!VecTy)
       return nullptr;

--- a/llvm/test/Transforms/InstCombine/icmp-vector-bitwise-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-vector-bitwise-reductions.ll
@@ -99,3 +99,20 @@ define i1 @scalable(<vscale x 4 x i8> %v) {
   %cmp = icmp eq i8 %red, -1
   ret i1 %cmp
 }
+
+define i1 @multiuse(<4 x i16> %v) {
+; CHECK-LABEL: define i1 @multiuse(
+; CHECK-SAME: <4 x i16> [[V:%.*]]) {
+; CHECK-NEXT:    [[RED:%.*]] = call i16 @llvm.vector.reduce.or.v4i16(<4 x i16> [[V]])
+; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x i16> [[V]] to i64
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[TMP1]], 0
+; CHECK-NEXT:    [[USE:%.*]] = trunc i16 [[RED]] to i1
+; CHECK-NEXT:    [[RET:%.*]] = xor i1 [[CMP]], [[USE]]
+; CHECK-NEXT:    ret i1 [[RET]]
+;
+  %red = call i16 @llvm.vector.reduce.or.v4i16(<4 x i16> %v)
+  %cmp = icmp ne i16 %red, 0
+  %use = trunc i16 %red to i1
+  %ret = xor i1 %use, %cmp
+  ret i1 %ret
+}

--- a/llvm/test/Transforms/InstCombine/icmp-vector-bitwise-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-vector-bitwise-reductions.ll
@@ -104,8 +104,7 @@ define i1 @multiuse(<4 x i16> %v) {
 ; CHECK-LABEL: define i1 @multiuse(
 ; CHECK-SAME: <4 x i16> [[V:%.*]]) {
 ; CHECK-NEXT:    [[RED:%.*]] = call i16 @llvm.vector.reduce.or.v4i16(<4 x i16> [[V]])
-; CHECK-NEXT:    [[TMP1:%.*]] = bitcast <4 x i16> [[V]] to i64
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i64 [[TMP1]], 0
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i16 [[RED]], 0
 ; CHECK-NEXT:    [[USE:%.*]] = trunc i16 [[RED]] to i1
 ; CHECK-NEXT:    [[RET:%.*]] = xor i1 [[CMP]], [[USE]]
 ; CHECK-NEXT:    ret i1 [[RET]]

--- a/llvm/test/Transforms/InstCombine/icmp-vector-bitwise-reductions.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-vector-bitwise-reductions.ll
@@ -100,18 +100,32 @@ define i1 @scalable(<vscale x 4 x i8> %v) {
   ret i1 %cmp
 }
 
-define i1 @multiuse(<4 x i16> %v) {
-; CHECK-LABEL: define i1 @multiuse(
+declare void @use(i16)
+
+define i1 @multiuse.or(<4 x i16> %v) {
+; CHECK-LABEL: define i1 @multiuse.or(
 ; CHECK-SAME: <4 x i16> [[V:%.*]]) {
 ; CHECK-NEXT:    [[RED:%.*]] = call i16 @llvm.vector.reduce.or.v4i16(<4 x i16> [[V]])
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i16 [[RED]], 0
-; CHECK-NEXT:    [[USE:%.*]] = trunc i16 [[RED]] to i1
-; CHECK-NEXT:    [[RET:%.*]] = xor i1 [[CMP]], [[USE]]
-; CHECK-NEXT:    ret i1 [[RET]]
+; CHECK-NEXT:    call void @use(i16 [[RED]])
+; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %red = call i16 @llvm.vector.reduce.or.v4i16(<4 x i16> %v)
   %cmp = icmp ne i16 %red, 0
-  %use = trunc i16 %red to i1
-  %ret = xor i1 %use, %cmp
-  ret i1 %ret
+  call void @use(i16 %red)
+  ret i1 %cmp
+}
+
+define i1 @multiuse.and(<4 x i16> %v) {
+; CHECK-LABEL: define i1 @multiuse.and(
+; CHECK-SAME: <4 x i16> [[V:%.*]]) {
+; CHECK-NEXT:    [[RED:%.*]] = call i16 @llvm.vector.reduce.and.v4i16(<4 x i16> [[V]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i16 [[RED]], 0
+; CHECK-NEXT:    call void @use(i16 [[RED]])
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %red = call i16 @llvm.vector.reduce.and.v4i16(<4 x i16> %v)
+  %cmp = icmp ne i16 %red, 0
+  call void @use(i16 %red)
+  ret i1 %cmp
 }


### PR DESCRIPTION
Follow up on 279b3dbe ([InstCombine] Fold icmp (vreduce_(or|and) %x), (0|-1), #182684) to fix a regression by restricting the fold to one-use.

Regression: https://godbolt.org/z/f38b169MM