### PR TITLE
[MC] Fix crash in x=0; .section x

### DIFF
--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -444,8 +444,12 @@ Symbol *MCContext::getOrCreateSectionSymbol(StringRef Section) {
   auto &SymEntry = getSymbolTableEntry(Section);
   MCSymbol *Sym = SymEntry.second.Symbol;
   if (Sym && Sym->isDefined() &&
-      (!Sym->isInSection() || Sym->getSection().getBeginSymbol() != Sym))
+      (!Sym->isInSection() || Sym->getSection().getBeginSymbol() != Sym)) {
     reportError(SMLoc(), "invalid symbol redefinition");
+    // Don't reuse the conflicting symbol (e.g. an equated symbol from `x=0`)
+    // as a section symbol, which would cause a crash in changeSection.
+    Sym = nullptr;
+  }
   // Use the symbol's index to track if it has been used as a section symbol.
   // Set to -1 to catch potential bugs if misused as a symbol index.
   if (Sym && Sym->getIndex() != -1u) {

--- a/llvm/test/MC/ELF/section-sym-err.s
+++ b/llvm/test/MC/ELF/section-sym-err.s
@@ -1,4 +1,4 @@
-# RUN: not llvm-mc -filetype=obj -triple x86_64 %s -o %t 2>&1 | FileCheck %s
+# RUN: not llvm-mc -filetype=obj -triple x86_64 %s -o %t 2>&1 | FileCheck %s --implicit-check-not=error:
 
 .section foo
 foo:
@@ -7,3 +7,10 @@ foo:
 x1:
 .section x1
 # CHECK: <unknown>:0: error: invalid symbol redefinition
+
+## Equated symbol followed by .section should report an error, not crash.
+x2 = 0
+.section x2
+# CHECK: <unknown>:0: error: invalid symbol redefinition
+x2 = 0
+# CHECK: [[#@LINE-1]]:6: error: redefinition of 'x2'


### PR DESCRIPTION
When an equated symbol (e.g. `x=0`) is followed by `.section x`,
getOrCreateSectionSymbol reports an "invalid symbol redefinition"
error but continues to reuse the equated symbol as a section symbol.
This causes an assertion failure in MCObjectStreamer::changeSection
when `setFragment` is called on the equated symbol.

Fix this by clearning `Sym`.