### PR TITLE
[flang] Remove usage of the `DependencyConsumer::finish()` API

### DIFF
--- a/flang/tools/flang-driver/driver.cpp
+++ b/flang/tools/flang-driver/driver.cpp
@@ -221,8 +221,6 @@ int main(int argc, const char **argv) {
     }
   }
 
-  diags.getClient()->finish();
-
   // If we have multiple failing commands, we return the result of the first
   // failing command.
   return res;


### PR DESCRIPTION
This fixes build failures after #183831.