### PR TITLE
[Hexagon] Define __HVX_IEEE_FP__ when -mhvx-ieee-fp is enabled

### DIFF
--- a/clang/lib/Basic/Targets/Hexagon.cpp
+++ b/clang/lib/Basic/Targets/Hexagon.cpp
@@ -102,6 +102,9 @@ void HexagonTargetInfo::getTargetDefines(const LangOptions &Opts,
       Builder.defineMacro("__HVXDBL__");
   }
 
+  if (HasHVXIeeeFp)
+    Builder.defineMacro("__HVX_IEEE_FP__");
+
   if (hasFeature("audio")) {
     Builder.defineMacro("__HEXAGON_AUDIO__");
   }
@@ -148,6 +151,8 @@ bool HexagonTargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
       UseLongCalls = true;
     else if (F == "-long-calls")
       UseLongCalls = false;
+    else if (F == "+hvx-ieee-fp")
+      HasHVXIeeeFp = true;
     else if (F == "+audio")
       HasAudio = true;
   }
@@ -242,6 +247,7 @@ bool HexagonTargetInfo::hasFeature(StringRef Feature) const {
       .Case("hvx", HasHVX)
       .Case("hvx-length64b", HasHVX64B)
       .Case("hvx-length128b", HasHVX128B)
+      .Case("hvx-ieee-fp", HasHVXIeeeFp)
       .Case("long-calls", UseLongCalls)
       .Case("audio", HasAudio)
       .Default(false);

--- a/clang/lib/Basic/Targets/Hexagon.h
+++ b/clang/lib/Basic/Targets/Hexagon.h
@@ -32,6 +32,7 @@ class LLVM_LIBRARY_VISIBILITY HexagonTargetInfo : public TargetInfo {
   bool HasHVX = false;
   bool HasHVX64B = false;
   bool HasHVX128B = false;
+  bool HasHVXIeeeFp = false;
   bool HasAudio = false;
   bool UseLongCalls = false;
 

--- a/clang/test/Preprocessor/hexagon-predefines.c
+++ b/clang/test/Preprocessor/hexagon-predefines.c
@@ -105,7 +105,20 @@
 // CHECK-V68HVX-128B: #define __HVX_ARCH__ 68
 // CHECK-V68HVX-128B: #define __HVX_LENGTH__ 128
 // CHECK-V68HVX-128B: #define __HVX__ 1
+// CHECK-V68HVX-128B-NOT: #define __HVX_IEEE_FP__ 1
 // CHECK-V68HVX-128B: #define __hexagon__ 1
+
+// RUN: %clang_cc1 -E -dM -triple hexagon-unknown-elf -target-cpu hexagonv68 \
+// RUN: -target-feature +hvxv68 -target-feature +hvx-length128b \
+// RUN: -target-feature +hvx-ieee-fp %s | FileCheck \
+// RUN: %s -check-prefix CHECK-V68HVX-IEEE-FP
+// CHECK-V68HVX-IEEE-FP: #define __HEXAGON_ARCH__ 68
+// CHECK-V68HVX-IEEE-FP: #define __HEXAGON_V68__ 1
+// CHECK-V68HVX-IEEE-FP: #define __HVX_ARCH__ 68
+// CHECK-V68HVX-IEEE-FP: #define __HVX_IEEE_FP__ 1
+// CHECK-V68HVX-IEEE-FP: #define __HVX_LENGTH__ 128
+// CHECK-V68HVX-IEEE-FP: #define __HVX__ 1
+// CHECK-V68HVX-IEEE-FP: #define __hexagon__ 1
 
 // RUN: %clang_cc1 -E -dM -triple hexagon-unknown-elf -target-cpu hexagonv69 \
 // RUN: -target-feature +hvxv69 -target-feature +hvx-length128b %s | FileCheck \


### PR DESCRIPTION
Add a __HVX_IEEE_FP__ define when the compiler is invoked with -mhvx-ieee-fp flag