### PR TITLE
[clang][CIR] Pass VFS to command-line parsing

### DIFF
--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -293,7 +293,9 @@ bool ExecuteCompilerInvocation(CompilerInstance *Clang) {
     for (unsigned i = 0; i != NumArgs; ++i)
       Args[i + 1] = Clang->getFrontendOpts().MLIRArgs[i].c_str();
     Args[NumArgs + 1] = nullptr;
-    llvm::cl::ParseCommandLineOptions(NumArgs + 1, Args.get());
+    llvm::cl::ParseCommandLineOptions(NumArgs + 1, Args.get(),
+                                      /*Description=*/"", /*Errs=*/nullptr,
+                                      &Clang->getVirtualFileSystem());
   }
 #endif
 


### PR DESCRIPTION
This explicitly passes Clang's VFS to MLIR command-line parsing that runs when ClangIR is enabled. This matches the rest of Clang and fixes a sandbox violation.