### PR TITLE
[HLSL] groupshared variables should be implicitly extern and should not be initialized

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6665,6 +6665,8 @@ def err_block_extern_cant_init : Error<
   "declaration of block scope identifier with linkage cannot have an initializer">;
 def warn_extern_init : Warning<"'extern' variable has an initializer">,
   InGroup<DiagGroup<"extern-initializer">>;
+def warn_hlsl_groupshared_init : Warning<"initializer of groupshared variable will be ignored">,
+  InGroup<DiagGroup<"groupshared-initializer">>;
 def err_variable_object_no_init : Error<
   "variable-sized object may not be initialized">;
 def err_excess_initializers : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6666,7 +6666,7 @@ def err_block_extern_cant_init : Error<
 def warn_extern_init : Warning<"'extern' variable has an initializer">,
   InGroup<DiagGroup<"extern-initializer">>;
 def warn_hlsl_groupshared_init : Warning<"initializer of groupshared variable will be ignored">,
-  InGroup<DiagGroup<"groupshared-initializer">>;
+  InGroup<DiagGroup<"groupshared-initializer">>, DefaultError;
 def err_variable_object_no_init : Error<
   "variable-sized object may not be initialized">;
 def err_excess_initializers : Error<

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13894,6 +13894,12 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
 
   this->CheckAttributesOnDeducedType(RealDecl);
 
+  // we don't initialize groupshared variables so warn and return
+  if (VDecl->hasAttr<HLSLGroupSharedAddressSpaceAttr>()) {
+    Diag(VDecl->getLocation(), diag::warn_hlsl_groupshared_init);
+    return;
+  }
+
   // dllimport cannot be used on variable definitions.
   if (VDecl->hasAttr<DLLImportAttr>() && !VDecl->isStaticDataMember()) {
     Diag(VDecl->getLocation(), diag::err_attribute_dllimport_data_definition);

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4510,6 +4510,11 @@ void SemaHLSL::ActOnVariableDeclarator(VarDecl *VD) {
         }
       }
     }
+
+    // Mark groupshared variables as extern so they will have
+    // external storage and won't be initialized
+    if (VD->hasAttr<HLSLGroupSharedAddressSpaceAttr>())
+      VD->setStorageClass(StorageClass::SC_Extern);
   }
 
   deduceAddressSpace(VD);

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4512,7 +4512,7 @@ void SemaHLSL::ActOnVariableDeclarator(VarDecl *VD) {
     }
 
     // Mark groupshared variables as extern so they will have
-    // external storage and won't be initialized
+    // external storage and won't be default initialized
     if (VD->hasAttr<HLSLGroupSharedAddressSpaceAttr>())
       VD->setStorageClass(StorageClass::SC_Extern);
   }

--- a/clang/test/CodeGenHLSL/group_shared.hlsl
+++ b/clang/test/CodeGenHLSL/group_shared.hlsl
@@ -8,12 +8,23 @@
 // RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s
 
 // Make sure groupshared translated into address space 3.
-// CHECK:@a = hidden addrspace(3) global [10 x float]
+// CHECK:@a = external hidden addrspace(3) global [10 x float], align 4
 
  groupshared float a[10];
+
+// CHECK:@b = external hidden addrspace(3) global [10 x float], align 4
+ groupshared float b[10] = {1,2,3,4,5,6,7,8,9,10};
+
+ struct S {
+   uint4 x;
+ };
+
+// CHECK:@c = external hidden addrspace(3) global %struct.S, align 1
+extern groupshared S c;
 
  [numthreads(8,8,1)]
  void main() {
    a[0] = 1;
+   b[0] = 1;
+   uint d = c.x[0];
  }
-

--- a/clang/test/CodeGenHLSL/group_shared.hlsl
+++ b/clang/test/CodeGenHLSL/group_shared.hlsl
@@ -1,10 +1,10 @@
 
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s \
+// RUN:   dxil-pc-shadermodel6.3-library %s -Wno-error=groupshared-initializer \
 // RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s
 
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan1.3-compute %s \
+// RUN:   spirv-unknown-vulkan1.3-compute %s -Wno-error=groupshared-initializer \
 // RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s
 
 // Make sure groupshared translated into address space 3.

--- a/clang/test/ParserHLSL/group_shared.hlsl
+++ b/clang/test/ParserHLSL/group_shared.hlsl
@@ -9,7 +9,7 @@ extern float groupshared f; // Ok, redeclaration?
 auto l = []() groupshared  {}; // #gs_lambda
 
 float groupshared [[]] i = 12;
-// expected-warning@-1{{initializer of groupshared variable will be ignored}}
+// expected-error@-1{{initializer of groupshared variable will be ignored}}
 
 float groupshared const i2 = 12;
-// expected-warning@-1{{initializer of groupshared variable will be ignored}}
+// expected-error@-1{{initializer of groupshared variable will be ignored}}

--- a/clang/test/ParserHLSL/group_shared.hlsl
+++ b/clang/test/ParserHLSL/group_shared.hlsl
@@ -9,5 +9,7 @@ extern float groupshared f; // Ok, redeclaration?
 auto l = []() groupshared  {}; // #gs_lambda
 
 float groupshared [[]] i = 12;
+// expected-warning@-1{{initializer of groupshared variable will be ignored}}
 
 float groupshared const i2 = 12;
+// expected-warning@-1{{initializer of groupshared variable will be ignored}}

--- a/clang/test/ParserHLSL/group_shared_202x.hlsl
+++ b/clang/test/ParserHLSL/group_shared_202x.hlsl
@@ -12,8 +12,10 @@ auto l = []() -> groupshared void {}; // #l
 auto l2 = []() -> groupshared {}; // #l2
 
 float groupshared [[]] i = 12;
+// expected-warning@-1{{initializer of groupshared variable will be ignored}}
 
 float groupshared const i2 = 12;
+// expected-warning@-1{{initializer of groupshared variable will be ignored}}
 
 void foo() {
     l();

--- a/clang/test/ParserHLSL/group_shared_202x.hlsl
+++ b/clang/test/ParserHLSL/group_shared_202x.hlsl
@@ -12,10 +12,10 @@ auto l = []() -> groupshared void {}; // #l
 auto l2 = []() -> groupshared {}; // #l2
 
 float groupshared [[]] i = 12;
-// expected-warning@-1{{initializer of groupshared variable will be ignored}}
+// expected-error@-1{{initializer of groupshared variable will be ignored}}
 
 float groupshared const i2 = 12;
-// expected-warning@-1{{initializer of groupshared variable will be ignored}}
+// expected-error@-1{{initializer of groupshared variable will be ignored}}
 
 void foo() {
     l();

--- a/clang/test/SemaHLSL/Language/ImpCastAddrSpace.hlsl
+++ b/clang/test/SemaHLSL/Language/ImpCastAddrSpace.hlsl
@@ -2,7 +2,7 @@
 
 static double D = 2.0;
 static int I = D; // expected-warning{{implicit conversion turns floating-point number into integer: 'double' to 'int'}}
-groupshared float F = I; // expected-warning{{implicit conversion from 'int' to 'float' may lose precision}}
+static float F = I; // expected-warning{{implicit conversion from 'int' to 'float' may lose precision}}
 
 export void fn() {
   half d = I; // expected-warning{{implicit conversion from 'int' to 'half' may lose precision}}


### PR DESCRIPTION
Makes groupshared variables have extern storage class which prevents them from being initialized if no initializer is provided. If one is provided as below:
```
groupshared uint A = 1;
```
A warning, which is an error by default, is produced that says the initializer is ignored and the variable is NOT initialized.
Closes #183602 