### PR TITLE
[amdgpu-cfi: 1/9]: [MIR] Error on signed integer in getUnsigned

### DIFF
--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -2104,7 +2104,10 @@ static bool getUnsigned(const MIToken &Token, unsigned &Result,
                         ErrorCallbackType ErrCB) {
   if (Token.hasIntegerValue()) {
     const uint64_t Limit = uint64_t(std::numeric_limits<unsigned>::max()) + 1;
-    uint64_t Val64 = Token.integerValue().getLimitedValue(Limit);
+    const APSInt &SInt = Token.integerValue();
+    if (SInt.isNegative())
+      return ErrCB(Token.location(), "expected unsigned integer");
+    uint64_t Val64 = SInt.getLimitedValue(Limit);
     if (Val64 == Limit)
       return ErrCB(Token.location(), "expected 32-bit integer (too large)");
     Result = Val64;

--- a/llvm/test/CodeGen/MIR/Generic/expected-unsigned.mir
+++ b/llvm/test/CodeGen/MIR/Generic/expected-unsigned.mir
@@ -1,0 +1,26 @@
+# RUN: not llc -run-pass=none -filetype=null %s 2>&1 | FileCheck %s
+
+# Stand in as a test of all uses of MIParser::getUnsigned to ensure it
+# rejects negative integers.
+
+--- |
+
+  define i32 @foo(i32 %a) {
+  entry:
+    %0 = icmp sle i32 %a, 10
+    br label %foo
+
+  foo:
+    ret i32 0
+  }
+
+...
+---
+name:            foo
+body: |
+  bb.0.entry:
+    ; CHECK: [[@LINE+1]]:27: expected unsigned integer
+    successors: %bb.1.foo(-2)
+
+  bb.1.foo:
+...


### PR DESCRIPTION
Previously we effectively took the absolute value of the APSInt, instead
diagnose the unexpected negative value.

Change-Id: I4efe961e7b29fdf1d5f97df12f8139aac12c9219

---

**Stack**:
- #183147
- #183149
- #183150
- #183146
- #183153
- #183152
- #183148
- #183151
- #183171⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
