### PR TITLE
[llvm][DebugInfo] Bump DWARFContext maximum DWARF version

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -402,7 +402,7 @@ public:
   getLocalsForAddress(object::SectionedAddress Address) override;
 
   bool isLittleEndian() const { return DObj->isLittleEndian(); }
-  static unsigned getMaxSupportedVersion() { return 5; }
+  static unsigned getMaxSupportedVersion() { return 6; }
   static bool isSupportedVersion(unsigned version) {
     return version >= 2 && version <= getMaxSupportedVersion();
   }

--- a/llvm/test/tools/llvm-dwarfdump/X86/verify_unit_header_chain.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/verify_unit_header_chain.s
@@ -53,7 +53,7 @@ Ltu_begin0:
 	.byte 	0
 Lcu_begin1:
 	.long	10                      ## Length of Unit
-	.short	6                       ## DWARF version number -- Error: The 16 bit unit header version is not valid.
+	.short	7                       ## DWARF version number -- Error: The 16 bit unit header version is not valid.
 	.byte	1                       ## DWARF Unit Type
 	.byte	4                       ## Address Size (in bytes) -- The offset into the .debug_abbrev section is not valid.
 	.long	Lline_table_start0

--- a/llvm/test/tools/llvm-dwp/X86/cu_tu_units_manual_v5_invalid.s
+++ b/llvm/test/tools/llvm-dwp/X86/cu_tu_units_manual_v5_invalid.s
@@ -13,15 +13,15 @@
 # CHECK-NOT: .debug_info.dwo contents:
 
 # CHECK-DAG: .debug_cu_index contents:
-# CHECK: warning: Failed to parse CU header in DWP file: DWARF unit at offset 0x00000000 has unsupported version 6, supported are 2-5
+# CHECK: warning: Failed to parse CU header in DWP file: DWARF unit at offset 0x00000000 has unsupported version 7, supported are 2-6
 
 # CHECK-DAG: .debug_tu_index contents:
-# CHECK: warning: Failed to parse CU header in DWP file: DWARF unit at offset 0x00000000 has unsupported version 6, supported are 2-5
+# CHECK: warning: Failed to parse CU header in DWP file: DWARF unit at offset 0x00000000 has unsupported version 7, supported are 2-6
 
     .section	.debug_info.dwo,"e",@progbits
     .long	.Ldebug_info_dwo_end0-.Ldebug_info_dwo_start0 # Length of Unit
 .Ldebug_info_dwo_start0:
-    .short	6                               # DWARF version number
+    .short	7                               # DWARF version number
     .byte	6                               # DWARF Unit Type (DW_UT_split_type)
     .byte	8                               # Address Size (in bytes)
     .long	0                               # Offset Into Abbrev. Section
@@ -34,7 +34,7 @@
     .section	.debug_info.dwo,"e",@progbits
     .long	.Ldebug_info_dwo_end1-.Ldebug_info_dwo_start1 # Length of Unit
 .Ldebug_info_dwo_start1:
-    .short	6                               # DWARF version number
+    .short	7                               # DWARF version number
     .byte	6                               # DWARF Unit Type (DW_UT_split_type)
     .byte	8                               # Address Size (in bytes)
     .long	0                               # Offset Into Abbrev. Section
@@ -47,7 +47,7 @@
     .section	.debug_info.dwo,"e",@progbits
     .long	.Ldebug_info_dwo_end2-.Ldebug_info_dwo_start2 # Length of Unit
 .Ldebug_info_dwo_start2:
-    .short	6                               # DWARF version number
+    .short	7                               # DWARF version number
     .byte	5                               # DWARF Unit Type (DW_UT_split_compile)
     .byte	8                               # Address Size (in bytes)
     .long	0                               # Offset Into Abbrev. Section

--- a/llvm/test/tools/llvm-symbolizer/split-dwarf-dwp-invalid.test
+++ b/llvm/test/tools/llvm-symbolizer/split-dwarf-dwp-invalid.test
@@ -20,8 +20,8 @@ that skips the null entries, keeping those only as an implementation detail?) -
 or perhaps just have a separate list of offsets that have failed to parse
 previously?
 
-CHECK: warning: DWARF unit at offset 0x00000000 has unsupported version 255, supported are 2-5
-CHECK: warning: DWARF unit at offset 0x00000000 has unsupported version 255, supported are 2-5
+CHECK: warning: DWARF unit at offset 0x00000000 has unsupported version 255, supported are 2-6
+CHECK: warning: DWARF unit at offset 0x00000000 has unsupported version 255, supported are 2-6
 
 CHECK: other()
 CHECK: /usr/local/google/home/blaikie/dev/scratch{{[/\\]}}other.cpp:1:16


### PR DESCRIPTION
In order to start testing DWARFv6 feature support we need to bump this version for tooling to work.

This does not mean we officially support DWARFv6. It just enables us testing the features gradually.