### PR TITLE
[flang] Inline trivial scalar allocatable assignments in HLFIR-to-FIR

### DIFF
--- a/flang/lib/Optimizer/HLFIR/Transforms/ConvertToFIR.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/ConvertToFIR.cpp
@@ -91,31 +91,61 @@ public:
     };
 
     if (assignOp.isAllocatableAssignment()) {
-      // Whole allocatable assignment: use the runtime to deal with the
-      // reallocation.
-      mlir::Value from = emboxRHS(rhsExv);
-      mlir::Value to = fir::getBase(lhsExv);
-      if (assignOp.mustKeepLhsLengthInAllocatableAssignment()) {
-        // Indicate the runtime that it should not reallocate in case of length
-        // mismatch, and that it should use the LHS explicit/assumed length if
-        // allocating/reallocation the LHS.
-        // Note that AssignExplicitLengthCharacter() must be used
-        // when isTemporaryLHS() is true here: the LHS is known to be
-        // character allocatable in this case, so finalization will not
-        // happen (as implied by temporary_lhs attribute), and LHS
-        // must keep its length (as implied by keep_lhs_length_if_realloc).
-        fir::runtime::genAssignExplicitLengthCharacter(builder, loc, to, from);
-      } else if (assignOp.isTemporaryLHS()) {
-        // Use AssignTemporary, when the LHS is a compiler generated temporary.
-        // Note that it also works properly for polymorphic LHS (i.e. the LHS
-        // will have the RHS dynamic type after the assignment).
-        fir::runtime::genAssignTemporary(builder, loc, to, from);
-      } else if (lhs.isPolymorphic()) {
-        // Indicate the runtime that the LHS must have the RHS dynamic type
-        // after the assignment.
-        fir::runtime::genAssignPolymorphic(builder, loc, to, from);
+      // For trivial scalar allocatable assignments that are not polymorphic,
+      // not character, and not temporary, inline the assignment instead of
+      // calling the runtime.
+      if (!assignOp.mustKeepLhsLengthInAllocatableAssignment() &&
+          !assignOp.isTemporaryLHS() && !lhs.isPolymorphic() &&
+          !lhs.isArray() && fir::isa_trivial(lhs.getFortranElementType())) {
+        mlir::Value rhsVal = fir::getBase(rhsExv);
+        mlir::Value boxRef = fir::getBase(lhsExv);
+        mlir::Value box = fir::LoadOp::create(builder, loc, boxRef);
+        mlir::Value addr = fir::BoxAddrOp::create(builder, loc, box);
+        mlir::Value isAllocated = builder.genIsNotNullAddr(loc, addr);
+        auto boxType = mlir::cast<fir::BoxType>(box.getType());
+        auto heapType = mlir::cast<fir::HeapType>(boxType.getEleTy());
+        mlir::Type elemType = heapType.getEleTy();
+        builder.genIfThenElse(loc, isAllocated)
+            .genThen(
+                [&]() { fir::StoreOp::create(builder, loc, rhsVal, addr); })
+            .genElse([&]() {
+              mlir::Value newMem =
+                  fir::AllocMemOp::create(builder, loc, elemType);
+              fir::StoreOp::create(builder, loc, rhsVal, newMem);
+              mlir::Value newBox =
+                  fir::EmboxOp::create(builder, loc, boxType, newMem);
+              fir::StoreOp::create(builder, loc, newBox, boxRef);
+            })
+            .end();
       } else {
-        fir::runtime::genAssign(builder, loc, to, from);
+        // Whole allocatable assignment: use the runtime to deal with the
+        // reallocation.
+        mlir::Value from = emboxRHS(rhsExv);
+        mlir::Value to = fir::getBase(lhsExv);
+        if (assignOp.mustKeepLhsLengthInAllocatableAssignment()) {
+          // Indicate the runtime that it should not reallocate in case of
+          // length mismatch, and that it should use the LHS
+          // explicit/assumed length if allocating/reallocation the LHS.
+          // Note that AssignExplicitLengthCharacter() must be used
+          // when isTemporaryLHS() is true here: the LHS is known to be
+          // character allocatable in this case, so finalization will not
+          // happen (as implied by temporary_lhs attribute), and LHS
+          // must keep its length (as implied by keep_lhs_length_if_realloc).
+          fir::runtime::genAssignExplicitLengthCharacter(builder, loc, to,
+                                                         from);
+        } else if (assignOp.isTemporaryLHS()) {
+          // Use AssignTemporary, when the LHS is a compiler generated
+          // temporary. Note that it also works properly for polymorphic
+          // LHS (i.e. the LHS will have the RHS dynamic type after the
+          // assignment).
+          fir::runtime::genAssignTemporary(builder, loc, to, from);
+        } else if (lhs.isPolymorphic()) {
+          // Indicate the runtime that the LHS must have the RHS dynamic
+          // type after the assignment.
+          fir::runtime::genAssignPolymorphic(builder, loc, to, from);
+        } else {
+          fir::runtime::genAssign(builder, loc, to, from);
+        }
       }
     } else if (lhs.isArray() ||
                // Special case for element-by-element (or scalar) assignments

--- a/flang/lib/Optimizer/HLFIR/Transforms/ConvertToFIR.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/ConvertToFIR.cpp
@@ -16,6 +16,7 @@
 #include "flang/Optimizer/Builder/Runtime/Derived.h"
 #include "flang/Optimizer/Builder/Runtime/Inquiry.h"
 #include "flang/Optimizer/Builder/Todo.h"
+#include "flang/Optimizer/Dialect/CUF/Attributes/CUFAttr.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
@@ -92,11 +93,12 @@ public:
 
     if (assignOp.isAllocatableAssignment()) {
       // For trivial scalar allocatable assignments that are not polymorphic,
-      // not character, and not temporary, inline the assignment instead of
-      // calling the runtime.
+      // not character, not temporary, and not CUDA Fortran, inline the
+      // assignment instead of calling the runtime.
       if (!assignOp.mustKeepLhsLengthInAllocatableAssignment() &&
           !assignOp.isTemporaryLHS() && !lhs.isPolymorphic() &&
-          !lhs.isArray() && fir::isa_trivial(lhs.getFortranElementType())) {
+          !lhs.isArray() && fir::isa_trivial(lhs.getFortranElementType()) &&
+          !cuf::getDataAttr(lhs.getDefiningOp())) {
         mlir::Value rhsVal = fir::getBase(rhsExv);
         mlir::Value boxRef = fir::getBase(lhsExv);
         mlir::Value box = fir::LoadOp::create(builder, loc, boxRef);

--- a/flang/test/HLFIR/assign-codegen.fir
+++ b/flang/test/HLFIR/assign-codegen.fir
@@ -530,7 +530,7 @@ func.func @alloc_assign_array(%arg0: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi3
 // CUDA Fortran device allocatable should still use the runtime
 func.func @alloc_assign_cuf_device(%arg0: !fir.ref<!fir.box<!fir.heap<i32>>>) {
   %c42 = arith.constant 42 : i32
-  %0:2 = hlfir.declare %arg0 {fortran_attrs = #fir.var_attrs<allocatable>, data_attr = #cuf<device>, uniq_name = "k"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+  %0:2 = hlfir.declare %arg0 {fortran_attrs = #fir.var_attrs<allocatable>, data_attr = #cuf.cuda<device>, uniq_name = "k"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
   hlfir.assign %c42 to %0#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
   return
 }

--- a/flang/test/HLFIR/assign-codegen.fir
+++ b/flang/test/HLFIR/assign-codegen.fir
@@ -526,3 +526,13 @@ func.func @alloc_assign_array(%arg0: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi3
 }
 // CHECK-LABEL:   func.func @alloc_assign_array(
 // CHECK:           fir.call @_FortranAAssign
+
+// CUDA Fortran device allocatable should still use the runtime
+func.func @alloc_assign_cuf_device(%arg0: !fir.ref<!fir.box<!fir.heap<i32>>>) {
+  %c42 = arith.constant 42 : i32
+  %0:2 = hlfir.declare %arg0 {fortran_attrs = #fir.var_attrs<allocatable>, data_attr = #cuf<device>, uniq_name = "k"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+  hlfir.assign %c42 to %0#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
+  return
+}
+// CHECK-LABEL:   func.func @alloc_assign_cuf_device(
+// CHECK:           fir.call @_FortranAAssign

--- a/flang/test/HLFIR/assign-codegen.fir
+++ b/flang/test/HLFIR/assign-codegen.fir
@@ -480,3 +480,49 @@ func.func @test_scalar_opt_char_box(%arg0: !fir.ref<!fir.char<1,10>>, %arg1: !fi
 // CHECK:           }
 // ...
 // CHECK:           "llvm.intr.memmove"
+
+// Trivial scalar allocatable: should inline instead of calling _FortranAAssign.
+// This avoids pulling in the heavyweight runtime which causes excessive
+// register and stack usage in GPU device kernels.
+//
+// Example 1 (already allocated, hits the "then" branch -- direct store):
+//   integer, allocatable :: k
+//   allocate(k)
+//   k = 42
+//
+// Example 2 (not allocated, hits the "else" branch -- allocmem + store):
+//   integer, allocatable :: k
+//   k = 42
+func.func @alloc_assign_trivial_scalar(%arg0: !fir.ref<!fir.box<!fir.heap<i32>>>) {
+  %c42 = arith.constant 42 : i32
+  %0:2 = hlfir.declare %arg0 {fortran_attrs = #fir.var_attrs<allocatable, target>, uniq_name = "k"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+  hlfir.assign %c42 to %0#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
+  return
+}
+// CHECK-LABEL:   func.func @alloc_assign_trivial_scalar(
+// CHECK-SAME:        %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>) {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 42 : i32
+// CHECK:           %[[VAL_2:.*]] = fir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<allocatable, target>, uniq_name = "k"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<!fir.heap<i32>>>
+// CHECK:           %[[BOX:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+// CHECK:           %[[ADDR:.*]] = fir.box_addr %[[BOX]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+// CHECK:           %[[ADDR_INT:.*]] = fir.convert %[[ADDR]]
+// CHECK:           %[[C0:.*]] = arith.constant 0
+// CHECK:           %[[IS_ALLOC:.*]] = arith.cmpi ne, %[[ADDR_INT]], %[[C0]]
+// CHECK:           fir.if %[[IS_ALLOC]] {
+// CHECK:             fir.store %[[VAL_1]] to %[[ADDR]] : !fir.heap<i32>
+// CHECK:           } else {
+// CHECK:             %[[NEW_MEM:.*]] = fir.allocmem i32
+// CHECK:             fir.store %[[VAL_1]] to %[[NEW_MEM]] : !fir.heap<i32>
+// CHECK:             %[[NEW_BOX:.*]] = fir.embox %[[NEW_MEM]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
+// CHECK:             fir.store %[[NEW_BOX]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+// CHECK:           }
+// CHECK-NOT:       _FortranAAssign
+// CHECK:           return
+
+// Array allocatable should still use the runtime
+func.func @alloc_assign_array(%arg0: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %arg1: !fir.box<!fir.array<?xi32>>) {
+  hlfir.assign %arg1 to %arg0 realloc : !fir.box<!fir.array<?xi32>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+  return
+}
+// CHECK-LABEL:   func.func @alloc_assign_array(
+// CHECK:           fir.call @_FortranAAssign

--- a/flang/test/Lower/OpenMP/cfg-conversion-omp.private.f90
+++ b/flang/test/Lower/OpenMP/cfg-conversion-omp.private.f90
@@ -7,7 +7,7 @@
 ! RUN: fir-opt --cfg-conversion -o test.cfg-conv.mlir
 ! RUN: FileCheck --input-file=test.cfg-conv.mlir %s --check-prefix="CFGConv"
 
-! RUN: fir-opt --convert-hlfir-to-fir --cg-rewrite --fir-to-llvm-ir test.cfg-conv.mlir -o - | \
+! RUN: fir-opt --convert-hlfir-to-fir --cfg-conversion --cg-rewrite --fir-to-llvm-ir test.cfg-conv.mlir -o - | \
 ! RUN: FileCheck %s --check-prefix="LLVMDialect"
 
 !--- test.f90


### PR DESCRIPTION
For trivial scalar allocatable assignments (non-polymorphic, non-character, non-array, non-temporary), inline the assignment directly instead of calling the `_FortranAAssign` runtime. The inlined code checks whether the allocatable is already allocated: if so, it stores directly; otherwise, it allocates memory via `fir.allocmem`, stores, and updates the box descriptor. The if-branch is necessary to handle both cases:

```fortran
integer, allocatable :: k
allocate(k)
k = 42    ! already allocated: store directly
```

```fortran
integer, allocatable :: k
k = 42    ! not allocated: allocmem, store, update box
```