### PR TITLE
[Clang] Enable response file support for 'llvm-offload-binary'

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9240,7 +9240,7 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   C.addCommand(std::make_unique<Command>(
-      JA, *this, ResponseFileSupport::None(),
+      JA, *this, ResponseFileSupport::AtFileUTF8(),
       Args.MakeArgString(getToolChain().GetProgramPath(getShortName())),
       CmdArgs, Inputs, Output));
 }

--- a/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
+++ b/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
@@ -1,6 +1,9 @@
 ; RUN: llvm-offload-binary -o %t --image=file=%s,arch=abc,triple=x-y-z
 ; RUN: llvm-objdump --offloading %t | FileCheck %s
 ; RUN: llvm-offload-binary %t --image=file=%t2,arch=abc,triple=x-y-z
+; RUN: echo "-o %t --image=file=%s,arch=abc,triple=x-y-z" > %t.rsp
+; RUN: llvm-offload-binary @%t.rsp
+; RUN: llvm-objdump --offloading %t | FileCheck %s
 ; RUN: diff %s %t2
 
 ;      CHECK: OFFLOADING IMAGE [0]:


### PR DESCRIPTION
Summary:
These command line invocations can become so large that they no longer
fit, we should support response files in this case so the build on
Windows can be unblocked with the new driver.
