### PR TITLE
[MLIR][WasmSSA] Fix formatting of code blocks in WasmSSAOps.td (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/WasmSSA/IR/WasmSSAOps.td
+++ b/mlir/include/mlir/Dialect/WasmSSA/IR/WasmSSAOps.td
@@ -53,12 +53,12 @@ def WasmSSA_BlockOp : WasmSSA_BlockLikeOp<
   Example:
 
   ```mlir
-
   wasmssa.block {
 
     // instructions
 
   } > ^successor
+  ```
   }];
 }
 
@@ -72,10 +72,10 @@ def WasmSSA_LoopOp : WasmSSA_BlockLikeOp<
   Example:
 
   ```mlir
-
   wasmssa.loop {
 
   } > ^successor
+  ```
   }];
 }
 
@@ -99,7 +99,7 @@ def WasmSSA_BlockReturnOp : WasmSSA_Op<"block_return", [Terminator,
     Example:
 
     ```mlir
-      wasmssa.block_return
+    wasmssa.block_return
     ```
   }];
   let assemblyFormat = "($inputs^ `:` type($inputs))? attr-dict";
@@ -542,7 +542,7 @@ def WasmSSA_MemImportOp : WasmSSA_Op<"import_mem", [Symbol, ImportOpInterface]> 
      ```mlir
      // Import the memory `mem` from `my_module` as @mem_0
      wasmssa.import_mem "mem" from "my_module" as @mem_0 {limits = !wasmssa<limit[2:]>}
-    ```
+     ```
     }];
   let arguments = (ins SymbolNameAttr: $sym_name,
                      StrAttr: $moduleName,
@@ -582,7 +582,7 @@ def WasmSSA_TableImportOp : WasmSSA_Op<"import_table", [Symbol, ImportOpInterfac
      ```mlir
      // Import the table `table` from `my_module` as @table_0
      wasmssa.import_table "table" from "my_module" as @table_0 {type = !wasmssa<tabletype !wasmssa.funcref [2:]>}
-    ```
+     ```
     }];
   let arguments = (ins SymbolNameAttr: $sym_name,
                      StrAttr: $moduleName,
@@ -624,7 +624,7 @@ def WasmSSA_AddOp : WasmSSA_BinaryNumericalOp<"add",
 
      ```mlir
      %a = wasmssa.add %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_NumericType]>{}
 
@@ -634,7 +634,7 @@ def WasmSSA_AndOp : WasmSSA_BinaryNumericalOp<"and",
 
      ```mlir
      %a = wasmssa.and %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_NumericType]>{}
 
@@ -644,7 +644,7 @@ def WasmSSA_DivOp : WasmSSA_BinaryNumericalOp<"div",
 
      ```mlir
      %a = wasmssa.div %b %c : f32
-    ```
+     ```
     }],
     [WasmSSA_FPType]>{}
 
@@ -654,7 +654,7 @@ def WasmSSA_DivUIOp : WasmSSA_BinaryNumericalOp<"div_ui",
 
      ```mlir
      %a = wasmssa.div_ui %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -664,7 +664,7 @@ def WasmSSA_DivSIOp : WasmSSA_BinaryNumericalOp<"div_si",
 
      ```mlir
      %a = wasmssa.div_si %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -674,7 +674,7 @@ def WasmSSA_MulOp : WasmSSA_BinaryNumericalOp<"mul",
 
      ```mlir
      %a = wasmssa.mul %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_NumericType]>{}
 
@@ -684,7 +684,7 @@ def WasmSSA_OrOp : WasmSSA_BinaryNumericalOp<"or",
 
      ```mlir
      %a = wasmssa.or %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_NumericType]>{}
 
@@ -694,7 +694,7 @@ def WasmSSA_SubOp : WasmSSA_BinaryNumericalOp<"sub",
 
      ```mlir
      %a = wasmssa.sub %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_NumericType]>{}
 
@@ -704,7 +704,7 @@ def WasmSSA_RemUIOp : WasmSSA_BinaryNumericalOp<"rem_ui",
 
      ```mlir
      %a = wasmssa.rem_ui %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -714,7 +714,7 @@ def WasmSSA_RemSIOp : WasmSSA_BinaryNumericalOp<"rem_si",
 
      ```mlir
      %a = wasmssa.rem_si %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -724,7 +724,7 @@ def WasmSSA_XOrOp : WasmSSA_BinaryNumericalOp<"xor",
 
      ```mlir
      %a = wasmssa.xor %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_NumericType]>{}
 
@@ -734,7 +734,7 @@ def WasmSSA_MinOp : WasmSSA_BinaryNumericalOp<"min",
 
      ```mlir
      %a = wasmssa.min %b %c : f32
-    ```
+     ```
     }],
     [WasmSSA_FPType]>{}
 
@@ -744,7 +744,7 @@ def WasmSSA_MaxOp : WasmSSA_BinaryNumericalOp<"max",
 
      ```mlir
      %a = wasmssa.max %b %c : f32
-    ```
+     ```
     }],
     [WasmSSA_FPType]>{}
 
@@ -754,7 +754,7 @@ def WasmSSA_CopySignOp : WasmSSA_BinaryNumericalOp<"copysign",
 
      ```mlir
      %a = wasmssa.copysign %b %c : f32
-    ```
+     ```
     }],
     [WasmSSA_FPType]>{}
 
@@ -774,7 +774,7 @@ def WasmSSA_EqOp : WasmSSA_BinaryComparisonOp<"eq",
 
      ```mlir
      %a = wasmssa.eq %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_NumericType]>{}
 
@@ -784,7 +784,7 @@ def WasmSSA_NeOp : WasmSSA_BinaryComparisonOp<"ne",
 
      ```mlir
      %a = wasmssa.ne %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_NumericType]>{}
 
