### PR TITLE
[InstCombine] Combine extract from get_active_lane_mask where all lanes inactive

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3910,12 +3910,12 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         return replaceOperand(CI, 0, InsertTuple);
     }
 
-    ConstantInt *ALMIdx;
+    ConstantInt *ALMUpperBound;
     if (match(Vec, m_Intrinsic<Intrinsic::get_active_lane_mask>(
-                       m_Zero(), m_ConstantInt(ALMIdx)))) {
+                       m_Value(), m_ConstantInt(ALMUpperBound)))) {
       const auto &Attrs = II->getFunction()->getAttributes().getFnAttrs();
       unsigned VScaleMin = Attrs.getVScaleRangeMin();
-      if (ExtractIdx * VScaleMin >= ALMIdx->getZExtValue())
+      if (ExtractIdx * VScaleMin >= ALMUpperBound->getZExtValue())
         return replaceInstUsesWith(CI,
                                    ConstantVector::getNullValue(ReturnType));
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3910,6 +3910,17 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         return replaceOperand(CI, 0, InsertTuple);
     }
 
+    ConstantInt *ALMIdx;
+    if (match(Vec, m_Intrinsic<Intrinsic::get_active_lane_mask>(
+                       m_Zero(), m_ConstantInt(ALMIdx)))) {
+      const auto &Attrs = II->getFunction()->getAttributes().getFnAttrs();
+      unsigned VScaleMin = Attrs.getVScaleRangeMin();
+      if (!ALMIdx->isNegative() &&
+          ExtractIdx * VScaleMin >= ALMIdx->getZExtValue())
+        return replaceInstUsesWith(CI,
+                                   ConstantVector::getNullValue(ReturnType));
+    }
+
     auto *DstTy = dyn_cast<VectorType>(ReturnType);
     auto *VecTy = dyn_cast<VectorType>(Vec->getType());
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3915,8 +3915,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
                        m_Zero(), m_ConstantInt(ALMIdx)))) {
       const auto &Attrs = II->getFunction()->getAttributes().getFnAttrs();
       unsigned VScaleMin = Attrs.getVScaleRangeMin();
-      if (!ALMIdx->isNegative() &&
-          ExtractIdx * VScaleMin >= ALMIdx->getZExtValue())
+      if (ExtractIdx * VScaleMin >= ALMIdx->getZExtValue())
         return replaceInstUsesWith(CI,
                                    ConstantVector::getNullValue(ReturnType));
     }

--- a/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
+++ b/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
@@ -46,7 +46,7 @@ define <4 x i1> @remove_all_false_subvector() {
   ret <4 x i1> %ext
 }
 
-define <vscale x 4 x i1> @remove_all_false_subvector_vscale() #0 {
+define <vscale x 4 x i1> @remove_all_false_subvector_vscale() vscale_range(2,16) {
 ; CHECK-LABEL: define <vscale x 4 x i1> @remove_all_false_subvector_vscale(
 ; CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:    ret <vscale x 4 x i1> zeroinitializer
@@ -76,5 +76,3 @@ define <4 x i1> @ext_has_active_lanes() {
   %ext = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 4)
   ret <4 x i1> %ext
 }
-
-attributes #0 = { vscale_range(2,16) }

--- a/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
+++ b/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
@@ -40,14 +40,14 @@ define <vscale x 4 x i1> @bail_lhs_is_zero() {
 define void @remove_all_false_subvector(<4 x i32> %val, ptr %a, ptr %b, ptr %c, ptr %d) {
 ; CHECK-LABEL: define void @remove_all_false_subvector(
 ; CHECK-SAME: <4 x i32> [[VAL:%.*]], ptr [[A:%.*]], ptr [[B:%.*]], ptr [[C:%.*]], ptr [[D:%.*]]) {
-; CHECK-NEXT:    [[WIDE_ALM:%.*]] = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 7)
+; CHECK-NEXT:    [[WIDE_ALM:%.*]] = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i32(i32 0, i32 7)
 ; CHECK-NEXT:    [[EXT1:%.*]] = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> [[WIDE_ALM]], i64 0)
 ; CHECK-NEXT:    [[EXT2:%.*]] = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> [[WIDE_ALM]], i64 4)
 ; CHECK-NEXT:    tail call void @llvm.masked.store.v4i32.p0(<4 x i32> [[VAL]], ptr [[A]], <4 x i1> [[EXT1]])
 ; CHECK-NEXT:    tail call void @llvm.masked.store.v4i32.p0(<4 x i32> [[VAL]], ptr [[B]], <4 x i1> [[EXT2]])
 ; CHECK-NEXT:    ret void
 ;
-  %wide.alm = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 7)
+  %wide.alm = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i32 0, i32 7)
   %ext1 = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 0)
   %ext2 = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 4)
   %ext3 = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 8)
