### PR TITLE
[clang][bytecode] Reject non-VarDecl DeclRefExprs

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -7293,7 +7293,7 @@ bool Compiler<Emitter>::visitDeclRef(const ValueDecl *D, const Expr *E) {
   // we haven't seen yet.
   const auto *VD = dyn_cast<VarDecl>(D);
   if (!VD)
-    return this->emitDummyPtr(D, E);
+    return this->emitError(E);
 
   // For C.
   if (!Ctx.getLangOpts().CPlusPlus) {


### PR DESCRIPTION
I have no idea how to test this, but this is what the current interpreter does.