### PR TITLE
[HEXAGON] fp_to_uint conversion for v32f32 to v32i1

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -434,6 +434,279 @@ SDValue HexagonTargetLowering::LowerCallResult(
   return Chain;
 }
 
+// Custom inserter for lowering PS_HVX_FPTU1_V32F32_TO_V32I1_Vec &
+// PS_HVX_FPTS1_V32F32_TO_V32I1_Vec..
+//
+// Converts the pseudo-instruction (dst: HvxQR, src: HvxVR) into a small CFG
+// with a counted loop that builds a 1-bit predicate vector where each lane is
+// set to 1 if the corresponding lane in SrcV is non-zero.
+//
+// CFG transformation:
+//   - Split the current block at  MI: MBB -> AfterBB (live-ins updated).
+//   - Create three blocks: HeaderBB (original MBB), BodyBB (loop body),
+//     ExitBB (loop exit).
+//   - Edges:
+//       HeaderBB -> BodyBB      (fallthrough)
+//       BodyBB   -> BodyBB      (backedge)
+//       BodyBB   -> ExitBB
+//       ExitBB   -> AfterBB
+//   - Erase the original pseudo (MI.eraseFromParent()) and return ExitBB.
+//
+// HeaderBB (initialization):
+//   - Scalar constants (A2_tfrsi):
+//       Rzero = 0, Rone = 1, Rmask = 0x01010101, Rcnt = 32, Rrot = 124
+//   - Build Vzero safely (no self-use before def):
+//       Vzero = V6_vxor  SrcV, SrcV
+//   - Compute zero-lane predicate:
+//       Qeq0  = V6_veqsf SrcV, Vzero            // float equality
+//   - Mask vector by predicate (bitplane source):
+//       V1    = V6_vandqrt Qeq0, Rmask          // Q-masked AND with scalar
+//   - Initialize accumulator:
+//       V3_init = V6_vxor Vzero, Vzero          // vector zero
+//   - Jump to loop body:
+//       J2_jump BodyBB
+//
+// BodyBB (PHI nodes at top; loop-carried values):
+//   - PHIs (Hexagon::PHI):
+//       V3_phi   <- { V3_init, HeaderBB ; V3_next, BodyBB }
+//       Rrot_phi <- { Rrot,    HeaderBB ; Rrot_next, BodyBB }
+//       Rcnt_phi <- { Rcnt,    HeaderBB ; Rcnt_next, BodyBB }
+//
+// BodyBB (loop body instructions):
+//   - Shift accumulator left by 1 bit:
+//       V3_shl   = V6_vaslw  V3_phi, Rone
+//   - Rotate masked bitplane by current rotation:
+//       V2       = V6_vror   V1, Rrot_phi
+//   - Advance rotation and decrement count:
+//       Rrot_next= A2_addi   Rrot_phi, -4
+//       V3_next  = V6_vor    V3_shl, V2
+//       Rcnt_next= A2_addi   Rcnt_phi, -1
+//   - Loop control:
+//       P0       = C2_cmpgtui Rcnt_next, 0
+//       J2_jumpf P0, ExitBB
+//       J2_jump  BodyBB
+//
+// ExitBB (finalization to produce HvxQR):
+//   - PHI to capture final accumulator:
+//       V3_final <- { V3_next, BodyBB }
+//   - Extract lane LSBs and test for zero:
+//       Vonetmp  = V6_lvsplatw Rone
+//       Vtmp     = V6_vand     V3_final, Vonetmp
+//       Qeq      = V6_veqw     Vtmp, Vzero        // 1 where Vtmp == 0
+//   - Invert to get predicate for (SrcV != 0.0f):
+//       DstQ     = V6_pred_not Qeq
+//   - Jump to continuation and wire successor:
+//       J2_jump  AfterBB
+//       ExitBB->addSuccessor(AfterBB)
+//
+// Implementation notes:
+//   - The loop iteratively assembles bitplanes into V3 via shift-OR of
+//     rotated masked bits from V1, controlled by Rrot and Rcnt.
+//   - V1 is effectively loop-invariant (encoded via a PHI for structural
+//     completeness). The carried state is V3_phi, Rrot_phi, and
+//     Rcnt_phi.
+//   - The final predicate is derived by isolating the least significant bit
+//     of each lane and comparing to zero, then inverting to represent
+//     "non-zero float" per lane.
+//   - The pseudo-instruction is removed once the concrete sequence and CFG
+//     are emitted.
+
+MachineBasicBlock *HexagonTargetLowering::EmitInstrWithCustomInserter(
+    MachineInstr &MI, MachineBasicBlock *MBB) const {
+
+  const DebugLoc DL = MI.getDebugLoc();
+  MachineFunction &MF = *MBB->getParent();
+  const HexagonSubtarget &HST = MF.getSubtarget<HexagonSubtarget>();
+  const TargetInstrInfo *TII = HST.getInstrInfo();
+  MachineRegisterInfo &MRI = MF.getRegInfo();
+
+  switch (MI.getOpcode()) {
+  case Hexagon::PS_HVX_FPTS1_V32F32_TO_V32I1_Vec:
+  case Hexagon::PS_HVX_FPTU1_V32F32_TO_V32I1_Vec: {
+    // Operands: dst(HvxQR), src(HvxVR)
+    Register DstQ = MI.getOperand(0).getReg();
+    Register SrcV = MI.getOperand(1).getReg();
+    MachineBasicBlock *AfterBB = MBB->splitAt(MI, /*UpdateLiveIns*/ true);
+    AfterBB->transferSuccessorsAndUpdatePHIs(MBB);
+
+    // Loop
+    // ---------- Create CFG blocks ----------
+    auto *HeaderBB = MBB;
+    auto *BodyBB = MF.CreateMachineBasicBlock(HeaderBB->getBasicBlock());
+    auto *ExitBB = MF.CreateMachineBasicBlock(HeaderBB->getBasicBlock());
+    MF.insert(++MachineFunction::iterator(HeaderBB), BodyBB);
+    MF.insert(++MachineFunction::iterator(BodyBB), ExitBB);
+
+    // Header -> Body (fallthrough), Body -> Body (backedge), Body -> Exit
+    HeaderBB->addSuccessor(BodyBB);
+    BodyBB->addSuccessor(BodyBB);
+    BodyBB->addSuccessor(ExitBB);
+    // Loop Header
+
+    // ---------- Scalar constants ----------
+    Register Rzero = MRI.createVirtualRegister(&Hexagon::IntRegsRegClass);
+    Register Rone = MRI.createVirtualRegister(&Hexagon::IntRegsRegClass);
+    Register Rcnt = MRI.createVirtualRegister(&Hexagon::IntRegsRegClass);
+    Register Rmask = MRI.createVirtualRegister(&Hexagon::IntRegsRegClass);
+    Register Rrot = MRI.createVirtualRegister(&Hexagon::IntRegsRegClass);
+
+    BuildMI(*HeaderBB, MI, DL, TII->get(Hexagon::A2_tfrsi))
+        .addDef(Rzero)
+        .addImm(0);
+    BuildMI(*HeaderBB, MI, DL, TII->get(Hexagon::A2_tfrsi))
+        .addDef(Rone)
+        .addImm(1);
+    BuildMI(*HeaderBB, MI, DL, TII->get(Hexagon::A2_tfrsi))
+        .addDef(Rmask)
+        .addImm(0x01010101);
+    BuildMI(*HeaderBB, MI, DL, TII->get(Hexagon::A2_tfrsi))
+        .addDef(Rcnt)
+        .addImm(32);
+    BuildMI(*HeaderBB, MI, DL, TII->get(Hexagon::A2_tfrsi))
+        .addDef(Rrot)
+        .addImm(124);
+
+    // ---------- Build Vzero safely (no self-use before def) ----------
+    Register Vzero = MRI.createVirtualRegister(&Hexagon::HvxVRRegClass);
+    BuildMI(*HeaderBB, MI, DL, TII->get(Hexagon::V6_vd0)).addDef(Vzero);
+
+    // Qeq0 = (SrcV == 0.0f)
+    Register Qeq0 = MRI.createVirtualRegister(&Hexagon::HvxQRRegClass);
+    BuildMI(*HeaderBB, MI, DL, TII->get(Hexagon::V6_veqsf))
+        .addDef(Qeq0)
+        .addUse(SrcV)
+        .addUse(Vzero);
+
+    //  V6_vandnqrt
+    Register V1 = MRI.createVirtualRegister(&Hexagon::HvxVRRegClass);
+    BuildMI(*HeaderBB, MI, DL, TII->get(Hexagon::V6_vandnqrt))
+        .addDef(V1)
+        .addUse(Qeq0)
+        .addUse(Rmask);
+
+    // V3_init
+    Register V3_init = MRI.createVirtualRegister(&Hexagon::HvxVRRegClass);
+    BuildMI(*HeaderBB, MI, DL, TII->get(Hexagon::V6_vd0)).addDef(V3_init);
+
+    BuildMI(*HeaderBB, HeaderBB->end(), DL, TII->get(Hexagon::J2_jump))
+        .addMBB(BodyBB);
+
+    // Loop Body
+
+    // ---------- PHIs (build once at the very top of BodyBB) ----------
+    auto PHIAtTop = BodyBB->begin();
+
+    Register V3_phi = MRI.createVirtualRegister(&Hexagon::HvxVRRegClass);
+    Register Rrot_phi = MRI.createVirtualRegister(&Hexagon::IntRegsRegClass);
+    Register Rcnt_phi = MRI.createVirtualRegister(&Hexagon::IntRegsRegClass);
+
+    MachineInstrBuilder V3PhiMIB =
+        BuildMI(*BodyBB, PHIAtTop, DL, TII->get(Hexagon::PHI), V3_phi)
+            .addReg(V3_init)
+            .addMBB(HeaderBB);
+
+    MachineInstrBuilder RrotPhiMIB =
+        BuildMI(*BodyBB, PHIAtTop, DL, TII->get(Hexagon::PHI), Rrot_phi)
+            .addReg(Rrot)
+            .addMBB(HeaderBB);
+
+    MachineInstrBuilder RcntPhiMIB =
+        BuildMI(*BodyBB, PHIAtTop, DL, TII->get(Hexagon::PHI), Rcnt_phi)
+            .addReg(Rcnt)
+            .addMBB(HeaderBB);
+
+    Register V3_shl = MRI.createVirtualRegister(&Hexagon::HvxVRRegClass);
+    BuildMI(*BodyBB, BodyBB->end(), DL, TII->get(Hexagon::V6_vaslw))
+        .addDef(V3_shl)
+        .addUse(V3_phi)
+        .addUse(Rone);
+
+    Register V2 = MRI.createVirtualRegister(&Hexagon::HvxVRRegClass);
+    BuildMI(*BodyBB, BodyBB->end(), DL, TII->get(Hexagon::V6_vror))
+        .addDef(V2)
+        .addUse(V1)
+        .addUse(Rrot_phi);
+
+    Register Rrot_next = MRI.createVirtualRegister(&Hexagon::IntRegsRegClass);
+    BuildMI(*BodyBB, BodyBB->end(), DL, TII->get(Hexagon::A2_addi))
+        .addDef(Rrot_next)
+        .addUse(Rrot_phi)
+        .addImm(-4);
+
+    Register V3_next = MRI.createVirtualRegister(&Hexagon::HvxVRRegClass);
+    BuildMI(*BodyBB, BodyBB->end(), DL, TII->get(Hexagon::V6_vor))
+        .addDef(V3_next)
+        .addUse(V3_shl)
+        .addUse(V2);
+
+    Register Rcnt_next = MRI.createVirtualRegister(&Hexagon::IntRegsRegClass);
+    BuildMI(*BodyBB, BodyBB->end(), DL, TII->get(Hexagon::A2_addi))
+        .addDef(Rcnt_next)
+        .addUse(Rcnt_phi)
+        .addImm(-1);
+
+    V3PhiMIB.addReg(V3_next).addMBB(BodyBB);
+    RrotPhiMIB.addReg(Rrot_next).addMBB(BodyBB);
+    RcntPhiMIB.addReg(Rcnt_next).addMBB(BodyBB);
+
+    // p0 = (Rcnt_next >u 0); if (!p0.new) jump Exit; else jump Body
+    Register P0 = MRI.createVirtualRegister(&Hexagon::PredRegsRegClass);
+    BuildMI(*BodyBB, BodyBB->end(), DL, TII->get(Hexagon::C2_cmpgtui))
+        .addDef(P0)
+        .addUse(Rcnt_next)
+        .addImm(0);
+
+    BuildMI(*BodyBB, BodyBB->end(), DL, TII->get(Hexagon::J2_jumpf))
+        .addUse(P0)
+        .addMBB(ExitBB);
+
+    BuildMI(*BodyBB, BodyBB->end(), DL, TII->get(Hexagon::J2_jump))
+        .addMBB(BodyBB);
+
+    // Exit:
+    auto PHIAtTopExit = ExitBB->begin();
+    Register V3_final = MRI.createVirtualRegister(&Hexagon::HvxVRRegClass);
+    BuildMI(*ExitBB, PHIAtTopExit, DL, TII->get(Hexagon::PHI), V3_final)
+        .addReg(V3_next)
+        .addMBB(BodyBB);
+
+    Register Vonetmp = MRI.createVirtualRegister(&Hexagon::HvxVRRegClass);
+    BuildMI(*ExitBB, ExitBB->end(), DL, TII->get(Hexagon::V6_lvsplatw))
+        .addDef(Vonetmp)
+        .addUse(Rone);
+
+    Register Vtmp = MRI.createVirtualRegister(&Hexagon::HvxVRRegClass);
+    BuildMI(*ExitBB, ExitBB->end(), DL, TII->get(Hexagon::V6_vand))
+        .addDef(Vtmp)
+        .addUse(V3_final)
+        .addUse(Vonetmp);
+
+    Register Qeq = MRI.createVirtualRegister(&Hexagon::HvxQRRegClass);
+    BuildMI(*ExitBB, ExitBB->end(), DL, TII->get(Hexagon::V6_veqw))
+        .addDef(Qeq)
+        .addUse(Vtmp)
+        .addUse(Vzero);
+
+    BuildMI(*ExitBB, ExitBB->end(), DL, TII->get(Hexagon::V6_pred_not))
+        .addDef(DstQ)
+        .addUse(Qeq);
+
+    BuildMI(*ExitBB, ExitBB->end(), DL, TII->get(Hexagon::J2_jump))
+        .addMBB(AfterBB);
+
+    // Remove the pseudo.
+    ExitBB->addSuccessor(AfterBB);
+    MI.eraseFromParent();
+    return ExitBB;
+  }
+
+  default:
+    break;
+  }
+
+  return MBB;
+}
+
 /// LowerCall - Functions arguments are copied from virtual regs to
 /// (physical regs)/(stack frame), CALLSEQ_START and CALLSEQ_END are emitted.
 SDValue

