### PR TITLE
[Driver] Add -Wa,--reloc-section-sym= to control section symbol conversion

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -29,6 +29,8 @@ CODEGENOPT(Name, Bits, Default, Compatibility)
 
 CODEGENOPT(DisableIntegratedAS, 1, 0, Benign) ///< -no-integrated-as
 CODEGENOPT(Crel, 1, 0, Benign) ///< -Wa,--crel
+ENUM_CODEGENOPT(RelocSectionSym, RelocSectionSymType, 2,
+                RelocSectionSymType::All, Benign) ///< -Wa,--reloc-section-sym=
 CODEGENOPT(ImplicitMapSyms, 1, 0, Benign) ///< -Wa,-mmapsyms=implicit
 CODEGENOPT(AsmVerbose        , 1, 0, Benign) ///< -dA, -fverbose-asm.
 CODEGENOPT(PreserveAsmComments, 1, 1, Benign) ///< -dA, -fno-preserve-as-comments.

--- a/clang/include/clang/Basic/CodeGenOptions.h
+++ b/clang/include/clang/Basic/CodeGenOptions.h
@@ -20,6 +20,7 @@
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/Frontend/Debug/Options.h"
 #include "llvm/Frontend/Driver/CodeGenOptions.h"
+#include "llvm/MC/MCTargetOptions.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Hash.h"
 #include "llvm/Support/Regex.h"
@@ -72,6 +73,7 @@ public:
   using DebugTemplateNamesKind = llvm::codegenoptions::DebugTemplateNamesKind;
   using DebugInfoKind = llvm::codegenoptions::DebugInfoKind;
   using DebuggerKind = llvm::DebuggerKind;
+  using RelocSectionSymType = llvm::RelocSectionSymType;
 
 #define CODEGENOPT(Name, Bits, Default, Compatibility) unsigned Name : Bits;
 #define ENUM_CODEGENOPT(Name, Type, Bits, Default, Compatibility)

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -7987,6 +7987,12 @@ def massembler_fatal_warnings : Flag<["-"], "massembler-fatal-warnings">,
 def crel : Flag<["--"], "crel">,
   HelpText<"Enable CREL relocation format (ELF only)">,
   MarshallingInfoFlag<CodeGenOpts<"Crel">>;
