### PR TITLE
[RISCV] Remove VL != 1 restriction in RISCVVLOptimizer

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
@@ -1235,13 +1235,6 @@ bool RISCVVLOptimizer::tryReduceVL(MachineInstr &MI,
   unsigned VLOpNum = RISCVII::getVLOpNum(MI.getDesc());
   MachineOperand &VLOp = MI.getOperand(VLOpNum);
 
-  // If the VL is 1, then there is no need to reduce it. This is an
-  // optimization, not needed to preserve correctness.
-  if (VLOp.isImm() && VLOp.getImm() == 1) {
-    LLVM_DEBUG(dbgs() << "  Abort due to VL == 1, no point in reducing.\n");
-    return false;
-  }
-
   assert((CommonVL.isImm() || CommonVL.getReg().isVirtual()) &&
          "Expected VL to be an Imm or virtual Reg");
 

--- a/llvm/test/CodeGen/RISCV/rvv/vl-opt.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vl-opt.ll
@@ -362,3 +362,16 @@ define void @vlseg2(ptr %p, iXLen %vl) {
   call void @llvm.riscv.vsseg2(target("riscv.vector.tuple", <vscale x 16 x i8>, 2) %x, ptr %p, iXLen %vl, iXLen 5)
   ret void
 }
+
+define <vscale x 4 x i32> @vl1(<vscale x 4 x i32> %passthru, <vscale x 4 x i32> %a, <vscale x 4 x i32> %b, iXLen %vl1, iXLen %vl2) {
+; CHECK-LABEL: vl1:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
+; CHECK-NEXT:    vadd.vv v8, v10, v12
+; CHECK-NEXT:    vsetivli zero, 0, e32, m2, ta, ma
+; CHECK-NEXT:    vadd.vv v8, v8, v10
+; CHECK-NEXT:    ret
+  %v = call <vscale x 4 x i32> @llvm.riscv.vadd.nxv4i32.nxv4i32(<vscale x 4 x i32> poison, <vscale x 4 x i32> %a, <vscale x 4 x i32> %b, iXLen 1)
+  %w = call <vscale x 4 x i32> @llvm.riscv.vadd.nxv4i32.nxv4i32(<vscale x 4 x i32> poison, <vscale x 4 x i32> %v, <vscale x 4 x i32> %a, iXLen 0)
+  ret <vscale x 4 x i32> %w
+}

--- a/llvm/test/CodeGen/RISCV/rvv/vl-opt.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vl-opt.ll
@@ -366,9 +366,8 @@ define void @vlseg2(ptr %p, iXLen %vl) {
 define <vscale x 4 x i32> @vl1(<vscale x 4 x i32> %passthru, <vscale x 4 x i32> %a, <vscale x 4 x i32> %b, iXLen %vl1, iXLen %vl2) {
 ; CHECK-LABEL: vl1:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e32, m2, ta, ma
-; CHECK-NEXT:    vadd.vv v8, v10, v12
 ; CHECK-NEXT:    vsetivli zero, 0, e32, m2, ta, ma
+; CHECK-NEXT:    vadd.vv v8, v10, v12
 ; CHECK-NEXT:    vadd.vv v8, v8, v10
 ; CHECK-NEXT:    ret
   %v = call <vscale x 4 x i32> @llvm.riscv.vadd.nxv4i32.nxv4i32(<vscale x 4 x i32> poison, <vscale x 4 x i32> %a, <vscale x 4 x i32> %b, iXLen 1)


### PR DESCRIPTION
This was added way back in #112228 when the VLs were reduced in-situ, and returning false in isSupportedInstr could trim the number of instructions processed.

However after #124530 the demanded VLs are all computed beforehand as an analysis so this is no longer an optimization.

This also removes the diff in rvv-peephole-vmerge-vops.ll in #184297