### PR TITLE
[CIR] builtin_signbit(x) implementation

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1822,7 +1822,14 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__scoped_atomic_thread_fence:
   case Builtin::BI__builtin_signbit:
   case Builtin::BI__builtin_signbitf:
-  case Builtin::BI__builtin_signbitl:
+  case Builtin::BI__builtin_signbitl: {
+    CIRGenFunction::CIRGenFPOptionsRAII FPOptsRAII(*this, e);
+    mlir::Location loc = getLoc(e->getBeginLoc());
+    mlir::Value v = emitScalarExpr(e->getArg(0));
+    mlir::Value signbit = emitSignBit(loc, *this, v);
+    return RValue::get(
+        builder.createBoolToInt(signbit, convertType(e->getType())));
+  }
   case Builtin::BI__warn_memset_zero_len:
   case Builtin::BI__annotation:
   case Builtin::BI__builtin_annotation:

--- a/clang/test/CIR/CodeGenBuiltins/builtin-signbit.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-signbit.cpp
@@ -1,0 +1,51 @@
+// RUN: %clang_cc1 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -fclangir -emit-llvm %s -o %t.cir.ll
+// RUN: FileCheck --input-file=%t.cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+int test_signbit_float(float x) {
+  return __builtin_signbit(x);
+}
+// CIR: cir.signbit %{{.*}} : !cir.float -> !cir.bool
+// LLVM: bitcast float {{.*}} to i32
+// LLVM: icmp slt i32 {{.*}}, 0
+// LLVM: zext i1 {{.*}} to i32
+// LLVM: ret i32
+
+int test_signbit_double(double x) {
+  return __builtin_signbit(x);
+}
+// CIR: cir.signbit %{{.*}} : !cir.double -> !cir.bool
+// LLVM: bitcast double {{.*}} to i64
+// LLVM: icmp slt i64 {{.*}}, 0
+// LLVM: zext i1 {{.*}} to i32
+// LLVM: ret i32
+
+int test_signbit_long_double(long double x) {
+  return __builtin_signbit(x);
+}
+// CIR: cir.signbit %{{.*}} : !cir.long_double<!cir.f80> -> !cir.bool
+// LLVM: bitcast x86_fp80 {{.*}} to i80
+// LLVM: icmp slt i80 {{.*}}, 0
+// LLVM: zext i1 {{.*}} to i32
+// LLVM: ret i32
+
+int test_signbitf(float x) {
+  return __builtin_signbitf(x);
+}
+// CIR: cir.signbit %{{.*}} : !cir.float -> !cir.bool
+// LLVM: bitcast float {{.*}} to i32
+// LLVM: icmp slt i32 {{.*}}, 0
+// LLVM: zext i1 {{.*}} to i32
+// LLVM: ret i32
+
+int test_signbitl(long double x) {
+  return __builtin_signbitl(x);
+}
+// CIR: cir.signbit %{{.*}} : !cir.long_double<!cir.f80> -> !cir.bool
+// LLVM: bitcast x86_fp80 {{.*}} to i80
+// LLVM: icmp slt i80 {{.*}}, 0
+// LLVM: zext i1 {{.*}} to i32
+// LLVM: ret i32

--- a/clang/test/CIR/CodeGenBuiltins/builtin-signbit.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-signbit.cpp
@@ -1,8 +1,8 @@
-// RUN: %clang_cc1 -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
-// RUN: %clang_cc1 -fclangir -emit-llvm %s -o %t.cir.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t.cir.ll
 // RUN: FileCheck --input-file=%t.cir.ll %s -check-prefix=LLVM
-// RUN: %clang_cc1 -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
 
 int test_signbit_float(float x) {


### PR DESCRIPTION
`cir.signbit` was not included in `CIROps.td`. `cir.signbit` is in the specification (https://llvm.github.io/clangir/Dialect/ops.html#cirsignbit-cirsignbitop), so I added it.