### PR TITLE
[llvm][DebugInfo] Emit DW_LNAME_Assembly for DWARFv6 assembly CUs

### DIFF
--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -1097,9 +1097,10 @@ static void EmitGenDwarfInfo(MCStreamer *MCOS,
     MCOS->emitBytes(StringRef("llvm-mc (based on LLVM " PACKAGE_VERSION ")"));
   MCOS->emitInt8(0); // NULL byte to terminate the string.
 
-  if (context.getDwarfVersion() >= 6)
+  if (context.getDwarfVersion() >= 6) {
+    // AT_language_name, a 4 byte value.
     MCOS->emitInt16(dwarf::DW_LNAME_Assembly);
-  else {
+  } else {
     // AT_language, a 4 byte value.  We use DW_LANG_Mips_Assembler as the dwarf2
     // draft has no standard code for assembler.
     // FIXME: dwarf4 has DW_LANG_Assembly which we could use instead.

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -860,7 +860,12 @@ static void EmitGenDwarfAbbrev(MCStreamer *MCOS) {
   if (!DwarfDebugFlags.empty())
     EmitAbbrev(MCOS, dwarf::DW_AT_APPLE_flags, dwarf::DW_FORM_string);
   EmitAbbrev(MCOS, dwarf::DW_AT_producer, dwarf::DW_FORM_string);
-  EmitAbbrev(MCOS, dwarf::DW_AT_language, dwarf::DW_FORM_data2);
+
+  if (context.getDwarfVersion() >= 6)
+    EmitAbbrev(MCOS, dwarf::DW_AT_language_name, dwarf::DW_FORM_data2);
+  else
+    EmitAbbrev(MCOS, dwarf::DW_AT_language, dwarf::DW_FORM_data2);
+
   EmitAbbrev(MCOS, 0, 0);
 
   // DW_TAG_label DIE abbrev (2).
@@ -1092,9 +1097,14 @@ static void EmitGenDwarfInfo(MCStreamer *MCOS,
     MCOS->emitBytes(StringRef("llvm-mc (based on LLVM " PACKAGE_VERSION ")"));
   MCOS->emitInt8(0); // NULL byte to terminate the string.
 
-  // AT_language, a 4 byte value.  We use DW_LANG_Mips_Assembler as the dwarf2
-  // draft has no standard code for assembler.
-  MCOS->emitInt16(dwarf::DW_LANG_Mips_Assembler);
+  if (context.getDwarfVersion() >= 6)
+    MCOS->emitInt16(dwarf::DW_LNAME_Assembly);
+  else {
+    // AT_language, a 4 byte value.  We use DW_LANG_Mips_Assembler as the dwarf2
+    // draft has no standard code for assembler.
+    // FIXME: dwarf4 has DW_LANG_Assembly which we could use instead.
+    MCOS->emitInt16(dwarf::DW_LANG_Mips_Assembler);
+  }
 
   // Third part: the list of label DIEs.
 

--- a/llvm/test/DebugInfo/AArch64/asm-cu-language.s
+++ b/llvm/test/DebugInfo/AArch64/asm-cu-language.s
@@ -1,0 +1,20 @@
+// RUN: llvm-mc -dwarf-version=2 -g -triple i386-apple-darwin10 %s -filetype=obj -o - \
+// RUN:     | llvm-dwarfdump --debug-abbrev --debug-info - | FileCheck %s --check-prefix=DWARF2
+
+// RUN: llvm-mc -dwarf-version=4 -g -triple i386-apple-darwin10 %s -filetype=obj -o - \
+// RUN:     | llvm-dwarfdump --debug-abbrev --debug-info - | FileCheck %s --check-prefix=DWARF4
+
+// RUN: llvm-mc -dwarf-version=6 -g -triple i386-apple-darwin10 %s -filetype=obj -o - \
+// RUN:     | llvm-dwarfdump --debug-abbrev --debug-info - | FileCheck %s --check-prefix=DWARF6
+
+_main:
+	nop
+
+// DWARF2:  DW_AT_language DW_FORM_data2
+// DWARF2:  DW_AT_language (DW_LANG_Mips_Assembler)
+
+// DWARF4:  DW_AT_language DW_FORM_data2
+// DWARF4:  DW_AT_language (DW_LANG_Mips_Assembler)
+
+// DWARF6:  DW_AT_language_name DW_FORM_data2
+// DWARF6:  DW_AT_language_name (DW_LNAME_Assembly)

--- a/llvm/test/DebugInfo/AArch64/asm-cu-language.s
+++ b/llvm/test/DebugInfo/AArch64/asm-cu-language.s
@@ -1,10 +1,10 @@
-// RUN: llvm-mc -dwarf-version=2 -g -triple i386-apple-darwin10 %s -filetype=obj -o - \
+// RUN: llvm-mc -dwarf-version=2 -g -triple aarch64-apple-darwin10 %s -filetype=obj -o - \
 // RUN:     | llvm-dwarfdump --debug-abbrev --debug-info - | FileCheck %s --check-prefix=DWARF2
 
-// RUN: llvm-mc -dwarf-version=4 -g -triple i386-apple-darwin10 %s -filetype=obj -o - \
+// RUN: llvm-mc -dwarf-version=4 -g -triple aarch64-apple-darwin10 %s -filetype=obj -o - \
 // RUN:     | llvm-dwarfdump --debug-abbrev --debug-info - | FileCheck %s --check-prefix=DWARF4
 
-// RUN: llvm-mc -dwarf-version=6 -g -triple i386-apple-darwin10 %s -filetype=obj -o - \
+// RUN: llvm-mc -dwarf-version=6 -g -triple aarch64-apple-darwin10 %s -filetype=obj -o - \
 // RUN:     | llvm-dwarfdump --debug-abbrev --debug-info - | FileCheck %s --check-prefix=DWARF6
 
 _main:


### PR DESCRIPTION
Use the new DWARFv6 language code for assembly CUs. While we have a `DW_LANG_Assembly` pre-DWARFv6 I kept the `DW_LANG_Mips_Assembler` pre-DWARFv6 for now (I added a FIXME if we want to address it).