### PR TITLE
[LoopUnrollAndJam] Drop ExplicitUnroll check from computeUnrollAndJamCount

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
@@ -157,25 +157,15 @@ static bool computeUnrollAndJamCount(
     TargetTransformInfo::UnrollingPreferences &UP,
     TargetTransformInfo::PeelingPreferences &PP) {
   unsigned OuterLoopSize = OuterUCE.getRolledLoopSize();
-  // First up use computeUnrollCount from the loop unroller to get a count
-  // for unrolling the outer loop, plus any loops requiring explicit
-  // unrolling we leave to the unroller. This uses UP.Threshold /
-  // UP.PartialThreshold / UP.MaxCount to come up with sensible loop values.
-  // We have already checked that the loop has no unroll.* pragmas.
+  // Use computeUnrollCount from the loop unroller to get a count for
+  // unrolling the outer loop. We have already checked that the loop has no
+  // unroll.* pragmas, so this is purely heuristic-driven.
   unsigned MaxTripCount = 0;
   bool UseUpperBound = false;
-  bool ExplicitUnroll = computeUnrollCount(
+  computeUnrollCount(
     L, TTI, DT, LI, AC, SE, EphValues, ORE, OuterTripCount, MaxTripCount,
       /*MaxOrZero*/ false, OuterTripMultiple, OuterUCE, UP, PP,
       UseUpperBound);
-  if (ExplicitUnroll || UseUpperBound) {
-    // If the user explicitly set the loop as unrolled, dont UnJ it. Leave it
-    // for the unroller instead.
-    LLVM_DEBUG(dbgs() << "Won't unroll-and-jam; explicit count set by "
-                         "computeUnrollCount\n");
-    UP.Count = 0;
-    return false;
-  }
 
   // Override with any explicit Count from the "unroll-and-jam-count" option.
   bool UserUnrollCount = UnrollAndJamCount.getNumOccurrences() > 0;


### PR DESCRIPTION
## Summary

- Remove the `ExplicitUnroll` and `UseUpperBound` checks from `computeUnrollAndJamCount`
- `tryToUnrollAndJamLoop` already bails out for loops with `unroll.*` pragmas (lines 310-314), making the pragma portion of `ExplicitUnroll` redundant
- The only remaining case `ExplicitUnroll` caught was the `-unroll-count` CLI flag, which is a testing-only option (`"for testing purposes"`) that no `LoopUnrollAndJam` tests exercise
- `UseUpperBound` is dead code: `computeUnrollAndJamCount` always passes `MaxTripCount = 0`, and `UseUpperBound` is only set when `MaxTripCount` is nonzero

## Test plan

- [x] `llvm-lit Transforms/LoopUnroll` — all 174 pass
- [x] `llvm-lit Transforms/LoopUnrollAndJam` — all 19 pass