### PR TITLE
[LLVM] Metric added - largest number of basic blocks in a single func…

### DIFF
--- a/llvm/lib/Analysis/InstCount.cpp
+++ b/llvm/lib/Analysis/InstCount.cpp
@@ -26,6 +26,8 @@ STATISTIC(TotalBlocks, "Number of basic blocks");
 STATISTIC(TotalFuncs, "Number of non-external functions");
 STATISTIC(LargestFunctionSize,
           "Largest number of instructions in a single function");
+STATISTIC(LargestFunctionBBCount,
+          "Largest number of basic blocks in a single function");
 
 #define HANDLE_INST(N, OPCODE, CLASS)                                          \
   STATISTIC(Num##OPCODE##Inst, "Number of " #OPCODE " insts");
@@ -39,6 +41,7 @@ class InstCount : public InstVisitor<InstCount> {
   void visitFunction(Function &F) {
     ++TotalFuncs;
     LargestFunctionSize.updateMax(F.getInstructionCount());
+    LargestFunctionBBCount.updateMax(F.size());
   }
   void visitBasicBlock(BasicBlock &BB) { ++TotalBlocks; }
 

--- a/llvm/test/Analysis/InstCount/instcount.ll
+++ b/llvm/test/Analysis/InstCount/instcount.ll
@@ -7,6 +7,7 @@
 ; RUN: opt -stats -O3 -disable-output < %s 2>&1 | FileCheck %s
 ; RUN: opt -stats -O0 -disable-output < %s 2>&1 | FileCheck %s
 
+; CHECK-DAG: 10 instcount - Largest number of basic blocks in a single function
 ; CHECK-DAG: 18 instcount - Largest number of instructions in a single function
 ; CHECK-DAG: 8 instcount - Number of Br insts
 ; CHECK-DAG: 6 instcount - Number of Call insts


### PR DESCRIPTION
This metric gets the size of the biggest count of basic blocks in a single function.