### PR TITLE
[NFC] Pass `DataLayout` to aggregate constant factory call sites

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1087,7 +1087,8 @@ static llvm::Constant *constStructWithPadding(CodeGenModule &CGM,
   }
   if (NestedIntact && Values.size() == STy->getNumElements())
     return constant;
-  return llvm::ConstantStruct::getAnon(Values, STy->isPacked());
+  return llvm::ConstantStruct::getAnon(Values, STy->isPacked(),
+                                       &CGM.getDataLayout());
 }
 
 /// Replace all padding bytes in a given constant with either a pattern byte or
@@ -1120,7 +1121,7 @@ static llvm::Constant *constWithPadding(CodeGenModule &CGM, IsPattern isPattern,
     if (NewElemTy == ElemTy)
       return constant;
     auto *NewArrayTy = llvm::ArrayType::get(NewElemTy, Size);
-    return llvm::ConstantArray::get(NewArrayTy, Values);
+    return llvm::ConstantArray::get(NewArrayTy, Values, &CGM.getDataLayout());
   }
   // FIXME: Add handling for tail padding in vectors. Vectors don't
   // have padding between or inside elements, but the total amount of
@@ -1335,11 +1336,13 @@ static llvm::Constant *replaceUndef(CodeGenModule &CGM, IsPattern isPattern,
     Values[Op] = replaceUndef(CGM, isPattern, OpValue);
   }
   if (Ty->isStructTy())
-    return llvm::ConstantStruct::get(cast<llvm::StructType>(Ty), Values);
+    return llvm::ConstantStruct::get(cast<llvm::StructType>(Ty), Values,
+                                     &CGM.getDataLayout());
   if (Ty->isArrayTy())
-    return llvm::ConstantArray::get(cast<llvm::ArrayType>(Ty), Values);
+    return llvm::ConstantArray::get(cast<llvm::ArrayType>(Ty), Values,
+                                    &CGM.getDataLayout());
   assert(Ty->isVectorTy());
-  return llvm::ConstantVector::get(Values);
+  return llvm::ConstantVector::get(Values, &CGM.getDataLayout());
 }
 
 /// EmitAutoVarDecl - Emit code and set up an entry in LocalDeclMap for a

