### PR TITLE
[Hexagon] Add coverage tests for CodeGen analysis and optimization passes

### DIFF
--- a/llvm/test/CodeGen/Hexagon/constprop-fp-cmp.ll
+++ b/llvm/test/CodeGen/Hexagon/constprop-fp-cmp.ll
@@ -1,0 +1,46 @@
+; RUN: llc -mtriple=hexagon -O2 < %s | FileCheck %s
+
+; Test coverage for HexagonConstPropagation: exercise floating-point
+; constant propagation paths by using FP comparisons and operations
+; with known constants.
+
+; CHECK-LABEL: test_fp_const_fold:
+; CHECK: jumpr r31
+define i32 @test_fp_const_fold() #0 {
+entry:
+  %cmp = fcmp ogt float 2.0, 1.0
+  %val = select i1 %cmp, i32 42, i32 0
+  ret i32 %val
+}
+
+; CHECK-LABEL: test_fp_zero_cmp:
+; CHECK: jumpr r31
+define i32 @test_fp_zero_cmp() #0 {
+entry:
+  %cmp = fcmp oeq float 0.0, 0.0
+  %val = select i1 %cmp, i32 1, i32 0
+  ret i32 %val
+}
+
+; CHECK-LABEL: test_fp_nan_cmp:
+; CHECK: jumpr r31
+define i32 @test_fp_nan_cmp() #0 {
+entry:
+  %nan = fdiv float 0.0, 0.0
+  %cmp = fcmp uno float %nan, 1.0
+  %val = select i1 %cmp, i32 1, i32 0
+  ret i32 %val
+}
+
+; Exercise the negative FP constant path.
+; CHECK-LABEL: test_fp_neg:
+; CHECK: jumpr r31
+define i32 @test_fp_neg(float %x) #0 {
+entry:
+  %neg = fneg float %x
+  %cmp = fcmp olt float %neg, 0.0
+  %val = select i1 %cmp, i32 1, i32 0
+  ret i32 %val
+}
+
+attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/constprop-fp-cmp.ll
+++ b/llvm/test/CodeGen/Hexagon/constprop-fp-cmp.ll
@@ -6,7 +6,7 @@
 
 ; CHECK-LABEL: test_fp_const_fold:
 ; CHECK: jumpr r31
