### PR TITLE
[clang][bytecode] Add `PtrView` for non-tracking pointers

### DIFF
--- a/clang/lib/AST/ByteCode/EvaluationResult.cpp
+++ b/clang/lib/AST/ByteCode/EvaluationResult.cpp
@@ -27,14 +27,14 @@ static void DiagnoseUninitializedSubobject(InterpState &S, SourceLocation Loc,
 }
 
 static bool CheckFieldsInitialized(InterpState &S, SourceLocation Loc,
-                                   const Pointer &BasePtr, const Record *R);
+                                   PtrView BasePtr, const Record *R);
 
 static bool CheckArrayInitialized(InterpState &S, SourceLocation Loc,
-                                  const Pointer &BasePtr) {
+                                  PtrView BasePtr) {
   const Descriptor *BaseDesc = BasePtr.getFieldDesc();
   assert(BaseDesc->isArray());
-  size_t NumElems = BaseDesc->getNumElems();
 
+  size_t NumElems = BaseDesc->getNumElems();
   if (NumElems == 0)
     return true;
 
@@ -51,13 +51,13 @@ static bool CheckArrayInitialized(InterpState &S, SourceLocation Loc,
   if (ElemDesc->isRecord()) {
     const Record *R = ElemDesc->ElemRecord;
     for (size_t I = 0; I != NumElems; ++I) {
-      Pointer ElemPtr = BasePtr.atIndex(I).narrow();
+      PtrView ElemPtr = BasePtr.atIndex(I).narrow();
       Result &= CheckFieldsInitialized(S, Loc, ElemPtr, R);
     }
   } else {
     assert(ElemDesc->isArray());
     for (size_t I = 0; I != NumElems; ++I) {
-      Pointer ElemPtr = BasePtr.atIndex(I).narrow();
+      PtrView ElemPtr = BasePtr.atIndex(I).narrow();
       Result &= CheckArrayInitialized(S, Loc, ElemPtr);
     }
   }
@@ -66,12 +66,12 @@ static bool CheckArrayInitialized(InterpState &S, SourceLocation Loc,
 }
 
 static bool CheckFieldsInitialized(InterpState &S, SourceLocation Loc,
-                                   const Pointer &BasePtr, const Record *R) {
+                                   PtrView BasePtr, const Record *R) {
   assert(R);
   bool Result = true;
   // Check all fields of this record are initialized.
   for (const Record::Field &F : R->fields()) {
-    Pointer FieldPtr = BasePtr.atField(F.Offset);
+    PtrView FieldPtr = BasePtr.atField(F.Offset);
 
     // Don't check inactive union members.
     if (R->isUnion() && !FieldPtr.isActive())
@@ -96,7 +96,7 @@ static bool CheckFieldsInitialized(InterpState &S, SourceLocation Loc,
 
   // Check Fields in all bases
   for (auto [I, B] : llvm::enumerate(R->bases())) {
-    Pointer P = BasePtr.atField(B.Offset);
+    PtrView P = BasePtr.atField(B.Offset);
     if (!P.isInitialized()) {
       const Descriptor *Desc = BasePtr.getDeclDesc();
       if (const auto *CD = dyn_cast_if_present<CXXRecordDecl>(R->getDecl())) {
@@ -114,7 +114,6 @@ static bool CheckFieldsInitialized(InterpState &S, SourceLocation Loc,
   }
 
   // TODO: Virtual bases
-
   return Result;
 }
 
@@ -140,10 +139,10 @@ bool EvaluationResult::checkFullyInitialized(InterpState &S,
     InitLoc = E->getExprLoc();
 
   if (const Record *R = Ptr.getRecord())
-    return CheckFieldsInitialized(S, InitLoc, Ptr, R);
+    return CheckFieldsInitialized(S, InitLoc, Ptr.view(), R);
 
   if (isa_and_nonnull<ConstantArrayType>(Ptr.getType()->getAsArrayTypeUnsafe()))
-    return CheckArrayInitialized(S, InitLoc, Ptr);
+    return CheckArrayInitialized(S, InitLoc, Ptr.view());
 
   return true;
 }
@@ -157,17 +156,16 @@ static bool isOrHasPtr(const Descriptor *D) {
   return false;
 }
 
-static void collectBlocks(const Pointer &Ptr,
-                          llvm::SetVector<const Block *> &Blocks) {
+static void collectBlocks(PtrView Ptr, llvm::SetVector<const Block *> &Blocks) {
   auto isUsefulPtr = [](const Pointer &P) -> bool {
     return P.isLive() && P.isBlockPointer() && !P.isZero() && !P.isDummy() &&
            P.isDereferencable() && !P.isUnknownSizeArray() && !P.isOnePastEnd();
   };
 
-  if (!isUsefulPtr(Ptr))
+  if (!isUsefulPtr(Pointer(Ptr)))
     return;
 
-  Blocks.insert(Ptr.block());
+  Blocks.insert(Ptr.Pointee);
 
   const Descriptor *Desc = Ptr.getFieldDesc();
   if (!Desc)
@@ -178,24 +176,23 @@ static void collectBlocks(const Pointer &Ptr,
     for (const Record::Field &F : R->fields()) {
       if (!isOrHasPtr(F.Desc))
         continue;
-      Pointer FieldPtr = Ptr.atField(F.Offset);
-      assert(FieldPtr.block() == Ptr.block());
+      PtrView FieldPtr = Ptr.atField(F.Offset);
       collectBlocks(FieldPtr, Blocks);
     }
   } else if (Desc->isPrimitive() && Desc->getPrimType() == PT_Ptr) {
     Pointer Pointee = Ptr.deref<Pointer>();
     if (isUsefulPtr(Pointee) && !Blocks.contains(Pointee.block()))
-      collectBlocks(Pointee, Blocks);
+      collectBlocks(Pointee.view(), Blocks);
 
   } else if (Desc->isPrimitiveArray() && Desc->getPrimType() == PT_Ptr) {
     for (unsigned I = 0; I != Desc->getNumElems(); ++I) {
       Pointer ElemPointee = Ptr.elem<Pointer>(I);
       if (isUsefulPtr(ElemPointee) && !Blocks.contains(ElemPointee.block()))
-        collectBlocks(ElemPointee, Blocks);
+        collectBlocks(ElemPointee.view(), Blocks);
     }
   } else if (Desc->isCompositeArray() && isOrHasPtr(Desc->ElemDesc)) {
     for (unsigned I = 0; I != Desc->getNumElems(); ++I) {
-      Pointer ElemPtr = Ptr.atIndex(I).narrow();
+      PtrView ElemPtr = Ptr.atIndex(I).narrow();
       collectBlocks(ElemPtr, Blocks);
     }
   }
@@ -204,11 +201,13 @@ static void collectBlocks(const Pointer &Ptr,
 bool EvaluationResult::checkReturnValue(InterpState &S, const Context &Ctx,
                                         const Pointer &Ptr,
                                         const SourceInfo &Info) {
+  if (!Ptr.isBlockPointer())
+    return true;
   // Collect all blocks that this pointer (transitively) points to and
   // return false if any of them is a dynamic block.
   llvm::SetVector<const Block *> Blocks;
 
-  collectBlocks(Ptr, Blocks);
+  collectBlocks(Ptr.view(), Blocks);
 
   for (const Block *B : Blocks) {
     if (B->isDynamic()) {

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -515,8 +515,7 @@ bool CheckNull(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
   return false;
 }
 
-bool CheckRange(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
-                AccessKinds AK) {
+bool CheckRange(InterpState &S, CodePtr OpPC, PtrView Ptr, AccessKinds AK) {
   if (!Ptr.isOnePastEnd() && !Ptr.isZeroSizeArray())
     return true;
   if (S.getLangOpts().CPlusPlus) {
@@ -592,14 +591,14 @@ bool CheckConst(InterpState &S, CodePtr OpPC, const Pointer &Ptr) {
   return false;
 }
 
-bool CheckMutable(InterpState &S, CodePtr OpPC, const Pointer &Ptr) {
+bool CheckMutable(InterpState &S, CodePtr OpPC, PtrView Ptr) {
   assert(Ptr.isLive() && "Pointer is not live");
   if (!Ptr.isMutable())
     return true;
 
   // In C++14 onwards, it is permitted to read a mutable member whose
   // lifetime began within the evaluation.
-  if (S.getLangOpts().CPlusPlus14 && Ptr.block()->getEvalID() == S.EvalID)
+  if (S.getLangOpts().CPlusPlus14 && Ptr.getEvalID() == S.EvalID)
     return true;
 
   const SourceInfo &Loc = S.Current->getSource(OpPC);
@@ -1940,6 +1939,10 @@ bool CallVirt(InterpState &S, CodePtr OpPC, const Function *Func,
   size_t ArgSize = Func->getArgSize() + VarArgSize;
   size_t ThisOffset = ArgSize - (Func->hasRVO() ? primSize(PT_Ptr) : 0);
   Pointer &ThisPtr = S.Stk.peek<Pointer>(ThisOffset);
+
+  if (!ThisPtr.isBlockPointer())
+    return false;
+
   const FunctionDecl *Callee = Func->getDecl();
 
   const CXXRecordDecl *DynamicDecl = nullptr;
@@ -2098,12 +2101,12 @@ bool CallPtr(InterpState &S, CodePtr OpPC, uint32_t ArgSize,
   return Call(S, OpPC, F, VarArgSize);
 }
 
-static void startLifetimeRecurse(const Pointer &Ptr) {
+static void startLifetimeRecurse(PtrView Ptr) {
   if (const Record *R = Ptr.getRecord()) {
     Ptr.startLifetime();
 
     for (const Record::Field &Fi : R->fields()) {
-      Pointer FP = Ptr.atField(Fi.Offset);
+      PtrView FP = Ptr.atField(Fi.Offset);
       if (FP.getLifetime() != Lifetime::Started)
         startLifetimeRecurse(FP);
     }
@@ -2113,7 +2116,7 @@ static void startLifetimeRecurse(const Pointer &Ptr) {
   if (const Descriptor *FieldDesc = Ptr.getFieldDesc();
       FieldDesc->isCompositeArray()) {
     for (unsigned I = 0; I != FieldDesc->getNumElems(); ++I) {
-      Pointer EP = Ptr.atIndex(I).narrow();
+      PtrView EP = Ptr.atIndex(I).narrow();
       if (EP.getLifetime() != Lifetime::Started)
         startLifetimeRecurse(EP);
     }
@@ -2130,7 +2133,7 @@ bool StartThisLifetime(InterpState &S, CodePtr OpPC) {
   const auto &Ptr = S.Current->getThis();
   if (!Ptr.isBlockPointer())
     return false;
-  startLifetimeRecurse(Ptr);
+  startLifetimeRecurse(Ptr.view());
   return true;
 }
 
@@ -2147,7 +2150,7 @@ bool StartThisLifetime1(InterpState &S, CodePtr OpPC) {
 
 // FIXME: It might be better to the recursing as part of the generated code for
 // a destructor?
-static void setLifeStateRecurse(const Pointer &Ptr, Lifetime L) {
+static void setLifeStateRecurse(PtrView Ptr, Lifetime L) {
   if (const Record *R = Ptr.getRecord()) {
     Ptr.setLifeState(L);
     for (const Record::Field &Fi : R->fields())
@@ -2174,7 +2177,7 @@ bool EndLifetime(InterpState &S, CodePtr OpPC) {
   if (Ptr.isBlockPointer() && !CheckDummy(S, OpPC, Ptr.block(), AK_Destroy))
     return false;
 
-  setLifeStateRecurse(Ptr.narrow(), Lifetime::Ended);
+  setLifeStateRecurse(Ptr.view().narrow(), Lifetime::Ended);
   return true;
 }
 
@@ -2184,7 +2187,7 @@ bool EndLifetimePop(InterpState &S, CodePtr OpPC) {
   if (Ptr.isBlockPointer() && !CheckDummy(S, OpPC, Ptr.block(), AK_Destroy))
     return false;
 
-  setLifeStateRecurse(Ptr.narrow(), Lifetime::Ended);
+  setLifeStateRecurse(Ptr.view().narrow(), Lifetime::Ended);
   return true;
 }
 
@@ -2193,7 +2196,7 @@ bool MarkDestroyed(InterpState &S, CodePtr OpPC) {
   if (Ptr.isBlockPointer() && !CheckDummy(S, OpPC, Ptr.block(), AK_Destroy))
     return false;
 
-  setLifeStateRecurse(Ptr.narrow(), Lifetime::Destroyed);
+  setLifeStateRecurse(Ptr.view().narrow(), Lifetime::Destroyed);
   return true;
 }
 
@@ -2223,7 +2226,7 @@ bool CheckNewTypeMismatch(InterpState &S, CodePtr OpPC, const Expr *E,
   if (!CheckRange(S, OpPC, Ptr, AK_Construct))
     return false;
 
-  startLifetimeRecurse(Ptr);
+  startLifetimeRecurse(Ptr.view());
 
   // Similar to CheckStore(), but with the additional CheckTemporary() call and
   // the AccessKinds are different.
@@ -2238,8 +2241,8 @@ bool CheckNewTypeMismatch(InterpState &S, CodePtr OpPC, const Expr *E,
     return false;
 
   // CheckLifetime for this and all base pointers.
-  for (Pointer P = Ptr;;) {
-    if (!CheckLifetime(S, OpPC, P, AK_Construct))
+  for (PtrView P = Ptr.view();;) {
+    if (!CheckLifetime(S, OpPC, P.getLifetime(), P.Pointee, AK_Construct))
       return false;
 
     if (P.isRoot())

--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -1249,7 +1249,7 @@ inline bool CmpHelper<Pointer>(InterpState &S, CodePtr OpPC, CompareFn Fn) {
 
   // Diagnose comparisons between fields with different access specifiers,
   // comparisons between bases and bases+fields.
-  if (std::optional<std::pair<Pointer, Pointer>> Split =
+  if (std::optional<std::pair<PtrView, PtrView>> Split =
           Pointer::computeSplitPoint(LHS, RHS)) {
     const FieldDecl *LF = Split->first.getField();
     const FieldDecl *RF = Split->second.getField();

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -328,8 +328,8 @@ static bool interp__builtin_strcmp(InterpState &S, CodePtr OpPC,
 
     if (Steps >= Limit)
       break;
-    const Pointer &PA = A.atIndex(IndexA);
-    const Pointer &PB = B.atIndex(IndexB);
+    PtrView PA = A.view().atIndex(IndexA);
+    PtrView PB = B.view().atIndex(IndexB);
     if (!CheckRange(S, OpPC, PA, AK_Read) ||
         !CheckRange(S, OpPC, PB, AK_Read)) {
       return false;
@@ -404,7 +404,7 @@ static bool interp__builtin_strlen(InterpState &S, CodePtr OpPC,
 
   size_t Len = 0;
   for (size_t I = StrPtr.getIndex();; ++I, ++Len) {
-    const Pointer &ElemPtr = StrPtr.atIndex(I);
+    PtrView ElemPtr = StrPtr.view().atIndex(I);
 
     if (!CheckRange(S, OpPC, ElemPtr, AK_Read))
       return false;
@@ -6592,8 +6592,8 @@ bool SetThreeWayComparisonField(InterpState &S, CodePtr OpPC,
   assert(R->getNumFields() == 1);
 
   unsigned FieldOffset = R->getField(0u)->Offset;
-  const Pointer &FieldPtr = Ptr.atField(FieldOffset);
-  PrimType FieldT = *S.getContext().classify(FieldPtr.getType());
+  PtrView FieldPtr = Ptr.view().atField(FieldOffset);
+  PrimType FieldT = FieldPtr.getFieldDesc()->getPrimType();
 
   INT_TYPE_SWITCH(FieldT,
                   FieldPtr.deref<T>() = T::from(IntValue.getSExtValue()));
@@ -6601,7 +6601,7 @@ bool SetThreeWayComparisonField(InterpState &S, CodePtr OpPC,
   return true;
 }
 
-static void zeroAll(Pointer &Dest) {
+static void zeroAll(PtrView Dest) {
   const Descriptor *Desc = Dest.getFieldDesc();
 
   if (Desc->isPrimitive()) {
@@ -6615,7 +6615,7 @@ static void zeroAll(Pointer &Dest) {
   if (Desc->isRecord()) {
     const Record *R = Desc->ElemRecord;
     for (const Record::Field &F : R->fields()) {
-      Pointer FieldPtr = Dest.atField(F.Offset);
+      PtrView FieldPtr = Dest.atField(F.Offset);
       zeroAll(FieldPtr);
     }
     return;
@@ -6633,22 +6633,22 @@ static void zeroAll(Pointer &Dest) {
 
   if (Desc->isCompositeArray()) {
     for (unsigned I = 0, N = Desc->getNumElems(); I != N; ++I) {
-      Pointer ElemPtr = Dest.atIndex(I).narrow();
+      PtrView ElemPtr = Dest.atIndex(I).narrow();
       zeroAll(ElemPtr);
     }
     return;
   }
 }
 
-static bool copyComposite(InterpState &S, CodePtr OpPC, const Pointer &Src,
-                          Pointer &Dest, bool Activate);
-static bool copyRecord(InterpState &S, CodePtr OpPC, const Pointer &Src,
-                       Pointer &Dest, bool Activate = false) {
+static bool copyComposite(InterpState &S, CodePtr OpPC, PtrView Src,
+                          PtrView Dest, bool Activate);
+static bool copyRecord(InterpState &S, CodePtr OpPC, PtrView Src, PtrView Dest,
+                       bool Activate = false) {
   [[maybe_unused]] const Descriptor *SrcDesc = Src.getFieldDesc();
   const Descriptor *DestDesc = Dest.getFieldDesc();
 
   auto copyField = [&](const Record::Field &F, bool Activate) -> bool {
-    Pointer DestField = Dest.atField(F.Offset);
+    PtrView DestField = Dest.atField(F.Offset);
     if (OptPrimType FT = S.Ctx.classify(F.Decl->getType())) {
       TYPE_SWITCH(*FT, {
         DestField.deref<T>() = Src.atField(F.Offset).deref<T>();
@@ -6667,7 +6667,7 @@ static bool copyRecord(InterpState &S, CodePtr OpPC, const Pointer &Src,
   assert(SrcDesc->ElemRecord == DestDesc->ElemRecord);
   const Record *R = DestDesc->ElemRecord;
   for (const Record::Field &F : R->fields()) {
-    Pointer FP = Src.atField(F.Offset);
+    PtrView FP = Src.atField(F.Offset);
 
     if (!CheckMutable(S, OpPC, FP))
       return false;
@@ -6678,7 +6678,7 @@ static bool copyRecord(InterpState &S, CodePtr OpPC, const Pointer &Src,
         if (!copyField(F, /*Activate=*/true))
           return false;
       } else {
-        Pointer DestField = Dest.atField(F.Offset);
+        PtrView DestField = Dest.atField(F.Offset);
         zeroAll(DestField);
       }
     } else {
@@ -6688,7 +6688,7 @@ static bool copyRecord(InterpState &S, CodePtr OpPC, const Pointer &Src,
   }
 
   for (const Record::Base &B : R->bases()) {
-    Pointer DestBase = Dest.atField(B.Offset);
+    PtrView DestBase = Dest.atField(B.Offset);
     if (!copyRecord(S, OpPC, Src.atField(B.Offset), DestBase, Activate))
       return false;
   }
@@ -6697,8 +6697,8 @@ static bool copyRecord(InterpState &S, CodePtr OpPC, const Pointer &Src,
   return true;
 }
 
-static bool copyComposite(InterpState &S, CodePtr OpPC, const Pointer &Src,
-                          Pointer &Dest, bool Activate = false) {
+static bool copyComposite(InterpState &S, CodePtr OpPC, PtrView Src,
+                          PtrView Dest, bool Activate = false) {
   assert(Src.isLive() && Dest.isLive());
 
   [[maybe_unused]] const Descriptor *SrcDesc = Src.getFieldDesc();
@@ -6722,8 +6722,9 @@ static bool copyComposite(InterpState &S, CodePtr OpPC, const Pointer &Src,
     assert(SrcDesc->getPrimType() == DestDesc->getPrimType());
     PrimType ET = DestDesc->getPrimType();
     for (unsigned I = 0, N = DestDesc->getNumElems(); I != N; ++I) {
-      TYPE_SWITCH(ET, { Dest.elem<T>(I) = Src.elem<T>(I); });
-      Dest.initializeElement(I);
+      PtrView DestElem = Dest.atIndex(I);
+      TYPE_SWITCH(ET, { DestElem.deref<T>() = Src.elem<T>(I); });
+      DestElem.initializeElement(I);
     }
     return true;
   }
@@ -6734,8 +6735,8 @@ static bool copyComposite(InterpState &S, CodePtr OpPC, const Pointer &Src,
     assert(SrcDesc->isCompositeArray());
     assert(SrcDesc->getNumElems() == DestDesc->getNumElems());
     for (unsigned I = 0, N = DestDesc->getNumElems(); I != N; ++I) {
-      const Pointer &SrcElem = Src.atIndex(I).narrow();
-      Pointer DestElem = Dest.atIndex(I).narrow();
+      PtrView SrcElem = Src.atIndex(I).narrow();
+      PtrView DestElem = Dest.atIndex(I).narrow();
       if (!copyComposite(S, OpPC, SrcElem, DestElem, Activate))
         return false;
     }
@@ -6756,7 +6757,7 @@ bool DoMemcpy(InterpState &S, CodePtr OpPC, const Pointer &Src, Pointer &Dest) {
   if (!Dest.isBlockPointer() || Dest.getFieldDesc()->isPrimitive())
     return false;
 
-  return copyComposite(S, OpPC, Src, Dest);
+  return copyComposite(S, OpPC, Src.view(), Dest.view());
 }
 
 } // namespace interp

--- a/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
@@ -39,7 +39,7 @@ enum class Result { Success, Skip, Failure };
 
 /// Used to iterate over pointer fields.
 using DataFunc =
-    llvm::function_ref<Result(const Pointer &P, PrimType Ty, Bits BitOffset,
+    llvm::function_ref<Result(PtrView P, PrimType Ty, Bits BitOffset,
                               Bits FullBitWidth, bool PackedBools)>;
 
 #define BITCAST_TYPE_SWITCH(Expr, B)                                           \
@@ -80,7 +80,7 @@ using DataFunc =
 
 /// We use this to recursively iterate over all fields and elements of a pointer
 /// and extract relevant data for a bitcast.
-static Result enumerateData(const Pointer &P, const Context &Ctx, Bits Offset,
+static Result enumerateData(PtrView P, const Context &Ctx, Bits Offset,
                             Bits BitsToRead, DataFunc F, bool Initialize) {
   const Descriptor *FieldDesc = P.getFieldDesc();
   assert(FieldDesc);
@@ -139,7 +139,7 @@ static Result enumerateData(const Pointer &P, const Context &Ctx, Bits Offset,
       if (Fi.isUnnamedBitField())
         continue;
 
-      Pointer Elem = P.atField(Fi.Offset);
+      PtrView Elem = P.atField(Fi.Offset);
       Bits BitOffset =
           Offset + Bits(Layout.getFieldOffset(Fi.Decl->getFieldIndex()));
       Result Res =
@@ -153,7 +153,7 @@ static Result enumerateData(const Pointer &P, const Context &Ctx, Bits Offset,
       Ok = Ok && Res != Result::Failure;
     }
     for (const Record::Base &B : R->bases()) {
-      Pointer Elem = P.atField(B.Offset);
+      PtrView Elem = P.atField(B.Offset);
       if (!Initialize && !Elem.isInitialized())
         return Result::Failure;
 
@@ -179,8 +179,9 @@ static Result enumerateData(const Pointer &P, const Context &Ctx, Bits Offset,
 static bool enumeratePointerFields(const Pointer &P, const Context &Ctx,
                                    Bits BitsToRead, DataFunc F,
                                    bool Initialize) {
-  return enumerateData(P, Ctx, Bits::zero(), BitsToRead, F, Initialize) !=
-         Result::Failure;
+
+  return enumerateData(P.view(), Ctx, Bits::zero(), BitsToRead, F,
+                       Initialize) != Result::Failure;
 }
 
 //  This function is constexpr if and only if To, From, and the types of
@@ -298,7 +299,7 @@ bool clang::interp::readPointerToBuffer(const Context &Ctx,
 
   return enumeratePointerFields(
       FromPtr, Ctx, Buffer.size(),
-      [&](const Pointer &P, PrimType T, Bits BitOffset, Bits FullBitWidth,
+      [&](PtrView P, PrimType T, Bits BitOffset, Bits FullBitWidth,
           bool PackedBools) -> Result {
         Bits BitWidth = FullBitWidth;
 
@@ -426,7 +427,7 @@ bool clang::interp::DoBitCastPtr(InterpState &S, CodePtr OpPC,
       ASTCtx.getTargetInfo().isLittleEndian() ? Endian::Little : Endian::Big;
   bool Success = enumeratePointerFields(
       ToPtr, S.getContext(), Buffer.size(),
-      [&](const Pointer &P, PrimType T, Bits BitOffset, Bits FullBitWidth,
+      [&](PtrView P, PrimType T, Bits BitOffset, Bits FullBitWidth,
           bool PackedBools) -> Result {
         QualType PtrType = P.getType();
         if (T == PT_Float) {
@@ -529,7 +530,7 @@ bool clang::interp::DoMemcpy(InterpState &S, CodePtr OpPC,
   llvm::SmallVector<PrimTypeVariant> Values;
   enumeratePointerFields(
       SrcPtr, S.getContext(), Size,
-      [&](const Pointer &P, PrimType T, Bits BitOffset, Bits FullBitWidth,
+      [&](const PtrView P, PrimType T, Bits BitOffset, Bits FullBitWidth,
           bool PackedBools) -> Result {
         TYPE_SWITCH(T, { Values.push_back(P.deref<T>()); });
         return Result::Success;
@@ -539,7 +540,7 @@ bool clang::interp::DoMemcpy(InterpState &S, CodePtr OpPC,
   unsigned ValueIndex = 0;
   enumeratePointerFields(
       DestPtr, S.getContext(), Size,
-      [&](const Pointer &P, PrimType T, Bits BitOffset, Bits FullBitWidth,
+      [&](const PtrView P, PrimType T, Bits BitOffset, Bits FullBitWidth,
           bool PackedBools) -> Result {
         TYPE_SWITCH(T, {
           P.deref<T>() = std::get<T>(Values[ValueIndex]);

--- a/clang/lib/AST/ByteCode/InterpHelpers.h
+++ b/clang/lib/AST/ByteCode/InterpHelpers.h
@@ -43,15 +43,27 @@ bool CheckLive(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
 bool CheckDummy(InterpState &S, CodePtr OpPC, const Block *B, AccessKinds AK);
 
 /// Checks if a pointer is in range.
-bool CheckRange(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
-                AccessKinds AK);
+bool CheckRange(InterpState &S, CodePtr OpPC, PtrView Ptr, AccessKinds AK);
+inline bool CheckRange(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
+                       AccessKinds AK) {
+  if (!Ptr.isBlockPointer()) {
+    assert(!Ptr.isOnePastEnd());
+    return true;
+  }
+  return CheckRange(S, OpPC, Ptr.view(), AK);
+}
 
 /// Checks if a field from which a pointer is going to be derived is valid.
 bool CheckRange(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
                 CheckSubobjectKind CSK);
 
 /// Checks if a pointer points to a mutable field.
-bool CheckMutable(InterpState &S, CodePtr OpPC, const Pointer &Ptr);
+bool CheckMutable(InterpState &S, CodePtr OpPC, PtrView Ptr);
+inline bool CheckMutable(InterpState &S, CodePtr OpPC, const Pointer &Ptr) {
+  if (!Ptr.isBlockPointer())
+    return true;
+  return CheckMutable(S, OpPC, Ptr.view());
+}
 
 /// Checks if a value can be loaded from a block.
 bool CheckLoad(InterpState &S, CodePtr OpPC, const Pointer &Ptr,

--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -35,7 +35,7 @@ Pointer::Pointer(Block *Pointee, uint64_t BaseAndOffset)
 Pointer::Pointer(Block *Pointee, unsigned Base, uint64_t Offset)
     : Offset(Offset), StorageKind(Storage::Block) {
   assert(Pointee);
-  assert((Base == RootPtrMark || Base % alignof(void *) == 0) && "wrong base");
+  assert(Base % alignof(void *) == 0 && "wrong base");
   assert(Base >= Pointee->getDescriptor()->getMetadataSize());
 
   BS = {Pointee, Base, nullptr, nullptr};
@@ -228,7 +228,8 @@ APValue Pointer::toAPValue(const ASTContext &ASTCtx) const {
 
   // Build the path into the object.
   bool OnePastEnd = isOnePastEnd() && !isZeroSizeArray();
-  Pointer Ptr = *this;
+
+  PtrView Ptr = view();
   while (Ptr.isField() || Ptr.isArrayElement()) {
 
     if (Ptr.isArrayRoot()) {
@@ -382,7 +383,7 @@ Pointer::computeOffsetForComparison(const ASTContext &ASTCtx) const {
   };
 
   size_t Result = 0;
-  Pointer P = *this;
+  PtrView P = view();
   while (true) {
     if (P.isVirtualBaseClass()) {
       Result += getInlineDesc()->Offset;
@@ -472,19 +473,15 @@ bool Pointer::isInitialized() const {
   return getInlineDesc()->IsInitialized;
 }
 
-bool Pointer::isElementInitialized(unsigned Index) const {
-  if (!isBlockPointer())
-    return true;
-
+bool PtrView::isElementInitialized(unsigned Index) const {
   const Descriptor *Desc = getFieldDesc();
   assert(Desc);
 
-  if (isStatic() && BS.Base == 0)
+  if (Pointee->isStatic() && Base == 0)
     return true;
 
-  if (isRoot() && BS.Base == sizeof(GlobalInlineDescriptor) &&
-      Offset == BS.Base) {
-    const auto &GD = block()->getBlockDesc<GlobalInlineDescriptor>();
+  if (isRoot() && Base == sizeof(GlobalInlineDescriptor) && Offset == Base) {
+    const auto &GD = Pointee->getBlockDesc<GlobalInlineDescriptor>();
     return GD.InitState == GlobalInitState::Initialized;
   }
 
@@ -514,14 +511,27 @@ bool Pointer::isElementAlive(unsigned Index) const {
   return IM->isElementAlive(Index);
 }
 
-void Pointer::startLifetime() const { setLifeState(Lifetime::Started); }
+Lifetime PtrView::getLifetime() const {
+  if (Base < sizeof(InlineDescriptor))
+    return Lifetime::Started;
 
-void Pointer::endLifetime() const { setLifeState(Lifetime::Ended); }
+  if (inArray() && !isArrayRoot()) {
+    InitMapPtr &IM = getInitMap();
 
-void Pointer::setLifeState(Lifetime L) const {
-  if (!isBlockPointer())
-    return;
-  if (BS.Base < sizeof(InlineDescriptor))
+    if (!IM.hasInitMap()) {
+      if (IM.allInitialized())
+        return Lifetime::Started;
+      return getArray().getLifetime();
+    }
+
+    return IM->isElementAlive(getIndex()) ? Lifetime::Started : Lifetime::Ended;
+  }
+
+  return getInlineDesc()->LifeState;
+}
+
+void PtrView::setLifeState(Lifetime L) const {
+  if (Base < sizeof(InlineDescriptor))
     return;
 
   if (inArray() && !isArrayRoot()) {
@@ -542,15 +552,9 @@ void Pointer::setLifeState(Lifetime L) const {
   getInlineDesc()->LifeState = L;
 }
 
-void Pointer::initialize() const {
-  if (!isBlockPointer())
-    return;
-
-  assert(BS.Pointee && "Cannot initialize null pointer");
-
-  if (isRoot() && BS.Base == sizeof(GlobalInlineDescriptor) &&
-      Offset == BS.Base) {
-    auto &GD = BS.Pointee->getBlockDesc<GlobalInlineDescriptor>();
+void PtrView::initialize() const {
+  if (isRoot() && Base == sizeof(GlobalInlineDescriptor) && Offset == Base) {
+    auto &GD = Pointee->getBlockDesc<GlobalInlineDescriptor>();
     GD.InitState = GlobalInitState::Initialized;
     return;
   }
@@ -564,14 +568,14 @@ void Pointer::initialize() const {
   }
 
   // Field has its bit in an inline descriptor.
-  assert(BS.Base != 0 && "Only composite fields can be initialised");
+  assert(Base != 0 && "Only composite fields can be initialised");
   getInlineDesc()->IsInitialized = true;
   getInlineDesc()->LifeState = Lifetime::Started;
 }
 
-void Pointer::initializeElement(unsigned Index) const {
+void PtrView::initializeElement(unsigned Index) const {
   // Primitive global arrays don't have an initmap.
-  if (isStatic() && BS.Base == 0)
+  if (Pointee->isStatic() && Base == 0)
     return;
 
   assert(Index < getFieldDesc()->getNumElems());
@@ -597,16 +601,15 @@ void Pointer::initializeAllElements() const {
   getInitMap().noteAllInitialized();
 }
 
-bool Pointer::allElementsInitialized() const {
+bool PtrView::allElementsInitialized() const {
   assert(getFieldDesc()->isPrimitiveArray());
   assert(isArrayRoot());
 
-  if (isStatic() && BS.Base == 0)
+  if (Pointee->isStatic() && Base == 0)
     return true;
 
-  if (isRoot() && BS.Base == sizeof(GlobalInlineDescriptor) &&
-      Offset == BS.Base) {
-    const auto &GD = block()->getBlockDesc<GlobalInlineDescriptor>();
+  if (isRoot() && Base == sizeof(GlobalInlineDescriptor) && Offset == Base) {
+    const auto &GD = Pointee->getBlockDesc<GlobalInlineDescriptor>();
     return GD.InitState == GlobalInitState::Initialized;
   }
 
@@ -631,22 +634,22 @@ bool Pointer::allElementsAlive() const {
   return IM.allInitialized() || (IM.hasInitMap() && IM->allElementsAlive());
 }
 
-void Pointer::activate() const {
+void PtrView::activate() const {
   // Field has its bit in an inline descriptor.
-  assert(BS.Base != 0 && "Only composite fields can be activated");
+  assert(Base != 0 && "Only composite fields can be activated");
 
-  if (isRoot() && BS.Base == sizeof(GlobalInlineDescriptor))
+  if (isRoot() && Base == sizeof(GlobalInlineDescriptor))
     return;
   if (!getInlineDesc()->InUnion)
     return;
 
-  std::function<void(Pointer &)> activate;
-  activate = [&activate](Pointer &P) -> void {
+  std::function<void(PtrView P)> activate;
+  activate = [&activate](PtrView P) -> void {
     P.getInlineDesc()->IsActive = true;
     P.startLifetime();
     if (const Record *R = P.getRecord(); R && !R->isUnion()) {
       for (const Record::Field &F : R->fields()) {
-        Pointer FieldPtr = P.atField(F.Offset);
+        PtrView FieldPtr = P.atField(F.Offset);
         if (!FieldPtr.getInlineDesc()->IsActive)
           activate(FieldPtr);
       }
@@ -654,13 +657,13 @@ void Pointer::activate() const {
     }
   };
 
-  std::function<void(Pointer &)> deactivate;
-  deactivate = [&deactivate](Pointer &P) -> void {
+  std::function<void(PtrView &)> deactivate;
+  deactivate = [&deactivate](PtrView &P) -> void {
     P.getInlineDesc()->IsActive = false;
 
     if (const Record *R = P.getRecord()) {
       for (const Record::Field &F : R->fields()) {
-        Pointer FieldPtr = P.atField(F.Offset);
+        PtrView FieldPtr = P.atField(F.Offset);
         if (FieldPtr.getInlineDesc()->IsActive)
           deactivate(FieldPtr);
       }
@@ -668,7 +671,7 @@ void Pointer::activate() const {
     }
   };
 
-  Pointer B = *this;
+  PtrView B = *this;
   // Primitive array elements can't be activated individually, so
   // look at the array root instead.
   if (B.getFieldDesc()->isPrimitiveArray() && B.isArrayElement())
@@ -679,20 +682,16 @@ void Pointer::activate() const {
 
     // When walking up the pointer chain, deactivate
     // all union child pointers that aren't on our path.
-    Pointer Cur = B;
+    PtrView Cur = B;
     B = B.getBase();
     if (const Record *BR = B.getRecord(); BR && BR->isUnion()) {
       for (const Record::Field &F : BR->fields()) {
-        Pointer FieldPtr = B.atField(F.Offset);
+        PtrView FieldPtr = B.atField(F.Offset);
         if (FieldPtr != Cur)
           deactivate(FieldPtr);
       }
     }
   }
-}
-
-void Pointer::deactivate() const {
-  // TODO: this only appears in constructors, so nothing to deactivate.
 }
 
 bool Pointer::hasSameBase(const Pointer &A, const Pointer &B) {
@@ -755,7 +754,7 @@ bool Pointer::pointsToLabel() const {
   return false;
 }
 
-std::optional<std::pair<Pointer, Pointer>>
+std::optional<std::pair<PtrView, PtrView>>
 Pointer::computeSplitPoint(const Pointer &A, const Pointer &B) {
   if (!A.isBlockPointer() || !B.isBlockPointer())
     return std::nullopt;
@@ -766,20 +765,20 @@ Pointer::computeSplitPoint(const Pointer &A, const Pointer &B) {
     return std::nullopt;
 
   if (A == B)
-    return std::make_pair(A, B);
+    return std::make_pair(A.view(), B.view());
 
-  auto getBase = [](const Pointer &P) -> Pointer {
+  auto getBase = [](PtrView P) -> PtrView {
     if (P.isArrayElement())
       return P.expand().getArray();
     return P.getBase();
   };
 
-  Pointer IterA = A;
-  Pointer IterB = B;
-  Pointer CurA = IterA;
-  Pointer CurB = IterB;
+  PtrView IterA = A.view();
+  PtrView IterB = B.view();
+  PtrView CurA = IterA;
+  PtrView CurB = IterB;
   for (;;) {
-    if (IterA.asBlockPointer().Base > IterB.asBlockPointer().Base) {
+    if (IterA.Base > IterB.Base) {
       CurA = IterA;
       IterA = getBase(IterA);
     } else {
@@ -807,15 +806,14 @@ std::optional<APValue> Pointer::toRValue(const Context &Ctx,
   const ASTContext &ASTCtx = Ctx.getASTContext();
   assert(!ResultType.isNull());
   // Method to recursively traverse composites.
-  std::function<bool(QualType, const Pointer &, APValue &)> Composite;
-  Composite = [&Composite, &Ctx, &ASTCtx](QualType Ty, const Pointer &Ptr,
+  std::function<bool(QualType, PtrView, APValue &)> Composite;
+  Composite = [&Composite, &Ctx, &ASTCtx](QualType Ty, PtrView Ptr,
                                           APValue &R) {
     if (const auto *AT = Ty->getAs<AtomicType>())
       Ty = AT->getValueType();
 
     // Invalid pointers.
-    if (Ptr.isDummy() || !Ptr.isLive() || !Ptr.isBlockPointer() ||
-        Ptr.isPastEnd())
+    if (Ptr.isDummy() || !Ptr.isLive() || Ptr.isPastEnd())
       return false;
 
     // Primitives should never end up here.
@@ -830,7 +828,7 @@ std::optional<APValue> Pointer::toRValue(const Context &Ctx,
         const FieldDecl *ActiveField = nullptr;
         APValue Value;
         for (const auto &F : Record->fields()) {
-          const Pointer &FP = Ptr.atField(F.Offset);
+          PtrView FP = Ptr.atField(F.Offset);
           if (FP.isActive()) {
             const Descriptor *Desc = F.Desc;
             if (Desc->isPrimitive()) {
@@ -855,7 +853,7 @@ std::optional<APValue> Pointer::toRValue(const Context &Ctx,
         for (unsigned I = 0; I != NF; ++I) {
           const Record::Field *FD = Record->getField(I);
           const Descriptor *Desc = FD->Desc;
-          const Pointer &FP = Ptr.atField(FD->Offset);
+          PtrView FP = Ptr.atField(FD->Offset);
           APValue &Value = R.getStructField(I);
           if (Desc->isPrimitive()) {
             TYPE_SWITCH(Desc->getPrimType(),
@@ -869,7 +867,7 @@ std::optional<APValue> Pointer::toRValue(const Context &Ctx,
         for (unsigned I = 0; I != NB; ++I) {
           const Record::Base *BD = Record->getBase(I);
           QualType BaseTy = Ctx.getASTContext().getCanonicalTagType(BD->Decl);
-          const Pointer &BP = Ptr.atField(BD->Offset);
+          PtrView BP = Ptr.atField(BD->Offset);
           Ok &= Composite(BaseTy, BP, R.getStructBase(I));
         }
 
@@ -877,7 +875,7 @@ std::optional<APValue> Pointer::toRValue(const Context &Ctx,
           const Record::Base *VD = Record->getVirtualBase(I);
           QualType VirtBaseTy =
               Ctx.getASTContext().getCanonicalTagType(VD->Decl);
-          const Pointer &VP = Ptr.atField(VD->Offset);
+          PtrView VP = Ptr.atField(VD->Offset);
           Ok &= Composite(VirtBaseTy, VP, R.getStructBase(NB + I));
         }
       }
@@ -992,7 +990,7 @@ std::optional<APValue> Pointer::toRValue(const Context &Ctx,
 
   // Return the composite type.
   APValue Result;
-  if (!Composite(ResultType, *this, Result))
+  if (!Composite(ResultType, view(), Result))
     return std::nullopt;
   return Result;
 }

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -33,6 +33,290 @@ class Context;
 class Pointer;
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Pointer &P);
 
+struct PtrView {
+  static constexpr unsigned PastEndMark = ~0u;
+
+  Block *Pointee;
+  unsigned Base;
+  uint64_t Offset;
+
+  bool isZero() const { return !Pointee; }
+  bool isLive() const { return Pointee && !Pointee->isDead(); }
+  bool isDummy() const { return Pointee && Pointee->isDummy(); }
+  bool isActive() const { return isRoot() || getInlineDesc()->IsActive; }
+  bool isArrayRoot() const { return inArray() && Offset == Base; }
+  bool isElementPastEnd() const { return Offset == PastEndMark; }
+  bool isZeroSizeArray() const { return getFieldDesc()->isZeroSizeArray(); }
+  bool isMutable() const {
+    return !isRoot() && getInlineDesc()->IsFieldMutable;
+  }
+  bool inUnion() const { return getInlineDesc()->InUnion; };
+  bool inArray() const { return getFieldDesc()->IsArray; }
+  bool inPrimitiveArray() const { return getFieldDesc()->isPrimitiveArray(); }
+
+  unsigned getEvalID() { return Pointee->getEvalID(); }
+
+  bool isRoot() const {
+    return Base == Pointee->getDescriptor()->getMetadataSize();
+  }
+
+  InlineDescriptor *getInlineDesc() const {
+    assert(Base != sizeof(GlobalInlineDescriptor));
+    assert(Base <= Pointee->getSize());
+    assert(Base >= sizeof(InlineDescriptor));
+    return getDescriptor(Base);
+  }
+
+  InlineDescriptor *getDescriptor(unsigned Offset) const {
+    assert(Offset != 0 && "Not a nested pointer");
+    return reinterpret_cast<InlineDescriptor *>(Pointee->rawData() + Offset) -
+           1;
+  }
+
+  const Descriptor *getFieldDesc() const {
+    if (isRoot())
+      return Pointee->getDescriptor();
+    return getInlineDesc()->Desc;
+  }
+
+  const Descriptor *getDeclDesc() const { return Pointee->getDescriptor(); }
+
+  size_t elemSize() const { return getFieldDesc()->getElemSize(); }
+
+  [[nodiscard]] PtrView narrow() const {
+    // Null pointers cannot be narrowed.
+    if (isZero() || isUnknownSizeArray())
+      return *this;
+
+    if (inArray()) {
+      // Pointer is one past end - magic offset marks that.
+      if (isOnePastEnd())
+        return PtrView{Pointee, Base, PastEndMark};
+
+      if (Offset != Base) {
+        // If we're pointing to a primitive array element, there's nothing to
+        // do.
+        if (inPrimitiveArray())
+          return *this;
+        // Pointer is to a composite array element - enter it.
+        return PtrView{Pointee, static_cast<unsigned>(Offset), Offset};
+      }
+    }
+    // Otherwise, we're pointing to a non-array element or
+    // are already narrowed to a composite array element. Nothing to do.
+    return *this;
+  }
+
+  [[nodiscard]] PtrView expand() const {
+    if (isElementPastEnd()) {
+      // Revert to an outer one-past-end pointer.
+      unsigned Adjust;
+      if (inPrimitiveArray())
+        Adjust = sizeof(InitMapPtr);
+      else
+        Adjust = sizeof(InlineDescriptor);
+      return PtrView{Pointee, Base, Base + getSize() + Adjust};
+    }
+
+    // Do not step out of array elements.
+    if (Base != Offset)
+      return *this;
+
+    if (isRoot())
+      return PtrView{Pointee, Base, Base};
+
+    // Step into the containing array, if inside one.
+    unsigned Next = Base - getInlineDesc()->Offset;
+    const Descriptor *Desc =
+        (Next == Pointee->getDescriptor()->getMetadataSize())
+            ? getDeclDesc()
+            : getDescriptor(Next)->Desc;
+    if (!Desc->IsArray)
+      return *this;
+    return PtrView{Pointee, Next, Offset};
+  }
+
+  [[nodiscard]] PtrView getArray() const {
+    assert(Offset != Base && "not an array element");
+    return PtrView{Pointee, Base, Base};
+  }
+
+  const Record *getRecord() const { return getFieldDesc()->ElemRecord; }
+  const Record *getElemRecord() const {
+    const Descriptor *ElemDesc = getFieldDesc()->ElemDesc;
+    return ElemDesc ? ElemDesc->ElemRecord : nullptr;
+  }
+  const FieldDecl *getField() const { return getFieldDesc()->asFieldDecl(); }
+
+  bool isField() const {
+    return !isZero() && !isRoot() && getFieldDesc()->asDecl();
+  }
+
+  bool isBaseClass() const { return isField() && getInlineDesc()->IsBase; }
+  bool isVirtualBaseClass() const {
+    return isField() && getInlineDesc()->IsVirtualBase;
+  }
+  bool isUnknownSizeArray() const {
+    return getFieldDesc()->isUnknownSizeArray();
+  }
+
+  bool isPastEnd() const { return Offset > Pointee->getSize(); }
+
+  unsigned getOffset() const {
+    assert(Offset != PastEndMark);
+
+    unsigned Adjust = 0;
+    if (Offset != Base) {
+      if (getFieldDesc()->ElemDesc)
+        Adjust = sizeof(InlineDescriptor);
+      else
+        Adjust = sizeof(InitMapPtr);
+    }
+    return Offset - Base - Adjust;
+  }
+  size_t getSize() const { return getFieldDesc()->getSize(); }
+
+  bool isOnePastEnd() const {
+    if (!Pointee)
+      return false;
+
+    if (isUnknownSizeArray())
+      return false;
+    return isPastEnd() || (getSize() == getOffset());
+  }
+
+  PtrView atIndex(unsigned Idx) const {
+    unsigned Off = Idx * elemSize();
+    if (getFieldDesc()->ElemDesc)
+      Off += sizeof(InlineDescriptor);
+    else
+      Off += sizeof(InitMapPtr);
+    return PtrView{Pointee, Base, Base + Off};
+  }
+
+  int64_t getIndex() const {
+    if (isZero())
+      return 0;
+    // narrow()ed element in a composite array.
+    if (Base > sizeof(InlineDescriptor) && Base == Offset)
+      return 0;
+
+    if (auto ElemSize = elemSize())
+      return getOffset() / ElemSize;
+    return 0;
+  }
+
+  unsigned getNumElems() const { return getSize() / elemSize(); }
+
+  bool isArrayElement() const {
+    if (inArray() && Base != Offset)
+      return true;
+
+    // Might be a narrow()'ed element in a composite array.
+    // Check the inline descriptor.
+    if (Base >= sizeof(InlineDescriptor) && getInlineDesc()->IsArrayElement)
+      return true;
+
+    return false;
+  }
+
+  template <typename T> T &deref() const {
+    assert(isLive() && "Invalid pointer");
+    assert(Pointee);
+
+    if (isArrayRoot())
+      return *reinterpret_cast<T *>(Pointee->rawData() + Base +
+                                    sizeof(InitMapPtr));
+
+    return *reinterpret_cast<T *>(Pointee->rawData() + Offset);
+  }
+
+  template <typename T> T &elem(unsigned I) const {
+    assert(isLive() && "Invalid pointer");
+    assert(Pointee);
+    assert(getFieldDesc()->isPrimitiveArray());
+    assert(I < getFieldDesc()->getNumElems());
+
+    unsigned ElemByteOffset = I * getFieldDesc()->getElemSize();
+    unsigned ReadOffset = Base + sizeof(InitMapPtr) + ElemByteOffset;
+    assert(ReadOffset + sizeof(T) <= Pointee->getDescriptor()->getAllocSize());
+
+    return *reinterpret_cast<T *>(Pointee->rawData() + ReadOffset);
+  }
+
+  [[nodiscard]] PtrView getBase() const {
+    unsigned NewBase = Base - getInlineDesc()->Offset;
+    return PtrView{Pointee, NewBase, NewBase};
+  }
+
+  [[nodiscard]] PtrView atField(unsigned Offset) const {
+    unsigned F = this->Offset + Offset;
+    return PtrView{Pointee, F, F};
+  }
+
+  QualType getType() const {
+    if (isRoot() && Base == Offset) {
+      // If this pointer points to the root of a declaration, try to consult
+      // the ValueDecl directly, since that has a type with more information,
+      // e.g. the correct ElaboratedTypeKeyword.
+      if (const ValueDecl *VD = getDeclDesc()->asValueDecl())
+        return VD->getType();
+      return getDeclDesc()->getType();
+    }
+    if (inPrimitiveArray() && Offset != Base) {
+      // Unfortunately, complex and vector types are not array types in clang,
+      // but they are for us.
+      if (const auto *AT = getFieldDesc()->getType()->getAsArrayTypeUnsafe())
+        return AT->getElementType();
+      if (const auto *CT = getFieldDesc()->getType()->getAs<ComplexType>())
+        return CT->getElementType();
+      if (const auto *CT = getFieldDesc()->getType()->getAs<VectorType>())
+        return CT->getElementType();
+    }
+
+    return getFieldDesc()->getType();
+  }
+
+  bool isInitialized() const {
+    if (isRoot() && Base == sizeof(GlobalInlineDescriptor) && Offset == Base) {
+      const auto &GD = Pointee->getBlockDesc<GlobalInlineDescriptor>();
+      return GD.InitState == GlobalInitState::Initialized;
+    }
+
+    assert(Pointee && "Cannot check if null pointer was initialized");
+    const Descriptor *Desc = getFieldDesc();
+    assert(Desc);
+    if (Desc->isPrimitiveArray())
+      return isElementInitialized(getIndex());
+
+    if (Base == 0)
+      return true;
+    // Field has its bit in an inline descriptor.
+    return getInlineDesc()->IsInitialized;
+  }
+
+  void initializeElement(unsigned Index) const;
+  bool allElementsInitialized() const;
+  bool isElementInitialized(unsigned Index) const;
+  InitMapPtr &getInitMap() const {
+    return *reinterpret_cast<InitMapPtr *>(Pointee->rawData() + Base);
+  }
+  void initialize() const;
+  void activate() const;
+
+  void setLifeState(Lifetime L) const;
+  Lifetime getLifetime() const;
+  void startLifetime() const { setLifeState(Lifetime::Started); }
+  void endLifetime() const { setLifeState(Lifetime::Ended); }
+
+  bool operator==(const PtrView &Other) const {
+    return Other.Pointee == Pointee && Base == Other.Base &&
+           Offset == Other.Offset;
+  }
+
+  bool operator!=(const PtrView &Other) const { return !(Other == *this); }
+};
+
 struct BlockPointer {
   /// The block the pointer is pointing to.
   Block *Pointee;
@@ -107,10 +391,6 @@ enum class Storage { Int, Block, Fn, Typeid };
 ///                     Base
 /// \endverbatim
 class Pointer {
-private:
-  static constexpr unsigned PastEndMark = ~0u;
-  static constexpr unsigned RootPtrMark = ~0u;
-
 public:
   Pointer() : StorageKind(Storage::Int), Int{nullptr, 0} {}
   Pointer(IntPointer &&IntPtr)
@@ -128,7 +408,9 @@ public:
     Typeid.TypePtr = TypePtr;
     Typeid.TypeInfoType = TypeInfoType;
   }
+
   Pointer(Block *Pointee, unsigned Base, uint64_t Offset);
+  explicit Pointer(PtrView V) : Pointer(V.Pointee, V.Base, V.Offset) {}
   ~Pointer();
 
   Pointer &operator=(const Pointer &P);
@@ -145,9 +427,7 @@ public:
     if (isFunctionPointer())
       return P.Fn.Func == Fn.Func && P.Offset == Offset;
 
-    assert(isBlockPointer());
-    return P.BS.Pointee == BS.Pointee && P.BS.Base == BS.Base &&
-           P.Offset == Offset;
+    return P.view() == view();
   }
 
   bool operator!=(const Pointer &P) const { return !(P == *this); }
@@ -166,6 +446,11 @@ public:
     return reinterpret_cast<uint64_t>(BS.Pointee) + Offset;
   }
 
+  PtrView view() const {
+    assert(isBlockPointer());
+    return PtrView{BS.Pointee, BS.Base, Offset};
+  }
+
   /// Converts the pointer to an APValue that is an rvalue.
   std::optional<APValue> toRValue(const Context &Ctx,
                                   QualType ResultType) const;
@@ -177,21 +462,12 @@ public:
     if (isFunctionPointer())
       return Pointer(Fn.Func, Idx);
 
-    if (BS.Base == RootPtrMark)
-      return Pointer(BS.Pointee, RootPtrMark, getDeclDesc()->getSize());
-    uint64_t Off = Idx * elemSize();
-    if (getFieldDesc()->ElemDesc)
-      Off += sizeof(InlineDescriptor);
-    else
-      Off += sizeof(InitMapPtr);
-    return Pointer(BS.Pointee, BS.Base, BS.Base + Off);
+    return Pointer(view().atIndex(Idx));
   }
 
   /// Creates a pointer to a field.
   [[nodiscard]] Pointer atField(unsigned Off) const {
-    assert(isBlockPointer());
-    unsigned Field = Offset + Off;
-    return Pointer(BS.Pointee, Field, Field);
+    return Pointer(view().atField(Off));
   }
 
   /// Subtract the given offset from the current Base and Offset
@@ -206,70 +482,14 @@ public:
   [[nodiscard]] Pointer narrow() const {
     if (!isBlockPointer())
       return *this;
-    assert(isBlockPointer());
-    // Null pointers cannot be narrowed.
-    if (isZero() || isUnknownSizeArray())
-      return *this;
-
-    unsigned Base = BS.Base;
-    // Pointer to an array of base types - enter block.
-    if (Base == RootPtrMark)
-      return Pointer(BS.Pointee, sizeof(InlineDescriptor),
-                     Offset == 0 ? Offset : PastEndMark);
-
-    if (inArray()) {
-      // Pointer is one past end - magic offset marks that.
-      if (isOnePastEnd())
-        return Pointer(BS.Pointee, Base, PastEndMark);
-
-      if (Offset != Base) {
-        // If we're pointing to a primitive array element, there's nothing to
-        // do.
-        if (inPrimitiveArray())
-          return *this;
-        // Pointer is to a composite array element - enter it.
-        return Pointer(BS.Pointee, Offset, Offset);
-      }
-    }
-
-    // Otherwise, we're pointing to a non-array element or
-    // are already narrowed to a composite array element. Nothing to do.
-    return *this;
+    return Pointer(view().narrow());
   }
 
   /// Expands a pointer to the containing array, undoing narrowing.
   [[nodiscard]] Pointer expand() const {
     if (!isBlockPointer())
       return *this;
-    assert(isBlockPointer());
-    Block *Pointee = BS.Pointee;
-
-    if (isElementPastEnd()) {
-      // Revert to an outer one-past-end pointer.
-      unsigned Adjust;
-      if (inPrimitiveArray())
-        Adjust = sizeof(InitMapPtr);
-      else
-        Adjust = sizeof(InlineDescriptor);
-      return Pointer(Pointee, BS.Base, BS.Base + getSize() + Adjust);
-    }
-
-    // Do not step out of array elements.
-    if (BS.Base != Offset)
-      return *this;
-
-    if (isRoot())
-      return Pointer(Pointee, BS.Base, BS.Base);
-
-    // Step into the containing array, if inside one.
-    unsigned Next = BS.Base - getInlineDesc()->Offset;
-    const Descriptor *Desc =
-        (Next == Pointee->getDescriptor()->getMetadataSize())
-            ? getDeclDesc()
-            : getDescriptor(Next)->Desc;
-    if (!Desc->IsArray)
-      return *this;
-    return Pointer(Pointee, Next, Offset);
+    return Pointer(view().expand());
   }
 
   /// Checks if the pointer is null.
@@ -290,14 +510,14 @@ public:
   bool isLive() const {
     if (!isBlockPointer())
       return true;
-    return BS.Pointee && !BS.Pointee->isDead();
+    return view().isLive();
   }
   /// Checks if the item is a field in an object.
   bool isField() const {
     if (!isBlockPointer())
       return false;
 
-    return !isRoot() && getFieldDesc()->asDecl();
+    return view().isField();
   }
 
   /// Accessor for information about the declaration site.
@@ -324,23 +544,9 @@ public:
   }
 
   /// Returns a pointer to the object of which this pointer is a field.
-  [[nodiscard]] Pointer getBase() const {
-    if (BS.Base == RootPtrMark) {
-      assert(Offset == PastEndMark && "cannot get base of a block");
-      return Pointer(BS.Pointee, BS.Base, 0);
-    }
-    unsigned NewBase = BS.Base - getInlineDesc()->Offset;
-    return Pointer(BS.Pointee, NewBase, NewBase);
-  }
+  [[nodiscard]] Pointer getBase() const { return Pointer(view().getBase()); }
   /// Returns the parent array.
-  [[nodiscard]] Pointer getArray() const {
-    if (BS.Base == RootPtrMark) {
-      assert(Offset != 0 && Offset != PastEndMark && "not an array element");
-      return Pointer(BS.Pointee, BS.Base, 0);
-    }
-    assert(Offset != BS.Base && "not an array element");
-    return Pointer(BS.Pointee, BS.Base, BS.Base);
-  }
+  [[nodiscard]] Pointer getArray() const { return Pointer(view().getArray()); }
 
   /// Accessors for information about the innermost field.
   const Descriptor *getFieldDesc() const {
@@ -354,34 +560,17 @@ public:
 
   /// Returns the type of the innermost field.
   QualType getType() const {
-    if (isTypeidPointer())
-      return QualType(Typeid.TypeInfoType, 0);
-    if (isFunctionPointer())
-      return Fn.Func->getDecl()->getType();
-    if (isIntegralPointer())
+    switch (StorageKind) {
+    case Storage::Int:
       return Int.getPointeeType();
-
-    if (isRoot() && BS.Base == Offset) {
-      // If this pointer points to the root of a declaration, try to consult
-      // the ValueDecl directly, since that has a type with more information,
-      // e.g. the correct ElaboratedTypeKeyword.
-      if (const ValueDecl *VD = getDeclDesc()->asValueDecl())
-        return VD->getType();
-      return getDeclDesc()->getType();
+    case Storage::Block:
+      return view().getType();
+    case Storage::Fn:
+      return Fn.Func->getDecl()->getType();
+    case Storage::Typeid:
+      return QualType(Typeid.TypeInfoType, 0);
     }
-
-    if (inPrimitiveArray() && Offset != BS.Base) {
-      // Unfortunately, complex and vector types are not array types in clang,
-      // but they are for us.
-      if (const auto *AT = getFieldDesc()->getType()->getAsArrayTypeUnsafe())
-        return AT->getElementType();
-      if (const auto *CT = getFieldDesc()->getType()->getAs<ComplexType>())
-        return CT->getElementType();
-      if (const auto *CT = getFieldDesc()->getType()->getAs<VectorType>())
-        return CT->getElementType();
-    }
-
-    return getFieldDesc()->getType();
+    llvm_unreachable("Unhandled StorageKind");
   }
 
   const VarDecl *getRootVarDecl() const;
@@ -395,9 +584,7 @@ public:
       return 1;
     }
 
-    if (BS.Base == RootPtrMark)
-      return getDeclDesc()->getSize();
-    return getFieldDesc()->getElemSize();
+    return view().elemSize();
   }
   /// Returns the total size of the innermost field.
   size_t getSize() const {
@@ -407,41 +594,30 @@ public:
 
   /// Returns the offset into an array.
   unsigned getOffset() const {
-    assert(Offset != PastEndMark && "invalid offset");
-    assert(isBlockPointer());
-    if (BS.Base == RootPtrMark)
-      return Offset;
-
-    unsigned Adjust = 0;
-    if (Offset != BS.Base) {
-      if (getFieldDesc()->ElemDesc)
-        Adjust = sizeof(InlineDescriptor);
-      else
-        Adjust = sizeof(InitMapPtr);
-    }
-    return Offset - BS.Base - Adjust;
+    assert(Offset != PtrView::PastEndMark && "invalid offset");
+    return view().getOffset();
   }
 
   /// Whether this array refers to an array, but not
   /// to the first element.
-  bool isArrayRoot() const { return inArray() && Offset == BS.Base; }
+  bool isArrayRoot() const { return view().isArrayRoot(); }
 
   /// Checks if the innermost field is an array.
   bool inArray() const {
     if (isBlockPointer())
-      return getFieldDesc()->IsArray;
+      return view().inArray();
     return false;
   }
   bool inUnion() const {
     if (isBlockPointer() && BS.Base >= sizeof(InlineDescriptor))
-      return getInlineDesc()->InUnion;
+      return view().inUnion();
     return false;
   };
 
   /// Checks if the structure is a primitive array.
   bool inPrimitiveArray() const {
     if (isBlockPointer())
-      return getFieldDesc()->isPrimitiveArray();
+      return view().inPrimitiveArray();
     return false;
   }
   /// Checks if the structure is an array of unknown size.
@@ -455,23 +631,13 @@ public:
     if (!isBlockPointer())
       return false;
 
-    const BlockPointer &BP = BS;
-    if (inArray() && BP.Base != Offset)
-      return true;
-
-    // Might be a narrow()'ed element in a composite array.
-    // Check the inline descriptor.
-    if (BP.Base >= sizeof(InlineDescriptor) && getInlineDesc()->IsArrayElement)
-      return true;
-
-    return false;
+    return view().isArrayElement();
   }
   /// Pointer points directly to a block.
   bool isRoot() const {
     if (isZero() || !isBlockPointer())
       return true;
-    return (BS.Base == BS.Pointee->getDescriptor()->getMetadataSize() ||
-            BS.Base == 0);
+    return view().isRoot();
   }
   /// If this pointer has an InlineDescriptor we can use to initialize.
   bool canBeInitialized() const {
@@ -504,12 +670,9 @@ public:
   bool isTypeidPointer() const { return StorageKind == Storage::Typeid; }
 
   /// Returns the record descriptor of a class.
-  const Record *getRecord() const { return getFieldDesc()->ElemRecord; }
+  const Record *getRecord() const { return view().getRecord(); }
   /// Returns the element record type, if this is a non-primive array.
-  const Record *getElemRecord() const {
-    const Descriptor *ElemDesc = getFieldDesc()->ElemDesc;
-    return ElemDesc ? ElemDesc->ElemRecord : nullptr;
-  }
+  const Record *getElemRecord() const { return view().getElemRecord(); }
   /// Returns the field information.
   const FieldDecl *getField() const {
     if (const Descriptor *FD = getFieldDesc())
@@ -553,7 +716,7 @@ public:
   bool isMutable() const {
     if (!isBlockPointer())
       return false;
-    return !isRoot() && getInlineDesc()->IsFieldMutable;
+    return view().isMutable();
   }
 
   bool isWeak() const {
@@ -573,21 +736,17 @@ public:
   bool isActive() const {
     if (!isBlockPointer())
       return true;
-    return isRoot() || getInlineDesc()->IsActive;
+    return view().isActive();
   }
   /// Checks if a structure is a base class.
-  bool isBaseClass() const { return isField() && getInlineDesc()->IsBase; }
-  bool isVirtualBaseClass() const {
-    return isField() && getInlineDesc()->IsVirtualBase;
-  }
+  bool isBaseClass() const { return view().isBaseClass(); }
+  bool isVirtualBaseClass() const { return view().isVirtualBaseClass(); }
+
   /// Checks if the pointer points to a dummy value.
   bool isDummy() const {
     if (!isBlockPointer())
       return false;
-
-    if (const Block *Pointee = BS.Pointee)
-      return Pointee->isDummy();
-    return false;
+    return view().isDummy();
   }
 
   /// Checks if an object or a subfield is mutable.
@@ -625,7 +784,7 @@ public:
     if (isTypeidPointer())
       return reinterpret_cast<uintptr_t>(Typeid.TypePtr) + Offset;
     if (isOnePastEnd())
-      return PastEndMark;
+      return PtrView::PastEndMark;
     return Offset;
   }
 
@@ -633,7 +792,7 @@ public:
   unsigned getNumElems() const {
     if (!isBlockPointer())
       return ~0u;
-    return getSize() / elemSize();
+    return view().getNumElems();
   }
 
   const Block *block() const { return BS.Pointee; }
@@ -650,16 +809,7 @@ public:
     if (!isBlockPointer())
       return getIntegerRepresentation();
 
-    if (isZero())
-      return 0;
-
-    // narrow()ed element in a composite array.
-    if (BS.Base > sizeof(InlineDescriptor) && BS.Base == Offset)
-      return 0;
-
-    if (auto ElemSize = elemSize())
-      return getOffset() / ElemSize;
-    return 0;
+    return view().getIndex();
   }
 
   /// Checks if the index is one past end.
@@ -685,7 +835,7 @@ public:
   }
 
   /// Checks if the pointer is an out-of-bounds element pointer.
-  bool isElementPastEnd() const { return Offset == PastEndMark; }
+  bool isElementPastEnd() const { return Offset == PtrView::PastEndMark; }
 
   /// Checks if the pointer is pointing to a zero-size array.
   bool isZeroSizeArray() const {
@@ -713,11 +863,7 @@ public:
     assert(isDereferencable());
     assert(Offset + sizeof(T) <= BS.Pointee->getDescriptor()->getAllocSize());
 
-    if (isArrayRoot())
-      return *reinterpret_cast<T *>(BS.Pointee->rawData() + BS.Base +
-                                    sizeof(InitMapPtr));
-
-    return *reinterpret_cast<T *>(BS.Pointee->rawData() + Offset);
+    return view().deref<T>();
   }
 
   /// Dereferences the element at index \p I.
@@ -730,12 +876,7 @@ public:
     assert(getFieldDesc()->isPrimitiveArray());
     assert(I < getFieldDesc()->getNumElems());
 
-    unsigned ElemByteOffset = I * getFieldDesc()->getElemSize();
-    unsigned ReadOffset = BS.Base + sizeof(InitMapPtr) + ElemByteOffset;
-    assert(ReadOffset + sizeof(T) <=
-           BS.Pointee->getDescriptor()->getAllocSize());
-
-    return *reinterpret_cast<T *>(BS.Pointee->rawData() + ReadOffset);
+    return view().elem<T>(I);
   }
 
   bool isConstexprUnknown() const {
@@ -760,9 +901,15 @@ public:
   }
 
   /// Initializes a field.
-  void initialize() const;
+  void initialize() const {
+    if (!isBlockPointer())
+      return;
+    view().initialize();
+  }
   /// Initialized the given element of a primitive array.
-  void initializeElement(unsigned Index) const;
+  void initializeElement(unsigned Index) const {
+    view().initializeElement(Index);
+  }
   /// Initialize all elements of a primitive array at once. This can be
   /// used in situations where we *know* we have initialized *all* elements
   /// of a primtive array.
@@ -770,15 +917,26 @@ public:
   /// Checks if an object was initialized.
   bool isInitialized() const;
   /// Like isInitialized(), but for primitive arrays.
-  bool isElementInitialized(unsigned Index) const;
-  bool allElementsInitialized() const;
+  bool isElementInitialized(unsigned Index) const {
+    if (!isBlockPointer())
+      return true;
+
+    return view().isElementInitialized(Index);
+  }
+  bool allElementsInitialized() const {
+    assert(getFieldDesc()->isPrimitiveArray());
+    assert(isArrayRoot());
+    return view().allElementsInitialized();
+  }
   bool allElementsAlive() const;
   bool isElementAlive(unsigned Index) const;
 
-  /// Activats a field.
-  void activate() const;
+  /// Activates a field.
+  void activate() const { view().activate(); }
   /// Deactivates an entire strurcutre.
-  void deactivate() const;
+  void deactivate() const {
+    // TODO: this only appears in constructors, so nothing to deactivate.
+  }
 
   Lifetime getLifetime() const {
     if (!isBlockPointer())
@@ -806,21 +964,26 @@ public:
   /// InlineDescriptor as well as primitive array elements. Pointers are usually
   /// alive by default, unless the underlying object has been allocated with
   /// std::allocator. This function is used by std::construct_at.
-  void startLifetime() const;
+  void startLifetime() const { setLifeState(Lifetime::Started); }
   /// Ends the lifetime of the pointer. This works for pointer with an
   /// InlineDescriptor as well as primitive array elements. This function is
   /// used by std::destroy_at.
-  void endLifetime() const;
-  void setLifeState(Lifetime L) const;
+  void endLifetime() const { setLifeState(Lifetime::Ended); }
+
+  void setLifeState(Lifetime L) const {
+    if (!isBlockPointer())
+      return;
+    view().setLifeState(L);
+  };
 
   /// Strip base casts from this Pointer.
   /// The result is either a root pointer or something
   /// that isn't a base class anymore.
   [[nodiscard]] Pointer stripBaseCasts() const {
-    Pointer P = *this;
-    while (P.isBaseClass())
-      P = P.getBase();
-    return P;
+    PtrView V = view();
+    while (V.isBaseClass())
+      V = V.getBase();
+    return Pointer(V);
   }
 
   /// Compare two pointers.
@@ -843,7 +1006,7 @@ public:
   /// Checks if both given pointers point to the same block.
   static bool pointToSameBlock(const Pointer &A, const Pointer &B);
 
-  static std::optional<std::pair<Pointer, Pointer>>
+  static std::optional<std::pair<PtrView, PtrView>>
   computeSplitPoint(const Pointer &A, const Pointer &B);
 
   /// Whether this points to a block that's been created for a "literal lvalue",
@@ -890,16 +1053,14 @@ private:
     assert(Offset != 0 && "Not a nested pointer");
     assert(isBlockPointer());
     assert(!isZero());
-    return reinterpret_cast<InlineDescriptor *>(BS.Pointee->rawData() +
-                                                Offset) -
-           1;
+    return view().getDescriptor(Offset);
   }
 
   /// Returns a reference to the InitMapPtr which stores the initialization map.
   InitMapPtr &getInitMap() const {
     assert(isBlockPointer());
     assert(!isZero());
-    return *reinterpret_cast<InitMapPtr *>(BS.Pointee->rawData() + BS.Base);
+    return view().getInitMap();
   }
 
   /// Offset into the storage.

--- a/clang/test/AST/ByteCode/cxx20.cpp
+++ b/clang/test/AST/ByteCode/cxx20.cpp
@@ -1413,3 +1413,13 @@ namespace StoreCannotDeref {
     *m = 42;
   }
 }
+
+namespace FuncPtrRef {
+  const int &foo(int &&);
+  constexpr bool bullet_five_tests() {
+    using FooType = const int &(int &&);
+    FooType &fn = foo;
+    return true;
+  }
+  static_assert(bullet_five_tests());
+}


### PR DESCRIPTION
Currently, when creating a `Pointer` (of block type, which I will assume here), the pointer will add itself (via its address) to its block's pointer list. This way, a block always knows what pointers point to it. That's important so we can handle the case when a block (which was e.g. created for a local variable) is destroyed and we now need to update its pointers.

However, since always do this for all `Pointer` instances, it creates a weird performance problem where we do this dance all the time for no reason, e.g. consider `Pointer::stripBaseCasts()`:
https://github.com/llvm/llvm-project/blob/88693c49d9ac58a33af5978d31f6c70fe1d5b45b/clang/lib/AST/ByteCode/Pointer.h#L778-L783

This will add and remove the newly created pointer from the block's pointer list every iteration. Other offenders are `Pointer::toRValue()`, `EvaluationResult::checkFullyInitialized()` or `Pointer::computeOffsetForComparison()`.

This commit introduces a `PtrView` struct, which is like a `BlockPointer`, but without the prev/next next links to other `Pointer`s in the block's pointer list. It also moves a lot of the accessors from `Pointer` to `PtrView` (e.g. `isRoot()` or `getFieldDesc()`, etc.).


This PR is mostly a draft but I'm looking for opinions on the approach. The downside of this is that all the accessors in `PtrView` are also duplicated in `Pointer`, since the two aren't related. I was also trying to keep both as simple as possible, i.e. without introducing any base classes or using CRTP.


compile-time-tracker: https://llvm-compile-time-tracker.com/compare.php?from=4716dc8c51719cbcc82928cd00e41a29e5b9adff&to=28d69d4ec16e77370938675826b07752e108eede&stat=instructions:u