### PR TITLE
[HIP] Fix wrong triple being passed to offload-bundler

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9439,8 +9439,12 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     }
   }
 
-  CmdArgs.push_back(
-      Args.MakeArgString("--host-triple=" + getToolChain().getTripleString()));
+  if (const llvm::Triple *AuxTriple = getToolChain().getAuxTriple())
+    CmdArgs.push_back(
+        Args.MakeArgString("--host-triple=" + AuxTriple->normalize()));
+  else
+    CmdArgs.push_back(Args.MakeArgString("--host-triple=" +
+                                         getToolChain().getTripleString()));
 
   // CMake hack, suppress passing verbose arguments for the special-case HIP
   // non-RDC mode compilation. This confuses default CMake implicit linker

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9441,7 +9441,7 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (const llvm::Triple *AuxTriple = getToolChain().getAuxTriple())
     CmdArgs.push_back(
-        Args.MakeArgString("--host-triple=" + AuxTriple->normalize()));
+        Args.MakeArgString("--host-triple=" + AuxTriple->getTriple()));
   else
     CmdArgs.push_back(Args.MakeArgString("--host-triple=" +
                                          getToolChain().getTripleString()));

--- a/clang/test/Driver/hip-toolchain-no-rdc.hip
+++ b/clang/test/Driver/hip-toolchain-no-rdc.hip
@@ -107,6 +107,7 @@
 // NEW-SAME: "--image=file=[[OBJ_DEV_A_900]],triple=amdgcn-amd-amdhsa,arch=gfx900,kind=hip"
 
 // NEW: [[WRAPPER:".*clang-linker-wrapper]]"
+// NEW-SAME: "--host-triple=x86_64-unknown-linux-gnu"
 // NEW-SAME: "--emit-fatbin-only"
 // NEW-SAME: "-o" "[[HIPFB_A:.*.hipfb]]" "[[PACKAGE_A]]"
 


### PR DESCRIPTION
Summary:
I made a previous fix that stopped us from hard-coding x64 host in the
HIP fatbinaries we made. However, this then triggered this failure where
we were passing the wrong host triple. Now we will use the aux-triple
for offloading toolchains.
