### PR TITLE
[WebAssembly][FastISel] Fold AND mask operations into ZExt load

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -1294,12 +1294,26 @@ static unsigned getSExtLoadOpcode(unsigned Opc, bool A64) {
   return Opc;
 }
 
+static unsigned getFoldedLoadOpcode(MachineInstr *MI, bool A64) {
+  switch (MI->getOpcode()) {
+  case WebAssembly::I32_EXTEND8_S_I32:
+  case WebAssembly::I32_EXTEND16_S_I32:
+  case WebAssembly::I64_EXTEND8_S_I64:
+  case WebAssembly::I64_EXTEND16_S_I64:
+  case WebAssembly::I64_EXTEND32_S_I64:
+  case WebAssembly::I64_EXTEND_S_I32:
+    return getSExtLoadOpcode(MI->getOpcode(), A64);
+
+  default:
+    return WebAssembly::INSTRUCTION_LIST_END;
+  }
+}
+
 bool WebAssemblyFastISel::tryToFoldLoadIntoMI(MachineInstr *MI, unsigned OpNo,
                                               const LoadInst *LI) {
   bool A64 = Subtarget->hasAddr64();
-  unsigned NewOpc;
-  if ((NewOpc = getSExtLoadOpcode(MI->getOpcode(), A64)) ==
-      WebAssembly::INSTRUCTION_LIST_END)
+  unsigned NewOpc = getFoldedLoadOpcode(MI, A64);
+  if (NewOpc == WebAssembly::INSTRUCTION_LIST_END)
     return false;
 
   Address Addr;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -1294,7 +1294,51 @@ static unsigned getSExtLoadOpcode(unsigned Opc, bool A64) {
   return Opc;
 }
 
-static unsigned getFoldedLoadOpcode(MachineInstr *MI, bool A64) {
+static unsigned getZExtLoadOpcodeFromAnd(MachineInstr *MI,
+                                         MachineRegisterInfo &MRI,
+                                         const LoadInst *LI, bool A64) {
+  uint64_t Mask = 0;
+  bool IsConstant = false;
+  for (unsigned I = 1; I <= 2; ++I) {
+    Register Reg = MI->getOperand(I).getReg();
+    MachineInstr *DefMI = MRI.getUniqueVRegDef(Reg);
+    if (DefMI && (DefMI->getOpcode() == WebAssembly::CONST_I32 ||
+                  DefMI->getOpcode() == WebAssembly::CONST_I64)) {
+      Mask = DefMI->getOperand(1).getImm();
+      IsConstant = true;
+      break;
+    }
+  }
+
+  if (!IsConstant)
+    return WebAssembly::INSTRUCTION_LIST_END;
+
+  unsigned LoadSize = LI->getType()->getPrimitiveSizeInBits();
+  if (Mask != llvm::maskTrailingOnes<uint64_t>(LoadSize))
+    return WebAssembly::INSTRUCTION_LIST_END;
+
+  if (MI->getOpcode() == WebAssembly::AND_I32) {
+    if (LoadSize == 8)
+      return A64 ? WebAssembly::LOAD8_U_I32_A64 : WebAssembly::LOAD8_U_I32_A32;
+    if (LoadSize == 16)
+      return A64 ? WebAssembly::LOAD16_U_I32_A64
+                 : WebAssembly::LOAD16_U_I32_A32;
+  } else if (MI->getOpcode() == WebAssembly::AND_I64) {
+    if (LoadSize == 8)
+      return A64 ? WebAssembly::LOAD8_U_I64_A64 : WebAssembly::LOAD8_U_I64_A32;
+    if (LoadSize == 16)
+      return A64 ? WebAssembly::LOAD16_U_I64_A64
+                 : WebAssembly::LOAD16_U_I64_A32;
+    if (LoadSize == 32)
+      return A64 ? WebAssembly::LOAD32_U_I64_A64
+                 : WebAssembly::LOAD32_U_I64_A32;
+  }
+
+  return WebAssembly::INSTRUCTION_LIST_END;
+}
+
+static unsigned getFoldedLoadOpcode(MachineInstr *MI, MachineRegisterInfo &MRI,
+                                    const LoadInst *LI, bool A64) {
   switch (MI->getOpcode()) {
   case WebAssembly::I32_EXTEND8_S_I32:
   case WebAssembly::I32_EXTEND16_S_I32:
@@ -1303,7 +1347,9 @@ static unsigned getFoldedLoadOpcode(MachineInstr *MI, bool A64) {
   case WebAssembly::I64_EXTEND32_S_I64:
   case WebAssembly::I64_EXTEND_S_I32:
     return getSExtLoadOpcode(MI->getOpcode(), A64);
-
+  case WebAssembly::AND_I32:
+  case WebAssembly::AND_I64:
+    return getZExtLoadOpcodeFromAnd(MI, MRI, LI, A64);
   default:
     return WebAssembly::INSTRUCTION_LIST_END;
   }
@@ -1312,7 +1358,8 @@ static unsigned getFoldedLoadOpcode(MachineInstr *MI, bool A64) {
 bool WebAssemblyFastISel::tryToFoldLoadIntoMI(MachineInstr *MI, unsigned OpNo,
                                               const LoadInst *LI) {
   bool A64 = Subtarget->hasAddr64();
-  unsigned NewOpc = getFoldedLoadOpcode(MI, A64);
+  MachineRegisterInfo &MRI = FuncInfo.MF->getRegInfo();
+  unsigned NewOpc = getFoldedLoadOpcode(MI, MRI, LI, A64);
   if (NewOpc == WebAssembly::INSTRUCTION_LIST_END)
     return false;
 

--- a/llvm/test/CodeGen/WebAssembly/load-ext.ll
+++ b/llvm/test/CodeGen/WebAssembly/load-ext.ll
@@ -87,18 +87,14 @@ define i32 @zext_i8_i32(ptr %p) {
 ; WASM32-FAST-LABEL: zext_i8_i32:
 ; WASM32-FAST:         .functype zext_i8_i32 (i32) -> (i32)
 ; WASM32-FAST-NEXT:  # %bb.0:
-; WASM32-FAST-NEXT:    i32.load8_u $push2=, 0($0)
-; WASM32-FAST-NEXT:    i32.const $push0=, 255
-; WASM32-FAST-NEXT:    i32.and $push1=, $pop2, $pop0
-; WASM32-FAST-NEXT:    return $pop1
+; WASM32-FAST-NEXT:    i32.load8_u $push0=, 0($0)
+; WASM32-FAST-NEXT:    return $pop0
 ;
 ; WASM32-FAST-MVP-LABEL: zext_i8_i32:
 ; WASM32-FAST-MVP:         .functype zext_i8_i32 (i32) -> (i32)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.load8_u $push2=, 0($0)
-; WASM32-FAST-MVP-NEXT:    i32.const $push0=, 255
-; WASM32-FAST-MVP-NEXT:    i32.and $push1=, $pop2, $pop0
-; WASM32-FAST-MVP-NEXT:    return $pop1
+; WASM32-FAST-MVP-NEXT:    i32.load8_u $push0=, 0($0)
+; WASM32-FAST-MVP-NEXT:    return $pop0
 ;
 ; WASM64-DAG-LABEL: zext_i8_i32:
 ; WASM64-DAG:         .functype zext_i8_i32 (i64) -> (i32)
@@ -115,18 +111,14 @@ define i32 @zext_i8_i32(ptr %p) {
 ; WASM64-FAST-LABEL: zext_i8_i32:
 ; WASM64-FAST:         .functype zext_i8_i32 (i64) -> (i32)
 ; WASM64-FAST-NEXT:  # %bb.0:
-; WASM64-FAST-NEXT:    i32.load8_u $push2=, 0($0)
-; WASM64-FAST-NEXT:    i32.const $push0=, 255
-; WASM64-FAST-NEXT:    i32.and $push1=, $pop2, $pop0
-; WASM64-FAST-NEXT:    return $pop1
+; WASM64-FAST-NEXT:    i32.load8_u $push0=, 0($0)
+; WASM64-FAST-NEXT:    return $pop0
 ;
 ; WASM64-FAST-MVP-LABEL: zext_i8_i32:
 ; WASM64-FAST-MVP:         .functype zext_i8_i32 (i64) -> (i32)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i32.load8_u $push2=, 0($0)
-; WASM64-FAST-MVP-NEXT:    i32.const $push0=, 255
-; WASM64-FAST-MVP-NEXT:    i32.and $push1=, $pop2, $pop0
-; WASM64-FAST-MVP-NEXT:    return $pop1
+; WASM64-FAST-MVP-NEXT:    i32.load8_u $push0=, 0($0)
+; WASM64-FAST-MVP-NEXT:    return $pop0
   %v = load i8, ptr %p
   %e = zext i8 %v to i32
   ret i32 %e
@@ -209,18 +201,14 @@ define i32 @zext_i16_i32(ptr %p) {
 ; WASM32-FAST-LABEL: zext_i16_i32:
 ; WASM32-FAST:         .functype zext_i16_i32 (i32) -> (i32)
 ; WASM32-FAST-NEXT:  # %bb.0:
-; WASM32-FAST-NEXT:    i32.load16_u $push2=, 0($0)
-; WASM32-FAST-NEXT:    i32.const $push0=, 65535
-; WASM32-FAST-NEXT:    i32.and $push1=, $pop2, $pop0
-; WASM32-FAST-NEXT:    return $pop1
+; WASM32-FAST-NEXT:    i32.load16_u $push0=, 0($0)
+; WASM32-FAST-NEXT:    return $pop0
 ;
 ; WASM32-FAST-MVP-LABEL: zext_i16_i32:
 ; WASM32-FAST-MVP:         .functype zext_i16_i32 (i32) -> (i32)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.load16_u $push2=, 0($0)
-; WASM32-FAST-MVP-NEXT:    i32.const $push0=, 65535
-; WASM32-FAST-MVP-NEXT:    i32.and $push1=, $pop2, $pop0
-; WASM32-FAST-MVP-NEXT:    return $pop1
+; WASM32-FAST-MVP-NEXT:    i32.load16_u $push0=, 0($0)
+; WASM32-FAST-MVP-NEXT:    return $pop0
 ;
 ; WASM64-DAG-LABEL: zext_i16_i32:
 ; WASM64-DAG:         .functype zext_i16_i32 (i64) -> (i32)
@@ -237,18 +225,14 @@ define i32 @zext_i16_i32(ptr %p) {
 ; WASM64-FAST-LABEL: zext_i16_i32:
 ; WASM64-FAST:         .functype zext_i16_i32 (i64) -> (i32)
 ; WASM64-FAST-NEXT:  # %bb.0:
-; WASM64-FAST-NEXT:    i32.load16_u $push2=, 0($0)
-; WASM64-FAST-NEXT:    i32.const $push0=, 65535
-; WASM64-FAST-NEXT:    i32.and $push1=, $pop2, $pop0
-; WASM64-FAST-NEXT:    return $pop1
+; WASM64-FAST-NEXT:    i32.load16_u $push0=, 0($0)
+; WASM64-FAST-NEXT:    return $pop0
 ;
 ; WASM64-FAST-MVP-LABEL: zext_i16_i32:
 ; WASM64-FAST-MVP:         .functype zext_i16_i32 (i64) -> (i32)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i32.load16_u $push2=, 0($0)
-; WASM64-FAST-MVP-NEXT:    i32.const $push0=, 65535
-; WASM64-FAST-MVP-NEXT:    i32.and $push1=, $pop2, $pop0
-; WASM64-FAST-MVP-NEXT:    return $pop1
+; WASM64-FAST-MVP-NEXT:    i32.load16_u $push0=, 0($0)
+; WASM64-FAST-MVP-NEXT:    return $pop0
   %v = load i16, ptr %p
   %e = zext i16 %v to i32
   ret i32 %e
@@ -337,20 +321,16 @@ define i64 @zext_i8_i64(ptr %p) {
 ; WASM32-FAST-LABEL: zext_i8_i64:
 ; WASM32-FAST:         .functype zext_i8_i64 (i32) -> (i64)
 ; WASM32-FAST-NEXT:  # %bb.0:
-; WASM32-FAST-NEXT:    i32.load8_u $push3=, 0($0)
-; WASM32-FAST-NEXT:    i32.const $push0=, 255
-; WASM32-FAST-NEXT:    i32.and $push1=, $pop3, $pop0
-; WASM32-FAST-NEXT:    i64.extend_i32_u $push2=, $pop1
-; WASM32-FAST-NEXT:    return $pop2
+; WASM32-FAST-NEXT:    i32.load8_u $push0=, 0($0)
+; WASM32-FAST-NEXT:    i64.extend_i32_u $push1=, $pop0
+; WASM32-FAST-NEXT:    return $pop1
 ;
 ; WASM32-FAST-MVP-LABEL: zext_i8_i64:
 ; WASM32-FAST-MVP:         .functype zext_i8_i64 (i32) -> (i64)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.load8_u $push3=, 0($0)
-; WASM32-FAST-MVP-NEXT:    i32.const $push0=, 255
-; WASM32-FAST-MVP-NEXT:    i32.and $push1=, $pop3, $pop0
-; WASM32-FAST-MVP-NEXT:    i64.extend_i32_u $push2=, $pop1
-; WASM32-FAST-MVP-NEXT:    return $pop2
+; WASM32-FAST-MVP-NEXT:    i32.load8_u $push0=, 0($0)
+; WASM32-FAST-MVP-NEXT:    i64.extend_i32_u $push1=, $pop0
+; WASM32-FAST-MVP-NEXT:    return $pop1
 ;
 ; WASM64-DAG-LABEL: zext_i8_i64:
 ; WASM64-DAG:         .functype zext_i8_i64 (i64) -> (i64)
@@ -367,20 +347,16 @@ define i64 @zext_i8_i64(ptr %p) {
 ; WASM64-FAST-LABEL: zext_i8_i64:
 ; WASM64-FAST:         .functype zext_i8_i64 (i64) -> (i64)
 ; WASM64-FAST-NEXT:  # %bb.0:
-; WASM64-FAST-NEXT:    i32.load8_u $push3=, 0($0)
-; WASM64-FAST-NEXT:    i32.const $push0=, 255
-; WASM64-FAST-NEXT:    i32.and $push1=, $pop3, $pop0
-; WASM64-FAST-NEXT:    i64.extend_i32_u $push2=, $pop1
-; WASM64-FAST-NEXT:    return $pop2
+; WASM64-FAST-NEXT:    i32.load8_u $push0=, 0($0)
+; WASM64-FAST-NEXT:    i64.extend_i32_u $push1=, $pop0
+; WASM64-FAST-NEXT:    return $pop1
 ;
 ; WASM64-FAST-MVP-LABEL: zext_i8_i64:
 ; WASM64-FAST-MVP:         .functype zext_i8_i64 (i64) -> (i64)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i32.load8_u $push3=, 0($0)
-; WASM64-FAST-MVP-NEXT:    i32.const $push0=, 255
-; WASM64-FAST-MVP-NEXT:    i32.and $push1=, $pop3, $pop0
-; WASM64-FAST-MVP-NEXT:    i64.extend_i32_u $push2=, $pop1
-; WASM64-FAST-MVP-NEXT:    return $pop2
+; WASM64-FAST-MVP-NEXT:    i32.load8_u $push0=, 0($0)
+; WASM64-FAST-MVP-NEXT:    i64.extend_i32_u $push1=, $pop0
+; WASM64-FAST-MVP-NEXT:    return $pop1
   %v = load i8, ptr %p
   %e = zext i8 %v to i64
   ret i64 %e
@@ -469,20 +445,16 @@ define i64 @zext_i16_i64(ptr %p) {
 ; WASM32-FAST-LABEL: zext_i16_i64:
 ; WASM32-FAST:         .functype zext_i16_i64 (i32) -> (i64)
 ; WASM32-FAST-NEXT:  # %bb.0:
-; WASM32-FAST-NEXT:    i32.load16_u $push3=, 0($0)
-; WASM32-FAST-NEXT:    i32.const $push0=, 65535
-; WASM32-FAST-NEXT:    i32.and $push1=, $pop3, $pop0
-; WASM32-FAST-NEXT:    i64.extend_i32_u $push2=, $pop1
-; WASM32-FAST-NEXT:    return $pop2
+; WASM32-FAST-NEXT:    i32.load16_u $push0=, 0($0)
+; WASM32-FAST-NEXT:    i64.extend_i32_u $push1=, $pop0
+; WASM32-FAST-NEXT:    return $pop1
 ;
 ; WASM32-FAST-MVP-LABEL: zext_i16_i64:
 ; WASM32-FAST-MVP:         .functype zext_i16_i64 (i32) -> (i64)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.load16_u $push3=, 0($0)
-; WASM32-FAST-MVP-NEXT:    i32.const $push0=, 65535
-; WASM32-FAST-MVP-NEXT:    i32.and $push1=, $pop3, $pop0
-; WASM32-FAST-MVP-NEXT:    i64.extend_i32_u $push2=, $pop1
-; WASM32-FAST-MVP-NEXT:    return $pop2
+; WASM32-FAST-MVP-NEXT:    i32.load16_u $push0=, 0($0)
+; WASM32-FAST-MVP-NEXT:    i64.extend_i32_u $push1=, $pop0
+; WASM32-FAST-MVP-NEXT:    return $pop1
 ;
 ; WASM64-DAG-LABEL: zext_i16_i64:
 ; WASM64-DAG:         .functype zext_i16_i64 (i64) -> (i64)
@@ -499,20 +471,16 @@ define i64 @zext_i16_i64(ptr %p) {
 ; WASM64-FAST-LABEL: zext_i16_i64:
 ; WASM64-FAST:         .functype zext_i16_i64 (i64) -> (i64)
 ; WASM64-FAST-NEXT:  # %bb.0:
-; WASM64-FAST-NEXT:    i32.load16_u $push3=, 0($0)
-; WASM64-FAST-NEXT:    i32.const $push0=, 65535
-; WASM64-FAST-NEXT:    i32.and $push1=, $pop3, $pop0
-; WASM64-FAST-NEXT:    i64.extend_i32_u $push2=, $pop1
-; WASM64-FAST-NEXT:    return $pop2
+; WASM64-FAST-NEXT:    i32.load16_u $push0=, 0($0)
+; WASM64-FAST-NEXT:    i64.extend_i32_u $push1=, $pop0
+; WASM64-FAST-NEXT:    return $pop1
 ;
 ; WASM64-FAST-MVP-LABEL: zext_i16_i64:
 ; WASM64-FAST-MVP:         .functype zext_i16_i64 (i64) -> (i64)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i32.load16_u $push3=, 0($0)
-; WASM64-FAST-MVP-NEXT:    i32.const $push0=, 65535
-; WASM64-FAST-MVP-NEXT:    i32.and $push1=, $pop3, $pop0
-; WASM64-FAST-MVP-NEXT:    i64.extend_i32_u $push2=, $pop1
-; WASM64-FAST-MVP-NEXT:    return $pop2
+; WASM64-FAST-MVP-NEXT:    i32.load16_u $push0=, 0($0)
+; WASM64-FAST-MVP-NEXT:    i64.extend_i32_u $push1=, $pop0
+; WASM64-FAST-MVP-NEXT:    return $pop1
   %v = load i16, ptr %p
   %e = zext i16 %v to i64
   ret i64 %e

--- a/llvm/test/CodeGen/WebAssembly/offset-fastisel.ll
+++ b/llvm/test/CodeGen/WebAssembly/offset-fastisel.ll
@@ -104,9 +104,7 @@ define i32 @load_i8_u_with_folded_offset(ptr %p) {
 ; CHECK-LABEL: load_i8_u_with_folded_offset:
 ; CHECK:         .functype load_i8_u_with_folded_offset (i32) -> (i32)
 ; CHECK-NEXT:  # %bb.0:
-; CHECK-NEXT:    i32.load8_u $push2=, 24($0)
-; CHECK-NEXT:    i32.const $push0=, 255
-; CHECK-NEXT:    i32.and $push1=, $pop2, $pop0
+; CHECK-NEXT:    i32.load8_u $push0=, 24($0)
 ; CHECK-NEXT:    # fallthrough-return
   %q = ptrtoint ptr %p to i32
   %r = add nuw i32 %q, 24


### PR DESCRIPTION
FastISel emits separate load and AND instructions for bitmasking.
(before) %1:i32 = LOAD_I32 %addr; %2:i32 = AND_I32 %1, 255

Fold AND masks into ZExt loads by verifying operands with
maskTrailingOnes. A getFoldedLoadOpcode wrapper is implemented
to manage dispatching logic for better extensibility.
(after) %1:i32 = LOAD8_U_I32 %addr

Fixed: https://github.com/llvm/llvm-project/issues/180783