### PR TITLE
[CIR] Fix bitfield store locations for assignment codegen

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -384,9 +384,9 @@ mlir::Value CIRGenFunction::emitStoreThroughBitfieldLValue(RValue src,
                      dst.isVolatileQualified() &&
                      info.volatileStorageSize != 0 && isAAPCS(cgm.getTarget());
 
-  mlir::Value dstAddr = dst.getAddress().getPointer();
+  assert(currSrcLoc && "must pass in source location");
 
-  return builder.createSetBitfield(dstAddr.getLoc(), resLTy, ptr,
+  return builder.createSetBitfield(*currSrcLoc, resLTy, ptr,
                                    ptr.getElementType(), src.getValue(), info,
                                    dst.isVolatileQualified(), useVoaltile);
 }

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1251,6 +1251,8 @@ public:
       // 'An assignment expression has the value of the left operand after the
       // assignment...'.
       if (lhs.isBitField()) {
+        CIRGenFunction::SourceLocRAIIObject loc{
+            cgf, cgf.getLoc(e->getSourceRange())};
         rhs = cgf.emitStoreThroughBitfieldLValue(RValue::get(rhs), lhs);
       } else {
         cgf.emitNullabilityCheck(lhs, rhs, e->getExprLoc());

--- a/clang/test/CIR/CodeGen/bitfield-assignment-loc.c
+++ b/clang/test/CIR/CodeGen/bitfield-assignment-loc.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-bitfield-constant-conversion -fclangir -emit-cir %s -o - | FileCheck %s
+
+struct C {
+  int c : 8;
+};
+
+void foo(void) {
+  struct C c;
+  c.c = 800;
+}
+
+// CHECK: %[[SETBF:.*]] = cir.set_bitfield{{.*}} loc(#[[SET_LOC:loc[0-9]+]])
+// CHECK-DAG: #[[SET_BEGIN:loc[0-9]+]] = loc("{{.*}}bitfield-assignment-loc.c":9:3)
+// CHECK-DAG: #[[SET_END:loc[0-9]+]] = loc("{{.*}}bitfield-assignment-loc.c":9:9)
+// CHECK-DAG: #[[SET_LOC]] = loc(fused[#[[SET_BEGIN]], #[[SET_END]]])

--- a/clang/test/CIR/CodeGen/bitfield-assignment-loc.c
+++ b/clang/test/CIR/CodeGen/bitfield-assignment-loc.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-bitfield-constant-conversion -fclangir -emit-cir %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-bitfield-constant-conversion -fclangir -emit-cir %s -o - | FileCheck %s --check-prefix=CIR
 
 struct C {
   int c : 8;
@@ -9,7 +9,7 @@ void foo(void) {
   c.c = 800;
 }
 
-// CHECK: %[[SETBF:.*]] = cir.set_bitfield{{.*}} loc(#[[SET_LOC:loc[0-9]+]])
-// CHECK-DAG: #[[SET_BEGIN:loc[0-9]+]] = loc("{{.*}}bitfield-assignment-loc.c":9:3)
-// CHECK-DAG: #[[SET_END:loc[0-9]+]] = loc("{{.*}}bitfield-assignment-loc.c":9:9)
-// CHECK-DAG: #[[SET_LOC]] = loc(fused[#[[SET_BEGIN]], #[[SET_END]]])
+// CIR: %[[SETBF:.*]] = cir.set_bitfield{{.*}} loc(#[[SET_LOC:loc[0-9]+]])
+// CIR-DAG: #[[SET_BEGIN:loc[0-9]+]] = loc("{{.*}}bitfield-assignment-loc.c":9:3)
+// CIR-DAG: #[[SET_END:loc[0-9]+]] = loc("{{.*}}bitfield-assignment-loc.c":9:9)
+// CIR-DAG: #[[SET_LOC]] = loc(fused[#[[SET_BEGIN]], #[[SET_END]]])


### PR DESCRIPTION
Update bitfield-assignment codegen to emit stores at assignment-expression source locations.
Keep `cir.set_bitfield` aligned with other store-like operations.
Prevent regressions that reattach bitfield stores to declaration-site locations.

Add a CIR test on `clang/test/CIR/CodeGen/bitfield-assignment-loc.c`.

Fix https://github.com/llvm/llvm-project/issues/183759