### PR TITLE
[LV] Restrict scalable vectorization to targets with power-of-2 vscale

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -25717,9 +25717,6 @@ bool RISCVTargetLowering::isVScaleKnownToBeAPowerOfTwo() const {
   // We define vscale to be VLEN/RVVBitsPerBlock.  VLEN is always a power
   // of two >= 64, and RVVBitsPerBlock is 64.  Thus, vscale must be
   // a power of two as well.
-  // FIXME: This doesn't work for zve32, but that's already broken
-  // elsewhere for the same reason.
-  assert(Subtarget.getRealMinVLen() >= 64 && "zve32* unsupported");
   static_assert(RISCV::RVVBitsPerBlock == 64,
                 "RVVBitsPerBlock changed, audit needed");
   return true;

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -296,9 +296,9 @@ cl::opt<unsigned> llvm::ForceTargetInstructionCost(
 
 static cl::opt<bool> ForceTargetSupportsScalableVectors(
     "force-target-supports-scalable-vectors", cl::init(false), cl::Hidden,
-    cl::desc(
-        "Pretend that scalable vectors are supported, even if the target does "
-        "not support them. This flag should only be used for testing."));
+    cl::desc("Pretend that scalable vectors are supported and vscale is a "
+             "power of two, even if the target does "
+             "not support them. This flag should only be used for testing."));
 
 static cl::opt<unsigned> SmallLoopCost(
     "small-loop-cost", cl::init(20), cl::Hidden,
@@ -3385,6 +3385,10 @@ bool LoopVectorizationCostModel::isScalableVectorizationAllowed() {
 
   IsScalableVectorizationAllowed = false;
   if (!TTI.supportsScalableVectors() && !ForceTargetSupportsScalableVectors)
+    return false;
+
+  if (!TTI.isVScaleKnownToBeAPowerOfTwo() &&
+      !ForceTargetSupportsScalableVectors)
     return false;
 
   if (Hints->isScalableVectorizationDisabled()) {


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/145098 we are proposing to restrict vscale to always be a power of 2.

This PR proposes to go ahead and remove support for non-power-of-2 vscales in the loop vectorizer independently of the LangRef. Given we don't have any targets with scalable vector support with non-power-of-2 vscales, this is essentially NFC.

The main benefit of this is that it means the IV can't overflow with tail folding anymore. This remove a lot of checks, both at runtime and statically, and simplifies other areas:

- We can remove the vscale-power-of-2 runtime check code, which isn't emitted on any target
- We can remove IVUpdateMayOverflow as it's now always false
- addMinimumIterationCheck doesn't need to check for IV overflow
- We don't need to drop nuw on the canonical IV when tail folding anymore
- We don't need to store two separate values for the tail folding style, (one for iv overflow, one without)
- I think we can remove TailFoldingStyle::DataAndControlFlowWithoutRuntimeCheck, since that's only used by SVE when the IV can overflow. But AFAIK that can't happen on SVE since it has power of two vscale.

I plan to post patches stacked on top of this for these to show how they can be removed. This patch just restricts it for now to show how no tests are affected.
