### PR TITLE
[LifetimeSafety] Use per-container invalidation rules to fix false positives

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -71,8 +71,13 @@ bool isGslOwnerType(QualType QT);
 // when ownership is manually transferred.
 bool isUniquePtrRelease(const CXXMethodDecl &MD);
 
-// Returns true if the given method invalidates iterators or references to
-// container elements (e.g. vector::push_back).
+// Returns true if the given method invalidates references to container
+// elements (e.g. vector::push_back). Methods that only invalidate iterators
+// but not references (e.g. unordered_map::emplace) are not considered
+// invalidating here.
+//
+// Invalidation rules are based on:
+// https://en.cppreference.com/w/cpp/container#Iterator_invalidation
 bool isContainerInvalidationMethod(const CXXMethodDecl &MD);
 
 } // namespace clang::lifetimes

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -279,7 +279,6 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
 
   // `pop_back` is excluded: it only invalidates references to the removed
   // element, not to other elements.
-  // https://en.cppreference.com/w/cpp/container/vector/pop_back.html
   static const llvm::StringSet<> Vector = {// Insertion
                                            "insert", "emplace", "emplace_back",
                                            "push_back", "insert_range",
@@ -293,7 +292,6 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
 
   // `pop_*` methods are excluded: they only invalidate references to the
   // removed element, not to other elements.
-  // https://en.cppreference.com/w/cpp/container/deque.html#Invalidation_notes
   static const llvm::StringSet<> Deque = {// Insertion
                                           "insert", "emplace", "insert_range",
                                           // Removal
@@ -324,8 +322,6 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
 
   // `erase` and `extract` are excluded: they only affect the removed element,
   // not to other elements.
-  // https://en.cppreference.com/w/cpp/container/map/erase.html
-  // https://en.cppreference.com/w/cpp/container/map/extract.html
   static const llvm::StringSet<> NodeBased = {// Removal
                                               "clear"};
 
@@ -342,6 +338,8 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
                                          "replace"};
 
   const StringRef ContainerName = getName(*RD);
+  // TODO: Consider caching this lookup by CXXMethodDecl pointer if this
+  // StringSwitch becomes a performance bottleneck.
   const llvm::StringSet<> *InvalidatingMethods =
       llvm::StringSwitch<const llvm::StringSet<> *>(ContainerName)
           .Case("vector", &Vector)
@@ -368,8 +366,6 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
     case OO_Subscript: // operator[] : Invalidation only for
                        // `flat_map` (Insert-or-access).
                        // `map` and `unordered_map` are excluded.
-      // https://en.cppreference.com/w/cpp/container/unordered_map.html#Iterator_invalidation
-      // https://en.cppreference.com/w/cpp/container/map/operator_at.html
       return ContainerName == "flat_map";
     default:
       return false;

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -272,28 +272,109 @@ bool isUniquePtrRelease(const CXXMethodDecl &MD) {
          MD.getNumParams() == 0 && isStdUniquePtr(*MD.getParent());
 }
 
+/// Returns the set of methods that invalidate iterators for the given
+/// container, or nullptr if the container is not recognized.
+///
+/// Iterator invalidation rules per the C++ standard:
+/// https://en.cppreference.com/w/cpp/container#Iterator_invalidation
+static const llvm::StringSet<> *
+getInvalidatingMethods(StringRef ContainerName) {
+  static const llvm::StringSet<> Vector = {// Insertion
+                                           "insert", "emplace", "emplace_back",
+                                           "push_back", "insert_range",
+                                           "append_range",
+                                           // Removal
+                                           "pop_back", "erase", "clear",
+                                           // Memory management
+                                           "reserve", "resize", "shrink_to_fit",
+                                           // Assignment
+                                           "swap", "assign", "assign_range"};
+
+  static const llvm::StringSet<> Deque = {
+      // Insertion
+      "insert", "emplace", "emplace_back", "push_back", "push_front",
+      "emplace_front", "insert_range", "append_range",
+      // Removal
+      "pop_back", "pop_front", "erase", "clear",
+      // Memory management
+      "resize", "shrink_to_fit",
+      // Assignment
+      "swap", "assign", "assign_range"};
+
+  static const llvm::StringSet<> String = {
+      // Insertion
+      "insert", "push_back", "append", "replace", "replace_with_range",
+      "insert_range", "append_range",
+      // Removal
+      "pop_back", "erase", "clear",
+      // Memory management
+      "reserve", "resize", "resize_and_overwrite", "shrink_to_fit",
+      // Assignment
+      "swap", "assign", "assign_range"};
+
+  // FIXME: Add queue and stack and check for underlying container
+  // (e.g. no invalidation for std::list).
+  static const llvm::StringSet<> PriorityQueue = {// Insertion
+                                                  "push", "emplace",
+                                                  "push_range",
+                                                  // Removal
+                                                  "pop",
+                                                  // Assignment
+                                                  "swap"};
+
+  static const llvm::StringSet<> Associative = {// Removal
+                                                "clear",
+                                                // Assignment
+                                                "swap"};
+
+  // For unordered associative containers, `try_emplace` and `insert_or_assign`
+  // only exist on `unordered_map`. Listing them here is harmless since the
+  // methods won't be found on other types.
+  static const llvm::StringSet<> UnorderedAssociative = {
+      // Insertion
+      "insert", "emplace", "emplace_hint", "try_emplace", "insert_or_assign",
+      "insert_range", "merge",
+      // Removal
+      "clear",
+      // Hash policy
+      "rehash", "reserve",
+      // Assignment
+      "swap"};
+
+  // For `flat_*` container adaptors, `try_emplace` and `insert_or_assign`
+  // only exist on `flat_map`. Listing them here is harmless since the methods
+  // won't be found on other types.
+  static const llvm::StringSet<> Flat = {// Insertion
+                                         "insert", "emplace", "emplace_hint",
+                                         "try_emplace", "insert_or_assign",
+                                         "insert_range", "merge",
+                                         // Removal
+                                         "extract", "erase", "clear",
+                                         // Assignment
+                                         "swap", "replace"};
+
+  return llvm::StringSwitch<const llvm::StringSet<> *>(ContainerName)
+      .Case("vector", &Vector)
+      .Case("basic_string", &String)
+      .Case("deque", &Deque)
+      .Case("priority_queue", &PriorityQueue)
+      .Cases({"set", "multiset", "map", "multimap"}, &Associative)
+      .Cases({"unordered_set", "unordered_multiset", "unordered_map",
+              "unordered_multimap"},
+             &UnorderedAssociative)
+      .Cases({"flat_map", "flat_set", "flat_multimap", "flat_multiset"}, &Flat)
+      .Default(nullptr);
+}
+
 bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
   const CXXRecordDecl *RD = MD.getParent();
   if (!isInStlNamespace(RD))
     return false;
 
   StringRef ContainerName = getName(*RD);
-  static const llvm::StringSet<> Containers = {
-      // Sequence
-      "vector", "basic_string", "deque",
-      // Adaptors
-      // FIXME: Add queue and stack and check for underlying container (e.g. no
-      // invalidation for std::list).
-      "priority_queue",
-      // Associative
-      "set", "multiset", "map", "multimap",
-      // Unordered Associative
-      "unordered_set", "unordered_multiset", "unordered_map",
-      "unordered_multimap",
-      // C++23 Flat
-      "flat_map", "flat_set", "flat_multimap", "flat_multiset"};
-
-  if (!Containers.contains(ContainerName))
+  const llvm::StringSet<> *InvalidatingMethods =
+      getInvalidatingMethods(ContainerName);
+  if (!InvalidatingMethods)
     return false;
 
   // Handle Operators via OverloadedOperatorKind
@@ -318,41 +399,6 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
   if (!MD.getIdentifier())
     return false;
 
-  StringRef MethodName = MD.getName();
-
-  // Special handling for 'erase':
-  // It invalidates the whole container (effectively) for contiguous/flat
-  // storage, but is safe for other iterators in node-based containers.
-  if (MethodName == "erase") {
-    static const llvm::StringSet<> NodeBasedContainers = {"map",
-                                                          "set",
-                                                          "multimap",
-                                                          "multiset",
-                                                          "unordered_map",
-                                                          "unordered_set",
-                                                          "unordered_multimap",
-                                                          "unordered_multiset"};
-
-    // 'erase' invalidates for non node-based containers (vector, deque, string,
-    // flat_map).
-    return !NodeBasedContainers.contains(ContainerName);
-  }
-
-  static const llvm::StringSet<> InvalidatingMembers = {
-      // Basic Insertion/Emplacement
-      "push_front", "push_back", "emplace_front", "emplace_back", "insert",
-      "emplace", "push",
-      // Basic Removal/Clearing
-      "pop_front", "pop_back", "pop", "clear",
-      // Memory Management
-      "reserve", "resize", "shrink_to_fit",
-      // Assignment (Named)
-      "assign", "swap",
-      // String Specifics
-      "append", "replace",
-      // Modern C++ (C++17/23)
-      "extract", "try_emplace", "insert_range", "append_range", "assign_range"};
-
-  return InvalidatingMembers.contains(MethodName);
+  return InvalidatingMethods->contains(MD.getName());
 }
 } // namespace clang::lifetimes

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -272,34 +272,36 @@ bool isUniquePtrRelease(const CXXMethodDecl &MD) {
          MD.getNumParams() == 0 && isStdUniquePtr(*MD.getParent());
 }
 
