### PR TITLE
[libc++] Use python3 in ssh.py's shebang

### DIFF
--- a/libcxx/utils/ssh.py
+++ b/libcxx/utils/ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ===----------------------------------------------------------------------===##
 #
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
This is the one I stumbled upon, but there are a few more in the project.
`find libcxx -type f -exec sed -i '1s/env python$/env python3/' {} \;` gives a dozen more, should I change all of them?

Also, I don't have write permissions here, so I will need help if this is to be accepted.