### PR TITLE
[X86] add X86DomainReassignmentPass to x86 npm pipeline

### DIFF
--- a/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
@@ -131,8 +131,7 @@ void X86CodeGenPassBuilder::addILPOpts(PassManagerWrapper &PMW) const {
 
 void X86CodeGenPassBuilder::addMachineSSAOptimization(
     PassManagerWrapper &PMW) const {
-  // TODO(boomanaiden154): Add X86DomainReassignmentPass here once it has been
-  // ported.
+  addMachineFunctionPass(X86DomainReassignmentPass(), PMW);
   Base::addMachineSSAOptimization(PMW);
 }
 

--- a/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
+++ b/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
@@ -114,6 +114,7 @@
 ; O2-NEXT: x86-global-base-reg
 ; O2-NEXT: x86-argument-stack-slot
 ; O2-NEXT: finalize-isel
+; O2-NEXT: x86-domain-reassignment
 ; O2-NEXT: early-tailduplication
 ; O2-NEXT: opt-phis
 ; O2-NEXT: stack-coloring
@@ -302,6 +303,7 @@
 ; O3-WINDOWS-NEXT: x86-global-base-reg
 ; O3-WINDOWS-NEXT: x86-argument-stack-slot
 ; O3-WINDOWS-NEXT: finalize-isel
+; O3-WINDOWS-NEXT: x86-domain-reassignment
 ; O3-WINDOWS-NEXT: early-tailduplication
 ; O3-WINDOWS-NEXT: opt-phis
 ; O3-WINDOWS-NEXT: stack-coloring


### PR DESCRIPTION
Seems that the pass has already been ported, but was not hooked into the npm pipeline