### PR TITLE
[libclc][NFC] Drop '#pragma clang fp contract(fast)' in clc_rsqrt

### DIFF
--- a/libclc/clc/lib/generic/math/clc_rsqrt.inc
+++ b/libclc/clc/lib/generic/math/clc_rsqrt.inc
@@ -7,6 +7,5 @@
 //===----------------------------------------------------------------------===//
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_rsqrt(__CLC_GENTYPE val) {
-#pragma clang fp contract(fast)
   return __CLC_FP_LIT(1.0) / __builtin_elementwise_sqrt(val);
 }


### PR DESCRIPTION
It becomes redundant since 2a48aab50254 which enabled -ffp-contract=fast-honor-pragmas globally.