### PR TITLE
[clang][TypePrinter][NFC] Extract logic that handles AnonymousTagNameStyle::SourceLocation into helper function

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -3774,6 +3774,9 @@ protected:
   void printAnonymousTagDecl(llvm::raw_ostream &OS,
                              const PrintingPolicy &Policy) const;
 
+  void printAnonymousTagDeclLocation(llvm::raw_ostream &OS,
+                                     const PrintingPolicy &Policy) const;
+
 public:
   friend class ASTDeclReader;
   friend class ASTDeclWriter;


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/168533 we're adding a new `AnonymousTagMode` and will be handled in `printAnonymousTagDecl`.

This patch extracts the logic that handles `AnonymousTagNameStyle::SourceLocation` into a helper function to make `printAnonymousTagDecl` easier to follow.

Drive-by changes:
* While copying the code into the helper I changed it to use early-return style.