### PR TITLE
InstCombine: Stop applying nofpclass from use nofpclass attribute

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -3649,11 +3649,6 @@ bool InstCombinerImpl::SimplifyDemandedFPClass(Instruction *I, unsigned OpNo,
     return true;
   }
 
-  if (const CallBase *CB = dyn_cast<CallBase>(VInst)) {
-    FPClassTest NoFPClass = CB->getParamNoFPClass(U.getOperandNo());
-    DemandedMask &= ~NoFPClass;
-  }
-
   if (Depth == MaxAnalysisRecursionDepth) {
     Known.knownNot(~DemandedMask);
     return false;


### PR DESCRIPTION
Functionally reverts a80d4329ce96856a02bd279c800c3d08619da4c9, with new test.
This should be applied somewhere, but this is the wrong place.

Fixes regression reported after #182444