### PR TITLE
[MLIR] Remove `let constructor = ` from mlir/include/mlir/Transforms/Passes.td

### DIFF
--- a/mlir/include/mlir/Transforms/Passes.h
+++ b/mlir/include/mlir/Transforms/Passes.h
@@ -32,28 +32,25 @@ class GreedyRewriteConfig;
 //===----------------------------------------------------------------------===//
 
 #define GEN_PASS_DECL_BUBBLEDOWNMEMORYSPACECASTS
-#define GEN_PASS_DECL_CSE
-#define GEN_PASS_DECL_CANONICALIZER
+#define GEN_PASS_DECL_CSEPASS
+#define GEN_PASS_DECL_CANONICALIZERPASS
 #define GEN_PASS_DECL_COMPOSITEFIXEDPOINTPASS
-#define GEN_PASS_DECL_CONTROLFLOWSINK
-#define GEN_PASS_DECL_GENERATERUNTIMEVERIFICATION
-#define GEN_PASS_DECL_LOOPINVARIANTCODEMOTION
-#define GEN_PASS_DECL_INLINER
+#define GEN_PASS_DECL_CONTROLFLOWSINKPASS
+#define GEN_PASS_DECL_GENERATERUNTIMEVERIFICATIONPASS
+#define GEN_PASS_DECL_LOOPINVARIANTCODEMOTIONPASS
+#define GEN_PASS_DECL_LOOPINVARIANTSUBSETHOISTINGPASS
+#define GEN_PASS_DECL_INLINERPASS
 #define GEN_PASS_DECL_MEM2REG
 #define GEN_PASS_DECL_PRINTIRPASS
-#define GEN_PASS_DECL_PRINTOPSTATS
-#define GEN_PASS_DECL_REMOVEDEADVALUES
-#define GEN_PASS_DECL_SCCP
+#define GEN_PASS_DECL_PRINTOPSTATSPASS
+#define GEN_PASS_DECL_REMOVEDEADVALUESPASS
+#define GEN_PASS_DECL_SCCPPASS
 #define GEN_PASS_DECL_SROA
-#define GEN_PASS_DECL_STRIPDEBUGINFO
-#define GEN_PASS_DECL_SYMBOLDCE
-#define GEN_PASS_DECL_SYMBOLPRIVATIZE
-#define GEN_PASS_DECL_TOPOLOGICALSORT
+#define GEN_PASS_DECL_STRIPDEBUGINFOPASS
+#define GEN_PASS_DECL_SYMBOLDCEPASS
+#define GEN_PASS_DECL_SYMBOLPRIVATIZEPASS
+#define GEN_PASS_DECL_TOPOLOGICALSORTPASS
 #include "mlir/Transforms/Passes.h.inc"
-
-/// Creates an instance of the Canonicalizer pass, configured with default
-/// settings (which can be overridden by pass options on the command line).
-std::unique_ptr<Pass> createCanonicalizerPass();
 
 /// Creates an instance of the Canonicalizer pass with the specified config.
 /// `disabledPatterns` is a set of labels used to filter out input patterns with
@@ -68,39 +65,6 @@ createCanonicalizerPass(const GreedyRewriteConfig &config,
                         ArrayRef<std::string> disabledPatterns = {},
                         ArrayRef<std::string> enabledPatterns = {});
 
-/// Creates a pass to perform control-flow sinking.
-std::unique_ptr<Pass> createControlFlowSinkPass();
-
-/// Creates a pass to perform common sub expression elimination.
-std::unique_ptr<Pass> createCSEPass();
-
-/// Creates a pass to print IR on the debug stream.
-std::unique_ptr<Pass> createPrintIRPass(const PrintIRPassOptions & = {});
-
-/// Creates a pass that generates IR to verify ops at runtime.
-std::unique_ptr<Pass> createGenerateRuntimeVerificationPass();
-
-/// Creates a loop invariant code motion pass that hoists loop invariant
-/// instructions out of the loop.
-std::unique_ptr<Pass> createLoopInvariantCodeMotionPass();
-
-/// Creates a pass that hoists loop-invariant subset ops.
-std::unique_ptr<Pass> createLoopInvariantSubsetHoistingPass();
-
-/// Creates a pass to strip debug information from a function.
-std::unique_ptr<Pass> createStripDebugInfoPass();
-
-/// Creates a pass which prints the list of ops and the number of occurrences in
-/// the module.
-std::unique_ptr<Pass> createPrintOpStatsPass(raw_ostream &os = llvm::errs());
-
-/// Creates a pass which prints the list of ops and the number of occurrences in
-/// the module with the output format option.
-std::unique_ptr<Pass> createPrintOpStatsPass(raw_ostream &os, bool printAsJSON);
-
-/// Creates a pass which inlines calls and callable operations as defined by
-/// the CallGraph.
-std::unique_ptr<Pass> createInlinerPass();
 /// Creates an instance of the inliner pass, and use the provided pass managers
 /// when optimizing callable operations with names matching the key type.
 /// Callable operations with a name not within the provided map will use the
@@ -115,26 +79,13 @@ std::unique_ptr<Pass>
 createInlinerPass(llvm::StringMap<OpPassManager> opPipelines,
                   std::function<void(OpPassManager &)> defaultPipelineBuilder);
 
-/// Creates an optimization pass to remove dead values.
-std::unique_ptr<Pass> createRemoveDeadValuesPass();
+/// Creates a pass which prints the list of ops and the number of occurrences in
+/// the module.
+std::unique_ptr<Pass> createPrintOpStatsPass(raw_ostream &os);
 
