### PR TITLE
[compiler-rt][ARM] Fix conditions for strict-mode FP testing

### DIFF
--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -79,13 +79,17 @@ foreach(arch ${BUILTIN_TEST_ARCH})
       # implementations are present in this library, and therefore, can be
       # expected to behave in the way expected by the extra-strict tests of NaN
       # and error handling.
-      list(APPEND BUILTINS_TEST_TARGET_CFLAGS -DCOMPILER_RT_ARM_OPTIMIZED_FP_THUMB1)
-    else()
-      # For AArch32 targets that are not just Thumb-1, set a more general flag
-      # _and_ the previous one too, so that tests can check
+      list(APPEND BUILTINS_TEST_TARGET_CFLAGS
+        -DCOMPILER_RT_ARM_OPTIMIZED_FP_THUMB1)
+    elseif(NOT arch MATCHES "armv[456]")
+      # For AArch32 targets that are not just Thumb-1 (and also not too old for
+      # the optimized functions to support them), set a more general flag _and_
+      # the previous one too, so that tests can check
       # COMPILER_RT_ARM_OPTIMIZED_FP_THUMB1 by itself to test for an optimized
       # function available on all AArch32 platforms.
-      list(APPEND BUILTINS_TEST_TARGET_CFLAGS -DCOMPILER_RT_ARM_OPTIMIZED_FP)
+      list(APPEND BUILTINS_TEST_TARGET_CFLAGS
+        -DCOMPILER_RT_ARM_OPTIMIZED_FP
+        -DCOMPILER_RT_ARM_OPTIMIZED_FP_THUMB1)
     endif()
     string(REPLACE ";" " " BUILTINS_TEST_TARGET_CFLAGS "${BUILTINS_TEST_TARGET_CFLAGS}")
   endif()

--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -82,11 +82,15 @@ foreach(arch ${BUILTIN_TEST_ARCH})
       list(APPEND BUILTINS_TEST_TARGET_CFLAGS
         -DCOMPILER_RT_ARM_OPTIMIZED_FP_THUMB1)
     elseif(NOT arch MATCHES "armv[456]")
-      # For AArch32 targets that are not just Thumb-1 (and also not too old for
-      # the optimized functions to support them), set a more general flag _and_
-      # the previous one too, so that tests can check
+      # For AArch32 targets that are not just Thumb-1, set a more general flag
+      # _and_ the previous one too, so that tests can check
       # COMPILER_RT_ARM_OPTIMIZED_FP_THUMB1 by itself to test for an optimized
       # function available on all AArch32 platforms.
+      #
+      # We exclude armv[456] because those architecture versions are too old
+      # for the optimized functions to support them at all. (And we test
+      # against the fixed set of too-old versions rather than the open-ended
+      # set of newer ones, for future-proofing.)
       list(APPEND BUILTINS_TEST_TARGET_CFLAGS
         -DCOMPILER_RT_ARM_OPTIMIZED_FP
         -DCOMPILER_RT_ARM_OPTIMIZED_FP_THUMB1)


### PR DESCRIPTION
On sufficiently old versions of the Arm architecture, the optimized FP routines are not enabled. So commit a84ee1416b6c179 should not have enabled the extra-strict tests that go with them.

Also in that commit, I wrote a comment saying I was setting two separate compile-time definitions (-DCOMPILER_RT_ARM_OPTIMIZED_FP and -DCOMPILER_RT_ARM_OPTIMIZED_FP_THUMB1), and then didn't actually do it!