### PR TITLE
[DAG] Move (X +/- Y) & Y --> ~X & Y fold from visitAnd to SimplifyDemandedBits

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -7972,13 +7972,6 @@ SDValue DAGCombiner::visitAND(SDNode *N) {
       return DAG.getNode(ISD::ZERO_EXTEND, DL, VT, X.getOperand(0));
   }
 
-  // (X +/- Y) & Y --> ~X & Y when Y is a power of 2 (or zero).
-  if (sd_match(N, m_And(m_Value(Y),
-                        m_OneUse(m_AnyOf(m_Add(m_Value(X), m_Deferred(Y)),
-                                         m_Sub(m_Value(X), m_Deferred(Y)))))) &&
-      DAG.isKnownToBeAPowerOfTwo(Y, /*OrZero=*/true))
-    return DAG.getNode(ISD::AND, DL, VT, DAG.getNOT(DL, X, VT), Y);
-
   // fold (and (sign_extend_inreg x, i16 to i32), 1) -> (and x, 1)
   // fold (and (sra)) -> (and (srl)) when possible.
   if (SimplifyDemandedBits(SDValue(N, 0)))

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -4944,11 +4944,14 @@ template <class MatchContextClass> SDValue DAGCombiner::visitMUL(SDNode *N) {
         Matcher.getNode(ISD::MUL, SDLoc(N1), VT, N0.getOperand(1), N1));
 
   // Fold (mul (vscale * C0), C1) to (vscale * (C0 * C1)).
+  // avoid if ISD::MUL handling is poor and ISD::SHL isn't an option.
   ConstantSDNode *NC1 = isConstOrConstSplat(N1);
   if (!UseVP && N0.getOpcode() == ISD::VSCALE && NC1) {
     const APInt &C0 = N0.getConstantOperandAPInt(0);
     const APInt &C1 = NC1->getAPIntValue();
-    return DAG.getVScale(DL, VT, C0 * C1);
+    if (!C0.isPowerOf2() || C1.isPowerOf2() ||
+        hasOperation(ISD::MUL, NC1->getValueType(0)))
+      return DAG.getVScale(DL, VT, C0 * C1);
   }
 
   // Fold (mul step_vector(C0), C1) to (step_vector(C0 * C1)).

