### PR TITLE
[CIR][docs] Fix table of contents for CIR eh and cleanups doc

### DIFF
--- a/clang/docs/ClangIRCleanupAndEHDesign.md
+++ b/clang/docs/ClangIRCleanupAndEHDesign.md
@@ -1,7 +1,10 @@
 # ClangIR Cleanup and Exception Handling Design
 
-::: {.contents local=""}
-:::
+```{contents}
+---
+local:
+---
+```
 
 ## Overview
 


### PR DESCRIPTION
When this document was converted from rst to markdown, the contents didn't get updated correctly.