### PR TITLE
[Hexagon] Fix createHvxPrefixPred storing i64 values in Words[]

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
@@ -1177,11 +1177,10 @@ HexagonTargetLowering::createHvxPrefixPred(SDValue PredV, const SDLoc &dl,
   SDValue W0 = isUndef(PredV)
                   ? DAG.getUNDEF(MVT::i64)
                   : DAG.getNode(HexagonISD::P2D, dl, MVT::i64, PredV);
-  if (Bytes < BitBytes) {
-    Words[IdxW].push_back(HiHalf(W0, DAG));
-    Words[IdxW].push_back(LoHalf(W0, DAG));
-  } else
-    Words[IdxW].push_back(W0);
+  // Words must always contain i32 values (since they are inserted via
+  // VINSERTW0 below). Always split the i64 P2D result into two i32 halves.
+  Words[IdxW].push_back(HiHalf(W0, DAG));
+  Words[IdxW].push_back(LoHalf(W0, DAG));
 
   while (Bytes < BitBytes) {
     IdxW ^= 1;
@@ -1206,26 +1205,33 @@ HexagonTargetLowering::createHvxPrefixPred(SDValue PredV, const SDLoc &dl,
     IdxW ^= 1;
     Words[IdxW].clear();
 
+    // contractPredicate takes an i64 and returns an i32.
+    // Pair adjacent i32 words back into i64 before contracting.
+    // This is the inverse of the expansion loop above, which splits
+    // each i64 (from expandPredicate) into two i32 halves.
+    auto &Src = Words[IdxW ^ 1];
     if (Bytes <= 4) {
-      for (const SDValue &W : Words[IdxW ^ 1]) {
-        SDValue T = contractPredicate(W, dl, DAG);
+      for (unsigned i = 0, e = Src.size(); i < e; i += 2) {
+        SDValue Hi = Src[i];
+        SDValue Lo = i + 1 < e ? Src[i + 1] : DAG.getUNDEF(MVT::i32);
+        SDValue Pair = getCombine(Hi, Lo, dl, MVT::i64, DAG);
+        SDValue T = contractPredicate(Pair, dl, DAG);
         Words[IdxW].push_back(T);
       }
     } else {
-      for (const SDValue &W : Words[IdxW ^ 1]) {
-        Words[IdxW].push_back(W);
+      for (unsigned i = 0, e = Src.size(); i < e; i += 2) {
+        Words[IdxW].push_back(Src[i]);
       }
     }
     Bytes /= 2;
   }
 
   assert(Bytes == BitBytes);
-  if (BitBytes == 1 && PredTy == MVT::v2i1)
-    ByteTy = MVT::getVectorVT(MVT::i16, HwLen);
 
   SDValue Vec = ZeroFill ? getZero(dl, ByteTy, DAG) : DAG.getUNDEF(ByteTy);
   SDValue S4 = DAG.getConstant(HwLen-4, dl, MVT::i32);
   for (const SDValue &W : Words[IdxW]) {
+    assert(ty(W).getSizeInBits() == 32 && "Words must be 32-bit values");
     Vec = DAG.getNode(HexagonISD::VROR, dl, ByteTy, Vec, S4);
     Vec = DAG.getNode(HexagonISD::VINSERTW0, dl, ByteTy, Vec, W);
   }

--- a/llvm/test/CodeGen/Hexagon/hvx-prefix-pred-i64-bug.ll
+++ b/llvm/test/CodeGen/Hexagon/hvx-prefix-pred-i64-bug.ll
@@ -1,0 +1,35 @@
+; REQUIRES: asserts
+; RUN: llc -mtriple=hexagon -mattr=+hvxv68,+hvx-length128b < %s -o /dev/null
+;
+; Verify that createHvxPrefixPred always stores 32-bit values in Words[].
+; Commit e5bb946d1818f introduced a path where the i64 P2D result was pushed
+; directly into Words[] without splitting into HiHalf/LoHalf, and the
+; contraction loop operated on individual words instead of pairing them.
+; This caused either a contractPredicate assertion (v2i1) or a BitTracker
+; WD >= WS assertion (v8i1) when VINSERTW0 received an i64 operand.
+;
+; Regression test for https://github.com/llvm/llvm-project/issues/181362
+
+; v2i1: Bytes=4, BitBytes=1 (needs two contraction steps)
+define <128 x i1> @test_insert_v2i1(<128 x i1> %pred, <2 x i1> %sub) #0 {
+  %res = call <128 x i1> @llvm.vector.insert.v128i1.v2i1(<128 x i1> %pred, <2 x i1> %sub, i64 0)
+  ret <128 x i1> %res
+}
+
+; v4i1: Bytes=2, BitBytes=1 (needs one contraction step)
+define <128 x i1> @test_insert_v4i1(<128 x i1> %pred, <4 x i1> %sub) #0 {
+  %res = call <128 x i1> @llvm.vector.insert.v128i1.v4i1(<128 x i1> %pred, <4 x i1> %sub, i64 0)
+  ret <128 x i1> %res
+}
+
+; v8i1: Bytes=1, BitBytes=1 (no contraction, but i64 was pushed into VINSERTW0)
+define <128 x i1> @test_insert_v8i1(<128 x i1> %pred, <8 x i1> %sub) #0 {
+  %res = call <128 x i1> @llvm.vector.insert.v128i1.v8i1(<128 x i1> %pred, <8 x i1> %sub, i64 0)
+  ret <128 x i1> %res
+}
+
+declare <128 x i1> @llvm.vector.insert.v128i1.v2i1(<128 x i1>, <2 x i1>, i64)
+declare <128 x i1> @llvm.vector.insert.v128i1.v4i1(<128 x i1>, <4 x i1>, i64)
+declare <128 x i1> @llvm.vector.insert.v128i1.v8i1(<128 x i1>, <8 x i1>, i64)
+
+attributes #0 = { nounwind "target-features"="+hvxv68,+hvx-length128b" }


### PR DESCRIPTION
Words[] must always contain i32 values since they are inserted via VINSERTW0, which expects i32 operands. Commit e5bb946d1818f introduced a path where the i64 P2D result was pushed directly into Words[] when Bytes >= BitBytes, and the contraction loop called contractPredicate on individual words instead of pairing them.

Fix by always splitting the P2D i64 result into HiHalf/LoHalf (i32), and fixing the contraction loop to pair adjacent i32 words back into i64 via getCombine before calling contractPredicate -- the inverse of the expansion loop which splits each expandPredicate i64 into two i32 halves. Also remove the unreachable v128i16 ByteTy override and add an assertion enforcing the i32 invariant at the VINSERTW0 site.

Fixes https://github.com/llvm/llvm-project/issues/181362