### PR TITLE
[NFC][RegisterInfoEmitter] Add target name prefix for a few variables

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -272,12 +272,14 @@ private:
   unsigned HwMode;
 
 protected:
-  TargetRegisterInfo(const TargetRegisterInfoDesc *ID, regclass_iterator RCB,
-                     regclass_iterator RCE, const char *SRIStrings,
-                     ArrayRef<uint32_t> SRINameOffsets,
-                     const SubRegCoveredBits *SubIdxRanges,
-                     const LaneBitmask *SRILaneMasks, LaneBitmask CoveringLanes,
-                     const RegClassInfo *const RCIs,
+  TargetRegisterInfo(const TargetRegisterInfoDesc *ID,
+                     ArrayRef<const TargetRegisterClass *> RegisterClasses,
+                     const char *SubRegIndexStrings,
+                     ArrayRef<uint32_t> SubRegIndexNameOffsets,
+                     const SubRegCoveredBits *SubRegIdxRanges,
+                     const LaneBitmask *SubRegIndexLaneMasks,
+                     LaneBitmask CoveringLanes,
+                     const RegClassInfo *const RCInfos,
                      const MVT::SimpleValueType *const RCVTLists,
                      unsigned Mode = 0);
 

--- a/llvm/lib/CodeGen/TargetRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/TargetRegisterInfo.cpp
@@ -50,17 +50,20 @@ static cl::opt<unsigned>
                      cl::init(5000));
 
 TargetRegisterInfo::TargetRegisterInfo(
-    const TargetRegisterInfoDesc *ID, regclass_iterator RCB,
-    regclass_iterator RCE, const char *SRIStrings,
-    ArrayRef<uint32_t> SRINameOffsets, const SubRegCoveredBits *SubIdxRanges,
-    const LaneBitmask *SRILaneMasks, LaneBitmask SRICoveringLanes,
-    const RegClassInfo *const RCIs, const MVT::SimpleValueType *const RCVTLists,
-    unsigned Mode)
-    : InfoDesc(ID), SubRegIndexStrings(SRIStrings),
-      SubRegIndexNameOffsets(SRINameOffsets), SubRegIdxRanges(SubIdxRanges),
-      SubRegIndexLaneMasks(SRILaneMasks), RegClassBegin(RCB), RegClassEnd(RCE),
-      CoveringLanes(SRICoveringLanes), RCInfos(RCIs), RCVTLists(RCVTLists),
-      HwMode(Mode) {}
+    const TargetRegisterInfoDesc *ID,
+    ArrayRef<const TargetRegisterClass *> RegisterClasses,
+    const char *SubRegIndexStrings, ArrayRef<uint32_t> SubRegIndexNameOffsets,
+    const SubRegCoveredBits *SubRegIdxRanges,
+    const LaneBitmask *SubRegIndexLaneMasks, LaneBitmask CoveringLanes,
+    const RegClassInfo *const RCInfos,
+    const MVT::SimpleValueType *const RCVTLists, unsigned Mode)
+    : InfoDesc(ID), SubRegIndexStrings(SubRegIndexStrings),
+      SubRegIndexNameOffsets(SubRegIndexNameOffsets),
+      SubRegIdxRanges(SubRegIdxRanges),
+      SubRegIndexLaneMasks(SubRegIndexLaneMasks),
+      RegClassBegin(RegisterClasses.begin()),
+      RegClassEnd(RegisterClasses.end()), CoveringLanes(CoveringLanes),
+      RCInfos(RCInfos), RCVTLists(RCVTLists), HwMode(Mode) {}
 
 TargetRegisterInfo::~TargetRegisterInfo() = default;
 

