### PR TITLE
[X86] Normalize relocation model for Windows targets

### DIFF
--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -163,6 +163,13 @@ static Reloc::Model getEffectiveRelocModel(const Triple &TT, bool JIT,
   if (*RM == Reloc::Static && TT.isOSDarwin() && is64Bit)
     return Reloc::PIC_;
 
+  // On 32-bit Windows, PIC is meaningless for PE/COFF. Force static.
+  // On 64-bit Windows, Clang enforces PIC regardless.
+  // See: https://github.com/llvm/llvm-project/pull/137643
+  if (TT.isOSWindows()) {
+    return is64Bit ? Reloc::PIC_ : Reloc::Static;
+  }
+
   return *RM;
 }
 

--- a/llvm/test/CodeGen/X86/tailcall-mem_enoughregs.ll
+++ b/llvm/test/CodeGen/X86/tailcall-mem_enoughregs.ll
@@ -1,5 +1,6 @@
 ; RUN: llc < %s -mtriple=i686-linux-gnu   | FileCheck %s --check-prefix=CHECK --check-prefix=LIN32
 ; RUN: llc < %s -mtriple=x86_64-linux-gnu | FileCheck %s --check-prefix=CHECK --check-prefix=LIN64
+; RUN: llc < %s -mtriple=i686-pc-win32 -relocation-model=pic | FileCheck %s --check-prefix=CHECK --check-prefix=WIN32
 ; RUN: llc < %s -mtriple=x86_64-pc-win32  | FileCheck %s --check-prefix=CHECK --check-prefix=WIN64
 
 ; Check that we only fold the address computation (load) into a tail call
@@ -16,6 +17,7 @@ entry:
 
 ; Call address load gets folded into the tail call.
 ; LIN32: jmpl *(%
+; WIN32: jmpl *(%
 ; LIN64: jmpq *(%
 ; WIN64: jmpq *(%
 }
@@ -29,6 +31,7 @@ entry:
 
 ; Call address load gets folded into the tail call.
 ; LIN32: jmpl *(%
+; WIN32: jmpl *(%
 ; LIN64: jmpq *(%
 ; WIN64: jmpq *(%
 }
@@ -42,6 +45,7 @@ entry:
 
 ; On 32-bit we're not sure there is enough register to fold the load.
 ; LIN32: jmpl *%
+; WIN32: jmpl *%
 ; LIN64: jmpq *(%
 ; WIN64: jmpq *(%
 }
@@ -55,6 +59,7 @@ entry:
 
 ; .. but if the load is from a global, we can fold it.
 ; LIN32: jmpl *globl
+; WIN32: jmpl *_globl
 ; LIN64: jmpq *(%
 ; WIN64: jmpq *globl(%rip)
 }
@@ -67,6 +72,7 @@ entry:
 
 ; and if the load is from the stack (on 32-bit, %func is passed on the stack):
 ; LIN32: jmpl *4(%esp)
+; WIN32: jmpl *4(%esp)
 }
 
 define i32 @test6(ptr %a, ptr %b) {


### PR DESCRIPTION
On 32-bit Windows, PIC is meaningless for PE/COFF, so force the static relocation model. On 64-bit Windows, PIC is always required.

Currently, the X86 backend does not enforce this when an explicit relocation model is passed through. Setting PIC on 32-bit Windows can trip assertions that were introduced in #137643.

Normalize the effective relocation model for Windows targets in getEffectiveRelocModel so that it is correct regardless of what the caller requests.

See: https://github.com/llvm/llvm-project/pull/137643