### PR TITLE
[AMDGPU][AMDGPUBaseInfo] Replace Waitcnt members with array

### DIFF
--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -199,22 +199,30 @@ iota_range<InstCounterType> inst_counter_types(InstCounterType MaxCounter) {
 }
 
 StringLiteral instCounterTypeToStr(InstCounterType T) {
-  // clang-format off
   switch (T) {
-  case LOAD_CNT:   return "LoadCnt";
-  case DS_CNT:     return "DsCnt";
-  case EXP_CNT:    return "ExpCnt";
-  case STORE_CNT:  return "StoreCnt";
-  case SAMPLE_CNT: return "SampleCnt";
-  case BVH_CNT:    return "BvhCnt";
-  case KM_CNT:     return "KmCnt";
-  case X_CNT:      return "XCnt";
-  case VA_VDST:    return "VaVdst";
-  case VM_VSRC:    return "VmVsrc";
+  case LOAD_CNT:
+    return "LOAD_CNT";
+  case DS_CNT:
+    return "DS_CNT";
+  case EXP_CNT:
+    return "EXP_CNT";
+  case STORE_CNT:
+    return "STORE_CNT";
+  case SAMPLE_CNT:
+    return "SAMPLE_CNT";
+  case BVH_CNT:
+    return "BVH_CNT";
+  case KM_CNT:
+    return "KM_CNT";
+  case X_CNT:
+    return "X_CNT";
+  case VA_VDST:
+    return "VA_VDST";
+  case VM_VSRC:
+    return "VM_VSRC";
   default:
     return "Unknown T";
   }
-  // clang-format on
 }
 
 #ifndef NDEBUG

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -218,10 +218,7 @@ StringLiteral instCounterTypeToStr(InstCounterType T) {
 }
 
 #ifndef NDEBUG
-void Waitcnt::dump() const {
-  print(dbgs());
-  dbgs() << "\n";
-}
+void Waitcnt::dump() const { dbgs() << *this << "\n"; }
 #endif
 
 /// \returns true if the target supports signed immediate offset for SMRD

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -225,7 +225,7 @@ StringLiteral instCounterTypeToStr(InstCounterType T) {
   }
 }
 
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void Waitcnt::dump() const { dbgs() << *this << "\n"; }
 #endif
 

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -198,6 +198,32 @@ iota_range<InstCounterType> inst_counter_types(InstCounterType MaxCounter) {
   return enum_seq(LOAD_CNT, MaxCounter);
 }
 
