### PR TITLE
Reland "[OpenMP][Offload] Handle `present/to/from` when a different entry did `alloc/delete`."

### DIFF
--- a/offload/libomptarget/interface.cpp
+++ b/offload/libomptarget/interface.cpp
@@ -168,19 +168,22 @@ targetData(ident_t *Loc, int64_t DeviceId, int32_t ArgNum, void **ArgsBase,
 
   int Rc = OFFLOAD_SUCCESS;
 
-  // Only allocate AttachInfo for targetDataBegin
-  std::unique_ptr<AttachInfoTy> AttachInfo;
-  if (TargetDataFunction == targetDataBegin)
-    AttachInfo = std::make_unique<AttachInfoTy>();
+  // Allocate StateInfo for targetDataBegin and targetDataEnd to track
+  // allocations, pointer attachments and deferred transfers.
+  // This is not needed for targetDataUpdate.
+  std::unique_ptr<StateInfoTy> StateInfo;
+  if (TargetDataFunction == targetDataBegin ||
+      TargetDataFunction == targetDataEnd)
+    StateInfo = std::make_unique<StateInfoTy>();
 
   Rc = TargetDataFunction(Loc, *DeviceOrErr, ArgNum, ArgsBase, Args, ArgSizes,
                           ArgTypes, ArgNames, ArgMappers, AsyncInfo,
-                          AttachInfo.get(), /*FromMapper=*/false);
+                          StateInfo.get(), /*FromMapper=*/false);
 
   if (Rc == OFFLOAD_SUCCESS) {
     // Process deferred ATTACH entries BEFORE synchronization
-    if (AttachInfo && !AttachInfo->AttachEntries.empty())
-      Rc = processAttachEntries(*DeviceOrErr, *AttachInfo, AsyncInfo);
+    if (StateInfo && !StateInfo->AttachEntries.empty())
+      Rc = processAttachEntries(*DeviceOrErr, *StateInfo, AsyncInfo);
 
     if (Rc == OFFLOAD_SUCCESS)
       Rc = AsyncInfo.synchronize();

--- a/offload/test/mapping/map_ordering_ptee_tgt_alloc_mapper_alloc_from_to.c
+++ b/offload/test/mapping/map_ordering_ptee_tgt_alloc_mapper_alloc_from_to.c
@@ -1,0 +1,48 @@
+// RUN: %libomptarget-compile-generic
+// RUN: %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=CHECK
+// RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=DEBUG
+// REQUIRES: libomptarget-debug
+// XFAIL: intelgpu
+
+// Since the allocation of the pointee happens on the "target" construct (1),
+// the "to" transfer requested as part of the mapper (2) should also happen.
+//
+// Similarly, the "from" transfer should also happen at the end of the target
+// construct, even if the ref-count of the pointee x has not gone down to 0
+// when "from" is encountered.
+
+#include <stdio.h>
+
+typedef struct {
+  int *p;
+  int *q;
+} S;
+#pragma omp declare mapper(my_mapper : S s) map(alloc : s.p, s.p[0 : 10])      \
+    map(from : s.p[0 : 10]) map(to : s.p[0 : 10])                              \
+    map(alloc : s.p[0 : 10]) // (2)
+
+S s1;
+int main() {
+  int x[10];
+  x[1] = 111;
+  s1.q = s1.p = &x[0];
+
+  // clang-format off
+  // DEBUG: omptarget --> HstPtrBegin 0x[[#%x,HOST_ADDRX:]] was newly allocated for the current region
+  // DEBUG: omptarget --> Moving [[#%u,SIZEX:]] bytes (hst:0x{{0*}}[[#HOST_ADDRX]]) -> (tgt:0x{{.*}})
+  // clang-format on
+#pragma omp target map(alloc : s1.p[0 : 10])                                   \
+    map(mapper(my_mapper), tofrom : s1) // (1)
+  {
+    printf("%d\n", s1.p[1]); // CHECK: 111
+    s1.p[1] = s1.p[1] + 111;
+  }
+
+  // clang-format off
+  // DEBUG: omptarget --> Found skipped FROM entry: HstPtr=0x{{0*}}[[#HOST_ADDRX]] size=[[#SIZEX]] within region being released
+  // DEBUG: omptarget --> Moving [[#SIZEX]] bytes (tgt:0x{{.*}}) -> (hst:0x{{0*}}[[#HOST_ADDRX]])
+  // clang-format on
+  printf("%d\n", s1.p[1]); // CHECK: 222
+}

--- a/offload/test/mapping/map_ordering_ptee_tgt_alloc_mapper_alloc_from_to.c
+++ b/offload/test/mapping/map_ordering_ptee_tgt_alloc_mapper_alloc_from_to.c
@@ -36,7 +36,7 @@ int main() {
 #pragma omp target map(alloc : s1.p[0 : 10])                                   \
     map(mapper(my_mapper), tofrom : s1) // (1)
   {
-    printf("%d\n", s1.p[1]); // CHECK: 111
+    printf("In tgt: %d\n", s1.p[1]); // CHECK-DAG: In tgt: 111
     s1.p[1] = s1.p[1] + 111;
   }
 
@@ -44,5 +44,5 @@ int main() {
   // DEBUG: omptarget --> Found skipped FROM entry: HstPtr=0x{{0*}}[[#HOST_ADDRX]] size=[[#SIZEX]] within region being released
   // DEBUG: omptarget --> Moving [[#SIZEX]] bytes (tgt:0x{{.*}}) -> (hst:0x{{0*}}[[#HOST_ADDRX]])
   // clang-format on
-  printf("%d\n", s1.p[1]); // CHECK: 222
+  printf("After tgt: %d\n", s1.p[1]); // CHECK-DAG: After tgt: 222
 }

--- a/offload/test/mapping/map_ordering_ptee_tgt_data_alloc_tgt_mapper_present_delete_from_to.c
+++ b/offload/test/mapping/map_ordering_ptee_tgt_data_alloc_tgt_mapper_present_delete_from_to.c
@@ -1,0 +1,49 @@
+// RUN: %libomptarget-compile-generic -fopenmp-version=60
+// RUN: %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=CHECK
+// RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=DEBUG
+// REQUIRES: libomptarget-debug
+
+// The "present" check should pass on the "target" construct (2),
+// and there should be no "to" transfer, because the pointee "x" is already
+// present (because of (1)).
+// However, there should be a "from" transfer at the end of (2) because of the
+// "delete" on the mapper.
+
+// FIXME: This currently fails, but should start passing once ATTACH-style maps
+// are enabled for mappers (#166874).
+// UNSUPPORTED: true
+
+#include <stdio.h>
+
+typedef struct {
+  int *p;
+  int *q;
+} S;
+#pragma omp declare mapper(my_mapper : S s) map(alloc : s.p)                   \
+    map(alloc, present : s.p[0 : 10]) map(delete : s.q[ : ])                   \
+    map(from : s.p[0 : 10]) map(to : s.p[0 : 10]) map(alloc : s.p[0 : 10])
+
+S s1;
+int main() {
+  int x[10];
+  x[1] = 111;
+  s1.q = s1.p = &x[0];
+
+#pragma omp target data map(alloc : x) // (1)
+  {
+// DEBUG-NOT: omptarget --> Moving {{.*}} bytes (hst:0x{{.*}}) -> (tgt:0x{{.*}})
+#pragma omp target map(mapper(my_mapper), tofrom : s1) // (2)
+    {
+      // NOTE: It's ok for this to be 111 under "unified_shared_memory"
+      printf("%d\n", s1.p[1]); // CHECK-NOT: 111
+      s1.p[1] = 222;
+    }
+    printf("%d\n", s1.p[1]); // CHECK: 222
+  }
+  // clang-format off
+  // DEBUG: omptarget --> Found skipped FROM entry: HstPtr=0x[[#%x,HOST_ADDR:]] size=[[#%u,SIZE:]] within region being released
+  // DEBUG: omptarget --> Moving [[#SIZE]] bytes (tgt:0x{{.*}}) -> (hst:0x{{0*}}[[#HOST_ADDR]])
+  // clang-format on
+}

--- a/offload/test/mapping/map_ordering_ptee_tgt_data_alloc_tgt_mapper_present_delete_from_to.c
+++ b/offload/test/mapping/map_ordering_ptee_tgt_data_alloc_tgt_mapper_present_delete_from_to.c
@@ -37,10 +37,10 @@ int main() {
 #pragma omp target map(mapper(my_mapper), tofrom : s1) // (2)
     {
       // NOTE: It's ok for this to be 111 under "unified_shared_memory"
-      printf("%d\n", s1.p[1]); // CHECK-NOT: 111
+      printf("In tgt: %d\n", s1.p[1]); // CHECK-NOT: In tgt: 111
       s1.p[1] = 222;
     }
-    printf("%d\n", s1.p[1]); // CHECK: 222
+    printf("After tgt: %d\n", s1.p[1]); // CHECK: After tgt: 222
   }
   // clang-format off
   // DEBUG: omptarget --> Found skipped FROM entry: HstPtr=0x[[#%x,HOST_ADDR:]] size=[[#%u,SIZE:]] within region being released

--- a/offload/test/mapping/map_ordering_tgt_alloc_from_to.c
+++ b/offload/test/mapping/map_ordering_tgt_alloc_from_to.c
@@ -1,0 +1,26 @@
+// RUN: %libomptarget-compile-generic
+// RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=DEBUG -check-prefix=CHECK
+// REQUIRES: libomptarget-debug
+// XFAIL: intelgpu
+
+#include <stdio.h>
+
+// Even if the "alloc" and "from" are encountered before the "to",
+// there should be a data-transfer from host to device, as the
+// ref-count goes from 0 to 1 at the entry of the target region.
+
+int main() {
+  int x = 111;
+  // clang-format off
+  // DEBUG: omptarget --> HstPtrBegin 0x[[#%x,HOST_ADDR:]] was newly allocated for the current region
+  // DEBUG: omptarget --> Moving {{.*}} bytes (hst:0x{{0*}}[[#HOST_ADDR]]) -> (tgt:0x{{.*}})
+  // clang-format on
+#pragma omp target map(alloc : x) map(from : x) map(to : x) map(alloc : x)
+  {
+    printf("%d\n", x); // CHECK: 111
+    x = x + 111;
+  }
+
+  printf("%d\n", x); // CHECK: 222
+}

--- a/offload/test/mapping/map_ordering_tgt_alloc_present_tofrom.c
+++ b/offload/test/mapping/map_ordering_tgt_alloc_present_tofrom.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-run-fail-generic 2>&1 \
 // RUN: | %fcheck-generic
-// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/map_ordering_tgt_alloc_present_tofrom.c
+++ b/offload/test/mapping/map_ordering_tgt_alloc_present_tofrom.c
@@ -1,0 +1,26 @@
+// RUN: %libomptarget-compile-generic
+// RUN: %libomptarget-run-fail-generic 2>&1 \
+// RUN: | %fcheck-generic
+// XFAIL: intelgpu
+
+#include <stdio.h>
+
+int main() {
+  // CHECK: addr=0x[[#%x,HOST_ADDR:]], size=[[#%u,SIZE:]]
+  int x = 111;
+  fprintf(stderr, "addr=%p, size=%ld\n", &x, sizeof(x));
+
+  // clang-format off
+  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: omptarget error: Pointer 0x{{0*}}[[#HOST_ADDR]] was not present on the device upon entry to the region.
+  // CHECK: omptarget error: Call to targetDataBegin failed, abort target.
+  // CHECK: omptarget error: Failed to process data before launching the kernel.
+  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // clang-format on
+#pragma omp target map(alloc : x) map(present, alloc : x) map(tofrom : x)
+  {
+    printf("%d\n", x);
+  }
+
+  return 0;
+}

--- a/offload/test/mapping/map_ordering_tgt_alloc_tofrom.c
+++ b/offload/test/mapping/map_ordering_tgt_alloc_tofrom.c
@@ -1,0 +1,15 @@
+// RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
+
+#include <stdio.h>
+
+int main() {
+  int x = 111;
+#pragma omp target map(alloc : x) map(tofrom : x) map(alloc : x)
+  {
+    printf("%d\n", x); // CHECK: 111
+    x = x + 111;
+  }
+
+  printf("%d\n", x); // CHECK: 222
+}

--- a/offload/test/mapping/map_ordering_tgt_alloc_tofrom.c
+++ b/offload/test/mapping/map_ordering_tgt_alloc_tofrom.c
@@ -7,9 +7,9 @@ int main() {
   int x = 111;
 #pragma omp target map(alloc : x) map(tofrom : x) map(alloc : x)
   {
-    printf("%d\n", x); // CHECK: 111
+    printf("In tgt: %d\n", x); // CHECK-DAG: In tgt: 111
     x = x + 111;
   }
 
-  printf("%d\n", x); // CHECK: 222
+  printf("After tgt: %d\n", x); // CHECK-DAG: After tgt: 222
 }

--- a/offload/test/mapping/map_ordering_tgt_data_alloc_from.c
+++ b/offload/test/mapping/map_ordering_tgt_data_alloc_from.c
@@ -1,0 +1,15 @@
+// RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
+
+#include <stdio.h>
+
+int main() {
+  int x = 111;
+#pragma omp target data map(alloc : x) map(from : x) map(alloc : x)
+  {
+#pragma omp target map(present, alloc : x)
+    x = 222;
+  }
+
+  printf("%d\n", x); // CHECK: 222
+}

--- a/offload/test/mapping/map_ordering_tgt_data_alloc_from.c
+++ b/offload/test/mapping/map_ordering_tgt_data_alloc_from.c
@@ -11,5 +11,5 @@ int main() {
     x = 222;
   }
 
-  printf("%d\n", x); // CHECK: 222
+  printf("After tgt data: %d\n", x); // CHECK: After tgt data: 222
 }

--- a/offload/test/mapping/map_ordering_tgt_data_alloc_to_from.c
+++ b/offload/test/mapping/map_ordering_tgt_data_alloc_to_from.c
@@ -1,0 +1,18 @@
+// RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
+
+#include <stdio.h>
+
+int main() {
+  int x = 111;
+#pragma omp target data map(alloc : x) map(to : x) map(from : x) map(alloc : x)
+  {
+#pragma omp target map(present, alloc : x)
+    {
+      printf("%d\n", x); // CHECK: 111
+      x = x + 111;
+    }
+  }
+
+  printf("%d\n", x); // CHECK: 222
+}

--- a/offload/test/mapping/map_ordering_tgt_data_alloc_tofrom.c
+++ b/offload/test/mapping/map_ordering_tgt_data_alloc_tofrom.c
@@ -1,0 +1,18 @@
+// RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
+
+#include <stdio.h>
+
+int main() {
+  int x = 111;
+#pragma omp target data map(alloc : x) map(tofrom : x) map(alloc : x)
+  {
+#pragma omp target map(present, alloc : x)
+    {
+      printf("%d\n", x); // CHECK: 111
+      x = x + 111;
+    }
+  }
+
+  printf("%d\n", x); // CHECK: 222
+}

--- a/offload/test/mapping/map_ordering_tgt_exit_data_always_always.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_always_always.c
@@ -24,5 +24,5 @@ int main() {
     // DEBUG-NOT: omptarget --> Moving {{.*}} bytes
   }
 
-  printf("%d\n", x); // CHECK: 222
+  printf("After tgt exit data: %d\n", x); // CHECK: After tgt exit data: 222
 }

--- a/offload/test/mapping/map_ordering_tgt_exit_data_always_always.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_always_always.c
@@ -1,0 +1,28 @@
+// RUN: %libomptarget-compile-generic
+// RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=DEBUG -check-prefix=CHECK
+// REQUIRES: libomptarget-debug
+// XFAIL: intelgpu
+
+// There should only be one "from" data-transfer, despite the two duplicate
+// maps.
+
+#include <stdio.h>
+
+int main() {
+  int x = 111;
+#pragma omp target data map(alloc : x)
+  {
+#pragma omp target enter data map(alloc : x) map(to : x)
+#pragma omp target map(present, alloc : x)
+    {
+      printf("In tgt: %d\n", x); // CHECK-NOT: In tgt: 111
+      x = 222;
+    }
+#pragma omp target exit data map(always, from : x) map(always, from : x)
+    // DEBUG: omptarget --> Moving {{.*}} bytes (tgt:0x{{.*}}) -> (hst:0x{{.*}})
+    // DEBUG-NOT: omptarget --> Moving {{.*}} bytes
+  }
+
+  printf("%d\n", x); // CHECK: 222
+}

--- a/offload/test/mapping/map_ordering_tgt_exit_data_delete_from.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_delete_from.c
@@ -11,10 +11,10 @@ int main() {
 #pragma omp target map(present, alloc : x)
     {
       // NOTE: It's ok for this to be 111 under "unified_shared_memory"
-      printf("%d\n", x); // CHECK-NOT: 111
+      printf("In tgt: %d\n", x); // CHECK-NOT: In tgt: 111
       x = 222;
     }
 #pragma omp target exit data map(delete : x) map(from : x) map(delete : x)
-    printf("%d\n", x); // CHECK: 222
+    printf("After tgt exit data: %d\n", x); // CHECK: After tgt exit data: 222
   }
 }

--- a/offload/test/mapping/map_ordering_tgt_exit_data_delete_from.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_delete_from.c
@@ -1,0 +1,20 @@
+// RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
+
+#include <stdio.h>
+
+int main() {
+  int x = 111;
+#pragma omp target data map(alloc : x)
+  {
+#pragma omp target enter data map(alloc : x) map(to : x)
+#pragma omp target map(present, alloc : x)
+    {
+      // NOTE: It's ok for this to be 111 under "unified_shared_memory"
+      printf("%d\n", x); // CHECK-NOT: 111
+      x = 222;
+    }
+#pragma omp target exit data map(delete : x) map(from : x) map(delete : x)
+    printf("%d\n", x); // CHECK: 222
+  }
+}

--- a/offload/test/mapping/map_ordering_tgt_exit_data_delete_from_assumedsize.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_delete_from_assumedsize.c
@@ -37,6 +37,7 @@ int main() {
     // DEBUG: omptarget --> Moving [[#SIZE]] bytes (tgt:0x{{.*}}) -> (hst:0x{{0*}}[[#HOST_ADDR]])
     // clang-format on
 
-    printf("%d\n", x[1]); // CHECK: 222
+    // CHECK: After tgt exit data: 222
+    printf("After tgt exit data: %d\n", x[1]);
   }
 }

