### PR TITLE
[TableGen][CodeGen][NFC] Add ImplicitRegByHwMode infrastructure

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -120,11 +120,18 @@ protected:
   /// MCOperandInfo's RegClass field for LookupRegClassByHwMode operands.
   const int16_t *const RegClassByHwMode;
 
+  /// Subtarget specific sub-array of MCInstrInfo's ImplicitRegByHwModeTables
+  /// (i.e. the row for the active HwMode). Used to resolve implicit operand
+  /// registers that vary by HwMode (e.g. VCC vs VCC_LO).
+  const MCPhysReg *ImplicitRegByHwModeResolved;
+
   TargetInstrInfo(const TargetRegisterInfo &TRI, unsigned CFSetupOpcode = ~0u,
                   unsigned CFDestroyOpcode = ~0u, unsigned CatchRetOpcode = ~0u,
                   unsigned ReturnOpcode = ~0u,
-                  const int16_t *const RegClassByHwModeTable = nullptr)
+                  const int16_t *const RegClassByHwModeTable = nullptr,
+                  const MCPhysReg *ImplicitRegByHwModeRow = nullptr)
       : TRI(TRI), RegClassByHwMode(RegClassByHwModeTable),
+        ImplicitRegByHwModeResolved(ImplicitRegByHwModeRow),
         CallFrameSetupOpcode(CFSetupOpcode),
         CallFrameDestroyOpcode(CFDestroyOpcode), CatchRetOpcode(CatchRetOpcode),
         ReturnOpcode(ReturnOpcode) {}
@@ -155,6 +162,17 @@ public:
     if (OpInfo.isLookupRegClassByHwMode())
       return RegClassByHwMode[OpInfo.RegClass];
     return OpInfo.RegClass;
+  }
+
+  /// Resolve an implicit register to its HwMode-specific variant.
+  /// Pre-indexed to the active subtarget's HwMode, so no HwModeId argument
+  /// is needed. Returns the input unchanged if no RegisterByHwMode entry
+  /// exists.
+  MCPhysReg resolveImplicitReg(MCPhysReg Reg) const {
+    for (int16_t I = 0; I < NumImplicitRegByHwModes; ++I)
+      if (ImplicitRegByHwModeTables[I] == Reg)
+        return ImplicitRegByHwModeResolved[I];
+    return Reg;
   }
 
   /// Given a machine instruction descriptor, returns the register

--- a/llvm/include/llvm/MC/MCInstrInfo.h
+++ b/llvm/include/llvm/MC/MCInstrInfo.h
@@ -48,6 +48,11 @@ protected:
   const int16_t *RegClassByHwModeTables;
   int16_t NumRegClassByHwModes;
 
+  // Pointer to 2d array [NumHwModes][NumImplicitRegByHwModes].
+  // Row 0 (DefaultMode) stores the default-mode registers used as lookup keys.
+  const MCPhysReg *ImplicitRegByHwModeTables;
+  int16_t NumImplicitRegByHwModes;
+
 public:
   /// Initialize MCInstrInfo, called by TableGen auto-generated routines.
   /// *DO NOT USE*.
@@ -55,7 +60,9 @@ public:
                        const uint8_t *DF,
                        const ComplexDeprecationPredicate *CDI, unsigned NO,
                        const int16_t *RCHWTables = nullptr,
-                       int16_t NumRegClassByHwMode = 0) {
+                       int16_t NumRegClassByHwMode = 0,
+                       const MCPhysReg *IRBHWTables = nullptr,
+                       int16_t NumImplicitRegByHwMode = 0) {
     LastDesc = D + NO - 1;
     InstrNameIndices = NI;
     InstrNameData = ND;
@@ -64,6 +71,8 @@ public:
     NumOpcodes = NO;
     RegClassByHwModeTables = RCHWTables;
     NumRegClassByHwModes = NumRegClassByHwMode;
+    ImplicitRegByHwModeTables = IRBHWTables;
+    NumImplicitRegByHwModes = NumImplicitRegByHwMode;
   }
 
   unsigned getNumOpcodes() const { return NumOpcodes; }
