### PR TITLE
[CIR] Update cir::ResumeOp to require an EH token

### DIFF
--- a/clang/docs/ClangIRCleanupAndEHDesign.md
+++ b/clang/docs/ClangIRCleanupAndEHDesign.md
@@ -333,7 +333,7 @@ cir.func @_ZN7DerivedC2Ev(%arg0: !cir.ptr<!rec_Derived>) {
   } cleanup eh {
     %3 = cir.base_class_addr %1 : !cir.ptr<!rec_Derived> nonnull [0] -> !cir.ptr<!rec_Base>
     cir.call @_ZN4BaseD2Ev(%3) : (!cir.ptr<!rec_Base>) -> ()
-    cir.resume
+    cir.yield
   }
   cir.return
 }
@@ -385,7 +385,7 @@ cir.try {
   }
   cir.yield
 } unwind (%eh_token : !cir.eh_token) {
-  cir.resume
+  cir.resume %eh_token : !cir.eh_token
 }
 ```
 
@@ -429,7 +429,7 @@ cir.func @someFunc(){
       }
       cir.yield
     } unwind (%eh_token : !cir.eh_token) {
-      cir.resume
+      cir.resume %eh_token : !cir.eh_token
     }
   }
   cir.return
@@ -596,7 +596,7 @@ cir.func @someFunc(){
         }
         cir.yield
       } unwind (%eh_token : !cir.eh_token) {
-        cir.resume
+        cir.resume %eh_token : !cir.eh_token
       }
     }
     cir.yield
@@ -939,7 +939,7 @@ cir.func @someFunc(){
   %2 = cir.begin_cleanup(%eh_token : !cir.eh_token) : !cir.cleanup_token
   cir.call @_ZN9SomeClassD1Ev(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
   cir.end_cleanup(%2 : !cir.cleanup_token)
-  cir.resume // Unwind to caller
+  cir.resume %eh_token : !cir.eh_token // Unwind to caller
 ^bb4 // Normal continue (from ^bb1)
   cir.return
 }

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1029,10 +1029,10 @@ def CIR_ResumeOp : CIR_Op<"resume", [
     The `cir.resume` operation handles an uncaught exception scenario.
 
     Before CFG flattening, this operation is used as the terminator of a
-    `CatchUnwind` region of `cir.try`, where it does not receive any arguments
-    (implied from the `cir.try` scope).
+    `CatchUnwind` region of `cir.try`, where it receives an `!cir.eh_token`
+    argument representing the in-flight exception.
 
-    During CFG flattening, this operartion may appear within a `cir.try`
+    During CFG flattening, this operation may appear within a `cir.try`
     operation where it indicates that exception unwinding should continue
     from that point. When the `cir.try` operation is flattened, the resume
     operation will be replaced with a branch to the flattened try operation's
@@ -1047,8 +1047,8 @@ def CIR_ResumeOp : CIR_Op<"resume", [
     // Before CFG flattening (in try unwind region)
     cir.try {
       cir.yield
-    } unwind {
-      cir.resume
+    } unwind (%eh_token : !cir.eh_token) {
+      cir.resume %eh_token : !cir.eh_token
     }
 
     // After CFG flattening (at function level, after cleanup)
@@ -1056,11 +1056,12 @@ def CIR_ResumeOp : CIR_Op<"resume", [
       %ct = cir.begin_cleanup %eh_token : !cir.eh_token -> !cir.cleanup_token
       cir.call @destructor() : () -> ()
       cir.end_cleanup %ct : !cir.cleanup_token
-      cir.resume
+      cir.resume %eh_token : !cir.eh_token
     ```
   }];
 
-  let assemblyFormat = "attr-dict";
+  let arguments = (ins CIR_EhTokenType:$eh_token);
+  let assemblyFormat = "$eh_token `:` type($eh_token) attr-dict";
   let hasLLVMLowering = false;
 }
 
