### PR TITLE
[Hexagon] Add coverage tests for AsmPrinter and misc CodeGen

### DIFF
--- a/llvm/test/CodeGen/Hexagon/asm-operand-modifiers.ll
+++ b/llvm/test/CodeGen/Hexagon/asm-operand-modifiers.ll
@@ -1,0 +1,32 @@
+; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+
+; Test coverage for HexagonAsmPrinter: exercise inline asm operand
+; printing with various constraint letters and address operands.
+
+; CHECK-LABEL: test_asm_reg:
+; CHECK: r{{[0-9]+}}
+define void @test_asm_reg(i32 %a) #0 {
+entry:
+  call void asm sideeffect "nop // $0", "r"(i32 %a)
+  ret void
+}
+
+; Exercise the memory operand printing path.
+; CHECK-LABEL: test_asm_mem:
+; CHECK: memw
+define i32 @test_asm_mem(ptr %p) #0 {
+entry:
+  %val = call i32 asm sideeffect "$0 = memw($1)", "=r,*m"(ptr elementtype(i32) %p)
+  ret i32 %val
+}
+
+; Exercise immediate operand with 'I' modifier.
+; CHECK-LABEL: test_asm_imm:
+; CHECK: nop
+define void @test_asm_imm() #0 {
+entry:
+  call void asm sideeffect "nop // $0", "i"(i32 42)
+  ret void
+}
+
+attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/asm-operand-modifiers.ll
+++ b/llvm/test/CodeGen/Hexagon/asm-operand-modifiers.ll
@@ -5,7 +5,7 @@
 
 ; CHECK-LABEL: test_asm_reg:
 ; CHECK: r{{[0-9]+}}
-define void @test_asm_reg(i32 %a) #0 {
+define void @test_asm_reg(i32 %a) {
 entry:
   call void asm sideeffect "nop // $0", "r"(i32 %a)
   ret void
@@ -14,7 +14,7 @@ entry:
 ; Exercise the memory operand printing path.
 ; CHECK-LABEL: test_asm_mem:
 ; CHECK: memw
-define i32 @test_asm_mem(ptr %p) #0 {
+define i32 @test_asm_mem(ptr %p) {
 entry:
   %val = call i32 asm sideeffect "$0 = memw($1)", "=r,*m"(ptr elementtype(i32) %p)
   ret i32 %val
@@ -23,10 +23,9 @@ entry:
 ; Exercise immediate operand with 'I' modifier.
 ; CHECK-LABEL: test_asm_imm:
 ; CHECK: nop
-define void @test_asm_imm() #0 {
+define void @test_asm_imm() {
 entry:
   call void asm sideeffect "nop // $0", "i"(i32 42)
   ret void
 }
 
-attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/asm-printer-cpool.ll
+++ b/llvm/test/CodeGen/Hexagon/asm-printer-cpool.ll
@@ -1,0 +1,34 @@
+; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+
+; Test coverage for HexagonAsmPrinter: exercise the constant pool index
+; and global address operand printing paths.
+
+@global_arr = external global [100 x i32]
+
+; CHECK-LABEL: test_constpool:
+; CHECK: ##
+define float @test_constpool(float %x) #0 {
+entry:
+  %add = fadd float %x, 0x400921FB60000000
+  ret float %add
+}
+
+; CHECK-LABEL: test_global_addr:
+; CHECK: ##global_arr
+define ptr @test_global_addr(i32 %idx) #0 {
+entry:
+  %gep = getelementptr [100 x i32], ptr @global_arr, i32 0, i32 %idx
+  ret ptr %gep
+}
+
+; Exercise the block address path.
+; CHECK-LABEL: test_blockaddr:
+; CHECK: ##.Ltmp
+define ptr @test_blockaddr() #0 {
+entry:
+  br label %target
+target:
+  ret ptr blockaddress(@test_blockaddr, %target)
+}
+
+attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/asm-printer-cpool.ll
+++ b/llvm/test/CodeGen/Hexagon/asm-printer-cpool.ll
@@ -7,7 +7,7 @@
 
 ; CHECK-LABEL: test_constpool:
 ; CHECK: ##
