### PR TITLE
[clang-tidy] Add misc-forbid-non-virtual-base-dtor check

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
@@ -23,6 +23,7 @@ add_clang_library(clangTidyMiscModule STATIC
   CoroutineHostileRAIICheck.cpp
   DefinitionsInHeadersCheck.cpp
   ConfusableIdentifierCheck.cpp
+  ForbidNonVirtualBaseDtorCheck.cpp
   HeaderIncludeCycleCheck.cpp
   IncludeCleanerCheck.cpp
   MiscTidyModule.cpp

--- a/clang-tools-extra/clang-tidy/misc/ForbidNonVirtualBaseDtorCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ForbidNonVirtualBaseDtorCheck.cpp
@@ -18,8 +18,16 @@ namespace clang::tidy::misc {
 
 void ForbidNonVirtualBaseDtorCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
-      cxxRecordDecl(isDefinition(),
-                    hasAnyBase(cxxBaseSpecifier().bind("BaseSpecifier")))
+      cxxRecordDecl(
+          isDefinition(), has(fieldDecl()),
+          hasAnyBase(
+              cxxBaseSpecifier(isPublic(),
+                               hasType(cxxRecordDecl(
+                                   isDefinition(),
+                                   unless(has(cxxDestructorDecl(isVirtual()))),
+                                   unless(has(cxxDestructorDecl(
+                                       isProtected(), unless(isVirtual())))))))
+                  .bind("base")))
           .bind("derived"),
       this);
 }
@@ -27,21 +35,12 @@ void ForbidNonVirtualBaseDtorCheck::registerMatchers(MatchFinder *Finder) {
 void ForbidNonVirtualBaseDtorCheck::check(
     const MatchFinder::MatchResult &Result) {
   const auto *Derived = Result.Nodes.getNodeAs<CXXRecordDecl>("derived");
-  const auto *BaseSpecifier =
-      Result.Nodes.getNodeAs<CXXBaseSpecifier>("BaseSpecifier");
-  if (!Derived || !BaseSpecifier)
+  const auto *Base = Result.Nodes.getNodeAs<CXXBaseSpecifier>("base");
+  if (!Derived || !Base)
     return;
-  if (BaseSpecifier->getAccessSpecifier() != AS_public)
-    return;
-  const auto *BaseType = BaseSpecifier->getType()->getAsCXXRecordDecl();
-  if (!BaseType || !BaseType->hasDefinition())
-    return;
-  const auto *Dtor = BaseType->getDestructor();
-  if (Dtor && Dtor->isVirtual())
-    return;
-  if (Dtor && Dtor->getAccess() == AS_protected && !Dtor->isVirtual())
-    return;
-  if (Derived->isEmpty())
+
+  const auto *BaseType = Base->getType()->getAsCXXRecordDecl();
+  if (!BaseType)
     return;
 
   diag(Derived->getLocation(),

--- a/clang-tools-extra/clang-tidy/misc/ForbidNonVirtualBaseDtorCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ForbidNonVirtualBaseDtorCheck.cpp
@@ -10,7 +10,6 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
-#include "clang/Basic/Specifiers.h"
 
 using namespace clang::ast_matchers;
 

--- a/clang-tools-extra/clang-tidy/misc/ForbidNonVirtualBaseDtorCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ForbidNonVirtualBaseDtorCheck.cpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ForbidNonVirtualBaseDtorCheck.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Basic/Specifiers.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::misc {
+
+void ForbidNonVirtualBaseDtorCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(
+      cxxRecordDecl(isDefinition(),
+                    hasAnyBase(cxxBaseSpecifier().bind("BaseSpecifier")))
+          .bind("derived"),
+      this);
+}
+
+void ForbidNonVirtualBaseDtorCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  const auto *Derived = Result.Nodes.getNodeAs<CXXRecordDecl>("derived");
+  const auto *BaseSpecifier =
+      Result.Nodes.getNodeAs<CXXBaseSpecifier>("BaseSpecifier");
+  if (!Derived || !BaseSpecifier)
+    return;
+  if (BaseSpecifier->getAccessSpecifier() != AS_public)
+    return;
+  const auto *BaseType = BaseSpecifier->getType()->getAsCXXRecordDecl();
+  if (!BaseType || !BaseType->hasDefinition())
+    return;
+  const auto *Dtor = BaseType->getDestructor();
+  if (Dtor && Dtor->isVirtual())
+    return;
+  if (Dtor && Dtor->getAccess() == AS_protected && !Dtor->isVirtual())
+    return;
+  if (Derived->isEmpty())
+    return;
+
+  diag(Derived->getLocation(),
+       "class '%0' inherits from '%1' which has a non-virtual destructor")
+      << Derived->getName() << BaseType->getName();
+}
+
+} // namespace clang::tidy::misc

--- a/clang-tools-extra/clang-tidy/misc/ForbidNonVirtualBaseDtorCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/ForbidNonVirtualBaseDtorCheck.h
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_FORBIDNONVIRTUALBASEDTORCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_FORBIDNONVIRTUALBASEDTORCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang::tidy::misc {
+
+/// Warns when a class or struct publicly inherits from a base class or struct
+/// whose destructor is neither virtual nor protected, and the derived class
+/// adds data members
+///
+/// For the user-facing documentation see:
+/// https://clang.llvm.org/extra/clang-tidy/checks/misc/forbid-non-virtual-base-dtor.html
+class ForbidNonVirtualBaseDtorCheck : public ClangTidyCheck {
+public:
+  ForbidNonVirtualBaseDtorCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
+};
+
+} // namespace clang::tidy::misc
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_FORBIDNONVIRTUALBASEDTORCHECK_H

--- a/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
@@ -13,6 +13,7 @@
 #include "ConstCorrectnessCheck.h"
 #include "CoroutineHostileRAIICheck.h"
 #include "DefinitionsInHeadersCheck.h"
+#include "ForbidNonVirtualBaseDtorCheck.h"
 #include "HeaderIncludeCycleCheck.h"
 #include "IncludeCleanerCheck.h"
 #include "MisleadingBidirectionalCheck.h"
@@ -53,6 +54,8 @@ public:
         "misc-coroutine-hostile-raii");
     CheckFactories.registerCheck<DefinitionsInHeadersCheck>(
         "misc-definitions-in-headers");
