### PR TITLE
[MLIR][CMake] Fix runtime libraries with PCH

### DIFF
--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -345,9 +345,11 @@ endfunction()
 #   aggregate shared library.
 #   TODO: Make this the default for all MLIR libraries once all libraries
 #   are compatible with building an object library.
+# STANDALONE
+#   Don't link against LLVMSupport.
 function(add_mlir_library name)
   cmake_parse_arguments(ARG
-    "SHARED;INSTALL_WITH_TOOLCHAIN;EXCLUDE_FROM_LIBMLIR;DISABLE_INSTALL;ENABLE_AGGREGATION;OBJECT"
+    "SHARED;INSTALL_WITH_TOOLCHAIN;EXCLUDE_FROM_LIBMLIR;DISABLE_INSTALL;ENABLE_AGGREGATION;OBJECT;STANDALONE"
     ""
     "ADDITIONAL_HEADERS;DEPENDS;LINK_COMPONENTS;LINK_LIBS"
     ${ARGN})
@@ -400,8 +402,10 @@ function(add_mlir_library name)
     list(APPEND LIBTYPE OBJECT)
   endif()
 
-  # MLIR libraries uniformly depend on LLVMSupport.  Just specify it once here.
-  list(APPEND ARG_LINK_COMPONENTS Support)
+  # Most MLIR libraries depend on LLVMSupport.  Just specify it once here.
+  if(NOT ARG_STANDALONE)
+    list(APPEND ARG_LINK_COMPONENTS Support)
+  endif()
   _check_llvm_components_usage(${name} ${ARG_LINK_LIBS})
 
   list(APPEND ARG_DEPENDS mlir-generic-headers)

--- a/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -164,6 +164,8 @@ if(LLVM_ENABLE_PIC)
     Float16bits.cpp
 
     EXCLUDE_FROM_LIBMLIR
+
+    STANDALONE
     )
   set_property(TARGET mlir_float16_utils PROPERTY CXX_STANDARD 17)
   target_compile_definitions(mlir_float16_utils PRIVATE mlir_float16_utils_EXPORTS)
@@ -176,6 +178,10 @@ if(LLVM_ENABLE_PIC)
       APFloatWrappers.cpp
 
       EXCLUDE_FROM_LIBMLIR
+
+      # Link against LLVMSupport.
+      LINK_COMPONENTS
+      Support
       )
     set_target_properties(
       mlir_apfloat_wrappers
@@ -201,6 +207,8 @@ if(LLVM_ENABLE_PIC)
     mlir_float16_utils
     MLIRSparseTensorEnums
     MLIRSparseTensorRuntime
+
+    STANDALONE
     )
   set_property(TARGET mlir_c_runner_utils PROPERTY CXX_STANDARD 17)
   target_compile_definitions(mlir_c_runner_utils PRIVATE mlir_c_runner_utils_EXPORTS)
@@ -218,6 +226,8 @@ if(LLVM_ENABLE_PIC)
 
     LINK_LIBS PUBLIC
     mlir_float16_utils
+
+    STANDALONE
   )
   target_compile_definitions(mlir_runner_utils PRIVATE mlir_runner_utils_EXPORTS)
 
@@ -234,6 +244,13 @@ if(LLVM_ENABLE_PIC)
 
     LINK_LIBS PUBLIC
     ${LLVM_PTHREAD_LIB}
+
+    # TODO: this is merely a workaround. If this library depends on LLVMSupport,
+    # it should suppress symbols, or if it doesn't, it shouldn't link against
+    # it. This workaround prevents the library from defining the symbol
+    # llvm::EnableABIBreakingChecks, which would cause ODR-violations when
+    # dlopen-ed.
+    DISABLE_PCH_REUSE
   )
   set_property(TARGET mlir_async_runtime PROPERTY CXX_VISIBILITY_PRESET hidden)
   target_compile_definitions(mlir_async_runtime PRIVATE mlir_async_runtime_EXPORTS)
@@ -246,12 +263,28 @@ if(LLVM_ENABLE_PIC)
 
   add_mlir_library(mlir_arm_sme_abi_stubs
     SHARED
-    ArmSMEStubs.cpp)
+    ArmSMEStubs.cpp
+
+    # TODO: this is merely a workaround. If this library depends on LLVMSupport,
+    # it should suppress symbols, or if it doesn't, it shouldn't link against
+    # it. This workaround prevents the library from defining the symbol
+    # llvm::EnableABIBreakingChecks, which would cause ODR-violations when
+    # dlopen-ed.
+    DISABLE_PCH_REUSE
+  )
   target_compile_definitions(mlir_arm_sme_abi_stubs PRIVATE mlir_arm_sme_abi_stubs_EXPORTS)
 
   add_mlir_library(mlir_arm_runner_utils
     SHARED
-    ArmRunnerUtils.cpp)
+    ArmRunnerUtils.cpp
+
+    # TODO: this is merely a workaround. If this library depends on LLVMSupport,
+    # it should suppress symbols, or if it doesn't, it shouldn't link against
+    # it. This workaround prevents the library from defining the symbol
+    # llvm::EnableABIBreakingChecks, which would cause ODR-violations when
+    # dlopen-ed.
+    DISABLE_PCH_REUSE
+  )
 
   if(MLIR_ENABLE_CUDA_RUNNER)
     # Configure CUDA support. Using check_language first allows us to give a
