### PR TITLE
[WebAssembly][FastISel] Call materializeLoadStoreOperands in load fold

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -1306,6 +1306,7 @@ bool WebAssemblyFastISel::tryToFoldLoadIntoMI(MachineInstr *MI, unsigned OpNo,
   if (!computeAddress(LI->getPointerOperand(), Addr))
     return false;
 
+  materializeLoadStoreOperands(Addr);
   Register ResultReg = MI->getOperand(0).getReg();
   MachineInstrBuilder MIB = BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD,
                                     TII.get(NewOpc), ResultReg);

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -156,6 +156,7 @@ private:
   void materializeLoadStoreOperands(Address &Addr);
   void addLoadStoreOperands(const Address &Addr, const MachineInstrBuilder &MIB,
                             MachineMemOperand *MMO);
+  bool emitLoad(Register ResultReg, unsigned Opc, const LoadInst *LoadInst);
   unsigned maskI1Value(unsigned Reg, const Value *V);
   unsigned getRegForI1Value(const Value *V, const BasicBlock *BB, bool &Not);
   unsigned zeroExtendToI32(unsigned Reg, const Value *V,
@@ -428,6 +429,20 @@ void WebAssemblyFastISel::addLoadStoreOperands(const Address &Addr,
     MIB.addFrameIndex(Addr.getFI());
 
   MIB.addMemOperand(MMO);
+}
+
+bool WebAssemblyFastISel::emitLoad(Register ResultReg, unsigned Opc,
+                                   const LoadInst *Load) {
+  Address Addr;
+  if (!computeAddress(Load->getPointerOperand(), Addr))
+    return false;
+
+  materializeLoadStoreOperands(Addr);
+  auto MIB =
+      BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD, TII.get(Opc), ResultReg);
+  addLoadStoreOperands(Addr, MIB, createMachineMemOperandFor(Load));
+
+  return true;
 }
 
 unsigned WebAssemblyFastISel::maskI1Value(unsigned Reg, const Value *V) {
@@ -1302,15 +1317,10 @@ bool WebAssemblyFastISel::tryToFoldLoadIntoMI(MachineInstr *MI, unsigned OpNo,
       WebAssembly::INSTRUCTION_LIST_END)
     return false;
 
-  Address Addr;
-  if (!computeAddress(LI->getPointerOperand(), Addr))
+  Register ResultReg = MI->getOperand(0).getReg();
+  if (!emitLoad(ResultReg, NewOpc, LI))
     return false;
 
-  materializeLoadStoreOperands(Addr);
-  Register ResultReg = MI->getOperand(0).getReg();
-  MachineInstrBuilder MIB = BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD,
-                                    TII.get(NewOpc), ResultReg);
-  addLoadStoreOperands(Addr, MIB, createMachineMemOperandFor(LI));
   MachineBasicBlock::iterator Iter(MI);
   removeDeadCode(Iter, std::next(Iter));
   return true;
@@ -1323,10 +1333,6 @@ bool WebAssemblyFastISel::selectLoad(const Instruction *I) {
   if (!WebAssembly::isDefaultAddressSpace(Load->getPointerAddressSpace()))
     return false;
   if (!Subtarget->hasSIMD128() && Load->getType()->isVectorTy())
-    return false;
-
-  Address Addr;
-  if (!computeAddress(Load->getPointerOperand(), Addr))
     return false;
 
   // TODO: Fold a following sign-/zero-extend into the load instruction.
@@ -1364,13 +1370,9 @@ bool WebAssemblyFastISel::selectLoad(const Instruction *I) {
     return false;
   }
 
-  materializeLoadStoreOperands(Addr);
-
   Register ResultReg = createResultReg(RC);
-  auto MIB =
-      BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD, TII.get(Opc), ResultReg);
-
-  addLoadStoreOperands(Addr, MIB, createMachineMemOperandFor(Load));
+  if (!emitLoad(ResultReg, Opc, Load))
+    return false;
 
   updateValueMap(Load, ResultReg);
   return true;

--- a/llvm/test/CodeGen/WebAssembly/load-ext.ll
+++ b/llvm/test/CodeGen/WebAssembly/load-ext.ll
@@ -10,8 +10,8 @@
 
 ; Test that extending loads are assembled properly.
 
-@gv8 = hidden global i8 0, align 1
-@gv16 = hidden global i16 0, align 1
+@gv8 = global i8 0
+@gv16 = global i16 0
 
 define i32 @global_sext_i8_i32() {
 ; WASM32-DAG-LABEL: global_sext_i8_i32:
@@ -87,28 +87,28 @@ define i32 @global_sext_i16_i32() {
 ; WASM32-DAG:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM32-DAG-NEXT:  # %bb.0:
 ; WASM32-DAG-NEXT:    i32.const $push0=, 0
-; WASM32-DAG-NEXT:    i32.load16_s $push1=, gv16($pop0):p2align=0
+; WASM32-DAG-NEXT:    i32.load16_s $push1=, gv16($pop0)
 ; WASM32-DAG-NEXT:    return $pop1
 ;
 ; WASM32-DAG-MVP-LABEL: global_sext_i16_i32:
 ; WASM32-DAG-MVP:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM32-DAG-MVP-NEXT:  # %bb.0:
 ; WASM32-DAG-MVP-NEXT:    i32.const $push0=, 0
-; WASM32-DAG-MVP-NEXT:    i32.load16_s $push1=, gv16($pop0):p2align=0
+; WASM32-DAG-MVP-NEXT:    i32.load16_s $push1=, gv16($pop0)
 ; WASM32-DAG-MVP-NEXT:    return $pop1
 ;
 ; WASM32-FAST-LABEL: global_sext_i16_i32:
 ; WASM32-FAST:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM32-FAST-NEXT:  # %bb.0:
 ; WASM32-FAST-NEXT:    i32.const $push1=, 0
-; WASM32-FAST-NEXT:    i32.load16_s $push0=, gv16($pop1):p2align=0
+; WASM32-FAST-NEXT:    i32.load16_s $push0=, gv16($pop1)
 ; WASM32-FAST-NEXT:    return $pop0
 ;
 ; WASM32-FAST-MVP-LABEL: global_sext_i16_i32:
 ; WASM32-FAST-MVP:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
 ; WASM32-FAST-MVP-NEXT:    i32.const $push[[P0:[0-9]+]]=, 0
-; WASM32-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]]):p2align=0
+; WASM32-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]])
 ; WASM32-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 16
 ; WASM32-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
 ; WASM32-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 16
@@ -119,28 +119,28 @@ define i32 @global_sext_i16_i32() {
 ; WASM64-DAG:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM64-DAG-NEXT:  # %bb.0:
 ; WASM64-DAG-NEXT:    i64.const $push0=, 0
-; WASM64-DAG-NEXT:    i32.load16_s $push1=, gv16($pop0):p2align=0
+; WASM64-DAG-NEXT:    i32.load16_s $push1=, gv16($pop0)
 ; WASM64-DAG-NEXT:    return $pop1
 ;
 ; WASM64-DAG-MVP-LABEL: global_sext_i16_i32:
 ; WASM64-DAG-MVP:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM64-DAG-MVP-NEXT:  # %bb.0:
 ; WASM64-DAG-MVP-NEXT:    i64.const $push0=, 0
-; WASM64-DAG-MVP-NEXT:    i32.load16_s $push1=, gv16($pop0):p2align=0
+; WASM64-DAG-MVP-NEXT:    i32.load16_s $push1=, gv16($pop0)
 ; WASM64-DAG-MVP-NEXT:    return $pop1
 ;
 ; WASM64-FAST-LABEL: global_sext_i16_i32:
 ; WASM64-FAST:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM64-FAST-NEXT:  # %bb.0:
 ; WASM64-FAST-NEXT:    i64.const $push1=, 0
-; WASM64-FAST-NEXT:    i32.load16_s $push0=, gv16($pop1):p2align=0
+; WASM64-FAST-NEXT:    i32.load16_s $push0=, gv16($pop1)
 ; WASM64-FAST-NEXT:    return $pop0
 ;
 ; WASM64-FAST-MVP-LABEL: global_sext_i16_i32:
 ; WASM64-FAST-MVP:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
 ; WASM64-FAST-MVP-NEXT:    i64.const $push[[P0:[0-9]+]]=, 0
-; WASM64-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]]):p2align=0
+; WASM64-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]])
 ; WASM64-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 16
 ; WASM64-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
 ; WASM64-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 16
