### PR TITLE
[flang][OpenMP] Fix crash in declare reduction with intrinsic operators

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -3955,8 +3955,28 @@ static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
       appendCombiner(construct, clauses, semaCtx);
   const auto &identifier =
       std::get<parser::OmpReductionIdentifier>(specifier.t);
-  const auto &designator = std::get<parser::ProcedureDesignator>(identifier.u);
-  const auto &reductionName = std::get<parser::Name>(designator.u);
+
+  std::string reductionNameStr = Fortran::common::visit(
+      common::visitors{
+          [](const parser::ProcedureDesignator &pd) -> std::string {
+            return std::get<parser::Name>(pd.u).ToString();
+          },
+          [](const parser::DefinedOperator &defOp) -> std::string {
+            return Fortran::common::visit(
+                common::visitors{
+                    [](const parser::DefinedOpName &opName) -> std::string {
+                      return opName.v.ToString();
+                    },
+                    [](parser::DefinedOperator::IntrinsicOperator intrOp)
+                        -> std::string {
+                      return std::string(
+                          parser::DefinedOperator::EnumToString(intrOp));
+                    },
+                },
+                defOp.u);
+          },
+      },
+      identifier.u);
 
   for (const auto &typeSpec : typeNameList.v) {
     (void)typeSpec; // Currently unused
@@ -3969,7 +3989,7 @@ static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
     bool isByRef = ReductionProcessor::doReductionByRef(reductionType);
     ReductionProcessor::createDeclareReductionHelper<
         mlir::omp::DeclareReductionOp>(
-        converter, reductionName.ToString(), reductionType,
+        converter, reductionNameStr, reductionType,
         converter.getCurrentLocation(), isByRef, genCombinerCB, genInitValueCB);
   }
 }

--- a/flang/test/Lower/OpenMP/declare-reduction-intrinsic-op.f90
+++ b/flang/test/Lower/OpenMP/declare-reduction-intrinsic-op.f90
@@ -1,0 +1,14 @@
+! RUN: not %flang_fc1 -emit-mlir -fopenmp %s -o - 2>&1 | FileCheck %s
+
+program test
+  type t
+     integer :: x
+  end type t
+  ! CHECK: not yet implemented: Reduction of some types is not supported
+  !$omp declare reduction(+:t: omp_out%x = omp_out%x + omp_in%x) initializer(omp_priv = t(0))
+  type(t) :: a
+  a = t(0)
+  !$omp parallel reduction(+:a)
+  a%x = a%x + 1
+  !$omp end parallel
+end program test


### PR DESCRIPTION
genOMP for OpenMPDeclareReductionConstruct unconditionally extracts
ProcedureDesignator from OmpReductionIdentifier, but when the reduction
identifier is an intrinsic operator like `+`, the parser produces a
DefinedOperator instead. This causes a std::get crash.

Visit both variants of OmpReductionIdentifier to extract the reduction
name string, handling DefinedOperator (with IntrinsicOperator and
DefinedOpName sub-variants) alongside the existing ProcedureDesignator
path.

This fixes the ICE; the underlying lack of derived-type reduction
support (TODO in ReductionProcessor::getReductionInitValue) remains
a separate issue.
