### PR TITLE
[lldb][Process/FreeBSDKernelCore] Improve DoUpdateThreadList()

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -227,7 +227,7 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
     uint32_t long_bit = long_size_bytes * 8;
 
     if (stopped_cpus != LLDB_INVALID_ADDRESS) {
-      // From sys/kern/subr_smp.c:
+      // https://cgit.freebsd.org/src/tree/sys/kern/subr_smp.c
       mp_maxid =
           ReadSignedIntegerFromMemory(FindSymbol("mp_maxid"), 4, 0, error);
       if (error.Fail())
@@ -245,7 +245,7 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
         llvm::consumeError(type_system_or_err.takeError());
     }
 
-    // From sys/param.h:
+    // https://cgit.freebsd.org/src/tree/sys/sys/param.h
     constexpr size_t fbsd_maxcomlen = 19;
 
     // Iterate through a linked list of all processes. New processes are added

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -220,20 +220,32 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
         ReadSignedIntegerFromMemory(FindSymbol("pcb_size"), 4, -1, error);
     lldb::addr_t stoppcbs = FindSymbol("stoppcbs");
 
-    // Read stopped_cpus bitmask and mp_maxid for CPU validation
+    // Read stopped_cpus bitmask and mp_maxid for CPU validation.
     lldb::addr_t stopped_cpus = FindSymbol("stopped_cpus");
-
-    // from sys/kern/subr_smp.c
-    uint32_t mp_maxid =
-        ReadUnsignedIntegerFromMemory(FindSymbol("mp_maxid"), 4, 0, error);
-    auto type_system_sp =
-        *GetTarget().GetScratchTypeSystemForLanguage(eLanguageTypeC);
-    uint32_t long_size_bytes =
-        *type_system_sp->GetBasicTypeFromAST(eBasicTypeLong)
-             .GetByteSize(nullptr);
+    uint32_t mp_maxid = 0;
+    uint32_t long_size_bytes = GetAddressByteSize();
     uint32_t long_bit = long_size_bytes * 8;
 
-    // from sys/param.h
+    if (stopped_cpus != LLDB_INVALID_ADDRESS) {
+      // From sys/kern/subr_smp.c:
+      mp_maxid =
+          ReadSignedIntegerFromMemory(FindSymbol("mp_maxid"), 4, 0, error);
+      if (error.Fail())
+        stopped_cpus = LLDB_INVALID_ADDRESS;
+      else if (auto type_system_or_err =
+                   GetTarget().GetScratchTypeSystemForLanguage(
+                       eLanguageTypeC)) {
+        CompilerType long_type =
+            (*type_system_or_err)->GetBasicTypeFromAST(eBasicTypeLong);
+        if (long_type.IsValid())
+          if (auto size = long_type.GetByteSize(nullptr))
+            long_size_bytes = *size;
+        long_bit = long_size_bytes * 8;
+      } else
+        llvm::consumeError(type_system_or_err.takeError());
+    }
+
+    // From sys/param.h:
     constexpr size_t fbsd_maxcomlen = 19;
 
     // Iterate through a linked list of all processes. New processes are added

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -222,12 +222,18 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
 
     // Read stopped_cpus bitmask and mp_maxid for CPU validation
     lldb::addr_t stopped_cpus = FindSymbol("stopped_cpus");
-    int32_t mp_maxid =
-        ReadSignedIntegerFromMemory(FindSymbol("mp_maxid"), 4, 0, error);
-    uint32_t long_size = GetAddressByteSize(); // approximation of sizeof(long)
-    uint32_t long_bits = long_size * 8;
 
-    // from FreeBSD sys/param.h
+    // from sys/kern/subr_smp.c
+    uint32_t mp_maxid =
+        ReadUnsignedIntegerFromMemory(FindSymbol("mp_maxid"), 4, 0, error);
+    auto type_system_sp =
+        *GetTarget().GetScratchTypeSystemForLanguage(eLanguageTypeC);
+    uint32_t long_size_bytes =
+        *type_system_sp->GetBasicTypeFromAST(eBasicTypeLong)
+             .GetByteSize(nullptr);
+    uint32_t long_bit = long_size_bytes * 8;
+
+    // from sys/param.h
     constexpr size_t fbsd_maxcomlen = 19;
 
     // Iterate through a linked list of all processes. New processes are added
@@ -235,23 +241,12 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
     // the end of the list, so we have to walk it backwards. First collect all
     // the processes in the list order.
     std::vector<lldb::addr_t> process_addrs;