@@ -90,24 +90,6 @@ define void @active_lane_mask_non_const_start(<vscale x 2 x i64> %val, ptr %a, p
 ; CHECK-NEXT:    ret void
 ;
   %wide.alm = tail call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i64(i64 %start, i64 1)
-  %ext1 = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> %wide.alm, i64 0)
-  %ext2 = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> %wide.alm, i64 2)
-  tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> %val, ptr %a, <vscale x 2 x i1> %ext1)
-  tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> %val, ptr %b, <vscale x 2 x i1> %ext2)
-  ret void
-}
-
-define void @active_lane_mask_negative(<vscale x 2 x i64> %val, ptr %a, ptr %b, i64 %start) {
-; CHECK-LABEL: define void @active_lane_mask_negative(
-; CHECK-SAME: <vscale x 2 x i64> [[VAL:%.*]], ptr [[A:%.*]], ptr [[B:%.*]], i64 [[START:%.*]]) {
-; CHECK-NEXT:    [[WIDE_ALM:%.*]] = tail call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i64(i64 0, i64 -1)
-; CHECK-NEXT:    [[EXT1:%.*]] = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> [[WIDE_ALM]], i64 0)
-; CHECK-NEXT:    [[EXT2:%.*]] = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> [[WIDE_ALM]], i64 2)
-; CHECK-NEXT:    tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[VAL]], ptr [[A]], <vscale x 2 x i1> [[EXT1]])
-; CHECK-NEXT:    tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[VAL]], ptr [[B]], <vscale x 2 x i1> [[EXT2]])
-; CHECK-NEXT:    ret void
-;
-  %wide.alm = tail call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i64(i64 0, i64 -1)
   %ext1 = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> %wide.alm, i64 0)
   %ext2 = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> %wide.alm, i64 2)
   tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> %val, ptr %a, <vscale x 2 x i1> %ext1)

--- a/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
+++ b/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
@@ -37,64 +37,44 @@ define <vscale x 4 x i1> @bail_lhs_is_zero() {
   ret <vscale x 4 x i1> %mask
 }
 
-define void @remove_all_false_subvector(<4 x i32> %val, ptr %a, ptr %b, ptr %c, ptr %d) {
-; CHECK-LABEL: define void @remove_all_false_subvector(
-; CHECK-SAME: <4 x i32> [[VAL:%.*]], ptr [[A:%.*]], ptr [[B:%.*]], ptr [[C:%.*]], ptr [[D:%.*]]) {
-; CHECK-NEXT:    [[WIDE_ALM:%.*]] = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i32(i32 0, i32 7)
-; CHECK-NEXT:    [[EXT1:%.*]] = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> [[WIDE_ALM]], i64 0)
-; CHECK-NEXT:    [[EXT2:%.*]] = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> [[WIDE_ALM]], i64 4)
-; CHECK-NEXT:    tail call void @llvm.masked.store.v4i32.p0(<4 x i32> [[VAL]], ptr [[A]], <4 x i1> [[EXT1]])
-; CHECK-NEXT:    tail call void @llvm.masked.store.v4i32.p0(<4 x i32> [[VAL]], ptr [[B]], <4 x i1> [[EXT2]])
-; CHECK-NEXT:    ret void
+define <4 x i1> @remove_all_false_subvector() {
+; CHECK-LABEL: define <4 x i1> @remove_all_false_subvector() {
+; CHECK-NEXT:    ret <4 x i1> zeroinitializer
 ;
   %wide.alm = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i32 0, i32 7)
-  %ext1 = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 0)
-  %ext2 = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 4)
-  %ext3 = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 8)
-  %ext4 = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 12)
-  tail call void @llvm.masked.store.v4i32.p0(<4 x i32> %val, ptr %a, <4 x i1> %ext1)
-  tail call void @llvm.masked.store.v4i32.p0(<4 x i32> %val, ptr %b, <4 x i1> %ext2)
-  tail call void @llvm.masked.store.v4i32.p0(<4 x i32> %val, ptr %c, <4 x i1> %ext3)
-  tail call void @llvm.masked.store.v4i32.p0(<4 x i32> %val, ptr %c, <4 x i1> %ext4)
-  ret void
+  %ext = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 8)
+  ret <4 x i1> %ext
 }
 
