### PR TITLE
[Hexagon] Fix memory type for vgather intrinsics

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -2158,7 +2158,8 @@ bool HexagonTargetLowering::getTgtMemIntrinsic(IntrinsicInfo &Info,
   case Intrinsic::hexagon_V6_vgather_vscattermh_128B: {
     const Module &M = *I.getParent()->getParent()->getParent();
     Info.opc = ISD::INTRINSIC_W_CHAIN;
-    Type *VecTy = I.getArgOperand(1)->getType();
+    Type *VecTy = I.getArgOperand(I.arg_size() - 1)->getType();
+    assert(VecTy->isVectorTy() && "Expected vector operand for vgather");
     Info.memVT = MVT::getVT(VecTy);
     Info.ptrVal = I.getArgOperand(0);
     Info.offset = 0;

--- a/llvm/test/CodeGen/Hexagon/vgather-memvt.ll
+++ b/llvm/test/CodeGen/Hexagon/vgather-memvt.ll
@@ -1,0 +1,35 @@
+; RUN: llc -mtriple=hexagon -O3 -stop-after=finalize-isel -o - < %s | FileCheck %s
+
+; CHECK: V6_vgathermh_pseudo {{.*}} :: (volatile load store (s1024)
+; CHECK: V6_vgathermw_pseudo {{.*}} :: (volatile load store (s1024)
+; CHECK: V6_vgathermhw_pseudo {{.*}} :: (volatile load store (s2048)
+; CHECK: V6_vgathermhq_pseudo {{.*}} :: (volatile load store (s1024)
+; CHECK: V6_vgathermwq_pseudo {{.*}} :: (volatile load store (s1024)
+; CHECK: V6_vgathermhwq_pseudo {{.*}} :: (volatile load store (s2048)
+; CHECK: V6_vgather_vscatter_mh_pseudo {{.*}} :: (volatile load store (s1024)
+
+target triple = "hexagon"
+
+define dso_local void @test_vgather_memvt_128B(ptr %p, i32 %Rb, i32 %mu, <32 x i32> %Vv, <64 x i32> %Vvv, <32 x i32> %Qs) local_unnamed_addr #0 {
+entry:
+  %Qp = tail call <128 x i1> @llvm.hexagon.V6.vandvrt.128B(<32 x i32> %Qs, i32 -1)
+  call void @llvm.hexagon.V6.vgathermh.128B(ptr %p, i32 %Rb, i32 %mu, <32 x i32> %Vv)
+  call void @llvm.hexagon.V6.vgathermw.128B(ptr %p, i32 %Rb, i32 %mu, <32 x i32> %Vv)
+  call void @llvm.hexagon.V6.vgathermhw.128B(ptr %p, i32 %Rb, i32 %mu, <64 x i32> %Vvv)
+  call void @llvm.hexagon.V6.vgathermhq.128B(ptr %p, <128 x i1> %Qp, i32 %Rb, i32 %mu, <32 x i32> %Vv)
+  call void @llvm.hexagon.V6.vgathermwq.128B(ptr %p, <128 x i1> %Qp, i32 %Rb, i32 %mu, <32 x i32> %Vv)
+  call void @llvm.hexagon.V6.vgathermhwq.128B(ptr %p, <128 x i1> %Qp, i32 %Rb, i32 %mu, <64 x i32> %Vvv)
+  call void @llvm.hexagon.V6.vgather.vscattermh.128B(ptr %p, i32 %Rb, i32 %mu, <32 x i32> %Vv)
+  ret void
+}
+
+declare void @llvm.hexagon.V6.vgathermh.128B(ptr, i32, i32, <32 x i32>) #1
+declare void @llvm.hexagon.V6.vgathermw.128B(ptr, i32, i32, <32 x i32>) #1
+declare void @llvm.hexagon.V6.vgathermhw.128B(ptr, i32, i32, <64 x i32>) #1
+declare void @llvm.hexagon.V6.vgathermhq.128B(ptr, <128 x i1>, i32, i32, <32 x i32>) #1
+declare void @llvm.hexagon.V6.vgathermwq.128B(ptr, <128 x i1>, i32, i32, <32 x i32>) #1
+declare void @llvm.hexagon.V6.vgathermhwq.128B(ptr, <128 x i1>, i32, i32, <64 x i32>) #1
+declare void @llvm.hexagon.V6.vgather.vscattermh.128B(ptr, i32, i32, <32 x i32>) #1
+declare <128 x i1> @llvm.hexagon.V6.vandvrt.128B(<32 x i32>, i32) #2
+
+attributes #0 = { nounwind "target-cpu"="hexagonv75" "target-features"="+hvx-length128b,+hvxv75,-long-calls" }


### PR DESCRIPTION
Some of the Hexagon vgather intrinsics were picking the memory type (memVT) from a fixed argument position, but for several variants (e.g. the predicated ones), that argument isn’t actually the data vector being gathered. As a result, LLVM could end up recording the wrong memory type or size (e.g. i32 or mask instead of the vector arg). This patch fixes that by always taking memVT from the last intrinsic argument, which is the actual data vector.

Co-authored-by: Sumanth Gundapaneni <sgundapa@quicinc.com>