### PR TITLE
[SelectionDAG] Use virtual registers instead of arbitrary physical registers in unit tests. NFC

### DIFF
--- a/llvm/unittests/CodeGen/SelectionDAGNodeConstructionTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGNodeConstructionTest.cpp
@@ -16,7 +16,8 @@ TEST_F(SelectionDAGNodeConstructionTest, ADD) {
   SDLoc DL;
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
 
   EXPECT_EQ(DAG->getNode(ISD::ADD, DL, MVT::i32, Op, Poison), Poison);
   EXPECT_EQ(DAG->getNode(ISD::ADD, DL, MVT::i32, Poison, Op), Poison);
@@ -30,7 +31,8 @@ TEST_F(SelectionDAGNodeConstructionTest, ADD) {
 
 TEST_F(SelectionDAGNodeConstructionTest, AND) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
@@ -47,7 +49,8 @@ TEST_F(SelectionDAGNodeConstructionTest, AND) {
 
 TEST_F(SelectionDAGNodeConstructionTest, MUL) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
@@ -64,7 +67,8 @@ TEST_F(SelectionDAGNodeConstructionTest, MUL) {
 
 TEST_F(SelectionDAGNodeConstructionTest, OR) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue AllOnes = DAG->getAllOnesConstant(DL, MVT::i32);
@@ -81,7 +85,8 @@ TEST_F(SelectionDAGNodeConstructionTest, OR) {
 
 TEST_F(SelectionDAGNodeConstructionTest, SADDSAT) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue AllOnes = DAG->getAllOnesConstant(DL, MVT::i32);
@@ -98,7 +103,8 @@ TEST_F(SelectionDAGNodeConstructionTest, SADDSAT) {
 
 TEST_F(SelectionDAGNodeConstructionTest, SDIV) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
@@ -115,7 +121,8 @@ TEST_F(SelectionDAGNodeConstructionTest, SDIV) {
 
 TEST_F(SelectionDAGNodeConstructionTest, SMAX) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue MaxInt = DAG->getConstant(APInt::getSignedMaxValue(32), DL, MVT::i32);
@@ -132,7 +139,8 @@ TEST_F(SelectionDAGNodeConstructionTest, SMAX) {
 
 TEST_F(SelectionDAGNodeConstructionTest, SMIN) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue MinInt = DAG->getConstant(APInt::getSignedMinValue(32), DL, MVT::i32);
@@ -149,7 +157,8 @@ TEST_F(SelectionDAGNodeConstructionTest, SMIN) {
 
 TEST_F(SelectionDAGNodeConstructionTest, SREM) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
@@ -166,7 +175,8 @@ TEST_F(SelectionDAGNodeConstructionTest, SREM) {
 
 TEST_F(SelectionDAGNodeConstructionTest, SSUBSAT) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
@@ -183,7 +193,8 @@ TEST_F(SelectionDAGNodeConstructionTest, SSUBSAT) {
 
 TEST_F(SelectionDAGNodeConstructionTest, SUB) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
 
@@ -199,7 +210,8 @@ TEST_F(SelectionDAGNodeConstructionTest, SUB) {
 
 TEST_F(SelectionDAGNodeConstructionTest, UADDSAT) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue AllOnes = DAG->getAllOnesConstant(DL, MVT::i32);
@@ -216,7 +228,8 @@ TEST_F(SelectionDAGNodeConstructionTest, UADDSAT) {
 
 TEST_F(SelectionDAGNodeConstructionTest, UDIV) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
@@ -233,7 +246,8 @@ TEST_F(SelectionDAGNodeConstructionTest, UDIV) {
 
 TEST_F(SelectionDAGNodeConstructionTest, UMAX) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue AllOnes = DAG->getAllOnesConstant(DL, MVT::i32);
@@ -250,7 +264,8 @@ TEST_F(SelectionDAGNodeConstructionTest, UMAX) {
 
 TEST_F(SelectionDAGNodeConstructionTest, UMIN) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
@@ -267,7 +282,8 @@ TEST_F(SelectionDAGNodeConstructionTest, UMIN) {
 
 TEST_F(SelectionDAGNodeConstructionTest, UREM) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
@@ -284,7 +300,8 @@ TEST_F(SelectionDAGNodeConstructionTest, UREM) {
 
 TEST_F(SelectionDAGNodeConstructionTest, USUBSAT) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
@@ -301,7 +318,8 @@ TEST_F(SelectionDAGNodeConstructionTest, USUBSAT) {
 
 TEST_F(SelectionDAGNodeConstructionTest, XOR) {
   SDLoc DL;
-  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i32);
+  SDValue Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), MVT::i32);
   SDValue Poison = DAG->getPOISON(MVT::i32);
   SDValue Undef = DAG->getUNDEF(MVT::i32);
   SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
@@ -334,7 +352,8 @@ TEST_F(SelectionDAGNodeConstructionTest, CTLS) {
   EXPECT_TRUE(isa<ConstantSDNode>(CtlsMinShort) &&
               cast<ConstantSDNode>(CtlsMinShort)->getZExtValue() == 16);
 
-  SDValue i1Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, MVT::i1);
+  SDValue i1Op = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                     Register::index2VirtReg(1), MVT::i1);
   SDValue Ctlsi1 = DAG->getNode(ISD::CTLS, DL, MVT::i32, i1Op);
   EXPECT_TRUE(isNullConstant(Ctlsi1));
 }

--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -21,9 +21,12 @@ TEST_F(SelectionDAGPatternMatchTest, matchValueType) {
   auto Float32VT = EVT::getFloatingPointVT(32);
   auto VInt32VT = EVT::getVectorVT(Context, Int32VT, 4);
 
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Float32VT);
-  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, VInt32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Int32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Float32VT);
+  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(3), VInt32VT);
 
   using namespace SDPatternMatch;
   EXPECT_TRUE(sd_match(Op0, m_SpecificVT(Int32VT)));
@@ -52,8 +55,10 @@ TEST_F(SelectionDAGPatternMatchTest, matchVecShuffle) {
   const std::array<int, 4> OtherMaskData = {1, 2, 3, 4};
   ArrayRef<int> Mask;
 
-  SDValue V0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, VInt32VT);
-  SDValue V1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, VInt32VT);
+  SDValue V0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(1), VInt32VT);
+  SDValue V1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(2), VInt32VT);
   SDValue VecShuffleWithMask =
       DAG->getVectorShuffle(VInt32VT, DL, V0, V1, MaskData);
 
@@ -75,8 +80,10 @@ TEST_F(SelectionDAGPatternMatchTest, matchTernaryOp) {
   SDLoc DL;
   auto Int32VT = EVT::getIntegerVT(Context, 32);
 
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Int32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Int32VT);
   SDValue Op3 = DAG->getConstant(1, DL, Int32VT);
 
   SDValue ICMP_UGT = DAG->getSetCC(DL, MVT::i1, Op0, Op1, ISD::SETUGT);
@@ -84,18 +91,24 @@ TEST_F(SelectionDAGPatternMatchTest, matchTernaryOp) {
   SDValue ICMP_EQ10 = DAG->getSetCC(DL, MVT::i1, Op1, Op0, ISD::SETEQ);
 
   auto Int1VT = EVT::getIntegerVT(Context, 1);
-  SDValue Cond = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, Int1VT);
-  SDValue T = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 4, Int1VT);
-  SDValue F = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 5, Int1VT);
+  SDValue Cond = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                     Register::index2VirtReg(3), Int1VT);
+  SDValue T = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                  Register::index2VirtReg(4), Int1VT);
+  SDValue F = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                  Register::index2VirtReg(5), Int1VT);
   SDValue Select = DAG->getSelect(DL, MVT::i1, Cond, T, F);
 
   auto VInt32VT = EVT::getVectorVT(Context, Int32VT, 4);
   auto SmallVInt32VT = EVT::getVectorVT(Context, Int32VT, 2);
   auto Idx0 = DAG->getVectorIdxConstant(0, DL);
   auto Idx3 = DAG->getVectorIdxConstant(3, DL);
-  SDValue V1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 6, VInt32VT);
-  SDValue V2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 7, VInt32VT);
-  SDValue V3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 8, SmallVInt32VT);
+  SDValue V1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(6), VInt32VT);
+  SDValue V2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(7), VInt32VT);
+  SDValue V3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(8), SmallVInt32VT);
   SDValue VSelect = DAG->getNode(ISD::VSELECT, DL, VInt32VT, Cond, V1, V2);
   SDValue InsertSubvector =
       DAG->getNode(ISD::INSERT_SUBVECTOR, DL, VInt32VT, V2, V3, Idx0);
