### PR TITLE
[lldb] Change more uses of AppendMessageWithFormat to AppendMessageWithFormatv

### DIFF
--- a/lldb/source/Commands/CommandObjectApropos.cpp
+++ b/lldb/source/Commands/CommandObjectApropos.cpp
@@ -42,13 +42,14 @@ void CommandObjectApropos::DoExecute(Args &args, CommandReturnObject &result) {
           search_word, commands_found, commands_help, true, true, true, true);
 
       if (commands_found.GetSize() == 0) {
-        result.AppendMessageWithFormat("No commands found pertaining to '%s'. "
-                                       "Try 'help' to see a complete list of "
-                                       "debugger commands.\n",
-                                       args[0].c_str());
+        result.AppendMessageWithFormatv(
+            "No commands found pertaining to '{0}'. "
+            "Try 'help' to see a complete list of "
+            "debugger commands.",
+            args[0].c_str());
       } else {
-        result.AppendMessageWithFormat(
-            "The following commands may relate to '%s':\n", args[0].c_str());
+        result.AppendMessageWithFormatv(
+            "The following commands may relate to '{0}':", args[0].c_str());
         const size_t commands_max_len = commands_found.GetMaxStringLength();
         for (size_t i = 0; i < commands_found.GetSize(); ++i)
           m_interpreter.OutputFormattedHelpText(
@@ -70,10 +71,10 @@ void CommandObjectApropos::DoExecute(Args &args, CommandReturnObject &result) {
       }
 
       if (num_properties == 0) {
-        result.AppendMessageWithFormat(
-            "No settings found pertaining to '%s'. "
+        result.AppendMessageWithFormatv(
+            "No settings found pertaining to '{0}'. "
             "Try 'settings show' to see a complete list of "
-            "debugger settings.\n",
+            "debugger settings.",
             args[0].c_str());
 
       } else {

--- a/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
@@ -611,8 +611,8 @@ protected:
                                     result.GetOutputStream().GetIndentLevel() +
                                         2);
             } else {
-              result.AppendMessageWithFormat(
-                  "Breakpoint %s does not have an associated command.\n",
+              result.AppendMessageWithFormatv(
+                  "Breakpoint {0} does not have an associated command.",
                   id_str.GetData());
             }
           }

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -489,7 +489,7 @@ public:
           File::eOpenOptionReadWrite | File::eOpenOptionCanCreate,
           perms, error);
       if (error.Success()) {
-        result.AppendMessageWithFormat("File Descriptor = %" PRIu64 "\n", fd);
+        result.AppendMessageWithFormatv("File Descriptor = {0}", fd);
         result.SetStatus(eReturnStatusSuccessFinishResult);
       } else {
         result.AppendError(error.AsCString());
@@ -537,7 +537,7 @@ public:
       Status error;
       bool success = platform_sp->CloseFile(fd, error);
       if (success) {
-        result.AppendMessageWithFormat("file %" PRIu64 " closed.\n", fd);
+        result.AppendMessageWithFormatv("file {0} closed.", fd);
         result.SetStatus(eReturnStatusSuccessFinishResult);
       } else {
         result.AppendError(error.AsCString());
@@ -581,8 +581,8 @@ public:
       uint64_t retcode = platform_sp->ReadFile(
           fd, m_options.m_offset, &buffer[0], m_options.m_count, error);
       if (retcode != UINT64_MAX) {
-        result.AppendMessageWithFormat("Return = %" PRIu64 "\n", retcode);
-        result.AppendMessageWithFormat("Data = \"%s\"\n", buffer.c_str());
+        result.AppendMessageWithFormatv("Return = {0}", retcode);
+        result.AppendMessageWithFormatv("Data = \"{0}\"", buffer.c_str());
         result.SetStatus(eReturnStatusSuccessFinishResult);
       } else {
         result.AppendError(error.AsCString());
@@ -675,7 +675,7 @@ public:
           platform_sp->WriteFile(fd, m_options.m_offset, &m_options.m_data[0],
                                  m_options.m_data.size(), error);
       if (retcode != UINT64_MAX) {
-        result.AppendMessageWithFormat("Return = %" PRIu64 "\n", retcode);
+        result.AppendMessageWithFormatv("Return = {0}", retcode);
         result.SetStatus(eReturnStatusSuccessFinishResult);
       } else {
         result.AppendError(error.AsCString());
@@ -828,13 +828,13 @@ public:
       Status error = platform_sp->GetFile(FileSpec(remote_file_path),
                                           FileSpec(local_file_path));
       if (error.Success()) {
-        result.AppendMessageWithFormat(
-            "successfully get-file from %s (remote) to %s (host)\n",
+        result.AppendMessageWithFormatv(
+            "successfully get-file from {0} (remote) to {1} (host)",
             remote_file_path, local_file_path);
         result.SetStatus(eReturnStatusSuccessFinishResult);
       } else {
-        result.AppendMessageWithFormat("get-file failed: %s\n",
-                                       error.AsCString());
+        result.AppendMessageWithFormatv("get-file failed: {0}",
+                                        error.AsCString());
       }
     } else {
       result.AppendError("no platform currently selected\n");
@@ -875,13 +875,12 @@ public:
       std::string remote_file_path(args.GetArgumentAtIndex(0));
       user_id_t size = platform_sp->GetFileSize(FileSpec(remote_file_path));
       if (size != UINT64_MAX) {
-        result.AppendMessageWithFormat("File size of %s (remote): %" PRIu64
-                                       "\n",
-                                       remote_file_path.c_str(), size);
+        result.AppendMessageWithFormatv("File size of {0} (remote): {1}",
+                                        remote_file_path.c_str(), size);
         result.SetStatus(eReturnStatusSuccessFinishResult);
       } else {
-        result.AppendMessageWithFormat(
-            "Error getting file size of %s (remote)\n",
+        result.AppendMessageWithFormatv(
+            "Error getting file size of {0} (remote)",
             remote_file_path.c_str());
       }
     } else {
@@ -925,9 +924,9 @@ public:
       Status error = platform_sp->GetFilePermissions(FileSpec(remote_file_path),
                                                      permissions);
       if (error.Success()) {
-        result.AppendMessageWithFormat(
-            "File permissions of %s (remote): 0o%04" PRIo32 "\n",
-            remote_file_path.c_str(), permissions);
+        result.AppendMessageWithFormatv(
+            "File permissions of {0} (remote): 0o{1}", remote_file_path,
+            llvm::format("%04o", permissions));
         result.SetStatus(eReturnStatusSuccessFinishResult);
       } else
         result.AppendError(error.AsCString());
@@ -969,9 +968,9 @@ public:
     if (platform_sp) {
       std::string remote_file_path(args.GetArgumentAtIndex(0));
       bool exists = platform_sp->GetFileExists(FileSpec(remote_file_path));
-      result.AppendMessageWithFormat(
-          "File %s (remote) %s\n",
-          remote_file_path.c_str(), exists ? "exists" : "does not exist");
+      result.AppendMessageWithFormatv("File {0} (remote) {1}",
+                                      remote_file_path.c_str(),
+                                      exists ? "exists" : "does not exist");
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {
       result.AppendError("no platform currently selected\n");

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -832,8 +832,8 @@ protected:
         target_search_filter.Search(m_breakpoint_locations);
       }
 
-      result.AppendMessageWithFormat(
-          "File: %s\n", start_file->GetSpecOnly().GetPath().c_str());
+      result.AppendMessageWithFormatv(
+          "File: {0}", start_file->GetSpecOnly().GetPath().c_str());
       // We don't care about the column here.
       const uint32_t column = 0;
       return target.GetSourceManager().DisplaySourceLinesWithLineNumbers(

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -2713,8 +2713,8 @@ public:
     }
 
     if (!any_found)
-      result.AppendMessageWithFormat("no type was found matching '%s'\n",
-                                     name_of_type);
+      result.AppendMessageWithFormatv("no type was found matching '{0}'",
+                                      name_of_type);
 
     result.SetStatus(any_found ? lldb::eReturnStatusSuccessFinishResult
                                : lldb::eReturnStatusSuccessFinishNoResult);

--- a/lldb/source/Commands/CommandObjectVersion.cpp
+++ b/lldb/source/Commands/CommandObjectVersion.cpp
@@ -65,7 +65,7 @@ static void dump(const StructuredData::Dictionary &config, Stream &s) {
 }
 
 void CommandObjectVersion::DoExecute(Args &args, CommandReturnObject &result) {
-  result.AppendMessageWithFormat("%s\n", lldb_private::GetVersion());
+  result.AppendMessageWithFormatv("{0}", lldb_private::GetVersion());
 
   if (m_options.verbose)
     dump(*Debugger::GetBuildConfiguration(), result.GetOutputStream());

--- a/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
@@ -548,8 +548,8 @@ protected:
                                     result.GetOutputStream().GetIndentLevel() +
                                         2);
             } else {
-              result.AppendMessageWithFormat(
-                  "Watchpoint %u does not have an associated command.\n",
+              result.AppendMessageWithFormatv(
+                  "Watchpoint {0} does not have an associated command.",
                   cur_wp_id);
             }
           }

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
@@ -441,8 +441,8 @@ protected:
       if (mangled.GuessLanguage() == lldb::eLanguageTypeC_plus_plus) {
         ConstString demangled(mangled.GetDisplayDemangledName());
         demangled_any = true;
-        result.AppendMessageWithFormat("%s ---> %s\n", entry.c_str(),
-                                       demangled.GetCString());
+        result.AppendMessageWithFormatv("{0} ---> {1}", entry.c_str(),
+                                        demangled.GetCString());
       } else {
         error_any = true;
         result.AppendErrorWithFormat("%s is not a valid C++ mangled name\n",


### PR DESCRIPTION
When the message includes a final newline, Formatv can add that for you.

The only unusual change is one place in platform where we need to print octal. LLVM doesn't have a built in way to do this (see llvm/include/llvm/Support/FormatProviders.h) and this is probably the only place in the codebase that wants to. So I decided not to add it there.

Instead I've put the number info a format adapter with the normal printf specifier, then put that into the Formatv format.