### PR TITLE
[libc] Fix GPU loader propagation to lit test infrastructure

### DIFF
--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -10,6 +10,11 @@ add_custom_target(libc-long-running-tests)
 add_custom_target(libc-unit-tests-build)
 add_custom_target(libc-hermetic-tests-build)
 
+# Resolve the GPU loader executable path for the lit site config.
+if(TARGET libc.utils.gpu.loader)
+  get_target_property(LIBC_GPU_LOADER_EXECUTABLE libc.utils.gpu.loader "EXECUTABLE")
+endif()
+
 # Configure the site config file for lit
 configure_lit_site_cfg(
   ${LIBC_SOURCE_DIR}/test/lit.site.cfg.py.in
@@ -23,6 +28,7 @@ configure_lit_site_cfg(
   "LLVM_LIBS_DIR"
   "LIBC_SOURCE_DIR"
   "LIBC_BUILD_DIR"
+  "LIBC_GPU_LOADER_EXECUTABLE"
 )
 
 add_lit_testsuite(check-libc-lit

--- a/libc/test/lit.site.cfg.py.in
+++ b/libc/test/lit.site.cfg.py.in
@@ -8,6 +8,11 @@ config.llvm_tools_dir = lit_config.substitute(path(r"@LLVM_TOOLS_DIR@"))
 config.libc_src_root = path(r"@LIBC_SOURCE_DIR@")
 config.libc_obj_root = path(r"@LIBC_BUILD_DIR@")
 config.libc_test_cmd = "@LIBC_TEST_CMD@"
+config.libc_gpu_loader = path(r"@LIBC_GPU_LOADER_EXECUTABLE@")
+
+# If running GPU tests and no explicit test command is set, use the GPU loader.
+if not config.libc_test_cmd and config.libc_gpu_loader:
+    config.libc_test_cmd = config.libc_gpu_loader + " @BINARY@"
 
 # Add libc's utils directory to the path so we can import the test format.
 site.addsitedir(os.path.join(config.libc_src_root, "utils"))


### PR DESCRIPTION
The lit-based test execution added in c776a52fa263 did not propagate the GPU loader executable to the lit site configuration. When building for GPU targets, the loader (amdhsa-loader, nvptx-loader, or a user-specified LIBC_GPU_LOADER_EXECUTABLE) was resolved into the libc.utils.gpu.loader target but never passed through to the generated lit.site.cfg.py.

Fix this by resolving the executable path from the libc.utils.gpu.loader target property and including it in configure_lit_site_cfg's PATHS list. In lit.site.cfg.py.in, if no explicit LIBC_TEST_CMD is set but a GPU loader is present, construct libc_test_cmd from the loader path, mirroring the logic in add_libc_hermetic() in LLVMLibCTestRules.cmake.

Tested:
 * GPU build with LIBC_GPU_LOADER_EXECUTABLE set to /bin/echo used to fail (tried to run the binary), now it works.
 * Native compiler check-libc-lit continues to work after this change.