### PR TITLE
[MC] Set UseAtForSpecifier in initializeAtSpecifiers and default to false

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -385,7 +385,7 @@ protected:
   bool DwarfRegNumForCFI = false;
 
   /// True if target uses @ (expr@specifier) for relocation specifiers.
-  bool UseAtForSpecifier = true;
+  bool UseAtForSpecifier = false;
 
   /// (ARM-specific) Uses parens for relocation specifier in data
   /// directives, e.g. .word foo(got).

--- a/llvm/lib/MC/MCAsmInfo.cpp
+++ b/llvm/lib/MC/MCAsmInfo.cpp
@@ -126,6 +126,7 @@ bool MCAsmInfo::shouldOmitSectionDirective(StringRef SectionName) const {
 
 void MCAsmInfo::initializeAtSpecifiers(ArrayRef<AtSpecifier> Descs) {
   assert(AtSpecifierToName.empty() && "cannot initialize twice");
+  UseAtForSpecifier = true;
   for (auto Desc : Descs) {
     [[maybe_unused]] auto It =
         AtSpecifierToName.try_emplace(Desc.Kind, Desc.Name);

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
@@ -144,11 +144,10 @@ AArch64MCAsmInfoDarwin::AArch64MCAsmInfoDarwin(bool IsILP32) {
   UsesELFSectionDirectiveForBSS = true;
   SupportsDebugInformation = true;
   UseDataRegionDirectives = true;
-  UseAtForSpecifier = false;
-
   ExceptionsType = ExceptionHandling::DwarfCFI;
 
   initializeAtSpecifiers(MachOAtSpecifiers);
+  UseAtForSpecifier = false;
 }
 
 const MCExpr *AArch64MCAsmInfoDarwin::getExprForPersonalitySymbol(
@@ -215,7 +214,6 @@ AArch64MCAsmInfoELF::AArch64MCAsmInfoELF(const Triple &T) {
   Data64bitsDirective = "\t.xword\t";
 
   UseDataRegionDirectives = false;
-  UseAtForSpecifier = false;
 
   WeakRefDirective = "\t.weak\t";
 
@@ -227,6 +225,7 @@ AArch64MCAsmInfoELF::AArch64MCAsmInfoELF(const Triple &T) {
   HasIdentDirective = true;
 
   initializeAtSpecifiers(ELFAtSpecifiers);
+  UseAtForSpecifier = false;
 }
 
 void AArch64MCAsmInfoELF::printSpecifierExpr(

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
@@ -98,11 +98,10 @@ ARMELFMCAsmInfo::ARMELFMCAsmInfo(const Triple &TheTriple) {
     break;
   }
 
+  initializeAtSpecifiers(atSpecifiers);
   // foo(plt) instead of foo@plt
   UseAtForSpecifier = false;
   UseParensForSpecifier = true;
-
-  initializeAtSpecifiers(atSpecifiers);
 }
 
 void ARMELFMCAsmInfo::setUseIntegratedAssembler(bool Value) {
@@ -146,15 +145,14 @@ ARMCOFFMCAsmInfoGNU::ARMCOFFMCAsmInfoGNU() {
   SupportsDebugInformation = true;
   ExceptionsType = ExceptionHandling::WinEH;
   WinEHEncodingType = WinEH::EncodingType::Itanium;
-  UseAtForSpecifier = false;
-  UseParensForSpecifier = true;
-
   DwarfRegNumForCFI = false;
 
   // Conditional Thumb 4-byte instructions can have an implicit IT.
   MaxInstLength = 6;
 
   initializeAtSpecifiers(atSpecifiers);
+  UseAtForSpecifier = false;
+  UseParensForSpecifier = true;
 }
 
 void ARM::printSpecifierExpr(const MCAsmInfo &MAI, raw_ostream &OS,


### PR DESCRIPTION
Set UseAtForSpecifier = true inside initializeAtSpecifiers() so that
all targets calling it automatically get the correct setting. Change
the default to false so targets that don't use @ for relocation
specifiers (RISC-V, Sparc, Mips, LoongArch, etc.) don't need to
explicitly opt out. In addition, discourage future targets from using
this @ , which has parsing ambiguity issues.

For ARM and AArch64, move UseAtForSpecifier = false to after the
initializeAtSpecifiers() call.