### PR TITLE
[lldb] Rename Lua -> LuaState (NFC)

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Lua/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_lldb_library(lldbPluginScriptInterpreterLua PLUGIN
-  Lua.cpp
+  LuaState.cpp
   ScriptInterpreterLua.cpp
 
   LINK_LIBS

--- a/lldb/source/Plugins/ScriptInterpreter/Lua/LuaState.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/LuaState.h
@@ -1,4 +1,4 @@
-//===-- ScriptInterpreterLua.h ----------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLDB_SOURCE_PLUGINS_SCRIPTINTERPRETER_LUA_LUA_H
-#define LLDB_SOURCE_PLUGINS_SCRIPTINTERPRETER_LUA_LUA_H
+#ifndef LLDB_SOURCE_PLUGINS_SCRIPTINTERPRETER_LUA_LUASTATE_H
+#define LLDB_SOURCE_PLUGINS_SCRIPTINTERPRETER_LUA_LUASTATE_H
 
-#include "lldb/API/SBBreakpointLocation.h"
-#include "lldb/API/SBFrame.h"
 #include "lldb/Core/StructuredDataImpl.h"
 #include "lldb/lldb-types.h"
 #include "llvm/ADT/StringRef.h"
@@ -18,18 +16,16 @@
 
 #include "lua.hpp"
 
-#include <mutex>
-
 namespace lldb_private {
 
 extern "C" {
 int luaopen_lldb(lua_State *L);
 }
 
-class Lua {
+class LuaState {
 public:
-  Lua();
-  ~Lua();
+  LuaState();
+  ~LuaState();
 
   llvm::Error Run(llvm::StringRef buffer);
   llvm::Error RegisterBreakpointCallback(void *baton, const char *body);

--- a/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.h
@@ -18,7 +18,7 @@
 #include "lldb/lldb-enumerations.h"
 
 namespace lldb_private {
-class Lua;
+class LuaState;
 class ScriptInterpreterLua : public ScriptInterpreter {
 public:
   class CommandDataLua : public BreakpointOptions::CommandData {
@@ -75,7 +75,7 @@ public:
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 
-  Lua &GetLua();
+  LuaState &GetLuaState();
 
   llvm::Error EnterSession(lldb::user_id_t debugger_id);
   llvm::Error LeaveSession();
@@ -101,7 +101,7 @@ public:
       StructuredData::ObjectSP extra_args_sp) override;
 
 private:
-  std::unique_ptr<Lua> m_lua;
+  std::unique_ptr<LuaState> m_lua_state;
   bool m_session_is_active = false;
 
   Status RegisterBreakpointCallback(BreakpointOptions &bp_options,

--- a/lldb/unittests/ScriptInterpreter/Lua/LuaTests.cpp
+++ b/lldb/unittests/ScriptInterpreter/Lua/LuaTests.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Plugins/ScriptInterpreter/Lua/Lua.h"
+#include "Plugins/ScriptInterpreter/Lua/LuaState.h"
 #include "Plugins/ScriptInterpreter/Lua/SWIGLuaBridge.h"
 #include "gtest/gtest.h"
 
@@ -29,14 +29,14 @@ lldb_private::lua::SWIGBridge::LLDBSwigLuaWatchpointCallbackFunction(
 }
 
 TEST(LuaTest, RunValid) {
-  Lua lua;
-  llvm::Error error = lua.Run("foo = 1");
+  LuaState lua_state;
+  llvm::Error error = lua_state.Run("foo = 1");
   EXPECT_FALSE(static_cast<bool>(error));
 }
 
 TEST(LuaTest, RunInvalid) {
-  Lua lua;
-  llvm::Error error = lua.Run("nil = foo");
+  LuaState lua_state;
+  llvm::Error error = lua_state.Run("nil = foo");
   EXPECT_TRUE(static_cast<bool>(error));
   EXPECT_EQ(llvm::toString(std::move(error)),
             "[string \"buffer\"]:1: unexpected symbol near 'nil'\n");


### PR DESCRIPTION
Rename Lua to LuaState to avoid conflicts between Lua.h and lua.h on case-insensitive file systems.