--- a/offload/test/mapping/map_ordering_tgt_exit_data_delete_from_assumedsize.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_delete_from_assumedsize.c
@@ -1,0 +1,42 @@
+// RUN: %libomptarget-compile-generic -fopenmp-version=60
+// RUN: %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=CHECK
+// RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=DEBUG
+// REQUIRES: libomptarget-debug
+// XFAIL: intelgpu
+
+// The from on target_exit_data should result in a data-transfer of 4 bytes,
+// even if when "from" is honored, the ref-count hasn't gone down to 0.
+// It will eventually go down to 0 as part of the same exit_data due to the
+// "delete" on it.
+// This is a case that cannot be handled at compile time because the list-items
+// are not related.
+
+#include <stdio.h>
+
+int main() {
+  int x[10];
+  int *p1x, *p2x;
+  p1x = p2x = &x[0];
+
+#pragma omp target data map(alloc : x)
+  {
+#pragma omp target enter data map(alloc : x) map(to : x)
+// DEBUG-NOT: omptarget --> Moving {{.*}} bytes (hst:0x{{.*}}) -> (tgt:0x{{.*}})
+#pragma omp target map(present, alloc : x)
+    {
+      // NOTE: It's ok for this to be 111 under "unified_shared_memory"
+      printf("In tgt: %d\n", x[1]); // CHECK-NOT: In tgt: 111
+      x[1] = 222;
+    }
+
+#pragma omp target exit data map(delete : p1x[ : ]) map(from : p2x[1])
+    // clang-format off
+    // DEBUG: omptarget --> Found skipped FROM entry: HstPtr=0x[[#%x,HOST_ADDR:]] size=[[#%u,SIZE:]] within region being released
+    // DEBUG: omptarget --> Moving [[#SIZE]] bytes (tgt:0x{{.*}}) -> (hst:0x{{0*}}[[#HOST_ADDR]])
+    // clang-format on
+
+    printf("%d\n", x[1]); // CHECK: 222
+  }
+}