+    CheckFactories.registerCheck<ForbidNonVirtualBaseDtorCheck>(
+        "misc-forbid-non-virtual-base-dtor");
     CheckFactories.registerCheck<HeaderIncludeCycleCheck>(
         "misc-header-include-cycle");
     CheckFactories.registerCheck<IncludeCleanerCheck>("misc-include-cleaner");

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -124,6 +124,13 @@ New checks
   ``llvm::to_vector(llvm::make_filter_range(...))`` that can be replaced with
   ``llvm::map_to_vector`` and ``llvm::filter_to_vector``.
 
+- New :doc:`misc-forbid-non-virtual-base-dtor
+  <clang-tidy/checks/misc/forbid-non-virtual-base-dtor>` check.
+
+  Warns when a class or struct publicly inherits from a base whose destructor
+  is neither virtual nor protected, and the derived type adds data members.
+  This pattern causes resource leaks when deleting through a base pointer.
+
 - New :doc:`modernize-use-string-view
   <clang-tidy/checks/modernize/use-string-view>` check.
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -129,7 +129,6 @@ New checks
 
   Warns when a class or struct publicly inherits from a base whose destructor
   is neither virtual nor protected, and the derived type adds data members.
-  This pattern causes resource leaks when deleting through a base pointer.
 
 - New :doc:`modernize-use-string-view
   <clang-tidy/checks/modernize/use-string-view>` check.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -266,6 +266,7 @@ Clang-Tidy Checks
    :doc:`misc-const-correctness <misc/const-correctness>`, "Yes"
    :doc:`misc-coroutine-hostile-raii <misc/coroutine-hostile-raii>`,
    :doc:`misc-definitions-in-headers <misc/definitions-in-headers>`, "Yes"
+   :doc:`misc-forbid-non-virtual-base-dtor <misc/forbid-non-virtual-base-dtor>`, "Yes"
    :doc:`misc-header-include-cycle <misc/header-include-cycle>`,
    :doc:`misc-include-cleaner <misc/include-cleaner>`, "Yes"
    :doc:`misc-misleading-bidirectional <misc/misleading-bidirectional>`,

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -266,7 +266,7 @@ Clang-Tidy Checks
    :doc:`misc-const-correctness <misc/const-correctness>`, "Yes"
    :doc:`misc-coroutine-hostile-raii <misc/coroutine-hostile-raii>`,
    :doc:`misc-definitions-in-headers <misc/definitions-in-headers>`, "Yes"
