### PR TITLE
[AArch64] Fix relative vtable PLT/GOTPCREL specifiers to use MCSpecifierExpr

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetObjectFile.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetObjectFile.cpp
@@ -25,7 +25,7 @@ using namespace dwarf;
 void AArch64_ELFTargetObjectFile::Initialize(MCContext &Ctx,
                                              const TargetMachine &TM) {
   TargetLoweringObjectFileELF::Initialize(Ctx, TM);
-  PLTRelativeSpecifier = AArch64::S_PLT;
+  PLTPCRelativeSpecifier = AArch64::S_PLT;
   SupportIndirectSymViaGOTPCRel = true;
 
   // AARCH64 ELF ABI does not define static relocation type for TLS offset
@@ -59,11 +59,12 @@ void AArch64_ELFTargetObjectFile::emitPersonalityValueImpl(
 const MCExpr *AArch64_ELFTargetObjectFile::getIndirectSymViaGOTPCRel(
     const GlobalValue *GV, const MCSymbol *Sym, const MCValue &MV,
     int64_t Offset, MachineModuleInfo *MMI, MCStreamer &Streamer) const {
-  int64_t FinalOffset = Offset + MV.getConstant();
-  const MCExpr *Res =
-      MCSymbolRefExpr::create(Sym, AArch64::S_GOTPCREL, getContext());
-  const MCExpr *Off = MCConstantExpr::create(FinalOffset, getContext());
-  return MCBinaryExpr::createAdd(Res, Off, getContext());
+  auto &Ctx = getContext();
+  const MCExpr *Res = MCSymbolRefExpr::create(Sym, Ctx);
+  if (int64_t FinalOffset = Offset + MV.getConstant())
+    Res = MCBinaryExpr::createAdd(Res, MCConstantExpr::create(FinalOffset, Ctx),
+                                  Ctx);
+  return MCSpecifierExpr::create(Res, AArch64::S_GOTPCREL, Ctx);
 }
 
 AArch64_MachoTargetObjectFile::AArch64_MachoTargetObjectFile() {

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
@@ -38,9 +38,6 @@ const MCAsmInfo::AtSpecifier COFFAtSpecifiers[] = {
 
 const MCAsmInfo::AtSpecifier ELFAtSpecifiers[] = {
     {AArch64::S_GOT, "GOT"},
-    {AArch64::S_GOTPCREL, "GOTPCREL"},
-    {AArch64::S_PLT, "PLT"},
-    {AArch64::S_FUNCINIT, "FUNCINIT"},
 };
 
 const MCAsmInfo::AtSpecifier MachOAtSpecifiers[] = {

--- a/llvm/test/CodeGen/AArch64/dso_local_equivalent.ll
+++ b/llvm/test/CodeGen/AArch64/dso_local_equivalent.ll
@@ -1,0 +1,39 @@
+; RUN: llc -mtriple=aarch64 < %s | FileCheck %s --match-full-lines
+
+declare void @extern_func()
+
+; CHECK-LABEL: const:
+; CHECK-NEXT:    .word   %pltpcrel(extern_func)
+
+@const = dso_local constant i32 trunc (i64 sub (i64 ptrtoint (ptr dso_local_equivalent @extern_func to i64), i64 ptrtoint (ptr @const to i64)) to i32)
+
+@_ZTV1B = dso_local constant { [7 x i32] } { [7 x i32] [
+  i32 0,
+  i32 0,
+  i32 trunc (i64 sub (i64 ptrtoint (ptr dso_local_equivalent @f0 to i64), i64 ptrtoint (ptr getelementptr inbounds ({ [7 x i32] }, ptr @_ZTV1B, i32 0, i32 0, i32 2) to i64)) to i32),
+  i32 trunc (i64 sub (i64 ptrtoint (ptr dso_local_equivalent @f1 to i64), i64 ptrtoint (ptr getelementptr inbounds ({ [7 x i32] }, ptr @_ZTV1B, i32 0, i32 0, i32 2) to i64)) to i32),
+  i32 trunc (i64 sub (i64 ptrtoint (ptr dso_local_equivalent @f2 to i64), i64 ptrtoint (ptr getelementptr inbounds ({ [7 x i32] }, ptr @_ZTV1B, i32 0, i32 0, i32 2) to i64)) to i32),
+  i32 trunc (i64 sub (i64 ptrtoint (ptr dso_local_equivalent @f3 to i64), i64 ptrtoint (ptr getelementptr inbounds ({ [7 x i32] }, ptr @_ZTV1B, i32 0, i32 0, i32 2) to i64)) to i32),
+  i32 trunc (i64 sub (i64 ptrtoint (ptr dso_local_equivalent @f4 to i64), i64 ptrtoint (ptr getelementptr inbounds ({ [7 x i32] }, ptr @_ZTV1B, i32 0, i32 0, i32 2) to i64)) to i32)
+] }, align 4
+
+; CHECK-LABEL: _ZTV1B:
+; CHECK-NEXT:    .word   0                               // 0x0
+; CHECK-NEXT:    .word   0                               // 0x0
+; CHECK-NEXT:    .word   %pltpcrel(f0)
+; CHECK-NEXT:    .word   %pltpcrel(f1+4)
+; CHECK-NEXT:    .word   %pltpcrel(f2+8)
+; CHECK-NEXT:    .word   %pltpcrel(f3+12)
+; CHECK-NEXT:    .word   %pltpcrel(f4+16)
+; CHECK-NEXT:    .size   _ZTV1B, 28
+declare void @f0()
+declare void @f1()
+define dso_local void @f2() {
+  ret void
+}
+define void @f3() {
+  ret void
+}
+define hidden void @f4() {
+  ret void
+}

--- a/llvm/test/MC/ELF/rtti-proxy-gotpcrel.ll
+++ b/llvm/test/MC/ELF/rtti-proxy-gotpcrel.ll
@@ -1,7 +1,7 @@
 ; REQUIRES: x86-registered-target && aarch64-registered-target && riscv-registered-target
 ; RUN: llc %s -mtriple=x86_64 -o - | FileCheck %s
-; RUN: llc %s -mtriple=aarch64 -o - | FileCheck %s
-; RUN: llc %s -mtriple=riscv64 -o - | FileCheck %s --check-prefix=RISCV
+; RUN: llc %s -mtriple=aarch64 -o - | FileCheck %s --check-prefix=SPECIFIER
+; RUN: llc %s -mtriple=riscv64 -o - | FileCheck %s --check-prefix=SPECIFIER
 
 @vtable = dso_local unnamed_addr constant i32 trunc (i64 sub (i64 ptrtoint (ptr @rtti.proxy to i64), i64 ptrtoint (ptr @vtable to i64)) to i32), align 4
 @vtable_with_offset = dso_local unnamed_addr constant [2 x i32] [i32 0, i32 trunc (i64 sub (i64 ptrtoint (ptr @rtti.proxy to i64), i64 ptrtoint (ptr @vtable_with_offset to i64)) to i32)], align 4
@@ -29,11 +29,11 @@
 ; CHECK-NEXT:    .{{word|long}}   rtti@GOTPCREL-4{{$}}
 ; CHECK-NEXT:    .{{word|long}}   0
 
-; RISCV-LABEL: vtable:
-; RISCV-NEXT:    .word   %gotpcrel(rtti+0)
-; RISCV-LABEL: vtable_with_offset:
-; RISCV-NEXT:    .word   0
-; RISCV-NEXT:    .word   %gotpcrel(rtti+4)
-; RISCV-LABEL: vtable_with_negative_offset:
-; RISCV-NEXT:    .word   %gotpcrel(rtti-4)
-; RISCV-NEXT:    .word   0
+; SPECIFIER-LABEL: vtable:
+; SPECIFIER-NEXT:    .word   %gotpcrel(rtti{{(\+0)?}})
+; SPECIFIER-LABEL: vtable_with_offset:
+; SPECIFIER-NEXT:    .word   0
+; SPECIFIER-NEXT:    .word   %gotpcrel(rtti+4)
+; SPECIFIER-LABEL: vtable_with_negative_offset:
+; SPECIFIER-NEXT:    .word   %gotpcrel(rtti-4)
+; SPECIFIER-NEXT:    .word   0


### PR DESCRIPTION
PR #155776 changed S_PLT/S_GOTPCREL printing to %pltpcrel(x)/%gotpcrel(x)
syntax via MCSpecifierExpr, but lowerSymbolDifference and
getIndirectSymViaGOTPCRel still created MCSymbolRefExpr with these
specifiers, which prints via the @-specifier table as @PLT/@GOTPCREL,
leading to incorrect relocation types.

Fixes: bed89970c3df5e755820708580e405f65ddaa1ba
(AArch64: Replace @plt/%gotpcrel in data directives with %pltpcrel %gotpcrel (#155776))

Add llvm/test/CodeGen/AArch64/dso_local_equivalent.ll