### PR TITLE
[lldb] Don't link TestingSupport as a component

### DIFF
--- a/lldb/unittests/Target/CMakeLists.txt
+++ b/lldb/unittests/Target/CMakeLists.txt
@@ -18,7 +18,6 @@ add_lldb_unittest(TargetTests
 
   LINK_COMPONENTS
       Support
-      TestingSupport
   LINK_LIBS
       lldbCore
       lldbHost
@@ -33,6 +32,7 @@ add_lldb_unittest(TargetTests
       lldbSymbol
       lldbUtility
       lldbUtilityHelpers
+      LLVMTestingSupport
   )
 
 set(test_inputs


### PR DESCRIPTION
This doesn't work with dylib builds, because TestingSupport is not part of the dylib. Instead, we should link it via LINK_LIBS, like other tests already do.