### PR TITLE
[scudo] Add reallocarray C wrapper.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/report.cpp
+++ b/compiler-rt/lib/scudo/standalone/report.cpp
@@ -175,6 +175,13 @@ void NORETURN reportCallocOverflow(uptr Count, uptr Size) {
                 Count, Size);
 }
 
+void NORETURN reportReallocarrayOverflow(uptr Count, uptr Size) {
+  ScopedErrorReport Report;
+  Report.append("reallocarray parameters overflow: count * size (%zu * %zu) "
+                "cannot be represented with type size_t\n",
+                Count, Size);
+}
+
 void NORETURN reportInvalidPosixMemalignAlignment(uptr Alignment) {
   ScopedErrorReport Report;
   Report.append(

--- a/compiler-rt/lib/scudo/standalone/report.h
+++ b/compiler-rt/lib/scudo/standalone/report.h
@@ -52,6 +52,7 @@ void NORETURN reportDeleteSizeMismatch(const void *Ptr, uptr Size,
 void NORETURN reportAlignmentNotPowerOfTwo(uptr Alignment);
 void NORETURN reportInvalidPosixMemalignAlignment(uptr Alignment);
 void NORETURN reportCallocOverflow(uptr Count, uptr Size);
+void NORETURN reportReallocarrayOverflow(uptr Count, uptr Size);
 void NORETURN reportPvallocOverflow(uptr Size);
 void NORETURN reportInvalidAlignedAllocAlignment(uptr Size, uptr Alignment);
 

--- a/compiler-rt/lib/scudo/standalone/tests/report_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/report_test.cpp
@@ -50,6 +50,8 @@ TEST(ScudoReportDeathTest, Generic) {
 TEST(ScudoReportDeathTest, CSpecific) {
   EXPECT_DEATH(scudo::reportAlignmentNotPowerOfTwo(123), "Scudo ERROR.*123");
   EXPECT_DEATH(scudo::reportCallocOverflow(123, 456), "Scudo ERROR.*123.*456");
+  EXPECT_DEATH(scudo::reportReallocarrayOverflow(123, 456),
+               "Scudo ERROR.*reallocarray parameters.*123.*456");
   EXPECT_DEATH(scudo::reportInvalidPosixMemalignAlignment(789),
                "Scudo ERROR.*789");
   EXPECT_DEATH(scudo::reportPvallocOverflow(123), "Scudo ERROR.*123");

--- a/compiler-rt/lib/scudo/standalone/wrappers_c.inc
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c.inc
@@ -217,6 +217,19 @@ INTERFACE WEAK void *SCUDO_PREFIX(realloc)(void *ptr, size_t size) {
   return scudo::setErrnoOnNull(NewPtr);
 }
 
+INTERFACE WEAK void *SCUDO_PREFIX(reallocarray)(void *ptr, size_t nmemb,
+                                                size_t size) {
+  scudo::uptr Product;
+  if (UNLIKELY(scudo::checkForCallocOverflow(size, nmemb, &Product))) {
+    if (SCUDO_ALLOCATOR.canReturnNull()) {
+      errno = ENOMEM;
+      return nullptr;
+    }
+    scudo::reportReallocarrayOverflow(nmemb, size);
+  }
+  return SCUDO_PREFIX(realloc)(ptr, Product);
+}
+
 INTERFACE WEAK void *SCUDO_PREFIX(valloc)(size_t size) {
   void *Ptr = SCUDO_ALLOCATOR.allocate(size, scudo::Chunk::Origin::Memalign,
                                        scudo::getPageSizeCached());

--- a/compiler-rt/lib/scudo/standalone/wrappers_c_checks.h
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c_checks.h
@@ -40,9 +40,9 @@ inline bool checkPosixMemalignAlignment(uptr Alignment) {
   return !isPowerOfTwo(Alignment) || !isAligned(Alignment, sizeof(void *));
 }
 
-// Returns true if calloc(Size, N) overflows on Size*N calculation. Use a
-// builtin supported by recent clang & GCC if it exists, otherwise fallback to a
-// costly division.
+// Returns true if calloc(N, Size) or reallocarray(Ptr, N, Size) overflows on
+// Size*N calculation. Use a builtin supported by recent clang & GCC if it
+// exists, otherwise fallback to a costly division.
 inline bool checkForCallocOverflow(uptr Size, uptr N, uptr *Product) {
 #if __has_builtin(__builtin_umull_overflow) && (SCUDO_WORDSIZE == 64U)
   return __builtin_umull_overflow(Size, N,


### PR DESCRIPTION
`reallocarray()` is a POSIX extension to C standard which wraps `realloc` function and adds `calloc`-like overflow detection. It is available in glibc and some other standard library implementations. Add `reallocarray` to the list of Scudo C wrappers, so that the code that depends on `reallocarray` presence will continue to work.