### PR TITLE
AMDGPU: llvm.amdgcn.trig.preop cannot return negative values

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -5500,7 +5500,8 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
       break;
     }
     case Intrinsic::amdgcn_trig_preop: {
-      Known.knownNot(fcNan | fcInf);
+      // Always returns a value [0, 1)
+      Known.knownNot(fcNan | fcInf | fcNegative);
       break;
     }
     default:

--- a/llvm/test/Transforms/Attributor/AMDGPU/nofpclass-amdgcn-trig-preop.ll
+++ b/llvm/test/Transforms/Attributor/AMDGPU/nofpclass-amdgcn-trig-preop.ll
@@ -2,9 +2,9 @@
 ; RUN: opt -S -passes=attributor -attributor-manifest-internal < %s | FileCheck %s
 
 define double @ret_trig_preop_f64(double %x, i32 %n) {
-; CHECK-LABEL: define nofpclass(nan inf) double @ret_trig_preop_f64(
+; CHECK-LABEL: define nofpclass(nan inf nzero nsub nnorm) double @ret_trig_preop_f64(
 ; CHECK-SAME: double [[X:%.*]], i32 [[N:%.*]]) #[[ATTR0:[0-9]+]] {
-; CHECK-NEXT:    [[RET:%.*]] = call nofpclass(nan inf) double @llvm.amdgcn.trig.preop.f64(double [[X]], i32 [[N]]) #[[ATTR2:[0-9]+]]
+; CHECK-NEXT:    [[RET:%.*]] = call nofpclass(nan inf nzero nsub nnorm) double @llvm.amdgcn.trig.preop.f64(double [[X]], i32 [[N]]) #[[ATTR2:[0-9]+]]
 ; CHECK-NEXT:    ret double [[RET]]
 ;
   %ret = call double @llvm.amdgcn.trig.preop.f64(double %x, i32 %n)


### PR DESCRIPTION
This returns a positive value less than 1.