### PR TITLE
[ThreadSafety] Add heuristic for not invalidating out parameters of annotated functions

### DIFF
--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -697,6 +697,20 @@ void VarMapBuilder::VisitCallExpr(const CallExpr *CE) {
     if (II->isStr("bind") || II->isStr("bind_front"))
       return;
   }
+  // Heuristic for annotated functions: acquire and release functions may mutate
+  // out parameters so that locks can be acquired/released. We do not want false
+  // positives on them.
+  if (llvm::any_of(FD->attrs(), [](const clang::Attr *At) -> bool {
+        switch (At->getKind()) {
+        case attr::AcquireCapability:
+        case attr::TryAcquireCapability:
+        case attr::ReleaseCapability:
+          return true;
+        default:
+          return false;
+        }
+      }))
+    return;
 
   // Invalidate local variable definitions that are passed by non-const
   // reference or non-const pointer.

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -7495,6 +7495,8 @@ void testPointerAliasEscapeMultiple(Foo *F) {
 } // expected-warning{{mutex 'F->mu' is still held at the end of function}}
 
 void unlockFooWithEscapablePointer(Foo **Fp) EXCLUSIVE_UNLOCK_FUNCTION((*Fp)->mu);
+void lockFooWithEscapablePointer(Foo **Fp) EXCLUSIVE_LOCK_FUNCTION((*Fp)->mu);
+bool tryLockFooWithEscapablePointer(Foo **Fp) EXCLUSIVE_LOCK_FUNCTION((*Fp)->mu);
 void testEscapeInvalidationHappensRightAfterTheCall(Foo* F) {
   Foo* L;
   L = F;
@@ -7517,6 +7519,44 @@ void testEscapeInvalidationHappensRightAfterTheCtorCall(Foo* F) {
 void testCleanUpFunctionWithLocalVarUpdated(Foo* F) {
   F->mu.Lock();
   Foo * __attribute__((unused, cleanup(unlockFooWithEscapablePointer))) L = F;
+}
+
+void testAcquireReleaseNotInvalidate() {
+  Foo* F = 0;
+
+  struct {
+    int DataMember GUARDED_BY(F->mu);
+  } Data;
+
+  lockFooWithEscapablePointer(&F);
+  Data.DataMember = 0;
+  unlockFooWithEscapablePointer(&F);
+}
+
+void testAcquireReleaseNotInvalidate2() {
+  Foo* F = 0;
+
+  struct {
+    int DataMember GUARDED_BY(F->mu);
+  } Data;
+
+  bool success = tryLockFooWithEscapablePointer(&F);
+  if (success)
+    Data.DataMember = 0;
+  unlockFooWithEscapablePointer(&F);
+}
+
+void invalidateFooWithEscapablePointer(Foo **Fp);
+void testAcquireReleaseNotInvalidate3() {
+  Foo* F = 0;
+
+  struct {
+    int DataMember GUARDED_BY(F->mu);
+  } Data;
+
+  invalidateFooWithEscapablePointer(&F);
+  Data.DataMember = 0; // expected-warning{{writing variable 'DataMember' requires holding mutex 'F->mu' exclusively}}
+  unlockFooWithEscapablePointer(&F); //expected-warning{{releasing mutex 'F->mu' that was not held}}
 }
 
 void testPointerAliasTryLock1() {


### PR DESCRIPTION
The conservative logic that local variable definitions should be invalidated if they can escape was added alongside the alias analysis. However, for acquire/release functions that take out parameters of capabilities, such logic creates false positives.

```
void f() {
  Cap* C = 0;
  int x;      // suppose 'x' is protected by 'C'

  lock(&C);
  x = 0;      // false alarm: accessing x requires holding lock C
  unlock(&C); // false alarm: releasing C that was not held
}
```
This commit adds a heuristic to avoid invalidating out parameters of acquire/release functions.

(Ideally, we still want to invalidate out parameters unrelated to the capabilities being acquired or released. But that would require greater effort while is expected to produce little benefit.)

rdar://171209196