--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.h
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.h
@@ -201,6 +201,10 @@ public:
   SDValue LowerConstantPool(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerJumpTable(SDValue Op, SelectionDAG &DAG) const;
 
+  MachineBasicBlock *
+  EmitInstrWithCustomInserter(MachineInstr &MI,
+                              MachineBasicBlock *MBB) const override;
+
   EVT getSetCCResultType(const DataLayout &, LLVMContext &C,
                          EVT VT) const override {
     if (!VT.isVector())

--- a/llvm/lib/Target/Hexagon/HexagonPseudo.td
+++ b/llvm/lib/Target/Hexagon/HexagonPseudo.td
@@ -495,6 +495,21 @@ def PS_vloadrq_ai: Pseudo<(outs HvxQR:$Qd),
       (ins IntRegs:$Rs, s32_0Imm:$Off), "", []>,
       Requires<[HasV60,UseHVX]>;
 
+let Predicates = [UseHVX], isPseudo = 1, isCodeGenOnly = 1, usesCustomInserter = 1 in
+def PS_HVX_FPTU1_V32F32_TO_V32I1_Vec
+  : InstHexagon<(outs HvxQR:$dst), (ins HvxVR:$src),
+                "", [], "", NoItinerary, TypeALU32_2op>;
+def : Pat<(v32i1 (fp_to_uint (v32f32 HvxVR:$s))),
+          (PS_HVX_FPTU1_V32F32_TO_V32I1_Vec HvxVR:$s)>,
+      Requires<[UseHVX]>;
+
+let Predicates = [UseHVX], isPseudo = 1, isCodeGenOnly = 1, usesCustomInserter = 1 in
+def PS_HVX_FPTS1_V32F32_TO_V32I1_Vec
+  : InstHexagon<(outs HvxQR:$dst), (ins HvxVR:$src),
+                "", [], "", NoItinerary, TypeALU32_2op>;
+def : Pat<(v32i1 (fp_to_sint (v32f32 HvxVR:$s))),
+          (PS_HVX_FPTS1_V32F32_TO_V32I1_Vec HvxVR:$s)>,
+      Requires<[UseHVX]>;
 
 let isCodeGenOnly = 1, isPseudo = 1, hasSideEffects = 0 in
 class VSELInst<dag outs, dag ins, InstHexagon rootInst>

--- a/llvm/lib/Target/Hexagon/HexagonRegisterInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonRegisterInfo.cpp
@@ -157,6 +157,31 @@ const uint32_t *HexagonRegisterInfo::getCallPreservedMask(
   return HexagonCSR_RegMask;
 }
 
+// Returns a conservative call-preserved register mask.
+// Produces a mask used for call sites where no registers are assumed preserved.
+// In this mask, all registers are considered clobbered except the stack pointer
+// (Hexagon::R29), which is marked as preserved to maintain stack integrity.
+// Returns Pointer to a static array of 32-bit words encoding the preserved
+// physical registers (bit = 1 means preserved; bit = 0 means clobbered).
+const uint32_t *HexagonRegisterInfo::getNoPreservedMask() const {
+  static std::vector<uint32_t> MaskWords;
+  static bool Inited = false;
+
+  if (!Inited) {
+    unsigned NumRegs = getNumRegs();
+    unsigned NumWords = (NumRegs + 31) / 32;
+    MaskWords.assign(NumWords, 0u); // All clobbered by default
+
+    // Preserve SP (Hexagon uses R29 as SP)
+    unsigned Reg = Hexagon::R29;
+    unsigned W = Reg / 32;
+    unsigned B = Reg % 32;
+    MaskWords[W] |= (1u << B);
+
+    Inited = true;
+  }
+  return MaskWords.data();
+}
 
 BitVector HexagonRegisterInfo::getReservedRegs(const MachineFunction &MF)
       const {

--- a/llvm/lib/Target/Hexagon/HexagonRegisterInfo.h
+++ b/llvm/lib/Target/Hexagon/HexagonRegisterInfo.h
@@ -30,6 +30,7 @@ class HexagonRegisterInfo : public HexagonGenRegisterInfo {
 public:
   HexagonRegisterInfo(unsigned HwMode);
 
+  const uint32_t *getNoPreservedMask() const override;
   /// Code Generation virtual methods...
   const MCPhysReg *getCalleeSavedRegs(const MachineFunction *MF)
         const override;

--- a/llvm/test/CodeGen/Hexagon/fp-to-sint.ll
+++ b/llvm/test/CodeGen/Hexagon/fp-to-sint.ll
@@ -1,0 +1,31 @@
+; RUN: llc --mtriple=hexagon -O2 -mattr=+hvxv79,+hvx-length128b %s -o - | FileCheck %s
+
+define <16 x i1> @autogen_SD24352(<16 x float> %I8) {
+BB:
+  %FC10 = fptosi <16 x float> %I8 to <16 x i1>
+  ret <16 x i1> %FC10
+}
+
+; CHECK:     r3:2 = combine(#1,##16843009)
+; CHECK:     r1 = #124
+; CHECK:     v1 = vxor(v1,v1)
+; CHECK:     q0 = vcmp.eq(v0.sf,v1.sf)
+; CHECK:     v0 = v1
+; CHECK:     loop0([[LOOP:.LBB0_[0-9]+]],#32)
+; CHECK:     v2 = vand(!q0,r2)
+; CHECK:     r29 = and(r29,#-128)
+; CHECK: [[LOOP]]:
+; CHECK:     // =>This Inner Loop Header: Depth=1
+; CHECK:     r1 = add(r1,#-4)
+; CHECK:     v3 = vror(v2,r1)
+; CHECK:     v0.w = vasl(v0.w,r3)
+; CHECK:     v0 = vor(v0,v3)
+; CHECK:     } :endloop0
+; CHECK:     v2 = vsplat(r3)
+; CHECK:     r1 = #-1
+; CHECK:     memw(r29+#124) = r0
+; CHECK:     v0 = vand(v0,v2)
+; CHECK:     q0 = vcmp.eq(v0.w,v1.w)
+; CHECK:     q0 = not(q0)
+; CHECK:     v{{[0-9]+}} = vand(q0,r1)
+; CHECK:     vmem(r29+#2) = v{{[0-9]+}}.new

--- a/llvm/test/CodeGen/Hexagon/fp-to-uint.ll
+++ b/llvm/test/CodeGen/Hexagon/fp-to-uint.ll
@@ -1,0 +1,31 @@
+; RUN: llc --mtriple=hexagon -O2 -mattr=+hvxv79,+hvx-length128b %s -o - | FileCheck %s
+
+define <16 x i1> @autogen_SD24352(<16 x float> %I8) {
+BB:
+  %FC10 = fptoui <16 x float> %I8 to <16 x i1>
+  ret <16 x i1> %FC10
+}
+
+; CHECK:     r3:2 = combine(#1,##16843009)
+; CHECK:     r1 = #124
+; CHECK:     v1 = vxor(v1,v1)
+; CHECK:     q0 = vcmp.eq(v0.sf,v1.sf)
+; CHECK:     v0 = v1
+; CHECK:     loop0([[LOOP:.LBB0_[0-9]+]],#32)
+; CHECK:     v2 = vand(!q0,r2)
+; CHECK:     r29 = and(r29,#-128)
+; CHECK: [[LOOP]]:
+; CHECK:     // =>This Inner Loop Header: Depth=1
+; CHECK:     r1 = add(r1,#-4)
+; CHECK:     v3 = vror(v2,r1)
+; CHECK:     v0.w = vasl(v0.w,r3)
+; CHECK:     v0 = vor(v0,v3)
+; CHECK:     } :endloop0
+; CHECK:     v2 = vsplat(r3)
+; CHECK:     r1 = #-1
+; CHECK:     memw(r29+#124) = r0
+; CHECK:     v0 = vand(v0,v2)
+; CHECK:     q0 = vcmp.eq(v0.w,v1.w)
+; CHECK:     q0 = not(q0)
+; CHECK:     v{{[0-9]+}} = vand(q0,r1)
+; CHECK:     vmem(r29+#2) = v{{[0-9]+}}.new


### PR DESCRIPTION
This Change implements support for converting HVX floating-point vectors to 1-bit predicate vectors on Hexagon architecture.

It adds custom instruction lowering for fp_to_uint and fp_to_sint operations that convert v32f32 to v32i1 vectors.