### PR TITLE
[libc][math] Fix FP add/sub for signed-zero operands

### DIFF
--- a/libc/src/__support/FPUtil/generic/add_sub.h
+++ b/libc/src/__support/FPUtil/generic/add_sub.h
@@ -96,6 +96,8 @@ add_or_sub(InType x, InType y) {
 
     if (x_bits.is_zero()) {
       if (y_bits.is_zero()) {
+        if (is_effectively_add)
+          return OutFPBits::zero(x_bits.sign()).get_val();
         switch (quick_get_round()) {
         case FE_DOWNWARD:
           return OutFPBits::zero(Sign::NEG).get_val();

--- a/libc/test/src/math/smoke/AddTest.h
+++ b/libc/test/src/math/smoke/AddTest.h
@@ -165,6 +165,15 @@ public:
     EXPECT_FP_EQ(OutType(-1.0), func(InType(-2.0), InType(1.0)));
     EXPECT_FP_EQ(OutType(-3.0), func(InType(-2.0), InType(-1.0)));
   }
+
+  void test_signed_zero_result(AddFunc func) {
+    EXPECT_FP_EQ_ALL_ROUNDING(zero, func(in.zero, in.zero));
+    EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, func(in.neg_zero, in.neg_zero));
+    EXPECT_FP_EQ_ALL_ROUNDING(zero, zero, neg_zero, zero,
+                              func(in.neg_zero, in.zero));
+    EXPECT_FP_EQ_ALL_ROUNDING(zero, zero, neg_zero, zero,
+                              func(in.zero, in.neg_zero));
+  }
 };
 
 #define LIST_ADD_TESTS(OutType, InType, func)                                  \
@@ -176,7 +185,8 @@ public:
   TEST_F(LlvmLibcAddTest, RangeErrors) { test_range_errors(&func); }           \
   TEST_F(LlvmLibcAddTest, InexactResults) { test_inexact_results(&func); }     \
   TEST_F(LlvmLibcAddTest, MixedNormality) { test_mixed_normality(&func); }     \
-  TEST_F(LlvmLibcAddTest, MixedSigns) { test_mixed_signs(&func); }
+  TEST_F(LlvmLibcAddTest, MixedSigns) { test_mixed_signs(&func); }             \
+  TEST_F(LlvmLibcAddTest, SignedZeroResult) { test_signed_zero_result(&func); }
 
 #define LIST_ADD_SAME_TYPE_TESTS(suffix, OutType, InType, func)                \
   using LlvmLibcAddTest##suffix = AddTest<OutType, InType>;                    \
@@ -193,6 +203,9 @@ public:
   TEST_F(LlvmLibcAddTest##suffix, MixedNormality) {                            \
     test_mixed_normality(&func);                                               \
   }                                                                            \
-  TEST_F(LlvmLibcAddTest##suffix, MixedSigns) { test_mixed_signs(&func); }
+  TEST_F(LlvmLibcAddTest##suffix, MixedSigns) { test_mixed_signs(&func); }     \
+  TEST_F(LlvmLibcAddTest##suffix, SignedZeroResult) {                          \
+    test_signed_zero_result(&func);                                            \
+  }
 
 #endif // LLVM_LIBC_TEST_SRC_MATH_SMOKE_ADDTEST_H

--- a/libc/test/src/math/smoke/SubTest.h
+++ b/libc/test/src/math/smoke/SubTest.h
@@ -156,6 +156,15 @@ public:
     EXPECT_FP_EQ(OutType(-3.0), func(InType(-2.0), InType(1.0)));
     EXPECT_FP_EQ(OutType(-1.0), func(InType(-2.0), InType(-1.0)));
   }
+
+  void test_signed_zero_result(SubFunc func) {
+    EXPECT_FP_EQ_ALL_ROUNDING(zero, func(in.zero, in.neg_zero));
+    EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, func(in.neg_zero, in.zero));
+    EXPECT_FP_EQ_ALL_ROUNDING(zero, zero, neg_zero, zero,
+                              func(in.zero, in.zero));
+    EXPECT_FP_EQ_ALL_ROUNDING(zero, zero, neg_zero, zero,
+                              func(in.neg_zero, in.neg_zero));
+  }
 };
 
 #define LIST_SUB_TESTS(OutType, InType, func)                                  \
@@ -166,7 +175,8 @@ public:
   }                                                                            \
   TEST_F(LlvmLibcSubTest, RangeErrors) { test_range_errors(&func); }           \
   TEST_F(LlvmLibcSubTest, InexactResults) { test_inexact_results(&func); }     \
-  TEST_F(LlvmLibcSubTest, MixedSigns) { test_mixed_signs(&func); }
+  TEST_F(LlvmLibcSubTest, MixedSigns) { test_mixed_signs(&func); }             \
+  TEST_F(LlvmLibcSubTest, SignedZeroResult) { test_signed_zero_result(&func); }
 
 #define LIST_SUB_SAME_TYPE_TESTS(suffix, OutType, InType, func)                \
   using LlvmLibcSubTest##suffix = SubTest<OutType, InType>;                    \
@@ -180,6 +190,9 @@ public:
   TEST_F(LlvmLibcSubTest##suffix, InexactResults) {                            \
     test_inexact_results(&func);                                               \
   }                                                                            \
-  TEST_F(LlvmLibcSubTest##suffix, MixedSigns) { test_mixed_signs(&func); }
+  TEST_F(LlvmLibcSubTest##suffix, MixedSigns) { test_mixed_signs(&func); }     \
+  TEST_F(LlvmLibcSubTest##suffix, SignedZeroResult) {                          \
+    test_signed_zero_result(&func);                                            \
+  }
 
 #endif // LLVM_LIBC_TEST_SRC_MATH_SMOKE_SUBTEST_H


### PR DESCRIPTION
(-0.0) + (-0.0) and (-0.0) - (+0.0) returned +0.0 instead of -0.0.

Ensure these cases comply with IEEE 754 §6.3 rule.