### PR TITLE
[LLD][AArch64] Handle R_AARCH64_TLS_DTPREL64 in non-alloc sections

### DIFF
--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -652,7 +652,6 @@ void AArch64::relocate(uint8_t *loc, const Relocation &rel,
     write32(ctx, loc, val);
     break;
   case R_AARCH64_TLS_DTPREL64:
-    checkInt(ctx, loc, val, 64, rel);
     write64(ctx, loc, val);
     break;
   case R_AARCH64_ADD_ABS_LO12_NC:

--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -156,6 +156,8 @@ RelExpr AArch64::getRelExpr(RelType type, const Symbol &s,
   case R_AARCH64_PREL32:
   case R_AARCH64_PREL64:
     return R_PC;
+  case R_AARCH64_TLS_DTPREL64:
+    return R_DTPREL;
   case R_AARCH64_NONE:
     return R_NONE;
   default:
@@ -648,6 +650,10 @@ void AArch64::relocate(uint8_t *loc, const Relocation &rel,
     // encode the schema.
     checkInt(ctx, loc, val, 32, rel);
     write32(ctx, loc, val);
+    break;
+  case R_AARCH64_TLS_DTPREL64:
+    checkInt(ctx, loc, val, 64, rel);
+    write64(ctx, loc, val);
     break;
   case R_AARCH64_ADD_ABS_LO12_NC:
   case R_AARCH64_AUTH_GOT_ADD_LO12_NC:

--- a/lld/test/ELF/aarch64-tls-dtprel.s
+++ b/lld/test/ELF/aarch64-tls-dtprel.s
@@ -4,8 +4,8 @@
 # RUN: ld.lld %t.o -o %t
 
 # CHECK:      .rela.debug_info {
-# CHECK-NEXT:   0x6 R_AARCH64_ABS32 .debug_abbrev 0x0
-# CHECK-NEXT:   0xD R_AARCH64_TLS_DTPREL64 var 0x0
+# CHECK-NEXT:   0x0 R_AARCH64_TLS_DTPREL64 var 0x0
+# CHECK-NEXT:   0x8 R_AARCH64_TLS_DTPREL64 var 0x1
 # CHECK-NEXT: }
 
 .section .tdata,"awT",@progbits
@@ -13,29 +13,6 @@
 var:
   .word 0
 
-.section .debug_abbrev,"",@progbits
-.byte 1                  // Abbreviation Code
-.byte 17                 // DW_TAG_compile_unit
-.byte 1                  // DW_CHILDREN_yes
-.byte 0                  // EOM(1)
-.byte 0                  // EOM(2)
-
-.byte 2                  // Abbreviation Code
-.byte 52                 // DW_TAG_variable
-.byte 0                  // DW_CHILDREN_no
-.byte 2;                 // DW_AT_location
-.byte 24                 // DW_FORM_exprloc
-.byte 0                  // EOM(1)
-.byte 0                  // EOM(2)
-
 .section        .debug_info,"",@progbits
-.Lcu_begin0:
-  .word .Lcu_end - .Lcu_body // Length of Unit
-.Lcu_body:
-  .hword 4               // DWARF version number
-  .word   .debug_abbrev  // Offset Into Abbrev. Section
-  .byte   8              // Address Size (in bytes)
-  .byte   1              // Abbrev [1] DW_TAG_compile_unit
-  .byte   2              // Abbrev [2] DW_TAG_variable
   .xword  %dtprel(var)
-.Lcu_end:
+  .xword  %dtprel(var+1)

--- a/lld/test/ELF/aarch64-tls-dtprel.s
+++ b/lld/test/ELF/aarch64-tls-dtprel.s
@@ -1,0 +1,41 @@
+# REQUIRES: aarch64
+# RUN: llvm-mc -filetype=obj -triple=aarch64-linux-gnu %s -o %t.o
+# RUN: llvm-readobj -r %t.o | FileCheck %s
+# RUN: ld.lld %t.o -o %t
+
+# CHECK:      .rela.debug_info {
+# CHECK-NEXT:   0x6 R_AARCH64_ABS32 .debug_abbrev 0x0
+# CHECK-NEXT:   0xD R_AARCH64_TLS_DTPREL64 var 0x0
+# CHECK-NEXT: }
+
+.section .tdata,"awT",@progbits
+.globl var
+var:
+  .word 0
+
+.section .debug_abbrev,"",@progbits
+.byte 1                  // Abbreviation Code
+.byte 17                 // DW_TAG_compile_unit
+.byte 1                  // DW_CHILDREN_yes
+.byte 0                  // EOM(1)
+.byte 0                  // EOM(2)
+
+.byte 2                  // Abbreviation Code
+.byte 52                 // DW_TAG_variable
+.byte 0                  // DW_CHILDREN_no
+.byte 2;                 // DW_AT_location
+.byte 24                 // DW_FORM_exprloc
+.byte 0                  // EOM(1)
+.byte 0                  // EOM(2)
+
+.section        .debug_info,"",@progbits
+.Lcu_begin0:
+  .word .Lcu_end - .Lcu_body // Length of Unit
+.Lcu_body:
+  .hword 4               // DWARF version number
+  .word   .debug_abbrev  // Offset Into Abbrev. Section
+  .byte   8              // Address Size (in bytes)
+  .byte   1              // Abbrev [1] DW_TAG_compile_unit
+  .byte   2              // Abbrev [2] DW_TAG_variable
+  .xword  %dtprel(var)
+.Lcu_end:

--- a/lld/test/ELF/aarch64-tls-dtprel.s
+++ b/lld/test/ELF/aarch64-tls-dtprel.s
@@ -1,14 +1,17 @@
 # REQUIRES: aarch64
-# RUN: llvm-mc -filetype=obj -triple=aarch64-linux-gnu %s -o %t.o
+# RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t.o
 # RUN: llvm-readobj -r %t.o | FileCheck %s
 # RUN: ld.lld %t.o -o %t
 
 # CHECK:      .rela.debug_info {
 # CHECK-NEXT:   0x0 R_AARCH64_TLS_DTPREL64 var 0x0
 # CHECK-NEXT:   0x8 R_AARCH64_TLS_DTPREL64 var 0x1
+# CHECK-NEXT:   0x10 R_AARCH64_TLS_DTPREL64 .tdata 0x0
+# CHECK-NEXT:   0x18 R_AARCH64_TLS_DTPREL64 .tdata 0x1
 # CHECK-NEXT: }
 
 .section .tdata,"awT",@progbits
+.skip 8
 .globl var
 var:
   .word 0
@@ -16,3 +19,5 @@ var:
 .section        .debug_info,"",@progbits
   .xword  %dtprel(var)
   .xword  %dtprel(var+1)
+  .xword  %dtprel(.tdata)
+  .xword  %dtprel(.tdata+1)


### PR DESCRIPTION
Clang plan to emit R_AARCH64_TLS_DTPREL64 in .debug_info (see PR #146572). LLD currently fails to recognize this relocation. 

This prevent the debugger from correctly locating TLS variables when using the DWARF DW_OP_GNU_push_tls_address or DW_AT_location with DTPREL offsets.

This patch adds support for R_AARCH64_TLS_DTPREL64, adds its mapping to R_DTPREL.