### PR TITLE
[lldb] Fix partial Unicode handling in TrimAndPad

### DIFF
--- a/lldb/unittests/Utility/AnsiTerminalTest.cpp
+++ b/lldb/unittests/Utility/AnsiTerminalTest.cpp
@@ -116,6 +116,18 @@ TEST(AnsiTerminal, TrimAndPad) {
   EXPECT_EQ("    ❤️", ansi::TrimAndPad("    ❤️", 5));
   EXPECT_EQ("12❤️4❤️", ansi::TrimAndPad("12❤️4❤️", 5));
   EXPECT_EQ("12❤️45", ansi::TrimAndPad("12❤️45❤️", 5));
+
+  // This string previously triggered a bug in handling incomplete Unicode
+  // characters, when we had already accumulated some previous parts of the
+  // string.
+  const char *quick = "The \x1B[0mquick\x1B[0m 💨\x1B[0m";
+  EXPECT_EQ(ansi::TrimAndPad(quick, 0), "");
+  EXPECT_EQ(ansi::TrimAndPad(quick, 9), "The \x1B[0mquick\x1B[0m");
+  EXPECT_EQ(ansi::TrimAndPad(quick, 10), "The \x1B[0mquick\x1B[0m ");
+  // The emoji is 2 columns, so 11 is not quite enough.
+  EXPECT_EQ(ansi::TrimAndPad(quick, 11, '_'), "The \x1B[0mquick\x1B[0m _");
+  // 12 exactly enough to include the emoji and proceeding ANSI code.
+  EXPECT_EQ(ansi::TrimAndPad(quick, 12), quick);
 }
 
 static void TestLines(const std::string &input, int indent,


### PR DESCRIPTION
This fixes an issue I found while writing a variant of TrimAndPad for word wrapping purposes.

TrimAndPad relies on llvm::sys::locale::ColumnWidth returning an error value, when there is a partial uft8 character. This error code is ErrorInvalidUTF8, which is -2.

The idea was that when you cast that into a size_t, it was always going to be larger than our target visible width.

The check for this was:
result_visibile_length + column_width <= visible_length

Where result_visible_length and column_width are size_ts.

And the idea is correct, as long as result_visible_width is not large enough to cause the result to wrap to be lower than visible_length.

In other words: when we have accumulated some part of the string already, if we have to trim the next part, sometimes we would return an incomplete Unicode character. When we should instead carry on trimming.

To fix this, I've made TrimAndPad check explicitly for the error code. Only if it's not found, will it cast to do the second check.