### PR TITLE
Revert "[CMake] Use keyword signature in two additional callsites (#1…

### DIFF
--- a/clang/cmake/modules/AddClang.cmake
+++ b/clang/cmake/modules/AddClang.cmake
@@ -217,7 +217,7 @@ endmacro()
 
 function(clang_target_link_libraries target type)
   if (TARGET obj.${target})
-    target_link_libraries(obj.${target} ${type} ${ARGN})
+    target_link_libraries(obj.${target} ${ARGN})
   endif()
 
   get_property(LLVM_DRIVER_TOOLS GLOBAL PROPERTY LLVM_DRIVER_TOOLS)

--- a/lld/tools/lld/CMakeLists.txt
+++ b/lld/tools/lld/CMakeLists.txt
@@ -13,7 +13,7 @@ export_executable_symbols_for_plugins(lld)
 
 function(lld_target_link_libraries target type)
   if (TARGET obj.${target})
-    target_link_libraries(obj.${target} ${type} ${ARGN})
+    target_link_libraries(obj.${target} ${ARGN})
   endif()
 
   get_property(LLVM_DRIVER_TOOLS GLOBAL PROPERTY LLVM_DRIVER_TOOLS)

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -636,12 +636,7 @@ function(llvm_add_library name)
     # Do add_dependencies(obj) later due to CMake issue 14747.
     list(APPEND objlibs ${obj_name})
 
-    # Bring in the target include directories and link info from our original
-    # target. target_link_libraries propagates transitive dependencies with
-    # proper SYSTEM include handling from IMPORTED targets.
-    # target_include_directories propagates include directories set directly on
-    # the target.
-    target_link_libraries(${obj_name} PRIVATE $<TARGET_PROPERTY:${name},LINK_LIBRARIES>)
+    # Bring in the target include directories from our original target.
     target_include_directories(${obj_name} PRIVATE $<TARGET_PROPERTY:${name},INCLUDE_DIRECTORIES>)
 
     set_target_properties(${obj_name} PROPERTIES FOLDER "${subproject_title}/Object Libraries")

--- a/llvm/cmake/modules/LLVM-Config.cmake
+++ b/llvm/cmake/modules/LLVM-Config.cmake
@@ -106,10 +106,7 @@ function(explicit_llvm_config executable)
   get_target_property(t ${executable} TYPE)
   if(t STREQUAL "STATIC_LIBRARY")
     target_link_libraries(${executable} INTERFACE ${LIBRARIES})
-  elseif(t STREQUAL "EXECUTABLE" OR
-         t STREQUAL "SHARED_LIBRARY" OR
-         t STREQUAL "MODULE_LIBRARY" OR
-         t STREQUAL "OBJECT_LIBRARY")
+  elseif(t STREQUAL "EXECUTABLE" OR t STREQUAL "SHARED_LIBRARY" OR t STREQUAL "MODULE_LIBRARY")
     target_link_libraries(${executable} PRIVATE ${LIBRARIES})
   else()
     # Use plain form for legacy user.

--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -769,7 +769,7 @@ endfunction(mlir_check_all_link_libraries)
 # used.
 function(mlir_target_link_libraries target type)
   if (TARGET obj.${target})
-    target_link_libraries(obj.${target} ${type} ${ARGN})
+    target_link_libraries(obj.${target} ${ARGN})
   endif()
 
   if (MLIR_LINK_MLIR_DYLIB)


### PR DESCRIPTION
…83889)"

This reverts commit 2342db00ab4d0305580814fb00f477b4b5cebec6.

Revert "[CMake] Propagate dependencies to OBJECT libraries in `add_llvm_library` (#183541)"

This reverts commit e3c045415ae52167e197d4a6ed4ad5a04e49423a.