### PR TITLE
[CodeGen] Add listener support to the rematerializer (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -240,8 +240,8 @@ public:
 
   /// Adds a listener to the rematerializer.
   void addListener(Listener *Listen) { Listeners.push_back(Listen); }
-  /// Removes all listeners from the rematerializers.
-  void clearListeners(Listener *Listen) { Listeners.clear(); }
+  /// Removes all listeners from the rematerializer.
+  void clearListeners() { Listeners.clear(); }
 
   inline const Reg &getReg(RegisterIdx RegIdx) const {
     assert(RegIdx < Regs.size() && "out of bounds");

--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -186,6 +186,37 @@ public:
     friend Rematerializer;
   };
 
+  /// Rematerializer listener. Defines overridable hooks that allow to catch
+  /// specific events inside the rematerializer. All hooks do nothing by
+  /// default. Listeners can be added or removed at any time during the
+  /// rematerializer's lifetime.
+  class Listener {
+  private:
+    /// Called before register \p RegIdx is rematerialized to register \p
+    /// RematRegIdx. At this point the rematerialization does not exist.
+    virtual void beforeRegRematerialized(const Rematerializer &Remater,
+                                         RegisterIdx RegIdx,
+                                         RegisterIdx RematRegIdx) {}
+
+    /// Called just after register \p NewRegIdx is created (following a
+    /// rematerializations). At this point the rematerialization exists but does
+    /// not yet have any user.
+    virtual void newRegCreated(const Rematerializer &Remater,
+                               RegisterIdx NewRegIdx) {}
+
+    /// Called juste before register \p RegIdx is deleted from the MIR. At this
+    /// point the register still exists and is guaranteed to have 0 users.
+    virtual void beforeRegDeleted(const Rematerializer &Remater,
+                                  RegisterIdx RegIdx) {}
+
+    friend Rematerializer;
+
+  public:
+    using RegisterIdx = Rematerializer::RegisterIdx;
+
+    virtual ~Listener() = default;
+  };
+
   /// Error value for register indices.
   static constexpr unsigned NoReg = ~0;
 
@@ -206,6 +237,11 @@ public:
   /// when they longer have any users. Returns whether there is any
   /// rematerializable register in regions.
   bool analyze(bool SupportRollback);
+
+  /// Adds a listener to the rematerializer.
+  void addListener(Listener *Listen) { Listeners.push_back(Listen); }
+  /// Removes all listeners from the rematerializers.
+  void clearListeners(Listener *Listen) { Listeners.clear(); }
 
   inline const Reg &getReg(RegisterIdx RegIdx) const {
     assert(RegIdx < Regs.size() && "out of bounds");
@@ -386,6 +422,13 @@ private:
   LiveIntervals &LIS;
   const TargetInstrInfo &TII;
   const TargetRegisterInfo &TRI;
+  SmallVector<Listener *, 2> Listeners;
+
+  template <typename Callback, typename... ArgsTy>
+  void notifyListeners(Callback Cb, ArgsTy &&...Args) const {
+    for (Listener *Listen : Listeners)
+      (Listen->*Cb)(*this, std::forward<ArgsTy>(Args)...);
+  }
 
   /// Rematerializable registers identified since the rematerializer's creation,
   /// both dead and alive, originals and rematerializations. No register is ever

--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -191,30 +191,24 @@ public:
   /// default. Listeners can be added or removed at any time during the
   /// rematerializer's lifetime.
   class Listener {
-  private:
-    /// Called before register \p RegIdx is rematerialized to register \p
-    /// RematRegIdx. At this point the rematerialization does not exist.
-    virtual void beforeRegRematerialized(const Rematerializer &Remater,
-                                         RegisterIdx RegIdx,
-                                         RegisterIdx RematRegIdx) {}
-
-    /// Called just after register \p NewRegIdx is created (following a
-    /// rematerializations). At this point the rematerialization exists but does
-    /// not yet have any user.
-    virtual void newRegCreated(const Rematerializer &Remater,
-                               RegisterIdx NewRegIdx) {}
-
-    /// Called juste before register \p RegIdx is deleted from the MIR. At this
-    /// point the register still exists and is guaranteed to have 0 users.
-    virtual void beforeRegDeleted(const Rematerializer &Remater,
-                                  RegisterIdx RegIdx) {}
-
-    friend Rematerializer;
-
   public:
     using RegisterIdx = Rematerializer::RegisterIdx;
 
+    /// Called just after register \p NewRegIdx is created (following a
+    /// rematerialization). At this point the rematerialization exists in the \p
+    /// Remater state and the MIR but does not yet have any user.
+    virtual void rematerializerNoteRegCreated(const Rematerializer &Remater,
+                                              RegisterIdx NewRegIdx) {}
+
+    /// Called juste before register \p RegIdx is deleted from the MIR. At this
+    /// point the register still exists in the MIR but no longer has any user.
+    virtual void rematerializerNoteRegDeleted(const Rematerializer &Remater,
+                                              RegisterIdx RegIdx) {}
+
     virtual ~Listener() = default;
+
+  private:
+    virtual void anchor();
   };
 
   /// Error value for register indices.
@@ -238,8 +232,19 @@ public:
   /// rematerializable register in regions.
   bool analyze(bool SupportRollback);
 
-  /// Adds a listener to the rematerializer.
-  void addListener(Listener *Listen) { Listeners.push_back(Listen); }
+  /// Adds a new listener to the rematerializer.
+  void addListener(Listener *Listen) {
+    assert(Listen && "null listener");
+    assert(!Listeners.contains(Listen) && "duplicate listener");
+    Listeners.insert(Listen);
+  }
+
+  /// Removes a listener from the rematerializer.
+  void removeListener(Listener *Listen) {
+    assert(Listeners.contains(Listen) && "unknown listener");
+    Listeners.erase(Listen);
+  }
+
   /// Removes all listeners from the rematerializer.
   void clearListeners() { Listeners.clear(); }
 
@@ -422,12 +427,16 @@ private:
   LiveIntervals &LIS;
   const TargetInstrInfo &TII;
   const TargetRegisterInfo &TRI;
-  SmallVector<Listener *, 2> Listeners;
+  SmallPtrSet<Listener *, 1> Listeners;
 
-  template <typename Callback, typename... ArgsTy>
-  void notifyListeners(Callback Cb, ArgsTy &&...Args) const {
+  void noteRegCreated(RegisterIdx RegIdx) const {
     for (Listener *Listen : Listeners)
-      (Listen->*Cb)(*this, std::forward<ArgsTy>(Args)...);
+      Listen->rematerializerNoteRegCreated(*this, RegIdx);
+  }
+
+  void noteRegDeleted(RegisterIdx RegIdx) const {
+    for (Listener *Listen : Listeners)
+      Listen->rematerializerNoteRegDeleted(*this, RegIdx);
   }
 
   /// Rematerializable registers identified since the rematerializer's creation,

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -405,7 +405,7 @@ void Rematerializer::deleteReg(RegisterIdx RegIdx) {
 
   Reg &DeleteReg = Regs[RegIdx];
   assert(DeleteReg.DefMI && "register was already deleted");
-  
+
   // It is not possible for the deleted instruction to be the upper region
   // boundary since we don't ever consider them rematerializable.
   MachineBasicBlock::iterator &RegionBegin = Regions[DeleteReg.DefRegion].first;

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -401,8 +401,11 @@ void Rematerializer::deleteRegIfUnused(RegisterIdx RootIdx) {
 }
 
 void Rematerializer::deleteReg(RegisterIdx RegIdx) {
+  notifyListeners(&Listener::beforeRegDeleted, RegIdx);
+
   Reg &DeleteReg = Regs[RegIdx];
   assert(DeleteReg.DefMI && "register was already deleted");
+  
   // It is not possible for the deleted instruction to be the upper region
   // boundary since we don't ever consider them rematerializable.
   MachineBasicBlock::iterator &RegionBegin = Regions[DeleteReg.DefRegion].first;
@@ -574,9 +577,10 @@ RegisterIdx Rematerializer::getDefRegIdx(const MachineInstr &MI) const {
 RegisterIdx Rematerializer::rematerializeReg(
     RegisterIdx RegIdx, MachineBasicBlock::iterator InsertPos,
     SmallVectorImpl<Reg::Dependency> &&Dependencies) {
-  unsigned UseRegion = MIRegion.at(&*InsertPos);
   RegisterIdx NewRegIdx = Regs.size();
+  notifyListeners(&Listener::beforeRegRematerialized, RegIdx, NewRegIdx);
 
+  unsigned UseRegion = MIRegion.at(&*InsertPos);
   Reg &NewReg = Regs.emplace_back();
   Reg &FromReg = Regs[RegIdx];
   NewReg.Mask = FromReg.Mask;
@@ -626,6 +630,8 @@ RegisterIdx Rematerializer::rematerializeReg(
     NewDepReg.addUser(NewReg.DefMI, UseRegion);
     LISUpdates.insert(NewDep.RegIdx);
   }
+
+  notifyListeners(&Listener::newRegCreated, NewRegIdx);
 
   LLVM_DEBUG({
     dbgs() << "** Rematerialized " << printID(RegIdx) << " as "

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -30,6 +30,9 @@
 using namespace llvm;
 using RegisterIdx = Rematerializer::RegisterIdx;
 
+// Pin the vtable to this file.
+void Rematerializer::Listener::anchor() {}
+
 /// Checks whether the value in \p LI at \p UseIdx is identical to \p OVNI (this
 /// implies it is also live there). When \p LI has sub-ranges, checks that
 /// all sub-ranges intersecting with \p Mask are also live at \p UseIdx.
@@ -401,11 +404,10 @@ void Rematerializer::deleteRegIfUnused(RegisterIdx RootIdx) {
 }
 
 void Rematerializer::deleteReg(RegisterIdx RegIdx) {
-  notifyListeners(&Listener::beforeRegDeleted, RegIdx);
+  noteRegDeleted(RegIdx);
 
   Reg &DeleteReg = Regs[RegIdx];
   assert(DeleteReg.DefMI && "register was already deleted");
-
   // It is not possible for the deleted instruction to be the upper region
   // boundary since we don't ever consider them rematerializable.
   MachineBasicBlock::iterator &RegionBegin = Regions[DeleteReg.DefRegion].first;
@@ -577,10 +579,9 @@ RegisterIdx Rematerializer::getDefRegIdx(const MachineInstr &MI) const {
 RegisterIdx Rematerializer::rematerializeReg(
     RegisterIdx RegIdx, MachineBasicBlock::iterator InsertPos,
     SmallVectorImpl<Reg::Dependency> &&Dependencies) {
-  RegisterIdx NewRegIdx = Regs.size();
-  notifyListeners(&Listener::beforeRegRematerialized, RegIdx, NewRegIdx);
-
   unsigned UseRegion = MIRegion.at(&*InsertPos);
+  RegisterIdx NewRegIdx = Regs.size();
+
   Reg &NewReg = Regs.emplace_back();
   Reg &FromReg = Regs[RegIdx];
   NewReg.Mask = FromReg.Mask;
@@ -631,7 +632,7 @@ RegisterIdx Rematerializer::rematerializeReg(
     LISUpdates.insert(NewDep.RegIdx);
   }
 
-  notifyListeners(&Listener::newRegCreated, NewRegIdx);
+  noteRegCreated(NewRegIdx);
 
   LLVM_DEBUG({
     dbgs() << "** Rematerialized " << printID(RegIdx) << " as "


### PR DESCRIPTION
This change adds support for adding listeners to the target-independent rematerializer; listeners can catch certain rematerialization-related events to implement some additional functionality on top of what the rematerializer already performs.

This is NFC and has no user at the moment, but the plan is to have listeners start being responsible for secondary/optional functionalities that are at the moment integrated with the rematerializer itself. Two examples of that are:

1. rollback support (currently optional), and
2. region tracking (currently mandatory, but not fundamentally necessary to the rematerializer).

- #189491
- #189489
- #189485
- #186674
- #184341
- #184339
- #184338 👈
- `main`