### PR TITLE
[InstCombine] make `foldBinOpIntoSelectOrPhi` fold on all operands

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -2314,20 +2314,19 @@ Instruction *InstCombinerImpl::foldBinopWithPhiOperands(BinaryOperator &BO) {
 }
 
 Instruction *InstCombinerImpl::foldBinOpIntoSelectOrPhi(BinaryOperator &I) {
-  auto TryFoldOperand = [&](unsigned OpIdx, bool IsOtherParamConst) {
+  auto TryFoldOperand = [&](unsigned OpIdx,
+                            bool IsOtherParamConst) -> Instruction * {
     if (auto *Sel = dyn_cast<SelectInst>(I.getOperand(OpIdx)))
       return FoldOpIntoSelect(I, Sel, false, !IsOtherParamConst);
     if (auto *PN = dyn_cast<PHINode>(I.getOperand(OpIdx)))
       return foldOpIntoPhi(I, PN);
-    return static_cast<Instruction *>(nullptr);
+    return nullptr;
   };
 
   if (Instruction *NewI =
           TryFoldOperand(/*OpIdx=*/0, isa<Constant>(I.getOperand(1))))
     return NewI;
-  if (I.isCommutative())
-    return TryFoldOperand(/*OpIdx=*/1, isa<Constant>(I.getOperand(0)));
-  return nullptr;
+  return TryFoldOperand(/*OpIdx=*/1, isa<Constant>(I.getOperand(0)));
 }
 
 static bool shouldMergeGEPs(GEPOperator &GEP, GEPOperator &Src) {

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -2314,25 +2314,19 @@ Instruction *InstCombinerImpl::foldBinopWithPhiOperands(BinaryOperator &BO) {
 }
 
 Instruction *InstCombinerImpl::foldBinOpIntoSelectOrPhi(BinaryOperator &I) {
-  bool IsOtherParamConst = isa<Constant>(I.getOperand(1));
+  auto TryFoldOperand = [&](unsigned OpIdx, bool IsOtherParamConst) {
+    if (auto *Sel = dyn_cast<SelectInst>(I.getOperand(OpIdx)))
+      return FoldOpIntoSelect(I, Sel, false, !IsOtherParamConst);
+    if (auto *PN = dyn_cast<PHINode>(I.getOperand(OpIdx)))
+      return foldOpIntoPhi(I, PN);
+    return static_cast<Instruction *>(nullptr);
+  };
 
-  if (auto *Sel = dyn_cast<SelectInst>(I.getOperand(0))) {
-    if (Instruction *NewSel =
-            FoldOpIntoSelect(I, Sel, false, !IsOtherParamConst))
-      return NewSel;
-  } else if (auto *PN = dyn_cast<PHINode>(I.getOperand(0))) {
-    if (Instruction *NewPhi = foldOpIntoPhi(I, PN))
-      return NewPhi;
-  }
-
-  if (I.isCommutative()) {
-    bool IsOtherParamConst = isa<Constant>(I.getOperand(0));
-    if (auto *Sel = dyn_cast<SelectInst>(I.getOperand(1))) {
-      if (Instruction *NewSel =
-              FoldOpIntoSelect(I, Sel, false, !IsOtherParamConst))
-        return NewSel;
-    }
-  }
+  if (Instruction *NewI = TryFoldOperand(/*OpIdx=*/0,
+                                         isa<Constant>(I.getOperand(1))))
+    return NewI;
+  if (I.isCommutative())
+    return TryFoldOperand(/*OpIdx=*/1, isa<Constant>(I.getOperand(0)));
   return nullptr;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -2322,8 +2322,8 @@ Instruction *InstCombinerImpl::foldBinOpIntoSelectOrPhi(BinaryOperator &I) {
     return static_cast<Instruction *>(nullptr);
   };
 
-  if (Instruction *NewI = TryFoldOperand(/*OpIdx=*/0,
-                                         isa<Constant>(I.getOperand(1))))
+  if (Instruction *NewI =
+          TryFoldOperand(/*OpIdx=*/0, isa<Constant>(I.getOperand(1))))
     return NewI;
   if (I.isCommutative())
     return TryFoldOperand(/*OpIdx=*/1, isa<Constant>(I.getOperand(0)));

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -2324,6 +2324,15 @@ Instruction *InstCombinerImpl::foldBinOpIntoSelectOrPhi(BinaryOperator &I) {
     if (Instruction *NewPhi = foldOpIntoPhi(I, PN))
       return NewPhi;
   }
+
+  if (I.isCommutative()) {
+    bool IsOtherParamConst = isa<Constant>(I.getOperand(0));
+    if (auto *Sel = dyn_cast<SelectInst>(I.getOperand(1))) {
+      if (Instruction *NewSel =
+              FoldOpIntoSelect(I, Sel, false, !IsOtherParamConst))
+        return NewSel;
+    }
+  }
   return nullptr;
 }
 

--- a/llvm/test/Transforms/InstCombine/binop-phi-operands.ll
+++ b/llvm/test/Transforms/InstCombine/binop-phi-operands.ll
@@ -777,3 +777,120 @@ f:
   %t21 = insertvalue { i64, i32 } %t20, i32 %t16, 1
   ret { i64, i32 } %t21
 }
+
+define i32 @sub_partial_fold_phi_operand1(i1 %which, i32 %x) {
+; CHECK-LABEL: @sub_partial_fold_phi_operand1(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br i1 [[WHICH:%.*]], label [[CONST_IN:%.*]], label [[VAR_IN:%.*]]
+; CHECK:       const.in:
+; CHECK-NEXT:    br label [[FINAL:%.*]]
+; CHECK:       var.in:
+; CHECK-NEXT:    [[SUB_X:%.*]] = sub i32 122, [[X:%.*]]
+; CHECK-NEXT:    br label [[FINAL]]
+; CHECK:       final:
+; CHECK-NEXT:    [[P_NEG:%.*]] = phi i32 [ 113, [[CONST_IN]] ], [ [[SUB_X]], [[VAR_IN]] ]
+; CHECK-NEXT:    ret i32 [[P_NEG]]
+;
+entry:
+  br i1 %which, label %const.in, label %var.in
+
+const.in:
+  br label %final
+
+var.in:
+  %x1 = add i32 %x, 1
+  br label %final
+
+final:
+  %p = phi i32 [ 10, %const.in ], [ %x1, %var.in ]
+  %value = sub i32 123, %p
+  ret i32 %value
+}
+
+define i32 @sub_partial_fold_phi_operand1_phi_swapped(i1 %which, i32 %x) {
+; CHECK-LABEL: @sub_partial_fold_phi_operand1_phi_swapped(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br i1 [[WHICH:%.*]], label [[VAR_IN:%.*]], label [[CONST_IN:%.*]]
+; CHECK:       var.in:
+; CHECK-NEXT:    [[SUB_X:%.*]] = sub i32 122, [[X:%.*]]
+; CHECK-NEXT:    br label [[FINAL:%.*]]
+; CHECK:       const.in:
+; CHECK-NEXT:    br label [[FINAL]]
+; CHECK:       final:
+; CHECK-NEXT:    [[P_NEG:%.*]] = phi i32 [ [[SUB_X]], [[VAR_IN]] ], [ 113, [[CONST_IN]] ]
+; CHECK-NEXT:    ret i32 [[P_NEG]]
+;
+entry:
+  br i1 %which, label %var.in, label %const.in
+
+var.in:
+  %x1 = add i32 %x, 1
+  br label %final
+
+const.in:
+  br label %final
+
+final:
+  %p = phi i32 [ %x1, %var.in ], [ 10, %const.in ]
+  %value = sub i32 123, %p
+  ret i32 %value
+}
+
+define i32 @sub_partial_fold_phi_operand0_binop_swapped(i1 %which, i32 %x) {
+; CHECK-LABEL: @sub_partial_fold_phi_operand0_binop_swapped(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br i1 [[WHICH:%.*]], label [[CONST_IN:%.*]], label [[VAR_IN:%.*]]
+; CHECK:       const.in:
+; CHECK-NEXT:    br label [[FINAL:%.*]]
+; CHECK:       var.in:
+; CHECK-NEXT:    [[ADD_X:%.*]] = add i32 [[X:%.*]], -122
+; CHECK-NEXT:    br label [[FINAL]]
+; CHECK:       final:
+; CHECK-NEXT:    [[P:%.*]] = phi i32 [ -113, [[CONST_IN]] ], [ [[ADD_X]], [[VAR_IN]] ]
+; CHECK-NEXT:    ret i32 [[P]]
+;
+entry:
+  br i1 %which, label %const.in, label %var.in
+
+const.in:
+  br label %final
+
+var.in:
+  %x1 = add i32 %x, 1
+  br label %final
+
+final:
+  %p = phi i32 [ 10, %const.in ], [ %x1, %var.in ]
+  %value = sub i32 %p, 123
+  ret i32 %value
+}
+
+define i32 @sub_partial_fold_phi_operand0_phi_swapped_binop_swapped(i1 %which,
+                                                                     i32 %x) {
+; CHECK-LABEL: @sub_partial_fold_phi_operand0_phi_swapped_binop_swapped(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br i1 [[WHICH:%.*]], label [[VAR_IN:%.*]], label [[CONST_IN:%.*]]
+; CHECK:       var.in:
+; CHECK-NEXT:    [[ADD_X:%.*]] = add i32 [[X:%.*]], -122
+; CHECK-NEXT:    br label [[FINAL:%.*]]
+; CHECK:       const.in:
+; CHECK-NEXT:    br label [[FINAL]]
+; CHECK:       final:
+; CHECK-NEXT:    [[P:%.*]] = phi i32 [ [[ADD_X]], [[VAR_IN]] ], [ -113, [[CONST_IN]] ]
+; CHECK-NEXT:    ret i32 [[P]]
+;
+entry:
+  br i1 %which, label %var.in, label %const.in
+
+var.in:
+  %x1 = add i32 %x, 1
+  br label %final
+
+const.in:
+  br label %final
+
+final:
+  %p = phi i32 [ %x1, %var.in ], [ 10, %const.in ]
+  %value = sub i32 %p, 123
+  ret i32 %value
+}

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -557,6 +557,18 @@ define i32 @OrSelectIcmpZero(i32 %a, i32 %b) {
   ret i32 %or
 }
 
+define i32 @OrSelectIcmpZeroCommuted(i32 %a, i32 %b) {
+; CHECK-LABEL: @OrSelectIcmpZeroCommuted(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[A:%.*]], 0
+; CHECK-NEXT:    [[OR:%.*]] = select i1 [[CMP]], i32 [[B:%.*]], i32 [[A]]
+; CHECK-NEXT:    ret i32 [[OR]]
+;
+  %cmp = icmp eq i32 %a, 0
+  %sel = select i1 %cmp, i32 %b, i32 0
+  %or = or i32 %a, %sel
+  ret i32 %or
+}
+
 define i32 @OrSelectIcmpNonZero(i32 %a, i32 %b) {
 ; CHECK-LABEL: @OrSelectIcmpNonZero(
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[A:%.*]], 0

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -557,18 +557,6 @@ define i32 @OrSelectIcmpZero(i32 %a, i32 %b) {
   ret i32 %or
 }
 
-define i32 @OrSelectIcmpZeroCommuted(i32 %a, i32 %b) {
-; CHECK-LABEL: @OrSelectIcmpZeroCommuted(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[A:%.*]], 0
-; CHECK-NEXT:    [[OR:%.*]] = select i1 [[CMP]], i32 [[B:%.*]], i32 [[A]]
-; CHECK-NEXT:    ret i32 [[OR]]
-;
-  %cmp = icmp eq i32 %a, 0
-  %sel = select i1 %cmp, i32 %b, i32 0
-  %or = or i32 %a, %sel
-  ret i32 %or
-}
-
 define i32 @OrSelectIcmpNonZero(i32 %a, i32 %b) {
 ; CHECK-LABEL: @OrSelectIcmpNonZero(
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[A:%.*]], 0

--- a/llvm/test/Transforms/InstCombine/fmul.ll
+++ b/llvm/test/Transforms/InstCombine/fmul.ll
@@ -1257,7 +1257,7 @@ define float @fmul_select_strict(float %x, i1 %c) {
 define double @fmul_sqrt_select(double %x, i1 %c) {
 ; CHECK-LABEL: @fmul_sqrt_select(
 ; CHECK-NEXT:    [[SQR:%.*]] = call double @llvm.sqrt.f64(double [[X:%.*]])
-; CHECK-NEXT:    [[MUL:%.*]] = select fast i1 [[C:%.*]], double [[X]], double [[SQR]]
+; CHECK-NEXT:    [[MUL:%.*]] = select i1 [[C:%.*]], double [[X]], double [[SQR]]
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
   %sqr = call double @llvm.sqrt.f64(double %x)

--- a/llvm/test/Transforms/InstCombine/icmp-binop.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-binop.ll
@@ -486,10 +486,7 @@ define <2 x i1> @icmp_eq_or_of_selects_with_constant_vectorized_nonsplat(<2 x i1
 define <2 x i1> @pr173177(<2 x i1> %a, i1 %b) {
 ; CHECK-LABEL: @pr173177(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[S1:%.*]] = select <2 x i1> [[A:%.*]], <2 x i16> splat (i16 179), <2 x i16> splat (i16 1)
-; CHECK-NEXT:    [[S2:%.*]] = select i1 [[B:%.*]], <2 x i16> zeroinitializer, <2 x i16> splat (i16 255)
-; CHECK-NEXT:    [[AND:%.*]] = and <2 x i16> [[S1]], [[S2]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x i16> [[AND]], zeroinitializer
+; CHECK-NEXT:    [[CMP:%.*]] = select i1 [[B:%.*]], <2 x i1> splat (i1 true), <2 x i1> zeroinitializer
 ; CHECK-NEXT:    ret <2 x i1> [[CMP]]
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/or-select-zero-icmp.ll
+++ b/llvm/test/Transforms/InstCombine/or-select-zero-icmp.ll
@@ -18,8 +18,7 @@ define i32 @basic(i32 %a, i32 %b) {
 define i32 @swap_operand_order(i32 %x, i32 %y) {
 ; CHECK-LABEL: @swap_operand_order(
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X:%.*]], 0
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i32 [[Y:%.*]], i32 0
-; CHECK-NEXT:    [[RES:%.*]] = or i32 [[X]], [[SEL]]
+; CHECK-NEXT:    [[RES:%.*]] = select i1 [[CMP]], i32 [[Y:%.*]], i32 [[X]]
 ; CHECK-NEXT:    ret i32 [[RES]]
 ;
   %cmp = icmp eq i32 %x, 0
@@ -60,8 +59,7 @@ define i32 @negative_wrong_predicate(i32 %a, i32 %b) {
 define i32 @cmp_swapped(i32 %x, i32 %y) {
 ; CHECK-LABEL: @cmp_swapped(
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X:%.*]], 0
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i32 [[Y:%.*]], i32 0
-; CHECK-NEXT:    [[RES:%.*]] = or i32 [[X]], [[SEL]]
+; CHECK-NEXT:    [[RES:%.*]] = select i1 [[CMP]], i32 [[Y:%.*]], i32 [[X]]
 ; CHECK-NEXT:    ret i32 [[RES]]
 ;
   %cmp = icmp eq i32 0, %x

--- a/llvm/test/Transforms/InstCombine/recurrence.ll
+++ b/llvm/test/Transforms/InstCombine/recurrence.ll
@@ -43,9 +43,9 @@ loop:                                             ; preds = %loop, %entry
 define i64 @test_or3(i64 %a, i64 %b) {
 ; CHECK-LABEL: @test_or3(
 ; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[IV_NEXT:%.*]] = or i64 [[B:%.*]], [[A:%.*]]
 ; CHECK-NEXT:    br label [[LOOP:%.*]]
 ; CHECK:       loop:
-; CHECK-NEXT:    [[IV_NEXT:%.*]] = or i64 [[A:%.*]], [[B:%.*]]
 ; CHECK-NEXT:    tail call void @use(i64 [[IV_NEXT]])
 ; CHECK-NEXT:    br label [[LOOP]]
 ;
@@ -123,9 +123,9 @@ loop:                                             ; preds = %loop, %entry
 define i64 @test_and3(i64 %a, i64 %b) {
 ; CHECK-LABEL: @test_and3(
 ; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[IV_NEXT:%.*]] = and i64 [[B:%.*]], [[A:%.*]]
 ; CHECK-NEXT:    br label [[LOOP:%.*]]
 ; CHECK:       loop:
-; CHECK-NEXT:    [[IV_NEXT:%.*]] = and i64 [[A:%.*]], [[B:%.*]]
 ; CHECK-NEXT:    tail call void @use(i64 [[IV_NEXT]])
 ; CHECK-NEXT:    br label [[LOOP]]
 ;

--- a/llvm/test/Transforms/InstCombine/select.ll
+++ b/llvm/test/Transforms/InstCombine/select.ll
@@ -3964,18 +3964,12 @@ define i32 @pr61361(i32 %arg) {
 
 define i32 @pr62088() {
 ; CHECK-LABEL: define i32 @pr62088() {
-; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label %[[LOOP:.*]]
 ; CHECK:       [[LOOP]]:
-; CHECK-NEXT:    [[NOT2:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ -2, %[[LOOP]] ]
-; CHECK-NEXT:    [[H_0:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ 1, %[[LOOP]] ]
-; CHECK-NEXT:    [[XOR:%.*]] = or disjoint i32 [[H_0]], [[NOT2]]
-; CHECK-NEXT:    [[SUB5:%.*]] = sub i32 -1824888657, [[XOR]]
-; CHECK-NEXT:    [[XOR6:%.*]] = xor i32 [[SUB5]], -1260914025
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[XOR6]], 824855120
-; CHECK-NEXT:    br i1 [[CMP]], label %[[LOOP]], label %[[EXIT:.*]]
+; CHECK-NEXT:    br i1 true, label %[[LOOP]], label %[[EXIT:.*]]
 ; CHECK:       [[EXIT]]:
-; CHECK-NEXT:    ret i32 [[H_0]]
+; CHECK-NEXT:    ret i32 poison
 ;
 entry:
   br label %loop

--- a/llvm/test/Transforms/LoopVectorize/induction.ll
+++ b/llvm/test/Transforms/LoopVectorize/induction.ll
@@ -3088,6 +3088,7 @@ define i32 @testoverflowcheck() {
 ; IND-NEXT:    [[TMP4:%.*]] = insertelement <2 x i32> <i32 poison, i32 -1>, i32 [[C_PROMOTED_I]], i64 0
 ; IND-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x i32> poison, i32 [[TMP0]], i64 0
 ; IND-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x i32> [[BROADCAST_SPLATINSERT]], <2 x i32> poison, <2 x i32> zeroinitializer
+; IND-NEXT:    [[TMP6:%.*]] = and <2 x i32> [[BROADCAST_SPLAT]], [[TMP4]]
 ; IND-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; IND:       vector.body:
 ; IND-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
@@ -3095,17 +3096,16 @@ define i32 @testoverflowcheck() {
 ; IND-NEXT:    [[TMP5:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
 ; IND-NEXT:    br i1 [[TMP5]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP30:![0-9]+]]
 ; IND:       middle.block:
-; IND-NEXT:    [[TMP6:%.*]] = and <2 x i32> [[TMP4]], [[BROADCAST_SPLAT]]
 ; IND-NEXT:    [[TMP7:%.*]] = call i32 @llvm.vector.reduce.and.v2i32(<2 x i32> [[TMP6]])
 ; IND-NEXT:    [[CMP_N:%.*]] = icmp eq i32 [[TMP3]], [[N_VEC]]
 ; IND-NEXT:    br i1 [[CMP_N]], label [[LOOPEXIT:%.*]], label [[SCALAR_PH]]
 ; IND:       scalar.ph:
 ; IND-NEXT:    [[BC_RESUME_VAL:%.*]] = phi i8 [ [[IND_END]], [[MIDDLE_BLOCK]] ], [ [[DOTPR_I]], [[ENTRY:%.*]] ]
 ; IND-NEXT:    [[BC_MERGE_RDX:%.*]] = phi i32 [ [[TMP7]], [[MIDDLE_BLOCK]] ], [ [[C_PROMOTED_I]], [[ENTRY]] ]
+; IND-NEXT:    [[AND_I:%.*]] = and i32 [[TMP0]], [[BC_MERGE_RDX]]
 ; IND-NEXT:    br label [[COND_END_I:%.*]]
 ; IND:       cond.end.i:
 ; IND-NEXT:    [[INC4_I:%.*]] = phi i8 [ [[BC_RESUME_VAL]], [[SCALAR_PH]] ], [ [[INC_I:%.*]], [[COND_END_I]] ]
-; IND-NEXT:    [[AND_I:%.*]] = and i32 [[BC_MERGE_RDX]], [[TMP0]]
 ; IND-NEXT:    [[INC_I]] = add i8 [[INC4_I]], 1
 ; IND-NEXT:    [[TOBOOL_I:%.*]] = icmp eq i8 [[INC_I]], 0
 ; IND-NEXT:    br i1 [[TOBOOL_I]], label [[LOOPEXIT]], label [[COND_END_I]], !llvm.loop [[LOOP31:![0-9]+]]
@@ -3130,6 +3130,7 @@ define i32 @testoverflowcheck() {
 ; UNROLL-NEXT:    [[TMP4:%.*]] = insertelement <2 x i32> <i32 poison, i32 -1>, i32 [[C_PROMOTED_I]], i64 0
 ; UNROLL-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <2 x i32> poison, i32 [[TMP0]], i64 0
 ; UNROLL-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <2 x i32> [[BROADCAST_SPLATINSERT]], <2 x i32> poison, <2 x i32> zeroinitializer
+; UNROLL-NEXT:    [[TMP6:%.*]] = and <2 x i32> [[BROADCAST_SPLAT]], [[TMP4]]
 ; UNROLL-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; UNROLL:       vector.body:
 ; UNROLL-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
@@ -3137,17 +3138,16 @@ define i32 @testoverflowcheck() {
 ; UNROLL-NEXT:    [[TMP5:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
 ; UNROLL-NEXT:    br i1 [[TMP5]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP30:![0-9]+]]
 ; UNROLL:       middle.block:
-; UNROLL-NEXT:    [[TMP6:%.*]] = and <2 x i32> [[TMP4]], [[BROADCAST_SPLAT]]
 ; UNROLL-NEXT:    [[TMP7:%.*]] = call i32 @llvm.vector.reduce.and.v2i32(<2 x i32> [[TMP6]])
 ; UNROLL-NEXT:    [[CMP_N:%.*]] = icmp eq i32 [[TMP3]], [[N_VEC]]
 ; UNROLL-NEXT:    br i1 [[CMP_N]], label [[LOOPEXIT:%.*]], label [[SCALAR_PH]]
 ; UNROLL:       scalar.ph:
 ; UNROLL-NEXT:    [[BC_RESUME_VAL:%.*]] = phi i8 [ [[IND_END]], [[MIDDLE_BLOCK]] ], [ [[DOTPR_I]], [[ENTRY:%.*]] ]
 ; UNROLL-NEXT:    [[BC_MERGE_RDX:%.*]] = phi i32 [ [[TMP7]], [[MIDDLE_BLOCK]] ], [ [[C_PROMOTED_I]], [[ENTRY]] ]
+; UNROLL-NEXT:    [[AND_I:%.*]] = and i32 [[TMP0]], [[BC_MERGE_RDX]]
 ; UNROLL-NEXT:    br label [[COND_END_I:%.*]]
 ; UNROLL:       cond.end.i:
 ; UNROLL-NEXT:    [[INC4_I:%.*]] = phi i8 [ [[BC_RESUME_VAL]], [[SCALAR_PH]] ], [ [[INC_I:%.*]], [[COND_END_I]] ]
-; UNROLL-NEXT:    [[AND_I:%.*]] = and i32 [[BC_MERGE_RDX]], [[TMP0]]
 ; UNROLL-NEXT:    [[INC_I]] = add i8 [[INC4_I]], 1
 ; UNROLL-NEXT:    [[TOBOOL_I:%.*]] = icmp eq i8 [[INC_I]], 0
 ; UNROLL-NEXT:    br i1 [[TOBOOL_I]], label [[LOOPEXIT]], label [[COND_END_I]], !llvm.loop [[LOOP31:![0-9]+]]
@@ -3220,6 +3220,7 @@ define i32 @testoverflowcheck() {
 ; INTERLEAVE-NEXT:    [[TMP4:%.*]] = insertelement <4 x i32> <i32 poison, i32 -1, i32 -1, i32 -1>, i32 [[C_PROMOTED_I]], i64 0
 ; INTERLEAVE-NEXT:    [[BROADCAST_SPLATINSERT:%.*]] = insertelement <4 x i32> poison, i32 [[TMP0]], i64 0
 ; INTERLEAVE-NEXT:    [[BROADCAST_SPLAT:%.*]] = shufflevector <4 x i32> [[BROADCAST_SPLATINSERT]], <4 x i32> poison, <4 x i32> zeroinitializer
+; INTERLEAVE-NEXT:    [[TMP6:%.*]] = and <4 x i32> [[BROADCAST_SPLAT]], [[TMP4]]
 ; INTERLEAVE-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; INTERLEAVE:       vector.body:
 ; INTERLEAVE-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
@@ -3227,17 +3228,16 @@ define i32 @testoverflowcheck() {
 ; INTERLEAVE-NEXT:    [[TMP5:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
 ; INTERLEAVE-NEXT:    br i1 [[TMP5]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP30:![0-9]+]]
 ; INTERLEAVE:       middle.block:
-; INTERLEAVE-NEXT:    [[TMP6:%.*]] = and <4 x i32> [[TMP4]], [[BROADCAST_SPLAT]]
 ; INTERLEAVE-NEXT:    [[TMP7:%.*]] = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> [[TMP6]])
 ; INTERLEAVE-NEXT:    [[CMP_N:%.*]] = icmp eq i32 [[TMP3]], [[N_VEC]]
 ; INTERLEAVE-NEXT:    br i1 [[CMP_N]], label [[LOOPEXIT:%.*]], label [[SCALAR_PH]]
 ; INTERLEAVE:       scalar.ph:
 ; INTERLEAVE-NEXT:    [[BC_RESUME_VAL:%.*]] = phi i8 [ [[IND_END]], [[MIDDLE_BLOCK]] ], [ [[DOTPR_I]], [[ENTRY:%.*]] ]
 ; INTERLEAVE-NEXT:    [[BC_MERGE_RDX:%.*]] = phi i32 [ [[TMP7]], [[MIDDLE_BLOCK]] ], [ [[C_PROMOTED_I]], [[ENTRY]] ]
+; INTERLEAVE-NEXT:    [[AND_I:%.*]] = and i32 [[TMP0]], [[BC_MERGE_RDX]]
 ; INTERLEAVE-NEXT:    br label [[COND_END_I:%.*]]
 ; INTERLEAVE:       cond.end.i:
 ; INTERLEAVE-NEXT:    [[INC4_I:%.*]] = phi i8 [ [[BC_RESUME_VAL]], [[SCALAR_PH]] ], [ [[INC_I:%.*]], [[COND_END_I]] ]
-; INTERLEAVE-NEXT:    [[AND_I:%.*]] = and i32 [[BC_MERGE_RDX]], [[TMP0]]
 ; INTERLEAVE-NEXT:    [[INC_I]] = add i8 [[INC4_I]], 1
 ; INTERLEAVE-NEXT:    [[TOBOOL_I:%.*]] = icmp eq i8 [[INC_I]], 0
 ; INTERLEAVE-NEXT:    br i1 [[TOBOOL_I]], label [[LOOPEXIT]], label [[COND_END_I]], !llvm.loop [[LOOP31:![0-9]+]]
@@ -5235,22 +5235,22 @@ define i32 @PR32419(i32 %a, i16 %b) {
 ; INTERLEAVE-NEXT:    br label [[FOR_BODY:%.*]]
 ; INTERLEAVE:       for.body:
 ; INTERLEAVE-NEXT:    [[I:%.*]] = phi i32 [ -4, [[SCALAR_PH]] ], [ [[I_NEXT:%.*]], [[FOR_INC:%.*]] ]
-; INTERLEAVE-NEXT:    [[VAR0:%.*]] = phi i32 [ [[BC_MERGE_RDX]], [[SCALAR_PH]] ], [ [[VAR6:%.*]], [[FOR_INC]] ]
+; INTERLEAVE-NEXT:    [[VAR0:%.*]] = phi i32 [ [[BC_MERGE_RDX]], [[SCALAR_PH]] ], [ [[VAR4:%.*]], [[FOR_INC]] ]
 ; INTERLEAVE-NEXT:    [[VAR1:%.*]] = trunc i32 [[I]] to i16
 ; INTERLEAVE-NEXT:    [[VAR2:%.*]] = icmp eq i16 [[VAR1]], 0
 ; INTERLEAVE-NEXT:    br i1 [[VAR2]], label [[FOR_INC]], label [[FOR_COND:%.*]]
 ; INTERLEAVE:       for.cond:
 ; INTERLEAVE-NEXT:    [[VAR3:%.*]] = urem i16 [[B]], [[VAR1]]
 ; INTERLEAVE-NEXT:    [[TMP50:%.*]] = sext i16 [[VAR3]] to i32
+; INTERLEAVE-NEXT:    [[TMP51:%.*]] = or i32 [[VAR0]], [[TMP50]]
 ; INTERLEAVE-NEXT:    br label [[FOR_INC]]
 ; INTERLEAVE:       for.inc:
-; INTERLEAVE-NEXT:    [[VAR4:%.*]] = phi i32 [ [[TMP50]], [[FOR_COND]] ], [ 0, [[FOR_BODY]] ]
-; INTERLEAVE-NEXT:    [[VAR6]] = or i32 [[VAR0]], [[VAR4]]
+; INTERLEAVE-NEXT:    [[VAR4]] = phi i32 [ [[TMP51]], [[FOR_COND]] ], [ [[VAR0]], [[FOR_BODY]] ]
 ; INTERLEAVE-NEXT:    [[I_NEXT]] = add nsw i32 [[I]], 1
 ; INTERLEAVE-NEXT:    [[COND:%.*]] = icmp eq i32 [[I_NEXT]], 0
 ; INTERLEAVE-NEXT:    br i1 [[COND]], label [[FOR_END:%.*]], label [[FOR_BODY]], !llvm.loop [[LOOP45:![0-9]+]]
 ; INTERLEAVE:       for.end:
-; INTERLEAVE-NEXT:    ret i32 [[VAR6]]
+; INTERLEAVE-NEXT:    ret i32 [[VAR4]]
 ;
 entry:
   br label %for.body


### PR DESCRIPTION
This PR makes `foldBinOpIntoSelectOrPhi` fold to select/phi both for operands 0 and 1.

alive2: https://alive2.llvm.org/ce/z/T56TMM
also fixes #183498