### PR TITLE
[clang-tidy] Fix bugprone-casting-through-void to run only on C++ code

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/CastingThroughVoidCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/CastingThroughVoidCheck.h
@@ -22,6 +22,9 @@ public:
       : ClangTidyCheck(Name, Context) {}
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
   std::optional<TraversalKind> getCheckTraversalKind() const override {
     return TK_IgnoreUnlessSpelledInSource;
   }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -153,6 +153,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/bad-signal-to-kill-thread>` check by fixing false
   negatives when the ``SIGTERM`` macro is obtained from a precompiled header.
 
+- Improved :doc:`bugprone-casting-through-void
+  <clang-tidy/checks/bugprone/casting-through-void>` check by running only on
+  C++ files because suggested ``reinterpret_cast`` is not available in pure C.
+
 - Improved :doc:`bugprone-exception-escape
   <clang-tidy/checks/bugprone/exception-escape>` check by adding
   `TreatFunctionsWithoutSpecificationAsThrowing` option to support reporting

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/casting-through-void.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/casting-through-void.c
@@ -1,0 +1,11 @@
+// RUN: clang-tidy -checks='-*,bugprone-casting-through-void' %s -- -std=c99 2>&1 | FileCheck %s --allow-empty
+// CHECK-NOT: warning:
+
+double d = 100;
+
+void normal_test() {
+  (int *)(void *)&d;
+  int x = 1;
+  char *y = (char*)(void*)&x;
+  char *z = (char*)&x;
+}


### PR DESCRIPTION
This check tells users to use `reinterpret_cast`, which is not possible in pure C code.