### PR TITLE
[alpha.webkit.NoDeleteChecker] Check if each field is trivially destructive

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -592,7 +592,7 @@ class TrivialFunctionAnalysisVisitor
           },
           Paths, /*LookupInDependent =*/true);
     })();
-    
+
     FieldDtorCache[Cls] = Result;
 
     return Result;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -560,7 +560,7 @@ class TrivialFunctionAnalysisVisitor
     return false; // Otherwise it's likely not trivial.
   }
 
-  bool HasFieldWithNonTrivialDtor(const CXXRecordDecl *R) {
+  bool HasFieldWithNonTrivialDtor(const CXXRecordDecl *Cls) {
 
     auto HasNonTrivialField = [&](const CXXRecordDecl *R) {
       for (const FieldDecl *F : R->fields()) {
@@ -570,18 +570,23 @@ class TrivialFunctionAnalysisVisitor
       return false;
     };
 
-    if (HasNonTrivialField(R))
+    if (HasNonTrivialField(Cls))
       return true;
 
+    if (!Cls->hasDefinition())
+      return false;
+
     CXXBasePaths Paths;
-    Paths.setOrigin(const_cast<CXXRecordDecl *>(R));
-    return R->lookupInBases([&](const CXXBaseSpecifier *B, CXXBasePath &) {
-      auto *T = B->getType().getTypePtrOrNull();
-      if (!T)
-        return false;
-      auto *R = T->getAsCXXRecordDecl();
-      return R && HasNonTrivialField(R);
-    }, Paths, /*LookupInDependent =*/true);
+    Paths.setOrigin(const_cast<CXXRecordDecl *>(Cls));
+    return Cls->lookupInBases(
+        [&](const CXXBaseSpecifier *B, CXXBasePath &) {
+          auto *T = B->getType().getTypePtrOrNull();
+          if (!T)
+            return false;
+          auto *R = T->getAsCXXRecordDecl();
+          return R && HasNonTrivialField(R);
+        },
+        Paths, /*LookupInDependent =*/true);
   }
 
 public:
@@ -792,7 +797,8 @@ public:
     if (!Callee)
       return false;
 
-    if (isa<CXXDestructorDecl>(Callee) && !CanTriviallyDestruct(MCE->getObjectType()))
+    if (isa<CXXDestructorDecl>(Callee) &&
+        !CanTriviallyDestruct(MCE->getObjectType()))
       return false;
 
     auto Name = safeGetName(Callee);

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -539,6 +539,9 @@ class TrivialFunctionAnalysisVisitor
       if (R->hasDefinition() && R->hasTrivialDestructor())
         return true;
 
+      if (HasFieldWithNonTrivialDtor(R))
+        return false;
+
       // For Webkit, side-effects are fine as long as we don't delete objects,
       // so check recursively.
       if (const auto *Dtor = R->getDestructor())
@@ -555,6 +558,30 @@ class TrivialFunctionAnalysisVisitor
       return CanTriviallyDestruct(AT->getElementType());
 
     return false; // Otherwise it's likely not trivial.
+  }
+
+  bool HasFieldWithNonTrivialDtor(const CXXRecordDecl *R) {
+
+    auto HasNonTrivialField = [&](const CXXRecordDecl *R) {
+      for (const FieldDecl *F : R->fields()) {
+        if (!CanTriviallyDestruct(F->getType()))
+          return true;
+      }
+      return false;
+    };
+
+    if (HasNonTrivialField(R))
+      return true;
+
+    CXXBasePaths Paths;
+    Paths.setOrigin(const_cast<CXXRecordDecl *>(R));
+    return R->lookupInBases([&](const CXXBaseSpecifier *B, CXXBasePath &) {
+      auto *T = B->getType().getTypePtrOrNull();
+      if (!T)
+        return false;
+      auto *R = T->getAsCXXRecordDecl();
+      return R && HasNonTrivialField(R);
+    }, Paths, /*LookupInDependent =*/true);
   }
 
 public:
@@ -763,6 +790,9 @@ public:
 
     auto *Callee = MCE->getMethodDecl();
     if (!Callee)
+      return false;
+
+    if (isa<CXXDestructorDecl>(Callee) && !CanTriviallyDestruct(MCE->getObjectType()))
       return false;
 
     auto Name = safeGetName(Callee);

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -561,32 +561,41 @@ class TrivialFunctionAnalysisVisitor
   }
 
   bool HasFieldWithNonTrivialDtor(const CXXRecordDecl *Cls) {
+    auto CacheIt = FieldDtorCache.find(Cls);
+    if (CacheIt != FieldDtorCache.end())
+      return CacheIt->second;
 
-    auto HasNonTrivialField = [&](const CXXRecordDecl *R) {
-      for (const FieldDecl *F : R->fields()) {
-        if (!CanTriviallyDestruct(F->getType()))
-          return true;
-      }
-      return false;
-    };
+    bool Result = ([&] {
+      auto HasNonTrivialField = [&](const CXXRecordDecl *R) {
+        for (const FieldDecl *F : R->fields()) {
+          if (!CanTriviallyDestruct(F->getType()))
+            return true;
+        }
+        return false;
+      };
 
-    if (HasNonTrivialField(Cls))
-      return true;
+      if (HasNonTrivialField(Cls))
+        return true;
 
-    if (!Cls->hasDefinition())
-      return false;
+      if (!Cls->hasDefinition())
+        return false;
 
-    CXXBasePaths Paths;
-    Paths.setOrigin(const_cast<CXXRecordDecl *>(Cls));
-    return Cls->lookupInBases(
-        [&](const CXXBaseSpecifier *B, CXXBasePath &) {
-          auto *T = B->getType().getTypePtrOrNull();
-          if (!T)
-            return false;
-          auto *R = T->getAsCXXRecordDecl();
-          return R && HasNonTrivialField(R);
-        },
-        Paths, /*LookupInDependent =*/true);
+      CXXBasePaths Paths;
+      Paths.setOrigin(const_cast<CXXRecordDecl *>(Cls));
+      return Cls->lookupInBases(
+          [&](const CXXBaseSpecifier *B, CXXBasePath &) {
+            auto *T = B->getType().getTypePtrOrNull();
+            if (!T)
+              return false;
+            auto *R = T->getAsCXXRecordDecl();
+            return R && HasNonTrivialField(R);
+          },
+          Paths, /*LookupInDependent =*/true);
+    })();
+    
+    FieldDtorCache[Cls] = Result;
+
+    return Result;
   }
 
 public:
@@ -955,6 +964,7 @@ public:
 
 private:
   CacheTy &Cache;
+  CacheTy FieldDtorCache;
   CacheTy RecursiveFn;
   const Stmt **OffendingStmt;
 };


### PR DESCRIPTION
This PR fixes the bug that NoDeleteChecker and trivial function analysis were not detecting any non-trivial destruction of class member variables.

When evaluating a delete expression or calling a destructor directly for triviality, check if each field in the class and its base classes is trivially destructive.