### PR TITLE
[lldb] Make TestProcessAttach.py more reliable

### DIFF
--- a/lldb/test/API/commands/process/attach/TestProcessAttach.py
+++ b/lldb/test/API/commands/process/attach/TestProcessAttach.py
@@ -59,11 +59,7 @@ class ProcessAttachTestCase(TestBase):
     def test_attach_to_process_from_different_dir_by_id(self):
         """Test attach by process id"""
         newdir = self.getBuildArtifact("newdir")
-        try:
-            os.mkdir(newdir)
-        except OSError as e:
-            if e.errno != os.errno.EEXIST:
-                raise
+        os.makedirs(newdir, exist_ok=True)
         testdir = self.getBuildDir()
         exe = os.path.join(newdir, "proc_attach")
         self.buildProgram("main.cpp", exe)


### PR DESCRIPTION
This test occasionally fails on GreenDragon. When the directory already exists and we enter the exception block, the `os.errno` symbol is not found because it was deprecated in Python 3.7.

Instead, replace `os.mkdir` with `os.makedirs` because it can handle a directory already existing.