### PR TITLE
[lldb-dap] Skip return_variable_with_children on arm64

### DIFF
--- a/lldb/test/API/tools/lldb-dap/variables/children/TestDAP_variables_children.py
+++ b/lldb/test/API/tools/lldb-dap/variables/children/TestDAP_variables_children.py
@@ -38,7 +38,7 @@ class TestDAP_variables_children(lldbdap_testcase.DAPTestCaseBase):
             )["body"]["result"],
         )
 
-    @expectedFailureAll(archs=["arm$", "aarch64"])
+    @expectedFailureAll(archs=["arm$", "arm64", "aarch64"])
     def test_return_variable_with_children(self):
         """
         Test the stepping out of a function with return value show the children correctly


### PR DESCRIPTION
In lldb arm64 does not support scalar return types that is larger than the register size. skip the test on that architecture.

Unblocks CI. 