### PR TITLE
[CIR] Fix HLSL test that crashes

### DIFF
--- a/clang/test/CIR/CodeGenHLSL/matrix-element-expr-load.hlsl
+++ b/clang/test/CIR/CodeGenHLSL/matrix-element-expr-load.hlsl
@@ -1,6 +1,8 @@
 // RUN: not %clang_cc1 -x hlsl -finclude-default-header -triple spirv-unknown-vulkan-compute %s \
 // RUN:   -fclangir -emit-cir -disable-llvm-passes 2>&1 | FileCheck %s
 
+// XFAIL: *
+
 // CHECK: ClangIR code gen Not Yet Implemented: processing of type: ConstantMatrix
 float1 test_zero_indexed(float2x2 M) { 
   // CHECK: ClangIR code gen Not Yet Implemented: ScalarExprEmitter: matrix element

--- a/clang/test/CIR/CodeGenHLSL/matrix-element-expr-load.hlsl
+++ b/clang/test/CIR/CodeGenHLSL/matrix-element-expr-load.hlsl
@@ -1,10 +1,8 @@
 // RUN: not %clang_cc1 -x hlsl -finclude-default-header -triple spirv-unknown-vulkan-compute %s \
 // RUN:   -fclangir -emit-cir -disable-llvm-passes 2>&1 | FileCheck %s
 
-// XFAIL: *
-
 // CHECK: ClangIR code gen Not Yet Implemented: processing of type: ConstantMatrix
-float1 test_zero_indexed(float2x2 M) { 
+float test_zero_indexed(float2x2 M) { 
   // CHECK: ClangIR code gen Not Yet Implemented: ScalarExprEmitter: matrix element
   return M._m00; 
 }


### PR DESCRIPTION
This was caused by #182609, which just changed the way the AST stores these, which causes us to hit an NYI in a way that doesn't recover nicely.  In the future, we could probably represent a 'no op' instead of an empty op in the IR for these cases, but there isn't much use for it,
   since it is always after NYI.

This patch changes the test to use float instead of float1 as suggested in review, which avoids the problematic conversion.