### PR TITLE
[ConstantFolding] Fold powf in single-precision.

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -2176,6 +2176,18 @@ Constant *ConstantFoldBinaryFP(double (*NativeFP)(double, double),
   return GetConstantFoldFPValue(Result, Ty);
 }
 
+Constant *ConstantFoldBinaryFP32(float (*NativeFP)(float, float),
+                                 const APFloat &V, const APFloat &W, Type *Ty) {
+  llvm_fenv_clearexcept();
+  float Result = NativeFP(V.convertToFloat(), W.convertToFloat());
+  if (llvm_fenv_testexcept()) {
+    llvm_fenv_clearexcept();
+    return nullptr;
+  }
+
+  return GetConstantFoldFPValue(Result, Ty);
+}
+
 Constant *constantFoldVectorReduce(Intrinsic::ID IID, Constant *Op) {
   auto *OpVT = cast<VectorType>(Op->getType());
 
@@ -3197,10 +3209,13 @@ static Constant *ConstantFoldLibCall2(StringRef Name, Type *Ty,
   switch (Func) {
   default:
     break;
-  case LibFunc_pow:
   case LibFunc_powf:
-  case LibFunc_pow_finite:
   case LibFunc_powf_finite:
+    if (TLI->has(Func))
+      return ConstantFoldBinaryFP32(powf, Op1V, Op2V, Ty);
+    break;
+  case LibFunc_pow:
+  case LibFunc_pow_finite:
     if (TLI->has(Func))
       return ConstantFoldBinaryFP(pow, Op1V, Op2V, Ty);
     break;

--- a/llvm/test/Transforms/EarlyCSE/math-2.ll
+++ b/llvm/test/Transforms/EarlyCSE/math-2.ll
@@ -83,7 +83,8 @@ define double @f_pow() {
 declare float @powf(float, float) #0
 define float @f_powf_inf_nofold() {
 ; CHECK-LABEL: @f_powf_inf_nofold(
-; CHECK-NEXT:    ret float 0x7FF0000000000000
+; CHECK-NEXT:    [[RES:%.*]] = tail call fast float @powf(float 1.000000e+01, float 1.000000e+02)
+; CHECK-NEXT:    ret float [[RES]]
 ;
   %res = tail call fast float @powf(float 10., float 100.)
   ret float %res

--- a/llvm/test/Transforms/EarlyCSE/math-2.ll
+++ b/llvm/test/Transforms/EarlyCSE/math-2.ll
@@ -80,6 +80,24 @@ define double @f_pow() {
   ret double %res
 }
 
+declare float @powf(float, float) #0
+define float @f_powf_inf_nofold() {
+; CHECK-LABEL: @f_powf_inf_nofold(
+; CHECK-NEXT:    ret float 0x7FF0000000000000
+;
+  %res = tail call fast float @powf(float 10., float 100.)
+  ret float %res
+}
+
+define double @f_pow_inf_nofold() {
+; CHECK-LABEL: @f_pow_inf_nofold(
+; CHECK-NEXT:    [[RES:%.*]] = tail call fast double @pow(double 1.000000e+01, double 1.000000e+03)
+; CHECK-NEXT:    ret double [[RES]]
+;
+  %res = tail call fast double @pow(double 10., double 1000.0)
+  ret double %res
+}
+
 declare float @llvm.pow.f32(float, float)
 define float @i_powf() {
 ; CHECK-LABEL: @i_powf(


### PR DESCRIPTION
This is the second part of #183099.

This patch folds powf with constant arguments in single-precision.  This avoids folding calls that would otherwise set ERANGE, for example (https://godbolt.org/z/zexsT373f).