### PR TITLE
[NFC][OpenMP] Remove redundant prints in `target` regions from tests added in #184260.

### DIFF
--- a/offload/test/mapping/map_ordering_ptee_tgt_alloc_mapper_alloc_from_to.c
+++ b/offload/test/mapping/map_ordering_ptee_tgt_alloc_mapper_alloc_from_to.c
@@ -36,7 +36,6 @@ int main() {
 #pragma omp target map(alloc : s1.p[0 : 10])                                   \
     map(mapper(my_mapper), tofrom : s1) // (1)
   {
-    printf("In tgt: %d\n", s1.p[1]); // CHECK-DAG: In tgt: 111
     s1.p[1] = s1.p[1] + 111;
   }
 
@@ -44,5 +43,5 @@ int main() {
   // DEBUG: omptarget --> Found skipped FROM entry: HstPtr=0x{{0*}}[[#HOST_ADDRX]] size=[[#SIZEX]] within region being released
   // DEBUG: omptarget --> Moving [[#SIZEX]] bytes (tgt:0x{{.*}}) -> (hst:0x{{0*}}[[#HOST_ADDRX]])
   // clang-format on
-  printf("After tgt: %d\n", s1.p[1]); // CHECK-DAG: After tgt: 222
+  printf("After tgt: %d\n", s1.p[1]); // CHECK: After tgt: 222
 }

--- a/offload/test/mapping/map_ordering_tgt_alloc_from_to.c
+++ b/offload/test/mapping/map_ordering_tgt_alloc_from_to.c
@@ -18,9 +18,8 @@ int main() {
   // clang-format on
 #pragma omp target map(alloc : x) map(from : x) map(to : x) map(alloc : x)
   {
-    printf("%d\n", x); // CHECK: 111
     x = x + 111;
   }
 
-  printf("%d\n", x); // CHECK: 222
+  printf("After tgt: %d\n", x); // CHECK: After tgt: 222
 }

--- a/offload/test/mapping/map_ordering_tgt_alloc_tofrom.c
+++ b/offload/test/mapping/map_ordering_tgt_alloc_tofrom.c
@@ -7,9 +7,8 @@ int main() {
   int x = 111;
 #pragma omp target map(alloc : x) map(tofrom : x) map(alloc : x)
   {
-    printf("In tgt: %d\n", x); // CHECK-DAG: In tgt: 111
     x = x + 111;
   }
 
-  printf("After tgt: %d\n", x); // CHECK-DAG: After tgt: 222
+  printf("After tgt: %d\n", x); // CHECK: After tgt: 222
 }

--- a/offload/test/mapping/map_ordering_tgt_data_alloc_to_from.c
+++ b/offload/test/mapping/map_ordering_tgt_data_alloc_to_from.c
@@ -9,10 +9,9 @@ int main() {
   {
 #pragma omp target map(present, alloc : x)
     {
-      printf("%d\n", x); // CHECK: 111
       x = x + 111;
     }
   }
 
-  printf("%d\n", x); // CHECK: 222
+  printf("After tgt data: %d\n", x); // CHECK: After tgt data: 222
 }

--- a/offload/test/mapping/map_ordering_tgt_data_alloc_tofrom.c
+++ b/offload/test/mapping/map_ordering_tgt_data_alloc_tofrom.c
@@ -9,10 +9,9 @@ int main() {
   {
 #pragma omp target map(present, alloc : x)
     {
-      printf("%d\n", x); // CHECK: 111
       x = x + 111;
     }
   }
 
-  printf("%d\n", x); // CHECK: 222
+  printf("After tgt data: %d\n", x); // CHECK: After tgt data: 222
 }


### PR DESCRIPTION
Some buildbots don't like them, and the correctness of the values in the `target` region is ensured via prints after the region.