### PR TITLE
[clang-tidy] Fix spurious errors from builtin macros in modernize-use-trailing-return-type

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -269,10 +269,8 @@ classifyTokensBeforeFunctionName(const FunctionDecl &F, const ASTContext &Ctx,
 
       if (Info.hasMacroDefinition()) {
         const MacroInfo *MI = PP->getMacroInfo(&Info);
-        if (!MI || MI->isFunctionLike()) {
-          // Cannot handle function style macros.
+        if (!MI || MI->isFunctionLike() || MI->isBuiltinMacro())
           return std::nullopt;
-        }
       }
 
       T.setIdentifierInfo(&Info);

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -265,6 +265,11 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-std-format>` check by fixing a crash
   when an argument is part of a macro expansion.
 
+- Improved :doc:`modernize-use-trailing-return-type
+  <clang-tidy/checks/modernize/use-trailing-return-type>` check by fixing
+  spurious ``missing '(' after '__has_feature'`` errors caused by builtin
+  macros appearing in the return type of a function.
+
 - Improved :doc:`modernize-use-using
   <clang-tidy/checks/modernize/use-using>` check by avoiding the generation
   of invalid code for function types with redundant parentheses.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-trailing-return-type.cpp
@@ -487,6 +487,17 @@ decltype(COMMAND_LINE_INT{}) h21();
 // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
 // CHECK-FIXES: auto h21() -> decltype(COMMAND_LINE_INT{});
 
+// Builtin macros like __has_feature are registered as object-like macros but
+// require function-like syntax when expanded. Ensure the check does not cause
+// spurious "missing '(' after '__has_feature'" errors when they appear in the
+// raw lex span of a function return type.
+const decltype(__has_feature(cxx_constexpr)) h22();
+// CHECK-MESSAGES: :[[@LINE-1]]:46: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
+// CHECK-FIXES: const decltype(__has_feature(cxx_constexpr)) h22();
+const decltype(__has_builtin(__builtin_expect)) h23();
+// CHECK-MESSAGES: :[[@LINE-1]]:49: warning: use a trailing return type for this function [modernize-use-trailing-return-type]
+// CHECK-FIXES: const decltype(__has_builtin(__builtin_expect)) h23();
+
 //
 // Name collisions
 //


### PR DESCRIPTION
## Summary

I hit the same issue as in #168360 when upgrading to LLVM 21 with clang-tidy reporting cryptic:

error: missing '(' after '__has_feature'

Further investigation confirmed that the issue is localized to modernize-use-trailing-return-type and only happens with C++20+ and llvm 21 system headers (where __has_feature started to be used by libc++). Initial non-localized repro had this error firing 7k+ on LLVM 21, but when I switched to HEAD the incidence dropped to just 5 'check()' calls firing. Answering the comment from @localspook , the drop in incidence is likely to be related to https://github.com/llvm/llvm-project/pull/151035 as there are no other plausibly relevant changes.

However, as I was still hitting the issue with HEAD, this helped develop the standalone repro (below) that still triggered against HEAD and develop the fix. The issue was in `classifyTokensBeforeFunctionName()` when lexing return type span and encountering builtin macros like `__has_feature`, `__has_builtin`, `__has_extension` etc would not bail out with 'std::nullopt' as these were not registered as function-like, but only as builtin. The change adds the check to `classifyTokensBeforeFunctionName()` to return 'std::nullopt' not only when there is a function-like macro, but also adds a condition for builtins.

## Root cause

  | Step | What happens |
  |------|-------------|
  | 1 | `RegisterBuiltinMacro("__has_feature")` sets `isBuiltinMacro=true` but **not** `isFunctionLike=true` |
  | 2 | `classifyTokensBeforeFunctionName` encounters `__has_feature` as a raw identifier |
  | 3 | Filter checks `!MI \|\| MI->isFunctionLike()` — both false for builtins → passes through |
  | 4 | `classifyToken()` enters `{__has_feature, EOF}` into preprocessor |
  | 5 | `PP.Lex()` → `ExpandBuiltinMacro` → `EvaluateFeatureLikeBuiltinMacro` expects `(` but gets `EOF` → error |

## Fix

  Add `MI->isBuiltinMacro()` to the bail-out condition in `classifyTokensBeforeFunctionName()`.

  ## Standalone reproducer

  ```cpp
  // const forces classifyTokensBeforeFunctionName to be called (local qualifier path).
  // __has_feature in the raw lex span triggers the bug.
  const decltype(__has_feature(cxx_constexpr)) bar() { return 1; }
  clang-tidy --checks='-*,modernize-use-trailing-return-type' test.cpp -- -std=c++20

  # Before fix: error: missing '(' after '__has_feature'
  # After fix:  warning (no error)
```

###  Test plan

  - Added lit regression tests for __has_feature and __has_builtin in return type expressions
  - Verified RED→GREEN: test fails without the fix (producing the exact missing '(' errors), passes with the fix
  - All 6 existing use-trailing-return-type*.cpp lit tests pass

  Fixes #168360

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com> with human in the loop.