### PR TITLE
[NFC][clang] Add HandleModuleName to avoid redundant module name handling code

### DIFF
--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -1833,8 +1833,13 @@ public:
   bool LexModuleNameContinue(Token &Tok, SourceLocation UseLoc,
                              SmallVectorImpl<Token> &Suffix,
                              SmallVectorImpl<IdentifierLoc> &Path,
-                             bool AllowMacroExpansion = true,
-                             bool IsPartition = false);
+                             bool IsPartition = false,
+                             bool AllowMacroExpansion = true);
+  bool HandleModuleName(StringRef DirType, SourceLocation UseLoc, Token &Tok,
+                        SmallVectorImpl<IdentifierLoc> &Path,
+                        SmallVectorImpl<Token> &DirToks,
+                        bool IsPartition = false,
+                        bool AllowMacroExpansion = true);
   void EnterModuleSuffixTokenStream(ArrayRef<Token> Toks);
   void HandleCXXImportDirective(Token Import);
   void HandleCXXModuleDirective(Token Module);

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -1833,13 +1833,11 @@ public:
   bool LexModuleNameContinue(Token &Tok, SourceLocation UseLoc,
                              SmallVectorImpl<Token> &Suffix,
                              SmallVectorImpl<IdentifierLoc> &Path,
-                             bool IsPartition = false,
-                             bool AllowMacroExpansion = true);
+                             bool AllowMacroExpansion, bool IsPartition);
   bool HandleModuleName(StringRef DirType, SourceLocation UseLoc, Token &Tok,
                         SmallVectorImpl<IdentifierLoc> &Path,
                         SmallVectorImpl<Token> &DirToks,
-                        bool IsPartition = false,
-                        bool AllowMacroExpansion = true);
+                        bool AllowMacroExpansion, bool IsPartition);
   void EnterModuleSuffixTokenStream(ArrayRef<Token> Toks);
   void HandleCXXImportDirective(Token Import);
   void HandleCXXModuleDirective(Token Module);

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -4207,7 +4207,7 @@ void Preprocessor::HandleCXXImportDirective(Token ImportTok) {
   SmallVector<IdentifierLoc, 2> Path;
   bool ImportingHeader = false;
   bool IsPartition = false;
-  std::string FlatName;
+
   switch (Tok.getKind()) {
   case tok::header_name:
     ImportingHeader = true;
@@ -4221,27 +4221,11 @@ void Preprocessor::HandleCXXImportDirective(Token ImportTok) {
     Lex(Tok);
     [[fallthrough]];
   case tok::identifier: {
-    bool LeadingSpace = Tok.hasLeadingSpace();
-    unsigned NumToksInDirective = DirToks.size();
-    if (LexModuleNameContinue(Tok, UseLoc, DirToks, Path)) {
-      if (Tok.isNot(tok::eod))
-        CheckEndOfDirective(ImportTok.getIdentifierInfo()->getName(),
-                            /*EnableMacros=*/false, &DirToks);
-      EnterModuleSuffixTokenStream(DirToks);
+    if (HandleModuleName(ImportTok.getIdentifierInfo()->getName(), UseLoc, Tok,
+                         Path, DirToks, IsPartition))
       return;
-    }
 
-    // Clean the module-name tokens and replace these tokens with
-    // annot_module_name.
-    DirToks.resize(NumToksInDirective);
-    ModuleNameLoc *NameLoc = ModuleNameLoc::Create(*this, Path);
-    DirToks.emplace_back();
-    DirToks.back().setKind(tok::annot_module_name);
-    DirToks.back().setAnnotationRange(NameLoc->getRange());
-    DirToks.back().setAnnotationValue(static_cast<void *>(NameLoc));
-    DirToks.back().setFlagValue(Token::LeadingSpace, LeadingSpace);
-    DirToks.push_back(Tok);
-
+    std::string FlatName;
     bool IsValid =
         (IsPartition && ModuleDeclState.isNamedModule()) || !IsPartition;
     if (Callbacks && IsValid) {
@@ -4382,57 +4366,20 @@ void Preprocessor::HandleCXXModuleDirective(Token ModuleTok) {
     DirToks.push_back(Tok);
     break;
   case tok::identifier: {
-    bool LeadingSpace = Tok.hasLeadingSpace();
-    unsigned NumToksInDirective = DirToks.size();
-
-    // C++ [cpp.module]p3: Any preprocessing tokens after the module
-    // preprocessing token in the module directive are processed just as in
-    // normal text.
-    //
-    // P3034R1 Module Declarations Shouldn’t be Macros.
-    if (LexModuleNameContinue(Tok, UseLoc, DirToks, Path,
-                              /*AllowMacroExpansion=*/false)) {
-      if (Tok.isNot(tok::eod))
-        CheckEndOfDirective(ModuleTok.getIdentifierInfo()->getName(),
-                            /*EnableMacros=*/false, &DirToks);
-      EnterModuleSuffixTokenStream(DirToks);
+    if (HandleModuleName(ModuleTok.getIdentifierInfo()->getName(), UseLoc, Tok,
+                         Path, DirToks, /*IsPartition=*/false,
+                         /*AllowMacroExpansion=*/false))
       return;
-    }
-
-    ModuleNameLoc *NameLoc = ModuleNameLoc::Create(*this, Path);
-    DirToks.resize(NumToksInDirective);
-    DirToks.emplace_back();
-    DirToks.back().setKind(tok::annot_module_name);
-    DirToks.back().setAnnotationRange(NameLoc->getRange());
-    DirToks.back().setAnnotationValue(static_cast<void *>(NameLoc));
-    DirToks.back().setFlagValue(Token::LeadingSpace, LeadingSpace);
-    DirToks.push_back(Tok);
 
     // C++20 [cpp.module]p
     //   The pp-tokens, if any, of a pp-module shall be of the form:
     //     pp-module-name pp-module-partition[opt] pp-tokens[opt]
     if (Tok.is(tok::colon)) {
-      NumToksInDirective = DirToks.size();
       LexUnexpandedToken(Tok);
-      LeadingSpace = Tok.hasLeadingSpace();
-      if (LexModuleNameContinue(Tok, UseLoc, DirToks, Partition,
-                                /*AllowMacroExpansion=*/false,
-                                /*IsPartition=*/true)) {
-        if (Tok.isNot(tok::eod))
-          CheckEndOfDirective(ModuleTok.getIdentifierInfo()->getName(),
-                              /*EnableMacros=*/false, &DirToks);
-        EnterModuleSuffixTokenStream(DirToks);
+      if (HandleModuleName(ModuleTok.getIdentifierInfo()->getName(), UseLoc,
+                           Tok, Partition, DirToks, /*IsPartition=*/true,
+                           /*AllowMacroExpansion=*/false))
         return;
-      }
-
-      ModuleNameLoc *PartitionLoc = ModuleNameLoc::Create(*this, Partition);
-      DirToks.resize(NumToksInDirective);
-      DirToks.emplace_back();
-      DirToks.back().setKind(tok::annot_module_name);
-      DirToks.back().setAnnotationRange(NameLoc->getRange());
-      DirToks.back().setAnnotationValue(static_cast<void *>(PartitionLoc));
-      DirToks.back().setFlagValue(Token::LeadingSpace, LeadingSpace);
-      DirToks.push_back(Tok);
     }
 
     // If the current token is a macro definition, put it back to token stream

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -4222,7 +4222,8 @@ void Preprocessor::HandleCXXImportDirective(Token ImportTok) {
     [[fallthrough]];
   case tok::identifier: {
     if (HandleModuleName(ImportTok.getIdentifierInfo()->getName(), UseLoc, Tok,
-                         Path, DirToks, IsPartition))
+                         Path, DirToks, /*AllowMacroExpansion=*/true,
+                         IsPartition))
       return;
 
     std::string FlatName;
@@ -4367,8 +4368,8 @@ void Preprocessor::HandleCXXModuleDirective(Token ModuleTok) {
     break;
   case tok::identifier: {
     if (HandleModuleName(ModuleTok.getIdentifierInfo()->getName(), UseLoc, Tok,
-                         Path, DirToks, /*IsPartition=*/false,
-                         /*AllowMacroExpansion=*/false))
+                         Path, DirToks, /*AllowMacroExpansion=*/false,
+                         /*IsPartition=*/false))
       return;
 
     // C++20 [cpp.module]p
@@ -4377,8 +4378,8 @@ void Preprocessor::HandleCXXModuleDirective(Token ModuleTok) {
     if (Tok.is(tok::colon)) {
       LexUnexpandedToken(Tok);
       if (HandleModuleName(ModuleTok.getIdentifierInfo()->getName(), UseLoc,
-                           Tok, Partition, DirToks, /*IsPartition=*/true,
-                           /*AllowMacroExpansion=*/false))
+                           Tok, Partition, DirToks,
+                           /*AllowMacroExpansion=*/false, /*IsPartition=*/true))
         return;
     }
 

--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -1205,8 +1205,8 @@ ModuleNameLoc *ModuleNameLoc::Create(Preprocessor &PP, ModuleIdPath Path) {
 bool Preprocessor::LexModuleNameContinue(Token &Tok, SourceLocation UseLoc,
                                          SmallVectorImpl<Token> &Suffix,
                                          SmallVectorImpl<IdentifierLoc> &Path,
-                                         bool AllowMacroExpansion,
-                                         bool IsPartition) {
+                                         bool IsPartition,
+                                         bool AllowMacroExpansion) {
   auto ConsumeToken = [&]() {
     if (AllowMacroExpansion)
       Lex(Tok);
@@ -1248,6 +1248,36 @@ bool Preprocessor::LexModuleNameContinue(Token &Tok, SourceLocation UseLoc,
 
     ConsumeToken();
   }
+}
+
+bool Preprocessor::HandleModuleName(StringRef DirType, SourceLocation UseLoc,
+                                    Token &Tok,
+                                    SmallVectorImpl<IdentifierLoc> &Path,
+                                    SmallVectorImpl<Token> &DirToks,
+                                    bool IsPartition,
+                                    bool AllowMacroExpansion) {
+  bool LeadingSpace = Tok.hasLeadingSpace();
+  unsigned NumToksInDirective = DirToks.size();
+  if (LexModuleNameContinue(Tok, UseLoc, DirToks, Path, IsPartition,
+                            AllowMacroExpansion)) {
+    if (Tok.isNot(tok::eod))
+      CheckEndOfDirective(DirType,
+                          /*EnableMacros=*/false, &DirToks);
+    EnterModuleSuffixTokenStream(DirToks);
+    return true;
+  }
+
+  // Clean the module-name tokens and replace these tokens with
+  // annot_module_name.
+  DirToks.resize(NumToksInDirective);
+  ModuleNameLoc *NameLoc = ModuleNameLoc::Create(*this, Path);
+  DirToks.emplace_back();
+  DirToks.back().setKind(tok::annot_module_name);
+  DirToks.back().setAnnotationRange(NameLoc->getRange());
+  DirToks.back().setAnnotationValue(static_cast<void *>(NameLoc));
+  DirToks.back().setFlagValue(Token::LeadingSpace, LeadingSpace);
+  DirToks.push_back(Tok);
+  return false;
 }
 
 /// [cpp.pre]/p2:

--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -1205,8 +1205,8 @@ ModuleNameLoc *ModuleNameLoc::Create(Preprocessor &PP, ModuleIdPath Path) {
 bool Preprocessor::LexModuleNameContinue(Token &Tok, SourceLocation UseLoc,
                                          SmallVectorImpl<Token> &Suffix,
                                          SmallVectorImpl<IdentifierLoc> &Path,
-                                         bool IsPartition,
-                                         bool AllowMacroExpansion) {
+                                         bool AllowMacroExpansion,
+                                         bool IsPartition) {
   auto ConsumeToken = [&]() {
     if (AllowMacroExpansion)
       Lex(Tok);
@@ -1254,12 +1254,12 @@ bool Preprocessor::HandleModuleName(StringRef DirType, SourceLocation UseLoc,
                                     Token &Tok,
                                     SmallVectorImpl<IdentifierLoc> &Path,
                                     SmallVectorImpl<Token> &DirToks,
-                                    bool IsPartition,
-                                    bool AllowMacroExpansion) {
+                                    bool AllowMacroExpansion,
+                                    bool IsPartition) {
   bool LeadingSpace = Tok.hasLeadingSpace();
   unsigned NumToksInDirective = DirToks.size();
-  if (LexModuleNameContinue(Tok, UseLoc, DirToks, Path, IsPartition,
-                            AllowMacroExpansion)) {
+  if (LexModuleNameContinue(Tok, UseLoc, DirToks, Path, AllowMacroExpansion,
+                            IsPartition)) {
     if (Tok.isNot(tok::eod))
       CheckEndOfDirective(DirType,
                           /*EnableMacros=*/false, &DirToks);
@@ -1440,7 +1440,9 @@ bool Preprocessor::LexAfterModuleImport(Token &Result) {
   SmallVector<Token, 32> Suffix;
   SmallVector<IdentifierLoc, 3> Path;
   Lex(Result);
-  if (LexModuleNameContinue(Result, ModuleImportLoc, Suffix, Path))
+  if (LexModuleNameContinue(Result, ModuleImportLoc, Suffix, Path,
+                            /*AllowMacroExpansion=*/true,
+                            /*IsPartition=*/false))
     return CollectPPImportSuffixAndEnterStream(Suffix);
 
   ModuleNameLoc *NameLoc = ModuleNameLoc::Create(*this, Path);


### PR DESCRIPTION
This patch introduce a new HandleModuleName function to avoid duplicated code snippet in module name handling stage.