@@ -177,17 +190,22 @@ TEST_F(SelectionDAGPatternMatchTest, matchBinaryOp) {
   auto BigVInt32VT = EVT::getVectorVT(Context, Int32VT, 8);
   auto VInt32VT = EVT::getVectorVT(Context, Int32VT, 4);
 
-  SDValue V1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 6, VInt32VT);
+  SDValue V1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(6), VInt32VT);
   auto Idx0 = DAG->getVectorIdxConstant(0, DL);
   auto Idx1 = DAG->getVectorIdxConstant(1, DL);
 
   SDValue SignBit = DAG->getConstant(0x80000000u, DL, Int32VT);
   SDValue NoSignBit = DAG->getConstant(0x7fffffffu, DL, Int32VT);
 
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int32VT);
-  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, Float32VT);
-  SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 8, Int32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Int32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Int32VT);
+  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(3), Float32VT);
+  SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(8), Int32VT);
   SDValue Op4 = DAG->getConstant(1, DL, Int32VT);
 
   SDValue NonNeg0 = DAG->getNode(ISD::AND, DL, Int32VT, Op0, NoSignBit);
@@ -288,7 +306,8 @@ TEST_F(SelectionDAGPatternMatchTest, matchBinaryOp) {
   SDValue SFAdd = DAG->getNode(ISD::STRICT_FADD, DL, {Float32VT, MVT::Other},
                                {DAG->getEntryNode(), Op2, Op2});
 
-  SDValue Vec = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 9, BigVInt32VT);
+  SDValue Vec = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(9), BigVInt32VT);
   SDValue SubVec =
       DAG->getNode(ISD::EXTRACT_SUBVECTOR, DL, VInt32VT, Vec, Idx0);
 
