### PR TITLE
[ADT] Refine MutableArrayRef forwarding constructor constraints

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -322,8 +322,8 @@ namespace llvm {
     /// Construct a MutableArrayRef from a range.
     MutableArrayRef(T *begin, T *end) : ArrayRef<T>(begin, end) {}
 
-    /// Construct a MutableArrayRef from a type that has a data() method that
-    /// returns a pointer convertible to T *.
+    /// Construct a MutableArrayRef from a type that has data() and size(),
+    /// where data() returns a pointer convertible to T *const *.
     template <typename C,
               typename = std::enable_if_t<
                   std::conjunction_v<
@@ -331,7 +331,7 @@ namespace llvm {
                           decltype(std::declval<C &>().data()) *, T *const *>,
                       std::is_integral<decltype(std::declval<C &>().size())>>,
                   void>>
-    /*implicit*/ constexpr MutableArrayRef(const C &V) : ArrayRef<T>(V) {}
+    /*implicit*/ constexpr MutableArrayRef(C &&V) : ArrayRef<T>(V) {}
 
     /// Construct a MutableArrayRef from a C array.
     template <size_t N>

--- a/llvm/unittests/ADT/ArrayRefTest.cpp
+++ b/llvm/unittests/ADT/ArrayRefTest.cpp
@@ -340,6 +340,12 @@ static_assert(
 static_assert(!std::is_constructible_v<ArrayRef<TestBase *>,
                                        iterator_range<TestDerived **>>,
               "cannot construct ArrayRef pointer of base type");
+static_assert(!std::is_constructible_v<MutableArrayRef<TestBase>,
+                                       iterator_range<TestDerived *>>,
+              "cannot construct MutableArrayRef base type");
+static_assert(!std::is_constructible_v<MutableArrayRef<TestBase *>,
+                                       iterator_range<TestDerived **>>,
+              "cannot construct MutableArrayRef pointer of base type");
 
 static_assert(
     !std::is_constructible_v<ArrayRef<int>, iterator_range<const int *>>,
@@ -468,6 +474,10 @@ TEST(ArrayRefTest, MutableArrayRefDeductionGuides) {
   }
 }
 
+static_assert(
+    !std::is_constructible_v<MutableArrayRef<int>, const SmallVector<int>>,
+    "cannot construct MutableArrayRef from const std::SmallVector<int>");
+
 #ifdef __cpp_lib_span
 static_assert(std::is_constructible_v<ArrayRef<int>, std::span<const int>>,
               "should be able to construct ArrayRef from const std::span");
@@ -491,6 +501,10 @@ static_assert(
     std::is_constructible_v<MutableArrayRef<int>, const std::span<int>>,
     "should be able to construct MutableArrayRef from const std::span with "
     "mutable elements");
+static_assert(
+    !std::is_constructible_v<MutableArrayRef<TestBase>, std::span<TestDerived>>,
+    "cannot construct MutableArrayRef base type from std::span with derived "
+    "elements");
 #endif
 
 } // end anonymous namespace


### PR DESCRIPTION
Keep MutableArrayRef on a single C&& constructor, with SFINAE on direct check on `C::data()`. This keeps const std::span<int> supported and rejects const vector/smallvector sources for MutableArrayRef<int>.