### PR TITLE
[Clang][NFC] Don't redefine __trap macro in tests for PowerPC

### DIFF
--- a/clang/test/Sema/attr-overflow-behavior-format-strings.c
+++ b/clang/test/Sema/attr-overflow-behavior-format-strings.c
@@ -11,9 +11,6 @@ int snprintf(char *restrict, __SIZE_TYPE__, const char *restrict, ...);
 int scanf(const char *restrict, ...);
 int sscanf(const char *restrict, const char *restrict, ...);
 
-#define __wrap __attribute__((overflow_behavior(wrap)))
-#define __trap __attribute__((overflow_behavior(trap)))
-
 typedef int __ob_wrap wrap_int;
 typedef int __ob_trap no_trap_int;
 typedef unsigned int __ob_wrap wrap_uint;

--- a/clang/test/Sema/attr-overflow-behavior-templates.cpp
+++ b/clang/test/Sema/attr-overflow-behavior-templates.cpp
@@ -1,8 +1,5 @@
 // RUN: %clang_cc1 %s -fexperimental-overflow-behavior-types -verify -fsyntax-only -Wimplicit-overflow-behavior-conversion
 
-#define __wrap __attribute__((overflow_behavior(wrap)))
-#define __trap __attribute__((overflow_behavior(trap)))
-
 template<typename T>
 constexpr int template_overload_test(T) {
   return 10;

--- a/clang/test/Sema/attr-overflow-behavior.c
+++ b/clang/test/Sema/attr-overflow-behavior.c
@@ -15,9 +15,6 @@ void foo() {
   (ok_wrap)2147483647 + 100; // no warn
 }
 
-#define __wrap __attribute__((overflow_behavior(wrap)))
-#define __trap __attribute__((overflow_behavior(trap)))
-
 void ptr(int a) {
   int __ob_trap *p = &a; // expected-warning {{initializing '__ob_trap int *' with an expression of type 'int *' discards overflow behavior}}
 }

--- a/clang/test/Sema/attr-overflow-behavior.cpp
+++ b/clang/test/Sema/attr-overflow-behavior.cpp
@@ -10,9 +10,6 @@ typedef long __attribute__((overflow_behavior(trap))) ok_nowrap; // OK
 typedef unsigned long __attribute__((overflow_behavior("wrap"))) str_ok_wrap; // OK
 typedef char __attribute__((overflow_behavior("trap"))) str_ok_nowrap; // OK
 
-#define __wrap __attribute__((overflow_behavior(wrap)))
-#define __trap __attribute__((overflow_behavior(trap)))
-
 struct struct_not_allowed {
   int i;
 } __attribute__((overflow_behavior(wrap))); // expected-warning {{'overflow_behavior' attribute only applies to variables, typedefs, and data members}}


### PR DESCRIPTION
These `OverflowBehaviorType` tests were failing due to PowerPC already defining a __trap macro.

`undef` whatever macros (including __wrap for robustness) that may have been defined before so we don't have to rewrite the tests.

edit: we can just remove these macros.

--

cc @amy-kwan 

Fixes: https://lab.llvm.org/buildbot/#/builders/145/builds/12863