-/// Creates a pass which performs sparse conditional constant propagation over
-/// nested operations.
-std::unique_ptr<Pass> createSCCPPass();
-
-/// Creates a pass which delete symbol operations that are unreachable. This
-/// pass may *only* be scheduled on an operation that defines a SymbolTable.
-std::unique_ptr<Pass> createSymbolDCEPass();
-
-/// Creates a pass which marks top-level symbol operations as `private` unless
-/// listed in `excludeSymbols`.
-std::unique_ptr<Pass>
-createSymbolPrivatizePass(ArrayRef<std::string> excludeSymbols = {});
-
-/// Creates a pass that recursively sorts nested regions without SSA dominance
-/// topologically such that, as much as possible, users of values appear after
-/// their producers.
-std::unique_ptr<Pass> createTopologicalSortPass();
+/// Creates a pass which prints the list of ops and the number of occurrences in
+/// the module with the output format option.
+std::unique_ptr<Pass> createPrintOpStatsPass(raw_ostream &os, bool printAsJSON);
 
 /// Create composite pass, which runs provided set of passes until fixed point
 /// or maximum number of iterations reached.

--- a/mlir/include/mlir/Transforms/Passes.td
+++ b/mlir/include/mlir/Transforms/Passes.td
@@ -16,7 +16,7 @@
 include "mlir/Pass/PassBase.td"
 include "mlir/Rewrite/PassUtil.td"
 
