### PR TITLE
[VectorCombine] Fold sign-bit check for multiple vectors

### DIFF
--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -111,6 +111,11 @@ inline class_match<BinaryOperator> m_BinOp() {
 /// Matches any compare instruction and ignore it.
 inline class_match<CmpInst> m_Cmp() { return class_match<CmpInst>(); }
 
+/// Matches any intrinsic call and ignore it.
+inline class_match<IntrinsicInst> m_AnyIntrinsic() {
+  return class_match<IntrinsicInst>();
+}
+
 struct undef_match {
   static bool check(const Value *V) {
     if (isa<UndefValue>(V))
@@ -899,6 +904,11 @@ inline bind_ty<const UnaryOperator> m_UnOp(const UnaryOperator *&I) {
 /// Match a binary operator, capturing it if we match.
 inline bind_ty<BinaryOperator> m_BinOp(BinaryOperator *&I) { return I; }
 inline bind_ty<const BinaryOperator> m_BinOp(const BinaryOperator *&I) {
+  return I;
+}
+/// Match any intrinsic call, capturing it if we match.
+inline bind_ty<IntrinsicInst> m_AnyIntrinsic(IntrinsicInst *&I) { return I; }
+inline bind_ty<const IntrinsicInst> m_AnyIntrinsic(const IntrinsicInst *&I) {
   return I;
 }
 /// Match a with overflow intrinsic, capturing it if we match.

--- a/llvm/test/Transforms/VectorCombine/AArch64/fold-signbit-reduction-cmp.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/fold-signbit-reduction-cmp.ll
@@ -555,8 +555,6 @@ define i1 @negative_add_v4i2(<4 x i2> %x) {
 }
 
 ; negative: ashr with NumElts=5 causes -5 to wrap to 3 (positive),
-; corrupting RangeLow/RangeHigh. Inequality patterns would miscompile.
-; https://alive2.llvm.org/ce/z/a6wxzD
 define i1 @negative_ashr_add_sgt_0(<5 x i3> %x) {
 ; CHECK-LABEL: define i1 @negative_ashr_add_sgt_0(
 ; CHECK-SAME: <5 x i3> [[X:%.*]]) {
@@ -736,6 +734,339 @@ define i1 @negative_ashr_or_ult_0(<4 x i32> %x) {
   %shr = ashr <4 x i32> %x, splat (i32 31)
   %red = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> %shr)
   %cmp = icmp ult i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_add_lshr_eq_0(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_lshr_eq_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_add_lshr_ne_0(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_lshr_ne_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp ne i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_add_lshr_eq_8(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_lshr_eq_8(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 8
+  ret i1 %cmp
+}
+
+define i1 @multi_add_lshr_ne_8(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_lshr_ne_8(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp ne i32 %red, 8
+  ret i1 %cmp
+}
+
+define i1 @multi_or_lshr_eq_0(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_or_lshr_eq_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %combined = or <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> %combined)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_and_lshr_eq_1(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_and_lshr_eq_1(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %combined = and <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> %combined)
+  %cmp = icmp eq i32 %red, 1
+  ret i1 %cmp
+}
+
+define i1 @multi_triple_add_lshr_eq_0(<4 x i32> %a, <4 x i32> %b, <4 x i32> %c) {
+; CHECK-LABEL: define i1 @multi_triple_add_lshr_eq_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]], <4 x i32> [[C:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[C]], [[B]]
+; CHECK-NEXT:    [[TMP2:%.*]] = or <4 x i32> [[TMP1]], [[A]]
+; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[TMP2]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP3]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sc = lshr <4 x i32> %c, splat (i32 31)
+  %ab = add <4 x i32> %sa, %sb
+  %abc = add <4 x i32> %ab, %sc
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %abc)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_triple_add_lshr_eq_12(<4 x i32> %a, <4 x i32> %b, <4 x i32> %c) {
+; CHECK-LABEL: define i1 @multi_triple_add_lshr_eq_12(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]], <4 x i32> [[C:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[C]], [[B]]
+; CHECK-NEXT:    [[TMP2:%.*]] = and <4 x i32> [[TMP1]], [[A]]
+; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> [[TMP2]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP3]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sc = lshr <4 x i32> %c, splat (i32 31)
+  %ab = add <4 x i32> %sa, %sb
+  %abc = add <4 x i32> %ab, %sc
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %abc)
+  %cmp = icmp eq i32 %red, 12
+  ret i1 %cmp
+}
+
+define i1 @multi_add_ashr_eq_0(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_ashr_eq_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = ashr <4 x i32> %a, splat (i32 31)
+  %sb = ashr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_add_ashr_eq_minus8(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_ashr_eq_minus8(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = ashr <4 x i32> %a, splat (i32 31)
+  %sb = ashr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, -8
+  ret i1 %cmp
+}
+
+define i1 @multi_add_ashr_sgt_minus1(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_ashr_sgt_minus1(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = ashr <4 x i32> %a, splat (i32 31)
+  %sb = ashr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp sgt i32 %red, -1
+  ret i1 %cmp
+}
+
+define i1 @multi_add_ashr_slt_minus7(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_ashr_slt_minus7(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = ashr <4 x i32> %a, splat (i32 31)
+  %sb = ashr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp slt i32 %red, -7
+  ret i1 %cmp
+}
+
+define i1 @multi_umax_or_tree_eq_0(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_umax_or_tree_eq_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %combined = or <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> %combined)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_umin_and_tree_eq_1(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_umin_and_tree_eq_1(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %combined = and <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> %combined)
+  %cmp = icmp eq i32 %red, 1
+  ret i1 %cmp
+}
+
+; negative: mixed lshr/ashr shifts
+define i1 @negative_multi_mixed_shifts(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @negative_multi_mixed_shifts(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[SA:%.*]] = lshr <4 x i32> [[A]], splat (i32 31)
+; CHECK-NEXT:    [[SB:%.*]] = ashr <4 x i32> [[B]], splat (i32 31)
+; CHECK-NEXT:    [[SUM:%.*]] = add <4 x i32> [[SA]], [[SB]]
+; CHECK-NEXT:    [[RED:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[SUM]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[RED]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = ashr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+; negative: overflow with two vectors (2*8 = 16 > max for i2)
+define i1 @negative_multi_overflow(<8 x i2> %a, <8 x i2> %b) {
+; CHECK-LABEL: define i1 @negative_multi_overflow(
+; CHECK-SAME: <8 x i2> [[A:%.*]], <8 x i2> [[B:%.*]]) {
+; CHECK-NEXT:    [[SA:%.*]] = lshr <8 x i2> [[A]], splat (i2 1)
+; CHECK-NEXT:    [[SB:%.*]] = lshr <8 x i2> [[B]], splat (i2 1)
+; CHECK-NEXT:    [[SUM:%.*]] = add <8 x i2> [[SA]], [[SB]]
+; CHECK-NEXT:    [[RED:%.*]] = call i2 @llvm.vector.reduce.add.v8i2(<8 x i2> [[SUM]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i2 [[RED]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <8 x i2> %a, splat (i2 1)
+  %sb = lshr <8 x i2> %b, splat (i2 1)
+  %sum = add <8 x i2> %sa, %sb
+  %red = call i2 @llvm.vector.reduce.add.v8i2(<8 x i2> %sum)
+  %cmp = icmp eq i2 %red, 0
+  ret i1 %cmp
+}
+
+; negative: shift has multiple uses
+define i1 @negative_multi_shift_multiuse(<4 x i32> %a, <4 x i32> %b, ptr %p) {
+; CHECK-LABEL: define i1 @negative_multi_shift_multiuse(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]], ptr [[P:%.*]]) {
+; CHECK-NEXT:    [[SA:%.*]] = lshr <4 x i32> [[A]], splat (i32 31)
+; CHECK-NEXT:    store <4 x i32> [[SA]], ptr [[P]], align 16
+; CHECK-NEXT:    [[SB:%.*]] = lshr <4 x i32> [[B]], splat (i32 31)
+; CHECK-NEXT:    [[SUM:%.*]] = add <4 x i32> [[SA]], [[SB]]
+; CHECK-NEXT:    [[RED:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[SUM]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[RED]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  store <4 x i32> %sa, ptr %p
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+; negative: internal tree node has multiple uses
+define i1 @negative_multi_tree_node_multiuse(<4 x i32> %a, <4 x i32> %b, <4 x i32> %c, ptr %p) {
+; CHECK-LABEL: define i1 @negative_multi_tree_node_multiuse(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]], <4 x i32> [[C:%.*]], ptr [[P:%.*]]) {
+; CHECK-NEXT:    [[SA:%.*]] = lshr <4 x i32> [[A]], splat (i32 31)
+; CHECK-NEXT:    [[SB:%.*]] = lshr <4 x i32> [[B]], splat (i32 31)
+; CHECK-NEXT:    [[SC:%.*]] = lshr <4 x i32> [[C]], splat (i32 31)
+; CHECK-NEXT:    [[AB:%.*]] = add <4 x i32> [[SA]], [[SB]]
+; CHECK-NEXT:    store <4 x i32> [[AB]], ptr [[P]], align 16
+; CHECK-NEXT:    [[ABC:%.*]] = add <4 x i32> [[AB]], [[SC]]
+; CHECK-NEXT:    [[RED:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[ABC]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[RED]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sc = lshr <4 x i32> %c, splat (i32 31)
+  %ab = add <4 x i32> %sa, %sb
+  store <4 x i32> %ab, ptr %p
+  %abc = add <4 x i32> %ab, %sc
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %abc)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+; negative: tree op (add) doesn't match reduction (or/umax expects or tree)
+define i1 @negative_multi_op_mismatch(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @negative_multi_op_mismatch(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[SA:%.*]] = lshr <4 x i32> [[A]], splat (i32 31)
+; CHECK-NEXT:    [[SB:%.*]] = lshr <4 x i32> [[B]], splat (i32 31)
+; CHECK-NEXT:    [[SUM:%.*]] = add <4 x i32> [[SA]], [[SB]]
+; CHECK-NEXT:    [[RED:%.*]] = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> [[SUM]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[RED]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 0
   ret i1 %cmp
 }
 

--- a/llvm/test/Transforms/VectorCombine/X86/fold-signbit-reduction-cmp.ll
+++ b/llvm/test/Transforms/VectorCombine/X86/fold-signbit-reduction-cmp.ll
@@ -567,6 +567,21 @@ define i1 @negative_add_v4i2(<4 x i2> %x) {
   ret i1 %cmp
 }
 
+; negative: ashr with NumElts=5 causes -5 to wrap to 3 (positive),
+define i1 @negative_ashr_add_sgt_0(<5 x i3> %x) {
+; CHECK-LABEL: define i1 @negative_ashr_add_sgt_0(
+; CHECK-SAME: <5 x i3> [[X:%.*]]) {
+; CHECK-NEXT:    [[SHR:%.*]] = ashr <5 x i3> [[X]], splat (i3 2)
+; CHECK-NEXT:    [[RED:%.*]] = call i3 @llvm.vector.reduce.add.v5i3(<5 x i3> [[SHR]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i3 [[RED]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %shr = ashr <5 x i3> %x, splat (i3 2)
+  %red = call i3 @llvm.vector.reduce.add.v5i3(<5 x i3> %shr)
+  %cmp = icmp sgt i3 %red, 0
+  ret i1 %cmp
+}
+
 define i1 @i1_or_eq_0(<4 x i1> %x) {
 ; CHECK-LABEL: define i1 @i1_or_eq_0(
 ; CHECK-SAME: <4 x i1> [[X:%.*]]) {
@@ -731,5 +746,338 @@ define i1 @negative_ashr_or_ult_0(<4 x i32> %x) {
   %shr = ashr <4 x i32> %x, splat (i32 31)
   %red = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> %shr)
   %cmp = icmp ult i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_add_lshr_eq_0(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_lshr_eq_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_add_lshr_ne_0(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_lshr_ne_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp ne i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_add_lshr_eq_8(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_lshr_eq_8(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 8
+  ret i1 %cmp
+}
+
+define i1 @multi_add_lshr_ne_8(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_lshr_ne_8(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp ne i32 %red, 8
+  ret i1 %cmp
+}
+
+define i1 @multi_or_lshr_eq_0(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_or_lshr_eq_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %combined = or <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> %combined)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_and_lshr_eq_1(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_and_lshr_eq_1(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %combined = and <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> %combined)
+  %cmp = icmp eq i32 %red, 1
+  ret i1 %cmp
+}
+
+define i1 @multi_triple_add_lshr_eq_0(<4 x i32> %a, <4 x i32> %b, <4 x i32> %c) {
+; CHECK-LABEL: define i1 @multi_triple_add_lshr_eq_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]], <4 x i32> [[C:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[C]], [[B]]
+; CHECK-NEXT:    [[TMP2:%.*]] = or <4 x i32> [[TMP1]], [[A]]
+; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[TMP2]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP3]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sc = lshr <4 x i32> %c, splat (i32 31)
+  %ab = add <4 x i32> %sa, %sb
+  %abc = add <4 x i32> %ab, %sc
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %abc)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_triple_add_lshr_eq_12(<4 x i32> %a, <4 x i32> %b, <4 x i32> %c) {
+; CHECK-LABEL: define i1 @multi_triple_add_lshr_eq_12(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]], <4 x i32> [[C:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[C]], [[B]]
+; CHECK-NEXT:    [[TMP2:%.*]] = and <4 x i32> [[TMP1]], [[A]]
+; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> [[TMP2]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP3]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sc = lshr <4 x i32> %c, splat (i32 31)
+  %ab = add <4 x i32> %sa, %sb
+  %abc = add <4 x i32> %ab, %sc
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %abc)
+  %cmp = icmp eq i32 %red, 12
+  ret i1 %cmp
+}
+
+define i1 @multi_add_ashr_eq_0(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_ashr_eq_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = ashr <4 x i32> %a, splat (i32 31)
+  %sb = ashr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_add_ashr_eq_minus8(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_ashr_eq_minus8(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = ashr <4 x i32> %a, splat (i32 31)
+  %sb = ashr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, -8
+  ret i1 %cmp
+}
+
+define i1 @multi_add_ashr_sgt_minus1(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_ashr_sgt_minus1(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = ashr <4 x i32> %a, splat (i32 31)
+  %sb = ashr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp sgt i32 %red, -1
+  ret i1 %cmp
+}
+
+define i1 @multi_add_ashr_slt_minus7(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_add_ashr_slt_minus7(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = ashr <4 x i32> %a, splat (i32 31)
+  %sb = ashr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp slt i32 %red, -7
+  ret i1 %cmp
+}
+
+define i1 @multi_umax_or_tree_eq_0(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_umax_or_tree_eq_0(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = or <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[TMP2]], -1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %combined = or <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.umax.v4i32(<4 x i32> %combined)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+define i1 @multi_umin_and_tree_eq_1(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @multi_umin_and_tree_eq_1(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = and <4 x i32> [[B]], [[A]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %combined = and <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> %combined)
+  %cmp = icmp eq i32 %red, 1
+  ret i1 %cmp
+}
+
+; negative: mixed lshr/ashr shifts
+define i1 @negative_multi_mixed_shifts(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @negative_multi_mixed_shifts(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[SA:%.*]] = lshr <4 x i32> [[A]], splat (i32 31)
+; CHECK-NEXT:    [[SB:%.*]] = ashr <4 x i32> [[B]], splat (i32 31)
+; CHECK-NEXT:    [[SUM:%.*]] = add <4 x i32> [[SA]], [[SB]]
+; CHECK-NEXT:    [[RED:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[SUM]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[RED]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = ashr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+; negative: overflow with two vectors (2*8 = 16 > max for i2)
+define i1 @negative_multi_overflow(<8 x i2> %a, <8 x i2> %b) {
+; CHECK-LABEL: define i1 @negative_multi_overflow(
+; CHECK-SAME: <8 x i2> [[A:%.*]], <8 x i2> [[B:%.*]]) {
+; CHECK-NEXT:    [[SA:%.*]] = lshr <8 x i2> [[A]], splat (i2 1)
+; CHECK-NEXT:    [[SB:%.*]] = lshr <8 x i2> [[B]], splat (i2 1)
+; CHECK-NEXT:    [[SUM:%.*]] = add <8 x i2> [[SA]], [[SB]]
+; CHECK-NEXT:    [[RED:%.*]] = call i2 @llvm.vector.reduce.add.v8i2(<8 x i2> [[SUM]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i2 [[RED]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <8 x i2> %a, splat (i2 1)
+  %sb = lshr <8 x i2> %b, splat (i2 1)
+  %sum = add <8 x i2> %sa, %sb
+  %red = call i2 @llvm.vector.reduce.add.v8i2(<8 x i2> %sum)
+  %cmp = icmp eq i2 %red, 0
+  ret i1 %cmp
+}
+
+; negative: shift has multiple uses
+define i1 @negative_multi_shift_multiuse(<4 x i32> %a, <4 x i32> %b, ptr %p) {
+; CHECK-LABEL: define i1 @negative_multi_shift_multiuse(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]], ptr [[P:%.*]]) {
+; CHECK-NEXT:    [[SA:%.*]] = lshr <4 x i32> [[A]], splat (i32 31)
+; CHECK-NEXT:    store <4 x i32> [[SA]], ptr [[P]], align 16
+; CHECK-NEXT:    [[SB:%.*]] = lshr <4 x i32> [[B]], splat (i32 31)
+; CHECK-NEXT:    [[SUM:%.*]] = add <4 x i32> [[SA]], [[SB]]
+; CHECK-NEXT:    [[RED:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[SUM]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[RED]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  store <4 x i32> %sa, ptr %p
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+; negative: internal tree node has multiple uses
+define i1 @negative_multi_tree_node_multiuse(<4 x i32> %a, <4 x i32> %b, <4 x i32> %c, ptr %p) {
+; CHECK-LABEL: define i1 @negative_multi_tree_node_multiuse(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]], <4 x i32> [[C:%.*]], ptr [[P:%.*]]) {
+; CHECK-NEXT:    [[SA:%.*]] = lshr <4 x i32> [[A]], splat (i32 31)
+; CHECK-NEXT:    [[SB:%.*]] = lshr <4 x i32> [[B]], splat (i32 31)
+; CHECK-NEXT:    [[SC:%.*]] = lshr <4 x i32> [[C]], splat (i32 31)
+; CHECK-NEXT:    [[AB:%.*]] = add <4 x i32> [[SA]], [[SB]]
+; CHECK-NEXT:    store <4 x i32> [[AB]], ptr [[P]], align 16
+; CHECK-NEXT:    [[ABC:%.*]] = add <4 x i32> [[AB]], [[SC]]
+; CHECK-NEXT:    [[RED:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[ABC]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[RED]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sc = lshr <4 x i32> %c, splat (i32 31)
+  %ab = add <4 x i32> %sa, %sb
+  store <4 x i32> %ab, ptr %p
+  %abc = add <4 x i32> %ab, %sc
+  %red = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> %abc)
+  %cmp = icmp eq i32 %red, 0
+  ret i1 %cmp
+}
+
+; negative: tree op (add) doesn't match reduction (or/umax expects or tree)
+define i1 @negative_multi_op_mismatch(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-LABEL: define i1 @negative_multi_op_mismatch(
+; CHECK-SAME: <4 x i32> [[A:%.*]], <4 x i32> [[B:%.*]]) {
+; CHECK-NEXT:    [[SA:%.*]] = lshr <4 x i32> [[A]], splat (i32 31)
+; CHECK-NEXT:    [[SB:%.*]] = lshr <4 x i32> [[B]], splat (i32 31)
+; CHECK-NEXT:    [[SUM:%.*]] = add <4 x i32> [[SA]], [[SB]]
+; CHECK-NEXT:    [[RED:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[SUM]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[RED]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %sa = lshr <4 x i32> %a, splat (i32 31)
+  %sb = lshr <4 x i32> %b, splat (i32 31)
+  %sum = add <4 x i32> %sa, %sb
+  %red = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> %sum)
+  %cmp = icmp eq i32 %red, 0
   ret i1 %cmp
 }


### PR DESCRIPTION
## Alive2 proofs

| Reduction | Shift | Cmp      | Sources | Proof |
|-----------|-------|----------|---------|-------|
| add       | lshr  | == 0     | 2       | [proof](https://alive2.llvm.org/ce/z/f44vco) |
| add       | lshr  | == 8     | 2       | [proof](https://alive2.llvm.org/ce/z/Ks_nea) |
| add       | ashr  | == 0     | 2       | [proof](https://alive2.llvm.org/ce/z/ZsXJ5k) |
| add       | ashr  | == -8    | 2       | [proof](https://alive2.llvm.org/ce/z/HZfans) |
| add       | lshr  | == 0     | 3       | [proof](https://alive2.llvm.org/ce/z/x-dEdz) |
| add       | lshr  | == 12    | 3       | [proof](https://alive2.llvm.org/ce/z/sfNvhr) |

These proofs are not very exhaustive, but somewhat show that it works for addition. Apart from the fact that we use multiple vectors, the proofs from the previous changes generally apply here as well because we effectively match on reductions of size M x N.