### PR TITLE
Revert "Merge commit '74ad4baef073' from llvm.org/main into next (#183126)"

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -46,8 +46,9 @@ ifeq "$(OS)" "Windows_NT"
 	RM_F = del /f /q $(subst /,\,$(1))
 	RM_RF = rd /s /q $(subst /,\,$(1))
 	LN_SF = mklink /D "$(subst /,\,$(2))" "$(subst /,\,$(1))"
-	ECHO = echo $(1)
-	ECHO_TO_FILE = echo $(1) > $(subst /,\,$(2))
+	ECHO = echo $(1);
+	ECHO_TO_FILE = printf "%s\n" $(1) > "$(subst /,\,$(2))"
+	ECHO_APPEND_FILE = printf "%s\n" $(1) >> "$(subst /,\,$(2))"
 else
 	MKDIR_P = mkdir -p $(1)
 	CP = cp $(1) $(2)
@@ -56,8 +57,9 @@ else
 	RM_F = rm -f $(1)
 	RM_RF = rm -rf $(1)
 	LN_SF = ln -sf $(1) $(2)
-	ECHO = echo "$(1)"
-	ECHO_TO_FILE = echo $(1) > $(2)
+	ECHO = echo $(1);
+	ECHO_TO_FILE = printf '%s\n' $(1) > "$(2)"
+	ECHO_APPEND_FILE = printf '%s\n' $(1) >> "$(2)"
 endif
 
 # Suppress built-in suffix rules. We explicitly define rules for %.o.

--- a/lldb/test/API/tools/lldb-dap/conpty-drain/Makefile
+++ b/lldb/test/API/tools/lldb-dap/conpty-drain/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/conpty-drain/TestDAP_conpty_drain.py
+++ b/lldb/test/API/tools/lldb-dap/conpty-drain/TestDAP_conpty_drain.py
@@ -1,0 +1,32 @@
+"""
+Test that all debuggee output is captured when the process exits quickly
+after producing output. This exercises the ConPTY pipe drain logic on
+Windows to ensure no data is lost at process exit.
+"""
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+import lldbdap_testcase
+
+
+class TestDAP_conpty_drain(lldbdap_testcase.DAPTestCaseBase):
+    @skipUnlessWindows
+    def test_output_not_lost_at_exit(self):
+        """Test that stdout is fully captured when the debuggee exits
+        immediately after writing output, exercising the ConPTY drain path."""
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program, disconnectAutomatically=False)
+        self.continue_to_exit()
+        self.dap_server.request_disconnect()
+
+        output = self.get_stdout()
+        self.assertIsNotNone(output, "expect program stdout")
+        self.assertIn(
+            "DONE",
+            output,
+            "final output marker not found, data was lost in the ConPTY pipe: "
+            + repr(output[-200:] if output else output),
+        )
+        # Verify we got a reasonable amount of the output
+        self.assertIn("line 99:", output, "last numbered line not found")
+        self.assertIn("line 0:", output, "first numbered line not found")

--- a/lldb/test/API/tools/lldb-dap/conpty-drain/main.c
+++ b/lldb/test/API/tools/lldb-dap/conpty-drain/main.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+int main() {
+  // Print a large amount of output to increase the chance that data is still in
+  // the ConPTY pipe buffer when the process exits. The test verifies that all
+  // lines are received, including the final marker.
+  for (int i = 0; i < 100; i++)
+    printf("line %d: the quick brown fox jumps over the lazy dog\n", i);
+  printf("DONE\n");
+  return 0;
+}


### PR DESCRIPTION
This reverts commit f4577641d15a6625966a018715c98ba8fad65c83 which has an incorrect name.