### PR TITLE
[Hexagon] Support .reloc asm directive

### DIFF
--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonAsmBackend.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonAsmBackend.cpp
@@ -13,6 +13,7 @@
 #include "MCTargetDesc/HexagonMCInstrInfo.h"
 #include "MCTargetDesc/HexagonMCShuffler.h"
 #include "MCTargetDesc/HexagonMCTargetDesc.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCContext.h"
@@ -79,6 +80,21 @@ public:
     MCInst * Result = Extender;
     const_cast<HexagonAsmBackend *>(this)->Extender = nullptr;
     return Result;
+  }
+
+  std::optional<MCFixupKind> getFixupKind(StringRef Name) const override {
+    unsigned Type = llvm::StringSwitch<unsigned>(Name)
+#define ELF_RELOC(X, Y) .Case(#X, Y)
+#include "llvm/BinaryFormat/ELFRelocs/Hexagon.def"
+#undef ELF_RELOC
+                        .Case("BFD_RELOC_NONE", ELF::R_HEX_NONE)
+                        .Case("BFD_RELOC_8", ELF::R_HEX_8)
+                        .Case("BFD_RELOC_16", ELF::R_HEX_16)
+                        .Case("BFD_RELOC_32", ELF::R_HEX_32)
+                        .Default(-1u);
+    if (Type == -1u)
+      return std::nullopt;
+    return static_cast<MCFixupKind>(FirstLiteralRelocationKind + Type);
   }
 
   MCFixupKindInfo getFixupKindInfo(MCFixupKind Kind) const override {

--- a/llvm/test/MC/Hexagon/reloc-directive.s
+++ b/llvm/test/MC/Hexagon/reloc-directive.s
@@ -1,0 +1,45 @@
+# RUN: llvm-mc -triple=hexagon %s | FileCheck --check-prefix=PRINT %s
+# RUN: llvm-mc -triple=hexagon -filetype=obj %s | llvm-objdump -r - | FileCheck %s
+
+# PRINT: .reloc {{.*}}+8, R_HEX_NONE, .data
+# PRINT: .reloc {{.*}}+4, R_HEX_NONE, foo+4
+# PRINT: .reloc {{.*}}+0, R_HEX_NONE, 8
+# PRINT: .reloc {{.*}}+0, R_HEX_16, .data+2
+# PRINT: .reloc {{.*}}+0, R_HEX_32, foo+3
+# PRINT: .reloc {{.*}}+0, BFD_RELOC_NONE, 9
+# PRINT: .reloc {{.*}}+0, BFD_RELOC_16, 9
+# PRINT: .reloc {{.*}}+0, BFD_RELOC_32, 9
+.text
+  .reloc .+8, R_HEX_NONE, .data
+  .reloc .+4, R_HEX_NONE, foo+4
+  .reloc .+0, R_HEX_NONE, 8
+
+  .reloc .+0, R_HEX_8, .data+2
+  .reloc .+0, R_HEX_16, .data+2
+  .reloc .+0, R_HEX_32, foo+3
+
+  .reloc .+0, BFD_RELOC_NONE, 9
+  .reloc .+0, BFD_RELOC_8, 9
+  .reloc .+0, BFD_RELOC_16, 9
+  .reloc .+0, BFD_RELOC_32, 9
+  nop
+  nop
+  nop
+
+.data
+.globl foo
+foo:
+  .word 0
+  .word 0
+  .word 0
+
+# CHECK:      {{0+}}[[#%x,8]] R_HEX_NONE .data
+# CHECK-NEXT: {{0+}}[[#%x,4]] R_HEX_NONE foo+0x4
+# CHECK-NEXT: {{0+}} R_HEX_NONE *ABS*+0x8
+# CHECK-NEXT: {{0+}} R_HEX_8 .data+0x2
+# CHECK-NEXT: {{0+}} R_HEX_16 .data+0x2
+# CHECK-NEXT: {{0+}} R_HEX_32 foo+0x3
+# CHECK-NEXT: {{0+}} R_HEX_NONE *ABS*+0x9
+# CHECK-NEXT: {{0+}} R_HEX_8 *ABS*+0x9
+# CHECK-NEXT: {{0+}} R_HEX_16 *ABS*+0x9
+# CHECK-NEXT: {{0+}} R_HEX_32 *ABS*+0x9


### PR DESCRIPTION
.reloc directive can be used in user assembly programs and created internally by LLVM. In addition to Hexagon relocations, there are a few generic names (BFD_RELOC_NONE, BFD_RELOC_16, and BFD_RELOC_32) that are mapped to Hexagon ones.