### PR TITLE
[MLIR][Math] Add lowering for isnormal and isinf

### DIFF
--- a/mlir/lib/Conversion/MathToLLVM/MathToLLVM.cpp
+++ b/mlir/lib/Conversion/MathToLLVM/MathToLLVM.cpp
@@ -359,14 +359,14 @@ struct RsqrtOpLowering
   }
 };
 
-struct IsNaNOpLowering
-    : public ConvertOpToLLVMPattern<math::IsNaNOp,
-                                    /*FailOnUnsupportedFP=*/true> {
+template <typename OpTy, int FPClass>
+struct IsFPClassOpLowering
+    : public ConvertOpToLLVMPattern<OpTy, /*FailOnUnsupportedFP=*/true> {
   using ConvertOpToLLVMPattern<
-      math::IsNaNOp, /*FailOnUnsupportedFP=*/true>::ConvertOpToLLVMPattern;
+      OpTy, /*FailOnUnsupportedFP=*/true>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(math::IsNaNOp op, OpAdaptor adaptor,
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     const auto &typeConverter = *this->getTypeConverter();
     auto operandType =
@@ -375,33 +375,18 @@ struct IsNaNOpLowering
     if (!operandType || !resultType)
       return failure();
 
-    rewriter.replaceOpWithNewOp<LLVM::IsFPClass>(
-        op, resultType, adaptor.getOperand(), llvm::fcNan);
+    rewriter.replaceOpWithNewOp<LLVM::IsFPClass>(op, resultType,
+                                                 adaptor.getOperand(), FPClass);
     return success();
   }
 };
 
-struct IsFiniteOpLowering
-    : public ConvertOpToLLVMPattern<math::IsFiniteOp,
-                                    /*FailOnUnsupportedFP=*/true> {
-  using ConvertOpToLLVMPattern<
-      math::IsFiniteOp, /*FailOnUnsupportedFP=*/true>::ConvertOpToLLVMPattern;
-
-  LogicalResult
-  matchAndRewrite(math::IsFiniteOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    const auto &typeConverter = *this->getTypeConverter();
-    auto operandType =
-        typeConverter.convertType(adaptor.getOperand().getType());
-    auto resultType = typeConverter.convertType(op.getResult().getType());
-    if (!operandType || !resultType)
-      return failure();
-
-    rewriter.replaceOpWithNewOp<LLVM::IsFPClass>(
-        op, resultType, adaptor.getOperand(), llvm::fcFinite);
-    return success();
-  }
-};
+using IsNaNOpLowering = IsFPClassOpLowering<math::IsNaNOp, llvm::fcNan>;
+using IsFiniteOpLowering =
+    IsFPClassOpLowering<math::IsFiniteOp, llvm::fcFinite>;
+using IsNormalOpLowering =
+    IsFPClassOpLowering<math::IsNormalOp, llvm::fcNormal>;
+using IsInfOpLowering = IsFPClassOpLowering<math::IsInfOp, llvm::fcInf>;
 
 struct ConvertMathToLLVMPass
     : public impl::ConvertMathToLLVMPassBase<ConvertMathToLLVMPass> {
@@ -428,6 +413,8 @@ void mlir::populateMathToLLVMConversionPatterns(
   patterns.add<
     IsNaNOpLowering,
     IsFiniteOpLowering,
+    IsNormalOpLowering,
+    IsInfOpLowering,
     AbsFOpLowering,
     AbsIOpLowering,
     CeilOpLowering,

--- a/mlir/test/Conversion/MathToLLVM/math-to-llvm.mlir
+++ b/mlir/test/Conversion/MathToLLVM/math-to-llvm.mlir
@@ -466,6 +466,26 @@ func.func @isfinite_0dvector(%arg0 : vector<f32>) {
 
 // -----
 
+// CHECK-LABEL: func @isnormal_double(
+// CHECK-SAME: f64
+func.func @isnormal_double(%arg0 : f64) {
+  // CHECK: "llvm.intr.is.fpclass"(%arg0) <{bit = 264 : i32}> : (f64) -> i1
+  %0 = math.isnormal %arg0 : f64
+  func.return
+}
+
+// -----
+
+// CHECK-LABEL: func @isinf_double(
+// CHECK-SAME: f64
+func.func @isinf_double(%arg0 : f64) {
+  // CHECK: "llvm.intr.is.fpclass"(%arg0) <{bit = 516 : i32}> : (f64) -> i1
+  %0 = math.isinf %arg0 : f64
+  func.return
+}
+
+// -----
+
 // CHECK-LABEL: func @rsqrt_double(
 // CHECK-SAME: f64
 func.func @rsqrt_double(%arg0 : f64) {


### PR DESCRIPTION
Summary of changes:
1. Refactored duplicate code for IsNaNOpLowering and IsFiniteOpLowering into a template class IsFPClassOpLowering for better maintainability.
2. Added lowering support for isnormal and isinf via IsNormalOpLowering and IsInfOpLowering.
