### PR TITLE
[CIR] Implement flattening of nested EH cleanup scopes

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -883,6 +883,48 @@ public:
         });
   }
 
+  // Collect all cir.resume operations in the body region that come from
+  // already-flattened inner cleanup scopes. These resume ops need to be
+  // chained through this cleanup's EH handler instead of unwinding directly
+  // to the caller. Skips resume ops inside nested TryOps because those will
+  // be handled by the TryOp's own flattening.
+  void collectResumeOps(
+      mlir::Region &bodyRegion,
+      llvm::SmallVectorImpl<cir::ResumeOp> &resumeOps) const {
+    bodyRegion.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+      // Skip resume ops inside nested TryOps - those are handled by TryOp
+      // flattening.
+      if (isa<cir::TryOp>(op))
+        return mlir::WalkResult::skip();
+
+      if (auto resumeOp = dyn_cast<cir::ResumeOp>(op))
+        resumeOps.push_back(resumeOp);
+      return mlir::WalkResult::advance();
+    });
+  }
+
+  // Given a cir.resume that terminates an EH cleanup block, trace back through
+  // the cir.end_cleanup -> cir.begin_cleanup chain to find the eh_token that
+  // represents the in-flight exception. This token is needed to branch to the
+  // outer cleanup's EH handler.
+  //
+  // Expected block structure:
+  //   ^eh_cleanup(%eh_token : !cir.eh_token):
+  //     %ct = cir.begin_cleanup %eh_token
+  //     <cleanup operations>
+  //     cir.end_cleanup %ct
+  //     cir.resume
+  static mlir::Value getEhTokenFromResume(cir::ResumeOp resumeOp) {
+    mlir::Operation *prevOp = resumeOp->getPrevNode();
+    assert(prevOp && isa<cir::EndCleanupOp>(prevOp) &&
+           "expected cir.end_cleanup immediately before cir.resume");
+    auto endCleanup = cast<cir::EndCleanupOp>(prevOp);
+    auto beginCleanup =
+        endCleanup.getCleanupToken().getDefiningOp<cir::BeginCleanupOp>();
+    assert(beginCleanup && "cleanup_token must come from cir.begin_cleanup");
+    return beginCleanup.getEhToken();
+  }
+
   // Collect all function calls in the cleanup scope body that may throw
   // exceptions and need to be replaced with try_call operations. Skips calls
   // that are marked nothrow and calls inside nested TryOps (the latter will be
