### PR TITLE
[lldb][Process/FreeBSDKernelCore] Set kernel displacement

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -118,7 +118,7 @@ bool ProcessFreeBSDKernelCore::CanDebug(lldb::TargetSP target_sp,
 
 Status ProcessFreeBSDKernelCore::DoLoadCore() {
   // The core is already loaded by CreateInstance().
-  ApplyKASLR();
+  SetKernelDisplacement();
 
   return Status();
 }
@@ -326,7 +326,7 @@ lldb::addr_t ProcessFreeBSDKernelCore::FindSymbol(const char *name) {
   return sym ? sym->GetLoadAddress(&GetTarget()) : LLDB_INVALID_ADDRESS;
 }
 
-void ProcessFreeBSDKernelCore::ApplyKASLR() {
+void ProcessFreeBSDKernelCore::SetKernelDisplacement() {
   kssize_t displacement = kvm_kerndisp(m_kvm);
 
   if (displacement == 0)

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -118,6 +118,8 @@ bool ProcessFreeBSDKernelCore::CanDebug(lldb::TargetSP target_sp,
 
 Status ProcessFreeBSDKernelCore::DoLoadCore() {
   // The core is already loaded by CreateInstance().
+  ApplyKASLR();
+
   return Status();
 }
 
@@ -322,6 +324,28 @@ lldb::addr_t ProcessFreeBSDKernelCore::FindSymbol(const char *name) {
   ModuleSP mod_sp = GetTarget().GetExecutableModule();
   const Symbol *sym = mod_sp->FindFirstSymbolWithNameAndType(ConstString(name));
   return sym ? sym->GetLoadAddress(&GetTarget()) : LLDB_INVALID_ADDRESS;
+}
+
+void ProcessFreeBSDKernelCore::ApplyKASLR() {
+  kssize_t displacement = kvm_kerndisp(m_kvm);
+
+  if (displacement == 0)
+    return;
+
+  Target &target = GetTarget();
+  lldb::ModuleSP kernel_module_sp = target.GetExecutableModule();
+  if (!kernel_module_sp)
+    return;
+
+  bool changed = false;
+  kernel_module_sp->SetLoadAddress(
+      target, static_cast<lldb::addr_t>(displacement), true, changed);
+
+  if (changed) {
+    ModuleList loaded_module_list;
+    loaded_module_list.Append(kernel_module_sp);
+    target.ModulesDidLoad(loaded_module_list);
+  }
 }
 
 void ProcessFreeBSDKernelCore::PrintUnreadMessage() {

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -338,8 +338,10 @@ void ProcessFreeBSDKernelCore::SetKernelDisplacement() {
     return;
 
   bool changed = false;
-  kernel_module_sp->SetLoadAddress(
-      target, static_cast<lldb::addr_t>(displacement), true, changed);
+  // Set offset (or displacement), not absolute address value.
+  kernel_module_sp->SetLoadAddress(target,
+                                   static_cast<lldb::addr_t>(displacement),
+                                   /*value_is_offset*/ true, changed);
 
   if (changed) {
     ModuleList loaded_module_list;

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -338,10 +338,9 @@ void ProcessFreeBSDKernelCore::SetKernelDisplacement() {
     return;
 
   bool changed = false;
-  // Set offset (or displacement), not absolute address value.
   kernel_module_sp->SetLoadAddress(target,
                                    static_cast<lldb::addr_t>(displacement),
-                                   /*value_is_offset*/ true, changed);
+                                   /*value_is_offset=*/true, changed);
 
   if (changed) {
     ModuleList loaded_module_list;

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
@@ -64,7 +64,7 @@ protected:
   lldb::addr_t FindSymbol(const char *name);
 
 private:
-  void ApplyKASLR();
+  void SetKernelDisplacement();
 
   void PrintUnreadMessage();
 

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.h
@@ -64,6 +64,8 @@ protected:
   lldb::addr_t FindSymbol(const char *name);
 
 private:
+  void ApplyKASLR();
+
   void PrintUnreadMessage();
 
   const char *GetError();

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -230,8 +230,6 @@ Changes to LLDB
   `plugin.process.freebsd-kernel-core.read-only` must be set to `false`. This setting is available when
   using `/dev/mem` or a kernel dump. However, since `kvm_write()` does not support writing to kernel dumps,
   writes to a kernel dump will still fail when the setting is false.
-* Debugging core with KASLR applied is now supported. Note that this does not work for some crash dumps due to
-  kvm's limitations.
 
 ### Linux
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -230,8 +230,8 @@ Changes to LLDB
   `plugin.process.freebsd-kernel-core.read-only` must be set to `false`. This setting is available when
   using `/dev/mem` or a kernel dump. However, since `kvm_write()` does not support writing to kernel dumps,
   writes to a kernel dump will still fail when the setting is false.
-* Debugging core with KASLR applied is now supported. Note that this doesn't work for some crash dumps due to
-  kvm's limitation.
+* Debugging core with KASLR applied is now supported. Note that this does not work for some crash dumps due to
+  kvm's limitations.
 
 ### Linux
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -230,6 +230,8 @@ Changes to LLDB
   `plugin.process.freebsd-kernel-core.read-only` must be set to `false`. This setting is available when
   using `/dev/mem` or a kernel dump. However, since `kvm_write()` does not support writing to kernel dumps,
   writes to a kernel dump will still fail when the setting is false.
+* Debugging core with KASLR applied is now supported. Note that this doesn't work for some crash dumps due to
+  kvm's limitation.
 
 ### Linux
 


### PR DESCRIPTION
Use `kvm_kerndisp()` on core load to retrieve the kernel displacement, that is the difference between the kernel's
base virtual address at run time and the kernel base virtual address specified in the kernel image file. Currently PowerPC is the only architecture supporting kernel displacement.