### PR TITLE
[libclc] Compile with -fdenormal-fp-math=dynamic

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -369,6 +369,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
       -Werror=undef
       -fdiscard-value-names
       -ffp-contract=fast-honor-pragmas
+      -fdenormal-fp-math=dynamic
     )
 
     if( NOT "${cpu}" STREQUAL "" )


### PR DESCRIPTION
This PR is extracted from #157633.
`-fdenormal-fp-math=dynamic` is required to defer denormal handling and should be used for libclc library compilation.

Additionally, if the default ieee value is incompatible with the user code's denormal-fp-math setting, this mismatch prevents libclc functions from being inlined.