### PR TITLE
[ARM] tADDrSPi no side effects change

### DIFF
--- a/llvm/lib/Target/ARM/ARMInstrThumb.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb.td
@@ -397,9 +397,6 @@ def tPICADD : TIt<(outs GPR:$dst), (ins GPR:$lhs, pclabel:$cp), IIC_iALUr, "",
 }
 
 // ADD <Rd>, sp, #<imm8>
-// FIXME: This should not be marked as having side effects, and it should be
-// rematerializable. Clearing the side effect bit causes miscompilations,
-// probably because the instruction can be moved around.
 def tADDrSPi : T1pI<(outs tGPR:$dst), (ins GPRsp:$sp, t_imm0_1020s4:$imm),
                     IIC_iALUi, "add", "\t$dst, $sp, $imm", []>,
                T1Encoding<{1,0,1,0,1,?}>, Sched<[WriteALU]> {
@@ -409,6 +406,7 @@ def tADDrSPi : T1pI<(outs tGPR:$dst), (ins GPRsp:$sp, t_imm0_1020s4:$imm),
   let Inst{10-8} = dst;
   let Inst{7-0}  = imm;
   let DecoderMethod = "DecodeThumbAddSpecialReg";
+  let hasSideEffects = 0;
 }
 
 // Thumb1 frame lowering is rather fragile, we hope to be able to use

--- a/llvm/test/tools/llvm-mca/ARM/simple-cortex-m33.s
+++ b/llvm/test/tools/llvm-mca/ARM/simple-cortex-m33.s
@@ -2,6 +2,7 @@
 # RUN: llvm-mca -mtriple=thumbv7 --mcpu=cortex-m33 -instruction-tables -o - %s | FileCheck %s
 
 sub sp, #4
+add r2, sp, #4
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -13,14 +14,16 @@ sub sp, #4
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      1     1.00                        sub	sp, #4
+# CHECK-NEXT:  1      1     1.00                        add	r2, sp, #4
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - M4Unit
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]
-# CHECK-NEXT: 1.00
+# CHECK-NEXT: 2.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    Instructions:
 # CHECK-NEXT: 1.00   sub	sp, #4
+# CHECK-NEXT: 1.00   add	r2, sp, #4


### PR DESCRIPTION
This is pulled out of #182771 in case it causes issues.  The mis-compile I believe is no longer present, as tADDrSPi is used in several test cases which do not change due to of marking tADDrSPi as not affect side effects.