### PR TITLE
[llvm][support] Refactor symlink handling and add readlink

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -92,6 +92,15 @@ Changes to LLVM infrastructure
   successor order. This can cause subtle breakage when using ``getOperand`` or
   ``setOperand`` to access successors.
 
+* The ``llvm::sys::fs`` link creation API has been refactored:
+
+  * ``create_link`` now tries to create a symbolic link first, falling back to a
+    hard link if that fails (previously it created a symlink on Unix and a hard
+    link on Windows).
+  * Added ``create_symlink``, which always creates a symbolic link. On windows
+    this may fail if symlink permissions are not available.
+  * Added ``readlink``, which reads the target of a symbolic link.
+
 Changes to building LLVM
 ------------------------
 

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -299,15 +299,23 @@ LLVM_ABI std::error_code create_directory(const Twine &path,
                                           bool IgnoreExisting = true,
                                           perms Perms = owner_all | group_all);
 
+/// Create a symbolic link from \a from to \a to.
+///
+/// This will fail on Windows if run without create symbolic link permissions.
+///
+/// @param to The path to the symlink target.
+/// @param from The path of the symlink to create.
+/// @returns errc::success if the link was created, otherwise a platform
+/// specific error_code.
+LLVM_ABI std::error_code create_symlink(const Twine &to, const Twine &from);
+
 /// Create a link from \a from to \a to.
 ///
-/// The link may be a soft or a hard link, depending on the platform. The caller
-/// may not assume which one. Currently on windows it creates a hard link since
-/// soft links require extra privileges. On unix, it creates a soft link since
-/// hard links don't work on SMB file systems.
+/// Tries to create a symbolic link first, and falls back to a hard link if
+/// that fails. The caller may not assume which type of link is created.
 ///
-/// @param to The path to hard link to.
-/// @param from The path to hard link from. This is created.
+/// @param to The path to link to.
+/// @param from The path to link from. This is created.
 /// @returns errc::success if the link was created, otherwise a platform
 /// specific error_code.
 LLVM_ABI std::error_code create_link(const Twine &to, const Twine &from);
@@ -330,6 +338,15 @@ LLVM_ABI std::error_code create_hard_link(const Twine &to, const Twine &from);
 LLVM_ABI std::error_code real_path(const Twine &path,
                                    SmallVectorImpl<char> &output,
                                    bool expand_tilde = false);
