### PR TITLE
[lldb][TypeSystem][NFC] Remove unused AccessType parameters to TypeSystemClang APIs

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -2011,8 +2011,8 @@ void ClangExpressionDeclMap::AddContextClassType(NameSearchContext &context,
 
     CXXMethodDecl *method_decl = m_clang_ast_context->AddMethodToCXXRecordType(
         copied_clang_type.GetOpaqueQualType(), "$__lldb_expr", /*asm_label=*/{},
-        method_type, lldb::eAccessPublic, is_virtual, is_static, is_inline,
-        is_explicit, is_attr_used, is_artificial);
+        method_type, is_virtual, is_static, is_inline, is_explicit,
+        is_attr_used, is_artificial);
 
     LLDB_LOG(log,
              "  CEDM::AddThisType Added function $__lldb_expr "

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -78,18 +78,17 @@ static CompilerType GetLLDBNSPairType(TargetSP target_sp) {
 
   if (!compiler_type) {
     compiler_type = scratch_ts_sp->CreateRecordType(
-        nullptr, OptionalClangModuleID(), lldb::eAccessPublic,
-        g_lldb_autogen_nspair, llvm::to_underlying(clang::TagTypeKind::Struct),
-        lldb::eLanguageTypeC);
+        nullptr, OptionalClangModuleID(), g_lldb_autogen_nspair,
+        llvm::to_underlying(clang::TagTypeKind::Struct), lldb::eLanguageTypeC);
 
     if (compiler_type) {
       TypeSystemClang::StartTagDeclarationDefinition(compiler_type);
       CompilerType id_compiler_type =
           scratch_ts_sp->GetBasicType(eBasicTypeObjCID);
-      TypeSystemClang::AddFieldToRecordType(
-          compiler_type, "key", id_compiler_type, lldb::eAccessPublic, 0);
-      TypeSystemClang::AddFieldToRecordType(
-          compiler_type, "value", id_compiler_type, lldb::eAccessPublic, 0);
+      TypeSystemClang::AddFieldToRecordType(compiler_type, "key",
+                                            id_compiler_type, 0);
+      TypeSystemClang::AddFieldToRecordType(compiler_type, "value",
+                                            id_compiler_type, 0);
       TypeSystemClang::CompleteTagDeclarationDefinition(compiler_type);
     }
   }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.cpp
@@ -145,8 +145,7 @@ clang::QualType AppleObjCTypeEncodingParser::BuildAggregate(
     return clang::QualType(); // This is where we bail out.  Sorry!
 
   CompilerType union_type(ast_ctx.CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, name, kind,
-      lldb::eLanguageTypeC));
+      nullptr, OptionalClangModuleID(), name, kind, lldb::eLanguageTypeC));
   if (union_type) {
     TypeSystemClang::StartTagDeclarationDefinition(union_type);
 
@@ -157,9 +156,9 @@ clang::QualType AppleObjCTypeEncodingParser::BuildAggregate(
         elem_name.Printf("__unnamed_%u", count);
         element.name = std::string(elem_name.GetString());
       }
-      TypeSystemClang::AddFieldToRecordType(
-          union_type, element.name.c_str(), ast_ctx.GetType(element.type),
-          lldb::eAccessPublic, element.bitfield);
+      TypeSystemClang::AddFieldToRecordType(union_type, element.name.c_str(),
+                                            ast_ctx.GetType(element.type),
+                                            element.bitfield);
       ++count;
     }
     TypeSystemClang::CompleteTagDeclarationDefinition(union_type);

