### PR TITLE
[APINotes][NFC] Fix typos and header comment errors

### DIFF
--- a/clang/include/clang/APINotes/APINotesReader.h
+++ b/clang/include/clang/APINotes/APINotesReader.h
@@ -33,7 +33,7 @@ class APINotesReader {
                  llvm::VersionTuple SwiftVersion, bool &Failed);
 
 public:
-  /// Create a new API notes reader from the given member buffer, which
+  /// Create a new API notes reader from the given memory buffer, which
   /// contains the contents of a binary API notes file.
   ///
   /// \returns the new API notes reader, or null if an error occurred.

--- a/clang/lib/APINotes/APINotesFormat.h
+++ b/clang/lib/APINotes/APINotesFormat.h
@@ -1,4 +1,4 @@
-//===-- APINotesFormat.h - API Notes Format ---------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/APINotes/APINotesFormat.h
+++ b/clang/lib/APINotes/APINotesFormat.h
@@ -1,4 +1,4 @@
-//===-- APINotesWriter.h - API Notes Writer ---------------------*- C++ -*-===//
+//===-- APINotesFormat.h - API Notes Format ---------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -103,7 +103,7 @@ template <> struct ScalarEnumerationTraits<NullabilityKind> {
     IO.enumCase(NK, "Optional", NullabilityKind::Nullable);
     IO.enumCase(NK, "Unspecified", NullabilityKind::Unspecified);
     IO.enumCase(NK, "NullableResult", NullabilityKind::NullableResult);
-    // TODO: Mapping this to it's own value would allow for better cross
+    // TODO: Mapping this to its own value would allow for better cross
     // checking. Also the default should be Unknown.
     IO.enumCase(NK, "Scalar", NullabilityKind::Unspecified);
 

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -911,8 +911,8 @@ static void ProcessVersionedAPINotes(
     auto Active = (i == Selected) ? IsActive_t::Active : IsActive_t::Inactive;
     auto Replacement = IsSubstitution_t::Original;
 
-    // When collection all APINotes as version-independent,
-    // capture all as inactive and defer to the client select the
+    // When collecting all APINotes as version-independent,
+    // capture all as inactive and defer to the client to select the
     // right one.
     if (S.captureSwiftVersionIndependentAPINotes()) {
       Active = IsActive_t::Inactive;


### PR DESCRIPTION
## Description

Fix minor typos and incorrect comments in the APINotes subsystem (No functional code is modified)

## Changes Made

- **`APINotesReader.h`** — Fixed `member buffer` → `memory buffer` in the `Create()` doc comment (`Create()` takes a `llvm::MemoryBuffer`)
- **`APINotesFormat.h`** — Corrected the file header comment which incorrectly referred to `APINotesWriter.h` instead of `APINotesFormat.h`
- **`APINotesYAMLCompiler.cpp`** — Fixed `it's` → `its` (possessive, not a contraction)
- **`SemaAPINotes.cpp`** — Fixed `collection` → `collecting` and added a missing `to` in `defer to the client to select`

## Motivation

First contribution to LLVM, aimed at getting familiar with the contributing workflow.