### PR TITLE
[libc][math] Cleanup shared/math

### DIFF
--- a/libc/shared/math/asinf16.h
+++ b/libc/shared/math/asinf16.h
@@ -9,10 +9,11 @@
 #ifndef LLVM_LIBC_SHARED_MATH_ASINF16_H
 #define LLVM_LIBC_SHARED_MATH_ASINF16_H
 
-#include "shared/libc_common.h"
+#include "include/llvm-libc-macros/float16-macros.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/asinf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/asinhf16.h
+++ b/libc/shared/math/asinhf16.h
@@ -9,10 +9,11 @@
 #ifndef LLVM_LIBC_SHARED_MATH_ASINHF16_H
 #define LLVM_LIBC_SHARED_MATH_ASINHF16_H
 
-#include "shared/libc_common.h"
+#include "include/llvm-libc-macros/float16-macros.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/asinhf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/asinpif16.h
+++ b/libc/shared/math/asinpif16.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_ASINPIF16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/asinpif16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/atanf16.h
+++ b/libc/shared/math/atanf16.h
@@ -9,10 +9,11 @@
 #ifndef LLVM_LIBC_SHARED_MATH_ATANF16_H
 #define LLVM_LIBC_SHARED_MATH_ATANF16_H
 
-#include "shared/libc_common.h"
+#include "include/llvm-libc-macros/float16-macros.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/atanf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/atanhf16.h
+++ b/libc/shared/math/atanhf16.h
@@ -9,10 +9,11 @@
 #ifndef LLVM_LIBC_SHARED_MATH_ATANHF16_H
 #define LLVM_LIBC_SHARED_MATH_ATANHF16_H
 
-#include "shared/libc_common.h"
+#include "include/llvm-libc-macros/float16-macros.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/atanhf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/bf16fmaf128.h
+++ b/libc/shared/math/bf16fmaf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/bf16fmaf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/bf16mul.h
+++ b/libc/shared/math/bf16mul.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_BF16MUL_H
 #define LLVM_LIBC_SHARED_MATH_BF16MUL_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/bf16mul.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/bf16mulf.h
+++ b/libc/shared/math/bf16mulf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_BF16MULF_H
 #define LLVM_LIBC_SHARED_MATH_BF16MULF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/bf16mulf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/bf16mulf128.h
+++ b/libc/shared/math/bf16mulf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/bf16mulf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/bf16mull.h
+++ b/libc/shared/math/bf16mull.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_BF16MULL_H
 #define LLVM_LIBC_SHARED_MATH_BF16MULL_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/bf16mull.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/bf16sub.h
+++ b/libc/shared/math/bf16sub.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_BF16SUB_H
 #define LLVM_LIBC_SHARED_MATH_BF16SUB_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/bf16sub.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/bf16subf.h
+++ b/libc/shared/math/bf16subf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_BF16SUBF_H
 #define LLVM_LIBC_SHARED_MATH_BF16SUBF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/bf16subf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/bf16subf128.h
+++ b/libc/shared/math/bf16subf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/bf16subf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/ceil.h
+++ b/libc/shared/math/ceil.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_CEIL_H
 #define LLVM_LIBC_SHARED_MATH_CEIL_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/ceil.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/ceilbf16.h
+++ b/libc/shared/math/ceilbf16.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_CEILBF16_H
 #define LLVM_LIBC_SHARED_MATH_CEILBF16_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/ceilbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/ceilf.h
+++ b/libc/shared/math/ceilf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_CEILF_H
 #define LLVM_LIBC_SHARED_MATH_CEILF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/ceilf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/ceilf128.h
+++ b/libc/shared/math/ceilf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/ceilf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/ceilf16.h
+++ b/libc/shared/math/ceilf16.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/ceilf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/ceill.h
+++ b/libc/shared/math/ceill.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_CEILL_H
 #define LLVM_LIBC_SHARED_MATH_CEILL_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/ceill.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/cosf16.h
