### PR TITLE
[CI] Enable LTO linker plugin tests

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -61,7 +61,8 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS=ON \
       -D CMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
       -D CMAKE_EXE_LINKER_FLAGS="-no-pie" \
-      -D LLVM_ENABLE_WERROR=ON
+      -D LLVM_ENABLE_WERROR=ON \
+      -D LLVM_BINUTILS_INCDIR=/usr
 
 start-group "ninja"
 


### PR DESCRIPTION
We've recently had two instances of test failures for the LTO linker plugin being introduced. Build and test the LTO linker plugin in pre-merge CI to avoid this.