### PR TITLE
[AMDGPU] Adding FoldMemRefOpsIntoTransposeLoadOp pattern

### DIFF
--- a/mlir/lib/Dialect/AMDGPU/Transforms/FoldMemRefsOps.cpp
+++ b/mlir/lib/Dialect/AMDGPU/Transforms/FoldMemRefsOps.cpp
@@ -100,8 +100,30 @@ struct FoldMemRefOpsIntoGatherToLDSOp final : OpRewritePattern<GatherToLDSOp> {
   }
 };
 
+struct FoldMemRefOpsIntoTransposeLoadOp final
+    : OpRewritePattern<TransposeLoadOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(TransposeLoadOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+
+    SmallVector<Value> sourceIndices;
+    Value memrefSource;
+
+    if (failed(foldMemrefViewOp(rewriter, loc, op.getSrc(), op.getSrcIndices(),
+                                sourceIndices, memrefSource, "source")))
+      return failure();
+
+    rewriter.replaceOpWithNewOp<TransposeLoadOp>(op, op.getResult().getType(),
+                                                 memrefSource, sourceIndices);
+    return success();
+  }
+};
+
 void populateAmdgpuFoldMemRefOpsPatterns(RewritePatternSet &patterns,
                                          PatternBenefit benefit) {
-  patterns.add<FoldMemRefOpsIntoGatherToLDSOp>(patterns.getContext(), benefit);
+  patterns
+      .add<FoldMemRefOpsIntoGatherToLDSOp, FoldMemRefOpsIntoTransposeLoadOp>(
+          patterns.getContext(), benefit);
 }
 } // namespace mlir::amdgpu

--- a/mlir/lib/Dialect/AMDGPU/Transforms/FoldMemRefsOps.cpp
+++ b/mlir/lib/Dialect/AMDGPU/Transforms/FoldMemRefsOps.cpp
@@ -66,7 +66,7 @@ static LogicalResult foldMemrefViewOp(PatternRewriter &rewriter, Location loc,
 }
 
 struct FoldMemRefOpsIntoGatherToLDSOp final : OpRewritePattern<GatherToLDSOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(GatherToLDSOp op,
                                 PatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
@@ -102,16 +102,15 @@ struct FoldMemRefOpsIntoGatherToLDSOp final : OpRewritePattern<GatherToLDSOp> {
 
 struct FoldMemRefOpsIntoTransposeLoadOp final
     : OpRewritePattern<TransposeLoadOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(TransposeLoadOp op,
                                 PatternRewriter &rewriter) const override {
-    Location loc = op.getLoc();
-
     SmallVector<Value> sourceIndices;
     Value memrefSource;
 
-    if (failed(foldMemrefViewOp(rewriter, loc, op.getSrc(), op.getSrcIndices(),
-                                sourceIndices, memrefSource, "source")))
+    if (failed(foldMemrefViewOp(rewriter, op.getLoc(), op.getSrc(),
+                                op.getSrcIndices(), sourceIndices, memrefSource,
+                                "source")))
       return failure();
 
     rewriter.replaceOpWithNewOp<TransposeLoadOp>(op, op.getResult().getType(),


### PR DESCRIPTION
Before the fix we wouldn't fold a trivial expand_shape as index computation. This will later force expand_shape to materialize into a extract_stride_metadata and a reinterpret_cast unnecessarily. The example below showcase the motivation of a source IR that won't be able to fold today.

```mlir
%expanded = memref.expand_shape %buf [[0, 1], [2, 3]]
    : memref<32x128xf16, strided<[128, 1], offset: ?>, #gpu.address_space<workgroup>>
    into memref<1x32x8x16xf16, strided<..., offset: ?>, #gpu.address_space<workgroup>>
amdgpu.transpose_load %expanded[%i, %j, %k, %l]
    : memref<1x32x8x16xf16, ...> -> vector<4xf16>
```

With this pattern that matches the more generic `FoldMemRefAliasOpsPass`, the expand_shape can now fold into transpose_load op like other load/stores.

The current `FoldMemRefAliasOps` pass doesn't use a more generic interface yet — it still uses the hardcoded overloads. This PR continues the pragmatic approach in providing its own folding pass (like `GatherToLDSOp`).

