### PR TITLE
[ConstantFolding] Respect AllowNonDeterministic when flushing denormals

### DIFF
--- a/llvm/include/llvm/Analysis/ConstantFolding.h
+++ b/llvm/include/llvm/Analysis/ConstantFolding.h
@@ -117,7 +117,7 @@ ConstantFoldFPInstOperands(unsigned Opcode, Constant *LHS, Constant *RHS,
 /// If the calling function's denormal_fpenv input mode is dynamic for the
 /// floating-point type, returns nullptr for denormal inputs.
 LLVM_ABI Constant *FlushFPConstant(Constant *Operand, const Instruction *I,
-                                   bool IsOutput);
+                                   bool IsOutput, bool AllowNonDeterministic);
 
 /// Attempt to constant fold a cast with the specified operand.  If it
 /// fails, it returns a constant expression of the specified operand.

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -1297,10 +1297,13 @@ Constant *llvm::ConstantFoldCompareInstOperands(
   if (CmpInst::isFPPredicate(Predicate)) {
     // Flush any denormal constant float input according to denormal handling
     // mode.
-    Ops0 = FlushFPConstant(Ops0, I, /*IsOutput=*/false);
+    // TODO: Pass through AllowNonDeterministic flag.
+    Ops0 = FlushFPConstant(Ops0, I, /*IsOutput=*/false,
+                           /*AllowNonDeterministic=*/true);
     if (!Ops0)
       return nullptr;
-    Ops1 = FlushFPConstant(Ops1, I, /*IsOutput=*/false);
+    Ops1 = FlushFPConstant(Ops1, I, /*IsOutput=*/false,
+                           /*AllowNonDeterministic=*/true);
     if (!Ops1)
       return nullptr;
   }
@@ -1329,7 +1332,12 @@ Constant *llvm::ConstantFoldBinaryOpOperands(unsigned Opcode, Constant *LHS,
 }
 
 static ConstantFP *flushDenormalConstant(Type *Ty, const APFloat &APF,
-                                         DenormalMode::DenormalModeKind Mode) {
+                                         DenormalMode::DenormalModeKind Mode,
+                                         bool AllowNonDeterministic) {
+  // All modes apart from ieee are non-deterministic.
+  if (!AllowNonDeterministic && Mode != DenormalMode::IEEE)
+    return nullptr;
+
   switch (Mode) {
   case DenormalMode::Dynamic:
     return nullptr;
@@ -1359,20 +1367,22 @@ static DenormalMode getInstrDenormalMode(const Instruction *CtxI, Type *Ty) {
 
 static ConstantFP *flushDenormalConstantFP(ConstantFP *CFP,
                                            const Instruction *Inst,
-                                           bool IsOutput) {
+                                           bool IsOutput,
+                                           bool AllowNonDeterministic) {
   const APFloat &APF = CFP->getValueAPF();
   if (!APF.isDenormal())
     return CFP;
 
   DenormalMode Mode = getInstrDenormalMode(Inst, CFP->getType());
   return flushDenormalConstant(CFP->getType(), APF,
-                               IsOutput ? Mode.Output : Mode.Input);
+                               IsOutput ? Mode.Output : Mode.Input,
+                               AllowNonDeterministic);
 }
 
 Constant *llvm::FlushFPConstant(Constant *Operand, const Instruction *Inst,
-                                bool IsOutput) {
+                                bool IsOutput, bool AllowNonDeterministic) {
   if (ConstantFP *CFP = dyn_cast<ConstantFP>(Operand))
-    return flushDenormalConstantFP(CFP, Inst, IsOutput);
+    return flushDenormalConstantFP(CFP, Inst, IsOutput, AllowNonDeterministic);
 
   if (isa<ConstantAggregateZero, UndefValue>(Operand))
     return Operand;
@@ -1381,7 +1391,8 @@ Constant *llvm::FlushFPConstant(Constant *Operand, const Instruction *Inst,
   VectorType *VecTy = dyn_cast<VectorType>(Ty);
   if (VecTy) {
     if (auto *Splat = dyn_cast_or_null<ConstantFP>(Operand->getSplatValue())) {
-      ConstantFP *Folded = flushDenormalConstantFP(Splat, Inst, IsOutput);
+      ConstantFP *Folded =
+          flushDenormalConstantFP(Splat, Inst, IsOutput, AllowNonDeterministic);
       if (!Folded)
         return nullptr;
       return ConstantVector::getSplat(VecTy->getElementCount(), Folded);
@@ -1406,7 +1417,8 @@ Constant *llvm::FlushFPConstant(Constant *Operand, const Instruction *Inst,
       if (!CFP)
         return nullptr;
 
-      ConstantFP *Folded = flushDenormalConstantFP(CFP, Inst, IsOutput);
+      ConstantFP *Folded =
+          flushDenormalConstantFP(CFP, Inst, IsOutput, AllowNonDeterministic);
       if (!Folded)
         return nullptr;
       NewElts.push_back(Folded);
@@ -1424,7 +1436,8 @@ Constant *llvm::FlushFPConstant(Constant *Operand, const Instruction *Inst,
       } else {
         DenormalMode Mode = getInstrDenormalMode(Inst, Ty);
         ConstantFP *Folded =
-            flushDenormalConstant(Ty, Elt, IsOutput ? Mode.Output : Mode.Input);
+            flushDenormalConstant(Ty, Elt, IsOutput ? Mode.Output : Mode.Input,
+                                  AllowNonDeterministic);
         if (!Folded)
           return nullptr;
         NewElts.push_back(Folded);
@@ -1443,10 +1456,12 @@ Constant *llvm::ConstantFoldFPInstOperands(unsigned Opcode, Constant *LHS,
                                            bool AllowNonDeterministic) {
   if (Instruction::isBinaryOp(Opcode)) {
     // Flush denormal inputs if needed.
-    Constant *Op0 = FlushFPConstant(LHS, I, /* IsOutput */ false);
+    Constant *Op0 =
+        FlushFPConstant(LHS, I, /*IsOutput=*/false, AllowNonDeterministic);
     if (!Op0)
       return nullptr;
-    Constant *Op1 = FlushFPConstant(RHS, I, /* IsOutput */ false);
+    Constant *Op1 =
+        FlushFPConstant(RHS, I, /*IsOutput=*/false, AllowNonDeterministic);
     if (!Op1)
       return nullptr;
 
@@ -1465,7 +1480,7 @@ Constant *llvm::ConstantFoldFPInstOperands(unsigned Opcode, Constant *LHS,
       return nullptr;
 
     // Flush denormal output if needed.
-    C = FlushFPConstant(C, I, /* IsOutput */ true);
+    C = FlushFPConstant(C, I, /*IsOutput=*/true, AllowNonDeterministic);
     if (!C)
       return nullptr;
 

--- a/llvm/test/Analysis/ScalarEvolution/exhaustive-trip-counts.ll
+++ b/llvm/test/Analysis/ScalarEvolution/exhaustive-trip-counts.ll
@@ -227,10 +227,9 @@ exit:
 define i64 @test_fp_fdiv_denormal_preservesign() denormal_fpenv(preservesign) {
 ; CHECK-LABEL: 'test_fp_fdiv_denormal_preservesign'
 ; CHECK-NEXT:  Determining loop execution counts for: @test_fp_fdiv_denormal_preservesign
-; CHECK-NEXT:  Loop %loop: backedge-taken count is i32 16
-; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i32 16
-; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is i32 16
-; CHECK-NEXT:  Loop %loop: Trip multiple is 17
+; CHECK-NEXT:  Loop %loop: Unpredictable backedge-taken count.
+; CHECK-NEXT:  Loop %loop: Unpredictable constant max backedge-taken count.
+; CHECK-NEXT:  Loop %loop: Unpredictable symbolic max backedge-taken count.
 ;
 entry:
   br label %loop
@@ -251,10 +250,9 @@ exit:
 define i64 @test_fp_fdiv_denormal_positivezero() denormal_fpenv(preservesign) {
 ; CHECK-LABEL: 'test_fp_fdiv_denormal_positivezero'
 ; CHECK-NEXT:  Determining loop execution counts for: @test_fp_fdiv_denormal_positivezero
-; CHECK-NEXT:  Loop %loop: backedge-taken count is i32 16
-; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i32 16
-; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is i32 16
-; CHECK-NEXT:  Loop %loop: Trip multiple is 17
+; CHECK-NEXT:  Loop %loop: Unpredictable backedge-taken count.
+; CHECK-NEXT:  Loop %loop: Unpredictable constant max backedge-taken count.
+; CHECK-NEXT:  Loop %loop: Unpredictable symbolic max backedge-taken count.
 ;
 entry:
   br label %loop

--- a/llvm/test/Analysis/ScalarEvolution/exhaustive-trip-counts.ll
+++ b/llvm/test/Analysis/ScalarEvolution/exhaustive-trip-counts.ll
@@ -177,6 +177,102 @@ exit:
   ret i64 %iv
 }
 
+define i64 @test_fp_fdiv_denormal_ieee() {
+; CHECK-LABEL: 'test_fp_fdiv_denormal_ieee'
+; CHECK-NEXT:  Determining loop execution counts for: @test_fp_fdiv_denormal_ieee
+; CHECK-NEXT:  Loop %loop: backedge-taken count is i32 39
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i32 39
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is i32 39
+; CHECK-NEXT:  Loop %loop: Trip multiple is 40
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %fv = phi float [ 0x3900000000000000, %entry ], [ %fv.next, %loop ]
+  call void @use.f32(float %fv)
+  %fv.next = fdiv float %fv, 2.0
+  %iv.next = add i64 %iv, 1
+  %fcmp = fcmp one float %fv, 0.0
+  br i1 %fcmp, label %loop, label %exit
+
+exit:
+  ret i64 %iv
+}
+
+define i64 @test_fp_fdiv_denormal_dynamic() denormal_fpenv(dynamic) {
+; CHECK-LABEL: 'test_fp_fdiv_denormal_dynamic'
+; CHECK-NEXT:  Determining loop execution counts for: @test_fp_fdiv_denormal_dynamic
+; CHECK-NEXT:  Loop %loop: Unpredictable backedge-taken count.
+; CHECK-NEXT:  Loop %loop: Unpredictable constant max backedge-taken count.
+; CHECK-NEXT:  Loop %loop: Unpredictable symbolic max backedge-taken count.
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %fv = phi float [ 0x3900000000000000, %entry ], [ %fv.next, %loop ]
+  call void @use.f32(float %fv)
+  %fv.next = fdiv float %fv, 2.0
+  %iv.next = add i64 %iv, 1
+  %fcmp = fcmp one float %fv, 0.0
+  br i1 %fcmp, label %loop, label %exit
+
+exit:
+  ret i64 %iv
+}
+
+define i64 @test_fp_fdiv_denormal_preservesign() denormal_fpenv(preservesign) {
+; CHECK-LABEL: 'test_fp_fdiv_denormal_preservesign'
+; CHECK-NEXT:  Determining loop execution counts for: @test_fp_fdiv_denormal_preservesign
+; CHECK-NEXT:  Loop %loop: backedge-taken count is i32 16
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i32 16
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is i32 16
+; CHECK-NEXT:  Loop %loop: Trip multiple is 17
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %fv = phi float [ 0x3900000000000000, %entry ], [ %fv.next, %loop ]
+  call void @use.f32(float %fv)
+  %fv.next = fdiv float %fv, 2.0
+  %iv.next = add i64 %iv, 1
+  %fcmp = fcmp one float %fv, 0.0
+  br i1 %fcmp, label %loop, label %exit
+
+exit:
+  ret i64 %iv
+}
+
+define i64 @test_fp_fdiv_denormal_positivezero() denormal_fpenv(preservesign) {
+; CHECK-LABEL: 'test_fp_fdiv_denormal_positivezero'
+; CHECK-NEXT:  Determining loop execution counts for: @test_fp_fdiv_denormal_positivezero
+; CHECK-NEXT:  Loop %loop: backedge-taken count is i32 16
+; CHECK-NEXT:  Loop %loop: constant max backedge-taken count is i32 16
+; CHECK-NEXT:  Loop %loop: symbolic max backedge-taken count is i32 16
+; CHECK-NEXT:  Loop %loop: Trip multiple is 17
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %loop ]
+  %fv = phi float [ 0x3900000000000000, %entry ], [ %fv.next, %loop ]
+  call void @use.f32(float %fv)
+  %fv.next = fdiv float %fv, 2.0
+  %iv.next = add i64 %iv, 1
+  %fcmp = fcmp one float %fv, 0.0
+  br i1 %fcmp, label %loop, label %exit
+
+exit:
+  ret i64 %iv
+}
+
 declare void @dummy()
-declare void @use(double %i)
+declare void @use(double)
+declare void @use.f32(float)
 declare double @llvm.sin.f64(double)


### PR DESCRIPTION
Apart from IEEE, all the denormal modes flush non-deterministically, so we should respect the AllowNonDeterministic flag.

In particular, this makes sure that SCEV does not compute brute-force exit counts for cases where the exit count depends on whether denormal flushing occurs or not.