### PR TITLE
[LLVM][LangRef] Restrict vscale to be a signed power-of-two integer.

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -4678,9 +4678,9 @@ elementtype may be any integer, floating-point, pointer type, or a sized
 target extension type that has the ``CanBeVectorElement`` property. Vectors
 of size zero are not allowed. For scalable vectors, the total number of
 elements is a constant multiple (called vscale) of the specified number
-of elements; vscale is a positive integer that is unknown at compile time
-and the same hardware-dependent constant for all scalable vectors at run
-time. The size of a specific scalable vector type is thus constant within
+of elements; vscale is a positive power-of-two integer that is unknown at
+compile time and the same hardware-dependent constant for all scalable vectors
+at run time. The size of a specific scalable vector type is thus constant within
 IR, even if the exact size in bytes cannot be determined until run time.
 
 :Examples:
@@ -31501,8 +31501,8 @@ vectors such as ``<vscale x 16 x i8>``.
 Semantics:
 """"""""""
 
-``vscale`` is a positive value that is constant throughout program
-execution, but is unknown at compile time.
+``vscale`` is a positive power-of-two integer that is constant throughout
+program execution, but is unknown at compile time.
 If the result value does not fit in the result type, then the result is
 a :ref:`poison value <poisonvalues>`.
 

--- a/mlir/docs/Dialects/Vector.md
+++ b/mlir/docs/Dialects/Vector.md
@@ -97,10 +97,11 @@ Finally, MLIR takes the same view on scalable Vectors as LLVM (c.f.
 [VectorType](https://llvm.org/docs/LangRef.html#vector-type)):
 > For scalable vectors, the total number of elements is a constant multiple
 > (called vscale) of the specified number of elements; vscale is a positive
-> integer that is unknown at compile time and the same hardware-dependent
-> constant for all scalable vectors at run time.  The size of a specific
-> scalable vector type is thus constant within IR, even if the exact size in
-> bytes cannot be determined until run time.
+> power-of-two integer that is unknown at compile time and the same
+> hardware-dependent constant for all scalable vectors at run time.
+> The size of a specific scalable vector type is thus constant within
+> IR, even if the exact size in bytes cannot be determined until run
+> time.
 
 ### Hardware Vector Ops
 


### PR DESCRIPTION
The rational for this change comes from https://github.com/llvm/llvm-project/pull/145098 and https://github.com/llvm/llvm-project/pull/183065 and essentially boils down to there being no known requirement to support non-power-of-two values of vscale and yet said support is leading to unnecessary complexity within LLVM.

Hopefully it's ok to land the LangRef change in isolation and then follow up with the codebase simplifications.