### PR TITLE
[ADT] Add StringRef::rfind_if/rfind_if_not

### DIFF
--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -325,6 +325,30 @@ namespace llvm {
       return find_if([F](char c) { return !F(c); }, From);
     }
 
+    /// Search for the last character satisfying the predicate \p F
+    ///
+    /// \returns The index of the last character satisfying \p F before \p End,
+    /// or npos is not found.
+    [[nodiscard]] size_t rfind_if(function_ref<bool(char)> F,
+                                  size_t End = npos) const {
+      size_t I = std::min(End, size());
+      while (I) {
+        --I;
+        if (F(data()[I]))
+          return I;
+      }
+      return npos;
+    }
+
+    /// Search for the last character not satisfying the predicate \p F
+    ///
+    /// \returns The index of the last character not satisfying \p F before \p
+    /// End, or npos is not found.
+    [[nodiscard]] size_t rfind_if_not(function_ref<bool(char)> F,
+                                      size_t End = npos) const {
+      return rfind_if([F](char C) { return !F(C); }, End);
+    }
+
     /// Search for the first string \p Str in the string.
     ///
     /// \returns The index of the first occurrence of \p Str, or npos if not

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -346,7 +346,7 @@ namespace llvm {
     /// End, or npos if not found.
     [[nodiscard]] size_t rfind_if_not(function_ref<bool(char)> F,
                                       size_t End = npos) const {
-      return rfind_if([F](char C) { return !F(C); }, End);
+      return rfind_if(std::not_fn(F), End);
     }
 
     /// Search for the first string \p Str in the string.

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -328,7 +328,7 @@ namespace llvm {
     /// Search for the last character satisfying the predicate \p F
     ///
     /// \returns The index of the last character satisfying \p F before \p End,
-    /// or npos is not found.
+    /// or npos if not found.
     [[nodiscard]] size_t rfind_if(function_ref<bool(char)> F,
                                   size_t End = npos) const {
       size_t I = std::min(End, size());
@@ -343,7 +343,7 @@ namespace llvm {
     /// Search for the last character not satisfying the predicate \p F
     ///
     /// \returns The index of the last character not satisfying \p F before \p
-    /// End, or npos is not found.
+    /// End, or npos if not found.
     [[nodiscard]] size_t rfind_if_not(function_ref<bool(char)> F,
                                       size_t End = npos) const {
       return rfind_if([F](char C) { return !F(C); }, End);

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -1093,7 +1093,7 @@ TEST(StringRefTest, Take) {
 }
 
 TEST(StringRefTest, FindIf) {
-  StringRef Punct("Test.String");
+  StringRef Punct("This.Is.Test.String");
   StringRef NoPunct("ABCDEFG");
   StringRef Empty;
 
@@ -1106,6 +1106,14 @@ TEST(StringRefTest, FindIf) {
   EXPECT_EQ(4U, Punct.find_if_not(IsAlpha));
   EXPECT_EQ(StringRef::npos, NoPunct.find_if_not(IsAlpha));
   EXPECT_EQ(StringRef::npos, Empty.find_if_not(IsAlpha));
+
+  EXPECT_EQ(12U, Punct.rfind_if(IsPunct));
+  EXPECT_EQ(7U, Punct.rfind_if(IsPunct, /*End=*/12));
+  EXPECT_EQ(StringRef::npos, Punct.rfind_if(IsPunct, /*End=*/4));
+
+  EXPECT_EQ(12U, Punct.rfind_if_not(IsAlpha));
+  EXPECT_EQ(7U, Punct.rfind_if_not(IsAlpha, /*End=*/12));
+  EXPECT_EQ(StringRef::npos, Punct.rfind_if_not(IsAlpha, /*End=*/4));
 }
 
 TEST(StringRefTest, TakeWhileUntil) {

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -1110,10 +1110,12 @@ TEST(StringRefTest, FindIf) {
   EXPECT_EQ(12U, Punct.rfind_if(IsPunct));
   EXPECT_EQ(7U, Punct.rfind_if(IsPunct, /*End=*/12));
   EXPECT_EQ(StringRef::npos, Punct.rfind_if(IsPunct, /*End=*/4));
+  EXPECT_EQ(StringRef::npos, Punct.rfind_if(IsPunct, /*End=*/0));
 
   EXPECT_EQ(12U, Punct.rfind_if_not(IsAlpha));
   EXPECT_EQ(7U, Punct.rfind_if_not(IsAlpha, /*End=*/12));
   EXPECT_EQ(StringRef::npos, Punct.rfind_if_not(IsAlpha, /*End=*/4));
+  EXPECT_EQ(StringRef::npos, Punct.rfind_if_not(IsAlpha, /*End=*/0));
 }
 
 TEST(StringRefTest, TakeWhileUntil) {


### PR DESCRIPTION
(Original Context: https://github.com/llvm/llvm-project/pull/182531#discussion_r2838541171)

As a parity to `StringRef::find_if/find_if_not`. 