### PR TITLE
[lldb-dap] Add memory history in ASan report

### DIFF
--- a/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
@@ -130,7 +130,7 @@ static bool fromJSON(const json::Value &params, RuntimeInstrumentReport &report,
 
 } // end namespace
 
-static raw_ostream &operator<<(raw_ostream &OS, UBSanReport &report) {
+static raw_ostream &operator<<(raw_ostream &OS, const UBSanReport &report) {
   if (!report.filename.empty()) {
     OS << report.filename;
     if (report.line != LLDB_INVALID_LINE_NUMBER) {
@@ -151,7 +151,7 @@ static raw_ostream &operator<<(raw_ostream &OS, UBSanReport &report) {
 }
 
 static raw_ostream &operator<<(raw_ostream &OS,
-                               MainThreadCheckerReport &report) {
+                               const MainThreadCheckerReport &report) {
   if (!report.description.empty())
     OS << report.description << "\n";
 
@@ -163,7 +163,7 @@ static raw_ostream &operator<<(raw_ostream &OS,
   return OS;
 }
 
-static raw_ostream &operator<<(raw_ostream &OS, ASanReport &report) {
+static raw_ostream &operator<<(raw_ostream &OS, const ASanReport &report) {
   if (!report.stop_type.empty())
     OS << report.stop_type << ": ";
   if (!report.description.empty())
@@ -183,8 +183,8 @@ static raw_ostream &operator<<(raw_ostream &OS, ASanReport &report) {
 }
 
 static raw_ostream &operator<<(raw_ostream &OS,
-                               RuntimeInstrumentReport &report) {
-  std::visit([&](auto &r) { OS << r; }, report);
+                               const RuntimeInstrumentReport &report) {
+  std::visit([&](const auto &r) { OS << r; }, report);
   return OS;
 }
 

--- a/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
@@ -231,6 +231,25 @@ static std::string FormatExtendedStopInfo(lldb::SBThread &thread) {
   // Check if we can improve the formatting of the raw JSON report.
   if (report) {
     OS << *report;
+    std::visit(
+        [&](auto &&report) {
+          using T = std::decay_t<decltype(report)>;
+          if constexpr (std::is_same_v<T, ASanReport>) {
+            lldb::addr_t address = report.address;
+            lldb::SBProcess process = thread.GetProcess();
+            lldb::SBThreadCollection history_threads =
+                process.GetHistoryThreads(address);
+            lldb::SBStream stream;
+            OS << "Memory history associated with addres: 0x"
+               << llvm::utohexstr(address) << "\n";
+            for (const auto history_thread : history_threads) {
+              if (history_thread.GetStatus(stream))
+                OS << stream << "\n";
+              stream.Clear();
+            }
+          }
+        },
+        *report);
   } else {
     consumeError(report.takeError());
     OS << stream;

--- a/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
@@ -240,7 +240,7 @@ static std::string FormatExtendedStopInfo(lldb::SBThread &thread) {
             lldb::SBThreadCollection history_threads =
                 process.GetHistoryThreads(address);
             lldb::SBStream stream;
-            OS << "Memory history associated with addres: 0x"
+            OS << "Memory history associated with address: 0x"
                << llvm::utohexstr(address) << "\n";
             for (const auto history_thread : history_threads) {
               if (history_thread.GetStatus(stream))


### PR DESCRIPTION
Added memory history in ASan report (like `memory history` console command)