### PR TITLE
[mlir][test-ir-visitors] Fix noSkipBlockErasure crash with block args used across blocks

### DIFF
--- a/mlir/test/IR/visitors.mlir
+++ b/mlir/test/IR/visitors.mlir
@@ -385,7 +385,7 @@ func.func @unordered_cfg_with_loop() {
 
 // -----
 
-// The following test should not crash while visiting the intra-op blocks (inside the top level 
+// The following test should not crash while visiting the intra-op blocks (inside the top level
 // function in this case). We are testing that the intra-block ops are erased after dropping their
 // uses from ops with same parent region.
 // CHECK-LABEL: func.func @test_no_skip_block_erasure
@@ -398,4 +398,17 @@ func.func @test_no_skip_block_erasure() {
   cf.br ^bb4
 ^bb4:
   return
+}
+
+// -----
+
+// Regression test for https://github.com/llvm/llvm-project/issues/182996:
+// Block erasure must also drop uses of block arguments (e.g. function args)
+// from sibling blocks in the same region before destroying the block.
+// CHECK-LABEL: func.func @test_no_skip_block_erasure_block_args
+func.func @test_no_skip_block_erasure_block_args(%arg0: i32, %arg1: i32) -> i32 {
+  cf.br ^bb1
+^bb1:
+  %0 = arith.addi %arg0, %arg1 : i32
+  return %0 : i32
 }


### PR DESCRIPTION
The noSkipBlockErasure callback in TestVisitors.cpp dropped uses of op results within the same region before erasing a block, but did not drop uses of the block's own arguments (e.g. function entry block arguments). When the block was subsequently erased its block arguments were destroyed while their use-lists were still non-empty, triggering the assertion in IRObjectWithUseList::~IRObjectWithUseList().

Fix this by also iterating over the block's arguments and dropping any uses that belong to the same parent region. This mirrors the existing logic for op result uses and makes the block-erasure walk handle IRs where function arguments are consumed by ops in sibling blocks.

Also replace `block->front().getParentRegion()` with `block->getParent()` for robustness (avoids UB when the block has no ops).

Add a regression test based on the reproducer from https://github.com/llvm/llvm-project/issues/182996.

Fixes #182996