### PR TITLE
[clang-tidy] Teach `misc-unused-using-decls` that exported using-decls aren't unused

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
@@ -99,6 +99,12 @@ void UnusedUsingDeclsCheck::check(const MatchFinder::MatchResult &Result) {
     if (isa<FunctionDecl>(Using->getDeclContext()))
       return;
 
+    // Ignore exported using-decls.
+    if (Using->hasOwningModule() &&
+        Using->getModuleOwnershipKind() <=
+            Decl::ModuleOwnershipKind::VisibleWhenImported)
+      return;
+
     UsingDeclContext Context(Using);
     Context.UsingDeclRange = CharSourceRange::getCharRange(
         Using->getBeginLoc(),

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -209,7 +209,7 @@ Changes in existing checks
     incorrectly diagnosed as allowing the pointee to be made ``const``.
 
 - Improved :doc:`misc-unused-using-decls
-  <clang-tidy/checks/misc/unused-using-decls>` to not diagnose using
+  <clang-tidy/checks/misc/unused-using-decls>` to not diagnose ``using``
   declarations as unused if they're exported from a module.
 
 - Improved :doc:`modernize-pass-by-value

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -208,6 +208,10 @@ Changes in existing checks
   - Fixed false positive where an array of pointers to ``const`` was
     incorrectly diagnosed as allowing the pointee to be made ``const``.
 
+- Improved :doc:`misc-unused-using-decls
+  <clang-tidy/checks/misc/unused-using-decls>` to not diagnose using
+  declarations as unused if they're exported from a module.
+
 - Improved :doc:`modernize-pass-by-value
   <clang-tidy/checks/modernize/pass-by-value>` check by adding `IgnoreMacros`
   option to suppress warnings in macros.

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls-module.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls-module.cpp
@@ -1,0 +1,69 @@
+// RUN: %check_clang_tidy -std=c++20-or-later %s misc-unused-using-decls %t -- --fix-notes
+
+module;
+
+namespace n {
+
+struct S {};
+
+} // namespace n
+
+using n::S; // n::S
+// CHECK-MESSAGES: :[[@LINE-1]]:10: warning: using decl 'S' is unused
+// CHECK-FIXES: // n::S
+
+export module foo;
+
+struct A {};
+export struct B {};
+export struct C {};
+export struct D {};
+
+namespace ns1 {
+
+using ::A; // ns1::A
+// CHECK-MESSAGES: :[[@LINE-1]]:9: warning: using decl 'A' is unused
+// CHECK-FIXES: // ns1::A
+
+// If the decl isn't exported, it's unused, even if the underlying struct is exported.
+using ::B; // ns1::B
+// CHECK-MESSAGES: :[[@LINE-1]]:9: warning: using decl 'B' is unused
+// CHECK-FIXES: // ns1::B
+
+export using ::C;
+
+export {
+
+using ::D;
+
+}
+
+} // namespace n
+
+export namespace ns2 {
+
+using ::B;
+
+} // namespace ns2
+
+export {
+
+namespace ns3 {
+
+using ::B;
+
+} // namespace ns3
+
+}
+
+export namespace ns3 {
+
+struct E {};
+
+} // namespace ns3
+
+module :private;
+
+using ns3::E; // ns3::E
+// CHECK-MESSAGES: :[[@LINE-1]]:12: warning: using decl 'E' is unused
+// CHECK-FIXES: // ns3::E


### PR DESCRIPTION
Fixes #162619.