### PR TITLE
[lldb] Expose block equality with SBBlock.

### DIFF
--- a/lldb/include/lldb/API/SBBlock.h
+++ b/lldb/include/lldb/API/SBBlock.h
@@ -39,8 +39,6 @@ public:
 
   bool IsValid() const;
 
-  lldb::user_id_t GetID() const;
-
   const char *GetInlinedName() const;
 
   lldb::SBFileSpec GetInlinedCallSiteFile() const;

--- a/lldb/include/lldb/API/SBBlock.h
+++ b/lldb/include/lldb/API/SBBlock.h
@@ -15,6 +15,7 @@
 #include "lldb/API/SBFrame.h"
 #include "lldb/API/SBTarget.h"
 #include "lldb/API/SBValueList.h"
+#include "lldb/lldb-types.h"
 
 namespace lldb {
 
@@ -32,7 +33,13 @@ public:
 
   explicit operator bool() const;
 
+  bool operator==(const lldb::SBBlock &rhs) const;
+
+  bool operator!=(const lldb::SBBlock &rhs) const;
+
   bool IsValid() const;
+
+  lldb::user_id_t GetID() const;
 
   const char *GetInlinedName() const;
 

--- a/lldb/source/API/SBBlock.cpp
+++ b/lldb/source/API/SBBlock.cpp
@@ -57,6 +57,9 @@ bool SBBlock::operator==(const SBBlock &rhs) const {
   LLDB_INSTRUMENT_VA(this, rhs);
 
   return m_opaque_ptr != nullptr && rhs.m_opaque_ptr != nullptr &&
+         m_opaque_ptr->GetFunction() == rhs.m_opaque_ptr->GetFunction() &&
+         m_opaque_ptr->GetFunction().GetCompileUnit() ==
+             rhs.m_opaque_ptr->GetFunction().GetCompileUnit() &&
          *m_opaque_ptr == *rhs.m_opaque_ptr;
 }
 
@@ -64,13 +67,6 @@ bool SBBlock::operator!=(const SBBlock &rhs) const {
   LLDB_INSTRUMENT_VA(this, rhs);
 
   return !(*this == rhs);
-}
-
-user_id_t SBBlock::GetID() const {
-  LLDB_INSTRUMENT_VA(this);
-  if (m_opaque_ptr)
-    return m_opaque_ptr->GetID();
-  return LLDB_INVALID_UID;
 }
 
 bool SBBlock::IsInlined() const {

--- a/lldb/source/API/SBBlock.cpp
+++ b/lldb/source/API/SBBlock.cpp
@@ -56,13 +56,14 @@ SBBlock::operator bool() const {
 bool SBBlock::operator==(const SBBlock &rhs) const {
   LLDB_INSTRUMENT_VA(this, rhs);
 
-  return *m_opaque_ptr == *rhs.m_opaque_ptr;
+  return m_opaque_ptr != nullptr && rhs.m_opaque_ptr != nullptr &&
+         *m_opaque_ptr == *rhs.m_opaque_ptr;
 }
 
 bool SBBlock::operator!=(const SBBlock &rhs) const {
   LLDB_INSTRUMENT_VA(this, rhs);
 
-  return *m_opaque_ptr != *rhs.m_opaque_ptr;
+  return !(*this == rhs);
 }
 
 user_id_t SBBlock::GetID() const {

--- a/lldb/source/API/SBBlock.cpp
+++ b/lldb/source/API/SBBlock.cpp
@@ -1,4 +1,4 @@
-//===-- SBBlock.cpp -------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -18,10 +18,9 @@
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/VariableList.h"
-#include "lldb/Target/StackFrame.h"
-#include "lldb/Target/Target.h"
 #include "lldb/Utility/Instrumentation.h"
 #include "lldb/ValueObject/ValueObjectVariable.h"
+#include "lldb/lldb-types.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -52,6 +51,25 @@ SBBlock::operator bool() const {
   LLDB_INSTRUMENT_VA(this);
 
   return m_opaque_ptr != nullptr;
+}
+
+bool SBBlock::operator==(const SBBlock &rhs) const {
+  LLDB_INSTRUMENT_VA(this, rhs);
+
+  return *m_opaque_ptr == *rhs.m_opaque_ptr;
+}
+
+bool SBBlock::operator!=(const SBBlock &rhs) const {
+  LLDB_INSTRUMENT_VA(this, rhs);
+
+  return *m_opaque_ptr != *rhs.m_opaque_ptr;
+}
+
+user_id_t SBBlock::GetID() const {
+  LLDB_INSTRUMENT_VA(this);
+  if (m_opaque_ptr)
+    return m_opaque_ptr->GetID();
+  return LLDB_INVALID_UID;
 }
 
 bool SBBlock::IsInlined() const {
@@ -116,8 +134,9 @@ void SBBlock::AppendVariables(bool can_create, bool get_parent_variables,
                               lldb_private::VariableList *var_list) {
   if (IsValid()) {
     bool show_inline = true;
-    m_opaque_ptr->AppendVariables(can_create, get_parent_variables, show_inline,
-                                  [](Variable *) { return true; }, var_list);
+    m_opaque_ptr->AppendVariables(
+        can_create, get_parent_variables, show_inline,
+        [](Variable *) { return true; }, var_list);
   }
 }
 

--- a/lldb/test/API/python_api/block/Makefile
+++ b/lldb/test/API/python_api/block/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/python_api/block/Makefile
+++ b/lldb/test/API/python_api/block/Makefile
@@ -1,3 +1,5 @@
 C_SOURCES := main.c
+DYLIB_NAME := fn
+DYLIB_C_SOURCES := fn.c
 
 include Makefile.rules

--- a/lldb/test/API/python_api/block/TestBlocks.py
+++ b/lldb/test/API/python_api/block/TestBlocks.py
@@ -10,39 +10,23 @@ from lldbsuite.test import lldbutil
 
 class BlockAPITestCase(TestBase):
     def test_block_equality(self):
-        """Exercise SBBlock equality checks."""
+        """Exercise SBBlock equality checks across frames and functions in different dylibs."""
         self.build()
-        exe = self.getBuildArtifact("a.out")
-
-        # Create a target by the debugger.
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        line1 = line_number("main.c", "// breakpoint 1")
-        line2 = line_number("fn.c", "// breakpoint 2")
-        breakpoint1 = target.BreakpointCreateByLocation("main.c", line1)
-        breakpoint2 = target.BreakpointCreateByLocation("fn.c", line2)
-
-        # Now launch the process, and do not stop at the entry point.
-        process = target.LaunchSimple(None, None, self.get_process_working_directory())
-        self.assertState(process.GetState(), lldb.eStateStopped, PROCESS_STOPPED)
-
-        threads = lldbutil.get_threads_stopped_at_breakpoint(process, breakpoint1)
-        self.assertEqual(
-            len(threads), 1, "There should be a thread stopped at breakpoint 1"
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "// breakpoint 1", lldb.SBFileSpec("main.c"), extra_images=["libfn"]
         )
 
-        thread = threads[0]
-        self.assertTrue(thread.IsValid(), "Thread must be valid")
         frame = thread.GetFrameAtIndex(0)
         self.assertTrue(frame.IsValid(), "Frame must be valid")
 
         main_frame_block = frame.GetFrameBlock()
 
-        # Continue to breakpoint 2
-        process.Continue()
-
-        threads = lldbutil.get_threads_stopped_at_breakpoint(process, breakpoint2)
+        threads = lldbutil.continue_to_source_breakpoint(
+            self,
+            process,
+            "// breakpoint 2",
+            lldb.SBFileSpec("fn.c"),
+        )
         self.assertEqual(
             len(threads), 1, "There should be a thread stopped at breakpoint 2"
         )

--- a/lldb/test/API/python_api/block/TestBlocks.py
+++ b/lldb/test/API/python_api/block/TestBlocks.py
@@ -18,11 +18,10 @@ class BlockAPITestCase(TestBase):
         target = self.dbg.CreateTarget(exe)
         self.assertTrue(target, VALID_TARGET)
 
-        source = "main.c"
-        line1 = line_number(source, "// breakpoint 1")
-        line2 = line_number(source, "// breakpoint 2")
-        breakpoint1 = target.BreakpointCreateByLocation(source, line1)
-        breakpoint2 = target.BreakpointCreateByLocation(source, line2)
+        line1 = line_number("main.c", "// breakpoint 1")
+        line2 = line_number("fn.c", "// breakpoint 2")
+        breakpoint1 = target.BreakpointCreateByLocation("main.c", line1)
+        breakpoint2 = target.BreakpointCreateByLocation("fn.c", line2)
         self.assertGreaterEqual(breakpoint1.GetNumLocations(), 1, PROCESS_IS_VALID)
         self.assertGreaterEqual(breakpoint2.GetNumLocations(), 1, PROCESS_IS_VALID)
 
@@ -41,7 +40,6 @@ class BlockAPITestCase(TestBase):
         self.assertTrue(frame.IsValid(), "Frame must be valid")
 
         main_frame_block = frame.GetFrameBlock()
-        self.assertNotEqual(main_frame_block.GetID(), 0, "Invalid block id")
 
         # Continue to breakpoint 2
         process.Continue()
@@ -57,10 +55,7 @@ class BlockAPITestCase(TestBase):
         self.assertTrue(frame.IsValid(), "Frame must be valid")
 
         fn_frame_block = frame.GetFrameBlock()
-        self.assertNotEqual(fn_frame_block.GetID(), 0, "Invalid block id")
-
         fn_inner_block = frame.GetBlock()
-        self.assertNotEqual(fn_inner_block.GetID(), 0, "Invalid block id")
 
         # Check __eq__ / __ne__
         self.assertNotEqual(fn_inner_block, fn_frame_block)

--- a/lldb/test/API/python_api/block/TestBlocks.py
+++ b/lldb/test/API/python_api/block/TestBlocks.py
@@ -1,0 +1,68 @@
+"""
+Use lldb Python SBBlock API to access specific scopes within a frame.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class BlockAPITestCase(TestBase):
+    def test_block_equality(self):
+        """Exercise SBBlock equality checks."""
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+
+        # Create a target by the debugger.
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        source = "main.c"
+        line1 = line_number(source, "// breakpoint 1")
+        line2 = line_number(source, "// breakpoint 2")
+        breakpoint1 = target.BreakpointCreateByLocation(source, line1)
+        breakpoint2 = target.BreakpointCreateByLocation(source, line2)
+        self.assertGreaterEqual(breakpoint1.GetNumLocations(), 1, PROCESS_IS_VALID)
+        self.assertGreaterEqual(breakpoint2.GetNumLocations(), 1, PROCESS_IS_VALID)
+
+        # Now launch the process, and do not stop at the entry point.
+        process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        self.assertState(process.GetState(), lldb.eStateStopped, PROCESS_STOPPED)
+
+        threads = lldbutil.get_threads_stopped_at_breakpoint(process, breakpoint1)
+        self.assertEqual(
+            len(threads), 1, "There should be a thread stopped at breakpoint 1"
+        )
+
+        thread = threads[0]
+        self.assertTrue(thread.IsValid(), "Thread must be valid")
+        frame = thread.GetFrameAtIndex(0)
+        self.assertTrue(frame.IsValid(), "Frame must be valid")
+
+        main_frame_block = frame.GetFrameBlock()
+        self.assertNotEqual(main_frame_block.GetID(), 0, "Invalid block id")
+
+        # Continue to breakpoint 2
+        process.Continue()
+
+        threads = lldbutil.get_threads_stopped_at_breakpoint(process, breakpoint2)
+        self.assertEqual(
+            len(threads), 1, "There should be a thread stopped at breakpoint 2"
+        )
+
+        thread = threads[0]
+        self.assertTrue(thread.IsValid(), "Thread must be valid")
+        frame = thread.GetFrameAtIndex(0)
+        self.assertTrue(frame.IsValid(), "Frame must be valid")
+
+        fn_frame_block = frame.GetFrameBlock()
+        self.assertNotEqual(fn_frame_block.GetID(), 0, "Invalid block id")
+
+        fn_inner_block = frame.GetBlock()
+        self.assertNotEqual(fn_inner_block.GetID(), 0, "Invalid block id")
+
+        # Check __eq__ / __ne__
+        self.assertNotEqual(fn_inner_block, fn_frame_block)
+        self.assertNotEqual(main_frame_block, fn_frame_block)
+        self.assertEqual(fn_inner_block.GetParent(), fn_frame_block)

--- a/lldb/test/API/python_api/block/TestBlocks.py
+++ b/lldb/test/API/python_api/block/TestBlocks.py
@@ -22,8 +22,6 @@ class BlockAPITestCase(TestBase):
         line2 = line_number("fn.c", "// breakpoint 2")
         breakpoint1 = target.BreakpointCreateByLocation("main.c", line1)
         breakpoint2 = target.BreakpointCreateByLocation("fn.c", line2)
-        self.assertGreaterEqual(breakpoint1.GetNumLocations(), 1, PROCESS_IS_VALID)
-        self.assertGreaterEqual(breakpoint2.GetNumLocations(), 1, PROCESS_IS_VALID)
 
         # Now launch the process, and do not stop at the entry point.
         process = target.LaunchSimple(None, None, self.get_process_working_directory())

--- a/lldb/test/API/python_api/block/TestBlocks.py
+++ b/lldb/test/API/python_api/block/TestBlocks.py
@@ -56,6 +56,20 @@ class BlockAPITestCase(TestBase):
         fn_inner_block = frame.GetBlock()
 
         # Check __eq__ / __ne__
+        self.assertNotEqual(lldb.SBBlock(), lldb.SBBlock())
         self.assertNotEqual(fn_inner_block, fn_frame_block)
         self.assertNotEqual(main_frame_block, fn_frame_block)
         self.assertEqual(fn_inner_block.GetParent(), fn_frame_block)
+        self.assertEqual(fn_frame_block.GetFirstChild(), fn_inner_block)
+
+        # Load the main function with a different API to ensure we have two
+        # distinct SBBlock objects.
+        main_func_list = target.FindModule(target.GetExecutable()).FindFunctions("main")
+        self.assertEqual(main_func_list.GetSize(), 1)
+        main_func = main_func_list.GetContextAtIndex(0).GetFunction()
+        self.assertIsNotNone(main_func)
+
+        # Ensure they we have two distinct objects that represent the same block
+        main_func_block = main_func.GetBlock()
+        self.assertIsNot(main_func_block, main_frame_block)
+        self.assertEqual(main_func_block, main_frame_block)

--- a/lldb/test/API/python_api/block/fn.c
+++ b/lldb/test/API/python_api/block/fn.c
@@ -1,0 +1,8 @@
+extern int fn(int a, int b) {
+  if (a < b) {
+    int sum = a + b;
+    return sum; // breakpoint 2
+  }
+
+  return a * b;
+}

--- a/lldb/test/API/python_api/block/main.c
+++ b/lldb/test/API/python_api/block/main.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+
+int fn(int a, int b) {
+    if (a < b) {
+      int sum = a + b;
+      return sum; // breakpoint 2
+    }
+
+    return a * b;
+}
+
+int main(int argc, char const *argv[]) {
+    int a = 3;
+    int b = 17;
+    int sum = fn(a, b); // breakpoint 1
+    printf("fn(3, 17) returns %d\n", sum);
+    return 0;
+}

--- a/lldb/test/API/python_api/block/main.c
+++ b/lldb/test/API/python_api/block/main.c
@@ -1,13 +1,6 @@
 #include <stdio.h>
 
-int fn(int a, int b) {
-  if (a < b) {
-    int sum = a + b;
-    return sum; // breakpoint 2
-  }
-
-  return a * b;
-}
+extern int fn(int a, int b);
 
 int main(int argc, char const *argv[]) {
   int a = 3;

--- a/lldb/test/API/python_api/block/main.c
+++ b/lldb/test/API/python_api/block/main.c
@@ -1,18 +1,18 @@
 #include <stdio.h>
 
 int fn(int a, int b) {
-    if (a < b) {
-      int sum = a + b;
-      return sum; // breakpoint 2
-    }
+  if (a < b) {
+    int sum = a + b;
+    return sum; // breakpoint 2
+  }
 
-    return a * b;
+  return a * b;
 }
 
 int main(int argc, char const *argv[]) {
-    int a = 3;
-    int b = 17;
-    int sum = fn(a, b); // breakpoint 1
-    printf("fn(3, 17) returns %d\n", sum);
-    return 0;
+  int a = 3;
+  int b = 17;
+  int sum = fn(a, b); // breakpoint 1
+  printf("fn(3, 17) returns %d\n", sum);
+  return 0;
 }


### PR DESCRIPTION
Adding the `operator==` and `operator!=` for SBBlock. This should allow us to compare blocks within a frame, like:

```python
block = frame.GetBlock()
while True:
  if block == frame.GetFrameBlock():
    # we're at the top function scope.
  else:
    # we're at an inner block scope.
```