### PR TITLE
[MemRefToEmitC] avoid crash when lower global from MemRef to EmitC

### DIFF
--- a/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
+++ b/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
@@ -285,8 +285,12 @@ struct ConvertGlobal final : public OpConversionPattern<memref::GlobalOp> {
 
     Attribute initialValue = operands.getInitialValueAttr();
     if (opTy.getRank() == 0) {
-      auto elementsAttr = llvm::cast<ElementsAttr>(*op.getInitialValue());
-      initialValue = elementsAttr.getSplatValue<Attribute>();
+      // special case for `variable : memref<i32> = dense<-1>`
+      if (std::optional<Attribute> initValueAttr = op.getInitialValue()) {
+        if (auto elementsAttr = llvm::dyn_cast<ElementsAttr>(*initValueAttr)) {
+          initialValue = elementsAttr.getSplatValue<Attribute>();
+        }
+      }
     }
     if (isa_and_present<UnitAttr>(initialValue))
       initialValue = {};

--- a/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc.mlir
+++ b/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc.mlir
@@ -58,3 +58,13 @@ module @globals {
     return
   }
 }
+
+// -----
+
+// CHECK-LABEL: rank0_globals
+module @rank0_globals {
+  memref.global @extern_global : memref<f32>
+  // CHECK-NEXT: emitc.global extern @extern_global : f32
+  memref.global @uninitialized_global : memref<f32> = uninitialized
+  // CHECK-NEXT: emitc.global extern @uninitialized_global : f32
+}


### PR DESCRIPTION
Fixed #181533.
Improve the robust when handling rank 0 special case
