### PR TITLE
[flang][NFC] Converted five tests from old lowering to new lowering (part 21)

### DIFF
--- a/flang/test/Lower/host-associated-globals.f90
+++ b/flang/test/Lower/host-associated-globals.f90
@@ -2,7 +2,7 @@
 ! A tuple function argument should not be created for associated globals, and
 ! instead globals should be instantiated with a fir.address_of inside the
 ! contained procedures.
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 module test_mod_used_in_host
   integer :: i, j_in_equiv
@@ -23,7 +23,9 @@ end subroutine
 ! CHECK:  %[[VAL_1:.*]] = arith.constant 0 : index
 ! CHECK:  %[[VAL_2:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_1]] : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
 ! CHECK:  %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<i8>) -> !fir.ptr<i32>
+! CHECK:  %{{.*}}:2 = hlfir.declare %[[VAL_3]] storage(%[[VAL_0]][0]) {uniq_name = "_QMtest_mod_used_in_hostEj_in_equiv"} : (!fir.ptr<i32>, !fir.ref<!fir.array<4xi8>>) -> (!fir.ptr<i32>, !fir.ptr<i32>)
 ! CHECK:  %[[VAL_4:.*]] = fir.address_of(@_QMtest_mod_used_in_hostEnot_in_equiv) : !fir.ref<i32>
+! CHECK:  %{{.*}}:2 = hlfir.declare %[[VAL_4]] {uniq_name = "_QMtest_mod_used_in_hostEnot_in_equiv"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 
 subroutine test_common()
   integer :: i(2)
@@ -42,9 +44,11 @@ end subroutine
 ! CHECK:  %[[VAL_2:.*]] = arith.constant 4 : index
 ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_2]] : (!fir.ref<!fir.array<12xi8>>, index) -> !fir.ref<i8>
 ! CHECK:  %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<i8>) -> !fir.ptr<i32>
+! CHECK:  %{{.*}}:2 = hlfir.declare %[[VAL_4]] storage(%[[VAL_0]][4]) {uniq_name = "_QFtest_commonEj_in_equiv"} : (!fir.ptr<i32>, !fir.ref<!fir.array<12xi8>>) -> (!fir.ptr<i32>, !fir.ptr<i32>)
 ! CHECK:  %[[VAL_6:.*]] = arith.constant 8 : index
 ! CHECK:  %[[VAL_7:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_6]] : (!fir.ref<!fir.array<12xi8>>, index) -> !fir.ref<i8>
 ! CHECK:  %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<i8>) -> !fir.ref<i32>
+! CHECK:  %{{.*}}:2 = hlfir.declare %[[VAL_8]] storage(%[[VAL_0]][8]) {uniq_name = "_QFtest_commonEnot_in_equiv"} : (!fir.ref<i32>, !fir.ref<!fir.array<12xi8>>) -> (!fir.ref<i32>, !fir.ref<i32>)
 
 subroutine saved_equiv()
   integer, save :: i(2)
@@ -62,7 +66,9 @@ end subroutine
 ! CHECK:  %[[VAL_1:.*]] = arith.constant 4 : index
 ! CHECK:  %[[VAL_2:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_1]] : (!fir.ref<!fir.array<8xi8>>, index) -> !fir.ref<i8>
 ! CHECK:  %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<i8>) -> !fir.ptr<i32>
+! CHECK:  %{{.*}}:2 = hlfir.declare %[[VAL_3]] storage(%[[VAL_0]][4]) {uniq_name = "_QFsaved_equivEj_in_equiv"} : (!fir.ptr<i32>, !fir.ref<!fir.array<8xi8>>) -> (!fir.ptr<i32>, !fir.ptr<i32>)
 ! CHECK:  %[[VAL_4:.*]] = fir.address_of(@_QFsaved_equivEnot_in_equiv) : !fir.ref<i32>
+! CHECK:  %{{.*}}:2 = hlfir.declare %[[VAL_4]] {uniq_name = "_QFsaved_equivEnot_in_equiv"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 
 subroutine mixed_capture()
   integer, save :: saved_i
@@ -83,8 +89,10 @@ end subroutine
 ! CHECK:  %[[VAL_2:.*]] = arith.constant 0 : index
 ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_1]], %[[VAL_2]] : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
 ! CHECK:  %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.ref<i8>) -> !fir.ptr<i32>
+! CHECK:  %[[VAL_declare_saved_j:.*]]:2 = hlfir.declare %[[VAL_4]] storage(%[[VAL_1]][0]) {uniq_name = "_QFmixed_captureEsaved_j"} : (!fir.ptr<i32>, !fir.ref<!fir.array<4xi8>>) -> (!fir.ptr<i32>, !fir.ptr<i32>)
 ! CHECK:  %[[VAL_5:.*]] = arith.constant 0 : i32
 ! CHECK:  %[[VAL_6:.*]] = fir.coordinate_of %[[VAL_0]], %[[VAL_5]] : (!fir.ref<tuple<!fir.ref<i32>>>, i32) -> !fir.llvm_ptr<!fir.ref<i32>>
 ! CHECK:  %[[VAL_7:.*]] = fir.load %[[VAL_6]] : !fir.llvm_ptr<!fir.ref<i32>>
