### PR TITLE
[Clang][NFCI] Make program state GDM key const pointer

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
@@ -70,7 +70,7 @@ template <typename T> struct ProgramStateTrait {
 ///  values will never change.
 class ProgramState : public llvm::FoldingSetNode {
 public:
-  typedef llvm::ImmutableMap<void*, void*>                 GenericDataMap;
+  typedef llvm::ImmutableMap<const void *, void *> GenericDataMap;
 
 private:
   void operator=(const ProgramState& R) = delete;
@@ -423,7 +423,7 @@ public:
   // Accessing the Generic Data Map (GDM).
   //==---------------------------------------------------------------------==//
 
-  void *const* FindGDM(void *K) const;
+  void *const *FindGDM(const void *K) const;
 
   template <typename T>
   [[nodiscard]] ProgramStateRef
@@ -512,7 +512,8 @@ private:
 
   ProgramState::GenericDataMap::Factory     GDMFactory;
 
-  typedef llvm::DenseMap<void*,std::pair<void*,void (*)(void*)> > GDMContextsTy;
+  typedef llvm::DenseMap<const void *, std::pair<void *, void (*)(void *)>>
+      GDMContextsTy;
   GDMContextsTy GDMContexts;
 
   /// StateSet - FoldingSet containing all the states created for analyzing
@@ -595,8 +596,8 @@ public:
   }
 
   // Methods that manipulate the GDM.
-  ProgramStateRef addGDM(ProgramStateRef St, void *Key, void *Data);
-  ProgramStateRef removeGDM(ProgramStateRef state, void *Key);
+  ProgramStateRef addGDM(ProgramStateRef St, const void *Key, void *Data);
+  ProgramStateRef removeGDM(ProgramStateRef state, const void *Key);
 
   // Methods that query & manipulate the Store.
 
@@ -677,9 +678,9 @@ public:
     return removeGDM(st, ProgramStateTrait<T>::GDMIndex());
   }
 
-  void *FindGDMContext(void *index,
-                       void *(*CreateContext)(llvm::BumpPtrAllocator&),
-                       void  (*DeleteContext)(void*));
+  void *FindGDMContext(const void *index,
+                       void *(*CreateContext)(llvm::BumpPtrAllocator &),
+                       void (*DeleteContext)(void *));
 
   template <typename T>
   typename ProgramStateTrait<T>::context_type get_context() {

--- a/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ProgramState.cpp
@@ -531,14 +531,13 @@ AnalysisManager& ProgramState::getAnalysisManager() const {
 // Generic Data Map.
 //===----------------------------------------------------------------------===//
 
-void *const* ProgramState::FindGDM(void *K) const {
+void *const *ProgramState::FindGDM(const void *K) const {
   return GDM.lookup(K);
 }
 
-void*
-ProgramStateManager::FindGDMContext(void *K,
-                               void *(*CreateContext)(llvm::BumpPtrAllocator&),
-                               void (*DeleteContext)(void*)) {
+void *ProgramStateManager::FindGDMContext(
+    const void *K, void *(*CreateContext)(llvm::BumpPtrAllocator &),
+    void (*DeleteContext)(void *)) {
 
   std::pair<void*, void (*)(void*)>& p = GDMContexts[K];
   if (!p.first) {
@@ -549,7 +548,8 @@ ProgramStateManager::FindGDMContext(void *K,
   return p.first;
 }
 
-ProgramStateRef ProgramStateManager::addGDM(ProgramStateRef St, void *Key, void *Data){
+ProgramStateRef ProgramStateManager::addGDM(ProgramStateRef St, const void *Key,
+                                            void *Data) {
   ProgramState::GenericDataMap M1 = St->getGDM();
   ProgramState::GenericDataMap M2 = GDMFactory.add(M1, Key, Data);
 
@@ -561,7 +561,8 @@ ProgramStateRef ProgramStateManager::addGDM(ProgramStateRef St, void *Key, void 
   return getPersistentState(NewSt);
 }
 
-ProgramStateRef ProgramStateManager::removeGDM(ProgramStateRef state, void *Key) {
+ProgramStateRef ProgramStateManager::removeGDM(ProgramStateRef state,
+                                               const void *Key) {
   ProgramState::GenericDataMap OldM = state->getGDM();
   ProgramState::GenericDataMap NewM = GDMFactory.remove(OldM, Key);
 


### PR DESCRIPTION
This commit makes the GDM key in ProgramState a constant pointer. This is done to better reflect the intention of the key as a unique identifier for the data stored in the GDM, and to prevent the use of the storage pointed to by the key as global state.