### PR TITLE
[CodeGen] Allow rematerializer to rematerialize at the end of a block

### DIFF
--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -240,8 +240,8 @@ public:
 
   /// Adds a listener to the rematerializer.
   void addListener(Listener *Listen) { Listeners.push_back(Listen); }
-  /// Removes all listeners from the rematerializers.
-  void clearListeners(Listener *Listen) { Listeners.clear(); }
+  /// Removes all listeners from the rematerializer.
+  void clearListeners() { Listeners.clear(); }
 
   inline const Reg &getReg(RegisterIdx RegIdx) const {
     assert(RegIdx < Regs.size() && "out of bounds");

--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -186,6 +186,37 @@ public:
     friend Rematerializer;
   };
 
+  /// Rematerializer listener. Defines overridable hooks that allow to catch
+  /// specific events inside the rematerializer. All hooks do nothing by
+  /// default. Listeners can be added or removed at any time during the
+  /// rematerializer's lifetime.
+  class Listener {
+  private:
+    /// Called before register \p RegIdx is rematerialized to register \p
+    /// RematRegIdx. At this point the rematerialization does not exist.
+    virtual void beforeRegRematerialized(const Rematerializer &Remater,
+                                         RegisterIdx RegIdx,
+                                         RegisterIdx RematRegIdx) {}
+
+    /// Called just after register \p NewRegIdx is created (following a
+    /// rematerializations). At this point the rematerialization exists but does
+    /// not yet have any user.
+    virtual void newRegCreated(const Rematerializer &Remater,
+                               RegisterIdx NewRegIdx) {}
+
+    /// Called juste before register \p RegIdx is deleted from the MIR. At this
+    /// point the register still exists and is guaranteed to have 0 users.
+    virtual void beforeRegDeleted(const Rematerializer &Remater,
+                                  RegisterIdx RegIdx) {}
+
+    friend Rematerializer;
+
+  public:
+    using RegisterIdx = Rematerializer::RegisterIdx;
+
+    virtual ~Listener() = default;
+  };
+
   /// Error value for register indices.
   static constexpr unsigned NoReg = ~0;
 
@@ -206,6 +237,11 @@ public:
   /// when they longer have any users. Returns whether there is any
   /// rematerializable register in regions.
   bool analyze(bool SupportRollback);
+
+  /// Adds a listener to the rematerializer.
+  void addListener(Listener *Listen) { Listeners.push_back(Listen); }
+  /// Removes all listeners from the rematerializers.
+  void clearListeners(Listener *Listen) { Listeners.clear(); }
 
   inline const Reg &getReg(RegisterIdx RegIdx) const {
     assert(RegIdx < Regs.size() && "out of bounds");
@@ -386,6 +422,13 @@ private:
   LiveIntervals &LIS;
   const TargetInstrInfo &TII;
   const TargetRegisterInfo &TRI;
+  SmallVector<Listener *, 2> Listeners;
+
+  template <typename Callback, typename... ArgsTy>
+  void notifyListeners(Callback Cb, ArgsTy &&...Args) const {
+    for (Listener *Listen : Listeners)
+      (Listen->*Cb)(*this, std::forward<ArgsTy>(Args)...);
+  }
 
   /// Rematerializable registers identified since the rematerializer's creation,
   /// both dead and alive, originals and rematerializations. No register is ever

--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -420,7 +420,8 @@ public:
   Printable printID(RegisterIdx RegIdx) const;
   Printable printRematReg(RegisterIdx RegIdx, bool SkipRegions = false) const;
   Printable printRegUsers(RegisterIdx RegIdx) const;
-  Printable printUser(const MachineInstr *MI) const;
+  Printable printUser(const MachineInstr *MI,
+                      std::optional<unsigned> UseRegion = std::nullopt) const;
 
 private:
   SmallVectorImpl<RegionBoundaries> &Regions;

--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -337,9 +337,10 @@ public:
   };
 
   /// Rematerializes register \p RootIdx just before its first user inside
-  /// region \p UseRegion, transfers all its users in the region to the new
-  /// register, and returns the latter's index. The root's dependency DAG is
-  /// rematerialized or re-used according to \p DRI.
+  /// region \p UseRegion (or at the end of the region if it has no user),
+  /// transfers all its users in the region to the new register, and returns the
+  /// latter's index. The root's dependency DAG is rematerialized or re-used
+  /// according to \p DRI.
   ///
   /// When the method returns, \p DRI contains additional entries for non-root
   /// registers of the root's dependency DAG that needed to be rematerialized
@@ -348,15 +349,15 @@ public:
   RegisterIdx rematerializeToRegion(RegisterIdx RootIdx, unsigned UseRegion,
                                     DependencyReuseInfo &DRI);
 
