### PR TITLE
[CIR] Implement TryOp flattening

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -606,6 +606,81 @@ static cir::AllocaOp getOrCreateCleanupDestSlot(cir::FuncOp funcOp,
   return allocaOp;
 }
 
+/// Shared EH flattening utilities used by both CIRCleanupScopeOpFlattening
+/// and CIRTryOpFlattening.
+
+// Collect all function calls in a region that may throw exceptions and need
+// to be replaced with try_call operations. Skips calls marked nothrow.
+// Nested cleanup scopes and try ops are always flattened before their
+// enclosing parents, so there are no nested regions to skip here.
+static void
+collectThrowingCalls(mlir::Region &region,
+                     llvm::SmallVectorImpl<cir::CallOp> &callsToRewrite) {
+  region.walk([&](cir::CallOp callOp) {
+    if (!callOp.getNothrow())
+      callsToRewrite.push_back(callOp);
+  });
+}
+
+// Collect all cir.resume operations in a region that come from
+// already-flattened try or cleanup scope operations. These resume ops need
+// to be chained through this scope's EH handler instead of unwinding
+// directly to the caller. Nested cleanup scopes and try ops are always
+// flattened before their enclosing parents, so there are no nested regions
+// to skip here.
+static void
+collectResumeOps(mlir::Region &region,
+                 llvm::SmallVectorImpl<cir::ResumeOp> &resumeOps) {
+  region.walk(
+      [&](cir::ResumeOp resumeOp) { resumeOps.push_back(resumeOp); });
+}
+
+// Replace a cir.call with a cir.try_call that unwinds to the `unwindDest`
+// block if an exception is thrown.
+static void replaceCallWithTryCall(cir::CallOp callOp,
+                                   mlir::Block *unwindDest, mlir::Location loc,
+                                   mlir::PatternRewriter &rewriter) {
+  mlir::Block *callBlock = callOp->getBlock();
+
+  assert(!callOp.getNothrow() && "call is not expected to throw");
+
+  // Split the block after the call - remaining ops become the normal
+  // destination.
+  mlir::Block *normalDest =
+      rewriter.splitBlock(callBlock, std::next(callOp->getIterator()));
+
+  // Build the try_call to replace the original call.
+  rewriter.setInsertionPoint(callOp);
+  mlir::Type resType = callOp->getNumResults() > 0
+                           ? callOp->getResult(0).getType()
+                           : mlir::Type();
+  auto tryCallOp =
+      cir::TryCallOp::create(rewriter, loc, callOp.getCalleeAttr(), resType,
+                             normalDest, unwindDest, callOp.getArgOperands());
+
+  // Replace uses of the call result with the try_call result.
+  if (callOp->getNumResults() > 0)
+    callOp->getResult(0).replaceAllUsesWith(tryCallOp.getResult());
+
+  rewriter.eraseOp(callOp);
+}
+
+// Create a shared unwind destination block. The block contains a
+// cir.eh.initiate operation (optionally with the cleanup attribute) and a
+// branch to the given destination block, passing the eh_token.
+static mlir::Block *buildUnwindBlock(mlir::Block *dest, bool hasCleanup,
+                                     mlir::Location loc,
+                                     mlir::Block *insertBefore,
+                                     mlir::PatternRewriter &rewriter) {
+  mlir::Block *unwindBlock = rewriter.createBlock(insertBefore);
+  rewriter.setInsertionPointToEnd(unwindBlock);
+  auto ehInitiate =
+      cir::EhInitiateOp::create(rewriter, loc, /*cleanup=*/hasCleanup);
+  cir::BrOp::create(rewriter, loc, mlir::ValueRange{ehInitiate.getEhToken()},
+                    dest);
+  return unwindBlock;
+}
+
 class CIRCleanupScopeOpFlattening
     : public mlir::OpRewritePattern<cir::CleanupScopeOp> {
 public:
@@ -883,45 +958,6 @@ public:
         });
   }
 
-  // Collect all cir.resume operations in the body region that come from
-  // already-flattened try or cleanup scope operations that were nested within
-  // this cleanup scope. These resume ops need to be chained through this
-  // cleanup's EH handler instead of unwinding directly to the caller.
-  void collectResumeOps(mlir::Region &bodyRegion,
-                        llvm::SmallVectorImpl<cir::ResumeOp> &resumeOps) const {
-    bodyRegion.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
-      // Skip resume ops inside nested TryOps - those are handled by TryOp
-      // flattening.
-      if (isa<cir::TryOp>(op))
-        return mlir::WalkResult::skip();
-
-      if (auto resumeOp = dyn_cast<cir::ResumeOp>(op))
-        resumeOps.push_back(resumeOp);
-      return mlir::WalkResult::advance();
-    });
-  }
-
-  // Collect all function calls in the cleanup scope body that may throw
-  // exceptions and need to be replaced with try_call operations. Skips calls
-  // that are marked nothrow and calls inside nested TryOps (the latter will be
-  // handled by the TryOp's own flattening).
-  void collectThrowingCalls(
-      mlir::Region &bodyRegion,
-      llvm::SmallVectorImpl<cir::CallOp> &callsToRewrite) const {
-    bodyRegion.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
-      // Skip calls inside nested TryOps - those are handled by TryOp
-      // flattening.
-      if (isa<cir::TryOp>(op))
-        return mlir::WalkResult::skip();
-
-      if (auto callOp = dyn_cast<cir::CallOp>(op)) {
-        if (!callOp.getNothrow())
-          callsToRewrite.push_back(callOp);
-      }
-      return mlir::WalkResult::advance();
-    });
-  }
-
 #ifndef NDEBUG
   // Check that no block other than the last one in a region exits the region.
   static bool regionExitsOnlyFromLastBlock(mlir::Region &region) {
@@ -1051,51 +1087,6 @@ public:
     return clonedEntry;
   }
 
-  // Create a shared unwind destination block for all calls within the same
-  // cleanup scope. The unwind block contains a cir.eh.initiate operation
-  // (with the cleanup attribute) and a branch to the EH cleanup block.
-  mlir::Block *buildUnwindBlock(mlir::Block *ehCleanupBlock, mlir::Location loc,
-                                mlir::Block *insertBefore,
-                                mlir::PatternRewriter &rewriter) const {
-    mlir::Block *unwindBlock = rewriter.createBlock(insertBefore);
-    rewriter.setInsertionPointToEnd(unwindBlock);
-    auto ehInitiate =
-        cir::EhInitiateOp::create(rewriter, loc, /*cleanup=*/true);
-    cir::BrOp::create(rewriter, loc, mlir::ValueRange{ehInitiate.getEhToken()},
-                      ehCleanupBlock);
-    return unwindBlock;
-  }
-
-  // Replace a cir.call with a cir.try_call that unwinds to the `unwindDest`
-  // block if an exception is thrown.
-  void replaceCallWithTryCall(cir::CallOp callOp, mlir::Block *unwindDest,
-                              mlir::Location loc,
-                              mlir::PatternRewriter &rewriter) const {
-    mlir::Block *callBlock = callOp->getBlock();
-
-    assert(!callOp.getNothrow() && "call is not expected to throw");
-
-    // Split the block after the call - remaining ops become the normal
-    // destination.
-    mlir::Block *normalDest =
-        rewriter.splitBlock(callBlock, std::next(callOp->getIterator()));
-
-    // Build the try_call to replace the original call.
-    rewriter.setInsertionPoint(callOp);
-    mlir::Type resType = callOp->getNumResults() > 0
-                             ? callOp->getResult(0).getType()
-                             : mlir::Type();
-    auto tryCallOp =
-        cir::TryCallOp::create(rewriter, loc, callOp.getCalleeAttr(), resType,
-                               normalDest, unwindDest, callOp.getArgOperands());
-
-    // Replace uses of the call result with the try_call result.
-    if (callOp->getNumResults() > 0)
-      callOp->getResult(0).replaceAllUsesWith(tryCallOp.getResult());
-
-    rewriter.eraseOp(callOp);
-  }
-
   // Flatten a cleanup scope. The body region's exits branch to the cleanup
   // block, and the cleanup block branches to destination blocks whose contents
   // depend on the type of operation that exited the body region. Yield becomes
@@ -1181,7 +1172,8 @@ public:
       // branch directly to the EH cleanup entry.
       if (!callsToRewrite.empty())
         unwindBlock =
-            buildUnwindBlock(ehCleanupEntry, loc, ehCleanupEntry, rewriter);
+            buildUnwindBlock(ehCleanupEntry, /*hasCleanup=*/true, loc,
+                             ehCleanupEntry, rewriter);
     }
 
     // All normal flow blocks are inserted before this point — either before
@@ -1384,80 +1376,6 @@ public:
 class CIRTryOpFlattening : public mlir::OpRewritePattern<cir::TryOp> {
 public:
   using OpRewritePattern<cir::TryOp>::OpRewritePattern;
-
-  // Collect all non-nothrow calls in the try body region that need to be
-  // rewritten to try_call. Skips calls inside nested TryOps.
-  void collectThrowingCalls(
-      mlir::Region &tryBodyRegion,
-      llvm::SmallVectorImpl<cir::CallOp> &callsToRewrite) const {
-    tryBodyRegion.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
-      if (isa<cir::TryOp>(op))
-        return mlir::WalkResult::skip();
-      if (auto callOp = dyn_cast<cir::CallOp>(op)) {
-        if (!callOp.getNothrow())
-          callsToRewrite.push_back(callOp);
-      }
-      return mlir::WalkResult::advance();
-    });
-  }
-
-  // Collect all cir.resume operations in the try body region that come from
-  // already-flattened cleanup scopes. These need to be chained to the catch
-  // dispatch block. Skips resumes inside nested TryOps.
-  void collectResumeOps(
-      mlir::Region &tryBodyRegion,
-      llvm::SmallVectorImpl<cir::ResumeOp> &resumeOps) const {
-    tryBodyRegion.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
-      if (isa<cir::TryOp>(op))
-        return mlir::WalkResult::skip();
-      if (auto resumeOp = dyn_cast<cir::ResumeOp>(op))
-        resumeOps.push_back(resumeOp);
-      return mlir::WalkResult::advance();
-    });
-  }
-
-  // Replace a cir.call with a cir.try_call that unwinds to the given block.
-  void replaceCallWithTryCall(cir::CallOp callOp, mlir::Block *unwindDest,
-                              mlir::Location loc,
-                              mlir::PatternRewriter &rewriter) const {
-    mlir::Block *callBlock = callOp->getBlock();
-    assert(!callOp.getNothrow() && "call is not expected to throw");
-
-    // Split the block after the call — remaining ops become the normal dest.
-    mlir::Block *normalDest =
-        rewriter.splitBlock(callBlock, std::next(callOp->getIterator()));
-
-    // Build the try_call to replace the original call.
-    rewriter.setInsertionPoint(callOp);
-    mlir::Type resType = callOp->getNumResults() > 0
-                             ? callOp->getResult(0).getType()
-                             : mlir::Type();
-    auto tryCallOp =
-        cir::TryCallOp::create(rewriter, loc, callOp.getCalleeAttr(), resType,
-                               normalDest, unwindDest, callOp.getArgOperands());
-
-    // Replace uses of the call result with the try_call result.
-    if (callOp->getNumResults() > 0)
-      callOp->getResult(0).replaceAllUsesWith(tryCallOp.getResult());
-
-    rewriter.eraseOp(callOp);
-  }
-
-  // Build an unwind block that initiates exception handling and branches to the
-  // catch dispatch block. If `hasCleanup` is true, the initiate op will be
-  // marked with the cleanup attribute.
-  mlir::Block *buildUnwindBlock(mlir::Block *catchDispatchBlock,
-                                bool hasCleanup, mlir::Location loc,
-                                mlir::Block *insertBefore,
-                                mlir::PatternRewriter &rewriter) const {
-    mlir::Block *unwindBlock = rewriter.createBlock(insertBefore);
-    rewriter.setInsertionPointToEnd(unwindBlock);
-    auto ehInitiate =
-        cir::EhInitiateOp::create(rewriter, loc, /*cleanup=*/hasCleanup);
-    cir::BrOp::create(rewriter, loc, mlir::ValueRange{ehInitiate.getEhToken()},
-                      catchDispatchBlock);
-    return unwindBlock;
-  }
 
   // Build the catch dispatch block with a cir.eh.dispatch operation.
   // The dispatch block receives an !cir.eh_token argument and dispatches

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -1596,7 +1596,7 @@ public:
     if (!callsToRewrite.empty()) {
       // Create a shared unwind block for all throwing calls.
       mlir::Block *unwindBlock = buildUnwindBlock(
-          dispatchBlock, hasCleanup, loc, continueBlock, rewriter);
+          dispatchBlock, hasCleanup, loc, dispatchBlock, rewriter);
 
       for (cir::CallOp callOp : callsToRewrite)
         replaceCallWithTryCall(callOp, unwindBlock, loc, rewriter);

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -1397,17 +1397,20 @@ public:
     mlir::Block *defaultDest = nullptr;
     bool defaultIsCatchAll = false;
 
