### PR TITLE
[flang] Catch recursive call to non_recursive ENTRY

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3316,6 +3316,12 @@ void ExpressionAnalyzer::CheckBadExplicitType(
 
 void ExpressionAnalyzer::CheckForBadRecursion(
     parser::CharBlock callSite, const semantics::Symbol &proc) {
+  if (const Symbol *mainEntry{GetMainEntry(&proc)}) {
+    if (mainEntry != &proc) {
+      CheckForBadRecursion(callSite, *mainEntry);
+      return;
+    }
+  }
   if (const auto *scope{proc.scope()}) {
     if (scope->sourceRange().Contains(callSite)) {
       parser::Message *msg{nullptr};

--- a/flang/test/Semantics/call01.f90
+++ b/flang/test/Semantics/call01.f90
@@ -4,11 +4,14 @@
 non_recursive function f01(n) result(res)
   integer, value :: n
   integer :: res
+  entry f01b(n) result(res)
   if (n <= 0) then
     res = n
   else
     !ERROR: NON_RECURSIVE procedure 'f01' cannot call itself
     res = n * f01(n-1) ! 15.6.2.1(3)
+    !ERROR: NON_RECURSIVE procedure 'f01b' cannot call itself
+    res = n * f01b(n-1) ! 15.6.2.1(3)
   end if
 end function
 


### PR DESCRIPTION
The check for a recursive call to a non-recursive subprogram doesn't allow for the case of an alternate ENTRY point.