### PR TITLE
Silence "switch statement contains default but not case labels"; NFC

### DIFF
--- a/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
@@ -2732,10 +2732,6 @@ static bool HasExtraNeonArgument(unsigned BuiltinID) {
   case ARM::BI__builtin_arm_vcvtr_d:
     mask = 1;
   }
-  switch (BuiltinID) {
-  default:
-    break;
-  }
 
   if (mask)
     return true;


### PR DESCRIPTION
Silences an MSVC C4065 diagnostic that was introduced in 0dd1cb015e8b1439e70c152eb134abb01e1af831