### PR TITLE
[lldb][TypeSystemClang] Unconditionally set access control to AS_public

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -424,11 +424,6 @@ ParsedDWARFTypeAttributes::ParsedDWARFTypeAttributes(const DWARFDIE &die) {
       abstract_origin = form_value;
       break;
 
-    case DW_AT_accessibility:
-      accessibility =
-          DWARFASTParser::GetAccessTypeFromDWARF(form_value.Unsigned());
-      break;
-
     case DW_AT_artificial:
       is_artificial = form_value.Boolean();
       break;
@@ -1266,15 +1261,10 @@ std::pair<bool, TypeSP> DWARFASTParserClang::ParseCXXMethod(
     return {true, nullptr};
 
   const bool is_attr_used = false;
-  // Neither GCC 4.2 nor clang++ currently set a valid
-  // accessibility in the DWARF for C++ methods...
-  // Default to public for now...
-  const auto accessibility =
-      attrs.accessibility == eAccessNone ? eAccessPublic : attrs.accessibility;
 
   clang::CXXMethodDecl *cxx_method_decl = m_ast.AddMethodToCXXRecordType(
       class_opaque_type.GetOpaqueQualType(), attrs.name.GetCString(),
-      MakeLLDBFuncAsmLabel(die), clang_type, accessibility, attrs.is_virtual,
+      MakeLLDBFuncAsmLabel(die), clang_type, /*access=*/{}, attrs.is_virtual,
       is_static, attrs.is_inline, attrs.is_explicit, is_attr_used,
       attrs.is_artificial);
 
@@ -1573,7 +1563,6 @@ void DWARFASTParserClang::ParseInheritance(
     return;
 
   DWARFFormValue encoding_form;
-  AccessType accessibility = default_accessibility;
   bool is_virtual = false;
   bool is_base_of_class = true;
   off_t member_byte_offset = 0;
@@ -1590,11 +1579,6 @@ void DWARFASTParserClang::ParseInheritance(
         if (auto maybe_offset =
                 ExtractDataMemberLocation(die, form_value, module_sp))
           member_byte_offset = *maybe_offset;
-        break;
-
-      case DW_AT_accessibility:
-        accessibility =
-            DWARFASTParser::GetAccessTypeFromDWARF(form_value.Unsigned());
         break;
 
       case DW_AT_virtuality:
@@ -1634,7 +1618,7 @@ void DWARFASTParserClang::ParseInheritance(
   }
   std::unique_ptr<clang::CXXBaseSpecifier> result =
       ast->CreateBaseClassSpecifier(base_class_clang_type.GetOpaqueQualType(),
-                                    accessibility, is_virtual,
+                                    /*access=*/{}, is_virtual,
                                     is_base_of_class);
   if (!result)
     return;
@@ -1799,19 +1783,6 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
     }
   }
 
-  int tag_decl_kind = -1;
-  AccessType default_accessibility = eAccessNone;
-  if (tag == DW_TAG_structure_type) {
-    tag_decl_kind = llvm::to_underlying(clang::TagTypeKind::Struct);
-    default_accessibility = eAccessPublic;
-  } else if (tag == DW_TAG_union_type) {
-    tag_decl_kind = llvm::to_underlying(clang::TagTypeKind::Union);
-    default_accessibility = eAccessPublic;
-  } else if (tag == DW_TAG_class_type) {
-    tag_decl_kind = llvm::to_underlying(clang::TagTypeKind::Class);
-    default_accessibility = eAccessPrivate;
-  }
-
   if ((attrs.class_language == eLanguageTypeObjC ||
        attrs.class_language == eLanguageTypeObjC_plus_plus) &&
       !attrs.is_complete_objc_class) {
@@ -1854,23 +1825,22 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
       return type_sp;
   }
 
-  assert(tag_decl_kind != -1);
-  UNUSED_IF_ASSERT_DISABLED(tag_decl_kind);
+  int tag_decl_kind = -1;
+  if (tag == DW_TAG_structure_type)
+    tag_decl_kind = llvm::to_underlying(clang::TagTypeKind::Struct);
+  else if (tag == DW_TAG_union_type)
+    tag_decl_kind = llvm::to_underlying(clang::TagTypeKind::Union);
+  else if (tag == DW_TAG_class_type)
+    tag_decl_kind = llvm::to_underlying(clang::TagTypeKind::Class);
+  else
+    assert(false && "Unexpected tag kind.");
+
   clang::DeclContext *containing_decl_ctx =
       GetClangDeclContextContainingDIE(die, nullptr);
 
   PrepareContextToReceiveMembers(m_ast, GetClangASTImporter(),
                                  containing_decl_ctx, die,
                                  attrs.name.GetCString());
-
-  if (attrs.accessibility == eAccessNone && containing_decl_ctx) {
-    // Check the decl context that contains this class/struct/union. If
-    // it is a class we must give it an accessibility.
-    const clang::Decl::Kind containing_decl_kind =
-        containing_decl_ctx->getDeclKind();
-    if (DeclKindIsCXXClass(containing_decl_kind))
-      attrs.accessibility = default_accessibility;
-  }
 
   ClangASTMetadata metadata;
   metadata.SetUserID(die.GetID());
@@ -1881,7 +1851,7 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
   if (ParseTemplateParameterInfos(die, template_param_infos)) {
     clang::ClassTemplateDecl *class_template_decl =
         m_ast.ParseClassTemplateDecl(
-            containing_decl_ctx, GetOwningClangModule(die), attrs.accessibility,
+            containing_decl_ctx, GetOwningClangModule(die), /*access*/ {},
             attrs.name.GetCString(), tag_decl_kind, template_param_infos);
     if (!class_template_decl) {
       if (log) {
@@ -1919,9 +1889,9 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
 
   if (!clang_type) {
     clang_type = m_ast.CreateRecordType(
-        containing_decl_ctx, GetOwningClangModule(die), attrs.accessibility,
-        attrs.name.GetCString(), tag_decl_kind, attrs.class_language, metadata,
-        attrs.exports_symbols);
+        containing_decl_ctx, GetOwningClangModule(die),
+        /*access_type=*/{}, attrs.name.GetCString(), tag_decl_kind,
+        attrs.class_language, metadata, attrs.exports_symbols);
   }
 
   TypeSP type_sp = dwarf->MakeType(
@@ -2191,7 +2161,6 @@ bool DWARFASTParserClang::ParseTemplateParameterInfos(
 
 bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
                                              const CompilerType &clang_type) {
-  const dw_tag_t tag = die.Tag();
   SymbolFileDWARF *dwarf = die.GetDWARF();
 
   ClangASTImporter::LayoutInfo layout_info;
@@ -2206,15 +2175,6 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
   if (!clang_type.IsBeingDefined())
     TypeSystemClang::StartTagDeclarationDefinition(clang_type);
 
-  AccessType default_accessibility = eAccessNone;
-  if (tag == DW_TAG_structure_type) {
-    default_accessibility = eAccessPublic;
-  } else if (tag == DW_TAG_union_type) {
-    default_accessibility = eAccessPublic;
-  } else if (tag == DW_TAG_class_type) {
-    default_accessibility = eAccessPrivate;
-  }
-
   std::vector<std::unique_ptr<clang::CXXBaseSpecifier>> bases;
   // Parse members and base classes first
   std::vector<DWARFDIE> member_function_dies;
@@ -2222,7 +2182,7 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
   DelayedPropertyList delayed_properties;
   ParseChildMembers(die, clang_type, bases, member_function_dies,
                     contained_type_dies, delayed_properties,
-                    default_accessibility, layout_info);
+                    /*default_accessibility=*/{}, layout_info);
 
   // Now parse any methods if there were any...
   for (const DWARFDIE &die : member_function_dies)
@@ -2737,10 +2697,6 @@ DWARFASTParserClang::MemberAttributes::MemberAttributes(
           member_byte_offset = *maybe_offset;
         break;
 
-      case DW_AT_accessibility:
-        accessibility =
-            DWARFASTParser::GetAccessTypeFromDWARF(form_value.Unsigned());
-        break;
       case DW_AT_artificial:
         is_artificial = form_value.Boolean();
         break;
@@ -2936,12 +2892,9 @@ void DWARFASTParserClang::CreateStaticMemberVariable(
   if (!var_type)
     return;
 
-  auto accessibility =
-      attrs.accessibility == eAccessNone ? eAccessPublic : attrs.accessibility;
-
   CompilerType ct = var_type->GetForwardCompilerType();
   clang::VarDecl *v = TypeSystemClang::AddVariableToRecordType(
-      class_clang_type, attrs.name, ct, accessibility);
+      class_clang_type, attrs.name, ct, /*access=*/{});
   if (!v) {
     LLDB_LOG(log, "Failed to add variable to the record type");
     return;
@@ -3017,10 +2970,6 @@ void DWARFASTParserClang::ParseSingleMember(
 
   const uint64_t character_width = 8;
   CompilerType member_clang_type = member_type->GetLayoutCompilerType();
-
-  const auto accessibility = attrs.accessibility == eAccessNone
-                                 ? default_accessibility
-                                 : attrs.accessibility;
 
   uint64_t field_bit_offset = (attrs.member_byte_offset == UINT32_MAX
                                    ? 0
@@ -3125,8 +3074,8 @@ void DWARFASTParserClang::ParseSingleMember(
   TypeSystemClang::RequireCompleteType(member_clang_type);
 
   clang::FieldDecl *field_decl = TypeSystemClang::AddFieldToRecordType(
-      class_clang_type, attrs.name, member_clang_type, accessibility,
-      attrs.bit_size);
+      class_clang_type, attrs.name, member_clang_type,
+      /*access=*/{}, attrs.bit_size);
 
   m_ast.SetMetadataAsUserID(field_decl, die.GetID());
 
@@ -3163,7 +3112,7 @@ bool DWARFASTParserClang::ParseChildMembers(
     case DW_TAG_variant_part:
       if (die.GetCU()->GetDWARFLanguageType() == eLanguageTypeRust) {
         ParseRustVariantPart(die, parent_die, class_clang_type,
-                             default_accessibility, layout_info);
+                             /*default_accesibility=*/{}, layout_info);
       }
       break;
 
@@ -3173,7 +3122,8 @@ bool DWARFASTParserClang::ParseChildMembers(
     } break;
     case DW_TAG_member:
       ParseSingleMember(die, parent_die, class_clang_type,
-                        default_accessibility, layout_info, last_field_info);
+                        /*default_accessibility=*/{}, layout_info,
+                        last_field_info);
       break;
 
     case DW_TAG_subprogram:
@@ -3182,8 +3132,9 @@ bool DWARFASTParserClang::ParseChildMembers(
       break;
 
     case DW_TAG_inheritance:
-      ParseInheritance(die, parent_die, class_clang_type, default_accessibility,
-                       module_sp, base_classes, layout_info);
+      ParseInheritance(die, parent_die, class_clang_type,
+                       /*default_accessibility=*/{}, module_sp, base_classes,
+                       layout_info);
       break;
 
     default:
@@ -3885,9 +3836,8 @@ void DWARFASTParserClang::ParseRustVariantPart(
                     ? llvm::formatv("$variant${0}", member.discr_value.value())
                     : std::string("$variant$");
 
-    auto variant_decl =
-        m_ast.AddFieldToRecordType(inner_holder, llvm::StringRef(name),
-                                   field_type, default_accesibility, 0);
+    auto variant_decl = m_ast.AddFieldToRecordType(
+        inner_holder, llvm::StringRef(name), field_type, /*access=*/{}, 0);
 
     layout_info.field_offsets.insert({variant_decl, 0});
   }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -1547,9 +1547,21 @@ TypeSP DWARFASTParserClang::ParsePointerToMemberType(
   return nullptr;
 }
 
+static AccessType GetDefaultAccessibility(const DWARFDIE &die) {
+  switch (die.Tag()) {
+  case DW_TAG_union_type:
+  case DW_TAG_structure_type:
+    return eAccessPublic;
+  case DW_TAG_class_type:
+    return eAccessPrivate;
+  default:
+    return eAccessNone;
+  }
+}
+
 void DWARFASTParserClang::ParseInheritance(
     const DWARFDIE &die, const DWARFDIE &parent_die,
-    const CompilerType class_clang_type, const AccessType default_accessibility,
+    const CompilerType class_clang_type, const AccessType,
     const lldb::ModuleSP &module_sp,
     std::vector<std::unique_ptr<clang::CXXBaseSpecifier>> &base_classes,
     ClangASTImporter::LayoutInfo &layout_info) {
@@ -1563,6 +1575,7 @@ void DWARFASTParserClang::ParseInheritance(
     return;
 
   DWARFFormValue encoding_form;
+  AccessType accessibility = GetDefaultAccessibility(parent_die);
   bool is_virtual = false;
   bool is_base_of_class = true;
   off_t member_byte_offset = 0;
@@ -1580,7 +1593,10 @@ void DWARFASTParserClang::ParseInheritance(
                 ExtractDataMemberLocation(die, form_value, module_sp))
           member_byte_offset = *maybe_offset;
         break;
-
+      case DW_AT_accessibility:
+        accessibility =
+            DWARFASTParser::GetAccessTypeFromDWARF(form_value.Unsigned());
+        break;
       case DW_AT_virtuality:
         is_virtual = form_value.Boolean();
         break;
@@ -1618,7 +1634,7 @@ void DWARFASTParserClang::ParseInheritance(
   }
   std::unique_ptr<clang::CXXBaseSpecifier> result =
       ast->CreateBaseClassSpecifier(base_class_clang_type.GetOpaqueQualType(),
-                                    /*access=*/{}, is_virtual,
+                                    accessibility, is_virtual,
                                     is_base_of_class);
   if (!result)
     return;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
@@ -335,7 +335,6 @@ private:
     /// Indicates the size of the field in bits.
     size_t bit_size = 0;
     uint64_t data_bit_offset = UINT64_MAX;
-    lldb::AccessType accessibility = lldb::eAccessNone;
     std::optional<uint64_t> byte_size;
     std::optional<lldb_private::plugin::dwarf::DWARFFormValue> const_value_form;
     lldb_private::plugin::dwarf::DWARFFormValue encoding_form;
@@ -553,7 +552,6 @@ struct ParsedDWARFTypeAttributes {
   explicit ParsedDWARFTypeAttributes(
       const lldb_private::plugin::dwarf::DWARFDIE &die);
 
-  lldb::AccessType accessibility = lldb::eAccessNone;
   bool is_artificial = false;
   bool is_complete_objc_class = false;
   bool is_explicit = false;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -446,6 +446,23 @@ bool TypeSystemClang::IsOperator(llvm::StringRef name,
   return true;
 }
 
+clang::AccessSpecifier
+TypeSystemClang::ConvertAccessTypeToAccessSpecifier(AccessType access) {
+  switch (access) {
+  default:
+    break;
+  case eAccessNone:
+    return AS_none;
+  case eAccessPublic:
+    return AS_public;
+  case eAccessPrivate:
+    return AS_private;
+  case eAccessProtected:
+    return AS_protected;
+  }
+  return AS_none;
+}
+
 static void ParseLangArgs(LangOptions &Opts, ArchSpec arch) {
   // FIXME: Cleanup per-file based stuff.
 
@@ -7876,7 +7893,8 @@ TypeSystemClang::CreateBaseClassSpecifier(lldb::opaque_compiler_type_t type,
     return nullptr;
 
   return std::make_unique<clang::CXXBaseSpecifier>(
-      clang::SourceRange(), is_virtual, base_of_class, AS_public,
+      clang::SourceRange(), is_virtual, base_of_class,
+      TypeSystemClang::ConvertAccessTypeToAccessSpecifier(access),
       getASTContext().getTrivialTypeSourceInfo(GetQualType(type)),
       clang::SourceLocation());
 }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -1267,7 +1267,7 @@ TypeSystemClang::GetOrCreateClangModule(llvm::StringRef name,
 
 CompilerType TypeSystemClang::CreateRecordType(
     clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
-    lldb::AccessType access_type, llvm::StringRef name, int kind,
+    AccessType access_type, llvm::StringRef name, int kind,
     LanguageType language, std::optional<ClangASTMetadata> metadata,
     bool exports_symbols) {
   ASTContext &ast = getASTContext();
@@ -7383,7 +7383,7 @@ TypeSystemClang::GetAsObjCInterfaceDecl(const CompilerType &type) {
 
 clang::FieldDecl *TypeSystemClang::AddFieldToRecordType(
     const CompilerType &type, llvm::StringRef name,
-    const CompilerType &field_clang_type, lldb::AccessType access,
+    const CompilerType &field_clang_type, AccessType access,
     uint32_t bitfield_bit_size) {
   if (!type.IsValid() || !field_clang_type.IsValid())
     return nullptr;
@@ -7601,7 +7601,7 @@ void TypeSystemClang::SetIsPacked(const CompilerType &type) {
 
 clang::VarDecl *TypeSystemClang::AddVariableToRecordType(
     const CompilerType &type, llvm::StringRef name,
-    const CompilerType &var_type, lldb::AccessType access) {
+    const CompilerType &var_type, AccessType access) {
   if (!type.IsValid() || !var_type.IsValid())
     return nullptr;
 
@@ -7887,8 +7887,8 @@ void TypeSystemClang::AddMethodOverridesForCXXRecordType(
 
 std::unique_ptr<clang::CXXBaseSpecifier>
 TypeSystemClang::CreateBaseClassSpecifier(lldb::opaque_compiler_type_t type,
-                                          lldb::AccessType access,
-                                          bool is_virtual, bool base_of_class) {
+                                          AccessType access, bool is_virtual,
+                                          bool base_of_class) {
   if (!type)
     return nullptr;
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -446,23 +446,6 @@ bool TypeSystemClang::IsOperator(llvm::StringRef name,
   return true;
 }
 
-clang::AccessSpecifier
-TypeSystemClang::ConvertAccessTypeToAccessSpecifier(AccessType access) {
-  switch (access) {
-  default:
-    break;
-  case eAccessNone:
-    return AS_none;
-  case eAccessPublic:
-    return AS_public;
-  case eAccessPrivate:
-    return AS_private;
-  case eAccessProtected:
-    return AS_protected;
-  }
-  return AS_none;
-}
-
 static void ParseLangArgs(LangOptions &Opts, ArchSpec arch) {
   // FIXME: Cleanup per-file based stuff.
 
@@ -1267,7 +1250,7 @@ TypeSystemClang::GetOrCreateClangModule(llvm::StringRef name,
 
 CompilerType TypeSystemClang::CreateRecordType(
     clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
-    AccessType access_type, llvm::StringRef name, int kind,
+    lldb::AccessType access_type, llvm::StringRef name, int kind,
     LanguageType language, std::optional<ClangASTMetadata> metadata,
     bool exports_symbols) {
   ASTContext &ast = getASTContext();
@@ -1327,8 +1310,7 @@ CompilerType TypeSystemClang::CreateRecordType(
   if (metadata)
     SetMetadata(decl, *metadata);
 
-  if (access_type != eAccessNone)
-    decl->setAccess(ConvertAccessTypeToAccessSpecifier(access_type));
+  decl->setAccess(AS_public);
 
   if (decl_ctx)
     decl_ctx->addDecl(decl);
@@ -1348,29 +1330,6 @@ QualType GetValueParamType(const clang::TemplateArgument &argument) {
     return argument.getStructuralValueType();
   default:
     return {};
-  }
-}
-
-void AddAccessSpecifierDecl(clang::CXXRecordDecl *cxx_record_decl,
-                            ASTContext &ct,
-                            clang::AccessSpecifier previous_access,
-                            clang::AccessSpecifier access_specifier) {
-  if (!cxx_record_decl->isClass() && !cxx_record_decl->isStruct())
-    return;
-  if (previous_access != access_specifier) {
-    // For struct, don't add AS_public if it's the first AccessSpecDecl.
-    // For class, don't add AS_private if it's the first AccessSpecDecl.
-    if ((cxx_record_decl->isStruct() &&
-         previous_access == clang::AccessSpecifier::AS_none &&
-         access_specifier == clang::AccessSpecifier::AS_public) ||
-        (cxx_record_decl->isClass() &&
-         previous_access == clang::AccessSpecifier::AS_none &&
-         access_specifier == clang::AccessSpecifier::AS_private)) {
-      return;
-    }
-    cxx_record_decl->addDecl(
-        AccessSpecDecl::Create(ct, access_specifier, cxx_record_decl,
-                               SourceLocation(), SourceLocation()));
   }
 }
 } // namespace
@@ -1462,11 +1421,7 @@ clang::FunctionTemplateDecl *TypeSystemClang::CreateFunctionTemplateDecl(
     // TODO: verify which decl context we should put template_param_decls into..
     template_param_decls[i]->setDeclContext(func_decl);
   }
-  // Function templates inside a record need to have an access specifier.
-  // It doesn't matter what access specifier we give the template as LLDB
-  // anyway allows accessing everything inside a record.
-  if (decl_ctx->isRecord())
-    func_tmpl_decl->setAccess(clang::AccessSpecifier::AS_public);
+  func_tmpl_decl->setAccess(clang::AccessSpecifier::AS_public);
 
   return func_tmpl_decl;
 }
@@ -1641,9 +1596,7 @@ ClassTemplateDecl *TypeSystemClang::CreateClassTemplateDecl(
   template_cxx_decl->setDescribedClassTemplate(class_template_decl);
   SetOwningModule(class_template_decl, owning_module);
 
-  if (access_type != eAccessNone)
-    class_template_decl->setAccess(
-        ConvertAccessTypeToAccessSpecifier(access_type));
+  class_template_decl->setAccess(AS_public);
 
   decl_ctx->addDecl(class_template_decl);
 
@@ -1774,20 +1727,6 @@ bool TypeSystemClang::CheckOverloadedOperatorKindParameterCount(
     break;
   }
   return false;
-}
-
-clang::AccessSpecifier
-TypeSystemClang::UnifyAccessSpecifiers(clang::AccessSpecifier lhs,
-                                       clang::AccessSpecifier rhs) {
-  // Make the access equal to the stricter of the field and the nested field's
-  // access
-  if (lhs == AS_none || rhs == AS_none)
-    return AS_none;
-  if (lhs == AS_private || rhs == AS_private)
-    return AS_private;
-  if (lhs == AS_protected || rhs == AS_protected)
-    return AS_protected;
-  return AS_public;
 }
 
 bool TypeSystemClang::FieldIsBitfield(FieldDecl *field,
@@ -2387,7 +2326,7 @@ CompilerType TypeSystemClang::CreateEnumerationType(
   // TODO: check if we should be setting the promotion type too?
   enum_decl->setIntegerType(ClangUtil::GetQualType(integer_clang_type));
 
-  enum_decl->setAccess(AS_public); // TODO respect what's in the debug info
+  enum_decl->setAccess(AS_public);
 
   return GetType(ast.getCanonicalTagType(enum_decl));
 }
@@ -2562,22 +2501,6 @@ TypeSystemClang::GetMetadata(const clang::Type *object) {
     return It->second;
 
   return std::nullopt;
-}
-
-void TypeSystemClang::SetCXXRecordDeclAccess(const clang::CXXRecordDecl *object,
-                                             clang::AccessSpecifier access) {
-  if (access == clang::AccessSpecifier::AS_none)
-    m_cxx_record_decl_access.erase(object);
-  else
-    m_cxx_record_decl_access[object] = access;
-}
-
-clang::AccessSpecifier
-TypeSystemClang::GetCXXRecordDeclAccess(const clang::CXXRecordDecl *object) {
-  auto It = m_cxx_record_decl_access.find(object);
-  if (It != m_cxx_record_decl_access.end())
-    return It->second;
-  return clang::AccessSpecifier::AS_none;
 }
 
 clang::DeclContext *
@@ -2818,23 +2741,6 @@ static bool GetCompleteQualType(clang::ASTContext *ast,
   }
 
   return true;
-}
-
-static clang::ObjCIvarDecl::AccessControl
-ConvertAccessTypeToObjCIvarAccessControl(AccessType access) {
-  switch (access) {
-  case eAccessNone:
-    return clang::ObjCIvarDecl::None;
-  case eAccessPublic:
-    return clang::ObjCIvarDecl::Public;
-  case eAccessPrivate:
-    return clang::ObjCIvarDecl::Private;
-  case eAccessProtected:
-    return clang::ObjCIvarDecl::Protected;
-  case eAccessPackage:
-    return clang::ObjCIvarDecl::Package;
-  }
-  return clang::ObjCIvarDecl::None;
 }
 
 // Tests
@@ -4690,7 +4596,7 @@ CompilerType TypeSystemClang::CreateTypedef(
     if (tdecl && !tdecl->getIdentifier() && !tdecl->getTypedefNameForAnonDecl())
       tdecl->setTypedefNameForAnonDecl(decl);
 
-    decl->setAccess(clang::AS_public); // TODO respect proper access specifier
+    decl->setAccess(clang::AS_public);
 
     // Get a uniqued clang::QualType for the typedef decl type
     NestedNameSpecifier Qualifier =
@@ -7460,7 +7366,7 @@ TypeSystemClang::GetAsObjCInterfaceDecl(const CompilerType &type) {
 
 clang::FieldDecl *TypeSystemClang::AddFieldToRecordType(
     const CompilerType &type, llvm::StringRef name,
-    const CompilerType &field_clang_type, AccessType access,
+    const CompilerType &field_clang_type, lldb::AccessType access,
     uint32_t bitfield_bit_size) {
   if (!type.IsValid() || !field_clang_type.IsValid())
     return nullptr;
@@ -7517,17 +7423,8 @@ clang::FieldDecl *TypeSystemClang::AddFieldToRecordType(
     }
 
     if (field) {
-      clang::AccessSpecifier access_specifier =
-          TypeSystemClang::ConvertAccessTypeToAccessSpecifier(access);
-      field->setAccess(access_specifier);
+      field->setAccess(AS_public);
 
-      if (clang::CXXRecordDecl *cxx_record_decl =
-              llvm::dyn_cast<CXXRecordDecl>(record_decl)) {
-        AddAccessSpecifierDecl(cxx_record_decl, ast->getASTContext(),
-                               ast->GetCXXRecordDeclAccess(cxx_record_decl),
-                               access_specifier);
-        ast->SetCXXRecordDeclAccess(cxx_record_decl, access_specifier);
-      }
       record_decl->addDecl(field);
 
       VerifyDecl(field);
@@ -7546,7 +7443,7 @@ clang::FieldDecl *TypeSystemClang::AddFieldToRecordType(
       ivar->setDeclContext(class_interface_decl);
       ivar->setDeclName(ident);
       ivar->setType(ClangUtil::GetQualType(field_clang_type));
-      ivar->setAccessControl(ConvertAccessTypeToObjCIvarAccessControl(access));
+      ivar->setAccessControl(ObjCIvarDecl::AccessControl::Public);
       if (bit_width)
         ivar->setBitWidth(bit_width);
       ivar->setSynthesize(is_synthesized);
@@ -7618,8 +7515,7 @@ void TypeSystemClang::BuildIndirectFields(const CompilerType &type) {
 
           indirect_field->setImplicit();
 
-          indirect_field->setAccess(TypeSystemClang::UnifyAccessSpecifiers(
-              field_pos->getAccess(), nested_field_decl->getAccess()));
+          indirect_field->setAccess(AS_public);
 
           indirect_fields.push_back(indirect_field);
         } else if (clang::IndirectFieldDecl *nested_indirect_field_decl =
@@ -7649,8 +7545,7 @@ void TypeSystemClang::BuildIndirectFields(const CompilerType &type) {
 
           indirect_field->setImplicit();
 
-          indirect_field->setAccess(TypeSystemClang::UnifyAccessSpecifiers(
-              field_pos->getAccess(), nested_indirect_field_decl->getAccess()));
+          indirect_field->setAccess(AS_public);
 
           indirect_fields.push_back(indirect_field);
         }
@@ -7689,7 +7584,7 @@ void TypeSystemClang::SetIsPacked(const CompilerType &type) {
 
 clang::VarDecl *TypeSystemClang::AddVariableToRecordType(
     const CompilerType &type, llvm::StringRef name,
-    const CompilerType &var_type, AccessType access) {
+    const CompilerType &var_type, lldb::AccessType access) {
   if (!type.IsValid() || !var_type.IsValid())
     return nullptr;
 
@@ -7716,8 +7611,7 @@ clang::VarDecl *TypeSystemClang::AddVariableToRecordType(
   if (!var_decl)
     return nullptr;
 
-  var_decl->setAccess(
-      TypeSystemClang::ConvertAccessTypeToAccessSpecifier(access));
+  var_decl->setAccess(AS_public);
   record_decl->addDecl(var_decl);
 
   VerifyDecl(var_decl);
@@ -7913,10 +7807,7 @@ clang::CXXMethodDecl *TypeSystemClang::AddMethodToCXXRecordType(
   }
   SetMemberOwningModule(cxx_method_decl, cxx_record_decl);
 
-  clang::AccessSpecifier access_specifier =
-      TypeSystemClang::ConvertAccessTypeToAccessSpecifier(access);
-
-  cxx_method_decl->setAccess(access_specifier);
+  cxx_method_decl->setAccess(AS_public);
   cxx_method_decl->setVirtualAsWritten(is_virtual);
 
   if (is_attr_used)
@@ -7930,11 +7821,6 @@ clang::CXXMethodDecl *TypeSystemClang::AddMethodToCXXRecordType(
   // have names, so we omit them when creating the ParmVarDecls.
   cxx_method_decl->setParams(CreateParameterDeclarations(
       cxx_method_decl, *method_function_prototype, /*parameter_names=*/{}));
-
-  AddAccessSpecifierDecl(cxx_record_decl, getASTContext(),
-                         GetCXXRecordDeclAccess(cxx_record_decl),
-                         access_specifier);
-  SetCXXRecordDeclAccess(cxx_record_decl, access_specifier);
 
   cxx_record_decl->addDecl(cxx_method_decl);
 
@@ -7984,14 +7870,13 @@ void TypeSystemClang::AddMethodOverridesForCXXRecordType(
 
 std::unique_ptr<clang::CXXBaseSpecifier>
 TypeSystemClang::CreateBaseClassSpecifier(lldb::opaque_compiler_type_t type,
-                                          AccessType access, bool is_virtual,
-                                          bool base_of_class) {
+                                          lldb::AccessType access,
+                                          bool is_virtual, bool base_of_class) {
   if (!type)
     return nullptr;
 
   return std::make_unique<clang::CXXBaseSpecifier>(
-      clang::SourceRange(), is_virtual, base_of_class,
-      TypeSystemClang::ConvertAccessTypeToAccessSpecifier(access),
+      clang::SourceRange(), is_virtual, base_of_class, AS_public,
       getASTContext().getTrivialTypeSourceInfo(GetQualType(type)),
       clang::SourceLocation());
 }
@@ -8494,8 +8379,6 @@ bool TypeSystemClang::CompleteTagDeclarationDefinition(
       cxx_record_decl->setHasLoadedFieldsFromExternalStorage(true);
       cxx_record_decl->setHasExternalLexicalStorage(false);
       cxx_record_decl->setHasExternalVisibleStorage(false);
-      lldb_ast->SetCXXRecordDeclAccess(cxx_record_decl,
-                                       clang::AccessSpecifier::AS_none);
       return true;
     }
   }
@@ -9093,7 +8976,8 @@ clang::ClassTemplateDecl *TypeSystemClang::ParseClassTemplateDecl(
     if (auto i = template_basename.find('<'); i != std::string::npos)
       template_basename.erase(i);
 
-    return CreateClassTemplateDecl(decl_ctx, owning_module, access_type,
+    return CreateClassTemplateDecl(decl_ctx, owning_module,
+                                   /*access_type=*/{},
                                    template_basename.c_str(), tag_decl_kind,
                                    template_param_infos);
   }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -205,11 +205,6 @@ public:
   std::optional<ClangASTMetadata> GetMetadata(const clang::Decl *object);
   std::optional<ClangASTMetadata> GetMetadata(const clang::Type *object);
 
-  void SetCXXRecordDeclAccess(const clang::CXXRecordDecl *object,
-                              clang::AccessSpecifier access);
-  clang::AccessSpecifier
-  GetCXXRecordDeclAccess(const clang::CXXRecordDecl *object);
-
   // Basic Types
   CompilerType GetBuiltinTypeForEncodingAndBitSize(lldb::Encoding encoding,
                                                    size_t bit_size) override;
@@ -308,12 +303,6 @@ public:
                          clang::OverloadedOperatorKind &op_kind);
 
   // Structure, Unions, Classes
-
-  static clang::AccessSpecifier
-  ConvertAccessTypeToAccessSpecifier(lldb::AccessType access);
-
-  static clang::AccessSpecifier
-  UnifyAccessSpecifiers(clang::AccessSpecifier lhs, clang::AccessSpecifier rhs);
 
   uint32_t GetNumBaseClasses(const clang::CXXRecordDecl *cxx_record_decl,
                              bool omit_empty_base_classes);
@@ -1243,12 +1232,6 @@ private:
   typedef llvm::DenseMap<const clang::Type *, ClangASTMetadata> TypeMetadataMap;
   /// Maps Types to their associated ClangASTMetadata.
   TypeMetadataMap m_type_metadata;
-
-  typedef llvm::DenseMap<const clang::CXXRecordDecl *, clang::AccessSpecifier>
-      CXXRecordDeclAccessMap;
-  /// Maps CXXRecordDecl to their most recent added method/field's
-  /// AccessSpecifier.
-  CXXRecordDeclAccessMap m_cxx_record_decl_access;
 
   /// The sema associated that is currently used to build this ASTContext.
   /// May be null if we are already done parsing this ASTContext or the

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -304,6 +304,9 @@ public:
 
   // Structure, Unions, Classes
 
+  static clang::AccessSpecifier
+  ConvertAccessTypeToAccessSpecifier(lldb::AccessType access);
+
   uint32_t GetNumBaseClasses(const clang::CXXRecordDecl *cxx_record_decl,
                              bool omit_empty_base_classes);
 

--- a/lldb/test/Shell/SymbolFile/NativePDB/inline_sites.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/inline_sites.test
@@ -165,11 +165,9 @@
 # CHECK-NEXT:  | `-FunctionDecl {{.*}} foo 'int (int)' inline
 # CHECK-NEXT:  |   `-ParmVarDecl {{.*}} x 'int'
 # CHECK-NEXT:  |-CXXRecordDecl {{.*}} <undeserialized declarations> class Class1
-# CHECK-NEXT:  | |-AccessSpecDecl {{.*}} public
 # CHECK-NEXT:  | `-CXXMethodDecl {{.*}} bar 'int (int)' static
 # CHECK-NEXT:  |   `-ParmVarDecl {{.*}} 'int'
 # CHECK-NEXT:  `-NamespaceDecl {{.*}} Namespace2
 # CHECK-NEXT:    `-CXXRecordDecl {{.*}} <undeserialized declarations> class Class2
-# CHECK-NEXT:      |-AccessSpecDecl {{.*}} public
 # CHECK-NEXT:      `-CXXMethodDecl {{.*}} func 'int (int)' static
 # CHECK-NEXT:        `-ParmVarDecl {{.*}} 'int'

--- a/lldb/test/Shell/SymbolFile/NativePDB/lookup-by-types.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/lookup-by-types.cpp
@@ -34,13 +34,11 @@ int main(int argc, char **argv) {
 // CHECK-NEXT:     static const A constA;
 // CHECK-NEXT:     static A a;
 // CHECK-NEXT:     static B b;
-// CHECK-NEXT: public:
 // CHECK-NEXT:     int val;
 // CHECK-NEXT: }"
 // CHECK:      image lookup -type B
 // CHECK-NEXT: 1 match found in {{.*}}.exe
 // CHECK-NEXT:  compiler_type = "class B {
 // CHECK-NEXT:     static A a;
-// CHECK-NEXT: public:
 // CHECK-NEXT:     int val;
 // CHECK-NEXT: }"

--- a/lldb/test/Shell/SymbolFile/NativePDB/tag-types.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/tag-types.cpp
@@ -167,22 +167,16 @@ int main(int argc, char **argv) {
 // CHECK-NEXT: (lldb) type lookup -- Struct
 // CHECK-NEXT: struct Struct {
 // CHECK-NEXT:     bool B;
-// CHECK-NEXT: private:
 // CHECK-NEXT:     char C;
-// CHECK-NEXT: public:
 // CHECK-NEXT:     signed char SC;
-// CHECK-NEXT: protected:
 // CHECK-NEXT:     unsigned char UC;
 // CHECK-NEXT:     char16_t C16;
 // CHECK-NEXT:     char32_t C32;
 // CHECK-NEXT:     wchar_t WC;
 // CHECK-NEXT:     short S;
 // CHECK-NEXT:     unsigned short US;
-// CHECK-NEXT: public:
 // CHECK-NEXT:     int I;
-// CHECK-NEXT: private:
 // CHECK-NEXT:     unsigned int UI;
-// CHECK-NEXT: public:
 // CHECK-NEXT:     long L;
 // CHECK-NEXT:     unsigned long UL;
 // CHECK-NEXT:     long long LL;
@@ -194,17 +188,11 @@ int main(int argc, char **argv) {
 // CHECK-NEXT: (lldb) type lookup -- Class
 // CHECK-NEXT: class Class {
 // CHECK-NEXT:     bool *PB;
-// CHECK-NEXT: public:
 // CHECK-NEXT:     char *PC;
-// CHECK-NEXT: private:
 // CHECK-NEXT:     signed char *PSC;
-// CHECK-NEXT: protected:
 // CHECK-NEXT:     unsigned char *PUC;
-// CHECK-NEXT: private:
 // CHECK-NEXT:     char16_t *PC16;
-// CHECK-NEXT: public:
 // CHECK-NEXT:     char32_t *PC32;
-// CHECK-NEXT: private:
 // CHECK-NEXT:     wchar_t *PWC;
 // CHECK-NEXT:     short *PS;
 // CHECK-NEXT:     unsigned short *PUS;
@@ -241,7 +229,6 @@ int main(int argc, char **argv) {
 // CHECK-NEXT: }
 // CHECK-NEXT: (lldb) type lookup -- Derived
 // CHECK-NEXT: class Derived : public Class {
-// CHECK-NEXT: public:
 // CHECK-NEXT:     Derived();
 // CHECK-NEXT:     Derived &Reference;
 // CHECK-NEXT:     OneMember Member;

--- a/lldb/test/Shell/SymbolFile/NativePDB/tag-types.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/tag-types.cpp
@@ -240,7 +240,7 @@ int main(int argc, char **argv) {
 // CHECK-NEXT:     OneMember &&RValueRefMember;
 // CHECK:      }
 // CHECK-NEXT: (lldb) type lookup -- Derived2
-// CHECK-NEXT: class Derived2 : protected Class, private Struct {
+// CHECK-NEXT: class Derived2 : public Class, public Struct {
 // CHECK-NEXT:     static unsigned int StaticDataMember;
 // CHECK-NEXT: }
 // CHECK-NEXT: (lldb) type lookup -- DerivedVirtual1

--- a/lldb/test/Shell/SymbolFile/NativePDB/tag-types.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/tag-types.cpp
@@ -240,7 +240,7 @@ int main(int argc, char **argv) {
 // CHECK-NEXT:     OneMember &&RValueRefMember;
 // CHECK:      }
 // CHECK-NEXT: (lldb) type lookup -- Derived2
-// CHECK-NEXT: class Derived2 : public Class, public Struct {
+// CHECK-NEXT: class Derived2 : protected Class, private Struct {
 // CHECK-NEXT:     static unsigned int StaticDataMember;
 // CHECK-NEXT: }
 // CHECK-NEXT: (lldb) type lookup -- DerivedVirtual1

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -596,6 +596,19 @@ TEST_F(TestTypeSystemClang, TestRemoveFastQualifiers) {
   EXPECT_EQ(0u, qt.getLocalFastQualifiers());
 }
 
+TEST_F(TestTypeSystemClang, TestConvertAccessTypeToAccessSpecifier) {
+  EXPECT_EQ(AS_none,
+            TypeSystemClang::ConvertAccessTypeToAccessSpecifier(eAccessNone));
+  EXPECT_EQ(AS_none, TypeSystemClang::ConvertAccessTypeToAccessSpecifier(
+                         eAccessPackage));
+  EXPECT_EQ(AS_public,
+            TypeSystemClang::ConvertAccessTypeToAccessSpecifier(eAccessPublic));
+  EXPECT_EQ(AS_private, TypeSystemClang::ConvertAccessTypeToAccessSpecifier(
+                            eAccessPrivate));
+  EXPECT_EQ(AS_protected, TypeSystemClang::ConvertAccessTypeToAccessSpecifier(
+                              eAccessProtected));
+}
+
 TEST_F(TestTypeSystemClang, TestRecordHasFields) {
   CompilerType int_type = m_ast->GetBasicType(eBasicTypeInt);
 

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -596,57 +596,6 @@ TEST_F(TestTypeSystemClang, TestRemoveFastQualifiers) {
   EXPECT_EQ(0u, qt.getLocalFastQualifiers());
 }
 
-TEST_F(TestTypeSystemClang, TestConvertAccessTypeToAccessSpecifier) {
-  EXPECT_EQ(AS_none,
-            TypeSystemClang::ConvertAccessTypeToAccessSpecifier(eAccessNone));
-  EXPECT_EQ(AS_none, TypeSystemClang::ConvertAccessTypeToAccessSpecifier(
-                         eAccessPackage));
-  EXPECT_EQ(AS_public,
-            TypeSystemClang::ConvertAccessTypeToAccessSpecifier(eAccessPublic));
-  EXPECT_EQ(AS_private, TypeSystemClang::ConvertAccessTypeToAccessSpecifier(
-                            eAccessPrivate));
-  EXPECT_EQ(AS_protected, TypeSystemClang::ConvertAccessTypeToAccessSpecifier(
-                              eAccessProtected));
-}
-
-TEST_F(TestTypeSystemClang, TestUnifyAccessSpecifiers) {
-  // Unifying two of the same type should return the same type
-  EXPECT_EQ(AS_public,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_public, AS_public));
-  EXPECT_EQ(AS_private,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_private, AS_private));
-  EXPECT_EQ(AS_protected,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_protected, AS_protected));
-
-  // Otherwise the result should be the strictest of the two.
-  EXPECT_EQ(AS_private,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_private, AS_public));
-  EXPECT_EQ(AS_private,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_private, AS_protected));
-  EXPECT_EQ(AS_private,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_public, AS_private));
-  EXPECT_EQ(AS_private,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_protected, AS_private));
-  EXPECT_EQ(AS_protected,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_protected, AS_public));
-  EXPECT_EQ(AS_protected,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_public, AS_protected));
-
-  // None is stricter than everything (by convention)
-  EXPECT_EQ(AS_none,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_none, AS_public));
-  EXPECT_EQ(AS_none,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_none, AS_protected));
-  EXPECT_EQ(AS_none,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_none, AS_private));
-  EXPECT_EQ(AS_none,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_public, AS_none));
-  EXPECT_EQ(AS_none,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_protected, AS_none));
-  EXPECT_EQ(AS_none,
-            TypeSystemClang::UnifyAccessSpecifiers(AS_private, AS_none));
-}
-
 TEST_F(TestTypeSystemClang, TestRecordHasFields) {
   CompilerType int_type = m_ast->GetBasicType(eBasicTypeInt);
 
@@ -1088,7 +1037,7 @@ TEST_F(TestTypeSystemClang, TestFunctionTemplateConstruction) {
 
   EXPECT_EQ(TU, func_template->getDeclContext());
   EXPECT_EQ("foo", func_template->getName());
-  EXPECT_EQ(clang::AccessSpecifier::AS_none, func_template->getAccess());
+  EXPECT_EQ(clang::AccessSpecifier::AS_public, func_template->getAccess());
 }
 
 TEST_F(TestTypeSystemClang, TestFunctionTemplateInRecordConstruction) {


### PR DESCRIPTION
This patch removes all our manual adjustments to the access control specifiers of Clang decls we create from DWARF.

This has led to occasional subtle bugs in the past (the latest being https://github.com/llvm/llvm-project/issues/171913) and it's ultimately redundant because Clang already has provisions for LLDB to bypass access control for C++ and Objective-C. Access control doesn't affect name lookup so really we're doing a lot of bookkeeping for not much benefit. The only "feature" that relied on this was that `type lookup <foo>` would print the access specifier in the output structure layout. I'm not convinced that's worth keeping the infrastructure in place for (but happy to be convinced otherwise).

I'd rather lean fully into the Clang access control bypass instead.

Note, i still kept the `AccessType` parameters to the various `TypeSystemClang` APIs to reduce the size of the diff. A follow-up NFC change will remove those parameters and adjust all the call-sites.