### PR TITLE
[LoopInterchange] Fix the way of insertion for the FirstIteration PHINode.

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -1901,7 +1901,7 @@ void LoopInterchangeTransform::reduction2Memory() {
 
   LoopInterchangeLegality::InnerReduction SR = InnerReductions[0];
   BasicBlock *InnerLoopHeader = InnerLoop->getHeader();
-  IRBuilder<> Builder(&*(InnerLoopHeader->getFirstNonPHIIt()));
+  IRBuilder<> Builder(InnerLoopHeader, InnerLoopHeader->getFirstNonPHIIt());
 
   // Check if it's the first iteration.
   LLVMContext &Context = InnerLoopHeader->getContext();


### PR DESCRIPTION

While testing the LLVM debug version, I found that the original insertion method could cause errors. 

An example of the IR is provided below: 
https://godbolt.org/z/b83v7Wfna

And compilation command for reference:
`opt -S -passes="loop-interchange" -o test.interchange.ll -da-disable-delinearization-checks -loop-interchange-reduction-to-mem -loop-interchange-profitabilities=ignore test.ll`

This patch optimizes the insertion of the FirstIteration PHINode, successfully eliminating this error. From my initial observations, this is a method commonly used by other passes