### PR TITLE
[lldb] Disable shared build for TestHiddenIvars.py and TestObjCIvarStripped.py

### DIFF
--- a/lldb/test/API/lang/objc/hidden-ivars/TestHiddenIvars.py
+++ b/lldb/test/API/lang/objc/hidden-ivars/TestHiddenIvars.py
@@ -1,6 +1,5 @@
 """Test that hidden ivars in a shared library are visible from the main executable."""
 
-
 import subprocess
 
 import unittest
@@ -11,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class HiddenIvarsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/objc-ivar-stripped/TestObjCIvarStripped.py
+++ b/lldb/test/API/lang/objc/objc-ivar-stripped/TestObjCIvarStripped.py
@@ -1,6 +1,5 @@
 """Test printing ObjC objects that use unbacked properties - so that the static ivar offsets are incorrect."""
 
-
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -8,6 +7,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestObjCIvarStripped(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)


### PR DESCRIPTION
These tests sporadically fail on Green Dragon. My hypothesis is that one test is rebuilding while another is trying to load a dSYM leading to a mismatch.