### PR TITLE
[sanitizer_common] [Darwin] Adopt _dyld_get_dyld_header

### DIFF
--- a/compiler-rt/lib/sanitizer_common/weak_symbols.txt
+++ b/compiler-rt/lib/sanitizer_common/weak_symbols.txt
@@ -10,3 +10,4 @@ ___sanitizer_symbolize_demangle
 ___sanitizer_symbolize_flush
 ___sanitizer_symbolize_set_demangle
 ___sanitizer_symbolize_set_inline_frames
+__dyld_get_dyld_header

--- a/compiler-rt/lib/tsan/go/buildgo.sh
+++ b/compiler-rt/lib/tsan/go/buildgo.sh
@@ -165,7 +165,7 @@ elif [ "$GOOS" = "netbsd" ]; then
 	"
 elif [ "$GOOS" = "darwin" ]; then
 	OSCFLAGS="-fPIC -Wno-unused-const-variable -Wno-unknown-warning-option -mmacosx-version-min=10.7"
-	OSLDFLAGS="-lpthread -fPIC -fpie -mmacosx-version-min=10.7"
+	OSLDFLAGS="-lpthread -fPIC -fpie -mmacosx-version-min=10.7 -Wl,-U,__dyld_get_dyld_header"
 	SRCS="
 		$SRCS
 		../rtl/tsan_platform_mac.cpp


### PR DESCRIPTION
There is an issue on recent macOS versions with `GetDyldImageHeaderViaSharedCache`, which is fixed by adopting `_dyld_get_dyld_header`. We weakly declare this to ensure runtimes compile with older SDK (currently on CI bots).

rdar://167854578