### PR TITLE
[flang][runtime] Catch asynchronous parent or child I/O

### DIFF
--- a/flang-rt/lib/runtime/io-api.cpp
+++ b/flang-rt/lib/runtime/io-api.cpp
@@ -785,8 +785,13 @@ bool IODEF(SetAsynchronous)(
     } else {
       handler.SignalError(IostatBadAsynchronous);
     }
-  } else if (!io.get_if<NoopStatementState>() &&
-      !io.get_if<ErroneousIoStatementState>()) {
+  } else if (io.get_if<NoopStatementState>() ||
+      io.get_if<ErroneousIoStatementState>()) {
+    // no error
+  } else if (io.get_if<ChildIoStatementState<Direction::Output>>() ||
+      io.get_if<ChildIoStatementState<Direction::Input>>()) {
+    io.GetIoErrorHandler().SignalError(IostatChildAsynchronous);
+  } else {
     handler.Crash("SetAsynchronous('YES') called when not in an OPEN or "
                   "external I/O statement");
   }

--- a/flang-rt/lib/runtime/iostat.cpp
+++ b/flang-rt/lib/runtime/iostat.cpp
@@ -121,6 +121,10 @@ const char *IostatErrorString(int iostat) {
     return "Defined unformatted I/O without an external unit";
   case IostatOpenNewExtant:
     return "OPEN(STATUS='NEW') on existing file";
+  case IostatParentAsynchronous:
+    return "ASYNCHRONOUS='YES' on a parent data transfer statement";
+  case IostatChildAsynchronous:
+    return "ASYNCHRONOUS='YES' on a child data transfer statement";
   default:
     return nullptr;
   }

--- a/flang/include/flang/Runtime/iostat-consts.h
+++ b/flang/include/flang/Runtime/iostat-consts.h
@@ -86,6 +86,8 @@ enum Iostat {
   IostatBadListDirectedInputSeparator,
   IostatNonExternalDefinedUnformattedIo,
   IostatOpenNewExtant,
+  IostatParentAsynchronous,
+  IostatChildAsynchronous,
 };
 
 } // namespace Fortran::runtime::io


### PR DESCRIPTION
ASYNCHRONOUS="YES" is not permitted for either a parent or child data transfer statement in ISO Fortran (F'2023 12.6.4.8.3 p19). Not that it matters much -- we don't support true asynchronous I/O anyway -- but someday we might, and in the meantime it's nice to be able to pass tests that check conformance.