### PR TITLE
[bazel] Add missing llc test dep

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/test/Dialect/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/Dialect/BUILD.bazel
@@ -11,6 +11,7 @@ package(default_visibility = ["//visibility:public"])
         data = [
             "EmitC/tosa/td.mlir",
             "Vector/vector-sink-transform.mlir",
+            "//llvm:llc",
             "//llvm:llvm-symbolizer",
             "//mlir:mlir-opt",
             "//mlir:mlir-pdll",


### PR DESCRIPTION
Used by mlir/test/Dialect/X86Vector/dot-bf16.mlir, which seems to not be running due to some other misconfiguration.