### PR TITLE
[profcheck] Expose likely/unlikely weights as constants in MDBuilder

### DIFF
--- a/llvm/include/llvm/IR/MDBuilder.h
+++ b/llvm/include/llvm/IR/MDBuilder.h
@@ -38,6 +38,20 @@ class MDBuilder {
   LLVMContext &Context;
 
 public:
+  /// The weight for a branch taken with high probability.
+  ///
+  /// This is the weight used for Likely branches, for example, as used by
+  /// __builtin_expect* or when profile indicates a branch is taken with very
+  /// high probability.
+  static constexpr uint32_t kLikelyBranchWeight = (1U << 20) - 1;
+
+  /// The weight for a branch taken with low probability.
+  ///
+  /// This is the weight used for unlikely branches, for example, as used by
+  /// __builtin_expect* or when profile indicates a branch is taken with very
+  /// low probability.
+  static constexpr uint32_t kUnlikelyBranchWeight = 1;
+
   MDBuilder(LLVMContext &context) : Context(context) {}
 
   /// Return the given string as metadata.

--- a/llvm/lib/IR/MDBuilder.cpp
+++ b/llvm/lib/IR/MDBuilder.cpp
@@ -42,12 +42,12 @@ MDNode *MDBuilder::createBranchWeights(uint32_t TrueWeight,
 
 MDNode *MDBuilder::createLikelyBranchWeights() {
   // Value chosen to match UR_NONTAKEN_WEIGHT, see BranchProbabilityInfo.cpp
-  return createBranchWeights((1U << 20) - 1, 1);
+  return createBranchWeights(kLikelyBranchWeight, kUnlikelyBranchWeight);
 }
 
 MDNode *MDBuilder::createUnlikelyBranchWeights() {
   // Value chosen to match UR_NONTAKEN_WEIGHT, see BranchProbabilityInfo.cpp
-  return createBranchWeights(1, (1U << 20) - 1);
+  return createBranchWeights(kUnlikelyBranchWeight, kLikelyBranchWeight);
 }
 
 MDNode *MDBuilder::createBranchWeights(ArrayRef<uint32_t> Weights,


### PR DESCRIPTION
Define `kLikelyBranchWeight` and `kUnlikelyBranchWeight` as static constexpr members in MDBuilder.h and use them in createLikelyBranchWeights and createUnlikelyBranchWeights. This makes the weights used for likely/unlikely branches more discoverable and reusable.