### PR TITLE
Re-enable MSVC C4722 diagnostic; NFC

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -755,7 +755,6 @@ if (MSVC)
       -wd4458 # Suppress 'declaration of 'var' hides class member'
       -wd4459 # Suppress 'declaration of 'var' hides global declaration'
       -wd4624 # Suppress ''derived class' : destructor could not be generated because a base class destructor is inaccessible'
-      -wd4722 # Suppress 'function' : destructor never returns, potential memory leak
       -wd4100 # Suppress 'unreferenced formal parameter'
       -wd4127 # Suppress 'conditional expression is constant'
       -wd4512 # Suppress 'assignment operator could not be generated'


### PR DESCRIPTION
From MSDN:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4722?view=msvc-170

> 'function' : destructor never returns, potential memory leak

This diagnostic was disabled in 24fdbe567638d942fff6b1cf3df3cb4f5adf6823 as not having value for us, but enabling the diagnostic triggers no new warnings, so I believe it's safe for us to re-enable. It may not be the most valuable diagnostic, but knowing about non-returning destructors is still good for code health.