### PR TITLE
[Offload][clang-linker-wrapper][SPIRV] Tell spirv-link to not optimize out exported symbols

### DIFF
--- a/clang/test/Driver/spirv-openmp-toolchain.c
+++ b/clang/test/Driver/spirv-openmp-toolchain.c
@@ -65,7 +65,8 @@
 // RUN:        -nogpulib %s 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHECK-LINKER-ARG
 // CHECK-LINKER-ARG: clang-linker-wrapper
-// CHECK-LINKER: --device-linker=spirv64-intel=--allow-partial-linkage"
+// CHECK-LINKER-ARG: --device-linker=spirv64-intel=--allow-partial-linkage"
+// CHECK-LINKER-ARG-SAME: --device-linker=spirv64-intel=--create-library"
 // CHECK-LINKER-ARG-NOT: -mllvm
 // CHECK-LINKER-ARG-NOT: --spirv-ext=+SPV_INTEL_function_pointers
 // CHECK-LINKER-ARG: --linker-path

--- a/offload/test/offloading/info.c
+++ b/offload/test/offloading/info.c
@@ -7,7 +7,6 @@
 
 // FIXME: Fails due to optimized debugging in 'ptxas'.
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
`spirv-link` seems to internalize all symbols, which ends up causing the OpenMP Device Environment global generated by the OMP FE to get optimized out which causes `liboffload` to run in the wrong parallelization mode which breaks at least one liboffload lit test.

Pass `--create-library` to tell it not to do that.

```
  --create-library
               Link the binaries into a library, keeping all exported symbols.
```

This fixes the test.

Closes: https://github.com/llvm/llvm-project/issues/182901

Signed-off-by: Nick Sarnie <nick.sarnie@intel.com>