### PR TITLE
[RISCV][llvm] Use [u]int32 vector for input arguments for zvdot4a8i

### DIFF
--- a/clang/include/clang/Basic/riscv_vector.td
+++ b/clang/include/clang/Basic/riscv_vector.td
@@ -2107,7 +2107,7 @@ multiclass RVVVDOTA4QBuiltinSet<list<list<string>> suffixes_prototypes> {
       HasMaskedOffOperand = false,
       OverloadedName = NAME,
       Log2LMUL = [-1, 0, 1, 2, 3] in {
-    defm NAME : RVVOutOp1Op2BuiltinSet<NAME, "i", suffixes_prototypes>;
+    defm NAME : RVVOutOp2BuiltinSet<NAME, "i", suffixes_prototypes>;
   }
 }
 
@@ -2115,13 +2115,13 @@ multiclass RVVVDOTA4QBuiltinSet<list<list<string>> suffixes_prototypes> {
 // four 8-bit integer bundles, we use unsigned type to represent all of them
 let RequiredFeatures = ["zvdot4a8i"] in {
   defm vdota4
-      : RVVVDOTA4QBuiltinSet<[["vv", "v", "vv(FixedSEW:8)v(FixedSEW:8)v"],
-                              ["vx", "v", "vv(FixedSEW:8)vUe"]]>;
+      : RVVVDOTA4QBuiltinSet<[["vv", "v", "vvUvUv"],
+                              ["vx", "v", "vvUvUe"]]>;
   defm vdota4u
-      : RVVVDOTA4QBuiltinSet<[["vv", "Uv", "UvUv(FixedSEW:8)Uv(FixedSEW:8)Uv"],
-                              ["vx", "Uv", "UvUv(FixedSEW:8)UvUe"]]>;
+      : RVVVDOTA4QBuiltinSet<[["vv", "Uv", "UvUvUvUv"],
+                              ["vx", "Uv", "UvUvUvUe"]]>;
   defm vdota4su
-      : RVVVDOTA4QBuiltinSet<[["vv", "v", "vv(FixedSEW:8)v(FixedSEW:8)Uv"],
-                              ["vx", "v", "vv(FixedSEW:8)vUe"]]>;
-  defm vdota4us : RVVVDOTA4QBuiltinSet<[["vx", "v", "vv(FixedSEW:8)UvUe"]]>;
+      : RVVVDOTA4QBuiltinSet<[["vv", "v", "vvUvUv"],
+                              ["vx", "v", "vvUvUe"]]>;
+  defm vdota4us : RVVVDOTA4QBuiltinSet<[["vx", "v", "vvUvUe"]]>;
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4_vv.c
@@ -7,111 +7,111 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vv_i32mf2(vint32mf2_t vd, vint8mf2_t vs2, vint8mf2_t vs1,
+vint32mf2_t test_vdota4_vv_i32mf2(vint32mf2_t vd, vuint32mf2_t vs2, vuint32mf2_t vs1,
                                   size_t vl) {
   return __riscv_vdota4_vv_i32mf2(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1(vint32m1_t vd, vint8m1_t vs2, vint8m1_t vs1,
+vint32m1_t test_vdota4_vv_i32m1(vint32m1_t vd, vuint32m1_t vs2, vuint32m1_t vs1,
                                 size_t vl) {
   return __riscv_vdota4_vv_i32m1(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2(vint32m2_t vd, vint8m2_t vs2, vint8m2_t vs1,
+vint32m2_t test_vdota4_vv_i32m2(vint32m2_t vd, vuint32m2_t vs2, vuint32m2_t vs1,
                                 size_t vl) {
   return __riscv_vdota4_vv_i32m2(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4(vint32m4_t vd, vint8m4_t vs2, vint8m4_t vs1,
+vint32m4_t test_vdota4_vv_i32m4(vint32m4_t vd, vuint32m4_t vs2, vuint32m4_t vs1,
                                 size_t vl) {
   return __riscv_vdota4_vv_i32m4(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8(vint32m8_t vd, vint8m8_t vs2, vint8m8_t vs1,
+vint32m8_t test_vdota4_vv_i32m8(vint32m8_t vd, vuint32m8_t vs2, vuint32m8_t vs1,
                                 size_t vl) {
   return __riscv_vdota4_vv_i32m8(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vv_i32mf2_m(vbool64_t vm, vint32mf2_t vd, vint8mf2_t vs2,
-                                    vint8mf2_t vs1, size_t vl) {
+vint32mf2_t test_vdota4_vv_i32mf2_m(vbool64_t vm, vint32mf2_t vd, vuint32mf2_t vs2,
+                                    vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32mf2_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                  vint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4_vv_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                  vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m1_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                  vint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4_vv_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                  vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m2_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                  vint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4_vv_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                  vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m4_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                  vint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4_vv_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                  vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m8_m(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4_vx.c
@@ -7,111 +7,111 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vx_i32mf2(vint32mf2_t vd, vint8mf2_t vs2, uint32_t rs1,
+vint32mf2_t test_vdota4_vx_i32mf2(vint32mf2_t vd, vuint32mf2_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4_vx_i32mf2(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1(vint32m1_t vd, vint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4_vx_i32m1(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                 size_t vl) {
   return __riscv_vdota4_vx_i32m1(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2(vint32m2_t vd, vint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4_vx_i32m2(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                 size_t vl) {
   return __riscv_vdota4_vx_i32m2(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4(vint32m4_t vd, vint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4_vx_i32m4(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                 size_t vl) {
   return __riscv_vdota4_vx_i32m4(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8(vint32m8_t vd, vint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4_vx_i32m8(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                 size_t vl) {
   return __riscv_vdota4_vx_i32m8(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vx_i32mf2_m(vbool64_t vm, vint32mf2_t vd, vint8mf2_t vs2,
+vint32mf2_t test_vdota4_vx_i32mf2_m(vbool64_t vm, vint32mf2_t vd, vuint32mf2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32mf2_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                   uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m1_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                   uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m2_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                   uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m4_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                   uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m8_m(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4su_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4su_vv.c
@@ -7,112 +7,112 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4su_vv_i32mf2(vint32mf2_t vd, vint8mf2_t vs2,
-                                    vuint8mf2_t vs1, size_t vl) {
+vint32mf2_t test_vdota4su_vv_i32mf2(vint32mf2_t vd, vuint32mf2_t vs2,
+                                    vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32mf2(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vv_i32m1(vint32m1_t vd, vint8m1_t vs2, vuint8m1_t vs1,
+vint32m1_t test_vdota4su_vv_i32m1(vint32m1_t vd, vuint32m1_t vs2, vuint32m1_t vs1,
                                   size_t vl) {
   return __riscv_vdota4su_vv_i32m1(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vv_i32m2(vint32m2_t vd, vint8m2_t vs2, vuint8m2_t vs1,
+vint32m2_t test_vdota4su_vv_i32m2(vint32m2_t vd, vuint32m2_t vs2, vuint32m2_t vs1,
                                   size_t vl) {
   return __riscv_vdota4su_vv_i32m2(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4(vint32m4_t vd, vint8m4_t vs2, vuint8m4_t vs1,
+vint32m4_t test_vdota4su_vv_i32m4(vint32m4_t vd, vuint32m4_t vs2, vuint32m4_t vs1,
                                   size_t vl) {
   return __riscv_vdota4su_vv_i32m4(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8(vint32m8_t vd, vint8m8_t vs2, vuint8m8_t vs1,
+vint32m8_t test_vdota4su_vv_i32m8(vint32m8_t vd, vuint32m8_t vs2, vuint32m8_t vs1,
                                   size_t vl) {
   return __riscv_vdota4su_vv_i32m8(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vv_i32mf2_m(vbool64_t vm, vint32mf2_t vd,
-                                      vint8mf2_t vs2, vuint8mf2_t vs1,
+                                      vuint32mf2_t vs2, vuint32mf2_t vs1,
                                      size_t vl) {
   return __riscv_vdota4su_vv_i32mf2_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vv_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                    vuint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4su_vv_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                    vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m1_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vv_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                    vuint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4su_vv_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                    vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m2_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                    vuint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4su_vv_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                    vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m4_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                    vuint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4su_vv_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                    vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m8_m(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4su_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4su_vx.c
@@ -7,111 +7,111 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4su_vx_i32mf2(vint32mf2_t vd, vint8mf2_t vs2, uint32_t rs1,
+vint32mf2_t test_vdota4su_vx_i32mf2(vint32mf2_t vd, vuint32mf2_t vs2, uint32_t rs1,
                                     size_t vl) {
   return __riscv_vdota4su_vx_i32mf2(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vx_i32m1(vint32m1_t vd, vint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4su_vx_i32m1(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4su_vx_i32m1(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vx_i32m2(vint32m2_t vd, vint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4su_vx_i32m2(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4su_vx_i32m2(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4(vint32m4_t vd, vint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4su_vx_i32m4(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4su_vx_i32m4(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8(vint32m8_t vd, vint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4su_vx_i32m8(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4su_vx_i32m8(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vx_i32mf2_m(vbool64_t vm, vint32mf2_t vd,
-                                      vint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32mf2_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4su_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m1_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4su_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m2_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4su_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m4_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4su_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m8_m(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4u_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4u_vv.c
@@ -7,112 +7,112 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vuint32mf2_t test_vdota4u_vv_u32mf2(vuint32mf2_t vd, vuint8mf2_t vs2,
-                                    vuint8mf2_t vs1, size_t vl) {
+vuint32mf2_t test_vdota4u_vv_u32mf2(vuint32mf2_t vd, vuint32mf2_t vs2,
+                                    vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32mf2(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vv_u32m1(vuint32m1_t vd, vuint8m1_t vs2, vuint8m1_t vs1,
+vuint32m1_t test_vdota4u_vv_u32m1(vuint32m1_t vd, vuint32m1_t vs2, vuint32m1_t vs1,
                                   size_t vl) {
   return __riscv_vdota4u_vv_u32m1(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vv_u32m2(vuint32m2_t vd, vuint8m2_t vs2, vuint8m2_t vs1,
+vuint32m2_t test_vdota4u_vv_u32m2(vuint32m2_t vd, vuint32m2_t vs2, vuint32m2_t vs1,
                                   size_t vl) {
   return __riscv_vdota4u_vv_u32m2(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vv_u32m4(vuint32m4_t vd, vuint8m4_t vs2, vuint8m4_t vs1,
+vuint32m4_t test_vdota4u_vv_u32m4(vuint32m4_t vd, vuint32m4_t vs2, vuint32m4_t vs1,
                                   size_t vl) {
   return __riscv_vdota4u_vv_u32m4(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vv_u32m8(vuint32m8_t vd, vuint8m8_t vs2, vuint8m8_t vs1,
+vuint32m8_t test_vdota4u_vv_u32m8(vuint32m8_t vd, vuint32m8_t vs2, vuint32m8_t vs1,
                                   size_t vl) {
   return __riscv_vdota4u_vv_u32m8(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                      vuint8mf2_t vs2, vuint8mf2_t vs1,
+                                      vuint32mf2_t vs2, vuint32mf2_t vs1,
                                      size_t vl) {
   return __riscv_vdota4u_vv_u32mf2_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint8m1_t vs2,
-                                    vuint8m1_t vs1, size_t vl) {
+vuint32m1_t test_vdota4u_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint32m1_t vs2,
+                                    vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m1_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint8m2_t vs2,
-                                    vuint8m2_t vs1, size_t vl) {
+vuint32m2_t test_vdota4u_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint32m2_t vs2,
+                                    vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m2_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint8m4_t vs2,
-                                    vuint8m4_t vs1, size_t vl) {
+vuint32m4_t test_vdota4u_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint32m4_t vs2,
+                                    vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m4_m(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
-                                    vuint8m8_t vs1, size_t vl) {
+vuint32m8_t test_vdota4u_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint32m8_t vs2,
+                                    vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m8_m(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4u_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4u_vx.c
@@ -7,111 +7,111 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vuint32mf2_t test_vdota4u_vx_u32mf2(vuint32mf2_t vd, vuint8mf2_t vs2,
+vuint32mf2_t test_vdota4u_vx_u32mf2(vuint32mf2_t vd, vuint32mf2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32mf2(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vx_u32m1(vuint32m1_t vd, vuint8m1_t vs2, uint32_t rs1,
+vuint32m1_t test_vdota4u_vx_u32m1(vuint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4u_vx_u32m1(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vx_u32m2(vuint32m2_t vd, vuint8m2_t vs2, uint32_t rs1,
+vuint32m2_t test_vdota4u_vx_u32m2(vuint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4u_vx_u32m2(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vx_u32m4(vuint32m4_t vd, vuint8m4_t vs2, uint32_t rs1,
+vuint32m4_t test_vdota4u_vx_u32m4(vuint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4u_vx_u32m4(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vx_u32m8(vuint32m8_t vd, vuint8m8_t vs2, uint32_t rs1,
+vuint32m8_t test_vdota4u_vx_u32m8(vuint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4u_vx_u32m8(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vx_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                      vuint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32mf2_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vx_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint8m1_t vs2,
+vuint32m1_t test_vdota4u_vx_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint32m1_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m1_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vx_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint8m2_t vs2,
+vuint32m2_t test_vdota4u_vx_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint32m2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m2_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vx_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint8m4_t vs2,
+vuint32m4_t test_vdota4u_vx_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint32m4_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m4_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vx_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+vuint32m8_t test_vdota4u_vx_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint32m8_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m8_m(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4us_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/non-overloaded/vdota4us_vx.c
@@ -7,111 +7,111 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4us_vx_i32mf2(vint32mf2_t vd, vuint8mf2_t vs2,
+vint32mf2_t test_vdota4us_vx_i32mf2(vint32mf2_t vd, vuint32mf2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32mf2(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4us_vx_i32m1(vint32m1_t vd, vuint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4us_vx_i32m1(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4us_vx_i32m1(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4us_vx_i32m2(vint32m2_t vd, vuint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4us_vx_i32m2(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4us_vx_i32m2(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4us_vx_i32m4(vint32m4_t vd, vuint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4us_vx_i32m4(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4us_vx_i32m4(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4us_vx_i32m8(vint32m8_t vd, vuint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4us_vx_i32m8(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4us_vx_i32m8(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4us_vx_i32mf2_m(vbool64_t vm, vint32mf2_t vd,
-                                      vuint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32mf2_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4us_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint8m1_t vs2,
+vint32m1_t test_vdota4us_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m1_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4us_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint8m2_t vs2,
+vint32m2_t test_vdota4us_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m2_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4us_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint8m4_t vs2,
+vint32m4_t test_vdota4us_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m4_m(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4us_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+vint32m8_t test_vdota4us_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m8_m(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4_vv.c
@@ -7,111 +7,111 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vv_i32mf2(vint32mf2_t vd, vint8mf2_t vs2, vint8mf2_t vs1,
+vint32mf2_t test_vdota4_vv_i32mf2(vint32mf2_t vd, vuint32mf2_t vs2, vuint32mf2_t vs1,
                                   size_t vl) {
   return __riscv_vdota4(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1(vint32m1_t vd, vint8m1_t vs2, vint8m1_t vs1,
+vint32m1_t test_vdota4_vv_i32m1(vint32m1_t vd, vuint32m1_t vs2, vuint32m1_t vs1,
                                 size_t vl) {
   return __riscv_vdota4(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2(vint32m2_t vd, vint8m2_t vs2, vint8m2_t vs1,
+vint32m2_t test_vdota4_vv_i32m2(vint32m2_t vd, vuint32m2_t vs2, vuint32m2_t vs1,
                                 size_t vl) {
   return __riscv_vdota4(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4(vint32m4_t vd, vint8m4_t vs2, vint8m4_t vs1,
+vint32m4_t test_vdota4_vv_i32m4(vint32m4_t vd, vuint32m4_t vs2, vuint32m4_t vs1,
                                 size_t vl) {
   return __riscv_vdota4(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8(vint32m8_t vd, vint8m8_t vs2, vint8m8_t vs1,
+vint32m8_t test_vdota4_vv_i32m8(vint32m8_t vd, vuint32m8_t vs2, vuint32m8_t vs1,
                                 size_t vl) {
   return __riscv_vdota4(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vv_i32mf2_m(vbool64_t vm, vint32mf2_t vd, vint8mf2_t vs2,
-                                    vint8mf2_t vs1, size_t vl) {
+vint32mf2_t test_vdota4_vv_i32mf2_m(vbool64_t vm, vint32mf2_t vd, vuint32mf2_t vs2,
+                                    vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                  vint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4_vv_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                  vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                  vint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4_vv_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                  vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                  vint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4_vv_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                  vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                  vint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4_vv_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                  vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4_vx.c
@@ -7,111 +7,111 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vx_i32mf2(vint32mf2_t vd, vint8mf2_t vs2, uint32_t rs1,
+vint32mf2_t test_vdota4_vx_i32mf2(vint32mf2_t vd, vuint32mf2_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1(vint32m1_t vd, vint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4_vx_i32m1(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                 size_t vl) {
   return __riscv_vdota4(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2(vint32m2_t vd, vint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4_vx_i32m2(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                 size_t vl) {
   return __riscv_vdota4(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4(vint32m4_t vd, vint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4_vx_i32m4(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                 size_t vl) {
   return __riscv_vdota4(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8(vint32m8_t vd, vint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4_vx_i32m8(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                 size_t vl) {
   return __riscv_vdota4(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vx_i32mf2_m(vbool64_t vm, vint32mf2_t vd, vint8mf2_t vs2,
+vint32mf2_t test_vdota4_vx_i32mf2_m(vbool64_t vm, vint32mf2_t vd, vuint32mf2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                   uint32_t rs1, size_t vl) {
   return __riscv_vdota4(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                   uint32_t rs1, size_t vl) {
   return __riscv_vdota4(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                   uint32_t rs1, size_t vl) {
   return __riscv_vdota4(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                   uint32_t rs1, size_t vl) {
   return __riscv_vdota4(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4su_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4su_vv.c
@@ -7,112 +7,112 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4su_vv_i32mf2(vint32mf2_t vd, vint8mf2_t vs2,
-                                    vuint8mf2_t vs1, size_t vl) {
+vint32mf2_t test_vdota4su_vv_i32mf2(vint32mf2_t vd, vuint32mf2_t vs2,
+                                    vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4su(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vv_i32m1(vint32m1_t vd, vint8m1_t vs2, vuint8m1_t vs1,
+vint32m1_t test_vdota4su_vv_i32m1(vint32m1_t vd, vuint32m1_t vs2, vuint32m1_t vs1,
                                   size_t vl) {
   return __riscv_vdota4su(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vv_i32m2(vint32m2_t vd, vint8m2_t vs2, vuint8m2_t vs1,
+vint32m2_t test_vdota4su_vv_i32m2(vint32m2_t vd, vuint32m2_t vs2, vuint32m2_t vs1,
                                   size_t vl) {
   return __riscv_vdota4su(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4(vint32m4_t vd, vint8m4_t vs2, vuint8m4_t vs1,
+vint32m4_t test_vdota4su_vv_i32m4(vint32m4_t vd, vuint32m4_t vs2, vuint32m4_t vs1,
                                   size_t vl) {
   return __riscv_vdota4su(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8(vint32m8_t vd, vint8m8_t vs2, vuint8m8_t vs1,
+vint32m8_t test_vdota4su_vv_i32m8(vint32m8_t vd, vuint32m8_t vs2, vuint32m8_t vs1,
                                   size_t vl) {
   return __riscv_vdota4su(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vv_i32mf2_m(vbool64_t vm, vint32mf2_t vd,
-                                      vint8mf2_t vs2, vuint8mf2_t vs1,
+                                      vuint32mf2_t vs2, vuint32mf2_t vs1,
                                      size_t vl) {
   return __riscv_vdota4su(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vv_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                    vuint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4su_vv_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                    vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4su(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vv_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                    vuint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4su_vv_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                    vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4su(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                    vuint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4su_vv_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                    vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4su(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                    vuint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4su_vv_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                    vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4su(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4su_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4su_vx.c
@@ -7,111 +7,111 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4su_vx_i32mf2(vint32mf2_t vd, vint8mf2_t vs2, uint32_t rs1,
+vint32mf2_t test_vdota4su_vx_i32mf2(vint32mf2_t vd, vuint32mf2_t vs2, uint32_t rs1,
                                     size_t vl) {
   return __riscv_vdota4su(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vx_i32m1(vint32m1_t vd, vint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4su_vx_i32m1(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4su(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vx_i32m2(vint32m2_t vd, vint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4su_vx_i32m2(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4su(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4(vint32m4_t vd, vint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4su_vx_i32m4(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4su(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8(vint32m8_t vd, vint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4su_vx_i32m8(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4su(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vx_i32mf2_m(vbool64_t vm, vint32mf2_t vd,
-                                      vint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4su(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4su_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4su(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4su_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4su(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4su_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4su(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4su_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4su(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4u_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4u_vv.c
@@ -7,112 +7,112 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vuint32mf2_t test_vdota4u_vv_u32mf2(vuint32mf2_t vd, vuint8mf2_t vs2,
-                                    vuint8mf2_t vs1, size_t vl) {
+vuint32mf2_t test_vdota4u_vv_u32mf2(vuint32mf2_t vd, vuint32mf2_t vs2,
+                                    vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4u(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vv_u32m1(vuint32m1_t vd, vuint8m1_t vs2, vuint8m1_t vs1,
+vuint32m1_t test_vdota4u_vv_u32m1(vuint32m1_t vd, vuint32m1_t vs2, vuint32m1_t vs1,
                                   size_t vl) {
   return __riscv_vdota4u(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vv_u32m2(vuint32m2_t vd, vuint8m2_t vs2, vuint8m2_t vs1,
+vuint32m2_t test_vdota4u_vv_u32m2(vuint32m2_t vd, vuint32m2_t vs2, vuint32m2_t vs1,
                                   size_t vl) {
   return __riscv_vdota4u(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vv_u32m4(vuint32m4_t vd, vuint8m4_t vs2, vuint8m4_t vs1,
+vuint32m4_t test_vdota4u_vv_u32m4(vuint32m4_t vd, vuint32m4_t vs2, vuint32m4_t vs1,
                                   size_t vl) {
   return __riscv_vdota4u(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vv_u32m8(vuint32m8_t vd, vuint8m8_t vs2, vuint8m8_t vs1,
+vuint32m8_t test_vdota4u_vv_u32m8(vuint32m8_t vd, vuint32m8_t vs2, vuint32m8_t vs1,
                                   size_t vl) {
   return __riscv_vdota4u(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vv_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                      vuint8mf2_t vs2, vuint8mf2_t vs1,
+                                      vuint32mf2_t vs2, vuint32mf2_t vs1,
                                      size_t vl) {
   return __riscv_vdota4u(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint8m1_t vs2,
-                                    vuint8m1_t vs1, size_t vl) {
+vuint32m1_t test_vdota4u_vv_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint32m1_t vs2,
+                                    vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4u(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint8m2_t vs2,
-                                    vuint8m2_t vs1, size_t vl) {
+vuint32m2_t test_vdota4u_vv_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint32m2_t vs2,
+                                    vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4u(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint8m4_t vs2,
-                                    vuint8m4_t vs1, size_t vl) {
+vuint32m4_t test_vdota4u_vv_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint32m4_t vs2,
+                                    vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4u(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
-                                    vuint8m8_t vs1, size_t vl) {
+vuint32m8_t test_vdota4u_vv_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint32m8_t vs2,
+                                    vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4u(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4u_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4u_vx.c
@@ -7,111 +7,111 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vuint32mf2_t test_vdota4u_vx_u32mf2(vuint32mf2_t vd, vuint8mf2_t vs2,
+vuint32mf2_t test_vdota4u_vx_u32mf2(vuint32mf2_t vd, vuint32mf2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4u(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vx_u32m1(vuint32m1_t vd, vuint8m1_t vs2, uint32_t rs1,
+vuint32m1_t test_vdota4u_vx_u32m1(vuint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4u(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vx_u32m2(vuint32m2_t vd, vuint8m2_t vs2, uint32_t rs1,
+vuint32m2_t test_vdota4u_vx_u32m2(vuint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4u(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vx_u32m4(vuint32m4_t vd, vuint8m4_t vs2, uint32_t rs1,
+vuint32m4_t test_vdota4u_vx_u32m4(vuint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4u(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vx_u32m8(vuint32m8_t vd, vuint8m8_t vs2, uint32_t rs1,
+vuint32m8_t test_vdota4u_vx_u32m8(vuint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4u(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vx_u32mf2_m(vbool64_t vm, vuint32mf2_t vd,
-                                      vuint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vx_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint8m1_t vs2,
+vuint32m1_t test_vdota4u_vx_u32m1_m(vbool32_t vm, vuint32m1_t vd, vuint32m1_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4u(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vx_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint8m2_t vs2,
+vuint32m2_t test_vdota4u_vx_u32m2_m(vbool16_t vm, vuint32m2_t vd, vuint32m2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4u(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vx_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint8m4_t vs2,
+vuint32m4_t test_vdota4u_vx_u32m4_m(vbool8_t vm, vuint32m4_t vd, vuint32m4_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4u(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vx_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+vuint32m8_t test_vdota4u_vx_u32m8_m(vbool4_t vm, vuint32m8_t vd, vuint32m8_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4u(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4us_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/non-policy/overloaded/vdota4us_vx.c
@@ -7,111 +7,111 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4us_vx_i32mf2(vint32mf2_t vd, vuint8mf2_t vs2,
+vint32mf2_t test_vdota4us_vx_i32mf2(vint32mf2_t vd, vuint32mf2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4us(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4us_vx_i32m1(vint32m1_t vd, vuint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4us_vx_i32m1(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4us(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4us_vx_i32m2(vint32m2_t vd, vuint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4us_vx_i32m2(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4us(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4us_vx_i32m4(vint32m4_t vd, vuint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4us_vx_i32m4(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4us(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4us_vx_i32m8(vint32m8_t vd, vuint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4us_vx_i32m8(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                   size_t vl) {
   return __riscv_vdota4us(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2_m(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4us_vx_i32mf2_m(vbool64_t vm, vint32mf2_t vd,
-                                      vuint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1_m(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4us_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint8m1_t vs2,
+vint32m1_t test_vdota4us_vx_i32m1_m(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4us(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2_m(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4us_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint8m2_t vs2,
+vint32m2_t test_vdota4us_vx_i32m2_m(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4us(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4_m(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4us_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint8m4_t vs2,
+vint32m4_t test_vdota4us_vx_i32m4_m(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4us(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8_m(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 3)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4us_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+vint32m8_t test_vdota4us_vx_i32m8_m(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4us(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4_vv.c
@@ -7,223 +7,223 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vv_i32mf2_tu(vint32mf2_t vd, vint8mf2_t vs2,
-                                     vint8mf2_t vs1, size_t vl) {
+vint32mf2_t test_vdota4_vv_i32mf2_tu(vint32mf2_t vd, vuint32mf2_t vs2,
+                                     vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32mf2_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1_tu(vint32m1_t vd, vint8m1_t vs2, vint8m1_t vs1,
+vint32m1_t test_vdota4_vv_i32m1_tu(vint32m1_t vd, vuint32m1_t vs2, vuint32m1_t vs1,
                                    size_t vl) {
   return __riscv_vdota4_vv_i32m1_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2_tu(vint32m2_t vd, vint8m2_t vs2, vint8m2_t vs1,
+vint32m2_t test_vdota4_vv_i32m2_tu(vint32m2_t vd, vuint32m2_t vs2, vuint32m2_t vs1,
                                    size_t vl) {
   return __riscv_vdota4_vv_i32m2_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4_tu(vint32m4_t vd, vint8m4_t vs2, vint8m4_t vs1,
+vint32m4_t test_vdota4_vv_i32m4_tu(vint32m4_t vd, vuint32m4_t vs2, vuint32m4_t vs1,
                                    size_t vl) {
   return __riscv_vdota4_vv_i32m4_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8_tu(vint32m8_t vd, vint8m8_t vs2, vint8m8_t vs1,
+vint32m8_t test_vdota4_vv_i32m8_tu(vint32m8_t vd, vuint32m8_t vs2, vuint32m8_t vs1,
                                    size_t vl) {
   return __riscv_vdota4_vv_i32m8_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vv_i32mf2_tum(vbool64_t vm, vint32mf2_t vd,
-                                      vint8mf2_t vs2, vint8mf2_t vs1,
+                                      vuint32mf2_t vs2, vuint32mf2_t vs1,
                                      size_t vl) {
   return __riscv_vdota4_vv_i32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                    vint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4_vv_i32m1_tum(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                    vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                    vint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4_vv_i32m2_tum(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                    vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                    vint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4_vv_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                    vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                    vint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4_vv_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                    vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vv_i32mf2_tumu(vbool64_t vm, vint32mf2_t vd,
-                                       vint8mf2_t vs2, vint8mf2_t vs1,
+                                       vuint32mf2_t vs2, vuint32mf2_t vs1,
                                       size_t vl) {
   return __riscv_vdota4_vv_i32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                     vint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4_vv_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                     vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                     vint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4_vv_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                     vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                     vint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4_vv_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                     vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                     vint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4_vv_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                     vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vv_i32mf2_mu(vbool64_t vm, vint32mf2_t vd,
-                                     vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+                                     vuint32mf2_t vs2, vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                   vint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4_vv_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                   vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                   vint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4_vv_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                   vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                   vint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4_vv_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                   vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                   vint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4_vv_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                   vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4_vv_i32m8_mu(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4_vx.c
@@ -7,221 +7,221 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vx_i32mf2_tu(vint32mf2_t vd, vint8mf2_t vs2,
+vint32mf2_t test_vdota4_vx_i32mf2_tu(vint32mf2_t vd, vuint32mf2_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32mf2_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1_tu(vint32m1_t vd, vint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4_vx_i32m1_tu(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                    size_t vl) {
   return __riscv_vdota4_vx_i32m1_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2_tu(vint32m2_t vd, vint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4_vx_i32m2_tu(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                    size_t vl) {
   return __riscv_vdota4_vx_i32m2_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4_tu(vint32m4_t vd, vint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4_vx_i32m4_tu(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                    size_t vl) {
   return __riscv_vdota4_vx_i32m4_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8_tu(vint32m8_t vd, vint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4_vx_i32m8_tu(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                    size_t vl) {
   return __riscv_vdota4_vx_i32m8_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vx_i32mf2_tum(vbool64_t vm, vint32mf2_t vd,
-                                      vint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4_vx_i32m1_tum(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m1_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4_vx_i32m2_tum(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m2_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m4_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m8_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vx_i32mf2_tumu(vbool64_t vm, vint32mf2_t vd,
-                                       vint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4_vx_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4_vx_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4_vx_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4_vx_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vx_i32mf2_mu(vbool64_t vm, vint32mf2_t vd,
-                                     vint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                     vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                    uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m1_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                    uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m2_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                    uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m4_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                    uint32_t rs1, size_t vl) {
   return __riscv_vdota4_vx_i32m8_mu(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4su_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4su_vv.c
@@ -7,226 +7,226 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4su_vv_i32mf2_tu(vint32mf2_t vd, vint8mf2_t vs2,
-                                       vuint8mf2_t vs1, size_t vl) {
+vint32mf2_t test_vdota4su_vv_i32mf2_tu(vint32mf2_t vd, vuint32mf2_t vs2,
+                                       vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32mf2_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vv_i32m1_tu(vint32m1_t vd, vint8m1_t vs2,
-                                     vuint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4su_vv_i32m1_tu(vint32m1_t vd, vuint32m1_t vs2,
+                                     vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m1_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vv_i32m2_tu(vint32m2_t vd, vint8m2_t vs2,
-                                     vuint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4su_vv_i32m2_tu(vint32m2_t vd, vuint32m2_t vs2,
+                                     vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m2_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4_tu(vint32m4_t vd, vint8m4_t vs2,
-                                     vuint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4su_vv_i32m4_tu(vint32m4_t vd, vuint32m4_t vs2,
+                                     vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m4_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
-                                     vuint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4su_vv_i32m8_tu(vint32m8_t vd, vuint32m8_t vs2,
+                                     vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m8_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vv_i32mf2_tum(vbool64_t vm, vint32mf2_t vd,
-                                        vint8mf2_t vs2, vuint8mf2_t vs1,
+                                        vuint32mf2_t vs2, vuint32mf2_t vs1,
                                        size_t vl) {
   return __riscv_vdota4su_vv_i32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vv_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                      vuint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4su_vv_i32m1_tum(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                      vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vv_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                      vuint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4su_vv_i32m2_tum(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                      vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                      vuint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4su_vv_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                      vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                      vuint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4su_vv_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                      vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vv_i32mf2_tumu(vbool64_t vm, vint32mf2_t vd,
-                                         vint8mf2_t vs2, vuint8mf2_t vs1,
+                                         vuint32mf2_t vs2, vuint32mf2_t vs1,
                                         size_t vl) {
   return __riscv_vdota4su_vv_i32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vint32m1_t test_vdota4su_vv_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
-                                       vint8m1_t vs2, vuint8m1_t vs1,
+                                       vuint32m1_t vs2, vuint32m1_t vs1,
                                       size_t vl) {
   return __riscv_vdota4su_vv_i32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vint32m2_t test_vdota4su_vv_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
-                                       vint8m2_t vs2, vuint8m2_t vs1,
+                                       vuint32m2_t vs2, vuint32m2_t vs1,
                                       size_t vl) {
   return __riscv_vdota4su_vv_i32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                       vuint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4su_vv_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                       vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                       vuint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4su_vv_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                       vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vv_i32mf2_mu(vbool64_t vm, vint32mf2_t vd,
-                                       vint8mf2_t vs2, vuint8mf2_t vs1,
+                                       vuint32mf2_t vs2, vuint32mf2_t vs1,
                                       size_t vl) {
   return __riscv_vdota4su_vv_i32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vv_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                     vuint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4su_vv_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                     vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vv_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                     vuint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4su_vv_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                     vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                     vuint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4su_vv_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                     vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                     vuint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4su_vv_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                     vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4su_vv_i32m8_mu(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4su_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4su_vx.c
@@ -7,223 +7,223 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4su_vx_i32mf2_tu(vint32mf2_t vd, vint8mf2_t vs2,
+vint32mf2_t test_vdota4su_vx_i32mf2_tu(vint32mf2_t vd, vuint32mf2_t vs2,
                                        uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32mf2_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vx_i32m1_tu(vint32m1_t vd, vint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4su_vx_i32m1_tu(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4su_vx_i32m1_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vx_i32m2_tu(vint32m2_t vd, vint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4su_vx_i32m2_tu(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4su_vx_i32m2_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4_tu(vint32m4_t vd, vint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4su_vx_i32m4_tu(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4su_vx_i32m4_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8_tu(vint32m8_t vd, vint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4su_vx_i32m8_tu(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4su_vx_i32m8_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vx_i32mf2_tum(vbool64_t vm, vint32mf2_t vd,
-                                        vint8mf2_t vs2, uint32_t rs1,
+                                        vuint32mf2_t vs2, uint32_t rs1,
                                        size_t vl) {
   return __riscv_vdota4su_vx_i32mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vx_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4su_vx_i32m1_tum(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m1_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vx_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4su_vx_i32m2_tum(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m2_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4su_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m4_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4su_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m8_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vx_i32mf2_tumu(vbool64_t vm, vint32mf2_t vd,
-                                         vint8mf2_t vs2, uint32_t rs1,
+                                         vuint32mf2_t vs2, uint32_t rs1,
                                         size_t vl) {
   return __riscv_vdota4su_vx_i32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vint32m1_t test_vdota4su_vx_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
-                                       vint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vint32m2_t test_vdota4su_vx_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
-                                       vint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4su_vx_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                        uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4su_vx_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                        uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vx_i32mf2_mu(vbool64_t vm, vint32mf2_t vd,
-                                       vint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4su_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m1_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4su_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m2_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4su_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m4_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4su_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_vx_i32m8_mu(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4u_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4u_vv.c
@@ -7,232 +7,232 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vuint32mf2_t test_vdota4u_vv_u32mf2_tu(vuint32mf2_t vd, vuint8mf2_t vs2,
-                                       vuint8mf2_t vs1, size_t vl) {
+vuint32mf2_t test_vdota4u_vv_u32mf2_tu(vuint32mf2_t vd, vuint32mf2_t vs2,
+                                       vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32mf2_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vv_u32m1_tu(vuint32m1_t vd, vuint8m1_t vs2,
-                                     vuint8m1_t vs1, size_t vl) {
+vuint32m1_t test_vdota4u_vv_u32m1_tu(vuint32m1_t vd, vuint32m1_t vs2,
+                                     vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m1_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vv_u32m2_tu(vuint32m2_t vd, vuint8m2_t vs2,
-                                     vuint8m2_t vs1, size_t vl) {
+vuint32m2_t test_vdota4u_vv_u32m2_tu(vuint32m2_t vd, vuint32m2_t vs2,
+                                     vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m2_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vv_u32m4_tu(vuint32m4_t vd, vuint8m4_t vs2,
-                                     vuint8m4_t vs1, size_t vl) {
+vuint32m4_t test_vdota4u_vv_u32m4_tu(vuint32m4_t vd, vuint32m4_t vs2,
+                                     vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m4_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vv_u32m8_tu(vuint32m8_t vd, vuint8m8_t vs2,
-                                     vuint8m8_t vs1, size_t vl) {
+vuint32m8_t test_vdota4u_vv_u32m8_tu(vuint32m8_t vd, vuint32m8_t vs2,
+                                     vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m8_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                        vuint8mf2_t vs2, vuint8mf2_t vs1,
+                                        vuint32mf2_t vs2, vuint32mf2_t vs1,
                                        size_t vl) {
   return __riscv_vdota4u_vv_u32mf2_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                      vuint8m1_t vs2, vuint8m1_t vs1,
+                                      vuint32m1_t vs2, vuint32m1_t vs1,
                                      size_t vl) {
   return __riscv_vdota4u_vv_u32m1_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                      vuint8m2_t vs2, vuint8m2_t vs1,
+                                      vuint32m2_t vs2, vuint32m2_t vs1,
                                      size_t vl) {
   return __riscv_vdota4u_vv_u32m2_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
 vuint32m4_t test_vdota4u_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                      vuint8m4_t vs2, vuint8m4_t vs1,
+                                      vuint32m4_t vs2, vuint32m4_t vs1,
                                      size_t vl) {
   return __riscv_vdota4u_vv_u32m4_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
 vuint32m8_t test_vdota4u_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                      vuint8m8_t vs2, vuint8m8_t vs1,
+                                      vuint32m8_t vs2, vuint32m8_t vs1,
                                      size_t vl) {
   return __riscv_vdota4u_vv_u32m8_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                         vuint8mf2_t vs2, vuint8mf2_t vs1,
+                                         vuint32mf2_t vs2, vuint32mf2_t vs1,
                                         size_t vl) {
   return __riscv_vdota4u_vv_u32mf2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                       vuint8m1_t vs2, vuint8m1_t vs1,
+                                       vuint32m1_t vs2, vuint32m1_t vs1,
                                       size_t vl) {
   return __riscv_vdota4u_vv_u32m1_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                       vuint8m2_t vs2, vuint8m2_t vs1,
+                                       vuint32m2_t vs2, vuint32m2_t vs1,
                                       size_t vl) {
   return __riscv_vdota4u_vv_u32m2_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
 vuint32m4_t test_vdota4u_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                       vuint8m4_t vs2, vuint8m4_t vs1,
+                                       vuint32m4_t vs2, vuint32m4_t vs1,
                                       size_t vl) {
   return __riscv_vdota4u_vv_u32m4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
 vuint32m8_t test_vdota4u_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                       vuint8m8_t vs2, vuint8m8_t vs1,
+                                       vuint32m8_t vs2, vuint32m8_t vs1,
                                       size_t vl) {
   return __riscv_vdota4u_vv_u32m8_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                       vuint8mf2_t vs2, vuint8mf2_t vs1,
+                                       vuint32mf2_t vs2, vuint32mf2_t vs1,
                                       size_t vl) {
   return __riscv_vdota4u_vv_u32mf2_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                     vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+                                     vuint32m1_t vs2, vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m1_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                     vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+                                     vuint32m2_t vs2, vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m2_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint8m4_t vs2,
-                                     vuint8m4_t vs1, size_t vl) {
+vuint32m4_t test_vdota4u_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint32m4_t vs2,
+                                     vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m4_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
-                                     vuint8m8_t vs1, size_t vl) {
+vuint32m8_t test_vdota4u_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint32m8_t vs2,
+                                     vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4u_vv_u32m8_mu(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4u_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4u_vx.c
@@ -7,224 +7,224 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vuint32mf2_t test_vdota4u_vx_u32mf2_tu(vuint32mf2_t vd, vuint8mf2_t vs2,
+vuint32mf2_t test_vdota4u_vx_u32mf2_tu(vuint32mf2_t vd, vuint32mf2_t vs2,
                                        uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32mf2_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vx_u32m1_tu(vuint32m1_t vd, vuint8m1_t vs2,
+vuint32m1_t test_vdota4u_vx_u32m1_tu(vuint32m1_t vd, vuint32m1_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m1_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vx_u32m2_tu(vuint32m2_t vd, vuint8m2_t vs2,
+vuint32m2_t test_vdota4u_vx_u32m2_tu(vuint32m2_t vd, vuint32m2_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m2_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vx_u32m4_tu(vuint32m4_t vd, vuint8m4_t vs2,
+vuint32m4_t test_vdota4u_vx_u32m4_tu(vuint32m4_t vd, vuint32m4_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m4_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vx_u32m8_tu(vuint32m8_t vd, vuint8m8_t vs2,
+vuint32m8_t test_vdota4u_vx_u32m8_tu(vuint32m8_t vd, vuint32m8_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m8_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vx_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                        vuint8mf2_t vs2, uint32_t rs1,
+                                        vuint32mf2_t vs2, uint32_t rs1,
                                        size_t vl) {
   return __riscv_vdota4u_vx_u32mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vx_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                      vuint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m1_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vx_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                      vuint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m2_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
 vuint32m4_t test_vdota4u_vx_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                      vuint8m4_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m4_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m4_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
 vuint32m8_t test_vdota4u_vx_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                      vuint8m8_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m8_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m8_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vx_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                         vuint8mf2_t vs2, uint32_t rs1,
+                                         vuint32mf2_t vs2, uint32_t rs1,
                                         size_t vl) {
   return __riscv_vdota4u_vx_u32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vx_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                       vuint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vx_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                       vuint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
 vuint32m4_t test_vdota4u_vx_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                       vuint8m4_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m4_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
 vuint32m8_t test_vdota4u_vx_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                       vuint8m8_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m8_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vx_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                       vuint8mf2_t vs2, uint32_t rs1,
+                                       vuint32mf2_t vs2, uint32_t rs1,
                                       size_t vl) {
   return __riscv_vdota4u_vx_u32mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vx_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                     vuint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                     vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m1_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vx_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                     vuint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                     vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m2_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vx_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint8m4_t vs2,
+vuint32m4_t test_vdota4u_vx_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint32m4_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m4_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vx_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+vuint32m8_t test_vdota4u_vx_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint32m8_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_vx_u32m8_mu(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4us_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/non-overloaded/vdota4us_vx.c
@@ -7,224 +7,224 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4us_vx_i32mf2_tu(vint32mf2_t vd, vuint8mf2_t vs2,
+vint32mf2_t test_vdota4us_vx_i32mf2_tu(vint32mf2_t vd, vuint32mf2_t vs2,
                                        uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32mf2_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4us_vx_i32m1_tu(vint32m1_t vd, vuint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4us_vx_i32m1_tu(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4us_vx_i32m1_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4us_vx_i32m2_tu(vint32m2_t vd, vuint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4us_vx_i32m2_tu(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4us_vx_i32m2_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4us_vx_i32m4_tu(vint32m4_t vd, vuint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4us_vx_i32m4_tu(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4us_vx_i32m4_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4us_vx_i32m8_tu(vint32m8_t vd, vuint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4us_vx_i32m8_tu(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4us_vx_i32m8_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4us_vx_i32mf2_tum(vbool64_t vm, vint32mf2_t vd,
-                                        vuint8mf2_t vs2, uint32_t rs1,
+                                        vuint32mf2_t vs2, uint32_t rs1,
                                        size_t vl) {
   return __riscv_vdota4us_vx_i32mf2_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vint32m1_t test_vdota4us_vx_i32m1_tum(vbool32_t vm, vint32m1_t vd,
-                                      vuint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m1_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vint32m2_t test_vdota4us_vx_i32m2_tum(vbool16_t vm, vint32m2_t vd,
-                                      vuint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m2_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4us_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint8m4_t vs2,
+vint32m4_t test_vdota4us_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m4_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4us_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+vint32m8_t test_vdota4us_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m8_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4us_vx_i32mf2_tumu(vbool64_t vm, vint32mf2_t vd,
-                                         vuint8mf2_t vs2, uint32_t rs1,
+                                         vuint32mf2_t vs2, uint32_t rs1,
                                         size_t vl) {
   return __riscv_vdota4us_vx_i32mf2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vint32m1_t test_vdota4us_vx_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
-                                       vuint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m1_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vint32m2_t test_vdota4us_vx_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
-                                       vuint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m2_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
 vint32m4_t test_vdota4us_vx_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
-                                       vuint8m4_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m4_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
 vint32m8_t test_vdota4us_vx_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
-                                       vuint8m8_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m8_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m8_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4us_vx_i32mf2_mu(vbool64_t vm, vint32mf2_t vd,
-                                       vuint8mf2_t vs2, uint32_t rs1,
+                                       vuint32mf2_t vs2, uint32_t rs1,
                                       size_t vl) {
   return __riscv_vdota4us_vx_i32mf2_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4us_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint8m1_t vs2,
+vint32m1_t test_vdota4us_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m1_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4us_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint8m2_t vs2,
+vint32m2_t test_vdota4us_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m2_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4us_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint8m4_t vs2,
+vint32m4_t test_vdota4us_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m4_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4us_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+vint32m8_t test_vdota4us_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_vx_i32m8_mu(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4_vv.c
@@ -7,223 +7,223 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vv_i32mf2_tu(vint32mf2_t vd, vint8mf2_t vs2,
-                                     vint8mf2_t vs1, size_t vl) {
+vint32mf2_t test_vdota4_vv_i32mf2_tu(vint32mf2_t vd, vuint32mf2_t vs2,
+                                     vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1_tu(vint32m1_t vd, vint8m1_t vs2, vint8m1_t vs1,
+vint32m1_t test_vdota4_vv_i32m1_tu(vint32m1_t vd, vuint32m1_t vs2, vuint32m1_t vs1,
                                    size_t vl) {
   return __riscv_vdota4_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2_tu(vint32m2_t vd, vint8m2_t vs2, vint8m2_t vs1,
+vint32m2_t test_vdota4_vv_i32m2_tu(vint32m2_t vd, vuint32m2_t vs2, vuint32m2_t vs1,
                                    size_t vl) {
   return __riscv_vdota4_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4_tu(vint32m4_t vd, vint8m4_t vs2, vint8m4_t vs1,
+vint32m4_t test_vdota4_vv_i32m4_tu(vint32m4_t vd, vuint32m4_t vs2, vuint32m4_t vs1,
                                    size_t vl) {
   return __riscv_vdota4_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8_tu(vint32m8_t vd, vint8m8_t vs2, vint8m8_t vs1,
+vint32m8_t test_vdota4_vv_i32m8_tu(vint32m8_t vd, vuint32m8_t vs2, vuint32m8_t vs1,
                                    size_t vl) {
   return __riscv_vdota4_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vv_i32mf2_tum(vbool64_t vm, vint32mf2_t vd,
-                                      vint8mf2_t vs2, vint8mf2_t vs1,
+                                      vuint32mf2_t vs2, vuint32mf2_t vs1,
                                      size_t vl) {
   return __riscv_vdota4_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                    vint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4_vv_i32m1_tum(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                    vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                    vint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4_vv_i32m2_tum(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                    vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                    vint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4_vv_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                    vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                    vint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4_vv_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                    vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vv_i32mf2_tumu(vbool64_t vm, vint32mf2_t vd,
-                                       vint8mf2_t vs2, vint8mf2_t vs1,
+                                       vuint32mf2_t vs2, vuint32mf2_t vs1,
                                       size_t vl) {
   return __riscv_vdota4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                     vint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4_vv_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                     vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                     vint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4_vv_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                     vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                     vint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4_vv_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                     vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                     vint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4_vv_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                     vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vv_i32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vv_i32mf2_mu(vbool64_t vm, vint32mf2_t vd,
-                                     vint8mf2_t vs2, vint8mf2_t vs1, size_t vl) {
+                                     vuint32mf2_t vs2, vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vv_i32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vv_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                   vint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4_vv_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                   vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vv_i32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vv_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                   vint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4_vv_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                   vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vv_i32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vv_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                   vint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4_vv_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                   vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vv_i32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vv_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                   vint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4_vv_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                   vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4_mu(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4_vx.c
@@ -7,221 +7,221 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4_vx_i32mf2_tu(vint32mf2_t vd, vint8mf2_t vs2,
+vint32mf2_t test_vdota4_vx_i32mf2_tu(vint32mf2_t vd, vuint32mf2_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1_tu(vint32m1_t vd, vint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4_vx_i32m1_tu(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                    size_t vl) {
   return __riscv_vdota4_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2_tu(vint32m2_t vd, vint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4_vx_i32m2_tu(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                    size_t vl) {
   return __riscv_vdota4_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4_tu(vint32m4_t vd, vint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4_vx_i32m4_tu(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                    size_t vl) {
   return __riscv_vdota4_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8_tu(vint32m8_t vd, vint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4_vx_i32m8_tu(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                    size_t vl) {
   return __riscv_vdota4_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vx_i32mf2_tum(vbool64_t vm, vint32mf2_t vd,
-                                      vint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4_vx_i32m1_tum(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4_vx_i32m2_tum(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                     uint32_t rs1, size_t vl) {
   return __riscv_vdota4_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vx_i32mf2_tumu(vbool64_t vm, vint32mf2_t vd,
-                                       vint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4_vx_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4_vx_i32m2_tumu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4_vx_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4_vx_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4_vx_i32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4_vx_i32mf2_mu(vbool64_t vm, vint32mf2_t vd,
-                                     vint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                     vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4_vx_i32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                    uint32_t rs1, size_t vl) {
   return __riscv_vdota4_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4_vx_i32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                    uint32_t rs1, size_t vl) {
   return __riscv_vdota4_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4_vx_i32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                    uint32_t rs1, size_t vl) {
   return __riscv_vdota4_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4_vx_i32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                    uint32_t rs1, size_t vl) {
   return __riscv_vdota4_mu(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4su_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4su_vv.c
@@ -7,226 +7,226 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4su_vv_i32mf2_tu(vint32mf2_t vd, vint8mf2_t vs2,
-                                       vuint8mf2_t vs1, size_t vl) {
+vint32mf2_t test_vdota4su_vv_i32mf2_tu(vint32mf2_t vd, vuint32mf2_t vs2,
+                                       vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4su_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vv_i32m1_tu(vint32m1_t vd, vint8m1_t vs2,
-                                     vuint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4su_vv_i32m1_tu(vint32m1_t vd, vuint32m1_t vs2,
+                                     vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4su_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vv_i32m2_tu(vint32m2_t vd, vint8m2_t vs2,
-                                     vuint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4su_vv_i32m2_tu(vint32m2_t vd, vuint32m2_t vs2,
+                                     vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4su_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4_tu(vint32m4_t vd, vint8m4_t vs2,
-                                     vuint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4su_vv_i32m4_tu(vint32m4_t vd, vuint32m4_t vs2,
+                                     vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4su_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8_tu(vint32m8_t vd, vint8m8_t vs2,
-                                     vuint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4su_vv_i32m8_tu(vint32m8_t vd, vuint32m8_t vs2,
+                                     vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4su_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vv_i32mf2_tum(vbool64_t vm, vint32mf2_t vd,
-                                        vint8mf2_t vs2, vuint8mf2_t vs1,
+                                        vuint32mf2_t vs2, vuint32mf2_t vs1,
                                        size_t vl) {
   return __riscv_vdota4su_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vv_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                      vuint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4su_vv_i32m1_tum(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                      vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4su_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vv_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                      vuint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4su_vv_i32m2_tum(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                      vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4su_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                      vuint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4su_vv_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                      vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4su_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                      vuint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4su_vv_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                      vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4su_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vv_i32mf2_tumu(vbool64_t vm, vint32mf2_t vd,
-                                         vint8mf2_t vs2, vuint8mf2_t vs1,
+                                         vuint32mf2_t vs2, vuint32mf2_t vs1,
                                         size_t vl) {
   return __riscv_vdota4su_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vint32m1_t test_vdota4su_vv_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
-                                       vint8m1_t vs2, vuint8m1_t vs1,
+                                       vuint32m1_t vs2, vuint32m1_t vs1,
                                       size_t vl) {
   return __riscv_vdota4su_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vint32m2_t test_vdota4su_vv_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
-                                       vint8m2_t vs2, vuint8m2_t vs1,
+                                       vuint32m2_t vs2, vuint32m2_t vs1,
                                       size_t vl) {
   return __riscv_vdota4su_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                       vuint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4su_vv_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                       vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4su_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                       vuint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4su_vv_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                       vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4su_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vv_i32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vv_i32mf2_mu(vbool64_t vm, vint32mf2_t vd,
-                                       vint8mf2_t vs2, vuint8mf2_t vs1,
+                                       vuint32mf2_t vs2, vuint32mf2_t vs1,
                                       size_t vl) {
   return __riscv_vdota4su_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vv_i32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vv_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
-                                     vuint8m1_t vs1, size_t vl) {
+vint32m1_t test_vdota4su_vv_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
+                                     vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4su_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vv_i32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vv_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
-                                     vuint8m2_t vs1, size_t vl) {
+vint32m2_t test_vdota4su_vv_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
+                                     vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4su_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vv_i32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vv_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
-                                     vuint8m4_t vs1, size_t vl) {
+vint32m4_t test_vdota4su_vv_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
+                                     vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4su_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vv_i32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vv_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
-                                     vuint8m8_t vs1, size_t vl) {
+vint32m8_t test_vdota4su_vv_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
+                                     vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4su_mu(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4su_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4su_vx.c
@@ -7,223 +7,223 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4su_vx_i32mf2_tu(vint32mf2_t vd, vint8mf2_t vs2,
+vint32mf2_t test_vdota4su_vx_i32mf2_tu(vint32mf2_t vd, vuint32mf2_t vs2,
                                        uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vx_i32m1_tu(vint32m1_t vd, vint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4su_vx_i32m1_tu(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4su_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vx_i32m2_tu(vint32m2_t vd, vint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4su_vx_i32m2_tu(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4su_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4_tu(vint32m4_t vd, vint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4su_vx_i32m4_tu(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4su_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8_tu(vint32m8_t vd, vint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4su_vx_i32m8_tu(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4su_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vx_i32mf2_tum(vbool64_t vm, vint32mf2_t vd,
-                                        vint8mf2_t vs2, uint32_t rs1,
+                                        vuint32mf2_t vs2, uint32_t rs1,
                                        size_t vl) {
   return __riscv_vdota4su_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vx_i32m1_tum(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4su_vx_i32m1_tum(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vx_i32m2_tum(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4su_vx_i32m2_tum(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4su_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4su_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vx_i32mf2_tumu(vbool64_t vm, vint32mf2_t vd,
-                                         vint8mf2_t vs2, uint32_t rs1,
+                                         vuint32mf2_t vs2, uint32_t rs1,
                                         size_t vl) {
   return __riscv_vdota4su_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vint32m1_t test_vdota4su_vx_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
-                                       vint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vint32m2_t test_vdota4su_vx_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
-                                       vint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4su_vx_i32m4_tumu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                        uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4su_vx_i32m8_tumu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                        uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4su_vx_i32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4su_vx_i32mf2_mu(vbool64_t vm, vint32mf2_t vd,
-                                       vint8mf2_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32mf2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4su_vx_i32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4su_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2,
+vint32m1_t test_vdota4su_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4su_vx_i32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4su_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vint8m2_t vs2,
+vint32m2_t test_vdota4su_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4su_vx_i32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4su_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vint8m4_t vs2,
+vint32m4_t test_vdota4su_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4su_vx_i32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4su_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vint8m8_t vs2,
+vint32m8_t test_vdota4su_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4su_mu(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4u_vv.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4u_vv.c
@@ -7,232 +7,232 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vuint32mf2_t test_vdota4u_vv_u32mf2_tu(vuint32mf2_t vd, vuint8mf2_t vs2,
-                                       vuint8mf2_t vs1, size_t vl) {
+vuint32mf2_t test_vdota4u_vv_u32mf2_tu(vuint32mf2_t vd, vuint32mf2_t vs2,
+                                       vuint32mf2_t vs1, size_t vl) {
   return __riscv_vdota4u_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vv_u32m1_tu(vuint32m1_t vd, vuint8m1_t vs2,
-                                     vuint8m1_t vs1, size_t vl) {
+vuint32m1_t test_vdota4u_vv_u32m1_tu(vuint32m1_t vd, vuint32m1_t vs2,
+                                     vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4u_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vv_u32m2_tu(vuint32m2_t vd, vuint8m2_t vs2,
-                                     vuint8m2_t vs1, size_t vl) {
+vuint32m2_t test_vdota4u_vv_u32m2_tu(vuint32m2_t vd, vuint32m2_t vs2,
+                                     vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4u_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vv_u32m4_tu(vuint32m4_t vd, vuint8m4_t vs2,
-                                     vuint8m4_t vs1, size_t vl) {
+vuint32m4_t test_vdota4u_vv_u32m4_tu(vuint32m4_t vd, vuint32m4_t vs2,
+                                     vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4u_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vv_u32m8_tu(vuint32m8_t vd, vuint8m8_t vs2,
-                                     vuint8m8_t vs1, size_t vl) {
+vuint32m8_t test_vdota4u_vv_u32m8_tu(vuint32m8_t vd, vuint32m8_t vs2,
+                                     vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4u_tu(vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vv_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                        vuint8mf2_t vs2, vuint8mf2_t vs1,
+                                        vuint32mf2_t vs2, vuint32mf2_t vs1,
                                        size_t vl) {
   return __riscv_vdota4u_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vv_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                      vuint8m1_t vs2, vuint8m1_t vs1,
+                                      vuint32m1_t vs2, vuint32m1_t vs1,
                                      size_t vl) {
   return __riscv_vdota4u_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vv_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                      vuint8m2_t vs2, vuint8m2_t vs1,
+                                      vuint32m2_t vs2, vuint32m2_t vs1,
                                      size_t vl) {
   return __riscv_vdota4u_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
 vuint32m4_t test_vdota4u_vv_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                      vuint8m4_t vs2, vuint8m4_t vs1,
+                                      vuint32m4_t vs2, vuint32m4_t vs1,
                                      size_t vl) {
   return __riscv_vdota4u_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
 vuint32m8_t test_vdota4u_vv_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                      vuint8m8_t vs2, vuint8m8_t vs1,
+                                      vuint32m8_t vs2, vuint32m8_t vs1,
                                      size_t vl) {
   return __riscv_vdota4u_tum(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vv_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                         vuint8mf2_t vs2, vuint8mf2_t vs1,
+                                         vuint32mf2_t vs2, vuint32mf2_t vs1,
                                         size_t vl) {
   return __riscv_vdota4u_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vv_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                       vuint8m1_t vs2, vuint8m1_t vs1,
+                                       vuint32m1_t vs2, vuint32m1_t vs1,
                                       size_t vl) {
   return __riscv_vdota4u_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vv_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                       vuint8m2_t vs2, vuint8m2_t vs1,
+                                       vuint32m2_t vs2, vuint32m2_t vs1,
                                       size_t vl) {
   return __riscv_vdota4u_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
 vuint32m4_t test_vdota4u_vv_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                       vuint8m4_t vs2, vuint8m4_t vs1,
+                                       vuint32m4_t vs2, vuint32m4_t vs1,
                                       size_t vl) {
   return __riscv_vdota4u_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
 vuint32m8_t test_vdota4u_vv_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                       vuint8m8_t vs2, vuint8m8_t vs1,
+                                       vuint32m8_t vs2, vuint32m8_t vs1,
                                       size_t vl) {
   return __riscv_vdota4u_tumu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vv_u32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], <vscale x 4 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], <vscale x 1 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.nxv4i8.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], <vscale x 4 x i8> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv1i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], <vscale x 1 x i32> [[VS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vv_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                       vuint8mf2_t vs2, vuint8mf2_t vs1,
+                                       vuint32mf2_t vs2, vuint32mf2_t vs1,
                                       size_t vl) {
   return __riscv_vdota4u_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vv_u32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], <vscale x 8 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], <vscale x 2 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.nxv8i8.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], <vscale x 8 x i8> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv2i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], <vscale x 2 x i32> [[VS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vv_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                     vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
+                                     vuint32m1_t vs2, vuint32m1_t vs1, size_t vl) {
   return __riscv_vdota4u_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vv_u32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], <vscale x 16 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], <vscale x 4 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.nxv16i8.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], <vscale x 16 x i8> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv4i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], <vscale x 4 x i32> [[VS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vv_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                     vuint8m2_t vs2, vuint8m2_t vs1, size_t vl) {
+                                     vuint32m2_t vs2, vuint32m2_t vs1, size_t vl) {
   return __riscv_vdota4u_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vv_u32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], <vscale x 32 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], <vscale x 8 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.nxv32i8.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], <vscale x 32 x i8> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv8i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], <vscale x 8 x i32> [[VS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint8m4_t vs2,
-                                     vuint8m4_t vs1, size_t vl) {
+vuint32m4_t test_vdota4u_vv_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint32m4_t vs2,
+                                     vuint32m4_t vs1, size_t vl) {
   return __riscv_vdota4u_mu(vm, vd, vs2, vs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vv_u32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], <vscale x 64 x i8> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], <vscale x 16 x i32> [[VS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.nxv64i8.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], <vscale x 64 x i8> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv16i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], <vscale x 16 x i32> [[VS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
-                                     vuint8m8_t vs1, size_t vl) {
+vuint32m8_t test_vdota4u_vv_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint32m8_t vs2,
+                                     vuint32m8_t vs1, size_t vl) {
   return __riscv_vdota4u_mu(vm, vd, vs2, vs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4u_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4u_vx.c
@@ -7,224 +7,224 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vuint32mf2_t test_vdota4u_vx_u32mf2_tu(vuint32mf2_t vd, vuint8mf2_t vs2,
+vuint32mf2_t test_vdota4u_vx_u32mf2_tu(vuint32mf2_t vd, vuint32mf2_t vs2,
                                        uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vuint32m1_t test_vdota4u_vx_u32m1_tu(vuint32m1_t vd, vuint8m1_t vs2,
+vuint32m1_t test_vdota4u_vx_u32m1_tu(vuint32m1_t vd, vuint32m1_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vuint32m2_t test_vdota4u_vx_u32m2_tu(vuint32m2_t vd, vuint8m2_t vs2,
+vuint32m2_t test_vdota4u_vx_u32m2_tu(vuint32m2_t vd, vuint32m2_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vx_u32m4_tu(vuint32m4_t vd, vuint8m4_t vs2,
+vuint32m4_t test_vdota4u_vx_u32m4_tu(vuint32m4_t vd, vuint32m4_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vx_u32m8_tu(vuint32m8_t vd, vuint8m8_t vs2,
+vuint32m8_t test_vdota4u_vx_u32m8_tu(vuint32m8_t vd, vuint32m8_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vx_u32mf2_tum(vbool64_t vm, vuint32mf2_t vd,
-                                        vuint8mf2_t vs2, uint32_t rs1,
+                                        vuint32mf2_t vs2, uint32_t rs1,
                                        size_t vl) {
   return __riscv_vdota4u_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vx_u32m1_tum(vbool32_t vm, vuint32m1_t vd,
-                                      vuint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vx_u32m2_tum(vbool16_t vm, vuint32m2_t vd,
-                                      vuint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
 vuint32m4_t test_vdota4u_vx_u32m4_tum(vbool8_t vm, vuint32m4_t vd,
-                                      vuint8m4_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m4_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
 vuint32m8_t test_vdota4u_vx_u32m8_tum(vbool4_t vm, vuint32m8_t vd,
-                                      vuint8m8_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m8_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vx_u32mf2_tumu(vbool64_t vm, vuint32mf2_t vd,
-                                         vuint8mf2_t vs2, uint32_t rs1,
+                                         vuint32mf2_t vs2, uint32_t rs1,
                                         size_t vl) {
   return __riscv_vdota4u_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vx_u32m1_tumu(vbool32_t vm, vuint32m1_t vd,
-                                       vuint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vx_u32m2_tumu(vbool16_t vm, vuint32m2_t vd,
-                                       vuint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
 vuint32m4_t test_vdota4u_vx_u32m4_tumu(vbool8_t vm, vuint32m4_t vd,
-                                       vuint8m4_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m4_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
 vuint32m8_t test_vdota4u_vx_u32m8_tumu(vbool4_t vm, vuint32m8_t vd,
-                                       vuint8m8_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m8_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4u_vx_u32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vuint32mf2_t test_vdota4u_vx_u32mf2_mu(vbool64_t vm, vuint32mf2_t vd,
-                                       vuint8mf2_t vs2, uint32_t rs1,
+                                       vuint32mf2_t vs2, uint32_t rs1,
                                       size_t vl) {
   return __riscv_vdota4u_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4u_vx_u32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vuint32m1_t test_vdota4u_vx_u32m1_mu(vbool32_t vm, vuint32m1_t vd,
-                                     vuint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                     vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4u_vx_u32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vuint32m2_t test_vdota4u_vx_u32m2_mu(vbool16_t vm, vuint32m2_t vd,
-                                     vuint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                     vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4u_vx_u32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vuint32m4_t test_vdota4u_vx_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint8m4_t vs2,
+vuint32m4_t test_vdota4u_vx_u32m4_mu(vbool8_t vm, vuint32m4_t vd, vuint32m4_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4u_vx_u32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vuint32m8_t test_vdota4u_vx_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint8m8_t vs2,
+vuint32m8_t test_vdota4u_vx_u32m8_mu(vbool4_t vm, vuint32m8_t vd, vuint32m8_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4u_mu(vm, vd, vs2, rs1, vl);
 }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4us_vx.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-autogenerated/zvdot4a8i/policy/overloaded/vdota4us_vx.c
@@ -7,224 +7,224 @@
 #include <sifive_vector.h>
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2_tu(
-// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
+// CHECK-RV64-SAME: <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
-vint32mf2_t test_vdota4us_vx_i32mf2_tu(vint32mf2_t vd, vuint8mf2_t vs2,
+vint32mf2_t test_vdota4us_vx_i32mf2_tu(vint32mf2_t vd, vuint32mf2_t vs2,
                                        uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1_tu(
-// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4us_vx_i32m1_tu(vint32m1_t vd, vuint8m1_t vs2, uint32_t rs1,
+vint32m1_t test_vdota4us_vx_i32m1_tu(vint32m1_t vd, vuint32m1_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4us_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2_tu(
-// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4us_vx_i32m2_tu(vint32m2_t vd, vuint8m2_t vs2, uint32_t rs1,
+vint32m2_t test_vdota4us_vx_i32m2_tu(vint32m2_t vd, vuint32m2_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4us_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4_tu(
-// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4us_vx_i32m4_tu(vint32m4_t vd, vuint8m4_t vs2, uint32_t rs1,
+vint32m4_t test_vdota4us_vx_i32m4_tu(vint32m4_t vd, vuint32m4_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4us_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8_tu(
-// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4us_vx_i32m8_tu(vint32m8_t vd, vuint8m8_t vs2, uint32_t rs1,
+vint32m8_t test_vdota4us_vx_i32m8_tu(vint32m8_t vd, vuint32m8_t vs2, uint32_t rs1,
                                      size_t vl) {
   return __riscv_vdota4us_tu(vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2_tum(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4us_vx_i32mf2_tum(vbool64_t vm, vint32mf2_t vd,
-                                        vuint8mf2_t vs2, uint32_t rs1,
+                                        vuint32mf2_t vs2, uint32_t rs1,
                                        size_t vl) {
   return __riscv_vdota4us_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1_tum(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vint32m1_t test_vdota4us_vx_i32m1_tum(vbool32_t vm, vint32m1_t vd,
-                                      vuint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2_tum(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vint32m2_t test_vdota4us_vx_i32m2_tum(vbool16_t vm, vint32m2_t vd,
-                                      vuint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                      vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4_tum(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4us_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint8m4_t vs2,
+vint32m4_t test_vdota4us_vx_i32m4_tum(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8_tum(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 2)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4us_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+vint32m8_t test_vdota4us_vx_i32m8_tum(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                       uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_tum(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2_tumu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4us_vx_i32mf2_tumu(vbool64_t vm, vint32mf2_t vd,
-                                         vuint8mf2_t vs2, uint32_t rs1,
+                                         vuint32mf2_t vs2, uint32_t rs1,
                                         size_t vl) {
   return __riscv_vdota4us_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1_tumu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
 vint32m1_t test_vdota4us_vx_i32m1_tumu(vbool32_t vm, vint32m1_t vd,
-                                       vuint8m1_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m1_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2_tumu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
 vint32m2_t test_vdota4us_vx_i32m2_tumu(vbool16_t vm, vint32m2_t vd,
-                                       vuint8m2_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m2_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4_tumu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
 vint32m4_t test_vdota4us_vx_i32m4_tumu(vbool8_t vm, vint32m4_t vd,
-                                       vuint8m4_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m4_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8_tumu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 0)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
 vint32m8_t test_vdota4us_vx_i32m8_tumu(vbool4_t vm, vint32m8_t vd,
-                                       vuint8m8_t vs2, uint32_t rs1, size_t vl) {
+                                       vuint32m8_t vs2, uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_tumu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 1 x i32> @test_vdota4us_vx_i32mf2_mu(
-// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 4 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 1 x i1> [[VM:%.*]], <vscale x 1 x i32> [[VD:%.*]], <vscale x 1 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.nxv4i8.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 4 x i8> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.i32.i64(<vscale x 1 x i32> [[VD]], <vscale x 1 x i32> [[VS2]], i32 [[RS1]], <vscale x 1 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 1 x i32> [[TMP0]]
 //
 vint32mf2_t test_vdota4us_vx_i32mf2_mu(vbool64_t vm, vint32mf2_t vd,
-                                       vuint8mf2_t vs2, uint32_t rs1,
+                                       vuint32mf2_t vs2, uint32_t rs1,
                                       size_t vl) {
   return __riscv_vdota4us_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 2 x i32> @test_vdota4us_vx_i32m1_mu(
-// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 8 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 2 x i1> [[VM:%.*]], <vscale x 2 x i32> [[VD:%.*]], <vscale x 2 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.nxv8i8.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 8 x i8> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.i32.i64(<vscale x 2 x i32> [[VD]], <vscale x 2 x i32> [[VS2]], i32 [[RS1]], <vscale x 2 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 2 x i32> [[TMP0]]
 //
-vint32m1_t test_vdota4us_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint8m1_t vs2,
+vint32m1_t test_vdota4us_vx_i32m1_mu(vbool32_t vm, vint32m1_t vd, vuint32m1_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 4 x i32> @test_vdota4us_vx_i32m2_mu(
-// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 16 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 4 x i1> [[VM:%.*]], <vscale x 4 x i32> [[VD:%.*]], <vscale x 4 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.nxv16i8.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 16 x i8> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.i32.i64(<vscale x 4 x i32> [[VD]], <vscale x 4 x i32> [[VS2]], i32 [[RS1]], <vscale x 4 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 4 x i32> [[TMP0]]
 //
-vint32m2_t test_vdota4us_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint8m2_t vs2,
+vint32m2_t test_vdota4us_vx_i32m2_mu(vbool16_t vm, vint32m2_t vd, vuint32m2_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 8 x i32> @test_vdota4us_vx_i32m4_mu(
-// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 32 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 8 x i1> [[VM:%.*]], <vscale x 8 x i32> [[VD:%.*]], <vscale x 8 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.nxv32i8.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 32 x i8> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.i32.i64(<vscale x 8 x i32> [[VD]], <vscale x 8 x i32> [[VS2]], i32 [[RS1]], <vscale x 8 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 8 x i32> [[TMP0]]
 //
-vint32m4_t test_vdota4us_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint8m4_t vs2,
+vint32m4_t test_vdota4us_vx_i32m4_mu(vbool8_t vm, vint32m4_t vd, vuint32m4_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_mu(vm, vd, vs2, rs1, vl);
 }
 
 // CHECK-RV64-LABEL: define dso_local <vscale x 16 x i32> @test_vdota4us_vx_i32m8_mu(
-// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 64 x i8> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-SAME: <vscale x 16 x i1> [[VM:%.*]], <vscale x 16 x i32> [[VD:%.*]], <vscale x 16 x i32> [[VS2:%.*]], i32 noundef signext [[RS1:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.nxv64i8.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 64 x i8> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.i32.i64(<vscale x 16 x i32> [[VD]], <vscale x 16 x i32> [[VS2]], i32 [[RS1]], <vscale x 16 x i1> [[VM]], i64 [[VL]], i64 1)
 // CHECK-RV64-NEXT:    ret <vscale x 16 x i32> [[TMP0]]
 //
-vint32m8_t test_vdota4us_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint8m8_t vs2,
+vint32m8_t test_vdota4us_vx_i32m8_mu(vbool4_t vm, vint32m8_t vd, vuint32m8_t vs2,
                                      uint32_t rs1, size_t vl) {
   return __riscv_vdota4us_mu(vm, vd, vs2, rs1, vl);
 }

--- a/llvm/include/llvm/IR/IntrinsicsRISCV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCV.td
@@ -1952,9 +1952,9 @@ let TargetPrefix = "riscv" in {
   // Input: (vector_in, vector_in, vector_in/scalar_in, vl, policy)
   class RISCVVDOTA4UnMasked<bit HasVV>
         : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
-                                [LLVMMatchType<0>, llvm_anyvector_ty,
+                                [LLVMMatchType<0>, LLVMMatchType<0>,
                                  !if(HasVV, llvm_any_ty, llvm_anyint_ty),
-                                 llvm_anyint_ty, LLVMMatchType<3>],
+                                 llvm_anyint_ty, LLVMMatchType<2>],
                                 [ImmArg<ArgIndex<4>>, IntrNoMem]>,
                                 RISCVVIntrinsic {
     let ScalarOperand = 2;
@@ -1963,10 +1963,10 @@ let TargetPrefix = "riscv" in {
   // Input: (vector_in, vector_in, vector_in/scalar_in, mask, vl, policy)
   class RISCVVDOTA4Masked<bit HasVV>
         : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
-                                [LLVMMatchType<0>, llvm_anyvector_ty,
+                                [LLVMMatchType<0>, LLVMMatchType<0>,
                                  !if(HasVV, llvm_any_ty, llvm_anyint_ty),
                                  LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
-                                 llvm_anyint_ty, LLVMMatchType<3>],
+                                 llvm_anyint_ty, LLVMMatchType<2>],
                                 [ImmArg<ArgIndex<5>>, IntrNoMem]>,
                                 RISCVVIntrinsic {
     let ScalarOperand = 2;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvdot4a8i.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvdot4a8i.td
@@ -95,53 +95,39 @@ defm : VPatBinaryVL_VV_VX<riscv_vdota4su_vl, "PseudoVDOTA4SU", AllE32Vectors, Ex
 
 // These VPat definitions are for vdota4 because they have a different operand
 // order with other ternary instructions (i.e. vop.vx vd, vs2, rs1)
-multiclass VPatTernaryV_VX_AABX<string intrinsic, string instruction,
-                                list<VTypeInfoToWide> info_pairs,
+multiclass VPatTernaryV_VX_AAAX<string intrinsic, string instruction,
+                                list<VTypeInfo> vtilist,
                                 list<Predicate> ExtraPreds> {
-  foreach pair = info_pairs in {
-    defvar VdInfo = pair.Wti;
-    defvar Vs2Info = pair.Vti;
-    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<VdInfo>.Predicates) in
+  foreach vti = vtilist in
+    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in
     defm : VPatTernaryWithPolicy<intrinsic, instruction,
-                                 "V"#VdInfo.ScalarSuffix,
-                                 VdInfo.Vector, Vs2Info.Vector, Vs2Info.Scalar,
-                                 VdInfo.Mask, VdInfo.Log2SEW, VdInfo.LMul,
-                                 VdInfo.RegClass, Vs2Info.RegClass,
-                                 Vs2Info.ScalarRegClass>;
-  }
+                                 "V"#vti.ScalarSuffix,
+                                 vti.Vector, vti.Vector, vti.Scalar,
+                                 vti.Mask, vti.Log2SEW, vti.LMul,
+                                 vti.RegClass, vti.RegClass,
+                                 vti.ScalarRegClass>;
 }
 
-multiclass VPatTernaryV_VV_AABX<string intrinsic, string instruction,
-                                list<VTypeInfoToWide> info_pairs,
+multiclass VPatTernaryV_VV_AAAX<string intrinsic, string instruction,
+                                list<VTypeInfo> vtilist,
                                 list<Predicate> ExtraPreds> {
-  foreach pair = info_pairs in {
-    defvar VdInfo = pair.Wti;
-    defvar Vs2Info = pair.Vti;
-    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<VdInfo>.Predicates) in
+  foreach vti = vtilist in
+    let Predicates = !listconcat(ExtraPreds, GetVTypePredicates<vti>.Predicates) in
     defm : VPatTernaryWithPolicy<intrinsic, instruction,
                                  "VV",
-                                 VdInfo.Vector, Vs2Info.Vector, Vs2Info.Vector,
-                                 VdInfo.Mask, VdInfo.Log2SEW, VdInfo.LMul,
-                                 VdInfo.RegClass, Vs2Info.RegClass,
-                                 Vs2Info.RegClass>;
-  }
+                                 vti.Vector, vti.Vector, vti.Vector,
+                                 vti.Mask, vti.Log2SEW, vti.LMul,
+                                 vti.RegClass, vti.RegClass,
+                                 vti.RegClass>;
 }
 
-multiclass VPatTernaryV_VV_VX_AABX<string intrinsic, string instruction,
-                                   list<VTypeInfoToWide> info_pairs,
+multiclass VPatTernaryV_VV_VX_AAAX<string intrinsic, string instruction,
+                                   list<VTypeInfo> vtilist,
                                    list<Predicate> ExtraPreds>
-    : VPatTernaryV_VV_AABX<intrinsic, instruction, info_pairs, ExtraPreds>,
-      VPatTernaryV_VX_AABX<intrinsic, instruction, info_pairs, ExtraPreds>;
+    : VPatTernaryV_VV_AAAX<intrinsic, instruction, vtilist, ExtraPreds>,
+      VPatTernaryV_VX_AAAX<intrinsic, instruction, vtilist, ExtraPreds>;
 
-defset list<VTypeInfoToWide> VDOTA4InfoPairs = {
-  def : VTypeInfoToWide<VI8MF2, VI32MF2>;
-  def : VTypeInfoToWide<VI8M1, VI32M1>;
-  def : VTypeInfoToWide<VI8M2, VI32M2>;
-  def : VTypeInfoToWide<VI8M4, VI32M4>;
-  def : VTypeInfoToWide<VI8M8, VI32M8>;
-}
-
-defm : VPatTernaryV_VV_VX_AABX<"int_riscv_vdota4", "PseudoVDOTA4", VDOTA4InfoPairs, [HasStdExtZvdot4a8i]>;
-defm : VPatTernaryV_VV_VX_AABX<"int_riscv_vdota4u", "PseudoVDOTA4U", VDOTA4InfoPairs, [HasStdExtZvdot4a8i]>;
-defm : VPatTernaryV_VV_VX_AABX<"int_riscv_vdota4su", "PseudoVDOTA4SU", VDOTA4InfoPairs, [HasStdExtZvdot4a8i]>;
-defm : VPatTernaryV_VX_AABX<"int_riscv_vdota4us", "PseudoVDOTA4US", VDOTA4InfoPairs, [HasStdExtZvdot4a8i]>;
+defm : VPatTernaryV_VV_VX_AAAX<"int_riscv_vdota4", "PseudoVDOTA4", AllE32Vectors, [HasStdExtZvdot4a8i]>;
+defm : VPatTernaryV_VV_VX_AAAX<"int_riscv_vdota4u", "PseudoVDOTA4U", AllE32Vectors, [HasStdExtZvdot4a8i]>;
+defm : VPatTernaryV_VV_VX_AAAX<"int_riscv_vdota4su", "PseudoVDOTA4SU", AllE32Vectors, [HasStdExtZvdot4a8i]>;
+defm : VPatTernaryV_VX_AAAX<"int_riscv_vdota4us", "PseudoVDOTA4US", AllE32Vectors, [HasStdExtZvdot4a8i]>;

--- a/llvm/test/CodeGen/RISCV/rvv/vdota4.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vdota4.ll
@@ -4,7 +4,7 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+zve64x,+experimental-zvdot4a8i \
 ; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK
 
-define <vscale x 1 x i32>  @intrinsic_vdota4_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, <vscale x 4 x i8> %2, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, <vscale x 1 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_vv_nxv1i32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, mf2, tu, ma
@@ -13,14 +13,14 @@ define <vscale x 1 x i32>  @intrinsic_vdota4_vv_nxv1i32_nxv1i32(<vscale x 1 x i3
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.nxv1i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
-    <vscale x 4 x i8> %2,
+    <vscale x 1 x i32> %1,
+    <vscale x 1 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, <vscale x 8 x i8> %2, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_vv_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m1, tu, ma
@@ -29,14 +29,14 @@ define <vscale x 2 x i32>  @intrinsic_vdota4_vv_nxv2i32_nxv2i32(<vscale x 2 x i3
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.nxv2i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
-    <vscale x 8 x i8> %2,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, <vscale x 16 x i8> %2, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_vv_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m2, tu, ma
@@ -45,14 +45,14 @@ define <vscale x 4 x i32>  @intrinsic_vdota4_vv_nxv4i32_nxv4i32(<vscale x 4 x i3
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.nxv4i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
-    <vscale x 16 x i8> %2,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, <vscale x 32 x i8> %2, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_vv_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m4, tu, ma
@@ -61,31 +61,31 @@ define <vscale x 8 x i32>  @intrinsic_vdota4_vv_nxv8i32_nxv8i32(<vscale x 8 x i3
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.nxv8i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
-    <vscale x 32 x i8> %2,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, <vscale x 64 x i8> %2, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_vv_nxv16i32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vl8r.v v24, (a0)
+; CHECK-NEXT:    vl8re32.v v24, (a0)
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, ma
 ; CHECK-NEXT:    vdota4.vv v8, v16, v24
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.nxv16i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
-    <vscale x 64 x i8> %2,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 16 x i32> %a
 }
 
-define <vscale x 1 x i32>  @intrinsic_vdota4_mask_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, <vscale x 4 x i8> %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4_mask_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, <vscale x 1 x i32> %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_mask_vv_nxv1i32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, mf2, tu, mu
@@ -94,15 +94,15 @@ define <vscale x 1 x i32>  @intrinsic_vdota4_mask_vv_nxv1i32_nxv1i32(<vscale x 1
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.nxv1i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
-    <vscale x 4 x i8> %2,
+    <vscale x 1 x i32> %1,
+    <vscale x 1 x i32> %2,
     <vscale x 1 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4_mask_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, <vscale x 8 x i8> %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4_mask_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_mask_vv_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m1, tu, mu
@@ -111,15 +111,15 @@ define <vscale x 2 x i32>  @intrinsic_vdota4_mask_vv_nxv2i32_nxv2i32(<vscale x 2
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.nxv2i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
-    <vscale x 8 x i8> %2,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
     <vscale x 2 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4_mask_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, <vscale x 16 x i8> %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4_mask_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_mask_vv_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m2, tu, mu
@@ -128,15 +128,15 @@ define <vscale x 4 x i32>  @intrinsic_vdota4_mask_vv_nxv4i32_nxv4i32(<vscale x 4
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.nxv4i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
-    <vscale x 16 x i8> %2,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
     <vscale x 4 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4_mask_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, <vscale x 32 x i8> %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4_mask_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_mask_vv_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m4, tu, mu
@@ -145,33 +145,33 @@ define <vscale x 8 x i32>  @intrinsic_vdota4_mask_vv_nxv8i32_nxv8i32(<vscale x 8
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.nxv8i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
-    <vscale x 32 x i8> %2,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
     <vscale x 8 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4_mask_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, <vscale x 64 x i8> %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4_mask_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_mask_vv_nxv16i32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vl8r.v v24, (a0)
+; CHECK-NEXT:    vl8re32.v v24, (a0)
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, mu
 ; CHECK-NEXT:    vdota4.vv v8, v16, v24, v0.t
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.nxv16i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
-    <vscale x 64 x i8> %2,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
     <vscale x 16 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 16 x i32> %a
 }
 
-define <vscale x 1 x i32>  @intrinsic_vdota4_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_vx_nxv1i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, tu, ma
@@ -180,14 +180,14 @@ define <vscale x 1 x i32>  @intrinsic_vdota4_vx_nxv1i32_i32(<vscale x 1 x i32> %
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4.nxv1i32.i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
+    <vscale x 1 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_vx_nxv2i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, tu, ma
@@ -196,14 +196,14 @@ define <vscale x 2 x i32>  @intrinsic_vdota4_vx_nxv2i32_i32(<vscale x 2 x i32> %
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4.nxv2i32.i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
+    <vscale x 2 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_vx_nxv4i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, tu, ma
@@ -212,14 +212,14 @@ define <vscale x 4 x i32>  @intrinsic_vdota4_vx_nxv4i32_i32(<vscale x 4 x i32> %
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4.nxv4i32.i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
+    <vscale x 4 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_vx_nxv8i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, ma
@@ -228,14 +228,14 @@ define <vscale x 8 x i32>  @intrinsic_vdota4_vx_nxv8i32_i32(<vscale x 8 x i32> %
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4.nxv8i32.i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
+    <vscale x 8 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_vx_nxv16i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, ma
@@ -244,14 +244,14 @@ define <vscale x 16 x i32>  @intrinsic_vdota4_vx_nxv16i32_i32(<vscale x 16 x i32
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4.nxv16i32.i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
+    <vscale x 16 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 16 x i32> %a
 }
 
-define <vscale x 1 x i32>  @intrinsic_vdota4_mask_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, i32 %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4_mask_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, i32 %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_mask_vx_nxv1i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, tu, mu
@@ -260,7 +260,7 @@ define <vscale x 1 x i32>  @intrinsic_vdota4_mask_vx_nxv1i32_i32(<vscale x 1 x i
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4.mask.nxv1i32.i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
+    <vscale x 1 x i32> %1,
     i32 %2,
     <vscale x 1 x i1> %m,
     iXLen %3, iXLen 0)
@@ -268,7 +268,7 @@ entry:
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4_mask_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, i32 %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4_mask_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, i32 %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_mask_vx_nxv2i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, tu, mu
@@ -277,7 +277,7 @@ define <vscale x 2 x i32>  @intrinsic_vdota4_mask_vx_nxv2i32_i32(<vscale x 2 x i
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4.mask.nxv2i32.i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
+    <vscale x 2 x i32> %1,
     i32 %2,
     <vscale x 2 x i1> %m,
     iXLen %3, iXLen 0)
@@ -285,7 +285,7 @@ entry:
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4_mask_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, i32 %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4_mask_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, i32 %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_mask_vx_nxv4i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, tu, mu
@@ -294,7 +294,7 @@ define <vscale x 4 x i32>  @intrinsic_vdota4_mask_vx_nxv4i32_i32(<vscale x 4 x i
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4.mask.nxv4i32.i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
+    <vscale x 4 x i32> %1,
     i32 %2,
     <vscale x 4 x i1> %m,
     iXLen %3, iXLen 0)
@@ -302,7 +302,7 @@ entry:
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4_mask_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, i32 %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4_mask_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, i32 %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_mask_vx_nxv8i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, mu
@@ -311,7 +311,7 @@ define <vscale x 8 x i32>  @intrinsic_vdota4_mask_vx_nxv8i32_i32(<vscale x 8 x i
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4.mask.nxv8i32.i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
+    <vscale x 8 x i32> %1,
     i32 %2,
     <vscale x 8 x i1> %m,
     iXLen %3, iXLen 0)
@@ -319,7 +319,7 @@ entry:
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4_mask_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, i32 %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4_mask_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, i32 %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4_mask_vx_nxv16i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, mu
@@ -328,7 +328,7 @@ define <vscale x 16 x i32>  @intrinsic_vdota4_mask_vx_nxv16i32_i32(<vscale x 16 
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4.mask.nxv16i32.i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
+    <vscale x 16 x i32> %1,
     i32 %2,
     <vscale x 16 x i1> %m,
     iXLen %3, iXLen 0)

--- a/llvm/test/CodeGen/RISCV/rvv/vdota4su.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vdota4su.ll
@@ -4,7 +4,7 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+zve64x,+experimental-zvdot4a8i \
 ; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK
 
-define <vscale x 1 x i32>  @intrinsic_vdota4su_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, <vscale x 4 x i8> %2, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4su_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, <vscale x 1 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_vv_nxv1i32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, mf2, tu, ma
@@ -13,14 +13,14 @@ define <vscale x 1 x i32>  @intrinsic_vdota4su_vv_nxv1i32_nxv1i32(<vscale x 1 x 
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.nxv1i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
-    <vscale x 4 x i8> %2,
+    <vscale x 1 x i32> %1,
+    <vscale x 1 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4su_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, <vscale x 8 x i8> %2, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4su_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_vv_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m1, tu, ma
@@ -29,14 +29,14 @@ define <vscale x 2 x i32>  @intrinsic_vdota4su_vv_nxv2i32_nxv2i32(<vscale x 2 x 
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.nxv2i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
-    <vscale x 8 x i8> %2,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4su_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, <vscale x 16 x i8> %2, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4su_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_vv_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m2, tu, ma
@@ -45,14 +45,14 @@ define <vscale x 4 x i32>  @intrinsic_vdota4su_vv_nxv4i32_nxv4i32(<vscale x 4 x 
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.nxv4i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
-    <vscale x 16 x i8> %2,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4su_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, <vscale x 32 x i8> %2, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4su_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_vv_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m4, tu, ma
@@ -61,31 +61,31 @@ define <vscale x 8 x i32>  @intrinsic_vdota4su_vv_nxv8i32_nxv8i32(<vscale x 8 x 
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.nxv8i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
-    <vscale x 32 x i8> %2,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4su_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, <vscale x 64 x i8> %2, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4su_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_vv_nxv16i32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vl8r.v v24, (a0)
+; CHECK-NEXT:    vl8re32.v v24, (a0)
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, ma
 ; CHECK-NEXT:    vdota4su.vv v8, v16, v24
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.nxv16i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
-    <vscale x 64 x i8> %2,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 16 x i32> %a
 }
 
-define <vscale x 1 x i32>  @intrinsic_vdota4su_mask_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, <vscale x 4 x i8> %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4su_mask_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, <vscale x 1 x i32> %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_mask_vv_nxv1i32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, mf2, tu, mu
@@ -94,15 +94,15 @@ define <vscale x 1 x i32>  @intrinsic_vdota4su_mask_vv_nxv1i32_nxv1i32(<vscale x
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.nxv1i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
-    <vscale x 4 x i8> %2,
+    <vscale x 1 x i32> %1,
+    <vscale x 1 x i32> %2,
     <vscale x 1 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4su_mask_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, <vscale x 8 x i8> %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4su_mask_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_mask_vv_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m1, tu, mu
@@ -111,15 +111,15 @@ define <vscale x 2 x i32>  @intrinsic_vdota4su_mask_vv_nxv2i32_nxv2i32(<vscale x
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.nxv2i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
-    <vscale x 8 x i8> %2,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
     <vscale x 2 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4su_mask_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, <vscale x 16 x i8> %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4su_mask_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_mask_vv_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m2, tu, mu
@@ -128,15 +128,15 @@ define <vscale x 4 x i32>  @intrinsic_vdota4su_mask_vv_nxv4i32_nxv4i32(<vscale x
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.nxv4i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
-    <vscale x 16 x i8> %2,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
     <vscale x 4 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4su_mask_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, <vscale x 32 x i8> %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4su_mask_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_mask_vv_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m4, tu, mu
@@ -145,33 +145,33 @@ define <vscale x 8 x i32>  @intrinsic_vdota4su_mask_vv_nxv8i32_nxv8i32(<vscale x
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.nxv8i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
-    <vscale x 32 x i8> %2,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
     <vscale x 8 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4su_mask_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, <vscale x 64 x i8> %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4su_mask_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_mask_vv_nxv16i32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vl8r.v v24, (a0)
+; CHECK-NEXT:    vl8re32.v v24, (a0)
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, mu
 ; CHECK-NEXT:    vdota4su.vv v8, v16, v24, v0.t
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.nxv16i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
-    <vscale x 64 x i8> %2,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
     <vscale x 16 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 16 x i32> %a
 }
 
-define <vscale x 1 x i32>  @intrinsic_vdota4su_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4su_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_vx_nxv1i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, tu, ma
@@ -180,14 +180,14 @@ define <vscale x 1 x i32>  @intrinsic_vdota4su_vx_nxv1i32_i32(<vscale x 1 x i32>
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4su.nxv1i32.i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
+    <vscale x 1 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4su_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4su_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_vx_nxv2i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, tu, ma
@@ -196,14 +196,14 @@ define <vscale x 2 x i32>  @intrinsic_vdota4su_vx_nxv2i32_i32(<vscale x 2 x i32>
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4su.nxv2i32.i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
+    <vscale x 2 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4su_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4su_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_vx_nxv4i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, tu, ma
@@ -212,14 +212,14 @@ define <vscale x 4 x i32>  @intrinsic_vdota4su_vx_nxv4i32_i32(<vscale x 4 x i32>
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4su.nxv4i32.i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
+    <vscale x 4 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4su_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4su_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_vx_nxv8i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, ma
@@ -228,14 +228,14 @@ define <vscale x 8 x i32>  @intrinsic_vdota4su_vx_nxv8i32_i32(<vscale x 8 x i32>
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4su.nxv8i32.i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
+    <vscale x 8 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4su_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4su_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_vx_nxv16i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, ma
@@ -244,14 +244,14 @@ define <vscale x 16 x i32>  @intrinsic_vdota4su_vx_nxv16i32_i32(<vscale x 16 x i
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4su.nxv16i32.i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
+    <vscale x 16 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 16 x i32> %a
 }
 
-define <vscale x 1 x i32>  @intrinsic_vdota4su_mask_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, i32 %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4su_mask_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, i32 %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_mask_vx_nxv1i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, tu, mu
@@ -260,7 +260,7 @@ define <vscale x 1 x i32>  @intrinsic_vdota4su_mask_vx_nxv1i32_i32(<vscale x 1 x
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4su.mask.nxv1i32.i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
+    <vscale x 1 x i32> %1,
     i32 %2,
     <vscale x 1 x i1> %m,
     iXLen %3, iXLen 0)
@@ -268,7 +268,7 @@ entry:
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4su_mask_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, i32 %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4su_mask_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, i32 %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_mask_vx_nxv2i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, tu, mu
@@ -277,7 +277,7 @@ define <vscale x 2 x i32>  @intrinsic_vdota4su_mask_vx_nxv2i32_i32(<vscale x 2 x
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4su.mask.nxv2i32.i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
+    <vscale x 2 x i32> %1,
     i32 %2,
     <vscale x 2 x i1> %m,
     iXLen %3, iXLen 0)
@@ -285,7 +285,7 @@ entry:
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4su_mask_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, i32 %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4su_mask_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, i32 %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_mask_vx_nxv4i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, tu, mu
@@ -294,7 +294,7 @@ define <vscale x 4 x i32>  @intrinsic_vdota4su_mask_vx_nxv4i32_i32(<vscale x 4 x
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4su.mask.nxv4i32.i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
+    <vscale x 4 x i32> %1,
     i32 %2,
     <vscale x 4 x i1> %m,
     iXLen %3, iXLen 0)
@@ -302,7 +302,7 @@ entry:
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4su_mask_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, i32 %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4su_mask_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, i32 %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_mask_vx_nxv8i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, mu
@@ -311,7 +311,7 @@ define <vscale x 8 x i32>  @intrinsic_vdota4su_mask_vx_nxv8i32_i32(<vscale x 8 x
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4su.mask.nxv8i32.i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
+    <vscale x 8 x i32> %1,
     i32 %2,
     <vscale x 8 x i1> %m,
     iXLen %3, iXLen 0)
@@ -319,7 +319,7 @@ entry:
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4su_mask_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, i32 %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4su_mask_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, i32 %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4su_mask_vx_nxv16i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, mu
@@ -328,7 +328,7 @@ define <vscale x 16 x i32>  @intrinsic_vdota4su_mask_vx_nxv16i32_i32(<vscale x 1
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4su.mask.nxv16i32.i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
+    <vscale x 16 x i32> %1,
     i32 %2,
     <vscale x 16 x i1> %m,
     iXLen %3, iXLen 0)

--- a/llvm/test/CodeGen/RISCV/rvv/vdota4u.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vdota4u.ll
@@ -4,7 +4,7 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+zve64x,+experimental-zvdot4a8i \
 ; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK
 
-define <vscale x 1 x i32>  @intrinsic_vdota4u_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, <vscale x 4 x i8> %2, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4u_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, <vscale x 1 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_vv_nxv1i32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, mf2, tu, ma
@@ -13,14 +13,14 @@ define <vscale x 1 x i32>  @intrinsic_vdota4u_vv_nxv1i32_nxv1i32(<vscale x 1 x i
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.nxv1i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
-    <vscale x 4 x i8> %2,
+    <vscale x 1 x i32> %1,
+    <vscale x 1 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4u_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, <vscale x 8 x i8> %2, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4u_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_vv_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m1, tu, ma
@@ -29,14 +29,14 @@ define <vscale x 2 x i32>  @intrinsic_vdota4u_vv_nxv2i32_nxv2i32(<vscale x 2 x i
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.nxv2i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
-    <vscale x 8 x i8> %2,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4u_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, <vscale x 16 x i8> %2, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4u_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_vv_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m2, tu, ma
@@ -45,14 +45,14 @@ define <vscale x 4 x i32>  @intrinsic_vdota4u_vv_nxv4i32_nxv4i32(<vscale x 4 x i
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.nxv4i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
-    <vscale x 16 x i8> %2,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4u_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, <vscale x 32 x i8> %2, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4u_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_vv_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m4, tu, ma
@@ -61,31 +61,31 @@ define <vscale x 8 x i32>  @intrinsic_vdota4u_vv_nxv8i32_nxv8i32(<vscale x 8 x i
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.nxv8i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
-    <vscale x 32 x i8> %2,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4u_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, <vscale x 64 x i8> %2, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4u_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_vv_nxv16i32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vl8r.v v24, (a0)
+; CHECK-NEXT:    vl8re32.v v24, (a0)
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, ma
 ; CHECK-NEXT:    vdota4u.vv v8, v16, v24
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.nxv16i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
-    <vscale x 64 x i8> %2,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 16 x i32> %a
 }
 
-define <vscale x 1 x i32>  @intrinsic_vdota4u_mask_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, <vscale x 4 x i8> %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4u_mask_vv_nxv1i32_nxv1i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, <vscale x 1 x i32> %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_mask_vv_nxv1i32_nxv1i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, mf2, tu, mu
@@ -94,15 +94,15 @@ define <vscale x 1 x i32>  @intrinsic_vdota4u_mask_vv_nxv1i32_nxv1i32(<vscale x 
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.nxv1i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
-    <vscale x 4 x i8> %2,
+    <vscale x 1 x i32> %1,
+    <vscale x 1 x i32> %2,
     <vscale x 1 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4u_mask_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, <vscale x 8 x i8> %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4u_mask_vv_nxv2i32_nxv2i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, <vscale x 2 x i32> %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_mask_vv_nxv2i32_nxv2i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m1, tu, mu
@@ -111,15 +111,15 @@ define <vscale x 2 x i32>  @intrinsic_vdota4u_mask_vv_nxv2i32_nxv2i32(<vscale x 
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.nxv2i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
-    <vscale x 8 x i8> %2,
+    <vscale x 2 x i32> %1,
+    <vscale x 2 x i32> %2,
     <vscale x 2 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4u_mask_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, <vscale x 16 x i8> %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4u_mask_vv_nxv4i32_nxv4i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, <vscale x 4 x i32> %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_mask_vv_nxv4i32_nxv4i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m2, tu, mu
@@ -128,15 +128,15 @@ define <vscale x 4 x i32>  @intrinsic_vdota4u_mask_vv_nxv4i32_nxv4i32(<vscale x 
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.nxv4i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
-    <vscale x 16 x i8> %2,
+    <vscale x 4 x i32> %1,
+    <vscale x 4 x i32> %2,
     <vscale x 4 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4u_mask_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, <vscale x 32 x i8> %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4u_mask_vv_nxv8i32_nxv8i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, <vscale x 8 x i32> %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_mask_vv_nxv8i32_nxv8i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a0, e32, m4, tu, mu
@@ -145,33 +145,33 @@ define <vscale x 8 x i32>  @intrinsic_vdota4u_mask_vv_nxv8i32_nxv8i32(<vscale x 
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.nxv8i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
-    <vscale x 32 x i8> %2,
+    <vscale x 8 x i32> %1,
+    <vscale x 8 x i32> %2,
     <vscale x 8 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4u_mask_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, <vscale x 64 x i8> %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4u_mask_vv_nxv16i32_nxv16i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, <vscale x 16 x i32> %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_mask_vv_nxv16i32_nxv16i32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vl8r.v v24, (a0)
+; CHECK-NEXT:    vl8re32.v v24, (a0)
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, mu
 ; CHECK-NEXT:    vdota4u.vv v8, v16, v24, v0.t
 ; CHECK-NEXT:    ret
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.nxv16i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
-    <vscale x 64 x i8> %2,
+    <vscale x 16 x i32> %1,
+    <vscale x 16 x i32> %2,
     <vscale x 16 x i1> %m,
     iXLen %3, iXLen 0)
 
   ret <vscale x 16 x i32> %a
 }
 
-define <vscale x 1 x i32>  @intrinsic_vdota4u_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4u_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_vx_nxv1i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, tu, ma
@@ -180,14 +180,14 @@ define <vscale x 1 x i32>  @intrinsic_vdota4u_vx_nxv1i32_i32(<vscale x 1 x i32> 
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4u.nxv1i32.i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
+    <vscale x 1 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4u_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4u_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_vx_nxv2i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, tu, ma
@@ -196,14 +196,14 @@ define <vscale x 2 x i32>  @intrinsic_vdota4u_vx_nxv2i32_i32(<vscale x 2 x i32> 
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4u.nxv2i32.i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
+    <vscale x 2 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4u_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4u_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_vx_nxv4i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, tu, ma
@@ -212,14 +212,14 @@ define <vscale x 4 x i32>  @intrinsic_vdota4u_vx_nxv4i32_i32(<vscale x 4 x i32> 
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4u.nxv4i32.i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
+    <vscale x 4 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4u_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4u_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_vx_nxv8i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, ma
@@ -228,14 +228,14 @@ define <vscale x 8 x i32>  @intrinsic_vdota4u_vx_nxv8i32_i32(<vscale x 8 x i32> 
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4u.nxv8i32.i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
+    <vscale x 8 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4u_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4u_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_vx_nxv16i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, ma
@@ -244,14 +244,14 @@ define <vscale x 16 x i32>  @intrinsic_vdota4u_vx_nxv16i32_i32(<vscale x 16 x i3
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4u.nxv16i32.i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
+    <vscale x 16 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 16 x i32> %a
 }
 
-define <vscale x 1 x i32>  @intrinsic_vdota4u_mask_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, i32 %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4u_mask_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, i32 %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_mask_vx_nxv1i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, tu, mu
@@ -260,7 +260,7 @@ define <vscale x 1 x i32>  @intrinsic_vdota4u_mask_vx_nxv1i32_i32(<vscale x 1 x 
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4u.mask.nxv1i32.i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
+    <vscale x 1 x i32> %1,
     i32 %2,
     <vscale x 1 x i1> %m,
     iXLen %3, iXLen 0)
@@ -268,7 +268,7 @@ entry:
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4u_mask_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, i32 %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4u_mask_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, i32 %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_mask_vx_nxv2i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, tu, mu
@@ -277,7 +277,7 @@ define <vscale x 2 x i32>  @intrinsic_vdota4u_mask_vx_nxv2i32_i32(<vscale x 2 x 
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4u.mask.nxv2i32.i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
+    <vscale x 2 x i32> %1,
     i32 %2,
     <vscale x 2 x i1> %m,
     iXLen %3, iXLen 0)
@@ -285,7 +285,7 @@ entry:
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4u_mask_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, i32 %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4u_mask_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, i32 %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_mask_vx_nxv4i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, tu, mu
@@ -294,7 +294,7 @@ define <vscale x 4 x i32>  @intrinsic_vdota4u_mask_vx_nxv4i32_i32(<vscale x 4 x 
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4u.mask.nxv4i32.i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
+    <vscale x 4 x i32> %1,
     i32 %2,
     <vscale x 4 x i1> %m,
     iXLen %3, iXLen 0)
@@ -302,7 +302,7 @@ entry:
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4u_mask_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, i32 %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4u_mask_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, i32 %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_mask_vx_nxv8i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, mu
@@ -311,7 +311,7 @@ define <vscale x 8 x i32>  @intrinsic_vdota4u_mask_vx_nxv8i32_i32(<vscale x 8 x 
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4u.mask.nxv8i32.i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
+    <vscale x 8 x i32> %1,
     i32 %2,
     <vscale x 8 x i1> %m,
     iXLen %3, iXLen 0)
@@ -319,7 +319,7 @@ entry:
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4u_mask_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, i32 %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4u_mask_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, i32 %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4u_mask_vx_nxv16i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, mu
@@ -328,7 +328,7 @@ define <vscale x 16 x i32>  @intrinsic_vdota4u_mask_vx_nxv16i32_i32(<vscale x 16
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4u.mask.nxv16i32.i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
+    <vscale x 16 x i32> %1,
     i32 %2,
     <vscale x 16 x i1> %m,
     iXLen %3, iXLen 0)

--- a/llvm/test/CodeGen/RISCV/rvv/vdota4us.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vdota4us.ll
@@ -4,7 +4,7 @@
 ; RUN: sed 's/iXLen/i64/g' %s | llc -mtriple=riscv64 -mattr=+zve64x,+experimental-zvdot4a8i \
 ; RUN:   -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK
 
-define <vscale x 1 x i32>  @intrinsic_vdota4us_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4us_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4us_vx_nxv1i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, tu, ma
@@ -13,14 +13,14 @@ define <vscale x 1 x i32>  @intrinsic_vdota4us_vx_nxv1i32_i32(<vscale x 1 x i32>
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4us.nxv1i32.i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
+    <vscale x 1 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4us_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4us_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4us_vx_nxv2i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, tu, ma
@@ -29,14 +29,14 @@ define <vscale x 2 x i32>  @intrinsic_vdota4us_vx_nxv2i32_i32(<vscale x 2 x i32>
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4us.nxv2i32.i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
+    <vscale x 2 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4us_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4us_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4us_vx_nxv4i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, tu, ma
@@ -45,14 +45,14 @@ define <vscale x 4 x i32>  @intrinsic_vdota4us_vx_nxv4i32_i32(<vscale x 4 x i32>
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4us.nxv4i32.i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
+    <vscale x 4 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4us_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4us_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4us_vx_nxv8i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, ma
@@ -61,14 +61,14 @@ define <vscale x 8 x i32>  @intrinsic_vdota4us_vx_nxv8i32_i32(<vscale x 8 x i32>
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4us.nxv8i32.i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
+    <vscale x 8 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4us_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, i32 %2, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4us_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, i32 %2, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4us_vx_nxv16i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, ma
@@ -77,14 +77,14 @@ define <vscale x 16 x i32>  @intrinsic_vdota4us_vx_nxv16i32_i32(<vscale x 16 x i
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4us.nxv16i32.i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
+    <vscale x 16 x i32> %1,
     i32 %2,
     iXLen %3, iXLen 0)
 
   ret <vscale x 16 x i32> %a
 }
 
-define <vscale x 1 x i32>  @intrinsic_vdota4us_mask_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 4 x i8> %1, i32 %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
+define <vscale x 1 x i32>  @intrinsic_vdota4us_mask_vx_nxv1i32_i32(<vscale x 1 x i32> %0, <vscale x 1 x i32> %1, i32 %2, <vscale x 1 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4us_mask_vx_nxv1i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, mf2, tu, mu
@@ -93,7 +93,7 @@ define <vscale x 1 x i32>  @intrinsic_vdota4us_mask_vx_nxv1i32_i32(<vscale x 1 x
 entry:
   %a = call <vscale x 1 x i32> @llvm.riscv.vdota4us.mask.nxv1i32.i32(
     <vscale x 1 x i32> %0,
-    <vscale x 4 x i8> %1,
+    <vscale x 1 x i32> %1,
     i32 %2,
     <vscale x 1 x i1> %m,
     iXLen %3, iXLen 0)
@@ -101,7 +101,7 @@ entry:
   ret <vscale x 1 x i32> %a
 }
 
-define <vscale x 2 x i32>  @intrinsic_vdota4us_mask_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 8 x i8> %1, i32 %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
+define <vscale x 2 x i32>  @intrinsic_vdota4us_mask_vx_nxv2i32_i32(<vscale x 2 x i32> %0, <vscale x 2 x i32> %1, i32 %2, <vscale x 2 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4us_mask_vx_nxv2i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, tu, mu
@@ -110,7 +110,7 @@ define <vscale x 2 x i32>  @intrinsic_vdota4us_mask_vx_nxv2i32_i32(<vscale x 2 x
 entry:
   %a = call <vscale x 2 x i32> @llvm.riscv.vdota4us.mask.nxv2i32.i32(
     <vscale x 2 x i32> %0,
-    <vscale x 8 x i8> %1,
+    <vscale x 2 x i32> %1,
     i32 %2,
     <vscale x 2 x i1> %m,
     iXLen %3, iXLen 0)
@@ -118,7 +118,7 @@ entry:
   ret <vscale x 2 x i32> %a
 }
 
-define <vscale x 4 x i32>  @intrinsic_vdota4us_mask_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 16 x i8> %1, i32 %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
+define <vscale x 4 x i32>  @intrinsic_vdota4us_mask_vx_nxv4i32_i32(<vscale x 4 x i32> %0, <vscale x 4 x i32> %1, i32 %2, <vscale x 4 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4us_mask_vx_nxv4i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m2, tu, mu
@@ -127,7 +127,7 @@ define <vscale x 4 x i32>  @intrinsic_vdota4us_mask_vx_nxv4i32_i32(<vscale x 4 x
 entry:
   %a = call <vscale x 4 x i32> @llvm.riscv.vdota4us.mask.nxv4i32.i32(
     <vscale x 4 x i32> %0,
-    <vscale x 16 x i8> %1,
+    <vscale x 4 x i32> %1,
     i32 %2,
     <vscale x 4 x i1> %m,
     iXLen %3, iXLen 0)
@@ -135,7 +135,7 @@ entry:
   ret <vscale x 4 x i32> %a
 }
 
-define <vscale x 8 x i32>  @intrinsic_vdota4us_mask_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 32 x i8> %1, i32 %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
+define <vscale x 8 x i32>  @intrinsic_vdota4us_mask_vx_nxv8i32_i32(<vscale x 8 x i32> %0, <vscale x 8 x i32> %1, i32 %2, <vscale x 8 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4us_mask_vx_nxv8i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m4, tu, mu
@@ -144,7 +144,7 @@ define <vscale x 8 x i32>  @intrinsic_vdota4us_mask_vx_nxv8i32_i32(<vscale x 8 x
 entry:
   %a = call <vscale x 8 x i32> @llvm.riscv.vdota4us.mask.nxv8i32.i32(
     <vscale x 8 x i32> %0,
-    <vscale x 32 x i8> %1,
+    <vscale x 8 x i32> %1,
     i32 %2,
     <vscale x 8 x i1> %m,
     iXLen %3, iXLen 0)
@@ -152,7 +152,7 @@ entry:
   ret <vscale x 8 x i32> %a
 }
 
-define <vscale x 16 x i32>  @intrinsic_vdota4us_mask_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 64 x i8> %1, i32 %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
+define <vscale x 16 x i32>  @intrinsic_vdota4us_mask_vx_nxv16i32_i32(<vscale x 16 x i32> %0, <vscale x 16 x i32> %1, i32 %2, <vscale x 16 x i1> %m, iXLen %3) nounwind {
 ; CHECK-LABEL: intrinsic_vdota4us_mask_vx_nxv16i32_i32:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, tu, mu
@@ -161,7 +161,7 @@ define <vscale x 16 x i32>  @intrinsic_vdota4us_mask_vx_nxv16i32_i32(<vscale x 1
 entry:
   %a = call <vscale x 16 x i32> @llvm.riscv.vdota4us.mask.nxv16i32.i32(
     <vscale x 16 x i32> %0,
-    <vscale x 64 x i8> %1,
+    <vscale x 16 x i32> %1,
     i32 %2,
     <vscale x 16 x i1> %m,
     iXLen %3, iXLen 0)


### PR DESCRIPTION
intrinsic spec PR: https://github.com/riscv-non-isa/rvv-intrinsic-doc/pull/422
