### PR TITLE
[lldb] Use UnimplementedError for GetSDKFromDebugInfo

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -453,8 +453,10 @@ public:
   ///          a conflicting combination of SDKs when parsing the CUs
   ///          (e.g., a public and internal SDK).
   virtual llvm::Expected<std::pair<XcodeSDK, bool>>
-  GetSDKPathFromDebugInfo(Module & /*module*/) {
-    return llvm::make_error<UnimplementedError>();
+  GetSDKPathFromDebugInfo(Module &module) {
+    return llvm::make_error<UnimplementedError>(
+        llvm::formatv("{0} not implemented for '{1}' platform.",
+                      LLVM_PRETTY_FUNCTION, GetName()));
   }
 
   /// Returns the full path of the most appropriate SDK for the
@@ -468,7 +470,7 @@ public:
   ///          Xcode SDK.
   virtual llvm::Expected<std::string>
   ResolveSDKPathFromDebugInfo(Module &module) {
-    return llvm::createStringError(
+    return llvm::make_error<UnimplementedError>(
         llvm::formatv("{0} not implemented for '{1}' platform.",
                       LLVM_PRETTY_FUNCTION, GetName()));
   }
@@ -480,7 +482,9 @@ public:
   /// \returns A parsed XcodeSDK object if successful, an Error otherwise.
   virtual llvm::Expected<XcodeSDK>
   GetSDKPathFromDebugInfo(CompileUnit & /*unit*/) {
-    return llvm::make_error<UnimplementedError>();
+    return llvm::make_error<UnimplementedError>(
+        llvm::formatv("{0} not implemented for '{1}' platform.",
+                      LLVM_PRETTY_FUNCTION, GetName()));
   }
 
   /// Returns the full path of the most appropriate SDK for the
@@ -493,7 +497,7 @@ public:
   ///          Xcode SDK.
   virtual llvm::Expected<std::string>
   ResolveSDKPathFromDebugInfo(CompileUnit &unit) {
-    return llvm::createStringError(
+    return llvm::make_error<UnimplementedError>(
         llvm::formatv("{0} not implemented for '{1}' platform.",
                       LLVM_PRETTY_FUNCTION, GetName()));
   }

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -27,6 +27,7 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/Timeout.h"
+#include "lldb/Utility/UnimplementedError.h"
 #include "lldb/Utility/UserIDResolver.h"
 #include "lldb/Utility/XcodeSDK.h"
 #include "lldb/lldb-private-forward.h"
@@ -452,10 +453,8 @@ public:
   ///          a conflicting combination of SDKs when parsing the CUs
   ///          (e.g., a public and internal SDK).
   virtual llvm::Expected<std::pair<XcodeSDK, bool>>
-  GetSDKPathFromDebugInfo(Module &module) {
-    return llvm::createStringError(
-        llvm::formatv("{0} not implemented for '{1}' platform.",
-                      LLVM_PRETTY_FUNCTION, GetName()));
+  GetSDKPathFromDebugInfo(Module & /*module*/) {
+    return llvm::make_error<UnimplementedError>();
   }
 
   /// Returns the full path of the most appropriate SDK for the
@@ -478,11 +477,10 @@ public:
   ///
   /// \param[in] unit The CU
   ///
-  /// \returns A parsed XcodeSDK object if successful, an Error otherwise. 
-  virtual llvm::Expected<XcodeSDK> GetSDKPathFromDebugInfo(CompileUnit &unit) {
-    return llvm::createStringError(
-        llvm::formatv("{0} not implemented for '{1}' platform.",
-                      LLVM_PRETTY_FUNCTION, GetName()));
+  /// \returns A parsed XcodeSDK object if successful, an Error otherwise.
+  virtual llvm::Expected<XcodeSDK>
+  GetSDKPathFromDebugInfo(CompileUnit & /*unit*/) {
+    return llvm::make_error<UnimplementedError>();
   }
 
   /// Returns the full path of the most appropriate SDK for the

--- a/lldb/include/lldb/Utility/UnimplementedError.h
+++ b/lldb/include/lldb/Utility/UnimplementedError.h
@@ -14,10 +14,21 @@
 
 namespace lldb_private {
 class UnimplementedError : public llvm::ErrorInfo<UnimplementedError> {
+  std::string m_message;
+
 public:
   static char ID;
 
-  void log(llvm::raw_ostream &OS) const override { OS << "Not implemented"; }
+  UnimplementedError() = default;
+  explicit UnimplementedError(std::string message)
+      : m_message(std::move(message)) {}
+
+  void log(llvm::raw_ostream &OS) const override {
+    if (!m_message.empty())
+      OS << m_message;
+    else
+      OS << "Not implemented";
+  }
 
   std::error_code convertToErrorCode() const override {
     return llvm::errc::not_supported;


### PR DESCRIPTION
We can now differentiate unimplemented errors from actual errors that may be useful to users.