### PR TITLE
[DwarfUnit] Fix comment mistake in shouldPlaceInUnitDIE()

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
@@ -350,7 +350,7 @@ protected:
   void emitCommonHeader(bool UseOffsets, dwarf::UnitType UT);
 
   bool shouldPlaceInUnitDIE(const DISubprogram *SP, bool Minimal) {
-    // Add subprogram declarations to the CU die directly.
+    // Add subprogram definitions to the CU die directly.
     return Minimal || SP->getDeclaration();
   }
 


### PR DESCRIPTION
Subprogram definition DIEs (for which `SP->getDeclaration() != nullptr`)
are placed at the CU scope, while subprogram declaration DIEs are placed
in their corresponding (local) scopes.