### PR TITLE
[SPIRV] Simplify `selectPhi` and remove unreachable code

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -403,7 +403,6 @@ void SPIRVTargetLowering::finalizeLowering(MachineFunction &MF) const {
   GR.setCurrentFunc(MF);
   for (MachineFunction::iterator I = MF.begin(), E = MF.end(); I != E; ++I) {
     MachineBasicBlock *MBB = &*I;
-    SmallPtrSet<MachineInstr *, 8> ToMove;
     for (MachineBasicBlock::iterator MBBI = MBB->begin(), MBBE = MBB->end();
          MBBI != MBBE;) {
       MachineInstr &MI = *MBBI++;
@@ -523,16 +522,6 @@ void SPIRVTargetLowering::finalizeLowering(MachineFunction &MF) const {
             MI.removeOperand(i);
         }
       } break;
-      case SPIRV::OpPhi: {
-        // Phi refers to a type definition that goes after the Phi
-        // instruction, so that the virtual register definition of the type
-        // doesn't dominate all uses. Let's place the type definition
-        // instruction at the end of the predecessor.
-        MachineBasicBlock *Curr = MI.getParent();
-        SPIRVTypeInst Type = GR.getSPIRVTypeForVReg(MI.getOperand(1).getReg());
-        if (Type->getParent() == Curr && !Curr->pred_empty())
-          ToMove.insert(const_cast<MachineInstr *>(&*Type));
-      } break;
       case SPIRV::OpExtInst: {
         // prefetch
         if (!MI.getOperand(2).isImm() || !MI.getOperand(3).isImm() ||
@@ -578,11 +567,6 @@ void SPIRVTargetLowering::finalizeLowering(MachineFunction &MF) const {
         }
       } break;
       }
-    }
-    for (MachineInstr *MI : ToMove) {
-      MachineBasicBlock *Curr = MI->getParent();
-      MachineBasicBlock *Pred = *Curr->pred_begin();
-      Pred->insert(Pred->getFirstTerminator(), Curr->remove_instr(MI));
     }
   }
   ProcessedMF.insert(&MF);

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -307,8 +307,7 @@ private:
   bool selectBranch(MachineInstr &I) const;
   bool selectBranchCond(MachineInstr &I) const;
 
-  bool selectPhi(Register ResVReg, SPIRVTypeInst ResType,
-                 MachineInstr &I) const;
+  bool selectPhi(Register ResVReg, MachineInstr &I) const;
 
   bool selectExtInst(Register ResVReg, SPIRVTypeInst RestType, MachineInstr &I,
                      GL::GLSLExtInst GLInst) const;
@@ -945,7 +944,7 @@ bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
     return selectBranchCond(I);
 
   case TargetOpcode::G_PHI:
-    return selectPhi(ResVReg, ResType, I);
+    return selectPhi(ResVReg, I);
 
   case TargetOpcode::G_FPTOSI:
     return selectUnOp(ResVReg, ResType, I, SPIRV::OpConvertFToS);
@@ -5143,19 +5142,16 @@ bool SPIRVInstructionSelector::selectBranchCond(MachineInstr &I) const {
 }
 
 bool SPIRVInstructionSelector::selectPhi(Register ResVReg,
-                                         SPIRVTypeInst ResType,
                                          MachineInstr &I) const {
-  auto MIB = BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(SPIRV::OpPhi))
-                 .addDef(ResVReg)
-                 .addUse(GR.getSPIRVTypeID(ResType));
+  auto MIB =
+      BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(TargetOpcode::PHI))
+          .addDef(ResVReg);
   const unsigned NumOps = I.getNumOperands();
   for (unsigned i = 1; i < NumOps; i += 2) {
     MIB.addUse(I.getOperand(i + 0).getReg());
     MIB.addMBB(I.getOperand(i + 1).getMBB());
   }
   MIB.constrainAllUses(TII, TRI, RBI);
-  MIB->setDesc(TII.get(TargetOpcode::PHI));
-  MIB->removeOperand(1);
   return true;
 }
 


### PR DESCRIPTION
Before it created a `OpPhi` with a Type argument, to immediately remove this Type and change the opcode to `PHI`.

Only `TargetOpcode::PHI` get to `SPIRVTargetLowering::finalizeLowering`.

The `TargetOpcode::PHI` gets lowered to `SPIRV::OpPhi` much later, by `patchPhi` in the `SPIRVModuleAnalysis`.

---

`SPIRVModuleAnalysis` is not executed directly, it's requested by the `SPIRVAsmPrinter` through `getAnalysisUsage` and executed by the pass manager.

```cpp
void SPIRVAsmPrinter::getAnalysisUsage(AnalysisUsage &AU) const {
  AU.addRequired<SPIRVModuleAnalysis>();
  AU.addPreserved<SPIRVModuleAnalysis>();
  AsmPrinter::getAnalysisUsage(AU);
}
```