### PR TITLE
[lldb] Disable shared build for TestTemplateArgs,TestEvents,TestTypeList

### DIFF
--- a/lldb/test/API/lang/cpp/template/TestTemplateArgs.py
+++ b/lldb/test/API/lang/cpp/template/TestTemplateArgs.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 
 
 class TemplateArgsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     def prepareProcess(self):
         self.build()
 

--- a/lldb/test/API/python_api/event/TestEvents.py
+++ b/lldb/test/API/python_api/event/TestEvents.py
@@ -12,6 +12,7 @@ import random
 @skipIfLinux  # llvm.org/pr25924, sometimes generating SIGSEGV
 class EventAPITestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test import lldbplatformutil
 
 class TypeAndTypeListTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/181720