### PR TITLE
[BOLT] Enable compatibility of instrumentation-file-append-pid with instrumentation-sleep-time

### DIFF
--- a/bolt/lib/RuntimeLibs/InstrumentationRuntimeLibrary.cpp
+++ b/bolt/lib/RuntimeLibs/InstrumentationRuntimeLibrary.cpp
@@ -66,13 +66,11 @@ void InstrumentationRuntimeLibrary::adjustCommandLineOptions(
     exit(1);
   }
 
-  if ((opts::InstrumentationWaitForks || opts::InstrumentationSleepTime) &&
-      opts::InstrumentationFileAppendPID) {
-    errs()
-        << "BOLT-ERROR: instrumentation-file-append-pid is not compatible with "
-           "instrumentation-sleep-time and instrumentation-wait-forks. If you "
-           "want a separate profile for each fork, it can only be dumped in "
-           "the end of process when instrumentation-file-append-pid is used.\n";
+  if (opts::InstrumentationWaitForks && opts::InstrumentationFileAppendPID) {
+    errs() << "BOLT-ERROR: instrumentation-file-append-pid is not compatible "
+              "with instrumentation-wait-forks. If you want a separate profile "
+              "for each fork, it can only be dumped in the end of process when "
+              "instrumentation-file-append-pid is used.\n";
     exit(1);
   }
 }

--- a/bolt/runtime/instr.cpp
+++ b/bolt/runtime/instr.cpp
@@ -1671,7 +1671,7 @@ extern "C" void __attribute((force_align_arg_pointer)) __bolt_instr_setup() {
   DEBUG(reportNumber("replace mmap stop: ", CountersEnd, 16));
   assert(CountersEnd > CountersStart, "no counters");
 
-  const bool Shared = !__bolt_instr_use_pid;
+  const bool Shared = !__bolt_instr_use_pid | !!__bolt_instr_sleep_time;
   const uint64_t MapPrivateOrShared = Shared ? MAP_SHARED : MAP_PRIVATE;
 
   void *Ret =


### PR DESCRIPTION
This commit enables compatibility of instrumentation-file-append-pid and instrumentation-sleep-time options. It also requires keeping the counters mapping between the watcher process and the instrumented binary process in shared mode. This is useful when we instrument a shared library that is used by several tasks running on the target system. In case when we cannot wait for every task to complete, we must use the sleep-time option. Without append-pid option, we would overwrite the profile at the same path but collected from different tasks, leading to unexpected or suboptimal optimization effects.