### PR TITLE
[libc][math] Disable float16 on Clang 11 and older

### DIFF
--- a/libc/include/llvm-libc-macros/float16-macros.h
+++ b/libc/include/llvm-libc-macros/float16-macros.h
@@ -12,7 +12,8 @@
 #include "../llvm-libc-types/float128.h"
 
 #if defined(__FLT16_MANT_DIG__) &&                                             \
-    (!defined(__GNUC__) || __GNUC__ >= 13 || defined(__clang__)) &&            \
+    (!defined(__GNUC__) || __GNUC__ >= 13 ||                                   \
+     (defined(__clang__) && __clang_major__ >= 12)) &&                         \
     !defined(__arm__) && !defined(_M_ARM) && !defined(__riscv) &&              \
     !defined(_WIN32)
 #define LIBC_TYPES_HAS_FLOAT16

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -1,5 +1,3 @@
-if(NOT LIBC_TARGET_ARCHITECTURE_IS_AARCH64)
-
 add_custom_target(libc-shared-tests)
 
 add_fp_unittest(
@@ -222,5 +220,3 @@ add_fp_unittest(
     libc.src.__support.math.tanhf16
     libc.src.__support.math.tanpif
 )
-
-endif()


### PR DESCRIPTION
This also reverts https://github.com/llvm/llvm-project/commit/c5d6feb3152bf39d820935df0d0490f90364d44c