### PR TITLE
[lldb][Process/FreeBSDKernelCore] Implement DoWriteMemory()

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/CMakeLists.txt
@@ -1,3 +1,11 @@
+lldb_tablegen(ProcessFreeBSDKernelCoreProperties.inc -gen-lldb-property-defs
+  SOURCE ProcessFreeBSDKernelCoreProperties.td
+  TARGET LLDBPluginProcessFreeBSDKernelCorePropertiesGen)
+
+lldb_tablegen(ProcessFreeBSDKernelCorePropertiesEnum.inc -gen-lldb-property-enum-defs
+  SOURCE ProcessFreeBSDKernelCoreProperties.td
+  TARGET LLDBPluginProcessFreeBSDKernelCorePropertiesEnumGen)
+
 add_lldb_library(lldbPluginProcessFreeBSDKernelCore PLUGIN
   ProcessFreeBSDKernelCore.cpp
   RegisterContextFreeBSDKernelCore_arm64.cpp
@@ -12,3 +20,7 @@ add_lldb_library(lldbPluginProcessFreeBSDKernelCore PLUGIN
     lldbTarget
     kvm
   )
+
+add_dependencies(lldbPluginProcessFreeBSDKernelCore
+  LLDBPluginProcessFreeBSDKernelCorePropertiesGen
+  LLDBPluginProcessFreeBSDKernelCorePropertiesEnumGen)

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
@@ -92,8 +91,20 @@ void ProcessFreeBSDKernelCore::Initialize() {
 
   llvm::call_once(g_once_flag, []() {
     PluginManager::RegisterPlugin(GetPluginNameStatic(),
-                                  GetPluginDescriptionStatic(), CreateInstance);
+                                  GetPluginDescriptionStatic(), CreateInstance,
+                                  DebuggerInitialize);
   });
+}
+
+void ProcessFreeBSDKernelCore::DebuggerInitialize(Debugger &debugger) {
+  if (!PluginManager::GetSettingForProcessPlugin(
+          debugger, PluginProperties::GetSettingName())) {
+    const bool is_global_setting = true;
+    PluginManager::CreateSettingForProcessPlugin(
+        debugger, GetGlobalPluginProperties().GetValueProperties(),
+        "Properties for the freebsd-kernel process plug-in.",
+        is_global_setting);
+  }
 }
 
 void ProcessFreeBSDKernelCore::Terminate() {

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -25,6 +25,42 @@ using namespace lldb_private;
 
 LLDB_PLUGIN_DEFINE(ProcessFreeBSDKernelCore)
 
+namespace {
+
+#define LLDB_PROPERTIES_processfreebsdkernelcore
+#include "ProcessFreeBSDKernelCoreProperties.inc"
+
+enum {
+#define LLDB_PROPERTIES_processfreebsdkernelcore
+#include "ProcessFreeBSDKernelCorePropertiesEnum.inc"
+};
+
+class PluginProperties : public Properties {
+public:
+  static llvm::StringRef GetSettingName() {
+    return ProcessFreeBSDKernelCore::GetPluginNameStatic();
+  }
+
+  PluginProperties() : Properties() {
+    m_collection_sp = std::make_shared<OptionValueProperties>(GetSettingName());
+    m_collection_sp->Initialize(g_processfreebsdkernelcore_properties_def);
+  }
+
+  ~PluginProperties() override = default;
+
+  bool GetReadOnly() const {
+    const uint32_t idx = ePropertyReadOnly;
+    return GetPropertyAtIndexAs<bool>(idx, true);
+  }
+};
+
+} // namespace
+
+static PluginProperties &GetGlobalPluginProperties() {
+  static PluginProperties g_settings;
+  return g_settings;
+}
+
 ProcessFreeBSDKernelCore::ProcessFreeBSDKernelCore(lldb::TargetSP target_sp,
                                                    ListenerSP listener_sp,
                                                    kvm_t *kvm,
@@ -88,6 +124,26 @@ void ProcessFreeBSDKernelCore::RefreshStateAfterStop() {
     PrintUnreadMessage();
     m_printed_unread_message = true;
   }
+}
+
+size_t ProcessFreeBSDKernelCore::DoWriteMemory(lldb::addr_t addr,
+                                               const void *buf, size_t size,
+                                               Status &error) {
+  if (GetGlobalPluginProperties().GetReadOnly()) {
+    error = Status::FromErrorString(
+        "Memory writes are disabled in read-only mode. Disable with 'settings "
+        "set plugin.process.freebsd-kernel-core.read-only false'");
+    return 0;
+  }
+
+  ssize_t rd = 0;
+  rd = kvm_write(m_kvm, addr, buf, size);
+  if (rd < 0 || static_cast<size_t>(rd) != size) {
+    error = Status::FromErrorStringWithFormat("Writing memory failed: %s",
+                                              GetError());
+    return rd > 0 ? rd : 0;
+  }
+  return rd;
 }
 
 bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
@@ -48,6 +48,9 @@ public:
 
   void RefreshStateAfterStop() override;
 
+  size_t DoWriteMemory(lldb::addr_t addr, const void *buf, size_t size,
+                       lldb_private::Status &error) override;
+
 protected:
   bool DoUpdateThreadList(lldb_private::ThreadList &old_thread_list,
                           lldb_private::ThreadList &new_thread_list) override;

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_SOURCE_PLUGINS_PROCESS_FREEBSDKERNEL_PROCESSFREEBSDKERNELCORE_H
 #define LLDB_SOURCE_PLUGINS_PROCESS_FREEBSDKERNEL_PROCESSFREEBSDKERNELCORE_H
 
+#include "lldb/Core/Debugger.h"
 #include "lldb/Target/PostMortemProcess.h"
 
 #include <kvm.h>
@@ -26,6 +27,8 @@ public:
                  bool can_connect);
 
   static void Initialize();
