### PR TITLE
[mlir][test] Reject TestWithBoundsOp with mismatched attribute width in verifier

### DIFF
--- a/mlir/test/Interfaces/InferIntRangeInterface/infer-int-range-test-ops-invalid.mlir
+++ b/mlir/test/Interfaces/InferIntRangeInterface/infer-int-range-test-ops-invalid.mlir
@@ -1,0 +1,12 @@
+// RUN: mlir-opt -split-input-file -verify-diagnostics %s
+
+// Verify that test.with_bounds with mismatched attribute width (e.g., i64
+// bounds for an i8 result) is rejected as invalid IR.
+// See: https://github.com/llvm/llvm-project/issues/120882
+func.func @with_bounds_mismatched_width() -> i8 {
+  // expected-error@+1 {{'test.with_bounds' op bound attribute width (64) does not match result type width (8)}}
+  %0 = test.with_bounds { umin = 10 : i64, umax = 15 : i64,
+                           smin = 10 : i64, smax = 15 : i64 } : i8
+  %1 = test.reflect_bounds %0 : i8
+  return %1 : i8
+}

--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -876,6 +876,20 @@ LogicalResult TestVerifiersOp::verifyRegions() {
 // TestWithBoundsOp
 //===----------------------------------------------------------------------===//
 
+LogicalResult TestWithBoundsOp::verify() {
+  Type type = getElementTypeOrSelf(getResult().getType());
+  unsigned expectedWidth = 0;
+  if (type.isIndex())
+    expectedWidth = IndexType::kInternalStorageBitWidth;
+  else if (auto intTy = llvm::dyn_cast<IntegerType>(type))
+    expectedWidth = intTy.getWidth();
+  if (expectedWidth != 0 && getUmin().getBitWidth() != expectedWidth)
+    return emitOpError("bound attribute width (")
+           << getUmin().getBitWidth() << ") does not match result type width ("
+           << expectedWidth << ")";
+  return success();
+}
+
 void TestWithBoundsOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
                                          SetIntRangeFn setResultRanges) {
   setResultRanges(getResult(), {getUmin(), getUmax(), getSmin(), getSmax()});

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3173,6 +3173,7 @@ def InferIntRangeType : AnyTypeOf<[AnyInteger, Index, VectorOfNonZeroRankOf<[Any
 def TestWithBoundsOp : TEST_Op<"with_bounds",
                           [DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>,
                            NoMemoryEffect]> {
+  let hasVerifier = 1;
   let description = [{
     Creates a value with specified [min, max] range for integer range analysis.
 


### PR DESCRIPTION
Add a verifier to `TestWithBoundsOp` that rejects bounds attributes whose
bit width does not match the result type's storage width (e.g., `10 : i64`
for an `i8` result). This makes the mismatch invalid IR rather than silently
accepting it, preventing downstream crashes in consumers such as
`TestReflectBoundsOp::inferResultRanges` that assert on matching widths.

`inferResultRanges` is reverted to its original one-liner; the new
`verify()` method enforces the invariant at IR construction time.

A dedicated test file (`infer-int-range-test-ops-invalid.mlir`) uses
`-verify-diagnostics` to check the emitted error message.

Fixes #120882

Assisted-by: Claude Code