### PR TITLE
[lldb][windows] fix VT sequences overriding (lldb) prompt

### DIFF
--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -101,6 +101,11 @@ llvm::Error PseudoConsole::OpenPseudoConsole() {
         std::error_code(GetLastError(), std::system_category()));
 
   COORD consoleSize{80, 25};
+  CONSOLE_SCREEN_BUFFER_INFO csbi;
+  if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi))
+    consoleSize = {
+        static_cast<SHORT>(csbi.srWindow.Right - csbi.srWindow.Left + 1),
+        static_cast<SHORT>(csbi.srWindow.Bottom - csbi.srWindow.Top + 1)};
   HPCON hPC = INVALID_HANDLE_VALUE;
   hr = kernel32.CreatePseudoConsole(consoleSize, hInputRead, hOutputWrite, 0,
                                     &hPC);


### PR DESCRIPTION
This patch fixes the `(lldb)` prompt being overwriten by the cursor position movements the ConPTY emits.

To be a complete solution we should also add a resize hook for the console's window.

I also think that we should look into injecting conpty VT sequences before printing the `(lldb)` prompt.
For instance, if we break on a breakpoint and the pty added a "hide cursor" VT sequence, we should emit a `show cursor` sequence before printing `(lldb)`. This should be done outside of this PR however.