### PR TITLE
[flang] Use std::uintptr_t instead of unsigned long for better cross-platform stability

### DIFF
--- a/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
@@ -253,31 +253,17 @@ constexpr TypeBuilderFunc getModel<void (*)(int)>() {
 }
 template <>
 constexpr TypeBuilderFunc
-getModel<void *(*)(void *, const void *, unsigned long)>() {
+getModel<void *(*)(void *, const void *, std::uintptr_t)>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {
     auto voidPtrTy =
         fir::LLVMPointerType::get(context, mlir::IntegerType::get(context, 8));
-    auto unsignedLongTy =
-        mlir::IntegerType::get(context, 8 * sizeof(unsigned long));
+    auto uintPtrTy =
+        mlir::IntegerType::get(context, 8 * sizeof(std::uintptr_t));
     auto funcTy = mlir::FunctionType::get(
-        context, {voidPtrTy, voidPtrTy, unsignedLongTy}, {voidPtrTy});
+        context, {voidPtrTy, voidPtrTy, uintPtrTy}, {voidPtrTy});
     return fir::LLVMPointerType::get(context, funcTy);
   };
 }
-#ifdef _MSC_VER
-template <>
-constexpr TypeBuilderFunc
-getModel<void *(*)(void *, const void *, unsigned __int64)>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
-    auto voidPtrTy =
-        fir::LLVMPointerType::get(context, mlir::IntegerType::get(context, 8));
-    auto uint64Ty = mlir::IntegerType::get(context, 64);
-    auto funcTy = mlir::FunctionType::get(
-        context, {voidPtrTy, voidPtrTy, uint64Ty}, {voidPtrTy});
-    return fir::LLVMPointerType::get(context, funcTy);
-  };
-}
-#endif
 template <>
 constexpr TypeBuilderFunc getModel<void (*)(void)>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {


### PR DESCRIPTION
Originally, the specialization hardcode unsigned long, and add another specialization of unsigned __int64 for MSVC. This is redundant, and will fails when compiling on MSYS2 (where uintptr_t is unsigned long long)