### PR TITLE
[flang-rt] Get rid of cyclic call chain in ChildIo.

### DIFF
--- a/flang-rt/include/flang-rt/runtime/memory.h
+++ b/flang-rt/include/flang-rt/runtime/memory.h
@@ -110,28 +110,8 @@ public:
 
 private:
   RT_API_ATTRS void delete_ptr(pointer_type p) {
-#if RT_USE_LIBCUDACXX && defined(RT_DEVICE_COMPILATION)
-    // FIXME: Calling the destructor here introduces an SCC call chain
-    // like this:
-    //
-    // |------------|
-    // |            V
-    // |    ChildIo::~ChildIo()
-    // |            |
-    // |            V
-    // | -> OwningPtr<Fortran::runtime::io::ChildIo>::~OwningPtr()
-    // |            |
-    // |            V
-    // | OwningPtr<Fortran::runtime::io::ChildIo>::delete_ptr(
-    // |   Fortran::runtime::io::ChildIo*)
-    // |____________|
-    //
-    // This prevents computing static stack size in CUDA kernels.
-    // This code is temporarily disabled for RT_USE_LIBCUDACXX builds
-    // on the device.
-#else
+    //    static_assert(std::is_trivially_destructible_v<A>);
     p->~A();
-#endif
     FreeMemory(p);
   }
   pointer_type ptr_{};

--- a/flang-rt/include/flang-rt/runtime/memory.h
+++ b/flang-rt/include/flang-rt/runtime/memory.h
@@ -110,7 +110,6 @@ public:
 
 private:
   RT_API_ATTRS void delete_ptr(pointer_type p) {
-    //    static_assert(std::is_trivially_destructible_v<A>);
     p->~A();
     FreeMemory(p);
   }

--- a/flang-rt/lib/runtime/unit.cpp
+++ b/flang-rt/lib/runtime/unit.cpp
@@ -826,20 +826,21 @@ void ExternalFileUnit::HitEndOnRead(IoErrorHandler &handler) {
 }
 
 ChildIo &ExternalFileUnit::PushChildIo(IoStatementState &parent) {
-  OwningPtr<ChildIo> current{std::move(child_)};
+  ChildIo *current{child_};
   Terminator &terminator{parent.GetIoErrorHandler()};
-  OwningPtr<ChildIo> next{New<ChildIo>{terminator}(parent, std::move(current))};
-  child_.reset(next.release());
+  child_ = new (AllocateMemoryOrCrash(terminator, sizeof(ChildIo)))
+      ChildIo{parent, current};
   leftTabLimit = positionInRecord;
   return *child_;
 }
 
 void ExternalFileUnit::PopChildIo(ChildIo &child) {
-  if (child_.get() != &child) {
+  if (child_ != &child) {
     child.parent().GetIoErrorHandler().Crash(
         "ChildIo being popped is not top of stack");
   }
-  child_.reset(child.AcquirePrevious().release()); // deletes top child
+  child_->~ChildIo(); // delete top child
+  child_ = child.AcquirePrevious();
 }
 
 std::uint32_t ExternalFileUnit::ReadHeaderOrFooter(std::int64_t frameOffset) {

--- a/flang-rt/lib/runtime/unit.cpp
+++ b/flang-rt/lib/runtime/unit.cpp
@@ -835,12 +835,14 @@ ChildIo &ExternalFileUnit::PushChildIo(IoStatementState &parent) {
 }
 
 void ExternalFileUnit::PopChildIo(ChildIo &child) {
+  ChildIo previous = child.AcquirePrevious();
   if (child_ != &child) {
     child.parent().GetIoErrorHandler().Crash(
         "ChildIo being popped is not top of stack");
   }
   child_->~ChildIo(); // delete top child
-  child_ = child.AcquirePrevious();
+  FreeMemory(child_);
+  child_ = previous;
 }
 
 std::uint32_t ExternalFileUnit::ReadHeaderOrFooter(std::int64_t frameOffset) {

--- a/flang-rt/lib/runtime/unit.cpp
+++ b/flang-rt/lib/runtime/unit.cpp
@@ -835,7 +835,7 @@ ChildIo &ExternalFileUnit::PushChildIo(IoStatementState &parent) {
 }
 
 void ExternalFileUnit::PopChildIo(ChildIo &child) {
-  ChildIo previous = child.AcquirePrevious();
+  ChildIo *previous = child.AcquirePrevious();
   if (child_ != &child) {
     child.parent().GetIoErrorHandler().Crash(
         "ChildIo being popped is not top of stack");

--- a/flang-rt/lib/runtime/unit.h
+++ b/flang-rt/lib/runtime/unit.h
@@ -195,7 +195,7 @@ public:
     return frameOffsetInFile_ + recordOffsetInFrame_ + positionInRecord + 1;
   }
 
-  RT_API_ATTRS ChildIo *GetChildIo() { return child_.get(); }
+  RT_API_ATTRS ChildIo *GetChildIo() { return child_; }
   RT_API_ATTRS ChildIo &PushChildIo(IoStatementState &);
   RT_API_ATTRS void PopChildIo(ChildIo &);
 
@@ -262,7 +262,7 @@ private:
 
   // A stack of child I/O pseudo-units for defined I/O that have this
   // unit number.
-  OwningPtr<ChildIo> child_;
+  ChildIo *child_{nullptr};
 };
 
 // A pseudo-unit for child I/O statements in defined I/O subroutines;
@@ -270,8 +270,8 @@ private:
 // be a child I/O statement.
 class ChildIo {
 public:
-  RT_API_ATTRS ChildIo(IoStatementState &parent, OwningPtr<ChildIo> &&previous)
-      : parent_{parent}, previous_{std::move(previous)} {}
+  RT_API_ATTRS ChildIo(IoStatementState &parent, ChildIo *previous)
+      : parent_{parent}, previous_{previous} {}
 
   RT_API_ATTRS IoStatementState &parent() const { return parent_; }
 
@@ -284,15 +284,13 @@ public:
     return *io_;
   }
 
-  RT_API_ATTRS OwningPtr<ChildIo> AcquirePrevious() {
-    return std::move(previous_);
-  }
+  RT_API_ATTRS ChildIo *AcquirePrevious() { return previous_; }
 
   RT_API_ATTRS Iostat CheckFormattingAndDirection(bool unformatted, Direction);
 
 private:
   IoStatementState &parent_;
-  OwningPtr<ChildIo> previous_;
+  ChildIo *previous_;
   std::variant<std::monostate,
       ChildFormattedIoStatementState<Direction::Output>,
       ChildFormattedIoStatementState<Direction::Input>,


### PR DESCRIPTION
This is a follow up on #182635

It was suggested to place `static_assert(std::is_trivially_destructible_c<A>)`
for the `OwningPtr` class. This cannot be done, because there are non-trivially
destructible types used with `OwnerPtr` (e.g. lots of types that inherit from
`IoErrorHandler`, which is not trivially destructible).

This patch brings back the desctructor call into `OwningPtr::delete_ptr`
just to be on the safe side (though, I do not think we had any memory
leaks even without the destructor call), and removes the cyclic
dependency for the `~ChildIo()` caused by `previous_` member.
