### PR TITLE
[flang] Don't unparse 1X or X format as X

### DIFF
--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -1514,9 +1514,7 @@ public:
       Walk(x.count);
       break;
     case format::ControlEditDesc::Kind::X:
-      if (x.count != 1) {
-        Walk(x.count);
-      }
+      Walk(x.count);
       Word("X");
       break;
     case format::ControlEditDesc::Kind::Slash:

--- a/flang/test/Parser/bug2280.f90
+++ b/flang/test/Parser/bug2280.f90
@@ -1,0 +1,6 @@
+!RUN: %flang -fc1 -fdebug-unparse %s | FileCheck %s
+!CHECK: 1 FORMAT(1X)
+1 format(1x)
+!CHECK: 2 FORMAT(1X)
+2 format(x)
+end


### PR DESCRIPTION
The unparsing code emits a bare X control edit descriptor when its repetition count is 1, since a bare X control edit descriptor defaults to 1X. But it's not conforming usage, so it might cause a warning if unparsed code is recompiled with -pedantic.  So don't do that.