### PR TITLE
[Github] Respect LLVM_VERSION when building windows container

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -116,18 +116,18 @@ RUN powershell -Command \
     Add-Type -AssemblyName "System.IO.Compression.FileSystem"; \
     [System.IO.Compression.ZipFile]::ExtractToDirectory('C:\temp-download\xz.zip', 'C:\xz-utils'); \ 
     # --- 2. Download and decompress Clang --- \
-    Invoke-WebRequest -Uri "http://github.com/llvm/llvm-project/releases/download/llvmorg-21.1.2/clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz" -OutFile "clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz" ; \
-    (Get-FileHash -Path "C:\temp-download\clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz" -Algorithm MD5).Hash -eq '0ae1d3effd9ab9d323f7fa595777f0a2' ; \
-    C:\xz-utils\bin_x86-64\xz.exe -d -qq clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar.xz ; \
+    Invoke-WebRequest -Uri "http://github.com/llvm/llvm-project/releases/download/llvmorg-${env:LLVM_VERSION}/clang+llvm-${env:LLVM_VERSION}-x86_64-pc-windows-msvc.tar.xz" -OutFile "clang+llvm-${env:LLVM_VERSION}-x86_64-pc-windows-msvc.tar.xz" ; \
+    (Get-FileHash -Path "C:\temp-download\clang+llvm-${env:LLVM_VERSION}-x86_64-pc-windows-msvc.tar.xz" -Algorithm MD5).Hash -eq '0ae1d3effd9ab9d323f7fa595777f0a2' ; \
+    C:\xz-utils\bin_x86-64\xz.exe -d -qq clang+llvm-${env:LLVM_VERSION}-x86_64-pc-windows-msvc.tar.xz ; \
     # --- 3. Extract clang --- \
-    C:\Windows\System32\tar.exe -xf clang+llvm-21.1.2-x86_64-pc-windows-msvc.tar -C C:\clang ; \
+    C:\Windows\System32\tar.exe -xf clang+llvm-${env:LLVM_VERSION}-x86_64-pc-windows-msvc.tar -C C:\clang ; \
     # --- 4. Clean up --- \
     Set-Location C:\ ; \
     Remove-Item C:\temp-download -Recurse -Force; \
     Remove-Item C:\xz-utils -Recurse -Force; \
     # -- 5. Shorten path to clang files & remove unnecessary files -- \
     Set-Location C:\clang ; \
-    Rename-Item -Path "C:\clang\clang+llvm-21.1.2-x86_64-pc-windows-msvc" -NewName "C:\clang\clang-msvc" ; \
+    Rename-Item -Path "C:\clang\clang+llvm-${env:LLVM_VERSION}-x86_64-pc-windows-msvc" -NewName "C:\clang\clang-msvc" ; \
     Set-Location C:\clang\clang-msvc ; \
     Remove-Item -Path C:\clang\clang-msvc\libexec -Recurse -Force ; \
     Remove-Item -Path C:\clang\clang-msvc\share -Recurse -Force ; \


### PR DESCRIPTION
Otherwise setting LLVM_VERSION does not actually do anything. This avoids needing to update ~8 different locations in the file when doing a toolchain bump to just 1 place.