### PR TITLE
[clang-tidy] Nominate myself as a maintainer

### DIFF
--- a/clang-tools-extra/Maintainers.rst
+++ b/clang-tools-extra/Maintainers.rst
@@ -30,6 +30,9 @@ clang-tidy
 | Victor Baranov
 | bar.victor.2002@gmail.com (email), vbvictor (GitHub), vbvictor (Discourse), vbvictor  (Discord)
 
+| Victor Chernyakin
+| chernyakin.victor.j@outlook.com (email), localspook (GitHub), LocalSpook (Discourse), localspook (Discord)
+
 
 clang-query
 -----------


### PR DESCRIPTION
For the past ~8 months, I've been regularly working on clang-tidy, doing features and cleanups, fixing issues, and reviewing PRs. I'm passionate about the project, and I'd like to step up to be a maintainer for it!