### PR TITLE
[InstSimplify] Implement `Cond ? V : V` -> `V` when no Refinment allowed

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -48,6 +48,7 @@
 #include "llvm/Support/KnownBits.h"
 #include "llvm/Support/KnownFPClass.h"
 #include <algorithm>
+#include <iterator>
 #include <optional>
 using namespace llvm;
 using namespace llvm::PatternMatch;
@@ -4395,6 +4396,50 @@ Value *llvm::simplifyFCmpInst(CmpPredicate Predicate, Value *LHS, Value *RHS,
   return ::simplifyFCmpInst(Predicate, LHS, RHS, FMF, Q, RecursionLimit);
 }
 
+// The value is only poison, if any of these values are poison.
+// It can be useful to decide if replacing a value with another would be
+// refining or introduce more poison.
+//
+// It is especially useful for select instructions. When it comes to selects and
+// impliesPoison, if select is the ValueAssumedToBePoison it is rare that it
+// yields true for any Value, that isn't a user of the select, due to the fact
+// that a select has more complex poison propagation than other instruction.
+static bool areTheseAllTheValuesThatMayCausePoisonInValue(
+    const SmallVector<const Value *, 2> ValuesAssumedPoison, const Value *V,
+    unsigned Depth) {
+  if (any_of(ValuesAssumedPoison, [V](const auto *P) { return P == V; }))
+    return true;
+
+  if (const Instruction *I = dyn_cast<Instruction>(V)) {
+    if (I->hasPoisonGeneratingAnnotations())
+      return false;
+
+    SmallVector<const Value *, 2> ValuesImplyingPoison;
+    copy_if(ValuesAssumedPoison, std::back_inserter(ValuesImplyingPoison),
+            [V](const auto *P) { return impliesPoison(P, V); });
+
+    if (ValuesImplyingPoison.empty())
+      return false;
+
+    const unsigned MaxDepth = 2;
+    if (Depth > MaxDepth)
+      return false;
+
+    return all_of(I->operand_values(),
+                  [&ValuesImplyingPoison, Depth](const auto *Op) {
+                    return areTheseAllTheValuesThatMayCausePoisonInValue(
+                        ValuesImplyingPoison, Op, Depth + 1);
+                  });
+  }
+  return false;
+}
+
+static bool areTheseAllTheValuesThatMayCausePoisonInValue(
+    const SmallVector<const Value *, 2> ValuesAssumedPoison, const Value *V) {
+  return areTheseAllTheValuesThatMayCausePoisonInValue(ValuesAssumedPoison, V,
+                                                       0);
+}
+
 static Value *simplifyWithOpsReplaced(Value *V,
                                       ArrayRef<std::pair<Value *, Value *>> Ops,
                                       const SimplifyQuery &Q,
@@ -4537,6 +4582,43 @@ static Value *simplifyWithOpsReplaced(Value *V,
       // This never returns poison, even if inbounds is set.
       if (NewOps.size() == 2 && match(NewOps[1], m_Zero()))
         return NewOps[0];
+    }
+
+    if (SelectInst *SI = dyn_cast<SelectInst>(I)) {
+      Value *SimplifiedValue = nullptr;
+      Value *Cond = SI->getCondition();
+
+      // The select couldn't act as a poison barrirer for its old operands and
+      // the new condition can't be more poisonus than the old one.
+      if (impliesPoison(NewOps[0], Cond) &&
+          impliesPoison(SI->getTrueValue(), Cond) &&
+          impliesPoison(SI->getFalseValue(), Cond)) {
+
+        // Cond ? V : V -> V
+        // We know that after replacement both of the operands will be the same.
+        // We have to make sure that no refinment happens. This is done by
+        // checking if the select condition can only be poison if any of the
+        // arms are poison. If the condition could be poison and neither of the
+        // arms would be poison, returning the less poisonus value would be a
+        // refinment.
+        if (NewOps[1] == NewOps[2] &&
+            areTheseAllTheValuesThatMayCausePoisonInValue(
+                {SI->getFalseValue(), SI->getTrueValue()}, Cond))
+          SimplifiedValue = NewOps[1];
+
+        // TODO: Implement more non refining select optimizations here!
+
+        // If we could do any simplification check if it has any poison
+        // generating flags and handle them.
+        if (SimplifiedValue) {
+          if (SI->hasPoisonGeneratingAnnotations()) {
+            if (!DropFlags)
+              return nullptr;
+            DropFlags->push_back(SI);
+          }
+          return SimplifiedValue;
+        }
+      }
     }
   } else {
     // The simplification queries below may return the original value. Consider:

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -4411,9 +4411,13 @@ static bool areTheseAllTheValuesThatMayCausePoisonInValue(
     return true;
 
   if (const Instruction *I = dyn_cast<Instruction>(V)) {
+    // Having a poison generating annotation means that it can be poison
+    // without any of the given values being poison.
     if (I->hasPoisonGeneratingAnnotations())
       return false;
 
+    // Filtering out the assumed poison values, so only the relevant ones are
+    // brought forward to the next recursive call.
     SmallVector<const Value *, 2> ValuesImplyingPoison;
     copy_if(ValuesAssumedPoison, std::back_inserter(ValuesImplyingPoison),
             [V](const auto *P) { return impliesPoison(P, V); });
@@ -4431,6 +4435,11 @@ static bool areTheseAllTheValuesThatMayCausePoisonInValue(
                         ValuesImplyingPoison, Op, Depth + 1);
                   });
   }
