### PR TITLE
Centralize prefetch target storage in MachineFunction.

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -488,6 +488,15 @@ public:
   void emitCallGraphSection(const MachineFunction &MF,
                             FunctionCallGraphInfo &FuncCGInfo);
 
+  /// Helper to emit a symbol for the prefetch target associated with the given
+  /// BBID and callsite index. The symbol is emitted as a label and its linkage
+  /// is set based on the function's linkage.
+  void emitPrefetchTargetSymbol(unsigned BaseID, unsigned CallsiteIndex);
+
+  /// Emit prefetch targets that were not mapped to any basic block. These
+  /// targets are emitted at the beginning of the function body.
+  void emitDanglingPrefetchTargets();
+
   void emitPseudoProbe(const MachineInstr &MI);
 
   void emitRemarksSection(remarks::RemarkStreamer &RS);

--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -71,14 +71,6 @@ struct CFGProfile {
   }
 };
 
-// The prefetch symbol is emitted immediately after the call of the given index,
-// in block `BBID` (First call has an index of 1). Zero callsite index means the
-// start of the block.
-struct CallsiteID {
-  UniqueBBID BBID;
-  unsigned CallsiteIndex;
-};
-
 // This struct represents the raw optimization profile for a function,
 // including CFG data (block and edge counts) and layout directives (clustering
 // and cloning paths).

