### PR TITLE
[clang-tidy][NFC] Don't call `getLangOpts` in `isLanguageVersionSupported`

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/ThrowingStaticInitializationCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/ThrowingStaticInitializationCheck.h
@@ -23,7 +23,7 @@ public:
   ThrowingStaticInitializationCheck(StringRef Name, ClangTidyContext *Context)
       : ClangTidyCheck(Name, Context) {}
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
-    return getLangOpts().CPlusPlus && getLangOpts().CXXExceptions;
+    return LangOpts.CPlusPlus && LangOpts.CXXExceptions;
   }
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;

--- a/clang-tools-extra/clang-tidy/llvm/UseNewMLIROpBuilderCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/UseNewMLIROpBuilderCheck.h
@@ -20,7 +20,7 @@ public:
   UseNewMlirOpBuilderCheck(StringRef Name, ClangTidyContext *Context);
 
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
-    return getLangOpts().CPlusPlus;
+    return LangOpts.CPlusPlus;
   }
 };
 


### PR DESCRIPTION
This is just a little inconsistency I noticed. Basically all checks inspect the `LangOpts` parameter, but these two ignore the parameter and call `getLangOpts` instead.