### PR TITLE
[clang] use typo-corrected name qualifier for expressions

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -2738,6 +2738,13 @@ bool Sema::DiagnoseEmptyLookup(Scope *S, CXXScopeSpec &SS, LookupResult &R,
                          << DroppedSpecifier << NameRange,
                      PDiag(NoteID), AcceptableWithRecovery);
 
+      if (Corrected.WillReplaceSpecifier()) {
+        NestedNameSpecifier NNS = Corrected.getCorrectionSpecifier();
+        // In order to be valid, a non-empty CXXScopeSpec needs a source range.
+        SS.MakeTrivial(Context, NNS,
+                       NNS ? NameRange.getBegin() : SourceRange());
+      }
+
       // Tell the callee whether to try to recover.
       return !AcceptableWithRecovery;
     }

--- a/clang/test/ParserOpenACC/parse-constructs.cpp
+++ b/clang/test/ParserOpenACC/parse-constructs.cpp
@@ -18,13 +18,13 @@ namespace NS {
 #pragma acc routine(NS::foo) seq
 
 // expected-error@+2{{use of undeclared identifier 'templ'; did you mean 'NS::templ'?}}
-// expected-error@+1{{OpenACC routine name 'templ' names a set of overloads}}
+// expected-error@+1{{OpenACC routine name 'NS::templ' names a set of overloads}}
 #pragma acc routine(templ) seq
 // expected-error@+1{{OpenACC routine name 'NS::templ' names a set of overloads}}
 #pragma acc routine(NS::templ) seq
 
 // expected-error@+2{{use of undeclared identifier 'templ'; did you mean 'NS::templ'?}}
-// expected-error@+1{{OpenACC routine name 'templ<int>' names a set of overloads}}
+// expected-error@+1{{OpenACC routine name 'NS::templ<int>' names a set of overloads}}
 #pragma acc routine(templ<int>) seq
 // expected-error@+1{{OpenACC routine name 'NS::templ<int>' names a set of overloads}}
 #pragma acc routine(NS::templ<int>) seq

--- a/clang/test/SemaCXX/GH175783.cpp
+++ b/clang/test/SemaCXX/GH175783.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -fspell-checking-limit=0 -verify %s
+
+namespace GH175783 {
+  class B {
+  public:
+    virtual void foo(); // #foo
+  };
+  void (*p)() = &GH175783::foo;
+  // expected-error@-1 {{no member named 'foo' in namespace 'GH175783'; did you mean 'B::foo'?}}
+  // expected-error@-2 {{cannot initialize a variable of type 'void (*)()' with an rvalue of type 'void (B::*)()'}}
+  // expected-note@#foo {{'B::foo' declared here}}
+} // namespace GH175783


### PR DESCRIPTION
Fixes #175783