### PR TITLE
Support unnamed functions in MIR parser

### DIFF
--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -54,8 +54,8 @@ class MIRParserImpl {
   yaml::Input In;
   StringRef Filename;
   SlotMapping IRSlots;
-  std::optional<unsigned> UnnamedFunctionID;
   std::unique_ptr<PerTargetMIParsingState> Target;
+  Module::iterator UnusedUnnamedFunction;
 
   /// True when the MIR file doesn't have LLVM IR. Dummy IR functions are
   /// created and inserted into the given module when this is true.
@@ -196,9 +196,9 @@ private:
   bool parseMachineInst(MachineFunction &MF, yaml::MachineInstrLoc MILoc,
                         MachineInstr const *&MI);
 
-  std::optional<unsigned> getFirstUnnamedFunctionID();
+  Module::iterator getFirstUnnamedFunction(Module &M);
 
-  std::optional<unsigned> getNextUnnamedFunctionID();
+  Module::iterator getNextUnnamedFunction(Module &M);
 };
 
 } // end namespace llvm
@@ -255,16 +255,6 @@ void MIRParserImpl::reportDiagnostic(const SMDiagnostic &Diag) {
   Context.diagnose(DiagnosticInfoMIRParser(Kind, Diag));
 }
 
-std::optional<unsigned> MIRParserImpl::getFirstUnnamedFunctionID() {
-  for (unsigned ID = 0; ID < IRSlots.GlobalValues.getNext(); ++ID) {
-    auto *GV = IRSlots.GlobalValues.get(ID);
-    if (GV && GV->getValueType()->isFunctionTy())
-      return ID;
-  }
-
-  return std::nullopt;
-}
-
 std::unique_ptr<Module>
 MIRParserImpl::parseIRModule(DataLayoutCallbackTy DataLayoutCallback) {
   if (!In.setCurrentDocument()) {
@@ -291,7 +281,6 @@ MIRParserImpl::parseIRModule(DataLayoutCallbackTy DataLayoutCallback) {
       reportDiagnostic(diagFromBlockStringDiag(Error, BSN->getSourceRange()));
       return nullptr;
     }
-    UnnamedFunctionID = getFirstUnnamedFunctionID();
     In.nextDocument();
     if (!In.setCurrentDocument())
       NoMIRDocuments = true;
@@ -306,11 +295,20 @@ MIRParserImpl::parseIRModule(DataLayoutCallbackTy DataLayoutCallback) {
   return M;
 }
 
+Module::iterator MIRParserImpl::getFirstUnnamedFunction(Module &M) {
+  for (auto F = M.begin(); F != M.end(); F++)
+    if (!F->hasName())
+      return F;
+
+  return M.end();
+}
+
 bool MIRParserImpl::parseMachineFunctions(Module &M, MachineModuleInfo &MMI,
                                           ModuleAnalysisManager *MAM) {
   if (NoMIRDocuments)
     return false;
 
+  UnusedUnnamedFunction = getFirstUnnamedFunction(M);
   // Parse the machine functions.
   do {
     if (parseMachineFunction(M, MMI, MAM))
@@ -335,18 +333,15 @@ Function *MIRParserImpl::createDummyFunction(StringRef Name, Module &M) {
   return F;
 }
 
-std::optional<unsigned> MIRParserImpl::getNextUnnamedFunctionID() {
-  if (!UnnamedFunctionID.has_value())
-    return std::nullopt;
+Module::iterator MIRParserImpl::getNextUnnamedFunction(Module &M) {
+  if (UnusedUnnamedFunction == M.end())
+    return UnusedUnnamedFunction;
 
-  for (unsigned ID = *UnnamedFunctionID + 1;
-       ID < IRSlots.GlobalValues.getNext(); ++ID) {
-    auto *GV = IRSlots.GlobalValues.get(ID);
-    if (GV && GV->getValueType()->isFunctionTy())
-      return ID;
-  }
+  for (auto F = ++UnusedUnnamedFunction; F != M.end(); F++)
+    if (!F->hasName())
+      return F;
 
-  return std::nullopt;
+  return M.end();
 }
 
 bool MIRParserImpl::parseMachineFunction(Module &M, MachineModuleInfo &MMI,
@@ -369,9 +364,9 @@ bool MIRParserImpl::parseMachineFunction(Module &M, MachineModuleInfo &MMI,
   if (!F) {
     if (NoLLVMIR) {
       F = createDummyFunction(FunctionName, M);
-    } else if (FunctionName.empty() && UnnamedFunctionID.has_value()) {
-      F = static_cast<Function *>(IRSlots.GlobalValues.get(*UnnamedFunctionID));
-      UnnamedFunctionID = getNextUnnamedFunctionID();
+    } else if (FunctionName.empty() && UnusedUnnamedFunction != M.end()) {
+      F = static_cast<Function *>(&*UnusedUnnamedFunction);
+      UnusedUnnamedFunction = getNextUnnamedFunction(M);
     } else {
       return error(Twine("function '") + FunctionName +
                    "' isn't defined in the provided LLVM IR");

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -55,7 +55,6 @@ class MIRParserImpl {
   StringRef Filename;
   SlotMapping IRSlots;
   std::unique_ptr<PerTargetMIParsingState> Target;
-  Module::iterator FirstUnvisitedFunction;
 
   /// True when the MIR file doesn't have LLVM IR. Dummy IR functions are
   /// created and inserted into the given module when this is true.
@@ -107,7 +106,8 @@ public:
   ///
   /// Return true if an error occurred.
   bool parseMachineFunction(Module &M, MachineModuleInfo &MMI,
-                            ModuleAnalysisManager *FAM);
+                            ModuleAnalysisManager *FAM,
+                            Module::iterator &FirstUnvisitedFunction);
 
   /// Initialize the machine function to the state that's described in the MIR
   /// file.
@@ -196,7 +196,9 @@ private:
   bool parseMachineInst(MachineFunction &MF, yaml::MachineInstrLoc MILoc,
                         MachineInstr const *&MI);
 
-  Function *getNextUnusedUnnamedFunction(Module &M);
+  static Function *
+  getNextUnusedUnnamedFunction(Module &M,
+                               Module::iterator &FirstUnvisitedFunction);
 };
 
 } // end namespace llvm
@@ -299,9 +301,9 @@ bool MIRParserImpl::parseMachineFunctions(Module &M, MachineModuleInfo &MMI,
     return false;
 
   // Parse the machine functions.
-  FirstUnvisitedFunction = M.begin();
+  auto FirstUnvisitedFunction = M.begin();
   do {
-    if (parseMachineFunction(M, MMI, MAM))
+    if (parseMachineFunction(M, MMI, MAM, FirstUnvisitedFunction))
       return true;
     In.nextDocument();
   } while (In.setCurrentDocument());
@@ -323,7 +325,8 @@ Function *MIRParserImpl::createDummyFunction(StringRef Name, Module &M) {
   return F;
 }
 
-Function *MIRParserImpl::getNextUnusedUnnamedFunction(Module &M) {
+Function *MIRParserImpl::getNextUnusedUnnamedFunction(
+    Module &M, Module::iterator &FirstUnvisitedFunction) {
   for (; FirstUnvisitedFunction != M.end(); ++FirstUnvisitedFunction)
     if (!FirstUnvisitedFunction->hasName()) {
       auto *F = &*FirstUnvisitedFunction;
@@ -334,8 +337,9 @@ Function *MIRParserImpl::getNextUnusedUnnamedFunction(Module &M) {
   return nullptr;
 }
 
-bool MIRParserImpl::parseMachineFunction(Module &M, MachineModuleInfo &MMI,
-                                         ModuleAnalysisManager *MAM) {
+bool MIRParserImpl::parseMachineFunction(
+    Module &M, MachineModuleInfo &MMI, ModuleAnalysisManager *MAM,
+    Module::iterator &FirstUnvisitedFunction) {
   // Parse the yaml.
   yaml::MachineFunction YamlMF;
   yaml::EmptyContext Ctx;
@@ -355,7 +359,7 @@ bool MIRParserImpl::parseMachineFunction(Module &M, MachineModuleInfo &MMI,
     if (NoLLVMIR) {
       F = createDummyFunction(FunctionName, M);
     } else if (!FunctionName.empty() ||
-               !(F = getNextUnusedUnnamedFunction(M))) {
+               !(F = getNextUnusedUnnamedFunction(M, FirstUnvisitedFunction))) {
       return error(Twine("function '") + FunctionName +
                    "' isn't defined in the provided LLVM IR");
     }

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -55,7 +55,7 @@ class MIRParserImpl {
   StringRef Filename;
   SlotMapping IRSlots;
   std::unique_ptr<PerTargetMIParsingState> Target;
-  Module::iterator UnusedUnnamedFunction;
+  Module::iterator FirstUnvisitedFunction;
 
   /// True when the MIR file doesn't have LLVM IR. Dummy IR functions are
   /// created and inserted into the given module when this is true.
@@ -196,9 +196,7 @@ private:
   bool parseMachineInst(MachineFunction &MF, yaml::MachineInstrLoc MILoc,
                         MachineInstr const *&MI);
 
-  Module::iterator getFirstUnnamedFunction(Module &M);
-
-  Module::iterator getNextUnnamedFunction(Module &M);
+  Function *getNextUnusedUnnamedFunction(Module &M);
 };
 
 } // end namespace llvm
@@ -295,21 +293,13 @@ MIRParserImpl::parseIRModule(DataLayoutCallbackTy DataLayoutCallback) {
   return M;
 }
 
-Module::iterator MIRParserImpl::getFirstUnnamedFunction(Module &M) {
-  for (auto F = M.begin(); F != M.end(); F++)
-    if (!F->hasName())
-      return F;
-
-  return M.end();
-}
-
 bool MIRParserImpl::parseMachineFunctions(Module &M, MachineModuleInfo &MMI,
                                           ModuleAnalysisManager *MAM) {
   if (NoMIRDocuments)
     return false;
 
-  UnusedUnnamedFunction = getFirstUnnamedFunction(M);
   // Parse the machine functions.
+  FirstUnvisitedFunction = M.begin();
   do {
     if (parseMachineFunction(M, MMI, MAM))
       return true;
@@ -333,15 +323,15 @@ Function *MIRParserImpl::createDummyFunction(StringRef Name, Module &M) {
   return F;
 }
 
-Module::iterator MIRParserImpl::getNextUnnamedFunction(Module &M) {
-  if (UnusedUnnamedFunction == M.end())
-    return UnusedUnnamedFunction;
-
-  for (auto F = ++UnusedUnnamedFunction; F != M.end(); F++)
-    if (!F->hasName())
+Function *MIRParserImpl::getNextUnusedUnnamedFunction(Module &M) {
+  for (; FirstUnvisitedFunction != M.end(); ++FirstUnvisitedFunction)
+    if (!FirstUnvisitedFunction->hasName()) {
+      auto *F = static_cast<Function *>(&*FirstUnvisitedFunction);
+      ++FirstUnvisitedFunction;
       return F;
+    }
 
-  return M.end();
+  return nullptr;
 }
 
 bool MIRParserImpl::parseMachineFunction(Module &M, MachineModuleInfo &MMI,
@@ -364,10 +354,8 @@ bool MIRParserImpl::parseMachineFunction(Module &M, MachineModuleInfo &MMI,
   if (!F) {
     if (NoLLVMIR) {
       F = createDummyFunction(FunctionName, M);
-    } else if (FunctionName.empty() && UnusedUnnamedFunction != M.end()) {
-      F = static_cast<Function *>(&*UnusedUnnamedFunction);
-      UnusedUnnamedFunction = getNextUnnamedFunction(M);
-    } else {
+    } else if (!FunctionName.empty() ||
+               !(F = getNextUnusedUnnamedFunction(M))) {
       return error(Twine("function '") + FunctionName +
                    "' isn't defined in the provided LLVM IR");
     }

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -197,7 +197,7 @@ private:
                         MachineInstr const *&MI);
 
   static Function *
-  getNextUnusedUnnamedFunction(Module &M,
+  getNextUnusedUnnamedFunction(const Module &M,
                                Module::iterator &FirstUnvisitedFunction);
 };
 
@@ -326,7 +326,7 @@ Function *MIRParserImpl::createDummyFunction(StringRef Name, Module &M) {
 }
 
 Function *MIRParserImpl::getNextUnusedUnnamedFunction(
-    Module &M, Module::iterator &FirstUnvisitedFunction) {
+    const Module &M, Module::iterator &FirstUnvisitedFunction) {
   for (; FirstUnvisitedFunction != M.end(); ++FirstUnvisitedFunction)
     if (!FirstUnvisitedFunction->hasName()) {
       auto *F = &*FirstUnvisitedFunction;

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -195,10 +195,6 @@ private:
 
   bool parseMachineInst(MachineFunction &MF, yaml::MachineInstrLoc MILoc,
                         MachineInstr const *&MI);
-
-  static Function *
-  getNextUnusedUnnamedFunction(const Module &M,
-                               Module::iterator &FirstUnvisitedFunction);
 };
 
 } // end namespace llvm
@@ -325,8 +321,9 @@ Function *MIRParserImpl::createDummyFunction(StringRef Name, Module &M) {
   return F;
 }
 
-Function *MIRParserImpl::getNextUnusedUnnamedFunction(
-    const Module &M, Module::iterator &FirstUnvisitedFunction) {
+static Function *
+getNextUnusedUnnamedFunction(const Module &M,
+                             Module::iterator &FirstUnvisitedFunction) {
   for (; FirstUnvisitedFunction != M.end(); ++FirstUnvisitedFunction)
     if (!FirstUnvisitedFunction->hasName()) {
       auto *F = &*FirstUnvisitedFunction;

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -326,7 +326,7 @@ Function *MIRParserImpl::createDummyFunction(StringRef Name, Module &M) {
 Function *MIRParserImpl::getNextUnusedUnnamedFunction(Module &M) {
   for (; FirstUnvisitedFunction != M.end(); ++FirstUnvisitedFunction)
     if (!FirstUnvisitedFunction->hasName()) {
-      auto *F = static_cast<Function *>(&*FirstUnvisitedFunction);
+      auto *F = &*FirstUnvisitedFunction;
       ++FirstUnvisitedFunction;
       return F;
     }

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -325,11 +325,8 @@ static Function *
 getNextUnusedUnnamedFunction(const Module &M,
                              Module::iterator &FirstUnvisitedFunction) {
   for (; FirstUnvisitedFunction != M.end(); ++FirstUnvisitedFunction)
-    if (!FirstUnvisitedFunction->hasName()) {
-      auto *F = &*FirstUnvisitedFunction;
-      ++FirstUnvisitedFunction;
-      return F;
-    }
+    if (!FirstUnvisitedFunction->hasName())
+      return &*FirstUnvisitedFunction++;
 
   return nullptr;
 }

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -54,6 +54,7 @@ class MIRParserImpl {
   yaml::Input In;
   StringRef Filename;
   SlotMapping IRSlots;
+  std::optional<unsigned> UnnamedFunctionID;
   std::unique_ptr<PerTargetMIParsingState> Target;
 
   /// True when the MIR file doesn't have LLVM IR. Dummy IR functions are
@@ -194,6 +195,10 @@ private:
 
   bool parseMachineInst(MachineFunction &MF, yaml::MachineInstrLoc MILoc,
                         MachineInstr const *&MI);
+
+  std::optional<unsigned> getFirstUnnamedFunctionID();
+
+  std::optional<unsigned> getNextUnnamedFunctionID();
 };
 
 } // end namespace llvm
@@ -250,6 +255,16 @@ void MIRParserImpl::reportDiagnostic(const SMDiagnostic &Diag) {
   Context.diagnose(DiagnosticInfoMIRParser(Kind, Diag));
 }
 
+std::optional<unsigned> MIRParserImpl::getFirstUnnamedFunctionID() {
+  for (unsigned ID = 0; ID < IRSlots.GlobalValues.getNext(); ++ID) {
+    auto *GV = IRSlots.GlobalValues.get(ID);
+    if (GV && GV->getValueType()->isFunctionTy())
+      return ID;
+  }
+
+  return std::nullopt;
+}
+
 std::unique_ptr<Module>
 MIRParserImpl::parseIRModule(DataLayoutCallbackTy DataLayoutCallback) {
   if (!In.setCurrentDocument()) {
@@ -276,6 +291,7 @@ MIRParserImpl::parseIRModule(DataLayoutCallbackTy DataLayoutCallback) {
       reportDiagnostic(diagFromBlockStringDiag(Error, BSN->getSourceRange()));
       return nullptr;
     }
+    UnnamedFunctionID = getFirstUnnamedFunctionID();
     In.nextDocument();
     if (!In.setCurrentDocument())
       NoMIRDocuments = true;
@@ -319,6 +335,20 @@ Function *MIRParserImpl::createDummyFunction(StringRef Name, Module &M) {
   return F;
 }
 
+std::optional<unsigned> MIRParserImpl::getNextUnnamedFunctionID() {
+  if (!UnnamedFunctionID.has_value())
+    return std::nullopt;
+
+  for (unsigned ID = *UnnamedFunctionID + 1;
+       ID < IRSlots.GlobalValues.getNext(); ++ID) {
+    auto *GV = IRSlots.GlobalValues.get(ID);
+    if (GV && GV->getValueType()->isFunctionTy())
+      return ID;
+  }
+
+  return std::nullopt;
+}
+
 bool MIRParserImpl::parseMachineFunction(Module &M, MachineModuleInfo &MMI,
                                          ModuleAnalysisManager *MAM) {
   // Parse the yaml.
@@ -339,6 +369,9 @@ bool MIRParserImpl::parseMachineFunction(Module &M, MachineModuleInfo &MMI,
   if (!F) {
     if (NoLLVMIR) {
       F = createDummyFunction(FunctionName, M);
+    } else if (FunctionName.empty() && UnnamedFunctionID.has_value()) {
+      F = static_cast<Function *>(IRSlots.GlobalValues.get(*UnnamedFunctionID));
+      UnnamedFunctionID = getNextUnnamedFunctionID();
     } else {
       return error(Twine("function '") + FunctionName +
                    "' isn't defined in the provided LLVM IR");

--- a/llvm/test/CodeGen/MIR/Generic/machine-function-empty-name-no-ir-section.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-function-empty-name-no-ir-section.mir
@@ -1,0 +1,8 @@
+# RUN: llc -run-pass=none -o - %s | FileCheck %s
+# This test ensures that the MIR parser is able to parse unnamed functions when
+# the LLVM IR module is not embedded.
+---
+# CHECK: name: ''
+name: ''
+...
+

--- a/llvm/test/CodeGen/MIR/Generic/machine-function-empty-name-no-ir.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-function-empty-name-no-ir.mir
@@ -1,0 +1,15 @@
+# RUN: not llc -run-pass none -o /dev/null %s 2>&1 | FileCheck %s
+# This test ensures that the MIR parser fails if there are more machine
+# functions with empty names than there unnamed functions in the embedded LLVM
+# IR.
+--- |
+  define void @0() {
+    ret void
+  }
+...
+---
+name: ''
+---
+# CHECK: function '' isn't defined in the provided LLVM IR
+name: ''
+...

--- a/llvm/test/CodeGen/MIR/Generic/machine-function-empty-name-no-matching-ir.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-function-empty-name-no-matching-ir.mir
@@ -1,10 +1,14 @@
-# RUN: not llc -run-pass none -o /dev/null %s 2>&1 | FileCheck %s
+# RUN: not llc -run-pass=none -filetype=null %s 2>&1 | FileCheck %s
 # This test ensures that the MIR parser fails if there are more machine
 # functions with empty names than there unnamed functions in the embedded LLVM
 # IR.
 --- |
   define void @0() {
     ret void
+  }
+
+  define void @foo() {
+    ret void 
   }
 ...
 ---

--- a/llvm/test/CodeGen/MIR/Generic/machine-function-empty-name.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-function-empty-name.mir
@@ -1,0 +1,22 @@
+# RUN: llc -run-pass none -o - %s | FileCheck %s
+# This test ensures that the MIR parser accepts files with unnamed functions.
+--- |
+  ; CHECK: define void @0
+  define void @0() {
+  ; CHECK: ret void
+    ret void
+  }
+  
+  ; CHECK: define i32 @1
+  define i32 @1() {
+  ; CHECK: ret i32 0
+    ret i32 0 
+  }
+...
+---
+# CHECK: name: ''
+name: ''
+---
+# CHECK: name: '' 
+name: ''
+...

--- a/llvm/test/CodeGen/MIR/Generic/machine-function-empty-name.mir
+++ b/llvm/test/CodeGen/MIR/Generic/machine-function-empty-name.mir
@@ -1,10 +1,16 @@
-# RUN: llc -run-pass none -o - %s | FileCheck %s
+# RUN: llc -run-pass=none -o - %s | FileCheck %s
 # This test ensures that the MIR parser accepts files with unnamed functions.
 --- |
   ; CHECK: define void @0
   define void @0() {
   ; CHECK: ret void
     ret void
+  }
+
+  ; CHECK: define void @foo
+  define void @foo() {
+  ; CHECK: ret void 
+    ret void 
   }
   
   ; CHECK: define i32 @1
@@ -16,6 +22,9 @@
 ---
 # CHECK: name: ''
 name: ''
+---
+# CHECK: name: foo
+name: foo
 ---
 # CHECK: name: '' 
 name: ''


### PR DESCRIPTION
Closes #36511 

In this PR, unnamed machine functions in an MIR file are associated with anonymous functions in the embedded LLVM IR according to the order in which they are specified. If there are more unnamed machine functions then there are LLVM IR functions, the parsing will fail by reporting the original error message of `function ‘’ isn’t defined in the provided LLVM IR`.

New lit tests:
- CodeGen/MIR/Generic/machine-function-empty-name.mir
- CodeGen/MIR/Generic/machine-function-empty-name-no-maching-ir.mir
- CodeGen/MIR/Generic/machine-function-empty-name-no-ir-section.mir