### PR TITLE
[Clang][Hexagon] Use --cstdlib flag to choose Picolibc

### DIFF
--- a/clang/lib/Driver/ToolChains/Hexagon.cpp
+++ b/clang/lib/Driver/ToolChains/Hexagon.cpp
@@ -399,18 +399,26 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
 
   if (IncStdLib && IncStartFiles) {
     if (!IsShared) {
-      if (HasStandalone) {
-        SmallString<128> Crt0SA = LibraryDir;
-        llvm::sys::path::append(Crt0SA, "crt0_standalone.o");
-        CmdArgs.push_back(Args.MakeArgString(Crt0SA));
+      if (HTC.GetCStdlibType(Args) == ToolChain::CST_Picolibc) {
+        SmallString<128> Crt0 = LibraryDir;
+        llvm::sys::path::append(Crt0, "crt0-semihost.o");
+        CmdArgs.push_back(Args.MakeArgString(Crt0));
+      } else {
+        if (HasStandalone) {
+          SmallString<128> Crt0SA = LibraryDir;
+          llvm::sys::path::append(Crt0SA, "crt0_standalone.o");
+          CmdArgs.push_back(Args.MakeArgString(Crt0SA));
+        }
+        SmallString<128> Crt0 = LibraryDir;
+        llvm::sys::path::append(Crt0, "crt0.o");
+        CmdArgs.push_back(Args.MakeArgString(Crt0));
       }
-      SmallString<128> Crt0 = LibraryDir;
-      llvm::sys::path::append(Crt0, "crt0.o");
-      CmdArgs.push_back(Args.MakeArgString(Crt0));
     }
-    SmallString<128> Init = LibraryDir;
-    llvm::sys::path::append(Init, UseShared ? "initS.o" : "init.o");
-    CmdArgs.push_back(Args.MakeArgString(Init));
+    if (HTC.GetCStdlibType(Args) != ToolChain::CST_Picolibc) {
+      SmallString<128> Init = LibraryDir;
+      llvm::sys::path::append(Init, UseShared ? "initS.o" : "init.o");
+      CmdArgs.push_back(Args.MakeArgString(Init));
+    }
   }
 
   //----------------------------------------------------------------------------
@@ -442,12 +450,23 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("--start-group");
 
     if (!IsShared) {
-      for (StringRef Lib : OsLibs)
-        CmdArgs.push_back(Args.MakeArgString("-l" + Lib));
+      if (HTC.GetCStdlibType(Args) == ToolChain::CST_Picolibc) {
+        CmdArgs.push_back("-lsemihost");
+      } else {
+        for (StringRef Lib : OsLibs)
+          CmdArgs.push_back(Args.MakeArgString("-l" + Lib));
+      }
       if (!Args.hasArg(options::OPT_nolibc))
         CmdArgs.push_back("-lc");
     }
-    CmdArgs.push_back("-lgcc");
+    if (HTC.GetCStdlibType(Args) == ToolChain::CST_Picolibc) {
+      if (HTC.GetRuntimeLibType(Args) == ToolChain::RLT_CompilerRT)
+        CmdArgs.push_back("-lclang_rt.builtins");
+      else
+        CmdArgs.push_back("-lgcc");
+    } else {
+      CmdArgs.push_back("-lgcc");
+    }
 
     CmdArgs.push_back("--end-group");
   }
@@ -456,9 +475,11 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
   // End files
   //----------------------------------------------------------------------------
   if (IncStdLib && IncStartFiles) {
-    SmallString<128> Fini = LibraryDir;
-    llvm::sys::path::append(Fini, UseShared ? "finiS.o" : "fini.o");
-    CmdArgs.push_back(Args.MakeArgString(Fini));
+    if (HTC.GetCStdlibType(Args) != ToolChain::CST_Picolibc) {
+      SmallString<128> Fini = LibraryDir;
+      llvm::sys::path::append(Fini, UseShared ? "finiS.o" : "fini.o");
+      CmdArgs.push_back(Args.MakeArgString(Fini));
+    }
   }
 }
 
