### PR TITLE
[MLIR][Python] Add `convert_type` API for TypeConverter

### DIFF
--- a/mlir/include/mlir-c/Rewrite.h
+++ b/mlir/include/mlir-c/Rewrite.h
@@ -546,6 +546,10 @@ mlirTypeConverterAddConversion(MlirTypeConverter typeConverter,
                                MlirTypeConverterConversionCallback convertType,
                                void *userData);
 
+/// Convert the given type using the given TypeConverter.
+MLIR_CAPI_EXPORTED MlirType
+mlirTypeConverterConvertType(MlirTypeConverter typeConverter, MlirType type);
+
 //===----------------------------------------------------------------------===//
 /// ConversionPattern API
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -101,6 +101,15 @@ public:
         convert.ptr());
   }
 
+  nb::typed<nb::object, std::optional<PyType>> convertType(PyType &type) {
+    MlirType converted = mlirTypeConverterConvertType(typeConverter, type);
+    if (mlirTypeIsNull(converted))
+      return nb::none();
+    return PyType(PyMlirContext::forContext(mlirTypeGetContext(converted)),
+                  converted)
+        .maybeDownCast();
+  }
+
   MlirTypeConverter get() { return typeConverter; }
 
 private:
@@ -621,7 +630,9 @@ void populateRewriteSubmodule(nb::module_ &m) {
   nb::class_<PyTypeConverter>(m, "TypeConverter")
       .def(nb::init<>(), "Create a new TypeConverter.")
       .def("add_conversion", &PyTypeConverter::addConversion, "convert"_a,
-           nb::keep_alive<0, 1>(), "Register a type conversion function.");
+           nb::keep_alive<0, 1>(), "Register a type conversion function.")
+      .def("convert_type", &PyTypeConverter::convertType, "type"_a,
+           "Convert the given type. Returns None if conversion fails.");
 
   //----------------------------------------------------------------------------
   // Mapping of the PDLResultList and PDLModule

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -590,6 +590,11 @@ void mlirTypeConverterAddConversion(
           });
 }
 
+MlirType mlirTypeConverterConvertType(MlirTypeConverter typeConverter,
+                                      MlirType type) {
+  return wrap(unwrap(typeConverter)->convertType(unwrap(type)));
+}
+
 //===----------------------------------------------------------------------===//
 /// ConversionPattern API
 //===----------------------------------------------------------------------===//

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -318,3 +318,12 @@ def testConversionPattern():
             # CHECK: caught exception: partial conversion failed
             # CHECK: failed to legalize unresolved materialization
             print("caught exception:", e)
+
+        t1 = converter.convert_type(IntegerType.get_signless(64))
+        # CHECK: IntType
+        print(type(t1))
+        # CHECK: !smt.int
+        print(str(t1))
+        t2 = converter.convert_type(F32Type.get())
+        # CHECK: None
+        print(t2)


### PR DESCRIPTION
This PR adds the  `convert_type` API for `TypeConverter`.