### PR TITLE
[Clang][Sema][Builtins] Check argument count for `__builtin_allow_sanitize_check`

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -302,6 +302,7 @@ Bug Fixes in This Version
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- Fixed a crash when calling `__builtin_allow_sanitize_check` with no arguments. (#GH183927)
 
 Bug Fixes to Attribute Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -3804,6 +3804,9 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
   }
 
   case Builtin::BI__builtin_allow_sanitize_check: {
+    if (checkArgCount(TheCall, 1))
+      return ExprError();
+
     Expr *Arg = TheCall->getArg(0);
     // Check if the argument is a string literal.
     const StringLiteral *SanitizerName =

--- a/clang/test/Sema/builtin-allow-sanitize-check.c
+++ b/clang/test/Sema/builtin-allow-sanitize-check.c
@@ -1,6 +1,9 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
 
 void test_builtin_allow_sanitize_check() {
+  // Test with no arguments.
+  (void)__builtin_allow_sanitize_check(); // expected-error {{too few arguments to function call, expected 1, have 0}}
+
   // Test with non-string literal argument.
   char str[] = "address";
   (void)__builtin_allow_sanitize_check(str); // expected-error {{expression is not a string literal}}


### PR DESCRIPTION
Fixes #183501.

The crash was due to calling `getArg(0)` without validating there was at least one argument. Since `__builtin_allow_sanitize_check` has the `CustomTypeChecking` attribute, it requires checking the argument count explicitely.