### PR TITLE
[MLIR] Make test-block-is-in-loop pass a module pass

### DIFF
--- a/mlir/test/Interfaces/LoopLikeInterface/test-block-loop.mlir
+++ b/mlir/test/Interfaces/LoopLikeInterface/test-block-loop.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s --mlir-disable-threading -test-block-is-in-loop 2>&1 | FileCheck %s
+// RUN: mlir-opt %s -test-block-is-in-loop 2>&1 | FileCheck %s
 
 module {
   // Test function with only one bb

--- a/mlir/test/lib/Interfaces/LoopLikeInterface/TestBlockInLoop.cpp
+++ b/mlir/test/lib/Interfaces/LoopLikeInterface/TestBlockInLoop.cpp
@@ -18,7 +18,7 @@ namespace {
 /// This is a test pass that tests Blocks's isInLoop method by checking if each
 /// block in a function is in a loop and outputing if it is
 struct IsInLoopPass
-    : public PassWrapper<IsInLoopPass, OperationPass<func::FuncOp>> {
+    : public PassWrapper<IsInLoopPass, OperationPass<ModuleOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(IsInLoopPass)
 
   StringRef getArgument() const final { return "test-block-is-in-loop"; }
@@ -27,16 +27,18 @@ struct IsInLoopPass
   }
 
   void runOnOperation() override {
-    mlir::func::FuncOp func = getOperation();
-    func.walk([](mlir::Block *block) {
-      llvm::outs() << "Block is ";
-      if (LoopLikeOpInterface::blockIsInLoop(block))
-        llvm::outs() << "in a loop\n";
-      else
-        llvm::outs() << "not in a loop\n";
-      block->print(llvm::outs());
-      llvm::outs() << "\n";
-    });
+    ModuleOp module = getOperation();
+    for (auto func : module.getOps<func::FuncOp>()) {
+      func.walk([](mlir::Block *block) {
+        llvm::outs() << "Block is ";
+        if (LoopLikeOpInterface::blockIsInLoop(block))
+          llvm::outs() << "in a loop\n";
+        else
+          llvm::outs() << "not in a loop\n";
+        block->print(llvm::outs());
+        llvm::outs() << "\n";
+      });
+    }
   }
 };
 


### PR DESCRIPTION
This pass can't run in parallel on function as it would trigger race conditions.

Fixes #183999