### PR TITLE
[flang] Silence confusing spurious error message

### DIFF
--- a/flang/lib/Evaluate/characteristics.cpp
+++ b/flang/lib/Evaluate/characteristics.cpp
@@ -625,8 +625,7 @@ static std::optional<Procedure> CharacterizeProcedure(
   if (seenProcs.find(symbol) != seenProcs.end()) {
     std::string procsList{GetSeenProcs(seenProcs)};
     context.messages().Say(symbol.name(),
-        "Procedure '%s' is recursively defined.  Procedures in the cycle:"
-        " %s"_err_en_US,
+        "Procedure '%s' is recursively defined.  Procedures in the cycle: %s"_err_en_US,
         symbol.name(), procsList);
     return std::nullopt;
   }
@@ -776,8 +775,10 @@ static std::optional<Procedure> CharacterizeProcedure(
             return std::optional<Procedure>{};
           },
           [&](const auto &) {
-            context.messages().Say(
-                "'%s' is not a procedure"_err_en_US, symbol.name());
+            if (emitError) {
+              context.messages().Say(
+                  "'%s' is not a procedure"_err_en_US, symbol.name());
+            }
             return std::optional<Procedure>{};
           },
       },

--- a/flang/test/Semantics/associated.f90
+++ b/flang/test/Semantics/associated.f90
@@ -251,7 +251,6 @@ subroutine assoc()
     lvar = associated(intPointerArr, targetIntArr([2,1]))
     !ERROR: TARGET= argument 'targetintcoarray[1_8]' may not have a vector subscript or coindexing
     lvar = associated(intPointerVar1, targetIntCoarray[1])
-    !ERROR: 'neverdeclared' is not a procedure
     !ERROR: Could not characterize intrinsic function actual argument 'badpointer'
     lvar = associated(badPointer)
   end subroutine test

--- a/flang/test/Semantics/bug2273.f90
+++ b/flang/test/Semantics/bug2273.f90
@@ -1,0 +1,10 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1
+module m
+  type dt
+  end type
+ contains
+  subroutine s(p)
+    !ERROR: 'dt' must be an abstract interface or a procedure with an explicit interface
+    procedure(dt), pointer :: p
+  end
+end


### PR DESCRIPTION
The procedure characterization module unconditionally emits a "'foobar' is not a procedure" when asked to analyze a symbol that is, well, not a procedure -- even when called with a flag to suppress errors from analysis, since the calling context is going to handle failure.  This leads to some error messages that have source positions completely unrelated to the symbol in question.  Make this error sensitive to the suppression flag.