### PR TITLE
[lldb] Fix the GoogleTest teardown in the DAP unit tests

### DIFF
--- a/lldb/unittests/DAP/TestBase.cpp
+++ b/lldb/unittests/DAP/TestBase.cpp
@@ -70,7 +70,7 @@ void DAPTestBase::SetUpTestSuite() {
   lldb::SBError error = SBDebugger::InitializeWithErrorHandling();
   EXPECT_TRUE(error.Success());
 }
-void DAPTestBase::TeatUpTestSuite() { SBDebugger::Terminate(); }
+void DAPTestBase::TearDownTestSuite() { SBDebugger::Terminate(); }
 
 bool DAPTestBase::GetDebuggerSupportsTarget(StringRef platform) {
   EXPECT_TRUE(dap->debugger);

--- a/lldb/unittests/DAP/TestBase.h
+++ b/lldb/unittests/DAP/TestBase.h
@@ -108,7 +108,7 @@ protected:
   static constexpr llvm::StringLiteral k_linux_core = "linux-x86_64.core.yaml";
 
   static void SetUpTestSuite();
-  static void TeatUpTestSuite();
+  static void TearDownTestSuite();
   void SetUp() override;
   void TearDown() override;
 

--- a/lldb/unittests/DAP/VariablesTest.cpp
+++ b/lldb/unittests/DAP/VariablesTest.cpp
@@ -33,7 +33,7 @@ public:
     lldb::SBError error = SBDebugger::InitializeWithErrorHandling();
     EXPECT_TRUE(error.Success());
   }
-  static void TeatUpTestSuite() { SBDebugger::Terminate(); }
+  static void TearDownTestSuite() { SBDebugger::Terminate(); }
 
   void TearDown() override {
     if (core)


### PR DESCRIPTION
Some of the DAP tests define a static method named `TeatUpTestSuite` which is calling `SBDebugger::Terminate`. Besides the typo, the correct method is `TearDownTestSuite`, which GoogleTest calls after running the last test in the test suite.

When addressing this, I realized that currently you can't really call Initialize and Terminate multiple times in the same process. This depends on:

- https://github.com/llvm/llvm-project/pull/184259
- https://github.com/llvm/llvm-project/pull/184261