### PR TITLE
[lldb] Terminate the LLDB Log in SystemInitializerCommon::Terminate

### DIFF
--- a/lldb/include/lldb/Utility/LLDBLog.h
+++ b/lldb/include/lldb/Utility/LLDBLog.h
@@ -56,7 +56,8 @@ enum class LLDBLog : Log::MaskType {
 
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 
-void InitializeLldbChannel();
+void InitializeLLDBChannel();
+void TerminateLLDBChannel();
 
 template <> Log::Channel &LogChannelFor<LLDBLog>();
 } // namespace lldb_private

--- a/lldb/source/Initialization/SystemInitializerCommon.cpp
+++ b/lldb/source/Initialization/SystemInitializerCommon.cpp
@@ -62,7 +62,7 @@ llvm::Error SystemInitializerCommon::Initialize() {
   }
 #endif
 
-  InitializeLldbChannel();
+  InitializeLLDBChannel();
 
   Diagnostics::Initialize();
   FileSystem::Initialize();
@@ -99,4 +99,6 @@ void SystemInitializerCommon::Terminate() {
   Log::DisableAllLogChannels();
   FileSystem::Terminate();
   Diagnostics::Terminate();
+
+  TerminateLLDBChannel();
 }

--- a/lldb/source/Utility/LLDBLog.cpp
+++ b/lldb/source/Utility/LLDBLog.cpp
@@ -84,6 +84,8 @@ template <> Log::Channel &lldb_private::LogChannelFor<LLDBLog>() {
   return g_log_channel;
 }
 
-void lldb_private::InitializeLldbChannel() {
+void lldb_private::InitializeLLDBChannel() {
   Log::Register("lldb", g_log_channel);
 }
+
+void lldb_private::TerminateLLDBChannel() { Log::Unregister("lldb"); }


### PR DESCRIPTION
Currently, when calling SBDebugger::Initialize after SBDebugger::Terminate, you hit an assert in LLDBLog when trying to register the LLDB log a second time. Also fix the awkward capitalization.