### PR TITLE
Support variable empty lines between include categories

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -4419,6 +4419,18 @@ the configuration (without a prefix: ``Auto``).
   Each regular expression can be marked as case sensitive with the field
   ``CaseSensitive``, per default it is not.
 
+  There is a fourth and optional field ``EmptyLines`` that defines how many
+  empty lines are inserted *before* this category when ``IncludeBlocks`` is
+  ``IBS_Regroup``. The default is ``1``. ``EmptyLines: 0`` can be used to
+  suppress separation.
+
+  When regrouping jumps over categories that are not present in the file,
+  clang-format uses the maximum ``EmptyLines`` value of all category
+  priorities between the previous and the next emitted category.
+
+  ``MaxEmptyLinesToKeep`` still applies to the final number of consecutive
+  empty lines kept in the formatted output.
+
   To configure this in the .clang-format file, use:
 
   .. code-block:: yaml
@@ -4432,6 +4444,7 @@ the configuration (without a prefix: ``Auto``).
         Priority:        3
       - Regex:           '<[[:alnum:].]+>'
         Priority:        4
+        EmptyLines:      2
       - Regex:           '.*'
         Priority:        1
         SortPriority:    0

--- a/clang/include/clang/Tooling/Inclusions/IncludeStyle.h
+++ b/clang/include/clang/Tooling/Inclusions/IncludeStyle.h
@@ -63,9 +63,12 @@ struct IncludeStyle {
     int SortPriority;
     /// If the regular expression is case sensitive.
     bool RegexIsCaseSensitive;
+    /// The number of blank lines to add *before* this category.
+    int EmptyLines;
     bool operator==(const IncludeCategory &Other) const {
       return Regex == Other.Regex && Priority == Other.Priority &&
-             RegexIsCaseSensitive == Other.RegexIsCaseSensitive;
+             RegexIsCaseSensitive == Other.RegexIsCaseSensitive &&
+             EmptyLines == Other.EmptyLines;
     }
   };
 
@@ -99,6 +102,18 @@ struct IncludeStyle {
   /// Each regular expression can be marked as case sensitive with the field
   /// ``CaseSensitive``, per default it is not.
   ///
+  /// There is a fourth and optional field ``EmptyLines`` that defines how many
+  /// empty lines are inserted *before* this category when ``IncludeBlocks`` is
+  /// ``IBS_Regroup``. The default is ``1``. ``EmptyLines: 0`` can be used to
+  /// suppress separation.
+  ///
+  /// When regrouping jumps over categories that are not present in the file,
+  /// clang-format uses the maximum ``EmptyLines`` value of all category
+  /// priorities between the previous and the next emitted category.
+  ///
+  /// ``MaxEmptyLinesToKeep`` still applies to the final number of consecutive
+  /// empty lines kept in the formatted output.
+  ///
   /// To configure this in the .clang-format file, use:
   /// \code{.yaml}
   ///   IncludeCategories:
@@ -110,6 +125,7 @@ struct IncludeStyle {
   ///       Priority:        3
   ///     - Regex:           '<[[:alnum:].]+>'
   ///       Priority:        4
+  ///       EmptyLines:      2
   ///     - Regex:           '.*'
   ///       Priority:        1
   ///       SortPriority:    0

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1809,9 +1809,9 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.IfMacros.push_back("KJ_IF_MAYBE");
   LLVMStyle.IncludeStyle.IncludeBlocks = tooling::IncludeStyle::IBS_Preserve;
   LLVMStyle.IncludeStyle.IncludeCategories = {
-      {"^\"(llvm|llvm-c|clang|clang-c)/", 2, 0, false},
-      {"^(<|\"(gtest|gmock|isl|json)/)", 3, 0, false},
-      {".*", 1, 0, false}};
+      {"^\"(llvm|llvm-c|clang|clang-c)/", 2, 0, false, 1},
+      {"^(<|\"(gtest|gmock|isl|json)/)", 3, 0, false, 1},
+      {".*", 1, 0, false, 1}};
   LLVMStyle.IncludeStyle.IncludeIsMainRegex = "(Test)?$";
   LLVMStyle.IncludeStyle.MainIncludeChar = tooling::IncludeStyle::MICD_Quote;
   LLVMStyle.IndentAccessModifiers = false;
@@ -1966,10 +1966,11 @@ FormatStyle getGoogleStyle(FormatStyle::LanguageKind Language) {
   GoogleStyle.AttributeMacros.push_back("absl_nullability_unknown");
   GoogleStyle.BreakTemplateDeclarations = FormatStyle::BTDS_Yes;
   GoogleStyle.IncludeStyle.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
-  GoogleStyle.IncludeStyle.IncludeCategories = {{"^<ext/.*\\.h>", 2, 0, false},
-                                                {"^<.*\\.h>", 1, 0, false},
-                                                {"^<.*", 2, 0, false},
-                                                {".*", 3, 0, false}};
+  GoogleStyle.IncludeStyle.IncludeCategories = {
+      {"^<ext/.*\\.h>", 2, 0, false, 1},
+      {"^<.*\\.h>", 1, 0, false, 1},
+      {"^<.*", 2, 0, false, 1},
+      {".*", 3, 0, false, 1}};
   GoogleStyle.IncludeStyle.IncludeIsMainRegex = "([-_](test|unittest))?$";
   GoogleStyle.IndentCaseLabels = true;
   GoogleStyle.KeepEmptyLines.AtStartOfBlock = false;
@@ -3539,6 +3540,21 @@ static void sortCppIncludes(const FormatStyle &Style,
                              }),
                 Indices.end());
 
