### PR TITLE
[libc] Replace check-libc with lit-based test execution

### DIFF
--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -1,10 +1,5 @@
-add_custom_target(check-libc)
 add_custom_target(libc-unit-tests)
 add_custom_target(libc-hermetic-tests)
-
-if (TARGET check-hdrgen)
-  add_dependencies(check-libc check-hdrgen)
-endif()
 
 add_custom_target(exhaustive-check-libc)
 add_custom_target(libc-long-running-tests)
@@ -31,10 +26,15 @@ configure_lit_site_cfg(
   "CMAKE_CROSSCOMPILING_EMULATOR"
 )
 
-add_lit_testsuite(check-libc-lit
+add_lit_testsuite(check-libc
   "Running libc tests via lit"
   ${LIBC_BUILD_DIR}/test
 )
+
+if (TARGET check-hdrgen)
+  add_dependencies(check-libc check-hdrgen)
+endif()
+
 
 if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
   add_dependencies(check-libc libc-unit-tests)

--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -38,12 +38,13 @@ endif()
 
 if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
   add_dependencies(check-libc libc-unit-tests)
-  add_dependencies(check-libc-lit libc-unit-tests-build)
+  add_dependencies(check-libc libc-unit-tests-build)
 endif()
 if(LIBC_ENABLE_HERMETIC_TESTS AND NOT LIBC_TEST_UNIT_TEST_ONLY)
   add_dependencies(check-libc libc-hermetic-tests)
-  add_dependencies(check-libc-lit libc-hermetic-tests-build)
+  add_dependencies(check-libc libc-hermetic-tests-build)
 endif()
+
 
 add_subdirectory(UnitTest)
 

--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -37,13 +37,12 @@ endif()
 
 
 if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
-  add_dependencies(check-libc libc-unit-tests)
   add_dependencies(check-libc libc-unit-tests-build)
 endif()
 if(LIBC_ENABLE_HERMETIC_TESTS AND NOT LIBC_TEST_UNIT_TEST_ONLY)
-  add_dependencies(check-libc libc-hermetic-tests)
   add_dependencies(check-libc libc-hermetic-tests-build)
 endif()
+
 
 
 add_subdirectory(UnitTest)

--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -35,15 +35,12 @@ if (TARGET check-hdrgen)
   add_dependencies(check-libc check-hdrgen)
 endif()
 
-
 if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
   add_dependencies(check-libc libc-unit-tests-build)
 endif()
 if(LIBC_ENABLE_HERMETIC_TESTS AND NOT LIBC_TEST_UNIT_TEST_ONLY)
   add_dependencies(check-libc libc-hermetic-tests-build)
 endif()
-
-
 
 add_subdirectory(UnitTest)
 

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_custom_target(libc_include_tests)
 add_dependencies(check-libc libc_include_tests-build)
 
-
 add_libc_test(
   assert_test
   SUITE

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_custom_target(libc_include_tests)
 add_dependencies(check-libc libc_include_tests)
-add_dependencies(check-libc-lit libc_include_tests-build)
 
 add_libc_test(
   assert_test

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_custom_target(libc_include_tests)
-add_dependencies(check-libc libc_include_tests)
+add_dependencies(check-libc libc_include_tests-build)
+
 
 add_libc_test(
   assert_test

--- a/libc/test/integration/CMakeLists.txt
+++ b/libc/test/integration/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_custom_target(libc-integration-tests)
 add_dependencies(check-libc libc-integration-tests-build)
 
-
 function(add_libc_integration_test_suite name)
   add_custom_target(${name})
   add_dependencies(libc-integration-tests ${name})

--- a/libc/test/integration/CMakeLists.txt
+++ b/libc/test/integration/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_custom_target(libc-integration-tests)
-add_dependencies(check-libc libc-integration-tests)
+add_dependencies(check-libc libc-integration-tests-build)
+
 
 function(add_libc_integration_test_suite name)
   add_custom_target(${name})

--- a/libc/test/integration/CMakeLists.txt
+++ b/libc/test/integration/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_custom_target(libc-integration-tests)
 add_dependencies(check-libc libc-integration-tests)
-add_dependencies(check-libc-lit libc-integration-tests-build)
 
 function(add_libc_integration_test_suite name)
   add_custom_target(${name})

--- a/libc/utils/libctest/format.py
+++ b/libc/utils/libctest/format.py
@@ -197,7 +197,6 @@ class LibcTest(lit.formats.ExecutableTest):
                 [test_path] + test_args, cwd=exec_dir, env=env
             )
 
-
         if not exit_code:
             return lit.Test.PASS, ""
 

--- a/libc/utils/libctest/format.py
+++ b/libc/utils/libctest/format.py
@@ -194,8 +194,9 @@ class LibcTest(lit.formats.ExecutableTest):
             )
         else:
             out, err, exit_code = lit.util.executeCommand(
-                [test_path] + extra_args, cwd=exec_dir, env=env
+                [test_path] + test_args, cwd=exec_dir, env=env
             )
+
 
         if not exit_code:
             return lit.Test.PASS, ""


### PR DESCRIPTION
Now that check-libc-lit has been validated alongside check-libc, make lit the default test runner by renaming check-libc-lit to check-libc. Remove the old CMake-driven check-libc custom target.