-/// Returns the set of methods that invalidate iterators for the given
-/// container, or nullptr if the container is not recognized.
-///
-/// Iterator invalidation rules per the C++ standard:
-/// https://en.cppreference.com/w/cpp/container#Iterator_invalidation
-static const llvm::StringSet<> *
-getInvalidatingMethods(StringRef ContainerName) {
+bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
+  const CXXRecordDecl *RD = MD.getParent();
+  if (!isInStlNamespace(RD))
+    return false;
+
+  // `pop_back` is excluded: it only invalidates references to the removed
+  // element, not to other elements.
+  // https://en.cppreference.com/w/cpp/container/vector/pop_back.html
   static const llvm::StringSet<> Vector = {// Insertion
                                            "insert", "emplace", "emplace_back",
                                            "push_back", "insert_range",
                                            "append_range",
                                            // Removal
-                                           "pop_back", "erase", "clear",
+                                           "erase", "clear",
                                            // Memory management
                                            "reserve", "resize", "shrink_to_fit",
                                            // Assignment
                                            "swap", "assign", "assign_range"};
 
-  static const llvm::StringSet<> Deque = {
-      // Insertion
-      "insert", "emplace", "emplace_back", "push_back", "push_front",
-      "emplace_front", "insert_range", "append_range",
-      // Removal
-      "pop_back", "pop_front", "erase", "clear",
-      // Memory management
-      "resize", "shrink_to_fit",
-      // Assignment
-      "swap", "assign", "assign_range"};
+  // `pop_*` methods are excluded: they only invalidate references to the
+  // removed element, not to other elements.
+  // https://en.cppreference.com/w/cpp/container/deque.html#Invalidation_notes
+  static const llvm::StringSet<> Deque = {// Insertion
+                                          "insert", "emplace", "insert_range",
+                                          // Removal
+                                          "erase", "clear",
+                                          // Memory management
+                                          "resize", "shrink_to_fit",
+                                          // Assignment
+                                          "swap", "assign", "assign_range"};
 
   static const llvm::StringSet<> String = {
       // Insertion
@@ -322,24 +324,14 @@ getInvalidatingMethods(StringRef ContainerName) {
                                                   // Assignment
                                                   "swap"};
 
-  static const llvm::StringSet<> Associative = {// Removal
-                                                "clear",
-                                                // Assignment
-                                                "swap"};
-
-  // For unordered associative containers, `try_emplace` and `insert_or_assign`
-  // only exist on `unordered_map`. Listing them here is harmless since the
-  // methods won't be found on other types.
-  static const llvm::StringSet<> UnorderedAssociative = {
-      // Insertion
-      "insert", "emplace", "emplace_hint", "try_emplace", "insert_or_assign",
-      "insert_range", "merge",
-      // Removal
-      "clear",
-      // Hash policy
-      "rehash", "reserve",
-      // Assignment
-      "swap"};
+  // `erase` and `extract` are excluded: they only affect the removed element,
+  // not to other elements.
+  // https://en.cppreference.com/w/cpp/container/map/erase.html
+  // https://en.cppreference.com/w/cpp/container/map/extract.html
+  static const llvm::StringSet<> NodeBased = {// Removal
+                                              "clear",
+                                              // Assignment
+                                              "swap"};
 
   // For `flat_*` container adaptors, `try_emplace` and `insert_or_assign`
   // only exist on `flat_map`. Listing them here is harmless since the methods
@@ -353,27 +345,20 @@ getInvalidatingMethods(StringRef ContainerName) {
                                          // Assignment
                                          "swap", "replace"};
 
-  return llvm::StringSwitch<const llvm::StringSet<> *>(ContainerName)
-      .Case("vector", &Vector)
-      .Case("basic_string", &String)
-      .Case("deque", &Deque)
-      .Case("priority_queue", &PriorityQueue)
-      .Cases({"set", "multiset", "map", "multimap"}, &Associative)
-      .Cases({"unordered_set", "unordered_multiset", "unordered_map",
-              "unordered_multimap"},
-             &UnorderedAssociative)
-      .Cases({"flat_map", "flat_set", "flat_multimap", "flat_multiset"}, &Flat)
-      .Default(nullptr);
-}
-
-bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
-  const CXXRecordDecl *RD = MD.getParent();
-  if (!isInStlNamespace(RD))
-    return false;
-
-  StringRef ContainerName = getName(*RD);
+  const StringRef ContainerName = getName(*RD);
   const llvm::StringSet<> *InvalidatingMethods =
-      getInvalidatingMethods(ContainerName);
+      llvm::StringSwitch<const llvm::StringSet<> *>(ContainerName)
+          .Case("vector", &Vector)
+          .Case("basic_string", &String)
+          .Case("deque", &Deque)
+          .Case("priority_queue", &PriorityQueue)
+          .Cases({"set", "multiset", "map", "multimap", "unordered_set",
+                  "unordered_multiset", "unordered_map", "unordered_multimap"},
+                 &NodeBased)
+          .Cases({"flat_map", "flat_set", "flat_multimap", "flat_multiset"},
+                 &Flat)
+          .Default(nullptr);
+
   if (!InvalidatingMethods)
     return false;
 
@@ -384,13 +369,12 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
     case OO_Equal:     // operator= : Always invalidates (Assignment)
     case OO_PlusEqual: // operator+= : Append (String/Vector)
       return true;
-    case OO_Subscript: // operator[] : Invalidation only for Maps
-                       // (Insert-or-access)
-    {
-      static const llvm::StringSet<> MapContainers = {"map", "unordered_map",
-                                                      "flat_map"};
-      return MapContainers.contains(ContainerName);
-    }
+    case OO_Subscript: // operator[] : Invalidation only for
+                       // `flat_map` (Insert-or-access).
+                       // `map` and `unordered_map` are excluded.
+      // https://en.cppreference.com/w/cpp/container/unordered_map.html#Iterator_invalidation
+      // https://en.cppreference.com/w/cpp/container/map/operator_at.html
+      return ContainerName == "flat_map";
     default:
       return false;
     }

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -339,7 +339,7 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
                                          // Removal
                                          "extract", "erase", "clear",
                                          // Assignment
