### PR TITLE
[NFC] Thread `DataLayout` through helper function signatures for aggregate construction

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/ValueMapper.h
+++ b/llvm/include/llvm/Transforms/Utils/ValueMapper.h
@@ -24,6 +24,7 @@
 namespace llvm {
 
 class Constant;
+class DataLayout;
 class DIBuilder;
 class DbgRecord;
 class Function;
@@ -167,7 +168,8 @@ public:
   LLVM_ABI ValueMapper(ValueToValueMapTy &VM, RemapFlags Flags = RF_None,
                        ValueMapTypeRemapper *TypeMapper = nullptr,
                        ValueMaterializer *Materializer = nullptr,
-                       const MetadataPredicate *IdentityMD = nullptr);
+                       const MetadataPredicate *IdentityMD = nullptr,
+                       const DataLayout *DL = nullptr);
   ValueMapper(ValueMapper &&) = delete;
   ValueMapper(const ValueMapper &) = delete;
   ValueMapper &operator=(ValueMapper &&) = delete;
@@ -237,8 +239,9 @@ inline Value *MapValue(const Value *V, ValueToValueMapTy &VM,
                        RemapFlags Flags = RF_None,
                        ValueMapTypeRemapper *TypeMapper = nullptr,
                        ValueMaterializer *Materializer = nullptr,
-                       const MetadataPredicate *IdentityMD = nullptr) {
-  return ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD)
+                       const MetadataPredicate *IdentityMD = nullptr,
+                       const DataLayout *DL = nullptr) {
+  return ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD, DL)
       .mapValue(*V);
 }
 
@@ -263,8 +266,9 @@ inline Metadata *MapMetadata(const Metadata *MD, ValueToValueMapTy &VM,
                              RemapFlags Flags = RF_None,
                              ValueMapTypeRemapper *TypeMapper = nullptr,
                              ValueMaterializer *Materializer = nullptr,
-                             const MetadataPredicate *IdentityMD = nullptr) {
-  return ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD)
+                             const MetadataPredicate *IdentityMD = nullptr,
+                             const DataLayout *DL = nullptr) {
+  return ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD, DL)
       .mapMetadata(*MD);
 }
 
@@ -273,8 +277,9 @@ inline MDNode *MapMetadata(const MDNode *MD, ValueToValueMapTy &VM,
                            RemapFlags Flags = RF_None,
                            ValueMapTypeRemapper *TypeMapper = nullptr,
                            ValueMaterializer *Materializer = nullptr,
-                           const MetadataPredicate *IdentityMD = nullptr) {
-  return ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD)
+                           const MetadataPredicate *IdentityMD = nullptr,
+                           const DataLayout *DL = nullptr) {
+  return ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD, DL)
       .mapMDNode(*MD);
 }
 
@@ -290,8 +295,9 @@ inline void RemapInstruction(Instruction *I, ValueToValueMapTy &VM,
                              RemapFlags Flags = RF_None,
                              ValueMapTypeRemapper *TypeMapper = nullptr,
                              ValueMaterializer *Materializer = nullptr,
-                             const MetadataPredicate *IdentityMD = nullptr) {
-  ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD)
+                             const MetadataPredicate *IdentityMD = nullptr,
+                             const DataLayout *DL = nullptr) {
+  ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD, DL)
       .remapInstruction(*I);
 }
 
@@ -307,8 +313,9 @@ inline void RemapDbgRecord(Module *M, DbgRecord *DR, ValueToValueMapTy &VM,
                            RemapFlags Flags = RF_None,
                            ValueMapTypeRemapper *TypeMapper = nullptr,
                            ValueMaterializer *Materializer = nullptr,
-                           const MetadataPredicate *IdentityMD = nullptr) {
-  ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD)
+                           const MetadataPredicate *IdentityMD = nullptr,
+                           const DataLayout *DL = nullptr) {
+  ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD, DL)
       .remapDbgRecord(M, *DR);
 }
 
@@ -320,8 +327,9 @@ inline void RemapDbgRecordRange(Module *M,
                                 RemapFlags Flags = RF_None,
                                 ValueMapTypeRemapper *TypeMapper = nullptr,
                                 ValueMaterializer *Materializer = nullptr,
-                                const MetadataPredicate *IdentityMD = nullptr) {
-  ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD)
+                                const MetadataPredicate *IdentityMD = nullptr,
+                                const DataLayout *DL = nullptr) {
+  ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD, DL)
       .remapDbgRecordRange(M, Range);
 }
 