-
-    lldb::addr_t zombproc_addr = FindSymbol("zombproc");
-    if (zombproc_addr != LLDB_INVALID_ADDRESS) {
-      for (lldb::addr_t proc = ReadPointerFromMemory(zombproc_addr, error);
-           proc != 0 && proc != LLDB_INVALID_ADDRESS;
-           proc = ReadPointerFromMemory(proc + offset_p_list, error)) {
-        process_addrs.push_back(proc);
-      }
-    }
-
-    lldb::addr_t allproc_addr = FindSymbol("allproc");
-    if (allproc_addr != LLDB_INVALID_ADDRESS) {
+    if (lldb::addr_t allproc_addr = FindSymbol("allproc");
+        allproc_addr != LLDB_INVALID_ADDRESS) {
       for (lldb::addr_t proc = ReadPointerFromMemory(allproc_addr, error);
-           proc != 0 && proc != LLDB_INVALID_ADDRESS;
-           proc = ReadPointerFromMemory(proc + offset_p_list, error)) {
+           proc != 0 && proc != LLDB_INVALID_ADDRESS && error.Success();
+           proc = ReadPointerFromMemory(proc + offset_p_list, error))
         process_addrs.push_back(proc);
-      }
     }
 
     // Processes are in the linked list in descending PID order, so we must walk
@@ -305,13 +300,13 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
           // Verify the CPU is actually in the stopped set before using
           // its stoppcbs entry.
           bool is_stopped = false;
