### PR TITLE
[Flang][OpenMP] Reject substring and section-component in affinity

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -5178,6 +5178,20 @@ void OmpStructureChecker::CheckArraySection(
   }
 }
 
+void OmpStructureChecker::CheckLastPartRefForArraySection(
+    const parser::Designator &designator, llvm::omp::Clause clauseId) {
+  if (!designator.EndsInBareName()) {
+    return;
+  }
+  if (MaybeExpr expr{AnalyzeExpr(context_, designator)}) {
+    if (evaluate::IsArraySection(*expr)) {
+      context_.Say(designator.source,
+          "If a list item is an array section, the last part-ref of the list item must have a section subscript list in %s clause"_err_en_US,
+          parser::ToUpperCaseLetters(getClauseName(clauseId).str()));
+    }
+  }
+}
+
 void OmpStructureChecker::CheckIntentInPointer(
     SymbolSourceMap &symbols, llvm::omp::Clause clauseId) {
   for (auto &[symbol, source] : symbols) {
@@ -5698,20 +5712,25 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Affinity &x) {
   for (const parser::OmpObject &object : objects.v) {
     if (const parser::Designator *designator{
             omp::GetDesignatorFromObj(object)}) {
+      if (const auto *dataRef{GetDataRefFromObj(object)}) {
+        if (const auto *arrayElement{GetArrayElementFromObj(object)}) {
+          CheckArraySection(*arrayElement, GetLastName(*dataRef),
+              llvm::omp::Clause::OMPC_affinity);
+        }
+      }
+
+      // CheckArraySection handles ArrayElement cases,
+      // but true substrings (e.g. a(2)(2:4)) are parser::Substring and bypass
+      // CheckArraySection.
       if (std::holds_alternative<parser::Substring>(designator->u)) {
         context_.Say(designator->source,
             "Substrings are not allowed on AFFINITY clause"_err_en_US);
-        continue;
       }
 
-      // OpenMP 5.2 3.2.1, unless otherwise specified, a variable
-      // that is part of another variable as a structure element cannot be a
-      // locator list item. AFFINITY does not provide an exception for
-      // structure components.
-      if (parser::Unwrap<parser::StructureComponent>(object)) {
-        context_.Say(designator->source,
-            "Structure components are not allowed in an AFFINITY clause"_err_en_US);
-      }
+      // OpenMP 5.2 5.2.5 Array section: if a list item is an array section, the
+      // last part-ref of the list item must have a section subscript list.
+      CheckLastPartRefForArraySection(
+          *designator, llvm::omp::Clause::OMPC_affinity);
     }
   }
 }

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -5687,12 +5687,40 @@ void OmpStructureChecker::Leave(const parser::OpenMPInvalidDirective &x) {
     RequiresPositiveParameter(llvm::omp::Clause::Y, c.v); \
   }
 
+void OmpStructureChecker::Enter(const parser::OmpClause::Affinity &x) {
+  CheckAllowedClause(llvm::omp::Clause::OMPC_affinity);
+
+  auto &modifiers{OmpGetModifiers(x.v)};
+  if (auto *iter{OmpGetUniqueModifier<parser::OmpIterator>(modifiers)})
+    CheckIteratorModifier(*iter);
+
+  const auto &objects{std::get<parser::OmpObjectList>(x.v.t)};
+  for (const parser::OmpObject &object : objects.v) {
+    if (const parser::Designator *designator{
+            omp::GetDesignatorFromObj(object)}) {
+      if (std::holds_alternative<parser::Substring>(designator->u)) {
+        context_.Say(designator->source,
+            "Substrings are not allowed on AFFINITY clause"_err_en_US);
+        continue;
+      }
+
+      // OpenMP 5.2 3.2.1, unless otherwise specified, a variable
+      // that is part of another variable as a structure element cannot be a
+      // locator list item. AFFINITY does not provide an exception for
+      // structure components.
+      if (parser::Unwrap<parser::StructureComponent>(object)) {
+        context_.Say(designator->source,
+            "Structure components are not allowed in an AFFINITY clause"_err_en_US);
+      }
+    }
+  }
+}
+
 // Following clauses do not have a separate node in parse-tree.h.
 CHECK_SIMPLE_CLAUSE(Absent, OMPC_absent)
 CHECK_SIMPLE_CLAUSE(AcqRel, OMPC_acq_rel)
 CHECK_SIMPLE_CLAUSE(Acquire, OMPC_acquire)
 CHECK_SIMPLE_CLAUSE(AdjustArgs, OMPC_adjust_args)
-CHECK_SIMPLE_CLAUSE(Affinity, OMPC_affinity)
 CHECK_SIMPLE_CLAUSE(AppendArgs, OMPC_append_args)
 CHECK_SIMPLE_CLAUSE(Apply, OMPC_apply)
 CHECK_SIMPLE_CLAUSE(Bind, OMPC_bind)

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -359,6 +359,8 @@ private:
       const parser::OmpObjectList &ompObjectList, llvm::omp::Clause clauseId);
   void CheckArraySection(const parser::ArrayElement &arrayElement,
       const parser::Name &name, const llvm::omp::Clause clause);
