### PR TITLE
[Clang][CodeComplete] Support Vector Swizzle Completion

### DIFF
--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -5399,6 +5399,48 @@ AddObjCProperties(const CodeCompletionContext &CCContext,
   }
 }
 
+static void AddExtVectorElementsCompletionResults(QualType BaseType,
+                                                  ResultBuilder &Results) {
+  const auto *VecType = BaseType->getAs<ExtVectorType>();
+  if (!VecType)
+    return;
+
+  unsigned NumElements = VecType->getNumElements();
+  unsigned MaxElements = std::min(NumElements, 4u);
+
+  auto AddResult = [&](const std::string &Name) {
+    CodeCompletionBuilder Builder(Results.getAllocator(),
+                                  Results.getCodeCompletionTUInfo());
+
+    char *SafeStr = Results.getAllocator().Allocate<char>(Name.length() + 1);
+    std::memcpy(SafeStr, Name.c_str(), Name.length() + 1);
+
+    Builder.AddTypedTextChunk(SafeStr);
+    Results.AddResult(CodeCompletionResult(Builder.TakeString()));
+  };
+
+  const char Coords[] = {'x', 'y', 'z', 'w'};
+  const char Colors[] = {'r', 'g', 'b', 'a'};
+
+  auto GenerateSwizzles = [&](auto &Self, const char *CharSet,
+                              std::string Current) -> void {
+    if (!Current.empty()) {
+      AddResult(Current);
+    }
+
+    if (Current.length() == 4) {
+      return;
+    }
+
+    for (unsigned i = 0; i < MaxElements; ++i) {
+      Self(Self, CharSet, Current + CharSet[i]);
+    }
+  };
+
+  GenerateSwizzles(GenerateSwizzles, Coords, "");
+  GenerateSwizzles(GenerateSwizzles, Colors, "");
+}
+
 static void
 AddRecordMembersCompletionResults(Sema &SemaRef, ResultBuilder &Results,
                                   Scope *S, QualType BaseType,
@@ -5924,6 +5966,8 @@ void SemaCodeCompletion::CodeCompleteMemberReferenceExpr(
     if (RecordDecl *RD = getAsRecordDecl(BaseType, Resolver)) {
       AddRecordMembersCompletionResults(SemaRef, Results, S, BaseType, BaseKind,
                                         RD, std::move(AccessOpFixIt));
+    } else if (BaseType->isExtVectorType()) {
+      AddExtVectorElementsCompletionResults(BaseType, Results);
     } else if (const auto *TTPT =
                    dyn_cast<TemplateTypeParmType>(BaseType.getTypePtr())) {
       auto Operator =

--- a/clang/test/CodeCompletion/ext-vector-swizzle.cpp
+++ b/clang/test/CodeCompletion/ext-vector-swizzle.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:9:7 %s -o - | FileCheck --check-prefix=CHECK-VEC4 %s
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:17:7 %s -o - | FileCheck --check-prefix=CHECK-VEC2 %s
+
+typedef float float4 __attribute__((ext_vector_type(4)));
+typedef float float2 __attribute__((ext_vector_type(2)));
+
+void test() {
+  float4 pos;
+  pos.
+}
+// CHECK-VEC4-DAG: COMPLETION: Pattern : x
+// CHECK-VEC4-DAG: COMPLETION: Pattern : xyzw
+// CHECK-VEC4-DAG: COMPLETION: Pattern : rgba
+
+void test2() {
+  float2 tex;
+  tex.
+}
+// CHECK-VEC2-DAG: COMPLETION: Pattern : x
+// CHECK-VEC2-DAG: COMPLETION: Pattern : y
+// CHECK-VEC2-NOT: COMPLETION: Pattern : z
+// CHECK-VEC2-NOT: COMPLETION: Pattern : w


### PR DESCRIPTION
This patch introduces code completion support for `ExtVectorElementExpr` (vector swizzles). 

Previously, when triggering code completion on an `ExtVectorType`, the parser correctly forwarded the request to `SemaCodeComplete`, but the type was unhandled, resulting in no suggestions.

This patch adds `AddExtVectorElementsCompletionResults` to generate all valid swizzle permutations (up to 4 characters) based on the vector's `getNumElements()`. It supports both coordinate (`xyzw`) and color (`rgba`) sets.

Testing:
Added `ext-vector-swizzle.cpp` to verify that permutations are correctly generated and bounded by the vector's size (e.g., `float2` does not suggest `z` or `w`).
