### PR TITLE
[flang] Fix explanatory messages for generic resolution error

### DIFF
--- a/flang/include/flang/Semantics/expression.h
+++ b/flang/include/flang/Semantics/expression.h
@@ -377,7 +377,8 @@ private:
       const AdjustActuals &, bool isSubroutine, SymbolVector &&tried,
       bool mightBeStructureConstructor = false);
   void EmitGenericResolutionError(const Symbol &, bool dueToNullActuals,
-      bool isSubroutine, ActualArguments &, const SymbolVector &);
+      bool isSubroutine, ActualArguments &, const SymbolVector &,
+      const AdjustActuals &);
   const Symbol &AccessSpecific(
       const Symbol &originalGeneric, const Symbol &specific);
   std::optional<CalleeAndArguments> GetCalleeAndArguments(const parser::Name &,

--- a/flang/test/Semantics/bug2295.f90
+++ b/flang/test/Semantics/bug2295.f90
@@ -1,0 +1,24 @@
+!RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
+module m
+  type t
+   contains
+    procedure :: s1, s2
+    generic :: g => s1, s2
+  end type
+ contains
+  subroutine s1(this, x, j)
+    class(t) this
+  end
+  subroutine s2(this, z, y)
+    class(t) this
+  end
+  subroutine test(that)
+    class(t) that
+!CHECK: error: No specific subroutine of generic 'g' matches the actual arguments
+!CHECK: Specific procedure 's1' does not match the actual arguments because
+!CHECK: Argument keyword 'z=' is not recognized for this procedure reference
+!CHECK: Specific procedure 's2' does not match the actual arguments because
+!CHECK: Keyword argument 'z=' has already been specified positionally (#2) in this procedure reference
+    call that%g(1., z=2.)
+  end
+end


### PR DESCRIPTION
The compiler emits messages to explain why each of a generic procedure's specific procedures is not a match for a given set of actual arguments.  In the case of specific procedures with PASS arguments in derived type procedure bindings or procedure components, these explanatory messages are often bogus, because the re-analysis didn't adjust the actual arguments to account for the PASS argument.  Fix.