### PR TITLE
ValueTracking: Teach computeKnownFPClass that multiply by <= 1 cannot overflow

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1104,18 +1104,6 @@ class APFloat : public APFloatBase {
   explicit APFloat(DoubleAPFloat F, const fltSemantics &S)
       : U(std::move(F), S) {}
 
-  // Compares the absolute value of this APFloat with another.  Both operands
-  // must be finite non-zero.
-  cmpResult compareAbsoluteValue(const APFloat &RHS) const {
-    assert(&getSemantics() == &RHS.getSemantics() &&
-           "Should only compare APFloats with the same semantics");
-    if (usesLayout<IEEEFloat>(getSemantics()))
-      return U.IEEE.compareAbsoluteValue(RHS.U.IEEE);
-    if (usesLayout<DoubleAPFloat>(getSemantics()))
-      return U.Double.compareAbsoluteValue(RHS.U.Double);
-    llvm_unreachable("Unexpected semantics");
-  }
-
 public:
   APFloat(const fltSemantics &Semantics) : U(Semantics) {}
   LLVM_ABI APFloat(const fltSemantics &Semantics, StringRef S);
@@ -1471,6 +1459,18 @@ public:
       return U.IEEE.compare(RHS.U.IEEE);
     if (usesLayout<DoubleAPFloat>(getSemantics()))
       return U.Double.compare(RHS.U.Double);
+    llvm_unreachable("Unexpected semantics");
+  }
+
+  // Compares the absolute value of this APFloat with another.  Both operands
+  // must be finite non-zero.
+  cmpResult compareAbsoluteValue(const APFloat &RHS) const {
+    assert(&getSemantics() == &RHS.getSemantics() &&
+           "Should only compare APFloats with the same semantics");
+    if (usesLayout<IEEEFloat>(getSemantics()))
+      return U.IEEE.compareAbsoluteValue(RHS.U.IEEE);
+    if (usesLayout<DoubleAPFloat>(getSemantics()))
+      return U.Double.compareAbsoluteValue(RHS.U.Double);
     llvm_unreachable("Unexpected semantics");
   }
 

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -370,8 +370,12 @@ KnownFPClass KnownFPClass::fmul(const KnownFPClass &KnownLHS,
     Known.knownNot(fcSubnormal);
 
   // Multiply of values <= 1 cannot introduce overflow.
-  if (KnownLHS.isKnownNever(fcInf) && MinKnownExponent <= 0)
-    Known.knownNot(fcInf);
+  if (KnownLHS.isKnownNever(fcInf)) {
+    if (MinKnownExponent < 0)
+      Known.knownNot(fcInf);
+    else if (MinKnownExponent == 0 && CRHS <= APFloat::getOne(Flt))
+      Known.knownNot(fcInf);
+  }
 
   return Known;
 }

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -369,6 +369,10 @@ KnownFPClass KnownFPClass::fmul(const KnownFPClass &KnownLHS,
   if (CannotBeSubnormal)
     Known.knownNot(fcSubnormal);
 
+  // Multiply of values <= 1 cannot introduce overflow.
+  if (KnownLHS.isKnownNever(fcInf) && MinKnownExponent <= 0)
+    Known.knownNot(fcInf);
+
   return Known;
 }
 

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -373,7 +373,8 @@ KnownFPClass KnownFPClass::fmul(const KnownFPClass &KnownLHS,
   if (KnownLHS.isKnownNever(fcInf)) {
     if (MinKnownExponent < 0)
       Known.knownNot(fcInf);
-    else if (MinKnownExponent == 0 && CRHS <= APFloat::getOne(Flt))
+    else if (MinKnownExponent == 0 && CRHS.compareAbsoluteValue(APFloat::getOne(
+                                          Flt)) == APFloat::cmpEqual)
       Known.knownNot(fcInf);
   }
 

--- a/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
@@ -815,6 +815,17 @@ define float @ret_fmul__not_inf__half(float nofpclass(inf) %x) {
   ret float %mul
 }
 
+; Cannot introduce overflow, propagate no-infs
+define float @ret_fmul__not_inf__neghalf(float nofpclass(inf) %x) {
+; CHECK-LABEL: define nofpclass(inf) float @ret_fmul__not_inf__neghalf(
+; CHECK-SAME: float nofpclass(inf) [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], -5.000000e-01
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %mul = fmul float %x, -0.5
+  ret float %mul
+}
+
 define float @ret_fmul__not_pinf__half(float nofpclass(pinf) %x) {
 ; CHECK-LABEL: define float @ret_fmul__not_pinf__half(
 ; CHECK-SAME: float nofpclass(pinf) [[X:%.*]]) #[[ATTR0]] {
@@ -843,6 +854,17 @@ define float @ret_fmul__not_inf__1(float nofpclass(inf) %x) {
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %mul = fmul float %x, 1.0
+  ret float %mul
+}
+
+; Cannot introduce overflow, propagate no-infs
+define float @ret_fmul__not_inf__neg1(float nofpclass(inf) %x) {
+; CHECK-LABEL: define nofpclass(inf) float @ret_fmul__not_inf__neg1(
+; CHECK-SAME: float nofpclass(inf) [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], -1.000000e+00
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %mul = fmul float %x, -1.0
   ret float %mul
 }
 
@@ -875,5 +897,16 @@ define float @ret_fmul__not_inf__1.5(float nofpclass(inf) %x) {
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %mul = fmul float %x, 1.5
+  ret float %mul
+}
+
+; Negative test
+define float @ret_fmul__not_inf__neg1.5(float nofpclass(inf) %x) {
+; CHECK-LABEL: define nofpclass(inf) float @ret_fmul__not_inf__neg1.5(
+; CHECK-SAME: float nofpclass(inf) [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], -1.500000e+00
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %mul = fmul float %x, -1.5
   ret float %mul
 }

--- a/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
@@ -803,3 +803,55 @@ define float @ret_known_inf_or_nan_fmul_known_inf_or_nan(float nofpclass(norm su
   %fmul = fmul float %arg0, %arg1
   ret float %fmul
 }
+
+; Cannot introduce overflow, propagate no-infs
+define float @ret_fmul__not_inf__half(float nofpclass(inf) %x) {
+; CHECK-LABEL: define float @ret_fmul__not_inf__half(
+; CHECK-SAME: float nofpclass(inf) [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], 5.000000e-01
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %mul = fmul float %x, 0.5
+  ret float %mul
+}
+
+define float @ret_fmul__not_pinf__half(float nofpclass(pinf) %x) {
+; CHECK-LABEL: define float @ret_fmul__not_pinf__half(
+; CHECK-SAME: float nofpclass(pinf) [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], 5.000000e-01
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %mul = fmul float %x, 0.5
+  ret float %mul
+}
+
+define float @ret_fmul__not_ninf__half(float nofpclass(ninf) %x) {
+; CHECK-LABEL: define float @ret_fmul__not_ninf__half(
+; CHECK-SAME: float nofpclass(ninf) [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], 5.000000e-01
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %mul = fmul float %x, 0.5
+  ret float %mul
+}
+
+; Cannot introduce overflow, propagate no-infs
+define float @ret_fmul__not_inf__1(float nofpclass(inf) %x) {
+; CHECK-LABEL: define float @ret_fmul__not_inf__1(
+; CHECK-SAME: float nofpclass(inf) [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], 1.000000e+00
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %mul = fmul float %x, 1.0
+  ret float %mul
+}
+
+define float @ret_fmul__not_inf__2(float nofpclass(inf) %x) {
+; CHECK-LABEL: define float @ret_fmul__not_inf__2(
+; CHECK-SAME: float nofpclass(inf) [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], 2.000000e+00
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %mul = fmul float %x, 2.0
+  ret float %mul
+}

--- a/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
@@ -855,3 +855,25 @@ define float @ret_fmul__not_inf__2(float nofpclass(inf) %x) {
   %mul = fmul float %x, 2.0
   ret float %mul
 }
+
+; Negative test
+define float @ret_fmul__not_inf__nextup_1(float nofpclass(inf) %x) {
+; CHECK-LABEL: define float @ret_fmul__not_inf__nextup_1(
+; CHECK-SAME: float nofpclass(inf) [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], 0x3FF0000020000000
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %mul = fmul float %x, 0x3ff0000020000000
+  ret float %mul
+}
+
+; Negative test
+define float @ret_fmul__not_inf__1.5(float nofpclass(inf) %x) {
+; CHECK-LABEL: define float @ret_fmul__not_inf__1.5(
+; CHECK-SAME: float nofpclass(inf) [[X:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], 1.500000e+00
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %mul = fmul float %x, 1.5
+  ret float %mul
+}

--- a/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
@@ -902,7 +902,7 @@ define float @ret_fmul__not_inf__1.5(float nofpclass(inf) %x) {
 
 ; Negative test
 define float @ret_fmul__not_inf__neg1.5(float nofpclass(inf) %x) {
-; CHECK-LABEL: define nofpclass(inf) float @ret_fmul__not_inf__neg1.5(
+; CHECK-LABEL: define float @ret_fmul__not_inf__neg1.5(
 ; CHECK-SAME: float nofpclass(inf) [[X:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], -1.500000e+00
 ; CHECK-NEXT:    ret float [[MUL]]

--- a/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
@@ -806,7 +806,7 @@ define float @ret_known_inf_or_nan_fmul_known_inf_or_nan(float nofpclass(norm su
 
 ; Cannot introduce overflow, propagate no-infs
 define float @ret_fmul__not_inf__half(float nofpclass(inf) %x) {
-; CHECK-LABEL: define float @ret_fmul__not_inf__half(
+; CHECK-LABEL: define nofpclass(inf) float @ret_fmul__not_inf__half(
 ; CHECK-SAME: float nofpclass(inf) [[X:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], 5.000000e-01
 ; CHECK-NEXT:    ret float [[MUL]]
@@ -837,7 +837,7 @@ define float @ret_fmul__not_ninf__half(float nofpclass(ninf) %x) {
 
 ; Cannot introduce overflow, propagate no-infs
 define float @ret_fmul__not_inf__1(float nofpclass(inf) %x) {
-; CHECK-LABEL: define float @ret_fmul__not_inf__1(
+; CHECK-LABEL: define nofpclass(inf) float @ret_fmul__not_inf__1(
 ; CHECK-SAME: float nofpclass(inf) [[X:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], 1.000000e+00
 ; CHECK-NEXT:    ret float [[MUL]]


### PR DESCRIPTION
If one operand is known not-inf, that can be propagated if the other operand is
known to have a magnitude <= 1.

This enables elimination of some inf checks inside the implementation of trig
functions when the input is known not-inf.