### PR TITLE
[llvm-gsymutil] Add --symtab-file option to specify separate symbol table file 

### DIFF
--- a/llvm/test/tools/llvm-gsymutil/ARM_AArch64/fat-macho-symtab-file.yaml
+++ b/llvm/test/tools/llvm-gsymutil/ARM_AArch64/fat-macho-symtab-file.yaml
@@ -1,0 +1,234 @@
+## Test --symtab-file with thin and fat Mach-O inputs.
+##
+## We reuse the existing fat Mach-O DWARF fixture as the debug-info input and
+## create separate symbol-table-only Mach-O objects. The arm64 symtab slice
+## intentionally has two function symbols so we can tell that the matching
+## symtab slice was selected instead of the input file's own symbol table.
+
+# RUN: split-file %s %t
+# RUN: yaml2obj %S/fat-macho-dwarf.yaml -o %t/debug-fat.o
+# RUN: yaml2obj %t/armv7-symtab.yaml -o %t/armv7-symtab.o
+# RUN: yaml2obj %t/arm64-symtab.yaml -o %t/arm64-symtab.o
+# RUN: llvm-lipo %t/armv7-symtab.o %t/arm64-symtab.o -create -output %t/symtab-fat.o
+# RUN: llvm-lipo %t/debug-fat.o -thin arm64 -output %t/debug-arm64.o
+# RUN: llvm-lipo %t/symtab-fat.o -thin arm64 -output %t/symtab-arm64.o
+# RUN: llvm-lipo %t/armv7-symtab.o -create -output %t/symtab-armv7-only-fat.o
+
+# RUN: llvm-gsymutil --convert %t/debug-arm64.o --symtab-file=%t/symtab-fat.o -o %t/thin-from-fat.gsym 2>&1 | FileCheck %s --check-prefix=THIN-FAT
+# RUN: llvm-gsymutil --convert %t/debug-fat.o --symtab-file=%t/symtab-fat.o -o %t/fat-from-fat.gsym 2>&1 | FileCheck %s --check-prefix=FAT-FAT
+# RUN: llvm-gsymutil --convert %t/debug-fat.o --arch arm64 --symtab-file=%t/symtab-arm64.o -o %t/fat-from-thin.gsym 2>&1 | FileCheck %s --check-prefix=FAT-THIN
+# RUN: not llvm-gsymutil --convert %t/debug-fat.o --symtab-file=%t/symtab-arm64.o -o %t/fat-from-thin-error.gsym 2>&1 | FileCheck %s --check-prefix=FAT-THIN-ERR
+# RUN: not llvm-gsymutil --convert %t/debug-arm64.o --symtab-file=%t/symtab-armv7-only-fat.o -o %t/missing-arch.gsym 2>&1 | FileCheck %s --check-prefix=MISSING-ARCH
+
+# THIN-FAT: Input file: {{.*}}debug-arm64.o
+# THIN-FAT: Output file (arm64): {{.*}}thin-from-fat.gsym
+# THIN-FAT: Using symbol table file: {{.*}}symtab-fat.o
+# THIN-FAT: Loaded 2 functions from symbol table.
+
+# FAT-FAT: Input file: {{.*}}debug-fat.o
+# FAT-FAT: Output file (armv7): {{.*}}fat-from-fat.gsym.armv7
+# FAT-FAT: Using symbol table file: {{.*}}symtab-fat.o
+# FAT-FAT: Loaded 1 functions from symbol table.
+# FAT-FAT: Output file (arm64): {{.*}}fat-from-fat.gsym.arm64
+# FAT-FAT: Using symbol table file: {{.*}}symtab-fat.o
+# FAT-FAT: Loaded 2 functions from symbol table.
+
+# FAT-THIN: Input file: {{.*}}debug-fat.o
+# FAT-THIN: Output file (arm64): {{.*}}fat-from-thin.gsym
+# FAT-THIN: Using symbol table file: {{.*}}symtab-arm64.o
+# FAT-THIN: Loaded 2 functions from symbol table.
+
+# FAT-THIN-ERR: use --arch to select a single architecture
+
+# MISSING-ARCH: symbol table file '{{.*}}symtab-armv7-only-fat.o' does not contain architecture 'arm64'
+
+#--- armv7-symtab.yaml
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACE
+  cputype:         0x0000000C
+  cpusubtype:      0x00000009
+  filetype:        0x00000001
+  ncmds:           4
+  sizeofcmds:      312
+  flags:           0x00002000
+LoadCommands:
+  - cmd:             LC_SEGMENT
+    cmdsize:         192
+    segname:         ''
+    vmaddr:          49136
+    vmsize:          72
+    fileoff:         340
+    filesize:        72
+    maxprot:         7
+    initprot:        7
+    nsects:          2
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x000000000000BFF0
+        size:            16
+        offset:          0x00000154
+        align:           4
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+        content:         00000000000000000000000000000000
+      - sectname:        __eh_frame
+        segname:         __TEXT
+        addr:            0x000000000000C000
+        size:            52
+        offset:          0x00000164
+        align:           2
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x6800000B
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+        content:         00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+  - cmd:             LC_VERSION_MIN_MACOSX
+    cmdsize:         16
+    version:         656384
+    sdk:             0
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          412
+    nsyms:           1
+    stroff:          424
+    strsize:         8
+  - cmd:             LC_DYSYMTAB
+    cmdsize:         80
+    ilocalsym:       0
+    nlocalsym:       0
+    iextdefsym:      0
+    nextdefsym:      1
+    iundefsym:       1
+    nundefsym:       0
+    tocoff:          0
+    ntoc:            0
+    modtaboff:       0
+    nmodtab:         0
+    extrefsymoff:    0
+    nextrefsyms:     0
+    indirectsymoff:  0
+    nindirectsyms:   0
+    extreloff:       0
+    nextrel:         0
+    locreloff:       0
+    nlocrel:         0
+LinkEditData:
+  NameList:
+    - n_strx:          1
+      n_type:          0x0F
+      n_sect:          1
+      n_desc:          0
+      n_value:         49136
+  StringTable:
+    - ''
+    - _main
+    - ''
+...
+
+#--- arm64-symtab.yaml
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x0100000C
+  cpusubtype:      0x00000000
+  filetype:        0x00000001
+  ncmds:           4
+  sizeofcmds:      352
+  flags:           0x00002000
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         232
+    segname:         ''
+    vmaddr:          4294999964
+    vmsize:          84
+    fileoff:         384
+    filesize:        80
+    maxprot:         7
+    initprot:        7
+    nsects:          2
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0000000100007F9C
+        size:            16
+        offset:          0x00000180
+        align:           4
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+        content:         00000000000000000000000000000000
+      - sectname:        __eh_frame
+        segname:         __TEXT
+        addr:            0x0000000100007FB0
+        size:            64
+        offset:          0x00000190
+        align:           3
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x6800000B
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+        content:         00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+  - cmd:             LC_VERSION_MIN_MACOSX
+    cmdsize:         16
+    version:         656384
+    sdk:             0
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          464
+    nsyms:           2
+    stroff:          496
+    strsize:         15
+  - cmd:             LC_DYSYMTAB
+    cmdsize:         80
+    ilocalsym:       0
+    nlocalsym:       0
+    iextdefsym:      0
+    nextdefsym:      2
+    iundefsym:       2
+    nundefsym:       0
+    tocoff:          0
+    ntoc:            0
+    modtaboff:       0
+    nmodtab:         0
+    extrefsymoff:    0
+    nextrefsyms:     0
+    indirectsymoff:  0
+    nindirectsyms:   0
+    extreloff:       0
+    nextrel:         0
+    locreloff:       0
+    nlocrel:         0
+LinkEditData:
+  NameList:
+    - n_strx:          1
+      n_type:          0x0F
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294999964
+    - n_strx:          7
+      n_type:          0x0F
+      n_sect:          1
+      n_desc:          0
+      n_value:         4294999976
+  StringTable:
+    - ''
+    - _main
+    - _helper
+    - ''
+...