-def Canonicalizer : Pass<"canonicalize"> {
+def CanonicalizerPass : Pass<"canonicalize"> {
   let summary = "Canonicalize operations";
   let description = [{
     This pass performs various types of canonicalizations over a set of
@@ -27,7 +27,6 @@ def Canonicalizer : Pass<"canonicalize"> {
     pass. See [Operation Canonicalization](Canonicalization.md) for more
     details.
   }];
-  let constructor = "mlir::createCanonicalizerPass()";
   let options = [
     Option<"topDownProcessingEnabled", "top-down", "bool",
            /*default=*/"true",
@@ -53,7 +52,7 @@ def Canonicalizer : Pass<"canonicalize"> {
   ] # RewritePassUtils.options;
 }
 
-def ControlFlowSink : Pass<"control-flow-sink"> {
+def ControlFlowSinkPass : Pass<"control-flow-sink"> {
   let summary = "Sink operations into conditional blocks";
   let description = [{
     This pass implements control-flow sink on operations that implement
@@ -71,13 +70,12 @@ def ControlFlowSink : Pass<"control-flow-sink"> {
     blocks: ops in unreachable blocks may prevent other operations from being
     sunk as they may contain uses of their results
   }];
-  let constructor = "::mlir::createControlFlowSinkPass()";
   let statistics = [
     Statistic<"numSunk", "num-sunk", "Number of operations sunk">,
   ];
 }
 
-def CSE : Pass<"cse"> {
+def CSEPass : Pass<"cse"> {
   let summary = "Eliminate common sub-expressions";
   let description = [{
     This pass implements a generalized algorithm for common sub-expression
@@ -86,14 +84,13 @@ def CSE : Pass<"cse"> {
     operations. See [Common subexpression elimination](https://en.wikipedia.org/wiki/Common_subexpression_elimination)
     for more general details on this optimization.
   }];
-  let constructor = "mlir::createCSEPass()";
   let statistics = [
     Statistic<"numCSE", "num-cse'd", "Number of operations CSE'd">,
     Statistic<"numDCE", "num-dce'd", "Number of operations DCE'd">
   ];
 }
 
-def RemoveDeadValues : Pass<"remove-dead-values"> {
+def RemoveDeadValuesPass : Pass<"remove-dead-values"> {
   let summary = "Remove dead values";
   let description = [{
     The goal of this pass is optimization (reducing runtime) by removing
@@ -257,7 +254,6 @@ def RemoveDeadValues : Pass<"remove-dead-values"> {
     Option<"canonicalize", "canonicalize", "bool", /*default=*/"true",
            "Canonicalize region branch ops">,
   ];
-  let constructor = "mlir::createRemoveDeadValuesPass()";
   let dependentDialects = ["ub::UBDialect"];
 }
 
@@ -267,20 +263,18 @@ def PrintIRPass : Pass<"print-ir"> {
     Print the entire IR on the debug stream. This is meant for debugging
     purposes to inspect the IR at a specific point in the pipeline.
   }];
-  let constructor = "mlir::createPrintIRPass()";
   let options = [
     Option<"label", "label", "std::string", /*default=*/"", "Label">,
   ];
 }
 
-def GenerateRuntimeVerification : Pass<"generate-runtime-verification"> {
+def GenerateRuntimeVerificationPass : Pass<"generate-runtime-verification"> {
   let summary = "Generate additional runtime op verification checks";
   let description = [{
     This pass generates op-specific runtime checks using the
     `RuntimeVerifiableOpInterface`. It can be run for debugging purposes after
     passes that are suspected to introduce faulty IR.
   }];
-  let constructor = "mlir::createGenerateRuntimeVerificationPass()";
   let options = [
     Option<"verboseLevel", "verbose-level", "unsigned", /*default=*/"1",
            "Verbosity level for runtime verification messages: "
@@ -290,9 +284,8 @@ def GenerateRuntimeVerification : Pass<"generate-runtime-verification"> {
 }
 
 
-def Inliner : Pass<"inline"> {
+def InlinerPass : Pass<"inline"> {
   let summary = "Inline function calls";
-  let constructor = "mlir::createInlinerPass()";
   let options = [
     Option<"defaultPipelineStr", "default-pipeline", "std::string",
            /*default=*/"\"canonicalize\"",
@@ -367,14 +360,12 @@ def LocationSnapshot : Pass<"snapshot-op-locations"> {
   ];
 }
 
-def LoopInvariantCodeMotion : Pass<"loop-invariant-code-motion"> {
+def LoopInvariantCodeMotionPass : Pass<"loop-invariant-code-motion"> {
   let summary = "Hoist loop invariant instructions outside of the loop";
-  let constructor = "mlir::createLoopInvariantCodeMotionPass()";
 }
 
-def LoopInvariantSubsetHoisting : Pass<"loop-invariant-subset-hoisting"> {
+def LoopInvariantSubsetHoistingPass : Pass<"loop-invariant-subset-hoisting"> {
   let summary = "Hoist loop invariant subset ops outside of the loop";
-  let constructor = "mlir::createLoopInvariantSubsetHoistingPass()";
 }
 
 def Mem2Reg : Pass<"mem2reg"> {
@@ -411,16 +402,15 @@ def Mem2Reg : Pass<"mem2reg"> {
   ];
 }
 
-def PrintOpStats : Pass<"print-op-stats"> {
+def PrintOpStatsPass : Pass<"print-op-stats"> {
   let summary = "Print statistics of operations";
-  let constructor = "mlir::createPrintOpStatsPass()";
   let options = [
     Option<"printAsJSON", "json", "bool", /*default=*/"false",
            "print the stats as JSON">
   ];
 }
 
-def SCCP : Pass<"sccp"> {
+def SCCPPass : Pass<"sccp"> {
   let summary = "Sparse Conditional Constant Propagation";
   let description = [{
     This pass implements a general algorithm for sparse conditional constant
@@ -431,7 +421,6 @@ def SCCP : Pass<"sccp"> {
     This implementation is based on the algorithm described by Wegman and Zadeck
     in [“Constant Propagation with Conditional Branches”](https://dl.acm.org/doi/10.1145/103135.103136) (1991).
   }];
-  let constructor = "mlir::createSCCPPass()";
 }
 
 def SROA : Pass<"sroa"> {
@@ -470,16 +459,15 @@ def SROA : Pass<"sroa"> {
   ];
 }
 
-def StripDebugInfo : Pass<"strip-debuginfo"> {
+def StripDebugInfoPass : Pass<"strip-debuginfo"> {
   let summary = "Strip debug info from all operations";
   let description = [{
     This pass strips the IR of any location information, by replacing all
     operation locations with [`unknown`](Dialects/Builtin.md/#unknownloc).
   }];
-  let constructor = "mlir::createStripDebugInfoPass()";
 }
 
-def SymbolDCE : Pass<"symbol-dce"> {
+def SymbolDCEPass : Pass<"symbol-dce"> {
   let summary = "Eliminate dead symbols";
   let description = [{
     This pass deletes all symbols that are found to be unreachable. This is done
@@ -519,14 +507,12 @@ def SymbolDCE : Pass<"symbol-dce"> {
     See [Symbols and SymbolTables](SymbolsAndSymbolTables.md) for more
     information on `Symbols`.
   }];
-  let constructor = "mlir::createSymbolDCEPass()";
-
   let statistics = [
     Statistic<"numDCE", "num-dce'd", "Number of symbols DCE'd">,
   ];
 }
 
-def SymbolPrivatize : Pass<"symbol-privatize"> {
+def SymbolPrivatizePass : Pass<"symbol-privatize"> {
   let summary = "Mark symbols private";
   let description = [{
     This pass marks all top-level symbols of the operation run as `private`
@@ -536,10 +522,9 @@ def SymbolPrivatize : Pass<"symbol-privatize"> {
     ListOption<"exclude", "exclude", "std::string",
        "Comma separated list of symbols that should not be marked private">
   ];
-  let constructor = "mlir::createSymbolPrivatizePass()";
 }
 
-def ViewOpGraph : Pass<"view-op-graph"> {
+def ViewOpGraphPass : Pass<"view-op-graph"> {
   let summary = "Print Graphviz visualization of an operation";
   let description = [{
     This pass prints a Graphviz graph of a module.
@@ -566,10 +551,9 @@ def ViewOpGraph : Pass<"view-op-graph"> {
     Option<"printResultTypes", "print-result-types", "bool",
             /*default=*/"true", "Print result types of operations">
   ];
-  let constructor = "mlir::createPrintOpGraphPass()";
 }
 
-def TopologicalSort : Pass<"topological-sort"> {
+def TopologicalSortPass : Pass<"topological-sort"> {
   let summary = "Sort regions without SSA dominance in topological order";
   let description = [{
     Recursively sorts all nested regions without SSA dominance in topological
@@ -583,7 +567,6 @@ def TopologicalSort : Pass<"topological-sort"> {
     regions in a stable order.
   }];
 
-  let constructor = "mlir::createTopologicalSortPass()";
 }
 
 def CompositeFixedPointPass : Pass<"composite-fixed-point-pass"> {

--- a/mlir/include/mlir/Transforms/ViewOpGraph.h
+++ b/mlir/include/mlir/Transforms/ViewOpGraph.h
@@ -19,11 +19,11 @@
 namespace mlir {
 class Pass;
 
-#define GEN_PASS_DECL_VIEWOPGRAPH
+#define GEN_PASS_DECL_VIEWOPGRAPHPASS
 #include "mlir/Transforms/Passes.h.inc"
 
-/// Creates a pass to print op graphs.
-std::unique_ptr<Pass> createPrintOpGraphPass(raw_ostream &os = llvm::errs());
+/// Creates a pass to print op graphs with the specified output stream.
+std::unique_ptr<Pass> createViewOpGraphPass(raw_ostream &os);
 
 } // namespace mlir
 

--- a/mlir/lib/Transforms/CSE.cpp
+++ b/mlir/lib/Transforms/CSE.cpp
@@ -25,7 +25,7 @@
 #include <deque>
 
 namespace mlir {
-#define GEN_PASS_DEF_CSE
+#define GEN_PASS_DEF_CSEPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -384,7 +384,7 @@ void mlir::eliminateCommonSubExpressions(RewriterBase &rewriter,
 
 namespace {
 /// CSE pass.
-struct CSE : public impl::CSEBase<CSE> {
+struct CSE : public impl::CSEPassBase<CSE> {
   void runOnOperation() override;
 };
 } // namespace
@@ -408,5 +408,3 @@ void CSE::runOnOperation() {
   // preserved.
   markAnalysesPreserved<DominanceInfo, PostDominanceInfo>();
 }
-
-std::unique_ptr<Pass> mlir::createCSEPass() { return std::make_unique<CSE>(); }

--- a/mlir/lib/Transforms/Canonicalizer.cpp
+++ b/mlir/lib/Transforms/Canonicalizer.cpp
@@ -17,7 +17,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CANONICALIZER
+#define GEN_PASS_DEF_CANONICALIZERPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -25,8 +25,8 @@ using namespace mlir;
 
 namespace {
 /// Canonicalize operations in nested regions.
-struct Canonicalizer : public impl::CanonicalizerBase<Canonicalizer> {
-  Canonicalizer() = default;
+struct Canonicalizer : public impl::CanonicalizerPassBase<Canonicalizer> {
+  using impl::CanonicalizerPassBase<Canonicalizer>::CanonicalizerPassBase;
   Canonicalizer(const GreedyRewriteConfig &config,
                 ArrayRef<std::string> disabledPatterns,
                 ArrayRef<std::string> enabledPatterns)
@@ -69,11 +69,6 @@ struct Canonicalizer : public impl::CanonicalizerBase<Canonicalizer> {
   std::shared_ptr<const FrozenRewritePatternSet> patterns;
 };
 } // namespace
-
-/// Create a Canonicalizer pass.
-std::unique_ptr<Pass> mlir::createCanonicalizerPass() {
-  return std::make_unique<Canonicalizer>();
-}
 
 /// Creates an instance of the Canonicalizer pass with the specified config.
 std::unique_ptr<Pass>

--- a/mlir/lib/Transforms/ControlFlowSink.cpp
+++ b/mlir/lib/Transforms/ControlFlowSink.cpp
@@ -21,7 +21,7 @@
 #include "mlir/Transforms/ControlFlowSinkUtils.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONTROLFLOWSINK
+#define GEN_PASS_DEF_CONTROLFLOWSINKPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -29,7 +29,7 @@ using namespace mlir;
 
 namespace {
 /// A control-flow sink pass.
-struct ControlFlowSink : public impl::ControlFlowSinkBase<ControlFlowSink> {
+struct ControlFlowSink : public impl::ControlFlowSinkPassBase<ControlFlowSink> {
   void runOnOperation() override;
 };
 } // end anonymous namespace
@@ -51,8 +51,4 @@ void ControlFlowSink::runOnOperation() {
           op->moveBefore(&region->front(), region->front().begin());
         });
   });
-}
-
-std::unique_ptr<Pass> mlir::createControlFlowSinkPass() {
-  return std::make_unique<ControlFlowSink>();
 }

--- a/mlir/lib/Transforms/GenerateRuntimeVerification.cpp
+++ b/mlir/lib/Transforms/GenerateRuntimeVerification.cpp
@@ -14,7 +14,7 @@
 #include "mlir/Interfaces/RuntimeVerifiableOpInterface.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_GENERATERUNTIMEVERIFICATION
+#define GEN_PASS_DEF_GENERATERUNTIMEVERIFICATIONPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -22,8 +22,10 @@ using namespace mlir;
 
 namespace {
 struct GenerateRuntimeVerificationPass
-    : public impl::GenerateRuntimeVerificationBase<
+    : public impl::GenerateRuntimeVerificationPassBase<
           GenerateRuntimeVerificationPass> {
+  using impl::GenerateRuntimeVerificationPassBase<
+      GenerateRuntimeVerificationPass>::GenerateRuntimeVerificationPassBase;
   void runOnOperation() override;
 };
 
@@ -98,8 +100,4 @@ void GenerateRuntimeVerificationPass::runOnOperation() {
     verifiableOp.generateRuntimeVerification(builder, verifiableOp.getLoc(),
                                              defaultErrMsgGenerator);
   };
-}
-
-std::unique_ptr<Pass> mlir::createGenerateRuntimeVerificationPass() {
-  return std::make_unique<GenerateRuntimeVerificationPass>();
 }

--- a/mlir/lib/Transforms/InlinerPass.cpp
+++ b/mlir/lib/Transforms/InlinerPass.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Support/DebugLog.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_INLINER
+#define GEN_PASS_DEF_INLINERPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -39,8 +39,9 @@ static void defaultInlinerOptPipeline(OpPassManager &pm) {
 //===----------------------------------------------------------------------===//
 
 namespace {
-class InlinerPass : public impl::InlinerBase<InlinerPass> {
+class InlinerPass : public impl::InlinerPassBase<InlinerPass> {
 public:
+  using impl::InlinerPassBase<InlinerPass>::InlinerPassBase;
   InlinerPass();
   InlinerPass(const InlinerPass &) = default;
   InlinerPass(std::function<void(OpPassManager &)> defaultPipeline);
@@ -183,9 +184,6 @@ LogicalResult InlinerPass::initializeOptions(
   return success();
 }
 
-std::unique_ptr<Pass> mlir::createInlinerPass() {
-  return std::make_unique<InlinerPass>();
-}
 std::unique_ptr<Pass>
 mlir::createInlinerPass(llvm::StringMap<OpPassManager> opPipelines) {
   return std::make_unique<InlinerPass>(defaultInlinerOptPipeline,

--- a/mlir/lib/Transforms/LoopInvariantCodeMotion.cpp
+++ b/mlir/lib/Transforms/LoopInvariantCodeMotion.cpp
@@ -17,8 +17,8 @@
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_LOOPINVARIANTCODEMOTION
-#define GEN_PASS_DEF_LOOPINVARIANTSUBSETHOISTING
+#define GEN_PASS_DEF_LOOPINVARIANTCODEMOTIONPASS
+#define GEN_PASS_DEF_LOOPINVARIANTSUBSETHOISTINGPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -27,12 +27,12 @@ using namespace mlir;
 namespace {
 /// Loop invariant code motion (LICM) pass.
 struct LoopInvariantCodeMotion
-    : public impl::LoopInvariantCodeMotionBase<LoopInvariantCodeMotion> {
+    : public impl::LoopInvariantCodeMotionPassBase<LoopInvariantCodeMotion> {
   void runOnOperation() override;
 };
 
 struct LoopInvariantSubsetHoisting
-    : public impl::LoopInvariantSubsetHoistingBase<
+    : public impl::LoopInvariantSubsetHoistingPassBase<
           LoopInvariantSubsetHoisting> {
   void runOnOperation() override;
 };
@@ -54,12 +54,4 @@ void LoopInvariantSubsetHoisting::runOnOperation() {
   getOperation()->walk([&](LoopLikeOpInterface loopLike) {
     (void)hoistLoopInvariantSubsets(rewriter, loopLike);
   });
-}
-
-std::unique_ptr<Pass> mlir::createLoopInvariantCodeMotionPass() {
-  return std::make_unique<LoopInvariantCodeMotion>();
-}
-
-std::unique_ptr<Pass> mlir::createLoopInvariantSubsetHoistingPass() {
-  return std::make_unique<LoopInvariantSubsetHoisting>();
 }

--- a/mlir/lib/Transforms/PrintIR.cpp
+++ b/mlir/lib/Transforms/PrintIR.cpp
@@ -11,10 +11,12 @@
 #include "llvm/Support/Debug.h"
 
 namespace mlir {
-namespace {
-
 #define GEN_PASS_DEF_PRINTIRPASS
 #include "mlir/Transforms/Passes.h.inc"
+} // namespace mlir
+
+namespace mlir {
+namespace {
 
 struct PrintIRPass : public impl::PrintIRPassBase<PrintIRPass> {
   using impl::PrintIRPassBase<PrintIRPass>::PrintIRPassBase;
@@ -30,9 +32,5 @@ struct PrintIRPass : public impl::PrintIRPassBase<PrintIRPass> {
 };
 
 } // namespace
-
-std::unique_ptr<Pass> createPrintIRPass(const PrintIRPassOptions &options) {
-  return std::make_unique<PrintIRPass>(options);
-}
 
 } // namespace mlir

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -63,7 +63,7 @@
 #define DEBUG_TYPE "remove-dead-values"
 
 namespace mlir {
-#define GEN_PASS_DEF_REMOVEDEADVALUES
+#define GEN_PASS_DEF_REMOVEDEADVALUESPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -764,7 +764,10 @@ static void cleanUpDeadVals(MLIRContext *ctx, RDVFinalCleanupList &list) {
   LDBG() << "Finished cleanup of dead values";
 }
 
-struct RemoveDeadValues : public impl::RemoveDeadValuesBase<RemoveDeadValues> {
+struct RemoveDeadValues
+    : public impl::RemoveDeadValuesPassBase<RemoveDeadValues> {
+  using impl::RemoveDeadValuesPassBase<
+      RemoveDeadValues>::RemoveDeadValuesPassBase;
   void runOnOperation() override;
 };
 } // namespace
@@ -822,8 +825,4 @@ void RemoveDeadValues::runOnOperation() {
     module->emitError("greedy pattern rewrite failed to converge");
     signalPassFailure();
   }
-}
-
-std::unique_ptr<Pass> mlir::createRemoveDeadValuesPass() {
-  return std::make_unique<RemoveDeadValues>();
 }

--- a/mlir/lib/Transforms/SCCP.cpp
+++ b/mlir/lib/Transforms/SCCP.cpp
@@ -25,7 +25,7 @@
 #include "mlir/Transforms/FoldUtils.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_SCCP
+#define GEN_PASS_DEF_SCCPPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -114,7 +114,7 @@ static void rewrite(DataFlowSolver &solver, MLIRContext *context,
 //===----------------------------------------------------------------------===//
 
 namespace {
-struct SCCP : public impl::SCCPBase<SCCP> {
+struct SCCP : public impl::SCCPPassBase<SCCP> {
   void runOnOperation() override;
 };
 } // namespace
@@ -128,8 +128,4 @@ void SCCP::runOnOperation() {
   if (failed(solver.initializeAndRun(op)))
     return signalPassFailure();
   rewrite(solver, op->getContext(), op->getRegions());
-}
-
-std::unique_ptr<Pass> mlir::createSCCPPass() {
-  return std::make_unique<SCCP>();
 }

--- a/mlir/lib/Transforms/StripDebugInfo.cpp
+++ b/mlir/lib/Transforms/StripDebugInfo.cpp
@@ -12,14 +12,14 @@
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_STRIPDEBUGINFO
+#define GEN_PASS_DEF_STRIPDEBUGINFOPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
 using namespace mlir;
 
 namespace {
-struct StripDebugInfo : public impl::StripDebugInfoBase<StripDebugInfo> {
+struct StripDebugInfo : public impl::StripDebugInfoPassBase<StripDebugInfo> {
   void runOnOperation() override;
 };
 } // namespace
@@ -39,9 +39,4 @@ void StripDebugInfo::runOnOperation() {
       }
     }
   });
-}
-
-/// Creates a pass to strip debug information from a function.
-std::unique_ptr<Pass> mlir::createStripDebugInfoPass() {
-  return std::make_unique<StripDebugInfo>();
 }

--- a/mlir/lib/Transforms/SymbolDCE.cpp
+++ b/mlir/lib/Transforms/SymbolDCE.cpp
@@ -20,7 +20,7 @@
 #include "llvm/Support/InterleavedRange.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_SYMBOLDCE
+#define GEN_PASS_DEF_SYMBOLDCEPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -29,7 +29,7 @@ using namespace mlir;
 #define DEBUG_TYPE "symbol-dce"
 
 namespace {
-struct SymbolDCE : public impl::SymbolDCEBase<SymbolDCE> {
+struct SymbolDCE : public impl::SymbolDCEPassBase<SymbolDCE> {
   void runOnOperation() override;
 
   /// Compute the liveness of the symbols within the given symbol table.
@@ -185,8 +185,4 @@ LogicalResult SymbolDCE::computeLiveness(Operation *symbolTableOp,
   }
 
   return success();
-}
-
-std::unique_ptr<Pass> mlir::createSymbolDCEPass() {
-  return std::make_unique<SymbolDCE>();
 }

--- a/mlir/lib/Transforms/SymbolPrivatize.cpp
+++ b/mlir/lib/Transforms/SymbolPrivatize.cpp
@@ -16,15 +16,15 @@
 #include "mlir/IR/SymbolTable.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_SYMBOLPRIVATIZE
+#define GEN_PASS_DEF_SYMBOLPRIVATIZEPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
 using namespace mlir;
 
 namespace {
-struct SymbolPrivatize : public impl::SymbolPrivatizeBase<SymbolPrivatize> {
-  explicit SymbolPrivatize(ArrayRef<std::string> excludeSymbols);
+struct SymbolPrivatize : public impl::SymbolPrivatizePassBase<SymbolPrivatize> {
+  using impl::SymbolPrivatizePassBase<SymbolPrivatize>::SymbolPrivatizePassBase;
   LogicalResult initialize(MLIRContext *context) override;
   void runOnOperation() override;
 
@@ -32,10 +32,6 @@ struct SymbolPrivatize : public impl::SymbolPrivatizeBase<SymbolPrivatize> {
   DenseSet<StringAttr> excludedSymbols;
 };
 } // namespace
-
-SymbolPrivatize::SymbolPrivatize(llvm::ArrayRef<std::string> excludeSymbols) {
-  exclude = excludeSymbols;
-}
 
 LogicalResult SymbolPrivatize::initialize(MLIRContext *context) {
   for (const std::string &symbol : exclude)
@@ -55,9 +51,4 @@ void SymbolPrivatize::runOnOperation() {
       }
     }
   }
-}
-
-std::unique_ptr<Pass>
-mlir::createSymbolPrivatizePass(ArrayRef<std::string> exclude) {
-  return std::make_unique<SymbolPrivatize>(exclude);
 }

--- a/mlir/lib/Transforms/TopologicalSort.cpp
+++ b/mlir/lib/Transforms/TopologicalSort.cpp
@@ -12,7 +12,7 @@
 #include "mlir/IR/RegionKindInterface.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_TOPOLOGICALSORT
+#define GEN_PASS_DEF_TOPOLOGICALSORTPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -20,7 +20,7 @@ using namespace mlir;
 
 namespace {
 struct TopologicalSortPass
-    : public impl::TopologicalSortBase<TopologicalSortPass> {
+    : public impl::TopologicalSortPassBase<TopologicalSortPass> {
   void runOnOperation() override {
     // Topologically sort the regions of the operation without SSA dominance.
     getOperation()->walk([](RegionKindInterface op) {
@@ -34,7 +34,3 @@ struct TopologicalSortPass
   }
 };
 } // end anonymous namespace
-
-std::unique_ptr<Pass> mlir::createTopologicalSortPass() {
-  return std::make_unique<TopologicalSortPass>();
-}

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -21,7 +21,7 @@
 #include <utility>
 
 namespace mlir {
-#define GEN_PASS_DEF_VIEWOPGRAPH
+#define GEN_PASS_DEF_VIEWOPGRAPHPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -97,8 +97,12 @@ struct DataFlowEdge {
 /// This pass generates a Graphviz dataflow visualization of an MLIR operation.
 /// Note: See https://www.graphviz.org/doc/info/lang.html for more information
 /// about the Graphviz DOT language.
-class PrintOpPass : public impl::ViewOpGraphBase<PrintOpPass> {
+class PrintOpPass : public impl::ViewOpGraphPassBase<PrintOpPass> {
 public:
+  PrintOpPass() : os(llvm::errs()) {}
+  explicit PrintOpPass(ViewOpGraphPassOptions options)
+      : impl::ViewOpGraphPassBase<PrintOpPass>(std::move(options)),
+        os(llvm::errs()) {}
   PrintOpPass(raw_ostream &os) : os(os) {}
   PrintOpPass(const PrintOpPass &o) : PrintOpPass(o.os.getOStream()) {}
 
@@ -459,7 +463,7 @@ private:
 
 } // namespace
 
-std::unique_ptr<Pass> mlir::createPrintOpGraphPass(raw_ostream &os) {
+std::unique_ptr<Pass> mlir::createViewOpGraphPass(raw_ostream &os) {
   return std::make_unique<PrintOpPass>(os);
 }
 

--- a/mlir/test/CAPI/pass.c
+++ b/mlir/test/CAPI/pass.c
@@ -53,7 +53,7 @@ void testRunPassOnModule(void) {
   // CHECK: func.return        , 1
   {
     MlirPassManager pm = mlirPassManagerCreate(ctx);
-    MlirPass printOpStatPass = mlirCreateTransformsPrintOpStats();
+    MlirPass printOpStatPass = mlirCreateTransformsPrintOpStatsPass();
     mlirPassManagerAddOwnedPass(pm, printOpStatPass);
     MlirLogicalResult success = mlirPassManagerRunOnOp(pm, func);
     if (mlirLogicalResultIsFailure(success)) {
@@ -98,7 +98,7 @@ void testRunPassOnNestedModule(void) {
     MlirPassManager pm = mlirPassManagerCreate(ctx);
     MlirOpPassManager nestedFuncPm = mlirPassManagerGetNestedUnder(
         pm, mlirStringRefCreateFromCString("func.func"));
-    MlirPass printOpStatPass = mlirCreateTransformsPrintOpStats();
+    MlirPass printOpStatPass = mlirCreateTransformsPrintOpStatsPass();
     mlirOpPassManagerAddOwnedPass(nestedFuncPm, printOpStatPass);
     MlirLogicalResult success = mlirPassManagerRunOnOp(pm, module);
     if (mlirLogicalResultIsFailure(success))
@@ -116,7 +116,7 @@ void testRunPassOnNestedModule(void) {
         pm, mlirStringRefCreateFromCString("builtin.module"));
     MlirOpPassManager nestedFuncPm = mlirOpPassManagerGetNestedUnder(
         nestedModulePm, mlirStringRefCreateFromCString("func.func"));
-    MlirPass printOpStatPass = mlirCreateTransformsPrintOpStats();
+    MlirPass printOpStatPass = mlirCreateTransformsPrintOpStatsPass();
     mlirOpPassManagerAddOwnedPass(nestedFuncPm, printOpStatPass);
     MlirLogicalResult success = mlirPassManagerRunOnOp(pm, module);
     if (mlirLogicalResultIsFailure(success))
@@ -147,7 +147,7 @@ void testPrintPassPipeline(void) {
       pm, mlirStringRefCreateFromCString("builtin.module"));
   MlirOpPassManager nestedFuncPm = mlirOpPassManagerGetNestedUnder(
       nestedModulePm, mlirStringRefCreateFromCString("func.func"));
-  MlirPass printOpStatPass = mlirCreateTransformsPrintOpStats();
+  MlirPass printOpStatPass = mlirCreateTransformsPrintOpStatsPass();
   mlirOpPassManagerAddOwnedPass(nestedFuncPm, printOpStatPass);
 
   // Print the top level pass manager
@@ -192,7 +192,7 @@ void testParsePassPipeline(void) {
     exit(EXIT_FAILURE);
   }
   // Try again after registrating the pass.
-  mlirRegisterTransformsPrintOpStats();
+  mlirRegisterTransformsPrintOpStatsPass();
   status = mlirParsePassPipeline(
       mlirPassManagerGetAsOpPassManager(pm),
       mlirStringRefCreateFromCString(

--- a/mlir/test/Pass/ir-printing.mlir
+++ b/mlir/test/Pass/ir-printing.mlir
@@ -15,50 +15,50 @@ func.func @bar() {
   return
 }
 
-// BEFORE: // -----// IR Dump Before{{.*}}CSE (cse) //----- //
+// BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
 // BEFORE-NEXT: func @foo()
-// BEFORE: // -----// IR Dump Before{{.*}}CSE (cse) //----- //
+// BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
 // BEFORE-NEXT: func @bar()
-// BEFORE-NOT: // -----// IR Dump Before{{.*}}Canonicalizer (canonicalize) //----- //
+// BEFORE-NOT: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
 // BEFORE-NOT: // -----// IR Dump After
 
-// BEFORE_ALL: // -----// IR Dump Before{{.*}}CSE (cse) //----- //
+// BEFORE_ALL: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
 // BEFORE_ALL-NEXT: func @foo()
-// BEFORE_ALL: // -----// IR Dump Before{{.*}}Canonicalizer (canonicalize) //----- //
+// BEFORE_ALL: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
 // BEFORE_ALL-NEXT: func @foo()
-// BEFORE_ALL: // -----// IR Dump Before{{.*}}CSE (cse) //----- //
+// BEFORE_ALL: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
 // BEFORE_ALL-NEXT: func @bar()
-// BEFORE_ALL: // -----// IR Dump Before{{.*}}Canonicalizer (canonicalize) //----- //
+// BEFORE_ALL: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
 // BEFORE_ALL-NEXT: func @bar()
 // BEFORE_ALL-NOT: // -----// IR Dump After
 
 // AFTER-NOT: // -----// IR Dump Before
-// AFTER: // -----// IR Dump After{{.*}}CSE (cse) //----- //
+// AFTER: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
 // AFTER-NEXT: func @foo()
-// AFTER: // -----// IR Dump After{{.*}}CSE (cse) //----- //
+// AFTER: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
 // AFTER-NEXT: func @bar()
-// AFTER-NOT: // -----// IR Dump After{{.*}}Canonicalizer (canonicalize) //----- //
+// AFTER-NOT: // -----// IR Dump After{{.*}}CanonicalizerPass (canonicalize) //----- //
 
 // AFTER_ALL-NOT: // -----// IR Dump Before
-// AFTER_ALL: // -----// IR Dump After{{.*}}CSE (cse) //----- //
+// AFTER_ALL: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
 // AFTER_ALL-NEXT: func @foo()
-// AFTER_ALL: // -----// IR Dump After{{.*}}Canonicalizer (canonicalize) //----- //
+// AFTER_ALL: // -----// IR Dump After{{.*}}CanonicalizerPass (canonicalize) //----- //
 // AFTER_ALL-NEXT: func @foo()
-// AFTER_ALL: // -----// IR Dump After{{.*}}CSE (cse) //----- //
+// AFTER_ALL: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
 // AFTER_ALL-NEXT: func @bar()
-// AFTER_ALL: // -----// IR Dump After{{.*}}Canonicalizer (canonicalize) //----- //
+// AFTER_ALL: // -----// IR Dump After{{.*}}CanonicalizerPass (canonicalize) //----- //
 // AFTER_ALL-NEXT: func @bar()
 
-// BEFORE_MODULE: // -----// IR Dump Before{{.*}}CSE (cse) ('func.func' operation: @foo) //----- //
+// BEFORE_MODULE: // -----// IR Dump Before{{.*}}CSEPass (cse) ('func.func' operation: @foo) //----- //
 // BEFORE_MODULE: func @foo()
 // BEFORE_MODULE: func @bar()
-// BEFORE_MODULE: // -----// IR Dump Before{{.*}}CSE (cse) ('func.func' operation: @bar) //----- //
+// BEFORE_MODULE: // -----// IR Dump Before{{.*}}CSEPass (cse) ('func.func' operation: @bar) //----- //
 // BEFORE_MODULE: func @foo()
 // BEFORE_MODULE: func @bar()
 
-// AFTER_ALL_CHANGE: // -----// IR Dump After{{.*}}CSE (cse) //----- //
+// AFTER_ALL_CHANGE: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
 // AFTER_ALL_CHANGE-NEXT: func @foo()
-// AFTER_ALL_CHANGE-NOT: // -----// IR Dump After{{.*}}CSE (cse) //----- //
+// AFTER_ALL_CHANGE-NOT: // -----// IR Dump After{{.*}}CSEPass (cse) //----- //
 // We expect that only 'foo' changed during CSE, and the second run of CSE did
 // nothing.
 

--- a/mlir/test/Pass/pass-timing.mlir
+++ b/mlir/test/Pass/pass-timing.mlir
@@ -17,8 +17,8 @@
 // LIST-JSON-NOT: Execution time report
 // LIST-JSON-NOT: Total Execution Time:
 // LIST-JSON-NOT: Name
-// LIST-JSON-DAG: "name": "Canonicalizer"}
-// LIST-JSON-DAG: "name": "CSE"}
+// LIST-JSON-DAG: "name": "CanonicalizerPass"}
+// LIST-JSON-DAG: "name": "CSEPass"}
 // LIST-JSON-DAG: "name": "(A) DominanceInfo"}
 // LIST-JSON: "name": "Total"}
 
@@ -42,13 +42,13 @@
 // PIPELINE-JSON:      "name": "Parser", "passes": [
 // PIPELINE-JSON-NEXT: {}]},
 // PIPELINE-JSON-NEXT: "name": "'func.func' Pipeline", "passes": [
-// PIPELINE-JSON-NEXT: "name": "CSE", "passes": [
+// PIPELINE-JSON-NEXT: "name": "CSEPass", "passes": [
 // PIPELINE-JSON-NEXT: "name": "(A) DominanceInfo", "passes": [
 // PIPELINE-JSON-NEXT: {}]},
 // PIPELINE-JSON-NEXT: {}]},
-// PIPELINE-JSON-NEXT: "name": "Canonicalizer", "passes": [
+// PIPELINE-JSON-NEXT: "name": "CanonicalizerPass", "passes": [
 // PIPELINE-JSON-NEXT: {}]},
-// PIPELINE-JSON-NEXT: "name": "CSE", "passes": [
+// PIPELINE-JSON-NEXT: "name": "CSEPass", "passes": [
 // PIPELINE-JSON-NEXT: "name": "(A) DominanceInfo", "passes": [
 // PIPELINE-JSON-NEXT: {}]},
 // PIPELINE-JSON-NEXT: {}]},

--- a/mlir/test/Pass/run-reproducer.mlir
+++ b/mlir/test/Pass/run-reproducer.mlir
@@ -26,9 +26,9 @@ func.func @bar() {
   }
 #-}
 
-// BEFORE: // -----// IR Dump Before{{.*}}CSE (cse) //----- //
+// BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
 // BEFORE-NEXT: func @foo()
-// BEFORE: // -----// IR Dump Before{{.*}}CSE (cse) //----- //
+// BEFORE: // -----// IR Dump Before{{.*}}CSEPass (cse) //----- //
 // BEFORE-NEXT: func @bar()
-// BEFORE-NOT: // -----// IR Dump Before{{.*}}Canonicalizer (canonicalize) //----- //
+// BEFORE-NOT: // -----// IR Dump Before{{.*}}CanonicalizerPass (canonicalize) //----- //
 // BEFORE-NOT: // -----// IR Dump After

--- a/mlir/test/Transforms/composite-pass.mlir
+++ b/mlir/test/Transforms/composite-pass.mlir
@@ -7,10 +7,10 @@
 // PIPELINE-SAME: pipeline=canonicalize{ max-iterations=10 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true},cse}
 
 // CHECK-LABEL: running `TestCompositePass`
-//       CHECK: running `Canonicalizer`
-//       CHECK: running `CSE`
-//   CHECK-NOT: running `Canonicalizer`
-//   CHECK-NOT: running `CSE`
+//       CHECK: running `CanonicalizerPass`
+//       CHECK: running `CSEPass`
+//   CHECK-NOT: running `CanonicalizerPass`
+//   CHECK-NOT: running `CSEPass`
 func.func @test() {
   return
 }
@@ -18,12 +18,12 @@ func.func @test() {
 // -----
 
 // CHECK-LABEL: running `TestCompositePass`
-//       CHECK: running `Canonicalizer`
-//       CHECK: running `CSE`
-//       CHECK: running `Canonicalizer`
-//       CHECK: running `CSE`
-//   CHECK-NOT: running `Canonicalizer`
-//   CHECK-NOT: running `CSE`
+//       CHECK: running `CanonicalizerPass`
+//       CHECK: running `CSEPass`
+//       CHECK: running `CanonicalizerPass`
+//       CHECK: running `CSEPass`
+//   CHECK-NOT: running `CanonicalizerPass`
+//   CHECK-NOT: running `CSEPass`
 func.func @test() {
 // this constant will be canonicalized away, causing another pass iteration
   %0 = arith.constant 1.5 : f32

--- a/mlir/test/python/pass_manager.py
+++ b/mlir/test/python/pass_manager.py
@@ -275,7 +275,7 @@ def testPrintIrAfterAll():
         pm = PassManager.parse("builtin.module(canonicalize)")
         ctx.enable_multithreading(False)
         pm.enable_ir_printing()
-        # CHECK: // -----// IR Dump After Canonicalizer (canonicalize) //----- //
+        # CHECK: // -----// IR Dump After CanonicalizerPass (canonicalize) //----- //
         # CHECK: module {
         # CHECK:   func.func @main() {
         # CHECK:     return
@@ -301,14 +301,14 @@ def testPrintIrBeforeAndAfterAll():
         pm = PassManager.parse("builtin.module(canonicalize)")
         ctx.enable_multithreading(False)
         pm.enable_ir_printing(print_before_all=True, print_after_all=True)
-        # CHECK: // -----// IR Dump Before Canonicalizer (canonicalize) //----- //
+        # CHECK: // -----// IR Dump Before CanonicalizerPass (canonicalize) //----- //
         # CHECK: module {
         # CHECK:   func.func @main() {
         # CHECK:     %[[C10:.*]] = arith.constant 10 : i64
         # CHECK:     return
         # CHECK:   }
         # CHECK: }
-        # CHECK: // -----// IR Dump After Canonicalizer (canonicalize) //----- //
+        # CHECK: // -----// IR Dump After CanonicalizerPass (canonicalize) //----- //
         # CHECK: module {
         # CHECK:   func.func @main() {
         # CHECK:     return


### PR DESCRIPTION
This makes the constructor auto-generated.