### PR TITLE
[Hexagon] Enable TSFlags2 usage

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,2 @@
 BasedOnStyle: LLVM
-LineEnding: LF
+#LineEnding: LF

--- a/clang-tools-extra/clang-tidy/.clang-format
+++ b/clang-tools-extra/clang-tidy/.clang-format
@@ -1,9 +1,6 @@
 BasedOnStyle: LLVM
 InsertNewlineAtEOF: true
-KeepEmptyLines:
-  AtEndOfFile: false
-  AtStartOfBlock: false
-  AtStartOfFile: false
+
 LineEnding: LF
 QualifierAlignment: Left
 RemoveBracesLLVM: true

--- a/llvm/include/llvm/MC/MCInstrDesc.h
+++ b/llvm/include/llvm/MC/MCInstrDesc.h
@@ -214,6 +214,7 @@ public:
   uint16_t ImplicitOffset; // Offset to start of implicit op list
   uint64_t Flags;          // Flags identifying machine instr class
   uint64_t TSFlags;        // Target Specific Flag values
+  uint64_t TSFlags2;       // Extension of Target Specific Flag values
 
   /// Returns the value of the specified operand constraint if
   /// it is present. Returns -1 if it is not present.

--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -796,7 +796,7 @@ class Instruction : InstructionEncoding {
   string PostEncoderMethod = "";
 
   /// Target-specific flags. This becomes the TSFlags field in TargetInstrDesc.
-  bits<64> TSFlags = 0;
+  bits<128> TSFlags = 0;
 
   ///@name Assembler Parser Support
   ///@{

--- a/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
@@ -861,8 +861,8 @@ unsigned HCE::getRegOffOpcode(unsigned ExtOpc) const {
   }
   const MCInstrDesc &D = HII->get(ExtOpc);
   if (D.mayLoad() || D.mayStore()) {
-    uint64_t F = D.TSFlags;
-    unsigned AM = (F >> HexagonII::AddrModePos) & HexagonII::AddrModeMask;
+    unsigned AM = HexagonII::getTSFlags(D, HexagonII::AddrModePos,
+                                        HexagonII::AddrModeMask);
     switch (AM) {
       case HexagonII::Absolute:
       case HexagonII::AbsoluteSet:
@@ -1061,9 +1061,10 @@ OffsetRange HCE::getOffsetRange(Register Rb, const MachineInstr &MI) const {
       !MI.getOperand(OffP).isImm())
     return OffsetRange::zero();
 
-  uint64_t F = (D.TSFlags >> HexagonII::MemAccessSizePos) &
-                  HexagonII::MemAccesSizeMask;
-  uint8_t A = HexagonII::getMemAccessSizeInBytes(HexagonII::MemAccessSize(F));
+  auto SizeEnum = HexagonII::getMemAccessEnum(D);
+  uint8_t A = HexagonII::getMemAccessSizeInBytesNoVector(SizeEnum);
+  if (A == 0)
+    return OffsetRange::zero();
   unsigned L = Log2_32(A);
   unsigned S = 10+L;  // sint11_L
   int32_t Min = -alignDown((1<<S)-1, A);
@@ -1101,9 +1102,10 @@ OffsetRange HCE::getOffsetRange(const ExtDesc &ED) const {
   if (!ED.UseMI->mayLoad() && !ED.UseMI->mayStore())
     return OffsetRange::zero();
   const MCInstrDesc &D = HII->get(IdxOpc);
-  uint64_t F = (D.TSFlags >> HexagonII::MemAccessSizePos) &
-                  HexagonII::MemAccesSizeMask;
-  uint8_t A = HexagonII::getMemAccessSizeInBytes(HexagonII::MemAccessSize(F));
+  uint8_t A = HexagonII::getMemAccessSizeInBytesNoVector(
+      HexagonII::getMemAccessEnum(D));
+  if (A == 0)
+    return OffsetRange::zero();
   unsigned L = Log2_32(A);
   unsigned S = 10+L;  // sint11_L
   int32_t Min = -alignDown((1<<S)-1, A);

--- a/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
@@ -229,10 +229,9 @@ SDNode *HexagonDAGToDAGISel::StoreInstrForLoadIntrinsic(MachineSDNode *LoadN,
   // The "LoadN" is just a machine load instruction. The intrinsic also
   // involves storing it. Generate an appropriate store to the location
   // given in the intrinsic's operand(3).
-  uint64_t F = HII->get(LoadN->getMachineOpcode()).TSFlags;
-  unsigned SizeBits = (F >> HexagonII::MemAccessSizePos) &
-                      HexagonII::MemAccesSizeMask;
-  unsigned Size = 1U << (SizeBits-1);
+  const auto &MID = HII->get(LoadN->getMachineOpcode());
+  auto SizeBits = HexagonII::getMemAccessEnum(MID);
+  unsigned Size = 1U << (SizeBits - 1);
 
   SDLoc dl(IntN);
   MachinePointerInfo PI;

--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
@@ -1683,8 +1683,9 @@ bool HexagonInstrInfo::isPostIncrement(const MachineInstr &MI) const {
 // Note: New-value stores are not included here as in the current
 // implementation, we don't need to check their predicate sense.
 bool HexagonInstrInfo::isPredicated(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return (F >> HexagonII::PredicatedPos) & HexagonII::PredicatedMask;
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::PredicatedPos,
+                               HexagonII::PredicatedMask);
 }
 
 bool HexagonInstrInfo::PredicateInstruction(
@@ -2153,8 +2154,9 @@ bool HexagonInstrInfo::isAbsoluteSet(const MachineInstr &MI) const {
 }
 
 bool HexagonInstrInfo::isAccumulator(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return((F >> HexagonII::AccumulatorPos) & HexagonII::AccumulatorMask);
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::AccumulatorPos,
+                               HexagonII::AccumulatorMask);
 }
 
 bool HexagonInstrInfo::isBaseImmOffset(const MachineInstr &MI) const {
@@ -2177,13 +2179,14 @@ bool HexagonInstrInfo::isCompoundBranchInstr(const MachineInstr &MI) const {
 // TODO: In order to have isExtendable for fpimm/f32Ext, we need to handle
 // isFPImm and later getFPImm as well.
 bool HexagonInstrInfo::isConstExtended(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  unsigned isExtended = (F >> HexagonII::ExtendedPos) & HexagonII::ExtendedMask;
+  const auto &MID = MI.getDesc();
+  unsigned isExtended = HexagonII::getTSFlags(MID, HexagonII::ExtendedPos,
+                                              HexagonII::ExtendedMask);
   if (isExtended) // Instruction must be extended.
     return true;
 
-  unsigned isExtendable =
-    (F >> HexagonII::ExtendablePos) & HexagonII::ExtendableMask;
+  unsigned isExtendable = HexagonII::getTSFlags(MID, HexagonII::ExtendablePos,
+                                                HexagonII::ExtendableMask);
   if (!isExtendable)
     return false;
 
@@ -2213,7 +2216,9 @@ bool HexagonInstrInfo::isConstExtended(const MachineInstr &MI) const {
   assert(MO.isImm() && "Extendable operand must be Immediate type");
 
   int64_t Value = MO.getImm();
-  if ((F >> HexagonII::ExtentSignedPos) & HexagonII::ExtentSignedMask) {
+  unsigned isExtSigned = HexagonII::getTSFlags(MID, HexagonII::ExtentSignedPos,
+                                               HexagonII::ExtentSignedMask);
+  if (isExtSigned) {
     int32_t SValue = Value;
     int32_t MinValue = getMinValue(MI);
     int32_t MaxValue = getMaxValue(MI);
@@ -2317,9 +2322,9 @@ bool HexagonInstrInfo::isExpr(unsigned OpType) const {
 }
 
 bool HexagonInstrInfo::isExtendable(const MachineInstr &MI) const {
-  const MCInstrDesc &MID = MI.getDesc();
-  const uint64_t F = MID.TSFlags;
-  if ((F >> HexagonII::ExtendablePos) & HexagonII::ExtendableMask)
+  const auto &MID = MI.getDesc();
+  if (HexagonII::getTSFlags(MID, HexagonII::ExtendablePos,
+                            HexagonII::ExtendableMask))
     return true;
 
   // TODO: This is largely obsolete now. Will need to be removed
@@ -2340,8 +2345,9 @@ bool HexagonInstrInfo::isExtendable(const MachineInstr &MI) const {
 // - One of MOs has been marked with HMOTF_ConstExtended flag.
 bool HexagonInstrInfo::isExtended(const MachineInstr &MI) const {
   // First check if this is permanently extended op code.
-  const uint64_t F = MI.getDesc().TSFlags;
-  if ((F >> HexagonII::ExtendedPos) & HexagonII::ExtendedMask)
+  const auto &MID = MI.getDesc();
+  if (HexagonII::getTSFlags(MID, HexagonII::ExtendedPos,
+                            HexagonII::ExtendedMask))
     return true;
   // Use MO operand flags to determine if one of MI's operands
   // has HMOTF_ConstExtended flag set.
@@ -2353,8 +2359,8 @@ bool HexagonInstrInfo::isExtended(const MachineInstr &MI) const {
 
 bool HexagonInstrInfo::isFloat(const MachineInstr &MI) const {
   unsigned Opcode = MI.getOpcode();
-  const uint64_t F = get(Opcode).TSFlags;
-  return (F >> HexagonII::FPPos) & HexagonII::FPMask;
+  const auto &MID = get(Opcode);
+  return HexagonII::getTSFlags(MID, HexagonII::FPPos, HexagonII::FPMask);
 }
 
 // No V60 HVX VMEM with A_INDIRECT.
@@ -2503,13 +2509,15 @@ bool HexagonInstrInfo::isMemOp(const MachineInstr &MI) const {
 }
 
 bool HexagonInstrInfo::isNewValue(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return (F >> HexagonII::NewValuePos) & HexagonII::NewValueMask;
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::NewValuePos,
+                               HexagonII::NewValueMask);
 }
 
 bool HexagonInstrInfo::isNewValue(unsigned Opcode) const {
-  const uint64_t F = get(Opcode).TSFlags;
-  return (F >> HexagonII::NewValuePos) & HexagonII::NewValueMask;
+  const auto &MID = get(Opcode);
+  return HexagonII::getTSFlags(MID, HexagonII::NewValuePos,
+                               HexagonII::NewValueMask);
 }
 
 bool HexagonInstrInfo::isNewValueInst(const MachineInstr &MI) const {
@@ -2525,64 +2533,71 @@ bool HexagonInstrInfo::isNewValueJump(unsigned Opcode) const {
 }
 
 bool HexagonInstrInfo::isNewValueStore(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return (F >> HexagonII::NVStorePos) & HexagonII::NVStoreMask;
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::NVStorePos,
+                               HexagonII::NVStoreMask);
 }
 
 bool HexagonInstrInfo::isNewValueStore(unsigned Opcode) const {
-  const uint64_t F = get(Opcode).TSFlags;
-  return (F >> HexagonII::NVStorePos) & HexagonII::NVStoreMask;
+  const auto &MID = get(Opcode);
+  return HexagonII::getTSFlags(MID, HexagonII::NVStorePos,
+                               HexagonII::NVStoreMask);
 }
 
 // Returns true if a particular operand is extendable for an instruction.
 bool HexagonInstrInfo::isOperandExtended(const MachineInstr &MI,
     unsigned OperandNum) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return ((F >> HexagonII::ExtendableOpPos) & HexagonII::ExtendableOpMask)
-          == OperandNum;
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::ExtendableOpPos,
+                               HexagonII::ExtendableOpMask) == OperandNum;
 }
 
 bool HexagonInstrInfo::isPredicatedNew(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
   assert(isPredicated(MI));
-  return (F >> HexagonII::PredicatedNewPos) & HexagonII::PredicatedNewMask;
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::PredicatedNewPos,
+                               HexagonII::PredicatedNewMask);
 }
 
 bool HexagonInstrInfo::isPredicatedNew(unsigned Opcode) const {
-  const uint64_t F = get(Opcode).TSFlags;
   assert(isPredicated(Opcode));
-  return (F >> HexagonII::PredicatedNewPos) & HexagonII::PredicatedNewMask;
+  const auto &MID = get(Opcode);
+  return HexagonII::getTSFlags(MID, HexagonII::PredicatedNewPos,
+                               HexagonII::PredicatedNewMask);
 }
 
 bool HexagonInstrInfo::isPredicatedTrue(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return !((F >> HexagonII::PredicatedFalsePos) &
-           HexagonII::PredicatedFalseMask);
+  const auto &MID = MI.getDesc();
+  return !HexagonII::getTSFlags(MID, HexagonII::PredicatedFalsePos,
+                                HexagonII::PredicatedFalseMask);
 }
 
 bool HexagonInstrInfo::isPredicatedTrue(unsigned Opcode) const {
-  const uint64_t F = get(Opcode).TSFlags;
+  const auto &MID = get(Opcode);
   // Make sure that the instruction is predicated.
-  assert((F>> HexagonII::PredicatedPos) & HexagonII::PredicatedMask);
-  return !((F >> HexagonII::PredicatedFalsePos) &
-           HexagonII::PredicatedFalseMask);
+  assert(HexagonII::getTSFlags(MID, HexagonII::PredicatedPos,
+                               HexagonII::PredicatedMask));
+  return !HexagonII::getTSFlags(MID, HexagonII::PredicatedFalsePos,
+                                HexagonII::PredicatedFalseMask);
 }
 
 bool HexagonInstrInfo::isPredicated(unsigned Opcode) const {
-  const uint64_t F = get(Opcode).TSFlags;
-  return (F >> HexagonII::PredicatedPos) & HexagonII::PredicatedMask;
+  const auto &MID = get(Opcode);
+  return HexagonII::getTSFlags(MID, HexagonII::PredicatedPos,
+                               HexagonII::PredicatedMask);
 }
 
 bool HexagonInstrInfo::isPredicateLate(unsigned Opcode) const {
-  const uint64_t F = get(Opcode).TSFlags;
-  return (F >> HexagonII::PredicateLatePos) & HexagonII::PredicateLateMask;
+  const auto &MID = get(Opcode);
+  return HexagonII::getTSFlags(MID, HexagonII::PredicateLatePos,
+                               HexagonII::PredicateLateMask);
 }
 
 bool HexagonInstrInfo::isPredictedTaken(unsigned Opcode) const {
-  const uint64_t F = get(Opcode).TSFlags;
+  const auto &MID = get(Opcode);
   assert(get(Opcode).isBranch() &&
          (isPredicatedNew(Opcode) || isNewValue(Opcode)));
-  return (F >> HexagonII::TakenPos) & HexagonII::TakenMask;
+  return HexagonII::getTSFlags(MID, HexagonII::TakenPos, HexagonII::TakenMask);
 }
 
 bool HexagonInstrInfo::isSaveCalleeSavedRegsCall(const MachineInstr &MI) const {
@@ -2671,8 +2686,8 @@ bool HexagonInstrInfo::isSignExtendingLoad(const MachineInstr &MI) const {
 }
 
 bool HexagonInstrInfo::isSolo(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return (F >> HexagonII::SoloPos) & HexagonII::SoloMask;
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::SoloPos, HexagonII::SoloMask);
 }
 
 bool HexagonInstrInfo::isSpillPredRegOp(const MachineInstr &MI) const {
@@ -2995,8 +3010,8 @@ bool HexagonInstrInfo::isVecAcc(const MachineInstr &MI) const {
 }
 
 bool HexagonInstrInfo::isVecALU(const MachineInstr &MI) const {
-  const uint64_t F = get(MI.getOpcode()).TSFlags;
-  const uint64_t V = ((F >> HexagonII::TypePos) & HexagonII::TypeMask);
+  const auto &MID = get(MI.getOpcode());
+  const auto V = HexagonII::getType(MID);
   return
     V == HexagonII::TypeCVI_VA         ||
     V == HexagonII::TypeCVI_VA_DV;
@@ -3209,9 +3224,9 @@ bool HexagonInstrInfo::hasUncondBranch(const MachineBasicBlock *B)
 
 // Returns true, if a LD insn can be promoted to a cur load.
 bool HexagonInstrInfo::mayBeCurLoad(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return ((F >> HexagonII::mayCVLoadPos) & HexagonII::mayCVLoadMask) &&
-         Subtarget.hasV60Ops();
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::mayCVLoadPos,
+                               HexagonII::mayCVLoadMask);
 }
 
 // Returns true, if a ST insn can be promoted to a new-value store.
@@ -3219,8 +3234,9 @@ bool HexagonInstrInfo::mayBeNewStore(const MachineInstr &MI) const {
   if (MI.mayStore() && !Subtarget.useNewValueStores())
     return false;
 
-  const uint64_t F = MI.getDesc().TSFlags;
-  return (F >> HexagonII::mayNVStorePos) & HexagonII::mayNVStoreMask;
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::mayNVStorePos,
+                               HexagonII::mayNVStoreMask);
 }
 
 bool HexagonInstrInfo::producesStall(const MachineInstr &ProdMI,
@@ -3314,8 +3330,9 @@ bool HexagonInstrInfo::predOpcodeHasNot(ArrayRef<MachineOperand> Cond) const {
 }
 
 unsigned HexagonInstrInfo::getAddrMode(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return (F >> HexagonII::AddrModePos) & HexagonII::AddrModeMask;
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::AddrModePos,
+                               HexagonII::AddrModeMask);
 }
 
 // Returns the base register in a memory access (load/store). The offset is
@@ -3451,8 +3468,9 @@ SmallVector<MachineInstr*, 2> HexagonInstrInfo::getBranchingInstrs(
 
 // Returns Operand Index for the constant extended instruction.
 unsigned HexagonInstrInfo::getCExtOpNum(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return (F >> HexagonII::ExtendableOpPos) & HexagonII::ExtendableOpMask;
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::ExtendableOpPos,
+                               HexagonII::ExtendableOpMask);
 }
 
 // See if instruction could potentially be a duplex candidate.
@@ -4424,11 +4442,11 @@ unsigned HexagonInstrInfo::getInvertedPredicatedOpcode(const int Opc) const {
 
 // Returns the max value that doesn't need to be extended.
 int HexagonInstrInfo::getMaxValue(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  unsigned isSigned = (F >> HexagonII::ExtentSignedPos)
-                    & HexagonII::ExtentSignedMask;
-  unsigned bits =  (F >> HexagonII::ExtentBitsPos)
-                    & HexagonII::ExtentBitsMask;
+  const auto &MID = MI.getDesc();
+  unsigned isSigned = HexagonII::getTSFlags(MID, HexagonII::ExtentSignedPos,
+                                            HexagonII::ExtentSignedMask);
+  unsigned bits = HexagonII::getTSFlags(MID, HexagonII::ExtentBitsPos,
+                                        HexagonII::ExtentBitsMask);
 
   if (isSigned) // if value is signed
     return ~(-1U << (bits - 1));
@@ -4455,9 +4473,9 @@ bool HexagonInstrInfo::isAddrModeWithOffset(const MachineInstr &MI) const {
   case Hexagon::S2_storerfgp:
     return true;
   }
-  const uint64_t F = MI.getDesc().TSFlags;
-  unsigned addrMode =
-    ((F >> HexagonII::AddrModePos) & HexagonII::AddrModeMask);
+  const auto &MID = MI.getDesc();
+  unsigned addrMode = HexagonII::getTSFlags(MID, HexagonII::AddrModePos,
+                                            HexagonII::AddrModeMask);
   // Disallow any base+offset instruction. The assembler does not yet reorder
   // based up any zero offset instruction.
   return (addrMode == HexagonII::BaseRegOffset ||
@@ -4478,9 +4496,9 @@ bool HexagonInstrInfo::isPureSlot0(const MachineInstr &MI) const {
 }
 
 bool HexagonInstrInfo::isRestrictNoSlot1Store(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return ((F >> HexagonII::RestrictNoSlot1StorePos) &
-          HexagonII::RestrictNoSlot1StoreMask);
+  const auto &MID = MI.getDesc();
+  return HexagonII::getTSFlags(MID, HexagonII::RestrictNoSlot1StorePos,
+                               HexagonII::RestrictNoSlot1StoreMask);
 }
 
 void HexagonInstrInfo::changeDuplexOpcode(MachineBasicBlock::instr_iterator MII,
@@ -4521,11 +4539,10 @@ void HexagonInstrInfo::translateInstrsForDup(
 }
 
 unsigned HexagonInstrInfo::getMemAccessSize(const MachineInstr &MI) const {
-  using namespace HexagonII;
 
-  const uint64_t F = MI.getDesc().TSFlags;
-  unsigned S = (F >> MemAccessSizePos) & MemAccesSizeMask;
-  unsigned Size = getMemAccessSizeInBytes(MemAccessSize(S));
+  const auto &MID = MI.getDesc();
+  auto SizeEnum = HexagonII::getMemAccessEnum(MID);
+  unsigned Size = HexagonII::getMemAccessSizeInBytesNoVector(SizeEnum);
   if (Size != 0)
     return Size;
   // Y2_dcfetchbo is special
@@ -4533,22 +4550,22 @@ unsigned HexagonInstrInfo::getMemAccessSize(const MachineInstr &MI) const {
     return HexagonII::DoubleWordAccess;
 
   // Handle vector access sizes.
-  const HexagonRegisterInfo &HRI = *Subtarget.getRegisterInfo();
-  switch (S) {
-    case HexagonII::HVXVectorAccess:
-      return HRI.getSpillSize(Hexagon::HvxVRRegClass);
-    default:
-      llvm_unreachable("Unexpected instruction");
+  const auto &HRI = *Subtarget.getRegisterInfo();
+  switch (SizeEnum) {
+  case HexagonII::HVXVectorAccess:
+    return HRI.getSpillSize(Hexagon::HvxVRRegClass);
+  default:
+    llvm_unreachable("Unexpected instruction");
   }
 }
 
 // Returns the min value that doesn't need to be extended.
 int HexagonInstrInfo::getMinValue(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  unsigned isSigned = (F >> HexagonII::ExtentSignedPos)
-                    & HexagonII::ExtentSignedMask;
-  unsigned bits =  (F >> HexagonII::ExtentBitsPos)
-                    & HexagonII::ExtentBitsMask;
+  const auto &MID = MI.getDesc();
+  unsigned isSigned = HexagonII::getTSFlags(MID, HexagonII::ExtentSignedPos,
+                                            HexagonII::ExtentSignedMask);
+  unsigned bits = HexagonII::getTSFlags(MID, HexagonII::ExtentBitsPos,
+                                        HexagonII::ExtentBitsMask);
 
   if (isSigned) // if value is signed
     return -1U << (bits - 1);
@@ -4649,8 +4666,8 @@ unsigned HexagonInstrInfo::getSize(const MachineInstr &MI) const {
 }
 
 uint64_t HexagonInstrInfo::getType(const MachineInstr &MI) const {
-  const uint64_t F = MI.getDesc().TSFlags;
-  return (F >> HexagonII::TypePos) & HexagonII::TypeMask;
+  const auto &MID = MI.getDesc();
+  return HexagonII::getType(MID);
 }
 
 InstrStage::FuncUnits HexagonInstrInfo::getUnits(const MachineInstr &MI) const {

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonBaseInfo.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonBaseInfo.h
@@ -16,8 +16,11 @@
 #ifndef LLVM_LIB_TARGET_HEXAGON_MCTARGETDESC_HEXAGONBASEINFO_H
 #define LLVM_LIB_TARGET_HEXAGON_MCTARGETDESC_HEXAGONBASEINFO_H
 
+#include <cassert>
+
 #include "HexagonDepITypes.h"
 #include "MCTargetDesc/HexagonMCTargetDesc.h"
+#include "llvm/MC/MCInstrDesc.h" // included for inline functions
 
 namespace llvm {
 
@@ -48,7 +51,7 @@ namespace HexagonII {
 
   // MCInstrDesc TSFlags
   // *** Must match HexagonInstrFormat*.td ***
-  enum {
+  enum HexagonTSFlagsVal {
     // This 7-bit field describes the insn type.
     TypePos = 0,
     TypeMask = 0x7f,
@@ -129,7 +132,7 @@ namespace HexagonII {
     AddrModeMask = 0x7,
     // Access size for load/store instructions.
     MemAccessSizePos = 43,
-    MemAccesSizeMask = 0xf,
+    MemAccessSizeMask = 0xf,
 
     // Branch predicted taken.
     TakenPos = 47,
@@ -172,6 +175,22 @@ namespace HexagonII {
     hasUnaryRestrictionPos = 62,
     hasUnaryRestrictionMask = 0x1,
   };
+
+  inline unsigned getTSFlags(const MCInstrDesc &MID, HexagonTSFlagsVal Pos,
+                             unsigned Mask) {
+    return (MID.TSFlags >> Pos) & Mask;
+  }
+
+  enum HexagonTSFlags2Val {
+    // To be filled in with Hexagon-specific Flags
+  };
+
+  inline unsigned getTSFlags(const MCInstrDesc &MID, HexagonTSFlags2Val Pos,
+                             unsigned Mask) {
+    unsigned Shift = static_cast<unsigned>(Pos);
+    assert(Shift >= 64 && "HexagonTSFlags2Val position must be >= 64");
+    return (MID.TSFlags2 >> (Shift - 64)) & Mask;
+  }
 
   // *** The code above must match HexagonInstrFormat*.td *** //
 
@@ -275,14 +294,30 @@ namespace HexagonII {
     INST_ICLASS_ALU32_3   = 0xf0000000
   };
 
-  [[maybe_unused]]
-  static unsigned getMemAccessSizeInBytes(MemAccessSize S) {
-    switch (S) {
-      case ByteAccess:        return 1;
-      case HalfWordAccess:    return 2;
-      case WordAccess:        return 4;
-      case DoubleWordAccess:  return 8;
-      default:                return 0;
+  inline bool isCVI(const MCInstrDesc &MID) {
+    return getTSFlags(MID, isCVIPos, isCVIMask) != 0;
+  }
+
+  inline Type getType(const MCInstrDesc &MID) {
+    return Type(getTSFlags(MID, TypePos, TypeMask));
+  }
+
+  inline MemAccessSize getMemAccessEnum(const MCInstrDesc &MID) {
+    return MemAccessSize(getTSFlags(MID, MemAccessSizePos, MemAccessSizeMask));
+  }
+
+  inline unsigned getMemAccessSizeInBytesNoVector(MemAccessSize SizeEnum) {
+    switch (SizeEnum) {
+    case ByteAccess:
+      return 1;
+    case HalfWordAccess:
+      return 2;
+    case WordAccess:
+      return 4;
+    case DoubleWordAccess:
+      return 8;
+    default:
+      return 0; // handles HVXVectorAccess
     }
   }
 } // end namespace HexagonII

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.cpp
@@ -238,17 +238,10 @@ void HexagonMCInstrInfo::extendIfNeeded(MCContext &Context,
     addConstExtender(Context, MCII, MCB, MCI);
 }
 
-unsigned HexagonMCInstrInfo::getMemAccessSize(MCInstrInfo const &MCII,
-      MCInst const &MCI) {
-  uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  unsigned S = (F >> HexagonII::MemAccessSizePos) & HexagonII::MemAccesSizeMask;
-  return HexagonII::getMemAccessSizeInBytes(HexagonII::MemAccessSize(S));
-}
-
 unsigned HexagonMCInstrInfo::getAddrMode(MCInstrInfo const &MCII,
                                          MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return static_cast<unsigned>((F >> HexagonII::AddrModePos) &
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::AddrModePos,
                                HexagonII::AddrModeMask);
 }
 
@@ -315,8 +308,9 @@ MCExpr const &HexagonMCInstrInfo::getExpr(MCExpr const &Expr) {
 
 unsigned short HexagonMCInstrInfo::getExtendableOp(MCInstrInfo const &MCII,
                                                    MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::ExtendableOpPos) & HexagonII::ExtendableOpMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::ExtendableOpPos,
+                               HexagonII::ExtendableOpMask);
 }
 
 MCOperand const &
@@ -333,20 +327,23 @@ HexagonMCInstrInfo::getExtendableOperand(MCInstrInfo const &MCII,
 
 unsigned HexagonMCInstrInfo::getExtentAlignment(MCInstrInfo const &MCII,
                                                 MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::ExtentAlignPos) & HexagonII::ExtentAlignMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::ExtentAlignPos,
+                               HexagonII::ExtentAlignMask);
 }
 
 unsigned HexagonMCInstrInfo::getExtentBits(MCInstrInfo const &MCII,
                                            MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::ExtentBitsPos) & HexagonII::ExtentBitsMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::ExtentBitsPos,
+                               HexagonII::ExtentBitsMask);
 }
 
 bool HexagonMCInstrInfo::isExtentSigned(MCInstrInfo const &MCII,
                                         MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return (F >> HexagonII::ExtentSignedPos) & HexagonII::ExtentSignedMask;
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::ExtentSignedPos,
+                               HexagonII::ExtentSignedMask);
 }
 
 /// Return the maximum value of an extendable operand.
@@ -378,8 +375,9 @@ StringRef HexagonMCInstrInfo::getName(MCInstrInfo const &MCII,
 
 unsigned short HexagonMCInstrInfo::getNewValueOp(MCInstrInfo const &MCII,
                                                  MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::NewValueOpPos) & HexagonII::NewValueOpMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::NewValueOpPos,
+                               HexagonII::NewValueOpMask);
 }
 
 MCOperand const &HexagonMCInstrInfo::getNewValueOperand(MCInstrInfo const &MCII,
@@ -403,8 +401,9 @@ MCOperand const &HexagonMCInstrInfo::getNewValueOperand(MCInstrInfo const &MCII,
 /// Return the new value or the newly produced value.
 unsigned short HexagonMCInstrInfo::getNewValueOp2(MCInstrInfo const &MCII,
                                                   MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::NewValueOpPos2) & HexagonII::NewValueOpMask2);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::NewValueOpPos2,
+                               HexagonII::NewValueOpMask2);
 }
 
 MCOperand const &
@@ -422,8 +421,8 @@ HexagonMCInstrInfo::getNewValueOperand2(MCInstrInfo const &MCII,
 /// Return the Hexagon ISA class for the insn.
 unsigned HexagonMCInstrInfo::getType(MCInstrInfo const &MCII,
                                      MCInst const &MCI) {
-  const uint64_t F = MCII.get(MCI.getOpcode()).TSFlags;
-  return ((F >> HexagonII::TypePos) & HexagonII::TypeMask);
+  const auto &MID = MCII.get(MCI.getOpcode());
+  return HexagonII::getType(MID);
 }
 
 /// Return the resources used by this instruction
@@ -512,15 +511,17 @@ bool HexagonMCInstrInfo::hasImmExt(MCInst const &MCI) {
 /// Return whether the insn produces a value.
 bool HexagonMCInstrInfo::hasNewValue(MCInstrInfo const &MCII,
                                      MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::hasNewValuePos) & HexagonII::hasNewValueMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::hasNewValuePos,
+                               HexagonII::hasNewValueMask);
 }
 
 /// Return whether the insn produces a second value.
 bool HexagonMCInstrInfo::hasNewValue2(MCInstrInfo const &MCII,
                                       MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::hasNewValuePos2) & HexagonII::hasNewValueMask2);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::hasNewValuePos2,
+                               HexagonII::hasNewValueMask2);
 }
 
 MCInst const &HexagonMCInstrInfo::instruction(MCInst const &MCB, size_t Index) {
@@ -532,8 +533,9 @@ MCInst const &HexagonMCInstrInfo::instruction(MCInst const &MCB, size_t Index) {
 /// Return where the instruction is an accumulator.
 bool HexagonMCInstrInfo::isAccumulator(MCInstrInfo const &MCII,
                                        MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::AccumulatorPos) & HexagonII::AccumulatorMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::AccumulatorPos,
+                               HexagonII::AccumulatorMask);
 }
 
 bool HexagonMCInstrInfo::isBundle(MCInst const &MCI) {
@@ -590,20 +592,23 @@ bool HexagonMCInstrInfo::isCanon(MCInstrInfo const &MCII, MCInst const &MCI) {
 }
 
 bool HexagonMCInstrInfo::isCofMax1(MCInstrInfo const &MCII, MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::CofMax1Pos) & HexagonII::CofMax1Mask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::CofMax1Pos,
+                               HexagonII::CofMax1Mask);
 }
 
 bool HexagonMCInstrInfo::isCofRelax1(MCInstrInfo const &MCII,
                                      MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::CofRelax1Pos) & HexagonII::CofRelax1Mask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::CofRelax1Pos,
+                               HexagonII::CofRelax1Mask);
 }
 
 bool HexagonMCInstrInfo::isCofRelax2(MCInstrInfo const &MCII,
                                      MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::CofRelax2Pos) & HexagonII::CofRelax2Mask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::CofRelax2Pos,
+                               HexagonII::CofRelax2Mask);
 }
 
 bool HexagonMCInstrInfo::isCompound(MCInstrInfo const &MCII,
@@ -612,8 +617,9 @@ bool HexagonMCInstrInfo::isCompound(MCInstrInfo const &MCII,
 }
 
 bool HexagonMCInstrInfo::isCVINew(MCInstrInfo const &MCII, MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::CVINewPos) & HexagonII::CVINewMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::CVINewPos,
+                               HexagonII::CVINewMask);
 }
 
 bool HexagonMCInstrInfo::isDblRegForSubInst(MCRegister Reg) {
@@ -627,19 +633,21 @@ bool HexagonMCInstrInfo::isDuplex(MCInstrInfo const &MCII, MCInst const &MCI) {
 
 bool HexagonMCInstrInfo::isExtendable(MCInstrInfo const &MCII,
                                       MCInst const &MCI) {
-  uint64_t const F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return (F >> HexagonII::ExtendablePos) & HexagonII::ExtendableMask;
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::ExtendablePos,
+                               HexagonII::ExtendableMask);
 }
 
 bool HexagonMCInstrInfo::isExtended(MCInstrInfo const &MCII,
                                     MCInst const &MCI) {
-  uint64_t const F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return (F >> HexagonII::ExtendedPos) & HexagonII::ExtendedMask;
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::ExtendedPos,
+                               HexagonII::ExtendedMask);
 }
 
 bool HexagonMCInstrInfo::isFloat(MCInstrInfo const &MCII, MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::FPPos) & HexagonII::FPMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::FPPos, HexagonII::FPMask);
 }
 
 bool HexagonMCInstrInfo::isHVX(MCInstrInfo const &MCII, MCInst const &MCI) {
@@ -669,14 +677,16 @@ bool HexagonMCInstrInfo::isIntRegForSubInst(MCRegister Reg) {
 /// Return whether the insn expects newly produced value.
 bool HexagonMCInstrInfo::isNewValue(MCInstrInfo const &MCII,
                                     MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::NewValuePos) & HexagonII::NewValueMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::NewValuePos,
+                               HexagonII::NewValueMask);
 }
 
 bool HexagonMCInstrInfo::isNewValueStore(MCInstrInfo const &MCII,
                                          MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return (F >> HexagonII::NVStorePos) & HexagonII::NVStoreMask;
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::NVStorePos,
+                               HexagonII::NVStoreMask);
 }
 
 /// Return whether the operand is extendable.
@@ -732,8 +742,9 @@ bool HexagonMCInstrInfo::IsSingleConsumerRefPairProducer(MCRegister Producer,
 
 bool HexagonMCInstrInfo::isPredicated(MCInstrInfo const &MCII,
                                       MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::PredicatedPos) & HexagonII::PredicatedMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::PredicatedPos,
+                               HexagonII::PredicatedMask);
 }
 
 bool HexagonMCInstrInfo::isPrefix(MCInstrInfo const &MCII, MCInst const &MCI) {
@@ -742,22 +753,24 @@ bool HexagonMCInstrInfo::isPrefix(MCInstrInfo const &MCII, MCInst const &MCI) {
 
 bool HexagonMCInstrInfo::isPredicateLate(MCInstrInfo const &MCII,
                                          MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return (F >> HexagonII::PredicateLatePos & HexagonII::PredicateLateMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::PredicateLatePos,
+                               HexagonII::PredicateLateMask);
 }
 
 /// Return whether the insn is newly predicated.
 bool HexagonMCInstrInfo::isPredicatedNew(MCInstrInfo const &MCII,
                                          MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::PredicatedNewPos) & HexagonII::PredicatedNewMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::PredicatedNewPos,
+                               HexagonII::PredicatedNewMask);
 }
 
 bool HexagonMCInstrInfo::isPredicatedTrue(MCInstrInfo const &MCII,
                                           MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return (
-      !((F >> HexagonII::PredicatedFalsePos) & HexagonII::PredicatedFalseMask));
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return !HexagonII::getTSFlags(MID, HexagonII::PredicatedFalsePos,
+                                HexagonII::PredicatedFalseMask);
 }
 
 bool HexagonMCInstrInfo::isPredReg(MCRegisterInfo const &MRI, MCRegister Reg) {
@@ -775,29 +788,30 @@ bool HexagonMCInstrInfo::isPredRegister(MCInstrInfo const &MCII,
 
 /// Return whether the insn can be packaged only with A and X-type insns.
 bool HexagonMCInstrInfo::isSoloAX(MCInstrInfo const &MCII, MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::SoloAXPos) & HexagonII::SoloAXMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::SoloAXPos,
+                               HexagonII::SoloAXMask);
 }
 
 /// Return whether the insn can be packaged only with an A-type insn in slot #1.
 bool HexagonMCInstrInfo::isRestrictSlot1AOK(MCInstrInfo const &MCII,
                                             MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::RestrictSlot1AOKPos) &
-          HexagonII::RestrictSlot1AOKMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::RestrictSlot1AOKPos,
+                               HexagonII::RestrictSlot1AOKMask);
 }
 
 bool HexagonMCInstrInfo::isRestrictNoSlot1Store(MCInstrInfo const &MCII,
                                                 MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return ((F >> HexagonII::RestrictNoSlot1StorePos) &
-          HexagonII::RestrictNoSlot1StoreMask);
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::RestrictNoSlot1StorePos,
+                               HexagonII::RestrictNoSlot1StoreMask);
 }
 
 /// Return whether the insn is solo, i.e., cannot be in a packet.
 bool HexagonMCInstrInfo::isSolo(MCInstrInfo const &MCII, MCInst const &MCI) {
-  const uint64_t F = MCII.get(MCI.getOpcode()).TSFlags;
-  return ((F >> HexagonII::SoloPos) & HexagonII::SoloMask);
+  const auto &MID = MCII.get(MCI.getOpcode());
+  return HexagonII::getTSFlags(MID, HexagonII::SoloPos, HexagonII::SoloMask);
 }
 
 bool HexagonMCInstrInfo::isMemReorderDisabled(MCInst const &MCI) {
@@ -867,8 +881,8 @@ bool HexagonMCInstrInfo::isSubInstruction(MCInst const &MCI) {
 }
 
 bool HexagonMCInstrInfo::isVector(MCInstrInfo const &MCII, MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return (F >> HexagonII::isCVIPos) & HexagonII::isCVIMask;
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::isCVI(MID);
 }
 
 int64_t HexagonMCInstrInfo::minConstant(MCInst const &MCI, size_t Index) {
@@ -947,8 +961,9 @@ HexagonMCInstrInfo::predicateInfo(MCInstrInfo const &MCII, MCInst const &MCI) {
 
 bool HexagonMCInstrInfo::prefersSlot3(MCInstrInfo const &MCII,
                                       MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return (F >> HexagonII::PrefersSlot3Pos) & HexagonII::PrefersSlot3Mask;
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::PrefersSlot3Pos,
+                               HexagonII::PrefersSlot3Mask);
 }
 
 bool HexagonMCInstrInfo::hasTmpDst(MCInstrInfo const &MCII, MCInst const &MCI) {
@@ -967,8 +982,9 @@ bool HexagonMCInstrInfo::hasTmpDst(MCInstrInfo const &MCII, MCInst const &MCI) {
 }
 
 bool HexagonMCInstrInfo::hasHvxTmp(MCInstrInfo const &MCII, MCInst const &MCI) {
-  const uint64_t F = HexagonMCInstrInfo::getDesc(MCII, MCI).TSFlags;
-  return (F >> HexagonII::HasHvxTmpPos) & HexagonII::HasHvxTmpMask;
+  const auto &MID = HexagonMCInstrInfo::getDesc(MCII, MCI);
+  return HexagonII::getTSFlags(MID, HexagonII::HasHvxTmpPos,
+                               HexagonII::HasHvxTmpMask);
 }
 
 bool HexagonMCInstrInfo::requiresSlot(MCSubtargetInfo const &STI,

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.h
@@ -117,9 +117,6 @@ MCInst const *extenderForIndex(MCInst const &MCB, size_t Index);
 void extendIfNeeded(MCContext &Context, MCInstrInfo const &MCII, MCInst &MCB,
                     MCInst const &MCI);
 
-// Return memory access size in bytes
-unsigned getMemAccessSize(MCInstrInfo const &MCII, MCInst const &MCI);
-
 // Return memory access size
 unsigned getAddrMode(MCInstrInfo const &MCII, MCInst const &MCI);
 

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -1403,13 +1403,26 @@ void InstrInfoEmitter::emitRecord(
   const BitsInit *TSF = Inst.TheDef->getValueAsBitsInit("TSFlags");
   if (!TSF)
     PrintFatalError(Inst.TheDef->getLoc(), "no TSFlags?");
-  std::optional<uint64_t> Value = TSF->convertInitializerToInt();
-  if (!Value)
-    PrintFatalError(Inst.TheDef, "Invalid TSFlags bit in " + Inst.getName());
-
+  uint64_t Value = 0, Value2 = 0;
+  unsigned NumBits = TSF->getNumBits();
+  if (NumBits > 128)
+    PrintFatalError(Inst.TheDef->getLoc(),
+                    "TSFlags exceeds 128 bits in " + Inst.TheDef->getName());
+  for (unsigned i = 0; i != NumBits; ++i) {
+    if (const auto *Bit = dyn_cast<BitInit>(TSF->getBit(i))) {
+      if (i < 64)
+        Value |= uint64_t(Bit->getValue()) << i;
+      else
+        Value2 |= uint64_t(Bit->getValue()) << (i - 64);
+    } else
+      PrintFatalError(Inst.TheDef->getLoc(),
+                      "Invalid TSFlags bit in " + Inst.TheDef->getName());
+  }
   OS << ", 0x";
-  OS.write_hex(*Value);
-  OS << "ULL";
+  OS.write_hex(Value);
+  OS << "ULL, 0x";
+  OS.write_hex(Value2);
+  OS << "ULL, ";
 
   OS << " },  // " << Inst.getName() << '\n';
 }


### PR DESCRIPTION
Enable TSFlags2 usage in Hexagon now that
TableGen emits 128-bit TSFlags split across
TSFlags/TSFlags2. Refactor TSFlags access
to avoid duplicated bit-extraction logic.

Co-authored-by: Alexey Karyakin <akaryaki@qti.qualcomm.com>