-define float @test_constpool(float %x) #0 {
+define float @test_constpool(float %x) {
 entry:
   %add = fadd float %x, 0x400921FB60000000
   ret float %add
@@ -15,7 +15,7 @@ entry:
 
 ; CHECK-LABEL: test_global_addr:
 ; CHECK: ##global_arr
-define ptr @test_global_addr(i32 %idx) #0 {
+define ptr @test_global_addr(i32 %idx) {
 entry:
   %gep = getelementptr [100 x i32], ptr @global_arr, i32 0, i32 %idx
   ret ptr %gep
@@ -24,11 +24,10 @@ entry:
 ; Exercise the block address path.
 ; CHECK-LABEL: test_blockaddr:
 ; CHECK: ##.Ltmp
-define ptr @test_blockaddr() #0 {
+define ptr @test_blockaddr() {
 entry:
   br label %target
 target:
   ret ptr blockaddress(@test_blockaddr, %target)
 }
 
-attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/constext-store-imm.ll
+++ b/llvm/test/CodeGen/Hexagon/constext-store-imm.ll
@@ -1,0 +1,57 @@
+; RUN: llc -mtriple=hexagon -o - %s | FileCheck %s
+
+; Test coverage for HexagonConstExtenders: exercise constant extender
+; optimization for store-immediate patterns. Multiple uses of the same
+; large immediate constant in store operations should share an extender.
+
+; CHECK-LABEL: test_store_imm:
+; CHECK: ##
+define void @test_store_imm(ptr %p) #0 {
+entry:
+  %p0 = getelementptr i8, ptr %p, i32 100000
+  %p1 = getelementptr i8, ptr %p, i32 100004
+  %p2 = getelementptr i8, ptr %p, i32 100008
+  %p3 = getelementptr i8, ptr %p, i32 100012
+  store i8 1, ptr %p0, align 1
+  store i8 2, ptr %p1, align 1
+  store i8 3, ptr %p2, align 1
+  store i8 4, ptr %p3, align 1
+  ret void
+}
+
+; Exercise constant extender optimization with multiple loads from a
+; global array with large offsets.
+@big_array = external global [100000 x i32], align 4
+
+; CHECK-LABEL: test_load_large_offsets:
+; CHECK: ##
+define i32 @test_load_large_offsets() #0 {
+entry:
+  %p0 = getelementptr [100000 x i32], ptr @big_array, i32 0, i32 25000
+  %p1 = getelementptr [100000 x i32], ptr @big_array, i32 0, i32 25001
+  %p2 = getelementptr [100000 x i32], ptr @big_array, i32 0, i32 25002
+  %p3 = getelementptr [100000 x i32], ptr @big_array, i32 0, i32 25003
+  %v0 = load i32, ptr %p0, align 4
+  %v1 = load i32, ptr %p1, align 4
+  %v2 = load i32, ptr %p2, align 4
+  %v3 = load i32, ptr %p3, align 4
+  %s0 = add i32 %v0, %v1
+  %s1 = add i32 %s0, %v2
+  %s2 = add i32 %s1, %v3
+  ret i32 %s2
+}
+
+; Exercise constant extender with arithmetic using large immediates.
+; CHECK-LABEL: test_arith_large_imm:
+; CHECK: ##
+define i32 @test_arith_large_imm(i32 %a, i32 %b, i32 %c) #0 {
+entry:
+  %add1 = add i32 %a, 100000
+  %add2 = add i32 %b, 100000
+  %add3 = add i32 %c, 100000
+  %s1 = add i32 %add1, %add2
+  %s2 = add i32 %s1, %add3
+  ret i32 %s2
+}
+
+attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/constext-store-imm.ll
+++ b/llvm/test/CodeGen/Hexagon/constext-store-imm.ll
@@ -6,7 +6,7 @@
 
 ; CHECK-LABEL: test_store_imm:
 ; CHECK: ##
