### PR TITLE
[flang][acc] Allow orphaned acc cache directive

### DIFF
--- a/flang/docs/OpenACC.md
+++ b/flang/docs/OpenACC.md
@@ -25,6 +25,7 @@ local:
   logical expression.
 * `!$acc routine` directive can be placed at the top level.
 * `!$acc cache` directive accepts scalar variable.
+* `!$acc cache` directive is accepted outside of a loop construct.
 * The `!$acc declare` directive accepts assumed size array arguments for
   `deviceptr` and `present` clauses.
 * The OpenACC specification disallows a variable appearing multiple times in

--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -422,7 +422,6 @@ void AccStructureChecker::Enter(const parser::OpenACCRoutineConstruct &x) {
           "part of a subroutine or function definition, or within an interface "
           "body for a subroutine or function in an interface block"_err_en_US);
     }
-    hasAccRoutineDirective = true;
   }
 }
 void AccStructureChecker::Leave(const parser::OpenACCRoutineConstruct &) {
@@ -669,11 +668,6 @@ void AccStructureChecker::Enter(const parser::OpenACCCacheConstruct &x) {
   const auto &verbatim = std::get<parser::Verbatim>(x.t);
   PushContextAndClauseSets(verbatim.source, llvm::acc::Directive::ACCD_cache);
   SetContextDirectiveSource(verbatim.source);
-  if (loopNestLevel == 0 && !hasAccRoutineDirective) {
-    context_.Say(verbatim.source,
-        "The CACHE directive must be inside a loop or an ACC ROUTINE subprogram"_err_en_US);
-  }
-
   // Check cache directive array section constraints
   const auto &objectListWithModifier =
       std::get<parser::AccObjectListWithModifier>(x.t);
@@ -1156,31 +1150,20 @@ void AccStructureChecker::Enter(const parser::OpenACCEndConstruct &x) {
 
 void AccStructureChecker::Enter(const parser::Module &) {
   declareSymbols.clear();
-  hasAccRoutineDirective = false;
 }
 
 void AccStructureChecker::Enter(const parser::FunctionSubprogram &x) {
   declareSymbols.clear();
-  hasAccRoutineDirective = false;
 }
 
 void AccStructureChecker::Enter(const parser::SubroutineSubprogram &) {
   declareSymbols.clear();
-  hasAccRoutineDirective = false;
 }
 
 void AccStructureChecker::Enter(const parser::SeparateModuleSubprogram &) {
   declareSymbols.clear();
-  hasAccRoutineDirective = false;
 }
 
-void AccStructureChecker::Enter(const parser::DoConstruct &) {
-  ++loopNestLevel;
-}
-
-void AccStructureChecker::Leave(const parser::DoConstruct &) {
-  --loopNestLevel;
-}
 
 llvm::StringRef AccStructureChecker::getDirectiveName(
     llvm::acc::Directive directive) {

--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -1164,6 +1164,13 @@ void AccStructureChecker::Enter(const parser::SeparateModuleSubprogram &) {
   declareSymbols.clear();
 }
 
+void AccStructureChecker::Enter(const parser::DoConstruct &) {
+  ++loopNestLevel;
+}
+
+void AccStructureChecker::Leave(const parser::DoConstruct &) {
+  --loopNestLevel;
+}
 
 llvm::StringRef AccStructureChecker::getDirectiveName(
     llvm::acc::Directive directive) {

--- a/flang/lib/Semantics/check-acc-structure.h
+++ b/flang/lib/Semantics/check-acc-structure.h
@@ -76,8 +76,6 @@ public:
   void Enter(const parser::SubroutineSubprogram &);
   void Enter(const parser::FunctionSubprogram &);
   void Enter(const parser::SeparateModuleSubprogram &);
-  void Enter(const parser::DoConstruct &);
-  void Leave(const parser::DoConstruct &);
 
 #define GEN_FLANG_CLAUSE_CHECK_ENTER
 #include "llvm/Frontend/OpenACC/ACC.inc"
@@ -114,8 +112,6 @@ private:
   llvm::StringRef getDirectiveName(llvm::acc::Directive directive) override;
 
   llvm::SmallDenseMap<Symbol *, llvm::acc::Clause> declareSymbols;
-  unsigned loopNestLevel = 0;
-  bool hasAccRoutineDirective = false;
 };
 
 } // namespace Fortran::semantics

--- a/flang/lib/Semantics/check-acc-structure.h
+++ b/flang/lib/Semantics/check-acc-structure.h
@@ -76,6 +76,8 @@ public:
   void Enter(const parser::SubroutineSubprogram &);
   void Enter(const parser::FunctionSubprogram &);
   void Enter(const parser::SeparateModuleSubprogram &);
+  void Enter(const parser::DoConstruct &);
+  void Leave(const parser::DoConstruct &);
 
 #define GEN_FLANG_CLAUSE_CHECK_ENTER
 #include "llvm/Frontend/OpenACC/ACC.inc"
@@ -112,6 +114,7 @@ private:
   llvm::StringRef getDirectiveName(llvm::acc::Directive directive) override;
 
   llvm::SmallDenseMap<Symbol *, llvm::acc::Clause> declareSymbols;
+  unsigned loopNestLevel = 0;
 };
 
 } // namespace Fortran::semantics

--- a/flang/test/Semantics/OpenACC/acc-cache-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-cache-validity.f90
@@ -52,7 +52,6 @@ program openacc_cache_validity
 
   end do
 
-  !ERROR: The CACHE directive must be inside a loop or an ACC ROUTINE subprogram
   !$acc cache(a)
 
   call routine_with_cache()


### PR DESCRIPTION
While the spec allows the cache directive at the top of a loop body, the directive has also been utilized at the top of an acc routine. This PR removes the semantic check that rejects the cache directive outside of a loop, allowing orphaned `!$acc cache` similar to CIR.

The OpenACC.md deviation document is updated to note this extension.
