### PR TITLE
[clang/APINotes] Fix assertion crash in addObjCMethod for protocol DesignatedInit methods

### DIFF
--- a/clang/lib/APINotes/APINotesWriter.cpp
+++ b/clang/lib/APINotes/APINotesWriter.cpp
@@ -50,6 +50,9 @@ class APINotesWriter::Implementation {
   /// Indexed by context ID, provides the parent context ID.
   llvm::DenseMap<uint32_t, uint32_t> ParentContexts;
 
+  /// Mapping from context IDs to the kind of context.
+  llvm::DenseMap<unsigned, uint8_t> ContextKinds;
+
   /// Mapping from context IDs to the identifier ID holding the name.
   llvm::DenseMap<unsigned, unsigned> ContextNames;
 
@@ -1461,6 +1464,7 @@ ContextID APINotesWriter::addContext(std::optional<ContextID> ParentCtxID,
 
     Implementation->ContextNames[NextID] = NameID;
     Implementation->ParentContexts[NextID] = RawParentCtxID;
+    Implementation->ContextKinds[NextID] = static_cast<uint8_t>(Kind);
   }
 
   // Add this version information.
@@ -1505,7 +1509,7 @@ void APINotesWriter::addObjCMethod(ContextID CtxID, ObjCSelectorRef Selector,
     assert(Implementation->ParentContexts.contains(CtxID.Value));
     uint32_t ParentCtxID = Implementation->ParentContexts[CtxID.Value];
     ContextTableKey CtxKey(ParentCtxID,
-                           static_cast<uint8_t>(ContextKind::ObjCClass),
+                           Implementation->ContextKinds[CtxID.Value],
                            Implementation->ContextNames[CtxID.Value]);
     assert(Implementation->Contexts.contains(CtxKey));
     auto &VersionedVec = Implementation->Contexts[CtxKey].second;

--- a/clang/test/APINotes/Inputs/Frameworks/SomeKit.framework/APINotes/SomeKit.apinotes
+++ b/clang/test/APINotes/Inputs/Frameworks/SomeKit.framework/APINotes/SomeKit.apinotes
@@ -45,6 +45,12 @@ Classes:
       - Name: intPropertyToMangle
         PropertyKind: Instance
         Type: 'double *'
+Protocols:
+  - Name: InitializableProtocolDUMP
+    Methods:
+      - Selector: "initWithValue:"
+        MethodKind: Instance
+        DesignatedInit: true
 Functions:
   - Name: global_int_fun
     ResultType: 'char *'

--- a/clang/test/APINotes/Inputs/Frameworks/SomeKit.framework/Headers/SomeKit.h
+++ b/clang/test/APINotes/Inputs/Frameworks/SomeKit.framework/Headers/SomeKit.h
@@ -57,4 +57,8 @@ __attribute__((objc_root_class))
 @property (class, nonatomic, readwrite, retain) A *implicitGetSetClass;
 @end
 
+@protocol InitializableProtocolDUMP
+- (instancetype)initWithValue:(int)value;
+@end
+
 #endif

--- a/clang/test/APINotes/objc_designated_init_protocol.m
+++ b/clang/test/APINotes/objc_designated_init_protocol.m
@@ -1,0 +1,17 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fapinotes-modules -Wno-private-module -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s
+
+// Regression test for APINotesWriter::addObjCMethod asserting when a protocol
+// method is annotated with DesignatedInit: true in an .apinotes file.
+// The writer was reconstructing the ContextTableKey with a hardcoded
+// ContextKind::ObjCClass, causing the Contexts lookup to fail when the
+// context was actually a protocol. Importing the module is sufficient to
+// trigger the writer path that previously crashed.
+
+// expected-no-diagnostics
+
+#import <SomeKit/SomeKit.h>
+
+id<InitializableProtocolDUMP> useProtocol(id<InitializableProtocolDUMP> p) {
+  return [p initWithValue:0];
+}


### PR DESCRIPTION
When a protocol method is annotated with `DesignatedInit: true` in an .apinotes file, `APINotesWriter::addObjCMethod` would crash with:

Assertion failed: (Implementation->Contexts.contains(CtxKey)), function addObjCMethod

The bug was introduced in 8dc789a2: when reconstructing the `ContextTableKey` to mark the parent context as having designated initializers, the code hardcoded `ContextKind::ObjCClass`. This is wrong when the context is a protocol — the key won't be found in `Implementation->Contexts`, triggering the assertion.

Fix by storing the context kind in a new `ContextKinds` map on the `Implementation` struct (populated in `addContext`), then using the stored kind in `addObjCMethod` instead of the hardcoded value.

rdar://171361188