### PR TITLE
[CMake][LLVM] Disable PCH for DISABLE_LLVM_LINK_LLVM_DYLIB

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -621,8 +621,16 @@ function(llvm_add_library name)
     add_library(${obj_name} OBJECT EXCLUDE_FROM_ALL
       ${ALL_FILES}
       )
+
+    # TODO(https://github.com/llvm/llvm-project/issues/145406): remove special case.
+    if(ARG_DISABLE_LLVM_LINK_LLVM_DYLIB)
+      target_compile_definitions(${obj_name} PRIVATE LLVM_BUILD_STATIC)
+      # Disable PCH reuse when we add new macro definitions.
+      set(ARG_DISABLE_PCH_REUSE ON)
+    endif()
     llvm_update_compile_flags(${obj_name})
     llvm_update_pch(${obj_name})
+
     if(CMAKE_GENERATOR STREQUAL "Xcode")
       set(DUMMY_FILE ${CMAKE_CURRENT_BINARY_DIR}/Dummy.c)
       file(WRITE ${DUMMY_FILE} "// This file intentionally empty\n")
@@ -659,10 +667,6 @@ function(llvm_add_library name)
           add_dependencies(${obj_name} ${link_lib})
         endif()
       endforeach()
-    endif()
-
-    if(ARG_DISABLE_LLVM_LINK_LLVM_DYLIB)
-      target_compile_definitions(${obj_name} PRIVATE LLVM_BUILD_STATIC)
     endif()
   endif()
 
@@ -743,6 +747,13 @@ function(llvm_add_library name)
   if(DEFINED windows_resource_file)
     set_windows_version_resource_properties(${name} ${windows_resource_file})
     set(windows_resource_file ${windows_resource_file} PARENT_SCOPE)
+  endif()
+
+  # TODO(https://github.com/llvm/llvm-project/issues/145406): remove special case.
+  if(NOT ARG_COMPONENT_LIB AND ARG_DISABLE_LLVM_LINK_LLVM_DYLIB)
+    target_compile_definitions(${name} PRIVATE LLVM_BUILD_STATIC)
+    # Disable PCH reuse when we add new macro definitions.
+    set(ARG_DISABLE_PCH_REUSE ON)
   endif()
 
   set_output_directory(${name} BINARY_DIR ${LLVM_RUNTIME_OUTPUT_INTDIR} LIBRARY_DIR ${LLVM_LIBRARY_OUTPUT_INTDIR})
@@ -832,9 +843,6 @@ function(llvm_add_library name)
     if (LLVM_LINK_LLVM_DYLIB AND NOT ARG_DISABLE_LLVM_LINK_LLVM_DYLIB)
       set(llvm_libs LLVM)
     else()
-      if(ARG_DISABLE_LLVM_LINK_LLVM_DYLIB)
-        target_compile_definitions(${name} PRIVATE LLVM_BUILD_STATIC)
-      endif()
       llvm_map_components_to_libnames(llvm_libs
         ${LLVM_LINK_COMPONENTS}
        )
@@ -1163,6 +1171,12 @@ macro(add_llvm_executable name)
   if(${cmake_pie})
     set(ARG_DISABLE_PCH_REUSE ON)
   endif()
+  # TODO(https://github.com/llvm/llvm-project/issues/145406): remove special case.
+  if(ARG_DISABLE_LLVM_LINK_LLVM_DYLIB OR NOT LLVM_LINK_LLVM_DYLIB)
+    target_compile_definitions(${name} PRIVATE LLVM_BUILD_STATIC)
+    # Disable PCH reuse when we add new macro definitions.
+    set(ARG_DISABLE_PCH_REUSE ON)
+  endif()
 
   # $<TARGET_OBJECTS> doesn't require compile flags.
   if(NOT LLVM_ENABLE_OBJLIB)
@@ -1236,10 +1250,6 @@ macro(add_llvm_executable name)
 
   if (ARG_EXPORT_SYMBOLS)
     export_executable_symbols(${name})
-  endif()
-
-  if(ARG_DISABLE_LLVM_LINK_LLVM_DYLIB OR NOT LLVM_LINK_LLVM_DYLIB)
-    target_compile_definitions(${name} PRIVATE LLVM_BUILD_STATIC)
   endif()
 
   if(LLVM_BUILD_LLVM_DYLIB_VIS AND NOT LLVM_DYLIB_EXPORT_INLINES AND


### PR DESCRIPTION
Targets with DISABLE_LLVM_LINK_LLVM_DYLIB currently add an extra macro definition, which might be problematic and cause errors in some build configurations.

The LLVM_BUILD_STATIC macro was introduced for Windows DLL support: https://github.com/llvm/llvm-project/pull/96630

Note that the added macro should be removed again later, see: https://github.com/llvm/llvm-project/issues/145406

If the macro is removed, PCH build should be possible on all platforms.