### PR TITLE
Add bogus unit test to (dis)prove that they run in pre-commit CI

### DIFF
--- a/lldb/unittests/Utility/UUIDTest.cpp
+++ b/lldb/unittests/Utility/UUIDTest.cpp
@@ -135,3 +135,7 @@ TEST(UUIDTest, DenseSet) {
   EXPECT_FALSE(uuid_set.contains(b16));
   EXPECT_FALSE(uuid_set.contains(b20));
 }
+
+TEST(UUIDTest, BogusTest) {
+  EXPECT_FALSE(true);
+}


### PR DESCRIPTION
The pre-commit test for https://github.com/llvm/llvm-project/pull/184262 are unexpectedly green and the most likely explanation would be that the unit tests aren't being run. However, I can't tell from the log, so this should (dis)prove my theory.