### PR TITLE
[CMake] Use keyword signature in two additional callsites

### DIFF
--- a/lld/tools/lld/CMakeLists.txt
+++ b/lld/tools/lld/CMakeLists.txt
@@ -13,7 +13,7 @@ export_executable_symbols_for_plugins(lld)
 
 function(lld_target_link_libraries target type)
   if (TARGET obj.${target})
-    target_link_libraries(obj.${target} ${ARGN})
+    target_link_libraries(obj.${target} ${type} ${ARGN})
   endif()
 
   get_property(LLVM_DRIVER_TOOLS GLOBAL PROPERTY LLVM_DRIVER_TOOLS)

--- a/llvm/cmake/modules/LLVM-Config.cmake
+++ b/llvm/cmake/modules/LLVM-Config.cmake
@@ -106,7 +106,10 @@ function(explicit_llvm_config executable)
   get_target_property(t ${executable} TYPE)
   if(t STREQUAL "STATIC_LIBRARY")
     target_link_libraries(${executable} INTERFACE ${LIBRARIES})
-  elseif(t STREQUAL "EXECUTABLE" OR t STREQUAL "SHARED_LIBRARY" OR t STREQUAL "MODULE_LIBRARY")
+  elseif(t STREQUAL "EXECUTABLE" OR
+         t STREQUAL "SHARED_LIBRARY" OR
+         t STREQUAL "MODULE_LIBRARY" OR
+         t STREQUAL "OBJECT_LIBRARY")
     target_link_libraries(${executable} PRIVATE ${LIBRARIES})
   else()
     # Use plain form for legacy user.


### PR DESCRIPTION
Fix-forward for https://github.com/llvm/llvm-project/pull/183541.
Two callsites to target_link_libraries were not migrated to the
keyword signature.