### PR TITLE
Add a test for handling a crashing breakpoint condition

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/Makefile
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
@@ -1,0 +1,49 @@
+"""
+Test that we recover gracefully from evaluating a breakpoint condition that crashes.
+"""
+
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+
+class TestCrashingCondition(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_crashing_condition(self):
+        """There can be many tests in a test case - describe this test here."""
+        self.build()
+        self.main_source_file = lldb.SBFileSpec("main.c")
+        self.do_crash_condition()
+
+    def do_crash_condition(self):
+        """You might use the test implementation in several ways, say so here."""
+
+        # This function starts a process, "a.out" by default, sets a source
+        # breakpoint, runs to it, and returns the thread, process & target.
+        # It optionally takes an SBLaunchOption argument if you want to pass
+        # arguments or environment variables.
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "Set a start breakpoint here", self.main_source_file
+        )
+
+        # Set a breakpoint with a condition that crashes on the next line:
+        bad_bkpt = target.BreakpointCreateBySourceRegex("Set the test breakpoint here", self.main_source_file)
+        self.assertGreater(bad_bkpt.GetNumLocations(), 0, "Found locations for our breakpoint")
+        bad_bkpt.SetCondition("do_crash()")
+
+        self.runCmd("continue")
+
+        self.assertState(process.state, lldb.eStateStopped)
+        self.assertStopReason(thread.stop_reason, lldb.eStopReasonBreakpoint)
+
+        # Now we should be able to continue to the real crash:
+        error = lldb.SBError()
+        self.runCmd("continue")
+        
+        # We should have crashed.
+        self.assertState(process.state, lldb.eStateStopped)
+        self.assertStopReason(thread.stop_reason, lldb.eStopReasonException)
+
+

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
@@ -54,4 +54,4 @@ class TestCrashingCondition(TestBase):
             thread.stop_reason == lldb.eStopReasonException
             or thread.stop_reason == lldb.eStopReasonSignal
         )
-        self.assertTrue(is_crash, "Ran to the actual crash")
+        self.assertIn(thread.stop_reason, [lldb.eStopReasonException, lldb.eStopReasonSignal], "Ran to the actual crash")

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
@@ -50,5 +50,8 @@ class TestCrashingCondition(TestBase):
         self.assertState(process.state, lldb.eStateStopped)
         # We don't actually know what stop reason a given system will
         # report - it could be eStopReasonException or eStopReasonSignal
-        is_crash = thread.stop_reason == lldb.eStopReasonException or thread.stop_reason == lldb.eStopReasonSignal
+        is_crash = (
+            thread.stop_reason == lldb.eStopReasonException
+            or thread.stop_reason == lldb.eStopReasonSignal
+        )
         self.assertTrue(is_crash, "Ran to the actual crash")

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
@@ -12,25 +12,33 @@ class TestCrashingCondition(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     def test_crashing_condition(self):
-        """There can be many tests in a test case - describe this test here."""
+        """Test that if a condition crashes we stop and recover cleanly"""
         self.build()
         self.main_source_file = lldb.SBFileSpec("main.c")
         self.do_crash_condition()
 
     def do_crash_condition(self):
-        """You might use the test implementation in several ways, say so here."""
+        """Test that if a condition crashes we stop and recover cleanly"""
 
         # This function starts a process, "a.out" by default, sets a source
         # breakpoint, runs to it, and returns the thread, process & target.
         # It optionally takes an SBLaunchOption argument if you want to pass
         # arguments or environment variables.
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
-            self, "Set a start breakpoint here", self.main_source_file
+            self,
+            "Set a start breakpoint here",
+            self.main_source_file
         )
 
         # Set a breakpoint with a condition that crashes on the next line:
-        bad_bkpt = target.BreakpointCreateBySourceRegex("Set the test breakpoint here", self.main_source_file)
-        self.assertGreater(bad_bkpt.GetNumLocations(), 0, "Found locations for our breakpoint")
+        bad_bkpt = target.BreakpointCreateBySourceRegex(
+            "Set the test breakpoint here",
+            self.main_source_file
+        )
+        self.assertGreater(
+            bad_bkpt.GetNumLocations(),
+            0,
+            "Found locations for our breakpoint")
         bad_bkpt.SetCondition("do_crash()")
 
         self.runCmd("continue")

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
@@ -25,20 +25,16 @@ class TestCrashingCondition(TestBase):
         # It optionally takes an SBLaunchOption argument if you want to pass
         # arguments or environment variables.
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
-            self,
-            "Set a start breakpoint here",
-            self.main_source_file
+            self, "Set a start breakpoint here", self.main_source_file
         )
 
         # Set a breakpoint with a condition that crashes on the next line:
         bad_bkpt = target.BreakpointCreateBySourceRegex(
-            "Set the test breakpoint here",
-            self.main_source_file
+            "Set the test breakpoint here", self.main_source_file
         )
         self.assertGreater(
-            bad_bkpt.GetNumLocations(),
-            0,
-            "Found locations for our breakpoint")
+            bad_bkpt.GetNumLocations(), 0, "Found locations for our breakpoint"
+        )
         bad_bkpt.SetCondition("do_crash()")
 
         self.runCmd("continue")
@@ -49,9 +45,7 @@ class TestCrashingCondition(TestBase):
         # Now we should be able to continue to the real crash:
         error = lldb.SBError()
         self.runCmd("continue")
-        
+
         # We should have crashed.
         self.assertState(process.state, lldb.eStateStopped)
         self.assertStopReason(thread.stop_reason, lldb.eStopReasonException)
-
-

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
@@ -48,4 +48,7 @@ class TestCrashingCondition(TestBase):
 
         # We should have crashed.
         self.assertState(process.state, lldb.eStateStopped)
-        self.assertStopReason(thread.stop_reason, lldb.eStopReasonException)
+        # We don't actually know what stop reason a given system will
+        # report - it could be eStopReasonException or eStopReasonSignal
+        is_crash = thread.stop_reason == lldb.eStopReasonException or thread.stop_reason == lldb.eStopReasonSignal
+        self.assertTrue(is_crash, "Ran to the actual crash")

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/main.c
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/main.c
@@ -1,0 +1,14 @@
+unsigned int
+do_crash() {
+  char *bad_ptr = (char *) (0x20);
+  bad_ptr[0] = 'a';
+  return bad_ptr[0] == 'a';
+}
+
+int
+main()
+{
+  char *filler = "Set a start breakpoint here";
+  do_crash(); // Set the test breakpoint here
+  return 0;
+}

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/main.c
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/crashing_condition/main.c
@@ -1,13 +1,10 @@
-unsigned int
-do_crash() {
-  char *bad_ptr = (char *) (0x20);
+unsigned int do_crash() {
+  char *bad_ptr = (char *)(0x20);
   bad_ptr[0] = 'a';
   return bad_ptr[0] == 'a';
 }
 
-int
-main()
-{
+int main() {
   char *filler = "Set a start breakpoint here";
   do_crash(); // Set the test breakpoint here
   return 0;


### PR DESCRIPTION
I was working on something and broke the handling of breakpoint conditions that crash.  In fixing that I noticed that there wasn't a test for this scenario, so this PR adds one.