### PR TITLE
[libc][math] Disable shared math tests on AArch64

### DIFF
--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -1,3 +1,5 @@
+if(NOT LIBC_TARGET_ARCHITECTURE_IS_AARCH64)
+
 add_custom_target(libc-shared-tests)
 
 add_fp_unittest(
@@ -213,3 +215,5 @@ add_fp_unittest(
     libc.src.__support.math.tanhf16
     libc.src.__support.math.tanpif
 )
+
+endif()


### PR DESCRIPTION
Clang-11 on AArch64 has problems when compiling `float16` targets in shared math tests
https://lab.llvm.org/buildbot/#/builders/104/builds/42271

This PR disables the tests on AArch64.