@@ -794,7 +794,7 @@ def WasmSSA_LtSIOp : WasmSSA_BinaryComparisonOp<"lt_si",
 
      ```mlir
      %a = wasmssa.lt_si %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -804,7 +804,7 @@ def WasmSSA_LtUIOp : WasmSSA_BinaryComparisonOp<"lt_ui",
 
      ```mlir
      %a = wasmssa.lt_ui %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -814,7 +814,7 @@ def WasmSSA_LeSIOp : WasmSSA_BinaryComparisonOp<"le_si",
 
      ```mlir
      %a = wasmssa.le_si %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -824,7 +824,7 @@ def WasmSSA_LeUIOp : WasmSSA_BinaryComparisonOp<"le_ui",
 
      ```mlir
      %a = wasmssa.le_ui %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -834,7 +834,7 @@ def WasmSSA_GtSIOp : WasmSSA_BinaryComparisonOp<"gt_si",
 
      ```mlir
      %a = wasmssa.gt_si %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -844,7 +844,7 @@ def WasmSSA_GtUIOp : WasmSSA_BinaryComparisonOp<"gt_ui",
 
      ```mlir
      %a = wasmssa.gt_ui %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -854,7 +854,7 @@ def WasmSSA_GeSIOp : WasmSSA_BinaryComparisonOp<"ge_si",
 
      ```mlir
      %a = wasmssa.ge_si %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -864,7 +864,7 @@ def WasmSSA_GeUIOp : WasmSSA_BinaryComparisonOp<"ge_ui",
 
      ```mlir
      %a = wasmssa.ge_ui %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_IntegerType]>{}
 
@@ -874,7 +874,7 @@ def WasmSSA_LtOp : WasmSSA_BinaryComparisonOp<"lt",
 
      ```mlir
      %a = wasmssa.lt %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_FPType]>{}
 
@@ -884,7 +884,7 @@ def WasmSSA_LeOp : WasmSSA_BinaryComparisonOp<"le",
 
      ```mlir
      %a = wasmssa.le %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_FPType]>{}
 
@@ -894,7 +894,7 @@ def WasmSSA_GtOp : WasmSSA_BinaryComparisonOp<"gt",
 
      ```mlir
      %a = wasmssa.gt %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_FPType]>{}
 
@@ -904,7 +904,7 @@ def WasmSSA_GeOp : WasmSSA_BinaryComparisonOp<"ge",
 
      ```mlir
      %a = wasmssa.ge %b %c : i32
-    ```
+     ```
     }],
     [WasmSSA_FPType]>{}
 
@@ -926,7 +926,7 @@ def WasmSSA_ShLOp : WasmSSA_ShiftRotateOp<"shl",
 
      ```mlir
      %a = wasmssa.shl %b by %c bits : i64
-    ```
+     ```
     }]
     >{}
 
@@ -942,7 +942,7 @@ def WasmSSA_ShRSOp : WasmSSA_ShiftRotateOp<"shr_s",
 
      ```mlir
      %a = wasmssa.shr_s %b by %c bits : i64
-    ```
+     ```
     }]
     >{}
 
@@ -958,7 +958,7 @@ def WasmSSA_ShRUOp : WasmSSA_ShiftRotateOp<"shr_u",
 
      ```mlir
      %a = wasmssa.shr_u %b by %c bits : i64
-    ```
+     ```
     }]
     >{}
 
@@ -972,7 +972,7 @@ def WasmSSA_RotlOp : WasmSSA_ShiftRotateOp<"rotl",
 
      ```mlir
      %a = wasmssa.rotl %b by %c bits : i64
-    ```
+     ```
     }]
     >{}
 
@@ -986,7 +986,7 @@ def WasmSSA_RotrOp : WasmSSA_ShiftRotateOp<"rotr",
 
      ```mlir
      %a = wasmssa.rotr %b by %c bits : i64
-    ```
+     ```
     }]
     >{}
 
@@ -1009,7 +1009,7 @@ def WasmSSA_ConvertUOp : WasmSSA_ConversionOp<"convert_u",
 
      ```mlir
      %a = wasmssa.convert_u %b : i32 to f64
-    ```
+     ```
     }],
     [WasmSSA_IntegerType],
     [WasmSSA_FPType]>{}
@@ -1022,7 +1022,7 @@ def WasmSSA_ConvertSOp : WasmSSA_ConversionOp<"convert_s",
 
      ```mlir
      %a = wasmssa.convert_s %b : i32 to f64
-    ```
+     ```
     }],
     [WasmSSA_IntegerType],
     [WasmSSA_FPType]>{}
@@ -1033,7 +1033,7 @@ def WasmSSA_DemoteOp : WasmSSA_ConversionOp<"demote",
 
      ```mlir
      %a = wasmssa.demote %b : f64 to f32
-    ```
+     ```
     }],
     [F64],
     [F32]>{}
@@ -1044,7 +1044,7 @@ def WasmSSA_ExtendSI32Op : WasmSSA_Op<"extend_i32_s">{
 
      ```mlir
      %a = wasmssa.extend_i32_s %b to i64
-    ```
+     ```
     }];
   let arguments = (ins I32:$input);
   let results = (outs I64:$result);
@@ -1057,7 +1057,7 @@ def WasmSSA_ExtendUI32Op : WasmSSA_Op<"extend_i32_u">{
 
      ```mlir
      %a = wasmssa.extend_i32_s %b to i64
-    ```
+     ```
     }];
   let arguments = (ins I32:$input);
   let results = (outs I64:$result);


### PR DESCRIPTION
The documentation for the wasmssa dialect has some issues, such as missing endings in some code blocks and misaligned code blocks, causing rendering problems. This PR fixes those issues.
