### PR TITLE
[Clang] Warn if both of `dllexport`/`dllimport` and `exclude_from_explicit_instantiation` are specified

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3784,17 +3784,20 @@ def warn_redeclaration_without_attribute_prev_attribute_ignored : Warning<
 def warn_redeclaration_without_import_attribute : Warning<
   "%q0 redeclared without 'dllimport' attribute: 'dllexport' attribute added">,
   InGroup<MicrosoftInconsistentDllImport>;
-def warn_dllattr_ignored_exclusion_takes_precedence : Warning<
-  "%0 attribute ignored; %1 takes precedence">,
-  InGroup<IgnoredAttributes>;
-def warn_exclusion_takes_precedence_over_dllattr : Warning<
-  "%0 attribute takes precedence over %1 attribute on the enclosing class">,
-  InGroup<IgnoredAttributes>;
 def warn_dllimport_dropped_from_inline_function : Warning<
   "%q0 redeclared inline; %1 attribute ignored">,
   InGroup<IgnoredAttributes>;
 def warn_nothrow_attribute_ignored : Warning<"'nothrow' attribute conflicts with"
   " exception specification; attribute ignored">,
+  InGroup<IgnoredAttributes>;
+def warn_dllattr_ignored_exclusion_takes_precedence : Warning<
+  "%0 attribute ignored; %1 takes precedence">,
+  InGroup<IgnoredAttributes>;
+def warn_attribute_ignored_on_non_member :
+  Warning<"%0 attribute ignored on a non-member declaration">,
+  InGroup<IgnoredAttributes>;
+def warn_attribute_ignored_in_non_template :
+  Warning<"%0 attribute ignored in a non-template context">,
   InGroup<IgnoredAttributes>;
 def warn_attribute_ignored_on_non_definition :
   Warning<"%0 attribute ignored on a non-definition declaration">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3784,6 +3784,9 @@ def warn_redeclaration_without_attribute_prev_attribute_ignored : Warning<
 def warn_redeclaration_without_import_attribute : Warning<
   "%q0 redeclared without 'dllimport' attribute: 'dllexport' attribute added">,
   InGroup<MicrosoftInconsistentDllImport>;
+def warn_dllattr_ignored_exclusion_takes_precedence : Warning<
+  "%0 attribute ignored; %1 takes precedence">,
+  InGroup<IgnoredAttributes>;
 def warn_dllimport_dropped_from_inline_function : Warning<
   "%q0 redeclared inline; %1 attribute ignored">,
   InGroup<IgnoredAttributes>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3787,6 +3787,9 @@ def warn_redeclaration_without_import_attribute : Warning<
 def warn_dllattr_ignored_exclusion_takes_precedence : Warning<
   "%0 attribute ignored; %1 takes precedence">,
   InGroup<IgnoredAttributes>;
+def warn_exclusion_takes_precedence_over_dllattr : Warning<
+  "%0 attribute takes precedence over %1 attribute on the enclosing class">,
+  InGroup<IgnoredAttributes>;
 def warn_dllimport_dropped_from_inline_function : Warning<
   "%q0 redeclared inline; %1 attribute ignored">,
   InGroup<IgnoredAttributes>;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -48,6 +48,7 @@
 #include "clang/Sema/SemaBPF.h"
 #include "clang/Sema/SemaCUDA.h"
 #include "clang/Sema/SemaHLSL.h"
+#include "clang/Sema/SemaInternal.h"
 #include "clang/Sema/SemaM68k.h"
 #include "clang/Sema/SemaMIPS.h"
 #include "clang/Sema/SemaMSP430.h"
@@ -705,6 +706,24 @@ static void handleExcludeFromExplicitInstantiationAttr(Sema &S, Decl *D,
         << AL << /*IsMember=*/!isa<CXXRecordDecl>(D);
     return;
   }
