### PR TITLE
[AMDGPU] Add -amdgpu-allow-lds-in-non-entry-functions flag

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -37,6 +37,12 @@ static cl::opt<bool> AMDGPUBypassSlowDiv(
   cl::desc("Skip 64-bit divide for dynamic 32-bit values"),
   cl::init(true));
 
+cl::opt<bool> AMDGPUAllowLDSInNonEntryFunctions(
+    "amdgpu-allow-lds-in-non-entry-functions",
+    cl::desc("Allow LDS global variables to be lowered in non-entry functions "
+             "instead of emitting a diagnostic and trap"),
+    cl::init(false), cl::Hidden);
+
 // Find a larger type to do a load / store of a vector with.
 EVT AMDGPUTargetLowering::getEquivalentMemType(LLVMContext &Ctx, EVT VT) {
   unsigned StoreSize = VT.getStoreSizeInBits();
@@ -1542,7 +1548,7 @@ SDValue AMDGPUTargetLowering::LowerGlobalAddress(AMDGPUMachineFunction* MFI,
 
   if (G->getAddressSpace() == AMDGPUAS::LOCAL_ADDRESS ||
       G->getAddressSpace() == AMDGPUAS::REGION_ADDRESS) {
-    if (!MFI->isModuleEntryFunction() &&
+    if (!AMDGPUAllowLDSInNonEntryFunctions && !MFI->isModuleEntryFunction() &&
         GV->getName() != "llvm.amdgcn.module.lds" &&
         !AMDGPU::isNamedBarrier(*cast<GlobalVariable>(GV))) {
       SDLoc DL(Op);

--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -36,6 +36,7 @@
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/IR/IntrinsicsR600.h"
+#include "llvm/Support/CommandLine.h"
 
 #define DEBUG_TYPE "amdgpu-legalinfo"
 
@@ -44,6 +45,8 @@ using namespace LegalizeActions;
 using namespace LegalizeMutations;
 using namespace LegalityPredicates;
 using namespace MIPatternMatch;
+
+extern cl::opt<bool> AMDGPUAllowLDSInNonEntryFunctions;
 
 // Hack until load/store selection patterns support any tuple of legal types.
 static cl::opt<bool> EnableNewLegality(
@@ -3166,7 +3169,7 @@ bool AMDGPULegalizerInfo::legalizeGlobalValue(
   SIMachineFunctionInfo *MFI = MF.getInfo<SIMachineFunctionInfo>();
 
   if (AS == AMDGPUAS::LOCAL_ADDRESS || AS == AMDGPUAS::REGION_ADDRESS) {
-    if (!MFI->isModuleEntryFunction() &&
+    if (!AMDGPUAllowLDSInNonEntryFunctions && !MFI->isModuleEntryFunction() &&
         GV->getName() != "llvm.amdgcn.module.lds" &&
         !AMDGPU::isNamedBarrier(*cast<GlobalVariable>(GV))) {
       const Function &Fn = MF.getFunction();

--- a/llvm/test/CodeGen/AMDGPU/lds-global-non-entry-func-allow.ll
+++ b/llvm/test/CodeGen/AMDGPU/lds-global-non-entry-func-allow.ll
@@ -1,0 +1,62 @@
+; RUN: llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -o - \
+; RUN:   -amdgpu-enable-lower-module-lds=false \
+; RUN:   -amdgpu-allow-lds-in-non-entry-functions %s 2> %t \
+; RUN:   | FileCheck -check-prefix=SDAG %s
+; RUN: FileCheck -check-prefix=NOERR --allow-empty %s < %t
+;
+; RUN: llc -global-isel=1 -new-reg-bank-select -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -o - \
+; RUN:   -amdgpu-enable-lower-module-lds=false \
+; RUN:   -amdgpu-allow-lds-in-non-entry-functions %s 2> %t \
+; RUN:   | FileCheck -check-prefix=GISEL %s
+; RUN: FileCheck -check-prefix=NOERR --allow-empty %s < %t
+
+; Verify that -amdgpu-allow-lds-in-non-entry-functions suppresses the
+; "local memory global used by non-kernel function" diagnostic and allows
+; normal LDS allocation in non-entry-point functions.
+
+; NOERR-NOT: warning
+; NOERR-NOT: local memory global used by non-kernel function
+
+@lds = internal addrspace(3) global float poison, align 4
+
+define void @func_use_lds_global() {
+; SDAG-LABEL: func_use_lds_global:
+; SDAG:       ; %bb.0:
+; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; SDAG-NEXT:    ds_write_b32 v0, v0
+; SDAG-NEXT:    s_waitcnt lgkmcnt(0)
+; SDAG-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-LABEL: func_use_lds_global:
+; GISEL:       ; %bb.0:
+; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GISEL-NEXT:    ds_write_b32 v0, v0
+; GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GISEL-NEXT:    s_setpc_b64 s[30:31]
+  store volatile float 0.0, ptr addrspace(3) @lds, align 4
+  ret void
+}
+
+; When the flag is set, the LDS address should be materialized as a constant
+; and stored normally, without a trap.
+define void @func_use_lds_global_constexpr_cast(ptr addrspace(1) %out) {
+; SDAG-LABEL: func_use_lds_global_constexpr_cast:
+; SDAG:       ; %bb.0:
+; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-NEXT:    v_mov_b32_e32 v2, 0
+; SDAG-NEXT:    global_store_dword v[0:1], v2, off
+; SDAG-NEXT:    s_waitcnt vmcnt(0)
+; SDAG-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-LABEL: func_use_lds_global_constexpr_cast:
+; GISEL:       ; %bb.0:
+; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-NEXT:    v_mov_b32_e32 v2, 0
+; GISEL-NEXT:    global_store_dword v[0:1], v2, off
+; GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GISEL-NEXT:    s_setpc_b64 s[30:31]
+  store i32 ptrtoint (ptr addrspace(3) @lds to i32), ptr addrspace(1) %out, align 4
+  ret void
+}


### PR DESCRIPTION
## Summary

- Add hidden `-amdgpu-allow-lds-in-non-entry-functions` flag (default off) to suppress the "local memory global used by non-kernel function" diagnostic and allow normal LDS allocation in non-entry functions.
- Gate the diagnostic+trap in both SelectionDAG (`AMDGPUISelLowering.cpp`) and GlobalISel (`AMDGPULegalizerInfo.cpp`) paths.
- Add lit test covering both SDAG and GlobalISel with the flag enabled.

## Motivation

There are use cases where a non-kernel function legitimately accesses LDS that has been set up by the calling kernel. The current unconditional diagnostic+trap prevents this. This flag allows a user to bypass this behavior.

## Test plan

- [x] New test: `lds-global-non-entry-func-allow.ll` (SDAG + GlobalISel)
- [x] Existing test `lds-global-non-entry-func.ll` passes unchanged
- [x] Full AMDGPU CodeGen test suite passes

Yes, I did let cursor write the code (after identifying it and commenting it out for testing) and draft the PR. I have tested the new flag extensively as part of a project to greatly improve RCCL build time.

Made with [Cursor](https://cursor.com)