### PR TITLE
[HIP] Check if Input is a file before constructing link job

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -39,8 +39,11 @@ void AMDGCN::Linker::constructLLVMLinkCommand(
 
   ArgStringList LinkerInputs;
 
-  for (auto Input : Inputs)
+  for (auto Input : Inputs) {
+    if (!Input.isFilename())
+      continue;
     LinkerInputs.push_back(Input.getFilename());
+  }
 
   // Look for archive of bundled bitcode in arguments, and add temporary files
   // for the extracted archive of bitcode to inputs.
@@ -131,8 +134,11 @@ void AMDGCN::Linker::constructLldCommand(Compilation &C, const JobAction &JA,
   }
 
   LldArgs.append({"-o", Output.getFilename()});
-  for (auto Input : Inputs)
+  for (auto Input : Inputs) {
+    if (!Input.isFilename())
+      continue;
     LldArgs.push_back(Input.getFilename());
+  }
 
   // Look for archive of bundled bitcode in arguments, and add temporary files
   // for the extracted archive of bitcode to inputs.

--- a/clang/lib/Driver/ToolChains/SPIRV.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRV.cpp
@@ -83,8 +83,11 @@ void SPIRV::constructLLVMLinkCommand(Compilation &C, const Tool &T,
 
   ArgStringList LlvmLinkArgs;
 
-  for (auto Input : Inputs)
+  for (auto Input : Inputs) {
+    if (!Input.isFilename())
+      continue;
     LlvmLinkArgs.push_back(Input.getFilename());
+  }
 
   tools::constructLLVMLinkCommand(C, T, JA, Inputs, LlvmLinkArgs, Output, Args);
 }


### PR DESCRIPTION
It feels awkward, but it seems like it's a drawback of the current design, see FIXME in InputInfo.h l23-28.
As sanity check: constructLldCommand also has this check.