### PR TITLE
[lldb-dap] Correct types in cancel reqs.

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -938,7 +938,7 @@ bool DAP::IsCancelled(const protocol::Request &req) {
 void DAP::ClearCancelRequest(const CancelArguments &args) {
   std::lock_guard<std::mutex> guard(m_cancelled_requests_mutex);
   if (args.requestId)
-    m_cancelled_requests.erase(*args.requestId);
+    m_cancelled_requests.erase(args.requestId);
 }
 
 template <typename T>
@@ -969,7 +969,7 @@ void DAP::Received(const protocol::Request &request) {
     {
       std::lock_guard<std::mutex> guard(m_cancelled_requests_mutex);
       if (cancel_args->requestId)
-        m_cancelled_requests.insert(*cancel_args->requestId);
+        m_cancelled_requests.insert(cancel_args->requestId);
     }
 
     // If a cancel is requested for the active request, make a best

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.cpp
@@ -148,8 +148,8 @@ namespace lldb_dap::protocol {
 
 bool fromJSON(const json::Value &Params, CancelArguments &CA, json::Path P) {
   json::ObjectMapper O(Params, P);
-  return O && O.map("requestId", CA.requestId) &&
-         O.map("progressId", CA.progressId);
+  return O && O.mapOptional("requestId", CA.requestId) &&
+         O.mapOptional("progressId", CA.progressId);
 }
 
 bool fromJSON(const json::Value &Params, DisconnectArguments &DA,

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -42,13 +42,13 @@ struct CancelArguments {
   /// is cancelled.
   ///
   /// Both a `requestId` and a `progressId` can be specified in one request.
-  std::optional<int64_t> requestId;
+  uint64_t requestId = 0;
 
   /// The ID (attribute `progressId`) of the progress to cancel. If missing no
   /// progress is cancelled.
   ///
   /// Both a `requestId` and a `progressId` can be specified in one request.
-  std::optional<int64_t> progressId;
+  std::string progressId;
 };
 bool fromJSON(const llvm::json::Value &, CancelArguments &, llvm::json::Path);
 

--- a/lldb/unittests/DAP/ProtocolRequestsTest.cpp
+++ b/lldb/unittests/DAP/ProtocolRequestsTest.cpp
@@ -433,3 +433,30 @@ TEST(ProtocolRequestsTest, SetVariableArguments) {
       parse<SetVariableArguments>(R"({})"),
       FailedWithMessage("missing value at (root).variablesReference"));
 }
+
+TEST(ProtocolRequestsTest, CancelRequestArguments) {
+  llvm::Expected<CancelArguments> expected = parse<CancelArguments>(R"({
+    "requestId": 42,
+    "progressId": "abc"
+  })");
+  ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
+  EXPECT_EQ(expected->requestId, 42U);
+  EXPECT_EQ(expected->progressId, "abc");
+
+  expected = parse<CancelArguments>(R"({
+    "requestId": 42
+  })");
+  ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
+  EXPECT_EQ(expected->requestId, 42U);
+  EXPECT_TRUE(expected->progressId.empty());
+
+  expected = parse<CancelArguments>(R"({
+    "progressId": "abc"
+  })");
+  ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
+  EXPECT_EQ(expected->requestId, 0u);
+  EXPECT_EQ(expected->progressId, "abc");
+
+  // Check an empty message, all keys are optional.
+  EXPECT_THAT_EXPECTED(parse<CancelArguments>(R"({})"), Succeeded());
+}


### PR DESCRIPTION
Correcting the types in cancel arguments. The `progressId` should have been a string and updating the requestId to default to 0.