### PR TITLE
[CIR] Implement function/call attribute parsing

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -72,6 +72,8 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getZeroCallUsedRegsAttrName() { return "zero_call_used_regs"; }
     static llvm::StringRef getSaveRegParamsAttrName() { return "save_reg_params"; }
     static llvm::StringRef getDefaultFuncAttrsAttrName() { return "default_func_attrs"; }
+    static llvm::StringRef getResAttrsAttrName() { return "res_attrs"; }
+    static llvm::StringRef getArgAttrsAttrName() { return "arg_attrs"; }
 
     void registerAttributes();
     void registerTypes();

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -828,7 +828,6 @@ static mlir::ParseResult parseCallCommon(mlir::OpAsmParser &parser,
   llvm::SmallVector<mlir::OpAsmParser::UnresolvedOperand, 4> ops;
   llvm::SMLoc opsLoc;
   mlir::FlatSymbolRefAttr calleeAttr;
-  llvm::ArrayRef<mlir::Type> allResultTypes;
 
   // If we cannot parse a string callee, it means this is an indirect call.
   if (!parser
@@ -878,15 +877,51 @@ static mlir::ParseResult parseCallCommon(mlir::OpAsmParser &parser,
   if (parser.parseColon())
     return ::mlir::failure();
 
-  mlir::FunctionType opsFnTy;
-  if (parser.parseType(opsFnTy))
+  SmallVector<Type> argTypes;
+  SmallVector<DictionaryAttr> argAttrs;
+  SmallVector<Type> resultTypes;
+  SmallVector<DictionaryAttr> resultAttrs;
+  if (call_interface_impl::parseFunctionSignature(parser, argTypes, argAttrs,
+                                                  resultTypes, resultAttrs))
     return mlir::failure();
 
-  allResultTypes = opsFnTy.getResults();
-  result.addTypes(allResultTypes);
+  if (resultTypes.size() > 1 || resultAttrs.size() > 1)
+    return parser.emitError(
+        parser.getCurrentLocation(),
+        "functions with multiple return types are not supported");
 
-  if (parser.resolveOperands(ops, opsFnTy.getInputs(), opsLoc, result.operands))
+  result.addTypes(resultTypes);
+
+  if (parser.resolveOperands(ops, argTypes, opsLoc, result.operands))
     return mlir::failure();
+
+  if (!resultAttrs.empty() && resultAttrs[0])
+    result.addAttribute(
+        CIRDialect::getResAttrsAttrName(),
+        mlir::ArrayAttr::get(parser.getContext(), {resultAttrs[0]}));
+
+  // ArrayAttr requires a vector of 'Attribute', so we have to do the conversion
+  // here into a separate collection.
+  llvm::SmallVector<Attribute> convertedArgAttrs;
+  bool argAttrsEmpty = true;
+
+  llvm::transform(argAttrs, std::back_inserter(convertedArgAttrs),
+                  [&](DictionaryAttr da) -> mlir::Attribute {
+                    if (da)
+                      argAttrsEmpty = false;
+                    return da;
+                  });
+
+  if (!argAttrsEmpty) {
+    llvm::ArrayRef argAttrsRef = convertedArgAttrs;
+    if (!calleeAttr) {
+      // Fixup for indirect calls, which get an extra entry in the 'args' for
+      // the indirect type, which doesn't get attributes.
+      argAttrsRef = argAttrsRef.drop_front();
+    }
+    result.addAttribute(CIRDialect::getArgAttrsAttrName(),
+                        mlir::ArrayAttr::get(parser.getContext(), argAttrsRef));
+  }
 
   return mlir::success();
 }
@@ -2006,6 +2041,7 @@ ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
   mlir::StringAttr inlineKindNameAttr = getInlineKindAttrName(state.name);
   mlir::StringAttr lambdaNameAttr = getLambdaAttrName(state.name);
   mlir::StringAttr noProtoNameAttr = getNoProtoAttrName(state.name);
+  mlir::StringAttr comdatNameAttr = getComdatAttrName(state.name);
   mlir::StringAttr visNameAttr = getSymVisibilityAttrName(state.name);
   mlir::StringAttr visibilityNameAttr = getGlobalVisibilityAttrName(state.name);
   mlir::StringAttr dsoLocalNameAttr = getDsoLocalAttrName(state.name);
@@ -2028,6 +2064,9 @@ ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
     state.addAttribute(lambdaNameAttr, parser.getBuilder().getUnitAttr());
   if (parser.parseOptionalKeyword(noProtoNameAttr).succeeded())
     state.addAttribute(noProtoNameAttr, parser.getBuilder().getUnitAttr());
+
+  if (parser.parseOptionalKeyword(comdatNameAttr).succeeded())
+    state.addAttribute(comdatNameAttr, parser.getBuilder().getUnitAttr());
 
   // Default to external linkage if no keyword is provided.
   state.addAttribute(getLinkageAttrNameString(),
@@ -2063,13 +2102,22 @@ ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
           resultAttrs))
     return failure();
   llvm::SmallVector<mlir::Type> argTypes;
-  for (OpAsmParser::Argument &arg : arguments)
+  llvm::SmallVector<mlir::Attribute> argAttrs;
+  bool argAttrsEmpty = true;
+  for (OpAsmParser::Argument &arg : arguments) {
     argTypes.push_back(arg.type);
+    // Add the 'empty' attribute anyway to make sure the arity matches, but we
+    // only want to 'set' the attribute at the top level if there is SOME data
+    // along the way.
+    argAttrs.push_back(arg.attrs);
+    if (arg.attrs)
+      argAttrsEmpty = false;
+  }
 
-  if (resultTypes.size() > 1) {
+  // These should be in sync anyway, but test both of them anyway.
+  if (resultTypes.size() > 1 || resultAttrs.size() > 1)
     return parser.emitError(
         loc, "functions with multiple return types are not supported");
-  }
 
   mlir::Type returnType =
       (resultTypes.empty() ? cir::VoidType::get(builder.getContext())
@@ -2078,8 +2126,18 @@ ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
   cir::FuncType fnType = cir::FuncType::get(argTypes, returnType, isVariadic);
   if (!fnType)
     return failure();
+
   state.addAttribute(getFunctionTypeAttrName(state.name),
                      TypeAttr::get(fnType));
+
+  if (!resultAttrs.empty() && resultAttrs[0])
+    state.addAttribute(
+        getResAttrsAttrName(state.name),
+        mlir::ArrayAttr::get(parser.getContext(), {resultAttrs[0]}));
+
+  if (!argAttrsEmpty)
+    state.addAttribute(getArgAttrsAttrName(state.name),
+                       mlir::ArrayAttr::get(parser.getContext(), argAttrs));
 
   bool hasAlias = false;
   mlir::StringAttr aliaseeNameAttr = getAliaseeAttrName(state.name);

--- a/clang/test/CIR/IR/func-attrs.cir
+++ b/clang/test/CIR/IR/func-attrs.cir
@@ -1,0 +1,77 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!s8i = !cir.int<s, 8>
+!u8i = !cir.int<u, 8>
+!void = !cir.void
+!rec_Struct = !cir.record<struct "Struct" padded {!u8i}>
+!rec_anon_struct = !cir.record<struct  {!s64i, !s64i}>
+
+cir.func no_inline dso_local @Func1(%arg0: !s32i {llvm.noundef}, %arg1: !cir.float {llvm.noundef}) -> (!cir.float {llvm.noundef}) {
+// CHECK: cir.func no_inline dso_local @Func1(%arg0: !s32i {llvm.noundef}, %arg1: !cir.float {llvm.noundef}) -> (!cir.float {llvm.noundef}) {
+  %ret = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["ret"] {alignment = 8 : i64}
+  %ret_load = cir.load %ret : !cir.ptr<!cir.float>, !cir.float
+  cir.return %ret_load : !cir.float
+}
+
+cir.func no_inline dso_local @Func2(%arg0: !s32i {llvm.noundef}, %arg1: !cir.float) -> (!cir.float {llvm.noundef}) {
+// CHECK: cir.func no_inline dso_local @Func2(%arg0: !s32i {llvm.noundef}, %arg1: !cir.float) -> (!cir.float {llvm.noundef}) {
+  %ret = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["ret"] {alignment = 8 : i64}
+  %ret_load = cir.load %ret : !cir.ptr<!cir.float>, !cir.float
+  cir.return %ret_load : !cir.float
+}
+
+cir.func no_inline dso_local @Func3(%arg0: !s32i, %arg1: !cir.float {llvm.noundef}) -> !cir.float {
+// CHECK: cir.func no_inline dso_local @Func3(%arg0: !s32i, %arg1: !cir.float {llvm.noundef}) -> !cir.float {
+  %ret = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["ret"] {alignment = 8 : i64}
+  %ret_load = cir.load %ret : !cir.ptr<!cir.float>, !cir.float
+  cir.return %ret_load : !cir.float
+}
+
+cir.func no_inline dso_local @Func4(%arg0: !s32i, %arg1: !cir.float) -> (!cir.float {llvm.noundef}) {
+// CHECK: cir.func no_inline dso_local @Func4(%arg0: !s32i, %arg1: !cir.float) -> (!cir.float {llvm.noundef}) {
+  %ret = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["ret"] {alignment = 8 : i64}
+  %ret_load = cir.load %ret : !cir.ptr<!cir.float>, !cir.float
+  cir.return %ret_load : !cir.float
+}
+
+cir.func no_inline dso_local @Func5(%arg0: !s32i, %arg1: !cir.float) -> !cir.float {
+// CHECK: cir.func no_inline dso_local @Func5(%arg0: !s32i, %arg1: !cir.float) -> !cir.float {
+  %ret = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["ret"] {alignment = 8 : i64}
+  %ret_load = cir.load %ret : !cir.ptr<!cir.float>, !cir.float
+  cir.return %ret_load : !cir.float
+}
+
+cir.func no_inline comdat linkonce_odr @MemFunc(%arg0: !cir.ptr<!rec_Struct> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, %arg1: !s32i {llvm.noundef}, %arg2: !cir.float {llvm.noundef}) -> (!cir.float {llvm.noundef}) {
+// CHECK: cir.func no_inline comdat linkonce_odr @MemFunc(%arg0: !cir.ptr<!rec_Struct> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, %arg1: !s32i {llvm.noundef}, %arg2: !cir.float {llvm.noundef}) -> (!cir.float {llvm.noundef}) {
+  %ret = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["ret"] {alignment = 8 : i64}
+  %ret_load = cir.load %ret : !cir.ptr<!cir.float>, !cir.float
+  cir.return %ret_load : !cir.float
+}
+
+cir.func @make_calls() {
+  %int = cir.const #cir.int<1> : !s32i  
+  %float = cir.cast int_to_float %int : !s32i -> !cir.float
+  cir.call @Func1(%int, %float) : (!s32i {llvm.noundef}, !cir.float {llvm.noundef}) -> (!cir.float {llvm.noundef})
+  // CHECK: cir.call @Func1(%{{.*}}, %{{.*}}) : (!s32i {llvm.noundef}, !cir.float {llvm.noundef}) -> (!cir.float {llvm.noundef})
+  cir.call @Func2(%int, %float) : (!s32i {llvm.noundef}, !cir.float) -> (!cir.float {llvm.noundef})
+  // CHECK: cir.call @Func2(%{{.*}}, %{{.*}}) : (!s32i {llvm.noundef}, !cir.float) -> (!cir.float {llvm.noundef})
+  cir.call @Func3(%int, %float) : (!s32i, !cir.float {llvm.noundef}) -> (!cir.float)
+  // CHECK: cir.call @Func3(%{{.*}}, %{{.*}}) : (!s32i, !cir.float {llvm.noundef}) -> !cir.float
+  cir.call @Func4(%int, %float) : (!s32i, !cir.float) -> (!cir.float {llvm.noundef})
+  // CHECK: cir.call @Func4(%{{.*}}, %{{.*}}) : (!s32i, !cir.float) -> (!cir.float {llvm.noundef})
+  cir.call @Func5(%int, %float) : (!s32i, !cir.float) -> (!cir.float)
+  // CHECK: cir.call @Func5(%{{.*}}, %{{.*}}) : (!s32i, !cir.float) -> !cir.float
+
+  %struct = cir.alloca !rec_Struct, !cir.ptr<!rec_Struct>, ["s"] {alignment = 1 : i64}
+  cir.call @MemFunc(%struct, %int, %float) : (!cir.ptr<!rec_Struct> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !s32i {llvm.noundef, llvm.hot}, !cir.float {llvm.noundef}) -> (!cir.float {llvm.noundef})
+  // CHECK: cir.call @MemFunc(%{{.*}}, %{{.*}}, %{{.*}}) : (!cir.ptr<!rec_Struct> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}, !s32i {llvm.hot, llvm.noundef}, !cir.float {llvm.noundef}) -> (!cir.float {llvm.noundef})
+
+  %fptr = cir.alloca !cir.ptr<!cir.func<(!s32i, !cir.float) -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<(!s32i, !cir.float) -> !s32i>>>, ["fp"] {alignment = 8 : i64}
+  %fptr_load = cir.load align(8) %fptr : !cir.ptr<!cir.ptr<!cir.func<(!s32i, !cir.float) -> !s32i>>>, !cir.ptr<!cir.func<(!s32i, !cir.float) -> !s32i>>
+  cir.call %fptr_load(%int, %float) : (!cir.ptr<!cir.func<(!s32i, !cir.float) -> !s32i>>, !s32i {llvm.noundef, llvm.hot}, !cir.float {llvm.noundef}) -> (!s32i {llvm.noundef})
+  // CHECK: cir.call %{{.*}}(%{{.*}}, %{{.*}}) : (!cir.ptr<!cir.func<(!s32i, !cir.float) -> !s32i>>, !s32i {llvm.hot, llvm.noundef}, !cir.float {llvm.noundef}) -> (!s32i {llvm.noundef})
+
+  cir.return
+}


### PR DESCRIPTION
It was brought to my attention that we didn't actually have a parsing test/parsing failed when attributes were included.  This patch adds the parsing functionality for attributes, and sets them correctly, plus makes sure we have a test that validates functions, member functions,
      calls, member calls, and indirect calls.