### PR TITLE
[clang-tools-extra] Turn misc copy-assign into move-assign

### DIFF
--- a/clang-tools-extra/clangd/Preamble.cpp
+++ b/clang-tools-extra/clangd/Preamble.cpp
@@ -689,7 +689,7 @@ buildPreamble(PathRef FileName, CompilerInvocation CI,
 
     Result->Macros = CapturedInfo.takeMacros();
     Result->Marks = CapturedInfo.takeMarks();
-    Result->StatCache = StatCache;
+    Result->StatCache = std::move(StatCache);
     Result->MainIsIncludeGuarded = CapturedInfo.isMainFileIncludeGuarded();
     // Move the options instead of copying them. The invocation doesn't need
     // them anymore.

--- a/clang-tools-extra/clangd/XRefs.cpp
+++ b/clang-tools-extra/clangd/XRefs.cpp
@@ -248,7 +248,7 @@ locateMacroReferent(const syntax::Token &TouchedIdentifier, ParsedAST &AST,
       LocatedSymbol Macro;
       Macro.Name = std::string(M->Name);
       Macro.PreferredDeclaration = *Loc;
-      Macro.Definition = Loc;
+      Macro.Definition = std::move(Loc);
       Macro.ID = getSymbolID(M->Name, M->Info, AST.getSourceManager());
       return Macro;
     }
@@ -1478,7 +1478,7 @@ maybeFindIncludeReferences(ParsedAST &AST, Position Pos,
   ReferencesResult::Reference Result;
   Result.Loc.range = rangeTillEOL(SM.getBufferData(SM.getMainFileID()),
                                   IncludeOnLine->HashOffset);
-  Result.Loc.uri = URIMainFile;
+  Result.Loc.uri = std::move(URIMainFile);
   Results.References.push_back(std::move(Result));
   return Results;
 }


### PR DESCRIPTION
That's an automated patch generated from clang-tidy performance-use-std-move as a follow-up to #184136