### PR TITLE
[AArch64] Cortex-A55/A320/A510 scheduling model "typo" fixes

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedA320.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedA320.td
@@ -344,12 +344,12 @@ def CortexA320WriteVLD4Latency6: SchedWriteRes<[CortexA320UnitLdSt]> { let Laten
 def : InstRW<[CortexA320WriteVLD4Latency5Release7], (instregex "LD4Fourv(8b|4h|2s|1d)$")>;
 def : InstRW<[CortexA320WriteVLD4Latency5Release8], (instregex "LD4Fourv(16b|8h|4s|2d)$")>;
 def : InstRW<[CortexA320WriteVLD4Latency6], (instregex "LD4i(8|16|32|64)$")>;
-def : InstRW<[CortexA320WriteVLD4Latency4], (instregex "LD4Rv(8b|16b|4h|8b|2s|4s|1d|2d)$")>;
+def : InstRW<[CortexA320WriteVLD4Latency4], (instregex "LD4Rv(8b|16b|4h|8h|2s|4s|1d|2d)$")>;
  
 def : InstRW<[WriteAdr, CortexA320WriteVLD4Latency5Release7], (instregex "LD4Fourv(8b|4h|2s|1d)_POST$")>;
 def : InstRW<[WriteAdr, CortexA320WriteVLD4Latency5Release8], (instregex "LD4Fourv(16b|8h|4s|2d)_POST$")>; 
 def : InstRW<[WriteAdr, CortexA320WriteVLD4Latency6], (instregex "LD4i(8|16|32|64)_POST$")>;
-def : InstRW<[WriteAdr, CortexA320WriteVLD4Latency4], (instregex "LD4Rv(8b|16b|4h|8b|2s|4s|1d|2d)_POST$")>;
+def : InstRW<[WriteAdr, CortexA320WriteVLD4Latency4], (instregex "LD4Rv(8b|16b|4h|8h|2s|4s|1d|2d)_POST$")>;
 //---
 // Vector Stores
 //---
@@ -460,7 +460,7 @@ def : InstRW<[CortexA320Write<3, CortexA320UnitVALU>], (instregex "(AND|EOR|NOT|
   "(ORR|BIC)v(16i8|4i32|8i16)$", "MVNIv(4i32|4s|8i16)")>;
 // ASIMD max/min, basic
 def : InstRW<[CortexA320Write<3, CortexA320UnitVALU>], (instregex "[SU](MIN|MAX)P?v(2i32|4i16|8i8)")>;
-def : InstRW<[CortexA320Write<3, CortexA320UnitVALU>], (instregex "[SU](MIN|MAX)P?v(16i8|4i132|8i16)")>;
+def : InstRW<[CortexA320Write<3, CortexA320UnitVALU>], (instregex "[SU](MIN|MAX)P?v(16i8|4i32|8i16)")>;
 // SIMD max/min, reduce
 def : InstRW<[CortexA320Write<4, CortexA320UnitVALU>], (instregex "[SU](MAX|MIN)Vv")>;
 // ASIMD multiply, by element

--- a/llvm/lib/Target/AArch64/AArch64SchedA510.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedA510.td
@@ -438,7 +438,7 @@ def : InstRW<[CortexA510Write<3, CortexA510UnitVALU>], (instregex "(AND|EOR|NOT|
   "(ORR|BIC)v(16i8|4i32|8i16)$", "MVNIv(4i32|4s|8i16)")>;
 // ASIMD max/min, basic
 def : InstRW<[CortexA510Write<3, CortexA510UnitVALU>], (instregex "[SU](MIN|MAX)P?v(2i32|4i16|8i8)")>;
-def : InstRW<[CortexA510Write<3, CortexA510UnitVALU>], (instregex "[SU](MIN|MAX)P?v(16i8|4i132|8i16)")>;
+def : InstRW<[CortexA510Write<3, CortexA510UnitVALU>], (instregex "[SU](MIN|MAX)P?v(16i8|4i32|8i16)")>;
 // SIMD max/min, reduce
 def : InstRW<[CortexA510Write<4, CortexA510UnitVALU>], (instregex "[SU](MAX|MIN)Vv")>;
 // ASIMD multiply, by element

--- a/llvm/lib/Target/AArch64/AArch64SchedA55.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedA55.td
@@ -426,7 +426,7 @@ def : InstRW<[CortexA55WriteAluVq_1], (instregex "(AND|EOR|NOT|ORN)v16i8",
   "(ORR|BIC)v(16i8|4i32|8i16)$", "MVNIv(4i32|4s|8i16)")>;
 // ASIMD max/min, basic
 def : InstRW<[CortexA55WriteAluVd_2], (instregex "[SU](MIN|MAX)P?v(2i32|4i16|8i8)")>;
-def : InstRW<[CortexA55WriteAluVq_2], (instregex "[SU](MIN|MAX)P?v(16i8|4i132|8i16)")>;
+def : InstRW<[CortexA55WriteAluVq_2], (instregex "[SU](MIN|MAX)P?v(16i8|4i32|8i16)")>;
 // SIMD max/min, reduce
 def : InstRW<[CortexA55WriteAluVq_4], (instregex "[SU](MAX|MIN)Vv")>;
 // ASIMD multiply, by element

--- a/llvm/test/CodeGen/AArch64/fp-to-int-to-fp.ll
+++ b/llvm/test/CodeGen/AArch64/fp-to-int-to-fp.ll
@@ -196,9 +196,9 @@ define <4 x float> @test_signed_v4f32_min_max(<4 x float> %x) {
 ; SIGNED-ZEROS:       // %bb.0: // %entry
 ; SIGNED-ZEROS-NEXT:    fcvtzs v0.4s, v0.4s
 ; SIGNED-ZEROS-NEXT:    mvni v1.4s, #1, msl #8
+; SIGNED-ZEROS-NEXT:    movi v2.4s, #3, msl #8
 ; SIGNED-ZEROS-NEXT:    smax v0.4s, v0.4s, v1.4s
-; SIGNED-ZEROS-NEXT:    movi v1.4s, #3, msl #8
-; SIGNED-ZEROS-NEXT:    smin v0.4s, v0.4s, v1.4s
+; SIGNED-ZEROS-NEXT:    smin v0.4s, v0.4s, v2.4s
 ; SIGNED-ZEROS-NEXT:    scvtf v0.4s, v0.4s
 ; SIGNED-ZEROS-NEXT:    ret
 ;
@@ -225,9 +225,9 @@ define <4 x float> @test_unsigned_v4f32_min_max(<4 x float> %x) {
 ; SIGNED-ZEROS:       // %bb.0: // %entry
 ; SIGNED-ZEROS-NEXT:    movi v1.4s, #2, lsl #8
 ; SIGNED-ZEROS-NEXT:    fcvtzu v0.4s, v0.4s
+; SIGNED-ZEROS-NEXT:    movi v2.4s, #3, msl #8
 ; SIGNED-ZEROS-NEXT:    umax v0.4s, v0.4s, v1.4s
-; SIGNED-ZEROS-NEXT:    movi v1.4s, #3, msl #8
-; SIGNED-ZEROS-NEXT:    umin v0.4s, v0.4s, v1.4s
+; SIGNED-ZEROS-NEXT:    umin v0.4s, v0.4s, v2.4s
 ; SIGNED-ZEROS-NEXT:    ucvtf v0.4s, v0.4s
 ; SIGNED-ZEROS-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/AArch64/fptosi-sat-vector.ll
+++ b/llvm/test/CodeGen/AArch64/fptosi-sat-vector.ll
@@ -1790,53 +1790,63 @@ declare <4 x i100> @llvm.fptosi.sat.v4f32.v4i100(<4 x float>)
 declare <4 x i128> @llvm.fptosi.sat.v4f32.v4i128(<4 x float>)
 
 define <4 x i1> @test_signed_v4f32_v4i1(<4 x float> %f) {
-; CHECK-SD-LABEL: test_signed_v4f32_v4i1:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-SD-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-SD-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-SD-NEXT:    movi v1.2d, #0xffffffffffffffff
-; CHECK-SD-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: test_signed_v4f32_v4i1:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-GI-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-GI-NEXT:    movi v2.2d, #0xffffffffffffffff
-; CHECK-GI-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-GI-NEXT:    smax v0.4s, v0.4s, v2.4s
-; CHECK-GI-NEXT:    xtn v0.4h, v0.4s
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: test_signed_v4f32_v4i1:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    movi v2.2d, #0xffffffffffffffff
+; CHECK-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-NEXT:    smax v0.4s, v0.4s, v2.4s
+; CHECK-NEXT:    xtn v0.4h, v0.4s
+; CHECK-NEXT:    ret
     %x = call <4 x i1> @llvm.fptosi.sat.v4f32.v4i1(<4 x float> %f)
     ret <4 x i1> %x
 }
 
 define <4 x i8> @test_signed_v4f32_v4i8(<4 x float> %f) {
-; CHECK-LABEL: test_signed_v4f32_v4i8:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.4s, #127
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-NEXT:    mvni v1.4s, #127
-; CHECK-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-NEXT:    xtn v0.4h, v0.4s
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: test_signed_v4f32_v4i8:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    movi v1.4s, #127
+; CHECK-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-SD-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-SD-NEXT:    mvni v1.4s, #127
+; CHECK-SD-NEXT:    smax v0.4s, v0.4s, v1.4s
+; CHECK-SD-NEXT:    xtn v0.4h, v0.4s
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: test_signed_v4f32_v4i8:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    movi v1.4s, #127
+; CHECK-GI-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-GI-NEXT:    mvni v2.4s, #127
+; CHECK-GI-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    smax v0.4s, v0.4s, v2.4s
+; CHECK-GI-NEXT:    xtn v0.4h, v0.4s
+; CHECK-GI-NEXT:    ret
     %x = call <4 x i8> @llvm.fptosi.sat.v4f32.v4i8(<4 x float> %f)
     ret <4 x i8> %x
 }
 
 define <4 x i13> @test_signed_v4f32_v4i13(<4 x float> %f) {
-; CHECK-LABEL: test_signed_v4f32_v4i13:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.4s, #15, msl #8
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-NEXT:    mvni v1.4s, #15, msl #8
-; CHECK-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-NEXT:    xtn v0.4h, v0.4s
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: test_signed_v4f32_v4i13:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    movi v1.4s, #15, msl #8
+; CHECK-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-SD-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-SD-NEXT:    mvni v1.4s, #15, msl #8
+; CHECK-SD-NEXT:    smax v0.4s, v0.4s, v1.4s
+; CHECK-SD-NEXT:    xtn v0.4h, v0.4s
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: test_signed_v4f32_v4i13:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    movi v1.4s, #15, msl #8
+; CHECK-GI-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-GI-NEXT:    mvni v2.4s, #15, msl #8
+; CHECK-GI-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    smax v0.4s, v0.4s, v2.4s
+; CHECK-GI-NEXT:    xtn v0.4h, v0.4s
+; CHECK-GI-NEXT:    ret
     %x = call <4 x i13> @llvm.fptosi.sat.v4f32.v4i13(<4 x float> %f)
     ret <4 x i13> %x
 }
@@ -1852,14 +1862,23 @@ define <4 x i16> @test_signed_v4f32_v4i16(<4 x float> %f) {
 }
 
 define <4 x i19> @test_signed_v4f32_v4i19(<4 x float> %f) {
-; CHECK-LABEL: test_signed_v4f32_v4i19:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.4s, #3, msl #16
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-NEXT:    mvni v1.4s, #3, msl #16
-; CHECK-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: test_signed_v4f32_v4i19:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    movi v1.4s, #3, msl #16
+; CHECK-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-SD-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-SD-NEXT:    mvni v1.4s, #3, msl #16
+; CHECK-SD-NEXT:    smax v0.4s, v0.4s, v1.4s
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: test_signed_v4f32_v4i19:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    movi v1.4s, #3, msl #16
+; CHECK-GI-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-GI-NEXT:    mvni v2.4s, #3, msl #16
+; CHECK-GI-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    smax v0.4s, v0.4s, v2.4s
+; CHECK-GI-NEXT:    ret
     %x = call <4 x i19> @llvm.fptosi.sat.v4f32.v4i19(<4 x float> %f)
     ret <4 x i19> %x
 }
@@ -2843,16 +2862,16 @@ declare <4 x i100> @llvm.fptosi.sat.v4f16.v4i100(<4 x half>)
 declare <4 x i128> @llvm.fptosi.sat.v4f16.v4i128(<4 x half>)
 
 define <4 x i1> @test_signed_v4f16_v4i1(<4 x half> %f) {
-; CHECK-SD-CVT-LABEL: test_signed_v4f16_v4i1:
-; CHECK-SD-CVT:       // %bb.0:
-; CHECK-SD-CVT-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-SD-CVT-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-SD-CVT-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-SD-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-SD-CVT-NEXT:    movi v1.2d, #0xffffffffffffffff
-; CHECK-SD-CVT-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-SD-CVT-NEXT:    xtn v0.4h, v0.4s
-; CHECK-SD-CVT-NEXT:    ret
+; CHECK-CVT-LABEL: test_signed_v4f16_v4i1:
+; CHECK-CVT:       // %bb.0:
+; CHECK-CVT-NEXT:    fcvtl v0.4s, v0.4h
+; CHECK-CVT-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-CVT-NEXT:    movi v2.2d, #0xffffffffffffffff
+; CHECK-CVT-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-CVT-NEXT:    smax v0.4s, v0.4s, v2.4s
+; CHECK-CVT-NEXT:    xtn v0.4h, v0.4s
+; CHECK-CVT-NEXT:    ret
 ;
 ; CHECK-SD-FP16-LABEL: test_signed_v4f16_v4i1:
 ; CHECK-SD-FP16:       // %bb.0:
@@ -2862,17 +2881,6 @@ define <4 x i1> @test_signed_v4f16_v4i1(<4 x half> %f) {
 ; CHECK-SD-FP16-NEXT:    smin v0.4h, v0.4h, v1.4h
 ; CHECK-SD-FP16-NEXT:    smax v0.4h, v0.4h, v2.4h
 ; CHECK-SD-FP16-NEXT:    ret
-;
-; CHECK-GI-CVT-LABEL: test_signed_v4f16_v4i1:
-; CHECK-GI-CVT:       // %bb.0:
-; CHECK-GI-CVT-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-GI-CVT-NEXT:    movi v1.2d, #0000000000000000
-; CHECK-GI-CVT-NEXT:    movi v2.2d, #0xffffffffffffffff
-; CHECK-GI-CVT-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-GI-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-GI-CVT-NEXT:    smax v0.4s, v0.4s, v2.4s
-; CHECK-GI-CVT-NEXT:    xtn v0.4h, v0.4s
-; CHECK-GI-CVT-NEXT:    ret
 ;
 ; CHECK-GI-FP16-LABEL: test_signed_v4f16_v4i1:
 ; CHECK-GI-FP16:       // %bb.0:
@@ -2887,16 +2895,16 @@ define <4 x i1> @test_signed_v4f16_v4i1(<4 x half> %f) {
 }
 
 define <4 x i8> @test_signed_v4f16_v4i8(<4 x half> %f) {
-; CHECK-CVT-LABEL: test_signed_v4f16_v4i8:
-; CHECK-CVT:       // %bb.0:
-; CHECK-CVT-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-CVT-NEXT:    movi v1.4s, #127
-; CHECK-CVT-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-CVT-NEXT:    mvni v1.4s, #127
-; CHECK-CVT-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-CVT-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-NEXT:    ret
+; CHECK-SD-CVT-LABEL: test_signed_v4f16_v4i8:
+; CHECK-SD-CVT:       // %bb.0:
+; CHECK-SD-CVT-NEXT:    fcvtl v0.4s, v0.4h
+; CHECK-SD-CVT-NEXT:    movi v1.4s, #127
+; CHECK-SD-CVT-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-SD-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-SD-CVT-NEXT:    mvni v1.4s, #127
+; CHECK-SD-CVT-NEXT:    smax v0.4s, v0.4s, v1.4s
+; CHECK-SD-CVT-NEXT:    xtn v0.4h, v0.4s
+; CHECK-SD-CVT-NEXT:    ret
 ;
 ; CHECK-SD-FP16-LABEL: test_signed_v4f16_v4i8:
 ; CHECK-SD-FP16:       // %bb.0:
@@ -2906,6 +2914,17 @@ define <4 x i8> @test_signed_v4f16_v4i8(<4 x half> %f) {
 ; CHECK-SD-FP16-NEXT:    mvni v1.4h, #127
 ; CHECK-SD-FP16-NEXT:    smax v0.4h, v0.4h, v1.4h
 ; CHECK-SD-FP16-NEXT:    ret
+;
+; CHECK-GI-CVT-LABEL: test_signed_v4f16_v4i8:
+; CHECK-GI-CVT:       // %bb.0:
+; CHECK-GI-CVT-NEXT:    fcvtl v0.4s, v0.4h
+; CHECK-GI-CVT-NEXT:    movi v1.4s, #127
+; CHECK-GI-CVT-NEXT:    mvni v2.4s, #127
+; CHECK-GI-CVT-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-GI-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-GI-CVT-NEXT:    smax v0.4s, v0.4s, v2.4s
+; CHECK-GI-CVT-NEXT:    xtn v0.4h, v0.4s
+; CHECK-GI-CVT-NEXT:    ret
 ;
 ; CHECK-GI-FP16-LABEL: test_signed_v4f16_v4i8:
 ; CHECK-GI-FP16:       // %bb.0:
@@ -2920,16 +2939,16 @@ define <4 x i8> @test_signed_v4f16_v4i8(<4 x half> %f) {
 }
 
 define <4 x i13> @test_signed_v4f16_v4i13(<4 x half> %f) {
-; CHECK-CVT-LABEL: test_signed_v4f16_v4i13:
-; CHECK-CVT:       // %bb.0:
-; CHECK-CVT-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-CVT-NEXT:    movi v1.4s, #15, msl #8
-; CHECK-CVT-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-CVT-NEXT:    mvni v1.4s, #15, msl #8
-; CHECK-CVT-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-CVT-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-NEXT:    ret
+; CHECK-SD-CVT-LABEL: test_signed_v4f16_v4i13:
+; CHECK-SD-CVT:       // %bb.0:
+; CHECK-SD-CVT-NEXT:    fcvtl v0.4s, v0.4h
+; CHECK-SD-CVT-NEXT:    movi v1.4s, #15, msl #8
+; CHECK-SD-CVT-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-SD-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-SD-CVT-NEXT:    mvni v1.4s, #15, msl #8
+; CHECK-SD-CVT-NEXT:    smax v0.4s, v0.4s, v1.4s
+; CHECK-SD-CVT-NEXT:    xtn v0.4h, v0.4s
+; CHECK-SD-CVT-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: test_signed_v4f16_v4i13:
 ; CHECK-FP16:       // %bb.0:
@@ -2939,6 +2958,17 @@ define <4 x i13> @test_signed_v4f16_v4i13(<4 x half> %f) {
 ; CHECK-FP16-NEXT:    smin v0.4h, v0.4h, v1.4h
 ; CHECK-FP16-NEXT:    smax v0.4h, v0.4h, v2.4h
 ; CHECK-FP16-NEXT:    ret
+;
+; CHECK-GI-CVT-LABEL: test_signed_v4f16_v4i13:
+; CHECK-GI-CVT:       // %bb.0:
+; CHECK-GI-CVT-NEXT:    fcvtl v0.4s, v0.4h
+; CHECK-GI-CVT-NEXT:    movi v1.4s, #15, msl #8
+; CHECK-GI-CVT-NEXT:    mvni v2.4s, #15, msl #8
+; CHECK-GI-CVT-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-GI-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-GI-CVT-NEXT:    smax v0.4s, v0.4s, v2.4s
+; CHECK-GI-CVT-NEXT:    xtn v0.4h, v0.4s
+; CHECK-GI-CVT-NEXT:    ret
     %x = call <4 x i13> @llvm.fptosi.sat.v4f16.v4i13(<4 x half> %f)
     ret <4 x i13> %x
 }
@@ -2960,15 +2990,25 @@ define <4 x i16> @test_signed_v4f16_v4i16(<4 x half> %f) {
 }
 
 define <4 x i19> @test_signed_v4f16_v4i19(<4 x half> %f) {
-; CHECK-LABEL: test_signed_v4f16_v4i19:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-NEXT:    movi v1.4s, #3, msl #16
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-NEXT:    mvni v1.4s, #3, msl #16
-; CHECK-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: test_signed_v4f16_v4i19:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    fcvtl v0.4s, v0.4h
+; CHECK-SD-NEXT:    movi v1.4s, #3, msl #16
+; CHECK-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-SD-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-SD-NEXT:    mvni v1.4s, #3, msl #16
+; CHECK-SD-NEXT:    smax v0.4s, v0.4s, v1.4s
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: test_signed_v4f16_v4i19:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    fcvtl v0.4s, v0.4h
+; CHECK-GI-NEXT:    movi v1.4s, #3, msl #16
+; CHECK-GI-NEXT:    mvni v2.4s, #3, msl #16
+; CHECK-GI-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-GI-NEXT:    smin v0.4s, v0.4s, v1.4s
+; CHECK-GI-NEXT:    smax v0.4s, v0.4s, v2.4s
+; CHECK-GI-NEXT:    ret
     %x = call <4 x i19> @llvm.fptosi.sat.v4f16.v4i19(<4 x half> %f)
     ret <4 x i19> %x
 }
@@ -3446,14 +3486,14 @@ define <8 x i8> @test_signed_v8f16_v8i8(<8 x half> %f) {
 ; CHECK-SD-CVT-NEXT:    fcvtl2 v2.4s, v0.8h
 ; CHECK-SD-CVT-NEXT:    fcvtl v0.4s, v0.4h
 ; CHECK-SD-CVT-NEXT:    movi v1.4s, #127
+; CHECK-SD-CVT-NEXT:    mvni v3.4s, #127
 ; CHECK-SD-CVT-NEXT:    fcvtzs v2.4s, v2.4s
 ; CHECK-SD-CVT-NEXT:    fcvtzs v0.4s, v0.4s
 ; CHECK-SD-CVT-NEXT:    smin v2.4s, v2.4s, v1.4s
 ; CHECK-SD-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-SD-CVT-NEXT:    mvni v1.4s, #127
-; CHECK-SD-CVT-NEXT:    smax v2.4s, v2.4s, v1.4s
-; CHECK-SD-CVT-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-SD-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
+; CHECK-SD-CVT-NEXT:    smax v1.4s, v2.4s, v3.4s
+; CHECK-SD-CVT-NEXT:    smax v0.4s, v0.4s, v3.4s
+; CHECK-SD-CVT-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
 ; CHECK-SD-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-SD-CVT-NEXT:    ret
 ;
@@ -3468,14 +3508,14 @@ define <8 x i8> @test_signed_v8f16_v8i8(<8 x half> %f) {
 ; CHECK-GI-CVT-NEXT:    fcvtl v2.4s, v0.4h
 ; CHECK-GI-CVT-NEXT:    fcvtl2 v0.4s, v0.8h
 ; CHECK-GI-CVT-NEXT:    movi v1.4s, #127
+; CHECK-GI-CVT-NEXT:    mvni v3.4s, #127
 ; CHECK-GI-CVT-NEXT:    fcvtzs v2.4s, v2.4s
 ; CHECK-GI-CVT-NEXT:    fcvtzs v0.4s, v0.4s
 ; CHECK-GI-CVT-NEXT:    smin v2.4s, v2.4s, v1.4s
 ; CHECK-GI-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-GI-CVT-NEXT:    mvni v1.4s, #127
-; CHECK-GI-CVT-NEXT:    smax v2.4s, v2.4s, v1.4s
-; CHECK-GI-CVT-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-GI-CVT-NEXT:    uzp1 v0.8h, v2.8h, v0.8h
+; CHECK-GI-CVT-NEXT:    smax v1.4s, v2.4s, v3.4s
+; CHECK-GI-CVT-NEXT:    smax v0.4s, v0.4s, v3.4s
+; CHECK-GI-CVT-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
 ; CHECK-GI-CVT-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-GI-CVT-NEXT:    ret
     %x = call <8 x i8> @llvm.fptosi.sat.v8f16.v8i8(<8 x half> %f)
@@ -3488,14 +3528,14 @@ define <8 x i13> @test_signed_v8f16_v8i13(<8 x half> %f) {
 ; CHECK-SD-CVT-NEXT:    fcvtl2 v2.4s, v0.8h
 ; CHECK-SD-CVT-NEXT:    fcvtl v0.4s, v0.4h
 ; CHECK-SD-CVT-NEXT:    movi v1.4s, #15, msl #8
+; CHECK-SD-CVT-NEXT:    mvni v3.4s, #15, msl #8
 ; CHECK-SD-CVT-NEXT:    fcvtzs v2.4s, v2.4s
 ; CHECK-SD-CVT-NEXT:    fcvtzs v0.4s, v0.4s
 ; CHECK-SD-CVT-NEXT:    smin v2.4s, v2.4s, v1.4s
 ; CHECK-SD-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-SD-CVT-NEXT:    mvni v1.4s, #15, msl #8
-; CHECK-SD-CVT-NEXT:    smax v2.4s, v2.4s, v1.4s
-; CHECK-SD-CVT-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-SD-CVT-NEXT:    uzp1 v0.8h, v0.8h, v2.8h
+; CHECK-SD-CVT-NEXT:    smax v1.4s, v2.4s, v3.4s
+; CHECK-SD-CVT-NEXT:    smax v0.4s, v0.4s, v3.4s
+; CHECK-SD-CVT-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
 ; CHECK-SD-CVT-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: test_signed_v8f16_v8i13:
@@ -3512,14 +3552,14 @@ define <8 x i13> @test_signed_v8f16_v8i13(<8 x half> %f) {
 ; CHECK-GI-CVT-NEXT:    fcvtl v2.4s, v0.4h
 ; CHECK-GI-CVT-NEXT:    fcvtl2 v0.4s, v0.8h
 ; CHECK-GI-CVT-NEXT:    movi v1.4s, #15, msl #8
+; CHECK-GI-CVT-NEXT:    mvni v3.4s, #15, msl #8
 ; CHECK-GI-CVT-NEXT:    fcvtzs v2.4s, v2.4s
 ; CHECK-GI-CVT-NEXT:    fcvtzs v0.4s, v0.4s
 ; CHECK-GI-CVT-NEXT:    smin v2.4s, v2.4s, v1.4s
 ; CHECK-GI-CVT-NEXT:    smin v0.4s, v0.4s, v1.4s
-; CHECK-GI-CVT-NEXT:    mvni v1.4s, #15, msl #8
-; CHECK-GI-CVT-NEXT:    smax v2.4s, v2.4s, v1.4s
-; CHECK-GI-CVT-NEXT:    smax v0.4s, v0.4s, v1.4s
-; CHECK-GI-CVT-NEXT:    uzp1 v0.8h, v2.8h, v0.8h
+; CHECK-GI-CVT-NEXT:    smax v1.4s, v2.4s, v3.4s
+; CHECK-GI-CVT-NEXT:    smax v0.4s, v0.4s, v3.4s
+; CHECK-GI-CVT-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
 ; CHECK-GI-CVT-NEXT:    ret
     %x = call <8 x i13> @llvm.fptosi.sat.v8f16.v8i13(<8 x half> %f)
     ret <8 x i13> %x
@@ -4283,11 +4323,11 @@ define <8 x i8> @test_signed_v8f32_v8i8(<8 x float> %f) {
 ; CHECK-SD-NEXT:    movi v2.4s, #127
 ; CHECK-SD-NEXT:    fcvtzs v1.4s, v1.4s
 ; CHECK-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-SD-NEXT:    mvni v3.4s, #127
 ; CHECK-SD-NEXT:    smin v1.4s, v1.4s, v2.4s
 ; CHECK-SD-NEXT:    smin v0.4s, v0.4s, v2.4s
-; CHECK-SD-NEXT:    mvni v2.4s, #127
-; CHECK-SD-NEXT:    smax v1.4s, v1.4s, v2.4s
-; CHECK-SD-NEXT:    smax v0.4s, v0.4s, v2.4s
+; CHECK-SD-NEXT:    smax v1.4s, v1.4s, v3.4s
+; CHECK-SD-NEXT:    smax v0.4s, v0.4s, v3.4s
 ; CHECK-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
 ; CHECK-SD-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-SD-NEXT:    ret
@@ -4297,11 +4337,11 @@ define <8 x i8> @test_signed_v8f32_v8i8(<8 x float> %f) {
 ; CHECK-GI-NEXT:    movi v2.4s, #127
 ; CHECK-GI-NEXT:    fcvtzs v0.4s, v0.4s
 ; CHECK-GI-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-GI-NEXT:    mvni v3.4s, #127
 ; CHECK-GI-NEXT:    smin v0.4s, v0.4s, v2.4s
 ; CHECK-GI-NEXT:    smin v1.4s, v1.4s, v2.4s
-; CHECK-GI-NEXT:    mvni v2.4s, #127
-; CHECK-GI-NEXT:    smax v0.4s, v0.4s, v2.4s
-; CHECK-GI-NEXT:    smax v1.4s, v1.4s, v2.4s
+; CHECK-GI-NEXT:    smax v0.4s, v0.4s, v3.4s
+; CHECK-GI-NEXT:    smax v1.4s, v1.4s, v3.4s
 ; CHECK-GI-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
 ; CHECK-GI-NEXT:    xtn v0.8b, v0.8h
 ; CHECK-GI-NEXT:    ret
@@ -4405,6 +4445,7 @@ define <16 x i8> @test_signed_v16f16_v16i8(<16 x half> %f) {
 ; CHECK-SD-CVT-NEXT:    fcvtl2 v4.4s, v0.8h
 ; CHECK-SD-CVT-NEXT:    fcvtl v0.4s, v0.4h
 ; CHECK-SD-CVT-NEXT:    movi v2.4s, #127
+; CHECK-SD-CVT-NEXT:    mvni v5.4s, #127
 ; CHECK-SD-CVT-NEXT:    fcvtzs v3.4s, v3.4s
 ; CHECK-SD-CVT-NEXT:    fcvtzs v1.4s, v1.4s
 ; CHECK-SD-CVT-NEXT:    fcvtzs v4.4s, v4.4s
@@ -4413,13 +4454,12 @@ define <16 x i8> @test_signed_v16f16_v16i8(<16 x half> %f) {
 ; CHECK-SD-CVT-NEXT:    smin v1.4s, v1.4s, v2.4s
 ; CHECK-SD-CVT-NEXT:    smin v4.4s, v4.4s, v2.4s
 ; CHECK-SD-CVT-NEXT:    smin v0.4s, v0.4s, v2.4s
-; CHECK-SD-CVT-NEXT:    mvni v2.4s, #127
-; CHECK-SD-CVT-NEXT:    smax v3.4s, v3.4s, v2.4s
-; CHECK-SD-CVT-NEXT:    smax v1.4s, v1.4s, v2.4s
-; CHECK-SD-CVT-NEXT:    smax v4.4s, v4.4s, v2.4s
-; CHECK-SD-CVT-NEXT:    smax v0.4s, v0.4s, v2.4s
-; CHECK-SD-CVT-NEXT:    uzp1 v1.8h, v1.8h, v3.8h
-; CHECK-SD-CVT-NEXT:    uzp1 v0.8h, v0.8h, v4.8h
+; CHECK-SD-CVT-NEXT:    smax v2.4s, v3.4s, v5.4s
+; CHECK-SD-CVT-NEXT:    smax v1.4s, v1.4s, v5.4s
+; CHECK-SD-CVT-NEXT:    smax v3.4s, v4.4s, v5.4s
+; CHECK-SD-CVT-NEXT:    smax v0.4s, v0.4s, v5.4s
+; CHECK-SD-CVT-NEXT:    uzp1 v1.8h, v1.8h, v2.8h
+; CHECK-SD-CVT-NEXT:    uzp1 v0.8h, v0.8h, v3.8h
 ; CHECK-SD-CVT-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
 ; CHECK-SD-CVT-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/AArch64/qmovn.ll
+++ b/llvm/test/CodeGen/AArch64/qmovn.ll
@@ -811,9 +811,9 @@ define <8 x i8> @sminsmax_range_unsigned_i64_to_i8(<4 x i8> %x, <4 x i32> %y) {
 ; CHECK-SD-LABEL: sminsmax_range_unsigned_i64_to_i8:
 ; CHECK-SD:       // %bb.0: // %entry
 ; CHECK-SD-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-SD-NEXT:    movi v3.2d, #0x0000ff000000ff
 ; CHECK-SD-NEXT:    smax v1.4s, v1.4s, v2.4s
-; CHECK-SD-NEXT:    movi v2.2d, #0x0000ff000000ff
-; CHECK-SD-NEXT:    smin v1.4s, v1.4s, v2.4s
+; CHECK-SD-NEXT:    smin v1.4s, v1.4s, v3.4s
 ; CHECK-SD-NEXT:    xtn v1.4h, v1.4s
 ; CHECK-SD-NEXT:    uzp1 v0.8b, v0.8b, v1.8b
 ; CHECK-SD-NEXT:    ret
@@ -843,9 +843,9 @@ define <8 x i8> @sminsmax_range_signed_i32_to_i8(<4 x i8> %x, <4 x i32> %y) {
 ; CHECK-SD-LABEL: sminsmax_range_signed_i32_to_i8:
 ; CHECK-SD:       // %bb.0: // %entry
 ; CHECK-SD-NEXT:    mvni v2.4s, #127
+; CHECK-SD-NEXT:    movi v3.4s, #127
 ; CHECK-SD-NEXT:    smax v1.4s, v1.4s, v2.4s
-; CHECK-SD-NEXT:    movi v2.4s, #127
-; CHECK-SD-NEXT:    smin v1.4s, v1.4s, v2.4s
+; CHECK-SD-NEXT:    smin v1.4s, v1.4s, v3.4s
 ; CHECK-SD-NEXT:    xtn v1.4h, v1.4s
 ; CHECK-SD-NEXT:    uzp1 v0.8b, v0.8b, v1.8b
 ; CHECK-SD-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/sat-add.ll
+++ b/llvm/test/CodeGen/AArch64/sat-add.ll
@@ -420,9 +420,9 @@ define <4 x i32> @unsigned_sat_constant_v4i32_using_min(<4 x i32> %x) {
 ; CHECK-LABEL: unsigned_sat_constant_v4i32_using_min:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mvni v1.4s, #42
+; CHECK-NEXT:    movi v2.4s, #42
 ; CHECK-NEXT:    umin v0.4s, v0.4s, v1.4s
-; CHECK-NEXT:    movi v1.4s, #42
-; CHECK-NEXT:    add v0.4s, v0.4s, v1.4s
+; CHECK-NEXT:    add v0.4s, v0.4s, v2.4s
 ; CHECK-NEXT:    ret
   %c = icmp ult <4 x i32> %x, <i32 -43, i32 -43, i32 -43, i32 -43>
   %s = select <4 x i1> %c, <4 x i32> %x, <4 x i32> <i32 -43, i32 -43, i32 -43, i32 -43>

--- a/llvm/test/CodeGen/AArch64/saturating-vec-smull.ll
+++ b/llvm/test/CodeGen/AArch64/saturating-vec-smull.ll
@@ -108,12 +108,12 @@ define <2 x i64> @saturating_2xi32_2xi64(<2 x i32> %a, <2 x i32> %b) {
 define <6 x i16> @saturating_6xi16(<6 x i16> %a, <6 x i16> %b) {
 ; CHECK-LABEL: saturating_6xi16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    smull2 v3.4s, v1.8h, v0.8h
-; CHECK-NEXT:    movi v2.4s, #127, msl #8
+; CHECK-NEXT:    smull2 v2.4s, v1.8h, v0.8h
+; CHECK-NEXT:    movi v3.4s, #127, msl #8
 ; CHECK-NEXT:    sqdmulh v0.4h, v1.4h, v0.4h
-; CHECK-NEXT:    sshr v3.4s, v3.4s, #15
-; CHECK-NEXT:    smin v2.4s, v3.4s, v2.4s
-; CHECK-NEXT:    xtn2 v0.8h, v2.4s
+; CHECK-NEXT:    sshr v2.4s, v2.4s, #15
+; CHECK-NEXT:    smin v1.4s, v2.4s, v3.4s
+; CHECK-NEXT:    xtn2 v0.8h, v1.4s
 ; CHECK-NEXT:    ret
   %as = sext <6 x i16> %a to <6 x i32>
   %bs = sext <6 x i16> %b to <6 x i32>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A320-neon-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A320-neon-instructions.s
@@ -1580,10 +1580,10 @@ zip2	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     1.00                        smaxp	v0.4h, v0.4h, v0.4h
 # CHECK-NEXT:  1      3     1.00                        smaxp	v0.8b, v0.8b, v0.8b
 # CHECK-NEXT:  1      3     1.00                        smin	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     1.00                        smin	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      3     1.00                        smin	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      3     1.00                        smin	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     1.00                        sminp	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     1.00                        sminp	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      3     1.00                        sminp	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      3     1.00                        sminp	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      4     1.00                        smlal	v0.2d, v0.2s, v0.2s
 # CHECK-NEXT:  1      4     1.00                        smlal	v0.4s, v0.4h, v0.4h
@@ -1939,10 +1939,10 @@ zip2	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     1.00                        uhadd	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     1.00                        uhsub	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      3     1.00                        umax	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     1.00                        umax	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      3     1.00                        umax	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      3     1.00                        umax	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     1.00                        umaxp	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     1.00                        umaxp	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      3     1.00                        umaxp	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      3     1.00                        umaxp	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     1.00                        umin	v0.2s, v0.2s, v0.2s
 # CHECK-NEXT:  1      3     1.00                        umin	v0.4h, v0.4h, v0.4h

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A510-neon-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A510-neon-instructions.s
@@ -1580,10 +1580,10 @@ zip2	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        smaxp	v0.4h, v0.4h, v0.4h
 # CHECK-NEXT:  1      3     0.50                        smaxp	v0.8b, v0.8b, v0.8b
 # CHECK-NEXT:  1      3     0.50                        smin	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     0.50                        smin	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      3     0.50                        smin	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      3     0.50                        smin	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        sminp	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     0.50                        sminp	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      3     0.50                        sminp	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      3     0.50                        sminp	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      4     0.50                        smlal	v0.2d, v0.2s, v0.2s
 # CHECK-NEXT:  1      4     0.50                        smlal	v0.4s, v0.4h, v0.4h
@@ -1939,10 +1939,10 @@ zip2	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        uhadd	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        uhsub	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      3     0.50                        umax	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     0.50                        umax	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      3     0.50                        umax	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      3     0.50                        umax	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        umaxp	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     0.50                        umaxp	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      3     0.50                        umaxp	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      3     0.50                        umaxp	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      3     0.50                        umin	v0.2s, v0.2s, v0.2s
 # CHECK-NEXT:  1      3     0.50                        umin	v0.4h, v0.4h, v0.4h

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-neon-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-neon-instructions.s
@@ -1580,10 +1580,10 @@ zip2	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      2     0.50                        smaxp	v0.4h, v0.4h, v0.4h
 # CHECK-NEXT:  1      2     0.50                        smaxp	v0.8b, v0.8b, v0.8b
 # CHECK-NEXT:  1      2     1.00                        smin	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     1.00                        smin	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      2     1.00                        smin	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      2     1.00                        smin	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      2     1.00                        sminp	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     1.00                        sminp	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      2     1.00                        sminp	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      2     1.00                        sminp	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      4     1.00                        smlal	v0.2d, v0.2s, v0.2s
 # CHECK-NEXT:  1      4     1.00                        smlal	v0.4s, v0.4h, v0.4h
@@ -1939,10 +1939,10 @@ zip2	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      2     1.00                        uhadd	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      2     1.00                        uhsub	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      2     1.00                        umax	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     1.00                        umax	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      2     1.00                        umax	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      2     1.00                        umax	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      2     1.00                        umaxp	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:  1      4     1.00                        umaxp	v0.4s, v0.4s, v0.4s
+# CHECK-NEXT:  1      2     1.00                        umaxp	v0.4s, v0.4s, v0.4s
 # CHECK-NEXT:  1      2     1.00                        umaxp	v0.8h, v0.8h, v0.8h
 # CHECK-NEXT:  1      2     0.50                        umin	v0.2s, v0.2s, v0.2s
 # CHECK-NEXT:  1      2     0.50                        umin	v0.4h, v0.4h, v0.4h


### PR DESCRIPTION
While working to introduce the C1-Nano scheduling model some existing "typos" were found in the definitions used in the Cortex-A55, Cortex-A320 and Cortex-A510 scheduling models.

This corrects these typos and updated any tests affected by the changes.

There were 2 forms of typos found:

  "8b" which should have been "8h"
  "i132" which should have been "i32"