### PR TITLE
[clang] fix crash when evaluating __is_bitwise_cloneable on an invalid type

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -341,6 +341,7 @@ Miscellaneous Clang Crashes Fixed
 - Fixed an assertion when diagnosing address-space qualified ``new``/``delete`` in language-defined address spaces such as OpenCL ``__local``. (#GH178319)
 - Fixed an assertion failure in ObjC++ ARC when binding a rvalue reference to reference with different lifetimes (#GH178524)
 - Fixed a crash when subscripting a vector type with large unsigned integer values. (#GH180563)
+- Fixed a crash when evaluating ``__is_bitwise_cloneable`` on invalid record types. (#GH183707)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2934,6 +2934,9 @@ bool QualType::isBitwiseCloneableType(const ASTContext &Context) const {
   if (!RD)
     return true;
 
+  if (RD->isInvalidDecl())
+    return false;
+
   // Never allow memcpy when we're adding poisoned padding bits to the struct.
   // Accessing these posioned bits will trigger false alarms on
   // SanitizeAddressFieldPadding etc.

--- a/clang/test/SemaCXX/builtin-is-bitwise-cloneable.cpp
+++ b/clang/test/SemaCXX/builtin-is-bitwise-cloneable.cpp
@@ -6,3 +6,16 @@ static_assert(__is_bitwise_cloneable(DynamicClass));
 
 struct InComplete; // expected-note{{forward declaration}}
 static_assert(!__is_bitwise_cloneable(InComplete)); // expected-error{{incomplete type 'InComplete' used in type trait expression}}
+
+// A struct with an incomplete field type is not bitwise cloneable.
+struct Bar; // expected-note{{forward declaration}}
+struct Foo {
+  Bar bar; // expected-error{{field has incomplete type 'Bar'}}
+};
+static_assert(!__is_bitwise_cloneable(Foo));
+
+// Don't crash when the type has a member of invalid/unknown type.
+struct ABC { // expected-note {{'ABC' declared here}} expected-note {{definition of 'ABC' is not complete until the closing '}'}}
+  ABCD ptr; // expected-error {{unknown type name 'ABCD'}} expected-error {{field has incomplete type 'ABC'}}
+};
+static_assert(!__is_bitwise_cloneable(ABC));


### PR DESCRIPTION
fixes https://github.com/llvm/llvm-project/issues/183665

The crash was caused by `isBitwiseCloneableType`  **infinitely recursing** when a record type contains a self-referential field produced by typo correction during error recovery (e.g. ABCD corrected to ABC inside struct ABC). 

This patch adds an early `RD->isInvalidDecl()` check to bail out before recursing into fields and bases of invalid record declarations.