### PR TITLE
[lld] Turn misc copy-assign to move-assign

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -868,7 +868,7 @@ void LinkerDriver::addWinSysRootLibSearchPaths() {
   llvm::StringSet<> noDefaultLibs;
   for (auto &iter : ctx.config.noDefaultLibs)
     noDefaultLibs.insert(findLib(iter.first()).lower());
-  ctx.config.noDefaultLibs = noDefaultLibs;
+  ctx.config.noDefaultLibs = std::move(noDefaultLibs);
 }
 
 // Parses LIB environment which contains a list of search paths.

--- a/lld/wasm/OutputSections.cpp
+++ b/lld/wasm/OutputSections.cpp
@@ -240,7 +240,7 @@ void CustomSection::finalizeInputSections() {
     return;
 
   mergedSection->finalizeContents();
-  inputSections = newSections;
+  inputSections = std::move(newSections);
 }
 
 void CustomSection::finalizeContents() {


### PR DESCRIPTION
That's an automated patch generated from clang-tidy performance-use-std-move as a follow-up to #184136