### PR TITLE
[RISCV] Extends RISCVMoveMerger to merge GPRPairs independent of even/odd pair instruction order.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
@@ -68,20 +68,25 @@ char RISCVMoveMerge::ID = 0;
 INITIALIZE_PASS(RISCVMoveMerge, "riscv-move-merge", RISCV_MOVE_MERGE_NAME,
                 false, false)
 
-static unsigned getMoveFromOpcode(const RISCVSubtarget &ST, bool MoveFromSToA) {
-  if (ST.hasStdExtZcmp())
-    return MoveFromSToA ? RISCV::CM_MVA01S : RISCV::CM_MVSA01;
-
-  if (ST.hasVendorXqccmp())
-    return MoveFromSToA ? RISCV::QC_CM_MVA01S : RISCV::QC_CM_MVSA01;
-
+static unsigned getGPRPairMoveFromOpcode(const RISCVSubtarget &ST) {
   if (ST.hasStdExtZdinx())
     return RISCV::FSGNJ_D_IN32X;
 
   if (ST.hasStdExtP())
     return RISCV::PADD_DW;
 
-  llvm_unreachable("Unhandled subtarget with paired A to S move.");
+  llvm_unreachable("Unhandled subtarget with paired move.");
+}
+
+static unsigned getMoveFromCMOpcode(const RISCVSubtarget &ST,
+                                    bool MoveFromSToA) {
+  if (ST.hasStdExtZcmp())
+    return MoveFromSToA ? RISCV::CM_MVA01S : RISCV::CM_MVSA01;
+
+  if (ST.hasVendorXqccmp())
+    return MoveFromSToA ? RISCV::QC_CM_MVA01S : RISCV::QC_CM_MVSA01;
+
+  llvm_unreachable("Unhandled subtarget with paired move.");
 }
 
 bool RISCVMoveMerge::isRegisterEven(const DestSourcePair &RegPair) {
@@ -155,7 +160,7 @@ RISCVMoveMerge::mergeGPRPairInsns(MachineBasicBlock::iterator I,
   // flag.
   MachineOperand PairedSource = *SecondPair.Source;
 
-  unsigned Opcode = getMoveFromOpcode(*ST, true);
+  unsigned Opcode = getGPRPairMoveFromOpcode(*ST);
   for (auto It = std::next(I); It != Paired && PairedSource.isKill(); ++It)
     if (It->readsRegister(PairedSource.getReg(), TRI))
       PairedSource.setIsKill(false);
@@ -207,7 +212,7 @@ RISCVMoveMerge::mergePairedInsns(MachineBasicBlock::iterator I,
   //
   //   mv a0, s2
   //   mv a1, s1    =>  cm.mva01s s2,s1
-  unsigned Opcode = getMoveFromOpcode(*ST, MoveFromSToA);
+  unsigned Opcode = getMoveFromCMOpcode(*ST, MoveFromSToA);
   if (MoveFromSToA) {
     // We are moving one of the copies earlier so its kill flag may become
     // invalid. Clear the copied kill flag if there are any reads of the

--- a/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
@@ -165,7 +165,8 @@ RISCVMoveMerge::mergeGPRPairInsns(MachineBasicBlock::iterator I,
       PairedSource.setIsKill(false);
 
   Register SrcReg1, SrcReg2, DestReg;
-  auto GPRPairIdx = RegPairIsEven ? RISCV::sub_gpr_even : RISCV::sub_gpr_odd;
+  unsigned GPRPairIdx =
+      RegPairIsEven ? RISCV::sub_gpr_even : RISCV::sub_gpr_odd;
   SrcReg1 = TRI->getMatchingSuperReg(FirstPair.Source->getReg(), GPRPairIdx,
                                      &RISCV::GPRPairRegClass);
   SrcReg2 = ST->hasStdExtZdinx() ? SrcReg1 : Register(RISCV::X0_Pair);

--- a/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
@@ -34,16 +34,20 @@ struct RISCVMoveMerge : public MachineFunctionPass {
   LiveRegUnits ModifiedRegUnits, UsedRegUnits;
 
   bool isRegisterEven(const DestSourcePair &RegPair);
+  bool isRegisterOdd(const DestSourcePair &RegPair);
 
   bool isCandidateToMergeMVA01S(const DestSourcePair &RegPair);
   bool isCandidateToMergeMVSA01(const DestSourcePair &RegPair);
   // Merge the two instructions indicated into a single pair instruction.
   MachineBasicBlock::iterator
+  mergeGPRPairInsns(MachineBasicBlock::iterator I,
+                    MachineBasicBlock::iterator Paired, bool RegPairIsEven);
+  MachineBasicBlock::iterator
   mergePairedInsns(MachineBasicBlock::iterator I,
                    MachineBasicBlock::iterator Paired, bool MoveFromSToA);
 
   MachineBasicBlock::iterator
-  findMatchingInstPair(MachineBasicBlock::iterator &MBBI,
+  findMatchingInstPair(MachineBasicBlock::iterator &MBBI, bool EvenRegPair,
                        const DestSourcePair &RegPair);
   // Look for C.MV instruction that can be combined with
   // the given instruction into CM.MVA01S or CM.MVSA01. Return the matching
@@ -95,6 +99,21 @@ bool RISCVMoveMerge::isRegisterEven(const DestSourcePair &RegPair) {
   return SrcPair.isValid() && DestPair.isValid();
 }
 
+bool RISCVMoveMerge::isRegisterOdd(const DestSourcePair &RegPair) {
+  Register Destination = RegPair.Destination->getReg();
+  Register Source = RegPair.Source->getReg();
+
+  if (Source == Destination)
+    return false;
+
+  Register SrcPair = TRI->getMatchingSuperReg(Source, RISCV::sub_gpr_odd,
+                                              &RISCV::GPRPairRegClass);
+  Register DestPair = TRI->getMatchingSuperReg(Destination, RISCV::sub_gpr_odd,
+                                               &RISCV::GPRPairRegClass);
+
+  return SrcPair.isValid() && DestPair.isValid();
+}
+
 // Check if registers meet CM.MVA01S constraints.
 bool RISCVMoveMerge::isCandidateToMergeMVA01S(const DestSourcePair &RegPair) {
   Register Destination = RegPair.Destination->getReg();
@@ -117,6 +136,48 @@ bool RISCVMoveMerge::isCandidateToMergeMVSA01(const DestSourcePair &RegPair) {
       RISCV::SR07RegClass.contains(Destination))
     return true;
   return false;
+}
+
+MachineBasicBlock::iterator
+RISCVMoveMerge::mergeGPRPairInsns(MachineBasicBlock::iterator I,
+                                  MachineBasicBlock::iterator Paired,
+                                  bool RegPairIsEven) {
+  MachineBasicBlock::iterator E = I->getParent()->end();
+  MachineBasicBlock::iterator NextI = next_nodbg(I, E);
+  DestSourcePair FirstPair = TII->isCopyInstrImpl(*I).value();
+  DestSourcePair SecondPair = TII->isCopyInstrImpl(*Paired).value();
+
+  if (NextI == Paired)
+    NextI = next_nodbg(NextI, E);
+  DebugLoc DL = I->getDebugLoc();
+
+  // Make a copy of the second instruction to update the kill
+  // flag.
+  MachineOperand PairedSource = *SecondPair.Source;
+
+  unsigned Opcode = getMoveFromOpcode(*ST, true);
+  for (auto It = std::next(I); It != Paired && PairedSource.isKill(); ++It)
+    if (It->readsRegister(PairedSource.getReg(), TRI))
+      PairedSource.setIsKill(false);
+
+  Register SrcReg1, SrcReg2, DestReg;
+  // auto &EvenPair = RegPairIsEven ? FirstPair : SecondPair;
+  auto GPRPairIdx = RegPairIsEven ? RISCV::sub_gpr_even : RISCV::sub_gpr_odd;
+  SrcReg1 = TRI->getMatchingSuperReg(FirstPair.Source->getReg(), GPRPairIdx,
+                                     &RISCV::GPRPairRegClass);
+  SrcReg2 = ST->hasStdExtZdinx() ? SrcReg1 : Register(RISCV::X0_Pair);
+  DestReg = TRI->getMatchingSuperReg(FirstPair.Destination->getReg(),
+                                     GPRPairIdx, &RISCV::GPRPairRegClass);
+
+  BuildMI(*I->getParent(), I, DL, TII->get(Opcode), DestReg)
+      .addReg(SrcReg1, getKillRegState(PairedSource.isKill() &&
+                                       FirstPair.Source->isKill()))
+      .addReg(SrcReg2, getKillRegState(PairedSource.isKill() &&
+                                       FirstPair.Source->isKill()));
+
+  I->eraseFromParent();
+  Paired->eraseFromParent();
+  return NextI;
 }
 
 MachineBasicBlock::iterator
@@ -147,15 +208,14 @@ RISCVMoveMerge::mergePairedInsns(MachineBasicBlock::iterator I,
   //   mv a0, s2
   //   mv a1, s1    =>  cm.mva01s s2,s1
   unsigned Opcode = getMoveFromOpcode(*ST, MoveFromSToA);
-  // We are moving one of the copies earlier so its kill flag may become
-  // invalid. Clear the copied kill flag if there are any reads of the
-  // register between the new location and the old location.
-  if (MoveFromSToA || (!ST->hasStdExtZcmp() && !ST->hasVendorXqccmp()))
+  if (MoveFromSToA) {
+    // We are moving one of the copies earlier so its kill flag may become
+    // invalid. Clear the copied kill flag if there are any reads of the
+    // register between the new location and the old location.
     for (auto It = std::next(I); It != Paired && PairedSource.isKill(); ++It)
       if (It->readsRegister(PairedSource.getReg(), TRI))
         PairedSource.setIsKill(false);
 
-  if (MoveFromSToA) {
     Sreg1 = FirstPair.Source;
     Sreg2 = &PairedSource;
     if (FirstPair.Destination->getReg() != RISCV::X10)
@@ -167,25 +227,7 @@ RISCVMoveMerge::mergePairedInsns(MachineBasicBlock::iterator I,
       std::swap(Sreg1, Sreg2);
   }
 
-  if (!ST->hasStdExtZcmp() && !ST->hasVendorXqccmp()) {
-    Register SrcReg1, SrcReg2, DestReg;
-
-    SrcReg1 =
-        TRI->getMatchingSuperReg(FirstPair.Source->getReg(),
-                                 RISCV::sub_gpr_even, &RISCV::GPRPairRegClass);
-    SrcReg2 = ST->hasStdExtZdinx() ? SrcReg1 : Register(RISCV::X0_Pair);
-    DestReg =
-        TRI->getMatchingSuperReg(FirstPair.Destination->getReg(),
-                                 RISCV::sub_gpr_even, &RISCV::GPRPairRegClass);
-
-    BuildMI(*I->getParent(), I, DL, TII->get(Opcode), DestReg)
-        .addReg(SrcReg1, getKillRegState(PairedSource.isKill() &&
-                                         FirstPair.Source->isKill()))
-        .addReg(SrcReg2, getKillRegState(PairedSource.isKill() &&
-                                         FirstPair.Source->isKill()));
-  } else {
-    BuildMI(*I->getParent(), I, DL, TII->get(Opcode)).add(*Sreg1).add(*Sreg2);
-  }
+  BuildMI(*I->getParent(), I, DL, TII->get(Opcode)).add(*Sreg1).add(*Sreg2);
 
   I->eraseFromParent();
   Paired->eraseFromParent();
@@ -194,6 +236,7 @@ RISCVMoveMerge::mergePairedInsns(MachineBasicBlock::iterator I,
 
 MachineBasicBlock::iterator
 RISCVMoveMerge::findMatchingInstPair(MachineBasicBlock::iterator &MBBI,
+                                     bool EvenRegPair,
                                      const DestSourcePair &RegPair) {
   MachineBasicBlock::iterator E = MBBI->getParent()->end();
   ModifiedRegUnits.clear();
@@ -212,18 +255,22 @@ RISCVMoveMerge::findMatchingInstPair(MachineBasicBlock::iterator &MBBI,
           RegPair.Source->getReg() == SourceReg)
         return E;
 
-      // Get the register pair from the even half
-      Register SrcGPRPair = TRI->getMatchingSuperReg(RegPair.Source->getReg(),
-                                                     RISCV::sub_gpr_even,
-                                                     &RISCV::GPRPairRegClass);
+      unsigned RegPairIdx =
+          EvenRegPair ? RISCV::sub_gpr_even : RISCV::sub_gpr_odd;
+      unsigned SecondPairIdx =
+          !EvenRegPair ? RISCV::sub_gpr_even : RISCV::sub_gpr_odd;
+
+      // Get the register GPRPair.
+      Register SrcGPRPair = TRI->getMatchingSuperReg(
+          RegPair.Source->getReg(), RegPairIdx, &RISCV::GPRPairRegClass);
 
       Register DestGPRPair = TRI->getMatchingSuperReg(
-          RegPair.Destination->getReg(), RISCV::sub_gpr_even,
-          &RISCV::GPRPairRegClass);
+          RegPair.Destination->getReg(), RegPairIdx, &RISCV::GPRPairRegClass);
 
-      // Check if the second pair match the odd registers of the GPR pair.
-      if (SourceReg != TRI->getSubReg(SrcGPRPair, RISCV::sub_gpr_odd) ||
-          DestReg != TRI->getSubReg(DestGPRPair, RISCV::sub_gpr_odd))
+      // Check if the second pair's registers match the other lane of the
+      // GPRPairs.
+      if (SourceReg != TRI->getSubReg(SrcGPRPair, SecondPairIdx) ||
+          DestReg != TRI->getSubReg(DestGPRPair, SecondPairIdx))
         return E;
 
       if (!ModifiedRegUnits.available(DestReg) ||
@@ -300,21 +347,29 @@ bool RISCVMoveMerge::mergeMoveSARegPair(MachineBasicBlock &MBB) {
     if (RegPair.has_value()) {
       bool MoveFromSToA = isCandidateToMergeMVA01S(*RegPair);
       bool IsEven = isRegisterEven(*RegPair);
-      if (!MoveFromSToA && !isCandidateToMergeMVSA01(*RegPair) && !IsEven) {
+      bool IsOdd = isRegisterOdd(*RegPair);
+      if (!MoveFromSToA && !isCandidateToMergeMVSA01(*RegPair) && !IsEven &&
+          !IsOdd) {
         ++MBBI;
         continue;
       }
 
       MachineBasicBlock::iterator Paired = E;
-      if (ST->hasStdExtZcmp() || ST->hasVendorXqccmp())
+      if (ST->hasStdExtZcmp() || ST->hasVendorXqccmp()) {
         Paired = findMatchingInst(MBBI, MoveFromSToA, RegPair.value());
-      else if (IsEven)
-        Paired = findMatchingInstPair(MBBI, RegPair.value());
-      // If matching instruction can be found merge them.
-      if (Paired != E) {
-        MBBI = mergePairedInsns(MBBI, Paired, MoveFromSToA);
-        Modified = true;
-        continue;
+        if (Paired != E) {
+          MBBI = mergePairedInsns(MBBI, Paired, MoveFromSToA);
+          Modified = true;
+          continue;
+        }
+      }
+      if (IsEven ^ IsOdd) {
+        Paired = findMatchingInstPair(MBBI, IsEven, RegPair.value());
+        if (Paired != E) {
+          MBBI = mergeGPRPairInsns(MBBI, Paired, IsEven);
+          Modified = true;
+          continue;
+        }
       }
     }
     ++MBBI;
@@ -331,7 +386,8 @@ bool RISCVMoveMerge::runOnMachineFunction(MachineFunction &Fn) {
       !ST->hasStdExtP())
     return false;
 
-  if ((ST->hasStdExtP() || ST->hasStdExtZdinx()) && ST->is64Bit())
+  if ((ST->hasStdExtZdinx() || ST->hasStdExtP()) && ST->is64Bit() &&
+      !ST->hasStdExtZcmp() && !ST->hasVendorXqccmp())
     return false;
 
   TII = ST->getInstrInfo();

--- a/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
@@ -366,7 +366,7 @@ bool RISCVMoveMerge::mergeMoveSARegPair(MachineBasicBlock &MBB) {
           continue;
         }
       }
-      if (IsEven ^ IsOdd) {
+      if (IsEven != IsOdd) {
         Paired = findMatchingInstPair(MBBI, IsEven, RegPair.value());
         if (Paired != E) {
           MBBI = mergeGPRPairInsns(MBBI, Paired, IsEven);

--- a/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
@@ -33,8 +33,8 @@ struct RISCVMoveMerge : public MachineFunctionPass {
   // Track which register units have been modified and used.
   LiveRegUnits ModifiedRegUnits, UsedRegUnits;
 
-  bool isRegisterEven(const DestSourcePair &RegPair);
-  bool isRegisterOdd(const DestSourcePair &RegPair);
+  bool isEvenRegisterCopy(const DestSourcePair &RegPair);
+  bool isOddRegisterCopy(const DestSourcePair &RegPair);
 
   bool isCandidateToMergeMVA01S(const DestSourcePair &RegPair);
   bool isCandidateToMergeMVSA01(const DestSourcePair &RegPair);
@@ -68,7 +68,7 @@ char RISCVMoveMerge::ID = 0;
 INITIALIZE_PASS(RISCVMoveMerge, "riscv-move-merge", RISCV_MOVE_MERGE_NAME,
                 false, false)
 
-static unsigned getGPRPairMoveFromOpcode(const RISCVSubtarget &ST) {
+static unsigned getGPRPairCopyOpcode(const RISCVSubtarget &ST) {
   if (ST.hasStdExtZdinx())
     return RISCV::FSGNJ_D_IN32X;
 
@@ -78,8 +78,7 @@ static unsigned getGPRPairMoveFromOpcode(const RISCVSubtarget &ST) {
   llvm_unreachable("Unhandled subtarget with paired move.");
 }
 
-static unsigned getMoveFromCMOpcode(const RISCVSubtarget &ST,
-                                    bool MoveFromSToA) {
+static unsigned getCM_MVOpcode(const RISCVSubtarget &ST, bool MoveFromSToA) {
   if (ST.hasStdExtZcmp())
     return MoveFromSToA ? RISCV::CM_MVA01S : RISCV::CM_MVSA01;
 
@@ -89,7 +88,7 @@ static unsigned getMoveFromCMOpcode(const RISCVSubtarget &ST,
   llvm_unreachable("Unhandled subtarget with paired move.");
 }
 
-bool RISCVMoveMerge::isRegisterEven(const DestSourcePair &RegPair) {
+bool RISCVMoveMerge::isEvenRegisterCopy(const DestSourcePair &RegPair) {
   Register Destination = RegPair.Destination->getReg();
   Register Source = RegPair.Source->getReg();
 
@@ -104,7 +103,7 @@ bool RISCVMoveMerge::isRegisterEven(const DestSourcePair &RegPair) {
   return SrcPair.isValid() && DestPair.isValid();
 }
 
-bool RISCVMoveMerge::isRegisterOdd(const DestSourcePair &RegPair) {
+bool RISCVMoveMerge::isOddRegisterCopy(const DestSourcePair &RegPair) {
   Register Destination = RegPair.Destination->getReg();
   Register Source = RegPair.Source->getReg();
 
@@ -160,13 +159,12 @@ RISCVMoveMerge::mergeGPRPairInsns(MachineBasicBlock::iterator I,
   // flag.
   MachineOperand PairedSource = *SecondPair.Source;
 
-  unsigned Opcode = getGPRPairMoveFromOpcode(*ST);
+  unsigned Opcode = getGPRPairCopyOpcode(*ST);
   for (auto It = std::next(I); It != Paired && PairedSource.isKill(); ++It)
     if (It->readsRegister(PairedSource.getReg(), TRI))
       PairedSource.setIsKill(false);
 
   Register SrcReg1, SrcReg2, DestReg;
-  // auto &EvenPair = RegPairIsEven ? FirstPair : SecondPair;
   auto GPRPairIdx = RegPairIsEven ? RISCV::sub_gpr_even : RISCV::sub_gpr_odd;
   SrcReg1 = TRI->getMatchingSuperReg(FirstPair.Source->getReg(), GPRPairIdx,
                                      &RISCV::GPRPairRegClass);
@@ -212,7 +210,7 @@ RISCVMoveMerge::mergePairedInsns(MachineBasicBlock::iterator I,
   //
   //   mv a0, s2
   //   mv a1, s1    =>  cm.mva01s s2,s1
-  unsigned Opcode = getMoveFromCMOpcode(*ST, MoveFromSToA);
+  unsigned Opcode = getCM_MVOpcode(*ST, MoveFromSToA);
   if (MoveFromSToA) {
     // We are moving one of the copies earlier so its kill flag may become
     // invalid. Clear the copied kill flag if there are any reads of the
@@ -351,8 +349,8 @@ bool RISCVMoveMerge::mergeMoveSARegPair(MachineBasicBlock &MBB) {
     auto RegPair = TII->isCopyInstrImpl(*MBBI);
     if (RegPair.has_value()) {
       bool MoveFromSToA = isCandidateToMergeMVA01S(*RegPair);
-      bool IsEven = isRegisterEven(*RegPair);
-      bool IsOdd = isRegisterOdd(*RegPair);
+      bool IsEven = isEvenRegisterCopy(*RegPair);
+      bool IsOdd = isOddRegisterCopy(*RegPair);
       if (!MoveFromSToA && !isCandidateToMergeMVSA01(*RegPair) && !IsEven &&
           !IsOdd) {
         ++MBBI;
@@ -387,12 +385,9 @@ bool RISCVMoveMerge::runOnMachineFunction(MachineFunction &Fn) {
     return false;
 
   ST = &Fn.getSubtarget<RISCVSubtarget>();
-  if (!ST->hasStdExtZcmp() && !ST->hasVendorXqccmp() && !ST->hasStdExtZdinx() &&
-      !ST->hasStdExtP())
-    return false;
-
-  if ((ST->hasStdExtZdinx() || ST->hasStdExtP()) && ST->is64Bit() &&
-      !ST->hasStdExtZcmp() && !ST->hasVendorXqccmp())
+  bool HasGPRPairCopy =
+      !ST->is64Bit() && (ST->hasStdExtZdinx() || ST->hasStdExtP());
+  if (!ST->hasStdExtZcmp() && !ST->hasVendorXqccmp() && !HasGPRPairCopy)
     return false;
 
   TII = ST->getInstrInfo();

--- a/llvm/test/CodeGen/RISCV/copysign-casts.ll
+++ b/llvm/test/CodeGen/RISCV/copysign-casts.ll
@@ -253,8 +253,7 @@ define double @fold_promote_d_h(double %a, half %b) nounwind {
 ; RV32IZDINX-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32IZDINX-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32IZDINX-NEXT:    sw s1, 4(sp) # 4-byte Folded Spill
-; RV32IZDINX-NEXT:    mv s1, a1
-; RV32IZDINX-NEXT:    mv s0, a0
+; RV32IZDINX-NEXT:    fmv.d s0, a0
 ; RV32IZDINX-NEXT:    mv a0, a2
 ; RV32IZDINX-NEXT:    call __extendhfsf2
 ; RV32IZDINX-NEXT:    fcvt.d.s a0, a0

--- a/llvm/test/CodeGen/RISCV/double-convert.ll
+++ b/llvm/test/CodeGen/RISCV/double-convert.ll
@@ -731,8 +731,7 @@ define i64 @fcvt_l_d_sat(double %a) nounwind {
 ; RV32IZFINXZDINX-NEXT:    lw a4, %lo(.LCPI12_0)(a2)
 ; RV32IZFINXZDINX-NEXT:    addi a2, a2, %lo(.LCPI12_0)
 ; RV32IZFINXZDINX-NEXT:    lw a5, 4(a2)
-; RV32IZFINXZDINX-NEXT:    mv s1, a1
-; RV32IZFINXZDINX-NEXT:    mv s0, a0
+; RV32IZFINXZDINX-NEXT:    fmv.d s0, a0
 ; RV32IZFINXZDINX-NEXT:    fle.d s2, a4, s0
 ; RV32IZFINXZDINX-NEXT:    call __fixdfdi
 ; RV32IZFINXZDINX-NEXT:    lui a3, 524288
@@ -975,8 +974,7 @@ define i64 @fcvt_lu_d_sat(double %a) nounwind {
 ; RV32IZFINXZDINX-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32IZFINXZDINX-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32IZFINXZDINX-NEXT:    sw s1, 4(sp) # 4-byte Folded Spill
-; RV32IZFINXZDINX-NEXT:    mv s1, a1
-; RV32IZFINXZDINX-NEXT:    mv s0, a0
+; RV32IZFINXZDINX-NEXT:    fmv.d s0, a0
 ; RV32IZFINXZDINX-NEXT:    call __fixunsdfdi
 ; RV32IZFINXZDINX-NEXT:    fle.d a2, zero, s0
 ; RV32IZFINXZDINX-NEXT:    lui a3, %hi(.LCPI14_0)

--- a/llvm/test/CodeGen/RISCV/double-mem.ll
+++ b/llvm/test/CodeGen/RISCV/double-mem.ll
@@ -249,8 +249,7 @@ define dso_local double @fld_stack(double %a) nounwind {
 ; RV32IZFINXZDINX-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
 ; RV32IZFINXZDINX-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
 ; RV32IZFINXZDINX-NEXT:    sw s1, 20(sp) # 4-byte Folded Spill
-; RV32IZFINXZDINX-NEXT:    mv s1, a1
-; RV32IZFINXZDINX-NEXT:    mv s0, a0
+; RV32IZFINXZDINX-NEXT:    fmv.d s0, a0
 ; RV32IZFINXZDINX-NEXT:    addi a0, sp, 8
 ; RV32IZFINXZDINX-NEXT:    call notdead
 ; RV32IZFINXZDINX-NEXT:    lw a1, 12(sp)
@@ -283,8 +282,7 @@ define dso_local double @fld_stack(double %a) nounwind {
 ; RV32IZFINXZDINXZILSD-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
 ; RV32IZFINXZDINXZILSD-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
 ; RV32IZFINXZDINXZILSD-NEXT:    sw s1, 20(sp) # 4-byte Folded Spill
-; RV32IZFINXZDINXZILSD-NEXT:    mv s1, a1
-; RV32IZFINXZDINXZILSD-NEXT:    mv s0, a0
+; RV32IZFINXZDINXZILSD-NEXT:    fmv.d s0, a0
 ; RV32IZFINXZDINXZILSD-NEXT:    addi a0, sp, 8
 ; RV32IZFINXZDINXZILSD-NEXT:    call notdead
 ; RV32IZFINXZDINXZILSD-NEXT:    ld a0, 8(sp)

--- a/llvm/test/CodeGen/RISCV/double-select-fcmp.ll
+++ b/llvm/test/CodeGen/RISCV/double-select-fcmp.ll
@@ -16,8 +16,7 @@ define double @select_fcmp_false(double %a, double %b) nounwind {
 ;
 ; CHECKRV32ZDINX-LABEL: select_fcmp_false:
 ; CHECKRV32ZDINX:       # %bb.0:
-; CHECKRV32ZDINX-NEXT:    mv a1, a3
-; CHECKRV32ZDINX-NEXT:    mv a0, a2
+; CHECKRV32ZDINX-NEXT:    fmv.d a0, a2
 ; CHECKRV32ZDINX-NEXT:    ret
 ;
 ; CHECKRV64ZDINX-LABEL: select_fcmp_false:

--- a/llvm/test/CodeGen/RISCV/double-stack-spill-restore.ll
+++ b/llvm/test/CodeGen/RISCV/double-stack-spill-restore.ll
@@ -66,8 +66,7 @@ define double @func(double %d, i32 %n) nounwind {
 ; RV32IZFINXZDINX-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32IZFINXZDINX-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32IZFINXZDINX-NEXT:    sw s1, 4(sp) # 4-byte Folded Spill
-; RV32IZFINXZDINX-NEXT:    mv s1, a1
-; RV32IZFINXZDINX-NEXT:    mv s0, a0
+; RV32IZFINXZDINX-NEXT:    fmv.d s0, a0
 ; RV32IZFINXZDINX-NEXT:    beqz a2, .LBB0_2
 ; RV32IZFINXZDINX-NEXT:  # %bb.1: # %if.else
 ; RV32IZFINXZDINX-NEXT:    addi a2, a2, -1


### PR DESCRIPTION
This PR addresses post-commit reviews in #182416

Previously, `RISCVMoveMerger` only identified and merged 32-bit moves into a 64-bit GPRPair move if the even-indexed register most appeared before the odd-index register move.  

This patch extends the pass by disregarding the order of even/odd-index pair.