### PR TITLE
[flang][runtime] Conditionally fail empty ALLOCATE

### DIFF
--- a/flang-rt/include/flang-rt/runtime/environment.h
+++ b/flang-rt/include/flang-rt/runtime/environment.h
@@ -74,6 +74,7 @@ struct ExecutionEnvironment {
   bool defaultUTF8{false}; // DEFAULT_UTF8
   bool checkPointerDeallocation{true}; // FORT_CHECK_POINTER_DEALLOCATION
   bool truncateStream{true}; // FORT_TRUNCATE_STREAM
+  bool noEmptyAllocation{false}; // FORT_NO_EMPTY_ALLOCATION
 
   enum InternalDebugging { WorkQueue = 1 };
   int internalDebugging{0}; // FLANG_RT_DEBUG

--- a/flang-rt/lib/runtime/environment.cpp
+++ b/flang-rt/lib/runtime/environment.cpp
@@ -218,6 +218,18 @@ void ExecutionEnvironment::Configure(int ac, const char *av[],
     }
   }
 
+  if (auto *x{std::getenv("FORT_NO_EMPTY_ALLOCATION")}) {
+    char *end;
+    auto n{std::strtol(x, &end, 10)};
+    if (n >= 0 && n <= 1 && *end == '\0') {
+      noEmptyAllocation = n != 0;
+    } else {
+      std::fprintf(stderr,
+          "Fortran runtime: FORT_NO_EMPTY_ALLOCATION=%s is invalid; ignored\n",
+          x);
+    }
+  }
+
   // TODO: Set RP/ROUND='PROCESSOR_DEFINED' from environment
 
   if (0 != nPostConfigEnvCallback) {

--- a/flang/docs/RuntimeEnvironment.md
+++ b/flang/docs/RuntimeEnvironment.md
@@ -66,3 +66,8 @@ when output takes place to a sequential unit after
 executing a `BACKSPACE` or `REWIND` statement.
 Truncation of a stream-access unit is common to several other
 compilers, but it is not mentioned in the standard.
+
+## `FORT_NO_EMPTY_ALLOCATION`
+
+Set `FORT_NO_EMPTY_ALLOCATION=1` to cause `ALLOCATE` statements
+fail when the allocated size is empty.


### PR DESCRIPTION
Add an environment variable (FORT_NO_EMPTY_ALLOCATION) that, when set to 1, changes the behavior of an ALLOCATE statement so that it will fail on an empty allocation rather than its default behavior of allocating one byte.