### PR TITLE
[BOLT] Remove some unused code (NFC)

### DIFF
--- a/bolt/include/bolt/Profile/DataReader.h
+++ b/bolt/include/bolt/Profile/DataReader.h
@@ -61,8 +61,6 @@ struct Location {
   friend raw_ostream &operator<<(raw_ostream &OS, const Location &Loc);
 };
 
-typedef std::vector<std::pair<Location, Location>> BranchContext;
-
 struct BranchInfo {
   Location From;
   Location To;
@@ -108,14 +106,6 @@ struct FuncBranchData {
   FuncBranchData(StringRef Name, ContainerTy Data = ContainerTy(),
                  ContainerTy EntryData = ContainerTy())
       : Name(Name), Data(std::move(Data)), EntryData(std::move(EntryData)) {}
-
-  ErrorOr<const BranchInfo &> getBranch(uint64_t From, uint64_t To) const;
-
-  /// Returns the branch info object associated with a direct call originating
-  /// from the given offset. If no branch info object is found, an error is
-  /// returned. If the offset corresponds to an indirect call the behavior is
-  /// undefined.
-  ErrorOr<const BranchInfo &> getDirectCallBranch(uint64_t From) const;
 
   /// Append the branch data of another function located \p Offset bytes away
   /// from the entry of this function.

--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -187,9 +187,6 @@ private:
   /// performing final relaxation.
   void emitAndLink();
 
-  /// Link additional runtime code to support instrumentation.
-  void linkRuntime();
-
   /// Process metadata in sections before functions are discovered.
   void processSectionMetadata();
 

--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -200,35 +200,6 @@ void BranchInfo::print(raw_ostream &OS) const {
      << '\n';
 }
 
-ErrorOr<const BranchInfo &> FuncBranchData::getBranch(uint64_t From,
-                                                      uint64_t To) const {
-  for (const BranchInfo &I : Data)
-    if (I.From.Offset == From && I.To.Offset == To && I.From.Name == I.To.Name)
-      return I;
-
-  return make_error_code(llvm::errc::invalid_argument);
-}
-
-ErrorOr<const BranchInfo &>
-FuncBranchData::getDirectCallBranch(uint64_t From) const {
-  // Commented out because it can be expensive.
-  // assert(std::is_sorted(Data.begin(), Data.end()));
-  struct Compare {
-    bool operator()(const BranchInfo &BI, const uint64_t Val) const {
-      return BI.From.Offset < Val;
-    }
-    bool operator()(const uint64_t Val, const BranchInfo &BI) const {
-      return Val < BI.From.Offset;
-    }
-  };
-  auto Range = std::equal_range(Data.begin(), Data.end(), From, Compare());
-  for (const auto &RI : llvm::make_range(Range))
-    if (RI.From.Name != RI.To.Name)
-      return RI;
-
-  return make_error_code(llvm::errc::invalid_argument);
-}
-
 void MemInfo::print(raw_ostream &OS) const {
   OS << (Offset.IsSymbol + 3) << " " << Offset.Name << " "
      << Twine::utohexstr(Offset.Offset) << " " << (Addr.IsSymbol + 3) << " "


### PR DESCRIPTION
Remove some unused code in BOLT:
- `RewriteInstance::linkRuntime` is declared but not defined
- `BranchContext` typedef is never used
- `FuncBranchData::getBranch` is defined but never used
- `FuncBranchData::getDirectCallBranch` is defined but never used