-   :doc:`misc-forbid-non-virtual-base-dtor <misc/forbid-non-virtual-base-dtor>`, "Yes"
+   :doc:`misc-forbid-non-virtual-base-dtor <misc/forbid-non-virtual-base-dtor>`,
    :doc:`misc-header-include-cycle <misc/header-include-cycle>`,
    :doc:`misc-include-cleaner <misc/include-cleaner>`, "Yes"
    :doc:`misc-misleading-bidirectional <misc/misleading-bidirectional>`,

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/forbid-non-virtual-base-dtor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/forbid-non-virtual-base-dtor.rst
@@ -1,0 +1,52 @@
+.. title:: clang-tidy - misc-forbid-non-virtual-base-dtor
+
+misc-forbid-non-virtual-base-dtor
+=================================
+
+Warns when a class or struct publicly inherits from a base class or struct
+whose destructor is neither virtual nor protected, and the derived class adds
+data members. This pattern causes resource leaks when the derived object is
+deleted through a base class pointer, because the derived destructor is never
+called.
+
+Examples
+--------
+
+The following code will trigger a warning:
+
+.. code-block:: c++
+
+  class Base {};  // non-virtual destructor
+
+  class Derived : public Base {  // warning: class 'Derived' inherits from
+      int data;                  // 'Base' which has a non-virtual destructor
+  };
+
+  Base *b = new Derived();
+  delete b;  // leaks Derived::data —> Base::~Base() is called, not ~Derived()
+
+The following patterns are safe and will **not** trigger a warning:
+
+.. code-block:: c++
+
+  // safe: base has a virtual destructor
+  class Base1 {
+  public:
+      virtual ~Base1() {}
+  };
+  class Derived1 : public Base1 { int data; };
+
+  // safe: base has a protected destructor (prevents delete-through-base)
+  class Base2 {
+  protected:
+      ~Base2() {}
+  };
+  class Derived2 : public Base2 { int data; };
+
+  // safe: derived adds no data members
+  class Base3 {};
+  class Derived3 : public Base3 {};  // OK
+
+  // safe: private/protected inheritance (base pointer not accessible)
+  class Base4 {};
+  class Derived4 : private Base4 { int data; };

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/forbid-non-virtual-base-dtor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/forbid-non-virtual-base-dtor.rst
@@ -29,24 +29,21 @@ The following patterns are safe and will **not** trigger a warning:
 
 .. code-block:: c++
 
-  // safe: base has a virtual destructor
   class Base1 {
   public:
       virtual ~Base1() {}
   };
   class Derived1 : public Base1 { int data; };
 
-  // safe: base has a protected destructor (prevents delete-through-base)
+destructor (prevents delete-through-base)
   class Base2 {
   protected:
       ~Base2() {}
   };
   class Derived2 : public Base2 { int data; };
 
-  // safe: derived adds no data members
   class Base3 {};
   class Derived3 : public Base3 {};  // OK
 
-  // safe: private/protected inheritance (base pointer not accessible)
   class Base4 {};
   class Derived4 : private Base4 { int data; };

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/forbid-non-virtual-base-dtor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/forbid-non-virtual-base-dtor.rst
@@ -23,7 +23,7 @@ The following code will trigger a warning:
   };
 
   Base *b = new Derived();
-  delete b;  // leaks Derived::data —> Base::~Base() is called, not ~Derived()
+  delete b;  // leaks Derived::data -> Base::~Base() is called, not ~Derived()
 
 The following patterns are safe and will **not** trigger a warning:
 
@@ -42,7 +42,7 @@ The following patterns are safe and will **not** trigger a warning:
   class Derived2 : public Base2 { int data; };
 
   class Base3 {};
-  class Derived3 : public Base3 {};  // OK
+  class Derived3 : public Base3 {};
 
   class Base4 {};
   class Derived4 : private Base4 { int data; };

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/forbid-non-virtual-base-dtor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/forbid-non-virtual-base-dtor.rst
@@ -35,7 +35,6 @@ The following patterns are safe and will **not** trigger a warning:
   };
   class Derived1 : public Base1 { int data; };
 
