### PR TITLE
[flang] Catch missed error cases of assumed-rank actual arguments

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -435,6 +435,24 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
               actualDesc);
         }
       }
+    } else if (actualIsAssumedRank) {
+      if (actualType.type().category() != TypeCategory::Character &&
+          !intrinsic) {
+        // A more specific message will have already been emitted for
+        // assumed-rank argument that's CHARACTER, a callee that's ELEMENTAL,
+        // or an intrinsic procedure that can't handle assumed-rank.
+        if (!context.languageFeatures().IsEnabled(
+                common::LanguageFeature::AssumedRankPassedToNonAssumedRank)) {
+          messages.Say(
+              "Assumed-rank actual argument may not be associated with a %s that is not also assumed-rank"_err_en_US,
+              dummyName);
+        } else {
+          foldingContext.Warn(
+              common::LanguageFeature::AssumedRankPassedToNonAssumedRank,
+              "Assumed-rank actual argument should not be associated with a %s that is not also assumed-rank"_port_en_US,
+              dummyName);
+        }
+      }
     } else if (dummy.ignoreTKR.test(common::IgnoreTKR::Rank)) {
     } else if (dummyRank > 0 && !dummyIsAllocatableOrPointer &&
         !dummy.type.attrs().test(

--- a/flang/test/Semantics/call03.f90
+++ b/flang/test/Semantics/call03.f90
@@ -374,6 +374,7 @@ module m01
     call volatileassumedsize(d(::2))
     !ERROR: ASYNCHRONOUS or VOLATILE actual argument that is not simply contiguous may not be associated with a contiguous ASYNCHRONOUS or VOLATILE dummy argument 'x='
     call volatilecontiguous(d(::2))
+    !ERROR: Assumed-rank actual argument may not be associated with a dummy argument 'x=' that is not also assumed-rank
     !ERROR: ASYNCHRONOUS or VOLATILE actual argument that is not simply contiguous may not be associated with a contiguous ASYNCHRONOUS or VOLATILE dummy argument 'x='
     call volatilecontiguous(assumedrank)
   end subroutine


### PR DESCRIPTION
Assumed-rank actual arguments are acceptable to some intrinsic procedures, and for association with assumed-rank dummy arguments, but other cases are not allowed.  We catch some, namely ELEMENTAL callees and CHARACTER arguments, but not the general case error of an assumed-rank array being associated with a non-assumed-rank dummy.