### PR TITLE
[SandboxVec][DAG] Handle unscheduled successors when user is external

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
@@ -523,8 +523,18 @@ void DependencyGraph::notifyEraseInstr(Instruction *I) {
 }
 
 void DependencyGraph::notifySetUse(const Use &U, Value *NewSrc) {
-  // Update the UnscheduledSuccs counter for both the current source and NewSrc
-  // if needed.
+  // If U.User is not in the DAG, then we should not attempt to decrement
+  // CurrSrcN's unscheduled successors.
+  //  -------   -------   -
+  //  CurrSrc             | DAG interval
+  //     |       NewSrc   |
+  //  ---|---   ---|---   -
+  //  U.User     U.User
+  auto *UserI = dyn_cast_or_null<Instruction>(U.getUser());
+  if (UserI == nullptr || !getNode(UserI))
+    return;
+  // Update the UnscheduledSuccs counter for both the current source and
+  // NewSrc if needed.
   if (auto *CurrSrcI = dyn_cast<Instruction>(U.get())) {
     if (auto *CurrSrcN = getNode(CurrSrcI)) {
       CurrSrcN->decrUnscheduledSuccs();

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
@@ -1190,3 +1190,44 @@ define void @foo(i8 %v0, i8 %v1) {
   Add1->setOperand(0, Add0);
   EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
 }
+
+// Make sure we maintain the unscheduled succs when the use-def edges cross the
+// DAG boundaries, i.e., when have an external user.
+TEST_F(DependencyGraphTest, MaintainUnscheduledSuccsExtUser) {
+  parseIR(C, R"IR(
+define void @foo(i8 %v0, i8 %v1) {
+  %add0 = add i8 %v0, %v1
+  %add1 = add i8 %add0, %v1
+  %extUser = add i8 %v0, 0   ; This is not in the DAG
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *Arg0 = F->getArg(0);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *Add0 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Add1 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *ExtUser = cast<sandboxir::BinaryOperator>(&*It++);
+  // DAG does not contain extUser
+  sandboxir::DependencyGraph DAG(getAA(*LLVMF), Ctx);
+  DAG.extend({Add0, Add1});
+  auto *Add0N = DAG.getNode(Add0);
+  EXPECT_EQ(DAG.getNode(ExtUser), nullptr);
+  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+
+  // Adding the use Add0->ExtUser shouldn't change Add's unscheduled succs.
+  ExtUser->setOperand(0, Add0);
+  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+  ExtUser->setOperand(0, Arg0);
+  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+
+  // Same with RUOW.
+  ExtUser->replaceUsesOfWith(Arg0, Add0);
+  EXPECT_EQ(ExtUser->getOperand(0), Add0);
+  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+  ExtUser->setOperand(0, Arg0);
+  EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
+}


### PR DESCRIPTION
Whenever an IR use-def edge gets updated, the DAG gets notified about the change by having its `notifySetUse()` callback called. The callback's job is to update the DAG node's `UnscheduledSuccs` counter which is the number of successor nodes that are yet to be scheduled. 

This update makes sense only if both ends of the use-def edge are in the DAG. Up until now we would still update the counter even if the user was outside the DAG. This patch fixes this, so from now on we skip updatinge `UnscheduledSuccs` if the user is outside the DAG.