### PR TITLE
[NFC][analyzer] Remove NodeBuilders: part I

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CoreEngine.h
@@ -184,7 +184,8 @@ public:
 
   /// Enqueue nodes that were created as a result of processing
   /// a statement onto the work list.
-  void enqueue(ExplodedNodeSet &Set, const CFGBlock *Block, unsigned Idx);
+  void enqueueStmtNodes(ExplodedNodeSet &Set, const CFGBlock *Block,
+                        unsigned Idx);
 
   /// enqueue the nodes corresponding to the end of function onto the
   /// end of path / work list.

--- a/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CoreEngine.cpp
@@ -688,8 +688,8 @@ void CoreEngine::enqueue(ExplodedNodeSet &Set) {
     WList->enqueue(I);
 }
 
-void CoreEngine::enqueue(ExplodedNodeSet &Set,
-                         const CFGBlock *Block, unsigned Idx) {
+void CoreEngine::enqueueStmtNodes(ExplodedNodeSet &Set, const CFGBlock *Block,
+                                  unsigned Idx) {
   for (const auto I : Set)
     enqueueStmtNode(I, Block, Idx);
 }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1144,7 +1144,7 @@ void ExprEngine::ProcessStmt(const Stmt *currStmt, ExplodedNode *Pred) {
   }
 
   // Enqueue the new nodes onto the work list.
-  Engine.enqueue(Dst, currBldrCtx->getBlock(), currStmtIdx);
+  Engine.enqueueStmtNodes(Dst, currBldrCtx->getBlock(), currStmtIdx);
 }
 
 void ExprEngine::ProcessLoopExit(const Stmt* S, ExplodedNode *Pred) {
@@ -1162,7 +1162,7 @@ void ExprEngine::ProcessLoopExit(const Stmt* S, ExplodedNode *Pred) {
   LoopExit PP(S, Pred->getLocationContext());
   Bldr.generateNode(PP, NewState, Pred);
   // Enqueue the new nodes onto the work list.
-  Engine.enqueue(Dst, currBldrCtx->getBlock(), currStmtIdx);
+  Engine.enqueueStmtNodes(Dst, currBldrCtx->getBlock(), currStmtIdx);
 }
 
 void ExprEngine::ProcessInitializer(const CFGInitializer CFGInit,
@@ -1255,7 +1255,7 @@ void ExprEngine::ProcessInitializer(const CFGInitializer CFGInit,
   }
 
   // Enqueue the new nodes onto the work list.
-  Engine.enqueue(Dst, currBldrCtx->getBlock(), currStmtIdx);
+  Engine.enqueueStmtNodes(Dst, currBldrCtx->getBlock(), currStmtIdx);
 }
 
 std::pair<ProgramStateRef, uint64_t>
@@ -1319,7 +1319,7 @@ void ExprEngine::ProcessImplicitDtor(const CFGImplicitDtor D,
   }
 
   // Enqueue the new nodes onto the work list.
-  Engine.enqueue(Dst, currBldrCtx->getBlock(), currStmtIdx);
+  Engine.enqueueStmtNodes(Dst, currBldrCtx->getBlock(), currStmtIdx);
 }
 
 void ExprEngine::ProcessNewAllocator(const CXXNewExpr *NE,
@@ -1339,7 +1339,7 @@ void ExprEngine::ProcessNewAllocator(const CXXNewExpr *NE,
                         getCFGElementRef());
     Bldr.generateNode(PP, Pred->getState(), Pred);
   }
