### PR TITLE
[CMake][AST] Add PCH

### DIFF
--- a/clang/include/clang/AST/pch.h
+++ b/clang/include/clang/AST/pch.h
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Precompiled header for clangAST.
+///
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/CanonicalType.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclObjC.h"
+#include "clang/AST/DeclOpenMP.h"
+#include "clang/AST/DeclTemplate.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
+#include "clang/AST/ExprObjC.h"
+#include "clang/AST/GlobalDecl.h"
+#include "clang/AST/OpenMPClause.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
+#include "clang/AST/StmtOpenMP.h"
+#include "clang/AST/StmtVisitor.h"
+#include "clang/AST/Type.h"
+#include "llvm/Support/pch.h"

--- a/clang/lib/AST/CMakeLists.txt
+++ b/clang/lib/AST/CMakeLists.txt
@@ -136,6 +136,9 @@ add_clang_library(clangAST
   VTableBuilder.cpp
   VTTBuilder.cpp
 
+  PRECOMPILE_HEADERS
+  [["clang/AST/pch.h"]]
+
   LINK_LIBS
   clangBasic
   clangLex


### PR DESCRIPTION
Add frequently used expensive headers from clang/AST to a PCH.

Results in a 13% stage2-clang build time improvement ([c-t-t](https://llvm-compile-time-tracker.com/compare.php?from=dc977924608276e4360b943a65c465b5afdacade&to=adce08d27de4260f2d25b2bb8780b7dabf419284&stat=instructions:u), [per-file](https://llvm-compile-time-tracker.com/compare_clang.php?from=dc977924608276e4360b943a65c465b5afdacade&to=adce08d27de4260f2d25b2bb8780b7dabf419284&stat=instructions%3Au&sortBy=absolute-difference)).