### PR TITLE
[Hexagon] Guard HVXIEEEFP intrinsics with __HVX_IEEE_FP__

### DIFF
--- a/clang/lib/Headers/hvx_hexagon_protos.h
+++ b/clang/lib/Headers/hvx_hexagon_protos.h
@@ -4386,7 +4386,7 @@
 #define Q6_Ww_v6mpyacc_WwWubWbI_v(Vxx,Vuu,Vvv,Iu2) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_v6mpyvubs10_vxx)(Vxx,Vuu,Vvv,Iu2)
 #endif /* __HEXAGON_ARCH___ >= 68 */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vabs(Vu32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vabs_Vhf(HVX_Vector Vu)
@@ -4395,9 +4395,9 @@
    ========================================================================== */
 
 #define Q6_Vhf_vabs_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vabs(Vu32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vabs_Vsf(HVX_Vector Vu)
@@ -4406,7 +4406,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vabs_Vsf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_sf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4419,7 +4419,7 @@
 #define Q6_Vqf16_vadd_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_hf)(Vu,Vv)
 #endif /* __HEXAGON_ARCH___ >= 68 */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vadd(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vadd_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4428,7 +4428,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vadd_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_hf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4485,7 +4485,7 @@
 #define Q6_Vqf32_vadd_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_sf)(Vu,Vv)
 #endif /* __HEXAGON_ARCH___ >= 68 */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vadd(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vadd_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4494,9 +4494,9 @@
    ========================================================================== */
 
 #define Q6_Wsf_vadd_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_sf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vadd(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vadd_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4505,9 +4505,9 @@
    ========================================================================== */
 
 #define Q6_Vsf_vadd_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_sf_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vfmv(Vu32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vfmv_Vw(HVX_Vector Vu)
@@ -4516,7 +4516,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vfmv_Vw(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vassign_fp)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4551,7 +4551,7 @@
 #define Q6_Vsf_equals_Vqf32(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_sf_qf32)(Vu)
 #endif /* __HEXAGON_ARCH___ >= 68 */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vcvt(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vcvt_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4560,9 +4560,9 @@
    ========================================================================== */
 
 #define Q6_Vb_vcvt_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_b_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vcvt(Vu32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vcvt_Vhf(HVX_Vector Vu)
@@ -4571,9 +4571,9 @@
    ========================================================================== */
 
 #define Q6_Vh_vcvt_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_h_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vcvt(Vu32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vcvt_Vb(HVX_Vector Vu)
@@ -4582,9 +4582,9 @@
    ========================================================================== */
 
 #define Q6_Whf_vcvt_Vb(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_b)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vcvt(Vu32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vcvt_Vh(HVX_Vector Vu)
@@ -4593,9 +4593,9 @@
    ========================================================================== */
 
 #define Q6_Vhf_vcvt_Vh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_h)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vcvt(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vcvt_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4604,9 +4604,9 @@
    ========================================================================== */
 
 #define Q6_Vhf_vcvt_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vcvt(Vu32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vcvt_Vub(HVX_Vector Vu)
@@ -4615,9 +4615,9 @@
    ========================================================================== */
 
 #define Q6_Whf_vcvt_Vub(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_ub)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vcvt(Vu32.uh)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vcvt_Vuh(HVX_Vector Vu)
@@ -4626,9 +4626,9 @@
    ========================================================================== */
 
 #define Q6_Vhf_vcvt_Vuh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_uh)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vcvt(Vu32.hf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vcvt_Vhf(HVX_Vector Vu)
@@ -4637,9 +4637,9 @@
    ========================================================================== */
 
 #define Q6_Wsf_vcvt_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_sf_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vcvt(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vcvt_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4648,9 +4648,9 @@
    ========================================================================== */
 
 #define Q6_Vub_vcvt_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_ub_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vcvt(Vu32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vcvt_Vhf(HVX_Vector Vu)
