### PR TITLE
[mlir][test] Fix crash in ReifyBoundOp with invalid 'type' attribute

### DIFF
--- a/mlir/test/Dialect/Affine/invalid-reify-bound-dim.mlir
+++ b/mlir/test/Dialect/Affine/invalid-reify-bound-dim.mlir
@@ -45,3 +45,13 @@ func.func @test_invalid_reify_without_dim(%size: index) -> (index) {
 
     return %dim: index
 }
+
+// -----
+
+// Verify that an invalid 'type' value produces a proper error rather than
+// crashing with llvm_unreachable. See: https://github.com/llvm/llvm-project/issues/128805
+func.func @test_invalid_bound_type(%val: index) -> index {
+    // expected-error@+1 {{'test.reify_bound' op invalid bound type 'scalable', expected 'EQ', 'LB', or 'UB'}}
+    %bound = "test.reify_bound"(%val) {type = "scalable"} : (index) -> index
+    return %bound : index
+}

--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -1014,6 +1014,9 @@ mlir::presburger::BoundType ReifyBoundOp::getBoundType() {
 }
 
 LogicalResult ReifyBoundOp::verify() {
+  if (getType() != "EQ" && getType() != "LB" && getType() != "UB")
+    return emitOpError("invalid bound type '")
+           << getType() << "', expected 'EQ', 'LB', or 'UB'";
   if (isa<ShapedType>(getVar().getType())) {
     if (!getDim().has_value())
       return emitOpError("expected 'dim' attribute for shaped type variable");


### PR DESCRIPTION
The `ReifyBoundOp::getBoundType()` called `llvm_unreachable("invalid bound type")` when the `type` attribute was set to a value other than "EQ", "LB", or "UB" (e.g., "scalable"). This caused an abort instead of a user-visible diagnostic.

Add a verification check that rejects invalid `type` values with a proper error message before `getBoundType()` is ever called.

Fixes #128805