### PR TITLE
[cmake] Don't pass -no-warn-on-unused-template-args to mlir-src-sharder

### DIFF
--- a/llvm/cmake/modules/TableGen.cmake
+++ b/llvm/cmake/modules/TableGen.cmake
@@ -95,7 +95,9 @@ function(tablegen project ofn)
     set(tblgen_change_flag "--write-if-changed")
   endif()
 
-  if (NOT LLVM_ENABLE_WARNINGS)
+  # Don't pass this flag to mlir-src-sharder, since it doesn't support the
+  # flag, and it doesn't need it.
+  if (NOT LLVM_ENABLE_WARNINGS AND NOT "${project}" STREQUAL "MLIR_SRC_SHARDER")
     list(APPEND LLVM_TABLEGEN_FLAGS "-no-warn-on-unused-template-args")
   endif()
 


### PR DESCRIPTION
Building with `LLVM_ENABLE_WARNINGS=OFF` fails when generating sharded test ops:

```bash
cmake -S llvm -B build -G Ninja \
  -DLLVM_ENABLE_PROJECTS="mlir" \
  -DLLVM_ENABLE_WARNINGS=OFF
cmake --build build --target MLIRTestOpsShardGen
```

```
mlir-src-sharder: Unknown command line argument '-no-warn-on-unused-template-args'.
```

`mlir-src-sharder` calls `ResetCommandLineParser()` on startup, so it doesn't recognize flags registered by the TableGen library. The `tablegen()` cmake function already excludes `--long-string-literals=0` for `MLIR_SRC_SHARDER` — this adds the same guard for `-no-warn-on-unused-template-args`.