@@ -83,6 +92,17 @@ public:
     if (OpInfo.isLookupRegClassByHwMode())
       RegClass = getRegClassByHwModeTable(HwModeId)[RegClass];
     return RegClass;
+  }
+
+  /// Resolve an implicit register to its HwMode-specific variant.
+  /// If the register has a RegisterByHwMode entry, returns the register for
+  /// the given HwModeId. Otherwise returns the input unchanged.
+  MCPhysReg resolveImplicitReg(MCPhysReg Reg, unsigned HwModeId) const {
+    for (int16_t I = 0; I < NumImplicitRegByHwModes; ++I)
+      if (ImplicitRegByHwModeTables[I] == Reg)
+        return ImplicitRegByHwModeTables[HwModeId * NumImplicitRegByHwModes +
+                                         I];
+    return Reg;
   }
 
   /// Return the machine instruction descriptor that corresponds to the

--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -168,9 +168,14 @@ class RegAltNameIndex {
 }
 def NoRegAltName : RegAltNameIndex;
 
+/// Abstract base class common to Register and ImplicitRegByHwMode.
+/// This permits using ImplicitRegByHwMode in Instruction Uses/Defs
+/// lists alongside plain Register references.
+class RegisterLike;
+
 // Register - You should define one instance of this class for each register
 // in the target machine. String n will become the "name" of the register.
