### PR TITLE
[lldb/test] Skip TestDelayInitDependency on remote platforms

### DIFF
--- a/lldb/test/API/macosx/delay-init-dependency/TestDelayInitDependency.py
+++ b/lldb/test/API/macosx/delay-init-dependency/TestDelayInitDependency.py
@@ -12,6 +12,7 @@ class TestDelayInitDependencies(TestBase):
 
     @skipUnlessDarwin
     @skipIf(macos_version=["<", "15.0"])
+    @skipIfRemote
     def test_delay_init_dependency(self):
         TestBase.setUp(self)
         out = subprocess.run(


### PR DESCRIPTION
This test exercises macOS-specific linker functionality (-delay_library) and uses a hardcoded local working directory for the launch info. It should not run against a remote platform where neither condition holds.