### PR TITLE
[llvm] fix: fix c++ narrowing conversion

### DIFF
--- a/llvm/include/llvm/IR/ModuleSummaryIndexYAML.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndexYAML.h
@@ -274,7 +274,7 @@ template <> struct CustomMappingTraits<GlobalValueSummaryMapTy> {
               static_cast<bool>(FSum->flags().Live),
               static_cast<bool>(FSum->flags().DSOLocal),
               static_cast<bool>(FSum->flags().CanAutoHide),
-              FSum->flags().ImportType,
+              static_cast<bool>(FSum->flags().ImportType),
               static_cast<bool>(FSum->flags().NoRenameOnPromotion),
               /*Aliasee=*/std::nullopt, Refs, FSum->type_tests(),
               FSum->type_test_assume_vcalls(), FSum->type_checked_load_vcalls(),
@@ -288,7 +288,7 @@ template <> struct CustomMappingTraits<GlobalValueSummaryMapTy> {
               static_cast<bool>(ASum->flags().Live),
               static_cast<bool>(ASum->flags().DSOLocal),
               static_cast<bool>(ASum->flags().CanAutoHide),
-              ASum->flags().ImportType,
+              static_cast<bool>(ASum->flags().ImportType),
               static_cast<bool>(ASum->flags().NoRenameOnPromotion),
               /*Aliasee=*/ASum->getAliaseeGUID()});
         }


### PR DESCRIPTION
Fix for the following:

```
[103/200] Building CXX object lib/Transforms/IPO/CMakeFiles/LLVMipo.dir/WholeProgramDevirt.cpp.o
FAILED: lib/Transforms/IPO/CMakeFiles/LLVMipo.dir/WholeProgramDevirt.cpp.o
/home/fmzakari/fbsource/fbcode/third-party-buck/platform010/build/llvm-fb/19/bin/clang++ -DLLVM_EXPORTS -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GLIBCXX_USE_CXX11_ABI=1 -D_GNU_SOURCE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/fmzakari/llvm-build/lib/Transforms/IPO -I/home/fmzakari/local/server-llvm/llvm-project/llvm/lib/Transforms/IPO -I/home/fmzakari/llvm-build/include -I/home/fmzakari/local/server-llvm/llvm-project/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wno-pass-failed -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -Xclang -fno-pch-timestamp -g -std=c++17 -fPIC -fno-exceptions -funwind-tables -fno-rtti -Winvalid-pch -Xclang -include-pch -Xclang /home/fmzakari/llvm-build/lib/IR/CMakeFiles/LLVMCore.dir/cmake_pch.hxx.pch -Xclang -include -Xclang /home/fmzakari/llvm-build/lib/IR/CMakeFiles/LLVMCore.dir/cmake_pch.hxx -MD -MT lib/Transforms/IPO/CMakeFiles/LLVMipo.dir/WholeProgramDevirt.cpp.o -MF lib/Transforms/IPO/CMakeFiles/LLVMipo.dir/WholeProgramDevirt.cpp.o.d -o lib/Transforms/IPO/CMakeFiles/LLVMipo.dir/WholeProgramDevirt.cpp.o -c /home/fmzakari/local/server-llvm/llvm-project/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
In file included from /home/fmzakari/local/server-llvm/llvm-project/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp:97:
/home/fmzakari/local/server-llvm/llvm-project/llvm/include/llvm/IR/ModuleSummaryIndexYAML.h:277:15: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'bool' in initializer list [-Wc++11-narrowing]
  277 |               FSum->flags().ImportType,
      |               ^~~~~~~~~~~~~~~~~~~~~~~~
/home/fmzakari/local/server-llvm/llvm-project/llvm/include/llvm/IR/ModuleSummaryIndexYAML.h:277:15: note: insert an explicit cast to silence this issue
  277 |               FSum->flags().ImportType,
      |               ^~~~~~~~~~~~~~~~~~~~~~~~
      |               static_cast<bool>(      )
```

**validation**
```
> ninja lld
[151/151] Linking CXX executable bin/lld
```