### PR TITLE
[lldb] Change the way the shlib directory helper is set

### DIFF
--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -96,8 +96,10 @@ public:
   /// (optionally) replace it with a file spec pointing to a more canonical
   /// copy.
   using SharedLibraryDirectoryHelper = void(FileSpec &this_file);
+  static void
+  SetSharedLibraryDirectoryHelper(SharedLibraryDirectoryHelper *helper);
 
-  static void Initialize(SharedLibraryDirectoryHelper *helper = nullptr);
+  static void Initialize();
   static void Terminate();
 
   /// Gets the host target triple.
@@ -273,7 +275,9 @@ public:
   static llvm::StringRef GetDistributionId() { return llvm::StringRef(); }
 
 protected:
-  static bool ComputeSharedLibraryDirectory(FileSpec &file_spec);
+  static bool
+  ComputeSharedLibraryDirectory(FileSpec &file_spec,
+                                SharedLibraryDirectoryHelper *helper);
   static bool ComputeSupportExeDirectory(FileSpec &file_spec);
   static bool ComputeProcessTempFileDirectory(FileSpec &file_spec);
   static bool ComputeGlobalTempFileDirectory(FileSpec &file_spec);

--- a/lldb/include/lldb/Host/aix/HostInfoAIX.h
+++ b/lldb/include/lldb/Host/aix/HostInfoAIX.h
@@ -18,7 +18,7 @@ class HostInfoAIX : public HostInfoPosix {
   friend class HostInfoBase;
 
 public:
-  static void Initialize(SharedLibraryDirectoryHelper *helper = nullptr);
+  static void Initialize();
   static void Terminate();
 
   static FileSpec GetProgramFileSpec();

--- a/lldb/include/lldb/Host/linux/HostInfoLinux.h
+++ b/lldb/include/lldb/Host/linux/HostInfoLinux.h
@@ -22,7 +22,7 @@ class HostInfoLinux : public HostInfoPosix {
   friend class HostInfoBase;
 
 public:
-  static void Initialize(SharedLibraryDirectoryHelper *helper = nullptr);
+  static void Initialize();
   static void Terminate();
 
   static llvm::StringRef GetDistributionId();

--- a/lldb/include/lldb/Host/windows/HostInfoWindows.h
+++ b/lldb/include/lldb/Host/windows/HostInfoWindows.h
@@ -21,7 +21,7 @@ class HostInfoWindows : public HostInfoBase {
   friend class HostInfoBase;
 
 public:
-  static void Initialize(SharedLibraryDirectoryHelper *helper = nullptr);
+  static void Initialize();
   static void Terminate();
 
   static size_t GetPageSize();

--- a/lldb/include/lldb/Initialization/SystemInitializerCommon.h
+++ b/lldb/include/lldb/Initialization/SystemInitializerCommon.h
@@ -23,14 +23,11 @@ namespace lldb_private {
 /// the constructor.
 class SystemInitializerCommon : public SystemInitializer {
 public:
-  SystemInitializerCommon(HostInfo::SharedLibraryDirectoryHelper *helper);
+  SystemInitializerCommon();
   ~SystemInitializerCommon() override;
 
   llvm::Error Initialize() override;
   void Terminate() override;
-
-private:
-  HostInfo::SharedLibraryDirectoryHelper *m_shlib_dir_helper;
 };
 
 } // namespace lldb_private

--- a/lldb/source/API/SystemInitializerFull.cpp
+++ b/lldb/source/API/SystemInitializerFull.cpp
@@ -32,22 +32,9 @@
 #define LLDB_PLUGIN(p) LLDB_PLUGIN_DECLARE(p)
 #include "Plugins/Plugins.def"
 
-#if LLDB_ENABLE_PYTHON
-#include "Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.h"
-
-constexpr lldb_private::HostInfo::SharedLibraryDirectoryHelper
-    *g_shlib_dir_helper =
-        lldb_private::ScriptInterpreterPython::SharedLibraryDirectoryHelper;
-
-#else
-constexpr lldb_private::HostInfo::SharedLibraryDirectoryHelper
-    *g_shlib_dir_helper = nullptr;
-#endif
-
 using namespace lldb_private;
 
-SystemInitializerFull::SystemInitializerFull()
-    : SystemInitializerCommon(g_shlib_dir_helper) {}
+SystemInitializerFull::SystemInitializerFull() : SystemInitializerCommon() {}
 SystemInitializerFull::~SystemInitializerFull() = default;
 
 llvm::Error SystemInitializerFull::Initialize() {

--- a/lldb/source/Host/aix/HostInfoAIX.cpp
+++ b/lldb/source/Host/aix/HostInfoAIX.cpp
@@ -12,9 +12,7 @@
 
 using namespace lldb_private;
 
-void HostInfoAIX::Initialize(SharedLibraryDirectoryHelper *helper) {
-  HostInfoPosix::Initialize(helper);
-}
+void HostInfoAIX::Initialize() { HostInfoPosix::Initialize(); }
 
 void HostInfoAIX::Terminate() { HostInfoBase::Terminate(); }
 

--- a/lldb/source/Host/linux/HostInfoLinux.cpp
+++ b/lldb/source/Host/linux/HostInfoLinux.cpp
@@ -35,8 +35,8 @@ struct HostInfoLinuxFields {
 
 static HostInfoLinuxFields *g_fields = nullptr;
 
-void HostInfoLinux::Initialize(SharedLibraryDirectoryHelper *helper) {
-  HostInfoPosix::Initialize(helper);
+void HostInfoLinux::Initialize() {
+  HostInfoPosix::Initialize();
 
   g_fields = new HostInfoLinuxFields();
 }

--- a/lldb/source/Host/windows/HostInfoWindows.cpp
+++ b/lldb/source/Host/windows/HostInfoWindows.cpp
@@ -40,9 +40,9 @@ protected:
 
 FileSpec HostInfoWindows::m_program_filespec;
 
-void HostInfoWindows::Initialize(SharedLibraryDirectoryHelper *helper) {
+void HostInfoWindows::Initialize() {
   ::CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-  HostInfoBase::Initialize(helper);
+  HostInfoBase::Initialize();
 }
 
 void HostInfoWindows::Terminate() {

--- a/lldb/source/Initialization/SystemInitializerCommon.cpp
+++ b/lldb/source/Initialization/SystemInitializerCommon.cpp
@@ -35,9 +35,7 @@
 
 using namespace lldb_private;
 
-SystemInitializerCommon::SystemInitializerCommon(
-    HostInfo::SharedLibraryDirectoryHelper *helper)
-    : m_shlib_dir_helper(helper) {}
+SystemInitializerCommon::SystemInitializerCommon() = default;
 
 SystemInitializerCommon::~SystemInitializerCommon() = default;
 
@@ -68,7 +66,7 @@ llvm::Error SystemInitializerCommon::Initialize() {
 
   Diagnostics::Initialize();
   FileSystem::Initialize();
-  HostInfo::Initialize(m_shlib_dir_helper);
+  HostInfo::Initialize();
 
   llvm::Error error = Socket::Initialize();
   if (error)

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -290,6 +290,8 @@ llvm::StringRef ScriptInterpreterPython::GetPluginDescriptionStatic() {
 }
 
 void ScriptInterpreterPython::Initialize() {
+  HostInfo::SetSharedLibraryDirectoryHelper(
+      ScriptInterpreterPython::SharedLibraryDirectoryHelper);
   static llvm::once_flag g_once_flag;
   llvm::call_once(g_once_flag, []() {
     PluginManager::RegisterPlugin(GetPluginNameStatic(),

--- a/lldb/tools/lldb-mcp/lldb-mcp.cpp
+++ b/lldb/tools/lldb-mcp/lldb-mcp.cpp
@@ -214,7 +214,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   if (llvm::Error err = g_debugger_lifetime->Initialize(
-          std::make_unique<lldb_private::SystemInitializerCommon>(nullptr)))
+          std::make_unique<lldb_private::SystemInitializerCommon>()))
     exitWithError(std::move(err));
 
   llvm::scope_exit cleanup([] { g_debugger_lifetime->Terminate(); });

--- a/lldb/tools/lldb-server/SystemInitializerLLGS.h
+++ b/lldb/tools/lldb-server/SystemInitializerLLGS.h
@@ -14,7 +14,7 @@
 
 class SystemInitializerLLGS : public lldb_private::SystemInitializerCommon {
 public:
-  SystemInitializerLLGS() : SystemInitializerCommon(nullptr) {}
+  SystemInitializerLLGS() : SystemInitializerCommon() {}
 
   llvm::Error Initialize() override;
   void Terminate() override;

--- a/lldb/tools/lldb-test/SystemInitializerTest.cpp
+++ b/lldb/tools/lldb-test/SystemInitializerTest.cpp
@@ -22,8 +22,7 @@
 
 using namespace lldb_private;
 
-SystemInitializerTest::SystemInitializerTest()
-    : SystemInitializerCommon(nullptr) {}
+SystemInitializerTest::SystemInitializerTest() : SystemInitializerCommon() {}
 SystemInitializerTest::~SystemInitializerTest() = default;
 
 llvm::Error SystemInitializerTest::Initialize() {


### PR DESCRIPTION
This PR changes the way we set the shlib directory helper. Instead of setting it while initializing the Host plugin, we register it when initializing the Python plugin. The motivation is that the current approach is incompatible with the dynamically linked script interpreters, as they will not have been loaded at the time the Host plugin is initialized. 

The downside of the new approach is that we set the helper after having initialized the Host plugin, which theoretically introduces a small window where someone could query the helper before it has been set. Fortunately the window is pretty small and limited to when we're initializing plugins, but it's less "pure" than what we had previously. That said, I think it balances out with removing the plugin include.