### PR TITLE
[AST][NFC] Move AST dump colors into separate namespace

### DIFF
--- a/clang/include/clang/AST/ASTDumperUtils.h
+++ b/clang/include/clang/AST/ASTDumperUtils.h
@@ -31,57 +31,60 @@ struct TerminalColor {
   bool Bold;
 };
 
-// Red           - CastColor
-// Green         - TypeColor
-// Bold Green    - DeclKindNameColor, UndeserializedColor
-// Yellow        - AddressColor, LocationColor
-// Blue          - CommentColor, NullColor, IndentColor
-// Bold Blue     - AttrColor
-// Bold Magenta  - StmtColor
-// Cyan          - ValueKindColor, ObjectKindColor
-// Bold Cyan     - ValueColor, DeclNameColor
+struct ASTDumpColor {
+  // Red           - Cast
+  // Green         - Type
+  // Bold Green    - DeclKindName, Undeserialized
+  // Yellow        - Address, Location
+  // Blue          - Comment, Null, Indent
+  // Bold Blue     - Attr
+  // Bold Magenta  - Stmt
+  // Cyan          - ValueKind, ObjectKind
+  // Bold Cyan     - Value, DeclName
 
-// Decl kind names (VarDecl, FunctionDecl, etc)
-static const TerminalColor DeclKindNameColor = {llvm::raw_ostream::GREEN, true};
-// Attr names (CleanupAttr, GuardedByAttr, etc)
-static const TerminalColor AttrColor = {llvm::raw_ostream::BLUE, true};
-// Statement names (DeclStmt, ImplicitCastExpr, etc)
-static const TerminalColor StmtColor = {llvm::raw_ostream::MAGENTA, true};
-// Comment names (FullComment, ParagraphComment, TextComment, etc)
-static const TerminalColor CommentColor = {llvm::raw_ostream::BLUE, false};
+  // Decl kind names (VarDecl, FunctionDecl, etc)
+  static constexpr TerminalColor DeclKindName = {llvm::raw_ostream::GREEN,
+                                                 true};
+  // Attr names (CleanupAttr, GuardedByAttr, etc)
+  static constexpr TerminalColor Attr = {llvm::raw_ostream::BLUE, true};
+  // Statement names (DeclStmt, ImplicitCastExpr, etc)
+  static constexpr TerminalColor Stmt = {llvm::raw_ostream::MAGENTA, true};
+  // Comment names (FullComment, ParagraphComment, TextComment, etc)
+  static constexpr TerminalColor Comment = {llvm::raw_ostream::BLUE, false};
 
-// Type names (int, float, etc, plus user defined types)
-static const TerminalColor TypeColor = {llvm::raw_ostream::GREEN, false};
+  // Type names (int, float, etc, plus user defined types)
+  static constexpr TerminalColor Type = {llvm::raw_ostream::GREEN, false};
 
-// Pointer address
-static const TerminalColor AddressColor = {llvm::raw_ostream::YELLOW, false};
-// Source locations
-static const TerminalColor LocationColor = {llvm::raw_ostream::YELLOW, false};
+  // Pointer address
+  static constexpr TerminalColor Address = {llvm::raw_ostream::YELLOW, false};
+  // Source locations
+  static constexpr TerminalColor Location = {llvm::raw_ostream::YELLOW, false};
 
-// lvalue/xvalue
-static const TerminalColor ValueKindColor = {llvm::raw_ostream::CYAN, false};
-// bitfield/objcproperty/objcsubscript/vectorcomponent
-static const TerminalColor ObjectKindColor = {llvm::raw_ostream::CYAN, false};
-// contains-errors
-static const TerminalColor ErrorsColor = {llvm::raw_ostream::RED, true};
+  // lvalue/xvalue
+  static constexpr TerminalColor ValueKind = {llvm::raw_ostream::CYAN, false};
+  // bitfield/objcproperty/objcsubscript/vectorcomponent
+  static constexpr TerminalColor ObjectKind = {llvm::raw_ostream::CYAN, false};
+  // contains-errors
+  static constexpr TerminalColor Errors = {llvm::raw_ostream::RED, true};
 
-// Null statements
-static const TerminalColor NullColor = {llvm::raw_ostream::BLUE, false};
+  // Null statements
+  static constexpr TerminalColor Null = {llvm::raw_ostream::BLUE, false};
 
-// Undeserialized entities
-static const TerminalColor UndeserializedColor = {llvm::raw_ostream::GREEN,
-                                                  true};
+  // Undeserialized entities
+  static constexpr TerminalColor Undeserialized = {llvm::raw_ostream::GREEN,
+                                                   true};
 
-// CastKind from CastExpr's
-static const TerminalColor CastColor = {llvm::raw_ostream::RED, false};
+  // CastKind from CastExpr's
+  static constexpr TerminalColor Cast = {llvm::raw_ostream::RED, false};
 
-// Value of the statement
-static const TerminalColor ValueColor = {llvm::raw_ostream::CYAN, true};
-// Decl names
-static const TerminalColor DeclNameColor = {llvm::raw_ostream::CYAN, true};
+  // Value of the statement
+  static constexpr TerminalColor Value = {llvm::raw_ostream::CYAN, true};
+  // Decl names
+  static constexpr TerminalColor DeclName = {llvm::raw_ostream::CYAN, true};
 
-// Indents ( `, -. | )
-static const TerminalColor IndentColor = {llvm::raw_ostream::BLUE, false};
+  // Indents ( `, -. | )
+  static constexpr TerminalColor Indent = {llvm::raw_ostream::BLUE, false};
+};
 
 class ColorScope {
   llvm::raw_ostream &OS;

--- a/clang/include/clang/AST/TextNodeDumper.h
+++ b/clang/include/clang/AST/TextNodeDumper.h
@@ -87,7 +87,7 @@ public:
       // Note that the first level gets no prefix.
       {
         OS << '\n';
-        ColorScope Color(OS, ShowColors, IndentColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::Indent);
         OS << Prefix << (IsLastChild ? '`' : '|') << '-';
         if (!Label.empty())
           OS << Label << ": ";

--- a/clang/lib/AST/ASTDumper.cpp
+++ b/clang/lib/AST/ASTDumper.cpp
@@ -25,7 +25,7 @@ using namespace clang::comments;
 void ASTDumper::dumpInvalidDeclContext(const DeclContext *DC) {
   NodeDumper.AddChild([=] {
     if (!DC) {
-      ColorScope Color(OS, ShowColors, NullColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
       OS << "<<<NULL>>>";
       return;
     }
@@ -36,13 +36,13 @@ void ASTDumper::dumpInvalidDeclContext(const DeclContext *DC) {
     // the information provided below is intended to provide some hints about
     // what might have gone awry.
     {
-      ColorScope Color(OS, ShowColors, DeclKindNameColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::DeclKindName);
       OS << "DeclContext";
     }
     NodeDumper.dumpPointer(DC);
     OS << " <";
     {
-      ColorScope Color(OS, ShowColors, DeclNameColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::DeclName);
       OS << "unrecognized Decl kind " << (unsigned)DC->getDeclKind();
     }
     OS << ">";
@@ -72,7 +72,7 @@ void ASTDumper::dumpLookups(const DeclContext *DC, bool DumpDecls) {
       NodeDumper.AddChild([=] {
         OS << "DeclarationName ";
         {
-          ColorScope Color(OS, ShowColors, DeclNameColor);
+          ColorScope Color(OS, ShowColors, ASTDumpColor::DeclName);
           OS << '\'' << Name << '\'';
         }
 
@@ -101,7 +101,7 @@ void ASTDumper::dumpLookups(const DeclContext *DC, bool DumpDecls) {
 
     if (HasUndeserializedLookups) {
       NodeDumper.AddChild([=] {
-        ColorScope Color(OS, ShowColors, UndeserializedColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::Undeserialized);
         OS << "<undeserialized lookups>";
       });
     }

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -73,13 +73,13 @@ TextNodeDumper::TextNodeDumper(raw_ostream &OS, bool ShowColors)
 void TextNodeDumper::Visit(const comments::Comment *C,
                            const comments::FullComment *FC) {
   if (!C) {
-    ColorScope Color(OS, ShowColors, NullColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
     OS << "<<<NULL>>>";
     return;
   }
 
   {
-    ColorScope Color(OS, ShowColors, CommentColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Comment);
     OS << C->getCommentKindName();
   }
   dumpPointer(C);
@@ -91,7 +91,7 @@ void TextNodeDumper::Visit(const comments::Comment *C,
 
 void TextNodeDumper::Visit(const Attr *A) {
   {
-    ColorScope Color(OS, ShowColors, AttrColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Attr);
 
     switch (A->getKind()) {
 #define ATTR(X)                                                                \
@@ -126,12 +126,12 @@ void TextNodeDumper::Visit(const TemplateArgument &TA, SourceRange R,
 
 void TextNodeDumper::Visit(const Stmt *Node) {
   if (!Node) {
-    ColorScope Color(OS, ShowColors, NullColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
     OS << "<<<NULL>>>";
     return;
   }
   {
-    ColorScope Color(OS, ShowColors, StmtColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Stmt);
     OS << Node->getStmtClassName();
   }
   dumpPointer(Node);
@@ -141,12 +141,12 @@ void TextNodeDumper::Visit(const Stmt *Node) {
     dumpType(E->getType());
 
     if (E->containsErrors()) {
-      ColorScope Color(OS, ShowColors, ErrorsColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::Errors);
       OS << " contains-errors";
     }
 
     {
-      ColorScope Color(OS, ShowColors, ValueKindColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::ValueKind);
       switch (E->getValueKind()) {
       case VK_PRValue:
         break;
@@ -160,7 +160,7 @@ void TextNodeDumper::Visit(const Stmt *Node) {
     }
 
     {
-      ColorScope Color(OS, ShowColors, ObjectKindColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::ObjectKind);
       switch (E->getObjectKind()) {
       case OK_Ordinary:
         break;
@@ -188,13 +188,13 @@ void TextNodeDumper::Visit(const Stmt *Node) {
 
 void TextNodeDumper::Visit(const Type *T) {
   if (!T) {
-    ColorScope Color(OS, ShowColors, NullColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
     OS << "<<<NULL>>>";
     return;
   }
   if (isa<LocInfoType>(T)) {
     {
-      ColorScope Color(OS, ShowColors, TypeColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::Type);
       OS << "LocInfo Type";
     }
     dumpPointer(T);
@@ -202,7 +202,7 @@ void TextNodeDumper::Visit(const Type *T) {
   }
 
   {
-    ColorScope Color(OS, ShowColors, TypeColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Type);
     OS << T->getTypeClassName() << "Type";
   }
   dumpPointer(T);
@@ -215,7 +215,7 @@ void TextNodeDumper::Visit(const Type *T) {
     OS << " sugar";
 
   if (T->containsErrors()) {
-    ColorScope Color(OS, ShowColors, ErrorsColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Errors);
     OS << " contains-errors";
   }
 
@@ -244,13 +244,13 @@ void TextNodeDumper::Visit(QualType T) {
 
 void TextNodeDumper::Visit(TypeLoc TL) {
   if (!TL) {
-    ColorScope Color(OS, ShowColors, NullColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
     OS << "<<<NULL>>>";
     return;
   }
 
   {
-    ColorScope Color(OS, ShowColors, TypeColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Type);
     OS << (TL.getTypeLocClass() == TypeLoc::Qualified
                ? "Qualified"
                : TL.getType()->getTypeClassName())
@@ -265,13 +265,13 @@ void TextNodeDumper::Visit(TypeLoc TL) {
 
 void TextNodeDumper::Visit(const Decl *D) {
   if (!D) {
-    ColorScope Color(OS, ShowColors, NullColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
     OS << "<<<NULL>>>";
     return;
   }
 
   {
-    ColorScope Color(OS, ShowColors, DeclKindNameColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::DeclKindName);
     OS << D->getDeclKindName() << "Decl";
   }
   dumpPointer(D);
@@ -318,7 +318,7 @@ void TextNodeDumper::Visit(const Decl *D) {
     if (!MD || !MD->isThisDeclarationADefinition()) {
       const auto *DC = dyn_cast<DeclContext>(D);
       if (DC && DC->hasExternalLexicalStorage()) {
-        ColorScope Color(OS, ShowColors, UndeserializedColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::Undeserialized);
         OS << " <undeserialized declarations>";
       }
     }
@@ -366,12 +366,12 @@ void TextNodeDumper::Visit(const BlockDecl::Capture &C) {
 
 void TextNodeDumper::Visit(const OMPClause *C) {
   if (!C) {
-    ColorScope Color(OS, ShowColors, NullColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
     OS << "<<<NULL>>> OMPClause";
     return;
   }
   {
-    ColorScope Color(OS, ShowColors, AttrColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Attr);
     StringRef ClauseName(llvm::omp::getOpenMPClauseName(C->getClauseKind()));
     OS << "OMP" << ClauseName.substr(/*Start=*/0, /*N=*/1).upper()
        << ClauseName.drop_front() << "Clause";
@@ -389,12 +389,12 @@ void TextNodeDumper::VisitOpenACCAsteriskSizeExpr(
 
 void TextNodeDumper::Visit(const OpenACCClause *C) {
   if (!C) {
-    ColorScope Color(OS, ShowColors, NullColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
     OS << "<<<NULL>>> OpenACCClause";
     return;
   }
   {
-    ColorScope Color(OS, ShowColors, AttrColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Attr);
     OS << C->getClauseKind();
 
     // Handle clauses with parens for types that have no children, likely
@@ -543,7 +543,7 @@ void TextNodeDumper::Visit(const GenericSelectionExpr::ConstAssociation &A) {
 
 void TextNodeDumper::Visit(const ConceptReference *R) {
   if (!R) {
-    ColorScope Color(OS, ShowColors, NullColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
     OS << "<<<NULL>>> ConceptReference";
     return;
   }
@@ -557,13 +557,13 @@ void TextNodeDumper::Visit(const ConceptReference *R) {
 
 void TextNodeDumper::Visit(const concepts::Requirement *R) {
   if (!R) {
-    ColorScope Color(OS, ShowColors, NullColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
     OS << "<<<NULL>>> Requirement";
     return;
   }
 
   {
-    ColorScope Color(OS, ShowColors, StmtColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Stmt);
     switch (R->getKind()) {
     case concepts::Requirement::RK_Type:
       OS << "TypeRequirement";
@@ -674,7 +674,7 @@ void TextNodeDumper::dumpAPValueChildren(
 }
 
 void TextNodeDumper::Visit(const APValue &Value, QualType Ty) {
-  ColorScope Color(OS, ShowColors, ValueKindColor);
+  ColorScope Color(OS, ShowColors, ASTDumpColor::ValueKind);
   switch (Value.getKind()) {
   case APValue::None:
     OS << "None";
@@ -685,21 +685,21 @@ void TextNodeDumper::Visit(const APValue &Value, QualType Ty) {
   case APValue::Int:
     OS << "Int ";
     {
-      ColorScope Color(OS, ShowColors, ValueColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
       OS << Value.getInt();
     }
     return;
   case APValue::Float:
     OS << "Float ";
     {
-      ColorScope Color(OS, ShowColors, ValueColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
       OS << GetApproxValue(Value.getFloat());
     }
     return;
   case APValue::FixedPoint:
     OS << "FixedPoint ";
     {
-      ColorScope Color(OS, ShowColors, ValueColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
       OS << Value.getFixedPoint();
     }
     return;
@@ -718,7 +718,7 @@ void TextNodeDumper::Visit(const APValue &Value, QualType Ty) {
   case APValue::ComplexInt:
     OS << "ComplexInt ";
     {
-      ColorScope Color(OS, ShowColors, ValueColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
       OS << Value.getComplexIntReal() << " + " << Value.getComplexIntImag()
          << 'i';
     }
@@ -726,7 +726,7 @@ void TextNodeDumper::Visit(const APValue &Value, QualType Ty) {
   case APValue::ComplexFloat:
     OS << "ComplexFloat ";
     {
-      ColorScope Color(OS, ShowColors, ValueColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
       OS << GetApproxValue(Value.getComplexFloatReal()) << " + "
          << GetApproxValue(Value.getComplexFloatImag()) << 'i';
     }
@@ -742,7 +742,7 @@ void TextNodeDumper::Visit(const APValue &Value, QualType Ty) {
       dumpPointer(BE);
     } else if (const auto BTI = B.dyn_cast<TypeInfoLValue>()) {
       OS << "TypeInfoLValue ";
-      ColorScope Color(OS, ShowColors, TypeColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::Type);
       BTI.print(OS, PrintPolicy);
     } else if (B.is<DynamicAllocLValue>()) {
       OS << "DynamicAllocLValue";
@@ -784,7 +784,7 @@ void TextNodeDumper::Visit(const APValue &Value, QualType Ty) {
     if (Value.hasArrayFiller()) {
       AddChild("filler", [=] {
         {
-          ColorScope Color(OS, ShowColors, ValueColor);
+          ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
           OS << ArraySize - NumInitializedElements << " x ";
         }
         Visit(Value.getArrayFiller(), Ty);
@@ -815,7 +815,7 @@ void TextNodeDumper::Visit(const APValue &Value, QualType Ty) {
   case APValue::Union: {
     OS << "Union";
     {
-      ColorScope Color(OS, ShowColors, ValueColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
       if (const FieldDecl *FD = Value.getUnionField())
         OS << " ." << *cast<NamedDecl>(FD);
     }
@@ -836,13 +836,13 @@ void TextNodeDumper::Visit(const APValue &Value, QualType Ty) {
     auto Path = Value.getMemberPointerPath();
     for (const CXXRecordDecl *D : Path) {
       {
-        ColorScope Color(OS, ShowColors, DeclNameColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::DeclName);
         OS << D->getDeclName();
       }
       OS << "::";
     }
 
-    ColorScope Color(OS, ShowColors, DeclNameColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::DeclName);
     if (const ValueDecl *MemDecl = Value.getMemberPointerDecl())
       OS << MemDecl->getDeclName();
     else
@@ -860,7 +860,7 @@ void TextNodeDumper::Visit(const APValue &Value, QualType Ty) {
 }
 
 void TextNodeDumper::dumpPointer(const void *Ptr) {
-  ColorScope Color(OS, ShowColors, AddressColor);
+  ColorScope Color(OS, ShowColors, ASTDumpColor::Address);
   OS << ' ' << Ptr;
 }
 
@@ -868,7 +868,7 @@ void TextNodeDumper::dumpLocation(SourceLocation Loc) {
   if (!SM)
     return;
 
-  ColorScope Color(OS, ShowColors, LocationColor);
+  ColorScope Color(OS, ShowColors, ASTDumpColor::Location);
   SourceLocation SpellingLoc = SM->getSpellingLoc(Loc);
 
   // The general format we print out is filename:line:col, but we drop pieces
@@ -910,7 +910,7 @@ void TextNodeDumper::dumpSourceRange(SourceRange R) {
 }
 
 void TextNodeDumper::dumpBareType(QualType T, bool Desugar) {
-  ColorScope Color(OS, ShowColors, TypeColor);
+  ColorScope Color(OS, ShowColors, ASTDumpColor::Type);
 
   SplitQualType T_split = T.split();
   std::string T_str = QualType::getAsString(T_split, PrintPolicy);
@@ -935,19 +935,19 @@ void TextNodeDumper::dumpType(QualType T) {
 
 void TextNodeDumper::dumpBareDeclRef(const Decl *D) {
   if (!D) {
-    ColorScope Color(OS, ShowColors, NullColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
     OS << "<<<NULL>>>";
     return;
   }
 
   {
-    ColorScope Color(OS, ShowColors, DeclKindNameColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::DeclKindName);
     OS << D->getDeclKindName();
   }
   dumpPointer(D);
 
   if (const NamedDecl *ND = dyn_cast<NamedDecl>(D)) {
-    ColorScope Color(OS, ShowColors, DeclNameColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::DeclName);
     if (DeclarationName Name = ND->getDeclName())
       OS << " '" << Name << '\'';
     else
@@ -991,7 +991,7 @@ void TextNodeDumper::dumpBareDeclRef(const Decl *D) {
 
 void TextNodeDumper::dumpName(const NamedDecl *ND) {
   if (ND->getDeclName()) {
-    ColorScope Color(OS, ShowColors, DeclNameColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::DeclName);
     OS << ' ' << ND->getDeclName();
   }
 }
@@ -1011,7 +1011,7 @@ void TextNodeDumper::dumpCleanupObject(
     AddChild([=] {
       OS << "cleanup ";
       {
-        ColorScope Color(OS, ShowColors, StmtColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::Stmt);
         OS << CLE->getStmtClassName();
       }
       dumpPointer(CLE);
@@ -1423,11 +1423,11 @@ void TextNodeDumper::VisitLoopControlStmt(const LoopControlStmt *Node) {
 
   auto *Target = Node->getNamedLoopOrSwitch();
   if (!Target) {
-    ColorScope Color(OS, ShowColors, NullColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
     OS << "<<<NULL>>>";
   } else {
     {
-      ColorScope Color(OS, ShowColors, StmtColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::Stmt);
       OS << Target->getStmtClassName();
     }
     dumpPointer(Target);
@@ -1522,7 +1522,7 @@ void TextNodeDumper::VisitCXXOperatorCallExpr(const CXXOperatorCallExpr *Node) {
 void TextNodeDumper::VisitCastExpr(const CastExpr *Node) {
   OS << " <";
   {
-    ColorScope Color(OS, ShowColors, CastColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Cast);
     OS << Node->getCastKindName();
   }
   dumpBasePath(OS, Node);
@@ -1584,7 +1584,7 @@ void TextNodeDumper::VisitUnresolvedLookupExpr(
 
 void TextNodeDumper::VisitObjCIvarRefExpr(const ObjCIvarRefExpr *Node) {
   {
-    ColorScope Color(OS, ShowColors, DeclKindNameColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::DeclKindName);
     OS << " " << Node->getDecl()->getDeclKindName() << "Decl";
   }
   OS << "='" << *Node->getDecl() << "'";
@@ -1603,28 +1603,28 @@ void TextNodeDumper::VisitPredefinedExpr(const PredefinedExpr *Node) {
 }
 
 void TextNodeDumper::VisitCharacterLiteral(const CharacterLiteral *Node) {
-  ColorScope Color(OS, ShowColors, ValueColor);
+  ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
   OS << " " << Node->getValue();
 }
 
 void TextNodeDumper::VisitIntegerLiteral(const IntegerLiteral *Node) {
   bool isSigned = Node->getType()->isSignedIntegerType();
-  ColorScope Color(OS, ShowColors, ValueColor);
+  ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
   OS << " " << toString(Node->getValue(), 10, isSigned);
 }
 
 void TextNodeDumper::VisitFixedPointLiteral(const FixedPointLiteral *Node) {
-  ColorScope Color(OS, ShowColors, ValueColor);
+  ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
   OS << " " << Node->getValueAsString(/*Radix=*/10);
 }
 
 void TextNodeDumper::VisitFloatingLiteral(const FloatingLiteral *Node) {
-  ColorScope Color(OS, ShowColors, ValueColor);
+  ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
   OS << " " << Node->getValueAsApproximateDouble();
 }
 
 void TextNodeDumper::VisitStringLiteral(const StringLiteral *Str) {
-  ColorScope Color(OS, ShowColors, ValueColor);
+  ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
   OS << " ";
   Str->outputString(OS);
 }
@@ -2411,7 +2411,7 @@ void TextNodeDumper::VisitLifetimeExtendedTemporaryDecl(
   dumpBareDeclRef(D->getExtendingDecl());
   OS << " mangling ";
   {
-    ColorScope Color(OS, ShowColors, ValueColor);
+    ColorScope Color(OS, ShowColors, ASTDumpColor::Value);
     OS << D->getManglingNumber();
   }
 }
@@ -2573,12 +2573,12 @@ void TextNodeDumper::VisitOMPRequiresDecl(const OMPRequiresDecl *D) {
   for (const auto *C : D->clauselists()) {
     AddChild([=] {
       if (!C) {
-        ColorScope Color(OS, ShowColors, NullColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::Null);
         OS << "<<<NULL>>> OMPClause";
         return;
       }
       {
-        ColorScope Color(OS, ShowColors, AttrColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::Attr);
         StringRef ClauseName(
             llvm::omp::getOpenMPClauseName(C->getClauseKind()));
         OS << "OMP" << ClauseName.substr(/*Start=*/0, /*N=*/1).upper()
@@ -2644,7 +2644,7 @@ void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
 
   AddChild([=] {
     {
-      ColorScope Color(OS, ShowColors, DeclKindNameColor);
+      ColorScope Color(OS, ShowColors, ASTDumpColor::DeclKindName);
       OS << "DefinitionData";
     }
 #define FLAG(fn, name)                                                         \
@@ -2675,7 +2675,7 @@ void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
 
     AddChild([=] {
       {
-        ColorScope Color(OS, ShowColors, DeclKindNameColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::DeclKindName);
         OS << "DefaultConstructor";
       }
       FLAG(hasDefaultConstructor, exists);
@@ -2689,7 +2689,7 @@ void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
 
     AddChild([=] {
       {
-        ColorScope Color(OS, ShowColors, DeclKindNameColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::DeclKindName);
         OS << "CopyConstructor";
       }
       FLAG(hasSimpleCopyConstructor, simple);
@@ -2707,7 +2707,7 @@ void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
 
     AddChild([=] {
       {
-        ColorScope Color(OS, ShowColors, DeclKindNameColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::DeclKindName);
         OS << "MoveConstructor";
       }
       FLAG(hasMoveConstructor, exists);
@@ -2724,7 +2724,7 @@ void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
 
     AddChild([=] {
       {
-        ColorScope Color(OS, ShowColors, DeclKindNameColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::DeclKindName);
         OS << "CopyAssignment";
       }
       FLAG(hasSimpleCopyAssignment, simple);
@@ -2739,7 +2739,7 @@ void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
 
     AddChild([=] {
       {
-        ColorScope Color(OS, ShowColors, DeclKindNameColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::DeclKindName);
         OS << "MoveAssignment";
       }
       FLAG(hasMoveAssignment, exists);
@@ -2753,7 +2753,7 @@ void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
 
     AddChild([=] {
       {
-        ColorScope Color(OS, ShowColors, DeclKindNameColor);
+        ColorScope Color(OS, ShowColors, ASTDumpColor::DeclKindName);
         OS << "Destructor";
       }
       FLAG(hasSimpleDestructor, simple);


### PR DESCRIPTION
Preparatory work for Clang AST PCH, which will include ASTDumperUtils.h. Polluting the clang namespace with colors would lead to a collision with clang/lib/Frontend/TextDiagnostic.cpp.