### PR TITLE
[libunwind][PAC] Resign explicitly in loadAndAuthenticateLinkRegister

### DIFF
--- a/libunwind/include/libunwind.h
+++ b/libunwind/include/libunwind.h
@@ -93,8 +93,10 @@
     __unwind_ptrauth_restricted_intptr(ptrauth_key_process_dependent_data, 1, 0x03DF)
 
   // ptrauth_string_discriminator("Registers_arm64::link_reg_t") == 0x8301
+  #define __ptrauth_unwind_registers_arm64_link_reg_disc 0x8301
   #define __ptrauth_unwind_registers_arm64_link_reg \
-    __unwind_ptrauth_restricted_intptr(ptrauth_key_process_dependent_code, 1, 0x8301)
+    __unwind_ptrauth_restricted_intptr(ptrauth_key_process_dependent_code, 1, \
+                                       __ptrauth_unwind_registers_arm64_link_reg_disc)
 
   // ptrauth_string_discriminator("UnwindInfoSections::dso_base") == 0x4FF5
   #define __ptrauth_unwind_uis_dso_base \

--- a/libunwind/src/Registers.hpp
+++ b/libunwind/src/Registers.hpp
@@ -1964,7 +1964,10 @@ private:
     uint64_t __fp = 0;            // Frame pointer x29
     uint64_t __lr = 0;            // Link register x30
     uint64_t __sp = 0;            // Stack pointer x31
-    uint64_t __pc = 0;            // Program counter
+    // Program counter.
+    // When PtrAuth-protected, uses ptrauth_key_return_address with address
+    // discrimination. Zero value must be signed to be valid (see getIP/setIP).
+    uint64_t __pc = 0;
     uint64_t __ra_sign_state = 0; // RA sign state register
   };
 
