### PR TITLE
[orc-rt] Rename ResourceManager detach/shutdown. NFCI.

### DIFF
--- a/orc-rt/include/orc-rt/ResourceManager.h
+++ b/orc-rt/include/orc-rt/ResourceManager.h
@@ -26,18 +26,18 @@ public:
 
   virtual ~ResourceManager();
 
-  /// The detach method will be called if the controller disconnects from the
+  /// The onDetach method will be called if the controller disconnects from the
   /// session without shutting the session down.
   ///
   /// Since no further requests for allocation will be made, the ResourceManager
   /// may discard any book-keeping data-structures used to support allocation.
   /// E.g. a JIT memory manager may discard its free-list, since no further
   /// JIT'd allocations will happen.
-  virtual void detach(OnCompleteFn OnComplete) = 0;
+  virtual void onDetach(OnCompleteFn OnComplete) = 0;
 
-  /// The shutdown operation will be called at the end of the session.
+  /// The onShutdown operation will be called at the end of the session.
   /// The ResourceManager should release all held resources.
-  virtual void shutdown(OnCompleteFn OnComplete) = 0;
+  virtual void onShutdown(OnCompleteFn OnComplete) = 0;
 };
 } // namespace orc_rt
 

--- a/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
+++ b/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
@@ -86,8 +86,8 @@ public:
   void deinitializeMultiple(OnDeinitializeCompleteFn &&OnComplete,
                             std::vector<void *> Bases);
 
-  void detach(ResourceManager::OnCompleteFn OnComplete) override;
-  void shutdown(ResourceManager::OnCompleteFn OnComplete) override;
+  void onDetach(ResourceManager::OnCompleteFn OnComplete) override;
+  void onShutdown(ResourceManager::OnCompleteFn OnComplete) override;
 
 private:
   struct SlabInfo {

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -94,7 +94,7 @@ void Session::shutdownNext(Error Err) {
   // Get the next ResourceManager to shut down.
   auto NextRM = std::move(SI->ResourceMgrs.back());
   SI->ResourceMgrs.pop_back();
-  NextRM->shutdown([this](Error Err) { shutdownNext(std::move(Err)); });
+  NextRM->onShutdown([this](Error Err) { shutdownNext(std::move(Err)); });
 }
 
 void Session::shutdownComplete() {

--- a/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
+++ b/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
@@ -222,13 +222,14 @@ void SimpleNativeMemoryMap::deinitializeMultiple(
                    Error::success());
 }
 
-void SimpleNativeMemoryMap::detach(ResourceManager::OnCompleteFn OnComplete) {
+void SimpleNativeMemoryMap::onDetach(ResourceManager::OnCompleteFn OnComplete) {
   // Detach is a noop for now: we just retain all actions to run at shutdown
   // time.
   OnComplete(Error::success());
 }
 
-void SimpleNativeMemoryMap::shutdown(ResourceManager::OnCompleteFn OnComplete) {
+void SimpleNativeMemoryMap::onShutdown(
+    ResourceManager::OnCompleteFn OnComplete) {
   // TODO: Establish a clear order to run deallocate actions across slabs,
   // object boundaries.
 

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -38,12 +38,12 @@ public:
       : DetachOpIdx(DetachOpIdx), ShutdownOpIdx(ShutdownOpIdx), OpIdx(OpIdx),
         GenResult(std::move(GenResult)) {}
 
-  void detach(OnCompleteFn OnComplete) override {
+  void onDetach(OnCompleteFn OnComplete) override {
     DetachOpIdx = OpIdx++;
     OnComplete(GenResult(Op::Detach));
   }
 
-  void shutdown(OnCompleteFn OnComplete) override {
+  void onShutdown(OnCompleteFn OnComplete) override {
     ShutdownOpIdx = OpIdx++;
     OnComplete(GenResult(Op::Shutdown));
   }

--- a/orc-rt/unittests/SimpleNativeMemoryMapTest.cpp
+++ b/orc-rt/unittests/SimpleNativeMemoryMapTest.cpp
@@ -289,7 +289,7 @@ TEST(SimpleNativeMemoryMap, ReserveInitializeShutdown) {
   EXPECT_EQ(SentinelValue, 0U);
 
   std::future<Error> ShutdownResult;
-  SNMM->shutdown(waitFor(ShutdownResult));
+  SNMM->onShutdown(waitFor(ShutdownResult));
   cantFail(ShutdownResult.get());
 
   EXPECT_EQ(SentinelValue, 42);
@@ -326,13 +326,13 @@ TEST(SimpleNativeMemoryMap, ReserveInitializeDetachShutdown) {
   EXPECT_EQ(SentinelValue, 0U);
 
   std::future<Error> DetachResult;
-  SNMM->detach(waitFor(DetachResult));
+  SNMM->onDetach(waitFor(DetachResult));
   cantFail(DetachResult.get());
 
   EXPECT_EQ(SentinelValue, 0);
 
   std::future<Error> ShutdownResult;
-  SNMM->shutdown(waitFor(ShutdownResult));
+  SNMM->onShutdown(waitFor(ShutdownResult));
   cantFail(ShutdownResult.get());
 
   EXPECT_EQ(SentinelValue, 42);


### PR DESCRIPTION
These methods are called by the session in the event of a detach or shutdown. The new names reflect their roles as event handlers.