### PR TITLE
[Clang] Use ptrtoaddr instead of ptrtoint for alignment check

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -857,7 +857,7 @@ void CodeGenFunction::EmitTypeCheck(TypeCheckKind TCK, SourceLocation Loc,
       // The glvalue must be suitably aligned.
       if (AlignVal && *AlignVal > llvm::Align(1) &&
           (!PtrToAlloca || PtrToAlloca->getAlign() < *AlignVal)) {
-        PtrAsInt = Builder.CreatePtrToInt(Ptr, IntPtrTy);
+        PtrAsInt = Builder.CreatePtrToAddr(Ptr);
         llvm::Value *Align = Builder.CreateAnd(
             PtrAsInt, llvm::ConstantInt::get(IntPtrTy, AlignVal->value() - 1));
         llvm::Value *Aligned =

--- a/clang/test/CodeGen/catch-alignment-assumption-builtin_assume_aligned-polymorphism.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-builtin_assume_aligned-polymorphism.cpp
@@ -21,7 +21,7 @@ void *f(C *c) {
   // CHECK:                             [[CAST_NOT_NULL]]:
   // CHECK-NOSANITIZE-NEXT:               %[[ADD_PTR:.*]] = getelementptr inbounds i8, ptr %[[C_RELOAD]], i64 4
   // CHECK-NOSANITIZE-NEXT:               br label %[[CAST_END]]
-  // CHECK-SANITIZE-NEXT:                 %[[PTRTOINT:.*]] = ptrtoint ptr %[[C_RELOAD]] to i64, !nosanitize
+  // CHECK-SANITIZE-NEXT:                 %[[PTRTOINT:.*]] = ptrtoaddr ptr %[[C_RELOAD]] to i64, !nosanitize
   // CHECK-SANITIZE-NEXT:                 %[[MASKEDPTR:.*]] = and i64 %[[PTRTOINT]], 3, !nosanitize
   // CHECK-SANITIZE-NEXT:                 %[[MASKCOND:.*]] = icmp eq i64 %[[MASKEDPTR]], 0, !nosanitize
   // CHECK-SANITIZE-NEXT:                 br i1 %[[MASKCOND]], label %[[CONT:[^,]+]], label %[[HANDLER_TYPE_MISMATCH:[^,]+]]

--- a/clang/test/CodeGen/catch-undef-behavior.c
+++ b/clang/test/CodeGen/catch-undef-behavior.c
@@ -55,7 +55,7 @@ int bar(int *a) {
   // CHECK-COMMON:      %[[SIZE:.*]] = call i64 @llvm.objectsize.i64
   // CHECK-COMMON-NEXT: icmp uge i64 %[[SIZE]], 4
 
-  // CHECK-COMMON:      %[[PTRINT:.*]] = ptrtoint
+  // CHECK-COMMON:      %[[PTRINT:.*]] = ptrtoaddr
   // CHECK-COMMON-NEXT: %[[MISALIGN:.*]] = and i64 %[[PTRINT]], 3
   // CHECK-COMMON-NEXT: icmp eq i64 %[[MISALIGN]], 0
 

--- a/clang/test/CodeGenCXX/catch-undef-behavior.cpp
+++ b/clang/test/CodeGenCXX/catch-undef-behavior.cpp
@@ -30,7 +30,7 @@ void reference_binding(int *p, S *q) {
   // CHECK: %[[SIZE:.*]] = call i64 @llvm.objectsize.i64
   // CHECK-NEXT: icmp uge i64 %[[SIZE]], 4
 
-  // CHECK: %[[PTRINT:.*]] = ptrtoint
+  // CHECK: %[[PTRINT:.*]] = ptrtoaddr
   // CHECK-NEXT: %[[MISALIGN:.*]] = and i64 %[[PTRINT]], 3
   // CHECK-NEXT: icmp eq i64 %[[MISALIGN]], 0
   int &r = *p;
@@ -50,7 +50,7 @@ void member_access(S *p) {
   // CHECK: %[[SIZE:.*]] = call i64 @llvm.objectsize.i64
   // CHECK-NEXT: icmp uge i64 %[[SIZE]], 24
 
-  // CHECK: %[[PTRINT:.*]] = ptrtoint
+  // CHECK: %[[PTRINT:.*]] = ptrtoaddr
   // CHECK-NEXT: %[[MISALIGN:.*]] = and i64 %[[PTRINT]], 7
   // CHECK-NEXT: icmp eq i64 %[[MISALIGN]], 0
 
@@ -92,7 +92,7 @@ void member_access(S *p) {
   // CHECK: %[[SIZE:.*]] = call i64 @llvm.objectsize.i64
   // CHECK-NEXT: icmp uge i64 %[[SIZE]], 4
 
-  // CHECK: %[[PTRINT:.*]] = ptrtoint
+  // CHECK: %[[PTRINT:.*]] = ptrtoaddr
   // CHECK-NEXT: %[[MISALIGN:.*]] = and i64 %[[PTRINT]], 3
   // CHECK-NEXT: icmp eq i64 %[[MISALIGN]], 0
   int k = p->b;
@@ -104,7 +104,7 @@ void member_access(S *p) {
   // CHECK: %[[SIZE:.*]] = call i64 @llvm.objectsize.i64
   // CHECK-NEXT: icmp uge i64 %[[SIZE]], 24
 
-  // CHECK: %[[PTRINT:.*]] = ptrtoint
+  // CHECK: %[[PTRINT:.*]] = ptrtoaddr
   // CHECK-NEXT: %[[MISALIGN:.*]] = and i64 %[[PTRINT]], 7
   // CHECK-NEXT: icmp eq i64 %[[MISALIGN]], 0
 
@@ -366,7 +366,7 @@ void downcast_pointer(B *b) {
   // null check goes here
   // CHECK: [[FROM_PHI:%.+]] = phi ptr [ [[SUB]], {{.*}} ], {{.*}}
   // Objectsize check goes here
-  // CHECK: [[C_INT:%.+]] = ptrtoint ptr [[FROM_PHI]] to i64
+  // CHECK: [[C_INT:%.+]] = ptrtoaddr ptr [[FROM_PHI]] to i64
   // CHECK-NEXT: [[MASKED:%.+]] = and i64 [[C_INT]], 15
   // CHECK-NEXT: [[TEST:%.+]] = icmp eq i64 [[MASKED]], 0
   // AND the alignment test with the objectsize test.
@@ -380,7 +380,7 @@ void downcast_reference(B &b) {
   // Alignment check from EmitTypeCheck(TCK_DowncastReference, ...)
   // CHECK:      [[SUB:%[.a-z0-9]*]] = getelementptr inbounds i8, ptr {{.*}}, i64 -16
   // Objectsize check goes here
-  // CHECK:      [[C_INT:%.+]] = ptrtoint ptr [[SUB]] to i64
+  // CHECK:      [[C_INT:%.+]] = ptrtoaddr ptr [[SUB]] to i64
   // CHECK-NEXT: [[MASKED:%.+]] = and i64 [[C_INT]], 15
   // CHECK-NEXT: [[TEST:%.+]] = icmp eq i64 [[MASKED]], 0
   // AND the alignment test with the objectsize test.
@@ -420,7 +420,7 @@ namespace VBaseObjectSize {
     // CHECK: icmp uge i{{32|64}} [[SIZE]], 16,
 
     // Alignment check: check for nvalign(B) == 8 (do not require align(B) == 16)
-    // CHECK: [[PTRTOINT:%.+]] = ptrtoint {{.*}} to i64,
+    // CHECK: [[PTRTOINT:%.+]] = ptrtoaddr {{.*}} to i64,
     // CHECK: and i64 [[PTRTOINT]], 7,
     return b;
   }
@@ -429,7 +429,7 @@ namespace VBaseObjectSize {
   void *B::g() {
     // Ensure that the check on the "this" pointer also uses the proper
     // alignment. We should be using nvalign(B) == 8, not 16.
-    // CHECK: [[PTRTOINT:%.+]] = ptrtoint {{.*}} to i64,
+    // CHECK: [[PTRTOINT:%.+]] = ptrtoaddr {{.*}} to i64,
     // CHECK: and i64 [[PTRTOINT]], 7
     return nullptr;
   }
@@ -629,7 +629,7 @@ void ThisAlign::this_align_lambda() {
   // CHECK: %[[this_outer:.*]] = load ptr, ptr %[[this_outer_addr]],
   //
   // CHECK: %[[this_inner_isnonnull:.*]] = icmp ne ptr %[[this_inner]], null
-  // CHECK: %[[this_inner_asint:.*]] = ptrtoint ptr %[[this_inner]] to i
+  // CHECK: %[[this_inner_asint:.*]] = ptrtoaddr ptr %[[this_inner]] to i
   // CHECK: %[[this_inner_misalignment:.*]] = and i{{32|64}} %[[this_inner_asint]], {{3|7}},
   // CHECK: %[[this_inner_isaligned:.*]] = icmp eq i{{32|64}} %[[this_inner_misalignment]], 0
   // CHECK: %[[this_inner_valid:.*]] = and i1 %[[this_inner_isnonnull]], %[[this_inner_isaligned]],

--- a/clang/test/CodeGenCXX/ubsan-global-alignment.cpp
+++ b/clang/test/CodeGenCXX/ubsan-global-alignment.cpp
@@ -11,7 +11,7 @@ extern S array_S[];
 int load_extern_global() {
   // FIXME: The IR builder constant-folds the alignment check away to 'true'
   // here, so we never call the diagnostic. This is PR32630.
-  // CHECK-NOT: ptrtoint ptr {{.*}} to i32, !nosanitize
+  // CHECK-NOT: ptrtoaddr ptr {{.*}} to i32, !nosanitize
   // CHECK: [[I:%.*]] = load i32, ptr @g_S, align 4
   // CHECK-NEXT: ret i32 [[I]]
   return g_S.I;
@@ -20,7 +20,7 @@ int load_extern_global() {
 // CHECK-LABEL: define{{.*}} i32 @_Z22load_from_extern_array
 int load_from_extern_array(int I) {
   // CHECK: [[I:%.*]] = getelementptr inbounds nuw %struct.S, ptr {{.*}}, i32 0, i32 0
-  // CHECK-NEXT: [[PTRTOINT:%.*]] = ptrtoint ptr [[I]] to i64, !nosanitize
+  // CHECK-NEXT: [[PTRTOINT:%.*]] = ptrtoaddr ptr [[I]] to i64, !nosanitize
   // CHECK-NEXT: [[AND:%.*]] = and i64 [[PTRTOINT]], 3, !nosanitize
   // CHECK-NEXT: [[ICMP:%.*]] = icmp eq i64 [[AND]], 0, !nosanitize
   // CHECK-NEXT: br i1 [[ICMP]]

--- a/clang/test/CodeGenCXX/ubsan-suppress-checks.cpp
+++ b/clang/test/CodeGenCXX/ubsan-suppress-checks.cpp
@@ -33,7 +33,7 @@ struct A {
 
   // CHECK-LABEL: define linkonce_odr void @_ZN1A10do_nothingEv
   void do_nothing() {
-    // ALIGN: %[[THISINT1:[0-9]+]] = ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN: %[[THISINT1:[0-9]+]] = ptrtoaddr ptr %{{.*}} to i64, !nosanitize
     // ALIGN: and i64 %[[THISINT1]], 3, !nosanitize
     // NULL: icmp ne ptr %[[THIS1:[a-z0-9]+]], null, !nosanitize
     // NULL: ptrtoint ptr %[[THIS1]] to i64, !nosanitize
@@ -46,7 +46,7 @@ struct A {
   // LAMBDA-LABEL: define linkonce_odr void @_ZN1A22do_nothing_with_lambdaEv
   void do_nothing_with_lambda() {
     // LAMBDA: icmp ne ptr %[[THIS2:[a-z0-9]+]], null, !nosanitize
-    // LAMBDA: %[[THISINT2:[0-9]+]] = ptrtoint ptr %[[THIS2]] to i64, !nosanitize
+    // LAMBDA: %[[THISINT2:[0-9]+]] = ptrtoaddr ptr %[[THIS2]] to i64, !nosanitize
     // LAMBDA: and i64 %[[THISINT2]], 3, !nosanitize
     // LAMBDA: call void @__ubsan_handle_type_mismatch
 
@@ -69,7 +69,7 @@ struct A {
 
   // CHECK-LABEL: define linkonce_odr noundef i32 @_ZN1A11load_memberEv
   int load_member() {
-    // ALIGN: %[[THISINT3:[0-9]+]] = ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN: %[[THISINT3:[0-9]+]] = ptrtoaddr ptr %{{.*}} to i64, !nosanitize
     // ALIGN: and i64 %[[THISINT3]], 3, !nosanitize
     // NULL: icmp ne ptr %[[THIS3:[a-z0-9]+]], null, !nosanitize
     // NULL: ptrtoint ptr %[[THIS3]] to i64, !nosanitize
@@ -81,7 +81,7 @@ struct A {
 
   // CHECK-LABEL: define linkonce_odr noundef i32 @_ZN1A11call_methodEv
   int call_method() {
-    // ALIGN: %[[THISINT4:[0-9]+]] = ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN: %[[THISINT4:[0-9]+]] = ptrtoaddr ptr %{{.*}} to i64, !nosanitize
     // ALIGN: and i64 %[[THISINT4]], 3, !nosanitize
     // NULL: icmp ne ptr %[[THIS4:[a-z0-9]+]], null, !nosanitize
     // NULL: ptrtoint ptr %[[THIS4]] to i64, !nosanitize
@@ -93,7 +93,7 @@ struct A {
 
   // CHECK-LABEL: define linkonce_odr void @_ZN1A15assign_member_1Ev
   void assign_member_1() {
-    // ALIGN: %[[THISINT5:[0-9]+]] = ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN: %[[THISINT5:[0-9]+]] = ptrtoaddr ptr %{{.*}} to i64, !nosanitize
     // ALIGN: and i64 %[[THISINT5]], 3, !nosanitize
     // NULL: icmp ne ptr %[[THIS5:[a-z0-9]+]], null, !nosanitize
     // NULL: ptrtoint ptr %[[THIS5]] to i64, !nosanitize
@@ -105,7 +105,7 @@ struct A {
 
   // CHECK-LABEL: define linkonce_odr void @_ZN1A15assign_member_2Ev
   void assign_member_2() {
-    // ALIGN: %[[THISINT6:[0-9]+]] = ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN: %[[THISINT6:[0-9]+]] = ptrtoaddr ptr %{{.*}} to i64, !nosanitize
     // ALIGN: and i64 %[[THISINT6]], 3, !nosanitize
     // NULL: icmp ne ptr %[[THIS6:[a-z0-9]+]], null, !nosanitize
     // NULL: ptrtoint ptr %[[THIS6]] to i64, !nosanitize
@@ -117,7 +117,7 @@ struct A {
 
   // CHECK-LABEL: define linkonce_odr void @_ZNK1A15assign_member_3Ev
   void assign_member_3() const {
-    // ALIGN: %[[THISINT7:[0-9]+]] = ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN: %[[THISINT7:[0-9]+]] = ptrtoaddr ptr %{{.*}} to i64, !nosanitize
     // ALIGN: and i64 %[[THISINT7]], 3, !nosanitize
     // NULL: icmp ne ptr %[[THIS7:[a-z0-9]+]], null, !nosanitize
     // NULL: ptrtoint ptr %[[THIS7]] to i64, !nosanitize
@@ -129,7 +129,7 @@ struct A {
 
   // CHECK-LABEL: define linkonce_odr noundef i32 @_ZN1A22call_through_referenceERS_
   static int call_through_reference(A &a) {
-    // ALIGN: %[[OBJINT:[0-9]+]] = ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN: %[[OBJINT:[0-9]+]] = ptrtoaddr ptr %{{.*}} to i64, !nosanitize
     // ALIGN: and i64 %[[OBJINT]], 3, !nosanitize
     // ALIGN: call void @__ubsan_handle_type_mismatch
     // NULL-NOT: call void @__ubsan_handle_type_mismatch
@@ -173,7 +173,7 @@ struct Derived : public Base {
 
   // CHECK-LABEL: define linkonce_odr noundef i32 @_ZN7Derived13load_member_2Ev
   int load_member_2() {
-    // ALIGN: %[[THISINT8:[0-9]+]] = ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN: %[[THISINT8:[0-9]+]] = ptrtoaddr ptr %{{.*}} to i64, !nosanitize
     // ALIGN: and i64 %[[THISINT8]], 7, !nosanitize
     // ALIGN: call void @__ubsan_handle_type_mismatch
     // NULL: icmp ne ptr %[[THIS8:[a-z0-9]+]], null, !nosanitize
@@ -190,7 +190,7 @@ struct Derived : public Base {
 
   // CHECK-LABEL: define linkonce_odr noundef i32 @_ZN7Derived13load_member_3Ev
   int load_member_3() {
-    // ALIGN: %[[THISINT9:[0-9]+]] = ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN: %[[THISINT9:[0-9]+]] = ptrtoaddr ptr %{{.*}} to i64, !nosanitize
     // ALIGN: and i64 %[[THISINT9]], 7, !nosanitize
     // ALIGN: call void @__ubsan_handle_type_mismatch
     // ALIGN: call void @__ubsan_handle_type_mismatch
@@ -204,7 +204,7 @@ struct Derived : public Base {
 
   // CHECK-LABEL: define linkonce_odr noundef i32 @_ZN7Derived13load_member_1Ev
   int load_member_1() override {
-    // ALIGN: %[[THISINT10:[0-9]+]] = ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN: %[[THISINT10:[0-9]+]] = ptrtoaddr ptr %{{.*}} to i64, !nosanitize
     // ALIGN: and i64 %[[THISINT10]], 7, !nosanitize
     // ALIGN: call void @__ubsan_handle_type_mismatch
     // NULL: icmp ne ptr %[[THIS10:[a-z0-9]+]], null, !nosanitize

--- a/clang/test/CodeGenCXX/ubsan-type-checks.cpp
+++ b/clang/test/CodeGenCXX/ubsan-type-checks.cpp
@@ -7,7 +7,7 @@
 struct A {
   // COMMON-LABEL: define linkonce_odr void @_ZN1A10do_nothingEv
   void do_nothing() {
-    // ALIGN-NOT: ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN-NOT: ptrtoaddr ptr %{{.*}} to i64, !nosanitize
  
     // NULL: icmp ne ptr %{{.*}}, null, !nosanitize
  
@@ -20,7 +20,7 @@ struct B {
 
   // COMMON-LABEL: define linkonce_odr void @_ZN1B10do_nothingEv
   void do_nothing() {
-    // ALIGN: ptrtoint ptr %{{.*}} to i64, !nosanitize
+    // ALIGN: ptrtoaddr ptr %{{.*}} to i64, !nosanitize
     // ALIGN: and i64 %{{.*}}, 3, !nosanitize
 
     // NULL: icmp ne ptr %{{.*}}, null, !nosanitize


### PR DESCRIPTION
We do not need or want to expose the pointer provenance here, so use ptrtoaddr instead of ptrtoint.