### PR TITLE
[compiler-rt] fix __sanitizer::struct_sock_fprog_sz availability

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
@@ -76,6 +76,7 @@
 #include <sys/vt.h>
 #include <linux/cdrom.h>
 #include <linux/fd.h>
+#include <linux/filter.h>
 #if SANITIZER_ANDROID
 #include <linux/fs.h>
 #endif
@@ -516,6 +517,7 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
   unsigned struct_seq_event_rec_sz = sizeof(struct seq_event_rec);
   unsigned struct_synth_info_sz = sizeof(struct synth_info);
   unsigned struct_vt_mode_sz = sizeof(struct vt_mode);
+  unsigned struct_sock_fprog_sz = sizeof(struct sock_fprog);
 #endif // SANITIZER_LINUX
 
 #if SANITIZER_GLIBC
@@ -543,7 +545,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
 
   unsigned struct_audio_buf_info_sz = sizeof(struct audio_buf_info);
   unsigned struct_ppp_stats_sz = sizeof(struct ppp_stats);
-  unsigned struct_sock_fprog_sz = sizeof(struct sock_fprog);
 #  endif  // SANITIZER_GLIBC
 
 #  if !SANITIZER_ANDROID && !SANITIZER_APPLE && !SANITIZER_HAIKU


### PR DESCRIPTION
`struct sock_fprog` is not provided by glibc, but rather by the linux headers (`#include <linux/filter.h`). It seems that glibc due to an implementation detail internally includes `<linux/filter.h>` somewhere other C libs (e.g. musl) do not, which previously caused build failures and let to disabling `struct sock_fprog` on non-glibc Linux systems.

This adds the missing include and provides it again for all Linux systems regardless of C lib.