### PR TITLE
[lldb] Limit Python include dir to ScriptInterpreterPython (NFC)

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -173,8 +173,6 @@ if (LLDB_ENABLE_PYTHON)
     "Embed PYTHONHOME in the binary. If set to OFF, PYTHONHOME environment variable will be used to to locate Python."
     ${default_embed_python_home})
 
-  include_directories(${Python3_INCLUDE_DIRS})
-
   if (LLDB_EMBED_PYTHON_HOME)
     get_filename_component(PYTHON_HOME "${Python3_EXECUTABLE}" DIRECTORY)
     set(LLDB_PYTHON_HOME "${PYTHON_HOME}" CACHE STRING

--- a/lldb/source/Plugins/ScriptInterpreter/Lua/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/CMakeLists.txt
@@ -5,7 +5,8 @@ add_lldb_library(lldbPluginScriptInterpreterLua PLUGIN
   LINK_LIBS
     lldbCore
     lldbInterpreter
+    ${LUA_LIBRARIES}
   )
 
-target_include_directories(lldbPluginScriptInterpreterLua PUBLIC ${LUA_INCLUDE_DIR})
-target_link_libraries(lldbPluginScriptInterpreterLua INTERFACE ${LUA_LIBRARIES})
+  target_include_directories(lldbPluginScriptInterpreterLua
+    PUBLIC ${LUA_INCLUDE_DIR})

--- a/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
@@ -48,3 +48,7 @@ add_lldb_library(lldbPluginScriptInterpreterPython PLUGIN
     ${Python3_LIBRARIES}
     ${LLDB_LIBEDIT_LIBS}
   )
+
+
+  target_include_directories(lldbPluginScriptInterpreterPython
+    PUBLIC ${Python3_INCLUDE_DIRS})


### PR DESCRIPTION
Limit Python include dir to ScriptInterpreterPython and any library that depends on it (i.e. liblldb), making it consistent with what we do for Lua.