-    for (const auto &[idx, typeAttr] : llvm::enumerate(handlerTypes)) {
+    for (auto [typeAttr, handlerBlock] :
+         llvm::zip(handlerTypes, catchHandlerBlocks)) {
       if (mlir::isa<cir::CatchAllAttr>(typeAttr)) {
-        defaultDest = catchHandlerBlocks[idx];
+        assert(!defaultDest && "multiple catch_all or unwind handlers");
+        defaultDest = handlerBlock;
         defaultIsCatchAll = true;
       } else if (mlir::isa<cir::UnwindAttr>(typeAttr)) {
-        defaultDest = catchHandlerBlocks[idx];
+        assert(!defaultDest && "multiple catch_all or unwind handlers");
+        defaultDest = handlerBlock;
         defaultIsCatchAll = false;
       } else {
         // This is a typed catch handler (GlobalViewAttr with type info).
         catchTypeAttrs.push_back(typeAttr);
-        catchDests.push_back(catchHandlerBlocks[idx]);
+        catchDests.push_back(handlerBlock);
       }
     }
 
@@ -1434,9 +1437,9 @@ public:
   //
   // The cleanup scope inside the catch handler is expected to have been
   // flattened before we get here, so what we see in the handler region is
-  // already flat code with begin_catch at the top and end_catch somewhere
-  // in the middle (from the flattened cleanup). We just need to inline
-  // the region and fix up terminators.
+  // already flat code with begin_catch at the top and end_catch in any place
+  // that we would exit the catch handler. We just need to inline the region
+  // and fix up terminators.
   mlir::Block *flattenCatchHandler(mlir::Region &handlerRegion,
                                    mlir::Block *continueBlock,
                                    mlir::Location loc,
@@ -1462,31 +1465,34 @@ public:
 
   // Flatten an unwind handler region. The unwind region just contains a
   // cir.resume that continues unwinding. We inline it and leave the resume
-  // in place — it will unwind to the caller.
+  // in place. If this try op is nested inside an EH cleanup or another try op,
+  // the enclosing op will rewrite the resume as a branch to its cleanup or
+  // dispatch block when it is flattened. Otherwise, the resume will unwind to
+  // the caller.
   mlir::Block *flattenUnwindHandler(mlir::Region &unwindRegion,
                                     mlir::Location loc,
                                     mlir::Block *insertBefore,
                                     mlir::PatternRewriter &rewriter) const {
     mlir::Block *unwindEntry = &unwindRegion.front();
-
-    // Inline the unwind region.
     rewriter.inlineRegionBefore(unwindRegion, insertBefore);
-
     return unwindEntry;
   }
 
   mlir::LogicalResult
   matchAndRewrite(cir::TryOp tryOp,
                   mlir::PatternRewriter &rewriter) const override {
-    // Cleanup scopes must be lowered before the enclosing try so that
-    // EH cleanup inside them is properly handled.
-    // Fail the match so the pattern rewriter will process cleanup scopes first.
-    bool hasNestedCleanup = tryOp
-                                ->walk([&](cir::CleanupScopeOp) {
-                                  return mlir::WalkResult::interrupt();
-                                })
-                                .wasInterrupted();
-    if (hasNestedCleanup)
+    // Nested try ops and cleanup scopes must be flattened before the enclosing
+    // try so that EH cleanup inside them is properly handled. Fail the match so
+    // the pattern rewriter will process nested ops first.
+    bool hasNestedOps = tryOp
+                            ->walk([&](mlir::Operation *op) {
+                              if (isa<cir::CleanupScopeOp, cir::TryOp>(op) &&
+                                  op != tryOp)
+                                return mlir::WalkResult::interrupt();
+                              return mlir::WalkResult::advance();
+                            })
+                            .wasInterrupted();
+    if (hasNestedOps)
       return mlir::failure();
 
     mlir::OpBuilder::InsertionGuard guard(rewriter);

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -1385,44 +1385,176 @@ class CIRTryOpFlattening : public mlir::OpRewritePattern<cir::TryOp> {
 public:
   using OpRewritePattern<cir::TryOp>::OpRewritePattern;
 
-  mlir::Block *buildTryBody(cir::TryOp tryOp,
-                            mlir::PatternRewriter &rewriter) const {
-    // Split the current block before the TryOp to create the inlining
-    // point.
-    mlir::Block *beforeTryScopeBlock = rewriter.getInsertionBlock();
-    mlir::Block *afterTry =
-        rewriter.splitBlock(beforeTryScopeBlock, rewriter.getInsertionPoint());
-
-    // Inline body region.
-    mlir::Block *beforeBody = &tryOp.getTryRegion().front();
-    rewriter.inlineRegionBefore(tryOp.getTryRegion(), afterTry);
-
-    // Branch into the body of the region.
-    rewriter.setInsertionPointToEnd(beforeTryScopeBlock);
-    cir::BrOp::create(rewriter, tryOp.getLoc(), mlir::ValueRange(), beforeBody);
-    return afterTry;
+  // Collect all non-nothrow calls in the try body region that need to be
+  // rewritten to try_call. Skips calls inside nested TryOps.
+  void collectThrowingCalls(
+      mlir::Region &tryBodyRegion,
+      llvm::SmallVectorImpl<cir::CallOp> &callsToRewrite) const {
+    tryBodyRegion.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+      if (isa<cir::TryOp>(op))
+        return mlir::WalkResult::skip();
+      if (auto callOp = dyn_cast<cir::CallOp>(op)) {
+        if (!callOp.getNothrow())
+          callsToRewrite.push_back(callOp);
+      }
+      return mlir::WalkResult::advance();
+    });
   }
 
-  void buildHandlers(cir::TryOp tryOp, mlir::PatternRewriter &rewriter,
-                     mlir::Block *afterBody, mlir::Block *afterTry,
-                     SmallVectorImpl<cir::CallOp> &callsToRewrite,
-                     SmallVectorImpl<mlir::Block *> &landingPads) const {
-    // Replace the tryOp return with a branch that jumps out of the body.
-    rewriter.setInsertionPointToEnd(afterBody);
+  // Collect all cir.resume operations in the try body region that come from
+  // already-flattened cleanup scopes. These need to be chained to the catch
+  // dispatch block. Skips resumes inside nested TryOps.
+  void collectResumeOps(
+      mlir::Region &tryBodyRegion,
+      llvm::SmallVectorImpl<cir::ResumeOp> &resumeOps) const {
+    tryBodyRegion.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+      if (isa<cir::TryOp>(op))
+        return mlir::WalkResult::skip();
+      if (auto resumeOp = dyn_cast<cir::ResumeOp>(op))
+        resumeOps.push_back(resumeOp);
+      return mlir::WalkResult::advance();
+    });
+  }
 
-    mlir::Block *beforeCatch = rewriter.getInsertionBlock();
-    rewriter.setInsertionPointToEnd(beforeCatch);
+  // Replace a cir.call with a cir.try_call that unwinds to the given block.
+  void replaceCallWithTryCall(cir::CallOp callOp, mlir::Block *unwindDest,
+                              mlir::Location loc,
+                              mlir::PatternRewriter &rewriter) const {
+    mlir::Block *callBlock = callOp->getBlock();
+    assert(!callOp.getNothrow() && "call is not expected to throw");
 
-    // Check if the terminator is a YieldOp because there could be another
-    // terminator, e.g. unreachable
-    if (auto tryBodyYield = dyn_cast<cir::YieldOp>(afterBody->getTerminator()))
-      rewriter.replaceOpWithNewOp<cir::BrOp>(tryBodyYield, afterTry);
+    // Split the block after the call — remaining ops become the normal dest.
+    mlir::Block *normalDest =
+        rewriter.splitBlock(callBlock, std::next(callOp->getIterator()));
 
-    mlir::ArrayAttr handlers = tryOp.getHandlerTypesAttr();
-    if (!handlers || handlers.empty())
-      return;
+    // Build the try_call to replace the original call.
+    rewriter.setInsertionPoint(callOp);
+    mlir::Type resType = callOp->getNumResults() > 0
+                             ? callOp->getResult(0).getType()
+                             : mlir::Type();
+    auto tryCallOp =
+        cir::TryCallOp::create(rewriter, loc, callOp.getCalleeAttr(), resType,
+                               normalDest, unwindDest, callOp.getArgOperands());
 
-    llvm_unreachable("TryOpFlattening buildHandlers with CallsOp is NYI");
+    // Replace uses of the call result with the try_call result.
+    if (callOp->getNumResults() > 0)
+      callOp->getResult(0).replaceAllUsesWith(tryCallOp.getResult());
+
+    rewriter.eraseOp(callOp);
+  }
+
+  // Build an unwind block that initiates exception handling and branches to the
+  // catch dispatch block. If `hasCleanup` is true, the initiate op will be
+  // marked with the cleanup attribute.
+  mlir::Block *buildUnwindBlock(mlir::Block *catchDispatchBlock,
+                                bool hasCleanup, mlir::Location loc,
+                                mlir::Block *insertBefore,
+                                mlir::PatternRewriter &rewriter) const {
+    mlir::Block *unwindBlock = rewriter.createBlock(insertBefore);
+    rewriter.setInsertionPointToEnd(unwindBlock);
+    auto ehInitiate =
+        cir::EhInitiateOp::create(rewriter, loc, /*cleanup=*/hasCleanup);
+    cir::BrOp::create(rewriter, loc, mlir::ValueRange{ehInitiate.getEhToken()},
+                      catchDispatchBlock);
+    return unwindBlock;
+  }
+
+  // Build the catch dispatch block with a cir.eh.dispatch operation.
+  // The dispatch block receives an !cir.eh_token argument and dispatches
+  // to the appropriate catch handler blocks based on exception types.
+  mlir::Block *buildCatchDispatchBlock(
+      cir::TryOp tryOp, mlir::ArrayAttr handlerTypes,
+      llvm::SmallVectorImpl<mlir::Block *> &catchHandlerBlocks,
+      mlir::Location loc, mlir::Block *insertBefore,
+      mlir::PatternRewriter &rewriter) const {
+    mlir::Block *dispatchBlock = rewriter.createBlock(insertBefore);
+    auto ehTokenType = cir::EhTokenType::get(rewriter.getContext());
+    mlir::Value ehToken = dispatchBlock->addArgument(ehTokenType, loc);
+
+    rewriter.setInsertionPointToEnd(dispatchBlock);
+
+    // Build the catch types and destinations for the dispatch.
+    llvm::SmallVector<mlir::Attribute> catchTypeAttrs;
+    llvm::SmallVector<mlir::Block *> catchDests;
+    mlir::Block *defaultDest = nullptr;
+    bool defaultIsCatchAll = false;
+
+    for (const auto &[idx, typeAttr] : llvm::enumerate(handlerTypes)) {
+      if (mlir::isa<cir::CatchAllAttr>(typeAttr)) {
+        defaultDest = catchHandlerBlocks[idx];
+        defaultIsCatchAll = true;
+      } else if (mlir::isa<cir::UnwindAttr>(typeAttr)) {
+        defaultDest = catchHandlerBlocks[idx];
+        defaultIsCatchAll = false;
+      } else {
+        // This is a typed catch handler (GlobalViewAttr with type info).
+        catchTypeAttrs.push_back(typeAttr);
+        catchDests.push_back(catchHandlerBlocks[idx]);
+      }
+    }
+
+    assert(defaultDest && "dispatch must have a catch_all or unwind handler");
+
+    mlir::ArrayAttr catchTypesArrayAttr;
+    if (!catchTypeAttrs.empty())
+      catchTypesArrayAttr = rewriter.getArrayAttr(catchTypeAttrs);
+
+    cir::EhDispatchOp::create(rewriter, loc, ehToken, catchTypesArrayAttr,
+                              defaultIsCatchAll, defaultDest, catchDests);
+
+    return dispatchBlock;
+  }
+
+  // Flatten a single catch handler region. Each handler region has an
+  // !cir.eh_token argument and starts with cir.begin_catch, followed by
+  // a cir.cleanup.scope containing the handler body (with cir.end_catch in
+  // its cleanup region), and ending with cir.yield.
+  //
+  // After flattening, the handler region becomes a block that receives the
+  // eh_token, calls begin_catch, runs the handler body inline, calls
+  // end_catch, and branches to the continue block.
+  //
+  // The cleanup scope inside the catch handler is expected to have been
+  // flattened before we get here, so what we see in the handler region is
+  // already flat code with begin_catch at the top and end_catch somewhere
+  // in the middle (from the flattened cleanup). We just need to inline
+  // the region and fix up terminators.
+  mlir::Block *flattenCatchHandler(mlir::Region &handlerRegion,
+                                   mlir::Block *continueBlock,
+                                   mlir::Location loc,
+                                   mlir::Block *insertBefore,
+                                   mlir::PatternRewriter &rewriter) const {
+    // The handler region entry block has the !cir.eh_token argument.
+    mlir::Block *handlerEntry = &handlerRegion.front();
+
+    // Inline the handler region before insertBefore.
+    rewriter.inlineRegionBefore(handlerRegion, insertBefore);
+
+    // Replace yield terminators in the handler with branches to continue.
+    for (mlir::Block &block : llvm::make_range(handlerEntry->getIterator(),
+                                               insertBefore->getIterator())) {
+      if (auto yieldOp = dyn_cast<cir::YieldOp>(block.getTerminator())) {
+        rewriter.setInsertionPoint(yieldOp);
+        rewriter.replaceOpWithNewOp<cir::BrOp>(yieldOp, continueBlock);
+      }
+    }
+
+    return handlerEntry;
+  }
+
+  // Flatten an unwind handler region. The unwind region just contains a
+  // cir.resume that continues unwinding. We inline it and leave the resume
+  // in place — it will unwind to the caller.
+  mlir::Block *flattenUnwindHandler(mlir::Region &unwindRegion,
+                                    mlir::Location loc,
+                                    mlir::Block *insertBefore,
+                                    mlir::PatternRewriter &rewriter) const {
+    mlir::Block *unwindEntry = &unwindRegion.front();
+
+    // Inline the unwind region.
+    rewriter.inlineRegionBefore(unwindRegion, insertBefore);
+
+    return unwindEntry;
   }
 
   mlir::LogicalResult
@@ -1439,51 +1571,96 @@ public:
     if (hasNestedCleanup)
       return mlir::failure();
 
-    mlir::ArrayAttr handlers = tryOp.getHandlerTypesAttr();
-    if (handlers && !handlers.empty())
-      return tryOp->emitError(
-          "TryOp flattening with handlers is not yet implemented");
-
     mlir::OpBuilder::InsertionGuard guard(rewriter);
-    mlir::Block *afterBody = &tryOp.getTryRegion().back();
+    mlir::Location loc = tryOp.getLoc();
 
-    // Grab the collection of `cir.call exception`s to rewrite to
-    // `cir.try_call`.
+    mlir::ArrayAttr handlerTypes = tryOp.getHandlerTypesAttr();
+    mlir::MutableArrayRef<mlir::Region> handlerRegions =
+        tryOp.getHandlerRegions();
+
+    // Collect throwing calls in the try body.
     llvm::SmallVector<cir::CallOp, 4> callsToRewrite;
-    tryOp.getTryRegion().walk([&](CallOp op) {
-      if (op.getNothrow())
-        return;
+    collectThrowingCalls(tryOp.getTryRegion(), callsToRewrite);
 
-      // Only grab calls within immediate closest TryOp scope.
-      if (op->getParentOfType<cir::TryOp>() != tryOp)
-        return;
-      callsToRewrite.push_back(op);
-    });
+    // Collect resume ops from already-flattened cleanup scopes in the try body.
+    llvm::SmallVector<cir::ResumeOp> resumeOpsToChain;
+    collectResumeOps(tryOp.getTryRegion(), resumeOpsToChain);
 
-    if (!callsToRewrite.empty())
-      llvm_unreachable(
-          "TryOpFlattening with try block that contains CallOps is NYI");
+    // ---- Step 1: Split the current block and inline the try body ----
+    mlir::Block *currentBlock = rewriter.getInsertionBlock();
+    mlir::Block *continueBlock =
+        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
 
-    // Build try body.
-    mlir::Block *afterTry = buildTryBody(tryOp, rewriter);
+    // Get reference to try body blocks before inlining.
+    mlir::Block *bodyEntry = &tryOp.getTryRegion().front();
+    mlir::Block *bodyExit = &tryOp.getTryRegion().back();
 
-    // Build handlers.
-    llvm::SmallVector<mlir::Block *, 4> landingPads;
-    buildHandlers(tryOp, rewriter, afterBody, afterTry, callsToRewrite,
-                  landingPads);
+    // Inline the try body region before the continue block.
+    rewriter.inlineRegionBefore(tryOp.getTryRegion(), continueBlock);
 
-    rewriter.eraseOp(tryOp);
+    // Branch from the current block to the body entry.
+    rewriter.setInsertionPointToEnd(currentBlock);
+    cir::BrOp::create(rewriter, loc, bodyEntry);
 
-    assert((landingPads.size() == callsToRewrite.size()) &&
-           "expected matching number of entries");
-
-    // Quick block cleanup: no indirection to the post try block.
-    auto brOp = dyn_cast<cir::BrOp>(afterTry->getTerminator());
-    if (brOp && brOp.getDest()->hasNoPredecessors()) {
-      mlir::Block *srcBlock = brOp.getDest();
-      rewriter.eraseOp(brOp);
-      rewriter.mergeBlocks(srcBlock, afterTry);
+    // Replace the try body's yield terminator with a branch to continue.
+    if (auto bodyYield = dyn_cast<cir::YieldOp>(bodyExit->getTerminator())) {
+      rewriter.setInsertionPoint(bodyYield);
+      rewriter.replaceOpWithNewOp<cir::BrOp>(bodyYield, continueBlock);
     }
+
+    // ---- Step 2: If there are no handlers, just inline the body ----
+    if (!handlerTypes || handlerTypes.empty()) {
+      rewriter.eraseOp(tryOp);
+      return mlir::success();
+    }
+
+    // ---- Step 3: Build catch handler blocks ----
+    // First, flatten all handler regions and collect the entry blocks.
+    llvm::SmallVector<mlir::Block *> catchHandlerBlocks;
+
+    for (const auto &[idx, typeAttr] : llvm::enumerate(handlerTypes)) {
+      mlir::Region &handlerRegion = handlerRegions[idx];
+
+      if (mlir::isa<cir::UnwindAttr>(typeAttr)) {
+        // Unwind handler: inline and leave cir.resume in place.
+        mlir::Block *unwindEntry = flattenUnwindHandler(
+            handlerRegion, loc, continueBlock, rewriter);
+        catchHandlerBlocks.push_back(unwindEntry);
+      } else {
+        // Catch handler (typed or catch-all): flatten inline.
+        mlir::Block *handlerEntry = flattenCatchHandler(
+            handlerRegion, continueBlock, loc, continueBlock, rewriter);
+        catchHandlerBlocks.push_back(handlerEntry);
+      }
+    }
+
+    // ---- Step 4: Build the catch dispatch block ----
+    mlir::Block *dispatchBlock = buildCatchDispatchBlock(
+        tryOp, handlerTypes, catchHandlerBlocks, loc, continueBlock, rewriter);
+
+    // ---- Step 5: Build unwind block(s) and replace throwing calls ----
+    bool hasCleanup = tryOp.getCleanup();
+    if (!callsToRewrite.empty()) {
+      // Create a shared unwind block for all throwing calls.
+      mlir::Block *unwindBlock = buildUnwindBlock(
+          dispatchBlock, hasCleanup, loc, continueBlock, rewriter);
+
+      for (cir::CallOp callOp : callsToRewrite)
+        replaceCallWithTryCall(callOp, unwindBlock, loc, rewriter);
+    }
+
+    // ---- Step 6: Chain resume ops from inner cleanup scopes ----
+    // Resume ops from already-flattened cleanup scopes within the try body
+    // should branch to the catch dispatch block instead of unwinding directly.
+    for (cir::ResumeOp resumeOp : resumeOpsToChain) {
+      mlir::Value ehToken = resumeOp.getEhToken();
+      rewriter.setInsertionPoint(resumeOp);
+      rewriter.replaceOpWithNewOp<cir::BrOp>(
+          resumeOp, mlir::ValueRange{ehToken}, dispatchBlock);
+    }
+
+    // ---- Step 7: Erase the original try op ----
+    rewriter.eraseOp(tryOp);
 
     return mlir::success();
   }

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -1455,6 +1455,30 @@ public:
     for (mlir::Block &block : llvm::make_range(handlerEntry->getIterator(),
                                                insertBefore->getIterator())) {
       if (auto yieldOp = dyn_cast<cir::YieldOp>(block.getTerminator())) {
+        // Verify that end_catch is the last non-branch operation before
+        // this yield. After cleanup scope flattening, end_catch may be in
+        // a predecessor block rather than immediately before the yield.
+        // Walk back through the single-predecessor chain, verifying that
+        // each intermediate block contains only a branch terminator, until
+        // we find end_catch as the last non-terminator in some block.
+        assert([&]() {
+          // Check if end_catch immediately precedes the yield.
+          if (mlir::Operation *prev = yieldOp->getPrevNode())
+            return isa<cir::EndCatchOp>(prev);
+          // The yield is alone in its block. Walk backward through
+          // single-predecessor blocks that contain only a branch.
+          mlir::Block *b = block.getSinglePredecessor();
+          while (b) {
+            mlir::Operation *term = b->getTerminator();
+            if (mlir::Operation *prev = term->getPrevNode())
+              return isa<cir::EndCatchOp>(prev);
+            if (!isa<cir::BrOp>(term))
+              return false;
+            b = b->getSinglePredecessor();
+          }
+          return false;
+        }() && "expected end_catch as last operation before yield "
+               "in catch handler, with only branches in between");
         rewriter.setInsertionPoint(yieldOp);
         rewriter.replaceOpWithNewOp<cir::BrOp>(yieldOp, continueBlock);
       }
@@ -1559,8 +1583,11 @@ public:
     }
 
     // ---- Step 4: Build the catch dispatch block ----
+    // Insert the dispatch block before the first handler block so that
+    // it appears above the individual catch blocks in the output.
     mlir::Block *dispatchBlock = buildCatchDispatchBlock(
-        tryOp, handlerTypes, catchHandlerBlocks, loc, continueBlock, rewriter);
+        tryOp, handlerTypes, catchHandlerBlocks, loc,
+        catchHandlerBlocks.front(), rewriter);
 
     // ---- Step 5: Build unwind block(s) and replace throwing calls ----
     bool hasCleanup = tryOp.getCleanup();

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -628,17 +628,15 @@ collectThrowingCalls(mlir::Region &region,
 // directly to the caller. Nested cleanup scopes and try ops are always
 // flattened before their enclosing parents, so there are no nested regions
 // to skip here.
-static void
-collectResumeOps(mlir::Region &region,
-                 llvm::SmallVectorImpl<cir::ResumeOp> &resumeOps) {
-  region.walk(
-      [&](cir::ResumeOp resumeOp) { resumeOps.push_back(resumeOp); });
+static void collectResumeOps(mlir::Region &region,
+                             llvm::SmallVectorImpl<cir::ResumeOp> &resumeOps) {
+  region.walk([&](cir::ResumeOp resumeOp) { resumeOps.push_back(resumeOp); });
 }
 
 // Replace a cir.call with a cir.try_call that unwinds to the `unwindDest`
 // block if an exception is thrown.
-static void replaceCallWithTryCall(cir::CallOp callOp,
-                                   mlir::Block *unwindDest, mlir::Location loc,
+static void replaceCallWithTryCall(cir::CallOp callOp, mlir::Block *unwindDest,
+                                   mlir::Location loc,
                                    mlir::PatternRewriter &rewriter) {
   mlir::Block *callBlock = callOp->getBlock();
 
@@ -1171,9 +1169,8 @@ public:
       // need a shared unwind destination. Resume ops from inner cleanups
       // branch directly to the EH cleanup entry.
       if (!callsToRewrite.empty())
-        unwindBlock =
-            buildUnwindBlock(ehCleanupEntry, /*hasCleanup=*/true, loc,
-                             ehCleanupEntry, rewriter);
+        unwindBlock = buildUnwindBlock(ehCleanupEntry, /*hasCleanup=*/true, loc,
+                                       ehCleanupEntry, rewriter);
     }
 
     // All normal flow blocks are inserted before this point — either before
@@ -1508,14 +1505,14 @@ public:
     // Nested try ops and cleanup scopes must be flattened before the enclosing
     // try so that EH cleanup inside them is properly handled. Fail the match so
     // the pattern rewriter will process nested ops first.
-    bool hasNestedOps = tryOp
-                            ->walk([&](mlir::Operation *op) {
-                              if (isa<cir::CleanupScopeOp, cir::TryOp>(op) &&
-                                  op != tryOp)
-                                return mlir::WalkResult::interrupt();
-                              return mlir::WalkResult::advance();
-                            })
-                            .wasInterrupted();
+    bool hasNestedOps =
+        tryOp
+            ->walk([&](mlir::Operation *op) {
+              if (isa<cir::CleanupScopeOp, cir::TryOp>(op) && op != tryOp)
+                return mlir::WalkResult::interrupt();
+              return mlir::WalkResult::advance();
+            })
+            .wasInterrupted();
     if (hasNestedOps)
       return mlir::failure();
 
@@ -1571,8 +1568,8 @@ public:
       mlir::Region &handlerRegion = handlerRegions[idx];
 
       if (mlir::isa<cir::UnwindAttr>(typeAttr)) {
-        mlir::Block *unwindEntry = flattenUnwindHandler(
-            handlerRegion, loc, continueBlock, rewriter);
+        mlir::Block *unwindEntry =
+            flattenUnwindHandler(handlerRegion, loc, continueBlock, rewriter);
         catchHandlerBlocks.push_back(unwindEntry);
       } else {
         mlir::Block *handlerEntry = flattenCatchHandler(
@@ -1582,9 +1579,9 @@ public:
     }
 
     // Build the catch dispatch block.
-    mlir::Block *dispatchBlock = buildCatchDispatchBlock(
-        tryOp, handlerTypes, catchHandlerBlocks, loc,
-        catchHandlerBlocks.front(), rewriter);
+    mlir::Block *dispatchBlock =
+        buildCatchDispatchBlock(tryOp, handlerTypes, catchHandlerBlocks, loc,
+                                catchHandlerBlocks.front(), rewriter);
 
     // Build a block to be the unwind desination for throwing calls and replace
     // the calls with try_call ops. Note that the unwind block created here is
@@ -1595,8 +1592,8 @@ public:
     bool hasCleanup = tryOp.getCleanup();
     if (!callsToRewrite.empty()) {
       // Create a shared unwind block for all throwing calls.
-      mlir::Block *unwindBlock = buildUnwindBlock(
-          dispatchBlock, hasCleanup, loc, dispatchBlock, rewriter);
+      mlir::Block *unwindBlock = buildUnwindBlock(dispatchBlock, hasCleanup,
+                                                  loc, dispatchBlock, rewriter);
 
       for (cir::CallOp callOp : callsToRewrite)
         replaceCallWithTryCall(callOp, unwindBlock, loc, rewriter);

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -1527,19 +1527,19 @@ public:
         tryOp.getHandlerRegions();
 
     // Collect throwing calls in the try body.
-    llvm::SmallVector<cir::CallOp, 4> callsToRewrite;
+    llvm::SmallVector<cir::CallOp> callsToRewrite;
     collectThrowingCalls(tryOp.getTryRegion(), callsToRewrite);
 
     // Collect resume ops from already-flattened cleanup scopes in the try body.
     llvm::SmallVector<cir::ResumeOp> resumeOpsToChain;
     collectResumeOps(tryOp.getTryRegion(), resumeOpsToChain);
 
-    // ---- Step 1: Split the current block and inline the try body ----
+    // Split the current block and inline the try body.
     mlir::Block *currentBlock = rewriter.getInsertionBlock();
     mlir::Block *continueBlock =
         rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
 
-    // Get reference to try body blocks before inlining.
+    // Get references to try body blocks before inlining.
     mlir::Block *bodyEntry = &tryOp.getTryRegion().front();
     mlir::Block *bodyExit = &tryOp.getTryRegion().back();
 
@@ -1556,13 +1556,14 @@ public:
       rewriter.replaceOpWithNewOp<cir::BrOp>(bodyYield, continueBlock);
     }
 
-    // ---- Step 2: If there are no handlers, just inline the body ----
+    // If there are no handlers, we're done.
     if (!handlerTypes || handlerTypes.empty()) {
       rewriter.eraseOp(tryOp);
       return mlir::success();
     }
 
-    // ---- Step 3: Build catch handler blocks ----
+    // Build the catch handler blocks.
+
     // First, flatten all handler regions and collect the entry blocks.
     llvm::SmallVector<mlir::Block *> catchHandlerBlocks;
 
@@ -1570,26 +1571,27 @@ public:
       mlir::Region &handlerRegion = handlerRegions[idx];
 
       if (mlir::isa<cir::UnwindAttr>(typeAttr)) {
-        // Unwind handler: inline and leave cir.resume in place.
         mlir::Block *unwindEntry = flattenUnwindHandler(
             handlerRegion, loc, continueBlock, rewriter);
         catchHandlerBlocks.push_back(unwindEntry);
       } else {
-        // Catch handler (typed or catch-all): flatten inline.
         mlir::Block *handlerEntry = flattenCatchHandler(
             handlerRegion, continueBlock, loc, continueBlock, rewriter);
         catchHandlerBlocks.push_back(handlerEntry);
       }
     }
 
-    // ---- Step 4: Build the catch dispatch block ----
-    // Insert the dispatch block before the first handler block so that
-    // it appears above the individual catch blocks in the output.
+    // Build the catch dispatch block.
     mlir::Block *dispatchBlock = buildCatchDispatchBlock(
         tryOp, handlerTypes, catchHandlerBlocks, loc,
         catchHandlerBlocks.front(), rewriter);
 
-    // ---- Step 5: Build unwind block(s) and replace throwing calls ----
+    // Build a block to be the unwind desination for throwing calls and replace
+    // the calls with try_call ops. Note that the unwind block created here is
+    // something different than the unwind handler that we may have created
+    // above. The unwind handler continues unwinding after uncaught exceptions.
+    // This is the block that will eventually become the landing pad for invoke
+    // instructions.
     bool hasCleanup = tryOp.getCleanup();
     if (!callsToRewrite.empty()) {
       // Create a shared unwind block for all throwing calls.
@@ -1600,7 +1602,7 @@ public:
         replaceCallWithTryCall(callOp, unwindBlock, loc, rewriter);
     }
 
-    // ---- Step 6: Chain resume ops from inner cleanup scopes ----
+    // Chain resume ops from inner cleanup scopes.
     // Resume ops from already-flattened cleanup scopes within the try body
     // should branch to the catch dispatch block instead of unwinding directly.
     for (cir::ResumeOp resumeOp : resumeOpsToChain) {
@@ -1610,7 +1612,7 @@ public:
           resumeOp, mlir::ValueRange{ehToken}, dispatchBlock);
     }
 
-    // ---- Step 7: Erase the original try op ----
+    // Finally, erase the original try op ----
     rewriter.eraseOp(tryOp);
 
     return mlir::success();

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
@@ -43,67 +43,6 @@ cir.func @test_all_cleanup_in_try() {
   cir.return
 }
 
-// Test that we issue a diagnostic for an EH cleanup nested in a try with a
-// catch all handlers.
-cir.func @test_eh_cleanup_in_try_catchall() {
-  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
-  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
-  // expected-error @below {{TryOp flattening with handlers is not yet implemented}}
-  cir.try {
-    cir.cleanup.scope {
-      cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
-      cir.yield
-    } cleanup all {
-      cir.call @dtor(%0) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
-      cir.yield
-    }
-    cir.yield
-  } catch all (%eh_token : !cir.eh_token) {
-    %catch_token, %1 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
-    cir.cleanup.scope {
-      cir.yield
-    } cleanup eh {
-      cir.end_catch %catch_token : !cir.catch_token
-      cir.yield
-    }
-    cir.yield
-  }
-  cir.return
-}
-
-// Test that we issue a diagnostic for an EH cleanup nested in a try with a
-// catch and unwind handlers.
-cir.func @test_eh_cleanup_in_try_catch_unwind() {
-  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
-  %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["e"] {alignment = 4 : i64}
-  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
-  // expected-error @below {{TryOp flattening with handlers is not yet implemented}}
-  cir.try {
-    cir.cleanup.scope {
-      cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
-      cir.yield
-    } cleanup all {
-      cir.call @dtor(%0) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
-      cir.yield
-    }
-    cir.yield
-  } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] (%eh_token : !cir.eh_token) {
-    %catch_token, %2 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
-    cir.cleanup.scope {
-      %3 = cir.load align(4) %2 : !cir.ptr<!s32i>, !s32i
-      cir.store align(4) %3, %1 : !s32i, !cir.ptr<!s32i>
-      cir.yield
-    } cleanup eh {
-      cir.end_catch %catch_token : !cir.catch_token
-      cir.yield
-    }
-    cir.yield
-  } unwind (%eh_token_1 : !cir.eh_token) {
-    cir.resume %eh_token_1 : !cir.eh_token
-  }
-  cir.return
-}
-
 // Test that we issue a diagnostic for throwing calls in the cleanup region
 // of a nested EH cleanup scope (the dtor is not nothrow).
 cir.func @test_nested_eh_cleanup() {
@@ -205,14 +144,13 @@ cir.func @test_goto_in_nested_cleanup() {
   cir.return
 }
 
-// Test that a try op with handlers nested inside a cleanup scope produces
-// a diagnostic. The cleanup scope defers to the try op, which then fails
-// because handler flattening is not yet implemented.
+// Test a try op with handlers nested inside a cleanup scope.
+// The try is flattened first, then the enclosing cleanup scope chains
+// its EH path through the try's catch dispatch.
 cir.func @test_try_with_handlers_in_cleanup() {
   %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
   cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
   cir.cleanup.scope {
-    // expected-error @below {{TryOp flattening with handlers is not yet implemented}}
     cir.try {
       cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
       cir.yield

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
@@ -144,34 +144,6 @@ cir.func @test_goto_in_nested_cleanup() {
   cir.return
 }
 
-// Test a try op with handlers nested inside a cleanup scope.
-// The try is flattened first, then the enclosing cleanup scope chains
-// its EH path through the try's catch dispatch.
-cir.func @test_try_with_handlers_in_cleanup() {
-  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
-  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
-  cir.cleanup.scope {
-    cir.try {
-      cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
-      cir.yield
-    } catch all (%eh_token : !cir.eh_token) {
-      %catch_token, %1 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
-      cir.cleanup.scope {
-        cir.yield
-      } cleanup eh {
-        cir.end_catch %catch_token : !cir.catch_token
-        cir.yield
-      }
-      cir.yield
-    }
-    cir.yield
-  } cleanup all {
-    cir.call @dtor(%0) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
-    cir.yield
-  }
-  cir.return
-}
-
 // Test that we issue a diagnostic for throwing calls in the cleanup region
 // of an EH cleanup scope.
 cir.func @test_throwing_call_in_eh_cleanup() {

--- a/clang/test/CIR/Transforms/flatten-try-op.cir
+++ b/clang/test/CIR/Transforms/flatten-try-op.cir
@@ -3,11 +3,11 @@
 
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
+!void = !cir.void
 !rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
 !rec_exception = !cir.record<struct "std::exception" {!s32i}>
 
-// Test: simple try with no handlers and no throwing calls.
-// The try body is just inlined.
+// Test a simple try with no handlers and no throwing calls.
 cir.func @test_try_no_handlers() {
   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init] {alignment = 4 : i64}
   cir.scope {
@@ -34,7 +34,7 @@ cir.func @test_try_no_handlers() {
 // CHECK:       ^[[SCOPE_EXIT]]:
 // CHECK:         cir.return
 
-// Test: try-catch with catch all, throwing call in try body.
+// Test try-catch with catch all, throwing call in try body.
 // The throwing call becomes try_call, and we get an unwind block,
 // catch dispatch, and a catch-all handler.
 cir.func @test_try_catch_all() {
@@ -57,37 +57,32 @@ cir.func @test_try_catch_all() {
 // CHECK:       ^[[SCOPE]]:
 // CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
 //
-// Try body: the call is replaced with try_call.
 // CHECK:       ^[[TRY_BODY]]:
 // CHECK:         cir.try_call @mayThrow() ^[[NORMAL:bb[0-9]+]], ^[[UNWIND:bb[0-9]+]]
 //
-// Normal continuation: branch to continue.
 // CHECK:       ^[[NORMAL]]:
 // CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
 //
-// Catch dispatch: dispatches to catch-all.
-// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[UNWIND]]:
+// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[EH_TOK]] : !cir.eh_token)
+//
+// CHECK:       ^[[DISPATCH]](%[[DISP_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
 // CHECK:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
 // CHECK:         ]
 //
-// Catch-all handler block: receives eh_token, does begin_catch/end_catch.
 // CHECK:       ^[[CATCH_ALL]](%[[ET:.*]]: !cir.eh_token):
 // CHECK:         %[[CT:.*]], %[[EXN:.*]] = cir.begin_catch %[[ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
 // CHECK:         cir.end_catch %[[CT]] : !cir.catch_token
 // CHECK:         cir.br ^[[CONTINUE]]
-//
-// Unwind block.
-// CHECK:       ^[[UNWIND]]:
-// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
-// CHECK:         cir.br ^[[DISPATCH]](%[[EH_TOK]] : !cir.eh_token)
 //
 // CHECK:       ^[[CONTINUE]]:
 // CHECK:         cir.br ^[[SCOPE_EXIT:bb[0-9]+]]
 // CHECK:       ^[[SCOPE_EXIT]]:
 // CHECK:         cir.return
 
-// Test: try-catch with typed handler and unwind.
+// Test try-catch with typed handler and unwind.
 // If the exception type doesn't match, control goes to the unwind handler
 // which resumes unwinding.
 cir.func @test_try_catch_typed_with_unwind() {
@@ -114,40 +109,35 @@ cir.func @test_try_catch_typed_with_unwind() {
 // CHECK:       ^[[SCOPE]]:
 // CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
 //
-// Try body: the call becomes try_call.
 // CHECK:       ^[[TRY_BODY]]:
 // CHECK:         cir.try_call @mayThrow() ^[[NORMAL:bb[0-9]+]], ^[[UNWIND:bb[0-9]+]]
 //
 // CHECK:       ^[[NORMAL]]:
 // CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
 //
-// Catch dispatch: dispatches to typed handler or unwind.
-// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[UNWIND]]:
+// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[EH_TOK]] : !cir.eh_token)
+//
+// CHECK:       ^[[DISPATCH]](%[[DISP_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
 // CHECK:           catch(#cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>) : ^[[CATCH_TYPED:bb[0-9]+]],
 // CHECK:           unwind : ^[[UNWIND_HANDLER:bb[0-9]+]]
 // CHECK:         ]
 //
-// Typed catch handler: receives eh_token.
 // CHECK:       ^[[CATCH_TYPED]](%[[CT_ET:.*]]: !cir.eh_token):
 // CHECK:         %[[CT:.*]], %[[EXN:.*]] = cir.begin_catch %[[CT_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.ptr<!rec_std3A3Aexception>>)
 // CHECK:         cir.end_catch %[[CT]] : !cir.catch_token
 // CHECK:         cir.br ^[[CONTINUE]]
 //
-// Unwind handler: continues unwinding.
 // CHECK:       ^[[UNWIND_HANDLER]](%[[UW_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.resume %[[UW_ET]] : !cir.eh_token
-//
-// Unwind block (from try_call).
-// CHECK:       ^[[UNWIND]]:
-// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
-// CHECK:         cir.br ^[[DISPATCH]](%[[EH_TOK]] : !cir.eh_token)
 //
 // CHECK:       ^[[CONTINUE]]:
 // CHECK:         cir.br ^{{.*}}
 // CHECK:         cir.return
 
-// Test: try-catch with cleanup inside the try body.
+// Test try-catch with cleanup inside the try body.
 // The cleanup scope is flattened first. The inner EH cleanup resume ops
 // are chained to the catch dispatch block of the enclosing try.
 cir.func @test_try_catch_with_cleanup() {
@@ -174,71 +164,59 @@ cir.func @test_try_catch_with_cleanup() {
 
 // CHECK-LABEL: cir.func @test_try_catch_with_cleanup()
 // CHECK:         %[[C:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
 //
-// The try body: ctor call becomes try_call (it may throw, and it's in
-// the try scope). The cleanup scope was already flattened.
-// CHECK:         cir.try_call @ctor(%[[C]]) ^[[AFTER_CTOR:bb[0-9]+]], ^{{bb[0-9]+}}
+// CHECK:       ^[[TRY_BODY]]:
+// CHECK:         cir.try_call @ctor(%[[C]]) ^[[AFTER_CTOR:bb[0-9]+]], ^[[OUTER_UNWIND:bb[0-9]+]]
 //
-// After ctor, enter the cleanup scope body.
 // CHECK:       ^[[AFTER_CTOR]]:
 // CHECK:         cir.br ^[[CLEANUP_BODY:bb[0-9]+]]
 //
-// Cleanup body: doSomething is try_call'd (from cleanup scope flattening).
 // CHECK:       ^[[CLEANUP_BODY]]:
 // CHECK:         cir.try_call @doSomething(%[[C]]) ^[[AFTER_DO:bb[0-9]+]], ^[[INNER_UNWIND:bb[0-9]+]]
 //
-// After doSomething, normal cleanup.
 // CHECK:       ^[[AFTER_DO]]:
 // CHECK:         cir.br ^[[NORMAL_CLEANUP:bb[0-9]+]]
 //
-// Normal cleanup: call dtor, then branch to exit.
 // CHECK:       ^[[NORMAL_CLEANUP]]:
 // CHECK:         cir.call @dtor(%[[C]]) nothrow
 // CHECK:         cir.br ^[[CLEANUP_EXIT:bb[0-9]+]]
 //
-// Cleanup exit: branch to try body yield -> continue.
 // CHECK:       ^[[CLEANUP_EXIT]]:
 // CHECK:         cir.br ^[[TRY_EXIT:bb[0-9]+]]
 //
-// Inner unwind block (from cleanup scope flattening).
 // CHECK:       ^[[INNER_UNWIND]]:
 // CHECK:         %[[INNER_EH:.*]] = cir.eh.initiate cleanup : !cir.eh_token
 // CHECK:         cir.br ^[[EH_CLEANUP:bb[0-9]+]](%[[INNER_EH]] : !cir.eh_token)
 //
-// EH cleanup block: begin_cleanup, dtor, end_cleanup, then chained to
-// the catch dispatch (resume was replaced by try op flattening).
 // CHECK:       ^[[EH_CLEANUP]](%[[EH_CT:.*]]: !cir.eh_token):
 // CHECK:         %[[CT:.*]] = cir.begin_cleanup %[[EH_CT]] : !cir.eh_token -> !cir.cleanup_token
 // CHECK:         cir.call @dtor(%[[C]]) nothrow
 // CHECK:         cir.end_cleanup %[[CT]] : !cir.cleanup_token
 // CHECK:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[EH_CT]] : !cir.eh_token)
 //
-// Try exit: branches to continue block after try.
 // CHECK:       ^[[TRY_EXIT]]:
 // CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
 //
-// Catch dispatch block.
+// CHECK:       ^[[OUTER_UNWIND]]:
+// CHECK:         %[[CTOR_EH:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH]](%[[CTOR_EH]] : !cir.eh_token)
+//
 // CHECK:       ^[[DISPATCH]](%[[DISP_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
 // CHECK:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
 // CHECK:         ]
 //
-// Catch-all handler.
 // CHECK:       ^[[CATCH_ALL]](%[[CA_ET:.*]]: !cir.eh_token):
 // CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[CA_ET]]
 // CHECK:         cir.end_catch
 // CHECK:         cir.br ^[[CONTINUE]]
 //
-// Unwind block (from try_call of ctor).
-// CHECK:       ^{{bb[0-9]+}}:
-// CHECK:         %[[CTOR_EH:.*]] = cir.eh.initiate : !cir.eh_token
-// CHECK:         cir.br ^[[DISPATCH]](%[[CTOR_EH]] : !cir.eh_token)
-//
 // CHECK:       ^[[CONTINUE]]:
 // CHECK:         cir.br ^{{.*}}
 // CHECK:         cir.return
 
-// Test: try-catch within a cleanup scope.
+// Test try-catch within a cleanup scope.
 // The try is nested inside a cleanup scope. If an exception is not caught
 // by the try's handlers, the resume from the unwind handler should chain
 // to the outer cleanup's EH handler.
@@ -271,63 +249,61 @@ cir.func @test_try_in_cleanup() {
 // CHECK:         %[[C:.*]] = cir.alloca !rec_SomeClass
 // CHECK:         %[[E:.*]] = cir.alloca !cir.ptr<!rec_std3A3Aexception>
 // CHECK:         cir.call @ctor(%[[C]])
+// CHECK:         cir.br ^[[OUTER_CLEANUP_BODY:bb[0-9]+]]
 //
-// Outer cleanup body starts.
-// CHECK:         cir.br ^[[OUTER_BODY:bb[0-9]+]]
+// CHECK:       ^[[OUTER_CLEANUP_BODY]]:
+// CHECK:         cir.br ^[[SCOPE_ENTER:bb[0-9]+]]
 //
-// Body contains the scope -> try. The try's call becomes try_call.
-// CHECK:       ^[[OUTER_BODY]]:
-// CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
-// CHECK:       ^[[SCOPE]]:
+// CHECK:       ^[[SCOPE_ENTER]]:
 // CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
 //
 // CHECK:       ^[[TRY_BODY]]:
 // CHECK:         cir.try_call @doSomething(%[[C]]) ^[[NORMAL:bb[0-9]+]], ^[[TRY_UNWIND:bb[0-9]+]]
 //
-// Normal path.
 // CHECK:       ^[[NORMAL]]:
 // CHECK:         cir.br ^[[TRY_CONT:bb[0-9]+]]
 //
-// Catch dispatch.
-// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[TRY_UNWIND]]:
+// CHECK:         %[[TRY_EH:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[TRY_EH]] : !cir.eh_token)
+//
+// CHECK:       ^[[DISPATCH]](%[[DISP_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
 // CHECK:           catch(#cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>) : ^[[CATCH:bb[0-9]+]],
 // CHECK:           unwind : ^[[UNWIND_HANDLER:bb[0-9]+]]
 // CHECK:         ]
 //
-// Typed catch handler.
 // CHECK:       ^[[CATCH]](%[[CATCH_ET:.*]]: !cir.eh_token):
 // CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[CATCH_ET]]
 // CHECK:         cir.end_catch
 // CHECK:         cir.br ^[[TRY_CONT]]
 //
-// Unwind handler: resume is chained to the outer EH cleanup by the
-// outer cleanup scope flattening.
 // CHECK:       ^[[UNWIND_HANDLER]](%[[UW_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.br ^[[OUTER_EH_CLEANUP:bb[0-9]+]](%[[UW_ET]] : !cir.eh_token)
 //
-// Try's unwind block.
-// CHECK:       ^[[TRY_UNWIND]]:
-// CHECK:         %[[TRY_EH:.*]] = cir.eh.initiate : !cir.eh_token
-// CHECK:         cir.br ^[[DISPATCH]](%[[TRY_EH]] : !cir.eh_token)
-//
-// After the try, normal flow continues.
 // CHECK:       ^[[TRY_CONT]]:
-// CHECK:         cir.br ^{{.*}}
+// CHECK:         cir.br ^[[SCOPE_EXIT:bb[0-9]+]]
 //
-// The outer cleanup scope's normal cleanup: call dtor.
+// CHECK:       ^[[SCOPE_EXIT]]:
+// CHECK:         cir.br ^[[NORMAL_CLEANUP:bb[0-9]+]]
+//
+// CHECK:       ^[[NORMAL_CLEANUP]]:
 // CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.br ^[[CLEANUP_EXIT:bb[0-9]+]]
 //
-// The outer EH cleanup: call dtor, then resume.
+// CHECK:       ^[[CLEANUP_EXIT]]:
+// CHECK:         cir.br ^[[RETURN:bb[0-9]+]]
+//
 // CHECK:       ^[[OUTER_EH_CLEANUP]](%[[OEH_ET:.*]]: !cir.eh_token):
 // CHECK:         %{{.*}} = cir.begin_cleanup %[[OEH_ET]]
 // CHECK:         cir.call @dtor(%[[C]]) nothrow
 // CHECK:         cir.end_cleanup
 // CHECK:         cir.resume %[[OEH_ET]] : !cir.eh_token
 //
+// CHECK:       ^[[RETURN]]:
 // CHECK:         cir.return
 
-// Test: try with catch all and no throwing calls.
+// Test try with catch all and no throwing calls.
 // The try body doesn't have throwing calls, so no try_call/unwind blocks are
 // needed. The handlers are still built but won't be reachable.
 cir.func @test_try_catch_all_no_throwing_calls() {
@@ -345,13 +321,10 @@ cir.func @test_try_catch_all_no_throwing_calls() {
 }
 
 // CHECK-LABEL: cir.func @test_try_catch_all_no_throwing_calls()
-// The body is inlined. Dispatch block and handler block are created
-// but no unwind blocks since no calls were rewritten to try_call.
 // CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
 // CHECK:       ^[[SCOPE]]:
 // CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
 //
-// Try body: no throwing calls, so no try_call.
 // CHECK:       ^[[TRY_BODY]]:
 // CHECK:         %{{.*}} = cir.const #cir.int<42> : !s32i
 // CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
@@ -373,7 +346,7 @@ cir.func @test_try_catch_all_no_throwing_calls() {
 // CHECK:       ^[[SCOPE_EXIT]]:
 // CHECK:         cir.return
 
-// Test: try-catch with multiple typed handlers and catch-all.
+// Test try-catch with multiple typed handlers and catch-all.
 cir.func @test_try_multiple_handlers() {
   cir.scope {
     cir.try {
@@ -397,42 +370,37 @@ cir.func @test_try_multiple_handlers() {
 // CHECK:       ^[[SCOPE]]:
 // CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
 //
-// Try body: call becomes try_call.
 // CHECK:       ^[[TRY_BODY]]:
 // CHECK:         cir.try_call @mayThrow() ^[[NORMAL:bb[0-9]+]], ^[[UNWIND:bb[0-9]+]]
 //
 // CHECK:       ^[[NORMAL]]:
 // CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
 //
-// Dispatch: routes to int handler or catch-all.
-// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[UNWIND]]:
+// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[EH_TOK]] : !cir.eh_token)
+//
+// CHECK:       ^[[DISPATCH]](%[[DISP_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
 // CHECK:           catch(#cir.global_view<@_ZTIi> : !cir.ptr<!u8i>) : ^[[CATCH_INT:bb[0-9]+]],
 // CHECK:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
 // CHECK:         ]
 //
-// Int catch handler.
 // CHECK:       ^[[CATCH_INT]](%[[INT_ET:.*]]: !cir.eh_token):
 // CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[INT_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
 // CHECK:         cir.end_catch
 // CHECK:         cir.br ^[[CONTINUE]]
 //
-// Catch-all handler.
 // CHECK:       ^[[CATCH_ALL]](%[[ALL_ET:.*]]: !cir.eh_token):
 // CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[ALL_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
 // CHECK:         cir.end_catch
 // CHECK:         cir.br ^[[CONTINUE]]
 //
-// Unwind block.
-// CHECK:       ^[[UNWIND]]:
-// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
-// CHECK:         cir.br ^[[DISPATCH]](%[[EH_TOK]] : !cir.eh_token)
-//
 // CHECK:       ^[[CONTINUE]]:
 // CHECK:         cir.br ^{{.*}}
 // CHECK:         cir.return
 
-// Test: nested try ops.
+// Test nested try ops.
 // The inner try is flattened first. Its unwind handler's resume is then
 // chained to the outer try's catch dispatch when the outer try is flattened.
 cir.func @test_nested_try() {
@@ -463,51 +431,41 @@ cir.func @test_nested_try() {
 // CHECK:       ^[[SCOPE]]:
 // CHECK:         cir.br ^[[OUTER_BODY:bb[0-9]+]]
 //
-// Outer try body: was the inner try, now inlined.
 // CHECK:       ^[[OUTER_BODY]]:
 // CHECK:         cir.br ^[[INNER_BODY:bb[0-9]+]]
 //
-// Inner try body: the call becomes try_call (from inner try flattening).
 // CHECK:       ^[[INNER_BODY]]:
 // CHECK:         cir.try_call @mayThrow() ^[[INNER_NORMAL:bb[0-9]+]], ^[[INNER_UNWIND:bb[0-9]+]]
 //
-// Inner normal path.
 // CHECK:       ^[[INNER_NORMAL]]:
 // CHECK:         cir.br ^[[INNER_CONTINUE:bb[0-9]+]]
 //
-// Inner catch dispatch.
-// CHECK:       ^[[INNER_DISPATCH:bb[0-9]+]](%[[ID_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[INNER_UNWIND]]:
+// CHECK:         %[[IEH:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[INNER_DISPATCH:bb[0-9]+]](%[[IEH]] : !cir.eh_token)
+//
+// CHECK:       ^[[INNER_DISPATCH]](%[[ID_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.eh.dispatch %[[ID_ET]] : !cir.eh_token [
 // CHECK:           catch(#cir.global_view<@_ZTIi> : !cir.ptr<!u8i>) : ^[[INNER_CATCH:bb[0-9]+]],
 // CHECK:           unwind : ^[[INNER_UW_HANDLER:bb[0-9]+]]
 // CHECK:         ]
 //
-// Inner typed catch handler.
 // CHECK:       ^[[INNER_CATCH]](%[[IC_ET:.*]]: !cir.eh_token):
 // CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[IC_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
 // CHECK:         cir.end_catch
 // CHECK:         cir.br ^[[INNER_CONTINUE]]
 //
-// Inner unwind handler: resume was chained to the outer catch dispatch.
 // CHECK:       ^[[INNER_UW_HANDLER]](%[[IUW_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.br ^[[OUTER_DISPATCH:bb[0-9]+]](%[[IUW_ET]] : !cir.eh_token)
 //
-// Inner unwind block (from try_call).
-// CHECK:       ^[[INNER_UNWIND]]:
-// CHECK:         %[[IEH:.*]] = cir.eh.initiate : !cir.eh_token
-// CHECK:         cir.br ^[[INNER_DISPATCH]](%[[IEH]] : !cir.eh_token)
-//
-// Inner continue → outer try body yield → outer continue.
 // CHECK:       ^[[INNER_CONTINUE]]:
 // CHECK:         cir.br ^[[OUTER_CONTINUE:bb[0-9]+]]
 //
-// Outer catch dispatch.
 // CHECK:       ^[[OUTER_DISPATCH]](%[[OD_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.eh.dispatch %[[OD_ET]] : !cir.eh_token [
 // CHECK:           catch_all : ^[[OUTER_CATCH:bb[0-9]+]]
 // CHECK:         ]
 //
-// Outer catch-all handler.
 // CHECK:       ^[[OUTER_CATCH]](%[[OC_ET:.*]]: !cir.eh_token):
 // CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[OC_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
 // CHECK:         cir.end_catch
@@ -517,9 +475,9 @@ cir.func @test_nested_try() {
 // CHECK:         cir.br ^{{.*}}
 // CHECK:         cir.return
 
-// Test a try op with handlers nested inside a cleanup scope.
-// The try is flattened first, then the enclosing cleanup scope chains
-// its EH path through the try's catch dispatch.
+// Test a try op with handlers nested inside a cleanup scope and a cleanup
+// scope inside a catch handler. This is the form of the catch handler that will
+// actually be generated. The representations above are all simplifications.
 cir.func @test_try_with_handlers_in_cleanup() {
   %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
   cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
@@ -550,26 +508,24 @@ cir.func @test_try_with_handlers_in_cleanup() {
 // CHECK:         cir.call @ctor(%[[C]])
 // CHECK:         cir.br ^[[CLEANUP_BODY:bb[0-9]+]]
 //
-// Cleanup scope body: enters the flattened try.
 // CHECK:       ^[[CLEANUP_BODY]]:
 // CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
 //
-// Try body: doSomething becomes try_call.
 // CHECK:       ^[[TRY_BODY]]:
 // CHECK:         cir.try_call @doSomething(%[[C]]) ^[[NORMAL:bb[0-9]+]], ^[[UNWIND:bb[0-9]+]]
 //
-// Normal continuation from try_call.
 // CHECK:       ^[[NORMAL]]:
 // CHECK:         cir.br ^[[TRY_CONTINUE:bb[0-9]+]]
 //
-// Catch dispatch.
-// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[UNWIND]]:
+// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[EH_TOK]] : !cir.eh_token)
+//
+// CHECK:       ^[[DISPATCH]](%[[DISP_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
 // CHECK:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
 // CHECK:         ]
 //
-// Catch-all handler: begin_catch, end_catch
-// (empty body), then normal cleanup runs end_catch, then exit.
 // CHECK:       ^[[CATCH_ALL]](%[[ET:.*]]: !cir.eh_token):
 // CHECK:         %[[CATCH_TOK:.*]], %{{.*}} = cir.begin_catch %[[ET]]
 // CHECK:         cir.br ^[[INNER_CLEANUP_BODY:bb[0-9]+]]
@@ -583,16 +539,194 @@ cir.func @test_try_with_handlers_in_cleanup() {
 // CHECK:       ^[[CATCH_EXIT]]:
 // CHECK:         cir.br ^[[TRY_CONTINUE]]
 //
-// Unwind block (from try_call).
-// CHECK:       ^[[UNWIND]]:
-// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
-// CHECK:         cir.br ^[[DISPATCH]](%[[EH_TOK]] : !cir.eh_token)
-//
-// After try, normal cleanup: call dtor.
 // CHECK:       ^[[TRY_CONTINUE]]:
 // CHECK:         cir.br ^{{.*}}
 // CHECK:         cir.call @dtor(%[[C]]) nothrow
 //
+// CHECK:         cir.return
+
+// Test nested try ops with a cleanup scope in the outer try body.
+// The inner try's unwind handler must execute the cleanup (dtor) before
+// the exception reaches the outer try's catch dispatch.
+cir.func @test_nested_try_with_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.scope {
+    cir.try {
+      cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.cleanup.scope {
+        cir.try {
+          cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+          cir.yield
+        } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] (%eh_token : !cir.eh_token) {
+          %ct, %exn = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
+          cir.end_catch %ct : !cir.catch_token
+          cir.yield
+        } unwind (%eh_token : !cir.eh_token) {
+          cir.resume %eh_token : !cir.eh_token
+        }
+        cir.yield
+      } cleanup all {
+        cir.call @dtor(%0) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
+        cir.yield
+      }
+      cir.yield
+    } catch all (%eh_token : !cir.eh_token) {
+      %ct, %exn = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.void>)
+      cir.end_catch %ct : !cir.catch_token
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_nested_try_with_cleanup()
+// CHECK:         %[[C:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
+//
+// CHECK:       ^[[SCOPE]]:
+// CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
+//
+// CHECK:       ^[[TRY_BODY]]:
+// CHECK:         cir.try_call @ctor(%[[C]]) ^[[AFTER_CTOR:bb[0-9]+]], ^[[CTOR_UNWIND:bb[0-9]+]]
+//
+// CHECK:       ^[[AFTER_CTOR]]:
+// CHECK:         cir.br ^[[CLEANUP_BODY:bb[0-9]+]]
+//
+// CHECK:       ^[[CLEANUP_BODY]]:
+// CHECK:         cir.br ^[[INNER_TRY_BODY:bb[0-9]+]]
+//
+// CHECK:       ^[[INNER_TRY_BODY]]:
+// CHECK:         cir.try_call @doSomething(%[[C]]) ^[[INNER_NORMAL:bb[0-9]+]], ^[[INNER_UNWIND:bb[0-9]+]]
+//
+// CHECK:       ^[[INNER_NORMAL]]:
+// CHECK:         cir.br ^[[INNER_CONTINUE:bb[0-9]+]]
+//
+// CHECK:       ^[[INNER_UNWIND]]:
+// CHECK:         %[[IEH:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[INNER_DISPATCH:bb[0-9]+]](%[[IEH]] : !cir.eh_token)
+//
+// CHECK:       ^[[INNER_DISPATCH]](%[[ID_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[ID_ET]] : !cir.eh_token [
+// CHECK:           catch(#cir.global_view<@_ZTIi> : !cir.ptr<!u8i>) : ^[[INNER_CATCH:bb[0-9]+]],
+// CHECK:           unwind : ^[[INNER_UW_HANDLER:bb[0-9]+]]
+// CHECK:         ]
+//
+// CHECK:       ^[[INNER_CATCH]](%[[IC_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[IC_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[INNER_CONTINUE]]
+//
+// The inner unwind handler goes through the EH cleanup (dtor) before
+// reaching the outer try's catch dispatch.
+// CHECK:       ^[[INNER_UW_HANDLER]](%[[IUW_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.br ^[[EH_CLEANUP:bb[0-9]+]](%[[IUW_ET]] : !cir.eh_token)
+//
+// The continuation path after the inner try catches an exception branches to
+// the normal outer cleanup.
+// CHECK:       ^[[INNER_CONTINUE]]:
+// CHECK:         cir.br ^[[NORMAL_CLEANUP:bb[0-9]+]]
+//
+// CHECK:       ^[[NORMAL_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.br ^[[CLEANUP_EXIT:bb[0-9]+]]
+//
+// CHECK:       ^[[CLEANUP_EXIT]]:
+// CHECK:         cir.br ^[[TRY_EXIT:bb[0-9]+]]
+//
+// EH cleanup: the cleanup (dtor) runs before unwinding to the outer dispatch.
+// CHECK:       ^[[EH_CLEANUP]](%[[EH_ET:.*]]: !cir.eh_token):
+// CHECK:         %[[CT:.*]] = cir.begin_cleanup %[[EH_ET]] : !cir.eh_token -> !cir.cleanup_token
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.end_cleanup %[[CT]] : !cir.cleanup_token
+// CHECK:         cir.br ^[[OUTER_DISPATCH:bb[0-9]+]](%[[EH_ET]] : !cir.eh_token)
+//
+// CHECK:       ^[[TRY_EXIT]]:
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+//
+// Ctor's unwind goes directly to outer dispatch (cleanup scope not yet entered).
+// CHECK:       ^[[CTOR_UNWIND]]:
+// CHECK:         %[[CTOR_EH:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[OUTER_DISPATCH]](%[[CTOR_EH]] : !cir.eh_token)
+//
+// CHECK:       ^[[OUTER_DISPATCH]](%[[OD_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[OD_ET]] : !cir.eh_token [
+// CHECK:           catch_all : ^[[OUTER_CATCH:bb[0-9]+]]
+// CHECK:         ]
+//
+// CHECK:       ^[[OUTER_CATCH]](%[[OC_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[OC_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[CONTINUE]]
+//
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.br ^[[RETURN:bb[0-9]+]]
+// CHECK:       ^[[RETURN]]:
+// CHECK:         cir.return
+
+// Test try-catch with multiple typed handlers and a catch-all.
+cir.func @test_try_multiple_typed_and_catch_all() {
+  cir.scope {
+    cir.try {
+      cir.call @mayThrow() : () -> ()
+      cir.yield
+    } catch [type #cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>] (%eh_token : !cir.eh_token) {
+      %ct1, %exn1 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.ptr<!rec_exception>>)
+      cir.end_catch %ct1 : !cir.catch_token
+      cir.yield
+    } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] (%eh_token : !cir.eh_token) {
+      %ct2, %exn2 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
+      cir.end_catch %ct2 : !cir.catch_token
+      cir.yield
+    } catch all (%eh_token : !cir.eh_token) {
+      %ct3, %exn3 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.void>)
+      cir.end_catch %ct3 : !cir.catch_token
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_try_multiple_typed_and_catch_all()
+// CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
+//
+// CHECK:       ^[[SCOPE]]:
+// CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
+//
+// CHECK:       ^[[TRY_BODY]]:
+// CHECK:         cir.try_call @mayThrow() ^[[NORMAL:bb[0-9]+]], ^[[UNWIND:bb[0-9]+]]
+//
+// CHECK:       ^[[NORMAL]]:
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+//
+// CHECK:       ^[[UNWIND]]:
+// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[EH_TOK]] : !cir.eh_token)
+//
+// CHECK:       ^[[DISPATCH]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch(#cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>) : ^[[CATCH_EXN:bb[0-9]+]],
+// CHECK:           catch(#cir.global_view<@_ZTIi> : !cir.ptr<!u8i>) : ^[[CATCH_INT:bb[0-9]+]],
+// CHECK:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
+// CHECK:         ]
+//
+// CHECK:       ^[[CATCH_EXN]](%[[EXN_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[EXN_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.ptr<!rec_std3A3Aexception>>)
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[CONTINUE]]
+//
+// CHECK:       ^[[CATCH_INT]](%[[INT_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[INT_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[CONTINUE]]
+//
+// CHECK:       ^[[CATCH_ALL]](%[[ALL_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[ALL_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[CONTINUE]]
+//
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.br ^[[RETURN:bb[0-9]+]]
+// CHECK:       ^[[RETURN]]:
 // CHECK:         cir.return
 
 cir.func private @mayThrow()

--- a/clang/test/CIR/Transforms/flatten-try-op.cir
+++ b/clang/test/CIR/Transforms/flatten-try-op.cir
@@ -517,6 +517,84 @@ cir.func @test_nested_try() {
 // CHECK:         cir.br ^{{.*}}
 // CHECK:         cir.return
 
+// Test a try op with handlers nested inside a cleanup scope.
+// The try is flattened first, then the enclosing cleanup scope chains
+// its EH path through the try's catch dispatch.
+cir.func @test_try_with_handlers_in_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.try {
+      cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    } catch all (%eh_token : !cir.eh_token) {
+      %catch_token, %1 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+      cir.cleanup.scope {
+        cir.yield
+      } cleanup all {
+        cir.end_catch %catch_token : !cir.catch_token
+        cir.yield
+      }
+      cir.yield
+    }
+    cir.yield
+  } cleanup all {
+    cir.call @dtor(%0) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_try_with_handlers_in_cleanup()
+// CHECK:         %[[C:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.call @ctor(%[[C]])
+// CHECK:         cir.br ^[[CLEANUP_BODY:bb[0-9]+]]
+//
+// Cleanup scope body: enters the flattened try.
+// CHECK:       ^[[CLEANUP_BODY]]:
+// CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
+//
+// Try body: doSomething becomes try_call.
+// CHECK:       ^[[TRY_BODY]]:
+// CHECK:         cir.try_call @doSomething(%[[C]]) ^[[NORMAL:bb[0-9]+]], ^[[UNWIND:bb[0-9]+]]
+//
+// Normal continuation from try_call.
+// CHECK:       ^[[NORMAL]]:
+// CHECK:         cir.br ^[[TRY_CONTINUE:bb[0-9]+]]
+//
+// Catch dispatch.
+// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
+// CHECK:         ]
+//
+// Catch-all handler: begin_catch, end_catch
+// (empty body), then normal cleanup runs end_catch, then exit.
+// CHECK:       ^[[CATCH_ALL]](%[[ET:.*]]: !cir.eh_token):
+// CHECK:         %[[CATCH_TOK:.*]], %{{.*}} = cir.begin_catch %[[ET]]
+// CHECK:         cir.br ^[[INNER_CLEANUP_BODY:bb[0-9]+]]
+// CHECK:       ^[[INNER_CLEANUP_BODY]]:
+// CHECK:         cir.br ^[[NORMAL_CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[NORMAL_CLEANUP]]:
+// CHECK:         cir.end_catch %[[CATCH_TOK]]
+// CHECK:         cir.br ^[[CLEANUP_EXIT:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP_EXIT]]:
+// CHECK:         cir.br ^[[CATCH_EXIT:bb[0-9]+]]
+// CHECK:       ^[[CATCH_EXIT]]:
+// CHECK:         cir.br ^[[TRY_CONTINUE]]
+//
+// Unwind block (from try_call).
+// CHECK:       ^[[UNWIND]]:
+// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH]](%[[EH_TOK]] : !cir.eh_token)
+//
+// After try, normal cleanup: call dtor.
+// CHECK:       ^[[TRY_CONTINUE]]:
+// CHECK:         cir.br ^{{.*}}
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+//
+// CHECK:         cir.return
+
 cir.func private @mayThrow()
 cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
 cir.func private @dtor(!cir.ptr<!rec_SomeClass>) attributes {nothrow}

--- a/clang/test/CIR/Transforms/flatten-try-op.cir
+++ b/clang/test/CIR/Transforms/flatten-try-op.cir
@@ -1,0 +1,430 @@
+// RUN: cir-opt %s -cir-flatten-cfg -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+!s32i = !cir.int<s, 32>
+!u8i = !cir.int<u, 8>
+!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+!rec_exception = !cir.record<struct "std::exception" {!s32i}>
+
+// Test: simple try with no handlers and no throwing calls.
+// The try body is just inlined.
+cir.func @test_try_no_handlers() {
+  %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init] {alignment = 4 : i64}
+  cir.scope {
+    cir.try {
+      %1 = cir.const #cir.int<1> : !s32i
+      cir.store %1, %0 : !s32i, !cir.ptr<!s32i>
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_try_no_handlers()
+// CHECK:         %[[ALLOCA:.*]] = cir.alloca !s32i
+// CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
+// CHECK:       ^[[SCOPE]]:
+// CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
+// CHECK:       ^[[TRY_BODY]]:
+// CHECK:         %[[C1:.*]] = cir.const #cir.int<1> : !s32i
+// CHECK:         cir.store %[[C1]], %[[ALLOCA]]
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.br ^[[SCOPE_EXIT:bb[0-9]+]]
+// CHECK:       ^[[SCOPE_EXIT]]:
+// CHECK:         cir.return
+
+// Test: try-catch with catch all, throwing call in try body.
+// The throwing call becomes try_call, and we get an unwind block,
+// catch dispatch, and a catch-all handler.
+cir.func @test_try_catch_all() {
+  cir.scope {
+    cir.try {
+      cir.call @mayThrow() : () -> ()
+      cir.yield
+    } catch all (%eh_token : !cir.eh_token) {
+      %catch_token, %exn_ptr = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.void>)
+      cir.end_catch %catch_token : !cir.catch_token
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_try_catch_all()
+// CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
+//
+// CHECK:       ^[[SCOPE]]:
+// CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
+//
+// Try body: the call is replaced with try_call.
+// CHECK:       ^[[TRY_BODY]]:
+// CHECK:         cir.try_call @mayThrow() ^[[NORMAL:bb[0-9]+]], ^[[UNWIND:bb[0-9]+]]
+//
+// Normal continuation: branch to continue.
+// CHECK:       ^[[NORMAL]]:
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+//
+// Catch-all handler block: receives eh_token, does begin_catch/end_catch.
+// CHECK:       ^[[CATCH_ALL:bb[0-9]+]](%[[ET:.*]]: !cir.eh_token):
+// CHECK:         %[[CT:.*]], %[[EXN:.*]] = cir.begin_catch %[[ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+// CHECK:         cir.end_catch %[[CT]] : !cir.catch_token
+// CHECK:         cir.br ^[[CONTINUE]]
+//
+// Catch dispatch: dispatches to catch-all.
+// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch_all : ^[[CATCH_ALL]]
+// CHECK:         ]
+//
+// Unwind block.
+// CHECK:       ^[[UNWIND]]:
+// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH]](%[[EH_TOK]] : !cir.eh_token)
+//
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.br ^[[SCOPE_EXIT:bb[0-9]+]]
+// CHECK:       ^[[SCOPE_EXIT]]:
+// CHECK:         cir.return
+
+// Test: try-catch with typed handler and unwind.
+// If the exception type doesn't match, control goes to the unwind handler
+// which resumes unwinding.
+cir.func @test_try_catch_typed_with_unwind() {
+  %0 = cir.alloca !cir.ptr<!rec_exception>, !cir.ptr<!cir.ptr<!rec_exception>>, ["e"] {alignment = 8 : i64}
+  cir.scope {
+    cir.try {
+      cir.call @mayThrow() : () -> ()
+      cir.yield
+    } catch [type #cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>] (%eh_token : !cir.eh_token) {
+      %catch_token, %1 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.ptr<!rec_exception>>)
+      cir.end_catch %catch_token : !cir.catch_token
+      cir.yield
+    } unwind (%eh_token : !cir.eh_token) {
+      cir.resume %eh_token : !cir.eh_token
+    }
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_try_catch_typed_with_unwind()
+// CHECK:         %[[E_ALLOCA:.*]] = cir.alloca !cir.ptr<!rec_std3A3Aexception>
+// CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
+//
+// CHECK:       ^[[SCOPE]]:
+// CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
+//
+// Try body: the call becomes try_call.
+// CHECK:       ^[[TRY_BODY]]:
+// CHECK:         cir.try_call @mayThrow() ^[[NORMAL:bb[0-9]+]], ^[[UNWIND:bb[0-9]+]]
+//
+// CHECK:       ^[[NORMAL]]:
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+//
+// Typed catch handler: receives eh_token.
+// CHECK:       ^[[CATCH_TYPED:bb[0-9]+]](%[[CT_ET:.*]]: !cir.eh_token):
+// CHECK:         %[[CT:.*]], %[[EXN:.*]] = cir.begin_catch %[[CT_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.ptr<!rec_std3A3Aexception>>)
+// CHECK:         cir.end_catch %[[CT]] : !cir.catch_token
+// CHECK:         cir.br ^[[CONTINUE]]
+//
+// Unwind handler: continues unwinding.
+// CHECK:       ^[[UNWIND_HANDLER:bb[0-9]+]](%[[UW_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.resume %[[UW_ET]] : !cir.eh_token
+//
+// Catch dispatch: dispatches to typed handler or unwind.
+// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch(#cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>) : ^[[CATCH_TYPED]],
+// CHECK:           unwind : ^[[UNWIND_HANDLER]]
+// CHECK:         ]
+//
+// Unwind block (from try_call).
+// CHECK:       ^[[UNWIND]]:
+// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH]](%[[EH_TOK]] : !cir.eh_token)
+//
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.br ^{{.*}}
+// CHECK:         cir.return
+
+// Test: try-catch with cleanup inside the try body.
+// The cleanup scope is flattened first. The inner EH cleanup resume ops
+// are chained to the catch dispatch block of the enclosing try.
+cir.func @test_try_catch_with_cleanup() {
+  cir.scope {
+    %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+    cir.try {
+      cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.cleanup.scope {
+        cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+        cir.yield
+      } cleanup all {
+        cir.call @dtor(%0) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
+        cir.yield
+      }
+      cir.yield
+    } catch all (%eh_token : !cir.eh_token) {
+      %catch_token, %1 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.void>)
+      cir.end_catch %catch_token : !cir.catch_token
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_try_catch_with_cleanup()
+// CHECK:         %[[C:.*]] = cir.alloca !rec_SomeClass
+//
+// The try body: ctor call becomes try_call (it may throw, and it's in
+// the try scope). The cleanup scope was already flattened.
+// CHECK:         cir.try_call @ctor(%[[C]]) ^[[AFTER_CTOR:bb[0-9]+]], ^{{bb[0-9]+}}
+//
+// After ctor, enter the cleanup scope body.
+// CHECK:       ^[[AFTER_CTOR]]:
+// CHECK:         cir.br ^[[CLEANUP_BODY:bb[0-9]+]]
+//
+// Cleanup body: doSomething is try_call'd (from cleanup scope flattening).
+// CHECK:       ^[[CLEANUP_BODY]]:
+// CHECK:         cir.try_call @doSomething(%[[C]]) ^[[AFTER_DO:bb[0-9]+]], ^[[INNER_UNWIND:bb[0-9]+]]
+//
+// After doSomething, normal cleanup.
+// CHECK:       ^[[AFTER_DO]]:
+// CHECK:         cir.br ^[[NORMAL_CLEANUP:bb[0-9]+]]
+//
+// Normal cleanup: call dtor, then branch to exit.
+// CHECK:       ^[[NORMAL_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.br ^[[CLEANUP_EXIT:bb[0-9]+]]
+//
+// Cleanup exit: branch to try body yield -> continue.
+// CHECK:       ^[[CLEANUP_EXIT]]:
+// CHECK:         cir.br ^[[TRY_EXIT:bb[0-9]+]]
+//
+// Inner unwind block (from cleanup scope flattening).
+// CHECK:       ^[[INNER_UNWIND]]:
+// CHECK:         %[[INNER_EH:.*]] = cir.eh.initiate cleanup : !cir.eh_token
+// CHECK:         cir.br ^[[EH_CLEANUP:bb[0-9]+]](%[[INNER_EH]] : !cir.eh_token)
+//
+// EH cleanup block: begin_cleanup, dtor, end_cleanup, then chained to
+// the catch dispatch (resume was replaced by try op flattening).
+// CHECK:       ^[[EH_CLEANUP]](%[[EH_CT:.*]]: !cir.eh_token):
+// CHECK:         %[[CT:.*]] = cir.begin_cleanup %[[EH_CT]] : !cir.eh_token -> !cir.cleanup_token
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.end_cleanup %[[CT]] : !cir.cleanup_token
+// CHECK:         cir.br ^[[DISPATCH:bb[0-9]+]](%[[EH_CT]] : !cir.eh_token)
+//
+// Try exit: branches to continue block after try.
+// CHECK:       ^[[TRY_EXIT]]:
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+//
+// Catch-all handler.
+// CHECK:       ^[[CATCH_ALL:bb[0-9]+]](%[[CA_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[CA_ET]]
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[CONTINUE]]
+//
+// Catch dispatch block.
+// CHECK:       ^[[DISPATCH]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch_all : ^[[CATCH_ALL]]
+// CHECK:         ]
+//
+// Unwind block (from try_call of ctor).
+// CHECK:       ^{{bb[0-9]+}}:
+// CHECK:         %[[CTOR_EH:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH]](%[[CTOR_EH]] : !cir.eh_token)
+//
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.br ^{{.*}}
+// CHECK:         cir.return
+
+// Test: try-catch within a cleanup scope.
+// The try is nested inside a cleanup scope. If an exception is not caught
+// by the try's handlers, the resume from the unwind handler should chain
+// to the outer cleanup's EH handler.
+cir.func @test_try_in_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  %1 = cir.alloca !cir.ptr<!rec_exception>, !cir.ptr<!cir.ptr<!rec_exception>>, ["e"] {alignment = 8 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.scope {
+      cir.try {
+        cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+        cir.yield
+      } catch [type #cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>] (%eh_token : !cir.eh_token) {
+        %catch_token, %2 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.ptr<!rec_exception>>)
+        cir.end_catch %catch_token : !cir.catch_token
+        cir.yield
+      } unwind (%eh_token : !cir.eh_token) {
+        cir.resume %eh_token : !cir.eh_token
+      }
+    }
+    cir.yield
+  } cleanup all {
+    cir.call @dtor(%0) nothrow : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_try_in_cleanup()
+// CHECK:         %[[C:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         %[[E:.*]] = cir.alloca !cir.ptr<!rec_std3A3Aexception>
+// CHECK:         cir.call @ctor(%[[C]])
+//
+// Outer cleanup body starts.
+// CHECK:         cir.br ^[[OUTER_BODY:bb[0-9]+]]
+//
+// Body contains the scope -> try. The try's call becomes try_call.
+// CHECK:       ^[[OUTER_BODY]]:
+// CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
+// CHECK:       ^[[SCOPE]]:
+// CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
+//
+// CHECK:       ^[[TRY_BODY]]:
+// CHECK:         cir.try_call @doSomething(%[[C]]) ^[[NORMAL:bb[0-9]+]], ^[[TRY_UNWIND:bb[0-9]+]]
+//
+// Normal path.
+// CHECK:       ^[[NORMAL]]:
+// CHECK:         cir.br ^[[TRY_CONT:bb[0-9]+]]
+//
+// Typed catch handler.
+// CHECK:       ^[[CATCH:bb[0-9]+]](%[[CATCH_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[CATCH_ET]]
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[TRY_CONT]]
+//
+// Unwind handler: resume is chained to the outer EH cleanup by the
+// outer cleanup scope flattening.
+// CHECK:       ^[[UNWIND_HANDLER:bb[0-9]+]](%[[UW_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.br ^[[OUTER_EH_CLEANUP:bb[0-9]+]](%[[UW_ET]] : !cir.eh_token)
+//
+// Catch dispatch.
+// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch(#cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>) : ^[[CATCH]],
+// CHECK:           unwind : ^[[UNWIND_HANDLER]]
+// CHECK:         ]
+//
+// Try's unwind block.
+// CHECK:       ^[[TRY_UNWIND]]:
+// CHECK:         %[[TRY_EH:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH]](%[[TRY_EH]] : !cir.eh_token)
+//
+// After the try, normal flow continues.
+// CHECK:       ^[[TRY_CONT]]:
+// CHECK:         cir.br ^{{.*}}
+//
+// The outer cleanup scope's normal cleanup: call dtor.
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+//
+// The outer EH cleanup: call dtor, then resume.
+// CHECK:       ^[[OUTER_EH_CLEANUP]](%[[OEH_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}} = cir.begin_cleanup %[[OEH_ET]]
+// CHECK:         cir.call @dtor(%[[C]]) nothrow
+// CHECK:         cir.end_cleanup
+// CHECK:         cir.resume %[[OEH_ET]] : !cir.eh_token
+//
+// CHECK:         cir.return
+
+// Test: try with catch all and no throwing calls.
+// The try body doesn't have throwing calls, so no try_call/unwind blocks are
+// needed. The handlers are still built but won't be reachable.
+cir.func @test_try_catch_all_no_throwing_calls() {
+  cir.scope {
+    cir.try {
+      %0 = cir.const #cir.int<42> : !s32i
+      cir.yield
+    } catch all (%eh_token : !cir.eh_token) {
+      %catch_token, %exn_ptr = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.void>)
+      cir.end_catch %catch_token : !cir.catch_token
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_try_catch_all_no_throwing_calls()
+// The body is inlined. Dispatch block and handler block are created
+// but no unwind blocks since no calls were rewritten to try_call.
+// CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
+// CHECK:       ^[[SCOPE]]:
+// CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
+// CHECK:       ^[[TRY_BODY]]:
+// CHECK:         %{{.*}} = cir.const #cir.int<42>
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+// CHECK:       ^[[CATCH_ALL:bb[0-9]+]](%{{.*}}: !cir.eh_token):
+// CHECK:         cir.begin_catch
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[CONTINUE]]
+// CHECK:       ^{{bb[0-9]+}}(%{{.*}}: !cir.eh_token):
+// CHECK:         cir.eh.dispatch
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.br ^{{.*}}
+// CHECK:         cir.return
+
+// Test: try-catch with multiple typed handlers and catch-all.
+cir.func @test_try_multiple_handlers() {
+  cir.scope {
+    cir.try {
+      cir.call @mayThrow() : () -> ()
+      cir.yield
+    } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] (%eh_token : !cir.eh_token) {
+      %ct1, %exn1 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
+      cir.end_catch %ct1 : !cir.catch_token
+      cir.yield
+    } catch all (%eh_token : !cir.eh_token) {
+      %ct2, %exn2 = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.void>)
+      cir.end_catch %ct2 : !cir.catch_token
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_try_multiple_handlers()
+// CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
+// CHECK:       ^[[SCOPE]]:
+// CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
+//
+// Try body: call becomes try_call.
+// CHECK:       ^[[TRY_BODY]]:
+// CHECK:         cir.try_call @mayThrow() ^[[NORMAL:bb[0-9]+]], ^[[UNWIND:bb[0-9]+]]
+//
+// CHECK:       ^[[NORMAL]]:
+// CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
+//
+// Int catch handler.
+// CHECK:       ^[[CATCH_INT:bb[0-9]+]](%[[INT_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[INT_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[CONTINUE]]
+//
+// Catch-all handler.
+// CHECK:       ^[[CATCH_ALL:bb[0-9]+]](%[[ALL_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[ALL_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[CONTINUE]]
+//
+// Dispatch: routes to int handler or catch-all.
+// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch(#cir.global_view<@_ZTIi> : !cir.ptr<!u8i>) : ^[[CATCH_INT]],
+// CHECK:           catch_all : ^[[CATCH_ALL]]
+// CHECK:         ]
+//
+// Unwind block.
+// CHECK:       ^[[UNWIND]]:
+// CHECK:         %[[EH_TOK:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[DISPATCH]](%[[EH_TOK]] : !cir.eh_token)
+//
+// CHECK:       ^[[CONTINUE]]:
+// CHECK:         cir.br ^{{.*}}
+// CHECK:         cir.return
+
+cir.func private @mayThrow()
+cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
+cir.func private @dtor(!cir.ptr<!rec_SomeClass>) attributes {nothrow}
+cir.func private @doSomething(!cir.ptr<!rec_SomeClass>)
+cir.global "private" constant external @_ZTISt9exception : !cir.ptr<!u8i>
+cir.global "private" constant external @_ZTIi : !cir.ptr<!u8i>

--- a/clang/test/CIR/Transforms/flatten-try-op.cir
+++ b/clang/test/CIR/Transforms/flatten-try-op.cir
@@ -65,17 +65,17 @@ cir.func @test_try_catch_all() {
 // CHECK:       ^[[NORMAL]]:
 // CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
 //
-// Catch-all handler block: receives eh_token, does begin_catch/end_catch.
-// CHECK:       ^[[CATCH_ALL:bb[0-9]+]](%[[ET:.*]]: !cir.eh_token):
-// CHECK:         %[[CT:.*]], %[[EXN:.*]] = cir.begin_catch %[[ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
-// CHECK:         cir.end_catch %[[CT]] : !cir.catch_token
-// CHECK:         cir.br ^[[CONTINUE]]
-//
 // Catch dispatch: dispatches to catch-all.
 // CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
-// CHECK:           catch_all : ^[[CATCH_ALL]]
+// CHECK:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
 // CHECK:         ]
+//
+// Catch-all handler block: receives eh_token, does begin_catch/end_catch.
+// CHECK:       ^[[CATCH_ALL]](%[[ET:.*]]: !cir.eh_token):
+// CHECK:         %[[CT:.*]], %[[EXN:.*]] = cir.begin_catch %[[ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+// CHECK:         cir.end_catch %[[CT]] : !cir.catch_token
+// CHECK:         cir.br ^[[CONTINUE]]
 //
 // Unwind block.
 // CHECK:       ^[[UNWIND]]:
@@ -121,22 +121,22 @@ cir.func @test_try_catch_typed_with_unwind() {
 // CHECK:       ^[[NORMAL]]:
 // CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
 //
+// Catch dispatch: dispatches to typed handler or unwind.
+// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch(#cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>) : ^[[CATCH_TYPED:bb[0-9]+]],
+// CHECK:           unwind : ^[[UNWIND_HANDLER:bb[0-9]+]]
+// CHECK:         ]
+//
 // Typed catch handler: receives eh_token.
-// CHECK:       ^[[CATCH_TYPED:bb[0-9]+]](%[[CT_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[CATCH_TYPED]](%[[CT_ET:.*]]: !cir.eh_token):
 // CHECK:         %[[CT:.*]], %[[EXN:.*]] = cir.begin_catch %[[CT_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.ptr<!rec_std3A3Aexception>>)
 // CHECK:         cir.end_catch %[[CT]] : !cir.catch_token
 // CHECK:         cir.br ^[[CONTINUE]]
 //
 // Unwind handler: continues unwinding.
-// CHECK:       ^[[UNWIND_HANDLER:bb[0-9]+]](%[[UW_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[UNWIND_HANDLER]](%[[UW_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.resume %[[UW_ET]] : !cir.eh_token
-//
-// Catch dispatch: dispatches to typed handler or unwind.
-// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
-// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
-// CHECK:           catch(#cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>) : ^[[CATCH_TYPED]],
-// CHECK:           unwind : ^[[UNWIND_HANDLER]]
-// CHECK:         ]
 //
 // Unwind block (from try_call).
 // CHECK:       ^[[UNWIND]]:
@@ -217,17 +217,17 @@ cir.func @test_try_catch_with_cleanup() {
 // CHECK:       ^[[TRY_EXIT]]:
 // CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
 //
-// Catch-all handler.
-// CHECK:       ^[[CATCH_ALL:bb[0-9]+]](%[[CA_ET:.*]]: !cir.eh_token):
-// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[CA_ET]]
-// CHECK:         cir.end_catch
-// CHECK:         cir.br ^[[CONTINUE]]
-//
 // Catch dispatch block.
 // CHECK:       ^[[DISPATCH]](%[[DISP_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
-// CHECK:           catch_all : ^[[CATCH_ALL]]
+// CHECK:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
 // CHECK:         ]
+//
+// Catch-all handler.
+// CHECK:       ^[[CATCH_ALL]](%[[CA_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[CA_ET]]
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[CONTINUE]]
 //
 // Unwind block (from try_call of ctor).
 // CHECK:       ^{{bb[0-9]+}}:
@@ -288,23 +288,23 @@ cir.func @test_try_in_cleanup() {
 // CHECK:       ^[[NORMAL]]:
 // CHECK:         cir.br ^[[TRY_CONT:bb[0-9]+]]
 //
+// Catch dispatch.
+// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch(#cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>) : ^[[CATCH:bb[0-9]+]],
+// CHECK:           unwind : ^[[UNWIND_HANDLER:bb[0-9]+]]
+// CHECK:         ]
+//
 // Typed catch handler.
-// CHECK:       ^[[CATCH:bb[0-9]+]](%[[CATCH_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[CATCH]](%[[CATCH_ET:.*]]: !cir.eh_token):
 // CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[CATCH_ET]]
 // CHECK:         cir.end_catch
 // CHECK:         cir.br ^[[TRY_CONT]]
 //
 // Unwind handler: resume is chained to the outer EH cleanup by the
 // outer cleanup scope flattening.
-// CHECK:       ^[[UNWIND_HANDLER:bb[0-9]+]](%[[UW_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[UNWIND_HANDLER]](%[[UW_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.br ^[[OUTER_EH_CLEANUP:bb[0-9]+]](%[[UW_ET]] : !cir.eh_token)
-//
-// Catch dispatch.
-// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
-// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
-// CHECK:           catch(#cir.global_view<@_ZTISt9exception> : !cir.ptr<!u8i>) : ^[[CATCH]],
-// CHECK:           unwind : ^[[UNWIND_HANDLER]]
-// CHECK:         ]
 //
 // Try's unwind block.
 // CHECK:       ^[[TRY_UNWIND]]:
@@ -350,17 +350,27 @@ cir.func @test_try_catch_all_no_throwing_calls() {
 // CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
 // CHECK:       ^[[SCOPE]]:
 // CHECK:         cir.br ^[[TRY_BODY:bb[0-9]+]]
+//
+// Try body: no throwing calls, so no try_call.
 // CHECK:       ^[[TRY_BODY]]:
-// CHECK:         %{{.*}} = cir.const #cir.int<42>
+// CHECK:         %{{.*}} = cir.const #cir.int<42> : !s32i
 // CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
-// CHECK:       ^[[CATCH_ALL:bb[0-9]+]](%{{.*}}: !cir.eh_token):
-// CHECK:         cir.begin_catch
-// CHECK:         cir.end_catch
+//
+// Catch dispatch (unreachable since there are no throwing calls).
+// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
+// CHECK:         ]
+//
+// Catch-all handler (unreachable).
+// CHECK:       ^[[CATCH_ALL]](%[[ET:.*]]: !cir.eh_token):
+// CHECK:         %[[CT:.*]], %{{.*}} = cir.begin_catch %[[ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+// CHECK:         cir.end_catch %[[CT]] : !cir.catch_token
 // CHECK:         cir.br ^[[CONTINUE]]
-// CHECK:       ^{{bb[0-9]+}}(%{{.*}}: !cir.eh_token):
-// CHECK:         cir.eh.dispatch
+//
 // CHECK:       ^[[CONTINUE]]:
-// CHECK:         cir.br ^{{.*}}
+// CHECK:         cir.br ^[[SCOPE_EXIT:bb[0-9]+]]
+// CHECK:       ^[[SCOPE_EXIT]]:
 // CHECK:         cir.return
 
 // Test: try-catch with multiple typed handlers and catch-all.
@@ -394,24 +404,24 @@ cir.func @test_try_multiple_handlers() {
 // CHECK:       ^[[NORMAL]]:
 // CHECK:         cir.br ^[[CONTINUE:bb[0-9]+]]
 //
+// Dispatch: routes to int handler or catch-all.
+// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
+// CHECK:           catch(#cir.global_view<@_ZTIi> : !cir.ptr<!u8i>) : ^[[CATCH_INT:bb[0-9]+]],
+// CHECK:           catch_all : ^[[CATCH_ALL:bb[0-9]+]]
+// CHECK:         ]
+//
 // Int catch handler.
-// CHECK:       ^[[CATCH_INT:bb[0-9]+]](%[[INT_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[CATCH_INT]](%[[INT_ET:.*]]: !cir.eh_token):
 // CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[INT_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
 // CHECK:         cir.end_catch
 // CHECK:         cir.br ^[[CONTINUE]]
 //
 // Catch-all handler.
-// CHECK:       ^[[CATCH_ALL:bb[0-9]+]](%[[ALL_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[CATCH_ALL]](%[[ALL_ET:.*]]: !cir.eh_token):
 // CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[ALL_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
 // CHECK:         cir.end_catch
 // CHECK:         cir.br ^[[CONTINUE]]
-//
-// Dispatch: routes to int handler or catch-all.
-// CHECK:       ^[[DISPATCH:bb[0-9]+]](%[[DISP_ET:.*]]: !cir.eh_token):
-// CHECK:         cir.eh.dispatch %[[DISP_ET]] : !cir.eh_token [
-// CHECK:           catch(#cir.global_view<@_ZTIi> : !cir.ptr<!u8i>) : ^[[CATCH_INT]],
-// CHECK:           catch_all : ^[[CATCH_ALL]]
-// CHECK:         ]
 //
 // Unwind block.
 // CHECK:       ^[[UNWIND]]:
@@ -465,22 +475,22 @@ cir.func @test_nested_try() {
 // CHECK:       ^[[INNER_NORMAL]]:
 // CHECK:         cir.br ^[[INNER_CONTINUE:bb[0-9]+]]
 //
+// Inner catch dispatch.
+// CHECK:       ^[[INNER_DISPATCH:bb[0-9]+]](%[[ID_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[ID_ET]] : !cir.eh_token [
+// CHECK:           catch(#cir.global_view<@_ZTIi> : !cir.ptr<!u8i>) : ^[[INNER_CATCH:bb[0-9]+]],
+// CHECK:           unwind : ^[[INNER_UW_HANDLER:bb[0-9]+]]
+// CHECK:         ]
+//
 // Inner typed catch handler.
-// CHECK:       ^[[INNER_CATCH:bb[0-9]+]](%[[IC_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[INNER_CATCH]](%[[IC_ET:.*]]: !cir.eh_token):
 // CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[IC_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
 // CHECK:         cir.end_catch
 // CHECK:         cir.br ^[[INNER_CONTINUE]]
 //
 // Inner unwind handler: resume was chained to the outer catch dispatch.
-// CHECK:       ^[[INNER_UW_HANDLER:bb[0-9]+]](%[[IUW_ET:.*]]: !cir.eh_token):
+// CHECK:       ^[[INNER_UW_HANDLER]](%[[IUW_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.br ^[[OUTER_DISPATCH:bb[0-9]+]](%[[IUW_ET]] : !cir.eh_token)
-//
-// Inner catch dispatch.
-// CHECK:       ^[[INNER_DISPATCH:bb[0-9]+]](%[[ID_ET:.*]]: !cir.eh_token):
-// CHECK:         cir.eh.dispatch %[[ID_ET]] : !cir.eh_token [
-// CHECK:           catch(#cir.global_view<@_ZTIi> : !cir.ptr<!u8i>) : ^[[INNER_CATCH]],
-// CHECK:           unwind : ^[[INNER_UW_HANDLER]]
-// CHECK:         ]
 //
 // Inner unwind block (from try_call).
 // CHECK:       ^[[INNER_UNWIND]]:
@@ -491,17 +501,17 @@ cir.func @test_nested_try() {
 // CHECK:       ^[[INNER_CONTINUE]]:
 // CHECK:         cir.br ^[[OUTER_CONTINUE:bb[0-9]+]]
 //
-// Outer catch-all handler.
-// CHECK:       ^[[OUTER_CATCH:bb[0-9]+]](%[[OC_ET:.*]]: !cir.eh_token):
-// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[OC_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
-// CHECK:         cir.end_catch
-// CHECK:         cir.br ^[[OUTER_CONTINUE]]
-//
 // Outer catch dispatch.
 // CHECK:       ^[[OUTER_DISPATCH]](%[[OD_ET:.*]]: !cir.eh_token):
 // CHECK:         cir.eh.dispatch %[[OD_ET]] : !cir.eh_token [
-// CHECK:           catch_all : ^[[OUTER_CATCH]]
+// CHECK:           catch_all : ^[[OUTER_CATCH:bb[0-9]+]]
 // CHECK:         ]
+//
+// Outer catch-all handler.
+// CHECK:       ^[[OUTER_CATCH]](%[[OC_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[OC_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[OUTER_CONTINUE]]
 //
 // CHECK:       ^[[OUTER_CONTINUE]]:
 // CHECK:         cir.br ^{{.*}}

--- a/clang/test/CIR/Transforms/flatten-try-op.cir
+++ b/clang/test/CIR/Transforms/flatten-try-op.cir
@@ -422,6 +422,91 @@ cir.func @test_try_multiple_handlers() {
 // CHECK:         cir.br ^{{.*}}
 // CHECK:         cir.return
 
+// Test: nested try ops.
+// The inner try is flattened first. Its unwind handler's resume is then
+// chained to the outer try's catch dispatch when the outer try is flattened.
+cir.func @test_nested_try() {
+  cir.scope {
+    cir.try {
+      cir.try {
+        cir.call @mayThrow() : () -> ()
+        cir.yield
+      } catch [type #cir.global_view<@_ZTIi> : !cir.ptr<!u8i>] (%eh_token : !cir.eh_token) {
+        %ct, %exn = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
+        cir.end_catch %ct : !cir.catch_token
+        cir.yield
+      } unwind (%eh_token : !cir.eh_token) {
+        cir.resume %eh_token : !cir.eh_token
+      }
+      cir.yield
+    } catch all (%eh_token : !cir.eh_token) {
+      %ct, %exn = cir.begin_catch %eh_token : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!cir.void>)
+      cir.end_catch %ct : !cir.catch_token
+      cir.yield
+    }
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_nested_try()
+// CHECK:         cir.br ^[[SCOPE:bb[0-9]+]]
+// CHECK:       ^[[SCOPE]]:
+// CHECK:         cir.br ^[[OUTER_BODY:bb[0-9]+]]
+//
+// Outer try body: was the inner try, now inlined.
+// CHECK:       ^[[OUTER_BODY]]:
+// CHECK:         cir.br ^[[INNER_BODY:bb[0-9]+]]
+//
+// Inner try body: the call becomes try_call (from inner try flattening).
+// CHECK:       ^[[INNER_BODY]]:
+// CHECK:         cir.try_call @mayThrow() ^[[INNER_NORMAL:bb[0-9]+]], ^[[INNER_UNWIND:bb[0-9]+]]
+//
+// Inner normal path.
+// CHECK:       ^[[INNER_NORMAL]]:
+// CHECK:         cir.br ^[[INNER_CONTINUE:bb[0-9]+]]
+//
+// Inner typed catch handler.
+// CHECK:       ^[[INNER_CATCH:bb[0-9]+]](%[[IC_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[IC_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!s32i>)
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[INNER_CONTINUE]]
+//
+// Inner unwind handler: resume was chained to the outer catch dispatch.
+// CHECK:       ^[[INNER_UW_HANDLER:bb[0-9]+]](%[[IUW_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.br ^[[OUTER_DISPATCH:bb[0-9]+]](%[[IUW_ET]] : !cir.eh_token)
+//
+// Inner catch dispatch.
+// CHECK:       ^[[INNER_DISPATCH:bb[0-9]+]](%[[ID_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[ID_ET]] : !cir.eh_token [
+// CHECK:           catch(#cir.global_view<@_ZTIi> : !cir.ptr<!u8i>) : ^[[INNER_CATCH]],
+// CHECK:           unwind : ^[[INNER_UW_HANDLER]]
+// CHECK:         ]
+//
+// Inner unwind block (from try_call).
+// CHECK:       ^[[INNER_UNWIND]]:
+// CHECK:         %[[IEH:.*]] = cir.eh.initiate : !cir.eh_token
+// CHECK:         cir.br ^[[INNER_DISPATCH]](%[[IEH]] : !cir.eh_token)
+//
+// Inner continue → outer try body yield → outer continue.
+// CHECK:       ^[[INNER_CONTINUE]]:
+// CHECK:         cir.br ^[[OUTER_CONTINUE:bb[0-9]+]]
+//
+// Outer catch-all handler.
+// CHECK:       ^[[OUTER_CATCH:bb[0-9]+]](%[[OC_ET:.*]]: !cir.eh_token):
+// CHECK:         %{{.*}}, %{{.*}} = cir.begin_catch %[[OC_ET]] : !cir.eh_token -> (!cir.catch_token, !cir.ptr<!void>)
+// CHECK:         cir.end_catch
+// CHECK:         cir.br ^[[OUTER_CONTINUE]]
+//
+// Outer catch dispatch.
+// CHECK:       ^[[OUTER_DISPATCH]](%[[OD_ET:.*]]: !cir.eh_token):
+// CHECK:         cir.eh.dispatch %[[OD_ET]] : !cir.eh_token [
+// CHECK:           catch_all : ^[[OUTER_CATCH]]
+// CHECK:         ]
+//
+// CHECK:       ^[[OUTER_CONTINUE]]:
+// CHECK:         cir.br ^{{.*}}
+// CHECK:         cir.return
+
 cir.func private @mayThrow()
 cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
 cir.func private @dtor(!cir.ptr<!rec_SomeClass>) attributes {nothrow}


### PR DESCRIPTION
This updates the FlattenCFG pass to add flattening for cir::TryOp in cases where the TryOp contains catch or unwind handlers.

Substantial amounts of this PR were created using agentic AI tools, but I have carefully reviewed the code, comments, and tests and made changes as needed. I've left intermediate commits in the initial PR if you'd like to see the progression.