### PR TITLE
[clang] Fix driver resignaling when cc1 runs out-of-process

### DIFF
--- a/clang/test/Driver/crash-report-no-integrated-cc1.c
+++ b/clang/test/Driver/crash-report-no-integrated-cc1.c
@@ -1,0 +1,8 @@
+// Test that the clang driver exits via signal when cc1 runs out-of-process
+// (-fno-integrated-cc1) and crashes.
+//
+// RUN: not %crash_opt %clang %s -fsyntax-only -fno-integrated-cc1 2>&1
+//
+// REQUIRES: crash-recovery
+
+#pragma clang __debug parser_crash

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -486,6 +486,13 @@ int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
     llvm::sys::unregisterHandlers();
     raise(CommandRes - 128);
   }
+  // When cc1 runs out-of-process (CLANG_SPAWN_CC1), ExecuteAndWait returns -2
+  // if the child was killed by a signal. The signal number is not preserved,
+  // so resignal with SIGABRT to ensure the driver exits via signal.
+  if (CommandRes == -2) {
+    llvm::sys::unregisterHandlers();
+    raise(SIGABRT);
+  }
 #endif
 
   // If we have multiple failing commands, we return the result of the first


### PR DESCRIPTION
When cc1 runs out-of-process and crashes, sys::ExecuteAndWait returns -2 for signal-killed children. The resignaling block added in 15488a7f78ce only handled CommandRes > 128, so the driver would exit normally with code 1 instead of dying by signal.