### PR TITLE
[libclang] Fix clang_CXXMethod_isDeleted for functions

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -430,6 +430,7 @@ libclang
 - Visit constraints of `auto` type to properly visit concept usages (#GH166580)
 - Visit switch initializer statements (https://bugs.kde.org/show_bug.cgi?id=415537#c2)
 - Fix crash in clang_getBinaryOperatorKindSpelling and clang_getUnaryOperatorKindSpelling
+- Fix clang_CXXMethod_isDeleted() to also work on functions, not only methods.
 
 Code Completion
 ---------------

--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -4748,7 +4748,7 @@ CINDEX_LINKAGE unsigned clang_CXXField_isMutable(CXCursor C);
 CINDEX_LINKAGE unsigned clang_CXXMethod_isDefaulted(CXCursor C);
 
 /**
- * Determine if a C++ method is declared '= delete'.
+ * Determine if a function is declared '= delete'.
  */
 CINDEX_LINKAGE unsigned clang_CXXMethod_isDeleted(CXCursor C);
 

--- a/clang/test/Index/availability.cpp
+++ b/clang/test/Index/availability.cpp
@@ -7,7 +7,7 @@ struct Foo {
 
 
 // RUN: c-index-test -test-print-type --std=c++11 %s | FileCheck %s
-// CHECK: FunctionDecl=foo:1:6 (unavailable) [type=void ()] [typekind=FunctionProto] [resulttype=void] [resulttypekind=Void] [isPOD=0]
+// CHECK: FunctionDecl=foo:1:6 (unavailable) (deleted) [type=void ()] [typekind=FunctionProto] [resulttype=void] [resulttypekind=Void] [isPOD=0]
 // CHECK: StructDecl=Foo:3:8 (Definition) [type=Foo] [typekind=Record] [isPOD=1]
 // CHECK: CXXMethod=foo:4:7 (unavailable) (deleted) [type=int (){{.*}}] [typekind=FunctionProto] [resulttype=int] [resulttypekind=Int] [isPOD=0]
 // CHECK: CXXConstructor=Foo:5:3 (unavailable) (default constructor) (deleted) [type=void (){{.*}}] [typekind=FunctionProto] [resulttype=void] [resulttypekind=Void] [isPOD=0]

--- a/clang/test/Index/deletion.cpp
+++ b/clang/test/Index/deletion.cpp
@@ -5,6 +5,14 @@ struct Foo {
   Foo(int);
 };
 
+int foo(int);
+int foo(double) = delete;
+
+template <typename T>
+void processPointer(T* ptr);
+
+template <>
+void processPointer<void>(void* ptr) = delete;
 
 // RUN: c-index-test -test-print-type --std=c++11 %s | FileCheck %s
 // CHECK: StructDecl=Foo:1:8 (Definition) [type=Foo] [typekind=Record] [isPOD=1]
@@ -12,3 +20,11 @@ struct Foo {
 // CHECK: CXXMethod=bar:3:7 [type=int (){{.*}}] [typekind=FunctionProto] [resulttype=int] [resulttypekind=Int] [isPOD=0]
 // CHECK: CXXConstructor=Foo:4:3 (unavailable) (default constructor) (deleted) [type=void (){{.*}}] [typekind=FunctionProto] [resulttype=void] [resulttypekind=Void] [isPOD=0]
 // CHECK: CXXConstructor=Foo:5:3 (converting constructor) [type=void (int){{.*}}] [typekind=FunctionProto] [resulttype=void] [resulttypekind=Void] [args= [int] [Int]] [isPOD=0]
+
+// CHECK: FunctionDecl=foo:8:5 [type=int (int)] [typekind=FunctionProto] [resulttype=int] [resulttypekind=Int] [args= [int] [Int]] [isPOD=0] [isAnonRecDecl=0]
+// CHECK: ParmDecl=:8:12 (Definition) [type=int] [typekind=Int] [isPOD=1] [isAnonRecDecl=0]
+// CHECK: FunctionDecl=foo:9:5 (unavailable) (deleted) [type=int (double)] [typekind=FunctionProto] [resulttype=int] [resulttypekind=Int] [args= [double] [Double]] [isPOD=0] [isAnonRecDecl=0]
+// CHECK: ParmDecl=:9:15 (Definition) [type=double] [typekind=Double] [isPOD=1] [isAnonRecDecl=0]
+
+// CHECK: FunctionTemplate=processPointer:12:6 [type=void (T *)] [typekind=FunctionProto] [canonicaltype=void (type-parameter-0-0 *)] [canonicaltypekind=FunctionProto] [resulttype=void] [resulttypekind=Void] [isPOD=0] [isAnonRecDecl=0]
+// CHECK: FunctionDecl=processPointer:15:6 (unavailable) (deleted) [Specialization of processPointer:12:6] [Template arg 0: kind: 1, type: void] [type=void (void *)] [typekind=FunctionProto] [resulttype=void] [resulttypekind=Void] [args= [void *] [Pointer]] [isPOD=0] [isAnonRecDecl=0]

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -9553,9 +9553,8 @@ unsigned clang_CXXMethod_isDeleted(CXCursor C) {
     return 0;
 
   const Decl *D = cxcursor::getCursorDecl(C);
-  const CXXMethodDecl *Method =
-      D ? dyn_cast_if_present<CXXMethodDecl>(D->getAsFunction()) : nullptr;
-  return (Method && Method->isDeleted()) ? 1 : 0;
+  const FunctionDecl *Function = D ? D->getAsFunction() : nullptr;
+  return (Function && Function->isDeleted()) ? 1 : 0;
 }
 
 unsigned clang_CXXMethod_isStatic(CXCursor C) {


### PR DESCRIPTION
clang_CXXMethod_isDeleted() reported only for C++ methods. However, all functions can be deleted.