### PR TITLE
[flang] Fail more gracefully when asked to read a bogus module file

### DIFF
--- a/flang/test/Driver/intrinsic-module-path.f90
+++ b/flang/test/Driver/intrinsic-module-path.f90
@@ -1,7 +1,7 @@
 ! Ensure argument -fintrinsic-modules-path works as expected.
 ! WITHOUT the option, the default location for the module is checked and no error generated.
 ! With the option GIVEN, the module with the same name is PREPENDED, and considered over the
-! default one, causing a CHECKSUM error.
+! default one, causing an error.
 
 !-----------------------------------------
 ! FRONTEND FLANG DRIVER (flang -fc1)
@@ -13,8 +13,8 @@
 ! WITHOUT-NOT: 'ieee_arithmetic.mod' was not found
 ! WITHOUT-NOT: 'iso_fortran_env.mod' was not found
 
-! GIVEN: error: Cannot use module file for module 'ieee_arithmetic': File has invalid checksum
-! GIVEN: error: Cannot use module file for module 'iso_fortran_env': File has invalid checksum
+! GIVEN: error: Cannot read module file for module 'ieee_arithmetic': 'ieee_arithmetic.mod' is not a module file for this compiler
+! GIVEN: error: Cannot read module file for module 'iso_fortran_env': 'iso_fortran_env.mod' is not a module file for this compiler
 
 
 program test_intrinsic_module_path

--- a/flang/test/Semantics/Inputs/modfile83.mod
+++ b/flang/test/Semantics/Inputs/modfile83.mod
@@ -1,0 +1,1 @@
+This is not a valid module file.

--- a/flang/test/Semantics/modfile83.f90
+++ b/flang/test/Semantics/modfile83.f90
@@ -1,0 +1,4 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1 -J %S/Inputs
+!ERROR: Cannot read module file for module 'modfile83': 'modfile83.mod' is not a module file for this compiler
+use modfile83
+end


### PR DESCRIPTION
Flang-new emits a torrent of Fortran tokenization error messages when asked to read a module file from another compiler.  Handle this case with a better error message.