### PR TITLE
[Hexagon] Use __HVX_IEEE_FP__ to guard protos that need -mhvx-ieee-fp

### DIFF
--- a/clang/lib/Headers/hvx_hexagon_protos.h
+++ b/clang/lib/Headers/hvx_hexagon_protos.h
@@ -19,7 +19,6 @@
 #define __BUILTIN_VECTOR_WRAP(a) a
 #endif
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Rd32=vextract(Vu32,Rs32)
    C Intrinsic Prototype: Word32 Q6_R_vextract_VR(HVX_Vector Vu, Word32 Rs)
@@ -28,9 +27,7 @@
    ========================================================================== */
 
 #define Q6_R_vextract_VR(Vu,Rs) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_extractw)(Vu,Rs)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=hi(Vss32)
    C Intrinsic Prototype: HVX_Vector Q6_V_hi_W(HVX_VectorPair Vss)
@@ -39,9 +36,7 @@
    ========================================================================== */
 
 #define Q6_V_hi_W(Vss) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_hi)(Vss)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=lo(Vss32)
    C Intrinsic Prototype: HVX_Vector Q6_V_lo_W(HVX_VectorPair Vss)
@@ -50,9 +45,7 @@
    ========================================================================== */
 
 #define Q6_V_lo_W(Vss) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_lo)(Vss)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vsplat(Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_V_vsplat_R(Word32 Rt)
@@ -61,9 +54,7 @@
    ========================================================================== */
 
 #define Q6_V_vsplat_R(Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_lvsplatw)(Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=and(Qs4,Qt4)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_and_QQ(HVX_VectorPred Qs, HVX_VectorPred Qt)
@@ -72,9 +63,7 @@
    ========================================================================== */
 
 #define Q6_Q_and_QQ(Qs,Qt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_pred_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qt),-1))),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=and(Qs4,!Qt4)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_and_QQn(HVX_VectorPred Qs, HVX_VectorPred Qt)
@@ -83,9 +72,7 @@
    ========================================================================== */
 
 #define Q6_Q_and_QQn(Qs,Qt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_pred_and_n)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qt),-1))),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=not(Qs4)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_not_Q(HVX_VectorPred Qs)
@@ -94,9 +81,7 @@
    ========================================================================== */
 
 #define Q6_Q_not_Q(Qs) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_pred_not)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1))),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=or(Qs4,Qt4)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_or_QQ(HVX_VectorPred Qs, HVX_VectorPred Qt)
@@ -105,9 +90,7 @@
    ========================================================================== */
 
 #define Q6_Q_or_QQ(Qs,Qt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_pred_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qt),-1))),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=or(Qs4,!Qt4)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_or_QQn(HVX_VectorPred Qs, HVX_VectorPred Qt)
@@ -116,9 +99,7 @@
    ========================================================================== */
 
 #define Q6_Q_or_QQn(Qs,Qt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_pred_or_n)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qt),-1))),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=vsetq(Rt32)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vsetq_R(Word32 Rt)
@@ -127,9 +108,7 @@
    ========================================================================== */
 
 #define Q6_Q_vsetq_R(Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_pred_scalar2)(Rt)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=xor(Qs4,Qt4)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_xor_QQ(HVX_VectorPred Qs, HVX_VectorPred Qt)
@@ -138,9 +117,7 @@
    ========================================================================== */
 
 #define Q6_Q_xor_QQ(Qs,Qt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_pred_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qt),-1))),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (!Qv4) vmem(Rt32+#s4)=Vs32
    C Intrinsic Prototype: void Q6_vmem_QnRIV(HVX_VectorPred Qv, HVX_Vector* Rt, HVX_Vector Vs)
@@ -149,9 +126,7 @@
    ========================================================================== */
 
 #define Q6_vmem_QnRIV(Qv,Rt,Vs) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vS32b_nqpred_ai)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Rt,Vs)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (!Qv4) vmem(Rt32+#s4):nt=Vs32
    C Intrinsic Prototype: void Q6_vmem_QnRIV_nt(HVX_VectorPred Qv, HVX_Vector* Rt, HVX_Vector Vs)
@@ -160,9 +135,7 @@
    ========================================================================== */
 
 #define Q6_vmem_QnRIV_nt(Qv,Rt,Vs) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vS32b_nt_nqpred_ai)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Rt,Vs)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (Qv4) vmem(Rt32+#s4):nt=Vs32
    C Intrinsic Prototype: void Q6_vmem_QRIV_nt(HVX_VectorPred Qv, HVX_Vector* Rt, HVX_Vector Vs)
@@ -171,9 +144,7 @@
    ========================================================================== */
 
 #define Q6_vmem_QRIV_nt(Qv,Rt,Vs) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vS32b_nt_qpred_ai)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Rt,Vs)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (Qv4) vmem(Rt32+#s4)=Vs32
    C Intrinsic Prototype: void Q6_vmem_QRIV(HVX_VectorPred Qv, HVX_Vector* Rt, HVX_Vector Vs)
@@ -182,9 +153,7 @@
    ========================================================================== */
 
 #define Q6_vmem_QRIV(Qv,Rt,Vs) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vS32b_qpred_ai)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Rt,Vs)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vabsdiff(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vabsdiff_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -193,9 +162,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vabsdiff_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabsdiffh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vabsdiff(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vabsdiff_VubVub(HVX_Vector Vu, HVX_Vector Vv)
