### PR TITLE
[bazel][libc][math] Fix fmul->mul for bf16mul family (#182018) 

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4876,28 +4876,28 @@ libc_math_function(
 )
 
 libc_math_function(
-    name = "bf16fmul",
+    name = "bf16mul",
     additional_deps = [
         ":__support_math_bf16mul",
     ],
 )
 
 libc_math_function(
-    name = "bf16fmulf",
+    name = "bf16mulf",
     additional_deps = [
         ":__support_math_bf16mulf",
     ],
 )
 
 libc_math_function(
-    name = "bf16fmulf128",
+    name = "bf16mulf128",
     additional_deps = [
         ":__support_math_bf16mulf128",
     ],
 )
 
 libc_math_function(
-    name = "bf16fmull",
+    name = "bf16mull",
     additional_deps = [
         ":__support_math_bf16mull",
     ],


### PR DESCRIPTION
#182018 made these header only but added the build targets as fmul instead of mul