### PR TITLE
[NFC][SPIRV] Fix compile warnings

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -2877,7 +2877,7 @@ bool SPIRVInstructionSelector::selectWaveReduceMax(Register ResVReg,
       [&](Register InputRegister, bool IsUnsigned) {
         const bool IsFloatTy =
             GR.isScalarOrVectorOfType(InputRegister, SPIRV::OpTypeFloat);
-        const unsigned IntOp = IsUnsigned ? SPIRV::OpGroupNonUniformUMax
+        const auto IntOp = IsUnsigned ? SPIRV::OpGroupNonUniformUMax
                                           : SPIRV::OpGroupNonUniformSMax;
         return IsFloatTy ? SPIRV::OpGroupNonUniformFMax : IntOp;
       });
@@ -2892,7 +2892,7 @@ bool SPIRVInstructionSelector::selectWaveReduceMin(Register ResVReg,
       [&](Register InputRegister, bool IsUnsigned) {
         const bool IsFloatTy =
             GR.isScalarOrVectorOfType(InputRegister, SPIRV::OpTypeFloat);
-        const unsigned IntOp = IsUnsigned ? SPIRV::OpGroupNonUniformUMin
+        const auto IntOp = IsUnsigned ? SPIRV::OpGroupNonUniformUMin
                                           : SPIRV::OpGroupNonUniformSMin;
         return IsFloatTy ? SPIRV::OpGroupNonUniformFMin : IntOp;
       });

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -2878,7 +2878,7 @@ bool SPIRVInstructionSelector::selectWaveReduceMax(Register ResVReg,
         const bool IsFloatTy =
             GR.isScalarOrVectorOfType(InputRegister, SPIRV::OpTypeFloat);
         const auto IntOp = IsUnsigned ? SPIRV::OpGroupNonUniformUMax
-                                          : SPIRV::OpGroupNonUniformSMax;
+                                      : SPIRV::OpGroupNonUniformSMax;
         return IsFloatTy ? SPIRV::OpGroupNonUniformFMax : IntOp;
       });
 }
@@ -2893,7 +2893,7 @@ bool SPIRVInstructionSelector::selectWaveReduceMin(Register ResVReg,
         const bool IsFloatTy =
             GR.isScalarOrVectorOfType(InputRegister, SPIRV::OpTypeFloat);
         const auto IntOp = IsUnsigned ? SPIRV::OpGroupNonUniformUMin
-                                          : SPIRV::OpGroupNonUniformSMin;
+                                      : SPIRV::OpGroupNonUniformSMin;
         return IsFloatTy ? SPIRV::OpGroupNonUniformFMin : IntOp;
       });
 }


### PR DESCRIPTION
Fix compile warnings in SPIR-V 

```
llvm-project/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp:2882:26: warning: enumerated and non-enumerated type in conditional expression [-Wextra]
 2882 |         return IsFloatTy ? SPIRV::OpGroupNonUniformFMax : IntOp;
      |                ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
llvm-project/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp: In lambda function:
llvm-project/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp:2897:26: warning: enumerated and non-enumerated type in conditional expression [-Wextra]
 2897 |         return IsFloatTy ? SPIRV::OpGroupNonUniformFMin : IntOp;
      |                ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
