### PR TITLE
[WebKit Checkers] Handle CXXRewrittenBinaryOperator in trivial analysis.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -723,7 +723,7 @@ public:
     return IsFunctionTrivial(Callee);
   }
 
-  bool VisitCXXRewrittenBinaryOperator(const CXXRewrittenBinaryOperator* Op) {
+  bool VisitCXXRewrittenBinaryOperator(const CXXRewrittenBinaryOperator *Op) {
     auto *SemanticExpr = Op->getSemanticForm();
     return SemanticExpr && Visit(SemanticExpr);
   }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -723,6 +723,11 @@ public:
     return IsFunctionTrivial(Callee);
   }
 
+  bool VisitCXXRewrittenBinaryOperator(const CXXRewrittenBinaryOperator* Op) {
+    auto *SemanticExpr = Op->getSemanticForm();
+    return SemanticExpr && Visit(SemanticExpr);
+  }
+
   bool VisitCXXDefaultArgExpr(const CXXDefaultArgExpr *E) {
     if (auto *Expr = E->getExpr()) {
       if (!Visit(Expr))


### PR DESCRIPTION
Visit the semantic form when encountering CXXRewrittenBinaryOperator in the trivial function analysis / no-delete analysis.