### PR TITLE
[InstCombine] Don't strip leading zero index for overaligned vector GEP

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -3429,7 +3429,8 @@ Instruction *InstCombinerImpl::visitGetElementPtrInst(GetElementPtrInst &GEP) {
       !FirstIdx->getType()->isVectorTy()) {
     gep_type_iterator GTI = gep_type_begin(GEP);
     ++GTI;
-    if (!GTI.isStruct())
+    if (!GTI.isStruct() && GTI.getSequentialElementStride(DL) ==
+                               DL.getTypeAllocSize(GTI.getIndexedType()))
       return replaceInstUsesWith(GEP, Builder.CreateGEP(GTI.getIndexedType(),
                                                         GEP.getPointerOperand(),
                                                         drop_begin(Indices), "",

--- a/llvm/test/Transforms/InstCombine/getelementptr.ll
+++ b/llvm/test/Transforms/InstCombine/getelementptr.ll
@@ -123,6 +123,15 @@ define void @test_overaligned_vec(i8 %B) {
   ret void
 }
 
+define ptr @test_overaligned_vec_dyn(ptr %p, i64 %idx) {
+; CHECK-LABEL: @test_overaligned_vec_dyn(
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr half, ptr [[P:%.*]], i64 [[IDX:%.*]]
+; CHECK-NEXT:    ret ptr [[GEP]]
+;
+  %gep = getelementptr <2 x half>, ptr %p, i64 0, i64 %idx
+  ret ptr %gep
+}
+
 define ptr @test7(ptr %I, i64 %C, i64 %D) {
 ; CHECK-LABEL: @test7(
 ; CHECK-NEXT:    [[A:%.*]] = getelementptr i32, ptr [[I:%.*]], i64 [[C:%.*]]
@@ -680,7 +689,7 @@ entry:
 define i32 @test28() nounwind  {
 ; CHECK-LABEL: @test28(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[ORIENTATIONS:%.*]] = alloca [1 x [1 x %struct.x]], align 8
+; CHECK-NEXT:    [[ORIENTATIONS:%.*]] = alloca [1 x [1 x [[STRUCT_X:%.*]]]], align 8
 ; CHECK-NEXT:    [[T3:%.*]] = call i32 @puts(ptr noundef nonnull dereferenceable(1) @.str) #[[ATTR0]]
 ; CHECK-NEXT:    br label [[BB10:%.*]]
 ; CHECK:       bb10:

--- a/llvm/test/Transforms/InstCombine/getelementptr.ll
+++ b/llvm/test/Transforms/InstCombine/getelementptr.ll
@@ -125,7 +125,7 @@ define void @test_overaligned_vec(i8 %B) {
 
 define ptr @test_overaligned_vec_dyn(ptr %p, i64 %idx) {
 ; CHECK-LABEL: @test_overaligned_vec_dyn(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr half, ptr [[P:%.*]], i64 [[IDX:%.*]]
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr <2 x half>, ptr [[P:%.*]], i64 0, i64 [[IDX:%.*]]
 ; CHECK-NEXT:    ret ptr [[GEP]]
 ;
   %gep = getelementptr <2 x half>, ptr %p, i64 0, i64 %idx


### PR DESCRIPTION
In this case the stride is not equal to the type alloc size.

Fixes issue reported in: https://github.com/llvm/llvm-project/pull/180745#discussion_r2860093376