+++ b/libc/shared/math/cosf16.h
@@ -9,10 +9,11 @@
 #ifndef LLVM_LIBC_SHARED_MATH_COSF16_H
 #define LLVM_LIBC_SHARED_MATH_COSF16_H
 
-#include "shared/libc_common.h"
+#include "include/llvm-libc-macros/float16-macros.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/cosf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/coshf16.h
+++ b/libc/shared/math/coshf16.h
@@ -9,10 +9,11 @@
 #ifndef LLVM_LIBC_SHARED_MATH_COSHF16_H
 #define LLVM_LIBC_SHARED_MATH_COSHF16_H
 
-#include "shared/libc_common.h"
+#include "include/llvm-libc-macros/float16-macros.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/coshf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/cospif16.h
+++ b/libc/shared/math/cospif16.h
@@ -9,10 +9,11 @@
 #ifndef LLVM_LIBC_SHARED_MATH_COSPIF16_H
 #define LLVM_LIBC_SHARED_MATH_COSPIF16_H
 
-#include "shared/libc_common.h"
+#include "include/llvm-libc-macros/float16-macros.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/cospif16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/dfmal.h
+++ b/libc/shared/math/dfmal.h
@@ -10,7 +10,6 @@
 #define LLVM_LIBC_SHARED_MATH_DFMAL_H
 
 #include "shared/libc_common.h"
-
 #include "src/__support/math/dfmal.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/exp10f16.h
+++ b/libc/shared/math/exp10f16.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_EXP10F16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/exp10f16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/exp10m1f16.h
+++ b/libc/shared/math/exp10m1f16.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_EXP10M1F16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/exp10m1f16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/exp2f16.h
+++ b/libc/shared/math/exp2f16.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_EXP2F16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/exp2f16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/exp2m1f16.h
+++ b/libc/shared/math/exp2m1f16.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_EXP2M1F16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/exp2m1f16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/expf16.h
+++ b/libc/shared/math/expf16.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_EXPF16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/expf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/expm1f16.h
+++ b/libc/shared/math/expm1f16.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_EXPM1F16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/expm1f16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16div.h
+++ b/libc/shared/math/f16div.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16div.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16divf.h
+++ b/libc/shared/math/f16divf.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16divf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16divf128.h
+++ b/libc/shared/math/f16divf128.h
@@ -15,6 +15,7 @@
 #ifdef LIBC_TYPES_HAS_FLOAT16
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16divf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16divl.h
+++ b/libc/shared/math/f16divl.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16divl.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16fma.h
+++ b/libc/shared/math/f16fma.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_F16FMA_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16fma.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16fmaf.h
+++ b/libc/shared/math/f16fmaf.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_F16FMAF_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16fmaf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16fmaf128.h
+++ b/libc/shared/math/f16fmaf128.h
@@ -11,11 +11,11 @@
 
 #include "include/llvm-libc-macros/float16-macros.h"
 #include "include/llvm-libc-types/float128.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16fmaf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16fmal.h
+++ b/libc/shared/math/f16fmal.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_F16FMAL_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16fmal.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16mul.h
+++ b/libc/shared/math/f16mul.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16mul.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16mulf.h
+++ b/libc/shared/math/f16mulf.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16mulf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16mulf128.h
+++ b/libc/shared/math/f16mulf128.h
@@ -15,6 +15,7 @@
 #ifdef LIBC_TYPES_HAS_FLOAT16
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16mulf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16mull.h
+++ b/libc/shared/math/f16mull.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16mull.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16sqrtf128.h
+++ b/libc/shared/math/f16sqrtf128.h
@@ -11,11 +11,11 @@
 
 #include "include/llvm-libc-macros/float16-macros.h"
 #include "include/llvm-libc-types/float128.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16sqrtf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16sqrtl.h
