### PR TITLE
[clang] allow canonicalizing assumed template names

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -259,6 +259,7 @@ Bug Fixes to Attribute Support
 
 Bug Fixes to C++ Support
 ^^^^^^^^^^^^^^^^^^^^^^^^
+- Fixed a crash on error recovery when dealing with invalid templates. (#GH183075)
 - Fixed a crash when instantiating ``requires`` expressions involving substitution failures in C++ concepts. (#GH176402)
 - Fixed a crash when a default argument is passed to an explicit object parameter. (#GH176639)
 - Fixed a crash when diagnosing an invalid static member function with an explicit object parameter (#GH177741)

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -7244,9 +7244,12 @@ TemplateName ASTContext::getCanonicalTemplateName(TemplateName Name,
     return TemplateName(cast<TemplateDecl>(Template->getCanonicalDecl()));
   }
 
-  case TemplateName::OverloadedTemplate:
   case TemplateName::AssumedTemplate:
-    llvm_unreachable("cannot canonicalize unresolved template");
+    // An assumed template is just a name, so it is already canonical.
+    return Name;
+
+  case TemplateName::OverloadedTemplate:
+    llvm_unreachable("cannot canonicalize overloaded template");
 
   case TemplateName::DependentTemplate: {
     DependentTemplateName *DTN = Name.getAsDependentTemplateName();

--- a/clang/test/SemaTemplate/GH183075.cpp
+++ b/clang/test/SemaTemplate/GH183075.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -verify %s
+
+int bar; // #bar
+
+int foo()
+{
+  // FIXME: Bad error recovery.
+  (void)(baz<> + baz<>);
+  // expected-error@-1 2{{use of undeclared identifier 'baz'; did you mean 'bar'?}}
+  // expected-note@#bar 2{{'bar' declared here}}
+  // expected-error@-3 2{{'bar' is expected to be a non-type template, but instantiated to a class template}}
+  // expected-note@#bar 2{{class template declared here}}
+}


### PR DESCRIPTION
Assumed template names are part of error recovery and encode just a declaration name, making them always canonical. This patch allows them to be canonicalized, which is trivial.

Fixes #183075