@@ -1104,6 +1146,7 @@ public:
   flattenCleanup(cir::CleanupScopeOp cleanupOp,
                  llvm::SmallVectorImpl<CleanupExit> &exits,
                  llvm::SmallVectorImpl<cir::CallOp> &callsToRewrite,
+                 llvm::SmallVectorImpl<cir::ResumeOp> &resumeOpsToChain,
                  mlir::PatternRewriter &rewriter) const {
     mlir::Location loc = cleanupOp.getLoc();
     cir::CleanupKind cleanupKind = cleanupOp.getCleanupKind();
@@ -1146,20 +1189,33 @@ public:
     // Build EH cleanup blocks if needed. This must be done before inlining
     // the cleanup region since buildEHCleanupBlocks clones from it. The unwind
     // block is inserted before the EH cleanup entry so that the final layout
-    // is: body -> normal cleanup -> exit ->unwind -> EH cleanup -> continue.
-    // If there are no throwing calls, we don't need to EH cleanup blocks.
+    // is: body -> normal cleanup -> exit -> unwind -> EH cleanup -> continue.
+    // EH cleanup blocks are needed when there are throwing calls that need to
+    // be rewritten to try_call, or when there are resume ops from
+    // already-flattened inner cleanup scopes that need to chain through this
+    // cleanup's EH handler.
     mlir::Block *unwindBlock = nullptr;
     mlir::Block *ehCleanupEntry = nullptr;
-    if (hasEHCleanup && !callsToRewrite.empty()) {
+    if (hasEHCleanup &&
+        (!callsToRewrite.empty() || !resumeOpsToChain.empty())) {
       ehCleanupEntry =
           buildEHCleanupBlocks(cleanupOp, loc, continueBlock, rewriter);
-      unwindBlock =
-          buildUnwindBlock(ehCleanupEntry, loc, ehCleanupEntry, rewriter);
+      // The unwind block is only needed when there are throwing calls that
+      // need a shared unwind destination. Resume ops from inner cleanups
+      // branch directly to the EH cleanup entry.
+      if (!callsToRewrite.empty())
+        unwindBlock =
+            buildUnwindBlock(ehCleanupEntry, loc, ehCleanupEntry, rewriter);
     }
 
     // All normal flow blocks are inserted before this point — either before
-    // the unwind block (if EH cleanup exists) or before the continue block.
-    mlir::Block *normalInsertPt = unwindBlock ? unwindBlock : continueBlock;
+    // the unwind block (if it exists), or before the EH cleanup entry (if EH
+    // cleanup exists but no unwind block is needed), or before the continue
+    // block.
+    mlir::Block *normalInsertPt =
+        unwindBlock
+            ? unwindBlock
+            : (ehCleanupEntry ? ehCleanupEntry : continueBlock);
 
     // Inline the body region.
     rewriter.inlineRegionBefore(cleanupOp.getBodyRegion(), normalInsertPt);
@@ -1274,6 +1330,20 @@ public:
         replaceCallWithTryCall(callOp, unwindBlock, loc, rewriter);
     }
 
+    // Chain inner EH cleanup resume ops to this cleanup's EH handler.
+    // Each cir.resume from an already-flattened inner cleanup is replaced
+    // with a branch to the outer EH cleanup entry, passing the eh_token
+    // from the inner's begin_cleanup so that the same in-flight exception
+    // flows through the outer cleanup before unwinding to the caller.
+    if (ehCleanupEntry) {
+      for (cir::ResumeOp resumeOp : resumeOpsToChain) {
+        mlir::Value ehToken = getEhTokenFromResume(resumeOp);
+        rewriter.setInsertionPoint(resumeOp);
+        rewriter.replaceOpWithNewOp<cir::BrOp>(
+            resumeOp, mlir::ValueRange{ehToken}, ehCleanupEntry);
+      }
+    }
+
     // Erase the original cleanup scope op.
     rewriter.eraseOp(cleanupOp);
 
@@ -1296,15 +1366,6 @@ public:
       return mlir::failure();
 
     cir::CleanupKind cleanupKind = cleanupOp.getCleanupKind();
-
-    // EH cleanups nested inside another cleanup scope are not yet supported
-    // because the inner EH unwind path must chain through the outer cleanup
-    // before unwinding to the caller.
-    if (cleanupKind != cir::CleanupKind::Normal) {
-      if (cleanupOp->getParentOfType<cir::CleanupScopeOp>())
-        return cleanupOp->emitError(
-            "nested EH cleanup scope flattening is not yet implemented");
-    }
 
     // Throwing calls in the cleanup region of an EH-enabled cleanup scope
     // are not yet supported. Such calls would need their own EH handling
@@ -1331,7 +1392,14 @@ public:
     if (cleanupKind != cir::CleanupKind::Normal)
       collectThrowingCalls(cleanupOp.getBodyRegion(), callsToRewrite);
 
-    return flattenCleanup(cleanupOp, exits, callsToRewrite, rewriter);
+    // Collect resume ops from already-flattened inner cleanup scopes that
+    // need to chain through this cleanup's EH handler.
+    llvm::SmallVector<cir::ResumeOp> resumeOpsToChain;
+    if (cleanupKind != cir::CleanupKind::Normal)
+      collectResumeOps(cleanupOp.getBodyRegion(), resumeOpsToChain);
+
+    return flattenCleanup(cleanupOp, exits, callsToRewrite, resumeOpsToChain,
+                          rewriter);
   }
 };
 

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -884,10 +884,9 @@ public:
   }
 
   // Collect all cir.resume operations in the body region that come from
