### PR TITLE
[MLIR][XeGPU] Allow uniform vectors in layout conflict resolution

### DIFF
--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
@@ -1310,8 +1310,12 @@ ResolveLayoutConflicts::resolveVectorConsumer(OpOperand &operand) {
   Operation *consumerOp = operand.getOwner();
   // Get the current layout of the vector value.
   auto producerLayout = xegpu::getDistributeLayoutAttr(vectorValue);
-  if (!producerLayout)
-    return success(); // vector with no layout is uniform
+  if (!producerLayout) {
+    if (auto vectorTy = dyn_cast<VectorType>(vectorValue.getType());
+        vectorTy && vectorTy.getRank() > 1)
+      consumerOp->emitWarning("Expected layout for non-1D vectors.");
+    return success(); // uniform non-tensor-data vector does not require layout
+  }
   // Get the consumer expected layout at this operand.
   auto consumerLayout = xegpu::getConsumerLayoutAt(operand);
   if (!consumerLayout)

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
@@ -1311,8 +1311,7 @@ ResolveLayoutConflicts::resolveVectorConsumer(OpOperand &operand) {
   // Get the current layout of the vector value.
   auto producerLayout = xegpu::getDistributeLayoutAttr(vectorValue);
   if (!producerLayout)
-    return consumerOp->emitError("Vector operand has no layout assigned.");
-
+    return success(); // vector with no layout is uniform
   // Get the consumer expected layout at this operand.
   auto consumerLayout = xegpu::getConsumerLayoutAt(operand);
   if (!consumerLayout)

--- a/mlir/test/Dialect/XeGPU/resolve-layout-conflicts.mlir
+++ b/mlir/test/Dialect/XeGPU/resolve-layout-conflicts.mlir
@@ -101,15 +101,15 @@ func.func @elementwise_conflict() -> vector<32x32xf16> {
 }
 
 // CHECK-LABEL: func.func @elementwise_conflict_uniform
-// CHECK-DAG:     %[[V0:.*]] = "some_op"() : () -> vector<32x32xf16>
-// CHECK-DAG:     %[[V1:.*]] = "some_op"() : () -> vector<32x32xf16>
-// CHECK:         %[[ADD:.*]] = arith.addf %[[V0]], %[[V1]] : vector<32x32xf16>
-// CHECK:         return %[[ADD]] : vector<32x32xf16>
-func.func @elementwise_conflict_uniform() -> vector<32x32xf16> {
-  %0 = "some_op"() : () -> vector<32x32xf16>
-  %1 = "some_op"() : () -> vector<32x32xf16>
-  %2 = arith.addf %0, %1 : vector<32x32xf16>
-  return %2 : vector<32x32xf16>
+// CHECK-DAG:     %[[V0:.*]] = "some_op"() : () -> vector<2xf16>
+// CHECK-DAG:     %[[V1:.*]] = "some_op"() : () -> vector<2xf16>
+// CHECK:         %[[ADD:.*]] = arith.addf %[[V0]], %[[V1]] : vector<2xf16>
+// CHECK:         return %[[ADD]] : vector<2xf16>
+func.func @elementwise_conflict_uniform() -> vector<2xf16> {
+  %0 = "some_op"() : () -> vector<2xf16>
+  %1 = "some_op"() : () -> vector<2xf16>
+  %non_tensor_data_vec = arith.addf %0, %1 : vector<2xf16>
+  return %non_tensor_data_vec : vector<2xf16>
 }
 
 // CHECK-LABEL: func.func @broadcast_source_conflict

--- a/mlir/test/Dialect/XeGPU/resolve-layout-conflicts.mlir
+++ b/mlir/test/Dialect/XeGPU/resolve-layout-conflicts.mlir
@@ -100,6 +100,18 @@ func.func @elementwise_conflict() -> vector<32x32xf16> {
   return %2 : vector<32x32xf16>
 }
 
+// CHECK-LABEL: func.func @elementwise_conflict_uniform
+// CHECK-DAG:     %[[V0:.*]] = "some_op"() : () -> vector<32x32xf16>
+// CHECK-DAG:     %[[V1:.*]] = "some_op"() : () -> vector<32x32xf16>
+// CHECK:         %[[ADD:.*]] = arith.addf %[[V0]], %[[V1]] : vector<32x32xf16>
+// CHECK:         return %[[ADD]] : vector<32x32xf16>
+func.func @elementwise_conflict_uniform() -> vector<32x32xf16> {
+  %0 = "some_op"() : () -> vector<32x32xf16>
+  %1 = "some_op"() : () -> vector<32x32xf16>
+  %2 = arith.addf %0, %1 : vector<32x32xf16>
+  return %2 : vector<32x32xf16>
+}
+
 // CHECK-LABEL: func.func @broadcast_source_conflict
 // CHECK:         %[[V0:.*]] = "some_op"() {layout_result_0 = #xegpu.layout<inst_data = [16]>} : () -> vector<16xf16>
 // CHECK:         %[[CVT:.*]] = xegpu.convert_layout %[[V0]]


### PR DESCRIPTION
A vector that has no layouts is a valid uniform vector, no need to fail. 