+  // Get the separation width between LastCategory and NewCategory
+  // including NewCategory. If no category is found, use 1 as default.
+  const auto GetEmptyLines = [&](int LastCategory, int NewCategory) -> int {
+    if (LastCategory > NewCategory)
+      std::swap(LastCategory, NewCategory);
+    int EmptyLines = -1;
+    for (const auto &IncludeCategory : Style.IncludeStyle.IncludeCategories) {
+      if (IncludeCategory.Priority > LastCategory &&
+          IncludeCategory.Priority <= NewCategory) {
+        EmptyLines = std::max(EmptyLines, IncludeCategory.EmptyLines);
+      }
+    }
+    return EmptyLines < 0 ? 1 : EmptyLines;
+  };
+
   int CurrentCategory = Includes.front().Category;
 
   // If the #includes are out of order, we generate a single replacement fixing
@@ -3555,18 +3571,21 @@ static void sortCppIncludes(const FormatStyle &Style,
   const auto OldCursor = Cursor ? *Cursor : 0;
   std::string result;
   for (unsigned Index : Indices) {
+    const auto NewCategory = Includes[Index].Category;
     if (!result.empty()) {
       result += "\n";
       if (Style.IncludeStyle.IncludeBlocks ==
               tooling::IncludeStyle::IBS_Regroup &&
-          CurrentCategory != Includes[Index].Category) {
-        result += "\n";
+          CurrentCategory != NewCategory) {
+        const int EmptyLineCount = GetEmptyLines(CurrentCategory, NewCategory);
+        for (int Count = 0; Count < EmptyLineCount; ++Count)
+          result += "\n";
       }
     }
     result += Includes[Index].Text;
     if (Cursor && CursorIndex == Index)
       *Cursor = IncludesBeginOffset + result.size() - CursorToEOLOffset;
-    CurrentCategory = Includes[Index].Category;
+    CurrentCategory = NewCategory;
   }
 
   if (Cursor && *Cursor >= IncludesEndOffset)

--- a/clang/lib/Tooling/Inclusions/IncludeStyle.cpp
+++ b/clang/lib/Tooling/Inclusions/IncludeStyle.cpp
@@ -19,6 +19,7 @@ void MappingTraits<IncludeStyle::IncludeCategory>::mapping(
   IO.mapOptional("Priority", Category.Priority);
   IO.mapOptional("SortPriority", Category.SortPriority);
   IO.mapOptional("CaseSensitive", Category.RegexIsCaseSensitive);
+  IO.mapOptional("EmptyLines", Category.EmptyLines, 1);
 }
 
 void ScalarEnumerationTraits<IncludeStyle::IncludeBlocksStyle>::enumeration(

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -1046,10 +1046,19 @@ TEST(ConfigParseTest, ParsesConfiguration) {
 
   Style.IncludeStyle.IncludeCategories.clear();
   std::vector<tooling::IncludeStyle::IncludeCategory> ExpectedCategories = {
-      {"abc/.*", 2, 0, false}, {".*", 1, 0, true}};
+      {"abc/.*", 2, 0, false, 1}, {".*", 1, 0, true, 1}};
   CHECK_PARSE("IncludeCategories:\n"
               "  - Regex: abc/.*\n"
               "    Priority: 2\n"
+              "  - Regex: .*\n"
+              "    Priority: 1\n"
+              "    CaseSensitive: true",
+              IncludeStyle.IncludeCategories, ExpectedCategories);
+  ExpectedCategories = {{"abc/.*", 2, 0, false, 2}, {".*", 1, 0, true, 1}};
+  CHECK_PARSE("IncludeCategories:\n"
+              "  - Regex: abc/.*\n"
+              "    Priority: 2\n"
+              "    EmptyLines: 2\n"
               "  - Regex: .*\n"
               "    Priority: 1\n"
               "    CaseSensitive: true",

--- a/clang/unittests/Format/SortIncludesTest.cpp
+++ b/clang/unittests/Format/SortIncludesTest.cpp
@@ -87,19 +87,19 @@ TEST_F(SortIncludesTest, TrailingComments) {
 TEST_F(SortIncludesTest, SortedIncludesUsingSortPriorityAttribute) {
   FmtStyle.IncludeStyle.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
   FmtStyle.IncludeStyle.IncludeCategories = {
-      {"^<sys/param\\.h>", 1, 0, false},
-      {"^<sys/types\\.h>", 1, 1, false},
-      {"^<sys.*/", 1, 2, false},
-      {"^<uvm/", 2, 3, false},
-      {"^<machine/", 3, 4, false},
-      {"^<dev/", 4, 5, false},
-      {"^<net.*/", 5, 6, false},
-      {"^<protocols/", 5, 7, false},
-      {"^<(fs|miscfs|msdosfs|nfs|ntfs|ufs)/", 6, 8, false},
-      {"^<(x86|amd64|i386|xen)/", 7, 8, false},
-      {"<path", 9, 11, false},
-      {"^<[^/].*\\.h>", 8, 10, false},
-      {"^\".*\\.h\"", 10, 12, false}};
+      {"^<sys/param\\.h>", 1, 0, false, 1},
+      {"^<sys/types\\.h>", 1, 1, false, 1},
+      {"^<sys.*/", 1, 2, false, 1},
+      {"^<uvm/", 2, 3, false, 1},
+      {"^<machine/", 3, 4, false, 1},
+      {"^<dev/", 4, 5, false, 1},
+      {"^<net.*/", 5, 6, false, 1},
+      {"^<protocols/", 5, 7, false, 1},
+      {"^<(fs|miscfs|msdosfs|nfs|ntfs|ufs)/", 6, 8, false, 1},
+      {"^<(x86|amd64|i386|xen)/", 7, 8, false, 1},
+      {"<path", 9, 11, false, 1},
+      {"^<[^/].*\\.h>", 8, 10, false, 1},
+      {"^\".*\\.h\"", 10, 12, false, 1}};
   verifyFormat("#include <sys/param.h>\n"
                "#include <sys/types.h>\n"
                "#include <sys/ioctl.h>\n"
@@ -627,6 +627,98 @@ TEST_F(SortIncludesTest, MainHeaderIsSeparatedWhenRegroupping) {
                     "a.cc"));
 }
 
+TEST_F(SortIncludesTest, EmptyLinesUseMaxAcrossSkippedCategories) {
+  Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
+  FmtStyle.MaxEmptyLinesToKeep = 2;
+  Style.IncludeCategories = {
+      {"^\"b", 1, 0, false, 2},
+      {"^\"c", 2, 0, false, 1},
+      {"^\"d", 3, 0, false, 2},
+      {"^\"e", 4, 0, false, 1},
+  };
+
+  verifyFormat("#include \"input.h\"\n"
+               "\n"
+               "\n"
+               "#include \"c.h\"\n"
+               "\n"
+               "\n"
+               "#include \"e.h\"\n",
+               sort("#include \"e.h\"\n"
+                    "#include \"c.h\"\n"
+                    "#include \"input.h\"\n",
+                    "input.cpp"),
+               FmtStyle);
+}
+
+TEST_F(SortIncludesTest, EmptyLinesCanSeparateMainHeaderByTwoBlankLines) {
+  Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
+  FmtStyle.MaxEmptyLinesToKeep = 2;
+  Style.IncludeCategories = {
+      {"^\"project/.*\"", 1, 0, false, 2},
+      {".*", 2, 0, false, 1},
+  };
+
+  verifyFormat("#include \"input.h\"\n"
+               "\n"
+               "\n"
+               "#include \"project/detail.h\"\n",
+               sort("#include \"project/detail.h\"\n"
+                    "#include \"input.h\"\n",
+                    "input.cpp"),
+               FmtStyle);
+}
+
+TEST_F(SortIncludesTest,
+       EmptyLinesAreIndependentOfIncludeCategoryDefinitionOrder) {
+  Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
+  FmtStyle.MaxEmptyLinesToKeep = 2;
+  StringRef UnsortedCode = "#include \"c.h\"\n"
+                           "#include \"b.h\"\n"
+                           "#include \"a.h\"\n";
+  StringRef ExpectedCode = "#include \"a.h\"\n"
+                           "\n"
+                           "\n"
+                           "#include \"b.h\"\n"
+                           "\n"
+                           "#include \"c.h\"\n";
+
+  Style.IncludeCategories = {
+      {"^\"a", 1, 0, false, 1},
+      {"^\"b", 2, 0, false, 2},
+      {"^\"c", 3, 0, false, 1},
+  };
+  const std::string Ordered = sort(UnsortedCode);
+  verifyFormat(ExpectedCode, Ordered, FmtStyle);
+
+  Style.IncludeCategories = {
+      {"^\"c", 3, 0, false, 1},
+      {"^\"b", 2, 0, false, 2},
+      {"^\"a", 1, 0, false, 1},
+  };
+  const std::string Reversed = sort(UnsortedCode);
+  verifyFormat(ExpectedCode, Reversed, FmtStyle);
+  EXPECT_EQ(Ordered, Reversed);
+}
+
+TEST_F(SortIncludesTest, EmptyLinesZeroOmitsSeparationBetweenCategories) {
+  Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
+  Style.IncludeCategories = {
+      {"^\"a", 1, 0, false, 0},
+      {"^\"b", 2, 0, false, 0},
+      {".*", 3, 0, false, 0},
+  };
+
+  verifyFormat("#include \"a.h\"\n"
+               "#include \"b.h\"\n"
+               "#include \"c.h\"\n",
+               sort("#include \"c.h\"\n"
+                    "\n"
+                    "#include \"b.h\"\n"
+                    "\n"
+                    "#include \"a.h\"\n"));
+}
+
 TEST_F(SortIncludesTest, SupportOptionalCaseSensitiveSorting) {
   FmtStyle.SortIncludes.IgnoreCase = true;
 
@@ -643,8 +735,9 @@ TEST_F(SortIncludesTest, SupportOptionalCaseSensitiveSorting) {
                     "a.h"));
 
   Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
-  Style.IncludeCategories = {
-      {"^\"", 1, 0, false}, {"^<.*\\.h>$", 2, 0, false}, {"^<", 3, 0, false}};
+  Style.IncludeCategories = {{"^\"", 1, 0, false, 1},
+                             {"^<.*\\.h>$", 2, 0, false, 1},
+                             {"^<", 3, 0, false, 1}};
 
   StringRef UnsortedCode = "#include \"qt.h\"\n"
                            "#include <algorithm>\n"
@@ -693,11 +786,11 @@ TEST_F(SortIncludesTest, SupportCaseInsensitiveMatching) {
 
 TEST_F(SortIncludesTest, SupportOptionalCaseSensitiveMachting) {
   Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
-  Style.IncludeCategories = {{"^\"", 1, 0, false},
-                             {"^<.*\\.h>$", 2, 0, false},
-                             {"^<Q[A-Z][^\\.]*>", 3, 0, false},
-                             {"^<Qt[^\\.]*>", 4, 0, false},
-                             {"^<", 5, 0, false}};
+  Style.IncludeCategories = {{"^\"", 1, 0, false, 1},
+                             {"^<.*\\.h>$", 2, 0, false, 1},
+                             {"^<Q[A-Z][^\\.]*>", 3, 0, false, 1},
+                             {"^<Qt[^\\.]*>", 4, 0, false, 1},
+                             {"^<", 5, 0, false, 1}};
 
   StringRef UnsortedCode = "#include <QWidget>\n"
                            "#include \"qt.h\"\n"
@@ -742,8 +835,8 @@ TEST_F(SortIncludesTest, SupportOptionalCaseSensitiveMachting) {
 }
 
 TEST_F(SortIncludesTest, NegativePriorities) {
-  Style.IncludeCategories = {{".*important_os_header.*", -1, 0, false},
-                             {".*", 1, 0, false}};
+  Style.IncludeCategories = {{".*important_os_header.*", -1, 0, false, 1},
+                             {".*", 1, 0, false, 1}};
   verifyFormat("#include \"important_os_header.h\"\n"
                "#include \"c_main.h\"\n"
                "#include \"a_other.h\"",
@@ -763,8 +856,8 @@ TEST_F(SortIncludesTest, NegativePriorities) {
 }
 
 TEST_F(SortIncludesTest, PriorityGroupsAreSeparatedWhenRegroupping) {
-  Style.IncludeCategories = {{".*important_os_header.*", -1, 0, false},
-                             {".*", 1, 0, false}};
+  Style.IncludeCategories = {{".*important_os_header.*", -1, 0, false, 1},
+                             {".*", 1, 0, false, 1}};
   Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
 
   verifyFormat("#include \"important_os_header.h\"\n"
@@ -789,6 +882,42 @@ TEST_F(SortIncludesTest, PriorityGroupsAreSeparatedWhenRegroupping) {
                     "\n"
                     "#include \"a_other.h\"",
                     "c_main.cc", 0));
+}
+
+TEST_F(SortIncludesTest,
+       TwoEmptyLinesAfterMainHeaderWithNegativeAndPositivePriorities) {
+  Style.IncludeCategories = {{".*important_os_header.*", -1, 0, false, 1},
+                             {".*", 1, 0, false, 2}};
+  Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
+  FmtStyle.MaxEmptyLinesToKeep = 2;
+
+  verifyFormat("#include \"important_os_header.h\"\n"
+               "\n"
+               "#include \"c_main.h\"\n"
+               "\n"
+               "\n"
+               "#include \"a_other.h\"",
+               sort("#include \"a_other.h\"\n"
+                    "#include \"c_main.h\"\n"
+                    "#include \"important_os_header.h\"",
+                    "c_main.cc"),
+               FmtStyle);
+
+  // check stable when re-run
+  verifyFormat("#include \"important_os_header.h\"\n"
+               "\n"
+               "#include \"c_main.h\"\n"
+               "\n"
+               "\n"
+               "#include \"a_other.h\"",
+               sort("#include \"important_os_header.h\"\n"
+                    "\n"
+                    "#include \"c_main.h\"\n"
+                    "\n"
+                    "\n"
+                    "#include \"a_other.h\"",
+                    "c_main.cc", 0),
+               FmtStyle);
 }
 
 TEST_F(SortIncludesTest, CalculatesCorrectCursorPosition) {
@@ -823,8 +952,9 @@ TEST_F(SortIncludesTest,
        CalculatesCorrectCursorPositionWhenNoReplacementsWithRegroupingAndCRLF) {
   Style.IncludeBlocks = Style.IBS_Regroup;
   FmtStyle.LineEnding = FormatStyle::LE_CRLF;
-  Style.IncludeCategories = {
-      {"^\"a\"", 0, 0, false}, {"^\"b\"", 1, 1, false}, {".*", 2, 2, false}};
+  Style.IncludeCategories = {{"^\"a\"", 0, 0, false, 1},
+                             {"^\"b\"", 1, 1, false, 1},
+                             {".*", 2, 2, false, 1}};
   StringRef Code = "#include \"a\"\r\n" // Start of line: 0
                    "\r\n"               // Start of line: 14
                    "#include \"b\"\r\n" // Start of line: 16
@@ -847,7 +977,7 @@ TEST_F(
     CalculatesCorrectCursorPositionWhenRemoveLinesReplacementsWithRegroupingAndCRLF) {
   Style.IncludeBlocks = Style.IBS_Regroup;
   FmtStyle.LineEnding = FormatStyle::LE_CRLF;
-  Style.IncludeCategories = {{".*", 0, 0, false}};
+  Style.IncludeCategories = {{".*", 0, 0, false, 1}};
   StringRef Code = "#include \"a\"\r\n"     // Start of line: 0
                    "\r\n"                   // Start of line: 14
                    "#include \"b\"\r\n"     // Start of line: 16
@@ -882,7 +1012,7 @@ TEST_F(
   Style.IncludeBlocks = Style.IBS_Regroup;
   FmtStyle.LineEnding = FormatStyle::LE_CRLF;
   Style.IncludeCategories = {
-      {"^\"a\"", 0, 0, false}, {"^\"b\"", 1, 1, false}, {".*", 2, 2, false}};
+      {"^\"a\"", 0, 0, false, 1}, {"^\"b\"", 1, 1, false, 1}, {".*", 2, 2, false, 1}};
   StringRef Code = "#include \"a\"\r\n"     // Start of line: 0
                    "#include \"b\"\r\n"     // Start of line: 14
                    "#include \"c\"\r\n"     // Start of line: 28
@@ -909,7 +1039,7 @@ TEST_F(
   Style.IncludeBlocks = Style.IBS_Regroup;
   FmtStyle.LineEnding = FormatStyle::LE_CRLF;
   Style.IncludeCategories = {
-      {"^\"a\"", 0, 0, false}, {"^\"b\"", 1, 1, false}, {".*", 2, 2, false}};
+      {"^\"a\"", 0, 0, false, 1}, {"^\"b\"", 1, 1, false, 1}, {".*", 2, 2, false, 1}};
   StringRef Code = "#include \"a\"\r\n"     // Start of line: 0
                    "\r\n"                   // Start of line: 14
                    "#include \"c\"\r\n"     // Start of line: 16
@@ -1156,8 +1286,9 @@ TEST_F(SortIncludesTest, MainIncludeCharAnyPickAngleBracket) {
 }
 
 TEST_F(SortIncludesTest, MainIncludeCharQuoteAndRegroup) {
-  Style.IncludeCategories = {
-      {"lib-a", 1, 0, false}, {"lib-b", 2, 0, false}, {"lib-c", 3, 0, false}};
+  Style.IncludeCategories = {{"lib-a", 1, 0, false, 1},
+                             {"lib-b", 2, 0, false, 1},
+                             {"lib-c", 3, 0, false, 1}};
   Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
   Style.MainIncludeChar = tooling::IncludeStyle::MICD_Quote;
 
@@ -1186,8 +1317,9 @@ TEST_F(SortIncludesTest, MainIncludeCharQuoteAndRegroup) {
 }
 
 TEST_F(SortIncludesTest, MainIncludeCharAngleBracketAndRegroup) {
-  Style.IncludeCategories = {
-      {"lib-a", 1, 0, false}, {"lib-b", 2, 0, false}, {"lib-c", 3, 0, false}};
+  Style.IncludeCategories = {{"lib-a", 1, 0, false, 1},
+                             {"lib-b", 2, 0, false, 1},
+                             {"lib-c", 3, 0, false, 1}};
   Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
   Style.MainIncludeChar = tooling::IncludeStyle::MICD_AngleBracket;
 


### PR DESCRIPTION
Resolves #183802.

Introduce a new optional `EmptyLines` key for entries in `IncludeCategories`, allowing configuration of the number of empty lines inserted between include groups.

Add tests to validate the new behavior and update the documentation.