### PR TITLE
[SPIRV] Fix disabling of default extensions

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
@@ -28,6 +28,8 @@
 
 using namespace llvm;
 
+std::set<SPIRV::Extension::Extension> SPIRVExtensionsParser::DisabledExtensions;
+
 static const std::map<StringRef, SPIRV::Extension::Extension>
     SPIRVExtensionMap = {
         {"SPV_EXT_shader_atomic_float_add",
@@ -231,7 +233,7 @@ bool SPIRVExtensionsParser::parse(cl::Option &O, StringRef ArgName,
       return O.error(
           "Extension cannot be allowed and disallowed at the same time: " +
           NameValuePair->first);
-
+    DisabledExtensions.insert(NameValuePair->second);
     Vals.erase(NameValuePair->second);
   }
 
@@ -270,7 +272,8 @@ SPIRVExtensionsParser::getValidExtensions(const Triple &TT) {
         SPIRV::OperandCategory::OperandCategory::ExtensionOperand,
         ExtensionEnum);
 
-    if (llvm::is_contained(AllowedEnv, CurrentEnvironment))
+    if (llvm::is_contained(AllowedEnv, CurrentEnvironment) &&
+        !llvm::is_contained(DisabledExtensions, ExtensionEnum))
       R.insert(ExtensionEnum);
   }
 

--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.h
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.h
@@ -48,6 +48,9 @@ public:
   /// target environment (i.e., OpenCL or Vulkan).
   static std::set<SPIRV::Extension::Extension>
   getValidExtensions(const Triple &TT);
+
+private:
+  static std::set<SPIRV::Extension::Extension> DisabledExtensions;
 };
 
 } // namespace llvm

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_EXT_relaxed_printf_string_address_space/non-constant-printf.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_EXT_relaxed_printf_string_address_space/non-constant-printf.ll
@@ -1,6 +1,9 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown --spirv-ext=+SPV_EXT_relaxed_printf_string_address_space %s -o - | FileCheck %s
 ; RUN: llc -O0 -mtriple=spirv32-intel-unknown %s -o - | FileCheck %s
 ; RUN: not llc -O0 -mtriple=spirv32-unknown-unknown %s -o %t.spvt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: not llc -O0 -mtriple=spirv32-intel-unknown --spirv-ext=-SPV_EXT_relaxed_printf_string_address_space %s -o %t.spvt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: not llc -O0 -mtriple=spirv32-intel-unknown --spirv-ext=all,-SPV_EXT_relaxed_printf_string_address_space %s -o %t.spvt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: not llc -O0 -mtriple=spirv32-intel-unknown --spirv-ext=-SPV_EXT_relaxed_printf_string_address_space,all %s -o %t.spvt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
 ; CHECK: OpExtension "SPV_EXT_relaxed_printf_string_address_space"
 ; CHECK: %[[#ExtInstSetId:]] = OpExtInstImport "OpenCL.std"


### PR DESCRIPTION
If you pass `-ExtName` to the `--spirv-ext` command line option. that should disable the extension. However some vendors have some extensions enabled by default when using a triple with that vendor, and disabling an extension with the option did not effect the default extensions.

This PR makes it so disabling an extension with the  `--spirv-ext` option actually disables the extension.

The problem was we only considered the disabled extension when parsing the arguments for `--spirv-ext`, but the default extensions are added separately, so we need to store the disabled extensions and factor them in when computing the final extension set to use.