### PR TITLE
[flang-rt] Handle NAMELIST logical comments without preceding space

### DIFF
--- a/flang-rt/lib/runtime/edit-input.cpp
+++ b/flang-rt/lib/runtime/edit-input.cpp
@@ -970,6 +970,11 @@ RT_API_ATTRS bool EditLogicalInput(
     // not list-directed.
     char32_t comma{edit.modes.GetSeparatorChar()};
     while (next && *next != comma) {
+      if (*next == '!') {
+        if (!io.AdvanceRecord()) { // skip namelist comment
+          return false;
+        }
+      }
       next = io.NextInField(remaining, edit);
     }
   }


### PR DESCRIPTION
If a comment appears immediately after a logical value in a NAMELIST file, the flang runtime returns IostatGenericError.  No error occurs when a space preceeds the exclamation point.  Add code to handle a comment while parsing logical values.

Co-authored-by: John Otken john.otken@hpe.com