### PR TITLE
[IR] Specify alloca with poison element count

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -11613,6 +11613,8 @@ See :ref:`llvm.lifetime.start <int_lifestart>` and
 :ref:`llvm.lifetime.end <int_lifeend>` for the precise semantics of
 lifetime-manipulating intrinsics.
 
+If the element count is ``poison``, this instruction has undefined behavior.
+
 Example:
 """"""""
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -11613,7 +11613,8 @@ See :ref:`llvm.lifetime.start <int_lifestart>` and
 :ref:`llvm.lifetime.end <int_lifeend>` for the precise semantics of
 lifetime-manipulating intrinsics.
 
-If the element count is ``poison``, this instruction has undefined behavior.
+If the element count is ``undef`` or ``poison``, this instruction has undefined
+behavior.
 
 Example:
 """"""""


### PR DESCRIPTION
An alloca with a poison element count is undefined behavior.

This matches existing behavior of optimizations. This also matches the behavior of llubui for `poison`, but llubi currently does not report immediate UB for `undef` element counts. A future patch will fix that.