### PR TITLE
[Github] Make prune unused branches workflow correctly handle reverts

### DIFF
--- a/.github/workflows/prune-unused-branches.py
+++ b/.github/workflows/prune-unused-branches.py
@@ -64,10 +64,13 @@ def query_prs(github_token, extra_query_criteria) -> list[str]:
 
 def get_branches_from_open_prs(github_token) -> list[str]:
     pr_data = []
+    # We will only ever be looking to delete branches with a `users/` prefix or
+    # a revert- prefix as a contract with get_branches.
     pr_data.extend(query_prs(github_token, "head:users/"))
+    pr_data.extend(query_prs(github_token, "head:revert-"))
     # We need to explicitly check cases where the base is a user branch to
     # ensure we capture branches that are used as a diff base for cross-repo
-    # PRs.
+    # PRs. Revert branches should never be the base branch of a PR.
     pr_data.extend(query_prs(github_token, "base:users/"))
 
     user_branches = []


### PR DESCRIPTION
Revert branches were not being correctly excluded from the list of branches to delete as we never even looked for them. Look for them, and add some comments to explain.

I have verified that after this patch, the workflow only deletes branches that are not associated with any PR.