-  /// Rematerializes register \p RootIdx before position \p InsertPos and
-  /// returns the new register's index. The root's dependency DAG is
-  /// rematerialized or re-used according to \p DRI.
+  /// Rematerializes register \p RootIdx before position \p InsertPos in \p
+  /// UseRegion and returns the new register's index. The root's dependency DAG
+  /// is rematerialized or re-used according to \p DRI.
   ///
   /// When the method returns, \p DRI contains additional entries for non-root
   /// registers of the root's dependency DAG that needed to be rematerialized
   /// along the root. References to \ref Rematerializer::Reg should be
   /// considered invalidated by calls to this method.
-  RegisterIdx rematerializeToPos(RegisterIdx RootIdx,
+  RegisterIdx rematerializeToPos(RegisterIdx RootIdx, unsigned UseRegion,
                                  MachineBasicBlock::iterator InsertPos,
                                  DependencyReuseInfo &DRI);
 
@@ -389,12 +390,12 @@ public:
   void transferRegionUsers(RegisterIdx FromRegIdx, RegisterIdx ToRegIdx,
                            unsigned UseRegion);
 
-  /// Transfers user \p UserMI from register \p FromRegIdx to \p ToRegIdx,
-  /// the latter of which must be a rematerialization of the former or have the
-  /// same origin register. \p UserMI must be a direct user of \p FromRegIdx. \p
-  /// UserMI must be reachable from \p ToRegIdx.
+  /// Transfers user \p UserMI in region \p UserRegion from register \p
+  /// FromRegIdx to \p ToRegIdx, the latter of which must be a rematerialization
+  /// of the former or have the same origin register. \p UserMI must be a direct
+  /// user of \p FromRegIdx. \p UserMI must be reachable from \p ToRegIdx.
   void transferUser(RegisterIdx FromRegIdx, RegisterIdx ToRegIdx,
-                    MachineInstr &UserMI);
+                    unsigned UserRegion, MachineInstr &UserMI);
 
   /// Recomputes all live intervals that have changed as a result of previous
   /// rematerializations/rollbacks.
@@ -464,9 +465,8 @@ private:
   /// data in the \ref Regs vector. This includes registers that no longer exist
   /// in the MIR.
   DenseMap<Register, RegisterIdx> RegToIdx;
-  /// Maps all MIs to their parent region. Region terminators are considered
-  /// part of the region they terminate.
-  DenseMap<MachineInstr *, unsigned> MIRegion;
+  /// Parent block of each region, in order.
+  SmallVector<MachineBasicBlock *> RegionMBB;
   /// Set of registers whose live-range may have changed during past
   /// rematerializations/rollbacks.
   DenseSet<RegisterIdx> LISUpdates;
@@ -479,8 +479,13 @@ private:
   bool SupportRollback = false;
 
   /// During the analysis phase, creates a \ref Rematerializer::Reg object for
-  /// virtual register \p VirtRegIdx if it
-  void addRegIfRematerializable(unsigned VirtRegIdx, BitVector &SeenRegs);
+  /// virtual register \p VirtRegIdx if it is rematerializable. \p MIRegion maps
+  /// all MIs to their parent region. Set bits in \p SeenRegs indicate virtual
+  /// register indices that have already been visited.
+  void
+  addRegIfRematerializable(unsigned VirtRegIdx,
+                           const DenseMap<MachineInstr *, unsigned> &MIRegion,
+                           BitVector &SeenRegs);
 
   /// Determines whether \p MI is considered rematerializable. This further
   /// restricts constraints imposed by the TII on rematerializable instructions,
@@ -488,16 +493,16 @@ private:
   /// defined once.
   bool isMIRematerializable(const MachineInstr &MI) const;
 
