### PR TITLE
[lldb] Fix logic issue in TestDAP_stopped_events.py

### DIFF
--- a/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
+++ b/lldb/test/API/tools/lldb-dap/stopped-events/TestDAP_stopped_events.py
@@ -33,7 +33,7 @@ class TestDAP_stopped_events(lldbdap_testcase.DAPTestCaseBase):
         for idx, expected_thread in enumerate(expected_threads):
             thread = threads[idx]
             self.assertTrue(
-                self.is_subdict(thread, expected_thread),
+                self.is_subdict(expected_thread, thread),
                 f"Invalid thread state in {threads_resp}",
             )
 


### PR DESCRIPTION
The subset should actually be the expected data because the real thread data may have additional information.