### PR TITLE
[llvm] Turn misc copy-assign to move-assign

### DIFF
--- a/llvm/lib/Analysis/CmpInstAnalysis.cpp
+++ b/llvm/lib/Analysis/CmpInstAnalysis.cpp
@@ -122,8 +122,8 @@ llvm::decomposeBitTestICmp(Value *LHS, Value *RHS, CmpInst::Predicate Pred,
 
     if (FlippedSign.isNegatedPowerOf2()) {
       // X s< 01111100 is equivalent to (X & 11111100 != 01111100)
-      Result.Mask = FlippedSign;
-      Result.C = C;
+      Result.Mask = std::move(FlippedSign);
+      Result.C = std::move(C);
       Result.Pred = ICmpInst::ICMP_NE;
       break;
     }
@@ -142,7 +142,7 @@ llvm::decomposeBitTestICmp(Value *LHS, Value *RHS, CmpInst::Predicate Pred,
     // X u< 11111100 is equivalent to (X & 11111100 != 11111100)
     if (C.isNegatedPowerOf2()) {
       Result.Mask = C;
-      Result.C = C;
+      Result.C = std::move(C);
       Result.Pred = ICmpInst::ICMP_NE;
       break;
     }
@@ -157,7 +157,7 @@ llvm::decomposeBitTestICmp(Value *LHS, Value *RHS, CmpInst::Predicate Pred,
     if (match(LHS, m_And(m_Value(AndVal), m_APIntAllowPoison(AndC)))) {
       LHS = AndVal;
       Result.Mask = *AndC;
-      Result.C = C;
+      Result.C = std::move(C);
       Result.Pred = Pred;
       break;
     }
@@ -166,7 +166,7 @@ llvm::decomposeBitTestICmp(Value *LHS, Value *RHS, CmpInst::Predicate Pred,
     if (LookThroughTrunc && isa<TruncInst>(LHS)) {
       Result.Pred = Pred;
       Result.Mask = APInt::getAllOnes(C.getBitWidth());
-      Result.C = C;
+      Result.C = std::move(C);
       break;
     }
 

--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -1087,7 +1087,7 @@ bool RecurrenceDescriptor::isReductionPHI(PHINode *Phi, Loop *TheLoop,
         RecurrenceDescriptor::isMinMaxRecurrenceKind(RD.getRecurrenceKind()) &&
         "Expected a min/max recurrence kind");
     LLVM_DEBUG(dbgs() << "Found a min/max reduction PHI." << *Phi << "\n");
-    RedDes = RD;
+    RedDes = std::move(RD);
     return true;
   }
   if (AddReductionVar(Phi, RecurKind::AnyOf, TheLoop, RedDes, DB, AC, DT, SE)) {

--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -1703,7 +1703,7 @@ bool CallAnalyzer::visitPHI(PHINode &I) {
 
   // Check if we can map phi to a pointer with constant offset.
   if (FirstBaseAndOffset.first) {
-    ConstantOffsetPtrs[&I] = FirstBaseAndOffset;
+    ConstantOffsetPtrs[&I] = std::move(FirstBaseAndOffset);
 
     if (auto *SROAArg = getSROAArgForValueOrNull(FirstV))
       SROAArgValues[&I] = SROAArg;
@@ -1879,7 +1879,7 @@ bool CallAnalyzer::visitBitCast(BitCastInst &I) {
       ConstantOffsetPtrs.lookup(I.getOperand(0));
   // Casts don't change the offset, just wrap it up.
   if (BaseAndOffset.first)
-    ConstantOffsetPtrs[&I] = BaseAndOffset;
+    ConstantOffsetPtrs[&I] = std::move(BaseAndOffset);
 
   // Also look for SROA candidates here.
   if (auto *SROAArg = getSROAArgForValueOrNull(I.getOperand(0)))
@@ -1902,7 +1902,7 @@ bool CallAnalyzer::visitPtrToInt(PtrToIntInst &I) {
     std::pair<Value *, APInt> BaseAndOffset =
         ConstantOffsetPtrs.lookup(I.getOperand(0));
     if (BaseAndOffset.first)
-      ConstantOffsetPtrs[&I] = BaseAndOffset;
+      ConstantOffsetPtrs[&I] = std::move(BaseAndOffset);
   }
 
   // This is really weird. Technically, ptrtoint will disable SROA. However,
@@ -1931,7 +1931,7 @@ bool CallAnalyzer::visitIntToPtr(IntToPtrInst &I) {
   if (IntegerSize <= DL.getPointerTypeSizeInBits(I.getType())) {
     std::pair<Value *, APInt> BaseAndOffset = ConstantOffsetPtrs.lookup(Op);
     if (BaseAndOffset.first)
-      ConstantOffsetPtrs[&I] = BaseAndOffset;
+      ConstantOffsetPtrs[&I] = std::move(BaseAndOffset);
   }
 
   // "Propagate" SROA here in the same manner as we do for ptrtoint above.
@@ -2597,7 +2597,7 @@ bool CallAnalyzer::visitSelectInst(SelectInst &SI) {
     std::pair<Value *, APInt> FalseBaseAndOffset =
         ConstantOffsetPtrs.lookup(FalseVal);
     if (TrueBaseAndOffset == FalseBaseAndOffset && TrueBaseAndOffset.first) {
-      ConstantOffsetPtrs[&SI] = TrueBaseAndOffset;
+      ConstantOffsetPtrs[&SI] = std::move(TrueBaseAndOffset);
 
       if (auto *SROAArg = getSROAArgForValueOrNull(TrueVal))
         SROAArgValues[&SI] = SROAArg;
@@ -2636,7 +2636,7 @@ bool CallAnalyzer::visitSelectInst(SelectInst &SI) {
   std::pair<Value *, APInt> BaseAndOffset =
       ConstantOffsetPtrs.lookup(SelectedV);
   if (BaseAndOffset.first) {
-    ConstantOffsetPtrs[&SI] = BaseAndOffset;
+    ConstantOffsetPtrs[&SI] = std::move(BaseAndOffset);
 
     if (auto *SROAArg = getSROAArgForValueOrNull(SelectedV))
       SROAArgValues[&SI] = SROAArg;

--- a/llvm/lib/Analysis/Loads.cpp
+++ b/llvm/lib/Analysis/Loads.cpp
@@ -357,7 +357,7 @@ bool llvm::isDereferenceableAndAlignedInLoop(
   const SCEV *AccessSizeSCEV = nullptr;
   if (const SCEVUnknown *NewBase = dyn_cast<SCEVUnknown>(AccessStart)) {
     Base = NewBase->getValue();
-    AccessSize = MaxPtrDiff;
+    AccessSize = std::move(MaxPtrDiff);
     AccessSizeSCEV = PtrDiff;
   } else if (auto *MinAdd = dyn_cast<SCEVAddExpr>(AccessStart)) {
     if (MinAdd->getNumOperands() != 2)

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -1340,7 +1340,7 @@ void llvm::adjustKnownBitsForSelectArm(KnownBits &Known, Value *Cond,
 
   // Finally, we know we get information from the condition and its valid,
   // so return it.
-  Known = CondRes;
+  Known = std::move(CondRes);
 }
 
 // Match a signed min+max clamp pattern like smax(smin(In, CHigh), CLow).

--- a/llvm/lib/CAS/OnDiskCommon.cpp
+++ b/llvm/lib/CAS/OnDiskCommon.cpp
@@ -230,7 +230,7 @@ cas::ondisk::UniqueTempFile::createAndCopyFrom(StringRef ParentPath,
   sys::path::append(Model, "%%%%%%%.tmp");
   if (std::error_code EC = sys::fs::createUniqueFile(Model, UniqueTmpPath))
     return createFileError(Model, EC);
-  TmpPath = UniqueTmpPath;
+  TmpPath = std::move(UniqueTmpPath);
   TmpPath += ".tmp"; // modify so that there's no file at that path.
   // \c copy_file will use \c clonefile when applicable.
   if (std::error_code EC = sys::fs::copy_file(CopyFromPath, TmpPath))

--- a/llvm/lib/CodeGen/RegisterClassInfo.cpp
+++ b/llvm/lib/CodeGen/RegisterClassInfo.cpp
@@ -101,7 +101,7 @@ void RegisterClassInfo::runOnMachineFunction(const MachineFunction &mf,
           STI.ignoreCSRForAllocationOrder(mf, *AI);
   if (IgnoreCSRForAllocOrder != CSRHintsForAllocOrder) {
     Update = true;
-    IgnoreCSRForAllocOrder = CSRHintsForAllocOrder;
+    IgnoreCSRForAllocOrder = std::move(CSRHintsForAllocOrder);
   }
 
   RegCosts = TRI->getRegisterCosts(*MF);

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/LibraryScanner.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/LibraryScanner.cpp
@@ -274,7 +274,7 @@ void DylibSubstitutor::configure(StringRef LoaderPath) {
 
   SmallString<512> LoaderDir;
   if (LoaderPath.empty()) {
-    LoaderDir = ExecPath;
+    LoaderDir = std::move(ExecPath);
   } else {
     LoaderDir = LoaderPath.str();
     if (!sys::fs::is_directory(LoaderPath))

--- a/llvm/lib/IR/ConstantRange.cpp
+++ b/llvm/lib/IR/ConstantRange.cpp
@@ -1862,16 +1862,16 @@ ConstantRange::ashr(const ConstantRange &Other) const {
   APInt max, min;
   if (getSignedMin().isNonNegative()) {
     // Upper and Lower of LHS are non-negative.
-    min = PosMin;
-    max = PosMax;
+    min = std::move(PosMin);
+    max = std::move(PosMax);
   } else if (getSignedMax().isNegative()) {
     // Upper and Lower of LHS are negative.
-    min = NegMin;
-    max = NegMax;
+    min = std::move(NegMin);
+    max = std::move(NegMax);
   } else {
     // Upper is non-negative and Lower is negative.
-    min = NegMin;
-    max = PosMax;
+    min = std::move(NegMin);
+    max = std::move(PosMax);
   }
   return getNonEmpty(std::move(min), std::move(max));
 }

--- a/llvm/lib/IR/Value.cpp
+++ b/llvm/lib/IR/Value.cpp
@@ -779,7 +779,7 @@ const Value *Value::stripAndAccumulateConstantOffsets(
         APInt OldOffset = Offset;
         Offset = Offset.sadd_ov(GEPOffsetST, Overflow);
         if (Overflow) {
-          Offset = OldOffset;
+          Offset = std::move(OldOffset);
           return V;
         }
       }

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -2399,7 +2399,7 @@ public:
     UID = itostr(sys::Process::getProcessId());
     Jobs.resize((size_t)ThinLTONumTasks);
     this->ThinLTOTaskOffset = ThinLTOTaskOffset;
-    this->Triple = Triple;
+    this->Triple = std::move(Triple);
     this->Conf.Dtlto = 1;
   }
 

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -208,7 +208,7 @@ public:
 
   void addDirectiveHandler(StringRef Directive,
                            ExtensionDirectiveHandler Handler) override {
-    ExtensionDirectiveMap[Directive] = Handler;
+    ExtensionDirectiveMap[Directive] = std::move(Handler);
   }
 
   void addAliasForDirective(StringRef Directive, StringRef Alias) override {

--- a/llvm/lib/MC/MCParser/MasmParser.cpp
+++ b/llvm/lib/MC/MCParser/MasmParser.cpp
@@ -462,7 +462,7 @@ public:
 
   void addDirectiveHandler(StringRef Directive,
                            ExtensionDirectiveHandler Handler) override {
-    ExtensionDirectiveMap[Directive] = Handler;
+    ExtensionDirectiveMap[Directive] = std::move(Handler);
     DirectiveKindMap.try_emplace(Directive, DK_HANDLER_DIRECTIVE);
   }
 
@@ -4098,7 +4098,7 @@ bool MasmParser::parseDirectiveEnds(StringRef Name, SMLoc NameLoc) {
   // and the size of its largest field.
   Structure.Size = llvm::alignTo(
       Structure.Size, std::min(Structure.Alignment, Structure.AlignmentSize));
-  Structs[Name.lower()] = Structure;
+  Structs[Name.lower()] = std::move(Structure);
 
   if (parseEOL())
     return addErrorSuffix(" in ENDS directive");

--- a/llvm/lib/Support/APFixedPoint.cpp
+++ b/llvm/lib/Support/APFixedPoint.cpp
@@ -286,9 +286,9 @@ APFixedPoint APFixedPoint::mul(const APFixedPoint &Other,
                                                  .extOrTrunc(Wide);
   if (CommonFXSema.isSaturated()) {
     if (Result < Min)
-      Result = Min;
+      Result = std::move(Min);
     else if (Result > Max)
-      Result = Max;
+      Result = std::move(Max);
   } else {
     Overflowed = Result < Min || Result > Max;
   }
@@ -349,9 +349,9 @@ APFixedPoint APFixedPoint::div(const APFixedPoint &Other,
                                                  .extOrTrunc(Wide);
   if (CommonFXSema.isSaturated()) {
     if (Result < Min)
-      Result = Min;
+      Result = std::move(Min);
     else if (Result > Max)
-      Result = Max;
+      Result = std::move(Max);
   } else {
     Overflowed = Result < Min || Result > Max;
   }
@@ -385,9 +385,9 @@ APFixedPoint APFixedPoint::shl(unsigned Amt, bool *Overflow) const {
   APSInt Min = APFixedPoint::getMin(Sema).getValue().extOrTrunc(Wide);
   if (Sema.isSaturated()) {
     if (Result < Min)
-      Result = Min;
+      Result = std::move(Min);
     else if (Result > Max)
-      Result = Max;
+      Result = std::move(Max);
   } else {
     Overflowed = Result < Min || Result > Max;
   }

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -4975,7 +4975,7 @@ APFloat::opStatus DoubleAPFloat::multiply(const DoubleAPFloat &RHS,
   APFloat T = A;
   Status |= T.multiply(C, RM);
   if (!T.isFiniteNonZero()) {
-    Floats[0] = T;
+    Floats[0] = std::move(T);
     Floats[1].makeZero(/* Neg = */ false);
     return (opStatus)Status;
   }
@@ -5007,7 +5007,7 @@ APFloat::opStatus DoubleAPFloat::multiply(const DoubleAPFloat &RHS,
     // Floats[1] = (t - u) + tau
     Status |= T.subtract(U, RM);
     Status |= T.add(Tau, RM);
-    Floats[1] = T;
+    Floats[1] = std::move(T);
   }
   return (opStatus)Status;
 }

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -49161,20 +49161,20 @@ static SDValue combineSetCCAtomicArith(SDValue Cmp, X86::CondCode &CC,
     APInt IncComparison = Comparison + 1;
     if (IncComparison == NegAddend) {
       if (CC == X86::COND_A && !Comparison.isMaxValue()) {
-        Comparison = IncComparison;
+        Comparison = std::move(IncComparison);
         CC = X86::COND_AE;
       } else if (CC == X86::COND_LE && !Comparison.isMaxSignedValue()) {
-        Comparison = IncComparison;
+        Comparison = std::move(IncComparison);
         CC = X86::COND_L;
       }
     }
     APInt DecComparison = Comparison - 1;
     if (DecComparison == NegAddend) {
       if (CC == X86::COND_AE && !Comparison.isMinValue()) {
-        Comparison = DecComparison;
+        Comparison = std::move(DecComparison);
         CC = X86::COND_A;
       } else if (CC == X86::COND_L && !Comparison.isMinSignedValue()) {
-        Comparison = DecComparison;
+        Comparison = std::move(DecComparison);
         CC = X86::COND_LE;
       }
     }

--- a/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
@@ -1392,7 +1392,7 @@ static Value *simplifyTernarylogic(const IntrinsicInst &II,
       Res = Xor(Nor(A, B), C);
     break;
   case 0xaa:
-    Res = C;
+    Res = std::move(C);
     break;
   case 0xab:
     if (ABCIsConst)
@@ -1526,7 +1526,7 @@ static Value *simplifyTernarylogic(const IntrinsicInst &II,
       Res = Or(Xnor(A, B), And(B, C));
     break;
   case 0xcc:
-    Res = B;
+    Res = std::move(B);
     break;
   case 0xcd:
     if (ABCIsConst)
@@ -1668,7 +1668,7 @@ static Value *simplifyTernarylogic(const IntrinsicInst &II,
       Res = Nand(A, Nor(B, C));
     break;
   case 0xf0:
-    Res = A;
+    Res = std::move(A);
     break;
   case 0xf1:
     if (ABCIsConst)

--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -430,7 +430,7 @@ static OffsetResult collectOffsets(GEPOperator &GEP, const DataLayout &DL) {
     Result.BasePtr = InnerGEP->getPointerOperand();
     Result.ConstantOffset += ConstantOffset2;
     if (Result.VariableOffsets.size() == 0 && VariableOffsets2.size() == 1)
-      Result.VariableOffsets = VariableOffsets2;
+      Result.VariableOffsets = std::move(VariableOffsets2);
     Result.NW &= InnerGEP->getNoWrapFlags();
   }
   return Result;

--- a/llvm/lib/Transforms/Scalar/NewGVN.cpp
+++ b/llvm/lib/Transforms/Scalar/NewGVN.cpp
@@ -309,7 +309,7 @@ public:
   // Leader functions
   Value *getLeader() const { return RepLeader.first; }
   void setLeader(std::pair<Value *, unsigned int> Leader) {
-    RepLeader = Leader;
+    RepLeader = std::move(Leader);
   }
   const std::pair<Value *, unsigned int> &getNextLeader() const {
     return NextLeader;
@@ -318,10 +318,10 @@ public:
   bool addPossibleLeader(std::pair<Value *, unsigned int> LeaderPair) {
     if (LeaderPair.second < RepLeader.second) {
       NextLeader = RepLeader;
-      RepLeader = LeaderPair;
+      RepLeader = std::move(LeaderPair);
       return true;
     } else if (LeaderPair.second < NextLeader.second) {
-      NextLeader = LeaderPair;
+      NextLeader = std::move(LeaderPair);
     }
     return false;
   }

--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -2063,7 +2063,7 @@ void SCCPInstVisitor::handlePredicate(Instruction *I, Value *CopyOf,
     // a chained predicate, as the != x information is more likely to be
     // helpful in practice.
     if (!CopyOfCR.contains(NewCR) && CopyOfCR.getSingleMissingElement())
-      NewCR = CopyOfCR;
+      NewCR = std::move(CopyOfCR);
 
     // The new range is based on a branch condition. That guarantees that
     // neither of the compare operands can be undef in the branch targets,
@@ -2128,7 +2128,7 @@ void SCCPInstVisitor::handleCallResult(CallBase &CB) {
 
       // If Count <= MaxLanes, getvectorlength(Count, MaxLanes) = Count
       if (Count.icmp(CmpInst::ICMP_ULE, MaxLanes))
-        Result = Count;
+        Result = std::move(Count);
 
       Result = Result.truncate(II->getType()->getScalarSizeInBits());
       return (void)mergeInValue(ValueState[II], II,

--- a/llvm/tools/llvm-dwarfdump/Coverage.cpp
+++ b/llvm/tools/llvm-dwarfdump/Coverage.cpp
@@ -90,7 +90,7 @@ computeVariableCoverage(DWARFContext &DICtx, DWARFDie VariableDIE,
   }
 
   if (!Lines && ParentLines)
-    Lines = ParentLines;
+    Lines = std::move(ParentLines);
   else if (ParentLines)
     llvm::set_intersect(*Lines, *ParentLines);
 

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -2003,11 +2003,11 @@ void ELFDumper<ELFT>::loadDynamicTable() {
     if (!IsSecTableValid)
       reportUniqueWarning(
           "SHT_DYNAMIC dynamic table is invalid: PT_DYNAMIC will be used");
-    DynamicTable = FromPhdr;
+    DynamicTable = std::move(FromPhdr);
   } else {
     reportUniqueWarning(
         "PT_DYNAMIC dynamic table is invalid: SHT_DYNAMIC will be used");
-    DynamicTable = FromSec;
+    DynamicTable = std::move(FromSec);
   }
 
   parseDynamicTable();
@@ -2286,7 +2286,7 @@ template <typename ELFT> void ELFDumper<ELFT>::parseDynamicTable() {
   // without worrying about tag order.
   if (DynSymFromTable) {
     if (!DynSymRegion) {
-      DynSymRegion = DynSymFromTable;
+      DynSymRegion = std::move(DynSymFromTable);
     } else {
       DynSymRegion->Addr = DynSymFromTable->Addr;
       DynSymRegion->EntSize = DynSymFromTable->EntSize;


### PR DESCRIPTION
That's an automated patch generated from clang-tidy performance-use-std-move as a follow-up to #184136