### PR TITLE
Create and use unsanitized versions of cpp::vector load and store.

### DIFF
--- a/libc/src/__support/CPP/simd.h
+++ b/libc/src/__support/CPP/simd.h
@@ -302,6 +302,24 @@ LIBC_INLINE constexpr static void store(T v, void *ptr, bool aligned = false) {
     ptr = __builtin_assume_aligned(ptr, alignof(T));
   __builtin_memcpy_inline(ptr, &v, sizeof(T));
 }
+template <typename T>
+LIBC_NO_SANITIZE_OOB_ACCESS
+    LIBC_INLINE T constexpr static load_unsanitized(const void *ptr,
+                                                     bool aligned = false) {
+  if (aligned)
+    ptr = __builtin_assume_aligned(ptr, alignof(T));
+  T tmp;
+  __builtin_memcpy_inline(
+      &tmp, reinterpret_cast<const simd_element_type_t<T> *>(ptr), sizeof(T));
+  return tmp;
+}
+template <typename T, internal::enable_if_simd_t<T> = 0>
+LIBC_NO_SANITIZE_OOB_ACCESS LIBC_INLINE constexpr static void
+store_unsanitized(T v, void *ptr, bool aligned = false) {
+  if (aligned)
+    ptr = __builtin_assume_aligned(ptr, alignof(T));
+  __builtin_memcpy_inline(ptr, &v, sizeof(T));
+}
 template <typename T, internal::enable_if_simd_t<T> = 0>
 LIBC_INLINE constexpr static T
 load_masked(simd<bool, simd_size_v<T>> mask, const void *ptr,

--- a/libc/src/__support/CPP/simd.h
+++ b/libc/src/__support/CPP/simd.h
@@ -303,9 +303,8 @@ LIBC_INLINE constexpr static void store(T v, void *ptr, bool aligned = false) {
   __builtin_memcpy_inline(ptr, &v, sizeof(T));
 }
 template <typename T>
-LIBC_NO_SANITIZE_OOB_ACCESS
-    LIBC_INLINE T constexpr static load_unsanitized(const void *ptr,
-                                                     bool aligned = false) {
+LIBC_NO_SANITIZE_OOB_ACCESS LIBC_INLINE
+    T constexpr static load_unsanitized(const void *ptr, bool aligned = false) {
   if (aligned)
     ptr = __builtin_assume_aligned(ptr, alignof(T));
   T tmp;

--- a/libc/src/string/memory_utils/generic/inline_strlen.h
+++ b/libc/src/string/memory_utils/generic/inline_strlen.h
@@ -32,15 +32,17 @@ LIBC_NO_SANITIZE_OOB_ACCESS LIBC_INLINE size_t string_length(const char *src) {
   const cpp::simd<char> *aligned = reinterpret_cast<const cpp::simd<char> *>(
       __builtin_align_down(src, alignment));
 
-  cpp::simd<char> chars = cpp::load<cpp::simd<char>>(aligned, /*aligned=*/true);
+  cpp::simd<char> chars =
+      cpp::load_unsanitized<cpp::simd<char>>(aligned, /*aligned=*/true);
   cpp::simd_mask<char> mask = chars == null_byte;
   size_t offset = src - reinterpret_cast<const char *>(aligned);
   if (cpp::any_of(shift_mask<char>(mask, offset)))
     return cpp::find_first_set(shift_mask<char>(mask, offset));
 
   for (;;) {
-    cpp::simd<char> chars = cpp::load<cpp::simd<char>>(++aligned,
-                                                       /*aligned=*/true);
+    cpp::simd<char> chars =
+        cpp::load_unsanitized<cpp::simd<char>>(++aligned,
+                                               /*aligned=*/true);
     cpp::simd_mask<char> mask = chars == null_byte;
     if (cpp::any_of(mask))
       return (reinterpret_cast<const char *>(aligned) - src) +
@@ -66,7 +68,7 @@ find_first_character(const unsigned char *s, unsigned char c, size_t n) {
   const Vector *aligned =
       reinterpret_cast<const Vector *>(__builtin_align_down(s, alignment));
 
-  Vector chars = cpp::load<Vector>(aligned, /*aligned=*/true);
+  Vector chars = cpp::load_unsanitized<Vector>(aligned, /*aligned=*/true);
   Mask cmp_v = chars == c_byte;
   size_t offset = s - reinterpret_cast<const unsigned char *>(aligned);
 
@@ -78,7 +80,7 @@ find_first_character(const unsigned char *s, unsigned char c, size_t n) {
   for (size_t bytes_checked = sizeof(Vector) - offset; bytes_checked < n;
        bytes_checked += sizeof(Vector)) {
     aligned++;
-    Vector chars = cpp::load<Vector>(aligned, /*aligned=*/true);
+    Vector chars = cpp::load_unsanitized<Vector>(aligned, /*aligned=*/true);
     Mask cmp_v = chars == c_byte;
     if (cpp::any_of(cmp_v))
       return calculate_find_first_character_return(


### PR DESCRIPTION
The plain load and store versions result in asan errors when called from places that read carefully read before or after the buffer like string_length or find_first_character.

These parent functions are properly marked that they may read out of bounds, but the load and store functions they call may also do so.

Although it is a little distasteful to have copies of the functions, as far as I know, one can't instantiate a template varying on a clang attribute. So a copy it is.

Happy to take another solution, if that is better.