### PR TITLE
[clang-tidy] Handle specialization of user-defined type in `bugprone-std-namespace-modification`

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/StdNamespaceModificationCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/StdNamespaceModificationCheck.cpp
@@ -43,10 +43,11 @@ void StdNamespaceModificationCheck::registerMatchers(MatchFinder *Finder) {
       hasDeclContext(namespaceDecl(hasAnyName("std", "posix"),
                                    unless(hasParent(namespaceDecl())))
                          .bind("nmspc"));
-  auto UserDefinedType = qualType(
-      hasUnqualifiedDesugaredType(tagType(unless(hasDeclaration(tagDecl(
-          hasAncestor(namespaceDecl(hasAnyName("std", "posix"),
-                                    unless(hasParent(namespaceDecl()))))))))));
+  auto UserDefinedDecl = tagDecl(hasAncestor(namespaceDecl(
+      hasAnyName("std", "posix"), unless(hasParent(namespaceDecl())))));
+  auto UserDefinedType = qualType(hasUnqualifiedDesugaredType(anyOf(
+      tagType(unless(hasDeclaration(UserDefinedDecl))),
+      templateSpecializationType(unless(hasDeclaration(UserDefinedDecl))))));
   auto HasNoProgramDefinedTemplateArgument = unless(
       hasAnyTemplateArgumentIncludingPack(refersToType(UserDefinedType)));
   auto InsideStdClassOrClassTemplateSpecialization = hasDeclContext(

--- a/clang-tools-extra/clang-tidy/bugprone/StdNamespaceModificationCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/StdNamespaceModificationCheck.cpp
@@ -43,8 +43,10 @@ void StdNamespaceModificationCheck::registerMatchers(MatchFinder *Finder) {
       hasDeclContext(namespaceDecl(hasAnyName("std", "posix"),
                                    unless(hasParent(namespaceDecl())))
                          .bind("nmspc"));
-  auto UserDefinedDecl = tagDecl(hasAncestor(namespaceDecl(
-      hasAnyName("std", "posix"), unless(hasParent(namespaceDecl())))));
+  auto UserDefinedDecl =
+      namedDecl(anyOf(classTemplateDecl(), tagDecl()),
+                hasAncestor(namespaceDecl(hasAnyName("std", "posix"),
+                                          unless(hasParent(namespaceDecl())))));
   auto UserDefinedType = qualType(hasUnqualifiedDesugaredType(anyOf(
       tagType(unless(hasDeclaration(UserDefinedDecl))),
       templateSpecializationType(unless(hasDeclaration(UserDefinedDecl))))));

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -181,6 +181,11 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/macro-parentheses>` check by printing the macro
   definition in the warning message if the macro is defined on command line.
 
+- Improved :doc:`bugprone-std-namespace-modification
+  <clang-tidy/checks/bugprone/std-namespace-modification>` check by fixing
+  false positives when extending the standard library with a specialization of
+  user-defined type.
+
 - Improved :doc:`bugprone-string-constructor
   <clang-tidy/checks/bugprone/string-constructor>` check to detect suspicious
   string constructor calls when the string class constructor has a default

--- a/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/system-header-simulation.h
+++ b/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/system-header-simulation.h
@@ -74,4 +74,7 @@ bool less<void>::operator()<short &&, short &&>(short &&, short &&) const {
 
 template <>
 struct less<void>::X<short> {};
+
+template <typename T>
+class vector;
 } // namespace std

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/std-namespace-modification.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/std-namespace-modification.cpp
@@ -282,6 +282,11 @@ template<typename> struct T {};
 T<B> b;
 }
 
+template <typename T>
+struct std::hash<std::vector<T>>
+// CHECK-MESSAGES: :[[@LINE-1]]:13: warning: modification of 'std' namespace can result in undefined behavior [bugprone-std-namespace-modification]
+{};
+
 // gh183752 begin
 template <typename T>
 struct Bar

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/std-namespace-modification.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/std-namespace-modification.cpp
@@ -281,3 +281,13 @@ template<typename> struct T {};
 
 T<B> b;
 }
+
+// gh183752 begin
+template <typename T>
+struct Bar
+{};
+
+template <typename T>
+struct std::hash<Bar<T>> // Should not warn as this specialization depends on a user-defined type.
+{};
+// gh183752 end


### PR DESCRIPTION
Ignore `templateSpecializationType` based on user-define classes too.

Fixes #183752 