@@ -335,8 +343,10 @@ inline void RemapFunction(Function &F, ValueToValueMapTy &VM,
                           RemapFlags Flags = RF_None,
                           ValueMapTypeRemapper *TypeMapper = nullptr,
                           ValueMaterializer *Materializer = nullptr,
-                          const MetadataPredicate *IdentityMD = nullptr) {
-  ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD).remapFunction(F);
+                          const MetadataPredicate *IdentityMD = nullptr,
+                          const DataLayout *DL = nullptr) {
+  ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD, DL)
+      .remapFunction(F);
 }
 
 /// Version of MapValue with type safety for Constant.
@@ -344,8 +354,9 @@ inline Constant *MapValue(const Constant *V, ValueToValueMapTy &VM,
                           RemapFlags Flags = RF_None,
                           ValueMapTypeRemapper *TypeMapper = nullptr,
                           ValueMaterializer *Materializer = nullptr,
-                          const MetadataPredicate *IdentityMD = nullptr) {
-  return ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD)
+                          const MetadataPredicate *IdentityMD = nullptr,
+                          const DataLayout *DL = nullptr) {
+  return ValueMapper(VM, Flags, TypeMapper, Materializer, IdentityMD, DL)
       .mapConstant(*V);
 }
 

--- a/llvm/lib/Linker/IRMover.cpp
+++ b/llvm/lib/Linker/IRMover.cpp
@@ -447,7 +447,8 @@ public:
         GValMaterializer(*this), LValMaterializer(*this), SharedMDs(SharedMDs),
         IsPerformingImport(IsPerformingImport),
         Mapper(ValueMap, RF_ReuseAndMutateDistinctMDs | RF_IgnoreMissingLocals,
-               &TypeMap, &GValMaterializer),
+               &TypeMap, &GValMaterializer, /*IdentityMD=*/nullptr,
+               &DstM.getDataLayout()),
         IndirectSymbolMCID(Mapper.registerAlternateMappingContext(
             IndirectSymbolValueMap, &LValMaterializer)) {
     ValueMap.getMDMap() = std::move(SharedMDs);

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
@@ -1199,6 +1199,7 @@ namespace {
 /// Handle the remapping of ptr addrspace(7) constants.
 class FatPtrConstMaterializer final : public ValueMaterializer {
   BufferFatPtrToStructTypeMap *TypeMap;
+  const DataLayout *DL;
   // An internal mapper that is used to recurse into the arguments of constants.
   // While the documentation for `ValueMapper` specifies not to use it
   // recursively, examination of the logic in mapValue() shows that it can
@@ -1211,9 +1212,11 @@ class FatPtrConstMaterializer final : public ValueMaterializer {
 public:
   // UnderlyingMap is the value map this materializer will be filling.
   FatPtrConstMaterializer(BufferFatPtrToStructTypeMap *TypeMap,
+                          const DataLayout *DL,
                           ValueToValueMapTy &UnderlyingMap)
-      : TypeMap(TypeMap),
-        InternalMapper(UnderlyingMap, RF_None, TypeMap, this) {}
+      : TypeMap(TypeMap), DL(DL),
+        InternalMapper(UnderlyingMap, RF_None, TypeMap, this,
+                       /*IdentityMD=*/nullptr, DL) {}
   ~FatPtrConstMaterializer() = default;
 
   Value *materialize(Value *V) override;
@@ -1228,12 +1231,14 @@ Constant *FatPtrConstMaterializer::materializeBufferFatPtrConst(Constant *C) {
   if (isa<PoisonValue>(C)) {
     return ConstantStruct::get(NewTy,
                                {PoisonValue::get(NewTy->getElementType(0)),
-                                PoisonValue::get(NewTy->getElementType(1))});
+                                PoisonValue::get(NewTy->getElementType(1))},
+                               DL);
   }
   if (isa<UndefValue>(C)) {
     return ConstantStruct::get(NewTy,
                                {UndefValue::get(NewTy->getElementType(0)),
-                                UndefValue::get(NewTy->getElementType(1))});
+                                UndefValue::get(NewTy->getElementType(1))},
+                               DL);
   }
 
   if (auto *VC = dyn_cast<ConstantVector>(C)) {
@@ -1243,8 +1248,10 @@ Constant *FatPtrConstMaterializer::materializeBufferFatPtrConst(Constant *C) {
         return nullptr;
       auto [Rsrc, Off] = splitLoweredFatBufferConst(NewS);
       auto EC = VC->getType()->getElementCount();
-      return ConstantStruct::get(NewTy, {ConstantVector::getSplat(EC, Rsrc),
-                                         ConstantVector::getSplat(EC, Off)});
+      return ConstantStruct::get(NewTy,
+                                 {ConstantVector::getSplat(EC, Rsrc, DL),
+                                  ConstantVector::getSplat(EC, Off, DL)},
+                                 DL);
     }
     SmallVector<Constant *> Rsrcs;
     SmallVector<Constant *> Offs;
@@ -1256,9 +1263,9 @@ Constant *FatPtrConstMaterializer::materializeBufferFatPtrConst(Constant *C) {
       Rsrcs.push_back(Rsrc);
       Offs.push_back(Off);
     }
-    Constant *RsrcVec = ConstantVector::get(Rsrcs);
-    Constant *OffVec = ConstantVector::get(Offs);
-    return ConstantStruct::get(NewTy, {RsrcVec, OffVec});
+    Constant *RsrcVec = ConstantVector::get(Rsrcs, DL);
+    Constant *OffVec = ConstantVector::get(Offs, DL);
+    return ConstantStruct::get(NewTy, {RsrcVec, OffVec}, DL);
   }
 
   if (isa<GlobalValue>(C))
@@ -2535,9 +2542,10 @@ bool AMDGPULowerBufferFatPointers::run(Module &M, const TargetMachine &TM) {
   SmallVector<Function *> Intrinsics;
   // Keep one big map so as to memoize constants across functions.
   ValueToValueMapTy CloneMap;
-  FatPtrConstMaterializer Materializer(&StructTM, CloneMap);
+  FatPtrConstMaterializer Materializer(&StructTM, &DL, CloneMap);
 
-  ValueMapper LowerInFuncs(CloneMap, RF_None, &StructTM, &Materializer);
+  ValueMapper LowerInFuncs(CloneMap, RF_None, &StructTM, &Materializer,
+                           /*IdentityMD=*/nullptr, &DL);
   for (auto [F, InterfaceChange] : NeedsRemap) {
     Function *NewF = F;
     if (InterfaceChange)

--- a/llvm/lib/Target/DirectX/DXILDataScalarization.cpp
+++ b/llvm/lib/Target/DirectX/DXILDataScalarization.cpp
@@ -352,7 +352,8 @@ bool DataScalarizerVisitor::visitGetElementPtrInst(GetElementPtrInst &GEPI) {
 }
 
 static Constant *transformInitializer(Constant *Init, Type *OrigType,
-                                      Type *NewType, LLVMContext &Ctx) {
+                                      Type *NewType, LLVMContext &Ctx,
+                                      const DataLayout *DL) {
   // Handle ConstantAggregateZero (zero-initialized constants)
   if (isa<ConstantAggregateZero>(Init)) {
     return ConstantAggregateZero::get(NewType);
@@ -375,7 +376,7 @@ static Constant *transformInitializer(Constant *Init, Type *OrigType,
 
     assert(ArrayElements.size() == E &&
            "Expected fixed length constant aggregate for vector initializer!");
-    return ConstantArray::get(cast<ArrayType>(NewType), ArrayElements);
+    return ConstantArray::get(cast<ArrayType>(NewType), ArrayElements, DL);
   }
 
   // Handle array of vectors transformation
@@ -388,11 +389,11 @@ static Constant *transformInitializer(Constant *Init, Type *OrigType,
       // Recursively transform array elements
       Constant *NewElemInit = transformInitializer(
           ArrayInit->getOperand(I), ArrayTy->getElementType(),
-          cast<ArrayType>(NewType)->getElementType(), Ctx);
+          cast<ArrayType>(NewType)->getElementType(), Ctx, DL);
       NewArrayElements.push_back(NewElemInit);
     }
 
-    return ConstantArray::get(cast<ArrayType>(NewType), NewArrayElements);
+    return ConstantArray::get(cast<ArrayType>(NewType), NewArrayElements, DL);
   }
 
   // If not a vector or array, return the original initializer
@@ -425,7 +426,8 @@ static bool findAndReplaceVectors(Module &M) {
 
       if (G.hasInitializer()) {
         Constant *Init = G.getInitializer();
-        Constant *NewInit = transformInitializer(Init, OrigType, NewType, Ctx);
+        Constant *NewInit = transformInitializer(Init, OrigType, NewType, Ctx,
+                                                 &M.getDataLayout());
         NewGlobal->setInitializer(NewInit);
       }
 

--- a/llvm/lib/Target/DirectX/DXILFlattenArrays.cpp
+++ b/llvm/lib/Target/DirectX/DXILFlattenArrays.cpp
@@ -417,7 +417,7 @@ static void collectElements(Constant *Init,
 
 static Constant *transformInitializer(Constant *Init, Type *OrigType,
                                       ArrayType *FlattenedType,
-                                      LLVMContext &Ctx) {
+                                      LLVMContext &Ctx, const DataLayout *DL) {
   // Handle ConstantAggregateZero (zero-initialized constants)
   if (isa<ConstantAggregateZero>(Init))
     return ConstantAggregateZero::get(FlattenedType);
@@ -433,7 +433,7 @@ static Constant *transformInitializer(Constant *Init, Type *OrigType,
   collectElements(Init, FlattenedElements);
   assert(FlattenedType->getNumElements() == FlattenedElements.size() &&
          "The number of collected elements should match the FlattenedType");
-  return ConstantArray::get(FlattenedType, FlattenedElements);
+  return ConstantArray::get(FlattenedType, FlattenedElements, DL);
 }
 
 static void flattenGlobalArrays(
@@ -465,8 +465,8 @@ static void flattenGlobalArrays(
 
     if (G.hasInitializer()) {
       Constant *Init = G.getInitializer();
-      Constant *NewInit =
-          transformInitializer(Init, OrigType, FattenedArrayType, Ctx);
+      Constant *NewInit = transformInitializer(
+          Init, OrigType, FattenedArrayType, Ctx, &M.getDataLayout());
       NewGlobal->setInitializer(NewInit);
     }
     GlobalMap[&G] = NewGlobal;

--- a/llvm/lib/Target/XCore/XCoreLowerThreadLocal.cpp
+++ b/llvm/lib/Target/XCore/XCoreLowerThreadLocal.cpp
@@ -62,15 +62,15 @@ static ArrayType *createLoweredType(Type *OriginalType) {
   return ArrayType::get(OriginalType, MaxThreads);
 }
 
-static Constant *
-createLoweredInitializer(ArrayType *NewType, Constant *OriginalInitializer) {
+static Constant *createLoweredInitializer(ArrayType *NewType,
+                                          Constant *OriginalInitializer,
+                                          const DataLayout *DL) {
   SmallVector<Constant *, 8> Elements(MaxThreads);
   for (unsigned i = 0; i != MaxThreads; ++i) {
     Elements[i] = OriginalInitializer;
   }
-  return ConstantArray::get(NewType, Elements);
+  return ConstantArray::get(NewType, Elements, DL);
 }
-
 
 static bool replaceConstantExprOp(ConstantExpr *CE, Pass *P) {
   do {
@@ -140,8 +140,8 @@ bool XCoreLowerThreadLocal::lowerGlobal(GlobalVariable *GV) {
   ArrayType *NewType = createLoweredType(GV->getValueType());
   Constant *NewInitializer = nullptr;
   if (GV->hasInitializer())
-    NewInitializer = createLoweredInitializer(NewType,
-                                              GV->getInitializer());
+    NewInitializer = createLoweredInitializer(NewType, GV->getInitializer(),
+                                              &M->getDataLayout());
   GlobalVariable *NewGV =
     new GlobalVariable(*M, NewType, GV->isConstant(), GV->getLinkage(),
                        NewInitializer, "", nullptr,

--- a/llvm/lib/Transforms/Scalar/InferAddressSpaces.cpp
+++ b/llvm/lib/Transforms/Scalar/InferAddressSpaces.cpp
@@ -1558,7 +1558,9 @@ bool InferAddressSpacesImpl::rewriteWithNewAddressSpaces(
 
   SmallVector<Instruction *, 16> DeadInstructions;
   ValueToValueMapTy VMap;
-  ValueMapper VMapper(VMap, RF_NoModuleLevelChanges | RF_IgnoreMissingLocals);
+  ValueMapper VMapper(VMap, RF_NoModuleLevelChanges | RF_IgnoreMissingLocals,
+                      /*TypeMapper=*/nullptr, /*Materializer=*/nullptr,
+                      /*IdentityMD=*/nullptr, DL);
 
   // Replaces the uses of the old address expressions with the new ones.
   for (const WeakTrackingVH &WVH : Postorder) {

--- a/llvm/lib/Transforms/Utils/ValueMapper.cpp
+++ b/llvm/lib/Transforms/Utils/ValueMapper.cpp
@@ -121,13 +121,15 @@ class Mapper {
   SmallVector<DelayedBasicBlock, 1> DelayedBBs;
   SmallVector<Constant *, 16> AppendingInits;
   const MetadataPredicate *IdentityMD;
+  const DataLayout *DL;
 
 public:
   Mapper(ValueToValueMapTy &VM, RemapFlags Flags,
          ValueMapTypeRemapper *TypeMapper, ValueMaterializer *Materializer,
-         const MetadataPredicate *IdentityMD)
+         const MetadataPredicate *IdentityMD, const DataLayout *DL)
       : Flags(Flags), TypeMapper(TypeMapper),
-        MCs(1, MappingContext(VM, Materializer)), IdentityMD(IdentityMD) {}
+        MCs(1, MappingContext(VM, Materializer)), IdentityMD(IdentityMD),
+        DL(DL) {}
 
   /// ValueMapper should explicitly call \a flush() before destruction.
   ~Mapper() { assert(!hasWorkToDo() && "Expected to be flushed"); }
@@ -520,11 +522,11 @@ Value *Mapper::mapValue(const Value *V) {
   if (ConstantExpr *CE = dyn_cast<ConstantExpr>(C))
     return getVM()[V] = CE->getWithOperands(Ops, NewTy, false, NewSrcTy);
   if (isa<ConstantArray>(C))
-    return getVM()[V] = ConstantArray::get(cast<ArrayType>(NewTy), Ops);
+    return getVM()[V] = ConstantArray::get(cast<ArrayType>(NewTy), Ops, DL);
   if (isa<ConstantStruct>(C))
-    return getVM()[V] = ConstantStruct::get(cast<StructType>(NewTy), Ops);
+    return getVM()[V] = ConstantStruct::get(cast<StructType>(NewTy), Ops, DL);
   if (isa<ConstantVector>(C))
-    return getVM()[V] = ConstantVector::get(Ops);
+    return getVM()[V] = ConstantVector::get(Ops, DL);
   if (isa<ConstantPtrAuth>(C))
     return getVM()[V] =
                ConstantPtrAuth::get(Ops[0], cast<ConstantInt>(Ops[1]),
@@ -1130,7 +1132,7 @@ void Mapper::mapAppendingVariable(GlobalVariable &GV, GlobalVariable *OldGV,
       auto *E1 = cast<Constant>(mapValue(S->getOperand(0)));
       auto *E2 = cast<Constant>(mapValue(S->getOperand(1)));
       Constant *Null = Constant::getNullValue(VoidPtrTy);
-      NewV = ConstantStruct::get(cast<StructType>(EltTy), E1, E2, Null);
+      NewV = ConstantStruct::get(cast<StructType>(EltTy), {E1, E2, Null}, DL);
     } else {
       NewV = cast_or_null<Constant>(mapValue(V));
     }
@@ -1138,7 +1140,7 @@ void Mapper::mapAppendingVariable(GlobalVariable &GV, GlobalVariable *OldGV,
   }
 
   GV.setInitializer(
-      ConstantArray::get(cast<ArrayType>(GV.getValueType()), Elements));
+      ConstantArray::get(cast<ArrayType>(GV.getValueType()), Elements, DL));
 }
 
 void Mapper::scheduleMapGlobalInitializer(GlobalVariable &GV, Constant &Init,
@@ -1228,8 +1230,9 @@ public:
 ValueMapper::ValueMapper(ValueToValueMapTy &VM, RemapFlags Flags,
                          ValueMapTypeRemapper *TypeMapper,
                          ValueMaterializer *Materializer,
-                         const MetadataPredicate *IdentityMD)
-    : pImpl(new Mapper(VM, Flags, TypeMapper, Materializer, IdentityMD)) {}
+                         const MetadataPredicate *IdentityMD,
+                         const DataLayout *DL)
+    : pImpl(new Mapper(VM, Flags, TypeMapper, Materializer, IdentityMD, DL)) {}
 
 ValueMapper::~ValueMapper() { delete getAsMapper(pImpl); }
 


### PR DESCRIPTION
Add `const DataLayout *DL` parameter to helper functions and classes that
construct aggregate constants but previously had no access to `DataLayout`. This
is the final preparatory step before the `ConstantPointerNull` semantic change,
ensuring aggregate collapse-to-`ConstantAggregateZero` checks have `DataLayout`
awareness in all remaining call sites.