@@ -502,8 +521,10 @@ TEST_F(SelectionDAGPatternMatchTest, matchSpecificFpOp) {
   SDLoc DL;
   APFloat Value(1.5f);
   auto Float32VT = EVT::getFloatingPointVT(32);
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Float32VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Float32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Float32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Float32VT);
   SDValue Op2 = DAG->getConstantFP(Value, DL, Float32VT);
   SDValue FAdd0 = DAG->getNode(ISD::FADD, DL, Float32VT, Op0, Op1);
   SDValue FAdd1 = DAG->getNode(ISD::FADD, DL, Float32VT, Op1, Op2);
@@ -542,9 +563,12 @@ TEST_F(SelectionDAGPatternMatchTest, matchGenericTernaryOp) {
   SDLoc DL;
   auto Float32VT = EVT::getFloatingPointVT(32);
 
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Float32VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Float32VT);
-  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, Float32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Float32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Float32VT);
+  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(3), Float32VT);
 
   SDValue FMA = DAG->getNode(ISD::FMA, DL, Float32VT, Op0, Op1, Op2);
   SDValue FAdd = DAG->getNode(ISD::FADD, DL, Float32VT, Op0, Op1);
@@ -614,10 +638,14 @@ TEST_F(SelectionDAGPatternMatchTest, matchUnaryOp) {
   auto Int64VT = EVT::getIntegerVT(Context, 64);
   auto FloatVT = EVT::getFloatingPointVT(32);
 
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int64VT);
-  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, FloatVT);
-  SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, Int32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Int32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Int64VT);
+  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(3), FloatVT);
+  SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(4), Int32VT);
 
   SDValue ZExt = DAG->getNode(ISD::ZERO_EXTEND, DL, Int64VT, Op0);
   SDValue ZExtNNeg =
@@ -771,7 +799,8 @@ TEST_F(SelectionDAGPatternMatchTest, matchConstants) {
   auto Int32VT = EVT::getIntegerVT(Context, 32);
   auto VInt32VT = EVT::getVectorVT(Context, Int32VT, 4);
 
-  SDValue Arg0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
+  SDValue Arg0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                     Register::index2VirtReg(1), Int32VT);
 
   SDValue Const3 = DAG->getConstant(3, DL, Int32VT);
   SDValue Const87 = DAG->getConstant(87, DL, Int32VT);
