### PR TITLE
[clang][CUDA] Allow `extern __shared__` on non-array types

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9719,6 +9719,10 @@ def err_cuda_vla : Error<
     "cannot use variable-length arrays in "
     "%select{__device__|__global__|__host__|__host__ __device__}0 functions">;
 def err_cuda_extern_shared : Error<"__shared__ variable %0 cannot be 'extern'">;
+def warn_cuda_extern_shared : Warning<
+    "'extern __shared__' variable %0 is not an incomplete array type; "
+    "NVCC accepts this but it is not standards-conforming">,
+    InGroup<DiagGroup<"cuda-extern-shared">>, DefaultIgnore;
 def err_cuda_host_shared : Error<
     "__shared__ local variables not allowed in "
     "%select{__device__|__global__|__host__|__host__ __device__}0 functions">;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5147,11 +5147,12 @@ static void handleConstantAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 static void handleSharedAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   const auto *VD = cast<VarDecl>(D);
   // extern __shared__ is only allowed on arrays with no length (e.g.
-  // "int x[]").
+  // "int x[]") per the CUDA spec. However, NVCC accepts extern __shared__
+  // on any type (commonly used for struct overlays on dynamic shared memory).
+  // We accept it too for compatibility, but can optionally warn.
   if (!S.getLangOpts().GPURelocatableDeviceCode && VD->hasExternalStorage() &&
       !isa<IncompleteArrayType>(VD->getType())) {
-    S.Diag(AL.getLoc(), diag::err_cuda_extern_shared) << VD;
-    return;
+    S.Diag(AL.getLoc(), diag::warn_cuda_extern_shared) << VD;
   }
   if (!S.CheckVarDeclSizeAddressSpace(VD, LangAS::cuda_shared))
     return;

--- a/clang/test/SemaCUDA/extern-shared.cu
+++ b/clang/test/SemaCUDA/extern-shared.cu
@@ -4,28 +4,59 @@
 // RUN: %clang_cc1 -fsyntax-only -Wundefined-internal -fgpu-rdc -verify=rdc %s
 // RUN: %clang_cc1 -fsyntax-only -Wundefined-internal -fcuda-is-device -fgpu-rdc -verify=rdc %s
 
+// RUN: %clang_cc1 -fsyntax-only -Wcuda-extern-shared -verify=warn %s
+// RUN: %clang_cc1 -fsyntax-only -Wcuda-extern-shared -fcuda-is-device -verify=warn %s
+
+// The warning is off by default, so the first two RUN lines expect no diagnostics.
+// expected-no-diagnostics
+
 // Most of these declarations are fine in separate compilation mode.
 
 #include "Inputs/cuda.h"
 
 __device__ void foo() {
-  extern __shared__ int x; // expected-error {{__shared__ variable 'x' cannot be 'extern'}}
+  // Scalar types.
+  extern __shared__ int x; // warn-warning {{'extern __shared__' variable 'x' is not an incomplete array type}}
+  extern __shared__ float f; // warn-warning {{'extern __shared__' variable 'f' is not an incomplete array type}}
+  extern __shared__ double d; // warn-warning {{'extern __shared__' variable 'd' is not an incomplete array type}}
+  extern __shared__ char c; // warn-warning {{'extern __shared__' variable 'c' is not an incomplete array type}}
+
+  // Incomplete array (the only standard-conforming form).
   extern __shared__ int arr[];  // ok
-  extern __shared__ int arr0[0]; // expected-error {{__shared__ variable 'arr0' cannot be 'extern'}}
-  extern __shared__ int arr1[1]; // expected-error {{__shared__ variable 'arr1' cannot be 'extern'}}
-  extern __shared__ int* ptr ; // expected-error {{__shared__ variable 'ptr' cannot be 'extern'}}
+  extern __shared__ float farr[]; // ok
+  extern __shared__ double darr[]; // ok
+
+  // Fixed-size arrays and pointers are not incomplete arrays.
+  extern __shared__ int arr0[0]; // warn-warning {{'extern __shared__' variable 'arr0' is not an incomplete array type}}
+  extern __shared__ int arr1[1]; // warn-warning {{'extern __shared__' variable 'arr1' is not an incomplete array type}}
+  extern __shared__ float farr1[4]; // warn-warning {{'extern __shared__' variable 'farr1' is not an incomplete array type}}
+  extern __shared__ int* ptr; // warn-warning {{'extern __shared__' variable 'ptr' is not an incomplete array type}}
 }
 
 __host__ __device__ void bar() {
   extern __shared__ int arr[];  // ok
-  extern __shared__ int arr0[0]; // expected-error {{__shared__ variable 'arr0' cannot be 'extern'}}
-  extern __shared__ int arr1[1]; // expected-error {{__shared__ variable 'arr1' cannot be 'extern'}}
-  extern __shared__ int* ptr ; // expected-error {{__shared__ variable 'ptr' cannot be 'extern'}}
+  extern __shared__ int arr0[0]; // warn-warning {{'extern __shared__' variable 'arr0' is not an incomplete array type}}
+  extern __shared__ int arr1[1]; // warn-warning {{'extern __shared__' variable 'arr1' is not an incomplete array type}}
+  extern __shared__ int* ptr; // warn-warning {{'extern __shared__' variable 'ptr' is not an incomplete array type}}
 }
 
-extern __shared__ int global; // expected-error {{__shared__ variable 'global' cannot be 'extern'}}
+extern __shared__ int global; // warn-warning {{'extern __shared__' variable 'global' is not an incomplete array type}}
 extern __shared__ int global_arr[]; // ok
-extern __shared__ int global_arr1[1]; // expected-error {{__shared__ variable 'global_arr1' cannot be 'extern'}}
+extern __shared__ int global_arr1[1]; // warn-warning {{'extern __shared__' variable 'global_arr1' is not an incomplete array type}}
+
+// Struct types (common NCCL pattern: overlay dynamic shared memory with a struct).
+struct ShmemData { int x; float y; };
+extern __shared__ ShmemData shmem; // warn-warning {{'extern __shared__' variable 'shmem' is not an incomplete array type}}
+__device__ void use_shmem() {
+  shmem.x = 1;
+  shmem.y = 2.0f;
+}
+
+// Struct incomplete array (standard-conforming alternative).
+extern __shared__ ShmemData shmem_arr[]; // ok
+__device__ void use_shmem_arr() {
+  shmem_arr[0].x = 1;
+}
 
 // Check that, iff we're not in rdc mode, extern __shared__ can appear in an
 // anonymous namespace / in a static function without generating a warning


### PR DESCRIPTION
NVCC allows `extern __shared__` on any type, not just incomplete arrays. This is commonly used in CUDA libraries like NCCL to overlay a struct on dynamically-allocated shared memory. Specifically, this diagnostic fails this line of code: https://github.com/NVIDIA/nccl/blob/361915904b456d397e6e1578f8f65ea1a45bdd28/src/device/common.h#L67

Previously, Clang rejected this with a hard error and did not add `CUDASharedAttr` to the VarDecl. This caused a cascade: `IdentifyTarget()` classified the variable as host-side, and any device code referencing it got a spurious "reference to __host__ variable in __device__ function" error.

Downgrade the error to a default-ignored warning (`-Wcuda-extern-shared`) and always add `CUDASharedAttr` so the variable is correctly classified as device-side.

Matches NVCC behaviour.