### PR TITLE
Fix `BuiltinTypeMethodBuilder` uninitialized pointer

### DIFF
--- a/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
+++ b/clang/lib/Sema/HLSLBuiltinTypeDeclBuilder.cpp
@@ -167,7 +167,7 @@ private:
   StorageClass SC;
   llvm::SmallVector<Param> Params;
   llvm::SmallVector<Stmt *> StmtsList;
-  TemplateParameterList *TemplateParams;
+  TemplateParameterList *TemplateParams = nullptr;
   llvm::SmallVector<NamedDecl *> TemplateParamDecls;
 
   // Argument placeholders, inspired by std::placeholder. These are the indices
@@ -202,7 +202,7 @@ public:
                            QualType ReturnTy, bool IsConst = false,
                            bool IsCtor = false, StorageClass SC = SC_None)
       : DeclBuilder(DB), Name(Name), ReturnTy(ReturnTy), Method(nullptr),
-        IsConst(IsConst), IsCtor(IsCtor), SC(SC), TemplateParams(nullptr) {}
+        IsConst(IsConst), IsCtor(IsCtor), SC(SC) {}
 
   BuiltinTypeMethodBuilder(BuiltinTypeDeclBuilder &DB, StringRef NameStr,
                            QualType ReturnTy, bool IsConst = false,


### PR DESCRIPTION
From [this comment](https://github.com/llvm/llvm-project/pull/176058/changes/BASE..50c5be4bdf19a8a80b7e6e9d3ae46e11ff20a6e0#r2856661750) on PR #176058, static analysis was flagging `TemplateParams` as not initialized on all paths. This change fixes it by initializing to `nullptr` at declaration.