@@ -231,14 +231,14 @@ define i64 @global_sext_i16_i64() {
 ; WASM32-DAG:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM32-DAG-NEXT:  # %bb.0:
 ; WASM32-DAG-NEXT:    i32.const $push0=, 0
-; WASM32-DAG-NEXT:    i64.load16_s $push1=, gv16($pop0):p2align=0
+; WASM32-DAG-NEXT:    i64.load16_s $push1=, gv16($pop0)
 ; WASM32-DAG-NEXT:    return $pop1
 ;
 ; WASM32-DAG-MVP-LABEL: global_sext_i16_i64:
 ; WASM32-DAG-MVP:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM32-DAG-MVP-NEXT:  # %bb.0:
 ; WASM32-DAG-MVP-NEXT:    i32.const $push0=, 0
-; WASM32-DAG-MVP-NEXT:    i64.load16_s $push1=, gv16($pop0):p2align=0
+; WASM32-DAG-MVP-NEXT:    i64.load16_s $push1=, gv16($pop0)
 ; WASM32-DAG-MVP-NEXT:    return $pop1
 ;
 ; WASM32-FAST-LABEL: global_sext_i16_i64:
@@ -254,7 +254,7 @@ define i64 @global_sext_i16_i64() {
 ; WASM32-FAST-MVP:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
 ; WASM32-FAST-MVP-NEXT:    i32.const $push[[P0:[0-9]+]]=, 0
-; WASM32-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]]):p2align=0
+; WASM32-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]])
 ; WASM32-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 16
 ; WASM32-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
 ; WASM32-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 16
@@ -266,21 +266,21 @@ define i64 @global_sext_i16_i64() {
 ; WASM64-DAG:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM64-DAG-NEXT:  # %bb.0:
 ; WASM64-DAG-NEXT:    i64.const $push0=, 0
-; WASM64-DAG-NEXT:    i64.load16_s $push1=, gv16($pop0):p2align=0
+; WASM64-DAG-NEXT:    i64.load16_s $push1=, gv16($pop0)
 ; WASM64-DAG-NEXT:    return $pop1
 ;
 ; WASM64-DAG-MVP-LABEL: global_sext_i16_i64:
 ; WASM64-DAG-MVP:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM64-DAG-MVP-NEXT:  # %bb.0:
 ; WASM64-DAG-MVP-NEXT:    i64.const $push0=, 0
-; WASM64-DAG-MVP-NEXT:    i64.load16_s $push1=, gv16($pop0):p2align=0
+; WASM64-DAG-MVP-NEXT:    i64.load16_s $push1=, gv16($pop0)
 ; WASM64-DAG-MVP-NEXT:    return $pop1
 ;
 ; WASM64-FAST-LABEL: global_sext_i16_i64:
 ; WASM64-FAST:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM64-FAST-NEXT:  # %bb.0:
 ; WASM64-FAST-NEXT:    i64.const $push[[P0:[0-9]+]]=, 0
-; WASM64-FAST-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]]):p2align=0
+; WASM64-FAST-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]])
 ; WASM64-FAST-NEXT:    i64.extend_i32_u $push[[P2:[0-9]+]]=, $pop[[P1]]
 ; WASM64-FAST-NEXT:    i64.extend16_s $push[[P3:[0-9]+]]=, $pop[[P2]]
 ; WASM64-FAST-NEXT:    return $pop[[P3]]
@@ -289,7 +289,7 @@ define i64 @global_sext_i16_i64() {
 ; WASM64-FAST-MVP:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
 ; WASM64-FAST-MVP-NEXT:    i64.const $push[[P0:[0-9]+]]=, 0
-; WASM64-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]]):p2align=0
+; WASM64-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]])
 ; WASM64-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 16
 ; WASM64-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
 ; WASM64-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 16

