### PR TITLE
[SPIRV][Debug Info] DebugCompilationUnit refactor for DebugFunction support

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -52,8 +52,11 @@ struct SPIRVEmitNonSemanticDI : public MachineFunctionPass {
   static char ID;
   SPIRVTargetMachine *TM;
   DenseMap<const DICompileUnit *, Register> CompileUnitRegMap;
+  const SPIRV::InstructionSet::InstructionSet DebugInfoInstSet;
   SPIRVEmitNonSemanticDI(SPIRVTargetMachine *TM = nullptr)
-      : MachineFunctionPass(ID), TM(TM) {}
+      : MachineFunctionPass(ID), TM(TM),
+        DebugInfoInstSet(
+            SPIRV::InstructionSet::NonSemantic_Shader_DebugInfo_100) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override;
 
@@ -63,7 +66,7 @@ private:
   convertDWARFToSPIRVSourceLanguage(int64_t LLVMSourceLanguage);
   static Register emitOpString(MachineRegisterInfo &MRI,
                                MachineIRBuilder &MIRBuilder, StringRef SR);
-  static Register
+  Register
   emitDIInstruction(MachineRegisterInfo &MRI, MachineIRBuilder &MIRBuilder,
                     SPIRVGlobalRegistry *GR, const SPIRVTypeInst &VoidTy,
                     const SPIRVInstrInfo *TII, const SPIRVRegisterInfo *TRI,
@@ -124,7 +127,7 @@ Register SPIRVEmitNonSemanticDI::emitOpString(MachineRegisterInfo &MRI,
                                               MachineIRBuilder &MIRBuilder,
                                               StringRef SR) {
   const Register StrReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
-  MRI.setType(StrReg, LLT::scalar(32));
+  MRI.setType(StrReg, LLT::scalar(64));
   MachineInstrBuilder MIB = MIRBuilder.buildInstr(SPIRV::OpString);
   MIB.addDef(StrReg);
   addStringImm(SR, MIB);
@@ -139,14 +142,12 @@ Register SPIRVEmitNonSemanticDI::emitDIInstruction(
     SPIRV::NonSemanticExtInst::NonSemanticExtInst Inst,
     ArrayRef<Register> Registers) {
   const Register InstReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
-  MRI.setType(InstReg, LLT::scalar(32));
-  MachineInstrBuilder MIB =
-      MIRBuilder.buildInstr(SPIRV::OpExtInst)
-          .addDef(InstReg)
-          .addUse(GR->getSPIRVTypeID(VoidTy))
-          .addImm(static_cast<int64_t>(
-              SPIRV::InstructionSet::NonSemantic_Shader_DebugInfo_100))
-          .addImm(Inst);
+  MRI.setType(InstReg, LLT::scalar(64));
+  MachineInstrBuilder MIB = MIRBuilder.buildInstr(SPIRV::OpExtInst)
+                                .addDef(InstReg)
+                                .addUse(GR->getSPIRVTypeID(VoidTy))
+                                .addImm(static_cast<int64_t>(DebugInfoInstSet))
+                                .addImm(Inst);
   for (auto Reg : Registers) {
     MIB.addUse(Reg);
   }

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
@@ -163,8 +164,6 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
 
   // Required variables to get from metadata search
   LLVMContext *Context;
-  SmallVector<SmallString<128>> FilePaths;
-  SmallVector<int64_t> LLVMSourceLanguages;
   SmallVector<const DICompileUnit *> CompileUnits;
   int64_t DwarfVersion = 0;
   int64_t DebugInfoVersion = 0;
@@ -178,17 +177,12 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
     const NamedMDNode *DbgCu = M->getNamedMetadata("llvm.dbg.cu");
     if (!DbgCu)
       return false;
-    for (const auto *Op : DbgCu->operands()) {
-      if (const auto *CompileUnit = dyn_cast<DICompileUnit>(Op)) {
-        DIFile *File = CompileUnit->getFile();
-        FilePaths.emplace_back();
-        sys::path::append(FilePaths.back(), File->getDirectory(),
-                          File->getFilename());
-        LLVMSourceLanguages.push_back(
-            CompileUnit->getSourceLanguage().getUnversionedName());
-        CompileUnits.push_back(CompileUnit);
-      }
-    }
+    CompileUnits =
+        map_to_vector(make_filter_range(DbgCu->operands(),
+                                        [](const MDNode *Op) {
+                                          return isa<DICompileUnit>(Op);
+                                        }),
+                      [](const MDNode *Op) { return cast<DICompileUnit>(Op); });
     const NamedMDNode *ModuleFlags = M->getNamedMetadata("llvm.module.flags");
     assert(ModuleFlags && "Expected llvm.module.flags metadata to be present");
     for (const auto *Op : ModuleFlags->operands()) {
@@ -262,16 +256,19 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
     const Register DebugInfoVersionReg =
         GR->buildConstantInt(DebugInfoVersion, MIRBuilder, I32Ty, false);
 
-    for (unsigned Idx = 0; Idx < LLVMSourceLanguages.size(); ++Idx) {
-      const Register FilePathStrReg =
-          emitOpString(MRI, MIRBuilder, FilePaths[Idx]);
+    for (unsigned Idx = 0; Idx < CompileUnits.size(); ++Idx) {
+      const DICompileUnit *CompileUnit = CompileUnits[Idx];
+      DIFile *File = CompileUnit->getFile();
+      SmallString<128> FilePath;
+      sys::path::append(FilePath, File->getDirectory(), File->getFilename());
+      const Register FilePathStrReg = emitOpString(MRI, MIRBuilder, FilePath);
 
       const Register DebugSourceResIdReg = emitDIInstruction(
           MRI, MIRBuilder, GR, VoidTy, TII, TRI, RBI, MF,
           SPIRV::NonSemanticExtInst::DebugSource, {FilePathStrReg});
 
-      SourceLanguage SpirvSourceLanguage =
-          convertDWARFToSPIRVSourceLanguage(LLVMSourceLanguages[Idx]);
+      SourceLanguage SpirvSourceLanguage = convertDWARFToSPIRVSourceLanguage(
+          CompileUnit->getSourceLanguage().getUnversionedName());
 
       const Register SourceLanguageReg =
           GR->buildConstantInt(SpirvSourceLanguage, MIRBuilder, I32Ty, false);
@@ -283,7 +280,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
                              DebugSourceResIdReg, SourceLanguageReg});
 
       // Store the register for this compile unit
-      CompileUnitRegMap[CompileUnits[Idx]] = DebugCompUnitResIdReg;
+      CompileUnitRegMap[CompileUnit] = DebugCompUnitResIdReg;
     }
 
     // We aren't extracting any DebugInfoFlags now so we

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -177,12 +177,9 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
     const NamedMDNode *DbgCu = M->getNamedMetadata("llvm.dbg.cu");
     if (!DbgCu)
       return false;
-    CompileUnits =
-        map_to_vector(make_filter_range(DbgCu->operands(),
-                                        [](const MDNode *Op) {
-                                          return isa<DICompileUnit>(Op);
-                                        }),
-                      [](const MDNode *Op) { return cast<DICompileUnit>(Op); });
+    CompileUnits = map_to_vector(
+        make_filter_range(DbgCu->operands(), llvm::IsaPred<DICompileUnit>),
+        llvm::CastTo<DICompileUnit>);
     const NamedMDNode *ModuleFlags = M->getNamedMetadata("llvm.module.flags");
     assert(ModuleFlags && "Expected llvm.module.flags metadata to be present");
     for (const auto *Op : ModuleFlags->operands()) {

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -49,13 +49,13 @@ enum SourceLanguage {
 struct SPIRVEmitNonSemanticDI : public MachineFunctionPass {
   static char ID;
   SPIRVTargetMachine *TM;
+  DenseMap<const DICompileUnit *, Register> CompileUnitRegMap;
   SPIRVEmitNonSemanticDI(SPIRVTargetMachine *TM = nullptr)
       : MachineFunctionPass(ID), TM(TM) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override;
 
 private:
-  bool IsGlobalDIEmitted = false;
   bool emitGlobalDI(MachineFunction &MF);
   static SourceLanguage
   convertDWARFToSPIRVSourceLanguage(int64_t LLVMSourceLanguage);
@@ -160,7 +160,6 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
   // If this MachineFunction doesn't have any BB repeat procedure
   // for the next
   if (MF.begin() == MF.end()) {
-    IsGlobalDIEmitted = false;
     return false;
   }
 
@@ -168,6 +167,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
   LLVMContext *Context;
   SmallVector<SmallString<128>> FilePaths;
   SmallVector<int64_t> LLVMSourceLanguages;
+  SmallVector<const DICompileUnit *> CompileUnits;
   int64_t DwarfVersion = 0;
   int64_t DebugInfoVersion = 0;
   SetVector<DIBasicType *> BasicTypes;
@@ -175,9 +175,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
   // Searching through the Module metadata to find nescessary
   // information like DwarfVersion or SourceLanguage
   {
-    const MachineModuleInfo &MMI =
-        getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
-    const Module *M = MMI.getModule();
+    const Module *M = getModule(MF);
     Context = &M->getContext();
     const NamedMDNode *DbgCu = M->getNamedMetadata("llvm.dbg.cu");
     if (!DbgCu)
@@ -190,6 +188,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
                           File->getFilename());
         LLVMSourceLanguages.push_back(
             CompileUnit->getSourceLanguage().getUnversionedName());
+        CompileUnits.push_back(CompileUnit);
       }
     }
     const NamedMDNode *ModuleFlags = M->getNamedMetadata("llvm.module.flags");
@@ -251,39 +250,9 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
     // and before first terminator
     MachineIRBuilder MIRBuilder(MBB, MBB.getFirstTerminator());
 
-    const auto EmitOpString = [&](StringRef SR) {
-      const Register StrReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
-      MRI.setType(StrReg, LLT::scalar(32));
-      MachineInstrBuilder MIB = MIRBuilder.buildInstr(SPIRV::OpString);
-      MIB.addDef(StrReg);
-      addStringImm(SR, MIB);
-      return StrReg;
-    };
-
     const SPIRVTypeInst VoidTy =
         GR->getOrCreateSPIRVType(Type::getVoidTy(*Context), MIRBuilder,
                                  SPIRV::AccessQualifier::ReadWrite, false);
-
-    const auto EmitDIInstruction =
-        [&](SPIRV::NonSemanticExtInst::NonSemanticExtInst Inst,
-            std::initializer_list<Register> Registers) {
-          const Register InstReg =
-              MRI.createVirtualRegister(&SPIRV::IDRegClass);
-          MRI.setType(InstReg, LLT::scalar(32));
-          MachineInstrBuilder MIB =
-              MIRBuilder.buildInstr(SPIRV::OpExtInst)
-                  .addDef(InstReg)
-                  .addUse(GR->getSPIRVTypeID(VoidTy))
-                  .addImm(static_cast<int64_t>(
-                      SPIRV::InstructionSet::NonSemantic_Shader_DebugInfo_100))
-                  .addImm(Inst);
-          for (auto Reg : Registers) {
-            MIB.addUse(Reg);
-          }
-          MIB.constrainAllUses(*TII, *TRI, *RBI);
-          GR->assignSPIRVTypeToVReg(VoidTy, InstReg, MF);
-          return InstReg;
-        };
 
     const SPIRVTypeInst I32Ty =
         GR->getOrCreateSPIRVType(Type::getInt32Ty(*Context), MIRBuilder,
@@ -296,43 +265,27 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
         GR->buildConstantInt(DebugInfoVersion, MIRBuilder, I32Ty, false);
 
     for (unsigned Idx = 0; Idx < LLVMSourceLanguages.size(); ++Idx) {
-      const Register FilePathStrReg = EmitOpString(FilePaths[Idx]);
+      const Register FilePathStrReg =
+          emitOpString(MRI, MIRBuilder, FilePaths[Idx]);
 
-      const Register DebugSourceResIdReg = EmitDIInstruction(
+      const Register DebugSourceResIdReg = emitDIInstruction(
+          MRI, MIRBuilder, GR, VoidTy, TII, TRI, RBI, MF,
           SPIRV::NonSemanticExtInst::DebugSource, {FilePathStrReg});
 
-      SourceLanguage SpirvSourceLanguage = SourceLanguage::Unknown;
-      switch (LLVMSourceLanguages[Idx]) {
-      case dwarf::DW_LANG_OpenCL:
-        SpirvSourceLanguage = SourceLanguage::OpenCL_C;
-        break;
-      case dwarf::DW_LANG_OpenCL_CPP:
-        SpirvSourceLanguage = SourceLanguage::OpenCL_CPP;
-        break;
-      case dwarf::DW_LANG_CPP_for_OpenCL:
-        SpirvSourceLanguage = SourceLanguage::CPP_for_OpenCL;
-        break;
-      case dwarf::DW_LANG_GLSL:
-        SpirvSourceLanguage = SourceLanguage::GLSL;
-        break;
-      case dwarf::DW_LANG_HLSL:
-        SpirvSourceLanguage = SourceLanguage::HLSL;
-        break;
-      case dwarf::DW_LANG_SYCL:
-        SpirvSourceLanguage = SourceLanguage::SYCL;
-        break;
-      case dwarf::DW_LANG_Zig:
-        SpirvSourceLanguage = SourceLanguage::Zig;
-      }
+      SourceLanguage SpirvSourceLanguage =
+          convertDWARFToSPIRVSourceLanguage(LLVMSourceLanguages[Idx]);
 
       const Register SourceLanguageReg =
           GR->buildConstantInt(SpirvSourceLanguage, MIRBuilder, I32Ty, false);
 
-      [[maybe_unused]]
       const Register DebugCompUnitResIdReg =
-          EmitDIInstruction(SPIRV::NonSemanticExtInst::DebugCompilationUnit,
+          emitDIInstruction(MRI, MIRBuilder, GR, VoidTy, TII, TRI, RBI, MF,
+                            SPIRV::NonSemanticExtInst::DebugCompilationUnit,
                             {DebugInfoVersionReg, DwarfVersionReg,
                              DebugSourceResIdReg, SourceLanguageReg});
+
+      // Store the register for this compile unit
+      CompileUnitRegMap[CompileUnits[Idx]] = DebugCompUnitResIdReg;
     }
 
     // We aren't extracting any DebugInfoFlags now so we
@@ -346,7 +299,8 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
     SmallVector<std::pair<const DIBasicType *const, const Register>, 12>
         BasicTypeRegPairs;
     for (auto *BasicType : BasicTypes) {
-      const Register BasicTypeStrReg = EmitOpString(BasicType->getName());
+      const Register BasicTypeStrReg =
+          emitOpString(MRI, MIRBuilder, BasicType->getName());
 
       const Register ConstIntBitwidthReg = GR->buildConstantInt(
           BasicType->getSizeInBits(), MIRBuilder, I32Ty, false);
@@ -379,7 +333,8 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
           GR->buildConstantInt(AttributeEncoding, MIRBuilder, I32Ty, false);
 
       const Register BasicTypeReg =
-          EmitDIInstruction(SPIRV::NonSemanticExtInst::DebugTypeBasic,
+          emitDIInstruction(MRI, MIRBuilder, GR, VoidTy, TII, TRI, RBI, MF,
+                            SPIRV::NonSemanticExtInst::DebugTypeBasic,
                             {BasicTypeStrReg, ConstIntBitwidthReg,
                              AttributeEncodingReg, I32ZeroReg});
       BasicTypeRegPairs.emplace_back(BasicType, BasicTypeReg);
@@ -403,19 +358,22 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
           for (const auto &BasicTypeRegPair : BasicTypeRegPairs) {
             const auto &[DefinedBasicType, BasicTypeReg] = BasicTypeRegPair;
             if (DefinedBasicType == MaybeNestedBasicType) {
-              [[maybe_unused]]
-              const Register DebugPointerTypeReg = EmitDIInstruction(
-                  SPIRV::NonSemanticExtInst::DebugTypePointer,
-                  {BasicTypeReg, StorageClassReg, I32ZeroReg});
+              [[maybe_unused]] const Register DebugPointerTypeReg =
+                  emitDIInstruction(
+                      MRI, MIRBuilder, GR, VoidTy, TII, TRI, RBI, MF,
+                      SPIRV::NonSemanticExtInst::DebugTypePointer,
+                      {BasicTypeReg, StorageClassReg, I32ZeroReg});
             }
           }
         } else {
           const Register DebugInfoNoneReg =
-              EmitDIInstruction(SPIRV::NonSemanticExtInst::DebugInfoNone, {});
-          [[maybe_unused]]
-          const Register DebugPointerTypeReg = EmitDIInstruction(
-              SPIRV::NonSemanticExtInst::DebugTypePointer,
-              {DebugInfoNoneReg, StorageClassReg, I32ZeroReg});
+              emitDIInstruction(MRI, MIRBuilder, GR, VoidTy, TII, TRI, RBI, MF,
+                                SPIRV::NonSemanticExtInst::DebugInfoNone, {});
+          [[maybe_unused]] const Register DebugPointerTypeReg =
+              emitDIInstruction(
+                  MRI, MIRBuilder, GR, VoidTy, TII, TRI, RBI, MF,
+                  SPIRV::NonSemanticExtInst::DebugTypePointer,
+                  {DebugInfoNoneReg, StorageClassReg, I32ZeroReg});
         }
       }
     }
@@ -424,12 +382,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
 }
 
 bool SPIRVEmitNonSemanticDI::runOnMachineFunction(MachineFunction &MF) {
-  bool Res = false;
-  // emitGlobalDI needs to be executed only once to avoid
-  // emitting duplicates
-  if (!IsGlobalDIEmitted) {
-    IsGlobalDIEmitted = true;
-    Res = emitGlobalDI(MF);
-  }
+  CompileUnitRegMap.clear();
+  bool Res = emitGlobalDI(MF);
   return Res;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -5,6 +5,7 @@
 #include "SPIRVRegisterInfo.h"
 #include "SPIRVTargetMachine.h"
 #include "SPIRVUtils.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
@@ -67,7 +68,7 @@ private:
                     const SPIRVInstrInfo *TII, const SPIRVRegisterInfo *TRI,
                     const RegisterBankInfo *RBI, MachineFunction &MF,
                     SPIRV::NonSemanticExtInst::NonSemanticExtInst Inst,
-                    std::initializer_list<Register> Registers);
+                    ArrayRef<Register> Registers);
 };
 } // anonymous namespace
 
@@ -135,7 +136,7 @@ Register SPIRVEmitNonSemanticDI::emitDIInstruction(
     const SPIRVInstrInfo *TII, const SPIRVRegisterInfo *TRI,
     const RegisterBankInfo *RBI, MachineFunction &MF,
     SPIRV::NonSemanticExtInst::NonSemanticExtInst Inst,
-    std::initializer_list<Register> Registers) {
+    ArrayRef<Register> Registers) {
   const Register InstReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
   MRI.setType(InstReg, LLT::scalar(32));
   MachineInstrBuilder MIB =

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -59,7 +59,6 @@ private:
   bool emitGlobalDI(MachineFunction &MF);
   static SourceLanguage
   convertDWARFToSPIRVSourceLanguage(int64_t LLVMSourceLanguage);
-  const Module *getModule(MachineFunction &MF);
   static Register emitOpString(MachineRegisterInfo &MRI,
                                MachineIRBuilder &MIRBuilder, StringRef SR);
   static Register
@@ -115,10 +114,8 @@ SourceLanguage SPIRVEmitNonSemanticDI::convertDWARFToSPIRVSourceLanguage(
   }
 }
 
-const Module *SPIRVEmitNonSemanticDI::getModule(MachineFunction &MF) {
-  const MachineModuleInfo &MMI =
-      getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
-  return MMI.getModule();
+static const Module *getModule(MachineFunction &MF) {
+  return MF.getFunction().getParent();
 }
 
 Register SPIRVEmitNonSemanticDI::emitOpString(MachineRegisterInfo &MRI,

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -5,7 +5,8 @@
 #include "SPIRVRegisterInfo.h"
 #include "SPIRVTargetMachine.h"
 #include "SPIRVUtils.h"
-#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
@@ -29,6 +30,22 @@
 using namespace llvm;
 
 namespace {
+enum SourceLanguage {
+  Unknown = 0,
+  ESSL = 1,
+  GLSL = 2,
+  OpenCL_C = 3,
+  OpenCL_CPP = 4,
+  HLSL = 5,
+  CPP_for_OpenCL = 6,
+  SYCL = 7,
+  HERO_C = 8,
+  NZSL = 9,
+  WGSL = 10,
+  Slang = 11,
+  Zig = 12
+};
+
 struct SPIRVEmitNonSemanticDI : public MachineFunctionPass {
   static char ID;
   SPIRVTargetMachine *TM;
@@ -40,6 +57,18 @@ struct SPIRVEmitNonSemanticDI : public MachineFunctionPass {
 private:
   bool IsGlobalDIEmitted = false;
   bool emitGlobalDI(MachineFunction &MF);
+  static SourceLanguage
+  convertDWARFToSPIRVSourceLanguage(int64_t LLVMSourceLanguage);
+  const Module *getModule(MachineFunction &MF);
+  static Register emitOpString(MachineRegisterInfo &MRI,
+                               MachineIRBuilder &MIRBuilder, StringRef SR);
+  static Register
+  emitDIInstruction(MachineRegisterInfo &MRI, MachineIRBuilder &MIRBuilder,
+                    SPIRVGlobalRegistry *GR, const SPIRVTypeInst &VoidTy,
+                    const SPIRVInstrInfo *TII, const SPIRVRegisterInfo *TRI,
+                    const RegisterBankInfo *RBI, MachineFunction &MF,
+                    SPIRV::NonSemanticExtInst::NonSemanticExtInst Inst,
+                    std::initializer_list<Register> Registers);
 };
 } // anonymous namespace
 
@@ -64,21 +93,68 @@ enum BaseTypeAttributeEncoding {
   UnsignedChar = 7
 };
 
-enum SourceLanguage {
-  Unknown = 0,
-  ESSL = 1,
-  GLSL = 2,
-  OpenCL_C = 3,
-  OpenCL_CPP = 4,
-  HLSL = 5,
-  CPP_for_OpenCL = 6,
-  SYCL = 7,
-  HERO_C = 8,
-  NZSL = 9,
-  WGSL = 10,
-  Slang = 11,
-  Zig = 12
-};
+SourceLanguage SPIRVEmitNonSemanticDI::convertDWARFToSPIRVSourceLanguage(
+    int64_t LLVMSourceLanguage) {
+  switch (LLVMSourceLanguage) {
+  case dwarf::DW_LANG_OpenCL:
+    return SourceLanguage::OpenCL_C;
+  case dwarf::DW_LANG_OpenCL_CPP:
+    return SourceLanguage::OpenCL_CPP;
+  case dwarf::DW_LANG_CPP_for_OpenCL:
+    return SourceLanguage::CPP_for_OpenCL;
+  case dwarf::DW_LANG_GLSL:
+    return SourceLanguage::GLSL;
+  case dwarf::DW_LANG_HLSL:
+    return SourceLanguage::HLSL;
+  case dwarf::DW_LANG_SYCL:
+    return SourceLanguage::SYCL;
+  case dwarf::DW_LANG_Zig:
+    return SourceLanguage::Zig;
+  default:
+    return SourceLanguage::Unknown;
+  }
+}
+
+const Module *SPIRVEmitNonSemanticDI::getModule(MachineFunction &MF) {
+  const MachineModuleInfo &MMI =
+      getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
+  return MMI.getModule();
+}
+
+Register SPIRVEmitNonSemanticDI::emitOpString(MachineRegisterInfo &MRI,
+                                              MachineIRBuilder &MIRBuilder,
+                                              StringRef SR) {
+  const Register StrReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
+  MRI.setType(StrReg, LLT::scalar(32));
+  MachineInstrBuilder MIB = MIRBuilder.buildInstr(SPIRV::OpString);
+  MIB.addDef(StrReg);
+  addStringImm(SR, MIB);
+  return StrReg;
+}
+
+Register SPIRVEmitNonSemanticDI::emitDIInstruction(
+    MachineRegisterInfo &MRI, MachineIRBuilder &MIRBuilder,
+    SPIRVGlobalRegistry *GR, const SPIRVTypeInst &VoidTy,
+    const SPIRVInstrInfo *TII, const SPIRVRegisterInfo *TRI,
+    const RegisterBankInfo *RBI, MachineFunction &MF,
+    SPIRV::NonSemanticExtInst::NonSemanticExtInst Inst,
+    std::initializer_list<Register> Registers) {
+  const Register InstReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
+  MRI.setType(InstReg, LLT::scalar(32));
+  MachineInstrBuilder MIB =
+      MIRBuilder.buildInstr(SPIRV::OpExtInst)
+          .addDef(InstReg)
+          .addUse(GR->getSPIRVTypeID(VoidTy))
+          .addImm(static_cast<int64_t>(
+              SPIRV::InstructionSet::NonSemantic_Shader_DebugInfo_100))
+          .addImm(Inst);
+  for (auto Reg : Registers) {
+    MIB.addUse(Reg);
+  }
+  MIB.constrainAllUses(*TII, *TRI, *RBI);
+  GR->assignSPIRVTypeToVReg(VoidTy, InstReg, MF);
+  return InstReg;
+}
 
 bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
   // If this MachineFunction doesn't have any BB repeat procedure

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -275,7 +275,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
                             {DebugInfoVersionReg, DwarfVersionReg,
                              DebugSourceResIdReg, SourceLanguageReg});
 
-      // Store the register for this compile unit
+      // Store the register for this compile unit.
       CompileUnitRegMap[CompileUnit] = DebugCompUnitResIdReg;
     }
 

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -253,9 +253,8 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
     const Register DebugInfoVersionReg =
         GR->buildConstantInt(DebugInfoVersion, MIRBuilder, I32Ty, false);
 
-    for (unsigned Idx = 0; Idx < CompileUnits.size(); ++Idx) {
-      const DICompileUnit *CompileUnit = CompileUnits[Idx];
-      DIFile *File = CompileUnit->getFile();
+    for (const DICompileUnit *CompileUnit : CompileUnits) {
+      const DIFile *File = CompileUnit->getFile();
       SmallString<128> FilePath;
       sys::path::append(FilePath, File->getDirectory(), File->getFilename());
       const Register FilePathStrReg = emitOpString(MRI, MIRBuilder, FilePath);

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -45,7 +45,9 @@ enum SourceLanguage {
   NZSL = 9,
   WGSL = 10,
   Slang = 11,
-  Zig = 12
+  Zig = 12,
+  Rust = 13,
+  Max = 0x7fffffff
 };
 
 struct SPIRVEmitNonSemanticDI : public MachineFunctionPass {
@@ -114,6 +116,8 @@ SourceLanguage SPIRVEmitNonSemanticDI::convertDWARFToSPIRVSourceLanguage(
     return SourceLanguage::SYCL;
   case dwarf::DW_LANG_Zig:
     return SourceLanguage::Zig;
+  case dwarf::DW_LANG_Rust:
+    return SourceLanguage::Rust;
   default:
     return SourceLanguage::Unknown;
   }

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-compilation-unit.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-compilation-unit.ll
@@ -1,20 +1,6 @@
-; RUN: llc --verify-machineinstrs --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info --print-after=spirv-nonsemantic-debug-info -O0 -mtriple=spirv64-unknown-unknown %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-MIR
 ; RUN: llc --verify-machineinstrs --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llc --verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_non_semantic_info %s -o - | FileCheck %s --check-prefix=CHECK-OPTION 
 ; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
-
-; CHECK-MIR-DAG: [[type_void:%[0-9]+\:type]] = OpTypeVoid
-; CHECK-MIR-DAG: [[type_i64:%[0-9]+\:type\(s64\)]] = OpTypeInt 32, 0
-; CHECK-MIR-DAG: [[dwarf_version:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i64]], 5
-; CHECK-MIR-DAG: [[debug_info_version:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i64]], 3
-; CHECK-MIR-DAG: [[source_language_sycl:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i64]], 7
-; CHECK-MIR-DAG: [[source_language_cpp:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i64]], 4
-; CHECK-MIR-DAG: [[filename_str_sycl:%[0-9]+\:id\(s32\)]] = OpString 1094795567, 1094795585, 792805697, 1111638594, 1111638594, 1128481583, 1128481603, {{1697596227|1700545347}}, 1886216568, 1663985004, 0
-; CHECK-MIR-DAG: [[filename_str_cpp:%[0-9]+\:id\(s32\)]] = OpString 1145324591, 1145324612, 793003076, 1162167621, 1162167621, 1179010607, 1179010630, {{1697596998|1700546118}}, 1886216568, 774989164, 7368803
-; CHECK-MIR-DAG: [[debug_source_sycl:%[0-9]+\:id\(s32\)]] = OpExtInst [[type_void]], 3, 35, [[filename_str_sycl]]
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 1, [[debug_info_version]], [[dwarf_version]], [[debug_source_sycl]], [[source_language_sycl]]
-; CHECK-MIR-DAG: [[debug_source_cpp:%[0-9]+\:id\(s32\)]] = OpExtInst [[type_void]], 3, 35, [[filename_str_cpp]]
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 1, [[debug_info_version]], [[dwarf_version]], [[debug_source_cpp]], [[source_language_cpp]]
 
 ; CHECK-SPIRV: [[ext_inst_non_semantic:%[0-9]+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 ; CHECK-SPIRV: [[filename_str_sycl:%[0-9]+]] = OpString "/AAAAAAAAAA/BBBBBBBB/CCCCCCCCC{{[/\\]}}example.c"

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-basic.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-basic.ll
@@ -1,43 +1,6 @@
-; RUN: llc --verify-machineinstrs --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info --print-after=spirv-nonsemantic-debug-info -O0 -mtriple=spirv64-unknown-unknown %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-MIR
 ; RUN: llc --verify-machineinstrs --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llc --verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_non_semantic_info %s -o - | FileCheck %s --check-prefix=CHECK-OPTION
 ; RUN: %if spirv-tools %{ llc --verify-machineinstrs --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
-
-; CHECK-MIR-DAG: [[type_void:%[0-9]+\:type]] = OpTypeVoid
-; CHECK-MIR-DAG: [[type_i32:%[0-9]+\:type]] = OpTypeInt 32, 0
-; CHECK-MIR-DAG: [[encoding_signedchar:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 5
-; CHECK-MIR-DAG: [[encoding_float:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 3
-; CHECK-MIR-DAG: [[flag_zero:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 0
-; CHECK-MIR-DAG: [[str_bool:%[0-9]+\:id\(s32\)]] = OpString 1819242338, 0
-; CHECK-MIR-DAG: [[size_8bits:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 8
-; CHECK-MIR-DAG: [[encoding_boolean:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 2
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 2, [[str_bool]], [[size_8bits]], [[encoding_boolean]], [[flag_zero]]
-; CHECK-MIR-DAG: [[str_int:%[0-9]+\:id\(s32\)]] = OpString 7630441
-; CHECK-MIR-DAG: [[size_32bits:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 32
-; CHECK-MIR-DAG: [[encoding_signed:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 4
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 2, [[str_int]], [[size_32bits]], [[encoding_signed]], [[flag_zero]]
-; CHECK-MIR-DAG: [[str_short:%[0-9]+\:id\(s32\)]] = OpString 1919903859, 116
-; CHECK-MIR-DAG: [[size_16bits:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 16
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 2, [[str_short]], [[size_16bits]], [[encoding_signed]], [[flag_zero]]
-; CHECK-MIR-DAG: [[str_char:%[0-9]+\:id\(s32\)]] = OpString 1918986339, 0
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 2, [[str_char]], [[size_8bits]], [[encoding_signedchar]], [[flag_zero]]
-; CHECK-MIR-DAG: [[str_long:%[0-9]+\:id\(s32\)]] = OpString 1735290732, 0
-; CHECK-MIR-DAG: [[size_64bits:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 64
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 2, [[str_long]], [[size_64bits]], [[encoding_signed]], [[flag_zero]]
-; CHECK-MIR-DAG: [[str_uint:%[0-9]+\:id\(s32\)]] = OpString 1769172597, 1684368999, 1953392928, 0
-; CHECK-MIR-DAG: [[encoding_unsigned:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 6
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 2, [[str_uint]], [[size_32bits]], [[encoding_unsigned]], [[flag_zero]]
-; CHECK-MIR-DAG: [[str_ushort:%[0-9]+\:id\(s32\)]] = OpString 1769172597, 1684368999, 1869116192, 29810
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 2, [[str_ushort]], [[size_16bits]], [[encoding_unsigned]], [[flag_zero]]
-; CHECK-MIR-DAG: [[str_uchar:%[0-9]+\:id\(s32\)]] = OpString 1769172597, 1684368999, 1634231072, 114
-; CHECK-MIR-DAG: [[encoding_unsignedchar:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 7
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 2, [[str_uchar]], [[size_8bits]], [[encoding_unsignedchar]], [[flag_zero]]
-; CHECK-MIR-DAG: [[str_ulong:%[0-9]+\:id\(s32\)]] = OpString 1769172597, 1684368999, 1852795936, 103
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 2, [[str_ulong]], [[size_64bits]], [[encoding_unsigned]], [[flag_zero]]
-; CHECK-MIR-DAG: [[str_float:%[0-9]+\:id\(s32\)]] = OpString 1634692198, 116
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 2, [[str_float]], [[size_32bits]], [[encoding_float]], [[flag_zero]]
-; CHECK-MIR-DAG: [[str_double:%[0-9]+\:id\(s32\)]] = OpString 1651863396, 25964
-; CHECK-MIR-DAG: OpExtInst [[type_void]], 3, 2, [[str_double]], [[size_64bits]], [[encoding_float]], [[flag_zero]]
 
 ; CHECK-SPIRV: [[ext_inst_non_semantic:%[0-9]+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 ; CHECK-SPIRV-DAG: [[str_bool:%[0-9]+]] = OpString "bool"

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-pointer.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-pointer.ll
@@ -1,48 +1,8 @@
-; RUN: llc --verify-machineinstrs --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info --print-after=spirv-nonsemantic-debug-info -O0 -mtriple=spirv64-unknown-unknown %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-MIR
-; RUN: llc --verify-machineinstrs --print-after=spirv-nonsemantic-debug-info -O0 -mtriple=spirv64-amd-amdhsa %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-MIR
 ; RUN: llc --verify-machineinstrs --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llc --verify-machineinstrs -O0 -mtriple=spirv64-amd-amdhsa %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llc --verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_non_semantic_info %s -o - | FileCheck %s --check-prefix=CHECK-OPTION
 ; TODO(#109287): When type is void * the spirv-val raises an error when DebugInfoNone is set as <id> Base Type argument of DebugTypePointer.
 ; DISABLED: %if spirv-tools %{ llc --verify-machineinstrs --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
-
-; CHECK-MIR-DAG:   [[i32type:%[0-9]+\:type]] = OpTypeInt 32, 0
-; CHECK-MIR-DAG:   [[void_type:%[0-9]+\:type\(s64\)]] = OpTypeVoid
-; CHECK-MIR-DAG:   [[i32_8:%[0-9]+\:iid]] = OpConstantI [[i32type]], 8{{$}}
-; CHECK-MIR-DAG:   [[i32_0:%[0-9]+\:iid(\(s32\))?]] = OpConstantNull [[i32type]]
-; CHECK-MIR-DAG:   [[i32_5:%[0-9]+\:iid\(s32\)]] = OpConstantI [[i32type]], 5{{$}}
-; CHECK-MIR-DAG:   [[enc_float:%[0-9]+\:iid\(s32\)]] = OpConstantI [[i32type]], 3{{$}}
-; CHECK-MIR-DAG:   [[enc_boolean:%[0-9]+\:iid\(s32\)]] = OpConstantI [[i32type]], 2{{$}}
-; CHECK-MIR-DAG:   [[bool:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 2, {{%[0-9]+\:[a-z0-9\(\)]+}}, [[i32_8]], [[enc_boolean]], [[i32_0]]
-; CHECK-MIR-DAG:   [[i32_16:%[0-9]+\:iid\(s32\)]] = OpConstantI [[i32type]], 16{{$}}
-; CHECK-MIR-DAG:   [[enc_signed:%[0-9]+\:iid\(s32\)]] = OpConstantI [[i32type]], 4{{$}}
-; CHECK-MIR-DAG:   [[short:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 2, {{%[0-9]+\:[a-z0-9\(\)]+}}, [[i32_16]], [[enc_signed]], [[i32_0]]
-; CHECK-MIR-DAG:   [[char:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 2, {{%[0-9]+\:[a-z0-9\(\)]+}}, [[i32_8]], [[i32_5]], [[i32_0]]
-; CHECK-MIR-DAG:   [[i32_64:%[0-9]+\:iid\(s32\)]] = OpConstantI [[i32type]], 64{{$}}
-; CHECK-MIR-DAG:   [[long:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 2, {{%[0-9]+\:[a-z0-9\(\)]+}}, [[i32_64]], [[enc_signed]], [[i32_0]]
-; CHECK-MIR-DAG:   [[i32_32:%[0-9]+\:iid\(s32\)]] = OpConstantI [[i32type]], 32{{$}}
-; CHECK-MIR-DAG:   [[enc_unsigned:%[0-9]+\:iid\(s32\)]] = OpConstantI [[i32type]], 6{{$}}
-; CHECK-MIR-DAG:   [[unsigned_int:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 2, {{%[0-9]+\:[a-z0-9\(\)]+}}, [[i32_32]], [[enc_unsigned]], [[i32_0]]
-; CHECK-MIR-DAG:   [[unsigned_short:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 2, {{%[0-9]+\:[a-z0-9\(\)]+}}, [[i32_16]], [[enc_unsigned]], [[i32_0]]
-; CHECK-MIR-DAG:   [[enc_unsigned_char:%[0-9]+\:iid\(s32\)]] = OpConstantI [[i32type]], 7{{$}}
-; CHECK-MIR-DAG:   [[unsigned_char:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 2, {{%[0-9]+\:[a-z0-9\(\)]+}}, [[i32_8]], [[enc_unsigned_char]], [[i32_0]]
-; CHECK-MIR-DAG:   [[unsigned_long:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 2, {{%[0-9]+\:[a-z0-9\(\)]+}}, [[i32_64]], [[enc_unsigned]], [[i32_0]]
-; CHECK-MIR-DAG:   [[float:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 2, {{%[0-9]+\:[a-z0-9\(\)]+}}, [[i32_32]], [[enc_float]], [[i32_0]]
-; CHECK-MIR-DAG:   [[double:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 2, {{%[0-9]+\:[a-z0-9\(\)]+}}, [[i32_64]], [[enc_float]], [[i32_0]]
-; CHECK-MIR-DAG:   [[int:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 2, {{%[0-9]+\:[a-z0-9\(\)]+}}, [[i32_32]], [[enc_signed]], [[i32_0]]
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[bool]], [[i32_8]], [[i32_0]]
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[short]], [[i32_8]], [[i32_0]]
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[char]], [[i32_8]], [[i32_0]]
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[long]], [[i32_8]], [[i32_0]]
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[unsigned_int]], [[i32_8]], [[i32_0]]
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[unsigned_short]], [[i32_8]], [[i32_0]]
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[unsigned_char]], [[i32_8]], [[i32_0]]
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[unsigned_long]], [[i32_8]], [[i32_0]]
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[float]], [[i32_8]], [[i32_0]]
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[double]], [[i32_8]], [[i32_0]]
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[int]], [[i32_5]], [[i32_0]]
-; CHECK-MIR:   [[debug_info_none:%[0-9]+\:id\(s32\)]] = OpExtInst [[void_type]], 3, 0
-; CHECK-MIR:   OpExtInst [[void_type]], 3, 3, [[debug_info_none]], [[i32_5]], [[i32_0]]
 
 ; CHECK-SPIRV:	[[i32type:%[0-9]+]] = OpTypeInt 32 0
 ; CHECK-SPIRV-DAG:	[[i32_8:%[0-9]+]] = OpConstant [[i32type]] 8{{$}}


### PR DESCRIPTION
This is one PR of a series that aim to introduce support for [DebugFunction](https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc#DebugFunction).

This PR introduces the following changes:

1. extracts some local lambdas and long regions of code into helper functions to avoid code duplication and improve readability.
2. It stores the `DebugCompilationUnit` into `CompileUnitRegMap` so they can be retrieved when needed (in https://github.com/llvm/llvm-project/pull/183122)
3. `DebugCompilationUnit` it is now emitted for every function because every function will require it when emitting `DebugFunction` (in https://github.com/llvm/llvm-project/pull/183122).

This PR makes `emitGlobalDI` emit multiple `DebugCompilationUnit` per function in addition to other opcodes (`DebugSource`, `DebugTypeBasic`, `DebugInfoNone` and `DebugTypePointer`). They will have to be deduplicated later. This deduplication handling is not yet implemented and will do in a separate PR. 

Stacked PRs:

- https://github.com/llvm/llvm-project/pull/183122
- https://github.com/llvm/llvm-project/pull/183121
- [current] https://github.com/llvm/llvm-project/pull/183117