### PR TITLE
[Driver][SPIRV] Fix SPIR-V build for AMD.

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9374,8 +9374,11 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       // For SPIR-V, pass some extra flags to `spirv-link`, the out-of-tree
       // SPIR-V linker. `spirv-link` isn't called in LTO mode so restrict these
       // flags to normal compilation.
-      if (TC->getTriple().isSPIRV() && !C.getDriver().isUsingLTO() &&
-          !C.getDriver().isUsingOffloadLTO()) {
+      // SPIR-V for AMD doesn't use spirv-link and therefore doesn't need these
+      // flags.
+      if (TC->getTriple().isSPIRV() &&
+          TC->getTriple().getVendor() != llvm::Triple::VendorType::AMD &&
+          !C.getDriver().isUsingLTO() && !C.getDriver().isUsingOffloadLTO()) {
         // For SPIR-V some functions will be defined by the runtime so allow
         // unresolved symbols in `spirv-link`.
         LinkerArgs.emplace_back("--allow-partial-linkage");


### PR DESCRIPTION
The AMD path doesn't use spirv-link, and the driver was incorrectly adding flags for it, which broke the build. The regression was introduced in https://github.com/llvm/llvm-project/commit/1870f3face71d6da2bc0095f751dd1b961b7e4c0.

Without this PR's fix, the following assertion is triggered [here](https://github.com/llvm/llvm-project/blob/aa3d6b37c7945bfb4c261dd994689de2a2de25bf/clang/lib/Driver/ToolChains/HIPAMD.cpp#L43) when the LLVM bitcode is linked because unexpected flags are forwarded: ```clang::driver::InputInfo::getFilename() const: Assertion `isFilename() && "Invalid accessor."' failed.```

The bug was triggered by:
 `clang++ --offload-new-driver -x hip -O3 --offload-arch=amdgcnspirv -use-spirv-backend -fvisibility=default -v ./repro/foo.hip -o out -save-temps`. 

This eventually invoked: `clang --no-default-config -o foo.hip-hip-spirv64-amd-amdhsa.hipfb.spirv64.amdgcnspirv.img -dumpdir foo.hip-hip-spirv64-amd-amdhsa.hipfb.spirv64.amdgcnspirv.img. --target=spirv64-amd-amdhsa -march=amdgcnspirv foo-hip-spirv64-amd-amdhsa-spirv64-amd-amdhsa-amdgcnspirv.o -Xlinker --allow-partial-linkage -O3 -use-spirv-backend -save-temps=cwd -flto-partitions=8 -###`.
It triggered the crash due to the incorrect flags. 