### PR TITLE
[flang] Fix crash on error case

### DIFF
--- a/flang/test/Semantics/bug2292.f90
+++ b/flang/test/Semantics/bug2292.f90
@@ -1,0 +1,5 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1
+subroutine sub(lb)
+  !ERROR: The lower bounds of the parameter 'const' are not constant
+  integer, parameter :: const(lb:*) = [0]
+end


### PR DESCRIPTION
A named constant implicit-shape array with a non-constant lower bound is an error case.  Emit an error message rather than crashing.