### PR TITLE
[NFC] Fix use-after-free: track TargetLibraryAnalysis in BasicAAResult invalidation

### DIFF
--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -86,7 +86,8 @@ bool BasicAAResult::invalidate(Function &Fn, const PreservedAnalyses &PA,
   // may be created without handles to some analyses and in that case don't
   // depend on them.
   if (Inv.invalidate<AssumptionAnalysis>(Fn, PA) ||
-      (DT_ && Inv.invalidate<DominatorTreeAnalysis>(Fn, PA)))
+      (DT_ && Inv.invalidate<DominatorTreeAnalysis>(Fn, PA)) ||
+      Inv.invalidate<TargetLibraryAnalysis>(Fn, PA))
     return true;
 
   // Otherwise this analysis result remains valid.


### PR DESCRIPTION
`BasicAAResult` holds a reference to `TargetLibraryInfo` but its `invalidate()` function did not check `TargetLibraryAnalysis`. When the pass manager destroyed and re-created `TLI` (e.g. during `CGSCC` invalidation or `FAM.clear()`), `BasicAAResult` survived with a dangling `TLI` reference.

This was exposed by #157495 which added `aliasErrno()`, the first code path that dereferences `TLI` from `BasicAAResult` during the `CGSCC` pipeline, causing a AV when compiling Rust's core library on Arm64 Windows.

This change adds `TargetLibraryAnalysis` to the invalidation check so `BasicAAResult` is properly invalidated when its `TLI` reference becomes stale.