--- a/clang/lib/CodeGen/CGException.cpp
+++ b/clang/lib/CodeGen/CGException.cpp
@@ -942,7 +942,8 @@ llvm::BasicBlock *CodeGenFunction::EmitLandingPad() {
 
     for (llvm::Value *filterType : filterTypes)
       Filters.push_back(cast<llvm::Constant>(filterType));
-    llvm::Constant *FilterArray = llvm::ConstantArray::get(AType, Filters);
+    llvm::Constant *FilterArray =
+        llvm::ConstantArray::get(AType, Filters, &CGM.getDataLayout());
     LPadInst->addClause(FilterArray);
 
     // Also check whether we need a cleanup.

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -2346,7 +2346,7 @@ LValue CodeGenFunction::EmitMatrixElementExpr(const MatrixElementExpr *E) {
 
   for (unsigned Index : Indices)
     CElts.push_back(BaseElts->getAggregateElement(Index));
-  llvm::Constant *CV = llvm::ConstantVector::get(CElts);
+  llvm::Constant *CV = llvm::ConstantVector::get(CElts, &CGM.getDataLayout());
   return LValue::MakeExtVectorElt(
       MaybeConvertMatrixAddress(Base.getExtVectorAddress(), *this), CV,
       ResultType, Base.getBaseInfo(), TBAAAccessInfo());
@@ -3918,7 +3918,8 @@ llvm::Constant *CodeGenFunction::EmitCheckTypeDescriptor(QualType T) {
     Builder.getInt16(TypeKind), Builder.getInt16(TypeInfo),
     llvm::ConstantDataArray::getString(getLLVMContext(), Buffer)
   };
-  llvm::Constant *Descriptor = llvm::ConstantStruct::getAnon(Components);
+  llvm::Constant *Descriptor =
+      llvm::ConstantStruct::getAnon(Components, false, &CGM.getDataLayout());
 
   auto *GV = new llvm::GlobalVariable(
       CGM.getModule(), Descriptor->getType(),
@@ -4018,7 +4019,7 @@ llvm::Constant *CodeGenFunction::EmitCheckSourceLocation(SourceLocation Loc) {
   llvm::Constant *Data[] = {Filename, Builder.getInt32(Line),
                             Builder.getInt32(Column)};
 
-  return llvm::ConstantStruct::getAnon(Data);
+  return llvm::ConstantStruct::getAnon(Data, false, &CGM.getDataLayout());
 }
 
 namespace {
@@ -4207,7 +4208,8 @@ void CodeGenFunction::EmitCheck(
 
   // Emit handler arguments and create handler function type.
   if (!StaticArgs.empty()) {
-    llvm::Constant *Info = llvm::ConstantStruct::getAnon(StaticArgs);
+    llvm::Constant *Info =
+        llvm::ConstantStruct::getAnon(StaticArgs, false, &CGM.getDataLayout());
     auto *InfoPtr = new llvm::GlobalVariable(
         CGM.getModule(), Info->getType(),
         // Non-constant global is used in a handler to deduplicate reports.
@@ -4272,7 +4274,8 @@ void CodeGenFunction::EmitCfiSlowPathCheck(
   llvm::CallInst *CheckCall;
   llvm::FunctionCallee SlowPathFn;
   if (WithDiag) {
-    llvm::Constant *Info = llvm::ConstantStruct::getAnon(StaticArgs);
+    llvm::Constant *Info =
+        llvm::ConstantStruct::getAnon(StaticArgs, false, &CGM.getDataLayout());
     auto *InfoPtr =
         new llvm::GlobalVariable(CGM.getModule(), Info->getType(), false,
                                  llvm::GlobalVariable::PrivateLinkage, Info);
@@ -5432,7 +5435,8 @@ EmitExtVectorElementExpr(const ExtVectorElementExpr *E) {
         MatIndices.push_back(llvm::ConstantInt::get(Int32Ty, Linear));
       }
 
-      llvm::Constant *ConstIdxs = llvm::ConstantVector::get(MatIndices);
+      llvm::Constant *ConstIdxs =
+          llvm::ConstantVector::get(MatIndices, &CGM.getDataLayout());
       return LValue::MakeExtVectorElt(Base.getMatrixAddress(), ConstIdxs,
                                       E->getBase()->getType(),
                                       Base.getBaseInfo(), TBAAAccessInfo());
@@ -5455,7 +5459,7 @@ EmitExtVectorElementExpr(const ExtVectorElementExpr *E) {
 
   for (unsigned Index : Indices)
     CElts.push_back(BaseElts->getAggregateElement(Index));
-  llvm::Constant *CV = llvm::ConstantVector::get(CElts);
+  llvm::Constant *CV = llvm::ConstantVector::get(CElts, &CGM.getDataLayout());
   return LValue::MakeExtVectorElt(Base.getExtVectorAddress(), CV, type,
                                   Base.getBaseInfo(), TBAAAccessInfo());
 }

--- a/clang/lib/CodeGen/CGExprConstant.cpp
+++ b/clang/lib/CodeGen/CGExprConstant.cpp
@@ -521,7 +521,8 @@ llvm::Constant *ConstantAggregateBuilder::buildFrom(
       STy = DesiredSTy;
   }
 
-  return llvm::ConstantStruct::get(STy, Packed ? PackedElems : UnpackedElems);
+  return llvm::ConstantStruct::get(STy, Packed ? PackedElems : UnpackedElems,
+                                   &CGM.getDataLayout());
 }
 
 void ConstantAggregateBuilder::condense(CharUnits Offset,
@@ -549,7 +550,8 @@ void ConstantAggregateBuilder::condense(CharUnits Offset,
     auto *STy = dyn_cast<llvm::StructType>(DesiredTy);
     if (STy && STy->getNumElements() == 1 &&
         STy->getElementType(0) == Elems[First]->getType())
-      Elems[First] = llvm::ConstantStruct::get(STy, Elems[First]);
+      Elems[First] =
+          llvm::ConstantStruct::get(STy, Elems[First], &CGM.getDataLayout());
     return;
   }
 
@@ -1106,7 +1108,7 @@ EmitArrayConstant(CodeGenModule &CGM, llvm::ArrayType *DesiredType,
     if (CommonElementType && NonzeroLength >= 8) {
       llvm::Constant *Initial = llvm::ConstantArray::get(
           llvm::ArrayType::get(CommonElementType, NonzeroLength),
-          ArrayRef(Elements).take_front(NonzeroLength));
+          ArrayRef(Elements).take_front(NonzeroLength), &CGM.getDataLayout());
       Elements.resize(2);
       Elements[0] = Initial;
     } else {
@@ -1128,7 +1130,8 @@ EmitArrayConstant(CodeGenModule &CGM, llvm::ArrayType *DesiredType,
   // If all elements have the same type, just emit an array constant.
   if (CommonElementType)
     return llvm::ConstantArray::get(
-        llvm::ArrayType::get(CommonElementType, ArrayBound), Elements);
+        llvm::ArrayType::get(CommonElementType, ArrayBound), Elements,
+        &CGM.getDataLayout());
 
   // We have mixed types. Use a packed struct.
   llvm::SmallVector<llvm::Type *, 16> Types;
@@ -1137,7 +1140,7 @@ EmitArrayConstant(CodeGenModule &CGM, llvm::ArrayType *DesiredType,
     Types.push_back(Elt->getType());
   llvm::StructType *SType =
       llvm::StructType::get(CGM.getLLVMContext(), Types, true);
-  return llvm::ConstantStruct::get(SType, Elements);
+  return llvm::ConstantStruct::get(SType, Elements, &CGM.getDataLayout());
 }
 
 // This class only needs to handle arrays, structs and unions. Outside C++11
@@ -1247,7 +1250,7 @@ public:
       }
 
       llvm::StructType *STy = llvm::StructType::get(VMContext, Types, false);
-      return llvm::ConstantStruct::get(STy, Elts);
+      return llvm::ConstantStruct::get(STy, Elts, &CGM.getDataLayout());
     }
 
     case CK_AddressSpaceConversion: {
@@ -2015,7 +2018,7 @@ llvm::Constant *ConstantEmitter::emitForMemory(CodeGenModule &CGM,
       llvm::ConstantAggregateZero::get(
           llvm::ArrayType::get(CGM.Int8Ty, (outerSize - innerSize) / 8))
     };
-    return llvm::ConstantStruct::getAnon(elts);
+    return llvm::ConstantStruct::getAnon(elts, false, &CGM.getDataLayout());
   }
 
   // Zero-extend bool.
@@ -2505,7 +2508,7 @@ ConstantEmitter::tryEmitPrivate(const APValue &Value, QualType DestType,
     // FIXME: the target may want to specify that this is packed.
     llvm::StructType *STy =
         llvm::StructType::get(Complex[0]->getType(), Complex[1]->getType());
-    return llvm::ConstantStruct::get(STy, Complex);
+    return llvm::ConstantStruct::get(STy, Complex, &CGM.getDataLayout());
   }
   case APValue::Float: {
     const llvm::APFloat &Init = Value.getFloat();
@@ -2528,7 +2531,7 @@ ConstantEmitter::tryEmitPrivate(const APValue &Value, QualType DestType,
     // FIXME: the target may want to specify that this is packed.
     llvm::StructType *STy =
         llvm::StructType::get(Complex[0]->getType(), Complex[1]->getType());
-    return llvm::ConstantStruct::get(STy, Complex);
+    return llvm::ConstantStruct::get(STy, Complex, &CGM.getDataLayout());
   }
   case APValue::Vector: {
     unsigned NumElts = Value.getVectorLength();
@@ -2546,7 +2549,7 @@ ConstantEmitter::tryEmitPrivate(const APValue &Value, QualType DestType,
       else
         llvm_unreachable("unsupported vector element type");
     }
-    return llvm::ConstantVector::get(Inits);
+    return llvm::ConstantVector::get(Inits, &CGM.getDataLayout());
   }
   case APValue::AddrLabelDiff: {
     const AddrLabelExpr *LHSExpr = Value.getAddrLabelDiffLHS();
@@ -2739,7 +2742,7 @@ static llvm::Constant *EmitNullConstant(CodeGenModule &CGM,
       elements[i] = llvm::Constant::getNullValue(structure->getElementType(i));
   }
 
-  return llvm::ConstantStruct::get(structure, elements);
+  return llvm::ConstantStruct::get(structure, elements, &CGM.getDataLayout());
 }
 
 /// Emit the null constant for a base subobject.
@@ -2779,7 +2782,7 @@ llvm::Constant *CodeGenModule::EmitNullConstant(QualType T) {
       ConstantEmitter::emitNullForMemory(*this, ElementTy);
     unsigned NumElements = CAT->getZExtSize();
     SmallVector<llvm::Constant *, 8> Array(NumElements, Element);
-    return llvm::ConstantArray::get(ATy, Array);
+    return llvm::ConstantArray::get(ATy, Array, &getDataLayout());
   }
 
   if (const auto *RD = T->getAsRecordDecl())

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -62,7 +62,8 @@ static Value *handleHlslClip(const CallExpr *E, CodeGenFunction *CGF) {
 
   if (const auto *VecTy = E->getArg(0)->getType()->getAs<clang::VectorType>()) {
     FZeroConst = ConstantVector::getSplat(
-        ElementCount::getFixed(VecTy->getNumElements()), FZeroConst);
+        ElementCount::getFixed(VecTy->getNumElements()), FZeroConst,
+        &CGF->CGM.getDataLayout());
     auto *FCompInst = CGF->Builder.CreateFCmpOLT(Op0, FZeroConst);
     CMP = CGF->Builder.CreateIntrinsic(
         CGF->Builder.getInt1Ty(), CGF->CGM.getHLSLRuntime().getAnyIntrinsic(),
@@ -1016,7 +1017,7 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
                         ? ConstantVector::getSplat(
                               ElementCount::getFixed(
                                   cast<FixedVectorType>(Ty)->getNumElements()),
-                              ConstantFP::get(EltTy, 1.0))
+                              ConstantFP::get(EltTy, 1.0), &CGM.getDataLayout())
                         : ConstantFP::get(EltTy, 1.0);
     return Builder.CreateFDiv(One, Op0, "hlsl.rcp");
   }

--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -1358,8 +1358,8 @@ class CGObjCGNUstep2 : public CGObjCGNUstep {
   llvm::Constant *GenerateProtocolList(ArrayRef<llvm::Constant*> Protocols) {
     llvm::ArrayType *ProtocolArrayTy = llvm::ArrayType::get(ProtocolPtrTy,
         Protocols.size());
-    llvm::Constant * ProtocolArray = llvm::ConstantArray::get(ProtocolArrayTy,
-        Protocols);
+    llvm::Constant *ProtocolArray = llvm::ConstantArray::get(
+        ProtocolArrayTy, Protocols, &CGM.getDataLayout());
     ConstantInitBuilder builder(CGM);
     auto ProtocolBuilder = builder.beginStruct();
     ProtocolBuilder.addNullPointer(PtrTy);

--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -3233,7 +3233,8 @@ llvm::Constant *CGObjCCommonMac::EmitProtocolMethodTypes(
 
   llvm::ArrayType *AT =
       llvm::ArrayType::get(ObjCTypes.Int8PtrTy, MethodTypes.size());
-  llvm::Constant *Init = llvm::ConstantArray::get(AT, MethodTypes);
+  llvm::Constant *Init =
+      llvm::ConstantArray::get(AT, MethodTypes, &CGM.getDataLayout());
 
   StringRef Section;
   if (CGM.getTriple().isOSBinFormatMachO() && ObjCABI == 2)
@@ -6120,7 +6121,8 @@ void CGObjCNonFragileABIMac::AddModuleClassList(
     Symbols[i] = Container[i];
 
   llvm::Constant *Init = llvm::ConstantArray::get(
-      llvm::ArrayType::get(ObjCTypes.Int8PtrTy, Symbols.size()), Symbols);
+      llvm::ArrayType::get(ObjCTypes.Int8PtrTy, Symbols.size()), Symbols,
+      &CGM.getDataLayout());
 
   // Section name is obtained by calling GetSectionName, which returns
   // sections in the __DATA segment on MachO.

--- a/clang/lib/CodeGen/CGVTT.cpp
+++ b/clang/lib/CodeGen/CGVTT.cpp
@@ -99,7 +99,8 @@ CodeGenVTables::EmitVTTDefinition(llvm::GlobalVariable *VTT,
      VTTComponents.push_back(Init);
   }
 
-  llvm::Constant *Init = llvm::ConstantArray::get(ArrayType, VTTComponents);
+  llvm::Constant *Init =
+      llvm::ConstantArray::get(ArrayType, VTTComponents, &CGM.getDataLayout());
 
   VTT->setInitializer(Init);
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1082,7 +1082,8 @@ void CodeGenModule::Release() {
 
     auto *GV = new llvm::GlobalVariable(
         getModule(), ATy, false, llvm::GlobalValue::InternalLinkage,
-        llvm::ConstantArray::get(ATy, UsedArray), "__clang_gpu_used_external");
+        llvm::ConstantArray::get(ATy, UsedArray, &getDataLayout()),
+        "__clang_gpu_used_external");
     addCompilerUsedGlobal(GV);
   }
   if (LangOpts.HIP) {
@@ -3487,7 +3488,7 @@ static void emitUsed(CodeGenModule &CGM, StringRef Name,
 
   auto *GV = new llvm::GlobalVariable(
       CGM.getModule(), ATy, false, llvm::GlobalValue::AppendingLinkage,
-      llvm::ConstantArray::get(ATy, UsedArray), Name);
+      llvm::ConstantArray::get(ATy, UsedArray, &CGM.getDataLayout()), Name);
 
   GV->setSection("llvm.metadata");
 }
@@ -3804,8 +3805,9 @@ void CodeGenModule::EmitGlobalAnnotations() {
     return;
 
   // Create a new global variable for the ConstantStruct in the Module.
-  llvm::Constant *Array = llvm::ConstantArray::get(llvm::ArrayType::get(
-    Annotations[0]->getType(), Annotations.size()), Annotations);
+  llvm::Constant *Array = llvm::ConstantArray::get(
+      llvm::ArrayType::get(Annotations[0]->getType(), Annotations.size()),
+      Annotations, &getDataLayout());
   auto *gv = new llvm::GlobalVariable(getModule(), Array->getType(), false,
                                       llvm::GlobalValue::AppendingLinkage,
                                       Array, "llvm.global.annotations");
@@ -3866,7 +3868,8 @@ llvm::Constant *CodeGenModule::EmitAnnotationArgs(const AnnotateAttr *Attr) {
     return ConstEmiter.emitAbstract(CE->getBeginLoc(), CE->getAPValueResult(),
                                     CE->getType());
   });
-  auto *Struct = llvm::ConstantStruct::getAnon(LLVMArgs);
+  auto *Struct =
+      llvm::ConstantStruct::getAnon(LLVMArgs, false, &getDataLayout());
   auto *GV = new llvm::GlobalVariable(getModule(), Struct->getType(), true,
                                       llvm::GlobalValue::PrivateLinkage, Struct,
                                       ".args");
@@ -3899,7 +3902,7 @@ llvm::Constant *CodeGenModule::EmitAnnotateAttr(llvm::GlobalValue *GV,
   llvm::Constant *Fields[] = {
       GVInGlobalsAS, AnnoGV, UnitGV, LineNoCst, Args,
   };
-  return llvm::ConstantStruct::getAnon(Fields);
+  return llvm::ConstantStruct::getAnon(Fields, false, &getDataLayout());
 }
 
 void CodeGenModule::AddGlobalAnnotations(const ValueDecl *D,
@@ -4129,7 +4132,7 @@ ConstantAddress CodeGenModule::GetAddrOfMSGuidDecl(const MSGuidDecl *GD) {
         llvm::ConstantDataArray::getRaw(
             StringRef(reinterpret_cast<char *>(Parts.Part4And5), 8), 8,
             Int8Ty)};
-    Init = llvm::ConstantStruct::getAnon(Fields);
+    Init = llvm::ConstantStruct::getAnon(Fields, false, &getDataLayout());
   }
 
   auto *GV = new llvm::GlobalVariable(

--- a/clang/lib/CodeGen/ConstantInitBuilder.cpp
+++ b/clang/lib/CodeGen/ConstantInitBuilder.cpp
@@ -270,7 +270,8 @@ llvm::Constant *ConstantAggregateBuilderBase::finishArray(llvm::Type *eltTy) {
   auto elts = llvm::ArrayRef(buffer).slice(Begin);
   if (!eltTy) eltTy = elts[0]->getType();
   auto type = llvm::ArrayType::get(eltTy, elts.size());
-  auto constant = llvm::ConstantArray::get(type, elts);
+  auto constant =
+      llvm::ConstantArray::get(type, elts, &Builder.CGM.getDataLayout());
   buffer.erase(buffer.begin() + Begin, buffer.end());
   return constant;
 }
@@ -288,9 +289,11 @@ ConstantAggregateBuilderBase::finishStruct(llvm::StructType *ty) {
   llvm::Constant *constant;
   if (ty) {
     assert(ty->isPacked() == Packed);
-    constant = llvm::ConstantStruct::get(ty, elts);
+    constant =
+        llvm::ConstantStruct::get(ty, elts, &Builder.CGM.getDataLayout());
   } else {
-    constant = llvm::ConstantStruct::getAnon(elts, Packed);
+    constant = llvm::ConstantStruct::getAnon(elts, Packed,
+                                             &Builder.CGM.getDataLayout());
   }
 
   buffer.erase(buffer.begin() + Begin, buffer.end());

--- a/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -2549,8 +2549,8 @@ void CoverageMappingModuleGen::emitFunctionMappingRecord(
   llvm::Constant *FunctionRecordVals[] = {
       #include "llvm/ProfileData/InstrProfData.inc"
   };
-  auto *FuncRecordConstant =
-      llvm::ConstantStruct::get(FunctionRecordTy, ArrayRef(FunctionRecordVals));
+  auto *FuncRecordConstant = llvm::ConstantStruct::get(
+      FunctionRecordTy, ArrayRef(FunctionRecordVals), &CGM.getDataLayout());
 
   // Create the function record global.
   auto *FuncRecord = new llvm::GlobalVariable(
@@ -2643,14 +2643,15 @@ void CoverageMappingModuleGen::emit() {
 #define COVMAP_HEADER(Type, LLVMType, Name, Init) Init,
 #include "llvm/ProfileData/InstrProfData.inc"
   };
-  auto CovDataHeaderVal =
-      llvm::ConstantStruct::get(CovDataHeaderTy, ArrayRef(CovDataHeaderVals));
+  auto CovDataHeaderVal = llvm::ConstantStruct::get(
+      CovDataHeaderTy, ArrayRef(CovDataHeaderVals), &CGM.getDataLayout());
 
   // Create the coverage data record
   llvm::Type *CovDataTypes[] = {CovDataHeaderTy, FilenamesVal->getType()};
   auto CovDataTy = llvm::StructType::get(Ctx, ArrayRef(CovDataTypes));
   llvm::Constant *TUDataVals[] = {CovDataHeaderVal, FilenamesVal};
-  auto CovDataVal = llvm::ConstantStruct::get(CovDataTy, ArrayRef(TUDataVals));
+  auto CovDataVal = llvm::ConstantStruct::get(CovDataTy, ArrayRef(TUDataVals),
+                                              &CGM.getDataLayout());
   auto CovData = new llvm::GlobalVariable(
       CGM.getModule(), CovDataTy, true, llvm::GlobalValue::PrivateLinkage,
       CovDataVal, llvm::getCoverageMappingVarName());
@@ -2665,7 +2666,8 @@ void CoverageMappingModuleGen::emit() {
     auto AddrSpace = FunctionNames.front()->getType()->getPointerAddressSpace();
     auto NamesArrTy = llvm::ArrayType::get(
         llvm::PointerType::get(Ctx, AddrSpace), FunctionNames.size());
-    auto NamesArrVal = llvm::ConstantArray::get(NamesArrTy, FunctionNames);
+    auto NamesArrVal = llvm::ConstantArray::get(NamesArrTy, FunctionNames,
+                                                &CGM.getDataLayout());
     // This variable will *NOT* be emitted to the object file. It is used
     // to pass the list of names referenced to codegen.
     new llvm::GlobalVariable(CGM.getModule(), NamesArrTy, true,

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -1139,7 +1139,7 @@ ItaniumCXXABI::EmitNullMemberPointer(const MemberPointerType *MPT) {
 
   llvm::Constant *Zero = llvm::ConstantInt::get(CGM.PtrDiffTy, 0);
   llvm::Constant *Values[2] = { Zero, Zero };
-  return llvm::ConstantStruct::getAnon(Values);
+  return llvm::ConstantStruct::getAnon(Values, false, &CGM.getDataLayout());
 }
 
 llvm::Constant *
@@ -1239,7 +1239,7 @@ llvm::Constant *ItaniumCXXABI::BuildMemberPointer(const CXXMethodDecl *MD,
                                        ThisAdjustment.getQuantity());
   }
 
-  return llvm::ConstantStruct::getAnon(MemPtr);
+  return llvm::ConstantStruct::getAnon(MemPtr, false, &CGM.getDataLayout());
 }
 
 llvm::Constant *ItaniumCXXABI::EmitMemberPointer(const APValue &MP,
@@ -4335,7 +4335,8 @@ llvm::Constant *ItaniumRTTIBuilder::BuildTypeInfo(
     llvm_unreachable("HLSL doesn't support RTTI");
   }
 
-  GV->replaceInitializer(llvm::ConstantStruct::getAnon(Fields));
+  GV->replaceInitializer(
+      llvm::ConstantStruct::getAnon(Fields, false, &CGM.getDataLayout()));
 
   // Export the typeinfo in the same circumstances as the vtable is exported.
   auto GVDLLStorageClass = DLLStorageClass;

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -401,7 +401,8 @@ public:
       return nullptr;
 
     llvm::ArrayType *VDispMapTy = llvm::ArrayType::get(CGM.IntTy, Map.size());
-    llvm::Constant *Init = llvm::ConstantArray::get(VDispMapTy, Map);
+    llvm::Constant *Init =
+        llvm::ConstantArray::get(VDispMapTy, Map, &CGM.getDataLayout());
     llvm::GlobalValue::LinkageTypes Linkage =
         SrcRD->isExternallyVisible() && DstRD->isExternallyVisible()
             ? llvm::GlobalValue::LinkOnceODRLinkage
@@ -2894,7 +2895,8 @@ MicrosoftCXXABI::EmitNullMemberPointer(const MemberPointerType *MPT) {
   GetNullMemberPointerFields(MPT, fields);
   if (fields.size() == 1)
     return fields[0];
-  llvm::Constant *Res = llvm::ConstantStruct::getAnon(fields);
+  llvm::Constant *Res =
+      llvm::ConstantStruct::getAnon(fields, false, &CGM.getDataLayout());
   assert(Res->getType() == ConvertMemberPointerType(MPT));
   return Res;
 }
@@ -2930,7 +2932,7 @@ MicrosoftCXXABI::EmitFullMemberPointer(llvm::Constant *FirstField,
   if (inheritanceModelHasVBTableOffsetField(Inheritance))
     fields.push_back(llvm::ConstantInt::get(CGM.IntTy, VBTableIndex));
 
-  return llvm::ConstantStruct::getAnon(fields);
+  return llvm::ConstantStruct::getAnon(fields, false, &CGM.getDataLayout());
 }
 
 llvm::Constant *
@@ -3840,7 +3842,8 @@ llvm::GlobalVariable *MSRTTIBuilder::getClassHierarchyDescriptor() {
           Bases->getValueType(), Bases,
           llvm::ArrayRef<llvm::Value *>(GEPIndices))),
   };
-  CHD->setInitializer(llvm::ConstantStruct::get(Type, Fields));
+  CHD->setInitializer(
+      llvm::ConstantStruct::get(Type, Fields, &CGM.getDataLayout()));
   return CHD;
 }
 
@@ -3872,7 +3875,8 @@ MSRTTIBuilder::getBaseClassArray(SmallVectorImpl<MSRTTIClass> &Classes) {
     BaseClassArrayData.push_back(
         ABI.getImageRelativeConstant(getBaseClassDescriptor(Class)));
   BaseClassArrayData.push_back(llvm::Constant::getNullValue(PtrType));
-  BCA->setInitializer(llvm::ConstantArray::get(ArrType, BaseClassArrayData));
+  BCA->setInitializer(llvm::ConstantArray::get(ArrType, BaseClassArrayData,
+                                               &CGM.getDataLayout()));
   return BCA;
 }
 
@@ -3920,7 +3924,8 @@ MSRTTIBuilder::getBaseClassDescriptor(const MSRTTIClass &Class) {
       ABI.getImageRelativeConstant(
           MSRTTIBuilder(ABI, Class.RD).getClassHierarchyDescriptor()),
   };
-  BCD->setInitializer(llvm::ConstantStruct::get(Type, Fields));
+  BCD->setInitializer(
+      llvm::ConstantStruct::get(Type, Fields, &CGM.getDataLayout()));
   return BCD;
 }
 
@@ -3965,7 +3970,8 @@ MSRTTIBuilder::getCompleteObjectLocator(const VPtrInfo &Info) {
   llvm::ArrayRef<llvm::Constant *> FieldsRef(Fields);
   if (!ABI.isImageRelative())
     FieldsRef = FieldsRef.drop_back();
-  COL->setInitializer(llvm::ConstantStruct::get(Type, FieldsRef));
+  COL->setInitializer(
+      llvm::ConstantStruct::get(Type, FieldsRef, &CGM.getDataLayout()));
   if (COL->isWeakForLinker())
     COL->setComdat(CGM.getModule().getOrInsertComdat(COL->getName()));
   return COL;
@@ -4067,7 +4073,8 @@ llvm::Constant *MicrosoftCXXABI::getAddrOfRTTIDescriptor(QualType Type) {
   auto *Var = new llvm::GlobalVariable(
       CGM.getModule(), TypeDescriptorType, /*isConstant=*/false,
       getLinkageForRTTI(Type),
-      llvm::ConstantStruct::get(TypeDescriptorType, Fields),
+      llvm::ConstantStruct::get(TypeDescriptorType, Fields,
+                                &CGM.getDataLayout()),
       MangledName);
   if (Var->isWeakForLinker())
     Var->setComdat(CGM.getModule().getOrInsertComdat(Var->getName()));
@@ -4315,7 +4322,8 @@ llvm::Constant *MicrosoftCXXABI::getCatchableType(QualType T,
   llvm::StructType *CTType = getCatchableTypeType();
   auto *GV = new llvm::GlobalVariable(
       CGM.getModule(), CTType, /*isConstant=*/true, getLinkageForRTTI(T),
-      llvm::ConstantStruct::get(CTType, Fields), MangledName);
+      llvm::ConstantStruct::get(CTType, Fields, &CGM.getDataLayout()),
+      MangledName);
   GV->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
   GV->setSection(".xdata");
   if (GV->isWeakForLinker())
@@ -4422,8 +4430,8 @@ llvm::GlobalVariable *MicrosoftCXXABI::getCatchableTypeArray(QualType T) {
   llvm::Constant *Fields[] = {
       llvm::ConstantInt::get(CGM.IntTy, NumEntries), // NumEntries
       llvm::ConstantArray::get(
-          AT, llvm::ArrayRef(CatchableTypes.begin(),
-                             CatchableTypes.end())) // CatchableTypes
+          AT, llvm::ArrayRef(CatchableTypes.begin(), CatchableTypes.end()),
+          &CGM.getDataLayout()) // CatchableTypes
   };
   SmallString<256> MangledName;
   {
@@ -4432,7 +4440,8 @@ llvm::GlobalVariable *MicrosoftCXXABI::getCatchableTypeArray(QualType T) {
   }
   CTA = new llvm::GlobalVariable(
       CGM.getModule(), CTAType, /*isConstant=*/true, getLinkageForRTTI(T),
-      llvm::ConstantStruct::get(CTAType, Fields), MangledName);
+      llvm::ConstantStruct::get(CTAType, Fields, &CGM.getDataLayout()),
+      MangledName);
   CTA->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
   CTA->setSection(".xdata");
   if (CTA->isWeakForLinker())
@@ -4498,7 +4507,8 @@ llvm::GlobalVariable *MicrosoftCXXABI::getThrowInfo(QualType T) {
   };
   auto *GV = new llvm::GlobalVariable(
       CGM.getModule(), TIType, /*isConstant=*/true, getLinkageForRTTI(T),
-      llvm::ConstantStruct::get(TIType, Fields), MangledName.str());
+      llvm::ConstantStruct::get(TIType, Fields, &CGM.getDataLayout()),
+      MangledName.str());
   GV->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
   GV->setSection(".xdata");
   if (GV->isWeakForLinker())

--- a/clang/lib/CodeGen/PatternInit.cpp
+++ b/clang/lib/CodeGen/PatternInit.cpp
@@ -68,7 +68,7 @@ llvm::Constant *clang::CodeGen::initializationPatternFor(CodeGenModule &CGM,
     llvm::SmallVector<llvm::Constant *, 8> Element(
         ArrTy->getNumElements(),
         initializationPatternFor(CGM, ArrTy->getElementType()));
-    return llvm::ConstantArray::get(ArrTy, Element);
+    return llvm::ConstantArray::get(ArrTy, Element, &CGM.getDataLayout());
   }
 
   // Note: this doesn't touch struct padding. It will initialize as much union
@@ -81,5 +81,5 @@ llvm::Constant *clang::CodeGen::initializationPatternFor(CodeGenModule &CGM,
   llvm::SmallVector<llvm::Constant *, 8> Struct(StructTy->getNumElements());
   for (unsigned El = 0; El != Struct.size(); ++El)
     Struct[El] = initializationPatternFor(CGM, StructTy->getElementType(El));
-  return llvm::ConstantStruct::get(StructTy, Struct);
+  return llvm::ConstantStruct::get(StructTy, Struct, &CGM.getDataLayout());
 }

--- a/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
@@ -413,7 +413,7 @@ static llvm::VectorType *GetFloatNeonType(CodeGenFunction *CGF,
 
 Value *CodeGenFunction::EmitNeonSplat(Value *V, Constant *C,
                                       const ElementCount &Count) {
-  Value *SV = llvm::ConstantVector::getSplat(Count, C);
+  Value *SV = llvm::ConstantVector::getSplat(Count, C, &CGM.getDataLayout());
   return Builder.CreateShuffleVector(V, V, SV, "lane");
 }
 
@@ -3315,7 +3315,8 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
       // Extract the other lane.
       Ops[1] = Builder.CreateBitCast(Ops[1], Ty);
       int Lane = cast<ConstantInt>(Ops[2])->getZExtValue();
-      Value *SV = llvm::ConstantVector::get(ConstantInt::get(Int32Ty, 1-Lane));
+      Value *SV = llvm::ConstantVector::get(
+          {ConstantInt::get(Int32Ty, 1 - Lane)}, &CGM.getDataLayout());
       Ops[1] = Builder.CreateShuffleVector(Ops[1], Ops[1], SV);
       // Load the value as a one-element vector.
       Ty = llvm::FixedVectorType::get(VTy->getElementType(), 1);
@@ -3383,7 +3384,8 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
     // a one-element vector and avoid poor code for i64 in the backend.
     if (VTy->getElementType()->isIntegerTy(64)) {
       Ops[1] = Builder.CreateBitCast(Ops[1], Ty);
-      Value *SV = llvm::ConstantVector::get(cast<llvm::Constant>(Ops[2]));
+      Value *SV = llvm::ConstantVector::get({cast<llvm::Constant>(Ops[2])},
+                                            &CGM.getDataLayout());
       Ops[1] = Builder.CreateShuffleVector(Ops[1], Ops[1], SV);
       Ops[2] = getAlignmentValue32(PtrOp0);
       llvm::Type *Tys[] = {Int8PtrTy, Ops[1]->getType()};
@@ -6741,7 +6743,8 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
                                            VTy->getNumElements() * 2);
     Ops[2] = Builder.CreateBitCast(Ops[2], STy);
     Value *SV = llvm::ConstantVector::getSplat(VTy->getElementCount(),
-                                               cast<ConstantInt>(Ops[3]));
+                                               cast<ConstantInt>(Ops[3]),
+                                               &CGM.getDataLayout());
     Ops[2] = Builder.CreateShuffleVector(Ops[2], Ops[2], SV, "lane");
 
     return emitCallMaybeConstrainedFPBuiltin(
@@ -7961,7 +7964,7 @@ BuildVector(ArrayRef<llvm::Value*> Ops) {
     SmallVector<llvm::Constant*, 16> CstOps;
     for (llvm::Value *Op : Ops)
       CstOps.push_back(cast<Constant>(Op));
-    return llvm::ConstantVector::get(CstOps);
+    return llvm::ConstantVector::get(CstOps, &CGM.getDataLayout());
   }
 
   // Otherwise, insertelement the values to build the vector.

--- a/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
@@ -408,7 +408,7 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
     SmallVector<Constant *, 16> Consts;
     for (int Idx = 0; Idx < 16; Idx++)
       Consts.push_back(Builder.getInt8(NumBytes + Idx));
-    Value *Mask2 = ConstantVector::get(Consts);
+    Value *Mask2 = ConstantVector::get(Consts, &CGM.getDataLayout());
     return Builder.CreateBitCast(
         Builder.CreateCall(Vperm, {Zero, AllElts, Mask2}, "shuffle2"), ResTy);
   }

--- a/llvm/include/llvm/Transforms/Utils/Evaluator.h
+++ b/llvm/include/llvm/Transforms/Utils/Evaluator.h
@@ -60,10 +60,10 @@ class Evaluator {
       return cast<MutableAggregate *>(Val)->Ty;
     }
 
-    Constant *toConstant() const {
+    Constant *toConstant(const DataLayout &DL) const {
       if (auto *C = dyn_cast_if_present<Constant *>(Val))
         return C;
-      return cast<MutableAggregate *>(Val)->toConstant();
+      return cast<MutableAggregate *>(Val)->toConstant(DL);
     }
 
     Constant *read(Type *Ty, APInt Offset, const DataLayout &DL) const;
@@ -75,7 +75,7 @@ class Evaluator {
     SmallVector<MutableValue> Elements;
 
     MutableAggregate(Type *Ty) : Ty(Ty) {}
-    Constant *toConstant() const;
+    Constant *toConstant(const DataLayout &DL) const;
   };
 
 public:
@@ -102,7 +102,7 @@ public:
   DenseMap<GlobalVariable *, Constant *> getMutatedInitializers() const {
     DenseMap<GlobalVariable *, Constant *> Result;
     for (const auto &Pair : MutatedMemory)
-      Result[Pair.first] = Pair.second.toConstant();
+      Result[Pair.first] = Pair.second.toConstant(DL);
     return Result;
   }
 

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -155,7 +155,7 @@ Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
   if (!isa<VectorType>(C->getType()) &&
       (isa<ConstantFP>(C) || isa<ConstantInt>(C))) {
     Constant *Ops = C; // don't take the address of C!
-    return FoldBitCast(ConstantVector::get(Ops), DestTy, DL);
+    return FoldBitCast(ConstantVector::get(Ops, &DL), DestTy, DL);
   }
 
   // Some of what follows may extend to cover scalable vectors but the current
@@ -258,7 +258,7 @@ Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
       }
       Result.push_back(Elt);
     }
-    return ConstantVector::get(Result);
+    return ConstantVector::get(Result, &DL);
   }
 
   // Handle: bitcast (<2 x i64> <i64 0, i64 1> to <4 x i32>)
@@ -294,7 +294,7 @@ Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
     }
   }
 
-  return ConstantVector::get(Result);
+  return ConstantVector::get(Result, &DL);
 }
 
 } // end anonymous namespace
@@ -1128,7 +1128,7 @@ ConstantFoldConstantImpl(const Constant *C, const DataLayout &DL,
   }
 
   assert(isa<ConstantVector>(C));
-  return ConstantVector::get(Ops);
+  return ConstantVector::get(Ops, &DL);
 }
 
 } // end anonymous namespace
@@ -4147,7 +4147,7 @@ static Constant *ConstantFoldFixedVectorCall(
     }
     if (NewElements.size() != FVTy->getNumElements())
       return nullptr;
-    return ConstantVector::get(NewElements);
+    return ConstantVector::get(NewElements, &DL);
   }
   case Intrinsic::arm_mve_vctp8:
   case Intrinsic::arm_mve_vctp16:
@@ -4164,7 +4164,7 @@ static Constant *ConstantFoldFixedVectorCall(
         else
           NCs.push_back(ConstantInt::getFalse(Ty));
       }
-      return ConstantVector::get(NCs);
+      return ConstantVector::get(NCs, &DL);
     }
     return nullptr;
   }
@@ -4210,7 +4210,7 @@ static Constant *ConstantFoldFixedVectorCall(
       Result[I - StartingIndex] = Elt;
     }
 
-    return ConstantVector::get(Result);
+    return ConstantVector::get(Result, &DL);
   }
   case Intrinsic::vector_insert: {
     Constant *Vec = Operands[0];
@@ -4238,7 +4238,7 @@ static Constant *ConstantFoldFixedVectorCall(
         return nullptr;
       Result[I] = Elt;
     }
-    return ConstantVector::get(Result);
+    return ConstantVector::get(Result, &DL);
   }
   case Intrinsic::vector_interleave2:
   case Intrinsic::vector_interleave3:
@@ -4258,7 +4258,7 @@ static Constant *ConstantFoldFixedVectorCall(
         Result[NumOperands * I + J] = Elt;
       }
     }