--- a/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
@@ -238,6 +238,9 @@ bool parseVirtualRegisterReference(PerFunctionMIParsingState &PFS,
 bool parseStackObjectReference(PerFunctionMIParsingState &PFS, int &FI,
                                StringRef Src, SMDiagnostic &Error);
 
+bool parsePrefetchTarget(PerFunctionMIParsingState &PFS,
+                          CallsiteID &Target, StringRef Src,
+                          SMDiagnostic &Error);
 bool parseMDNode(PerFunctionMIParsingState &PFS, MDNode *&Node, StringRef Src,
                  SMDiagnostic &Error);
 

--- a/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
@@ -20,6 +20,7 @@
 #include "llvm/IR/TrackingMDRef.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/SMLoc.h"
+#include "llvm/Support/UniqueBBID.h"
 #include <map>
 #include <utility>
 

--- a/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
+++ b/llvm/include/llvm/CodeGen/MIRParser/MIParser.h
@@ -238,9 +238,8 @@ bool parseVirtualRegisterReference(PerFunctionMIParsingState &PFS,
 bool parseStackObjectReference(PerFunctionMIParsingState &PFS, int &FI,
                                StringRef Src, SMDiagnostic &Error);
 
-bool parsePrefetchTarget(PerFunctionMIParsingState &PFS,
-                          CallsiteID &Target, StringRef Src,
-                          SMDiagnostic &Error);
+bool parsePrefetchTarget(PerFunctionMIParsingState &PFS, CallsiteID &Target,
+                         StringRef Src, SMDiagnostic &Error);
 bool parseMDNode(PerFunctionMIParsingState &PFS, MDNode *&Node, StringRef Src,
                  SMDiagnostic &Error);
 

--- a/llvm/include/llvm/CodeGen/MIRYamlMapping.h
+++ b/llvm/include/llvm/CodeGen/MIRYamlMapping.h
@@ -831,6 +831,7 @@ struct MachineFunction {
   MachineJumpTable JumpTableInfo;
   std::vector<StringValue> MachineMetadataNodes;
   std::vector<CalledGlobal> CalledGlobals;
+  std::vector<FlowStringValue> PrefetchTargets;
   BlockStringValue Body;
 };
 
@@ -892,6 +893,10 @@ template <> struct MappingTraits<MachineFunction> {
     if (!YamlIO.outputting() || !MF.CalledGlobals.empty())
       YamlIO.mapOptional("calledGlobals", MF.CalledGlobals,
                          std::vector<CalledGlobal>());
+    if (!YamlIO.outputting() || !MF.PrefetchTargets.empty())
+      YamlIO.mapOptional("prefetch-targets", MF.PrefetchTargets,
+                         std::vector<FlowStringValue>());
+
     YamlIO.mapOptional("body", MF.Body, BlockStringValue());
   }
 };

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -231,12 +231,6 @@ private:
   /// is only computed once and is cached.
   mutable MCSymbol *CachedMCSymbol = nullptr;
 
-  /// Contains the callsite indices in this block that are targets of code
-  /// prefetching. The index `i` specifies the `i`th call, with zero
-  /// representing the beginning of the block and 1 representing the first call.
-  /// Must be in ascending order and without duplicates.
-  SmallVector<unsigned> PrefetchTargetCallsiteIndexes;
-
   /// Cached MCSymbol for this block (used if IsEHContTarget).
   mutable MCSymbol *CachedEHContMCSymbol = nullptr;
 
@@ -717,14 +711,6 @@ public:
   void setIsEndSection(bool V = true) { IsEndSection = V; }
 
   std::optional<UniqueBBID> getBBID() const { return BBID; }
-
-  const SmallVector<unsigned> &getPrefetchTargetCallsiteIndexes() const {
-    return PrefetchTargetCallsiteIndexes;
-  }
-
-  void setPrefetchTargetCallsiteIndexes(const SmallVector<unsigned> &V) {
-    PrefetchTargetCallsiteIndexes = V;
-  }
 
   /// Returns the section ID of this basic block.
   MBBSectionID getSectionID() const { return SectionID; }

--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -32,6 +32,7 @@
 #include "llvm/Support/AtomicOrdering.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Recycler.h"
+#include "llvm/Support/UniqueBBID.h"
 #include "llvm/Target/TargetOptions.h"
 #include <bitset>
 #include <cassert>
@@ -422,6 +423,10 @@ class LLVM_ABI MachineFunction {
   /// Section Type for basic blocks, only relevant with basic block sections.
   BasicBlockSection BBSectionsType = BasicBlockSection::None;
 
+  /// Prefetch targets in this function. This includes targets that are mapped
+  /// to a basic block and dangling targets.
+  DenseMap<UniqueBBID, SmallVector<unsigned>> PrefetchTargets;
+
   /// List of C++ TypeInfo used.
   std::vector<const GlobalValue *> TypeInfos;
 
@@ -763,6 +768,14 @@ public:
   }
 
   void setBBSectionsType(BasicBlockSection V) { BBSectionsType = V; }
+
+  void setPrefetchTargets(const DenseMap<UniqueBBID, SmallVector<unsigned>> &V) {
+    PrefetchTargets = V;
+  }
+
+  const DenseMap<UniqueBBID, SmallVector<unsigned>> &getPrefetchTargets() const {
+    return PrefetchTargets;
+  }
 
   /// Assign IsBeginSection IsEndSection fields for basic blocks in this
   /// function.

--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -769,11 +769,13 @@ public:
 
   void setBBSectionsType(BasicBlockSection V) { BBSectionsType = V; }
 
-  void setPrefetchTargets(const DenseMap<UniqueBBID, SmallVector<unsigned>> &V) {
+  void
+  setPrefetchTargets(const DenseMap<UniqueBBID, SmallVector<unsigned>> &V) {
     PrefetchTargets = V;
   }
 
-  const DenseMap<UniqueBBID, SmallVector<unsigned>> &getPrefetchTargets() const {
+  const DenseMap<UniqueBBID, SmallVector<unsigned>> &
+  getPrefetchTargets() const {
     return PrefetchTargets;
   }
 

--- a/llvm/include/llvm/Support/UniqueBBID.h
+++ b/llvm/include/llvm/Support/UniqueBBID.h
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Unique fixed ID assigned to basic blocks upon their creation.
+// This file contains a structure that uniquely identifies a basic block within
+// a function.
 //
 //===----------------------------------------------------------------------===//
 
@@ -24,21 +25,31 @@ struct UniqueBBID {
   unsigned CloneID;
 };
 
+// The prefetch symbol is emitted immediately after the call of the given index,
+// in block `BBID` (First call has an index of 1). Zero callsite index means the
+// start of the block.
+struct CallsiteID {
+  UniqueBBID BBID;
+  unsigned CallsiteIndex;
+};
+
 // Provides DenseMapInfo for UniqueBBID.
 template <> struct DenseMapInfo<UniqueBBID> {
   static inline UniqueBBID getEmptyKey() {
     unsigned EmptyKey = DenseMapInfo<unsigned>::getEmptyKey();
     return UniqueBBID{EmptyKey, EmptyKey};
   }
+
   static inline UniqueBBID getTombstoneKey() {
     unsigned TombstoneKey = DenseMapInfo<unsigned>::getTombstoneKey();
     return UniqueBBID{TombstoneKey, TombstoneKey};
   }
+
   static unsigned getHashValue(const UniqueBBID &Val) {
-    std::pair<unsigned, unsigned> PairVal =
-        std::make_pair(Val.BaseID, Val.CloneID);
-    return DenseMapInfo<std::pair<unsigned, unsigned>>::getHashValue(PairVal);
+    return DenseMapInfo<unsigned>::getHashValue(Val.BaseID) ^
+           DenseMapInfo<unsigned>::getHashValue(Val.CloneID);
   }
+
   static bool isEqual(const UniqueBBID &LHS, const UniqueBBID &RHS) {
     return DenseMapInfo<unsigned>::isEqual(LHS.BaseID, RHS.BaseID) &&
            DenseMapInfo<unsigned>::isEqual(LHS.CloneID, RHS.CloneID);

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2024,8 +2024,8 @@ void AsmPrinter::emitPrefetchTargetSymbol(unsigned BaseID,
   SmallString<128> FunctionName;
   getNameWithPrefix(FunctionName, &MF->getFunction());
   MCSymbol *PrefetchTargetSymbol = OutContext.getOrCreateSymbol(
-      "__llvm_prefetch_target_" + FunctionName + "_" +
-      Twine(BaseID) + "_" + Twine(CallsiteIndex));
+      "__llvm_prefetch_target_" + FunctionName + "_" + Twine(BaseID) + "_" +
+      Twine(CallsiteIndex));
   // If the function is weak-linkage it may be replaced by a strong
   // version, in which case the prefetch targets should also be replaced.
   OutStreamer->emitSymbolAttribute(

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2024,8 +2024,8 @@ void AsmPrinter::emitPrefetchTargetSymbol(unsigned BaseID,
   SmallString<128> FunctionName;
   getNameWithPrefix(FunctionName, &MF->getFunction());
   MCSymbol *PrefetchTargetSymbol = OutContext.getOrCreateSymbol(
-      Twine("__llvm_prefetch_target_") + FunctionName + Twine("_") +
-      Twine(BaseID) + Twine("_") + Twine(CallsiteIndex));
+      "__llvm_prefetch_target_" + FunctionName + "_" +
+      Twine(BaseID) + "_" + Twine(CallsiteIndex));
   // If the function is weak-linkage it may be replaced by a strong
   // version, in which case the prefetch targets should also be replaced.
   OutStreamer->emitSymbolAttribute(

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2021,9 +2021,11 @@ void AsmPrinter::handleCallsiteForCallgraph(
 /// BBID and callsite index.
 void AsmPrinter::emitPrefetchTargetSymbol(unsigned BaseID,
                                           unsigned CallsiteIndex) {
+  SmallString<128> FunctionName;
+  getNameWithPrefix(FunctionName, &MF->getFunction());
   MCSymbol *PrefetchTargetSymbol = OutContext.getOrCreateSymbol(
-      Twine("__llvm_prefetch_target_") + MF->getName() + Twine("_") +
-      Twine(BaseID) + Twine("_") + Twine(static_cast<unsigned>(CallsiteIndex)));
+      Twine("__llvm_prefetch_target_") + FunctionName + Twine("_") +
+      Twine(BaseID) + Twine("_") + Twine(CallsiteIndex));
   // If the function is weak-linkage it may be replaced by a strong
   // version, in which case the prefetch targets should also be replaced.
   OutStreamer->emitSymbolAttribute(
@@ -2034,18 +2036,18 @@ void AsmPrinter::emitPrefetchTargetSymbol(unsigned BaseID,
 
 /// Emit dangling prefetch targets that were not mapped to any basic block.
 void AsmPrinter::emitDanglingPrefetchTargets() {
-  const auto &MFPrefetchTargets = MF->getPrefetchTargets();
+  const DenseMap<UniqueBBID, SmallVector<unsigned>> &MFPrefetchTargets = MF->getPrefetchTargets();
   if (MFPrefetchTargets.empty())
     return;
   DenseSet<UniqueBBID> MFBBIDs;
-  for (auto &MBB : *MF)
-    if (auto BBID = MBB.getBBID())
+  for (const MachineBasicBlock &MBB : *MF)
+    if (std::optional<UniqueBBID> BBID = MBB.getBBID())
       MFBBIDs.insert(*BBID);
 
   for (const auto &[BBID, CallsiteIndexes] : MFPrefetchTargets) {
     if (MFBBIDs.contains(BBID))
       continue;
-    for (auto CallsiteIndex : CallsiteIndexes)
+    for (unsigned CallsiteIndex : CallsiteIndexes)
       emitPrefetchTargetSymbol(BBID.BaseID, CallsiteIndex);
   }
 }

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2036,7 +2036,8 @@ void AsmPrinter::emitPrefetchTargetSymbol(unsigned BaseID,
 
 /// Emit dangling prefetch targets that were not mapped to any basic block.
 void AsmPrinter::emitDanglingPrefetchTargets() {
-  const DenseMap<UniqueBBID, SmallVector<unsigned>> &MFPrefetchTargets = MF->getPrefetchTargets();
+  const DenseMap<UniqueBBID, SmallVector<unsigned>> &MFPrefetchTargets =
+      MF->getPrefetchTargets();
   if (MFPrefetchTargets.empty())
     return;
   DenseSet<UniqueBBID> MFBBIDs;

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2020,7 +2020,7 @@ void AsmPrinter::handleCallsiteForCallgraph(
 /// Helper to emit a symbol for the prefetch target associated with the given
 /// BBID and callsite index.
 void AsmPrinter::emitPrefetchTargetSymbol(unsigned BaseID,
-                                         unsigned CallsiteIndex) {
+                                          unsigned CallsiteIndex) {
   MCSymbol *PrefetchTargetSymbol = OutContext.getOrCreateSymbol(
       Twine("__llvm_prefetch_target_") + MF->getName() + Twine("_") +
       Twine(BaseID) + Twine("_") + Twine(static_cast<unsigned>(CallsiteIndex)));

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2017,6 +2017,39 @@ void AsmPrinter::handleCallsiteForCallgraph(
   }
 }
 
+/// Helper to emit a symbol for the prefetch target associated with the given
+/// BBID and callsite index.
+void AsmPrinter::emitPrefetchTargetSymbol(unsigned BaseID,
+                                         unsigned CallsiteIndex) {
+  MCSymbol *PrefetchTargetSymbol = OutContext.getOrCreateSymbol(
+      Twine("__llvm_prefetch_target_") + MF->getName() + Twine("_") +
+      Twine(BaseID) + Twine("_") + Twine(static_cast<unsigned>(CallsiteIndex)));
+  // If the function is weak-linkage it may be replaced by a strong
+  // version, in which case the prefetch targets should also be replaced.
+  OutStreamer->emitSymbolAttribute(
+      PrefetchTargetSymbol,
+      MF->getFunction().isWeakForLinker() ? MCSA_Weak : MCSA_Global);
+  OutStreamer->emitLabel(PrefetchTargetSymbol);
+}
+
+/// Emit dangling prefetch targets that were not mapped to any basic block.
+void AsmPrinter::emitDanglingPrefetchTargets() {
+  const auto &MFPrefetchTargets = MF->getPrefetchTargets();
+  if (MFPrefetchTargets.empty())
+    return;
+  DenseSet<UniqueBBID> MFBBIDs;
+  for (auto &MBB : *MF)
+    if (auto BBID = MBB.getBBID())
+      MFBBIDs.insert(*BBID);
+
+  for (const auto &[BBID, CallsiteIndexes] : MFPrefetchTargets) {
+    if (MFBBIDs.contains(BBID))
+      continue;
+    for (auto CallsiteIndex : CallsiteIndexes)
+      emitPrefetchTargetSymbol(BBID.BaseID, CallsiteIndex);
+  }
+}
+
 /// EmitFunctionBody - This method emits the body and trailer for a
 /// function.
 void AsmPrinter::emitFunctionBody() {
@@ -2063,34 +2096,30 @@ void AsmPrinter::emitFunctionBody() {
 
   FunctionCallGraphInfo FuncCGInfo;
   const auto &CallSitesInfoMap = MF->getCallSitesInfo();
+
+  emitDanglingPrefetchTargets();
+
+  const auto &MFPrefetchTargets = MF->getPrefetchTargets();
   for (auto &MBB : *MF) {
     // Print a label for the basic block.
     emitBasicBlockStart(MBB);
     DenseMap<StringRef, unsigned> MnemonicCounts;
 
-    // Helper to emit a symbol for the prefetch target associated with the given
-    // callsite index in the current MBB.
-    auto EmitPrefetchTargetSymbol = [&](unsigned CallsiteIndex) {
-      MCSymbol *PrefetchTargetSymbol = OutContext.getOrCreateSymbol(
-          Twine("__llvm_prefetch_target_") + MF->getName() + Twine("_") +
-          Twine(MBB.getBBID()->BaseID) + Twine("_") +
-          Twine(static_cast<unsigned>(CallsiteIndex)));
-      // If the function is weak-linkage it may be replaced by a strong
-      // version, in which case the prefetch targets should also be replaced.
-      OutStreamer->emitSymbolAttribute(
-          PrefetchTargetSymbol,
-          MF->getFunction().isWeakForLinker() ? MCSA_Weak : MCSA_Global);
-      OutStreamer->emitLabel(PrefetchTargetSymbol);
-    };
-    SmallVector<unsigned> PrefetchTargets =
-        MBB.getPrefetchTargetCallsiteIndexes();
-    auto PrefetchTargetIt = PrefetchTargets.begin();
+    const SmallVector<unsigned> *PrefetchTargets = nullptr;
+    if (auto BBID = MBB.getBBID()) {
+      auto R = MFPrefetchTargets.find(*BBID);
+      if (R != MFPrefetchTargets.end())
+        PrefetchTargets = &R->second;
+    }
+    auto PrefetchTargetIt =
+        PrefetchTargets ? PrefetchTargets->begin() : nullptr;
+    auto PrefetchTargetEnd = PrefetchTargets ? PrefetchTargets->end() : nullptr;
     unsigned LastCallsiteIndex = 0;
 
     for (auto &MI : MBB) {
-      if (PrefetchTargetIt != PrefetchTargets.end() &&
+      if (PrefetchTargetIt != PrefetchTargetEnd &&
           *PrefetchTargetIt == LastCallsiteIndex) {
-        EmitPrefetchTargetSymbol(*PrefetchTargetIt);
+        emitPrefetchTargetSymbol(MBB.getBBID()->BaseID, *PrefetchTargetIt);
         ++PrefetchTargetIt;
       }
 
@@ -2247,10 +2276,9 @@ void AsmPrinter::emitFunctionBody() {
       for (auto &Handler : Handlers)
         Handler->endInstruction();
     }
-    // Emit the last prefetch target in case the last instruction was a call.
-    if (PrefetchTargetIt != PrefetchTargets.end() &&
-        *PrefetchTargetIt == LastCallsiteIndex) {
-      EmitPrefetchTargetSymbol(*PrefetchTargetIt);
+    // Emit the remaining prefetch targets for this block.
+    while (PrefetchTargetIt != PrefetchTargetEnd) {
+      emitPrefetchTargetSymbol(MBB.getBBID()->BaseID, *PrefetchTargetIt);
       ++PrefetchTargetIt;
     }
 

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2100,6 +2100,8 @@ void AsmPrinter::emitFunctionBody() {
   FunctionCallGraphInfo FuncCGInfo;
   const auto &CallSitesInfoMap = MF->getCallSitesInfo();
 
+  // Dangling targets are not mapped to any blocks and must be emitted at the
+  // beginning of the function.
   emitDanglingPrefetchTargets();
 
   const auto &MFPrefetchTargets = MF->getPrefetchTargets();
@@ -2279,7 +2281,8 @@ void AsmPrinter::emitFunctionBody() {
       for (auto &Handler : Handlers)
         Handler->endInstruction();
     }
-    // Emit the remaining prefetch targets for this block.
+    // Emit the remaining prefetch targets for this block. This includes
+    // nonexisting callsite indexes.
     while (PrefetchTargetIt != PrefetchTargetEnd) {
       emitPrefetchTargetSymbol(MBB.getBBID()->BaseID, *PrefetchTargetIt);
       ++PrefetchTargetIt;

--- a/llvm/lib/CodeGen/InsertCodePrefetch.cpp
+++ b/llvm/lib/CodeGen/InsertCodePrefetch.cpp
@@ -17,6 +17,7 @@
 /// prefetch instruction from any module.
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -79,12 +80,7 @@ bool InsertCodePrefetch::runOnMachineFunction(MachineFunction &MF) {
     llvm::sort(V);
     V.erase(llvm::unique(V), V.end());
   }
-  for (auto &MBB : MF) {
-    auto R = PrefetchTargetsByBBID.find(*MBB.getBBID());
-    if (R == PrefetchTargetsByBBID.end())
-      continue;
-    MBB.setPrefetchTargetCallsiteIndexes(R->second);
-  }
+  MF.setPrefetchTargets(PrefetchTargetsByBBID);
   return false;
 }
 

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -3747,19 +3747,19 @@ bool llvm::parseVirtualRegisterReference(PerFunctionMIParsingState &PFS,
   return MIParser(PFS, Error, Src).parseStandaloneVirtualRegister(Info);
 }
 
-bool llvm::parseStackObjectReference(PerFunctionMIParsingState &PFS,
-                                      int &FI, StringRef Src,
-                                      SMDiagnostic &Error) {
+bool llvm::parseStackObjectReference(PerFunctionMIParsingState &PFS, int &FI,
+                                     StringRef Src, SMDiagnostic &Error) {
   return MIParser(PFS, Error, Src).parseStandaloneStackObject(FI);
 }
 
 bool llvm::parsePrefetchTarget(PerFunctionMIParsingState &PFS,
-                                CallsiteID &Target, StringRef Src,
-                                SMDiagnostic &Error) {
+                               CallsiteID &Target, StringRef Src,
+                               SMDiagnostic &Error) {
   return MIParser(PFS, Error, Src).parsePrefetchTarget(Target);
 }
-bool llvm::parseMDNode(PerFunctionMIParsingState &PFS,
-                        MDNode *&Node, StringRef Src, SMDiagnostic &Error) {  return MIParser(PFS, Error, Src).parseStandaloneMDNode(Node);
+bool llvm::parseMDNode(PerFunctionMIParsingState &PFS, MDNode *&Node,
+                       StringRef Src, SMDiagnostic &Error) {
+  return MIParser(PFS, Error, Src).parseStandaloneMDNode(Node);
 }
 
 bool llvm::parseMachineMetadata(PerFunctionMIParsingState &PFS, StringRef Src,

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -512,6 +512,7 @@ public:
   bool parseSectionID(std::optional<MBBSectionID> &SID);
   bool parseBBID(std::optional<UniqueBBID> &BBID);
   bool parseCallFrameSize(unsigned &CallFrameSize);
+  bool parsePrefetchTarget(CallsiteID &Target);
   bool parseOperandsOffset(MachineOperand &Op);
   bool parseIRValue(const Value *&V);
   bool parseMemoryOperandFlag(MachineMemOperand::Flags &Flags);
@@ -678,17 +679,32 @@ bool MIParser::parseSectionID(std::optional<MBBSectionID> &SID) {
 
 // Parse Machine Basic Block ID.
 bool MIParser::parseBBID(std::optional<UniqueBBID> &BBID) {
-  assert(Token.is(MIToken::kw_bb_id));
+  if (Token.isNot(MIToken::kw_bb_id))
+    return error("expected 'bb_id'");
   lex();
   unsigned BaseID = 0;
   unsigned CloneID = 0;
-  if (getUnsigned(BaseID))
-    return error("Unknown BB ID");
-  lex();
-  if (Token.is(MIToken::IntegerLiteral)) {
-    if (getUnsigned(CloneID))
-      return error("Unknown Clone ID");
+  if (Token.is(MIToken::FloatingPointLiteral)) {
+    StringRef S = Token.range();
+    auto Parts = S.split('.');
+    if (Parts.first.getAsInteger(10, BaseID) ||
+        Parts.second.getAsInteger(10, CloneID))
+      return error("Unknown BB ID");
     lex();
+  } else {
+    if (getUnsigned(BaseID))
+      return error("Unknown BB ID");
+    lex();
+    if (Token.is(MIToken::comma) || Token.is(MIToken::dot)) {
+      lex();
+      if (getUnsigned(CloneID))
+        return error("Unknown Clone ID");
+      lex();
+    } else if (Token.is(MIToken::IntegerLiteral)) {
+      if (getUnsigned(CloneID))
+        return error("Unknown Clone ID");
+      lex();
+    }
   }
   BBID = {BaseID, CloneID};
   return false;
@@ -704,6 +720,17 @@ bool MIParser::parseCallFrameSize(unsigned &CallFrameSize) {
   CallFrameSize = Value;
   lex();
   return false;
+}
+
+bool MIParser::parsePrefetchTarget(CallsiteID &Target) {
+  lex();
+  std::optional<UniqueBBID> BBID;
+  if (parseBBID(BBID))
+    return true;
+  Target.BBID = *BBID;
+  if (expectAndConsume(MIToken::comma))
+    return true;
+  return getUnsigned(Target.CallsiteIndex);
 }
 
 bool MIParser::parseBasicBlockDefinition(
@@ -3721,14 +3748,18 @@ bool llvm::parseVirtualRegisterReference(PerFunctionMIParsingState &PFS,
 }
 
 bool llvm::parseStackObjectReference(PerFunctionMIParsingState &PFS,
-                                     int &FI, StringRef Src,
-                                     SMDiagnostic &Error) {
+                                      int &FI, StringRef Src,
+                                      SMDiagnostic &Error) {
   return MIParser(PFS, Error, Src).parseStandaloneStackObject(FI);
 }
 
+bool llvm::parsePrefetchTarget(PerFunctionMIParsingState &PFS,
+                                CallsiteID &Target, StringRef Src,
+                                SMDiagnostic &Error) {
+  return MIParser(PFS, Error, Src).parsePrefetchTarget(Target);
+}
 bool llvm::parseMDNode(PerFunctionMIParsingState &PFS,
-                       MDNode *&Node, StringRef Src, SMDiagnostic &Error) {
-  return MIParser(PFS, Error, Src).parseStandaloneMDNode(Node);
+                        MDNode *&Node, StringRef Src, SMDiagnostic &Error) {  return MIParser(PFS, Error, Src).parseStandaloneMDNode(Node);
 }
 
 bool llvm::parseMachineMetadata(PerFunctionMIParsingState &PFS, StringRef Src,

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -115,6 +115,12 @@ public:
   bool initializeMachineFunction(const yaml::MachineFunction &YamlMF,
                                  MachineFunction &MF);
 
+  bool initializeCallSiteInfo(PerFunctionMIParsingState &PFS,
+                              const yaml::MachineFunction &YamlMF);
+
+  bool initializePrefetchTargets(PerFunctionMIParsingState &PFS,
+                                 const yaml::MachineFunction &YamlMF);
+
   bool parseRegisterInfo(PerFunctionMIParsingState &PFS,
                          const yaml::MachineFunction &YamlMF);
 
@@ -128,9 +134,6 @@ public:
       PerFunctionMIParsingState &PFS,
       const std::vector<yaml::SaveRestorePointEntry> &YamlSRPoints,
       llvm::SaveRestorePoints &SaveRestorePoints);
-
-  bool initializeCallSiteInfo(PerFunctionMIParsingState &PFS,
-                              const yaml::MachineFunction &YamlMF);
 
   bool parseCalleeSavedRegister(PerFunctionMIParsingState &PFS,
                                 std::vector<CalleeSavedInfo> &CSIInfo,
@@ -586,6 +589,8 @@ MIRParserImpl::initializeMachineFunction(const yaml::MachineFunction &YamlMF,
   PerFunctionMIParsingState PFS(MF, SM, IRSlots, *Target);
   if (parseRegisterInfo(PFS, YamlMF))
     return true;
+  if (initializePrefetchTargets(PFS, YamlMF))
+    return true;
   if (!YamlMF.Constants.empty()) {
     auto *ConstantPool = MF.getConstantPool();
     assert(ConstantPool && "Constant pool must be created");
@@ -671,11 +676,29 @@ MIRParserImpl::initializeMachineFunction(const yaml::MachineFunction &YamlMF,
   if (parseCalledGlobals(PFS, MF, YamlMF))
     return true;
 
+  if (initializePrefetchTargets(PFS, YamlMF))
+    return true;
+
   setupDebugValueTracking(MF, PFS, YamlMF);
 
   MF.getSubtarget().mirFileLoaded(MF);
 
   MF.verify(nullptr, nullptr, &errs());
+  return false;
+}
+
+bool MIRParserImpl::initializePrefetchTargets(
+    PerFunctionMIParsingState &PFS, const yaml::MachineFunction &YamlMF) {
+  MachineFunction &MF = PFS.MF;
+  SMDiagnostic Error;
+  DenseMap<UniqueBBID, SmallVector<unsigned>> Targets;
+  for (const auto &YamlTarget : YamlMF.PrefetchTargets) {
+    CallsiteID Target;
+    if (llvm::parsePrefetchTarget(PFS, Target, YamlTarget.Value, Error))
+      return error(Error, YamlTarget.SourceRange);
+    Targets[Target.BBID].push_back(Target.CallsiteIndex);
+  }
+  MF.setPrefetchTargets(Targets);
   return false;
 }
 

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -168,11 +168,12 @@ static void convertMachineMetadataNodes(yaml::MachineFunction &YMF,
                                         const MachineFunction &MF,
                                         MachineModuleSlotTracker &MST);
 static void convertCalledGlobals(yaml::MachineFunction &YMF,
-                                 const MachineFunction &MF,
-                                 MachineModuleSlotTracker &MST);
+                                  const MachineFunction &MF,
+                                  MachineModuleSlotTracker &MST);
+static void convertPrefetchTargets(yaml::MachineFunction &YMF,
+                                   const MachineFunction &MF);
 
-static void printMF(raw_ostream &OS, MFGetterFnT Fn,
-                    const MachineFunction &MF) {
+static void printMF(raw_ostream &OS, MFGetterFnT Fn,                    const MachineFunction &MF) {
   MFPrintState State(std::move(Fn), MF);
 
   State.RegisterMaskIds = initRegisterMaskIds(MF);
@@ -241,6 +242,8 @@ static void printMF(raw_ostream &OS, MFGetterFnT Fn,
   convertMachineMetadataNodes(YamlMF, MF, MST);
 
   convertCalledGlobals(YamlMF, MF, MST);
+
+  convertPrefetchTargets(YamlMF, MF);
 
   yaml::Output Out(OS);
   if (!SimplifyMIR)
@@ -597,6 +600,19 @@ static void convertCalledGlobals(yaml::MachineFunction &YMF,
                return std::tie(A.CallSite.BlockNum, A.CallSite.Offset) <
                       std::tie(B.CallSite.BlockNum, B.CallSite.Offset);
              });
+}
+
+static void convertPrefetchTargets(yaml::MachineFunction &YMF,
+                                   const MachineFunction &MF) {
+  for (const auto &[BBID, CallsiteIndexes] : MF.getPrefetchTargets()) {
+    for (auto CallsiteIndex : CallsiteIndexes) {
+      std::string Str;
+      raw_string_ostream StrOS(Str);
+      StrOS << "bb_id " << BBID.BaseID << ", " << BBID.CloneID << ", "
+            << CallsiteIndex;
+      YMF.PrefetchTargets.push_back(yaml::FlowStringValue(Str));
+    }
+  }
 }
 
 static void convertMCP(yaml::MachineFunction &MF,

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -168,12 +168,13 @@ static void convertMachineMetadataNodes(yaml::MachineFunction &YMF,
                                         const MachineFunction &MF,
                                         MachineModuleSlotTracker &MST);
 static void convertCalledGlobals(yaml::MachineFunction &YMF,
-                                  const MachineFunction &MF,
-                                  MachineModuleSlotTracker &MST);
+                                 const MachineFunction &MF,
+                                 MachineModuleSlotTracker &MST);
 static void convertPrefetchTargets(yaml::MachineFunction &YMF,
                                    const MachineFunction &MF);
 
-static void printMF(raw_ostream &OS, MFGetterFnT Fn,                    const MachineFunction &MF) {
+static void printMF(raw_ostream &OS, MFGetterFnT Fn,
+                    const MachineFunction &MF) {
   MFPrintState State(std::move(Fn), MF);
 
   State.RegisterMaskIds = initRegisterMaskIds(MF);

--- a/llvm/test/CodeGen/MIR/Generic/prefetch-targets-error.mir
+++ b/llvm/test/CodeGen/MIR/Generic/prefetch-targets-error.mir
@@ -1,13 +1,13 @@
 # RUN: split-file %s %t
-# RUN: not llc -run-pass=none -o /dev/null %t/missing-bb-id.mir 2>&1 | FileCheck %s --check-prefix=MISSING-BB-ID
-# RUN: not llc -run-pass=none -o /dev/null %t/missing-comma.mir 2>&1 | FileCheck %s --check-prefix=MISSING-COMMA
-# RUN: not llc -run-pass=none -o /dev/null %t/missing-index.mir 2>&1 | FileCheck %s --check-prefix=MISSING-INDEX
-# RUN: not llc -run-pass=none -o /dev/null %t/invalid-index.mir 2>&1 | FileCheck %s --check-prefix=INVALID-INDEX
+# RUN: not llc -run-pass=none -o --filetype=null %t/missing-bb-id.mir 2>&1 | FileCheck %s --check-prefix=MISSING-BB-ID
+# RUN: not llc -run-pass=none -o --filetype=null %t/missing-comma.mir 2>&1 | FileCheck %s --check-prefix=MISSING-COMMA
+# RUN: not llc -run-pass=none -o --filetype=null %t/missing-index.mir 2>&1 | FileCheck %s --check-prefix=MISSING-INDEX
+# RUN: not llc -run-pass=none -o --filetype=null %t/invalid-index.mir 2>&1 | FileCheck %s --check-prefix=INVALID-INDEX
 
 # MISSING-BB-ID: {{.*}}missing-bb-id.mir:3:22: expected 'bb_id'
 # MISSING-COMMA: {{.*}}missing-comma.mir:3:33: expected ','
-# MISSING-INDEX: {{.*}}missing-index.mir:3:22: 
-# INVALID-INDEX: {{.*}}invalid-index.mir:3:22: 
+# MISSING-INDEX: {{.*}}missing-index.mir:3:22:
+# INVALID-INDEX: {{.*}}invalid-index.mir:3:22:
 
 #--- missing-bb-id.mir
 ---

--- a/llvm/test/CodeGen/MIR/Generic/prefetch-targets-error.mir
+++ b/llvm/test/CodeGen/MIR/Generic/prefetch-targets-error.mir
@@ -1,0 +1,43 @@
+# RUN: split-file %s %t
+# RUN: not llc -run-pass=none -o /dev/null %t/missing-bb-id.mir 2>&1 | FileCheck %s --check-prefix=MISSING-BB-ID
+# RUN: not llc -run-pass=none -o /dev/null %t/missing-comma.mir 2>&1 | FileCheck %s --check-prefix=MISSING-COMMA
+# RUN: not llc -run-pass=none -o /dev/null %t/missing-index.mir 2>&1 | FileCheck %s --check-prefix=MISSING-INDEX
+# RUN: not llc -run-pass=none -o /dev/null %t/invalid-index.mir 2>&1 | FileCheck %s --check-prefix=INVALID-INDEX
+
+# MISSING-BB-ID: {{.*}}missing-bb-id.mir:3:22: expected 'bb_id'
+# MISSING-COMMA: {{.*}}missing-comma.mir:3:33: expected ','
+# MISSING-INDEX: {{.*}}missing-index.mir:3:22: 
+# INVALID-INDEX: {{.*}}invalid-index.mir:3:22: 
+
+#--- missing-bb-id.mir
+---
+name:            test
+prefetch-targets: [ '0, 0, 1' ]
+body:             |
+  bb.0:
+    RET 0
+...
+#--- missing-comma.mir
+---
+name:            test
+prefetch-targets: [ 'bb_id 0, 0 1' ]
+body:             |
+  bb.0:
+    RET 0
+...
+#--- missing-index.mir
+---
+name:            test
+prefetch-targets: [ 'bb_id 0, 0,' ]
+body:             |
+  bb.0:
+    RET 0
+...
+#--- invalid-index.mir
+---
+name:            test
+prefetch-targets: [ 'bb_id 0, 0, a' ]
+body:             |
+  bb.0:
+    RET 0
+...

--- a/llvm/test/CodeGen/MIR/Generic/prefetch-targets.mir
+++ b/llvm/test/CodeGen/MIR/Generic/prefetch-targets.mir
@@ -1,0 +1,13 @@
+# RUN: llc -run-pass=none -o - %s | FileCheck %s
+
+...
+---
+name:            test
+prefetch-targets: [ 'bb_id 0, 0, 1', 'bb_id 1, 0, 2' ]
+body:             |
+  bb.0:
+    RET 0
+...
+
+# CHECK: name: test
+# CHECK: prefetch-targets: [ bb_id 0, 0, 1, bb_id 1, 0, 2 ]

--- a/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
@@ -8,6 +8,7 @@
 ; RUN: echo 't 1,1' >> %t
 ; RUN: echo 't 2,1' >> %t
 ; RUN: echo 't 3,0' >> %t
+; RUN: echo 't 3,1' >> %t
 ; RUN: echo 'f bar' >> %t
 ; RUN: echo 't 0,0' >> %t
 ; RUN: echo 't 21,1' >> %t
@@ -44,12 +45,16 @@ end:                                             ; preds = %11, %9
 ; CHECK:      .LBB0_3:
 ; CHECK-NEXT:   .globl	__llvm_prefetch_target_foo_3_0
 ; CHECK-NEXT: __llvm_prefetch_target_foo_3_0:
+; CHECK:        .globl	__llvm_prefetch_target_foo_3_1
+; CHECK-NEXT: __llvm_prefetch_target_foo_3_1:
 }
 
 define weak i32 @bar() nounwind {
   %call = call i32 @baz()
   ret i32 %call
 ; CHECK:      bar:
+; CHECK-NEXT:   .weak __llvm_prefetch_target_bar_21_1
+; CHECK-NEXT: __llvm_prefetch_target_bar_21_1:
 ; CHECK-NEXT:   .weak __llvm_prefetch_target_bar_0_0
 ; CHECK-NEXT: __llvm_prefetch_target_bar_0_0:
 ; CHECK:        callq baz@PLT


### PR DESCRIPTION
### Prefetch Symbol Resolution

Based on this [suggestion](https://discourse.llvm.org/t/rfc-code-prefetch-insertion/88668/29?u=rlavaee), we must identify if a prefetch target is defined in the current module to avoid **undefined symbol errors**. Since this occurs during sequential **CodeGen**, we must rely on function names rather than IR Module APIs.

**Key Changes:**
* **`MachineFunction` Integration:** Added a `PrefetchTargets` field (with serialization) to track all targets associated with a function.
* **Guaranteed Emission:** All prefetch targets are now emitted regardless of basic block or callsite index matches to ensure the symbol exists.
* **Fallback Placement:** Targets with non-matching callsite indices are emitted at the end of the block to resolve the reference.