### PR TITLE
[SPIRV] Fix Phi Legalization

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -357,6 +357,20 @@ public:
     return getSPIRVTypeForVReg(VReg) != nullptr;
   }
 
+  // Returns true if a live (non-debug) VReg in VRegToTypeMap references this
+  // type. Avoids deleting types still needed by live values (e.g., PHIs).
+  bool isTypeInstructionUsed(const MachineInstr *TypeMI,
+                             const MachineFunction *MF,
+                             const MachineRegisterInfo &MRI) const {
+    auto It = VRegToTypeMap.find(MF);
+    if (It == VRegToTypeMap.end())
+      return false;
+    for (const auto &[Reg, TypeInst] : It->second)
+      if (TypeInst == TypeMI && !MRI.use_nodbg_empty(Reg))
+        return true;
+    return false;
+  }
+
   // Return the VReg holding the result of the given OpTypeXXX instruction.
   Register getSPIRVTypeID(SPIRVTypeInst SpirvType) const;
 

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -673,7 +673,8 @@ static bool isOpcodeWithNoSideEffects(unsigned Opcode) {
   }
 }
 
-bool isDead(const MachineInstr &MI, const MachineRegisterInfo &MRI) {
+bool isDead(const MachineInstr &MI, const MachineRegisterInfo &MRI,
+            const SPIRVGlobalRegistry &GR) {
   // If there are no definitions, then assume there is some other
   // side-effect that makes this instruction live.
   if (MI.getNumDefs() == 0)
@@ -731,6 +732,14 @@ bool isDead(const MachineInstr &MI, const MachineRegisterInfo &MRI) {
   }
 
   if (isOpcodeWithNoSideEffects(MI.getOpcode())) {
+    // A type instruction may have no MRI uses but still referenced by 
+    // VRegToTypeMap (e.g., PHIs). Erasing it leaves a dangling pointer 
+    // and can crash patchPhis/getSPIRVTypeID.
+    if (GR.isTypeInstructionUsed(&MI, MI.getMF(), MRI)) {
+      LLVM_DEBUG(dbgs() << "Not dead: type instruction still referenced "
+                           "by VRegToTypeMap\n");
+      return false;
+    }
     LLVM_DEBUG(dbgs() << "Dead: known opcode with no side effects\n");
     return true;
   }
@@ -771,7 +780,7 @@ bool SPIRVInstructionSelector::select(MachineInstr &I) {
   assert(I.getParent()->getParent() && "Instruction should be in a function!");
 
   LLVM_DEBUG(dbgs() << "Checking if instruction is dead: " << I;);
-  if (isDead(I, *MRI)) {
+  if (isDead(I, *MRI, GR)) {
     LLVM_DEBUG(dbgs() << "Instruction is dead.\n");
     removeDeadInstruction(I);
     return true;
@@ -807,7 +816,7 @@ bool SPIRVInstructionSelector::select(MachineInstr &I) {
         });
         assert(Res || Def->getOpcode() == TargetOpcode::G_CONSTANT);
         if (Res) {
-          if (!isTriviallyDead(*Def, *MRI) && isDead(*Def, *MRI))
+          if (!isTriviallyDead(*Def, *MRI) && isDead(*Def, *MRI, GR))
             DeadMIs.insert(Def);
           return Res;
         }

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -264,6 +264,15 @@ class SPIRVLegalizePointerCast : public FunctionPass {
     // - float a = array[0];
     if (isTypeFirstElementAggregate(ToTy, FromTy))
       Output = loadFirstValueFromAggregate(B, ToTy, OriginalOperand, LI);
+    // Scalar load. No aggregate/vector down-cast reconstruction is needed.
+    else if (LI->getType()->isSingleValueType() && !LI->getType()->isVectorTy()) {
+      Type *LoadTy = ToTy ? ToTy : LI->getType();
+      GR->buildAssignPtr(B, LoadTy, OriginalOperand);
+      LoadInst *NewLoad = B.CreateLoad(LI->getType(), OriginalOperand);
+      NewLoad->setAlignment(LI->getAlign());
+      buildAssignType(B, LI->getType(), NewLoad);
+      Output = NewLoad;
+    }
     // Destination is a smaller vector than source or different vector type.
     // - float3 v3 = vector4;
     // - float4 v2 = int4;

--- a/llvm/test/CodeGen/SPIRV/pointers/ptrcast-phi-load-scalar.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/ptrcast-phi-load-scalar.ll
@@ -1,0 +1,36 @@
+; RUN: llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s
+
+
+; Legalizing for load from a pointer PHI
+
+; CHECK-DAG: %[[#INT:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#FTYPE:]] = OpTypeFunction %[[#INT]]
+; CHECK-DAG: %[[#PTR:]] = OpTypePointer StorageBuffer %[[#INT]]
+; CHECK-DAG: %[[#BOOL:]] = OpTypeBool
+; CHECK-DAG: %[[#NULL:]] = OpConstantNull %[[#PTR]]
+; CHECK-DAG: %[[#FALSE:]] = OpConstantFalse %[[#BOOL]]
+; CHECK:     %[[#]] = OpFunction %[[#INT]] None %[[#FTYPE]]
+; CHECK:     %[[#]] = OpLabel
+; CHECK:     OpSelectionMerge %[[#MERGE:]] None
+; CHECK:     OpBranchConditional %[[#FALSE]] %[[#]] %[[#]]
+; CHECK:     %[[#]] = OpLabel
+; CHECK:     OpBranch %[[#MERGE]]
+; CHECK:     %[[#]] = OpLabel
+; CHECK:     OpBranch %[[#MERGE]]
+; CHECK-NEXT:     %[[#MERGE]] = OpLabel
+; CHECK-NEXT:     %[[#RES:]] = OpLoad %[[#INT]] %[[#NULL]]
+; CHECK-NEXT:     OpReturnValue %[[#RES]]
+; CHECK:     OpFunctionEnd
+
+define i32 @main() {
+entry:
+  br i1 false, label %sw.epilog23.i.sink.split, label %sw.epilog.i.thread
+
+sw.epilog.i.thread:                               ; preds = %entry
+  br label %sw.epilog23.i.sink.split
+
+sw.epilog23.i.sink.split:                         ; preds = %sw.epilog.i.thread, %entry
+  %.sink = phi ptr addrspace(11) [ null, %sw.epilog.i.thread ], [ null, %entry ]
+  %0 = load i32, ptr addrspace(11) %.sink, align 4
+  ret i32 %0
+}


### PR DESCRIPTION
fixes #180258

During instruction selection, `isDead()` erases type instructions (like OpTypePointer) that have zero MRI uses. However, VRegToTypeMap holds raw MachineInstr* pointers to these type instructions outside of MRI's use-def tracking. For PHI results, the type register never gets an MRI use (because G_PHI is not in getTypeFoldingSupportedOpcodes(), so no ASSIGN_TYPE is created). The type instruction gets erased -> VRegToTypeMap holds a dangling pointer -> crash in patchPhis() when calling getSPIRVTypeID().

- SPIRVGlobalRegistry.h — Added isTypeInstructionUsed() method that checks whether a type instruction is still referenced by any live VReg (one with non-debug uses) in VRegToTypeMap.
- SPIRVInstructionSelector.cpp — Modified isDead() to consult isTypeInstructionUsed() before declaring a type instruction dead. This prevents erasing type instructions that are still needed by live values but happen to have no direct MRI uses of their type register.
- SPIRVLegalizePointerCast.cpp — Added scalar-load fallback in transformLoad() for single-value non-vector types, handling the phi ptr addrspace(11) → load i32 pattern that was hitting llvm_unreachable