### PR TITLE
[lldb][Process/FreeBSDKernelCore] Fix RegisterContext for arm64

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm64.cpp
@@ -101,7 +101,7 @@ bool RegisterContextFreeBSDKernelCore_arm64::ReadRegister(
       // The pc of crashing thread is stored in lr.
       static_assert(gpr_lr_arm64 - gpr_x19_arm64 == PCB_LR,
                     "nonconsecutive arm64 register numbers");
-      value = pcb.x[reg - gpr_x19_arm64];
+      value = pcb.x[gpr_lr_arm64 - gpr_x19_arm64];
       break;
     case gpr_sp_arm64:
       value = pcb.sp;
@@ -151,12 +151,13 @@ bool RegisterContextFreeBSDKernelCore_arm64::ReadRegister(
                     "nonconsecutive arm64 register numbers");
       value = pcb13.x[reg - gpr_x0_arm64];
       break;
-    case gpr_sp_arm64:
-      value = pcb13.sp;
-      break;
+    case gpr_lr_arm64:
     case gpr_pc_arm64:
       // The pc of crashing thread is stored in lr.
       value = pcb13.lr;
+      break;
+    case gpr_sp_arm64:
+      value = pcb13.sp;
       break;
     default:
       return false;

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm64.cpp
@@ -96,15 +96,14 @@ bool RegisterContextFreeBSDKernelCore_arm64::ReadRegister(
                     "nonconsecutive arm64 register numbers");
       value = pcb.x[reg - gpr_x19_arm64];
       break;
-    case gpr_lr_arm64:
+    case gpr_sp_arm64:
+      value = pcb.sp;
+      break;
     case gpr_pc_arm64:
       // The pc of crashing thread is stored in lr.
       static_assert(gpr_lr_arm64 - gpr_x19_arm64 == PCB_LR,
                     "nonconsecutive arm64 register numbers");
       value = pcb.x[gpr_lr_arm64 - gpr_x19_arm64];
-      break;
-    case gpr_sp_arm64:
-      value = pcb.sp;
       break;
     default:
       return false;
@@ -151,13 +150,12 @@ bool RegisterContextFreeBSDKernelCore_arm64::ReadRegister(
                     "nonconsecutive arm64 register numbers");
       value = pcb13.x[reg - gpr_x0_arm64];
       break;
-    case gpr_lr_arm64:
+    case gpr_sp_arm64:
+      value = pcb13.sp;
+      break;
     case gpr_pc_arm64:
       // The pc of crashing thread is stored in lr.
       value = pcb13.lr;
-      break;
-    case gpr_sp_arm64:
-      value = pcb13.sp;
       break;
     default:
       return false;


### PR DESCRIPTION
Since `pcb.lr` always contains the value of pc, `gpr_lr_arm64` should be unavailable. This also fixes the case where `gpr_pc_arm64` displays sp not lr field in pcb.

Reported by: jrtc27
Fixes: 4f0eb3d3af443ff54425ebafce83b87ee61ee403 (#180222)