### PR TITLE
[libc] Use response files for hdrgen entry points

### DIFF
--- a/libc/cmake/modules/LLVMLibCHeaderRules.cmake
+++ b/libc/cmake/modules/LLVMLibCHeaderRules.cmake
@@ -109,11 +109,10 @@ function(add_gen_header target_name)
     set(entry_points "${TARGET_ENTRYPOINT_NAME_LIST}")
   endif()
 
+  # TODO: Use $<LIST:PREPEND,list,item,...> after we bump CMake to 3.27.
   list(TRANSFORM entry_points PREPEND "--entry-point=")
-
-  set(rsp_file "${CMAKE_CURRENT_BINARY_DIR}/${out_file}.rsp")
-  string(REPLACE ";" " " entry_points "${entry_points}")
-  file(WRITE ${rsp_file} "${entry_points}")
+  set(rsp_file "${CMAKE_CURRENT_BINARY_DIR}/${relative_path}.rsp")
+  file(GENERATE OUTPUT ${rsp_file} CONTENT "$<JOIN:${entry_points},\n>")
 
   add_custom_command(
     OUTPUT ${out_file}

--- a/libc/cmake/modules/LLVMLibCHeaderRules.cmake
+++ b/libc/cmake/modules/LLVMLibCHeaderRules.cmake
@@ -111,6 +111,10 @@ function(add_gen_header target_name)
 
   list(TRANSFORM entry_points PREPEND "--entry-point=")
 
+  set(rsp_file "${CMAKE_CURRENT_BINARY_DIR}/${out_file}.rsp")
+  string(REPLACE ";" " " entry_points "${entry_points}")
+  file(WRITE ${rsp_file} "${entry_points}")
+
   add_custom_command(
     OUTPUT ${out_file}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
@@ -119,9 +123,9 @@ function(add_gen_header target_name)
             --depfile ${dep_file}
             --write-if-changed
             ${proxy_arg}
-            ${entry_points}
             ${yaml_file}
-    DEPENDS ${yaml_file}
+            "@${rsp_file}"
+    DEPENDS ${yaml_file} ${rsp_file}
     DEPFILE ${dep_file}
     COMMENT "Generating header ${ADD_GEN_HDR_GEN_HDR} from ${yaml_file}"
   )

--- a/libc/utils/hdrgen/hdrgen/main.py
+++ b/libc/utils/hdrgen/hdrgen/main.py
@@ -18,8 +18,9 @@ from hdrgen.yaml_to_classes import load_yaml_file, fill_public_api
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Generate header files from YAML",
-                                     fromfile_prefix_chars="@")
+    parser = argparse.ArgumentParser(
+        description="Generate header files from YAML", fromfile_prefix_chars="@"
+    )
     parser.add_argument(
         "yaml_file",
         help="Path to the YAML file containing header specification",

--- a/libc/utils/hdrgen/hdrgen/main.py
+++ b/libc/utils/hdrgen/hdrgen/main.py
@@ -18,7 +18,8 @@ from hdrgen.yaml_to_classes import load_yaml_file, fill_public_api
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Generate header files from YAML")
+    parser = argparse.ArgumentParser(description="Generate header files from YAML",
+                                     fromfile_prefix_chars="@")
     parser.add_argument(
         "yaml_file",
         help="Path to the YAML file containing header specification",


### PR DESCRIPTION
This avoids the build failure when the command line ends up being too long which can be especially problematic on Windows.

Fixes #182374