### PR TITLE
[mlir][spirv] Fix crash when spirv.struct member type is not a SPIR-V type

### DIFF
--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
@@ -774,6 +774,11 @@ static Type parseStructType(SPIRVDialect const &dialect,
     Type memberType;
     if (parser.parseType(memberType))
       return Type();
+    if (!isa<SPIRVType>(memberType)) {
+      parser.emitError(parser.getNameLoc(),
+                       "member type must be a valid SPIR-V type");
+      return Type();
+    }
     memberTypes.push_back(memberType);
 
     if (succeeded(parser.parseOptionalLSquare()))

--- a/mlir/test/Dialect/SPIRV/IR/types.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/types.mlir
@@ -384,6 +384,12 @@ func.func private @struct_missing_member_decorator_value(!spirv.struct<(!spirv.m
 
 // -----
 
+// Regression test for https://github.com/llvm/llvm-project/issues/179675
+// expected-error @+1 {{member type must be a valid SPIR-V type}}
+func.func private @struct_type_non_spirv_member(!spirv.struct<(vector<2x2xi1>)>) -> ()
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // StructType (identified)
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
When parsing a spirv.struct type, any MLIR type was accepted as a member type without validation. This caused a crash in TypeExtensionVisitor and TypeCapabilityVisitor which unconditionally used cast<SPIRVType> on struct element types, asserting when a non-SPIR-V type (e.g., vector<2x2xi1>) was encountered.

Fix the parser to reject non-SPIR-V member types with a proper error message.

Fixes #179675