### PR TITLE
[Github] Enable long paths in windows CI Container

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -89,6 +89,11 @@ RUN powershell -Command \
 RUN git config --system core.longpaths true & \
     git config --global core.autocrlf false
 
+# Enable long paths so that ninja can work with paths longer than 260 characters.
+RUN powershell -Command \
+    New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" \
+    -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+
 ARG RUNNER_VERSION=2.331.0
 ENV RUNNER_VERSION=$RUNNER_VERSION
 


### PR DESCRIPTION
Otherwise we run into issues with file paths >260 characters. This was preventing us from updating the Windows container as last time we built the container it came with a MSVC supplied CMake update, which used absolute paths in more places, bumping us over the limit.

https://github.com/ninja-build/ninja/issues/2400
https://gitlab.kitware.com/cmake/cmake/-/issues/22435