### PR TITLE
[lldb/test] Fix tests reading log from remote platform instead of host

### DIFF
--- a/lldb/test/API/lang/objc/failing-description/TestObjCFailingDescription.py
+++ b/lldb/test/API/lang/objc/failing-description/TestObjCFailingDescription.py
@@ -17,7 +17,7 @@ class TestCase(TestBase):
             substrs=["`po` was unsuccessful, running `p` instead\n", "(Bad *) 0x"],
         )
         self.filecheck(
-            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-EXPR"
+            f"platform shell -h -- cat {log}", __file__, f"-check-prefix=CHECK-EXPR"
         )
         # CHECK-EXPR: Object description fallback due to error: could not evaluate print object function: expression interrupted
 
@@ -26,6 +26,8 @@ class TestCase(TestBase):
             substrs=["`po` was unsuccessful, running `p` instead\n", "_lookHere = NO"],
         )
         self.filecheck(
-            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-DWIM-PRINT"
+            f"platform shell -h -- cat {log}",
+            __file__,
+            f"-check-prefix=CHECK-DWIM-PRINT",
         )
         # CHECK-DWIM-PRINT: Object description fallback due to error: could not evaluate print object function: expression interrupted

--- a/lldb/test/API/lang/objc/struct-description/TestObjCStructDescription.py
+++ b/lldb/test/API/lang/objc/struct-description/TestObjCStructDescription.py
@@ -19,7 +19,9 @@ class TestCase(TestBase):
                 "(Pair) pair = (f = 2, e = 3)",
             ],
         )
-        self.filecheck(f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-VO")
+        self.filecheck(
+            f"platform shel -h -- cat {log}", __file__, f"-check-prefix=CHECK-VO"
+        )
         # CHECK-VO: Object description fallback due to error: not a pointer type
 
         self.expect(
@@ -30,6 +32,6 @@ class TestCase(TestBase):
             ],
         )
         self.filecheck(
-            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-EXPR"
+            f"platform shel -h -- cat {log}", __file__, f"-check-prefix=CHECK-EXPR"
         )
         # CHECK-EXPR: Object description fallback due to error: not a pointer type


### PR DESCRIPTION
Some tests are using logs to validate that a test behaves correctly however they used `platform shell cat {log}` to read the logfile.

This doesn't work when running the testsuite against a remote platform since the logs are saved on the host's filesystem.

This patch addresses those failures by making sure we read the log file from the host platform.