### PR TITLE
[docs] Add exception to AI tool policy for Bazel build fixer

### DIFF
--- a/llvm/docs/AIToolPolicy.md
+++ b/llvm/docs/AIToolPolicy.md
@@ -143,6 +143,23 @@ contributors are responsible for ensuring that such material does not appear in
 their contributions. Contributions found to violate this policy will be removed
 just like any other offending contribution.
 
+## Exceptions
+
+We have made exceptions to this policy for tools that do not demand maintainer
+attention, are useful, and generally don't interfere with other activities.
+
+* Bazel-fixer bot: The project council approved [this RFC][bazel-rfc] proposing
+  to use a combination of [dwyu][dwyu] and LLMs to maintain the Bazel build files.
+
+We've only made one formally approved policy exception, but perhaps this list
+will grow. We're aware of the [@llvmgnsyncbot][llvmgnsyncbot] tool, but the
+project has not made a decision to approve this tool, therefore doesn't appear
+in the list above.
+
+[bazel-rfc]: https://discourse.llvm.org/t/rfc-ai-assisted-bazel-fixer-bot/89178/93
+[dwyu]: https://github.com/hzeller/bant?tab=readme-ov-file#dwyu--depend-on-what-you-use
+[llvmgnsyncbot]: https://github.com/llvm/llvm-project/commits?author=llvmgnsyncbot
+
 ## Examples
 
 Here are some examples of contributions that demonstrate how to apply

--- a/llvm/docs/AIToolPolicy.md
+++ b/llvm/docs/AIToolPolicy.md
@@ -145,20 +145,15 @@ just like any other offending contribution.
 
 ## Exceptions
 
-We have made exceptions to this policy for tools that do not demand maintainer
-attention, are useful, and generally don't interfere with other activities.
-
-* Bazel-fixer bot: The project council approved [this RFC][bazel-rfc] proposing
-  to use a combination of [dwyu][dwyu] and LLMs to maintain the Bazel build files.
-
-We've only made one formally approved policy exception, but perhaps this list
-will grow. We're aware of the [@llvmgnsyncbot][llvmgnsyncbot] tool, but the
-project has not made a decision to approve this tool, therefore it doesn't
-appear in the list above.
+We have one exception to this policy for the Bazel-fixer bot. The project
+council approved [this RFC][bazel-rfc] proposing to use a combination of
+[dwyu][dwyu] and LLMs to maintain the Bazel build files.
 
 [bazel-rfc]: https://discourse.llvm.org/t/rfc-ai-assisted-bazel-fixer-bot/89178/93
 [dwyu]: https://github.com/hzeller/bant?tab=readme-ov-file#dwyu--depend-on-what-you-use
-[llvmgnsyncbot]: https://github.com/llvm/llvm-project/commits?author=llvmgnsyncbot
+
+Any future exception will be considered individually on its own merits as to
+whether it is useful to the project or extracts work from maintainers.
 
 ## Examples
 

--- a/llvm/docs/AIToolPolicy.md
+++ b/llvm/docs/AIToolPolicy.md
@@ -153,8 +153,8 @@ attention, are useful, and generally don't interfere with other activities.
 
 We've only made one formally approved policy exception, but perhaps this list
 will grow. We're aware of the [@llvmgnsyncbot][llvmgnsyncbot] tool, but the
-project has not made a decision to approve this tool, therefore doesn't appear
-in the list above.
+project has not made a decision to approve this tool, therefore it doesn't
+appear in the list above.
 
 [bazel-rfc]: https://discourse.llvm.org/t/rfc-ai-assisted-bazel-fixer-bot/89178/93
 [dwyu]: https://github.com/hzeller/bant?tab=readme-ov-file#dwyu--depend-on-what-you-use


### PR DESCRIPTION
The Bazel RFC concluded earlier this month:
https://discourse.llvm.org/t/rfc-ai-assisted-bazel-fixer-bot/89178/93

I felt the best way to document this decision was to incorporate it into this policy document.