### PR TITLE
[nfc][analyzer][test][z3] Replace "REQUIRES: no-z3" with "UNSUPPORTED: z3"

### DIFF
--- a/clang/test/Analysis/missing-z3-nocrash.c
+++ b/clang/test/Analysis/missing-z3-nocrash.c
@@ -1,5 +1,5 @@
 // RUN: not %clang_analyze_cc1 -analyzer-constraints=z3 %s 2>&1 | FileCheck %s
-// REQUIRES: no-z3
+// UNSUPPORTED: z3
 
 // CHECK: error: analyzer constraint manager 'z3' is only available if LLVM
 // CHECK: was built with -DLLVM_ENABLE_Z3_SOLVER=ON

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -224,8 +224,6 @@ if config.clang_staticanalyzer:
         config.available_features.add("z3")
         if config.clang_staticanalyzer_z3_mock:
             config.available_features.add("z3-mock")
-    else:
-        config.available_features.add("no-z3")
 
     check_analyzer_fixit_path = os.path.join(
         config.test_source_root, "Analysis", "check-analyzer-fixit.py"


### PR DESCRIPTION
Fixing D120325, continuing #183724

Lit feature "no-z3" is the opposite of "z3", requiring "no-z3" is the same as unsupporting "z3".