-class Register<string n, list<string> altNames = []> {
+class Register<string n, list<string> altNames = []> : RegisterLike {
   string Namespace = "";
   string AsmName = n;
   list<string> AltNames = altNames;
@@ -647,8 +652,8 @@ class Instruction : InstructionEncoding {
   // The follow state will eventually be inferred automatically from the
   // instruction pattern.
 
-  list<Register> Uses = []; // Default to using no non-operand registers
-  list<Register> Defs = []; // Default to modifying no non-operand registers
+  list<RegisterLike> Uses = []; // Default to using no non-operand registers
+  list<RegisterLike> Defs = []; // Default to modifying no non-operand registers
 
   // Predicates - List of predicates which will be turned into isel matching
   // code.
@@ -999,6 +1004,16 @@ class RegClassByHwMode<list<HwMode> Modes,
                        list<RegisterClass> RegClasses>
   : HwModeSelect<Modes, !size(RegClasses)>, RegisterClassLike {
   list<RegisterClass> Objects = RegClasses;
+}
+
+/// ImplicitRegByHwMode - Maps a register to different physical registers
+/// depending on the HwMode, for use in Instruction Uses/Defs lists.
+/// For example, on AMDGPU wave32 targets VCC (64-bit) is narrowed to
+/// VCC_LO (32-bit). This allows the MCInstrDesc implicit operands to
+/// resolve to the correct register per subtarget.
+class ImplicitRegByHwMode<list<HwMode> Modes, list<Register> Regs>
+    : HwModeSelect<Modes, !size(Regs)>, RegisterLike {
+  list<Register> Objects = Regs;
 }
 
 /// unknown definition - Mark this operand as being of unknown type, causing

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
@@ -69,8 +69,8 @@ class ILFormat<dag outs, dag ins, string asmstr, list<dag> pattern>
 }
 
 // Get the union of two Register lists
-class RegListUnion<list<Register> lstA, list<Register> lstB> {
-  list<Register> ret = !listconcat(lstA, !listremove(lstB, lstA));
+class RegListUnion<list<RegisterLike> lstA, list<RegisterLike> lstB> {
+  list<RegisterLike> ret = !listconcat(lstA, !listremove(lstB, lstA));
 }
 
 class AMDGPUPat<dag pattern, dag result> : Pat<pattern, result>,

--- a/llvm/test/TableGen/RegClassByHwMode.td
+++ b/llvm/test/TableGen/RegClassByHwMode.td
@@ -63,8 +63,23 @@ include "Common/RegClassByHwModeCommon.td"
 // INSTRINFO-NEXT:  },
 // INSTRINFO-NEXT: };
 
+// INSTRINFO: extern const MCPhysReg MyTargetImplicitRegByHwModeTables[4][1] = {
+// INSTRINFO-NEXT:   { // DefaultMode
+// INSTRINFO-NEXT:     MyTarget::X0, // MyImplicitReg
+// INSTRINFO-NEXT:   },
+// INSTRINFO-NEXT:   { // EvenMode
+// INSTRINFO-NEXT:     MyTarget::X1, // MyImplicitReg
+// INSTRINFO-NEXT:   },
+// INSTRINFO-NEXT:   { // OddMode
+// INSTRINFO-NEXT:     MyTarget::X0, // MyImplicitReg (default)
+// INSTRINFO-NEXT:   },
+// INSTRINFO-NEXT:   { // Ptr64
+// INSTRINFO-NEXT:     MyTarget::X0, // MyImplicitReg (default)
+// INSTRINFO-NEXT:   },
+// INSTRINFO-NEXT: };
+
 // INSTRINFO: static inline void InitMyTargetMCInstrInfo(
-// INSTRINFO-NEXT: II->InitMCInstrInfo(MyTargetDescs.Insts, MyTargetInstrNameIndices, MyTargetInstrNameData, nullptr, nullptr, {{[0-9]+}}, &MyTargetRegClassByHwModeTables[0][0], 3);
+// INSTRINFO-NEXT: II->InitMCInstrInfo({{.*}}, &MyTargetImplicitRegByHwModeTables[0][0], 1);
 
 // INSTRINFO: #ifdef GET_INSTRINFO_HEADER
 // INSTRINFO-NEXT: #undef GET_INSTRINFO_HEADER
@@ -76,6 +91,7 @@ include "Common/RegClassByHwModeCommon.td"
 // INSTRINFO-NEXT:   ~MyTargetGenInstrInfo() override = default;
 // INSTRINFO-NEXT: };
 // INSTRINFO-NEXT: extern const int16_t MyTargetRegClassByHwModeTables[4][3];
+// INSTRINFO-NEXT: extern const MCPhysReg MyTargetImplicitRegByHwModeTables[4][1];
 // INSTRINFO-EMPTY:
 // INSTRINFO-NEXT: } // namespace llvm
 // INSTRINFO: #endif // GET_INSTRINFO_HEADER
@@ -471,6 +487,18 @@ def : Pat<
 >;
 
 defm : RemapAllTargetPseudoPointerOperands<XRegs_EvenIfRequired>;
+
+// Test ImplicitRegByHwMode: X0 is used in DefaultMode, X1 in EvenMode.
+def MyImplicitReg : ImplicitRegByHwMode<[DefaultMode, EvenMode], [X0, X1]>;
+
+def IMPLICIT_REG_INSTR : TestInstruction {
+  let OutOperandList = (outs XRegs:$dst);
+  let InOperandList = (ins XRegs:$src);
+  let AsmString = "implicit_reg_instr $dst, $src";
+  let opcode = 7;
+  let Uses = [MyImplicitReg];
+  let Defs = [MyImplicitReg];
+}
 
 def MyTargetISA : InstrInfo;
 def MyTarget : Target { let InstructionSet = MyTargetISA; }

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
@@ -506,7 +506,9 @@ MVT CodeGenInstruction::HasOneImplicitDefWithKnownVT(
 
   // Check to see if the first implicit def has a resolvable type.
   const Record *FirstImplicitDef = ImplicitDefs[0];
-  assert(FirstImplicitDef->isSubClassOf("Register"));
+  assert(FirstImplicitDef->isSubClassOf("RegisterLike"));
+  if (FirstImplicitDef->isSubClassOf("ImplicitRegByHwMode"))
+    return MVT::Other;
   const std::vector<ValueTypeByHwMode> &RegVTs =
       TargetInfo.getRegisterVTs(FirstImplicitDef);
   if (RegVTs.size() == 1 && RegVTs[0].isSimple())

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -13,6 +13,7 @@
 
 #include "Basic/SequenceToOffsetTable.h"
 #include "Common/CodeGenDAGPatterns.h"
+#include "Common/CodeGenHwModes.h"
 #include "Common/CodeGenInstruction.h"
 #include "Common/CodeGenRegisters.h"
 #include "Common/CodeGenSchedule.h"
@@ -902,6 +903,21 @@ void InstrInfoEmitter::buildTargetSpecializedPseudoInstsMap() {
 //===----------------------------------------------------------------------===//
 
 // run - Emit the main instruction description records for the target...
+/// If R is an ImplicitRegByHwMode record, return the default-mode Register
+/// record. Otherwise return R unchanged. The default-mode register is used as
+/// the canonical value in MCInstrDesc implicit operand slots and as the lookup
+/// key in ImplicitRegByHwModeTables (row 0) for runtime resolution.
+static const Record *resolveImplicitRegByHwMode(const Record *R,
+                                                const CodeGenHwModes &CGH) {
+  if (!R->isSubClassOf("ImplicitRegByHwMode"))
+    return R;
+  const HwModeSelect &MS = CGH.getHwModeSelect(R);
+  for (const auto &P : MS.Items)
+    if (P.first == CodeGenHwModes::DefaultMode)
+      return P.second;
+  PrintFatalError(R->getLoc(), "ImplicitRegByHwMode has no default mode entry");
+}
+
 void InstrInfoEmitter::run(raw_ostream &OS) {
   TGTimer &Timer = Records.getTimer();
   Timer.startTimer("Analyze DAG patterns");
@@ -933,18 +949,38 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
   bool HasUseLogicalOperandMappings = false;
   bool HasUseNamedOperandTable = false;
 
+  const CodeGenHwModes &CGH = Target.getHwModes();
+
   Timer.startTimer("Collect uses/defs");
   std::map<std::vector<const Record *>, unsigned> EmittedLists;
   std::vector<std::vector<const Record *>> ImplicitLists;
   unsigned ImplicitListSize = 0;
+
+  // Collect all unique ImplicitRegByHwMode records for table generation.
+  std::vector<const Record *> ImplicitRegByHwModes;
+  auto addImplicitRegByHwMode = [&](const Record *R) {
+    if (R->isSubClassOf("ImplicitRegByHwMode") &&
+        !llvm::is_contained(ImplicitRegByHwModes, R))
+      ImplicitRegByHwModes.push_back(R);
+  };
+
   for (const CodeGenInstruction *Inst : NumberedInstructions) {
     HasUseLogicalOperandMappings |=
         Inst->TheDef->getValueAsBit("UseLogicalOperandMappings");
     HasUseNamedOperandTable |=
         Inst->TheDef->getValueAsBit("UseNamedOperandTable");
 
-    std::vector<const Record *> ImplicitOps = Inst->ImplicitUses;
-    llvm::append_range(ImplicitOps, Inst->ImplicitDefs);
+    // Resolve ImplicitRegByHwMode records to their default-mode Register
+    // for the ImplicitOps array.  Collect the originals for table generation.
+    std::vector<const Record *> ImplicitOps;
+    for (const Record *R : Inst->ImplicitUses) {
+      addImplicitRegByHwMode(R);
+      ImplicitOps.push_back(resolveImplicitRegByHwMode(R, CGH));
+    }
+    for (const Record *R : Inst->ImplicitDefs) {
+      addImplicitRegByHwMode(R);
+      ImplicitOps.push_back(resolveImplicitRegByHwMode(R, CGH));
+    }
     if (EmittedLists.try_emplace(ImplicitOps, ImplicitListSize).second) {
       ImplicitLists.push_back(ImplicitOps);
       ImplicitListSize += ImplicitOps.size();
@@ -976,7 +1012,6 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
   }
 
   const CodeGenRegBank &RegBank = Target.getRegBank();
-  const CodeGenHwModes &CGH = Target.getHwModes();
   unsigned NumModes = CGH.getNumModeIds();
   ArrayRef<const Record *> RegClassByHwMode = Target.getAllRegClassByHwMode();
   unsigned NumClassesByHwMode = RegClassByHwMode.size();
@@ -1132,6 +1167,40 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
       OS << "};\n\n";
     }
 
+    unsigned NumImplicitRegByHwModes = ImplicitRegByHwModes.size();
+    if (NumImplicitRegByHwModes != 0) {
+      // Emit the RegisterByHwMode lookup table: for each HwMode, the resolved
+      // MCPhysReg for each ImplicitRegByHwMode definition.
+      OS << "extern const MCPhysReg " << TargetName
+         << "ImplicitRegByHwModeTables[" << NumModes << "]["
+         << NumImplicitRegByHwModes << "] = {\n";
+
+      for (unsigned M = 0; M < NumModes; ++M) {
+        OS << "  { // " << CGH.getModeName(M, /*IncludeDefault=*/true) << '\n';
+        for (unsigned I = 0; I != NumImplicitRegByHwModes; ++I) {
+          const Record *Def = ImplicitRegByHwModes[I];
+          const HwModeSelect &ModeSelect = CGH.getHwModeSelect(Def);
+
+          auto FoundMode =
+              find_if(ModeSelect.Items, [=](const HwModeSelect::PairType P) {
+                return P.first == M;
+              });
+
+          if (FoundMode == ModeSelect.Items.end()) {
+            // Fall back to the default-mode register.
+            const Record *DefaultReg = resolveImplicitRegByHwMode(Def, CGH);
+            OS << indent(4) << getQualifiedName(DefaultReg) << ", // "
+               << Def->getName() << " (default)\n";
+          } else {
+            OS << indent(4) << getQualifiedName(FoundMode->second) << ", // "
+               << Def->getName() << "\n";
+          }
+        }
+        OS << "  },\n";
+      }
+      OS << "};\n\n";
+    }
+
     OS << "static inline void Init" << TargetName
        << "MCInstrInfo(MCInstrInfo *II) {\n";
     OS << "  II->InitMCInstrInfo(" << TargetName << "Descs.Insts, "
@@ -1149,6 +1218,13 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
     if (NumClassesByHwMode != 0) {
       OS << '&' << TargetName << "RegClassByHwModeTables[0][0], "
          << NumClassesByHwMode;
+    } else
+      OS << "nullptr, 0";
+
+    OS << ", ";
+    if (NumImplicitRegByHwModes != 0) {
+      OS << '&' << TargetName << "ImplicitRegByHwModeTables[0][0], "
+         << NumImplicitRegByHwModes;
     } else
       OS << "nullptr, 0";
 
@@ -1175,6 +1251,11 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
       if (NumClassesByHwMode != 0) {
         OS << "extern const int16_t " << TargetName << "RegClassByHwModeTables["
            << NumModes << "][" << NumClassesByHwMode << "];\n";
+      }
+      if (!ImplicitRegByHwModes.empty()) {
+        OS << "extern const MCPhysReg " << TargetName
+           << "ImplicitRegByHwModeTables[" << NumModes << "]["
+           << ImplicitRegByHwModes.size() << "];\n";
       }
     } // end llvm namespace.
 
@@ -1218,6 +1299,9 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
     if (HasComplexDeprecationInfos)
       OS << "extern const MCInstrInfo::ComplexDeprecationPredicate "
          << TargetName << "InstrComplexDeprecationInfos[];\n";
+
+    unsigned NumImplicitRegByHwModes = ImplicitRegByHwModes.size();
+
     Twine ClassName = TargetName + "GenInstrInfo";
     OS << ClassName << "::" << ClassName
        << "(const TargetSubtargetInfo &STI, const TargetRegisterInfo &TRI, "
@@ -1229,6 +1313,13 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
     if (NumClassesByHwMode != 0)
       OS << ", " << TargetName
          << "RegClassByHwModeTables[STI.getHwMode(MCSubtargetInfo::HwMode_"
+            "RegInfo)]";
+    else
+      OS << ", nullptr";
+
+    if (NumImplicitRegByHwModes != 0)
+      OS << ", " << TargetName
+         << "ImplicitRegByHwModeTables[STI.getHwMode(MCSubtargetInfo::HwMode_"
             "RegInfo)]";
 
     OS << ") {\n"
@@ -1242,12 +1333,20 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
       OS << TargetName << "InstrComplexDeprecationInfos, ";
     else
       OS << "nullptr, ";
-    OS << NumberedInstructions.size();
+    OS << NumberedInstructions.size() << ", ";
 
-    if (NumClassesByHwMode != 0) {
-      OS << ", &" << TargetName << "RegClassByHwModeTables[0][0], "
+    if (NumClassesByHwMode != 0)
+      OS << "&" << TargetName << "RegClassByHwModeTables[0][0], "
          << NumClassesByHwMode;
-    }
+    else
+      OS << "nullptr, 0";
+
+    OS << ", ";
+    if (NumImplicitRegByHwModes != 0)
+      OS << "&" << TargetName << "ImplicitRegByHwModeTables[0][0], "
+         << NumImplicitRegByHwModes;
+    else
+      OS << "nullptr, 0";
 
     OS << ");\n"
           "}\n";
@@ -1303,9 +1402,15 @@ void InstrInfoEmitter::emitRecord(
   const CodeGenTarget &Target = CDP.getTargetInfo();
 
   // Emit the implicit use/def list...
+  // Resolve ImplicitRegByHwMode to default-mode registers so the lookup
+  // into EmittedLists matches the resolved keys used during collection.
+  const CodeGenHwModes &CGH = Target.getHwModes();
   OS << Inst.ImplicitUses.size() << ",\t" << Inst.ImplicitDefs.size() << ",\t";
-  std::vector<const Record *> ImplicitOps = Inst.ImplicitUses;
-  llvm::append_range(ImplicitOps, Inst.ImplicitDefs);
+  std::vector<const Record *> ImplicitOps;
+  for (const Record *R : Inst.ImplicitUses)
+    ImplicitOps.push_back(resolveImplicitRegByHwMode(R, CGH));
+  for (const Record *R : Inst.ImplicitDefs)
+    ImplicitOps.push_back(resolveImplicitRegByHwMode(R, CGH));
 
   // Emit the operand info offset.
   OperandInfoTy OperandInfo = GetOperandInfo(Inst);


### PR DESCRIPTION
Add infrastructure for resolving implicit operand registers based on HwMode, analogous to the existing `RegClassByHwMode` mechanism.

On AMDGPU, instructions declare Uses/Defs with 64-bit registers (`VCC`, `EXEC`) in TableGen, but wave32 subtargets need the 32-bit variants (`VCC_LO`, `EXEC_LO`). Currently the `MCInstrDesc` stores a fixed register, causing MIR round-trip failures: the printer emits `$vcc_lo` but the parser rejects it because the `MCInstrDesc` expects `$vcc`.

This commit adds the plumbing without activating it:

- Target.td: `RegisterLike` base class, `ImplicitRegByHwMode` class, Uses/Defs fields changed from `list<Register>` to `list<RegisterLike>`
- InstrInfoEmitter: Emit `ImplicitRegByHwModeTables` side table (same pattern as `RegClassByHwModeTables`). Row 0 stores the default-mode registers used as lookup keys for runtime resolution.
- `MCInstrInfo::resolveImplicitReg(MCPhysReg, HwModeId)` for the MC layer, where the caller must specify which HwMode to resolve to.
- `TargetInstrInfo::resolveImplicitReg(MCPhysReg)` for CodeGen, where the active HwMode row is pre-indexed at construction time by the tablegen-generated constructor, so callers don't need to look up the `HwModeId`.

Follow-up patches will adopt this for AMDGPU `VCC`/`EXEC` and enable runtime resolution to fix MIR round-trip failures on wave32 targets (see https://github.com/llvm/llvm-project/pull/180707).