### PR TITLE
Fix AffineOps.md "more than 1 dialect" build error

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/Affine/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_mlir_dialect(AffineOps affine)
-add_mlir_doc(AffineOps AffineOps Dialects/ -gen-op-doc)
+add_mlir_doc(AffineOps AffineOps Dialects/ -gen-op-doc -dialect=affine)
 
 add_mlir_interface(AffineMemoryOpInterfaces)
 add_dependencies(MLIRAffineOpsIncGen MLIRAffineMemoryOpInterfacesIncGen)


### PR DESCRIPTION
AffineOps.md fails to build with the following:
"when more than 1 dialect is present, one must be selected via '-dialect'"

This commit adds the missing -dialect=affine.

Signed-off-by: Thomas Preud'homme <thomas.preudhomme@arm.com>
