### PR TITLE
[amdgpu-cfi: 3/9]: [Clang] Default to async unwind tables for amdgcn

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -3068,6 +3068,7 @@ Generic_GCC::getDefaultUnwindTableLevel(const ArgList &Args) const {
   switch (getArch()) {
   case llvm::Triple::aarch64:
   case llvm::Triple::aarch64_be:
+  case llvm::Triple::amdgcn:
   case llvm::Triple::ppc:
   case llvm::Triple::ppcle:
   case llvm::Triple::ppc64:

--- a/clang/test/Driver/amdgpu-unwind.cl
+++ b/clang/test/Driver/amdgpu-unwind.cl
@@ -1,0 +1,26 @@
+// REQUIRES: amdgpu-registered-target
+
+// Default options
+// RUN: %clang -### -x cl --target=amdgcn-amd-amdhsa -c -emit-llvm --no-offloadlib -nogpuinc %s 2>&1 | FileCheck -check-prefix=ASYNC-TABLES %s
+// RUN: %clang -### -x hip --offload-arch=gfx90a --offload-device-only --no-offloadlib -c -emit-llvm -nogpuinc %s 2>&1 | FileCheck -check-prefix=ASYNC-TABLES  %s
+// RUN: %clang -### -fopenmp --offload-arch=gfx90a --offload-device-only --no-offloadlib -c -emit-llvm -nogpuinc %s 2>&1 | FileCheck -check-prefix=ASYNC-TABLES  %s
+
+// Explicitly enable sync-tables (somewhat surprisingly this is still preempted by the default-on async tables)
+// RUN: %clang -### -x cl --target=amdgcn-amd-amdhsa -c -emit-llvm --no-offloadlib -funwind-tables -nogpuinc %s 2>&1 | FileCheck -check-prefix=ASYNC-TABLES %s
+// RUN: %clang -### -x hip --offload-arch=gfx90a --offload-device-only --no-offloadlib -c -emit-llvm -funwind-tables -nogpuinc %s 2>&1 | FileCheck -check-prefix=ASYNC-TABLES  %s
+// RUN: %clang -### -fopenmp --offload-arch=gfx90a --offload-device-only --no-offloadlib -c -emit-llvm -funwind-tables -nogpuinc %s 2>&1 | FileCheck -check-prefix=ASYNC-TABLES  %s
+
+// Explicitly enable sync-tables and surpress default async-tables
+// RUN: %clang -### -x cl --target=amdgcn-amd-amdhsa -c -emit-llvm --no-offloadlib -funwind-tables -fno-asynchronous-unwind-tables -nogpuinc %s 2>&1 | FileCheck -check-prefix=SYNC-TABLES %s
+// RUN: %clang -### -x hip --offload-arch=gfx90a --offload-device-only --no-offloadlib -c -emit-llvm -funwind-tables -fno-asynchronous-unwind-tables -nogpuinc %s 2>&1 | FileCheck -check-prefix=SYNC-TABLES  %s
+// RUN: %clang -### -fopenmp --offload-arch=gfx90a --offload-device-only --no-offloadlib -c -emit-llvm -funwind-tables -fno-asynchronous-unwind-tables -nogpuinc %s 2>&1 | FileCheck -check-prefix=SYNC-TABLES  %s
+
+// Suppress the default async-tables
+// RUN: %clang -### -x cl --target=amdgcn-amd-amdhsa -c -emit-llvm --no-offloadlib -fno-asynchronous-unwind-tables -nogpuinc %s 2>&1 | FileCheck -check-prefix=NO-TABLES %s
+// RUN: %clang -### -x hip --offload-arch=gfx90a --offload-device-only --no-offloadlib -c -emit-llvm -fno-asynchronous-unwind-tables -nogpuinc %s 2>&1 | FileCheck -check-prefix=NO-TABLES  %s
+// RUN: %clang -### -fopenmp --offload-arch=gfx90a --offload-device-only --no-offloadlib -c -emit-llvm -fno-asynchronous-unwind-tables -nogpuinc %s 2>&1 | FileCheck -check-prefix=NO-TABLES  %s
+
+
+// ASYNC-TABLES: "-triple" "amdgcn-amd-amdhsa" {{.*}} "-funwind-tables=2"
+// SYNC-TABLES: "-triple" "amdgcn-amd-amdhsa" {{.*}} "-funwind-tables=1"
+// NO-TABLES-NOT: "-triple" "amdgcn-amd-amdhsa" {{.*}} "-funwind-tables={{.*}}"


### PR DESCRIPTION
To avoid codegen changes when enabling debug-info (see
https://bugs.llvm.org/show_bug.cgi?id=37240) we want to
enable unwind tables by default.

There is some pessimization in post-prologepilog scheduling, and a
general solution to the problem of CFI_INSTRUCTION-as-scheduling-barrier
should be explored.

Change-Id: I83625875966928c7c4411cd7b95174dc58bda25a

---

**Stack**:
- #183147
- #183149
- #183150
- #183146
- #183153
- #183152
- #183148⬅
- #183151
- #183171
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
