### PR TITLE
[bazel][libc] Add some deps for layering_check

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -638,6 +638,7 @@ libc_support_library(
     deps = [
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
+        ":__support_macros_config",
     ],
 )
 
@@ -647,6 +648,7 @@ libc_support_library(
     deps = [
         ":__support_cpp_iterator",
         ":__support_macros_attributes",
+        ":__support_macros_config",
     ],
 )
 
@@ -657,7 +659,10 @@ libc_support_library(
         ":__support_cpp_limits",
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
+        ":__support_macros_config",
+        ":__support_macros_properties_compiler",
         ":__support_macros_sanitizer",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -676,6 +681,7 @@ libc_support_library(
     deps = [
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
+        ":__support_macros_config",
     ],
 )
 
@@ -695,6 +701,8 @@ libc_support_library(
         "__support_cpp_type_traits",
         "__support_cpp_utility",
         "__support_macros_attributes",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -703,6 +711,7 @@ libc_support_library(
     hdrs = ["src/__support/CPP/tuple.h"],
     deps = [
         "__support_cpp_utility",
+        ":__support_cpp_type_traits",
     ],
 )
 
@@ -723,6 +732,8 @@ libc_support_library(
     hdrs = ["src/__support/CPP/new.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
+        ":__support_macros_properties_compiler",
         ":__support_macros_properties_os",
         ":func_aligned_alloc",
         ":func_free",
@@ -734,7 +745,10 @@ libc_support_library(
     name = "__support_cpp_optional",
     hdrs = ["src/__support/CPP/optional.h"],
     deps = [
+        ":__support_cpp_type_traits",
         ":__support_cpp_utility",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
         ":hdr_stdint_proxy",
     ],
 )
@@ -745,9 +759,12 @@ libc_support_library(
     deps = [
         ":__support_cpp_algorithm",
         ":__support_cpp_bit",
+        ":__support_cpp_limits",
         ":__support_cpp_tuple",
         ":__support_cpp_type_traits",
+        ":__support_cpp_utility",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":hdr_stdint_proxy",
     ],
 )
@@ -759,6 +776,8 @@ libc_support_library(
         ":__support_cpp_array",
         ":__support_cpp_limits",
         ":__support_cpp_type_traits",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
     ],
 )
 
@@ -768,6 +787,7 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_cpp_limits",
+        ":__support_macros_config",
     ],
 )
 
@@ -779,6 +799,7 @@ libc_support_library(
         ":__support_cpp_string_view",
         ":__support_cpp_type_traits",
         ":__support_integer_to_string",
+        ":__support_macros_config",
     ],
 )
 
@@ -789,6 +810,7 @@ libc_support_library(
         ":__support_common",
         ":__support_cpp_string_view",
         ":__support_integer_to_string",
+        ":__support_macros_config",
         ":func_free",
         ":func_malloc",
         ":func_realloc",
@@ -823,6 +845,7 @@ libc_support_library(
     deps = [
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
+        ":__support_macros_config",
     ],
 )
 
@@ -832,6 +855,7 @@ libc_support_library(
     deps = [
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_macros_properties_architectures",
         ":hdr_stdint_proxy",
     ],
@@ -844,7 +868,10 @@ libc_support_library(
         ":__support_alloc_checker",
         ":__support_cpp_array",
         ":__support_cpp_new",
+        ":__support_cpp_type_traits",
         ":__support_libc_assert",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -853,6 +880,8 @@ libc_support_library(
     hdrs = ["src/__support/arg_list.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
         ":string_memory_utils",
     ],
 )
@@ -862,6 +891,8 @@ libc_support_library(
     hdrs = ["src/__support/c_string.h"],
     deps = [
         ":__support_cpp_string",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
     ],
 )
 
@@ -872,6 +903,7 @@ libc_support_library(
         ":__support_cpp_array",
         ":__support_cpp_iterator",
         ":__support_libc_assert",
+        ":__support_macros_config",
         ":string_memory_utils",
     ],
 )
@@ -881,6 +913,7 @@ libc_support_library(
     hdrs = ["src/__support/char_vector.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":func_free",
         ":func_malloc",
         ":func_realloc",
@@ -893,6 +926,7 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_cpp_expected",
+        ":__support_macros_config",
     ],
 )
 
@@ -906,10 +940,15 @@ libc_support_library(
     deps = [
         ":__support_big_int",
         ":__support_common",
+        ":__support_cpp_limits",
         ":__support_cpp_type_traits",
         ":__support_fputil_dyadic_float",
         ":__support_fputil_fp_bits",
         ":__support_libc_assert",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
+        ":__support_sign",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -918,6 +957,7 @@ libc_support_library(
     hdrs = ["src/__support/number_pair.h"],
     deps = [
         ":__support_cpp_type_traits",
+        ":__support_macros_config",
     ],
 )
 
@@ -931,10 +971,13 @@ libc_support_library(
         ":__support_cpp_optional",
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_compiler",
         ":__support_macros_properties_types",
         ":__support_math_extras",
         ":__support_number_pair",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -962,7 +1005,10 @@ libc_support_library(
     deps = [
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_uint128",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -978,7 +1024,11 @@ libc_support_library(
 libc_support_library(
     name = "__support_integer_operations",
     hdrs = ["src/__support/integer_operations.h"],
-    deps = [":__support_cpp_type_traits"],
+    deps = [
+        ":__support_cpp_type_traits",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
+    ],
 )
 
 libc_support_library(
@@ -988,6 +1038,7 @@ libc_support_library(
         ":__support_big_int",
         ":__support_common",
         ":__support_cpp_algorithm",
+        ":__support_cpp_array",
         ":__support_cpp_bit",
         ":__support_cpp_limits",
         ":__support_cpp_optional",
@@ -995,6 +1046,8 @@ libc_support_library(
         ":__support_cpp_string_view",
         ":__support_cpp_type_traits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -1016,10 +1069,12 @@ libc_support_library(
     name = "__support_str_to_integer",
     hdrs = ["src/__support/str_to_integer.h"],
     deps = [
+        ":__support_big_int",
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_cpp_type_traits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
         ":__support_str_to_num_result",
         ":__support_uint128",
         ":__support_wctype_utils",
@@ -1043,12 +1098,15 @@ libc_support_library(
         ":__support_ctype_utils",
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_null_check",
+        ":__support_macros_optimization",
         ":__support_str_to_integer",
         ":__support_str_to_num_result",
         ":__support_uint128",
         ":__support_wctype_utils",
         ":hdr_errno_macros",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -1081,15 +1139,24 @@ libc_support_library(
         "src/__support/FPUtil/generic/mul.h",
     ],
     deps = [
+        ":__support_big_int",
         ":__support_common",
+        ":__support_cpp_algorithm",
+        ":__support_cpp_bit",
         ":__support_cpp_type_traits",
         ":__support_fputil_cast",
         ":__support_fputil_dyadic_float",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_architectures",
+        ":__support_macros_properties_types",
         ":__support_uint128",
+        ":hdr_errno_macros",
+        ":hdr_fenv_macros",
     ],
 )
 
@@ -1116,12 +1183,16 @@ libc_support_library(
         ":__support_cpp_new",
         ":__support_cpp_span",
         ":__support_error_or",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_macros_properties_architectures",
         ":__support_threads_mutex",
         ":errno",
         ":func_aligned_alloc",
         ":func_free",
         ":func_malloc",
         ":func_realloc",
+        ":hdr_stdint_proxy",
         ":hdr_stdio_macros",
         ":hdr_stdio_overlay",
         ":string_memory_utils",
@@ -1133,9 +1204,13 @@ libc_support_library(
     name = "__support_alloc_checker",
     hdrs = ["src/__support/alloc-checker.h"],
     deps = [
+        ":__support_common",
         ":__support_cpp_new",
         ":__support_cpp_type_traits",
         ":__support_macros_config",
+        ":__support_macros_properties_os",
+        ":func_aligned_alloc",
+        ":func_malloc",
     ],
 )
 
@@ -1145,8 +1220,11 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_error_or",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
+        ":hdr_stdint_proxy",
         ":hdr_stdio_overlay",
         ":types_off_t",
     ],
@@ -1160,6 +1238,7 @@ libc_support_library(
         ":__support_cpp_limits",
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
+        ":__support_macros_config",
     ],
 )
 
@@ -1172,12 +1251,15 @@ libc_support_library(
     deps = [
         ":__support_cpp_algorithm",
         ":__support_cpp_bit",
+        ":__support_cpp_limits",
         ":__support_cpp_type_traits",
         ":__support_libc_assert",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":__support_macros_optimization",
         ":__support_math_extras",
+        ":hdr_stdint_proxy",
         ":llvm_libc_macros_stdfix_macros",
     ],
 )
@@ -1192,6 +1274,8 @@ libc_support_library(
         ":__support_cpp_type_traits",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
+        ":__support_macros_config",
+        ":__support_macros_optimization",
     ],
 )
 
@@ -1207,6 +1291,7 @@ libc_support_library(
         ":__support_fputil_dyadic_float",
         ":__support_macros_config",
         ":__support_macros_properties_types",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -1237,6 +1322,7 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_fputil_manipulation_functions",
         ":__support_fputil_normal_float",
+        ":__support_macros_config",
     ],
 )
 
@@ -1249,6 +1335,8 @@ libc_support_library(
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
+        ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_macros_properties_types",
     ],
@@ -1267,13 +1355,22 @@ libc_support_library(
         "src/__support/FPUtil/aarch64/fenv_darwin_impl.h",
     ],
     deps = [
+        ":__support_cpp_bit",
+        ":__support_cpp_type_traits",
         ":__support_fputil_fp_bits",
+        ":__support_libc_errno",
         ":__support_macros_attributes",
+        ":__support_macros_config",
+        ":__support_macros_optimization",
         ":__support_macros_properties_architectures",
+        ":__support_macros_properties_compiler",
+        ":__support_macros_properties_cpu_features",
+        ":__support_macros_properties_types",
         ":__support_macros_sanitizer",
         ":errno",
         ":hdr_fenv_macros",
         ":hdr_math_macros",
+        ":hdr_stdint_proxy",
         ":types_fenv_t",
     ],
 )
@@ -1298,10 +1395,12 @@ libc_support_library(
         ":__support_cpp_type_traits",
         ":__support_libc_assert",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_macros_properties_types",
         ":__support_math_extras",
         ":__support_sign",
         ":__support_uint128",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -1314,6 +1413,8 @@ libc_support_library(
         ":__support_cpp_type_traits",
         ":__support_fputil_fp_bits",
         ":__support_integer_to_string",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_uint128",
     ],
 )
@@ -1330,6 +1431,7 @@ libc_support_library(
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_uint128",
     ],
 )
@@ -1348,12 +1450,18 @@ libc_support_library(
         ":__support_cpp_type_traits",
         ":__support_fputil_cast",
         ":__support_fputil_dyadic_float",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_nearest_integer_operations",
         ":__support_fputil_normal_float",
+        ":__support_fputil_rounding_mode",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_architectures",
         ":__support_uint128",
         ":hdr_math_macros",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -1367,6 +1475,7 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":hdr_math_macros",
     ],
 )
@@ -1378,6 +1487,8 @@ libc_support_library(
         ":__support_common",
         ":__support_cpp_type_traits",
         ":__support_fputil_fp_bits",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -1405,8 +1516,11 @@ libc_support_library(
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
+        ":__support_macros_properties_architectures",
         ":__support_macros_properties_cpu_features",
         ":__support_uint128",
+        ":hdr_fenv_macros",
     ],
 )
 
@@ -1452,17 +1566,23 @@ libc_support_library(
     name = "__support_fputil_fma",
     hdrs = fma_common_hdrs,
     deps = [
+        ":__support_big_int",
         ":__support_cpp_bit",
+        ":__support_cpp_limits",
         ":__support_cpp_type_traits",
         ":__support_fputil_basic_operations",
+        ":__support_fputil_cast",
         ":__support_fputil_dyadic_float",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_architectures",
         ":__support_macros_properties_cpu_features",
         ":__support_uint128",
+        ":hdr_fenv_macros",
     ],
 )
 
@@ -1472,6 +1592,9 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_cpp_type_traits",
+        ":__support_macros_config",
+        ":__support_macros_properties_architectures",
+        ":__support_macros_properties_cpu_features",
     ],
 )
 
@@ -1480,7 +1603,9 @@ libc_support_library(
     hdrs = ["src/__support/FPUtil/PolyEval.h"],
     deps = [
         ":__support_common",
+        ":__support_cpp_type_traits",
         ":__support_fputil_multiply_add",
+        ":__support_macros_config",
     ],
 )
 
@@ -1502,6 +1627,7 @@ libc_support_library(
     textual_hdrs = nearest_integer_platform_hdrs,
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_architectures",
         ":__support_macros_properties_cpu_features",
@@ -1514,6 +1640,8 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_fputil_multiply_add",
+        ":__support_macros_config",
+        ":__support_macros_properties_cpu_features",
         ":__support_number_pair",
     ],
 )
@@ -1523,6 +1651,7 @@ libc_support_library(
     hdrs = ["src/__support/FPUtil/triple_double.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
     ],
 )
 
@@ -1537,7 +1666,11 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_types",
+        ":hdr_errno_macros",
+        ":hdr_fenv_macros",
     ],
 )
 
@@ -1559,7 +1692,9 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_cpp_bit",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_architectures",
         ":__support_macros_sanitizer",
     ],
 )
@@ -1596,13 +1731,18 @@ libc_support_library(
         "src/__support/OSUtil/linux/aarch64/vdso.h",
     ],
     deps = [
+        ":__support_common",
         ":__support_cpp_array",
         ":__support_cpp_optional",
         ":__support_cpp_string_view",
+        ":__support_macros_attributes",
+        ":__support_macros_properties_architectures",
         ":__support_threads_callonce",
         ":types_clock_t",
         ":types_clockid_t",
+        ":types_struct_timespec",
         ":types_struct_timeval",
+        ":types_time_t",
     ],
 )
 
@@ -1617,6 +1757,8 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_cpp_string_view",
+        ":__support_macros_config",
+        ":__support_macros_properties_architectures",
         ":__support_osutil_syscall",
         ":string_utils",
     ],
@@ -1633,6 +1775,7 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_error_or",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":hdr_errno_macros",
         ":hdr_fcntl_macros",
@@ -1653,6 +1796,8 @@ libc_support_library(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":__support_common",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
     ],
 )
@@ -1676,12 +1821,16 @@ libc_support_library(
     }),
     deps = [
         ":__support_cpp_array",
+        ":__support_cpp_optional",
         ":__support_cpp_span",
         ":__support_cpp_string_view",
         ":__support_cpp_stringstream",
         ":__support_integer_to_string",
+        ":__support_libc_errno",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":errno",
+        ":hdr_errno_macros",
     ],
 )
 