@@ -4659,9 +4659,9 @@
    ========================================================================== */
 
 #define Q6_Vuh_vcvt_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_uh_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vdmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vdmpy_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4670,9 +4670,9 @@
    ========================================================================== */
 
 #define Q6_Vsf_vdmpy_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpy_sf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vx32.sf+=vdmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vdmpyacc_VsfVhfVhf(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -4681,9 +4681,9 @@
    ========================================================================== */
 
 #define Q6_Vsf_vdmpyacc_VsfVhfVhf(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpy_sf_hf_acc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vfmax(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vfmax_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4692,9 +4692,9 @@
    ========================================================================== */
 
 #define Q6_Vhf_vfmax_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmax_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vfmax(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vfmax_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4703,9 +4703,9 @@
    ========================================================================== */
 
 #define Q6_Vsf_vfmax_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmax_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vfmin(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vfmin_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4714,9 +4714,9 @@
    ========================================================================== */
 
 #define Q6_Vhf_vfmin_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmin_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vfmin(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vfmin_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4725,9 +4725,9 @@
    ========================================================================== */
 
 #define Q6_Vsf_vfmin_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmin_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vfneg(Vu32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vfneg_Vhf(HVX_Vector Vu)
@@ -4736,9 +4736,9 @@
    ========================================================================== */
 
 #define Q6_Vhf_vfneg_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfneg_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vfneg(Vu32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vfneg_Vsf(HVX_Vector Vu)
@@ -4747,7 +4747,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vfneg_Vsf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfneg_sf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4881,7 +4881,7 @@
 #define Q6_Vsf_vmin_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmin_sf)(Vu,Vv)
 #endif /* __HEXAGON_ARCH___ >= 68 */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vmpy_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4890,9 +4890,9 @@
    ========================================================================== */
 
 #define Q6_Vhf_vmpy_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_hf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vx32.hf+=vmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vmpyacc_VhfVhfVhf(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -4901,7 +4901,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vmpyacc_VhfVhfVhf(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_hf_hf_acc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4991,7 +4991,7 @@
 #define Q6_Vqf32_vmpy_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_qf32_sf)(Vu,Vv)
 #endif /* __HEXAGON_ARCH___ >= 68 */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vmpy_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -5000,9 +5000,9 @@
    ========================================================================== */
 
 #define Q6_Wsf_vmpy_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vxx32.sf+=vmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vmpyacc_WsfVhfVhf(HVX_VectorPair Vxx, HVX_Vector Vu, HVX_Vector Vv)