-                                         "swap", "replace"};
+                                         "replace"};
 
   const StringRef ContainerName = getName(*RD);
   const llvm::StringSet<> *InvalidatingMethods =

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -289,7 +289,7 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
                                            // Memory management
                                            "reserve", "resize", "shrink_to_fit",
                                            // Assignment
-                                           "swap", "assign", "assign_range"};
+                                           "assign", "assign_range"};
 
   // `pop_*` methods are excluded: they only invalidate references to the
   // removed element, not to other elements.
@@ -301,7 +301,7 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
                                           // Memory management
                                           "resize", "shrink_to_fit",
                                           // Assignment
-                                          "swap", "assign", "assign_range"};
+                                          "assign", "assign_range"};
 
   static const llvm::StringSet<> String = {
       // Insertion
@@ -320,18 +320,14 @@ bool isContainerInvalidationMethod(const CXXMethodDecl &MD) {
                                                   "push", "emplace",
                                                   "push_range",
                                                   // Removal
-                                                  "pop",
-                                                  // Assignment
-                                                  "swap"};
+                                                  "pop"};
 
   // `erase` and `extract` are excluded: they only affect the removed element,
   // not to other elements.
   // https://en.cppreference.com/w/cpp/container/map/erase.html
   // https://en.cppreference.com/w/cpp/container/map/extract.html
   static const llvm::StringSet<> NodeBased = {// Removal
-                                              "clear",
-                                              // Assignment
-                                              "swap"};
+                                              "clear"};
 
   // For `flat_*` container adaptors, `try_emplace` and `insert_or_assign`
   // only exist on `flat_map`. Listing them here is harmless since the methods

