### PR TITLE
[SystemZ] Allow folding from another MBB in foldMemoryOperandImpl().

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -1593,17 +1593,15 @@ MachineInstr *SystemZInstrInfo::foldMemoryOperandImpl(
 
   // If RegMemOpcode clobbers CC, first make sure CC is not live at this point.
   if (get(RegMemOpcode).hasImplicitDefOfPhysReg(SystemZ::CC)) {
-    assert(LoadMI.getParent() == MI.getParent() && "Assuming a local fold.");
-    assert(LoadMI != InsertPt && "Assuming InsertPt not to be first in MBB.");
-    for (MachineBasicBlock::iterator MII = std::prev(InsertPt);;
-         --MII) {
-      if (MII->definesRegister(SystemZ::CC, /*TRI=*/nullptr)) {
-        if (!MII->registerDefIsDead(SystemZ::CC, /*TRI=*/nullptr))
+    for (MachineBasicBlock::iterator MII = InsertPt;;) {
+      if (MII == MBB->begin()) {
+        if (MBB->isLiveIn(SystemZ::CC))
           return nullptr;
         break;
       }
-      if (MII == MBB->begin()) {
-        if (MBB->isLiveIn(SystemZ::CC))
+      --MII;
+      if (MII->definesRegister(SystemZ::CC, /*TRI=*/nullptr)) {
+        if (!MII->registerDefIsDead(SystemZ::CC, /*TRI=*/nullptr))
           return nullptr;
         break;
       }

--- a/llvm/test/CodeGen/SystemZ/foldmemop-global.mir
+++ b/llvm/test/CodeGen/SystemZ/foldmemop-global.mir
@@ -1,0 +1,124 @@
+# RUN: llc -mtriple=s390x-linux-gnu -mcpu=z17 -run-pass=greedy %s -o - \
+# RUN:   | FileCheck %s
+#
+# Test folding where the original load is in another MBB.
+
+--- |
+  define void @fun0() { ret void }
+...
+
+# CHECK-LABEL: name: fun0
+# CHECK-LABEL:   bb.0:
+# CHECK-NEXT:      successors: %bb.1(0x80000000)
+# CHECK-NEXT:      liveins: $f0s, $f2s, $f4s, $f6s, $r2l
+# CHECK-NEXT: {{  $}}
+# CHECK-NEXT:      %1:gr32bit = COPY $r2l
+# CHECK-NEXT:      %0:fp32bit = COPY $f6s
+# CHECK-NEXT:      %5:fp32bit = COPY $f4s
+# CHECK-NEXT:      %6:fp32bit = COPY $f2s
+# CHECK-NEXT:      %7:fp32bit = COPY $f0s
+# CHECK-NEXT:      %2:vr32bit = VL32 %fixed-stack.0, 4, $noreg :: (load (s32) from %fixed-stack.0)
+# CHECK-NEXT:      %3:fp32bit = VL32 %fixed-stack.1, 4, $noreg :: (load (s32) from %fixed-stack.1)
+# CHECK-NEXT:      %8:vr32bit = VL32 %fixed-stack.3, 4, $noreg :: (load (s32) from %fixed-stack.3)
+# CHECK-NEXT:      %9:fp32bit = LZER
+# CHECK-NEXT:      %10:addr64bit = LGHI 0
+# CHECK-NEXT: {{  $}}
+# CHECK:         bb.2:
+# CHECK-NEXT:      successors: %bb.4(0x80000000)
+# CHECK-NEXT: {{  $}}
+# CHECK-NEXT:      %12:fp32bit = nofpexcept SEB %9, %fixed-stack.2, 4, $noreg, implicit-def dead $cc, implicit $fpc :: (load (s32) from %fixed-stack.2)
+# CHECK-NEXT:      %13:vr32bit = nofpexcept WFMSB %5, %12, implicit $fpc
+# CHECK-NEXT:      %14:fp32bit = nofpexcept WFMSB %13, %9, implicit $fpc
+# CHECK-NEXT:      J %bb.4
+---
+name:            fun0
+alignment:       2
+tracksRegLiveness: true
+noPhis:          true
+isSSA:           false
+noVRegs:         false
+hasFakeUses:     false
+liveins:
+  - { reg: '$f0s', virtual-reg: '%3' }
+  - { reg: '$f2s', virtual-reg: '%4' }
+  - { reg: '$f4s', virtual-reg: '%5' }
+  - { reg: '$f6s', virtual-reg: '%6' }
+  - { reg: '$r2l', virtual-reg: '%7' }
+frameInfo:
+  maxAlignment:    8
+  adjustsStack:    true
+  hasCalls:        true
+fixedStack:
+  - { id: 0, offset: 24, size: 4, alignment: 8, isImmutable: true }
+  - { id: 1, offset: 16, size: 4, alignment: 8, isImmutable: true }
+  - { id: 2, offset: 8, size: 4, alignment: 8, isImmutable: true }
+  - { id: 3, size: 4, alignment: 8, isImmutable: true }
+machineFunctionInfo: {}
+body:             |
+  bb.0:
+    successors: %bb.1(0x80000000)
+    liveins: $f0s, $f2s, $f4s, $f6s, $r2l
+  
+    %4:gr32bit = COPY $r2l
+    %3:fp32bit = COPY $f6s
+    %2:fp32bit = COPY $f4s
+    %1:fp32bit = COPY $f2s
+    %0:fp32bit = COPY $f0s
+    %5:vr32bit = VL32 %fixed-stack.3, 4, $noreg :: (load (s32) from %fixed-stack.3)
+    %6:fp32bit = VL32 %fixed-stack.2, 4, $noreg :: (load (s32) from %fixed-stack.2)
+    %7:vr32bit = VL32 %fixed-stack.1, 4, $noreg :: (load (s32) from %fixed-stack.1)
+    %8:vr32bit = VL32 %fixed-stack.0, 4, $noreg :: (load (s32) from %fixed-stack.0)
+    %9:fp32bit = LZER
+    %10:addr64bit = LGHI 0
+  
+  bb.1:
+    successors: %bb.2(0x40000000), %bb.3(0x40000000)
+  
+    dead %11:fp32bit = nofpexcept LTEBR %6, implicit-def $cc, implicit $fpc
+    BRC 15, 13, %bb.3, implicit killed $cc
+  
+  bb.2:
+    successors: %bb.4(0x80000000)
+  
+    %12:vr32bit = nofpexcept WFSSB %9, %7, implicit $fpc
+    %13:vr32bit = nofpexcept WFMSB %2, %12, implicit $fpc
+    %14:fp32bit = nofpexcept WFMSB %13, %9, implicit $fpc
+    J %bb.4
+  
+  bb.3:
+    successors: %bb.4(0x80000000)
+  
+    %14:fp32bit = COPY %8
+  
+  bb.4:
+    successors: %bb.5(0x80000000)
+  
+    %15:vr32bit = nofpexcept WFSSB %9, %1, implicit $fpc
+    %16:vr32bit = nofpexcept WFMSB %5, %15, implicit $fpc
+  
+  bb.5:
+    successors: %bb.6(0x40000000), %bb.7(0x40000000)
+  
+    TMLMux %4, 1, implicit-def $cc
+    BRC 15, 8, %bb.7, implicit killed $cc
+  
+  bb.6:
+    successors: %bb.8(0x80000000)
+  
+    %17:vr32bit = nofpexcept WFMSB %16, %3, implicit $fpc
+    %14:fp32bit = nofpexcept WFASB %0, %17, implicit $fpc
+    J %bb.8
+  
+  bb.7:
+    successors: %bb.8(0x80000000)
+  
+  bb.8:
+    successors: %bb.1(0x80000000)
+  
+    %18:gr32bit = nofpexcept CFEBR 5, %14, implicit-def dead $cc, implicit $fpc
+    $r2d = LGHI 0
+    $r3l = COPY %18
+    $r4l = LHIMux 0
+    CallBASR %10, $r2d, killed $r3l, killed $r4l, csr_systemz_elf, implicit-def dead $r14d, implicit-def dead $cc, implicit $fpc
+    J %bb.1
+...


### PR DESCRIPTION
After 7c1d517 "[SystemZ] Enable rematerialization for scalar loads (#179838)", I got a crash when building f526.blender. This is because there was an assertion to check that the original load and the subsuming instruction are in the same MBB.

Previously, it just never happened that there was a global fold, so the assertion was made probably so that the algorithm could be kept as simple as possible when checking for CC liveness.

It seems straightforward to remove this rule and simply allow this case as well - I cannot think of any reason it should not work. Compile-time has a potential to increase - have not checked it - but hopefully not problematic since CC defs are not that uncommon. With this, there may be more searches that in theory could go all the way through a big MBB. One option might be to have a limit in order to bail out after N MIs have been searched. This now however happens only 10 times across SPEC.

@uweigand

@anoopkg6: Did you see this problem when building spec or am I missing something? Maybe you built without assertions?
