### PR TITLE
[libc++] Fix vector::append_range growing before the capacity is reached

### DIFF
--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -483,7 +483,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr void append_range(_Range&& __range) {
     if constexpr (ranges::forward_range<_Range> || ranges::sized_range<_Range>) {
       auto __len = ranges::distance(__range);
-      if (__len < __cap_ - __end_) {
+      if (__len <= __cap_ - __end_) {
         __construct_at_end(ranges::begin(__range), ranges::end(__range), __len);
       } else {
         _SplitBuffer __buffer(__recommend(size() + __len), size(), __alloc_);


### PR DESCRIPTION
Currently `vector::append_range` grows even when appending a number of elements that is exactly equal to its spare capacity, which is guaranteed by the standard to _not_ happen.

Fixes #183256
