### PR TITLE
[Arch][X86] Raising FreeBSD low requirement to pentium4

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/X86.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/X86.cpp
@@ -108,8 +108,6 @@ std::string x86::getX86TargetCPU(const Driver &D, const ArgList &Args,
   case llvm::Triple::Haiku:
   case llvm::Triple::OpenBSD:
     return "i586";
-  case llvm::Triple::FreeBSD:
-    return "i686";
   default:
     // Fallback to p4.
     return "pentium4";


### PR DESCRIPTION
Using pentium4 by default allows us to build 32bit compiler-rt.builtins on x86_64 platform since _Float16 requires SSE2, which is only available after pentium3. Since FreeBSD does not support x86 after 16-CURRENT. It makes sense to put the x86_64 compatibility first.

In FreeBSD's base, we set the target to i686 with -sse2 to build 32bit compiler-rt.builtins. But we don't ship x86 compiler-rt.builtins in our llvm port.