### PR TITLE
[lldb] Fix crash in ObjectFileWasm when using a VirtualDataExtractor

### DIFF
--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -157,8 +157,11 @@ ObjectFile *ObjectFileWasm::CreateInstance(const ModuleSP &module_sp,
     data_offset = 0;
   }
 
-  assert(extractor_sp);
-  if (!ValidateModuleHeader(extractor_sp->GetData())) {
+  // If this is operating on a VirtualDataExtractor, it can have gaps between
+  // valid bytes in the DataBuffer, so only get the contiguous part.
+  assert(extractor_sp && extractor_sp->GetContiguousDataExtractorSP());
+  if (!ValidateModuleHeader(
+          extractor_sp->GetContiguousDataExtractorSP()->GetData())) {
     LLDB_LOGF(log,
               "Failed to create ObjectFileWasm instance: invalid Wasm header");
     return nullptr;


### PR DESCRIPTION
When ObjectFileWasm is passed a VirtualDataExtractor, it can have gaps between valid bytes in the DataBuffer. When we pass it to ValidateModuleHeader, we convert it to an ArrayRef (and later a StringRef) which crashes when we're trying to read across those gaps.

rdar://171106338