--- a/offload/test/mapping/map_ordering_tgt_exit_data_from_delete_assumedsize.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_from_delete_assumedsize.c
@@ -1,0 +1,42 @@
+// RUN: %libomptarget-compile-generic -fopenmp-version=60
+// RUN: %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=CHECK
+// RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=DEBUG
+// REQUIRES: libomptarget-debug
+// XFAIL: intelgpu
+
+// The from on target_exit_data should result in a data-transfer of 4 bytes,
+// even if when "delete" is honored first, and by the time "from" is
+// encountered, the ref-count had already been 0 (i.e. it's not transitioning
+// from non-zero to zero).
+// This is a case that cannot be handled at compile time because the list-items
+// are not related.
+
+#include <stdio.h>
+int main() {
+  int x[10];
+  int *p1x, *p2x;
+  p1x = p2x = &x[1];
+  x[1] = 111;
+
+#pragma omp target data map(alloc : x)
+  {
+#pragma omp target enter data map(alloc : x) map(to : x)
+// DEBUG-NOT: omptarget --> Moving {{.*}} bytes (hst:0x{{.*}}) -> (tgt:0x{{.*}})
+#pragma omp target map(present, alloc : x)
+    {
+      // NOTE: It's ok for this to be 111 under "unified_shared_memory"
+      printf("In tgt: %d\n", x[1]); // CHECK-NOT: In tgt: 111
+      x[1] = 222;
+    }
+
+#pragma omp target exit data map(from : p2x[0]) map(delete : p1x[ : ])
+    // clang-format off
+    // DEBUG: omptarget --> Pointer HstPtr=0x[[#%x,HOST_ADDR:]] falls within a range previously released
+    // DEBUG: omptarget --> Moving {{.*}} bytes (tgt:0x{{.*}}) -> (hst:0x{{0*}}[[#HOST_ADDR]])
+    // clang-format on
+
+    printf("%d\n", x[1]); // CHECK: 222
+  }
+}

