### PR TITLE
[bazel] Enable `parse_headers` for llvm/BUILD.bazel

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -2,7 +2,6 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
@@ -19,7 +18,10 @@ load(":targets.bzl", "llvm_targets")
 
 package(
     default_visibility = ["//visibility:public"],
-    features = ["layering_check"],
+    features = [
+        "parse_headers",
+        "layering_check",
+    ],
 )
 
 licenses(["notice"])
@@ -343,6 +345,7 @@ cc_library(
             "BLAKE3_NO_SSE41",
         ],
     }),
+    features = ["-parse_headers"],
     includes = ["include"],
     linkopts = select({
         ":is_windows_clang_mingw": [
@@ -466,6 +469,7 @@ cc_library(
         "include/llvm/IR/Value.def",
     ],
     copts = llvm_copts,
+    features = ["-parse_headers"],
 )
 
 cc_library(
@@ -510,6 +514,7 @@ cc_library(
     hdrs = glob(["include/llvm/DebugInfo/*.h"]),
     copts = llvm_copts,
     deps = [
+        ":BinaryFormatELF",
         ":Object",
         ":Support",
     ],
@@ -650,6 +655,7 @@ cc_library(
         "include/llvm/MC/*.h",
     ]),
     copts = llvm_copts,
+    features = ["-parse_headers"],
     deps = [
         ":BinaryFormat",
         ":DebugInfoCodeView",
@@ -841,6 +847,7 @@ cc_binary(
         ],
     ) + ["include/llvm/TargetParser/SubtargetFeature.h"],
     copts = llvm_copts,
+    features = ["-parse_headers"],
     includes = ["utils/TableGen"],
     stamp = 0,
     deps = [
@@ -1091,6 +1098,7 @@ cc_library(
         "include/llvm/ProfileData/InstrProfData.inc",
     ] + [":llvm_intrinsics_headers"],
     copts = llvm_copts,
+    features = ["-parse_headers"],
     textual_hdrs = glob([
         "include/llvm/IR/*.def",
     ]),
@@ -1321,6 +1329,7 @@ cc_library(
         ],
     ) + ["include/llvm-c/Analysis.h"],
     copts = llvm_copts + ["-ftrapping-math"],
+    features = ["-parse_headers"],
     textual_hdrs = glob([
         "include/llvm/Analysis/*.def",
     ]),
@@ -1576,6 +1585,7 @@ cc_library(
         "include/llvm/Transforms/Utils.h",
     ],
     copts = llvm_copts,
+    features = ["-parse_headers"],
     deps = [
         ":Analysis",
         ":BinaryFormat",
@@ -2165,6 +2175,7 @@ cc_library(
         ],
     ),
     copts = llvm_copts,
+    features = ["-parse_headers"],
     textual_hdrs = glob([
         "include/llvm/CodeGen/**/*.def",
     ]),
@@ -3800,7 +3811,10 @@ gentbl_cc_library(
         ),
         hdrs = ["lib/Target/" + target["name"] + "/" + target["short_name"] + ".h"],
         copts = llvm_copts,
-        features = ["-layering_check"],
+        features = [
+            "-layering_check",
+            "-parse_headers",
+        ],
         strip_include_prefix = "lib/Target/" + target["name"],
         textual_hdrs = glob(
             [
@@ -3841,6 +3855,7 @@ gentbl_cc_library(
             allow_empty = True,
         ),
         copts = llvm_copts,
+        features = ["-parse_headers"],
         deps = [
             ":BinaryFormat",
             ":CodeGenTypes",
@@ -4095,11 +4110,13 @@ cc_library(
         ],
     ) + ["include/llvm-c/ExecutionEngine.h"],
     copts = llvm_copts,
+    features = ["-parse_headers"],
     deps = [
         ":BinaryFormat",
         ":CodeGen",
         ":Core",
         ":DebugInfo",
+        ":DebugInfoDWARF",
         ":MC",
         ":MCDisassembler",
         ":Object",
@@ -4152,7 +4169,9 @@ cc_library(
     ]),
     copts = llvm_copts,
     deps = [
+        ":Analysis",
         ":BinaryFormat",
+        ":Core",
         ":ExecutionEngine",
         ":JITLinkTableGen",
         ":Object",
@@ -4160,7 +4179,9 @@ cc_library(
         ":OrcShared",
         ":OrcTargetProcess",
         ":Support",
+        ":Target",
         ":TargetParser",
+        ":TransformUtils",
         ":config",
     ],
 )
@@ -4451,6 +4472,7 @@ cc_library(
         "include/llvm/WindowsDriver/*.h",
     ]),
     copts = llvm_copts,
+    features = ["-parse_headers"],
     deps = [
         ":Option",
         ":Support",
@@ -4764,6 +4786,7 @@ cc_binary(
         "tools/llubi/lib/*.cpp",
         "tools/llubi/lib/*.h",
     ]),
+    features = ["-parse_headers"],
     stamp = 0,
     deps = [
         ":Analysis",
@@ -6422,6 +6445,7 @@ cc_library(
     ]),
     hdrs = glob(["include/llvm/Testing/Support/*.h"]),
     copts = llvm_copts,
+    features = ["-layering_check"],
     deps = [
         ":Support",
         ":config",


### PR DESCRIPTION
Instead of excluding the whole package, push any existing parse_headers failures to individual targets. In some cases we can avoid suppressing a target by adding a few missing deps.