### PR TITLE
[flang][acc] Improve clause validity check around do concurrent

### DIFF
--- a/flang/lib/Semantics/canonicalize-acc.cpp
+++ b/flang/lib/Semantics/canonicalize-acc.cpp
@@ -98,10 +98,14 @@ private:
     const auto &accClauseList =
         std::get<parser::AccClauseList>(beginLoopDirective.t);
     for (const auto &clause : accClauseList.v) {
-      if (std::holds_alternative<parser::AccClause::Collapse>(clause.u) ||
-          std::holds_alternative<parser::AccClause::Tile>(clause.u)) {
+      if (std::holds_alternative<parser::AccClause::Tile>(clause.u)) {
         messages_.Say(beginLoopDirective.source,
-            "TILE and COLLAPSE clause may not appear on loop construct "
+            "TILE clause may not appear on loop construct "
+            "associated with DO CONCURRENT"_err_en_US);
+      }
+      if (std::holds_alternative<parser::AccClause::Collapse>(clause.u)) {
+        messages_.Say(beginLoopDirective.source,
+            "COLLAPSE clause may not appear on loop construct "
             "associated with DO CONCURRENT"_err_en_US);
       }
     }

--- a/flang/test/Semantics/OpenACC/acc-canonicalization-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-canonicalization-validity.f90
@@ -85,7 +85,7 @@ program openacc_clause_validity
   end do
 
   !$acc parallel
-  !ERROR: TILE and COLLAPSE clause may not appear on loop construct associated with DO CONCURRENT
+  !ERROR: COLLAPSE clause may not appear on loop construct associated with DO CONCURRENT
   !$acc loop collapse(2)
   do concurrent (i = 1:N, j = 1:N)
     aa(i, j) = 3.14
@@ -93,8 +93,17 @@ program openacc_clause_validity
   !$acc end parallel
 
   !$acc parallel
-  !ERROR: TILE and COLLAPSE clause may not appear on loop construct associated with DO CONCURRENT
+  !ERROR: TILE clause may not appear on loop construct associated with DO CONCURRENT
   !$acc loop tile(2, 2)
+  do concurrent (i = 1:N, j = 1:N)
+    aa(i, j) = 3.14
+  end do
+  !$acc end parallel
+
+  !$acc parallel
+  !ERROR: TILE clause may not appear on loop construct associated with DO CONCURRENT
+  !ERROR: COLLAPSE clause may not appear on loop construct associated with DO CONCURRENT
+  !$acc loop tile(2, 2) collapse(2)
   do concurrent (i = 1:N, j = 1:N)
     aa(i, j) = 3.14
   end do


### PR DESCRIPTION
The current validity message prints out both "TILE" and "COLLAPSE" even if just one of them is used. This makes it confusing if the user only used one of them. This improves the messages to be precise which clause is not allowed (and separate messages are issued when both clauses are used).