-define void @test_store_imm(ptr %p) #0 {
+define void @test_store_imm(ptr %p) {
 entry:
   %p0 = getelementptr i8, ptr %p, i32 100000
   %p1 = getelementptr i8, ptr %p, i32 100004
@@ -25,7 +25,7 @@ entry:
 
 ; CHECK-LABEL: test_load_large_offsets:
 ; CHECK: ##
-define i32 @test_load_large_offsets() #0 {
+define i32 @test_load_large_offsets() {
 entry:
   %p0 = getelementptr [100000 x i32], ptr @big_array, i32 0, i32 25000
   %p1 = getelementptr [100000 x i32], ptr @big_array, i32 0, i32 25001
@@ -44,7 +44,7 @@ entry:
 ; Exercise constant extender with arithmetic using large immediates.
 ; CHECK-LABEL: test_arith_large_imm:
 ; CHECK: ##
-define i32 @test_arith_large_imm(i32 %a, i32 %b, i32 %c) #0 {
+define i32 @test_arith_large_imm(i32 %a, i32 %b, i32 %c) {
 entry:
   %add1 = add i32 %a, 100000
   %add2 = add i32 %b, 100000
@@ -54,4 +54,3 @@ entry:
   ret i32 %s2
 }
 
-attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/reg-info-types.ll
+++ b/llvm/test/CodeGen/Hexagon/reg-info-types.ll
@@ -1,0 +1,32 @@
+; RUN: llc -mtriple=hexagon -mattr=+hvxv60,+hvx-length128b < %s | FileCheck %s
+
+; Test coverage for HexagonRegisterInfo: exercise different register class
+; type mappings including HvxWR (double vector) and HvxQR (predicate vector).
+
+; CHECK-LABEL: test_hvx_wr:
+; CHECK: vadd
+define <64 x i32> @test_hvx_wr(<64 x i32> %a, <64 x i32> %b) #0 {
+entry:
+  %add = add <64 x i32> %a, %b
+  ret <64 x i32> %add
+}
+
+; CHECK-LABEL: test_hvx_qr:
+; CHECK: vmax
+define <32 x i32> @test_hvx_qr(<32 x i32> %a, <32 x i32> %b) #0 {
+entry:
+  %cmp = icmp sgt <32 x i32> %a, %b
+  %sel = select <32 x i1> %cmp, <32 x i32> %a, <32 x i32> %b
+  ret <32 x i32> %sel
+}
+
+; CHECK-LABEL: test_pred_reg:
+; CHECK: cmp
+define i32 @test_pred_reg(i32 %a, i32 %b, i32 %c) #0 {
+entry:
+  %cmp = icmp sgt i32 %a, %b
+  %sel = select i1 %cmp, i32 %a, i32 %c
+  ret i32 %sel
+}
+
+attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/reg-info-types.ll
+++ b/llvm/test/CodeGen/Hexagon/reg-info-types.ll
@@ -5,7 +5,7 @@
 
 ; CHECK-LABEL: test_hvx_wr:
 ; CHECK: vadd
-define <64 x i32> @test_hvx_wr(<64 x i32> %a, <64 x i32> %b) #0 {
+define <64 x i32> @test_hvx_wr(<64 x i32> %a, <64 x i32> %b) {
 entry:
   %add = add <64 x i32> %a, %b
   ret <64 x i32> %add
@@ -13,7 +13,7 @@ entry:
 
 ; CHECK-LABEL: test_hvx_qr:
 ; CHECK: vmax
-define <32 x i32> @test_hvx_qr(<32 x i32> %a, <32 x i32> %b) #0 {
+define <32 x i32> @test_hvx_qr(<32 x i32> %a, <32 x i32> %b) {
 entry:
   %cmp = icmp sgt <32 x i32> %a, %b
   %sel = select <32 x i1> %cmp, <32 x i32> %a, <32 x i32> %b
@@ -22,11 +22,10 @@ entry:
 
 ; CHECK-LABEL: test_pred_reg:
 ; CHECK: cmp
-define i32 @test_pred_reg(i32 %a, i32 %b, i32 %c) #0 {
+define i32 @test_pred_reg(i32 %a, i32 %b, i32 %c) {
 entry:
   %cmp = icmp sgt i32 %a, %b
   %sel = select i1 %cmp, i32 %a, i32 %c
   ret i32 %sel
 }
 
-attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/split-double-volatile.ll
+++ b/llvm/test/CodeGen/Hexagon/split-double-volatile.ll
@@ -1,0 +1,32 @@
+; RUN: llc -mtriple=hexagon -O2 < %s | FileCheck %s
+
+; Test coverage for HexagonSplitDoubleRegs: exercise the volatile memory
+; operation path and the load/store splitting for 64-bit register operations.
+
+; CHECK-LABEL: test_volatile_load:
+; CHECK: memd
+define i64 @test_volatile_load(ptr %p) #0 {
+entry:
+  %val = load volatile i64, ptr %p, align 8
+  ret i64 %val
+}
+
+; CHECK-LABEL: test_volatile_store:
+; CHECK: memd
+define void @test_volatile_store(ptr %p, i64 %val) #0 {
+entry:
+  store volatile i64 %val, ptr %p, align 8
+  ret void
+}
+
+; Non-volatile 64-bit loads can be split into two 32-bit loads.
+; CHECK-LABEL: test_split_load:
+; CHECK: memw
+define i64 @test_split_load(ptr %p) #0 {
+entry:
+  %val = load i64, ptr %p, align 4
+  %add = add i64 %val, 1
+  ret i64 %add
+}
+
+attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/split-double-volatile.ll
+++ b/llvm/test/CodeGen/Hexagon/split-double-volatile.ll
@@ -5,7 +5,7 @@
 
 ; CHECK-LABEL: test_volatile_load:
 ; CHECK: memd
