### PR TITLE
[llvm][release] Note that some packages have 2 signature files

### DIFF
--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -180,7 +180,7 @@ In addition, source archives are available:
 
 ## Verifying Packages
 
-All packages come with a matching `.sig` or `.jsonl` file. You should use these to verify the integrity of the packages.
+All packages come with a matching `.sig` and/or `.jsonl` file. You should use these to verify the integrity of the packages.
 
 If it has a `.sig` file, it should have been signed by the release managers using GPG. Download the keys from the [LLVM website](https://releases.llvm.org/release-keys.asc), import them into your keyring and use them to verify the file:
 ```


### PR DESCRIPTION
For example in the latest release, there is:
LLVM-22.1.0-Linux-ARM64.tar.xz

Which has 2 signature files:
LLVM-22.1.0-Linux-ARM64.tar.xz.jsonl
LLVM-22.1.0-Linux-ARM64.tar.xz.sig

jsonl comes from the GitHub build and the sig is uploaded by the release manager.