### PR TITLE
[flang] Warn about assumed-rank items in I/O lists

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -483,6 +483,7 @@ end
   are to the same value.  Distinct initializations remain errors.
 * A pointer component that has no default initialization or explicit value
   in a structure constructor is defaulted to `NULL()`.
+* An assumed-rank entity is an acceptable `NAMELIST` group item.
 
 ### Extensions supported when enabled by options
 

--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -57,7 +57,7 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     ForwardRefExplicitTypeDummy, InaccessibleDeferredOverride,
     CudaWarpMatchFunction, DoConcurrentOffload, TransferBOZ, Coarray,
     PointerPassObject, MultipleIdenticalDATA,
-    DefaultStructConstructorNullPointer)
+    DefaultStructConstructorNullPointer, AssumedRankIoItem)
 
 // Portability and suspicious usage warnings
 ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,

--- a/flang/lib/Semantics/check-io.h
+++ b/flang/lib/Semantics/check-io.h
@@ -133,6 +133,7 @@ private:
       const SomeExpr &, common::DefinedIo, parser::CharBlock) const;
   parser::Message *CheckForBadIoType(
       const Symbol &, common::DefinedIo, parser::CharBlock) const;
+  void CheckForAssumedRank(const Symbol *, parser::CharBlock) const;
 
   void CheckNamelist(
       const Symbol &, common::DefinedIo, parser::CharBlock) const;

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -7228,6 +7228,13 @@ void DeclarationVisitor::FinishNamelists() {
             } else if (!ConvertToObjectEntity(symbol->GetUltimate())) {
               SayWithDecl(name, *symbol, "'%s' is not a variable"_err_en_US);
               context().SetError(*groupSymbol);
+            } else if (IsAssumedRank(*symbol)) {
+              evaluate::AttachDeclaration(
+                  context().Warn(common::LanguageFeature::AssumedRankIoItem,
+                      name.source,
+                      "Assumed-rank object '%s' should not be a namelist group item"_port_en_US,
+                      symbol->name()),
+                  *symbol);
             }
             symbol->GetUltimate().set(Symbol::Flag::InNamelist);
             details->add_object(*symbol);

--- a/flang/test/Semantics/io16.f90
+++ b/flang/test/Semantics/io16.f90
@@ -1,0 +1,15 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
+subroutine assumedRank(x, y)
+  real x(..), y(*)
+  !PORTABILITY: Assumed-rank object 'x' should not be a namelist group item [-Wassumed-rank-io-item]
+  !ERROR: A namelist group object 'y' must not be assumed-size
+  namelist /nml/x, y
+  !ERROR: Assumed-rank object 'x' may not be an I/O list item
+  !ERROR: Whole assumed-size array 'y' may not appear here without subscripts
+  read *, x, y
+  !ERROR: Assumed-rank object 'x' may not be an I/O list item
+  !ERROR: Whole assumed-size array 'y' may not appear here without subscripts
+  print *, x, y
+  read(*,nml=nml)
+  write(*,nml=nml)
+end


### PR DESCRIPTION
An assumed-rank dummy argument is not a conforming I/O list or NAMELIST group item.  Add a -pedantic warning and some documentation.