+
+  if (auto *DA = getDLLAttr(D); DA && !DA->isInherited()) {
+    if (auto *RD = dyn_cast<CXXRecordDecl>(D->getDeclContext())) {
+      if (RD->isTemplated()) {
+        S.Diag(DA->getLoc(),
+               diag::warn_dllattr_ignored_exclusion_takes_precedence)
+            << DA << AL;
+        D->dropAttrs<DLLExportAttr, DLLImportAttr>();
+      } else {
+        S.Diag(AL.getLoc(), diag::warn_attribute_ignored_in_non_template) << AL;
+        return;
+      }
+    } else {
+      S.Diag(AL.getLoc(), diag::warn_attribute_ignored_on_non_member) << AL;
+      return;
+    }
+  }
+
   D->addAttr(::new (S.Context)
                  ExcludeFromExplicitInstantiationAttr(S.Context, AL));
 }
@@ -6466,6 +6485,22 @@ static void handleDLLAttr(Sema &S, Decl *D, const ParsedAttr &A) {
         MD->getParent()->isLambda()) {
       S.Diag(A.getRange().getBegin(), diag::err_attribute_dll_lambda) << A;
       return;
+    }
+  }
+
+  if (auto *EA = D->getAttr<ExcludeFromExplicitInstantiationAttr>()) {
+    if (auto *RD = dyn_cast<CXXRecordDecl>(D->getDeclContext())) {
+      if (RD->isTemplated()) {
+        S.Diag(A.getRange().getBegin(),
+               diag::warn_dllattr_ignored_exclusion_takes_precedence)
+            << A << EA;
+        return;
+      }
+      S.Diag(EA->getLoc(), diag::warn_attribute_ignored_in_non_template) << EA;
+      D->dropAttr<ExcludeFromExplicitInstantiationAttr>();
+    } else {
+      S.Diag(EA->getLoc(), diag::warn_attribute_ignored_on_non_member) << EA;
+      D->dropAttr<ExcludeFromExplicitInstantiationAttr>();
     }
   }
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -7229,21 +7229,6 @@ void Sema::CheckCompletedCXXClass(Scope *S, CXXRecordDecl *Record) {
   bool HasMethodWithOverrideControl = false,
        HasOverridingMethodWithoutOverrideControl = false;
   for (auto *D : Record->decls()) {
-    if (auto *EA = D->getAttr<ExcludeFromExplicitInstantiationAttr>()) {
-      if (auto *DA = getDLLAttr(D)) {
-        if (DA->isInherited()) {
-          Diag(EA->getLoc(), diag::warn_exclusion_takes_precedence_over_dllattr)
-              << EA << DA;
-          Diag(DA->getLoc(), diag::note_attribute);
-        } else {
-          Diag(DA->getLoc(),
-               diag::warn_dllattr_ignored_exclusion_takes_precedence)
-              << DA << EA;
-        }
-        D->dropAttrs<DLLExportAttr, DLLImportAttr>();
-      }
-    }
-
     if (auto *M = dyn_cast<CXXMethodDecl>(D)) {
       // FIXME: We could do this check for dependent types with non-dependent
       // bases.

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -7229,6 +7229,15 @@ void Sema::CheckCompletedCXXClass(Scope *S, CXXRecordDecl *Record) {
   bool HasMethodWithOverrideControl = false,
        HasOverridingMethodWithoutOverrideControl = false;
   for (auto *D : Record->decls()) {
+    if (auto *EA = D->getAttr<ExcludeFromExplicitInstantiationAttr>()) {
+      if (auto *DA = getDLLAttr(D)) {
+        Diag(DA->getRange().getBegin(),
+             diag::warn_dllattr_ignored_exclusion_takes_precedence)
+            << *DA << EA;
+        D->dropAttrs<DLLExportAttr, DLLImportAttr>();
+      }
+    }
+
     if (auto *M = dyn_cast<CXXMethodDecl>(D)) {
       // FIXME: We could do this check for dependent types with non-dependent
       // bases.

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -7231,9 +7231,15 @@ void Sema::CheckCompletedCXXClass(Scope *S, CXXRecordDecl *Record) {
   for (auto *D : Record->decls()) {
     if (auto *EA = D->getAttr<ExcludeFromExplicitInstantiationAttr>()) {
       if (auto *DA = getDLLAttr(D)) {
-        Diag(DA->getRange().getBegin(),
-             diag::warn_dllattr_ignored_exclusion_takes_precedence)
-            << *DA << EA;
+        if (DA->isInherited()) {
+          Diag(EA->getLoc(), diag::warn_exclusion_takes_precedence_over_dllattr)
+              << EA << DA;
+          Diag(DA->getLoc(), diag::note_attribute);
+        } else {
+          Diag(DA->getLoc(),
+               diag::warn_dllattr_ignored_exclusion_takes_precedence)
+              << DA << EA;
+        }
         D->dropAttrs<DLLExportAttr, DLLImportAttr>();
       }
     }

--- a/clang/test/SemaCXX/attr-exclude_from_explicit_instantiation.ignore-dllattr.cpp
+++ b/clang/test/SemaCXX/attr-exclude_from_explicit_instantiation.ignore-dllattr.cpp
@@ -9,18 +9,12 @@
 
 template <class T>
 struct C {
-  EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported();
-// expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-  EXCLUDE_ATTR __declspec(dllimport) void fn_excluded_imported();
-// expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-  EXCLUDE_ATTR __declspec(dllexport) static int var_excluded_exported;
-// expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-  EXCLUDE_ATTR __declspec(dllimport) static int var_excluded_imported;
-// expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-  struct EXCLUDE_ATTR __declspec(dllexport) nested_excluded_exported {};
-// expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-  struct EXCLUDE_ATTR __declspec(dllimport) nested_excluded_imported {};
-// expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported(); // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  EXCLUDE_ATTR __declspec(dllimport) void fn_excluded_imported(); // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  EXCLUDE_ATTR __declspec(dllexport) static int var_excluded_exported; // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  EXCLUDE_ATTR __declspec(dllimport) static int var_excluded_imported; // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  struct EXCLUDE_ATTR __declspec(dllexport) nested_excluded_exported {}; // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  struct EXCLUDE_ATTR __declspec(dllimport) nested_excluded_imported {}; // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
 
   // No warnings here since nested_excluded is not instantiated.
   struct EXCLUDE_ATTR nested_excluded {
@@ -39,14 +33,10 @@ struct C {
   };
 
   struct nested {
-    EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported();
-    // expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-    EXCLUDE_ATTR __declspec(dllimport) void fn_excluded_imported();
-    // expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-    EXCLUDE_ATTR __declspec(dllexport) static int var_excluded_exported;
-    // expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-    EXCLUDE_ATTR __declspec(dllimport) static int var_excluded_imported;
-    // expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+    EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported(); // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+    EXCLUDE_ATTR __declspec(dllimport) void fn_excluded_imported(); // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+    EXCLUDE_ATTR __declspec(dllexport) static int var_excluded_exported; // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+    EXCLUDE_ATTR __declspec(dllimport) static int var_excluded_imported; // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
   };
 };
 
@@ -75,12 +65,10 @@ struct E {
     __declspec(dllimport) void fn_imported();
   };
 
-  struct __declspec(dllexport) nested_exported_1 {
-    // expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  struct __declspec(dllexport) nested_exported_1 { // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
     EXCLUDE_ATTR void fn_excluded();
   };
-  struct __declspec(dllimport) nested_imported_1 {
-    // expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  struct __declspec(dllimport) nested_imported_1 { // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
     EXCLUDE_ATTR void fn_excluded();
   };
 

--- a/clang/test/SemaCXX/attr-exclude_from_explicit_instantiation.ignore-dllattr.cpp
+++ b/clang/test/SemaCXX/attr-exclude_from_explicit_instantiation.ignore-dllattr.cpp
@@ -2,85 +2,171 @@
 // RUN: %clang_cc1 -triple x86_64-mingw                 -fsyntax-only -verify %s
 // RUN: %clang_cc1 -triple x86_64-cygwin                -fsyntax-only -verify %s
 
-// Test that memberwise dllexport and dllimport are warned if the
-// exclude_from_explicit_instantiation attribute is attached.
+// Test that attaching the exclude_from_explicit_instantiation attribute and
+// either the dllexport or dllimport attribute together causes a warning.
+// One of them is ignored, depending on the context that is declared.
 
 #define EXCLUDE_ATTR __attribute__((exclude_from_explicit_instantiation))
 
+// Test that exclude_from_explicit_instantiation takes precedence over
+// dllexport/dllimport in a template context.
 template <class T>
-struct C {
+struct class_tmpl_no_instantiated {
   EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported(); // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
   EXCLUDE_ATTR __declspec(dllimport) void fn_excluded_imported(); // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  __declspec(dllexport) EXCLUDE_ATTR void fn_exported_excluded(); // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  __declspec(dllimport) EXCLUDE_ATTR void fn_imported_excluded(); // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+
   EXCLUDE_ATTR __declspec(dllexport) static int var_excluded_exported; // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
   EXCLUDE_ATTR __declspec(dllimport) static int var_excluded_imported; // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  __declspec(dllexport) EXCLUDE_ATTR static int var_exported_excluded; // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  __declspec(dllimport) EXCLUDE_ATTR static int var_imported_excluded; // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+
   struct EXCLUDE_ATTR __declspec(dllexport) nested_excluded_exported {}; // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
   struct EXCLUDE_ATTR __declspec(dllimport) nested_excluded_imported {}; // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  struct __declspec(dllexport) EXCLUDE_ATTR nested_exported_excluded {}; // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  struct __declspec(dllimport) EXCLUDE_ATTR nested_imported_excluded {}; // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
 
-  // No warnings here since nested_excluded is not instantiated.
-  struct EXCLUDE_ATTR nested_excluded {
-    __declspec(dllexport) void fn_exported();
-    __declspec(dllimport) void fn_imported();
-  };
-  // This too. nested_exported is not instantiated.
-  struct __declspec(dllexport) nested_exported {
-    EXCLUDE_ATTR void fn_excluded();
-    EXCLUDE_ATTR static int var_excluded;
-  };
-  // The same. nested_imported is not instantiated.
-  struct __declspec(dllimport) nested_imported {
-    EXCLUDE_ATTR void fn_excluded();
-    EXCLUDE_ATTR static int var_excluded;
-  };
+  template <class U>
+  struct EXCLUDE_ATTR __declspec(dllexport) nested_tmpl_excluded_exported {}; // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  template <class U>
+  EXCLUDE_ATTR __declspec(dllexport) static T var_template_excluded; // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  template <class U>
+  EXCLUDE_ATTR __declspec(dllexport) void fn_template_excluded(); // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
 
   struct nested {
     EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported(); // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-    EXCLUDE_ATTR __declspec(dllimport) void fn_excluded_imported(); // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-    EXCLUDE_ATTR __declspec(dllexport) static int var_excluded_exported; // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-    EXCLUDE_ATTR __declspec(dllimport) static int var_excluded_imported; // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  };
+
+  struct EXCLUDE_ATTR nested_excluded {
+    __declspec(dllexport) void fn_exported();
+  };
+  struct __declspec(dllexport) nested_exported {
+    EXCLUDE_ATTR void fn_excluded();
+  };
+  struct __declspec(dllimport) nested_imported {
+    EXCLUDE_ATTR void fn_excluded();
+  };
+
+  template <class U>
+  struct nested_tmpl {
+    EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported(); // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
   };
 };
 
-// Test that class-level dll attributes doesn't cause a warning on an excluded member.
+// Test that a class-level dll attribute doesn't cause a warning on an excluded member.
 template <class T>
-struct __declspec(dllexport) DE {
+struct __declspec(dllexport) class_tmpl_exported {
   EXCLUDE_ATTR void fn_excluded();
 };
-template struct DE<int>;
+template struct class_tmpl_exported<int>;
+void use_class_tmpl_exported() { class_tmpl_exported<long>().fn_excluded(); }
 
 template <class T>
-struct __declspec(dllimport) DI {
+struct __declspec(dllimport) class_tmpl_imported {
   EXCLUDE_ATTR void fn_excluded();
 };
-template struct DI<int>;
+template struct class_tmpl_imported<int>;
+void use_class_tmpl_imported() { class_tmpl_imported<long>().fn_excluded(); }
 
-// Test that dll attributes on explicit instantiation doesn't cause a warning on
+// Test that a dll attribute on an explicit instantiation doesn't cause a warning on
 // an excluded member.
-// However, a non-template nested type may be warned on an excluded member by
-// its dll attribute.
 template <class T>
-struct E {
+struct class_tmpl_explicit_inst {
   EXCLUDE_ATTR void fn_excluded();
+  EXCLUDE_ATTR static T var_excluded;
   struct EXCLUDE_ATTR nested_excluded {
     __declspec(dllexport) void fn_exported();
     __declspec(dllimport) void fn_imported();
   };
 
-  struct __declspec(dllexport) nested_exported_1 { // expected-note{{attribute is here}}
-    EXCLUDE_ATTR void fn_excluded(); // expected-warning{{'exclude_from_explicit_instantiation' attribute takes precedence over 'dllexport' attribute on the enclosing class}}
+  struct __declspec(dllexport) nested_exported {
+    EXCLUDE_ATTR void fn_excluded();
   };
-  struct __declspec(dllimport) nested_imported_1 { // expected-note{{attribute is here}}
-    EXCLUDE_ATTR void fn_excluded(); // expected-warning{{'exclude_from_explicit_instantiation' attribute takes precedence over 'dllimport' attribute on the enclosing class}}
-  };
-
-  // Make sure that any warning isn't emitted if the nested type has no excluded members.
-  struct __declspec(dllexport) nested_exported_2 {
-    void fn();
-  };
-  struct __declspec(dllimport) nested_imported_2 {
-    void fn();
+  struct __declspec(dllimport) nested_imported {
+    EXCLUDE_ATTR void fn_excluded();
   };
 };
-extern template struct __declspec(dllimport) E<long>;
-template struct __declspec(dllexport) E<int>;
-// expected-note@-1{{in instantiation of member class 'E<int>::nested_exported_1' requested here}}
-// expected-note@-2{{in instantiation of member class 'E<int>::nested_imported_1' requested here}}
+extern template struct __declspec(dllimport) class_tmpl_explicit_inst<long>;
+template struct __declspec(dllexport) class_tmpl_explicit_inst<int>;
+
+// Test that exclude_from_explicit_instantiation is ignored in a non-template context.
+struct class_nontmpl {
+  EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported(); // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  EXCLUDE_ATTR __declspec(dllimport) void fn_excluded_imported(); // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  __declspec(dllexport) EXCLUDE_ATTR void fn_exported_excluded(); // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  __declspec(dllimport) EXCLUDE_ATTR void fn_imported_excluded(); // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+
+  EXCLUDE_ATTR __declspec(dllexport) static int var_excluded_exported; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  EXCLUDE_ATTR __declspec(dllimport) static int var_excluded_imported; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  __declspec(dllexport) EXCLUDE_ATTR static int var_exported_excluded; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  __declspec(dllimport) EXCLUDE_ATTR static int var_imported_excluded; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+
+  struct EXCLUDE_ATTR __declspec(dllexport) nested_excluded_exported {}; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  struct EXCLUDE_ATTR __declspec(dllimport) nested_excluded_imported {}; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  struct __declspec(dllexport) EXCLUDE_ATTR nested_exported_excluded {}; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  struct __declspec(dllimport) EXCLUDE_ATTR nested_imported_excluded {}; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+
+  template <class T>
+  struct EXCLUDE_ATTR __declspec(dllexport) class_template_excluded {}; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  template <class T>
+  EXCLUDE_ATTR __declspec(dllexport) static T var_template_excluded; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  template <class T>
+  EXCLUDE_ATTR __declspec(dllexport) void fn_template_excluded(); // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+
+  struct nested {
+    EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported(); // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored in a non-template context}}
+  };
+
+  struct EXCLUDE_ATTR nested_excluded {
+    __declspec(dllexport) void fn_excluded_exported();
+  };
+  struct __declspec(dllexport) nested_exported {
+    EXCLUDE_ATTR void fn_excluded();
+  };
+  struct __declspec(dllimport) nested_imported {
+    EXCLUDE_ATTR void fn_excluded();
+  };
+
+  template <class T>
+  struct nested_tmpl {
+    EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported(); // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  };
+};
+
+// Test that exclude_from_explicit_instantiation is ignored on a non-member entity.
+EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported(); // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+EXCLUDE_ATTR __declspec(dllimport) void fn_excluded_imported(); // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+__declspec(dllexport) EXCLUDE_ATTR void fn_exported_excluded(); // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+__declspec(dllimport) EXCLUDE_ATTR void fn_imported_excluded(); // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+
+EXCLUDE_ATTR __declspec(dllexport) int var_excluded_exported; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+EXCLUDE_ATTR __declspec(dllimport) int var_excluded_imported; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+__declspec(dllexport) EXCLUDE_ATTR int var_exported_excluded; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+__declspec(dllimport) EXCLUDE_ATTR int var_imported_excluded; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+
+struct EXCLUDE_ATTR __declspec(dllexport) class_excluded_exported {}; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+struct EXCLUDE_ATTR __declspec(dllimport) class_excluded_imported {}; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+struct __declspec(dllexport) EXCLUDE_ATTR class_exported_excluded {}; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+struct __declspec(dllimport) EXCLUDE_ATTR class_imported_excluded {}; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+
+template <class T>
+struct EXCLUDE_ATTR __declspec(dllexport) class_tmpl_excluded_exported {}; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+template <class T>
+EXCLUDE_ATTR __declspec(dllexport) T var_template_excluded; // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+template <class T>
+EXCLUDE_ATTR __declspec(dllexport) void fn_template_excluded(); // expected-warning{{'exclude_from_explicit_instantiation' attribute ignored on a non-member declaration}}
+
+EXCLUDE_ATTR void fn_excluded();
+
+EXCLUDE_ATTR int var_excluded;
+
+struct EXCLUDE_ATTR class_excluded {
+  __declspec(dllexport) void fn_excluded_exported();
+};
+struct __declspec(dllexport) class_exported {
+  EXCLUDE_ATTR void fn_excluded();
+};
+struct __declspec(dllimport) class_imported {
+  EXCLUDE_ATTR void fn_excluded();
+};

--- a/clang/test/SemaCXX/attr-exclude_from_explicit_instantiation.ignore-dllattr.cpp
+++ b/clang/test/SemaCXX/attr-exclude_from_explicit_instantiation.ignore-dllattr.cpp
@@ -1,0 +1,98 @@
+// RUN: %clang_cc1 -triple x86_64-win32 -fms-extensions -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple x86_64-mingw                 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple x86_64-cygwin                -fsyntax-only -verify %s
+
+// Test that memberwise dllexport and dllimport are warned if the
+// exclude_from_explicit_instantiation attribute is attached.
+
+#define EXCLUDE_ATTR __attribute__((exclude_from_explicit_instantiation))
+
+template <class T>
+struct C {
+  EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported();
+// expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  EXCLUDE_ATTR __declspec(dllimport) void fn_excluded_imported();
+// expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  EXCLUDE_ATTR __declspec(dllexport) static int var_excluded_exported;
+// expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  EXCLUDE_ATTR __declspec(dllimport) static int var_excluded_imported;
+// expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  struct EXCLUDE_ATTR __declspec(dllexport) nested_excluded_exported {};
+// expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  struct EXCLUDE_ATTR __declspec(dllimport) nested_excluded_imported {};
+// expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+
+  // No warnings here since nested_excluded is not instantiated.
+  struct EXCLUDE_ATTR nested_excluded {
+    __declspec(dllexport) void fn_exported();
+    __declspec(dllimport) void fn_imported();
+  };
+  // This too. nested_exported is not instantiated.
+  struct __declspec(dllexport) nested_exported {
+    EXCLUDE_ATTR void fn_excluded();
+    EXCLUDE_ATTR static int var_excluded;
+  };
+  // The same. nested_imported is not instantiated.
+  struct __declspec(dllimport) nested_imported {
+    EXCLUDE_ATTR void fn_excluded();
+    EXCLUDE_ATTR static int var_excluded;
+  };
+
+  struct nested {
+    EXCLUDE_ATTR __declspec(dllexport) void fn_excluded_exported();
+    // expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+    EXCLUDE_ATTR __declspec(dllimport) void fn_excluded_imported();
+    // expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+    EXCLUDE_ATTR __declspec(dllexport) static int var_excluded_exported;
+    // expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+    EXCLUDE_ATTR __declspec(dllimport) static int var_excluded_imported;
+    // expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+  };
+};
+
+// Test that class-level dll attributes doesn't cause a warning on an excluded member.
+template <class T>
+struct __declspec(dllexport) DE {
+  EXCLUDE_ATTR void fn_excluded();
+};
+template struct DE<int>;
+
+template <class T>
+struct __declspec(dllimport) DI {
+  EXCLUDE_ATTR void fn_excluded();
+};
+template struct DI<int>;
+
+// Test that dll attributes on explicit instantiation doesn't cause a warning on
+// an excluded member.
+// However, a non-template nested type may be warned on an excluded member by
+// its dll attribute.
+template <class T>
+struct E {
+  EXCLUDE_ATTR void fn_excluded();
+  struct EXCLUDE_ATTR nested_excluded {
+    __declspec(dllexport) void fn_exported();
+    __declspec(dllimport) void fn_imported();
+  };
+
+  struct __declspec(dllexport) nested_exported_1 {
+    // expected-warning@-1{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+    EXCLUDE_ATTR void fn_excluded();
+  };
+  struct __declspec(dllimport) nested_imported_1 {
+    // expected-warning@-1{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
+    EXCLUDE_ATTR void fn_excluded();
+  };
+
+  // Make sure that any warning isn't emitted if the nested type has no excluded members.
+  struct __declspec(dllexport) nested_exported_2 {
+    void fn();
+  };
+  struct __declspec(dllimport) nested_imported_2 {
+    void fn();
+  };
+};
+extern template struct __declspec(dllimport) E<long>;
+template struct __declspec(dllexport) E<int>;
+// expected-note@-1{{in instantiation of member class 'E<int>::nested_exported_1' requested here}}
+// expected-note@-2{{in instantiation of member class 'E<int>::nested_imported_1' requested here}}

--- a/clang/test/SemaCXX/attr-exclude_from_explicit_instantiation.ignore-dllattr.cpp
+++ b/clang/test/SemaCXX/attr-exclude_from_explicit_instantiation.ignore-dllattr.cpp
@@ -65,11 +65,11 @@ struct E {
     __declspec(dllimport) void fn_imported();
   };
 
-  struct __declspec(dllexport) nested_exported_1 { // expected-warning{{'dllexport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-    EXCLUDE_ATTR void fn_excluded();
+  struct __declspec(dllexport) nested_exported_1 { // expected-note{{attribute is here}}
+    EXCLUDE_ATTR void fn_excluded(); // expected-warning{{'exclude_from_explicit_instantiation' attribute takes precedence over 'dllexport' attribute on the enclosing class}}
   };
-  struct __declspec(dllimport) nested_imported_1 { // expected-warning{{'dllimport' attribute ignored; 'exclude_from_explicit_instantiation' takes precedence}}
-    EXCLUDE_ATTR void fn_excluded();
+  struct __declspec(dllimport) nested_imported_1 { // expected-note{{attribute is here}}
+    EXCLUDE_ATTR void fn_excluded(); // expected-warning{{'exclude_from_explicit_instantiation' attribute takes precedence over 'dllimport' attribute on the enclosing class}}
   };
 
   // Make sure that any warning isn't emitted if the nested type has no excluded members.


### PR DESCRIPTION
The attributes `exclude_from_explicit_instantiation` and `dllexport`/`dllimport` serve opposite purposes.
Therefore, if an entity has both attributes, drop one with a warning, depending on the context of the declaration.
In a template context, the `exclude_from_explicit_instantiation` attribute takes precedence over the `dllexport` or `dllimport` attribute. Conversely, the `dllexport` and `dllimport` attributes are prioritized, in a non-template context.