### PR TITLE
[DA] Remove isPeelFirst and isPeelLast

### DIFF
--- a/llvm/include/llvm/Analysis/DependenceAnalysis.h
+++ b/llvm/include/llvm/Analysis/DependenceAnalysis.h
@@ -105,11 +105,8 @@ public:
     };
     unsigned char Direction : 3; // Init to ALL, then refine.
     bool Scalar : 1;             // Init to true.
-    bool PeelFirst : 1; // Peeling the first iteration will break dependence.
-    bool PeelLast : 1;  // Peeling the last iteration will break the dependence.
     const SCEV *Distance = nullptr; // NULL implies no distance available.
-    DVEntry()
-        : Direction(ALL), Scalar(true), PeelFirst(false), PeelLast(false) {}
+    DVEntry() : Direction(ALL), Scalar(true) {}
   };
 
   /// getSrc - Returns the source instruction for this dependence.
@@ -177,18 +174,6 @@ public:
   /// Src and Dst, plus reversing the dependence directions and distances
   /// in the vector.
   virtual bool normalize(ScalarEvolution *SE) { return false; }
-
-  /// isPeelFirst - Returns true if peeling the first iteration from
-  /// this regular or SameSD loop level will break this dependence.
-  virtual bool isPeelFirst(unsigned Level, bool SameSD = false) const {
-    return false;
-  }
-
-  /// isPeelLast - Returns true if peeling the last iteration from
-  /// this regular or SameSD loop level will break this dependence.
-  virtual bool isPeelLast(unsigned Level, bool SameSD = false) const {
-    return false;
-  }
 
   /// inSameSDLoops - Returns true if this level is an SameSD level, i.e.,
   /// performed across two separate loop nests that have the Same Iteration and
@@ -295,14 +280,6 @@ public:
   /// Src and Dst, plus reversing the dependence directions and distances
   /// in the vector.
   bool normalize(ScalarEvolution *SE) override;
-
-  /// isPeelFirst - Returns true if peeling the first iteration from
-  /// this regular or SameSD loop level will break this dependence.
-  bool isPeelFirst(unsigned Level, bool SameSD = false) const override;
-
-  /// isPeelLast - Returns true if peeling the last iteration from
-  /// this regular or SameSD loop level will break this dependence.
-  bool isPeelLast(unsigned Level, bool SameSD = false) const override;
 
   /// inSameSDLoops - Returns true if this level is an SameSD level, i.e.,
   /// performed across two separate loop nests that have the Same Iteration and

--- a/llvm/lib/Analysis/DependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/DependenceAnalysis.cpp
@@ -671,18 +671,6 @@ bool FullDependence::isScalar(unsigned Level, bool IsSameSD) const {
   return getDVEntry(Level, IsSameSD).Scalar;
 }
 
-// Returns true if peeling the first iteration from this regular or SameSD
-// loop level will break this dependence.
-bool FullDependence::isPeelFirst(unsigned Level, bool IsSameSD) const {
-  return getDVEntry(Level, IsSameSD).PeelFirst;
-}
-
-// Returns true if peeling the last iteration from this regular or SameSD
-// loop level will break this dependence.
-bool FullDependence::isPeelLast(unsigned Level, bool IsSameSD) const {
-  return getDVEntry(Level, IsSameSD).PeelLast;
-}
-
 // inSameSDLoops - Returns true if this level is an SameSD level, i.e.,
 // performed across two separate loop nests that have the Same iteration space
 // and Depth.
@@ -814,8 +802,6 @@ void Dependence::dumpImp(raw_ostream &OS, bool IsSameSD) const {
   for (unsigned II = 1; II <= LevelNum; ++II) {
     if (!OnSameSD && inSameSDLoops(II))
       OnSameSD = true;
-    if (isPeelFirst(II, OnSameSD))
-      OS << 'p';
     const SCEV *Distance = getDistance(II, OnSameSD);
     if (Distance)
       OS << *Distance;
@@ -834,8 +820,6 @@ void Dependence::dumpImp(raw_ostream &OS, bool IsSameSD) const {
           OS << ">";
       }
     }
-    if (isPeelLast(II, OnSameSD))
-      OS << 'p';
     if (II < LevelNum)
       OS << " ";
   }