+++ b/libc/shared/math/f16sqrtl.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16sqrtl.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16sub.h
+++ b/libc/shared/math/f16sub.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16sub.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16subf.h
+++ b/libc/shared/math/f16subf.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16subf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16subf128.h
+++ b/libc/shared/math/f16subf128.h
@@ -15,6 +15,7 @@
 #ifdef LIBC_TYPES_HAS_FLOAT16
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16subf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/f16subl.h
+++ b/libc/shared/math/f16subl.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/f16subl.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fadd.h
+++ b/libc/shared/math/fadd.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FADD_H
 #define LLVM_LIBC_SHARED_MATH_FADD_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fadd.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/faddf128.h
+++ b/libc/shared/math/faddf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/faddf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/faddl.h
+++ b/libc/shared/math/faddl.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FADDL_H
 #define LLVM_LIBC_SHARED_MATH_FADDL_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/faddl.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fdim.h
+++ b/libc/shared/math/fdim.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FDIM_H
 #define LLVM_LIBC_SHARED_MATH_FDIM_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fdim.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fdimbf16.h
+++ b/libc/shared/math/fdimbf16.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FDIMBF16_H
 #define LLVM_LIBC_SHARED_MATH_FDIMBF16_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fdimbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fdimf.h
+++ b/libc/shared/math/fdimf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FDIMF_H
 #define LLVM_LIBC_SHARED_MATH_FDIMF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fdimf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fdimf128.h
+++ b/libc/shared/math/fdimf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fdimf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fdimf16.h
+++ b/libc/shared/math/fdimf16.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fdimf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fdiml.h
+++ b/libc/shared/math/fdiml.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FDIML_H
 #define LLVM_LIBC_SHARED_MATH_FDIML_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fdiml.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/floor.h
+++ b/libc/shared/math/floor.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FLOOR_H
 #define LLVM_LIBC_SHARED_MATH_FLOOR_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/floor.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/floorbf16.h
+++ b/libc/shared/math/floorbf16.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FLOORBF16_H
 #define LLVM_LIBC_SHARED_MATH_FLOORBF16_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/floorbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/floorf.h
+++ b/libc/shared/math/floorf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FLOORF_H
 #define LLVM_LIBC_SHARED_MATH_FLOORF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/floorf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/floorf128.h
+++ b/libc/shared/math/floorf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/floorf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/floorf16.h
+++ b/libc/shared/math/floorf16.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/floorf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/floorl.h
+++ b/libc/shared/math/floorl.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FLOORL_H
 #define LLVM_LIBC_SHARED_MATH_FLOORL_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/floorl.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fmax.h
+++ b/libc/shared/math/fmax.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FMAX_H
 #define LLVM_LIBC_SHARED_MATH_FMAX_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fmax.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fmaxbf16.h
+++ b/libc/shared/math/fmaxbf16.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FMAXBF16_H
 #define LLVM_LIBC_SHARED_MATH_FMAXBF16_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fmaxbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fmaxf.h
+++ b/libc/shared/math/fmaxf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FMAXF_H
 #define LLVM_LIBC_SHARED_MATH_FMAXF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fmaxf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fmaxf128.h
+++ b/libc/shared/math/fmaxf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fmaxf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fmaxf16.h
+++ b/libc/shared/math/fmaxf16.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fmaxf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fmaxl.h
+++ b/libc/shared/math/fmaxl.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_FMAXL_H
 #define LLVM_LIBC_SHARED_MATH_FMAXL_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fmaxl.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/frexpf16.h
+++ b/libc/shared/math/frexpf16.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_FREXPF16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/frexpf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/fsqrtf128.h
+++ b/libc/shared/math/fsqrtf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/fsqrtf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/getpayload.h
+++ b/libc/shared/math/getpayload.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_GETPAYLOAD_H
 #define LLVM_LIBC_SHARED_MATH_GETPAYLOAD_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/getpayload.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/getpayloadbf16.h
+++ b/libc/shared/math/getpayloadbf16.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_GETPAYLOADBF16_H
 #define LLVM_LIBC_SHARED_MATH_GETPAYLOADBF16_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/getpayloadbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/getpayloadf.h