--- a/llvm/test/tools/llvm-gsymutil/X86/elf-symtab-file.yaml
+++ b/llvm/test/tools/llvm-gsymutil/X86/elf-symtab-file.yaml
@@ -1,0 +1,150 @@
+## Test the --symtab-file option to specify a separate file for the symbol table.
+## We create two ELF files: one with DWARF debug info (but no function symbols)
+## and one with function symbols (but no DWARF). Then we use --symtab-file to
+## combine them during GSYM conversion.
+
+# RUN: split-file %s %t
+
+## Create the debug-only and symtab-only ELF files.
+# RUN: yaml2obj %t/debug.yaml -o %t/debug.elf
+# RUN: yaml2obj %t/symtab.yaml -o %t/symtab.elf
+
+## Test 1: Basic --symtab-file usage.
+# RUN: llvm-gsymutil --convert %t/debug.elf --symtab-file=%t/symtab.elf -o %t/out.gsym 2>&1 | FileCheck %s --check-prefix=BASIC
+# BASIC: Input file: {{.*}}debug.elf
+# BASIC: Output file (x86_64): {{.*}}out.gsym
+# BASIC: Using symbol table file: {{.*}}symtab.elf
+# BASIC: Loaded 2 functions from symbol table.
+
+## Test 2: Architecture mismatch error.
+# RUN: yaml2obj %t/aarch64-symtab.yaml -o %t/aarch64-symtab.elf
+# RUN: not llvm-gsymutil --convert %t/debug.elf --symtab-file=%t/aarch64-symtab.elf -o %t/mismatch.gsym 2>&1 | FileCheck %s --check-prefix=MISMATCH
+# MISMATCH: architecture mismatch: input file is x86_64 but symbol table file '{{.*}}aarch64-symtab.elf' is aarch64
+
+## Test 3: Invalid symtab file error.
+# RUN: not llvm-gsymutil --convert %t/debug.elf --symtab-file=%t/debug.yaml -o %t/invalid.gsym 2>&1 | FileCheck %s --check-prefix=INVALID
+# INVALID: The file was not recognized as a valid object file
+
+#--- debug.yaml
+## An x86_64 ELF with DWARF debug info for one function (main) but no function
+## symbols in the symbol table.
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_X86_64
+  Entry:   0x0000000000401000
+Sections:
+  - Name:    .text
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address: 0x0000000000401000
+    AddressAlign: 0x10
+    ## Simple function: push rbp; mov rbp,rsp; xor eax,eax; pop rbp; ret
+    Content: 554889E531C05DC3
+  - Name:    .debug_abbrev
+    Type:    SHT_PROGBITS
+    AddressAlign: 0x1
+    ## Abbrev 1: DW_TAG_compile_unit (DW_CHILDREN_yes)
+    ##   DW_AT_low_pc (DW_FORM_addr), DW_AT_high_pc (DW_FORM_data4),
+    ##   DW_AT_name (DW_FORM_strp)
+    ## Abbrev 2: DW_TAG_subprogram (DW_CHILDREN_no)
+    ##   DW_AT_low_pc (DW_FORM_addr), DW_AT_high_pc (DW_FORM_data4),
+    ##   DW_AT_name (DW_FORM_strp)
+    Content: 01110100110112060000023F19030E3A0B3B0B491311011207401897421901130000022E003F19030E110112070000022E00110112060003080000
+  - Name:    .debug_info
+    Type:    SHT_PROGBITS
+    AddressAlign: 0x1
+    ## Compile unit header + DIEs referencing .debug_abbrev and .debug_str
+    Content: 2900000004000000000008010010400000000000080000000000000002001040000000000008000000050000
+  - Name:    .debug_str
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_MERGE, SHF_STRINGS ]
+    AddressAlign: 0x1
+    EntSize:  0x1
+    ## "test.cpp\0main\0"
+    Content: 746573742E63707000006D61696E00
+  - Name:    .debug_line
+    Type:    SHT_PROGBITS
+    AddressAlign: 0x1
+    Content: 3300000002001F0000000101FB0E0D000101010100000001000001007465737400746573742E637070000000000000090200104000000000000105030A0101
+ProgramHeaders:
+  - Type:  PT_LOAD
+    Flags: [ PF_X, PF_R ]
+    VAddr: 0x0000000000400000
+    Align: 0x1000
+    FirstSec: .text
+    LastSec:  .text
+Symbols: []
+...
+
+#--- symtab.yaml
+## An x86_64 ELF with function symbols but no DWARF debug info.
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_X86_64
+  Entry:   0x0000000000401000
+Sections:
+  - Name:    .text
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address: 0x0000000000401000
+    AddressAlign: 0x10
+    Content: 554889E531C05DC3
+ProgramHeaders:
+  - Type:  PT_LOAD
+    Flags: [ PF_X, PF_R ]
+    VAddr: 0x0000000000400000
+    Align: 0x1000
+    FirstSec: .text
+    LastSec:  .text
+Symbols:
+  - Name:    main
+    Type:    STT_FUNC
+    Section: .text
+    Binding: STB_GLOBAL
+    Value:   0x0000000000401000
+    Size:    0x0000000000000008
+  - Name:    _start
+    Type:    STT_FUNC
+    Section: .text
+    Binding: STB_GLOBAL
+    Value:   0x0000000000401000
+    Size:    0x0000000000000008
+...
+
+#--- aarch64-symtab.yaml
+## An AArch64 ELF to test architecture mismatch.
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_AARCH64
+  Entry:   0x0000000000401000
+Sections:
+  - Name:    .text
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address: 0x0000000000401000
+    AddressAlign: 0x10
+    Content: C0035FD6
+ProgramHeaders:
+  - Type:  PT_LOAD
+    Flags: [ PF_X, PF_R ]
+    VAddr: 0x0000000000400000
+    Align: 0x1000
+    FirstSec: .text
+    LastSec:  .text
+Symbols:
+  - Name:    main
+    Type:    STT_FUNC
+    Section: .text
+    Binding: STB_GLOBAL
+    Value:   0x0000000000401000
+    Size:    0x0000000000000004
+...

