### PR TITLE
[llvm][DebugInfo] Bump DWARFListTable maximum DWARF version

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFListTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFListTable.cpp
@@ -50,7 +50,7 @@ Error DWARFListTableHeader::extract(DWARFDataExtractor Data,
   HeaderData.OffsetEntryCount = Data.getU32(OffsetPtr);
 
   // Perform basic validation of the remaining header fields.
-  if (HeaderData.Version != 5)
+  if (HeaderData.Version < 5 || HeaderData.Version > 6)
     return createStringError(errc::invalid_argument,
                        "unrecognised %s table version %" PRIu16
                        " in table at offset 0x%" PRIx64,

--- a/llvm/unittests/DebugInfo/DWARF/DWARFListTableTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFListTableTest.cpp
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/DebugInfo/DWARF/DWARFListTable.h"
+#include "llvm/Support/EndianStream.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 
@@ -98,5 +101,66 @@ TEST(DWARFListTableHeader, OffsetEntryCount) {
   EXPECT_FALSE(!!Offset1);
   EXPECT_EQ(Header.length(), sizeof(SecData) - 1);
 }
+
+struct VersionTestCase {
+  uint16_t Version;
+  bool Supported;
+};
+
+struct ListTableVersionFixture
+    : public testing::TestWithParam<VersionTestCase> {};
+
+TEST_P(ListTableVersionFixture, VersionTest) {
+  // Tests that we correctly reject unsupported DWARF versions.
+
+  const auto [Version, Supported] = GetParam();
+
+  std::string SecData;
+  llvm::raw_string_ostream OS(SecData);
+  OS.write("\x10\x00\x00\x00", 4); // Length
+  llvm::support::endian::write<uint16_t>(OS, Version, llvm::endianness::little);
+  OS.write("\x08",1 );             // Address size
+  OS.write("\x00", 1);             // Segment selector size
+  OS.write("\x01\x00\x00\x00", 4); // Offset entry count
+  OS.write("\x04\x00\x00\x00", 4); // offset[0]
+  OS.write("\x04", 1);             // DW_RLE_offset_pair
+  OS.write("\x01", 1);             // ULEB128 starting offset
+  OS.write("\x02", 1);             // ULEB128 ending offset
+  OS.write("\x00", 1);             // DW_RLE_end_of_list
+  OS.flush();
+
+  DWARFDataExtractor Extractor(SecData,
+                               /*isLittleEndian=*/true,
+                               /*AddrSize=*/4);
+  DWARFListTableHeader Header(/*SectionName=*/".debug_rnglists",
+                              /*ListTypeString=*/"range");
+  uint64_t Offset = 0;
+  auto Err = Header.extract(Extractor, &Offset);
+
+  if (Supported) {
+    EXPECT_THAT_ERROR(std::move(Err), llvm::Succeeded());
+    EXPECT_EQ(Header.getVersion(), Version);
+  } else {
+    EXPECT_THAT_ERROR(std::move(Err),
+                      llvm::FailedWithMessage(
+                          llvm::formatv("unrecognised .debug_rnglists table "
+                                        "version {0} in table at offset 0x0",
+                                        Version)
+                              .str()));
+  }
+}
+
+VersionTestCase g_version_test_cases[] = {
+    {/* 1 less than min. */ 4, false},
+    {/* 1 above max. */ 7, false},
+    {/* maximum */ 0xFFFF, false},
+
+    // Supported Versions
+    {5, true},
+    {6, true},
+};
+
+INSTANTIATE_TEST_SUITE_P(UnsupportedVersionTestParams, ListTableVersionFixture,
+                         testing::ValuesIn(g_version_test_cases));
 
 } // end anonymous namespace

--- a/llvm/unittests/DebugInfo/DWARF/DWARFListTableTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFListTableTest.cpp
@@ -119,7 +119,7 @@ TEST_P(ListTableVersionFixture, VersionTest) {
   llvm::raw_string_ostream OS(SecData);
   OS.write("\x10\x00\x00\x00", 4); // Length
   llvm::support::endian::write<uint16_t>(OS, Version, llvm::endianness::little);
-  OS.write("\x08",1 );             // Address size
+  OS.write("\x08", 1);             // Address size
   OS.write("\x00", 1);             // Segment selector size
   OS.write("\x01\x00\x00\x00", 4); // Offset entry count
   OS.write("\x04\x00\x00\x00", 4); // offset[0]


### PR DESCRIPTION
Bumps `.debug_rnglists` maximum supported version to DWARFv6.

This does not mean we officially support DWARFv6. It just enables us testing the features gradually.

Added unit-test since there was no prior test in the entire LLVM test-suite that checked this.