### PR TITLE
RISCVMCAsmInfo: Remove redundant `UseAtForSpecifier = false`. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
@@ -27,7 +27,6 @@ RISCVMCAsmInfo::RISCVMCAsmInfo(const Triple &TT) {
   AlignmentIsInBytes = false;
   SupportsDebugInformation = true;
   ExceptionsType = ExceptionHandling::DwarfCFI;
-  UseAtForSpecifier = false;
   Data16bitsDirective = "\t.half\t";
   Data32bitsDirective = "\t.word\t";
 }


### PR DESCRIPTION
UseAtForSpecifier defaults to false in MCAsmInfo, and RISCVMCAsmInfo
never calls initializeAtSpecifiers (which sets it to true).