### PR TITLE
[MC] Remove redundant setting of AllowDollarAtStartOfIdentifier. NFC

### DIFF
--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
@@ -53,7 +53,6 @@ ARMMCAsmInfoDarwin::ARMMCAsmInfoDarwin(const Triple &TheTriple) {
 
   Data64bitsDirective = nullptr;
   CommentString = "@";
-  AllowDollarAtStartOfIdentifier = false;
   UseDataRegionDirectives = true;
 
   SupportsDebugInformation = true;
@@ -81,7 +80,6 @@ ARMELFMCAsmInfo::ARMELFMCAsmInfo(const Triple &TheTriple) {
 
   Data64bitsDirective = nullptr;
   CommentString = "@";
-  AllowDollarAtStartOfIdentifier = false;
 
   SupportsDebugInformation = true;
 
@@ -138,7 +136,6 @@ ARMCOFFMCAsmInfoGNU::ARMCOFFMCAsmInfoGNU() {
   HasSingleParameterDotFile = true;
 
   CommentString = "@";
-  AllowDollarAtStartOfIdentifier = false;
   PrivateGlobalPrefix = ".L";
   PrivateLabelPrefix = ".L";
 

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCAsmInfo.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCAsmInfo.cpp
@@ -245,7 +245,6 @@ LoongArchMCAsmInfo::LoongArchMCAsmInfo(const Triple &TT) {
   Data64bitsDirective = "\t.dword\t";
   ZeroDirective = "\t.space\t";
   CommentString = "#";
-  AllowDollarAtStartOfIdentifier = false;
   SupportsDebugInformation = true;
   DwarfRegNumForCFI = true;
   ExceptionsType = ExceptionHandling::DwarfCFI;

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
@@ -41,7 +41,6 @@ MipsELFMCAsmInfo::MipsELFMCAsmInfo(const Triple &TheTriple,
   Data32bitsDirective         = "\t.4byte\t";
   Data64bitsDirective         = "\t.8byte\t";
   CommentString               = "#";
-  AllowDollarAtStartOfIdentifier = false;
   ZeroDirective               = "\t.space\t";
   UseAssignmentForEHBegin = true;
   SupportsDebugInformation = true;

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCAsmInfo.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCAsmInfo.cpp
@@ -192,7 +192,6 @@ PPCELFMCAsmInfo::PPCELFMCAsmInfo(bool is64Bit, const Triple& T) {
   SupportsDebugInformation = true;
 
   DollarIsPC = true;
-  AllowDollarAtStartOfIdentifier = false;
 
   // Set up DWARF directives
   MinInstAlignment = 4;
@@ -236,7 +235,6 @@ PPCXCOFFMCAsmInfo::PPCXCOFFMCAsmInfo(bool Is64Bit, const Triple &T) {
 
   // Support $ as PC in inline asm
   DollarIsPC = true;
-  AllowDollarAtStartOfIdentifier = false;
 
   UsesSetToEquateSymbol = true;
 

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
@@ -84,8 +84,6 @@ X86MCAsmInfoDarwin::X86MCAsmInfoDarwin(const Triple &T) {
   // wasn't always case preserving or something.
   CommentString = "##";
 
-  AllowDollarAtStartOfIdentifier = false;
-
   SupportsDebugInformation = true;
   UseDataRegionDirectives = MarkedJTDataRegions;
 
@@ -125,7 +123,6 @@ X86ELFMCAsmInfo::X86ELFMCAsmInfo(const Triple &T) {
   CalleeSaveStackSlotSize = is64Bit ? 8 : 4;
 
   AssemblerDialect = X86AsmSyntax;
-  AllowDollarAtStartOfIdentifier = false;
 
   // Debug Information
   SupportsDebugInformation = true;
@@ -164,7 +161,6 @@ X86MCAsmInfoMicrosoft::X86MCAsmInfoMicrosoft(const Triple &Triple) {
   ExceptionsType = ExceptionHandling::WinEH;
 
   AssemblerDialect = X86AsmSyntax;
-  AllowDollarAtStartOfIdentifier = false;
 
   AllowAtInName = true;
 
@@ -202,7 +198,6 @@ X86MCAsmInfoGNUCOFF::X86MCAsmInfoGNUCOFF(const Triple &Triple) {
   AssemblerDialect = X86AsmSyntax;
 
   AllowAtInName = true;
-  AllowDollarAtStartOfIdentifier = false;
 
   initializeAtSpecifiers(atSpecifiers);
 }


### PR DESCRIPTION
This setting defaults to false so there is no need to set it unless we want it to be true.

This makes it easy to see at a glace which backends support this, and matches the existing behaviour of other fields such as `AllowAtAtStartOfIdentifier`, `AllowQuestionAtStartOfIdentifier`, `UseAssignmentForEHBegin` and `AllowAtInName`.  These are all only ever set to true in subclasses, never false.