@@ -856,8 +885,10 @@ TEST_F(SelectionDAGPatternMatchTest, patternCombinators) {
   SDLoc DL;
   auto Int32VT = EVT::getIntegerVT(Context, 32);
 
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Int32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Int32VT);
 
   SDValue Add = DAG->getNode(ISD::ADD, DL, Int32VT, Op0, Op1);
   SDValue Sub = DAG->getNode(ISD::SUB, DL, Int32VT, Add, Op0);
@@ -874,8 +905,10 @@ TEST_F(SelectionDAGPatternMatchTest, optionalResizing) {
   auto Int32VT = EVT::getIntegerVT(Context, 32);
   auto Int64VT = EVT::getIntegerVT(Context, 64);
 
-  SDValue Op32 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue Op64 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int64VT);
+  SDValue Op32 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                     Register::index2VirtReg(1), Int32VT);
+  SDValue Op64 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                     Register::index2VirtReg(2), Int64VT);
   SDValue ZExt = DAG->getNode(ISD::ZERO_EXTEND, DL, Int64VT, Op32);
   SDValue SExt = DAG->getNode(ISD::SIGN_EXTEND, DL, Int64VT, Op32);
   SDValue AExt = DAG->getNode(ISD::ANY_EXTEND, DL, Int64VT, Op32);
@@ -907,8 +940,10 @@ TEST_F(SelectionDAGPatternMatchTest, matchNode) {
   SDLoc DL;
   auto Int32VT = EVT::getIntegerVT(Context, 32);
 
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Int32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Int32VT);
 
   SDValue Add = DAG->getNode(ISD::ADD, DL, Int32VT, Op0, Op1);
 
@@ -926,13 +961,19 @@ TEST_F(SelectionDAGPatternMatchTest, matchSelectLike) {
   auto Int32VT = EVT::getIntegerVT(Context, 32);
   auto VInt32VT = EVT::getVectorVT(Context, Int32VT, 4);
 
-  SDValue Cond = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 0, Int32VT);
-  SDValue TVal = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue FVal = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int32VT);
+  SDValue Cond = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                     Register::index2VirtReg(0), Int32VT);
+  SDValue TVal = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                     Register::index2VirtReg(1), Int32VT);
+  SDValue FVal = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                     Register::index2VirtReg(2), Int32VT);
 
-  SDValue VCond = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 0, VInt32VT);
-  SDValue VTVal = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, VInt32VT);
-  SDValue VFVal = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, VInt32VT);
+  SDValue VCond = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                      Register::index2VirtReg(4), VInt32VT);
+  SDValue VTVal = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                      Register::index2VirtReg(5), VInt32VT);
+  SDValue VFVal = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                      Register::index2VirtReg(6), VInt32VT);
 
   SDValue Select = DAG->getNode(ISD::SELECT, DL, Int32VT, Cond, TVal, FVal);
   SDValue VSelect =
@@ -955,11 +996,16 @@ TEST_F(SelectionDAGPatternMatchTest, matchIntrinsicWOChain) {
       DAG->getConstant(Intrinsic::wasm_bitmask, DL, Int32VT);
   SDValue X86Aadd32IntrinsicId =
       DAG->getConstant(Intrinsic::x86_aadd32, DL, Int32VT);
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 0, Int32VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int32VT);
-  SDValue PtrOp = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, Int64VT);
-  SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 4, Int32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(0), Int32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Int32VT);
+  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Int32VT);
+  SDValue PtrOp = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                      Register::index2VirtReg(3), Int64VT);
+  SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(4), Int32VT);
 
   SDValue WasmBitmask = DAG->getNode(ISD::INTRINSIC_WO_CHAIN, DL, Int32VT,
                                      WasmBitmaskIntrinsicId, Op0);