--- a/llvm/test/CodeGen/WebAssembly/load-ext.ll
+++ b/llvm/test/CodeGen/WebAssembly/load-ext.ll
@@ -38,10 +38,10 @@ define i32 @global_sext_i8_i32() {
 ; WASM32-FAST-MVP-LABEL: global_sext_i8_i32:
 ; WASM32-FAST-MVP:         .functype global_sext_i8_i32 () -> (i32)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.const $push3=, 0
-; WASM32-FAST-MVP-NEXT:    i32.load8_u $push4=, gv8($pop3)
+; WASM32-FAST-MVP-NEXT:    i32.const $push4=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load8_u $push3=, gv8($pop4)
 ; WASM32-FAST-MVP-NEXT:    i32.const $push0=, 24
-; WASM32-FAST-MVP-NEXT:    i32.shl $push1=, $pop4, $pop0
+; WASM32-FAST-MVP-NEXT:    i32.shl $push1=, $pop3, $pop0
 ; WASM32-FAST-MVP-NEXT:    i32.const $push5=, 24
 ; WASM32-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
 ; WASM32-FAST-MVP-NEXT:    return $pop2
@@ -70,10 +70,10 @@ define i32 @global_sext_i8_i32() {
 ; WASM64-FAST-MVP-LABEL: global_sext_i8_i32:
 ; WASM64-FAST-MVP:         .functype global_sext_i8_i32 () -> (i32)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i64.const $push3=, 0
-; WASM64-FAST-MVP-NEXT:    i32.load8_u $push4=, gv8($pop3)
+; WASM64-FAST-MVP-NEXT:    i64.const $push4=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load8_u $push3=, gv8($pop4)
 ; WASM64-FAST-MVP-NEXT:    i32.const $push0=, 24
-; WASM64-FAST-MVP-NEXT:    i32.shl $push1=, $pop4, $pop0
+; WASM64-FAST-MVP-NEXT:    i32.shl $push1=, $pop3, $pop0
 ; WASM64-FAST-MVP-NEXT:    i32.const $push5=, 24
 ; WASM64-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
 ; WASM64-FAST-MVP-NEXT:    return $pop2
@@ -107,10 +107,10 @@ define i32 @global_sext_i16_i32() {
 ; WASM32-FAST-MVP-LABEL: global_sext_i16_i32:
 ; WASM32-FAST-MVP:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.const $push3=, 0
-; WASM32-FAST-MVP-NEXT:    i32.load16_u $push4=, gv16($pop3):p2align=0
+; WASM32-FAST-MVP-NEXT:    i32.const $push4=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load16_u $push3=, gv16($pop4):p2align=0
 ; WASM32-FAST-MVP-NEXT:    i32.const $push0=, 16
-; WASM32-FAST-MVP-NEXT:    i32.shl $push1=, $pop4, $pop0
+; WASM32-FAST-MVP-NEXT:    i32.shl $push1=, $pop3, $pop0
 ; WASM32-FAST-MVP-NEXT:    i32.const $push5=, 16
 ; WASM32-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
 ; WASM32-FAST-MVP-NEXT:    return $pop2
@@ -139,10 +139,10 @@ define i32 @global_sext_i16_i32() {
 ; WASM64-FAST-MVP-LABEL: global_sext_i16_i32:
 ; WASM64-FAST-MVP:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i64.const $push3=, 0
-; WASM64-FAST-MVP-NEXT:    i32.load16_u $push4=, gv16($pop3):p2align=0
+; WASM64-FAST-MVP-NEXT:    i64.const $push4=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load16_u $push3=, gv16($pop4):p2align=0
 ; WASM64-FAST-MVP-NEXT:    i32.const $push0=, 16
-; WASM64-FAST-MVP-NEXT:    i32.shl $push1=, $pop4, $pop0
+; WASM64-FAST-MVP-NEXT:    i32.shl $push1=, $pop3, $pop0
 ; WASM64-FAST-MVP-NEXT:    i32.const $push5=, 16
 ; WASM64-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
 ; WASM64-FAST-MVP-NEXT:    return $pop2
@@ -169,19 +169,19 @@ define i64 @global_sext_i8_i64() {
 ; WASM32-FAST-LABEL: global_sext_i8_i64:
 ; WASM32-FAST:         .functype global_sext_i8_i64 () -> (i64)
 ; WASM32-FAST-NEXT:  # %bb.0:
-; WASM32-FAST-NEXT:    i32.const $push2=, 0
-; WASM32-FAST-NEXT:    i32.load8_u $push3=, gv8($pop2)
-; WASM32-FAST-NEXT:    i64.extend_i32_u $push0=, $pop3
+; WASM32-FAST-NEXT:    i32.const $push3=, 0
+; WASM32-FAST-NEXT:    i32.load8_u $push2=, gv8($pop3)
+; WASM32-FAST-NEXT:    i64.extend_i32_u $push0=, $pop2
 ; WASM32-FAST-NEXT:    i64.extend8_s $push1=, $pop0
 ; WASM32-FAST-NEXT:    return $pop1
 ;
 ; WASM32-FAST-MVP-LABEL: global_sext_i8_i64:
 ; WASM32-FAST-MVP:         .functype global_sext_i8_i64 () -> (i64)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.const $push4=, 0
-; WASM32-FAST-MVP-NEXT:    i32.load8_u $push5=, gv8($pop4)
+; WASM32-FAST-MVP-NEXT:    i32.const $push5=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load8_u $push4=, gv8($pop5)
 ; WASM32-FAST-MVP-NEXT:    i32.const $push1=, 24
-; WASM32-FAST-MVP-NEXT:    i32.shl $push2=, $pop5, $pop1
+; WASM32-FAST-MVP-NEXT:    i32.shl $push2=, $pop4, $pop1
 ; WASM32-FAST-MVP-NEXT:    i32.const $push6=, 24
 ; WASM32-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
 ; WASM32-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3
@@ -204,19 +204,19 @@ define i64 @global_sext_i8_i64() {
 ; WASM64-FAST-LABEL: global_sext_i8_i64:
 ; WASM64-FAST:         .functype global_sext_i8_i64 () -> (i64)
 ; WASM64-FAST-NEXT:  # %bb.0:
-; WASM64-FAST-NEXT:    i64.const $push2=, 0
-; WASM64-FAST-NEXT:    i32.load8_u $push3=, gv8($pop2)
-; WASM64-FAST-NEXT:    i64.extend_i32_u $push0=, $pop3
+; WASM64-FAST-NEXT:    i64.const $push3=, 0
+; WASM64-FAST-NEXT:    i32.load8_u $push2=, gv8($pop3)
+; WASM64-FAST-NEXT:    i64.extend_i32_u $push0=, $pop2
 ; WASM64-FAST-NEXT:    i64.extend8_s $push1=, $pop0
 ; WASM64-FAST-NEXT:    return $pop1
 ;
 ; WASM64-FAST-MVP-LABEL: global_sext_i8_i64:
 ; WASM64-FAST-MVP:         .functype global_sext_i8_i64 () -> (i64)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i64.const $push4=, 0
-; WASM64-FAST-MVP-NEXT:    i32.load8_u $push5=, gv8($pop4)
+; WASM64-FAST-MVP-NEXT:    i64.const $push5=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load8_u $push4=, gv8($pop5)
 ; WASM64-FAST-MVP-NEXT:    i32.const $push1=, 24
-; WASM64-FAST-MVP-NEXT:    i32.shl $push2=, $pop5, $pop1
+; WASM64-FAST-MVP-NEXT:    i32.shl $push2=, $pop4, $pop1
 ; WASM64-FAST-MVP-NEXT:    i32.const $push6=, 24
 ; WASM64-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
 ; WASM64-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3
@@ -244,19 +244,19 @@ define i64 @global_sext_i16_i64() {
 ; WASM32-FAST-LABEL: global_sext_i16_i64:
 ; WASM32-FAST:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM32-FAST-NEXT:  # %bb.0:
-; WASM32-FAST-NEXT:    i32.const $push2=, 0
-; WASM32-FAST-NEXT:    i32.load16_u $push3=, gv16($pop2):p2align=0
-; WASM32-FAST-NEXT:    i64.extend_i32_u $push0=, $pop3
+; WASM32-FAST-NEXT:    i32.const $push3=, 0
+; WASM32-FAST-NEXT:    i32.load16_u $push2=, gv16($pop3):p2align=0
+; WASM32-FAST-NEXT:    i64.extend_i32_u $push0=, $pop2
 ; WASM32-FAST-NEXT:    i64.extend16_s $push1=, $pop0
 ; WASM32-FAST-NEXT:    return $pop1
 ;
 ; WASM32-FAST-MVP-LABEL: global_sext_i16_i64:
 ; WASM32-FAST-MVP:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.const $push4=, 0
-; WASM32-FAST-MVP-NEXT:    i32.load16_u $push5=, gv16($pop4):p2align=0
+; WASM32-FAST-MVP-NEXT:    i32.const $push5=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load16_u $push4=, gv16($pop5):p2align=0
 ; WASM32-FAST-MVP-NEXT:    i32.const $push1=, 16
-; WASM32-FAST-MVP-NEXT:    i32.shl $push2=, $pop5, $pop1
+; WASM32-FAST-MVP-NEXT:    i32.shl $push2=, $pop4, $pop1
 ; WASM32-FAST-MVP-NEXT:    i32.const $push6=, 16
 ; WASM32-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
 ; WASM32-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3
@@ -279,19 +279,19 @@ define i64 @global_sext_i16_i64() {
 ; WASM64-FAST-LABEL: global_sext_i16_i64:
 ; WASM64-FAST:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM64-FAST-NEXT:  # %bb.0:
-; WASM64-FAST-NEXT:    i64.const $push2=, 0
-; WASM64-FAST-NEXT:    i32.load16_u $push3=, gv16($pop2):p2align=0
-; WASM64-FAST-NEXT:    i64.extend_i32_u $push0=, $pop3
+; WASM64-FAST-NEXT:    i64.const $push3=, 0
+; WASM64-FAST-NEXT:    i32.load16_u $push2=, gv16($pop3):p2align=0
+; WASM64-FAST-NEXT:    i64.extend_i32_u $push0=, $pop2
 ; WASM64-FAST-NEXT:    i64.extend16_s $push1=, $pop0
 ; WASM64-FAST-NEXT:    return $pop1
 ;
 ; WASM64-FAST-MVP-LABEL: global_sext_i16_i64:
 ; WASM64-FAST-MVP:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i64.const $push4=, 0
-; WASM64-FAST-MVP-NEXT:    i32.load16_u $push5=, gv16($pop4):p2align=0
+; WASM64-FAST-MVP-NEXT:    i64.const $push5=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load16_u $push4=, gv16($pop5):p2align=0
 ; WASM64-FAST-MVP-NEXT:    i32.const $push1=, 16
-; WASM64-FAST-MVP-NEXT:    i32.shl $push2=, $pop5, $pop1
+; WASM64-FAST-MVP-NEXT:    i32.shl $push2=, $pop4, $pop1
 ; WASM64-FAST-MVP-NEXT:    i32.const $push6=, 16
 ; WASM64-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
 ; WASM64-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3

--- a/llvm/test/CodeGen/WebAssembly/load-ext.ll
+++ b/llvm/test/CodeGen/WebAssembly/load-ext.ll
@@ -10,6 +10,297 @@
 
 ; Test that extending loads are assembled properly.
 
+@gv8 = hidden global i8 0, align 1
+@gv16 = hidden global i16 0, align 1
+
+define i32 @global_sext_i8_i32() {
+; WASM32-DAG-LABEL: global_sext_i8_i32:
+; WASM32-DAG:         .functype global_sext_i8_i32 () -> (i32)
+; WASM32-DAG-NEXT:  # %bb.0:
+; WASM32-DAG-NEXT:    i32.const $push0=, 0
+; WASM32-DAG-NEXT:    i32.load8_s $push1=, gv8($pop0)
+; WASM32-DAG-NEXT:    return $pop1
+;
+; WASM32-DAG-MVP-LABEL: global_sext_i8_i32:
+; WASM32-DAG-MVP:         .functype global_sext_i8_i32 () -> (i32)
+; WASM32-DAG-MVP-NEXT:  # %bb.0:
+; WASM32-DAG-MVP-NEXT:    i32.const $push0=, 0
+; WASM32-DAG-MVP-NEXT:    i32.load8_s $push1=, gv8($pop0)
+; WASM32-DAG-MVP-NEXT:    return $pop1
+;
+; WASM32-FAST-LABEL: global_sext_i8_i32:
+; WASM32-FAST:         .functype global_sext_i8_i32 () -> (i32)
+; WASM32-FAST-NEXT:  # %bb.0:
+; WASM32-FAST-NEXT:    i32.const $push1=, 0
+; WASM32-FAST-NEXT:    i32.load8_s $push0=, gv8($pop1)
+; WASM32-FAST-NEXT:    return $pop0
+;
+; WASM32-FAST-MVP-LABEL: global_sext_i8_i32:
+; WASM32-FAST-MVP:         .functype global_sext_i8_i32 () -> (i32)
+; WASM32-FAST-MVP-NEXT:  # %bb.0:
+; WASM32-FAST-MVP-NEXT:    i32.const $push3=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load8_u $push4=, gv8($pop3)
+; WASM32-FAST-MVP-NEXT:    i32.const $push0=, 24
+; WASM32-FAST-MVP-NEXT:    i32.shl $push1=, $pop4, $pop0
+; WASM32-FAST-MVP-NEXT:    i32.const $push5=, 24
+; WASM32-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
+; WASM32-FAST-MVP-NEXT:    return $pop2
+;
+; WASM64-DAG-LABEL: global_sext_i8_i32:
+; WASM64-DAG:         .functype global_sext_i8_i32 () -> (i32)
+; WASM64-DAG-NEXT:  # %bb.0:
+; WASM64-DAG-NEXT:    i64.const $push0=, 0
+; WASM64-DAG-NEXT:    i32.load8_s $push1=, gv8($pop0)
+; WASM64-DAG-NEXT:    return $pop1
+;
+; WASM64-DAG-MVP-LABEL: global_sext_i8_i32:
+; WASM64-DAG-MVP:         .functype global_sext_i8_i32 () -> (i32)
+; WASM64-DAG-MVP-NEXT:  # %bb.0:
+; WASM64-DAG-MVP-NEXT:    i64.const $push0=, 0
+; WASM64-DAG-MVP-NEXT:    i32.load8_s $push1=, gv8($pop0)
+; WASM64-DAG-MVP-NEXT:    return $pop1
+;
+; WASM64-FAST-LABEL: global_sext_i8_i32:
+; WASM64-FAST:         .functype global_sext_i8_i32 () -> (i32)
+; WASM64-FAST-NEXT:  # %bb.0:
+; WASM64-FAST-NEXT:    i64.const $push1=, 0
+; WASM64-FAST-NEXT:    i32.load8_s $push0=, gv8($pop1)
+; WASM64-FAST-NEXT:    return $pop0
+;
+; WASM64-FAST-MVP-LABEL: global_sext_i8_i32:
+; WASM64-FAST-MVP:         .functype global_sext_i8_i32 () -> (i32)
+; WASM64-FAST-MVP-NEXT:  # %bb.0:
+; WASM64-FAST-MVP-NEXT:    i64.const $push3=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load8_u $push4=, gv8($pop3)
+; WASM64-FAST-MVP-NEXT:    i32.const $push0=, 24
+; WASM64-FAST-MVP-NEXT:    i32.shl $push1=, $pop4, $pop0
+; WASM64-FAST-MVP-NEXT:    i32.const $push5=, 24
+; WASM64-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
+; WASM64-FAST-MVP-NEXT:    return $pop2
+  %ld = load i8, ptr @gv8, align 1
+  %conv = sext i8 %ld to i32
+  ret i32 %conv
+}
+
+define i32 @global_sext_i16_i32() {
+; WASM32-DAG-LABEL: global_sext_i16_i32:
+; WASM32-DAG:         .functype global_sext_i16_i32 () -> (i32)
+; WASM32-DAG-NEXT:  # %bb.0:
+; WASM32-DAG-NEXT:    i32.const $push0=, 0
+; WASM32-DAG-NEXT:    i32.load16_s $push1=, gv16($pop0):p2align=0
+; WASM32-DAG-NEXT:    return $pop1
+;
+; WASM32-DAG-MVP-LABEL: global_sext_i16_i32:
+; WASM32-DAG-MVP:         .functype global_sext_i16_i32 () -> (i32)
+; WASM32-DAG-MVP-NEXT:  # %bb.0:
+; WASM32-DAG-MVP-NEXT:    i32.const $push0=, 0
+; WASM32-DAG-MVP-NEXT:    i32.load16_s $push1=, gv16($pop0):p2align=0
+; WASM32-DAG-MVP-NEXT:    return $pop1
+;
+; WASM32-FAST-LABEL: global_sext_i16_i32:
+; WASM32-FAST:         .functype global_sext_i16_i32 () -> (i32)
+; WASM32-FAST-NEXT:  # %bb.0:
+; WASM32-FAST-NEXT:    i32.const $push1=, 0
+; WASM32-FAST-NEXT:    i32.load16_s $push0=, gv16($pop1):p2align=0
+; WASM32-FAST-NEXT:    return $pop0
+;
+; WASM32-FAST-MVP-LABEL: global_sext_i16_i32:
+; WASM32-FAST-MVP:         .functype global_sext_i16_i32 () -> (i32)
+; WASM32-FAST-MVP-NEXT:  # %bb.0:
+; WASM32-FAST-MVP-NEXT:    i32.const $push3=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load16_u $push4=, gv16($pop3):p2align=0
+; WASM32-FAST-MVP-NEXT:    i32.const $push0=, 16
+; WASM32-FAST-MVP-NEXT:    i32.shl $push1=, $pop4, $pop0
+; WASM32-FAST-MVP-NEXT:    i32.const $push5=, 16
+; WASM32-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
+; WASM32-FAST-MVP-NEXT:    return $pop2
+;
+; WASM64-DAG-LABEL: global_sext_i16_i32:
+; WASM64-DAG:         .functype global_sext_i16_i32 () -> (i32)
+; WASM64-DAG-NEXT:  # %bb.0:
+; WASM64-DAG-NEXT:    i64.const $push0=, 0
+; WASM64-DAG-NEXT:    i32.load16_s $push1=, gv16($pop0):p2align=0
+; WASM64-DAG-NEXT:    return $pop1
+;
+; WASM64-DAG-MVP-LABEL: global_sext_i16_i32:
+; WASM64-DAG-MVP:         .functype global_sext_i16_i32 () -> (i32)
+; WASM64-DAG-MVP-NEXT:  # %bb.0:
+; WASM64-DAG-MVP-NEXT:    i64.const $push0=, 0
+; WASM64-DAG-MVP-NEXT:    i32.load16_s $push1=, gv16($pop0):p2align=0
+; WASM64-DAG-MVP-NEXT:    return $pop1
+;
+; WASM64-FAST-LABEL: global_sext_i16_i32:
+; WASM64-FAST:         .functype global_sext_i16_i32 () -> (i32)
+; WASM64-FAST-NEXT:  # %bb.0:
+; WASM64-FAST-NEXT:    i64.const $push1=, 0
+; WASM64-FAST-NEXT:    i32.load16_s $push0=, gv16($pop1):p2align=0
+; WASM64-FAST-NEXT:    return $pop0
+;
+; WASM64-FAST-MVP-LABEL: global_sext_i16_i32:
+; WASM64-FAST-MVP:         .functype global_sext_i16_i32 () -> (i32)
+; WASM64-FAST-MVP-NEXT:  # %bb.0:
+; WASM64-FAST-MVP-NEXT:    i64.const $push3=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load16_u $push4=, gv16($pop3):p2align=0
+; WASM64-FAST-MVP-NEXT:    i32.const $push0=, 16
+; WASM64-FAST-MVP-NEXT:    i32.shl $push1=, $pop4, $pop0
+; WASM64-FAST-MVP-NEXT:    i32.const $push5=, 16
+; WASM64-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
+; WASM64-FAST-MVP-NEXT:    return $pop2
+  %ld = load i16, ptr @gv16, align 1
+  %conv = sext i16 %ld to i32
+  ret i32 %conv
+}
+
+define i64 @global_sext_i8_i64() {
+; WASM32-DAG-LABEL: global_sext_i8_i64:
+; WASM32-DAG:         .functype global_sext_i8_i64 () -> (i64)
+; WASM32-DAG-NEXT:  # %bb.0:
+; WASM32-DAG-NEXT:    i32.const $push0=, 0
+; WASM32-DAG-NEXT:    i64.load8_s $push1=, gv8($pop0)
+; WASM32-DAG-NEXT:    return $pop1
+;
+; WASM32-DAG-MVP-LABEL: global_sext_i8_i64:
+; WASM32-DAG-MVP:         .functype global_sext_i8_i64 () -> (i64)
+; WASM32-DAG-MVP-NEXT:  # %bb.0:
+; WASM32-DAG-MVP-NEXT:    i32.const $push0=, 0
+; WASM32-DAG-MVP-NEXT:    i64.load8_s $push1=, gv8($pop0)
+; WASM32-DAG-MVP-NEXT:    return $pop1
+;
+; WASM32-FAST-LABEL: global_sext_i8_i64:
+; WASM32-FAST:         .functype global_sext_i8_i64 () -> (i64)
+; WASM32-FAST-NEXT:  # %bb.0:
+; WASM32-FAST-NEXT:    i32.const $push2=, 0
+; WASM32-FAST-NEXT:    i32.load8_u $push3=, gv8($pop2)
+; WASM32-FAST-NEXT:    i64.extend_i32_u $push0=, $pop3
+; WASM32-FAST-NEXT:    i64.extend8_s $push1=, $pop0
+; WASM32-FAST-NEXT:    return $pop1
+;
+; WASM32-FAST-MVP-LABEL: global_sext_i8_i64:
+; WASM32-FAST-MVP:         .functype global_sext_i8_i64 () -> (i64)
+; WASM32-FAST-MVP-NEXT:  # %bb.0:
+; WASM32-FAST-MVP-NEXT:    i32.const $push4=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load8_u $push5=, gv8($pop4)
+; WASM32-FAST-MVP-NEXT:    i32.const $push1=, 24
+; WASM32-FAST-MVP-NEXT:    i32.shl $push2=, $pop5, $pop1
+; WASM32-FAST-MVP-NEXT:    i32.const $push6=, 24
+; WASM32-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
+; WASM32-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3
+; WASM32-FAST-MVP-NEXT:    return $pop0
+;
+; WASM64-DAG-LABEL: global_sext_i8_i64:
+; WASM64-DAG:         .functype global_sext_i8_i64 () -> (i64)
+; WASM64-DAG-NEXT:  # %bb.0:
+; WASM64-DAG-NEXT:    i64.const $push0=, 0
+; WASM64-DAG-NEXT:    i64.load8_s $push1=, gv8($pop0)
+; WASM64-DAG-NEXT:    return $pop1
+;
+; WASM64-DAG-MVP-LABEL: global_sext_i8_i64:
+; WASM64-DAG-MVP:         .functype global_sext_i8_i64 () -> (i64)
+; WASM64-DAG-MVP-NEXT:  # %bb.0:
+; WASM64-DAG-MVP-NEXT:    i64.const $push0=, 0
+; WASM64-DAG-MVP-NEXT:    i64.load8_s $push1=, gv8($pop0)
+; WASM64-DAG-MVP-NEXT:    return $pop1
+;
+; WASM64-FAST-LABEL: global_sext_i8_i64:
+; WASM64-FAST:         .functype global_sext_i8_i64 () -> (i64)
+; WASM64-FAST-NEXT:  # %bb.0:
+; WASM64-FAST-NEXT:    i64.const $push2=, 0
+; WASM64-FAST-NEXT:    i32.load8_u $push3=, gv8($pop2)
+; WASM64-FAST-NEXT:    i64.extend_i32_u $push0=, $pop3
+; WASM64-FAST-NEXT:    i64.extend8_s $push1=, $pop0
+; WASM64-FAST-NEXT:    return $pop1
+;
+; WASM64-FAST-MVP-LABEL: global_sext_i8_i64:
+; WASM64-FAST-MVP:         .functype global_sext_i8_i64 () -> (i64)
+; WASM64-FAST-MVP-NEXT:  # %bb.0:
+; WASM64-FAST-MVP-NEXT:    i64.const $push4=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load8_u $push5=, gv8($pop4)
+; WASM64-FAST-MVP-NEXT:    i32.const $push1=, 24
+; WASM64-FAST-MVP-NEXT:    i32.shl $push2=, $pop5, $pop1
+; WASM64-FAST-MVP-NEXT:    i32.const $push6=, 24
+; WASM64-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
+; WASM64-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3
+; WASM64-FAST-MVP-NEXT:    return $pop0
+  %ld = load i8, ptr @gv8, align 1
+  %conv = sext i8 %ld to i64
+  ret i64 %conv
+}
+
+define i64 @global_sext_i16_i64() {
+; WASM32-DAG-LABEL: global_sext_i16_i64:
+; WASM32-DAG:         .functype global_sext_i16_i64 () -> (i64)
+; WASM32-DAG-NEXT:  # %bb.0:
+; WASM32-DAG-NEXT:    i32.const $push0=, 0
+; WASM32-DAG-NEXT:    i64.load16_s $push1=, gv16($pop0):p2align=0
+; WASM32-DAG-NEXT:    return $pop1
+;
+; WASM32-DAG-MVP-LABEL: global_sext_i16_i64:
+; WASM32-DAG-MVP:         .functype global_sext_i16_i64 () -> (i64)
+; WASM32-DAG-MVP-NEXT:  # %bb.0:
+; WASM32-DAG-MVP-NEXT:    i32.const $push0=, 0
+; WASM32-DAG-MVP-NEXT:    i64.load16_s $push1=, gv16($pop0):p2align=0
+; WASM32-DAG-MVP-NEXT:    return $pop1
+;
+; WASM32-FAST-LABEL: global_sext_i16_i64:
+; WASM32-FAST:         .functype global_sext_i16_i64 () -> (i64)
+; WASM32-FAST-NEXT:  # %bb.0:
+; WASM32-FAST-NEXT:    i32.const $push2=, 0
+; WASM32-FAST-NEXT:    i32.load16_u $push3=, gv16($pop2):p2align=0
+; WASM32-FAST-NEXT:    i64.extend_i32_u $push0=, $pop3
+; WASM32-FAST-NEXT:    i64.extend16_s $push1=, $pop0
+; WASM32-FAST-NEXT:    return $pop1
+;
+; WASM32-FAST-MVP-LABEL: global_sext_i16_i64:
+; WASM32-FAST-MVP:         .functype global_sext_i16_i64 () -> (i64)
+; WASM32-FAST-MVP-NEXT:  # %bb.0:
+; WASM32-FAST-MVP-NEXT:    i32.const $push4=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load16_u $push5=, gv16($pop4):p2align=0
+; WASM32-FAST-MVP-NEXT:    i32.const $push1=, 16
+; WASM32-FAST-MVP-NEXT:    i32.shl $push2=, $pop5, $pop1
+; WASM32-FAST-MVP-NEXT:    i32.const $push6=, 16
+; WASM32-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
+; WASM32-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3
+; WASM32-FAST-MVP-NEXT:    return $pop0
+;
+; WASM64-DAG-LABEL: global_sext_i16_i64:
+; WASM64-DAG:         .functype global_sext_i16_i64 () -> (i64)
+; WASM64-DAG-NEXT:  # %bb.0:
+; WASM64-DAG-NEXT:    i64.const $push0=, 0
+; WASM64-DAG-NEXT:    i64.load16_s $push1=, gv16($pop0):p2align=0
+; WASM64-DAG-NEXT:    return $pop1
+;
+; WASM64-DAG-MVP-LABEL: global_sext_i16_i64:
+; WASM64-DAG-MVP:         .functype global_sext_i16_i64 () -> (i64)
+; WASM64-DAG-MVP-NEXT:  # %bb.0:
+; WASM64-DAG-MVP-NEXT:    i64.const $push0=, 0
+; WASM64-DAG-MVP-NEXT:    i64.load16_s $push1=, gv16($pop0):p2align=0
+; WASM64-DAG-MVP-NEXT:    return $pop1
+;
+; WASM64-FAST-LABEL: global_sext_i16_i64:
+; WASM64-FAST:         .functype global_sext_i16_i64 () -> (i64)
+; WASM64-FAST-NEXT:  # %bb.0:
+; WASM64-FAST-NEXT:    i64.const $push2=, 0
+; WASM64-FAST-NEXT:    i32.load16_u $push3=, gv16($pop2):p2align=0
+; WASM64-FAST-NEXT:    i64.extend_i32_u $push0=, $pop3
+; WASM64-FAST-NEXT:    i64.extend16_s $push1=, $pop0
+; WASM64-FAST-NEXT:    return $pop1
+;
+; WASM64-FAST-MVP-LABEL: global_sext_i16_i64:
+; WASM64-FAST-MVP:         .functype global_sext_i16_i64 () -> (i64)
+; WASM64-FAST-MVP-NEXT:  # %bb.0:
+; WASM64-FAST-MVP-NEXT:    i64.const $push4=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load16_u $push5=, gv16($pop4):p2align=0
+; WASM64-FAST-MVP-NEXT:    i32.const $push1=, 16
+; WASM64-FAST-MVP-NEXT:    i32.shl $push2=, $pop5, $pop1
+; WASM64-FAST-MVP-NEXT:    i32.const $push6=, 16
+; WASM64-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
+; WASM64-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3
+; WASM64-FAST-MVP-NEXT:    return $pop0
+  %ld= load i16, ptr @gv16, align 1
+  %conv = sext i16 %ld to i64
+  ret i64 %conv
+}
+
 define i32 @sext_i8_i32(ptr %p) {
 ; WASM32-DAG-LABEL: sext_i8_i32:
 ; WASM32-DAG:         .functype sext_i8_i32 (i32) -> (i32)

--- a/llvm/test/CodeGen/WebAssembly/load-ext.ll
+++ b/llvm/test/CodeGen/WebAssembly/load-ext.ll
@@ -38,13 +38,13 @@ define i32 @global_sext_i8_i32() {
 ; WASM32-FAST-MVP-LABEL: global_sext_i8_i32:
 ; WASM32-FAST-MVP:         .functype global_sext_i8_i32 () -> (i32)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.const $push4=, 0
-; WASM32-FAST-MVP-NEXT:    i32.load8_u $push3=, gv8($pop4)
-; WASM32-FAST-MVP-NEXT:    i32.const $push0=, 24
-; WASM32-FAST-MVP-NEXT:    i32.shl $push1=, $pop3, $pop0
-; WASM32-FAST-MVP-NEXT:    i32.const $push5=, 24
-; WASM32-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
-; WASM32-FAST-MVP-NEXT:    return $pop2
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P0:[0-9]+]]=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load8_u $push[[P1:[0-9]+]]=, gv8($pop[[P0]])
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 24
+; WASM32-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 24
+; WASM32-FAST-MVP-NEXT:    i32.shr_s $push[[P5:[0-9]+]]=, $pop[[P3]], $pop[[P4]]
+; WASM32-FAST-MVP-NEXT:    return $pop[[P5]]
 ;
 ; WASM64-DAG-LABEL: global_sext_i8_i32:
 ; WASM64-DAG:         .functype global_sext_i8_i32 () -> (i32)
@@ -70,13 +70,13 @@ define i32 @global_sext_i8_i32() {
 ; WASM64-FAST-MVP-LABEL: global_sext_i8_i32:
 ; WASM64-FAST-MVP:         .functype global_sext_i8_i32 () -> (i32)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i64.const $push4=, 0
-; WASM64-FAST-MVP-NEXT:    i32.load8_u $push3=, gv8($pop4)
-; WASM64-FAST-MVP-NEXT:    i32.const $push0=, 24
-; WASM64-FAST-MVP-NEXT:    i32.shl $push1=, $pop3, $pop0
-; WASM64-FAST-MVP-NEXT:    i32.const $push5=, 24
-; WASM64-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
-; WASM64-FAST-MVP-NEXT:    return $pop2
+; WASM64-FAST-MVP-NEXT:    i64.const $push[[P0:[0-9]+]]=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load8_u $push[[P1:[0-9]+]]=, gv8($pop[[P0]])
+; WASM64-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 24
+; WASM64-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
+; WASM64-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 24
+; WASM64-FAST-MVP-NEXT:    i32.shr_s $push[[P5:[0-9]+]]=, $pop[[P3]], $pop[[P4]]
+; WASM64-FAST-MVP-NEXT:    return $pop[[P5]]
   %ld = load i8, ptr @gv8, align 1
   %conv = sext i8 %ld to i32
   ret i32 %conv
@@ -107,13 +107,13 @@ define i32 @global_sext_i16_i32() {
 ; WASM32-FAST-MVP-LABEL: global_sext_i16_i32:
 ; WASM32-FAST-MVP:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.const $push4=, 0
-; WASM32-FAST-MVP-NEXT:    i32.load16_u $push3=, gv16($pop4):p2align=0
-; WASM32-FAST-MVP-NEXT:    i32.const $push0=, 16
-; WASM32-FAST-MVP-NEXT:    i32.shl $push1=, $pop3, $pop0
-; WASM32-FAST-MVP-NEXT:    i32.const $push5=, 16
-; WASM32-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
-; WASM32-FAST-MVP-NEXT:    return $pop2
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P0:[0-9]+]]=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]]):p2align=0
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 16
+; WASM32-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 16
+; WASM32-FAST-MVP-NEXT:    i32.shr_s $push[[P5:[0-9]+]]=, $pop[[P3]], $pop[[P4]]
+; WASM32-FAST-MVP-NEXT:    return $pop[[P5]]
 ;
 ; WASM64-DAG-LABEL: global_sext_i16_i32:
 ; WASM64-DAG:         .functype global_sext_i16_i32 () -> (i32)
@@ -139,13 +139,13 @@ define i32 @global_sext_i16_i32() {
 ; WASM64-FAST-MVP-LABEL: global_sext_i16_i32:
 ; WASM64-FAST-MVP:         .functype global_sext_i16_i32 () -> (i32)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i64.const $push4=, 0
-; WASM64-FAST-MVP-NEXT:    i32.load16_u $push3=, gv16($pop4):p2align=0
-; WASM64-FAST-MVP-NEXT:    i32.const $push0=, 16
-; WASM64-FAST-MVP-NEXT:    i32.shl $push1=, $pop3, $pop0
-; WASM64-FAST-MVP-NEXT:    i32.const $push5=, 16
-; WASM64-FAST-MVP-NEXT:    i32.shr_s $push2=, $pop1, $pop5
-; WASM64-FAST-MVP-NEXT:    return $pop2
+; WASM64-FAST-MVP-NEXT:    i64.const $push[[P0:[0-9]+]]=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]]):p2align=0
+; WASM64-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 16
+; WASM64-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
+; WASM64-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 16
+; WASM64-FAST-MVP-NEXT:    i32.shr_s $push[[P5:[0-9]+]]=, $pop[[P3]], $pop[[P4]]
+; WASM64-FAST-MVP-NEXT:    return $pop[[P5]]
   %ld = load i16, ptr @gv16, align 1
   %conv = sext i16 %ld to i32
   ret i32 %conv
@@ -169,23 +169,23 @@ define i64 @global_sext_i8_i64() {
 ; WASM32-FAST-LABEL: global_sext_i8_i64:
 ; WASM32-FAST:         .functype global_sext_i8_i64 () -> (i64)
 ; WASM32-FAST-NEXT:  # %bb.0:
-; WASM32-FAST-NEXT:    i32.const $push3=, 0
-; WASM32-FAST-NEXT:    i32.load8_u $push2=, gv8($pop3)
-; WASM32-FAST-NEXT:    i64.extend_i32_u $push0=, $pop2
-; WASM32-FAST-NEXT:    i64.extend8_s $push1=, $pop0
-; WASM32-FAST-NEXT:    return $pop1
+; WASM32-FAST-NEXT:    i32.const $push[[P0:[0-9]+]]=, 0
+; WASM32-FAST-NEXT:    i32.load8_u $push[[P1:[0-9]+]]=, gv8($pop[[P0]])
+; WASM32-FAST-NEXT:    i64.extend_i32_u $push[[P2:[0-9]+]]=, $pop[[P1]]
+; WASM32-FAST-NEXT:    i64.extend8_s $push[[P3:[0-9]+]]=, $pop[[P2]]
+; WASM32-FAST-NEXT:    return $pop[[P3]]
 ;
 ; WASM32-FAST-MVP-LABEL: global_sext_i8_i64:
 ; WASM32-FAST-MVP:         .functype global_sext_i8_i64 () -> (i64)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.const $push5=, 0
-; WASM32-FAST-MVP-NEXT:    i32.load8_u $push4=, gv8($pop5)
-; WASM32-FAST-MVP-NEXT:    i32.const $push1=, 24
-; WASM32-FAST-MVP-NEXT:    i32.shl $push2=, $pop4, $pop1
-; WASM32-FAST-MVP-NEXT:    i32.const $push6=, 24
-; WASM32-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
-; WASM32-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3
-; WASM32-FAST-MVP-NEXT:    return $pop0
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P0:[0-9]+]]=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load8_u $push[[P1:[0-9]+]]=, gv8($pop[[P0]])
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 24
+; WASM32-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 24
+; WASM32-FAST-MVP-NEXT:    i32.shr_s $push[[P5:[0-9]+]]=, $pop[[P3]], $pop[[P4]]
+; WASM32-FAST-MVP-NEXT:    i64.extend_i32_s $push[[P6:[0-9]+]]=, $pop[[P5]]
+; WASM32-FAST-MVP-NEXT:    return $pop[[P6]]
 ;
 ; WASM64-DAG-LABEL: global_sext_i8_i64:
 ; WASM64-DAG:         .functype global_sext_i8_i64 () -> (i64)
@@ -204,23 +204,23 @@ define i64 @global_sext_i8_i64() {
 ; WASM64-FAST-LABEL: global_sext_i8_i64:
 ; WASM64-FAST:         .functype global_sext_i8_i64 () -> (i64)
 ; WASM64-FAST-NEXT:  # %bb.0:
-; WASM64-FAST-NEXT:    i64.const $push3=, 0
-; WASM64-FAST-NEXT:    i32.load8_u $push2=, gv8($pop3)
-; WASM64-FAST-NEXT:    i64.extend_i32_u $push0=, $pop2
-; WASM64-FAST-NEXT:    i64.extend8_s $push1=, $pop0
-; WASM64-FAST-NEXT:    return $pop1
+; WASM64-FAST-NEXT:    i64.const $push[[P0:[0-9]+]]=, 0
+; WASM64-FAST-NEXT:    i32.load8_u $push[[P1:[0-9]+]]=, gv8($pop[[P0]])
+; WASM64-FAST-NEXT:    i64.extend_i32_u $push[[P2:[0-9]+]]=, $pop[[P1]]
+; WASM64-FAST-NEXT:    i64.extend8_s $push[[P3:[0-9]+]]=, $pop[[P2]]
+; WASM64-FAST-NEXT:    return $pop[[P3]]
 ;
 ; WASM64-FAST-MVP-LABEL: global_sext_i8_i64:
 ; WASM64-FAST-MVP:         .functype global_sext_i8_i64 () -> (i64)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i64.const $push5=, 0
-; WASM64-FAST-MVP-NEXT:    i32.load8_u $push4=, gv8($pop5)
-; WASM64-FAST-MVP-NEXT:    i32.const $push1=, 24
-; WASM64-FAST-MVP-NEXT:    i32.shl $push2=, $pop4, $pop1
-; WASM64-FAST-MVP-NEXT:    i32.const $push6=, 24
-; WASM64-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
-; WASM64-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3
-; WASM64-FAST-MVP-NEXT:    return $pop0
+; WASM64-FAST-MVP-NEXT:    i64.const $push[[P0:[0-9]+]]=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load8_u $push[[P1:[0-9]+]]=, gv8($pop[[P0]])
+; WASM64-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 24
+; WASM64-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
+; WASM64-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 24
+; WASM64-FAST-MVP-NEXT:    i32.shr_s $push[[P5:[0-9]+]]=, $pop[[P3]], $pop[[P4]]
+; WASM64-FAST-MVP-NEXT:    i64.extend_i32_s $push[[P6:[0-9]+]]=, $pop[[P5]]
+; WASM64-FAST-MVP-NEXT:    return $pop[[P6]]
   %ld = load i8, ptr @gv8, align 1
   %conv = sext i8 %ld to i64
   ret i64 %conv
@@ -244,23 +244,23 @@ define i64 @global_sext_i16_i64() {
 ; WASM32-FAST-LABEL: global_sext_i16_i64:
 ; WASM32-FAST:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM32-FAST-NEXT:  # %bb.0:
-; WASM32-FAST-NEXT:    i32.const $push3=, 0
-; WASM32-FAST-NEXT:    i32.load16_u $push2=, gv16($pop3):p2align=0
-; WASM32-FAST-NEXT:    i64.extend_i32_u $push0=, $pop2
-; WASM32-FAST-NEXT:    i64.extend16_s $push1=, $pop0
-; WASM32-FAST-NEXT:    return $pop1
+; WASM32-FAST-NEXT:    i32.const $push[[P0:[0-9]+]]=, 0
+; WASM32-FAST-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]]):p2align=0
+; WASM32-FAST-NEXT:    i64.extend_i32_u $push[[P2:[0-9]+]]=, $pop[[P1]]
+; WASM32-FAST-NEXT:    i64.extend16_s $push[[P3:[0-9]+]]=, $pop[[P2]]
+; WASM32-FAST-NEXT:    return $pop[[P3]]
 ;
 ; WASM32-FAST-MVP-LABEL: global_sext_i16_i64:
 ; WASM32-FAST-MVP:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM32-FAST-MVP-NEXT:  # %bb.0:
-; WASM32-FAST-MVP-NEXT:    i32.const $push5=, 0
-; WASM32-FAST-MVP-NEXT:    i32.load16_u $push4=, gv16($pop5):p2align=0
-; WASM32-FAST-MVP-NEXT:    i32.const $push1=, 16
-; WASM32-FAST-MVP-NEXT:    i32.shl $push2=, $pop4, $pop1
-; WASM32-FAST-MVP-NEXT:    i32.const $push6=, 16
-; WASM32-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
-; WASM32-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3
-; WASM32-FAST-MVP-NEXT:    return $pop0
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P0:[0-9]+]]=, 0
+; WASM32-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]]):p2align=0
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 16
+; WASM32-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
+; WASM32-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 16
+; WASM32-FAST-MVP-NEXT:    i32.shr_s $push[[P5:[0-9]+]]=, $pop[[P3]], $pop[[P4]]
+; WASM32-FAST-MVP-NEXT:    i64.extend_i32_s $push[[P6:[0-9]+]]=, $pop[[P5]]
+; WASM32-FAST-MVP-NEXT:    return $pop[[P6]]
 ;
 ; WASM64-DAG-LABEL: global_sext_i16_i64:
 ; WASM64-DAG:         .functype global_sext_i16_i64 () -> (i64)