-destructor (prevents delete-through-base)
   class Base2 {
   protected:
       ~Base2() {}

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/forbid-non-virtual-base-dtor.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/forbid-non-virtual-base-dtor.cpp
@@ -2,27 +2,98 @@
 
 // should warn -> non-virtual base + derived has data
 class A {};
-class B: public A{
-    int x;
+class B : public A {
+  // CHECK-MESSAGES: :[[@LINE-1]]:{{.*}}: warning: class 'B' inherits from 'A' which has a non-virtual destructor [misc-forbid-non-virtual-base-dtor]
+  int x;
 };
-// CHECK-MESSAGES: warning: class 'B' inherits from 'A' which has a non-virtual destructor [misc-forbid-non-virtual-base-dtor]
 
-//shouldn't warn -> derived has no data
-class C : public A{};
+// shouldn't warn -> derived has no data
+class C : public A {};
 
 // shouldn't warn -> base has virtual destructor
 class D {
-    public:
-    virtual ~D(){};
+public:
+  virtual ~D() {}
 };
-class E : public D{
-    int y;
+class E : public D {
+  int y;
 };
 
-//shouldn't crash -> incomplete base
+// shouldn't crash -> incomplete then defined base
 class F;
 class F {};
-class G: public F{
-    int z;
+class G : public F {
+  // CHECK-MESSAGES: :[[@LINE-1]]:{{.*}}: warning: class 'G' inherits from 'F' which has a non-virtual destructor [misc-forbid-non-virtual-base-dtor]
+  int z;
 };
-// CHECK-MESSAGES: warning: class 'G' inherits from 'F' which has a non-virtual destructor [misc-forbid-non-virtual-base-dtor]
+
+// shouldn't warn -> base has protected non-virtual destructor
+class H {
+protected:
+  ~H() {}
+};
+class I : public H {
+  int w;
+};
+
+// shouldn't warn -> private inheritance
+class J : private A {
+  int w;
+};
+
+// shouldn't warn -> protected inheritance
+class K : protected A {
+  int w;
+};
+
+// should warn for both bases
+class M1 {};
+class M2 {};
+class M3 : public M1, public M2 {
+  // CHECK-MESSAGES: :[[@LINE-1]]:{{.*}}: warning: class 'M3' inherits from 'M2' which has a non-virtual destructor [misc-forbid-non-virtual-base-dtor]
+  int x;
+};
+
+// should warn only for non-virtual base
+class M4 : public D, public A {
+  // CHECK-MESSAGES: :[[@LINE-1]]:{{.*}}: warning: class 'M4' inherits from 'A' which has a non-virtual destructor [misc-forbid-non-virtual-base-dtor]
+  int x;
+};
+
+// should warn -> non-virtual base instantiated with data member
+template <typename T>
+class TBase {};
+
+template <typename T>
+class TDerived : public TBase<T> {
+  // CHECK-MESSAGES: :[[@LINE-1]]:{{.*}}: warning: class 'TDerived' inherits from 'TBase' which has a non-virtual destructor [misc-forbid-non-virtual-base-dtor]
+  T x;
+};
+TDerived<int> td;
+
+// shouldn't warn -> templated base with virtual destructor
+template <typename T>
+class TVBase {
+public:
+  virtual ~TVBase() {}
+};
+
+template <typename T>
+class TVDerived : public TVBase<T> {
+  T x;
+};
+TVDerived<int> tvd;
+
+#define DERIVE_WITH_DATA(Derived, Base) \
+  class Derived : public Base {         \
+    int x;                              \
+  };
+
+DERIVE_WITH_DATA(MacroDerived, A)
+// CHECK-MESSAGES: :[[@LINE-1]]:{{.*}}: warning: class 'MacroDerived' inherits from 'A' which has a non-virtual destructor [misc-forbid-non-virtual-base-dtor]
+
+#define DERIVE_NO_DATA(Derived, Base) \
+  class Derived : public Base {};
+
+// shouldn't warn -> no data member
+DERIVE_NO_DATA(MacroDerivedEmpty, A)

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/forbid-non-virtual-base-dtor.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/forbid-non-virtual-base-dtor.cpp
@@ -1,0 +1,28 @@
+// RUN: %check_clang_tidy %s misc-forbid-non-virtual-base-dtor %t
+
+// should warn -> non-virtual base + derived has data
+class A {};
+class B: public A{
+    int x;
+};
+// CHECK-MESSAGES: warning: class 'B' inherits from 'A' which has a non-virtual destructor [misc-forbid-non-virtual-base-dtor]
+
+//shouldn't warn -> derived has no data
+class C : public A{};
+
+// shouldn't warn -> base has virtual destructor
+class D {
+    public:
+    virtual ~D(){};
+};
+class E : public D{
+    int y;
+};
+
+//shouldn't crash -> incomplete base
+class F;
+class F {};
+class G: public F{
+    int z;
+};
+// CHECK-MESSAGES: warning: class 'G' inherits from 'F' which has a non-virtual destructor [misc-forbid-non-virtual-base-dtor]


### PR DESCRIPTION
Adds a clang-tidy check that warns when a class inherits from a base class
with a non-virtual destructor while introducing data members. Deleting such
objects through a base pointer can lead to undefined behavior because the
derived portion of the object will not be destroyed.

The check skips cases where the base class has a virtual destructor, a protected non-virtual destructor, or when the derived class introduces no
data members.

Includes tests and documentation.

Fixes #183101