@@ -1012,9 +1058,12 @@ TEST_F(SelectionDAGPatternMatchTest, matchContext) {
   auto VInt32VT = EVT::getVectorVT(Context, Int32VT, 4);
   auto MaskVT = EVT::getVectorVT(Context, BoolVT, 4);
 
-  SDValue Scalar0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue Vector0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, VInt32VT);
-  SDValue Mask0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, MaskVT);
+  SDValue Scalar0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                        Register::index2VirtReg(1), Int32VT);
+  SDValue Vector0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                        Register::index2VirtReg(2), VInt32VT);
+  SDValue Mask0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                      Register::index2VirtReg(3), MaskVT);
 
   SDValue VPAdd = DAG->getNode(ISD::VP_ADD, DL, VInt32VT,
                                {Vector0, Vector0, Mask0, Scalar0});
@@ -1057,9 +1106,12 @@ TEST_F(SelectionDAGPatternMatchTest, matchVPWithBasicContext) {
   auto VInt32VT = EVT::getVectorVT(Context, Int32VT, 4);
   auto MaskVT = EVT::getVectorVT(Context, BoolVT, 4);
 
-  SDValue Vector0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, VInt32VT);
-  SDValue Mask = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, MaskVT);
-  SDValue EL = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, Int32VT);
+  SDValue Vector0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                        Register::index2VirtReg(1), VInt32VT);
+  SDValue Mask = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                     Register::index2VirtReg(2), MaskVT);
+  SDValue EL = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                   Register::index2VirtReg(3), Int32VT);
 
   SDValue VPAdd =
       DAG->getNode(ISD::VP_ADD, DL, VInt32VT, Vector0, Vector0, Mask, EL);
@@ -1075,8 +1127,10 @@ TEST_F(SelectionDAGPatternMatchTest, matchAdvancedProperties) {
   auto Int16VT = EVT::getIntegerVT(Context, 16);
   auto Int64VT = EVT::getIntegerVT(Context, 64);
 
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int64VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int16VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Int64VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Int16VT);
 
   SDValue Add = DAG->getNode(ISD::ADD, DL, Int64VT, Op0, Op0);
 
@@ -1093,10 +1147,14 @@ TEST_F(SelectionDAGPatternMatchTest, matchReassociatableOp) {
   SDLoc DL;
   auto Int32VT = EVT::getIntegerVT(Context, 32);
 
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int32VT);
-  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, Int32VT);
-  SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 8, Int32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Int32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Int32VT);
+  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(3), Int32VT);
+  SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(8), Int32VT);
 
   // (Op0 + Op1) + (Op2 + Op3)
   SDValue ADD01 = DAG->getNode(ISD::ADD, DL, Int32VT, Op0, Op1);
@@ -1387,7 +1445,8 @@ TEST_F(SelectionDAGPatternMatchTest, MatchSpecificNeg) {
   auto Int32VT = EVT::getIntegerVT(Context, 32);
   auto VecVT = EVT::getVectorVT(Context, Int32VT, 4);
 
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Int32VT);
 
   using namespace SDPatternMatch;
 
@@ -1395,7 +1454,8 @@ TEST_F(SelectionDAGPatternMatchTest, MatchSpecificNeg) {
   EXPECT_TRUE(sd_match(Neg, m_SpecificNeg(Op0)));
   EXPECT_TRUE(sd_match(Neg, m_Neg(m_Specific(Op0))));
 
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Int32VT);
   EXPECT_FALSE(sd_match(Neg, m_SpecificNeg(Op1)));
 
   SDValue Const5 = DAG->getConstant(5, DL, Int32VT);
@@ -1447,9 +1507,12 @@ TEST_F(SelectionDAGPatternMatchTest, matchReassociatableFlags) {
   SDLoc DL;
   auto Int32VT = EVT::getIntegerVT(Context, 32);
 
-  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
-  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int32VT);
-  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, Int32VT);
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(1), Int32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(2), Int32VT);
+  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(3), Int32VT);
 
   SDNodeFlags NSWFlags;
   NSWFlags.setNoSignedWrap(true);
@@ -1458,17 +1521,23 @@ TEST_F(SelectionDAGPatternMatchTest, matchReassociatableFlags) {
   SDValue Add0 = DAG->getNode(ISD::ADD, DL, Int32VT, Op0, Op1, NSWFlags);
   SDValue Add1 = DAG->getNode(ISD::ADD, DL, Int32VT, Add0, Op2, NSWFlags);
 
-  SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 4, Int32VT);
-  SDValue Op4 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 5, Int32VT);
-  SDValue Op5 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 6, Int32VT);
+  SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(4), Int32VT);
+  SDValue Op4 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(5), Int32VT);
+  SDValue Op5 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(6), Int32VT);
 
   // (Op3 + Op4) +nsw Op5
   SDValue Add2 = DAG->getNode(ISD::ADD, DL, Int32VT, Op3, Op4);
   SDValue Add3 = DAG->getNode(ISD::ADD, DL, Int32VT, Add2, Op5, NSWFlags);
 