-define i32 @test_fp_const_fold() #0 {
+define i32 @test_fp_const_fold() {
 entry:
   %cmp = fcmp ogt float 2.0, 1.0
   %val = select i1 %cmp, i32 42, i32 0
@@ -15,7 +15,7 @@ entry:
 
 ; CHECK-LABEL: test_fp_zero_cmp:
 ; CHECK: jumpr r31
-define i32 @test_fp_zero_cmp() #0 {
+define i32 @test_fp_zero_cmp() {
 entry:
   %cmp = fcmp oeq float 0.0, 0.0
   %val = select i1 %cmp, i32 1, i32 0
@@ -24,7 +24,7 @@ entry:
 
 ; CHECK-LABEL: test_fp_nan_cmp:
 ; CHECK: jumpr r31
-define i32 @test_fp_nan_cmp() #0 {
+define i32 @test_fp_nan_cmp() {
 entry:
   %nan = fdiv float 0.0, 0.0
   %cmp = fcmp uno float %nan, 1.0
@@ -35,7 +35,7 @@ entry:
 ; Exercise the negative FP constant path.
 ; CHECK-LABEL: test_fp_neg:
 ; CHECK: jumpr r31
-define i32 @test_fp_neg(float %x) #0 {
+define i32 @test_fp_neg(float %x) {
 entry:
   %neg = fneg float %x
   %cmp = fcmp olt float %neg, 0.0
@@ -43,4 +43,3 @@ entry:
   ret i32 %val
 }
 
-attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/gen-pred-andn-orn.ll
+++ b/llvm/test/CodeGen/Hexagon/gen-pred-andn-orn.ll
@@ -1,0 +1,130 @@
+; RUN: llc -mtriple=hexagon -O2 < %s | FileCheck %s
+
+; Test coverage for HexagonGenPredicate: exercise various predicate
+; conversion paths including A4_andn/C2_andn, A4_orn/C2_orn,
+; C2_cmpeqi==0 to C2_not, C4_cmpneqi==0 to COPY, and deeper
+; predicate chains using various comparison types.
+
+; CHECK-LABEL: test_pred_andn:
+; CHECK: cmp
+define i32 @test_pred_andn(i32 %a, i32 %b, i32 %c) #0 {
+entry:
+  %cmp1 = icmp sgt i32 %a, 0
+  %cmp2 = icmp sgt i32 %b, 0
+  %not2 = xor i1 %cmp2, true
+  %and = and i1 %cmp1, %not2
+  %sel = select i1 %and, i32 %a, i32 %c
+  ret i32 %sel
+}
+
+; CHECK-LABEL: test_pred_orn:
+; CHECK: cmp
+define i32 @test_pred_orn(i32 %a, i32 %b, i32 %c) #0 {
+entry:
+  %cmp1 = icmp sgt i32 %a, 0
+  %cmp2 = icmp sgt i32 %b, 0
+  %not2 = xor i1 %cmp2, true
+  %or = or i1 %cmp1, %not2
+  %sel = select i1 %or, i32 %a, i32 %c
+  ret i32 %sel
+}
+
+; Exercise a more complex predicate chain involving and_and (C4_and_and)
+; and or_or (C4_or_or).
+; CHECK-LABEL: test_pred_chain:
+; CHECK: cmp
+define i32 @test_pred_chain(i32 %a, i32 %b, i32 %c, i32 %d) #0 {
+entry:
+  %cmp1 = icmp sgt i32 %a, 0
+  %cmp2 = icmp sgt i32 %b, 0
+  %cmp3 = icmp sgt i32 %c, 0
+  %and12 = and i1 %cmp1, %cmp2
+  %and123 = and i1 %and12, %cmp3
+  %sel = select i1 %and123, i32 %d, i32 0
+  ret i32 %sel
+}
+
+; Predicate comparison against 0: exercise C2_cmpeqi path.
+; CHECK-LABEL: test_pred_cmp0:
+; CHECK: cmp
+define i32 @test_pred_cmp0(i32 %a, i32 %b) #0 {
+entry:
+  %cmp = icmp eq i32 %a, 0
+  %ext = zext i1 %cmp to i32
+  %and = and i32 %ext, %b
+  ret i32 %and
+}
+
+; Test cmpeq with 0 feeding into predicate logic (triggers C2_cmpeqi
+; == 0 conversion path).
+; CHECK-LABEL: test_cmpeq_zero:
+; CHECK: cmp
+define i32 @test_cmpeq_zero(i32 %a, i32 %b, i32 %x, i32 %y) #0 {
+entry:
+  %c1 = icmp eq i32 %a, 0
+  %c2 = icmp sgt i32 %b, 0
+  %and = and i1 %c1, %c2
+  %sel = select i1 %and, i32 %x, i32 %y
+  ret i32 %sel
+}
+
+; Test ne with 0 feeding into predicate logic (triggers C4_cmpneqi
+; == 0 conversion path).
+; CHECK-LABEL: test_cmpne_zero:
+; CHECK: cmp
+define i32 @test_cmpne_zero(i32 %a, i32 %b, i32 %x, i32 %y) #0 {
+entry:
+  %c1 = icmp ne i32 %a, 0
+  %c2 = icmp sgt i32 %b, 0
+  %and = and i1 %c1, %c2
+  %sel = select i1 %and, i32 %x, i32 %y
+  ret i32 %sel
+}
+
+; Test deeper predicate chain with multiple comparison types:
+; signed ge and signed le (exercises C2_cmpgei / C4_cmpltei paths).
+; CHECK-LABEL: test_deep_pred_chain:
+; CHECK: cmp
+define i32 @test_deep_pred_chain(i32 %a, i32 %b, i32 %c, i32 %d, i32 %x, i32 %y) #0 {
+entry:
+  %c1 = icmp sge i32 %a, 10
+  %c2 = icmp sle i32 %b, 20
+  %c3 = icmp uge i32 %c, 5
+  %c4 = icmp sgt i32 %d, 0
+  %and1 = and i1 %c1, %c2
+  %and2 = and i1 %c3, %c4
+  %or = or i1 %and1, %and2
+  %sel = select i1 %or, i32 %x, i32 %y
+  ret i32 %sel
+}
+
+; Test predicate OR-NOT chain (exercises C2_orn path in GenPredicate).
+; CHECK-LABEL: test_pred_orn_chain:
+; CHECK: cmp
+define i32 @test_pred_orn_chain(i32 %a, i32 %b, i32 %c, i32 %x, i32 %y) #0 {
+entry:
+  %c1 = icmp sgt i32 %a, 0
+  %c2 = icmp sgt i32 %b, 0
+  %c3 = icmp eq i32 %c, 0
+  %not = xor i1 %c2, true
+  %or = or i1 %c1, %not
+  %and = and i1 %or, %c3
+  %sel = select i1 %and, i32 %x, i32 %y
+  ret i32 %sel
+}
+
+; Test byte comparisons to exercise A4_cmpb* in isScalarCmp.
+; CHECK-LABEL: test_byte_cmp:
+; CHECK: cmp
+define i32 @test_byte_cmp(i32 %a, i32 %b, i32 %x, i32 %y) #0 {
+entry:
+  %a8 = and i32 %a, 255
+  %b8 = and i32 %b, 255
+  %c1 = icmp eq i32 %a8, %b8
+  %c2 = icmp ugt i32 %a8, 10
+  %and = and i1 %c1, %c2
+  %sel = select i1 %and, i32 %x, i32 %y
+  ret i32 %sel
+}
+
+attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/gen-pred-andn-orn.ll
+++ b/llvm/test/CodeGen/Hexagon/gen-pred-andn-orn.ll
@@ -7,7 +7,7 @@
 
 ; CHECK-LABEL: test_pred_andn:
 ; CHECK: cmp