@@ -279,23 +279,23 @@ define i64 @global_sext_i16_i64() {
 ; WASM64-FAST-LABEL: global_sext_i16_i64:
 ; WASM64-FAST:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM64-FAST-NEXT:  # %bb.0:
-; WASM64-FAST-NEXT:    i64.const $push3=, 0
-; WASM64-FAST-NEXT:    i32.load16_u $push2=, gv16($pop3):p2align=0
-; WASM64-FAST-NEXT:    i64.extend_i32_u $push0=, $pop2
-; WASM64-FAST-NEXT:    i64.extend16_s $push1=, $pop0
-; WASM64-FAST-NEXT:    return $pop1
+; WASM64-FAST-NEXT:    i64.const $push[[P0:[0-9]+]]=, 0
+; WASM64-FAST-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]]):p2align=0
+; WASM64-FAST-NEXT:    i64.extend_i32_u $push[[P2:[0-9]+]]=, $pop[[P1]]
+; WASM64-FAST-NEXT:    i64.extend16_s $push[[P3:[0-9]+]]=, $pop[[P2]]
+; WASM64-FAST-NEXT:    return $pop[[P3]]
 ;
 ; WASM64-FAST-MVP-LABEL: global_sext_i16_i64:
 ; WASM64-FAST-MVP:         .functype global_sext_i16_i64 () -> (i64)
 ; WASM64-FAST-MVP-NEXT:  # %bb.0:
