### PR TITLE
[lldb-dap] Improve test performance for 'cancel' request.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -241,11 +241,13 @@ class DAPTestCaseBase(TestBase):
     def verify_stop_on_entry(self) -> None:
         """Waits for the process to be stopped and then verifies at least one
         thread has the stop reason 'entry'."""
+        if not self.dap_server.configuration_done_sent:
+            self.verify_configuration_done()
         self.dap_server.wait_for_stopped()
         self.assertIn(
             "entry",
             (t["reason"] for t in self.dap_server.thread_stop_reasons.values()),
-            "Expected at least one thread to report stop reason 'entry' in {self.dap_server.thread_stop_reasons}",
+            f"Expected at least one thread to report stop reason 'entry' in {self.dap_server.thread_stop_reasons}",
         )
 
     def verify_commands(self, flavor: str, output: str, commands: List[str]):

--- a/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
+++ b/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
@@ -74,7 +74,7 @@ class TestDAP_cancel(lldbdap_testcase.DAPTestCaseBase):
         Tests cancelling an inflight request.
         """
         program = self.getBuildArtifact("a.out")
-        busy_loop = os.path.join(os.path.dirname(__file__), "busy_loop.py")
+        busy_loop = self.getSourcePath("busy_loop.py")
         self.build_and_launch(
             program,
             initCommands=[f"command script import {busy_loop}"],

--- a/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
+++ b/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
@@ -2,10 +2,8 @@
 Test lldb-dap cancel request
 """
 
+import os
 import time
-
-from lldbsuite.test.decorators import *
-from lldbsuite.test.lldbtest import *
 import lldbdap_testcase
 
 
@@ -13,25 +11,21 @@ class TestDAP_cancel(lldbdap_testcase.DAPTestCaseBase):
     def send_async_req(self, command: str, arguments: dict = {}) -> int:
         return self.dap_server.send_packet(
             {
+                "seq": 0,
                 "type": "request",
                 "command": command,
                 "arguments": arguments,
             }
         )
 
-    def async_blocking_request(self, duration: float) -> int:
+    def async_blocking_request(self, count: int) -> int:
         """
-        Sends an evaluate request that will sleep for the specified duration to
+        Sends an evaluate request that will sleep for the specified count to
         block the request handling thread.
         """
         return self.send_async_req(
             command="evaluate",
-            arguments={
-                "expression": '`script import time; print("starting sleep", file=lldb.debugger.GetOutputFileHandle()); time.sleep({})'.format(
-                    duration
-                ),
-                "context": "repl",
-            },
+            arguments={"expression": f"`busy-loop {count}", "context": "repl"},
         )
 
     def async_cancel(self, requestId: int) -> int:
@@ -42,14 +36,20 @@ class TestDAP_cancel(lldbdap_testcase.DAPTestCaseBase):
         Tests cancelling a pending request.
         """
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program)
+        busy_loop = self.getSourcePath("busy_loop.py")
+        self.build_and_launch(
+            program,
+            initCommands=[f"command script import {busy_loop}"],
+            stopOnEntry=True,
+        )
+        self.verify_stop_on_entry()
 
         # Use a relatively short timeout since this is only to ensure the
         # following request is queued.
-        blocking_seq = self.async_blocking_request(duration=self.DEFAULT_TIMEOUT / 10)
+        blocking_seq = self.async_blocking_request(count=1)
         # Use a longer timeout to ensure we catch if the request was interrupted
         # properly.
-        pending_seq = self.async_blocking_request(duration=self.DEFAULT_TIMEOUT / 2)
+        pending_seq = self.async_blocking_request(count=10)
         cancel_seq = self.async_cancel(requestId=pending_seq)
 
         blocking_resp = self.dap_server.receive_response(blocking_seq)
@@ -74,11 +74,17 @@ class TestDAP_cancel(lldbdap_testcase.DAPTestCaseBase):
         Tests cancelling an inflight request.
         """
         program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program)
+        busy_loop = os.path.join(os.path.dirname(__file__), "busy_loop.py")
+        self.build_and_launch(
+            program,
+            initCommands=[f"command script import {busy_loop}"],
+            stopOnEntry=True,
+        )
+        self.verify_stop_on_entry()
 
-        blocking_seq = self.async_blocking_request(duration=self.DEFAULT_TIMEOUT / 2)
+        blocking_seq = self.async_blocking_request(count=10)
         # Wait for the sleep to start to cancel the inflight request.
-        self.collect_console(pattern="starting sleep")
+        time.sleep(0.5)
         cancel_seq = self.async_cancel(requestId=blocking_seq)
 
         blocking_resp = self.dap_server.receive_response(blocking_seq)

--- a/lldb/test/API/tools/lldb-dap/cancel/busy_loop.py
+++ b/lldb/test/API/tools/lldb-dap/cancel/busy_loop.py
@@ -1,0 +1,17 @@
+import time
+import lldb
+
+
+@lldb.command(command_name="busy-loop")
+def busy_loop(debugger, command, exe_ctx, result, internal_dict):
+    """Test helper as a busy loop."""
+    if not command:
+        command = "10"
+    count = int(command)
+    print("Starting loop...", count)
+    for i in range(count):
+        if debugger.InterruptRequested():
+            print("interrupt requested, stopping loop", i)
+            break
+        print("No interrupted requested, sleeping", i)
+        time.sleep(1)


### PR DESCRIPTION
Update the test to more cleanly handle making a 'blocking' call using a custom command instead of python `time.sleep`, which we cannot easily interrupt.

This should improve the overall performance of the tests, locally they took around 30s and now finish in around 6s.