+
+  // A constant can't cause poison, unless it is itself a poison.
+  if (const Constant *C = dyn_cast<Constant>(V))
+    return !C->containsUndefOrPoisonElement();
+
   return false;
 }
 
@@ -4603,7 +4612,7 @@ static Value *simplifyWithOpsReplaced(Value *V,
         // refinment.
         if (NewOps[1] == NewOps[2] &&
             areTheseAllTheValuesThatMayCausePoisonInValue(
-                {SI->getFalseValue(), SI->getTrueValue()}, Cond))
+                {SI->getFalseValue(), SI->getTrueValue(), NewOps[1]}, Cond))
           SimplifiedValue = NewOps[1];
 
         // TODO: Implement more non refining select optimizations here!

--- a/llvm/test/Transforms/InstSimplify/select-icmp.ll
+++ b/llvm/test/Transforms/InstSimplify/select-icmp.ll
@@ -309,3 +309,98 @@ define <2 x ptr> @ptr_eq_replace_vector_constant(<2 x ptr> %a) {
   %sel = select <2 x i1> %cmp, <2 x ptr> %a, <2 x ptr> <ptr inttoptr (i64 42 to ptr), ptr inttoptr (i64 88 to ptr)>
   ret <2 x ptr> %sel
 }
+
+define i32 @selectICmpSelectInArmNotSimplifiedDueToMorePoison(i32 %1, i32 %2, i1 %scond) {
+; CHECK-LABEL: @selectICmpSelectInArmNotSimplifiedDueToMorePoison(
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[TMP0:%.*]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[TMP4:%.*]] = select i1 [[SCOND:%.*]], i32 [[TMP1]], i32 [[TMP0]]
+; CHECK-NEXT:    [[TMP5:%.*]] = select i1 [[TMP3]], i32 [[TMP0]], i32 [[TMP4]]
+; CHECK-NEXT:    ret i32 [[TMP5]]
+;
+  %4 = icmp eq i32 %1, %2
+  %5 = select i1 %scond, i32 %2, i32 %1
+  %6 = select i1 %4, i32 %1, i32 %5
+  ret i32 %6
+}
+
+define i32 @selectICmpSelectInArmSimplifiedDueToSameValues(i32 %1, i32 %2, i1 %scond) {
+; CHECK-LABEL: @selectICmpSelectInArmSimplifiedDueToSameValues(
+; CHECK-NEXT:    [[SAMEVALUES:%.*]] = icmp ule i32 [[TMP0:%.*]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[TMP6:%.*]] = select i1 [[SAMEVALUES]], i32 [[TMP1]], i32 [[TMP0]]
+; CHECK-NEXT:    ret i32 [[TMP6]]
+;
+  %4 = icmp eq i32 %1, %2
+  %sameValues = icmp ule i32 %1, %2
+  %5 = select i1 %sameValues, i32 %2, i32 %1
+  %6 = select i1 %4, i32 %1, i32 %5
+  ret i32 %6
+}
+
+define i32 @selectICmpSelectInArmSimplifiedNoPoisonFlagOnCondUseDefChain(i32 %1, i32 %2, i1 %scond) {
+; CHECK-LABEL: @selectICmpSelectInArmSimplifiedNoPoisonFlagOnCondUseDefChain(
+; CHECK-NEXT:    [[TMP4:%.*]] = icmp eq i32 [[TMP0:%.*]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[WITHPOISONFLAG:%.*]] = or i32 [[TMP0]], 42
+; CHECK-NEXT:    [[SAMEVALUES:%.*]] = icmp ule i32 [[WITHPOISONFLAG]], [[TMP1]]
+; CHECK-NEXT:    [[TMP3:%.*]] = select i1 [[SAMEVALUES]], i32 [[TMP1]], i32 [[TMP0]]
+; CHECK-NEXT:    [[TMP5:%.*]] = select i1 [[TMP4]], i32 [[TMP0]], i32 [[TMP3]]
+; CHECK-NEXT:    ret i32 [[TMP5]]
+;
+  %4 = icmp eq i32 %1, %2
+  %withPoisonFlag = or i32 %1, 42
+  %sameValues = icmp ule i32 %withPoisonFlag, %2
+  %5 = select i1 %sameValues, i32 %2, i32 %1
+  %6 = select i1 %4, i32 %1, i32 %5
+  ret i32 %6
+}
+
+define i32 @selectICmpSelectInArmNotSimplifiedPoisonFlagOnCondUseDefChain(i32 %1, i32 %2, i1 %scond) {
+; CHECK-LABEL: @selectICmpSelectInArmNotSimplifiedPoisonFlagOnCondUseDefChain(
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[TMP0:%.*]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[WITHPOISONFLAG:%.*]] = or disjoint i32 [[TMP0]], 42
+; CHECK-NEXT:    [[SAMEVALUES:%.*]] = icmp ule i32 [[WITHPOISONFLAG]], [[TMP1]]
+; CHECK-NEXT:    [[TMP4:%.*]] = select i1 [[SAMEVALUES]], i32 [[TMP1]], i32 [[TMP0]]
+; CHECK-NEXT:    [[TMP5:%.*]] = select i1 [[TMP3]], i32 [[TMP0]], i32 [[TMP4]]
+; CHECK-NEXT:    ret i32 [[TMP5]]
+;
+  %4 = icmp eq i32 %1, %2
+  %withPoisonFlag = or disjoint i32 %1, 42
+  %sameValues = icmp ule i32 %withPoisonFlag, %2
+  %5 = select i1 %sameValues, i32 %2, i32 %1
+  %6 = select i1 %4, i32 %1, i32 %5
+  ret i32 %6
+}
+
+define i32 @selectICmpSelectInArmNotSimplifiedSecondSelectPoisonBarrier(i32 %1, i32 %2, i1 %scond) {
+; CHECK-LABEL: @selectICmpSelectInArmNotSimplifiedSecondSelectPoisonBarrier(
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[TMP0:%.*]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[SAMEVALUES:%.*]] = icmp ule i32 [[TMP0]], [[TMP1]]
+; CHECK-NEXT:    [[OR:%.*]] = or i1 [[SAMEVALUES]], [[SCOND:%.*]]
+; CHECK-NEXT:    [[TMP4:%.*]] = select i1 [[OR]], i32 [[TMP1]], i32 [[TMP0]]
+; CHECK-NEXT:    [[TMP5:%.*]] = select i1 [[TMP3]], i32 [[TMP0]], i32 [[TMP4]]
+; CHECK-NEXT:    ret i32 [[TMP5]]
+;
+  %4 = icmp eq i32 %1, %2
+  %sameValues = icmp ule i32 %1, %2
+  %or = or i1 %sameValues, %scond
+  %5 = select i1 %or, i32 %2, i32 %1
+  %6 = select i1 %4, i32 %1, i32 %5
+  ret i32 %6
+}
+
+define i32 @selectICmpSelectInArmNotSimplifiedSecondSelectPoisonBarrierPoisonFlagInCond(i32 %1, i32 %2, i1 %scond) {
+; CHECK-LABEL: @selectICmpSelectInArmNotSimplifiedSecondSelectPoisonBarrierPoisonFlagInCond(
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[TMP0:%.*]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[SAMEVALUES:%.*]] = icmp ule i32 [[TMP0]], [[TMP1]]
+; CHECK-NEXT:    [[OR:%.*]] = or disjoint i1 [[SAMEVALUES]], [[SCOND:%.*]]
+; CHECK-NEXT:    [[TMP4:%.*]] = select i1 [[OR]], i32 [[TMP1]], i32 [[TMP0]]
+; CHECK-NEXT:    [[TMP5:%.*]] = select i1 [[TMP3]], i32 [[TMP0]], i32 [[TMP4]]
+; CHECK-NEXT:    ret i32 [[TMP5]]
+;
+  %4 = icmp eq i32 %1, %2
+  %sameValues = icmp ule i32 %1, %2
+  %or = or disjoint i1 %sameValues, %scond
+  %5 = select i1 %or, i32 %2, i32 %1
+  %6 = select i1 %4, i32 %1, i32 %5
+  ret i32 %6
+}
+

--- a/llvm/test/Transforms/InstSimplify/select-icmp.ll
+++ b/llvm/test/Transforms/InstSimplify/select-icmp.ll
@@ -338,11 +338,9 @@ define i32 @selectICmpSelectInArmSimplifiedDueToSameValues(i32 %1, i32 %2, i1 %s
 
 define i32 @selectICmpSelectInArmSimplifiedNoPoisonFlagOnCondUseDefChain(i32 %1, i32 %2, i1 %scond) {
 ; CHECK-LABEL: @selectICmpSelectInArmSimplifiedNoPoisonFlagOnCondUseDefChain(
-; CHECK-NEXT:    [[TMP4:%.*]] = icmp eq i32 [[TMP0:%.*]], [[TMP1:%.*]]
-; CHECK-NEXT:    [[WITHPOISONFLAG:%.*]] = or i32 [[TMP0]], 42
-; CHECK-NEXT:    [[SAMEVALUES:%.*]] = icmp ule i32 [[WITHPOISONFLAG]], [[TMP1]]
-; CHECK-NEXT:    [[TMP3:%.*]] = select i1 [[SAMEVALUES]], i32 [[TMP1]], i32 [[TMP0]]
-; CHECK-NEXT:    [[TMP5:%.*]] = select i1 [[TMP4]], i32 [[TMP0]], i32 [[TMP3]]
+; CHECK-NEXT:    [[WITHPOISONFLAG:%.*]] = or i32 [[TMP0:%.*]], 42
+; CHECK-NEXT:    [[SAMEVALUES:%.*]] = icmp ule i32 [[WITHPOISONFLAG]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[TMP5:%.*]] = select i1 [[SAMEVALUES]], i32 [[TMP1]], i32 [[TMP0]]
 ; CHECK-NEXT:    ret i32 [[TMP5]]
 ;
   %4 = icmp eq i32 %1, %2


### PR DESCRIPTION
Related to #179183 and #177410 .

I am not sure how profitable would this be. But I may be somewhat optimistic, since there is use for this in #177410 and optimizations can already improve code without the cases in #177410. See the tests.

When the select wasn't a poison barrier and returning an arm also isn't a refinment some optimizations can be done with selects in `simplifyWithOpsReplaced`.

The new recursive function was needed because `impliesPoison` can't really give any useful information, when a select is assumed poison and the right side of the implication isn't a user of that select. (Because of select poison semantics.) Also the behaviour of this recursive function could be added to `impliesPoison`, but then it would need extra parameters.

I have some test cases but I see that there is more to add. Alove2 for the current cases: https://alive2.llvm.org/ce/z/pKwffE

I am also open to any other ideas to address this issue.