### PR TITLE
[llvm][DebugInfo] Bump DWARFDebugLine maximum DWARF version

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -43,7 +43,7 @@ using ContentDescriptors = SmallVector<ContentDescriptor, 4>;
 } // end anonymous namespace
 
 static bool versionIsSupported(uint16_t Version) {
-  return Version >= 2 && Version <= 5;
+  return Version >= 2 && Version <= 6;
 }
 
 void DWARFDebugLine::ContentTypeTracker::trackContentType(

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
@@ -444,7 +444,7 @@ TEST_P(DebugLineUnsupportedVersionFixture, ErrorForUnsupportedVersion) {
 
 INSTANTIATE_TEST_SUITE_P(UnsupportedVersionTestParams,
                          DebugLineUnsupportedVersionFixture,
-                         Values(/*1 below min */ 1, /* 1 above max */ 6,
+                         Values(/*1 below min */ 1, /* 1 above max */ 7,
                                 /* Maximum possible */ 0xffff));
 
 #ifdef NO_SUPPORT_DEBUG_ADDR


### PR DESCRIPTION
Bumps `.debug_line` maximum supported version to DWARFv6.

This does not mean we officially support DWARFv6. It just enables us testing the features gradually.