+
+  static void DebuggerInitialize(lldb_private::Debugger &debugger);
 
   static void Terminate();
 

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCoreProperties.td
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCoreProperties.td
@@ -1,0 +1,8 @@
+include "../../../../include/lldb/Core/PropertiesBase.td"
+
+let Definition = "processfreebsdkernelcore", Path = "plugin.process.freebsd-kernel-core" in {
+  def ReadOnly: Property<"read-only", "Boolean">,
+    Global,
+    DefaultTrue,
+    Desc<"Disable memory writes to the core. This is enabled by default for safety.">;
+}

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -220,8 +220,7 @@ Changes to LLDB
 * Threads are listed in incrmental order by pid then by tid.
 * Unread kernel messages saved in msgbufp are now printed when lldb starts. This information is printed only
   when lldb is in the interactive mode (i.e. not in batch mode).
-* Writing to core is now supported. For security, `plugin.process.freebsd-kernel-core.read-only` must be set
-  to `false` to enable this feature.
+* Memory writes are currently disabled. You can enable them with `set plugin.process.freebsd-kernel-core.read-only false`.
 
 ### Linux
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -220,7 +220,8 @@ Changes to LLDB
 * Threads are listed in incrmental order by pid then by tid.
 * Unread kernel messages saved in msgbufp are now printed when lldb starts. This information is printed only
   when lldb is in the interactive mode (i.e. not in batch mode).
-* Memory writes are currently disabled. You can enable them with `set plugin.process.freebsd-kernel-core.read-only false`.
+* Memory writes are currently disabled. You can enable them with
+  `settings set plugin.process.freebsd-kernel-core.read-only false`.
 
 ### Linux
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -220,6 +220,8 @@ Changes to LLDB
 * Threads are listed in incrmental order by pid then by tid.
 * Unread kernel messages saved in msgbufp are now printed when lldb starts. This information is printed only
   when lldb is in the interactive mode (i.e. not in batch mode).
+* Writing to core is now supported. For security, `plugin.process.freebsd-kernel-core.read-only` must be set
+  to `false` to enable this feature.
 
 ### Linux
 


### PR DESCRIPTION
Implement `ProcessFreeBSDKernelCore::DoWriteMemory()` to write data on kernel dump or `/dev/mem`. Due to security concerns (e.g. writing wrong value on `/dev/mem` can trigger kernel panic), this feature is only enabled when `plugin.process.freebsd-kernel-core.read-only` is set to false (true by default).