### PR TITLE
[lldb/test] Use filecheck_log to read log files from the host platform

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2411,6 +2411,16 @@ FileCheck output:
 
         self.assertEqual(cmd_status, 0)
 
+    def filecheck_log(
+        self, log_file, check_file, filecheck_options="", expect_cmd_failure=False
+    ):
+        return self.filecheck(
+            f"platform shell -h -- cat {log_file}",
+            check_file,
+            filecheck_options,
+            expect_cmd_failure,
+        )
+
     def expect(
         self,
         string,

--- a/lldb/test/API/lang/objc/failing-description/TestObjCFailingDescription.py
+++ b/lldb/test/API/lang/objc/failing-description/TestObjCFailingDescription.py
@@ -16,16 +16,12 @@ class TestCase(TestBase):
             "expr -O -- bad",
             substrs=["`po` was unsuccessful, running `p` instead\n", "(Bad *) 0x"],
         )
-        self.filecheck(
-            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-EXPR"
-        )
+        self.filecheck_log(log, __file__, f"-check-prefix=CHECK-EXPR")
         # CHECK-EXPR: Object description fallback due to error: could not evaluate print object function: expression interrupted
 
         self.expect(
             "dwim-print -O -- bad",
             substrs=["`po` was unsuccessful, running `p` instead\n", "_lookHere = NO"],
         )
-        self.filecheck(
-            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-DWIM-PRINT"
-        )
+        self.filecheck_log(log, __file__, f"-check-prefix=CHECK-DWIM-PRINT")
         # CHECK-DWIM-PRINT: Object description fallback due to error: could not evaluate print object function: expression interrupted

--- a/lldb/test/API/lang/objc/struct-description/TestObjCStructDescription.py
+++ b/lldb/test/API/lang/objc/struct-description/TestObjCStructDescription.py
@@ -19,7 +19,7 @@ class TestCase(TestBase):
                 "(Pair) pair = (f = 2, e = 3)",
             ],
         )
-        self.filecheck(f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-VO")
+        self.filecheck_log(log, __file__, f"-check-prefix=CHECK-VO")
         # CHECK-VO: Object description fallback due to error: not a pointer type
 
         self.expect(
@@ -29,7 +29,5 @@ class TestCase(TestBase):
                 "(Pair)  (f = 2, e = 3)",
             ],
         )
-        self.filecheck(
-            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-EXPR"
-        )
+        self.filecheck_log(log, __file__, f"-check-prefix=CHECK-EXPR")
         # CHECK-EXPR: Object description fallback due to error: not a pointer type


### PR DESCRIPTION
Some tests were using `self.filecheck` with `platform shell cat {log}` to validate test behavior through log inspection.

This doesn't work when running the testsuite against a remote platform since the logs are saved on the host's filesystem.

This patch refactors those call sites to use the new `filecheck_log` helper, which ensures the log file is always read from the host platform.