### PR TITLE
[mlir][CFGToSCF] Fix crash when region contains unconvertible multi-successor op

### DIFF
--- a/mlir/include/mlir/Conversion/ControlFlowToSCF/ControlFlowToSCF.h
+++ b/mlir/include/mlir/Conversion/ControlFlowToSCF/ControlFlowToSCF.h
@@ -24,6 +24,10 @@ class Pass;
 /// operations to SCF Dialect operations.
 class ControlFlowToSCFTransformation : public CFGToSCFInterface {
 public:
+  /// Returns true only for `cf.cond_br` and `cf.switch`, the two multi-
+  /// successor ops this transformation knows how to convert.
+  bool canConvertMultiSuccessorBranchOp(Operation *op) override;
+
   /// Creates an `scf.if` op if `controlFlowCondOp` is a `cf.cond_br` op or
   /// an `scf.index_switch` if `controlFlowCondOp` is a `cf.switch`.
   /// Returns failure otherwise.

--- a/mlir/include/mlir/Transforms/CFGToSCF.h
+++ b/mlir/include/mlir/Transforms/CFGToSCF.h
@@ -96,6 +96,12 @@ public:
   /// control-flow paths where an SSA-value is undefined.
   virtual Value getUndefValue(Location loc, OpBuilder &builder, Type type) = 0;
 
+  /// Returns true if this operation (which has >1 successors) can be
+  /// converted to structured control flow by `createStructuredBranchRegionOp`.
+  /// Called during precondition checking, before any IR modifications.
+  /// Default implementation accepts all ops.
+  virtual bool canConvertMultiSuccessorBranchOp(Operation *op) { return true; }
+
   /// Creates a return-like terminator indicating unreachable.
   /// This is required when the transformation encounters a statically known
   /// infinite loop. Since structured control flow ops are not terminators,

--- a/mlir/lib/Conversion/ControlFlowToSCF/ControlFlowToSCF.cpp
+++ b/mlir/lib/Conversion/ControlFlowToSCF/ControlFlowToSCF.cpp
@@ -27,6 +27,11 @@ namespace mlir {
 
 using namespace mlir;
 
+bool ControlFlowToSCFTransformation::canConvertMultiSuccessorBranchOp(
+    Operation *op) {
+  return isa<cf::CondBranchOp, cf::SwitchOp>(op);
+}
+
 FailureOr<Operation *>
 ControlFlowToSCFTransformation::createStructuredBranchRegionOp(
     OpBuilder &builder, Operation *controlFlowCondOp, TypeRange resultTypes,

--- a/mlir/lib/Transforms/Utils/CFGToSCF.cpp
+++ b/mlir/lib/Transforms/Utils/CFGToSCF.cpp
@@ -1235,7 +1235,8 @@ static ReturnLikeExitCombiner createSingleExitBlocksForReturnLike(
 
 /// Checks all preconditions of the transformation prior to any transformations.
 /// Returns failure if any precondition is violated.
-static LogicalResult checkTransformationPreconditions(Region &region) {
+static LogicalResult
+checkTransformationPreconditions(Region &region, CFGToSCFInterface &interface) {
   for (Block &block : region.getBlocks())
     if (block.hasNoPredecessors() && !block.isEntryBlock())
       return block.front().emitOpError(
@@ -1279,7 +1280,21 @@ static LogicalResult checkTransformationPreconditions(Region &region) {
     }
     return WalkResult::advance();
   });
-  return failure(result.wasInterrupted());
+  if (result.wasInterrupted())
+    return failure();
+
+  // Verify all multi-successor terminators are convertible before touching IR.
+  for (Block &block : region.getBlocks()) {
+    if (block.getNumSuccessors() <= 1)
+      continue;
+    Operation *terminator = block.getTerminator();
+    if (!interface.canConvertMultiSuccessorBranchOp(terminator)) {
+      terminator->emitOpError(
+          "cannot convert unknown control flow op to structured control flow");
+      return failure();
+    }
+  }
+  return success();
 }
 
 FailureOr<bool> mlir::transformCFGToSCF(Region &region,
@@ -1288,7 +1303,7 @@ FailureOr<bool> mlir::transformCFGToSCF(Region &region,
   if (region.empty() || region.hasOneBlock())
     return false;
 
-  if (failed(checkTransformationPreconditions(region)))
+  if (failed(checkTransformationPreconditions(region, interface)))
     return failure();
 
   DenseMap<Type, Value> typedUndefCache;

--- a/mlir/test/Conversion/ControlFlowToSCF/invalid.mlir
+++ b/mlir/test/Conversion/ControlFlowToSCF/invalid.mlir
@@ -1,0 +1,18 @@
+// RUN: mlir-opt --lift-cf-to-scf -split-input-file --verify-diagnostics %s
+
+// Regression test: spirv.BranchConditional inside a spirv.mlir.loop region
+// must produce a clean diagnostic rather than an assertion crash.
+
+func.func @spirv_loop_no_crash(%cond: i1) {
+  spirv.mlir.loop {
+    spirv.Branch ^bb1
+  ^bb1:
+    // expected-error@below {{cannot convert unknown control flow op to structured control flow}}
+    spirv.BranchConditional %cond, ^bb2, ^bb3
+  ^bb2:
+    spirv.Branch ^bb1
+  ^bb3:
+    spirv.mlir.merge
+  }
+  return
+}

--- a/mlir/test/Conversion/ControlFlowToSCF/unknown-cf-op.mlir
+++ b/mlir/test/Conversion/ControlFlowToSCF/unknown-cf-op.mlir
@@ -20,7 +20,7 @@ func.func private @unknown_cf_in_loop(%arg0: f32) -> (i32, i32) {
     spirv.Branch ^bb1(%cst0_i32, %cst-1_i32 : i32, i32)
   ^bb1(%3: i32, %4: i32):  // 2 preds: ^bb0, ^bb2
     %5 = spirv.SLessThan %3, %cst-1_i32 : i32
-    // expected-error@below {{'spirv.BranchConditional' op Cannot convert unknown control flow op to structured control flow}}
+    // expected-error@below {{'spirv.BranchConditional' op cannot convert unknown control flow op to structured control flow}}
     spirv.BranchConditional %5, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
     %6 = spirv.IAdd %3, %4 : i32


### PR DESCRIPTION
`transformCFGToSCF` would crash with a use-list assertion when it encountered an op like `spirv.BranchConditional` that implements `BranchOpInterface` (passing the existing precondition checks) but is not handled by `createStructuredBranchRegionOp`. The algorithm mutated the IR significantly before discovering the op was unsupported, leaving it in a corrupt half-transformed state that triggered the assertion on teardown.

Fix by adding `canConvertBranchOp` to `CFGToSCFInterface` (default: accept all ops) and calling it inside `checkTransformationPreconditions` for every block with more than one successor, before any IR modifications are made. `ControlFlowToSCFTransformation` overrides the method to accept only `cf.cond_br` and `cf.switch`.

Add a regression test covering `spirv.BranchConditional` inside a `spirv.mlir.loop` region nested in a `func.func`.

Fixes #173566

Assisted-by: Claude Code