-    return ConstantVector::get(Result);
+    return ConstantVector::get(Result, &DL);
   }
   case Intrinsic::wasm_dot: {
     unsigned NumElements =
@@ -4282,7 +4282,7 @@ static Constant *ConstantFoldFixedVectorCall(
       Result[I] = ConstantInt::getSigned(Ty, IAdd, /*ImplicitTrunc=*/true);
     }
 
-    return ConstantVector::get(Result);
+    return ConstantVector::get(Result, &DL);
   }
   default:
     break;
@@ -4312,7 +4312,7 @@ static Constant *ConstantFoldFixedVectorCall(
     Result[I] = Folded;
   }
 
-  return ConstantVector::get(Result);
+  return ConstantVector::get(Result, &DL);
 }
 
 static Constant *ConstantFoldScalableVectorCall(
@@ -4348,7 +4348,7 @@ static Constant *ConstantFoldScalableVectorCall(
     if (!llvm::all_equal(Operands))
       return nullptr;
 
-    return ConstantVector::getSplat(SVTy->getElementCount(), SplatVal);
+    return ConstantVector::getSplat(SVTy->getElementCount(), SplatVal, &DL);
   }
   default:
     break;
@@ -4376,7 +4376,7 @@ static Constant *ConstantFoldScalableVectorCall(
       Name, IntrinsicID, SVTy->getElementType(), SplatOps, TLI, Call);
   if (!Folded)
     return nullptr;
-  return ConstantVector::getSplat(SVTy->getElementCount(), Folded);
+  return ConstantVector::getSplat(SVTy->getElementCount(), Folded, &DL);
 }
 
 static std::pair<Constant *, Constant *>
@@ -4425,14 +4425,16 @@ ConstantFoldStructCall(StringRef Name, Intrinsic::ID IntrinsicID,
           return nullptr;
       }
 
-      return ConstantStruct::get(StTy, ConstantVector::get(Results0),
-                                 ConstantVector::get(Results1));
+      return ConstantStruct::get(StTy,
+                                 {ConstantVector::get(Results0, &DL),
+                                  ConstantVector::get(Results1, &DL)},
+                                 &DL);
     }
 
     auto [Result0, Result1] = ConstantFoldScalarFrexpCall(Operands[0], Ty1);
     if (!Result0)
       return nullptr;
-    return ConstantStruct::get(StTy, Result0, Result1);
+    return ConstantStruct::get(StTy, {Result0, Result1}, &DL);
   }
   case Intrinsic::sincos: {
     Type *Ty = StTy->getContainedType(0);
@@ -4459,14 +4461,16 @@ ConstantFoldStructCall(StringRef Name, Intrinsic::ID IntrinsicID,
           return nullptr;
       }
 
-      return ConstantStruct::get(StTy, ConstantVector::get(SinResults),
-                                 ConstantVector::get(CosResults));
+      return ConstantStruct::get(StTy,
+                                 {ConstantVector::get(SinResults, &DL),
+                                  ConstantVector::get(CosResults, &DL)},
+                                 &DL);
     }
 
     auto [SinResult, CosResult] = ConstantFoldScalarSincosCall(Operands[0]);
     if (!SinResult || !CosResult)
       return nullptr;
-    return ConstantStruct::get(StTy, SinResult, CosResult);
+    return ConstantStruct::get(StTy, {SinResult, CosResult}, &DL);
   }
   case Intrinsic::vector_deinterleave2:
   case Intrinsic::vector_deinterleave3:
@@ -4483,9 +4487,9 @@ ConstantFoldStructCall(StringRef Name, Intrinsic::ID IntrinsicID,
         VecTy->getElementCount().divideCoefficientBy(NumResults);
 
     if (auto *EltC = Vec->getSplatValue()) {
-      auto *ResultVec = ConstantVector::getSplat(ResultEC, EltC);
+      auto *ResultVec = ConstantVector::getSplat(ResultEC, EltC, &DL);
       SmallVector<Constant *, 8> Results(NumResults, ResultVec);
-      return ConstantStruct::get(StTy, Results);
+      return ConstantStruct::get(StTy, Results, &DL);
     }
 
     if (!ResultEC.isFixed())
@@ -4501,9 +4505,9 @@ ConstantFoldStructCall(StringRef Name, Intrinsic::ID IntrinsicID,
           return nullptr;
         Elements[J] = Elt;
       }
-      Results[I] = ConstantVector::get(Elements);
+      Results[I] = ConstantVector::get(Elements, &DL);
     }
-    return ConstantStruct::get(StTy, Results);
+    return ConstantStruct::get(StTy, Results, &DL);
   }
   default:
     // TODO: Constant folding of vector intrinsics that fall through here does

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -701,7 +701,7 @@ static Constant *computePointerDifference(const DataLayout &DL, Value *LHS,
   //  = LHSOffset - RHSOffset
   Constant *Res = ConstantInt::get(LHS->getContext(), LHSOffset - RHSOffset);
   if (auto *VecTy = dyn_cast<VectorType>(LHS->getType()))
-    Res = ConstantVector::getSplat(VecTy->getElementCount(), Res);
+    Res = ConstantVector::getSplat(VecTy->getElementCount(), Res, &DL);
   return Res;
 }
 
@@ -5195,7 +5195,7 @@ static Value *simplifySelectInst(Value *Cond, Value *TrueVal, Value *FalseVal,
         break;
     }
     if (NewC.size() == NumElts)
-      return ConstantVector::get(NewC);
+      return ConstantVector::get(NewC, &Q.DL);
   }
 
   if (Value *V =
@@ -5756,7 +5756,7 @@ static Value *simplifyShuffleVectorInst(Value *Op0, Value *Op1,
       for (unsigned i = 0; i != MaskNumElts; ++i)
         if (Indices[i] == -1)
           VecC[i] = PoisonValue::get(C->getType());
-      return ConstantVector::get(VecC);
+      return ConstantVector::get(VecC, &Q.DL);
     }
   }
 
@@ -7131,7 +7131,7 @@ Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
           // Handle splat vectors (including scalable vectors)
           OptResult = OptimizeConstMinMax(SplatVal, IID, Call, &NewConst);
           if (OptResult == MinMaxOptResult::UseNewConstVal)
-            NewConst = ConstantVector::getSplat(ElemCount, NewConst);
+            NewConst = ConstantVector::getSplat(ElemCount, NewConst, &Q.DL);
 
         } else if (ElemCount.isFixed()) {
           // Storage to build up new const return value (with NaNs quieted)
@@ -7161,7 +7161,7 @@ Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
               OptResult = ElemResult;
           }
           if (OptResult == MinMaxOptResult::UseNewConstVal)
-            NewConst = ConstantVector::get(NewC);
+            NewConst = ConstantVector::get(NewC, &Q.DL);
         }
       } else {
         // Handle scalar inputs

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4203,7 +4203,8 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
                                       " is not of type '" +
                                       getTypeString(Elts[0]->getType()));
 
-    ID.ConstantVal = ConstantVector::get(Elts);
+    const auto &DL = M->getDataLayout();
+    ID.ConstantVal = ConstantVector::get(Elts, &DL);
     ID.Kind = ValID::t_Constant;
     return false;
   }
@@ -6816,8 +6817,9 @@ bool LLParser::convertValIDToValue(Type *Ty, ValID &ID, Value *&V,
               "element " + Twine(i) +
                   " of struct initializer doesn't match struct element type");
 
