### PR TITLE
[Github][bazel] Run `buildifier --mode=diff` on error

### DIFF
--- a/.github/workflows/bazel-checks.yml
+++ b/.github/workflows/bazel-checks.yml
@@ -29,8 +29,17 @@ jobs:
           sudo chmod +x /usr/bin/buildifier
       - name: Run Buildifier
         run: |
-          buildifier --mode=check $(find ./utils/bazel -name *BUILD*)
-  
+          BZL_FILES=$(find ./utils/bazel -name *BUILD* -o -name '*bzl' -o -name '*.bazel')
+          if ! buildifier --mode=check $BZL_FILES; then
+            echo "::error::Buildifier formatting issues found."
+            echo "::group::Buildifier Diff"
+            buildifier --mode=diff $BZL_FILES
+            echo "::endgroup::"
+            exit 1
+          else
+            echo "All files are formatted correctly."
+          fi
+
   bazel-build:
     name: "Bazel Build/Test"
     # Only run on US Central workers so we only have to keep one cache warm as

--- a/utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel
@@ -87,8 +87,8 @@ cc_library(
     copts = llvm_copts,
     deps = [
         ":gmock",
-        "//llvm:Support",
         ":gtest",
+        "//llvm:Support",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel
@@ -87,8 +87,8 @@ cc_library(
     copts = llvm_copts,
     deps = [
         ":gmock",
-        ":gtest",
         "//llvm:Support",
+        ":gtest",
     ],
 )
 


### PR DESCRIPTION
Displaying the diff helps point to what the issue is, including if it's even related to the change at all.

This also expands the pattern to some other files that don't match `*BUILD*`, e.g. `*.bzl` files.

Example failure: https://github.com/llvm/llvm-project/actions/runs/22595929783/job/65465781106