### PR TITLE
[CI][SPIRV][NFC] Remove unneccessary mkdir from workflow

### DIFF
--- a/.github/workflows/spirv-tests.yml
+++ b/.github/workflows/spirv-tests.yml
@@ -33,7 +33,6 @@ jobs:
           variant: sccache
       - name: Build and Test
         run: |
-          mkdir build
           cmake -GNinja \
             -S llvm \
             -B build \


### PR DESCRIPTION
The `CMake` command does the `mkdir` automatically.

Pointed out in https://github.com/llvm/llvm-project/pull/184174