@@ -273,6 +306,8 @@ if(LLVM_ENABLE_PIC)
       CudaRuntimeWrappers.cpp
 
       EXCLUDE_FROM_LIBMLIR
+
+      STANDALONE
     )
     set_property(TARGET mlir_cuda_runtime PROPERTY CXX_STANDARD 14)
 
@@ -368,6 +403,13 @@ if(LLVM_ENABLE_PIC)
       RocmRuntimeWrappers.cpp
 
       EXCLUDE_FROM_LIBMLIR
+
+      # TODO: this is merely a workaround. If this library depends on LLVMSupport,
+      # it should suppress symbols, or if it doesn't, it shouldn't link against
+      # it. This workaround prevents the library from defining the symbol
+      # llvm::EnableABIBreakingChecks, which would cause ODR-violations when
+      # dlopen-ed.
+      DISABLE_PCH_REUSE
     )
 
     # Supress compiler warnings from HIP headers
@@ -426,6 +468,8 @@ if(LLVM_ENABLE_PIC)
       SyclRuntimeWrappers.cpp
 
       EXCLUDE_FROM_LIBMLIR
+
+      STANDALONE
     )
 
     check_cxx_compiler_flag("-frtti" CXX_HAS_FRTTI_FLAG)
@@ -449,6 +493,9 @@ if(LLVM_ENABLE_PIC)
       LevelZeroRuntimeWrappers.cpp
 
       EXCLUDE_FROM_LIBMLIR
+
+      # Disable PCH due to RTTI/Exceptions override.
+      DISABLE_PCH_REUSE
     )
 
     target_compile_options(mlir_levelzero_runtime PUBLIC -fexceptions -frtti)
@@ -468,6 +515,8 @@ if(LLVM_ENABLE_PIC)
       SpirvCpuRuntimeWrappers.cpp
 
       EXCLUDE_FROM_LIBMLIR
+
+      STANDALONE
     )
 
     target_compile_definitions(mlir_spirv_cpu_runtime
@@ -497,9 +546,13 @@ if(LLVM_ENABLE_PIC)
       message(FATAL_ERROR "Cannot find Vulkan library")
     endif()
 
-    add_llvm_library(mlir_vulkan_runtime SHARED
+    add_mlir_library(mlir_vulkan_runtime SHARED
       VulkanRuntimeWrappers.cpp
       VulkanRuntime.cpp
+
+      EXCLUDE_FROM_LIBMLIR
+
+      STANDALONE
     )
 
     target_include_directories(mlir_vulkan_runtime

--- a/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -179,9 +179,8 @@ if(LLVM_ENABLE_PIC)
 
       EXCLUDE_FROM_LIBMLIR
 
-      # Link against LLVMSupport.
-      LINK_COMPONENTS
-      Support
+      # Disable PCH reuse due to non-default symbol visibility.
+      DISABLE_PCH_REUSE
       )
     set_target_properties(
       mlir_apfloat_wrappers

--- a/mlir/lib/ExecutionEngine/SparseTensor/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/SparseTensor/CMakeLists.txt
@@ -11,6 +11,8 @@ add_mlir_library(MLIRSparseTensorRuntime
   Storage.cpp
 
   EXCLUDE_FROM_LIBMLIR
+
+  STANDALONE
   )
 mlir_target_link_libraries(MLIRSparseTensorRuntime PUBLIC
   MLIRSparseTensorEnums


### PR DESCRIPTION
Some MLIR libraries are intended to be dlopen-ed, but currently all MLIR libraries link against LLVMSupport. After the recent PCH introduction, this causes these libraries to implicitly use the LLVMSupport PCH, which results in the definition of llvm::*ABIBreakingChecks, which results in a ODR violation when loaded with dlopen.

Conceptually, libraries that are designed to be dlopen-ed should not simply link against LLVM libraries in non-dylib builds for this reason. (This apparently was a problem before with mlir_apfloat_wrappers.)

To fix builds, remove LLVMSupport from runtime libraries that don't need it and, as a workaround, disable PCH for libraries that are in a weird state (use LLVMSupport but happen to not export symbols currently).