-  // already-flattened inner cleanup scopes. These resume ops need to be
-  // chained through this cleanup's EH handler instead of unwinding directly
-  // to the caller. Skips resume ops inside nested TryOps because those will
-  // be handled by the TryOp's own flattening.
+  // already-flattened try or cleanup scope operations that were nested within
+  // this cleanup scope. These resume ops need to be chained through this
+  // cleanup's EH handler instead of unwinding directly to the caller.
   void collectResumeOps(
       mlir::Region &bodyRegion,
       llvm::SmallVectorImpl<cir::ResumeOp> &resumeOps) const {
@@ -1355,14 +1354,17 @@ public:
                   mlir::PatternRewriter &rewriter) const override {
     mlir::OpBuilder::InsertionGuard guard(rewriter);
 
-    // Nested cleanup scopes must be lowered before the enclosing cleanup scope.
-    // Fail the match so the pattern rewriter will process inner cleanups first.
-    bool hasNestedCleanup = cleanupOp.getBodyRegion()
-                                .walk([&](cir::CleanupScopeOp) {
-                                  return mlir::WalkResult::interrupt();
-                                })
-                                .wasInterrupted();
-    if (hasNestedCleanup)
+    // Nested cleanup scopes and try operations must be flattened before the
+    // enclosing cleanup scope so that EH cleanup inside them is properly
+    // handled. Fail the match so the pattern rewriter processes them first.
+    bool hasNestedOps = cleanupOp.getBodyRegion()
+                            .walk([&](mlir::Operation *op) {
+                              if (isa<cir::CleanupScopeOp, cir::TryOp>(op))
+                                return mlir::WalkResult::interrupt();
+                              return mlir::WalkResult::advance();
+                            })
+                            .wasInterrupted();
+    if (hasNestedOps)
       return mlir::failure();
 
     cir::CleanupKind cleanupKind = cleanupOp.getCleanupKind();

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -887,9 +887,8 @@ public:
   // already-flattened try or cleanup scope operations that were nested within
   // this cleanup scope. These resume ops need to be chained through this
   // cleanup's EH handler instead of unwinding directly to the caller.
-  void collectResumeOps(
-      mlir::Region &bodyRegion,
-      llvm::SmallVectorImpl<cir::ResumeOp> &resumeOps) const {
+  void collectResumeOps(mlir::Region &bodyRegion,
+                        llvm::SmallVectorImpl<cir::ResumeOp> &resumeOps) const {
     bodyRegion.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
       // Skip resume ops inside nested TryOps - those are handled by TryOp
       // flattening.
@@ -1190,9 +1189,8 @@ public:
     // cleanup exists but no unwind block is needed), or before the continue
     // block.
     mlir::Block *normalInsertPt =
-        unwindBlock
-            ? unwindBlock
-            : (ehCleanupEntry ? ehCleanupEntry : continueBlock);
+        unwindBlock ? unwindBlock
+                    : (ehCleanupEntry ? ehCleanupEntry : continueBlock);
 
     // Inline the body region.
     rewriter.inlineRegionBefore(cleanupOp.getBodyRegion(), normalInsertPt);

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -902,28 +902,6 @@ public:
     });
   }
 
-  // Given a cir.resume that terminates an EH cleanup block, trace back through
-  // the cir.end_cleanup -> cir.begin_cleanup chain to find the eh_token that
-  // represents the in-flight exception. This token is needed to branch to the
-  // outer cleanup's EH handler.
-  //
-  // Expected block structure:
-  //   ^eh_cleanup(%eh_token : !cir.eh_token):
-  //     %ct = cir.begin_cleanup %eh_token
-  //     <cleanup operations>
-  //     cir.end_cleanup %ct
-  //     cir.resume
-  static mlir::Value getEhTokenFromResume(cir::ResumeOp resumeOp) {
-    mlir::Operation *prevOp = resumeOp->getPrevNode();
-    assert(prevOp && isa<cir::EndCleanupOp>(prevOp) &&
-           "expected cir.end_cleanup immediately before cir.resume");
-    auto endCleanup = cast<cir::EndCleanupOp>(prevOp);
-    auto beginCleanup =
-        endCleanup.getCleanupToken().getDefiningOp<cir::BeginCleanupOp>();
-    assert(beginCleanup && "cleanup_token must come from cir.begin_cleanup");
-    return beginCleanup.getEhToken();
-  }
-
   // Collect all function calls in the cleanup scope body that may throw
   // exceptions and need to be replaced with try_call operations. Skips calls
   // that are marked nothrow and calls inside nested TryOps (the latter will be
