### PR TITLE
[CMake] Propagate dependencies to OBJECT libraries in `add_llvm_library`

### DIFF
--- a/clang/cmake/modules/AddClang.cmake
+++ b/clang/cmake/modules/AddClang.cmake
@@ -217,7 +217,7 @@ endmacro()
 
 function(clang_target_link_libraries target type)
   if (TARGET obj.${target})
-    target_link_libraries(obj.${target} ${ARGN})
+    target_link_libraries(obj.${target} ${type} ${ARGN})
   endif()
 
   get_property(LLVM_DRIVER_TOOLS GLOBAL PROPERTY LLVM_DRIVER_TOOLS)

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -636,7 +636,12 @@ function(llvm_add_library name)
     # Do add_dependencies(obj) later due to CMake issue 14747.
     list(APPEND objlibs ${obj_name})
 
-    # Bring in the target include directories from our original target.
+    # Bring in the target include directories and link info from our original
+    # target. target_link_libraries propagates transitive dependencies with
+    # proper SYSTEM include handling from IMPORTED targets.
+    # target_include_directories propagates include directories set directly on
+    # the target.
+    target_link_libraries(${obj_name} PRIVATE $<TARGET_PROPERTY:${name},LINK_LIBRARIES>)
     target_include_directories(${obj_name} PRIVATE $<TARGET_PROPERTY:${name},INCLUDE_DIRECTORIES>)
 
     set_target_properties(${obj_name} PROPERTIES FOLDER "${subproject_title}/Object Libraries")

--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -769,7 +769,7 @@ endfunction(mlir_check_all_link_libraries)
 # used.
 function(mlir_target_link_libraries target type)
   if (TARGET obj.${target})
-    target_link_libraries(obj.${target} ${ARGN})
+    target_link_libraries(obj.${target} ${type} ${ARGN})
   endif()
 
   if (MLIR_LINK_MLIR_DYLIB)


### PR DESCRIPTION
Previously, transitively inherited calls to `target_include_directories(foo SYSTEM ...)` were being squashed into a flat list of includes, effectively stripping off `-isystem` and unintentionally forwarding warnings from such dependencies.

To correctly propagate `SYSTEM` dependencies, use `target_link_libraries` to forward the parent target's link dependencies to the OBJECT library (similar to the `_static` flow below). Unlike a flat `target_include_directories`, this lets CMake resolve transitive SYSTEM include directories through the proper dependency chain.

Note that `target_link_libraries` on an OBJECT library propagates all usage requirements, not just includes. This also brings in transitive `INTERFACE_COMPILE_DEFINITIONS`, `INTERFACE_COMPILE_OPTIONS`, and `INTERFACE_COMPILE_FEATURES`. This is arguably more correct, as the OBJECT library compiles the same sources and should see the same flags.

The existing `target_include_directories` call is retained for include directories set directly on the target (not through link dependencies). CMake deduplicates include directories that appear through both paths. Compile definitions and options may technically appear twice (once via the OBJECT library, once via the consuming target), but duplicate `-D` and flag entries should be harmless in practice.

Also fix `clang_target_link_libraries` and `mlir_target_link_libraries` to forward the link type (PUBLIC/PRIVATE/INTERFACE) to `obj.*` targets. Previously the type keyword was silently dropped, resulting in plain-signature  `target_link_libraries` calls. This is now required because the new keyword-signature call in `llvm_add_library` would otherwise conflict (CMake requires all calls on a target to use the same signature).