### PR TITLE
[SPIRV][NFCI] Use unordered data structures for SPIR-V extensions

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
@@ -15,10 +15,12 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVSYMBOLICOPERANDS_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVSYMBOLICOPERANDS_H
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/VersionTuple.h"
 #include <string>
+#include <type_traits>
 
 namespace llvm {
 namespace SPIRV {
@@ -255,6 +257,27 @@ enum InstFlags {
 using CapabilityList = SmallVector<SPIRV::Capability::Capability, 8>;
 using ExtensionList = SmallVector<SPIRV::Extension::Extension, 8>;
 using EnvironmentList = SmallVector<SPIRV::Environment::Environment, 8>;
+
+// Tablegen enum types don't have an underlying type which is required for
+// DenseMap so just use the DenseMapInfo for std::underlying_type_t.
+template <> struct DenseMapInfo<SPIRV::Extension::Extension> {
+  using DMI = DenseMapInfo<std::underlying_type_t<SPIRV::Extension::Extension>>;
+  static SPIRV::Extension::Extension getEmptyKey() {
+    return static_cast<SPIRV::Extension::Extension>(DMI::getEmptyKey());
+  }
+  static SPIRV::Extension::Extension getTombstoneKey() {
+    return static_cast<SPIRV::Extension::Extension>(DMI::getTombstoneKey());
+  }
+  static unsigned getHashValue(SPIRV::Extension::Extension Ty) {
+    return DMI::getHashValue(Ty);
+  }
+  static bool isEqual(SPIRV::Extension::Extension Ty1,
+                      SPIRV::Extension::Extension Ty2) {
+    return Ty1 == Ty2;
+  }
+};
+
+using ExtensionSet = DenseSet<SPIRV::Extension::Extension>;
 
 std::string
 getSymbolicOperandMnemonic(SPIRV::OperandCategory::OperandCategory Category,

--- a/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
@@ -59,7 +59,7 @@ SPIRVTranslate(Module *M, std::string &SpirvObj, std::string &ErrMsg,
   static const std::string DefaultTriple = "spirv64-unknown-unknown";
   static const std::string DefaultMArch = "";
 
-  std::set<SPIRV::Extension::Extension> AllowedExtIds;
+  ExtensionSet AllowedExtIds;
   StringRef UnknownExt =
       SPIRVExtensionsParser::checkExtensions(AllowExtNames, AllowedExtIds);
   if (!UnknownExt.empty()) {

--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.h
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.h
@@ -16,7 +16,6 @@
 
 #include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "llvm/Support/CommandLine.h"
-#include <set>
 #include <string>
 
 namespace llvm {
@@ -24,33 +23,29 @@ class StringRef;
 class Triple;
 
 /// Command line parser for toggling SPIR-V extensions.
-struct SPIRVExtensionsParser
-    : public cl::parser<std::set<SPIRV::Extension::Extension>> {
+struct SPIRVExtensionsParser : public cl::parser<ExtensionSet> {
 public:
-  SPIRVExtensionsParser(cl::Option &O)
-      : cl::parser<std::set<SPIRV::Extension::Extension>>(O) {}
+  SPIRVExtensionsParser(cl::Option &O) : cl::parser<ExtensionSet>(O) {}
 
   /// Parses SPIR-V extension name from CLI arguments.
   ///
   /// \return Returns true on error.
   bool parse(cl::Option &O, StringRef ArgName, StringRef ArgValue,
-             std::set<SPIRV::Extension::Extension> &Vals);
+             ExtensionSet &Vals);
 
   /// Validates and converts extension names into internal enum values.
   ///
   /// \return Returns a reference to the unknown SPIR-V extension name from the
   /// list if present, or an empty StringRef on success.
-  static StringRef
-  checkExtensions(const std::vector<std::string> &ExtNames,
-                  std::set<SPIRV::Extension::Extension> &AllowedExtensions);
+  static StringRef checkExtensions(const std::vector<std::string> &ExtNames,
+                                   ExtensionSet &AllowedExtensions);
 
   /// Returns the list of extensions that are valid for a particular
   /// target environment (i.e., OpenCL or Vulkan).
-  static std::set<SPIRV::Extension::Extension>
-  getValidExtensions(const Triple &TT);
+  static ExtensionSet getValidExtensions(const Triple &TT);
 
 private:
-  static std::set<SPIRV::Extension::Extension> DisabledExtensions;
+  static ExtensionSet DisabledExtensions;
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -32,15 +32,13 @@ static cl::opt<bool>
                         cl::desc("SPIR-V Translator compatibility mode"),
                         cl::Optional, cl::init(false));
 
-static cl::opt<std::set<SPIRV::Extension::Extension>, false,
-               SPIRVExtensionsParser>
+static cl::opt<ExtensionSet, false, SPIRVExtensionsParser>
     Extensions("spirv-ext",
                cl::desc("Specify list of enabled SPIR-V extensions"));
 
 // Provides access to the cl::opt<...> `Extensions` variable from outside of the
 // module.
-void SPIRVSubtarget::addExtensionsToClOpt(
-    const std::set<SPIRV::Extension::Extension> &AllowList) {
+void SPIRVSubtarget::addExtensionsToClOpt(const ExtensionSet &AllowList) {
   Extensions.insert(AllowList.begin(), AllowList.end());
 }
 
@@ -214,9 +212,9 @@ void SPIRVSubtarget::resolveEnvFromModule(const Module &M) {
 
 // Set available extensions after SPIRVSubtarget is created.
 void SPIRVSubtarget::initAvailableExtensions(
-    const std::set<SPIRV::Extension::Extension> &AllowedExtIds) {
+    const ExtensionSet &AllowedExtIds) {
   AvailableExtensions.clear();
-  const std::set<SPIRV::Extension::Extension> &ValidExtensions =
+  const ExtensionSet &ValidExtensions =
       SPIRVExtensionsParser::getValidExtensions(TargetTriple);
 
   for (const auto &Ext : AllowedExtIds) {

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
@@ -73,8 +73,7 @@ public:
                  const std::string &FS, const SPIRVTargetMachine &TM);
   SPIRVSubtarget &initSubtargetDependencies(StringRef CPU, StringRef FS);
 
-  void initAvailableExtensions(
-      const std::set<SPIRV::Extension::Extension> &AllowedExtIds);
+  void initAvailableExtensions(const ExtensionSet &AllowedExtIds);
   void resolveEnvFromModule(const Module &M);
 
   // Parses features string setting specified subtarget options.
@@ -145,9 +144,8 @@ public:
 
   // Adds known SPIR-V extensions to the global list of allowed extensions that
   // SPIRVSubtarget module owns as
-  // cl::opt<std::set<SPIRV::Extension::Extension>, ...> global variable.
-  static void
-  addExtensionsToClOpt(const std::set<SPIRV::Extension::Extension> &AllowList);
+  // cl::opt<ExtensionSet, ...> global variable.
+  static void addExtensionsToClOpt(const ExtensionSet &AllowList);
 };
 } // namespace llvm
 


### PR DESCRIPTION
Review follow-up from https://github.com/llvm/llvm-project/pull/183325
No reason for these data structures to be ordered.

Minor annoyance when trying to use `DenseMap` because of the C++ code for enums generated by TableGen, but not too bad.