### PR TITLE
[AMDGPU] Exec-protect regular VGPR spill saves under narrowed exec

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
@@ -1707,7 +1707,8 @@ void SIFrameLowering::determineCalleeSaves(MachineFunction &MF,
     for (MachineInstr &MI : MBB) {
       // TODO: Walking through all MBBs here would be a bad heuristic. Better
       // handle them elsewhere.
-      if (TII->isWWMRegSpillOpcode(MI.getOpcode()))
+      if (TII->isWWMRegSpillOpcode(MI.getOpcode()) ||
+          (TII->isVGPRSpill(MI) && MFI->getSGPRForEXECCopy()))
         NeedExecCopyReservedReg = true;
       else if (MI.getOpcode() == AMDGPU::SI_RETURN ||
                MI.getOpcode() == AMDGPU::SI_RETURN_TO_EPILOG ||

--- a/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
@@ -563,9 +563,23 @@ bool SILowerSGPRSpills::run(MachineFunction &MF) {
                              TRI->getHWRegIndex(FuncInfo->getSGPRForEXECCopy()))
       FuncInfo->setSGPRForEXECCopy(UnusedLowSGPR);
   } else {
-    // No SGPR spills to virtual VGPR lanes and hence there won't be any WWM
-    // spills/copies. Reset the SGPR reserved for EXEC copy.
-    FuncInfo->setSGPRForEXECCopy(AMDGPU::NoRegister);
+    // Keep SGPRForEXECCopy reserved if exec may be narrowed in this function.
+    // Regular VGPR scratch spills require exec protection: memory ops respect
+    // the exec mask, so spills under narrowed exec leave inactive lanes
+    // unwritten, corrupting values on reload under wider exec.
+    bool HasExecModify = false;
+    for (const MachineBasicBlock &MBB : MF) {
+      for (const MachineInstr &MI : MBB) {
+        if (MI.modifiesRegister(AMDGPU::EXEC, TRI)) {
+          HasExecModify = true;
+          break;
+        }
+      }
+      if (HasExecModify)
+        break;
+    }
+    if (!HasExecModify)
+      FuncInfo->setSGPRForEXECCopy(AMDGPU::NoRegister);
   }
 
   SaveBlocks.clear();

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -2460,18 +2460,18 @@ bool SIRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,
       }
 
       auto *MBB = MI->getParent();
-      bool IsWWMRegSpill = TII->isWWMRegSpillOpcode(MI->getOpcode());
-      if (IsWWMRegSpill) {
-        TII->insertScratchExecCopy(*MF, *MBB, MI, DL, MFI->getSGPRForEXECCopy(),
-                                  RS->isRegUsed(AMDGPU::SCC));
+      Register ExecCopyReg = MFI->getSGPRForEXECCopy();
+      if (ExecCopyReg) {
+        TII->insertScratchExecCopy(*MF, *MBB, MI, DL, ExecCopyReg,
+                                   RS->isRegUsed(AMDGPU::SCC));
       }
       buildSpillLoadStore(
           *MBB, MI, DL, Opc, Index, VData->getReg(), VData->isKill(), FrameReg,
           TII->getNamedOperand(*MI, AMDGPU::OpName::offset)->getImm(),
           *MI->memoperands_begin(), RS);
       MFI->addToSpilledVGPRs(getNumSubRegsForSpillOp(*MI, TII));
-      if (IsWWMRegSpill)
-        TII->restoreExec(*MF, *MBB, MI, DL, MFI->getSGPRForEXECCopy());
+      if (ExecCopyReg)
+        TII->restoreExec(*MF, *MBB, MI, DL, ExecCopyReg);
 
       MI->eraseFromParent();
       return true;
@@ -2548,8 +2548,10 @@ bool SIRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,
 
       auto *MBB = MI->getParent();
       bool IsWWMRegSpill = TII->isWWMRegSpillOpcode(MI->getOpcode());
-      if (IsWWMRegSpill) {
-        TII->insertScratchExecCopy(*MF, *MBB, MI, DL, MFI->getSGPRForEXECCopy(),
+      Register ExecCopyReg =
+          IsWWMRegSpill ? MFI->getSGPRForEXECCopy() : Register();
+      if (ExecCopyReg) {
+        TII->insertScratchExecCopy(*MF, *MBB, MI, DL, ExecCopyReg,
                                    RS->isRegUsed(AMDGPU::SCC));
       }
 
@@ -2558,8 +2560,8 @@ bool SIRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator MI,
           TII->getNamedOperand(*MI, AMDGPU::OpName::offset)->getImm(),
           *MI->memoperands_begin(), RS);
 
-      if (IsWWMRegSpill)
-        TII->restoreExec(*MF, *MBB, MI, DL, MFI->getSGPRForEXECCopy());
+      if (ExecCopyReg)
+        TII->restoreExec(*MF, *MBB, MI, DL, ExecCopyReg);
 
       MI->eraseFromParent();
       return true;


### PR DESCRIPTION
Changes:
- SIRegisterInfo::eliminateFrameIndex: save path uses SGPRForEXECCopy (when valid) instead of gating on isWWMRegSpillOpcode; restore path retains WWM-only exec protection.
- SILowerSGPRSpills: keep SGPRForEXECCopy reserved when the function has exec-modifying instructions, not only when WWM spills exist.
- SIFrameLowering: extend NeedExecCopyReservedReg to include regular VGPR spill pseudos when SGPRForEXECCopy is valid, so the reservation survives PrologEpilogInserter. The guard prevents assertion failures when exec is never narrowed (no exec copy SGPR reserved).

Made-with: Cursor