### PR TITLE
[RISCV] Treat zext.h as a separate instruction from pack(w) with Zbkb.

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -3905,6 +3905,26 @@ bool RISCVAsmParser::processInstruction(MCInst &Inst, SMLoc IDLoc,
           Out, MCInstBuilder(RISCV::C_NOP_HINT).addOperand(Inst.getOperand(2)));
     return false;
   }
+  case RISCV::PACK: {
+    // Convert PACK wth RS2==X0 to ZEXT_H_RV32 to match disassembler output.
+    if (Inst.getOperand(2).getReg() != RISCV::X0)
+      break;
+    if (getSTI().hasFeature(RISCV::Feature64Bit))
+      break;
+    emitToStreamer(Out, MCInstBuilder(RISCV::ZEXT_H_RV32)
+                            .addOperand(Inst.getOperand(0))
+                            .addOperand(Inst.getOperand(1)));
+    return false;
+  }
+  case RISCV::PACKW: {
+    // Convert PACKW with RS2==X0 to ZEXT_H_RV64 to match disassembler output.
+    if (Inst.getOperand(2).getReg() != RISCV::X0)
+      break;
+    emitToStreamer(Out, MCInstBuilder(RISCV::ZEXT_H_RV64)
+                            .addOperand(Inst.getOperand(0))
+                            .addOperand(Inst.getOperand(1)));
+    return false;
+  }
   case RISCV::PseudoLLAImm:
   case RISCV::PseudoLAImm:
   case RISCV::PseudoLI: {

--- a/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
@@ -1181,18 +1181,11 @@ bool RISCVInstructionSelector::select(MachineInstr &MI) {
     }
 
     // Use sext.h/zext.h for i16 with Zbb.
-    if (SrcSize == 16 && STI.hasStdExtZbb()) {
+    if (SrcSize == 16 &&
+        (STI.hasStdExtZbb() || (!IsSigned && STI.hasStdExtZbkb()))) {
       MI.setDesc(TII.get(IsSigned       ? RISCV::SEXT_H
                          : STI.isRV64() ? RISCV::ZEXT_H_RV64
                                         : RISCV::ZEXT_H_RV32));
-      constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
-      return true;
-    }
-
-    // Use pack(w) SrcReg, X0 for i16 zext with Zbkb.
-    if (!IsSigned && SrcSize == 16 && STI.hasStdExtZbkb()) {
-      MI.setDesc(TII.get(STI.is64Bit() ? RISCV::PACKW : RISCV::PACK));
-      MI.addOperand(MachineOperand::CreateReg(RISCV::X0, /*isDef=*/false));
       constrainSelectedInstRegOperands(MI, TII, TRI, RBI);
       return true;
     }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
@@ -409,12 +409,12 @@ def PACKW  : ALUW_rr<0b0000100, 0b100, "packw">,
 let Predicates = [HasStdExtZbbOrZbkb, IsRV32] in {
 def ZEXT_H_RV32 : RVBUnaryR<0b0000100, 0b100, OPC_OP, "zext.h">,
                   Sched<[WriteIALU, ReadIALU]>;
-} // Predicates = [HasStdExtZbb, IsRV32]
+} // Predicates = [HasStdExtZbbOrZbkb, IsRV32]
 
 let Predicates = [HasStdExtZbbOrZbkb, IsRV64], IsSignExtendingOpW = 1 in {
 def ZEXT_H_RV64 : RVBUnaryR<0b0000100, 0b100, OPC_OP_32, "zext.h">,
                   Sched<[WriteIALU, ReadIALU]>;
-} // Predicates = [HasStdExtZbb, IsRV64]
+} // Predicates = [HasStdExtZbbOrZbkb, IsRV64]
 
 let Predicates = [HasStdExtZbbOrZbkb, IsRV32] in {
 def REV8_RV32 : Unary_r<0b011010011000, 0b101, "rev8">,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
@@ -406,12 +406,12 @@ let Predicates = [HasStdExtZbkb, IsRV64], IsSignExtendingOpW = 1 in
 def PACKW  : ALUW_rr<0b0000100, 0b100, "packw">,
              Sched<[WritePACK32, ReadPACK32, ReadPACK32]>;
 
-let Predicates = [HasStdExtZbb, IsRV32] in {
+let Predicates = [HasStdExtZbbOrZbkb, IsRV32] in {
 def ZEXT_H_RV32 : RVBUnaryR<0b0000100, 0b100, OPC_OP, "zext.h">,
                   Sched<[WriteIALU, ReadIALU]>;
 } // Predicates = [HasStdExtZbb, IsRV32]
 
-let Predicates = [HasStdExtZbb, IsRV64], IsSignExtendingOpW = 1 in {
+let Predicates = [HasStdExtZbbOrZbkb, IsRV64], IsSignExtendingOpW = 1 in {
 def ZEXT_H_RV64 : RVBUnaryR<0b0000100, 0b100, OPC_OP_32, "zext.h">,
                   Sched<[WriteIALU, ReadIALU]>;
 } // Predicates = [HasStdExtZbb, IsRV64]
@@ -471,14 +471,6 @@ def : InstAlias<"binv $rd, $rs1, $shamt",
 def : InstAlias<"bext $rd, $rs1, $shamt",
                 (BEXTI GPR:$rd, GPR:$rs1, uimmlog2xlen:$shamt), 0>;
 } // Predicates = [HasStdExtZbs]
-
-let Predicates = [HasStdExtZbkbOrP, NoStdExtZbb, IsRV32] in {
-def : InstAlias<"zext.h $rd, $rs", (PACK GPR:$rd, GPR:$rs, X0)>;
-} // Predicates = [HasStdExtZbkbOrP, NoStdExtZbb, IsRV32]
-
-let Predicates = [HasStdExtZbkb, NoStdExtZbb, IsRV64] in {
-def : InstAlias<"zext.h $rd, $rs", (PACKW GPR:$rd, GPR:$rs, X0)>;
-} // Predicates = [HasStdExtZbkb, NoStdExtZbb, IsRV64]
 
 //===----------------------------------------------------------------------===//
 // Codegen patterns
@@ -721,15 +713,10 @@ def : Pat<(or (or (shl GPR:$op1rs2, (i64 48)),
                 (XLenVT (PACKW zexti16:$op1rs1, GPR:$op1rs2)))>;
 } // Predicates = [HasStdExtZbkb, IsRV64]
 
-let Predicates = [HasStdExtZbb, IsRV32] in
+let Predicates = [HasStdExtZbbOrZbkb, IsRV32] in
 def : Pat<(i32 (and GPR:$rs, 0xFFFF)), (ZEXT_H_RV32 GPR:$rs)>;
-let Predicates = [HasStdExtZbb, IsRV64] in
+let Predicates = [HasStdExtZbbOrZbkb, IsRV64] in
 def : Pat<(i64 (and GPR:$rs, 0xFFFF)), (ZEXT_H_RV64 GPR:$rs)>;
-
-let Predicates = [HasStdExtZbkb, NoStdExtZbb, IsRV32] in
-def : Pat<(i32 (and GPR:$rs, 0xFFFF)), (PACK GPR:$rs, (XLenVT X0))>;
-let Predicates = [HasStdExtZbkb, NoStdExtZbb, IsRV64] in
-def : Pat<(i64 (and GPR:$rs, 0xFFFF)), (PACKW GPR:$rs, (XLenVT X0))>;
 
 multiclass ShxAddPat<int i, Instruction shxadd> {
   def : Pat<(XLenVT (add_like_non_imm12 (shl GPR:$rs1, (XLenVT i)), GPR:$rs2)),

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
@@ -965,14 +965,14 @@ bool RISCVRegisterInfo::getRegAllocationHints(
     case RISCV::ADDIW:
       return MI.getOperand(2).isImm() && isInt<6>(MI.getOperand(2).getImm());
     case RISCV::MUL:
-      // c.mul, c.sext.b, c.sext.h, c.zext.h
+      // c.mul
       NeedGPRC = true;
       return Subtarget.hasStdExtZcb();
     case RISCV::SEXT_B:
     case RISCV::SEXT_H:
     case RISCV::ZEXT_H_RV32:
     case RISCV::ZEXT_H_RV64:
-      // c.mul, c.sext.b, c.sext.h, c.zext.h
+      // c.sext.b, c.sext.h, c.zext.h
       NeedGPRC = true;
       return Subtarget.hasStdExtZcb() && Subtarget.hasStdExtZbb();
     case RISCV::ADD_UW:

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
@@ -965,13 +965,16 @@ bool RISCVRegisterInfo::getRegAllocationHints(
     case RISCV::ADDIW:
       return MI.getOperand(2).isImm() && isInt<6>(MI.getOperand(2).getImm());
     case RISCV::MUL:
+      // c.mul, c.sext.b, c.sext.h, c.zext.h
+      NeedGPRC = true;
+      return Subtarget.hasStdExtZcb();
     case RISCV::SEXT_B:
     case RISCV::SEXT_H:
     case RISCV::ZEXT_H_RV32:
     case RISCV::ZEXT_H_RV64:
       // c.mul, c.sext.b, c.sext.h, c.zext.h
       NeedGPRC = true;
-      return Subtarget.hasStdExtZcb();
+      return Subtarget.hasStdExtZcb() && Subtarget.hasStdExtZbb();
     case RISCV::ADD_UW:
       // c.zext.w
       NeedGPRC = true;

--- a/llvm/test/MC/RISCV/rv32p-valid.s
+++ b/llvm/test/MC/RISCV/rv32p-valid.s
@@ -2,7 +2,7 @@
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
 # RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+experimental-p < %s \
 # RUN:     | llvm-objdump --mattr=+experimental-p -d -r --no-print-imm-hex - \
-# RUN:     | FileCheck --check-prefixes=CHECK-OBJ,CHECK-ASM-AND-OBJ %s
+# RUN:     | FileCheck --check-prefixes=CHECK-ASM-AND-OBJ %s
 
 # CHECK-ASM-AND-OBJ: cls a1, a2
 # CHECK-ASM: encoding: [0x93,0x15,0x36,0x60]
@@ -16,8 +16,7 @@ rev s2, s3
 # CHECK-ASM-AND-OBJ: pack s0, s1, s2
 # CHECK-ASM: encoding: [0x33,0xc4,0x24,0x09]
 pack s0, s1, s2
-# CHECK-ASM: pack t0, t1, zero
-# CHECK-OBJ: zext.h t0, t1
+# CHECK-ASM-AND-OBJ: zext.h t0, t1
 # CHECK-ASM: encoding: [0xb3,0x42,0x03,0x08]
 pack t0, t1, x0
 # CHECK-ASM-AND-OBJ: zext.h t0, t1

--- a/llvm/test/MC/RISCV/rv32zcb-zbkb-valid.s
+++ b/llvm/test/MC/RISCV/rv32zcb-zbkb-valid.s
@@ -1,0 +1,11 @@
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+zbb,+zbkb,+zcb -M no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+zbb,+zbkb,+zcb < %s \
+# RUN:     | llvm-objdump --mattr=+zbb,+zbkb,+zcb --no-print-imm-hex -M no-aliases -d -r - \
+# RUN:     | FileCheck --check-prefixes=CHECK-ASM-AND-OBJ %s
+
+# Make sure pack spelling of zext.h compresses when Zbb is enabled.
+
+# CHECK-ASM-AND-OBJ: c.zext.h s0
+# CHECK-ASM: encoding: [0x69,0x9c]
+pack s0, s0, zero

--- a/llvm/test/MC/RISCV/rv64zcb-zbkb-valid.s
+++ b/llvm/test/MC/RISCV/rv64zcb-zbkb-valid.s
@@ -1,0 +1,11 @@
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+zbb,+zbkb,+zcb -M no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+zbb,+zbkb,+zcb < %s \
+# RUN:     | llvm-objdump --mattr=+zbb,+zbkb,+zcb --no-print-imm-hex -M no-aliases -d -r - \
+# RUN:     | FileCheck --check-prefixes=CHECK-ASM-AND-OBJ %s
+
+# Make sure packw spelling of zext.h compresses when Zbb is enabled.
+
+# CHECK-ASM-AND-OBJ: c.zext.h s0
+# CHECK-ASM: encoding: [0x69,0x9c]
+packw s0, s0, zero


### PR DESCRIPTION
The Zbb encoding for zext.h is a subset of the encoding for pack(w).

There is a statement in the ISA manual that says "For RV32, the pack instruction with rs2=x0 is the zext.h instruction. Hence, for RV32, any extension that contains the pack instruction also contains the zext.h instruction"

This patch makes the zext.h instruction mnemonic canonical when only Zbkb is enabled. -Mno-aliases will not disable the printing of zext.h. I believe this matches binutils.

I've taught the assembler to remap PACK/PACKW to ZEXT_H to make printing parsed assembly match the disassembler output.