@@ -1336,7 +1314,7 @@ public:
     // flows through the outer cleanup before unwinding to the caller.
     if (ehCleanupEntry) {
       for (cir::ResumeOp resumeOp : resumeOpsToChain) {
-        mlir::Value ehToken = getEhTokenFromResume(resumeOp);
+        mlir::Value ehToken = resumeOp.getEhToken();
         rewriter.setInsertionPoint(resumeOp);
         rewriter.replaceOpWithNewOp<cir::BrOp>(
             resumeOp, mlir::ValueRange{ehToken}, ehCleanupEntry);

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-eh.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-eh.cir
@@ -372,6 +372,205 @@ cir.func @test_eh_cleanup_in_try() {
 // CHECK: ^[[CONTINUE]]:
 // CHECK:   cir.return
 
+// Test nested EH cleanup flattening. After both cleanup scopes are flattened,
+// the inner EH cleanup block branches to the outer EH cleanup block before
+// unwinding to the caller.
+//
+// C++ equivalent:
+//   void test() {
+//     SomeClass c;
+//     SomeClass c2;
+//     doSomething(&c);
+//   }
+cir.func @test_nested_eh_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.cleanup.scope {
+      cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    } cleanup all {
+      cir.call @dtor(%1) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  } cleanup all {
+    cir.call @dtor(%0) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_nested_eh_cleanup()
+// CHECK:         %[[C:.*]] = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init]
+// CHECK:         %[[C2:.*]] = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init]
+// CHECK:         cir.call @ctor(%[[C]])
+// CHECK:         cir.br ^[[OUTER_BODY:bb[0-9]+]]
+//
+// Outer body: ctor for c2 may throw. Since c2 is not yet constructed,
+// the unwind skips the inner cleanup and goes to the outer unwind.
+// CHECK:       ^[[OUTER_BODY]]:
+// CHECK:         cir.try_call @ctor(%[[C2]]) ^[[AFTER_CTOR:bb[0-9]+]], ^[[OUTER_UNWIND:bb[0-9]+]]
+//
+// After c2 construction, branch to inner body.
+// CHECK:       ^[[AFTER_CTOR]]:
+// CHECK:         cir.br ^[[INNER_BODY:bb[0-9]+]]
+//
+// Inner body: doSomething may throw, unwinding to the inner unwind block.
+// CHECK:       ^[[INNER_BODY]]:
+// CHECK:         cir.try_call @doSomething(%[[C]]) ^[[INNER_NORMAL:bb[0-9]+]], ^[[INNER_UNWIND:bb[0-9]+]]
+//
+// Inner normal continuation: branch to inner normal cleanup.
+// CHECK:       ^[[INNER_NORMAL]]:
+// CHECK:         cir.br ^[[INNER_NORMAL_CLEANUP:bb[0-9]+]]
+//
+// Inner normal cleanup: destroy c2.
+// CHECK:       ^[[INNER_NORMAL_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[C2]]) nothrow
+// CHECK:         cir.br ^[[INNER_EXIT:bb[0-9]+]]
+//
+// Inner exit: branch toward outer normal cleanup.
+// CHECK:       ^[[INNER_EXIT]]:
+// CHECK:         cir.br ^[[YIELD_BLOCK:bb[0-9]+]]
+//
+// Inner unwind block: initiate EH and branch to inner EH cleanup.
+// CHECK:       ^[[INNER_UNWIND]]:
+// CHECK:         %[[INNER_ET:.*]] = cir.eh.initiate cleanup : !cir.eh_token
+// CHECK:         cir.br ^[[INNER_EH_CLEANUP:bb[0-9]+]](%[[INNER_ET]] : !cir.eh_token)
+//
+// Inner EH cleanup: destroy c2, then chain to OUTER EH cleanup (not resume).
+// CHECK:       ^[[INNER_EH_CLEANUP]](%[[INNER_EH:.*]]: !cir.eh_token):
+// CHECK:         %[[INNER_CT:.*]] = cir.begin_cleanup %[[INNER_EH]] : !cir.eh_token -> !cir.cleanup_token
+// CHECK:         cir.call @dtor(%[[C2]]) nothrow
+// CHECK:         cir.end_cleanup %[[INNER_CT]] : !cir.cleanup_token
+// CHECK:         cir.br ^[[OUTER_EH_CLEANUP:bb[0-9]+]](%[[INNER_EH]] : !cir.eh_token)
+//
+// Outer body yield branches to normal cleanup.
+// CHECK:       ^[[YIELD_BLOCK]]:
+// CHECK:         cir.br ^[[OUTER_NORMAL_CLEANUP:bb[0-9]+]]
+//
+// Outer normal cleanup: destroy c.
+// CHECK:       ^[[OUTER_NORMAL_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.br ^[[OUTER_EXIT:bb[0-9]+]]
+//
+// Outer exit: branch to continue.
+// CHECK:       ^[[OUTER_EXIT]]:
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+//
+// Outer unwind block: initiate EH and branch to outer EH cleanup.
+// CHECK:       ^[[OUTER_UNWIND]]:
+// CHECK:         %[[OUTER_ET:.*]] = cir.eh.initiate cleanup : !cir.eh_token
+// CHECK:         cir.br ^[[OUTER_EH_CLEANUP]](%[[OUTER_ET]] : !cir.eh_token)
+//
+// Outer EH cleanup: destroy c, then resume unwinding to caller.
+// Both inner EH cleanup and outer unwind branch here.
+// CHECK:       ^[[OUTER_EH_CLEANUP]](%[[OUTER_EH:.*]]: !cir.eh_token):
+// CHECK:         %[[OUTER_CT:.*]] = cir.begin_cleanup %[[OUTER_EH]] : !cir.eh_token -> !cir.cleanup_token
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.end_cleanup %[[OUTER_CT]] : !cir.cleanup_token
+// CHECK:         cir.resume
+//
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.return
+
+// Test nested EH cleanup where the outer cleanup is EH-only and has no
+// direct throwing calls -- only resume ops from the inner cleanup need
+// chaining.
+//
+// C++ equivalent (simplified):
+//   struct Derived : Base {
+//     Derived() : Base() {
+//       SomeClass c;
+//       doSomething(&c);
+//     }
+//   };
+cir.func @test_nested_eh_only_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["base", init] {alignment = 4 : i64}
+  %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.cleanup.scope {
+      cir.call @doSomething(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    } cleanup all {
+      cir.call @dtor(%1) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  } cleanup eh {
+    cir.call @dtor(%0) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_nested_eh_only_cleanup()
+// CHECK:         %[[BASE:.*]] = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["base", init]
+// CHECK:         %[[C:.*]] = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init]
+// CHECK:         cir.call @ctor(%[[BASE]])
+// CHECK:         cir.br ^[[OUTER_BODY:bb[0-9]+]]
+//
+// Outer body: ctor for c may throw. The outer flattening rewrites it to
+// try_call with the outer unwind as destination (the inner cleanup should
+// not run if c was never constructed).
+// CHECK:       ^[[OUTER_BODY]]:
+// CHECK:         cir.try_call @ctor(%[[C]]) ^[[AFTER_CTOR:bb[0-9]+]], ^[[OUTER_UNWIND:bb[0-9]+]]
+//
+// CHECK:       ^[[AFTER_CTOR]]:
+// CHECK:         cir.br ^[[INNER_BODY:bb[0-9]+]]
+//
+// Inner body: doSomething is a try_call unwinding to the inner unwind.
+// CHECK:       ^[[INNER_BODY]]:
+// CHECK:         cir.try_call @doSomething(%[[C]]) ^[[INNER_NORMAL:bb[0-9]+]], ^[[INNER_UNWIND:bb[0-9]+]]
+//
+// Inner normal cleanup.
+// CHECK:       ^[[INNER_NORMAL]]:
+// CHECK:         cir.br ^[[INNER_NORMAL_CLEANUP:bb[0-9]+]]
+//
+// CHECK:       ^[[INNER_NORMAL_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.br ^[[INNER_EXIT:bb[0-9]+]]
+//
+// Inner exit: branch toward continue (outer is EH-only, no normal cleanup).
+// CHECK:       ^[[INNER_EXIT]]:
+// CHECK:         cir.br ^[[OUTER_EXIT:bb[0-9]+]]
+//
+// Inner unwind block.
+// CHECK:       ^[[INNER_UNWIND]]:
+// CHECK:         %[[INNER_ET:.*]] = cir.eh.initiate cleanup : !cir.eh_token
+// CHECK:         cir.br ^[[INNER_EH_CLEANUP:bb[0-9]+]](%[[INNER_ET]] : !cir.eh_token)
+//
+// Inner EH cleanup: destroy c, then chain to outer EH cleanup.
+// CHECK:       ^[[INNER_EH_CLEANUP]](%[[INNER_EH:.*]]: !cir.eh_token):
+// CHECK:         %[[INNER_CT:.*]] = cir.begin_cleanup %[[INNER_EH]] : !cir.eh_token -> !cir.cleanup_token
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.end_cleanup %[[INNER_CT]] : !cir.cleanup_token
+// CHECK:         cir.br ^[[OUTER_EH_CLEANUP:bb[0-9]+]](%[[INNER_EH]] : !cir.eh_token)
+//
+// Outer body exit: branch to continue (outer is EH-only, no normal cleanup).
+// CHECK:       ^[[OUTER_EXIT]]:
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+//
+// Outer unwind block: initiate EH and branch to outer EH cleanup.
+// CHECK:       ^[[OUTER_UNWIND]]:
+// CHECK:         %[[OUTER_ET:.*]] = cir.eh.initiate cleanup : !cir.eh_token
+// CHECK:         cir.br ^[[OUTER_EH_CLEANUP]](%[[OUTER_ET]] : !cir.eh_token)
+//
+// Outer EH cleanup: destroy base, then resume to caller.
+// Both inner EH cleanup and outer unwind branch here.
+// CHECK:       ^[[OUTER_EH_CLEANUP]](%[[OUTER_EH:.*]]: !cir.eh_token):
+// CHECK:         %[[OUTER_CT:.*]] = cir.begin_cleanup %[[OUTER_EH]] : !cir.eh_token -> !cir.cleanup_token
+// CHECK:         cir.call @dtor(%[[BASE]]) nothrow
+// CHECK:         cir.end_cleanup %[[OUTER_CT]] : !cir.cleanup_token
+// CHECK:         cir.resume
+//
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.return
+
 cir.func private @get() -> !s32i
 cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
 cir.func private @dtor(!cir.ptr<!rec_SomeClass>) attributes {nothrow}

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-eh.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-eh.cir
@@ -571,6 +571,119 @@ cir.func @test_nested_eh_only_cleanup() {
 // CHECK:       ^[[CONTINUE]]:
 // CHECK:         cir.return
 
+// Test nested cleanup where both the inner and outer cleanup scopes have
+// throwing calls. The outer body contains a throwing call (doSomethingElse)
+// AFTER the inner cleanup scope, so both scopes independently contribute
+// try_call operations.
+//
+// C++ equivalent:
+//   void test() {
+//     SomeClass c;
+//     {
+//       SomeClass c2;
+//       doSomething(&c);
+//     }
+//     doSomethingElse(&c);
+//   }
+cir.func @test_nested_eh_both_throwing() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.cleanup.scope {
+      cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    } cleanup all {
+      cir.call @dtor(%1) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.call @doSomethingElse(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  } cleanup all {
+    cir.call @dtor(%0) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_nested_eh_both_throwing()
+// CHECK:         %[[C:.*]] = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init]
+// CHECK:         %[[C2:.*]] = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init]
+// CHECK:         cir.call @ctor(%[[C]])
+// CHECK:         cir.br ^[[OUTER_BODY:bb[0-9]+]]
+//
+// Outer body: ctor for c2 may throw, unwinding to the outer unwind block
+// (shared with doSomethingElse below).
+// CHECK:       ^[[OUTER_BODY]]:
+// CHECK:         cir.try_call @ctor(%[[C2]]) ^[[AFTER_CTOR:bb[0-9]+]], ^[[OUTER_UNWIND:bb[0-9]+]]
+//
+// CHECK:       ^[[AFTER_CTOR]]:
+// CHECK:         cir.br ^[[INNER_BODY:bb[0-9]+]]
+//
+// Inner body: doSomething may throw, unwinding to the inner unwind block.
+// CHECK:       ^[[INNER_BODY]]:
+// CHECK:         cir.try_call @doSomething(%[[C]]) ^[[INNER_NORMAL:bb[0-9]+]], ^[[INNER_UNWIND:bb[0-9]+]]
+//
+// Inner normal continuation: branch to inner normal cleanup.
+// CHECK:       ^[[INNER_NORMAL]]:
+// CHECK:         cir.br ^[[INNER_NORMAL_CLEANUP:bb[0-9]+]]
+//
+// Inner normal cleanup: destroy c2.
+// CHECK:       ^[[INNER_NORMAL_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[C2]]) nothrow
+// CHECK:         cir.br ^[[INNER_EXIT:bb[0-9]+]]
+//
+// Inner exit: branch to the rest of the outer body.
+// CHECK:       ^[[INNER_EXIT]]:
+// CHECK:         cir.br ^[[OUTER_BODY_CONT:bb[0-9]+]]
+//
+// Inner unwind block: initiate EH and branch to inner EH cleanup.
+// CHECK:       ^[[INNER_UNWIND]]:
+// CHECK:         %[[INNER_ET:.*]] = cir.eh.initiate cleanup : !cir.eh_token
+// CHECK:         cir.br ^[[INNER_EH_CLEANUP:bb[0-9]+]](%[[INNER_ET]] : !cir.eh_token)
+//
+// Inner EH cleanup: destroy c2, then chain to OUTER EH cleanup.
+// CHECK:       ^[[INNER_EH_CLEANUP]](%[[INNER_EH:.*]]: !cir.eh_token):
+// CHECK:         %[[INNER_CT:.*]] = cir.begin_cleanup %[[INNER_EH]] : !cir.eh_token -> !cir.cleanup_token
+// CHECK:         cir.call @dtor(%[[C2]]) nothrow
+// CHECK:         cir.end_cleanup %[[INNER_CT]] : !cir.cleanup_token
+// CHECK:         cir.br ^[[OUTER_EH_CLEANUP:bb[0-9]+]](%[[INNER_EH]] : !cir.eh_token)
+//
+// Outer body continues after inner cleanup: doSomethingElse may throw,
+// unwinding to the SAME outer unwind block as ctor.
+// CHECK:       ^[[OUTER_BODY_CONT]]:
+// CHECK:         cir.try_call @doSomethingElse(%[[C]]) ^[[AFTER_ELSE:bb[0-9]+]], ^[[OUTER_UNWIND]]
+//
+// After doSomethingElse: branch to outer normal cleanup.
+// CHECK:       ^[[AFTER_ELSE]]:
+// CHECK:         cir.br ^[[OUTER_NORMAL_CLEANUP:bb[0-9]+]]
+//
+// Outer normal cleanup: destroy c.
+// CHECK:       ^[[OUTER_NORMAL_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.br ^[[OUTER_EXIT:bb[0-9]+]]
+//
+// Outer exit: branch to continue.
+// CHECK:       ^[[OUTER_EXIT]]:
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+//
+// Outer unwind block: shared by ctor and doSomethingElse try_calls.
+// CHECK:       ^[[OUTER_UNWIND]]:
+// CHECK:         %[[OUTER_ET:.*]] = cir.eh.initiate cleanup : !cir.eh_token
+// CHECK:         cir.br ^[[OUTER_EH_CLEANUP]](%[[OUTER_ET]] : !cir.eh_token)
+//
+// Outer EH cleanup: destroy c, then resume. Reached from both the inner
+// EH cleanup chain and the outer unwind block.
+// CHECK:       ^[[OUTER_EH_CLEANUP]](%[[OUTER_EH:.*]]: !cir.eh_token):
+// CHECK:         %[[OUTER_CT:.*]] = cir.begin_cleanup %[[OUTER_EH]] : !cir.eh_token -> !cir.cleanup_token
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.end_cleanup %[[OUTER_CT]] : !cir.cleanup_token
+// CHECK:         cir.resume
+//
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.return
+
 cir.func private @get() -> !s32i
 cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
 cir.func private @dtor(!cir.ptr<!rec_SomeClass>) attributes {nothrow}

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
@@ -104,16 +104,15 @@ cir.func @test_eh_cleanup_in_try_catch_unwind() {
   cir.return
 }
 
-// Test that we issue a diagnostic for nested EH cleanup scopes.
-// The inner EH unwind path must chain through the outer cleanup, which is
-// not yet implemented.
+// Test that we issue a diagnostic for throwing calls in the cleanup region
+// of a nested EH cleanup scope (the dtor is not nothrow).
 cir.func @test_nested_eh_cleanup() {
   %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c1", init] {alignment = 4 : i64}
   %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
   cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
   cir.cleanup.scope {
     cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
-    // expected-error @below {{nested EH cleanup scope flattening is not yet implemented}}
+    // expected-error @below {{throwing calls in cleanup region are not yet implemented}}
     cir.cleanup.scope {
       cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
       cir.yield
@@ -129,16 +128,15 @@ cir.func @test_nested_eh_cleanup() {
   cir.return
 }
 
-// Test that we issue a diagnostic for nested Normal+EH cleanup scopes.
-// The inner EH unwind path must chain through the outer cleanup, which is
-// not yet implemented.
+// Test that we issue a diagnostic for throwing calls in the cleanup region
+// of a nested Normal+EH cleanup scope (the dtor is not nothrow).
 cir.func @test_nested_all_cleanup() {
   %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c1", init] {alignment = 4 : i64}
   %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
   cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
   cir.cleanup.scope {
     cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
-    // expected-error @below {{nested EH cleanup scope flattening is not yet implemented}}
+    // expected-error @below {{throwing calls in cleanup region are not yet implemented}}
     cir.cleanup.scope {
       cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
       cir.yield

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
@@ -205,6 +205,35 @@ cir.func @test_goto_in_nested_cleanup() {
   cir.return
 }
 
+// Test that a try op with handlers nested inside a cleanup scope produces
+// a diagnostic. The cleanup scope defers to the try op, which then fails
+// because handler flattening is not yet implemented.
+cir.func @test_try_with_handlers_in_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    // expected-error @below {{TryOp flattening with handlers is not yet implemented}}
+    cir.try {
+      cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    } catch all (%eh_token : !cir.eh_token) {
+      %catch_token, %1 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+      cir.cleanup.scope {
+        cir.yield
+      } cleanup eh {
+        cir.end_catch %catch_token : !cir.catch_token
+        cir.yield
+      }
+      cir.yield
+    }
+    cir.yield
+  } cleanup all {
+    cir.call @dtor(%0) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
 // Test that we issue a diagnostic for throwing calls in the cleanup region
 // of an EH cleanup scope.
 cir.func @test_throwing_call_in_eh_cleanup() {


### PR DESCRIPTION
This implements flattening of nested EH cleanup scopes, rewriting the inner scope's resume to branch to the outer scope's EH cleanup block.

I used AI tools to generate many of the changes in this PR, but I have carefully reviewed the changes and updated as needed.