-  Engine.enqueue(Dst, currBldrCtx->getBlock(), currStmtIdx);
+  Engine.enqueueStmtNodes(Dst, currBldrCtx->getBlock(), currStmtIdx);
 }
 
 void ExprEngine::ProcessAutomaticObjDtor(const CFGAutomaticObjDtor Dtor,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1190,9 +1190,8 @@ void ExprEngine::ProcessInitializer(const CFGInitializer CFGInit,
       // The field was directly constructed, so there is no need to bind.
       // But we still need to stop tracking the object under construction.
       State = finishObjectConstruction(State, BMI, LC);
-      NodeBuilder Bldr(Pred, Tmp, *currBldrCtx);
       PostStore PS(Init, LC, /*Loc*/ nullptr, /*tag*/ nullptr);
-      Bldr.generateNode(PS, State, Pred);
+      Tmp.Add(Engine.makeNode(PS, State, Pred));
     } else {
       const ValueDecl *Field;
       if (BMI->isIndirectMemberInitializer()) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1327,11 +1327,10 @@ void ExprEngine::ProcessNewAllocator(const CXXNewExpr *NE,
   if (Opts.MayInlineCXXAllocator)
     VisitCXXNewAllocatorCall(NE, Pred, Dst);
   else {
-    NodeBuilder Bldr(Pred, Dst, *currBldrCtx);
     const LocationContext *LCtx = Pred->getLocationContext();
     PostImplicitCall PP(NE->getOperatorNew(), NE->getBeginLoc(), LCtx,
                         getCFGElementRef());
-    Bldr.generateNode(PP, Pred->getState(), Pred);
+    Dst.Add(Engine.makeNode(PP, Pred->getState(), Pred));
   }
   Engine.enqueueStmtNodes(Dst, currBldrCtx->getBlock(), currStmtIdx);
 }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1151,18 +1151,15 @@ void ExprEngine::ProcessLoopExit(const Stmt* S, ExplodedNode *Pred) {
   PrettyStackTraceLoc CrashInfo(getContext().getSourceManager(),
                                 S->getBeginLoc(),
                                 "Error evaluating end of the loop");
-  ExplodedNodeSet Dst;
-  Dst.Add(Pred);
-  NodeBuilder Bldr(Pred, Dst, *currBldrCtx);
   ProgramStateRef NewState = Pred->getState();
 
   if(AMgr.options.ShouldUnrollLoops)
     NewState = processLoopEnd(S, NewState);
 
   LoopExit PP(S, Pred->getLocationContext());
-  Bldr.generateNode(PP, NewState, Pred);
-  // Enqueue the new nodes onto the work list.
-  Engine.enqueueStmtNodes(Dst, currBldrCtx->getBlock(), currStmtIdx);
+  ExplodedNode *N = Engine.makeNode(PP, NewState, Pred);
+  if (N && !N->isSink())
+    Engine.enqueueStmtNode(N, currBldrCtx->getBlock(), currStmtIdx);
 }
 
 void ExprEngine::ProcessInitializer(const CFGInitializer CFGInit,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1245,9 +1245,8 @@ void ExprEngine::ProcessInitializer(const CFGInitializer CFGInit,
   PostInitializer PP(BMI, FieldLoc.getAsRegion(), stackFrame);
 
   ExplodedNodeSet Dst;
-  for (ExplodedNode *Pred : Tmp) {
+  for (ExplodedNode *Pred : Tmp)
     Dst.Add(Engine.makeNode(PP, Pred->getState(), Pred));
-  }
   // Enqueue the new nodes onto the work list.
   Engine.enqueueStmtNodes(Dst, currBldrCtx->getBlock(), currStmtIdx);
 }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1244,13 +1244,11 @@ void ExprEngine::ProcessInitializer(const CFGInitializer CFGInit,
   // Construct PostInitializer nodes whether the state changed or not,
   // so that the diagnostics don't get confused.
   PostInitializer PP(BMI, FieldLoc.getAsRegion(), stackFrame);
-  ExplodedNodeSet Dst;
-  NodeBuilder Bldr(Tmp, Dst, *currBldrCtx);
-  for (const auto I : Tmp) {
-    ProgramStateRef State = I->getState();
-    Bldr.generateNode(PP, State, I);
-  }
 
+  ExplodedNodeSet Dst;
+  for (ExplodedNode *Pred : Tmp) {
+    Dst.Add(Engine.makeNode(PP, Pred->getState(), Pred));
+  }
   // Enqueue the new nodes onto the work list.
   Engine.enqueueStmtNodes(Dst, currBldrCtx->getBlock(), currStmtIdx);
 }


### PR DESCRIPTION
This commit simplifies some parts of the engine by replacing short-lived `NodeBuilder`s with `CoreEngine::makeNode`.

Additionally, the three-argument overload of `CoreEngine::enqueue` is renamed to `enqueueStmtNodes` to highlight that it just calls `enqueueStmtNode` in a loop.

----

Note for reviewers: The verbose commit messages of the individual commits explain why are they all NFCs -- I mostly wrote these to convince myself that my reasoning is correct.

As my time permits, I intend to push several similar PRs in the future.