### PR TITLE
Reland "CodeGen: Emit .prefalign directives based on the prefalign attribute."

### DIFF
--- a/lld/test/ELF/lto/linker-script-symbols-ipo.ll
+++ b/lld/test/ELF/lto/linker-script-symbols-ipo.ll
@@ -18,7 +18,7 @@
 ; NOIPO:      <foo>:
 ; NOIPO-NEXT:   movl $2, %eax
 ; NOIPO:      <_start>:
-; NOIPO-NEXT:   jmp 0x201160 <foo>
+; NOIPO-NEXT:   jmp 0x201158 <foo>
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -999,8 +999,20 @@ void AsmPrinter::emitFunctionHeader() {
     emitVisibility(CurrentFnSym, F.getVisibility());
 
   emitLinkage(&F, CurrentFnSym);
-  if (MAI->hasFunctionAlignment())
-    emitAlignment(MF->getPreferredAlignment(), &F);
+  if (MAI->hasFunctionAlignment()) {
+    // The preferred alignment directive will not have the intended effect
+    // unless function sections are enabled.
+    if (MAI->useIntegratedAssembler() && MAI->hasPreferredAlignment() &&
+        TM.getFunctionSections()) {
+      Align Alignment = MF->getAlignment();
+      Align PrefAlignment = MF->getPreferredAlignment();
+      emitAlignment(Alignment, &F);
+      if (Alignment != PrefAlignment)
+        OutStreamer->emitPrefAlign(PrefAlignment);
+    } else {
+      emitAlignment(MF->getPreferredAlignment(), &F);
+    }
+  }
 
   if (MAI->hasDotTypeDotSizeDirective())
     OutStreamer->emitSymbolAttribute(CurrentFnSym, MCSA_ELF_TypeFunction);

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1000,8 +1000,10 @@ void AsmPrinter::emitFunctionHeader() {
 
   emitLinkage(&F, CurrentFnSym);
   if (MAI->hasFunctionAlignment()) {
-    // The preferred alignment directive will not have the intended effect
-    // unless function sections are enabled.
+    // Make sure that the preferred alignment directive (.prefalign) is
+    // supported before using it. The preferred alignment directive will not
+    // have the intended effect unless function sections are enabled, so check
+    // for that as well.
     if (MAI->useIntegratedAssembler() && MAI->hasPreferredAlignment() &&
         TM.getFunctionSections()) {
       Align Alignment = MF->getAlignment();

--- a/llvm/test/CodeGen/X86/prefalign.ll
+++ b/llvm/test/CodeGen/X86/prefalign.ll
@@ -1,0 +1,27 @@
+; RUN: llc < %s | FileCheck --check-prefixes=CHECK,NOFS %s
+; RUN: llc -function-sections < %s | FileCheck --check-prefixes=CHECK,FS %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; CHECK: .globl f1
+; NOFS-NEXT: .p2align 4
+; FS-NEXT: .prefalign 16
+define void @f1() {
+  ret void
+}
+
+; CHECK: .globl f2
+; CHECK-NOT: .prefalign
+; CHECK-NOT: .p2align
+define void @f2() prefalign(1) {
+  ret void
+}
+
+; CHECK: .globl f3
+; NOFS-NEXT: .p2align 2
+; FS-NEXT: .p2align 1
+; FS-NEXT: .prefalign 4
+define void @f3() align 2 prefalign(4) {
+  ret void
+}

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-emit.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-emit.ll
@@ -129,7 +129,7 @@ entry:
 ; CHECK-SEC-ELF:       [Nr] Name               Type     {{.*}} ES Flg Lk Inf Al
 ; CHECK-SEC-ELF:       [ 3] .text.foo          PROGBITS {{.*}} 00  AX  0   0 16
 ; CHECK-SEC-ELF:       [ 5] .text.foo2         PROGBITS {{.*}} 00  AX  0   0 16
-; CHECK-SEC-ELF:       [ 8] .text.foo3         PROGBITS {{.*}} 00  AXG 0   0 16
+; CHECK-SEC-ELF:       [ 8] .text.foo3         PROGBITS {{.*}} 00  AXG 0   0  1
 ; CHECK-SEC-ELF-COUNT-3:    .pseudo_probe_desc PROGBITS
 ; CHECK-SEC-ELF:            .pseudo_probe      PROGBITS {{.*}} 00   L  3   0  1
 ; CHECK-SEC-ELF-NEXT:       .pseudo_probe      PROGBITS {{.*}} 00   L  5   0  1
@@ -156,7 +156,7 @@ entry:
 ; CHECK-SEC2-ELF:      [Nr] Name               Type     {{.*}} ES Flg Lk Inf Al
 ; CHECK-SEC2-ELF:      [ 3] .text              PROGBITS {{.*}} 00  AX  0   0 16
 ; CHECK-SEC2-ELF:      [ 5] .text              PROGBITS {{.*}} 00  AX  0   0 16
-; CHECK-SEC2-ELF:      [ 8] .text              PROGBITS {{.*}} 00  AXG 0   0 16
+; CHECK-SEC2-ELF:      [ 8] .text              PROGBITS {{.*}} 00  AXG 0   0  1
 ; CHECK-SEC2-ELF-COUNT-3:   .pseudo_probe_desc PROGBITS
 ; CHECK-SEC2-ELF:           .pseudo_probe      PROGBITS {{.*}} 00   L  3   0  1
 ; CHECK-SEC2-ELF-NEXT:      .pseudo_probe      PROGBITS {{.*}} 00   L  5   0  1

--- a/llvm/test/tools/gold/X86/multiple-sections.ll
+++ b/llvm/test/tools/gold/X86/multiple-sections.ll
@@ -7,7 +7,7 @@
 
 ; Check that the order of the sections is tin -> _start -> pat.
 
-; CHECK:      00000000004000d0     1 FUNC    LOCAL  DEFAULT    1 pat
+; CHECK:      00000000004000cf     1 FUNC    LOCAL  DEFAULT    1 pat
 ; CHECK:      00000000004000b0     1 FUNC    LOCAL  DEFAULT    1 tin
 ; CHECK:      00000000004000c0    15 FUNC    GLOBAL DEFAULT    1 _start
 


### PR DESCRIPTION
The result of the MachineFunction preferred alignment query is emitted
as a .prefalign directive if supported, otherwise it gets combined into
the minimum alignment.

Part of this RFC:
https://discourse.llvm.org/t/rfc-enhancing-function-alignment-attributes/88019

Reland of #155529 with fix for gold test case.
