### PR TITLE
[MLIR][XeVM] Mark gpu.printf test with XFAIL.

### DIFF
--- a/mlir/test/Integration/Dialect/XeVM/GPU/gpu_printf.mlir
+++ b/mlir/test/Integration/Dialect/XeVM/GPU/gpu_printf.mlir
@@ -9,6 +9,10 @@
 // RUN:   --entry-point-result=void \
 // RUN: | FileCheck %s
 
+// SPIR-V backend generates incorrect printf ops after
+// https://github.com/llvm/llvm-project/pull/178980 changed the way variadic arguments.
+// are handled. Test is expected to fail until the issue is resolved.
+
 // XFAIL: *
 module @test attributes {gpu.container_module} {
   gpu.module @test_module {

--- a/mlir/test/Integration/Dialect/XeVM/GPU/gpu_printf.mlir
+++ b/mlir/test/Integration/Dialect/XeVM/GPU/gpu_printf.mlir
@@ -9,6 +9,7 @@
 // RUN:   --entry-point-result=void \
 // RUN: | FileCheck %s
 
+// XFAIL: *
 module @test attributes {gpu.container_module} {
   gpu.module @test_module {
     gpu.func @test_printf(%arg0: i32, %arg1: f32) kernel {

--- a/mlir/test/Integration/Dialect/XeVM/GPU/lit.local.cfg
+++ b/mlir/test/Integration/Dialect/XeVM/GPU/lit.local.cfg
@@ -2,5 +2,3 @@ if not config.run_xevm_tests:
     config.unsupported = True
 if not config.enable_levelzero_runner:
     config.unsupported = True
-# Temporary until gpu.printf issue is resolved
-config.excludes = ["gpu_printf.mlir"]

--- a/mlir/test/Integration/Dialect/XeVM/GPU/lit.local.cfg
+++ b/mlir/test/Integration/Dialect/XeVM/GPU/lit.local.cfg
@@ -2,3 +2,5 @@ if not config.run_xevm_tests:
     config.unsupported = True
 if not config.enable_levelzero_runner:
     config.unsupported = True
+# Temporary until gpu.printf issue is resolved
+config.excludes = ["gpu_printf.mlir"]


### PR DESCRIPTION
gpu.printf test is expect to fail until vararg handling issue with SPIR-V backend is resolved.