-define i32 @test_pred_andn(i32 %a, i32 %b, i32 %c) #0 {
+define i32 @test_pred_andn(i32 %a, i32 %b, i32 %c) {
 entry:
   %cmp1 = icmp sgt i32 %a, 0
   %cmp2 = icmp sgt i32 %b, 0
@@ -19,7 +19,7 @@ entry:
 
 ; CHECK-LABEL: test_pred_orn:
 ; CHECK: cmp
-define i32 @test_pred_orn(i32 %a, i32 %b, i32 %c) #0 {
+define i32 @test_pred_orn(i32 %a, i32 %b, i32 %c) {
 entry:
   %cmp1 = icmp sgt i32 %a, 0
   %cmp2 = icmp sgt i32 %b, 0
@@ -33,7 +33,7 @@ entry:
 ; and or_or (C4_or_or).
 ; CHECK-LABEL: test_pred_chain:
 ; CHECK: cmp
-define i32 @test_pred_chain(i32 %a, i32 %b, i32 %c, i32 %d) #0 {
+define i32 @test_pred_chain(i32 %a, i32 %b, i32 %c, i32 %d) {
 entry:
   %cmp1 = icmp sgt i32 %a, 0
   %cmp2 = icmp sgt i32 %b, 0
@@ -47,7 +47,7 @@ entry:
 ; Predicate comparison against 0: exercise C2_cmpeqi path.
 ; CHECK-LABEL: test_pred_cmp0:
 ; CHECK: cmp
-define i32 @test_pred_cmp0(i32 %a, i32 %b) #0 {
+define i32 @test_pred_cmp0(i32 %a, i32 %b) {
 entry:
   %cmp = icmp eq i32 %a, 0
   %ext = zext i1 %cmp to i32
@@ -59,7 +59,7 @@ entry:
 ; == 0 conversion path).
 ; CHECK-LABEL: test_cmpeq_zero:
 ; CHECK: cmp
-define i32 @test_cmpeq_zero(i32 %a, i32 %b, i32 %x, i32 %y) #0 {
+define i32 @test_cmpeq_zero(i32 %a, i32 %b, i32 %x, i32 %y) {
 entry:
   %c1 = icmp eq i32 %a, 0
   %c2 = icmp sgt i32 %b, 0
@@ -72,7 +72,7 @@ entry:
 ; == 0 conversion path).
 ; CHECK-LABEL: test_cmpne_zero:
 ; CHECK: cmp
-define i32 @test_cmpne_zero(i32 %a, i32 %b, i32 %x, i32 %y) #0 {
+define i32 @test_cmpne_zero(i32 %a, i32 %b, i32 %x, i32 %y) {
 entry:
   %c1 = icmp ne i32 %a, 0
   %c2 = icmp sgt i32 %b, 0
@@ -85,7 +85,7 @@ entry:
 ; signed ge and signed le (exercises C2_cmpgei / C4_cmpltei paths).
 ; CHECK-LABEL: test_deep_pred_chain:
 ; CHECK: cmp
-define i32 @test_deep_pred_chain(i32 %a, i32 %b, i32 %c, i32 %d, i32 %x, i32 %y) #0 {
+define i32 @test_deep_pred_chain(i32 %a, i32 %b, i32 %c, i32 %d, i32 %x, i32 %y) {
 entry:
   %c1 = icmp sge i32 %a, 10
   %c2 = icmp sle i32 %b, 20
@@ -101,7 +101,7 @@ entry:
 ; Test predicate OR-NOT chain (exercises C2_orn path in GenPredicate).
 ; CHECK-LABEL: test_pred_orn_chain:
 ; CHECK: cmp
-define i32 @test_pred_orn_chain(i32 %a, i32 %b, i32 %c, i32 %x, i32 %y) #0 {
+define i32 @test_pred_orn_chain(i32 %a, i32 %b, i32 %c, i32 %x, i32 %y) {
 entry:
   %c1 = icmp sgt i32 %a, 0
   %c2 = icmp sgt i32 %b, 0
@@ -116,7 +116,7 @@ entry:
 ; Test byte comparisons to exercise A4_cmpb* in isScalarCmp.
 ; CHECK-LABEL: test_byte_cmp:
 ; CHECK: cmp
-define i32 @test_byte_cmp(i32 %a, i32 %b, i32 %x, i32 %y) #0 {
+define i32 @test_byte_cmp(i32 %a, i32 %b, i32 %x, i32 %y) {
 entry:
   %a8 = and i32 %a, 255
   %b8 = and i32 %b, 255
@@ -127,4 +127,3 @@ entry:
   ret i32 %sel
 }
 
-attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/memcpy-likely-aligned.ll
+++ b/llvm/test/CodeGen/Hexagon/memcpy-likely-aligned.ll
@@ -1,27 +1,35 @@
 ; RUN: llc -mtriple=hexagon < %s | FileCheck %s
-; CHECK: __hexagon_memcpy_likely_aligned_min32bytes_mult8bytes
 
-target datalayout = "e-p:32:32:32-i64:64:64-i32:32:32-i16:16:16-i1:32:32-f64:64:64-f32:32:32-a0:0-n32"
-target triple = "hexagon-unknown-linux-gnu"
+; Test coverage for HexagonSelectionDAGInfo::EmitTargetCodeForMemcpy.
+; When a memcpy has known size >= 32, alignment >= 4, and size is a
+; multiple of 8, the Hexagon backend should call a specialized memcpy.
 
-%struct.e = type { i8, i8, [2 x i8] }
-%struct.s = type { ptr }
-%struct.o = type { %struct.n }
-%struct.n = type { [2 x %struct.l] }
-%struct.l = type { %struct.e, %struct.d, %struct.e }
-%struct.d = type <{ i8, i8, i8, i8, [2 x i8], [2 x i8] }>
-
-@y = global { <{ { %struct.e, { i8, i8, i8, [5 x i8] }, %struct.e }, { %struct.e, { i8, i8, i8, [5 x i8] }, %struct.e } }> } { <{ { %struct.e, { i8, i8, i8, [5 x i8] }, %struct.e }, { %struct.e, { i8, i8, i8, [5 x i8] }, %struct.e } }> <{ { %struct.e, { i8, i8, i8, [5 x i8] }, %struct.e } { %struct.e { i8 3, i8 0, [2 x i8] undef }, { i8, i8, i8, [5 x i8] } { i8 -47, i8 2, i8 0, [5 x i8] undef }, %struct.e { i8 3, i8 0, [2 x i8] undef } }, { %struct.e, { i8, i8, i8, [5 x i8] }, %struct.e } { %struct.e { i8 3, i8 0, [2 x i8] undef }, { i8, i8, i8, [5 x i8] } { i8 -47, i8 2, i8 0, [5 x i8] undef }, %struct.e { i8 3, i8 0, [2 x i8] undef } } }> }, align 4
-@t = common global %struct.s zeroinitializer, align 4
-@q = internal global ptr null, align 4
-
-define void @foo() nounwind {
+; CHECK-LABEL: test_memcpy_aligned:
+; CHECK: call __hexagon_memcpy_likely_aligned_min32bytes_mult8bytes
+define void @test_memcpy_aligned(ptr %dst, ptr %src) #0 {
 entry:
-  %0 = load ptr, ptr @t, align 4
-  store ptr %0, ptr @q, align 4
-  %1 = load ptr, ptr @q, align 4
-  call void @llvm.memcpy.p0.p0.i32(ptr align 4 %1, ptr align 4 @y, i32 32, i1 false)
+  call void @llvm.memcpy.p0.p0.i32(ptr align 8 %dst, ptr align 8 %src, i32 64, i1 false)
   ret void
 }
 
-declare void @llvm.memcpy.p0.p0.i32(ptr nocapture, ptr nocapture, i32, i1) nounwind
+; Smaller memcpy (< 32 bytes) should NOT use the specialized path.
+; CHECK-LABEL: test_memcpy_small:
+; CHECK-NOT: likely_aligned
+define void @test_memcpy_small(ptr %dst, ptr %src) #0 {
+entry:
+  call void @llvm.memcpy.p0.p0.i32(ptr align 4 %dst, ptr align 4 %src, i32 16, i1 false)
+  ret void
+}
+
+; Non-aligned memcpy should NOT use the specialized path.
+; CHECK-LABEL: test_memcpy_unaligned:
+; CHECK-NOT: likely_aligned
+define void @test_memcpy_unaligned(ptr %dst, ptr %src) #0 {
+entry:
+  call void @llvm.memcpy.p0.p0.i32(ptr align 1 %dst, ptr align 1 %src, i32 64, i1 false)
+  ret void
+}
+
+declare void @llvm.memcpy.p0.p0.i32(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i32, i1 immarg)
+
+attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/memcpy-likely-aligned.ll
+++ b/llvm/test/CodeGen/Hexagon/memcpy-likely-aligned.ll
@@ -6,7 +6,7 @@
 
 ; CHECK-LABEL: test_memcpy_aligned:
 ; CHECK: call __hexagon_memcpy_likely_aligned_min32bytes_mult8bytes
-define void @test_memcpy_aligned(ptr %dst, ptr %src) #0 {
+define void @test_memcpy_aligned(ptr %dst, ptr %src) {
 entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %dst, ptr align 8 %src, i32 64, i1 false)
   ret void
@@ -15,7 +15,7 @@ entry:
 ; Smaller memcpy (< 32 bytes) should NOT use the specialized path.
 ; CHECK-LABEL: test_memcpy_small:
 ; CHECK-NOT: likely_aligned
-define void @test_memcpy_small(ptr %dst, ptr %src) #0 {
+define void @test_memcpy_small(ptr %dst, ptr %src) {
 entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %dst, ptr align 4 %src, i32 16, i1 false)
   ret void
@@ -24,7 +24,7 @@ entry:
 ; Non-aligned memcpy should NOT use the specialized path.
 ; CHECK-LABEL: test_memcpy_unaligned:
 ; CHECK-NOT: likely_aligned
-define void @test_memcpy_unaligned(ptr %dst, ptr %src) #0 {
+define void @test_memcpy_unaligned(ptr %dst, ptr %src) {
 entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 1 %dst, ptr align 1 %src, i32 64, i1 false)
   ret void
@@ -32,4 +32,3 @@ entry:
 
 declare void @llvm.memcpy.p0.p0.i32(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i32, i1 immarg)
 
-attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/sched-timing-classes.ll
+++ b/llvm/test/CodeGen/Hexagon/sched-timing-classes.ll
@@ -1,0 +1,79 @@
+; RUN: llc -mtriple=hexagon -o - %s | FileCheck %s
+
+; Test coverage for HexagonDepTimingClasses and HexagonInstrInfo::isComplex.
+; Exercise multiply instructions (TC3x/TC4x) and ALU instructions
+; (TC1/TC2) so the timing-class classification functions get invoked
+; during scheduling.
+
+; TC3x: multiply instructions
+; CHECK-LABEL: test_multiply_timing:
+; CHECK: mpyi
+define i32 @test_multiply_timing(i32 %a, i32 %b, i32 %c) #0 {
+entry:
+  %m1 = mul i32 %a, %b
+  %m2 = mul i32 %m1, %c
+  %m3 = mul i32 %m2, %a
+  ret i32 %m3
+}
+
+; TC4x: multiply-accumulate instructions
+; CHECK-LABEL: test_mac_timing:
+; CHECK: mpyi
+define i32 @test_mac_timing(i32 %a, i32 %b, i32 %c, i32 %d) #0 {
+entry:
+  %m1 = mul i32 %a, %b
+  %add1 = add i32 %m1, %c
+  %m2 = mul i32 %add1, %d
+  %add2 = add i32 %m2, %a
+  ret i32 %add2
+}
+
+; TC1: simple ALU operations mixed with TC3x multiplies to force
+; scheduling decisions that query timing classes.
+; CHECK-LABEL: test_alu_mix:
+; CHECK: add
+define i32 @test_alu_mix(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e) #0 {
+entry:
+  %add1 = add i32 %a, %b
+  %mul1 = mul i32 %c, %d
+  %add2 = add i32 %add1, %mul1
+  %xor1 = xor i32 %add2, %e
+  %and1 = and i32 %xor1, %a
+  %mul2 = mul i32 %and1, %b
+  %or1 = or i32 %mul2, %c
+  ret i32 %or1
+}
+
+; TC2early: compare + jump patterns that exercise early-timing predicates.
+; CHECK-LABEL: test_cmp_jump:
+; CHECK: cmp
+define i32 @test_cmp_jump(i32 %a, i32 %b, i32 %c) #0 {
+entry:
+  %cmp = icmp sgt i32 %a, %b
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:
+  %mul = mul i32 %a, %c
+  br label %if.end
+
+if.else:
+  %add = add i32 %b, %c
+  br label %if.end
+
+if.end:
+  %result = phi i32 [ %mul, %if.then ], [ %add, %if.else ]
+  ret i32 %result
+}
+
+; Exercise 64-bit operations that may use different timing classes.
+; CHECK-LABEL: test_64bit_ops:
+; CHECK: add
+define i64 @test_64bit_ops(i64 %a, i64 %b, i32 %c) #0 {
+entry:
+  %add = add i64 %a, %b
+  %ext = zext i32 %c to i64
+  %mul = mul i64 %add, %ext
+  ret i64 %mul
+}
+
+attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/sched-timing-classes.ll
+++ b/llvm/test/CodeGen/Hexagon/sched-timing-classes.ll
@@ -8,7 +8,7 @@
 ; TC3x: multiply instructions
 ; CHECK-LABEL: test_multiply_timing:
 ; CHECK: mpyi