+StringLiteral instCounterTypeToStr(InstCounterType T) {
+  // clang-format off
+  switch (T) {
+  case LOAD_CNT:   return "LoadCnt";
+  case DS_CNT:     return "DsCnt";
+  case EXP_CNT:    return "ExpCnt";
+  case STORE_CNT:  return "StoreCnt";
+  case SAMPLE_CNT: return "SampleCnt";
+  case BVH_CNT:    return "BvhCnt";
+  case KM_CNT:     return "KmCnt";
+  case X_CNT:      return "XCnt";
+  case VA_VDST:    return "VaVdst";
+  case VM_VSRC:    return "VmVsrc";
+  default:
+    return "Unknown T";
+  }
+  // clang-format on
+}
+
+#ifndef NDEBUG
+void Waitcnt::dump() const {
+  print(dbgs());
+  dbgs() << "\n";
+}
+#endif
+
 /// \returns true if the target supports signed immediate offset for SMRD
 /// instructions.
 bool hasSMRDSignedImmOffset(const MCSubtargetInfo &ST) {
@@ -1753,30 +1779,6 @@ bool hasValueInRangeLikeMetadata(const MDNode &MD, int64_t Val) {
   }
 
   return false;
-}
-
-raw_ostream &operator<<(raw_ostream &OS, const AMDGPU::Waitcnt &Wait) {
-  ListSeparator LS;
-  if (Wait.LoadCnt != ~0u)
-    OS << LS << "LoadCnt: " << Wait.LoadCnt;
-  if (Wait.ExpCnt != ~0u)
-    OS << LS << "ExpCnt: " << Wait.ExpCnt;
-  if (Wait.DsCnt != ~0u)
-    OS << LS << "DsCnt: " << Wait.DsCnt;
-  if (Wait.StoreCnt != ~0u)
-    OS << LS << "StoreCnt: " << Wait.StoreCnt;
-  if (Wait.SampleCnt != ~0u)
-    OS << LS << "SampleCnt: " << Wait.SampleCnt;
-  if (Wait.BvhCnt != ~0u)
-    OS << LS << "BvhCnt: " << Wait.BvhCnt;
-  if (Wait.KmCnt != ~0u)
-    OS << LS << "KmCnt: " << Wait.KmCnt;
-  if (Wait.XCnt != ~0u)
-    OS << LS << "XCnt: " << Wait.XCnt;
-  if (LS.unused())
-    OS << "none";
-  OS << '\n';
-  return OS;
 }
 
 unsigned getVmcntBitMask(const IsaVersion &Version) {

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -198,7 +198,7 @@ iota_range<InstCounterType> inst_counter_types(InstCounterType MaxCounter) {
   return enum_seq(LOAD_CNT, MaxCounter);
 }
 
-StringLiteral instCounterTypeToStr(InstCounterType T) {
+StringLiteral getInstCounterName(InstCounterType T) {
   switch (T) {
   case LOAD_CNT:
     return "LOAD_CNT";

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -1186,23 +1186,21 @@ public:
     // Does the right thing provided self and Other are either both pre-gfx12
     // or both gfx12+.
     Waitcnt Wait;
-    for (InstCounterType T : inst_counter_types()) {
+    for (InstCounterType T : inst_counter_types())
       Wait.Cnt[T] = std::min(Cnt[T], Other.Cnt[T]);
-    }
     return Wait;
   }
 
   void print(raw_ostream &OS) const {
     ListSeparator LS;
-    for (InstCounterType T : inst_counter_types()) {
+    for (InstCounterType T : inst_counter_types())
       OS << LS << instCounterTypeToStr(T) << ": " << Cnt[T];
-    }
     if (LS.unused())
       OS << "none";
     OS << '\n';
   }
 
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
 #endif
 

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -11,6 +11,7 @@
 
 #include "AMDGPUSubtarget.h"
 #include "SIDefines.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Module.h"
@@ -1107,6 +1108,8 @@ enum InstCounterType {
   NUM_INST_CNTS = NUM_EXPERT_INST_CNTS
 };
 
+StringLiteral instCounterTypeToStr(InstCounterType T);
+
 // Return an iterator over all counters between LOAD_CNT (the first counter)
 // and \c MaxCounter (exclusive, default value yields an enumeration over
 // all counters).
@@ -1126,118 +1129,86 @@ namespace AMDGPU {
 /// Large values (including the maximum possible integer) can be used to
 /// represent "don't care" waits.
 class Waitcnt {
-  unsigned LoadCnt = ~0u; // Corresponds to Vmcnt prior to gfx12.
-  unsigned ExpCnt = ~0u;
-  unsigned DsCnt = ~0u;     // Corresponds to LGKMcnt prior to gfx12.
-  unsigned StoreCnt = ~0u;  // Corresponds to VScnt on gfx10/gfx11.
-  unsigned SampleCnt = ~0u; // gfx12+ only.
-  unsigned BvhCnt = ~0u;    // gfx12+ only.
-  unsigned KmCnt = ~0u;     // gfx12+ only.
-  unsigned XCnt = ~0u;      // gfx1250.
-  unsigned VaVdst = ~0u;    // gfx12+ expert scheduling mode only.
-  unsigned VmVsrc = ~0u;    // gfx12+ expert scheduling mode only.
+  std::array<unsigned, NUM_INST_CNTS> Cnt;
 
 public:
-  unsigned get(InstCounterType T) const {
-    switch (T) {
-    case LOAD_CNT:
-      return LoadCnt;
-    case EXP_CNT:
-      return ExpCnt;
-    case DS_CNT:
-      return DsCnt;
-    case STORE_CNT:
-      return StoreCnt;
-    case SAMPLE_CNT:
-      return SampleCnt;
-    case BVH_CNT:
-      return BvhCnt;
-    case KM_CNT:
-      return KmCnt;
-    case X_CNT:
-      return XCnt;
-    case VA_VDST:
-      return VaVdst;
-    case VM_VSRC:
-      return VmVsrc;
-    default:
-      llvm_unreachable("bad InstCounterType");
-    }
-  }
-  void set(InstCounterType T, unsigned Val) {
-    switch (T) {
-    case LOAD_CNT:
-      LoadCnt = Val;
-      break;
-    case EXP_CNT:
-      ExpCnt = Val;
-      break;
-    case DS_CNT:
-      DsCnt = Val;
-      break;
-    case STORE_CNT:
-      StoreCnt = Val;
-      break;
-    case SAMPLE_CNT:
-      SampleCnt = Val;
-      break;
-    case BVH_CNT:
-      BvhCnt = Val;
-      break;
-    case KM_CNT:
-      KmCnt = Val;
-      break;
-    case X_CNT:
-      XCnt = Val;
-      break;
-    case VA_VDST:
-      VaVdst = Val;
-      break;
-    case VM_VSRC:
-      VmVsrc = Val;
-      break;
-    default:
-      llvm_unreachable("bad InstCounterType");
-    }
-  }
+  unsigned get(InstCounterType T) const { return Cnt[T]; }
+  void set(InstCounterType T, unsigned Val) { Cnt[T] = Val; }
 
-  Waitcnt() = default;
+  Waitcnt() { fill(Cnt, ~0u); }
   // Pre-gfx12 constructor.
   Waitcnt(unsigned VmCnt, unsigned ExpCnt, unsigned LgkmCnt, unsigned VsCnt)
-      : LoadCnt(VmCnt), ExpCnt(ExpCnt), DsCnt(LgkmCnt), StoreCnt(VsCnt) {}
+      : Waitcnt() {
+    Cnt[LOAD_CNT] = VmCnt;
+    Cnt[EXP_CNT] = ExpCnt;
+    Cnt[DS_CNT] = LgkmCnt;
+    Cnt[STORE_CNT] = VsCnt;
+  }
 
   // gfx12+ constructor.
   Waitcnt(unsigned LoadCnt, unsigned ExpCnt, unsigned DsCnt, unsigned StoreCnt,
           unsigned SampleCnt, unsigned BvhCnt, unsigned KmCnt, unsigned XCnt,
-          unsigned VaVdst, unsigned VmVsrc)
-      : LoadCnt(LoadCnt), ExpCnt(ExpCnt), DsCnt(DsCnt), StoreCnt(StoreCnt),
-        SampleCnt(SampleCnt), BvhCnt(BvhCnt), KmCnt(KmCnt), XCnt(XCnt),
-        VaVdst(VaVdst), VmVsrc(VmVsrc) {}
-
-  bool hasWait() const { return StoreCnt != ~0u || hasWaitExceptStoreCnt(); }
-
-  bool hasWaitExceptStoreCnt() const {
-    return LoadCnt != ~0u || ExpCnt != ~0u || DsCnt != ~0u ||
-           SampleCnt != ~0u || BvhCnt != ~0u || KmCnt != ~0u || XCnt != ~0u ||
-           VaVdst != ~0u || VmVsrc != ~0u;
+          unsigned VaVdst, unsigned VmVsrc) {
+    Cnt[LOAD_CNT] = LoadCnt;
+    Cnt[DS_CNT] = DsCnt;
+    Cnt[EXP_CNT] = ExpCnt;
+    Cnt[STORE_CNT] = StoreCnt;
+    Cnt[SAMPLE_CNT] = SampleCnt;
+    Cnt[BVH_CNT] = BvhCnt;
+    Cnt[KM_CNT] = KmCnt;
+    Cnt[X_CNT] = XCnt;
+    Cnt[VA_VDST] = VaVdst;
+    Cnt[VM_VSRC] = VmVsrc;
   }
 
-  bool hasWaitStoreCnt() const { return StoreCnt != ~0u; }
+  bool hasWait() const {
+    return any_of(Cnt, [](unsigned Val) { return Val != ~0u; });
+  }
 
-  bool hasWaitDepctr() const { return VaVdst != ~0u || VmVsrc != ~0u; }
+  bool hasWaitExceptStoreCnt() const {
+    for (InstCounterType T : inst_counter_types()) {
+      if (T == STORE_CNT)
+        continue;
+      if (Cnt[T] != ~0u)
+        return true;
+    }
+    return false;
+  }
+
+  bool hasWaitStoreCnt() const { return Cnt[STORE_CNT] != ~0u; }
+
+  bool hasWaitDepctr() const {
+    return Cnt[VA_VDST] != ~0u || Cnt[VM_VSRC] != ~0u;
+  }
 
   Waitcnt combined(const Waitcnt &Other) const {
     // Does the right thing provided self and Other are either both pre-gfx12
     // or both gfx12+.
-    return Waitcnt(
-        std::min(LoadCnt, Other.LoadCnt), std::min(ExpCnt, Other.ExpCnt),
-        std::min(DsCnt, Other.DsCnt), std::min(StoreCnt, Other.StoreCnt),
-        std::min(SampleCnt, Other.SampleCnt), std::min(BvhCnt, Other.BvhCnt),
-        std::min(KmCnt, Other.KmCnt), std::min(XCnt, Other.XCnt),
-        std::min(VaVdst, Other.VaVdst), std::min(VmVsrc, Other.VmVsrc));
+    Waitcnt Wait;
+    for (InstCounterType T : inst_counter_types()) {
+      Wait.Cnt[T] = std::min(Cnt[T], Other.Cnt[T]);
+    }
+    return Wait;
   }
 
-  friend raw_ostream &operator<<(raw_ostream &OS, const AMDGPU::Waitcnt &Wait);
+  void print(raw_ostream &OS) const {
+    ListSeparator LS;
+    for (InstCounterType T : inst_counter_types()) {
+      OS << LS << instCounterTypeToStr(T) << ": " << Cnt[T];
+    }
+    if (LS.unused())
+      OS << "none";
+    OS << '\n';
+  }
+
+#ifndef NDEBUG
+  LLVM_DUMP_METHOD void dump() const;
+#endif
+
+  friend raw_ostream &operator<<(raw_ostream &OS, const AMDGPU::Waitcnt &Wait) {
+    Wait.print(OS);
+    return OS;
+  }
 };
 
 /// Represents the hardware counter limits for different wait count types.

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -1108,7 +1108,7 @@ enum InstCounterType {
   NUM_INST_CNTS = NUM_EXPERT_INST_CNTS
 };
 
-StringLiteral instCounterTypeToStr(InstCounterType T);
+StringLiteral getInstCounterName(InstCounterType T);
 
 // Return an iterator over all counters between LOAD_CNT (the first counter)
 // and \c MaxCounter (exclusive, default value yields an enumeration over
@@ -1194,7 +1194,7 @@ public:
   void print(raw_ostream &OS) const {
     ListSeparator LS;
     for (InstCounterType T : inst_counter_types())
-      OS << LS << instCounterTypeToStr(T) << ": " << Cnt[T];
+      OS << LS << getInstCounterName(T) << ": " << Cnt[T];
     if (LS.unused())
       OS << "none";
     OS << '\n';

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -1148,7 +1148,8 @@ public:
   // gfx12+ constructor.
   Waitcnt(unsigned LoadCnt, unsigned ExpCnt, unsigned DsCnt, unsigned StoreCnt,
           unsigned SampleCnt, unsigned BvhCnt, unsigned KmCnt, unsigned XCnt,
-          unsigned VaVdst, unsigned VmVsrc) {
+          unsigned VaVdst, unsigned VmVsrc)
+      : Waitcnt() {
     Cnt[LOAD_CNT] = LoadCnt;
     Cnt[DS_CNT] = DsCnt;
     Cnt[EXP_CNT] = ExpCnt;


### PR DESCRIPTION
This patch replaces the member variables of Waitcnt with an array. This helps in several ways:
(i) It helps replace switch cases with array accesses, and 
(ii) It makes operating on all elements with a loop which is much easier, and should require less maintenance if we add more counters