### PR TITLE
[pdb] Fix libc++ strict-weak-ordering assertion failures from gsiRecordCmp

### DIFF
--- a/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
@@ -166,7 +166,7 @@ static int gsiRecordCmp(StringRef S1, StringRef S2) {
     return memcmp(S1.data(), S2.data(), LS);
 
   // Both strings are ascii, perform a case-insensitive comparison.
-  return S1.compare_insensitive(S2.data());
+  return S1.compare_insensitive(S2);
 }
 
 void GSIStreamBuilder::finalizePublicBuckets() {


### PR DESCRIPTION
Builds using libc++ hardening was hitting asserts like

  libc++ Hardening assertion
  !__comp(*(__first + __a), *(__first + __b)) failed:
  Your comparator is not a valid strict-weak ordering

printf-debugging revealed that symbols like "?ST@@3JA" were not comparing equal with themselves. It turns out the comparison was done with

  return S1.compare_insensitive(S2.data());

and even when S1 == S2, S1 and S2.data() may not refer to identical strings, since data() may not have a null terminator where the StringRef locally ends.

This fixes the ordering, simplifies the code, and makes it a little faster :)

Fixes: #163755