### PR TITLE
[LoopUnroll] Eliminate `computeUnrollCount`'s return value

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
+++ b/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
@@ -157,14 +157,15 @@ public:
                       unsigned CountOverwrite = 0) const;
 };
 
-LLVM_ABI void computeUnrollCount(
-    Loop *L, const TargetTransformInfo &TTI, DominatorTree &DT, LoopInfo *LI,
-    AssumptionCache *AC, ScalarEvolution &SE,
-    const SmallPtrSetImpl<const Value *> &EphValues,
-    OptimizationRemarkEmitter *ORE, unsigned TripCount, unsigned MaxTripCount,
-    bool MaxOrZero, unsigned TripMultiple, const UnrollCostEstimator &UCE,
-    TargetTransformInfo::UnrollingPreferences &UP,
-    TargetTransformInfo::PeelingPreferences &PP);
+LLVM_ABI void
+computeUnrollCount(Loop *L, const TargetTransformInfo &TTI, DominatorTree &DT,
+                   LoopInfo *LI, AssumptionCache *AC, ScalarEvolution &SE,
+                   const SmallPtrSetImpl<const Value *> &EphValues,
+                   OptimizationRemarkEmitter *ORE, unsigned TripCount,
+                   unsigned MaxTripCount, bool MaxOrZero, unsigned TripMultiple,
+                   const UnrollCostEstimator &UCE,
+                   TargetTransformInfo::UnrollingPreferences &UP,
+                   TargetTransformInfo::PeelingPreferences &PP);
 
 LLVM_ABI std::optional<RecurrenceDescriptor>
 canParallelizeReductionWhenUnrolling(PHINode &Phi, Loop *L,

--- a/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
+++ b/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
@@ -157,7 +157,7 @@ public:
                       unsigned CountOverwrite = 0) const;
 };
 