+  void CheckLastPartRefForArraySection(
+      const parser::Designator &designator, llvm::omp::Clause clauseId);
   void CheckSharedBindingInOuterContext(
       const parser::OmpObjectList &ompObjectList);
   void CheckIfContiguous(const parser::OmpObject &object);

--- a/flang/test/Semantics/OpenMP/affinity-invalid.f90
+++ b/flang/test/Semantics/OpenMP/affinity-invalid.f90
@@ -1,0 +1,57 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp -fopenmp-version=52
+
+subroutine affinity_substring()
+  character(len=7) :: a(8)
+  !ERROR: Substrings are not allowed on AFFINITY clause
+  !$omp task affinity(a(2)(2:4))
+    a(1) = "abcdefg"
+  !$omp end task
+end subroutine
+
+subroutine affinity_iterator_substring(n)
+  integer, intent(in) :: n
+  integer :: i
+  character(len=7) :: a(n)
+  !ERROR: Substrings are not allowed on AFFINITY clause
+  !$omp task affinity(iterator(i = 1:n) : a(i)(2:4))
+    a(1) = "abcdefg"
+  !$omp end task
+end subroutine
+
+subroutine affinity_section_component(n)
+  integer, intent(in) :: n
+  type t
+    integer :: x
+  end type
+  type(t) :: a(n)
+  !ERROR: Structure components are not allowed in an AFFINITY clause
+  !$omp task affinity(a(1:n)%x)
+    a(1)%x = 1
+  !$omp end task
+end subroutine
+
+subroutine affinity_iterator_component(n)
+  integer, intent(in) :: n
+  integer :: i
+  type t
+    integer :: x
+  end type
+  type(t) :: a(n)
+  !ERROR: Structure components are not allowed in an AFFINITY clause
+  !$omp task affinity(iterator(i = 1:n) : a(i)%x)
+    a(1)%x = 1
+  !$omp end task
+end subroutine
+
+subroutine affinity_iterator_section_component(n)
+  integer, intent(in) :: n
+  integer :: i
+  type t
+    integer :: x
+  end type
+  type(t) :: a(n)
+  !ERROR: Structure components are not allowed in an AFFINITY clause
+  !$omp task affinity(iterator(i = 1:n) : a(i:i+1)%x)
+    a(1)%x = 1
+  !$omp end task
+end subroutine

--- a/flang/test/Semantics/OpenMP/affinity-invalid.f90
+++ b/flang/test/Semantics/OpenMP/affinity-invalid.f90
@@ -18,40 +18,89 @@ subroutine affinity_iterator_substring(n)
   !$omp end task
 end subroutine
 
-subroutine affinity_section_component(n)
-  integer, intent(in) :: n
+subroutine affinity_iterator_section_component(n, m)
+  integer, intent(in) :: n, m
   type t
-    integer :: x
+    integer :: x(10)
+    integer :: y
   end type
