### PR TITLE
[libc][math][C23] add software float16 support

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -400,6 +400,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf16
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -656,7 +657,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.f16sub
     libc.src.math.f16subf
     libc.src.math.f16subl
-    libc.src.math.fabsf16
     libc.src.math.fdimf16
     libc.src.math.floorf16
     libc.src.math.fmaf16

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -412,6 +412,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf16
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -668,7 +669,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.f16sub
     libc.src.math.f16subf
     libc.src.math.f16subl
-    libc.src.math.fabsf16
     libc.src.math.fdimf16
     libc.src.math.floorf16
     libc.src.math.fmaf16

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -408,6 +408,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf16
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -664,7 +665,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.f16sub
     libc.src.math.f16subf
     libc.src.math.f16subl
-    libc.src.math.fabsf16
     libc.src.math.fdimf16
     libc.src.math.floorf16
     libc.src.math.fmaf16

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -219,6 +219,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf16
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -476,7 +477,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.f16sub
     libc.src.math.f16subf
     libc.src.math.f16subl
-    libc.src.math.fabsf16
     libc.src.math.fdimf16
     libc.src.math.floorf16
     libc.src.math.fmaf16

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -155,6 +155,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf16
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -426,7 +427,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.f16sub
     libc.src.math.f16subf
     libc.src.math.f16subl
-    libc.src.math.fabsf16
     libc.src.math.fdimf16
     libc.src.math.floorf16
     libc.src.math.fmaf16

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -569,6 +569,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf16
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -815,7 +816,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.f16sub
     libc.src.math.f16subf
     # libc.src.math.f16subl
