### PR TITLE
[Clang] Use llvm.ptrmask to mask out thumb bit

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -6884,13 +6884,9 @@ RValue CodeGenFunction::EmitCall(QualType CalleeType,
       // might be passed function pointers of both types.
       llvm::Value *AlignedCalleePtr;
       if (CGM.getTriple().isARM() || CGM.getTriple().isThumb()) {
-        llvm::Value *CalleeAddress =
-            Builder.CreatePtrToInt(CalleePtr, IntPtrTy);
-        llvm::Value *Mask = llvm::ConstantInt::getSigned(IntPtrTy, ~1);
-        llvm::Value *AlignedCalleeAddress =
-            Builder.CreateAnd(CalleeAddress, Mask);
-        AlignedCalleePtr =
-            Builder.CreateIntToPtr(AlignedCalleeAddress, CalleePtr->getType());
+        AlignedCalleePtr = Builder.CreateIntrinsic(
+            CalleePtr->getType(), llvm::Intrinsic::ptrmask,
+            {CalleePtr, llvm::ConstantInt::getSigned(IntPtrTy, ~1)});
       } else {
         AlignedCalleePtr = CalleePtr;
       }

--- a/clang/test/CodeGen/ubsan-function-sugared.cpp
+++ b/clang/test/CodeGen/ubsan-function-sugared.cpp
@@ -10,9 +10,7 @@ auto fun() {}
 
 // GNU-LABEL:  define{{.*}} void @_Z6callerv()
 // MSVC-LABEL: define{{.*}} void @"?caller@@YAXXZ"()
-// ARM:   ptrtoint ptr {{.*}} to i32, !nosanitize !6
-// ARM:   and i32 {{.*}}, -2, !nosanitize !6
-// ARM:   inttoptr i32 {{.*}} to ptr, !nosanitize !6
+// ARM:   call ptr @llvm.ptrmask.p0.i32(ptr {{.*}}, i32 -2), !nosanitize !6
 // CHECK: getelementptr <{ i32, i32 }>, ptr {{.*}}, i32 -1, i32 0, !nosanitize
 // CHECK: load i32, ptr {{.*}}, align {{.*}}, !nosanitize
 // CHECK: icmp eq i32 {{.*}}, -1056584962, !nosanitize

--- a/clang/test/CodeGen/ubsan-function.cpp
+++ b/clang/test/CodeGen/ubsan-function.cpp
@@ -13,9 +13,7 @@ void fun() {}
 
 // GNU-LABEL:  define{{.*}} void @_Z6callerPFvvE(ptr noundef %f)
 // MSVC-LABEL: define{{.*}} void @"?caller@@YAXP6AXXZ@Z"(ptr noundef %f)
-// ARM:   ptrtoint ptr {{.*}} to i32, !nosanitize !7
-// ARM:   and i32 {{.*}}, -2, !nosanitize !7
-// ARM:   inttoptr i32 {{.*}} to ptr, !nosanitize !7
+// ARM:   call ptr @llvm.ptrmask.p0.i32(ptr {{.*}}, i32 -2), !nosanitize !7
 // AUTH:  %[[STRIPPED:.*]] = ptrtoint ptr {{.*}} to i64, !nosanitize
 // AUTH:  call i64 @llvm.ptrauth.auth(i64 %[[STRIPPED]], i32 0, i64 0), !nosanitize
 // CHECK: getelementptr <{ i32, i32 }>, ptr {{.*}}, i32 -1, i32 0, !nosanitize


### PR DESCRIPTION
Use llvm.ptrmask instead of a ptrtoint + and + inttoptr sequence to mask out the thumb bit.