### PR TITLE
[utils] update type hint for python 3.8-3.9 compatibility

### DIFF
--- a/llvm/utils/lit/lit/display.py
+++ b/llvm/utils/lit/lit/display.py
@@ -1,7 +1,7 @@
 import sys
 
 from argparse import Namespace
-from typing import Optional
+from typing import Optional, List
 from lit.Test import Test
 
 
@@ -94,7 +94,7 @@ class Display(object):
     def __init__(
         self,
         opts: Namespace,
-        tests: list[Test],
+        tests: List[Test],
         header: Optional[str],
         progress_bar,
     ):


### PR DESCRIPTION
Type hints before 3.10 require importing, and are spelled with a leading capital.