### PR TITLE
[Support] Fix APFloat conversion crash on zero-bit APInt

### DIFF
--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -2775,6 +2775,12 @@ IEEEFloat::convertToInteger(MutableArrayRef<integerPart> parts,
    point number is not modified.  */
 APFloat::opStatus IEEEFloat::convertFromUnsignedParts(
     const integerPart *src, unsigned int srcCount, roundingMode rounding_mode) {
+  if (srcCount == 0) {
+    category = fcZero;
+    sign = false;
+    return APFloat::opOK;
+  }
+
   unsigned int omsb, precision, dstCount;
   integerPart *dst;
   lostFraction lost_fraction;


### PR DESCRIPTION
### Summary
This PR resolves https://github.com/llvm/llvm-project/issues/180463