### PR TITLE
[LoopFusion] clear FusionCandidates more often

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopFuse.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFuse.cpp
@@ -545,6 +545,7 @@ public:
 
         collectFusionCandidates(LV);
         Changed |= fuseCandidates();
+        FusionCandidates.clear();
       }
 
       // Finished analyzing candidates at this level.
@@ -555,7 +556,6 @@ public:
       // with all of the candidates collected so far.
       LLVM_DEBUG(dbgs() << "Descend one level!\n");
       LDT.descend();
-      FusionCandidates.clear();
     }
 
     if (Changed)


### PR DESCRIPTION
A LoopVector contains all the loops with the same parent loop (or all loops with no parent). Once loop fusion is done with the transformation for candidates extracted from one LoopVector we can safely clear FusionCandidates. This avoids unnecssary work and results in more meaningful statistics.