### PR TITLE
[lldb][Process/FreeBSDKernelCore] Add assertion for pcb

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/CMakeLists.txt
@@ -1,3 +1,11 @@
+# Used for pcb assertion
+# List of architectures:
+# https://man.freebsd.org/cgi/man.cgi?query=arch&apropos=0&sektion=0&manpath=FreeBSD+16.0-CURRENT&format=html
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(HOST_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
+    add_definitions(-DFreeBSD_${HOST_ARCH})
+endif()
+
 lldb_tablegen(ProcessFreeBSDKernelCoreProperties.inc -gen-lldb-property-defs
   SOURCE ProcessFreeBSDKernelCoreProperties.td
   TARGET LLDBPluginProcessFreeBSDKernelCorePropertiesGen)

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/CMakeLists.txt
@@ -1,11 +1,3 @@
-# Used for pcb assertion
-# List of architectures:
-# https://man.freebsd.org/cgi/man.cgi?query=arch&apropos=0&sektion=0&manpath=FreeBSD+16.0-CURRENT&format=html
-if(CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD")
-    set(HOST_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
-    add_definitions(-DFreeBSD_${HOST_ARCH})
-endif()
-
 lldb_tablegen(ProcessFreeBSDKernelCoreProperties.inc -gen-lldb-property-defs
   SOURCE ProcessFreeBSDKernelCoreProperties.td
   TARGET LLDBPluginProcessFreeBSDKernelCorePropertiesGen)

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm.cpp
@@ -14,6 +14,11 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
+#ifdef FreeBSD_armv7
+#include <cstddef>
+#include <machine/frame.h>
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -60,6 +65,33 @@ bool RegisterContextFreeBSDKernelCore_arm::ReadRegister(
     llvm::support::ulittle32_t lr;
     llvm::support::ulittle32_t pc;
   } pcb;
+
+#ifdef FreeBSD_armv7
+  static_assert(offsetof(struct switchframe, sf_r4) ==
+                offsetof(decltype(pcb), r4));
+  static_assert(offsetof(struct switchframe, sf_r5) ==
+                offsetof(decltype(pcb), r5));
+  static_assert(offsetof(struct switchframe, sf_r6) ==
+                offsetof(decltype(pcb), r6));
+  static_assert(offsetof(struct switchframe, sf_r7) ==
+                offsetof(decltype(pcb), r7));
+  static_assert(offsetof(struct switchframe, sf_r8) ==
+                offsetof(decltype(pcb), r8));
+  static_assert(offsetof(struct switchframe, sf_r9) ==
+                offsetof(decltype(pcb), r9));
+  static_assert(offsetof(struct switchframe, sf_r10) ==
+                offsetof(decltype(pcb), r10));
+  static_assert(offsetof(struct switchframe, sf_r11) ==
+                offsetof(decltype(pcb), r11));
+  static_assert(offsetof(struct switchframe, sf_r12) ==
+                offsetof(decltype(pcb), r12));
+  static_assert(offsetof(struct switchframe, sf_sp) ==
+                offsetof(decltype(pcb), sp));
+  static_assert(offsetof(struct switchframe, sf_lr) ==
+                offsetof(decltype(pcb), lr));
+  static_assert(offsetof(struct switchframe, sf_pc) ==
+                offsetof(decltype(pcb), pc));
+#endif
 
   Status error;
   size_t rd =

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm.cpp
@@ -14,7 +14,7 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
-#ifdef FreeBSD_armv7
+#if defined(__FreeBSD__) && defined(__arm__)
 #include <cstddef>
 #include <machine/frame.h>
 #endif
@@ -66,7 +66,7 @@ bool RegisterContextFreeBSDKernelCore_arm::ReadRegister(
     llvm::support::ulittle32_t pc;
   } pcb;
 
-#ifdef FreeBSD_armv7
+#if defined(__FreeBSD__) && defined(__arm__)
   static_assert(offsetof(struct switchframe, sf_r4) ==
                 offsetof(decltype(pcb), r4));
   static_assert(offsetof(struct switchframe, sf_r5) ==

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm64.cpp
@@ -18,6 +18,12 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
+#ifdef FreeBSD_aarch64
+#include <cstddef>
+#include <machine/pcb.h>
+#include <sys/param.h>
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -52,6 +58,11 @@ bool RegisterContextFreeBSDKernelCore_arm64::ReadRegister(
     llvm::support::ulittle64_t sp;
   } pcb;
 
+#if defined(FreeBSD_aarch64) && __FreeBSD_version >= 1400084
+  static_assert(offsetof(struct pcb, pcb_x) == offsetof(decltype(pcb), x));
+  static_assert(offsetof(struct pcb, pcb_sp) == offsetof(decltype(pcb), sp));
+#endif
+
   // https://cgit.freebsd.org/src/tree/sys/arm64/include/pcb.h?h=stable%2F13
   struct {
     llvm::support::ulittle64_t x[30];
@@ -59,6 +70,12 @@ bool RegisterContextFreeBSDKernelCore_arm64::ReadRegister(
     llvm::support::ulittle64_t _reserved;
     llvm::support::ulittle64_t sp;
   } pcb13;
+
+#if defined(FreeBSD_aarch64) && __FreeBSD_version < 1400084
+  static_assert(offsetof(struct pcb, pcb_x) == offsetof(decltype(pcb13), x));
+  static_assert(offsetof(struct pcb, pcb_lr) == offsetof(decltype(pcb13), lr));
+  static_assert(offsetof(struct pcb, pcb_sp) == offsetof(decltype(pcb13), sp));
+#endif
 
   Status error;
   constexpr int FBSD14 = 1400084;
@@ -72,8 +89,8 @@ bool RegisterContextFreeBSDKernelCore_arm64::ReadRegister(
 
   // TODO: LLVM 24: Remove FreeBSD 13 support
   if (osreldate >= FBSD14) {
-    constexpr uint32_t PCB_FP = 10;
-    constexpr uint32_t PCB_LR = 11;
+    constexpr uint32_t pcb_fp = 10;
+    constexpr uint32_t pcb_lr = 11;
     size_t rd =
         m_thread.GetProcess()->ReadMemory(m_pcb_addr, &pcb, sizeof(pcb), error);
     if (rd != sizeof(pcb))
@@ -92,14 +109,14 @@ bool RegisterContextFreeBSDKernelCore_arm64::ReadRegister(
     case gpr_x27_arm64:
     case gpr_x28_arm64:
     case gpr_fp_arm64:
-      static_assert(gpr_fp_arm64 - gpr_x19_arm64 == PCB_FP,
+      static_assert(gpr_fp_arm64 - gpr_x19_arm64 == pcb_fp,
                     "nonconsecutive arm64 register numbers");
       value = pcb.x[reg - gpr_x19_arm64];
       break;
     case gpr_lr_arm64:
     case gpr_pc_arm64:
       // The pc of crashing thread is stored in lr.
-      static_assert(gpr_lr_arm64 - gpr_x19_arm64 == PCB_LR,
+      static_assert(gpr_lr_arm64 - gpr_x19_arm64 == pcb_lr,
                     "nonconsecutive arm64 register numbers");
       value = pcb.x[reg - gpr_x19_arm64];
       break;

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_arm64.cpp
@@ -18,7 +18,7 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
-#ifdef FreeBSD_aarch64
+#if defined(__FreeBSD__) && defined(__aarch64__)
 #include <cstddef>
 #include <machine/pcb.h>
 #include <sys/param.h>
@@ -58,7 +58,7 @@ bool RegisterContextFreeBSDKernelCore_arm64::ReadRegister(
     llvm::support::ulittle64_t sp;
   } pcb;
 
-#if defined(FreeBSD_aarch64) && __FreeBSD_version >= 1400084
+#if defined(__FreeBSD__) && defined(__aarch64__) && __FreeBSD_version >= 1400084
   static_assert(offsetof(struct pcb, pcb_x) == offsetof(decltype(pcb), x));
   static_assert(offsetof(struct pcb, pcb_sp) == offsetof(decltype(pcb), sp));
 #endif
@@ -71,7 +71,7 @@ bool RegisterContextFreeBSDKernelCore_arm64::ReadRegister(
     llvm::support::ulittle64_t sp;
   } pcb13;
 
-#if defined(FreeBSD_aarch64) && __FreeBSD_version < 1400084
+#if defined(__FreeBSD__) && defined(__aarch64__) && __FreeBSD_version < 1400084
   static_assert(offsetof(struct pcb, pcb_x) == offsetof(decltype(pcb13), x));
   static_assert(offsetof(struct pcb, pcb_lr) == offsetof(decltype(pcb13), lr));
   static_assert(offsetof(struct pcb, pcb_sp) == offsetof(decltype(pcb13), sp));

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_i386.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_i386.cpp
@@ -13,6 +13,11 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
+#ifdef FreeBSD_i386
+#include <cstddef>
+#include <machine/pcb.h>
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -49,6 +54,15 @@ bool RegisterContextFreeBSDKernelCore_i386::ReadRegister(
     llvm::support::ulittle32_t ebx;
     llvm::support::ulittle32_t eip;
   } pcb;
+
+#ifdef FreeBSD_i386
+  static_assert(offsetof(struct pcb, pcb_edi) == offsetof(decltype(pcb), edi));
+  static_assert(offsetof(struct pcb, pcb_esi) == offsetof(decltype(pcb), esi));
+  static_assert(offsetof(struct pcb, pcb_ebp) == offsetof(decltype(pcb), ebp));
+  static_assert(offsetof(struct pcb, pcb_esp) == offsetof(decltype(pcb), esp));
+  static_assert(offsetof(struct pcb, pcb_ebx) == offsetof(decltype(pcb), ebx));
+  static_assert(offsetof(struct pcb, pcb_eip) == offsetof(decltype(pcb), eip));
+#endif
 
   Status error;
   size_t rd =

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_i386.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_i386.cpp
@@ -13,7 +13,7 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
-#ifdef FreeBSD_i386
+#if defined(__FreeBSD__) && defined(__i386__)
 #include <cstddef>
 #include <machine/pcb.h>
 #endif
@@ -55,7 +55,7 @@ bool RegisterContextFreeBSDKernelCore_i386::ReadRegister(
     llvm::support::ulittle32_t eip;
   } pcb;
 
-#ifdef FreeBSD_i386
+#if defined(__FreeBSD__) && defined(__i386__)
   static_assert(offsetof(struct pcb, pcb_edi) == offsetof(decltype(pcb), edi));
   static_assert(offsetof(struct pcb, pcb_esi) == offsetof(decltype(pcb), esi));
   static_assert(offsetof(struct pcb, pcb_ebp) == offsetof(decltype(pcb), ebp));

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_ppc64le.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_ppc64le.cpp
@@ -13,6 +13,11 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
+#ifdef FreeBSD_powerpc64le
+#include <cstddef>
+#include <machine/pcb.h>
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -36,6 +41,15 @@ bool RegisterContextFreeBSDKernelCore_ppc64le::ReadRegister(
     llvm::support::ulittle64_t toc;
     llvm::support::ulittle64_t lr;
   } pcb;
+
+#ifdef FreeBSD_powerpc64le
+  static_assert(offsetof(struct pcb, pcb_context) ==
+                offsetof(decltype(pcb), context));
+  static_assert(offsetof(struct pcb, pcb_cr) == offsetof(decltype(pcb), cr));
+  static_assert(offsetof(struct pcb, pcb_sp) == offsetof(decltype(pcb), sp));
+  static_assert(offsetof(struct pcb, pcb_toc) == offsetof(decltype(pcb), toc));
+  static_assert(offsetof(struct pcb, pcb_lr) == offsetof(decltype(pcb), lr));
+#endif
 
   Status error;
   size_t rd =

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_ppc64le.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_ppc64le.cpp
@@ -13,7 +13,7 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
-#ifdef FreeBSD_powerpc64le
+#if defined(__FreeBSD__) && defined(__powerpc64__) && defined(__LITTLE_ENDIAN__)
 #include <cstddef>
 #include <machine/pcb.h>
 #endif
@@ -42,7 +42,7 @@ bool RegisterContextFreeBSDKernelCore_ppc64le::ReadRegister(
     llvm::support::ulittle64_t lr;
   } pcb;
 
-#ifdef FreeBSD_powerpc64le
+#if defined(__FreeBSD__) && defined(__powerpc64__) && defined(__LITTLE_ENDIAN__)
   static_assert(offsetof(struct pcb, pcb_context) ==
                 offsetof(decltype(pcb), context));
   static_assert(offsetof(struct pcb, pcb_cr) == offsetof(decltype(pcb), cr));

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_riscv64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_riscv64.cpp
@@ -13,6 +13,11 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
+#ifdef FreeBSD_riscv64
+#include <cstddef>
+#include <machine/pcb.h>
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -51,6 +56,14 @@ bool RegisterContextFreeBSDKernelCore_riscv64::ReadRegister(
     llvm::support::ulittle64_t tp;
     llvm::support::ulittle64_t s[12];
   } pcb;
+
+#ifdef FreeBSD_riscv64
+  static_assert(offsetof(struct pcb, pcb_ra) == offsetof(decltype(pcb), ra));
+  static_assert(offsetof(struct pcb, pcb_sp) == offsetof(decltype(pcb), sp));
+  static_assert(offsetof(struct pcb, pcb_gp) == offsetof(decltype(pcb), gp));
+  static_assert(offsetof(struct pcb, pcb_tp) == offsetof(decltype(pcb), tp));
+  static_assert(offsetof(struct pcb, pcb_s) == offsetof(decltype(pcb), s));
+#endif
 
   Status error;
   size_t rd =

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_riscv64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_riscv64.cpp
@@ -13,7 +13,7 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
-#ifdef FreeBSD_riscv64
+#if defined(__FreeBSD__) && defined(__riscv) && __riscv_xlen == 64
 #include <cstddef>
 #include <machine/pcb.h>
 #endif
@@ -57,7 +57,7 @@ bool RegisterContextFreeBSDKernelCore_riscv64::ReadRegister(
     llvm::support::ulittle64_t s[12];
   } pcb;
 
-#ifdef FreeBSD_riscv64
+#if defined(__FreeBSD__) && defined(__riscv) && __riscv_xlen == 64
   static_assert(offsetof(struct pcb, pcb_ra) == offsetof(decltype(pcb), ra));
   static_assert(offsetof(struct pcb, pcb_sp) == offsetof(decltype(pcb), sp));
   static_assert(offsetof(struct pcb, pcb_gp) == offsetof(decltype(pcb), gp));

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_x86_64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_x86_64.cpp
@@ -13,6 +13,11 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
+#ifdef FreeBSD_amd64
+#include <cstddef>
+#include <machine/pcb.h>
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -53,6 +58,17 @@ bool RegisterContextFreeBSDKernelCore_x86_64::ReadRegister(
     llvm::support::ulittle64_t rbx;
     llvm::support::ulittle64_t rip;
   } pcb;
+
+#ifdef FreeBSD_amd64
+  static_assert(offsetof(struct pcb, pcb_r15) == offsetof(decltype(pcb), r15));
+  static_assert(offsetof(struct pcb, pcb_r14) == offsetof(decltype(pcb), r14));
+  static_assert(offsetof(struct pcb, pcb_r13) == offsetof(decltype(pcb), r13));
+  static_assert(offsetof(struct pcb, pcb_r12) == offsetof(decltype(pcb), r12));
+  static_assert(offsetof(struct pcb, pcb_rbp) == offsetof(decltype(pcb), rbp));
+  static_assert(offsetof(struct pcb, pcb_rsp) == offsetof(decltype(pcb), rsp));
+  static_assert(offsetof(struct pcb, pcb_rbx) == offsetof(decltype(pcb), rbx));
+  static_assert(offsetof(struct pcb, pcb_rip) == offsetof(decltype(pcb), rip));
+#endif
 
   Status error;
   size_t rd =

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_x86_64.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/RegisterContextFreeBSDKernelCore_x86_64.cpp
@@ -13,7 +13,7 @@
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/Support/Endian.h"
 
-#ifdef FreeBSD_amd64
+#if defined(__FreeBSD__) && defined(__amd64__)
 #include <cstddef>
 #include <machine/pcb.h>
 #endif
@@ -59,7 +59,7 @@ bool RegisterContextFreeBSDKernelCore_x86_64::ReadRegister(
     llvm::support::ulittle64_t rip;
   } pcb;
 
-#ifdef FreeBSD_amd64
+#if defined(__FreeBSD__) && defined(__amd64__)
   static_assert(offsetof(struct pcb, pcb_r15) == offsetof(decltype(pcb), r15));
   static_assert(offsetof(struct pcb, pcb_r14) == offsetof(decltype(pcb), r14));
   static_assert(offsetof(struct pcb, pcb_r13) == offsetof(decltype(pcb), r13));


### PR DESCRIPTION
pcb layout is not stable yet so it can be changed anytime on FreeBSD side. Changes to pcb might not be reflected to FreeBSD source tree or upstream LLDB possibly because the developer forgot to do so, which breaks kernel debugging functionality. This patch adds assertion thus LLDB cannot be built if its expected pcb layout doesn't match the real one. This assertion is only enabled when the build machine architecture matches `RegisterContextFreeBSDKernelCore_<arch>`.

Due to identifier conflict, I had to lower PCB_FP and PCB_LR.