### PR TITLE
[Clang][NFC] Correct the test in PR183010

### DIFF
--- a/clang/test/SemaTemplate/concepts.cpp
+++ b/clang/test/SemaTemplate/concepts.cpp
@@ -1714,10 +1714,9 @@ template <typename T>
   requires false
 void f() = delete;
 
-template <typename T>
 struct Bar {};
 
-template <typename T> using Foo = Bar<T>;
+template <typename T> using Foo = Bar;
 
 template <typename T> void use() {
   f<Foo<T>>();


### PR DESCRIPTION
We should test non-type-dependent type aliases.

(I copy-pasted wrong code which is used for debugging. Thanks to Richard for spotting that)