### PR TITLE
[AggressiveInstCombine] trunc to i1 in any or all bits set check

### DIFF
--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
@@ -259,60 +259,45 @@ static bool foldAnyOrAllBitsSet(Instruction &I) {
   // The 'any-bits-set' ('or' chain) pattern is simpler to match because the
   // final "and X, 1" instruction must be the final op in the sequence.
   bool MatchAllBitsSet;
-  if (match(&I, m_c_And(m_OneUse(m_And(m_Value(), m_Value())), m_Value())))
-    MatchAllBitsSet = true;
-  else if (match(&I, m_And(m_OneUse(m_Or(m_Value(), m_Value())), m_One())))
-    MatchAllBitsSet = false;
-  else
-    return false;
-
-  MaskOps MOps(I.getType()->getScalarSizeInBits(), MatchAllBitsSet);
-  if (MatchAllBitsSet) {
-    if (!matchAndOrChain(cast<BinaryOperator>(&I), MOps) || !MOps.FoundAnd1)
+  bool MatchTrunc;
+  Value *X;
+  if (I.getType()->isIntOrIntVectorTy(1)) {
+    if (match(&I, m_Trunc(m_OneUse(m_And(m_Value(), m_Value())))))
+      MatchAllBitsSet = true;
+    else if (match(&I, m_Trunc(m_OneUse(m_Or(m_Value(), m_Value())))))
+      MatchAllBitsSet = false;
+    else
       return false;
+    MatchTrunc = true;
+    X = I.getOperand(0);
   } else {
-    if (!matchAndOrChain(cast<BinaryOperator>(&I)->getOperand(0), MOps))
+    if (match(&I, m_c_And(m_OneUse(m_And(m_Value(), m_Value())), m_Value()))) {
+      X = &I;
+      MatchAllBitsSet = true;
+    } else if (match(&I,
+                     m_And(m_OneUse(m_Or(m_Value(), m_Value())), m_One()))) {
+      X = I.getOperand(0);
+      MatchAllBitsSet = false;
+    } else
       return false;
+    MatchTrunc = false;
   }
+  Type *Ty = X->getType();
+
+  MaskOps MOps(Ty->getScalarSizeInBits(), MatchAllBitsSet);
+  if (!matchAndOrChain(X, MOps) ||
+      (MatchAllBitsSet && !MatchTrunc && !MOps.FoundAnd1))
+    return false;
 
   // The pattern was found. Create a masked compare that replaces all of the
   // shift and logic ops.
   IRBuilder<> Builder(&I);
-  Constant *Mask = ConstantInt::get(I.getType(), MOps.Mask);
+  Constant *Mask = ConstantInt::get(Ty, MOps.Mask);
   Value *And = Builder.CreateAnd(MOps.Root, Mask);
   Value *Cmp = MatchAllBitsSet ? Builder.CreateICmpEQ(And, Mask)
                                : Builder.CreateIsNotNull(And);
-  Value *Zext = Builder.CreateZExt(Cmp, I.getType());
+  Value *Zext = MatchTrunc ? Cmp : Builder.CreateZExt(Cmp, Ty);
   I.replaceAllUsesWith(Zext);
-  ++NumAnyOrAllBitsSet;
-  return true;
-}
-
-static bool foldAnyOrAllBitsSetTrunc(Instruction &I) {
-  if (!I.getType()->isIntOrIntVectorTy(1))
-    return false;
-
-  bool MatchAllBitsSet;
-  if (match(&I, m_Trunc(m_OneUse(m_And(m_Value(), m_Value())))))
-    MatchAllBitsSet = true;
-  else if (match(&I, m_Trunc(m_OneUse(m_Or(m_Value(), m_Value())))))
-    MatchAllBitsSet = false;
-  else
-    return false;
-  Value *X = I.getOperand(0);
-
-  MaskOps MOps(X->getType()->getScalarSizeInBits(), MatchAllBitsSet);
-  if (!matchAndOrChain(X, MOps))
-    return false;
-
-  // The pattern was found. Create a masked compare that replaces all of the
-  // shift and logic ops.
-  IRBuilder<> Builder(&I);
-  Constant *Mask = ConstantInt::get(X->getType(), MOps.Mask);
-  Value *And = Builder.CreateAnd(MOps.Root, Mask);
-  Value *Cmp = MatchAllBitsSet ? Builder.CreateICmpEQ(And, Mask)
-                               : Builder.CreateIsNotNull(And);
-  I.replaceAllUsesWith(Cmp);
   ++NumAnyOrAllBitsSet;
   return true;
 }
@@ -1853,7 +1838,6 @@ static bool foldUnusualPatterns(Function &F, DominatorTree &DT,
     // iteratively in this loop rather than waiting until the end.
     for (Instruction &I : make_early_inc_range(llvm::reverse(BB))) {
       MadeChange |= foldAnyOrAllBitsSet(I);
-      MadeChange |= foldAnyOrAllBitsSetTrunc(I);
       MadeChange |= foldGuardedFunnelShift(I, DT);
       MadeChange |= tryToRecognizePopCount(I);
       MadeChange |= tryToFPToSat(I, TTI);

--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
@@ -288,6 +288,35 @@ static bool foldAnyOrAllBitsSet(Instruction &I) {
   return true;
 }
 
+static bool foldAnyOrAllBitsSetTrunc(Instruction &I) {
+  if (!I.getType()->isIntOrIntVectorTy(1))
+    return false;
+
+  bool MatchAllBitsSet;
+  if (match(&I, m_Trunc(m_OneUse(m_And(m_Value(), m_Value())))))
+    MatchAllBitsSet = true;
+  else if (match(&I, m_Trunc(m_OneUse(m_Or(m_Value(), m_Value())))))
+    MatchAllBitsSet = false;
+  else
+    return false;
+  Value *X = I.getOperand(0);
+
+  MaskOps MOps(X->getType()->getScalarSizeInBits(), MatchAllBitsSet);
+  if (!matchAndOrChain(X, MOps))
+    return false;
+
+  // The pattern was found. Create a masked compare that replaces all of the
+  // shift and logic ops.
+  IRBuilder<> Builder(&I);
+  Constant *Mask = ConstantInt::get(X->getType(), MOps.Mask);
+  Value *And = Builder.CreateAnd(MOps.Root, Mask);
+  Value *Cmp = MatchAllBitsSet ? Builder.CreateICmpEQ(And, Mask)
+                               : Builder.CreateIsNotNull(And);
+  I.replaceAllUsesWith(Cmp);
+  ++NumAnyOrAllBitsSet;
+  return true;
+}
+
 // Try to recognize below function as popcount intrinsic.
 // This is the "best" algorithm from
 // http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
@@ -1824,6 +1853,7 @@ static bool foldUnusualPatterns(Function &F, DominatorTree &DT,
     // iteratively in this loop rather than waiting until the end.
     for (Instruction &I : make_early_inc_range(llvm::reverse(BB))) {
       MadeChange |= foldAnyOrAllBitsSet(I);
+      MadeChange |= foldAnyOrAllBitsSetTrunc(I);
       MadeChange |= foldGuardedFunnelShift(I, DT);
       MadeChange |= tryToRecognizePopCount(I);
       MadeChange |= tryToFPToSat(I, TTI);

--- a/llvm/test/Transforms/AggressiveInstCombine/masked-cmp.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/masked-cmp.ll
@@ -16,6 +16,19 @@ define i32 @anyset_two_bit_mask(i32 %x) {
   ret i32 %r
 }
 
+define i1 @anyset_two_bit_mask_trunc(i32 %x) {
+; CHECK-LABEL: @anyset_two_bit_mask_trunc(
+; CHECK-NEXT:    [[S:%.*]] = lshr i32 [[X:%.*]], 3
+; CHECK-NEXT:    [[O:%.*]] = or i32 [[S]], [[X]]
+; CHECK-NEXT:    [[R:%.*]] = trunc i32 [[O]] to i1
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %s = lshr i32 %x, 3
+  %o = or i32 %s, %x
+  %r = trunc i32 %o to i1
+  ret i1 %r
+}
+
 define <2 x i32> @anyset_two_bit_mask_uniform(<2 x i32> %x) {
 ; CHECK-LABEL: @anyset_two_bit_mask_uniform(
 ; CHECK-NEXT:    [[TMP1:%.*]] = and <2 x i32> [[X:%.*]], splat (i32 9)
@@ -61,6 +74,27 @@ define <2 x i32> @anyset_four_bit_mask_uniform(<2 x i32> %x) {
   %o3 = or <2 x i32> %o1, %o2
   %r = and <2 x i32> %o3, <i32 1, i32 1>
   ret <2 x i32> %r
+}
+
+define <2 x i1> @anyset_four_bit_mask_uniform_trunc(<2 x i32> %x) {
+; CHECK-LABEL: @anyset_four_bit_mask_uniform_trunc(
+; CHECK-NEXT:    [[T1:%.*]] = lshr <2 x i32> [[X:%.*]], splat (i32 3)
+; CHECK-NEXT:    [[T2:%.*]] = lshr <2 x i32> [[X]], splat (i32 5)
+; CHECK-NEXT:    [[T3:%.*]] = lshr <2 x i32> [[X]], splat (i32 8)
+; CHECK-NEXT:    [[O1:%.*]] = or <2 x i32> [[T1]], [[X]]
+; CHECK-NEXT:    [[O2:%.*]] = or <2 x i32> [[T2]], [[T3]]
+; CHECK-NEXT:    [[O3:%.*]] = or <2 x i32> [[O1]], [[O2]]
+; CHECK-NEXT:    [[R:%.*]] = trunc <2 x i32> [[O3]] to <2 x i1>
+; CHECK-NEXT:    ret <2 x i1> [[R]]
+;
+  %t1 = lshr <2 x i32> %x, <i32 3, i32 3>
+  %t2 = lshr <2 x i32> %x, <i32 5, i32 5>
+  %t3 = lshr <2 x i32> %x, <i32 8, i32 8>
+  %o1 = or <2 x i32> %t1, %x
+  %o2 = or <2 x i32> %t2, %t3
+  %o3 = or <2 x i32> %o1, %o2
+  %r = trunc <2 x i32> %o3 to <2 x i1>
+  ret <2 x i1> %r
 }
 
 ; We're not testing the LSB here, so all of the 'or' operands are shifts.
@@ -112,6 +146,19 @@ define i32 @allset_two_bit_mask(i32 %x) {
   ret i32 %r
 }
 
+define i1 @allset_two_bit_mask_trunc(i32 %x) {
+; CHECK-LABEL: @allset_two_bit_mask_trunc(
+; CHECK-NEXT:    [[S:%.*]] = lshr i32 [[X:%.*]], 7
+; CHECK-NEXT:    [[O:%.*]] = and i32 [[S]], [[X]]
+; CHECK-NEXT:    [[R:%.*]] = trunc i32 [[O]] to i1
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %s = lshr i32 %x, 7
+  %o = and i32 %s, %x
+  %r = trunc i32 %o to i1
+  ret i1 %r
+}
+
 define <2 x i32> @allset_two_bit_mask_uniform(<2 x i32> %x) {
 ; CHECK-LABEL: @allset_two_bit_mask_uniform(
 ; CHECK-NEXT:    [[TMP1:%.*]] = and <2 x i32> [[X:%.*]], splat (i32 129)
@@ -123,6 +170,19 @@ define <2 x i32> @allset_two_bit_mask_uniform(<2 x i32> %x) {
   %o = and <2 x i32> %s, %x
   %r = and <2 x i32> %o, <i32 1, i32 1>
   ret <2 x i32> %r
+}
+
+define <2 x i1> @allset_two_bit_mask_uniform_trunc(<2 x i32> %x) {
+; CHECK-LABEL: @allset_two_bit_mask_uniform_trunc(
+; CHECK-NEXT:    [[S:%.*]] = lshr <2 x i32> [[X:%.*]], splat (i32 7)
+; CHECK-NEXT:    [[O:%.*]] = and <2 x i32> [[S]], [[X]]
+; CHECK-NEXT:    [[R:%.*]] = trunc <2 x i32> [[O]] to <2 x i1>
+; CHECK-NEXT:    ret <2 x i1> [[R]]
+;
+  %s = lshr <2 x i32> %x, <i32 7, i32 7>
+  %o = and <2 x i32> %s, %x
+  %r = trunc <2 x i32> %o to <2 x i1>
+  ret <2 x i1> %r
 }
 
 define i64 @allset_four_bit_mask(i64 %x) {
@@ -160,6 +220,36 @@ define i32 @allset_two_bit_mask_multiuse(i32 %x) {
   %r = and i32 %o, 1
   call void @use(i32 %o)
   ret i32 %r
+}
+
+define i1 @anyset_two_bit_mask_trunc_multiuse(i32 %x) {
+; CHECK-LABEL: @anyset_two_bit_mask_trunc_multiuse(
+; CHECK-NEXT:    [[S:%.*]] = lshr i32 [[X:%.*]], 3
+; CHECK-NEXT:    [[O:%.*]] = or i32 [[S]], [[X]]
+; CHECK-NEXT:    [[R:%.*]] = trunc i32 [[O]] to i1
+; CHECK-NEXT:    call void @use(i32 [[O]])
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %s = lshr i32 %x, 3
+  %o = or i32 %s, %x
+  %r = trunc i32 %o to i1
+  call void @use(i32 %o)
+  ret i1 %r
+}
+
+define i1 @allset_two_bit_mask_trunc_multiuse(i32 %x) {
+; CHECK-LABEL: @allset_two_bit_mask_trunc_multiuse(
+; CHECK-NEXT:    [[S:%.*]] = lshr i32 [[X:%.*]], 7
+; CHECK-NEXT:    [[O:%.*]] = and i32 [[S]], [[X]]
+; CHECK-NEXT:    [[R:%.*]] = trunc i32 [[O]] to i1
+; CHECK-NEXT:    call void @use(i32 [[O]])
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %s = lshr i32 %x, 7
+  %o = and i32 %s, %x
+  %r = trunc i32 %o to i1
+  call void @use(i32 %o)
+  ret i1 %r
 }
 
 ; negative test - missing 'and 1' mask, so more than the low bit is used here

--- a/llvm/test/Transforms/AggressiveInstCombine/masked-cmp.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/masked-cmp.ll
@@ -18,9 +18,8 @@ define i32 @anyset_two_bit_mask(i32 %x) {
 
 define i1 @anyset_two_bit_mask_trunc(i32 %x) {
 ; CHECK-LABEL: @anyset_two_bit_mask_trunc(
-; CHECK-NEXT:    [[S:%.*]] = lshr i32 [[X:%.*]], 3
-; CHECK-NEXT:    [[O:%.*]] = or i32 [[S]], [[X]]
-; CHECK-NEXT:    [[R:%.*]] = trunc i32 [[O]] to i1
+; CHECK-NEXT:    [[TMP1:%.*]] = and i32 [[X:%.*]], 9
+; CHECK-NEXT:    [[R:%.*]] = icmp ne i32 [[TMP1]], 0
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %s = lshr i32 %x, 3
@@ -78,13 +77,8 @@ define <2 x i32> @anyset_four_bit_mask_uniform(<2 x i32> %x) {
 
 define <2 x i1> @anyset_four_bit_mask_uniform_trunc(<2 x i32> %x) {
 ; CHECK-LABEL: @anyset_four_bit_mask_uniform_trunc(
-; CHECK-NEXT:    [[T1:%.*]] = lshr <2 x i32> [[X:%.*]], splat (i32 3)
-; CHECK-NEXT:    [[T2:%.*]] = lshr <2 x i32> [[X]], splat (i32 5)
-; CHECK-NEXT:    [[T3:%.*]] = lshr <2 x i32> [[X]], splat (i32 8)
-; CHECK-NEXT:    [[O1:%.*]] = or <2 x i32> [[T1]], [[X]]
-; CHECK-NEXT:    [[O2:%.*]] = or <2 x i32> [[T2]], [[T3]]
-; CHECK-NEXT:    [[O3:%.*]] = or <2 x i32> [[O1]], [[O2]]
-; CHECK-NEXT:    [[R:%.*]] = trunc <2 x i32> [[O3]] to <2 x i1>
+; CHECK-NEXT:    [[TMP1:%.*]] = and <2 x i32> [[X:%.*]], splat (i32 297)
+; CHECK-NEXT:    [[R:%.*]] = icmp ne <2 x i32> [[TMP1]], zeroinitializer
 ; CHECK-NEXT:    ret <2 x i1> [[R]]
 ;
   %t1 = lshr <2 x i32> %x, <i32 3, i32 3>
@@ -148,9 +142,8 @@ define i32 @allset_two_bit_mask(i32 %x) {
 
 define i1 @allset_two_bit_mask_trunc(i32 %x) {
 ; CHECK-LABEL: @allset_two_bit_mask_trunc(
-; CHECK-NEXT:    [[S:%.*]] = lshr i32 [[X:%.*]], 7
-; CHECK-NEXT:    [[O:%.*]] = and i32 [[S]], [[X]]
-; CHECK-NEXT:    [[R:%.*]] = trunc i32 [[O]] to i1
+; CHECK-NEXT:    [[TMP1:%.*]] = and i32 [[X:%.*]], 129
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i32 [[TMP1]], 129
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
   %s = lshr i32 %x, 7
@@ -174,9 +167,8 @@ define <2 x i32> @allset_two_bit_mask_uniform(<2 x i32> %x) {
 
 define <2 x i1> @allset_two_bit_mask_uniform_trunc(<2 x i32> %x) {
 ; CHECK-LABEL: @allset_two_bit_mask_uniform_trunc(
-; CHECK-NEXT:    [[S:%.*]] = lshr <2 x i32> [[X:%.*]], splat (i32 7)
-; CHECK-NEXT:    [[O:%.*]] = and <2 x i32> [[S]], [[X]]
-; CHECK-NEXT:    [[R:%.*]] = trunc <2 x i32> [[O]] to <2 x i1>
+; CHECK-NEXT:    [[TMP1:%.*]] = and <2 x i32> [[X:%.*]], splat (i32 129)
+; CHECK-NEXT:    [[R:%.*]] = icmp eq <2 x i32> [[TMP1]], splat (i32 129)
 ; CHECK-NEXT:    ret <2 x i1> [[R]]
 ;
   %s = lshr <2 x i32> %x, <i32 7, i32 7>


### PR DESCRIPTION
trunc (or  (lshr X, C), ...)) to i1 --> (X & CMask) != 0
trunc (and (lshr X, C), ...)) to i1 --> (X & CMask) == CMask

Regression noticed in https://github.com/llvm/llvm-project/pull/184182

Proof: https://alive2.llvm.org/ce/z/8QXWrq