@@ -1693,7 +1842,9 @@ libc_support_library(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":__support_macros_config",
         ":__support_osutil_syscall",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -1706,7 +1857,10 @@ libc_support_library(
     }),
     deps = [
         ":__support_cpp_atomic",
+        ":__support_cpp_limits",
         ":__support_cpp_optional",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":__support_threads_linux_futex_word_type",
         ":__support_time",
@@ -1738,6 +1892,7 @@ libc_support_library(
     }),
     deps = [
         ":__support_cpp_optional",
+        ":__support_libc_assert",
         ":__support_macros_config",
         ":__support_threads_mutex_common",
         ":__support_threads_raw_mutex",
@@ -1753,8 +1908,12 @@ libc_support_library(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":__support_common",
         ":__support_cpp_optional",
+        ":__support_libc_assert",
+        ":__support_macros_attributes",
         ":__support_macros_config",
+        ":__support_macros_optimization",
         ":__support_threads_linux_futex_utils",
         ":__support_threads_sleep",
         ":__support_time",
@@ -1795,8 +1954,10 @@ libc_support_library(
     hdrs = glob(["src/__support/time/*.h"]),
     deps = [
         ":__support_common",
+        ":__support_cpp_expected",
         ":__support_error_or",
         ":__support_libc_assert",
+        ":__support_macros_config",
         ":hdr_time_macros",
         ":types_clockid_t",
         ":types_struct_timespec",
@@ -1812,6 +1973,7 @@ libc_support_library(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":__support_macros_config",
         ":__support_time",
         ":__support_time_clock_gettime",
     ],
@@ -1848,6 +2010,7 @@ libc_support_library(
     hdrs = ["src/__support/wchar/mbstate.h"],
     deps = [
         ":__support_common",
+        ":hdr_stdint_proxy",
         ":types_char32_t",
     ],
 )
@@ -1858,6 +2021,7 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_cpp_bit",
+        ":__support_cpp_type_traits",
         ":__support_error_or",
         ":__support_math_extras",
         ":__support_wchar_mbstate",
@@ -1872,10 +2036,15 @@ libc_support_library(
     name = "__support_wchar_wcrtomb",
     hdrs = ["src/__support/wchar/wcrtomb.h"],
     deps = [
+        ":__support_common",
         ":__support_error_or",
         ":__support_libc_assert",
         ":__support_macros_null_check",
         ":__support_wchar_character_converter",
+        ":__support_wchar_mbstate",
+        ":hdr_errno_macros",
+        ":types_char32_t",
+        ":types_size_t",
         ":types_wchar_t",
     ],
 )
@@ -1917,6 +2086,7 @@ libc_support_library(
         ":__support_cpp_atomic",
         ":__support_libc_errno",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_macros_properties_architectures",
         ":hdr_errno_macros",
     ],
@@ -1932,6 +2102,7 @@ libc_function(
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -1943,6 +2114,7 @@ libc_function(
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -1953,6 +2125,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -1963,6 +2136,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -1973,6 +2147,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -1984,6 +2159,7 @@ libc_function(
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -1995,6 +2171,7 @@ libc_function(
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -2006,6 +2183,7 @@ libc_function(
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -2016,6 +2194,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -2027,6 +2206,7 @@ libc_function(
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -2038,6 +2218,7 @@ libc_function(
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -2049,6 +2230,7 @@ libc_function(
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -2060,6 +2242,7 @@ libc_function(
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -2070,6 +2253,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -2081,6 +2265,7 @@ libc_function(
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -2092,6 +2277,7 @@ libc_function(
         ":__support_common",
         ":__support_cpp_limits",
         ":__support_ctype_utils",
+        ":__support_macros_config",
     ],
 )
 
@@ -2104,6 +2290,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
     ],
 )
 
@@ -2114,6 +2301,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
         ":types_fexcept_t",
     ],
 )
@@ -2125,6 +2313,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
     ],
 )
 
@@ -2135,6 +2324,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
     ],
 )
 
@@ -2145,6 +2335,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
     ],
 )
 
@@ -2155,6 +2346,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
     ],
 )
 
@@ -2165,6 +2357,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
     ],
 )
 
@@ -2175,6 +2368,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
     ],
 )
 
@@ -2185,6 +2379,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
     ],
 )
 
@@ -2195,6 +2390,8 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
+        ":types_fenv_t",
     ],
 )
 
@@ -2205,6 +2402,8 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
+        ":types_fenv_t",
     ],
 )
 
@@ -2215,6 +2414,8 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
+        ":types_fenv_t",
     ],
 )
 
@@ -2225,6 +2426,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
     ],
 )
 
@@ -2235,6 +2437,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
         ":types_fexcept_t",
     ],
 )
@@ -2246,6 +2449,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
         ":types_fexcept_t",
     ],
 )
@@ -2257,6 +2461,8 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_fputil_fenv_impl",
+        ":__support_macros_config",
+        ":types_fenv_t",
     ],
 )
 
@@ -2268,6 +2474,7 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_fputil_dyadic_float",
+        ":__support_macros_config",
         ":__support_math_common_constants",
         ":__support_uint128",
     ],