--- a/offload/test/mapping/map_ordering_tgt_exit_data_from_delete_assumedsize.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_from_delete_assumedsize.c
@@ -37,6 +37,7 @@ int main() {
     // DEBUG: omptarget --> Moving {{.*}} bytes (tgt:0x{{.*}}) -> (hst:0x{{0*}}[[#HOST_ADDR]])
     // clang-format on
 
-    printf("%d\n", x[1]); // CHECK: 222
+    // CHECK: After tgt exit data: 222
+    printf("After tgt exit data: %d\n", x[1]);
   }
 }

--- a/offload/test/mapping/map_ordering_tgt_exit_data_from_mapper_overlap.c
+++ b/offload/test/mapping/map_ordering_tgt_exit_data_from_mapper_overlap.c
@@ -1,0 +1,50 @@
+// RUN: %libomptarget-compile-generic
+// RUN: %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=CHECK
+// RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
+// RUN: | %fcheck-generic -check-prefix=DEBUG
+// REQUIRES: libomptarget-debug
+// XFAIL: intelgpu
+
+// The test ensures that the FROM transfer for the full "s1" is performed, and
+// not just the FROM done via the mapper of s1.s2.
+
+#include <stdio.h>
+
+typedef struct {
+  int a;
+  int b;
+} S2;
+
+#pragma omp declare mapper(my_mapper : S2 s2) map(tofrom : s2.a)
+
+typedef struct {
+  S2 s2;
+  int c;
+  int d;
+} S1;
+
+S1 s1;
+
+int main() {
+#pragma omp target enter data map(alloc : s1)
+
+#pragma omp target map(present, alloc : s1)
+  {
+    s1.s2.a = 111;
+    s1.s2.b = 222;
+    s1.c = 333;
+    s1.d = 444;
+  }
+
+  // clang-format off
+  // DEBUG: omptarget --> Tracking released entry: HstPtr=0x[[#%x,HOST_ADDR:]], Size=[[#%u,SIZE:]], ForceDelete=0
+  // DEBUG: omptarget --> Moving {{.*}} bytes (tgt:0x{{.*}}) -> (hst:0x{{.*}})
+  // DEBUG: omptarget --> Pointer HstPtr=0x{{0*}}[[#HOST_ADDR]] falls within a range previously released
+  // DEBUG: omptarget --> Moving [[#SIZE]] bytes (tgt:0x{{.*}}) -> (hst:0x{{0*}}[[#HOST_ADDR]])
+  // clang-format on
+#pragma omp target exit data map(from : s1) map(mapper(my_mapper), from : s1.s2)
+
+  // CHECK: 111 222 333 444
+  printf("%d %d %d %d\n", s1.s2.a, s1.s2.b, s1.c, s1.d);
+}


