### PR TITLE
[X86] Add include for Pass Registry directly

### DIFF
--- a/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
@@ -274,6 +274,7 @@ void X86CodeGenPassBuilder::addAsmPrinterEnd(
 } // namespace
 
 void X86TargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
+#include "X86PassRegistry.def"
 #define GET_PASS_REGISTRY "X86PassRegistry.def"
 #include "llvm/Passes/TargetPassRegistry.inc"
   // TODO(boomanaiden154): Move this into the base CodeGenPassBuilder once all


### PR DESCRIPTION
Otherwise builds using clang header modules will fail on __has_include and within the #include within TargetPassRegistry.inc.