### PR TITLE
[BOLT][instr] Disable stderr diagnostic output when targeting Android

### DIFF
--- a/bolt/runtime/common.h
+++ b/bolt/runtime/common.h
@@ -232,15 +232,21 @@ void *strStr(const char *const Haystack, const char *const Needle) {
 }
 
 void reportNumber(const char *Msg, uint64_t Num, uint32_t Base) {
+#if !defined(__ANDROID__)
   char Buf[BufSize];
   char *Ptr = Buf;
   Ptr = strCopy(Ptr, Msg, BufSize - 23);
   Ptr = intToStr(Ptr, Num, Base);
   Ptr = strCopy(Ptr, "\n");
   __write(2, Buf, Ptr - Buf);
+#endif
 }
 
-void report(const char *Msg) { __write(2, Msg, strLen(Msg)); }
+void report(const char *Msg) {
+#if !defined(__ANDROID__)
+  __write(2, Msg, strLen(Msg));
+#endif
+}
 
 unsigned long hexToLong(const char *Str, char Terminator = '\0') {
   unsigned long Res = 0;
@@ -278,19 +284,25 @@ static bool scanUInt32(const char *&Buf, const char *End, uint32_t &Ret) {
 }
 
 void reportError(const char *Msg, uint64_t Size) {
+#if !defined(__ANDROID__)
   __write(2, Msg, Size);
+#endif
   __exit(1);
 }
 
 void assert(bool Assertion, const char *Msg) {
   if (Assertion)
     return;
+#if defined(__ANDROID__)
+  __exit(1);
+#else
   char Buf[BufSize];
   char *Ptr = Buf;
   Ptr = strCopy(Ptr, "Assertion failed: ");
   Ptr = strCopy(Ptr, Msg, BufSize - 40);
   Ptr = strCopy(Ptr, "\n");
   reportError(Buf, Ptr - Buf);
+#endif
 }
 
 #define SIG_BLOCK 0

--- a/bolt/runtime/instr.cpp
+++ b/bolt/runtime/instr.cpp
@@ -131,6 +131,9 @@ class BumpPtrAllocator {
   };
 
 public:
+#if defined(__ANDROID__)
+  __attribute__((noinline))
+#endif
   void *allocate(size_t Size) {
     Lock L(M);
 
@@ -158,6 +161,9 @@ public:
   /// bugs by checking magic bytes. Ordinarily, we reset the allocator once
   /// we are done with it. Reset is done with clear(). There's no need
   /// to deallocate each element individually.
+#if defined(__ANDROID__)
+  __attribute__((noinline))
+#endif
   void deallocate(void *Ptr) {
     Lock L(M);
     uint8_t MetadataOffset = sizeof(EntryMetadata);
@@ -259,6 +265,7 @@ struct SimpleHashTableEntryBase {
   uint64_t Key;
   uint64_t Val;
   void dump(const char *Msg = nullptr) {
+#if !defined(__ANDROID__)
     // TODO: make some sort of formatting function
     // Currently we have to do it the ugly way because
     // we want every message to be printed atomically via a single call to
@@ -288,6 +295,7 @@ struct SimpleHashTableEntryBase {
     assert(Ptr - Buf < BufSize, "Buffer overflow!");
     // print everything all at once for atomicity
     __write(2, Buf, Ptr - Buf);
+#endif
   }
 };
 
@@ -601,6 +609,9 @@ int compareStr(const char *Str1, const char *Str2, int Size) {
 }
 
 /// Output Location to the fdata file
+#if defined(__ANDROID__)
+__attribute__((noinline))
+#endif
 char *serializeLoc(const ProfileWriterContext &Ctx, char *OutBuf,
                    const Location Loc, uint32_t BufSize) {
   // fdata location format: Type Name Offset
@@ -823,6 +834,7 @@ ProfileWriterContext readDescriptions() {
 #if !defined(__APPLE__)
 /// Debug by printing overall metadata global numbers to check it is sane
 void printStats(const ProfileWriterContext &Ctx) {
+#if !defined(__ANDROID__)
   char StatMsg[BufSize];
   char *StatPtr = StatMsg;
   StatPtr =
@@ -843,6 +855,7 @@ void printStats(const ProfileWriterContext &Ctx) {
   StatPtr = intToStr(StatPtr, __bolt_instr_num_funcs, 10);
   StatPtr = strCopy(StatPtr, "\n");
   __write(2, StatMsg, StatPtr - StatMsg);
+#endif
 }
 #endif
 


### PR DESCRIPTION
Disable all stderr diagnostic output on Android since there is typically
no terminal to read diagnostic message. The `noinline`annotation is to
keep same inline decision before and after this change. On AArch64
the `.text` section in instr runtime library is now ~4.8 KB smaller.