### PR TITLE
[LV] Adjust exit recipe detection to run on early vplan

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -471,10 +471,9 @@ unsigned vputils::getVFScaleFactor(VPRecipeBase *R) {
   return 1;
 }
 
-std::optional<VPValue *>
-vputils::getRecipesForUncountableExit(VPlan &Plan,
-                                      SmallVectorImpl<VPRecipeBase *> &Recipes,
-                                      SmallVectorImpl<VPRecipeBase *> &GEPs) {
+std::optional<VPValue *> vputils::getRecipesForUncountableExit(
+    VPlan &Plan, SmallVectorImpl<VPInstruction *> &Recipes,
+    SmallVectorImpl<VPInstruction *> &GEPs, VPBasicBlock *LatchVPBB) {
   // Given a VPlan like the following (just including the recipes contributing
   // to loop control exiting here, not the actual work), we're looking to match
   // the recipes contributing to the uncountable exit condition comparison
@@ -487,43 +486,49 @@ vputils::getRecipesForUncountableExit(VPlan &Plan,
   // and a live-in base address. This constraint may be relaxed later.
   //
   // VPlan ' for UF>=1' {
-  // Live-in vp<%0> = VF
-  // Live-in ir<64> = original trip-count
+  // Live-in vp<%0> = VF * UF
+  // Live-in vp<%1> = vector-trip-count
+  // Live-in ir<20> = original trip-count
   //
-  // entry:
-  // Successor(s): preheader, vector.ph
+  // ir-bb<entry>:
+  // Successor(s): scalar.ph, vector.ph
   //
   // vector.ph:
-  // Successor(s): vector loop
+  // Successor(s): for.body
   //
-  // <x1> vector loop: {
-  //   vector.body:
-  //     EMIT vp<%2> = CANONICAL-INDUCTION ir<0>
-  //     vp<%3> = SCALAR-STEPS vp<%2>, ir<1>, vp<%0>
-  //     CLONE ir<%ee.addr> = getelementptr ir<0>, vp<%3>
-  //     WIDEN ir<%ee.load> = load ir<%ee.addr>
-  //     WIDEN vp<%4> = icmp eq ir<%ee.load>, ir<0>
-  //     EMIT vp<%5> = any-of vp<%4>
-  //     EMIT vp<%6> = add vp<%2>, vp<%0>
-  //     EMIT vp<%7> = icmp eq vp<%6>, ir<64>
-  //     EMIT branch-on-two-conds vp<%5>, vp<%7>
-  //   No successors
-  // }
-  // Successor(s): early.exit, middle.block
+  // for.body:
+  //   EMIT vp<%2> = CANONICAL-INDUCTION ir<0>, vp<%index.next>
+  //   EMIT-SCALAR ir<%iv> = phi [ ir<0>, vector.ph ], [ ir<%iv.next>, for.inc ]
+  //   EMIT ir<%uncountable.addr> = getelementptr inbounds nuw ir<%pred>,ir<%iv>
+  //   EMIT ir<%uncountable.val> = load ir<%uncountable.addr>
+  //   EMIT ir<%uncountable.cond> = icmp sgt ir<%uncountable.val>, ir<500>
+  //   EMIT vp<%3> = masked-cond ir<%uncountable.cond>
+  // Successor(s): for.inc
+  //
+  // for.inc:
+  //   EMIT ir<%iv.next> = add nuw nsw ir<%iv>, ir<1>
+  //   EMIT ir<%countable.cond> = icmp eq ir<%iv.next>, ir<20>
+  //   EMIT vp<%index.next> = add nuw vp<%2>, vp<%0>
+  //   EMIT vp<%4> = any-of ir<%3>
+  //   EMIT vp<%5> = icmp eq vp<%index.next>, vp<%1>
+  //   EMIT vp<%6> = or vp<%4>, vp<%5>
+  //   EMIT branch-on-cond vp<%6>
+  // Successor(s): middle.block, for.body
   //
   // middle.block:
-  // Successor(s): preheader
+  // Successor(s): ir-bb<exit>, scalar.ph
   //
-  // preheader:
+  // ir-bb<exit>:
   // No successors
+  //
+  // scalar.ph:
   // }
 
   // Find the uncountable loop exit condition.
-  auto *Region = Plan.getVectorLoopRegion();
   VPValue *UncountableCondition = nullptr;
-  if (!match(Region->getExitingBasicBlock()->getTerminator(),
-             m_BranchOnTwoConds(m_AnyOf(m_VPValue(UncountableCondition)),
-                                m_VPValue())))
+  if (!match(LatchVPBB->getTerminator(),
+             m_BranchOnCond(m_c_BinaryOr(
+                 m_AnyOf(m_VPValue(UncountableCondition)), m_VPValue()))))
     return std::nullopt;
 
   SmallVector<VPValue *, 4> Worklist;
@@ -546,23 +551,31 @@ vputils::getRecipesForUncountableExit(VPlan &Plan,
     if (match(V, m_ICmp(m_VPValue(Op1), m_VPValue(Op2)))) {
       Worklist.push_back(Op1);
       Worklist.push_back(Op2);
-      Recipes.push_back(V->getDefiningRecipe());
-    } else if (auto *Load = dyn_cast<VPWidenLoadRecipe>(V)) {
-      // Reject masked loads for the time being; they make the exit condition
-      // more complex.
-      if (Load->isMasked())
+      Recipes.push_back(cast<VPInstruction>(V->getDefiningRecipe()));
+    } else if (match(V, m_VPInstruction<Instruction::Load>(m_VPValue(Op1)))) {
+      VPRecipeBase *GepR = Op1->getDefiningRecipe();
+      // Only matching base + single offset term for now.
+      if (GepR->getNumOperands() != 2)
         return std::nullopt;
-
-      VPValue *GEP = Load->getAddr();
-      if (!match(GEP, m_GetElementPtr(m_LiveIn(), m_VPValue())))
+      // Matching a GEP with a loop-invariant base ptr.
+      if (!match(GepR, m_VPInstruction<Instruction::GetElementPtr>(
+                           m_LiveIn(), m_VPValue())))
         return std::nullopt;
-
-      Recipes.push_back(Load);
-      Recipes.push_back(GEP->getDefiningRecipe());
-      GEPs.push_back(GEP->getDefiningRecipe());
+      Recipes.push_back(cast<VPInstruction>(V->getDefiningRecipe()));
+      Recipes.push_back(cast<VPInstruction>(GepR));
+      GEPs.push_back(cast<VPInstruction>(GepR));
+    } else if (match(V, m_VPInstruction<VPInstruction::MaskedCond>(
+                            m_VPValue(Op1)))) {
+      Worklist.push_back(Op1);
+      Recipes.push_back(cast<VPInstruction>(V->getDefiningRecipe()));
     } else
       return std::nullopt;
   }
+
+  // If we couldn't match anything, don't return the condition. It may be
+  // defined outside the loop.
+  if (Recipes.empty() || GEPs.empty())
+    return std::nullopt;
 
   return UncountableCondition;
 }

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -471,16 +471,17 @@ unsigned vputils::getVFScaleFactor(VPRecipeBase *R) {
   return 1;
 }
 
-std::optional<VPValue *> vputils::getRecipesForUncountableExit(
-    VPlan &Plan, SmallVectorImpl<VPInstruction *> &Recipes,
-    SmallVectorImpl<VPInstruction *> &GEPs, VPBasicBlock *LatchVPBB) {
-  // Given a VPlan like the following (just including the recipes contributing
-  // to loop control exiting here, not the actual work), we're looking to match
-  // the recipes contributing to the uncountable exit condition comparison
-  // (here, vp<%4>) back to either live-ins or the address nodes for the load
-  // used as part of the uncountable exit comparison so that we can copy them
-  // to a preheader and rotate the address in the loop to the next vector
-  // iteration.
+std::optional<VPValue *>
+vputils::getRecipesForUncountableExit(SmallVectorImpl<VPInstruction *> &Recipes,
+                                      SmallVectorImpl<VPInstruction *> &GEPs,
+                                      VPBasicBlock *LatchVPBB) {
+  /// Given a plain CFG VPlan loop with countable latch exiting block
+  /// \p LatchVPBB, we're looking to match the recipes contributing to the
+  /// uncountable exit condition comparison (here, vp<%4>) back to either
+  /// live-ins or the address nodes for the load used as part of the uncountable
+  /// exit comparison so that we can either move them within the loop, or copy
+  /// them to the preheader depending on the chosen method for dealing with
+  /// stores in uncountable exit loops.
   //
   // Currently, the address of the load is restricted to a GEP with 2 operands
   // and a live-in base address. This constraint may be relaxed later.

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -475,13 +475,13 @@ std::optional<VPValue *>
 vputils::getRecipesForUncountableExit(SmallVectorImpl<VPInstruction *> &Recipes,
                                       SmallVectorImpl<VPInstruction *> &GEPs,
                                       VPBasicBlock *LatchVPBB) {
-  /// Given a plain CFG VPlan loop with countable latch exiting block
-  /// \p LatchVPBB, we're looking to match the recipes contributing to the
-  /// uncountable exit condition comparison (here, vp<%4>) back to either
-  /// live-ins or the address nodes for the load used as part of the uncountable
-  /// exit comparison so that we can either move them within the loop, or copy
-  /// them to the preheader depending on the chosen method for dealing with
-  /// stores in uncountable exit loops.
+  // Given a plain CFG VPlan loop with countable latch exiting block
+  // \p LatchVPBB, we're looking to match the recipes contributing to the
+  // uncountable exit condition comparison (here, vp<%4>) back to either
+  // live-ins or the address nodes for the load used as part of the uncountable
+  // exit comparison so that we can either move them within the loop, or copy
+  // them to the preheader depending on the chosen method for dealing with
+  // stores in uncountable exit loops.
   //
   // Currently, the address of the load is restricted to a GEP with 2 operands
   // and a live-in base address. This constraint may be relaxed later.

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.h
@@ -79,10 +79,9 @@ unsigned getVFScaleFactor(VPRecipeBase *R);
 /// \p Recipes, and recipes forming an address for a load are also added to
 /// \p GEPs.
 LLVM_ABI_FOR_TEST
-std::optional<VPValue *>
-getRecipesForUncountableExit(VPlan &Plan,
-                             SmallVectorImpl<VPRecipeBase *> &Recipes,
-                             SmallVectorImpl<VPRecipeBase *> &GEPs);
+std::optional<VPValue *> getRecipesForUncountableExit(
+    VPlan &Plan, SmallVectorImpl<VPInstruction *> &Recipes,
+    SmallVectorImpl<VPInstruction *> &GEPs, VPBasicBlock *LatchVPBB);
 
 /// Return a MemoryLocation for \p R with noalias metadata populated from
 /// \p R, if the recipe is supported and std::nullopt otherwise. The pointer of

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.h
@@ -79,9 +79,10 @@ unsigned getVFScaleFactor(VPRecipeBase *R);
 /// \p Recipes, and recipes forming an address for a load are also added to
 /// \p GEPs.
 LLVM_ABI_FOR_TEST
-std::optional<VPValue *> getRecipesForUncountableExit(
-    VPlan &Plan, SmallVectorImpl<VPInstruction *> &Recipes,
-    SmallVectorImpl<VPInstruction *> &GEPs, VPBasicBlock *LatchVPBB);
+std::optional<VPValue *>
+getRecipesForUncountableExit(SmallVectorImpl<VPInstruction *> &Recipes,
+                             SmallVectorImpl<VPInstruction *> &GEPs,
+                             VPBasicBlock *LatchVPBB);
 
 /// Return a MemoryLocation for \p R with noalias metadata populated from
 /// \p R, if the recipe is supported and std::nullopt otherwise. The pointer of

--- a/llvm/unittests/Transforms/Vectorize/VPlanTestBase.h
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTestBase.h
@@ -101,6 +101,17 @@ protected:
     VPlanTransforms::createLoopRegions(*Plan);
     return Plan;
   }
+
+  VPlanPtr buildVPlan0(BasicBlock *LoopHeader) {
+    Function &F = *LoopHeader->getParent();
+    assert(!verifyFunction(F) && "input function must be valid");
+    doAnalysis(F);
+
+    Loop *L = LI->getLoopFor(LoopHeader);
+    PredicatedScalarEvolution PSE(*SE, *L);
+    return VPlanTransforms::buildVPlan0(L, *LI, IntegerType::get(*Ctx, 64), {},
+                                        PSE);
+  }
 };
 
 class VPlanTestBase : public testing::Test {

--- a/llvm/unittests/Transforms/Vectorize/VPlanUncountableExitTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanUncountableExitTest.cpp
@@ -7,7 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "../lib/Transforms/Vectorize/VPRecipeBuilder.h"
 #include "../lib/Transforms/Vectorize/VPlan.h"
+#include "../lib/Transforms/Vectorize/VPlanPatternMatch.h"
 #include "../lib/Transforms/Vectorize/VPlanUtils.h"
 #include "VPlanTestBase.h"
 #include "llvm/ADT/SmallVector.h"
@@ -17,6 +19,91 @@ namespace llvm {
 
 namespace {
 class VPUncountableExitTest : public VPlanTestIRBase {};
+using namespace VPlanPatternMatch;
+
+// TODO: This performs part of VPlanTransforms::handleUncountableEarlyExits,
+//       perhaps we could share the code...
+static void combineExitConditions(VPlan &Plan) {
+  struct EarlyExitInfo {
+    VPBasicBlock *EarlyExitingVPBB;
+    VPIRBasicBlock *EarlyExitVPBB;
+    VPValue *CondToExit;
+  };
+
+  auto *MiddleVPBB = cast<VPBasicBlock>(
+      Plan.getScalarHeader()->getSinglePredecessor()->getPredecessors()[0]);
+  auto *LatchVPBB = cast<VPBasicBlock>(MiddleVPBB->getSinglePredecessor());
+
+  VPDominatorTree VPDT(Plan);
+  VPBuilder Builder(LatchVPBB->getTerminator());
+  SmallVector<EarlyExitInfo> Exits;
+  for (VPIRBasicBlock *ExitBlock : Plan.getExitBlocks()) {
+    for (VPBlockBase *Pred : to_vector(ExitBlock->getPredecessors())) {
+      if (Pred == MiddleVPBB)
+        continue;
+      // Collect condition for this early exit.
+      auto *EarlyExitingVPBB = cast<VPBasicBlock>(Pred);
+      VPBlockBase *TrueSucc = EarlyExitingVPBB->getSuccessors()[0];
+      VPValue *CondOfEarlyExitingVPBB;
+      [[maybe_unused]] bool Matched =
+          match(EarlyExitingVPBB->getTerminator(),
+                m_BranchOnCond(m_VPValue(CondOfEarlyExitingVPBB)));
+      assert(Matched && "Terminator must be BranchOnCond");
+      VPBuilder EarlyExitingBuilder(EarlyExitingVPBB->getTerminator());
+      auto *CondToEarlyExit = EarlyExitingBuilder.createNaryOp(
+          VPInstruction::MaskedCond,
+          TrueSucc == ExitBlock
+              ? CondOfEarlyExitingVPBB
+              : EarlyExitingBuilder.createNot(CondOfEarlyExitingVPBB));
+      assert((isa<VPIRValue>(CondOfEarlyExitingVPBB) ||
+              !VPDT.properlyDominates(EarlyExitingVPBB, LatchVPBB) ||
+              VPDT.properlyDominates(
+                  CondOfEarlyExitingVPBB->getDefiningRecipe()->getParent(),
+                  LatchVPBB)) &&
+             "exit condition must dominate the latch");
+      Exits.push_back({
+          EarlyExitingVPBB,
+          ExitBlock,
+          CondToEarlyExit,
+      });
+    }
+  }
+
+  // For the negative test case.
+  if (Exits.empty())
+    return;
+
+  // Build the AnyOf condition for the latch terminator using logical OR
+  // to avoid poison propagation from later exit conditions when an earlier
+  // exit is taken.
+  VPValue *Combined = Exits[0].CondToExit;
+  for (const EarlyExitInfo &Info : drop_begin(Exits))
+    Combined = Builder.createLogicalOr(Combined, Info.CondToExit);
+
+  VPValue *IsAnyExitTaken =
+      Builder.createNaryOp(VPInstruction::AnyOf, {Combined});
+
+  auto *LatchExitingBranch = cast<VPInstruction>(LatchVPBB->getTerminator());
+  assert(LatchExitingBranch->getOpcode() == VPInstruction::BranchOnCount &&
+         "Unexpected terminator");
+  auto *IsLatchExitTaken =
+      Builder.createICmp(CmpInst::ICMP_EQ, LatchExitingBranch->getOperand(0),
+                         LatchExitingBranch->getOperand(1));
+  LatchExitingBranch->eraseFromParent();
+  Builder.setInsertPoint(LatchVPBB);
+  VPValue *CombineAllExits = Builder.createOr(IsAnyExitTaken, IsLatchExitTaken);
+  Builder.createNaryOp(VPInstruction::BranchOnCond, {CombineAllExits});
+
+  // Disconnect early exiting blocks from successors, remove branches. We
+  // currently don't support multiple uses for recipes involved in creating
+  // the uncountable exit condition.
+  for (auto &Exit : Exits) {
+    if (Exit.EarlyExitingVPBB == LatchVPBB)
+      continue;
+    Exit.EarlyExitingVPBB->getTerminator()->eraseFromParent();
+    VPBlockUtils::disconnectBlocks(Exit.EarlyExitingVPBB, Exit.EarlyExitVPBB);
+  }
+}
 
 TEST_F(VPUncountableExitTest, FindUncountableExitRecipes) {
   const char *ModuleString =
@@ -53,18 +140,21 @@ TEST_F(VPUncountableExitTest, FindUncountableExitRecipes) {
 
   Function *F = M.getFunction("f");
   BasicBlock *LoopHeader = F->getEntryBlock().getSingleSuccessor();
-  auto Plan = buildVPlan(LoopHeader, UncountableExitStyle::ReadOnly);
-  VPlanTransforms::tryToConvertVPInstructionsToVPRecipes(*Plan, *TLI);
-  VPlanTransforms::optimize(*Plan);
+  VPlanPtr Plan = buildVPlan0(LoopHeader);
+  combineExitConditions(*Plan);
 
-  SmallVector<VPRecipeBase *> Recipes;
-  SmallVector<VPRecipeBase *> GEPs;
+  SmallVector<VPInstruction *> Recipes;
+  SmallVector<VPInstruction *> GEPs;
+
+  auto *MiddleVPBB = cast<VPBasicBlock>(
+      Plan->getScalarHeader()->getSinglePredecessor()->getPredecessors()[0]);
+  auto *LatchVPBB = cast<VPBasicBlock>(MiddleVPBB->getSinglePredecessor());
 
   std::optional<VPValue *> UncountableCondition =
-      vputils::getRecipesForUncountableExit(*Plan, Recipes, GEPs);
+      vputils::getRecipesForUncountableExit(*Plan, Recipes, GEPs, LatchVPBB);
   ASSERT_TRUE(UncountableCondition.has_value());
   ASSERT_EQ(GEPs.size(), 1ull);
-  ASSERT_EQ(Recipes.size(), 3ull);
+  ASSERT_EQ(Recipes.size(), 4ull);
 }
 
 TEST_F(VPUncountableExitTest, NoUncountableExit) {
@@ -89,15 +179,18 @@ TEST_F(VPUncountableExitTest, NoUncountableExit) {
 
   Function *F = M.getFunction("f");
   BasicBlock *LoopHeader = F->getEntryBlock().getSingleSuccessor();
-  auto Plan = buildVPlan(LoopHeader);
-  VPlanTransforms::tryToConvertVPInstructionsToVPRecipes(*Plan, *TLI);
-  VPlanTransforms::optimize(*Plan);
+  auto Plan = buildVPlan0(LoopHeader);
+  combineExitConditions(*Plan);
 
-  SmallVector<VPRecipeBase *> Recipes;
-  SmallVector<VPRecipeBase *> GEPs;
+  SmallVector<VPInstruction *> Recipes;
+  SmallVector<VPInstruction *> GEPs;
+
+  auto *MiddleVPBB = cast<VPBasicBlock>(
+      Plan->getScalarHeader()->getSinglePredecessor()->getPredecessors()[0]);
+  auto *LatchVPBB = cast<VPBasicBlock>(MiddleVPBB->getSinglePredecessor());
 
   std::optional<VPValue *> UncountableCondition =
-      vputils::getRecipesForUncountableExit(*Plan, Recipes, GEPs);
+      vputils::getRecipesForUncountableExit(*Plan, Recipes, GEPs, LatchVPBB);
   ASSERT_FALSE(UncountableCondition.has_value());
   ASSERT_EQ(GEPs.size(), 0ull);
   ASSERT_EQ(Recipes.size(), 0ull);

--- a/llvm/unittests/Transforms/Vectorize/VPlanUncountableExitTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanUncountableExitTest.cpp
@@ -151,7 +151,7 @@ TEST_F(VPUncountableExitTest, FindUncountableExitRecipes) {
   auto *LatchVPBB = cast<VPBasicBlock>(MiddleVPBB->getSinglePredecessor());
 
   std::optional<VPValue *> UncountableCondition =
-      vputils::getRecipesForUncountableExit(*Plan, Recipes, GEPs, LatchVPBB);
+      vputils::getRecipesForUncountableExit(Recipes, GEPs, LatchVPBB);
   ASSERT_TRUE(UncountableCondition.has_value());
   ASSERT_EQ(GEPs.size(), 1ull);
   ASSERT_EQ(Recipes.size(), 4ull);
@@ -190,7 +190,7 @@ TEST_F(VPUncountableExitTest, NoUncountableExit) {
   auto *LatchVPBB = cast<VPBasicBlock>(MiddleVPBB->getSinglePredecessor());
 
   std::optional<VPValue *> UncountableCondition =
-      vputils::getRecipesForUncountableExit(*Plan, Recipes, GEPs, LatchVPBB);
+      vputils::getRecipesForUncountableExit(Recipes, GEPs, LatchVPBB);
   ASSERT_FALSE(UncountableCondition.has_value());
   ASSERT_EQ(GEPs.size(), 0ull);
   ASSERT_EQ(Recipes.size(), 0ull);

--- a/llvm/unittests/Transforms/Vectorize/VPlanUncountableExitTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanUncountableExitTest.cpp
@@ -21,8 +21,6 @@ namespace {
 class VPUncountableExitTest : public VPlanTestIRBase {};
 using namespace VPlanPatternMatch;
 
-// TODO: This performs part of VPlanTransforms::handleUncountableEarlyExits,
-//       perhaps we could share the code...
 static void combineExitConditions(VPlan &Plan) {
   struct EarlyExitInfo {
     VPBasicBlock *EarlyExitingVPBB;
@@ -34,75 +32,46 @@ static void combineExitConditions(VPlan &Plan) {
       Plan.getScalarHeader()->getSinglePredecessor()->getPredecessors()[0]);
   auto *LatchVPBB = cast<VPBasicBlock>(MiddleVPBB->getSinglePredecessor());
 
-  VPDominatorTree VPDT(Plan);
-  VPBuilder Builder(LatchVPBB->getTerminator());
-  SmallVector<EarlyExitInfo> Exits;
+  // Find the single early exit: a non-middle predecessor of an exit block.
+  VPBasicBlock *EarlyExitingVPBB = nullptr;
+  VPIRBasicBlock *EarlyExitVPBB = nullptr;
   for (VPIRBasicBlock *ExitBlock : Plan.getExitBlocks()) {
-    for (VPBlockBase *Pred : to_vector(ExitBlock->getPredecessors())) {
-      if (Pred == MiddleVPBB)
-        continue;
-      // Collect condition for this early exit.
-      auto *EarlyExitingVPBB = cast<VPBasicBlock>(Pred);
-      VPBlockBase *TrueSucc = EarlyExitingVPBB->getSuccessors()[0];
-      VPValue *CondOfEarlyExitingVPBB;
-      [[maybe_unused]] bool Matched =
-          match(EarlyExitingVPBB->getTerminator(),
-                m_BranchOnCond(m_VPValue(CondOfEarlyExitingVPBB)));
-      assert(Matched && "Terminator must be BranchOnCond");
-      VPBuilder EarlyExitingBuilder(EarlyExitingVPBB->getTerminator());
-      auto *CondToEarlyExit = EarlyExitingBuilder.createNaryOp(
-          VPInstruction::MaskedCond,
-          TrueSucc == ExitBlock
-              ? CondOfEarlyExitingVPBB
-              : EarlyExitingBuilder.createNot(CondOfEarlyExitingVPBB));
-      assert((isa<VPIRValue>(CondOfEarlyExitingVPBB) ||
-              !VPDT.properlyDominates(EarlyExitingVPBB, LatchVPBB) ||
-              VPDT.properlyDominates(
-                  CondOfEarlyExitingVPBB->getDefiningRecipe()->getParent(),
-                  LatchVPBB)) &&
-             "exit condition must dominate the latch");
-      Exits.push_back({
-          EarlyExitingVPBB,
-          ExitBlock,
-          CondToEarlyExit,
-      });
+    for (VPBlockBase *Pred : ExitBlock->getPredecessors()) {
+      if (Pred != MiddleVPBB) {
+        EarlyExitingVPBB = cast<VPBasicBlock>(Pred);
+        EarlyExitVPBB = ExitBlock;
+      }
     }
   }
-
-  // For the negative test case.
-  if (Exits.empty())
+  if (!EarlyExitingVPBB)
     return;
 
-  // Build the AnyOf condition for the latch terminator using logical OR
-  // to avoid poison propagation from later exit conditions when an earlier
-  // exit is taken.
-  VPValue *Combined = Exits[0].CondToExit;
-  for (const EarlyExitInfo &Info : drop_begin(Exits))
-    Combined = Builder.createLogicalOr(Combined, Info.CondToExit);
+  // Wrap the early exit condition in a MaskedCond.
+  VPValue *Cond;
+  [[maybe_unused]] bool Matched =
+      match(EarlyExitingVPBB->getTerminator(), m_BranchOnCond(m_VPValue(Cond)));
+  assert(Matched && "Terminator must be BranchOnCond");
+  VPBuilder EarlyExitBuilder(EarlyExitingVPBB->getTerminator());
+  if (EarlyExitingVPBB->getSuccessors()[0] != EarlyExitVPBB)
+    Cond = EarlyExitBuilder.createNot(Cond);
+  auto *MaskedCond =
+      EarlyExitBuilder.createNaryOp(VPInstruction::MaskedCond, {Cond});
 
-  VPValue *IsAnyExitTaken =
-      Builder.createNaryOp(VPInstruction::AnyOf, {Combined});
-
-  auto *LatchExitingBranch = cast<VPInstruction>(LatchVPBB->getTerminator());
-  assert(LatchExitingBranch->getOpcode() == VPInstruction::BranchOnCount &&
-         "Unexpected terminator");
-  auto *IsLatchExitTaken =
-      Builder.createICmp(CmpInst::ICMP_EQ, LatchExitingBranch->getOperand(0),
-                         LatchExitingBranch->getOperand(1));
-  LatchExitingBranch->eraseFromParent();
+  // Combine the early exit with the latch exit on the latch terminator.
+  VPBuilder Builder(LatchVPBB->getTerminator());
+  auto *IsAnyExitTaken =
+      Builder.createNaryOp(VPInstruction::AnyOf, {MaskedCond});
+  auto *LatchBranch = cast<VPInstruction>(LatchVPBB->getTerminator());
+  auto *IsLatchExitTaken = Builder.createICmp(
+      CmpInst::ICMP_EQ, LatchBranch->getOperand(0), LatchBranch->getOperand(1));
+  LatchBranch->eraseFromParent();
   Builder.setInsertPoint(LatchVPBB);
-  VPValue *CombineAllExits = Builder.createOr(IsAnyExitTaken, IsLatchExitTaken);
-  Builder.createNaryOp(VPInstruction::BranchOnCond, {CombineAllExits});
+  Builder.createNaryOp(VPInstruction::BranchOnCond,
+                       {Builder.createOr(IsAnyExitTaken, IsLatchExitTaken)});
 
-  // Disconnect early exiting blocks from successors, remove branches. We
-  // currently don't support multiple uses for recipes involved in creating
-  // the uncountable exit condition.
-  for (auto &Exit : Exits) {
-    if (Exit.EarlyExitingVPBB == LatchVPBB)
-      continue;
-    Exit.EarlyExitingVPBB->getTerminator()->eraseFromParent();
-    VPBlockUtils::disconnectBlocks(Exit.EarlyExitingVPBB, Exit.EarlyExitVPBB);
-  }
+  // Disconnect the early exit edge.
+  EarlyExitingVPBB->getTerminator()->eraseFromParent();
+  VPBlockUtils::disconnectBlocks(EarlyExitingVPBB, EarlyExitVPBB);
 }
 
 TEST_F(VPUncountableExitTest, FindUncountableExitRecipes) {
@@ -120,9 +89,7 @@ TEST_F(VPUncountableExitTest, FindUncountableExitRecipes) {
       "  %st.addr = getelementptr inbounds i16, ptr %array, i64 %iv\n"
       "  %data = load i16, ptr %st.addr, align 2\n"
       "  %inc = add nsw i16 %data, 1\n"
-      // TODO: Uncomment store once more support is added for uncountable exits
-      //       in loops with stores.
-      // "  store i16 %inc, ptr %st.addr, align 2\n"
+      "  store i16 %inc, ptr %st.addr, align 2\n"
       "  %uncountable.addr = getelementptr inbounds nuw i16, ptr %pred, i64 "
       "%iv\n"
       "  %uncountable.val = load i16, ptr %uncountable.addr, align 2\n"

--- a/llvm/unittests/Transforms/Vectorize/VPlanUncountableExitTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanUncountableExitTest.cpp
@@ -43,8 +43,7 @@ static void combineExitConditions(VPlan &Plan) {
       }
     }
   }
-  if (!EarlyExitingVPBB)
-    return;
+  assert(EarlyExitingVPBB && "must have an early exit");
 
   // Wrap the early exit condition in a MaskedCond.
   VPValue *Cond;
@@ -147,7 +146,6 @@ TEST_F(VPUncountableExitTest, NoUncountableExit) {
   Function *F = M.getFunction("f");
   BasicBlock *LoopHeader = F->getEntryBlock().getSingleSuccessor();
   auto Plan = buildVPlan0(LoopHeader);
-  combineExitConditions(*Plan);
 
   SmallVector<VPInstruction *> Recipes;
   SmallVector<VPInstruction *> GEPs;


### PR DESCRIPTION
Splitting out some work from #178454; this covers the enums for
early exit loop type (none, readonly, readwrite) and the style
used (readonly with multiple exit blocks, or masking with the
last iteration done in scalar code), along with changing the early
exit recipe detection to suit moving the transform for handling
early exit readwrite loops earlier in the vplan pipeline.