+
+/// Read the target of a symbolic link.
+///
+/// @param path The path of the symlink.
+/// @param output The location to store the symlink target.
+/// @returns errc::success if the symlink target has been stored in output,
+///          otherwise a platform-specific error_code.
+LLVM_ABI std::error_code readlink(const Twine &path,
+                                  SmallVectorImpl<char> &output);
 
 /// Expands ~ expressions to the user's home directory. On Unix ~user
 /// directories are resolved as well.

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -301,7 +301,9 @@ LLVM_ABI std::error_code create_directory(const Twine &path,
 
 /// Create a symbolic link from \a from to \a to.
 ///
-/// This will fail on Windows if run without create symbolic link permissions.
+/// This may fail on Windows if run without create symbolic link permissions.
+///
+/// On Windows slashes in the symlink target are normalized to `\`.
 ///
 /// @param to The path to the symlink target.
 /// @param from The path of the symlink to create.

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -344,7 +344,8 @@ LLVM_ABI std::error_code real_path(const Twine &path,
 /// @param path The path of the symlink.
 /// @param output The location to store the symlink target.
 /// @returns errc::success if the symlink target has been stored in output,
-///          otherwise a platform-specific error_code.
+///          errc::invalid_argument if path is not a symbolic link, otherwise
+///          a platform-specific error_code.
 LLVM_ABI std::error_code readlink(const Twine &path,
                                   SmallVectorImpl<char> &output);
 

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -303,7 +303,9 @@ LLVM_ABI std::error_code create_directory(const Twine &path,
 ///
 /// This may fail on Windows if run without create symbolic link permissions.
 ///
-/// On Windows slashes in the symlink target are normalized to `\`.
+/// On Windows
+///   - slashes in the symlink target are normalized to `\`, and
+///   - if \a to does not exist, it will always create a file symlink.
 ///
 /// @param to The path to the symlink target.
 /// @param from The path of the symlink to create.

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -241,7 +241,7 @@ std::string getMainExecutable(const char *argv0, void *MainAddr) {
   const char *curproc = "/proc/curproc/file";
   char exe_path[PATH_MAX];
   if (sys::fs::exists(curproc)) {
-    ssize_t len = readlink(curproc, exe_path, sizeof(exe_path));
+    ssize_t len = ::readlink(curproc, exe_path, sizeof(exe_path));
     if (len > 0) {
       // Null terminate the string for realpath. readlink never null
       // terminates its output.
@@ -259,7 +259,7 @@ std::string getMainExecutable(const char *argv0, void *MainAddr) {
   const char *aPath = "/proc/self/exe";
   if (sys::fs::exists(aPath)) {
     // /proc is not always mounted under Linux (chroot for example).
-    ssize_t len = readlink(aPath, exe_path, sizeof(exe_path));
+    ssize_t len = ::readlink(aPath, exe_path, sizeof(exe_path));
     if (len < 0)
       return "";
 
@@ -430,9 +430,7 @@ std::error_code create_directory(const Twine &path, bool IgnoreExisting,
   return std::error_code();
 }
 
-// Note that we are using symbolic link because hard links are not supported by
-// all filesystems (SMB doesn't).
-std::error_code create_link(const Twine &to, const Twine &from) {
+std::error_code create_symlink(const Twine &to, const Twine &from) {
   // Get arguments.
   SmallString<128> from_storage;
   SmallString<128> to_storage;
@@ -443,6 +441,13 @@ std::error_code create_link(const Twine &to, const Twine &from) {
     return errnoAsErrorCode();
 
   return std::error_code();
+}
+
+std::error_code create_link(const Twine &to, const Twine &from) {
+  std::error_code EC = create_symlink(to, from);
+  if (EC)
+    EC = create_hard_link(to, from);
+  return EC;
 }
 
 std::error_code create_hard_link(const Twine &to, const Twine &from) {
@@ -1420,6 +1425,31 @@ std::error_code real_path(const Twine &path, SmallVectorImpl<char> &dest,
     return errnoAsErrorCode();
   dest.append(Buffer, Buffer + strlen(Buffer));
   return std::error_code();
+}
+
+std::error_code readlink(const Twine &path, SmallVectorImpl<char> &dest) {
+  dest.clear();
+
+  SmallString<128> Storage;
+  StringRef P = path.toNullTerminatedStringRef(Storage);
+
+  // Call ::readlink in a loop, growing the buffer until the result fits. We
+  // can't use lstat to get the size ahead of time because it's racy (the
+  // symlink can be replaced between lstat and readlink), and some filesystems
+  // (e.g. /proc on Linux) report st_size == 0 for symlinks.
+  size_t BufSize = 128;
+  for (;;) {
+    dest.resize_for_overwrite(BufSize);
+    ssize_t Len = ::readlink(P.begin(), dest.data(), dest.size());
+    if (Len < 0)
+      return errnoAsErrorCode();
+    if (static_cast<size_t>(Len) < BufSize) {
+      dest.truncate(Len);
+      return std::error_code();
+    }
+    // Result may have been truncated. Grow and retry.
+    BufSize *= 2;
+  }
 }
 
 std::error_code changeFileOwnership(int FD, uint32_t Owner, uint32_t Group) {

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1437,7 +1437,12 @@ std::error_code readlink(const Twine &path, SmallVectorImpl<char> &dest) {
   // can't use lstat to get the size ahead of time because it's racy (the
   // symlink can be replaced between lstat and readlink), and some filesystems
   // (e.g. /proc on Linux) report st_size == 0 for symlinks.
-  size_t BufSize = 128;
+  //
+  // Default buffer starts at destination's current capacity unless that's too
+  // small. 32 is the somewhat arbitrary lower bound, but if we're going to have
+  // to allocate anyway it should have a reasonable chance of holding the
+  // result. This is to handle cases of `SmallString<0>` as buffers.
+  size_t BufSize = std::max(32, dest.capacity());
   for (;;) {
     dest.resize_for_overwrite(BufSize);
     ssize_t Len = ::readlink(P.begin(), dest.data(), dest.size());

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1442,7 +1442,7 @@ std::error_code readlink(const Twine &path, SmallVectorImpl<char> &dest) {
   // small. 32 is the somewhat arbitrary lower bound, but if we're going to have
   // to allocate anyway it should have a reasonable chance of holding the
   // result. This is to handle cases of `SmallString<0>` as buffers.
-  size_t BufSize = std::max(32, dest.capacity());
+  size_t BufSize = std::max(std::size_t{32}, dest.capacity());
   for (;;) {
     dest.resize_for_overwrite(BufSize);
     ssize_t Len = ::readlink(P.begin(), dest.data(), dest.size());

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -338,8 +338,46 @@ std::error_code create_directory(const Twine &path, bool IgnoreExisting,
   return std::error_code();
 }
 
-// We can't use symbolic links for windows.
+std::error_code create_symlink(const Twine &to, const Twine &from) {
+  SmallVector<wchar_t, 128> wide_from;
+  SmallVector<wchar_t, 128> wide_to;
+  if (std::error_code ec = widenPath(from, wide_from))
+    return ec;
+  if (std::error_code ec = widenPath(to, wide_to))
+    return ec;
+
+  // Windows requires SYMBOLIC_LINK_FLAG_DIRECTORY for directory symlinks.
+  DWORD Flags = 0;
+  DWORD Attr = ::GetFileAttributesW(wide_to.begin());
+  if (Attr != INVALID_FILE_ATTRIBUTES && (Attr & FILE_ATTRIBUTE_DIRECTORY))
+    Flags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
+
+  // Try with SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE first, which works
+  // when Developer Mode is enabled on Windows 10+.
+  if (::CreateSymbolicLinkW(wide_from.begin(), wide_to.begin(),
+                            Flags |
+                                SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))
+    return std::error_code();
+
+  // If the flag is not recognized (older Windows), retry without it.
+  DWORD Err = ::GetLastError();
+  if (Err == ERROR_INVALID_PARAMETER) {
+    if (::CreateSymbolicLinkW(wide_from.begin(), wide_to.begin(), Flags))
+      return std::error_code();
+    Err = ::GetLastError();
+  }
+
+  return mapWindowsError(Err);
+}
+
 std::error_code create_link(const Twine &to, const Twine &from) {
+  std::error_code EC = create_symlink(to, from);
+  if (EC)
+    EC = create_hard_link(to, from);
+  return EC;
+}
+
+std::error_code create_hard_link(const Twine &to, const Twine &from) {
   // Convert to utf-16.
   SmallVector<wchar_t, 128> wide_from;
   SmallVector<wchar_t, 128> wide_to;
@@ -352,10 +390,6 @@ std::error_code create_link(const Twine &to, const Twine &from) {
     return mapWindowsError(::GetLastError());
 
   return std::error_code();
-}
-
-std::error_code create_hard_link(const Twine &to, const Twine &from) {
-  return create_link(to, from);
 }
 
 std::error_code remove(const Twine &path, bool IgnoreNonExisting) {
@@ -1646,6 +1680,92 @@ std::error_code real_path(const Twine &path, SmallVectorImpl<char> &dest,
           llvm::sys::fs::openFileForRead(path, fd, OF_None, &dest))
     return EC;
   ::close(fd);
+  return std::error_code();
+}
+
+// This struct is normally only available in the Windows Driver Kit (WDK)
+// headers, not in the standard Windows SDK.
+struct LLVM_REPARSE_DATA_BUFFER {
+  unsigned long ReparseTag;
+  unsigned short ReparseDataLength;
+  unsigned short Reserved;
+  union {
+    struct {
+      unsigned short SubstituteNameOffset;
+      unsigned short SubstituteNameLength;
+      unsigned short PrintNameOffset;
+      unsigned short PrintNameLength;
+      unsigned long Flags;
+      wchar_t PathBuffer[1];
+    } SymbolicLinkReparseBuffer;
+    struct {
+      unsigned short SubstituteNameOffset;
+      unsigned short SubstituteNameLength;
+      unsigned short PrintNameOffset;
+      unsigned short PrintNameLength;
+      wchar_t PathBuffer[1];
+    } MountPointReparseBuffer;
+    struct {
+      unsigned char DataBuffer[1];
+    } GenericReparseBuffer;
+  };
+};
+
+std::error_code readlink(const Twine &path, SmallVectorImpl<char> &dest) {
+  dest.clear();
+
+  SmallVector<wchar_t, 128> PathUTF16;
+  if (std::error_code EC = widenPath(path, PathUTF16))
+    return EC;
+
+  // Open the symlink without following it.
+  ScopedFileHandle H(::CreateFileW(
+      c_str(PathUTF16), FILE_READ_ATTRIBUTES,
+      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL,
+      OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+      NULL));
+  if (!H)
+    return mapWindowsError(::GetLastError());
+
+  // Read the reparse point data.
+  union {
+    LLVM_REPARSE_DATA_BUFFER RDB;
+    char Buffer[MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
+  };
+  DWORD BytesReturned;
+  if (!::DeviceIoControl(H, FSCTL_GET_REPARSE_POINT, NULL, 0, &RDB,
+                         sizeof(Buffer), &BytesReturned, NULL))
+    return mapWindowsError(::GetLastError());
+
+  if (RDB.ReparseTag != IO_REPARSE_TAG_SYMLINK)
+    return make_error_code(errc::invalid_argument);
+
+  const auto &SLB = RDB.SymbolicLinkReparseBuffer;
+  size_t PathBufOffset =
+      offsetof(LLVM_REPARSE_DATA_BUFFER, SymbolicLinkReparseBuffer.PathBuffer);
+
+  // Prefer PrintName (user-friendly, e.g. "C:\foo") over SubstituteName
+  // (NT-internal, e.g. "\??\C:\foo").
+  USHORT NameOffset, NameLength;
+  if (SLB.PrintNameLength != 0) {
+    NameOffset = SLB.PrintNameOffset;
+    NameLength = SLB.PrintNameLength;
+  } else {
+    NameOffset = SLB.SubstituteNameOffset;
+    NameLength = SLB.SubstituteNameLength;
+  }
+
+  // Validate that the returned data is large enough to contain the name.
+  if (PathBufOffset + NameOffset + NameLength > BytesReturned)
+    return make_error_code(errc::invalid_argument);
+
+  const wchar_t *Target = SLB.PathBuffer + NameOffset / sizeof(wchar_t);
+  USHORT TargetLen = NameLength / sizeof(wchar_t);
+
+  if (std::error_code EC = UTF16ToUTF8(Target, TargetLen, dest))
+    return EC;
+
+  llvm::sys::path::make_preferred(dest);
   return std::error_code();
 }
 

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1769,7 +1769,6 @@ std::error_code readlink(const Twine &path, SmallVectorImpl<char> &dest) {
   if (std::error_code EC = UTF16ToUTF8(Target, TargetLen, dest))
     return EC;
 
-  llvm::sys::path::make_preferred(dest);
   return std::error_code();
 }
 

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1734,8 +1734,12 @@ std::error_code readlink(const Twine &path, SmallVectorImpl<char> &dest) {
   };
   DWORD BytesReturned;
   if (!::DeviceIoControl(H, FSCTL_GET_REPARSE_POINT, NULL, 0, &RDB,
-                         sizeof(Buffer), &BytesReturned, NULL))
-    return mapWindowsError(::GetLastError());
+                         sizeof(Buffer), &BytesReturned, NULL)) {
+    DWORD Err = ::GetLastError();
+    if (Err == ERROR_NOT_A_REPARSE_POINT)
+      return make_error_code(errc::invalid_argument);
+    return mapWindowsError(Err);
+  }
 
   if (RDB.ReparseTag != IO_REPARSE_TAG_SYMLINK)
     return make_error_code(errc::invalid_argument);

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -346,6 +346,12 @@ std::error_code create_symlink(const Twine &to, const Twine &from) {
   if (std::error_code ec = widenPath(to, wide_to))
     return ec;
 
+  // The Win32 API normally allows forward slashes, but under some cases it does
+  // not correctly handle them in the target of a symlink.
+  for (wchar_t &C : wide_to)
+    if (C == L'/')
+      C = L'\\';
+
   // Windows requires SYMBOLIC_LINK_FLAG_DIRECTORY for directory symlinks.
   DWORD Flags = 0;
   DWORD Attr = ::GetFileAttributesW(wide_to.begin());

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -367,10 +367,17 @@ std::error_code create_symlink(const Twine &to, const Twine &from) {
       return ec;
     attr_path = &wide_resolved;
   }
-  DWORD Attr = ::GetFileAttributesW(attr_path->begin());
   DWORD Flags = 0;
-  if (Attr != INVALID_FILE_ATTRIBUTES && (Attr & FILE_ATTRIBUTE_DIRECTORY))
+  DWORD Attr = ::GetFileAttributesW(attr_path->begin());
+  if (Attr == INVALID_FILE_ATTRIBUTES) {
+    DWORD Err = ::GetLastError();
+    if (Err != ERROR_FILE_NOT_FOUND && Err != ERROR_PATH_NOT_FOUND)
+      return mapWindowsError(Err);
+    // Target doesn't exist. Default to a file symlink, matching the Unix
+    // behavior of allowing dangling symlinks.
+  } else if (Attr & FILE_ATTRIBUTE_DIRECTORY) {
     Flags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
+  }
 
   // Try with SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE first, which works
   // in non-UWP programs and when Developer Mode is enabled on Windows 10+.

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -341,34 +341,34 @@ std::error_code create_directory(const Twine &path, bool IgnoreExisting,
 std::error_code create_symlink(const Twine &to, const Twine &from) {
   // The Win32 API normally allows forward slashes, but under some cases it does
   // not correctly handle them in the target of a symlink.
-  SmallString<128> to_str;
-  llvm::sys::path::native(to, to_str);
+  SmallString<128> ToStr;
+  llvm::sys::path::native(to, ToStr);
 
-  SmallVector<wchar_t, 128> wide_from;
-  SmallVector<wchar_t, 128> wide_to;
-  if (std::error_code ec = widenPath(from, wide_from))
+  SmallVector<wchar_t, 128> WideFrom;
+  SmallVector<wchar_t, 128> WideTo;
+  if (std::error_code ec = widenPath(from, WideFrom))
     return ec;
-  if (std::error_code ec = widenPath(to, wide_to))
+  if (std::error_code ec = widenPath(to, WideTo))
     return ec;
 
   // Windows requires SYMBOLIC_LINK_FLAG_DIRECTORY for directory symlinks, so
   // check first what type the target is. Relative symlink targets are relative
   // to the link's parent directory, not the CWD, so resolve accordingly before
   // checking attributes.
-  SmallVector<wchar_t, 128> wide_resolved;
-  const SmallVectorImpl<wchar_t> *attr_path = &wide_to;
+  SmallVector<wchar_t, 128> WideResolved;
+  const SmallVectorImpl<wchar_t> *AttrPath = &WideTo;
 
-  if (sys::path::is_relative(to_str)) {
-    SmallString<128> from_str;
-    from.toVector(from_str);
-    SmallString<128> resolved = sys::path::parent_path(from_str);
-    sys::path::append(resolved, to_str);
-    if (std::error_code ec = widenPath(resolved, wide_resolved))
+  if (sys::path::is_relative(ToStr)) {
+    SmallString<128> FromStr;
+    from.toVector(FromStr);
+    SmallString<128> Resolved = sys::path::parent_path(FromStr);
+    sys::path::append(Resolved, ToStr);
+    if (std::error_code ec = widenPath(Resolved, WideResolved))
       return ec;
-    attr_path = &wide_resolved;
+    AttrPath = &WideResolved;
   }
   DWORD Flags = 0;
-  DWORD Attr = ::GetFileAttributesW(attr_path->begin());
+  DWORD Attr = ::GetFileAttributesW(AttrPath->begin());
   if (Attr == INVALID_FILE_ATTRIBUTES) {
     DWORD Err = ::GetLastError();
     if (Err != ERROR_FILE_NOT_FOUND && Err != ERROR_PATH_NOT_FOUND)
@@ -381,7 +381,7 @@ std::error_code create_symlink(const Twine &to, const Twine &from) {
 
   // Try with SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE first, which works
   // in non-UWP programs and when Developer Mode is enabled on Windows 10+.
-  if (::CreateSymbolicLinkW(wide_from.begin(), wide_to.begin(),
+  if (::CreateSymbolicLinkW(WideFrom.begin(), WideTo.begin(),
                             Flags |
                                 SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))
     return std::error_code();
@@ -389,7 +389,7 @@ std::error_code create_symlink(const Twine &to, const Twine &from) {
   // If the flag is not recognized (older Windows), retry without it.
   DWORD Err = ::GetLastError();
   if (Err == ERROR_INVALID_PARAMETER) {
-    if (::CreateSymbolicLinkW(wide_from.begin(), wide_to.begin(), Flags))
+    if (::CreateSymbolicLinkW(WideFrom.begin(), WideTo.begin(), Flags))
       return std::error_code();
     Err = ::GetLastError();
   }

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -339,6 +339,11 @@ std::error_code create_directory(const Twine &path, bool IgnoreExisting,
 }
 
 std::error_code create_symlink(const Twine &to, const Twine &from) {
+  // The Win32 API normally allows forward slashes, but under some cases it does
+  // not correctly handle them in the target of a symlink.
+  SmallString<128> to_str;
+  llvm::sys::path::native(to, to_str);
+
   SmallVector<wchar_t, 128> wide_from;
   SmallVector<wchar_t, 128> wide_to;
   if (std::error_code ec = widenPath(from, wide_from))
@@ -346,20 +351,13 @@ std::error_code create_symlink(const Twine &to, const Twine &from) {
   if (std::error_code ec = widenPath(to, wide_to))
     return ec;
 
-  // The Win32 API normally allows forward slashes, but under some cases it does
-  // not correctly handle them in the target of a symlink.
-  for (wchar_t &C : wide_to)
-    if (C == L'/')
-      C = L'\\';
-
   // Windows requires SYMBOLIC_LINK_FLAG_DIRECTORY for directory symlinks, so
   // check first what type the target is. Relative symlink targets are relative
   // to the link's parent directory, not the CWD, so resolve accordingly before
   // checking attributes.
   SmallVector<wchar_t, 128> wide_resolved;
   const SmallVectorImpl<wchar_t> *attr_path = &wide_to;
-  SmallString<128> to_str;
-  to.toVector(to_str);
+
   if (sys::path::is_relative(to_str)) {
     SmallString<128> from_str;
     from.toVector(from_str);

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -348,7 +348,7 @@ std::error_code create_symlink(const Twine &to, const Twine &from) {
   SmallVector<wchar_t, 128> WideTo;
   if (std::error_code ec = widenPath(from, WideFrom))
     return ec;
-  if (std::error_code ec = widenPath(to, WideTo))
+  if (std::error_code ec = widenPath(ToStr, WideTo))
     return ec;
 
   // Windows requires SYMBOLIC_LINK_FLAG_DIRECTORY for directory symlinks, so

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -352,14 +352,30 @@ std::error_code create_symlink(const Twine &to, const Twine &from) {
     if (C == L'/')
       C = L'\\';
 
-  // Windows requires SYMBOLIC_LINK_FLAG_DIRECTORY for directory symlinks.
+  // Windows requires SYMBOLIC_LINK_FLAG_DIRECTORY for directory symlinks, so
+  // check first what type the target is. Relative symlink targets are relative
+  // to the link's parent directory, not the CWD, so resolve accordingly before
+  // checking attributes.
+  SmallVector<wchar_t, 128> wide_resolved;
+  const SmallVectorImpl<wchar_t> *attr_path = &wide_to;
+  SmallString<128> to_str;
+  to.toVector(to_str);
+  if (sys::path::is_relative(to_str)) {
+    SmallString<128> from_str;
+    from.toVector(from_str);
+    SmallString<128> resolved = sys::path::parent_path(from_str);
+    sys::path::append(resolved, to_str);
+    if (std::error_code ec = widenPath(resolved, wide_resolved))
+      return ec;
+    attr_path = &wide_resolved;
+  }
+  DWORD Attr = ::GetFileAttributesW(attr_path->begin());
   DWORD Flags = 0;
-  DWORD Attr = ::GetFileAttributesW(wide_to.begin());
   if (Attr != INVALID_FILE_ATTRIBUTES && (Attr & FILE_ATTRIBUTE_DIRECTORY))
     Flags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
 
   // Try with SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE first, which works
-  // when Developer Mode is enabled on Windows 10+.
+  // in non-UWP programs and when Developer Mode is enabled on Windows 10+.
   if (::CreateSymbolicLinkW(wide_from.begin(), wide_to.begin(),
                             Flags |
                                 SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -830,6 +830,40 @@ TEST_F(FileSystemTest, ReadlinkRelative) {
   ASSERT_NO_ERROR(fs::remove(Target));
 }
 
+TEST_F(FileSystemTest, ReadlinkRelativeWithSlash) {
+  // Verify that a symlink target created with forward slashes is read back
+  // with the native separator. On Windows, create_symlink normalizes forward
+  // slashes to backslashes.
+  SmallString<128> SubDir(TestDirectory);
+  path::append(SubDir, "subdir");
+  ASSERT_NO_ERROR(fs::create_directory(SubDir));
+
+  int FD;
+  SmallString<128> Target(SubDir);
+  path::append(Target, "target");
+  ASSERT_NO_ERROR(fs::openFileForWrite(Target, FD, fs::CD_CreateNew));
+  ::close(FD);
+
+  SmallString<128> Link(TestDirectory);
+  path::append(Link, "link");
+  std::error_code EC = fs::create_symlink("subdir/target", Link);
+  if (EC) {
+    ASSERT_NO_ERROR(fs::remove(Target));
+    ASSERT_NO_ERROR(fs::remove(SubDir));
+    GTEST_SKIP() << "Symlinks not supported: " << EC.message();
+  }
+
+  SmallString<128> Result;
+  ASSERT_NO_ERROR(fs::readlink(Link, Result));
+  SmallString<128> Expected("subdir/target");
+  path::native(Expected);
+  EXPECT_EQ(Expected, Result);
+
+  ASSERT_NO_ERROR(fs::remove(Link));
+  ASSERT_NO_ERROR(fs::remove(Target));
+  ASSERT_NO_ERROR(fs::remove(SubDir));
+}
+
 TEST_F(FileSystemTest, ReadlinkNonSymlink) {
   int FD;
   SmallString<128> Regular(TestDirectory);

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -784,6 +784,71 @@ TEST_F(FileSystemTest, RealPath) {
   ASSERT_NO_ERROR(fs::remove_directories(Twine(TestDirectory) + "/test1"));
 }
 
+TEST_F(FileSystemTest, Readlink) {
+  int FD;
+  SmallString<128> Target(TestDirectory);
+  path::append(Target, "target");
+  ASSERT_NO_ERROR(fs::openFileForWrite(Target, FD, fs::CD_CreateNew));
+  ::close(FD);
+
+  SmallString<128> Link(TestDirectory);
+  path::append(Link, "link");
+  std::error_code EC = fs::create_symlink(Target, Link);
+  if (EC) {
+    ASSERT_NO_ERROR(fs::remove(Target));
+    GTEST_SKIP() << "Symlinks not supported: " << EC.message();
+  }
+
+  SmallString<128> Result;
+  ASSERT_NO_ERROR(fs::readlink(Link, Result));
+  EXPECT_EQ(Target, Result);
+
+  ASSERT_NO_ERROR(fs::remove(Link));
+  ASSERT_NO_ERROR(fs::remove(Target));
+}
+
+TEST_F(FileSystemTest, ReadlinkRelative) {
+  int FD;
+  SmallString<128> Target(TestDirectory);
+  path::append(Target, "target");
+  ASSERT_NO_ERROR(fs::openFileForWrite(Target, FD, fs::CD_CreateNew));
+  ::close(FD);
+
+  SmallString<128> Link(TestDirectory);
+  path::append(Link, "link");
+  std::error_code EC = fs::create_symlink("target", Link);
+  if (EC) {
+    ASSERT_NO_ERROR(fs::remove(Target));
+    GTEST_SKIP() << "Symlinks not supported: " << EC.message();
+  }
+
+  SmallString<128> Result;
+  ASSERT_NO_ERROR(fs::readlink(Link, Result));
+  EXPECT_EQ("target", Result);
+
+  ASSERT_NO_ERROR(fs::remove(Link));
+  ASSERT_NO_ERROR(fs::remove(Target));
+}
+
+TEST_F(FileSystemTest, ReadlinkNonSymlink) {
+  int FD;
+  SmallString<128> Regular(TestDirectory);
+  path::append(Regular, "regular");
+  ASSERT_NO_ERROR(fs::openFileForWrite(Regular, FD, fs::CD_CreateNew));
+  ::close(FD);
+
+  SmallString<128> Result;
+  EXPECT_EQ(fs::readlink(Regular, Result), errc::invalid_argument);
+
+  ASSERT_NO_ERROR(fs::remove(Regular));
+}
+
+TEST_F(FileSystemTest, ReadlinkNonExistent) {
+  SmallString<128> Result;
+  EXPECT_EQ(fs::readlink(TestDirectory + "/does_not_exist", Result),
+            errc::no_such_file_or_directory);
+}
+
 TEST_F(FileSystemTest, ExpandTilde) {
   SmallString<64> Expected;
   SmallString<64> Actual;
@@ -1179,21 +1244,21 @@ TEST_F(FileSystemTest, BrokenSymlinkDirectoryIteration) {
   // Create a known hierarchy to recurse over.
   ASSERT_NO_ERROR(fs::create_directories(Twine(TestDirectory) + "/symlink"));
   ASSERT_NO_ERROR(
-      fs::create_link("no_such_file", Twine(TestDirectory) + "/symlink/a"));
+      fs::create_symlink("no_such_file", Twine(TestDirectory) + "/symlink/a"));
   ASSERT_NO_ERROR(
       fs::create_directories(Twine(TestDirectory) + "/symlink/b/bb"));
+  ASSERT_NO_ERROR(fs::create_symlink("no_such_file",
+                                     Twine(TestDirectory) + "/symlink/b/ba"));
+  ASSERT_NO_ERROR(fs::create_symlink("no_such_file",
+                                     Twine(TestDirectory) + "/symlink/b/bc"));
   ASSERT_NO_ERROR(
-      fs::create_link("no_such_file", Twine(TestDirectory) + "/symlink/b/ba"));
-  ASSERT_NO_ERROR(
-      fs::create_link("no_such_file", Twine(TestDirectory) + "/symlink/b/bc"));
-  ASSERT_NO_ERROR(
-      fs::create_link("no_such_file", Twine(TestDirectory) + "/symlink/c"));
+      fs::create_symlink("no_such_file", Twine(TestDirectory) + "/symlink/c"));
   ASSERT_NO_ERROR(
       fs::create_directories(Twine(TestDirectory) + "/symlink/d/dd/ddd"));
-  ASSERT_NO_ERROR(fs::create_link(Twine(TestDirectory) + "/symlink/d/dd",
-                                  Twine(TestDirectory) + "/symlink/d/da"));
+  ASSERT_NO_ERROR(fs::create_symlink(Twine(TestDirectory) + "/symlink/d/dd",
+                                     Twine(TestDirectory) + "/symlink/d/da"));
   ASSERT_NO_ERROR(
-      fs::create_link("no_such_file", Twine(TestDirectory) + "/symlink/e"));
+      fs::create_symlink("no_such_file", Twine(TestDirectory) + "/symlink/e"));
 
   typedef std::vector<std::string> v_t;
   v_t VisitedNonBrokenSymlinks;
@@ -2731,13 +2796,13 @@ TEST_F(FileSystemTest, CopyFile) {
   verifyFileContents(Destination, Data[1]);
 
   // Note: The remaining logic is targeted at a potential failure case related
-  // to file cloning and symlinks on Darwin. On Windows, fs::create_link() does
-  // not return success here so the test is skipped.
+  // to file cloning and symlinks on Darwin. On Windows, fs::create_symlink()
+  // may not return success here so the test is skipped.
 #if !defined(_WIN32)
   // Set up a symlink to the third file.
   SmallString<128> Symlink(RootTestDirectory.path());
   path::append(Symlink, "symlink");
-  ASSERT_NO_ERROR(fs::create_link(path::filename(Sources[2]), Symlink));
+  ASSERT_NO_ERROR(fs::create_symlink(path::filename(Sources[2]), Symlink));
   verifyFileContents(Symlink, Data[2]);
 
   // fs::getUniqueID() should follow symlinks. Otherwise, this isn't good test

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -864,6 +864,53 @@ TEST_F(FileSystemTest, ReadlinkRelativeWithSlash) {
   ASSERT_NO_ERROR(fs::remove(SubDir));
 }
 
+TEST_F(FileSystemTest, CreateRelativeDirectorySymlink) {
+  // Verify that a relative symlink to a directory is correctly detected as a
+  // directory symlink. On Windows, create_symlink needs to resolve the relative
+  // target against the link's parent to check if the target is a directory.
+  SmallString<128> SubDir(TestDirectory);
+  path::append(SubDir, "subdir");
+  ASSERT_NO_ERROR(fs::create_directory(SubDir));
+
+  SmallString<128> TargetDir(SubDir);
+  path::append(TargetDir, "target_dir");
+  ASSERT_NO_ERROR(fs::create_directory(TargetDir));
+
+  // Create a symlink in TestDirectory pointing to "subdir/target_dir" using a
+  // relative path. The target is relative to the link's parent (TestDirectory),
+  // not the CWD.
+  SmallString<128> Link(TestDirectory);
+  path::append(Link, "link");
+  SmallString<128> RelTarget("subdir");
+  path::append(RelTarget, "target_dir");
+  path::native(RelTarget);
+  std::error_code EC = fs::create_symlink(RelTarget, Link);
+  if (EC) {
+    ASSERT_NO_ERROR(fs::remove(TargetDir));
+    ASSERT_NO_ERROR(fs::remove(SubDir));
+    GTEST_SKIP() << "Symlinks not supported: " << EC.message();
+  }
+
+  // The symlink should be recognized as a directory.
+  EXPECT_TRUE(fs::is_directory(Link));
+
+  // Verify we can access a file through the directory symlink.
+  int FD;
+  SmallString<128> FileInTarget(TargetDir);
+  path::append(FileInTarget, "file");
+  ASSERT_NO_ERROR(fs::openFileForWrite(FileInTarget, FD, fs::CD_CreateNew));
+  ::close(FD);
+
+  SmallString<128> FileThroughLink(Link);
+  path::append(FileThroughLink, "file");
+  EXPECT_TRUE(fs::is_regular_file(FileThroughLink));
+
+  ASSERT_NO_ERROR(fs::remove(FileInTarget));
+  ASSERT_NO_ERROR(fs::remove(Link));
+  ASSERT_NO_ERROR(fs::remove(TargetDir));
+  ASSERT_NO_ERROR(fs::remove(SubDir));
+}
+
 TEST_F(FileSystemTest, ReadlinkNonSymlink) {
   int FD;
   SmallString<128> Regular(TestDirectory);


### PR DESCRIPTION
This adds a portable `readlink` function, and adds `create_symlink` to enable testing this on Windows. `create_link` previously created a hard link on Windows, but it now tries to create a symlink first.

The Windows implementation is based on posix_compat.h from libc++.

Assisted-by: claude-opus-4.6