--- a/llvm/test/TableGen/RegisterInfoEmitter-BaseClassOrder.td
+++ b/llvm/test/TableGen/RegisterInfoEmitter-BaseClassOrder.td
@@ -28,7 +28,7 @@ def BaseC : RegisterClass<"MyTarget", [i32], 32, (sequence "R%u", 2, 3)> {
 
 def MyTarget : Target;
 
-// CHECK:      static const uint16_t Mapping[8] = {
+// CHECK:      static constexpr uint16_t Mapping[8] = {
 // CHECK-NEXT:   InvalidRegClassID,  // NoRegister
 // CHECK-NEXT:   MyTarget::BaseARegClassID,  // R0
 // CHECK-NEXT:   MyTarget::BaseARegClassID,  // R1

--- a/llvm/test/TableGen/RegisterInfoEmitter-BaseClassOrder.td
+++ b/llvm/test/TableGen/RegisterInfoEmitter-BaseClassOrder.td
@@ -28,7 +28,7 @@ def BaseC : RegisterClass<"MyTarget", [i32], 32, (sequence "R%u", 2, 3)> {
 
 def MyTarget : Target;
 
-// CHECK:      static constexpr uint16_t Mapping[8] = {
+// CHECK:      static const uint16_t Mapping[8] = {
 // CHECK-NEXT:   InvalidRegClassID,  // NoRegister
 // CHECK-NEXT:   MyTarget::BaseARegClassID,  // R0
 // CHECK-NEXT:   MyTarget::BaseARegClassID,  // R1

--- a/llvm/test/TableGen/RegisterInfoEmitter-regcost-list.td
+++ b/llvm/test/TableGen/RegisterInfoEmitter-regcost-list.td
@@ -22,13 +22,13 @@ def DRegs : RegisterClass<"MyTarget", [i32], 32, (sequence "D%u", 0, 1)>;
 
 def MyTarget : Target;
 
-// CHECK:  static const uint8_t CostPerUseTable[] = {
+// CHECK:  static const uint8_t MyTargetCostPerUseTable[] = {
 // CHECK-NEXT:  0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 2, 3, };
 
-// CHECK:  static const bool InAllocatableClassTable[] = {
+// CHECK:  static const bool MyTargetInAllocatableClassTable[] = {
 // CHECK-NEXT:  false, true, true, true, true, true, true, };
 
 // CHECK:  static const TargetRegisterInfoDesc MyTargetRegInfoDesc = { // Extra Descriptors
-// CHECK-NEXT:  CostPerUseTable, 2, InAllocatableClassTable};
+// CHECK-NEXT:  MyTargetCostPerUseTable, 2, MyTargetInAllocatableClassTable};
 
-// CHECK:  TargetRegisterInfo(&MyTargetRegInfoDesc, RegisterClasses, RegisterClasses+2,
+// CHECK:  TargetRegisterInfo(&MyTargetRegInfoDesc, MyTargetRegisterClasses,

--- a/llvm/test/TableGen/RegisterInfoEmitter-regcost-tuple.td
+++ b/llvm/test/TableGen/RegisterInfoEmitter-regcost-tuple.td
@@ -43,10 +43,10 @@ def GPR_128 : MyClass<128, [v4i32], (add GPR128)>;
 
 def MyTarget : Target;
 
-// CHECK: static const uint8_t CostPerUseTable[] = {
+// CHECK: static const uint8_t MyTargetCostPerUseTable[] = {
 // CHECK-NEXT:  0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, };
 
 // CHECK:  static const TargetRegisterInfoDesc MyTargetRegInfoDesc = { // Extra Descriptors
-// CHECK-NEXT:  CostPerUseTable, 2, InAllocatableClassTable};
+// CHECK-NEXT:  MyTargetCostPerUseTable, 2, MyTargetInAllocatableClassTable};
 
-// CHECK:  TargetRegisterInfo(&MyTargetRegInfoDesc, RegisterClasses, RegisterClasses+3,
+// CHECK:  TargetRegisterInfo(&MyTargetRegInfoDesc, MyTargetRegisterClasses,

--- a/llvm/test/TableGen/RegisterInfoEmitter-regcost.td
+++ b/llvm/test/TableGen/RegisterInfoEmitter-regcost.td
@@ -24,13 +24,13 @@ def DRegs : RegisterClass<"MyTarget", [i32], 32, (sequence "D%u", 0, 1)>;
 
 def MyTarget : Target;
 
-// CHECK:  static const uint8_t CostPerUseTable[] = {
+// CHECK:  static const uint8_t MyTargetCostPerUseTable[] = {
 // CHECK-NEXT:  0, 0, 0, 1, 1, 1, 1, };
 
-// CHECK:  static const bool InAllocatableClassTable[] = {
+// CHECK:  static const bool MyTargetInAllocatableClassTable[] = {
 // CHECK-NEXT:  false, true, true, true, true, true, true, };
 
 // CHECK:  static const TargetRegisterInfoDesc MyTargetRegInfoDesc = { // Extra Descriptors
-// CHECK-NEXT:  CostPerUseTable, 1, InAllocatableClassTable};
+// CHECK-NEXT:  MyTargetCostPerUseTable, 1, MyTargetInAllocatableClassTable};
 
-// CHECK:  TargetRegisterInfo(&MyTargetRegInfoDesc, RegisterClasses, RegisterClasses+2,
+// CHECK:  TargetRegisterInfo(&MyTargetRegInfoDesc, MyTargetRegisterClasses,

--- a/llvm/unittests/CodeGen/MFCommon.inc
+++ b/llvm/unittests/CodeGen/MFCommon.inc
@@ -20,14 +20,11 @@ protected:
   bool hasFPImpl(const MachineFunction &MF) const override { return false; }
 };
 
-static TargetRegisterClass *const BogusRegisterClasses[] = {nullptr};
-
 class BogusRegisterInfo : public TargetRegisterInfo {
 public:
   BogusRegisterInfo()
-      : TargetRegisterInfo(nullptr, BogusRegisterClasses, BogusRegisterClasses,
-                           nullptr, {}, nullptr, nullptr, LaneBitmask(~0u),
-                           nullptr, nullptr) {
+      : TargetRegisterInfo(nullptr, {}, nullptr, {}, nullptr, nullptr,
+                           LaneBitmask(~0u), nullptr, nullptr) {
     InitMCRegisterInfo(nullptr, 0, 0, 0, nullptr, 0, nullptr, 0, nullptr,
                        nullptr, nullptr, nullptr, nullptr, 0, nullptr);
   }

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -1691,8 +1691,7 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
          << "::getPhysRegBaseClass(MCRegister Reg)"
          << " const {\n";
       OS << "  static const uint16_t InvalidRegClassID = UINT16_MAX;\n\n";
-      OS << "  static constexpr uint16_t Mapping[" << Regs.size() + 1
-         << "] = {\n";
+      OS << "  static const uint16_t Mapping[" << Regs.size() + 1 << "] = {\n";
       OS << "    InvalidRegClassID,  // NoRegister\n";
       for (const CodeGenRegister &Reg : Regs) {
         const CodeGenRegisterClass *BaseRC = nullptr;

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -1311,6 +1311,7 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
 
   const CodeGenHwModes &CGH = Target.getHwModes();
   unsigned NumModes = CGH.getNumModeIds();
+  StringRef TargetName = Target.getName();
 
   // Build a shared array of value types.
   SequenceToOffsetTable<std::vector<MVT>> VTSeqs(
@@ -1325,11 +1326,11 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
     }
   }
   VTSeqs.layout();
-  OS << "\nstatic const MVT::SimpleValueType VTLists[] = {\n";
+  OS << "\nstatic const MVT::SimpleValueType " << TargetName
+     << "VTLists[] = {\n";
   VTSeqs.emit(OS, printSimpleValueType);
   OS << "};\n";
 
-  StringRef TargetName = Target.getName();
   // Emit SubRegIndex names, skipping 0.
   SequenceToOffsetTable<std::string> SubRegIndexStrings;
   for (const auto &Idx : SubRegIndices)
@@ -1349,8 +1350,8 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
   OS << "};\n\n";
 
   // Emit the table of sub-register index sizes.
-  OS << "static const TargetRegisterInfo::SubRegCoveredBits "
-        "SubRegIdxRangeTable[] = {\n";
+  OS << "static const TargetRegisterInfo::SubRegCoveredBits " << TargetName
+     << "SubRegIdxRangeTable[] = {\n";
   for (unsigned M = 0; M < NumModes; ++M) {
     OS << "  { " << (uint16_t)-1 << ", " << (uint16_t)-1 << " },\n";
     for (const auto &Idx : SubRegIndices) {
@@ -1362,7 +1363,8 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
   OS << "};\n\n";
 
   // Emit SubRegIndex lane masks, including 0.
-  OS << "\nstatic const LaneBitmask SubRegIndexLaneMaskTable[] = {\n  "
+  OS << "\nstatic const LaneBitmask " << TargetName
+     << "SubRegIndexLaneMaskTable[] = {\n  "
         "LaneBitmask::getAll(),\n";
   for (const auto &Idx : SubRegIndices) {
     printMask(OS << "  ", Idx.LaneMask);
@@ -1374,8 +1376,8 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
 
   // Now that all of the structs have been emitted, emit the instances.
   if (!RegisterClasses.empty()) {
-    OS << "\nstatic const TargetRegisterInfo::RegClassInfo RegClassInfos[]"
-       << " = {\n";
+    OS << "\nstatic const TargetRegisterInfo::RegClassInfo " << TargetName
+       << "RegClassInfos[]" << " = {\n";
     for (unsigned M = 0; M < NumModes; ++M) {
       unsigned EV = 0;
       OS << "  // Mode = " << M << " ("
@@ -1391,8 +1393,8 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
         for (const ValueTypeByHwMode &VVT : RC.VTs)
           if (VVT.hasDefault() || VVT.hasMode(M))
             VTs.push_back(VVT.get(M));
-        OS << ", /*VTLists+*/" << VTSeqs.get(VTs) << " },    // "
-           << RC.getName() << '\n';
+        OS << ", /*" << TargetName << "VTLists+*/" << VTSeqs.get(VTs)
+           << " },    // " << RC.getName() << '\n';
       }
     }
     OS << "};\n";
@@ -1496,7 +1498,7 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
 
     // Now emit the actual value-initialized register class instances.
     NamespaceEmitter RegClassNS(OS, RegisterClasses.front().Namespace);
-    OS << "// Register class instances\n";
+    OS << "// Register class instances.\n";
 
     for (const auto &RC : RegisterClasses) {
       OS << "  extern const TargetRegisterClass " << RC.getName()
@@ -1525,13 +1527,11 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
     }
   }
 
-  {
-    AnonNamespaceEmitter AnonNS(OS);
-    OS << "  const TargetRegisterClass *const RegisterClasses[] = {\n";
-    for (const auto &RC : RegisterClasses)
-      OS << "    &" << RC.getQualifiedName() << "RegClass,\n";
-    OS << "  };\n";
-  }
+  OS << "static const TargetRegisterClass *const " << TargetName
+     << "RegisterClasses[] = {\n";
+  for (const auto &RC : RegisterClasses)
+    OS << "    &" << RC.getQualifiedName() << "RegClass,\n";
+  OS << "  };\n";
 
   // Emit extra information about registers.
   const auto &Regs = RegBank.getRegisters();
@@ -1560,15 +1560,14 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
   // Emit the cost values as a 1D-array after grouping them by their indices,
   // i.e. the costs for all registers corresponds to index 0, 1, 2, etc.
   // Size of the emitted array should be NumRegCosts * (Regs.size() + 1).
-  OS << "\nstatic const uint8_t "
-     << "CostPerUseTable[] = { \n";
+  OS << "\nstatic const uint8_t " << TargetName << "CostPerUseTable[] = { \n";
   for (unsigned int I = 0; I < NumRegCosts; ++I) {
     for (unsigned J = I, E = AllRegCostPerUse.size(); J < E; J += NumRegCosts)
       OS << AllRegCostPerUse[J] << ", ";
   }
   OS << "};\n\n";
 
-  OS << "\nstatic const bool "
+  OS << "\nstatic const bool " << TargetName
      << "InAllocatableClassTable[] = { \n";
   for (unsigned I = 0, E = InAllocClass.size(); I < E; ++I) {
     OS << (InAllocClass[I] ? "true" : "false") << ", ";
@@ -1577,9 +1576,9 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
 
   OS << "\nstatic const TargetRegisterInfoDesc " << TargetName
      << "RegInfoDesc = { // Extra Descriptors\n";
-  OS << "CostPerUseTable, " << NumRegCosts << ", "
+  OS << TargetName << "CostPerUseTable, " << NumRegCosts << ", " << TargetName
      << "InAllocatableClassTable";
-  OS << "};\n\n"; // End of register descriptors...
+  OS << "};\n\n"; // End of register descriptors.
 
   std::string ClassName = Target.getName().str() + "GenRegisterInfo";
 
@@ -1692,7 +1691,8 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
          << "::getPhysRegBaseClass(MCRegister Reg)"
          << " const {\n";
       OS << "  static const uint16_t InvalidRegClassID = UINT16_MAX;\n\n";
-      OS << "  static const uint16_t Mapping[" << Regs.size() + 1 << "] = {\n";
+      OS << "  static constexpr uint16_t Mapping[" << Regs.size() + 1
+         << "] = {\n";
       OS << "    InvalidRegClassID,  // NoRegister\n";
       for (const CodeGenRegister &Reg : Regs) {
         const CodeGenRegisterClass *BaseRC = nullptr;
@@ -1712,7 +1712,9 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
             "  unsigned RCID = Mapping[Reg.id()];\n"
             "  if (RCID == InvalidRegClassID)\n"
             "    return nullptr;\n"
-            "  return RegisterClasses[RCID];\n"
+            "  return "
+         << TargetName
+         << "RegisterClasses[RCID];\n"
             "}\n";
     }
   }
@@ -1735,31 +1737,25 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
 {0}::
 {0}(unsigned RA, unsigned DwarfFlavour, unsigned EHFlavour,
     unsigned PC, unsigned HwMode)
-  : TargetRegisterInfo(&{1}RegInfoDesc, RegisterClasses, RegisterClasses+{2},
+  : TargetRegisterInfo(&{1}RegInfoDesc, {1}RegisterClasses,
       {1}SubRegIndexStrings, {1}SubRegIndexNameOffsets,
-      SubRegIdxRangeTable, SubRegIndexLaneMaskTable,
+      {1}SubRegIdxRangeTable, {1}SubRegIndexLaneMaskTable,
 
   )",
-                ClassName, TargetName, RegisterClasses.size());
+                ClassName, TargetName);
   printMask(OS, RegBank.CoveringLanes);
-  OS << ", RegClassInfos, VTLists, HwMode) {\n"
-     << "  InitMCRegisterInfo(" << TargetName << "RegDesc, " << Regs.size() + 1
-     << ", RA, PC,\n                     " << TargetName
-     << "MCRegisterClasses, " << RegisterClasses.size() << ",\n"
-     << "                     " << TargetName << "RegUnitRoots,\n"
-     << "                     " << RegBank.getNumNativeRegUnits() << ",\n"
-     << "                     " << TargetName << "RegDiffLists,\n"
-     << "                     " << TargetName << "LaneMaskLists,\n"
-     << "                     " << TargetName << "RegStrings,\n"
-     << "                     " << TargetName << "RegClassStrings,\n"
-     << "                     " << TargetName << "SubRegIdxLists,\n"
-     << "                     " << SubRegIndicesSize + 1 << ",\n"
-     << "                     " << TargetName << "RegEncodingTable,\n"
-     << "                     "
-     << (Target.getRegistersAreIntervals() ? TargetName + "RegUnitIntervals"
-                                           : "nullptr")
-     << ");\n\n";
+  OS << formatv(R"(, {0}RegClassInfos, {0}VTLists, HwMode) {{
+  InitMCRegisterInfo({0}RegDesc, {1}, RA, PC,
+    {0}MCRegisterClasses, {2}, {0}RegUnitRoots, {3}, {0}RegDiffLists,
+    {0}LaneMaskLists, {0}RegStrings, {0}RegClassStrings, {0}SubRegIdxLists, {4},
+    {0}RegEncodingTable, {5});
 
+)",
+                TargetName, Regs.size() + 1, RegisterClasses.size(),
+                RegBank.getNumNativeRegUnits(), SubRegIndicesSize + 1,
+                Target.getRegistersAreIntervals()
+                    ? TargetName + "RegUnitIntervals"
+                    : Twine("nullptr"));
   EmitRegMapping(OS, Regs, true);
 
   OS << "}\n\n";


### PR DESCRIPTION
Add target name prefix for a few static global variables in the generated code. Also rework the TargetRegisterInfo constructor a bit to use a ArrayRef for array of register classes and rename a few constructor arguments to match the member names they initialize.