@@ -2284,6 +2491,7 @@ libc_support_library(
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_fputil_sqrt",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_macros_properties_types",
@@ -2296,10 +2504,12 @@ libc_support_library(
     hdrs = ["src/__support/math/acosf.h"],
     deps = [
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_fputil_sqrt",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_inv_trigf_utils",
     ],
@@ -2311,12 +2521,15 @@ libc_support_library(
     deps = [
         ":__support_fputil_cast",
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_sqrt",
         ":__support_macros_optimization",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -2348,6 +2561,7 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_sqrt",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_acoshf_utils",
     ],
@@ -2364,8 +2578,10 @@ libc_support_library(
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_fputil_sqrt",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_acoshf_utils",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -2381,6 +2597,7 @@ libc_support_library(
         ":__support_fputil_sqrt",
         ":__support_macros_optimization",
         ":__support_macros_properties_types",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -2406,6 +2623,7 @@ libc_support_library(
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_manipulation_functions",
+        ":__support_fputil_multiply_add",
         ":__support_fputil_sqrt",
         ":__support_macros_optimization",
         ":hdr_errno_macros",
@@ -2532,6 +2750,7 @@ libc_support_library(
     hdrs = ["src/__support/math/sqrtf16.h"],
     deps = [
         ":__support_fputil_sqrt",
+        ":__support_macros_config",
         ":llvm_libc_macros_float16_macros",
     ],
 )
@@ -2546,6 +2765,7 @@ libc_support_library(
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_integer_literals",
+        ":__support_macros_config",
         ":__support_macros_optimization",
     ],
 )
@@ -2561,6 +2781,7 @@ libc_support_library(
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_fputil_sqrt",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_math_asin_utils",
@@ -2596,6 +2817,7 @@ libc_support_library(
         ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_acoshf_utils",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -2608,6 +2830,7 @@ libc_support_library(
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_integer_literals",
+        ":__support_macros_config",
         ":__support_macros_optimization",
     ],
 )
@@ -2617,7 +2840,11 @@ libc_support_library(
     hdrs = ["src/__support/math/atan.h"],
     deps = [
         ":__support_fputil_double_double",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_atan_utils",
     ],
@@ -2628,7 +2855,12 @@ libc_support_library(
     hdrs = ["src/__support/math/atan2.h"],
     deps = [
         ":__support_fputil_double_double",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
+        ":__support_macros_config",
+        ":__support_macros_optimization",
         ":__support_math_atan_utils",
     ],
 )
@@ -2645,6 +2877,7 @@ libc_support_library(
         ":__support_fputil_polyeval",
         ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
         ":__support_math_inv_trigf_utils",
     ],
 )
@@ -2661,6 +2894,7 @@ libc_support_library(
         ":__support_macros_optimization",
         ":__support_math_atan_utils",
         ":__support_uint128",
+        ":llvm_libc_types_float128",
     ],
 )
 
@@ -2669,10 +2903,12 @@ libc_support_library(
     hdrs = ["src/__support/math/atanf.h"],
     deps = [
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_inv_trigf_utils",
     ],
@@ -2690,6 +2926,7 @@ libc_support_library(
         ":__support_fputil_polyeval",
         ":__support_fputil_sqrt",
         ":__support_macros_optimization",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -2713,12 +2950,14 @@ libc_support_library(
     name = "__support_math_asinf16",
     hdrs = ["src/__support/math/asinf16.h"],
     deps = [
+        ":__support_fputil_cast",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_fputil_sqrt",
         ":__support_macros_optimization",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -2945,8 +3184,12 @@ libc_support_library(
         ":__support_fputil_double_double",
         ":__support_fputil_dyadic_float",
         ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_integer_literals",
+        ":__support_macros_config",
+        ":__support_macros_optimization",
     ],
 )
 
@@ -2957,6 +3200,8 @@ libc_support_library(
         ":__support_fputil_double_double",
         ":__support_fputil_dyadic_float",
         ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_integer_literals",
     ],
@@ -3024,6 +3269,7 @@ libc_support_library(
     name = "__support_math_common_constants",
     hdrs = ["src/__support/math/common_constants.h"],
     deps = [
+        ":__support_macros_config",
         ":__support_math_acosh_float_constants",
         ":__support_math_exp_constants",
         ":__support_number_pair",
@@ -3034,8 +3280,13 @@ libc_support_library(
     name = "__support_math_cos",
     hdrs = ["src/__support/math/cos.h"],
     deps = [
+        ":__support_fputil_double_double",
+        ":__support_fputil_dyadic_float",
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_range_reduction_double",
@@ -3048,6 +3299,10 @@ libc_support_library(
     hdrs = ["src/__support/math/cosf.h"],
     deps = [
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_sincosf_utils",
@@ -3062,10 +3317,12 @@ libc_support_library(
         ":__support_fputil_cast",
         ":__support_fputil_except_value_utils",
         ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_macros_optimization",
         ":__support_math_sincosf16_utils",
         ":errno",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -3073,9 +3330,11 @@ libc_support_library(
     name = "__support_math_coshf",
     hdrs = ["src/__support/math/coshf.h"],
     deps = [
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_sinhfcoshf_utils",
     ],
@@ -3092,6 +3351,7 @@ libc_support_library(
         ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_expxf16_utils",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -3099,12 +3359,17 @@ libc_support_library(
     name = "__support_math_cospif",
     hdrs = ["src/__support/math/cospif.h"],
     deps = [
+        ":__support_common",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
         ":__support_math_common_constants",
         ":__support_sincosf_utils",
     ],
@@ -3116,9 +3381,11 @@ libc_support_library(
     deps = [
         ":__support_fputil_cast",
         ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_macros_optimization",
         ":__support_math_sincosf16_utils",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -3134,12 +3401,15 @@ libc_support_library(
     name = "__support_math_exp10m1f",
     hdrs = ["src/__support/math/exp10m1f.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_except_value_utils",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_exp10f_utils",
         ":errno",
@@ -3150,15 +3420,20 @@ libc_support_library(
     name = "__support_math_exp10m1f16",
     hdrs = ["src/__support/math/exp10m1f16.h"],
     deps = [
+        ":__support_common",
+        ":__support_fputil_cast",
         ":__support_fputil_except_value_utils",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
         ":__support_math_exp10f16_utils",
         ":errno",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -3170,6 +3445,7 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
+        ":__support_macros_config",
         ":__support_macros_optimization",
     ],
 )
@@ -3209,6 +3485,7 @@ libc_support_library(
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_macros_attributes",
+        ":__support_macros_properties_types",
         ":llvm_libc_macros_float16_macros",
     ],
 )
@@ -3228,8 +3505,11 @@ libc_support_library(
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
         ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_expf16_utils",
+        ":hdr_errno_macros",
+        ":hdr_fenv_macros",
         ":llvm_libc_macros_float16_macros",
     ],
 )
@@ -3240,7 +3520,10 @@ libc_support_library(
     deps = [
         ":__support_fputil_cast",
         ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_math_exp10_float16_constants",
         ":__support_math_expf16_utils",
     ],
@@ -3439,8 +3722,10 @@ libc_support_library(
     name = "__support_math_frexpf128",
     hdrs = ["src/__support/math/frexpf128.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_manipulation_functions",
-        ":__support_macros_properties_types",
+        ":__support_macros_config",
+        ":llvm_libc_types_float128",
     ],
 )
 
@@ -3448,7 +3733,9 @@ libc_support_library(
     name = "__support_math_ilogbf128",
     hdrs = ["src/__support/math/ilogbf128.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_manipulation_functions",
+        ":__support_macros_config",
         ":__support_macros_properties_types",
         ":llvm_libc_types_float128",
     ],
@@ -3469,6 +3756,7 @@ libc_support_library(
         ":__support_common",
         ":__support_fputil_sqrt",
         ":__support_macros_config",
+        ":llvm_libc_types_float128",
     ],
 )
 
@@ -3544,6 +3832,7 @@ libc_support_library(
         ":__support_common",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
+        ":__support_macros_config",
     ],
 )
 
@@ -3551,6 +3840,7 @@ libc_support_library(
     name = "__support_math_frexpf16",
     hdrs = ["src/__support/math/frexpf16.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_manipulation_functions",
         ":__support_macros_config",
         ":__support_macros_properties_types",
@@ -3562,7 +3852,9 @@ libc_support_library(
     name = "__support_math_frexpf",
     hdrs = ["src/__support/math/frexpf.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_manipulation_functions",
+        ":__support_macros_config",
     ],
 )
 
@@ -3601,6 +3893,7 @@ libc_support_library(
     name = "__support_math_ilogbl",
     hdrs = ["src/__support/math/ilogbl.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_manipulation_functions",
     ],
 )
@@ -3666,7 +3959,9 @@ libc_support_library(
     name = "__support_math_ldexpf128",
     hdrs = ["src/__support/math/ldexpf128.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_manipulation_functions",
+        ":__support_macros_config",
         ":__support_macros_properties_types",
         ":llvm_libc_types_float128",
     ],
@@ -3676,6 +3971,7 @@ libc_support_library(
     name = "__support_math_llogbf128",
     hdrs = ["src/__support/math/llogbf128.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_manipulation_functions",
         ":__support_macros_config",
         ":llvm_libc_types_float128",
@@ -3686,7 +3982,9 @@ libc_support_library(
     name = "__support_math_ldexpf16",
     hdrs = ["src/__support/math/ldexpf16.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_manipulation_functions",
+        ":__support_macros_config",
         ":__support_macros_properties_types",
         ":llvm_libc_macros_float16_macros",
     ],
@@ -3696,7 +3994,9 @@ libc_support_library(
     name = "__support_math_ldexpf",
     hdrs = ["src/__support/math/ldexpf.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_manipulation_functions",
+        ":__support_macros_config",
     ],
 )
 
@@ -3745,12 +4045,16 @@ libc_support_library(
     name = "__support_math_log",
     hdrs = ["src/__support/math/log.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_double_double",
         ":__support_fputil_dyadic_float",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_integer_literals",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_math_common_constants",
@@ -3772,12 +4076,16 @@ libc_support_library(
     name = "__support_math_log10",
     hdrs = ["src/__support/math/log10.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_double_double",
         ":__support_fputil_dyadic_float",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_integer_literals",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_math_common_constants",
@@ -3789,12 +4097,16 @@ libc_support_library(
     name = "__support_math_log1p",
     hdrs = ["src/__support/math/log1p.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_double_double",
         ":__support_fputil_dyadic_float",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_integer_literals",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_math_common_constants",
@@ -3805,12 +4117,17 @@ libc_support_library(
     name = "__support_math_log1pf",
     hdrs = ["src/__support/math/log1pf.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_except_value_utils",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
         ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
+        ":__support_math_acosh_float_constants",
         ":__support_math_common_constants",
     ],
 )
@@ -3819,12 +4136,16 @@ libc_support_library(
     name = "__support_math_log2",
     hdrs = ["src/__support/math/log2.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_double_double",
         ":__support_fputil_dyadic_float",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_integer_literals",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_math_common_constants",
@@ -3846,14 +4167,20 @@ libc_support_library(
     name = "__support_math_log10f16",
     hdrs = ["src/__support/math/log10f16.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_cast",
         ":__support_fputil_except_value_utils",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
         ":__support_math_expxf16_utils",
+        ":hdr_errno_macros",
+        ":hdr_fenv_macros",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -3866,8 +4193,11 @@ libc_support_library(
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
         ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_macros_config",
+        ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
         ":__support_math_common_constants",
     ],
 )
@@ -3876,14 +4206,20 @@ libc_support_library(
     name = "__support_math_log2f16",
     hdrs = ["src/__support/math/log2f16.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_cast",
         ":__support_fputil_except_value_utils",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
         ":__support_math_expxf16_utils",
+        ":hdr_errno_macros",
+        ":hdr_fenv_macros",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -3891,11 +4227,14 @@ libc_support_library(
     name = "__support_math_log2f",
     hdrs = ["src/__support/math/log2f.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_except_value_utils",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
         ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_common_constants",
     ],
@@ -3907,6 +4246,7 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_fputil_manipulation_functions",
+        ":__support_macros_config",
     ],
 )
 
@@ -3914,7 +4254,10 @@ libc_support_library(
     name = "__support_math_logbf128",
     hdrs = ["src/__support/math/logbf128.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_manipulation_functions",
+        ":__support_macros_config",
+        ":llvm_libc_types_float128",
     ],
 )
 
@@ -3922,7 +4265,10 @@ libc_support_library(
     name = "__support_math_logbf16",
     hdrs = ["src/__support/math/logbf16.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_manipulation_functions",
+        ":__support_macros_config",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -3947,6 +4293,7 @@ libc_support_library(
     name = "__support_math_pow",
     hdrs = ["src/__support/math/pow.h"],
     deps = [
+        ":__support_common",
         ":__support_cpp_bit",
         ":__support_fputil_double_double",
         ":__support_fputil_fenv_impl",
@@ -3955,9 +4302,12 @@ libc_support_library(
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_sqrt",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_common_constants",
         ":__support_math_exp_constants",
+        ":hdr_errno_macros",
+        ":hdr_fenv_macros",
     ],
 )
 
@@ -3966,6 +4316,7 @@ libc_support_library(
     hdrs = ["src/__support/math/exp_constants.h"],
     deps = [
         ":__support_fputil_triple_double",
+        ":__support_macros_attributes",
     ],
 )
 
@@ -3983,6 +4334,7 @@ libc_support_library(
     name = "__support_math_powf",
     hdrs = ["src/__support/math/powf.h"],
     deps = [
+        ":__support_common",
         ":__support_cpp_bit",
         ":__support_fputil_double_double",
         ":__support_fputil_fenv_impl",
@@ -3992,10 +4344,12 @@ libc_support_library(
         ":__support_fputil_polyeval",
         ":__support_fputil_sqrt",
         ":__support_fputil_triple_double",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_common_constants",
         ":__support_math_exp10f",
         ":__support_math_exp2f",
+        ":__support_math_exp_constants",
     ],
 )
 
@@ -4003,6 +4357,7 @@ libc_support_library(
     name = "__support_math_exp",
     hdrs = ["src/__support/math/exp.h"],
     deps = [
+        ":__support_common",
         ":__support_cpp_bit",
         ":__support_cpp_optional",
         ":__support_fputil_double_double",
@@ -4015,6 +4370,7 @@ libc_support_library(
         ":__support_fputil_rounding_mode",
         ":__support_fputil_triple_double",
         ":__support_integer_literals",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_exp_constants",
         ":__support_math_exp_utils",
@@ -4025,16 +4381,23 @@ libc_support_library(
     name = "__support_math_exp2",
     hdrs = ["src/__support/math/exp2.h"],
     deps = [
+        ":__support_common",
+        ":__support_cpp_bit",
+        ":__support_cpp_optional",
         ":__support_fputil_double_double",
         ":__support_fputil_dyadic_float",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
         ":__support_fputil_triple_double",
         ":__support_integer_literals",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_common_constants",
+        ":__support_math_exp_constants",
         ":__support_math_exp_utils",
     ],
 )
@@ -4043,13 +4406,18 @@ libc_support_library(
     name = "__support_math_exp2f",
     hdrs = ["src/__support/math/exp2f.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
         ":__support_math_common_constants",
         ":__support_math_exp10f_utils",
     ],
@@ -4059,15 +4427,21 @@ libc_support_library(
     name = "__support_math_exp2f16",
     hdrs = ["src/__support/math/exp2f16.h"],
     deps = [
+        ":__support_common",
+        ":__support_fputil_cast",
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_common_constants",
         ":__support_math_expxf16_utils",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -4075,13 +4449,19 @@ libc_support_library(
     name = "__support_math_exp2m1f",
     hdrs = ["src/__support/math/exp2m1f.h"],
     deps = [
+        ":__support_common",
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
         ":__support_math_common_constants",
         ":__support_math_exp10f_utils",
     ],
@@ -4091,15 +4471,21 @@ libc_support_library(
     name = "__support_math_exp2m1f16",
     hdrs = ["src/__support/math/exp2m1f16.h"],
     deps = [
+        ":__support_fputil_cast",
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
+        ":__support_macros_properties_cpu_features",
         ":__support_math_common_constants",
         ":__support_math_expxf16_utils",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -4107,14 +4493,20 @@ libc_support_library(
     name = "__support_math_exp10",
     hdrs = ["src/__support/math/exp10.h"],
     deps = [
+        ":__support_common",
+        ":__support_cpp_bit",
+        ":__support_cpp_optional",
         ":__support_fputil_double_double",
         ":__support_fputil_dyadic_float",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
         ":__support_fputil_triple_double",
         ":__support_integer_literals",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_exp_constants",
         ":__support_math_exp_utils",
@@ -4128,9 +4520,11 @@ libc_support_library(
         ":__support_common",
         ":__support_fputil_basic_operations",
         ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
+        ":__support_macros_config",
         ":__support_math_exp_utils",
     ],
 )
@@ -4143,6 +4537,7 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_exp10f_utils",
     ],
@@ -4153,6 +4548,8 @@ libc_support_library(
     hdrs = ["src/__support/math/exp10_float16_constants.h"],
     deps = [
         ":__support_cpp_array",
+        ":hdr_stdint_proxy",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -4163,6 +4560,7 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_math_exp10_float16_constants",
         ":__support_math_expf16_utils",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -4172,11 +4570,14 @@ libc_support_library(
     deps = [
         ":__support_fputil_cast",
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_math_exp10f16_utils",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -4184,14 +4585,19 @@ libc_support_library(
     name = "__support_math_expm1",
     hdrs = ["src/__support/math/expm1.h"],
     deps = [
+        ":__support_common",
+        ":__support_cpp_bit",
         ":__support_fputil_double_double",
         ":__support_fputil_dyadic_float",
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
         ":__support_fputil_triple_double",
         ":__support_integer_literals",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_math_common_constants",
         ":__support_math_exp_constants",
@@ -4202,11 +4608,16 @@ libc_support_library(
     name = "__support_math_expm1f",
     hdrs = ["src/__support/math/expm1f.h"],
     deps = [
+        ":__support_common",
+        ":__support_fputil_basic_operations",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_math_common_constants",
@@ -4217,15 +4628,21 @@ libc_support_library(
     name = "__support_math_expm1f16",
     hdrs = ["src/__support/math/expm1f16.h"],
     deps = [
+        ":__support_common",
+        ":__support_fputil_cast",
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_math_expxf16_utils",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -4246,6 +4663,7 @@ libc_support_library(
         ":__support_common",
         ":__support_fputil_fma",
         ":__support_macros_config",
+        ":llvm_libc_types_float128",
     ],
 )
 
@@ -4301,6 +4719,8 @@ libc_support_library(
         ":__support_fputil_nearest_integer",
         ":__support_fputil_rounding_mode",
         ":__support_integer_literals",
+        ":__support_macros_config",
+        ":__support_macros_optimization",
     ],
 )
 
@@ -4350,6 +4770,7 @@ libc_support_library(
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_integer_literals",
+        ":__support_macros_config",
     ],
 )
 
@@ -4361,8 +4782,13 @@ libc_support_library(
     ],
     deps = [
         ":__support_fputil_double_double",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
+        ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
+        ":__support_macros_config",
+        ":__support_macros_properties_cpu_features",
         ":__support_range_reduction",
     ],
 )
@@ -4393,6 +4819,7 @@ libc_support_library(
         ":__support_common",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
+        ":__support_macros_config",
     ],
 )
 
@@ -4400,7 +4827,12 @@ libc_support_library(
     name = "__support_math_sin",
     hdrs = ["src/__support/math/sin.h"],
     deps = [
+        ":__support_fputil_double_double",
+        ":__support_fputil_dyadic_float",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_range_reduction_double",
@@ -4412,9 +4844,14 @@ libc_support_library(
     name = "__support_math_sinf",
     hdrs = ["src/__support/math/sinf.h"],
     deps = [
+        ":__support_fputil_basic_operations",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_range_reduction",
@@ -4455,6 +4892,7 @@ libc_support_library(
         ":__support_math_expxf16_utils",
         ":hdr_errno_macros",
         ":hdr_fenv_macros",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 
@@ -4537,6 +4975,7 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_sincosf_utils",
     ],
@@ -4583,12 +5022,20 @@ libc_support_library(
     name = "__support_math_tan",
     hdrs = ["src/__support/math/tan.h"],
     deps = [
+        ":__support_fputil_double_double",
+        ":__support_fputil_dyadic_float",
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
+        ":__support_fputil_polyeval",
+        ":__support_fputil_rounding_mode",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_range_reduction_double",
         ":__support_sincos_eval",
+        ":hdr_errno_macros",
     ],
 )
 
@@ -4597,10 +5044,13 @@ libc_support_library(
     hdrs = ["src/__support/math/tanf.h"],
     deps = [
         ":__support_fputil_except_value_utils",
+        ":__support_fputil_fenv_impl",
         ":__support_fputil_fma",
+        ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":__support_range_reduction",
@@ -4889,6 +5339,7 @@ libc_function(
         ":__support_cpp_bit",
         ":__support_macros_config",
         ":__support_macros_properties_complex_types",
+        ":__support_macros_properties_types",
     ],
 )
 
@@ -4902,6 +5353,7 @@ libc_function(
         ":__support_cpp_bit",
         ":__support_macros_config",
         ":__support_macros_properties_complex_types",
+        ":__support_macros_properties_types",
     ],
 )
 
@@ -4932,6 +5384,7 @@ libc_math_function(
 libc_math_function(
     name = "acosf16",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_acosf16",
         ":errno",
     ],
@@ -4945,6 +5398,7 @@ libc_math_function(
 libc_math_function(
     name = "acoshf16",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_acoshf16",
         ":errno",
     ],
@@ -4953,6 +5407,7 @@ libc_math_function(
 libc_math_function(
     name = "acospif16",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_acospif16",
         ":errno",
     ],
@@ -4970,7 +5425,10 @@ libc_math_function(
 
 libc_math_function(
     name = "asinf16",
-    additional_deps = [":__support_math_asinf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_asinf16",
+    ],
 )
 
 libc_math_function(
@@ -4980,7 +5438,10 @@ libc_math_function(
 
 libc_math_function(
     name = "asinhf16",
-    additional_deps = [":__support_math_asinhf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_asinhf16",
+    ],
 )
 
 libc_math_function(
@@ -4990,7 +5451,10 @@ libc_math_function(
 
 libc_math_function(
     name = "atanf16",
-    additional_deps = [":__support_math_atanf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_atanf16",
+    ],
 )
 
 libc_math_function(
@@ -5005,7 +5469,10 @@ libc_math_function(
 
 libc_math_function(
     name = "atan2f128",
-    additional_deps = [":__support_math_atan2f128"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_atan2f128",
+    ],
 )
 
 libc_math_function(
@@ -5020,7 +5487,10 @@ libc_math_function(
 
 libc_math_function(
     name = "atanhf16",
-    additional_deps = [":__support_math_atanhf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_atanhf16",
+    ],
 )
 
 libc_math_function(
@@ -5139,9 +5609,15 @@ libc_math_function(name = "iscanonicalf")
 
 libc_math_function(name = "iscanonicall")
 
-libc_math_function(name = "iscanonicalf128")
+libc_math_function(
+    name = "iscanonicalf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "iscanonicalf16")
+libc_math_function(
+    name = "iscanonicalf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "issignaling")
 
@@ -5149,9 +5625,15 @@ libc_math_function(name = "issignalingf")
 
 libc_math_function(name = "issignalingl")
 
-libc_math_function(name = "issignalingf128")
+libc_math_function(
+    name = "issignalingf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "issignalingf16")
+libc_math_function(
+    name = "issignalingf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "cbrt",
@@ -5211,9 +5693,15 @@ libc_math_function(name = "copysignf")
 
 libc_math_function(name = "copysignl")
 
-libc_math_function(name = "copysignf128")
+libc_math_function(
+    name = "copysignf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "copysignf16")
+libc_math_function(
+    name = "copysignf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "cos",
@@ -5227,7 +5715,10 @@ libc_math_function(
 
 libc_math_function(
     name = "cosf16",
-    additional_deps = [":__support_math_cosf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_cosf16",
+    ],
 )
 
 libc_math_function(
@@ -5237,7 +5728,10 @@ libc_math_function(
 
 libc_math_function(
     name = "coshf16",
-    additional_deps = [":__support_math_coshf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_coshf16",
+    ],
 )
 
 libc_math_function(
@@ -5247,16 +5741,25 @@ libc_math_function(
 
 libc_math_function(
     name = "cospif16",
-    additional_deps = [":__support_math_cospif16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_cospif16",
+    ],
 )
 
 libc_math_function(name = "daddl")
 
-libc_math_function(name = "daddf128")
+libc_math_function(
+    name = "daddf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "ddivl")
 
-libc_math_function(name = "ddivf128")
+libc_math_function(
+    name = "ddivf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "dfmal",
@@ -5266,6 +5769,7 @@ libc_math_function(
 libc_math_function(
     name = "dfmaf128",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_dfmaf128",
         ":llvm_libc_types_float128",
     ],
@@ -5273,7 +5777,10 @@ libc_math_function(
 
 libc_math_function(name = "dmull")
 
-libc_math_function(name = "dmulf128")
+libc_math_function(
+    name = "dmulf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "dsqrtl",
@@ -5282,12 +5789,18 @@ libc_math_function(
 
 libc_math_function(
     name = "dsqrtf128",
-    additional_deps = [":__support_fputil_sqrt"],
+    additional_deps = [
+        ":__support_fputil_sqrt",
+        ":__support_macros_properties_types",
+    ],
 )
 
 libc_math_function(name = "dsubl")
 
-libc_math_function(name = "dsubf128")
+libc_math_function(
+    name = "dsubf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "erff",
@@ -5313,6 +5826,7 @@ libc_math_function(
 libc_math_function(
     name = "expf16",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_expf16",
         ":__support_math_expxf16_utils",
     ],
@@ -5337,6 +5851,7 @@ libc_math_function(
 libc_math_function(
     name = "exp10f16",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_exp10f16",
         ":errno",
     ],
@@ -5344,7 +5859,10 @@ libc_math_function(
 
 libc_math_function(
     name = "exp10m1f16",
-    additional_deps = [":__support_math_exp10m1f16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_exp10m1f16",
+    ],
 )
 
 libc_math_function(
@@ -5364,7 +5882,10 @@ libc_math_function(
 
 libc_math_function(
     name = "exp2f16",
-    additional_deps = [":__support_math_exp2f16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_exp2f16",
+    ],
 )
 
 libc_math_function(
@@ -5374,7 +5895,10 @@ libc_math_function(
 
 libc_math_function(
     name = "exp2m1f16",
-    additional_deps = [":__support_math_exp2m1f16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_exp2m1f16",
+    ],
 )
 
 libc_math_function(
@@ -5389,7 +5913,10 @@ libc_math_function(
 
 libc_math_function(
     name = "expm1f16",
-    additional_deps = [":__support_math_expm1f16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_expm1f16",
+    ],
 )
 
 libc_math_function(
@@ -5412,72 +5939,130 @@ libc_math_function(
     additional_deps = [":__support_math_f16addl"],
 )
 
-libc_math_function(name = "f16div")
+libc_math_function(
+    name = "f16div",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "f16divf")
+libc_math_function(
+    name = "f16divf",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "f16divf128")
+libc_math_function(
+    name = "f16divf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "f16divl")
+libc_math_function(
+    name = "f16divl",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "f16fma",
-    additional_deps = [":__support_math_f16fma"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_f16fma",
+    ],
 )
 
 libc_math_function(
     name = "f16fmaf",
-    additional_deps = [":__support_math_f16fmaf"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_f16fmaf",
+    ],
 )
 
 libc_math_function(
     name = "f16fmaf128",
-    additional_deps = [":__support_math_f16fmaf128"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_f16fmaf128",
+    ],
 )
 
 libc_math_function(
     name = "f16fmal",
-    additional_deps = [":__support_math_f16fmal"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_f16fmal",
+    ],
 )
 
-libc_math_function(name = "f16mul")
+libc_math_function(
+    name = "f16mul",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "f16mulf")
+libc_math_function(
+    name = "f16mulf",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "f16mulf128")
+libc_math_function(
+    name = "f16mulf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "f16mull")
+libc_math_function(
+    name = "f16mull",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "f16sqrt",
-    additional_deps = [":__support_math_f16sqrt"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_f16sqrt",
+    ],
 )
 
 libc_math_function(
     name = "f16sqrtf",
-    additional_deps = [":__support_math_f16sqrtf"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_f16sqrtf",
+    ],
 )
 
 libc_math_function(
     name = "f16sqrtf128",
-    additional_deps = [":__support_fputil_sqrt"],
+    additional_deps = [
+        ":__support_fputil_sqrt",
+        ":__support_macros_properties_types",
+    ],
 )
 
 libc_math_function(
     name = "f16sqrtl",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_f16sqrtl",
         ":errno",
     ],
 )
 
-libc_math_function(name = "f16sub")
+libc_math_function(
+    name = "f16sub",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "f16subf")
+libc_math_function(
+    name = "f16subf",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "f16subf128")
+libc_math_function(
+    name = "f16subf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "f16subl")
+libc_math_function(
+    name = "f16subl",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "fabs")
 
@@ -5485,9 +6070,19 @@ libc_math_function(name = "fabsf")
 
 libc_math_function(name = "fabsl")
 
-libc_math_function(name = "fabsf128")
+libc_math_function(
+    name = "fabsf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fabsf16")
+libc_math_function(
+    name = "fabsf16",
+    additional_deps = [
+        ":__support_macros_properties_architectures",
+        ":__support_macros_properties_compiler",
+        ":__support_macros_properties_types",
+    ],
+)
 
 libc_math_function(
     name = "fadd",
@@ -5516,15 +6111,24 @@ libc_math_function(name = "fdimf")
 
 libc_math_function(name = "fdiml")
 
-libc_math_function(name = "fdimf128")
+libc_math_function(
+    name = "fdimf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fdimf16")
+libc_math_function(
+    name = "fdimf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "fdiv")
 
 libc_math_function(name = "fdivl")
 
-libc_math_function(name = "fdivf128")
+libc_math_function(
+    name = "fdivf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "ffma",
@@ -5540,7 +6144,10 @@ libc_math_function(
 
 libc_math_function(
     name = "ffmaf128",
-    additional_deps = [":__support_fputil_fma"],
+    additional_deps = [
+        ":__support_fputil_fma",
+        ":__support_macros_properties_types",
+    ],
 )
 
 libc_math_function(name = "floor")
@@ -5549,9 +6156,19 @@ libc_math_function(name = "floorf")
 
 libc_math_function(name = "floorl")
 
-libc_math_function(name = "floorf128")
+libc_math_function(
+    name = "floorf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "floorf16")
+libc_math_function(
+    name = "floorf16",
+    additional_deps = [
+        ":__support_fputil_cast",
+        ":__support_macros_properties_cpu_features",
+        ":__support_macros_properties_types",
+    ],
+)
 
 libc_math_function(
     name = "fma",
@@ -5565,7 +6182,10 @@ libc_math_function(
 
 libc_math_function(
     name = "fmaf16",
-    additional_deps = [":__support_fputil_fma"],
+    additional_deps = [
+        ":__support_fputil_fma",
+        ":__support_macros_properties_types",
+    ],
 )
 
 libc_math_function(
@@ -5616,9 +6236,15 @@ libc_math_function(name = "fmaximumf")
 
 libc_math_function(name = "fmaximuml")
 
-libc_math_function(name = "fmaximumf128")
+libc_math_function(
+    name = "fmaximumf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fmaximumf16")
+libc_math_function(
+    name = "fmaximumf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "fmaximum_mag")
 
@@ -5626,9 +6252,15 @@ libc_math_function(name = "fmaximum_magf")
 
 libc_math_function(name = "fmaximum_magl")
 
-libc_math_function(name = "fmaximum_magf128")
+libc_math_function(
+    name = "fmaximum_magf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fmaximum_magf16")
+libc_math_function(
+    name = "fmaximum_magf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "fmaximum_mag_num")
 
@@ -5636,9 +6268,15 @@ libc_math_function(name = "fmaximum_mag_numf")
 
 libc_math_function(name = "fmaximum_mag_numl")
 
-libc_math_function(name = "fmaximum_mag_numf128")
+libc_math_function(
+    name = "fmaximum_mag_numf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fmaximum_mag_numf16")
+libc_math_function(
+    name = "fmaximum_mag_numf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "fmaximum_num")
 
@@ -5646,9 +6284,15 @@ libc_math_function(name = "fmaximum_numf")
 
 libc_math_function(name = "fmaximum_numl")
 
-libc_math_function(name = "fmaximum_numf128")
+libc_math_function(
+    name = "fmaximum_numf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fmaximum_numf16")
+libc_math_function(
+    name = "fmaximum_numf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "fmin")
 
@@ -5656,9 +6300,15 @@ libc_math_function(name = "fminf")
 
 libc_math_function(name = "fminl")
 
-libc_math_function(name = "fminf128")
+libc_math_function(
+    name = "fminf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fminf16")
+libc_math_function(
+    name = "fminf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "fminimum")
 
@@ -5666,9 +6316,15 @@ libc_math_function(name = "fminimumf")
 
 libc_math_function(name = "fminimuml")
 
-libc_math_function(name = "fminimumf128")
+libc_math_function(
+    name = "fminimumf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fminimumf16")
+libc_math_function(
+    name = "fminimumf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "fminimum_mag")
 
@@ -5676,9 +6332,15 @@ libc_math_function(name = "fminimum_magf")
 
 libc_math_function(name = "fminimum_magl")
 
-libc_math_function(name = "fminimum_magf128")
+libc_math_function(
+    name = "fminimum_magf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fminimum_magf16")
+libc_math_function(
+    name = "fminimum_magf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "fminimum_mag_num")
 
@@ -5686,9 +6348,15 @@ libc_math_function(name = "fminimum_mag_numf")
 
 libc_math_function(name = "fminimum_mag_numl")
 
-libc_math_function(name = "fminimum_mag_numf128")
+libc_math_function(
+    name = "fminimum_mag_numf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fminimum_mag_numf16")
+libc_math_function(
+    name = "fminimum_mag_numf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "fminimum_num")
 
@@ -5696,9 +6364,15 @@ libc_math_function(name = "fminimum_numf")
 
 libc_math_function(name = "fminimum_numl")
 
-libc_math_function(name = "fminimum_numf128")
+libc_math_function(
+    name = "fminimum_numf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fminimum_numf16")
+libc_math_function(
+    name = "fminimum_numf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "fmod",
@@ -5710,6 +6384,7 @@ libc_math_function(
     additional_deps = [
         ":__support_fputil_bfloat16",
         ":__support_fputil_generic_fmod",
+        ":__support_macros_properties_types",
     ],
 )
 
@@ -5725,22 +6400,35 @@ libc_math_function(
 
 libc_math_function(
     name = "fmodf128",
-    additional_deps = [":__support_fputil_generic_fmod"],
+    additional_deps = [
+        ":__support_fputil_generic_fmod",
+        ":__support_macros_properties_types",
+    ],
 )
 
 libc_math_function(
     name = "fmodf16",
-    additional_deps = [":__support_fputil_generic_fmod"],
+    additional_deps = [
+        ":__support_fputil_generic_fmod",
+        ":__support_macros_properties_types",
+    ],
 )
 
 libc_math_function(
     name = "fmul",
-    additional_deps = [":__support_fputil_double_double"],
+    additional_deps = [
+        ":__support_fputil_double_double",
+        ":hdr_errno_macros",
+        ":hdr_fenv_macros",
+    ],
 )
 
 libc_math_function(name = "fmull")
 
-libc_math_function(name = "fmulf128")
+libc_math_function(
+    name = "fmulf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "frexp")
 
@@ -5753,12 +6441,18 @@ libc_math_function(name = "frexpl")
 
 libc_math_function(
     name = "frexpf128",
-    additional_deps = [":__support_math_frexpf128"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_frexpf128",
+    ],
 )
 
 libc_math_function(
     name = "frexpf16",
-    additional_deps = [":__support_math_frexpf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_frexpf16",
+    ],
 )
 
 libc_math_function(name = "fromfp")
@@ -5767,9 +6461,15 @@ libc_math_function(name = "fromfpf")
 
 libc_math_function(name = "fromfpl")
 
-libc_math_function(name = "fromfpf128")
+libc_math_function(
+    name = "fromfpf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fromfpf16")
+libc_math_function(
+    name = "fromfpf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "fromfpx")
 
@@ -5777,9 +6477,15 @@ libc_math_function(name = "fromfpxf")
 
 libc_math_function(name = "fromfpxl")
 
-libc_math_function(name = "fromfpxf128")
+libc_math_function(
+    name = "fromfpxf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "fromfpxf16")
+libc_math_function(
+    name = "fromfpxf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "fsqrt",
@@ -5794,6 +6500,7 @@ libc_math_function(
 libc_math_function(
     name = "fsqrtf128",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_fsqrtf128",
         ":errno",
     ],
@@ -5803,7 +6510,10 @@ libc_math_function(name = "fsub")
 
 libc_math_function(name = "fsubl")
 
-libc_math_function(name = "fsubf128")
+libc_math_function(
+    name = "fsubf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "getpayload",
@@ -5875,13 +6585,17 @@ libc_math_function(
 libc_math_function(
     name = "ilogbf128",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_ilogbf128",
     ],
 )
 
 libc_math_function(
     name = "ilogbf16",
-    additional_deps = [":__support_math_ilogbf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_ilogbf16",
+    ],
 )
 
 libc_math_function(name = "ldexp")
@@ -5895,27 +6609,40 @@ libc_math_function(name = "ldexpl")
 
 libc_math_function(
     name = "ldexpf128",
-    additional_deps = [":__support_math_ldexpf128"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_ldexpf128",
+    ],
 )
 
 libc_math_function(
     name = "ldexpf16",
-    additional_deps = [":__support_math_ldexpf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_ldexpf16",
+    ],
 )
 
 libc_math_function(
     name = "llogb",
-    additional_deps = [":__support_math_llogb"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_llogb",
+    ],
 )
 
 libc_math_function(
     name = "llogbf",
-    additional_deps = [":__support_math_llogbf"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_llogbf",
+    ],
 )
 
 libc_math_function(
     name = "llogbl",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_llogbl",
     ],
 )
@@ -5923,13 +6650,17 @@ libc_math_function(
 libc_math_function(
     name = "llogbf128",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_llogbf128",
     ],
 )
 
 libc_math_function(
     name = "llogbf16",
-    additional_deps = [":__support_math_llogbf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_llogbf16",
+    ],
 )
 
 libc_math_function(name = "llrint")
@@ -5938,9 +6669,15 @@ libc_math_function(name = "llrintf")
 
 libc_math_function(name = "llrintl")
 
-libc_math_function(name = "llrintf128")
+libc_math_function(
+    name = "llrintf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "llrintf16")
+libc_math_function(
+    name = "llrintf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "llround")
 
@@ -5948,9 +6685,15 @@ libc_math_function(name = "llroundf")
 
 libc_math_function(name = "llroundl")
 
-libc_math_function(name = "llroundf128")
+libc_math_function(
+    name = "llroundf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "llroundf16")
+libc_math_function(
+    name = "llroundf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "log",
@@ -5966,7 +6709,10 @@ libc_math_function(
 
 libc_math_function(
     name = "logf16",
-    additional_deps = [":__support_math_logf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_logf16",
+    ],
 )
 
 libc_math_function(
@@ -5984,6 +6730,7 @@ libc_math_function(
 libc_math_function(
     name = "log10f16",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_log10f16",
     ],
 )
@@ -6015,6 +6762,7 @@ libc_math_function(
 libc_math_function(
     name = "log2f16",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_log2f16",
     ],
 )
@@ -6038,12 +6786,16 @@ libc_math_function(
 
 libc_math_function(
     name = "logbf128",
-    additional_deps = [":__support_math_logbf128"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_logbf128",
+    ],
 )
 
 libc_math_function(
     name = "logbf16",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_logbf16",
     ],
 )
@@ -6054,9 +6806,15 @@ libc_math_function(name = "lrintf")
 
 libc_math_function(name = "lrintl")
 
-libc_math_function(name = "lrintf128")
+libc_math_function(
+    name = "lrintf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "lrintf16")
+libc_math_function(
+    name = "lrintf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "lround")
 
@@ -6064,9 +6822,15 @@ libc_math_function(name = "lroundf")
 
 libc_math_function(name = "lroundl")
 
-libc_math_function(name = "lroundf128")
+libc_math_function(
+    name = "lroundf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "lroundf16")
+libc_math_function(
+    name = "lroundf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "modf")
 
@@ -6074,13 +6838,20 @@ libc_math_function(name = "modff")
 
 libc_math_function(name = "modfl")
 
-libc_math_function(name = "modff128")
+libc_math_function(
+    name = "modff128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "modff16")
+libc_math_function(
+    name = "modff16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "nan",
     additional_deps = [
+        ":__support_libc_errno",
         ":__support_str_to_float",
         ":errno",
     ],
@@ -6089,6 +6860,7 @@ libc_math_function(
 libc_math_function(
     name = "nanf",
     additional_deps = [
+        ":__support_libc_errno",
         ":__support_str_to_float",
         ":errno",
     ],
@@ -6097,6 +6869,7 @@ libc_math_function(
 libc_math_function(
     name = "nanl",
     additional_deps = [
+        ":__support_libc_errno",
         ":__support_str_to_float",
         ":errno",
     ],
@@ -6105,6 +6878,8 @@ libc_math_function(
 libc_math_function(
     name = "nanf128",
     additional_deps = [
+        ":__support_libc_errno",
+        ":__support_macros_properties_types",
         ":__support_str_to_float",
         ":errno",
     ],
@@ -6113,6 +6888,8 @@ libc_math_function(
 libc_math_function(
     name = "nanf16",
     additional_deps = [
+        ":__support_libc_errno",
+        ":__support_macros_properties_types",
         ":__support_str_to_float",
         ":errno",
     ],
@@ -6124,9 +6901,15 @@ libc_math_function(name = "nearbyintf")
 
 libc_math_function(name = "nearbyintl")
 
-libc_math_function(name = "nearbyintf128")
+libc_math_function(
+    name = "nearbyintf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "nearbyintf16")
+libc_math_function(
+    name = "nearbyintf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "nextafter")
 
@@ -6134,9 +6917,15 @@ libc_math_function(name = "nextafterf")
 
 libc_math_function(name = "nextafterl")
 
-libc_math_function(name = "nextafterf128")
+libc_math_function(
+    name = "nextafterf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "nextafterf16")
+libc_math_function(
+    name = "nextafterf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "nextdown",
@@ -6177,7 +6966,10 @@ libc_math_function(name = "nexttoward")
 
 libc_math_function(name = "nexttowardf")
 
-libc_math_function(name = "nexttowardf16")
+libc_math_function(
+    name = "nexttowardf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "nexttowardl")
 
@@ -6187,9 +6979,15 @@ libc_math_function(name = "nextupf")
 
 libc_math_function(name = "nextupl")
 
-libc_math_function(name = "nextupf128")
+libc_math_function(
+    name = "nextupf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "nextupf16")
+libc_math_function(
+    name = "nextupf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(
     name = "pow",
@@ -6213,9 +7011,15 @@ libc_math_function(name = "remainderf")
 
 libc_math_function(name = "remainderl")
 
-libc_math_function(name = "remainderf128")
+libc_math_function(
+    name = "remainderf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "remainderf16")
+libc_math_function(
+    name = "remainderf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "remquo")
 
@@ -6223,9 +7027,15 @@ libc_math_function(name = "remquof")
 
 libc_math_function(name = "remquol")
 
-libc_math_function(name = "remquof128")
+libc_math_function(
+    name = "remquof128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "remquof16")
+libc_math_function(
+    name = "remquof16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "rint")
 
@@ -6233,9 +7043,19 @@ libc_math_function(name = "rintf")
 
 libc_math_function(name = "rintl")
 
-libc_math_function(name = "rintf128")
+libc_math_function(
+    name = "rintf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "rintf16")
+libc_math_function(
+    name = "rintf16",
+    additional_deps = [
+        ":__support_fputil_cast",
+        ":__support_macros_properties_cpu_features",
+        ":__support_macros_properties_types",
+    ],
+)
 
 libc_math_function(name = "round")
 
@@ -6243,9 +7063,19 @@ libc_math_function(name = "roundf")
 
 libc_math_function(name = "roundl")
 
-libc_math_function(name = "roundf128")
+libc_math_function(
+    name = "roundf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "roundf16")
+libc_math_function(
+    name = "roundf16",
+    additional_deps = [
+        ":__support_fputil_cast",
+        ":__support_macros_properties_cpu_features",
+        ":__support_macros_properties_types",
+    ],
+)
 
 libc_math_function(name = "roundeven")
 
@@ -6253,9 +7083,19 @@ libc_math_function(name = "roundevenf")
 
 libc_math_function(name = "roundevenl")
 
-libc_math_function(name = "roundevenf128")
+libc_math_function(
+    name = "roundevenf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "roundevenf16")
+libc_math_function(
+    name = "roundevenf16",
+    additional_deps = [
+        ":__support_fputil_cast",
+        ":__support_macros_properties_cpu_features",
+        ":__support_macros_properties_types",
+    ],
+)
 
 libc_math_function(
     name = "rsqrtf",
@@ -6264,28 +7104,73 @@ libc_math_function(
 
 libc_math_function(
     name = "rsqrtf16",
-    additional_deps = [":__support_math_rsqrtf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_rsqrtf16",
+    ],
 )
 
-libc_math_function(name = "scalbln")
+libc_math_function(
+    name = "scalbln",
+    additional_deps = [":hdr_float_macros"],
+)
 
-libc_math_function(name = "scalblnf")
+libc_math_function(
+    name = "scalblnf",
+    additional_deps = [":hdr_float_macros"],
+)
 
-libc_math_function(name = "scalblnl")
+libc_math_function(
+    name = "scalblnl",
+    additional_deps = [":hdr_float_macros"],
+)
 
-libc_math_function(name = "scalblnf128")
+libc_math_function(
+    name = "scalblnf128",
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":hdr_float_macros",
+    ],
+)
 
-libc_math_function(name = "scalblnf16")
+libc_math_function(
+    name = "scalblnf16",
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":hdr_float_macros",
+    ],
+)
 
-libc_math_function(name = "scalbn")
+libc_math_function(
+    name = "scalbn",
+    additional_deps = [":hdr_float_macros"],
+)
 
-libc_math_function(name = "scalbnf")
+libc_math_function(
+    name = "scalbnf",
+    additional_deps = [":hdr_float_macros"],
+)
 
-libc_math_function(name = "scalbnl")
+libc_math_function(
+    name = "scalbnl",
+    additional_deps = [":hdr_float_macros"],
+)
 
-libc_math_function(name = "scalbnf128")
+libc_math_function(
+    name = "scalbnf128",
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":hdr_float_macros",
+    ],
+)
 
-libc_math_function(name = "scalbnf16")
+libc_math_function(
+    name = "scalbnf16",
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":hdr_float_macros",
+    ],
+)
 
 libc_math_function(
     name = "setpayload",
@@ -6370,6 +7255,7 @@ libc_math_function(
 libc_math_function(
     name = "sinf16",
     additional_deps = [
+        ":__support_macros_properties_types",
         ":__support_math_sinf16",
         ":errno",
     ],
@@ -6395,7 +7281,10 @@ libc_math_function(
 
 libc_math_function(
     name = "sinhf16",
-    additional_deps = [":__support_math_sinhf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_sinhf16",
+    ],
 )
 
 libc_math_function(
@@ -6435,12 +7324,18 @@ libc_math_function(
 
 libc_math_function(
     name = "sqrtf128",
-    additional_deps = [":__support_math_sqrtf128"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_sqrtf128",
+    ],
 )
 
 libc_math_function(
     name = "sqrtf16",
-    additional_deps = [":__support_math_sqrtf16"],
+    additional_deps = [
+        ":__support_macros_properties_types",
+        ":__support_math_sqrtf16",
+    ],
 )
 
 libc_math_function(
@@ -6484,6 +7379,8 @@ libc_math_function(
 libc_math_function(
     name = "tanpif16",
     additional_deps = [
+        ":__support_macros_optimization",
+        ":__support_macros_properties_types",
         ":__support_math_sincosf16_utils",
         ":hdr_errno_macros",
         ":hdr_fenv_macros",
@@ -6498,9 +7395,15 @@ libc_math_function(name = "totalorderf")
 
 libc_math_function(name = "totalorderl")
 
-libc_math_function(name = "totalorderf128")
+libc_math_function(
+    name = "totalorderf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "totalorderf16")
+libc_math_function(
+    name = "totalorderf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "totalordermag")
 
@@ -6508,9 +7411,15 @@ libc_math_function(name = "totalordermagf")
 
 libc_math_function(name = "totalordermagl")
 
-libc_math_function(name = "totalordermagf128")
+libc_math_function(
+    name = "totalordermagf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "totalordermagf16")
+libc_math_function(
+    name = "totalordermagf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "trunc")
 
@@ -6518,9 +7427,19 @@ libc_math_function(name = "truncf")
 
 libc_math_function(name = "truncl")
 
-libc_math_function(name = "truncf128")
+libc_math_function(
+    name = "truncf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "truncf16")
+libc_math_function(
+    name = "truncf16",
+    additional_deps = [
+        ":__support_fputil_cast",
+        ":__support_macros_properties_cpu_features",
+        ":__support_macros_properties_types",
+    ],
+)
 
 libc_math_function(name = "ufromfp")
 
@@ -6528,9 +7447,15 @@ libc_math_function(name = "ufromfpf")
 
 libc_math_function(name = "ufromfpl")
 
-libc_math_function(name = "ufromfpf128")
+libc_math_function(
+    name = "ufromfpf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "ufromfpf16")
+libc_math_function(
+    name = "ufromfpf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 libc_math_function(name = "ufromfpx")
 
@@ -6538,9 +7463,15 @@ libc_math_function(name = "ufromfpxf")
 
 libc_math_function(name = "ufromfpxl")
 
-libc_math_function(name = "ufromfpxf128")
+libc_math_function(
+    name = "ufromfpxf128",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
-libc_math_function(name = "ufromfpxf16")
+libc_math_function(
+    name = "ufromfpxf16",
+    additional_deps = [":__support_macros_properties_types"],
+)
 
 ############################## inttypes targets ##############################
 
@@ -6550,8 +7481,11 @@ libc_function(
     hdrs = ["src/inttypes/strtoimax.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":errno",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -6561,8 +7495,11 @@ libc_function(
     hdrs = ["src/inttypes/strtoumax.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":errno",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -6573,6 +7510,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_integer_operations",
+        ":__support_macros_config",
     ],
 )
 
@@ -6583,6 +7521,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_integer_operations",
+        ":__support_macros_config",
     ],
 )
 
@@ -6624,6 +7563,7 @@ bit_prefix_needs_math_list = [
         deps = [
             ":__support_common",
             ":__support_cpp_bit",
+            ":__support_macros_config",
         ],
     )
     for bit_prefix in bit_prefix_list
@@ -6637,6 +7577,7 @@ bit_prefix_needs_math_list = [
         hdrs = ["src/stdbit/" + bit_prefix + bit_suffix + ".h"],
         deps = [
             ":__support_common",
+            ":__support_macros_config",
             ":__support_math_extras",
         ],
     )
@@ -6653,6 +7594,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_integer_operations",
+        ":__support_macros_config",
     ],
 )
 
@@ -6663,6 +7605,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_integer_operations",
+        ":__support_macros_config",
     ],
 )
 
@@ -6673,6 +7616,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_integer_operations",
+        ":__support_macros_config",
     ],
 )
 
@@ -6683,6 +7627,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_integer_operations",
+        ":__support_macros_config",
         ":types_div_t",
     ],
 )
@@ -6694,6 +7639,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_integer_operations",
+        ":__support_macros_config",
         ":types_ldiv_t",
     ],
 )
@@ -6705,6 +7651,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_integer_operations",
+        ":__support_macros_config",
         ":types_lldiv_t",
     ],
 )
@@ -6715,6 +7662,8 @@ libc_function(
     hdrs = ["src/stdlib/atoi.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":errno",
     ],
@@ -6726,6 +7675,8 @@ libc_function(
     hdrs = ["src/stdlib/atol.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":errno",
     ],
@@ -6737,6 +7688,8 @@ libc_function(
     hdrs = ["src/stdlib/atoll.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":errno",
     ],
@@ -6748,6 +7701,8 @@ libc_function(
     hdrs = ["src/stdlib/atof.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_float",
         ":errno",
     ],
@@ -6759,6 +7714,8 @@ libc_function(
     hdrs = ["src/stdlib/bsearch.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -6776,6 +7733,8 @@ libc_support_library(
         ":__support_cpp_bit",
         ":__support_cpp_cstddef",
         ":__support_macros_attributes",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
         ":string_memory_utils",
     ],
 )
@@ -6786,6 +7745,8 @@ libc_function(
     hdrs = ["src/stdlib/qsort.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
         ":qsort_util",
         ":types_size_t",
     ],
@@ -6797,6 +7758,8 @@ libc_function(
     hdrs = ["src/stdlib/qsort_r.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
         ":qsort_util",
         ":types_size_t",
     ],
@@ -6843,6 +7806,7 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_cpp_type_traits",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":printf_converter",
         ":printf_core_structs",
@@ -6856,6 +7820,9 @@ libc_function(
     hdrs = ["src/stdlib/strfromf.h"],
     deps = [
         ":__support_common",
+        ":__support_cpp_limits",
+        ":__support_macros_config",
+        ":printf_core_structs",
         ":printf_error_mapper",
         ":str_from_util",
     ],
@@ -6867,6 +7834,9 @@ libc_function(
     hdrs = ["src/stdlib/strfromd.h"],
     deps = [
         ":__support_common",
+        ":__support_cpp_limits",
+        ":__support_macros_config",
+        ":printf_core_structs",
         ":printf_error_mapper",
         ":str_from_util",
     ],
@@ -6878,6 +7848,9 @@ libc_function(
     hdrs = ["src/stdlib/strfroml.h"],
     deps = [
         ":__support_common",
+        ":__support_cpp_limits",
+        ":__support_macros_config",
+        ":printf_core_structs",
         ":printf_error_mapper",
         ":str_from_util",
     ],
@@ -6889,6 +7862,8 @@ libc_function(
     hdrs = ["src/stdlib/strtol.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":errno",
     ],
@@ -6900,6 +7875,8 @@ libc_function(
     hdrs = ["src/stdlib/strtoll.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":errno",
     ],
@@ -6911,6 +7888,8 @@ libc_function(
     hdrs = ["src/stdlib/strtoul.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":errno",
     ],
@@ -6922,6 +7901,8 @@ libc_function(
     hdrs = ["src/stdlib/strtoull.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":errno",
     ],
@@ -6933,6 +7914,8 @@ libc_function(
     hdrs = ["src/stdlib/strtof.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_float",
         ":errno",
     ],
@@ -6944,6 +7927,8 @@ libc_function(
     hdrs = ["src/stdlib/strtod.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_float",
         ":errno",
     ],
@@ -6955,6 +7940,8 @@ libc_function(
     hdrs = ["src/stdlib/strtold.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_float",
         ":errno",
     ],
@@ -7014,9 +8001,13 @@ libc_support_library(
         ":__support_cpp_simd",
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":__support_macros_properties_architectures",
+        ":__support_macros_properties_compiler",
         ":__support_macros_properties_cpu_features",
+        ":__support_macros_properties_types",
+        ":hdr_stdint_proxy",
     ],
 )
 
@@ -7031,8 +8022,10 @@ libc_support_library(
         ":__support_cpp_bitset",
         ":__support_cpp_type_traits",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":hdr_limits_macros",
+        ":hdr_stdint_proxy",
         ":llvm_libc_types_size_t",
         ":string_memory_utils",
         ":types_size_t",
@@ -7045,6 +8038,7 @@ libc_function(
     hdrs = ["src/strings/index.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_utils",
     ],
 )
@@ -7055,6 +8049,7 @@ libc_function(
     hdrs = ["src/strings/rindex.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_utils",
     ],
@@ -7066,6 +8061,7 @@ libc_function(
     hdrs = ["src/string/memchr.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_utils",
     ],
@@ -7077,6 +8073,7 @@ libc_function(
     hdrs = ["src/string/memcpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
     ],
@@ -7088,6 +8085,7 @@ libc_function(
     hdrs = ["src/string/memccpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
     ],
 )
@@ -7098,6 +8096,7 @@ libc_function(
     hdrs = ["src/string/memset.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
     ],
@@ -7109,6 +8108,7 @@ libc_function(
     hdrs = ["src/string/memset_explicit.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
     ],
@@ -7120,6 +8120,7 @@ libc_function(
     hdrs = ["src/string/memmove.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
     ],
@@ -7131,6 +8132,7 @@ libc_function(
     hdrs = ["src/string/memmem.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
     ],
@@ -7142,6 +8144,7 @@ libc_function(
     hdrs = ["src/string/mempcpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
     ],
@@ -7153,6 +8156,7 @@ libc_function(
     hdrs = ["src/strings/bcopy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_memory_utils",
     ],
 )
@@ -7164,6 +8168,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_integer_operations",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
     ],
@@ -7175,6 +8180,7 @@ libc_function(
     hdrs = ["src/strings/bcmp.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_memory_utils",
     ],
 )
@@ -7185,6 +8191,7 @@ libc_function(
     hdrs = ["src/strings/bzero.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_memory_utils",
     ],
 )
@@ -7195,6 +8202,7 @@ libc_function(
     hdrs = ["src/string/memrchr.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_utils",
     ],
@@ -7206,6 +8214,7 @@ libc_function(
     hdrs = ["src/string/stpcpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
         ":string_utils",
@@ -7218,6 +8227,7 @@ libc_function(
     hdrs = ["src/string/stpncpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
         ":string_utils",
@@ -7230,7 +8240,9 @@ libc_function(
     hdrs = ["src/string/strlen.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
+        ":llvm_libc_types_size_t",
         ":string_utils",
     ],
 )
@@ -7241,7 +8253,9 @@ libc_function(
     hdrs = ["src/string/strcpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
+        ":llvm_libc_types_size_t",
         ":string_memory_utils",
         ":string_utils",
     ],
@@ -7253,6 +8267,7 @@ libc_function(
     hdrs = ["src/string/strlcpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":llvm_libc_types_size_t",
         ":string_utils",
     ],
@@ -7264,6 +8279,7 @@ libc_function(
     hdrs = ["src/string/strncpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
     ],
 )
@@ -7274,6 +8290,7 @@ libc_function(
     hdrs = ["src/string/strcmp.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_memory_utils",
         ":string_utils",
     ],
@@ -7285,6 +8302,7 @@ libc_function(
     hdrs = ["src/string/strncmp.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
         ":string_utils",
@@ -7298,6 +8316,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_ctype_utils",
+        ":__support_macros_config",
         ":string_memory_utils",
     ],
 )
@@ -7309,6 +8328,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_ctype_utils",
+        ":__support_macros_config",
         ":string_memory_utils",
     ],
 )
@@ -7319,6 +8339,7 @@ libc_function(
     hdrs = ["src/string/strchr.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_utils",
     ],
 )
@@ -7329,6 +8350,7 @@ libc_function(
     hdrs = ["src/string/strrchr.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_utils",
     ],
 )
@@ -7339,6 +8361,7 @@ libc_function(
     hdrs = ["src/string/strchrnul.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_utils",
     ],
 )
@@ -7349,6 +8372,7 @@ libc_function(
     hdrs = ["src/string/strsep.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":hdr_signal_macros",
         ":string_memory_utils",
@@ -7362,6 +8386,7 @@ libc_function(
     hdrs = ["src/string/strstr.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
         ":string_utils",
@@ -7375,6 +8400,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_ctype_utils",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_memory_utils",
         ":string_utils",
@@ -7387,7 +8413,9 @@ libc_function(
     hdrs = ["src/string/strcat.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
+        ":llvm_libc_types_size_t",
         ":string_utils",
     ],
 )
@@ -7398,6 +8426,8 @@ libc_function(
     hdrs = ["src/string/strlcat.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
+        ":llvm_libc_types_size_t",
         ":string_utils",
     ],
 )
@@ -7408,7 +8438,9 @@ libc_function(
     hdrs = ["src/string/strncat.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
+        ":llvm_libc_types_size_t",
         ":string_utils",
     ],
 )
@@ -7419,6 +8451,7 @@ libc_function(
     hdrs = ["src/string/strnlen.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_utils",
     ],
 )
@@ -7429,6 +8462,7 @@ libc_function(
     hdrs = ["src/string/strcspn.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_utils",
     ],
 )
@@ -7440,6 +8474,7 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_cpp_bitset",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":string_utils",
     ],
@@ -7451,6 +8486,7 @@ libc_function(
     hdrs = ["src/string/strpbrk.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_utils",
     ],
 )
@@ -7461,6 +8497,7 @@ libc_function(
     hdrs = ["src/string/strtok.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_utils",
     ],
 )
@@ -7471,6 +8508,7 @@ libc_function(
     hdrs = ["src/string/strtok_r.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_utils",
     ],
 )
@@ -7487,6 +8525,8 @@ libc_function(
     }),
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_fcntl",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7504,6 +8544,8 @@ libc_function(
     }),
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_fcntl",
         ":errno",
     ],
@@ -7519,6 +8561,8 @@ libc_function(
     }),
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7532,6 +8576,8 @@ libc_function(
     hdrs = ["src/fcntl/creat.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7546,6 +8592,8 @@ libc_function(
     hdrs = ["src/unistd/access.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7558,6 +8606,8 @@ libc_function(
     hdrs = ["src/unistd/chdir.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -7569,6 +8619,8 @@ libc_function(
     hdrs = ["src/unistd/close.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_fcntl",
         ":errno",
     ],
@@ -7580,6 +8632,8 @@ libc_function(
     hdrs = ["src/unistd/dup.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_unistd_macros",
@@ -7592,6 +8646,8 @@ libc_function(
     hdrs = ["src/unistd/dup2.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7609,6 +8665,8 @@ libc_function(
     }),
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_unistd_macros",
@@ -7621,6 +8679,7 @@ libc_function(
     hdrs = ["src/unistd/environ.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -7632,6 +8691,8 @@ libc_function(
     hdrs = ["src/unistd/fchdir.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -7643,6 +8704,8 @@ libc_function(
     hdrs = ["src/unistd/fsync.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -7654,8 +8717,11 @@ libc_function(
     hdrs = ["src/unistd/ftruncate.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
+        ":hdr_stdint_proxy",
         ":hdr_unistd_macros",
         ":types_off_t",
     ],
@@ -7680,6 +8746,7 @@ libc_function(
     hdrs = ["src/unistd/geteuid.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_unistd_macros",
@@ -7693,6 +8760,8 @@ libc_function(
     srcs = ["src/unistd/linux/getpagesize.cpp"],
     hdrs = ["src/unistd/getpagesize.h"],
     deps = [
+        ":__support_common",
+        ":__support_macros_config",
         ":__support_osutil_linux_auxv",
     ],
 )
@@ -7703,6 +8772,7 @@ libc_function(
     hdrs = ["src/unistd/getppid.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_unistd_macros",
@@ -7716,6 +8786,7 @@ libc_function(
     hdrs = ["src/unistd/getuid.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_unistd_macros",
@@ -7744,6 +8815,8 @@ libc_function(
     hdrs = ["src/unistd/isatty.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_unistd_macros",
@@ -7756,6 +8829,8 @@ libc_function(
     hdrs = ["src/unistd/link.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7769,6 +8844,8 @@ libc_function(
     hdrs = ["src/unistd/linkat.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7782,6 +8859,8 @@ libc_function(
     hdrs = ["src/unistd/pipe.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
@@ -7795,6 +8874,8 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_file_linux_lseekimpl",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_unistd_macros",
@@ -7812,9 +8893,12 @@ libc_function(
     }),
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
+        ":hdr_stdint_proxy",
         ":hdr_unistd_macros",
         ":types_off_t",
         ":types_size_t",
@@ -7832,8 +8916,11 @@ libc_function(
     }),
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
+        ":hdr_stdint_proxy",
         ":hdr_unistd_macros",
         ":types_off_t",
         ":types_size_t",
@@ -7847,6 +8934,8 @@ libc_function(
     hdrs = ["src/unistd/read.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
@@ -7862,6 +8951,8 @@ libc_function(
     hdrs = ["src/unistd/readlink.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7877,6 +8968,8 @@ libc_function(
     hdrs = ["src/unistd/readlinkat.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7892,6 +8985,8 @@ libc_function(
     hdrs = ["src/unistd/rmdir.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7904,6 +8999,8 @@ libc_function(
     hdrs = ["src/unistd/symlink.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7917,6 +9014,8 @@ libc_function(
     hdrs = ["src/unistd/symlinkat.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7945,6 +9044,7 @@ libc_function(
     hdrs = ["src/unistd/swab.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_unistd_macros",
@@ -7958,8 +9058,11 @@ libc_function(
     hdrs = ["src/unistd/truncate.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
+        ":hdr_stdint_proxy",
         ":hdr_unistd_macros",
         ":types_off_t",
     ],
@@ -7971,6 +9074,8 @@ libc_function(
     hdrs = ["src/unistd/unlink.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7983,6 +9088,8 @@ libc_function(
     hdrs = ["src/unistd/unlinkat.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -7996,6 +9103,8 @@ libc_function(
     hdrs = ["src/unistd/sysconf.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_linux_auxv",
         ":errno",
         ":hdr_unistd_macros",
@@ -8008,6 +9117,8 @@ libc_function(
     hdrs = ["src/unistd/write.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_unistd_macros",
@@ -8030,7 +9141,9 @@ libc_support_library(
     hdrs = ["src/stdio/printf_core/core_structs.h"],
     deps = [
         ":__support_cpp_string_view",
+        ":__support_cpp_type_traits",
         ":__support_fputil_fp_bits",
+        ":__support_macros_config",
         ":printf_config",
     ],
 )
@@ -8043,13 +9156,18 @@ libc_support_library(
         ":__support_common",
         ":__support_cpp_algorithm",
         ":__support_cpp_bit",
+        ":__support_cpp_limits",
         ":__support_cpp_optional",
         ":__support_cpp_string_view",
         ":__support_cpp_type_traits",
         ":__support_ctype_utils",
+        ":__support_fixed_point",
         ":__support_fputil_fp_bits",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":errno",
+        ":llvm_libc_macros_stdfix_macros",
         ":printf_config",
         ":printf_core_structs",
         ":types_wint_t",
@@ -8061,6 +9179,7 @@ libc_support_library(
     hdrs = ["src/stdio/printf_core/writer.h"],
     deps = [
         ":__support_cpp_string_view",
+        ":__support_macros_config",
         ":__support_macros_optimization",
         ":printf_core_structs",
         ":string_memory_utils",
@@ -8096,10 +9215,12 @@ libc_support_library(
         ":__support_fputil_rounding_mode",
         ":__support_integer_to_string",
         ":__support_libc_assert",
+        ":__support_macros_config",
         ":__support_stringutil",
         ":__support_uint128",
         ":__support_wchar_mbstate",
         ":__support_wchar_wcrtomb",
+        ":hdr_limits_macros",
         ":hdr_wchar_macros",
         ":printf_config",
         ":printf_core_structs",
@@ -8133,6 +9254,8 @@ libc_support_library(
     hdrs = ["src/stdio/printf_core/printf_main.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_error_or",
+        ":__support_macros_config",
         ":printf_converter",
         ":printf_core_structs",
         ":printf_error_mapper",
@@ -8146,8 +9269,11 @@ libc_support_library(
     hdrs = ["src/stdio/printf_core/vfprintf_internal.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_error_or",
         ":__support_file_file",
         ":__support_macros_attributes",
+        ":__support_macros_config",
+        ":printf_core_structs",
         ":printf_main",
         ":printf_writer",
         ":types_FILE",
@@ -8159,10 +9285,12 @@ libc_support_library(
     hdrs = ["src/stdio/printf_core/vasprintf_internal.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_error_or",
         ":__support_macros_attributes",
         ":func_free",
         ":func_malloc",
         ":func_realloc",
+        ":printf_core_structs",
         ":printf_main",
         ":printf_writer",
         ":types_FILE",
@@ -8175,6 +9303,11 @@ libc_function(
     hdrs = ["src/stdio/asprintf.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_cpp_limits",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":printf_core_structs",
+        ":printf_error_mapper",
         ":vasprintf_internal",
     ],
 )
@@ -8186,7 +9319,11 @@ libc_function(
     deps = [
         ":__support_arg_list",
         ":__support_cpp_limits",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":errno",
+        ":printf_core_structs",
+        ":printf_error_mapper",
         ":printf_main",
         ":printf_writer",
     ],
@@ -8198,7 +9335,12 @@ libc_function(
     hdrs = ["src/stdio/snprintf.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_cpp_limits",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":errno",
+        ":printf_core_structs",
+        ":printf_error_mapper",
         ":printf_main",
         ":printf_writer",
     ],
@@ -8210,8 +9352,12 @@ libc_function(
     hdrs = ["src/stdio/printf.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_cpp_limits",
         ":__support_file_file",
+        ":__support_macros_config",
         ":errno",
+        ":printf_core_structs",
+        ":printf_error_mapper",
         ":types_FILE",
         ":vfprintf_internal",
     ],
@@ -8223,8 +9369,12 @@ libc_function(
     hdrs = ["src/stdio/fprintf.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_cpp_limits",
         ":__support_file_file",
+        ":__support_macros_config",
         ":errno",
+        ":printf_core_structs",
+        ":printf_error_mapper",
         ":types_FILE",
         ":vfprintf_internal",
     ],
@@ -8236,6 +9386,11 @@ libc_function(
     hdrs = ["src/stdio/vasprintf.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_cpp_limits",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":printf_core_structs",
+        ":printf_error_mapper",
         ":vasprintf_internal",
     ],
 )
@@ -8247,7 +9402,11 @@ libc_function(
     deps = [
         ":__support_arg_list",
         ":__support_cpp_limits",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":errno",
+        ":printf_core_structs",
+        ":printf_error_mapper",
         ":printf_main",
         ":printf_writer",
     ],
@@ -8259,7 +9418,12 @@ libc_function(
     hdrs = ["src/stdio/vsnprintf.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_cpp_limits",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":errno",
+        ":printf_core_structs",
+        ":printf_error_mapper",
         ":printf_main",
         ":printf_writer",
     ],
@@ -8271,8 +9435,12 @@ libc_function(
     hdrs = ["src/stdio/vprintf.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_cpp_limits",
         ":__support_file_file",
+        ":__support_macros_config",
         ":errno",
+        ":printf_core_structs",
+        ":printf_error_mapper",
         ":types_FILE",
         ":vfprintf_internal",
     ],
@@ -8284,8 +9452,12 @@ libc_function(
     hdrs = ["src/stdio/vfprintf.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_cpp_limits",
         ":__support_file_file",
+        ":__support_macros_config",
         ":errno",
+        ":printf_core_structs",
+        ":printf_error_mapper",
         ":types_FILE",
         ":vfprintf_internal",
     ],
@@ -8303,6 +9475,7 @@ libc_support_library(
         ":__support_cpp_bitset",
         ":__support_cpp_string_view",
         ":__support_fputil_fp_bits",
+        ":__support_macros_config",
         ":scanf_config",
     ],
 )
@@ -8314,6 +9487,7 @@ libc_support_library(
         ":__support_arg_list",
         ":__support_cpp_bitset",
         ":__support_ctype_utils",
+        ":__support_macros_config",
         ":__support_str_to_integer",
         ":scanf_config",
         ":scanf_core_structs",
@@ -8326,6 +9500,7 @@ libc_support_library(
     deps = [
         ":__support_cpp_string_view",
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":types_FILE",
     ],
 )
@@ -8335,6 +9510,7 @@ libc_support_library(
     hdrs = ["src/stdio/scanf_core/string_reader.h"],
     deps = [
         ":__support_macros_attributes",
+        ":__support_macros_config",
         ":scanf_reader",
     ],
 )
@@ -8356,6 +9532,7 @@ libc_support_library(
         ":__support_cpp_limits",
         ":__support_cpp_string_view",
         ":__support_ctype_utils",
+        ":__support_macros_config",
         ":__support_str_to_float",
         ":scanf_core_structs",
         ":scanf_reader",
@@ -8367,6 +9544,7 @@ libc_support_library(
     hdrs = ["src/stdio/scanf_core/scanf_main.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_macros_config",
         ":scanf_config",
         ":scanf_converter",
         ":scanf_core_structs",
@@ -8382,6 +9560,8 @@ libc_support_library(
         ":__support_arg_list",
         ":__support_file_file",
         ":__support_macros_attributes",
+        ":__support_macros_config",
+        ":__support_macros_properties_architectures",
         ":scanf_main",
         ":scanf_reader",
         ":types_FILE",
@@ -8395,6 +9575,7 @@ libc_function(
     deps = [
         ":__support_arg_list",
         ":__support_file_file",
+        ":__support_macros_config",
         ":types_FILE",
         ":vfscanf_internal",
     ],
@@ -8407,6 +9588,7 @@ libc_function(
     deps = [
         ":__support_arg_list",
         ":__support_file_file",
+        ":__support_macros_config",
         ":types_FILE",
         ":vfscanf_internal",
     ],
@@ -8419,6 +9601,7 @@ libc_function(
     deps = [
         ":__support_arg_list",
         ":__support_file_file",
+        ":__support_macros_config",
         ":types_FILE",
         ":vfscanf_internal",
     ],
@@ -8431,6 +9614,7 @@ libc_function(
     deps = [
         ":__support_arg_list",
         ":__support_file_file",
+        ":__support_macros_config",
         ":types_FILE",
         ":vfscanf_internal",
     ],
@@ -8442,7 +9626,10 @@ libc_function(
     hdrs = ["src/stdio/sscanf.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_cpp_limits",
         ":__support_file_file",
+        ":__support_macros_config",
+        ":hdr_stdio_macros",
         ":scanf_main",
         ":scanf_string_reader",
         ":types_FILE",
@@ -8455,7 +9642,10 @@ libc_function(
     hdrs = ["src/stdio/vsscanf.h"],
     deps = [
         ":__support_arg_list",
+        ":__support_cpp_limits",
         ":__support_file_file",
+        ":__support_macros_config",
+        ":hdr_stdio_macros",
         ":scanf_main",
         ":scanf_string_reader",
         ":types_FILE",
@@ -8468,6 +9658,8 @@ libc_function(
     hdrs = ["src/stdio/remove.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -8486,6 +9678,8 @@ libc_function(
     }),
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -8501,6 +9695,8 @@ libc_function(
     hdrs = ["src/sys/mman/madvise.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8512,6 +9708,8 @@ libc_function(
     hdrs = ["src/sys/mman/mincore.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8523,6 +9721,8 @@ libc_function(
     hdrs = ["src/sys/mman/mlock.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8534,6 +9734,8 @@ libc_function(
     hdrs = ["src/sys/mman/mlock2.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8545,6 +9747,8 @@ libc_function(
     hdrs = ["src/sys/mman/mlockall.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8556,6 +9760,8 @@ libc_function(
     hdrs = ["src/sys/mman/mmap.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8567,6 +9773,9 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_error_or",
+        ":__support_libc_errno",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8578,6 +9787,9 @@ libc_function(
     hdrs = ["src/sys/mman/mprotect.h"],
     deps = [
         ":__support_common",
+        ":__support_error_or",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":mprotect_common",
@@ -8590,6 +9802,8 @@ libc_function(
     hdrs = ["src/sys/mman/mremap.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8601,6 +9815,8 @@ libc_function(
     hdrs = ["src/sys/mman/msync.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8612,6 +9828,8 @@ libc_function(
     hdrs = ["src/sys/mman/munlock.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8623,6 +9841,8 @@ libc_function(
     hdrs = ["src/sys/mman/munlockall.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8634,6 +9854,8 @@ libc_function(
     hdrs = ["src/sys/mman/munmap.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8645,8 +9867,11 @@ libc_function(
     hdrs = ["src/sys/mman/pkey_alloc.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
+        ":hdr_errno_macros",
     ],
 )
 
@@ -8656,8 +9881,11 @@ libc_function(
     hdrs = ["src/sys/mman/pkey_free.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
+        ":hdr_errno_macros",
     ],
 )
 
@@ -8668,6 +9896,9 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_error_or",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_macros_properties_architectures",
         ":__support_osutil_syscall",
         ":errno",
         ":pkey_common",
@@ -8680,8 +9911,12 @@ libc_function(
     hdrs = ["src/sys/mman/pkey_mprotect.h"],
     deps = [
         ":__support_common",
+        ":__support_error_or",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
+        ":hdr_errno_macros",
         ":mprotect_common",
         ":types_size_t",
     ],
@@ -8694,6 +9929,9 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_error_or",
+        ":__support_libc_errno",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":pkey_common",
@@ -8723,6 +9961,7 @@ libc_function(
     hdrs = ["src/sys/mman/posix_madvise.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8734,6 +9973,8 @@ libc_function(
     hdrs = ["src/sys/mman/remap_file_pages.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8749,6 +9990,7 @@ libc_support_library(
         ":__support_error_or",
         ":__support_macros_config",
         ":errno",
+        ":hdr_errno_macros",
         ":string_memory_utils",
     ],
 )
@@ -8759,6 +10001,8 @@ libc_function(
     hdrs = ["src/sys/mman/shm_open.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_fcntl",
         ":errno",
         ":hdr_fcntl_macros",
@@ -8773,6 +10017,8 @@ libc_function(
     hdrs = ["src/sys/mman/shm_unlink.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -8789,6 +10035,8 @@ libc_function(
     hdrs = ["src/sys/resource/getrlimit.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":types_struct_rlimit",
@@ -8801,6 +10049,8 @@ libc_function(
     hdrs = ["src/sys/resource/setrlimit.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":types_struct_rlimit",
@@ -8815,6 +10065,8 @@ libc_function(
     hdrs = ["src/sys/stat/mkdir.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_fcntl_macros",
@@ -8828,6 +10080,8 @@ libc_function(
     hdrs = ["src/sys/stat/mkdirat.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8841,6 +10095,8 @@ libc_function(
     hdrs = ["src/sys/socket/socket.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8852,6 +10108,9 @@ libc_function(
     hdrs = ["src/sys/socket/socketpair.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8863,6 +10122,8 @@ libc_function(
     hdrs = ["src/sys/socket/send.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":types_socklen_t",
@@ -8877,6 +10138,8 @@ libc_function(
     hdrs = ["src/sys/socket/sendto.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":types_socklen_t",
@@ -8891,6 +10154,8 @@ libc_function(
     hdrs = ["src/sys/socket/sendmsg.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":types_ssize_t",
@@ -8904,6 +10169,9 @@ libc_function(
     hdrs = ["src/sys/socket/recv.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
         ":types_socklen_t",
@@ -8918,6 +10186,9 @@ libc_function(
     hdrs = ["src/sys/socket/recvfrom.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
         ":types_socklen_t",
@@ -8932,6 +10203,9 @@ libc_function(
     hdrs = ["src/sys/socket/recvmsg.h"],
     deps = [
         ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
         ":types_ssize_t",
@@ -8950,6 +10224,9 @@ libc_function(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8964,6 +10241,9 @@ libc_function(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
     ],
@@ -8978,6 +10258,9 @@ libc_function(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_osutil_syscall",
         ":errno",
         ":hdr_sys_epoll_macros",
@@ -8994,6 +10277,9 @@ libc_function(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
@@ -9013,6 +10299,9 @@ libc_function(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
@@ -9032,6 +10321,9 @@ libc_function(
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
         ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
@@ -9126,6 +10418,7 @@ libc_function(
     hdrs = ["src/wchar/wcscmp.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":types_size_t",
         ":types_wchar_t",
@@ -9217,6 +10510,7 @@ libc_function(
     hdrs = ["src/wchar/wcsncmp.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":types_size_t",
         ":types_wchar_t",
@@ -9241,6 +10535,7 @@ libc_function(
     hdrs = ["src/wchar/wcspbrk.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":types_wchar_t",
         ":wchar_utils",
@@ -9343,6 +10638,7 @@ libc_function(
     hdrs = ["src/wchar/wmemmove.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":__support_macros_null_check",
         ":types_size_t",
         ":types_wchar_t",
@@ -9355,6 +10651,7 @@ libc_function(
     hdrs = ["src/wchar/wmempcpy.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":string_memory_utils",
         ":types_size_t",
         ":types_wchar_t",
@@ -9367,6 +10664,7 @@ libc_function(
     hdrs = ["src/wchar/wmemset.h"],
     deps = [
         ":__support_common",
+        ":__support_macros_config",
         ":types_size_t",
         ":types_wchar_t",
     ],

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5384,7 +5384,6 @@ libc_math_function(
 libc_math_function(
     name = "acosf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_acosf16",
         ":errno",
     ],
@@ -5398,7 +5397,6 @@ libc_math_function(
 libc_math_function(
     name = "acoshf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_acoshf16",
         ":errno",
     ],
@@ -5407,7 +5405,6 @@ libc_math_function(
 libc_math_function(
     name = "acospif16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_acospif16",
         ":errno",
     ],
@@ -5426,7 +5423,6 @@ libc_math_function(
 libc_math_function(
     name = "asinf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_asinf16",
     ],
 )
@@ -5439,7 +5435,6 @@ libc_math_function(
 libc_math_function(
     name = "asinhf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_asinhf16",
     ],
 )
@@ -5452,7 +5447,6 @@ libc_math_function(
 libc_math_function(
     name = "atanf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_atanf16",
     ],
 )
@@ -5470,7 +5464,6 @@ libc_math_function(
 libc_math_function(
     name = "atan2f128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_atan2f128",
     ],
 )
@@ -5488,7 +5481,6 @@ libc_math_function(
 libc_math_function(
     name = "atanhf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_atanhf16",
     ],
 )
@@ -5611,12 +5603,10 @@ libc_math_function(name = "iscanonicall")
 
 libc_math_function(
     name = "iscanonicalf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "iscanonicalf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "issignaling")
@@ -5627,12 +5617,10 @@ libc_math_function(name = "issignalingl")
 
 libc_math_function(
     name = "issignalingf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "issignalingf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -5695,12 +5683,10 @@ libc_math_function(name = "copysignl")
 
 libc_math_function(
     name = "copysignf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "copysignf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -5716,7 +5702,6 @@ libc_math_function(
 libc_math_function(
     name = "cosf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_cosf16",
     ],
 )
@@ -5729,7 +5714,6 @@ libc_math_function(
 libc_math_function(
     name = "coshf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_coshf16",
     ],
 )
@@ -5742,7 +5726,6 @@ libc_math_function(
 libc_math_function(
     name = "cospif16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_cospif16",
     ],
 )
@@ -5751,14 +5734,12 @@ libc_math_function(name = "daddl")
 
 libc_math_function(
     name = "daddf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "ddivl")
 
 libc_math_function(
     name = "ddivf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -5769,7 +5750,6 @@ libc_math_function(
 libc_math_function(
     name = "dfmaf128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_dfmaf128",
         ":llvm_libc_types_float128",
     ],
@@ -5779,7 +5759,6 @@ libc_math_function(name = "dmull")
 
 libc_math_function(
     name = "dmulf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -5791,7 +5770,6 @@ libc_math_function(
     name = "dsqrtf128",
     additional_deps = [
         ":__support_fputil_sqrt",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -5799,7 +5777,6 @@ libc_math_function(name = "dsubl")
 
 libc_math_function(
     name = "dsubf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -5826,7 +5803,6 @@ libc_math_function(
 libc_math_function(
     name = "expf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_expf16",
         ":__support_math_expxf16_utils",
     ],
@@ -5851,7 +5827,6 @@ libc_math_function(
 libc_math_function(
     name = "exp10f16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_exp10f16",
         ":errno",
     ],
@@ -5860,7 +5835,6 @@ libc_math_function(
 libc_math_function(
     name = "exp10m1f16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_exp10m1f16",
     ],
 )
@@ -5883,7 +5857,6 @@ libc_math_function(
 libc_math_function(
     name = "exp2f16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_exp2f16",
     ],
 )
@@ -5896,7 +5869,6 @@ libc_math_function(
 libc_math_function(
     name = "exp2m1f16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_exp2m1f16",
     ],
 )
@@ -5914,7 +5886,6 @@ libc_math_function(
 libc_math_function(
     name = "expm1f16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_expm1f16",
     ],
 )
@@ -5941,28 +5912,23 @@ libc_math_function(
 
 libc_math_function(
     name = "f16div",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "f16divf",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "f16divf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "f16divl",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "f16fma",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_f16fma",
     ],
 )
@@ -5970,7 +5936,6 @@ libc_math_function(
 libc_math_function(
     name = "f16fmaf",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_f16fmaf",
     ],
 )
@@ -5978,7 +5943,6 @@ libc_math_function(
 libc_math_function(
     name = "f16fmaf128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_f16fmaf128",
     ],
 )
@@ -5986,35 +5950,29 @@ libc_math_function(
 libc_math_function(
     name = "f16fmal",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_f16fmal",
     ],
 )
 
 libc_math_function(
     name = "f16mul",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "f16mulf",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "f16mulf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "f16mull",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "f16sqrt",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_f16sqrt",
     ],
 )
@@ -6022,7 +5980,6 @@ libc_math_function(
 libc_math_function(
     name = "f16sqrtf",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_f16sqrtf",
     ],
 )
@@ -6031,14 +5988,12 @@ libc_math_function(
     name = "f16sqrtf128",
     additional_deps = [
         ":__support_fputil_sqrt",
-        ":__support_macros_properties_types",
     ],
 )
 
 libc_math_function(
     name = "f16sqrtl",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_f16sqrtl",
         ":errno",
     ],
@@ -6046,22 +6001,18 @@ libc_math_function(
 
 libc_math_function(
     name = "f16sub",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "f16subf",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "f16subf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "f16subl",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "fabs")
@@ -6072,7 +6023,6 @@ libc_math_function(name = "fabsl")
 
 libc_math_function(
     name = "fabsf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -6080,7 +6030,6 @@ libc_math_function(
     additional_deps = [
         ":__support_macros_properties_architectures",
         ":__support_macros_properties_compiler",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -6113,12 +6062,10 @@ libc_math_function(name = "fdiml")
 
 libc_math_function(
     name = "fdimf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fdimf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "fdiv")
@@ -6127,7 +6074,6 @@ libc_math_function(name = "fdivl")
 
 libc_math_function(
     name = "fdivf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -6146,7 +6092,6 @@ libc_math_function(
     name = "ffmaf128",
     additional_deps = [
         ":__support_fputil_fma",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -6158,7 +6103,6 @@ libc_math_function(name = "floorl")
 
 libc_math_function(
     name = "floorf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -6166,7 +6110,6 @@ libc_math_function(
     additional_deps = [
         ":__support_fputil_cast",
         ":__support_macros_properties_cpu_features",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -6184,7 +6127,6 @@ libc_math_function(
     name = "fmaf16",
     additional_deps = [
         ":__support_fputil_fma",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -6238,12 +6180,10 @@ libc_math_function(name = "fmaximuml")
 
 libc_math_function(
     name = "fmaximumf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fmaximumf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "fmaximum_mag")
@@ -6254,12 +6194,10 @@ libc_math_function(name = "fmaximum_magl")
 
 libc_math_function(
     name = "fmaximum_magf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fmaximum_magf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "fmaximum_mag_num")
@@ -6270,12 +6208,10 @@ libc_math_function(name = "fmaximum_mag_numl")
 
 libc_math_function(
     name = "fmaximum_mag_numf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fmaximum_mag_numf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "fmaximum_num")
@@ -6286,12 +6222,10 @@ libc_math_function(name = "fmaximum_numl")
 
 libc_math_function(
     name = "fmaximum_numf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fmaximum_numf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "fmin")
@@ -6302,12 +6236,10 @@ libc_math_function(name = "fminl")
 
 libc_math_function(
     name = "fminf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fminf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "fminimum")
@@ -6318,12 +6250,10 @@ libc_math_function(name = "fminimuml")
 
 libc_math_function(
     name = "fminimumf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fminimumf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "fminimum_mag")
@@ -6334,12 +6264,10 @@ libc_math_function(name = "fminimum_magl")
 
 libc_math_function(
     name = "fminimum_magf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fminimum_magf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "fminimum_mag_num")
@@ -6350,12 +6278,10 @@ libc_math_function(name = "fminimum_mag_numl")
 
 libc_math_function(
     name = "fminimum_mag_numf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fminimum_mag_numf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "fminimum_num")
@@ -6366,12 +6292,10 @@ libc_math_function(name = "fminimum_numl")
 
 libc_math_function(
     name = "fminimum_numf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fminimum_numf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -6384,7 +6308,6 @@ libc_math_function(
     additional_deps = [
         ":__support_fputil_bfloat16",
         ":__support_fputil_generic_fmod",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -6402,7 +6325,6 @@ libc_math_function(
     name = "fmodf128",
     additional_deps = [
         ":__support_fputil_generic_fmod",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -6410,7 +6332,6 @@ libc_math_function(
     name = "fmodf16",
     additional_deps = [
         ":__support_fputil_generic_fmod",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -6427,7 +6348,6 @@ libc_math_function(name = "fmull")
 
 libc_math_function(
     name = "fmulf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "frexp")
@@ -6442,7 +6362,6 @@ libc_math_function(name = "frexpl")
 libc_math_function(
     name = "frexpf128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_frexpf128",
     ],
 )
@@ -6450,7 +6369,6 @@ libc_math_function(
 libc_math_function(
     name = "frexpf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_frexpf16",
     ],
 )
@@ -6463,12 +6381,10 @@ libc_math_function(name = "fromfpl")
 
 libc_math_function(
     name = "fromfpf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fromfpf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "fromfpx")
@@ -6479,12 +6395,10 @@ libc_math_function(name = "fromfpxl")
 
 libc_math_function(
     name = "fromfpxf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "fromfpxf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -6500,7 +6414,6 @@ libc_math_function(
 libc_math_function(
     name = "fsqrtf128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_fsqrtf128",
         ":errno",
     ],
@@ -6512,7 +6425,6 @@ libc_math_function(name = "fsubl")
 
 libc_math_function(
     name = "fsubf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -6585,7 +6497,6 @@ libc_math_function(
 libc_math_function(
     name = "ilogbf128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_ilogbf128",
     ],
 )
@@ -6593,7 +6504,6 @@ libc_math_function(
 libc_math_function(
     name = "ilogbf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_ilogbf16",
     ],
 )
@@ -6610,7 +6520,6 @@ libc_math_function(name = "ldexpl")
 libc_math_function(
     name = "ldexpf128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_ldexpf128",
     ],
 )
@@ -6618,7 +6527,6 @@ libc_math_function(
 libc_math_function(
     name = "ldexpf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_ldexpf16",
     ],
 )
@@ -6626,7 +6534,6 @@ libc_math_function(
 libc_math_function(
     name = "llogb",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_llogb",
     ],
 )
@@ -6634,7 +6541,6 @@ libc_math_function(
 libc_math_function(
     name = "llogbf",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_llogbf",
     ],
 )
@@ -6642,7 +6548,6 @@ libc_math_function(
 libc_math_function(
     name = "llogbl",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_llogbl",
     ],
 )
@@ -6650,7 +6555,6 @@ libc_math_function(
 libc_math_function(
     name = "llogbf128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_llogbf128",
     ],
 )
@@ -6658,7 +6562,6 @@ libc_math_function(
 libc_math_function(
     name = "llogbf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_llogbf16",
     ],
 )
@@ -6671,12 +6574,10 @@ libc_math_function(name = "llrintl")
 
 libc_math_function(
     name = "llrintf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "llrintf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "llround")
@@ -6687,12 +6588,10 @@ libc_math_function(name = "llroundl")
 
 libc_math_function(
     name = "llroundf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "llroundf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -6710,7 +6609,6 @@ libc_math_function(
 libc_math_function(
     name = "logf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_logf16",
     ],
 )
@@ -6730,7 +6628,6 @@ libc_math_function(
 libc_math_function(
     name = "log10f16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_log10f16",
     ],
 )
@@ -6762,7 +6659,6 @@ libc_math_function(
 libc_math_function(
     name = "log2f16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_log2f16",
     ],
 )
@@ -6787,7 +6683,6 @@ libc_math_function(
 libc_math_function(
     name = "logbf128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_logbf128",
     ],
 )
@@ -6795,7 +6690,6 @@ libc_math_function(
 libc_math_function(
     name = "logbf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_logbf16",
     ],
 )
@@ -6808,12 +6702,10 @@ libc_math_function(name = "lrintl")
 
 libc_math_function(
     name = "lrintf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "lrintf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "lround")
@@ -6824,12 +6716,10 @@ libc_math_function(name = "lroundl")
 
 libc_math_function(
     name = "lroundf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "lroundf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "modf")
@@ -6840,12 +6730,10 @@ libc_math_function(name = "modfl")
 
 libc_math_function(
     name = "modff128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "modff16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -6879,7 +6767,6 @@ libc_math_function(
     name = "nanf128",
     additional_deps = [
         ":__support_libc_errno",
-        ":__support_macros_properties_types",
         ":__support_str_to_float",
         ":errno",
     ],
@@ -6889,7 +6776,6 @@ libc_math_function(
     name = "nanf16",
     additional_deps = [
         ":__support_libc_errno",
-        ":__support_macros_properties_types",
         ":__support_str_to_float",
         ":errno",
     ],
@@ -6903,12 +6789,10 @@ libc_math_function(name = "nearbyintl")
 
 libc_math_function(
     name = "nearbyintf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "nearbyintf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "nextafter")
@@ -6919,12 +6803,10 @@ libc_math_function(name = "nextafterl")
 
 libc_math_function(
     name = "nextafterf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "nextafterf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -6968,7 +6850,6 @@ libc_math_function(name = "nexttowardf")
 
 libc_math_function(
     name = "nexttowardf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "nexttowardl")
@@ -6981,12 +6862,10 @@ libc_math_function(name = "nextupl")
 
 libc_math_function(
     name = "nextupf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "nextupf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -7013,12 +6892,10 @@ libc_math_function(name = "remainderl")
 
 libc_math_function(
     name = "remainderf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "remainderf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "remquo")
@@ -7029,12 +6906,10 @@ libc_math_function(name = "remquol")
 
 libc_math_function(
     name = "remquof128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "remquof16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "rint")
@@ -7045,7 +6920,6 @@ libc_math_function(name = "rintl")
 
 libc_math_function(
     name = "rintf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -7053,7 +6927,6 @@ libc_math_function(
     additional_deps = [
         ":__support_fputil_cast",
         ":__support_macros_properties_cpu_features",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -7065,7 +6938,6 @@ libc_math_function(name = "roundl")
 
 libc_math_function(
     name = "roundf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -7073,7 +6945,6 @@ libc_math_function(
     additional_deps = [
         ":__support_fputil_cast",
         ":__support_macros_properties_cpu_features",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -7085,7 +6956,6 @@ libc_math_function(name = "roundevenl")
 
 libc_math_function(
     name = "roundevenf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -7093,7 +6963,6 @@ libc_math_function(
     additional_deps = [
         ":__support_fputil_cast",
         ":__support_macros_properties_cpu_features",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -7105,7 +6974,6 @@ libc_math_function(
 libc_math_function(
     name = "rsqrtf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_rsqrtf16",
     ],
 )
@@ -7128,7 +6996,6 @@ libc_math_function(
 libc_math_function(
     name = "scalblnf128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":hdr_float_macros",
     ],
 )
@@ -7136,7 +7003,6 @@ libc_math_function(
 libc_math_function(
     name = "scalblnf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":hdr_float_macros",
     ],
 )
@@ -7159,7 +7025,6 @@ libc_math_function(
 libc_math_function(
     name = "scalbnf128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":hdr_float_macros",
     ],
 )
@@ -7167,7 +7032,6 @@ libc_math_function(
 libc_math_function(
     name = "scalbnf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":hdr_float_macros",
     ],
 )
@@ -7255,7 +7119,6 @@ libc_math_function(
 libc_math_function(
     name = "sinf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_sinf16",
         ":errno",
     ],
@@ -7282,7 +7145,6 @@ libc_math_function(
 libc_math_function(
     name = "sinhf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_sinhf16",
     ],
 )
@@ -7325,7 +7187,6 @@ libc_math_function(
 libc_math_function(
     name = "sqrtf128",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_sqrtf128",
     ],
 )
@@ -7333,7 +7194,6 @@ libc_math_function(
 libc_math_function(
     name = "sqrtf16",
     additional_deps = [
-        ":__support_macros_properties_types",
         ":__support_math_sqrtf16",
     ],
 )
@@ -7380,7 +7240,6 @@ libc_math_function(
     name = "tanpif16",
     additional_deps = [
         ":__support_macros_optimization",
-        ":__support_macros_properties_types",
         ":__support_math_sincosf16_utils",
         ":hdr_errno_macros",
         ":hdr_fenv_macros",
@@ -7397,12 +7256,10 @@ libc_math_function(name = "totalorderl")
 
 libc_math_function(
     name = "totalorderf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "totalorderf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "totalordermag")
@@ -7413,12 +7270,10 @@ libc_math_function(name = "totalordermagl")
 
 libc_math_function(
     name = "totalordermagf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "totalordermagf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "trunc")
@@ -7429,7 +7284,6 @@ libc_math_function(name = "truncl")
 
 libc_math_function(
     name = "truncf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
@@ -7437,7 +7291,6 @@ libc_math_function(
     additional_deps = [
         ":__support_fputil_cast",
         ":__support_macros_properties_cpu_features",
-        ":__support_macros_properties_types",
     ],
 )
 
@@ -7449,12 +7302,10 @@ libc_math_function(name = "ufromfpl")
 
 libc_math_function(
     name = "ufromfpf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "ufromfpf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(name = "ufromfpx")
@@ -7465,12 +7316,10 @@ libc_math_function(name = "ufromfpxl")
 
 libc_math_function(
     name = "ufromfpxf128",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 libc_math_function(
     name = "ufromfpxf16",
-    additional_deps = [":__support_macros_properties_types"],
 )
 
 ############################## inttypes targets ##############################

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -317,5 +317,6 @@ def libc_math_function(
         deps = [
             ":__support_common",
             ":__support_macros_config",
+            ":__support_macros_properties_types",
         ] + OLD_FPUTIL_DEPS + additional_deps,
     )

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -314,5 +314,8 @@ def libc_math_function(
         name = name,
         srcs = ["src/math/generic/" + name + ".cpp"],
         hdrs = ["src/math/" + name + ".h"],
-        deps = [":__support_common"] + OLD_FPUTIL_DEPS + additional_deps,
+        deps = [
+            ":__support_common",
+            ":__support_macros_config",
+        ] + OLD_FPUTIL_DEPS + additional_deps,
     )


### PR DESCRIPTION
This adds a whole bunch of deps to get things _mostly_ building w/ `layering_check` enabled. It does not yet enable `layering_check`.

I used some tools to add deps to all these targets that break when enabling the layering check feature, and a few things were added in between when I ran the script and where trunk is at now. Since this is a large change, I plan to do a second (and possibly third) pass later to catch those new changes, at which point it would be safer to actually enable `layering_check` for this package.