### PR TITLE
[ValueTracking] impliesPoison(V, Cond ? V : V) = true

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -7630,6 +7630,12 @@ static bool directlyImpliesPoison(const Value *ValAssumedPoison, const Value *V,
         (match(ValAssumedPoison, m_ExtractValue(m_Specific(II))) ||
          llvm::is_contained(II->args(), ValAssumedPoison)))
       return true;
+
+    // If both arms of the select are the same, then it can only return that
+    // value and that value is poison now.
+    if (match(I, m_Select(m_Value(), m_Specific(ValAssumedPoison),
+                          m_Specific(ValAssumedPoison))))
+      return true;
   }
   return false;
 }

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -902,7 +902,7 @@ TEST_F(ValueTrackingTest, impliesPoison_Select_SameArm) {
                 "  ret void\n"
                 "}");
   EXPECT_TRUE(impliesPoison(A, A4));
-  EXPECT_FALSE(impliesPoison(A2, A4));
+  EXPECT_TRUE(impliesPoison(A2, A4));
 
   EXPECT_FALSE(impliesPoison(A4, A));
   EXPECT_FALSE(impliesPoison(A4, A2));


### PR DESCRIPTION
Extend `impliesPoison` (or rather `directlyImpliesPoison`, which is called by `impliesPoison`) to handle the case where a `select` instructions both arms are the `ValueAssumedPoison`. In that case only poison can result from the `select`.