### PR TITLE
[libc] Fix LIBC_INLINE build error in riscv/irelative.cpp

### DIFF
--- a/libc/startup/linux/riscv/irelative.cpp
+++ b/libc/startup/linux/riscv/irelative.cpp
@@ -16,7 +16,7 @@ namespace LIBC_NAMESPACE_DECL {
 
 // RISC-V may be 32-bit or 64-bit. ElfW(Rela) handles the struct type,
 // but we need the correct R_TYPE extraction macro.
-static LIBC_INLINE constexpr unsigned get_r_type(uintptr_t info) {
+static constexpr unsigned get_r_type(uintptr_t info) {
 #ifdef __LP64__
   return ELF64_R_TYPE(info);
 #else


### PR DESCRIPTION
LIBC_INLINE is defined in attributes.h, which was not included. Since constexpr already implies inline, simply remove the LIBC_INLINE qualifier from the static helper, matching the x86_64 and aarch64 irelative implementations.