### PR TITLE
[clang][Sema] Diagnose use of variably modified type alias from enclosing scope in local class

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -14038,4 +14038,9 @@ def err_cuda_device_kernel_launch_not_supported
 def err_cuda_device_kernel_launch_require_rdc
     : Error<"kernel launch from __device__ or __global__ function requires "
             "relocatable device code (i.e. requires -fgpu-rdc)">;
+
+def err_vmt_declared_outside_of_local_class : Error<
+  "variably modified type %0 from enclosing scope cannot be used in local class %1">;
+def note_vmt_type_declared_here : Note<
+  "type declared here">;
 } // end of sema component.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -14608,6 +14608,15 @@ public:
   bool DiagnoseUnexpandedParameterPack(TemplateArgumentLoc Arg,
                                        UnexpandedParameterPackContext UPPC);
 
+  /// If the given type is a variably modified type from an enclosing scope
+  /// used inside a local class method, diagnose the error.
+  ///
+  /// \param T The type of the declaration or expression being checked.
+  /// \param Loc The source location, used for diagnostics.
+  ///
+  /// \returns true if an error was diagnosed, false otherwise.
+  bool DiagnoseVLAInLocalClass(QualType T, SourceLocation Loc);
+
   /// Collect the set of unexpanded parameter packs within the given
   /// template argument.
   ///

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1493,8 +1493,10 @@ CodeGenFunction::EmitAutoVarAlloca(const VarDecl &D) {
   CharUnits alignment = getContext().getDeclAlign(&D);
 
   // If the type is variably-modified, emit all the VLA sizes for it.
-  if (Ty->isVariablyModifiedType())
-    EmitVariablyModifiedType(Ty);
+  if (Ty->isVariablyModifiedType()) {
+    QualType DesugaredTy = Ty.getDesugaredType(getContext());
+    EmitVariablyModifiedType(DesugaredTy);
+  }
 
   auto *DI = getDebugInfo();
   bool EmitDebugInfo = DI && CGM.getCodeGenOpts().hasReducedDebugInfo();

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -2978,3 +2978,28 @@ Attr *Sema::CreateAnnotationAttr(const ParsedAttr &AL) {
 
   return CreateAnnotationAttr(AL, Str, Args);
 }
+
+bool Sema::DiagnoseVLAInLocalClass(QualType T, SourceLocation Loc) {
+  if (T.isNull() || !T->isVariablyModifiedType())
+    return false;
+
+  const auto *TT = dyn_cast<TypedefType>(T.getTypePtr());
+  if (!TT)
+    return false;
+
+  const auto *MD = dyn_cast<CXXMethodDecl>(CurContext);
+  if (!MD)
+    return false;
+
+  const CXXRecordDecl *RD = MD->getParent();
+  if (!RD->isLocalClass())
+    return false;
+
+  const TypedefNameDecl *TD = TT->getDecl();
+  if (TD->getDeclContext()->getRedeclContext()->Equals(RD))
+    return false;
+
+  Diag(Loc, diag::err_vmt_declared_outside_of_local_class) << T << RD;
+  Diag(TD->getLocation(), diag::note_vmt_type_declared_here);
+  return true;
+}

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -6513,6 +6513,9 @@ NamedDecl *Sema::HandleDeclarator(Scope *S, Declarator &D,
   TypeSourceInfo *TInfo = GetTypeForDeclarator(D);
   QualType R = TInfo->getType();
 
+  if (DiagnoseVLAInLocalClass(R, D.getIdentifierLoc()))
+    D.setInvalidType();
+
   if (DiagnoseUnexpandedParameterPack(D.getIdentifierLoc(), TInfo,
                                       UPPC_DeclarationType))
     D.setInvalidType();

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -4865,6 +4865,8 @@ Sema::ActOnUnaryExprOrTypeTraitExpr(SourceLocation OpLoc,
   if (IsType) {
     TypeSourceInfo *TInfo;
     (void) GetTypeFromParser(ParsedType::getFromOpaquePtr(TyOrEx), &TInfo);
+    if (TInfo)
+      DiagnoseVLAInLocalClass(TInfo->getType(), OpLoc);
     return CreateUnaryExprOrTypeTraitExpr(TInfo, OpLoc, ExprKind, ArgRange);
   }
 

--- a/clang/test/CodeGenCXX/vla-alias-local-struct.cpp
+++ b/clang/test/CodeGenCXX/vla-alias-local-struct.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -std=gnu++20 -emit-llvm %s -o - >/dev/null
+
+int f() { return 1; }
+
+int test0() {
+  using X = int[f()];
+
+  struct S {
+    S() {
+      X x;
+    }
+  } s;
+
+  return 0;
+}

--- a/clang/test/SemaCXX/vla-alias-local-class.cpp
+++ b/clang/test/SemaCXX/vla-alias-local-class.cpp
@@ -1,0 +1,70 @@
+// RUN: %clang_cc1 -std=gnu++20 -verify %s
+
+int foo();
+
+// VLA alias used in normal function scope — no error.
+int test0() {
+  using X = int[foo()];
+  X x;
+  return 0;
+}
+
+// VLA alias declared inside the local class itself — no error.
+int test1() {
+  struct S {
+    using X = int[foo()];
+    S() { X x; }
+  };
+  return 0;
+}
+
+// VLA alias from enclosing scope used as a variable in a local class
+int test3() {
+  using X = int[foo()]; // expected-note {{type declared here}}
+  struct S {
+    S() {
+      X x; // expected-error {{variably modified type 'X' (aka 'int[f()]') from enclosing scope cannot be used in local class 'S'}}
+    }
+  };
+  return 0;
+}
+
+// VLA typedef alias from enclosing scope used as a variable in a local class
+int test4() {
+  typedef int X[foo()]; // expected-note {{type declared here}}
+  struct S {
+    S() {
+      X x; // expected-error {{variably modified type 'X' (aka 'int[f()]') from enclosing scope cannot be used in local class 'S'}}
+    }
+  };
+  return 0;
+}
+
+// VLA alias from enclosing scope used in sizeof inside a local class method
+int test5() {
+  using X = int[foo()]; // expected-note {{type declared here}}
+  struct S {
+    int method() {
+      return sizeof(X); // expected-error {{variably modified type 'X' (aka 'int[f()]') from enclosing scope cannot be used in local class 'S'}}
+    }
+  };
+  return 0;
+}
+
+// VLA alias from enclosing scope used in sizeof in an overriding method
+int bar(int&);
+struct IFace {
+  virtual int a() = 0;
+  virtual ~IFace();
+};
+
+IFace *bad_sizeof_override() {
+  int z = 10;
+  using X = int[bar(z)]; // expected-note {{type declared here}}
+  struct S : public IFace {
+    int a() override {
+      return sizeof(X); // expected-error {{variably modified type 'X' (aka 'int[f_param(z)]') from enclosing scope cannot be used in local class 'S'}}
+    }
+  };
+  return new S;
+}


### PR DESCRIPTION
When a VLA type is hidden behind a type alias and used as a local variable inside a local class or struct constructor, CodeGen could fail to emit VLA size information, leading to an assertion failure in getVLASize().

Desugar the variable type before emitting variably-modified type information.

Add a regression test.