### PR TITLE
[CMake][LLVM] Disable PCH on Clang for file with custom flags too

### DIFF
--- a/llvm/lib/Analysis/CMakeLists.txt
+++ b/llvm/lib/Analysis/CMakeLists.txt
@@ -34,6 +34,10 @@ if (MSVC)
   set_source_files_properties(ConstantFolding.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   set_source_files_properties(ConstantFolding.cpp PROPERTIES COMPILE_OPTIONS "-ftrapping-math")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # Clang's -ftrapping-math may conflict with precompiled headers too, #183643.
+    set_source_files_properties(ConstantFolding.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+  endif()
 endif()
 
 add_llvm_component_library(LLVMAnalysis

--- a/llvm/lib/Analysis/CMakeLists.txt
+++ b/llvm/lib/Analysis/CMakeLists.txt
@@ -34,10 +34,8 @@ if (MSVC)
   set_source_files_properties(ConstantFolding.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   set_source_files_properties(ConstantFolding.cpp PROPERTIES COMPILE_OPTIONS "-ftrapping-math")
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    # Clang's -ftrapping-math may conflict with precompiled headers too, #183643.
-    set_source_files_properties(ConstantFolding.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
-  endif()
+  # Clang's -ftrapping-math may conflict with precompiled headers too, #183643.
+  set_source_files_properties(ConstantFolding.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 endif()
 
 add_llvm_component_library(LLVMAnalysis


### PR DESCRIPTION
Precompiled headers are already skipped when building ConstantFolding.cpp with MSVC, they cause problems with Clang too so disable it there the same way.