### PR TITLE
Changing MutableArrayRef constructor checks

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -331,7 +331,7 @@ namespace llvm {
                           decltype(std::declval<C &>().data()) *, T *const *>,
                       std::is_integral<decltype(std::declval<C &>().size())>>,
                   void>>
-    /*implicit*/ constexpr MutableArrayRef(const C &V) : ArrayRef<T>(V) {}
+    /*implicit*/ constexpr MutableArrayRef(C &V) : ArrayRef<T>(V) {}
 
     /// Construct a MutableArrayRef from a C array.
     template <size_t N>

--- a/llvm/unittests/ADT/ArrayRefTest.cpp
+++ b/llvm/unittests/ADT/ArrayRefTest.cpp
@@ -468,6 +468,11 @@ TEST(ArrayRefTest, MutableArrayRefDeductionGuides) {
   }
 }
 
+
+static_assert(
+    !std::is_constructible_v<MutableArrayRef<int>, const SmallVector<int>>,
+    "cannot construct MutableArrayRef from const std::SmallVector<int>");
+
 #ifdef __cpp_lib_span
 static_assert(std::is_constructible_v<ArrayRef<int>, std::span<const int>>,
               "should be able to construct ArrayRef from const std::span");
@@ -485,7 +490,7 @@ static_assert(
     std::is_constructible_v<std::span<const int>, MutableArrayRef<int>>,
     "should be able to construct const std::span from MutableArrayRef");
 static_assert(
-    std::is_constructible_v<MutableArrayRef<int>, std::span<int>>,
+    std::is_constructible_v<MutableArrayRef<int>, std::span<int>&>,
     "should be able to construct MutableArrayRef from mutable std::span");
 static_assert(
     std::is_constructible_v<MutableArrayRef<int>, const std::span<int>>,

--- a/llvm/unittests/ADT/ArrayRefTest.cpp
+++ b/llvm/unittests/ADT/ArrayRefTest.cpp
@@ -468,7 +468,6 @@ TEST(ArrayRefTest, MutableArrayRefDeductionGuides) {
   }
 }
 
-
 static_assert(
     !std::is_constructible_v<MutableArrayRef<int>, const SmallVector<int>>,
     "cannot construct MutableArrayRef from const std::SmallVector<int>");
@@ -490,7 +489,7 @@ static_assert(
     std::is_constructible_v<std::span<const int>, MutableArrayRef<int>>,
     "should be able to construct const std::span from MutableArrayRef");
 static_assert(
-    std::is_constructible_v<MutableArrayRef<int>, std::span<int>&>,
+    std::is_constructible_v<MutableArrayRef<int>, std::span<int> &>,
     "should be able to construct MutableArrayRef from mutable std::span");
 static_assert(
     std::is_constructible_v<MutableArrayRef<int>, const std::span<int>>,


### PR DESCRIPTION
Proposing the same solution, but with fix to avoid C++20 build failure and creation MutableArrayRef from rvalue `std::span<int>`. 

Related PRs: 
https://github.com/llvm/llvm-project/pull/181190
https://github.com/llvm/llvm-project/pull/181758