### PR TITLE
[flang] Fix test breakage from recent preprocessor change

### DIFF
--- a/flang/lib/Parser/prescan.cpp
+++ b/flang/lib/Parser/prescan.cpp
@@ -46,8 +46,7 @@ Prescanner::Prescanner(const Prescanner &that, Preprocessor &prepro,
       prescannerNesting_{that.prescannerNesting_ + 1},
       skipLeadingAmpersand_{that.skipLeadingAmpersand_},
       compilerDirectiveBloomFilter_{that.compilerDirectiveBloomFilter_},
-      compilerDirectiveSentinels_{that.compilerDirectiveSentinels_},
-      maxSentinelLength_{that.maxSentinelLength_} {}
+      compilerDirectiveSentinels_{that.compilerDirectiveSentinels_} {}
 
 // Returns number of bytes to skip
 static inline int IsSpace(const char *p) {
@@ -1731,10 +1730,6 @@ Prescanner &Prescanner::AddCompilerDirectiveSentinel(const std::string &dir) {
   compilerDirectiveBloomFilter_.set(packed % prime1);
   compilerDirectiveBloomFilter_.set(packed % prime2);
   compilerDirectiveSentinels_.insert(dir);
-  int len{static_cast<int>(dir.size())};
-  if (len > maxSentinelLength_) {
-    maxSentinelLength_ = len;
-  }
   return *this;
 }
 
@@ -1789,19 +1784,15 @@ const char *Prescanner::IsCompilerDirectiveSentinel(CharBlock token) const {
   while (end > p && (end[-1] == ' ' || end[-1] == '\t')) {
     --end;
   }
-  if (end > p + maxSentinelLength_) {
-    end = p + maxSentinelLength_;
-  }
   return end > p && IsCompilerDirectiveSentinel(p, end - p) ? p : nullptr;
 }
 
 std::optional<std::pair<const char *, const char *>>
 Prescanner::IsCompilerDirectiveSentinel(const char *p) const {
   char sentinel[8];
-  std::size_t maxLen{static_cast<std::size_t>(maxSentinelLength_)};
   for (std::size_t j{0}; j + 1 < sizeof sentinel; ++p, ++j) {
     if (int n{IsSpaceOrTab(p)};
-        n || j >= maxLen || !(IsLetter(*p) || *p == '$' || *p == '@')) {
+        n || !(IsLetter(*p) || *p == '$' || *p == '@')) {
       if (j <= 1 && sentinel[0] == '$' && n == 0 && *p != '&' && *p != '\n') {
         // Free form OpenMP conditional compilation line sentinels have to
         // be immediately followed by a space or &, not a digit

--- a/flang/lib/Parser/prescan.h
+++ b/flang/lib/Parser/prescan.h
@@ -324,7 +324,6 @@ private:
   static const int prime1{1019}, prime2{1021};
   std::bitset<prime2> compilerDirectiveBloomFilter_; // 128 bytes
   std::unordered_set<std::string> compilerDirectiveSentinels_;
-  int maxSentinelLength_{0};
 };
 } // namespace Fortran::parser
 #endif // FORTRAN_PARSER_PRESCAN_H_

--- a/flang/test/Parser/not-sentinel.f90
+++ b/flang/test/Parser/not-sentinel.f90
@@ -1,0 +1,5 @@
+!RUN: flang -fc1 -fopenmp -fdebug-unparse %s 2>&1 | FileCheck %s
+!CHECK-NOT: error:
+!CHECK: END PROGRAM
+!$ompx foo
+end


### PR DESCRIPTION
!$omp must never be recognized as a compiler directive sentinel when it is immediately followed by anything other than a space or &.  Revert a bit of a recent change that broke this.