### PR TITLE
[Hexagon] Add missing early architecture features to V81 processor

### DIFF
--- a/llvm/lib/Target/Hexagon/Hexagon.td
+++ b/llvm/lib/Target/Hexagon/Hexagon.td
@@ -499,8 +499,8 @@ def : Proc<"hexagonv79", HexagonModelV79,
            FeatureCompound, FeatureDuplex, FeatureMemNoShuf, FeatureMemops,
            FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData]>;
 def : Proc<"hexagonv81", HexagonModelV81,
-           [ArchV65, ArchV66, ArchV67, ArchV68, ArchV69, ArchV71, ArchV73,
-            ArchV75, ArchV79, ArchV81,
+           [ArchV5, ArchV55, ArchV60, ArchV62, ArchV65, ArchV66, ArchV67,
+            ArchV68, ArchV69, ArchV71, ArchV73, ArchV75, ArchV79, ArchV81,
             FeatureCompound, FeatureDuplex, FeatureMemNoShuf, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData]>;
 

--- a/llvm/test/CodeGen/Hexagon/v81-early-arch-features.ll
+++ b/llvm/test/CodeGen/Hexagon/v81-early-arch-features.ll
@@ -1,0 +1,16 @@
+; RUN: llc -mtriple=hexagon -mcpu=hexagonv81 -mattr=+hvxv81,+hvx-length128b,+hvx-ieee-fp,-packets < %s | FileCheck %s
+
+; Before the fix, V81 processor definition in Hexagon.td was missing early
+; architecture features (ArchV5, ArchV55, ArchV60, ArchV62), causing compilation
+; to fail with:
+;   "fatal error: Attempting to emit S6_vsplatrbp instruction but the
+;    Feature_HasV62 predicate(s) are not met"
+
+; CHECK-LABEL: test_hvx_v16i8_return:
+; CHECK: vsplatb
+
+define <16 x i8> @test_hvx_v16i8_return() {
+entry:
+  ret <16 x i8> zeroinitializer
+}
+


### PR DESCRIPTION
V81 was missing ArchV5, ArchV55, ArchV60, and ArchV62 in its feature list, causing instructions requiring these architecture versions to fail during compilation.
