### PR TITLE
[SystemZ] Emit external aliases for indirect function descriptors in the ADA section

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1275,12 +1275,15 @@ void SystemZAsmPrinter::emitADASection() {
       EmittedBytes += PointerSize;
       break;
     case SystemZII::MO_ADA_INDIRECT_FUNC_DESC: {
-      MCSymbol *Alias = OutContext.createTempSymbol(
+      MCSymbol *Alias = OutContext.getOrCreateSymbol(
           Twine(Sym->getName()).concat("@indirect"));
-      OutStreamer->emitAssignment(Alias,
-                                  MCSymbolRefExpr::create(Sym, OutContext));
       OutStreamer->emitSymbolAttribute(Alias, MCSA_IndirectSymbol);
-
+      OutStreamer->emitSymbolAttribute(Alias, MCSA_ELF_TypeFunction);
+      OutStreamer->emitSymbolAttribute(Alias, MCSA_Global);
+      OutStreamer->emitSymbolAttribute(Alias, MCSA_Extern);
+      MCSymbolGOFF *GOFFSym =
+          static_cast<llvm::MCSymbolGOFF *>(const_cast<llvm::MCSymbol *>(Sym));
+      getTargetStreamer()->emitExternalName(Alias, GOFFSym->getExternalName());
       EMIT_COMMENT("pointer to function descriptor");
       OutStreamer->emitValue(
           MCSpecifierExpr::create(MCSymbolRefExpr::create(Alias, OutContext),

--- a/llvm/test/CodeGen/SystemZ/zos-ada-relocations.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ada-relocations.ll
@@ -60,7 +60,7 @@ declare signext i32 @callout(i32 signext)
 ; CHECK:                in#S)
 ; CHECK: stdin#S XATTR LINKAGE(XPLINK),REFERENCE(DATA),SCOPE(SECTION)
 ; CHECK: * Offset 0 pointer to function descriptor DoFunc
-; CHECK:  DC VD(L#DoFunc@indirect0)
+; CHECK:  DC VD(DoFunc@indirect)
 ; CHECK: * Offset 8 function descriptor of Caller
 ; CHECK:  DC RD(Caller)
 ; CHECK:  DC VD(Caller)
@@ -71,3 +71,7 @@ declare signext i32 @callout(i32 signext)
 ; CHECK: * Offset 40 function descriptor of callout
 ; CHECK:  DC RD(callout)
 ; CHECK:  DC VD(callout)
+; CHECK: EXTRN DoFunc@indirect
+; CHECK: DoFunc@indirect XATTR LINKAGE(XPLINK),REFERENCE(CODE,INDIRECT),SCOPE(EX
+; CHECK:                PORT)
+; CHECK: DoFunc@indirect ALIAS "DoFunc"

--- a/llvm/test/CodeGen/SystemZ/zos-ada-relocations.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ada-relocations.ll
@@ -74,4 +74,4 @@ declare signext i32 @callout(i32 signext)
 ; CHECK: EXTRN DoFunc@indirect
 ; CHECK: DoFunc@indirect XATTR LINKAGE(XPLINK),REFERENCE(CODE,INDIRECT),SCOPE(EX
 ; CHECK:                PORT)
-; CHECK: DoFunc@indirect ALIAS "DoFunc"
+; CHECK: DoFunc@indirect ALIAS C'DoFunc'


### PR DESCRIPTION

This is the last of the three patches aimed to support indirect symbol handling for the SystemZ backend.

An external alias is emitted for indirect function descriptors within the ADA section, rather than a temporary alias, while also setting all of the appropriate symbol attributes that are needed for the HLASM streamer to emit the correct XATTR and ALIAS instructions for the indirect symbols.

Moreover, this patch updates the `CodeGen/SystemZ/zos-ada-relocations.ll` test as the ADA section is currently the only user of indirect symbols on z/OS.

Depends on https://github.com/llvm/llvm-project/pull/183442.