### PR TITLE
[WebAssembly] optimize ext + shuffle + add into addext

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
@@ -1562,6 +1562,23 @@ multiclass ExtAddPairwiseShuffle<ValueType from_ty, ValueType to_ty, string suff
                                   (i32 srcvalue), (i32 srcvalue), (i32 srcvalue), (i32 srcvalue),
                                   (i32 srcvalue), (i32 srcvalue), (i32 srcvalue), (i32 srcvalue)))))),
               (!cast<Instruction>("extadd_pairwise_"#sign#"_"#suffix) V128:$vec)>;
+
+    def : Pat<(to_ty (add
+                    (wasm_shuffle
+                      (to_ty (!cast<SDNode>("extend_low_"#sign)  (from_ty V128:$vec))),
+                      (to_ty (!cast<SDNode>("extend_high_"#sign) (from_ty V128:$vec))),
+                      (i32 0),  (i32 1),  (i32 2),  (i32 3),
+                      (i32 8),  (i32 9),  (i32 10), (i32 11),
+                      (i32 16), (i32 17), (i32 18), (i32 19),
+                      (i32 24), (i32 25), (i32 26), (i32 27)),
+                    (wasm_shuffle
+                      (to_ty (!cast<SDNode>("extend_low_"#sign)  (from_ty V128:$vec))),
+                      (to_ty (!cast<SDNode>("extend_high_"#sign) (from_ty V128:$vec))),
+                      (i32 4),  (i32 5),  (i32 6),  (i32 7),
+                      (i32 12), (i32 13), (i32 14), (i32 15),
+                      (i32 20), (i32 21), (i32 22), (i32 23),
+                      (i32 28), (i32 29), (i32 30), (i32 31)))),
+              (!cast<Instruction>("extadd_pairwise_"#sign#"_"#suffix) V128:$vec)>;
   }
 }
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
@@ -1546,7 +1546,7 @@ def : Pat<(v4i32 (int_wasm_extadd_pairwise_signed (v8i16 V128:$in))),
 def : Pat<(v8i16 (int_wasm_extadd_pairwise_signed (v16i8 V128:$in))),
           (extadd_pairwise_s_I16x8 V128:$in)>;
 
-multiclass ExtAddPairwiseShuffle<ValueType from_ty, ValueType to_ty, string suffix,
+multiclass ExtAddPairwiseExtendShuffle<ValueType from_ty, ValueType to_ty, string suffix,
                               int a0, int a1, int a2, int a3, int a4, int a5, int a6, int a7,
                               int b0, int b1, int b2, int b3, int b4, int b5, int b6, int b7> {
   foreach sign = ["s", "u"] in {
@@ -1562,32 +1562,64 @@ multiclass ExtAddPairwiseShuffle<ValueType from_ty, ValueType to_ty, string suff
                                   (i32 srcvalue), (i32 srcvalue), (i32 srcvalue), (i32 srcvalue),
                                   (i32 srcvalue), (i32 srcvalue), (i32 srcvalue), (i32 srcvalue)))))),
               (!cast<Instruction>("extadd_pairwise_"#sign#"_"#suffix) V128:$vec)>;
+  }
+}
 
+defm : ExtAddPairwiseExtendShuffle<v8i16, v4i32, "I32x4",
+                         0, 1, 4, 5, 8, 9, 12, 13,
+                         2, 3, 6, 7, 10, 11, 14, 15>;
+defm : ExtAddPairwiseExtendShuffle<v16i8, v8i16, "I16x8",
+                         0, 2, 4, 6, 8, 10, 12, 14,
+                         1, 3, 5, 7, 9, 11, 13, 15>;
+
+multiclass ExtAddPairwiseShuffleExtend<ValueType from_ty, ValueType to_ty, string suffix,
+                                       int a0,  int a1,  int a2,  int a3,
+                                       int a4,  int a5,  int a6,  int a7,
+                                       int a8,  int a9,  int a10, int a11,
+                                       int a12, int a13, int a14, int a15,
+                                       int b0,  int b1,  int b2,  int b3,
+                                       int b4,  int b5,  int b6,  int b7,
+                                       int b8,  int b9,  int b10, int b11,
+                                       int b12, int b13, int b14, int b15> {
+  foreach sign = ["s", "u"] in {
     def : Pat<(to_ty (add
-                    (wasm_shuffle
-                      (to_ty (!cast<SDNode>("extend_low_"#sign)  (from_ty V128:$vec))),
-                      (to_ty (!cast<SDNode>("extend_high_"#sign) (from_ty V128:$vec))),
-                      (i32 0),  (i32 1),  (i32 2),  (i32 3),
-                      (i32 8),  (i32 9),  (i32 10), (i32 11),
-                      (i32 16), (i32 17), (i32 18), (i32 19),
-                      (i32 24), (i32 25), (i32 26), (i32 27)),
-                    (wasm_shuffle
-                      (to_ty (!cast<SDNode>("extend_low_"#sign)  (from_ty V128:$vec))),
-                      (to_ty (!cast<SDNode>("extend_high_"#sign) (from_ty V128:$vec))),
-                      (i32 4),  (i32 5),  (i32 6),  (i32 7),
-                      (i32 12), (i32 13), (i32 14), (i32 15),
-                      (i32 20), (i32 21), (i32 22), (i32 23),
-                      (i32 28), (i32 29), (i32 30), (i32 31)))),
+                      (wasm_shuffle
+                        (to_ty (!cast<SDNode>("extend_low_"#sign)  (from_ty V128:$vec))),
+                        (to_ty (!cast<SDNode>("extend_high_"#sign) (from_ty V128:$vec))),
+                        (i32 a0),  (i32 a1),  (i32 a2),  (i32 a3),
+                        (i32 a4),  (i32 a5),  (i32 a6),  (i32 a7),
+                        (i32 a8),  (i32 a9),  (i32 a10), (i32 a11),
+                        (i32 a12), (i32 a13), (i32 a14), (i32 a15)),
+                      (wasm_shuffle
+                        (to_ty (!cast<SDNode>("extend_low_"#sign)  (from_ty V128:$vec))),
+                        (to_ty (!cast<SDNode>("extend_high_"#sign) (from_ty V128:$vec))),
+                        (i32 b0),  (i32 b1),  (i32 b2),  (i32 b3),
+                        (i32 b4),  (i32 b5),  (i32 b6),  (i32 b7),
+                        (i32 b8),  (i32 b9),  (i32 b10), (i32 b11),
+                        (i32 b12), (i32 b13), (i32 b14), (i32 b15)))),
               (!cast<Instruction>("extadd_pairwise_"#sign#"_"#suffix) V128:$vec)>;
   }
 }
 
-defm : ExtAddPairwiseShuffle<v8i16, v4i32, "I32x4",
-                         0, 1, 4, 5, 8, 9, 12, 13,
-                         2, 3, 6, 7, 10, 11, 14, 15>;
-defm : ExtAddPairwiseShuffle<v16i8, v8i16, "I16x8",
-                         0, 2, 4, 6, 8, 10, 12, 14,
-                         1, 3, 5, 7, 9, 11, 13, 15>;
+defm : ExtAddPairwiseShuffleExtend<v8i16, v4i32, "I32x4",
+                                   0,  1,  2,  3,
+                                   8,  9,  10, 11,
+                                   16, 17, 18, 19,
+                                   24, 25, 26, 27,
+                                   4,  5,  6,  7,
+                                   12, 13, 14, 15,
+                                   20, 21, 22, 23,
+                                   28, 29, 30, 31>;
+
+defm : ExtAddPairwiseShuffleExtend<v16i8, v8i16, "I16x8",
+                                   0,  1,  4,  5,
+                                   8,  9,  12, 13,
+                                   16, 17, 20, 21,
+                                   24, 25, 28, 29,
+                                   2,  3,  6,  7,
+                                   10, 11, 14, 15,
+                                   18, 19, 22, 23,
+                                   26, 27, 30, 31>;
 
 // f64x2 <-> f32x4 conversions
 def demote_t : SDTypeProfile<1, 1, [SDTCisVec<0>, SDTCisVec<1>]>;

--- a/llvm/test/CodeGen/WebAssembly/simd-extadd.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-extadd.ll
@@ -65,6 +65,22 @@ define <4 x i32> @test_extadd_pairwise_i16x8_u(<8 x i16> %v) {
   ret <4 x i32> %result
 }
 
+; Extend first, then shuffle.
+define <4 x i32> @extend_shuffle(<8 x i16> %a) {
+; CHECK-LABEL: extend_shuffle:
+; CHECK:         .functype extend_shuffle (v128) -> (v128)
+; CHECK-NEXT:  # %bb.0: # %start
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i32x4.extadd_pairwise_i16x8_s
+; CHECK-NEXT:    # fallthrough-return
+start:
+  %1 = sext <8 x i16> %a to <8 x i32>
+  %2 = shufflevector <8 x i32> %1, <8 x i32> poison, <4 x i32> <i32 0, i32 2, i32 4, i32 6>
+  %3 = shufflevector <8 x i32> %1, <8 x i32> poison, <4 x i32> <i32 1, i32 3, i32 5, i32 7>
+  %4 = add nsw <4 x i32> %2, %3
+  ret <4 x i32> %4
+}
+
 ; Negative test: shuffling mask doesn't fit pattern
 define <4 x i32> @negative_test_extadd_pairwise_i16x8_u(<8 x i16> %v) {
 ; CHECK-LABEL: negative_test_extadd_pairwise_i16x8_u:

--- a/llvm/test/CodeGen/WebAssembly/simd-extadd.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-extadd.ll
@@ -66,9 +66,9 @@ define <4 x i32> @test_extadd_pairwise_i16x8_u(<8 x i16> %v) {
 }
 
 ; Extend first, then shuffle.
-define <4 x i32> @extend_shuffle(<8 x i16> %a) {
-; CHECK-LABEL: extend_shuffle:
-; CHECK:         .functype extend_shuffle (v128) -> (v128)
+define <4 x i32> @extend_shuffle_4xi32(<8 x i16> %a) {
+; CHECK-LABEL: extend_shuffle_4xi32:
+; CHECK:         .functype extend_shuffle_4xi32 (v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0: # %start
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    i32x4.extadd_pairwise_i16x8_s
@@ -79,6 +79,22 @@ start:
   %3 = shufflevector <8 x i32> %1, <8 x i32> poison, <4 x i32> <i32 1, i32 3, i32 5, i32 7>
   %4 = add nsw <4 x i32> %2, %3
   ret <4 x i32> %4
+}
+
+; Extend first, then shuffle.
+define <8 x i16> @extend_shuffle_8xi16(<16 x i8> %a) {
+; CHECK-LABEL: extend_shuffle_8xi16:
+; CHECK:         .functype extend_shuffle_8xi16 (v128) -> (v128)
+; CHECK-NEXT:  # %bb.0: # %start
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    i16x8.extadd_pairwise_i8x16_s
+; CHECK-NEXT:    # fallthrough-return
+start:
+  %1 = sext <16 x i8> %a to <16 x i16>
+  %2 = shufflevector <16 x i16> %1, <16 x i16> poison, <8 x i32> <i32 0, i32 2, i32 4, i32 6, i32 8, i32 10, i32 12, i32 14>
+  %3 = shufflevector <16 x i16> %1, <16 x i16> poison, <8 x i32> <i32 1, i32 3, i32 5, i32 7, i32 9, i32 11, i32 13, i32 15>
+  %4 = add nsw <8 x i16> %2, %3
+  ret <8 x i16> %4
 }
 
 ; Negative test: shuffling mask doesn't fit pattern


### PR DESCRIPTION
cc https://github.com/llvm/llvm-project/issues/179143

This adds a second pattern: we already recognize "shuffle + extend + add" as `addext`, this adds another pattern for "extend + shuffle + add", which can come up when programs are optimized.