### PR TITLE
[openmp][tests] Fix bug63197.c

### DIFF
--- a/openmp/runtime/test/parallel/bug63197.c
+++ b/openmp/runtime/test/parallel/bug63197.c
@@ -3,16 +3,22 @@
 #include <omp.h>
 #include <stdio.h>
 
+/* This code tests that state pushed for the num_threads clause does not
+   reach the next parallel region. omp_get_max_threads() + 1 can never
+   be chosen as team size for the second parallel and could only be the
+   result of some left-over state from the first parallel.
+ */
+
 int main(int argc, char *argv[]) {
-  unsigned N = omp_get_max_threads() - 1;
-#pragma omp parallel num_threads(N) if (0)
+  unsigned N = omp_get_max_threads();
+#pragma omp parallel num_threads(N + 1) if (0)
 #pragma omp single
   { printf("BBB %2d\n", omp_get_num_threads()); }
 
 #pragma omp parallel
 #pragma omp single
   {
-    if (omp_get_num_threads() != N)
+    if (omp_get_num_threads() <= N)
       printf("PASS\n");
   }
   return 0;


### PR DESCRIPTION
#183269 tried to fix the test, but the test can still randomly fail. The OpenMP spec does not prevent the runtime to chose a smaller team size than returned from omp_max_threads() for the second parallel region.

Using a larger value than `omp_max_threads()` in a `num_threads` clause is valid OpenMP code. With a correct OpenMP implementation, the team-size of the second parallel region must still be smaller or equal the value returned from `omp_max_threads()`.