### PR TITLE
[lldb] Remove Debugger::{FindTargetWithProcessID, FindTargetWithProcess}

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -100,10 +100,6 @@ public:
   CreateInstance(lldb::LogOutputCallback log_callback = nullptr,
                  void *baton = nullptr);
 
-  static lldb::TargetSP FindTargetWithProcessID(lldb::pid_t pid);
-
-  static lldb::TargetSP FindTargetWithProcess(Process *process);
-
   static void Initialize(LoadPluginCallbackType load_plugin_callback);
 
   static void Terminate();

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -528,22 +528,6 @@ public:
                                     const FileSpec *crash_file_path,
                                     bool can_connect);
 
-  /// Static function that can be used with the \b host function
-  /// Host::StartMonitoringChildProcess ().
-  ///
-  /// This function can be used by lldb_private::Process subclasses when they
-  /// want to watch for a local process and have its exit status automatically
-  /// set when the host child process exits. Subclasses should call
-  /// Host::StartMonitoringChildProcess () with:
-  ///     callback = Process::SetHostProcessExitStatus
-  ///     pid = Process::GetID()
-  ///     monitor_signals = false
-  static bool
-  SetProcessExitStatus(lldb::pid_t pid, // The process ID we want to monitor
-                       bool exited,
-                       int signo,   // Zero for no signal
-                       int status); // Exit value of process if signal is zero
-
   lldb::ByteOrder GetByteOrder() const;
 
   uint32_t GetAddressByteSize() const;

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -967,34 +967,6 @@ Debugger::FindDebuggerWithInstanceName(llvm::StringRef instance_name) {
   return nullptr;
 }
 
-TargetSP Debugger::FindTargetWithProcessID(lldb::pid_t pid) {
-  std::lock_guard<std::mutex> guard(GetDebuggerListMutex());
-  if (!g_debugger_list_ptr)
-    return nullptr;
-
-  for (const DebuggerSP &debugger_sp : *g_debugger_list_ptr) {
-    if (TargetSP target_sp =
-            debugger_sp->GetTargetList().FindTargetWithProcessID(pid))
-      return target_sp;
-  }
-
-  return nullptr;
-}
-
-TargetSP Debugger::FindTargetWithProcess(Process *process) {
-  std::lock_guard<std::mutex> guard(GetDebuggerListMutex());
-  if (!g_debugger_list_ptr)
-    return nullptr;
-
-  for (const DebuggerSP &debugger_sp : *g_debugger_list_ptr) {
-    if (TargetSP target_sp =
-            debugger_sp->GetTargetList().FindTargetWithProcess(process))
-      return target_sp;
-  }
-
-  return nullptr;
-}
-
 llvm::StringRef Debugger::GetStaticBroadcasterClass() {
   static constexpr llvm::StringLiteral class_name("lldb.debugger");
   return class_name;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1100,36 +1100,6 @@ bool Process::IsAlive() {
   }
 }
 
-// This static callback can be used to watch for local child processes on the
-// current host. The child process exits, the process will be found in the
-// global target list (we want to be completely sure that the
-// lldb_private::Process doesn't go away before we can deliver the signal.
-bool Process::SetProcessExitStatus(
-    lldb::pid_t pid, bool exited,
-    int signo,      // Zero for no signal
-    int exit_status // Exit value of process if signal is zero
-    ) {
-  Log *log = GetLog(LLDBLog::Process);
-  LLDB_LOGF(log,
-            "Process::SetProcessExitStatus (pid=%" PRIu64
-            ", exited=%i, signal=%i, exit_status=%i)\n",
-            pid, exited, signo, exit_status);
-
-  if (exited) {
-    TargetSP target_sp(Debugger::FindTargetWithProcessID(pid));
-    if (target_sp) {
-      ProcessSP process_sp(target_sp->GetProcessSP());
-      if (process_sp) {
-        llvm::StringRef signal_str =
-            process_sp->GetUnixSignals()->GetSignalAsStringRef(signo);
-        process_sp->SetExitStatus(exit_status, signal_str);
-      }
-    }
-    return true;
-  }
-  return false;
-}
-
 bool Process::UpdateThreadList(ThreadList &old_thread_list,
                                ThreadList &new_thread_list) {
   m_thread_plans.ClearThreadCache();


### PR DESCRIPTION
In #184259, Jim noticed that Debugger::FindTargetWithProcess and Debugger::FindTargetWithProcessID are rather poorly designed APIs as tehy allow code running in one Debugger to mess with Targets from another Debugger. The only use is Process::SetProcessExitStatus which isn't actually used.