@@ -2056,8 +2059,12 @@ inline uint64_t Registers_arm64::lazyGetVG() const {
 }
 
 inline uint64_t Registers_arm64::getRegister(int regNum) const {
+  // When _LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING is in effect, the
+  // return value is signed with (ptrauth_key_return_address, getSP()) schema
+  // with 0 value signed as any other value.
   if (regNum == UNW_REG_IP || regNum == UNW_AARCH64_PC)
     return getIP();
+
   if (regNum == UNW_REG_SP || regNum == UNW_AARCH64_SP)
     return _registers.__sp;
   if (regNum == UNW_AARCH64_RA_SIGN_STATE)
@@ -2074,8 +2081,12 @@ inline uint64_t Registers_arm64::getRegister(int regNum) const {
 }
 
 inline void Registers_arm64::setRegister(int regNum, uint64_t value) {
+  // When _LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING is in effect,
+  // `value` must be signed with (ptrauth_key_return_address, getSP()) schema
+  // with 0 value signed as any other value.
   if (regNum == UNW_REG_IP || regNum == UNW_AARCH64_PC)
     setIP(value);
+
   else if (regNum == UNW_REG_SP || regNum == UNW_AARCH64_SP)
     _registers.__sp = value;
   else if (regNum == UNW_AARCH64_RA_SIGN_STATE)

--- a/libunwind/src/Registers.hpp
+++ b/libunwind/src/Registers.hpp
@@ -1919,14 +1919,14 @@ public:
   void setFP(uint64_t value) { _registers.__fp = value; }
 
 #if defined(_LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING)
-  void loadAndResignIP(link_hardened_reg_arg_t result) {
+  void loadAndResignIP(link_reg_t *output) {
     // Make sure that zero result is written as all zero bits, as implicitly
     // assumed for __ptrauth-qualified types.
     // FIXME Drop this hack when options support for __ptrauth qualifier
     //       will be implemented.
     if (0 == ptrauth_auth_data((void *)_registers.__pc,
                                ptrauth_key_return_address, &_registers.__pc)) {
-      memset((void *)&result, 0, sizeof(result));
+      memset((void *)output, 0, sizeof(*output));
       return;
     }
 
@@ -1938,11 +1938,11 @@ public:
     // as the latter results in comparison against 0 between auth and sign
     // operations.
     const auto newDiscriminator = ptrauth_blend_discriminator(
-        &result, __ptrauth_unwind_registers_arm64_link_reg_disc);
+        output, __ptrauth_unwind_registers_arm64_link_reg_disc);
     reg_t resigned = (reg_t)ptrauth_auth_and_resign(
         (void *)_registers.__pc, ptrauth_key_return_address, &_registers.__pc,
         ptrauth_key_return_address, newDiscriminator);
-    memcpy((void *)&result, &resigned, sizeof(resigned));
+    memcpy((void *)output, &resigned, sizeof(resigned));
   }
 #endif
 

--- a/libunwind/src/Registers.hpp
+++ b/libunwind/src/Registers.hpp
@@ -1922,6 +1922,17 @@ public:
   void
   loadAndAuthenticateLinkRegister(reg_t inplaceAuthedLinkRegister,
                                   link_reg_t *referenceAuthedLinkRegister) {
+    // Make sure that zero result is written as all zero bits, as implicitly
+    // assumed for __ptrauth-qualified types.
+    // FIXME Drop this hack when options support for __ptrauth qualifier
+    //       will be implemented.
+    if (0 == ptrauth_auth_data((void *)inplaceAuthedLinkRegister,
+                               ptrauth_key_return_address, _registers.__sp)) {
+      memset((void *)referenceAuthedLinkRegister, 0,
+             sizeof(referenceAuthedLinkRegister));
+      return;
+    }
+
     // In arm64e or pauthtest ABI frame, the PC should have been signed with
     // the SP - resign it with a schema that can be represented with __ptrauth.
     //

--- a/libunwind/src/Registers.hpp
+++ b/libunwind/src/Registers.hpp
@@ -1940,8 +1940,8 @@ public:
     const auto newDiscriminator = ptrauth_blend_discriminator(
         &result, __ptrauth_unwind_registers_arm64_link_reg_disc);
     reg_t resigned = (reg_t)ptrauth_auth_and_resign(
-        (void *)_registers.__pc, ptrauth_key_return_address,
-        &_registers.__pc, ptrauth_key_return_address, newDiscriminator);
+        (void *)_registers.__pc, ptrauth_key_return_address, &_registers.__pc,
+        ptrauth_key_return_address, newDiscriminator);
     memcpy((void *)&result, &resigned, sizeof(resigned));
   }
 #endif

--- a/libunwind/src/Registers.hpp
+++ b/libunwind/src/Registers.hpp
@@ -1922,12 +1922,20 @@ public:
   void
   loadAndAuthenticateLinkRegister(reg_t inplaceAuthedLinkRegister,
                                   link_reg_t *referenceAuthedLinkRegister) {
-    // If we are in an arm64/arm64e frame, then the PC should have been signed
-    // with the SP
-    *referenceAuthedLinkRegister =
-      (uint64_t)ptrauth_auth_data((void *)inplaceAuthedLinkRegister,
-                                  ptrauth_key_return_address,
-                                  _registers.__sp);
+    // In arm64e or pauthtest ABI frame, the PC should have been signed with
+    // the SP - resign it with a schema that can be represented with __ptrauth.
+    //
+    // Call the resign builtin explicitly instead of relying on implicit signing
+    // of the authenticated value on assignment to *referenceAuthedLinkRegister,
+    // as the latter results in comparison against 0 between auth and sign
+    // operations.
+    const auto newDiscriminator = ptrauth_blend_discriminator(
+        referenceAuthedLinkRegister,
+        __ptrauth_unwind_registers_arm64_link_reg_disc);
+    reg_t resigned = (reg_t)ptrauth_auth_and_resign(
+        (void *)inplaceAuthedLinkRegister, ptrauth_key_return_address,
+        _registers.__sp, ptrauth_key_return_address, newDiscriminator);
+    memcpy((void *)referenceAuthedLinkRegister, &resigned, sizeof(resigned));
   }
 #endif
 

--- a/libunwind/src/Registers.hpp
+++ b/libunwind/src/Registers.hpp
@@ -1919,34 +1919,30 @@ public:
   void setFP(uint64_t value) { _registers.__fp = value; }
 
 #if defined(_LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING)
-  void
-  loadAndAuthenticateLinkRegister(reg_t inplaceAuthedLinkRegister,
-                                  link_reg_t *referenceAuthedLinkRegister) {
+  void loadAndResignIP(link_hardened_reg_arg_t result) {
     // Make sure that zero result is written as all zero bits, as implicitly
     // assumed for __ptrauth-qualified types.
     // FIXME Drop this hack when options support for __ptrauth qualifier
     //       will be implemented.
-    if (0 == ptrauth_auth_data((void *)inplaceAuthedLinkRegister,
-                               ptrauth_key_return_address, _registers.__sp)) {
-      memset((void *)referenceAuthedLinkRegister, 0,
-             sizeof(referenceAuthedLinkRegister));
+    if (0 == ptrauth_auth_data((void *)_registers.__pc,
+                               ptrauth_key_return_address, &_registers.__pc)) {
+      memset((void *)&result, 0, sizeof(result));
       return;
     }
 
-    // In arm64e or pauthtest ABI frame, the PC should have been signed with
-    // the SP - resign it with a schema that can be represented with __ptrauth.
+    // _registers.__pc is signed with its storage address as the discriminator,
+    // with zero values signed as any other values.
     //
     // Call the resign builtin explicitly instead of relying on implicit signing
     // of the authenticated value on assignment to *referenceAuthedLinkRegister,
     // as the latter results in comparison against 0 between auth and sign
     // operations.
     const auto newDiscriminator = ptrauth_blend_discriminator(
-        referenceAuthedLinkRegister,
-        __ptrauth_unwind_registers_arm64_link_reg_disc);
+        &result, __ptrauth_unwind_registers_arm64_link_reg_disc);
     reg_t resigned = (reg_t)ptrauth_auth_and_resign(
-        (void *)inplaceAuthedLinkRegister, ptrauth_key_return_address,
-        _registers.__sp, ptrauth_key_return_address, newDiscriminator);
-    memcpy((void *)referenceAuthedLinkRegister, &resigned, sizeof(resigned));
+        (void *)_registers.__pc, ptrauth_key_return_address,
+        &_registers.__pc, ptrauth_key_return_address, newDiscriminator);
+    memcpy((void *)&result, &resigned, sizeof(resigned));
   }
 #endif
 

--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -1069,12 +1069,11 @@ private:
                                const UnwindInfoSections &sects,
                                uint32_t fdeSectionOffsetHint = 0);
   int stepWithDwarfFDE(bool stage2) {
-#if defined(_LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING)
-    typename R::reg_t rawPC = this->getReg(UNW_REG_IP);
     typename R::link_reg_t pc;
-    _registers.loadAndAuthenticateLinkRegister(rawPC, &pc);
+#if defined(_LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING)
+    _registers.loadAndResignIP(pc);
 #else
-    typename R::link_reg_t pc = this->getReg(UNW_REG_IP);
+    pc = this->getReg(UNW_REG_IP);
 #endif
     return DwarfInstructions<A, R>::stepWithDwarf(
         _addressSpace, pc, (pint_t)_info.unwind_info, _registers,
@@ -2729,19 +2728,16 @@ void UnwindCursor<A, R>::setInfoBasedOnIPRegister(bool isReturnAddress) {
   _isSigReturn = false;
 #endif
 
-  typename R::reg_t rawPC = this->getReg(UNW_REG_IP);
-
-#if defined(_LIBUNWIND_ARM_EHABI)
-  // Remove the thumb bit so the IP represents the actual instruction address.
-  // This matches the behaviour of _Unwind_GetIP on arm.
-  rawPC &= (pint_t)~0x1;
-#endif
-
   typename R::link_reg_t pc;
 #if defined(_LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING)
-  _registers.loadAndAuthenticateLinkRegister(rawPC, &pc);
+  _registers.loadAndResignIP(pc);
+#elif defined(_LIBUNWIND_ARM_EHABI)
+  pc = this->getReg(UNW_REG_IP);
+  // Remove the thumb bit so the IP represents the actual instruction address.
+  // This matches the behaviour of _Unwind_GetIP on arm.
+  pc &= (pint_t)~0x1;
 #else
-  pc = rawPC;
+  pc = this->getReg(UNW_REG_IP);
 #endif
 
   // Exit early if at the top of the stack.
@@ -3308,12 +3304,11 @@ void UnwindCursor<A, R>::getInfo(unw_proc_info_t *info) {
 template <typename A, typename R>
 bool UnwindCursor<A, R>::getFunctionName(char *buf, size_t bufLen,
                                          unw_word_t *offset) {
-#if defined(_LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING)
-  typename R::reg_t rawPC = this->getReg(UNW_REG_IP);
   typename R::link_reg_t pc;
-  _registers.loadAndAuthenticateLinkRegister(rawPC, &pc);
+#if defined(_LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING)
+  _registers.loadAndResignIP(pc);
 #else
-  typename R::link_reg_t pc = this->getReg(UNW_REG_IP);
+  pc = this->getReg(UNW_REG_IP);
 #endif
   return _addressSpace.template findFunctionName<R>(pc, buf, bufLen, offset);
 }

--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -1071,7 +1071,7 @@ private:
   int stepWithDwarfFDE(bool stage2) {
     typename R::link_reg_t pc;
 #if defined(_LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING)
-    _registers.loadAndResignIP(pc);
+    _registers.loadAndResignIP(&pc);
 #else
     pc = this->getReg(UNW_REG_IP);
 #endif
@@ -2730,7 +2730,7 @@ void UnwindCursor<A, R>::setInfoBasedOnIPRegister(bool isReturnAddress) {
 
   typename R::link_reg_t pc;
 #if defined(_LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING)
-  _registers.loadAndResignIP(pc);
+  _registers.loadAndResignIP(&pc);
 #elif defined(_LIBUNWIND_ARM_EHABI)
   pc = this->getReg(UNW_REG_IP);
   // Remove the thumb bit so the IP represents the actual instruction address.
@@ -3306,7 +3306,7 @@ bool UnwindCursor<A, R>::getFunctionName(char *buf, size_t bufLen,
                                          unw_word_t *offset) {
   typename R::link_reg_t pc;
 #if defined(_LIBUNWIND_TARGET_AARCH64_AUTHENTICATED_UNWINDING)
-  _registers.loadAndResignIP(pc);
+  _registers.loadAndResignIP(&pc);
 #else
   pc = this->getReg(UNW_REG_IP);
 #endif


### PR DESCRIPTION
Explicitly call `ptrauth_auth_and_resign` to prevent separate auth and sign intrinsics being emitted by Clang frontend.

Even if replacing separate "auth" and "sign" operations with a safer "resign" would be implemented in LLVM optimizer pipeline, Clang frontend treats zero pointer as a special case w.r.t. PtrAuth. This results in such combination of an explicit authentication and an implicit signing to be emitted as a hard-to-simplify comparison against zero along these lines:

    tmp = auth(input)
    if (tmp == 0)
      *output = sign(tmp)
    else
      *output = 0