### PR TITLE
[Offload] Fix copy-elision warning

### DIFF
--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1077,7 +1077,7 @@ Expected<void *> PinnedAllocationMapTy::registerMemory(void *HstPtr,
   auto IsPinnedOrErr = Device.isPinnedPtrImpl(HstPtr, BaseHstPtr,
                                               BaseDevAccessiblePtr, BaseSize);
   if (!IsPinnedOrErr)
-    return std::move(IsPinnedOrErr.takeError());
+    return IsPinnedOrErr.takeError();
 
   // If pinned, just insert the entry representing the whole pinned buffer.
   if (*IsPinnedOrErr) {
@@ -1095,7 +1095,7 @@ Expected<void *> PinnedAllocationMapTy::registerMemory(void *HstPtr,
   // host buffer and retrieve the device accessible pointer.
   auto DevAccessiblePtrOrErr = Device.dataLockImpl(HstPtr, Size);
   if (!DevAccessiblePtrOrErr)
-    return std::move(DevAccessiblePtrOrErr.takeError());
+    return DevAccessiblePtrOrErr.takeError();
 
   // Now insert the new entry into the map.
   if (auto Err = insertEntry(HstPtr, *DevAccessiblePtrOrErr, Size))


### PR DESCRIPTION
This fixes a warning about a prohibited copy-elision due to the move of a temporary object.