### PR DESCRIPTION
    
Some tests that were checking for prints inside/outside `target` regions
needed to be updated to work on systems where the ordering wasn't
deterministic.

Reverts llvm/llvm-project#184240
    
Original description from #165494:

-----

OpenMP allows cases like the following:

```c
  int *p1, *p2, x;
  p1 = p2 = &x;
  ...
  #pragma omp target_exit_data map(delete: p1[:]) from(p2[0])
```

Which means, when the runtime encounters the `from` entry, the ref-count may
not be zero, but it will go down to zero at the end of the current construct,
which should cause the "from" transfer to happen.

Similarly, a user may have:

```c
  struct S {
    int *p;
  };

  #pragma omp declare_mapper (id1: S s) map(s.p) map(present, alloc: s.p[0:10])
  #pragma omp declare_mapper (id2: S s) map(s.p, s.p[0:10])

  S s1;

 // present-check should fail here
 #pragma omp target_enter_data map(alloc: s.p[0:10]) map(mapper(id1), to: s)
 // "to" should be honored here
 #pragma omp target_enter_data map(alloc: s.p[0:10]) map(mapper(id2), to: s)
```

Where the allocation happens before the "to" entry is encountered by the
runtime. Or, an allocation happens before a "present" entry is encountered.

To handle cases like this, we need to use the state information of previously
seen new allocations, deletions, "from" entries, when honoring
`to`/`from`/`present` map entries.

-----