-          if (stopped_cpus != LLDB_INVALID_ADDRESS && oncpu >= 0 &&
-              oncpu <= mp_maxid) {
-            uint32_t bit = oncpu % long_bits;
-            uint32_t word = oncpu / long_bits;
-            lldb::addr_t mask_addr = stopped_cpus + word * long_size;
-            uint64_t mask =
-                ReadUnsignedIntegerFromMemory(mask_addr, long_size, 0, error);
+          if (oncpu >= 0 && static_cast<uint32_t>(oncpu) <= mp_maxid &&
+              stopped_cpus != LLDB_INVALID_ADDRESS) {
+            uint32_t bit = oncpu % long_bit;
+            uint32_t word = oncpu / long_bit;
+            lldb::addr_t mask_addr = stopped_cpus + word * long_size_bytes;
+            uint64_t mask = ReadUnsignedIntegerFromMemory(
+                mask_addr, long_size_bytes, 0, error);
             if (error.Success())
               is_stopped = (mask & (1ULL << bit)) != 0;
           }

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -167,7 +167,10 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
     // LLDB but we can construct a process without threads to provide minimal
     // memory reading support.
     switch (GetTarget().GetArchitecture().GetMachine()) {
+    case llvm::Triple::arm:
     case llvm::Triple::aarch64:
+    case llvm::Triple::ppc64le:
+    case llvm::Triple::riscv64:
     case llvm::Triple::x86:
     case llvm::Triple::x86_64:
       break;
@@ -217,6 +220,13 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
         ReadSignedIntegerFromMemory(FindSymbol("pcb_size"), 4, -1, error);
     lldb::addr_t stoppcbs = FindSymbol("stoppcbs");
 
+    // Read stopped_cpus bitmask and mp_maxid for CPU validation
+    lldb::addr_t stopped_cpus = FindSymbol("stopped_cpus");
+    int32_t mp_maxid =
+        ReadSignedIntegerFromMemory(FindSymbol("mp_maxid"), 4, 0, error);
+    uint32_t long_size = GetAddressByteSize(); // approximation of sizeof(long)
+    uint32_t long_bits = long_size * 8;
+
     // from FreeBSD sys/param.h
     constexpr size_t fbsd_maxcomlen = 19;
 
@@ -225,11 +235,23 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
     // the end of the list, so we have to walk it backwards. First collect all
     // the processes in the list order.
     std::vector<lldb::addr_t> process_addrs;
-    for (lldb::addr_t proc =
-             ReadPointerFromMemory(FindSymbol("allproc"), error);
-         proc != 0 && proc != LLDB_INVALID_ADDRESS;
-         proc = ReadPointerFromMemory(proc + offset_p_list, error)) {
-      process_addrs.push_back(proc);
+
+    lldb::addr_t zombproc_addr = FindSymbol("zombproc");
+    if (zombproc_addr != LLDB_INVALID_ADDRESS) {
+      for (lldb::addr_t proc = ReadPointerFromMemory(zombproc_addr, error);
+           proc != 0 && proc != LLDB_INVALID_ADDRESS;
+           proc = ReadPointerFromMemory(proc + offset_p_list, error)) {
+        process_addrs.push_back(proc);
+      }
+    }
+
+    lldb::addr_t allproc_addr = FindSymbol("allproc");
+    if (allproc_addr != LLDB_INVALID_ADDRESS) {
+      for (lldb::addr_t proc = ReadPointerFromMemory(allproc_addr, error);
+           proc != 0 && proc != LLDB_INVALID_ADDRESS;
+           proc = ReadPointerFromMemory(proc + offset_p_list, error)) {
+        process_addrs.push_back(proc);
+      }
     }
 
     // Processes are in the linked list in descending PID order, so we must walk
@@ -280,12 +302,27 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
           pcb_addr = dumppcb;
           thread_desc += " (crashed)";
         } else if (oncpu != -1) {
-          // If we managed to read stoppcbs and pcb_size, use them to find
-          // the correct PCB.
-          if (stoppcbs != LLDB_INVALID_ADDRESS && pcbsize > 0)
+          // Verify the CPU is actually in the stopped set before using
+          // its stoppcbs entry.
+          bool is_stopped = false;
+          if (stopped_cpus != LLDB_INVALID_ADDRESS && oncpu >= 0 &&
+              oncpu <= mp_maxid) {
+            uint32_t bit = oncpu % long_bits;
+            uint32_t word = oncpu / long_bits;
+            lldb::addr_t mask_addr = stopped_cpus + word * long_size;
+            uint64_t mask =
+                ReadUnsignedIntegerFromMemory(mask_addr, long_size, 0, error);
+            if (error.Success())
+              is_stopped = (mask & (1ULL << bit)) != 0;
+          }
+
+          // If we managed to read stoppcbs and pcb_size and the cpu is marked
+          // as stopped, use them to find the correct PCB.
+          if (is_stopped && stoppcbs != LLDB_INVALID_ADDRESS && pcbsize > 0) {
             pcb_addr = stoppcbs + oncpu * pcbsize;
-          else
+          } else {
             pcb_addr = LLDB_INVALID_ADDRESS;
+          }
           thread_desc += llvm::formatv(" (on CPU {0})", oncpu);
         }
 

--- a/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD-Kernel-Core/ProcessFreeBSDKernelCore.cpp
@@ -223,8 +223,6 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
     // Read stopped_cpus bitmask and mp_maxid for CPU validation.
     lldb::addr_t stopped_cpus = FindSymbol("stopped_cpus");
     uint32_t mp_maxid = 0;
-    uint32_t long_size_bytes = GetAddressByteSize();
-    uint32_t long_bit = long_size_bytes * 8;
 
     if (stopped_cpus != LLDB_INVALID_ADDRESS) {
       // https://cgit.freebsd.org/src/tree/sys/kern/subr_smp.c
@@ -232,18 +230,21 @@ bool ProcessFreeBSDKernelCore::DoUpdateThreadList(ThreadList &old_thread_list,
           ReadSignedIntegerFromMemory(FindSymbol("mp_maxid"), 4, 0, error);
       if (error.Fail())
         stopped_cpus = LLDB_INVALID_ADDRESS;
-      else if (auto type_system_or_err =
-                   GetTarget().GetScratchTypeSystemForLanguage(
-                       eLanguageTypeC)) {
-        CompilerType long_type =
-            (*type_system_or_err)->GetBasicTypeFromAST(eBasicTypeLong);
-        if (long_type.IsValid())
-          if (auto size = long_type.GetByteSize(nullptr))
-            long_size_bytes = *size;
-        long_bit = long_size_bytes * 8;
-      } else
-        llvm::consumeError(type_system_or_err.takeError());
     }
+
+    uint32_t long_size_bytes = GetAddressByteSize();
+    uint32_t long_bit = long_size_bytes * 8;
+
+    if (auto type_system_or_err =
+            GetTarget().GetScratchTypeSystemForLanguage(eLanguageTypeC)) {
+      CompilerType long_type =
+          (*type_system_or_err)->GetBasicTypeFromAST(eBasicTypeLong);
+      if (long_type.IsValid())
+        if (auto size = long_type.GetByteSize(nullptr))
+          long_size_bytes = *size;
+      long_bit = long_size_bytes * 8;
+    } else
+      llvm::consumeError(type_system_or_err.takeError());
 
     // https://cgit.freebsd.org/src/tree/sys/sys/param.h
     constexpr size_t fbsd_maxcomlen = 19;

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -230,7 +230,6 @@ Changes to LLDB
   `plugin.process.freebsd-kernel-core.read-only` must be set to `false`. This setting is available when
   using `/dev/mem` or a kernel dump. However, since `kvm_write()` does not support writing to kernel dumps,
   writes to a kernel dump will still fail when the setting is false.
-* Zombie processes are now shown in the thread list as well.
 
 ### Linux
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -230,6 +230,7 @@ Changes to LLDB
   `plugin.process.freebsd-kernel-core.read-only` must be set to `false`. This setting is available when
   using `/dev/mem` or a kernel dump. However, since `kvm_write()` does not support writing to kernel dumps,
   writes to a kernel dump will still fail when the setting is false.
+* Zombie processes are now shown in the thread list as well.
 
 ### Linux
 


### PR DESCRIPTION
This commit brings improves `ProcessFreeBSDKernelCore::DoUpdateThreadList()` by porting features from KGDB (`fbsd_kthr.c` specifically) and adding fixes. It includes:

1. Validate `stopped_cpus` before accessing `stoppcbs`
2. Check bounds for `mp_maxid`
3. Check errors when reading proc from memory
4. Detect new architectures from previous PRs (ppc64le, riscv64, arm) which weren't handled correctly in `DoUpdateThreadList()`.

Fallbacks for finding offsets aren't ported since kernel exposes hardcoded variables for offsets starting from FreeBSD 11. Fallbacks aren't needed as LLDB 23 only supports FreeBSD 14 and later.

This commit also 

Fixes: 2430410b7d879fce3db76c21bb8c60ed22abd0b5(#180669), 4a602c03ea050d7adf666d5a440164ca6f78707c(#180670), 3d251288df0642762d1bd86efa05e190005c2539(#180674)