### PR TITLE
[mlir][rocdl] Add `InferIntRangeInterface` to readlane operations.

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLDialect.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLDialect.h
@@ -26,6 +26,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/InferIntRangeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 ///// Ops /////

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -15,6 +15,7 @@
 
 include "mlir/Dialect/GPU/IR/CompilationAttrInterfaces.td"
 include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
+include "mlir/Interfaces/InferIntRangeInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
@@ -381,7 +382,10 @@ def ROCDL_BallotOp :
   let assemblyFormat = "$pred attr-dict `:` type($res)";
 }
 
-def ROCDL_ReadfirstlaneOp : ROCDL_IntrOp<"readfirstlane", [], [0], [AllTypesMatch<["res", "src"]>], 1>,
+def ROCDL_ReadfirstlaneOp : ROCDL_IntrOp<"readfirstlane", [], [0],
+  [AllTypesMatch<["res", "src"]>,
+   DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>],
+  1>,
   Arguments<(ins LLVM_Type:$src)> {
   let results = (outs LLVM_Type:$res);
   let summary = "Get the value in first active lane.";
@@ -402,9 +406,20 @@ def ROCDL_ReadfirstlaneOp : ROCDL_IntrOp<"readfirstlane", [], [0], [AllTypesMatc
   let assemblyFormat = [{
     $src attr-dict `:` type($res)
   }];
+
+  let extraClassDefinition = [{
+    void $cppClass::inferResultRanges(
+        ArrayRef<::mlir::ConstantIntRanges> argRanges,
+        SetIntRangeFn setResultRanges) {
+      setResultRanges(getResult(), argRanges[0]);
+    }
+  }];
 }
 
-def ROCDL_ReadlaneOp : ROCDL_IntrOp<"readlane", [], [0], [AllTypesMatch<["res", "src0"]>], 1>,
+def ROCDL_ReadlaneOp : ROCDL_IntrOp<"readlane", [], [0],
+  [AllTypesMatch<["res", "src0"]>,
+   DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>],
+  1>,
   Arguments<(ins LLVM_Type:$src0,
                  I32:$src1)> {
   let results = (outs LLVM_Type:$res);
@@ -425,6 +440,14 @@ def ROCDL_ReadlaneOp : ROCDL_IntrOp<"readlane", [], [0], [AllTypesMatch<["res", 
 
   let assemblyFormat = [{
     $src0 `,` $src1  attr-dict `:` `(` type($src0) `,` type($src1) `)` `->` type($res)
+  }];
+
+  let extraClassDefinition = [{
+    void $cppClass::inferResultRanges(
+        ArrayRef<::mlir::ConstantIntRanges> argRanges,
+        SetIntRangeFn setResultRanges) {
+      setResultRanges(getResult(), argRanges[0]);
+    }
   }];
 }
 

--- a/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
@@ -86,6 +86,7 @@ add_mlir_dialect_library(MLIRROCDLDialect
   Core
 
   LINK_LIBS PUBLIC
+  MLIRInferIntRangeInterface
   MLIRIR
   MLIRLLVMDialect
   MLIRSideEffectInterfaces

--- a/mlir/test/Dialect/LLVMIR/rocdl-int-range-interface.mlir
+++ b/mlir/test/Dialect/LLVMIR/rocdl-int-range-interface.mlir
@@ -1,0 +1,21 @@
+// RUN: mlir-opt -int-range-optimizations -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func @readfirstlane
+// CHECK: test.reflect_bounds {smax = 10 : si32, smin = 0 : si32, umax = 10 : ui32, umin = 0 : ui32}
+func.func @readfirstlane() -> i32 {
+  %0 = test.with_bounds { umin = 0 : ui32, umax = 10 : ui32, smin = 0 : si32, smax = 10 : si32 } : i32
+  %1 = rocdl.readfirstlane %0 : i32
+  %2 = test.reflect_bounds %1 : i32
+  return %2 : i32
+}
+
+// -----
+
+// CHECK-LABEL: func @readlane
+// CHECK: test.reflect_bounds {smax = 10 : si32, smin = 0 : si32, umax = 10 : ui32, umin = 0 : ui32}
+func.func @readlane(%idx: i32) -> i32 {
+  %0 = test.with_bounds { umin = 0 : ui32, umax = 10 : ui32, smin = 0 : si32, smax = 10 : si32 } : i32
+  %1 = rocdl.readlane %0, %idx : (i32, i32) -> i32
+  %2 = test.reflect_bounds %1 : i32
+  return %2 : i32
+}


### PR DESCRIPTION
Allows for integer range analysis to work for these operations.

* `ROCDL_ReadfirstlaneOp`  declares `InferIntRangeInterface`
* `ROCDL_ReadlaneOp` declares `InferIntRangeInterface`
* Adds tests.