### PR TITLE
[mlir][affine] Fix crash in affine.linearize_index fold with non-integer operands

### DIFF
--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -5298,10 +5298,14 @@ OpFoldResult AffineLinearizeIndexOp::fold(FoldAdaptor adaptor) {
   if (getMultiIndex().size() == 1)
     return getMultiIndex().front();
 
-  if (llvm::is_contained(adaptor.getMultiIndex(), nullptr))
+  if (!adaptor.getDynamicBasis().empty())
     return nullptr;
 
-  if (!adaptor.getDynamicBasis().empty())
+  // Fold only when all multi-index operands folded to integer constants.
+  // Non-null but non-integer attributes (e.g. ub.poison) must not be cast.
+  if (llvm::any_of(adaptor.getMultiIndex(), [](Attribute attr) {
+        return !attr || !isa<IntegerAttr>(attr);
+      }))
     return nullptr;
 
   int64_t result = 0;

--- a/mlir/test/Dialect/Affine/canonicalize.mlir
+++ b/mlir/test/Dialect/Affine/canonicalize.mlir
@@ -2415,3 +2415,19 @@ func.func @linearize_dont_fold_poison_basis(%arg0: index) -> index {
   %ret = affine.linearize_index [%arg0] by (%poison) : index
   return %ret : index
 }
+
+// -----
+
+// Ensure affine.linearize_index fold doesn't crash with ub.poison operands.
+// ub.poison folds to a PoisonAttr (not IntegerAttr), so the fold must not
+// attempt to cast it to IntegerAttr.
+// CHECK-LABEL: func @linearize_index_with_poison
+func.func @linearize_index_with_poison() -> index {
+  // CHECK: %[[POISON:.*]] = ub.poison : index
+  // CHECK-NOT: affine.linearize_index
+  // CHECK: return %[[POISON]]
+  %0 = ub.poison : index
+  %c0 = arith.constant 0 : index
+  %1 = affine.linearize_index [%0, %c0] by (1) : index
+  return %1 : index
+}


### PR DESCRIPTION
The fold for affine.linearize_index checked for null attributes in the multi-index operands but did not guard against non-null attributes that are not IntegerAttr (e.g. ub.poison, which folds to PoisonAttr). The unchecked cast<IntegerAttr> then crashed at runtime.

Fix this by replacing the separate null check with a combined predicate that returns early if any multi-index operand is absent or not an IntegerAttr.

Fixes #180106
Fixes #179405