### PR TITLE
[lldb][Target] Allow eLanguageTypeAssembly to use ScratchTypeSystemClang

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2619,6 +2619,7 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
 
   if (language == eLanguageTypeMipsAssembler // GNU AS and LLVM use it for all
                                              // assembly code
+      || language == eLanguageTypeAssembly
       || language == eLanguageTypeUnknown) {
     LanguageSet languages_for_expressions =
         Language::GetLanguagesSupportingTypeSystemsForExpressions();

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2619,8 +2619,8 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
 
   if (language == eLanguageTypeMipsAssembler // GNU AS and LLVM use it for all
                                              // assembly code
-      || language == eLanguageTypeAssembly
-      || language == eLanguageTypeUnknown) {
+      || language == eLanguageTypeAssembly ||
+      language == eLanguageTypeUnknown) {
     LanguageSet languages_for_expressions =
         Language::GetLanguagesSupportingTypeSystemsForExpressions();
 

--- a/lldb/unittests/Target/CMakeLists.txt
+++ b/lldb/unittests/Target/CMakeLists.txt
@@ -11,12 +11,14 @@ add_lldb_unittest(TargetTests
   PathMappingListTest.cpp
   RegisterFlagsTest.cpp
   RemoteAwarePlatformTest.cpp
+  ScratchTypeSystemTest.cpp
   StackFrameRecognizerTest.cpp
   SummaryStatisticsTest.cpp
   FindFileTest.cpp
 
   LINK_COMPONENTS
       Support
+      TestingSupport
   LINK_LIBS
       lldbCore
       lldbHost

--- a/lldb/unittests/Target/ScratchTypeSystemTest.cpp
+++ b/lldb/unittests/Target/ScratchTypeSystemTest.cpp
@@ -1,0 +1,59 @@
+//===-- TestTypeSystem.cpp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Plugins/Platform/MacOSX/PlatformMacOSX.h"
+#include "Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h"
+#include "TestingSupport/SubsystemRAII.h"
+#include "TestingSupport/TestUtilities.h"
+#include "lldb/Core/Debugger.h"
+#include "lldb/Core/Module.h"
+#include "lldb/Host/FileSystem.h"
+#include "lldb/Host/HostInfo.h"
+#include "lldb/lldb-enumerations.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+class TestTypeSystemMap : public testing::Test {
+public:
+  SubsystemRAII<FileSystem, HostInfo, PlatformMacOSX> subsystems;
+
+protected:
+  void SetUp() override {
+    std::call_once(TestUtilities::g_debugger_initialize_flag,
+                   []() { Debugger::Initialize(nullptr); });
+  };
+
+  DebuggerSP m_debugger_sp;
+  PlatformSP m_platform_sp;
+};
+
+TEST_F(TestTypeSystemMap, GetScratchTypeSystemForLanguage) {
+  // Set up the debugger, make sure that was done properly.
+  TargetSP target_sp;
+  ArchSpec arch("x86_64-apple-macosx-");
+  Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
+
+  m_debugger_sp = Debugger::CreateInstance();
+
+  auto &target = m_debugger_sp->GetDummyTarget();
+  EXPECT_THAT_EXPECTED(
+      target.GetScratchTypeSystemForLanguage(lldb::eLanguageTypeMipsAssembler),
+      llvm::FailedWithMessage("No expression support for any languages"));
+  EXPECT_THAT_EXPECTED(
+      target.GetScratchTypeSystemForLanguage(lldb::eLanguageTypeAssembly),
+      llvm::FailedWithMessage("No expression support for any languages"));
+  EXPECT_THAT_EXPECTED(
+      target.GetScratchTypeSystemForLanguage(lldb::eLanguageTypeUnknown),
+      llvm::FailedWithMessage("No expression support for any languages"));
+  EXPECT_THAT_EXPECTED(
+      target.GetScratchTypeSystemForLanguage(lldb::eLanguageTypeModula2),
+      llvm::FailedWithMessage("TypeSystem for language modula2 doesn't exist"));
+}


### PR DESCRIPTION
After cleaning up some of our `LanguageType`/`SourceLangage` round-tripping (see `7f51a2a47d2e706d04855b0e41690ebafa2b3238`), a CU with `DW_LANG_MIPS_Assembler` will get a language type of `eLanguageTypeAssembly` (as opposed to `eLanguageTypeMipsAssembler`). Reason being that there is no `DW_LNAME_` (DWARFv6 language code) for `MIPS Assembler`, only for generic `Assembly`. So it's not possible to round-trip cleanly between pre-DWARFv6 and DWARFv6 language codes, which LLDB relies on for storing language types (and will lean into more heavily in the future). This broke a special provision we have where we allow `ScratchTypeSystemClang` to be used when evaluating expressions in assembly CUs (i.e., CUs where the debug-info explicitly sets the language to assembly).

If we ever want to distinguish MIPS from other Assembly, the proper way to do so is introduce a `DW_LNAME_Mips_Assembler`. For now, this patch adds another case for `eLanguageTypeAssembly` in `GetScratchTypeSystemForLanguage`.

The test is a bit quirky because it checks for error messages in all cases. For the `TypeSystem`s to exist we would have to initialize the `TypeSystem` plugins, which I couldn't find a precedent for. But happy to hear other suggestions for testing

Fixes https://github.com/llvm/llvm-project/issues/183388