@@ -498,18 +519,22 @@ std::string HexagonToolChain::getHexagonTargetDir(
   return std::string(Dir);
 }
 
-SmallString<128> HexagonToolChain::getEffectiveSysRoot() const {
+SmallString<128>
+HexagonToolChain::getEffectiveSysRoot(const ArgList &Args) const {
   const Driver &D = getDriver();
   // The user-specified `--sysroot` always takes precedence.
   if (!D.SysRoot.empty())
     return SmallString<128>(D.SysRoot);
-  // Otherwise, pick a path relative to the install directory. Try a triple
-  // subdirectory first.
   SmallString<128> Dir(getHexagonTargetDir(D.Dir, D.PrefixDirs));
+  // For Picolibc, use picolibc/<triple> with no fallback.
+  if (GetCStdlibType(Args) == ToolChain::CST_Picolibc) {
+    llvm::sys::path::append(Dir, "picolibc", getTriple().normalize());
+    return Dir;
+  }
+  // Otherwise, try a triple subdirectory first, then fall back to "hexagon".
   llvm::sys::path::append(Dir, getTriple().normalize());
   if (getVFS().exists(Dir))
     return Dir;
-  // Otherwise, fall back to "../target/hexagon".
   Dir = getHexagonTargetDir(D.Dir, D.PrefixDirs);
   llvm::sys::path::append(Dir, "hexagon");
   return Dir;
@@ -518,7 +543,7 @@ SmallString<128> HexagonToolChain::getEffectiveSysRoot() const {
 void HexagonToolChain::getLibraryDir(const ArgList &Args,
                                      llvm::SmallString<128> &Dir) const {
   bool IsLinuxMusl = getTriple().isMusl() && getTriple().isOSLinux();
-  const llvm::SmallString<128> SysRoot = getEffectiveSysRoot();
+  const llvm::SmallString<128> SysRoot = getEffectiveSysRoot(Args);
   // Linux toolchain uses "usr/lib" but it also should accept "lib" in case an
   // external sysroot is used. Similar logic is for include paths.
   if (IsLinuxMusl) {
@@ -540,9 +565,10 @@ void HexagonToolChain::getLibraryDir(const ArgList &Args,
     llvm::sys::path::append(Dir, "pic");
 }
 
-void HexagonToolChain::getBaseIncludeDir(llvm::SmallString<128> &Dir) const {
+void HexagonToolChain::getBaseIncludeDir(const ArgList &Args,
+                                         llvm::SmallString<128> &Dir) const {
   bool IsLinuxMusl = getTriple().isMusl() && getTriple().isOSLinux();
-  const llvm::SmallString<128> SysRoot = getEffectiveSysRoot();
+  const llvm::SmallString<128> SysRoot = getEffectiveSysRoot(Args);
   if (IsLinuxMusl) {
     Dir = SysRoot;
     llvm::sys::path::append(Dir, "usr", "include");
@@ -596,7 +622,7 @@ void HexagonToolChain::getHexagonLibraryPaths(const ArgList &Args,
   std::copy(D.PrefixDirs.begin(), D.PrefixDirs.end(),
             std::back_inserter(RootDirs));
 
-  std::string SysRoot(getEffectiveSysRoot());
+  std::string SysRoot(getEffectiveSysRoot(Args));
   if (!llvm::is_contained(RootDirs, SysRoot))
     RootDirs.push_back(SysRoot);
 
@@ -731,11 +757,11 @@ void HexagonToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
   }
   if (!DriverArgs.hasArg(options::OPT_nostdlibinc)) {
     SmallString<128> CIncludeDir;
-    getBaseIncludeDir(CIncludeDir);
+    getBaseIncludeDir(DriverArgs, CIncludeDir);
     addExternCSystemInclude(DriverArgs, CC1Args, std::string(CIncludeDir));
     bool IsLinuxMusl = getTriple().isMusl() && getTriple().isOSLinux();
     if (IsLinuxMusl) {
-      SmallString<128> LocalIncludeDir = getEffectiveSysRoot();
+      SmallString<128> LocalIncludeDir = getEffectiveSysRoot(DriverArgs);
       llvm::sys::path::append(LocalIncludeDir, "usr", "local", "include");
       addSystemInclude(DriverArgs, CC1Args, LocalIncludeDir);
     }
@@ -748,7 +774,7 @@ void HexagonToolChain::addLibCxxIncludePaths(
     const llvm::opt::ArgList &DriverArgs,
     llvm::opt::ArgStringList &CC1Args) const {
   SmallString<128> Dir;
-  getBaseIncludeDir(Dir);
+  getBaseIncludeDir(DriverArgs, Dir);
   llvm::sys::path::append(Dir, "c++", "v1");
   addLibStdCXXIncludePaths(Dir, "", "", DriverArgs, CC1Args);
 }
@@ -757,16 +783,36 @@ void HexagonToolChain::addLibStdCxxIncludePaths(
     const llvm::opt::ArgList &DriverArgs,
     llvm::opt::ArgStringList &CC1Args) const {
   SmallString<128> Dir;
-  getBaseIncludeDir(Dir);
+  getBaseIncludeDir(DriverArgs, Dir);
   llvm::sys::path::append(Dir, "c++");
   addLibStdCXXIncludePaths(Dir, "", "", DriverArgs, CC1Args);
+}
+
+ToolChain::RuntimeLibType
+HexagonToolChain::GetRuntimeLibType(const ArgList &Args) const {
+  if (GetCStdlibType(Args) == ToolChain::CST_Picolibc) {
+    if (Args.getLastArg(options::OPT_rtlib_EQ))
+      return ToolChain::GetRuntimeLibType(Args);
+    return ToolChain::RLT_CompilerRT;
+  }
+  return ToolChain::GetRuntimeLibType(Args);
+}
+
+ToolChain::UnwindLibType
+HexagonToolChain::GetUnwindLibType(const ArgList &Args) const {
+  if (GetCStdlibType(Args) == ToolChain::CST_Picolibc) {
+    if (Args.getLastArg(options::OPT_unwindlib_EQ))
+      return ToolChain::GetUnwindLibType(Args);
+    return ToolChain::UNW_CompilerRT;
+  }
+  return ToolChain::GetUnwindLibType(Args);
 }
 
 ToolChain::CXXStdlibType
 HexagonToolChain::GetCXXStdlibType(const ArgList &Args) const {
   Arg *A = Args.getLastArg(options::OPT_stdlib_EQ);
   if (!A) {
-    if (getTriple().isMusl())
+    if (getTriple().isMusl() || GetCStdlibType(Args) == ToolChain::CST_Picolibc)
       return ToolChain::CST_Libcxx;
     else
       return ToolChain::CST_Libstdcxx;

--- a/clang/lib/Driver/ToolChains/Hexagon.h
+++ b/clang/lib/Driver/ToolChains/Hexagon.h
@@ -92,6 +92,11 @@ public:
     return getTriple().isMusl() ? "ld.lld" : "hexagon-link";
   }
 
+  RuntimeLibType
+  GetRuntimeLibType(const llvm::opt::ArgList &Args) const override;
+
+  UnwindLibType GetUnwindLibType(const llvm::opt::ArgList &Args) const override;
+
   CXXStdlibType GetCXXStdlibType(const llvm::opt::ArgList &Args) const override;
 
   void AddCXXStdlibLibArgs(const llvm::opt::ArgList &Args,
@@ -102,8 +107,9 @@ public:
   std::string getHexagonTargetDir(
       const std::string &InstalledDir,
       const SmallVectorImpl<std::string> &PrefixDirs) const;
-  SmallString<128> getEffectiveSysRoot() const;
-  void getBaseIncludeDir(llvm::SmallString<128> &) const;
+  SmallString<128> getEffectiveSysRoot(const llvm::opt::ArgList &Args) const;
+  void getBaseIncludeDir(const llvm::opt::ArgList &Args,
+                         llvm::SmallString<128> &) const;
   void getLibraryDir(const llvm::opt::ArgList &Args,
                      llvm::SmallString<128> &) const;
   void getHexagonLibraryPaths(const llvm::opt::ArgList &Args,

--- a/clang/test/Driver/Inputs/hexagon_tree/Tools/target/picolibc/hexagon-unknown-none-elf/include/c++/readme
+++ b/clang/test/Driver/Inputs/hexagon_tree/Tools/target/picolibc/hexagon-unknown-none-elf/include/c++/readme
@@ -1,0 +1,4 @@
+Git does not record empty directories. Create a dummy file in each directory
+here. Strictly speaking, putting dummy files in leaf directories should be
+sufficient, but adding them everywhere reduces the risk of repeating the same
+problem in case new directories are added.

--- a/clang/test/Driver/Inputs/hexagon_tree/Tools/target/picolibc/hexagon-unknown-none-elf/include/c++/v1/readme
+++ b/clang/test/Driver/Inputs/hexagon_tree/Tools/target/picolibc/hexagon-unknown-none-elf/include/c++/v1/readme
@@ -1,0 +1,4 @@
+Git does not record empty directories. Create a dummy file in each directory
+here. Strictly speaking, putting dummy files in leaf directories should be
+sufficient, but adding them everywhere reduces the risk of repeating the same
+problem in case new directories are added.

--- a/clang/test/Driver/Inputs/hexagon_tree/Tools/target/picolibc/hexagon-unknown-none-elf/include/readme
+++ b/clang/test/Driver/Inputs/hexagon_tree/Tools/target/picolibc/hexagon-unknown-none-elf/include/readme
@@ -1,0 +1,4 @@
+Git does not record empty directories. Create a dummy file in each directory
+here. Strictly speaking, putting dummy files in leaf directories should be
+sufficient, but adding them everywhere reduces the risk of repeating the same
+problem in case new directories are added.

--- a/clang/test/Driver/Inputs/hexagon_tree/Tools/target/picolibc/hexagon-unknown-none-elf/readme
+++ b/clang/test/Driver/Inputs/hexagon_tree/Tools/target/picolibc/hexagon-unknown-none-elf/readme
@@ -1,0 +1,4 @@
+Git does not record empty directories. Create a dummy file in each directory
+here. Strictly speaking, putting dummy files in leaf directories should be
+sufficient, but adding them everywhere reduces the risk of repeating the same
+problem in case new directories are added.

--- a/clang/test/Driver/Inputs/hexagon_tree/Tools/target/picolibc/readme
+++ b/clang/test/Driver/Inputs/hexagon_tree/Tools/target/picolibc/readme
@@ -1,0 +1,4 @@
+Git does not record empty directories. Create a dummy file in each directory
+here. Strictly speaking, putting dummy files in leaf directories should be
+sufficient, but adding them everywhere reduces the risk of repeating the same
+problem in case new directories are added.

--- a/clang/test/Driver/hexagon-toolchain-picolibc.c
+++ b/clang/test/Driver/hexagon-toolchain-picolibc.c
@@ -1,0 +1,120 @@
+// REQUIRES: hexagon-registered-target
+
+// -----------------------------------------------------------------------------
+// Test standard include paths
+// -----------------------------------------------------------------------------
+// RUN: %clang -### --target=hexagon-none-elf --cstdlib=picolibc \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-C-INCLUDES %s
+// CHECK-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}lib{{/|\\\\}}clang{{/|\\\\}}{{[0-9]+}}{{/|\\\\}}include"
+// CHECK-C-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include"
+
+// RUN: %clangxx -### --target=hexagon-none-elf --cstdlib=picolibc \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-CXX-INCLUDES %s
+// CHECK-CXX-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
+// CHECK-CXX-INCLUDES: "-internal-isystem" "{{.*}}{{/|\\\\}}lib{{/|\\\\}}clang{{/|\\\\}}{{[0-9]+}}{{/|\\\\}}include"
+// CHECK-CXX-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include"
+// -----------------------------------------------------------------------------
+// Passing start files for Picolibc
+// -----------------------------------------------------------------------------
+// RUN: %clang --target=hexagon-none-elf --cstdlib=picolibc -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-STARTUP
+// CHECK-STARTUP: "{{.*}}crt0-semihost.o"
+//
+// RUN: %clang --target=hexagon-none-elf --cstdlib=picolibc -nostartfiles -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-NOSTART
+// CHECK-NOSTART-NOT: "{{.*}}crt0-semihost.o"
+// -----------------------------------------------------------------------------
+// Passing  -nostdlib, -nostartfiles, -nodefaultlibs, -nolibc
+// -----------------------------------------------------------------------------
+// RUN: %clangxx -### --target=hexagon-none-elf --cstdlib=picolibc \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv60 \
+// RUN:   -nostdlib %s 2>&1 | FileCheck -check-prefix=CHECK-NOSTDLIB %s
+// CHECK-NOSTDLIB: "-cc1"
+// CHECK-NOSTDLIB: {{hexagon-link|ld}}
+// CHECK-NOSTDLIB-NOT: {{.*}}crt0-semihost.o
+// CHECK-NOSTDLIB-NOT: "-lc++"
+// CHECK-NOSTDLIB-NOT: "-lm"
+// CHECK-NOSTDLIB-NOT: "--start-group"
+// CHECK-NOSTDLIB-NOT: "-lsemihost"
+// CHECK-NOSTDLIB-NOT: "-lc"
+// CHECK-NOSTDLIB-NOT: "-l{{(clang_rt\.builtins)}}"
+// CHECK-NOSTDLIB-NOT: "--end-group"
+
+// RUN: %clangxx -### --target=hexagon-none-elf --cstdlib=picolibc \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv60 \
+// RUN:   -nostartfiles %s 2>&1 | FileCheck -check-prefix=CHECK-NOSTARTFILES %s
+// CHECK-NOSTARTFILES: "-cc1"
+// CHECK-NOSTARTFILES: {{hexagon-link|ld}}
+// CHECK-NOSTARTFILES-NOT: {{.*}}crt0-semihost.o
+// CHECK-NOSTARTFILES: "-lc++" "-lc++abi" "-lunwind" "-lm" "--start-group" "-lsemihost" "-lc" "-lclang_rt.builtins" "--end-group"
+
+// RUN: %clangxx -### --target=hexagon-none-elf --cstdlib=picolibc \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv60 \
+// RUN:   -nodefaultlibs %s 2>&1 | FileCheck -check-prefix=CHECK-NODEFAULTLIBS %s
+// CHECK-NODEFAULTLIBS: "-cc1"
+// CHECK-NODEFAULTLIBS: {{hexagon-link|ld}}
+// CHECK-NODEFAULTLIBS: "{{.*}}crt0-semihost.o"
+// CHECK-NODEFAULTLIBS-NOT: "-lc++"
+// CHECK-NODEFAULTLIBS-NOT: "-lm"
+// CHECK-NODEFAULTLIBS-NOT: "--start-group"
+// CHECK-NODEFAULTLIBS-NOT: "-lsemihost"
+// CHECK-NODEFAULTLIBS-NOT: "-lc"
+// CHECK-NODEFAULTLIBS-NOT: "-lclang_rt.builtins"
+// CHECK-NODEFAULTLIBS-NOT: "--end-group"
+
+// RUN: %clangxx -### --target=hexagon-none-elf --cstdlib=picolibc \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin -mcpu=hexagonv60 \
+// RUN:   -nolibc %s 2>&1 | FileCheck -check-prefix=CHECK-NOLIBC %s
+// CHECK-NOLIBC: "-cc1"
+// CHECK-NOLIBC: hexagon-link
+// CHECK-NOLIBC-SAME: "{{.*}}crt0-semihost.o"
+// CHECK-NOLIBC-SAME: "-lc++"
+// CHECK-NOLIBC-SAME: "-lm"
+// CHECK-NOLIBC-SAME: "--start-group"
+// CHECK-NOLIBC-SAME: "-lsemihost"
+// CHECK-NOLIBC-NOT: "-lc"
+// CHECK-NOLIBC-SAME: "-lclang_rt.builtins"
+// CHECK-NOLIBC-SAME: "--end-group"
+// -----------------------------------------------------------------------------
+// Force compiler-rt when Picolibc is selected
+// -----------------------------------------------------------------------------
+// RUN: %clang --target=hexagon-none-elf --cstdlib=picolibc -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-RTLIB
+// RUN: %clangxx --target=hexagon-none-elf --cstdlib=picolibc -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-RTLIB
+// CHECK-RTLIB: "-lclang_rt.builtins"
+// CHECK-RTLIB-NOT: "-lgcc"
+// -----------------------------------------------------------------------------
+// Allow --rtlib to override the default compiler-rt when Picolibc is selected
+// -----------------------------------------------------------------------------
+// RUN: %clang --target=hexagon-none-elf --cstdlib=picolibc --rtlib=libgcc -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-RTLIB-OVERRIDE
+// CHECK-RTLIB-OVERRIDE: "-lgcc"
+// CHECK-RTLIB-OVERRIDE-NOT: "-lclang_rt.builtins"
+// -----------------------------------------------------------------------------
+// libunwind is linked by default for C++ when Picolibc is selected; user can
+// override with --unwindlib=
+// -----------------------------------------------------------------------------
+// RUN: %clangxx --target=hexagon-none-elf --cstdlib=picolibc -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-CXX-UNWIND
+// CHECK-CXX-UNWIND: "-lunwind"
+// RUN: %clangxx --target=hexagon-none-elf --cstdlib=picolibc --unwindlib=none -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-UNWIND-OVERRIDE
+// CHECK-UNWIND-OVERRIDE-NOT: "-lunwind"
+// -----------------------------------------------------------------------------
+// Library search paths
+// -----------------------------------------------------------------------------
+// RUN: %clang --target=hexagon-none-elf --cstdlib=picolibc \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv68 -### %s 2>&1 | FileCheck -check-prefix=CHECK-LIBPATHS %s
+// CHECK-LIBPATHS: "-L{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}lib{{/|\\\\}}v68"
+// CHECK-LIBPATHS-NOT: "-L{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}lib{{/|\\\\}}v68{{/|\\\\}}G0"
+
+// RUN: %clang --target=hexagon-none-elf --cstdlib=picolibc \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv68 -G0 -### %s 2>&1 | FileCheck -check-prefix=CHECK-LIBPATHS-G0 %s
+// CHECK-LIBPATHS-G0: "-L{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}lib{{/|\\\\}}v68{{/|\\\\}}G0"
+// CHECK-LIBPATHS-G0: "-L{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}lib{{/|\\\\}}v68"
+
+// RUN: %clang --target=hexagon-none-elf --cstdlib=picolibc \
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
+// RUN:   -mcpu=hexagonv68 -fpic -### %s 2>&1 | FileCheck -check-prefix=CHECK-LIBPATHS-PIC %s
+// CHECK-LIBPATHS-PIC: "-L{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}lib{{/|\\\\}}v68{{/|\\\\}}G0{{/|\\\\}}pic"
+// CHECK-LIBPATHS-PIC: "-L{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}lib{{/|\\\\}}v68{{/|\\\\}}G0"
+// CHECK-LIBPATHS-PIC: "-L{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}lib{{/|\\\\}}v68"


### PR DESCRIPTION
Update the Hexagon toolchain to use --cstdlib flag to allow users to
choose Picolibc as the C library.
This allows proper selection of C library when targeting
Hexagon environments.

depends on https://github.com/llvm/llvm-project/pull/183254