### PR TITLE
[NFC][ThinLTO] Check that refs between split modules have the same GUID

### DIFF
--- a/llvm/test/Transforms/ThinLTOBitcodeWriter/split-internal2.ll
+++ b/llvm/test/Transforms/ThinLTOBitcodeWriter/split-internal2.ll
@@ -33,3 +33,8 @@ define internal void @f2() {
 
 ; M1: !0 = !{i32 0, !"typeid"}
 !0 = !{i32 0, !"typeid"}
+
+; test that the GUID of f.<hash> is the same in the summaries of the 2 split
+; modules
+; M0: = gv: (name: "f.13757e0fb71915e385efa4dc9d1e08fd", {{.*}} ; guid = 11302379072751562722
+; M1: = gv: (name: "f.13757e0fb71915e385efa4dc9d1e08fd") ; guid = 11302379072751562722


### PR DESCRIPTION
Right now, the GUIDs are computed from the names with the hash suffix. Once we land [this RFC](https://discourse.llvm.org/t/rfc-keep-globalvalue-guids-stable/84801), we'll want to use the original symbol's GUID, and also ensure any refs to such symbols (in the case of a split module) keep that GUID. This test prepares that.

Note that an effect of the aforementioned RFC is that the GUIDs will be different from the ones checked in the test (but will still be the same wrt eachother) 