-define void @remove_all_false_subvector_vscale(<vscale x 4 x i32> %val, ptr %a, ptr %b, ptr %c, ptr %d) #0 {
-; CHECK-LABEL: define void @remove_all_false_subvector_vscale(
-; CHECK-SAME: <vscale x 4 x i32> [[VAL:%.*]], ptr [[A:%.*]], ptr [[B:%.*]], ptr [[C:%.*]], ptr [[D:%.*]]) #[[ATTR0:[0-9]+]] {
-; CHECK-NEXT:    [[WIDE_ALM:%.*]] = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 7)
-; CHECK-NEXT:    [[EXT1:%.*]] = tail call <vscale x 4 x i1> @llvm.vector.extract.nxv4i1.nxv16i1(<vscale x 16 x i1> [[WIDE_ALM]], i64 0)
-; CHECK-NEXT:    tail call void @llvm.masked.store.nxv4i32.p0(<vscale x 4 x i32> [[VAL]], ptr [[A]], <vscale x 4 x i1> [[EXT1]])
-; CHECK-NEXT:    ret void
+define <vscale x 4 x i1> @remove_all_false_subvector_vscale() #0 {
+; CHECK-LABEL: define <vscale x 4 x i1> @remove_all_false_subvector_vscale(
+; CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
+; CHECK-NEXT:    ret <vscale x 4 x i1> zeroinitializer
 ;
   %wide.alm = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 7)
-  %ext1 = tail call <vscale x 4 x i1> @llvm.vector.extract.nxv4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 0)
-  %ext2 = tail call <vscale x 4 x i1> @llvm.vector.extract.nxv4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 4)
-  %ext3 = tail call <vscale x 4 x i1> @llvm.vector.extract.nxv4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 8)
-  %ext4 = tail call <vscale x 4 x i1> @llvm.vector.extract.nxv4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 12)
-  tail call void @llvm.masked.store.nxv4i32.p0(<vscale x 4 x i32> %val, ptr %a, <vscale x 4 x i1> %ext1)
-  tail call void @llvm.masked.store.nxv4i32.p0(<vscale x 4 x i32> %val, ptr %b, <vscale x 4 x i1> %ext2)
-  tail call void @llvm.masked.store.nxv4i32.p0(<vscale x 4 x i32> %val, ptr %c, <vscale x 4 x i1> %ext3)
-  tail call void @llvm.masked.store.nxv4i32.p0(<vscale x 4 x i32> %val, ptr %c, <vscale x 4 x i1> %ext4)
-  ret void
+  %ext = tail call <vscale x 4 x i1> @llvm.vector.extract.nxv4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 4)
+  ret <vscale x 4 x i1> %ext
 }
 
-define void @active_lane_mask_non_const_start(<vscale x 2 x i64> %val, ptr %a, ptr %b, i64 %start) {
-; CHECK-LABEL: define void @active_lane_mask_non_const_start(
-; CHECK-SAME: <vscale x 2 x i64> [[VAL:%.*]], ptr [[A:%.*]], ptr [[B:%.*]], i64 [[START:%.*]]) {
-; CHECK-NEXT:    [[WIDE_ALM:%.*]] = tail call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i64(i64 [[START]], i64 1)
-; CHECK-NEXT:    [[EXT1:%.*]] = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> [[WIDE_ALM]], i64 0)
-; CHECK-NEXT:    [[EXT2:%.*]] = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> [[WIDE_ALM]], i64 2)
-; CHECK-NEXT:    tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[VAL]], ptr [[A]], <vscale x 2 x i1> [[EXT1]])
-; CHECK-NEXT:    tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[VAL]], ptr [[B]], <vscale x 2 x i1> [[EXT2]])
-; CHECK-NEXT:    ret void
+define <vscale x 2 x i1> @active_lane_mask_non_const_start(i64 %start) {
+; CHECK-LABEL: define <vscale x 2 x i1> @active_lane_mask_non_const_start(
+; CHECK-SAME: i64 [[START:%.*]]) {
+; CHECK-NEXT:    ret <vscale x 2 x i1> zeroinitializer
 ;
   %wide.alm = tail call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i64(i64 %start, i64 1)
-  %ext1 = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> %wide.alm, i64 0)
-  %ext2 = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> %wide.alm, i64 2)
-  tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> %val, ptr %a, <vscale x 2 x i1> %ext1)
-  tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> %val, ptr %b, <vscale x 2 x i1> %ext2)
-  ret void
+  %ext = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> %wide.alm, i64 2)
+  ret <vscale x 2 x i1> %ext
+}
+
+define <4 x i1> @ext_has_active_lanes() {
+; CHECK-LABEL: define <4 x i1> @ext_has_active_lanes() {
+; CHECK-NEXT:    [[WIDE_ALM:%.*]] = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i32(i32 0, i32 7)
+; CHECK-NEXT:    [[EXT:%.*]] = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> [[WIDE_ALM]], i64 4)
+; CHECK-NEXT:    ret <4 x i1> [[EXT]]
+;
+  %wide.alm = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i32 0, i32 7)
+  %ext = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 4)
+  ret <4 x i1> %ext
 }
 
 attributes #0 = { vscale_range(2,16) }

