### PR TITLE
[DWARFLinker] Fix buildbot crash: NewUnit can be null during garbage

### DIFF
--- a/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerCompileUnit.h
+++ b/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerCompileUnit.h
@@ -167,8 +167,8 @@ public:
   uint64_t getNextUnitOffset() const { return NextUnitOffset; }
   void setStartOffset(uint64_t DebugInfoSize) {
     StartOffset = DebugInfoSize;
-    assert(NewUnit && "NewUnit should exist when setting start offset");
-    NewUnit->setDebugSectionOffset(DebugInfoSize);
+    if (NewUnit)
+      NewUnit->setDebugSectionOffset(DebugInfoSize);
   }
 
   std::optional<uint64_t> getLowPc() const { return LowPc; }


### PR DESCRIPTION
The assert added in [0ab1d23fbfa2ae0ba14315cb11678d2289510f66](https://github.com/llvm/llvm-project/commit/0ab1d23fbfa2ae0ba14315cb11678d2289510f66) is incorrect, NewUnit is legitimately null for compile units that are skipped during garbage collection (e.g. dwarf5-macro.test). Revert to the original null check.