### PR TITLE
[PowerPC] Update dmr builtin names

### DIFF
--- a/clang/include/clang/Basic/BuiltinsPPC.def
+++ b/clang/include/clang/Basic/BuiltinsPPC.def
@@ -1114,15 +1114,15 @@ UNALIASED_CUSTOM_BUILTIN(mma_dmxvi8gerx4spp, "vW1024*W256V", true,
                          "mma,paired-vector-memops")
 UNALIASED_CUSTOM_BUILTIN(mma_pmdmxvi8gerx4spp, "vW1024*W256Vi255i15i15", true,
                          "mma,paired-vector-memops")
-UNALIASED_CUSTOM_BUILTIN(mma_dmsetdmrz, "vW1024*", false,
+UNALIASED_CUSTOM_BUILTIN(dmsetdmrz, "vW1024*", false,
                          "mma,isa-future-instructions")
-UNALIASED_CUSTOM_BUILTIN(mma_dmmr, "vW1024*W1024*", false,
+UNALIASED_CUSTOM_BUILTIN(dmmr, "vW1024*W1024*", false,
                          "mma,isa-future-instructions")
-UNALIASED_CUSTOM_BUILTIN(mma_dmxor, "vW1024*W1024*", true,
+UNALIASED_CUSTOM_BUILTIN(dmxor, "vW1024*W1024*", true,
                          "mma,isa-future-instructions")
-UNALIASED_CUSTOM_BUILTIN(mma_disassemble_dmr, "vv*W1024*", false,
+UNALIASED_CUSTOM_BUILTIN(disassemble_dmr, "vv*W1024*", false,
                          "mma,isa-future-instructions")
-UNALIASED_CUSTOM_BUILTIN(mma_build_dmr, "vW1024*VVVVVVVV", false,
+UNALIASED_CUSTOM_BUILTIN(build_dmr, "vW1024*VVVVVVVV", false,
                          "mma,isa-future-instructions")
 
 UNALIASED_CUSTOM_BUILTIN(mma_dmsha2hash, "vW1024*W1024*Ii", true,

--- a/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
@@ -1151,14 +1151,14 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
       Value *Acc = Builder.CreateLoad(Addr);
       CallOps.push_back(Acc);
     }
-    if (BuiltinID == PPC::BI__builtin_mma_dmmr ||
-        BuiltinID == PPC::BI__builtin_mma_dmxor ||
-        BuiltinID == PPC::BI__builtin_mma_disassemble_dmr ||
+    if (BuiltinID == PPC::BI__builtin_dmmr ||
+        BuiltinID == PPC::BI__builtin_dmxor ||
+        BuiltinID == PPC::BI__builtin_disassemble_dmr ||
         BuiltinID == PPC::BI__builtin_mma_dmsha2hash) {
       Address Addr = EmitPointerWithAlignment(E->getArg(1));
       Ops[1] = Builder.CreateLoad(Addr);
     }
-    if (BuiltinID == PPC::BI__builtin_mma_disassemble_dmr)
+    if (BuiltinID == PPC::BI__builtin_disassemble_dmr)
       return Builder.CreateAlignedStore(Ops[1], Ops[0], MaybeAlign());
     for (unsigned i=1; i<Ops.size(); i++)
       CallOps.push_back(Ops[i]);

--- a/clang/test/CodeGen/PowerPC/builtins-ppc-dmf.c
+++ b/clang/test/CodeGen/PowerPC/builtins-ppc-dmf.c
@@ -154,39 +154,39 @@ void test_pmdmxvi8gerx4spp(unsigned char *vdmrp, unsigned char *vpp, vector unsi
 // CHECK-LABEL: define dso_local void @test_dmf_basic(
 // CHECK-SAME: ptr noundef readonly captures(none) [[P:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RES1:%.*]], ptr noundef captures(none) [[RES2:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmsetdmrz()
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmmr(<1024 x i1> [[TMP0]])
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call <1024 x i1> @llvm.ppc.dmsetdmrz()
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmmr(<1024 x i1> [[TMP0]])
 // CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RES1]], align 128
 // CHECK-NEXT:    [[TMP2:%.*]] = load <1024 x i1>, ptr [[RES2]], align 128
 // CHECK-NEXT:    [[TMP3:%.*]] = load <1024 x i1>, ptr [[P]], align 128
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxor(<1024 x i1> [[TMP2]], <1024 x i1> [[TMP3]])
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxor(<1024 x i1> [[TMP2]], <1024 x i1> [[TMP3]])
 // CHECK-NEXT:    store <1024 x i1> [[TMP4]], ptr [[RES2]], align 128
 // CHECK-NEXT:    ret void
 //
 // AIX-LABEL: define void @test_dmf_basic(
 // AIX-SAME: ptr noundef readonly captures(none) [[P:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RES1:%.*]], ptr noundef captures(none) [[RES2:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
-// AIX-NEXT:    [[TMP0:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmsetdmrz()
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmmr(<1024 x i1> [[TMP0]])
+// AIX-NEXT:    [[TMP0:%.*]] = tail call <1024 x i1> @llvm.ppc.dmsetdmrz()
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmmr(<1024 x i1> [[TMP0]])
 // AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RES1]], align 128
 // AIX-NEXT:    [[TMP2:%.*]] = load <1024 x i1>, ptr [[RES2]], align 128
 // AIX-NEXT:    [[TMP3:%.*]] = load <1024 x i1>, ptr [[P]], align 128
-// AIX-NEXT:    [[TMP4:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxor(<1024 x i1> [[TMP2]], <1024 x i1> [[TMP3]])
+// AIX-NEXT:    [[TMP4:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxor(<1024 x i1> [[TMP2]], <1024 x i1> [[TMP3]])
 // AIX-NEXT:    store <1024 x i1> [[TMP4]], ptr [[RES2]], align 128
 // AIX-NEXT:    ret void
 //
 void test_dmf_basic(char *p, char *res1, char *res2) {
   __dmr1024 x[2];
-  __builtin_mma_dmsetdmrz(&x[0]);
-  __builtin_mma_dmmr((__dmr1024*)res1, &x[0]);
-  __builtin_mma_dmxor((__dmr1024*)res2, (__dmr1024*)p);
+  __builtin_dmsetdmrz(&x[0]);
+  __builtin_dmmr((__dmr1024*)res1, &x[0]);
+  __builtin_dmxor((__dmr1024*)res2, (__dmr1024*)p);
 }
 
 // CHECK-LABEL: define dso_local void @test_dmf_basic2(
 // CHECK-SAME: ptr noundef readonly captures(none) [[P1:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RES1:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RES2:%.*]], ptr noundef readonly captures(none) [[V:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <16 x i8>, ptr [[V]], align 16, !tbaa [[CHAR_TBAA10:![0-9]+]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.build.dmr(<16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]])
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.build.dmr(<16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]])
 // CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RES2]], align 128
 // CHECK-NEXT:    [[TMP2:%.*]] = load <1024 x i1>, ptr [[P1]], align 128
 // CHECK-NEXT:    store <1024 x i1> [[TMP2]], ptr [[RES1]], align 128
@@ -196,7 +196,7 @@ void test_dmf_basic(char *p, char *res1, char *res2) {
 // AIX-SAME: ptr noundef readonly captures(none) [[P1:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RES1:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RES2:%.*]], ptr noundef readonly captures(none) [[V:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <16 x i8>, ptr [[V]], align 16, !tbaa [[CHAR_TBAA10:![0-9]+]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.build.dmr(<16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]])
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.build.dmr(<16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]], <16 x i8> [[TMP0]])
 // AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RES2]], align 128
 // AIX-NEXT:    [[TMP2:%.*]] = load <1024 x i1>, ptr [[P1]], align 128
 // AIX-NEXT:    store <1024 x i1> [[TMP2]], ptr [[RES1]], align 128
@@ -205,8 +205,8 @@ void test_dmf_basic(char *p, char *res1, char *res2) {
 void test_dmf_basic2(char *p1, char *res1, char *res2,
                      vector unsigned char *v) {
   vector unsigned char vv = *v;
-  __builtin_mma_build_dmr((__dmr1024*)res2, vv, vv, vv, vv, vv, vv, vv, vv);
-  __builtin_mma_disassemble_dmr(res1, (__dmr1024*)p1);
+  __builtin_build_dmr((__dmr1024*)res2, vv, vv, vv, vv, vv, vv, vv, vv);
+  __builtin_disassemble_dmr(res1, (__dmr1024*)p1);
 }
 
 // CHECK-LABEL: define dso_local void @test_dmsha2hash(

--- a/clang/test/CodeGen/PowerPC/ppc-dmf-mma-builtin-err.c
+++ b/clang/test/CodeGen/PowerPC/ppc-dmf-mma-builtin-err.c
@@ -20,11 +20,11 @@ void test_mma(unsigned char *vdmrpp, unsigned char *vdmrp, unsigned char *vpp, v
   __builtin_mma_pmdmxvi8gerx4pp(&vdmr, vp, vc, 0, 0, 0);
   __builtin_mma_dmxvi8gerx4spp(&vdmr, vp, vc);
   __builtin_mma_pmdmxvi8gerx4spp(&vdmr, vp, vc, 0, 0, 0);
-  __builtin_mma_dmsetdmrz(&vdmr);
-  __builtin_mma_dmmr(&vdmr, (__dmr1024*)vpp);
-  __builtin_mma_dmxor(&vdmr, (__dmr1024*)vpp);
-  __builtin_mma_build_dmr(&vdmr, vc, vc, vc, vc, vc, vc, vc, vc);
-  __builtin_mma_disassemble_dmr(vdmrp, &vdmr);
+  __builtin_dmsetdmrz(&vdmr);
+  __builtin_dmmr(&vdmr, (__dmr1024*)vpp);
+  __builtin_dmxor(&vdmr, (__dmr1024*)vpp);
+  __builtin_build_dmr(&vdmr, vc, vc, vc, vc, vc, vc, vc, vc);
+  __builtin_disassemble_dmr(vdmrp, &vdmr);
   __builtin_mma_dmsha2hash(&vdmr, &vdmr, 0);
   __builtin_mma_dmsha3hash(&vdmrpair, 0);
   __builtin_mma_dmxxshapad(&vdmr, vc, 0, 0, 0);
@@ -35,11 +35,11 @@ void test_mma(unsigned char *vdmrpp, unsigned char *vdmrp, unsigned char *vpp, v
 // CHECK: error: '__builtin_mma_pmdmxvi8gerx4pp' needs target feature mma,paired-vector-memops
 // CHECK: error: '__builtin_mma_dmxvi8gerx4spp' needs target feature mma,paired-vector-memops
 // CHECK: error: '__builtin_mma_pmdmxvi8gerx4spp' needs target feature mma,paired-vector-memops
-// ISA_FUTURE: error: '__builtin_mma_dmsetdmrz' needs target feature mma,isa-future-instructions
-// ISA_FUTURE: error: '__builtin_mma_dmmr' needs target feature mma,isa-future-instructions
-// ISA_FUTURE: error: '__builtin_mma_dmxor' needs target feature mma,isa-future-instructions
-// ISA_FUTURE: error: '__builtin_mma_build_dmr' needs target feature mma,isa-future-instructions
-// ISA_FUTURE: error: '__builtin_mma_disassemble_dmr' needs target feature mma,isa-future-instructions
+// ISA_FUTURE: error: '__builtin_dmsetdmrz' needs target feature mma,isa-future-instructions
+// ISA_FUTURE: error: '__builtin_dmmr' needs target feature mma,isa-future-instructions
+// ISA_FUTURE: error: '__builtin_dmxor' needs target feature mma,isa-future-instructions
+// ISA_FUTURE: error: '__builtin_build_dmr' needs target feature mma,isa-future-instructions
+// ISA_FUTURE: error: '__builtin_disassemble_dmr' needs target feature mma,isa-future-instructions
 // CHECK: error: '__builtin_mma_dmsha2hash' needs target feature mma,isa-future-instructions
 // CHECK: error: '__builtin_mma_dmsha3hash' needs target feature mma,isa-future-instructions
 // CHECK: error: '__builtin_mma_dmxxshapad' needs target feature mma,isa-future-instructions

--- a/llvm/include/llvm/IR/IntrinsicsPowerPC.td
+++ b/llvm/include/llvm/IR/IntrinsicsPowerPC.td
@@ -1739,13 +1739,13 @@ let TargetPrefix = "ppc" in {
   def int_ppc_mma_xxsetaccz :
       DefaultAttrsIntrinsic<[llvm_v512i1_ty], [], [IntrNoMem]>;
 
-  def int_ppc_mma_dmsetdmrz :
+  def int_ppc_dmsetdmrz :
       DefaultAttrsIntrinsic<[llvm_v1024i1_ty], [], [IntrNoMem]>;
 
-  def int_ppc_mma_dmmr :
+  def int_ppc_dmmr :
       DefaultAttrsIntrinsic<[llvm_v1024i1_ty], [llvm_v1024i1_ty], [IntrNoMem]>;
 
-  def int_ppc_mma_dmxor :
+  def int_ppc_dmxor :
       DefaultAttrsIntrinsic<[llvm_v1024i1_ty], [llvm_v1024i1_ty,
                              llvm_v1024i1_ty], [IntrNoMem]>;
 
@@ -1765,11 +1765,11 @@ let TargetPrefix = "ppc" in {
       DefaultAttrsIntrinsic<[llvm_v1024i1_ty], [llvm_v1024i1_ty, llvm_v256i1_ty,
                              llvm_i32_ty], [IntrNoMem]>;
 
-  def int_ppc_mma_disassemble_dmr :
+  def int_ppc_disassemble_dmr :
       DefaultAttrsIntrinsic<[], [llvm_ptr_ty, llvm_v1024i1_ty],
                             [IntrWriteMem, IntrArgMemOnly]>;
 
-  def int_ppc_mma_build_dmr :
+  def int_ppc_build_dmr :
       DefaultAttrsIntrinsic<[llvm_v1024i1_ty], [llvm_v16i8_ty, llvm_v16i8_ty,
                              llvm_v16i8_ty, llvm_v16i8_ty, llvm_v16i8_ty,
                              llvm_v16i8_ty, llvm_v16i8_ty, llvm_v16i8_ty],

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -11177,7 +11177,7 @@ SDValue PPCTargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
     return DAG.getMergeValues(RetOps, dl);
   }
 
-  case Intrinsic::ppc_mma_build_dmr: {
+  case Intrinsic::ppc_build_dmr: {
     SmallVector<SDValue, 8> Pairs;
     SmallVector<SDValue, 8> Chains;
     for (int i = 1; i < 9; i += 2) {
@@ -11554,7 +11554,7 @@ SDValue PPCTargetLowering::LowerINTRINSIC_VOID(SDValue Op,
             Op.getOperand(0)),
         0);
   }
-  case Intrinsic::ppc_mma_disassemble_dmr: {
+  case Intrinsic::ppc_disassemble_dmr: {
     return DAG.getStore(DAG.getEntryNode(), DL, Op.getOperand(ArgStart + 2),
                         Op.getOperand(ArgStart + 1), MachinePointerInfo());
   }

--- a/llvm/lib/Target/PowerPC/PPCInstrFutureMMA.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrFutureMMA.td
@@ -476,17 +476,17 @@ let Predicates = [MMA, IsISAFuture] in {
 
   def DMMR
       : XForm_ATB3<31, 6, 177, (outs dmr:$AT), (ins dmr:$AB), "dmmr $AT, $AB",
-                   [(set v1024i1:$AT, (int_ppc_mma_dmmr v1024i1:$AB))]>;
+                   [(set v1024i1:$AT, (int_ppc_dmmr v1024i1:$AB))]>;
 
   def DMXOR : XForm_ATB3<31, 7, 177, (outs dmr:$AT), (ins dmr:$ATi, dmr:$AB),
                          "dmxor $AT, $AB",
-                         [(set v1024i1:$AT, (int_ppc_mma_dmxor v1024i1:$ATi,
+                         [(set v1024i1:$AT, (int_ppc_dmxor v1024i1:$ATi,
                                                 v1024i1:$AB))]>,
               RegConstraint<"$ATi = $AT">;
 
   def DMSETDMRZ
       : XForm_AT3<31, 2, 177, (outs dmr:$AT), (ins), "dmsetdmrz $AT",
-                  NoItinerary, [(set v1024i1:$AT, (int_ppc_mma_dmsetdmrz))]>;
+                  NoItinerary, [(set v1024i1:$AT, (int_ppc_dmsetdmrz))]>;
 
   // DMXVI8GERX4, DMXVI8GERX4PP, PMDMXVI8GERX4,  PMDMXVI8GERX4PP
   defm DMXVI8GERX4 : DMR_UM_M448_XOEO<59, 10, (ins vsrprc:$XAp, vsrc:$XB),

--- a/llvm/test/CodeGen/PowerPC/dmr-copy.ll
+++ b/llvm/test/CodeGen/PowerPC/dmr-copy.ll
@@ -223,21 +223,21 @@ define void @foo(ptr noundef readonly captures(none) %p1, ptr noundef readonly c
 ; CHECK-BE-NEXT:    stxvp vsp34, 0(r6)
 ; CHECK-BE-NEXT:    blr
 entry:
-  %0 = tail call <1024 x i1> @llvm.ppc.mma.dmsetdmrz()
+  %0 = tail call <1024 x i1> @llvm.ppc.dmsetdmrz()
   %1 = load <1024 x i1>, ptr %p1, align 128
-  %2 = tail call <1024 x i1> @llvm.ppc.mma.dmxor(<1024 x i1> %0, <1024 x i1> %1)
+  %2 = tail call <1024 x i1> @llvm.ppc.dmxor(<1024 x i1> %0, <1024 x i1> %1)
   %3 = load <1024 x i1>, ptr %p2, align 128
-  %4 = tail call <1024 x i1> @llvm.ppc.mma.dmxor(<1024 x i1> %0, <1024 x i1> %3)
-  %5 = tail call <1024 x i1> @llvm.ppc.mma.dmmr(<1024 x i1> %2)
+  %4 = tail call <1024 x i1> @llvm.ppc.dmxor(<1024 x i1> %0, <1024 x i1> %3)
+  %5 = tail call <1024 x i1> @llvm.ppc.dmmr(<1024 x i1> %2)
   store <1024 x i1> %5, ptr %res1, align 128
-  %6 = tail call <1024 x i1> @llvm.ppc.mma.dmmr(<1024 x i1> %4)
+  %6 = tail call <1024 x i1> @llvm.ppc.dmmr(<1024 x i1> %4)
   store <1024 x i1> %6, ptr %res2, align 128
   ret void
 }
 
-declare <1024 x i1> @llvm.ppc.mma.dmsetdmrz()
-declare <1024 x i1> @llvm.ppc.mma.dmxor(<1024 x i1>, <1024 x i1>)
-declare <1024 x i1> @llvm.ppc.mma.dmmr(<1024 x i1>)
+declare <1024 x i1> @llvm.ppc.dmsetdmrz()
+declare <1024 x i1> @llvm.ppc.dmxor(<1024 x i1>, <1024 x i1>)
+declare <1024 x i1> @llvm.ppc.dmmr(<1024 x i1>)
 declare <1024 x i1> @llvm.ppc.mma.dmxvi8gerx4(<256 x i1>, <16 x i8>)
 
 attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="future" "target-features"="+64bit,+allow-unaligned-fp-access,+altivec,+bpermd,+cmpb,+crbits,+crypto,+direct-move,+extdiv,+fast-MFLR,+fcpsgn,+fpcvt,+fprnd,+fpu,+fre,+fres,+frsqrte,+frsqrtes,+fsqrt,+fuse-add-logical,+fuse-arith-add,+fuse-logical,+fuse-logical-add,+fuse-sha3,+fuse-store,+fusion,+hard-float,+icbt,+isa-future-instructions,+isa-v206-instructions,+isa-v207-instructions,+isa-v30-instructions,+isa-v31-instructions,+isel,+ldbrx,+lfiwax,+mfocrf,+mma,+paired-vector-memops,+partword-atomics,+pcrelative-memops,+popcntd,+power10-vector,+power8-altivec,+power8-vector,+power9-altivec,+power9-vector,+ppc-postra-sched,+ppc-prera-sched,+predictable-select-expensive,+prefix-instrs,+quadword-atomics,+recipprec,+stfiwx,+two-const-nr,+vsx" }

--- a/llvm/test/CodeGen/PowerPC/dmr-enable.ll
+++ b/llvm/test/CodeGen/PowerPC/dmr-enable.ll
@@ -29,7 +29,7 @@ define void @tdmrz(ptr nocapture readonly %vp1, ptr nocapture %resp)  {
 ; CHECK-BE-NEXT:    stxvp vsp34, 0(r4)
 ; CHECK-BE-NEXT:    blr
 entry:
-  %z = call <1024 x i1> @llvm.ppc.mma.dmsetdmrz()
+  %z = call <1024 x i1> @llvm.ppc.dmsetdmrz()
   store <1024 x i1> %z, ptr %resp, align 32
   ret void
 }
@@ -70,7 +70,7 @@ define void @tdmmr(ptr nocapture readonly %vp1, ptr nocapture %resp)  {
 ; CHECK-BE-NEXT:    blr
 entry:
   %l = load <1024 x i1>, ptr %vp1, align 32
-  %c = call <1024 x i1> @llvm.ppc.mma.dmmr(<1024 x i1> %l)
+  %c = call <1024 x i1> @llvm.ppc.dmmr(<1024 x i1> %l)
   store <1024 x i1> %c, ptr %resp, align 32
   ret void
 }
@@ -124,7 +124,7 @@ define void @tdmxor(ptr nocapture readonly %vp1, ptr %vp2, ptr nocapture %resp) 
 entry:
   %l = load <1024 x i1>, ptr %vp1, align 32
   %r = load <1024 x i1>, ptr %vp2, align 32
-  %x = call <1024 x i1> @llvm.ppc.mma.dmxor(<1024 x i1> %l, <1024 x i1> %r)
+  %x = call <1024 x i1> @llvm.ppc.dmxor(<1024 x i1> %l, <1024 x i1> %r)
   store <1024 x i1> %x, ptr %resp, align 32
   ret void
 }
@@ -152,7 +152,7 @@ define void @text512(ptr %vp1, ptr %rp1, ptr %rp2, ptr %rp3, ptr %rp4)  {
 ; CHECK-BE-NEXT:    stxv v2, 0(r6)
 ; CHECK-BE-NEXT:    blr
 entry:
-  %z = call <1024 x i1> @llvm.ppc.mma.dmsetdmrz()
+  %z = call <1024 x i1> @llvm.ppc.dmsetdmrz()
   %x = call { <256 x i1>, <256 x i1> } @llvm.ppc.mma.dmxxextfdmr512(<1024 x i1> %z, i32 0)
   %p = extractvalue { <256 x i1>, <256 x i1 > } %x, 0
   store <256 x i1> %p, ptr %rp1, align 16
@@ -197,7 +197,7 @@ define void @text256(ptr %vp1, ptr %rp1, ptr %rp2, ptr %rp3, ptr %rp4)  {
 ; CHECK-BE-NEXT:    stxv v2, 0(r7)
 ; CHECK-BE-NEXT:    blr
 entry:
-  %z = call <1024 x i1> @llvm.ppc.mma.dmsetdmrz()
+  %z = call <1024 x i1> @llvm.ppc.dmsetdmrz()
   %x = call <256 x i1> @llvm.ppc.mma.dmxxextfdmr256(<1024 x i1> %z, i32 0)
   store <256 x i1> %x, ptr %rp1, align 16
   %q = call <256 x i1> @llvm.ppc.mma.dmxxextfdmr256(<1024 x i1> %z, i32 1)
@@ -264,7 +264,7 @@ define void @tins512(ptr %vp1, ptr %vp2, ptr %vp3, ptr %vp4, ptr %rp1, ptr %rp2)
 ; CHECK-BE-NEXT:    stxvp vsp34, 0(r8)
 ; CHECK-BE-NEXT:    blr
 entry:
-  %z = call <1024 x i1> @llvm.ppc.mma.dmsetdmrz()
+  %z = call <1024 x i1> @llvm.ppc.dmsetdmrz()
   %l1 = load <256 x i1>, ptr %vp1, align 16
   %r1 = load <256 x i1>, ptr %vp2, align 16
   %a = call <1024 x i1> @llvm.ppc.mma.dmxxinstdmr512(<1024 x i1> %z, <256 x i1> %l1, <256 x i1> %r1, i32 0)
@@ -351,7 +351,7 @@ define void @tins256(ptr %vp1, ptr %vp2, ptr %vp3, ptr %vp4, ptr %rp1, ptr %rp2,
 ; CHECK-BE-NEXT:    stxvp vsp34, 0(r10)
 ; CHECK-BE-NEXT:    blr
 entry:
-  %z = call <1024 x i1> @llvm.ppc.mma.dmsetdmrz()
+  %z = call <1024 x i1> @llvm.ppc.dmsetdmrz()
   %l1 = load <256 x i1>, ptr %vp1, align 16
   %a = call <1024 x i1> @llvm.ppc.mma.dmxxinstdmr256(<1024 x i1> %z, <256 x i1> %l1, i32 0)
   store <1024 x i1> %a, ptr %rp1, align 16
@@ -421,18 +421,18 @@ define void @tbuild(ptr %p1, ptr %p2, ptr %res1, ptr %res2, ptr %v) {
 ; CHECK-BE-NEXT:    blr
 entry:
   %0 = load <16 x i8>, ptr %v, align 16
-  %1 = tail call <1024 x i1> @llvm.ppc.mma.build.dmr(<16 x i8> %0, <16 x i8> %0, <16 x i8> %0, <16 x i8> %0, <16 x i8> %0, <16 x i8> %0, <16 x i8> %0, <16 x i8> %0)
+  %1 = tail call <1024 x i1> @llvm.ppc.build.dmr(<16 x i8> %0, <16 x i8> %0, <16 x i8> %0, <16 x i8> %0, <16 x i8> %0, <16 x i8> %0, <16 x i8> %0, <16 x i8> %0)
   store <1024 x i1> %1, ptr %res2, align 128
   %2 = load <1024 x i1>, ptr %p1, align 128
-  tail call void @llvm.ppc.mma.disassemble.dmr(ptr %res1, <1024 x i1> %2)
+  tail call void @llvm.ppc.disassemble.dmr(ptr %res1, <1024 x i1> %2)
   ret void
 }
 
-declare <1024 x i1> @llvm.ppc.mma.build.dmr(<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>)
-declare void @llvm.ppc.mma.disassemble.dmr(ptr, <1024 x i1>)
-declare <1024 x i1> @llvm.ppc.mma.dmsetdmrz()
-declare <1024 x i1> @llvm.ppc.mma.dmmr(<1024 x i1>)
-declare <1024 x i1> @llvm.ppc.mma.dmxor(<1024 x i1>, <1024 x i1>)
+declare <1024 x i1> @llvm.ppc.build.dmr(<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>)
+declare void @llvm.ppc.disassemble.dmr(ptr, <1024 x i1>)
+declare <1024 x i1> @llvm.ppc.dmsetdmrz()
+declare <1024 x i1> @llvm.ppc.dmmr(<1024 x i1>)
+declare <1024 x i1> @llvm.ppc.dmxor(<1024 x i1>, <1024 x i1>)
 declare <1024 x i1> @llvm.ppc.mma.dmxxinstdmr512(<1024 x i1>, <256 x i1>, <256 x i1>, i32)
 declare <1024 x i1> @llvm.ppc.mma.dmxxinstdmr256(<1024 x i1>, <256 x i1>, i32)
 declare { <256 x i1>, <256 x i1> } @llvm.ppc.mma.dmxxextfdmr512(<1024 x i1>, i32)

--- a/llvm/test/CodeGen/PowerPC/v1024ls.ll
+++ b/llvm/test/CodeGen/PowerPC/v1024ls.ll
@@ -44,4 +44,4 @@ entry:
   ret void
 }
 
-declare <1024 x i1> @llvm.ppc.mma.dmsetdmrz()
+declare <1024 x i1> @llvm.ppc.dmsetdmrz()


### PR DESCRIPTION
Remove `_mma` from the following built-ins as they are not related to MMA:

* __builtin_mma_dmsetdmrz
* __builtin_mma_dmmr
* __builtin_mma_dmxor
* __builtin_mma_build_dmr
* __builtin_mma_disassemble_dmr

AI Assisted.
