### PR TITLE
[mlir][Analysis] Print all blocks in `-test-liveness-analysis`

### DIFF
--- a/mlir/test/Analysis/DataFlow/test-liveness-analysis.mlir
+++ b/mlir/test/Analysis/DataFlow/test-liveness-analysis.mlir
@@ -193,6 +193,7 @@ func.func private @private0(%0 : i32) -> i32 {
 // CHECK-NEXT:  result #0: live
 // CHECK-NEXT:  result #1: not live
 // CHECK-NEXT:  region: #0:
+// CHECK-NEXT:  block: #0:
 // CHECK-NEXT:  argument: #0: live
 // CHECK-NEXT:  argument: #1: not live
 // CHECK-NEXT:  argument: #2: not live
@@ -320,7 +321,8 @@ func.func @dead_block() {
 
 // CHECK-LABEL: test_tag: for:
 // CHECK-NEXT: region: #0:
-// CHECK-NEXT:   argument: #0: live
+// CHECK-NEXT:   block: #0:
+// CHECK-NEXT:     argument: #0: live
 func.func @affine_loop_no_use_iv_has_side_effect_op() {
   %c1 = arith.constant 1 : index
   %alloc = memref.alloc() : memref<10xindex>
@@ -334,7 +336,8 @@ func.func @affine_loop_no_use_iv_has_side_effect_op() {
 
 // CHECK-LABEL: test_tag: for:
 // CHECK-NEXT: region: #0:
-// CHECK-NEXT:   argument: #0: not live
+// CHECK-NEXT:   block: #0:
+// CHECK-NEXT:     argument: #0: not live
 func.func @affine_loop_no_use_iv() {
   affine.for %arg0 = 0 to 79 {
   } {tag = "for"}
@@ -346,7 +349,8 @@ func.func @affine_loop_no_use_iv() {
 // CHECK-LABEL: test_tag: forall:
 // CHECK-NEXT: operand #0: live
 // CHECK-NEXT: region: #0:
-// CHECK-NEXT:   argument: #0: live
+// CHECK-NEXT:   block: #0:
+// CHECK-NEXT:     argument: #0: live
 
 func.func @forall_no_use_iv_has_side_effect_op(%idx1: index, %idx2: index) {
   scf.parallel (%i) = (%idx1) to (%idx2) step (%idx2) {
@@ -376,4 +380,23 @@ func.func @test_for_loop_read_only(%arg0: memref<10xindex>) {
     scf.yield %loaded : index
   } {tag = "for"}
   return
+}
+
+// -----
+
+// CHECK-LABEL:  test_tag: func:
+// CHECK-NEXT:   region: #0:
+// CHECK-NEXT:      block: #0:
+// CHECK-NEXT:       argument: #0: live
+// CHECK-NEXT:       argument: #1: not live
+// CHECK-NEXT:      block: #1:
+// CHECK-NEXT:       argument: #0: not live
+// CHECK-NEXT:      block: #2:
+// CHECK-NEXT:       argument: #0: live
+func.func @unstructured_cf(%val: f32, %c: i1) -> f32 attributes {tag = "func"} {
+  cf.br ^bb1(%val : f32)
+^bb0(%arg0: f32):
+  return %arg0: f32
+^bb1(%arg1: f32):
+  return %arg1: f32
 }

--- a/mlir/test/lib/Analysis/DataFlow/TestLivenessAnalysis.cpp
+++ b/mlir/test/lib/Analysis/DataFlow/TestLivenessAnalysis.cpp
@@ -58,13 +58,16 @@ struct TestLivenessAnalysisPass
       }
       for (auto [regionIndex, region] : llvm::enumerate(op->getRegions())) {
         os << " region: #" << regionIndex << ":\n";
-        for (auto [argumntIndex, argument] :
-             llvm::enumerate(region.getArguments())) {
-          const Liveness *liveness = livenessAnalysis.getLiveness(argument);
-          assert(liveness && "expected a sparse lattice");
-          os << "   argument: #" << argumntIndex << ": ";
-          liveness->print(os);
-          os << "\n";
+        for (auto [blockIndex, block] : llvm::enumerate(region)) {
+          os << "    block: #" << blockIndex << ":\n";
+          for (auto [argumentIndex, argument] :
+               llvm::enumerate(block.getArguments())) {
+            const Liveness *liveness = livenessAnalysis.getLiveness(argument);
+            assert(liveness && "expected a sparse lattice");
+            os << "     argument: #" << argumentIndex << ": ";
+            liveness->print(os);
+            os << "\n";
+          }
         }
       }
     });


### PR DESCRIPTION
Improve the output of the test pass: print liveness for block arguments from all blocks.