### PR TITLE
[mlir][gpu] Validate `gpu-module-to-binary` format

### DIFF
--- a/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
@@ -44,8 +44,10 @@ void GpuModuleToBinaryPass::runOnOperation() {
           .Cases({"binary", "bin"}, CompilationTarget::Binary)
           .Cases({"fatbinary", "fatbin"}, CompilationTarget::Fatbin)
           .Default(std::nullopt);
-  if (!targetFormat)
+  if (!targetFormat) {
     getOperation()->emitError() << "Invalid format specified.";
+    return signalPassFailure();
+  }
 
   // Lazy symbol table builder callback.
   std::optional<SymbolTable> parentTable;

--- a/mlir/test/Dialect/GPU/module-to-binary-invalid-format.mlir
+++ b/mlir/test/Dialect/GPU/module-to-binary-invalid-format.mlir
@@ -1,0 +1,5 @@
+// RUN: mlir-opt %s --gpu-module-to-binary="format=invalid-format" --verify-diagnostics
+
+// expected-error @+1 {{Invalid format specified.}}
+module attributes {gpu.container_module} {
+}


### PR DESCRIPTION
`GpuModuleToBinaryPass::runOnOperation` now treats an unsupported `format` value as a pass failure after emitting `"Invalid format specified."`.

Add a regression test in `mlir/test/Dialect/GPU/module-to-binary-invalid-format.mlir`.

Fix: https://github.com/llvm/llvm-project/issues/77052
Fix: https://github.com/llvm/llvm-project/issues/116344
Fix: https://github.com/llvm/llvm-project/issues/116346
Fix: https://github.com/llvm/llvm-project/issues/116352