--- a/lldb/source/Plugins/Platform/FreeBSD/PlatformFreeBSD.cpp
+++ b/lldb/source/Plugins/Platform/FreeBSD/PlatformFreeBSD.cpp
@@ -204,40 +204,30 @@ CompilerType PlatformFreeBSD::GetSiginfoType(const llvm::Triple &triple) {
   CompilerType &uid_type = uint_type;
 
   CompilerType sigval_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "__lldb_sigval_t",
+      nullptr, OptionalClangModuleID(), "__lldb_sigval_t",
       llvm::to_underlying(clang::TagTypeKind::Union), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(sigval_type);
-  ast->AddFieldToRecordType(sigval_type, "sival_int", int_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(sigval_type, "sival_ptr", voidp_type,
-                            lldb::eAccessPublic, 0);
+  ast->AddFieldToRecordType(sigval_type, "sival_int", int_type, 0);
+  ast->AddFieldToRecordType(sigval_type, "sival_ptr", voidp_type, 0);
   ast->CompleteTagDeclarationDefinition(sigval_type);
 
   // siginfo_t
   CompilerType siginfo_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "__lldb_siginfo_t",
+      nullptr, OptionalClangModuleID(), "__lldb_siginfo_t",
       llvm::to_underlying(clang::TagTypeKind::Struct), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(siginfo_type);
-  ast->AddFieldToRecordType(siginfo_type, "si_signo", int_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(siginfo_type, "si_errno", int_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(siginfo_type, "si_code", int_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(siginfo_type, "si_pid", pid_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(siginfo_type, "si_uid", uid_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(siginfo_type, "si_status", int_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(siginfo_type, "si_addr", voidp_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(siginfo_type, "si_value", sigval_type,
-                            lldb::eAccessPublic, 0);
+  ast->AddFieldToRecordType(siginfo_type, "si_signo", int_type, 0);
+  ast->AddFieldToRecordType(siginfo_type, "si_errno", int_type, 0);
+  ast->AddFieldToRecordType(siginfo_type, "si_code", int_type, 0);
+  ast->AddFieldToRecordType(siginfo_type, "si_pid", pid_type, 0);
+  ast->AddFieldToRecordType(siginfo_type, "si_uid", uid_type, 0);
+  ast->AddFieldToRecordType(siginfo_type, "si_status", int_type, 0);
+  ast->AddFieldToRecordType(siginfo_type, "si_addr", voidp_type, 0);
+  ast->AddFieldToRecordType(siginfo_type, "si_value", sigval_type, 0);
 
   // union used to hold the signal data
   CompilerType union_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "",
+      nullptr, OptionalClangModuleID(), "",
       llvm::to_underlying(clang::TagTypeKind::Union), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(union_type);
 
@@ -247,7 +237,7 @@ CompilerType PlatformFreeBSD::GetSiginfoType(const llvm::Triple &triple) {
                                      {
                                          {"_trapno", int_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(
       union_type, "_timer",
@@ -256,7 +246,7 @@ CompilerType PlatformFreeBSD::GetSiginfoType(const llvm::Triple &triple) {
                                          {"_timerid", int_type},
                                          {"_overrun", int_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(
       union_type, "_mesgq",
@@ -264,7 +254,7 @@ CompilerType PlatformFreeBSD::GetSiginfoType(const llvm::Triple &triple) {
                                      {
                                          {"_mqd", int_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(
       union_type, "_poll",
@@ -272,11 +262,10 @@ CompilerType PlatformFreeBSD::GetSiginfoType(const llvm::Triple &triple) {
                                      {
                                          {"_band", long_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->CompleteTagDeclarationDefinition(union_type);
-  ast->AddFieldToRecordType(siginfo_type, "_reason", union_type,
-                            lldb::eAccessPublic, 0);
+  ast->AddFieldToRecordType(siginfo_type, "_reason", union_type, 0);
 
   ast->CompleteTagDeclarationDefinition(siginfo_type);
   return siginfo_type;

--- a/lldb/source/Plugins/Platform/Linux/PlatformLinux.cpp
+++ b/lldb/source/Plugins/Platform/Linux/PlatformLinux.cpp
@@ -446,17 +446,15 @@ CompilerType PlatformLinux::GetSiginfoType(const llvm::Triple &triple) {
   CompilerType &band_type = long_type;
 
   CompilerType sigval_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "__lldb_sigval_t",
+      nullptr, OptionalClangModuleID(), "__lldb_sigval_t",
       llvm::to_underlying(clang::TagTypeKind::Union), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(sigval_type);
-  ast->AddFieldToRecordType(sigval_type, "sival_int", int_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(sigval_type, "sival_ptr", voidp_type,
-                            lldb::eAccessPublic, 0);
+  ast->AddFieldToRecordType(sigval_type, "sival_int", int_type, 0);
+  ast->AddFieldToRecordType(sigval_type, "sival_ptr", voidp_type, 0);
   ast->CompleteTagDeclarationDefinition(sigval_type);
 
   CompilerType sigfault_bounds_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "",
+      nullptr, OptionalClangModuleID(), "",
       llvm::to_underlying(clang::TagTypeKind::Union), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(sigfault_bounds_type);
   ast->AddFieldToRecordType(
@@ -466,39 +464,32 @@ CompilerType PlatformLinux::GetSiginfoType(const llvm::Triple &triple) {
                                          {"_lower", voidp_type},
                                          {"_upper", voidp_type},
                                      }),
-      lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(sigfault_bounds_type, "_pkey", uint_type,
-                            lldb::eAccessPublic, 0);
+      0);
+  ast->AddFieldToRecordType(sigfault_bounds_type, "_pkey", uint_type, 0);
   ast->CompleteTagDeclarationDefinition(sigfault_bounds_type);
 
   // siginfo_t
   CompilerType siginfo_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "__lldb_siginfo_t",
+      nullptr, OptionalClangModuleID(), "__lldb_siginfo_t",
       llvm::to_underlying(clang::TagTypeKind::Struct), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(siginfo_type);
-  ast->AddFieldToRecordType(siginfo_type, "si_signo", int_type,
-                            lldb::eAccessPublic, 0);
+  ast->AddFieldToRecordType(siginfo_type, "si_signo", int_type, 0);
 
   if (si_errno_then_code) {
-    ast->AddFieldToRecordType(siginfo_type, "si_errno", int_type,
-                              lldb::eAccessPublic, 0);
-    ast->AddFieldToRecordType(siginfo_type, "si_code", int_type,
-                              lldb::eAccessPublic, 0);
+    ast->AddFieldToRecordType(siginfo_type, "si_errno", int_type, 0);
+    ast->AddFieldToRecordType(siginfo_type, "si_code", int_type, 0);
   } else {
-    ast->AddFieldToRecordType(siginfo_type, "si_code", int_type,
-                              lldb::eAccessPublic, 0);
-    ast->AddFieldToRecordType(siginfo_type, "si_errno", int_type,
-                              lldb::eAccessPublic, 0);
+    ast->AddFieldToRecordType(siginfo_type, "si_code", int_type, 0);
+    ast->AddFieldToRecordType(siginfo_type, "si_errno", int_type, 0);
   }
 
   // the structure is padded on 64-bit arches to fix alignment
   if (triple.isArch64Bit())
-    ast->AddFieldToRecordType(siginfo_type, "__pad0", int_type,
-                              lldb::eAccessPublic, 0);
+    ast->AddFieldToRecordType(siginfo_type, "__pad0", int_type, 0);
 
   // union used to hold the signal data
   CompilerType union_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "",
+      nullptr, OptionalClangModuleID(), "",
       llvm::to_underlying(clang::TagTypeKind::Union), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(union_type);
 
@@ -509,7 +500,7 @@ CompilerType PlatformLinux::GetSiginfoType(const llvm::Triple &triple) {
                                          {"si_pid", pid_type},
                                          {"si_uid", uid_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(
       union_type, "_timer",
@@ -519,7 +510,7 @@ CompilerType PlatformLinux::GetSiginfoType(const llvm::Triple &triple) {
                                          {"si_overrun", int_type},
                                          {"si_sigval", sigval_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(
       union_type, "_rt",
@@ -529,7 +520,7 @@ CompilerType PlatformLinux::GetSiginfoType(const llvm::Triple &triple) {
                                          {"si_uid", uid_type},
                                          {"si_sigval", sigval_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(
       union_type, "_sigchld",
@@ -541,7 +532,7 @@ CompilerType PlatformLinux::GetSiginfoType(const llvm::Triple &triple) {
                                          {"si_utime", clock_type},
                                          {"si_stime", clock_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(
       union_type, "_sigfault",
@@ -551,7 +542,7 @@ CompilerType PlatformLinux::GetSiginfoType(const llvm::Triple &triple) {
                                          {"si_addr_lsb", short_type},
                                          {"_bounds", sigfault_bounds_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(
       union_type, "_sigpoll",
@@ -560,7 +551,7 @@ CompilerType PlatformLinux::GetSiginfoType(const llvm::Triple &triple) {
                                          {"si_band", band_type},
                                          {"si_fd", int_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   // NB: SIGSYS is not present on ia64 but we don't seem to support that
   ast->AddFieldToRecordType(
@@ -571,11 +562,10 @@ CompilerType PlatformLinux::GetSiginfoType(const llvm::Triple &triple) {
                                          {"_syscall", int_type},
                                          {"_arch", uint_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->CompleteTagDeclarationDefinition(union_type);
-  ast->AddFieldToRecordType(siginfo_type, "_sifields", union_type,
-                            lldb::eAccessPublic, 0);
+  ast->AddFieldToRecordType(siginfo_type, "_sifields", union_type, 0);
 
   ast->CompleteTagDeclarationDefinition(siginfo_type);
   return siginfo_type;

--- a/lldb/source/Plugins/Platform/NetBSD/PlatformNetBSD.cpp
+++ b/lldb/source/Plugins/Platform/NetBSD/PlatformNetBSD.cpp
@@ -227,51 +227,43 @@ CompilerType PlatformNetBSD::GetSiginfoType(const llvm::Triple &triple) {
   CompilerType &lwpid_type = int_type;
 
   CompilerType sigval_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "__lldb_sigval_t",
+      nullptr, OptionalClangModuleID(), "__lldb_sigval_t",
       llvm::to_underlying(clang::TagTypeKind::Union), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(sigval_type);
-  ast->AddFieldToRecordType(sigval_type, "sival_int", int_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(sigval_type, "sival_ptr", voidp_type,
-                            lldb::eAccessPublic, 0);
+  ast->AddFieldToRecordType(sigval_type, "sival_int", int_type, 0);
+  ast->AddFieldToRecordType(sigval_type, "sival_ptr", voidp_type, 0);
   ast->CompleteTagDeclarationDefinition(sigval_type);
 
   CompilerType ptrace_option_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "",
+      nullptr, OptionalClangModuleID(), "",
       llvm::to_underlying(clang::TagTypeKind::Union), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(ptrace_option_type);
-  ast->AddFieldToRecordType(ptrace_option_type, "_pe_other_pid", pid_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(ptrace_option_type, "_pe_lwp", lwpid_type,
-                            lldb::eAccessPublic, 0);
+  ast->AddFieldToRecordType(ptrace_option_type, "_pe_other_pid", pid_type, 0);
+  ast->AddFieldToRecordType(ptrace_option_type, "_pe_lwp", lwpid_type, 0);
   ast->CompleteTagDeclarationDefinition(ptrace_option_type);
 
   // siginfo_t
   CompilerType siginfo_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "__lldb_siginfo_t",
+      nullptr, OptionalClangModuleID(), "__lldb_siginfo_t",
       llvm::to_underlying(clang::TagTypeKind::Union), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(siginfo_type);
 
   // struct _ksiginfo
   CompilerType ksiginfo_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "",
+      nullptr, OptionalClangModuleID(), "",
       llvm::to_underlying(clang::TagTypeKind::Struct), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(ksiginfo_type);
-  ast->AddFieldToRecordType(ksiginfo_type, "_signo", int_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(ksiginfo_type, "_code", int_type,
-                            lldb::eAccessPublic, 0);
-  ast->AddFieldToRecordType(ksiginfo_type, "_errno", int_type,
-                            lldb::eAccessPublic, 0);
+  ast->AddFieldToRecordType(ksiginfo_type, "_signo", int_type, 0);
+  ast->AddFieldToRecordType(ksiginfo_type, "_code", int_type, 0);
+  ast->AddFieldToRecordType(ksiginfo_type, "_errno", int_type, 0);
 
   // the structure is padded on 64-bit arches to fix alignment
   if (triple.isArch64Bit())
-    ast->AddFieldToRecordType(ksiginfo_type, "__pad0", int_type,
-                              lldb::eAccessPublic, 0);
+    ast->AddFieldToRecordType(ksiginfo_type, "__pad0", int_type, 0);
 
   // union used to hold the signal data
   CompilerType union_type = ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "",
+      nullptr, OptionalClangModuleID(), "",
       llvm::to_underlying(clang::TagTypeKind::Union), lldb::eLanguageTypeC);
   ast->StartTagDeclarationDefinition(union_type);
 
@@ -283,7 +275,7 @@ CompilerType PlatformNetBSD::GetSiginfoType(const llvm::Triple &triple) {
                                          {"_uid", uid_type},
                                          {"_value", sigval_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(
       union_type, "_child",
@@ -295,7 +287,7 @@ CompilerType PlatformNetBSD::GetSiginfoType(const llvm::Triple &triple) {
                                          {"_utime", clock_type},
                                          {"_stime", clock_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(
       union_type, "_fault",
@@ -306,7 +298,7 @@ CompilerType PlatformNetBSD::GetSiginfoType(const llvm::Triple &triple) {
                                          {"_trap2", int_type},
                                          {"_trap3", int_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(
       union_type, "_poll",
@@ -315,7 +307,7 @@ CompilerType PlatformNetBSD::GetSiginfoType(const llvm::Triple &triple) {
                                          {"_band", long_type},
                                          {"_fd", int_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->AddFieldToRecordType(union_type, "_syscall",
                             ast->CreateStructForIdentifier(
@@ -326,7 +318,7 @@ CompilerType PlatformNetBSD::GetSiginfoType(const llvm::Triple &triple) {
                                     {"_error", int_type},
                                     {"_args", long_long_type.GetArrayType(8)},
                                 }),
-                            lldb::eAccessPublic, 0);
+                            0);
 
   ast->AddFieldToRecordType(
       union_type, "_ptrace_state",
@@ -335,15 +327,13 @@ CompilerType PlatformNetBSD::GetSiginfoType(const llvm::Triple &triple) {
                                          {"_pe_report_event", int_type},
                                          {"_option", ptrace_option_type},
                                      }),
-      lldb::eAccessPublic, 0);
+      0);
 
   ast->CompleteTagDeclarationDefinition(union_type);
-  ast->AddFieldToRecordType(ksiginfo_type, "_reason", union_type,
-                            lldb::eAccessPublic, 0);
+  ast->AddFieldToRecordType(ksiginfo_type, "_reason", union_type, 0);
 
   ast->CompleteTagDeclarationDefinition(ksiginfo_type);
-  ast->AddFieldToRecordType(siginfo_type, "_info", ksiginfo_type,
-                            lldb::eAccessPublic, 0);
+  ast->AddFieldToRecordType(siginfo_type, "_info", ksiginfo_type, 0);
 
   ast->CompleteTagDeclarationDefinition(siginfo_type);
   return siginfo_type;

--- a/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
+++ b/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
@@ -58,9 +58,8 @@ CompilerType RegisterTypeBuilderClang::GetRegisterType(
                                                          byte_size * 8);
 
     fields_type = type_system->CreateRecordType(
-        nullptr, OptionalClangModuleID(), lldb::eAccessPublic,
-        register_type_name, llvm::to_underlying(clang::TagTypeKind::Struct),
-        lldb::eLanguageTypeC);
+        nullptr, OptionalClangModuleID(), register_type_name,
+        llvm::to_underlying(clang::TagTypeKind::Struct), lldb::eLanguageTypeC);
     type_system->StartTagDeclarationDefinition(fields_type);
 
     // We assume that RegisterFlags has padded and sorted the fields
@@ -107,8 +106,7 @@ CompilerType RegisterTypeBuilderClang::GetRegisterType(
       }
 
       type_system->AddFieldToRecordType(fields_type, field.GetName(),
-                                        field_type, lldb::eAccessPublic,
-                                        field.GetSizeInBits());
+                                        field_type, field.GetSizeInBits());
     }
 
     type_system->CompleteTagDeclarationDefinition(fields_type);

--- a/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
+++ b/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
@@ -502,7 +502,7 @@ llvm::Expected<lldb::TypeSP>
 SymbolFileCTF::CreateRecord(const CTFRecord &ctf_record) {
   const clang::TagTypeKind tag_kind = TranslateRecordKind(ctf_record.kind);
   CompilerType record_type = m_ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), eAccessPublic, ctf_record.name.data(),
+      nullptr, OptionalClangModuleID(), ctf_record.name.data(),
       llvm::to_underlying(tag_kind), eLanguageTypeC);
   m_compiler_types[record_type.GetOpaqueQualType()] = &ctf_record;
   Declaration decl;
@@ -545,7 +545,7 @@ bool SymbolFileCTF::CompleteType(CompilerType &compiler_type) {
         llvm::expectedToOptional(field_type->GetByteSize(nullptr)).value_or(0);
     TypeSystemClang::AddFieldToRecordType(compiler_type, field.name,
                                           field_type->GetFullCompilerType(),
-                                          eAccessPublic, field_size);
+                                          field_size);
   }
   m_ast->CompleteTagDeclarationDefinition(compiler_type);
 
@@ -560,7 +560,7 @@ bool SymbolFileCTF::CompleteType(CompilerType &compiler_type) {
 llvm::Expected<lldb::TypeSP>
 SymbolFileCTF::CreateForward(const CTFForward &ctf_forward) {
   CompilerType forward_compiler_type = m_ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), eAccessPublic, ctf_forward.name,
+      nullptr, OptionalClangModuleID(), ctf_forward.name,
       llvm::to_underlying(clang::TagTypeKind::Struct), eLanguageTypeC);
   Declaration decl;
   return MakeType(ctf_forward.uid, ConstString(ctf_forward.name), 0, nullptr,

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -1264,9 +1264,8 @@ std::pair<bool, TypeSP> DWARFASTParserClang::ParseCXXMethod(
 
   clang::CXXMethodDecl *cxx_method_decl = m_ast.AddMethodToCXXRecordType(
       class_opaque_type.GetOpaqueQualType(), attrs.name.GetCString(),
-      MakeLLDBFuncAsmLabel(die), clang_type, /*access=*/{}, attrs.is_virtual,
-      is_static, attrs.is_inline, attrs.is_explicit, is_attr_used,
-      attrs.is_artificial);
+      MakeLLDBFuncAsmLabel(die), clang_type, attrs.is_virtual, is_static,
+      attrs.is_inline, attrs.is_explicit, is_attr_used, attrs.is_artificial);
 
   if (cxx_method_decl) {
     LinkDeclContextToDIE(cxx_method_decl, die);
@@ -1561,8 +1560,7 @@ static AccessType GetDefaultAccessibility(const DWARFDIE &die) {
 
 void DWARFASTParserClang::ParseInheritance(
     const DWARFDIE &die, const DWARFDIE &parent_die,
-    const CompilerType class_clang_type, const AccessType,
-    const lldb::ModuleSP &module_sp,
+    const CompilerType class_clang_type, const lldb::ModuleSP &module_sp,
     std::vector<std::unique_ptr<clang::CXXBaseSpecifier>> &base_classes,
     ClangASTImporter::LayoutInfo &layout_info) {
   auto ast = class_clang_type.GetTypeSystem<TypeSystemClang>();
@@ -1867,7 +1865,7 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
   if (ParseTemplateParameterInfos(die, template_param_infos)) {
     clang::ClassTemplateDecl *class_template_decl =
         m_ast.ParseClassTemplateDecl(
-            containing_decl_ctx, GetOwningClangModule(die), /*access*/ {},
+            containing_decl_ctx, GetOwningClangModule(die),
             attrs.name.GetCString(), tag_decl_kind, template_param_infos);
     if (!class_template_decl) {
       if (log) {
@@ -1905,9 +1903,8 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
 
   if (!clang_type) {
     clang_type = m_ast.CreateRecordType(
-        containing_decl_ctx, GetOwningClangModule(die),
-        /*access_type=*/{}, attrs.name.GetCString(), tag_decl_kind,
-        attrs.class_language, metadata, attrs.exports_symbols);
+        containing_decl_ctx, GetOwningClangModule(die), attrs.name.GetCString(),
+        tag_decl_kind, attrs.class_language, metadata, attrs.exports_symbols);
   }
 
   TypeSP type_sp = dwarf->MakeType(
@@ -2197,8 +2194,7 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
 
   DelayedPropertyList delayed_properties;
   ParseChildMembers(die, clang_type, bases, member_function_dies,
-                    contained_type_dies, delayed_properties,
-                    /*default_accessibility=*/{}, layout_info);
+                    contained_type_dies, delayed_properties, layout_info);
 
   // Now parse any methods if there were any...
   for (const DWARFDIE &die : member_function_dies)
@@ -2909,8 +2905,8 @@ void DWARFASTParserClang::CreateStaticMemberVariable(
     return;
 
   CompilerType ct = var_type->GetForwardCompilerType();
-  clang::VarDecl *v = TypeSystemClang::AddVariableToRecordType(
-      class_clang_type, attrs.name, ct, /*access=*/{});
+  clang::VarDecl *v = TypeSystemClang::AddVariableToRecordType(class_clang_type,
+                                                               attrs.name, ct);
   if (!v) {
     LLDB_LOG(log, "Failed to add variable to the record type");
     return;
@@ -2936,7 +2932,6 @@ void DWARFASTParserClang::CreateStaticMemberVariable(
 void DWARFASTParserClang::ParseSingleMember(
     const DWARFDIE &die, const DWARFDIE &parent_die,
     const lldb_private::CompilerType &class_clang_type,
-    lldb::AccessType default_accessibility,
     lldb_private::ClangASTImporter::LayoutInfo &layout_info,
     FieldInfo &last_field_info) {
   // This function can only parse DW_TAG_member.
@@ -3090,8 +3085,7 @@ void DWARFASTParserClang::ParseSingleMember(
   TypeSystemClang::RequireCompleteType(member_clang_type);
 
   clang::FieldDecl *field_decl = TypeSystemClang::AddFieldToRecordType(
-      class_clang_type, attrs.name, member_clang_type,
-      /*access=*/{}, attrs.bit_size);
+      class_clang_type, attrs.name, member_clang_type, attrs.bit_size);
 
   m_ast.SetMetadataAsUserID(field_decl, die.GetID());
 
@@ -3105,7 +3099,6 @@ bool DWARFASTParserClang::ParseChildMembers(
     std::vector<DWARFDIE> &member_function_dies,
     std::vector<DWARFDIE> &contained_type_dies,
     DelayedPropertyList &delayed_properties,
-    const AccessType default_accessibility,
     ClangASTImporter::LayoutInfo &layout_info) {
   if (!parent_die)
     return false;
@@ -3127,8 +3120,7 @@ bool DWARFASTParserClang::ParseChildMembers(
 
     case DW_TAG_variant_part:
       if (die.GetCU()->GetDWARFLanguageType() == eLanguageTypeRust) {
-        ParseRustVariantPart(die, parent_die, class_clang_type,
-                             /*default_accesibility=*/{}, layout_info);
+        ParseRustVariantPart(die, parent_die, class_clang_type, layout_info);
       }
       break;
 
@@ -3137,8 +3129,7 @@ bool DWARFASTParserClang::ParseChildMembers(
       CreateStaticMemberVariable(die, attrs, class_clang_type);
     } break;
     case DW_TAG_member:
-      ParseSingleMember(die, parent_die, class_clang_type,
-                        /*default_accessibility=*/{}, layout_info,
+      ParseSingleMember(die, parent_die, class_clang_type, layout_info,
                         last_field_info);
       break;
 
@@ -3148,9 +3139,8 @@ bool DWARFASTParserClang::ParseChildMembers(
       break;
 
     case DW_TAG_inheritance:
-      ParseInheritance(die, parent_die, class_clang_type,
-                       /*default_accessibility=*/{}, module_sp, base_classes,
-                       layout_info);
+      ParseInheritance(die, parent_die, class_clang_type, module_sp,
+                       base_classes, layout_info);
       break;
 
     default:
@@ -3785,7 +3775,7 @@ void DWARFASTParserClang::AddUnnamedBitfieldToRecordTypeIfNeeded(
       TypeSystemClang::AddFieldToRecordType(
           class_clang_type, llvm::StringRef(),
           m_ast.GetBuiltinTypeForEncodingAndBitSize(eEncodingSint, word_width),
-          lldb::AccessType::eAccessPublic, unnamed_bit_size);
+          unnamed_bit_size);
 
   class_layout_info.field_offsets.insert(
       std::make_pair(unnamed_bitfield_decl, unnamed_bit_offset));
@@ -3794,7 +3784,6 @@ void DWARFASTParserClang::AddUnnamedBitfieldToRecordTypeIfNeeded(
 void DWARFASTParserClang::ParseRustVariantPart(
     DWARFDIE &die, const DWARFDIE &parent_die,
     const CompilerType &class_clang_type,
-    const lldb::AccessType default_accesibility,
     ClangASTImporter::LayoutInfo &layout_info) {
   assert(die.Tag() == llvm::dwarf::DW_TAG_variant_part);
   assert(SymbolFileDWARF::GetLanguage(*die.GetCU()) ==
@@ -3810,7 +3799,7 @@ void DWARFASTParserClang::ParseRustVariantPart(
   auto decl_context = m_ast.GetDeclContextForType(class_clang_type);
 
   auto inner_holder = m_ast.CreateRecordType(
-      decl_context, OptionalClangModuleID(), lldb::eAccessPublic,
+      decl_context, OptionalClangModuleID(),
       std::string(
           llvm::formatv("{0}$Inner", class_clang_type.GetTypeName(false))),
       llvm::to_underlying(clang::TagTypeKind::Union), lldb::eLanguageTypeRust);
@@ -3825,7 +3814,6 @@ void DWARFASTParserClang::ParseRustVariantPart(
 
     auto field_type = m_ast.CreateRecordType(
         m_ast.GetDeclContextForType(inner_holder), OptionalClangModuleID(),
-        lldb::eAccessPublic,
         std::string(llvm::formatv("{0}$Variant", member.GetName())),
         llvm::to_underlying(clang::TagTypeKind::Struct),
         lldb::eLanguageTypeRust);
@@ -3834,17 +3822,16 @@ void DWARFASTParserClang::ParseRustVariantPart(
     auto offset = member.byte_offset;
 
     if (has_discriminant) {
-      m_ast.AddFieldToRecordType(
-          field_type, "$discr$", discriminant_type->GetFullCompilerType(),
-          lldb::eAccessPublic, variants.discriminant().byte_offset);
+      m_ast.AddFieldToRecordType(field_type, "$discr$",
+                                 discriminant_type->GetFullCompilerType(),
+                                 variants.discriminant().byte_offset);
       offset +=
           llvm::expectedToOptional(discriminant_type->GetByteSize(nullptr))
               .value_or(0);
     }
 
     m_ast.AddFieldToRecordType(field_type, "value",
-                               member_type->GetFullCompilerType(),
-                               lldb::eAccessPublic, offset * 8);
+                               member_type->GetFullCompilerType(), offset * 8);
 
     m_ast.CompleteTagDeclarationDefinition(field_type);
 
@@ -3853,14 +3840,13 @@ void DWARFASTParserClang::ParseRustVariantPart(
                     : std::string("$variant$");
 
     auto variant_decl = m_ast.AddFieldToRecordType(
-        inner_holder, llvm::StringRef(name), field_type, /*access=*/{}, 0);
+        inner_holder, llvm::StringRef(name), field_type, 0);
 
     layout_info.field_offsets.insert({variant_decl, 0});
   }
 
-  auto inner_field = m_ast.AddFieldToRecordType(class_clang_type,
-                                                llvm::StringRef("$variants$"),
-                                                inner_holder, eAccessPublic, 0);
+  auto inner_field = m_ast.AddFieldToRecordType(
+      class_clang_type, llvm::StringRef("$variants$"), inner_holder, 0);
 
   m_ast.CompleteTagDeclarationDefinition(inner_holder);
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
@@ -202,7 +202,6 @@ protected:
       std::vector<lldb_private::plugin::dwarf::DWARFDIE> &member_function_dies,
       std::vector<lldb_private::plugin::dwarf::DWARFDIE> &contained_type_dies,
       DelayedPropertyList &delayed_properties,
-      const lldb::AccessType default_accessibility,
       lldb_private::ClangASTImporter::LayoutInfo &layout_info);
 
   void ParseChildParameters(
@@ -412,7 +411,6 @@ private:
   ParseSingleMember(const lldb_private::plugin::dwarf::DWARFDIE &die,
                     const lldb_private::plugin::dwarf::DWARFDIE &parent_die,
                     const lldb_private::CompilerType &class_clang_type,
-                    lldb::AccessType default_accessibility,
                     lldb_private::ClangASTImporter::LayoutInfo &layout_info,
                     FieldInfo &last_field_info);
 
@@ -512,8 +510,6 @@ private:
   /// \param class_clang_type The C++/Objective-C class representing parent_die.
   /// For an Objective-C class this method sets the super class on success. For
   /// a C++ class this will *not* add the result as a base class.
-  /// \param default_accessibility The default accessibility that is given to
-  /// base classes if they don't have an explicit accessibility set.
   /// \param module_sp The current Module.
   /// \param base_classes The list of C++ base classes that will be appended
   /// with the parsed base class on success.
@@ -523,7 +519,6 @@ private:
       const lldb_private::plugin::dwarf::DWARFDIE &die,
       const lldb_private::plugin::dwarf::DWARFDIE &parent_die,
       const lldb_private::CompilerType class_clang_type,
-      const lldb::AccessType default_accessibility,
       const lldb::ModuleSP &module_sp,
       std::vector<std::unique_ptr<clang::CXXBaseSpecifier>> &base_classes,
       lldb_private::ClangASTImporter::LayoutInfo &layout_info);
@@ -533,15 +528,12 @@ private:
   /// \param die DW_TAG_variant_part DIE to parse
   /// \param parent_die The parent DW_TAG_structure_type to parse
   /// \param class_clang_type The Rust struct representing parent_die.
-  /// \param default_accesibility The default accessibility that is given to
-  ///  base classes if they don't have an explicit accessibility set
   /// \param layout_info The layout information that will be updated for
   //   base classes with the base offset
   void
   ParseRustVariantPart(lldb_private::plugin::dwarf::DWARFDIE &die,
                        const lldb_private::plugin::dwarf::DWARFDIE &parent_die,
                        const lldb_private::CompilerType &class_clang_type,
-                       const lldb::AccessType default_accesibility,
                        lldb_private::ClangASTImporter::LayoutInfo &layout_info);
 };
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.h
@@ -124,7 +124,6 @@ private:
       llvm::codeview::TypeIndex ti, llvm::codeview::MemberAccess access,
       std::optional<uint64_t> vtable_idx = std::optional<uint64_t>());
   void AddMethod(llvm::StringRef name, llvm::codeview::TypeIndex type_idx,
-                 llvm::codeview::MemberAccess access,
                  llvm::codeview::MethodOptions options,
                  llvm::codeview::MemberAttributes attrs);
   void FinishRecord();

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/SystemRuntimeMacOSX.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/SystemRuntimeMacOSX.cpp
@@ -425,24 +425,19 @@ void SystemRuntimeMacOSX::ReadLibdispatchTSDIndexes() {
       CompilerType uint16 =
           scratch_ts_sp->GetBuiltinTypeForEncodingAndBitSize(eEncodingUint, 16);
       CompilerType dispatch_tsd_indexes_s = scratch_ts_sp->CreateRecordType(
-          nullptr, OptionalClangModuleID(), lldb::eAccessPublic,
-          "__lldb_dispatch_tsd_indexes_s",
+          nullptr, OptionalClangModuleID(), "__lldb_dispatch_tsd_indexes_s",
           llvm::to_underlying(clang::TagTypeKind::Struct),
           lldb::eLanguageTypeC);
 
       TypeSystemClang::StartTagDeclarationDefinition(dispatch_tsd_indexes_s);
       TypeSystemClang::AddFieldToRecordType(dispatch_tsd_indexes_s,
-                                            "dti_version", uint16,
-                                            lldb::eAccessPublic, 0);
+                                            "dti_version", uint16, 0);
       TypeSystemClang::AddFieldToRecordType(dispatch_tsd_indexes_s,
-                                            "dti_queue_index", uint16,
-                                            lldb::eAccessPublic, 0);
+                                            "dti_queue_index", uint16, 0);
       TypeSystemClang::AddFieldToRecordType(dispatch_tsd_indexes_s,
-                                            "dti_voucher_index", uint16,
-                                            lldb::eAccessPublic, 0);
+                                            "dti_voucher_index", uint16, 0);
       TypeSystemClang::AddFieldToRecordType(dispatch_tsd_indexes_s,
-                                            "dti_qos_class_index", uint16,
-                                            lldb::eAccessPublic, 0);
+                                            "dti_qos_class_index", uint16, 0);
       TypeSystemClang::CompleteTagDeclarationDefinition(dispatch_tsd_indexes_s);
 
       ProcessStructReader struct_reader(m_process, m_dispatch_tsd_indexes_addr,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -1267,9 +1267,8 @@ TypeSystemClang::GetOrCreateClangModule(llvm::StringRef name,
 
 CompilerType TypeSystemClang::CreateRecordType(
     clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
-    AccessType access_type, llvm::StringRef name, int kind,
-    LanguageType language, std::optional<ClangASTMetadata> metadata,
-    bool exports_symbols) {
+    llvm::StringRef name, int kind, LanguageType language,
+    std::optional<ClangASTMetadata> metadata, bool exports_symbols) {
   ASTContext &ast = getASTContext();
 
   if (decl_ctx == nullptr)
@@ -1551,7 +1550,7 @@ static bool ClassTemplateAllowsToInstantiationArgs(
 
 ClassTemplateDecl *TypeSystemClang::CreateClassTemplateDecl(
     DeclContext *decl_ctx, OptionalClangModuleID owning_module,
-    lldb::AccessType access_type, llvm::StringRef class_name, int kind,
+    llvm::StringRef class_name, int kind,
     const TemplateParameterInfos &template_param_infos) {
   ASTContext &ast = getASTContext();
 
@@ -2285,13 +2284,12 @@ CompilerType TypeSystemClang::CreateStructForIdentifier(
     return type;
   }
 
-  type = CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, type_name,
-      llvm::to_underlying(clang::TagTypeKind::Struct), lldb::eLanguageTypeC);
+  type = CreateRecordType(nullptr, OptionalClangModuleID(), type_name,
+                          llvm::to_underlying(clang::TagTypeKind::Struct),
+                          lldb::eLanguageTypeC);
   StartTagDeclarationDefinition(type);
   for (const auto &field : type_fields)
-    AddFieldToRecordType(type, field.first, field.second, lldb::eAccessPublic,
-                         0);
+    AddFieldToRecordType(type, field.first, field.second, 0);
   if (packed)
     SetIsPacked(type);
   CompleteTagDeclarationDefinition(type);
@@ -7383,8 +7381,7 @@ TypeSystemClang::GetAsObjCInterfaceDecl(const CompilerType &type) {
 
 clang::FieldDecl *TypeSystemClang::AddFieldToRecordType(
     const CompilerType &type, llvm::StringRef name,
-    const CompilerType &field_clang_type, AccessType access,
-    uint32_t bitfield_bit_size) {
+    const CompilerType &field_clang_type, uint32_t bitfield_bit_size) {
   if (!type.IsValid() || !field_clang_type.IsValid())
     return nullptr;
   auto ast = type.GetTypeSystem<TypeSystemClang>();
@@ -7599,9 +7596,10 @@ void TypeSystemClang::SetIsPacked(const CompilerType &type) {
   }
 }
 
-clang::VarDecl *TypeSystemClang::AddVariableToRecordType(
-    const CompilerType &type, llvm::StringRef name,
-    const CompilerType &var_type, AccessType access) {
+clang::VarDecl *
+TypeSystemClang::AddVariableToRecordType(const CompilerType &type,
+                                         llvm::StringRef name,
+                                         const CompilerType &var_type) {
   if (!type.IsValid() || !var_type.IsValid())
     return nullptr;
 
@@ -7701,8 +7699,8 @@ TypeSystemClang::CreateParameterDeclarations(
 clang::CXXMethodDecl *TypeSystemClang::AddMethodToCXXRecordType(
     lldb::opaque_compiler_type_t type, llvm::StringRef name,
     llvm::StringRef asm_label, const CompilerType &method_clang_type,
-    lldb::AccessType access, bool is_virtual, bool is_static, bool is_inline,
-    bool is_explicit, bool is_attr_used, bool is_artificial) {
+    bool is_virtual, bool is_static, bool is_inline, bool is_explicit,
+    bool is_attr_used, bool is_artificial) {
   if (!type || !method_clang_type.IsValid() || name.empty())
     return nullptr;
 
@@ -8986,7 +8984,7 @@ void TypeSystemClang::DumpTypeName(const CompilerType &type) {
 
 clang::ClassTemplateDecl *TypeSystemClang::ParseClassTemplateDecl(
     clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
-    lldb::AccessType access_type, const char *parent_name, int tag_decl_kind,
+    const char *parent_name, int tag_decl_kind,
     const TypeSystemClang::TemplateParameterInfos &template_param_infos) {
   if (template_param_infos.IsValid()) {
     std::string template_basename(parent_name);
@@ -8995,7 +8993,6 @@ clang::ClassTemplateDecl *TypeSystemClang::ParseClassTemplateDecl(
       template_basename.erase(i);
 
     return CreateClassTemplateDecl(decl_ctx, owning_module,
-                                   /*access_type=*/{},
                                    template_basename.c_str(), tag_decl_kind,
                                    template_param_infos);
   }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -326,9 +326,8 @@ public:
 
   CompilerType
   CreateRecordType(clang::DeclContext *decl_ctx,
-                   OptionalClangModuleID owning_module,
-                   lldb::AccessType access_type, llvm::StringRef name, int kind,
-                   lldb::LanguageType language,
+                   OptionalClangModuleID owning_module, llvm::StringRef name,
+                   int kind, lldb::LanguageType language,
                    std::optional<ClangASTMetadata> metadata = std::nullopt,
                    bool exports_symbols = false);
 
@@ -424,10 +423,11 @@ public:
       clang::FunctionDecl *func_decl, clang::FunctionTemplateDecl *Template,
       const TemplateParameterInfos &infos);
 
-  clang::ClassTemplateDecl *CreateClassTemplateDecl(
-      clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
-      lldb::AccessType access_type, llvm::StringRef class_name, int kind,
-      const TemplateParameterInfos &infos);
+  clang::ClassTemplateDecl *
+  CreateClassTemplateDecl(clang::DeclContext *decl_ctx,
+                          OptionalClangModuleID owning_module,
+                          llvm::StringRef class_name, int kind,
+                          const TemplateParameterInfos &infos);
 
   clang::TemplateTemplateParmDecl *
   CreateTemplateTemplateParmDecl(const char *template_name);
@@ -955,7 +955,6 @@ public:
   static clang::FieldDecl *AddFieldToRecordType(const CompilerType &type,
                                                 llvm::StringRef name,
                                                 const CompilerType &field_type,
-                                                lldb::AccessType access,
                                                 uint32_t bitfield_bit_size);
 
   static void BuildIndirectFields(const CompilerType &type);
@@ -964,8 +963,7 @@ public:
 
   static clang::VarDecl *AddVariableToRecordType(const CompilerType &type,
                                                  llvm::StringRef name,
-                                                 const CompilerType &var_type,
-                                                 lldb::AccessType access);
+                                                 const CompilerType &var_type);
 
   /// Initializes a variable with an integer value.
   /// \param var The variable to initialize. Must not already have an
@@ -1003,11 +1001,12 @@ public:
       clang::FunctionDecl *context, const clang::FunctionProtoType &prototype,
       const llvm::SmallVector<llvm::StringRef> &param_names);
 
-  clang::CXXMethodDecl *AddMethodToCXXRecordType(
-      lldb::opaque_compiler_type_t type, llvm::StringRef name,
-      llvm::StringRef asm_label, const CompilerType &method_type,
-      lldb::AccessType access, bool is_virtual, bool is_static, bool is_inline,
-      bool is_explicit, bool is_attr_used, bool is_artificial);
+  clang::CXXMethodDecl *
+  AddMethodToCXXRecordType(lldb::opaque_compiler_type_t type,
+                           llvm::StringRef name, llvm::StringRef asm_label,
+                           const CompilerType &method_type, bool is_virtual,
+                           bool is_static, bool is_inline, bool is_explicit,
+                           bool is_attr_used, bool is_artificial);
 
   void AddMethodOverridesForCXXRecordType(lldb::opaque_compiler_type_t type);
 
@@ -1121,7 +1120,7 @@ public:
 
   clang::ClassTemplateDecl *ParseClassTemplateDecl(
       clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
-      lldb::AccessType access_type, const char *parent_name, int tag_decl_kind,
+      const char *parent_name, int tag_decl_kind,
       const TypeSystemClang::TemplateParameterInfos &template_param_infos);
 
   clang::BlockDecl *CreateBlockDeclaration(clang::DeclContext *ctx,

--- a/lldb/unittests/Language/CPlusPlus/LibStdcppTupleTest.cpp
+++ b/lldb/unittests/Language/CPlusPlus/LibStdcppTupleTest.cpp
@@ -98,14 +98,13 @@ public:
     // Create outer type
     CompilerType outer_type = m_type_system->CreateRecordType(
         m_type_system->getASTContext().getTranslationUnitDecl(),
-        OptionalClangModuleID(), lldb::AccessType::eAccessPublic,
-        "std::tuple<int>", 0, lldb::LanguageType::eLanguageTypeC_plus_plus);
+        OptionalClangModuleID(), "std::tuple<int>", 0,
+        lldb::LanguageType::eLanguageTypeC_plus_plus);
 
     // Create inner _Tuple_impl type
     CompilerType inner_type = m_type_system->CreateRecordType(
         m_type_system->getASTContext().getTranslationUnitDecl(),
-        OptionalClangModuleID(), lldb::AccessType::eAccessPublic,
-        "std::_Tuple_impl<0, int>", 0,
+        OptionalClangModuleID(), "std::_Tuple_impl<0, int>", 0,
         lldb::LanguageType::eLanguageTypeC_plus_plus);
 
     TypeSystemClang::StartTagDeclarationDefinition(inner_type);
@@ -114,8 +113,7 @@ public:
     // Add the inner type as a field of the outer type
     TypeSystemClang::StartTagDeclarationDefinition(outer_type);
     m_type_system->AddFieldToRecordType(outer_type, "std::_Tuple_impl<0, int>",
-                                        inner_type,
-                                        lldb::AccessType::eAccessPublic, 0);
+                                        inner_type, 0);
     TypeSystemClang::CompleteTagDeclarationDefinition(outer_type);
 
     return outer_type;

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -349,13 +349,13 @@ TEST_F(TestTypeSystemClang, TestBuiltinTypeForEmptyTriple) {
   EXPECT_FALSE(ast.GetPointerSizedIntType(/*is_signed=*/false));
   EXPECT_FALSE(ast.GetIntTypeFromBitSize(8, /*is_signed=*/false));
 
-  CompilerType record_type = ast.CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "Record",
-      llvm::to_underlying(clang::TagTypeKind::Struct),
-      lldb::eLanguageTypeC_plus_plus, std::nullopt);
+  CompilerType record_type =
+      ast.CreateRecordType(nullptr, OptionalClangModuleID(), "Record",
+                           llvm::to_underlying(clang::TagTypeKind::Struct),
+                           lldb::eLanguageTypeC_plus_plus, std::nullopt);
   TypeSystemClang::StartTagDeclarationDefinition(record_type);
   EXPECT_EQ(ast.AddFieldToRecordType(record_type, "field", record_type,
-                                     eAccessPublic, /*bitfield_bit_size=*/8),
+                                     /*bitfield_bit_size=*/8),
             nullptr);
   TypeSystemClang::CompleteTagDeclarationDefinition(record_type);
 }
@@ -544,10 +544,10 @@ TEST_F(TestTypeSystemClang, TestOwningModule) {
   EXPECT_FALSE(!ed);
   EXPECT_EQ(ed->getOwningModuleID(), 100u);
 
-  CompilerType record_type = ast.CreateRecordType(
-      nullptr, OptionalClangModuleID(200), lldb::eAccessPublic, "FooRecord",
-      llvm::to_underlying(clang::TagTypeKind::Struct),
-      lldb::eLanguageTypeC_plus_plus, std::nullopt);
+  CompilerType record_type =
+      ast.CreateRecordType(nullptr, OptionalClangModuleID(200), "FooRecord",
+                           llvm::to_underlying(clang::TagTypeKind::Struct),
+                           lldb::eLanguageTypeC_plus_plus, std::nullopt);
   auto *rd = TypeSystemClang::GetAsRecordDecl(record_type);
   EXPECT_FALSE(!rd);
   EXPECT_EQ(rd->getOwningModuleID(), 200u);
@@ -565,10 +565,10 @@ TEST_F(TestTypeSystemClang, TestIsClangType) {
   lldb::opaque_compiler_type_t bool_ctype =
       TypeSystemClang::GetOpaqueCompilerType(&context, lldb::eBasicTypeBool);
   CompilerType bool_type(m_ast->weak_from_this(), bool_ctype);
-  CompilerType record_type = m_ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(100), lldb::eAccessPublic, "FooRecord",
-      llvm::to_underlying(clang::TagTypeKind::Struct),
-      lldb::eLanguageTypeC_plus_plus, std::nullopt);
+  CompilerType record_type =
+      m_ast->CreateRecordType(nullptr, OptionalClangModuleID(100), "FooRecord",
+                              llvm::to_underlying(clang::TagTypeKind::Struct),
+                              lldb::eLanguageTypeC_plus_plus, std::nullopt);
   // Clang builtin type and record type should pass
   EXPECT_TRUE(ClangUtil::IsClangType(bool_type));
   EXPECT_TRUE(ClangUtil::IsClangType(record_type));
@@ -578,10 +578,10 @@ TEST_F(TestTypeSystemClang, TestIsClangType) {
 }
 
 TEST_F(TestTypeSystemClang, TestRemoveFastQualifiers) {
-  CompilerType record_type = m_ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "FooRecord",
-      llvm::to_underlying(clang::TagTypeKind::Struct),
-      lldb::eLanguageTypeC_plus_plus, std::nullopt);
+  CompilerType record_type =
+      m_ast->CreateRecordType(nullptr, OptionalClangModuleID(), "FooRecord",
+                              llvm::to_underlying(clang::TagTypeKind::Struct),
+                              lldb::eLanguageTypeC_plus_plus, std::nullopt);
   QualType qt;
 
   qt = ClangUtil::GetQualType(record_type);
@@ -613,10 +613,10 @@ TEST_F(TestTypeSystemClang, TestRecordHasFields) {
   CompilerType int_type = m_ast->GetBasicType(eBasicTypeInt);
 
   // Test that a record with no fields returns false
-  CompilerType empty_base = m_ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "EmptyBase",
-      llvm::to_underlying(clang::TagTypeKind::Struct),
-      lldb::eLanguageTypeC_plus_plus, std::nullopt);
+  CompilerType empty_base =
+      m_ast->CreateRecordType(nullptr, OptionalClangModuleID(), "EmptyBase",
+                              llvm::to_underlying(clang::TagTypeKind::Struct),
+                              lldb::eLanguageTypeC_plus_plus, std::nullopt);
   TypeSystemClang::StartTagDeclarationDefinition(empty_base);
   TypeSystemClang::CompleteTagDeclarationDefinition(empty_base);
 
@@ -625,13 +625,13 @@ TEST_F(TestTypeSystemClang, TestRecordHasFields) {
   EXPECT_FALSE(m_ast->RecordHasFields(empty_base_decl));
 
   // Test that a record with direct fields returns true
-  CompilerType non_empty_base = m_ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "NonEmptyBase",
-      llvm::to_underlying(clang::TagTypeKind::Struct),
-      lldb::eLanguageTypeC_plus_plus, std::nullopt);
+  CompilerType non_empty_base =
+      m_ast->CreateRecordType(nullptr, OptionalClangModuleID(), "NonEmptyBase",
+                              llvm::to_underlying(clang::TagTypeKind::Struct),
+                              lldb::eLanguageTypeC_plus_plus, std::nullopt);
   TypeSystemClang::StartTagDeclarationDefinition(non_empty_base);
-  FieldDecl *non_empty_base_field_decl = m_ast->AddFieldToRecordType(
-      non_empty_base, "MyField", int_type, eAccessPublic, 0);
+  FieldDecl *non_empty_base_field_decl =
+      m_ast->AddFieldToRecordType(non_empty_base, "MyField", int_type, 0);
   TypeSystemClang::CompleteTagDeclarationDefinition(non_empty_base);
   RecordDecl *non_empty_base_decl =
       TypeSystemClang::GetAsRecordDecl(non_empty_base);
@@ -642,10 +642,10 @@ TEST_F(TestTypeSystemClang, TestRecordHasFields) {
   std::vector<std::unique_ptr<clang::CXXBaseSpecifier>> bases;
 
   // Test that a record with no direct fields, but fields in a base returns true
-  CompilerType empty_derived = m_ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "EmptyDerived",
-      llvm::to_underlying(clang::TagTypeKind::Struct),
-      lldb::eLanguageTypeC_plus_plus, std::nullopt);
+  CompilerType empty_derived =
+      m_ast->CreateRecordType(nullptr, OptionalClangModuleID(), "EmptyDerived",
+                              llvm::to_underlying(clang::TagTypeKind::Struct),
+                              lldb::eLanguageTypeC_plus_plus, std::nullopt);
   TypeSystemClang::StartTagDeclarationDefinition(empty_derived);
   std::unique_ptr<clang::CXXBaseSpecifier> non_empty_base_spec =
       m_ast->CreateBaseClassSpecifier(non_empty_base.GetOpaqueQualType(),
@@ -665,10 +665,10 @@ TEST_F(TestTypeSystemClang, TestRecordHasFields) {
 
   // Test that a record with no direct fields, but fields in a virtual base
   // returns true
-  CompilerType empty_derived2 = m_ast->CreateRecordType(
-      nullptr, OptionalClangModuleID(), lldb::eAccessPublic, "EmptyDerived2",
-      llvm::to_underlying(clang::TagTypeKind::Struct),
-      lldb::eLanguageTypeC_plus_plus, std::nullopt);
+  CompilerType empty_derived2 =
+      m_ast->CreateRecordType(nullptr, OptionalClangModuleID(), "EmptyDerived2",
+                              llvm::to_underlying(clang::TagTypeKind::Struct),
+                              lldb::eLanguageTypeC_plus_plus, std::nullopt);
   TypeSystemClang::StartTagDeclarationDefinition(empty_derived2);
   std::unique_ptr<CXXBaseSpecifier> non_empty_vbase_spec =
       m_ast->CreateBaseClassSpecifier(non_empty_base.GetOpaqueQualType(),
@@ -708,8 +708,8 @@ TEST_F(TestTypeSystemClang, TemplateArguments) {
 
   // template<typename T, int I, float F, double D> struct foo;
   ClassTemplateDecl *decl = m_ast->CreateClassTemplateDecl(
-      m_ast->GetTranslationUnitDecl(), OptionalClangModuleID(), eAccessPublic,
-      "foo", llvm::to_underlying(clang::TagTypeKind::Struct), infos);
+      m_ast->GetTranslationUnitDecl(), OptionalClangModuleID(), "foo",
+      llvm::to_underlying(clang::TagTypeKind::Struct), infos);
   ASSERT_NE(decl, nullptr);
 
   // foo<int, 47>
@@ -800,8 +800,8 @@ protected:
   ClassTemplateDecl *
   CreateClassTemplate(const TypeSystemClang::TemplateParameterInfos &infos) {
     ClassTemplateDecl *decl = m_ast->CreateClassTemplateDecl(
-        m_ast->GetTranslationUnitDecl(), OptionalClangModuleID(), eAccessPublic,
-        "foo", llvm::to_underlying(clang::TagTypeKind::Struct), infos);
+        m_ast->GetTranslationUnitDecl(), OptionalClangModuleID(), "foo",
+        llvm::to_underlying(clang::TagTypeKind::Struct), infos);
     return decl;
   }
 
@@ -1108,10 +1108,10 @@ TEST_F(TestTypeSystemClang, TestDeletingImplicitCopyCstrDueToMoveCStr) {
   bool is_explicit = true;
   bool is_attr_used = false;
   bool is_artificial = false;
-  m_ast->AddMethodToCXXRecordType(
-      t.GetOpaqueQualType(), class_name, /*asm_label=*/{}, function_type,
-      lldb::AccessType::eAccessPublic, is_virtual, is_static, is_inline,
-      is_explicit, is_attr_used, is_artificial);
+  m_ast->AddMethodToCXXRecordType(t.GetOpaqueQualType(), class_name,
+                                  /*asm_label=*/{}, function_type, is_virtual,
+                                  is_static, is_inline, is_explicit,
+                                  is_attr_used, is_artificial);
 
   // Complete the definition and check the created record.
   m_ast->CompleteTagDeclarationDefinition(t);
@@ -1145,10 +1145,10 @@ TEST_F(TestTypeSystemClang, TestNotDeletingUserCopyCstrDueToMoveCStr) {
     std::array<CompilerType, 1> args{t.GetRValueReferenceType()};
     CompilerType function_type = m_ast->CreateFunctionType(
         return_type, args, /*variadic=*/false, /*quals*/ 0U);
-    m_ast->AddMethodToCXXRecordType(
-        t.GetOpaqueQualType(), class_name, /*asm_label=*/{}, function_type,
-        lldb::AccessType::eAccessPublic, is_virtual, is_static, is_inline,
-        is_explicit, is_attr_used, is_artificial);
+    m_ast->AddMethodToCXXRecordType(t.GetOpaqueQualType(), class_name,
+                                    /*asm_label=*/{}, function_type, is_virtual,
+                                    is_static, is_inline, is_explicit,
+                                    is_attr_used, is_artificial);
   }
   // Create a copy constructor.
   {
@@ -1157,10 +1157,10 @@ TEST_F(TestTypeSystemClang, TestNotDeletingUserCopyCstrDueToMoveCStr) {
     CompilerType function_type =
         m_ast->CreateFunctionType(return_type, args,
                                   /*variadic=*/false, /*quals*/ 0U);
-    m_ast->AddMethodToCXXRecordType(
-        t.GetOpaqueQualType(), class_name, /*asm_label=*/{}, function_type,
-        lldb::AccessType::eAccessPublic, is_virtual, is_static, is_inline,
-        is_explicit, is_attr_used, is_artificial);
+    m_ast->AddMethodToCXXRecordType(t.GetOpaqueQualType(), class_name,
+                                    /*asm_label=*/{}, function_type, is_virtual,
+                                    is_static, is_inline, is_explicit,
+                                    is_attr_used, is_artificial);
   }
 
   // Complete the definition and check the created record.
@@ -1268,10 +1268,10 @@ TEST_F(TestTypeSystemClang, AddMethodToCXXRecordType_ParmVarDecls) {
   CompilerType function_type =
       m_ast->CreateFunctionType(return_type, param_types,
                                 /*variadic=*/false, /*quals*/ 0U);
-  m_ast->AddMethodToCXXRecordType(
-      t.GetOpaqueQualType(), "myFunc", /*asm_label=*/{}, function_type,
-      lldb::AccessType::eAccessPublic, is_virtual, is_static, is_inline,
-      is_explicit, is_attr_used, is_artificial);
+  m_ast->AddMethodToCXXRecordType(t.GetOpaqueQualType(), "myFunc",
+                                  /*asm_label=*/{}, function_type, is_virtual,
+                                  is_static, is_inline, is_explicit,
+                                  is_attr_used, is_artificial);
 
   // Complete the definition and check the created record.
   m_ast->CompleteTagDeclarationDefinition(t);
@@ -1397,24 +1397,22 @@ TEST_F(TestTypeSystemClang, AsmLabel_CtorDtor) {
       m_ast->CreateFunctionType(return_type, {},
                                 /*variadic=*/false, /*quals*/ 0U);
   auto *ctor_nolabel = m_ast->AddMethodToCXXRecordType(
-      t.GetOpaqueQualType(), "S", /*asm_label=*/{}, function_type,
-      lldb::AccessType::eAccessPublic, is_virtual, is_static, is_inline,
-      is_explicit, is_attr_used, is_artificial);
+      t.GetOpaqueQualType(), "S", /*asm_label=*/{}, function_type, is_virtual,
+      is_static, is_inline, is_explicit, is_attr_used, is_artificial);
 
   auto *dtor_nolabel = m_ast->AddMethodToCXXRecordType(
-      t.GetOpaqueQualType(), "~S", /*asm_label=*/{}, function_type,
-      lldb::AccessType::eAccessPublic, is_virtual, is_static, is_inline,
-      is_explicit, is_attr_used, is_artificial);
+      t.GetOpaqueQualType(), "~S", /*asm_label=*/{}, function_type, is_virtual,
+      is_static, is_inline, is_explicit, is_attr_used, is_artificial);
 
   auto *ctor = m_ast->AddMethodToCXXRecordType(
       t.GetOpaqueQualType(), "S", /*asm_label=*/"$__lldb_func::0x0:0x0:S",
-      function_type, lldb::AccessType::eAccessPublic, is_virtual, is_static,
-      is_inline, is_explicit, is_attr_used, is_artificial);
+      function_type, is_virtual, is_static, is_inline, is_explicit,
+      is_attr_used, is_artificial);
 
   auto *dtor = m_ast->AddMethodToCXXRecordType(
       t.GetOpaqueQualType(), "~S", /*asm_label=*/"$__lldb_func::0x0:0x0:~S",
-      function_type, lldb::AccessType::eAccessPublic, is_virtual, is_static,
-      is_inline, is_explicit, is_attr_used, is_artificial);
+      function_type, is_virtual, is_static, is_inline, is_explicit,
+      is_attr_used, is_artificial);
 
   m_ast->CompleteTagDeclarationDefinition(t);
 

--- a/lldb/unittests/TestingSupport/Symbol/ClangTestUtils.h
+++ b/lldb/unittests/TestingSupport/Symbol/ClangTestUtils.h
@@ -25,8 +25,7 @@ inline CompilerType
 createRecord(TypeSystemClang &ast, llvm::StringRef name,
              lldb::LanguageType lang = lldb::LanguageType::eLanguageTypeC) {
   return ast.CreateRecordType(ast.getASTContext().getTranslationUnitDecl(),
-                              OptionalClangModuleID(),
-                              lldb::AccessType::eAccessPublic, name, 0, lang);
+                              OptionalClangModuleID(), name, 0, lang);
 }
 
 /// Create a record with the given name and a field with the given type
@@ -38,8 +37,7 @@ inline CompilerType createRecordWithField(
   CompilerType t = createRecord(ast, record_name, lang);
 
   TypeSystemClang::StartTagDeclarationDefinition(t);
-  ast.AddFieldToRecordType(t, field_name, field_type,
-                           lldb::AccessType::eAccessPublic, 7);
+  ast.AddFieldToRecordType(t, field_name, field_type, 7);
   TypeSystemClang::CompleteTagDeclarationDefinition(t);
 
   return t;


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/182956 we stopped using the access specifiers and unconditionally set all access to `AS_public`. This patch is a follow-up cleanup to remove all the `AccessType` parameters of the `TypeSystemClang` APIs (which since https://github.com/llvm/llvm-project/pull/182956  are never used)