### PR TITLE
[CIR] Fix dominance problems with values defined in cleanup scopes

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
@@ -389,10 +389,49 @@ void CIRGenFunction::popCleanupBlock() {
 
 /// Pops cleanup blocks until the given savepoint is reached.
 void CIRGenFunction::popCleanupBlocks(
-    EHScopeStack::stable_iterator oldCleanupStackDepth) {
+    EHScopeStack::stable_iterator oldCleanupStackDepth,
+    std::initializer_list<mlir::Value *> valuesToReload) {
+  // If the current stack depth is the same as the cleanup stack depth,
+  // we won't be exiting any cleanup scopes, so we don't need to reload
+  // any values.
+  bool requiresCleanup = false;
+  for (auto it = ehStack.begin(), ie = ehStack.find(oldCleanupStackDepth);
+       it != ie; ++it) {
+    if (isa<EHCleanupScope>(&*it)) {
+      requiresCleanup = true;
+      break;
+    }
+  }
+
+  // If there are values that we need to keep live, spill them now before
+  // we pop the cleanup blocks. These are passed as pointers to mlir::Value
+  // because we're going to replace them with the reloaded value.
+  SmallVector<Address> tempAllocas;
+  if (requiresCleanup) {
+    for (mlir::Value *valPtr : valuesToReload) {
+      mlir::Value val = *valPtr;
+      if (!val)
+        continue;
+
+      // TODO(cir): Check for static allocas.
+
+      Address temp = createDefaultAlignTempAlloca(val.getType(), val.getLoc(),
+                                                  "tmp.exprcleanup");
+      tempAllocas.push_back(temp);
+      builder.createStore(val.getLoc(), val, temp);
+    }
+  }
+
   // Pop cleanup blocks until we reach the base stack depth for the
   // current scope.
-  while (ehStack.stable_begin() != oldCleanupStackDepth) {
+  while (ehStack.stable_begin() != oldCleanupStackDepth)
     popCleanupBlock();
+
+  // Reload the values that we spilled, if necessary.
+  if (requiresCleanup) {
+    for (auto [addr, valPtr] : llvm::zip(tempAllocas, valuesToReload)) {
+      mlir::Location loc = valPtr->getLoc();
+      *valPtr = builder.createLoad(loc, addr);
+    }
   }
 }

--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
@@ -390,7 +390,7 @@ void CIRGenFunction::popCleanupBlock() {
 /// Pops cleanup blocks until the given savepoint is reached.
 void CIRGenFunction::popCleanupBlocks(
     EHScopeStack::stable_iterator oldCleanupStackDepth,
-    std::initializer_list<mlir::Value *> valuesToReload) {
+    ArrayRef<mlir::Value *> valuesToReload) {
   // If the current stack depth is the same as the cleanup stack depth,
   // we won't be exiting any cleanup scopes, so we don't need to reload
   // any values.

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2548,6 +2548,18 @@ cir::AllocaOp CIRGenFunction::createTempAlloca(mlir::Type ty,
           .getDefiningOp());
 }
 
+/// CreateDefaultAlignTempAlloca - This creates an alloca with the
+/// default alignment of the corresponding LLVM type, which is *not*
+/// guaranteed to be related in any way to the expected alignment of
+/// an AST type that might have been lowered to Ty.
+Address CIRGenFunction::createDefaultAlignTempAlloca(mlir::Type ty,
+                                                     mlir::Location loc,
+                                                     const Twine &name) {
+  CharUnits align =
+      CharUnits::fromQuantity(cgm.getDataLayout().getABITypeAlign(ty));
+  return createTempAlloca(ty, align, loc, name);
+}
+
 /// Try to emit a reference to the given value without producing it as
 /// an l-value.  For many cases, this is just an optimization, but it avoids
 /// us needing to emit global copies of variables if they're named without

--- a/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
@@ -214,7 +214,7 @@ public:
     mlir::Value complexVal = Visit(e->getSubExpr());
     // Defend against dominance problems caused by jumps out of expression
     // evaluation through the shared cleanup block.
-    scope.forceCleanup();
+    scope.forceCleanup({&complexVal});
     return complexVal;
   }
   mlir::Value VisitCXXScalarValueInitExpr(CXXScalarValueInitExpr *e) {

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -961,7 +961,9 @@ public:
 
   /// Takes the old cleanup stack size and emits the cleanup blocks
   /// that have been added.
-  void popCleanupBlocks(EHScopeStack::stable_iterator oldCleanupStackDepth);
+  void
+  popCleanupBlocks(EHScopeStack::stable_iterator oldCleanupStackDepth,
+                   std::initializer_list<mlir::Value *> valuesToReload = {});
   void popCleanupBlock();
 
   /// Push a cleanup to be run at the end of the current full-expression.  Safe
@@ -1012,10 +1014,11 @@ public:
 
     /// Force the emission of cleanups now, instead of waiting
     /// until this object is destroyed.
-    void forceCleanup() {
+    void
+    forceCleanup(std::initializer_list<mlir::Value *> valuesToReload = {}) {
       assert(performCleanup && "Already forced cleanup");
       cgf.didCallStackSave = oldDidCallStackSave;
-      cgf.popCleanupBlocks(cleanupStackDepth);
+      cgf.popCleanupBlocks(cleanupStackDepth, valuesToReload);
       performCleanup = false;
       cgf.currentCleanupStackDepth = oldCleanupStackDepth;
     }
@@ -2030,6 +2033,8 @@ public:
                                       const Twine &name = "tmp",
                                       mlir::Value arraySize = nullptr,
                                       mlir::OpBuilder::InsertPoint ip = {});
+  Address createDefaultAlignTempAlloca(mlir::Type ty, mlir::Location loc,
+                                       const Twine &name);
 
   /// Create a temporary memory object of the given type, with
   /// appropriate alignmen and cast it to the default address space. Returns

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -961,9 +961,8 @@ public:
 
   /// Takes the old cleanup stack size and emits the cleanup blocks
   /// that have been added.
-  void
-  popCleanupBlocks(EHScopeStack::stable_iterator oldCleanupStackDepth,
-                   std::initializer_list<mlir::Value *> valuesToReload = {});
+  void popCleanupBlocks(EHScopeStack::stable_iterator oldCleanupStackDepth,
+                        ArrayRef<mlir::Value *> valuesToReload = {});
   void popCleanupBlock();
 
   /// Push a cleanup to be run at the end of the current full-expression.  Safe
@@ -1014,8 +1013,7 @@ public:
 
     /// Force the emission of cleanups now, instead of waiting
     /// until this object is destroyed.
-    void
-    forceCleanup(std::initializer_list<mlir::Value *> valuesToReload = {}) {
+    void forceCleanup(ArrayRef<mlir::Value *> valuesToReload = {}) {
       assert(performCleanup && "Already forced cleanup");
       cgf.didCallStackSave = oldDidCallStackSave;
       cgf.popCleanupBlocks(cleanupStackDepth, valuesToReload);

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -153,6 +153,9 @@ VoidTask silly_task() {
 // CIR: %[[VoidTaskAddr:.*]] = cir.alloca ![[VoidTask]], {{.*}}, ["__retval"]
 // CIR: %[[SavedFrameAddr:.*]] = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["__coro_frame_addr"]
 // CIR: %[[VoidPromisseAddr:.*]] = cir.alloca ![[VoidPromisse]], {{.*}}, ["__promise"]
+// CIR: %[[SuspendAlwaysAddr:.*]] = cir.alloca ![[SuspendAlways]], {{.*}} ["ref.tmp0"]
+// CIR: %[[CoroHandleVoidAddr:.*]] = cir.alloca ![[CoroHandleVoid]], {{.*}} ["agg.tmp0"]
+// CIR: %[[CoroHandlePromiseAddr:.*]] = cir.alloca ![[CoroHandlePromiseVoid]], {{.*}} ["agg.tmp1"]
 
 // OGCG: %[[VoidPromisseAddr:.*]] = alloca %[[VoidPromisse]], align 1
 // OGCG: %[[VoidTaskAddr:.*]] = alloca %[[VoidTask]], align 1
@@ -203,17 +206,12 @@ VoidTask silly_task() {
 // Start a new scope for the actual codegen for co_await, create temporary allocas for
 // holding coroutine handle and the suspend_always struct.
 
-// CIR: cir.scope {
-// CIR:   %[[SuspendAlwaysAddr:.*]] = cir.alloca ![[SuspendAlways]], {{.*}} ["ref.tmp0"] {alignment = 1 : i64}
-// CIR:   %[[CoroHandleVoidAddr:.*]] = cir.alloca ![[CoroHandleVoid]], {{.*}} ["agg.tmp0"] {alignment = 1 : i64}
-// CIR:   %[[CoroHandlePromiseAddr:.*]] = cir.alloca ![[CoroHandlePromiseVoid]], {{.*}} ["agg.tmp1"] {alignment = 1 : i64}
-
 // Effectively execute `coawait promise_type::initial_suspend()` by calling initial_suspend() and getting
 // the suspend_always struct to use for cir.await. Note that we return by-value since we defer ABI lowering
 // to later passes, same is done elsewhere.
 
-// CIR:   %[[Tmp0:.*]] = cir.call @_ZN5folly4coro4TaskIvE12promise_type15initial_suspendEv(%[[VoidPromisseAddr]])
-// CIR:   cir.store{{.*}} %[[Tmp0:.*]], %[[SuspendAlwaysAddr]]
+// CIR: %[[Tmp0:.*]] = cir.call @_ZN5folly4coro4TaskIvE12promise_type15initial_suspendEv(%[[VoidPromisseAddr]])
+// CIR: cir.store{{.*}} %[[Tmp0:.*]], %[[SuspendAlwaysAddr]]
 
 // OGCG: call void @_ZN5folly4coro4TaskIvE12promise_type15initial_suspendEv(ptr noundef nonnull align 1 dereferenceable(1) %[[VoidPromisseAddr]])
 
@@ -223,12 +221,9 @@ VoidTask silly_task() {
 
 // First regions `ready` has a special cir.yield code to veto suspension.
 
-// CIR:   cir.await(init, ready : {
-// CIR:     %[[ReadyVeto:.*]] = cir.scope {
-// CIR:       %[[TmpCallRes:.*]] = cir.call @_ZNSt14suspend_always11await_readyEv(%[[SuspendAlwaysAddr]])
-// CIR:       cir.yield %[[TmpCallRes:.*]] : !cir.bool
-// CIR:     }
-// CIR:     cir.condition(%[[ReadyVeto]])
+// CIR: cir.await(init, ready : {
+// CIR:   %[[ReadyVeto:.*]] = cir.call @_ZNSt14suspend_always11await_readyEv(%[[SuspendAlwaysAddr]])
+// CIR:   cir.condition(%[[ReadyVeto]])
 
 // OGCG: %[[Tmp0:.*]] = call noundef zeroext i1 @_ZNSt14suspend_always11await_readyEv(ptr noundef nonnull align 1 dereferenceable(1) %[[SuspendAlwaysAddr]])
 // OGCG: br i1 %[[Tmp0]], label %init.ready, label %init.suspend
@@ -242,14 +237,14 @@ VoidTask silly_task() {
 //
 // FIXME: add veto support for non-void await_suspends.
 
-// CIR:   }, suspend : {
-// CIR:     %[[FromAddrRes:.*]] = cir.call @_ZNSt16coroutine_handleIN5folly4coro4TaskIvE12promise_typeEE12from_addressEPv(%[[CoroFrameAddr]])
-// CIR:     cir.store{{.*}} %[[FromAddrRes]], %[[CoroHandlePromiseAddr]] : ![[CoroHandlePromiseVoid]]
-// CIR:     %[[CoroHandlePromiseReload:.*]] = cir.load{{.*}} %[[CoroHandlePromiseAddr]]
-// CIR:     cir.call @_ZNSt16coroutine_handleIvEC1IN5folly4coro4TaskIvE12promise_typeEEES_IT_E(%[[CoroHandleVoidAddr]], %[[CoroHandlePromiseReload]])
-// CIR:     %[[CoroHandleVoidReload:.*]] = cir.load{{.*}} %[[CoroHandleVoidAddr]] : !cir.ptr<![[CoroHandleVoid]]>, ![[CoroHandleVoid]]
-// CIR:     cir.call @_ZNSt14suspend_always13await_suspendESt16coroutine_handleIvE(%[[SuspendAlwaysAddr]], %[[CoroHandleVoidReload]])
-// CIR:     cir.yield
+// CIR: }, suspend : {
+// CIR:   %[[FromAddrRes:.*]] = cir.call @_ZNSt16coroutine_handleIN5folly4coro4TaskIvE12promise_typeEE12from_addressEPv(%[[CoroFrameAddr]])
+// CIR:   cir.store{{.*}} %[[FromAddrRes]], %[[CoroHandlePromiseAddr]] : ![[CoroHandlePromiseVoid]]
+// CIR:   %[[CoroHandlePromiseReload:.*]] = cir.load{{.*}} %[[CoroHandlePromiseAddr]]
+// CIR:   cir.call @_ZNSt16coroutine_handleIvEC1IN5folly4coro4TaskIvE12promise_typeEEES_IT_E(%[[CoroHandleVoidAddr]], %[[CoroHandlePromiseReload]])
+// CIR:   %[[CoroHandleVoidReload:.*]] = cir.load{{.*}} %[[CoroHandleVoidAddr]] : !cir.ptr<![[CoroHandleVoid]]>, ![[CoroHandleVoid]]
+// CIR:   cir.call @_ZNSt14suspend_always13await_suspendESt16coroutine_handleIvE(%[[SuspendAlwaysAddr]], %[[CoroHandleVoidReload]])
+// CIR:   cir.yield
 
 // OGCG: init.suspend:
 // OGCG:   %[[Save:.*]] = call token @llvm.coro.save(ptr null)
@@ -262,11 +257,10 @@ VoidTask silly_task() {
 
 // Third region `resume` handles coroutine resuming logic.
 
-// CIR:   }, resume : {
-// CIR:     cir.call @_ZNSt14suspend_always12await_resumeEv(%[[SuspendAlwaysAddr]])
-// CIR:     cir.yield
-// CIR:   },)
-// CIR: }
+// CIR: }, resume : {
+// CIR:   cir.call @_ZNSt14suspend_always12await_resumeEv(%[[SuspendAlwaysAddr]])
+// CIR:   cir.yield
+// CIR: },)
 
 // OGCG: init.ready:
 // OGCG:   call void @_ZNSt14suspend_always12await_resumeEv(ptr noundef nonnull align 1 dereferenceable(1) %[[SuspendAlwaysAddr]]
@@ -279,12 +273,10 @@ VoidTask silly_task() {
 // - Return
 
 // The actual user written co_await
-// CIR: cir.scope {
-// CIR:   cir.await(user, ready : {
-// CIR:   }, suspend : {
-// CIR:   }, resume : {
-// CIR:   },)
-// CIR: }
+// CIR: cir.await(user, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
 
 // OGCG: cleanup.cont
 // OGCG: await.suspend:
@@ -296,12 +288,10 @@ VoidTask silly_task() {
 // OGCG: call void @_ZN5folly4coro4TaskIvE12promise_type11return_voidEv(ptr noundef nonnull align 1 dereferenceable(1) %[[VoidPromisseAddr]])
 
 // The final suspend co_await
-// CIR: cir.scope {
-// CIR:   cir.await(final, ready : {
-// CIR:   }, suspend : {
-// CIR:   }, resume : {
-// CIR:   },)
-// CIR: }
+// CIR: cir.await(final, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
 
 // OGCG: coro.final:
 // OGCG: final.suspend:
@@ -309,13 +299,13 @@ VoidTask silly_task() {
 
 // Call builtin coro end and return
 
-// CIR-NEXT: %[[CoroEndArg0:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!void>
-// CIR-NEXT: %[[CoroEndArg1:.*]] = cir.const #false
-// CIR-NEXT: = cir.call @__builtin_coro_end(%[[CoroEndArg0]], %[[CoroEndArg1]])
+// CIR: %[[CoroEndArg0:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!void>
+// CIR: %[[CoroEndArg1:.*]] = cir.const #false
+// CIR: = cir.call @__builtin_coro_end(%[[CoroEndArg0]], %[[CoroEndArg1]])
 
 // CIR: %[[Tmp1:.*]] = cir.load{{.*}} %[[VoidTaskAddr]]
-// CIR-NEXT: cir.return %[[Tmp1]]
-// CIR-NEXT: }
+// CIR: cir.return %[[Tmp1]]
+// CIR: }
 
 // OGCG: coro.ret:
 // OGCG:   call void @llvm.coro.end(ptr null, i1 false, token none)
@@ -331,49 +321,43 @@ folly::coro::Task<int> byRef(const std::string& s) {
 // CIR:    %[[SavedFrameAddr:.*]]  = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["__coro_frame_addr"]
 // CIR:    %[[AllocaFnUse:.*]] = cir.alloca !cir.ptr<![[StdString]]>, {{.*}}, ["s", init, const]
 // CIR:    %[[IntPromisseAddr:.*]] = cir.alloca ![[IntPromisse]], {{.*}}, ["__promise"]
+// CIR:    %[[SuspendAlwaysAddr:.*]] = cir.alloca ![[SuspendAlways]], {{.*}} ["ref.tmp0"] {alignment = 1 : i64}
+// CIR:    %[[CoroHandleVoidAddr:.*]] = cir.alloca ![[CoroHandleVoid]], {{.*}} ["agg.tmp0"] {alignment = 1 : i64}
+// CIR:    %[[CoroHandlePromiseAddr:.*]] = cir.alloca ![[CoroHandlePromiseInt]], {{.*}} ["agg.tmp1"] {alignment = 1 : i64}
 // CIR:    cir.store %[[ARG]], %[[AllocaParam]] : !cir.ptr<![[StdString]]>, {{.*}}
 
 // Call promise.get_return_object() to retrieve the task object.
 
 // CIR:    %[[LOAD:.*]] = cir.load %[[AllocaParam]] : !cir.ptr<!cir.ptr<![[StdString]]>>, !cir.ptr<![[StdString]]>
 // CIR:    cir.store {{.*}} %[[LOAD]], %[[AllocaFnUse]] : !cir.ptr<![[StdString]]>, !cir.ptr<!cir.ptr<![[StdString]]>>
-// CIR:    %[[RetObj:.*]] = cir.call @_ZN5folly4coro4TaskIiE12promise_type17get_return_objectEv(%4) nothrow : {{.*}} -> ![[IntTask]]
+// CIR:    %[[RetObj:.*]] = cir.call @_ZN5folly4coro4TaskIiE12promise_type17get_return_objectEv(%[[IntPromisseAddr]]) nothrow : {{.*}} -> ![[IntTask]]
 // CIR:    cir.store {{.*}} %[[RetObj]], %[[IntTaskAddr]] : ![[IntTask]]
-// CIR:    cir.scope {
-// CIR:      %[[SuspendAlwaysAddr:.*]] = cir.alloca ![[SuspendAlways]], {{.*}} ["ref.tmp0"] {alignment = 1 : i64}
-// CIR:      %[[CoroHandleVoidAddr:.*]] = cir.alloca ![[CoroHandleVoid]], {{.*}} ["agg.tmp0"] {alignment = 1 : i64}
-// CIR:      %[[CoroHandlePromiseAddr:.*]] = cir.alloca ![[CoroHandlePromiseInt]], {{.*}} ["agg.tmp1"] {alignment = 1 : i64}
-// CIR:      %[[Tmp0:.*]] = cir.call @_ZN5folly4coro4TaskIiE12promise_type15initial_suspendEv(%[[IntPromisseAddr]])
-// CIR:      cir.await(init, ready : {
-// CIR:       %[[ReadyVeto:.*]] = cir.scope {
-// CIR:         %[[TmpCallRes:.*]] = cir.call @_ZNSt14suspend_always11await_readyEv(%[[SuspendAlwaysAddr]])
-// CIR:         cir.yield %[[TmpCallRes:.*]] : !cir.bool
-// CIR:       }
-// CIR:       cir.condition(%[[ReadyVeto]])
-// CIR:      }, suspend : {
-// CIR:       %[[FromAddrRes:.*]] = cir.call @_ZNSt16coroutine_handleIN5folly4coro4TaskIiE12promise_typeEE12from_addressEPv(%[[CoroFrameAddr:.*]])
-// CIR:       cir.store{{.*}} %[[FromAddrRes]], %[[CoroHandlePromiseAddr]] : ![[CoroHandlePromiseInt]]
-// CIR:       %[[CoroHandlePromiseReload:.*]] = cir.load{{.*}} %[[CoroHandlePromiseAddr]]
-// CIR:       cir.call @_ZNSt16coroutine_handleIvEC1IN5folly4coro4TaskIiE12promise_typeEEES_IT_E(%[[CoroHandleVoidAddr]], %[[CoroHandlePromiseReload]])
-// CIR:       %[[CoroHandleVoidReload:.*]] = cir.load{{.*}} %[[CoroHandleVoidAddr]] : !cir.ptr<![[CoroHandleVoid]]>, ![[CoroHandleVoid]]
-// CIR:       cir.call @_ZNSt14suspend_always13await_suspendESt16coroutine_handleIvE(%[[SuspendAlwaysAddr]], %[[CoroHandleVoidReload]])
-// CIR:       cir.yield
-// CIR:       }, resume : {
-// CIR:         cir.call @_ZNSt14suspend_always12await_resumeEv(%[[SuspendAlwaysAddr]])
-// CIR:         cir.yield
-// CIR:       },)
-// CIR:     }
+// CIR:    %[[Tmp0:.*]] = cir.call @_ZN5folly4coro4TaskIiE12promise_type15initial_suspendEv(%[[IntPromisseAddr]])
+// CIR:    cir.store{{.*}} %[[Tmp0]], %[[SuspendAlwaysAddr]]
+// CIR:    cir.await(init, ready : {
+// CIR:      %[[TmpCallRes:.*]] = cir.call @_ZNSt14suspend_always11await_readyEv(%[[SuspendAlwaysAddr]])
+// CIR:      cir.condition(%[[TmpCallRes]])
+// CIR:    }, suspend : {
+// CIR:      %[[FromAddrRes:.*]] = cir.call @_ZNSt16coroutine_handleIN5folly4coro4TaskIiE12promise_typeEE12from_addressEPv(%[[CoroFrameAddr:.*]])
+// CIR:      cir.store{{.*}} %[[FromAddrRes]], %[[CoroHandlePromiseAddr]] : ![[CoroHandlePromiseInt]]
+// CIR:      %[[CoroHandlePromiseReload:.*]] = cir.load{{.*}} %[[CoroHandlePromiseAddr]]
+// CIR:      cir.call @_ZNSt16coroutine_handleIvEC1IN5folly4coro4TaskIiE12promise_typeEEES_IT_E(%[[CoroHandleVoidAddr]], %[[CoroHandlePromiseReload]])
+// CIR:      %[[CoroHandleVoidReload:.*]] = cir.load{{.*}} %[[CoroHandleVoidAddr]] : !cir.ptr<![[CoroHandleVoid]]>, ![[CoroHandleVoid]]
+// CIR:      cir.call @_ZNSt14suspend_always13await_suspendESt16coroutine_handleIvE(%[[SuspendAlwaysAddr]], %[[CoroHandleVoidReload]])
+// CIR:      cir.yield
+// CIR:    }, resume : {
+// CIR:      cir.call @_ZNSt14suspend_always12await_resumeEv(%[[SuspendAlwaysAddr]])
+// CIR:      cir.yield
+// CIR:    },)
 
 // can't fallthrough
 // CIR-NOT:   cir.await(user
 
 // The final suspend co_await
-// CIR: cir.scope {
-// CIR:   cir.await(final, ready : {
-// CIR:   }, suspend : {
-// CIR:   }, resume : {
-// CIR:   },)
-// CIR: }
+// CIR: cir.await(final, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
 
 folly::coro::Task<void> silly_coro() {
   std::optional<folly::coro::Task<int>> task;
@@ -390,9 +374,15 @@ folly::coro::Task<void> silly_coro() {
 
 // CIR: cir.func coroutine {{.*}} @_Z10silly_corov() {{.*}} ![[VoidTask]]
 // CIR: cir.await(init, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
 // CIR: cir.call @_ZN5folly4coro4TaskIvE12promise_type11return_voidEv
 // CIR-NOT: cir.call @_ZN5folly4coro4TaskIvE12promise_type11return_voidEv
 // CIR: cir.await(final, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
 
 folly::coro::Task<void> yield();
 folly::coro::Task<void> yield1() {
@@ -400,46 +390,89 @@ folly::coro::Task<void> yield1() {
   co_yield t;
 }
 
-// CHECK: cir.func coroutine {{.*}} @_Z6yield1v() -> !rec_folly3A3Acoro3A3ATask3Cvoid3E
+// CIR: cir.func coroutine {{.*}} @_Z6yield1v() -> !rec_folly3A3Acoro3A3ATask3Cvoid3E
 
+// Prologue allocas (still present in output)
+// CIR-DAG: %[[RETVAL:.*]] = cir.alloca ![[VoidTask]], {{.*}} ["__retval"]
+// CIR-DAG: %[[FRAME:.*]] = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["__coro_frame_addr"]
+// CIR-DAG: %[[PROMISE:.*]] = cir.alloca ![[VoidPromisse]], {{.*}} ["__promise"]
+// CIR-DAG: %[[SUSP0:.*]] = cir.alloca ![[SuspendAlways]], {{.*}} ["ref.tmp0"]
+// CIR-DAG: %[[CH_VOID0:.*]] = cir.alloca ![[CoroHandleVoid]], {{.*}} ["agg.tmp0"]
+// CIR-DAG: %[[CH_PROM0:.*]] = cir.alloca ![[CoroHandlePromiseVoid]], {{.*}} ["agg.tmp1"]
+// CIR-DAG: %[[T_ADDR:.*]] = cir.alloca ![[VoidTask]], {{.*}} ["t", init]
+// CIR-DAG: %[[SUSP1:.*]] = cir.alloca ![[SuspendAlways]], {{.*}} ["ref.tmp1"]
+// CIR-DAG: %[[AWAITER_COPY_ADDR:.*]] = cir.alloca ![[VoidTask]], {{.*}} ["agg.tmp2"]
+// CIR-DAG: %[[CH_VOID1:.*]] = cir.alloca ![[CoroHandleVoid]], {{.*}} ["agg.tmp3"]
+// CIR-DAG: %[[CH_PROM1:.*]] = cir.alloca ![[CoroHandlePromiseVoid]], {{.*}} ["agg.tmp4"]
+// CIR-DAG: %[[SUSP2:.*]] = cir.alloca ![[SuspendAlways]], {{.*}} ["ref.tmp2"]
+// CIR-DAG: %[[CH_VOID2:.*]] = cir.alloca ![[CoroHandleVoid]], {{.*}} ["agg.tmp5"]
+// CIR-DAG: %[[CH_PROM2:.*]] = cir.alloca ![[CoroHandlePromiseVoid]], {{.*}} ["agg.tmp6"]
+
+// initial_suspend + await(init)
+// CIR: %[[INIT_SUSP:.*]] = cir.call @_ZN5folly4coro4TaskIvE12promise_type15initial_suspendEv(%[[PROMISE]]){{.*}}
+// CIR: cir.store{{.*}} %[[INIT_SUSP]], %[[SUSP0]]
 // CIR: cir.await(init, ready : {
+// CIR:   %[[READY0:.*]] = cir.call @_ZNSt14suspend_always11await_readyEv(%[[SUSP0]]){{.*}}
+// CIR:   cir.condition(%[[READY0]])
 // CIR: }, suspend : {
+// CIR:   %[[FROMADDR0:.*]] = cir.call @_ZNSt16coroutine_handleIN5folly4coro4TaskIvE12promise_typeEE12from_addressEPv(%{{.*}}){{.*}}
+// CIR:   cir.store{{.*}} %[[FROMADDR0]], %[[CH_PROM0]]
+// CIR:   %[[PROM_RELOAD0:.*]] = cir.load{{.*}} %[[CH_PROM0]]
+// CIR:   cir.call @_ZNSt16coroutine_handleIvEC1IN5folly4coro4TaskIvE12promise_typeEEES_IT_E(%[[CH_VOID0]], %[[PROM_RELOAD0]]){{.*}}
+// CIR:   %[[VOID_RELOAD0:.*]] = cir.load{{.*}} %[[CH_VOID0]]
+// CIR:   cir.call @_ZNSt14suspend_always13await_suspendESt16coroutine_handleIvE(%[[SUSP0]], %[[VOID_RELOAD0]]){{.*}}
+// CIR:   cir.yield
 // CIR: }, resume : {
+// CIR:   cir.call @_ZNSt14suspend_always12await_resumeEv(%[[SUSP0]]){{.*}}
+// CIR:   cir.yield
 // CIR: },)
 
-//      CIR:  cir.scope {
-// CIR-NEXT:   %[[SUSPEND_PTR:.*]] = cir.alloca ![[SuspendAlways]], !cir.ptr<![[SuspendAlways]]>
-// CIR-NEXT:   %[[AWAITER_PTR:.*]] = cir.alloca ![[VoidTask]], !cir.ptr<![[VoidTask]]>
-// CIR-NEXT:   %[[CORO_PTR:.*]] = cir.alloca ![[CoroHandleVoid]], !cir.ptr<![[CoroHandleVoid]]>
-// CIR-NEXT:   %[[CORO2_PTR:.*]] = cir.alloca ![[CoroHandlePromiseVoid]], !cir.ptr<![[CoroHandlePromiseVoid]]>
-// CIR-NEXT:   cir.copy {{.*}} to %[[AWAITER_PTR]] : !cir.ptr<![[VoidTask]]>
-// CIR-NEXT:   %[[AWAITER:.*]] = cir.load{{.*}} %[[AWAITER_PTR]] : !cir.ptr<![[VoidTask]]>, ![[VoidTask]]
-// CIR-NEXT:   %[[SUSPEND:.*]] = cir.call @_ZN5folly4coro4TaskIvE12promise_type11yield_valueES2_(%{{.+}}, %[[AWAITER]]) nothrow : (!cir.ptr<![[VoidPromisse]]> {{.*}}, ![[VoidTask]]) -> ![[SuspendAlways]]
-// CIR-NEXT:   cir.store{{.*}} %[[SUSPEND]], %[[SUSPEND_PTR]] : ![[SuspendAlways]], !cir.ptr<![[SuspendAlways]]>
-// CIR-NEXT:   cir.await(yield, ready : {
-// CIR-NEXT:     %[[READY:.*]] = cir.scope {
-// CIR-NEXT:       %[[A:.*]] = cir.call @_ZNSt14suspend_always11await_readyEv(%[[SUSPEND_PTR]]) nothrow : (!cir.ptr<![[SuspendAlways]]>{{.*}}) -> (!cir.bool {llvm.noundef})
-// CIR-NEXT:       cir.yield %[[A]] : !cir.bool
-// CIR-NEXT:     } : !cir.bool
-// CIR-NEXT:     cir.condition(%[[READY]])
-// CIR-NEXT:   }, suspend : {
-// CIR-NEXT:     %[[CORO2:.*]] = cir.call @_ZNSt16coroutine_handleIN5folly4coro4TaskIvE12promise_typeEE12from_addressEPv(%9) nothrow : (!cir.ptr<!void> {{.*}}) -> ![[CoroHandlePromiseVoid]]
-// CIR-NEXT:     cir.store{{.*}} %[[CORO2]], %[[CORO2_PTR]] : ![[CoroHandlePromiseVoid]], !cir.ptr<![[CoroHandlePromiseVoid]]>
-// CIR-NEXT:     %[[B:.*]] = cir.load{{.*}} %[[CORO2_PTR]] : !cir.ptr<![[CoroHandlePromiseVoid]]>, ![[CoroHandlePromiseVoid]]
-// CIR-NEXT:     cir.call @_ZNSt16coroutine_handleIvEC1IN5folly4coro4TaskIvE12promise_typeEEES_IT_E(%[[CORO_PTR]], %[[B]]) nothrow : (!cir.ptr<![[CoroHandleVoid]]> {{.*}}, ![[CoroHandlePromiseVoid]]) -> ()
-// CIR-NEXT:     %[[C:.*]] = cir.load{{.*}} %[[CORO_PTR]] : !cir.ptr<![[CoroHandleVoid]]>, ![[CoroHandleVoid]]
-// CIR-NEXT:     cir.call @_ZNSt14suspend_always13await_suspendESt16coroutine_handleIvE(%[[SUSPEND_PTR]], %[[C]]) nothrow : (!cir.ptr<![[SuspendAlways]]> {{.*}}, ![[CoroHandleVoid]]) -> ()
-// CIR-NEXT:     cir.yield
-// CIR-NEXT:   }, resume : {
-// CIR-NEXT:     cir.call @_ZNSt14suspend_always12await_resumeEv(%[[SUSPEND_PTR]]) nothrow : (!cir.ptr<![[SuspendAlways]]>{{.*}}) -> ()
-// CIR-NEXT:     cir.yield
-// CIR-NEXT:   },)
-// CIR-NEXT: }
+// yield_value + await(yield)
+// CIR: %[[YIELD_TASK:.*]] = cir.call @_Z5yieldv(){{.*}}
+// CIR: cir.store{{.*}} %[[YIELD_TASK]], %[[T_ADDR]]
+// CIR: cir.copy %[[T_ADDR]] to %[[AWAITER_COPY_ADDR]]
+// CIR: %[[AWAITER:.*]] = cir.load{{.*}} %[[AWAITER_COPY_ADDR]]
+// CIR: %[[YIELD_SUSP:.*]] = cir.call @_ZN5folly4coro4TaskIvE12promise_type11yield_valueES2_(%[[PROMISE]], %[[AWAITER]]){{.*}}
+// CIR: cir.store{{.*}} %[[YIELD_SUSP]], %[[SUSP1]]
+// CIR: cir.await(yield, ready : {
+// CIR:   %[[READY1:.*]] = cir.call @_ZNSt14suspend_always11await_readyEv(%[[SUSP1]]){{.*}}
+// CIR:   cir.condition(%[[READY1]])
+// CIR: }, suspend : {
+// CIR:   %[[FROMADDR1:.*]] = cir.call @_ZNSt16coroutine_handleIN5folly4coro4TaskIvE12promise_typeEE12from_addressEPv(%{{.*}}){{.*}}
+// CIR:   cir.store{{.*}} %[[FROMADDR1]], %[[CH_PROM1]]
+// CIR:   %[[PROM_RELOAD1:.*]] = cir.load{{.*}} %[[CH_PROM1]]
+// CIR:   cir.call @_ZNSt16coroutine_handleIvEC1IN5folly4coro4TaskIvE12promise_typeEEES_IT_E(%[[CH_VOID1]], %[[PROM_RELOAD1]]){{.*}}
+// CIR:   %[[VOID_RELOAD1:.*]] = cir.load{{.*}} %[[CH_VOID1]]
+// CIR:   cir.call @_ZNSt14suspend_always13await_suspendESt16coroutine_handleIvE(%[[SUSP1]], %[[VOID_RELOAD1]]){{.*}}
+// CIR:   cir.yield
+// CIR: }, resume : {
+// CIR:   cir.call @_ZNSt14suspend_always12await_resumeEv(%[[SUSP1]]){{.*}}
+// CIR:   cir.yield
+// CIR: },)
 
+// return_void + await(final)
+// CIR: cir.call @_ZN5folly4coro4TaskIvE12promise_type11return_voidEv(%[[PROMISE]]){{.*}}
+// CIR: %[[FINAL_SUSP:.*]] = cir.call @_ZN5folly4coro4TaskIvE12promise_type13final_suspendEv(%[[PROMISE]]){{.*}}
+// CIR: cir.store{{.*}} %[[FINAL_SUSP]], %[[SUSP2]]
 // CIR: cir.await(final, ready : {
+// CIR:   %[[READY2:.*]] = cir.call @_ZNSt14suspend_always11await_readyEv(%[[SUSP2]]){{.*}}
+// CIR:   cir.condition(%[[READY2]])
 // CIR: }, suspend : {
+// CIR:   %[[FROMADDR2:.*]] = cir.call @_ZNSt16coroutine_handleIN5folly4coro4TaskIvE12promise_typeEE12from_addressEPv(%{{.*}}){{.*}}
+// CIR:   cir.store{{.*}} %[[FROMADDR2]], %[[CH_PROM2]]
+// CIR:   %[[PROM_RELOAD2:.*]] = cir.load{{.*}} %[[CH_PROM2]]
+// CIR:   cir.call @_ZNSt16coroutine_handleIvEC1IN5folly4coro4TaskIvE12promise_typeEEES_IT_E(%[[CH_VOID2]], %[[PROM_RELOAD2]]){{.*}}
+// CIR:   %[[VOID_RELOAD2:.*]] = cir.load{{.*}} %[[CH_VOID2]]
+// CIR:   cir.call @_ZNSt14suspend_always13await_suspendESt16coroutine_handleIvE(%[[SUSP2]], %[[VOID_RELOAD2]]){{.*}}
+// CIR:   cir.yield
 // CIR: }, resume : {
+// CIR:   cir.call @_ZNSt14suspend_always12await_resumeEv(%[[SUSP2]]){{.*}}
+// CIR:   cir.yield
 // CIR: },)
+// CIR: = cir.call @__builtin_coro_end(%{{.*}}, %{{.*}}){{.*}}
+// CIR: %[[RETLOAD:.*]] = cir.load{{.*}} %[[RETVAL]]
+// CIR: cir.return %[[RETLOAD]]
+// CIR: }
 
 // CHECK: }
 
@@ -452,11 +485,10 @@ folly::coro::Task<int> go1() {
 // CIR: cir.func coroutine {{.*}} @_Z3go1v() {{.*}} ![[IntTask]]
 // CIR: %[[IntTaskAddr:.*]] = cir.alloca ![[IntTask]], !cir.ptr<![[IntTask]]>, ["task", init]
 
-// CIR:   cir.await(init, ready : {
-// CIR:   }, suspend : {
-// CIR:   }, resume : {
-// CIR:   },)
-// CIR: }
+// CIR: cir.await(init, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
 
 // The call to go(1) has its own scope due to full-expression rules.
 // CIR: cir.scope {
@@ -467,15 +499,19 @@ folly::coro::Task<int> go1() {
 // CIR:   cir.store{{.*}} %[[IntTaskTmp]], %[[IntTaskAddr]] : ![[IntTask]], !cir.ptr<![[IntTask]]>
 // CIR: }
 
-// CIR: %[[CoReturnValAddr:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__coawait_resume_rval"] {alignment = 1 : i64}
 // CIR: cir.await(user, ready : {
 // CIR: }, suspend : {
 // CIR: }, resume : {
-// CIR:   %[[ResumeVal:.*]] = cir.call @_ZN5folly4coro4TaskIiE12await_resumeEv(%3)
-// CIR:   cir.store{{.*}} %[[ResumeVal]], %[[CoReturnValAddr]] : !s32i, !cir.ptr<!s32i>
+// CIR: %[[ResumeVal:.*]] = cir.call @_ZN5folly4coro4TaskIiE12await_resumeEv(%[[IntTaskAddr]])
+// CIR: cir.store{{.*}} %[[ResumeVal]], %[[CoReturnValAddr:.*]] : !s32i, !cir.ptr<!s32i>
 // CIR: },)
 // CIR: %[[V:.*]] = cir.load{{.*}} %[[CoReturnValAddr]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.call @_ZN5folly4coro4TaskIiE12promise_type12return_valueEi({{.*}}, %[[V]])
+
+// CIR: cir.await(final, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
 
 
 folly::coro::Task<int> go1_lambda() {
@@ -486,7 +522,27 @@ folly::coro::Task<int> go1_lambda() {
 }
 
 // CIR: cir.func coroutine {{.*}} @_ZZ10go1_lambdavENK3$_0clEv{{.*}} ![[IntTask]]
+// CIR: cir.await(init, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
+// CIR: cir.await(final, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
 // CIR: cir.func coroutine {{.*}} @_Z10go1_lambdav() {{.*}} ![[IntTask]]
+// CIR: cir.await(init, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
+// CIR: cir.await(user, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
+// CIR: cir.await(final, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
 
 folly::coro::Task<int> go4() {
   auto* fn = +[](int const& i) -> folly::coro::Task<int> { co_return i; };
@@ -494,39 +550,51 @@ folly::coro::Task<int> go4() {
   co_return co_await std::move(task);
 }
 
+// CIR: cir.func coroutine{{.*}} @_ZZ3go4vENK3$_0clERKi(
+// CIR: cir.await(init, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
+// CIR: cir.await(final, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
+
 // CIR: cir.func coroutine {{.*}} @_Z3go4v() {{.*}} ![[IntTask]]
 
-// CIR:   cir.await(init, ready : {
-// CIR:   }, suspend : {
-// CIR:   }, resume : {
-// CIR:   },)
-// CIR: }
-
-// CIR: %[[RES:.*]] = cir.scope {
-// CIR:   %[[LAMBDA:.*]] = cir.alloca !rec_anon2E2, !cir.ptr<!rec_anon2E2>, ["ref.tmp1"] {alignment = 1 : i64}
+// CIR: cir.await(init, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
 
 // Get the lambda invoker ptr via `lambda operator folly::coro::Task<int> (*)(int const&)()`
-// CIR:   %[[INVOKER:.*]] = cir.call @_ZZ3go4vENK3$_0cvPFN5folly4coro4TaskIiEERKiEEv(%[[LAMBDA]]) nothrow : (!cir.ptr<!rec_anon2E2>{{.*}}) -> (!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>> {llvm.noundef})
-// CIR:   %[[PLUS:.*]] = cir.unary(plus, %[[INVOKER]]) : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>
-// CIR:   cir.yield %[[PLUS]] : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>
-// CIR: }
-// CIR: cir.store{{.*}} %[[RES]], %[[PTR_TASK:.*]] : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>>
+// CIR: %[[INVOKER:.*]] = cir.call @_ZZ3go4vENK3$_0cvPFN5folly4coro4TaskIiEERKiEEv(%{{.*}}) nothrow : {{.*}} -> (!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>> {llvm.noundef})
+// CIR: %[[PLUS:.*]] = cir.unary(plus, %[[INVOKER]]) : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>
+// CIR: cir.store{{.*}} %[[PLUS]], %[[FN_ADDR:.*]] : !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>>
 // CIR: cir.scope {
 // CIR:   %[[ARG:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["ref.tmp2", init] {alignment = 4 : i64}
-// CIR:   %[[LAMBDA2:.*]] = cir.load{{.*}} %[[PTR_TASK]] : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>>, !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>
+// CIR:   %[[FN:.*]] = cir.load{{.*}} %[[FN_ADDR]] : !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>>, !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>
 // CIR:   %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
 // CIR:   cir.store{{.*}} %[[THREE]], %[[ARG]] : !s32i, !cir.ptr<!s32i>
 
 // Call invoker, which calls operator() indirectly.
-// CIR:   %[[RES:.*]] = cir.call %[[LAMBDA2]](%[[ARG]]) : (!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!s32i> {{.*}}) -> ![[IntTask]]
-// CIR:   cir.store{{.*}} %[[RES]], %4 : ![[IntTask]], !cir.ptr<![[IntTask]]>
+// CIR:   %[[CALLRES:.*]] = cir.call %[[FN]](%[[ARG]]) : (!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> ![[IntTask]]>>, !cir.ptr<!s32i> {{.*}}) -> ![[IntTask]]
+// CIR:   cir.store{{.*}} %[[CALLRES]], %[[TASK_ADDR:.*]] : ![[IntTask]], !cir.ptr<![[IntTask]]>
 // CIR: }
 
-// CIR:   cir.await(user, ready : {
-// CIR:   }, suspend : {
-// CIR:   }, resume : {
-// CIR:   },)
-// CIR: }
+// CIR: cir.await(user, ready : {
+// CIR:   = cir.call @_ZN5folly4coro4TaskIiE11await_readyEv(%[[TASK_ADDR]])
+// CIR:   cir.condition(
+// CIR: }, suspend : {
+// CIR:   cir.yield
+// CIR: }, resume : {
+// CIR:   cir.yield
+// CIR: },)
+
+// CIR: cir.await(final, ready : {
+// CIR: }, suspend : {
+// CIR: }, resume : {
+// CIR: },)
 
 // OGCG: define {{.*}}__await_suspend_wrapper__init(ptr noundef nonnull %[[Awaiter:.*]], ptr noundef %[[Handle:.*]])
 // OGCG: entry:

--- a/clang/test/CIR/CodeGen/defaultarg.cpp
+++ b/clang/test/CIR/CodeGen/defaultarg.cpp
@@ -12,17 +12,13 @@ void foo() {
 }
 
 // CIR: cir.func {{.*}} @_Z3foov()
-// CIR:   cir.scope {
-// CIR:     %[[TMP0:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["ref.tmp0"]
-// CIR:     %[[TMP1:.*]] = cir.const #cir.int<42>
-// CIR:     cir.store{{.*}} %[[TMP1]], %[[TMP0]]
-// CIR:     cir.call @_Z3barRKi(%[[TMP0]])
-// CIR:   }
+// CIR:   %[[TMP0:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["ref.tmp0"]
+// CIR:   %[[TMP1:.*]] = cir.const #cir.int<42>
+// CIR:   cir.store{{.*}} %[[TMP1]], %[[TMP0]]
+// CIR:   cir.call @_Z3barRKi(%[[TMP0]])
 
 // LLVM: define{{.*}} @_Z3foov()
 // LLVM:   %[[TMP0:.*]] = alloca i32
-// LLVM:   br label %[[SCOPE_LABEL:.*]]
-// LLVM: [[SCOPE_LABEL]]:
 // LLVM:   store i32 42, ptr %[[TMP0]]
 // LLVM:   call void @_Z3barRKi(ptr {{.*}} %[[TMP0]])
 

--- a/clang/test/CIR/CodeGen/dtors.cpp
+++ b/clang/test/CIR/CodeGen/dtors.cpp
@@ -5,8 +5,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -mconstructor-aliases -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
 
-// XFAIL: *
-
 struct A {
   ~A();
 };
@@ -37,43 +35,79 @@ bool make_temp(const B &) { return false; }
 bool test_temp_or() { return make_temp(1) || make_temp(2); }
 
 // CIR: cir.func{{.*}} @_Z12test_temp_orv()
+// CIR:   %[[RET_ADDR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["__retval"]
 // CIR:   cir.scope {
 // CIR:     %[[REF_TMP0:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp0"]
 // CIR:     %[[ONE:.*]] = cir.const #cir.int<1>
 // CIR:     cir.call @_ZN1BC2Ei(%[[REF_TMP0]], %[[ONE]])
-// CIR:     %[[MAKE_TEMP0:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP0]])
-// CIR:     %[[TERNARY:.*]] = cir.ternary(%[[MAKE_TEMP0]], true {
-// CIR:       %[[TRUE:.*]] = cir.const #true
-// CIR:       cir.yield %[[TRUE]] : !cir.bool
-// CIR:     }, false {
-// CIR:       %[[REF_TMP1:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp1"]
-// CIR:       %[[TWO:.*]] = cir.const #cir.int<2>
-// CIR:       cir.call @_ZN1BC2Ei(%[[REF_TMP1]], %[[TWO]])
-// CIR:       %[[MAKE_TEMP1:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP1]])
-// CIR:       cir.call @_ZN1BD2Ev(%[[REF_TMP1]])
-// CIR:       cir.yield %[[MAKE_TEMP1]] : !cir.bool
-// CIR:     })
-// CIR:     cir.store{{.*}} %[[TERNARY]], %[[RETVAL:.*]]
-// CIR:     cir.call @_ZN1BD2Ev(%[[REF_TMP0]])
+// CIR:     cir.cleanup.scope {
+// CIR:       %[[MAKE_TEMP0:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP0]])
+// CIR:       %[[TERNARY:.*]] = cir.ternary(%[[MAKE_TEMP0]], true {
+// CIR:         %[[TRUE:.*]] = cir.const #true
+// CIR:         cir.yield %[[TRUE]] : !cir.bool
+// CIR:       }, false {
+// CIR:         %[[REF_TMP1:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp1"]
+// CIR:         %[[CLEANUP_TMP:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["tmp.exprcleanup"]
+// CIR:         %[[TWO:.*]] = cir.const #cir.int<2>
+// CIR:         cir.call @_ZN1BC2Ei(%[[REF_TMP1]], %[[TWO]])
+// CIR:         cir.cleanup.scope {
+// CIR:           %[[MAKE_TEMP1:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP1]]) : (!cir.ptr<!rec_B>
+// CIR:           cir.store{{.*}} %[[MAKE_TEMP1]], %[[CLEANUP_TMP]]
+// CIR:           cir.yield
+// CIR:         } cleanup  normal {
+// CIR:           cir.call @_ZN1BD2Ev(%[[REF_TMP1]])
+// CIR:           cir.yield
+// CIR:         }
+// CIR:         %[[TERNARY_TMP:.*]] = cir.load{{.*}} %[[CLEANUP_TMP]]
+// CIR:         cir.yield %[[TERNARY_TMP]] : !cir.bool
+// CIR:       })
+// CIR:       cir.store{{.*}} %[[TERNARY]], %[[RET_ADDR]]
+// CIR:       cir.yield
+// CIR:     } cleanup  normal {
+// CIR:       cir.call @_ZN1BD2Ev(%[[REF_TMP0]])
+// CIR:       cir.yield
+// CIR:     }
 // CIR:   }
+// CIR:   %[[RETVAL:.*]] = cir.load{{.*}} %[[RET_ADDR]]
+// CIR:   cir.return %[[RETVAL]]
 
 // LLVM: define{{.*}} i1 @_Z12test_temp_orv(){{.*}} {
 // LLVM:   %[[REF_TMP0:.*]] = alloca %struct.B
 // LLVM:   %[[REF_TMP1:.*]] = alloca %struct.B
+// LLVM:   %[[TMP_RESULT1:.*]] = alloca i8
+// LLVM:   %[[TMP_RESULT2:.*]] = alloca i8
 // LLVM:   br label %[[LOR_BEGIN:.*]]
 // LLVM: [[LOR_BEGIN]]:
 // LLVM:   call void @_ZN1BC2Ei(ptr {{.*}} %[[REF_TMP0]], i32 {{.*}} 1)
+// LLVM:   br label %[[SCOPE_BEGIN:.*]]
+// LLVM: [[SCOPE_BEGIN]]:
 // LLVM:   %[[MAKE_TEMP0:.*]] = call {{.*}} i1 @_Z9make_tempRK1B(ptr {{.*}} %[[REF_TMP0]])
-// LLVM:   br i1 %[[MAKE_TEMP0]], label %[[LHS_TRUE_BLOCK:.*]], label %[[LHS_FALSE_BLOCK:.*]]
-// LLVM: [[LHS_TRUE_BLOCK]]:
+// LLVM:   br i1 %[[MAKE_TEMP0]], label %[[TERN_TRUE:.*]], label %[[TERN_FALSE:.*]]
+// LLVM: [[TERN_TRUE]]:
 // LLVM:   br label %[[RESULT_BLOCK:.*]]
-// LLVM: [[LHS_FALSE_BLOCK]]:
+// LLVM: [[TERN_FALSE]]:
 // LLVM:   call void @_ZN1BC2Ei(ptr {{.*}} %[[REF_TMP1]], i32 {{.*}} 2)
+// LLVM:   br label %[[FALSE_CLEANUP_SCOPE:.*]]
+// LLVM: [[FALSE_CLEANUP_SCOPE]]:
 // LLVM:   %[[MAKE_TEMP1:.*]] = call {{.*}} i1 @_Z9make_tempRK1B(ptr {{.*}} %[[REF_TMP1]])
+// LLVM:   %[[ZEXT:.*]] = zext i1 %[[MAKE_TEMP1]] to i8
+// LLVM:   store i8 %[[ZEXT]], ptr %[[TMP_RESULT1]]
+// LLVM:   br label %[[FALSE_CLEANUP:.*]]
+// LLVM: [[FALSE_CLEANUP]]:
 // LLVM:   call void @_ZN1BD2Ev(ptr {{.*}} %[[REF_TMP1]])
-// LLVM:   br label %[[RESULT_BLOCK]]
+// LLVM:   br label %[[FALSE_END:.*]]
+// LLVM: [[FALSE_END]]:
+// LLVM:   br label %[[FALSE_RESULT:.*]]
+// LLVM: [[FALSE_RESULT]]:
+// LLVM:   %[[LOAD_TEMP1:.*]] = load i8, ptr %[[TMP_RESULT1]]
+// LLVM:   %[[TRUNC:.*]] = trunc i8 %[[LOAD_TEMP1]] to i1
+// LLVM:   br label %[[RESULT_BLOCK:.*]]
 // LLVM: [[RESULT_BLOCK]]:
-// LLVM:   %[[RESULT:.*]] = phi i1 [ %[[MAKE_TEMP1]], %[[LHS_FALSE_BLOCK]] ], [ true, %[[LHS_TRUE_BLOCK]] ]
+// LLVM:   %[[RESULT:.*]] = phi i1 [ %[[TRUNC]], %[[FALSE_RESULT]] ], [ true, %[[TERN_TRUE]] ]
+// LLVM:   br label %[[TERN_END:.*]]
+// LLVM: [[TERN_END]]:
+// LLVM:   %[[ZEXT_RESULT:.*]] = zext i1 %[[RESULT]] to i8
+// LLVM:   store i8 %[[ZEXT_RESULT]], ptr %[[TMP_RESULT2]]
 // LLVM:   br label %[[LOR_END:.*]]
 // LLVM: [[LOR_END]]:
 // LLVM:   call void @_ZN1BD2Ev(ptr {{.*}} %[[REF_TMP0]])
@@ -107,46 +141,91 @@ bool test_temp_or() { return make_temp(1) || make_temp(2); }
 bool test_temp_and() { return make_temp(1) && make_temp(2); }
 
 // CIR: cir.func{{.*}} @_Z13test_temp_andv()
+// CIR:   %[[RET_ADDR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["__retval"]
 // CIR:   cir.scope {
 // CIR:     %[[REF_TMP0:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp0"]
 // CIR:     %[[ONE:.*]] = cir.const #cir.int<1>
 // CIR:     cir.call @_ZN1BC2Ei(%[[REF_TMP0]], %[[ONE]])
-// CIR:     %[[MAKE_TEMP0:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP0]])
-// CIR:     %[[TERNARY:.*]] = cir.ternary(%[[MAKE_TEMP0]], true {
-// CIR:       %[[REF_TMP1:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp1"]
-// CIR:       %[[TWO:.*]] = cir.const #cir.int<2>
-// CIR:       cir.call @_ZN1BC2Ei(%[[REF_TMP1]], %[[TWO]])
-// CIR:       %[[MAKE_TEMP1:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP1]])
-// CIR:       cir.call @_ZN1BD2Ev(%[[REF_TMP1]])
-// CIR:       cir.yield %[[MAKE_TEMP1]] : !cir.bool
-// CIR:     }, false {
-// CIR:       %[[FALSE:.*]] = cir.const #false
-// CIR:       cir.yield %[[FALSE]] : !cir.bool
-// CIR:     })
-// CIR:     cir.store{{.*}} %[[TERNARY]], %[[RETVAL:.*]]
-// CIR:     cir.call @_ZN1BD2Ev(%[[REF_TMP0]])
+// CIR:     cir.cleanup.scope {
+// CIR:       %[[MAKE_TEMP0:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP0]])
+// CIR:       %[[TERNARY:.*]] = cir.ternary(%[[MAKE_TEMP0]], true {
+// CIR:         %[[REF_TMP1:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp1"]
+// CIR:         %[[CLEANUP_TMP:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["tmp.exprcleanup"]
+// CIR:         %[[TWO:.*]] = cir.const #cir.int<2>
+// CIR:         cir.call @_ZN1BC2Ei(%[[REF_TMP1]], %[[TWO]])
+// CIR:         cir.cleanup.scope {
+// CIR:           %[[MAKE_TEMP1:.*]] = cir.call @_Z9make_tempRK1B(%[[REF_TMP1]]) : (!cir.ptr<!rec_B>
+// CIR:           cir.store{{.*}} %[[MAKE_TEMP1]], %[[CLEANUP_TMP]]
+// CIR:           cir.yield
+// CIR:         } cleanup  normal {
+// CIR:           cir.call @_ZN1BD2Ev(%[[REF_TMP1]])
+// CIR:           cir.yield
+// CIR:         }
+// CIR:         %[[TERNARY_TMP:.*]] = cir.load{{.*}} %[[CLEANUP_TMP]]
+// CIR:         cir.yield %[[TERNARY_TMP]] : !cir.bool
+// CIR:       }, false {
+// CIR:         %[[FALSE:.*]] = cir.const #false
+// CIR:         cir.yield %[[FALSE]] : !cir.bool
+// CIR:       })
+// CIR:       cir.store{{.*}} %[[TERNARY]], %[[RET_ADDR]]
+// CIR:       cir.yield
+// CIR:     } cleanup  normal {
+// CIR:       cir.call @_ZN1BD2Ev(%[[REF_TMP0]])
+// CIR:       cir.yield
+// CIR:     }
 // CIR:   }
+// CIR:   %[[RETVAL:.*]] = cir.load{{.*}} %[[RET_ADDR]]
+// CIR:   cir.return %[[RETVAL]]
 
 // LLVM: define{{.*}} i1 @_Z13test_temp_andv(){{.*}} {
-// LLVM:   %[[REF_TMP0:.*]] = alloca %struct.B
-// LLVM:   %[[REF_TMP1:.*]] = alloca %struct.B
+// LLVM:   %[[REF_TMP0:.*]] = alloca %struct.B{{.*}}
+// LLVM:   %[[REF_TMP1:.*]] = alloca %struct.B{{.*}}
+// LLVM:   %[[TMP_RESULT:.*]] = alloca i8{{.*}}
+// LLVM:   %[[TMP_RESULT2:.*]] = alloca i8{{.*}}
 // LLVM:   br label %[[LAND_BEGIN:.*]]
 // LLVM: [[LAND_BEGIN]]:
 // LLVM:   call void @_ZN1BC2Ei(ptr {{.*}} %[[REF_TMP0]], i32 {{.*}} 1)
+// LLVM:   br label %[[SCOPE_BEGIN:.*]]
+// LLVM: [[SCOPE_BEGIN]]:
 // LLVM:   %[[MAKE_TEMP0:.*]] = call {{.*}} i1 @_Z9make_tempRK1B(ptr {{.*}} %[[REF_TMP0]])
-// LLVM:   br i1 %[[MAKE_TEMP0]], label %[[LHS_TRUE_BLOCK:.*]], label %[[LHS_FALSE_BLOCK:.*]]
-// LLVM: [[LHS_TRUE_BLOCK]]:
+// LLVM:   br i1 %[[MAKE_TEMP0]], label %[[TERN_TRUE:.*]], label %[[TERN_FALSE:.*]]
+// LLVM: [[TERN_TRUE]]:
 // LLVM:   call void @_ZN1BC2Ei(ptr {{.*}} %[[REF_TMP1]], i32 {{.*}} 2)
+// LLVM:   br label %[[TRUE_CLEANUP_SCOPE:.*]]
+// LLVM: [[TRUE_CLEANUP_SCOPE]]:
 // LLVM:   %[[MAKE_TEMP1:.*]] = call {{.*}} i1 @_Z9make_tempRK1B(ptr {{.*}} %[[REF_TMP1]])
+// LLVM:   %[[ZEXT_MAKE_TEMP1:.*]] = zext i1 %[[MAKE_TEMP1]] to i8
+// LLVM:   store i8 %[[ZEXT_MAKE_TEMP1]], ptr %[[TMP_RESULT]], align 1
+// LLVM:   br label %[[TRUE_CLEANUP:.*]]
+// LLVM: [[TRUE_CLEANUP]]:
 // LLVM:   call void @_ZN1BD2Ev(ptr {{.*}} %[[REF_TMP1]])
+// LLVM:   br label %[[TRUE_END:.*]]
+// LLVM: [[TRUE_END]]:
+// LLVM:   br label %[[TRUE_RESULT:.*]]
+// LLVM: [[TRUE_RESULT]]:
+// LLVM:   %[[TMP_LOAD:.*]] = load i8, ptr %[[TMP_RESULT]], align 1
+// LLVM:   %[[TMP_TRUNC:.*]] = trunc i8 %[[TMP_LOAD]] to i1
 // LLVM:   br label %[[RESULT_BLOCK:.*]]
-// LLVM: [[LHS_FALSE_BLOCK]]:
+// LLVM: [[TERN_FALSE]]:
 // LLVM:   br label %[[RESULT_BLOCK]]
 // LLVM: [[RESULT_BLOCK]]:
-// LLVM:   %[[RESULT:.*]] = phi i1 [ false, %[[LHS_FALSE_BLOCK]] ], [ %[[MAKE_TEMP1]], %[[LHS_TRUE_BLOCK]] ]
+// LLVM:   %[[RESULT:.*]] = phi i1 [ false, %[[TERN_FALSE]] ], [ %[[TMP_TRUNC]], %[[TRUE_RESULT]] ]
+// LLVM:   br label %[[TERN_END:.*]]
+// LLVM: [[TERN_END]]:
+// LLVM:   %[[ZEXT_RESULT:.*]] = zext i1 %[[RESULT]] to i8
+// LLVM:   store i8 %[[ZEXT_RESULT]], ptr %[[TMP_RESULT2]], align 1
 // LLVM:   br label %[[LAND_END:.*]]
 // LLVM: [[LAND_END]]:
 // LLVM:   call void @_ZN1BD2Ev(ptr {{.*}} %[[REF_TMP0]])
+// LLVM:   br label %[[LAND_END2:.*]]
+// LLVM: [[LAND_END2]]:
+// LLVM:   br label %[[LAND_END3:.*]]
+// LLVM: [[LAND_END3]]:
+// LLVM:   br label %[[RETURN_BLOCK:.*]]
+// LLVM: [[RETURN_BLOCK]]:
+// LLVM:   %[[TMP2_LOAD:.*]] = load i8, ptr %[[TMP_RESULT2]], align 1
+// LLVM:   %[[TMP2_TRUNC:.*]] = trunc i8 %[[TMP2_LOAD]] to i1
+// LLVM:   ret i1 %[[TMP2_TRUNC]]
 
 // OGCG: define {{.*}} i1 @_Z13test_temp_andv()
 // OGCG: [[ENTRY:.*]]:
@@ -246,6 +325,131 @@ void test_base_dtor_call() {
 
 // OGCG: define {{.*}} void @_ZN1FD2Ev
 // OGCG:   call void @_ZN1ED2Ev(ptr {{.*}} %{{.*}})
+
+struct G {
+  G(int);
+  ~G();
+  G copy() const;
+  bool operator==(const G &) const;
+};
+
+// Test the valesToReload handling in ScalarExprEmitter::VisitExprWithCleanups.
+int test_temp_in_condition(G &obj) {
+  if (obj.copy() == 1)
+    return 1;
+  return 0;
+}
+
+// CIR: cir.func {{.*}} @_Z22test_temp_in_conditionR1G(%[[ARG0:.*]]: !cir.ptr<!rec_G> {{.*}}) -> (!s32i {{.*}}) {
+// CIR:   %[[OBJ:.*]] = cir.alloca !cir.ptr<!rec_G>, !cir.ptr<!cir.ptr<!rec_G>>, ["obj", init, const]
+// CIR:   %[[RET_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// CIR:   cir.store %[[ARG0]], %[[OBJ]]
+// CIR:   cir.scope {
+// CIR:     %[[REF_TMP0:.*]] = cir.alloca !rec_G, !cir.ptr<!rec_G>, ["ref.tmp0"]
+// CIR:     %[[REF_TMP1:.*]] = cir.alloca !rec_G, !cir.ptr<!rec_G>, ["ref.tmp1"]
+// CIR:     %[[CLEANUP_TMP:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["tmp.exprcleanup"]
+// CIR:     %[[LOAD_OBJ:.*]] = cir.load{{.*}} %[[OBJ]] : !cir.ptr<!cir.ptr<!rec_G>>, !cir.ptr<!rec_G>
+// CIR:     %[[COPY:.*]] = cir.call @_ZNK1G4copyEv(%[[LOAD_OBJ]]) : (!cir.ptr<!rec_G> {{.*}}) -> !rec_G
+// CIR:     cir.store{{.*}} %[[COPY]], %[[REF_TMP0]]
+// CIR:     cir.cleanup.scope {
+// CIR:       %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+// CIR:       cir.call @_ZN1GC1Ei(%[[REF_TMP1]], %[[ONE]]) : (!cir.ptr<!rec_G> {{.*}}, !s32i {{.*}}) -> ()
+// CIR:       cir.cleanup.scope {
+// CIR:         %[[EQUAL:.*]] = cir.call @_ZNK1GeqERKS_(%[[REF_TMP0]], %[[REF_TMP1]]) : (!cir.ptr<!rec_G> {{.*}}, !cir.ptr<!rec_G> {{.*}}) -> (!cir.bool {{.*}})
+// CIR:         cir.store{{.*}} %[[EQUAL]], %[[CLEANUP_TMP]]
+// CIR:         cir.yield
+// CIR:       } cleanup  normal {
+// CIR:         cir.call @_ZN1GD1Ev(%[[REF_TMP1]]) nothrow : (!cir.ptr<!rec_G> {{.*}}) -> ()
+// CIR:         cir.yield
+// CIR:       }
+// CIR:       cir.yield
+// CIR:     } cleanup  normal {
+// CIR:       cir.call @_ZN1GD1Ev(%[[REF_TMP0]]) nothrow : (!cir.ptr<!rec_G> {{.*}}) -> ()
+// CIR:       cir.yield
+// CIR:     }
+// CIR:     %[[CONDITION:.*]] = cir.load{{.*}} %[[CLEANUP_TMP]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:     cir.if %[[CONDITION]] {
+// CIR:       %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+// CIR:       cir.store{{.*}} %[[ONE]], %[[RET_ADDR]]
+// CIR:       %[[RETVAL:.*]] = cir.load{{.*}} %[[RET_ADDR]]
+// CIR:       cir.return %[[RETVAL]]
+// CIR:     }
+// CIR:   }
+// CIR:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR:   cir.store{{.*}} %[[ZERO]], %[[RET_ADDR]]
+// CIR:   %[[RETVAL:.*]] = cir.load{{.*}} %[[RET_ADDR]]
+// CIR:   cir.return %[[RETVAL]]
+
+// LLVM: define {{.*}} i32 @_Z22test_temp_in_conditionR1G(ptr {{.*}} %[[ARG0:.*]])
+// LLVM:   %[[REF_TMP0:.*]] = alloca %struct.G
+// LLVM:   %[[REF_TMP1:.*]] = alloca %struct.G
+// LLVM:   %[[TMP_RESULT:.*]] = alloca i8
+// LLVM:   %[[OBJ:.*]] = alloca ptr
+// LLVM:   %[[RET_ADDR:.*]] = alloca i32
+// LLVM:   store ptr %[[ARG0]], ptr %[[OBJ]]
+// LLVM:   br label %[[SCOPE_BEGIN:.*]]
+// LLVM: [[SCOPE_BEGIN]]:
+// LLVM:   %[[LOAD_OBJ:.*]] = load ptr, ptr %[[OBJ]]
+// LLVM:   %[[COPY:.*]] = call %struct.G @_ZNK1G4copyEv(ptr {{.*}} %[[LOAD_OBJ]])
+// LLVM:   store %struct.G %[[COPY]], ptr %[[REF_TMP0]]
+// LLVM:   br label %[[CLEAN_SCOPE_ONE:.*]]
+// LLVM: [[CLEAN_SCOPE_ONE]]:
+// LLVM:   call void @_ZN1GC1Ei(ptr {{.*}} %[[REF_TMP1]], i32 {{.*}} 1)
+// LLVM:   br label %[[CLEAN_SCOPE_TWO:.*]]
+// LLVM: [[CLEAN_SCOPE_TWO]]:
+// LLVM:   %[[EQUAL:.*]] = call noundef i1 @_ZNK1GeqERKS_(ptr {{.*}} %[[REF_TMP0]], ptr {{.*}} %[[REF_TMP1]])
+// LLVM:   %[[ZEXT:.*]] = zext i1 %[[EQUAL]] to i8
+// LLVM:   store i8 %[[ZEXT]], ptr %[[TMP_RESULT]]
+// LLVM:   br label %[[CLEAN_SCOPE_TWO_CLEANUP:.*]]
+// LLVM: [[CLEAN_SCOPE_TWO_CLEANUP]]:
+// LLVM:   call void @_ZN1GD1Ev(ptr {{.*}} %[[REF_TMP1]])
+// LLVM:   br label %[[EXIT_CLEAN_SCOPE_TWO:.*]]
+// LLVM: [[EXIT_CLEAN_SCOPE_TWO]]:
+// LLVM:   br label %[[CLEAN_SCOPE_ONE_CONTINUE:.*]]
+// LLVM: [[CLEAN_SCOPE_ONE_CONTINUE]]:
+// LLVM:   br label %[[CLEAN_SCOPE_ONE_CLEANUP:.*]]
+// LLVM: [[CLEAN_SCOPE_ONE_CLEANUP]]:
+// LLVM:   call void @_ZN1GD1Ev(ptr {{.*}} %[[REF_TMP0]])
+// LLVM:   br label %[[EXIT_CLEAN_SCOPE_ONE:.*]]
+// LLVM: [[EXIT_CLEAN_SCOPE_ONE]]:
+// LLVM:   br label %[[SCOPE_CONTINUE:.*]]
+// LLVM: [[SCOPE_CONTINUE]]:
+// LLVM:   %[[LOAD_RESULT:.*]] = load i8, ptr %[[TMP_RESULT]]
+// LLVM:   %[[TRUNC:.*]] = trunc i8 %[[LOAD_RESULT]] to i1
+// LLVM:   br i1 %[[TRUNC]], label %[[TRUE_BLOCK:.*]], label %[[FALSE_BLOCK:.*]]
+// LLVM: [[TRUE_BLOCK]]:
+// LLVM:   store i32 1, ptr %[[RET_ADDR]]
+// LLVM:   %[[RETVAL:.*]] = load i32, ptr %[[RET_ADDR]]
+// LLVM:   ret i32 %[[RETVAL]]
+// LLVM: [[FALSE_BLOCK]]:
+// LLVM:   br label %[[EXIT_SCOPE:.*]]
+// LLVM: [[EXIT_SCOPE]]:
+// LLVM:   store i32 0, ptr %[[RET_ADDR]]
+// LLVM:   %[[RETVAL:.*]] = load i32, ptr %[[RET_ADDR]]
+// LLVM:   ret i32 %[[RETVAL]]
+
+// OGCG: define {{.*}} i32 @_Z22test_temp_in_conditionR1G(ptr {{.*}} %[[ARG0:.*]])
+// OGCG:   %[[RET_ADDR:.*]] = alloca i32
+// OGCG:   %[[OBJ:.*]] = alloca ptr
+// OGCG:   %[[REF_TMP0:.*]] = alloca %struct.G
+// OGCG:   %[[REF_TMP1:.*]] = alloca %struct.G
+// OGCG:   store ptr %[[ARG0]], ptr %[[OBJ]]
+// OGCG:   %[[LOAD_OBJ:.*]] = load ptr, ptr %[[OBJ]]
+// OGCG:   call void @_ZNK1G4copyEv(ptr {{.*}} %[[LOAD_OBJ]])
+// OGCG:   call void @_ZN1GC1Ei(ptr {{.*}} %[[REF_TMP1]], i32 {{.*}} 1)
+// OGCG:   %[[CALL:.*]] = call noundef zeroext i1 @_ZNK1GeqERKS_(ptr {{.*}} %[[REF_TMP0]], ptr {{.*}} %[[REF_TMP1]])
+// OGCG:   call void @_ZN1GD1Ev(ptr {{.*}} %[[REF_TMP1]])
+// OGCG:   call void @_ZN1GD1Ev(ptr {{.*}} %[[REF_TMP0]])
+// OGCG:   br i1 %[[CALL]], label %[[IF_THEN:.*]], label %[[IF_END:.*]]
+// OGCG: [[IF_THEN]]:
+// OGCG:   store i32 1, ptr %[[RETVAL]]
+// OGCG:   br label %[[RETURN:.*]]
+// OGCG: [[IF_END]]:
+// OGCG:   store i32 0, ptr %[[RETVAL]]
+// OGCG:   br label %[[RETURN:.*]]
+// OGCG: [[RETURN]]:
+// OGCG:   %[[RETVAL:.*]] = load i32, ptr %[[RET_ADDR]]
+// OGCG:   ret i32 %[[RETVAL]]
 
 struct VirtualBase {
   ~VirtualBase();

--- a/clang/test/CIR/CodeGen/lambda-static-invoker.cpp
+++ b/clang/test/CIR/CodeGen/lambda-static-invoker.cpp
@@ -115,64 +115,42 @@ int g3() {
 // CIR: cir.func{{.*}} @_Z2g3v() -> (!s32i{{.*}}){{.*}} {
 // CIR:   %[[RETVAL:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
 // CIR:   %[[FN_ADDR:.*]] = cir.alloca !cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!cir.ptr<!s32i>) -> !s32i>>>, ["fn", init]
+// CIR:   %[[LAM_ALLOCA:.*]] = cir.alloca ![[REC_LAM_G3]], !cir.ptr<![[REC_LAM_G3]]>, ["ref.tmp0"]
 // CIR:   %[[TASK:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["task", init]
+// CIR:   %[[REF_TMP1:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["ref.tmp1", init]
 
 // 1. Use `operator int (*)(int const&)()` to retrieve the fnptr to `__invoke()`.
-// CIR:     %[[SCOPE_RET:.*]] = cir.scope {
-// CIR:       %[[LAM_ALLOCA:.*]] = cir.alloca ![[REC_LAM_G3]], !cir.ptr<![[REC_LAM_G3]]>, ["ref.tmp0"]
-// CIR:       %[[OPERATOR_RESULT:.*]] = cir.call @_ZZ2g3vENK3$_0cvPFiRKiEEv(%[[LAM_ALLOCA]]){{.*}}
-// CIR:       %[[PLUS:.*]] = cir.unary(plus, %[[OPERATOR_RESULT]])
-// CIR:       cir.yield %[[PLUS]]
-// CIR:     }
+// CIR:   %[[OPERATOR_RESULT:.*]] = cir.call @_ZZ2g3vENK3$_0cvPFiRKiEEv(%[[LAM_ALLOCA]]){{.*}}
+// CIR:   %[[PLUS:.*]] = cir.unary(plus, %[[OPERATOR_RESULT]])
 
 // 2. Load ptr to `__invoke()`.
-// CIR:     cir.store{{.*}} %[[SCOPE_RET]], %[[FN_ADDR]]
-// CIR:     %[[SCOPE_RET2:.*]] = cir.scope {
-// CIR:       %[[REF_TMP1:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["ref.tmp1", init]
-// CIR:       %[[FN:.*]] = cir.load{{.*}} %[[FN_ADDR]]
-// CIR:       %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
-// CIR:       cir.store{{.*}} %[[THREE]], %[[REF_TMP1]]
+// CIR:   cir.store{{.*}} %[[PLUS]], %[[FN_ADDR]]
+// CIR:   %[[FN:.*]] = cir.load{{.*}} %[[FN_ADDR]]
+// CIR:   %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
+// CIR:   cir.store{{.*}} %[[THREE]], %[[REF_TMP1]]
 
 // 3. Call `__invoke()`, which effectively executes `operator()`.
-// CIR:       %[[RESULT:.*]] = cir.call %[[FN]](%[[REF_TMP1]])
-// CIR:       cir.yield %[[RESULT]]
-// CIR:     }
-
-// CIR:     cir.store{{.*}} %[[SCOPE_RET2]], %[[TASK]]
-// CIR:     %[[TASK_RET:.*]] = cir.load{{.*}} %[[TASK]]
-// CIR:     cir.store{{.*}} %[[TASK_RET]], %[[RETVAL]]
-// CIR:     %[[RET:.*]] = cir.load{{.*}} %[[RETVAL]]
-// CIR:     cir.return %[[RET]]
-// CIR:   }
+// CIR:   %[[RESULT:.*]] = cir.call %[[FN]](%[[REF_TMP1]])
+// CIR:   cir.store{{.*}} %[[RESULT]], %[[TASK]]
+// CIR:   %[[TASK_RET:.*]] = cir.load{{.*}} %[[TASK]]
+// CIR:   cir.store{{.*}} %[[TASK_RET]], %[[RETVAL]]
+// CIR:   %[[RET:.*]] = cir.load{{.*}} %[[RETVAL]]
+// CIR:   cir.return %[[RET]]
 
 // LLVM: define dso_local {{.*}}i32 @_Z2g3v(){{.*}} {
-// LLVM:   %[[LAM_ALLOCA:.*]] = alloca %[[REC_LAM_G3]]
-// LLVM:   %[[REF_TMP1:.*]] = alloca i32
 // LLVM:   %[[RETVAL:.*]] = alloca i32
 // LLVM:   %[[FN_PTR:.*]] = alloca ptr
+// LLVM:   %[[LAM_ALLOCA:.*]] = alloca %[[REC_LAM_G3]]
 // LLVM:   %[[TASK:.*]] = alloca i32
-// LLVM:   br label %[[SCOPE_BB0:.*]]
-
-// LLVM: [[SCOPE_BB0]]:
+// LLVM:   %[[REF_TMP1:.*]] = alloca i32
 // LLVM:   %[[OPERATOR_RESULT:.*]] = call {{.*}}ptr @"_ZZ2g3vENK3$_0cvPFiRKiEEv"(ptr {{.*}} %[[LAM_ALLOCA]])
-// LLVM:   br label %[[SCOPE_BB1:.*]]
-
-// LLVM: [[SCOPE_BB1]]:
-// LLVM:   %[[TMP0:.*]] = phi ptr [ %[[OPERATOR_RESULT]], %[[SCOPE_BB0]] ]
-// LLVM:   store ptr %[[TMP0]], ptr %[[FN_PTR]]
-// LLVM:   br label %[[SCOPE_BB2:.*]]
-
-// LLVM: [[SCOPE_BB2]]:
+// LLVM:   store ptr %[[OPERATOR_RESULT]], ptr %[[FN_PTR]]
 // LLVM:   %[[FN:.*]] = load ptr, ptr %[[FN_PTR]]
 // LLVM:   store i32 3, ptr %[[REF_TMP1]]
 // LLVM:   %[[RESULT:.*]] = call {{.*}}i32 %[[FN]](ptr {{.*}} %[[REF_TMP1]])
-// LLVM:   br label %[[RET_BB:.*]]
-
-// LLVM: [[RET_BB]]:
-// LLVM:   %[[TMP1:.*]] = phi i32 [ %[[RESULT]], %[[SCOPE_BB2]] ]
-// LLVM:   store i32 %[[TMP1]], ptr %[[TASK]]
-// LLVM:   %[[TMP2:.*]] = load i32, ptr %[[TASK]]
-// LLVM:   store i32 %[[TMP2]], ptr %[[RETVAL]]
+// LLVM:   store i32 %[[RESULT]], ptr %[[TASK]]
+// LLVM:   %[[TMP:.*]] = load i32, ptr %[[TASK]]
+// LLVM:   store i32 %[[TMP]], ptr %[[RETVAL]]
 // LLVM:   %[[RET:.*]] = load i32, ptr %[[RETVAL]]
 // LLVM:   ret i32 %[[RET]]
 

--- a/clang/test/CIR/CodeGen/stmt-expr.cpp
+++ b/clang/test/CIR/CodeGen/stmt-expr.cpp
@@ -21,33 +21,27 @@ void test1() {
 }
 
 // CIR: cir.func {{.*}} @_Z5test1v()
+// CIR:   %[[REF_TMP0:.+]] = cir.alloca !rec_A, !cir.ptr<!rec_A>, ["ref.tmp0"]
+// CIR:   %[[TMP:.+]]      = cir.alloca !rec_A, !cir.ptr<!rec_A>, ["tmp"]
 // CIR:   cir.scope {
-// CIR:     %[[REF_TMP0:.+]] = cir.alloca !rec_A, !cir.ptr<!rec_A>, ["ref.tmp0"]
-// CIR:     %[[TMP:.+]]      = cir.alloca !rec_A, !cir.ptr<!rec_A>, ["tmp"]
-// CIR:     cir.scope {
-// CIR:       %[[A:.+]] = cir.alloca !rec_A, !cir.ptr<!rec_A>, ["a", init]
-// CIR:       cir.call @_ZN1AC2Ev(%[[A]]) : (!cir.ptr<!rec_A> {{.*}}) -> ()
-// CIR:       cir.call @_ZN1AC2ERS_(%[[REF_TMP0]], %[[A]]) : (!cir.ptr<!rec_A> {{.*}}, !cir.ptr<!rec_A> {{.*}}) -> ()
-// CIR:     }
-// CIR:     cir.call @_ZN1A3FooEv(%[[REF_TMP0]]) : (!cir.ptr<!rec_A> {{.*}}) -> ()
+// CIR:     %[[A:.+]] = cir.alloca !rec_A, !cir.ptr<!rec_A>, ["a", init]
+// CIR:     cir.call @_ZN1AC2Ev(%[[A]]) : (!cir.ptr<!rec_A> {{.*}}) -> ()
+// CIR:     cir.call @_ZN1AC2ERS_(%[[REF_TMP0]], %[[A]]) : (!cir.ptr<!rec_A> {{.*}}, !cir.ptr<!rec_A> {{.*}}) -> ()
 // CIR:   }
+// CIR:   cir.call @_ZN1A3FooEv(%[[REF_TMP0]]) : (!cir.ptr<!rec_A> {{.*}}) -> ()
 // CIR:   cir.return
 
 // LLVM: define dso_local void @_Z5test1v()
-// LLVM:   %[[VAR1:.+]] = alloca %class.A, i64 1
-// LLVM:   %[[VAR2:.+]] = alloca %class.A, i64 1
-// LLVM:   %[[VAR3:.+]] = alloca %class.A, i64 1
+// LLVM:   %[[A:.+]] = alloca %class.A, i64 1
+// LLVM:   %[[REF_TMP:.+]] = alloca %class.A, i64 1
+// LLVM:   %[[TMP:.+]] = alloca %class.A, i64 1
 // LLVM:   br label %[[LBL4:.+]]
 // LLVM: [[LBL4]]:
+// LLVM:     call void @_ZN1AC2Ev(ptr {{.*}} %[[A]])
+// LLVM:     call void @_ZN1AC2ERS_(ptr {{.*}} %[[REF_TMP]], ptr {{.*}} %[[A]])
 // LLVM:     br label %[[LBL5:.+]]
 // LLVM: [[LBL5]]:
-// LLVM:     call void @_ZN1AC2Ev(ptr {{.*}} %[[VAR3]])
-// LLVM:     call void @_ZN1AC2ERS_(ptr {{.*}} %[[VAR1]], ptr {{.*}} %[[VAR3]])
-// LLVM:     br label %[[LBL6:.+]]
-// LLVM: [[LBL6]]:
-// LLVM:     call void @_ZN1A3FooEv(ptr {{.*}} %[[VAR1]])
-// LLVM:     br label %[[LBL7:.+]]
-// LLVM: [[LBL7]]:
+// LLVM:     call void @_ZN1A3FooEv(ptr {{.*}} %[[REF_TMP]])
 // LLVM:     ret void
 
 // OGCG: define dso_local void @_Z5test1v()
@@ -70,7 +64,12 @@ void cleanup() {
 // CIR: cir.func {{.*}} @_Z7cleanupv()
 // CIR:   cir.scope {
 // CIR:     %[[WD:.+]] = cir.alloca !rec_with_dtor, !cir.ptr<!rec_with_dtor>, ["wd"]
-// CIR:     cir.call @_ZN9with_dtorD1Ev(%[[WD]]) nothrow : (!cir.ptr<!rec_with_dtor> {{.*}}) -> ()
+// CIR:     cir.cleanup.scope {
+// CIR:       cir.yield
+// CIR:     } cleanup normal {
+// CIR:       cir.call @_ZN9with_dtorD1Ev(%[[WD]]) nothrow : (!cir.ptr<!rec_with_dtor> {{.*}}) -> ()
+// CIR:       cir.yield
+// CIR:     }
 // CIR:   }
 // CIR:   cir.return
 

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -299,31 +299,23 @@ void struct_with_const_member_expr() {
 }
 
 // CIR: %[[A_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
-// CIR: %[[RESULT:.*]] = cir.scope {
-// CIR:   %[[REF_ADDR:.*]] = cir.alloca !rec_StructWithConstMember, !cir.ptr<!rec_StructWithConstMember>, ["ref.tmp0"]
-// CIR:   %[[ELEM_0_PTR:.*]] = cir.get_member %[[REF_ADDR]][0] {name = "a"} : !cir.ptr<!rec_StructWithConstMember> -> !cir.ptr<!u8i>
-// CIR:   %[[CONST_0:.*]] = cir.const #cir.int<0> : !s32i
-// CIR:   %[[SET_BF:.*]] = cir.set_bitfield{{.*}} (#bfi_a, %[[ELEM_0_PTR]] : !cir.ptr<!u8i>, %[[CONST_0]] : !s32i) -> !s32i
-// CIR:   %[[CONST_0:.*]] = cir.const #cir.int<0> : !s32i
-// CIR:   cir.yield %[[CONST_0]] : !s32i
-// CIR: } : !s32i
-// CIR: cir.store{{.*}} %[[RESULT]], %[[A_ADDR]] : !s32i, !cir.ptr<!s32i>
+// CIR: %[[REF_ADDR:.*]] = cir.alloca !rec_StructWithConstMember, !cir.ptr<!rec_StructWithConstMember>, ["ref.tmp0"]
+// CIR: %[[ELEM_0_PTR:.*]] = cir.get_member %[[REF_ADDR]][0] {name = "a"} : !cir.ptr<!rec_StructWithConstMember> -> !cir.ptr<!u8i>
+// CIR: %[[CONST_0:.*]] = cir.const #cir.int<0> : !s32i
+// CIR: %[[SET_BF:.*]] = cir.set_bitfield{{.*}} (#bfi_a, %[[ELEM_0_PTR]] : !cir.ptr<!u8i>, %[[CONST_0]] : !s32i) -> !s32i
+// CIR: %[[CONST_0:.*]] = cir.const #cir.int<0> : !s32i
+// CIR: cir.store{{.*}} %[[CONST_0]], %[[A_ADDR]] : !s32i, !cir.ptr<!s32i>
 
 // TODO(cir): zero-initialize the padding
 
-// LLVM:  %[[REF_ADDR:.*]] = alloca %struct.StructWithConstMember, i64 1, align 4
 // LLVM:  %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
-// LLVM:  br label %[[BF_LABEL:.*]]
-// LLVM: [[BF_LABEL]]:
+// LLVM:  %[[REF_ADDR:.*]] = alloca %struct.StructWithConstMember, i64 1, align 4
 // LLVM:  %[[ELEM_0_PTR:.*]] = getelementptr %struct.StructWithConstMember, ptr %[[REF_ADDR]], i32 0, i32 0
 // LLVM:  %[[TMP_REF:.*]] = load i8, ptr %[[ELEM_0_PTR]], align 4
 // LLVM:  %[[BF_CLEAR:.*]] = and i8 %[[TMP_REF]], -2
 // LLVM:  %[[BF_SET:.*]] = or i8 %[[BF_CLEAR]], 0
 // LLVM:  store i8 %[[BF_SET]], ptr %[[ELEM_0_PTR]], align 4
-// LLVM:  br label %[[RESULT_LABEL:.*]]
-// LLVM: [[RESULT_LABEL]]:
-// LLVM:  %[[RESULT:.*]] = phi i32 [ 0, %[[BF_LABEL]] ]
-// LLVM:  store i32 %[[RESULT]], ptr %[[A_ADDR]], align 4
+// LLVM:  store i32 0, ptr %[[A_ADDR]], align 4
 
 // OGCG: %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG: %[[REF_ADDR:.*]] = alloca %struct.StructWithConstMember, align 4


### PR DESCRIPTION
We currently encounter dominance verification errors when a value is defined inside a cleanup scope but used outside the scope. This occurs when forceCleanup() is used to exit a cleanup scope while a variable is holding a value that was created in the scope body. Classic codegen solved this problem by passing a list of values to spill and reload to forceCleanup(). This change implements that same solution for CIR.

I have also aligned the ScalarExprEmitter::VisitExprWithCleanups implementation with that of classic codegen, eliminating an extra lexical scope. This causes temporary allocas to be created at the next higher existing lexical scope, but I think that's OK since they would be hoisted there anyway by a later pass.