### PR TITLE
[ARM] Mark tADDrSPi as rematerializable and no side effects

### DIFF
--- a/llvm/lib/Target/ARM/ARMInstrThumb.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb.td
@@ -397,6 +397,7 @@ def tPICADD : TIt<(outs GPR:$dst), (ins GPR:$lhs, pclabel:$cp), IIC_iALUr, "",
 }
 
 // ADD <Rd>, sp, #<imm8>
+let isReMaterializable = 1 in
 def tADDrSPi : T1pI<(outs tGPR:$dst), (ins GPRsp:$sp, t_imm0_1020s4:$imm),
                     IIC_iALUi, "add", "\t$dst, $sp, $imm", []>,
                T1Encoding<{1,0,1,0,1,?}>, Sched<[WriteALU]> {


### PR DESCRIPTION
20 versions later, this is no longer a problem. Granted we don't even handle stack pointer updates the same way anymore, as those are considered to have side effects anyway. Also, we can remat this.