-    libc.src.math.fabsf16
     libc.src.math.fdimf16
     libc.src.math.fdiv
     libc.src.math.fdivl

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -392,6 +392,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf16
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -584,6 +584,11 @@ set(TARGET_LIBM_ENTRYPOINTS
 )
 
 list(APPEND TARGET_LIBM_ENTRYPOINTS
+  # float16 entrypoints
+  libc.src.math.fabsf16
+)
+
+list(APPEND TARGET_LIBM_ENTRYPOINTS
   # bfloat16 entrypoints
   libc.src.math.atanbf16
   libc.src.math.acosbf16

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -634,6 +634,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf16
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -898,7 +899,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.f16sub
     libc.src.math.f16subf
     libc.src.math.f16subl
-    libc.src.math.fabsf16
     libc.src.math.fdimf16
     libc.src.math.floorf16
     libc.src.math.fmaf16

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -643,6 +643,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf16
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl
@@ -907,7 +908,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.f16sub
     libc.src.math.f16subf
     libc.src.math.f16subl
-    libc.src.math.fabsf16
     libc.src.math.fdimf16
     libc.src.math.floorf16
     libc.src.math.fmaf16

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -187,6 +187,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.expm1f
     libc.src.math.fabs
     libc.src.math.fabsf
+    libc.src.math.fabsf16
     libc.src.math.fabsl
     libc.src.math.fadd
     libc.src.math.faddl

--- a/libc/include/llvm-libc-macros/float16-macros.h
+++ b/libc/include/llvm-libc-macros/float16-macros.h
@@ -11,11 +11,18 @@
 
 #include "../llvm-libc-types/float128.h"
 
-#if defined(__FLT16_MANT_DIG__) &&                                             \
+#if defined(__arm__) && defined(_M_ARM)
+#define LIBC_USE_SOFT_FLOAT16
+#endif
+
+#ifdef LIBC_USE_SOFT_FLOAT16
+#define LIBC_TYPES_HAS_FLOAT16
+#endif
+
+#if !defined(LIBC_TYPES_HAS_FLOAT16) && defined(__FLT16_MANT_DIG__) &&         \
     (!defined(__GNUC__) || __GNUC__ >= 13 ||                                   \
      (defined(__clang__) && __clang_major__ >= 12)) &&                         \
-    !defined(__arm__) && !defined(_M_ARM) && !defined(__riscv) &&              \
-    !defined(_WIN32)
+    !defined(__riscv) && !defined(_WIN32)
 #define LIBC_TYPES_HAS_FLOAT16
 
 // TODO: This would no longer be required if HdrGen let us guard function

--- a/libc/include/llvm-libc-macros/float16-macros.h
+++ b/libc/include/llvm-libc-macros/float16-macros.h
@@ -11,7 +11,7 @@
 
 #include "../llvm-libc-types/float128.h"
 
-#if defined(__arm__) && defined(_M_ARM)
+#if (defined(__arm__) && defined(_M_ARM)) || defined(__riscv)
 #define LIBC_USE_SOFT_FLOAT16
 #endif
 

--- a/libc/include/llvm-libc-macros/float16-macros.h
+++ b/libc/include/llvm-libc-macros/float16-macros.h
@@ -11,25 +11,18 @@
 
 #include "../llvm-libc-types/float128.h"
 
-#if (defined(__arm__) && defined(_M_ARM)) || defined(__riscv)
-#define LIBC_USE_SOFT_FLOAT16
-#endif
-
-#ifdef LIBC_USE_SOFT_FLOAT16
-#define LIBC_TYPES_HAS_FLOAT16
-#endif
-
-#if !defined(LIBC_TYPES_HAS_FLOAT16) && defined(__FLT16_MANT_DIG__) &&         \
+#if defined(__FLT16_MANT_DIG__) &&                                             \
     (!defined(__GNUC__) || __GNUC__ >= 13 ||                                   \
      (defined(__clang__) && __clang_major__ >= 12)) &&                         \
-    !defined(__riscv) && !defined(_WIN32)
+    !defined(__arm__) && !defined(_M_ARM) && !defined(__riscv) &&              \
+    !defined(_WIN32)
 #define LIBC_TYPES_HAS_FLOAT16
+#endif
 
 // TODO: This would no longer be required if HdrGen let us guard function
 // declarations with multiple macros.
-#ifdef LIBC_TYPES_HAS_NATIVE_FLOAT128
+#if defined(LIBC_TYPES_HAS_FLOAT16) && defined(LIBC_TYPES_HAS_NATIVE_FLOAT128)
 #define LIBC_TYPES_HAS_FLOAT16_AND_FLOAT128
-#endif // LIBC_TYPES_HAS_NATIVE_FLOAT128
-#endif
+#endif // LIBC_TYPES_HAS_FLOAT16 && LIBC_TYPES_HAS_NATIVE_FLOAT128
 
 #endif // LLVM_LIBC_MACROS_FLOAT16_MACROS_H

--- a/libc/src/__support/CPP/type_traits/is_floating_point.h
+++ b/libc/src/__support/CPP/type_traits/is_floating_point.h
@@ -42,7 +42,8 @@ public:
 #endif
                               ,
                               bfloat16
-
+                              ,
+                              fputil::Float16
                               ,
                               fputil::Float128
 

--- a/libc/src/__support/CPP/type_traits/is_floating_point.h
+++ b/libc/src/__support/CPP/type_traits/is_floating_point.h
@@ -41,11 +41,7 @@ public:
                               float128
 #endif
                               ,
-                              bfloat16
-                              ,
-                              fputil::Float16
-                              ,
-                              fputil::Float128
+                              bfloat16, fputil::Float16, fputil::Float128
 
                               ,
                               fputil::Float80>();

--- a/libc/src/__support/FPUtil/BasicOperations.h
+++ b/libc/src/__support/FPUtil/BasicOperations.h
@@ -53,6 +53,7 @@ max(T x, T y) {
 }
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
+#if !defined(LIBC_USE_SOFT_FLOAT16)
 #if defined(__LIBC_USE_BUILTIN_FMAXF16_FMINF16)
 template <> LIBC_INLINE constexpr float16 max(float16 x, float16 y) {
   if (cpp::is_constant_evaluated())
@@ -69,6 +70,7 @@ template <> LIBC_INLINE constexpr float16 max(float16 x, float16 y) {
   return ((xi > yi) != (xi < 0 && yi < 0)) ? x : y;
 }
 #endif
+#endif // !LIBC_USE_SOFT_FLOAT16
 #endif // LIBC_TYPES_HAS_FLOAT16
 
 #if defined(__LIBC_USE_BUILTIN_FMAX_FMIN) && !defined(LIBC_TARGET_ARCH_IS_X86)
@@ -106,6 +108,7 @@ min(T x, T y) {
 }
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
+#if !defined(LIBC_USE_SOFT_FLOAT16)
 #if defined(__LIBC_USE_BUILTIN_FMAXF16_FMINF16)
 template <> LIBC_INLINE constexpr float16 min(float16 x, float16 y) {
   if (cpp::is_constant_evaluated())
@@ -122,6 +125,7 @@ template <> LIBC_INLINE constexpr float16 min(float16 x, float16 y) {
   return ((xi < yi) != (xi < 0 && yi < 0)) ? x : y;
 }
 #endif
+#endif // !LIBC_USE_SOFT_FLOAT16
 #endif // LIBC_TYPES_HAS_FLOAT16
 
 #if defined(__LIBC_USE_BUILTIN_FMAX_FMIN) && !defined(LIBC_TARGET_ARCH_IS_X86)

--- a/libc/src/__support/FPUtil/BasicOperations.h
+++ b/libc/src/__support/FPUtil/BasicOperations.h
@@ -52,8 +52,7 @@ max(T x, T y) {
   return constexpr_max(x, y);
 }
 
-#ifdef LIBC_TYPES_HAS_FLOAT16
-#if !defined(LIBC_USE_SOFT_FLOAT16)
+#if defined(LIBC_TYPES_HAS_FLOAT16) && !defined(LIBC_USE_SOFT_FLOAT16)
 #if defined(__LIBC_USE_BUILTIN_FMAXF16_FMINF16)
 template <> LIBC_INLINE constexpr float16 max(float16 x, float16 y) {
   if (cpp::is_constant_evaluated())
@@ -70,8 +69,7 @@ template <> LIBC_INLINE constexpr float16 max(float16 x, float16 y) {
   return ((xi > yi) != (xi < 0 && yi < 0)) ? x : y;
 }
 #endif
-#endif // !LIBC_USE_SOFT_FLOAT16
-#endif // LIBC_TYPES_HAS_FLOAT16
+#endif // defined(LIBC_TYPES_HAS_FLOAT16) && !defined(LIBC_USE_SOFT_FLOAT16)
 
 #if defined(__LIBC_USE_BUILTIN_FMAX_FMIN) && !defined(LIBC_TARGET_ARCH_IS_X86)
 template <> LIBC_INLINE constexpr float max(float x, float y) {
@@ -107,8 +105,7 @@ min(T x, T y) {
   return constexpr_min(x, y);
 }
 
-#ifdef LIBC_TYPES_HAS_FLOAT16
-#if !defined(LIBC_USE_SOFT_FLOAT16)
+#if defined(LIBC_TYPES_HAS_FLOAT16) && !defined(LIBC_USE_SOFT_FLOAT16)
 #if defined(__LIBC_USE_BUILTIN_FMAXF16_FMINF16)
 template <> LIBC_INLINE constexpr float16 min(float16 x, float16 y) {
   if (cpp::is_constant_evaluated())
@@ -125,8 +122,7 @@ template <> LIBC_INLINE constexpr float16 min(float16 x, float16 y) {
   return ((xi < yi) != (xi < 0 && yi < 0)) ? x : y;
 }
 #endif
-#endif // !LIBC_USE_SOFT_FLOAT16
-#endif // LIBC_TYPES_HAS_FLOAT16
+#endif // defined(LIBC_TYPES_HAS_FLOAT16) && !defined(LIBC_USE_SOFT_FLOAT16)
 
 #if defined(__LIBC_USE_BUILTIN_FMAX_FMIN) && !defined(LIBC_TARGET_ARCH_IS_X86)
 template <> LIBC_INLINE constexpr float min(float x, float y) {

--- a/libc/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/src/__support/FPUtil/CMakeLists.txt
@@ -44,6 +44,24 @@ add_header_library(
 )
 
 add_header_library(
+  Float16
+  HDRS
+    Float16.h
+  DEPENDS
+    .cast
+    .comparison_operations
+    .dyadic_float
+    libc.hdr.stdint_proxy
+    libc.src.__support.CPP.bit
+    libc.src.__support.CPP.type_traits
+    libc.src.__support.FPUtil.generic.add_sub
+    libc.src.__support.FPUtil.generic.div
+    libc.src.__support.FPUtil.generic.mul
+    libc.src.__support.macros.config
+    libc.src.__support.macros.properties.types
+)
+
+add_header_library(
   fpbits_str
   HDRS
     fpbits_str.h

--- a/libc/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/src/__support/FPUtil/CMakeLists.txt
@@ -44,24 +44,6 @@ add_header_library(
 )
 
 add_header_library(
-  Float16
-  HDRS
-    Float16.h
-  DEPENDS
-    .cast
-    .comparison_operations
-    .dyadic_float
-    libc.hdr.stdint_proxy
-    libc.src.__support.CPP.bit
-    libc.src.__support.CPP.type_traits
-    libc.src.__support.FPUtil.generic.add_sub
-    libc.src.__support.FPUtil.generic.div
-    libc.src.__support.FPUtil.generic.mul
-    libc.src.__support.macros.config
-    libc.src.__support.macros.properties.types
-)
-
-add_header_library(
   fpbits_str
   HDRS
     fpbits_str.h
@@ -291,6 +273,25 @@ add_header_library(
     libc.hdr.fenv_macros
     libc.src.__support.CPP.algorithm
     libc.src.__support.CPP.type_traits
+    libc.src.__support.macros.properties.types
+)
+
+add_header_library(
+  float16
+  HDRS
+    float16.h
+  DEPENDS
+    .cast
+    .comparison_operations
+    .dyadic_float
+    libc.hdr.stdint_proxy
+    libc.src.__support.CPP.bit
+    libc.src.__support.CPP.type_traits
+    libc.src.__support.FPUtil.generic.add_sub
+    libc.src.__support.FPUtil.generic.div
+    libc.src.__support.FPUtil.generic.mul
+    libc.src.__support.macros.attributes
+    libc.src.__support.macros.config
     libc.src.__support.macros.properties.types
 )
 

--- a/libc/src/__support/FPUtil/FPBits.h
+++ b/libc/src/__support/FPUtil/FPBits.h
@@ -818,6 +818,8 @@ template <typename T> LIBC_INLINE static constexpr FPType get_fp_type() {
     return FPType::IEEE754_Binary128;
   else if constexpr (cpp::is_same_v<UnqualT, Float80>)
     return FPType::X86_Binary80;
+  else if constexpr (cpp::is_same_v<UnqualT, Float16>)
+    return FPType::IEEE754_Binary16;
   else
     static_assert(cpp::always_false<UnqualT>, "Unsupported type");
 }

--- a/libc/src/__support/FPUtil/Float16.h
+++ b/libc/src/__support/FPUtil/Float16.h
@@ -1,0 +1,127 @@
+//===-- Definition of float16 data type. ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_FPUTIL_FLOAT16_H
+#define LLVM_LIBC_SRC___SUPPORT_FPUTIL_FLOAT16_H
+
+#include "src/__support/macros/properties/types.h"
+
+#ifdef LIBC_USE_SOFT_FLOAT16
+
+#include "hdr/stdint_proxy.h"
+#include "src/__support/CPP/type_traits.h"
+#include "src/__support/FPUtil/cast.h"
+#include "src/__support/FPUtil/comparison_operations.h"
+#include "src/__support/FPUtil/dyadic_float.h"
+#include "src/__support/FPUtil/generic/add_sub.h"
+#include "src/__support/FPUtil/generic/div.h"
+#include "src/__support/FPUtil/generic/mul.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace fputil {
+
+struct Float16 {
+  uint16_t bits;
+
+  LIBC_INLINE Float16() = default;
+
+  template <typename T>
+  LIBC_INLINE constexpr explicit Float16(T value)
+      : bits(static_cast<uint16_t>(0U)) {
+    if constexpr (cpp::is_floating_point_v<T>) {
+      bits = fputil::cast<Float16>(value).bits;
+    } else if constexpr (cpp::is_integral_v<T>) {
+      Sign sign = Sign::POS;
+
+      if constexpr (cpp::is_signed_v<T>) {
+        if (value < 0) {
+          sign = Sign::NEG;
+          value = -value;
+        }
+      }
+
+      fputil::DyadicFloat<cpp::numeric_limits<cpp::make_unsigned_t<T>>::digits>
+          xd(sign, 0, value);
+      bits = xd.template as<Float16, /*ShouldSignalExceptions=*/true>().bits;
+
+    } else if constexpr (cpp::is_convertible_v<T, Float16>) {
+      bits = value.operator Float16().bits;
+    }
+  }
+
+  template <cpp::enable_if_t<fputil::get_fp_type<float>() ==
+                                 fputil::FPType::IEEE754_Binary32,
+                             int> = 0>
+  LIBC_INLINE constexpr operator float() const {
+    return fputil::cast<float>(*this);
+  }
+
+  template <typename T, cpp::enable_if_t<cpp::is_integral_v<T>, int> = 0>
+  LIBC_INLINE constexpr explicit operator T() const {
+    return static_cast<T>(static_cast<float>(*this));
+  }
+
+  LIBC_INLINE bool operator==(Float16 other) const {
+    return fputil::equals(*this, other);
+  }
+
+  LIBC_INLINE bool operator!=(Float16 other) const {
+    return !fputil::equals(*this, other);
+  }
+
+  LIBC_INLINE bool operator<(Float16 other) const {
+    return fputil::less_than(*this, other);
+  }
+
+  LIBC_INLINE bool operator<=(Float16 other) const {
+    return fputil::less_than_or_equals(*this, other);
+  }
+
+  LIBC_INLINE bool operator>(Float16 other) const {
+    return fputil::greater_than(*this, other);
+  }
+
+  LIBC_INLINE bool operator>=(Float16 other) const {
+    return fputil::greater_than_or_equals(*this, other);
+  }
+
+  LIBC_INLINE constexpr Float16 operator-() const {
+    fputil::FPBits<float16> result(*this);
+    result.set_sign(result.is_pos() ? Sign::NEG : Sign::POS);
+    return result.get_val();
+  }
+
+  LIBC_INLINE Float16 operator+(Float16 other) const {
+    return fputil::generic::add<Float16>(*this, other);
+  }
+
+  LIBC_INLINE Float16 operator-(Float16 other) const {
+    return fputil::generic::sub<Float16>(*this, other);
+  }
+
+  LIBC_INLINE Float16 operator*(Float16 other) const {
+    return fputil::generic::mul<float16>(*this, other);
+  }
+
+  LIBC_INLINE Float16 operator/(Float16 other) const {
+    return fputil::generic::div<float16>(*this, other);
+  }
+
+  LIBC_INLINE Float16 &operator*=(const Float16 &other) {
+    *this = *this * other;
+    return *this;
+  }
+}; // struct Float16
+
+} // namespace fputil
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_USE_SOFT_FLOAT16
+
+#endif // LLVM_LIBC_SRC___SUPPORT_FPUTIL_FLOAT16_H

--- a/libc/src/__support/FPUtil/cast.h
+++ b/libc/src/__support/FPUtil/cast.h
@@ -35,7 +35,9 @@ cast(InType x) {
                   cpp::is_same_v<OutType, Float128> ||
                   cpp::is_same_v<InType, Float128> ||
                   cpp::is_same_v<OutType, Float80> ||
-                  cpp::is_same_v<InType, Float80>
+                  cpp::is_same_v<InType, Float80> ||
+                  cpp::is_same_v<OutType, Float16> ||
+                  cpp::is_same_v<InType, Float16>
 #if defined(LIBC_TYPES_HAS_FLOAT16) && !defined(__LIBC_USE_FLOAT16_CONVERSION)
                   || cpp::is_same_v<OutType, float16> ||
                   cpp::is_same_v<InType, float16>
@@ -54,12 +56,18 @@ cast(InType x) {
           return OutFPBits::quiet_nan().get_val();
         }
 
-        InStorageType x_mant = x_bits.get_mantissa();
-        if (InFPBits::FRACTION_LEN > OutFPBits::FRACTION_LEN)
-          x_mant >>= InFPBits::FRACTION_LEN - OutFPBits::FRACTION_LEN;
-        return OutFPBits::quiet_nan(x_bits.sign(),
-                                    static_cast<OutStorageType>(x_mant))
-            .get_val();
+        OutStorageType out_mant = 0;
+        if constexpr (InFPBits::FRACTION_LEN > OutFPBits::FRACTION_LEN) {
+          InStorageType in_mant = x_bits.get_mantissa();
+          in_mant >>= InFPBits::FRACTION_LEN - OutFPBits::FRACTION_LEN;
+          out_mant = static_cast<OutStorageType>(in_mant);
+        } else if constexpr (InFPBits::FRACTION_LEN < OutFPBits::FRACTION_LEN) {
+          out_mant = static_cast<OutStorageType>(x_bits.get_mantissa());
+          out_mant <<= OutFPBits::FRACTION_LEN - InFPBits::FRACTION_LEN;
+        } else {
+          out_mant = static_cast<OutStorageType>(x_bits.get_mantissa());
+        }
+        return OutFPBits::quiet_nan(x_bits.sign(), out_mant).get_val();
       }
 
       if (x_bits.is_inf())

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -441,7 +441,7 @@ template <size_t Bits> struct DyadicFloat {
                                         void>>
   LIBC_INLINE LIBC_CONSTEXPR_DEFAULT T as() const {
     if constexpr (cpp::is_same_v<T, bfloat16> || cpp::is_same_v<T, Float128> ||
-                  cpp::is_same_v<T, Float80>
+                  cpp::is_same_v<T, Float80> || cpp::is_same_v<T, Float16>
 #if defined(LIBC_TYPES_HAS_FLOAT16) && !defined(__LIBC_USE_FLOAT16_CONVERSION)
                   || cpp::is_same_v<T, float16>
 #endif

--- a/libc/src/__support/FPUtil/float16.h
+++ b/libc/src/__support/FPUtil/float16.h
@@ -29,6 +29,11 @@ struct Float16 {
 
   LIBC_INLINE Float16() = default;
 
+  template <size_t Bits>
+  LIBC_INLINE constexpr explicit Float16(const DyadicFloat<Bits> &df)
+      : bits(df.template as<Float16, /*ShouldSignalExceptions=*/false>().bits) {
+  }
+
   template <typename T>
   LIBC_INLINE constexpr explicit Float16(T value)
       : bits(static_cast<uint16_t>(0U)) {

--- a/libc/src/__support/FPUtil/float16.h
+++ b/libc/src/__support/FPUtil/float16.h
@@ -9,10 +9,6 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FPUTIL_FLOAT16_H
 #define LLVM_LIBC_SRC___SUPPORT_FPUTIL_FLOAT16_H
 
-#include "src/__support/macros/properties/types.h"
-
-#ifdef LIBC_USE_SOFT_FLOAT16
-
 #include "hdr/stdint_proxy.h"
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/FPUtil/cast.h"
@@ -21,7 +17,9 @@
 #include "src/__support/FPUtil/generic/add_sub.h"
 #include "src/__support/FPUtil/generic/div.h"
 #include "src/__support/FPUtil/generic/mul.h"
+#include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace fputil {
@@ -52,6 +50,8 @@ struct Float16 {
 
     } else if constexpr (cpp::is_convertible_v<T, Float16>) {
       bits = value.operator Float16().bits;
+    } else {
+      bits = fputil::cast<Float16>(static_cast<float>(value)).bits;
     }
   }
 
@@ -67,61 +67,74 @@ struct Float16 {
     return static_cast<T>(static_cast<float>(*this));
   }
 
-  LIBC_INLINE bool operator==(Float16 other) const {
+  LIBC_INLINE constexpr bool operator==(Float16 other) const {
     return fputil::equals(*this, other);
   }
 
-  LIBC_INLINE bool operator!=(Float16 other) const {
+  LIBC_INLINE constexpr bool operator!=(Float16 other) const {
     return !fputil::equals(*this, other);
   }
 
-  LIBC_INLINE bool operator<(Float16 other) const {
+  LIBC_INLINE constexpr bool operator<(Float16 other) const {
     return fputil::less_than(*this, other);
   }
 
-  LIBC_INLINE bool operator<=(Float16 other) const {
+  LIBC_INLINE constexpr bool operator<=(Float16 other) const {
     return fputil::less_than_or_equals(*this, other);
   }
 
-  LIBC_INLINE bool operator>(Float16 other) const {
+  LIBC_INLINE constexpr bool operator>(Float16 other) const {
     return fputil::greater_than(*this, other);
   }
 
-  LIBC_INLINE bool operator>=(Float16 other) const {
+  LIBC_INLINE constexpr bool operator>=(Float16 other) const {
     return fputil::greater_than_or_equals(*this, other);
   }
 
-  LIBC_INLINE constexpr Float16 operator-() const {
-    fputil::FPBits<float16> result(*this);
+  LIBC_INLINE LIBC_BIT_CAST_CONSTEXPR Float16 operator-() const {
+    fputil::FPBits<Float16> result(*this);
     result.set_sign(result.is_pos() ? Sign::NEG : Sign::POS);
     return result.get_val();
   }
 
-  LIBC_INLINE Float16 operator+(Float16 other) const {
+  LIBC_INLINE constexpr Float16 operator+(Float16 other) const {
     return fputil::generic::add<Float16>(*this, other);
   }
 
-  LIBC_INLINE Float16 operator-(Float16 other) const {
+  LIBC_INLINE constexpr Float16 operator-(Float16 other) const {
     return fputil::generic::sub<Float16>(*this, other);
   }
 
-  LIBC_INLINE Float16 operator*(Float16 other) const {
-    return fputil::generic::mul<float16>(*this, other);
+  LIBC_INLINE constexpr Float16 operator*(Float16 other) const {
+    return fputil::generic::mul<Float16>(*this, other);
   }
 
-  LIBC_INLINE Float16 operator/(Float16 other) const {
-    return fputil::generic::div<float16>(*this, other);
+  LIBC_INLINE constexpr Float16 operator/(Float16 other) const {
+    return fputil::generic::div<Float16>(*this, other);
   }
 
-  LIBC_INLINE Float16 &operator*=(const Float16 &other) {
+  LIBC_INLINE constexpr Float16 &operator+=(Float16 other) {
+    *this = *this + other;
+    return *this;
+  }
+
+  LIBC_INLINE constexpr Float16 &operator-=(Float16 other) {
+    *this = *this - other;
+    return *this;
+  }
+
+  LIBC_INLINE constexpr Float16 &operator*=(Float16 other) {
     *this = *this * other;
+    return *this;
+  }
+
+  LIBC_INLINE constexpr Float16 &operator/=(Float16 other) {
+    *this = *this / other;
     return *this;
   }
 }; // struct Float16
 
 } // namespace fputil
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_USE_SOFT_FLOAT16
 
 #endif // LLVM_LIBC_SRC___SUPPORT_FPUTIL_FLOAT16_H

--- a/libc/src/__support/macros/properties/types.h
+++ b/libc/src/__support/macros/properties/types.h
@@ -69,15 +69,15 @@
 // -- float16 support ---------------------------------------------------------
 // LIBC_TYPES_HAS_FLOAT16 is provided by
 // "include/llvm-libc-macros/float16-macros.h"
-#ifdef LIBC_TYPES_HAS_FLOAT16
-
-#ifdef LIBC_USE_SOFT_FLOAT16
 namespace LIBC_NAMESPACE_DECL {
 namespace fputil {
 struct Float16;
 } // namespace fputil
 } // namespace LIBC_NAMESPACE_DECL
 
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
+#ifdef LIBC_USE_SOFT_FLOAT16
 using float16 = LIBC_NAMESPACE::fputil::Float16;
 #else
 // Type alias for internal use.

--- a/libc/src/__support/macros/properties/types.h
+++ b/libc/src/__support/macros/properties/types.h
@@ -70,8 +70,20 @@
 // LIBC_TYPES_HAS_FLOAT16 is provided by
 // "include/llvm-libc-macros/float16-macros.h"
 #ifdef LIBC_TYPES_HAS_FLOAT16
+
+#ifdef LIBC_USE_SOFT_FLOAT16
+namespace LIBC_NAMESPACE_DECL {
+namespace fputil {
+struct Float16;
+} // namespace fputil
+} // namespace LIBC_NAMESPACE_DECL
+
+using float16 = LIBC_NAMESPACE::fputil::Float16;
+#else
 // Type alias for internal use.
 using float16 = _Float16;
+#endif
+
 #endif // LIBC_TYPES_HAS_FLOAT16
 
 // -- float128 support --------------------------------------------------------

--- a/libc/src/__support/macros/properties/types.h
+++ b/libc/src/__support/macros/properties/types.h
@@ -69,22 +69,19 @@
 // -- float16 support ---------------------------------------------------------
 // LIBC_TYPES_HAS_FLOAT16 is provided by
 // "include/llvm-libc-macros/float16-macros.h"
+#ifdef LIBC_TYPES_HAS_FLOAT16
+// Type alias for internal use.
+using float16 = _Float16;
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+// -- Emulated float16 support ------------------------------------------------
+// Float16 is always available regardless of built-in float16 type support in
+// the compiler.
 namespace LIBC_NAMESPACE_DECL {
 namespace fputil {
 struct Float16;
 } // namespace fputil
 } // namespace LIBC_NAMESPACE_DECL
-
-#ifdef LIBC_TYPES_HAS_FLOAT16
-
-#ifdef LIBC_USE_SOFT_FLOAT16
-using float16 = LIBC_NAMESPACE::fputil::Float16;
-#else
-// Type alias for internal use.
-using float16 = _Float16;
-#endif
-
-#endif // LIBC_TYPES_HAS_FLOAT16
 
 // -- float128 support --------------------------------------------------------
 // LIBC_TYPES_HAS_NATIVE_FLOAT128 and 'float128' type are provided by

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -3257,7 +3257,7 @@ add_header_library(
     fabsf16.h
   DEPENDS
     libc.include.llvm-libc-macros.float16_macros
-    libc.src.__support.FPUtil.Float16
+    libc.src.__support.FPUtil.float16
     libc.src.__support.FPUtil.basic_operations
     libc.src.__support.macros.config
   FLAGS

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -3257,6 +3257,7 @@ add_header_library(
     fabsf16.h
   DEPENDS
     libc.include.llvm-libc-macros.float16_macros
+    libc.src.__support.FPUtil.Float16
     libc.src.__support.FPUtil.basic_operations
     libc.src.__support.macros.config
   FLAGS

--- a/libc/src/__support/math/fabsf16.h
+++ b/libc/src/__support/math/fabsf16.h
@@ -14,6 +14,7 @@
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
 #include "src/__support/FPUtil/BasicOperations.h"
+#include "src/__support/FPUtil/Float16.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/architectures.h"
 #include "src/__support/macros/properties/compiler.h"
@@ -27,7 +28,8 @@ LIBC_INLINE constexpr float16 fabsf16(float16 x) {
   // For x86, GCC generates better code from the generic implementation.
   // https://godbolt.org/z/K9orM4hTa
 #if defined(__LIBC_MISC_MATH_BASIC_OPS_OPT) &&                                 \
-    !(defined(LIBC_TARGET_ARCH_IS_X86) && defined(LIBC_COMPILER_IS_GCC))
+    !(defined(LIBC_TARGET_ARCH_IS_X86) && defined(LIBC_COMPILER_IS_GCC)) &&    \
+    !defined(LIBC_USE_SOFT_FLOAT16)
   return __builtin_fabsf16(x);
 #else
   return fputil::abs(x);

--- a/libc/src/__support/math/fabsf16.h
+++ b/libc/src/__support/math/fabsf16.h
@@ -14,7 +14,7 @@
 #ifdef LIBC_TYPES_HAS_FLOAT16
 
 #include "src/__support/FPUtil/BasicOperations.h"
-#include "src/__support/FPUtil/Float16.h"
+#include "src/__support/FPUtil/float16.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/architectures.h"
 #include "src/__support/macros/properties/compiler.h"

--- a/libc/src/__support/math/fabsf16.h
+++ b/libc/src/__support/math/fabsf16.h
@@ -9,17 +9,19 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FABSF16_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_FABSF16_H
 
-#include "include/llvm-libc-macros/float16-macros.h"
-
-#ifdef LIBC_TYPES_HAS_FLOAT16
-
 #include "src/__support/FPUtil/BasicOperations.h"
 #include "src/__support/FPUtil/float16.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/architectures.h"
 #include "src/__support/macros/properties/compiler.h"
+#include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_FLOAT16
+using float16 = LIBC_NAMESPACE::fputil::Float16;
+#endif // LIBC_TYPES_HAS_FLOAT16
+
 namespace math {
 
 LIBC_INLINE constexpr float16 fabsf16(float16 x) {
@@ -29,7 +31,7 @@ LIBC_INLINE constexpr float16 fabsf16(float16 x) {
   // https://godbolt.org/z/K9orM4hTa
 #if defined(__LIBC_MISC_MATH_BASIC_OPS_OPT) &&                                 \
     !(defined(LIBC_TARGET_ARCH_IS_X86) && defined(LIBC_COMPILER_IS_GCC)) &&    \
-    !defined(LIBC_USE_SOFT_FLOAT16)
+    defined(LIBC_TYPES_HAS_FLOAT16)
   return __builtin_fabsf16(x);
 #else
   return fputil::abs(x);
@@ -38,7 +40,5 @@ LIBC_INLINE constexpr float16 fabsf16(float16 x) {
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
-
-#endif // LIBC_TYPES_HAS_FLOAT16
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_FABSF16_H

--- a/libc/src/math/fabsf16.h
+++ b/libc/src/math/fabsf16.h
@@ -9,10 +9,15 @@
 #ifndef LLVM_LIBC_SRC_MATH_FABSF16_H
 #define LLVM_LIBC_SRC_MATH_FABSF16_H
 
+#include "src/__support/FPUtil/float16.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+#ifndef LIBC_TYPES_HAS_FLOAT16
+using float16 = LIBC_NAMESPACE::fputil::Float16;
+#endif // LIBC_TYPES_HAS_FLOAT16
 
 float16 fabsf16(float16 x);
 

--- a/libc/test/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/test/src/__support/FPUtil/CMakeLists.txt
@@ -71,6 +71,17 @@ if(LLVM_LIBC_FULL_BUILD)
 endif()
 
 add_fp_unittest(
+  float16_test
+  NEED_MPFR
+  SUITE
+    libc-fputil-tests
+  SRCS
+    float16_test.cpp
+  DEPENDS
+    libc.src.__support.FPUtil.float16
+)
+
+add_fp_unittest(
   bfloat16_test
   NEED_MPFR
   SUITE

--- a/libc/test/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/test/src/__support/FPUtil/CMakeLists.txt
@@ -9,6 +9,7 @@ add_fp_unittest(
     dyadic_float_test.cpp
   DEPENDS
     libc.src.__support.FPUtil.dyadic_float
+    libc.src.__support.FPUtil.float16
     libc.src.__support.macros.properties.types
   COMPILE_OPTIONS
     # Prevent constant folding with a default rounding mode.
@@ -101,5 +102,6 @@ add_fp_unittest(
   DEPENDS
     libc.src.__support.FPUtil.bfloat16
     libc.src.__support.FPUtil.comparison_operations
+    libc.src.__support.FPUtil.float16
     libc.src.__support.macros.properties.types
 )

--- a/libc/test/src/__support/FPUtil/comparison_operations_test.cpp
+++ b/libc/test/src/__support/FPUtil/comparison_operations_test.cpp
@@ -8,6 +8,7 @@
 
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/__support/FPUtil/comparison_operations.h"
+#include "src/__support/FPUtil/float16.h"
 #include "src/__support/macros/properties/types.h"
 #include "test/UnitTest/FEnvSafeTest.h"
 #include "test/UnitTest/FPMatcher.h"

--- a/libc/test/src/__support/FPUtil/dyadic_float_test.cpp
+++ b/libc/test/src/__support/FPUtil/dyadic_float_test.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/FPUtil/dyadic_float.h"
+#include "src/__support/FPUtil/float16.h"
 #include "src/__support/big_int.h"
 #include "src/__support/macros/properties/types.h"
 #include "test/UnitTest/FPMatcher.h"

--- a/libc/test/src/__support/FPUtil/float16_test.cpp
+++ b/libc/test/src/__support/FPUtil/float16_test.cpp
@@ -12,8 +12,7 @@
 #include "utils/MPFRWrapper/MPCommon.h"
 
 using Float16 = LIBC_NAMESPACE::fputil::Float16;
-using LlvmLibcFloat16ConversionTest =
-    LIBC_NAMESPACE::testing::FPTest<Float16>;
+using LlvmLibcFloat16ConversionTest = LIBC_NAMESPACE::testing::FPTest<Float16>;
 
 // range: [0, inf]
 static constexpr uint16_t POS_START = 0x0000U;
@@ -69,9 +68,9 @@ TEST_F(LlvmLibcFloat16ConversionTest, FromInteger) {
 }
 
 TEST_F(LlvmLibcFloat16ConversionTest, CompoundAssignmentOperators) {
-  constexpr Float16 VAL[] = {zero,           neg_zero,        inf,
-                             neg_inf,        min_normal,      max_normal,
-                             Float16(1.0f),  Float16(-1.0f),  Float16(2.0f),
+  constexpr Float16 VAL[] = {zero,          neg_zero,       inf,
+                             neg_inf,       min_normal,     max_normal,
+                             Float16(1.0f), Float16(-1.0f), Float16(2.0f),
                              Float16(3.0f)};
   // *=
   for (const Float16 &x : VAL) {

--- a/libc/test/src/__support/FPUtil/float16_test.cpp
+++ b/libc/test/src/__support/FPUtil/float16_test.cpp
@@ -1,0 +1,124 @@
+//===-- Unit tests for float16 type ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/FPUtil/float16.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+#include "utils/MPFRWrapper/MPCommon.h"
+
+using Float16 = LIBC_NAMESPACE::fputil::Float16;
+using LlvmLibcFloat16ConversionTest =
+    LIBC_NAMESPACE::testing::FPTest<Float16>;
+
+// range: [0, inf]
+static constexpr uint16_t POS_START = 0x0000U;
+static constexpr uint16_t POS_STOP = 0x7c00U;
+
+// range: [-0, -inf]
+static constexpr uint16_t NEG_START = 0x8000U;
+static constexpr uint16_t NEG_STOP = 0xfc00U;
+
+using MPFRNumber = LIBC_NAMESPACE::testing::mpfr::MPFRNumber;
+
+TEST_F(LlvmLibcFloat16ConversionTest, ToFloatPositiveRange) {
+  for (uint16_t bits = POS_START; bits <= POS_STOP; bits++) {
+    Float16 f16_num{bits};
+    MPFRNumber mpfr_num{f16_num};
+
+    // float16 to float
+    float mpfr_float = mpfr_num.as<float>();
+    EXPECT_FP_EQ_ALL_ROUNDING(mpfr_float, static_cast<float>(f16_num));
+
+    // float to float16
+    Float16 f16_from_float{mpfr_float};
+    MPFRNumber mpfr_num_2{mpfr_float};
+    Float16 mpfr_f16 = mpfr_num_2.as<Float16>();
+    EXPECT_FP_EQ_ALL_ROUNDING(mpfr_f16, f16_from_float);
+  }
+}
+
+TEST_F(LlvmLibcFloat16ConversionTest, ToFloatNegativeRange) {
+  for (uint16_t bits = NEG_START; bits <= NEG_STOP; bits++) {
+    Float16 f16_num{bits};
+    MPFRNumber mpfr_num{f16_num};
+
+    // float16 to float
+    float mpfr_float = mpfr_num.as<float>();
+    EXPECT_FP_EQ_ALL_ROUNDING(mpfr_float, static_cast<float>(f16_num));
+
+    // float to float16
+    Float16 f16_from_float{mpfr_float};
+    MPFRNumber mpfr_num_2{mpfr_float};
+    Float16 mpfr_f16 = mpfr_num_2.as<Float16>();
+    EXPECT_FP_EQ_ALL_ROUNDING(mpfr_f16, f16_from_float);
+  }
+}
+
+TEST_F(LlvmLibcFloat16ConversionTest, FromInteger) {
+  constexpr int RANGE = 1'234;
+  for (int i = -RANGE; i <= RANGE; i++) {
+    Float16 mpfr_f16 = MPFRNumber(i).as<Float16>();
+    Float16 libc_f16{i};
+    EXPECT_FP_EQ_ALL_ROUNDING(mpfr_f16, libc_f16);
+  }
+}
+
+TEST_F(LlvmLibcFloat16ConversionTest, CompoundAssignmentOperators) {
+  constexpr Float16 VAL[] = {zero,           neg_zero,        inf,
+                             neg_inf,        min_normal,      max_normal,
+                             Float16(1.0f),  Float16(-1.0f),  Float16(2.0f),
+                             Float16(3.0f)};
+  // *=
+  for (const Float16 &x : VAL) {
+    for (const Float16 &y : VAL) {
+      Float16 a = x, b = y;
+      MPFRNumber mpfr_a{a}, mpfr_b{b};
+      MPFRNumber mpfr_c = mpfr_a.mul(mpfr_b);
+      Float16 mpfr_f16 = mpfr_c.as<Float16>();
+      a *= b;
+      Float16 libc_f16 = a;
+      EXPECT_FP_EQ_ALL_ROUNDING(mpfr_f16, libc_f16);
+    }
+  }
+  // /=
+  for (const Float16 &x : VAL) {
+    for (const Float16 &y : VAL) {
+      Float16 a = x, b = y;
+      MPFRNumber mpfr_a{a}, mpfr_b{b};
+      MPFRNumber mpfr_c = mpfr_a.div(mpfr_b);
+      Float16 mpfr_f16 = mpfr_c.as<Float16>();
+      a /= b;
+      Float16 libc_f16 = a;
+      EXPECT_FP_EQ_ALL_ROUNDING(mpfr_f16, libc_f16);
+    }
+  }
+  // +=
+  for (const Float16 &x : VAL) {
+    for (const Float16 &y : VAL) {
+      Float16 a = x, b = y;
+      MPFRNumber mpfr_a{a}, mpfr_b{b};
+      MPFRNumber mpfr_c = mpfr_a.add(mpfr_b);
+      Float16 mpfr_f16 = mpfr_c.as<Float16>();
+      a += b;
+      Float16 libc_f16 = a;
+      EXPECT_FP_EQ_ALL_ROUNDING(mpfr_f16, libc_f16);
+    }
+  }
+  // -=
+  for (const Float16 &x : VAL) {
+    for (const Float16 &y : VAL) {
+      Float16 a = x, b = y;
+      MPFRNumber mpfr_a{a}, mpfr_b{b};
+      MPFRNumber mpfr_c = mpfr_a.sub(mpfr_b);
+      Float16 mpfr_f16 = mpfr_c.as<Float16>();
+      a -= b;
+      Float16 libc_f16 = a;
+      EXPECT_FP_EQ_ALL_ROUNDING(mpfr_f16, libc_f16);
+    }
+  }
+}

--- a/libc/test/src/math/exhaustive/CMakeLists.txt
+++ b/libc/test/src/math/exhaustive/CMakeLists.txt
@@ -740,6 +740,23 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
+  float16_test
+  NO_RUN_POSTBUILD
+  NEED_MPFR
+  SUITE
+    libc_math_exhaustive_tests
+  SRCS
+    float16_test.cpp
+  DEPENDS
+    .exhaustive_test
+    libc.src.__support.FPUtil.Float16
+    libc.src.__support.FPUtil.cast
+    libc.src.__support.FPUtil.fp_bits
+  LINK_LIBRARIES
+    -lpthread
+)
+
+add_fp_unittest(
   bfloat16_test
   NO_RUN_POSTBUILD
   NEED_MPFR

--- a/libc/test/src/math/exhaustive/CMakeLists.txt
+++ b/libc/test/src/math/exhaustive/CMakeLists.txt
@@ -749,7 +749,7 @@ add_fp_unittest(
     float16_test.cpp
   DEPENDS
     .exhaustive_test
-    libc.src.__support.FPUtil.Float16
+    libc.src.__support.FPUtil.float16
     libc.src.__support.FPUtil.cast
     libc.src.__support.FPUtil.fp_bits
   LINK_LIBRARIES

--- a/libc/test/src/math/exhaustive/exhaustive_test.h
+++ b/libc/test/src/math/exhaustive/exhaustive_test.h
@@ -8,6 +8,7 @@
 
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/Float16.h"
 #include "src/__support/macros/properties/types.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"

--- a/libc/test/src/math/exhaustive/exhaustive_test.h
+++ b/libc/test/src/math/exhaustive/exhaustive_test.h
@@ -8,7 +8,7 @@
 
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/FPUtil/FPBits.h"
-#include "src/__support/FPUtil/Float16.h"
+#include "src/__support/FPUtil/float16.h"
 #include "src/__support/macros/properties/types.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"

--- a/libc/test/src/math/exhaustive/float16_test.cpp
+++ b/libc/test/src/math/exhaustive/float16_test.cpp
@@ -1,0 +1,67 @@
+//===-- Exhaustive tests for float -> float16 conversion ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "exhaustive_test.h"
+#include "src/__support/FPUtil/cast.h"
+#include "utils/MPFRWrapper/MPCommon.h"
+
+using namespace LIBC_NAMESPACE::fputil;
+namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
+
+template <typename InType>
+struct Float16ConversionChecker : public virtual LIBC_NAMESPACE::testing::Test {
+  using FloatType = InType;
+  using FPBits = LIBC_NAMESPACE::fputil::FPBits<FloatType>;
+  using StorageType = typename FPBits::StorageType;
+
+  // Check in a range, return the number of failures.
+  uint64_t check(StorageType start, StorageType stop,
+                 mpfr::RoundingMode rounding) {
+    mpfr::ForceRoundingMode r(rounding);
+    if (!r.success)
+      return (stop > start);
+    StorageType bits = start;
+    uint64_t failed = 0;
+    do {
+      FPBits x_bits(bits);
+      FloatType x = x_bits.get_val();
+
+      const float16 libc_result = cast<float16>(x);
+      const float16 mpfr_result = mpfr::MPFRNumber(x).as<float16>();
+
+      const bool correct =
+          LIBC_NAMESPACE::testing::getMatcher<
+              LIBC_NAMESPACE::testing::TestCond::EQ>(mpfr_result)
+              .match(libc_result);
+
+      failed += (!correct);
+    } while (bits++ < stop);
+    return failed;
+  }
+};
+
+template <typename FloatType>
+using LlvmLibcFloat16ExhaustiveTest =
+    LlvmLibcExhaustiveMathTest<Float16ConversionChecker<FloatType>>;
+using LlvmLibcFloat16FromFloatTest = LlvmLibcFloat16ExhaustiveTest<float>;
+
+// Positive Range: [0, Inf];
+constexpr uint32_t POS_START = 0x0000'0000U;
+constexpr uint32_t POS_STOP = 0x7f80'0000U;
+
+// Negative Range: [-Inf, 0];
+constexpr uint32_t NEG_START = 0xb000'0000U;
+constexpr uint32_t NEG_STOP = 0xff80'0000U;
+
+TEST_F(LlvmLibcFloat16FromFloatTest, PostiveRange) {
+  test_full_range_all_roundings(POS_START, POS_STOP);
+}
+
+TEST_F(LlvmLibcFloat16FromFloatTest, NegativeRange) {
+  test_full_range_all_roundings(NEG_START, NEG_STOP);
+}

--- a/libc/test/src/math/exhaustive/float16_test.cpp
+++ b/libc/test/src/math/exhaustive/float16_test.cpp
@@ -31,8 +31,8 @@ struct Float16ConversionChecker : public virtual LIBC_NAMESPACE::testing::Test {
       FPBits x_bits(bits);
       FloatType x = x_bits.get_val();
 
-      const float16 libc_result = cast<float16>(x);
-      const float16 mpfr_result = mpfr::MPFRNumber(x).as<float16>();
+      const Float16 libc_result = cast<Float16>(x);
+      const Float16 mpfr_result = mpfr::MPFRNumber(x).as<Float16>();
 
       const bool correct =
           LIBC_NAMESPACE::testing::getMatcher<

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -240,6 +240,7 @@ add_fp_unittest(
     FAbsTest.h
   DEPENDS
     libc.src.math.fabsf16
+    libc.src.__support.FPUtil.Float16
 )
 
 add_fp_unittest(

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -240,7 +240,7 @@ add_fp_unittest(
     FAbsTest.h
   DEPENDS
     libc.src.math.fabsf16
-    libc.src.__support.FPUtil.Float16
+    libc.src.__support.FPUtil.float16
 )
 
 add_fp_unittest(

--- a/libc/test/src/math/smoke/fabsf16_test.cpp
+++ b/libc/test/src/math/smoke/fabsf16_test.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "FAbsTest.h"
-
+#include "src/__support/FPUtil/Float16.h"
 #include "src/math/fabsf16.h"
 
 LIST_FABS_TESTS(float16, LIBC_NAMESPACE::fabsf16)

--- a/libc/test/src/math/smoke/fabsf16_test.cpp
+++ b/libc/test/src/math/smoke/fabsf16_test.cpp
@@ -10,4 +10,8 @@
 #include "src/__support/FPUtil/float16.h"
 #include "src/math/fabsf16.h"
 
+#ifndef LIBC_TYPES_HAS_FLOAT16
+using float16 = LIBC_NAMESPACE::fputil::Float16;
+#endif // LIBC_TYPES_HAS_FLOAT16
+
 LIST_FABS_TESTS(float16, LIBC_NAMESPACE::fabsf16)

--- a/libc/test/src/math/smoke/fabsf16_test.cpp
+++ b/libc/test/src/math/smoke/fabsf16_test.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "FAbsTest.h"
-#include "src/__support/FPUtil/Float16.h"
+#include "src/__support/FPUtil/float16.h"
 #include "src/math/fabsf16.h"
 
 LIST_FABS_TESTS(float16, LIBC_NAMESPACE::fabsf16)

--- a/libc/utils/MPFRWrapper/CMakeLists.txt
+++ b/libc/utils/MPFRWrapper/CMakeLists.txt
@@ -14,6 +14,7 @@ if(LIBC_TESTS_CAN_USE_MPFR OR LIBC_TESTS_CAN_USE_MPC)
     libc.src.__support.CPP.string
     libc.src.__support.CPP.string_view
     libc.src.__support.CPP.type_traits
+    libc.src.__support.FPUtil.Float16
     libc.src.__support.FPUtil.bfloat16
     libc.src.__support.FPUtil.cast
     libc.src.__support.FPUtil.fp_bits
@@ -44,6 +45,7 @@ if(LIBC_TESTS_CAN_USE_MPFR)
     libc.hdr.stdint_proxy
     libc.src.__support.CPP.array
     libc.src.__support.CPP.stringstream
+    libc.src.__support.FPUtil.Float16
     libc.src.__support.FPUtil.bfloat16
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.fpbits_str

--- a/libc/utils/MPFRWrapper/CMakeLists.txt
+++ b/libc/utils/MPFRWrapper/CMakeLists.txt
@@ -14,7 +14,7 @@ if(LIBC_TESTS_CAN_USE_MPFR OR LIBC_TESTS_CAN_USE_MPC)
     libc.src.__support.CPP.string
     libc.src.__support.CPP.string_view
     libc.src.__support.CPP.type_traits
-    libc.src.__support.FPUtil.Float16
+    libc.src.__support.FPUtil.float16
     libc.src.__support.FPUtil.bfloat16
     libc.src.__support.FPUtil.cast
     libc.src.__support.FPUtil.fp_bits
@@ -45,7 +45,7 @@ if(LIBC_TESTS_CAN_USE_MPFR)
     libc.hdr.stdint_proxy
     libc.src.__support.CPP.array
     libc.src.__support.CPP.stringstream
-    libc.src.__support.FPUtil.Float16
+    libc.src.__support.FPUtil.float16
     libc.src.__support.FPUtil.bfloat16
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.fpbits_str

--- a/libc/utils/MPFRWrapper/MPCommon.cpp
+++ b/libc/utils/MPFRWrapper/MPCommon.cpp
@@ -10,6 +10,11 @@
 
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/FPUtil/bfloat16.h"
+
+#ifdef LIBC_USE_SOFT_FLOAT16
+#include "src/__support/FPUtil/Float16.h"
+#endif
+
 #include "src/__support/FPUtil/cast.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
@@ -632,7 +637,7 @@ template <> long double MPFRNumber::as<long double>() const {
   return mpfr_get_ld(value, mpfr_rounding);
 }
 
-#ifdef LIBC_TYPES_HAS_FLOAT16
+#if defined(LIBC_TYPES_HAS_FLOAT16) || defined(LIBC_USE_SOFT_FLOAT16)
 template <> float16 MPFRNumber::as<float16>() const {
   // TODO: Either prove that this cast won't cause double-rounding errors, or
   // find a better way to get a float16.

--- a/libc/utils/MPFRWrapper/MPCommon.cpp
+++ b/libc/utils/MPFRWrapper/MPCommon.cpp
@@ -10,8 +10,8 @@
 
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/FPUtil/bfloat16.h"
-#include "src/__support/FPUtil/float16.h"
 #include "src/__support/FPUtil/cast.h"
+#include "src/__support/FPUtil/float16.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
 
@@ -641,11 +641,9 @@ template <> float16 MPFRNumber::as<float16>() const {
 }
 #endif
 
-#if !defined(LIBC_USE_SOFT_FLOAT16)
 template <> fputil::Float16 MPFRNumber::as<fputil::Float16>() const {
   return fputil::cast<fputil::Float16>(mpfr_get_d(value, mpfr_rounding));
 }
-#endif
 
 #ifdef LIBC_TYPES_FLOAT128_IS_NOT_LONG_DOUBLE
 template <> float128 MPFRNumber::as<float128>() const {

--- a/libc/utils/MPFRWrapper/MPCommon.cpp
+++ b/libc/utils/MPFRWrapper/MPCommon.cpp
@@ -10,11 +10,7 @@
 
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/FPUtil/bfloat16.h"
-
-#ifdef LIBC_USE_SOFT_FLOAT16
-#include "src/__support/FPUtil/Float16.h"
-#endif
-
+#include "src/__support/FPUtil/float16.h"
 #include "src/__support/FPUtil/cast.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"
@@ -637,11 +633,17 @@ template <> long double MPFRNumber::as<long double>() const {
   return mpfr_get_ld(value, mpfr_rounding);
 }
 
-#if defined(LIBC_TYPES_HAS_FLOAT16) || defined(LIBC_USE_SOFT_FLOAT16)
+#ifdef LIBC_TYPES_HAS_FLOAT16
 template <> float16 MPFRNumber::as<float16>() const {
   // TODO: Either prove that this cast won't cause double-rounding errors, or
   // find a better way to get a float16.
   return fputil::cast<float16>(mpfr_get_d(value, mpfr_rounding));
+}
+#endif
+
+#if !defined(LIBC_USE_SOFT_FLOAT16)
+template <> fputil::Float16 MPFRNumber::as<fputil::Float16>() const {
+  return fputil::cast<fputil::Float16>(mpfr_get_d(value, mpfr_rounding));
 }
 #endif
 

--- a/libc/utils/MPFRWrapper/MPCommon.h
+++ b/libc/utils/MPFRWrapper/MPCommon.h
@@ -65,6 +65,12 @@ template <> struct ExtraPrecision<float128> {
 };
 #endif // LIBC_TYPES_FLOAT128_IS_NOT_LONG_DOUBLE
 
+#if !defined(LIBC_USE_SOFT_FLOAT16)
+template <> struct ExtraPrecision<LIBC_NAMESPACE::fputil::Float16> {
+  static constexpr unsigned int VALUE = 128;
+};
+#endif
+
 template <> struct ExtraPrecision<bfloat16> {
   static constexpr unsigned int VALUE = 64;
 };
@@ -115,6 +121,9 @@ public:
             cpp::enable_if_t<cpp::is_same_v<float, XType>
 #ifdef LIBC_TYPES_HAS_FLOAT16
                                  || cpp::is_same_v<float16, XType>
+#endif
+#if !defined(LIBC_USE_SOFT_FLOAT16)
+                                 || cpp::is_same_v<LIBC_NAMESPACE::fputil::Float16, XType>
 #endif
                                  || cpp::is_same_v<bfloat16, XType>,
                              int> = 0>

--- a/libc/utils/MPFRWrapper/MPCommon.h
+++ b/libc/utils/MPFRWrapper/MPCommon.h
@@ -65,11 +65,9 @@ template <> struct ExtraPrecision<float128> {
 };
 #endif // LIBC_TYPES_FLOAT128_IS_NOT_LONG_DOUBLE
 
-#if !defined(LIBC_USE_SOFT_FLOAT16)
 template <> struct ExtraPrecision<LIBC_NAMESPACE::fputil::Float16> {
   static constexpr unsigned int VALUE = 128;
 };
-#endif
 
 template <> struct ExtraPrecision<bfloat16> {
   static constexpr unsigned int VALUE = 64;
@@ -118,15 +116,14 @@ public:
   // to float, as the MPFR API does not support float16, thus requiring
   // conversion to a higher-precision format.
   template <typename XType,
-            cpp::enable_if_t<cpp::is_same_v<float, XType>
+            cpp::enable_if_t<
+                cpp::is_same_v<float, XType>
 #ifdef LIBC_TYPES_HAS_FLOAT16
-                                 || cpp::is_same_v<float16, XType>
+                    || cpp::is_same_v<float16, XType>
 #endif
-#if !defined(LIBC_USE_SOFT_FLOAT16)
-                                 || cpp::is_same_v<LIBC_NAMESPACE::fputil::Float16, XType>
-#endif
-                                 || cpp::is_same_v<bfloat16, XType>,
-                             int> = 0>
+                    || cpp::is_same_v<LIBC_NAMESPACE::fputil::Float16, XType> ||
+                    cpp::is_same_v<bfloat16, XType>,
+                int> = 0>
   explicit MPFRNumber(XType x,
                       unsigned int precision = ExtraPrecision<XType>::VALUE,
                       RoundingMode rounding = RoundingMode::Nearest)

--- a/libc/utils/MPFRWrapper/MPFRUtils.cpp
+++ b/libc/utils/MPFRWrapper/MPFRUtils.cpp
@@ -11,6 +11,7 @@
 
 #include "src/__support/CPP/array.h"
 #include "src/__support/CPP/stringstream.h"
+#include "src/__support/FPUtil/Float16.h"
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/__support/FPUtil/fpbits_str.h"
 #include "src/__support/macros/config.h"

--- a/libc/utils/MPFRWrapper/MPFRUtils.cpp
+++ b/libc/utils/MPFRWrapper/MPFRUtils.cpp
@@ -11,7 +11,7 @@
 
 #include "src/__support/CPP/array.h"
 #include "src/__support/CPP/stringstream.h"
-#include "src/__support/FPUtil/Float16.h"
+#include "src/__support/FPUtil/float16.h"
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/__support/FPUtil/fpbits_str.h"
 #include "src/__support/macros/config.h"

--- a/libc/utils/MPFRWrapper/MPFRUtils.cpp
+++ b/libc/utils/MPFRWrapper/MPFRUtils.cpp
@@ -11,8 +11,8 @@
 
 #include "src/__support/CPP/array.h"
 #include "src/__support/CPP/stringstream.h"
-#include "src/__support/FPUtil/float16.h"
 #include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/FPUtil/float16.h"
 #include "src/__support/FPUtil/fpbits_str.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/types.h"


### PR DESCRIPTION
I wanted to get your opinion on this implementation first. 

For now, it just adds the flag `LIBC_USE_SOFT_FLOAT16`, which switches from hardware to software emulation.

I have enabled the flag only on ARM, and the test for `fabsf16` passes.
<img width="1116" height="441" alt="image" src="https://github.com/user-attachments/assets/02dbef6d-284f-41e6-b60c-895d405f3239" />

CC: @lntue @overmighty @krishna2803 @bassiounix 

Part of: #213460