### PR TITLE
[lldb][windows] add a 50ms sleep when closing the ConPTY

### DIFF
--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -138,6 +138,10 @@ bool PseudoConsole::IsConnected() const {
 }
 
 void PseudoConsole::Close() {
+  Sleep(50); // FIXME: This mitigates a race condition when closing the
+             // PseudoConsole. It's possible that there is still data in the
+             // pipe when we try to close it. We should wait until the data has
+             // been consumed.
   SetStopping(true);
   std::unique_lock<std::mutex> guard(m_mutex);
   if (m_conpty_handle != INVALID_HANDLE_VALUE)


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/182302 was merged, `x86-64-gp-write.test` is flaky.

This patch reintroduces the 50ms sleep that was removed in https://github.com/llvm/llvm-project/pull/182302 to fix the flakyness while we investigate it.