### PR TITLE
[affine] Support xori/maxnumf/minnumf reduction types.

### DIFF
--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -4212,8 +4212,9 @@ static bool isResultTypeMatchAtomicRMWKind(Type resultType,
   case arith::AtomicRMWKind::muli:
     return isa<IntegerType>(resultType);
   case arith::AtomicRMWKind::maximumf:
-    return isa<FloatType>(resultType);
+  case arith::AtomicRMWKind::maxnumf:
   case arith::AtomicRMWKind::minimumf:
+  case arith::AtomicRMWKind::minnumf:
     return isa<FloatType>(resultType);
   case arith::AtomicRMWKind::maxs: {
     auto intType = dyn_cast<IntegerType>(resultType);
@@ -4232,12 +4233,11 @@ static bool isResultTypeMatchAtomicRMWKind(Type resultType,
     return intType && intType.isUnsigned();
   }
   case arith::AtomicRMWKind::ori:
-    return isa<IntegerType>(resultType);
   case arith::AtomicRMWKind::andi:
+  case arith::AtomicRMWKind::xori:
     return isa<IntegerType>(resultType);
-  default:
-    return false;
   }
+  llvm_unreachable("Unhandled atomic rmw kind");
 }
 
 LogicalResult AffineParallelOp::verify() {

--- a/mlir/test/Dialect/Affine/ops.mlir
+++ b/mlir/test/Dialect/Affine/ops.mlir
@@ -426,3 +426,43 @@ func.func @arith_add_vaild_symbol_lower_bound(%arg : index) {
 // CHECK:   affine.for %[[VAL_3:.*]] = #[[$ATTR_0]](%[[VAL_2]]){{\[}}%[[VAL_0]]] to 7 {
 // CHECK:   }
 // CHECK: }
+
+// -----
+
+// CHECK-LABEL:   func.func @parallel_xori_reduce() {
+// CHECK:           %[[PARALLEL_0:.*]] = affine.parallel (%[[VAL_0:.*]]) = (0) to (100) reduce ("xori") -> (i32) {
+func.func @parallel_xori_reduce() {
+  %0 = memref.alloc() : memref<100xi32>
+  %1 = affine.parallel (%i) = (0) to (100) reduce ("xori") -> (i32) {
+    %2 = affine.load %0[%i] : memref<100xi32>
+    affine.yield %2 : i32
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @parallel_maxnumf_reduce() {
+// CHECK:           %[[PARALLEL_0:.*]] = affine.parallel (%[[VAL_0:.*]]) = (0) to (100) reduce ("maxnumf") -> (f32) {
+func.func @parallel_maxnumf_reduce() {
+  %0 = memref.alloc() : memref<100xf32>
+  %1 = affine.parallel (%i) = (0) to (100) reduce ("maxnumf") -> (f32) {
+    %2 = affine.load %0[%i] : memref<100xf32>
+    affine.yield %2 : f32
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @parallel_minnumf_reduce() {
+// CHECK:           %[[PARALLEL_0:.*]] = affine.parallel (%[[VAL_0:.*]]) = (0) to (100) reduce ("minnumf") -> (f32) {
+func.func @parallel_minnumf_reduce() {
+  %0 = memref.alloc() : memref<100xf32>
+  %1 = affine.parallel (%i) = (0) to (100) reduce ("minnumf") -> (f32) {
+    %2 = affine.load %0[%i] : memref<100xf32>
+    affine.yield %2 : f32
+  }
+  return
+}
+


### PR DESCRIPTION
This is a follow-up on #163310, which supported the above reduction
kinds, but did not update affine.parallel verification code.
