### PR TITLE
[clang-tidy][NFC] Add `getCommentsInRange` utility

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/LexerUtils.h
+++ b/clang-tools-extra/clang-tidy/utils/LexerUtils.h
@@ -120,6 +120,11 @@ struct CommentToken {
   StringRef Text;
 };
 
+/// Returns all comment tokens found in the given range.
+std::vector<CommentToken> getCommentsInRange(CharSourceRange Range,
+                                             const SourceManager &SM,
+                                             const LangOptions &LangOpts);
+
 /// Returns comment tokens found in the given range. If a non-comment token is
 /// encountered, clears previously collected comments and continues.
 std::vector<CommentToken>


### PR DESCRIPTION
Introduce `getCommentsInRange` in `LexerUtils` and refactor `getTrailingCommentsInRange` to reuse a shared comment collector with mode-based behavior. Add unit tests for all-comments behavior and preserve existing trailing-comment semantics.