--- a/llvm/test/tools/llvm-gsymutil/cmdline.test
+++ b/llvm/test/tools/llvm-gsymutil/cmdline.test
@@ -11,6 +11,7 @@ HELP: --help
 HELP: --num-threads=<value>
 HELP: --out-file=<value>
 HELP: --quiet
+HELP: --symtab-file=<value>
 HELP: --verbose
 HELP: --verify
 HELP: --version

--- a/llvm/tools/llvm-gsymutil/Opts.td
+++ b/llvm/tools/llvm-gsymutil/Opts.td
@@ -16,6 +16,11 @@ def verbose : FF<"verbose", "Enable verbose logging and encoding details">;
 defm convert :
   Eq<"convert",
      "Convert the specified file to the GSYM format.\nSupported files include ELF and mach-o files that will have their debug info (DWARF) and symbol table converted">;
+defm symtab_file :
+  Eq<"symtab-file",
+     "Specify a separate file to read the symbol table from during GSYM conversion.\n"
+     "Use when the symbol table and debug info are in separate files.\n"
+     "Matching architectures are selected automatically for universal binaries">;
 def merged_functions :
   FF<"merged-functions", "When used with --convert, encodes merged function information for functions in debug info that have matching address ranges.\n"
                          "Without this option one function per unique address range will be emitted.\n"

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -92,6 +92,7 @@ public:
 static bool Verbose;
 static std::vector<std::string> InputFilenames;
 static std::string ConvertFilename;
