### PR TITLE
[X86][GlobalISel] Ignore non-vregs in regbank mapping

### DIFF
--- a/llvm/lib/Target/X86/GISel/X86RegisterBankInfo.cpp
+++ b/llvm/lib/Target/X86/GISel/X86RegisterBankInfo.cpp
@@ -201,7 +201,7 @@ void X86RegisterBankInfo::getInstrPartialMappingIdxs(
   unsigned NumOperands = MI.getNumOperands();
   for (unsigned Idx = 0; Idx < NumOperands; ++Idx) {
     auto &MO = MI.getOperand(Idx);
-    if (!MO.isReg() || !MO.getReg())
+    if (!MO.isReg() || !MO.getReg().isVirtual())
       OpRegBankIdx[Idx] = PMI_None;
     else
       OpRegBankIdx[Idx] =
@@ -218,7 +218,7 @@ bool X86RegisterBankInfo::getInstrValueMapping(
   for (unsigned Idx = 0; Idx < NumOperands; ++Idx) {
     if (!MI.getOperand(Idx).isReg())
       continue;
-    if (!MI.getOperand(Idx).getReg())
+    if (!MI.getOperand(Idx).getReg().isVirtual())
       continue;
 
     auto Mapping = getValueMapping(OpRegBankIdx[Idx], 1);

--- a/llvm/test/CodeGen/X86/GlobalISel/regbankselect-dbg-value-physreg-crash.mir
+++ b/llvm/test/CodeGen/X86/GlobalISel/regbankselect-dbg-value-physreg-crash.mir
@@ -1,0 +1,34 @@
+# RUN: llc -mtriple=x86_64-linux-gnu                       -run-pass=regbankselect -verify-machineinstrs %s -o - | FileCheck %s
+# RUN: llc -mtriple=x86_64-linux-gnu -regbankselect-greedy -run-pass=regbankselect -verify-machineinstrs %s -o - | FileCheck %s
+
+# This reproduces a pre-regbankselect GMIR where DBG_VALUE already carries a
+# physical register. Regressions here used to crash when X86RegisterBankInfo
+# queried LLT for non-vreg register operands.
+
+--- |
+  define void @foo() {
+  entry:
+    ret void
+  }
+
+  !0 = distinct !DISubprogram(name: "foo")
+  !1 = !DILocation(line: 1, column: 1, scope: !0)
+...
+
+---
+name:            foo
+legalized:       true
+regBankSelected: false
+body:             |
+  bb.0:
+    liveins: $rdi
+
+    %0:_(p0) = COPY $rdi
+    DBG_VALUE $rdi, $noreg, 0, 0, debug-location !1
+    RET 0
+
+...
+
+# CHECK-LABEL: name: foo
+# CHECK: %0:gpr(p0) = COPY $rdi
+# CHECK: DBG_VALUE $rdi, $noreg, 0, 0


### PR DESCRIPTION
`X86RegisterBankInfo`'s regbank-mapping helpers work under the assumption that every register operand was a typed virtual register.

This caused `RegBankSelect` crashes when such operands reached these helpers:
* `getInstrPartialMappingIdxs` called `MRI.getType()` on a non-vreg operand.
* `getInstrValueMapping` then called `getValueMapping(PMI_None, ...)` for it.

Skip non-virtual register operands in both helpers. This keeps non-vregs out of LLT/mapping logic while still mapping real vreg operands.

Fixes https://github.com/llvm/llvm-project/issues/182735