### PR TITLE
[mlir][scf] Fix crash in ForOp verifier when body block has no arguments

### DIFF
--- a/mlir/test/Dialect/SCF/invalid.mlir
+++ b/mlir/test/Dialect/SCF/invalid.mlir
@@ -835,3 +835,18 @@ func.func @invalid_reference(%a: index) {
   }
   return
 }
+
+// -----
+
+// Regression test for https://github.com/llvm/llvm-project/issues/159737
+// A scf.for whose body block has no arguments used to crash in
+// getRegionIterArgs() via verifyLoopLikeOpInterface instead of producing a
+// proper diagnostic.
+func.func @for_missing_induction_var(%arg0: index, %arg1: index) {
+  %c1 = arith.constant 1 : index
+  // expected-error@+1 {{expected body to have at least 1 argument(s) for the induction variable, but got 0}}
+  "scf.for"(%arg0, %arg1, %c1) ({
+    "scf.yield"() : () -> ()
+  }) : (index, index, index) -> ()
+  return
+}


### PR DESCRIPTION
A malformed `scf.for` whose body block contains no arguments caused `getRegionIterArgs()` to crash via an out-of-bounds `drop_front(1)` call. This happened because `verifyLoopLikeOpInterface` (a `verifyRegionTrait`) invokes `getRegionIterArgs()` during `verifyRegionInvariants`, which runs before `verifyRegions()` has a chance to report a proper diagnostic.

Fix by adding an explicit check in `ForOp::verify()` (which runs in `verifyInvariants`, before any region trait verifiers execute) that ensures the body block has at least as many arguments as there are induction variables. This prevents the crash and produces a clear error message.

Fixes #159737