### PR TITLE
[LICM] Reassociate add/sub expressions to hoist invariant computations

### DIFF
--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -2927,6 +2927,92 @@ static bool hoistBOAssociation(Instruction &I, Loop &L,
   return true;
 }
 
+/// Reassociate add/sub expressions of the form:
+///
+/// 1. "(LV + C1) - C2" ==> "LV + (C1 - C2)"
+/// 2. "(LV - C1) - C2" ==> "LV - (C1 + C2)"
+/// 3. "(LV - C1) + C2" ==> "LV + (C2 - C1)"
+///
+/// where LV is a loop variant, and C1 and C2 are loop invariants.
+/// Sub is not associative, but these algebraic identities allow hoisting
+/// invariant computations out of the loop.
+static bool hoistSubAddAssociation(Instruction &I, Loop &L,
+                                   ICFLoopSafetyInfo &SafetyInfo,
+                                   MemorySSAUpdater &MSSAU, AssumptionCache *AC,
+                                   DominatorTree *DT) {
+  using namespace PatternMatch;
+
+  Instruction *BO;
+  Value *LV, *C1, *C2;
+  Instruction::BinaryOps InvOp, ResultOp;
+
+  // Try to match one of three reassociation patterns involving sub.
+  //
+  //   1. (LV + C1) - C2 ==> LV + (C1 - C2)
+  //   2. (LV - C1) - C2 ==> LV - (C1 + C2)
+  //   3. (LV - C1) + C2 ==> LV + (C2 - C1)
+  //                            ^     ^
+  //                             \     \___ InvOp
+  //                              \
+  //                               \____ ResultOp
+  //
+  if (match(&I,
+            m_Sub(m_OneUse(m_Instruction(BO, m_Add(m_Value(LV), m_Value(C1)))),
+                  m_Value(C2)))) {
+    // Case 1.
+    //
+    // Depending on which of the addition is invariant, we might need to swap
+    // the arguments
+    if (L.isLoopInvariant(LV) && !L.isLoopInvariant(C1))
+      std::swap(LV, C1);
+    InvOp = Instruction::Sub;
+    ResultOp = Instruction::Add;
+  } else if (match(&I, m_Sub(m_OneUse(m_Instruction(
+                                 BO, m_Sub(m_Value(LV), m_Value(C1)))),
+                             m_Value(C2)))) {
+    // Case 2.
+    InvOp = Instruction::Add;
+    ResultOp = Instruction::Sub;
+  } else if (match(&I, m_c_Add(m_OneUse(m_Instruction(
+                                   BO, m_Sub(m_Value(LV), m_Value(C1)))),
+                               m_Value(C2)))) {
+    // Case 3.
+    //
+    // We use (C2 - C1) as the invariant as opposed to case 1, but instead of
+    // adding a special case in invariant creation, we can just swap the
+    // operands here.
+    std::swap(C1, C2);
+    InvOp = Instruction::Sub;
+    ResultOp = Instruction::Add;
+  } else {
+    return false;
+  }
+
+  if (L.isLoopInvariant(LV) || !L.isLoopInvariant(C1) || !L.isLoopInvariant(C2))
+    return false;
+
+  auto *Preheader = L.getLoopPreheader();
+  assert(Preheader && "Loop is not in simplify form?");
+
+  IRBuilder<> Builder(Preheader->getTerminator());
+  auto *Inv = Builder.CreateBinOp(InvOp, C1, C2, "invariant.op");
+
+  auto *NewBO = BinaryOperator::Create(ResultOp, LV, Inv,
+                                       I.getName() + ".reass", I.getIterator());
+  NewBO->setDebugLoc(DebugLoc::getDropped());
+
+  // No overflow flags are set on the new instructions -- reassociation
+  // involving sub does not preserve nsw/nuw in general.
+
+  I.replaceAllUsesWith(NewBO);
+  eraseInstruction(I, SafetyInfo, MSSAU);
+
+  salvageDebugInfo(*BO);
+  eraseInstruction(*BO, SafetyInfo, MSSAU);
+
+  return true;
+}
+
 static bool hoistArithmetics(Instruction &I, Loop &L,
                              ICFLoopSafetyInfo &SafetyInfo,
                              MemorySSAUpdater &MSSAU, AssumptionCache *AC,
@@ -2965,6 +3051,12 @@ static bool hoistArithmetics(Instruction &I, Loop &L,
   }
 
   if (hoistBOAssociation(I, L, SafetyInfo, MSSAU, AC, DT)) {
+    ++NumHoisted;
+    ++NumBOAssociationsHoisted;
+    return true;
+  }
+
+  if (hoistSubAddAssociation(I, L, SafetyInfo, MSSAU, AC, DT)) {
     ++NumHoisted;
     ++NumBOAssociationsHoisted;
     return true;

--- a/llvm/test/Transforms/LICM/hoist-binop.ll
+++ b/llvm/test/Transforms/LICM/hoist-binop.ll
@@ -475,15 +475,15 @@ loop:
   br label %loop
 }
 
-; Don't hoist if the ops are not associative.
-define void @noassoc_ops(i64 %c1, i64 %c2) {
-; CHECK-LABEL: @noassoc_ops(
+; Hoist sub-sub by reassociation.
+define void @sub_sub(i64 %c1, i64 %c2) {
+; CHECK-LABEL: @sub_sub(
 ; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = add i64 [[C1:%.*]], [[C2:%.*]]
 ; CHECK-NEXT:    br label [[LOOP:%.*]]
 ; CHECK:       loop:
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDEX_NEXT:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[STEP_ADD:%.*]] = sub i64 [[INDEX]], [[C1:%.*]]
-; CHECK-NEXT:    [[INDEX_NEXT]] = sub i64 [[STEP_ADD]], [[C2:%.*]]
+; CHECK-NEXT:    [[INDEX_NEXT]] = sub i64 [[INDEX]], [[INVARIANT_OP]]
 ; CHECK-NEXT:    br label [[LOOP]]
 ;
 entry:
@@ -926,6 +926,155 @@ loop:
   %step.add = add <2 x i64> %vec.ind, %.splat
   call void @use(<2 x i64> %step.add)
   %vec.ind.next = add <2 x i64> %step.add, %.splat
+  br label %loop
+}
+
+; Hoist add-sub by reassociation.
+define void @add_sub(i64 %c1, i64 %c2) {
+; CHECK-LABEL: @add_sub(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = sub i64 [[C1:%.*]], [[C2:%.*]]
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDEX_NEXT_REASS:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[INDEX_NEXT_REASS]] = add i64 [[INDEX]], [[INVARIANT_OP]]
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  br label %loop
+
+loop:
+  %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
+  %step.add = add i64 %index, %c1
+  %index.next = sub i64 %step.add, %c2
+  br label %loop
+}
+
+; Hoist add-sub by reassociation, inner add operands commuted.
+define void @add_sub_comm(i64 %c1, i64 %c2) {
+; CHECK-LABEL: @add_sub_comm(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = sub i64 [[C1:%.*]], [[C2:%.*]]
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDEX_NEXT_REASS:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[INDEX_NEXT_REASS]] = add i64 [[INDEX]], [[INVARIANT_OP]]
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  br label %loop
+
+loop:
+  %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
+  %step.add = add i64 %c1, %index
+  %index.next = sub i64 %step.add, %c2
+  br label %loop
+}
+
+; Hoist sub-add by reassociation.
+define void @sub_add(i64 %c1, i64 %c2) {
+; CHECK-LABEL: @sub_add(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = sub i64 [[C2:%.*]], [[C1:%.*]]
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDEX_NEXT_REASS:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[INDEX_NEXT_REASS]] = add i64 [[INDEX]], [[INVARIANT_OP]]
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  br label %loop
+
+loop:
+  %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
+  %step.sub = sub i64 %index, %c1
+  %index.next = add i64 %step.sub, %c2
+  br label %loop
+}
+
+; Hoist sub-add by reassociation, outer add operands commuted.
+define void @sub_add_comm(i64 %c1, i64 %c2) {
+; CHECK-LABEL: @sub_add_comm(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = sub i64 [[C2:%.*]], [[C1:%.*]]
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDEX_NEXT_REASS:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[INDEX_NEXT_REASS]] = add i64 [[INDEX]], [[INVARIANT_OP]]
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  br label %loop
+
+loop:
+  %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
+  %step.sub = sub i64 %index, %c1
+  %index.next = add i64 %c2, %step.sub
+  br label %loop
+}
+
+; Hoist sub-sub and drop overflow flags.
+define void @sub_sub_drop_flags(i64 %c1, i64 %c2) {
+; CHECK-LABEL: @sub_sub_drop_flags(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = add i64 [[C1:%.*]], [[C2:%.*]]
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 1000, [[ENTRY:%.*]] ], [ [[INDEX_NEXT_REASS:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[INDEX_NEXT_REASS]] = sub i64 [[INDEX]], [[INVARIANT_OP]]
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  br label %loop
+
+loop:
+  %index = phi i64 [ 1000, %entry ], [ %index.next, %loop ]
+  %step.sub = sub nuw nsw i64 %index, %c1
+  %index.next = sub nuw nsw i64 %step.sub, %c2
+  br label %loop
+}
+
+; Don't hoist sub-sub if the inner op has more than one use.
+define void @sub_sub_two_uses(i64 %c1, i64 %c2) {
+; CHECK-LABEL: @sub_sub_two_uses(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 1000, [[ENTRY:%.*]] ], [ [[INDEX_NEXT:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[STEP_SUB:%.*]] = sub i64 [[INDEX]], [[C1:%.*]]
+; CHECK-NEXT:    call void @use(i64 [[STEP_SUB]])
+; CHECK-NEXT:    [[INDEX_NEXT]] = sub i64 [[STEP_SUB]], [[C2:%.*]]
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  br label %loop
+
+loop:
+  %index = phi i64 [ 1000, %entry ], [ %index.next, %loop ]
+  %step.sub = sub i64 %index, %c1
+  call void @use(i64 %step.sub)
+  %index.next = sub i64 %step.sub, %c2
+  br label %loop
+}
+
+; Don't hoist if the variant is on the RHS of the outer sub.
+define void @sub_sub_variant_rhs_neg(i64 %c1, i64 %c2) {
+; CHECK-LABEL: @sub_sub_variant_rhs_neg(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[INDEX_NEXT:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[STEP_SUB:%.*]] = sub i64 [[INDEX]], [[C1:%.*]]
+; CHECK-NEXT:    [[INDEX_NEXT]] = sub i64 [[C2:%.*]], [[STEP_SUB]]
+; CHECK-NEXT:    br label [[LOOP]]
+;
+entry:
+  br label %loop
+
+loop:
+  %index = phi i64 [ 0, %entry ], [ %index.next, %loop ]
+  %step.sub = sub i64 %index, %c1
+  %index.next = sub i64 %c2, %step.sub
   br label %loop
 }
 


### PR DESCRIPTION
While `sub` is not associative, we can still reassociate `add` and `sub`.

## Alive2 proofs

| Case | Transform | Proof |
|------|-----------|-------|
| 1 | `(x + c1) - c2` => `x + (c1 - c2)` | [proof](https://alive2.llvm.org/ce/z/iofzYy) |
| 2 | `(x - c1) - c2` => `x - (c1 + c2)` | [proof](https://alive2.llvm.org/ce/z/U4K_tE) |
| 3 | `(x - c1) + c2` => `x + (c2 - c1)` | [proof](https://alive2.llvm.org/ce/z/moiJVw) |