### PR TITLE
[Github] Bump clang-format/clang-tidy to v22.1.0

### DIFF
--- a/.github/workflows/containers/github-action-ci-tooling/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-tooling/Dockerfile
@@ -1,6 +1,6 @@
-ARG LLVM_VERSION=21.1.8
+ARG LLVM_VERSION=22.1.0
 # FIXME: Use "${LLVM_VERSION%%.*}" instead of "LLVM_VERSION_MAJOR" once we update runners to Ubuntu-26.04 with Buildah >= 1.37
-ARG LLVM_VERSION_MAJOR=21
+ARG LLVM_VERSION_MAJOR=22
 
 FROM docker.io/library/ubuntu:24.04 AS llvm-downloader
 ARG LLVM_VERSION


### PR DESCRIPTION
Per the version policy for these tools to bump them at the beginning of the release cycle and at the end of the release cycle.