### PR TITLE
[Clang] Check the underlying type dependency in concept checking guards

### DIFF
--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -185,12 +185,13 @@ enum class TemplateSubstitutionKind : char {
       return !(*this)(Depth, Index).isNull();
     }
 
-    bool isAnyArgInstantiationDependent() const {
+    bool isAnyArgInstantiationDependent(const ASTContext &C) const {
       for (ArgumentListLevel ListLevel : TemplateArgumentLists)
         for (const TemplateArgument &TA : ListLevel.Args)
           // There might be null template arguments representing unused template
           // parameter mappings in an MLTAL during concept checking.
-          if (!TA.isNull() && TA.isInstantiationDependent())
+          if (!TA.isNull() &&
+              C.getCanonicalTemplateArgument(TA).isInstantiationDependent())
             return true;
       return false;
     }

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1154,7 +1154,7 @@ static bool CheckConstraintSatisfaction(
     return false;
   }
 
-  if (TemplateArgsLists.isAnyArgInstantiationDependent()) {
+  if (TemplateArgsLists.isAnyArgInstantiationDependent(S.Context)) {
     // No need to check satisfaction for dependent constraint expressions.
     Satisfaction.IsSatisfied = true;
     return false;

--- a/clang/test/AST/ByteCode/libcxx/end-primitive-array-root-lifetime.cpp
+++ b/clang/test/AST/ByteCode/libcxx/end-primitive-array-root-lifetime.cpp
@@ -15,7 +15,7 @@ concept range = requires { end; };
 template <class _Tp>
 concept input_range = input_iterator<_Tp>;
 template <class>
-concept forward_range = false;
+concept forward_range = true;
 template <range _Rp> struct owning_view {
   _Rp __r_;
 };

--- a/clang/test/SemaTemplate/concepts.cpp
+++ b/clang/test/SemaTemplate/concepts.cpp
@@ -1704,6 +1704,27 @@ struct ice_point : relative_point_origin<point<kelvin>> {};
 
 }
 
+namespace GH182344 {
+
+template <typename T>
+  requires true
+void f() {}
+
+template <typename T>
+  requires false
+void f() = delete;
+
+template <typename T>
+struct Bar {};
+
+template <typename T> using Foo = Bar<T>;
+
+template <typename T> void use() {
+  f<Foo<T>>();
+}
+
+}
+
 namespace GH174667 {
 
 template<class T, class, class U>


### PR DESCRIPTION
In the concept parameter mapping patch, we partially preserved sugar for concept checking. However, in dependent contexts there may be non-dependent aliases that still require concept checking to filter out unwanted functions.

No release note because of being a regression.

Fixes https://github.com/llvm/llvm-project/issues/182344