--- a/clang/test/Sema/Inputs/lifetime-analysis.h
+++ b/clang/test/Sema/Inputs/lifetime-analysis.h
@@ -104,6 +104,48 @@ struct unordered_map {
   iterator erase(iterator);
 };
 
+template<class Key>
+struct set {
+  using iterator = __gnu_cxx::basic_iterator<const Key>;
+  iterator begin();
+  iterator end();
+  void insert(const Key& key);
+  iterator erase(iterator);
+  void extract(iterator);
+  void clear();
+};
+
+template<class Key>
+struct multiset {
+  using iterator = __gnu_cxx::basic_iterator<const Key>;
+  iterator begin();
+  iterator end();
+  void insert(const Key& key);
+  void clear();
+};
+
+template<class Key, class T>
+struct map {
+  using iterator = __gnu_cxx::basic_iterator<std::pair<const Key, T>>;
+  T& operator[](const Key& key);
+  iterator begin();
+  iterator end();
+  void insert(const std::pair<const Key, T>& value);
+  template<class... Args>
+  void emplace(Args&&... args);
+  iterator erase(iterator);
+  void clear();
+};
+
+template<class Key, class T>
+struct multimap {
+  using iterator = __gnu_cxx::basic_iterator<std::pair<const Key, T>>;
+  iterator begin();
+  iterator end();
+  void insert(const std::pair<const Key, T>& value);
+  void clear();
+};
+
 template<typename T>
 struct basic_string_view {
   basic_string_view();

--- a/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
+++ b/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
@@ -831,23 +831,6 @@ void test13() {
 
 } // namespace GH100526
 
-namespace std {
-template <typename T>
-class __set_iterator {};
-
-template<typename T>
-struct BB {
-  typedef  __set_iterator<T> iterator;
-};
-
-template <typename T>
-class set {
-public:
-  ~set();
-  typedef typename BB<T>::iterator iterator;
-  iterator begin() const;
-};
-} // namespace std
 namespace GH118064{
 
 void test() {

--- a/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
@@ -374,3 +374,78 @@ void ChangingRegionOwnedByContainerIsOk() {
 }
 
 } // namespace ContainersAsFields
+
+namespace AssociativeContainers {
+void SetInsertDoesNotInvalidate() {
+  std::set<int> s;
+  s.insert(0);
+  auto it = s.begin();
+  s.insert(2);
+  *it;
+}
+
+void MapInsertDoesNotInvalidate() {
+  std::map<int, int> m;
+  auto it = m.begin();
+  m.insert({1, 2});
+  *it;
+}
+
+void MapEmplaceDoesNotInvalidate() {
+  std::map<int, int> m;
+  auto it = m.begin();
+  m.emplace(1, 2);
+  *it;
+}
+
+void MultisetInsertDoesNotInvalidate() {
+  std::multiset<int> s;
+  auto it = s.begin();
+  s.insert(1);
+  *it;
+}
+
+void MultimapInsertDoesNotInvalidate() {
+  std::multimap<int, int> m;
+  auto it = m.begin();
+  m.insert({1, 2});
+  *it;
+}
+
+void SetEraseDoesNotInvalidateOthers() {
+  std::set<int> s;
+  s.insert(1);
+  s.insert(2);
+  auto it1 = s.begin();
+  auto it2 = it1;
+  ++it2;
+  s.erase(it2);
+  *it1;
+}
+
+void SetExtractDoesNotInvalidateOthers() {
+  std::set<int> s;
+  s.insert(1);
+  s.insert(2);
+  auto it1 = s.begin();
+  auto it2 = it1;
+  ++it2;
+  s.extract(it2);
+  *it1;
+}
+
+void SetClearInvalidates() {
+  std::set<int> s;
+  auto it = s.begin(); // expected-warning {{object whose reference is captured is later invalidated}}
+  s.clear(); // expected-note {{invalidated here}}
+  *it; // expected-note {{later used here}}
+}
+
+void MapClearInvalidates() {
+  std::map<int, int> m;
+  auto it = m.begin();  // expected-warning {{object whose reference is captured is later invalidated}}
+  m.clear(); // expected-note {{invalidated here}}
+  *it; // expected-note {{later used here}}
+}
+
+} // namespace AssociativeContainers

--- a/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
@@ -455,4 +455,16 @@ void MapSubscriptDoesNotInvalidate() {
   *it;
 }
 
+void PrintMax(const int& a, const int& b);
+
+void MapSubscriptMultipleCallsDoesNotInvalidate(std::map<int, int> mp, int a, int b) {
+    PrintMax(mp[a], mp[b]);
+}
+
+void FlatMapSubscriptMultipleCallsInvalidate(std::flat_map<int, int> mp, int a, int b) {
+    PrintMax(mp[a], mp[b]); // expected-warning {{object whose reference is captured is later invalidated}} \
+                                 // expected-note {{invalidated here}} \
+                                 // expected-note {{later used here}}
+}
+
 } // namespace AssociativeContainers

--- a/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
@@ -164,12 +164,12 @@ void IteratorInvalidationInAForeachLoop(std::vector<int> v) {
 }  // namespace InvalidationInLoops
 
 namespace StdVectorPopBack {
-void StdVectorPopBackInvalid(std::vector<int> v) {
-  auto it = v.begin();  // expected-warning {{object whose reference is captured is later invalidated}}
+void StdVectorPopBackDoesNotInvalidateOthers(std::vector<int> v) {
+  auto it = v.begin();
   if (it == v.end()) return;
-  *it;  // ok
-  v.pop_back(); // expected-note {{invalidated here}}
-  *it;          // expected-note {{later used here}}
+  *it;
+  v.pop_back();
+  *it;
 }
 }  // namespace StdVectorPopBack
 
@@ -446,6 +446,13 @@ void MapClearInvalidates() {
   auto it = m.begin();  // expected-warning {{object whose reference is captured is later invalidated}}
   m.clear(); // expected-note {{invalidated here}}
   *it; // expected-note {{later used here}}
+}
+
+void MapSubscriptDoesNotInvalidate() {
+  std::map<int, int> m;
+  auto it = m.begin();
+  m[1];
+  *it;
 }
 
 } // namespace AssociativeContainers


### PR DESCRIPTION
- Refactor `isContainerInvalidationMethod()` to per-container invalidation sets, based on https://en.cppreference.com/w/cpp/container#Iterator_invalidation.
- Follow reference invalidation rules instead of iterator invalidation rules. Specifically:
   - Methods that only invalidate iterators but not references are excluded (e.g. `deque::push_back`, `unordered_map::emplace`).
   - Methods that only invalidate references to the removed element itself are excluded (e.g. `vector::pop_back`, `deque::pop_*`, and `erase`/`extract` on all node-based containers).
- Fix false positives for `insert`/`emplace` etc on ordered associative containers (`set`, `map`, `multiset`, `multimap`), which never invalidate iterators per the standard.
- Add previously missing methods: `emplace_hint`, `insert_or_assign`, `push_range`, `replace_with_range`, `resize_and_overwrite`, `merge`.
- `operator[]` now only invalidates for `flat_map`. `map::operator[]` and `unordered_map::operator[]` may insert but don't invalidate references.

Fixes #181912