+def reloc_section_sym : Joined<["--"], "reloc-section-sym=">,
+  HelpText<"Section symbol conversion for relocations: all, internal, none (ELF only)">,
+  Values<"all,internal,none">,
+  NormalizedValuesScope<"llvm::RelocSectionSymType">,
+  NormalizedValues<["All", "Internal", "None"]>,
+  MarshallingInfoEnum<CodeGenOpts<"RelocSectionSym">, "All">;
 // The leading 'g' is misleading. This is an unwind tables option, not
 // a debug option. But uses this name for gnu compatibility.
 def gsframe : Flag<["--"], "gsframe">,

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -503,6 +503,7 @@ static bool initTargetOptions(const CompilerInstance &CI,
   Options.MCOptions.Dwarf64 = CodeGenOpts.Dwarf64;
   Options.MCOptions.PreserveAsmComments = CodeGenOpts.PreserveAsmComments;
   Options.MCOptions.Crel = CodeGenOpts.Crel;
+  Options.MCOptions.RelocSectionSym = CodeGenOpts.getRelocSectionSym();
   Options.MCOptions.ImplicitMapSyms = CodeGenOpts.ImplicitMapSyms;
   Options.MCOptions.X86RelaxRelocations = CodeGenOpts.X86RelaxRelocations;
   Options.MCOptions.CompressDebugSections =

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2436,6 +2436,7 @@ static void CollectArgsForIntegratedAssembler(Compilation &C,
   const llvm::Triple &Triple = C.getDefaultToolChain().getTriple();
   bool IsELF = Triple.isOSBinFormatELF();
   bool Crel = false, ExperimentalCrel = false;
+  StringRef RelocSectionSym;
   bool SFrame = false, ExperimentalSFrame = false;
   bool ImplicitMapSyms = false;
   bool UseRelaxRelocations = C.getDefaultToolChain().useRelaxRelocations();
@@ -2636,6 +2637,8 @@ static void CollectArgsForIntegratedAssembler(Compilation &C,
         Crel = false;
       } else if (Value == "--allow-experimental-crel") {
         ExperimentalCrel = true;
+      } else if (Value.starts_with("--reloc-section-sym=")) {
+        RelocSectionSym = Value.substr(strlen("--reloc-section-sym="));
       } else if (Value.starts_with("-I")) {
         CmdArgs.push_back(Value.data());
         // We need to consume the next argument if the current arg is a plain
@@ -2708,6 +2711,19 @@ static void CollectArgsForIntegratedAssembler(Compilation &C,
       D.Diag(diag::err_drv_unsupported_opt_for_target)
           << "-Wa,--crel" << D.getTargetTriple();
     }
+  }
+  if (!RelocSectionSym.empty()) {
+    if (RelocSectionSym != "all" && RelocSectionSym != "internal" &&
+        RelocSectionSym != "none")
+      D.Diag(diag::err_drv_invalid_value)
+          << ("-Wa,--reloc-section-sym=" + RelocSectionSym).str()
+          << RelocSectionSym;
+    else if (Triple.isOSBinFormatELF())
+      CmdArgs.push_back(
+          Args.MakeArgString("--reloc-section-sym=" + RelocSectionSym));
+    else
+      D.Diag(diag::err_drv_unsupported_opt_for_target)
+          << "-Wa,--reloc-section-sym" << D.getTargetTriple();
   }
   if (SFrame) {
     if (Triple.isOSBinFormatELF() && Triple.isX86()) {

--- a/clang/test/Driver/reloc-section-sym.c
+++ b/clang/test/Driver/reloc-section-sym.c
@@ -1,0 +1,9 @@
+// RUN: %clang -### -c --target=x86_64 -Wa,--reloc-section-sym=internal %s -Werror 2>&1 | FileCheck %s
+// RUN: %clang -### -c --target=aarch64 -Wa,--reloc-section-sym=internal,--reloc-section-sym=none %s -Werror 2>&1 | FileCheck %s --check-prefix=NONE
+// RUN: not %clang -### -c --target=arm64-apple-darwin -Wa,--reloc-section-sym=internal %s 2>&1 | FileCheck %s --check-prefix=ERR
+// RUN: not %clang -### -c --target=x86_64 -Wa,--reloc-section-sym=x %s 2>&1 | FileCheck %s --check-prefix=BADVAL
+
+// CHECK:      "--reloc-section-sym=internal"
+// NONE:       "--reloc-section-sym=none"
+// ERR:        error: unsupported option '-Wa,--reloc-section-sym' for target
+// BADVAL:     error: invalid value 'x' in '-Wa,--reloc-section-sym=x'

--- a/clang/test/Misc/cc1as-reloc-section-sym.s
+++ b/clang/test/Misc/cc1as-reloc-section-sym.s
@@ -1,0 +1,27 @@
+// REQUIRES: x86-registered-target
+/// cc1as option for --reloc-section-sym. See llvm/test/MC/ELF/reloc-section-sym.s
+
+// RUN: %clang -cc1as -triple x86_64 %s -filetype obj -o %t.default.o
+// RUN: %clang -cc1as -triple x86_64 %s -filetype obj --reloc-section-sym=internal -o %t.internal.o
+// RUN: %clang -cc1as -triple x86_64 %s -filetype obj --reloc-section-sym=none -o %t.none.o
+// RUN: llvm-readelf -rs %t.default.o | FileCheck %s --check-prefix=DEFAULT
+// RUN: llvm-readelf -rs %t.internal.o | FileCheck %s --check-prefix=INTERNAL
+// RUN: llvm-readelf -rs %t.none.o | FileCheck %s --check-prefix=NONE
+
+.text
+  nop
+local:
+  nop
+.Ltemp:
+  nop
+
+.section .text1,"ax"
+  call local
+  call .Ltemp
+
+// DEFAULT:       R_X86_64_PLT32 {{.*}} .text - 3
+// DEFAULT-NEXT:  R_X86_64_PLT32 {{.*}} .text - 2
+// INTERNAL:      R_X86_64_PLT32 {{.*}} local - 4
+// INTERNAL-NEXT: R_X86_64_PLT32 {{.*}} .text - 2
+// NONE:          R_X86_64_PLT32 {{.*}} local - 4
+// NONE-NEXT:     R_X86_64_PLT32 {{.*}} .Ltemp - 4

--- a/clang/tools/driver/cc1as_main.cpp
+++ b/clang/tools/driver/cc1as_main.cpp
@@ -177,6 +177,8 @@ struct AssemblerInvocation {
   LLVM_PREFERRED_TYPE(bool)
   unsigned X86Sse2Avx : 1;
 
+  RelocSectionSymType RelocSectionSym = RelocSectionSymType::All;
+
   /// The name of the relocation model to use.
   std::string RelocationModel;
 
@@ -394,6 +396,12 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
       Args.hasArg(OPT_femit_compact_unwind_non_canonical);
   Opts.EmitSFrameUnwind = Args.hasArg(OPT_gsframe);
   Opts.Crel = Args.hasArg(OPT_crel);
+  Opts.RelocSectionSym = RelocSectionSymType::All;
+  if (auto *A = Args.getLastArg(OPT_reloc_section_sym))
+    Opts.RelocSectionSym = StringSwitch<RelocSectionSymType>(A->getValue())
+                               .Case("internal", RelocSectionSymType::Internal)
+                               .Case("none", RelocSectionSymType::None)
+                               .Default(RelocSectionSymType::All);
   Opts.ImplicitMapsyms = Args.hasArg(OPT_mmapsyms_implicit);
   Opts.X86RelaxRelocations = !Args.hasArg(OPT_mrelax_relocations_no);
   Opts.X86Sse2Avx = Args.hasArg(OPT_msse2avx);
@@ -461,6 +469,7 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
   MCOptions.EmitSFrameUnwind = Opts.EmitSFrameUnwind;
   MCOptions.MCSaveTempLabels = Opts.SaveTemporaryLabels;
   MCOptions.Crel = Opts.Crel;
+  MCOptions.RelocSectionSym = Opts.RelocSectionSym;
   MCOptions.ImplicitMapSyms = Opts.ImplicitMapsyms;
   MCOptions.X86RelaxRelocations = Opts.X86RelaxRelocations;
   MCOptions.X86Sse2Avx = Opts.X86Sse2Avx;


### PR DESCRIPTION
Wire the llvm-mc --reloc-section-sym={all,internal,none} option through
the clang driver (-Wa,--reloc-section-sym=) and cc1as
(--reloc-section-sym=). The option is only valid for ELF targets.

GNU Assembler will add the option as well.
