### PR TITLE
[CI][libsycl] Add libsycl precommit testing job

### DIFF
--- a/.github/workflows/sycl-tests.yml
+++ b/.github/workflows/sycl-tests.yml
@@ -32,7 +32,6 @@ jobs:
           variant: sccache
       - name: Build and Test
         run: |
-          mkdir build
           cmake -GNinja \
             -S llvm \
             -B build \

--- a/.github/workflows/sycl-tests.yml
+++ b/.github/workflows/sycl-tests.yml
@@ -1,0 +1,48 @@
+name: SYCL Tests
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'libsycl/**'
+      - '.github/workflows/sycl-tests.yml'
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  check_sycl:
+    if: github.repository_owner == 'llvm'
+    name: Test SYCL
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/llvm/ci-ubuntu-24.04:latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
+        with:
+          max-size: 2G
+          key: sycl-ubuntu-24.04
+          variant: sccache
+      - name: Build and Test
+        run: |
+          mkdir build
+          cmake -GNinja \
+            -S llvm \
+            -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+            -DLLVM_ENABLE_PROJECTS=clang \
+            -DLLVM_ENABLE_RUNTIMES="offload;openmp;libsycl" \
+            -DLLVM_TARGETS_TO_BUILD="host;SPIRV" \
+            -DLLVM_INCLUDE_SPIRV_TOOLS_TESTS=ON
+
+          ninja -C build check-sycl


### PR DESCRIPTION
We want to add some basic precommit CI for `libsycl`, similar to what we have for `SPIR-V`. 

Here it just builds `libsycl` and runs `check-sycl`, but only non-GPU tests will be run because this job is run on GitHub-hosted runners which don't have a GPU, so we will never run GPU tests in this CI job. Postcommit already runs SYCL GPU tests.

We have runtime GPU detection as part of the `check-sycl` lit setup so everything works fine.

Currently there is only one `check-sycl` test at all and it is a GPU test, so `check-sycl` is basically a no op, so this is de-facto build only.