@@ -204,9 +171,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vabsdiff_VubVub(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabsdiffub)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vabsdiff(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vabsdiff_VuhVuh(HVX_Vector Vu, HVX_Vector Vv)
@@ -215,9 +180,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vabsdiff_VuhVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabsdiffuh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uw=vabsdiff(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vuw_vabsdiff_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -226,9 +189,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vabsdiff_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabsdiffw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vabs(Vu32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vabs_Vh(HVX_Vector Vu)
@@ -237,9 +198,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vabs_Vh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabsh)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vabs(Vu32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vabs_Vh_sat(HVX_Vector Vu)
@@ -248,9 +207,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vabs_Vh_sat(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabsh_sat)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vabs(Vu32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vabs_Vw(HVX_Vector Vu)
@@ -259,9 +216,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vabs_Vw(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabsw)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vabs(Vu32.w):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vabs_Vw_sat(HVX_Vector Vu)
@@ -270,9 +225,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vabs_Vw_sat(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabsw_sat)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vadd(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vadd_VbVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -281,9 +234,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vadd_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddb)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.b=vadd(Vuu32.b,Vvv32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wb_vadd_WbWb(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -292,9 +243,7 @@
    ========================================================================== */
 
 #define Q6_Wb_vadd_WbWb(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddb_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (!Qv4) Vx32.b+=Vu32.b
    C Intrinsic Prototype: HVX_Vector Q6_Vb_condacc_QnVbVb(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -303,9 +252,7 @@
    ========================================================================== */
 
 #define Q6_Vb_condacc_QnVbVb(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddbnq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (Qv4) Vx32.b+=Vu32.b
    C Intrinsic Prototype: HVX_Vector Q6_Vb_condacc_QVbVb(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -314,9 +261,7 @@
    ========================================================================== */
 
 #define Q6_Vb_condacc_QVbVb(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddbq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vadd(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vadd_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -325,9 +270,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vadd_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vadd(Vuu32.h,Vvv32.h)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vadd_WhWh(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -336,9 +279,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vadd_WhWh(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddh_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (!Qv4) Vx32.h+=Vu32.h
    C Intrinsic Prototype: HVX_Vector Q6_Vh_condacc_QnVhVh(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -347,9 +288,7 @@
    ========================================================================== */
 
 #define Q6_Vh_condacc_QnVhVh(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddhnq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (Qv4) Vx32.h+=Vu32.h
    C Intrinsic Prototype: HVX_Vector Q6_Vh_condacc_QVhVh(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -358,9 +297,7 @@
    ========================================================================== */
 
 #define Q6_Vh_condacc_QVhVh(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddhq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vadd(Vu32.h,Vv32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vadd_VhVh_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -369,9 +306,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vadd_VhVh_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddhsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vadd(Vuu32.h,Vvv32.h):sat
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vadd_WhWh_sat(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -380,9 +315,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vadd_WhWh_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddhsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vadd(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vadd_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -391,9 +324,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vadd_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddhw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vadd(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vadd_VubVub(HVX_Vector Vu, HVX_Vector Vv)
@@ -402,9 +333,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vadd_VubVub(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddubh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vadd(Vu32.ub,Vv32.ub):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vadd_VubVub_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -413,9 +342,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vadd_VubVub_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddubsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.ub=vadd(Vuu32.ub,Vvv32.ub):sat
    C Intrinsic Prototype: HVX_VectorPair Q6_Wub_vadd_WubWub_sat(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -424,9 +351,7 @@
    ========================================================================== */
 
 #define Q6_Wub_vadd_WubWub_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddubsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vadd(Vu32.uh,Vv32.uh):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vadd_VuhVuh_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -435,9 +360,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vadd_VuhVuh_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadduhsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uh=vadd(Vuu32.uh,Vvv32.uh):sat
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuh_vadd_WuhWuh_sat(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -446,9 +369,7 @@
    ========================================================================== */
 
 #define Q6_Wuh_vadd_WuhWuh_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadduhsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vadd(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vadd_VuhVuh(HVX_Vector Vu, HVX_Vector Vv)
@@ -457,9 +378,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vadd_VuhVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadduhw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vadd(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vadd_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -468,9 +387,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vadd_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vadd(Vuu32.w,Vvv32.w)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vadd_WwWw(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -479,9 +396,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vadd_WwWw(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddw_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (!Qv4) Vx32.w+=Vu32.w
    C Intrinsic Prototype: HVX_Vector Q6_Vw_condacc_QnVwVw(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -490,9 +405,7 @@
    ========================================================================== */
 
 #define Q6_Vw_condacc_QnVwVw(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddwnq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (Qv4) Vx32.w+=Vu32.w
    C Intrinsic Prototype: HVX_Vector Q6_Vw_condacc_QVwVw(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -501,9 +414,7 @@
    ========================================================================== */
 
 #define Q6_Vw_condacc_QVwVw(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddwq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vadd(Vu32.w,Vv32.w):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vadd_VwVw_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -512,9 +423,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vadd_VwVw_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddwsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vadd(Vuu32.w,Vvv32.w):sat
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vadd_WwWw_sat(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -523,9 +432,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vadd_WwWw_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddwsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=valign(Vu32,Vv32,Rt8)
    C Intrinsic Prototype: HVX_Vector Q6_V_valign_VVR(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -534,9 +441,7 @@
    ========================================================================== */
 
 #define Q6_V_valign_VVR(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_valignb)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=valign(Vu32,Vv32,#u3)
    C Intrinsic Prototype: HVX_Vector Q6_V_valign_VVI(HVX_Vector Vu, HVX_Vector Vv, Word32 Iu3)
@@ -545,9 +450,7 @@
    ========================================================================== */
 
 #define Q6_V_valign_VVI(Vu,Vv,Iu3) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_valignbi)(Vu,Vv,Iu3)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vand(Vu32,Vv32)
    C Intrinsic Prototype: HVX_Vector Q6_V_vand_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -556,9 +459,7 @@
    ========================================================================== */
 
 #define Q6_V_vand_VV(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vand)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vand(Qu4,Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_V_vand_QR(HVX_VectorPred Qu, Word32 Rt)
@@ -567,9 +468,7 @@
    ========================================================================== */
 
 #define Q6_V_vand_QR(Qu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qu),-1),Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32|=vand(Qu4,Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_V_vandor_VQR(HVX_Vector Vx, HVX_VectorPred Qu, Word32 Rt)
@@ -578,9 +477,7 @@
    ========================================================================== */
 
 #define Q6_V_vandor_VQR(Vx,Qu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt_acc)(Vx,__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qu),-1),Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=vand(Vu32,Rt32)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vand_VR(HVX_Vector Vu, Word32 Rt)
@@ -589,9 +486,7 @@
    ========================================================================== */
 
 #define Q6_Q_vand_VR(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)(Vu,Rt)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4|=vand(Vu32,Rt32)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vandor_QVR(HVX_VectorPred Qx, HVX_Vector Vu, Word32 Rt)
@@ -600,9 +495,7 @@
    ========================================================================== */
 
 #define Q6_Q_vandor_QVR(Qx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt_acc)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Rt)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vasl(Vu32.h,Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vasl_VhR(HVX_Vector Vu, Word32 Rt)
@@ -611,9 +504,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vasl_VhR(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaslh)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vasl(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vasl_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -622,9 +513,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vasl_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaslhv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vasl(Vu32.w,Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vasl_VwR(HVX_Vector Vu, Word32 Rt)
@@ -633,9 +522,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vasl_VwR(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaslw)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vasl(Vu32.w,Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vaslacc_VwVwR(HVX_Vector Vx, HVX_Vector Vu, Word32 Rt)
@@ -644,9 +531,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vaslacc_VwVwR(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaslw_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vasl(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vasl_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -655,9 +540,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vasl_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaslwv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vasr(Vu32.h,Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vasr_VhR(HVX_Vector Vu, Word32 Rt)
@@ -666,9 +549,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vasr_VhR(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrh)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vasr(Vu32.h,Vv32.h,Rt8):rnd:sat
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vasr_VhVhR_rnd_sat(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -677,9 +558,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vasr_VhVhR_rnd_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrhbrndsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vasr(Vu32.h,Vv32.h,Rt8):rnd:sat
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vasr_VhVhR_rnd_sat(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -688,9 +567,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vasr_VhVhR_rnd_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrhubrndsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vasr(Vu32.h,Vv32.h,Rt8):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vasr_VhVhR_sat(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -699,9 +576,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vasr_VhVhR_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrhubsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vasr(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vasr_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -710,9 +585,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vasr_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrhv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vasr(Vu32.w,Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vasr_VwR(HVX_Vector Vu, Word32 Rt)
@@ -721,9 +594,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vasr_VwR(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrw)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vasr(Vu32.w,Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vasracc_VwVwR(HVX_Vector Vx, HVX_Vector Vu, Word32 Rt)
@@ -732,9 +603,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vasracc_VwVwR(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrw_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vasr(Vu32.w,Vv32.w,Rt8)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vasr_VwVwR(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -743,9 +612,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vasr_VwVwR(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrwh)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vasr(Vu32.w,Vv32.w,Rt8):rnd:sat
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vasr_VwVwR_rnd_sat(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -754,9 +621,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vasr_VwVwR_rnd_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrwhrndsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vasr(Vu32.w,Vv32.w,Rt8):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vasr_VwVwR_sat(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -765,9 +630,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vasr_VwVwR_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrwhsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vasr(Vu32.w,Vv32.w,Rt8):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vasr_VwVwR_sat(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -776,9 +639,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vasr_VwVwR_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrwuhsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vasr(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vasr_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -787,9 +648,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vasr_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrwv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=Vu32
    C Intrinsic Prototype: HVX_Vector Q6_V_equals_V(HVX_Vector Vu)
@@ -798,9 +657,7 @@
    ========================================================================== */
 
 #define Q6_V_equals_V(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vassign)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32=Vuu32
    C Intrinsic Prototype: HVX_VectorPair Q6_W_equals_W(HVX_VectorPair Vuu)
@@ -809,9 +666,7 @@
    ========================================================================== */
 
 #define Q6_W_equals_W(Vuu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vassignp)(Vuu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vavg(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vavg_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -820,9 +675,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vavg_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavgh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vavg(Vu32.h,Vv32.h):rnd
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vavg_VhVh_rnd(HVX_Vector Vu, HVX_Vector Vv)
@@ -831,9 +684,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vavg_VhVh_rnd(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavghrnd)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vavg(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vavg_VubVub(HVX_Vector Vu, HVX_Vector Vv)
@@ -842,9 +693,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vavg_VubVub(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavgub)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vavg(Vu32.ub,Vv32.ub):rnd
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vavg_VubVub_rnd(HVX_Vector Vu, HVX_Vector Vv)
@@ -853,9 +702,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vavg_VubVub_rnd(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavgubrnd)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vavg(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vavg_VuhVuh(HVX_Vector Vu, HVX_Vector Vv)
@@ -864,9 +711,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vavg_VuhVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavguh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vavg(Vu32.uh,Vv32.uh):rnd
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vavg_VuhVuh_rnd(HVX_Vector Vu, HVX_Vector Vv)
@@ -875,9 +720,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vavg_VuhVuh_rnd(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavguhrnd)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vavg(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vavg_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -886,9 +729,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vavg_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavgw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vavg(Vu32.w,Vv32.w):rnd
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vavg_VwVw_rnd(HVX_Vector Vu, HVX_Vector Vv)
@@ -897,9 +738,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vavg_VwVw_rnd(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavgwrnd)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vcl0(Vu32.uh)
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vcl0_Vuh(HVX_Vector Vu)
@@ -908,9 +747,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vcl0_Vuh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcl0h)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uw=vcl0(Vu32.uw)
    C Intrinsic Prototype: HVX_Vector Q6_Vuw_vcl0_Vuw(HVX_Vector Vu)
@@ -919,9 +756,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vcl0_Vuw(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcl0w)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32=vcombine(Vu32,Vv32)
    C Intrinsic Prototype: HVX_VectorPair Q6_W_vcombine_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -930,9 +765,7 @@
    ========================================================================== */
 
 #define Q6_W_vcombine_VV(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcombine)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=#0
    C Intrinsic Prototype: HVX_Vector Q6_V_vzero()
@@ -941,9 +774,7 @@
    ========================================================================== */
 
 #define Q6_V_vzero() __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vd0)()
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vdeal(Vu32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vdeal_Vb(HVX_Vector Vu)
@@ -952,9 +783,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vdeal_Vb(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdealb)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vdeale(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vdeale_VbVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -963,9 +792,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vdeale_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdealb4w)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vdeal(Vu32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vdeal_Vh(HVX_Vector Vu)
@@ -974,9 +801,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vdeal_Vh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdealh)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32=vdeal(Vu32,Vv32,Rt8)
    C Intrinsic Prototype: HVX_VectorPair Q6_W_vdeal_VVR(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -985,9 +810,7 @@
    ========================================================================== */
 
 #define Q6_W_vdeal_VVR(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdealvdd)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vdelta(Vu32,Vv32)
    C Intrinsic Prototype: HVX_Vector Q6_V_vdelta_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -996,9 +819,7 @@
    ========================================================================== */
 
 #define Q6_V_vdelta_VV(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdelta)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vdmpy(Vu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vdmpy_VubRb(HVX_Vector Vu, Word32 Rt)
@@ -1007,9 +828,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vdmpy_VubRb(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpybus)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.h+=vdmpy(Vu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vdmpyacc_VhVubRb(HVX_Vector Vx, HVX_Vector Vu, Word32 Rt)
@@ -1018,9 +837,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vdmpyacc_VhVubRb(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpybus_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vdmpy(Vuu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vdmpy_WubRb(HVX_VectorPair Vuu, Word32 Rt)
@@ -1029,9 +846,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vdmpy_WubRb(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpybus_dv)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.h+=vdmpy(Vuu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vdmpyacc_WhWubRb(HVX_VectorPair Vxx, HVX_VectorPair Vuu, Word32 Rt)
@@ -1040,9 +855,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vdmpyacc_WhWubRb(Vxx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpybus_dv_acc)(Vxx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vdmpy(Vu32.h,Rt32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpy_VhRb(HVX_Vector Vu, Word32 Rt)
@@ -1051,9 +864,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpy_VhRb(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhb)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vdmpy(Vu32.h,Rt32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpyacc_VwVhRb(HVX_Vector Vx, HVX_Vector Vu, Word32 Rt)
@@ -1062,9 +873,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpyacc_VwVhRb(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhb_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vdmpy(Vuu32.h,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vdmpy_WhRb(HVX_VectorPair Vuu, Word32 Rt)
@@ -1073,9 +882,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vdmpy_WhRb(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhb_dv)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.w+=vdmpy(Vuu32.h,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vdmpyacc_WwWhRb(HVX_VectorPair Vxx, HVX_VectorPair Vuu, Word32 Rt)
@@ -1084,9 +891,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vdmpyacc_WwWhRb(Vxx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhb_dv_acc)(Vxx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vdmpy(Vuu32.h,Rt32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpy_WhRh_sat(HVX_VectorPair Vuu, Word32 Rt)
@@ -1095,9 +900,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpy_WhRh_sat(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhisat)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vdmpy(Vuu32.h,Rt32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpyacc_VwWhRh_sat(HVX_Vector Vx, HVX_VectorPair Vuu, Word32 Rt)
@@ -1106,9 +909,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpyacc_VwWhRh_sat(Vx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhisat_acc)(Vx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vdmpy(Vu32.h,Rt32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpy_VhRh_sat(HVX_Vector Vu, Word32 Rt)
@@ -1117,9 +918,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpy_VhRh_sat(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhsat)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vdmpy(Vu32.h,Rt32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpyacc_VwVhRh_sat(HVX_Vector Vx, HVX_Vector Vu, Word32 Rt)
@@ -1128,9 +927,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpyacc_VwVhRh_sat(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhsat_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vdmpy(Vuu32.h,Rt32.uh,#1):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpy_WhRuh_sat(HVX_VectorPair Vuu, Word32 Rt)
@@ -1139,9 +936,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpy_WhRuh_sat(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhsuisat)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vdmpy(Vuu32.h,Rt32.uh,#1):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpyacc_VwWhRuh_sat(HVX_Vector Vx, HVX_VectorPair Vuu, Word32 Rt)
@@ -1150,9 +945,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpyacc_VwWhRuh_sat(Vx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhsuisat_acc)(Vx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vdmpy(Vu32.h,Rt32.uh):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpy_VhRuh_sat(HVX_Vector Vu, Word32 Rt)
@@ -1161,9 +954,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpy_VhRuh_sat(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhsusat)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vdmpy(Vu32.h,Rt32.uh):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpyacc_VwVhRuh_sat(HVX_Vector Vx, HVX_Vector Vu, Word32 Rt)
@@ -1172,9 +963,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpyacc_VwVhRuh_sat(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhsusat_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vdmpy(Vu32.h,Vv32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpy_VhVh_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -1183,9 +972,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpy_VhVh_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhvsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vdmpy(Vu32.h,Vv32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vdmpyacc_VwVhVh_sat(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1194,9 +981,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vdmpyacc_VwVhVh_sat(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpyhvsat_acc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uw=vdsad(Vuu32.uh,Rt32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vdsad_WuhRuh(HVX_VectorPair Vuu, Word32 Rt)
@@ -1205,9 +990,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vdsad_WuhRuh(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdsaduh)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.uw+=vdsad(Vuu32.uh,Rt32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vdsadacc_WuwWuhRuh(HVX_VectorPair Vxx, HVX_VectorPair Vuu, Word32 Rt)
@@ -1216,9 +999,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vdsadacc_WuwWuhRuh(Vxx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdsaduh_acc)(Vxx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=vcmp.eq(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eq_VbVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -1227,9 +1008,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eq_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqb)(Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4&=vcmp.eq(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eqand_QVbVb(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1238,9 +1017,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eqand_QVbVb(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqb_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4|=vcmp.eq(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eqor_QVbVb(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1249,9 +1026,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eqor_QVbVb(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqb_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4^=vcmp.eq(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eqxacc_QVbVb(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1260,9 +1035,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eqxacc_QVbVb(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqb_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=vcmp.eq(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eq_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -1271,9 +1044,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eq_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqh)(Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4&=vcmp.eq(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eqand_QVhVh(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1282,9 +1053,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eqand_QVhVh(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqh_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4|=vcmp.eq(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eqor_QVhVh(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1293,9 +1062,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eqor_QVhVh(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqh_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4^=vcmp.eq(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eqxacc_QVhVh(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1304,9 +1071,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eqxacc_QVhVh(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqh_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=vcmp.eq(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eq_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -1315,9 +1080,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eq_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqw)(Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4&=vcmp.eq(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eqand_QVwVw(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1326,9 +1089,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eqand_QVwVw(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqw_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4|=vcmp.eq(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eqor_QVwVw(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1337,9 +1098,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eqor_QVwVw(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqw_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4^=vcmp.eq(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_eqxacc_QVwVw(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1348,9 +1107,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_eqxacc_QVwVw(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqw_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=vcmp.gt(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gt_VbVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -1359,9 +1116,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gt_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtb)(Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4&=vcmp.gt(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtand_QVbVb(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1370,9 +1125,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtand_QVbVb(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtb_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4|=vcmp.gt(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtor_QVbVb(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1381,9 +1134,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtor_QVbVb(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtb_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4^=vcmp.gt(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtxacc_QVbVb(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1392,9 +1143,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtxacc_QVbVb(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtb_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=vcmp.gt(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gt_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -1403,9 +1152,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gt_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgth)(Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4&=vcmp.gt(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtand_QVhVh(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1414,9 +1161,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtand_QVhVh(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgth_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4|=vcmp.gt(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtor_QVhVh(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1425,9 +1170,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtor_QVhVh(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgth_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4^=vcmp.gt(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtxacc_QVhVh(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1436,9 +1179,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtxacc_QVhVh(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgth_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=vcmp.gt(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gt_VubVub(HVX_Vector Vu, HVX_Vector Vv)
@@ -1447,9 +1188,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gt_VubVub(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtub)(Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4&=vcmp.gt(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtand_QVubVub(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1458,9 +1197,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtand_QVubVub(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtub_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4|=vcmp.gt(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtor_QVubVub(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1469,9 +1206,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtor_QVubVub(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtub_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4^=vcmp.gt(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtxacc_QVubVub(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1480,9 +1215,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtxacc_QVubVub(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtub_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=vcmp.gt(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gt_VuhVuh(HVX_Vector Vu, HVX_Vector Vv)
@@ -1491,9 +1224,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gt_VuhVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtuh)(Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4&=vcmp.gt(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtand_QVuhVuh(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1502,9 +1233,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtand_QVuhVuh(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtuh_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4|=vcmp.gt(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtor_QVuhVuh(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1513,9 +1242,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtor_QVuhVuh(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtuh_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4^=vcmp.gt(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtxacc_QVuhVuh(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1524,9 +1251,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtxacc_QVuhVuh(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtuh_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=vcmp.gt(Vu32.uw,Vv32.uw)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gt_VuwVuw(HVX_Vector Vu, HVX_Vector Vv)
@@ -1535,9 +1260,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gt_VuwVuw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtuw)(Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4&=vcmp.gt(Vu32.uw,Vv32.uw)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtand_QVuwVuw(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1546,9 +1269,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtand_QVuwVuw(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtuw_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4|=vcmp.gt(Vu32.uw,Vv32.uw)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtor_QVuwVuw(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1557,9 +1278,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtor_QVuwVuw(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtuw_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4^=vcmp.gt(Vu32.uw,Vv32.uw)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtxacc_QVuwVuw(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1568,9 +1287,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtxacc_QVuwVuw(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtuw_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qd4=vcmp.gt(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gt_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -1579,9 +1296,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gt_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtw)(Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4&=vcmp.gt(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtand_QVwVw(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1590,9 +1305,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtand_QVwVw(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtw_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4|=vcmp.gt(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtor_QVwVw(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1601,9 +1314,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtor_QVwVw(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtw_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Qx4^=vcmp.gt(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_VectorPred Q6_Q_vcmp_gtxacc_QVwVw(HVX_VectorPred Qx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1612,9 +1323,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtxacc_QVwVw(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtw_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w=vinsert(Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vinsert_VwR(HVX_Vector Vx, Word32 Rt)
@@ -1623,9 +1332,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vinsert_VwR(Vx,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vinsertwr)(Vx,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vlalign(Vu32,Vv32,Rt8)
    C Intrinsic Prototype: HVX_Vector Q6_V_vlalign_VVR(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -1634,9 +1341,7 @@
    ========================================================================== */
 
 #define Q6_V_vlalign_VVR(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlalignb)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vlalign(Vu32,Vv32,#u3)
    C Intrinsic Prototype: HVX_Vector Q6_V_vlalign_VVI(HVX_Vector Vu, HVX_Vector Vv, Word32 Iu3)
@@ -1645,9 +1350,7 @@
    ========================================================================== */
 
 #define Q6_V_vlalign_VVI(Vu,Vv,Iu3) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlalignbi)(Vu,Vv,Iu3)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vlsr(Vu32.uh,Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vlsr_VuhR(HVX_Vector Vu, Word32 Rt)
@@ -1656,9 +1359,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vlsr_VuhR(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlsrh)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vlsr(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vlsr_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -1667,9 +1368,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vlsr_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlsrhv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uw=vlsr(Vu32.uw,Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_Vuw_vlsr_VuwR(HVX_Vector Vu, Word32 Rt)
@@ -1678,9 +1377,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vlsr_VuwR(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlsrw)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vlsr(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vlsr_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -1689,9 +1386,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vlsr_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlsrwv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vlut32(Vu32.b,Vv32.b,Rt8)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vlut32_VbVbR(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -1700,9 +1395,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vlut32_VbVbR(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlutvvb)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.b|=vlut32(Vu32.b,Vv32.b,Rt8)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vlut32or_VbVbVbR(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -1711,9 +1404,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vlut32or_VbVbVbR(Vx,Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlutvvb_oracc)(Vx,Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vlut16(Vu32.b,Vv32.h,Rt8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vlut16_VbVhR(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -1722,9 +1413,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vlut16_VbVhR(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlutvwh)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.h|=vlut16(Vu32.b,Vv32.h,Rt8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vlut16or_WhVbVhR(HVX_VectorPair Vxx, HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -1733,9 +1422,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vlut16or_WhVbVhR(Vxx,Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlutvwh_oracc)(Vxx,Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vmax(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vmax_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -1744,9 +1431,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmax_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmaxh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vmax(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vmax_VubVub(HVX_Vector Vu, HVX_Vector Vv)
@@ -1755,9 +1440,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vmax_VubVub(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmaxub)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vmax(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vmax_VuhVuh(HVX_Vector Vu, HVX_Vector Vv)
@@ -1766,9 +1449,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vmax_VuhVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmaxuh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vmax(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmax_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -1777,9 +1458,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmax_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmaxw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vmin(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vmin_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -1788,9 +1467,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmin_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vminh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vmin(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vmin_VubVub(HVX_Vector Vu, HVX_Vector Vv)
@@ -1799,9 +1476,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vmin_VubVub(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vminub)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vmin(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vmin_VuhVuh(HVX_Vector Vu, HVX_Vector Vv)
@@ -1810,9 +1485,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vmin_VuhVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vminuh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vmin(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmin_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -1821,9 +1494,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmin_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vminw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vmpa(Vuu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vmpa_WubRb(HVX_VectorPair Vuu, Word32 Rt)
@@ -1832,9 +1503,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpa_WubRb(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpabus)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.h+=vmpa(Vuu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vmpaacc_WhWubRb(HVX_VectorPair Vxx, HVX_VectorPair Vuu, Word32 Rt)
@@ -1843,9 +1512,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpaacc_WhWubRb(Vxx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpabus_acc)(Vxx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vmpa(Vuu32.ub,Vvv32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vmpa_WubWb(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -1854,9 +1521,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpa_WubWb(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpabusv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vmpa(Vuu32.ub,Vvv32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vmpa_WubWub(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -1865,9 +1530,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpa_WubWub(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpabuuv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vmpa(Vuu32.h,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vmpa_WhRb(HVX_VectorPair Vuu, Word32 Rt)
@@ -1876,9 +1539,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vmpa_WhRb(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpahb)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.w+=vmpa(Vuu32.h,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vmpaacc_WwWhRb(HVX_VectorPair Vxx, HVX_VectorPair Vuu, Word32 Rt)
@@ -1887,9 +1548,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vmpaacc_WwWhRb(Vxx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpahb_acc)(Vxx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vmpy(Vu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vmpy_VubRb(HVX_Vector Vu, Word32 Rt)
@@ -1898,9 +1557,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpy_VubRb(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpybus)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.h+=vmpy(Vu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vmpyacc_WhVubRb(HVX_VectorPair Vxx, HVX_Vector Vu, Word32 Rt)
@@ -1909,9 +1566,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpyacc_WhVubRb(Vxx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpybus_acc)(Vxx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vmpy(Vu32.ub,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vmpy_VubVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -1920,9 +1575,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpy_VubVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpybusv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.h+=vmpy(Vu32.ub,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vmpyacc_WhVubVb(HVX_VectorPair Vxx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1931,9 +1584,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpyacc_WhVubVb(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpybusv_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vmpy(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vmpy_VbVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -1942,9 +1593,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpy_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpybv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.h+=vmpy(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vmpyacc_WhVbVb(HVX_VectorPair Vxx, HVX_Vector Vu, HVX_Vector Vv)
@@ -1953,9 +1602,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpyacc_WhVbVb(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpybv_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vmpye(Vu32.w,Vv32.uh)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpye_VwVuh(HVX_Vector Vu, HVX_Vector Vv)
@@ -1964,9 +1611,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpye_VwVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyewuh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vmpy(Vu32.h,Rt32.h)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vmpy_VhRh(HVX_Vector Vu, Word32 Rt)
@@ -1975,9 +1620,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vmpy_VhRh(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyh)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.w+=vmpy(Vu32.h,Rt32.h):sat
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vmpyacc_WwVhRh_sat(HVX_VectorPair Vxx, HVX_Vector Vu, Word32 Rt)
@@ -1986,9 +1629,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vmpyacc_WwVhRh_sat(Vxx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyhsat_acc)(Vxx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vmpy(Vu32.h,Rt32.h):<<1:rnd:sat
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vmpy_VhRh_s1_rnd_sat(HVX_Vector Vu, Word32 Rt)
@@ -1997,9 +1638,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmpy_VhRh_s1_rnd_sat(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyhsrs)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vmpy(Vu32.h,Rt32.h):<<1:sat
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vmpy_VhRh_s1_sat(HVX_Vector Vu, Word32 Rt)
@@ -2008,9 +1647,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmpy_VhRh_s1_sat(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyhss)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vmpy(Vu32.h,Vv32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vmpy_VhVuh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2019,9 +1656,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vmpy_VhVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyhus)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.w+=vmpy(Vu32.h,Vv32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vmpyacc_WwVhVuh(HVX_VectorPair Vxx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2030,9 +1665,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vmpyacc_WwVhVuh(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyhus_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vmpy(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vmpy_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2041,9 +1674,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vmpy_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyhv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.w+=vmpy(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vmpyacc_WwVhVh(HVX_VectorPair Vxx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2052,9 +1683,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vmpyacc_WwVhVh(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyhv_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vmpy(Vu32.h,Vv32.h):<<1:rnd:sat
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vmpy_VhVh_s1_rnd_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -2063,9 +1692,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmpy_VhVh_s1_rnd_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyhvsrs)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vmpyieo(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyieo_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2074,9 +1701,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyieo_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyieoh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vmpyie(Vu32.w,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyieacc_VwVwVh(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2085,9 +1710,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyieacc_VwVwVh(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyiewh_acc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vmpyie(Vu32.w,Vv32.uh)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyie_VwVuh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2096,9 +1719,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyie_VwVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyiewuh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vmpyie(Vu32.w,Vv32.uh)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyieacc_VwVwVuh(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2107,9 +1728,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyieacc_VwVwVuh(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyiewuh_acc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vmpyi(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vmpyi_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2118,9 +1737,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmpyi_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyih)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.h+=vmpyi(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vmpyiacc_VhVhVh(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2129,9 +1746,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmpyiacc_VhVhVh(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyih_acc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vmpyi(Vu32.h,Rt32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vmpyi_VhRb(HVX_Vector Vu, Word32 Rt)
@@ -2140,9 +1755,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmpyi_VhRb(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyihb)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.h+=vmpyi(Vu32.h,Rt32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vmpyiacc_VhVhRb(HVX_Vector Vx, HVX_Vector Vu, Word32 Rt)
@@ -2151,9 +1764,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmpyiacc_VhVhRb(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyihb_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vmpyio(Vu32.w,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyio_VwVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2162,9 +1773,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyio_VwVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyiowh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vmpyi(Vu32.w,Rt32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyi_VwRb(HVX_Vector Vu, Word32 Rt)
@@ -2173,9 +1782,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyi_VwRb(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyiwb)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vmpyi(Vu32.w,Rt32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyiacc_VwVwRb(HVX_Vector Vx, HVX_Vector Vu, Word32 Rt)
@@ -2184,9 +1791,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyiacc_VwVwRb(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyiwb_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vmpyi(Vu32.w,Rt32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyi_VwRh(HVX_Vector Vu, Word32 Rt)
@@ -2195,9 +1800,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyi_VwRh(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyiwh)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vmpyi(Vu32.w,Rt32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyiacc_VwVwRh(HVX_Vector Vx, HVX_Vector Vu, Word32 Rt)
@@ -2206,9 +1809,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyiacc_VwVwRh(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyiwh_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vmpyo(Vu32.w,Vv32.h):<<1:sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyo_VwVh_s1_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -2217,9 +1818,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyo_VwVh_s1_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyowh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vmpyo(Vu32.w,Vv32.h):<<1:rnd:sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyo_VwVh_s1_rnd_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -2228,9 +1827,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyo_VwVh_s1_rnd_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyowh_rnd)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vmpyo(Vu32.w,Vv32.h):<<1:rnd:sat:shift
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyoacc_VwVwVh_s1_rnd_sat_shift(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2239,9 +1836,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyoacc_VwVwVh_s1_rnd_sat_shift(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyowh_rnd_sacc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vmpyo(Vu32.w,Vv32.h):<<1:sat:shift
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vmpyoacc_VwVwVh_s1_sat_shift(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2250,9 +1845,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyoacc_VwVwVh_s1_sat_shift(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyowh_sacc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uh=vmpy(Vu32.ub,Rt32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuh_vmpy_VubRub(HVX_Vector Vu, Word32 Rt)
@@ -2261,9 +1854,7 @@
    ========================================================================== */
 
 #define Q6_Wuh_vmpy_VubRub(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyub)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.uh+=vmpy(Vu32.ub,Rt32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuh_vmpyacc_WuhVubRub(HVX_VectorPair Vxx, HVX_Vector Vu, Word32 Rt)
@@ -2272,9 +1863,7 @@
    ========================================================================== */
 
 #define Q6_Wuh_vmpyacc_WuhVubRub(Vxx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyub_acc)(Vxx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uh=vmpy(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuh_vmpy_VubVub(HVX_Vector Vu, HVX_Vector Vv)
@@ -2283,9 +1872,7 @@
    ========================================================================== */
 
 #define Q6_Wuh_vmpy_VubVub(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyubv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.uh+=vmpy(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuh_vmpyacc_WuhVubVub(HVX_VectorPair Vxx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2294,9 +1881,7 @@
    ========================================================================== */
 
 #define Q6_Wuh_vmpyacc_WuhVubVub(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyubv_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uw=vmpy(Vu32.uh,Rt32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vmpy_VuhRuh(HVX_Vector Vu, Word32 Rt)
@@ -2305,9 +1890,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vmpy_VuhRuh(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyuh)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.uw+=vmpy(Vu32.uh,Rt32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vmpyacc_WuwVuhRuh(HVX_VectorPair Vxx, HVX_Vector Vu, Word32 Rt)
@@ -2316,9 +1899,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vmpyacc_WuwVuhRuh(Vxx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyuh_acc)(Vxx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uw=vmpy(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vmpy_VuhVuh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2327,9 +1908,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vmpy_VuhVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyuhv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.uw+=vmpy(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vmpyacc_WuwVuhVuh(HVX_VectorPair Vxx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2338,9 +1917,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vmpyacc_WuwVuhVuh(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyuhv_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vmux(Qt4,Vu32,Vv32)
    C Intrinsic Prototype: HVX_Vector Q6_V_vmux_QVV(HVX_VectorPred Qt, HVX_Vector Vu, HVX_Vector Vv)
@@ -2349,9 +1926,7 @@
    ========================================================================== */
 
 #define Q6_V_vmux_QVV(Qt,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmux)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qt),-1),Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vnavg(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vnavg_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2360,9 +1935,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vnavg_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vnavgh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vnavg(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vnavg_VubVub(HVX_Vector Vu, HVX_Vector Vv)
@@ -2371,9 +1944,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vnavg_VubVub(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vnavgub)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vnavg(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vnavg_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -2382,9 +1953,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vnavg_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vnavgw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vnormamt(Vu32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vnormamt_Vh(HVX_Vector Vu)
@@ -2393,9 +1962,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vnormamt_Vh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vnormamth)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vnormamt(Vu32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vnormamt_Vw(HVX_Vector Vu)
@@ -2404,9 +1971,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vnormamt_Vw(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vnormamtw)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vnot(Vu32)
    C Intrinsic Prototype: HVX_Vector Q6_V_vnot_V(HVX_Vector Vu)
@@ -2415,9 +1980,7 @@
    ========================================================================== */
 
 #define Q6_V_vnot_V(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vnot)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vor(Vu32,Vv32)
    C Intrinsic Prototype: HVX_Vector Q6_V_vor_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -2426,9 +1989,7 @@
    ========================================================================== */
 
 #define Q6_V_vor_VV(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vor)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vpacke(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vpacke_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2437,9 +1998,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vpacke_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vpackeb)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vpacke(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vpacke_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -2448,9 +2007,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vpacke_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vpackeh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vpack(Vu32.h,Vv32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vpack_VhVh_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -2459,9 +2016,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vpack_VhVh_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vpackhb_sat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vpack(Vu32.h,Vv32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vpack_VhVh_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -2470,9 +2025,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vpack_VhVh_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vpackhub_sat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vpacko(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vpacko_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2481,9 +2034,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vpacko_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vpackob)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vpacko(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vpacko_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -2492,9 +2043,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vpacko_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vpackoh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vpack(Vu32.w,Vv32.w):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vpack_VwVw_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -2503,9 +2052,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vpack_VwVw_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vpackwh_sat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vpack(Vu32.w,Vv32.w):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vpack_VwVw_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -2514,9 +2061,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vpack_VwVw_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vpackwuh_sat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vpopcount(Vu32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vpopcount_Vh(HVX_Vector Vu)
@@ -2525,9 +2070,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vpopcount_Vh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vpopcounth)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vrdelta(Vu32,Vv32)
    C Intrinsic Prototype: HVX_Vector Q6_V_vrdelta_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -2536,9 +2079,7 @@
    ========================================================================== */
 
 #define Q6_V_vrdelta_VV(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrdelta)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vrmpy(Vu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vrmpy_VubRb(HVX_Vector Vu, Word32 Rt)
@@ -2547,9 +2088,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vrmpy_VubRb(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpybus)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vrmpy(Vu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vrmpyacc_VwVubRb(HVX_Vector Vx, HVX_Vector Vu, Word32 Rt)
@@ -2558,9 +2097,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vrmpyacc_VwVubRb(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpybus_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vrmpy(Vuu32.ub,Rt32.b,#u1)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vrmpy_WubRbI(HVX_VectorPair Vuu, Word32 Rt, Word32 Iu1)
@@ -2569,9 +2106,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vrmpy_WubRbI(Vuu,Rt,Iu1) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpybusi)(Vuu,Rt,Iu1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.w+=vrmpy(Vuu32.ub,Rt32.b,#u1)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vrmpyacc_WwWubRbI(HVX_VectorPair Vxx, HVX_VectorPair Vuu, Word32 Rt, Word32 Iu1)
@@ -2580,9 +2115,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vrmpyacc_WwWubRbI(Vxx,Vuu,Rt,Iu1) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpybusi_acc)(Vxx,Vuu,Rt,Iu1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vrmpy(Vu32.ub,Vv32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vrmpy_VubVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -2591,9 +2124,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vrmpy_VubVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpybusv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vrmpy(Vu32.ub,Vv32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vrmpyacc_VwVubVb(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2602,9 +2133,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vrmpyacc_VwVubVb(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpybusv_acc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vrmpy(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vrmpy_VbVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -2613,9 +2142,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vrmpy_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpybv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.w+=vrmpy(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vrmpyacc_VwVbVb(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2624,9 +2151,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vrmpyacc_VwVbVb(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpybv_acc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uw=vrmpy(Vu32.ub,Rt32.ub)
    C Intrinsic Prototype: HVX_Vector Q6_Vuw_vrmpy_VubRub(HVX_Vector Vu, Word32 Rt)
@@ -2635,9 +2160,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vrmpy_VubRub(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpyub)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.uw+=vrmpy(Vu32.ub,Rt32.ub)
    C Intrinsic Prototype: HVX_Vector Q6_Vuw_vrmpyacc_VuwVubRub(HVX_Vector Vx, HVX_Vector Vu, Word32 Rt)
@@ -2646,9 +2169,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vrmpyacc_VuwVubRub(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpyub_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uw=vrmpy(Vuu32.ub,Rt32.ub,#u1)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vrmpy_WubRubI(HVX_VectorPair Vuu, Word32 Rt, Word32 Iu1)
@@ -2657,9 +2178,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vrmpy_WubRubI(Vuu,Rt,Iu1) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpyubi)(Vuu,Rt,Iu1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.uw+=vrmpy(Vuu32.ub,Rt32.ub,#u1)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vrmpyacc_WuwWubRubI(HVX_VectorPair Vxx, HVX_VectorPair Vuu, Word32 Rt, Word32 Iu1)
@@ -2668,9 +2187,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vrmpyacc_WuwWubRubI(Vxx,Vuu,Rt,Iu1) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpyubi_acc)(Vxx,Vuu,Rt,Iu1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uw=vrmpy(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_Vector Q6_Vuw_vrmpy_VubVub(HVX_Vector Vu, HVX_Vector Vv)
@@ -2679,9 +2196,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vrmpy_VubVub(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpyubv)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vx32.uw+=vrmpy(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_Vector Q6_Vuw_vrmpyacc_VuwVubVub(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -2690,9 +2205,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vrmpyacc_VuwVubVub(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrmpyubv_acc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vror(Vu32,Rt32)
    C Intrinsic Prototype: HVX_Vector Q6_V_vror_VR(HVX_Vector Vu, Word32 Rt)
@@ -2701,9 +2214,7 @@
    ========================================================================== */
 
 #define Q6_V_vror_VR(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vror)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vround(Vu32.h,Vv32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vround_VhVh_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -2712,9 +2223,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vround_VhVh_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vroundhb)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vround(Vu32.h,Vv32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vround_VhVh_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -2723,9 +2232,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vround_VhVh_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vroundhub)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vround(Vu32.w,Vv32.w):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vround_VwVw_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -2734,9 +2241,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vround_VwVw_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vroundwh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vround(Vu32.w,Vv32.w):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vround_VwVw_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -2745,9 +2250,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vround_VwVw_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vroundwuh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uw=vrsad(Vuu32.ub,Rt32.ub,#u1)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vrsad_WubRubI(HVX_VectorPair Vuu, Word32 Rt, Word32 Iu1)
@@ -2756,9 +2259,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vrsad_WubRubI(Vuu,Rt,Iu1) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrsadubi)(Vuu,Rt,Iu1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.uw+=vrsad(Vuu32.ub,Rt32.ub,#u1)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vrsadacc_WuwWubRubI(HVX_VectorPair Vxx, HVX_VectorPair Vuu, Word32 Rt, Word32 Iu1)
@@ -2767,9 +2268,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vrsadacc_WuwWubRubI(Vxx,Vuu,Rt,Iu1) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrsadubi_acc)(Vxx,Vuu,Rt,Iu1)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vsat(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vsat_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2778,9 +2277,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vsat_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsathub)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vsat(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vsat_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -2789,9 +2286,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vsat_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsatwh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vsxt(Vu32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vsxt_Vb(HVX_Vector Vu)
@@ -2800,9 +2295,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vsxt_Vb(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsb)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vsxt(Vu32.h)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vsxt_Vh(HVX_Vector Vu)
@@ -2811,9 +2304,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vsxt_Vh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsh)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vshuffe(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vshuffe_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2822,9 +2313,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vshuffe_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vshufeh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vshuff(Vu32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vshuff_Vb(HVX_Vector Vu)
@@ -2833,9 +2322,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vshuff_Vb(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vshuffb)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vshuffe(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vshuffe_VbVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -2844,9 +2331,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vshuffe_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vshuffeb)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vshuff(Vu32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vshuff_Vh(HVX_Vector Vu)
@@ -2855,9 +2340,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vshuff_Vh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vshuffh)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vshuffo(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vshuffo_VbVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -2866,9 +2349,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vshuffo_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vshuffob)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32=vshuff(Vu32,Vv32,Rt8)
    C Intrinsic Prototype: HVX_VectorPair Q6_W_vshuff_VVR(HVX_Vector Vu, HVX_Vector Vv, Word32 Rt)
@@ -2877,9 +2358,7 @@
    ========================================================================== */
 
 #define Q6_W_vshuff_VVR(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vshuffvdd)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.b=vshuffoe(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wb_vshuffoe_VbVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -2888,9 +2367,7 @@
    ========================================================================== */
 
 #define Q6_Wb_vshuffoe_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vshufoeb)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vshuffoe(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vshuffoe_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2899,9 +2376,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vshuffoe_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vshufoeh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vshuffo(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vshuffo_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2910,9 +2385,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vshuffo_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vshufoh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vsub(Vu32.b,Vv32.b)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vsub_VbVb(HVX_Vector Vu, HVX_Vector Vv)
@@ -2921,9 +2394,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vsub_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubb)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.b=vsub(Vuu32.b,Vvv32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wb_vsub_WbWb(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -2932,9 +2403,7 @@
    ========================================================================== */
 
 #define Q6_Wb_vsub_WbWb(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubb_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (!Qv4) Vx32.b-=Vu32.b
    C Intrinsic Prototype: HVX_Vector Q6_Vb_condnac_QnVbVb(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -2943,9 +2412,7 @@
    ========================================================================== */
 
 #define Q6_Vb_condnac_QnVbVb(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubbnq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (Qv4) Vx32.b-=Vu32.b
    C Intrinsic Prototype: HVX_Vector Q6_Vb_condnac_QVbVb(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -2954,9 +2421,7 @@
    ========================================================================== */
 
 #define Q6_Vb_condnac_QVbVb(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubbq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vsub(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vsub_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -2965,9 +2430,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vsub_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vsub(Vuu32.h,Vvv32.h)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vsub_WhWh(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -2976,9 +2439,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vsub_WhWh(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubh_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (!Qv4) Vx32.h-=Vu32.h
    C Intrinsic Prototype: HVX_Vector Q6_Vh_condnac_QnVhVh(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -2987,9 +2448,7 @@
    ========================================================================== */
 
 #define Q6_Vh_condnac_QnVhVh(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubhnq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (Qv4) Vx32.h-=Vu32.h
    C Intrinsic Prototype: HVX_Vector Q6_Vh_condnac_QVhVh(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -2998,9 +2457,7 @@
    ========================================================================== */
 
 #define Q6_Vh_condnac_QVhVh(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubhq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vsub(Vu32.h,Vv32.h):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vsub_VhVh_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -3009,9 +2466,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vsub_VhVh_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubhsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vsub(Vuu32.h,Vvv32.h):sat
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vsub_WhWh_sat(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -3020,9 +2475,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vsub_WhWh_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubhsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vsub(Vu32.h,Vv32.h)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vsub_VhVh(HVX_Vector Vu, HVX_Vector Vv)
@@ -3031,9 +2484,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vsub_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubhw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vsub(Vu32.ub,Vv32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vsub_VubVub(HVX_Vector Vu, HVX_Vector Vv)
@@ -3042,9 +2493,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vsub_VubVub(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsububh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vsub(Vu32.ub,Vv32.ub):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vsub_VubVub_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -3053,9 +2502,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vsub_VubVub_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsububsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.ub=vsub(Vuu32.ub,Vvv32.ub):sat
    C Intrinsic Prototype: HVX_VectorPair Q6_Wub_vsub_WubWub_sat(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -3064,9 +2511,7 @@
    ========================================================================== */
 
 #define Q6_Wub_vsub_WubWub_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsububsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vsub(Vu32.uh,Vv32.uh):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vsub_VuhVuh_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -3075,9 +2520,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vsub_VuhVuh_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubuhsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uh=vsub(Vuu32.uh,Vvv32.uh):sat
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuh_vsub_WuhWuh_sat(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -3086,9 +2529,7 @@
    ========================================================================== */
 
 #define Q6_Wuh_vsub_WuhWuh_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubuhsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vsub(Vu32.uh,Vv32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vsub_VuhVuh(HVX_Vector Vu, HVX_Vector Vv)
@@ -3097,9 +2538,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vsub_VuhVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubuhw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vsub(Vu32.w,Vv32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vsub_VwVw(HVX_Vector Vu, HVX_Vector Vv)
@@ -3108,9 +2547,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vsub_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vsub(Vuu32.w,Vvv32.w)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vsub_WwWw(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -3119,9 +2556,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vsub_WwWw(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubw_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (!Qv4) Vx32.w-=Vu32.w
    C Intrinsic Prototype: HVX_Vector Q6_Vw_condnac_QnVwVw(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -3130,9 +2565,7 @@
    ========================================================================== */
 
 #define Q6_Vw_condnac_QnVwVw(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubwnq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       if (Qv4) Vx32.w-=Vu32.w
    C Intrinsic Prototype: HVX_Vector Q6_Vw_condnac_QVwVw(HVX_VectorPred Qv, HVX_Vector Vx, HVX_Vector Vu)
@@ -3141,9 +2574,7 @@
    ========================================================================== */
 
 #define Q6_Vw_condnac_QVwVw(Qv,Vx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubwq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vsub(Vu32.w,Vv32.w):sat
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vsub_VwVw_sat(HVX_Vector Vu, HVX_Vector Vv)
@@ -3152,9 +2583,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vsub_VwVw_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubwsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vsub(Vuu32.w,Vvv32.w):sat
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vsub_WwWw_sat(HVX_VectorPair Vuu, HVX_VectorPair Vvv)
@@ -3163,9 +2592,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vsub_WwWw_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubwsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32=vswap(Qt4,Vu32,Vv32)
    C Intrinsic Prototype: HVX_VectorPair Q6_W_vswap_QVV(HVX_VectorPred Qt, HVX_Vector Vu, HVX_Vector Vv)
@@ -3174,9 +2601,7 @@
    ========================================================================== */
 
 #define Q6_W_vswap_QVV(Qt,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vswap)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qt),-1),Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vtmpy(Vuu32.b,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vtmpy_WbRb(HVX_VectorPair Vuu, Word32 Rt)
@@ -3185,9 +2610,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vtmpy_WbRb(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vtmpyb)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.h+=vtmpy(Vuu32.b,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vtmpyacc_WhWbRb(HVX_VectorPair Vxx, HVX_VectorPair Vuu, Word32 Rt)
@@ -3196,9 +2619,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vtmpyacc_WhWbRb(Vxx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vtmpyb_acc)(Vxx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vtmpy(Vuu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vtmpy_WubRb(HVX_VectorPair Vuu, Word32 Rt)
@@ -3207,9 +2628,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vtmpy_WubRb(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vtmpybus)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.h+=vtmpy(Vuu32.ub,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vtmpyacc_WhWubRb(HVX_VectorPair Vxx, HVX_VectorPair Vuu, Word32 Rt)
@@ -3218,9 +2637,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vtmpyacc_WhWubRb(Vxx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vtmpybus_acc)(Vxx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vtmpy(Vuu32.h,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vtmpy_WhRb(HVX_VectorPair Vuu, Word32 Rt)
@@ -3229,9 +2646,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vtmpy_WhRb(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vtmpyhb)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.w+=vtmpy(Vuu32.h,Rt32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vtmpyacc_WwWhRb(HVX_VectorPair Vxx, HVX_VectorPair Vuu, Word32 Rt)
@@ -3240,9 +2655,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vtmpyacc_WwWhRb(Vxx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vtmpyhb_acc)(Vxx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.h=vunpack(Vu32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vunpack_Vb(HVX_Vector Vu)
@@ -3251,9 +2664,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vunpack_Vb(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vunpackb)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.w=vunpack(Vu32.h)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vunpack_Vh(HVX_Vector Vu)
@@ -3262,9 +2673,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vunpack_Vh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vunpackh)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.h|=vunpacko(Vu32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wh_vunpackoor_WhVb(HVX_VectorPair Vxx, HVX_Vector Vu)
@@ -3273,9 +2682,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vunpackoor_WhVb(Vxx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vunpackob)(Vxx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vxx32.w|=vunpacko(Vu32.h)
    C Intrinsic Prototype: HVX_VectorPair Q6_Ww_vunpackoor_WwVh(HVX_VectorPair Vxx, HVX_Vector Vu)
@@ -3284,9 +2691,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vunpackoor_WwVh(Vxx,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vunpackoh)(Vxx,Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uh=vunpack(Vu32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuh_vunpack_Vub(HVX_Vector Vu)
@@ -3295,9 +2700,7 @@
    ========================================================================== */
 
 #define Q6_Wuh_vunpack_Vub(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vunpackub)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uw=vunpack(Vu32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vunpack_Vuh(HVX_Vector Vu)
@@ -3306,9 +2709,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vunpack_Vuh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vunpackuh)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vd32=vxor(Vu32,Vv32)
    C Intrinsic Prototype: HVX_Vector Q6_V_vxor_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -3317,9 +2718,7 @@
    ========================================================================== */
 
 #define Q6_V_vxor_VV(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vxor)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uh=vzxt(Vu32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuh_vzxt_Vub(HVX_Vector Vu)
@@ -3328,9 +2727,7 @@
    ========================================================================== */
 
 #define Q6_Wuh_vzxt_Vub(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vzb)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
-#if __HVX_ARCH__ >= 60
 /* ==========================================================================
    Assembly Syntax:       Vdd32.uw=vzxt(Vu32.uh)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wuw_vzxt_Vuh(HVX_Vector Vu)
@@ -3339,7 +2736,6 @@
    ========================================================================== */
 
 #define Q6_Wuw_vzxt_Vuh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vzh)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 60 */
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================

--- a/clang/lib/Headers/hvx_hexagon_protos.h
+++ b/clang/lib/Headers/hvx_hexagon_protos.h
@@ -2746,7 +2746,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vsplat_R(Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_lvsplatb)(Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2757,7 +2757,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vsplat_R(Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_lvsplath)(Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2768,7 +2768,7 @@
    ========================================================================== */
 
 #define Q6_Q_vsetq2_R(Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_pred_scalar2v2)(Rt)),-1)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2779,7 +2779,7 @@
    ========================================================================== */
 
 #define Q6_Qb_vshuffe_QhQh(Qs,Qt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_shuffeqh)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qt),-1))),-1)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2790,7 +2790,7 @@
    ========================================================================== */
 
 #define Q6_Qh_vshuffe_QwQw(Qs,Qt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_shuffeqw)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qt),-1))),-1)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2801,7 +2801,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vadd_VbVb_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddbsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2812,7 +2812,7 @@
    ========================================================================== */
 
 #define Q6_Wb_vadd_WbWb_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddbsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2823,7 +2823,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vadd_VwVwQ_carry(Vu,Vv,Qx) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddcarry)(Vu,Vv,Qx)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2834,7 +2834,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vadd_vclb_VhVh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddclbh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2845,7 +2845,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vadd_vclb_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddclbw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2856,7 +2856,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vaddacc_WwVhVh(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddhw_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2867,7 +2867,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vaddacc_WhVubVub(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddubh_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2878,7 +2878,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vadd_VubVb_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddububb_sat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2889,7 +2889,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vaddacc_WwVuhVuh(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadduhw_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2900,7 +2900,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vadd_VuwVuw_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadduwsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2911,7 +2911,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vadd_WuwWuw_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadduwsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2922,7 +2922,7 @@
    ========================================================================== */
 
 #define Q6_V_vand_QnR(Qu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandnqrt)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qu),-1),Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2933,7 +2933,7 @@
    ========================================================================== */
 
 #define Q6_V_vandor_VQnR(Vx,Qu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandnqrt_acc)(Vx,__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qu),-1),Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2944,7 +2944,7 @@
    ========================================================================== */
 
 #define Q6_V_vand_QnV(Qv,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvnqv)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vu)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2955,7 +2955,7 @@
    ========================================================================== */
 
 #define Q6_V_vand_QV(Qv,Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvqv)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1),Vu)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2966,7 +2966,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vasr_VhVhR_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrhbsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2977,7 +2977,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vasr_VuwVuwR_rnd_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasruwuhrndsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2988,7 +2988,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vasr_VwVwR_rnd_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrwuhrndsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -2999,7 +2999,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vlsr_VubR(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlsrb)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3010,7 +3010,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vlut32_VbVbR_nomatch(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlutvvb_nm)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3021,7 +3021,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vlut32or_VbVbVbI(Vx,Vu,Vv,Iu3) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlutvvb_oracci)(Vx,Vu,Vv,Iu3)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3032,7 +3032,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vlut32_VbVbI(Vu,Vv,Iu3) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlutvvbi)(Vu,Vv,Iu3)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3043,7 +3043,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vlut16_VbVhR_nomatch(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlutvwh_nm)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3054,7 +3054,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vlut16or_WhVbVhI(Vxx,Vu,Vv,Iu3) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlutvwh_oracci)(Vxx,Vu,Vv,Iu3)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3065,7 +3065,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vlut16_VbVhI(Vu,Vv,Iu3) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlutvwhi)(Vu,Vv,Iu3)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3076,7 +3076,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vmax_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmaxb)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3087,7 +3087,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vmin_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vminb)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3098,7 +3098,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vmpa_WuhRb(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpauhb)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3109,7 +3109,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vmpaacc_WwWuhRb(Vxx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpauhb_acc)(Vxx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3120,7 +3120,7 @@
    ========================================================================== */
 
 #define Q6_W_vmpye_VwVuh(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyewuh_64)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3131,7 +3131,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyi_VwRub(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyiwub)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3142,7 +3142,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vmpyiacc_VwVwRub(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyiwub_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3153,7 +3153,7 @@
    ========================================================================== */
 
 #define Q6_W_vmpyoacc_WVwVh(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyowh_64_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3164,7 +3164,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vround_VuhVuh_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrounduhub)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3175,7 +3175,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vround_VuwVuw_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrounduwuh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3186,7 +3186,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vsat_VuwVuw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsatuwuh)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3197,7 +3197,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vsub_VbVb_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubbsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3208,7 +3208,7 @@
    ========================================================================== */
 
 #define Q6_Wb_vsub_WbWb_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubbsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3219,7 +3219,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vsub_VwVwQ_carry(Vu,Vv,Qx) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubcarry)(Vu,Vv,Qx)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3230,7 +3230,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vsub_VubVb_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubububb_sat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3241,7 +3241,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vsub_VuwVuw_sat(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubuwsat)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 62
 /* ==========================================================================
@@ -3252,7 +3252,7 @@
    ========================================================================== */
 
 #define Q6_Wuw_vsub_WuwWuw_sat(Vuu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsubuwsat_dv)(Vuu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 62 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3263,7 +3263,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vabs_Vb(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabsb)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3274,7 +3274,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vabs_Vb_sat(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabsb_sat)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3285,7 +3285,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vaslacc_VhVhR(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaslh_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3296,7 +3296,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vasracc_VhVhR(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrh_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3307,7 +3307,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vasr_VuhVuhR_rnd_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasruhubrndsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3318,7 +3318,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vasr_VuhVuhR_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasruhubsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3329,7 +3329,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vasr_VuwVuwR_sat(Vu,Vv,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasruwuhsat)(Vu,Vv,Rt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3340,7 +3340,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vavg_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavgb)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3351,7 +3351,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vavg_VbVb_rnd(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavgbrnd)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3362,7 +3362,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vavg_VuwVuw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavguw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3373,7 +3373,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vavg_VuwVuw_rnd(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vavguwrnd)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3384,7 +3384,7 @@
    ========================================================================== */
 
 #define Q6_W_vzero() __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdd0)()
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3395,7 +3395,7 @@
    ========================================================================== */
 
 #define Q6_vgather_ARMVh(Rs,Rt,Mu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgathermh)(Rs,Rt,Mu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3406,7 +3406,7 @@
    ========================================================================== */
 
 #define Q6_vgather_AQRMVh(Rs,Qs,Rt,Mu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgathermhq)(Rs,__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),Rt,Mu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3417,7 +3417,7 @@
    ========================================================================== */
 
 #define Q6_vgather_ARMWw(Rs,Rt,Mu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgathermhw)(Rs,Rt,Mu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3428,7 +3428,7 @@
    ========================================================================== */
 
 #define Q6_vgather_AQRMWw(Rs,Qs,Rt,Mu,Vvv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgathermhwq)(Rs,__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),Rt,Mu,Vvv)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3439,7 +3439,7 @@
    ========================================================================== */
 
 #define Q6_vgather_ARMVw(Rs,Rt,Mu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgathermw)(Rs,Rt,Mu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3450,7 +3450,7 @@
    ========================================================================== */
 
 #define Q6_vgather_AQRMVw(Rs,Qs,Rt,Mu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgathermwq)(Rs,__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),Rt,Mu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3461,7 +3461,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vlut4_VuhPh(Vu,Rtt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vlut4)(Vu,Rtt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3472,7 +3472,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpa_WubRub(Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpabuu)(Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3483,7 +3483,7 @@
    ========================================================================== */
 
 #define Q6_Wh_vmpaacc_WhWubRub(Vxx,Vuu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpabuu_acc)(Vxx,Vuu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3494,7 +3494,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmpa_VhVhVhPh_sat(Vx,Vu,Rtt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpahhsat)(Vx,Vu,Rtt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3505,7 +3505,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmpa_VhVhVuhPuh_sat(Vx,Vu,Rtt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpauhuhsat)(Vx,Vu,Rtt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3516,7 +3516,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vmps_VhVhVuhPuh_sat(Vx,Vu,Rtt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpsuhuhsat)(Vx,Vu,Rtt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3527,7 +3527,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vmpyacc_WwVhRh(Vxx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyh_acc)(Vxx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3538,7 +3538,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vmpye_VuhRuh(Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyuhe)(Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3549,7 +3549,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vmpyeacc_VuwVuhRuh(Vx,Vu,Rt) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyuhe_acc)(Vx,Vu,Rt)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3560,7 +3560,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vnavg_VbVb(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vnavgb)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3571,7 +3571,7 @@
    ========================================================================== */
 
 #define Q6_Vb_prefixsum_Q(Qv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vprefixqb)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1))
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3582,7 +3582,7 @@
    ========================================================================== */
 
 #define Q6_Vh_prefixsum_Q(Qv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vprefixqh)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1))
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3593,7 +3593,7 @@
    ========================================================================== */
 
 #define Q6_Vw_prefixsum_Q(Qv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vprefixqw)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qv),-1))
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3604,7 +3604,7 @@
    ========================================================================== */
 
 #define Q6_vscatter_RMVhV(Rt,Mu,Vv,Vw) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vscattermh)(Rt,Mu,Vv,Vw)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3615,7 +3615,7 @@
    ========================================================================== */
 
 #define Q6_vscatteracc_RMVhV(Rt,Mu,Vv,Vw) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vscattermh_add)(Rt,Mu,Vv,Vw)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3626,7 +3626,7 @@
    ========================================================================== */
 
 #define Q6_vscatter_QRMVhV(Qs,Rt,Mu,Vv,Vw) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vscattermhq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),Rt,Mu,Vv,Vw)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3637,7 +3637,7 @@
    ========================================================================== */
 
 #define Q6_vscatter_RMWwV(Rt,Mu,Vvv,Vw) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vscattermhw)(Rt,Mu,Vvv,Vw)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3648,7 +3648,7 @@
    ========================================================================== */
 
 #define Q6_vscatteracc_RMWwV(Rt,Mu,Vvv,Vw) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vscattermhw_add)(Rt,Mu,Vvv,Vw)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3659,7 +3659,7 @@
    ========================================================================== */
 
 #define Q6_vscatter_QRMWwV(Qs,Rt,Mu,Vvv,Vw) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vscattermhwq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),Rt,Mu,Vvv,Vw)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3670,7 +3670,7 @@
    ========================================================================== */
 
 #define Q6_vscatter_RMVwV(Rt,Mu,Vv,Vw) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vscattermw)(Rt,Mu,Vv,Vw)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3681,7 +3681,7 @@
    ========================================================================== */
 
 #define Q6_vscatteracc_RMVwV(Rt,Mu,Vv,Vw) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vscattermw_add)(Rt,Mu,Vv,Vw)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 65
 /* ==========================================================================
@@ -3692,7 +3692,7 @@
    ========================================================================== */
 
 #define Q6_vscatter_QRMVwV(Qs,Rt,Mu,Vv,Vw) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vscattermwq)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1),Rt,Mu,Vv,Vw)
-#endif /* __HEXAGON_ARCH___ >= 65 */
+#endif
 
 #if __HVX_ARCH__ >= 66
 /* ==========================================================================
@@ -3703,7 +3703,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vadd_VwVwQ_carry_sat(Vu,Vv,Qs) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vaddcarrysat)(Vu,Vv,__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qs),-1))
-#endif /* __HEXAGON_ARCH___ >= 66 */
+#endif
 
 #if __HVX_ARCH__ >= 66
 /* ==========================================================================
@@ -3714,7 +3714,7 @@
    ========================================================================== */
 
 #define Q6_Ww_vasrinto_WwVwVw(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasr_into)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 66 */
+#endif
 
 #if __HVX_ARCH__ >= 66
 /* ==========================================================================
@@ -3725,7 +3725,7 @@
    ========================================================================== */
 
 #define Q6_Vuw_vrotr_VuwVuw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vrotr)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 66 */
+#endif
 
 #if __HVX_ARCH__ >= 66
 /* ==========================================================================
@@ -3736,7 +3736,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vsatdw_VwVw(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsatdw)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 66 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3747,7 +3747,7 @@
    ========================================================================== */
 
 #define Q6_Ww_v6mpy_WubWbI_h(Vuu,Vvv,Iu2) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_v6mpyhubs10)(Vuu,Vvv,Iu2)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3758,7 +3758,7 @@
    ========================================================================== */
 
 #define Q6_Ww_v6mpyacc_WwWubWbI_h(Vxx,Vuu,Vvv,Iu2) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_v6mpyhubs10_vxx)(Vxx,Vuu,Vvv,Iu2)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3769,7 +3769,7 @@
    ========================================================================== */
 
 #define Q6_Ww_v6mpy_WubWbI_v(Vuu,Vvv,Iu2) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_v6mpyvubs10)(Vuu,Vvv,Iu2)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3780,7 +3780,7 @@
    ========================================================================== */
 
 #define Q6_Ww_v6mpyacc_WwWubWbI_v(Vxx,Vuu,Vvv,Iu2) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_v6mpyvubs10_vxx)(Vxx,Vuu,Vvv,Iu2)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3791,7 +3791,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vabs_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3802,7 +3802,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vabs_Vsf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_sf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3813,7 +3813,7 @@
    ========================================================================== */
 
 #define Q6_Vqf16_vadd_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3824,7 +3824,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vadd_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_hf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3835,7 +3835,7 @@
    ========================================================================== */
 
 #define Q6_Vqf16_vadd_Vqf16Vqf16(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_qf16)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3846,7 +3846,7 @@
    ========================================================================== */
 
 #define Q6_Vqf16_vadd_Vqf16Vhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_qf16_mix)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3857,7 +3857,7 @@
    ========================================================================== */
 
 #define Q6_Vqf32_vadd_Vqf32Vqf32(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_qf32)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3868,7 +3868,7 @@
    ========================================================================== */
 
 #define Q6_Vqf32_vadd_Vqf32Vsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_qf32_mix)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3879,7 +3879,7 @@
    ========================================================================== */
 
 #define Q6_Vqf32_vadd_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3890,7 +3890,7 @@
    ========================================================================== */
 
 #define Q6_Wsf_vadd_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_sf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3901,7 +3901,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vadd_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_sf_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3912,7 +3912,7 @@
    ========================================================================== */
 
 #define Q6_Vw_vfmv_Vw(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vassign_fp)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3923,7 +3923,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_equals_Vqf16(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_hf_qf16)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3934,7 +3934,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_equals_Wqf32(Vuu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_hf_qf32)(Vuu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3945,7 +3945,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_equals_Vqf32(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_sf_qf32)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3956,7 +3956,7 @@
    ========================================================================== */
 
 #define Q6_Vb_vcvt_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_b_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3967,7 +3967,7 @@
    ========================================================================== */
 
 #define Q6_Vh_vcvt_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_h_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3978,7 +3978,7 @@
    ========================================================================== */
 
 #define Q6_Whf_vcvt_Vb(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_b)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -3989,7 +3989,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vcvt_Vh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_h)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4000,7 +4000,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vcvt_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4011,7 +4011,7 @@
    ========================================================================== */
 
 #define Q6_Whf_vcvt_Vub(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_ub)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4022,7 +4022,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vcvt_Vuh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_uh)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4033,7 +4033,7 @@
    ========================================================================== */
 
 #define Q6_Wsf_vcvt_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_sf_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4044,7 +4044,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vcvt_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_ub_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4055,7 +4055,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vcvt_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_uh_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4066,7 +4066,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vdmpy_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpy_sf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4077,7 +4077,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vdmpyacc_VsfVhfVhf(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpy_sf_hf_acc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4088,7 +4088,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vfmax_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmax_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4099,7 +4099,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vfmax_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmax_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4110,7 +4110,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vfmin_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmin_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4121,7 +4121,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vfmin_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmin_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4132,7 +4132,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vfneg_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfneg_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4143,7 +4143,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vfneg_Vsf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfneg_sf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4154,7 +4154,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gt_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgthf)(Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4165,7 +4165,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtand_QVhfVhf(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgthf_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4176,7 +4176,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtor_QVhfVhf(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgthf_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4187,7 +4187,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtxacc_QVhfVhf(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgthf_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4198,7 +4198,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gt_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtsf)(Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4209,7 +4209,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtand_QVsfVsf(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtsf_and)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4220,7 +4220,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtor_QVsfVsf(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtsf_or)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4231,7 +4231,7 @@
    ========================================================================== */
 
 #define Q6_Q_vcmp_gtxacc_QVsfVsf(Qx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtsf_xor)(__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx),-1),Vu,Vv)),-1)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4242,7 +4242,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vmax_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmax_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4253,7 +4253,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vmax_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmax_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4264,7 +4264,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vmin_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmin_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4275,7 +4275,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vmin_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmin_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4286,7 +4286,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vmpy_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_hf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4297,7 +4297,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vmpyacc_VhfVhfVhf(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_hf_hf_acc)(Vx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4308,7 +4308,7 @@
    ========================================================================== */
 
 #define Q6_Vqf16_vmpy_Vqf16Vqf16(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_qf16)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4319,7 +4319,7 @@
    ========================================================================== */
 
 #define Q6_Vqf16_vmpy_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_qf16_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4330,7 +4330,7 @@
    ========================================================================== */
 
 #define Q6_Vqf16_vmpy_Vqf16Vhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_qf16_mix_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4341,7 +4341,7 @@
    ========================================================================== */
 
 #define Q6_Vqf32_vmpy_Vqf32Vqf32(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_qf32)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4352,7 +4352,7 @@
    ========================================================================== */
 
 #define Q6_Wqf32_vmpy_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_qf32_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4363,7 +4363,7 @@
    ========================================================================== */
 
 #define Q6_Wqf32_vmpy_Vqf16Vhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_qf32_mix_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4374,7 +4374,7 @@
    ========================================================================== */
 
 #define Q6_Wqf32_vmpy_Vqf16Vqf16(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_qf32_qf16)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4385,7 +4385,7 @@
    ========================================================================== */
 
 #define Q6_Vqf32_vmpy_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_qf32_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4396,7 +4396,7 @@
    ========================================================================== */
 
 #define Q6_Wsf_vmpy_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4407,7 +4407,7 @@
    ========================================================================== */
 
 #define Q6_Wsf_vmpyacc_WsfVhfVhf(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_hf_acc)(Vxx,Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4418,7 +4418,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vmpy_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4429,7 +4429,7 @@
    ========================================================================== */
 
 #define Q6_Vqf16_vsub_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4440,7 +4440,7 @@
    ========================================================================== */
 
 #define Q6_Vhf_vsub_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_hf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4451,7 +4451,7 @@
    ========================================================================== */
 
 #define Q6_Vqf16_vsub_Vqf16Vqf16(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_qf16)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4462,7 +4462,7 @@
    ========================================================================== */
 
 #define Q6_Vqf16_vsub_Vqf16Vhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_qf16_mix)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4473,7 +4473,7 @@
    ========================================================================== */
 
 #define Q6_Vqf32_vsub_Vqf32Vqf32(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_qf32)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4484,7 +4484,7 @@
    ========================================================================== */
 
 #define Q6_Vqf32_vsub_Vqf32Vsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_qf32_mix)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4495,7 +4495,7 @@
    ========================================================================== */
 
 #define Q6_Vqf32_vsub_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4506,7 +4506,7 @@
    ========================================================================== */
 
 #define Q6_Wsf_vsub_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_sf_hf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 68
 /* ==========================================================================
@@ -4517,7 +4517,7 @@
    ========================================================================== */
 
 #define Q6_Vsf_vsub_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_sf_sf)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 68 */
+#endif
 
 #if __HVX_ARCH__ >= 69
 /* ==========================================================================
@@ -4528,7 +4528,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vasr_WuhVub_rnd_sat(Vuu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrvuhubrndsat)(Vuu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 69 */
+#endif
 
 #if __HVX_ARCH__ >= 69
 /* ==========================================================================
@@ -4539,7 +4539,7 @@
    ========================================================================== */
 
 #define Q6_Vub_vasr_WuhVub_sat(Vuu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrvuhubsat)(Vuu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 69 */
+#endif
 
 #if __HVX_ARCH__ >= 69
 /* ==========================================================================
@@ -4550,7 +4550,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vasr_WwVuh_rnd_sat(Vuu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrvwuhrndsat)(Vuu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 69 */
+#endif
 
 #if __HVX_ARCH__ >= 69
 /* ==========================================================================
@@ -4561,7 +4561,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vasr_WwVuh_sat(Vuu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vasrvwuhsat)(Vuu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 69 */
+#endif
 
 #if __HVX_ARCH__ >= 69
 /* ==========================================================================
@@ -4572,7 +4572,7 @@
    ========================================================================== */
 
 #define Q6_Vuh_vmpy_VuhVuh_rs16(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyuhvs)(Vu,Vv)
-#endif /* __HEXAGON_ARCH___ >= 69 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4584,7 +4584,7 @@
 
 #define Q6_Wsf_vadd_VbfVbf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_sf_bf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4596,7 +4596,7 @@
 
 #define Q6_Vh_equals_Vhf(Vu)                                                   \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_h_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4608,7 +4608,7 @@
 
 #define Q6_Vhf_equals_Vh(Vu)                                                   \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_hf_h)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4620,7 +4620,7 @@
 
 #define Q6_Vsf_equals_Vw(Vu)                                                   \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_sf_w)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4632,7 +4632,7 @@
 
 #define Q6_Vw_equals_Vsf(Vu)                                                   \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_w_sf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4644,7 +4644,7 @@
 
 #define Q6_Vbf_vcvt_VsfVsf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_bf_sf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4657,7 +4657,7 @@
 #define Q6_Q_vcmp_gt_VbfVbf(Vu, Vv)                                            \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)                          \
   ((__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vgtbf)(Vu, Vv)), -1)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4673,7 +4673,7 @@
        __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx), -1), Vu,      \
        Vv)),                                                                   \
    -1)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4689,7 +4689,7 @@
        __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx), -1), Vu,      \
        Vv)),                                                                   \
    -1)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4705,7 +4705,7 @@
        __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx), -1), Vu,      \
        Vv)),                                                                   \
    -1)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4717,7 +4717,7 @@
 
 #define Q6_Vbf_vmax_VbfVbf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmax_bf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4729,7 +4729,7 @@
 
 #define Q6_Vbf_vmin_VbfVbf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmin_bf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4741,7 +4741,7 @@
 
 #define Q6_Wsf_vmpy_VbfVbf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_bf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4753,7 +4753,7 @@
 
 #define Q6_Wsf_vmpyacc_WsfVbfVbf(Vxx, Vu, Vv)                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_bf_acc)(Vxx, Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 73
 /* ==========================================================================
@@ -4765,7 +4765,7 @@
 
 #define Q6_Wsf_vsub_VbfVbf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_sf_bf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 73 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4777,7 +4777,7 @@
 
 #define Q6_V_vgetqfext_VR(Vu, Rt)                                              \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_get_qfext)(Vu, Rt)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4789,7 +4789,7 @@
 
 #define Q6_V_vgetqfextor_VVR(Vx, Vu, Rt)                                       \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_get_qfext_oracc)(Vx, Vu, Rt)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4801,7 +4801,7 @@
 
 #define Q6_V_vsetqfext_VR(Vu, Rt)                                              \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_set_qfext)(Vu, Rt)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4812,7 +4812,7 @@
    ========================================================================== */
 
 #define Q6_V_vabs_V(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_f8)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4824,7 +4824,7 @@
 
 #define Q6_Whf_vadd_VV(Vu, Vv)                                                 \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_hf_f8)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4836,7 +4836,7 @@
 
 #define Q6_Vb_vcvt2_VhfVhf(Vu, Vv)                                             \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_b_hf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4848,7 +4848,7 @@
 
 #define Q6_Whf_vcvt2_Vb(Vu)                                                    \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_hf_b)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4860,7 +4860,7 @@
 
 #define Q6_Whf_vcvt2_Vub(Vu)                                                   \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_hf_ub)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4872,7 +4872,7 @@
 
 #define Q6_Vub_vcvt2_VhfVhf(Vu, Vv)                                            \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_ub_hf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4884,7 +4884,7 @@
 
 #define Q6_V_vcvt_VhfVhf(Vu, Vv)                                               \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_f8_hf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4896,7 +4896,7 @@
 
 #define Q6_Whf_vcvt_V(Vu)                                                      \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_f8)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4908,7 +4908,7 @@
 
 #define Q6_V_vfmax_VV(Vu, Vv)                                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmax_f8)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4920,7 +4920,7 @@
 
 #define Q6_V_vfmin_VV(Vu, Vv)                                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmin_f8)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4932,7 +4932,7 @@
 
 #define Q6_V_vfneg_V(Vu)                                                       \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfneg_f8)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4944,7 +4944,7 @@
 
 #define Q6_V_vmerge_VVw(Vu, Vv)                                                \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmerge_qf)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4956,7 +4956,7 @@
 
 #define Q6_Whf_vmpy_VV(Vu, Vv)                                                 \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_hf_f8)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4968,7 +4968,7 @@
 
 #define Q6_Whf_vmpyacc_WhfVV(Vxx, Vu, Vv)                                      \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_hf_f8_acc)(Vxx, Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4980,7 +4980,7 @@
 
 #define Q6_Vqf16_vmpy_VhfRhf(Vu, Rt)                                           \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_rt_hf)(Vu, Rt)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -4992,7 +4992,7 @@
 
 #define Q6_Vqf16_vmpy_Vqf16Rhf(Vu, Rt)                                         \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_rt_qf16)(Vu, Rt)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -5004,7 +5004,7 @@
 
 #define Q6_Vqf32_vmpy_VsfRsf(Vu, Rt)                                           \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_rt_sf)(Vu, Rt)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 79
 /* ==========================================================================
@@ -5016,7 +5016,7 @@
 
 #define Q6_Whf_vsub_VV(Vu, Vv)                                                 \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_hf_f8)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 79 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5028,7 +5028,7 @@
 
 #define Q6_Vqf16_vabs_Vhf(Vu)                                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_qf16_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5040,7 +5040,7 @@
 
 #define Q6_Vqf16_vabs_Vqf16(Vu)                                                \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_qf16_qf16)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5052,7 +5052,7 @@
 
 #define Q6_Vqf32_vabs_Vqf32(Vu)                                                \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_qf32_qf32)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5064,7 +5064,7 @@
 
 #define Q6_Vqf32_vabs_Vsf(Vu)                                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_qf32_sf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5076,7 +5076,7 @@
 
 #define Q6_V_valign4_VVR(Vu, Vv, Rt)                                           \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_valign4)(Vu, Vv, Rt)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5088,7 +5088,7 @@
 
 #define Q6_Vbf_equals_Wqf32(Vuu)                                               \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_bf_qf32)(Vuu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5100,7 +5100,7 @@
 
 #define Q6_V_equals_Vqf16(Vu)                                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_f8_qf16)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5112,7 +5112,7 @@
 
 #define Q6_Vh_equals_Vhf_rnd(Vu)                                               \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_h_hf_rnd)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5124,7 +5124,7 @@
 
 #define Q6_Wqf16_equals_V(Vu)                                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_qf16_f8)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5136,7 +5136,7 @@
 
 #define Q6_Vqf16_equals_Vhf(Vu)                                                \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_qf16_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5148,7 +5148,7 @@
 
 #define Q6_Vqf16_equals_Vqf16(Vu)                                              \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_qf16_qf16)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5160,7 +5160,7 @@
 
 #define Q6_Vqf32_equals_Vqf32(Vu)                                              \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_qf32_qf32)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5172,7 +5172,7 @@
 
 #define Q6_Vqf32_equals_Vsf(Vu)                                                \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_qf32_sf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5185,7 +5185,7 @@
 #define Q6_Q_vcmp_eq_VhfVhf(Vu, Vv)                                            \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)(                         \
       (__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqhf)(Vu, Vv)), -1)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5201,7 +5201,7 @@
           __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx), -1), Vu,   \
           Vv)),                                                                \
       -1)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5217,7 +5217,7 @@
           __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx), -1), Vu,   \
           Vv)),                                                                \
       -1)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5233,7 +5233,7 @@
           __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx), -1), Vu,   \
           Vv)),                                                                \
       -1)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5246,7 +5246,7 @@
 #define Q6_Q_vcmp_eq_VsfVsf(Vu, Vv)                                            \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandqrt)(                         \
       (__BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_veqsf)(Vu, Vv)), -1)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5262,7 +5262,7 @@
           __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx), -1), Vu,   \
           Vv)),                                                                \
       -1)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5278,7 +5278,7 @@
           __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx), -1), Vu,   \
           Vv)),                                                                \
       -1)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5294,7 +5294,7 @@
           __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vandvrt)((Qx), -1), Vu,   \
           Vv)),                                                                \
       -1)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5306,7 +5306,7 @@
 
 #define Q6_Vw_vilog2_Vhf(Vu)                                                   \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vilog2_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5318,7 +5318,7 @@
 
 #define Q6_Vw_vilog2_Vqf16(Vu)                                                 \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vilog2_qf16)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5330,7 +5330,7 @@
 
 #define Q6_Vw_vilog2_Vqf32(Vu)                                                 \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vilog2_qf32)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5342,7 +5342,7 @@
 
 #define Q6_Vw_vilog2_Vsf(Vu)                                                   \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vilog2_sf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5354,7 +5354,7 @@
 
 #define Q6_Vqf16_vneg_Vhf(Vu)                                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vneg_qf16_hf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5366,7 +5366,7 @@
 
 #define Q6_Vqf16_vneg_Vqf16(Vu)                                                \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vneg_qf16_qf16)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5378,7 +5378,7 @@
 
 #define Q6_Vqf32_vneg_Vqf32(Vu)                                                \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vneg_qf32_qf32)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5390,7 +5390,7 @@
 
 #define Q6_Vqf32_vneg_Vsf(Vu)                                                  \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vneg_qf32_sf)(Vu)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5402,7 +5402,7 @@
 
 #define Q6_Vqf16_vsub_VhfVqf16(Vu, Vv)                                         \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_hf_mix)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #if __HVX_ARCH__ >= 81
 /* ==========================================================================
@@ -5414,7 +5414,7 @@
 
 #define Q6_Vqf32_vsub_VsfVqf32(Vu, Vv)                                         \
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_sf_mix)(Vu, Vv)
-#endif /* __HEXAGON_ARCH___ >= 81 */
+#endif
 
 #endif /* __HVX__ */
 

--- a/clang/lib/Headers/hvx_hexagon_protos.h
+++ b/clang/lib/Headers/hvx_hexagon_protos.h
@@ -3782,7 +3782,7 @@
 #define Q6_Ww_v6mpyacc_WwWubWbI_v(Vxx,Vuu,Vvv,Iu2) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_v6mpyvubs10_vxx)(Vxx,Vuu,Vvv,Iu2)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vabs(Vu32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vabs_Vhf(HVX_Vector Vu)
@@ -3793,7 +3793,7 @@
 #define Q6_Vhf_vabs_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_hf)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vabs(Vu32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vabs_Vsf(HVX_Vector Vu)
@@ -3815,7 +3815,7 @@
 #define Q6_Vqf16_vadd_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_hf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vadd(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vadd_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -3881,7 +3881,7 @@
 #define Q6_Vqf32_vadd_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_sf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vadd(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vadd_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -3892,7 +3892,7 @@
 #define Q6_Wsf_vadd_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_sf_hf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vadd(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vadd_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -3903,7 +3903,7 @@
 #define Q6_Vsf_vadd_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_sf_sf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.w=vfmv(Vu32.w)
    C Intrinsic Prototype: HVX_Vector Q6_Vw_vfmv_Vw(HVX_Vector Vu)
@@ -3947,7 +3947,7 @@
 #define Q6_Vsf_equals_Vqf32(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_sf_qf32)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vcvt(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vcvt_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -3958,7 +3958,7 @@
 #define Q6_Vb_vcvt_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_b_hf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.h=vcvt(Vu32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vh_vcvt_Vhf(HVX_Vector Vu)
@@ -3969,7 +3969,7 @@
 #define Q6_Vh_vcvt_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_h_hf)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vcvt(Vu32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vcvt_Vb(HVX_Vector Vu)
@@ -3980,7 +3980,7 @@
 #define Q6_Whf_vcvt_Vb(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_b)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vcvt(Vu32.h)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vcvt_Vh(HVX_Vector Vu)
@@ -3991,7 +3991,7 @@
 #define Q6_Vhf_vcvt_Vh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_h)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vcvt(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vcvt_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4002,7 +4002,7 @@
 #define Q6_Vhf_vcvt_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_sf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vcvt(Vu32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vcvt_Vub(HVX_Vector Vu)
@@ -4013,7 +4013,7 @@
 #define Q6_Whf_vcvt_Vub(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_ub)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vcvt(Vu32.uh)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vcvt_Vuh(HVX_Vector Vu)
@@ -4024,7 +4024,7 @@
 #define Q6_Vhf_vcvt_Vuh(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_uh)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vcvt(Vu32.hf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vcvt_Vhf(HVX_Vector Vu)
@@ -4035,7 +4035,7 @@
 #define Q6_Wsf_vcvt_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_sf_hf)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vcvt(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vcvt_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4046,7 +4046,7 @@
 #define Q6_Vub_vcvt_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_ub_hf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.uh=vcvt(Vu32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vuh_vcvt_Vhf(HVX_Vector Vu)
@@ -4057,7 +4057,7 @@
 #define Q6_Vuh_vcvt_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_uh_hf)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vdmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vdmpy_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4068,7 +4068,7 @@
 #define Q6_Vsf_vdmpy_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpy_sf_hf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vx32.sf+=vdmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vdmpyacc_VsfVhfVhf(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -4079,7 +4079,7 @@
 #define Q6_Vsf_vdmpyacc_VsfVhfVhf(Vx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vdmpy_sf_hf_acc)(Vx,Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vfmax(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vfmax_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4090,7 +4090,7 @@
 #define Q6_Vhf_vfmax_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmax_hf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vfmax(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vfmax_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4101,7 +4101,7 @@
 #define Q6_Vsf_vfmax_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmax_sf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vfmin(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vfmin_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4112,7 +4112,7 @@
 #define Q6_Vhf_vfmin_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmin_hf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vfmin(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vfmin_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4123,7 +4123,7 @@
 #define Q6_Vsf_vfmin_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmin_sf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vfneg(Vu32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vfneg_Vhf(HVX_Vector Vu)
@@ -4134,7 +4134,7 @@
 #define Q6_Vhf_vfneg_Vhf(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfneg_hf)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vfneg(Vu32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vfneg_Vsf(HVX_Vector Vu)
@@ -4277,7 +4277,7 @@
 #define Q6_Vsf_vmin_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmin_sf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vmpy_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4288,7 +4288,7 @@
 #define Q6_Vhf_vmpy_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_hf_hf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vx32.hf+=vmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vmpyacc_VhfVhfVhf(HVX_Vector Vx, HVX_Vector Vu, HVX_Vector Vv)
@@ -4387,7 +4387,7 @@
 #define Q6_Vqf32_vmpy_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_qf32_sf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vmpy_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4398,7 +4398,7 @@
 #define Q6_Wsf_vmpy_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_hf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vxx32.sf+=vmpy(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vmpyacc_WsfVhfVhf(HVX_VectorPair Vxx, HVX_Vector Vu, HVX_Vector Vv)
@@ -4409,7 +4409,7 @@
 #define Q6_Wsf_vmpyacc_WsfVhfVhf(Vxx,Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_hf_acc)(Vxx,Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vmpy(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vmpy_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4431,7 +4431,7 @@
 #define Q6_Vqf16_vsub_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_hf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.hf=vsub(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vhf_vsub_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4497,7 +4497,7 @@
 #define Q6_Vqf32_vsub_VsfVsf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_sf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vsub(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vsub_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4508,7 +4508,7 @@
 #define Q6_Wsf_vsub_VhfVhf(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vsub_sf_hf)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 68
+#if __HVX_ARCH__ >= 68 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.sf=vsub(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vsf_vsub_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4574,7 +4574,7 @@
 #define Q6_Vuh_vmpy_VuhVuh_rs16(Vu,Vv) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpyuhvs)(Vu,Vv)
 #endif
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vadd(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vadd_VbfVbf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4634,7 +4634,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vconv_w_sf)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.bf=vcvt(Vu32.sf,Vv32.sf)
    C Intrinsic Prototype: HVX_Vector Q6_Vbf_vcvt_VsfVsf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4707,7 +4707,7 @@
    -1)
 #endif
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.bf=vmax(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_Vector Q6_Vbf_vmax_VbfVbf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4719,7 +4719,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmax_bf)(Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.bf=vmin(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_Vector Q6_Vbf_vmin_VbfVbf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4731,7 +4731,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmin_bf)(Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vmpy(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vmpy_VbfVbf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4743,7 +4743,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_bf)(Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vxx32.sf+=vmpy(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vmpyacc_WsfVbfVbf(HVX_VectorPair Vxx, HVX_Vector Vu, HVX_Vector Vv)
@@ -4755,7 +4755,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_sf_bf_acc)(Vxx, Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 73
+#if __HVX_ARCH__ >= 73 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.sf=vsub(Vu32.bf,Vv32.bf)
    C Intrinsic Prototype: HVX_VectorPair Q6_Wsf_vsub_VbfVbf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4803,7 +4803,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_set_qfext)(Vu, Rt)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.f8=vabs(Vu32.f8)
    C Intrinsic Prototype: HVX_Vector Q6_V_vabs_V(HVX_Vector Vu)
@@ -4814,7 +4814,7 @@
 #define Q6_V_vabs_V(Vu) __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vabs_f8)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vadd(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vadd_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -4826,7 +4826,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vadd_hf_f8)(Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.b=vcvt2(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vb_vcvt2_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4838,7 +4838,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_b_hf)(Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vcvt2(Vu32.b)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vcvt2_Vb(HVX_Vector Vu)
@@ -4850,7 +4850,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_hf_b)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vcvt2(Vu32.ub)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vcvt2_Vub(HVX_Vector Vu)
@@ -4862,7 +4862,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_hf_ub)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.ub=vcvt2(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_Vub_vcvt2_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4874,7 +4874,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt2_ub_hf)(Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.f8=vcvt(Vu32.hf,Vv32.hf)
    C Intrinsic Prototype: HVX_Vector Q6_V_vcvt_VhfVhf(HVX_Vector Vu, HVX_Vector Vv)
@@ -4886,7 +4886,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_f8_hf)(Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vcvt(Vu32.f8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vcvt_V(HVX_Vector Vu)
@@ -4898,7 +4898,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vcvt_hf_f8)(Vu)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.f8=vfmax(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_Vector Q6_V_vfmax_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -4910,7 +4910,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmax_f8)(Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.f8=vfmin(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_Vector Q6_V_vfmin_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -4922,7 +4922,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vfmin_f8)(Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vd32.f8=vfneg(Vu32.f8)
    C Intrinsic Prototype: HVX_Vector Q6_V_vfneg_V(HVX_Vector Vu)
@@ -4946,7 +4946,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmerge_qf)(Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vmpy(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vmpy_VV(HVX_Vector Vu, HVX_Vector Vv)
@@ -4958,7 +4958,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_hf_f8)(Vu, Vv)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vxx32.hf+=vmpy(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vmpyacc_WhfVV(HVX_VectorPair Vxx, HVX_Vector Vu, HVX_Vector Vv)
@@ -5006,7 +5006,7 @@
   __BUILTIN_VECTOR_WRAP(__builtin_HEXAGON_V6_vmpy_rt_sf)(Vu, Rt)
 #endif
 
-#if __HVX_ARCH__ >= 79
+#if __HVX_ARCH__ >= 79 && defined __HVX_IEEE_FP__
 /* ==========================================================================
    Assembly Syntax:       Vdd32.hf=vsub(Vu32.f8,Vv32.f8)
    C Intrinsic Prototype: HVX_VectorPair Q6_Whf_vsub_VV(HVX_Vector Vu, HVX_Vector Vv)

--- a/clang/test/Headers/hexagon-hvx-ieee-headers.c
+++ b/clang/test/Headers/hexagon-hvx-ieee-headers.c
@@ -1,0 +1,20 @@
+// REQUIRES: hexagon-registered-target
+
+// RUN: %clang_cc1 -internal-isystem %S/../../lib/Headers/ \
+// RUN:   -triple hexagon-unknown-elf -target-cpu hexagonv68  \
+// RUN:   -target-feature +hvx-length128b -target-feature +hvxv68 \
+// RUN:   -target-feature +hvx-ieee-fp -emit-llvm %s -o - | FileCheck %s
+
+// RUN: not %clang_cc1 -internal-isystem %S/../../lib/Headers/ \
+// RUN:   -triple hexagon-unknown-elf -target-cpu hexagonv68 \
+// RUN:   -target-feature +hvx-length128b -target-feature +hvxv68 \
+// RUN:   -fsyntax-only %s 2>&1 | FileCheck --check-prefix=CHECK-ERR %s
+
+#include <hvx_hexagon_protos.h>
+#include <hexagon_types.h>
+
+HVX_Vector f(HVX_Vector v) {
+  // CHECK-ERR: error: call to undeclared function 'Q6_Vhf_vabs_Vhf'
+  // CHECK: call <32 x i32> @llvm.hexagon.V6.vabs.hf.128B
+  return Q6_Vhf_vabs_Vhf(v);
+}


### PR DESCRIPTION
Hexagon clang recently started to define __HVX_IEEE_FP__ when the
-mhvx-ieee-fp option is specified. Guard the intrinsic macros for
instructions that should only be available with -mhvx-ieee-fp with
__HVX_IEEE_FP__.

Additionally, the following NFC changes are included:

- Remove guards around HVX v60 intrinsic macros
  Hexagon v60 is the oldest supported version so these guards were
  redundant.

- Remove comments from closing guards (HVX protos)
  These comments served very limited function as they only guard
  one macro. Also, they were incorrect. Instead of fixing remove them.
  This will also reduce by the factor of two the amount of changes
  when guarding conditions change.
