### PR TITLE
[Clang][Hexagon] Add QURT as recognized OS in target triple

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -126,6 +126,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     if (os == llvm::Triple::Linux &&
         Triple.getEnvironment() == llvm::Triple::Musl)
       return std::make_unique<LinuxTargetInfo<HexagonTargetInfo>>(Triple, Opts);
+    if (Triple.isOSQurt())
+      return std::make_unique<QURTTargetInfo<HexagonTargetInfo>>(Triple, Opts);
     return std::make_unique<HexagonTargetInfo>(Triple, Opts);
 
   case llvm::Triple::lanai:

--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -1091,6 +1091,19 @@ public:
   }
 };
 
+// QURT Target
+template <typename Target>
+class LLVM_LIBRARY_VISIBILITY QURTTargetInfo : public OSTargetInfo<Target> {
+protected:
+  void getOSDefines(const LangOptions &Opts, const llvm::Triple &Triple,
+                    MacroBuilder &Builder) const override {
+    Builder.defineMacro("__qurt__");
+  }
+
+public:
+  using OSTargetInfo<Target>::OSTargetInfo;
+};
+
 } // namespace targets
 } // namespace clang
 #endif // LLVM_CLANG_LIB_BASIC_TARGETS_OSTARGETS_H

--- a/clang/test/Preprocessor/hexagon-predefines.c
+++ b/clang/test/Preprocessor/hexagon-predefines.c
@@ -236,3 +236,9 @@
 // RUN: %s -check-prefix CHECK-INTERFERENCE-73
 // CHECK-INTERFERENCE-73: #define __GCC_CONSTRUCTIVE_SIZE 64
 // CHECK-INTERFERENCE-73: #define __GCC_DESTRUCTIVE_SIZE 64
+
+// RUN: %clang_cc1 -E -dM -triple hexagon-unknown-qurt %s | FileCheck \
+// RUN: %s -check-prefix CHECK-QURT
+// CHECK-QURT: #define __hexagon__ 1
+// CHECK-QURT: #define __qurt__ 1
+// CHECK-QURT-NOT: #define __linux__

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -797,9 +797,7 @@ public:
   }
 
   /// Tests whether the OS is QURT.
-  bool isOSQurt() const {
-    return getOS() == Triple::QURT;
-  }
+  bool isOSQurt() const { return getOS() == Triple::QURT; }
 
   /// Tests whether the OS uses the ELF binary format.
   bool isOSBinFormatELF() const {

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -255,7 +255,8 @@ public:
     OpenCL,
     ChipStar,
     Firmware,
-    LastOSType = Firmware
+    QURT,
+    LastOSType = QURT
   };
   enum EnvironmentType {
     UnknownEnvironment,
@@ -793,6 +794,11 @@ public:
 
   bool isOSSerenity() const {
     return getOS() == Triple::Serenity;
+  }
+
+  /// Tests whether the OS is QURT.
+  bool isOSQurt() const {
+    return getOS() == Triple::QURT;
   }
 
   /// Tests whether the OS uses the ELF binary format.

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -347,6 +347,8 @@ StringRef Triple::getOSTypeName(OSType Kind) {
     return "chipstar";
   case Firmware:
     return "firmware";
+  case QURT:
+    return "qurt";
   }
 
   llvm_unreachable("Invalid OSType");
@@ -761,6 +763,7 @@ static Triple::OSType parseOS(StringRef OSName) {
       .StartsWith("opencl", Triple::OpenCL)
       .StartsWith("chipstar", Triple::ChipStar)
       .StartsWith("firmware", Triple::Firmware)
+      .StartsWith("qurt", Triple::QURT)
       .Default(Triple::UnknownOS);
 }
 


### PR DESCRIPTION
Add support for the QURT as a recognized OS type in the LLVM triple system, and define the __qurt__ predefined macro when targeting it.