+++ b/libc/shared/math/getpayloadf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_GETPAYLOADF_H
 #define LLVM_LIBC_SHARED_MATH_GETPAYLOADF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/getpayloadf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/getpayloadf128.h
+++ b/libc/shared/math/getpayloadf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/getpayloadf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/getpayloadf16.h
+++ b/libc/shared/math/getpayloadf16.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/getpayloadf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/getpayloadl.h
+++ b/libc/shared/math/getpayloadl.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_GETPAYLOADL_H
 #define LLVM_LIBC_SHARED_MATH_GETPAYLOADL_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/getpayloadl.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/hypotf.h
+++ b/libc/shared/math/hypotf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_HYPOTF_H
 #define LLVM_LIBC_SHARED_MATH_HYPOTF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/hypotf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/hypotf16.h
+++ b/libc/shared/math/hypotf16.h
@@ -10,20 +10,18 @@
 #define LLVM_LIBC_SHARED_MATH_HYPOTF16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/hypotf16.h"
 
 namespace LIBC_NAMESPACE_DECL {
-
 namespace shared {
 
 using math::hypotf16;
 
 } // namespace shared
-
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LIBC_TYPES_HAS_FLOAT16

--- a/libc/shared/math/ilogbf.h
+++ b/libc/shared/math/ilogbf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_ILOGBF_H
 #define LLVM_LIBC_SHARED_MATH_ILOGBF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/ilogbf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/ilogbf16.h
+++ b/libc/shared/math/ilogbf16.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/ilogbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/ldexpf16.h
+++ b/libc/shared/math/ldexpf16.h
@@ -17,13 +17,11 @@
 #include "src/__support/math/ldexpf16.h"
 
 namespace LIBC_NAMESPACE_DECL {
-
 namespace shared {
 
 using math::ldexpf16;
 
 } // namespace shared
-
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LIBC_TYPES_HAS_FLOAT16

--- a/libc/shared/math/log.h
+++ b/libc/shared/math/log.h
@@ -11,12 +11,13 @@
 
 #include "shared/libc_common.h"
 #include "src/__support/math/log.h"
+
 namespace LIBC_NAMESPACE_DECL {
-
 namespace shared {
-using math::log;
-} // namespace shared
 
+using math::log;
+
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LLVM_LIBC_SHARED_MATH_LOG_H

--- a/libc/shared/math/log10.h
+++ b/libc/shared/math/log10.h
@@ -11,12 +11,13 @@
 
 #include "shared/libc_common.h"
 #include "src/__support/math/log10.h"
+
 namespace LIBC_NAMESPACE_DECL {
-
 namespace shared {
-using math::log10;
-} // namespace shared
 
+using math::log10;
+
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LLVM_LIBC_SHARED_MATH_LOG10_H

--- a/libc/shared/math/log1p.h
+++ b/libc/shared/math/log1p.h
@@ -11,12 +11,13 @@
 
 #include "shared/libc_common.h"
 #include "src/__support/math/log1p.h"
+
 namespace LIBC_NAMESPACE_DECL {
-
 namespace shared {
-using math::log1p;
-} // namespace shared
 
+using math::log1p;
+
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LLVM_LIBC_SHARED_MATH_LOG1P_H

--- a/libc/shared/math/log2.h
+++ b/libc/shared/math/log2.h
@@ -11,12 +11,13 @@
 
 #include "shared/libc_common.h"
 #include "src/__support/math/log2.h"
+
 namespace LIBC_NAMESPACE_DECL {
-
 namespace shared {
-using math::log2;
-} // namespace shared
 
+using math::log2;
+
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LLVM_LIBC_SHARED_MATH_LOG2_H

--- a/libc/shared/math/logb.h
+++ b/libc/shared/math/logb.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_LOGB_H
 #define LLVM_LIBC_SHARED_MATH_LOGB_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/logb.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/logbf.h
+++ b/libc/shared/math/logbf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_LOGBF_H
 #define LLVM_LIBC_SHARED_MATH_LOGBF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/logbf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/logbf128.h
+++ b/libc/shared/math/logbf128.h
@@ -11,10 +11,9 @@
 
 #include "include/llvm-libc-types/float128.h"
 
-#include "shared/libc_common.h"
-
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/logbf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/logbf16.h
+++ b/libc/shared/math/logbf16.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_LOGBF16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/logbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/logf16.h
+++ b/libc/shared/math/logf16.h
@@ -10,9 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_LOGF16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
+
+#include "shared/libc_common.h"
 #include "src/__support/math/logf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayload.h
+++ b/libc/shared/math/setpayload.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_SETPAYLOAD_H
 #define LLVM_LIBC_SHARED_MATH_SETPAYLOAD_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayload.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayloadbf16.h
+++ b/libc/shared/math/setpayloadbf16.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_SETPAYLOADBF16_H
 #define LLVM_LIBC_SHARED_MATH_SETPAYLOADBF16_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayloadbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayloadf.h
+++ b/libc/shared/math/setpayloadf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_SETPAYLOADF_H
 #define LLVM_LIBC_SHARED_MATH_SETPAYLOADF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayloadf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayloadf128.h
+++ b/libc/shared/math/setpayloadf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayloadf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayloadf16.h
+++ b/libc/shared/math/setpayloadf16.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayloadf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayloadl.h
+++ b/libc/shared/math/setpayloadl.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_SETPAYLOADL_H
 #define LLVM_LIBC_SHARED_MATH_SETPAYLOADL_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayloadl.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayloadsig.h
+++ b/libc/shared/math/setpayloadsig.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_SETPAYLOADSIG_H
 #define LLVM_LIBC_SHARED_MATH_SETPAYLOADSIG_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayloadsig.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayloadsigbf16.h
+++ b/libc/shared/math/setpayloadsigbf16.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_SETPAYLOADSIGBF16_H
 #define LLVM_LIBC_SHARED_MATH_SETPAYLOADSIGBF16_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayloadsigbf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayloadsigf.h
+++ b/libc/shared/math/setpayloadsigf.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_SETPAYLOADSIGF_H
 #define LLVM_LIBC_SHARED_MATH_SETPAYLOADSIGF_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayloadsigf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayloadsigf128.h
+++ b/libc/shared/math/setpayloadsigf128.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayloadsigf128.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayloadsigf16.h
+++ b/libc/shared/math/setpayloadsigf16.h
@@ -13,6 +13,7 @@
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayloadsigf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/setpayloadsigl.h
+++ b/libc/shared/math/setpayloadsigl.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SHARED_MATH_SETPAYLOADSIGL_H
 #define LLVM_LIBC_SHARED_MATH_SETPAYLOADSIGL_H
 
+#include "shared/libc_common.h"
 #include "src/__support/math/setpayloadsigl.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/sinhf16.h
+++ b/libc/shared/math/sinhf16.h
@@ -10,10 +10,10 @@
 #define LLVM_LIBC_SHARED_MATH_SINHF16_H
 
 #include "include/llvm-libc-macros/float16-macros.h"
-#include "shared/libc_common.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/sinhf16.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/shared/math/tanpif16.h
+++ b/libc/shared/math/tanpif16.h
@@ -9,10 +9,11 @@
 #ifndef LLVM_LIBC_SHARED_MATH_TANPIF16_H
 #define LLVM_LIBC_SHARED_MATH_TANPIF16_H
 
-#include "shared/libc_common.h"
+#include "include/llvm-libc-macros/float16-macros.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
+#include "shared/libc_common.h"
 #include "src/__support/math/tanpif16.h"
 
 namespace LIBC_NAMESPACE_DECL {


### PR DESCRIPTION
- Clean file format for consistency
- Ensure `#include "shared/libc_common.h"` is present in every file
- Fix macro source header (`float16`, `float128`, etc)