### PR TITLE
[MLIR][Python] Fix typeid support for DynamicType and DynamicAttr

### DIFF
--- a/mlir/include/mlir-c/ExtensibleDialect.h
+++ b/mlir/include/mlir-c/ExtensibleDialect.h
@@ -87,9 +87,6 @@ mlirExtensibleDialectLookupTypeDefinition(MlirDialect dialect,
 /// Check if the given type is a dynamic type.
 MLIR_CAPI_EXPORTED bool mlirTypeIsADynamicType(MlirType type);
 
-/// Get the type ID of a dynamic type.
-MLIR_CAPI_EXPORTED MlirTypeID mlirDynamicTypeGetTypeID(void);
-
 /// Get a dynamic type by instantiating the given type definition with the
 /// provided attributes.
 MLIR_CAPI_EXPORTED MlirType mlirDynamicTypeGet(
@@ -105,6 +102,10 @@ MLIR_CAPI_EXPORTED MlirAttribute mlirDynamicTypeGetParam(MlirType type,
 /// Get the type definition of the given dynamic type.
 MLIR_CAPI_EXPORTED MlirDynamicTypeDefinition
 mlirDynamicTypeGetTypeDef(MlirType type);
+
+/// Get the type ID of a dynamic type definition.
+MLIR_CAPI_EXPORTED MlirTypeID
+mlirDynamicTypeDefinitionGetTypeID(MlirDynamicTypeDefinition typeDef);
 
 /// Get the name of the given dynamic type definition.
 MLIR_CAPI_EXPORTED MlirStringRef
@@ -123,9 +124,6 @@ mlirExtensibleDialectLookupAttrDefinition(MlirDialect dialect,
 /// Check if the given attribute is a dynamic attribute.
 MLIR_CAPI_EXPORTED bool mlirAttributeIsADynamicAttr(MlirAttribute attr);
 
-/// Get the type ID of a dynamic attribute.
-MLIR_CAPI_EXPORTED MlirTypeID mlirDynamicAttrGetTypeID(void);
-
 /// Get a dynamic attribute by instantiating the given attribute definition with
 /// the provided attributes.
 MLIR_CAPI_EXPORTED MlirAttribute mlirDynamicAttrGet(
@@ -141,6 +139,10 @@ MLIR_CAPI_EXPORTED MlirAttribute mlirDynamicAttrGetParam(MlirAttribute attr,
 /// Get the attribute definition of the given dynamic attribute.
 MLIR_CAPI_EXPORTED MlirDynamicAttrDefinition
 mlirDynamicAttrGetAttrDef(MlirAttribute attr);
+
+/// Get the type ID of a dynamic attribute definition.
+MLIR_CAPI_EXPORTED MlirTypeID
+mlirDynamicAttrDefinitionGetTypeID(MlirDynamicAttrDefinition attrDef);
 
 /// Get the name of the given dynamic attribute definition.
 MLIR_CAPI_EXPORTED MlirStringRef

--- a/mlir/include/mlir/Bindings/Python/IRAttributes.h
+++ b/mlir/include/mlir/Bindings/Python/IRAttributes.h
@@ -594,8 +594,6 @@ public:
   static constexpr IsAFunctionTy isaFunction = mlirAttributeIsADynamicAttr;
   static constexpr const char *pyClassName = "DynamicAttr";
   using PyConcreteAttribute::PyConcreteAttribute;
-  static constexpr GetTypeIDFunctionTy getTypeIdFunction =
-      mlirDynamicAttrGetTypeID;
 
   static void bindDerived(ClassTy &c);
 };

--- a/mlir/include/mlir/Bindings/Python/IRTypes.h
+++ b/mlir/include/mlir/Bindings/Python/IRTypes.h
@@ -450,8 +450,6 @@ class MLIR_PYTHON_API_EXPORTED PyDynamicType
     : public PyConcreteType<PyDynamicType> {
 public:
   static constexpr IsAFunctionTy isaFunction = mlirTypeIsADynamicType;
-  static constexpr GetTypeIDFunctionTy getTypeIdFunction =
-      mlirDynamicTypeGetTypeID;
   static constexpr const char *pyClassName = "DynamicType";
   using PyConcreteType::PyConcreteType;
 

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -18,6 +18,7 @@
 
 #include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/BuiltinTypes.h"
+#include "mlir-c/ExtensibleDialect.h"
 #include "mlir/Bindings/Python/IRAttributes.h"
 #include "mlir/Bindings/Python/IRCore.h"
 #include "mlir/Bindings/Python/Nanobind.h"
@@ -1374,41 +1375,47 @@ void PyStringAttribute::bindDerived(ClassTy &c) {
       "Returns the value of the string attribute as `bytes`");
 }
 
+static MlirDynamicAttrDefinition
+getDynamicAttrDef(const std::string &fullAttrName,
+                  DefaultingPyMlirContext context) {
+  size_t dotPos = fullAttrName.find('.');
+  if (dotPos == std::string::npos) {
+    throw nb::value_error("Expected full attribute name to be in the format "
+                          "'<dialectName>.<attributeName>'.");
+  }
+
+  std::string dialectName = fullAttrName.substr(0, dotPos);
+  std::string attrName = fullAttrName.substr(dotPos + 1);
+  PyDialects dialects(context->getRef());
+  MlirDialect dialect = dialects.getDialectForKey(dialectName, false);
+  if (!mlirDialectIsAExtensibleDialect(dialect))
+    throw nb::value_error(
+        ("Dialect '" + dialectName + "' is not an extensible dialect.")
+            .c_str());
+
+  MlirDynamicAttrDefinition attrDef = mlirExtensibleDialectLookupAttrDefinition(
+      dialect, toMlirStringRef(attrName));
+  if (attrDef.ptr == nullptr) {
+    throw nb::value_error(("Dialect '" + dialectName +
+                           "' does not contain an attribute named '" +
+                           attrName + "'.")
+                              .c_str());
+  }
+  return attrDef;
+}
+
 void PyDynamicAttribute::bindDerived(ClassTy &c) {
   c.def_static(
       "get",
       [](const std::string &fullAttrName, const std::vector<PyAttribute> &attrs,
          DefaultingPyMlirContext context) {
-        size_t dotPos = fullAttrName.find('.');
-        if (dotPos == std::string::npos) {
-          throw nb::value_error(
-              "Expected full attribute name to be in the format "
-              "'<dialectName>.<attributeName>'.");
-        }
-
-        std::string dialectName = fullAttrName.substr(0, dotPos);
-        std::string attrName = fullAttrName.substr(dotPos + 1);
-        PyDialects dialects(context->getRef());
-        MlirDialect dialect = dialects.getDialectForKey(dialectName, false);
-        if (!mlirDialectIsAExtensibleDialect(dialect))
-          throw nb::value_error(
-              ("Dialect '" + dialectName + "' is not an extensible dialect.")
-                  .c_str());
-
-        MlirDynamicAttrDefinition attrDef =
-            mlirExtensibleDialectLookupAttrDefinition(
-                dialect, toMlirStringRef(attrName));
-        if (attrDef.ptr == nullptr) {
-          throw nb::value_error(("Dialect '" + dialectName +
-                                 "' does not contain an attribute named '" +
-                                 attrName + "'.")
-                                    .c_str());
-        }
-
         std::vector<MlirAttribute> mlirAttrs;
         mlirAttrs.reserve(attrs.size());
         for (const auto &attr : attrs)
           mlirAttrs.push_back(attr.get());
+
+        MlirDynamicAttrDefinition attrDef =
+            getDynamicAttrDef(fullAttrName, context);
         MlirAttribute attr =
             mlirDynamicAttrGet(attrDef, mlirAttrs.data(), mlirAttrs.size());
         return PyDynamicAttribute(context->getRef(), attr);
@@ -1436,6 +1443,15 @@ void PyDynamicAttribute::bindDerived(ClassTy &c) {
     return std::string(dialectNamespace.data, dialectNamespace.length) + "." +
            std::string(name.data, name.length);
   });
+  c.def_static(
+      "get_typeid",
+      [](const std::string &fullAttrName, DefaultingPyMlirContext context) {
+        MlirDynamicAttrDefinition attrDef =
+            getDynamicAttrDef(fullAttrName, context);
+        return PyTypeID(mlirDynamicAttrDefinitionGetTypeID(attrDef));
+      },
+      nb::arg("full_attr_name"), nb::arg("context") = nb::none(),
+      "Returns the TypeID for the given dynamic attribute name.");
 }
 
 void populateIRAttributes(nb::module_ &m) {

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -1444,14 +1444,14 @@ void PyDynamicAttribute::bindDerived(ClassTy &c) {
            std::string(name.data, name.length);
   });
   c.def_static(
-      "get_typeid",
+      "lookup_typeid",
       [](const std::string &fullAttrName, DefaultingPyMlirContext context) {
         MlirDynamicAttrDefinition attrDef =
             getDynamicAttrDef(fullAttrName, context);
         return PyTypeID(mlirDynamicAttrDefinitionGetTypeID(attrDef));
       },
       nb::arg("full_attr_name"), nb::arg("context") = nb::none(),
-      "Returns the TypeID for the given dynamic attribute name.");
+      "Look up the TypeID for the given dynamic attribute name.");
 }
 
 void populateIRAttributes(nb::module_ &m) {

--- a/mlir/lib/Bindings/Python/IRTypes.cpp
+++ b/mlir/lib/Bindings/Python/IRTypes.cpp
@@ -842,35 +842,43 @@ void PyOpaqueType::bindDerived(ClassTy &c) {
       "Returns the data for the Opaque type as a string.");
 }
 
+static MlirDynamicTypeDefinition
+getDynamicTypeDef(const std::string &fullTypeName,
+                  DefaultingPyMlirContext context) {
+  size_t dotPos = fullTypeName.find('.');
+  if (dotPos == std::string::npos) {
+    throw nb::value_error("Expected full type name to be in the format "
+                          "'<dialectName>.<typeName>'.");
+  }
+
+  std::string dialectName = fullTypeName.substr(0, dotPos);
+  std::string typeName = fullTypeName.substr(dotPos + 1);
+  PyDialects dialects(context->getRef());
+  MlirDialect dialect = dialects.getDialectForKey(dialectName, false);
+  if (!mlirDialectIsAExtensibleDialect(dialect))
+    throw nb::value_error(
+        ("Dialect '" + dialectName + "' is not an extensible dialect.")
+            .c_str());
+
+  MlirDynamicTypeDefinition typeDef = mlirExtensibleDialectLookupTypeDefinition(
+      dialect, toMlirStringRef(typeName));
+  if (typeDef.ptr == nullptr) {
+    throw nb::value_error(("Dialect '" + dialectName +
+                           "' does not contain a type named '" + typeName +
+                           "'.")
+                              .c_str());
+  }
+
+  return typeDef;
+}
+
 void PyDynamicType::bindDerived(ClassTy &c) {
   c.def_static(
       "get",
       [](const std::string &fullTypeName, const std::vector<PyAttribute> &attrs,
          DefaultingPyMlirContext context) {
-        size_t dotPos = fullTypeName.find('.');
-        if (dotPos == std::string::npos) {
-          throw nb::value_error("Expected full type name to be in the format "
-                                "'<dialectName>.<typeName>'.");
-        }
-
-        std::string dialectName = fullTypeName.substr(0, dotPos);
-        std::string typeName = fullTypeName.substr(dotPos + 1);
-        PyDialects dialects(context->getRef());
-        MlirDialect dialect = dialects.getDialectForKey(dialectName, false);
-        if (!mlirDialectIsAExtensibleDialect(dialect))
-          throw nb::value_error(
-              ("Dialect '" + dialectName + "' is not an extensible dialect.")
-                  .c_str());
-
         MlirDynamicTypeDefinition typeDef =
-            mlirExtensibleDialectLookupTypeDefinition(
-                dialect, toMlirStringRef(typeName));
-        if (typeDef.ptr == nullptr) {
-          throw nb::value_error(("Dialect '" + dialectName +
-                                 "' does not contain a type named '" +
-                                 typeName + "'.")
-                                    .c_str());
-        }
+            getDynamicTypeDef(fullTypeName, context);
 
         std::vector<MlirAttribute> mlirAttrs;
         mlirAttrs.reserve(attrs.size());
@@ -902,6 +910,15 @@ void PyDynamicType::bindDerived(ClassTy &c) {
     return std::string(dialectNamespace.data, dialectNamespace.length) + "." +
            std::string(name.data, name.length);
   });
+  c.def_static(
+      "get_typeid",
+      [](const std::string &fullTypeName, DefaultingPyMlirContext context) {
+        MlirDynamicTypeDefinition typeDef =
+            getDynamicTypeDef(fullTypeName, context);
+        return PyTypeID(mlirDynamicTypeDefinitionGetTypeID(typeDef));
+      },
+      nb::arg("full_type_name"), nb::arg("context") = nb::none(),
+      "Returns the TypeID for the given dynamic type name.");
 }
 
 void populateIRTypes(nb::module_ &m) {

--- a/mlir/lib/Bindings/Python/IRTypes.cpp
+++ b/mlir/lib/Bindings/Python/IRTypes.cpp
@@ -911,14 +911,14 @@ void PyDynamicType::bindDerived(ClassTy &c) {
            std::string(name.data, name.length);
   });
   c.def_static(
-      "get_typeid",
+      "lookup_typeid",
       [](const std::string &fullTypeName, DefaultingPyMlirContext context) {
         MlirDynamicTypeDefinition typeDef =
             getDynamicTypeDef(fullTypeName, context);
         return PyTypeID(mlirDynamicTypeDefinitionGetTypeID(typeDef));
       },
       nb::arg("full_type_name"), nb::arg("context") = nb::none(),
-      "Returns the TypeID for the given dynamic type name.");
+      "Look up the TypeID for the given dynamic type name.");
 }
 
 void populateIRTypes(nb::module_ &m) {

--- a/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
+++ b/mlir/lib/CAPI/IR/ExtensibleDialect.cpp
@@ -129,6 +129,11 @@ MlirDynamicTypeDefinition mlirDynamicTypeGetTypeDef(MlirType type) {
   return wrap(llvm::cast<mlir::DynamicType>(unwrap(type)).getTypeDef());
 }
 
+MlirTypeID
+mlirDynamicTypeDefinitionGetTypeID(MlirDynamicTypeDefinition typeDef) {
+  return wrap(unwrap(typeDef)->getTypeID());
+}
+
 MlirStringRef
 mlirDynamicTypeDefinitionGetName(MlirDynamicTypeDefinition typeDef) {
   return wrap(unwrap(typeDef)->getName());
@@ -174,6 +179,11 @@ MlirAttribute mlirDynamicAttrGetParam(MlirAttribute attr, intptr_t index) {
 
 MlirDynamicAttrDefinition mlirDynamicAttrGetAttrDef(MlirAttribute attr) {
   return wrap(llvm::cast<mlir::DynamicAttr>(unwrap(attr)).getAttrDef());
+}
+
+MlirTypeID
+mlirDynamicAttrDefinitionGetTypeID(MlirDynamicAttrDefinition attrDef) {
+  return wrap(unwrap(attrDef)->getTypeID());
 }
 
 MlirStringRef

--- a/mlir/python/mlir/dialects/ext.py
+++ b/mlir/python/mlir/dialects/ext.py
@@ -678,3 +678,7 @@ class Dialect(ir.Dialect):
             register_dialect_operation = register_operation(cls)
             for op in cls.operations:
                 register_dialect_operation(op)
+
+            for type_ in cls.types:
+                typeid = ir.DynamicType.get_typeid(type_.type_name)
+                _cext.register_type_caster(typeid)(type_)

--- a/mlir/python/mlir/dialects/ext.py
+++ b/mlir/python/mlir/dialects/ext.py
@@ -680,5 +680,5 @@ class Dialect(ir.Dialect):
                 register_dialect_operation(op)
 
             for type_ in cls.types:
-                typeid = ir.DynamicType.get_typeid(type_.type_name)
+                typeid = ir.DynamicType.lookup_typeid(type_.type_name)
                 _cext.register_type_caster(typeid)(type_)

--- a/mlir/test/python/dialects/ext.py
+++ b/mlir/test/python/dialects/ext.py
@@ -581,6 +581,9 @@ def testExtDialectWithType():
         # CHECK: 6 : i32
         print(a6.length)
 
+        # CHECK: <locals>.Array
+        print(type(Type(a4).maybe_downcast()))
+
         module = Module.create()
         with InsertionPoint(module.body):
             MakeArrayOp(a4)

--- a/mlir/test/python/dialects/irdl.py
+++ b/mlir/test/python/dialects/irdl.py
@@ -134,6 +134,22 @@ def testIRDLTypes():
         # CHECK: unit
         t2.params[1].dump()
 
+        # CHECK: True
+        print(
+            t2.typeid == DynamicType.lookup_typeid("irdl_type_test.type2"),
+            file=sys.stderr,
+        )
+        # CHECK: False
+        print(
+            t1.typeid == DynamicType.lookup_typeid("irdl_type_test.type2"),
+            file=sys.stderr,
+        )
+        # CHECK: True
+        print(
+            t1.typeid == DynamicType.lookup_typeid("irdl_type_test.type1"),
+            file=sys.stderr,
+        )
+
         m = Module.create()
         with InsertionPoint(m.body):
             Operation.create("irdl_type_test.op1", results=[t1])
@@ -210,6 +226,22 @@ def testIRDLAttrs():
         a2.params[0].dump()
         # CHECK: unit
         a2.params[1].dump()
+
+        # CHECK: True
+        print(
+            a2.typeid == DynamicAttr.lookup_typeid("irdl_attr_test.attr2"),
+            file=sys.stderr,
+        )
+        # CHECK: False
+        print(
+            a1.typeid == DynamicAttr.lookup_typeid("irdl_attr_test.attr2"),
+            file=sys.stderr,
+        )
+        # CHECK: True
+        print(
+            a1.typeid == DynamicAttr.lookup_typeid("irdl_attr_test.attr1"),
+            file=sys.stderr,
+        )
 
         m = Module.create()
         with InsertionPoint(m.body):


### PR DESCRIPTION
Previously, we were using the static `typeid` of `DynamicType` for checks, which is incorrect. We should instead check against the `typeid` of `DynamicTypeDefinition` (which is a subclass of `SelfOwningTypeID`), and register it via `register_type_caster` so that Python-defined types can use `maybe_downcast`. (The attribute part is same.)
