### PR TITLE
[libc] Enable ifunc support in static startup

### DIFF
--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -266,6 +266,15 @@ add_proxy_header_library(
     libc.include.stdint
 )
 
+add_proxy_header_library(
+  elf_macros
+  HDRS
+    elf_macros.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-macros.elf_macros
+    libc.include.elf
+)
+
 add_gen_header(
   elf_proxy
   YAML_FILE

--- a/libc/include/elf.yaml
+++ b/libc/include/elf.yaml
@@ -441,12 +441,14 @@ macros:
   - macro_name: GNU_PROPERTY_X86_FEATURE_1_SHSTK
     macro_value: '0x00000002'
   # Architecture-specific IRELATIVE relocation types
-  - macro_name: R_X86_64_IRELATIVE
-    macro_value: 37
   - macro_name: R_AARCH64_IRELATIVE
     macro_value: 1032
+  - macro_name: R_ARM_IRELATIVE
+    macro_value: 160
   - macro_name: R_RISCV_IRELATIVE
     macro_value: 58
+  - macro_name: R_X86_64_IRELATIVE
+    macro_value: 37
 types:
   - type_name: Elf32_Addr
   - type_name: Elf32_Chdr

--- a/libc/include/elf.yaml
+++ b/libc/include/elf.yaml
@@ -440,6 +440,13 @@ macros:
     macro_value: '0xc0000002'
   - macro_name: GNU_PROPERTY_X86_FEATURE_1_SHSTK
     macro_value: '0x00000002'
+  # Architecture-specific IRELATIVE relocation types
+  - macro_name: R_X86_64_IRELATIVE
+    macro_value: 37
+  - macro_name: R_AARCH64_IRELATIVE
+    macro_value: 1032
+  - macro_name: R_RISCV_IRELATIVE
+    macro_value: 58
 types:
   - type_name: Elf32_Addr
   - type_name: Elf32_Chdr

--- a/libc/include/llvm-libc-macros/elf-macros.h
+++ b/libc/include/llvm-libc-macros/elf-macros.h
@@ -1,4 +1,4 @@
-//===-- Definition of macros from elf.h -----------------------------------===//
+//===-- Definition of macros from elf.h ------------------------ *- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -31,5 +31,11 @@
 #define ELF64_R_SYM(i) ((i) >> 32)
 #define ELF64_R_TYPE(i) ((i) & 0xffffffffL)
 #define ELF64_R_INFO(s, t) (((s) << 32) + ((t) & 0xffffffffL))
+
+// Architecture-specific IRELATIVE relocation types
+
+#define R_X86_64_IRELATIVE 37
+#define R_AARCH64_IRELATIVE 1032
+#define R_RISCV_IRELATIVE 58
 
 #endif // LLVM_LIBC_MACROS_ELF_MACROS_H

--- a/libc/include/llvm-libc-macros/elf-macros.h
+++ b/libc/include/llvm-libc-macros/elf-macros.h
@@ -1,4 +1,4 @@
-//===-- Definition of macros from elf.h ------------------------ *- C++ -*-===//
+//===-- Definition of macros from elf.h -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -31,11 +31,5 @@
 #define ELF64_R_SYM(i) ((i) >> 32)
 #define ELF64_R_TYPE(i) ((i) & 0xffffffffL)
 #define ELF64_R_INFO(s, t) (((s) << 32) + ((t) & 0xffffffffL))
-
-// Architecture-specific IRELATIVE relocation types
-
-#define R_X86_64_IRELATIVE 37
-#define R_AARCH64_IRELATIVE 1032
-#define R_RISCV_IRELATIVE 58
 
 #endif // LLVM_LIBC_MACROS_ELF_MACROS_H

--- a/libc/startup/linux/CMakeLists.txt
+++ b/libc/startup/linux/CMakeLists.txt
@@ -107,6 +107,7 @@ add_object_library(
     do_start.cpp
   HDRS
     do_start.h
+    irelative.h
   DEPENDS
     libc.config.app_h
     libc.hdr.elf_proxy
@@ -117,6 +118,8 @@ add_object_library(
     libc.src.__support.OSUtil.linux.auxv
     libc.src.__support.OSUtil.osutil
     libc.src.__support.threads.thread
+    libc.src.__support.macros.config
+    libc.startup.linux.${LIBC_TARGET_ARCHITECTURE}.irelative
     libc.src.stdlib.exit
     libc.src.stdlib.atexit
     libc.src.unistd.environ
@@ -131,6 +134,7 @@ merge_relocatable_object(
   crt1
   .${LIBC_TARGET_ARCHITECTURE}.start
   .${LIBC_TARGET_ARCHITECTURE}.tls
+  .${LIBC_TARGET_ARCHITECTURE}.irelative
   .do_start
   .gnu_property_section
 )

--- a/libc/startup/linux/aarch64/CMakeLists.txt
+++ b/libc/startup/linux/aarch64/CMakeLists.txt
@@ -23,3 +23,19 @@ add_startup_object(
     -fno-omit-frame-pointer
     -ffreestanding # To avoid compiler warnings about calling the main function.
 )
+
+add_startup_object(
+  irelative
+  SRC
+    irelative.cpp
+  DEPENDS
+    libc.hdr.link_macros
+    libc.hdr.elf_macros
+    libc.hdr.stdint_proxy
+    libc.src.__support.macros.config
+  COMPILE_OPTIONS
+    -fno-stack-protector
+    -fno-omit-frame-pointer
+    -ffreestanding
+    -fno-builtin
+)

--- a/libc/startup/linux/aarch64/CMakeLists.txt
+++ b/libc/startup/linux/aarch64/CMakeLists.txt
@@ -31,6 +31,7 @@ add_startup_object(
   DEPENDS
     libc.hdr.link_macros
     libc.hdr.elf_macros
+    libc.hdr.elf_proxy
     libc.hdr.stdint_proxy
     libc.src.__support.macros.config
   COMPILE_OPTIONS

--- a/libc/startup/linux/aarch64/irelative.cpp
+++ b/libc/startup/linux/aarch64/irelative.cpp
@@ -1,0 +1,39 @@
+//===-- Implementation of apply_irelative_relocs (AArch64) ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "startup/linux/irelative.h"
+#include "hdr/elf_macros.h"
+#include "hdr/link_macros.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+void apply_irelative_relocs(intptr_t base, unsigned long hwcap,
+                            unsigned long hwcap2) {
+  for (const ElfW(Rela) *rela = __rela_iplt_start; rela != __rela_iplt_end;
+       ++rela) {
+    if (ELF64_R_TYPE(rela->r_info) != R_AARCH64_IRELATIVE)
+      continue;
+
+    // AArch64 resolvers receive hwcap and hwcap2.
+    // Use unsigned arithmetic to avoid undefined behavior on signed overflow,
+    // which can occur with very large binaries or high load addresses.
+    uintptr_t resolver_addr =
+        static_cast<uintptr_t>(base) + static_cast<uintptr_t>(rela->r_addend);
+    auto resolver =
+        reinterpret_cast<uintptr_t (*)(unsigned long, unsigned long)>(
+            resolver_addr);
+    uintptr_t result = resolver(hwcap, hwcap2);
+
+    // Write the resolved function pointer to the target location.
+    uintptr_t target_addr = static_cast<uintptr_t>(base) + rela->r_offset;
+    *reinterpret_cast<uintptr_t *>(target_addr) = result;
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/startup/linux/aarch64/irelative.cpp
+++ b/libc/startup/linux/aarch64/irelative.cpp
@@ -8,6 +8,7 @@
 
 #include "startup/linux/irelative.h"
 #include "hdr/elf_macros.h"
+#include "hdr/elf_proxy.h"
 #include "hdr/link_macros.h"
 #include "src/__support/macros/config.h"
 

--- a/libc/startup/linux/irelative.h
+++ b/libc/startup/linux/irelative.h
@@ -1,0 +1,34 @@
+//===-- Implementation header for IRELATIVE relocations -------- *- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_STARTUP_LINUX_IRELATIVE_H
+#define LLVM_LIBC_STARTUP_LINUX_IRELATIVE_H
+
+#include "hdr/link_macros.h"
+#include "hdr/stdint_proxy.h"
+#include "src/__support/macros/config.h"
+
+extern "C" {
+[[gnu::weak, gnu::visibility("hidden")]] extern const ElfW(Rela)
+    __rela_iplt_start[]; // NOLINT
+[[gnu::weak, gnu::visibility("hidden")]] extern const ElfW(Rela)
+    __rela_iplt_end[]; // NOLINT
+}
+
+namespace LIBC_NAMESPACE_DECL {
+
+// Process IRELATIVE relocations (ifunc resolvers).
+// base is the load bias (actual load address − link-time address).  It is
+// intptr_t (signed) because it is a difference; it is negative if the binary
+// loaded below its link address. (unlikely but possible in principle)
+void apply_irelative_relocs(intptr_t base, unsigned long hwcap,
+                            unsigned long hwcap2);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_STARTUP_LINUX_IRELATIVE_H

--- a/libc/startup/linux/riscv/CMakeLists.txt
+++ b/libc/startup/linux/riscv/CMakeLists.txt
@@ -24,3 +24,19 @@ add_startup_object(
     -fno-omit-frame-pointer
     -ffreestanding # To avoid compiler warnings about calling the main function.
 )
+
+add_startup_object(
+  irelative
+  SRC
+    irelative.cpp
+  DEPENDS
+    libc.hdr.link_macros
+    libc.hdr.elf_macros
+    libc.hdr.stdint_proxy
+    libc.src.__support.macros.config
+  COMPILE_OPTIONS
+    -fno-stack-protector
+    -fno-omit-frame-pointer
+    -ffreestanding
+    -fno-builtin
+)

--- a/libc/startup/linux/riscv/CMakeLists.txt
+++ b/libc/startup/linux/riscv/CMakeLists.txt
@@ -32,6 +32,7 @@ add_startup_object(
   DEPENDS
     libc.hdr.link_macros
     libc.hdr.elf_macros
+    libc.hdr.elf_proxy
     libc.hdr.stdint_proxy
     libc.src.__support.macros.config
   COMPILE_OPTIONS

--- a/libc/startup/linux/riscv/irelative.cpp
+++ b/libc/startup/linux/riscv/irelative.cpp
@@ -1,0 +1,46 @@
+//===-- Implementation of apply_irelative_relocs (RISC-V) -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "startup/linux/irelative.h"
+#include "hdr/elf_macros.h"
+#include "hdr/link_macros.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// RISC-V may be 32-bit or 64-bit. ElfW(Rela) handles the struct type,
+// but we need the correct R_TYPE extraction macro.
+static LIBC_INLINE constexpr unsigned get_r_type(uintptr_t info) {
+#ifdef __LP64__
+  return ELF64_R_TYPE(info);
+#else
+  return ELF32_R_TYPE(info);
+#endif
+}
+
+void apply_irelative_relocs(intptr_t base, unsigned long /*hwcap*/,
+                            unsigned long /*hwcap2*/) {
+  for (const ElfW(Rela) *rela = __rela_iplt_start; rela != __rela_iplt_end;
+       ++rela) {
+    if (get_r_type(rela->r_info) != R_RISCV_IRELATIVE)
+      continue;
+
+    // RISC-V resolvers take no arguments (same as x86_64).
+    // Use unsigned arithmetic to avoid undefined behavior on signed overflow,
+    // which can occur with very large binaries or high load addresses.
+    uintptr_t resolver_addr =
+        static_cast<uintptr_t>(base) + static_cast<uintptr_t>(rela->r_addend);
+    auto resolver = reinterpret_cast<uintptr_t (*)(void)>(resolver_addr);
+    uintptr_t result = resolver();
+
+    uintptr_t target_addr = static_cast<uintptr_t>(base) + rela->r_offset;
+    *reinterpret_cast<uintptr_t *>(target_addr) = result;
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/startup/linux/riscv/irelative.cpp
+++ b/libc/startup/linux/riscv/irelative.cpp
@@ -8,6 +8,7 @@
 
 #include "startup/linux/irelative.h"
 #include "hdr/elf_macros.h"
+#include "hdr/elf_proxy.h"
 #include "hdr/link_macros.h"
 #include "src/__support/macros/config.h"
 

--- a/libc/startup/linux/x86_64/CMakeLists.txt
+++ b/libc/startup/linux/x86_64/CMakeLists.txt
@@ -28,3 +28,19 @@ add_startup_object(
     -ffreestanding
     -fno-builtin
 )
+
+add_startup_object(
+  irelative
+  SRC
+    irelative.cpp
+  DEPENDS
+    libc.hdr.link_macros
+    libc.hdr.elf_macros
+    libc.hdr.stdint_proxy
+    libc.src.__support.macros.config
+  COMPILE_OPTIONS
+    -fno-stack-protector
+    -fno-omit-frame-pointer
+    -ffreestanding
+    -fno-builtin
+)

--- a/libc/startup/linux/x86_64/CMakeLists.txt
+++ b/libc/startup/linux/x86_64/CMakeLists.txt
@@ -36,6 +36,7 @@ add_startup_object(
   DEPENDS
     libc.hdr.link_macros
     libc.hdr.elf_macros
+    libc.hdr.elf_proxy
     libc.hdr.stdint_proxy
     libc.src.__support.macros.config
   COMPILE_OPTIONS

--- a/libc/startup/linux/x86_64/irelative.cpp
+++ b/libc/startup/linux/x86_64/irelative.cpp
@@ -1,0 +1,36 @@
+//===-- Implementation of apply_irelative_relocs (x86_64) -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "startup/linux/irelative.h"
+#include "hdr/elf_macros.h"
+#include "hdr/link_macros.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+void apply_irelative_relocs(intptr_t base, unsigned long /*hwcap*/,
+                            unsigned long /*hwcap2*/) {
+  for (const ElfW(Rela) *rela = __rela_iplt_start; rela != __rela_iplt_end;
+       ++rela) {
+    if (ELF64_R_TYPE(rela->r_info) != R_X86_64_IRELATIVE)
+      continue;
+
+    // x86_64 resolvers take no arguments.
+    // Use unsigned arithmetic to avoid undefined behavior on signed overflow,
+    // which can occur with very large binaries or high load addresses.
+    uintptr_t resolver_addr =
+        static_cast<uintptr_t>(base) + static_cast<uintptr_t>(rela->r_addend);
+    auto resolver = reinterpret_cast<uintptr_t (*)(void)>(resolver_addr);
+    uintptr_t result = resolver();
+
+    uintptr_t target_addr = static_cast<uintptr_t>(base) + rela->r_offset;
+    *reinterpret_cast<uintptr_t *>(target_addr) = result;
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/startup/linux/x86_64/irelative.cpp
+++ b/libc/startup/linux/x86_64/irelative.cpp
@@ -8,6 +8,7 @@
 
 #include "startup/linux/irelative.h"
 #include "hdr/elf_macros.h"
+#include "hdr/elf_proxy.h"
 #include "hdr/link_macros.h"
 #include "src/__support/macros/config.h"
 

--- a/libc/test/integration/startup/linux/CMakeLists.txt
+++ b/libc/test/integration/startup/linux/CMakeLists.txt
@@ -49,3 +49,17 @@ add_integration_test(
   SRCS
     init_fini_array_test.cpp
 )
+
+add_integration_test(
+  startup_irelative_test
+  SUITE libc-startup-tests
+  SRCS
+    irelative_test.cpp
+)
+
+add_integration_test(
+  startup_irelative_no_ifunc_test
+  SUITE libc-startup-tests
+  SRCS
+    irelative_no_ifunc_test.cpp
+)

--- a/libc/test/integration/startup/linux/irelative_no_ifunc_test.cpp
+++ b/libc/test/integration/startup/linux/irelative_no_ifunc_test.cpp
@@ -1,0 +1,16 @@
+//===-- Implementation of apply_irelative_relocs (no ifunc) test ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "startup/linux/irelative.h"
+#include "test/IntegrationTest/test.h"
+
+TEST_MAIN() {
+  ASSERT_EQ(reinterpret_cast<uintptr_t>(__rela_iplt_start),
+            reinterpret_cast<uintptr_t>(__rela_iplt_end));
+  return 0;
+}

--- a/libc/test/integration/startup/linux/irelative_test.cpp
+++ b/libc/test/integration/startup/linux/irelative_test.cpp
@@ -1,0 +1,48 @@
+//===-- Implementation of apply_irelative_relocs test ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "test/IntegrationTest/test.h"
+
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#if __has_attribute(ifunc)
+
+// Two trivial implementations that return different constants.
+static int impl_a() { return 42; }
+static int impl_b() { return 84; }
+
+// The resolver function. On x86_64 this takes no arguments; on AArch64 it
+// receives (hwcap, hwcap2). We use extern "C" to ensure C linkage for the
+// ifunc attribute.
+extern "C" {
+// Declare the resolver to return a generic function pointer.
+// For testing, unconditionally select impl_a.
+void *my_ifunc_resolver() {
+  (void)impl_b; // Suppress unused warning.
+  return reinterpret_cast<void *>(impl_a);
+}
+}
+
+// Declare the ifunc. The compiler and linker will generate an IRELATIVE
+// relocation that calls my_ifunc_resolver at startup.
+extern "C" int my_ifunc() __attribute__((ifunc("my_ifunc_resolver")));
+
+TEST_MAIN() {
+  // If IRELATIVE processing works correctly, my_ifunc() should call impl_a
+  // and return 42.
+  ASSERT_EQ(my_ifunc(), 42);
+  return 0;
+}
+
+#else
+
+TEST_MAIN() { return 0; }
+
+#endif


### PR DESCRIPTION
Resolves ifunc targets before `main()` runs in static libc

This enables static binaries to use ifunc-based dispatch during early process startup, so optimized implementations can be selected based on CPU features. Without this relocation step in startup, those targets are not ready when program code begins executing.

This change:
- adds IRELATIVE relocation handling for x86_64, AArch64, and RISC-V,
- reads `AT_HWCAP` / `AT_HWCAP2` from auxv and passes them to resolvers where required (notably AArch64),
- runs IRELATIVE processing after base-address discovery and before TLS setup,
- adds integration tests for both the ifunc path and the no-ifunc path.
- Changed the load bias type for ptrdiff_t to intptr_t to align with IRELATIVE handling, which uses intptr_t for load bias calculations.