### PR TITLE
[AMDGPU] Add early LDS resource check before register allocation

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.h
@@ -167,6 +167,9 @@ private:
 void initializeAMDGPUPrepareAGPRAllocLegacyPass(PassRegistry &);
 extern char &AMDGPUPrepareAGPRAllocLegacyID;
 
+void initializeAMDGPUEarlyResourceCheckLegacyPass(PassRegistry &);
+extern char &AMDGPUEarlyResourceCheckLegacyID;
+
 void initializeAMDGPUReserveWWMRegsLegacyPass(PassRegistry &);
 extern char &AMDGPUReserveWWMRegsLegacyID;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUEarlyResourceCheck.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUEarlyResourceCheck.cpp
@@ -1,0 +1,122 @@
+//===-- AMDGPUEarlyResourceCheck.cpp ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Check AMDGPU resource limits (LDS size) before register allocation so we
+// fail fast instead of hanging in RA on impossible IR.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AMDGPUEarlyResourceCheck.h"
+#include "AMDGPU.h"
+#include "AMDGPUMachineFunction.h"
+#include "GCNSubtarget.h"
+#include "SIInstrInfo.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/IR/DiagnosticInfo.h"
+#include "llvm/InitializePasses.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "amdgpu-early-resource-check"
+
+namespace {
+
+class AMDGPUEarlyResourceCheckImpl {
+public:
+  bool run(MachineFunction &MF);
+};
+
+class AMDGPUEarlyResourceCheckLegacy : public MachineFunctionPass {
+public:
+  static char ID;
+
+  AMDGPUEarlyResourceCheckLegacy() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+
+  StringRef getPassName() const override {
+    return "AMDGPU Early Resource Check";
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    // We may replace the function body on resource limit violation,
+    // so we cannot claim to preserve all analyses.
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+};
+} // End anonymous namespace.
+
+INITIALIZE_PASS(AMDGPUEarlyResourceCheckLegacy, DEBUG_TYPE,
+                "AMDGPU Early Resource Check", false, false)
+
+char AMDGPUEarlyResourceCheckLegacy::ID = 0;
+
+char &llvm::AMDGPUEarlyResourceCheckLegacyID =
+    AMDGPUEarlyResourceCheckLegacy::ID;
+
+bool AMDGPUEarlyResourceCheckLegacy::runOnMachineFunction(
+    MachineFunction &MF) {
+  if (skipFunction(MF.getFunction()))
+    return false;
+
+  return AMDGPUEarlyResourceCheckImpl().run(MF);
+}
+
+PreservedAnalyses
+AMDGPUEarlyResourceCheckPass::run(MachineFunction &MF,
+                                  MachineFunctionAnalysisManager &MFAM) {
+  if (AMDGPUEarlyResourceCheckImpl().run(MF))
+    return PreservedAnalyses::none();
+  return PreservedAnalyses::all();
+}
+
+bool AMDGPUEarlyResourceCheckImpl::run(MachineFunction &MF) {
+  const AMDGPUMachineFunction *MFI = MF.getInfo<AMDGPUMachineFunction>();
+  const GCNSubtarget &STM = MF.getSubtarget<GCNSubtarget>();
+  unsigned Limit = STM.getAddressableLocalMemorySize();
+
+  // Static LDS: from globals allocated during ISel. Same check as
+  // AMDGPUAsmPrinter.cpp:1147-1153, but before RA instead of after.
+  unsigned LDSUsed = MFI->getLDSSize();
+
+  // Dynamic LDS: frontends that use zero-size LDS globals with runtime
+  // allocation (e.g. Triton) communicate the expected size via function
+  // attribute. The dynamic allocation is ON TOP of any static allocation,
+  // so we add them.
+  const Function &F = MF.getFunction();
+  Attribute DynAttr = F.getFnAttribute("amdgpu-dynamic-lds-bytes");
+  if (DynAttr.isStringAttribute()) {
+    unsigned DynLDS = 0;
+    DynAttr.getValueAsString().getAsInteger(0, DynLDS);
+    LDSUsed += DynLDS;
+  }
+
+  if (LDSUsed > Limit) {
+    LLVMContext &Ctx = F.getContext();
+    DiagnosticInfoResourceLimit Diag(F, "local memory", LDSUsed, Limit,
+                                     DS_Error);
+    Ctx.diagnose(Diag);
+
+    // Replace the function body with a minimal stub (single S_ENDPGM) so
+    // that subsequent passes -- especially register allocation -- don't hang
+    // trying to compile impossible IR. The diagnostic handler records the
+    // error; the caller checks for it after the pass pipeline completes.
+    const SIInstrInfo *TII = STM.getInstrInfo();
+    while (!MF.empty())
+      MF.erase(MF.begin());
+    MachineBasicBlock *MBB = MF.CreateMachineBasicBlock();
+    MF.push_back(MBB);
+    BuildMI(*MBB, MBB->end(), DebugLoc(), TII->get(AMDGPU::S_ENDPGM))
+        .addImm(0);
+
+    return true;
+  }
+
+  return false;
+}

--- a/llvm/lib/Target/AMDGPU/AMDGPUEarlyResourceCheck.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUEarlyResourceCheck.h
@@ -1,0 +1,23 @@
+//===- AMDGPUEarlyResourceCheck.h -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_AMDGPU_AMDGPUEARLYRESOURCECHECK_H
+#define LLVM_LIB_TARGET_AMDGPU_AMDGPUEARLYRESOURCECHECK_H
+
+#include "llvm/CodeGen/MachinePassManager.h"
+
+namespace llvm {
+class AMDGPUEarlyResourceCheckPass
+    : public PassInfoMixin<AMDGPUEarlyResourceCheckPass> {
+public:
+  PreservedAnalyses run(MachineFunction &MF,
+                        MachineFunctionAnalysisManager &MFAM);
+};
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_AMDGPU_AMDGPUEARLYRESOURCECHECK_H

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -28,6 +28,7 @@
 #include "AMDGPUMacroFusion.h"
 #include "AMDGPUPerfHintAnalysis.h"
 #include "AMDGPUPreloadKernArgProlog.h"
+#include "AMDGPUEarlyResourceCheck.h"
 #include "AMDGPUPrepareAGPRAlloc.h"
 #include "AMDGPURemoveIncompatibleFunctions.h"
 #include "AMDGPUReserveWWMRegs.h"
@@ -622,6 +623,7 @@ extern "C" LLVM_ABI LLVM_EXTERNAL_VISIBILITY void LLVMInitializeAMDGPUTarget() {
   initializeAMDGPUAsmPrinterPass(*PR);
   initializeAMDGPUDAGToDAGISelLegacyPass(*PR);
   initializeAMDGPUPrepareAGPRAllocLegacyPass(*PR);
+  initializeAMDGPUEarlyResourceCheckLegacyPass(*PR);
   initializeGCNDPPCombineLegacyPass(*PR);
   initializeSILowerI1CopiesLegacyPass(*PR);
   initializeAMDGPUGlobalISelDivergenceLoweringPass(*PR);
@@ -1660,6 +1662,11 @@ void GCNPassConfig::addFastRegAlloc() {
 }
 
 void GCNPassConfig::addPreRegAlloc() {
+  // Check resource limits before RA. This is unconditional (safety, not
+  // optimization) -- without it, kernels exceeding LDS limits cause RA to
+  // hang instead of reporting an error.
+  addPass(&AMDGPUEarlyResourceCheckLegacyID);
+
   if (getOptLevel() != CodeGenOptLevel::None)
     addPass(&AMDGPUPrepareAGPRAllocLegacyID);
 }
@@ -2476,6 +2483,8 @@ Error AMDGPUCodeGenPassBuilder::addOptimizedRegAlloc(
 }
 
 void AMDGPUCodeGenPassBuilder::addPreRegAlloc(PassManagerWrapper &PMW) const {
+  addMachineFunctionPass(AMDGPUEarlyResourceCheckPass(), PMW);
+
   if (getOptLevel() != CodeGenOptLevel::None)
     addMachineFunctionPass(AMDGPUPrepareAGPRAllocPass(), PMW);
 }

--- a/llvm/lib/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/CMakeLists.txt
@@ -79,6 +79,7 @@ add_llvm_target(AMDGPUCodeGen
   AMDGPULowerKernelAttributes.cpp
   AMDGPULowerModuleLDSPass.cpp
   AMDGPUPrepareAGPRAlloc.cpp
+  AMDGPUEarlyResourceCheck.cpp
   AMDGPULowerExecSync.cpp
   AMDGPUSwLowerLDS.cpp
   AMDGPUMachineFunction.cpp


### PR DESCRIPTION
The existing LDS limit check in `AMDGPUAsmPrinter::getSIProgramInfo()` runs after register allocation. When a kernel requests more LDS than the hardware supports, RA can hang indefinitely on impossible IR before the check ever runs.

This adds `AMDGPUEarlyResourceCheck`, a `MachineFunctionPass` that runs the same `DiagnosticInfoResourceLimit` check in `addPreRegAlloc()`. `AMDGPUMachineFunction::LDSSize` is fully computed during ISel, so it's available at this point. Also reads an optional `amdgpu-dynamic-lds-bytes` function attribute for frontends that use runtime LDS allocation.

On violation, replaces the function body with `S_ENDPGM` so subsequent passes don't choke on the impossible IR.