### PR TITLE
[SPIRV] Fix legalization of zero-size external global

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizeZeroSizeArrays.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizeZeroSizeArrays.cpp
@@ -297,7 +297,8 @@ bool SPIRVLegalizeZeroSizeArraysImpl::runOnModule(Module &M) {
       continue;
 
     Type *NewTy = legalizeType(GV.getValueType());
-    Constant *LegalizedInitializer = legalizeConstant(GV.getInitializer());
+    Constant *LegalizedInitializer =
+        GV.hasInitializer() ? legalizeConstant(GV.getInitializer()) : nullptr;
 
     // Use an empty name for now, we will update it in the
     // following step.

--- a/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-extern.ll
+++ b/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-extern.ll
@@ -6,3 +6,12 @@
 @global_zero_array = external global [0 x i32]
 
 ; CHECK: @global_zero_array = external global ptr addrspace(4)
+define spir_kernel void @test_extern(ptr %ptr) {
+; CHECK-LABEL: @test_extern(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    ret void
+entry:
+  %val = load [0 x i32], ptr @global_zero_array, align 4
+  store [0 x i32] %val, ptr %ptr, align 4
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-extern.ll
+++ b/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-extern.ll
@@ -1,0 +1,8 @@
+; RUN: opt -S -passes=spirv-legalize-zero-size-arrays -mtriple=spirv64-unknown-unknown < %s | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Test that an externally initialized global with no initializer
+
+@global_zero_array = external global [0 x i32]
+
+; CHECK: @global_zero_array = external global ptr addrspace(4)

--- a/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-extern.ll
+++ b/llvm/test/CodeGen/SPIRV/legalize-zero-size-arrays-extern.ll
@@ -1,7 +1,7 @@
 ; RUN: opt -S -passes=spirv-legalize-zero-size-arrays -mtriple=spirv64-unknown-unknown < %s | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; Test that an externally initialized global with no initializer
+; Test that an externally initialized global with no initializer.
 
 @global_zero_array = external global [0 x i32]
 


### PR DESCRIPTION
`getInitializer` asserts if there's no initializer, so check first.

I found this compiling some `liboffload` unit tests.