### PR TITLE
[llvm][release] Link to .jsonl signatures for Windows x86_64 and ARM64

### DIFF
--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -102,9 +102,9 @@ release_links = (
             "* Windows x64 (64-bit): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
             (
                 "LLVM-{release}-win64.exe",
-                "LLVM-{release}-win64.exe.sig",
+                "LLVM-{release}-win64.exe.jsonl",
                 "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz",
-                "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz.sig",
+                "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz.jsonl",
             ),
         ),
         (
@@ -117,9 +117,9 @@ release_links = (
             "* Windows on Arm (ARM64): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
             (
                 "LLVM-{release}-woa64.exe",
-                "LLVM-{release}-woa64.exe.sig",
+                "LLVM-{release}-woa64.exe.jsonl",
                 "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz",
-                "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz.sig",
+                "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz.jsonl",
             ),
         ),
     ),


### PR DESCRIPTION
Previously we linked to .sig files, which were created by the person who built the release.

Now these are built in GitHub so they have .jsonl signature files instead.