### PR TITLE
[openmp] Fix bug63197.c test with 3 cores

### DIFF
--- a/openmp/runtime/test/parallel/bug63197.c
+++ b/openmp/runtime/test/parallel/bug63197.c
@@ -8,6 +8,13 @@ int main(int argc, char *argv[]) {
 #pragma omp single
   { printf("BBB %2d\n", omp_get_num_threads()); }
 
+  // This test relies on the number of available threads
+  // being something other than 3.
+  if (omp_get_max_threads() == 3) {
+    printf("PASS\n");
+    return 0;
+  }
+
 #pragma omp parallel
 #pragma omp single
   {

--- a/openmp/runtime/test/parallel/bug63197.c
+++ b/openmp/runtime/test/parallel/bug63197.c
@@ -4,21 +4,15 @@
 #include <stdio.h>
 
 int main(int argc, char *argv[]) {
-#pragma omp parallel num_threads(3) if (0)
+  unsigned N = omp_get_max_threads() - 1;
+#pragma omp parallel num_threads(N) if (0)
 #pragma omp single
   { printf("BBB %2d\n", omp_get_num_threads()); }
-
-  // This test relies on the number of available threads
-  // being something other than 3.
-  if (omp_get_max_threads() == 3) {
-    printf("PASS\n");
-    return 0;
-  }
 
 #pragma omp parallel
 #pragma omp single
   {
-    if (omp_get_num_threads() != 3)
+    if (omp_get_num_threads() != N)
       printf("PASS\n");
   }
   return 0;


### PR DESCRIPTION
This test assumes that the number of available threads is not 3, otherwise `#pragma omp parallel` and `#pragma omp parallel num_thread(3)` are naturally going to do the same thing.

Instead use `omp_get_max_threads() - 1` as the number of threads in the initial `omp parallel num_thread(N)` and then check that the number of threads does not match the value in the later `omp parallel`.