### PR TITLE
[Clang][OpenMP][NFC] Extract the accelerator check into helper

### DIFF
--- a/clang/include/clang/Basic/OpenMPKinds.h
+++ b/clang/include/clang/Basic/OpenMPKinds.h
@@ -19,6 +19,10 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Frontend/OpenMP/OMPConstants.h"
 
+namespace llvm {
+class Triple;
+} // namespace llvm
+
 namespace clang {
 
 /// OpenMP directives.
@@ -491,7 +495,19 @@ bool isOpenMPCapturingDirective(OpenMPDirectiveKind DKind);
 /// otherwise - false.
 bool isOpenMPOrderConcurrentNestableDirective(OpenMPDirectiveKind DKind,
                                               const LangOptions &LangOpts);
-}
+
+/// Checks if the target is an OpenMP accelerator (NVPTX, AMDGPU or SPIRV).
+/// \param T Target triple.
+/// \param OpenMPOffloading True if OpenMP offloading is enabled.
+/// \param NVPTX True if NVPTX is allowed.
+/// \param AMDGPU True if AMDGPU is allowed.
+/// \param SPIRV True if SPIRV is allowed.
+/// \return true if the target is an allowed OpenMP accelerator, false
+/// otherwise.
+bool isOpenMPAccelerator(const llvm::Triple &T, bool OpenMPOffloading,
+                         bool NVPTX = true, bool AMDGPU = true,
+                         bool SPIRV = true);
+} // namespace clang
 
 template <>
 struct llvm::enum_iteration_traits<clang::OpenMPDefaultmapClauseKind> {

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -43,6 +43,7 @@
 #include "clang/Basic/Linkage.h"
 #include "clang/Basic/Module.h"
 #include "clang/Basic/NoSanitizeList.h"
+#include "clang/Basic/OpenMPKinds.h"
 #include "clang/Basic/PartialDiagnostic.h"
 #include "clang/Basic/Sanitizers.h"
 #include "clang/Basic/SourceLocation.h"
@@ -996,9 +997,10 @@ LinkageComputer::getLVForClassMember(const NamedDecl *D,
     // functions as the host-callable kernel functions are emitted at codegen.
     ASTContext &Context = D->getASTContext();
     if (Context.getLangOpts().OpenMP &&
-        Context.getLangOpts().OpenMPIsTargetDevice &&
-        ((Context.getTargetInfo().getTriple().isAMDGPU() ||
-          Context.getTargetInfo().getTriple().isNVPTX()) ||
+        (isOpenMPAccelerator(Context.getTargetInfo().getTriple(),
+                             Context.getLangOpts().OpenMPIsTargetDevice,
+                             /*NVPTX=*/true, /*AMDGPU=*/true,
+                             /*SPIRV=*/false) ||
          OMPDeclareTargetDeclAttr::isDeclareTargetDeclaration(MD)))
       LV.mergeVisibility(HiddenVisibility, /*newExplicit=*/false);
 

--- a/clang/lib/Basic/OpenMPKinds.cpp
+++ b/clang/lib/Basic/OpenMPKinds.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/TargetParser/Triple.h"
 #include <cassert>
 
 using namespace clang;
@@ -1001,4 +1002,19 @@ bool clang::checkFailClauseParameter(OpenMPClauseKind FailClauseParameter) {
   return FailClauseParameter == llvm::omp::OMPC_acquire ||
          FailClauseParameter == llvm::omp::OMPC_relaxed ||
          FailClauseParameter == llvm::omp::OMPC_seq_cst;
+}
+
+bool clang::isOpenMPAccelerator(const llvm::Triple &T, bool OpenMPOffloading,
+                                bool NVPTX, bool AMDGPU, bool SPIRV) {
+  if (!OpenMPOffloading)
+    return false;
+
+  if (NVPTX && T.isNVPTX())
+    return true;
+  if (AMDGPU && T.isAMDGPU())
+    return true;
+  if (SPIRV && T.isSPIRV())
+    return true;
+
+  return false;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenException.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenException.cpp
@@ -13,6 +13,7 @@
 #include "CIRGenCXXABI.h"
 #include "CIRGenFunction.h"
 
+#include "clang/Basic/OpenMPKinds.h"
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/Support/SaveAndRestore.h"
 
@@ -198,8 +199,8 @@ static llvm::StringRef getPersonalityFn(CIRGenModule &cgm,
 
 void CIRGenFunction::emitCXXThrowExpr(const CXXThrowExpr *e) {
   const llvm::Triple &triple = getTarget().getTriple();
-  if (cgm.getLangOpts().OpenMPIsTargetDevice &&
-      (triple.isNVPTX() || triple.isAMDGCN())) {
+  if (isOpenMPAccelerator(triple, cgm.getLangOpts().OpenMPIsTargetDevice,
+                          /*NVPTX=*/true, /*AMDGPU=*/true, /*SPIRV=*/false)) {
     cgm.errorNYI("emitCXXThrowExpr OpenMP with NVPTX or AMDGCN Triples");
     return;
   }
@@ -293,7 +294,8 @@ CIRGenFunction::emitCXXTryStmtUnderScope(const CXXTryStmt &s) {
   // If we encounter a try statement on in an OpenMP target region offloaded to
   // a GPU, we treat it as a basic block.
   const bool isTargetDevice =
-      (cgm.getLangOpts().OpenMPIsTargetDevice && (t.isNVPTX() || t.isAMDGCN()));
+      isOpenMPAccelerator(t, cgm.getLangOpts().OpenMPIsTargetDevice,
+                          /*NVPTX=*/true, /*AMDGPU=*/true, /*SPIRV=*/false);
   if (isTargetDevice) {
     cgm.errorNYI(
         "emitCXXTryStmtUnderScope: OpenMP target region offloaded to GPU");

--- a/clang/lib/Lex/LiteralSupport.cpp
+++ b/clang/lib/Lex/LiteralSupport.cpp
@@ -14,6 +14,7 @@
 #include "clang/Lex/LiteralSupport.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/LangOptions.h"
+#include "clang/Basic/OpenMPKinds.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Lex/LexDiagnostic.h"
@@ -1019,7 +1020,9 @@ NumericLiteralParser::NumericLiteralParser(StringRef TokSpelling,
       // ToDo: more precise check for CUDA.
       // TODO: AMDGPU might also support it in the future.
       if ((Target.hasFloat16Type() || LangOpts.CUDA ||
-           (LangOpts.OpenMPIsTargetDevice && Target.getTriple().isNVPTX())) &&
+           isOpenMPAccelerator(Target.getTriple(),
+                               LangOpts.OpenMPIsTargetDevice, /*NVPTX=*/true,
+                               /*AMDGPU=*/false, /*SPIRV=*/false)) &&
           s + 2 < ThisTokEnd && s[1] == '1' && s[2] == '6') {
         s += 2; // success, eat up 2 characters.
         isFloat16 = true;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -35,6 +35,7 @@
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/DiagnosticSema.h"
+#include "clang/Basic/OpenMPKinds.h"
 #include "clang/Basic/PartialDiagnostic.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
@@ -16967,8 +16968,10 @@ ExprResult Sema::BuildVAArgExpr(SourceLocation BuiltinLoc,
   }
 
   // NVPTX does not support va_arg expression.
-  if (getLangOpts().OpenMP && getLangOpts().OpenMPIsTargetDevice &&
-      Context.getTargetInfo().getTriple().isNVPTX())
+  if (getLangOpts().OpenMP &&
+      isOpenMPAccelerator(Context.getTargetInfo().getTriple(),
+                          getLangOpts().OpenMPIsTargetDevice, /*NVPTX=*/true,
+                          /*AMDGPU=*/false, /*SPIRV=*/false))
     targetDiag(E->getBeginLoc(), diag::err_va_arg_in_device);
 
   // It might be a __builtin_ms_va_list. (But don't ever mark a va_arg()


### PR DESCRIPTION
It is much easier to add new accelerators and to check for inconsistencies if we have a helper function.