### PR TITLE
[LICM] Relax overflow flag requirements for eq/ne in hoistAdd/hoistSub

### DIFF
--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -2582,16 +2582,25 @@ static bool hoistAdd(ICmpInst::Predicate Pred, Value *VariantLHS,
   assert(!L.isLoopInvariant(VariantLHS) && "Precondition.");
   assert(L.isLoopInvariant(InvariantRHS) && "Precondition.");
 
-  bool IsSigned = ICmpInst::isSigned(Pred);
+  const bool IsSigned = ICmpInst::isSigned(Pred);
+  const bool IsEquality = ICmpInst::isEquality(Pred);
+
+  // For signed/unsigned predicates we need nsw/nuw respectively.
+  // For equality predicates everything works.
+  const bool RequiresNSW = !IsEquality && IsSigned;
+  const bool RequiresNUW = !IsEquality && !IsSigned;
 
   // Try to represent VariantLHS as sum of invariant and variant operands.
   using namespace PatternMatch;
   Value *VariantOp, *InvariantOp;
-  if (IsSigned && !match(VariantLHS, m_NSWAddLike(m_Value(VariantOp),
-                                                  m_Value(InvariantOp))))
+  if (IsEquality &&
+      !match(VariantLHS, m_AddLike(m_Value(VariantOp), m_Value(InvariantOp))))
     return false;
-  if (!IsSigned && !match(VariantLHS, m_NUWAddLike(m_Value(VariantOp),
-                                                   m_Value(InvariantOp))))
+  if (RequiresNSW && !match(VariantLHS, m_NSWAddLike(m_Value(VariantOp),
+                                                     m_Value(InvariantOp))))
+    return false;
+  if (RequiresNUW && !match(VariantLHS, m_NUWAddLike(m_Value(VariantOp),
+                                                     m_Value(InvariantOp))))
     return false;
 
   // LHS itself is a loop-variant, try to represent it in the form:
@@ -2607,19 +2616,22 @@ static bool hoistAdd(ICmpInst::Predicate Pred, Value *VariantLHS,
   // we want to avoid this.
   auto &DL = L.getHeader()->getDataLayout();
   SimplifyQuery SQ(DL, DT, AC, &ICmp);
-  if (IsSigned && computeOverflowForSignedSub(InvariantRHS, InvariantOp, SQ) !=
-                      llvm::OverflowResult::NeverOverflows)
+
+  if (RequiresNSW &&
+      computeOverflowForSignedSub(InvariantRHS, InvariantOp, SQ) !=
+          llvm::OverflowResult::NeverOverflows)
     return false;
-  if (!IsSigned &&
+  if (RequiresNUW &&
       computeOverflowForUnsignedSub(InvariantRHS, InvariantOp, SQ) !=
           llvm::OverflowResult::NeverOverflows)
     return false;
+
   auto *Preheader = L.getLoopPreheader();
   assert(Preheader && "Loop is not in simplify form?");
   IRBuilder<> Builder(Preheader->getTerminator());
   Value *NewCmpOp =
       Builder.CreateSub(InvariantRHS, InvariantOp, "invariant.op",
-                        /*HasNUW*/ !IsSigned, /*HasNSW*/ IsSigned);
+                        /*HasNUW*/ RequiresNUW, /*HasNSW*/ RequiresNSW);
   ICmp.setPredicate(Pred);
   ICmp.setOperand(0, VariantOp);
   ICmp.setOperand(1, NewCmpOp);
@@ -2640,15 +2652,24 @@ static bool hoistSub(ICmpInst::Predicate Pred, Value *VariantLHS,
   assert(!L.isLoopInvariant(VariantLHS) && "Precondition.");
   assert(L.isLoopInvariant(InvariantRHS) && "Precondition.");
 
-  bool IsSigned = ICmpInst::isSigned(Pred);
+  const bool IsSigned = ICmpInst::isSigned(Pred);
+  const bool IsEquality = ICmpInst::isEquality(Pred);
+
+  // For signed/unsigned predicates we need nsw/nuw respectively.
+  // For equality predicates everything works.
+  const bool RequiresNSW = !IsEquality && IsSigned;
+  const bool RequiresNUW = !IsEquality && !IsSigned;
 
   // Try to represent VariantLHS as sum of invariant and variant operands.
   using namespace PatternMatch;
   Value *VariantOp, *InvariantOp;
-  if (IsSigned &&
+  if (IsEquality &&
+      !match(VariantLHS, m_Sub(m_Value(VariantOp), m_Value(InvariantOp))))
+    return false;
+  if (RequiresNSW &&
       !match(VariantLHS, m_NSWSub(m_Value(VariantOp), m_Value(InvariantOp))))
     return false;
-  if (!IsSigned &&
+  if (RequiresNUW &&
       !match(VariantLHS, m_NUWSub(m_Value(VariantOp), m_Value(InvariantOp))))
     return false;
 
@@ -2671,22 +2692,22 @@ static bool hoistSub(ICmpInst::Predicate Pred, Value *VariantLHS,
   // "C1 - C2" does not overflow.
   auto &DL = L.getHeader()->getDataLayout();
   SimplifyQuery SQ(DL, DT, AC, &ICmp);
-  if (VariantSubtracted && IsSigned) {
+  if (VariantSubtracted && RequiresNSW) {
     // C1 - LV < C2 --> LV > C1 - C2
     if (computeOverflowForSignedSub(InvariantOp, InvariantRHS, SQ) !=
         llvm::OverflowResult::NeverOverflows)
       return false;
-  } else if (VariantSubtracted && !IsSigned) {
+  } else if (VariantSubtracted && RequiresNUW) {
     // C1 - LV < C2 --> LV > C1 - C2
     if (computeOverflowForUnsignedSub(InvariantOp, InvariantRHS, SQ) !=
         llvm::OverflowResult::NeverOverflows)
       return false;
-  } else if (!VariantSubtracted && IsSigned) {
+  } else if (!VariantSubtracted && RequiresNSW) {
     // LV - C1 < C2 --> LV < C1 + C2
     if (computeOverflowForSignedAdd(InvariantOp, InvariantRHS, SQ) !=
         llvm::OverflowResult::NeverOverflows)
       return false;
-  } else { // !VariantSubtracted && !IsSigned
+  } else if (!VariantSubtracted && RequiresNUW) {
     // LV - C1 < C2 --> LV < C1 + C2
     if (computeOverflowForUnsignedAdd(InvariantOp, InvariantRHS, SQ) !=
         llvm::OverflowResult::NeverOverflows)
@@ -2698,9 +2719,11 @@ static bool hoistSub(ICmpInst::Predicate Pred, Value *VariantLHS,
   Value *NewCmpOp =
       VariantSubtracted
           ? Builder.CreateSub(InvariantOp, InvariantRHS, "invariant.op",
-                              /*HasNUW*/ !IsSigned, /*HasNSW*/ IsSigned)
+                              /*HasNUW*/ RequiresNUW,
+                              /*HasNSW*/ RequiresNSW)
           : Builder.CreateAdd(InvariantOp, InvariantRHS, "invariant.op",
-                              /*HasNUW*/ !IsSigned, /*HasNSW*/ IsSigned);
+                              /*HasNUW*/ RequiresNUW,
+                              /*HasNSW*/ RequiresNSW);
   ICmp.setPredicate(Pred);
   ICmp.setOperand(0, VariantOp);
   ICmp.setOperand(1, NewCmpOp);

--- a/llvm/test/Transforms/LICM/hoist-add-sub.ll
+++ b/llvm/test/Transforms/LICM/hoist-add-sub.ll
@@ -1007,11 +1007,11 @@ define void @or_disjoint_signed(ptr %x_p) {
 ; CHECK:       loop:
 ; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
 ; CHECK-NEXT:    [[X_CHECK:%.*]] = icmp slt i32 [[IV]], [[INVARIANT_OP]]
-; CHECK-NEXT:    br i1 [[X_CHECK]], label [[OUT_OF_BOUNDS:%.*]], label [[BACKEDGE]]
+; CHECK-NEXT:    br i1 [[X_CHECK]], label [[EXIT:%.*]], label [[BACKEDGE]]
 ; CHECK:       backedge:
 ; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i32 [[IV]], 4
 ; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp slt i32 [[IV_NEXT]], 1000
-; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT:%.*]]
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void
 ;
@@ -1045,11 +1045,11 @@ define void @or_disjoint_unsigned(ptr %x_p) {
 ; CHECK:       loop:
 ; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
 ; CHECK-NEXT:    [[X_CHECK:%.*]] = icmp ult i32 [[IV]], [[INVARIANT_OP]]
-; CHECK-NEXT:    br i1 [[X_CHECK]], label [[OUT_OF_BOUNDS:%.*]], label [[BACKEDGE]]
+; CHECK-NEXT:    br i1 [[X_CHECK]], label [[EXIT:%.*]], label [[BACKEDGE]]
 ; CHECK:       backedge:
 ; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i32 [[IV]], 4
 ; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp ult i32 [[IV_NEXT]], 1000
-; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT:%.*]]
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void
 ;
@@ -1083,11 +1083,11 @@ define void @or_no_disjoint_neg(ptr %x_p) {
 ; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
 ; CHECK-NEXT:    [[ARITH:%.*]] = or i32 [[IV]], [[X]]
 ; CHECK-NEXT:    [[X_CHECK:%.*]] = icmp slt i32 [[ARITH]], 100
-; CHECK-NEXT:    br i1 [[X_CHECK]], label [[OUT_OF_BOUNDS:%.*]], label [[BACKEDGE]]
+; CHECK-NEXT:    br i1 [[X_CHECK]], label [[EXIT:%.*]], label [[BACKEDGE]]
 ; CHECK:       backedge:
 ; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i32 [[IV]], 4
 ; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp slt i32 [[IV_NEXT]], 1000
-; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT:%.*]]
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void
 ;
@@ -1099,6 +1099,230 @@ loop:
   %iv = phi i32 [0, %entry], [%iv.next, %backedge]
   %arith = or i32 %iv, %x
   %x_check = icmp slt i32 %arith, 100
+  br i1 %x_check, label %exit, label %backedge
+
+backedge:
+  %iv.next = add nuw nsw i32 %iv, 4
+  %loop_cond = icmp slt i32 %iv.next, 1000
+  br i1 %loop_cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+define void @add_eq(ptr %x_p) {
+; CHECK-LABEL: define void @add_eq
+; CHECK-SAME: (ptr [[X_P:%.*]]) {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[X:%.*]] = load i32, ptr [[X_P]], align 4
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = sub i32 100, [[X]]
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
+; CHECK-NEXT:    [[X_CHECK:%.*]] = icmp eq i32 [[IV]], [[INVARIANT_OP]]
+; CHECK-NEXT:    br i1 [[X_CHECK]], label [[EXIT:%.*]], label [[BACKEDGE]]
+; CHECK:       backedge:
+; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i32 [[IV]], 4
+; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp slt i32 [[IV_NEXT]], 1000
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %x = load i32, ptr %x_p
+  br label %loop
+
+loop:
+  %iv = phi i32 [0, %entry], [%iv.next, %backedge]
+  %arith = add i32 %iv, %x
+  %x_check = icmp eq i32 %arith, 100
+  br i1 %x_check, label %exit, label %backedge
+
+backedge:
+  %iv.next = add nuw nsw i32 %iv, 4
+  %loop_cond = icmp slt i32 %iv.next, 1000
+  br i1 %loop_cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+define void @sub_lv_c_ne(ptr %x_p) {
+; CHECK-LABEL: define void @sub_lv_c_ne
+; CHECK-SAME: (ptr [[X_P:%.*]]) {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[X:%.*]] = load i32, ptr [[X_P]], align 4
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = add i32 [[X]], 100
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
+; CHECK-NEXT:    [[X_CHECK:%.*]] = icmp ne i32 [[IV]], [[INVARIANT_OP]]
+; CHECK-NEXT:    br i1 [[X_CHECK]], label [[BACKEDGE]], label [[EXIT:%.*]]
+; CHECK:       backedge:
+; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i32 [[IV]], 4
+; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp slt i32 [[IV_NEXT]], 1000
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %x = load i32, ptr %x_p
+  br label %loop
+
+loop:
+  %iv = phi i32 [0, %entry], [%iv.next, %backedge]
+  %arith = sub i32 %iv, %x
+  %x_check = icmp ne i32 %arith, 100
+  br i1 %x_check, label %backedge, label %exit
+
+backedge:
+  %iv.next = add nuw nsw i32 %iv, 4
+  %loop_cond = icmp slt i32 %iv.next, 1000
+  br i1 %loop_cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+define void @sub_c_lv_eq(ptr %x_p) {
+; CHECK-LABEL: define void @sub_c_lv_eq
+; CHECK-SAME: (ptr [[X_P:%.*]]) {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[X:%.*]] = load i32, ptr [[X_P]], align 4
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = sub i32 [[X]], 100
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
+; CHECK-NEXT:    [[X_CHECK:%.*]] = icmp eq i32 [[IV]], [[INVARIANT_OP]]
+; CHECK-NEXT:    br i1 [[X_CHECK]], label [[EXIT:%.*]], label [[BACKEDGE]]
+; CHECK:       backedge:
+; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i32 [[IV]], 4
+; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp slt i32 [[IV_NEXT]], 1000
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %x = load i32, ptr %x_p
+  br label %loop
+
+loop:
+  %iv = phi i32 [0, %entry], [%iv.next, %backedge]
+  %arith = sub i32 %x, %iv
+  %x_check = icmp eq i32 %arith, 100
+  br i1 %x_check, label %exit, label %backedge
+
+backedge:
+  %iv.next = add nuw nsw i32 %iv, 4
+  %loop_cond = icmp slt i32 %iv.next, 1000
+  br i1 %loop_cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+define void @or_disjoint_eq(ptr %x_p) {
+; CHECK-LABEL: define void @or_disjoint_eq
+; CHECK-SAME: (ptr [[X_P:%.*]]) {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[X:%.*]] = load i32, ptr [[X_P]], align 4
+; CHECK-NEXT:    [[INVARIANT_OP:%.*]] = sub i32 100, [[X]]
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
+; CHECK-NEXT:    [[X_CHECK:%.*]] = icmp eq i32 [[IV]], [[INVARIANT_OP]]
+; CHECK-NEXT:    br i1 [[X_CHECK]], label [[EXIT:%.*]], label [[BACKEDGE]]
+; CHECK:       backedge:
+; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i32 [[IV]], 4
+; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp slt i32 [[IV_NEXT]], 1000
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %x = load i32, ptr %x_p
+  br label %loop
+
+loop:
+  %iv = phi i32 [0, %entry], [%iv.next, %backedge]
+  %arith = or disjoint i32 %iv, %x
+  %x_check = icmp eq i32 %arith, 100
+  br i1 %x_check, label %exit, label %backedge
+
+backedge:
+  %iv.next = add nuw nsw i32 %iv, 4
+  %loop_cond = icmp slt i32 %iv.next, 1000
+  br i1 %loop_cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+; Negative: plain add (no nsw) with slt should not hoist
+define void @add_no_flags_slt_neg(ptr %x_p) {
+; CHECK-LABEL: define void @add_no_flags_slt_neg
+; CHECK-SAME: (ptr [[X_P:%.*]]) {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[X:%.*]] = load i32, ptr [[X_P]], align 4
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
+; CHECK-NEXT:    [[ARITH:%.*]] = add i32 [[IV]], [[X]]
+; CHECK-NEXT:    [[X_CHECK:%.*]] = icmp slt i32 [[ARITH]], 100
+; CHECK-NEXT:    br i1 [[X_CHECK]], label [[EXIT:%.*]], label [[BACKEDGE]]
+; CHECK:       backedge:
+; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i32 [[IV]], 4
+; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp slt i32 [[IV_NEXT]], 1000
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %x = load i32, ptr %x_p
+  br label %loop
+
+loop:
+  %iv = phi i32 [0, %entry], [%iv.next, %backedge]
+  %arith = add i32 %iv, %x
+  %x_check = icmp slt i32 %arith, 100
+  br i1 %x_check, label %exit, label %backedge
+
+backedge:
+  %iv.next = add nuw nsw i32 %iv, 4
+  %loop_cond = icmp slt i32 %iv.next, 1000
+  br i1 %loop_cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+; Negative: plain sub (no nuw) with ult should not hoist
+define void @sub_no_flags_ult_neg(ptr %x_p) {
+; CHECK-LABEL: define void @sub_no_flags_ult_neg
+; CHECK-SAME: (ptr [[X_P:%.*]]) {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[X:%.*]] = load i32, ptr [[X_P]], align 4
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
+; CHECK-NEXT:    [[ARITH:%.*]] = sub i32 [[IV]], [[X]]
+; CHECK-NEXT:    [[X_CHECK:%.*]] = icmp ult i32 [[ARITH]], 100
+; CHECK-NEXT:    br i1 [[X_CHECK]], label [[EXIT:%.*]], label [[BACKEDGE]]
+; CHECK:       backedge:
+; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i32 [[IV]], 4
+; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp slt i32 [[IV_NEXT]], 1000
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret void
+;
+entry:
+  %x = load i32, ptr %x_p
+  br label %loop
+
+loop:
+  %iv = phi i32 [0, %entry], [%iv.next, %backedge]
+  %arith = sub i32 %iv, %x
+  %x_check = icmp ult i32 %arith, 100
   br i1 %x_check, label %exit, label %backedge
 
 backedge:


### PR DESCRIPTION
Equality predicates don't need nsw/nuw because wrapping add/sub are bijections, so `(A op B) == C` iff `A == C op_inv B` unconditionally.

## Alive2 proofs

| Transform | `eq` | `ne` |
|---|---|---|
| `LV + C1` pred `C2` => `LV` pred `C2 - C1` | [proof](https://alive2.llvm.org/ce/z/vTNEUY) | [proof](https://alive2.llvm.org/ce/z/DVSKcq) |
| `LV - C1` pred `C2` => `LV` pred `C1 + C2` | [proof](https://alive2.llvm.org/ce/z/Rc3sjm) | [proof](https://alive2.llvm.org/ce/z/Zf6kGN) |
| `C1 - LV` pred `C2` => `LV` pred `C1 - C2` | [proof](https://alive2.llvm.org/ce/z/_tmGcV) | [proof](https://alive2.llvm.org/ce/z/Q3j-sv) |
