### PR TITLE
[RISCV] Partial support for using PPAIRE.B/H to optimize unaligned load sequences.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -4307,6 +4307,12 @@ bool RISCVDAGToDAGISel::hasAllNBitUsers(SDNode *Node, unsigned Bits,
       if (Bits >= (Subtarget->getXLen() / 2))
         break;
       return false;
+    case RISCV::PPAIRE_H:
+      // If only the lower 32-bits of the result are used, then only the
+      // lower 16 bits of the inputs are used.
+      if (Bits >= 16 && hasAllNBitUsers(User, 32, Depth + 1))
+        break;
+      return false;
     case RISCV::ADD_UW:
     case RISCV::SH1ADD_UW:
     case RISCV::SH2ADD_UW:

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1560,6 +1560,12 @@ let Predicates = [HasStdExtP] in {
   def : Pat<(XLenVT (riscv_merge GPR:$rd, GPR:$rs1, GPR:$rs2)),
             (PseudoMERGE GPR:$rd, GPR:$rs1, GPR:$rs2)>;
 
+  // Match a pattern of 2 bytes being inserted into bits [15:8] when only the
+  // upper 16 bits are being demanded.
+  def : Pat<(binop_allhusers<or> (shl GPR:$rs2, (XLenVT 8)),
+                                 zexti8:$rs1),
+            (PPAIRE_B zexti8:$rs1, GPR:$rs2)>;
+
   // Basic 8-bit arithmetic patterns
   def: Pat<(XLenVecI8VT (add GPR:$rs1, GPR:$rs2)), (PADD_B GPR:$rs1, GPR:$rs2)>;
   def: Pat<(XLenVecI8VT (sub GPR:$rs1, GPR:$rs2)), (PSUB_B GPR:$rs1, GPR:$rs2)>;
@@ -1745,6 +1751,16 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def : Pat<(i32 (riscv_nsra GPR:$lo, GPR:$hi, shiftMask64:$shamt)),
             (NSRA (BuildGPRPair GPR:$lo, GPR:$hi), shiftMask64:$shamt)>;
 
+  // Match a pattern of 2 bytes being inserted into bits [31:16], with bits
+  // bits [15:0] coming from a zero extended value. We can use pack with
+  // ppaire.b for bits [31:16]. If bits [15:0] can also be a ppaire.b, it can be
+  // matched separately.
+  def : Pat<(i32 (or (or (shl GPR:$op1rs2, (XLenVT 24)),
+                       (shl zexti8:$op1rs1, (XLenVT 16))),
+                     zexti16:$rs1)),
+            (PACK zexti16:$rs1,
+                  (XLenVT (PPAIRE_B zexti8:$op1rs1, GPR:$op1rs2)))>;
+
   // 8/16-bit multiply low patterns
   def: Pat<(v4i8 (mul GPR:$rs1, GPR:$rs2)),
            (PNSRLI_B (PWMUL_B GPR:$rs1, GPR:$rs2), 0)>;
@@ -1767,6 +1783,17 @@ let Predicates = [HasStdExtP, IsRV64] in {
   def : PatGpr<riscv_clsw, CLSW>;
 
   def : PatGpr<bitreverse, REV_RV64>;
+
+  // Match a pattern of 2 bytes being inserted into bits [31:16], with bits
+  // bits [15:0] coming from a zero extended value, and bits [63:32] being
+  // ignored. We can use ppaire.h with ppaire.b for bits [31:16]. If bits [15:0]
+  // can also be a ppaire.b, it can be matched separately.
+  def : Pat<(binop_allwusers<or>
+                 (or (shl GPR:$op1rs2, (XLenVT 24)),
+                     (shl zexti8:$op1rs1, (XLenVT 16))),
+                 zexti16:$rs1),
+            (PPAIRE_H zexti16:$rs1,
+                      (XLenVT (PPAIRE_B zexti8:$op1rs1, GPR:$op1rs2)))>;
 
   // 32-bit PLI SD node pattern
   def: Pat<(v2i32 (splat_vector simm10:$imm10)), (PLI_W simm10:$imm10)>;

--- a/llvm/test/CodeGen/RISCV/rvp-unaligned-load-store.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-unaligned-load-store.ll
@@ -11,52 +11,40 @@
 define void @test_load_v4i8_align1(ptr %ret_ptr, ptr %a_ptr) {
 ; CHECK-RV32-LABEL: test_load_v4i8_align1:
 ; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    lbu a2, 5(a1)
-; CHECK-RV32-NEXT:    lbu a3, 6(a1)
-; CHECK-RV32-NEXT:    lbu a4, 7(a1)
-; CHECK-RV32-NEXT:    lbu a5, 4(a1)
-; CHECK-RV32-NEXT:    slli a2, a2, 8
-; CHECK-RV32-NEXT:    slli a3, a3, 16
-; CHECK-RV32-NEXT:    slli a4, a4, 24
-; CHECK-RV32-NEXT:    or a2, a2, a5
-; CHECK-RV32-NEXT:    or a3, a4, a3
-; CHECK-RV32-NEXT:    lbu a4, 1(a1)
-; CHECK-RV32-NEXT:    lbu a5, 0(a1)
-; CHECK-RV32-NEXT:    lbu a6, 2(a1)
-; CHECK-RV32-NEXT:    lbu a1, 3(a1)
-; CHECK-RV32-NEXT:    slli a4, a4, 8
-; CHECK-RV32-NEXT:    or a4, a4, a5
-; CHECK-RV32-NEXT:    slli a6, a6, 16
-; CHECK-RV32-NEXT:    slli a1, a1, 24
-; CHECK-RV32-NEXT:    or a1, a1, a6
-; CHECK-RV32-NEXT:    or a2, a3, a2
-; CHECK-RV32-NEXT:    or a1, a1, a4
+; CHECK-RV32-NEXT:    lbu a2, 4(a1)
+; CHECK-RV32-NEXT:    lbu a3, 5(a1)
+; CHECK-RV32-NEXT:    lbu a4, 6(a1)
+; CHECK-RV32-NEXT:    lbu a5, 7(a1)
+; CHECK-RV32-NEXT:    lbu a6, 1(a1)
+; CHECK-RV32-NEXT:    lbu a7, 2(a1)
+; CHECK-RV32-NEXT:    lbu t0, 3(a1)
+; CHECK-RV32-NEXT:    lbu a1, 0(a1)
+; CHECK-RV32-NEXT:    ppaire.b a4, a4, a5
+; CHECK-RV32-NEXT:    ppaire.b a2, a2, a3
+; CHECK-RV32-NEXT:    ppaire.b a3, a7, t0
+; CHECK-RV32-NEXT:    ppaire.b a1, a1, a6
+; CHECK-RV32-NEXT:    pack a2, a2, a4
+; CHECK-RV32-NEXT:    pack a1, a1, a3
 ; CHECK-RV32-NEXT:    sw a1, 0(a0)
 ; CHECK-RV32-NEXT:    sw a2, 4(a0)
 ; CHECK-RV32-NEXT:    ret
 ;
 ; CHECK-RV64-LABEL: test_load_v4i8_align1:
 ; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    lbu a2, 5(a1)
-; CHECK-RV64-NEXT:    lbu a3, 6(a1)
-; CHECK-RV64-NEXT:    lbu a4, 7(a1)
-; CHECK-RV64-NEXT:    lbu a5, 4(a1)
-; CHECK-RV64-NEXT:    slli a2, a2, 8
-; CHECK-RV64-NEXT:    slli a3, a3, 16
-; CHECK-RV64-NEXT:    slli a4, a4, 24
-; CHECK-RV64-NEXT:    or a2, a2, a5
-; CHECK-RV64-NEXT:    or a3, a4, a3
-; CHECK-RV64-NEXT:    lbu a4, 1(a1)
-; CHECK-RV64-NEXT:    lbu a5, 0(a1)
-; CHECK-RV64-NEXT:    lbu a6, 2(a1)
-; CHECK-RV64-NEXT:    lbu a1, 3(a1)
-; CHECK-RV64-NEXT:    slli a4, a4, 8
-; CHECK-RV64-NEXT:    or a4, a4, a5
-; CHECK-RV64-NEXT:    slli a6, a6, 16
-; CHECK-RV64-NEXT:    slli a1, a1, 24
-; CHECK-RV64-NEXT:    or a1, a1, a6
-; CHECK-RV64-NEXT:    or a2, a3, a2
-; CHECK-RV64-NEXT:    or a1, a1, a4
+; CHECK-RV64-NEXT:    lbu a2, 4(a1)
+; CHECK-RV64-NEXT:    lbu a3, 5(a1)
+; CHECK-RV64-NEXT:    lbu a4, 6(a1)
+; CHECK-RV64-NEXT:    lbu a5, 7(a1)
+; CHECK-RV64-NEXT:    lbu a6, 1(a1)
+; CHECK-RV64-NEXT:    lbu a7, 2(a1)
+; CHECK-RV64-NEXT:    lbu t0, 3(a1)
+; CHECK-RV64-NEXT:    lbu a1, 0(a1)
+; CHECK-RV64-NEXT:    ppaire.b a4, a4, a5
+; CHECK-RV64-NEXT:    ppaire.b a2, a2, a3
+; CHECK-RV64-NEXT:    ppaire.b a3, a7, t0
+; CHECK-RV64-NEXT:    ppaire.b a1, a1, a6
+; CHECK-RV64-NEXT:    ppaire.h a2, a2, a4
+; CHECK-RV64-NEXT:    ppaire.h a1, a1, a3
 ; CHECK-RV64-NEXT:    pack a1, a1, a2
 ; CHECK-RV64-NEXT:    sd a1, 0(a0)
 ; CHECK-RV64-NEXT:    ret
@@ -301,30 +289,24 @@ define void @test_load_v2i16_align1(ptr %ret_ptr, ptr %a_ptr) {
 ; CHECK-RV32-LABEL: test_load_v2i16_align1:
 ; CHECK-RV32:       # %bb.0:
 ; CHECK-RV32-NEXT:    lbu a2, 1(a1)
-; CHECK-RV32-NEXT:    lbu a3, 0(a1)
-; CHECK-RV32-NEXT:    lbu a4, 2(a1)
-; CHECK-RV32-NEXT:    lbu a1, 3(a1)
-; CHECK-RV32-NEXT:    slli a2, a2, 8
-; CHECK-RV32-NEXT:    or a2, a2, a3
-; CHECK-RV32-NEXT:    slli a4, a4, 16
-; CHECK-RV32-NEXT:    slli a1, a1, 24
-; CHECK-RV32-NEXT:    or a1, a1, a4
-; CHECK-RV32-NEXT:    or a1, a1, a2
+; CHECK-RV32-NEXT:    lbu a3, 2(a1)
+; CHECK-RV32-NEXT:    lbu a4, 3(a1)
+; CHECK-RV32-NEXT:    lbu a1, 0(a1)
+; CHECK-RV32-NEXT:    ppaire.b a3, a3, a4
+; CHECK-RV32-NEXT:    ppaire.b a1, a1, a2
+; CHECK-RV32-NEXT:    pack a1, a1, a3
 ; CHECK-RV32-NEXT:    sw a1, 0(a0)
 ; CHECK-RV32-NEXT:    ret
 ;
 ; CHECK-RV64-LABEL: test_load_v2i16_align1:
 ; CHECK-RV64:       # %bb.0:
 ; CHECK-RV64-NEXT:    lbu a2, 1(a1)
-; CHECK-RV64-NEXT:    lbu a3, 0(a1)
-; CHECK-RV64-NEXT:    lbu a4, 2(a1)
-; CHECK-RV64-NEXT:    lb a1, 3(a1)
-; CHECK-RV64-NEXT:    slli a2, a2, 8
-; CHECK-RV64-NEXT:    or a2, a2, a3
-; CHECK-RV64-NEXT:    slli a4, a4, 16
-; CHECK-RV64-NEXT:    slli a1, a1, 24
-; CHECK-RV64-NEXT:    or a1, a1, a4
-; CHECK-RV64-NEXT:    or a1, a1, a2
+; CHECK-RV64-NEXT:    lbu a3, 2(a1)
+; CHECK-RV64-NEXT:    lb a4, 3(a1)
+; CHECK-RV64-NEXT:    lbu a1, 0(a1)
+; CHECK-RV64-NEXT:    ppaire.b a3, a3, a4
+; CHECK-RV64-NEXT:    ppaire.b a1, a1, a2
+; CHECK-RV64-NEXT:    ppaire.h a1, a1, a3
 ; CHECK-RV64-NEXT:    sw a1, 0(a0)
 ; CHECK-RV64-NEXT:    ret
 ;
@@ -411,52 +393,40 @@ define void @test_store_v2i16_align2(ptr %a_ptr, ptr %b_ptr) {
 define void @test_load_v8i8_align1(ptr %ret_ptr, ptr %a_ptr) {
 ; CHECK-RV32-LABEL: test_load_v8i8_align1:
 ; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    lbu a2, 5(a1)
-; CHECK-RV32-NEXT:    lbu a3, 6(a1)
-; CHECK-RV32-NEXT:    lbu a4, 7(a1)
-; CHECK-RV32-NEXT:    lbu a5, 4(a1)
-; CHECK-RV32-NEXT:    slli a2, a2, 8
-; CHECK-RV32-NEXT:    slli a3, a3, 16
-; CHECK-RV32-NEXT:    slli a4, a4, 24
-; CHECK-RV32-NEXT:    or a2, a2, a5
-; CHECK-RV32-NEXT:    or a3, a4, a3
-; CHECK-RV32-NEXT:    lbu a4, 1(a1)
-; CHECK-RV32-NEXT:    lbu a5, 0(a1)
-; CHECK-RV32-NEXT:    lbu a6, 2(a1)
-; CHECK-RV32-NEXT:    lbu a1, 3(a1)
-; CHECK-RV32-NEXT:    slli a4, a4, 8
-; CHECK-RV32-NEXT:    or a4, a4, a5
-; CHECK-RV32-NEXT:    slli a6, a6, 16
-; CHECK-RV32-NEXT:    slli a1, a1, 24
-; CHECK-RV32-NEXT:    or a1, a1, a6
-; CHECK-RV32-NEXT:    or a2, a3, a2
-; CHECK-RV32-NEXT:    or a1, a1, a4
+; CHECK-RV32-NEXT:    lbu a2, 4(a1)
+; CHECK-RV32-NEXT:    lbu a3, 5(a1)
+; CHECK-RV32-NEXT:    lbu a4, 6(a1)
+; CHECK-RV32-NEXT:    lbu a5, 7(a1)
+; CHECK-RV32-NEXT:    lbu a6, 1(a1)
+; CHECK-RV32-NEXT:    lbu a7, 2(a1)
+; CHECK-RV32-NEXT:    lbu t0, 3(a1)
+; CHECK-RV32-NEXT:    lbu a1, 0(a1)
+; CHECK-RV32-NEXT:    ppaire.b a4, a4, a5
+; CHECK-RV32-NEXT:    ppaire.b a2, a2, a3
+; CHECK-RV32-NEXT:    ppaire.b a3, a7, t0
+; CHECK-RV32-NEXT:    ppaire.b a1, a1, a6
+; CHECK-RV32-NEXT:    pack a2, a2, a4
+; CHECK-RV32-NEXT:    pack a1, a1, a3
 ; CHECK-RV32-NEXT:    sw a1, 0(a0)
 ; CHECK-RV32-NEXT:    sw a2, 4(a0)
 ; CHECK-RV32-NEXT:    ret
 ;
 ; CHECK-RV64-LABEL: test_load_v8i8_align1:
 ; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    lbu a2, 5(a1)
-; CHECK-RV64-NEXT:    lbu a3, 6(a1)
-; CHECK-RV64-NEXT:    lbu a4, 7(a1)
-; CHECK-RV64-NEXT:    lbu a5, 4(a1)
-; CHECK-RV64-NEXT:    slli a2, a2, 8
-; CHECK-RV64-NEXT:    slli a3, a3, 16
-; CHECK-RV64-NEXT:    slli a4, a4, 24
-; CHECK-RV64-NEXT:    or a2, a2, a5
-; CHECK-RV64-NEXT:    or a3, a4, a3
-; CHECK-RV64-NEXT:    lbu a4, 1(a1)
-; CHECK-RV64-NEXT:    lbu a5, 0(a1)
-; CHECK-RV64-NEXT:    lbu a6, 2(a1)
-; CHECK-RV64-NEXT:    lbu a1, 3(a1)
-; CHECK-RV64-NEXT:    slli a4, a4, 8
-; CHECK-RV64-NEXT:    or a4, a4, a5
-; CHECK-RV64-NEXT:    slli a6, a6, 16
-; CHECK-RV64-NEXT:    slli a1, a1, 24
-; CHECK-RV64-NEXT:    or a1, a1, a6
-; CHECK-RV64-NEXT:    or a2, a3, a2
-; CHECK-RV64-NEXT:    or a1, a1, a4
+; CHECK-RV64-NEXT:    lbu a2, 4(a1)
+; CHECK-RV64-NEXT:    lbu a3, 5(a1)
+; CHECK-RV64-NEXT:    lbu a4, 6(a1)
+; CHECK-RV64-NEXT:    lbu a5, 7(a1)
+; CHECK-RV64-NEXT:    lbu a6, 1(a1)
+; CHECK-RV64-NEXT:    lbu a7, 2(a1)
+; CHECK-RV64-NEXT:    lbu t0, 3(a1)
+; CHECK-RV64-NEXT:    lbu a1, 0(a1)
+; CHECK-RV64-NEXT:    ppaire.b a4, a4, a5
+; CHECK-RV64-NEXT:    ppaire.b a2, a2, a3
+; CHECK-RV64-NEXT:    ppaire.b a3, a7, t0
+; CHECK-RV64-NEXT:    ppaire.b a1, a1, a6
+; CHECK-RV64-NEXT:    ppaire.h a2, a2, a4
+; CHECK-RV64-NEXT:    ppaire.h a1, a1, a3
 ; CHECK-RV64-NEXT:    pack a1, a1, a2
 ; CHECK-RV64-NEXT:    sd a1, 0(a0)
 ; CHECK-RV64-NEXT:    ret
@@ -630,52 +600,40 @@ define void @test_store_v8i8_align2(ptr %a_ptr, ptr %b_ptr) {
 define void @test_load_v4i16_align1(ptr %ret_ptr, ptr %a_ptr) {
 ; CHECK-RV32-LABEL: test_load_v4i16_align1:
 ; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    lbu a2, 5(a1)
-; CHECK-RV32-NEXT:    lbu a3, 6(a1)
-; CHECK-RV32-NEXT:    lbu a4, 7(a1)
-; CHECK-RV32-NEXT:    lbu a5, 4(a1)
-; CHECK-RV32-NEXT:    slli a2, a2, 8
-; CHECK-RV32-NEXT:    slli a3, a3, 16
-; CHECK-RV32-NEXT:    slli a4, a4, 24
-; CHECK-RV32-NEXT:    or a2, a2, a5
-; CHECK-RV32-NEXT:    or a3, a4, a3
-; CHECK-RV32-NEXT:    lbu a4, 1(a1)
-; CHECK-RV32-NEXT:    lbu a5, 0(a1)
-; CHECK-RV32-NEXT:    lbu a6, 2(a1)
-; CHECK-RV32-NEXT:    lbu a1, 3(a1)
-; CHECK-RV32-NEXT:    slli a4, a4, 8
-; CHECK-RV32-NEXT:    or a4, a4, a5
-; CHECK-RV32-NEXT:    slli a6, a6, 16
-; CHECK-RV32-NEXT:    slli a1, a1, 24
-; CHECK-RV32-NEXT:    or a1, a1, a6
-; CHECK-RV32-NEXT:    or a2, a3, a2
-; CHECK-RV32-NEXT:    or a1, a1, a4
+; CHECK-RV32-NEXT:    lbu a2, 4(a1)
+; CHECK-RV32-NEXT:    lbu a3, 5(a1)
+; CHECK-RV32-NEXT:    lbu a4, 6(a1)
+; CHECK-RV32-NEXT:    lbu a5, 7(a1)
+; CHECK-RV32-NEXT:    lbu a6, 1(a1)
+; CHECK-RV32-NEXT:    lbu a7, 2(a1)
+; CHECK-RV32-NEXT:    lbu t0, 3(a1)
+; CHECK-RV32-NEXT:    lbu a1, 0(a1)
+; CHECK-RV32-NEXT:    ppaire.b a4, a4, a5
+; CHECK-RV32-NEXT:    ppaire.b a2, a2, a3
+; CHECK-RV32-NEXT:    ppaire.b a3, a7, t0
+; CHECK-RV32-NEXT:    ppaire.b a1, a1, a6
+; CHECK-RV32-NEXT:    pack a2, a2, a4
+; CHECK-RV32-NEXT:    pack a1, a1, a3
 ; CHECK-RV32-NEXT:    sw a1, 0(a0)
 ; CHECK-RV32-NEXT:    sw a2, 4(a0)
 ; CHECK-RV32-NEXT:    ret
 ;
 ; CHECK-RV64-LABEL: test_load_v4i16_align1:
 ; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    lbu a2, 5(a1)
-; CHECK-RV64-NEXT:    lbu a3, 6(a1)
-; CHECK-RV64-NEXT:    lbu a4, 7(a1)
-; CHECK-RV64-NEXT:    lbu a5, 4(a1)
-; CHECK-RV64-NEXT:    slli a2, a2, 8
-; CHECK-RV64-NEXT:    slli a3, a3, 16
-; CHECK-RV64-NEXT:    slli a4, a4, 24
-; CHECK-RV64-NEXT:    or a2, a2, a5
-; CHECK-RV64-NEXT:    or a3, a4, a3
-; CHECK-RV64-NEXT:    lbu a4, 1(a1)
-; CHECK-RV64-NEXT:    lbu a5, 0(a1)
-; CHECK-RV64-NEXT:    lbu a6, 2(a1)
-; CHECK-RV64-NEXT:    lbu a1, 3(a1)
-; CHECK-RV64-NEXT:    slli a4, a4, 8
-; CHECK-RV64-NEXT:    or a4, a4, a5
-; CHECK-RV64-NEXT:    slli a6, a6, 16
-; CHECK-RV64-NEXT:    slli a1, a1, 24
-; CHECK-RV64-NEXT:    or a1, a1, a6
-; CHECK-RV64-NEXT:    or a2, a3, a2
-; CHECK-RV64-NEXT:    or a1, a1, a4
+; CHECK-RV64-NEXT:    lbu a2, 4(a1)
+; CHECK-RV64-NEXT:    lbu a3, 5(a1)
+; CHECK-RV64-NEXT:    lbu a4, 6(a1)
+; CHECK-RV64-NEXT:    lbu a5, 7(a1)
+; CHECK-RV64-NEXT:    lbu a6, 1(a1)
+; CHECK-RV64-NEXT:    lbu a7, 2(a1)
+; CHECK-RV64-NEXT:    lbu t0, 3(a1)
+; CHECK-RV64-NEXT:    lbu a1, 0(a1)
+; CHECK-RV64-NEXT:    ppaire.b a4, a4, a5
+; CHECK-RV64-NEXT:    ppaire.b a2, a2, a3
+; CHECK-RV64-NEXT:    ppaire.b a3, a7, t0
+; CHECK-RV64-NEXT:    ppaire.b a1, a1, a6
+; CHECK-RV64-NEXT:    ppaire.h a2, a2, a4
+; CHECK-RV64-NEXT:    ppaire.h a1, a1, a3
 ; CHECK-RV64-NEXT:    pack a1, a1, a2
 ; CHECK-RV64-NEXT:    sd a1, 0(a0)
 ; CHECK-RV64-NEXT:    ret
@@ -919,52 +877,40 @@ define void @test_store_v4i16_align4(ptr %a_ptr, ptr %b_ptr) {
 define void @test_load_v2i32_align1(ptr %ret_ptr, ptr %a_ptr) {
 ; CHECK-RV32-LABEL: test_load_v2i32_align1:
 ; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    lbu a2, 1(a1)
-; CHECK-RV32-NEXT:    lbu a3, 2(a1)
-; CHECK-RV32-NEXT:    lbu a4, 3(a1)
-; CHECK-RV32-NEXT:    lbu a5, 0(a1)
-; CHECK-RV32-NEXT:    slli a2, a2, 8
-; CHECK-RV32-NEXT:    slli a3, a3, 16
-; CHECK-RV32-NEXT:    slli a4, a4, 24
-; CHECK-RV32-NEXT:    or a2, a2, a5
-; CHECK-RV32-NEXT:    or a3, a4, a3
-; CHECK-RV32-NEXT:    lbu a4, 5(a1)
-; CHECK-RV32-NEXT:    lbu a5, 4(a1)
-; CHECK-RV32-NEXT:    lbu a6, 6(a1)
-; CHECK-RV32-NEXT:    lbu a1, 7(a1)
-; CHECK-RV32-NEXT:    slli a4, a4, 8
-; CHECK-RV32-NEXT:    or a4, a4, a5
-; CHECK-RV32-NEXT:    slli a6, a6, 16
-; CHECK-RV32-NEXT:    slli a1, a1, 24
-; CHECK-RV32-NEXT:    or a1, a1, a6
-; CHECK-RV32-NEXT:    or a2, a3, a2
-; CHECK-RV32-NEXT:    or a1, a1, a4
+; CHECK-RV32-NEXT:    lbu a2, 0(a1)
+; CHECK-RV32-NEXT:    lbu a3, 1(a1)
+; CHECK-RV32-NEXT:    lbu a4, 2(a1)
+; CHECK-RV32-NEXT:    lbu a5, 3(a1)
+; CHECK-RV32-NEXT:    lbu a6, 5(a1)
+; CHECK-RV32-NEXT:    lbu a7, 6(a1)
+; CHECK-RV32-NEXT:    lbu t0, 7(a1)
+; CHECK-RV32-NEXT:    lbu a1, 4(a1)
+; CHECK-RV32-NEXT:    ppaire.b a4, a4, a5
+; CHECK-RV32-NEXT:    ppaire.b a2, a2, a3
+; CHECK-RV32-NEXT:    ppaire.b a3, a7, t0
+; CHECK-RV32-NEXT:    ppaire.b a1, a1, a6
+; CHECK-RV32-NEXT:    pack a2, a2, a4
+; CHECK-RV32-NEXT:    pack a1, a1, a3
 ; CHECK-RV32-NEXT:    sw a2, 0(a0)
 ; CHECK-RV32-NEXT:    sw a1, 4(a0)
 ; CHECK-RV32-NEXT:    ret
 ;
 ; CHECK-RV64-LABEL: test_load_v2i32_align1:
 ; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    lbu a2, 5(a1)
-; CHECK-RV64-NEXT:    lbu a3, 6(a1)
-; CHECK-RV64-NEXT:    lbu a4, 7(a1)
-; CHECK-RV64-NEXT:    lbu a5, 4(a1)
-; CHECK-RV64-NEXT:    slli a2, a2, 8
-; CHECK-RV64-NEXT:    slli a3, a3, 16
-; CHECK-RV64-NEXT:    slli a4, a4, 24
-; CHECK-RV64-NEXT:    or a2, a2, a5
-; CHECK-RV64-NEXT:    or a3, a4, a3
-; CHECK-RV64-NEXT:    lbu a4, 1(a1)
-; CHECK-RV64-NEXT:    lbu a5, 0(a1)
-; CHECK-RV64-NEXT:    lbu a6, 2(a1)
-; CHECK-RV64-NEXT:    lbu a1, 3(a1)
-; CHECK-RV64-NEXT:    slli a4, a4, 8
-; CHECK-RV64-NEXT:    or a4, a4, a5
-; CHECK-RV64-NEXT:    slli a6, a6, 16
-; CHECK-RV64-NEXT:    slli a1, a1, 24
-; CHECK-RV64-NEXT:    or a1, a1, a6
-; CHECK-RV64-NEXT:    or a2, a3, a2
-; CHECK-RV64-NEXT:    or a1, a1, a4
+; CHECK-RV64-NEXT:    lbu a2, 4(a1)
+; CHECK-RV64-NEXT:    lbu a3, 5(a1)
+; CHECK-RV64-NEXT:    lbu a4, 6(a1)
+; CHECK-RV64-NEXT:    lbu a5, 7(a1)
+; CHECK-RV64-NEXT:    lbu a6, 1(a1)
+; CHECK-RV64-NEXT:    lbu a7, 2(a1)
+; CHECK-RV64-NEXT:    lbu t0, 3(a1)
+; CHECK-RV64-NEXT:    lbu a1, 0(a1)
+; CHECK-RV64-NEXT:    ppaire.b a4, a4, a5
+; CHECK-RV64-NEXT:    ppaire.b a2, a2, a3
+; CHECK-RV64-NEXT:    ppaire.b a3, a7, t0
+; CHECK-RV64-NEXT:    ppaire.b a1, a1, a6
+; CHECK-RV64-NEXT:    ppaire.h a2, a2, a4
+; CHECK-RV64-NEXT:    ppaire.h a1, a1, a3
 ; CHECK-RV64-NEXT:    pack a1, a1, a2
 ; CHECK-RV64-NEXT:    sd a1, 0(a0)
 ; CHECK-RV64-NEXT:    ret


### PR DESCRIPTION
Patterns are based on patterns we use for Zbkb. We can't copy all patterns because PPAIRE.B/H are a little different than PACKW/PACKH.

PACKW packs the first 16 bits of rs1 and rs2 and sign extends the upper 32 bits of rd. PACKH packs the first 8 bits of rs1 and rs2 and puts zeros in bits 16 of rd.

PPAIRE.B copies the even bytes of rs1 to the even bytes of rd and copies the even bytes of rs2 to the odd bytes of rd. PPAIRE.H is similar, but copys halfwords instead of bytes. We can treat them equivalently to PACKH/PACKW when we know that we only care about the lower halfword or word, respectively of the result.