@@ -1850,7 +1834,6 @@ bool DependenceInfo::weakZeroSrcSIVtest(const SCEV *DstCoeff,
   if (SrcConst == DstConst && SE->isKnownNonZero(DstCoeff)) {
     if (Level < CommonLevels) {
       Result.DV[Level].Direction &= Dependence::DVEntry::GE;
-      Result.DV[Level].PeelFirst = true;
       ++WeakZeroSIVsuccesses;
     }
     return false; // dependences caused by first iteration
@@ -1882,7 +1865,6 @@ bool DependenceInfo::weakZeroSrcSIVtest(const SCEV *DstCoeff,
       // dependences caused by last iteration
       if (Level < CommonLevels) {
         Result.DV[Level].Direction &= Dependence::DVEntry::LE;
-        Result.DV[Level].PeelLast = true;
         ++WeakZeroSIVsuccesses;
       }
       return false;
@@ -1962,7 +1944,6 @@ bool DependenceInfo::weakZeroDstSIVtest(const SCEV *SrcCoeff,
   if (DstConst == SrcConst && SE->isKnownNonZero(SrcCoeff)) {
     if (Level < CommonLevels) {
       Result.DV[Level].Direction &= Dependence::DVEntry::LE;
-      Result.DV[Level].PeelFirst = true;
       ++WeakZeroSIVsuccesses;
     }
     return false; // dependences caused by first iteration
@@ -1994,7 +1975,6 @@ bool DependenceInfo::weakZeroDstSIVtest(const SCEV *SrcCoeff,
       // dependences caused by last iteration
       if (Level < CommonLevels) {
         Result.DV[Level].Direction &= Dependence::DVEntry::GE;
-        Result.DV[Level].PeelLast = true;
         ++WeakZeroSIVsuccesses;
       }
       return false;

--- a/llvm/test/Analysis/DependenceAnalysis/WeakZeroDstSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakZeroDstSIV.ll
@@ -16,7 +16,7 @@ define void @dstzero(ptr nocapture %A, i32 %N) {
 ; CHECK-NEXT:  Src: store i32 0, ptr %arrayidx, align 4 --> Dst: store i32 0, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 0, ptr %arrayidx, align 4 --> Dst: store i32 1, ptr %A, align 4
-; CHECK-NEXT:    da analyze - output [p<=|<]!
+; CHECK-NEXT:    da analyze - output [<=|<]!
 ; CHECK-NEXT:  Src: store i32 1, ptr %A, align 4 --> Dst: store i32 1, ptr %A, align 4
 ; CHECK-NEXT:    da analyze - output [S]!
 ;
@@ -49,7 +49,7 @@ define void @weakzerodst0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
-; CHECK-NEXT:    da analyze - flow [p<=|<]!
+; CHECK-NEXT:    da analyze - flow [<=|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
@@ -186,7 +186,7 @@ define void @weakzerodst3(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
-; CHECK-NEXT:    da analyze - flow [=>p|<]!
+; CHECK-NEXT:    da analyze - flow [=>|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/WeakZeroSrcSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakZeroSrcSIV.ll
@@ -16,7 +16,7 @@ define void @dstzero(ptr nocapture %A, i32 %N) {
 ; CHECK-NEXT:  Src: store i32 0, ptr %A, align 4 --> Dst: store i32 0, ptr %A, align 4
 ; CHECK-NEXT:    da analyze - output [S]!
 ; CHECK-NEXT:  Src: store i32 0, ptr %A, align 4 --> Dst: store i32 1, ptr %arrayidx1, align 4
-; CHECK-NEXT:    da analyze - output [p=>|<]!
+; CHECK-NEXT:    da analyze - output [=>|<]!
 ; CHECK-NEXT:  Src: store i32 1, ptr %arrayidx1, align 4 --> Dst: store i32 1, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - none!
 ;
@@ -47,7 +47,7 @@ define void @weakzerosrc0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - output [S]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
-; CHECK-NEXT:    da analyze - flow [p=>|<]!
+; CHECK-NEXT:    da analyze - flow [=>|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
@@ -184,7 +184,7 @@ define void @weakzerosrc3(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - output [S]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
-; CHECK-NEXT:    da analyze - flow [<=p|<]!
+; CHECK-NEXT:    da analyze - flow [<=|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4


### PR DESCRIPTION
`isPeelFirst` and `isPeelLast` are updated only in the Weak Zero SIV tests, and no clients actually use them. Keeping these features while fixing the existing defects in DA would add unnecessary complexity. If they are unnecessary in the first place, it would be better to delete them to mitigate maintenance burden.