-  type(t) :: a(n)
-  !ERROR: Structure components are not allowed in an AFFINITY clause
-  !$omp task affinity(a(1:n)%x)
-    a(1)%x = 1
+  type(t) :: a(10)
+
+  !ERROR: Subscripts of component 'x' of rank-1 derived type array have rank 1 but must all be scalar
+  !$omp task affinity(a(1:n)%x(1:m))
+  !$omp end task
+
+  !ERROR: If a list item is an array section, the last part-ref of the list item must have a section subscript list in AFFINITY clause
+  !$omp task affinity(a(1:n)%y)
   !$omp end task
 end subroutine
 
-subroutine affinity_iterator_component(n)
+subroutine affinity_section_bad_stride(n)
   integer, intent(in) :: n
-  integer :: i
-  type t
-    integer :: x
-  end type
-  type(t) :: a(n)
-  !ERROR: Structure components are not allowed in an AFFINITY clause
-  !$omp task affinity(iterator(i = 1:n) : a(i)%x)
-    a(1)%x = 1
+  integer :: a(n)
+  !ERROR: 'a' in AFFINITY clause must have a positive stride
+  !$omp task affinity(a(1:n:-1))
   !$omp end task
 end subroutine
 
-subroutine affinity_iterator_section_component(n)
+subroutine affinity_section_zero_size(n)
   integer, intent(in) :: n
-  integer :: i
-  type t
-    integer :: x
-  end type
-  type(t) :: a(n)
-  !ERROR: Structure components are not allowed in an AFFINITY clause
-  !$omp task affinity(iterator(i = 1:n) : a(i:i+1)%x)
-    a(1)%x = 1
+  integer :: a(n)
+  !ERROR: 'a' in AFFINITY clause is a zero size array section
+  !$omp task affinity(a(5:2))
+  !$omp end task
+end subroutine
+
+
+subroutine affinity_iterator_noninteger_iv()
+  integer :: x(10)
+  !ERROR: The iterator variable must be of integer type
+  !$omp task affinity(iterator(real :: i = 1:10): x(1))
+  !$omp end task
+end subroutine
+
+subroutine affinity_iterator_missing_begin()
+  integer :: x(10)
+  !ERROR: The begin and end expressions in iterator range-specification are mandatory
+  !$omp task affinity(iterator(integer :: i = :10:1): x(1))
+  !$omp end task
+end subroutine
+
+subroutine affinity_iterator_step_zero()
+  integer :: x(10)
+  !WARNING: The step value in the iterator range is 0
+  !$omp task affinity(iterator(integer :: i = 1:10:0): x(1))
+  !$omp end task
+end subroutine
+
+subroutine affinity_iterator_section_bad_stride(n)
+  integer, intent(in) :: n
+  integer :: a(n)
+  !ERROR: 'a' in AFFINITY clause must have a positive stride
+  !$omp task affinity(iterator(i = 1:n): a(i:n:-1))
+  !$omp end task
+end subroutine
+
+subroutine affinity_substring_like_single_index()
+  character(len=7) :: s
+  !PORTABILITY: The use of substrings in OpenMP argument lists has been disallowed since OpenMP 5.2.
+  !ERROR: Substrings must be in the form parent-string(lb:ub)
+  !$omp task affinity(s(2))
+  !$omp end task
+end subroutine
+
+subroutine affinity_substring_like_step()
+  character(len=7) :: s
+  !PORTABILITY: The use of substrings in OpenMP argument lists has been disallowed since OpenMP 5.2.
+  !ERROR: Cannot specify a step for a substring
+  !$omp task affinity(s(2:6:2))
+  !$omp end task
+end subroutine
+
+subroutine affinity_section_step_zero()
+  integer :: a(10)
+  !ERROR: 'a' in AFFINITY clause must have a positive stride
+  !ERROR: Stride of triplet must not be zero
+  !$omp task affinity(a(1:10:0))
   !$omp end task
 end subroutine


### PR DESCRIPTION
Add semantic checks for OpenMP AFFINITY clauses to reject substring and structure members taken from array sections.