### PR TITLE
Revert "[SPIRV][NFCI] Use unordered data structures for SPIR-V extensions"

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
@@ -15,12 +15,10 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVSYMBOLICOPERANDS_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVSYMBOLICOPERANDS_H
 
-#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/VersionTuple.h"
 #include <string>
-#include <type_traits>
 
 namespace llvm {
 namespace SPIRV {
@@ -257,27 +255,6 @@ enum InstFlags {
 using CapabilityList = SmallVector<SPIRV::Capability::Capability, 8>;
 using ExtensionList = SmallVector<SPIRV::Extension::Extension, 8>;
 using EnvironmentList = SmallVector<SPIRV::Environment::Environment, 8>;
-
-// Tablegen enum types don't have an underlying type which is required for
-// DenseMap so just use the DenseMapInfo for std::underlying_type_t.
-template <> struct DenseMapInfo<SPIRV::Extension::Extension> {
-  using DMI = DenseMapInfo<std::underlying_type_t<SPIRV::Extension::Extension>>;
-  static SPIRV::Extension::Extension getEmptyKey() {
-    return static_cast<SPIRV::Extension::Extension>(DMI::getEmptyKey());
-  }
-  static SPIRV::Extension::Extension getTombstoneKey() {
-    return static_cast<SPIRV::Extension::Extension>(DMI::getTombstoneKey());
-  }
-  static unsigned getHashValue(SPIRV::Extension::Extension Ty) {
-    return DMI::getHashValue(Ty);
-  }
-  static bool isEqual(SPIRV::Extension::Extension Ty1,
-                      SPIRV::Extension::Extension Ty2) {
-    return Ty1 == Ty2;
-  }
-};
-
-using ExtensionSet = DenseSet<SPIRV::Extension::Extension>;
 
 std::string
 getSymbolicOperandMnemonic(SPIRV::OperandCategory::OperandCategory Category,

--- a/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
@@ -59,7 +59,7 @@ SPIRVTranslate(Module *M, std::string &SpirvObj, std::string &ErrMsg,
   static const std::string DefaultTriple = "spirv64-unknown-unknown";
   static const std::string DefaultMArch = "";
 
-  ExtensionSet AllowedExtIds;
+  std::set<SPIRV::Extension::Extension> AllowedExtIds;
   StringRef UnknownExt =
       SPIRVExtensionsParser::checkExtensions(AllowExtNames, AllowedExtIds);
   if (!UnknownExt.empty()) {

--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
@@ -14,11 +14,12 @@
 #include "SPIRVCommandLine.h"
 #include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringMap.h"
 #include "llvm/TargetParser/Triple.h"
 
 #include <functional>
 #include <iterator>
+#include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -27,167 +28,178 @@
 
 using namespace llvm;
 
-ExtensionSet SPIRVExtensionsParser::DisabledExtensions;
+std::set<SPIRV::Extension::Extension> SPIRVExtensionsParser::DisabledExtensions;
 
-static const StringMap<SPIRV::Extension::Extension> SPIRVExtensionMap = {
-    {"SPV_EXT_shader_atomic_float_add",
-     SPIRV::Extension::Extension::SPV_EXT_shader_atomic_float_add},
-    {"SPV_EXT_shader_atomic_float16_add",
-     SPIRV::Extension::Extension::SPV_EXT_shader_atomic_float16_add},
-    {"SPV_EXT_shader_atomic_float_min_max",
-     SPIRV::Extension::Extension::SPV_EXT_shader_atomic_float_min_max},
-    {"SPV_INTEL_16bit_atomics",
-     SPIRV::Extension::Extension::SPV_INTEL_16bit_atomics},
-    {"SPV_NV_shader_atomic_fp16_vector",
-     SPIRV::Extension::Extension::SPV_NV_shader_atomic_fp16_vector},
-    {"SPV_EXT_arithmetic_fence",
-     SPIRV::Extension::Extension::SPV_EXT_arithmetic_fence},
-    {"SPV_EXT_demote_to_helper_invocation",
-     SPIRV::Extension::Extension::SPV_EXT_demote_to_helper_invocation},
-    {"SPV_EXT_descriptor_indexing",
-     SPIRV::Extension::Extension::SPV_EXT_descriptor_indexing},
-    {"SPV_EXT_fragment_fully_covered",
-     SPIRV::Extension::Extension::SPV_EXT_fragment_fully_covered},
-    {"SPV_EXT_fragment_invocation_density",
-     SPIRV::Extension::Extension::SPV_EXT_fragment_invocation_density},
-    {"SPV_EXT_fragment_shader_interlock",
-     SPIRV::Extension::Extension::SPV_EXT_fragment_shader_interlock},
-    {"SPV_EXT_mesh_shader", SPIRV::Extension::Extension::SPV_EXT_mesh_shader},
-    {"SPV_EXT_shader_stencil_export",
-     SPIRV::Extension::Extension::SPV_EXT_shader_stencil_export},
-    {"SPV_EXT_shader_viewport_index_layer",
-     SPIRV::Extension::Extension::SPV_EXT_shader_viewport_index_layer},
-    {"SPV_GOOGLE_hlsl_functionality1",
-     SPIRV::Extension::Extension::SPV_GOOGLE_hlsl_functionality1},
-    {"SPV_GOOGLE_user_type", SPIRV::Extension::Extension::SPV_GOOGLE_user_type},
-    {"SPV_ALTERA_arbitrary_precision_integers",
-     SPIRV::Extension::Extension::SPV_ALTERA_arbitrary_precision_integers},
-    {"SPV_ALTERA_arbitrary_precision_floating_point",
-     SPIRV::Extension::Extension::
-         SPV_ALTERA_arbitrary_precision_floating_point},
-    {"SPV_INTEL_cache_controls",
-     SPIRV::Extension::Extension::SPV_INTEL_cache_controls},
-    {"SPV_INTEL_float_controls2",
-     SPIRV::Extension::Extension::SPV_INTEL_float_controls2},
-    {"SPV_INTEL_global_variable_fpga_decorations",
-     SPIRV::Extension::Extension::SPV_INTEL_global_variable_fpga_decorations},
-    {"SPV_INTEL_global_variable_host_access",
-     SPIRV::Extension::Extension::SPV_INTEL_global_variable_host_access},
-    {"SPV_INTEL_optnone", SPIRV::Extension::Extension::SPV_INTEL_optnone},
-    {"SPV_EXT_optnone", SPIRV::Extension::Extension::SPV_EXT_optnone},
-    {"SPV_INTEL_usm_storage_classes",
-     SPIRV::Extension::Extension::SPV_INTEL_usm_storage_classes},
-    {"SPV_INTEL_split_barrier",
-     SPIRV::Extension::Extension::SPV_INTEL_split_barrier},
-    {"SPV_INTEL_subgroups", SPIRV::Extension::Extension::SPV_INTEL_subgroups},
-    {"SPV_INTEL_media_block_io",
-     SPIRV::Extension::Extension::SPV_INTEL_media_block_io},
-    {"SPV_INTEL_memory_access_aliasing",
-     SPIRV::Extension::Extension::SPV_INTEL_memory_access_aliasing},
-    {"SPV_INTEL_joint_matrix",
-     SPIRV::Extension::Extension::SPV_INTEL_joint_matrix},
-    {"SPV_KHR_16bit_storage",
-     SPIRV::Extension::Extension::SPV_KHR_16bit_storage},
-    {"SPV_KHR_device_group", SPIRV::Extension::Extension::SPV_KHR_device_group},
-    {"SPV_KHR_fragment_shading_rate",
-     SPIRV::Extension::Extension::SPV_KHR_fragment_shading_rate},
-    {"SPV_KHR_multiview", SPIRV::Extension::Extension::SPV_KHR_multiview},
-    {"SPV_KHR_post_depth_coverage",
-     SPIRV::Extension::Extension::SPV_KHR_post_depth_coverage},
-    {"SPV_KHR_shader_draw_parameters",
-     SPIRV::Extension::Extension::SPV_KHR_shader_draw_parameters},
-    {"SPV_KHR_ray_tracing", SPIRV::Extension::Extension::SPV_KHR_ray_tracing},
-    {"SPV_KHR_uniform_group_instructions",
-     SPIRV::Extension::Extension::SPV_KHR_uniform_group_instructions},
-    {"SPV_KHR_no_integer_wrap_decoration",
-     SPIRV::Extension::Extension::SPV_KHR_no_integer_wrap_decoration},
-    {"SPV_KHR_float_controls",
-     SPIRV::Extension::Extension::SPV_KHR_float_controls},
-    {"SPV_KHR_expect_assume",
-     SPIRV::Extension::Extension::SPV_KHR_expect_assume},
-    {"SPV_KHR_bit_instructions",
-     SPIRV::Extension::Extension::SPV_KHR_bit_instructions},
-    {"SPV_KHR_integer_dot_product",
-     SPIRV::Extension::Extension::SPV_KHR_integer_dot_product},
-    {"SPV_KHR_linkonce_odr", SPIRV::Extension::Extension::SPV_KHR_linkonce_odr},
-    {"SPV_KHR_fma", SPIRV::Extension::Extension::SPV_KHR_fma},
-    {"SPV_INTEL_inline_assembly",
-     SPIRV::Extension::Extension::SPV_INTEL_inline_assembly},
-    {"SPV_INTEL_bindless_images",
-     SPIRV::Extension::Extension::SPV_INTEL_bindless_images},
-    {"SPV_INTEL_bfloat16_arithmetic",
-     SPIRV::Extension::Extension::SPV_INTEL_bfloat16_arithmetic},
-    {"SPV_INTEL_bfloat16_conversion",
-     SPIRV::Extension::Extension::SPV_INTEL_bfloat16_conversion},
-    {"SPV_KHR_subgroup_rotate",
-     SPIRV::Extension::Extension::SPV_KHR_subgroup_rotate},
-    {"SPV_INTEL_variable_length_array",
-     SPIRV::Extension::Extension::SPV_INTEL_variable_length_array},
-    {"SPV_INTEL_function_pointers",
-     SPIRV::Extension::Extension::SPV_INTEL_function_pointers},
-    {"SPV_KHR_shader_clock", SPIRV::Extension::Extension::SPV_KHR_shader_clock},
-    {"SPV_KHR_cooperative_matrix",
-     SPIRV::Extension::Extension::SPV_KHR_cooperative_matrix},
-    {"SPV_KHR_non_semantic_info",
-     SPIRV::Extension::Extension::SPV_KHR_non_semantic_info},
-    {"SPV_KHR_ray_query", SPIRV::Extension::Extension::SPV_KHR_ray_query},
-    {"SPV_EXT_shader_image_int64",
-     SPIRV::Extension::Extension::SPV_EXT_shader_image_int64},
-    {"SPV_KHR_fragment_shader_barycentric",
-     SPIRV::Extension::Extension::SPV_KHR_fragment_shader_barycentric},
-    {"SPV_KHR_physical_storage_buffer",
-     SPIRV::Extension::Extension::SPV_KHR_physical_storage_buffer},
-    {"SPV_KHR_vulkan_memory_model",
-     SPIRV::Extension::Extension::SPV_KHR_vulkan_memory_model},
-    {"SPV_NV_shader_subgroup_partitioned",
-     SPIRV::Extension::Extension::SPV_NV_shader_subgroup_partitioned},
-    {"SPV_INTEL_long_composites",
-     SPIRV::Extension::Extension::SPV_INTEL_long_composites},
-    {"SPV_INTEL_fp_max_error",
-     SPIRV::Extension::Extension::SPV_INTEL_fp_max_error},
-    {"SPV_INTEL_subgroup_matrix_multiply_accumulate",
-     SPIRV::Extension::Extension::
-         SPV_INTEL_subgroup_matrix_multiply_accumulate},
-    {"SPV_INTEL_ternary_bitwise_function",
-     SPIRV::Extension::Extension::SPV_INTEL_ternary_bitwise_function},
-    {"SPV_INTEL_2d_block_io",
-     SPIRV::Extension::Extension::SPV_INTEL_2d_block_io},
-    {"SPV_INTEL_int4", SPIRV::Extension::Extension::SPV_INTEL_int4},
-    {"SPV_KHR_float_controls2",
-     SPIRV::Extension::Extension::SPV_KHR_float_controls2},
-    {"SPV_INTEL_tensor_float32_conversion",
-     SPIRV::Extension::Extension::SPV_INTEL_tensor_float32_conversion},
-    {"SPV_KHR_bfloat16", SPIRV::Extension::Extension::SPV_KHR_bfloat16},
-    {"SPV_EXT_relaxed_printf_string_address_space",
-     SPIRV::Extension::Extension::SPV_EXT_relaxed_printf_string_address_space},
-    {"SPV_INTEL_predicated_io",
-     SPIRV::Extension::Extension::SPV_INTEL_predicated_io},
-    {"SPV_KHR_maximal_reconvergence",
-     SPIRV::Extension::Extension::SPV_KHR_maximal_reconvergence},
-    {"SPV_INTEL_kernel_attributes",
-     SPIRV::Extension::Extension::SPV_INTEL_kernel_attributes},
-    {"SPV_ALTERA_blocking_pipes",
-     SPIRV::Extension::Extension::SPV_ALTERA_blocking_pipes},
-    {"SPV_INTEL_int4", SPIRV::Extension::Extension::SPV_INTEL_int4},
-    {"SPV_ALTERA_arbitrary_precision_fixed_point",
-     SPIRV::Extension::Extension::SPV_ALTERA_arbitrary_precision_fixed_point},
-    {"SPV_EXT_image_raw10_raw12",
-     SPIRV::Extension::Extension::SPV_EXT_image_raw10_raw12},
-    {"SPV_INTEL_unstructured_loop_controls",
-     SPIRV::Extension::Extension::SPV_INTEL_unstructured_loop_controls}};
+static const std::map<StringRef, SPIRV::Extension::Extension>
+    SPIRVExtensionMap = {
+        {"SPV_EXT_shader_atomic_float_add",
+         SPIRV::Extension::Extension::SPV_EXT_shader_atomic_float_add},
+        {"SPV_EXT_shader_atomic_float16_add",
+         SPIRV::Extension::Extension::SPV_EXT_shader_atomic_float16_add},
+        {"SPV_EXT_shader_atomic_float_min_max",
+         SPIRV::Extension::Extension::SPV_EXT_shader_atomic_float_min_max},
+        {"SPV_INTEL_16bit_atomics",
+         SPIRV::Extension::Extension::SPV_INTEL_16bit_atomics},
+        {"SPV_NV_shader_atomic_fp16_vector",
+         SPIRV::Extension::Extension::SPV_NV_shader_atomic_fp16_vector},
+        {"SPV_EXT_arithmetic_fence",
+         SPIRV::Extension::Extension::SPV_EXT_arithmetic_fence},
+        {"SPV_EXT_demote_to_helper_invocation",
+         SPIRV::Extension::Extension::SPV_EXT_demote_to_helper_invocation},
+        {"SPV_EXT_descriptor_indexing",
+         SPIRV::Extension::Extension::SPV_EXT_descriptor_indexing},
+        {"SPV_EXT_fragment_fully_covered",
+         SPIRV::Extension::Extension::SPV_EXT_fragment_fully_covered},
+        {"SPV_EXT_fragment_invocation_density",
+         SPIRV::Extension::Extension::SPV_EXT_fragment_invocation_density},
+        {"SPV_EXT_fragment_shader_interlock",
+         SPIRV::Extension::Extension::SPV_EXT_fragment_shader_interlock},
+        {"SPV_EXT_mesh_shader",
+         SPIRV::Extension::Extension::SPV_EXT_mesh_shader},
+        {"SPV_EXT_shader_stencil_export",
+         SPIRV::Extension::Extension::SPV_EXT_shader_stencil_export},
+        {"SPV_EXT_shader_viewport_index_layer",
+         SPIRV::Extension::Extension::SPV_EXT_shader_viewport_index_layer},
+        {"SPV_GOOGLE_hlsl_functionality1",
+         SPIRV::Extension::Extension::SPV_GOOGLE_hlsl_functionality1},
+        {"SPV_GOOGLE_user_type",
+         SPIRV::Extension::Extension::SPV_GOOGLE_user_type},
+        {"SPV_ALTERA_arbitrary_precision_integers",
+         SPIRV::Extension::Extension::SPV_ALTERA_arbitrary_precision_integers},
+        {"SPV_ALTERA_arbitrary_precision_floating_point",
+         SPIRV::Extension::Extension::
+             SPV_ALTERA_arbitrary_precision_floating_point},
+        {"SPV_INTEL_cache_controls",
+         SPIRV::Extension::Extension::SPV_INTEL_cache_controls},
+        {"SPV_INTEL_float_controls2",
+         SPIRV::Extension::Extension::SPV_INTEL_float_controls2},
+        {"SPV_INTEL_global_variable_fpga_decorations",
+         SPIRV::Extension::Extension::
+             SPV_INTEL_global_variable_fpga_decorations},
+        {"SPV_INTEL_global_variable_host_access",
+         SPIRV::Extension::Extension::SPV_INTEL_global_variable_host_access},
+        {"SPV_INTEL_optnone", SPIRV::Extension::Extension::SPV_INTEL_optnone},
+        {"SPV_EXT_optnone", SPIRV::Extension::Extension::SPV_EXT_optnone},
+        {"SPV_INTEL_usm_storage_classes",
+         SPIRV::Extension::Extension::SPV_INTEL_usm_storage_classes},
+        {"SPV_INTEL_split_barrier",
+         SPIRV::Extension::Extension::SPV_INTEL_split_barrier},
+        {"SPV_INTEL_subgroups",
+         SPIRV::Extension::Extension::SPV_INTEL_subgroups},
+        {"SPV_INTEL_media_block_io",
+         SPIRV::Extension::Extension::SPV_INTEL_media_block_io},
+        {"SPV_INTEL_memory_access_aliasing",
+         SPIRV::Extension::Extension::SPV_INTEL_memory_access_aliasing},
+        {"SPV_INTEL_joint_matrix",
+         SPIRV::Extension::Extension::SPV_INTEL_joint_matrix},
+        {"SPV_KHR_16bit_storage",
+         SPIRV::Extension::Extension::SPV_KHR_16bit_storage},
+        {"SPV_KHR_device_group",
+         SPIRV::Extension::Extension::SPV_KHR_device_group},
+        {"SPV_KHR_fragment_shading_rate",
+         SPIRV::Extension::Extension::SPV_KHR_fragment_shading_rate},
+        {"SPV_KHR_multiview", SPIRV::Extension::Extension::SPV_KHR_multiview},
+        {"SPV_KHR_post_depth_coverage",
+         SPIRV::Extension::Extension::SPV_KHR_post_depth_coverage},
+        {"SPV_KHR_shader_draw_parameters",
+         SPIRV::Extension::Extension::SPV_KHR_shader_draw_parameters},
+        {"SPV_KHR_ray_tracing",
+         SPIRV::Extension::Extension::SPV_KHR_ray_tracing},
+        {"SPV_KHR_uniform_group_instructions",
+         SPIRV::Extension::Extension::SPV_KHR_uniform_group_instructions},
+        {"SPV_KHR_no_integer_wrap_decoration",
+         SPIRV::Extension::Extension::SPV_KHR_no_integer_wrap_decoration},
+        {"SPV_KHR_float_controls",
+         SPIRV::Extension::Extension::SPV_KHR_float_controls},
+        {"SPV_KHR_expect_assume",
+         SPIRV::Extension::Extension::SPV_KHR_expect_assume},
+        {"SPV_KHR_bit_instructions",
+         SPIRV::Extension::Extension::SPV_KHR_bit_instructions},
+        {"SPV_KHR_integer_dot_product",
+         SPIRV::Extension::Extension::SPV_KHR_integer_dot_product},
+        {"SPV_KHR_linkonce_odr",
+         SPIRV::Extension::Extension::SPV_KHR_linkonce_odr},
+        {"SPV_KHR_fma", SPIRV::Extension::Extension::SPV_KHR_fma},
+        {"SPV_INTEL_inline_assembly",
+         SPIRV::Extension::Extension::SPV_INTEL_inline_assembly},
+        {"SPV_INTEL_bindless_images",
+         SPIRV::Extension::Extension::SPV_INTEL_bindless_images},
+        {"SPV_INTEL_bfloat16_arithmetic",
+         SPIRV::Extension::Extension::SPV_INTEL_bfloat16_arithmetic},
+        {"SPV_INTEL_bfloat16_conversion",
+         SPIRV::Extension::Extension::SPV_INTEL_bfloat16_conversion},
+        {"SPV_KHR_subgroup_rotate",
+         SPIRV::Extension::Extension::SPV_KHR_subgroup_rotate},
+        {"SPV_INTEL_variable_length_array",
+         SPIRV::Extension::Extension::SPV_INTEL_variable_length_array},
+        {"SPV_INTEL_function_pointers",
+         SPIRV::Extension::Extension::SPV_INTEL_function_pointers},
+        {"SPV_KHR_shader_clock",
+         SPIRV::Extension::Extension::SPV_KHR_shader_clock},
+        {"SPV_KHR_cooperative_matrix",
+         SPIRV::Extension::Extension::SPV_KHR_cooperative_matrix},
+        {"SPV_KHR_non_semantic_info",
+         SPIRV::Extension::Extension::SPV_KHR_non_semantic_info},
+        {"SPV_KHR_ray_query", SPIRV::Extension::Extension::SPV_KHR_ray_query},
+        {"SPV_EXT_shader_image_int64",
+         SPIRV::Extension::Extension::SPV_EXT_shader_image_int64},
+        {"SPV_KHR_fragment_shader_barycentric",
+         SPIRV::Extension::Extension::SPV_KHR_fragment_shader_barycentric},
+        {"SPV_KHR_physical_storage_buffer",
+         SPIRV::Extension::Extension::SPV_KHR_physical_storage_buffer},
+        {"SPV_KHR_vulkan_memory_model",
+         SPIRV::Extension::Extension::SPV_KHR_vulkan_memory_model},
+        {"SPV_NV_shader_subgroup_partitioned",
+         SPIRV::Extension::Extension::SPV_NV_shader_subgroup_partitioned},
+        {"SPV_INTEL_long_composites",
+         SPIRV::Extension::Extension::SPV_INTEL_long_composites},
+        {"SPV_INTEL_fp_max_error",
+         SPIRV::Extension::Extension::SPV_INTEL_fp_max_error},
+        {"SPV_INTEL_subgroup_matrix_multiply_accumulate",
+         SPIRV::Extension::Extension::
+             SPV_INTEL_subgroup_matrix_multiply_accumulate},
+        {"SPV_INTEL_ternary_bitwise_function",
+         SPIRV::Extension::Extension::SPV_INTEL_ternary_bitwise_function},
+        {"SPV_INTEL_2d_block_io",
+         SPIRV::Extension::Extension::SPV_INTEL_2d_block_io},
+        {"SPV_INTEL_int4", SPIRV::Extension::Extension::SPV_INTEL_int4},
+        {"SPV_KHR_float_controls2",
+         SPIRV::Extension::Extension::SPV_KHR_float_controls2},
+        {"SPV_INTEL_tensor_float32_conversion",
+         SPIRV::Extension::Extension::SPV_INTEL_tensor_float32_conversion},
+        {"SPV_KHR_bfloat16", SPIRV::Extension::Extension::SPV_KHR_bfloat16},
+        {"SPV_EXT_relaxed_printf_string_address_space",
+         SPIRV::Extension::Extension::
+             SPV_EXT_relaxed_printf_string_address_space},
+        {"SPV_INTEL_predicated_io",
+         SPIRV::Extension::Extension::SPV_INTEL_predicated_io},
+        {"SPV_KHR_maximal_reconvergence",
+         SPIRV::Extension::Extension::SPV_KHR_maximal_reconvergence},
+        {"SPV_INTEL_kernel_attributes",
+         SPIRV::Extension::Extension::SPV_INTEL_kernel_attributes},
+        {"SPV_ALTERA_blocking_pipes",
+         SPIRV::Extension::Extension::SPV_ALTERA_blocking_pipes},
+        {"SPV_INTEL_int4", SPIRV::Extension::Extension::SPV_INTEL_int4},
+        {"SPV_ALTERA_arbitrary_precision_fixed_point",
+         SPIRV::Extension::Extension::
+             SPV_ALTERA_arbitrary_precision_fixed_point},
+        {"SPV_EXT_image_raw10_raw12",
+         SPIRV::Extension::Extension::SPV_EXT_image_raw10_raw12},
+        {"SPV_INTEL_unstructured_loop_controls",
+         SPIRV::Extension::Extension::SPV_INTEL_unstructured_loop_controls}};
 
 bool SPIRVExtensionsParser::parse(cl::Option &O, StringRef ArgName,
-                                  StringRef ArgValue, ExtensionSet &Vals) {
+                                  StringRef ArgValue,
+                                  std::set<SPIRV::Extension::Extension> &Vals) {
   SmallVector<StringRef, 10> Tokens;
   ArgValue.split(Tokens, ",", -1, false);
 
-  ExtensionSet EnabledExtensions;
+  std::set<SPIRV::Extension::Extension> EnabledExtensions;
 
   auto M = partition(Tokens, [](auto &&T) { return T.starts_with('+'); });
 
   if (std::any_of(M, Tokens.end(), equal_to("all")))
-    for (auto &&El : make_second_range(SPIRVExtensionMap))
-      Vals.insert(El);
+    copy(make_second_range(SPIRVExtensionMap), std::inserter(Vals, Vals.end()));
 
   for (auto &&Token : make_range(Tokens.begin(), M)) {
     StringRef ExtensionName = Token.substr(1);
@@ -215,24 +227,24 @@ bool SPIRVExtensionsParser::parse(cl::Option &O, StringRef ArgName,
 
     auto NameValuePair = SPIRVExtensionMap.find(Token.substr(1));
 
-    if (NameValuePair == SPIRVExtensionMap.end())
+    if (NameValuePair == SPIRVExtensionMap.cend())
       return O.error("Unknown SPIR-V extension: " + Token.str());
     if (EnabledExtensions.count(NameValuePair->second))
       return O.error(
           "Extension cannot be allowed and disallowed at the same time: " +
-          NameValuePair->first());
+          NameValuePair->first);
     DisabledExtensions.insert(NameValuePair->second);
     Vals.erase(NameValuePair->second);
   }
 
-  Vals.insert(EnabledExtensions.begin(), EnabledExtensions.end());
+  Vals.insert(EnabledExtensions.cbegin(), EnabledExtensions.cend());
 
   return false;
 }
 
-StringRef
-SPIRVExtensionsParser::checkExtensions(const std::vector<std::string> &ExtNames,
-                                       ExtensionSet &AllowedExtensions) {
+StringRef SPIRVExtensionsParser::checkExtensions(
+    const std::vector<std::string> &ExtNames,
+    std::set<SPIRV::Extension::Extension> &AllowedExtensions) {
   for (const auto &Ext : ExtNames) {
     if (Ext == "all") {
       for (const auto &[ExtensionName, ExtensionEnum] : SPIRVExtensionMap)
@@ -247,8 +259,9 @@ SPIRVExtensionsParser::checkExtensions(const std::vector<std::string> &ExtNames,
   return StringRef();
 }
 
-ExtensionSet SPIRVExtensionsParser::getValidExtensions(const Triple &TT) {
-  ExtensionSet R;
+std::set<SPIRV::Extension::Extension>
+SPIRVExtensionsParser::getValidExtensions(const Triple &TT) {
+  std::set<SPIRV::Extension::Extension> R;
   SPIRV::Environment::Environment CurrentEnvironment =
       SPIRV::Environment::Environment::EnvOpenCL;
   if (TT.getOS() == Triple::Vulkan)

--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.h
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.h
@@ -16,6 +16,7 @@
 
 #include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "llvm/Support/CommandLine.h"
+#include <set>
 #include <string>
 
 namespace llvm {
@@ -23,29 +24,33 @@ class StringRef;
 class Triple;
 
 /// Command line parser for toggling SPIR-V extensions.
-struct SPIRVExtensionsParser : public cl::parser<ExtensionSet> {
+struct SPIRVExtensionsParser
+    : public cl::parser<std::set<SPIRV::Extension::Extension>> {
 public:
-  SPIRVExtensionsParser(cl::Option &O) : cl::parser<ExtensionSet>(O) {}
+  SPIRVExtensionsParser(cl::Option &O)
+      : cl::parser<std::set<SPIRV::Extension::Extension>>(O) {}
 
   /// Parses SPIR-V extension name from CLI arguments.
   ///
   /// \return Returns true on error.
   bool parse(cl::Option &O, StringRef ArgName, StringRef ArgValue,
-             ExtensionSet &Vals);
+             std::set<SPIRV::Extension::Extension> &Vals);
 
   /// Validates and converts extension names into internal enum values.
   ///
   /// \return Returns a reference to the unknown SPIR-V extension name from the
   /// list if present, or an empty StringRef on success.
-  static StringRef checkExtensions(const std::vector<std::string> &ExtNames,
-                                   ExtensionSet &AllowedExtensions);
+  static StringRef
+  checkExtensions(const std::vector<std::string> &ExtNames,
+                  std::set<SPIRV::Extension::Extension> &AllowedExtensions);
 
   /// Returns the list of extensions that are valid for a particular
   /// target environment (i.e., OpenCL or Vulkan).
-  static ExtensionSet getValidExtensions(const Triple &TT);
+  static std::set<SPIRV::Extension::Extension>
+  getValidExtensions(const Triple &TT);
 
 private:
-  static ExtensionSet DisabledExtensions;
+  static std::set<SPIRV::Extension::Extension> DisabledExtensions;
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -32,13 +32,15 @@ static cl::opt<bool>
                         cl::desc("SPIR-V Translator compatibility mode"),
                         cl::Optional, cl::init(false));
 
-static cl::opt<ExtensionSet, false, SPIRVExtensionsParser>
+static cl::opt<std::set<SPIRV::Extension::Extension>, false,
+               SPIRVExtensionsParser>
     Extensions("spirv-ext",
                cl::desc("Specify list of enabled SPIR-V extensions"));
 
 // Provides access to the cl::opt<...> `Extensions` variable from outside of the
 // module.
-void SPIRVSubtarget::addExtensionsToClOpt(const ExtensionSet &AllowList) {
+void SPIRVSubtarget::addExtensionsToClOpt(
+    const std::set<SPIRV::Extension::Extension> &AllowList) {
   Extensions.insert(AllowList.begin(), AllowList.end());
 }
 
@@ -212,9 +214,9 @@ void SPIRVSubtarget::resolveEnvFromModule(const Module &M) {
 
 // Set available extensions after SPIRVSubtarget is created.
 void SPIRVSubtarget::initAvailableExtensions(
-    const ExtensionSet &AllowedExtIds) {
+    const std::set<SPIRV::Extension::Extension> &AllowedExtIds) {
   AvailableExtensions.clear();
-  const ExtensionSet &ValidExtensions =
+  const std::set<SPIRV::Extension::Extension> &ValidExtensions =
       SPIRVExtensionsParser::getValidExtensions(TargetTriple);
 
   for (const auto &Ext : AllowedExtIds) {

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
@@ -73,7 +73,8 @@ public:
                  const std::string &FS, const SPIRVTargetMachine &TM);
   SPIRVSubtarget &initSubtargetDependencies(StringRef CPU, StringRef FS);
 
-  void initAvailableExtensions(const ExtensionSet &AllowedExtIds);
+  void initAvailableExtensions(
+      const std::set<SPIRV::Extension::Extension> &AllowedExtIds);
   void resolveEnvFromModule(const Module &M);
 
   // Parses features string setting specified subtarget options.
@@ -144,8 +145,9 @@ public:
 
   // Adds known SPIR-V extensions to the global list of allowed extensions that
   // SPIRVSubtarget module owns as
-  // cl::opt<ExtensionSet, ...> global variable.
-  static void addExtensionsToClOpt(const ExtensionSet &AllowList);
+  // cl::opt<std::set<SPIRV::Extension::Extension>, ...> global variable.
+  static void
+  addExtensionsToClOpt(const std::set<SPIRV::Extension::Extension> &AllowList);
 };
 } // namespace llvm
 


### PR DESCRIPTION
Reverts llvm/llvm-project#183567

UBSan failure.