### PR TITLE
[lldb][RISCV] Add vector VCSR register definitions

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_riscv64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_riscv64.cpp
@@ -16,6 +16,7 @@
 
 #define GPR_OFFSET(idx) ((idx)*8 + 0)
 #define FPR_OFFSET(idx) ((idx)*8 + sizeof(RegisterInfoPOSIX_riscv64::GPR))
+#define VCSR_OFFSET(idx) ((idx) * 8 + 0)
 
 #define DECLARE_REGISTER_INFOS_RISCV64_STRUCT
 #include "RegisterInfos_riscv64.h"

--- a/lldb/source/Plugins/Process/Utility/RegisterInfos_riscv64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfos_riscv64.h
@@ -25,6 +25,10 @@
 #error FPR_OFFSET must be defined before including this header file
 #endif
 
+#ifndef VCSR_OFFSET
+#error VCSR_OFFSET must be defined before including this header file
+#endif
+
 using namespace riscv_dwarf;
 
 // clang-format off
@@ -74,6 +78,14 @@ using namespace riscv_dwarf;
 #define DEFINE_VPR_ALT(reg, alt, generic_kind)                                 \
   {                                                                            \
     #reg, #alt, 16, 0, lldb::eEncodingVector, lldb::eFormatVectorOfUInt8,      \
+    VPR_KIND(vpr_##reg, generic_kind), nullptr, nullptr, nullptr               \
+  }
+
+#define DEFINE_VCSR(reg, generic_kind) DEFINE_VCSR_ALT(reg, reg, 8, generic_kind)
+
+#define DEFINE_VCSR_ALT(reg, alt, size, generic_kind)                           \
+  {                                                                            \
+    #reg, #alt, size, VCSR_OFFSET(vpr_##reg##_riscv - vcsr_first_riscv), lldb::eEncodingUint, lldb::eFormatHex,                \
     VPR_KIND(vpr_##reg, generic_kind), nullptr, nullptr, nullptr               \
   }
 
@@ -153,22 +165,43 @@ static lldb_private::RegisterInfo g_register_infos_riscv64_fpr[] = {
 };
 
 static lldb_private::RegisterInfo g_register_infos_riscv64_vpr[] = {
-    DEFINE_VPR(v0, LLDB_INVALID_REGNUM),  DEFINE_VPR(v1, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v2, LLDB_INVALID_REGNUM),  DEFINE_VPR(v3, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v4, LLDB_INVALID_REGNUM),  DEFINE_VPR(v5, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v6, LLDB_INVALID_REGNUM),  DEFINE_VPR(v7, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v8, LLDB_INVALID_REGNUM),  DEFINE_VPR(v9, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v10, LLDB_INVALID_REGNUM), DEFINE_VPR(v11, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v12, LLDB_INVALID_REGNUM), DEFINE_VPR(v13, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v14, LLDB_INVALID_REGNUM), DEFINE_VPR(v15, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v16, LLDB_INVALID_REGNUM), DEFINE_VPR(v17, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v18, LLDB_INVALID_REGNUM), DEFINE_VPR(v19, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v20, LLDB_INVALID_REGNUM), DEFINE_VPR(v21, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v22, LLDB_INVALID_REGNUM), DEFINE_VPR(v23, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v24, LLDB_INVALID_REGNUM), DEFINE_VPR(v25, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v26, LLDB_INVALID_REGNUM), DEFINE_VPR(v27, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v28, LLDB_INVALID_REGNUM), DEFINE_VPR(v29, LLDB_INVALID_REGNUM),
-    DEFINE_VPR(v30, LLDB_INVALID_REGNUM), DEFINE_VPR(v31, LLDB_INVALID_REGNUM),
+    DEFINE_VCSR(vstart, LLDB_INVALID_REGNUM),
+    DEFINE_VCSR(vl, LLDB_INVALID_REGNUM),
+    DEFINE_VCSR(vtype, LLDB_INVALID_REGNUM),
+    DEFINE_VCSR(vcsr, LLDB_INVALID_REGNUM),
+    DEFINE_VCSR(vlenb, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v0, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v1, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v2, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v3, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v4, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v5, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v6, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v7, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v8, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v9, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v10, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v11, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v12, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v13, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v14, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v15, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v16, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v17, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v18, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v19, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v20, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v21, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v22, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v23, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v24, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v25, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v26, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v27, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v28, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v29, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v30, LLDB_INVALID_REGNUM),
+    DEFINE_VPR(v31, LLDB_INVALID_REGNUM),
 };
 
 #endif // DECLARE_REGISTER_INFOS_RISCV64_STRUCT

--- a/lldb/source/Plugins/Process/Utility/lldb-riscv-register-enums.h
+++ b/lldb/source/Plugins/Process/Utility/lldb-riscv-register-enums.h
@@ -152,7 +152,15 @@ enum {
   fpr_ft11_riscv = fpr_f31_riscv,
   fpr_last_riscv = fpr_fcsr_riscv,
 
-  vpr_first_riscv = 66,
+  vcsr_first_riscv = 66,
+  vpr_vstart_riscv = vcsr_first_riscv,
+  vpr_vl_riscv,
+  vpr_vtype_riscv,
+  vpr_vcsr_riscv,
+  vpr_vlenb_riscv,
+  vcsr_last_riscv = vpr_vlenb_riscv,
+
+  vpr_first_riscv = 71,
   vpr_v0_riscv = vpr_first_riscv,
   vpr_v1_riscv,
   vpr_v2_riscv,


### PR DESCRIPTION
Support RISC-V vector register context (1/3)

Add definitions for RISC-V vector CSRs to support RVV debugging. This includes the vstart, vl, vtype, vcsr, and vlenb registers, which control the vector operation state and behavior.