### PR TITLE
[AMDGPU][Scheduler] Fix compilation fail in EXPENSIVE_CHECKS

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -3003,7 +3003,7 @@ MachineInstr *PreRARematStage::ScoredRemat::rematerialize(
     if (LI.hasSubRanges() && MO.getSubReg())
       LM = DAG.TRI->getSubRegIndexLaneMask(MO.getSubReg());
 
-    LaneBitmask LiveInMask = DAG.LiveIns[Remat.UseRegion].at(UseReg);
+    LaneBitmask LiveInMask = DAG.LiveIns[Remat->UseRegion].at(UseReg);
     LaneBitmask UncoveredLanes = LM & ~(LiveInMask & LM);
     // If this register has lanes not covered by the LiveIns, be sure they
     // do not map to any subrange. ref:


### PR DESCRIPTION
Bug introduced by #182853 (`Remat` is now a pointer).