### PR TITLE
[mlir][bazel] Fix build after changes from #183856.

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
@@ -49,6 +49,7 @@ expand_template(
         "@MLIR_ENABLE_VULKAN_RUNNER@": "0",
         "@MLIR_ENABLE_BINDINGS_PYTHON@": "0",
         "@MLIR_ENABLE_XEVM_CONVERSIONS@": "0",
+        "@MLIR_ENABLE_PYTHON_STABLE_ABI@": "0",
         "@MLIR_RUN_AMX_TESTS@": "0",
         "@MLIR_RUN_ARM_SVE_TESTS@": "0",
         "@MLIR_RUN_ARM_SME_TESTS@": "0",


### PR DESCRIPTION
This PR fixes the bazel build breakages introduced by #183856, which introduced a new CMake flag that wasn't set in the bazel build, thus leading to a placeholder not being replaced and a consequent syntax error. The fix consists of setting this value to the default (`0`), which is how similar flags are handled.