-  SDValue Op6 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 7, Int32VT);
-  SDValue Op7 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 8, Int32VT);
-  SDValue Op8 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 9, Int32VT);
+  SDValue Op6 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(7), Int32VT);
+  SDValue Op7 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(8), Int32VT);
+  SDValue Op8 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(9), Int32VT);
 
   SDNodeFlags NUWFlags;
   NUWFlags.setNoUnsignedWrap(true);
@@ -1482,9 +1551,12 @@ TEST_F(SelectionDAGPatternMatchTest, matchReassociatableFlags) {
   BothFlags.setNoSignedWrap(true);
   BothFlags.setNoUnsignedWrap(true);
 
-  SDValue Op9 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 10, Int32VT);
-  SDValue Op10 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 11, Int32VT);
-  SDValue Op11 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 12, Int32VT);
+  SDValue Op9 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                    Register::index2VirtReg(10), Int32VT);
+  SDValue Op10 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                     Register::index2VirtReg(11), Int32VT);
+  SDValue Op11 = DAG->getCopyFromReg(DAG->getEntryNode(), DL,
+                                     Register::index2VirtReg(12), Int32VT);
 
   SDValue Add6 = DAG->getNode(ISD::ADD, DL, Int32VT, Op9, Op10, BothFlags);
   SDValue Add7 = DAG->getNode(ISD::ADD, DL, Int32VT, Add6, Op11, BothFlags);

