### PR TITLE
Re-enable MSVC C4510 diagnostic; NFC

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -758,7 +758,6 @@ if (MSVC)
       -wd4127 # Suppress 'conditional expression is constant'
       -wd4512 # Suppress 'assignment operator could not be generated'
       -wd4505 # Suppress 'unreferenced local function has been removed'
-      -wd4510 # Suppress 'default constructor could not be generated'
       -wd4702 # Suppress 'unreachable code'
       -wd4245 # Suppress ''conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch'
       -wd4310 # Suppress 'cast truncates constant value'


### PR DESCRIPTION
From MSDN:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4510?view=msvc-170

> 'class' : default constructor could not be generated

This diagnostic was disabled in 5c73e1f85c5d37a5b037c70f3c112eec5646acb3 because it was generating 1700+ diagnostics at the time. Locally enabling the warning causes no new diagnostics to be emitted, so I think the false positives have been addressed and this can be enabled.