--- a/llvm/test/CodeGen/RISCV/rvv/known-never-zero.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/known-never-zero.ll
@@ -9,33 +9,24 @@
 define i32 @vscale_known_nonzero() {
 ; CHECK-LABEL: vscale_known_nonzero:
 ; CHECK:       # %bb.0:
+; CHECK-NEXT:    addi sp, sp, -16
+; CHECK-NEXT:    .cfi_def_cfa_offset 16
+; CHECK-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
+; CHECK-NEXT:    .cfi_offset ra, -8
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    slli a2, a0, 1
-; CHECK-NEXT:    slli a3, a0, 3
-; CHECK-NEXT:    slli a4, a0, 5
-; CHECK-NEXT:    slli a5, a0, 7
-; CHECK-NEXT:    sub a1, a1, a2
-; CHECK-NEXT:    slli a2, a0, 9
-; CHECK-NEXT:    add a3, a3, a4
-; CHECK-NEXT:    slli a4, a0, 13
-; CHECK-NEXT:    sub a5, a5, a2
-; CHECK-NEXT:    slli a2, a0, 15
-; CHECK-NEXT:    sub a4, a4, a2
-; CHECK-NEXT:    add a1, a1, a3
-; CHECK-NEXT:    slli a2, a0, 11
-; CHECK-NEXT:    sub a5, a5, a2
-; CHECK-NEXT:    slli a2, a0, 20
-; CHECK-NEXT:    sub a4, a4, a2
-; CHECK-NEXT:    slli a0, a0, 24
-; CHECK-NEXT:    add a1, a1, a5
-; CHECK-NEXT:    add a0, a4, a0
-; CHECK-NEXT:    add a0, a1, a0
+; CHECK-NEXT:    lui a1, 30667
+; CHECK-NEXT:    srli a0, a0, 3
+; CHECK-NEXT:    addi a1, a1, 1329
+; CHECK-NEXT:    call __muldi3
 ; CHECK-NEXT:    srliw a0, a0, 27
 ; CHECK-NEXT:    lui a1, %hi(.LCPI0_0)
 ; CHECK-NEXT:    addi a1, a1, %lo(.LCPI0_0)
 ; CHECK-NEXT:    add a0, a1, a0
 ; CHECK-NEXT:    lbu a0, 0(a0)
+; CHECK-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
+; CHECK-NEXT:    .cfi_restore ra
+; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
   %x = call i32 @llvm.vscale()
   %r = call i32 @llvm.cttz.i32(i32 %x, i1 false)

--- a/llvm/test/CodeGen/RISCV/rvv/known-never-zero.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/known-never-zero.ll
@@ -9,24 +9,33 @@
 define i32 @vscale_known_nonzero() {
 ; CHECK-LABEL: vscale_known_nonzero:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
-; CHECK-NEXT:    .cfi_offset ra, -8
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    lui a1, 30667
-; CHECK-NEXT:    srli a0, a0, 3
-; CHECK-NEXT:    addi a1, a1, 1329
-; CHECK-NEXT:    call __muldi3
+; CHECK-NEXT:    srli a1, a0, 3
+; CHECK-NEXT:    slli a2, a0, 1
+; CHECK-NEXT:    slli a3, a0, 3
+; CHECK-NEXT:    slli a4, a0, 5
+; CHECK-NEXT:    slli a5, a0, 7
+; CHECK-NEXT:    sub a1, a1, a2
+; CHECK-NEXT:    slli a2, a0, 9
+; CHECK-NEXT:    add a3, a3, a4
+; CHECK-NEXT:    slli a4, a0, 13
+; CHECK-NEXT:    sub a5, a5, a2
+; CHECK-NEXT:    slli a2, a0, 15
+; CHECK-NEXT:    sub a4, a4, a2
+; CHECK-NEXT:    add a1, a1, a3
+; CHECK-NEXT:    slli a2, a0, 11
+; CHECK-NEXT:    sub a5, a5, a2
+; CHECK-NEXT:    slli a2, a0, 20
+; CHECK-NEXT:    sub a4, a4, a2
+; CHECK-NEXT:    slli a0, a0, 24
+; CHECK-NEXT:    add a1, a1, a5
+; CHECK-NEXT:    add a0, a4, a0
+; CHECK-NEXT:    add a0, a1, a0
 ; CHECK-NEXT:    srliw a0, a0, 27
 ; CHECK-NEXT:    lui a1, %hi(.LCPI0_0)
 ; CHECK-NEXT:    addi a1, a1, %lo(.LCPI0_0)
 ; CHECK-NEXT:    add a0, a1, a0
 ; CHECK-NEXT:    lbu a0, 0(a0)
-; CHECK-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
-; CHECK-NEXT:    .cfi_restore ra
-; CHECK-NEXT:    addi sp, sp, 16
-; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
   %x = call i32 @llvm.vscale()
   %r = call i32 @llvm.cttz.i32(i32 %x, i1 false)

--- a/llvm/test/CodeGen/X86/known-pow2.ll
+++ b/llvm/test/CodeGen/X86/known-pow2.ll
@@ -775,7 +775,6 @@ define i1 @pow2_and(i32 %x, i32 %y) {
   ret i1 %r
 }
 
-; FIXME: Missing isKnownToBeAPowerOfTwo DemandedElts handling
 define <4 x i32> @pow2_and_vector(<4 x i32> %x, <4 x i32> %y) {
 ; CHECK-LABEL: pow2_and_vector:
 ; CHECK:       # %bb.0:
@@ -783,16 +782,11 @@ define <4 x i32> @pow2_and_vector(<4 x i32> %x, <4 x i32> %y) {
 ; CHECK-NEXT:    paddd {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
 ; CHECK-NEXT:    cvttps2dq %xmm1, %xmm1
 ; CHECK-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[1,1,3,3]
-; CHECK-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1 # [1,2,4,9]
-; CHECK-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[0,2,2,3]
-; CHECK-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm2 # [2,2,9,9]
-; CHECK-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[0,2,2,3]
-; CHECK-NEXT:    punpckldq {{.*#+}} xmm1 = xmm1[0],xmm2[0],xmm1[1],xmm2[1]
-; CHECK-NEXT:    pxor %xmm2, %xmm2
-; CHECK-NEXT:    psubd %xmm1, %xmm2
-; CHECK-NEXT:    pand %xmm1, %xmm2
-; CHECK-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[0,2,1,0]
-; CHECK-NEXT:    pand %xmm1, %xmm0
+; CHECK-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1 # [1,2,4,u]
+; CHECK-NEXT:    pmuludq {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm2 # [2,2,u,u]
+; CHECK-NEXT:    punpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm1[0]
+; CHECK-NEXT:    shufps {{.*#+}} xmm1 = xmm1[0,2],xmm2[0,2]
+; CHECK-NEXT:    andps %xmm1, %xmm0
 ; CHECK-NEXT:    pcmpeqd %xmm1, %xmm0
 ; CHECK-NEXT:    retq
   %yy = shl nuw nsw <4 x i32> <i32 1, i32 2, i32 4, i32 9>, %y


### PR DESCRIPTION
Add DemandedElts handling to allow better vector support

To prevent RISCV falling back to a mul call in known-never-zero.ll I've had to tweak the (mul step_vector(C0), C1) to (step_vector(C0 * C1)) fold to only occur if C0 is already non-power-of-2, C0 * C1 is a power-of-2 or the target has good mul support.