--- a/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
@@ -921,7 +921,8 @@ TEST_F(AArch64SelectionDAGTest, KnownToBeAPowerOfTwo_Select) {
   auto Cst4 = DAG->getConstant(4, Loc, MVT::i32);
   auto CstBig = DAG->getConstant(2 << 17, Loc, MVT::i32);
 
-  auto Cond = DAG->getCopyFromReg(DAG->getEntryNode(), Loc, 1, MVT::i1);
+  auto Cond = DAG->getCopyFromReg(DAG->getEntryNode(), Loc,
+                                  Register::index2VirtReg(1), MVT::i1);
   auto Select40 = DAG->getNode(ISD::SELECT, Loc, MVT::i32, Cond, Cst4, Cst0);
   auto Select43 = DAG->getNode(ISD::SELECT, Loc, MVT::i32, Cond, Cst4, Cst3);
   auto Select4Big =
@@ -938,7 +939,8 @@ TEST_F(AArch64SelectionDAGTest, KnownToBeAPowerOfTwo_Select) {
   auto Vec4Big = DAG->getBuildVector(VecVT, Loc, {Cst4, CstBig});
   auto Vec0Big = DAG->getBuildVector(VecVT, Loc, {Cst0, CstBig});
 
-  auto VecCond = DAG->getCopyFromReg(DAG->getEntryNode(), Loc, 2, MVT::v2i1);
+  auto VecCond = DAG->getCopyFromReg(DAG->getEntryNode(), Loc,
+                                     Register::index2VirtReg(2), MVT::v2i1);
   auto VSelect0444 =
       DAG->getNode(ISD::VSELECT, Loc, VecVT, VecCond, Vec04, Vec44);
   auto VSelect4444 =
@@ -1478,7 +1480,8 @@ TEST_F(AArch64SelectionDAGTest, KnownNeverZero_Select) {
   auto Cst4 = DAG->getConstant(4, Loc, MVT::i32);
   auto CstBig = DAG->getConstant(2 << 17, Loc, MVT::i32);
 
-  auto Cond = DAG->getCopyFromReg(DAG->getEntryNode(), Loc, 1, MVT::i1);
+  auto Cond = DAG->getCopyFromReg(DAG->getEntryNode(), Loc,
+                                  Register::index2VirtReg(1), MVT::i1);
   auto Select40 = DAG->getNode(ISD::SELECT, Loc, MVT::i32, Cond, Cst4, Cst0);
   auto Select43 = DAG->getNode(ISD::SELECT, Loc, MVT::i32, Cond, Cst4, Cst3);
   auto Select4Big =
@@ -1495,7 +1498,8 @@ TEST_F(AArch64SelectionDAGTest, KnownNeverZero_Select) {
   auto Vec4Big = DAG->getBuildVector(VecVT, Loc, {Cst4, CstBig});
   auto Vec0Big = DAG->getBuildVector(VecVT, Loc, {Cst0, CstBig});
 
-  auto VecCond = DAG->getCopyFromReg(DAG->getEntryNode(), Loc, 2, MVT::v2i1);
+  auto VecCond = DAG->getCopyFromReg(DAG->getEntryNode(), Loc,
+                                     Register::index2VirtReg(2), MVT::v2i1);
   auto VSelect0444 =
       DAG->getNode(ISD::VSELECT, Loc, VecVT, VecCond, Vec04, Vec44);
   auto VSelect4444 =

--- a/llvm/unittests/Target/X86/X86SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/X86/X86SelectionDAGTest.cpp
@@ -79,13 +79,15 @@ protected:
 TEST_F(X86SelectionDAGTest, computeKnownBits_FAND) {
   SDLoc Loc;
 
-  auto SrcF32 = DAG->getCopyFromReg(DAG->getEntryNode(), Loc, 1, MVT::f32);
+  auto SrcF32 = DAG->getCopyFromReg(DAG->getEntryNode(), Loc,
+                                    Register::index2VirtReg(1), MVT::f32);
   auto ZeroF32 = DAG->getConstantFP(+0.0, Loc, MVT::f32);
   auto OpF32 = DAG->getNode(X86ISD::FAND, Loc, MVT::f32, ZeroF32, SrcF32);
   KnownBits KnownF32 = DAG->computeKnownBits(OpF32);
   EXPECT_TRUE(KnownF32.isZero());
 
-  auto Src2xF64 = DAG->getCopyFromReg(DAG->getEntryNode(), Loc, 1, MVT::v2f64);
+  auto Src2xF64 = DAG->getCopyFromReg(DAG->getEntryNode(), Loc,
+                                      Register::index2VirtReg(2), MVT::v2f64);
   auto ZeroF64 = DAG->getConstantFP(+0.0, Loc, MVT::f64);
   auto SignBitF64 = DAG->getConstantFP(-0.0, Loc, MVT::f64);
   auto LoZeroHiSign2xF64 =
@@ -103,13 +105,15 @@ TEST_F(X86SelectionDAGTest, computeKnownBits_FAND) {
 TEST_F(X86SelectionDAGTest, computeKnownBits_FANDN) {
   SDLoc Loc;
 
-  auto SrcF32 = DAG->getCopyFromReg(DAG->getEntryNode(), Loc, 1, MVT::f32);
+  auto SrcF32 = DAG->getCopyFromReg(DAG->getEntryNode(), Loc,
+                                    Register::index2VirtReg(1), MVT::f32);
   auto SignBitF32 = DAG->getConstantFP(-0.0f, Loc, MVT::f32);
   auto OpF32 = DAG->getNode(X86ISD::FANDN, Loc, MVT::f32, SignBitF32, SrcF32);
   KnownBits KnownF32 = DAG->computeKnownBits(OpF32);
   EXPECT_TRUE(KnownF32.isNonNegative());
 
-  auto Src2xF64 = DAG->getCopyFromReg(DAG->getEntryNode(), Loc, 1, MVT::v2f64);
+  auto Src2xF64 = DAG->getCopyFromReg(DAG->getEntryNode(), Loc,
+                                      Register::index2VirtReg(2), MVT::v2f64);
   auto ZeroF64 = DAG->getConstantFP(+0.0f, Loc, MVT::f64);
   auto SignBitF64 = DAG->getConstantFP(-0.0f, Loc, MVT::f64);
   auto HiSign2xF64 =


### PR DESCRIPTION
These tests use constants in the physical register space. These will correspond to different registers on different targets and aren't stable.

Using virtual registers makes more sense here. This will print in a coherent way if anyone were to dump the DAG created by these tests.