### PR TITLE
Add TSFlags2 to carry upper TSFlags bits

### DIFF
--- a/llvm/include/llvm/MC/MCInstrDesc.h
+++ b/llvm/include/llvm/MC/MCInstrDesc.h
@@ -214,6 +214,7 @@ public:
   uint16_t ImplicitOffset; // Offset to start of implicit op list
   uint64_t Flags;          // Flags identifying machine instr class
   uint64_t TSFlags;        // Target Specific Flag values
+  uint64_t TSFlags2;       // Extension of Target Specific Flag values
 
   /// Returns the value of the specified operand constraint if
   /// it is present. Returns -1 if it is not present.

--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -796,7 +796,7 @@ class Instruction : InstructionEncoding {
   string PostEncoderMethod = "";
 
   /// Target-specific flags. This becomes the TSFlags field in TargetInstrDesc.
-  bits<64> TSFlags = 0;
+  bits<128> TSFlags = 0;
 
   ///@name Assembler Parser Support
   ///@{

--- a/llvm/test/TableGen/RegClassByHwMode.td
+++ b/llvm/test/TableGen/RegClassByHwMode.td
@@ -24,7 +24,7 @@ include "Common/RegClassByHwModeCommon.td"
 // INSTRINFO-NEXT: } // namespace llvm::MyTarget
 
 
-// INSTRINFO: { [[LOAD_STACK_GUARD_OPCODE]],	1,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + [[LOAD_STACK_GUARD_OP_INDEX:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::Rematerializable)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // anonymous_
+// INSTRINFO: { [[LOAD_STACK_GUARD_OPCODE]],	1,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + [[LOAD_STACK_GUARD_OP_INDEX:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::Rematerializable)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL, 0x0ULL{{,?}} },  // anonymous_
 
 // INSTRINFO: /* [[LOAD_STACK_GUARD_OP_INDEX]] */ { MyTarget::XRegs_EvenIfRequired, 0|(1<<MCOI::LookupRegClassByHwMode), MCOI::OPERAND_REGISTER, 0 },
 // INSTRINFO: { MyTarget::XRegs_EvenIfRequired, 0|(1<<MCOI::LookupRegClassByHwMode), MCOI::OPERAND_REGISTER, 0 }, { -1, 0, MCOI::OPERAND_IMMEDIATE, 0 }, { -1, 0, MCOI::OPERAND_IMMEDIATE, 0 },

--- a/llvm/test/TableGen/target-specialized-pseudos.td
+++ b/llvm/test/TableGen/target-specialized-pseudos.td
@@ -22,13 +22,13 @@
 
 // CHECK: extern const MyTargetInstrTable MyTargetDescs = {
 // CHECK-NEXT: {
-// CHECK-NEXT: { [[MY_MOV_OPCODE]],	2,	1,	2,	0,	0,	0,	MyTargetOpInfoBase + {{[0-9]+}},	0,	0|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // MY_MOV
-// CHECK-NEXT: { [[G_UBFX_OPCODE]],	4,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + {{[0-9]+}},	0,	0|(1ULL<<MCID::PreISelOpcode)|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // G_UBFX
+// CHECK-NEXT: { [[MY_MOV_OPCODE]],	2,	1,	2,	0,	0,	0,	MyTargetOpInfoBase + {{[0-9]+}},	0,	0|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL, 0x0ULL{{,?}} },  // MY_MOV
+// CHECK-NEXT: { [[G_UBFX_OPCODE]],	4,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + {{[0-9]+}},	0,	0|(1ULL<<MCID::PreISelOpcode)|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL, 0x0ULL{{,?}} },  // G_UBFX
 
-// ALLCASES: { [[PATCHABLE_TYPED_EVENT_CALL_OPCODE]],	3,	0,	0,	0,	0,	0,	MyTargetOpInfoBase + [[PATCHABLE_TYPED_EVENT_CALL_OP_ENTRY:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::Call)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::MayStore)|(1ULL<<MCID::UsesCustomInserter)|(1ULL<<MCID::UnmodeledSideEffects)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // anonymous_
-// ALLCASES: { [[PATCHABLE_EVENT_CALL_OPCODE]],	2,	0,	0,	0,	0,	0,	MyTargetOpInfoBase + [[PATCHABLE_EVENT_CALL_OP_ENTRY:[0-9]+]],	0, 0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::Call)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::MayStore)|(1ULL<<MCID::UsesCustomInserter)|(1ULL<<MCID::UnmodeledSideEffects)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // anonymous_
-// ALLCASES: { [[PREALLOCATED_ARG_OPCODE]],	3,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + [[PREALLOCATED_ARG_OP_ENTRY:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::UsesCustomInserter)|(1ULL<<MCID::UnmodeledSideEffects)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // anonymous_
-// ALLCASES: { [[LOAD_STACK_GUARD_OPCODE]],	1,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + [[LOAD_STACK_GUARD_OP_ENTRY:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::Rematerializable)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // anonymous_
+// ALLCASES: { [[PATCHABLE_TYPED_EVENT_CALL_OPCODE]],	3,	0,	0,	0,	0,	0,	MyTargetOpInfoBase + [[PATCHABLE_TYPED_EVENT_CALL_OP_ENTRY:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::Call)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::MayStore)|(1ULL<<MCID::UsesCustomInserter)|(1ULL<<MCID::UnmodeledSideEffects)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL, 0x0ULL{{,?}} },  // anonymous_
+// ALLCASES: { [[PATCHABLE_EVENT_CALL_OPCODE]],	2,	0,	0,	0,	0,	0,	MyTargetOpInfoBase + [[PATCHABLE_EVENT_CALL_OP_ENTRY:[0-9]+]],	0, 0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::Call)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::MayStore)|(1ULL<<MCID::UsesCustomInserter)|(1ULL<<MCID::UnmodeledSideEffects)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL, 0x0ULL{{,?}} },  // anonymous_
+// ALLCASES: { [[PREALLOCATED_ARG_OPCODE]],	3,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + [[PREALLOCATED_ARG_OP_ENTRY:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::UsesCustomInserter)|(1ULL<<MCID::UnmodeledSideEffects)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL, 0x0ULL{{,?}} },  // anonymous_
+// ALLCASES: { [[LOAD_STACK_GUARD_OPCODE]],	1,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + [[LOAD_STACK_GUARD_OP_ENTRY:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::Rematerializable)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL, 0x0ULL{{,?}} },  // anonymous_
 
 // CHECK: /* 0 */ { -1, 0, MCOI::OPERAND_UNKNOWN, 0 },
 

--- a/llvm/unittests/CodeGen/MachineBasicBlockTest.cpp
+++ b/llvm/unittests/CodeGen/MachineBasicBlockTest.cpp
@@ -67,8 +67,8 @@ TEST(FindDebugLocTest, DifferentIterators) {
 
   // Insert two MIs with DebugLoc DL1 and DL3.
   // Also add a DBG_VALUE with a different DebugLoc in between.
-  MCInstrDesc COPY = {TargetOpcode::COPY, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  MCInstrDesc DBG = {TargetOpcode::DBG_VALUE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc COPY = {TargetOpcode::COPY, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc DBG = {TargetOpcode::DBG_VALUE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   auto MI3 = MF->CreateMachineInstr(COPY, DL3);
   MBB.insert(MBB.begin(), MI3);
   auto MI2 = MF->CreateMachineInstr(DBG, DL2);

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -56,10 +56,10 @@ TEST(IsIdenticalToTest, DifferentDefs) {
   struct {
     MCInstrDesc MCID;
     MCOperandInfo OpInfo[2];
-  } Table = {
-      {0, NumOps, NumDefs, 0, 0, 0, 0, 0, 0, 1ULL << MCID::HasOptionalDef, 0},
-      {{0, 0, MCOI::OPERAND_REGISTER, 0},
-       {0, 1 << MCOI::OptionalDef, MCOI::OPERAND_REGISTER, 0}}};
+  } Table = {{0, NumOps, NumDefs, 0, 0, 0, 0, 0, 0,
+              1ULL << MCID::HasOptionalDef, 0, 0},
+             {{0, 0, MCOI::OPERAND_REGISTER, 0},
+              {0, 1 << MCOI::OptionalDef, MCOI::OPERAND_REGISTER, 0}}};
 
   // Create two MIs with different virtual reg defs and the same uses.
   unsigned VirtualDef1 = -42; // The value doesn't matter, but the sign does.
@@ -128,10 +128,10 @@ TEST(MachineInstrExpressionTraitTest, IsEqualAgreesWithGetHashValue) {
   struct {
     MCInstrDesc MCID;
     MCOperandInfo OpInfo[2];
-  } Table = {
-      {0, NumOps, NumDefs, 0, 0, 0, 0, 0, 0, 1ULL << MCID::HasOptionalDef, 0},
-      {{0, 0, MCOI::OPERAND_REGISTER, 0},
-       {0, 1 << MCOI::OptionalDef, MCOI::OPERAND_REGISTER, 0}}};
+  } Table = {{0, NumOps, NumDefs, 0, 0, 0, 0, 0, 0,
+              1ULL << MCID::HasOptionalDef, 0, 0},
+             {{0, 0, MCOI::OPERAND_REGISTER, 0},
+              {0, 1 << MCOI::OptionalDef, MCOI::OPERAND_REGISTER, 0}}};
 
   // Define a series of instructions with different kinds of operands and make
   // sure that the hash function is consistent with isEqual for various
@@ -207,7 +207,7 @@ TEST(MachineInstrPrintingTest, DebugLocPrinting) {
   struct {
     MCInstrDesc MCID;
     MCOperandInfo OpInfo;
-  } Table = {{0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0},
+  } Table = {{0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0},
              {0, 0, MCOI::OPERAND_REGISTER, 0}};
 
   DIFile *DIF = DIFile::getDistinct(Ctx, "filename", "");
@@ -233,7 +233,7 @@ TEST(MachineInstrSpan, DistanceBegin) {
   auto MF = createMachineFunction(Ctx, Mod);
   auto MBB = MF->CreateMachineBasicBlock();
 
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   auto MII = MBB->begin();
   MachineInstrSpan MIS(MII, MBB);
@@ -250,7 +250,7 @@ TEST(MachineInstrSpan, DistanceEnd) {
   auto MF = createMachineFunction(Ctx, Mod);
   auto MBB = MF->CreateMachineBasicBlock();
 
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   auto MII = MBB->end();
   MachineInstrSpan MIS(MII, MBB);
@@ -265,7 +265,7 @@ TEST(MachineInstrExtraInfo, AddExtraInfo) {
   LLVMContext Ctx;
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   auto MI = MF->CreateMachineInstr(MCID, DebugLoc());
   auto MAI = MCAsmInfo();
@@ -346,7 +346,7 @@ TEST(MachineInstrExtraInfo, ChangeExtraInfo) {
   LLVMContext Ctx;
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   auto MI = MF->CreateMachineInstr(MCID, DebugLoc());
   auto MAI = MCAsmInfo();
@@ -401,7 +401,7 @@ TEST(MachineInstrExtraInfo, RemoveExtraInfo) {
   LLVMContext Ctx;
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   auto MI = MF->CreateMachineInstr(MCID, DebugLoc());
   auto MAI = MCAsmInfo();
@@ -486,7 +486,7 @@ TEST(MachineInstrDebugValue, AddDebugValueOperand) {
     const MCInstrDesc MCID = {
         Opcode, 0, 0, 0, 0,
         0,      0, 0, 0, (1ULL << MCID::Pseudo) | (1ULL << MCID::Variadic),
-        0};
+        0,      0};
 
     auto *MI = MF->CreateMachineInstr(MCID, DebugLoc());
     MI->addOperand(*MF, MachineOperand::CreateReg(0, /*isDef*/ false));
@@ -516,7 +516,7 @@ TEST(MachineInstrBuilder, BuildMI) {
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
   auto MBB = MF->CreateMachineBasicBlock();
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   EXPECT_THAT(BuildMI(*MF, MIMD, MCID), HasMIMetadata(MIMD));
   EXPECT_THAT(BuildMI(*MF, MIMD, MCID), HasMIMetadata(MIMD));
   EXPECT_THAT(BuildMI(*MBB, MBB->end(), MIMD, MCID), HasMIMetadata(MIMD));
@@ -544,6 +544,7 @@ TEST(MachineInstrTest, SpliceOperands) {
                       0,
                       0,
                       (1ULL << MCID::Pseudo) | (1ULL << MCID::Variadic),
+                      0,
                       0};
   MachineInstr *MI = MF->CreateMachineInstr(MCID, DebugLoc());
   MBB->insert(MBB->begin(), MI);

--- a/llvm/unittests/CodeGen/MachineOperandTest.cpp
+++ b/llvm/unittests/CodeGen/MachineOperandTest.cpp
@@ -446,7 +446,7 @@ TEST(MachineOperandTest, RegisterLiveOutHashValue) {
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
   MachineBasicBlock *MBB = MF->CreateMachineBasicBlock();
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   auto *MI1 = MF->CreateMachineInstr(MCID, DebugLoc());
   auto *MI2 = MF->CreateMachineInstr(MCID, DebugLoc());
   MBB->insert(MBB->begin(), MI1);

--- a/llvm/unittests/CodeGen/RegAllocScoreTest.cpp
+++ b/llvm/unittests/CodeGen/RegAllocScoreTest.cpp
@@ -69,7 +69,7 @@ enum MockInstrId {
 
 const std::array<MCInstrDesc, MockInstrId::TotalMockInstrs> MockInstrDescs{{
 #define MOCK_SPEC(IGNORE, OPCODE, FLAGS)                                       \
-  {OPCODE, 0, 0, 0, 0, 0, 0, 0, 0, FLAGS, 0},
+  {OPCODE, 0, 0, 0, 0, 0, 0, 0, 0, FLAGS, 0, 0},
     MOCK_INSTR(MOCK_SPEC)
 #undef MOCK_SPEC
 }};

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -1403,13 +1403,26 @@ void InstrInfoEmitter::emitRecord(
   const BitsInit *TSF = Inst.TheDef->getValueAsBitsInit("TSFlags");
   if (!TSF)
     PrintFatalError(Inst.TheDef->getLoc(), "no TSFlags?");
-  std::optional<uint64_t> Value = TSF->convertInitializerToInt();
-  if (!Value)
-    PrintFatalError(Inst.TheDef, "Invalid TSFlags bit in " + Inst.getName());
-
+  uint64_t Value = 0, Value2 = 0;
+  unsigned NumBits = TSF->getNumBits();
+  if (NumBits > 128)
+    PrintFatalError(Inst.TheDef->getLoc(),
+                    "TSFlags exceeds 128 bits in " + Inst.TheDef->getName());
+  for (unsigned i = 0; i != NumBits; ++i) {
+    if (const auto *Bit = dyn_cast<BitInit>(TSF->getBit(i))) {
+      if (i < 64)
+        Value |= uint64_t(Bit->getValue()) << i;
+      else
+        Value2 |= uint64_t(Bit->getValue()) << (i - 64);
+    } else
+      PrintFatalError(Inst.TheDef->getLoc(),
+                      "Invalid TSFlags bit in " + Inst.TheDef->getName());
+  }
   OS << ", 0x";
-  OS.write_hex(*Value);
-  OS << "ULL";
+  OS.write_hex(Value);
+  OS << "ULL, 0x";
+  OS.write_hex(Value2);
+  OS << "ULL, ";
 
   OS << " },  // " << Inst.getName() << '\n';
 }


### PR DESCRIPTION
Add TSFlags2 to carry the upper 64 bits of
the 128-bit TargetInstrDesc::TSFlags value
emitted by TableGen. This is needed because
some targets may outgrow the 64-bit TSFlags
field and require more target-specific
instruction flag bits.

Co-authored-by: Alexey Karyakin <akaryaki@qti.qualcomm.com>