### PR TITLE
[AArch64] Reject non-constant expressions in tryParseAdjImm0_63

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -8934,7 +8934,10 @@ ParseStatus AArch64AsmParser::tryParseAdjImm0_63(OperandVector &Operands) {
   if (getParser().parseExpression(Ex))
     return ParseStatus::NoMatch;
 
-  int64_t Imm = dyn_cast<MCConstantExpr>(Ex)->getValue();
+  const MCConstantExpr *Value = dyn_cast<MCConstantExpr>(Ex);
+  if(check(!Value, S, "expected constant expression"))
+    return ParseStatus::Failure;
+  int64_t Imm = Value->getValue();
   if (IsNegative)
     Imm = -Imm;
 

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -8930,14 +8930,10 @@ ParseStatus AArch64AsmParser::tryParseAdjImm0_63(OperandVector &Operands) {
   if (getTok().isNot(AsmToken::Integer))
     return ParseStatus::NoMatch;
 
-  const MCExpr *Ex;
-  if (getParser().parseExpression(Ex))
+  int64_t Imm;
+  if (parseImmExpr(Imm))
     return ParseStatus::NoMatch;
 
-  const MCConstantExpr *Value = dyn_cast<MCConstantExpr>(Ex);
-  if(check(!Value, S, "expected constant expression"))
-    return ParseStatus::Failure;
-  int64_t Imm = Value->getValue();
   if (IsNegative)
     Imm = -Imm;
 

--- a/llvm/test/MC/AArch64/CMPBR/cmpbr_aliases-diagnostics.s
+++ b/llvm/test/MC/AArch64/CMPBR/cmpbr_aliases-diagnostics.s
@@ -21,5 +21,9 @@ L:
     cbls x5, #63, L
 // CHECK: [[@LINE-1]]:{{[0-9]+}}: error: immediate must be an integer in range [-1, 62]
 
-   cbls x3, w5, L
+    cbls x3, w5, L
 // CHECK: [[@LINE-1]]:{{[0-9]+}}: error: immediate must be an integer in range [-1, 62]
+
+    cbge w5, 1f, L
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: expected constant expression
+1:


### PR DESCRIPTION
Fixes [182757](https://github.com/llvm/llvm-project/issues/182757)

This fixes a crash in `tryParseAdjImm0_63` when `parseExpression()` returns a
non-constant expression.

Although the parser first checks that the current token is an integer token,
`parseExpression()` may consume additional tokens and produce a non-constant
expression (e.g. a directional label reference like `1f`), causing
`dyn_cast<MCConstantExpr>(Ex)` to return null and be dereferenced.

Although this helper is named `tryParseAdjImm0_63`, in this parsing path it is
used for a specific immediate operand form once the operand has already been
dispatched here. A non-constant expression such as `1f` is therefore not a
valid alternative parse to be deferred as `NoMatch`, but an invalid operand for
this form, so emitting a diagnostic is appropriate.

Fix by validating that the parsed expression is an `MCConstantExpr` and emit
an error otherwise.

Adds a regression test for `cbge w5, 1f, L`.