-! CHECK:  %[[VAL_9:.*]] = fir.convert %[[VAL_4]] : (!fir.ptr<i32>) -> !fir.ref<i32>
-! CHECK:  fir.call @_QPtest(%[[VAL_9]], %[[VAL_7]]) {{.*}} : (!fir.ref<i32>, !fir.ref<i32>) -> ()
+! CHECK:  %[[VAL_declare_j:.*]]:2 = hlfir.declare %[[VAL_7]] {fortran_attrs = #fir.var_attrs<host_assoc>, uniq_name = "_QFmixed_captureEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:  %[[VAL_9:.*]] = fir.convert %[[VAL_declare_saved_j]]#0 : (!fir.ptr<i32>) -> !fir.ref<i32>
+! CHECK:  fir.call @_QPtest(%[[VAL_9]], %[[VAL_declare_j]]#0) {{.*}} : (!fir.ref<i32>, !fir.ref<i32>) -> ()

--- a/flang/test/Lower/identical-block-merge-disable.f90
+++ b/flang/test/Lower/identical-block-merge-disable.f90
@@ -1,6 +1,6 @@
 ! Test disable identical block merge in the canonicalizer pass in bbc.
 ! Temporary fix for issue #1021.
-! RUN: bbc -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 MODULE DMUMPS_SOL_LR
 IMPLICIT NONE
@@ -36,100 +36,42 @@ END SUBROUTINE DMUMPS_SOL_FWD_LR_SU
 
 END MODULE DMUMPS_SOL_LR
 
-! CHECK-LABEL: func @_QMdmumps_sol_lrPdmumps_sol_fwd_lr_su(
+! CHECK-LABEL: func.func @_QMdmumps_sol_lrPdmumps_sol_fwd_lr_su(
 ! CHECK-SAME:                                              %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}) {
-! CHECK-DAG:     %[[VAL_2:.*]] = arith.constant 0 : i64
-! CHECK-DAG:     %[[VAL_3:.*]] = arith.constant 0 : index
-! CHECK-DAG:     %[[VAL_4:.*]] = arith.constant 1 : i32
-! CHECK:         %[[VAL_5:.*]] = fir.address_of(@_QMdmumps_sol_lrEblr_array) : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_6:.*]] = fir.alloca i32 {bindc_name = "nb_blr", uniq_name = "_QMdmumps_sol_lrFdmumps_sol_fwd_lr_suEnb_blr"}
-! CHECK:         %[[VAL_7:.*]] = fir.alloca i32 {bindc_name = "npartsass", uniq_name = "_QMdmumps_sol_lrFdmumps_sol_fwd_lr_suEnpartsass"}
-! CHECK:         %[[VAL_8:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
-! CHECK:         %[[VAL_9:.*]] = arith.cmpi eq, %[[VAL_8]], %[[VAL_4]] : i32
-! CHECK:         cond_br %[[VAL_9]], ^bb1, ^bb3
-! CHECK:       ^bb1:
-! CHECK:         %[[VAL_10:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_11:.*]]:3 = fir.box_dims %[[VAL_10]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_12:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_13:.*]] = fir.convert %[[VAL_12]] : (i32) -> i64
-! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_11]]#0 : (index) -> i64
-! CHECK:         %[[VAL_15:.*]] = arith.subi %[[VAL_13]], %[[VAL_14]] : i64
-! CHECK:         %[[VAL_16:.*]] = fir.coordinate_of %[[VAL_10]], %[[VAL_15]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_18:.*]] = fir.coordinate_of %[[VAL_16]], panels_l : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_19:.*]] = fir.load %[[VAL_18]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_20:.*]] = fir.box_addr %[[VAL_19]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.ptr<!fir.array<?xi32>>
-! CHECK:         %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (!fir.ptr<!fir.array<?xi32>>) -> i64
-! CHECK:         %[[VAL_22:.*]] = arith.cmpi ne, %[[VAL_21]], %[[VAL_2]] : i64
-! CHECK:         cond_br %[[VAL_22]], ^bb2, ^bb5
-! CHECK:       ^bb2:
-! CHECK:         %[[VAL_23:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_24:.*]]:3 = fir.box_dims %[[VAL_23]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_25:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_26:.*]] = fir.convert %[[VAL_25]] : (i32) -> i64
-! CHECK:         %[[VAL_27:.*]] = fir.convert %[[VAL_24]]#0 : (index) -> i64
-! CHECK:         %[[VAL_28:.*]] = arith.subi %[[VAL_26]], %[[VAL_27]] : i64
-! CHECK:         %[[VAL_29:.*]] = fir.coordinate_of %[[VAL_23]], %[[VAL_28]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_30:.*]] = fir.coordinate_of %[[VAL_29]], panels_l : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_31:.*]] = fir.load %[[VAL_30]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_32:.*]]:3 = fir.box_dims %[[VAL_31]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_33:.*]] = fir.convert %[[VAL_32]]#1 : (index) -> i32
-! CHECK:         fir.store %[[VAL_33]] to %[[VAL_7]] : !fir.ref<i32>
-! CHECK:         %[[VAL_34:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_35:.*]]:3 = fir.box_dims %[[VAL_34]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_36:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i32) -> i64
-! CHECK:         %[[VAL_38:.*]] = fir.convert %[[VAL_35]]#0 : (index) -> i64
-! CHECK:         %[[VAL_39:.*]] = arith.subi %[[VAL_37]], %[[VAL_38]] : i64
-! CHECK:         %[[VAL_40:.*]] = fir.coordinate_of %[[VAL_34]], %[[VAL_39]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_42:.*]] = fir.coordinate_of %[[VAL_40]], begs_blr_static : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_43:.*]] = fir.load %[[VAL_42]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_44:.*]]:3 = fir.box_dims %[[VAL_43]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_45:.*]] = fir.convert %[[VAL_44]]#1 : (index) -> i32
-! CHECK:         %[[VAL_46:.*]] = arith.subi %[[VAL_45]], %[[VAL_4]] : i32
-! CHECK:         fir.store %[[VAL_46]] to %[[VAL_6]] : !fir.ref<i32>
-! CHECK:         br ^bb5
-! CHECK:       ^bb3:
-! CHECK:         %[[VAL_47:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_48:.*]]:3 = fir.box_dims %[[VAL_47]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_49:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_50:.*]] = fir.convert %[[VAL_49]] : (i32) -> i64
-! CHECK:         %[[VAL_51:.*]] = fir.convert %[[VAL_48]]#0 : (index) -> i64
-! CHECK:         %[[VAL_52:.*]] = arith.subi %[[VAL_50]], %[[VAL_51]] : i64
-! CHECK:         %[[VAL_53:.*]] = fir.coordinate_of %[[VAL_47]], %[[VAL_52]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_55:.*]] = fir.coordinate_of %[[VAL_53]], panels_u : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_56:.*]] = fir.load %[[VAL_55]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_57:.*]] = fir.box_addr %[[VAL_56]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.ptr<!fir.array<?xi32>>
-! CHECK:         %[[VAL_58:.*]] = fir.convert %[[VAL_57]] : (!fir.ptr<!fir.array<?xi32>>) -> i64
-! CHECK:         %[[VAL_59:.*]] = arith.cmpi ne, %[[VAL_58]], %[[VAL_2]] : i64
-! CHECK:         cond_br %[[VAL_59]], ^bb4, ^bb5
-! CHECK:       ^bb4:
-! CHECK:         %[[VAL_60:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_61:.*]]:3 = fir.box_dims %[[VAL_60]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_62:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_63:.*]] = fir.convert %[[VAL_62]] : (i32) -> i64
-! CHECK:         %[[VAL_64:.*]] = fir.convert %[[VAL_61]]#0 : (index) -> i64
-! CHECK:         %[[VAL_65:.*]] = arith.subi %[[VAL_63]], %[[VAL_64]] : i64
-! CHECK:         %[[VAL_66:.*]] = fir.coordinate_of %[[VAL_60]], %[[VAL_65]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_67:.*]] = fir.coordinate_of %[[VAL_66]], panels_u : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_68:.*]] = fir.load %[[VAL_67]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_69:.*]]:3 = fir.box_dims %[[VAL_68]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_70:.*]] = fir.convert %[[VAL_69]]#1 : (index) -> i32
-! CHECK:         fir.store %[[VAL_70]] to %[[VAL_7]] : !fir.ref<i32>
-! CHECK:         %[[VAL_71:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_72:.*]]:3 = fir.box_dims %[[VAL_71]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_73:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_74:.*]] = fir.convert %[[VAL_73]] : (i32) -> i64
-! CHECK:         %[[VAL_75:.*]] = fir.convert %[[VAL_72]]#0 : (index) -> i64
-! CHECK:         %[[VAL_76:.*]] = arith.subi %[[VAL_74]], %[[VAL_75]] : i64
-! CHECK:         %[[VAL_77:.*]] = fir.coordinate_of %[[VAL_71]], %[[VAL_76]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_79:.*]] = fir.coordinate_of %[[VAL_77]], begs_blr_static : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_80:.*]] = fir.load %[[VAL_79]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_81:.*]]:3 = fir.box_dims %[[VAL_80]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_82:.*]] = fir.convert %[[VAL_81]]#1 : (index) -> i32
-! CHECK:         %[[VAL_83:.*]] = arith.subi %[[VAL_82]], %[[VAL_4]] : i32
-! CHECK:         fir.store %[[VAL_83]] to %[[VAL_6]] : !fir.ref<i32>
-! CHECK:         br ^bb5
-! CHECK:       ^bb5:
+! CHECK-DAG:     %[[VAL_2:.*]] = fir.address_of(@_QMdmumps_sol_lrEblr_array) : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
+! CHECK-DAG:     %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMdmumps_sol_lrEblr_array"}
+! CHECK-DAG:     %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_0]] dummy_scope %{{.*}} arg 1 {fortran_attrs = #fir.var_attrs<intent_in>, uniq_name = "_QMdmumps_sol_lrFdmumps_sol_fwd_lr_suEiwhdlr"}
+! CHECK-DAG:     %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_1]] dummy_scope %{{.*}} arg 2 {fortran_attrs = #fir.var_attrs<intent_in>, uniq_name = "_QMdmumps_sol_lrFdmumps_sol_fwd_lr_suEmtype"}
+! CHECK:         %[[VAL_6:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<i32>
+! CHECK:         %[[VAL_7:.*]] = arith.cmpi eq, %[[VAL_6]], %{{.*}} : i32
+! CHECK:         fir.if %[[VAL_7]] {
+! CHECK:           %[[VAL_8:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
+! CHECK:           %[[VAL_9:.*]] = fir.load %[[VAL_4]]#0 : !fir.ref<i32>
+! CHECK:           %[[VAL_10:.*]] = hlfir.designate %[[VAL_8]] (%{{.*}}) : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<{{.*}}>>>>, i64) -> !fir.ref<!fir.type<{{.*}}>>
+! CHECK:           %[[VAL_11:.*]] = hlfir.designate %[[VAL_10]]{"panels_l"} {fortran_attrs = #fir.var_attrs<pointer>}
+! CHECK:           %[[VAL_12:.*]] = fir.load %[[VAL_11]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_13:.*]] = fir.box_addr %[[VAL_12]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.ptr<!fir.array<?xi32>>
+! CHECK:           %[[VAL_14:.*]] = arith.cmpi ne, %{{.*}}, %{{.*}} : i64
+! CHECK:           fir.if %[[VAL_14]] {
+! CHECK:             {{.*}} = hlfir.designate %{{.*}}{"panels_l"}
+! CHECK:             hlfir.assign %{{.*}} to %{{.*}}#0 : i32, !fir.ref<i32>
+! CHECK:             {{.*}} = hlfir.designate %{{.*}}{"begs_blr_static"}
+! CHECK:             hlfir.assign %{{.*}} to %{{.*}}#0 : i32, !fir.ref<i32>
+! CHECK:           }
+! CHECK:         } else {
+! CHECK:           %[[VAL_15:.*]] = fir.load %[[VAL_8_else:.*]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<{{.*}}>>>>>
+! CHECK:           %[[VAL_16:.*]] = hlfir.designate %[[VAL_15]] (%{{.*}}) : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<{{.*}}>>>>, i64) -> !fir.ref<!fir.type<{{.*}}>>
+! CHECK:           %[[VAL_17:.*]] = hlfir.designate %[[VAL_16]]{"panels_u"} {fortran_attrs = #fir.var_attrs<pointer>}
+! CHECK:           %[[VAL_18:.*]] = fir.load %[[VAL_17]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_19:.*]] = fir.box_addr %[[VAL_18]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.ptr<!fir.array<?xi32>>
+! CHECK:           %[[VAL_20:.*]] = arith.cmpi ne, %{{.*}}, %{{.*}} : i64
+! CHECK:           fir.if %[[VAL_20]] {
+! CHECK:             {{.*}} = hlfir.designate %{{.*}}{"panels_u"}
+! CHECK:             hlfir.assign %{{.*}} to %{{.*}}#0 : i32, !fir.ref<i32>
+! CHECK:             {{.*}} = hlfir.designate %{{.*}}{"begs_blr_static"}
+! CHECK:             hlfir.assign %{{.*}} to %{{.*}}#0 : i32, !fir.ref<i32>
+! CHECK:           }
+! CHECK:         }
 ! CHECK:         return
 ! CHECK:       }
 

--- a/flang/test/Lower/implicit-call-mismatch.f90
+++ b/flang/test/Lower/implicit-call-mismatch.f90
@@ -2,7 +2,7 @@
 ! Lowering must close the eyes and do as if it did not know
 ! about the function definition since semantic lets these
 ! programs through with a warning.
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! Test reference to non-char procedure conversion.
 
@@ -15,52 +15,45 @@ subroutine pass_int_to_proc(a)
   call takes_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_int_to_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<i32>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: fir.call @_QPtakes_proc(%[[boxProc]]) {{.*}}: (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_proc) : (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((!fir.boxproc<() -> ()>) -> ()) -> ((!fir.ref<i32>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<i32>) -> ()
 
 subroutine pass_logical_to_proc(a)
   logical(4) :: a
   call takes_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_logical_to_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.logical<4>>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<!fir.logical<4>>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: fir.call @_QPtakes_proc(%[[boxProc]]) {{.*}}: (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_proc) : (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((!fir.boxproc<() -> ()>) -> ()) -> ((!fir.ref<!fir.logical<4>>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<!fir.logical<4>>) -> ()
 
 subroutine pass_real_to_proc(a)
   real(8) :: a
   call takes_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_real_to_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<f64>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<f64>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: fir.call @_QPtakes_proc(%[[boxProc]]) {{.*}}: (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_proc) : (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((!fir.boxproc<() -> ()>) -> ()) -> ((!fir.ref<f64>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<f64>) -> ()
 
 subroutine pass_complex_to_proc(a)
   complex(4) :: a
   call takes_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_complex_to_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<complex<f32>>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<complex<f32>>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: fir.call @_QPtakes_proc(%[[boxProc]]) {{.*}}: (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_proc) : (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((!fir.boxproc<() -> ()>) -> ()) -> ((!fir.ref<complex<f32>>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<complex<f32>>) -> ()
 
 subroutine pass_char_to_proc(a)
   character(8) :: a
   call takes_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_char_to_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.boxchar<1>
-! CHECK: %[[charAndLen:.*]]:2 = fir.unboxchar %[[arg0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK: %[[charRef:.*]] = fir.convert %[[charAndLen]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,8>>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[charRef]] : (!fir.ref<!fir.char<1,8>>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: fir.call @_QPtakes_proc(%[[boxProc]]) {{.*}}: (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_proc) : (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((!fir.boxproc<() -> ()>) -> ()) -> ((!fir.boxchar<1>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.boxchar<1>) -> ()
 
 subroutine pass_dt_to_proc(a)
   type :: dt
@@ -71,20 +64,18 @@ subroutine pass_dt_to_proc(a)
   call takes_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_dt_to_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QFpass_dt_to_procTdt{i:i32,j:i32}>>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<!fir.type<_QFpass_dt_to_procTdt{i:i32,j:i32}>>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: fir.call @_QPtakes_proc(%[[boxProc]]) {{.*}}: (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_proc) : (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((!fir.boxproc<() -> ()>) -> ()) -> ((!fir.ref<!fir.type<{{.*}}>>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<!fir.type<{{.*}}>>) -> ()
 
 subroutine pass_array_to_proc(a)
   integer(4) :: a(10,10)
   call takes_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_array_to_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.array<10x10xi32>>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<!fir.array<10x10xi32>>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: fir.call @_QPtakes_proc(%[[boxProc]]) {{.*}}: (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_proc) : (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((!fir.boxproc<() -> ()>) -> ()) -> ((!fir.ref<!fir.array<10x10xi32>>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<!fir.array<10x10xi32>>) -> ()
 
 ! Test procedure conversion.
 
@@ -93,19 +84,16 @@ subroutine pass_char_proc_to_proc(a)
   call takes_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_char_proc_to_proc(
-! CHECK-SAME: %[[arg0:.*]]: tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[extract:.*]] = fir.extract_value %[[arg0]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
-! CHECK: %[[procAddr:.*]] = fir.box_addr %[[extract]] : (!fir.boxproc<() -> ()>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: fir.call @_QPtakes_proc(%[[boxProc]]) {{.*}}: (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_proc) : (!fir.boxproc<() -> ()>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((!fir.boxproc<() -> ()>) -> ()) -> ((tuple<!fir.boxproc<() -> ()>, i64>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
 
 subroutine pass_proc_to_proc(a)
   external :: a
   call takes_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_proc_to_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.boxproc<() -> ()>
-! CHECK: fir.call @_QPtakes_proc(%[[arg0]]) {{.*}}: (!fir.boxproc<() -> ()>) -> ()
+! CHECK: fir.call @_QPtakes_proc({{.*}}) {{.*}}: (!fir.boxproc<() -> ()>) -> ()
 
 ! Test conversion from procedure to other data types.
 
@@ -114,48 +102,59 @@ subroutine test_conversion_from_proc
   external :: proc
 
   ! CHECK: %[[proc:.*]] = fir.address_of(@_QPproc) : () -> ()
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : (() -> ()) -> !fir.ref<i32>
-  ! CHECK: fir.call @_QPpass_int_to_proc(%[[convert]])
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : (() -> ()) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_int_to_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]]
+  ! CHECK: fir.call %[[convert]](%[[boxproc]])
   call pass_int_to_proc(proc)
 
   ! CHECK: %[[proc:.*]] = fir.address_of(@_QPproc) : () -> ()
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : (() -> ()) -> !fir.ref<!fir.logical<4>>
-  ! CHECK: fir.call @_QPpass_logical_to_proc(%[[convert]])
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : (() -> ()) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_logical_to_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]]
+  ! CHECK: fir.call %[[convert]](%[[boxproc]])
   call pass_logical_to_proc(proc)
 
   ! CHECK: %[[proc:.*]] = fir.address_of(@_QPproc) : () -> ()
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : (() -> ()) -> !fir.ref<f64>
-  ! CHECK: fir.call @_QPpass_real_to_proc(%[[convert]])
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : (() -> ()) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_real_to_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]]
+  ! CHECK: fir.call %[[convert]](%[[boxproc]])
   call pass_real_to_proc(proc)
 
   ! CHECK: %[[proc:.*]] = fir.address_of(@_QPproc) : () -> ()
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : (() -> ()) -> !fir.ref<complex<f32>>
-  ! CHECK: fir.call @_QPpass_complex_to_proc(%[[convert]])
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : (() -> ()) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_complex_to_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]]
+  ! CHECK: fir.call %[[convert]](%[[boxproc]])
   call pass_complex_to_proc(proc)
 
   ! CHECK: %[[proc:.*]] = fir.address_of(@_QPproc) : () -> ()
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : (() -> ()) -> !fir.ref<!fir.char<1,?>>
-  ! CHECK: %[[box:.*]] = fir.emboxchar %[[convert]], %c0{{.*}} : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
-  ! CHECK: fir.call @_QPpass_char_to_proc(%[[box]])
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : (() -> ()) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_char_to_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]]
+  ! CHECK: fir.call %[[convert]](%[[boxproc]])
   call pass_char_to_proc(proc)
 
   ! CHECK: %[[proc:.*]] = fir.address_of(@_QPproc) : () -> ()
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : (() -> ()) -> !fir.ref<!fir.type<_QFpass_dt_to_procTdt{i:i32,j:i32}>>
-  ! CHECK: fir.call @_QPpass_dt_to_proc(%[[convert]])
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : (() -> ()) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_dt_to_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]]
+  ! CHECK: fir.call %[[convert]](%[[boxproc]])
   call pass_dt_to_proc(proc)
 
   ! CHECK: %[[proc:.*]] = fir.address_of(@_QPproc) : () -> ()
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : (() -> ()) -> !fir.ref<!fir.array<10x10xi32>>
-  ! CHECK: fir.call @_QPpass_array_to_proc(%[[convert]])
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : (() -> ()) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_array_to_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]]
+  ! CHECK: fir.call %[[convert]](%[[boxproc]])
   call pass_array_to_proc(proc)
 
   ! CHECK: %[[proc:.*]] = fir.address_of(@_QPproc) : () -> ()
   ! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[proc]] : (() -> ()) -> !fir.boxproc<() -> ()>
-  ! CHECK: %[[len:.*]] = fir.undefined i64
-  ! CHECK: %[[tuple:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
-  ! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple]], %[[boxProc]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
-  ! CHECK: %[[tuple3:.*]] = fir.insert_value %[[tuple2]], %[[len]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
-  ! CHECK: fir.call @_QPpass_char_proc_to_proc(%[[tuple3]]) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_char_proc_to_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]]
+  ! CHECK: fir.call %[[convert]](%[[boxProc]])
   call pass_char_proc_to_proc(proc)
 
   ! CHECK: %[[proc:.*]] = fir.address_of(@_QPproc) : () -> ()
@@ -175,73 +174,45 @@ subroutine pass_int_to_char_proc(a)
   call takes_char_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_int_to_char_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<i32>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: %[[charLen:.*]] = fir.undefined i64
-! CHECK: %[[tuple:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple]], %[[boxProc]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple3:.*]] = fir.insert_value %[[tuple2]], %[[charLen]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: fir.call @_QPtakes_char_proc(%[[tuple3]]) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_char_proc) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((tuple<!fir.boxproc<() -> ()>, i64>) -> ()) -> ((!fir.ref<i32>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<i32>) -> ()
 
 subroutine pass_logical_to_char_proc(a)
   logical(4) :: a
   call takes_char_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_logical_to_char_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.logical<4>>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<!fir.logical<4>>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: %[[charLen:.*]] = fir.undefined i64
-! CHECK: %[[tuple:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple]], %[[boxProc]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple3:.*]] = fir.insert_value %[[tuple2]], %[[charLen]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: fir.call @_QPtakes_char_proc(%[[tuple3]]) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_char_proc) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((tuple<!fir.boxproc<() -> ()>, i64>) -> ()) -> ((!fir.ref<!fir.logical<4>>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<!fir.logical<4>>) -> ()
 
 subroutine pass_real_to_char_proc(a)
   real(8) :: a
   call takes_char_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_real_to_char_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<f64>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<f64>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: %[[charLen:.*]] = fir.undefined i64
-! CHECK: %[[tuple:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple]], %[[boxProc]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple3:.*]] = fir.insert_value %[[tuple2]], %[[charLen]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: fir.call @_QPtakes_char_proc(%[[tuple3]]) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_char_proc) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((tuple<!fir.boxproc<() -> ()>, i64>) -> ()) -> ((!fir.ref<f64>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<f64>) -> ()
 
 subroutine pass_complex_to_char_proc(a)
   complex(4) :: a
   call takes_char_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_complex_to_char_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<complex<f32>>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<complex<f32>>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: %[[charLen:.*]] = fir.undefined i64
-! CHECK: %[[tuple:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple]], %[[boxProc]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple3:.*]] = fir.insert_value %[[tuple2]], %[[charLen]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: fir.call @_QPtakes_char_proc(%[[tuple3]]) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_char_proc) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((tuple<!fir.boxproc<() -> ()>, i64>) -> ()) -> ((!fir.ref<complex<f32>>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<complex<f32>>) -> ()
 
 subroutine pass_char_to_char_proc(a)
   character(8) :: a
   call takes_char_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_char_to_char_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.boxchar<1>
-! CHECK: %[[charRefAndLen:.*]]:2 = fir.unboxchar %[[arg0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK: %[[charRef:.*]] = fir.convert %[[charRefAndLen]]#0 : (!fir.ref<!fir.char<1,?>>) -> !fir.ref<!fir.char<1,8>>
-! CHECK: %[[charLen:.*]] = arith.constant 8 : index
-! CHECK: %[[procAddr:.*]] = fir.convert %[[charRef]] : (!fir.ref<!fir.char<1,8>>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: %[[charLen2:.*]] = fir.convert %[[charLen]] : (index) -> i64
-! CHECK: %[[tuple:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple]], %[[boxProc]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple3:.*]] = fir.insert_value %[[tuple2]], %[[charLen2]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: fir.call @_QPtakes_char_proc(%[[tuple3]]) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_char_proc) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((tuple<!fir.boxproc<() -> ()>, i64>) -> ()) -> ((!fir.boxchar<1>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.boxchar<1>) -> ()
 
 subroutine pass_dt_to_char_proc(a)
   type :: dt
@@ -252,28 +223,18 @@ subroutine pass_dt_to_char_proc(a)
   call takes_char_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_dt_to_char_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.type<_QFpass_dt_to_char_procTdt{i:i32,j:i32}>>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<!fir.type<_QFpass_dt_to_char_procTdt{i:i32,j:i32}>>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: %[[charLen:.*]] = fir.undefined i64
-! CHECK: %[[tuple:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple]], %[[boxProc]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple3:.*]] = fir.insert_value %[[tuple2]], %[[charLen]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: fir.call @_QPtakes_char_proc(%[[tuple3]]) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_char_proc) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((tuple<!fir.boxproc<() -> ()>, i64>) -> ()) -> ((!fir.ref<!fir.type<{{.*}}>>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<!fir.type<{{.*}}>>) -> ()
 
 subroutine pass_array_to_char_proc(a)
   integer(4) :: a(10,10)
   call takes_char_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_array_to_char_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<!fir.array<10x10xi32>>
-! CHECK: %[[procAddr:.*]] = fir.convert %[[arg0]] : (!fir.ref<!fir.array<10x10xi32>>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: %[[charLen:.*]] = fir.undefined i64
-! CHECK: %[[tuple:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple]], %[[boxProc]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple3:.*]] = fir.insert_value %[[tuple2]], %[[charLen]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: fir.call @_QPtakes_char_proc(%[[tuple3]]) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_char_proc) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((tuple<!fir.boxproc<() -> ()>, i64>) -> ()) -> ((!fir.ref<!fir.array<10x10xi32>>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.ref<!fir.array<10x10xi32>>) -> ()
 
 ! Test procedure conversion.
 
@@ -282,29 +243,16 @@ subroutine pass_proc_to_char_proc(a)
   call takes_char_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_proc_to_char_proc(
-! CHECK-SAME: %[[arg0:.*]]: !fir.boxproc<() -> ()>
-! CHECK: %[[procAddr:.*]] = fir.box_addr %[[arg0]] : (!fir.boxproc<() -> ()>) -> (() -> ())
-! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: %[[charLen:.*]] = fir.undefined i64
-! CHECK: %[[tuple:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple]], %[[boxProc]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple3:.*]] = fir.insert_value %[[tuple2]], %[[charLen]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: fir.call @_QPtakes_char_proc(%[[tuple3]]) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_addr:.*]] = fir.address_of(@_QPtakes_char_proc) : (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: %[[VAL_conv:.*]] = fir.convert %[[VAL_addr]] : ((tuple<!fir.boxproc<() -> ()>, i64>) -> ()) -> ((!fir.boxproc<() -> ()>) -> ())
+! CHECK: fir.call %[[VAL_conv]]({{.*}}) {{.*}}: (!fir.boxproc<() -> ()>) -> ()
 
 subroutine pass_char_proc_to_char_proc(a)
   character(8), external :: a
   call takes_char_proc(a)
 end subroutine
 ! CHECK-LABEL: func.func @_QPpass_char_proc_to_char_proc(
-! CHECK-SAME: %[[arg0:.*]]: tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[boxProc:.*]] = fir.extract_value %arg0, [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>) -> !fir.boxproc<() -> ()>
-! CHECK: %[[procAddr:.*]] = fir.box_addr %[[boxProc]] : (!fir.boxproc<() -> ()>) -> (() -> ())
-! CHECK: %[[charLen:.*]] = arith.constant 8 : i64
-! CHECK: %[[boxProc2:.*]] = fir.emboxproc %[[procAddr]] : (() -> ()) -> !fir.boxproc<() -> ()>
-! CHECK: %[[tuple:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple]], %[[boxProc2]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: %[[tuple3:.*]] = fir.insert_value %[[tuple2]], %[[charLen]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>
-! CHECK: fir.call @_QPtakes_char_proc(%[[tuple3]]) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
+! CHECK: fir.call @_QPtakes_char_proc({{.*}}) {{.*}}: (tuple<!fir.boxproc<() -> ()>, i64>) -> ()
 
 ! Test conversion from character procedure to other data types.
 
@@ -312,51 +260,65 @@ end subroutine
 subroutine test_conversion_from_char_proc
   character(8), external :: char_proc
 
-  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : (!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : ((!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>) -> !fir.ref<i32>
-  ! CHECK: fir.call @_QPpass_int_to_char_proc(%[[convert]])
+  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : {{.*}} -> !fir.boxchar<1>
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : ({{.*}} -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_int_to_char_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]] : ((!fir.ref<i32>) -> ()) -> ((tuple<!fir.boxproc<() -> ()>, i64>) -> ())
+  ! CHECK: fir.call %[[convert]]({{.*}})
   call pass_int_to_char_proc(char_proc)
 
-  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : (!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : ((!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>) -> !fir.ref<!fir.logical<4>>
-  ! CHECK: fir.call @_QPpass_logical_to_char_proc(%[[convert]])
+  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : {{.*}} -> !fir.boxchar<1>
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : ({{.*}} -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_logical_to_char_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]] : ((!fir.ref<!fir.logical<4>>) -> ()) -> ((tuple<!fir.boxproc<() -> ()>, i64>) -> ())
+  ! CHECK: fir.call %[[convert]]({{.*}})
   call pass_logical_to_char_proc(char_proc)
 
-  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : (!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : ((!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>) -> !fir.ref<f64>
-  ! CHECK: fir.call @_QPpass_real_to_char_proc(%[[convert]])
+  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : {{.*}} -> !fir.boxchar<1>
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : ({{.*}} -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_real_to_char_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]] : ((!fir.ref<f64>) -> ()) -> ((tuple<!fir.boxproc<() -> ()>, i64>) -> ())
+  ! CHECK: fir.call %[[convert]]({{.*}})
   call pass_real_to_char_proc(char_proc)
 
-  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : (!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : ((!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>) -> !fir.ref<complex<f32>>
-  ! CHECK: fir.call @_QPpass_complex_to_char_proc(%[[convert]])
+  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : {{.*}} -> !fir.boxchar<1>
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : ({{.*}} -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_complex_to_char_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]] : ((!fir.ref<complex<f32>>) -> ()) -> ((tuple<!fir.boxproc<() -> ()>, i64>) -> ())
+  ! CHECK: fir.call %[[convert]]({{.*}})
   call pass_complex_to_char_proc(char_proc)
 
-  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : (!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : ((!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>) -> !fir.ref<!fir.char<1,?>>
-  ! CHECK: %[[len:.*]] = fir.undefined index
-  ! CHECK: %[[box:.*]] = fir.emboxchar %[[convert]], %[[len]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
-  ! CHECK: fir.call @_QPpass_char_to_char_proc(%[[box]])
+  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : {{.*}} -> !fir.boxchar<1>
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : ({{.*}} -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_char_to_char_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]] : ((!fir.boxchar<1>) -> ()) -> ((tuple<!fir.boxproc<() -> ()>, i64>) -> ())
+  ! CHECK: fir.call %[[convert]]({{.*}})
   call pass_char_to_char_proc(char_proc)
 
-  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : (!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : ((!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>) -> !fir.ref<!fir.type<_QFpass_dt_to_char_procTdt{i:i32,j:i32}>>
-  ! CHECK: fir.call @_QPpass_dt_to_char_proc(%[[convert]])
+  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : {{.*}} -> !fir.boxchar<1>
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : ({{.*}} -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_dt_to_char_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]] : ((!fir.ref<!fir.type<{{.*}}>>) -> ()) -> ((tuple<!fir.boxproc<() -> ()>, i64>) -> ())
+  ! CHECK: fir.call %[[convert]]({{.*}})
   call pass_dt_to_char_proc(char_proc)
 
-  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : (!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>
-  ! CHECK: %[[convert:.*]] = fir.convert %[[proc]] : ((!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>) -> !fir.ref<!fir.array<10x10xi32>>
-  ! CHECK: fir.call @_QPpass_array_to_char_proc(%[[convert]])
+  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : {{.*}} -> !fir.boxchar<1>
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : ({{.*}} -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_array_to_char_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]] : ((!fir.ref<!fir.array<10x10xi32>>) -> ()) -> ((tuple<!fir.boxproc<() -> ()>, i64>) -> ())
+  ! CHECK: fir.call %[[convert]]({{.*}})
   call pass_array_to_char_proc(char_proc)
 
-  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : (!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>
-  ! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[proc]] : ((!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
-  ! CHECK: fir.call @_QPpass_proc_to_char_proc(%[[boxProc]])
+  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : {{.*}} -> !fir.boxchar<1>
+  ! CHECK: %[[boxproc:.*]] = fir.emboxproc %[[proc]] : ({{.*}} -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[callee:.*]] = fir.address_of(@_QPpass_proc_to_char_proc)
+  ! CHECK: %[[convert:.*]] = fir.convert %[[callee]] : ((!fir.boxproc<() -> ()>) -> ()) -> ((tuple<!fir.boxproc<() -> ()>, i64>) -> ())
+  ! CHECK: fir.call %[[convert]]({{.*}})
   call pass_proc_to_char_proc(char_proc)
 
-  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : (!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>
+  ! CHECK: %[[proc:.*]] = fir.address_of(@_QPchar_proc) : {{.*}} -> !fir.boxchar<1>
   ! CHECK: %[[len:.*]] = arith.constant 8 : i64
-  ! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[proc]] : ((!fir.ref<!fir.char<1,8>>, index) -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
+  ! CHECK: %[[boxProc:.*]] = fir.emboxproc %[[proc]] : ({{.*}} -> !fir.boxchar<1>) -> !fir.boxproc<() -> ()>
   ! CHECK: %[[tuple:.*]] = fir.undefined tuple<!fir.boxproc<() -> ()>, i64>
   ! CHECK: %[[tuple2:.*]] = fir.insert_value %[[tuple]], %[[boxProc]], [0 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, !fir.boxproc<() -> ()>) -> tuple<!fir.boxproc<() -> ()>, i64>
   ! CHECK: %[[tuple3:.*]] = fir.insert_value %[[tuple2]], %[[len]], [1 : index] : (tuple<!fir.boxproc<() -> ()>, i64>, i64) -> tuple<!fir.boxproc<() -> ()>, i64>

--- a/flang/test/Lower/implicit-interface.f90
+++ b/flang/test/Lower/implicit-interface.f90
@@ -1,27 +1,28 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
-! CHECK-LABEL: func @_QPchar_return_callee(
-! CHECK-SAME: %{{.*}}: !fir.ref<!fir.char<1,10>>{{.*}}, %{{.*}}: index{{.*}}, %{{.*}}: !fir.ref<i32>{{.*}}) -> !fir.boxchar<1> {
+! CHECK-LABEL: func.func @_QPchar_return_callee(
+! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<!fir.char<1,10>>, %[[VAL_1:.*]]: index, %[[VAL_2:.*]]: !fir.ref<i32>{{.*}}) -> !fir.boxchar<1> {
 function char_return_callee(i)
   character(10) :: char_return_callee
   integer :: i
 end function
 
-! CHECK-LABEL: @_QPtest_char_return_caller()
+! CHECK-LABEL: func.func @_QPtest_char_return_caller()
 subroutine test_char_return_caller
   character(10) :: char_return_caller
   ! CHECK: fir.call @_QPchar_return_caller({{.*}}) {{.*}}: (!fir.ref<!fir.char<1,10>>, index, !fir.ref<i32>) -> !fir.boxchar<1>
   print *, char_return_caller(5)
 end subroutine
 
-! CHECK-LABEL: func @_QPtest_passing_char_array()
+! CHECK-LABEL: func.func @_QPtest_passing_char_array()
 subroutine test_passing_char_array
   character(len=3) :: x(4)
   call sub_taking_a_char_array(x)
   ! CHECK-DAG: %[[xarray:.*]] = fir.alloca !fir.array<4x!fir.char<1,3>>
   ! CHECK-DAG: %[[c3:.*]] = arith.constant 3 : index
-  ! CHECK-DAG: %[[xbuff:.*]] = fir.convert %[[xarray]] : (!fir.ref<!fir.array<4x!fir.char<1,3>>>) -> !fir.ref<!fir.char<1,?>>
-  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[xbuff]], %[[c3]] : (!fir.ref<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+  ! CHECK-DAG: %[[declare:.*]]:2 = hlfir.declare %[[xarray]](%{{.*}}) typeparams %[[c3]]
+  ! CHECK-DAG: %[[xbuff:.*]] = fir.convert %[[declare]]#0 : (!fir.ref<!fir.array<4x!fir.char<1,3>>>) -> !fir.ref<!fir.char<1,3>>
+  ! CHECK: %[[boxchar:.*]] = fir.emboxchar %[[xbuff]], %[[c3]] : (!fir.ref<!fir.char<1,3>>, index) -> !fir.boxchar<1>
   ! CHECK: fir.call @_QPsub_taking_a_char_array(%[[boxchar]]) {{.*}}: (!fir.boxchar<1>) -> ()
 end subroutine
 

--- a/flang/test/Lower/integer-operations.f90
+++ b/flang/test/Lower/integer-operations.f90
@@ -1,109 +1,139 @@
-! RUN: bbc -hlfir=false %s -o "-" | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s
 
 ! Test integer intrinsic operation lowering to fir.
 
-! CHECK-LABEL:eq0_test
+! CHECK-LABEL: func.func @_QPeq0_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32> {{.*}}, %[[arg1:.*]]: !fir.ref<i32> {{.*}})
+! CHECK: %[[VAL_1:.*]]:2 = hlfir.declare %[[arg0]]
+! CHECK: %[[VAL_2:.*]]:2 = hlfir.declare %[[arg1]]
+! CHECK-DAG: %[[reg1:.*]] = fir.load %[[VAL_1]]#0
+! CHECK-DAG: %[[reg2:.*]] = fir.load %[[VAL_2]]#0
+! CHECK: %[[reg3:.*]] = arith.cmpi eq, %[[reg1]], %[[reg2]] : i32
+! CHECK: fir.convert %[[reg3]] : (i1) -> !fir.logical<4>
 LOGICAL FUNCTION eq0_test(x0, x1)
 INTEGER(4) :: x0
 INTEGER(4) :: x1
-! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
-! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:[[reg3:%[0-9]+]] = arith.cmpi eq, [[reg1]], [[reg2]] : i32
-! CHECK:fir.convert [[reg3]] {{.*}} -> !fir.logical<4>
 eq0_test = x0 .EQ. x1
 END FUNCTION
 
-! CHECK-LABEL:ne1_test
+! CHECK-LABEL: func.func @_QPne1_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32> {{.*}}, %[[arg1:.*]]: !fir.ref<i32> {{.*}})
+! CHECK: %[[VAL_1:.*]]:2 = hlfir.declare %[[arg0]]
+! CHECK: %[[VAL_2:.*]]:2 = hlfir.declare %[[arg1]]
+! CHECK-DAG: %[[reg1:.*]] = fir.load %[[VAL_1]]#0
+! CHECK-DAG: %[[reg2:.*]] = fir.load %[[VAL_2]]#0
+! CHECK: %[[reg3:.*]] = arith.cmpi ne, %[[reg1]], %[[reg2]] : i32
+! CHECK: fir.convert %[[reg3]] : (i1) -> !fir.logical<4>
 LOGICAL FUNCTION ne1_test(x0, x1)
 INTEGER(4) :: x0
 INTEGER(4) :: x1
-! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
-! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:[[reg3:%[0-9]+]] = arith.cmpi ne, [[reg1]], [[reg2]] : i32
-! CHECK:fir.convert [[reg3]] {{.*}} -> !fir.logical<4>
 ne1_test = x0 .NE. x1
 END FUNCTION
 
-! CHECK-LABEL:lt2_test
+! CHECK-LABEL: func.func @_QPlt2_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32> {{.*}}, %[[arg1:.*]]: !fir.ref<i32> {{.*}})
+! CHECK: %[[VAL_1:.*]]:2 = hlfir.declare %[[arg0]]
+! CHECK: %[[VAL_2:.*]]:2 = hlfir.declare %[[arg1]]
+! CHECK-DAG: %[[reg1:.*]] = fir.load %[[VAL_1]]#0
+! CHECK-DAG: %[[reg2:.*]] = fir.load %[[VAL_2]]#0
+! CHECK: %[[reg3:.*]] = arith.cmpi slt, %[[reg1]], %[[reg2]] : i32
+! CHECK: fir.convert %[[reg3]] : (i1) -> !fir.logical<4>
 LOGICAL FUNCTION lt2_test(x0, x1)
 INTEGER(4) :: x0
 INTEGER(4) :: x1
-! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
-! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:[[reg3:%[0-9]+]] = arith.cmpi slt, [[reg1]], [[reg2]] : i32
-! CHECK:fir.convert [[reg3]] {{.*}} -> !fir.logical<4>
 lt2_test = x0 .LT. x1
 END FUNCTION
 
-! CHECK-LABEL:le3_test
+! CHECK-LABEL: func.func @_QPle3_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32> {{.*}}, %[[arg1:.*]]: !fir.ref<i32> {{.*}})
+! CHECK: %[[VAL_1:.*]]:2 = hlfir.declare %[[arg0]]
+! CHECK: %[[VAL_2:.*]]:2 = hlfir.declare %[[arg1]]
+! CHECK-DAG: %[[reg1:.*]] = fir.load %[[VAL_1]]#0
+! CHECK-DAG: %[[reg2:.*]] = fir.load %[[VAL_2]]#0
+! CHECK: %[[reg3:.*]] = arith.cmpi sle, %[[reg1]], %[[reg2]] : i32
+! CHECK: fir.convert %[[reg3]] : (i1) -> !fir.logical<4>
 LOGICAL FUNCTION le3_test(x0, x1)
 INTEGER(4) :: x0
 INTEGER(4) :: x1
-! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
-! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:[[reg3:%[0-9]+]] = arith.cmpi sle, [[reg1]], [[reg2]] : i32
-! CHECK:fir.convert [[reg3]] {{.*}} -> !fir.logical<4>
 le3_test = x0 .LE. x1
 END FUNCTION
 
-! CHECK-LABEL:gt4_test
+! CHECK-LABEL: func.func @_QPgt4_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32> {{.*}}, %[[arg1:.*]]: !fir.ref<i32> {{.*}})
+! CHECK: %[[VAL_1:.*]]:2 = hlfir.declare %[[arg0]]
+! CHECK: %[[VAL_2:.*]]:2 = hlfir.declare %[[arg1]]
+! CHECK-DAG: %[[reg1:.*]] = fir.load %[[VAL_1]]#0
+! CHECK-DAG: %[[reg2:.*]] = fir.load %[[VAL_2]]#0
+! CHECK: %[[reg3:.*]] = arith.cmpi sgt, %[[reg1]], %[[reg2]] : i32
+! CHECK: fir.convert %[[reg3]] : (i1) -> !fir.logical<4>
 LOGICAL FUNCTION gt4_test(x0, x1)
 INTEGER(4) :: x0
 INTEGER(4) :: x1
-! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
-! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:[[reg3:%[0-9]+]] = arith.cmpi sgt, [[reg1]], [[reg2]] : i32
-! CHECK:fir.convert [[reg3]] {{.*}} -> !fir.logical<4>
 gt4_test = x0 .GT. x1
 END FUNCTION
 
-! CHECK-LABEL:ge5_test
+! CHECK-LABEL: func.func @_QPge5_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32> {{.*}}, %[[arg1:.*]]: !fir.ref<i32> {{.*}})
+! CHECK: %[[VAL_1:.*]]:2 = hlfir.declare %[[arg0]]
+! CHECK: %[[VAL_2:.*]]:2 = hlfir.declare %[[arg1]]
+! CHECK-DAG: %[[reg1:.*]] = fir.load %[[VAL_1]]#0
+! CHECK-DAG: %[[reg2:.*]] = fir.load %[[VAL_2]]#0
+! CHECK: %[[reg3:.*]] = arith.cmpi sge, %[[reg1]], %[[reg2]] : i32
+! CHECK: fir.convert %[[reg3]] : (i1) -> !fir.logical<4>
 LOGICAL FUNCTION ge5_test(x0, x1)
 INTEGER(4) :: x0
 INTEGER(4) :: x1
-! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
-! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:[[reg3:%[0-9]+]] = arith.cmpi sge, [[reg1]], [[reg2]] : i32
-! CHECK:fir.convert [[reg3]] {{.*}} -> !fir.logical<4>
 ge5_test = x0 .GE. x1
 END FUNCTION
 
-! CHECK-LABEL:add6_test
+! CHECK-LABEL: func.func @_QPadd6_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32> {{.*}}, %[[arg1:.*]]: !fir.ref<i32> {{.*}})
+! CHECK: %[[VAL_1:.*]]:2 = hlfir.declare %[[arg0]]
+! CHECK: %[[VAL_2:.*]]:2 = hlfir.declare %[[arg1]]
+! CHECK-DAG: %[[reg1:.*]] = fir.load %[[VAL_1]]#0
+! CHECK-DAG: %[[reg2:.*]] = fir.load %[[VAL_2]]#0
+! CHECK: arith.addi %[[reg1]], %[[reg2]] : i32
 INTEGER(4) FUNCTION add6_test(x0, x1)
 INTEGER(4) :: x0
 INTEGER(4) :: x1
-! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
-! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:addi [[reg1]], [[reg2]] : i32
 add6_test = x0 + x1
 END FUNCTION
 
-! CHECK-LABEL:sub7_test
+! CHECK-LABEL: func.func @_QPsub7_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32> {{.*}}, %[[arg1:.*]]: !fir.ref<i32> {{.*}})
+! CHECK: %[[VAL_1:.*]]:2 = hlfir.declare %[[arg0]]
+! CHECK: %[[VAL_2:.*]]:2 = hlfir.declare %[[arg1]]
+! CHECK-DAG: %[[reg1:.*]] = fir.load %[[VAL_1]]#0
+! CHECK-DAG: %[[reg2:.*]] = fir.load %[[VAL_2]]#0
+! CHECK: arith.subi %[[reg1]], %[[reg2]] : i32
 INTEGER(4) FUNCTION sub7_test(x0, x1)
 INTEGER(4) :: x0
 INTEGER(4) :: x1
-! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
-! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:subi [[reg1]], [[reg2]] : i32
 sub7_test = x0 - x1
 END FUNCTION
 
-! CHECK-LABEL:mult8_test
+! CHECK-LABEL: func.func @_QPmult8_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32> {{.*}}, %[[arg1:.*]]: !fir.ref<i32> {{.*}})
+! CHECK: %[[VAL_1:.*]]:2 = hlfir.declare %[[arg0]]
+! CHECK: %[[VAL_2:.*]]:2 = hlfir.declare %[[arg1]]
+! CHECK-DAG: %[[reg1:.*]] = fir.load %[[VAL_1]]#0
+! CHECK-DAG: %[[reg2:.*]] = fir.load %[[VAL_2]]#0
+! CHECK: arith.muli %[[reg1]], %[[reg2]] : i32
 INTEGER(4) FUNCTION mult8_test(x0, x1)
 INTEGER(4) :: x0
 INTEGER(4) :: x1
-! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
-! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:muli [[reg1]], [[reg2]] : i32
 mult8_test = x0 * x1
 END FUNCTION
 
-! CHECK-LABEL:div9_test
+! CHECK-LABEL: func.func @_QPdiv9_test(
+! CHECK-SAME: %[[arg0:.*]]: !fir.ref<i32> {{.*}}, %[[arg1:.*]]: !fir.ref<i32> {{.*}})
+! CHECK: %[[VAL_1:.*]]:2 = hlfir.declare %[[arg0]]
+! CHECK: %[[VAL_2:.*]]:2 = hlfir.declare %[[arg1]]
+! CHECK-DAG: %[[reg1:.*]] = fir.load %[[VAL_1]]#0
+! CHECK-DAG: %[[reg2:.*]] = fir.load %[[VAL_2]]#0
+! CHECK: arith.divsi %[[reg1]], %[[reg2]] : i32
 INTEGER(4) FUNCTION div9_test(x0, x1)
 INTEGER(4) :: x0
 INTEGER(4) :: x1
-! CHECK-DAG:[[reg1:%[0-9]+]] = fir.load %arg0
-! CHECK-DAG:[[reg2:%[0-9]+]] = fir.load %arg1
-! CHECK:arith.divsi [[reg1]], [[reg2]] : i32
 div9_test = x0 / x1
 END FUNCTION


### PR DESCRIPTION
Tests converted from test/Lower: host-associated-globals.f90, identical-block-merge-disable.f90, implicit-call-mismatch.f90, implicit-interface.f90, integer-operations.f90