### PR TITLE
[clang][ssaf] Skip permission-based tests when permissions are not enforced

### DIFF
--- a/clang/unittests/Analysis/Scalable/Serialization/JSONFormatTest/TUSummaryTest.cpp
+++ b/clang/unittests/Analysis/Scalable/Serialization/JSONFormatTest/TUSummaryTest.cpp
@@ -303,6 +303,10 @@ TEST_F(JSONFormatTUSummaryTest, NoReadPermission) {
 #ifdef _WIN32
   GTEST_SKIP() << "Permission model differs on Windows";
 #endif
+  if (!permissionsAreEnforced()) {
+    GTEST_SKIP() << "File permission checks are not enforced in this "
+                    "environment";
+  }
 
   PathString FileName("no-read-permission.json");
 
@@ -1915,6 +1919,10 @@ TEST_F(JSONFormatTUSummaryTest, WriteStreamOpenFailure) {
 #ifdef _WIN32
   GTEST_SKIP() << "Permission model differs on Windows";
 #endif
+  if (!permissionsAreEnforced()) {
+    GTEST_SKIP() << "File permission checks are not enforced in this "
+                    "environment";
+  }
 
   const PathString DirName("write-protected-dir");
 

--- a/clang/unittests/Analysis/Scalable/Serialization/JSONFormatTest/TUSummaryTest.cpp
+++ b/clang/unittests/Analysis/Scalable/Serialization/JSONFormatTest/TUSummaryTest.cpp
@@ -300,9 +300,6 @@ TEST_F(JSONFormatTUSummaryTest, BrokenSymlink) {
 }
 
 TEST_F(JSONFormatTUSummaryTest, NoReadPermission) {
-#ifdef _WIN32
-  GTEST_SKIP() << "Permission model differs on Windows";
-#endif
   if (!permissionsAreEnforced()) {
     GTEST_SKIP() << "File permission checks are not enforced in this "
                     "environment";
@@ -1916,9 +1913,6 @@ TEST_F(JSONFormatTUSummaryTest, WriteNotJsonExtension) {
 }
 
 TEST_F(JSONFormatTUSummaryTest, WriteStreamOpenFailure) {
-#ifdef _WIN32
-  GTEST_SKIP() << "Permission model differs on Windows";
-#endif
   if (!permissionsAreEnforced()) {
     GTEST_SKIP() << "File permission checks are not enforced in this "
                     "environment";


### PR DESCRIPTION
`JSONFormatTest/NoReadPermission` and `JSONFormatTest/WriteStreamOpenFailure` are negative tests that expect file operations to fail when Unix permissions are revoked. These tests unexpectedly succeed instead of failing if they are run as root, or executed in environments with non-standard filesystem semantics that do not enforce permission checks.

This change adds a `permissionsAreEnforced()` helper to the `JSONFormatTest` fixture that detects if:
  - The process is running as root `(getuid() == 0)`
  - A probe file with read permission removed can still be opened, indicating that file permission has no effect in the current environment. The probe file's permissions are restored before returning so `TearDown` can clean up the temp directory unconditionally.

This method is used to skip the two negative tests rather than failing with a spurious assertion error. 

rdar://170917013
rdar://170916929