### PR TITLE
[BOLT][instr] Make instrumentation counter reset thread safe

### DIFF
--- a/bolt/runtime/instr.cpp
+++ b/bolt/runtime/instr.cpp
@@ -1516,10 +1516,18 @@ int openProfile() {
 /// Where 0xdeadbeef is this function address and PROCESSNAME your binary file
 /// name.
 extern "C" void __bolt_instr_clear_counters() {
-  memset(reinterpret_cast<char *>(__bolt_instr_locations), 0,
-         __bolt_num_counters * 8);
+  while (!GlobalWriteProfileMutex->acquire()) {
+  }
+
+  // Use atomic stores instead of memset to avoid torn writes that could be
+  // observed by other threads concurrently incrementing counters.
+  for (uint32_t I = 0; I < __bolt_num_counters; ++I)
+    __atomic_store_n(&__bolt_instr_locations[I], 0ULL, __ATOMIC_RELAXED);
+
   for (int I = 0; I < __bolt_instr_num_ind_calls; ++I)
     GlobalIndCallCounters[I].resetCounters();
+
+  GlobalWriteProfileMutex->release();
 }
 
 /// This is the entry point for profile writing.


### PR DESCRIPTION
Use `GlobalWriteProfileMutex` to synchronize between data reset and
dump. Between static counter reset and increment, we use atomic store
in counter reset - the counter increment sequence inserted within user
code already takes care of thread safety, so we just need to make sure
the counter reset code is also thread safe (no torn write to counter).