### PR TITLE
[AsmPrinter] Use default capture for assertion only lambda

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -463,7 +463,7 @@ AsmPrinter::AsmPrinter(TargetMachine &tm, std::unique_ptr<MCStreamer> Streamer,
     if (NeedsDefault)
       SM.serializeToStackMapSection();
   };
-  AssertDebugEHFinalized = [this]() {
+  AssertDebugEHFinalized = [&]() {
     assert(!DD && Handlers.size() == NumUserHandlers &&
            "Debug/EH info didn't get finalized");
   };


### PR DESCRIPTION
Otherwise we get an unused variable warning/error in non-assertion builds.