### PR TITLE
[lldb][FreeBSD] Fix some missed renaming to x86 for shared files

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_x86.h
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_x86.h
@@ -33,9 +33,8 @@ namespace process_freebsd {
 
 class NativeProcessFreeBSD;
 
-class NativeRegisterContextFreeBSD_x86
-    : public NativeRegisterContextFreeBSD,
-      public NativeRegisterContextDBReg_x86 {
+class NativeRegisterContextFreeBSD_x86 : public NativeRegisterContextFreeBSD,
+                                         public NativeRegisterContextDBReg_x86 {
 public:
   NativeRegisterContextFreeBSD_x86(const ArchSpec &target_arch,
                                    NativeThreadFreeBSD &native_thread);

--- a/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_x86.h
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeRegisterContextFreeBSD_x86.h
@@ -33,12 +33,12 @@ namespace process_freebsd {
 
 class NativeProcessFreeBSD;
 
-class NativeRegisterContextFreeBSD_x86_64
+class NativeRegisterContextFreeBSD_x86
     : public NativeRegisterContextFreeBSD,
       public NativeRegisterContextDBReg_x86 {
 public:
-  NativeRegisterContextFreeBSD_x86_64(const ArchSpec &target_arch,
-                                      NativeThreadFreeBSD &native_thread);
+  NativeRegisterContextFreeBSD_x86(const ArchSpec &target_arch,
+                                   NativeThreadFreeBSD &native_thread);
   uint32_t GetRegisterSetCount() const override;
 
   const RegisterSet *GetRegisterSet(uint32_t set_index) const override;


### PR DESCRIPTION
Fix #180624.
Apparently a slight oversight.