### PR TITLE
[lld][LoongArch] Fix range checking of R_LARCH_*_PCADD_HI20 relocations on 64-bit

### DIFF
--- a/lld/ELF/Arch/LoongArch.cpp
+++ b/lld/ELF/Arch/LoongArch.cpp
@@ -734,7 +734,7 @@ void LoongArch::relocate(uint8_t *loc, const Relocation &rel,
   case R_LARCH_TLS_GD_PCADD_HI20:
   case R_LARCH_TLS_DESC_PCADD_HI20: {
     uint64_t hi = val + 0x800;
-    checkInt(ctx, loc, val, 32, rel);
+    checkInt(ctx, loc, SignExtend64(hi, ctx.arg.wordsize * 8) >> 12, 20, rel);
     write32le(loc, setJ20(read32le(loc), extractBits(hi, 31, 12)));
     return;
   }

--- a/lld/ELF/Arch/LoongArch.cpp
+++ b/lld/ELF/Arch/LoongArch.cpp
@@ -874,7 +874,7 @@ void LoongArch::relocate(uint8_t *loc, const Relocation &rel,
   case R_LARCH_TLS_GD_PCADD_HI20:
   case R_LARCH_TLS_DESC_PCADD_HI20: {
     uint64_t hi = val + 0x800;
-    checkInt(ctx, loc, val, 32, rel);
+    checkInt(ctx, loc, SignExtend64(hi, ctx.arg.wordsize * 8) >> 12, 20, rel);
     write32le(loc, setJ20(read32le(loc), extractBits(hi, 31, 12)));
     return;
   }

--- a/lld/test/ELF/loongarch-pcadd-hi20.s
+++ b/lld/test/ELF/loongarch-pcadd-hi20.s
@@ -1,0 +1,32 @@
+# REQUIRES: loongarch
+
+# RUN: llvm-mc --filetype=obj --triple=loongarch64-unknown-elf %s -o %t.o
+
+# RUN: ld.lld %t.o --section-start=.text=0x20000 --section-start=.data=0x21000 --section-start=.got=0x21080 -o %t.1
+# RUN: llvm-objdump --no-show-raw-insn -d %t.1 | FileCheck --match-full-lines %s
+# CHECK: 20000: pcaddu12i $t0, 1
+# CHECK: 20004: pcaddu12i $t0, 1
+
+# RUN: not ld.lld %t.o --section-start=.text=0x80021000 --section-start=.data=0x20000 --section-start=.got=0x20080 -o /dev/null 2>&1 | \
+# RUN:   FileCheck -DFILE=%t.o --check-prefix=ERROR-RANGE-LOWER %s
+# ERROR-RANGE-LOWER: error: [[FILE]]:(.text+0x0): relocation R_LARCH_PCADD_HI20 out of range: -524289 is not in [-524288, 524287]; references section '.data'
+# ERROR-RANGE-LOWER: error: [[FILE]]:(.text+0x4): relocation R_LARCH_GOT_PCADD_HI20 out of range: -524289 is not in [-524288, 524287]; references section '.data'
+
+# RUN: not ld.lld %t.o --section-start=.text=0x20000 --section-start=.data=0x8001f800 --section-start=.got=0x8001f880 -o /dev/null 2>&1 | \
+# RUN:   FileCheck -DFILE=%t.o --check-prefix=ERROR-RANGE-UPPER %s
+# ERROR-RANGE-UPPER: error: [[FILE]]:(.text+0x0): relocation R_LARCH_PCADD_HI20 out of range: 524288 is not in [-524288, 524287]; references section '.data'
+# ERROR-RANGE-UPPER: error: [[FILE]]:(.text+0x4): relocation R_LARCH_GOT_PCADD_HI20 out of range: 524288 is not in [-524288, 524287]; references section '.data'
+
+.global _start
+
+_start:
+1:
+  pcaddu12i $t0, 0
+  .reloc 1b, R_LARCH_PCADD_HI20, .data
+
+1:
+  pcaddu12i $t0, 0
+  .reloc 1b, R_LARCH_GOT_PCADD_HI20, .data
+
+.data
+  .word 0


### PR DESCRIPTION
According to the la-abi-specs, the `R_LARCH_*_PCADD_HI20` relocations are also used on 64-bit LoongArch. Fix the range checking accordingly.