### PR TITLE
[clang][test] Add missing FileCheck pipe in n1311.c

### DIFF
--- a/clang/test/C/C11/n1311.c
+++ b/clang/test/C/C11/n1311.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -emit-llvm -o - %s
+// RUN: %clang_cc1 -emit-llvm -o - %s | FileCheck %s
 
 /* WG14 N1311: Yes
  * Initializing static or external variables


### PR DESCRIPTION
The test had CHECK directives that were never executed because the RUN line did not pipe the output to FileCheck.