### PR TITLE
build: correct `MSVC` and Windows mixup for `CLANG_BUILD_STATIC`

### DIFF
--- a/clang/cmake/modules/AddClang.cmake
+++ b/clang/cmake/modules/AddClang.cmake
@@ -108,7 +108,7 @@ macro(add_clang_library name)
   endif()
   llvm_add_library(${name} ${LIBTYPE} ${ARG_UNPARSED_ARGUMENTS} ${srcs})
 
-  if(MSVC AND NOT CLANG_LINK_CLANG_DYLIB)
+  if((WIN32 AND NOT MINGW) AND NOT CLANG_LINK_CLANG_DYLIB)
     # Make sure all consumers also turn off visibility macros so they're not
     # trying to dllimport symbols.
     target_compile_definitions(${name} PUBLIC CLANG_BUILD_STATIC)


### PR DESCRIPTION
The build incorrectly used `MSVC` to determine that we were building for Windows (MS ABI). This prevents the use of the GNU driver for building LLVM for Windows. Adjust the condition to `WIN32 AND NOT MINGW` to correctly identify that we are building for Windows MS ABI.