### PR TITLE
[clang][bytecode] Add `Record::hasPtrField()`

### DIFF
--- a/clang/lib/AST/ByteCode/Record.h
+++ b/clang/lib/AST/ByteCode/Record.h
@@ -75,6 +75,8 @@ public:
       return CXXDecl->getDestructor();
     return nullptr;
   }
+  /// If this record (or any of its bases) contains a field of type PT_Ptr.
+  bool hasPtrField() const { return HasPtrField; }
 
   /// Returns true for anonymous unions and records
   /// with no destructor or for those with a trivial destructor.
@@ -125,7 +127,7 @@ private:
   /// Constructor used by Program to create record descriptors.
   Record(const RecordDecl *, BaseList &&Bases, FieldList &&Fields,
          VirtualBaseList &&VirtualBases, unsigned VirtualSize,
-         unsigned BaseSize);
+         unsigned BaseSize, bool HasPtrField = true);
 
 private:
   friend class Program;
@@ -151,6 +153,8 @@ private:
   bool IsUnion;
   /// If this is an anonymous union.
   bool IsAnonymousUnion;
+  /// If any of the fields are pointers (or references).
+  bool HasPtrField = false;
 };
 
 } // namespace interp


### PR DESCRIPTION
So we can short-circuit the checking in `EvaluationResult::collectBlock()`. This improves the compile time of `X86Disassembler.cpp` by roughly 3.8%: https://llvm-compile-time-tracker.com/compare_clang.php?from=d69c6a8528c60a8f8013651ff18ed4882f6e6836&to=b8b6333551d7c644e3c1b00ed19aceea09da40cc&stat=instructions%3Au