### PR TITLE
[clang] fix common type calculation for l-values of 'void' type

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -300,6 +300,7 @@ Bug Fixes in This Version
 - Fixes an assertion failure when evaluating ``__underlying_type`` on enum redeclarations. (#GH177943)
 - Fixed an assertion failure caused by nested macro expansion during header-name lexing (``__has_embed(__has_include)``). (#GH178635)
 - Clang now outputs relative paths of embeds for dependency output. (#GH161950)
+- Fix the result type of a binary operation where both operands are 'void' l-values. (#GH111300)
 - Fixed an assertion failure when evaluating ``_Countof`` on invalid ``void``-typed operands. (#GH180893)
 - Fixed an assertion failure in the serialized diagnostic printer when it is destroyed without calling ``finish()``. (#GH140433)
 - Fixed an assertion failure caused by error recovery while extending a nested name specifier with results from ordinary lookup. (#GH181470)

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -8892,9 +8892,9 @@ QualType Sema::CheckConditionalOperands(ExprResult &Cond, ExprResult &LHS,
   // C99 6.5.15p5: "If both operands have void type, the result has void type."
   // The following || allows only one side to be void (a GCC-ism).
   if (LHSTy->isVoidType() || RHSTy->isVoidType()) {
-    QualType ResTy;
     if (LHSTy->isVoidType() && RHSTy->isVoidType()) {
-      ResTy = Context.getCommonSugaredType(LHSTy, RHSTy);
+      // UsualArithmeticConversions already handled the case where both sides
+      // are the same type.
     } else if (RHSTy->isVoidType()) {
       ResTy = RHSTy;
       Diag(RHS.get()->getBeginLoc(), diag::ext_typecheck_cond_one_void)

--- a/clang/test/Sema/sugar-common-types.c
+++ b/clang/test/Sema/sugar-common-types.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c99 -triple aarch64 -target-feature +bf16 -target-feature +sve
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c99 -triple aarch64 -target-feature +bf16 -target-feature +sve -Wno-void-ptr-dereference
 
 typedef struct N {} N;
 
@@ -42,3 +42,7 @@ void f8() {
   Y6 y6;
   N t8 = 0 ? x6 : y6; // expected-error {{incompatible type 'B6'}}
 }
+
+const volatile X2 *x7;
+volatile Y2 *y7;
+N t9 = 0 ? *x7 : *y7; // expected-error {{incompatible type 'B2'}}


### PR DESCRIPTION
Fixes #111300