### PR TITLE
[clang] Backport: create local instantiation scope for matching template template parameters

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -6501,6 +6501,8 @@ bool Sema::isTemplateTemplateParameterAtLeastAsSpecializedAs(
   if (Inst.isInvalid())
     return false;
 
+  LocalInstantiationScope Scope(*this);
+
   //   Given an invented class template X with the template parameter list of
   //   A (including default arguments):
   //    - Each function template has a single function parameter whose type is

--- a/clang/test/SemaTemplate/temp_arg_template_p0522.cpp
+++ b/clang/test/SemaTemplate/temp_arg_template_p0522.cpp
@@ -168,3 +168,10 @@ namespace GH101394 {
     // expected-note@#B  {{passing argument to parameter here}}
   } // namespace t2
 } // namespace GH101394
+
+namespace GH181166 {
+  template <template <class...> class> struct A;
+  template <template <class...> class... TT1> A<TT1...> f();
+  template <class ...Ts> struct B {};
+  using T = decltype(f<B>());
+} // namespace GH181166


### PR DESCRIPTION
This fixes a bug where a partial substitution from the enclosing scope is used to prepopulate an unrelated template argument deduction.

Backport from #183219

Fixes #181166