### PR TITLE
[Github] Turn on prune-unused-branches workflow

### DIFF
--- a/.github/workflows/prune-unused-branches.py
+++ b/.github/workflows/prune-unused-branches.py
@@ -141,10 +141,6 @@ def generate_patches_for_all_branches(branches_to_remove: list[str], patches_pat
 
 def delete_branches(branches_to_remove: list[str]):
     for branch in branches_to_remove:
-        # TODO(boomanaiden154): Only delete my branches for now to verify that
-        # everything is working in the production environment.
-        if "boomanaiden154" not in branch:
-            continue
         command_vector = ["git", "push", "-d", "origin", branch]
         try:
             subprocess.run(


### PR DESCRIPTION
This patch turns on the prune-unused-branches workflow for everyone rather than just my user branches now that all feedback from the discourse thread has been addressed.