### PR TITLE
[MLIR][Transform] tile_using_for: allow transform.any_param in mixed args

### DIFF
--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -3526,7 +3526,7 @@ transform::TileUsingForOp::apply(transform::TransformRewriter &rewriter,
   dynamicSizeProducers.reserve(getDynamicSizes().size());
   paramSizes.reserve(getDynamicSizes().size());
   for (Value transformValue : getDynamicSizes()) {
-    if (isa<ParamType>(transformValue.getType())) {
+    if (isa<TransformParamTypeInterface>(transformValue.getType())) {
       dynamicSizeProducers.push_back({});
       ArrayRef<Attribute> params = state.getParams(transformValue);
       paramSizes.push_back(llvm::map_to_vector(params, [](Attribute attr) {

--- a/mlir/test/Dialect/Linalg/transform-op-tile.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-tile.mlir
@@ -84,10 +84,11 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     // expected-note @below {{for this parameter}}
-    %1 = transform.test_produce_param (0 : i64) : !transform.param<i64>
+    %c0 = transform.test_produce_param (0 : i64) : !transform.param<i64>
+    %c0_as_any = transform.test_produce_param (0 : i64) : !transform.any_param
     // expected-error @below {{expected as many parameter values (0) as target ops (2)}}
-    transform.structured.tile_using_for %0 tile_sizes [%1, %1, %1]
-      : (!transform.any_op, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
+    transform.structured.tile_using_for %0 tile_sizes [%c0, %c0, %c0_as_any]
+      : (!transform.any_op, !transform.param<i64>, !transform.param<i64>, !transform.any_param)
       -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
       transform.yield
   }


### PR DESCRIPTION
Changes check to be on the interface so that `!transform.any_param` typed values are accepted in addition to `!transform.param<...>`.