### PR TITLE
[win] Control Flow Guard: Add support for the MSVC /d2guardnochecks command

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -168,6 +168,10 @@ New Compiler Flags
   enable parsing of the experimental ``overflow_behavior`` type attribute and
   type specifiers.
 
+- New ``-cl`` option ``/d2guardnochecks`` added to match MSVC. When Windows
+  Control Flow Guard (CFG) is enabled by other options, it will instruct Clang
+  to emit the CFG metadata, but disable adding checks.
+
 Deprecated Compiler Flags
 -------------------------
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9504,6 +9504,8 @@ def _SLASH_d2epilogunwind : CLFlag<"d2epilogunwind">,
   HelpText<"Best effort generate unwind v2 (epilog) information for x64 Windows">;
 def _SLASH_d2epilogunwindrequirev2 : CLFlag<"d2epilogunwindrequirev2">,
   HelpText<"Require generation of unwind v2 (epilog) information for x64 Windows">;
+def _SLASH_d2guardnochecks : CLFlag<"d2guardnochecks">,
+  HelpText<"When used with /guard:cf, emits Windows Control Flow Guard tables only (no checks)">;
 def _SLASH_EH : CLJoined<"EH">, HelpText<"Set exception handling model">;
 def _SLASH_EP : CLFlag<"EP">,
   HelpText<"Disable linemarker output and preprocess to stdout">;

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -671,13 +671,26 @@
 
 // RUN: %clang_cl /guard:cf /guard:ehcont -Wall -Wno-msvc-not-found -### -- %s 2>&1 | \
 // RUN:   FileCheck -check-prefix=BOTHGUARD %s --implicit-check-not=warning:
-// BOTHGUARD: -cfguard
-// BOTHGUARD-SAME: -ehcontguard
+// BOTHGUARD: -ehcontguard
+// BOTHGUARD-SAME: -cfguard
 // BOTHGUARD: -guard:cf
 // BOTHGUARD-SAME: -guard:ehcont
 
 // RUN: not %clang_cl /guard:foo -### -- %s 2>&1 | FileCheck -check-prefix=CFGUARDINVALID %s
 // CFGUARDINVALID: invalid value 'foo' in '/guard:'
+
+// /d2guardnochecks downgrades /guard:cf to table-only (no-checks).
+// RUN: %clang_cl /guard:cf /d2guardnochecks -### -- %s 2>&1 | FileCheck -check-prefix=D2GUARDNOCHECKS %s
+// D2GUARDNOCHECKS-NOT: "-cfguard"
+// D2GUARDNOCHECKS: "-cfguard-no-checks"
+
+// /d2guardnochecks is a no-op without /guard:cf.
+// RUN: %clang_cl /d2guardnochecks -### -- %s 2>&1 | FileCheck -check-prefix=D2GUARDNOCHECKS-NOOP %s
+// D2GUARDNOCHECKS-NOOP-NOT: -cfguard
+
+// /d2guardnochecks with /guard:cf,nochecks stays as nochecks.
+// RUN: %clang_cl /guard:cf,nochecks /d2guardnochecks -### -- %s 2>&1 | FileCheck -check-prefix=D2GUARDNOCHECKS-ALREADY %s
+// D2GUARDNOCHECKS-ALREADY: -cfguard-no-checks
 
 // Accept "core" clang options.
 // (/Zs is for syntax-only, -Werror makes it fail hard on unknown options)


### PR DESCRIPTION
This adds support for MSVC's `/d2guardnochecks` undocumented flag. This flag is similar to `-guard:cf,nochecks` and `-cfguard-no-checks` in that it instructs the compiler to emit the metadata for Control Flow Guard WITHOUT emitting checks (aka: "table only" mode), but it differs from those existing flags because if only takes effect if another flag is used to enable Control Flow Guard (i.e., `/d2guardnochecks` by itself does nothing, `/d2guardnochecks /guard:cf` enables table-only mode for Control Flow Guard).