### PR TITLE
[lldb] Prevent concurrent calls to dlopen in PlatformPOSIX

### DIFF
--- a/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -685,6 +685,10 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
                                     const std::vector<std::string> *paths,
                                     lldb_private::Status &error,
                                     lldb_private::FileSpec *loaded_image) {
+  // The dlopen setup/calling code cannot be called concurrently on the same
+  // process.
+  std::lock_guard<std::mutex> locker(m_dlopen_mutex);
+
   if (loaded_image)
     loaded_image->Clear();
 

--- a/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.h
+++ b/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.h
@@ -81,6 +81,14 @@ protected:
            std::unique_ptr<lldb_private::OptionGroupOptions>>
       m_options;
 
+  /// Prevents multiple dlopen calls to the same target.
+  /// Running dlopen on the target can only be done by one thread at a time as
+  /// the dlopen call setup process requires the target to be stopped, and
+  /// calling dlopen runs the target for a brief moment.
+  /// While we could allow parallel dlopen calls on different processes, the
+  /// fact that we call dlopen at all is specific to this class.
+  std::mutex m_dlopen_mutex;
+
   lldb_private::Status
   EvaluateLibdlExpression(lldb_private::Process *process, const char *expr_cstr,
                           llvm::StringRef expr_prefix,


### PR DESCRIPTION
LLDB calls `dlopen` to open dylibs. The setup code for preparing the `dlopen` call assumes that the target is not running, but calling `dlopen` will run the target for a brief moment. This means that the code cannot be called concurrently on the same process as on `dlopen` call might cause the other `dlopen` call to fail as the target is already running.

Fix this by putting a lock around the code in PlatformPOSIX. This lock is a bit larger than necessary as we could allow concurrent dlopen calls on different processes, but the fact we call dlopen is really an implementation detail of PlatformPOSIX.

This should fix the random failures in TestSwiftLazyFramework in downstream Swift. I don't see a way to reach this code with multiple threads on standard LLDB.