-LLVM_ABI bool computeUnrollCount(
+LLVM_ABI void computeUnrollCount(
     Loop *L, const TargetTransformInfo &TTI, DominatorTree &DT, LoopInfo *LI,
     AssumptionCache *AC, ScalarEvolution &SE,
     const SmallPtrSetImpl<const Value *> &EphValues,

--- a/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
+++ b/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
@@ -164,7 +164,7 @@ LLVM_ABI void computeUnrollCount(
     OptimizationRemarkEmitter *ORE, unsigned TripCount, unsigned MaxTripCount,
     bool MaxOrZero, unsigned TripMultiple, const UnrollCostEstimator &UCE,
     TargetTransformInfo::UnrollingPreferences &UP,
-    TargetTransformInfo::PeelingPreferences &PP, bool &UseUpperBound);
+    TargetTransformInfo::PeelingPreferences &PP);
 
 LLVM_ABI std::optional<RecurrenceDescriptor>
 canParallelizeReductionWhenUnrolling(PHINode &Phi, Loop *L,

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -7110,10 +7110,8 @@ static int32_t computeHeuristicUnrollFactor(CanonicalLoopInfo *CLI) {
   bool MaxOrZero = false;
   unsigned TripMultiple = 0;
 
-  bool UseUpperBound = false;
   computeUnrollCount(L, TTI, DT, &LI, &AC, SE, EphValues, &ORE, TripCount,
-                     MaxTripCount, MaxOrZero, TripMultiple, UCE, UP, PP,
-                     UseUpperBound);
+                     MaxTripCount, MaxOrZero, TripMultiple, UCE, UP, PP);
   unsigned Factor = UP.Count;
   LLVM_DEBUG(dbgs() << "Suggesting unroll factor of " << Factor << "\n");
 

--- a/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
@@ -160,12 +160,10 @@ static bool computeUnrollAndJamCount(
   // Use computeUnrollCount from the loop unroller to get a count for
   // unrolling the outer loop. We have already checked that the loop has no
   // unroll.* pragmas, so this is purely heuristic-driven.
-  unsigned MaxTripCount = 0;
-  bool UseUpperBound = false;
   computeUnrollCount(
-    L, TTI, DT, LI, AC, SE, EphValues, ORE, OuterTripCount, MaxTripCount,
-      /*MaxOrZero*/ false, OuterTripMultiple, OuterUCE, UP, PP,
-      UseUpperBound);
+    L, TTI, DT, LI, AC, SE, EphValues, ORE, OuterTripCount,
+      /*MaxTripCount*/ 0, /*MaxOrZero*/ false, OuterTripMultiple, OuterUCE,
+      UP, PP);
 
   // Override with any explicit Count from the "unroll-and-jam-count" option.
   bool UserUnrollCount = UnrollAndJamCount.getNumOccurrences() > 0;

--- a/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
@@ -157,25 +157,15 @@ static bool computeUnrollAndJamCount(
     TargetTransformInfo::UnrollingPreferences &UP,
     TargetTransformInfo::PeelingPreferences &PP) {
   unsigned OuterLoopSize = OuterUCE.getRolledLoopSize();
-  // First up use computeUnrollCount from the loop unroller to get a count
-  // for unrolling the outer loop, plus any loops requiring explicit
-  // unrolling we leave to the unroller. This uses UP.Threshold /
-  // UP.PartialThreshold / UP.MaxCount to come up with sensible loop values.
-  // We have already checked that the loop has no unroll.* pragmas.
+  // Use computeUnrollCount from the loop unroller to get a count for
+  // unrolling the outer loop. We have already checked that the loop has no
+  // unroll.* pragmas, so this is purely heuristic-driven.
   unsigned MaxTripCount = 0;
   bool UseUpperBound = false;
-  bool ExplicitUnroll = computeUnrollCount(
+  computeUnrollCount(
     L, TTI, DT, LI, AC, SE, EphValues, ORE, OuterTripCount, MaxTripCount,
       /*MaxOrZero*/ false, OuterTripMultiple, OuterUCE, UP, PP,
       UseUpperBound);
-  if (ExplicitUnroll || UseUpperBound) {
-    // If the user explicitly set the loop as unrolled, dont UnJ it. Leave it
-    // for the unroller instead.
-    LLVM_DEBUG(dbgs() << "Won't unroll-and-jam; explicit count set by "
-                         "computeUnrollCount\n");
-    UP.Count = 0;
-    return false;
-  }
 
   // Override with any explicit Count from the "unroll-and-jam-count" option.
   bool UserUnrollCount = UnrollAndJamCount.getNumOccurrences() > 0;

--- a/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
@@ -160,10 +160,9 @@ static bool computeUnrollAndJamCount(
   // Use computeUnrollCount from the loop unroller to get a count for
   // unrolling the outer loop. We have already checked that the loop has no
   // unroll.* pragmas, so this is purely heuristic-driven.
-  computeUnrollCount(
-    L, TTI, DT, LI, AC, SE, EphValues, ORE, OuterTripCount,
-      /*MaxTripCount*/ 0, /*MaxOrZero*/ false, OuterTripMultiple, OuterUCE,
-      UP, PP);
+  computeUnrollCount(L, TTI, DT, LI, AC, SE, EphValues, ORE, OuterTripCount,
+                     /*MaxTripCount*/ 0, /*MaxOrZero*/ false, OuterTripMultiple,
+                     OuterUCE, UP, PP);
 
   // Override with any explicit Count from the "unroll-and-jam-count" option.
   bool UserUnrollCount = UnrollAndJamCount.getNumOccurrences() > 0;

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -330,13 +330,12 @@ struct EstimatedUnrollCost {
 };
 
 struct PragmaInfo {
-  PragmaInfo(bool UUC, bool PFU, unsigned PC, bool PEU)
-      : UserUnrollCount(UUC), PragmaFullUnroll(PFU), PragmaCount(PC),
-        PragmaEnableUnroll(PEU) {}
+  PragmaInfo(Loop *L);
   const bool UserUnrollCount;
   const bool PragmaFullUnroll;
   const unsigned PragmaCount;
   const bool PragmaEnableUnroll;
+  const bool ExplicitUnroll;
 };
 
 } // end anonymous namespace
@@ -786,6 +785,14 @@ static unsigned unrollCountPragmaValue(const Loop *L) {
   return 0;
 }
 
+PragmaInfo::PragmaInfo(Loop *L)
+    : UserUnrollCount(UnrollCount.getNumOccurrences() > 0),
+      PragmaFullUnroll(hasUnrollFullPragma(L)),
+      PragmaCount(unrollCountPragmaValue(L)),
+      PragmaEnableUnroll(hasUnrollEnablePragma(L)),
+      ExplicitUnroll(PragmaCount > 0 || PragmaFullUnroll ||
+                     PragmaEnableUnroll || UserUnrollCount) {}
+
 // Computes the boosting factor for complete unrolling.
 // If fully unrolling the loop would save a lot of RolledDynamicCost, it would
 // be beneficial to fully unroll the loop even if unrolledcost is large. We
@@ -932,7 +939,7 @@ shouldPartialUnroll(const unsigned LoopSize, const unsigned TripCount,
 // FIXME: This function is used by LoopUnroll and LoopUnrollAndJam, but consumes
 // many LoopUnroll-specific options. The shared functionality should be
 // refactored into it own function.
-bool llvm::computeUnrollCount(
+void llvm::computeUnrollCount(
     Loop *L, const TargetTransformInfo &TTI, DominatorTree &DT, LoopInfo *LI,
     AssumptionCache *AC, ScalarEvolution &SE,
     const SmallPtrSetImpl<const Value *> &EphValues,
@@ -943,16 +950,7 @@ bool llvm::computeUnrollCount(
 
   unsigned LoopSize = UCE.getRolledLoopSize();
 
-  const bool UserUnrollCount = UnrollCount.getNumOccurrences() > 0;
-  const bool PragmaFullUnroll = hasUnrollFullPragma(L);
-  const unsigned PragmaCount = unrollCountPragmaValue(L);
-  const bool PragmaEnableUnroll = hasUnrollEnablePragma(L);
-
-  const bool ExplicitUnroll = PragmaCount > 0 || PragmaFullUnroll ||
-                              PragmaEnableUnroll || UserUnrollCount;
-
-  PragmaInfo PInfo(UserUnrollCount, PragmaFullUnroll, PragmaCount,
-                   PragmaEnableUnroll);
+  PragmaInfo PInfo(L);
   // Use an explicit peel count that has been specified for testing. In this
   // case it's not permitted to also specify an explicit unroll count.
   if (PP.PeelCount) {
@@ -962,7 +960,7 @@ bool llvm::computeUnrollCount(
     }
     UP.Count = 1;
     UP.Runtime = false;
-    return true;
+    return;
   }
   // Check for explicit Count.
   // 1st priority is unroll count set by "unroll-count" option.
@@ -971,14 +969,14 @@ bool llvm::computeUnrollCount(
                                              MaxTripCount, UCE, UP)) {
     UP.Count = *UnrollFactor;
 
-    if (UserUnrollCount || (PragmaCount > 0)) {
+    if (PInfo.UserUnrollCount || (PInfo.PragmaCount > 0)) {
       UP.AllowExpensiveTripCount = true;
       UP.Force = true;
     }
-    UP.Runtime |= (PragmaCount > 0);
-    return ExplicitUnroll;
+    UP.Runtime |= (PInfo.PragmaCount > 0);
+    return;
   } else {
-    if (ExplicitUnroll && TripCount != 0) {
+    if (PInfo.ExplicitUnroll && TripCount != 0) {
       // If the loop has an unrolling pragma, we want to be more aggressive with
       // unrolling limits. Set thresholds to at least the PragmaUnrollThreshold
       // value which is larger than the default limits.
@@ -997,7 +995,7 @@ bool llvm::computeUnrollCount(
                                              TripCount, UCE, UP)) {
       UP.Count = *UnrollFactor;
       UseUpperBound = false;
-      return ExplicitUnroll;
+      return;
     }
   }
 
@@ -1020,7 +1018,7 @@ bool llvm::computeUnrollCount(
                                              MaxTripCount, UCE, UP)) {
       UP.Count = *UnrollFactor;
       UseUpperBound = true;
-      return ExplicitUnroll;
+      return;
     }
   }
 
@@ -1029,20 +1027,20 @@ bool llvm::computeUnrollCount(
   if (PP.PeelCount) {
     UP.Runtime = false;
     UP.Count = 1;
-    return ExplicitUnroll;
+    return;
   }
 
   // Before starting partial unrolling, set up.partial to true,
   // if user explicitly asked  for unrolling
   if (TripCount)
-    UP.Partial |= ExplicitUnroll;
+    UP.Partial |= PInfo.ExplicitUnroll;
 
   // 6th priority is partial unrolling.
   // Try partial unroll only when TripCount could be statically calculated.
   if (auto UnrollFactor = shouldPartialUnroll(LoopSize, TripCount, UCE, UP)) {
     UP.Count = *UnrollFactor;
 
-    if ((PragmaFullUnroll || PragmaEnableUnroll) && TripCount &&
+    if ((PInfo.PragmaFullUnroll || PInfo.PragmaEnableUnroll) && TripCount &&
         UP.Count != TripCount)
       ORE->emit([&]() {
         return OptimizationRemarkMissed(DEBUG_TYPE,
@@ -1055,7 +1053,7 @@ bool llvm::computeUnrollCount(
 
     if (UP.PartialThreshold != NoThreshold) {
       if (UP.Count == 0) {
-        if (PragmaEnableUnroll)
+        if (PInfo.PragmaEnableUnroll)
           ORE->emit([&]() {
             return OptimizationRemarkMissed(DEBUG_TYPE,
                                             "UnrollAsDirectedTooLarge",
@@ -1066,11 +1064,11 @@ bool llvm::computeUnrollCount(
           });
       }
     }
-    return ExplicitUnroll;
+    return;
   }
   assert(TripCount == 0 &&
          "All cases when TripCount is constant should be covered here.");
-  if (PragmaFullUnroll)
+  if (PInfo.PragmaFullUnroll)
     ORE->emit([&]() {
       return OptimizationRemarkMissed(
                  DEBUG_TYPE, "CantFullUnrollAsDirectedRuntimeTripCount",
@@ -1084,31 +1082,32 @@ bool llvm::computeUnrollCount(
   // Don't unroll a runtime trip count loop when it is disabled.
   if (hasRuntimeUnrollDisablePragma(L)) {
     UP.Count = 0;
-    return false;
+    return;
   }
 
   // Don't unroll a small upper bound loop unless user or TTI asked to do so.
   if (MaxTripCount && !UP.Force && MaxTripCount < UP.MaxUpperBound) {
     UP.Count = 0;
-    return false;
+    return;
   }
 
   // Check if the runtime trip count is too small when profile is available.
   if (L->getHeader()->getParent()->hasProfileData()) {
     if (auto ProfileTripCount = getLoopEstimatedTripCount(L)) {
       if (*ProfileTripCount < FlatLoopTripCountThreshold)
-        return false;
+        return;
       else
         UP.AllowExpensiveTripCount = true;
     }
   }
-  UP.Runtime |= PragmaEnableUnroll || PragmaCount > 0 || UserUnrollCount;
+  UP.Runtime |= PInfo.PragmaEnableUnroll || PInfo.PragmaCount > 0 ||
+                PInfo.UserUnrollCount;
   if (!UP.Runtime) {
     LLVM_DEBUG(dbgs().indent(2)
                << "Will not try to unroll loop with runtime trip count "
                << "because -unroll-runtime not given\n");
     UP.Count = 0;
-    return false;
+    return;
   }
   if (UP.Count == 0)
     UP.Count = UP.DefaultUnrollRuntimeCount;
@@ -1136,7 +1135,7 @@ bool llvm::computeUnrollCount(
 
     using namespace ore;
 
-    if (PragmaCount > 0 && !UP.AllowRemainder)
+    if (PInfo.PragmaCount > 0 && !UP.AllowRemainder)
       ORE->emit([&]() {
         return OptimizationRemarkMissed(DEBUG_TYPE,
                                         "DifferentUnrollCountFromDirected",
@@ -1162,7 +1161,6 @@ bool llvm::computeUnrollCount(
              << "Runtime unrolling with count: " << UP.Count << "\n");
   if (UP.Count < 2)
     UP.Count = 0;
-  return ExplicitUnroll;
 }
 
 static LoopUnrollResult
@@ -1304,9 +1302,9 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
   // computeUnrollCount() decides whether it is beneficial to use upper bound to
   // fully unroll the loop.
   bool UseUpperBound = false;
-  bool IsCountSetExplicitly = computeUnrollCount(
-      L, TTI, DT, LI, &AC, SE, EphValues, &ORE, TripCount, MaxTripCount,
-      MaxOrZero, TripMultiple, UCE, UP, PP, UseUpperBound);
+  computeUnrollCount(L, TTI, DT, LI, &AC, SE, EphValues, &ORE, TripCount,
+                     MaxTripCount, MaxOrZero, TripMultiple, UCE, UP, PP,
+                     UseUpperBound);
   if (!UP.Count)
     return LoopUnrollResult::Unmodified;
 
@@ -1393,7 +1391,8 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
 
   // If loop has an unroll count pragma or unrolled by explicitly set count
   // mark loop as unrolled to prevent unrolling beyond that requested.
-  if (UnrollResult != LoopUnrollResult::FullyUnrolled && IsCountSetExplicitly)
+  if (UnrollResult != LoopUnrollResult::FullyUnrolled &&
+      PragmaInfo(L).ExplicitUnroll)
     L->setLoopAlreadyUnrolled();
 
   return UnrollResult;

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -939,14 +939,16 @@ shouldPartialUnroll(const unsigned LoopSize, const unsigned TripCount,
 // FIXME: This function is used by LoopUnroll and LoopUnrollAndJam, but consumes
 // many LoopUnroll-specific options. The shared functionality should be
 // refactored into it own function.
-void llvm::computeUnrollCount(
-    Loop *L, const TargetTransformInfo &TTI, DominatorTree &DT, LoopInfo *LI,
-    AssumptionCache *AC, ScalarEvolution &SE,
-    const SmallPtrSetImpl<const Value *> &EphValues,
-    OptimizationRemarkEmitter *ORE, unsigned TripCount, unsigned MaxTripCount,
-    bool MaxOrZero, unsigned TripMultiple, const UnrollCostEstimator &UCE,
-    TargetTransformInfo::UnrollingPreferences &UP,
-    TargetTransformInfo::PeelingPreferences &PP) {
+void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
+                              DominatorTree &DT, LoopInfo *LI,
+                              AssumptionCache *AC, ScalarEvolution &SE,
+                              const SmallPtrSetImpl<const Value *> &EphValues,
+                              OptimizationRemarkEmitter *ORE,
+                              unsigned TripCount, unsigned MaxTripCount,
+                              bool MaxOrZero, unsigned TripMultiple,
+                              const UnrollCostEstimator &UCE,
+                              TargetTransformInfo::UnrollingPreferences &UP,
+                              TargetTransformInfo::PeelingPreferences &PP) {
 
   unsigned LoopSize = UCE.getRolledLoopSize();
 

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -946,7 +946,7 @@ void llvm::computeUnrollCount(
     OptimizationRemarkEmitter *ORE, unsigned TripCount, unsigned MaxTripCount,
     bool MaxOrZero, unsigned TripMultiple, const UnrollCostEstimator &UCE,
     TargetTransformInfo::UnrollingPreferences &UP,
-    TargetTransformInfo::PeelingPreferences &PP, bool &UseUpperBound) {
+    TargetTransformInfo::PeelingPreferences &PP) {
 
   unsigned LoopSize = UCE.getRolledLoopSize();
 
@@ -994,7 +994,6 @@ void llvm::computeUnrollCount(
     if (auto UnrollFactor = shouldFullUnroll(L, TTI, DT, SE, EphValues,
                                              TripCount, UCE, UP)) {
       UP.Count = *UnrollFactor;
-      UseUpperBound = false;
       return;
     }
   }
@@ -1017,7 +1016,6 @@ void llvm::computeUnrollCount(
     if (auto UnrollFactor = shouldFullUnroll(L, TTI, DT, SE, EphValues,
                                              MaxTripCount, UCE, UP)) {
       UP.Count = *UnrollFactor;
-      UseUpperBound = true;
       return;
     }
   }
@@ -1299,12 +1297,8 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
     MaxOrZero = SE.isBackedgeTakenCountMaxOrZero(L);
   }
 
-  // computeUnrollCount() decides whether it is beneficial to use upper bound to
-  // fully unroll the loop.
-  bool UseUpperBound = false;
   computeUnrollCount(L, TTI, DT, LI, &AC, SE, EphValues, &ORE, TripCount,
-                     MaxTripCount, MaxOrZero, TripMultiple, UCE, UP, PP,
-                     UseUpperBound);
+                     MaxTripCount, MaxOrZero, TripMultiple, UCE, UP, PP);
   if (!UP.Count)
     return LoopUnrollResult::Unmodified;
 


### PR DESCRIPTION
## Summary

Stacked on #184239. Please review that PR first — this PR's diff includes its changes.

- Change `computeUnrollCount` return type from `bool` to `void` — the `ExplicitUnroll` return value is no longer needed by any caller
- Refactor `PragmaInfo`: add `ExplicitUnroll` field, change constructor to take just a `Loop*` and compute all fields internally
- In `tryToUnrollLoop`, replace `IsCountSetExplicitly` (the old return value) with `PragmaInfo(L).ExplicitUnroll` at the `setLoopAlreadyUnrolled` call site

The semantic equivalence holds because on all reachable paths to `setLoopAlreadyUnrolled`, the old `IsCountSetExplicitly` equaled `PragmaInfo(L).ExplicitUnroll`. The paths where `computeUnrollCount` returned `false` all set `UP.Count = 0`, causing `tryToUnrollLoop` to early-return before reaching that check.

## Test plan

- [x] `llvm-lit Transforms/LoopUnroll` — all 174 pass
- [x] `llvm-lit Transforms/LoopUnrollAndJam` — all 19 pass