### PR TITLE
[flang] Catch empty nested parenthsized format item list

### DIFF
--- a/flang/include/flang/Common/format.h
+++ b/flang/include/flang/Common/format.h
@@ -909,6 +909,9 @@ template <typename CHAR> bool FormatValidator<CHAR>::Check() {
       if (++nestLevel > maxNesting_) {
         maxNesting_ = nestLevel;
       }
+      if (LookAheadChar() == ')') {
+        ReportError("Nested parenthesized format item list is empty");
+      }
       break;
     case TokenKind::RParen:
       if (knrValue_ >= 0) {

--- a/flang/test/Semantics/io08.f90
+++ b/flang/test/Semantics/io08.f90
@@ -40,6 +40,7 @@
   write(*,'($)')
   write(*,'(\)')
   write(*,'(RZ,RU,RP,RN,RD,RC,SS,SP,S,3G15.3e2)')
+  write(*, "()")
   write(*, '(' // achar( 9) // ')') ! horizontal tab
   write(*, '(' // achar(11) // ')') ! vertical tab
   write(*, '(' // achar(32) // ')') ! space
@@ -320,4 +321,8 @@
 
   !ERROR: Negative scale factor k (from kP) and width d in a 'E' edit descriptor must satisfy '-d < k'
   write(*, '(-4P,E20.5,E15.2)')
+
+  !ERROR: Nested parenthesized format item list is empty
+  write(*, "(I6.3, ( ))")
+
 end


### PR DESCRIPTION
While a completely empty format item list is meaningful -- it does nothing when there are no data items -- an empty nested parenthesized format item list is neither conforming nor useful, and will cause a runtime error if it is interpreted as unlimited repetition.  We essentially catch these cases as parsing errors when they appear in a FORMAT statement, but the format string checker used for character constants is missing them.