### PR TITLE
[LangRef] Clarify in vscale_range that vscale is a power-of-two without the attribute

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2771,12 +2771,12 @@ For example:
     than `UINT_MAX`.  It's unspecified which threshold will be used when
     duplicate definitions are linked together with differing values.
 ``vscale_range(<min>[, <max>])``
-    This function attribute indicates `vscale` is a power-of-two within a
-    specified range. `min` must be a power-of-two that is greater than 0. When
-    specified, `max` must be a power-of-two greater-than-or-equal to `min` or 0
-    to signify an unbounded maximum. The syntax `vscale_range(<val>)` can be
-    used to set both `min` and `max` to the same value. Functions that don't
-    include this attribute make no assumptions about the value of `vscale`.
+    This function attribute indicates `vscale` is within a specified
+    range. `min` must be a power-of-two that is greater than 0. When specified,
+    `max` must be a power-of-two greater-than-or-equal to `min` or 0 to signify
+    an unbounded maximum. The syntax `vscale_range(<val>)` can be used to set
+    both `min` and `max` to the same value. Functions that don't include this
+    attribute make no assumptions about the range of `vscale`.
 ``nooutline``
     This attribute indicates that outlining passes should not modify the
     function.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2771,12 +2771,12 @@ For example:
     than `UINT_MAX`.  It's unspecified which threshold will be used when
     duplicate definitions are linked together with differing values.
 ``vscale_range(<min>[, <max>])``
-    This function attribute indicates `vscale` is within a specified
-    range. `min` must be a power-of-two that is greater than 0. When specified,
-    `max` must be a power-of-two greater-than-or-equal to `min` or 0 to signify
-    an unbounded maximum. The syntax `vscale_range(<val>)` can be used to set
-    both `min` and `max` to the same value. Functions that don't include this
-    attribute make no assumptions about the range of `vscale`.
+    This function attribute indicates `vscale` is a power-of-two within a
+    specified range. `min` must be a power-of-two that is greater than 0. When
+    specified, `max` must be a power-of-two greater-than-or-equal to `min` or 0
+    to signify an unbounded maximum. The syntax `vscale_range(<val>)` can be
+    used to set both `min` and `max` to the same value. Functions that don't
+    include this attribute make no assumptions about the range of `vscale`.
 ``nooutline``
     This attribute indicates that outlining passes should not modify the
     function.


### PR DESCRIPTION
Previously vscale_range used to add the constraint that vscale is a
power-of-two, but after #183080 it's already a power-of-two to begin with.

This clarifies the sentence about assumptions when there is no attribute
