### PR TITLE
[clang-tidy] Fix yet another false positive in `readability-redundant-typename`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
@@ -50,7 +50,7 @@ void RedundantTypenameCheck::registerMatchers(MatchFinder *Finder) {
 void RedundantTypenameCheck::check(const MatchFinder::MatchResult &Result) {
   const TypeLoc TL = [&] {
     if (const auto *TL = Result.Nodes.getNodeAs<TypeLoc>("typeLoc"))
-      return TL->getType()->isDependentType() ? TypeLoc() : *TL;
+      return TL->getType()->isInstantiationDependentType() ? TypeLoc() : *TL;
 
     auto TL = *Result.Nodes.getNodeAs<TypeLoc>("dependentTypeLoc");
     while (const TypeLoc Next = TL.getNextTypeLoc())

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
@@ -283,6 +283,7 @@ WHOLE_TYPE_IN_MACRO Macro2;
 WHOLE_DECLARATION_IN_MACRO;
 
 template <typename T> struct Wrapper {};
+
 template <typename T>
 struct ClassWrapper {
   using R = T;
@@ -302,16 +303,34 @@ typename ClassWrapper<T>::R ClassWrapper<T>::g() {
   return {};
 }
 
-template <typename T> struct StructWrapper {};
+template <typename T>
+struct IntWrapper {
+  using R = int;
+  Wrapper<R> f();
+  R g();
+};
+
+template <typename T>
+Wrapper<typename IntWrapper<T>::R> IntWrapper<T>::f() {
+  return {};
+}
+
+template <typename T>
+typename IntWrapper<T>::R IntWrapper<T>::g() {
+// CHECK-MESSAGES-20: :[[@LINE-1]]:1: warning: redundant 'typename' [readability-redundant-typename]
+// CHECK-FIXES-20: IntWrapper<T>::R IntWrapper<T>::g() {
+  return {};
+}
+
 template <typename T>
 class ClassWithNestedStruct {
   struct Nested {};
-  StructWrapper<Nested> f();
+  Wrapper<Nested> f();
   Nested g();
 };
 
 template <typename T>
-StructWrapper<typename ClassWithNestedStruct<T>::Nested> ClassWithNestedStruct<T>::f() {
+Wrapper<typename ClassWithNestedStruct<T>::Nested> ClassWithNestedStruct<T>::f() {
   return {};
 }
 


### PR DESCRIPTION
Fixes #184083.

I plan to backport this, so no release note.