--- a/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
+++ b/llvm/test/Transforms/InstCombine/get_active_lane_mask.ll
@@ -36,3 +36,83 @@ define <vscale x 4 x i1> @bail_lhs_is_zero() {
   %mask = call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i32(i32 0, i32 4)
   ret <vscale x 4 x i1> %mask
 }
+
+define void @remove_all_false_subvector(<4 x i32> %val, ptr %a, ptr %b, ptr %c, ptr %d) {
+; CHECK-LABEL: define void @remove_all_false_subvector(
+; CHECK-SAME: <4 x i32> [[VAL:%.*]], ptr [[A:%.*]], ptr [[B:%.*]], ptr [[C:%.*]], ptr [[D:%.*]]) {
+; CHECK-NEXT:    [[WIDE_ALM:%.*]] = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 7)
+; CHECK-NEXT:    [[EXT1:%.*]] = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> [[WIDE_ALM]], i64 0)
+; CHECK-NEXT:    [[EXT2:%.*]] = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> [[WIDE_ALM]], i64 4)
+; CHECK-NEXT:    tail call void @llvm.masked.store.v4i32.p0(<4 x i32> [[VAL]], ptr [[A]], <4 x i1> [[EXT1]])
+; CHECK-NEXT:    tail call void @llvm.masked.store.v4i32.p0(<4 x i32> [[VAL]], ptr [[B]], <4 x i1> [[EXT2]])
+; CHECK-NEXT:    ret void
+;
+  %wide.alm = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 7)
+  %ext1 = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 0)
+  %ext2 = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 4)
+  %ext3 = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 8)
+  %ext4 = tail call <4 x i1> @llvm.vector.extract.v4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 12)
+  tail call void @llvm.masked.store.v4i32.p0(<4 x i32> %val, ptr %a, <4 x i1> %ext1)
+  tail call void @llvm.masked.store.v4i32.p0(<4 x i32> %val, ptr %b, <4 x i1> %ext2)
+  tail call void @llvm.masked.store.v4i32.p0(<4 x i32> %val, ptr %c, <4 x i1> %ext3)
+  tail call void @llvm.masked.store.v4i32.p0(<4 x i32> %val, ptr %c, <4 x i1> %ext4)
+  ret void
+}
+
+define void @remove_all_false_subvector_vscale(<vscale x 4 x i32> %val, ptr %a, ptr %b, ptr %c, ptr %d) #0 {
+; CHECK-LABEL: define void @remove_all_false_subvector_vscale(
+; CHECK-SAME: <vscale x 4 x i32> [[VAL:%.*]], ptr [[A:%.*]], ptr [[B:%.*]], ptr [[C:%.*]], ptr [[D:%.*]]) #[[ATTR0:[0-9]+]] {
+; CHECK-NEXT:    [[WIDE_ALM:%.*]] = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 7)
+; CHECK-NEXT:    [[EXT1:%.*]] = tail call <vscale x 4 x i1> @llvm.vector.extract.nxv4i1.nxv16i1(<vscale x 16 x i1> [[WIDE_ALM]], i64 0)
+; CHECK-NEXT:    tail call void @llvm.masked.store.nxv4i32.p0(<vscale x 4 x i32> [[VAL]], ptr [[A]], <vscale x 4 x i1> [[EXT1]])
+; CHECK-NEXT:    ret void
+;
+  %wide.alm = tail call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 7)
+  %ext1 = tail call <vscale x 4 x i1> @llvm.vector.extract.nxv4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 0)
+  %ext2 = tail call <vscale x 4 x i1> @llvm.vector.extract.nxv4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 4)
+  %ext3 = tail call <vscale x 4 x i1> @llvm.vector.extract.nxv4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 8)
+  %ext4 = tail call <vscale x 4 x i1> @llvm.vector.extract.nxv4i1.nxv16i1(<vscale x 16 x i1> %wide.alm, i64 12)
+  tail call void @llvm.masked.store.nxv4i32.p0(<vscale x 4 x i32> %val, ptr %a, <vscale x 4 x i1> %ext1)
+  tail call void @llvm.masked.store.nxv4i32.p0(<vscale x 4 x i32> %val, ptr %b, <vscale x 4 x i1> %ext2)
+  tail call void @llvm.masked.store.nxv4i32.p0(<vscale x 4 x i32> %val, ptr %c, <vscale x 4 x i1> %ext3)
+  tail call void @llvm.masked.store.nxv4i32.p0(<vscale x 4 x i32> %val, ptr %c, <vscale x 4 x i1> %ext4)
+  ret void
+}
+
+define void @active_lane_mask_non_const_start(<vscale x 2 x i64> %val, ptr %a, ptr %b, i64 %start) {
+; CHECK-LABEL: define void @active_lane_mask_non_const_start(
+; CHECK-SAME: <vscale x 2 x i64> [[VAL:%.*]], ptr [[A:%.*]], ptr [[B:%.*]], i64 [[START:%.*]]) {
+; CHECK-NEXT:    [[WIDE_ALM:%.*]] = tail call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i64(i64 [[START]], i64 1)
+; CHECK-NEXT:    [[EXT1:%.*]] = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> [[WIDE_ALM]], i64 0)
+; CHECK-NEXT:    [[EXT2:%.*]] = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> [[WIDE_ALM]], i64 2)
+; CHECK-NEXT:    tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[VAL]], ptr [[A]], <vscale x 2 x i1> [[EXT1]])
+; CHECK-NEXT:    tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[VAL]], ptr [[B]], <vscale x 2 x i1> [[EXT2]])
+; CHECK-NEXT:    ret void
+;
+  %wide.alm = tail call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i64(i64 %start, i64 1)
+  %ext1 = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> %wide.alm, i64 0)
+  %ext2 = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> %wide.alm, i64 2)
+  tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> %val, ptr %a, <vscale x 2 x i1> %ext1)
+  tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> %val, ptr %b, <vscale x 2 x i1> %ext2)
+  ret void
+}
+
+define void @active_lane_mask_negative(<vscale x 2 x i64> %val, ptr %a, ptr %b, i64 %start) {
+; CHECK-LABEL: define void @active_lane_mask_negative(
+; CHECK-SAME: <vscale x 2 x i64> [[VAL:%.*]], ptr [[A:%.*]], ptr [[B:%.*]], i64 [[START:%.*]]) {
+; CHECK-NEXT:    [[WIDE_ALM:%.*]] = tail call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i64(i64 0, i64 -1)
+; CHECK-NEXT:    [[EXT1:%.*]] = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> [[WIDE_ALM]], i64 0)
+; CHECK-NEXT:    [[EXT2:%.*]] = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> [[WIDE_ALM]], i64 2)
+; CHECK-NEXT:    tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[VAL]], ptr [[A]], <vscale x 2 x i1> [[EXT1]])
+; CHECK-NEXT:    tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> [[VAL]], ptr [[B]], <vscale x 2 x i1> [[EXT2]])
+; CHECK-NEXT:    ret void
+;
+  %wide.alm = tail call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i64(i64 0, i64 -1)
+  %ext1 = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> %wide.alm, i64 0)
+  %ext2 = tail call <vscale x 2 x i1> @llvm.vector.extract.nxv2i1.nxv4i1(<vscale x 4 x i1> %wide.alm, i64 2)
+  tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> %val, ptr %a, <vscale x 2 x i1> %ext1)
+  tail call void @llvm.masked.store.nxv2i64.p0(<vscale x 2 x i64> %val, ptr %b, <vscale x 2 x i1> %ext2)
+  ret void
+}
+
+attributes #0 = { vscale_range(2,16) }


### PR DESCRIPTION
When extracting a subvector from the result of a get_active_lane_mask, return
a constant zero vector if it can be proven that all lanes will be inactive.

For example, the result of the extract below will be a subvector where
every lane is inactive if X & Y are const, and `Y * VScale >= X`:
  vector.extract(get.active.lane.mask(Start, X), Y)