### PR TITLE
[analyzer] Suppress optin.cplusplus.VirtualCall warnings in system headers

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/VirtualCallChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/VirtualCallChecker.cpp
@@ -118,6 +118,11 @@ void VirtualCallChecker::checkPreCall(const CallEvent &Call,
   if (!isVirtualCall(CE))
     return;
 
+  // Don't warn about virtual calls in system headers (e.g. libraries included
+  // via -isystem), as the user has no control over such code.
+  if (C.getSourceManager().isInSystemHeader(CE->getBeginLoc()))
+    return;
+
   const MemRegion *Reg = MC->getCXXThisVal().getAsRegion();
   const ObjectState *ObState = State->get<CtorDtorMap>(Reg);
   if (!ObState)

--- a/clang/test/Analysis/Inputs/virtualcall-system-header.h
+++ b/clang/test/Analysis/Inputs/virtualcall-system-header.h
@@ -1,0 +1,11 @@
+#pragma clang system_header
+
+struct SysBase {
+  virtual void shutdown() = 0;
+  virtual ~SysBase() = default;
+};
+
+struct SysService : SysBase {
+  void shutdown() override {}
+  ~SysService() override { shutdown(); } // no-warning
+};

--- a/clang/test/Analysis/virtualcall.cpp
+++ b/clang/test/Analysis/virtualcall.cpp
@@ -13,7 +13,7 @@
 
 // Verify no warnings for virtual calls in system headers.
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.VirtualCall \
-// RUN:                    -std=c++11 -verify=system %s
+// RUN:                    -std=c++11 -verify=system,impure %s
 // system-no-diagnostics
 
 #include "virtualcall.h"

--- a/clang/test/Analysis/virtualcall.cpp
+++ b/clang/test/Analysis/virtualcall.cpp
@@ -14,7 +14,6 @@
 // Verify no warnings for virtual calls in system headers.
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.VirtualCall \
 // RUN:                    -std=c++11 -verify=system,impure %s
-// system-no-diagnostics
 
 #include "virtualcall.h"
 #include "Inputs/virtualcall-system-header.h"

--- a/clang/test/Analysis/virtualcall.cpp
+++ b/clang/test/Analysis/virtualcall.cpp
@@ -11,7 +11,13 @@
 // RUN:                    -analyzer-checker=debug.ExprInspection \
 // RUN:                    -std=c++11 -verify=pure,impure -std=c++11 %s
 
+// Verify no warnings for virtual calls in system headers.
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.VirtualCall \
+// RUN:                    -std=c++11 -verify=system %s
+// system-no-diagnostics
+
 #include "virtualcall.h"
+#include "Inputs/virtualcall-system-header.h"
 
 void clang_analyzer_warnIfReached();
 


### PR DESCRIPTION
 Fixes #184178

The optin.cplusplus.VirtualCall checker reports warnings for virtual method calls during construction/destruction even when the call site is in a system header (included via -isystem). Users cannot fix such code and must resort to NOLINT suppressions.

Add a system header check in checkPreCall before emitting the report, consistent with how other checkers (e.g. MallocChecker) handle this.