### PR TITLE
[flang] Silence build warning

### DIFF
--- a/flang/include/flang/Semantics/expression.h
+++ b/flang/include/flang/Semantics/expression.h
@@ -580,7 +580,8 @@ public:
 
 private:
   template <typename A>
-  void AnalyzeAndNoteUses(const A &x, bool isDefinition = false) {
+  void AnalyzeAndNoteUses(
+      const A &x, [[maybe_unused]] bool isDefinition = false) {
     exprAnalyzer_.Analyze(x);
     if constexpr (parser::HasTypedExpr<A>::value) {
       if (x.typedExpr && x.typedExpr->v) {


### PR DESCRIPTION
Add a [[maybe_unused]] to a parameter of a function with several constexpr ifs, some of whose branches don't use the parameter.