### PR TITLE
[SCF] allow indexing operations for loop coalesceing

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/TransformOps/SCFTransformOps.td
+++ b/mlir/include/mlir/Dialect/SCF/TransformOps/SCFTransformOps.td
@@ -392,6 +392,34 @@ def LoopCoalesceOp : Op<Transform_Dialect, "loop.coalesce", [
   }];
 }
 
+def LoopCoalesceNestedOp : Op<Transform_Dialect, "loop.coalesce_nested", [
+  FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+  TransformOpInterface, TransformEachOpTrait]> {
+  let summary = "Coalesces nested loops including imperfectly nested ones";
+  let description = [{
+    Given a loop, collects all nested loops (including imperfectly nested
+    loops with operations between them) and coalesces them directly using
+    coalesceLoops.
+
+    #### Return modes
+
+    The return handle points to the coalesced loop.
+  }];
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs TransformHandleTypeInterface:$transformed);
+
+  let assemblyFormat =
+      "$target attr-dict `:` functional-type($target, $transformed)";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::Operation *target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 def TakeAssumedBranchOp : Op<Transform_Dialect, "scf.take_assumed_branch", [
   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
   TransformOpInterface, TransformEachOpTrait]> {

--- a/mlir/lib/Dialect/SCF/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/SCF/Utils/Utils.cpp
@@ -957,7 +957,8 @@ LogicalResult mlir::coalesceLoops(RewriterBase &rewriter,
   Value upperBound = getProductOfIntsOrIndexes(rewriter, loc, upperBounds);
   outermost.setUpperBound(upperBound);
 
-  rewriter.setInsertionPointToStart(innermost.getBody());
+  // Insert delinearization at the start of the outermost loop body.
+  rewriter.setInsertionPointToStart(outermost.getBody());
   auto [delinearizeIvs, preservedUsers] = delinearizeInductionVariable(
       rewriter, loc, outermost.getInductionVar(), upperBounds);
   rewriter.replaceAllUsesExcept(outermost.getInductionVar(), delinearizeIvs[0],


### PR DESCRIPTION
Currently if there are operations between the loops we get a dominance issue as the delinearlized index is added after the operations. This PR fixes that. 

For testing we also add a transform pattern that makes a direct call to coalesceLoops as the existing pattern calls coalescePerfectlyNestedSCFForLoops which does not consider the loop nest perfectly nested if there are operations between them which is safer for that usage.