### PR TITLE
[X86] vector-shuffle-combining-xop.ll - tests showing failure to combine shuffles with non-uniform rotates

### DIFF
--- a/llvm/test/CodeGen/X86/vector-shuffle-combining-xop.ll
+++ b/llvm/test/CodeGen/X86/vector-shuffle-combining-xop.ll
@@ -249,6 +249,24 @@ define <16 x i8> @combine_vpperm_as_proti_v8i16(<16 x i8> %a0, <16 x i8> %a1) {
   ret <16 x i8> %res0
 }
 
+define <16 x i8> @combine_shuffle_prot_v2i64(<2 x i64> %a0) {
+; X86-LABEL: combine_shuffle_prot_v2i64:
+; X86:       # %bb.0:
+; X86-NEXT:    vprotq {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm0
+; X86-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0]
+; X86-NEXT:    retl
+;
+; X64-LABEL: combine_shuffle_prot_v2i64:
+; X64:       # %bb.0:
+; X64-NEXT:    vprotq {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0]
+; X64-NEXT:    retq
+  %1 = call <2 x i64> @llvm.fshr.v2i64(<2 x i64> %a0, <2 x i64> %a0, <2 x i64> <i64 56, i64 16>)
+  %2 = bitcast <2 x i64> %1 to <16 x i8>
+  %3 = shufflevector <16 x i8> %2, <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+  ret <16 x i8> %3
+}
+
 define <16 x i8> @combine_shuffle_proti_v2i64(<2 x i64> %a0) {
 ; CHECK-LABEL: combine_shuffle_proti_v2i64:
 ; CHECK:       # %bb.0:
@@ -260,6 +278,24 @@ define <16 x i8> @combine_shuffle_proti_v2i64(<2 x i64> %a0) {
   ret <16 x i8> %3
 }
 declare <2 x i64> @llvm.fshr.v2i64(<2 x i64>, <2 x i64>, <2 x i64>)
+
+define <16 x i8> @combine_shuffle_prot_v4i32(<4 x i32> %a0) {
+; X86-LABEL: combine_shuffle_prot_v4i32:
+; X86:       # %bb.0:
+; X86-NEXT:    vprotd {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0, %xmm0
+; X86-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0]
+; X86-NEXT:    retl
+;
+; X64-LABEL: combine_shuffle_prot_v4i32:
+; X64:       # %bb.0:
+; X64-NEXT:    vprotd {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm0
+; X64-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0]
+; X64-NEXT:    retq
+  %1 = call <4 x i32> @llvm.fshl.v4i32(<4 x i32> %a0, <4 x i32> %a0, <4 x i32> <i32 0, i32 8, i32 16, i32 24>)
+  %2 = bitcast <4 x i32> %1 to <16 x i8>
+  %3 = shufflevector <16 x i8> %2, <16 x i8> undef, <16 x i32> <i32 15, i32 14, i32 13, i32 12, i32 11, i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1, i32 0>
+  ret <16 x i8> %3
+}
 
 define <16 x i8> @combine_shuffle_proti_v4i32(<4 x i32> %a0) {
 ; CHECK-LABEL: combine_shuffle_proti_v4i32:


### PR DESCRIPTION
We only handle this for VROTLI/VROTRI nodes

Noticed while working on #184002