### PR TITLE
[clang-tidy][NFC] Remove ad-hoc `unless(isExpansionInSystemHeader())` from matchers

### DIFF
--- a/clang-tools-extra/clang-tidy/abseil/UncheckedStatusOrAccessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/UncheckedStatusOrAccessCheck.cpp
@@ -29,10 +29,8 @@ void UncheckedStatusOrAccessCheck::registerMatchers(MatchFinder *Finder) {
   auto HasStatusOrCallDescendant =
       hasDescendant(callExpr(callee(cxxMethodDecl(ofClass(hasAnyName(
           "absl::StatusOr", "absl::internal_statusor::OperatorBase"))))));
-  Finder->addMatcher(functionDecl(unless(isExpansionInSystemHeader()),
-                                  hasBody(HasStatusOrCallDescendant))
-                         .bind(FuncID),
-                     this);
+  Finder->addMatcher(
+      functionDecl(hasBody(HasStatusOrCallDescendant)).bind(FuncID), this);
   Finder->addMatcher(
       cxxConstructorDecl(hasAnyConstructorInitializer(
                              withInitializer(HasStatusOrCallDescendant)))

--- a/clang-tools-extra/clang-tidy/altera/StructPackAlignCheck.cpp
+++ b/clang-tools-extra/clang-tidy/altera/StructPackAlignCheck.cpp
@@ -17,9 +17,7 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::altera {
 
 void StructPackAlignCheck::registerMatchers(MatchFinder *Finder) {
-  Finder->addMatcher(recordDecl(isStruct(), isDefinition(),
-                                unless(isExpansionInSystemHeader()))
-                         .bind("struct"),
+  Finder->addMatcher(recordDecl(isStruct(), isDefinition()).bind("struct"),
                      this);
 }
 

--- a/clang-tools-extra/clang-tidy/bugprone/EmptyCatchCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/EmptyCatchCheck.cpp
@@ -88,7 +88,7 @@ void EmptyCatchCheck::registerMatchers(MatchFinder *Finder) {
                      hasCanonicalType(AllowedNamedExceptionTypes)));
 
   Finder->addMatcher(
-      cxxCatchStmt(unless(isExpansionInSystemHeader()), unless(isInMacro()),
+      cxxCatchStmt(unless(isInMacro()),
                    unless(hasCaughtType(IgnoredExceptionType)),
                    hasHandler(compoundStmt(
                        statementCountIs(0),

--- a/clang-tools-extra/clang-tidy/bugprone/IncDecInConditionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/IncDecInConditionsCheck.cpp
@@ -41,8 +41,8 @@ void IncDecInConditionsCheck::registerMatchers(MatchFinder *Finder) {
 
   Finder->addMatcher(
       expr(
-          OperatorMatcher, unless(isExpansionInSystemHeader()),
-          unless(hasAncestor(OperatorMatcher)), expr().bind("parent"),
+          OperatorMatcher, unless(hasAncestor(OperatorMatcher)),
+          expr().bind("parent"),
 
           forEachDescendant(
               expr(anyOf(unaryOperator(isUnaryPrePostOperator(),

--- a/clang-tools-extra/clang-tidy/bugprone/IncorrectEnableSharedFromThisCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/IncorrectEnableSharedFromThisCheck.cpp
@@ -27,7 +27,6 @@ void IncorrectEnableSharedFromThisCheck::registerMatchers(MatchFinder *Finder) {
           .bind("base_rec")));
   Finder->addMatcher(
       cxxRecordDecl(
-          unless(isExpansionInSystemHeader()),
           hasDirectBase(cxxBaseSpecifier(unless(isPublic()), hasType(QType))
                             .bind("base")))
           .bind("derived"),

--- a/clang-tools-extra/clang-tidy/bugprone/NonZeroEnumToBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NonZeroEnumToBoolConversionCheck.cpp
@@ -53,8 +53,7 @@ void NonZeroEnumToBoolConversionCheck::registerMatchers(MatchFinder *Finder) {
       "|", "&", "^", "<<", ">>", "~", "|=", "&=", "^=", "<<=", ">>="));
 
   Finder->addMatcher(
-      castExpr(hasCastKind(CK_IntegralToBoolean),
-               unless(isExpansionInSystemHeader()), hasType(booleanType()),
+      castExpr(hasCastKind(CK_IntegralToBoolean), hasType(booleanType()),
                hasSourceExpression(
                    expr(hasType(qualType(hasCanonicalType(hasDeclaration(
                             enumDecl(isCompleteAndHasNoZeroValue(),

--- a/clang-tools-extra/clang-tidy/bugprone/StdNamespaceModificationCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/StdNamespaceModificationCheck.cpp
@@ -91,8 +91,7 @@ void StdNamespaceModificationCheck::registerMatchers(MatchFinder *Finder) {
 
   Finder->addMatcher(decl(anyOf(BadNonTemplateSpecializationDecl,
                                 BadClassTemplateSpec, BadInnerClassTemplateSpec,
-                                BadFunctionTemplateSpec, BadMemberFunctionSpec),
-                          unless(isExpansionInSystemHeader()))
+                                BadFunctionTemplateSpec, BadMemberFunctionSpec))
                          .bind("decl"),
                      this);
 }

--- a/clang-tools-extra/clang-tidy/bugprone/UncheckedOptionalAccessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UncheckedOptionalAccessCheck.cpp
@@ -30,11 +30,11 @@ void UncheckedOptionalAccessCheck::registerMatchers(MatchFinder *Finder) {
   auto HasOptionalCallDescendant = hasDescendant(callExpr(callee(cxxMethodDecl(
       ofClass(UncheckedOptionalAccessModel::optionalClassDecl())))));
   Finder->addMatcher(
-      decl(anyOf(functionDecl(unless(isExpansionInSystemHeader()),
-                              // FIXME: Remove the filter below when lambdas are
-                              // well supported by the check.
-                              unless(hasDeclContext(cxxRecordDecl(isLambda()))),
-                              hasBody(HasOptionalCallDescendant)),
+      decl(anyOf(functionDecl(
+                     // FIXME: Remove the filter below when lambdas are
+                     // well supported by the check.
+                     unless(hasDeclContext(cxxRecordDecl(isLambda()))),
+                     hasBody(HasOptionalCallDescendant)),
                  cxxConstructorDecl(hasAnyConstructorInitializer(
                      withInitializer(HasOptionalCallDescendant)))))
           .bind(FuncID),

--- a/clang-tools-extra/clang-tidy/google/FunctionNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/FunctionNamingCheck.cpp
@@ -82,16 +82,14 @@ static FixItHint generateFixItHint(const FunctionDecl *Decl) {
 
 void FunctionNamingCheck::registerMatchers(MatchFinder *Finder) {
   // Enforce Objective-C function naming conventions on all functions except:
-  // • Functions defined in system headers.
   // • C++ member functions.
   // • Namespaced functions.
   // • Implicitly defined functions.
   // • The main function.
   Finder->addMatcher(
       functionDecl(
-          unless(anyOf(isExpansionInSystemHeader(), cxxMethodDecl(),
-                       hasAncestor(namespaceDecl()), isMain(), isImplicit(),
-                       matchesName(validFunctionNameRegex(true)),
+          unless(anyOf(cxxMethodDecl(), hasAncestor(namespaceDecl()), isMain(),
+                       isImplicit(), matchesName(validFunctionNameRegex(true)),
                        allOf(isStaticStorageClass(),
                              matchesName(validFunctionNameRegex(false))))))
           .bind("function"),

--- a/clang-tools-extra/clang-tidy/llvm/PreferStaticOverAnonymousNamespaceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/PreferStaticOverAnonymousNamespaceCheck.cpp
@@ -52,8 +52,7 @@ void PreferStaticOverAnonymousNamespaceCheck::storeOptions(
 void PreferStaticOverAnonymousNamespaceCheck::registerMatchers(
     MatchFinder *Finder) {
   const auto IsDefinitionInAnonymousNamespace = allOf(
-      unless(isExpansionInSystemHeader()), isLexicallyInAnonymousNamespace(),
-      unless(isInMacro()), isDefinition());
+      isLexicallyInAnonymousNamespace(), unless(isInMacro()), isDefinition());
 
   if (AllowMemberFunctionsInClass) {
     Finder->addMatcher(

--- a/clang-tools-extra/clang-tidy/misc/OverrideWithDifferentVisibilityCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/OverrideWithDifferentVisibilityCheck.cpp
@@ -79,8 +79,7 @@ void OverrideWithDifferentVisibilityCheck::registerMatchers(
   Finder->addMatcher(
       cxxMethodDecl(
           isVirtual(), FilterDestructors, FilterOperators,
-          ofClass(
-              cxxRecordDecl(unless(isExpansionInSystemHeader())).bind("class")),
+          ofClass(cxxRecordDecl().bind("class")),
           forEachOverridden(cxxMethodDecl(ofClass(cxxRecordDecl().bind("base")),
                                           unless(IgnoredDecl))
                                 .bind("base_func")))

--- a/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
@@ -42,8 +42,6 @@ AST_MATCHER(FunctionDecl, hasOtherDeclarations) {
 void UseConstraintsCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       functionTemplateDecl(
-          // Skip external libraries included as system headers
-          unless(isExpansionInSystemHeader()),
           has(functionDecl(unless(hasOtherDeclarations()), isDefinition(),
                            hasReturnTypeLoc(typeLoc().bind("return")))
                   .bind("function")))

--- a/clang-tools-extra/clang-tidy/modernize/UseScopedLockCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseScopedLockCheck.cpp
@@ -137,7 +137,6 @@ void UseScopedLockCheck::registerMatchers(MatchFinder *Finder) {
   if (WarnOnSingleLocks) {
     Finder->addMatcher(
         compoundStmt(
-            unless(isExpansionInSystemHeader()),
             has(declStmt(has(LockVarDecl)).bind("lock-decl-single")),
             unless(has(declStmt(unless(equalsBoundNode("lock-decl-single")),
                                 has(LockVarDecl))))),
@@ -145,8 +144,7 @@ void UseScopedLockCheck::registerMatchers(MatchFinder *Finder) {
   }
 
   Finder->addMatcher(
-      compoundStmt(unless(isExpansionInSystemHeader()),
-                   has(declStmt(has(LockVarDecl)).bind("lock-decl-multiple")),
+      compoundStmt(has(declStmt(has(LockVarDecl)).bind("lock-decl-multiple")),
                    has(declStmt(unless(equalsBoundNode("lock-decl-multiple")),
                                 has(LockVarDecl))))
           .bind("block-multiple"),
@@ -154,22 +152,19 @@ void UseScopedLockCheck::registerMatchers(MatchFinder *Finder) {
 
   if (WarnOnUsingAndTypedef) {
     // Match 'typedef std::lock_guard<std::mutex> Lock'
-    Finder->addMatcher(typedefDecl(unless(isExpansionInSystemHeader()),
-                                   hasType(hasUnderlyingType(LockGuardType)))
+    Finder->addMatcher(typedefDecl(hasType(hasUnderlyingType(LockGuardType)))
                            .bind("lock-guard-typedef"),
                        this);
 
     // Match 'using Lock = std::lock_guard<std::mutex>'
-    Finder->addMatcher(typeAliasDecl(unless(isExpansionInSystemHeader()),
-                                     hasType(templateSpecializationType(
+    Finder->addMatcher(typeAliasDecl(hasType(templateSpecializationType(
                                          hasDeclaration(LockGuardClassDecl))))
                            .bind("lock-guard-using-alias"),
                        this);
 
     // Match 'using std::lock_guard'
     Finder->addMatcher(
-        usingDecl(unless(isExpansionInSystemHeader()),
-                  hasAnyUsingShadowDecl(hasTargetDecl(LockGuardClassDecl)))
+        usingDecl(hasAnyUsingShadowDecl(hasTargetDecl(LockGuardClassDecl)))
             .bind("lock-guard-using-decl"),
         this);
   }

--- a/clang-tools-extra/clang-tidy/performance/AvoidEndlCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/AvoidEndlCheck.cpp
@@ -22,7 +22,6 @@ namespace clang::tidy::performance {
 void AvoidEndlCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       callExpr(
-          unless(isExpansionInSystemHeader()),
           anyOf(cxxOperatorCallExpr(
                     hasOverloadedOperatorName("<<"),
                     hasRHS(declRefExpr(to(namedDecl(hasName("::std::endl"))))

--- a/clang-tools-extra/clang-tidy/performance/EnumSizeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/EnumSizeCheck.cpp
@@ -100,8 +100,7 @@ bool EnumSizeCheck::isLanguageVersionSupported(
 
 void EnumSizeCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
-      enumDecl(unless(isExpansionInSystemHeader()), isDefinition(),
-               hasEnumerators(), unless(isExternC()),
+      enumDecl(isDefinition(), hasEnumerators(), unless(isExternC()),
                unless(anyOf(
                    matchers::matchesAnyListedRegexName(EnumIgnoreList),
                    hasTypedefNameForAnonDecl(

--- a/clang-tools-extra/clang-tidy/portability/SIMDIntrinsicsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/portability/SIMDIntrinsicsCheck.cpp
@@ -91,8 +91,7 @@ void SIMDIntrinsicsCheck::registerMatchers(MatchFinder *Finder) {
 
   Finder->addMatcher(callExpr(callee(functionDecl(
                                   matchesName("^::(_mm_|_mm256_|_mm512_|vec_)"),
-                                  isVectorFunction())),
-                              unless(isExpansionInSystemHeader()))
+                                  isVectorFunction())))
                          .bind("call"),
                      this);
 }

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -74,7 +74,7 @@ void ContainerDataPointerCheck::registerMatchers(MatchFinder *Finder) {
 
   Finder->addMatcher(
       unaryOperator(
-          unless(isExpansionInSystemHeader()), hasOperatorName("&"),
+          hasOperatorName("&"),
           hasUnaryOperand(expr(
               anyOf(cxxOperatorCallExpr(SubscriptOperator, argumentCountIs(2),
                                         hasArgument(0, ContainerExpr),

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStaticCheck.cpp
@@ -84,9 +84,8 @@ void ConvertMemberFunctionsToStaticCheck::registerMatchers(
       cxxMethodDecl(
           isDefinition(), isUserProvided(),
           unless(anyOf(
-              isExpansionInSystemHeader(), isVirtual(), isStatic(),
-              hasTrivialBody(), isOverloadedOperator(), cxxConstructorDecl(),
-              cxxDestructorDecl(), cxxConversionDecl(),
+              isVirtual(), isStatic(), hasTrivialBody(), isOverloadedOperator(),
+              cxxConstructorDecl(), cxxDestructorDecl(), cxxConversionDecl(),
               isExplicitObjectMemberFunction(), isTemplate(),
               isDependentContext(),
               ofClass(anyOf(

--- a/clang-tools-extra/clang-tidy/readability/MakeMemberFunctionConstCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/MakeMemberFunctionConstCheck.cpp
@@ -224,9 +224,9 @@ void MakeMemberFunctionConstCheck::registerMatchers(MatchFinder *Finder) {
           cxxMethodDecl(
               isDefinition(), isUserProvided(),
               unless(anyOf(
-                  isExpansionInSystemHeader(), isVirtual(), isConst(),
-                  isStatic(), hasTrivialBody(), cxxConstructorDecl(),
-                  cxxDestructorDecl(), isTemplate(), isDependentContext(),
+                  isVirtual(), isConst(), isStatic(), hasTrivialBody(),
+                  cxxConstructorDecl(), cxxDestructorDecl(), isTemplate(),
+                  isDependentContext(),
                   ofClass(anyOf(isLambda(),
                                 hasAnyDependentBases()) // Method might become
                                                         // virtual depending on

--- a/clang-tools-extra/clang-tidy/readability/OperatorsRepresentationCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/OperatorsRepresentationCheck.cpp
@@ -177,7 +177,6 @@ void OperatorsRepresentationCheck::registerBinaryOperatorMatcher(
 
   Finder->addMatcher(
       binaryOperator(
-          unless(isExpansionInSystemHeader()),
           anyOf(hasInvalidBinaryOperatorRepresentation(
                     BO_LAnd, getRepresentation(BinaryOperators, "&&", "and")),
                 hasInvalidBinaryOperatorRepresentation(
@@ -210,7 +209,6 @@ void OperatorsRepresentationCheck::registerUnaryOperatorMatcher(
 
   Finder->addMatcher(
       unaryOperator(
-          unless(isExpansionInSystemHeader()),
           anyOf(hasInvalidUnaryOperatorRepresentation(
                     UO_LNot, getRepresentation(BinaryOperators, "!", "not")),
                 hasInvalidUnaryOperatorRepresentation(
@@ -227,7 +225,6 @@ void OperatorsRepresentationCheck::registerOverloadedOperatorMatcher(
 
   Finder->addMatcher(
       cxxOperatorCallExpr(
-          unless(isExpansionInSystemHeader()),
           anyOf(
               hasInvalidOverloadedOperatorRepresentation(
                   OO_AmpAmp,

--- a/clang-tools-extra/clang-tidy/readability/ReferenceToConstructedTemporaryCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ReferenceToConstructedTemporaryCheck.cpp
@@ -57,8 +57,7 @@ ReferenceToConstructedTemporaryCheck::getCheckTraversalKind() const {
 void ReferenceToConstructedTemporaryCheck::registerMatchers(
     MatchFinder *Finder) {
   Finder->addMatcher(
-      varDecl(unless(isExpansionInSystemHeader()),
-              hasType(qualType(references(qualType().bind("type")))),
+      varDecl(hasType(qualType(references(qualType().bind("type")))),
               decl().bind("var"),
               hasInitializer(expr(hasDescendant(
                   materializeTemporaryExpr(


### PR DESCRIPTION
#151035 centralized the code to skip matching nodes in system headers, so individual checks no longer need the `unless(isExpansionInSystemHeader())` boilerplate to achieve that. You can verify that the logic introduced in that PR is equivalent to `unless(isExpansionInSystemHeader())`; they both essentially boil down to
`!SourceManager.isInSystemHeader(Node.getBeginLoc())`:

https://github.com/llvm/llvm-project/blob/7c5c58cdc6553c969a11fee51bfd23ae659220d4/clang/include/clang/ASTMatchers/ASTMatchers.h#L283-L291

https://github.com/llvm/llvm-project/blob/7c5c58cdc6553c969a11fee51bfd23ae659220d4/clang/lib/ASTMatchers/ASTMatchFinder.cpp#L1363-L1372

I audited all the uses of `isExpansionInSystemHeader` in the codebase, and the only one I found that wasn't redundant was this one:
https://github.com/llvm/llvm-project/blob/12d8360727c0f366f293faaf294c9f9bf953f38d/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp#L104-L105

