### PR TITLE
[flang] Fix distribution build of `ISO_Fortran_binding.h` to also install it in `CMAKE_INSTALL_INCLUDEDIR`.

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -584,5 +584,9 @@ install(
   FILES include/flang/ISO_Fortran_binding.h
   DESTINATION ${HEADER_INSTALL_DIR}
   COMPONENT flang-fortran-binding)
+install(
+  FILES include/flang/ISO_Fortran_binding.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/flang
+  COMPONENT flang-fortran-binding)
 add_llvm_install_targets(install-flang-fortran-binding
   COMPONENT flang-fortran-binding)


### PR DESCRIPTION
Currently with `-DLLVM_DISTRIBUTION_COMPONENTS="flang-fortran-binding"`, header file `ISO_Fortran_binding.h` is only installed at  `./lib/clang/23/include/ISO_Fortran_binding.h`, but not in the user include.
This PR is to fix that so that the `ISO_Fortran_binding.h` is also installed at `./include/flang/ISO_Fortran_binding.h`, which is the same as the "normal" (non-distribution) build.