### PR TITLE
[SystemZ] Emit external aliases required for indirect symbol handling  support

### DIFF
--- a/llvm/include/llvm/MC/MCSectionGOFF.h
+++ b/llvm/include/llvm/MC/MCSectionGOFF.h
@@ -27,6 +27,8 @@ namespace llvm {
 class MCExpr;
 
 class LLVM_ABI MCSectionGOFF final : public MCSection {
+  StringRef ExternalName; // Alternate external name.
+
   // Parent of this section. Implies that the parent is emitted first.
   MCSectionGOFF *Parent;
 
@@ -115,6 +117,12 @@ public:
   bool requiresNonZeroLength() const { return RequiresNonZeroLength; }
 
   void setName(StringRef SectionName) { Name = SectionName; }
+
+  bool hasExternalName() const { return !ExternalName.empty(); }
+  void setExternalName(StringRef Name) { ExternalName = Name; }
+  StringRef getExternalName() const {
+    return hasExternalName() ? ExternalName : getName();
+  }
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/MC/MCSymbolGOFF.h
+++ b/llvm/include/llvm/MC/MCSymbolGOFF.h
@@ -23,6 +23,9 @@
 namespace llvm {
 
 class MCSymbolGOFF : public MCSymbol {
+
+  StringRef ExternalName; // Alternate external name.
+
   // Associated data area of the section. Needs to be emitted first.
   MCSectionGOFF *ADA = nullptr;
 
@@ -47,6 +50,12 @@ public:
 
   bool isExternal() const { return IsExternal; }
   void setExternal(bool Value) const { IsExternal = Value; }
+
+  bool hasExternalName() const { return !ExternalName.empty(); }
+  void setExternalName(StringRef Name) { ExternalName = Name; }
+  StringRef getExternalName() const {
+    return hasExternalName() ? ExternalName : getName();
+  }
 
   void setHidden(bool Value = true) {
     modifyFlags(Value ? SF_Hidden : 0, SF_Hidden);

--- a/llvm/lib/MC/GOFFObjectWriter.cpp
+++ b/llvm/lib/MC/GOFFObjectWriter.cpp
@@ -315,13 +315,13 @@ GOFFWriter::GOFFWriter(raw_pwrite_stream &OS, MCAssembler &Asm,
 
 void GOFFWriter::defineSectionSymbols(const MCSectionGOFF &Section) {
   if (Section.isSD()) {
-    GOFFSymbol SD(Section.getName(), Section.getOrdinal(),
+    GOFFSymbol SD(Section.getExternalName(), Section.getOrdinal(),
                   Section.getSDAttributes());
     writeSymbol(SD);
   }
 
   if (Section.isED()) {
-    GOFFSymbol ED(Section.getName(), Section.getOrdinal(),
+    GOFFSymbol ED(Section.getExternalName(), Section.getOrdinal(),
                   Section.getParent()->getOrdinal(), Section.getEDAttributes());
     ED.SectionLength = Asm.getSectionAddressSize(Section);
     writeSymbol(ED);
@@ -329,8 +329,9 @@ void GOFFWriter::defineSectionSymbols(const MCSectionGOFF &Section) {
 
   if (Section.isPR()) {
     MCSectionGOFF *Parent = Section.getParent();
-    GOFFSymbol PR(Section.getName(), Section.getOrdinal(), Parent->getOrdinal(),
-                  Parent->getEDAttributes(), Section.getPRAttributes());
+    GOFFSymbol PR(Section.getExternalName(), Section.getOrdinal(),
+                  Parent->getOrdinal(), Parent->getEDAttributes(),
+                  Section.getPRAttributes());
     PR.SectionLength = Asm.getSectionAddressSize(Section);
     if (Section.requiresNonZeroLength()) {
       // We cannot have a zero-length section for data.  If we do,
@@ -347,8 +348,8 @@ void GOFFWriter::defineSectionSymbols(const MCSectionGOFF &Section) {
 
 void GOFFWriter::defineLabel(const MCSymbolGOFF &Symbol) {
   MCSectionGOFF &Section = static_cast<MCSectionGOFF &>(Symbol.getSection());
-  GOFFSymbol LD(Symbol.getName(), Symbol.getIndex(), Section.getOrdinal(),
-                Section.getEDAttributes().NameSpace,
+  GOFFSymbol LD(Symbol.getExternalName(), Symbol.getIndex(),
+                Section.getOrdinal(), Section.getEDAttributes().NameSpace,
                 GOFF::LDAttr{false, Symbol.getCodeData(),
                              Symbol.getBindingStrength(), Symbol.getLinkage(),
                              GOFF::ESD_AMODE_64, Symbol.getBindingScope()});
@@ -359,7 +360,8 @@ void GOFFWriter::defineLabel(const MCSymbolGOFF &Symbol) {
 }
 
 void GOFFWriter::defineExtern(const MCSymbolGOFF &Symbol) {
-  GOFFSymbol ER(Symbol.getName(), Symbol.getIndex(), RootSD->getOrdinal(),
+  GOFFSymbol ER(Symbol.getExternalName(), Symbol.getIndex(),
+                RootSD->getOrdinal(),
                 GOFF::ERAttr{Symbol.isIndirect(), Symbol.getCodeData(),
                              Symbol.getBindingStrength(), Symbol.getLinkage(),
                              GOFF::ESD_AMODE_64, Symbol.getBindingScope()});
@@ -695,25 +697,26 @@ void GOFFObjectWriter::recordRelocation(const MCFragment &F,
       Asm->reportError(
           Fixup.getLoc(),
           Twine("symbol ")
-              .concat(A.getName())
+              .concat(A.getExternalName())
               .concat(" must be defined for a relative immediate relocation"));
       return;
     }
     if (&A.getSection() != PSection) {
+      MCSectionGOFF &GOFFSection = static_cast<MCSectionGOFF &>(A.getSection());
       Asm->reportError(Fixup.getLoc(),
                        Twine("relative immediate relocation section mismatch: ")
-                           .concat(A.getSection().getName())
+                           .concat(GOFFSection.getExternalName())
                            .concat(" of symbol ")
-                           .concat(A.getName())
+                           .concat(A.getExternalName())
                            .concat(" <-> ")
-                           .concat(PSection->getName()));
+                           .concat(PSection->getExternalName()));
       return;
     }
     if (B) {
       Asm->reportError(
           Fixup.getLoc(),
           Twine("subtractive symbol ")
-              .concat(B->getName())
+              .concat(B->getExternalName())
               .concat(" not supported for a relative immediate relocation"));
       return;
     }
@@ -767,9 +770,11 @@ void GOFFObjectWriter::recordRelocation(const MCFragment &F,
     default:
       Con = "(unknown)";
     }
-    dbgs() << "Reloc " << N << ": " << Con << " Rptr: " << Sym->getName()
-           << " Pptr: " << PSection->getName() << " Offset: " << FixupOffset
-           << " Fixed Imm: " << FixedValue << "\n";
+    dbgs() << "Reloc " << N << ": " << Con
+           << " Rptr: " << Sym->getExternalName()
+           << " Pptr: " << PSection->getExternalName()
+           << " Offset: " << FixupOffset << " Fixed Imm: " << FixedValue
+           << "\n";
   };
   (void)DumpReloc;
 

--- a/llvm/lib/MC/MCAsmInfoGOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoGOFF.cpp
@@ -121,8 +121,8 @@ void MCAsmInfoGOFF::printSwitchToSection(const MCSection &Section,
   auto &Sec =
       const_cast<MCSectionGOFF &>(static_cast<const MCSectionGOFF &>(Section));
   auto EmitExternalName = [&Sec, &OS]() {
-  if (Sec.hasExternalName())
-    OS << Sec.getName() << " ALIAS C'" << Sec.getExternalName() << "'\n";
+    if (Sec.hasExternalName())
+      OS << Sec.getName() << " ALIAS C'" << Sec.getExternalName() << "'\n";
   };
   switch (Sec.SymbolType) {
   case GOFF::ESD_ST_SectionDefinition: {

--- a/llvm/lib/MC/MCAsmInfoGOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoGOFF.cpp
@@ -120,12 +120,15 @@ void MCAsmInfoGOFF::printSwitchToSection(const MCSection &Section,
                                          raw_ostream &OS) const {
   auto &Sec =
       const_cast<MCSectionGOFF &>(static_cast<const MCSectionGOFF &>(Section));
+  auto EmitExternalName = [&Sec, &OS]() {
+  if (Sec.hasExternalName())
+    OS << Sec.getName() << " ALIAS C'" << Sec.getExternalName() << "'\n";
+  };
   switch (Sec.SymbolType) {
   case GOFF::ESD_ST_SectionDefinition: {
     OS << Sec.getName() << " CSECT\n";
     Sec.Emitted = true;
-    if (Sec.hasExternalName())
-      OS << Sec.getName() << " ALIAS \"" << Sec.getExternalName() << "\"\n";
+    EmitExternalName();
     break;
   }
   case GOFF::ESD_ST_ElementDefinition: {
@@ -136,8 +139,7 @@ void MCAsmInfoGOFF::printSwitchToSection(const MCSection &Section,
                 GOFF::ESD_EXE_Unspecified, Sec.EDAttributes.IsReadOnly, 0,
                 Sec.EDAttributes.FillByteValue, StringRef());
       Sec.Emitted = true;
-      if (Sec.hasExternalName())
-        OS << Sec.getName() << " ALIAS \"" << Sec.getExternalName() << "\"\n";
+      EmitExternalName();
     } else
       OS << Sec.getName() << " CATTR\n";
     break;
@@ -155,8 +157,7 @@ void MCAsmInfoGOFF::printSwitchToSection(const MCSection &Section,
                 Sec.PRAttributes.Executable, Sec.PRAttributes.BindingScope);
       ED->Emitted = true;
       Sec.Emitted = true;
-      if (Sec.hasExternalName())
-        OS << Sec.getName() << " ALIAS \"" << Sec.getExternalName() << "\"\n";
+      EmitExternalName();
     } else
       OS << ED->getName() << " CATTR PART(" << Sec.getName() << ")\n";
     break;

--- a/llvm/lib/MC/MCAsmInfoGOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoGOFF.cpp
@@ -124,6 +124,8 @@ void MCAsmInfoGOFF::printSwitchToSection(const MCSection &Section,
   case GOFF::ESD_ST_SectionDefinition: {
     OS << Sec.getName() << " CSECT\n";
     Sec.Emitted = true;
+    if (Sec.hasExternalName())
+      OS << Sec.getName() << " ALIAS \"" << Sec.getExternalName() << "\"\n";
     break;
   }
   case GOFF::ESD_ST_ElementDefinition: {
@@ -134,6 +136,8 @@ void MCAsmInfoGOFF::printSwitchToSection(const MCSection &Section,
                 GOFF::ESD_EXE_Unspecified, Sec.EDAttributes.IsReadOnly, 0,
                 Sec.EDAttributes.FillByteValue, StringRef());
       Sec.Emitted = true;
+      if (Sec.hasExternalName())
+        OS << Sec.getName() << " ALIAS \"" << Sec.getExternalName() << "\"\n";
     } else
       OS << Sec.getName() << " CATTR\n";
     break;
@@ -151,6 +155,8 @@ void MCAsmInfoGOFF::printSwitchToSection(const MCSection &Section,
                 Sec.PRAttributes.Executable, Sec.PRAttributes.BindingScope);
       ED->Emitted = true;
       Sec.Emitted = true;
+      if (Sec.hasExternalName())
+        OS << Sec.getName() << " ALIAS \"" << Sec.getExternalName() << "\"\n";
     } else
       OS << ED->getName() << " CATTR PART(" << Sec.getName() << ")\n";
     break;

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
@@ -259,7 +259,7 @@ void SystemZHLASMAsmStreamer::emitLabel(MCSymbol *Symbol, SMLoc Loc) {
               Sym->getCodeData(), Sym->getBindingScope());
     EmitEOL();
     if (Sym->hasExternalName())
-      OS << Sym->getName() << " ALIAS \"" << Sym->getExternalName() << "\"\n";
+      OS << Sym->getName() << " ALIAS C'" << Sym->getExternalName() << "'\n";
   }
 
   if (EmitLabelAndEntry) {
@@ -371,7 +371,7 @@ void SystemZHLASMAsmStreamer::finishImpl() {
               Sym.getCodeData(), Sym.getBindingScope());
     EmitEOL();
     if (Sym.hasExternalName())
-      OS << Sym.getName() << " ALIAS \"" << Sym.getExternalName() << "\"\n";
+      OS << Sym.getName() << " ALIAS C'" << Sym.getExternalName() << "'\n";
   }
 
   // Finish the assembly output.

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZHLASMAsmStreamer.cpp
@@ -258,6 +258,8 @@ void SystemZHLASMAsmStreamer::emitLabel(MCSymbol *Symbol, SMLoc Loc) {
     emitXATTR(OS, Sym->getName(), Sym->isIndirect(), Sym->getLinkage(),
               Sym->getCodeData(), Sym->getBindingScope());
     EmitEOL();
+    if (Sym->hasExternalName())
+      OS << Sym->getName() << " ALIAS \"" << Sym->getExternalName() << "\"\n";
   }
 
   if (EmitLabelAndEntry) {
@@ -368,6 +370,8 @@ void SystemZHLASMAsmStreamer::finishImpl() {
     emitXATTR(OS, Sym.getName(), Sym.isIndirect(), Sym.getLinkage(),
               Sym.getCodeData(), Sym.getBindingScope());
     EmitEOL();
+    if (Sym.hasExternalName())
+      OS << Sym.getName() << " ALIAS \"" << Sym.getExternalName() << "\"\n";
   }
 
   // Finish the assembly output.

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZTargetStreamer.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZTargetStreamer.h
@@ -13,8 +13,10 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCSectionGOFF.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSymbol.h"
+#include "llvm/MC/MCSymbolGOFF.h"
 #include "llvm/Support/FormattedStream.h"
 #include <map>
 #include <utility>
@@ -58,6 +60,9 @@ public:
 
   virtual void emitMachine(StringRef CPUOrCommand) {};
 
+  virtual void emitExternalName(MCSymbol *Sym, StringRef Name) {}
+  virtual void emitExternalName(MCSection *Sec, StringRef Name) {}
+
   virtual const MCExpr *createWordDiffExpr(MCContext &Ctx, const MCSymbol *Hi,
                                            const MCSymbol *Lo) {
     return nullptr;
@@ -69,6 +74,12 @@ public:
   SystemZTargetGOFFStreamer(MCStreamer &S) : SystemZTargetStreamer(S) {}
   const MCExpr *createWordDiffExpr(MCContext &Ctx, const MCSymbol *Hi,
                                    const MCSymbol *Lo) override;
+  virtual void emitExternalName(MCSymbol *Sym, StringRef Name) override {
+    static_cast<MCSymbolGOFF *>(Sym)->setExternalName(Name);
+  }
+  virtual void emitExternalName(MCSection *Sec, StringRef Name) override {
+    static_cast<MCSectionGOFF *>(Sec)->setExternalName(Name);
+  }
 };
 
 class SystemZTargetHLASMStreamer : public SystemZTargetStreamer {
@@ -80,6 +91,12 @@ public:
   SystemZHLASMAsmStreamer &getHLASMStreamer();
   const MCExpr *createWordDiffExpr(MCContext &Ctx, const MCSymbol *Hi,
                                    const MCSymbol *Lo) override;
+  virtual void emitExternalName(MCSymbol *Sym, StringRef Name) override {
+    static_cast<MCSymbolGOFF *>(Sym)->setExternalName(Name);
+  }
+  virtual void emitExternalName(MCSection *Sec, StringRef Name) override {
+    static_cast<MCSectionGOFF *>(Sec)->setExternalName(Name);
+  }
 };
 
 class SystemZTargetELFStreamer : public SystemZTargetStreamer {


### PR DESCRIPTION


This is the second of three patches aimed to support indirect symbol handling for the SystemZ backend. An external name is added for both MC sections and symbols and makes the relevant printers and writers utilize the external name when present. Furthermore, the ALIAS HLASM instruction is emitted after every XATTR instruction.

Depends on https://github.com/llvm/llvm-project/pull/183441.