+      const auto &DL = M->getDataLayout();
       V = ConstantStruct::get(
-          ST, ArrayRef(ID.ConstantStructElts.get(), ID.UIntVal));
+          ST, ArrayRef(ID.ConstantStructElts.get(), ID.UIntVal), &DL);
     } else
       return error(ID.Loc, "constant expression type mismatch");
     return false;

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -1685,7 +1685,8 @@ Expected<Value *> BitcodeReader::materializeValue(unsigned StartValID,
             if (Op->getType() != Ty)
               return error("Incorrect type in struct initializer");
 
-          C = ConstantStruct::get(ST, ConstOps);
+          const auto *DL = TheModule ? &TheModule->getDataLayout() : nullptr;
+          C = ConstantStruct::get(ST, ConstOps, DL);
           break;
         }
         case BitcodeConstant::ConstantArrayOpcode: {
@@ -1697,7 +1698,8 @@ Expected<Value *> BitcodeReader::materializeValue(unsigned StartValID,
             if (Op->getType() != AT->getElementType())
               return error("Incorrect type in array initializer");
 
-          C = ConstantArray::get(AT, ConstOps);
+          const auto *DL = TheModule ? &TheModule->getDataLayout() : nullptr;
+          C = ConstantArray::get(AT, ConstOps, DL);
           break;
         }
         case BitcodeConstant::ConstantVectorOpcode: {
@@ -1709,7 +1711,8 @@ Expected<Value *> BitcodeReader::materializeValue(unsigned StartValID,
             if (Op->getType() != VT->getElementType())
               return error("Incorrect type in vector initializer");
 
-          C = ConstantVector::get(ConstOps);
+          const auto *DL = TheModule ? &TheModule->getDataLayout() : nullptr;
+          C = ConstantVector::get(ConstOps, DL);
           break;
         }
         case Instruction::GetElementPtr:

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -5924,9 +5924,10 @@ void llvm::embedBitcodeInModule(llvm::Module &M, llvm::MemoryBufferRef Buf,
     return;
 
   // Recreate llvm.compiler.used.
+  const auto &DL = M.getDataLayout();
   ArrayType *ATy = ArrayType::get(UsedElementType, UsedArray.size());
   auto *NewUsed = new GlobalVariable(
       M, ATy, false, llvm::GlobalValue::AppendingLinkage,
-      llvm::ConstantArray::get(ATy, UsedArray), "llvm.compiler.used");
+      llvm::ConstantArray::get(ATy, UsedArray, &DL), "llvm.compiler.used");
   NewUsed->setSection("llvm.metadata");
 }

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2763,7 +2763,8 @@ static void tagGlobalDefinition(Module &M, GlobalVariable *G) {
     llvm::SmallVector<uint8_t> Init(NewSize - SizeInBytes, 0);
     Constant *Padding = ConstantDataArray::get(M.getContext(), Init);
     Constant *Initializer = G->getInitializer();
-    Initializer = ConstantStruct::getAnon({Initializer, Padding});
+    Initializer = ConstantStruct::getAnon({Initializer, Padding},
+                                          /*Packed=*/false, &M.getDataLayout());
     auto *NewGV = new GlobalVariable(
         M, Initializer->getType(), G->isConstant(), G->getLinkage(),
         Initializer, "", G, G->getThreadLocalMode(), G->getAddressSpace());

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -8289,7 +8289,7 @@ class VectorPromoteHelper {
 
     ElementCount EC = cast<VectorType>(getTransitionType())->getElementCount();
     if (UseSplat)
-      return ConstantVector::getSplat(EC, Val);
+      return ConstantVector::getSplat(EC, Val, &DL);
 
     if (!EC.isScalable()) {
       SmallVector<Constant *, 4> ConstVec;
@@ -8300,7 +8300,7 @@ class VectorPromoteHelper {
         else
           ConstVec.push_back(PoisonVal);
       }
-      return ConstantVector::get(ConstVec);
+      return ConstantVector::get(ConstVec, &DL);
     } else
       llvm_unreachable(
           "Generate scalable vector for non-splat is unimplemented");

--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -540,7 +540,8 @@ bool GlobalMergeImpl::doMerge(const SmallVectorImpl<GlobalVariable *> &Globals,
                                             : GlobalValue::InternalLinkage;
     // Use a packed struct so we can control alignment.
     StructType *MergedTy = StructType::get(M.getContext(), Tys, true);
-    Constant *MergedInit = ConstantStruct::get(MergedTy, Inits);
+    const auto &DL = M.getDataLayout();
+    Constant *MergedInit = ConstantStruct::get(MergedTy, Inits, &DL);
 
     // On Darwin external linkage needs to be preserved, otherwise
     // dsymutil cannot preserve the debug info for the merged

--- a/llvm/lib/CodeGen/LowerEmuTLS.cpp
+++ b/llvm/lib/CodeGen/LowerEmuTLS.cpp
@@ -39,7 +39,7 @@ public:
 
   bool runOnModule(Module &M) override;
 };
-}
+} // namespace
 
 static bool addEmuTlsVar(Module &M, const GlobalVariable *GV);
 
@@ -94,7 +94,7 @@ bool LowerEmuTLS::runOnModule(Module &M) {
     return false;
 
   bool Changed = false;
-  SmallVector<const GlobalVariable*, 8> TlsVars;
+  SmallVector<const GlobalVariable *, 8> TlsVars;
   for (const auto &G : M.globals()) {
     if (G.isThreadLocal())
       TlsVars.append({&G});
@@ -111,7 +111,7 @@ bool addEmuTlsVar(Module &M, const GlobalVariable *GV) {
   std::string EmuTlsVarName = ("__emutls_v." + GV->getName()).str();
   GlobalVariable *EmuTlsVar = M.getNamedGlobal(EmuTlsVarName);
   if (EmuTlsVar)
-    return false;  // It has been added before.
+    return false; // It has been added before.
 
   const DataLayout &DL = M.getDataLayout();
   Constant *NullPtr = ConstantPointerNull::get(VoidPtrType);
@@ -155,7 +155,7 @@ bool addEmuTlsVar(Module &M, const GlobalVariable *GV) {
     EmuTlsTmplVar = M.getOrInsertGlobal(EmuTlsTmplName, GVType);
     assert(EmuTlsTmplVar && "Failed to create emualted TLS initializer");
     EmuTlsTmplVar->setConstant(true);
-    EmuTlsTmplVar->setInitializer(const_cast<Constant*>(InitValue));
+    EmuTlsTmplVar->setInitializer(const_cast<Constant *>(InitValue));
     EmuTlsTmplVar->setAlignment(GVAlignment);
     copyLinkageVisibility(M, GV, EmuTlsTmplVar);
   }
@@ -165,7 +165,8 @@ bool addEmuTlsVar(Module &M, const GlobalVariable *GV) {
       ConstantInt::get(WordType, DL.getTypeStoreSize(GVType)),
       ConstantInt::get(WordType, GVAlignment.value()), NullPtr,
       EmuTlsTmplVar ? EmuTlsTmplVar : NullPtr};
-  EmuTlsVar->setInitializer(ConstantStruct::get(EmuTlsVarType, ElementValues));
+  EmuTlsVar->setInitializer(
+      ConstantStruct::get(EmuTlsVarType, ElementValues, &DL));
   Align MaxAlignment =
       std::max(DL.getABITypeAlign(WordType), DL.getABITypeAlign(VoidPtrType));
   EmuTlsVar->setAlignment(MaxAlignment);

--- a/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
+++ b/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
@@ -314,7 +314,7 @@ static Constant *getMemSetPattern16Value(MemSetPatternInst *Inst,
   // Otherwise, we'll use an array of the constants.
   uint64_t ArraySize = 16 / Size;
   ArrayType *AT = ArrayType::get(V->getType(), ArraySize);
-  return ConstantArray::get(AT, std::vector<Constant *>(ArraySize, C));
+  return ConstantArray::get(AT, std::vector<Constant *>(ArraySize, C), &DL);
 }
 
 // TODO: Handle atomic memcpy and memcpy.inline

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -29850,7 +29850,7 @@ SDValue DAGCombiner::convertSelectOfFPConstantsToLoadOffset(
   const DataLayout &TD = DAG.getDataLayout();
 
   // Create a ConstantArray of the two constants.
-  Constant *CA = ConstantArray::get(ArrayType::get(FPTy, 2), Elts);
+  Constant *CA = ConstantArray::get(ArrayType::get(FPTy, 2), Elts, &TD);
   SDValue CPIdx = DAG.getConstantPool(CA, TLI.getPointerTy(DAG.getDataLayout()),
                                       TD.getPrefTypeAlign(FPTy));
   Align Alignment = cast<ConstantPoolSDNode>(CPIdx)->getAlign();

--- a/llvm/lib/CodeGen/ShadowStackGCLowering.cpp
+++ b/llvm/lib/CodeGen/ShadowStackGCLowering.cpp
@@ -80,8 +80,8 @@ private:
                                       Type *Ty, Value *BasePtr, int Idx1,
                                       const char *Name);
   static GetElementPtrInst *CreateGEP(LLVMContext &Context, IRBuilder<> &B,
-                                      Type *Ty, Value *BasePtr, int Idx1, int Idx2,
-                                      const char *Name);
+                                      Type *Ty, Value *BasePtr, int Idx1,
+                                      int Idx2, const char *Name);
 };
 
 class ShadowStackGCLowering : public FunctionPass {
@@ -139,11 +139,14 @@ INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 INITIALIZE_PASS_END(ShadowStackGCLowering, DEBUG_TYPE,
                     "Shadow Stack GC Lowering", false, false)
 
-FunctionPass *llvm::createShadowStackGCLoweringPass() { return new ShadowStackGCLowering(); }
+FunctionPass *llvm::createShadowStackGCLoweringPass() {
+  return new ShadowStackGCLowering();
+}
 
 ShadowStackGCLowering::ShadowStackGCLowering() : FunctionPass(ID) {}
 
 Constant *ShadowStackGCLoweringImpl::GetFrameMap(Function &F) {
+  const auto &DL = F.getDataLayout();
   // doInitialization creates the abstract type of this value.
   Type *VoidPtr = PointerType::getUnqual(F.getContext());
 
@@ -166,13 +169,13 @@ Constant *ShadowStackGCLoweringImpl::GetFrameMap(Function &F) {
   };
 
   Constant *DescriptorElts[] = {
-      ConstantStruct::get(FrameMapTy, BaseElts),
-      ConstantArray::get(ArrayType::get(VoidPtr, NumMeta), Metadata)};
+      ConstantStruct::get(FrameMapTy, BaseElts, &DL),
+      ConstantArray::get(ArrayType::get(VoidPtr, NumMeta), Metadata, &DL)};
 
   Type *EltTys[] = {DescriptorElts[0]->getType(), DescriptorElts[1]->getType()};
   StructType *STy = StructType::create(EltTys, "gc_map." + utostr(NumMeta));
 
-  Constant *FrameMap = ConstantStruct::get(STy, DescriptorElts);
+  Constant *FrameMap = ConstantStruct::get(STy, DescriptorElts, &DL);
 
   // FIXME: Is this actually dangerous as WritingAnLLVMPass.html claims? Seems
   //        that, short of multithreaded LLVM, it should be safe; all that is
@@ -188,8 +191,8 @@ Constant *ShadowStackGCLoweringImpl::GetFrameMap(Function &F) {
   //        (which uses a FunctionPassManager (which segfaults (not asserts) if
   //        provided a ModulePass))).
   return new GlobalVariable(*F.getParent(), FrameMap->getType(), true,
-                                    GlobalVariable::InternalLinkage, FrameMap,
-                                    "__gc_" + F.getName());
+                            GlobalVariable::InternalLinkage, FrameMap,
+                            "__gc_" + F.getName());
 }
 
 Type *ShadowStackGCLoweringImpl::GetConcreteStackEntryType(Function &F) {

--- a/llvm/lib/Frontend/Offloading/OffloadWrapper.cpp
+++ b/llvm/lib/Frontend/Offloading/OffloadWrapper.cpp
@@ -127,6 +127,7 @@ GlobalVariable *createBinDesc(Module &M, ArrayRef<ArrayRef<char>> Bufs,
                               EntryArrayTy EntryArray, StringRef Suffix,
                               bool Relocatable) {
   LLVMContext &C = M.getContext();
+  const auto &DL = M.getDataLayout();
   auto [EntriesB, EntriesE] = EntryArray;
 
   auto *Zero = ConstantInt::get(getSizeTTy(M), 0u);
@@ -175,13 +176,14 @@ GlobalVariable *createBinDesc(Module &M, ArrayRef<ArrayRef<char>> Bufs,
     auto *ImageE =
         ConstantExpr::getGetElementPtr(Image->getValueType(), Image, ZeroSize);
 
-    ImagesInits.push_back(ConstantStruct::get(getDeviceImageTy(M), ImageB,
-                                              ImageE, EntriesB, EntriesE));
+    ImagesInits.push_back(ConstantStruct::get(
+        getDeviceImageTy(M), {ImageB, ImageE, EntriesB, EntriesE}, &DL));
   }
 
   // Then create images array.
   auto *ImagesData = ConstantArray::get(
-      ArrayType::get(getDeviceImageTy(M), ImagesInits.size()), ImagesInits);
+      ArrayType::get(getDeviceImageTy(M), ImagesInits.size()), ImagesInits,
+      &DL);
 
   auto *Images =
       new GlobalVariable(M, ImagesData->getType(), /*isConstant*/ true,
@@ -192,8 +194,9 @@ GlobalVariable *createBinDesc(Module &M, ArrayRef<ArrayRef<char>> Bufs,
   // And finally create the binary descriptor object.
   auto *DescInit = ConstantStruct::get(
       getBinDescTy(M),
-      ConstantInt::get(Type::getInt32Ty(C), ImagesInits.size()), Images,
-      EntriesB, EntriesE);
+      {ConstantInt::get(Type::getInt32Ty(C), ImagesInits.size()), Images,
+       EntriesB, EntriesE},
+      &DL);
 
   return new GlobalVariable(M, DescInit->getType(), /*isConstant=*/true,
                             GlobalValue::InternalLinkage, DescInit,
@@ -303,8 +306,9 @@ GlobalVariable *createFatbinDesc(Module &M, ArrayRef<char> Image, bool IsHIP,
       ConstantExpr::getPointerBitCastOrAddrSpaceCast(Fatbin, Int8PtrTy),
       ConstantPointerNull::get(PointerType::getUnqual(C))};
 
+  const auto &DL = M.getDataLayout();
   Constant *FatbinInitializer =
-      ConstantStruct::get(getFatbinWrapperTy(M), FatbinWrapper);
+      ConstantStruct::get(getFatbinWrapperTy(M), FatbinWrapper, &DL);
 
   auto *FatbinDesc =
       new GlobalVariable(M, getFatbinWrapperTy(M),
@@ -916,8 +920,9 @@ private:
       EntriesInits.push_back(GV->getInitializer());
     }
 
+    const auto &DL = M.getDataLayout();
     Constant *Arr = ConstantArray::get(
-        ArrayType::get(EntryTy, EntriesInits.size()), EntriesInits);
+        ArrayType::get(EntryTy, EntriesInits.size()), EntriesInits, &DL);
     GlobalVariable *EntriesGV = new GlobalVariable(
         M, Arr->getType(), /*isConstant*/ true, GlobalVariable::InternalLinkage,
         Arr, OffloadKindTag + "entries_arr");
@@ -967,19 +972,24 @@ private:
 
     // .first and .second arguments below correspond to start and end pointers
     // respectively.
+    const auto &DL = M.getDataLayout();
     Constant *WrappedBinary = ConstantStruct::get(
-        SyclDeviceImageTy, Version, OffloadKindConstant, ImageKindConstant,
-        TripleConstant, CompileOptions, LinkOptions, Binary.first,
-        Binary.second, ImageEntriesPtrs.first, ImageEntriesPtrs.second,
-        PropertiesConstants.first, PropertiesConstants.second);
+        SyclDeviceImageTy,
+        {Version, OffloadKindConstant, ImageKindConstant, TripleConstant,
+         CompileOptions, LinkOptions, Binary.first, Binary.second,
+         ImageEntriesPtrs.first, ImageEntriesPtrs.second,
+         PropertiesConstants.first, PropertiesConstants.second},
+        &DL);
 
     return WrappedBinary;
   }
 
   GlobalVariable *combineWrappedImages(ArrayRef<Constant *> WrappedImages,
                                        StringRef OffloadKindTag) {
+    const auto &DL = M.getDataLayout();
     Constant *ImagesData = ConstantArray::get(
-        ArrayType::get(SyclDeviceImageTy, WrappedImages.size()), WrappedImages);
+        ArrayType::get(SyclDeviceImageTy, WrappedImages.size()), WrappedImages,
+        &DL);
     GlobalVariable *ImagesGV =
         new GlobalVariable(M, ImagesData->getType(), /*isConstant*/ true,
                            GlobalValue::InternalLinkage, ImagesData,
@@ -991,9 +1001,10 @@ private:
     static constexpr uint16_t BinDescStructVersion = 1;
     Constant *DescInit = ConstantStruct::get(
         SyclBinDescTy,
-        ConstantInt::get(Type::getInt16Ty(C), BinDescStructVersion),
-        ConstantInt::get(Type::getInt16Ty(C), WrappedImages.size()), ImagesGV,
-        EntriesB, EntriesE);
+        {ConstantInt::get(Type::getInt16Ty(C), BinDescStructVersion),
+         ConstantInt::get(Type::getInt16Ty(C), WrappedImages.size()), ImagesGV,
+         EntriesB, EntriesE},
+        &DL);
 
     return new GlobalVariable(M, DescInit->getType(), /*isConstant*/ true,
                               GlobalValue::InternalLinkage, DescInit,

--- a/llvm/lib/Frontend/Offloading/Utility.cpp
+++ b/llvm/lib/Frontend/Offloading/Utility.cpp
@@ -67,6 +67,7 @@ offloading::getOffloadingEntryInitializer(Module &M, object::OffloadKind Kind,
   MD->addOperand(llvm::MDNode::get(M.getContext(), MDVals));
 
   // Construct the offloading entry.
+  const auto &DL = M.getDataLayout();
   Constant *EntryData[] = {
       ConstantExpr::getNullValue(Int64Ty),
       ConstantInt::get(Int16Ty, 1),
@@ -78,7 +79,8 @@ offloading::getOffloadingEntryInitializer(Module &M, object::OffloadKind Kind,
       ConstantInt::get(Int64Ty, Data),
       AuxAddr ? ConstantExpr::getPointerBitCastOrAddrSpaceCast(AuxAddr, PtrTy)
               : ConstantExpr::getNullValue(PtrTy)};
-  Constant *EntryInitializer = ConstantStruct::get(getEntryTy(M), EntryData);
+  Constant *EntryInitializer =
+      ConstantStruct::get(getEntryTy(M), EntryData, &DL);
   return {EntryInitializer, Str};
 }
 

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -1020,8 +1020,9 @@ Constant *OpenMPIRBuilder::getOrCreateIdent(Constant *SrcLocStr,
         IdentData[SrcLocStrArgIdx]->getType()->getPointerAddressSpace())
       IdentData[SrcLocStrArgIdx] = ConstantExpr::getAddrSpaceCast(
           SrcLocStr, OpenMPIRBuilder::Ident->getElementType(SrcLocStrArgIdx));
+    const auto &DL = M.getDataLayout();
     Constant *Initializer =
-        ConstantStruct::get(OpenMPIRBuilder::Ident, IdentData);
+        ConstantStruct::get(OpenMPIRBuilder::Ident, IdentData, &DL);
 
     // Look for existing encoding of the location + flags, not needed but
     // minimizes the difference to the existing solution while we transition.
@@ -7769,24 +7770,23 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTargetInit(
           : ConstantExpr::getAddrSpaceCast(DynamicEnvironmentGV,
                                            DynamicEnvironmentPtr);
 
-  Constant *ConfigurationEnvironmentInitializer = ConstantStruct::get(
-      ConfigurationEnvironment, {
-                                    UseGenericStateMachineVal,
-                                    MayUseNestedParallelismVal,
-                                    IsSPMDVal,
-                                    MinThreads,
-                                    MaxThreads,
-                                    MinTeams,
-                                    MaxTeams,
-                                    ReductionDataSize,
-                                    ReductionBufferLength,
-                                });
+  Constant *ConfigurationEnvironmentInitializer =
+      ConstantStruct::get(ConfigurationEnvironment,
+                          {
+                              UseGenericStateMachineVal,
+                              MayUseNestedParallelismVal,
+                              IsSPMDVal,
+                              MinThreads,
+                              MaxThreads,
+                              MinTeams,
+                              MaxTeams,
+                              ReductionDataSize,
+                              ReductionBufferLength,
+                          },
+                          &DL);
   Constant *KernelEnvironmentInitializer = ConstantStruct::get(
-      KernelEnvironment, {
-                             ConfigurationEnvironmentInitializer,
-                             Ident,
-                             DynamicEnvironment,
-                         });
+      KernelEnvironment,
+      {ConfigurationEnvironmentInitializer, Ident, DynamicEnvironment}, &DL);
   std::string KernelEnvironmentName =
       (KernelName + "_kernel_environment").str();
   GlobalVariable *KernelEnvironmentGV = new GlobalVariable(
@@ -9967,8 +9967,9 @@ Error OpenMPIRBuilder::emitOffloadingArrays(
         SizeArrayType, /* ArraySize = */ nullptr, ".offload_sizes");
     restoreIPandDebugLoc(Builder, CodeGenIP);
   } else {
+    const auto &DL = M.getDataLayout();
     auto *SizesArrayInit = ConstantArray::get(
-        ArrayType::get(Int64Ty, ConstSizes.size()), ConstSizes);
+        ArrayType::get(Int64Ty, ConstSizes.size()), ConstSizes, &DL);
     std::string Name = createPlatformSpecificName({"offload_sizes"});
     auto *SizesArrayGbl =
         new GlobalVariable(M, SizesArrayInit->getType(), /*isConstant=*/true,
@@ -10993,10 +10994,11 @@ OpenMPIRBuilder::createDistribute(const LocationDescription &Loc,
 GlobalVariable *
 OpenMPIRBuilder::createOffloadMapnames(SmallVectorImpl<llvm::Constant *> &Names,
                                        std::string VarName) {
+  const auto &DL = M.getDataLayout();
   llvm::Constant *MapNamesArrayInit = llvm::ConstantArray::get(
       llvm::ArrayType::get(llvm::PointerType::getUnqual(M.getContext()),
                            Names.size()),
-      Names);
+      Names, &DL);
   auto *MapNamesArrayGlobal = new llvm::GlobalVariable(
       M, MapNamesArrayInit->getType(),
       /*isConstant=*/true, llvm::GlobalValue::PrivateLinkage, MapNamesArrayInit,

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1913,16 +1913,20 @@ GlobalVariable *llvm::UpgradeGlobalVariable(GlobalVariable *GV) {
   IRBuilder<> IRB(C);
   auto EltTy = StructType::get(STy->getElementType(0), STy->getElementType(1),
                                IRB.getPtrTy());
+  const auto &DL = GV->getParent()->getDataLayout();
   Constant *Init = GV->getInitializer();
   unsigned N = Init->getNumOperands();
   std::vector<Constant *> NewCtors(N);
   for (unsigned i = 0; i != N; ++i) {
     auto Ctor = cast<Constant>(Init->getOperand(i));
-    NewCtors[i] = ConstantStruct::get(EltTy, Ctor->getAggregateElement(0u),
-                                      Ctor->getAggregateElement(1),
-                                      ConstantPointerNull::get(IRB.getPtrTy()));
+    NewCtors[i] = ConstantStruct::get(
+        EltTy,
+        {Ctor->getAggregateElement(0u), Ctor->getAggregateElement(1),
+         ConstantPointerNull::get(IRB.getPtrTy())},
+        &DL);
   }
-  Constant *NewInit = ConstantArray::get(ArrayType::get(EltTy, N), NewCtors);
+  Constant *NewInit =
+      ConstantArray::get(ArrayType::get(EltTy, N), NewCtors, &DL);
 
   return new GlobalVariable(NewInit->getType(), false, GV->getLinkage(),
                             NewInit, GV->getName());

--- a/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
@@ -922,16 +922,18 @@ bool AArch64Arm64ECCallLowering::runOnModule(Module &Mod) {
   }
 
   if (!ThunkMapping.empty()) {
+    const DataLayout &DL = Mod.getDataLayout();
     SmallVector<Constant *> ThunkMappingArrayElems;
     for (ThunkInfo &Thunk : ThunkMapping) {
       ThunkMappingArrayElems.push_back(ConstantStruct::getAnon(
           {Thunk.Src, Thunk.Dst,
-           ConstantInt::get(M->getContext(), APInt(32, uint8_t(Thunk.Kind)))}));
+           ConstantInt::get(M->getContext(), APInt(32, uint8_t(Thunk.Kind)))},
+          /*Packed=*/false, &DL));
     }
     Constant *ThunkMappingArray = ConstantArray::get(
         llvm::ArrayType::get(ThunkMappingArrayElems[0]->getType(),
                              ThunkMappingArrayElems.size()),
-        ThunkMappingArrayElems);
+        ThunkMappingArrayElems, &DL);
     new GlobalVariable(Mod, ThunkMappingArray->getType(), /*isConstant*/ false,
                        GlobalValue::ExternalLinkage, ThunkMappingArray,
                        "llvm.arm64ec.symbolmap");

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -1730,7 +1730,7 @@ static Value *stripInactiveLanes(Value *V, const Value *Pg) {
       Dup->getOperand(1) == Pg && isa<Constant>(Dup->getOperand(2)))
     return ConstantVector::getSplat(
         cast<VectorType>(V->getType())->getElementCount(),
-        cast<Constant>(Dup->getOperand(2)));
+        cast<Constant>(Dup->getOperand(2)), &Dup->getDataLayout());
 
   return V;
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerModuleLDSPass.cpp
@@ -312,7 +312,8 @@ public:
 
   static Constant *getAddressesOfVariablesInKernel(
       LLVMContext &Ctx, ArrayRef<GlobalVariable *> Variables,
-      const DenseMap<GlobalVariable *, Constant *> &LDSVarsToConstantGEP) {
+      const DenseMap<GlobalVariable *, Constant *> &LDSVarsToConstantGEP,
+      const DataLayout *DL) {
     // Create a ConstantArray containing the address of each Variable within the
     // kernel corresponding to LDSVarsToConstantGEP, or poison if that kernel
     // does not allocate it
@@ -329,7 +330,7 @@ public:
         Elements.push_back(PoisonValue::get(LocalPtrTy));
       }
     }
-    return ConstantArray::get(KernelOffsetsType, Elements);
+    return ConstantArray::get(KernelOffsetsType, Elements, DL);
   }
 
   static GlobalVariable *buildLookupTable(
@@ -358,11 +359,12 @@ public:
           (Replacement == KernelToReplacement.end())
               ? Missing
               : getAddressesOfVariablesInKernel(
-                    Ctx, Variables, Replacement->second.LDSVarsToConstantGEP);
+                    Ctx, Variables, Replacement->second.LDSVarsToConstantGEP,
+                    &M.getDataLayout());
     }
 
-    Constant *init =
-        ConstantArray::get(AllKernelsOffsetsType, overallConstantExprElts);
+    Constant *init = ConstantArray::get(
+        AllKernelsOffsetsType, overallConstantExprElts, &M.getDataLayout());
 
     return new GlobalVariable(
         M, AllKernelsOffsetsType, true, GlobalValue::InternalLinkage, init,
@@ -889,7 +891,7 @@ public:
       assert(OrderedKernels.size() == newDynamicLDS.size());
 
       ArrayType *t = ArrayType::get(LocalPtrTy, newDynamicLDS.size());
-      Constant *init = ConstantArray::get(t, newDynamicLDS);
+      Constant *init = ConstantArray::get(t, newDynamicLDS, &M.getDataLayout());
       GlobalVariable *table = new GlobalVariable(
           M, t, true, GlobalValue::InternalLinkage, init,
           "llvm.amdgcn.dynlds.offset.table", nullptr,

--- a/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
@@ -449,9 +449,10 @@ void AMDGPUSwLowerLDS::populateSwMetadataGlobal(Function *Func) {
               ConstantInt::get(Int32Ty, AlignedSize);
           // Align MallocSize
           MallocSize = alignTo(MallocSize, MaxAlignment);
-          Constant *InitItem =
-              ConstantStruct::get(LDSItemTy, {ItemStartOffset, SizeInBytesConst,
-                                              AlignedSizeInBytesConst});
+          Constant *InitItem = ConstantStruct::get(
+              LDSItemTy,
+              {ItemStartOffset, SizeInBytesConst, AlignedSizeInBytesConst},
+              &DL);
           Initializers.push_back(InitItem);
         }
       };
@@ -480,7 +481,7 @@ void AMDGPUSwLowerLDS::populateSwMetadataGlobal(Function *Func) {
       M, MetadataStructType, false, GlobalValue::InternalLinkage,
       PoisonValue::get(MetadataStructType), MDOS.str(), nullptr,
       GlobalValue::NotThreadLocal, AMDGPUAS::GLOBAL_ADDRESS, false);
-  Constant *data = ConstantStruct::get(MetadataStructType, Initializers);
+  Constant *data = ConstantStruct::get(MetadataStructType, Initializers, &DL);
   LDSParams.SwLDSMetadata->setInitializer(data);
   assert(LDSParams.SwLDS);
   // Set the alignment to MaxAlignment for SwLDS.
@@ -979,7 +980,8 @@ Constant *AMDGPUSwLowerLDS::getAddressesOfVariablesInKernel(
                                                    SwLDSMetadata, GEPIdx, true);
     Elements.push_back(GEP);
   }
-  return ConstantArray::get(KernelOffsetsType, Elements);
+  const DataLayout &DL = M.getDataLayout();
+  return ConstantArray::get(KernelOffsetsType, Elements, &DL);
 }
 
 void AMDGPUSwLowerLDS::buildNonKernelLDSBaseTable(
@@ -999,8 +1001,9 @@ void AMDGPUSwLowerLDS::buildNonKernelLDSBaseTable(
     auto &LDSParams = FuncLDSAccessInfo.KernelToLDSParametersMap[Func];
     OverallConstantExprElts[i] = LDSParams.SwLDS;
   }
+  const DataLayout &DL = M.getDataLayout();
   Constant *init =
-      ConstantArray::get(AllKernelsOffsetsType, OverallConstantExprElts);
+      ConstantArray::get(AllKernelsOffsetsType, OverallConstantExprElts, &DL);
   NKLDSParams.LDSBaseTable = new GlobalVariable(
       M, AllKernelsOffsetsType, true, GlobalValue::InternalLinkage, init,
       "llvm.amdgcn.sw.lds.base.table", nullptr, GlobalValue::NotThreadLocal,
@@ -1037,8 +1040,9 @@ void AMDGPUSwLowerLDS::buildNonKernelLDSOffsetTable(
     overallConstantExprElts[i] =
         getAddressesOfVariablesInKernel(Func, Variables);
   }
+  const DataLayout &DL = M.getDataLayout();
   Constant *Init =
-      ConstantArray::get(AllKernelsOffsetsType, overallConstantExprElts);
+      ConstantArray::get(AllKernelsOffsetsType, overallConstantExprElts, &DL);
   NKLDSParams.LDSOffsetTable = new GlobalVariable(
       M, AllKernelsOffsetsType, true, GlobalValue::InternalLinkage, Init,
       "llvm.amdgcn.sw.lds.offset.table", nullptr, GlobalValue::NotThreadLocal,

--- a/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
+++ b/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
@@ -96,7 +96,7 @@ bool PPCPrepareIFuncsOnAIX::runOnModule(Module &M) {
     // function descriptor, which is what these two values end up being
     // in assembly.
     Constant *InitVals[] = {&IFunc, IFunc.getResolver()};
-    GV->setInitializer(ConstantStruct::get(IFuncPairType, InitVals));
+    GV->setInitializer(ConstantStruct::get(IFuncPairType, InitVals, &DL));
 
     // Liveness of __update_foo is dependent on liveness of ifunc foo.
     IFunc.setMetadata(LLVMContext::MD_implicit_ref,

--- a/llvm/lib/Target/RISCV/RISCVPromoteConstant.cpp
+++ b/llvm/lib/Target/RISCV/RISCVPromoteConstant.cpp
@@ -149,8 +149,9 @@ bool RISCVPromoteConstant::runOnFunction(Function &F,
     ConstantVector.push_back(Pair.first);
 
   ArrayType *ArrayTy = ArrayType::get(DoubleTy, ConstantVector.size());
+  const DataLayout &DL = M->getDataLayout();
   Constant *GlobalArrayInitializer =
-      ConstantArray::get(ArrayTy, ConstantVector);
+      ConstantArray::get(ArrayTy, ConstantVector, &DL);
 
   auto *GlobalArray = new GlobalVariable(
       *M, ArrayTy,

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -616,8 +616,9 @@ Register SPIRVGlobalRegistry::getOrCreateConstVector(const APInt &Val,
   assert(LLVMBaseTy->isIntegerTy() &&
          "Expected integer element type for APInt constant vector");
   auto *ConstVal = cast<ConstantInt>(ConstantInt::get(LLVMBaseTy, Val));
+  const DataLayout &DL = CurMF->getFunction().getParent()->getDataLayout();
   auto *ConstVec =
-      ConstantVector::getSplat(LLVMVecTy->getElementCount(), ConstVal);
+      ConstantVector::getSplat(LLVMVecTy->getElementCount(), ConstVal, &DL);
   unsigned BW = getScalarOrVectorBitWidth(SpvType);
   return getOrCreateCompositeOrNull(ConstVal, I, SpvType, TII, ConstVec, BW,
                                     SpvType->getOperand(2).getImm(),
@@ -635,8 +636,9 @@ Register SPIRVGlobalRegistry::getOrCreateConstVector(APFloat Val,
   Type *LLVMBaseTy = LLVMVecTy->getElementType();
   assert(LLVMBaseTy->isFloatingPointTy());
   auto *ConstVal = ConstantFP::get(LLVMBaseTy, Val);
+  const DataLayout &DL = CurMF->getFunction().getParent()->getDataLayout();
   auto *ConstVec =
-      ConstantVector::getSplat(LLVMVecTy->getElementCount(), ConstVal);
+      ConstantVector::getSplat(LLVMVecTy->getElementCount(), ConstVal, &DL);
   unsigned BW = getScalarOrVectorBitWidth(SpvType);
   return getOrCreateCompositeOrNull(ConstVal, I, SpvType, TII, ConstVec, BW,
                                     SpvType->getOperand(2).getImm(),
@@ -663,9 +665,11 @@ Register SPIRVGlobalRegistry::getOrCreateConstIntArray(
   // the creation of constants of arbitrary length (that is, the parameter of
   // memset) which were missing in the original module.
   Type *I64Ty = Type::getInt64Ty(LLVMBaseTy->getContext());
+  const DataLayout &DL = CurMF->getFunction().getParent()->getDataLayout();
   Constant *UniqueKey = ConstantStruct::getAnon(
       {PoisonValue::get(const_cast<ArrayType *>(LLVMArrTy)),
-       ConstantInt::get(LLVMBaseTy, Val), ConstantInt::get(I64Ty, Num)});
+       ConstantInt::get(LLVMBaseTy, Val), ConstantInt::get(I64Ty, Num)},
+      /*Packed=*/false, &DL);
   return getOrCreateCompositeOrNull(CI, I, SpvType, TII, UniqueKey, BW,
                                     LLVMArrTy->getNumElements());
 }
@@ -717,8 +721,9 @@ Register SPIRVGlobalRegistry::getOrCreateConsIntVector(
   const FixedVectorType *LLVMVecTy = cast<FixedVectorType>(LLVMTy);
   Type *LLVMBaseTy = LLVMVecTy->getElementType();
   const auto ConstInt = ConstantInt::get(LLVMBaseTy, Val);
+  const DataLayout &DL = CurMF->getFunction().getParent()->getDataLayout();
   auto ConstVec =
-      ConstantVector::getSplat(LLVMVecTy->getElementCount(), ConstInt);
+      ConstantVector::getSplat(LLVMVecTy->getElementCount(), ConstInt, &DL);
   unsigned BW = getScalarOrVectorBitWidth(SpvType);
   return getOrCreateIntCompositeOrNull(Val, MIRBuilder, SpvType, EmitIR,
                                        ConstVec, BW,

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizeZeroSizeArrays.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizeZeroSizeArrays.cpp
@@ -75,7 +75,7 @@ public:
 
 private:
   Type *legalizeType(Type *Ty);
-  Constant *legalizeConstant(Constant *C);
+  Constant *legalizeConstant(Constant *C, const DataLayout *DL);
 
   const SPIRVTargetMachine &TM;
   DenseMap<Type *, Type *> TypeMap;

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -7946,7 +7946,8 @@ static SDValue combineToConsecutiveLoads(EVT VT, SDValue Op, const SDLoc &DL,
 }
 
 static Constant *getConstantVector(MVT VT, ArrayRef<APInt> Bits,
-                                   const APInt &Undefs, LLVMContext &C) {
+                                   const APInt &Undefs, LLVMContext &C,
+                                   const DataLayout *DL) {
   unsigned ScalarSize = VT.getScalarSizeInBits();
   Type *Ty = EVT(VT.getScalarType()).getTypeForEVT(C);
 
@@ -7967,11 +7968,12 @@ static Constant *getConstantVector(MVT VT, ArrayRef<APInt> Bits,
     ConstantVec.push_back(Undefs[I] ? UndefValue::get(Ty)
                                     : getConstantScalar(Bits[I]));
 
-  return ConstantVector::get(ArrayRef<Constant *>(ConstantVec));
+  return ConstantVector::get(ArrayRef<Constant *>(ConstantVec), DL);
 }
 
 static Constant *getConstantVector(MVT VT, const APInt &SplatValue,
-                                   unsigned SplatBitSize, LLVMContext &C) {
+                                   unsigned SplatBitSize, LLVMContext &C,
+                                   const DataLayout *DL) {
   unsigned ScalarSize = VT.getScalarSizeInBits();
 
   auto getConstantScalar = [&](const APInt &Val) -> Constant * {
@@ -7995,7 +7997,7 @@ static Constant *getConstantVector(MVT VT, const APInt &SplatValue,
     APInt Val = SplatValue.extractBits(ScalarSize, ScalarSize * I);
     ConstantVec.push_back(getConstantScalar(Val));
   }
-  return ConstantVector::get(ArrayRef<Constant *>(ConstantVec));
+  return ConstantVector::get(ArrayRef<Constant *>(ConstantVec), DL);
 }
 
 static bool isFoldableUseOfShuffle(SDNode *N) {
@@ -8125,7 +8127,8 @@ static SDValue lowerBuildVectorAsBroadcast(BuildVectorSDNode *BVOp,
           (SplatBitSize < 32 && Subtarget.hasAVX2())) {
         // Load the constant scalar/subvector and broadcast it.
         MVT CVT = MVT::getIntegerVT(SplatBitSize);
-        Constant *C = getConstantVector(VT, SplatValue, SplatBitSize, *Ctx);
+        Constant *C = getConstantVector(VT, SplatValue, SplatBitSize, *Ctx,
+                                        &DAG.getDataLayout());
         SDValue CP = DAG.getConstantPool(C, PVT);
         unsigned Repeat = VT.getSizeInBits() / SplatBitSize;
 
@@ -8141,7 +8144,8 @@ static SDValue lowerBuildVectorAsBroadcast(BuildVectorSDNode *BVOp,
       }
       if (SplatBitSize > 64) {
         // Load the vector of constants and broadcast it.
-        Constant *VecC = getConstantVector(VT, SplatValue, SplatBitSize, *Ctx);
+        Constant *VecC = getConstantVector(VT, SplatValue, SplatBitSize, *Ctx,
+                                           &DAG.getDataLayout());
         SDValue VCP = DAG.getConstantPool(VecC, PVT);
         unsigned NumElm = SplatBitSize / VT.getScalarSizeInBits();
         MVT VVT = MVT::getVectorVT(VT.getScalarType(), NumElm);
@@ -9813,7 +9817,7 @@ X86TargetLowering::LowerBUILD_VECTOR(SDValue Op, SelectionDAG &DAG) const {
         InsIndex = DAG.getVectorIdxConstant(i, dl);
       }
     }
-    Constant *CV = ConstantVector::get(ConstVecOps);
+    Constant *CV = ConstantVector::get(ConstVecOps, &DAG.getDataLayout());
     SDValue DAGConstVec = DAG.getConstantPool(CV, VT);
 
     // The constants we just created may not be legal (eg, floating point). We
@@ -20861,7 +20865,7 @@ static SDValue LowerUINT_TO_FP_i64(SDValue Op, const SDLoc &dl,
   CV1.push_back(
     ConstantFP::get(*Context, APFloat(APFloat::IEEEdouble(),
                                       APInt(64, 0x4530000000000000ULL))));
-  Constant *C1 = ConstantVector::get(CV1);
+  Constant *C1 = ConstantVector::get(CV1, &DAG.getDataLayout());
   SDValue CPIdx1 = DAG.getConstantPool(C1, PtrVT, Align(16));
 
   // Load the 64-bit value into an XMM register.
@@ -29278,7 +29282,8 @@ SDValue X86TargetLowering::LowerRESET_FPENV(SDValue Op,
   // MXCSR: mask all floating-point exceptions, sets rounding to nearest, clear
   // all exceptions, sets DAZ and FTZ to 0.
   FPEnvVals.push_back(ConstantInt::get(ItemTy, 0x1F80));
-  Constant *FPEnvBits = ConstantArray::get(FPEnvTy, FPEnvVals);
+  Constant *FPEnvBits =
+      ConstantArray::get(FPEnvTy, FPEnvVals, &DAG.getDataLayout());
   MVT PtrVT = DAG.getTargetLoweringInfo().getPointerTy(DAG.getDataLayout());
   SDValue Env = DAG.getConstantPool(FPEnvBits, PtrVT);
   MachinePointerInfo MPI =
@@ -43254,7 +43259,8 @@ static SDValue combineTargetShuffle(SDValue N, const SDLoc &DL,
 
         // Load the vector constant from constant pool.
         MVT PVT = TLI.getPointerTy(DAG.getDataLayout());
-        SDValue CP = DAG.getConstantPool(ConstantVector::get(ConstantVec), PVT);
+        SDValue CP = DAG.getConstantPool(
+            ConstantVector::get(ConstantVec, &DAG.getDataLayout()), PVT);
         MachinePointerInfo MPI =
             MachinePointerInfo::getConstantPool(DAG.getMachineFunction());
         Align Alignment = cast<ConstantPoolSDNode>(CP)->getAlign();
@@ -44214,7 +44220,8 @@ bool X86TargetLowering::SimplifyDemandedVectorEltsForTargetShuffle(
 
   // Generate new constant pool entry + legalize immediately for the load.
   SDLoc DL(Op);
-  SDValue CV = TLO.DAG.getConstantPool(ConstantVector::get(ConstVecOps), BCVT);
+  SDValue CV = TLO.DAG.getConstantPool(
+      ConstantVector::get(ConstVecOps, &TLO.DAG.getDataLayout()), BCVT);
   SDValue LegalCV = LowerConstantPool(CV, TLO.DAG);
   SDValue NewMask = TLO.DAG.getLoad(
       BCVT, DL, TLO.DAG.getEntryNode(), LegalCV,
@@ -60757,7 +60764,8 @@ static SDValue combineConcatVectorOps(const SDLoc &DL, MVT VT,
       UndefElts.insertBits(OpUndefElts, I * OpUndefElts.getBitWidth());
     }
     if (EltBits.size() == VT.getVectorNumElements()) {
-      Constant *C = getConstantVector(VT, EltBits, UndefElts, Ctx);
+      Constant *C =
+          getConstantVector(VT, EltBits, UndefElts, Ctx, &DAG.getDataLayout());
       MVT PVT = TLI.getPointerTy(DAG.getDataLayout());
       SDValue CV = DAG.getConstantPool(C, PVT);
       MachineFunction &MF = DAG.getMachineFunction();

--- a/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
@@ -404,7 +404,7 @@ static Value *simplifyX86varShift(const IntrinsicInst &II,
         ConstantVec.push_back(ConstantInt::getNullValue(SVT));
       }
     }
-    return ConstantVector::get(ConstantVec);
+    return ConstantVector::get(ConstantVec, &II.getDataLayout());
   }
 
   // We can't handle only some out of range values with generic logical shifts.
@@ -419,7 +419,7 @@ static Value *simplifyX86varShift(const IntrinsicInst &II,
     else
       ShiftVecAmts.push_back(ConstantInt::get(SVT, Idx));
   }
-  auto ShiftVec = ConstantVector::get(ShiftVecAmts);
+  auto ShiftVec = ConstantVector::get(ShiftVecAmts, &II.getDataLayout());
 
   if (ShiftLeft)
     return Builder.CreateShl(Vec, ShiftVec);
@@ -1844,11 +1844,12 @@ static Value *simplifyX86insertps(const IntrinsicInst &II,
 static Value *simplifyX86extrq(IntrinsicInst &II, Value *Op0,
                                ConstantInt *CILength, ConstantInt *CIIndex,
                                InstCombiner::BuilderTy &Builder) {
+  const DataLayout &DL = II.getDataLayout();
   auto LowConstantHighUndef = [&](uint64_t Val) {
     Type *IntTy64 = Type::getInt64Ty(II.getContext());
     Constant *Args[] = {ConstantInt::get(IntTy64, Val),
                         UndefValue::get(IntTy64)};
-    return ConstantVector::get(Args);
+    return ConstantVector::get(Args, &DL);
   };
 
   // See if we're dealing with constant values.
@@ -2003,7 +2004,7 @@ static Value *simplifyX86insertq(IntrinsicInst &II, Value *Op0, Value *Op1,
     Type *IntTy64 = Type::getInt64Ty(II.getContext());
     Constant *Args[] = {ConstantInt::get(IntTy64, Val.getZExtValue()),
                         UndefValue::get(IntTy64)};
-    return ConstantVector::get(Args);
+    return ConstantVector::get(Args, &II.getDataLayout());
   }
 
   // If we were an INSERTQ call, we'll save demanded elements if we convert to

--- a/llvm/lib/Transforms/Coroutines/CoroCleanup.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroCleanup.cpp
@@ -54,7 +54,7 @@ private:
   bool tryEraseCallInvoke(Instruction *I);
   void eraseFromWorklist(Instruction *I);
 };
-}
+} // namespace
 
 static void lowerSubFn(IRBuilder<> &Builder, CoroSubFnInst *SubFn) {
   Builder.SetInsertPoint(SubFn);
@@ -149,8 +149,9 @@ bool Lowerer::lower(Function &F) {
           break;
         }
         auto *TargetRelativeFunOffset = Target->getOperand(0);
+        const auto &DL = II->getModule()->getDataLayout();
         auto *NewFuncPtrStruct = ConstantStruct::get(
-            Target->getType(), TargetRelativeFunOffset, SourceSize);
+            Target->getType(), {TargetRelativeFunOffset, SourceSize}, &DL);
         Target->replaceAllUsesWith(NewFuncPtrStruct);
         break;
       }
@@ -188,7 +189,8 @@ void Lowerer::lowerCoroNoop(IntrinsicInst *II) {
 
     // Create a constant struct for the frame.
     Constant *Values[] = {NoopFn, NoopFn};
-    Constant *NoopCoroConst = ConstantStruct::get(FrameTy, Values);
+    const auto &DL = M.getDataLayout();
+    Constant *NoopCoroConst = ConstantStruct::get(FrameTy, Values, &DL);
     NoopCoro = new GlobalVariable(
         M, NoopCoroConst->getType(), /*isConstant=*/true,
         GlobalVariable::PrivateLinkage, NoopCoroConst, "NoopCoro.Frame.Const");
@@ -264,8 +266,7 @@ static bool declaresCoroCleanupIntrinsics(const Module &M) {
        Intrinsic::coro_async_resume, Intrinsic::coro_begin_custom_abi});
 }
 
-PreservedAnalyses CoroCleanupPass::run(Module &M,
-                                       ModuleAnalysisManager &MAM) {
+PreservedAnalyses CoroCleanupPass::run(Module &M, ModuleAnalysisManager &MAM) {
   if (!declaresCoroCleanupIntrinsics(M))
     return PreservedAnalyses::all();
 

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -623,8 +623,7 @@ static void replaceSwiftErrorOps(Function &F, coro::Shape &Shape,
 }
 
 /// Returns all debug records in F.
-static SmallVector<DbgVariableRecord *>
-collectDbgVariableRecords(Function &F) {
+static SmallVector<DbgVariableRecord *> collectDbgVariableRecords(Function &F) {
   SmallVector<DbgVariableRecord *> DbgVariableRecords;
   for (auto &I : instructions(F)) {
     for (DbgVariableRecord &DVR : filterDbgVars(I.getDbgRecordRange()))
@@ -1112,8 +1111,10 @@ static void updateAsyncFuncPointerContextSize(coro::Shape &Shape) {
   auto *OrigContextSize = FuncPtrStruct->getOperand(1);
   auto *NewContextSize = ConstantInt::get(OrigContextSize->getType(),
                                           Shape.AsyncLowering.ContextSize);
+  const auto &DL =
+      Shape.AsyncLowering.AsyncFuncPointer->getParent()->getDataLayout();
   auto *NewFuncPtrStruct = ConstantStruct::get(
-      FuncPtrStruct->getType(), OrigRelativeFunOffset, NewContextSize);
+      FuncPtrStruct->getType(), {OrigRelativeFunOffset, NewContextSize}, &DL);
 
   Shape.AsyncLowering.AsyncFuncPointer->setInitializer(NewFuncPtrStruct);
 }
@@ -1651,9 +1652,10 @@ private:
     assert(!Args.empty());
     Function *Part = *Fns.begin();
     Module *M = Part->getParent();
+    const auto &DL = M->getDataLayout();
     auto *ArrTy = ArrayType::get(Part->getType(), Args.size());
 
-    auto *ConstVal = ConstantArray::get(ArrTy, Args);
+    auto *ConstVal = ConstantArray::get(ArrTy, Args, &DL);
     auto *GV = new GlobalVariable(*M, ConstVal->getType(), /*isConstant=*/true,
                                   GlobalVariable::PrivateLinkage, ConstVal,
                                   F.getName() + Twine(".resumers"));

--- a/llvm/lib/Transforms/HipStdPar/HipStdPar.cpp
+++ b/llvm/lib/Transforms/HipStdPar/HipStdPar.cpp
@@ -185,11 +185,14 @@ appendIndirectedGlobal(const GlobalVariable *IndirectionTable,
   Type *NameTy = SymbolListTy->getElementType(0);
   Type *IndirectTy = SymbolListTy->getElementType(1);
 
+  const auto &DL = M->getDataLayout();
   Constant *NameG = getGlobalForName(ToIndirect);
   Constant *IndirectG = getIndirectionGlobal(M);
   Constant *Entry = ConstantStruct::get(
-      SymbolListTy, {ConstantExpr::getAddrSpaceCast(NameG, NameTy),
-                     ConstantExpr::getAddrSpaceCast(IndirectG, IndirectTy)});
+      SymbolListTy,
+      {ConstantExpr::getAddrSpaceCast(NameG, NameTy),
+       ConstantExpr::getAddrSpaceCast(IndirectG, IndirectTy)},
+      &DL);
   SymbolIndirections.push_back(Entry);
 
   return IndirectG;
@@ -208,14 +211,15 @@ static void fillIndirectionTable(GlobalVariable *IndirectionTable,
   M->removeGlobalVariable(IndirectionTable);
   GlobalVariable *Symbols =
       M->getOrInsertGlobal("", ArrayType::get(SymbolTy, SymCnt));
+  const auto &DL = M->getDataLayout();
   Symbols->setLinkage(GlobalValue::LinkageTypes::PrivateLinkage);
-  Symbols->setInitializer(
-      ConstantArray::get(ArrayType::get(SymbolTy, SymCnt), {Indirections}));
+  Symbols->setInitializer(ConstantArray::get(ArrayType::get(SymbolTy, SymCnt),
+                                             {Indirections}, &DL));
   Symbols->setConstant(true);
 
   Constant *ASCSymbols = ConstantExpr::getAddrSpaceCast(Symbols, SymbolListTy);
   Constant *Init = ConstantStruct::get(
-      InitTy, {Count, ASCSymbols, PoisonValue::get(SymbolTy)});
+      InitTy, {Count, ASCSymbols, PoisonValue::get(SymbolTy)}, &DL);
   M->insertGlobalVariable(IndirectionTable);
   IndirectionTable->setInitializer(Init);
 }

--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -2145,10 +2145,11 @@ static void setUsedInitializer(GlobalVariable &V,
   ArrayType *ATy = ArrayType::get(PtrTy, UsedArray.size());
 
   Module *M = V.getParent();
+  const auto &DL = M->getDataLayout();
   V.removeFromParent();
   GlobalVariable *NV = new GlobalVariable(
       *M, ATy, false, GlobalValue::AppendingLinkage,
-      ConstantArray::get(ATy, UsedArray), "", nullptr,
+      ConstantArray::get(ATy, UsedArray, &DL), "", nullptr,
       GlobalVariable::NotThreadLocal, V.getType()->getAddressSpace());
   NV->takeName(&V);
   NV->setSection("llvm.metadata");

--- a/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
+++ b/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
@@ -862,7 +862,8 @@ void LowerTypeTestsModule::buildBitSetsFromGlobalVariables(
       DesiredPadding = alignTo(InitSize, 32) - InitSize;
   }
 
-  Constant *NewInit = ConstantStruct::getAnon(M.getContext(), GlobalInits);
+  Constant *NewInit = ConstantStruct::getAnon(M.getContext(), GlobalInits,
+                                              /*Packed=*/false, &DL);
   auto *CombinedGlobal =
       new GlobalVariable(M, NewInit->getType(), /*isConstant=*/true,
                          GlobalValue::PrivateLinkage, NewInit);

--- a/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
+++ b/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
@@ -366,8 +366,7 @@ void wholeprogramdevirt::setAfterReturnValues(
 }
 
 VirtualCallTarget::VirtualCallTarget(GlobalValue *Fn, const TypeMemberInfo *TM)
-    : Fn(Fn), TM(TM),
-      IsBigEndian(Fn->getDataLayout().isBigEndian()),
+    : Fn(Fn), TM(TM), IsBigEndian(Fn->getDataLayout().isBigEndian()),
       WasDevirt(false) {}
 
 namespace {
@@ -395,8 +394,7 @@ template <> struct llvm::DenseMapInfo<VTableSlot> {
     return DenseMapInfo<Metadata *>::getHashValue(I.TypeID) ^
            DenseMapInfo<uint64_t>::getHashValue(I.ByteOffset);
   }
-  static bool isEqual(const VTableSlot &LHS,
-                      const VTableSlot &RHS) {
+  static bool isEqual(const VTableSlot &LHS, const VTableSlot &RHS) {
     return LHS.TypeID == RHS.TypeID && LHS.ByteOffset == RHS.ByteOffset;
   }
 };
@@ -1604,7 +1602,7 @@ void DevirtModule::applyICallBranchFunnel(VTableSlotInfo &SlotInfo,
       NewArgAttrs.push_back(AttributeSet::get(
           M.getContext(), ArrayRef<Attribute>{Attribute::get(
                               M.getContext(), Attribute::Nest)}));
-      for (unsigned I = 0; I + 2 <  Attrs.getNumAttrSets(); ++I)
+      for (unsigned I = 0; I + 2 < Attrs.getNumAttrSets(); ++I)
         NewArgAttrs.push_back(Attrs.getParamAttrs(I));
       NewCS->setAttributes(
           AttributeList::get(M.getContext(), Attrs.getFnAttrs(),
@@ -2008,7 +2006,6 @@ bool DevirtModule::tryVirtualConstProp(
       for (auto &&Target : TargetsForSlot)
         Target.WasDevirt = true;
 
-
     if (CSByConstantArg.second.isExported()) {
       ResByArg->TheKind = WholeProgramDevirtResolution::ByArg::VirtualConstProp;
       exportConstant(Slot, CSByConstantArg.first, "byte", OffsetByte,
@@ -2042,10 +2039,12 @@ void DevirtModule::rebuildGlobal(VTableBits &B) {
 
   // Build an anonymous global containing the before bytes, followed by the
   // original initializer, followed by the after bytes.
+  const auto &DL = M.getDataLayout();
   auto *NewInit = ConstantStruct::getAnon(
       {ConstantDataArray::get(M.getContext(), B.Before.Bytes),
        B.GV->getInitializer(),
-       ConstantDataArray::get(M.getContext(), B.After.Bytes)});
+       ConstantDataArray::get(M.getContext(), B.After.Bytes)},
+      /*Packed=*/false, &DL);
   auto *NewGV =
       new GlobalVariable(M, NewInit->getType(), B.GV->isConstant(),
                          GlobalVariable::PrivateLinkage, NewInit, "", B.GV);
@@ -2655,7 +2654,8 @@ void DevirtIndex::run() {
     // function implementation at offset S.first.ByteOffset, and add to
     // TargetsForSlot.
     std::vector<ValueInfo> TargetsForSlot;
-    auto TidSummary = ExportSummary.getTypeIdCompatibleVtableSummary(S.first.TypeID);
+    auto TidSummary =
+        ExportSummary.getTypeIdCompatibleVtableSummary(S.first.TypeID);
     assert(TidSummary);
     // The type id summary would have been created while building the NameByGUID
     // map earlier.

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -2552,7 +2552,7 @@ Instruction *InstCombinerImpl::visitSRem(BinaryOperator &I) {
         }
       }
 
-      Constant *NewRHSV = ConstantVector::get(Elts);
+      Constant *NewRHSV = ConstantVector::get(Elts, &getDataLayout());
       if (NewRHSV != C)  // Don't loop on -MININT
         return replaceOperand(I, 1, NewRHSV);
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -1525,7 +1525,7 @@ Value *InstCombinerImpl::SimplifyDemandedVectorElts(Value *V,
     }
 
     // If we changed the constant, return it.
-    Constant *NewCV = ConstantVector::get(Elts);
+    Constant *NewCV = ConstantVector::get(Elts, &getDataLayout());
     return NewCV != C ? NewCV : nullptr;
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
@@ -1507,7 +1507,8 @@ static Instruction *hoistInsEltConst(InsertElementInst &InsElt2,
 
 /// insertelt (shufflevector X, CVec, Mask|insertelt X, C1, CIndex1), C, CIndex
 /// --> shufflevector X, CVec', Mask'
-static Instruction *foldConstantInsEltIntoShuffle(InsertElementInst &InsElt) {
+static Instruction *foldConstantInsEltIntoShuffle(InsertElementInst &InsElt,
+                                                  InstCombinerImpl &IC) {
   auto *Inst = dyn_cast<Instruction>(InsElt.getOperand(0));
   // Bail out if the parent has more than one use. In that case, we'd be
   // replacing the insertelt with a shuffle, and that's not a clear win.
@@ -1560,8 +1561,9 @@ static Instruction *foldConstantInsEltIntoShuffle(InsertElementInst &InsElt) {
 
     // Create new operands for a shuffle that includes the constant of the
     // original insertelt. The old shuffle will be dead now.
-    return new ShuffleVectorInst(Shuf->getOperand(0),
-                                 ConstantVector::get(NewShufElts), NewMaskElts);
+    return new ShuffleVectorInst(
+        Shuf->getOperand(0),
+        ConstantVector::get(NewShufElts, &IC.getDataLayout()), NewMaskElts);
   } else if (auto *IEI = dyn_cast<InsertElementInst>(Inst)) {
     // Transform sequences of insertelements ops with constant data/indexes into
     // a single shuffle op.
@@ -1601,8 +1603,9 @@ static Instruction *foldConstantInsEltIntoShuffle(InsertElementInst &InsElt) {
     }
     // Create new operands for a shuffle that includes the constant of the
     // original insertelt.
-    return new ShuffleVectorInst(IEI->getOperand(0),
-                                 ConstantVector::get(Values), Mask);
+    return new ShuffleVectorInst(
+        IEI->getOperand(0), ConstantVector::get(Values, &IC.getDataLayout()),
+        Mask);
   }
   return nullptr;
 }
@@ -1836,7 +1839,7 @@ Instruction *InstCombinerImpl::visitInsertElementInst(InsertElementInst &IE) {
     }
   }
 
-  if (Instruction *Shuf = foldConstantInsEltIntoShuffle(IE))
+  if (Instruction *Shuf = foldConstantInsEltIntoShuffle(IE, *this))
     return Shuf;
 
   if (Instruction *NewInsElt = hoistInsEltConst(IE, Builder))

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -2349,7 +2349,8 @@ Constant *InstCombinerImpl::unshuffleConstant(ArrayRef<int> ShMask, Constant *C,
     Constant *Splat = C->getSplatValue();
     if (!Splat)
       return nullptr;
-    return ConstantVector::getSplat(NewCTy->getElementCount(), Splat);
+    return ConstantVector::getSplat(NewCTy->getElementCount(), Splat,
+                                    &getDataLayout());
   }
 
   if (cast<FixedVectorType>(NewCTy)->getNumElements() >
@@ -2377,7 +2378,7 @@ Constant *InstCombinerImpl::unshuffleConstant(ArrayRef<int> ShMask, Constant *C,
       NewVecC[ShMask[I]] = CElt;
     }
   }
-  return ConstantVector::get(NewVecC);
+  return ConstantVector::get(NewVecC, &getDataLayout());
 }
 
 // Get the result of `Vector Op Splat` (or Splat Op Vector if \p SplatLHS).
@@ -2385,7 +2386,7 @@ static Constant *constantFoldBinOpWithSplat(unsigned Opcode, Constant *Vector,
                                             Constant *Splat, bool SplatLHS,
                                             const DataLayout &DL) {
   ElementCount EC = cast<VectorType>(Vector->getType())->getElementCount();
-  Constant *LHS = ConstantVector::getSplat(EC, Splat);
+  Constant *LHS = ConstantVector::getSplat(EC, Splat, &DL);
   Constant *RHS = Vector;
   if (!SplatLHS)
     std::swap(LHS, RHS);
@@ -5024,7 +5025,8 @@ Instruction *InstCombinerImpl::visitLandingPadInst(LandingPadInst &LI) {
       if (MakeNewFilter) {
         FilterType = ArrayType::get(FilterType->getElementType(),
                                     NewFilterElts.size());
-        FilterClause = ConstantArray::get(FilterType, NewFilterElts);
+        FilterClause =
+            ConstantArray::get(FilterType, NewFilterElts, &getDataLayout());
         MakeNewInstruction = true;
       }
 

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -2507,9 +2507,12 @@ void ModuleAddressSanitizer::InstrumentGlobalsMachO(
 
     // On recent Mach-O platforms, we emit the global metadata in a way that
     // allows the linker to properly strip dead globals.
+    const auto &DL = M.getDataLayout();
     auto LivenessBinder =
-        ConstantStruct::get(LivenessTy, Initializer->getAggregateElement(0u),
-                            ConstantExpr::getPointerCast(Metadata, IntptrTy));
+        ConstantStruct::get(LivenessTy,
+                            {Initializer->getAggregateElement(0u),
+                             ConstantExpr::getPointerCast(Metadata, IntptrTy)},
+                            &DL);
     GlobalVariable *Liveness = new GlobalVariable(
         M, LivenessTy, false, GlobalVariable::InternalLinkage, LivenessBinder,
         Twine("__asan_binder_") + G->getName());

--- a/llvm/lib/Transforms/Instrumentation/GCOVProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/GCOVProfiling.cpp
@@ -1041,10 +1041,11 @@ void GCOVProfiler::emitModuleInitFunctionPtrs(
 #include "llvm/ProfileData/InstrProfData.inc"
   };
 
+  const auto &DL = M->getDataLayout();
   auto *CovInitGV =
       new GlobalVariable(*M, STy, false, GlobalValue::PrivateLinkage, nullptr,
                          "__llvm_covinit_functions");
-  CovInitGV->setInitializer(ConstantStruct::get(STy, InitFuncPtrs));
+  CovInitGV->setInitializer(ConstantStruct::get(STy, InitFuncPtrs, &DL));
   CovInitGV->setVisibility(GlobalValue::VisibilityTypes::DefaultVisibility);
   CovInitGV->setSection(getInstrProfSectionName(
       IPSK_covinit, M->getTargetTriple().getObjectFormat()));
@@ -1122,6 +1123,7 @@ Function *GCOVProfiler::insertCounterWriteout(
 
   // Collect the relevant data into a large constant data structure that we can
   // walk to write out everything.
+  const auto &DL = M->getDataLayout();
   StructType *StartFileCallArgsTy = StructType::create(
       {Builder.getPtrTy(), Builder.getInt32Ty(), Builder.getInt32Ty()},
       "start_file_args_ty");
@@ -1148,7 +1150,8 @@ Function *GCOVProfiler::insertCounterWriteout(
         StartFileCallArgsTy,
         {Builder.CreateGlobalString(FilenameGcda),
          Builder.getInt32(endian::read32be(Options.Version)),
-         Builder.getInt32(CfgChecksum)});
+         Builder.getInt32(CfgChecksum)},
+        &DL);
 
     SmallVector<Constant *, 8> EmitFunctionCallArgsArray;
     SmallVector<Constant *, 8> EmitArcsCallArgsArray;
@@ -1156,14 +1159,14 @@ Function *GCOVProfiler::insertCounterWriteout(
       uint32_t FuncChecksum = Funcs.empty() ? 0 : Funcs[j]->getFuncChecksum();
       EmitFunctionCallArgsArray.push_back(ConstantStruct::get(
           EmitFunctionCallArgsTy,
-          {Builder.getInt32(j),
-           Builder.getInt32(FuncChecksum),
-           Builder.getInt32(CfgChecksum)}));
+          {Builder.getInt32(j), Builder.getInt32(FuncChecksum),
+           Builder.getInt32(CfgChecksum)},
+          &DL));
 
       GlobalVariable *GV = CountersBySP[j].first;
       unsigned Arcs = cast<ArrayType>(GV->getValueType())->getNumElements();
       EmitArcsCallArgsArray.push_back(ConstantStruct::get(
-          EmitArcsCallArgsTy, {Builder.getInt32(Arcs), GV}));
+          EmitArcsCallArgsTy, {Builder.getInt32(Arcs), GV}, &DL));
     }
     // Create global arrays for the two emit calls.
     int CountersSize = CountersBySP.size();
@@ -1177,7 +1180,7 @@ Function *GCOVProfiler::insertCounterWriteout(
         *M, EmitFunctionCallArgsArrayTy, /*isConstant*/ true,
         GlobalValue::InternalLinkage,
         ConstantArray::get(EmitFunctionCallArgsArrayTy,
-                           EmitFunctionCallArgsArray),
+                           EmitFunctionCallArgsArray, &DL),
         Twine("__llvm_internal_gcov_emit_function_args.") + Twine(i));
     auto *EmitArcsCallArgsArrayTy =
         ArrayType::get(EmitArcsCallArgsTy, CountersSize);
@@ -1186,13 +1189,15 @@ Function *GCOVProfiler::insertCounterWriteout(
     auto *EmitArcsCallArgsArrayGV = new GlobalVariable(
         *M, EmitArcsCallArgsArrayTy, /*isConstant*/ true,
         GlobalValue::InternalLinkage,
-        ConstantArray::get(EmitArcsCallArgsArrayTy, EmitArcsCallArgsArray),
+        ConstantArray::get(EmitArcsCallArgsArrayTy, EmitArcsCallArgsArray, &DL),
         Twine("__llvm_internal_gcov_emit_arcs_args.") + Twine(i));
     EmitArcsCallArgsArrayGV->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
 
     FileInfos.push_back(ConstantStruct::get(
-        FileInfoTy, {StartFileCallArgs, Builder.getInt32(CountersSize),
-                     EmitFunctionCallArgsArrayGV, EmitArcsCallArgsArrayGV}));
+        FileInfoTy,
+        {StartFileCallArgs, Builder.getInt32(CountersSize),
+         EmitFunctionCallArgsArrayGV, EmitArcsCallArgsArrayGV},
+        &DL));
   }
 
   // If we didn't find anything to actually emit, bail on out.
@@ -1214,7 +1219,7 @@ Function *GCOVProfiler::insertCounterWriteout(
   auto *FileInfoArrayTy = ArrayType::get(FileInfoTy, FileInfos.size());
   auto *FileInfoArrayGV = new GlobalVariable(
       *M, FileInfoArrayTy, /*isConstant*/ true, GlobalValue::InternalLinkage,
-      ConstantArray::get(FileInfoArrayTy, FileInfos),
+      ConstantArray::get(FileInfoArrayTy, FileInfos, &DL),
       "__llvm_internal_gcov_emit_file_info");
   FileInfoArrayGV->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
 

--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -613,11 +613,13 @@ void HWAddressSanitizer::createHwasanNote() {
                              ConstantExpr::getPtrToInt(Note, Int64Ty)),
         Int32Ty);
   };
+  const auto &DL = M.getDataLayout();
   Note->setInitializer(ConstantStruct::getAnon(
       {ConstantInt::get(Int32Ty, 8),                           // n_namesz
        ConstantInt::get(Int32Ty, 8),                           // n_descsz
        ConstantInt::get(Int32Ty, ELF::NT_LLVM_HWASAN_GLOBALS), // n_type
-       Name, CreateRelPtr(Start), CreateRelPtr(Stop)}));
+       Name, CreateRelPtr(Start), CreateRelPtr(Stop)},
+      /*Packed=*/false, &DL));
   appendToCompilerUsed(M, Note);
 
   // Create a zero-length global in hwasan_globals so that the linker will
@@ -1723,7 +1725,9 @@ void HWAddressSanitizer::instrumentGlobal(GlobalVariable *GV, uint8_t Tag) {
     std::vector<uint8_t> Init(NewSize - SizeInBytes, 0);
     Init.back() = Tag;
     Constant *Padding = ConstantDataArray::get(*C, Init);
-    Initializer = ConstantStruct::getAnon({Initializer, Padding});
+    const auto &DL = M.getDataLayout();
+    Initializer = ConstantStruct::getAnon({Initializer, Padding},
+                                          /*Packed=*/false, &DL);
   }
 
   auto *NewGV = new GlobalVariable(M, Initializer->getType(), GV->isConstant(),
@@ -1768,7 +1772,9 @@ void HWAddressSanitizer::instrumentGlobal(GlobalVariable *GV, uint8_t Tag) {
     uint32_t Size = std::min(SizeInBytes - DescriptorPos, MaxDescriptorSize);
     auto *SizeAndTag = ConstantInt::get(Int32Ty, Size | (uint32_t(Tag) << 24));
     Descriptor->setComdat(NewGV->getComdat());
-    Descriptor->setInitializer(ConstantStruct::getAnon({GVRelPtr, SizeAndTag}));
+    const auto &DL = M.getDataLayout();
+    Descriptor->setInitializer(
+        ConstantStruct::getAnon({GVRelPtr, SizeAndTag}, /*Packed=*/false, &DL));
     Descriptor->setSection("hwasan_globals");
     Descriptor->setMetadata(LLVMContext::MD_associated,
                             MDNode::get(*C, ValueAsMetadata::get(NewGV)));

--- a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
@@ -1544,9 +1544,10 @@ void InstrLowerer::getOrCreateVTableProfData(GlobalVariable *GV) {
 #undef INSTR_PROF_VTABLE_DATA
   };
 
+  const auto &DL = M.getDataLayout();
   auto *Data =
       new GlobalVariable(M, DataTy, /*constant=*/false, Linkage,
-                         ConstantStruct::get(DataTy, DataVals),
+                         ConstantStruct::get(DataTy, DataVals, &DL),
                          getInstrProfVTableVarPrefix() + PGOVTableName);
 
   Data->setVisibility(Visibility);
@@ -1656,9 +1657,10 @@ InstrLowerer::createRegionCounters(InstrProfCntrInstBase *Inc, StringRef Name,
     // TODO: `Constant::getAllOnesValue()` does not yet accept an array type.
     std::vector<Constant *> InitialValues(NumCounters,
                                           Constant::getAllOnesValue(CounterTy));
-    GV = new GlobalVariable(M, CounterArrTy, false, Linkage,
-                            ConstantArray::get(CounterArrTy, InitialValues),
-                            Name);
+    const auto &DL = M.getDataLayout();
+    GV = new GlobalVariable(
+        M, CounterArrTy, false, Linkage,
+        ConstantArray::get(CounterArrTy, InitialValues, &DL), Name);
     GV->setAlignment(Align(1));
   } else {
     auto *CounterTy = ArrayType::get(Type::getInt64Ty(Ctx), NumCounters);
@@ -1856,7 +1858,8 @@ void InstrLowerer::createDataVariable(InstrProfCntrInstBase *Inc) {
 #define INSTR_PROF_DATA(Type, LLVMType, Name, Init) Init,
 #include "llvm/ProfileData/InstrProfData.inc"
   };
-  Data->setInitializer(ConstantStruct::get(DataTy, DataVals));
+  const auto &DL = M.getDataLayout();
+  Data->setInitializer(ConstantStruct::get(DataTy, DataVals, &DL));
 
   Data->setVisibility(Visibility);
   Data->setSection(

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -1797,9 +1797,10 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
 
   Constant *constToIntPtr(Type *IntPtrTy, uint64_t C) const {
     if (VectorType *VectTy = dyn_cast<VectorType>(IntPtrTy)) {
+      const auto &DL = F.getDataLayout();
       return ConstantVector::getSplat(
-          VectTy->getElementCount(),
-          constToIntPtr(VectTy->getElementType(), C));
+          VectTy->getElementCount(), constToIntPtr(VectTy->getElementType(), C),
+          &DL);
     }
     assert(IntPtrTy == MS.IntptrTy);
     // TODO: Avoid implicit trunc?
@@ -2017,16 +2018,17 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     assert(ShadowTy);
     if (isa<IntegerType>(ShadowTy) || isa<VectorType>(ShadowTy))
       return Constant::getAllOnesValue(ShadowTy);
+    const auto &DL = F.getDataLayout();
     if (ArrayType *AT = dyn_cast<ArrayType>(ShadowTy)) {
       SmallVector<Constant *, 4> Vals(AT->getNumElements(),
                                       getPoisonedShadow(AT->getElementType()));
-      return ConstantArray::get(AT, Vals);
+      return ConstantArray::get(AT, Vals, &DL);
     }
     if (StructType *ST = dyn_cast<StructType>(ShadowTy)) {
       SmallVector<Constant *, 4> Vals;
       for (unsigned i = 0, n = ST->getNumElements(); i < n; i++)
         Vals.push_back(getPoisonedShadow(ST->getElementType(i)));
-      return ConstantStruct::get(ST, Vals);
+      return ConstantStruct::get(ST, Vals, &DL);
     }
     llvm_unreachable("Unexpected shadow type");
   }
@@ -2168,7 +2170,8 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
                                                 : getCleanShadow(Elem);
       }
 
-      Value *ShadowConstant = ConstantVector::get(ShadowVector);
+      const auto &DL = F.getDataLayout();
+      Value *ShadowConstant = ConstantVector::get(ShadowVector, &DL);
       LLVM_DEBUG(dbgs() << "Partial undef constant vector: " << *V << " ==> "
                         << *ShadowConstant << "\n");
 
@@ -3033,7 +3036,8 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
           Elements.push_back(ConstantInt::get(EltTy, 1));
         }
       }
-      ShadowMul = ConstantVector::get(Elements);
+      const auto &DL = I.getModule()->getDataLayout();
+      ShadowMul = ConstantVector::get(Elements, &DL);
     } else {
       if (ConstantInt *Elt = dyn_cast<ConstantInt>(ConstArg)) {
         const APInt &V = Elt->getValue();
@@ -3910,7 +3914,8 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       M = ConstantInt::getBool(F.getContext(), Mask & 1);
       Mask >>= 1;
     }
-    return ConstantVector::get(R);
+    const auto &DL = F.getDataLayout();
+    return ConstantVector::get(R, &DL);
   }
 
   // Calculate output shadow as array of booleans `<n x i1>`, assuming if any
@@ -5657,9 +5662,10 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     // ummla multiplies a 2x8 matrix with an 8x2 matrix. If all entries of the
     // input matrices are equal to 0x1, all entries of the output matrix will
     // be 0x8.
+    const auto &DL = F.getDataLayout();
     Value *FullyInit = ConstantVector::getSplat(
         ExpectedRTy->getElementCount(),
-        ConstantInt::get(ExpectedRTy->getElementType(), 0x8));
+        ConstantInt::get(ExpectedRTy->getElementType(), 0x8), &DL);
 
     ShadowAB = IRB.CreateSExt(IRB.CreateICmpNE(ShadowAB, FullyInit),
                               ShadowAB->getType());

--- a/llvm/lib/Transforms/Instrumentation/PGOCtxProfLowering.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOCtxProfLowering.cpp
@@ -138,16 +138,18 @@ CtxInstrumentationLowerer::CtxInstrumentationLowerer(Module &M,
 #undef _VOLATILE_PTRDECL
 #undef _MUTEXDECL
 
+  const auto &DL = M.getDataLayout();
 #define _PTRDECL(_, __) Constant::getNullValue(PointerTy),
 #define _VOLATILE_PTRDECL(_, __) _PTRDECL(_, __)
 #define _MUTEXDECL(_) Constant::getNullValue(SanitizerMutexType),
 #define _CONTEXT_ROOT                                                          \
   Constant::getIntegerValue(                                                   \
-      PointerTy,                                                               \
-      APInt(M.getDataLayout().getPointerTypeSizeInBits(PointerTy), 1U)),
+      PointerTy, APInt(DL.getPointerTypeSizeInBits(PointerTy), 1U)),
   CannotBeRootInitializer = ConstantStruct::get(
-      FunctionDataTy, {CTXPROF_FUNCTION_DATA(_PTRDECL, _CONTEXT_ROOT,
-                                             _VOLATILE_PTRDECL, _MUTEXDECL)});
+      FunctionDataTy,
+      {CTXPROF_FUNCTION_DATA(_PTRDECL, _CONTEXT_ROOT, _VOLATILE_PTRDECL,
+                             _MUTEXDECL)},
+      &DL);
 #undef _PTRDECL
 #undef _CONTEXT_ROOT
 #undef _VOLATILE_PTRDECL

--- a/llvm/lib/Transforms/Instrumentation/SanitizerCoverage.cpp
+++ b/llvm/lib/Transforms/Instrumentation/SanitizerCoverage.cpp
@@ -806,7 +806,7 @@ ModuleSanitizerCoverage::CreatePCArray(Function &F,
   auto *PCArray =
       CreateFunctionLocalArrayInSection(N * 2, F, PtrTy, SanCovPCsSectionName);
   PCArray->setInitializer(
-      ConstantArray::get(ArrayType::get(PtrTy, N * 2), PCs));
+      ConstantArray::get(ArrayType::get(PtrTy, N * 2), PCs, DL));
   PCArray->setConstant(true);
 
   return PCArray;
@@ -925,7 +925,7 @@ void ModuleSanitizerCoverage::InjectTraceForSwitch(
       ArrayType *ArrayOfInt64Ty = ArrayType::get(Int64Ty, Initializers.size());
       GlobalVariable *GV = new GlobalVariable(
           *CurModule, ArrayOfInt64Ty, false, GlobalVariable::InternalLinkage,
-          ConstantArray::get(ArrayOfInt64Ty, Initializers),
+          ConstantArray::get(ArrayOfInt64Ty, Initializers, DL),
           "__sancov_gen_cov_switch_values");
       if (Options.GatedCallbacks) {
         auto GateBranch = CreateGateBranch(F, FunctionGateCmp, I);
@@ -1235,6 +1235,6 @@ void ModuleSanitizerCoverage::createFunctionControlFlow(Function &F) {
   FunctionCFsArray = CreateFunctionLocalArrayInSection(CFs.size(), F, PtrTy,
                                                        SanCovCFsSectionName);
   FunctionCFsArray->setInitializer(
-      ConstantArray::get(ArrayType::get(PtrTy, CFs.size()), CFs));
+      ConstantArray::get(ArrayType::get(PtrTy, CFs.size()), CFs, DL));
   FunctionCFsArray->setConstant(true);
 }

--- a/llvm/lib/Transforms/Instrumentation/TypeSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/TypeSanitizer.cpp
@@ -381,8 +381,9 @@ bool TypeSanitizer::generateBaseTypeDescriptor(
 
   PushTDSub(NameData);
 
+  const auto &DL = M.getDataLayout();
   StructType *TDTy = StructType::get(C, TDSubTys);
-  Constant *TD = ConstantStruct::get(TDTy, TDSubData);
+  Constant *TD = ConstantStruct::get(TDTy, TDSubData, &DL);
 
   GlobalVariable *TDGV =
       new GlobalVariable(TDTy, true,
@@ -460,11 +461,14 @@ bool TypeSanitizer::generateTypeDescriptor(
   // The descriptor for a scalar is:
   //   [1, base-type pointer, access-type pointer, offset]
 
+  const auto &DL = M.getDataLayout();
   StructType *TDTy =
       StructType::get(IntptrTy, Base->getType(), Access->getType(), IntptrTy);
   Constant *TD =
-      ConstantStruct::get(TDTy, ConstantInt::get(IntptrTy, 1), Base, Access,
-                          ConstantInt::get(IntptrTy, Offset));
+      ConstantStruct::get(TDTy,
+                          {ConstantInt::get(IntptrTy, 1), Base, Access,
+                           ConstantInt::get(IntptrTy, Offset)},
+                          &DL);
 
   bool ShouldBeComdat = cast<GlobalVariable>(Base)->getLinkage() ==
                         GlobalValue::LinkOnceODRLinkage;

--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -639,9 +639,12 @@ static bool processOverflowIntrinsic(WithOverflowInst *WO, LazyValueInfo *LVI) {
   setDeducedOverflowingFlags(NewOp, Opcode, NSW, NUW);
 
   StructType *ST = cast<StructType>(WO->getType());
-  Constant *Struct = ConstantStruct::get(ST,
-      { PoisonValue::get(ST->getElementType(0)),
-        ConstantInt::getFalse(ST->getElementType(1)) });
+  const auto &DL = WO->getDataLayout();
+  Constant *Struct =
+      ConstantStruct::get(ST,
+                          {PoisonValue::get(ST->getElementType(0)),
+                           ConstantInt::getFalse(ST->getElementType(1))},
+                          &DL);
   Value *NewI = B.CreateInsertValue(Struct, NewOp, 0);
   WO->replaceAllUsesWith(NewI);
   WO->eraseFromParent();

--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -1559,7 +1559,7 @@ bool LoopIdiomRecognize::optimizeCRCLoop(const PolynomialInfo &Info) {
             CRCConstants.begin(),
             [CRCTy](const APInt &E) { return ConstantInt::get(CRCTy, E); });
   Constant *ConstArray =
-      ConstantArray::get(ArrayType::get(CRCTy, 256), CRCConstants);
+      ConstantArray::get(ArrayType::get(CRCTy, 256), CRCConstants, DL);
   GlobalVariable *GV =
       new GlobalVariable(M, ConstArray->getType(), true,
                          GlobalValue::PrivateLinkage, ConstArray, ".crctable");

--- a/llvm/lib/Transforms/Utils/CtorUtils.cpp
+++ b/llvm/lib/Transforms/Utils/CtorUtils.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Transforms/Utils/CtorUtils.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Module.h"
@@ -25,7 +26,9 @@
 using namespace llvm;
 
 /// Given a specified llvm.global_ctors list, remove the listed elements.
-static void removeGlobalCtors(GlobalVariable *GCL, const BitVector &CtorsToRemove) {
+static void removeGlobalCtors(GlobalVariable *GCL,
+                              const BitVector &CtorsToRemove) {
+  const auto &DL = GCL->getParent()->getDataLayout();
   // Filter out the initializer elements to remove.
   ConstantArray *OldCA = cast<ConstantArray>(GCL->getInitializer());
   SmallVector<Constant *, 10> CAList;
@@ -36,7 +39,7 @@ static void removeGlobalCtors(GlobalVariable *GCL, const BitVector &CtorsToRemov
   // Create the new array initializer.
   ArrayType *ATy =
       ArrayType::get(OldCA->getType()->getElementType(), CAList.size());
-  Constant *CA = ConstantArray::get(ATy, CAList);
+  Constant *CA = ConstantArray::get(ATy, CAList, &DL);
 
   // If we didn't change the number of elements, don't create a new GV.
   if (CA->getType() == OldCA->getType()) {

--- a/llvm/lib/Transforms/Utils/Evaluator.cpp
+++ b/llvm/lib/Transforms/Utils/Evaluator.cpp
@@ -198,17 +198,17 @@ bool Evaluator::MutableValue::write(Constant *V, APInt Offset,
   return true;
 }
 
-Constant *Evaluator::MutableAggregate::toConstant() const {
+Constant *Evaluator::MutableAggregate::toConstant(const DataLayout &DL) const {
   SmallVector<Constant *, 32> Consts;
   for (const MutableValue &MV : Elements)
-    Consts.push_back(MV.toConstant());
+    Consts.push_back(MV.toConstant(DL));
 
   if (auto *ST = dyn_cast<StructType>(Ty))
-    return ConstantStruct::get(ST, Consts);
+    return ConstantStruct::get(ST, Consts, &DL);
   if (auto *AT = dyn_cast<ArrayType>(Ty))
-    return ConstantArray::get(AT, Consts);
+    return ConstantArray::get(AT, Consts, &DL);
   assert(isa<FixedVectorType>(Ty) && "Must be vector");
-  return ConstantVector::get(Consts);
+  return ConstantVector::get(Consts, &DL);
 }
 
 /// Return the value that would be computed by a load from P after the stores

--- a/llvm/lib/Transforms/Utils/ModuleUtils.cpp
+++ b/llvm/lib/Transforms/Utils/ModuleUtils.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Analysis/VectorUtils.h"
+#include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
@@ -71,11 +72,13 @@ static void appendToGlobalArray(StringRef ArrayName, Module &M, Function *F,
                            GlobalValue::AppendingLinkage, NewInit, ArrayName);
 }
 
-void llvm::appendToGlobalCtors(Module &M, Function *F, int Priority, Constant *Data) {
+void llvm::appendToGlobalCtors(Module &M, Function *F, int Priority,
+                               Constant *Data) {
   appendToGlobalArray("llvm.global_ctors", M, F, Priority, Data);
 }
 
-void llvm::appendToGlobalDtors(Module &M, Function *F, int Priority, Constant *Data) {
+void llvm::appendToGlobalDtors(Module &M, Function *F, int Priority,
+                               Constant *Data) {
   appendToGlobalArray("llvm.global_dtors", M, F, Priority, Data);
 }
 
@@ -106,8 +109,9 @@ static void transformGlobalArray(StringRef ArrayName, Module &M,
   GVCtor->eraseFromParent();
 
   // Create a new initializer.
+  const auto &DL = M.getDataLayout();
   ArrayType *AT = ArrayType::get(EltTy, CurrentCtors.size());
-  Constant *NewInit = ConstantArray::get(AT, CurrentCtors);
+  Constant *NewInit = ConstantArray::get(AT, CurrentCtors, &DL);
 
   // Create the new global variable and replace all uses of
   // the old global variable with the new one.
@@ -133,7 +137,9 @@ static void collectUsedGlobals(GlobalVariable *GV,
     Init.insert(cast<Constant>(Op));
 }
 
-static void appendToUsedList(Module &M, StringRef Name, ArrayRef<GlobalValue *> Values) {
+static void appendToUsedList(Module &M, StringRef Name,
+                             ArrayRef<GlobalValue *> Values) {
+  const auto &DL = M.getDataLayout();
   GlobalVariable *GV = M.getGlobalVariable(Name);
 
   SmallSetVector<Constant *, 16> Init;
@@ -149,9 +155,9 @@ static void appendToUsedList(Module &M, StringRef Name, ArrayRef<GlobalValue *> 
     return;
 
   ArrayType *ATy = ArrayType::get(ArrayEltTy, Init.size());
-  GV = new llvm::GlobalVariable(M, ATy, false, GlobalValue::AppendingLinkage,
-                                ConstantArray::get(ATy, Init.getArrayRef()),
-                                Name);
+  GV = new llvm::GlobalVariable(
+      M, ATy, false, GlobalValue::AppendingLinkage,
+      ConstantArray::get(ATy, Init.getArrayRef(), &DL), Name);
   GV->setSection("llvm.metadata");
 }
 
@@ -165,6 +171,7 @@ void llvm::appendToCompilerUsed(Module &M, ArrayRef<GlobalValue *> Values) {
 
 static void removeFromUsedList(Module &M, StringRef Name,
                                function_ref<bool(Constant *)> ShouldRemove) {
+  const auto &DL = M.getDataLayout();
   GlobalVariable *GV = M.getNamedGlobal(Name);
   if (!GV)
     return;
@@ -184,7 +191,7 @@ static void removeFromUsedList(Module &M, StringRef Name,
     ArrayType *ATy = ArrayType::get(ArrayEltTy, NewInit.size());
     GlobalVariable *NewGV =
         new GlobalVariable(M, ATy, false, GlobalValue::AppendingLinkage,
-                           ConstantArray::get(ATy, NewInit), "", GV,
+                           ConstantArray::get(ATy, NewInit, &DL), "", GV,
                            GV->getThreadLocalMode(), GV->getAddressSpace());
     NewGV->setSection(GV->getSection());
     NewGV->takeName(GV);

--- a/llvm/lib/Transforms/Utils/RelLookupTableConverter.cpp
+++ b/llvm/lib/Transforms/Utils/RelLookupTableConverter.cpp
@@ -15,6 +15,7 @@
 #include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/DataLayout.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
@@ -111,8 +112,7 @@ static bool shouldConvertToRelLookupTable(LookupTableInfo &Info, Module &M,
     if (!GlovalVarOp || !GlovalVarOp->isConstant())
       return false;
 
-    if (!GlovalVarOp->hasLocalLinkage() ||
-        !GlovalVarOp->isDSOLocal() ||
+    if (!GlovalVarOp->hasLocalLinkage() || !GlovalVarOp->isDSOLocal() ||
         !GlovalVarOp->isImplicitDSOLocal())
       return false;
 
@@ -133,6 +133,7 @@ static GlobalVariable *createRelLookupTable(LookupTableInfo &Info,
                                             Function &Func,
                                             GlobalVariable &LookupTable) {
   Module &M = *Func.getParent();
+  const auto &DL = M.getDataLayout();
   ArrayType *IntArrayTy =
       ArrayType::get(Type::getInt32Ty(M.getContext()), Info.Ptrs.size());
 
@@ -156,7 +157,7 @@ static GlobalVariable *createRelLookupTable(LookupTableInfo &Info,
   }
 
   Constant *Initializer =
-      ConstantArray::get(IntArrayTy, RelLookupTableContents);
+      ConstantArray::get(IntArrayTy, RelLookupTableContents, &DL);
   RelLookupTable->setInitializer(Initializer);
   RelLookupTable->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
   RelLookupTable->setAlignment(llvm::Align(4));

--- a/llvm/lib/Transforms/Utils/SanitizerStats.cpp
+++ b/llvm/lib/Transforms/Utils/SanitizerStats.cpp
@@ -46,13 +46,15 @@ void SanitizerStatReport::create(IRBuilder<> &B, SanitizerStatKind SK) {
   IntegerType *IntPtrTy = B.getIntPtrTy(M->getDataLayout());
   ArrayType *StatTy = ArrayType::get(PtrTy, 2);
 
+  const auto &DL = M->getDataLayout();
   Inits.push_back(ConstantArray::get(
       StatTy,
       {Constant::getNullValue(PtrTy),
        ConstantExpr::getIntToPtr(
            ConstantInt::get(IntPtrTy, uint64_t(SK) << (IntPtrTy->getBitWidth() -
                                                        kSanitizerStatKindBits)),
-           PtrTy)}));
+           PtrTy)},
+      &DL));
 
   FunctionType *StatReportTy = FunctionType::get(B.getVoidTy(), PtrTy, false);
   FunctionCallee StatReport =
@@ -73,6 +75,7 @@ void SanitizerStatReport::finish() {
     return;
   }
 
+  const auto &DL = M->getDataLayout();
   PointerType *Int8PtrTy = PointerType::getUnqual(M->getContext());
   IntegerType *Int32Ty = Type::getInt32Ty(M->getContext());
   Type *VoidTy = Type::getVoidTy(M->getContext());
@@ -84,7 +87,8 @@ void SanitizerStatReport::finish() {
       ConstantStruct::getAnon(
           {Constant::getNullValue(Int8PtrTy),
            ConstantInt::get(Int32Ty, Inits.size()),
-           ConstantArray::get(makeModuleStatsArrayTy(), Inits)}));
+           ConstantArray::get(makeModuleStatsArrayTy(), Inits, &DL)},
+          /*Packed=*/false, &DL));
   ModuleStatsGV->replaceAllUsesWith(NewModuleStatsGV);
   ModuleStatsGV->eraseFromParent();
 

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -6962,7 +6962,7 @@ SwitchReplacement::SwitchReplacement(
 
   // Store the table in an array.
   auto *TableTy = ArrayType::get(ValueType, TableSize);
-  Initializer = ConstantArray::get(TableTy, TableContents);
+  Initializer = ConstantArray::get(TableTy, TableContents, &DL);
 
   Kind = LookupTableKind;
 }

--- a/llvm/lib/Transforms/Vectorize/LoadStoreVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoadStoreVectorizer.cpp
@@ -1990,7 +1990,7 @@ Value *Vectorizer::createMaskForExtraElements(const ArrayRef<ChainElem> C,
     else
       MaskElts[VecIdx] = Builder.getInt1(true);
   }
-  return ConstantVector::get(MaskElts);
+  return ConstantVector::get(MaskElts, &DL);
 }
 
 void Vectorizer::deleteExtraElements() {

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -14260,7 +14260,7 @@ class BoUpSLP::ShuffleCostEstimator : public BaseShuffleAnalysis {
                                DL.getTypeStoreSizeInBits(Ty->getScalarType()))),
           Ty->getScalarType());
       if (auto *VTy = dyn_cast<VectorType>(Ty))
-        Res = ConstantVector::getSplat(VTy->getElementCount(), Res);
+        Res = ConstantVector::getSplat(VTy->getElementCount(), Res, &DL);
       return Res;
     }
     return Constant::getAllOnesValue(Ty);
@@ -15045,12 +15045,12 @@ public:
         // types.
         Vals = replicateMask(Vals, VecTy->getNumElements());
       }
-      return ConstantVector::get(Vals);
+      return ConstantVector::get(Vals, R.DL);
     }
     return ConstantVector::getSplat(
         ElementCount::getFixed(
             cast<FixedVectorType>(Root->getType())->getNumElements()),
-        getAllOnesValue(*R.DL, ScalarTy->getScalarType()));
+        getAllOnesValue(*R.DL, ScalarTy->getScalarType()), R.DL);
   }
   InstructionCost createFreeze(InstructionCost Cost) { return Cost; }
   /// Finalize emission of the shuffles.
@@ -21201,7 +21201,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
             assert(SLPReVec && "Only supported by REVEC.");
             MaskValues = replicateMask(MaskValues, VecTy->getNumElements());
           }
-          Constant *MaskValue = ConstantVector::get(MaskValues);
+          Constant *MaskValue = ConstantVector::get(MaskValues, DL);
           NewLI = Builder.CreateMaskedLoad(LoadVecTy, PO, CommonAlignment,
                                            MaskValue);
         } else {
@@ -21276,7 +21276,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
               VecTy->getElementType(),
               Builder.CreateShuffleVector(
                   VecPtr, createReplicatedMask(ScalarTyNumElements, VF)),
-              ConstantVector::get(Indices));
+              ConstantVector::get(Indices, DL));
         }
         // Use the minimum alignment of the gathered loads.
         Align CommonAlignment = computeCommonAlignment<LoadInst>(E->Scalars);
@@ -26368,7 +26368,7 @@ public:
         // Emit code to correctly handle reused reduced values, if required.
         if (OptReusedScalars && !SameScaleFactor) {
           VectorizedRoot = emitReusedOps(VectorizedRoot, Builder, V,
-                                         SameValuesCounter, TrackedToOrig);
+                                         SameValuesCounter, TrackedToOrig, DL);
         }
 
         Type *ScalarTy = VL.front()->getType();
@@ -26415,7 +26415,7 @@ public:
     if (!VectorValuesAndScales.empty())
       VectorizedTree = GetNewVectorizedTree(
           VectorizedTree,
-          emitReduction(Builder, *TTI, ReductionRoot->getType()));
+          emitReduction(Builder, *TTI, ReductionRoot->getType(), DL));
 
     if (!VectorizedTree) {
       if (!CheckForReusedReductionOps) {
@@ -26825,7 +26825,7 @@ private:
   /// sub-registers, combines them with the given reduction operation as a
   /// vector operation and then performs single (small enough) reduction.
   Value *emitReduction(IRBuilderBase &Builder, const TargetTransformInfo &TTI,
-                       Type *DestTy) {
+                       Type *DestTy, const DataLayout &DL) {
     Value *ReducedSubTree = nullptr;
     // Creates reduction and combines with the previous reduction.
     auto CreateSingleOp = [&](Value *Vec, unsigned Scale, bool IsSigned,
@@ -26878,7 +26878,7 @@ private:
                 Vec, getWidenedType(DestTy, getNumElements(Vec->getType())),
                 IsSigned);
           Value *Scale = ConstantVector::getSplat(
-              EC, ConstantInt::get(DestTy->getScalarType(), Cnt));
+              EC, ConstantInt::get(DestTy->getScalarType(), Cnt), &DL);
           LLVM_DEBUG(dbgs() << "SLP: Add (to-mul) " << Cnt << "of " << Vec
                             << ". (HorRdx)\n");
           ++NumVectorInstructions;
@@ -26896,7 +26896,7 @@ private:
         case RecurKind::FAdd: {
           // res = fmul v, n
           Value *Scale =
-              ConstantVector::getSplat(EC, ConstantFP::get(ScalarTy, Cnt));
+              ConstantVector::getSplat(EC, ConstantFP::get(ScalarTy, Cnt), &DL);
           LLVM_DEBUG(dbgs() << "SLP: FAdd (to-fmul) " << Cnt << "of " << Vec
                             << ". (HorRdx)\n");
           ++NumVectorInstructions;
@@ -27080,7 +27080,8 @@ private:
   Value *
   emitReusedOps(Value *VectorizedValue, IRBuilderBase &Builder, BoUpSLP &R,
                 const SmallMapVector<Value *, unsigned, 16> &SameValuesCounter,
-                const DenseMap<Value *, Value *> &TrackedToOrig) {
+                const DenseMap<Value *, Value *> &TrackedToOrig,
+                const DataLayout &DL) {
     assert(IsSupportedHorRdxIdentityOp &&
            "The optimization of matched scalar identity horizontal reductions "
            "must be supported.");
@@ -27100,7 +27101,7 @@ private:
         unsigned Cnt = SameValuesCounter.lookup(TrackedToOrig.at(V));
         Vals.push_back(ConstantInt::get(V->getType(), Cnt, /*IsSigned=*/false));
       }
-      auto *Scale = ConstantVector::get(Vals);
+      auto *Scale = ConstantVector::get(Vals, &DL);
       LLVM_DEBUG(dbgs() << "SLP: Add (to-mul) " << Scale << "of "
                         << VectorizedValue << ". (HorRdx)\n");
       return Builder.CreateMul(VectorizedValue, Scale);
@@ -27158,7 +27159,7 @@ private:
         unsigned Cnt = SameValuesCounter.lookup(TrackedToOrig.at(V));
         Vals.push_back(ConstantFP::get(V->getType(), Cnt));
       }
-      auto *Scale = ConstantVector::get(Vals);
+      auto *Scale = ConstantVector::get(Vals, &DL);
       return Builder.CreateFMul(VectorizedValue, Scale);
     }
     case RecurKind::Sub:

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -1540,7 +1540,7 @@ bool VectorCombine::foldExtractedCmps(Instruction &I) {
                                    PoisonValue::get(VecTy->getElementType()));
   CmpC[Index0] = C0;
   CmpC[Index1] = C1;
-  Value *VCmp = Builder.CreateCmp(Pred, X, ConstantVector::get(CmpC));
+  Value *VCmp = Builder.CreateCmp(Pred, X, ConstantVector::get(CmpC, DL));
   Value *Shuf = createShiftShuffle(VCmp, ExpensiveIndex, CheapIndex, Builder);
   Value *LHS = ConvertToShuf == Ext0 ? Shuf : VCmp;
   Value *RHS = ConvertToShuf == Ext0 ? VCmp : Shuf;
@@ -5428,7 +5428,8 @@ bool VectorCombine::foldInterleaveIntrinsics(Instruction &I) {
   NewSplatVal <<= Width;
   NewSplatVal |= SplatVal0->zext(Width * 2);
   auto *NewSplat = ConstantVector::getSplat(
-      ExtVTy->getElementCount(), ConstantInt::get(F.getContext(), NewSplatVal));
+      ExtVTy->getElementCount(), ConstantInt::get(F.getContext(), NewSplatVal),
+      DL);
 
   IRBuilder<> Builder(&I);
   replaceValue(I, *Builder.CreateBitCast(NewSplat, I.getType()));


### PR DESCRIPTION
Update callers of `ConstantArray::get`, `ConstantStruct::get`/`getAnon`,
`ConstantVector::get`, and `ConstantVector::getSplat` to pass the `DataLayout`
pointer where available.

This is preparatory work for the `ConstantPointerNull` semantic change. After
that change, aggregates containing pointer-null elements need `DataLayout` to
correctly determine whether they can collapse to `ConstantAggregateZero`.
Threading `DL` through callers now (NFC) ensures the eventual semantic change
does not break aggregate collapse for zero-null targets.