-  /// Rematerializes register \p RegIdx at \p InsertPos, adding the new
-  /// rematerializable register to the backing vector \ref Regs and returning
-  /// its index inside the vector. Sets the new registers' rematerializable
-  /// dependencies to \p Dependencies (these are assumed to already exist in the
-  /// MIR) and its unrematerializable dependencies to the same as \p RegIdx. The
-  /// new register initially has no user. Since the method appends to \ref Regs,
-  /// references to elements within it should be considered invalidated across
-  /// calls to this method unless the vector can be guaranteed to have enough
-  /// space for an extra element.
-  RegisterIdx rematerializeReg(RegisterIdx RegIdx,
+  /// Rematerializes register \p RegIdx at \p InsertPos in \p UseRegion, adding
+  /// the new rematerializable register to the backing vector \ref Regs and
+  /// returning its index inside the vector. Sets the new registers'
+  /// rematerializable dependencies to \p Dependencies (these are assumed to
+  /// already exist in the MIR) and its unrematerializable dependencies to the
+  /// same as \p RegIdx. The new register initially has no user. Since the
+  /// method appends to \ref Regs, references to elements within it should be
+  /// considered invalidated across calls to this method unless the vector can
+  /// be guaranteed to have enough space for an extra element.
+  RegisterIdx rematerializeReg(RegisterIdx RegIdx, unsigned UseRegion,
                                MachineBasicBlock::iterator InsertPos,
                                SmallVectorImpl<Reg::Dependency> &&Dependencies);
 

--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -191,30 +191,24 @@ public:
   /// default. Listeners can be added or removed at any time during the
   /// rematerializer's lifetime.
   class Listener {
-  private:
-    /// Called before register \p RegIdx is rematerialized to register \p
-    /// RematRegIdx. At this point the rematerialization does not exist.
-    virtual void beforeRegRematerialized(const Rematerializer &Remater,
-                                         RegisterIdx RegIdx,
-                                         RegisterIdx RematRegIdx) {}
-
-    /// Called just after register \p NewRegIdx is created (following a
-    /// rematerializations). At this point the rematerialization exists but does
-    /// not yet have any user.
-    virtual void newRegCreated(const Rematerializer &Remater,
-                               RegisterIdx NewRegIdx) {}
-
-    /// Called juste before register \p RegIdx is deleted from the MIR. At this
-    /// point the register still exists and is guaranteed to have 0 users.
-    virtual void beforeRegDeleted(const Rematerializer &Remater,
-                                  RegisterIdx RegIdx) {}
-
-    friend Rematerializer;
-
   public:
     using RegisterIdx = Rematerializer::RegisterIdx;
 
+    /// Called just after register \p NewRegIdx is created (following a
+    /// rematerialization). At this point the rematerialization exists in the \p
+    /// Remater state and the MIR but does not yet have any user.
+    virtual void rematerializerNoteRegCreated(const Rematerializer &Remater,
+                                              RegisterIdx NewRegIdx) {}
+
+    /// Called juste before register \p RegIdx is deleted from the MIR. At this
+    /// point the register still exists in the MIR but no longer has any user.
+    virtual void rematerializerNoteRegDeleted(const Rematerializer &Remater,
+                                              RegisterIdx RegIdx) {}
+
     virtual ~Listener() = default;
+
+  private:
+    virtual void anchor();
   };
 
   /// Error value for register indices.
@@ -238,8 +232,19 @@ public:
   /// rematerializable register in regions.
   bool analyze(bool SupportRollback);
 
-  /// Adds a listener to the rematerializer.
-  void addListener(Listener *Listen) { Listeners.push_back(Listen); }
+  /// Adds a new listener to the rematerializer.
+  void addListener(Listener *Listen) {
+    assert(Listen && "null listener");
+    assert(!Listeners.contains(Listen) && "duplicate listener");
+    Listeners.insert(Listen);
+  }
+
+  /// Removes a listener from the rematerializer.
+  void removeListener(Listener *Listen) {
+    assert(Listeners.contains(Listen) && "unknown listener");
+    Listeners.erase(Listen);
+  }
+
   /// Removes all listeners from the rematerializer.
   void clearListeners() { Listeners.clear(); }
 
@@ -422,12 +427,16 @@ private:
   LiveIntervals &LIS;
   const TargetInstrInfo &TII;
   const TargetRegisterInfo &TRI;
-  SmallVector<Listener *, 2> Listeners;
+  SmallPtrSet<Listener *, 1> Listeners;
 
-  template <typename Callback, typename... ArgsTy>
-  void notifyListeners(Callback Cb, ArgsTy &&...Args) const {
+  void noteRegCreated(RegisterIdx RegIdx) const {
     for (Listener *Listen : Listeners)
-      (Listen->*Cb)(*this, std::forward<ArgsTy>(Args)...);
+      Listen->rematerializerNoteRegCreated(*this, RegIdx);
+  }
+
+  void noteRegDeleted(RegisterIdx RegIdx) const {
+    for (Listener *Listen : Listeners)
+      Listen->rematerializerNoteRegDeleted(*this, RegIdx);
   }
 
   /// Rematerializable registers identified since the rematerializer's creation,

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -405,7 +405,7 @@ void Rematerializer::deleteReg(RegisterIdx RegIdx) {
 
   Reg &DeleteReg = Regs[RegIdx];
   assert(DeleteReg.DefMI && "register was already deleted");
-  
+
   // It is not possible for the deleted instruction to be the upper region
   // boundary since we don't ever consider them rematerializable.
   MachineBasicBlock::iterator &RegionBegin = Regions[DeleteReg.DefRegion].first;

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -401,8 +401,11 @@ void Rematerializer::deleteRegIfUnused(RegisterIdx RootIdx) {
 }
 
 void Rematerializer::deleteReg(RegisterIdx RegIdx) {
+  notifyListeners(&Listener::beforeRegDeleted, RegIdx);
+
   Reg &DeleteReg = Regs[RegIdx];
   assert(DeleteReg.DefMI && "register was already deleted");
+  
   // It is not possible for the deleted instruction to be the upper region
   // boundary since we don't ever consider them rematerializable.
   MachineBasicBlock::iterator &RegionBegin = Regions[DeleteReg.DefRegion].first;
@@ -574,9 +577,10 @@ RegisterIdx Rematerializer::getDefRegIdx(const MachineInstr &MI) const {
 RegisterIdx Rematerializer::rematerializeReg(
     RegisterIdx RegIdx, MachineBasicBlock::iterator InsertPos,
     SmallVectorImpl<Reg::Dependency> &&Dependencies) {
-  unsigned UseRegion = MIRegion.at(&*InsertPos);
   RegisterIdx NewRegIdx = Regs.size();
+  notifyListeners(&Listener::beforeRegRematerialized, RegIdx, NewRegIdx);
 
+  unsigned UseRegion = MIRegion.at(&*InsertPos);
   Reg &NewReg = Regs.emplace_back();
   Reg &FromReg = Regs[RegIdx];
   NewReg.Mask = FromReg.Mask;
@@ -626,6 +630,8 @@ RegisterIdx Rematerializer::rematerializeReg(
     NewDepReg.addUser(NewReg.DefMI, UseRegion);
     LISUpdates.insert(NewDep.RegIdx);
   }
+
+  notifyListeners(&Listener::newRegCreated, NewRegIdx);
 
   LLVM_DEBUG({
     dbgs() << "** Rematerialized " << printID(RegIdx) << " as "

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -213,10 +213,6 @@ void Rematerializer::reviveRegIfDead(RegisterIdx RootIdx) {
 
 void Rematerializer::transferUser(RegisterIdx FromRegIdx, RegisterIdx ToRegIdx,
                                   unsigned UserRegion, MachineInstr &UserMI) {
-  assert(getReg(FromRegIdx).Uses.contains(UserRegion) && "no user in region");
-  assert(getReg(FromRegIdx).Uses.at(UserRegion).contains(&UserMI) &&
-         "not a region user");
-
   transferUserImpl(FromRegIdx, ToRegIdx, UserMI);
   Regs[FromRegIdx].eraseUser(&UserMI, UserRegion);
   Regs[ToRegIdx].addUser(&UserMI, UserRegion);
@@ -690,9 +686,8 @@ void Rematerializer::Reg::addUsers(const RegionUsers &NewUsers,
 }
 
 void Rematerializer::Reg::eraseUser(MachineInstr *MI, unsigned Region) {
-  assert(Uses.contains(Region) && "no user in region");
-  assert(Uses.at(Region).contains(MI) && "user not in region");
-  RegionUsers &RUsers = Uses[Region];
+  RegionUsers &RUsers = Uses.at(Region);
+  assert(RUsers.contains(MI) && "user not in region");
   if (RUsers.size() == 1)
     Uses.erase(Region);
   else

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -77,18 +77,22 @@ RegisterIdx Rematerializer::rematerializeToRegion(RegisterIdx RootIdx,
                                                   DependencyReuseInfo &DRI) {
   MachineInstr *FirstMI =
       getReg(RootIdx).getRegionUseBounds(UseRegion, LIS).first;
-  RegisterIdx NewRegIdx = rematerializeToPos(RootIdx, FirstMI, DRI);
+  // If there are no users in the region, rematerialize the register at the very
+  // end of the region.
+  MachineBasicBlock::iterator InsertPos =
+      FirstMI ? FirstMI : Regions[UseRegion].second;
+  RegisterIdx NewRegIdx =
+      rematerializeToPos(RootIdx, UseRegion, InsertPos, DRI);
   transferRegionUsers(RootIdx, NewRegIdx, UseRegion);
   return NewRegIdx;
 }
 
 RegisterIdx
-Rematerializer::rematerializeToPos(RegisterIdx RootIdx,
+Rematerializer::rematerializeToPos(RegisterIdx RootIdx, unsigned UseRegion,
                                    MachineBasicBlock::iterator InsertPos,
                                    DependencyReuseInfo &DRI) {
   assert(!DRI.DependencyMap.contains(RootIdx));
-  LLVM_DEBUG(dbgs() << "Rematerializing " << printID(RootIdx) << " to "
-                    << printUser(&*InsertPos) << '\n');
+  LLVM_DEBUG(dbgs() << "Rematerializing " << printID(RootIdx) << '\n');
 
   // Traverse the root's dependency DAG depth-first to find the set of
   // registers we must rematerialize along with it and a legal order to
@@ -118,7 +122,8 @@ Rematerializer::rematerializeToPos(RegisterIdx RootIdx,
     SmallVector<Reg::Dependency, 2> Dependencies;
     for (const Reg::Dependency &Dep : getReg(RegIdx).Dependencies)
       Dependencies.emplace_back(Dep.MOIdx, DRI.DependencyMap.at(Dep.RegIdx));
-    LastNewIdx = rematerializeReg(RegIdx, InsertPos, std::move(Dependencies));
+    LastNewIdx =
+        rematerializeReg(RegIdx, UseRegion, InsertPos, std::move(Dependencies));
     DRI.DependencyMap.insert({RegIdx, LastNewIdx});
   }
 
@@ -206,9 +211,12 @@ void Rematerializer::reviveRegIfDead(RegisterIdx RootIdx) {
 }
 
 void Rematerializer::transferUser(RegisterIdx FromRegIdx, RegisterIdx ToRegIdx,
-                                  MachineInstr &UserMI) {
+                                  unsigned UserRegion, MachineInstr &UserMI) {
+  assert(getReg(FromRegIdx).Uses.contains(UserRegion) && "no user in region");
+  assert(getReg(FromRegIdx).Uses.at(UserRegion).contains(&UserMI) &&
+         "not a region user");
+
   transferUserImpl(FromRegIdx, ToRegIdx, UserMI);
-  unsigned UserRegion = MIRegion.at(&UserMI);
   Regs[FromRegIdx].eraseUser(&UserMI, UserRegion);
   Regs[ToRegIdx].addUser(&UserMI, UserRegion);
   deleteRegIfUnused(FromRegIdx);
@@ -233,9 +241,6 @@ void Rematerializer::transferRegionUsers(RegisterIdx FromRegIdx,
 void Rematerializer::transferUserImpl(RegisterIdx FromRegIdx,
                                       RegisterIdx ToRegIdx,
                                       MachineInstr &UserMI) {
-  assert(MIRegion.contains(&UserMI) && "unknown user");
-  assert(getReg(FromRegIdx).Uses.at(MIRegion.at(&UserMI)).contains(&UserMI) &&
-         "not a user");
   assert(FromRegIdx != ToRegIdx && "identical registers");
   assert(getOriginOrSelf(FromRegIdx) == getOriginOrSelf(ToRegIdx) &&
          "unrelated registers");
@@ -415,7 +420,6 @@ void Rematerializer::deleteReg(RegisterIdx RegIdx) {
     RegionBegin = std::next(MachineBasicBlock::iterator(DeleteReg.DefMI));
   LIS.RemoveMachineInstrFromMaps(*DeleteReg.DefMI);
   DeleteReg.DefMI->eraseFromParent();
-  MIRegion.erase(DeleteReg.DefMI);
   DeleteReg.DefMI = nullptr;
 }
 
@@ -447,7 +451,7 @@ bool Rematerializer::analyze(bool SupportRollback) {
   UnrematableOprds.clear();
   Origins.clear();
   Rematerializations.clear();
-  MIRegion.clear();
+  RegionMBB.clear();
   RegToIdx.clear();
   LISUpdates.clear();
   Revivable.clear();
@@ -455,7 +459,12 @@ bool Rematerializer::analyze(bool SupportRollback) {
   if (Regions.empty())
     return false;
 
+  /// Maps all MIs to their parent region. Region terminators are considered
+  /// part of the region they terminate.
+  DenseMap<MachineInstr *, unsigned> MIRegion;
+
   // Initialize MI to containing region mapping.
+  RegionMBB.reserve(Regions.size());
   for (unsigned I = 0, E = Regions.size(); I < E; ++I) {
     RegionBoundaries Region = Regions[I];
     assert(Region.first != Region.second && "empty cannot be region");
@@ -463,9 +472,11 @@ bool Rematerializer::analyze(bool SupportRollback) {
       assert(!MIRegion.contains(&*MI) && "regions should not intersect");
       MIRegion.insert({&*MI, I});
     }
+    MachineBasicBlock &MBB = *Region.first->getParent();
+    RegionMBB.push_back(&MBB);
 
     // A terminator instruction is considered part of the region it terminates.
-    if (Region.second != Region.first->getParent()->end()) {
+    if (Region.second != MBB.end()) {
       MachineInstr *RegionTerm = &*Region.second;
       assert(!MIRegion.contains(RegionTerm) && "regions should not intersect");
       MIRegion.insert({RegionTerm, I});
@@ -476,7 +487,7 @@ bool Rematerializer::analyze(bool SupportRollback) {
   BitVector SeenRegs(NumVirtRegs);
   for (unsigned I = 0, E = NumVirtRegs; I != E; ++I) {
     if (!SeenRegs[I])
-      addRegIfRematerializable(I, SeenRegs);
+      addRegIfRematerializable(I, MIRegion, SeenRegs);
   }
   assert(Regs.size() == UnrematableOprds.size());
 
@@ -487,8 +498,9 @@ bool Rematerializer::analyze(bool SupportRollback) {
   return !Regs.empty();
 }
 
-void Rematerializer::addRegIfRematerializable(unsigned VirtRegIdx,
-                                              BitVector &SeenRegs) {
+void Rematerializer::addRegIfRematerializable(
+    unsigned VirtRegIdx, const DenseMap<MachineInstr *, unsigned> &MIRegion,
+    BitVector &SeenRegs) {
   assert(!SeenRegs[VirtRegIdx] && "register already seen");
   Register DefReg = Register::index2VirtReg(VirtRegIdx);
   SeenRegs.set(VirtRegIdx);
@@ -532,7 +544,7 @@ void Rematerializer::addRegIfRematerializable(unsigned VirtRegIdx,
       continue;
     unsigned DepRegIdx = DepReg.virtRegIndex();
     if (!SeenRegs[DepRegIdx])
-      addRegIfRematerializable(DepRegIdx, SeenRegs);
+      addRegIfRematerializable(DepRegIdx, MIRegion, SeenRegs);
     if (auto DepIt = RegToIdx.find(DepReg); DepIt != RegToIdx.end())
       RematReg.Dependencies.push_back(Reg::Dependency(MOIdx, DepIt->second));
     else
@@ -577,9 +589,9 @@ RegisterIdx Rematerializer::getDefRegIdx(const MachineInstr &MI) const {
 }
 
 RegisterIdx Rematerializer::rematerializeReg(
-    RegisterIdx RegIdx, MachineBasicBlock::iterator InsertPos,
+    RegisterIdx RegIdx, unsigned UseRegion,
+    MachineBasicBlock::iterator InsertPos,
     SmallVectorImpl<Reg::Dependency> &&Dependencies) {
-  unsigned UseRegion = MIRegion.at(&*InsertPos);
   RegisterIdx NewRegIdx = Regs.size();
 
   Reg &NewReg = Regs.emplace_back();
@@ -591,15 +603,14 @@ RegisterIdx Rematerializer::rematerializeReg(
   // Track rematerialization link between registers. Origins are always
   // registers that existed originally, and rematerializations are always
   // attached to them.
-  RegisterIdx OriginIdx =
-      isRematerializedRegister(RegIdx) ? getOriginOf(RegIdx) : RegIdx;
+  const RegisterIdx OriginIdx = getOriginOrSelf(RegIdx);
   Origins.push_back(OriginIdx);
   Rematerializations[OriginIdx].insert(NewRegIdx);
 
   // Use the TII to rematerialize the defining instruction with a new defined
   // register.
   Register NewDefReg = MRI.cloneVirtualRegister(FromReg.getDefReg());
-  TII.reMaterialize(*InsertPos->getParent(), InsertPos, NewDefReg, 0,
+  TII.reMaterialize(*RegionMBB[UseRegion], InsertPos, NewDefReg, 0,
                     *FromReg.DefMI);
   NewReg.DefMI = &*std::prev(InsertPos);
   RegToIdx.insert({NewDefReg, NewRegIdx});
@@ -609,7 +620,6 @@ RegisterIdx Rematerializer::rematerializeReg(
   if (Bounds.first == std::next(MachineBasicBlock::iterator(NewReg.DefMI)))
     Bounds.first = NewReg.DefMI;
   LIS.InsertMachineInstrInMaps(*NewReg.DefMI);
-  MIRegion.emplace_or_assign(NewReg.DefMI, UseRegion);
   LISUpdates.insert(NewRegIdx);
 
   // Replace dependencies as needed in the rematerialized MI. All dependencies
@@ -786,7 +796,7 @@ Printable Rematerializer::printUser(const MachineInstr *MI) const {
     if (RegIdx != NoReg)
       OS << printID(RegIdx);
     else
-      OS << "(-/-)[" << MIRegion.at(MI) << ']';
+      OS << "(-/-)[?]";
     OS << ' ';
     MI->print(OS, /*IsStandalone=*/true, /*SkipOpers=*/false,
               /*SkipDebugLoc=*/false, /*AddNewLine=*/false);

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -30,6 +30,9 @@
 using namespace llvm;
 using RegisterIdx = Rematerializer::RegisterIdx;
 
+// Pin the vtable to this file.
+void Rematerializer::Listener::anchor() {}
+
 /// Checks whether the value in \p LI at \p UseIdx is identical to \p OVNI (this
 /// implies it is also live there). When \p LI has sub-ranges, checks that
 /// all sub-ranges intersecting with \p Mask are also live at \p UseIdx.
@@ -401,11 +404,10 @@ void Rematerializer::deleteRegIfUnused(RegisterIdx RootIdx) {
 }
 
 void Rematerializer::deleteReg(RegisterIdx RegIdx) {
-  notifyListeners(&Listener::beforeRegDeleted, RegIdx);
+  noteRegDeleted(RegIdx);
 
   Reg &DeleteReg = Regs[RegIdx];
   assert(DeleteReg.DefMI && "register was already deleted");
-
   // It is not possible for the deleted instruction to be the upper region
   // boundary since we don't ever consider them rematerializable.
   MachineBasicBlock::iterator &RegionBegin = Regions[DeleteReg.DefRegion].first;
@@ -577,10 +579,9 @@ RegisterIdx Rematerializer::getDefRegIdx(const MachineInstr &MI) const {
 RegisterIdx Rematerializer::rematerializeReg(
     RegisterIdx RegIdx, MachineBasicBlock::iterator InsertPos,
     SmallVectorImpl<Reg::Dependency> &&Dependencies) {
-  RegisterIdx NewRegIdx = Regs.size();
-  notifyListeners(&Listener::beforeRegRematerialized, RegIdx, NewRegIdx);
-
   unsigned UseRegion = MIRegion.at(&*InsertPos);
+  RegisterIdx NewRegIdx = Regs.size();
+
   Reg &NewReg = Regs.emplace_back();
   Reg &FromReg = Regs[RegIdx];
   NewReg.Mask = FromReg.Mask;
@@ -631,7 +632,7 @@ RegisterIdx Rematerializer::rematerializeReg(
     LISUpdates.insert(NewDep.RegIdx);
   }
 
-  notifyListeners(&Listener::newRegCreated, NewRegIdx);
+  noteRegCreated(NewRegIdx);
 
   LLVM_DEBUG({
     dbgs() << "** Rematerialized " << printID(RegIdx) << " as "

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -24,6 +24,7 @@
 #include "llvm/CodeGen/TargetOpcodes.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/Support/Debug.h"
+#include <optional>
 
 #define DEBUG_TYPE "rematerializer"
 
@@ -783,24 +784,31 @@ Printable Rematerializer::printRematReg(RegisterIdx RegIdx,
 
 Printable Rematerializer::printRegUsers(RegisterIdx RegIdx) const {
   return Printable([&, RegIdx](raw_ostream &OS) {
-    for (const auto &[_, Users] : getReg(RegIdx).Uses) {
+    for (const auto &[UseRegion, Users] : getReg(RegIdx).Uses) {
       for (MachineInstr *MI : Users)
-        dbgs() << "  User " << printUser(MI) << '\n';
+        OS << "  User " << printUser(MI, UseRegion) << '\n';
     }
   });
 }
 
-Printable Rematerializer::printUser(const MachineInstr *MI) const {
-  return Printable([&, MI](raw_ostream &OS) {
+Printable Rematerializer::printUser(const MachineInstr *MI,
+                                    std::optional<unsigned> UseRegion) const {
+  return Printable([&, MI, UseRegion](raw_ostream &OS) {
     RegisterIdx RegIdx = getDefRegIdx(*MI);
-    if (RegIdx != NoReg)
+    if (RegIdx != NoReg) {
       OS << printID(RegIdx);
-    else
-      OS << "(-/-)[?]";
+    } else {
+      OS << "(-/-)[";
+      if (UseRegion)
+        OS << *UseRegion;
+      else
+        OS << '?';
+      OS << ']';
+    }
     OS << ' ';
     MI->print(OS, /*IsStandalone=*/true, /*SkipOpers=*/false,
               /*SkipDebugLoc=*/false, /*AddNewLine=*/false);
     OS << " @ ";
-    LIS.getInstructionIndex(*MI).print(dbgs());
+    LIS.getInstructionIndex(*MI).print(OS);
   });
 }

--- a/llvm/unittests/CodeGen/RematerializerTest.cpp
+++ b/llvm/unittests/CodeGen/RematerializerTest.cpp
@@ -271,7 +271,7 @@ body:             |
 
     DRI.clear().reuse(Cst0).reuse(Cst1);
     const RegisterIdx RematAdd01 =
-        Remater.rematerializeToPos(/*RootIdx=*/Add01, NopMI, DRI);
+        Remater.rematerializeToPos(Add01, MBB1, NopMI, DRI);
     // This adds an additional user to the used constants, and does not change
     // existing users for the original register.
     EXPECT_NO_USERS(RematAdd01);
@@ -281,14 +281,14 @@ body:             |
 
     DRI.clear();
     const RegisterIdx RematCst3 =
-        Remater.rematerializeToPos(/*RootIdx=*/Cst3, NopMI, DRI);
+        Remater.rematerializeToPos(Cst3, MBB1, NopMI, DRI);
     // This does not change existing users for the original register.
     EXPECT_NO_USERS(RematCst3);
     EXPECT_NUM_USERS(Cst3, 1);
 
     DRI.clear().useRemat(Add01, RematAdd01).useRemat(Cst3, RematCst3);
     const RegisterIdx RematAdd23 =
-        Remater.rematerializeToPos(/*RootIdx=*/Add23, NopMI, DRI);
+        Remater.rematerializeToPos(Add23, MBB1, NopMI, DRI);
     // This adds a user to used rematerializations, and does not change existing
     // users for the original register.
     EXPECT_NO_USERS(RematAdd23);
@@ -298,7 +298,7 @@ body:             |
 
     // Finally transfer the NOP user from the original to the rematerialized
     // register.
-    Remater.transferUser(Add23, RematAdd23, *NopMI);
+    Remater.transferUser(Add23, RematAdd23, MBB1, *NopMI);
     EXPECT_NO_USERS(Add23);
     EXPECT_NUM_USERS(RematAdd23, 1);
 
@@ -516,24 +516,26 @@ body:             |
   // regions are empty. %2's region ends at the end of its parent block, whereas
   // %3's region ends at a terminator MI (S_BRANCH).
   Remater.rematerializeToRegion(/*RootIdx=*/Cst2, /*UseRegion=*/MBB3, DRI);
-  Remater.rematerializeToRegion(/*RootIdx=*/Cst3, /*UseRegion=*/MBB3, DRI);
+  Remater.rematerializeToRegion(/*RootIdx=*/Cst3, /*UseRegion=*/MBB3,
+                                DRI.clear());
   RegionSizes[MBB1] -= 1;
   RegionSizes[MBB2] -= 1;
   RegionSizes[MBB3] += 2;
   ASSERT_REGION_SIZES(RegionSizes);
 
-  // We can move %0 and %1 to bb.2 because the boundary of bb.2's region points
-  // to the region terminator (S_BRANCH), which is a valid position to insert
-  // before. We couldn't move them to bb.1 however, since after %2 is
-  // rematerialized there is no MI left to reference inside the region.
-  RegisterIdx RematCst0 =
-      Remater.rematerializeToPos(/*RootIdx=*/Cst0, (*Regions)[MBB2].first, DRI);
-  RegisterIdx RematCst1 =
-      Remater.rematerializeToPos(/*RootIdx=*/Cst1, (*Regions)[MBB2].first, DRI);
+  // Move %0 to the empty MBB1 block/region.
+  const RegisterIdx RematCst0 =
+      Remater.rematerializeToRegion(Cst0, MBB1, DRI.clear());
   Remater.transferRegionUsers(Cst0, RematCst0, MBB3);
+
+  // Move %1 to the empty MBB2 region, right before the S_BRANCH terminator.
+  const RegisterIdx RematCst1 = Remater.rematerializeToPos(
+      Cst1, MBB2, (*Regions)[MBB2].first, DRI.clear());
   Remater.transferRegionUsers(Cst1, RematCst1, MBB3);
+
   RegionSizes[MBB0] -= 2;
-  RegionSizes[MBB2] += 2;
+  RegionSizes[MBB1] += 1;
+  RegionSizes[MBB2] += 1;
   ASSERT_REGION_SIZES(RegionSizes);
 
   Remater.updateLiveIntervals();


### PR DESCRIPTION
This makes the rematerializer able to rematerialize MIs at the end of a basic block. We achieve this by tracking the parent basic block of every region inside the rematerializer and adding an explicit target region to some of the class's methods. The latter removes the requirement that we track the MI of every region (`Rematerializer::MIRegion`) after the analysis phase; the class member is therefore deleted.

This new ability will be used shortly to improve the design of the rollback mechanism.

- #189491
- #189489
- #189485
- #186674
- #184341
- #184339 👈
- #184338
- `main`