### PR TITLE
[AMDGPU] Stop treating AMDGPU_CS_ChainPreserve as a module entry funtion

### DIFF
--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -1639,13 +1639,18 @@ constexpr bool isChainCC(CallingConv::ID CC) {
 // the hardware. Module entry points include all entry functions but also
 // include functions that can be called from other functions inside or outside
 // the current module. Module entry functions are allowed to allocate LDS.
+//
+// AMDGPU_CS_Chain is intended for externally callable chain functions, so it is
+// treated as a module entrypoint. AMDGPU_CS_ChainPreserve is used for internal
+// helper functions (e.g. retry helpers), so it is not a module entrypoint.
 LLVM_READNONE
 constexpr bool isModuleEntryFunctionCC(CallingConv::ID CC) {
   switch (CC) {
   case CallingConv::AMDGPU_Gfx:
+  case CallingConv::AMDGPU_CS_Chain:
     return true;
   default:
-    return isEntryFunctionCC(CC) || isChainCC(CC);
+    return isEntryFunctionCC(CC);
   }
 }
 

--- a/llvm/test/CodeGen/AMDGPU/amdpal-chain-metadata.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdpal-chain-metadata.ll
@@ -9,6 +9,7 @@
 ; CHECK-NEXT:      amdgpu_cs_chain_func:
 ; CHECK:             .backend_stack_size: 0x10{{$}}
 ; CHECK:             .stack_frame_size_in_bytes: 0x10{{$}}
+; CHECK-NOT:       amdgpu_cs_chain_preserve_func:
 ; CHECK:amdpal.version:
 ; CHECK-NEXT:  - 0x3
 ; CHECK-NEXT:  - 0
@@ -20,6 +21,11 @@ define amdgpu_cs_chain void @amdgpu_cs_chain_func(<40 x i32> %should_spill) {
   %v = alloca [3 x i32], addrspace(5)
   store i32 42, ptr addrspace(5) %v
   call amdgpu_gfx void @use(<40 x i32> %should_spill, ptr addrspace(5) %v)
+  ret void
+}
+
+define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_func() {
+.entry:
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/amdpal-chain-metadata.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdpal-chain-metadata.ll
@@ -9,7 +9,8 @@
 ; CHECK-NEXT:      amdgpu_cs_chain_func:
 ; CHECK:             .backend_stack_size: 0x10{{$}}
 ; CHECK:             .stack_frame_size_in_bytes: 0x10{{$}}
-; CHECK-NOT:       amdgpu_cs_chain_preserve_func:
+; CHECK-NEXT:            .vgpr_count:
+; CHECK-NEXT:    .shaders:
 ; CHECK:amdpal.version:
 ; CHECK-NEXT:  - 0x3
 ; CHECK-NEXT:  - 0


### PR DESCRIPTION
Starting with AMD PAL metadata v3.6, pipeline ELFs cannot have a
`.shader_functions` section. However, dynamic VGPR retry helpers use
the `AMDGPU_CS_ChainPreserve` calling convention, which LLVM previously
treated as a module entrypoint, incorrectly emitting this metadata.