### PR TITLE
[X86] known-never-zero.ll - improve demandedelts test coverage for #183227

### DIFF
--- a/llvm/test/CodeGen/X86/known-never-zero.ll
+++ b/llvm/test/CodeGen/X86/known-never-zero.ll
@@ -1481,38 +1481,45 @@ define i32 @udiv_known_nonzero(i32 %xx, i32 %y) {
 define i32 @udiv_known_nonzero_vec(<4 x i32> %xx, <4 x i32> %y, ptr %p) nounwind {
 ; X86-LABEL: udiv_known_nonzero_vec:
 ; X86:       # %bb.0:
+; X86-NEXT:    pushl %edi
 ; X86-NEXT:    pushl %esi
-; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %esi
 ; X86-NEXT:    por {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0
-; X86-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[3,3,3,3]
-; X86-NEXT:    movd %xmm2, %esi
+; X86-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[1,1,1,1]
+; X86-NEXT:    movd %xmm2, %ecx
 ; X86-NEXT:    movl $-1, %eax
 ; X86-NEXT:    xorl %edx, %edx
-; X86-NEXT:    divl %esi
+; X86-NEXT:    divl %ecx
 ; X86-NEXT:    movd %eax, %xmm3
-; X86-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X86-NEXT:    movd %xmm2, %esi
-; X86-NEXT:    movl $-1, %eax
-; X86-NEXT:    xorl %edx, %edx
-; X86-NEXT:    divl %esi
-; X86-NEXT:    movd %eax, %xmm2
-; X86-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; X86-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[1,1,1,1]
-; X86-NEXT:    movd %xmm3, %esi
-; X86-NEXT:    movl $-1, %eax
-; X86-NEXT:    xorl %edx, %edx
-; X86-NEXT:    divl %esi
-; X86-NEXT:    movd %eax, %xmm3
-; X86-NEXT:    movd %xmm1, %esi
+; X86-NEXT:    movd %xmm1, %ecx
 ; X86-NEXT:    movd %xmm0, %eax
 ; X86-NEXT:    xorl %edx, %edx
-; X86-NEXT:    divl %esi
+; X86-NEXT:    divl %ecx
+; X86-NEXT:    movl %eax, %ecx
+; X86-NEXT:    movd %eax, %xmm2
+; X86-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
+; X86-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[3,3,3,3]
+; X86-NEXT:    movd %xmm3, %edi
+; X86-NEXT:    pshufd {{.*#+}} xmm3 = xmm0[3,3,3,3]
+; X86-NEXT:    movd %xmm3, %eax
+; X86-NEXT:    xorl %edx, %edx
+; X86-NEXT:    divl %edi
+; X86-NEXT:    movd %eax, %xmm3
+; X86-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[2,3,2,3]
+; X86-NEXT:    movd %xmm1, %edi
+; X86-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[2,3,2,3]
+; X86-NEXT:    movd %xmm0, %eax
+; X86-NEXT:    xorl %edx, %edx
+; X86-NEXT:    divl %edi
 ; X86-NEXT:    movd %eax, %xmm0
 ; X86-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
-; X86-NEXT:    punpcklqdq {{.*#+}} xmm0 = xmm0[0],xmm2[0]
-; X86-NEXT:    movdqa %xmm0, (%ecx)
-; X86-NEXT:    rep bsfl %eax, %eax
+; X86-NEXT:    punpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm0[0]
+; X86-NEXT:    movdqa %xmm2, (%esi)
+; X86-NEXT:    bsfl %ecx, %ecx
+; X86-NEXT:    movl $32, %eax
+; X86-NEXT:    cmovnel %ecx, %eax
 ; X86-NEXT:    popl %esi
+; X86-NEXT:    popl %edi
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: udiv_known_nonzero_vec:
@@ -1540,10 +1547,11 @@ define i32 @udiv_known_nonzero_vec(<4 x i32> %xx, <4 x i32> %y, ptr %p) nounwind
 ; X64-NEXT:    divl %ecx
 ; X64-NEXT:    vpinsrd $3, %eax, %xmm2, %xmm0
 ; X64-NEXT:    vmovdqa %xmm0, (%rdi)
-; X64-NEXT:    vmovd %xmm0, %eax
-; X64-NEXT:    rep bsfl %eax, %eax
+; X64-NEXT:    vmovd %xmm0, %ecx
+; X64-NEXT:    movl $32, %eax
+; X64-NEXT:    rep bsfl %ecx, %eax
 ; X64-NEXT:    retq
-  %x = or <4 x i32> %xx, <i32 64, i32 -1, i32 -1, i32 -1>
+  %x = or <4 x i32> %xx, <i32 64, i32 -1, i32 0, i32 0>
   %z = udiv exact <4 x i32> %x, %y
   store <4 x i32> %z, ptr %p
   %e = extractelement <4 x i32> %z, i32 0
@@ -1603,38 +1611,45 @@ define i32 @sdiv_known_nonzero(i32 %xx, i32 %y) {
 define i32 @sdiv_known_nonzero_vec(<4 x i32> %xx, <4 x i32> %y, ptr %p) nounwind {
 ; X86-LABEL: sdiv_known_nonzero_vec:
 ; X86:       # %bb.0:
+; X86-NEXT:    pushl %edi
 ; X86-NEXT:    pushl %esi
-; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %esi
 ; X86-NEXT:    por {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0
-; X86-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[3,3,3,3]
-; X86-NEXT:    movd %xmm2, %esi
+; X86-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[1,1,1,1]
+; X86-NEXT:    movd %xmm2, %ecx
 ; X86-NEXT:    movl $-1, %eax
 ; X86-NEXT:    cltd
-; X86-NEXT:    idivl %esi
+; X86-NEXT:    idivl %ecx
 ; X86-NEXT:    movd %eax, %xmm3
-; X86-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X86-NEXT:    movd %xmm2, %esi
-; X86-NEXT:    movl $-1, %eax
-; X86-NEXT:    cltd
-; X86-NEXT:    idivl %esi
-; X86-NEXT:    movd %eax, %xmm2
-; X86-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-; X86-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[1,1,1,1]
-; X86-NEXT:    movd %xmm3, %esi
-; X86-NEXT:    movl $-1, %eax
-; X86-NEXT:    cltd
-; X86-NEXT:    idivl %esi
-; X86-NEXT:    movd %eax, %xmm3
-; X86-NEXT:    movd %xmm1, %esi
+; X86-NEXT:    movd %xmm1, %ecx
 ; X86-NEXT:    movd %xmm0, %eax
 ; X86-NEXT:    cltd
-; X86-NEXT:    idivl %esi
+; X86-NEXT:    idivl %ecx
+; X86-NEXT:    movl %eax, %ecx
+; X86-NEXT:    movd %eax, %xmm2
+; X86-NEXT:    punpckldq {{.*#+}} xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
+; X86-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[3,3,3,3]
+; X86-NEXT:    movd %xmm3, %edi
+; X86-NEXT:    pshufd {{.*#+}} xmm3 = xmm0[3,3,3,3]
+; X86-NEXT:    movd %xmm3, %eax
+; X86-NEXT:    cltd
+; X86-NEXT:    idivl %edi
+; X86-NEXT:    movd %eax, %xmm3
+; X86-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[2,3,2,3]
+; X86-NEXT:    movd %xmm1, %edi
+; X86-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[2,3,2,3]
+; X86-NEXT:    movd %xmm0, %eax
+; X86-NEXT:    cltd
+; X86-NEXT:    idivl %edi
 ; X86-NEXT:    movd %eax, %xmm0
 ; X86-NEXT:    punpckldq {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1]
-; X86-NEXT:    punpcklqdq {{.*#+}} xmm0 = xmm0[0],xmm2[0]
-; X86-NEXT:    movdqa %xmm0, (%ecx)
-; X86-NEXT:    rep bsfl %eax, %eax
+; X86-NEXT:    punpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm0[0]
+; X86-NEXT:    movdqa %xmm2, (%esi)
+; X86-NEXT:    bsfl %ecx, %ecx
+; X86-NEXT:    movl $32, %eax
+; X86-NEXT:    cmovnel %ecx, %eax
 ; X86-NEXT:    popl %esi
+; X86-NEXT:    popl %edi
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: sdiv_known_nonzero_vec:
@@ -1662,10 +1677,11 @@ define i32 @sdiv_known_nonzero_vec(<4 x i32> %xx, <4 x i32> %y, ptr %p) nounwind
 ; X64-NEXT:    idivl %ecx
 ; X64-NEXT:    vpinsrd $3, %eax, %xmm2, %xmm0
 ; X64-NEXT:    vmovdqa %xmm0, (%rdi)
-; X64-NEXT:    vmovd %xmm0, %eax
-; X64-NEXT:    rep bsfl %eax, %eax
+; X64-NEXT:    vmovd %xmm0, %ecx
+; X64-NEXT:    movl $32, %eax
+; X64-NEXT:    rep bsfl %ecx, %eax
 ; X64-NEXT:    retq
-  %x = or <4 x i32> %xx, <i32 64, i32 -1, i32 -1, i32 -1>
+  %x = or <4 x i32> %xx, <i32 64, i32 -1, i32 0, i32 0>
   %z = sdiv exact <4 x i32> %x, %y
   store <4 x i32> %z, ptr %p
   %e = extractelement <4 x i32> %z, i32 0


### PR DESCRIPTION
The original tests from #184350 were recognising every element as non-zero