-define i64 @test_volatile_load(ptr %p) #0 {
+define i64 @test_volatile_load(ptr %p) {
 entry:
   %val = load volatile i64, ptr %p, align 8
   ret i64 %val
@@ -13,7 +13,7 @@ entry:
 
 ; CHECK-LABEL: test_volatile_store:
 ; CHECK: memd
-define void @test_volatile_store(ptr %p, i64 %val) #0 {
+define void @test_volatile_store(ptr %p, i64 %val) {
 entry:
   store volatile i64 %val, ptr %p, align 8
   ret void
@@ -22,11 +22,10 @@ entry:
 ; Non-volatile 64-bit loads can be split into two 32-bit loads.
 ; CHECK-LABEL: test_split_load:
 ; CHECK: memw
-define i64 @test_split_load(ptr %p) #0 {
+define i64 @test_split_load(ptr %p) {
 entry:
   %val = load i64, ptr %p, align 4
   %add = add i64 %val, 1
   ret i64 %add
 }
 
-attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/target-objfile-sdata.ll
+++ b/llvm/test/CodeGen/Hexagon/target-objfile-sdata.ll
@@ -1,0 +1,41 @@
+; RUN: llc -mtriple=hexagon -hexagon-small-data-threshold=8 < %s | FileCheck %s
+; RUN: llc -mtriple=hexagon -hexagon-small-data-threshold=0 < %s \
+; RUN:   | FileCheck --check-prefix=NOSDATA %s
+
+; Test coverage for HexagonTargetObjectFile: exercise the small data/BSS
+; section selection logic.
+
+@small_global = global i32 0, align 4
+@large_global = global [256 x i32] zeroinitializer, align 4
+@small_init = global i32 7, align 4
+
+; With small data threshold=8, small globals go into .sdata/.sbss.
+; CHECK-LABEL: test_small_data:
+; CHECK: memw(gp+#small_global)
+; NOSDATA-LABEL: test_small_data:
+; NOSDATA: memw(##small_global)
+define i32 @test_small_data() #0 {
+entry:
+  %val = load i32, ptr @small_global, align 4
+  ret i32 %val
+}
+
+; Large arrays should NOT go into small data.
+; CHECK-LABEL: test_large_data:
+; CHECK: ##large_global
+define i32 @test_large_data() #0 {
+entry:
+  %val = load i32, ptr @large_global, align 4
+  ret i32 %val
+}
+
+; Initialized small data should also be accessible via GP.
+; CHECK-LABEL: test_init:
+; CHECK: memw(gp+#small_init)
+define i32 @test_init() #0 {
+entry:
+  %val = load i32, ptr @small_init, align 4
+  ret i32 %val
+}
+
+attributes #0 = { nounwind "target-cpu"="hexagonv60" }

--- a/llvm/test/CodeGen/Hexagon/target-objfile-sdata.ll
+++ b/llvm/test/CodeGen/Hexagon/target-objfile-sdata.ll
@@ -14,7 +14,7 @@
 ; CHECK: memw(gp+#small_global)
 ; NOSDATA-LABEL: test_small_data:
 ; NOSDATA: memw(##small_global)
-define i32 @test_small_data() #0 {
+define i32 @test_small_data() {
 entry:
   %val = load i32, ptr @small_global, align 4
   ret i32 %val
@@ -23,7 +23,7 @@ entry:
 ; Large arrays should NOT go into small data.
 ; CHECK-LABEL: test_large_data:
 ; CHECK: ##large_global
-define i32 @test_large_data() #0 {
+define i32 @test_large_data() {
 entry:
   %val = load i32, ptr @large_global, align 4
   ret i32 %val
@@ -32,10 +32,9 @@ entry:
 ; Initialized small data should also be accessible via GP.
 ; CHECK-LABEL: test_init:
 ; CHECK: memw(gp+#small_init)
-define i32 @test_init() #0 {
+define i32 @test_init() {
 entry:
   %val = load i32, ptr @small_init, align 4
   ret i32 %val
 }
 
-attributes #0 = { nounwind "target-cpu"="hexagonv60" }


### PR DESCRIPTION
Add tests targeting assembly printing and miscellaneous CodeGen areas with low coverage:

- asm-printer-cpool.ll: HexagonAsmPrinter exercising constant pool entry emission.

- asm-operand-modifiers.ll: Inline asm operand modifier printing paths (lo/hi/mem).

- target-objfile-sdata.ll, split-double-volatile.ll, reg-info-types.ll: Miscellaneous CodeGen coverage for HexagonTargetObjectFile small data classification, HexagonSplitDouble volatile load handling, and HexagonRegisterInfo register class queries.

- constext-store-imm.ll: HexagonConstExtenders store-immediate optimization paths.