### PR TITLE
[clang][bytecode] Attach block scope variables to the root scope

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.h
+++ b/clang/lib/AST/ByteCode/Compiler.h
@@ -490,7 +490,14 @@ public:
   void addForScopeKind(const Scope::Local &Local, ScopeKind Kind) {
     VariableScope *P = this;
     while (P) {
+      // We found the right scope kind.
       if (P->Kind == Kind) {
+        P->addLocal(Local);
+        return;
+      }
+      // If we reached the root scope and we're looking for a Block scope,
+      // attach it to the root instead of the current scope.
+      if (!P->Parent && Kind == ScopeKind::Block) {
         P->addLocal(Local);
         return;
       }

--- a/clang/test/AST/ByteCode/codegen-constexpr-unknown.cpp
+++ b/clang/test/AST/ByteCode/codegen-constexpr-unknown.cpp
@@ -1,5 +1,23 @@
-// RUN: %clang_cc1 -triple x86_64-linux -emit-llvm -fcxx-exceptions -o - %s                                         | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-linux -emit-llvm -fcxx-exceptions -o - %s -fexperimental-new-constant-interpreter | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-linux -emit-llvm -fcxx-exceptions -o - %s                                                  | FileCheck %s --check-prefix=CHECK
+// RUN: %clang_cc1 -triple x86_64-linux -emit-llvm -fcxx-exceptions -o - %s -fexperimental-new-constant-interpreter -DINTERP | FileCheck %s --check-prefix=CHECK,INTERP
+
+/// CodeGenFunction::ConstantFoldsToSimpleInteger() for the if condition
+/// needs to succeed and return true.
+extern void abort2();
+constexpr const int* to_address(const int *p) {
+  return p;
+}
+void rightscope() {
+  const int p = 0;
+  if (to_address(&p) == &p)
+    return;
+  abort2();
+}
+// CHECK:      define dso_local void @_Z10rightscopev()
+// CHECK-NEXT: entry:
+// CHECK-NEXT: %p = alloca i32
+// CHECK-NEXT: store i32 0, ptr %p
+// INTERP-NEXT: call noundef ptr @_Z10to_addressPKi(ptr noundef %p)
 
 
 /// In the if expression below, the read from s.i should fail.
@@ -39,7 +57,7 @@ int main() {
 /// Similarly, here we revisit the BindingDecl.
 struct F { int x; };
 int main2() {
-  const F const s{99};
+  const F s{99};
   const auto& [r1] = s;
   if (&r1 != &s.x)
     __builtin_abort();
@@ -70,3 +88,4 @@ X test24() {
 // CHECK: define dso_local void @_Z6test24v
 // CHECK-NOT: lpad
 // CHECK-NOT: eh.resume
+

--- a/clang/test/AST/ByteCode/codegen-constexpr-unknown.cpp
+++ b/clang/test/AST/ByteCode/codegen-constexpr-unknown.cpp
@@ -3,9 +3,15 @@
 
 /// CodeGenFunction::ConstantFoldsToSimpleInteger() for the if condition
 /// needs to succeed and return true.
+/// When re-visiting p during that evaluation, we need to attach the local
+/// variable to the topmost scope, otherwise we will pick the call scope
+/// of to_address and de-allocate the local variable at the end of the
+/// to_address call.
+/// FIXME: This is not currently correct since we still mark p as
+/// constexpr-unknown and then reject it when comparing.
 extern void abort2();
-constexpr const int* to_address(const int *p) {
-  return p;
+constexpr const int* to_address(const int *a) {
+  return a;
 }
 void rightscope() {
   const int p = 0;


### PR DESCRIPTION
... if we don't have a block scope available. This can happen in `EvalEmitter` scenarios and can cause local variable blocks to be prematurely converted to dead blocks. Attach `ScopeKind::Block` variable to the root scope instead.