### PR TITLE
[ELF] Move PPC32Got2Section into Arch/PPC.cpp

### DIFF
--- a/lld/ELF/Arch/PPC.cpp
+++ b/lld/ELF/Arch/PPC.cpp
@@ -59,6 +59,18 @@ private:
   void relaxTlsLdToLe(uint8_t *loc, const Relocation &rel, uint64_t val) const;
   void relaxTlsIeToLe(uint8_t *loc, const Relocation &rel, uint64_t val) const;
 };
+
+// Used to compute outSecOff of .got2 in each object file. This is needed to
+// synthesize PLT entries for PPC32 Secure PLT ABI.
+struct Got2Section : SyntheticSection {
+  Got2Section(Ctx &ctx)
+      : SyntheticSection(ctx, ".got2", SHT_PROGBITS, SHF_ALLOC | SHF_WRITE, 4) {
+  }
+  bool isNeeded() const override;
+  size_t getSize() const override { return 0; }
+  void writeTo(uint8_t *buf) override {}
+  void finalizeContents() override;
+};
 } // namespace
 
 static uint16_t lo(uint32_t v) { return v; }
@@ -181,6 +193,11 @@ PPC::PPC(Ctx &ctx) : TargetInfo(ctx) {
   write32(ctx, trapInstr.data(), 0x7fe00008);
 }
 
+void PPC::initTargetSpecificSections() {
+  ctx.in.ppc32Got2 = std::make_unique<Got2Section>(ctx);
+  ctx.inputSections.push_back(ctx.in.ppc32Got2.get());
+}
+
 void PPC::writeIplt(uint8_t *buf, const Symbol &sym,
                     uint64_t /*pltEntryAddr*/) const {
   // In -pie or -shared mode, assume r30 points to .got2+0x8000, and use a
@@ -219,11 +236,6 @@ bool PPC::inBranchRange(RelType type, uint64_t src, uint64_t dst) const {
   if (type == R_PPC_LOCAL24PC || type == R_PPC_REL24 || type == R_PPC_PLTREL24)
     return isInt<26>(offset);
   llvm_unreachable("unsupported relocation type used in branch");
-}
-
-void PPC::initTargetSpecificSections() {
-  ctx.in.ppc32Got2 = std::make_unique<PPC32Got2Section>(ctx);
-  ctx.inputSections.push_back(ctx.in.ppc32Got2.get());
 }
 
 // Only needed to support relocations used by relocateNonAlloc and
@@ -607,3 +619,27 @@ void PPC::relaxTlsIeToLe(uint8_t *loc, const Relocation &rel,
 }
 
 void elf::setPPCTargetInfo(Ctx &ctx) { ctx.target.reset(new PPC(ctx)); }
+
+bool Got2Section::isNeeded() const {
+  for (SectionCommand *cmd : getParent()->commands)
+    if (auto *isd = dyn_cast<InputSectionDescription>(cmd))
+      for (InputSection *isec : isd->sections)
+        if (isec != this)
+          return true;
+  return false;
+}
+
+void Got2Section::finalizeContents() {
+  // PPC32 may create multiple GOT sections for -fPIC/-fPIE, one per file in
+  // .got2 . This function computes outSecOff of each .got2 to be used in
+  // PPC32PltCallStub::writeTo(). The purpose of this empty synthetic section is
+  // to collect input sections named ".got2".
+  for (SectionCommand *cmd : getParent()->commands)
+    if (auto *isd = dyn_cast<InputSectionDescription>(cmd)) {
+      for (InputSection *isec : isd->sections) {
+        // isec->file may be nullptr for MergeSyntheticSection.
+        if (isec != this && isec->file)
+          isec->file->ppc32Got2 = isec;
+      }
+    }
+}

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -4283,35 +4283,6 @@ bool ThunkSection::assignOffsets() {
   return changed;
 }
 
-PPC32Got2Section::PPC32Got2Section(Ctx &ctx)
-    : SyntheticSection(ctx, ".got2", SHT_PROGBITS, SHF_ALLOC | SHF_WRITE, 4) {}
-
-bool PPC32Got2Section::isNeeded() const {
-  // See the comment below. This is not needed if there is no other
-  // InputSection.
-  for (SectionCommand *cmd : getParent()->commands)
-    if (auto *isd = dyn_cast<InputSectionDescription>(cmd))
-      for (InputSection *isec : isd->sections)
-        if (isec != this)
-          return true;
-  return false;
-}
-
-void PPC32Got2Section::finalizeContents() {
-  // PPC32 may create multiple GOT sections for -fPIC/-fPIE, one per file in
-  // .got2 . This function computes outSecOff of each .got2 to be used in
-  // PPC32PltCallStub::writeTo(). The purpose of this empty synthetic section is
-  // to collect input sections named ".got2".
-  for (SectionCommand *cmd : getParent()->commands)
-    if (auto *isd = dyn_cast<InputSectionDescription>(cmd)) {
-      for (InputSection *isec : isd->sections) {
-        // isec->file may be nullptr for MergeSyntheticSection.
-        if (isec != this && isec->file)
-          isec->file->ppc32Got2 = isec;
-      }
-    }
-}
-
 // If linking position-dependent code then the table will store the addresses
 // directly in the binary so the section has type SHT_PROGBITS. If linking
 // position-independent code the section has type SHT_NOBITS since it will be

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -1345,17 +1345,6 @@ private:
   uint64_t newEntries = 0;
 };
 
-// Used to compute outSecOff of .got2 in each object file. This is needed to
-// synthesize PLT entries for PPC32 Secure PLT ABI.
-class PPC32Got2Section final : public SyntheticSection {
-public:
-  PPC32Got2Section(Ctx &);
-  size_t getSize() const override { return 0; }
-  bool isNeeded() const override;
-  void finalizeContents() override;
-  void writeTo(uint8_t *buf) override {}
-};
-
 // This section is used to store the addresses of functions that are called
 // in range-extending thunks on PowerPC64. When producing position dependent
 // code the addresses are link-time constants and the table is written out to


### PR DESCRIPTION
Move PPC32Got2Section from SyntheticSections.h/cpp into the anonymous
namespace in Arch/PPC.cpp, renaming it to Got2Section.

Extracted from #184292. Moved initTargetSpecificSections after ctor and
before other hooks to match the linker's pass order.