@@ -6287,7 +6288,7 @@ def CIR_TryOp : CIR_Op<"try",[
       }
       cir.yield
     } unwind (%eh_token : !cir.eh_token) {
-      cir.resume
+      cir.resume %eh_token : !cir.eh_token
     }
     ```
   }];

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1021,7 +1021,8 @@ def CIR_ContinueOp : CIR_Op<"continue", [Terminator]> {
 //===----------------------------------------------------------------------===//
 
 def CIR_ResumeOp : CIR_Op<"resume", [
-  ReturnLike, Terminator,
+  DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>,
+  Terminator,
   ParentOneOf<["cir::TryOp", "cir::CleanupScopeOp", "cir::FuncOp"]>
 ]> {
   let summary = "Resumes execution after not catching exceptions";

--- a/clang/lib/CIR/CodeGen/CIRGenException.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenException.cpp
@@ -344,8 +344,9 @@ mlir::LogicalResult CIRGenFunction::emitCXXTryStmt(const CXXTryStmt &s) {
         if (!hasCatchAll) {
           // Create unwind region.
           mlir::Region *region = result.addRegion();
-          builder.createBlock(region, /*insertPt=*/{}, {ehTokenTy}, {loc});
-          cir::ResumeOp::create(builder, loc);
+          mlir::Block *unwindBlock =
+              builder.createBlock(region, /*insertPt=*/{}, {ehTokenTy}, {loc});
+          cir::ResumeOp::create(builder, loc, unwindBlock->getArgument(0));
           handlerAttrs.push_back(cir::UnwindAttr::get(&getMLIRContext()));
         }
       });

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -339,6 +339,12 @@ cir::ConditionOp::getMutableSuccessorOperands(RegionSuccessor point) {
   return MutableOperandRange(getOperation(), 0, 0);
 }
 
+MutableOperandRange
+cir::ResumeOp::getMutableSuccessorOperands(RegionSuccessor point) {
+  // The eh_token operand is not forwarded to the parent region.
+  return MutableOperandRange(getOperation(), 0, 0);
+}
+
 LogicalResult cir::ConditionOp::verify() {
   if (!isa<LoopOpInterface, AwaitOp>(getOperation()->getParentOp()))
     return emitOpError("condition must be within a conditional region");

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -979,7 +979,7 @@ public:
   //     %ct = cir.begin_cleanup %eh_token : !cir.eh_token -> !cir.cleanup_token
   //     <cloned cleanup operations>
   //     cir.end_cleanup %ct : !cir.cleanup_token
-  //     cir.resume
+  //     cir.resume %eh_token : !cir.eh_token
   //
   // For a multi-block cleanup region (e.g. containing a flattened cir.if),
   // the same wrapping is applied around the cloned block structure: the entry
@@ -1024,7 +1024,7 @@ public:
     if (yieldOp) {
       rewriter.setInsertionPoint(yieldOp);
       cir::EndCleanupOp::create(rewriter, loc, beginCleanup.getCleanupToken());
-      rewriter.replaceOpWithNewOp<cir::ResumeOp>(yieldOp);
+      rewriter.replaceOpWithNewOp<cir::ResumeOp>(yieldOp, ehToken);
     } else {
       cleanupOp->emitError("Not yet implemented: cleanup region terminated "
                            "with non-yield operation");

--- a/clang/test/CIR/CodeGen/try-catch-tmp.cpp
+++ b/clang/test/CIR/CodeGen/try-catch-tmp.cpp
@@ -78,7 +78,7 @@ void call_function_inside_try_catch_with_exception_type() {
 // CIR:     }
 // CIR:     cir.yield
 // CIR:   } unwind (%{{.*}}: !cir.eh_token{{.*}}) {
-// CIR:     cir.resume
+// CIR:     cir.resume %{{.*}} : !cir.eh_token
 // CIR:   }
 // CIR: }
 
@@ -144,7 +144,7 @@ void call_function_inside_try_catch_with_complex_exception_type() {
 // CIR:     }
 // CIR:     cir.yield
 // CIR:   } unwind (%{{.*}}: !cir.eh_token{{.*}}) {
-// CIR:     cir.resume
+// CIR:     cir.resume %{{.*}} : !cir.eh_token
 // CIR:   }
 // CIR: }
 
@@ -215,7 +215,7 @@ void call_function_inside_try_catch_with_array_exception_type() {
 // CIR:     }
 // CIR:     cir.yield
 // CIR:   } unwind (%{{.*}}: !cir.eh_token{{.*}}) {
-// CIR:     cir.resume
+// CIR:     cir.resume %{{.*}} : !cir.eh_token
 // CIR:   }
 // CIR: }
 

--- a/clang/test/CIR/IR/invalid-eh-flat.cir
+++ b/clang/test/CIR/IR/invalid-eh-flat.cir
@@ -49,7 +49,7 @@ cir.func @eh_dispatch_catch_all_and_unwind(%eh_token: !cir.eh_token) {
 ^bb3:
   cir.return
 ^bb4:
-  cir.resume
+  cir.resume %eh_token : !cir.eh_token
 }
 
 }
@@ -78,7 +78,7 @@ cir.func @eh_dispatch_unwind_and_catch_all(%eh_token: !cir.eh_token) {
 ^bb2:
   cir.return
 ^bb3:
-  cir.resume
+  cir.resume %eh_token : !cir.eh_token
 ^bb4:
   cir.return
 }
@@ -109,9 +109,9 @@ cir.func @eh_dispatch_duplicate_unwind(%eh_token: !cir.eh_token) {
 ^bb2:
   cir.return
 ^bb3:
-  cir.resume
+  cir.resume %eh_token : !cir.eh_token
 ^bb4:
-  cir.resume
+  cir.resume %eh_token : !cir.eh_token
 }
 
 }

--- a/clang/test/CIR/IR/invalid-try-catch.cir
+++ b/clang/test/CIR/IR/invalid-try-catch.cir
@@ -151,7 +151,7 @@ cir.func dso_local @catch_handler_missing_begin_catch() {
     } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] (%eh_token : !cir.eh_token) {
       cir.yield
     } unwind (%eh_token_1 : !cir.eh_token) {
-      cir.resume
+      cir.resume %eh_token_1 : !cir.eh_token
     }
   }
   cir.return

--- a/clang/test/CIR/IR/try-catch.cir
+++ b/clang/test/CIR/IR/try-catch.cir
@@ -130,7 +130,7 @@ cir.func @empty_try_block_with_catch_unwind_contains_resume() {
     cir.try {
       cir.yield
     } unwind (%eh_token : !cir.eh_token) {
-      cir.resume
+      cir.resume %eh_token : !cir.eh_token
     }
   }
   cir.return
@@ -140,8 +140,8 @@ cir.func @empty_try_block_with_catch_unwind_contains_resume() {
 // CHECK:   cir.scope {
 // CHECK:     cir.try {
 // CHECK:       cir.yield
-// CHECK:     } unwind (%{{.*}}: !cir.eh_token) {
-// CHECK:       cir.resume
+// CHECK:     } unwind (%[[ET:.*]]: !cir.eh_token) {
+// CHECK:       cir.resume %[[ET]] : !cir.eh_token
 // CHECK:     }
 // CHECK:   }
 // CHECK:   cir.return

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-eh.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-eh.cir
@@ -45,7 +45,7 @@ cir.func @test_eh_only_cleanup() {
 // CHECK:         %[[CT:.*]] = cir.begin_cleanup %[[ET]] : !cir.eh_token -> !cir.cleanup_token
 // CHECK:         cir.call @dtor(%[[ALLOCA]]) nothrow
 // CHECK:         cir.end_cleanup %[[CT]] : !cir.cleanup_token
-// CHECK:         cir.resume
+// CHECK:         cir.resume %[[ET]] : !cir.eh_token
 //
 // CHECK:       ^[[CONTINUE]]:
 // CHECK:         cir.return
@@ -93,7 +93,7 @@ cir.func @test_all_cleanup() {
 // CHECK:         %[[CT:.*]] = cir.begin_cleanup %[[ET]] : !cir.eh_token -> !cir.cleanup_token
 // CHECK:         cir.call @dtor(%[[ALLOCA]]) nothrow
 // CHECK:         cir.end_cleanup %[[CT]] : !cir.cleanup_token
-// CHECK:         cir.resume
+// CHECK:         cir.resume %[[ET]] : !cir.eh_token
 //
 // CHECK:       ^[[CONTINUE]]:
 // CHECK:         cir.return
@@ -140,7 +140,7 @@ cir.func @test_eh_cleanup_multiple_calls() {
 // CHECK:         %[[CT:.*]] = cir.begin_cleanup %[[ET]] : !cir.eh_token -> !cir.cleanup_token
 // CHECK:         cir.call @dtor(%[[ALLOCA]]) nothrow
 // CHECK:         cir.end_cleanup %[[CT]] : !cir.cleanup_token
-// CHECK:         cir.resume
+// CHECK:         cir.resume %[[ET]] : !cir.eh_token
 //
 // CHECK:       ^[[CONTINUE]]:
 // CHECK:         cir.return
@@ -182,7 +182,7 @@ cir.func @test_eh_cleanup_nothrow_call() {
 // CHECK:         %[[CT:.*]] = cir.begin_cleanup %[[ET]] : !cir.eh_token -> !cir.cleanup_token
 // CHECK:         cir.call @dtor(%[[ALLOCA]]) nothrow
 // CHECK:         cir.end_cleanup %[[CT]] : !cir.cleanup_token
-// CHECK:         cir.resume
+// CHECK:         cir.resume %[[ET]] : !cir.eh_token
 //
 // CHECK:       ^[[CONTINUE]]:
 // CHECK:         cir.return
@@ -225,7 +225,7 @@ cir.func @test_eh_cleanup_call_with_result() -> !s32i {
 // CHECK:         %{{.*}} = cir.begin_cleanup %[[ET]] : !cir.eh_token -> !cir.cleanup_token
 // CHECK:         cir.call @dtor(%[[ALLOCA_CLASS]]) nothrow
 // CHECK:         cir.end_cleanup
-// CHECK:         cir.resume
+// CHECK:         cir.resume %[[ET]] : !cir.eh_token
 //
 // CHECK:       ^[[CONTINUE]]:
 // CHECK:         %[[RETVAL:.*]] = cir.load %[[ALLOCA_RET]]
@@ -310,7 +310,7 @@ cir.func @test_nrvo() -> !rec_NonTrivial {
 // EH cleanup merge: end cleanup and resume unwinding.
 // CHECK:       ^[[EH_MERGE]]:
 // CHECK:         cir.end_cleanup %[[CT]] : !cir.cleanup_token
-// CHECK:         cir.resume
+// CHECK:         cir.resume %[[ET]] : !cir.eh_token
 //
 // CHECK:       ^[[CONTINUE]]:
 // CHECK:         %[[RET:.*]] = cir.load %[[RETVAL]]
@@ -363,7 +363,7 @@ cir.func @test_eh_cleanup_in_try() {
 // CHECK:   %[[CT:.*]] = cir.begin_cleanup %[[ET]] : !cir.eh_token -> !cir.cleanup_token
 // CHECK:   cir.call @dtor(%[[C]]) nothrow
 // CHECK:   cir.end_cleanup %[[CT]] : !cir.cleanup_token
-// CHECK:   cir.resume
+// CHECK:   cir.resume %[[ET]] : !cir.eh_token
 //
 // Try exit: branches to continue.
 // CHECK: ^[[TRY_EXIT]]:

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
@@ -99,7 +99,7 @@ cir.func @test_eh_cleanup_in_try_catch_unwind() {
     }
     cir.yield
   } unwind (%eh_token_1 : !cir.eh_token) {
-    cir.resume
+    cir.resume %eh_token_1 : !cir.eh_token
   }
   cir.return
 }


### PR DESCRIPTION
This updates the cir::ResumeOp operation to require an EH token operand. We already had the token available at both locations where the operation was being created. Adding this operand makes finding the token more robust during CFG flattening.

This change was entirely AI generated, but I have reviewed it closely.