### PR TITLE
[BOLT][merge-fdata] Skip truncated lines in raw profile data

### DIFF
--- a/bolt/test/merge-fdata-bat-no-lbr.test
+++ b/bolt/test/merge-fdata-bat-no-lbr.test
@@ -8,13 +8,13 @@
 
 # CHECK: boltedcollection
 # CHECK: no_lbr
-# CHECK: 1 main 2
+# CHECK: 1 main 0 2
 
 #--- a.fdata
 boltedcollection
 no_lbr
-1 main 1
+1 main 0 1
 #--- b.fdata
 boltedcollection
 no_lbr
-1 main 1
+1 main 0 1

--- a/bolt/test/merge-fdata-mixed-bat-no-lbr.test
+++ b/bolt/test/merge-fdata-mixed-bat-no-lbr.test
@@ -10,7 +10,7 @@
 #--- a.fdata
 boltedcollection
 no_lbr
-1 main 1
+1 main 0 1
 #--- b.fdata
 no_lbr
-1 main 1
+1 main 0 1

--- a/bolt/test/merge-fdata-mixed-mode.test
+++ b/bolt/test/merge-fdata-mixed-mode.test
@@ -10,6 +10,6 @@
 
 #--- a.fdata
 no_lbr
-1 main 1
+1 main 0 1
 #--- b.fdata
-1 main 1
+1 main 0 1

--- a/bolt/test/merge-fdata-no-lbr-mode.test
+++ b/bolt/test/merge-fdata-no-lbr-mode.test
@@ -8,11 +8,11 @@
 # RUN: FileCheck %s --input-file %t/merged.fdata
 
 # CHECK: no_lbr
-# CHECK: 1 main 2
+# CHECK: 1 main 0 2
 
 #--- a.fdata
 no_lbr
-1 main 1
+1 main 0 1
 #--- b.fdata
 no_lbr
-1 main 1
+1 main 0 1

--- a/bolt/test/merge-fdata-skip-truncated.test
+++ b/bolt/test/merge-fdata-skip-truncated.test
@@ -1,0 +1,20 @@
+## Check that merge-fdata skips truncated lines with a warning
+
+# REQUIRES: system-linux
+
+# RUN: split-file %s %t
+# RUN: merge-fdata %t/a.fdata %t/b.fdata -o %t/merged.fdata 2>&1 | \
+# RUN:     FileCheck -check-prefix=CHECK-WARN %s
+# RUN: FileCheck %s --input-file %t/merged.fdata
+
+# CHECK-WARN: WARNING: {{.*}}b.fdata: ignoring malformed entry
+
+## Only the valid entry should appear in the merged output
+# CHECK: 1 main 0 1 main 2 1 3
+# CHECK-NOT: trunc
+
+#--- a.fdata
+1 main 0 1 main 2 0 1
+#--- b.fdata
+1 main 0 1 main 2 1 2
+1 trunc 0 1


### PR DESCRIPTION
Raw profile data file may contain lines truncated due to unexpected app exit.
This change is to have merge_fdata check number of fields in each line of raw
profile data file and ignore the line if the number is not expected.