-define i32 @test_multiply_timing(i32 %a, i32 %b, i32 %c) #0 {
+define i32 @test_multiply_timing(i32 %a, i32 %b, i32 %c) {
 entry:
   %m1 = mul i32 %a, %b
   %m2 = mul i32 %m1, %c
@@ -19,7 +19,7 @@ entry:
 ; TC4x: multiply-accumulate instructions
 ; CHECK-LABEL: test_mac_timing:
 ; CHECK: mpyi
-define i32 @test_mac_timing(i32 %a, i32 %b, i32 %c, i32 %d) #0 {
+define i32 @test_mac_timing(i32 %a, i32 %b, i32 %c, i32 %d) {
 entry:
   %m1 = mul i32 %a, %b
   %add1 = add i32 %m1, %c
@@ -32,7 +32,7 @@ entry:
 ; scheduling decisions that query timing classes.
 ; CHECK-LABEL: test_alu_mix:
 ; CHECK: add
-define i32 @test_alu_mix(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e) #0 {
+define i32 @test_alu_mix(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e) {
 entry:
   %add1 = add i32 %a, %b
   %mul1 = mul i32 %c, %d
@@ -47,7 +47,7 @@ entry:
 ; TC2early: compare + jump patterns that exercise early-timing predicates.
 ; CHECK-LABEL: test_cmp_jump:
 ; CHECK: cmp
-define i32 @test_cmp_jump(i32 %a, i32 %b, i32 %c) #0 {
+define i32 @test_cmp_jump(i32 %a, i32 %b, i32 %c) {
 entry:
   %cmp = icmp sgt i32 %a, %b
   br i1 %cmp, label %if.then, label %if.else
@@ -68,7 +68,7 @@ if.end:
 ; Exercise 64-bit operations that may use different timing classes.
 ; CHECK-LABEL: test_64bit_ops:
 ; CHECK: add
-define i64 @test_64bit_ops(i64 %a, i64 %b, i32 %c) #0 {
+define i64 @test_64bit_ops(i64 %a, i64 %b, i32 %c) {
 entry:
   %add = add i64 %a, %b
   %ext = zext i32 %c to i64
@@ -76,4 +76,3 @@ entry:
   ret i64 %mul
 }
 
-attributes #0 = { nounwind "target-cpu"="hexagonv60" }


### PR DESCRIPTION
Add tests targeting Hexagon CodeGen analysis and optimization passes:

- gen-pred-andn-orn.ll: HexagonGenPredicate pass exercising andn/orn logical operations, cmp-zero conversion paths, deeper predicate chains, and byte comparison classification.

- memcpy-likely-aligned.ll: HexagonSelectionDAGInfo exercising the aligned memcpy specialization path.

- constprop-fp-cmp.ll: HexagonConstPropagation exercising floating- point comparison constant folding paths.

- sched-timing-classes.ll: Scheduling timing class coverage for various Hexagon instruction classes.