+static std::string SymtabFilename;
 static std::vector<std::string> ArchFilters;
 static std::string OutputFilename;
 static std::string JsonSummaryFile;
@@ -146,6 +147,9 @@ static void parseArgs(int argc, char **argv) {
 
   if (const llvm::opt::Arg *A = Args.getLastArg(OPT_convert_EQ))
     ConvertFilename = A->getValue();
+
+  if (const llvm::opt::Arg *A = Args.getLastArg(OPT_symtab_file_EQ))
+    SymtabFilename = A->getValue();
 
   for (const llvm::opt::Arg *A : Args.filtered(OPT_arch_EQ))
     ArchFilters.emplace_back(A->getValue());
@@ -266,6 +270,16 @@ static uint32_t getCPUType(MachOObjectFile &MachO) {
     return MachO.getHeader().cputype;
 }
 
+static std::string getArchitectureName(const ObjectFile &Obj) {
+  if (const auto *MachO = dyn_cast<object::MachOObjectFile>(&Obj)) {
+    Triple ObjTriple(MachO->getArchTriple());
+    return ObjTriple.getArchName().str();
+  }
+
+  Triple ObjTriple(Obj.makeTriple());
+  return ObjTriple.getArchName().str();
+}
+
 /// Return true if the object file has not been filtered by an --arch option.
 static bool filterArch(MachOObjectFile &Obj) {
   if (ArchFilters.empty())
@@ -363,7 +377,45 @@ static std::optional<uint64_t> getImageBaseAddress(object::ObjectFile &Obj) {
   return std::nullopt;
 }
 
-static llvm::Error handleObjectFile(ObjectFile &Obj, const std::string &OutFile,
+static Expected<ObjectFile *>
+resolveSymtabObject(StringRef ArchName, Binary *SymtabBinary,
+                    StringRef SymtabPath,
+                    std::unique_ptr<ObjectFile> &OwnedSymtabObj) {
+  if (!SymtabBinary)
+    return nullptr;
+
+  if (auto *SymtabObj = dyn_cast<ObjectFile>(SymtabBinary)) {
+    std::string SymtabArchName = getArchitectureName(*SymtabObj);
+    if (SymtabArchName != ArchName)
+      return createStringError(std::errc::invalid_argument,
+                               "architecture mismatch: input file is %s but "
+                               "symbol table file '%s' is %s",
+                               ArchName.str().c_str(), SymtabPath.str().c_str(),
+                               SymtabArchName.c_str());
+
+    return SymtabObj;
+  }
+
+  if (auto *SymtabFat = dyn_cast<MachOUniversalBinary>(SymtabBinary)) {
+    auto SymtabObjOrErr = SymtabFat->getMachOObjectForArch(ArchName);
+    if (!SymtabObjOrErr)
+      return createStringError(
+          std::errc::invalid_argument,
+          "symbol table file '%s' does not contain architecture '%s'",
+          SymtabPath.str().c_str(), ArchName.str().c_str());
+
+    OwnedSymtabObj = std::move(*SymtabObjOrErr);
+    return OwnedSymtabObj.get();
+  }
+
+  return createStringError(std::errc::invalid_argument,
+                           "symbol table file '%s' is not a valid object file",
+                           SymtabPath.str().c_str());
+}
+
+static llvm::Error handleObjectFile(ObjectFile &Obj, ObjectFile *SymtabObj,
+                                    StringRef SymtabPath,
+                                    const std::string &OutFile,
                                     OutputAggregator &Out) {
   auto ThreadCount =
       NumThreads > 0 ? NumThreads : std::thread::hardware_concurrency();
@@ -436,8 +488,13 @@ static llvm::Error handleObjectFile(ObjectFile &Obj, const std::string &OutFile,
     Gsym.prepareMergedFunctions(Out);
 
   // Get the UUID and convert symbol table to GSYM.
-  if (auto Err = ObjectFileTransformer::convert(Obj, Out, Gsym))
+  if (SymtabObj) {
+    Out << "Using symbol table file: " << SymtabPath << "\n";
+    if (auto Err = ObjectFileTransformer::convert(*SymtabObj, Out, Gsym))
+      return Err;
+  } else if (auto Err = ObjectFileTransformer::convert(Obj, Out, Gsym)) {
     return Err;
+  }
 
   // If any call site YAML files were specified, load them now.
   if (!CallSiteYamlPath.empty())
@@ -472,16 +529,23 @@ static llvm::Error handleObjectFile(ObjectFile &Obj, const std::string &OutFile,
 }
 
 static llvm::Error handleBuffer(StringRef Filename, MemoryBufferRef Buffer,
+                                Binary *SymtabBinary, StringRef SymtabPath,
                                 const std::string &OutFile,
                                 OutputAggregator &Out) {
   Expected<std::unique_ptr<Binary>> BinOrErr = object::createBinary(Buffer);
   error(Filename, errorToErrorCode(BinOrErr.takeError()));
 
   if (auto *Obj = dyn_cast<ObjectFile>(BinOrErr->get())) {
-    Triple ObjTriple(Obj->makeTriple());
-    auto ArchName = ObjTriple.getArchName();
+    std::string ArchName = getArchitectureName(*Obj);
+    std::unique_ptr<ObjectFile> OwnedSymtabObj;
+    auto SymtabObjOrErr =
+        resolveSymtabObject(ArchName, SymtabBinary, SymtabPath, OwnedSymtabObj);
+    if (!SymtabObjOrErr)
+      return SymtabObjOrErr.takeError();
+
     outs() << "Output file (" << ArchName << "): " << OutFile << "\n";
-    if (auto Err = handleObjectFile(*Obj, OutFile, Out))
+    if (auto Err =
+            handleObjectFile(*Obj, *SymtabObjOrErr, SymtabPath, OutFile, Out))
       return Err;
   } else if (auto *Fat = dyn_cast<MachOUniversalBinary>(BinOrErr->get())) {
     // Iterate over all contained architectures and filter out any that were
@@ -489,33 +553,51 @@ static llvm::Error handleBuffer(StringRef Filename, MemoryBufferRef Buffer,
     // not specified on the command line, we will process all architectures.
     std::vector<std::unique_ptr<MachOObjectFile>> FilterObjs;
     for (auto &ObjForArch : Fat->objects()) {
-      if (auto MachOOrErr = ObjForArch.getAsObjectFile()) {
-        auto &Obj = **MachOOrErr;
-        if (filterArch(Obj))
-          FilterObjs.emplace_back(MachOOrErr->release());
-      } else {
+      auto MachOOrErr = ObjForArch.getAsObjectFile();
+      if (!MachOOrErr) {
         error(Filename, MachOOrErr.takeError());
+        continue;
       }
+
+      std::unique_ptr<MachOObjectFile> Obj = std::move(*MachOOrErr);
+      if (filterArch(*Obj))
+        FilterObjs.emplace_back(std::move(Obj));
     }
     if (FilterObjs.empty())
       error(Filename, createStringError(std::errc::invalid_argument,
                                         "no matching architectures found"));
 
     // Now handle each architecture we need to convert.
+    bool MultipleArchitecturesSelected = FilterObjs.size() > 1;
+    if (MultipleArchitecturesSelected && SymtabBinary &&
+        isa<ObjectFile>(SymtabBinary))
+      return createStringError(
+          std::errc::invalid_argument,
+          "symbol table file '%s' is not a universal binary, but the input "
+          "contains multiple architectures; use --arch to select a single "
+          "architecture",
+          SymtabPath.str().c_str());
+
     for (auto &Obj : FilterObjs) {
-      Triple ObjTriple(Obj->getArchTriple());
-      auto ArchName = ObjTriple.getArchName();
+      std::string ArchName = getArchitectureName(*Obj);
+      std::unique_ptr<ObjectFile> OwnedSymtabObj;
+      auto SymtabObjOrErr = resolveSymtabObject(ArchName, SymtabBinary,
+                                                SymtabPath, OwnedSymtabObj);
+      if (!SymtabObjOrErr)
+        return SymtabObjOrErr.takeError();
+
       std::string ArchOutFile(OutFile);
       // If we are only handling a single architecture, then we will use the
       // normal output file. If we are handling multiple architectures append
       // the architecture name to the end of the out file path so that we
       // don't overwrite the previous architecture's gsym file.
-      if (FilterObjs.size() > 1) {
+      if (MultipleArchitecturesSelected) {
         ArchOutFile.append(1, '.');
-        ArchOutFile.append(ArchName.str());
+        ArchOutFile.append(ArchName);
       }
       outs() << "Output file (" << ArchName << "): " << ArchOutFile << "\n";
-      if (auto Err = handleObjectFile(*Obj, ArchOutFile, Out))
+      if (auto Err = handleObjectFile(*Obj, *SymtabObjOrErr, SymtabPath,
+                                      ArchOutFile, Out))
         return Err;
     }
   }
@@ -529,7 +611,25 @@ static llvm::Error handleFileConversionToGSYM(StringRef Filename,
       MemoryBuffer::getFileOrSTDIN(Filename);
   error(Filename, BuffOrErr.getError());
   std::unique_ptr<MemoryBuffer> Buffer = std::move(BuffOrErr.get());
-  return handleBuffer(Filename, *Buffer, OutFile, Out);
+
+  std::unique_ptr<MemoryBuffer> SymtabBuffer;
+  std::unique_ptr<Binary> SymtabBinary;
+  if (!SymtabFilename.empty()) {
+    auto SymtabBufOrErr = MemoryBuffer::getFile(SymtabFilename);
+    if (!SymtabBufOrErr)
+      return createStringError(SymtabBufOrErr.getError(),
+                               "failed to open symbol table file '%s'",
+                               SymtabFilename.c_str());
+
+    SymtabBuffer = std::move(*SymtabBufOrErr);
+    auto SymtabBinOrErr = object::createBinary(*SymtabBuffer);
+    if (!SymtabBinOrErr)
+      return SymtabBinOrErr.takeError();
+    SymtabBinary = std::move(*SymtabBinOrErr);
+  }
+
+  return handleBuffer(Filename, *Buffer, SymtabBinary.get(), SymtabFilename,
+                      OutFile, Out);
 }
 
 static llvm::Error convertFileToGSYM(OutputAggregator &Out) {

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -398,11 +398,13 @@ resolveSymtabObject(StringRef ArchName, Binary *SymtabBinary,
 
   if (auto *SymtabFat = dyn_cast<MachOUniversalBinary>(SymtabBinary)) {
     auto SymtabObjOrErr = SymtabFat->getMachOObjectForArch(ArchName);
-    if (!SymtabObjOrErr)
+    if (!SymtabObjOrErr) {
+      consumeError(SymtabObjOrErr.takeError());
       return createStringError(
           std::errc::invalid_argument,
           "symbol table file '%s' does not contain architecture '%s'",
           SymtabPath.str().c_str(), ArchName.str().c_str());
+    }
 
     OwnedSymtabObj = std::move(*SymtabObjOrErr);
     return OwnedSymtabObj.get();


### PR DESCRIPTION
 Add a `--symtab-file` option that allows specifying a separate file from which
  to read the symbol table during GSYM conversion. This is useful when DWARF and
  function symbols are stored in separate files.

  Example:
  `llvm-gsymutil --convert debug_info.elf --symtab-file=symbols.elf -o output.gsym`

  ## Changes
  - Added `--symtab-file` to `Opts.td` and command-line help.
  - Parsed and used `--symtab-file` in `llvm-gsymutil.cpp` during conversion.
  - Kept architecture validation for thin object inputs.
  - Added support for universal Mach-O inputs by selecting the matching symbol-table slice for each selected
  architecture.
  - Reject the case where a multi-arch universal input is converted with a thin `--symtab-file`; `--arch` can be used
  to narrow the conversion to one architecture.
  - Added lit tests covering basic ELF usage, architecture mismatch, invalid symtab file, and thin/fat Mach-O cases.

  ## Test Plan
  - `ninja -C /tmp/llvm-gsymutil-build llvm-gsymutil`
  - `/tmp/llvm-gsymutil-build/bin/llvm-lit -sv llvm/test/tools/llvm-gsymutil/X86/elf-symtab-file.yaml llvm/test/tools/
  llvm-gsymutil/ARM_AArch64/fat-macho-symtab-file.yaml`