### PR TITLE
[clang-tidy] Don't report unnamed params for misc-const-correctness

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
@@ -23,6 +23,12 @@ namespace {
 // FIXME: This matcher exists in some other code-review as well.
 // It should probably move to ASTMatchers.
 AST_MATCHER(VarDecl, isLocal) { return Node.isLocalVarDecl(); }
+// FIXME: The matcher 'hasName(Name)' asserts that its argument 'Name' is
+// nonempty. Perhaps remove that assertion and replace 'isUnnamed()' with
+// 'hasName("")'.
+AST_MATCHER(VarDecl, isUnnamed) {
+  return Node.getDeclName().isIdentifier() && Node.getName().empty();
+}
 AST_MATCHER_P(DeclStmt, containsAnyDeclaration,
               ast_matchers::internal::Matcher<Decl>, InnerMatcher) {
   return ast_matchers::internal::matchesFirstInPointerRange(
@@ -148,7 +154,7 @@ void ConstCorrectnessCheck::registerMatchers(MatchFinder *Finder) {
 
   if (AnalyzeParameters) {
     const auto ParamMatcher =
-        parmVarDecl(unless(CommonExcludeTypes),
+        parmVarDecl(unless(CommonExcludeTypes), unless(isUnnamed()),
                     anyOf(hasType(referenceType()), hasType(pointerType())))
             .bind("value");
 
@@ -206,13 +212,6 @@ void ConstCorrectnessCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *VarDeclStmt = Result.Nodes.getNodeAs<DeclStmt>("decl-stmt");
 
   assert(Variable && LocalScope && Function);
-
-  // If a variable (e.g. function parameter) is unnamed, don't report it. Being
-  // unnamed already guarantees that the variable can't be accessed, so
-  // 'const'ness (can't be modified) doesn't add extra information. Also, the
-  // messages would be awkward in this case.
-  if (Variable->getDeclName().isIdentifier() && Variable->getName().empty())
-    return;
 
   // It can not be guaranteed that the variable is declared isolated,
   // therefore a transformation might effect the other variables as well and

--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
@@ -207,6 +207,13 @@ void ConstCorrectnessCheck::check(const MatchFinder::MatchResult &Result) {
 
   assert(Variable && LocalScope && Function);
 
+  // If a variable (e.g. function parameter) is unnamed, don't report it. Being
+  // unnamed already guarantees that the variable can't be accessed, so
+  // 'const'ness (can't be modified) doesn't add extra information. Also, the
+  // messages would be awkward in this case.
+  if (Variable->getDeclName().isIdentifier() && Variable->getName().empty())
+    return;
+
   // It can not be guaranteed that the variable is declared isolated,
   // therefore a transformation might effect the other variables as well and
   // be incorrect. Parameters don't need this check - they receive values from

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/const-correctness.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/const-correctness.rst
@@ -110,15 +110,15 @@ Options
 
   Enable or disable the analysis of function parameters, like
   ``void foo(int* ptr)``. Only reference and pointer parameters are analyzed.
-  Currently, member functions (including constructors) and lambdas are excluded
-  from the analysis. Default is `true`.
+  Unnamed parameters, member functions (including constructors) and lambdas are
+  excluded from the analysis. Default is `true`.
 
   .. code-block:: c++
 
     // Warning
     void function(int& param) {}
     // No warning
-    void function(const int& param) {}
+    void function(const int& param, int&) {}
 
 .. option:: WarnPointersAsValues
 

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-parameters.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-parameters.cpp
@@ -509,3 +509,7 @@ void struct_ptr_param_modified(Bar** bp) {
   // CHECK-FIXES: void struct_ptr_param_modified(Bar** const bp) {
   (*bp)->mutating_method();
 }
+
+void unnamed_parameters(int, char *, Bar, Bar&, int[5]) {
+    // Unnamed parameters are never reported.
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-parameters.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-parameters.cpp
@@ -510,6 +510,33 @@ void struct_ptr_param_modified(Bar** bp) {
   (*bp)->mutating_method();
 }
 
-void unnamed_parameters(int, char *, Bar, Bar&, int[5]) {
-    // Unnamed parameters are never reported.
+void unnamed_parameters(int&, char*, Bar, Bar&, int[5]) {
+  // Unnamed parameters are never reported.
+}
+
+void unnamed_and_named_irrelevant_params(const int& X, char*, Bar Z, Bar&, int[5]) {
+  // No report, all parameters are excluded for various reasons.
+}
+
+void unnamed_and_named_params(int& X, int&) {
+  // But a named parameter is reported even if it is next to an unnamed one.
+  // CHECK-MESSAGES: [[@LINE-2]]:31: warning: variable 'X' of type 'int &' can be declared 'const'
+  // CHECK-FIXES: void unnamed_and_named_params(int const& X, int&) {
+}
+
+// If the parameter is named in the definition, its type will be updated in all
+// declarations, inclunding ones where it is unnamed.
+void unnamed_in_decl_named_in_def(int&);
+// CHECK-FIXES: void unnamed_in_decl_named_in_def(int const&);
+
+void unnamed_in_decl_named_in_def(int& X) {
+  // CHECK-MESSAGES: [[@LINE-1]]:35: warning: variable 'X' of type 'int &' can be declared 'const'
+  // CHECK-FIXES: void unnamed_in_decl_named_in_def(int const& X) {
+}
+
+void named_in_decl_unnamed_in_def(int& X);
+
+void named_in_decl_unnamed_in_def(int&) {
+  // If the parameter is unnamed in the definition, it will not be reported, even
+  // if it is named in some declaration.
 }


### PR DESCRIPTION
Previously misc-const-correctness warned about non-const unnamed parameters; but this commit excludes them because these warnings are not actually useful. An unnamed parameter cannot be referenced at all, so marking them as 'const' doesn't add additional information.

Also the diagnostic messages look awkward without a name.

Fixes #184330