### PR TITLE
[clangd] Handle MemberPointerTypeLoc in SelectionTree

### DIFF
--- a/clang-tools-extra/clangd/Selection.cpp
+++ b/clang-tools-extra/clangd/Selection.cpp
@@ -954,6 +954,10 @@ private:
         claimRange(PTL.getStarLoc(), Result);
         return;
       }
+      if (auto MPTL = TL->getAs<MemberPointerTypeLoc>()) {
+        claimRange(MPTL.getLocalSourceRange(), Result);
+        return;
+      }
       if (auto FTL = TL->getAs<FunctionTypeLoc>()) {
         claimRange(SourceRange(FTL.getLParenLoc(), FTL.getEndLoc()), Result);
         return;

--- a/clang-tools-extra/clangd/unittests/XRefsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/XRefsTests.cpp
@@ -2329,6 +2329,16 @@ TEST(FindReferences, WithinAST) {
           [$(Bar)[[F^oo]]...$(Bar)[[Fo^o]] + 1] = 0,
           [$(Bar)[[^Foo]] + 2] = 1
         };
+      )cpp",
+      // Field of pointer-to-member type
+      R"cpp(
+        struct S { void foo(); };
+        struct A {
+          void (S::*$def(A)[[fi^eld]])();
+        };
+        void bar(A& a, S& s) {
+          (s.*(a.$(bar)[[field]]))();
+        }
       )cpp"};
   for (const char *Test : Tests)
     checkFindRefs(Test);


### PR DESCRIPTION
This is another type loc that overlaps the name of the declaration whose type it is, and so needs special handling to allow the declaration itself to be targeted.

Fixes https://github.com/clangd/clangd/issues/2608