### PR TITLE
[libc] Remove MSAN_UNPOISON from `bit_cast` and `bit_copy`

### DIFF
--- a/libc/src/__support/CPP/bit.h
+++ b/libc/src/__support/CPP/bit.h
@@ -46,7 +46,6 @@ LIBC_INLINE static constexpr cpp::enable_if_t<
         cpp::is_trivially_copyable<From>::value,
     To>
 bit_cast(const From &from) {
-  MSAN_UNPOISON(&from, sizeof(From));
 #if __has_builtin(__builtin_bit_cast) || defined(LIBC_COMPILER_IS_MSVC)
   return __builtin_bit_cast(To, from);
 #else
@@ -67,7 +66,6 @@ LIBC_INLINE constexpr cpp::enable_if_t<
         cpp::is_trivially_copyable<From>::value,
     void>
 bit_copy(const From &from, To &to) {
-  MSAN_UNPOISON(&from, sizeof(From));
   char *dst = reinterpret_cast<char *>(&to);
   const char *src = reinterpret_cast<const char *>(&from);
   inline_copy<sizeof(From)>(src, dst);


### PR DESCRIPTION
The `MSAN_UNPOISON` calls were manually unpoisoning the source memory,
which can hide legitimate bugs where uninitialized memory is being
copied.

`MSAN_UNPOISON` should not be used in such wide spread utilities as
`bit_cast` and `bit_copy` but rather close to API boundary where
have no better way to avoid uninitialized bits.

* `MSAN_UNPOISON`  was add to `bit_copy` with #165015, but it looks like a copy-paste from `bit_cast`.
* `bit_cast` has it from #70067, but I can't find valid reproducer any more. If it's still the issue, `MSAN_UNPOISON` \
  should move close the source of uninitialized values.