### PR TITLE
[MemorySSA] Make `getBlockDefs` and `getBlockAccesses` return a non-const list (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/MemorySSA.h
+++ b/llvm/include/llvm/Analysis/MemorySSA.h
@@ -755,18 +755,16 @@ public:
       simple_ilist<MemoryAccess, ilist_tag<MSSAHelpers::DefsOnlyTag>>;
 
   /// Return the list of MemoryAccess's for a given basic block.
-  ///
-  /// This list is not modifiable by the user.
-  const AccessList *getBlockAccesses(const BasicBlock *BB) const {
-    return getWritableBlockAccesses(BB);
+  AccessList *getBlockAccesses(const BasicBlock *BB) const {
+    auto It = PerBlockAccesses.find(BB);
+    return It == PerBlockAccesses.end() ? nullptr : It->second.get();
   }
 
   /// Return the list of MemoryDef's and MemoryPhi's for a given basic
   /// block.
-  ///
-  /// This list is not modifiable by the user.
-  const DefsList *getBlockDefs(const BasicBlock *BB) const {
-    return getWritableBlockDefs(BB);
+  DefsList *getBlockDefs(const BasicBlock *BB) const {
+    auto It = PerBlockDefs.find(BB);
+    return It == PerBlockDefs.end() ? nullptr : It->second.get();
   }
 
   /// Given two memory accesses in the same basic block, determine
@@ -810,18 +808,6 @@ protected:
       IterT Blocks, VerificationLevel = VerificationLevel::Fast) const;
   template <typename IterT> void verifyDominationNumbers(IterT Blocks) const;
   template <typename IterT> void verifyPrevDefInPhis(IterT Blocks) const;
-
-  // This is used by the use optimizer and updater.
-  AccessList *getWritableBlockAccesses(const BasicBlock *BB) const {
-    auto It = PerBlockAccesses.find(BB);
-    return It == PerBlockAccesses.end() ? nullptr : It->second.get();
-  }
-
-  // This is used by the use optimizer and updater.
-  DefsList *getWritableBlockDefs(const BasicBlock *BB) const {
-    auto It = PerBlockDefs.find(BB);
-    return It == PerBlockDefs.end() ? nullptr : It->second.get();
-  }
 
   // These is used by the updater to perform various internal MemorySSA
   // machinsations.  They do not always leave the IR in a correct state, and

--- a/llvm/lib/Analysis/MemorySSA.cpp
+++ b/llvm/lib/Analysis/MemorySSA.cpp
@@ -1180,7 +1180,7 @@ void MemorySSA::renamePass(DomTreeNode *Root, MemoryAccess *IncomingVal,
         // which is the last def.
         // Incoming value can only change if there is a block def, and in that
         // case, it's the last block def in the list.
-        if (auto *BlockDefs = getWritableBlockDefs(BB))
+        if (auto *BlockDefs = getBlockDefs(BB))
           IncomingVal = &*BlockDefs->rbegin();
       } else
         IncomingVal = renameBlock(BB, IncomingVal, RenameAllUses);
@@ -1357,7 +1357,7 @@ void MemorySSA::OptimizeUses::optimizeUsesInBlock(
     DenseMap<MemoryLocOrCall, MemlocStackInfo> &LocStackInfo) {
 
   /// If no accesses, nothing to do.
-  MemorySSA::AccessList *Accesses = MSSA->getWritableBlockAccesses(BB);
+  MemorySSA::AccessList *Accesses = MSSA->getBlockAccesses(BB);
   if (Accesses == nullptr)
     return;
 
@@ -1649,7 +1649,7 @@ void MemorySSA::insertIntoListsForBlock(MemoryAccess *NewAccess,
 
 void MemorySSA::insertIntoListsBefore(MemoryAccess *What, const BasicBlock *BB,
                                       AccessList::iterator InsertPt) {
-  auto *Accesses = getWritableBlockAccesses(BB);
+  auto *Accesses = getBlockAccesses(BB);
   bool WasEnd = InsertPt == Accesses->end();
   Accesses->insert(AccessList::iterator(InsertPt), What);
   if (!isa<MemoryUse>(What)) {


### PR DESCRIPTION
As per discussion at https://github.com/llvm/llvm-project/pull/181709#discussion_r2847595945, users may already get a non-const MemoryAccess pointer via `getMemoryAccess` for a given instruction. Drop the restriction on directly iterate over them by modifying public `getBlockDefs`/`getBlockAccesses` APIs to return a mutable list, thus dropping the now obsolete distinction with `getWritableBlockDefs`/`getWritableBlockAccesses` helpers.