### PR TITLE
[clang][ssaf][NFC] Avoid incomplete EntitySummary type breakage

### DIFF
--- a/clang/include/clang/Analysis/Scalable/EntityLinker/LUSummary.h
+++ b/clang/include/clang/Analysis/Scalable/EntityLinker/LUSummary.h
@@ -19,12 +19,11 @@
 #include "clang/Analysis/Scalable/Model/EntityIdTable.h"
 #include "clang/Analysis/Scalable/Model/EntityLinkage.h"
 #include "clang/Analysis/Scalable/Model/SummaryName.h"
+#include "clang/Analysis/Scalable/TUSummary/EntitySummary.h"
 #include <map>
 #include <memory>
 
 namespace clang::ssaf {
-
-class EntitySummary;
 
 /// Represents a link unit (LU) summary containing merged entity summaries.
 ///


### PR DESCRIPTION
When parsing LUSummary.h as a standalone header unit, EntitySummary is an incomplete type, causing compilation to fail:

```
__memory/unique_ptr.h:72:19: error: invalid application of 'sizeof' to an incomplete type 'clang::ssaf::EntitySummary'
   72 |     static_assert(sizeof(_Tp) >= 0, "cannot delete an incomplete type");
...
clang/include/clang/Analysis/Scalable/EntityLinker/LUSummary.h:48:12: note: in instantiation of member function 'std::map<clang::ssaf::SummaryName, std::map<clang::ssaf::EntityId, std::unique_ptr<clang::ssaf::EntitySummary>>>::map' requested here
   48 |   explicit LUSummary(NestedBuildNamespace LUNamespace)
      |            ^
clang/include/clang/Analysis/Scalable/EntityLinker/LUSummary.h:27:7: note: forward declaration of 'clang::ssaf::EntitySummary'
   27 | class EntitySummary;
```

This is not a total breakage because this header file builds successfully when used in a .cpp file that includes EntitySummary.h prior to this.

See https://llvm.org/docs/CodingStandards.html#self-contained-headers