@@ -5011,9 +5011,9 @@
    ========================================================================== */
 
 #define Q6_Wsf_vmpyacc_WsfVhfVhf(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_hf_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vmpy(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vmpy_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -5022,7 +5022,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vmpy_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -5035,7 +5035,7 @@
 #define Q6_Vqf16_vsub_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_hf)(Vu,Vv)
 #endif /* __HEXAGON_ARCH___ >= 68 */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vsub(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vsub_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -5044,7 +5044,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vsub_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_hf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -5101,7 +5101,7 @@
 #define Q6_Vqf32_vsub_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_sf)(Vu,Vv)
 #endif /* __HEXAGON_ARCH___ >= 68 */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vsub(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vsub_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -5110,9 +5110,9 @@
    ========================================================================== */
 
 #define Q6_Wsf_vsub_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_sf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vsub(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vsub_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -5121,7 +5121,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vsub_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_sf_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif /* __HEXAGON_ARCH___ >= 68 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 69
 /* ==========================================================================
@@ -5178,7 +5178,7 @@
 #define Q6_Vuh_vmpy_VuhVuh_rs16(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyuhvs)(Vu,Vv)
 #endif /* __HEXAGON_ARCH___ >= 69 */
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vadd(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vadd_VbfVbf(HVX_Vector Vu,
@@ -5187,7 +5187,7 @@
 
 #define Q6_Wsf_vadd_VbfVbf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_sf_bf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif /* __HEXAGON_ARCH___ >= 73 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -5237,7 +5237,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_w_sf)(Vu)
 #endif /* __HEXAGON_ARCH___ >= 73 */
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.bf=vcvt(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vbf_vcvt_VsfVsf(HVX_Vector Vu,
@@ -5246,7 +5246,7 @@
 
 #define Q6_Vbf_vcvt_VsfVsf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_bf_sf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif /* __HEXAGON_ARCH___ >= 73 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -5308,7 +5308,7 @@
    -1)
 #endif /* __HEXAGON_ARCH___ >= 73 */
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.bf=vmax(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_Vector Q6_Vbf_vmax_VbfVbf(HVX_Vector Vu,
@@ -5317,9 +5317,9 @@
 
 #define Q6_Vbf_vmax_VbfVbf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmax_bf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif /* __HEXAGON_ARCH___ >= 73 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.bf=vmin(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_Vector Q6_Vbf_vmin_VbfVbf(HVX_Vector Vu,
@@ -5328,9 +5328,9 @@
 
 #define Q6_Vbf_vmin_VbfVbf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmin_bf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif /* __HEXAGON_ARCH___ >= 73 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vmpy(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vmpy_VbfVbf(HVX_Vector Vu,
@@ -5339,9 +5339,9 @@
 
 #define Q6_Wsf_vmpy_VbfVbf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_bf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif /* __HEXAGON_ARCH___ >= 73 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vxx32.sf+=vmpy(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vmpyacc_WsfVbfVbf(HVX_VectorPair
@@ -5351,9 +5351,9 @@
 
 #define Q6_Wsf_vmpyacc_WsfVbfVbf(Vxx, Vu, Vv)                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_bf_acc)(Vxx, Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif /* __HEXAGON_ARCH___ >= 73 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vsub(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vsub_VbfVbf(HVX_Vector Vu,
@@ -5362,7 +5362,7 @@
 
 #define Q6_Wsf_vsub_VbfVbf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_sf_bf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif /* __HEXAGON_ARCH___ >= 73 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -5400,7 +5400,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_set_qfext)(Vu, Rt)
 #endif /* __HEXAGON_ARCH___ >= 79 */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.f8=vabs(Vu32.f8)
    C Intrinsic Prototype: HVX_Vector Q6_V_vabs_V(HVX_Vector Vu)
@@ -5409,9 +5409,9 @@
    ========================================================================== */
 
 #define Q6_V_vabs_V(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_f8)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vadd(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vadd_VV(HVX_Vector Vu,
@@ -5420,9 +5420,9 @@
 
 #define Q6_Whf_vadd_VV(Vu, Vv)                                                 \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_hf_f8)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vcvt2(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vcvt2_VhfVhf(HVX_Vector Vu,
@@ -5431,9 +5431,9 @@
 
 #define Q6_Vb_vcvt2_VhfVhf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_b_hf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vcvt2(Vu32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vcvt2_Vb(HVX_Vector Vu)
@@ -5443,9 +5443,9 @@
 
 #define Q6_Whf_vcvt2_Vb(Vu)                                                    \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_hf_b)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vcvt2(Vu32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vcvt2_Vub(HVX_Vector Vu)
@@ -5455,9 +5455,9 @@
 
 #define Q6_Whf_vcvt2_Vub(Vu)                                                   \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_hf_ub)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vcvt2(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vcvt2_VhfVhf(HVX_Vector Vu,
@@ -5466,9 +5466,9 @@
 
 #define Q6_Vub_vcvt2_VhfVhf(Vu, Vv)                                            \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_ub_hf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.f8=vcvt(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_V_vcvt_VhfVhf(HVX_Vector Vu, HVX_Vector
@@ -5477,9 +5477,9 @@
 
 #define Q6_V_vcvt_VhfVhf(Vu, Vv)                                               \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_f8_hf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vcvt(Vu32.f8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vcvt_V(HVX_Vector Vu)
@@ -5489,9 +5489,9 @@
 
 #define Q6_Whf_vcvt_V(Vu)                                                      \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_f8)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.f8=vfmax(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_Vector Q6_V_vfmax_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -5501,9 +5501,9 @@
 
 #define Q6_V_vfmax_VV(Vu, Vv)                                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmax_f8)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.f8=vfmin(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_Vector Q6_V_vfmin_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -5513,9 +5513,9 @@
 
 #define Q6_V_vfmin_VV(Vu, Vv)                                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmin_f8)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vd32.f8=vfneg(Vu32.f8)
    C Intrinsic Prototype: HVX_Vector Q6_V_vfneg_V(HVX_Vector Vu)
@@ -5525,7 +5525,7 @@
 
 #define Q6_V_vfneg_V(Vu)                                                       \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfneg_f8)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -5538,7 +5538,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmerge_qf)(Vu, Vv)
 #endif /* __HEXAGON_ARCH___ >= 79 */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vmpy(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vmpy_VV(HVX_Vector Vu,
@@ -5547,9 +5547,9 @@
 
 #define Q6_Whf_vmpy_VV(Vu, Vv)                                                 \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_hf_f8)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vxx32.hf+=vmpy(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vmpyacc_WhfVV(HVX_VectorPair
@@ -5559,7 +5559,7 @@
 
 #define Q6_Whf_vmpyacc_WhfVV(Vxx, Vu, Vv)                                      \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_hf_f8_acc)(Vxx, Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -5594,7 +5594,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_rt_sf)(Vu, Rt)
 #endif /* __HEXAGON_ARCH___ >= 79 */
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined(__HVX_IEEE_FP__)
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vsub(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vsub_VV(HVX_Vector Vu,
@@ -5603,7 +5603,7 @@
 
 #define Q6_Whf_vsub_VV(Vu, Vv)                                                 \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_hf_f8)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif /* __HEXAGON_ARCH___ >= 79 && __HVX_IEEE_FP__ */
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================

--- a/clang/test/Headers/hexagon-hvx-headers.c
+++ b/clang/test/Headers/hexagon-hvx-headers.c
@@ -20,6 +20,19 @@
 // RUN:   -target-feature +hvx-length64b -target-feature +hvxv68 \
 // RUN:   -emit-llvm %s -o - | FileCheck --check-prefix=CHECK-64 %s
 
+// Test that HVXIEEEFP intrinsics are available with +hvx-ieee-fp.
+// RUN: %clang_cc1 -O0 -internal-isystem %S/../../lib/Headers/ \
+// RUN:   -target-cpu hexagonv79 -triple hexagon-unknown-elf \
+// RUN:   -target-feature +hvx-length128b -target-feature +hvxv79 \
+// RUN:   -target-feature +hvx-ieee-fp \
+// RUN:   -emit-llvm %s -o - | FileCheck --check-prefix=CHECK-IEEEFP %s
+
+// Test that HVXIEEEFP intrinsics are NOT visible without +hvx-ieee-fp.
+// RUN: %clang_cc1 -O0 -internal-isystem %S/../../lib/Headers/ \
+// RUN:   -target-cpu hexagonv79 -triple hexagon-unknown-elf \
+// RUN:   -target-feature +hvx-length128b -target-feature +hvxv79 \
+// RUN:   -fsyntax-only %s
+
 #ifdef DIRECT
 #include <hvx_hexagon_protos.h>
 #else
@@ -35,3 +48,29 @@ void test_hvx_protos(float a, unsigned int b) {
   // CHECK:    call <64 x i32> @llvm.hexagon.V6.v6mpyhubs10.128B
   c = Q6_Ww_v6mpy_WubWbI_h(c, c, 2);
 }
+
+#ifdef __HVX_IEEE_FP__
+void test_hvx_ieeefp(HVX_Vector a, HVX_Vector b) {
+  // CHECK-IEEEFP: call <32 x i32> @llvm.hexagon.V6.vabs.hf.128B
+  HVX_Vector r0 = Q6_Vhf_vabs_Vhf(a);
+#if __HVX_ARCH__ >= 73
+  // CHECK-IEEEFP: call <32 x i32> @llvm.hexagon.V6.vcvt.bf.sf.128B
+  HVX_Vector r1 = Q6_Vbf_vcvt_VsfVsf(a, b);
+#endif
+#if __HVX_ARCH__ >= 79
+  // CHECK-IEEEFP: call <32 x i32> @llvm.hexagon.V6.vfneg.f8.128B
+  HVX_Vector r2 = Q6_V_vfneg_V(a);
+#endif
+}
+#else
+// Verify IEEE FP intrinsic macros are not defined without +hvx-ieee-fp.
+#ifdef Q6_Vhf_vabs_Vhf
+#error "Q6_Vhf_vabs_Vhf should not be defined without __HVX_IEEE_FP__"
+#endif
+#ifdef Q6_Vbf_vcvt_VsfVsf
+#error "Q6_Vbf_vcvt_VsfVsf should not be defined without __HVX_IEEE_FP__"
+#endif
+#ifdef Q6_V_vfneg_V
+#error "Q6_V_vfneg_V should not be defined without __HVX_IEEE_FP__"
+#endif
+#endif


### PR DESCRIPTION
The C intrinsic header hvx_hexagon_protos.h only guarded the 53 HVXIEEEFP intrinsics by architecture version (__HVX_ARCH__ >= 68/73/79), making them visible even when IEEE FP is not enabled. Add defined(__HVX_IEEE_FP__) to each guard so the intrinsics are only available when the extension is active (+hvx-ieee-fp).