### PR TITLE
[CIR][NFC] Fix Call no decl test

### DIFF
--- a/clang/test/CIR/CodeGen/call-no-decl.c
+++ b/clang/test/CIR/CodeGen/call-no-decl.c
@@ -19,3 +19,4 @@ int bar(void) {
 // CHECK: cir.func private @printf(!cir.ptr<!s8i> {{.*}}, ...) -> !s32i
 // CHECK: cir.call @printf({{.*}}, {{.*}}) : (!cir.ptr<!s8i> {{.*}}, !s32i {{.*}}) -> !s32i
 // CHECK: cir.call @printf({{.*}}) : (!cir.ptr<!s8i> {{.*}}) -> !s32i
+

--- a/clang/test/CIR/CodeGen/call-no-decl.c
+++ b/clang/test/CIR/CodeGen/call-no-decl.c
@@ -16,6 +16,6 @@ int bar(void) {
   return 0;
 }
 
-// CHECK: cir.func private @printf(!cir.ptr<!s8i>, ...) -> !s32i
-// CHECK: cir.call @printf({{.*}}, {{.*}}) : (!cir.ptr<!s8i>, !s32i) -> !s32i
-// CHECK: cir.call @printf({{.*}}) : (!cir.ptr<!s8i>) -> !s32i
+// CHECK: cir.func private @printf(!cir.ptr<!s8i> {{.*}}, ...) -> !s32i
+// CHECK: cir.call @printf({{.*}}, {{.*}}) : (!cir.ptr<!s8i> {{.*}}, !s32i {{.*}}) -> !s32i
+// CHECK: cir.call @printf({{.*}}) : (!cir.ptr<!s8i> {{.*}}) -> !s32i


### PR DESCRIPTION
Update the call-no-decl test file to ignore for parameter attribute `{llvm.noundef}`