-; WASM64-FAST-MVP-NEXT:    i64.const $push5=, 0
-; WASM64-FAST-MVP-NEXT:    i32.load16_u $push4=, gv16($pop5):p2align=0
-; WASM64-FAST-MVP-NEXT:    i32.const $push1=, 16
-; WASM64-FAST-MVP-NEXT:    i32.shl $push2=, $pop4, $pop1
-; WASM64-FAST-MVP-NEXT:    i32.const $push6=, 16
-; WASM64-FAST-MVP-NEXT:    i32.shr_s $push3=, $pop2, $pop6
-; WASM64-FAST-MVP-NEXT:    i64.extend_i32_s $push0=, $pop3
-; WASM64-FAST-MVP-NEXT:    return $pop0
+; WASM64-FAST-MVP-NEXT:    i64.const $push[[P0:[0-9]+]]=, 0
+; WASM64-FAST-MVP-NEXT:    i32.load16_u $push[[P1:[0-9]+]]=, gv16($pop[[P0]]):p2align=0
+; WASM64-FAST-MVP-NEXT:    i32.const $push[[P2:[0-9]+]]=, 16
+; WASM64-FAST-MVP-NEXT:    i32.shl $push[[P3:[0-9]+]]=, $pop[[P1]], $pop[[P2]]
+; WASM64-FAST-MVP-NEXT:    i32.const $push[[P4:[0-9]+]]=, 16
+; WASM64-FAST-MVP-NEXT:    i32.shr_s $push[[P5:[0-9]+]]=, $pop[[P3]], $pop[[P4]]
+; WASM64-FAST-MVP-NEXT:    i64.extend_i32_s $push[[P6:[0-9]+]]=, $pop[[P5]]
+; WASM64-FAST-MVP-NEXT:    return $pop[[P6]]
   %ld= load i16, ptr @gv16, align 1
   %conv = sext i16 %ld to i64
   ret i64 %conv


### PR DESCRIPTION
The `tryToFoldLoadIntoMI` function omitted materializing base registers for addresses before folding sign-extend instructions into loads. This left `$noreg` as the base register, crashing subsequent passes.

WebAssembly memory instructions structurally require a valid base register. Calling the existing `materializeLoadStoreOperands` function ensures that a `CONST 0` virtual register is generated when addressing global variables directly without a pre-existing base register.

(before) %1:i32 = LOAD8_S_I32_A32 0, @ch, $noreg ... -> CRASH (after)  %3:i32 = CONST_I32 0
         %1:i32 = LOAD8_S_I32_A32 0, @ch, %3:i32 ... -> Folded safely