### PR TITLE
[Clang][docs] Fix proposal number typo for P1847R4

### DIFF
--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -387,7 +387,7 @@ C++23, informally referred to as C++26.</p>
     </tr>
     <tr>
       <td>Make declaration order layout mandated</td>
-      <td><a href="https://wg21.link/p1847r4">P1874R4</a></td>
+      <td><a href="https://wg21.link/p1847r4">P1847R4</a></td>
       <td class="full" align="center">Yes</td>
     </tr>
     <tr>


### PR DESCRIPTION
This PR fixes a typo in `clang/www/cxx_status.html`. 

The link text for the feature "Make declaration order layout mandated" incorrectly referred to **P1874R4**, while the actual URL (https://wg21.link/p1847r4) and the feature name correctly point to **P1847R4**.

This change corrects the displayed text to match the proposal number.