### PR TITLE
[clang][deps] Remove the `finalize()` API for by-module-name scans

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
+++ b/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
@@ -147,14 +147,13 @@ public:
                               const std::vector<std::string> &CMD)
       : Worker(Worker), CWD(CWD), CommandLine(CMD) {};
 
-  // The three methods below returns false when they fail, with the detail
+  // The two methods below returns false when they fail, with the detail
   // accumulated in \c DiagEngineWithDiagOpts's diagnostic consumer.
   bool initialize(
       std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithDiagOpts,
       IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS);
   bool computeDependencies(StringRef ModuleName, DependencyConsumer &Consumer,
                            DependencyActionController &Controller);
-  bool finalize();
 };
 } // namespace dependencies
 } // namespace clang

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -125,7 +125,7 @@ public:
       llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS =
           nullptr);
 
-  /// The three method below implements a new interface for by name
+  /// The two method below implements a new interface for by name
   /// dependency scanning. They together enable the dependency scanning worker
   /// to more effectively perform scanning for a sequence of modules
   /// by name when the CWD and CommandLine do not change across the queries.
@@ -163,10 +163,6 @@ public:
   computeDependenciesByNameWithContext(StringRef ModuleName,
                                        DependencyConsumer &Consumer,
                                        DependencyActionController &Controller);
-
-  /// @brief Finalizes the diagnostics engine and deletes the compiler instance.
-  /// @return False if errors occur during finalization.
-  bool finalizeCompilerInstanceWithContext();
 
   llvm::vfs::FileSystem &getVFS() const { return *DepFS; }
 

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -111,7 +111,7 @@ public:
       const llvm::DenseSet<dependencies::ModuleID> &AlreadySeen,
       dependencies::LookupModuleOutputCallback LookupModuleOutput);
 
-  /// The following three methods provide a new interface to perform
+  /// The following two methods provide a new interface to perform
   /// by name dependency scan. The new interface's intention is to improve
   /// dependency scanning performance when a sequence of name is looked up
   /// with the same current working directory and the command line.
@@ -144,12 +144,6 @@ public:
       StringRef ModuleName,
       const llvm::DenseSet<dependencies::ModuleID> &AlreadySeen,
       dependencies::LookupModuleOutputCallback LookupModuleOutput);
-
-  /// @brief This method finializes the compiler instance. It finalizes the
-  ///        diagnostics and deletes the compiler instance. Call this method
-  ///        once all names for a same commandline are scanned.
-  /// @return Error if an error occured during finalization.
-  llvm::Error finalizeCompilerInstanceWithContextOrError();
 
   llvm::vfs::FileSystem &getWorkerVFS() const { return Worker.getVFS(); }
 

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -958,5 +958,3 @@ bool CompilerInstanceWithContext::computeDependencies(
 
   return true;
 }
-
-bool CompilerInstanceWithContext::finalize() { return true; }

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -137,10 +137,6 @@ bool DependencyScanningWorker::computeDependenciesByNameWithContext(
   return CIWithContext->computeDependencies(ModuleName, Consumer, Controller);
 }
 
-bool DependencyScanningWorker::finalizeCompilerInstanceWithContext() {
-  return CIWithContext->finalize();
-}
-
 std::pair<IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem>,
           std::vector<std::string>>
 dependencies::initVFSForTUBufferScanning(

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -286,13 +286,8 @@ DependencyScanningTool::getModuleDependencies(
           initializeCompilerInstanceWithContextOrError(CWD, CommandLine))
     return Error;
 
-  auto Result = computeDependenciesByNameWithContextOrError(
-      ModuleName, AlreadySeen, LookupModuleOutput);
-
-  if (auto Error = finalizeCompilerInstanceWithContextOrError())
-    return Error;
-
-  return Result;
+  return computeDependenciesByNameWithContextOrError(ModuleName, AlreadySeen,
+                                                     LookupModuleOutput);
 }
 
 static std::optional<SmallVector<std::string, 0>> getFirstCC1CommandLine(
@@ -370,12 +365,5 @@ DependencyScanningTool::computeDependenciesByNameWithContextOrError(
   if (Worker.computeDependenciesByNameWithContext(ModuleName, Consumer,
                                                   Controller))
     return Consumer.takeTranslationUnitDeps();
-  return makeErrorFromDiagnosticsOS(*DiagPrinterWithOS);
-}
-
-llvm::Error
-DependencyScanningTool::finalizeCompilerInstanceWithContextOrError() {
-  if (Worker.finalizeCompilerInstanceWithContext())
-    return llvm::Error::success();
   return makeErrorFromDiagnosticsOS(*DiagPrinterWithOS);
 }

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1090,14 +1090,6 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
               HadErrors = true;
             }
           }
-
-          if (llvm::Error Err =
-                  WorkerTool.finalizeCompilerInstanceWithContextOrError()) {
-            handleErrorWithInfoString(
-                "Compiler instance with context finialization error",
-                std::move(Err), DependencyOS, Errs);
-            HadErrors = true;
-          }
         }
       } else {
         std::unique_ptr<llvm::MemoryBuffer> TU;


### PR DESCRIPTION
The `DiagnosticConsumer::finish()` API was removed in #183831. Since that was the only thing the by-module-name `finalize()` API called, we can safely remove that and simplify the scanner.