### PR TITLE
[mlir][Python] Drop Python <=3.9 compatibility path

### DIFF
--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -774,12 +774,6 @@ std::unique_ptr<nb_buffer_info> PyDenseElementsAttribute::accessBuffer() {
 }
 
 void PyDenseElementsAttribute::bindDerived(ClassTy &c) {
-#if PY_VERSION_HEX < 0x03090000
-  PyTypeObject *tp = reinterpret_cast<PyTypeObject *>(c.ptr());
-  tp->tp_as_buffer->bf_getbuffer = PyDenseElementsAttribute::bf_getbuffer;
-  tp->tp_as_buffer->bf_releasebuffer =
-      PyDenseElementsAttribute::bf_releasebuffer;
-#endif
   c.def("__len__", &PyDenseElementsAttribute::dunderLen)
       .def_static(
           "get", PyDenseElementsAttribute::getFromBuffer, nb::arg("array"),
@@ -931,14 +925,10 @@ MlirAttribute PyDenseElementsAttribute::getAttributeFromBuffer(
 }
 
 PyType_Slot PyDenseElementsAttribute::slots[] = {
-// Python 3.8 doesn't allow setting the buffer protocol slots from a type spec.
-#if PY_VERSION_HEX >= 0x03090000
     {Py_bf_getbuffer,
      reinterpret_cast<void *>(PyDenseElementsAttribute::bf_getbuffer)},
     {Py_bf_releasebuffer,
      reinterpret_cast<void *>(PyDenseElementsAttribute::bf_releasebuffer)},
-#endif
-    {0, nullptr},
 };
 
 /*static*/ int PyDenseElementsAttribute::bf_getbuffer(PyObject *obj,

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -929,6 +929,7 @@ PyType_Slot PyDenseElementsAttribute::slots[] = {
      reinterpret_cast<void *>(PyDenseElementsAttribute::bf_getbuffer)},
     {Py_bf_releasebuffer,
      reinterpret_cast<void *>(PyDenseElementsAttribute::bf_releasebuffer)},
+    {0, nullptr},
 };
 
 /*static*/ int PyDenseElementsAttribute::bf_getbuffer(PyObject *obj,

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2714,30 +2714,6 @@ namespace {
 
 #endif // Python 3.10.0a3
 
-// Python 3.9.0b1
-#if PY_VERSION_HEX < 0x030900B1 && !defined(PYPY_VERSION)
-
-// bpo-40429 added PyThreadState_GetFrame()
-PyFrameObject *PyThreadState_GetFrame(PyThreadState *tstate) {
-  assert(tstate != _Py_NULL && "expected tstate != _Py_NULL");
-  return _Py_CAST(PyFrameObject *, Py_XNewRef(tstate->frame));
-}
-
-// bpo-40421 added PyFrame_GetBack()
-PyFrameObject *PyFrame_GetBack(PyFrameObject *frame) {
-  assert(frame != _Py_NULL && "expected frame != _Py_NULL");
-  return _Py_CAST(PyFrameObject *, Py_XNewRef(frame->f_back));
-}
-
-// bpo-40421 added PyFrame_GetCode()
-PyCodeObject *PyFrame_GetCode(PyFrameObject *frame) {
-  assert(frame != _Py_NULL && "expected frame != _Py_NULL");
-  assert(frame->f_code != _Py_NULL && "expected frame->f_code != _Py_NULL");
-  return _Py_CAST(PyCodeObject *, Py_NewRef(frame->f_code));
-}
-
-#endif // Python 3.9.0b1
-
 using namespace mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN;
 
 MlirLocation tracebackToLocation(MlirContext ctx) {


### PR DESCRIPTION
According to PR #163499, minimum Python version for mlir-py is now 3.10, we no longer need patches for py<=3.9.

This change aligns with the Python version bump policy discussed [here](https://discourse.llvm.org/t/rfc-adopt-regularly-scheduled-python-minimum-version-bumps/88841).