### PR TITLE
fix explicit incomplete enum

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -334,6 +334,7 @@ Bug Fixes to C++ Support
 - Fixed a bug where captured variables in non-mutable lambdas were incorrectly treated as mutable 
   when used inside decltype in the return type. (#GH180460)
 - Fixed a crash when evaluating uninitialized GCC vector/ext_vector_type vectors in ``constexpr``. (#GH180044)
+- Fixed a crash when `explicit(bool)` is used with an incomplete enumeration. (#GH183887)
 - Fixed a crash on ``typeid`` of incomplete local types during template instantiation. (#GH63242), (#GH176397)
 
 - Fix initialization of GRO when GRO-return type mismatches, as part of CWG2563. (#GH98744)

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -6464,6 +6464,9 @@ static ExprResult BuildConvertedConstantExpression(Sema &S, Expr *From,
   if (checkPlaceholderForOverload(S, From))
     return ExprError();
 
+  if (From->containsErrors())
+    return S.ImpCastExprToType(From, T, CK_NoOp, From->getValueKind());
+
   // C++1z [expr.const]p3:
   //  A converted constant expression of type T is an expression,
   //  implicitly converted to type T, where the converted

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -6464,8 +6464,13 @@ static ExprResult BuildConvertedConstantExpression(Sema &S, Expr *From,
   if (checkPlaceholderForOverload(S, From))
     return ExprError();
 
-  if (From->containsErrors())
-    return S.ImpCastExprToType(From, T, CK_NoOp, From->getValueKind());
+  if (From->containsErrors()) {
+    // The expression already has errors, so the correct cast kind can't be
+    // determined. Use RecoveryExpr to keep the expected type T and mark the
+    // result as invalid, preventing further cascading errors.
+    return S.CreateRecoveryExpr(From->getBeginLoc(), From->getEndLoc(), {From},
+                                T);
+  }
 
   // C++1z [expr.const]p3:
   //  A converted constant expression of type T is an expression,

--- a/clang/test/SemaCXX/gh183887.cpp
+++ b/clang/test/SemaCXX/gh183887.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+namespace GH183887 {
+enum E1 explicit(E1()); // expected-error {{ISO C++ forbids forward references to 'enum' types}} \
+                        // expected-error {{invalid use of incomplete type 'E1'}} \
+                        // expected-error {{'explicit' can only appear on non-static member functions}} \
+                        // expected-note {{forward declaration of 'GH183887::E1'}}
+}


### PR DESCRIPTION
stop BuildConvertedConstantExpression early for already-broken expressions to prevent crashes in the constant conversion 
fixes #183887