### PR TITLE
[InstSimplify] Add support for llvm.structured.gep

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -79,7 +79,6 @@ static Value *simplifyCastInst(unsigned, Value *, Type *, const SimplifyQuery &,
                                unsigned);
 static Value *simplifyGEPInst(Type *, Value *, ArrayRef<Value *>,
                               GEPNoWrapFlags, const SimplifyQuery &, unsigned);
-static Value *simplifyStructuredGEP(StructuredGEPInst *I);
 static Value *simplifySelectInst(Value *, Value *, Value *,
                                  const SimplifyQuery &, unsigned);
 static Value *simplifyInstructionWithOperands(Instruction *I,
@@ -4539,11 +4538,6 @@ static Value *simplifyWithOpsReplaced(Value *V,
       if (NewOps.size() == 2 && match(NewOps[1], m_Zero()))
         return NewOps[0];
     }
-
-    if (auto SGEP = dyn_cast<StructuredGEPInst>(I)) {
-      if (SGEP->getNumIndices() == 0)
-        return NewOps[0];
-    }
   } else {
     // The simplification queries below may return the original value. Consider:
     //   %div = udiv i32 %arg, %arg2
@@ -5369,10 +5363,6 @@ static Value *simplifyGEPInst(Type *SrcTy, Value *Ptr,
 Value *llvm::simplifyGEPInst(Type *SrcTy, Value *Ptr, ArrayRef<Value *> Indices,
                              GEPNoWrapFlags NW, const SimplifyQuery &Q) {
   return ::simplifyGEPInst(SrcTy, Ptr, Indices, NW, Q, RecursionLimit);
-}
-
-static Value *simplifyStructuredGEP(StructuredGEPInst *I) {
-  return I->getNumIndices() == 0 ? I->getPointerOperand() : nullptr;
 }
 
 /// Given operands for an InsertValueInst, see if we can fold the result.
@@ -6626,6 +6616,8 @@ static Value *simplifyUnaryIntrinsic(Function *F, Value *Op0,
     if (isSplatValue(Op0))
       return Op0;
     break;
+  case Intrinsic::structured_gep:
+    return cast<StructuredGEPInst>(Call)->getPointerOperand();
   default:
     break;
   }
@@ -7577,9 +7569,6 @@ static Value *simplifyInstructionWithOperands(Instruction *I,
          "context instruction should be in the same function");
 
   const SimplifyQuery Q = SQ.CxtI ? SQ : SQ.getWithInstruction(I);
-
-  if (auto *SGEP = dyn_cast<StructuredGEPInst>(I))
-    return simplifyStructuredGEP(SGEP);
 
   switch (I->getOpcode()) {
   default:

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -79,6 +79,7 @@ static Value *simplifyCastInst(unsigned, Value *, Type *, const SimplifyQuery &,
                                unsigned);
 static Value *simplifyGEPInst(Type *, Value *, ArrayRef<Value *>,
                               GEPNoWrapFlags, const SimplifyQuery &, unsigned);
+static Value *simplifyStructuredGEP(StructuredGEPInst *I);
 static Value *simplifySelectInst(Value *, Value *, Value *,
                                  const SimplifyQuery &, unsigned);
 static Value *simplifyInstructionWithOperands(Instruction *I,
@@ -4538,6 +4539,11 @@ static Value *simplifyWithOpsReplaced(Value *V,
       if (NewOps.size() == 2 && match(NewOps[1], m_Zero()))
         return NewOps[0];
     }
+
+    if (auto SGEP = dyn_cast<StructuredGEPInst>(I)) {
+      if (SGEP->getNumIndices() == 0)
+        return NewOps[0];
+    }
   } else {
     // The simplification queries below may return the original value. Consider:
     //   %div = udiv i32 %arg, %arg2
@@ -5363,6 +5369,10 @@ static Value *simplifyGEPInst(Type *SrcTy, Value *Ptr,
 Value *llvm::simplifyGEPInst(Type *SrcTy, Value *Ptr, ArrayRef<Value *> Indices,
                              GEPNoWrapFlags NW, const SimplifyQuery &Q) {
   return ::simplifyGEPInst(SrcTy, Ptr, Indices, NW, Q, RecursionLimit);
+}
+
+static Value *simplifyStructuredGEP(StructuredGEPInst *I) {
+  return I->getNumIndices() == 0 ? I->getPointerOperand() : nullptr;
 }
 
 /// Given operands for an InsertValueInst, see if we can fold the result.
@@ -7567,6 +7577,9 @@ static Value *simplifyInstructionWithOperands(Instruction *I,
          "context instruction should be in the same function");
 
   const SimplifyQuery Q = SQ.CxtI ? SQ : SQ.getWithInstruction(I);
+
+  if (auto *SGEP = dyn_cast<StructuredGEPInst>(I))
+    return simplifyStructuredGEP(SGEP);
 
   switch (I->getOpcode()) {
   default:

--- a/llvm/test/Transforms/InstSimplify/structured-gep.ll
+++ b/llvm/test/Transforms/InstSimplify/structured-gep.ll
@@ -1,0 +1,91 @@
+; RUN: opt -S -passes=instsimplify < %s | FileCheck %s
+
+%struct.S = type { i32, float }
+%struct.Nested = type { %struct.S, i32 }
+
+@g = external global i32
+@arr = external global [10 x i32]
+
+define ptr @zero_index_local(ptr %p) {
+; CHECK-LABEL: @zero_index_local(ptr %p
+; CHECK-NEXT:    ret ptr %p
+;
+  %sgep = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(i32) %p)
+  ret ptr %sgep
+}
+
+define ptr @zero_index_global() {
+; CHECK-LABEL: @zero_index_global(
+; CHECK-NEXT:    ret ptr @g
+;
+  %sgep = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(i32) @g)
+  ret ptr %sgep
+}
+
+define ptr @zero_index_array(ptr %p) {
+; CHECK-LABEL: @zero_index_array(ptr %p
+; CHECK-NEXT:    ret ptr %p
+;
+  %sgep = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([10 x i32]) %p)
+  ret ptr %sgep
+}
+
+define ptr addrspace(11) @zero_index_addrspace(ptr addrspace(11) %p) {
+; CHECK-LABEL: @zero_index_addrspace(ptr addrspace(11) %p
+; CHECK-NEXT:    ret ptr addrspace(11) %p
+;
+  %sgep = call ptr addrspace(11) (ptr addrspace(11), ...) @llvm.structured.gep.p11(ptr addrspace(11) elementtype(i32) %p)
+  ret ptr addrspace(11) %sgep
+}
+
+define i32 @zero_index_with_load(ptr %p) {
+; CHECK-LABEL: @zero_index_with_load(ptr %p
+; CHECK-NEXT:    [[V:%.*]] = load i32, ptr %p, align 4
+; CHECK-NEXT:    ret i32 [[V]]
+;
+  %sgep = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(i32) %p)
+  %v = load i32, ptr %sgep, align 4
+  ret i32 %v
+}
+
+; GEP with a zero index can be simplified, but SGEP cannot.
+define ptr @zero_index_struct(ptr %p) {
+; CHECK-LABEL: @zero_index_struct(ptr %p
+; CHECK-NEXT:    [[SGEP:%.*]] = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S) %p, i32 0)
+; CHECK-NEXT:    ret ptr [[SGEP]]
+;
+  %sgep = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S) %p, i32 0)
+  ret ptr %sgep
+}
+
+define ptr @one_index_struct(ptr %p) {
+; CHECK-LABEL: @one_index_struct(ptr %p
+; CHECK-NEXT:    [[SGEP:%.*]] = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S) %p, i32 1)
+; CHECK-NEXT:    ret ptr [[SGEP]]
+;
+  %sgep = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.S) %p, i32 1)
+  ret ptr %sgep
+}
+
+define ptr @multi_index_nested(ptr %p) {
+; CHECK-LABEL: @multi_index_nested(
+; CHECK-NEXT:    [[SGEP:%.*]] = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.Nested) %p, i32 0, i32 0)
+; CHECK-NEXT:    ret ptr [[SGEP]]
+;
+  %sgep = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype(%struct.Nested) %p, i32 0, i32 0)
+  ret ptr %sgep
+}
+
+define ptr @dynamic_index(ptr %p, i32 %i) {
+; CHECK-LABEL: @dynamic_index(
+; CHECK-NEXT:    [[SGEP:%.*]] = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([10 x i32]) %p, i32 %i)
+; CHECK-NEXT:    ret ptr [[SGEP]]
+;
+  %sgep = call ptr (ptr, ...) @llvm.structured.gep.p0(ptr elementtype([10 x i32]) %p, i32 %i)
+  ret ptr %sgep
+}
+
+declare ptr @llvm.structured.gep.p0(ptr, ...) #0
+declare ptr addrspace(11) @llvm.structured.gep.p11(ptr addrspace(11), ...) #0
+
+attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }


### PR DESCRIPTION
Similar to GEP, the SGEP instruction with no indices can be simplified by directly using the base pointer.